### PR TITLE
Fix critical security issues from architectural audit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1389,6 +1389,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "ureq",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/nucleus-mcp/Cargo.toml
+++ b/crates/nucleus-mcp/Cargo.toml
@@ -22,6 +22,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
 ureq = { version = "3.1", features = ["json"] }
+uuid = { version = "1", features = ["v4"] }
 
 nucleus-client = { path = "../nucleus-client" }
 nucleus-spec = { path = "../nucleus-spec" }


### PR DESCRIPTION
## Summary

Based on a skeptical code audit, this PR fixes several critical security and architectural issues:

- **MCP approval nonce (CRITICAL)**: Approval requests now include UUID nonce, fixing the completely broken approval flow
- **Network policy race (HIGH)**: Added `apply_default_deny()` before process spawn to close vulnerability window
- **Rate limiting (HIGH)**: Token bucket limiter on `/v1/approve` prevents DoS attacks
- **IP reclamation**: Pool-based allocator with `release()` prevents node exhaustion after 255 pods

## Test plan

- [x] All existing tests pass
- [x] Added 8 unit tests for nucleus-mcp (was 0)
- [x] Added 5 unit tests for nucleus-tool-proxy (was 0)
- [x] Added 2 unit tests for IP allocator reclamation
- [ ] Manual test of MCP approval flow with nonce
- [ ] Verify default-deny applied before Firecracker spawn (Linux)

## Changes

| Issue | Severity | Fix |
|-------|----------|-----|
| MCP sends no nonce but proxy requires it | CRITICAL | Generate UUID per approval request |
| iptables applied after process spawn | HIGH | `apply_default_deny()` on netns before spawn |
| No rate limiting on approval endpoint | HIGH | Token bucket (20 burst, 10/sec) |
| IP indices never reclaimed | Medium | Pool with `release()` on cleanup |

🤖 Generated with [Claude Code](https://claude.com/claude-code)