### PR TITLE
fix: bump Dockerfile Rust to 1.88 for time crate MSRV

### DIFF
--- a/docker/Dockerfile.node
+++ b/docker/Dockerfile.node
@@ -18,7 +18,7 @@
 #     nucleus-node
 
 # ── Planner (cargo-chef recipe) ───────────────────────────────────────
-FROM rust:1.85-bookworm AS planner
+FROM rust:1.88-bookworm AS planner
 
 RUN cargo install cargo-chef --locked
 WORKDIR /build
@@ -27,7 +27,7 @@ COPY crates/ crates/
 RUN cargo chef prepare --recipe-path recipe.json
 
 # ── Cook (compile dependencies only — cached across source changes) ───
-FROM rust:1.85-bookworm AS cook
+FROM rust:1.88-bookworm AS cook
 
 RUN cargo install cargo-chef --locked
 WORKDIR /build

--- a/docker/Dockerfile.tool-proxy
+++ b/docker/Dockerfile.tool-proxy
@@ -12,7 +12,7 @@
 #   docker build -f docker/Dockerfile.tool-proxy -t nucleus-tool-proxy .
 
 # ── Planner (cargo-chef recipe) ───────────────────────────────────────
-FROM rust:1.85-bookworm AS planner
+FROM rust:1.88-bookworm AS planner
 
 RUN cargo install cargo-chef --locked
 WORKDIR /build
@@ -21,7 +21,7 @@ COPY crates/ crates/
 RUN cargo chef prepare --recipe-path recipe.json
 
 # ── Cook (compile dependencies only — cached across source changes) ───
-FROM rust:1.85-bookworm AS cook
+FROM rust:1.88-bookworm AS cook
 
 RUN cargo install cargo-chef --locked
 WORKDIR /build


### PR DESCRIPTION
## Summary
- Bump `rust:1.85-bookworm` → `rust:1.88-bookworm` in both Dockerfiles
- `time@0.3.47` in Cargo.lock requires rustc >= 1.88.0
- Docker workflow run [#22083886160](https://github.com/coproduct-opensource/nucleus/actions/runs/22083886160) failed with this MSRV mismatch

## Test plan
- [ ] Re-trigger `docker.yml` workflow after merge — both images should build successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)