### PR TITLE
fix: Update time crate to 0.3.47 (RUSTSEC-2026-0009)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3851,9 +3851,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.46"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9da98b7d9b7dad93488a84b8248efc35352b0b2657397d4167e7ad67e5d535e5"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
@@ -3874,9 +3874,9 @@ checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.26"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78cc610bac2dcee56805c99642447d4c5dbde4d01f752ffea0199aee1f601dc4"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",


### PR DESCRIPTION
## Summary
- Updates `time` crate from 0.3.46 to 0.3.47 to fix RUSTSEC-2026-0009 (DoS via stack exhaustion)
- Lockfile-only change, no code modifications

## Test plan
- [ ] CI passes (cargo audit / cargo deny check advisories)

🤖 Generated with [Claude Code](https://claude.com/claude-code)