### PR TITLE
Default nucleus-node to Firecracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Current enforced tools: read, write, run. Web/search tools are not yet wired.
 ## Firecracker Notes
 
 - Firecracker pods require `--proxy-auth-secret` and `--proxy-approval-secret` for signed tool and approval calls.
-- The local driver is opt-in via `--allow-local-driver` (no VM isolation).
+- The driver defaults to Firecracker; local is opt-in via `--allow-local-driver` (no VM isolation).
 - Firecracker runs in a fresh network namespace by default (`--firecracker-netns=false` to disable); default-deny iptables apply even without `spec.network` (no NIC unless policy is set).
 - Audit logs are hash-chained and signed (tamper-evident; verification tooling pending).
 - Guest init is the Rust binary `nucleus-guest-init`, baked into the rootfs.

--- a/crates/nucleus-node/src/main.rs
+++ b/crates/nucleus-node/src/main.rs
@@ -52,7 +52,12 @@ struct Args {
     #[arg(long, env = "NUCLEUS_NODE_STATE_DIR", default_value = "./nucleus-node")]
     state_dir: PathBuf,
     /// Driver backend.
-    #[arg(long, env = "NUCLEUS_NODE_DRIVER", value_enum, default_value = "local")]
+    #[arg(
+        long,
+        env = "NUCLEUS_NODE_DRIVER",
+        value_enum,
+        default_value = "firecracker"
+    )]
     driver: DriverKind,
     /// Allow the local driver (no VM isolation).
     #[arg(long, env = "NUCLEUS_ALLOW_LOCAL_DRIVER", default_value_t = false)]


### PR DESCRIPTION
## Summary\n- Default nucleus-node driver to Firecracker\n- Clarify in README that local driver is explicit opt-in\n\n## Testing\n- cargo check -p nucleus-node\n