### PR TITLE
fix(ci): update release workflow for retired runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-          - os: macos-13
+          - os: macos-15-large
             target: x86_64-apple-darwin
           - os: macos-14
             target: aarch64-apple-darwin
@@ -125,6 +125,7 @@ jobs:
           platforms: arm64
       - name: Build rootfs
         run: |
+          chmod +x ./scripts/firecracker/build-rootfs.sh
           ARCH=${{ matrix.arch }} DEBIAN_IMAGE=${{ matrix.debian_image }} ./scripts/firecracker/build-rootfs.sh
       - name: Package rootfs
         run: |


### PR DESCRIPTION
## Summary

Fix release workflow failures:
- Replace `macos-13` with `macos-15-large` (macos-13 is retired as of Jan 2025)
- Add `chmod +x` for build-rootfs.sh script (permission denied error)

This will allow the v0.1.0 release to complete after re-tagging.

## Test plan

- [ ] Re-tag v0.1.0 after merge
- [ ] Verify all release artifacts build successfully

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)