### PR TITLE
Require signed requests to nucleus-node

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ nucleus profiles
 Note: `nucleus run` uses `nucleus-node` (Firecracker) for enforcement and
 connects via MCP to the in‑VM tool proxy. You must provide:
 - `NUCLEUS_NODE_URL`
+- `NUCLEUS_NODE_AUTH_SECRET`
 - `NUCLEUS_FIRECRACKER_KERNEL_PATH`
 - `NUCLEUS_FIRECRACKER_ROOTFS_PATH`
 - `NUCLEUS_FIRECRACKER_VSOCK_CID` and `NUCLEUS_FIRECRACKER_VSOCK_PORT`

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -13,9 +13,9 @@
 
 ```
 Agent / Tool Adapter
-  |  (optional signed HTTP)
+  |  (signed HTTP)
   v
-Host Control Plane (nucleus-node + optional signed proxy)
+Host Control Plane (nucleus-node + signed proxy)
   |  (vsock bridge, no guest TCP)
   v
 Firecracker VM (nucleus-tool-proxy + enforcement runtime)
@@ -25,7 +25,7 @@ Side effects (filesystem/commands)
 ```
 
 ### Boundary 1: Agent -> Control Plane
-- If enabled, requests are signed (HMAC; asymmetric is roadmap).
+- Requests are signed (HMAC today; asymmetric is roadmap).
 - Control plane forwards only to the VM proxy.
 
 ### Boundary 2: Control Plane -> VM
@@ -43,7 +43,7 @@ Side effects (filesystem/commands)
 - Pod lifecycle (Firecracker + resources).
 - Starts vsock bridge to the proxy.
 - Applies cgroups/seccomp to the VMM process.
-- Optionally starts a signed proxy on 127.0.0.1.
+- Starts a signed proxy on 127.0.0.1.
 
 ### approval authority (host, separate process, roadmap)
 - Issues signed approval bundles (roadmap).

--- a/docs/assurance/hardening-checklist.md
+++ b/docs/assurance/hardening-checklist.md
@@ -16,6 +16,10 @@ Status key: `DONE`, `PARTIAL`, `TODO`.
   - Pass: No unsafe flags; enforced mode is the default path.
   - Current: `DONE` (unsafe flag removed).
   - Evidence: `crates/nucleus-cli/src/run.rs`
+- **Node API requires signed requests**
+  - Pass: nucleus-node rejects unsigned HTTP/gRPC calls.
+  - Current: `DONE` (auth secret required).
+  - Evidence: `crates/nucleus-node/src/main.rs`, `crates/nucleus-node/src/auth.rs`
 
 ## 2) Network Egress Control
 


### PR DESCRIPTION
## Summary\n- Require NUCLEUS_NODE_AUTH_SECRET and enforce auth on HTTP + gRPC\n- Make CLI require node auth secret when creating pods\n- Update README and hardening checklist to reflect signed node API\n\n## Testing\n- cargo check -p nucleus-cli -p nucleus-node\n