### PR TITLE
feat: add Python SDK for nucleus intents and tool-proxy APIs

### DIFF
--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -1,0 +1,64 @@
+# Nucleus Python SDK (Draft)
+
+Intent-first SDK for Nucleus. This package wraps the node and tool-proxy APIs and exposes user-facing intents.
+
+## Status
+
+Draft. API will change.
+
+## Quick Start
+
+```python
+from nucleus_sdk import Nucleus, Intent
+from nucleus_sdk.auth import MtlsConfig
+
+mtls = MtlsConfig(
+    cert_path="/var/run/nucleus/svid.pem",
+    key_path="/var/run/nucleus/key.pem",
+    ca_bundle="/var/run/nucleus/bundle.pem",
+)
+
+client = Nucleus(proxy_url="https://tool-proxy.local:8443", mtls=mtls)
+
+with client.intent(Intent.FIX_ISSUE, work_dir=".") as sess:
+    sess.read("README.md")
+    sess.run(["rg", "TODO", "-n"])
+    sess.write("notes.md", "todo list")
+```
+
+## Intents
+
+Each intent maps to a built-in Nucleus profile. The SDK exposes intent metadata so users can see what is allowed vs gated.
+
+- `research_web` -> `web_research`
+- `code_review` -> `code_review`
+- `fix_issue` -> `fix_issue`
+- `generate_code` -> `codegen`
+- `release` -> `release`
+- `database_client` -> `database_client`
+- `read_only` -> `read_only`
+- `edit_only` -> `edit_only`
+- `local_dev` -> `local_dev`
+- `network_only` -> `network_only`
+
+## Pod Lifecycle
+
+Staticless path: connect directly to `nucleus-tool-proxy` with mTLS and skip node orchestration. If you need pod creation, you will currently need a node client with legacy HMAC or a gRPC client (not included yet).
+
+## Authentication
+
+Preferred: SPIFFE mTLS (staticless). The proxy accepts mTLS first and skips HMAC when a valid SPIFFE ID is present.
+
+Legacy fallback: HMAC signing using the same header format as the CLI examples. This is deprecated on the node side and should be avoided where possible.
+
+## Error Model
+
+`NucleusError` wraps proxy errors with `kind` and optional `operation` fields, including:
+
+- `approval_required`
+- `path_denied`
+- `command_denied`
+- `budget_exhausted`
+- `time_violation`
+- `trifecta_blocked`
+- `insufficient_capability`

--- a/sdk/python/nucleus_sdk/__init__.py
+++ b/sdk/python/nucleus_sdk/__init__.py
@@ -1,0 +1,28 @@
+from .client import Nucleus, NodeClient, ProxyClient
+from .intent import Intent, IntentSession, IntentProfile
+from .auth import MtlsConfig, HmacAuth
+from .errors import (
+    NucleusError,
+    ApprovalRequired,
+    AccessDenied,
+    AuthError,
+    RequestError,
+    SpecError,
+)
+
+__all__ = [
+    "Nucleus",
+    "NodeClient",
+    "ProxyClient",
+    "Intent",
+    "IntentSession",
+    "IntentProfile",
+    "MtlsConfig",
+    "HmacAuth",
+    "NucleusError",
+    "ApprovalRequired",
+    "AccessDenied",
+    "AuthError",
+    "RequestError",
+    "SpecError",
+]

--- a/sdk/python/nucleus_sdk/auth.py
+++ b/sdk/python/nucleus_sdk/auth.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import hmac
+import hashlib
+import time
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+
+@dataclass(frozen=True)
+class MtlsConfig:
+    cert_path: str
+    key_path: str
+    ca_bundle: Optional[str] = None
+
+    def cert_pair(self) -> tuple[str, str]:
+        return (self.cert_path, self.key_path)
+
+
+class AuthStrategy:
+    def headers(self, body: bytes) -> Dict[str, str]:
+        return {}
+
+
+@dataclass
+class HmacAuth(AuthStrategy):
+    secret: bytes
+    actor: Optional[str] = None
+
+    def headers(self, body: bytes) -> Dict[str, str]:
+        timestamp = str(int(time.time()))
+        actor_value = self.actor or ""
+        message = b".".join(
+            [
+                timestamp.encode("utf-8"),
+                actor_value.encode("utf-8"),
+                body,
+            ]
+        )
+        signature = hmac.new(self.secret, message, hashlib.sha256).hexdigest()
+
+        headers = {
+            "X-Nucleus-Timestamp": timestamp,
+            "X-Nucleus-Signature": signature,
+        }
+        if actor_value:
+            headers["X-Nucleus-Actor"] = actor_value
+        return headers

