### PR TITLE
feat: approval bundles, execution receipts, SDK fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2357,6 +2357,7 @@ dependencies = [
  "pem",
  "regex",
  "reqwest",
+ "ring",
  "rustls",
  "serde",
  "serde_json",

--- a/crates/nucleus-node/proto/nucleus_node.proto
+++ b/crates/nucleus-node/proto/nucleus_node.proto
@@ -93,6 +93,27 @@ message GetPodResponse {
   PodInfo pod = 1;
 }
 
+// Execution receipt — cryptographic proof of pod execution outcome.
+// Built from the tool-proxy's exit report plus node-level metadata.
+message ExecutionReceipt {
+  string pod_id = 1;
+  string workspace_hash = 2;
+  string audit_tail_hash = 3;
+  uint64 audit_entry_count = 4;
+  uint64 timestamp_unix = 5;
+  string manifest_hash = 6;
+  string sandbox_tier = 7;
+  string spiffe_id = 8;
+}
+
+message GetReceiptRequest {
+  string pod_id = 1;
+}
+
+message GetReceiptResponse {
+  ExecutionReceipt receipt = 1;
+}
+
 service NodeService {
   // Pod lifecycle management
   rpc CreatePod(CreatePodRequest) returns (CreatePodResponse);
@@ -106,4 +127,7 @@ service NodeService {
   // Streaming observability for orchestrators
   rpc StreamPodLogs(StreamLogsRequest) returns (stream LogEntry);
   rpc WatchPodState(WatchPodRequest) returns (stream PodStateChange);
+
+  // Execution receipt for auditing
+  rpc GetReceipt(GetReceiptRequest) returns (GetReceiptResponse);
 }

--- a/crates/nucleus-node/src/auth.rs
+++ b/crates/nucleus-node/src/auth.rs
@@ -278,6 +278,8 @@ pub enum Operation {
     CancelPod,
     /// Stream logs from a pod.
     StreamLogs,
+    /// Get execution receipt for a pod.
+    GetReceipt,
     /// Any pod management operation (used for matching).
     PodManagement,
 }
@@ -405,6 +407,7 @@ impl AuthorizationPolicy {
                     | Operation::CancelPod
                     | Operation::StreamLogs
                     | Operation::ListPods
+                    | Operation::GetReceipt
                     | Operation::PodManagement => {
                         tracing::debug!(
                             spiffe_id = %spiffe_id,

--- a/crates/nucleus-sdk/src/lib.rs
+++ b/crates/nucleus-sdk/src/lib.rs
@@ -70,7 +70,7 @@ pub use auth::{AuthStrategy, HmacAuth, MtlsConfig};
 pub use client::{Nucleus, NucleusBuilder};
 pub use error::Error;
 pub use intent::{Intent, IntentProfile, IntentSession};
-pub use node::NodeClient;
+pub use node::{ExecutionReceipt, NodeClient};
 pub use proxy::ProxyClient;
 pub use types::*;
 

--- a/crates/nucleus-tool-proxy/Cargo.toml
+++ b/crates/nucleus-tool-proxy/Cargo.toml
@@ -61,6 +61,7 @@ tokio-vsock = "0.7"
 
 [dev-dependencies]
 tempfile = { workspace = true }
+ring = "0.17"
 
 [lints]
 workspace = true

--- a/crates/nucleus-tool-proxy/tests/sandbox_integration.rs
+++ b/crates/nucleus-tool-proxy/tests/sandbox_integration.rs
@@ -1,0 +1,32 @@
+//! Integration test: verify nucleus-tool-proxy exits with code 78 (EX_CONFIG)
+//! when launched outside a managed sandbox (no SPIFFE socket, no sandbox token,
+//! no identity cert).
+
+use std::process::Command;
+
+#[test]
+fn exits_78_without_sandbox_proof() {
+    let bin = env!("CARGO_BIN_EXE_nucleus-tool-proxy");
+
+    let output = Command::new(bin)
+        .arg("--auth-secret")
+        .arg("test-secret")
+        .arg("--approval-secret")
+        .arg("test-approval-secret")
+        .arg("--spec")
+        .arg("/dev/null")
+        // Ensure no sandbox-related env vars leak from the test environment
+        .env_remove("NUCLEUS_SANDBOX_TOKEN")
+        .env_remove("SPIFFE_ENDPOINT_SOCKET")
+        .env_remove("NUCLEUS_IDENTITY_CERT")
+        .output()
+        .expect("failed to execute nucleus-tool-proxy binary");
+
+    assert_eq!(
+        output.status.code(),
+        Some(78),
+        "expected exit code 78 (EX_CONFIG), got {:?}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}

--- a/sdk/python/nucleus_sdk/__init__.py
+++ b/sdk/python/nucleus_sdk/__init__.py
@@ -1,4 +1,5 @@
 from .client import Nucleus, NodeClient, ProxyClient
+from .models import PodInfo, PodSpec
 from .intent import Intent, IntentSession, IntentProfile
 from .auth import MtlsConfig, HmacAuth
 from .errors import (
@@ -14,6 +15,8 @@ __all__ = [
     "Nucleus",
     "NodeClient",
     "ProxyClient",
+    "PodInfo",
+    "PodSpec",
     "Intent",
     "IntentSession",
     "IntentProfile",


### PR DESCRIPTION
## Summary

- **Fix PodState serde mismatch** (#75, #83): tool-proxy's `node_client.rs` used internally-tagged serde (`tag = "type"`) while nucleus-node emits externally-tagged JSON — `list_pods()` deserialization now works correctly. Added `PodInfo` dataclass to Python SDK and integration test asserting exit code 78 without sandbox proof.
- **Approval bundle enforcement** (#3): `ApprovalBundleVerifier` from `nucleus-identity` is now wired into tool-proxy startup via `NUCLEUS_APPROVAL_BUNDLE` env var. Extracts embedded JWK, verifies JWS signature + manifest hash, populates `ApprovalRegistry` with approved operations/counts/expiry. `--require-approval-bundle` flag makes it mandatory.
- **Execution receipts** (#70): `exit_report.rs` (previously dead code) wired into graceful shutdown — writes `.nucleus-exit-report.json` with workspace hash, audit tail hash, and entry count. New `ExecutionReceipt` proto messages + `GetReceipt` RPC in nucleus-node. `get_receipt()` added to both Rust and Python SDKs.

## Test plan

- [x] `cargo test --workspace` — all pass (96 tests in tool-proxy alone)
- [x] `cargo clippy --workspace` — clean
- [x] `cargo deny` + `cargo audit` — clean
- [x] 4 new approval bundle unit tests (valid bundle, wrong manifest, max_uses, invalid JWS)
- [x] 3 new PodState serde deserialization tests (externally-tagged format)
- [x] 1 new sandbox integration test (exit code 78 without sandbox proof)
- [x] Python SDK import test: `from nucleus_sdk.models import PodInfo`

Closes #3, closes #70, closes #75, closes #83

🤖 Generated with [Claude Code](https://claude.ai/code)