### PR TITLE
feat: add .editorconfig with consistent editor settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,30 @@
+# EditorConfig helps maintain consistent coding styles
+# https://editorconfig.org/
+
+root = true
+
+# All files
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# Rust files
+[*.rs]
+indent_style = space
+indent_size = 4
+
+# YAML files
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2
+
+# TOML files
+[*.toml]
+indent_style = space
+indent_size = 2
+
+# Markdown files
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
## Summary

Adds a `.editorconfig` file to establish consistent editor settings across contributors.

## Context

This PR was produced by the groundtruth autonomous orbit pipeline (work_id: `75534f0f`).
The ship pipeline initially failed with a 422 because the work branch was pushed without
the agent's commit (Claude CLI creates `agent/*` branches inside the worktree rather than
committing on the `work/<uuid>` branch). The branch has been manually corrected and the
underlying bug fixed in the daemon code.

## Autonomous Attestation

- **Orbit ID**: 75534f0f-64ab-4407-b6fc-14f56d8fa121
- **Agent**: Architect
- **Commit**: 417d9c5

---
Generated by groundtruth daemon ship pipeline