--- a/sdk/python/nucleus_sdk/client.py
+++ b/sdk/python/nucleus_sdk/client.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, Optional
+
+import requests
+
+from .auth import AuthStrategy, MtlsConfig
+from .errors import NucleusError, RequestError, from_error_payload
+from .models import PodSpec
+
+
+class BaseClient:
+    def __init__(
+        self,
+        base_url: str,
+        auth: Optional[AuthStrategy] = None,
+        mtls: Optional[MtlsConfig] = None,
+        timeout: float = 30.0,
+    ) -> None:
+        if not base_url:
+            raise ValueError("base_url is required")
+        self.base_url = base_url.rstrip("/")
+        self.auth = auth
+        self.timeout = timeout
+        self.session = requests.Session()
+
+        if mtls is not None:
+            self.session.cert = mtls.cert_pair()
+            if mtls.ca_bundle:
+                self.session.verify = mtls.ca_bundle
+            else:
+                self.session.verify = True
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        payload: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        url = f"{self.base_url}{path}"
+        headers: Dict[str, str] = {"Content-Type": "application/json"}
+
+        body_bytes = b""
+        if payload is not None:
+            body = json.dumps(payload, separators=(",", ":"), ensure_ascii=False)
+            body_bytes = body.encode("utf-8")
+        if self.auth is not None:
+            headers.update(self.auth.headers(body_bytes))
+
+        response = self.session.request(
+            method,
+            url,
+            data=body_bytes if payload is not None else None,
+            headers=headers,
+            timeout=self.timeout,
+        )
+
+        if response.status_code >= 400:
+            try:
+                error_payload = response.json()
+            except ValueError:
+                raise RequestError(
+                    f"request failed ({response.status_code})",
+                    status=response.status_code,
+                )
+            raise from_error_payload(error_payload, response.status_code)
+
+        if response.content:
+            return response.json()
+        return {}
+
+
+class ProxyClient(BaseClient):
+    def read(self, path: str) -> str:
+        payload = {"path": path}
+        data = self._request("POST", "/v1/read", payload)
+        return data.get("contents", "")
+
+    def write(self, path: str, contents: str) -> None:
+        payload = {"path": path, "contents": contents}
+        self._request("POST", "/v1/write", payload)
+
+    def run(
+        self,
+        args: list[str],
+        stdin: Optional[str] = None,
+        directory: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {"args": args}
+        if stdin is not None:
+            payload["stdin"] = stdin
+        if directory is not None:
+            payload["directory"] = directory
+        return self._request("POST", "/v1/run", payload)
+
+    def web_fetch(
+        self,
+        url: str,
+        method: Optional[str] = None,
+        headers: Optional[Dict[str, str]] = None,
+        body: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {"url": url}
+        if method is not None:
+            payload["method"] = method
+        if headers is not None:
+            payload["headers"] = headers
+        if body is not None:
+            payload["body"] = body
+        return self._request("POST", "/v1/web_fetch", payload)
+
+    def web_search(self, query: str, max_results: Optional[int] = None) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {"query": query}
+        if max_results is not None:
+            payload["max_results"] = max_results
+        return self._request("POST", "/v1/web_search", payload)
+
+    def glob(
+        self,
+        pattern: str,
+        directory: Optional[str] = None,
+        max_results: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {"pattern": pattern}
+        if directory is not None:
+            payload["directory"] = directory
+        if max_results is not None:
+            payload["max_results"] = max_results
+        return self._request("POST", "/v1/glob", payload)
+
+    def grep(
+        self,
+        pattern: str,
+        path: Optional[str] = None,
+        file_glob: Optional[str] = None,
+        context_lines: Optional[int] = None,
+        max_matches: Optional[int] = None,
+        case_insensitive: Optional[bool] = None,
+    ) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {"pattern": pattern}
+        if path is not None:
+            payload["path"] = path
+        if file_glob is not None:
+            payload["glob"] = file_glob
+        if context_lines is not None:
+            payload["context_lines"] = context_lines
+        if max_matches is not None:
+            payload["max_matches"] = max_matches
+        if case_insensitive is not None:
+            payload["case_insensitive"] = case_insensitive
+        return self._request("POST", "/v1/grep", payload)
+
+    def approve(self, operation: str, count: int = 1, expires_at_unix: Optional[int] = None, nonce: Optional[str] = None) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {"operation": operation, "count": count}
+        if expires_at_unix is not None:
+            payload["expires_at_unix"] = expires_at_unix
+        if nonce is not None:
+            payload["nonce"] = nonce
+        return self._request("POST", "/v1/approve", payload)
+
+
+class NodeClient(BaseClient):
+    def create_pod(self, spec: PodSpec) -> Dict[str, Any]:
+        payload = {"spec": spec.to_dict()}
+        return self._request("POST", "/v1/pods", payload)
+
+    def list_pods(self) -> Dict[str, Any]:
+        return self._request("GET", "/v1/pods")
+
+    def pod_logs(self, pod_id: str) -> Dict[str, Any]:
+        return self._request("GET", f"/v1/pods/{pod_id}/logs")
+
+    def cancel_pod(self, pod_id: str) -> Dict[str, Any]:
+        return self._request("POST", f"/v1/pods/{pod_id}/cancel")
+
+
+class Nucleus:
+    def __init__(
+        self,
+        proxy_url: Optional[str] = None,
+        node_url: Optional[str] = None,
+        auth: Optional[AuthStrategy] = None,
+        mtls: Optional[MtlsConfig] = None,
+        timeout: float = 30.0,
+    ) -> None:
+        self.proxy_url = proxy_url
+        self.node_url = node_url
+        self.auth = auth
+        self.mtls = mtls
+        self.timeout = timeout
+
+    def proxy(self) -> ProxyClient:
+        if not self.proxy_url:
+            raise ValueError("proxy_url is required to create a ProxyClient")
+        return ProxyClient(self.proxy_url, auth=self.auth, mtls=self.mtls, timeout=self.timeout)
+
+    def node(self) -> NodeClient:
+        if not self.node_url:
+            raise ValueError("node_url is required to create a NodeClient")
+        return NodeClient(self.node_url, auth=self.auth, mtls=self.mtls, timeout=self.timeout)
+
+    def intent(self, intent, work_dir: str = ".", timeout_seconds: int = 3600):
+        from .intent import Intent, IntentSession, profile_for_intent, pod_spec_for_intent
+
+        if not isinstance(intent, Intent):
+            raise ValueError("intent must be an Intent enum")
+
+        profile = profile_for_intent(intent)
+
+        if self.proxy_url:
+            proxy_client = self.proxy()
+            return IntentSession(proxy_client, profile)
+
+        if not self.node_url:
+            raise ValueError("proxy_url or node_url is required to open an intent")
+
+        node_client = self.node()
+        pod_spec = pod_spec_for_intent(intent, work_dir=work_dir, timeout_seconds=timeout_seconds)
+        result = node_client.create_pod(pod_spec)
+        proxy_addr = result.get("proxy_addr")
+        if not proxy_addr:
+            raise NucleusError("pod created but proxy address missing")
+
+        proxy_client = ProxyClient(proxy_addr, auth=self.auth, mtls=self.mtls, timeout=self.timeout)
+        return IntentSession(proxy_client, profile, pod_id=str(result.get("id")))

--- a/sdk/python/nucleus_sdk/errors.py
+++ b/sdk/python/nucleus_sdk/errors.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class NucleusError(Exception):
+    message: str
+    kind: Optional[str] = None
+    status: Optional[int] = None
+    operation: Optional[str] = None
+
+    def __str__(self) -> str:
+        return self.message
+
+
+class ApprovalRequired(NucleusError):
+    pass
+
+
+class AccessDenied(NucleusError):
+    pass
+
+
+class AuthError(NucleusError):
+    pass
+
+
+class SpecError(NucleusError):
+    pass
+
+
+class RequestError(NucleusError):
+    pass
+
+
+def from_error_payload(payload: dict, status: int) -> NucleusError:
+    message = payload.get("error", "request failed")
+    kind = payload.get("kind")
+    operation = payload.get("operation")
+
+    if kind == "approval_required":
+        return ApprovalRequired(message, kind=kind, status=status, operation=operation)
+
+    if kind in {
+        "path_denied",
+        "command_denied",
+        "sandbox_escape",
+        "trifecta_blocked",
+        "insufficient_capability",
+        "dns_not_allowed",
+    }:
+        return AccessDenied(message, kind=kind, status=status, operation=operation)
+
+    if kind == "auth_error":
+        return AuthError(message, kind=kind, status=status, operation=operation)
+
+    if kind in {"spec_error", "serde_error", "body_error", "validation_error"}:
+        return SpecError(message, kind=kind, status=status, operation=operation)
+
+    return RequestError(message, kind=kind, status=status, operation=operation)

--- a/sdk/python/nucleus_sdk/intent.py
+++ b/sdk/python/nucleus_sdk/intent.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Dict, List, Optional
+
+from .models import PodSpec
+from .client import ProxyClient
+
+
+class Intent(str, Enum):
+    RESEARCH_WEB = "research_web"
+    CODE_REVIEW = "code_review"
+    FIX_ISSUE = "fix_issue"
+    GENERATE_CODE = "generate_code"
+    RELEASE = "release"
+    DATABASE_CLIENT = "database_client"
+    READ_ONLY = "read_only"
+    EDIT_ONLY = "edit_only"
+    LOCAL_DEV = "local_dev"
+    NETWORK_ONLY = "network_only"
+
+
+@dataclass(frozen=True)
+class IntentProfile:
+    intent: Intent
+    profile: str
+    description: str
+    allowed_ops: List[str]
+    gated_ops: List[str]
+    notes: Optional[str] = None
+
+
+INTENT_PROFILES: Dict[Intent, IntentProfile] = {
+    Intent.RESEARCH_WEB: IntentProfile(
+        intent=Intent.RESEARCH_WEB,
+        profile="web_research",
+        description="Read files plus web search/fetch.",
+        allowed_ops=["read", "glob", "grep", "web_search", "web_fetch"],
+        gated_ops=[],
+    ),
+    Intent.CODE_REVIEW: IntentProfile(
+        intent=Intent.CODE_REVIEW,
+        profile="code_review",
+        description="Read-only repo review with optional web lookup.",
+        allowed_ops=["read", "glob", "grep", "web_search"],
+        gated_ops=[],
+    ),
+    Intent.FIX_ISSUE: IntentProfile(
+        intent=Intent.FIX_ISSUE,
+        profile="fix_issue",
+        description="Edit + run tools; approvals required when trifecta is active.",
+        allowed_ops=["read", "write", "run", "glob", "grep"],
+        gated_ops=["run", "web_fetch", "web_search", "git_push"],
+        notes="Exfiltration vectors may require approval when trifecta is complete.",
+    ),
+    Intent.GENERATE_CODE: IntentProfile(
+        intent=Intent.GENERATE_CODE,
+        profile="codegen",
+        description="Write + run tools without network.",
+        allowed_ops=["read", "write", "run", "glob", "grep"],
+        gated_ops=[],
+    ),
+    Intent.RELEASE: IntentProfile(
+        intent=Intent.RELEASE,
+        profile="release",
+        description="Release flow with explicit approvals.",
+        allowed_ops=["read", "write", "run", "web_search", "web_fetch"],
+        gated_ops=["git_push", "create_pr", "run"],
+    ),
+    Intent.DATABASE_CLIENT: IntentProfile(
+        intent=Intent.DATABASE_CLIENT,
+        profile="database_client",
+        description="Database CLI only.",
+        allowed_ops=["run"],
+        gated_ops=[],
+    ),
+    Intent.READ_ONLY: IntentProfile(
+        intent=Intent.READ_ONLY,
+        profile="read_only",
+        description="Explore files safely; no writes or execution.",
+        allowed_ops=["read", "glob", "grep"],
+        gated_ops=[],
+    ),
+    Intent.EDIT_ONLY: IntentProfile(
+        intent=Intent.EDIT_ONLY,
+        profile="edit_only",
+        description="Edit files without execution or network.",
+        allowed_ops=["read", "write", "glob", "grep"],
+        gated_ops=[],
+    ),
+    Intent.LOCAL_DEV: IntentProfile(
+        intent=Intent.LOCAL_DEV,
+        profile="local_dev",
+        description="Local development without network.",
+        allowed_ops=["read", "write", "run", "glob", "grep"],
+        gated_ops=[],
+    ),
+    Intent.NETWORK_ONLY: IntentProfile(
+        intent=Intent.NETWORK_ONLY,
+        profile="network_only",
+        description="Web-only research with no file access.",
+        allowed_ops=["web_search", "web_fetch"],
+        gated_ops=[],
+    ),
+}
+
+
+class IntentSession:
+    def __init__(self, proxy: ProxyClient, profile: IntentProfile, pod_id: Optional[str] = None):
+        self._proxy = proxy
+        self.profile = profile
+        self.pod_id = pod_id
+
+    def describe(self) -> IntentProfile:
+        return self.profile
+
+    def read(self, path: str) -> str:
+        return self._proxy.read(path)
+
+    def write(self, path: str, contents: str) -> None:
+        self._proxy.write(path, contents)
+
+    def run(self, args: List[str], stdin: Optional[str] = None, directory: Optional[str] = None):
+        return self._proxy.run(args=args, stdin=stdin, directory=directory)
+
+    def web_fetch(self, url: str, method: Optional[str] = None, headers: Optional[Dict[str, str]] = None, body: Optional[str] = None):
+        return self._proxy.web_fetch(url=url, method=method, headers=headers, body=body)
+
+    def web_search(self, query: str, max_results: Optional[int] = None):
+        return self._proxy.web_search(query=query, max_results=max_results)
+
+    def glob(self, pattern: str, directory: Optional[str] = None, max_results: Optional[int] = None):
+        return self._proxy.glob(pattern=pattern, directory=directory, max_results=max_results)
+
+    def grep(self, pattern: str, path: Optional[str] = None, file_glob: Optional[str] = None, context_lines: Optional[int] = None, max_matches: Optional[int] = None, case_insensitive: Optional[bool] = None):
+        return self._proxy.grep(
+            pattern=pattern,
+            path=path,
+            file_glob=file_glob,
+            context_lines=context_lines,
+            max_matches=max_matches,
+            case_insensitive=case_insensitive,
+        )
+
+
+def profile_for_intent(intent: Intent) -> IntentProfile:
+    return INTENT_PROFILES[intent]
+
+
+def pod_spec_for_intent(intent: Intent, work_dir: str = ".", timeout_seconds: int = 3600) -> PodSpec:
+    profile = profile_for_intent(intent)
+    return PodSpec(work_dir=work_dir, timeout_seconds=timeout_seconds, profile=profile.profile)

--- a/sdk/python/nucleus_sdk/models.py
+++ b/sdk/python/nucleus_sdk/models.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+
+@dataclass
+class PodSpec:
+    work_dir: str = "."
+    timeout_seconds: int = 3600
+    profile: str = "default"
+    network_allow: Optional[List[str]] = None
+    dns_allow: Optional[List[str]] = None
+    cpu_cores: Optional[int] = None
+    memory_mib: Optional[int] = None
+
+    def to_dict(self) -> Dict[str, object]:
+        spec: Dict[str, object] = {
+            "apiVersion": "nucleus/v1",
+            "kind": "Pod",
+            "metadata": {},
+            "spec": {
+                "work_dir": self.work_dir,
+                "timeout_seconds": self.timeout_seconds,
+                "policy": {"type": "profile", "name": self.profile},
+            },
+        }
+
+        if self.network_allow or self.dns_allow:
+            spec["spec"]["network"] = {
+                "allow": self.network_allow or [],
+                "dns_allow": self.dns_allow or [],
+            }
+
+        if self.cpu_cores is not None or self.memory_mib is not None:
+            spec["spec"]["resources"] = {
+                "cpu_cores": self.cpu_cores,
+                "memory_mib": self.memory_mib,
+            }
+
+        return spec

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,0 +1,29 @@
+[build-system]
+requires = ["setuptools>=69", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "nucleus-sdk"
+version = "0.0.0"
+description = "Python SDK for Nucleus intents and tool-proxy APIs"
+readme = "README.md"
+requires-python = ">=3.9"
+license = { text = "Apache-2.0" }
+authors = [
+  { name = "Coproduct" }
+]
+classifiers = [
+  "Development Status :: 2 - Pre-Alpha",
+  "License :: OSI Approved :: Apache Software License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3 :: Only",
+]
+dependencies = [
+  "requests>=2.31",
+]
+
+[project.urls]
+Homepage = "https://github.com/coproduct-opensource/nucleus"
+
+[tool.setuptools]
+packages = ["nucleus_sdk"]


### PR DESCRIPTION
## Summary
- Add `sdk/python/` with an intent-first Python SDK wrapping the nucleus node and tool-proxy HTTP APIs
- 7 modules: client, intent, auth, models, errors, plus `__init__.py` and `pyproject.toml`
- Supports HMAC-SHA256 signing and mTLS authentication
- 10 built-in intent profiles (research_web, code_review, fix_issue, generate_code, release, database_client, read_only, edit_only, local_dev, network_only)
- Typed error hierarchy: `ApprovalRequired`, `AccessDenied`, `AuthError`, `SpecError`, `RequestError`
- Status: Pre-Alpha (v0.0.0) — API will change

## Modules
| Module | Purpose |
|--------|---------|
| `client.py` | `ProxyClient` (read/write/run/web/glob/grep/approve), `NodeClient` (create/list/logs/cancel pods), `Nucleus` facade |
| `intent.py` | `Intent` enum, `IntentProfile` dataclasses, `IntentSession` wrapper |
| `auth.py` | `HmacAuth` (HMAC-SHA256 signing matching Rust format), `MtlsConfig` |
| `models.py` | `PodSpec` builder with `to_dict()` |
| `errors.py` | Typed exceptions with `from_error_payload()` parser |

## Test plan
- [ ] Manual: `python -c "from nucleus_sdk import Nucleus, Intent; print(Intent.FIX_ISSUE)"`
- [ ] Future: Add pytest suite (out of scope for this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)