### PR TITLE
chore: add .github/groundtruth.yml — enable daemon auto-merge

### DIFF
--- a/.github/groundtruth.yml
+++ b/.github/groundtruth.yml
@@ -1,0 +1,32 @@
+# Groundtruth configuration for coproduct-opensource/nucleus
+# https://github.com/coproduct-opensource/nucleus
+
+enabled: true
+
+# Watch the main CI workflow (required status checks: Clippy, Tests, Rustfmt)
+watch_workflows:
+  - "CI"
+
+# Budget per fix attempt
+budget_limit_usd: 3.0
+
+# Auto-merge: enabled, CI required, conservative file/cost caps
+auto_merge:
+  enabled: true
+  require_ci_pass: true
+  max_cost_usd: 2.00
+  max_files_changed: 10
+  allowed_risk_grades:
+    - none
+    - low
+
+# Labels the daemon adds to its PRs
+pr_labels:
+  - groundtruth
+  - autonomous
+
+# Autonomy cap: full (public repo, branch protection enforces safety)
+autonomy_cap: full
+
+# Max concurrent fix sessions for this repo
+max_concurrent_fixes: 2


### PR DESCRIPTION
## Summary
- Adds `.github/groundtruth.yml` to configure the Groundtruth daemon for this repo
- Enables auto-merge for daemon-created PRs (CI required, cost ≤ \$2, ≤10 files, risk grade none/low)
- Declares `CI/CD` as the watched workflow (maps to existing branch protection checks: Clippy, Tests, Rustfmt)
- Sets `autonomy_cap: full` — branch protection already enforces safety gates

## Test plan
- [ ] Verify `cargo test` CI passes
- [ ] Confirm `RepoConfigLoader` correctly parses the file via unit test coverage in `repo_config.rs`
- [ ] After merge: confirm daemon logs "auto_merge.enabled=true" for nucleus on next config reload

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)