### PR TITLE
chore: gitignore runtime pod artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ Thumbs.db
 
 # Proptest regression artifacts
 *.proptest-regressions
+
+# Runtime artifacts (pod logs, specs)
+nucleus-node/pods/


### PR DESCRIPTION
## Summary
- Add `nucleus-node/pods/` to `.gitignore` to prevent committing runtime artifacts (pod specs, logs, proxy addresses) generated during local execution

## Test plan
- [ ] Verify `nucleus-node/pods/` no longer shows in `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)