### PR TITLE
fix(start): use shell to interpret redirection operators

### DIFF
--- a/crates/nucleus-cli/src/start.rs
+++ b/crates/nucleus-cli/src/start.rs
@@ -197,7 +197,7 @@ fn start_nucleus_node_service(vm_name: &str) -> Result<()> {
         return Ok(());
     }
 
-    // Fallback: start directly
+    // Fallback: start directly using a shell to interpret redirection
     println!("systemd service failed, starting nucleus-node directly...");
     let result = Command::new("limactl")
         .args([
@@ -205,12 +205,9 @@ fn start_nucleus_node_service(vm_name: &str) -> Result<()> {
             vm_name,
             "--",
             "sudo",
-            "nohup",
-            "/usr/local/bin/nucleus-node",
-            ">",
-            "/var/log/nucleus-node.log",
-            "2>&1",
-            "&",
+            "sh",
+            "-c",
+            "nohup /usr/local/bin/nucleus-node > /var/log/nucleus-node.log 2>&1 &",
         ])
         .output()
         .context("Failed to start nucleus-node directly")?;


### PR DESCRIPTION
## Summary
Fix broken shell command in `nucleus start` fallback path.

## Problem
The previous code passed shell operators (`>`, `2>&1`, `&`) as literal arguments to `nohup`:

```rust
.args([
    "shell", vm_name, "--",
    "sudo", "nohup", "/usr/local/bin/nucleus-node",
    ">", "/var/log/nucleus-node.log", "2>&1", "&",
])
```

This doesn't work because `limactl shell` doesn't interpret these as shell operators - they're passed as arguments to `nucleus-node`.

## Fix
Wrap the command in `sh -c` so the shell interprets the redirection:

```rust
.args([
    "shell", vm_name, "--",
    "sudo", "sh", "-c",
    "nohup /usr/local/bin/nucleus-node > /var/log/nucleus-node.log 2>&1 &",
])
```

## Test plan
- [ ] Run `nucleus start` when systemd service is not available
- [ ] Verify nucleus-node starts in background
- [ ] Verify logs written to `/var/log/nucleus-node.log`

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)