### PR TITLE
feat: Marp slide deck + GitHub Pages deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,8 @@ on:
     branches: [main]
     paths:
       - "docs/**"
+      - "slides/**"
+      - "blog/**"
       - "book.toml"
       - ".github/workflows/docs.yml"
 
@@ -24,10 +26,24 @@ jobs:
         with:
           toolchain: stable
           cache: true
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
       - name: Install mdBook
         run: cargo install mdbook --locked
       - name: Build docs
         run: mdbook build
+      - name: Build slides
+        run: |
+          mkdir -p book/slides
+          npx --yes @marp-team/marp-cli@latest \
+            -I slides \
+            --html \
+            -o book/slides
+      - name: Copy blog posts
+        run: |
+          mkdir -p book/blog
+          cp blog/*.md book/blog/
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v4
         with:

--- a/blog/2026-03-04-we-audited-our-own-agent-platform.md
+++ b/blog/2026-03-04-we-audited-our-own-agent-platform.md
@@ -1,0 +1,201 @@
+# We Audited Our Own AI Agent Platform. Here's What We Found.
+
+*March 4, 2026*
+
+We build [Nucleus](https://github.com/coproduct-opensource/nucleus), an open-source security runtime for AI agents. Last week, we turned our own tools on our production orchestration platform — the closed-source system that actually runs our agents — and found **5 critical fail-open vulnerabilities**.
+
+Every one of them was a variant of the same pattern: **security that was present in code but absent in enforcement**.
+
+This is the story of what we found, why it matters for anyone running AI agents in production, and what we did about it.
+
+## The Threat Model Has Changed
+
+If you're running AI agents that can read files, process web content, and push code, you have what Simon Willison calls the [lethal trifecta](https://simonwillison.net/2025/Jun/16/the-lethal-trifecta/):
+
+```
+Private Data Access  +  Untrusted Content  +  Exfiltration Vector
+```
+
+When all three are present, prompt injection becomes data exfiltration. A carefully crafted comment in a PR, a poisoned web page, a manipulated search result — any of these can instruct your agent to send your secrets somewhere they shouldn't go.
+
+The standard defense is a YAML configuration file that says "don't do that." We wanted to know: does our own platform do any better?
+
+## What We Found
+
+We ran a systematic security audit of our orchestration daemon — the service that manages work queues, dispatches tasks to agents, handles GitHub webhooks, and serves the operations dashboard. Here are the five critical findings.
+
+### Finding 1: gRPC Server With No Authentication
+
+**The vulnerability:** Our gRPC server (port 4003) had no authentication middleware by default. The SPIFFE mTLS path existed behind a feature flag, but if TLS configuration failed at startup, the server silently fell back to plaintext with a warning log.
+
+```rust
+// Before: silent degradation to insecure
+Err(e) => {
+    warn!("Failed to build TLS config, starting without mTLS");
+    Server::builder() // No auth, no TLS, full access
+}
+```
+
+**Why it matters:** Any process on the same private network could register fake executors, enqueue malicious work items, or submit fabricated results. gRPC reflection was always enabled, making service discovery trivial.
+
+**The fix:** TLS failure now panics. If SPIFFE mTLS can't be established, the gRPC server refuses to start. Reflection is gated behind `#[cfg(debug_assertions)]`.
+
+```rust
+// After: fail-closed
+Err(e) => panic!("SPIFFE TLS failed: {e}. Refusing insecure gRPC fallback."),
+```
+
+### Finding 2: Webhook Signature Verification Disabled by Default
+
+**The vulnerability:** The `verify_github_signature()` function returned `true` when the webhook secret was empty. Since the secret defaulted to an empty string via `unwrap_or_default()`, a fresh deployment accepted **any** webhook payload without verification.
+
+```rust
+// Before: empty secret = accept everything
+if secret.is_empty() {
+    warn!("Webhook signature verification disabled");
+    return true; // ← every forged payload passes
+}
+```
+
+**Why it matters:** An attacker could forge GitHub webhook events to enqueue work items with crafted payloads, trigger workflows with malicious directives, or inject PR review comments that steer agent behavior. This is a direct vector for prompt injection at the orchestration layer.
+
+**The fix:** Empty secret now rejects all payloads.
+
+```rust
+// After: no secret = no webhooks
+if secret.is_empty() {
+    error!("Webhook rejected: GITHUB_WEBHOOK_SECRET is not configured.");
+    return false;
+}
+```
+
+### Finding 3: Sessions That Never Expire
+
+**The vulnerability:** The session store was an in-memory `HashMap` with no TTL enforcement, no cleanup task, and no size bound. The token endpoint advertised `expires_in: 3600` in its response — but the server never checked `created_at` against the current time.
+
+**Why it matters:** Two problems. First, a compromised token could never be revoked without restarting the daemon. Second, the unbounded HashMap meant an attacker could hit the token endpoint repeatedly to exhaust memory — a trivial denial of service.
+
+**The fix:** Sessions now have a 24-hour TTL enforced at read time, a 10,000 session size cap, and a background reaper that prunes expired sessions every 5 minutes.
+
+```rust
+pub fn spawn_session_reaper(sessions: SessionStore) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut interval = interval(Duration::from_secs(300));
+        loop {
+            interval.tick().await;
+            let now = Utc::now().timestamp();
+            let mut store = sessions.write().await;
+            store.retain(|_, s| now - s.created_at <= SESSION_TTL_SECS);
+        }
+    })
+}
+```
+
+### Finding 4: Authentication That Was Optional
+
+**The vulnerability:** A `maybe_auth!` macro made authentication entirely conditional. If no auth mechanism was configured — no OAuth, no API keys, no client credentials — every API route was served without any authentication at all.
+
+```rust
+// Before: no config = no auth = full access
+macro_rules! maybe_auth {
+    ($routes:expr) => {
+        if auth_enabled {
+            $routes.layer(auth_middleware)
+        } else {
+            $routes // ← every route wide open
+        }
+    };
+}
+```
+
+**Why it matters:** A single missing environment variable silently degraded every protected endpoint to zero security. State-mutating operations — approve, reject, pause, resume, drain queue, enable autonomous mode — all became publicly accessible.
+
+**The fix:** When auth is not configured, all protected routes now return 503 Service Unavailable. The system is unusable until properly configured, which is exactly right.
+
+```rust
+// After: no config = fail closed
+} else {
+    $routes.layer(axum::middleware::from_fn(
+        handlers::auth_not_configured_middleware,
+    ))
+}
+```
+
+### Finding 5: Hardcoded Cookie Secret + No Security Headers
+
+**The vulnerability:** If `DASHBOARD_COOKIE_SECRET` wasn't set, the fallback was a hardcoded string: `"development-secret-change-in-production-32bytes!"`. Additionally, no security headers (HSTS, X-Frame-Options, CSP, X-Content-Type-Options) were set on any response.
+
+**Why it matters:** The hardcoded secret meant every deployment without explicit configuration shared the same signing key. The missing headers left the dashboard vulnerable to clickjacking, protocol downgrade, and MIME sniffing attacks.
+
+**The fix:** Cookie secret is now required when any auth mechanism is configured, validated to be at least 32 bytes. A `security_headers` middleware adds HSTS, X-Frame-Options DENY, X-Content-Type-Options nosniff, and Referrer-Policy to every response.
+
+## The Common Pattern: Fail-Open Defaults
+
+Every finding shares the same root cause: **the secure path existed but wasn't the default path**.
+
+| Finding | Secure Code Existed? | Default Behavior |
+|---------|---------------------|------------------|
+| gRPC auth | Yes (SPIFFE mTLS) | Falls back to plaintext |
+| Webhook verification | Yes (HMAC-SHA256) | Disabled on empty secret |
+| Session expiry | Yes (advertised TTL) | Never enforced |
+| Route auth | Yes (OAuth/API key) | Skipped when unconfigured |
+| Cookie secret | Yes (env var) | Hardcoded fallback |
+
+This is the most dangerous category of vulnerability. The security features pass code review because they exist. They pass testing because tests configure them. They fail in production because the deployment doesn't set the right environment variables, and the code silently degrades instead of refusing to start.
+
+**The fix is always the same: fail closed.** If the secure configuration isn't present, the system should refuse to operate — not operate insecurely.
+
+## What This Means for AI Agent Security
+
+These aren't exotic vulnerabilities. They're standard web application security issues that happen to exist in a platform that orchestrates AI agents. But the blast radius is different.
+
+When your web app has a session expiry bug, an attacker can access user data. When your agent orchestration platform has a session expiry bug, an attacker can:
+
+- Enqueue work items that instruct agents to read and exfiltrate secrets
+- Approve autonomous operations that should require human review
+- Inject webhook payloads that look like legitimate GitHub events
+- Register rogue executors that intercept credentials and prompts
+
+The lethal trifecta means that every orchestration vulnerability is also an exfiltration vulnerability. The agents have the access. The question is whether the guardrails are real.
+
+## How We Catch This Now
+
+We built `nucleus-audit scan` to catch these patterns statically — before deployment:
+
+```bash
+cargo install nucleus-audit
+
+nucleus-audit scan --pod-spec your-agent.yaml
+```
+
+The scan checks for:
+- **Trifecta risk** — does this configuration combine private data, untrusted content, and exfiltration?
+- **Permission surface area** — how many capabilities are granted at autonomous levels?
+- **Network posture** — is egress restricted or wide open?
+- **Isolation level** — is the agent running in a VM, a container, or on bare metal?
+- **Credential exposure** — how many secrets are passed to the agent?
+- **Timeout hygiene** — are there execution time limits?
+
+Exit code is non-zero when critical or high findings exist. Drop it into CI and block unsafe deployments.
+
+```bash
+# CI integration
+nucleus-audit scan --pod-spec agent.yaml --format json
+echo $?  # 0 = clean, 1 = critical/high findings
+```
+
+Static analysis catches misconfigurations. But as our own audit proved, you also need runtime enforcement that can't be degraded. That's why Nucleus runs agents inside Firecracker microVMs with an enforcing tool proxy — the permissions are checked on every operation, and they can only tighten, never relax.
+
+## The Takeaway
+
+We build security tools for AI agents. We still had five critical fail-open vulnerabilities in our own platform.
+
+The lesson isn't that security is hard (it is). The lesson is that **advisory security doesn't work**. Warn-and-continue is indistinguishable from no security at all in the deployment that matters — the one where someone forgot to set an environment variable.
+
+Every default must be secure. Every missing configuration must be a hard failure. Every policy must be enforced, not just declared.
+
+That's what Nucleus does. And we know it works, because we used it to find the holes in our own platform.
+
+---
+
+*Nucleus is open source under MIT/Apache-2.0. [Star it on GitHub](https://github.com/coproduct-opensource/nucleus), try `nucleus-audit scan` on your agent configs, and [file issues](https://github.com/coproduct-opensource/nucleus/issues) when you find gaps.*

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -17,6 +17,8 @@
 - [Use Cases](use-cases/README.md)
   - [OpenClaw Hardening](use-cases/openclaw-hardening.md)
   - [Enterprise AI Agents](use-cases/enterprise-ai-agents.md)
+- [Talks & Slides]()
+  - [We Audited Our Own Agent Platform](../slides/we-audited-our-agent-platform.html)
 - [Terminology](terminology.md)
 - [Temporal Workflow](temporal.md)
 - [Theoretical Foundations](THEORY.md)

--- a/slides/we-audited-our-agent-platform.md
+++ b/slides/we-audited-our-agent-platform.md
@@ -1,0 +1,405 @@
+---
+marp: true
+theme: default
+paginate: true
+backgroundColor: #1a1a2e
+color: #e0e0e0
+style: |
+  section {
+    font-family: 'Inter', 'Segoe UI', sans-serif;
+  }
+  code {
+    color: #e06c75;
+    background: #2d2d44;
+    border-radius: 4px;
+    padding: 2px 6px;
+  }
+  pre {
+    background: #16213e;
+    border-radius: 8px;
+    border: 1px solid #333;
+  }
+  pre code {
+    background: transparent;
+    color: #abb2bf;
+  }
+  h1, h2 {
+    color: #61dafb;
+  }
+  h3 {
+    color: #c678dd;
+  }
+  strong {
+    color: #f5a623;
+  }
+  a {
+    color: #61dafb;
+  }
+  table {
+    font-size: 0.85em;
+  }
+  th {
+    background: #16213e;
+    color: #61dafb;
+  }
+  td {
+    background: #1a1a2e;
+  }
+  blockquote {
+    border-left: 4px solid #f5a623;
+    background: #16213e;
+    padding: 0.5em 1em;
+    border-radius: 0 8px 8px 0;
+  }
+  .columns {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1em;
+  }
+---
+
+<!-- _class: lead -->
+<!-- _paginate: false -->
+
+# We Audited Our Own AI Agent Platform
+
+## Here's What We Found.
+
+**5 critical fail-open vulnerabilities** in our own production system
+
+<br>
+
+coproduct-opensource/nucleus
+
+---
+
+# Who We Are
+
+We build **Nucleus** — an open-source security runtime for AI agents.
+
+Policy, enforcement, and audit in one stack.
+
+Last week, we turned our own tools on our **production orchestration platform**.
+
+> Every finding was a variant of the same pattern:
+> **security that was present in code but absent in enforcement.**
+
+---
+
+# The Threat Model Has Changed
+
+Your AI agent has three capabilities:
+
+```
+Private Data Access  +  Untrusted Content  +  Exfiltration Vector
+───────────────────      ─────────────────     ──────────────────
+read_files               web_fetch              git_push
+read_env                 web_search             create_pr
+database access          user input             run_bash (curl)
+```
+
+When **all three** are present at autonomous levels:
+
+**Prompt injection = Data exfiltration**
+
+*— Simon Willison, ["The Lethal Trifecta"](https://simonwillison.net/2025/Jun/16/the-lethal-trifecta/)*
+
+---
+
+# The Standard Defense
+
+A YAML file that says "don't do that."
+
+```yaml
+permissions:
+  git_push: "ask_human"    # advisory
+  web_fetch: "restricted"  # not enforced
+  read_files: "allowed"    # who checks?
+```
+
+<br>
+
+We wanted to know: **does our own platform do any better?**
+
+---
+
+<!-- _class: lead -->
+<!-- _paginate: false -->
+
+# The Five Findings
+
+---
+
+# Finding 1: gRPC With No Authentication
+
+The SPIFFE mTLS path existed — behind a feature flag.
+
+If TLS config failed, the server **silently fell back to plaintext**.
+
+```rust
+// Before: silent degradation to insecure
+Err(e) => {
+    warn!("Failed to build TLS config, starting without mTLS");
+    Server::builder() // No auth, no TLS, full access
+}
+```
+
+Any process on the same network could register fake executors,
+enqueue malicious work, or submit fabricated results.
+
+---
+
+# Finding 1: The Fix
+
+**Fail closed.** TLS failure = panic. No fallback.
+
+```rust
+// After: fail-closed
+Err(e) => panic!(
+    "SPIFFE TLS failed: {e}. Refusing insecure gRPC fallback."
+),
+```
+
+gRPC reflection gated behind `#[cfg(debug_assertions)]`.
+
+---
+
+# Finding 2: Webhooks Accepted Without Verification
+
+`verify_github_signature()` returned **`true`** on empty secret.
+
+Secret defaulted to `""` via `unwrap_or_default()`.
+
+```rust
+// Before: empty secret = accept everything
+if secret.is_empty() {
+    warn!("Webhook signature verification disabled");
+    return true; // ← every forged payload passes
+}
+```
+
+**Impact:** Forge GitHub events to inject work items with malicious directives.
+Direct vector for **prompt injection at the orchestration layer**.
+
+---
+
+# Finding 2: The Fix
+
+No secret = **reject all payloads**.
+
+```rust
+// After: no secret = no webhooks
+if secret.is_empty() {
+    error!("Webhook rejected: GITHUB_WEBHOOK_SECRET not configured.");
+    return false;
+}
+```
+
+---
+
+# Finding 3: Sessions That Never Expire
+
+Token endpoint advertised `expires_in: 3600`.
+
+The server **never checked** `created_at` against current time.
+
+- In-memory `HashMap` — no TTL, no cleanup, no size bound
+- Compromised tokens valid **forever** (until daemon restart)
+- Unbounded growth = trivial **denial of service**
+
+---
+
+# Finding 3: The Fix
+
+24-hour TTL + 10k cap + background reaper.
+
+```rust
+pub fn spawn_session_reaper(sessions: SessionStore) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut interval = interval(Duration::from_secs(300));
+        loop {
+            interval.tick().await;
+            let now = Utc::now().timestamp();
+            let mut store = sessions.write().await;
+            store.retain(|_, s| now - s.created_at <= SESSION_TTL_SECS);
+        }
+    })
+}
+```
+
+---
+
+# Finding 4: Auth Was Optional
+
+A `maybe_auth!` macro skipped auth when unconfigured.
+
+```rust
+// Before: no config = no auth = full access
+macro_rules! maybe_auth {
+    ($routes:expr) => {
+        if auth_enabled {
+            $routes.layer(auth_middleware)
+        } else {
+            $routes // ← every route wide open
+        }
+    };
+}
+```
+
+**One missing env var** → approve, reject, drain queue, enable autonomous mode — all public.
+
+---
+
+# Finding 4: The Fix
+
+Unconfigured = **503 on all protected routes**.
+
+```rust
+// After: no config = fail closed
+} else {
+    $routes.layer(axum::middleware::from_fn(
+        handlers::auth_not_configured_middleware,
+    ))
+}
+```
+
+The system is **unusable** until properly configured. That's correct.
+
+---
+
+# Finding 5: Hardcoded Secret + No Headers
+
+Cookie secret fallback: `"development-secret-change-in-production-32bytes!"`
+
+Every deployment without explicit config → **same signing key**.
+
+No security headers on any response:
+- No HSTS (protocol downgrade)
+- No X-Frame-Options (clickjacking)
+- No X-Content-Type-Options (MIME sniffing)
+- No CSP
+
+**Fix:** Secret required (≥ 32 bytes) + `security_headers` middleware on all responses.
+
+---
+
+<!-- _class: lead -->
+<!-- _paginate: false -->
+
+# The Pattern
+
+---
+
+# Fail-Open Defaults
+
+Every finding has the same root cause.
+
+| Finding | Secure Code Existed? | Default Behavior |
+|---------|---------------------|------------------|
+| gRPC auth | Yes (SPIFFE mTLS) | Falls back to plaintext |
+| Webhooks | Yes (HMAC-SHA256) | Disabled on empty secret |
+| Session expiry | Yes (advertised TTL) | Never enforced |
+| Route auth | Yes (OAuth/API key) | Skipped when unconfigured |
+| Cookie secret | Yes (env var) | Hardcoded fallback |
+
+Security features **pass code review** because they exist.
+They **pass testing** because tests configure them.
+They **fail in production** because deployments don't.
+
+---
+
+# Why It's Worse for Agent Platforms
+
+Web app session bug → attacker accesses **user data**.
+
+Agent platform session bug → attacker can:
+
+- **Enqueue work** that instructs agents to exfiltrate secrets
+- **Approve operations** that should require human review
+- **Inject webhooks** that look like legitimate GitHub events
+- **Register rogue executors** that intercept credentials
+
+Every orchestration vulnerability is an **exfiltration vulnerability**.
+
+The agents have the access. The guardrails must be real.
+
+---
+
+# How We Catch This Now
+
+```bash
+cargo install nucleus-audit
+
+nucleus-audit scan --pod-spec your-agent.yaml
+
+# ╔══════════════════════════════════════════════════════════════╗
+# ║  Nucleus PodSpec Security Scan                              ║
+# ╠══════════════════════════════════════════════════════════════╣
+# ║  Pod: yolo-agent                                            ║
+# ║  Findings: 4 critical, 2 high, 1 medium                    ║
+# ╠══════════════════════════════════════════════════════════════╣
+# ║  [CRITICAL] Lethal trifecta detected                        ║
+# ║  [CRITICAL] 7 credentials exposed                           ║
+# ║  [HIGH]     No network restrictions                         ║
+# ║  [HIGH]     No VM isolation                                 ║
+# ╚══════════════════════════════════════════════════════════════╝
+# Exit code: 1
+```
+
+Drop it in CI. Block unsafe deployments.
+
+---
+
+# Static Analysis + Runtime Enforcement
+
+**`nucleus-audit scan`** catches misconfigurations before deploy.
+
+**Nucleus runtime** enforces at execution:
+- Firecracker microVMs — isolated by default
+- Enforcing tool proxy — every side effect is checked
+- Permissions only **tighten**, never relax
+- Hash-chained audit logs — tampering is detectable
+
+Policy without enforcement is theater.
+
+---
+
+<!-- _class: lead -->
+<!-- _paginate: false -->
+
+# The Takeaway
+
+---
+
+# Advisory Security Doesn't Work
+
+We build security tools for AI agents.
+
+We still had **five critical fail-open vulnerabilities**.
+
+<br>
+
+**Every default must be secure.**
+**Every missing config must be a hard failure.**
+**Every policy must be enforced, not just declared.**
+
+<br>
+
+> Warn-and-continue is indistinguishable from no security
+> in the deployment where someone forgot an env var.
+
+---
+
+<!-- _class: lead -->
+<!-- _paginate: false -->
+
+# Try It
+
+```bash
+cargo install nucleus-audit
+nucleus-audit scan --pod-spec your-agent.yaml
+```
+
+**github.com/coproduct-opensource/nucleus**
+
+MIT / Apache-2.0


### PR DESCRIPTION
## Summary

- **Marp slide deck** — 22 slides distilled from the "We Audited Our Own Agent Platform" blog post, with dark theme, syntax-highlighted Rust code, and the fail-open defaults summary table
- **Blog post** — Full markdown blog post included for GH Pages hosting
- **docs.yml workflow** — Extended to build Marp slides alongside mdBook, deploying both to GitHub Pages
- **DOCS_DEPLOY enabled** — Repository variable set to `true` to activate deployment

## Slide deck preview

Slides cover: lethal trifecta, 5 findings with before/after code, fail-open defaults pattern, AI agent blast radius, and `nucleus-audit scan` CTA.

Locally verified with `npx @marp-team/marp-cli` — all 22 slides render correctly.

## Deploy target

- Docs: `https://coproduct-opensource.github.io/nucleus/`
- Slides: `https://coproduct-opensource.github.io/nucleus/slides/we-audited-our-agent-platform.html`
- Blog: `https://coproduct-opensource.github.io/nucleus/blog/`

## Test plan

- [x] `npx @marp-team/marp-cli -I slides --html -o book/slides` builds successfully
- [x] Slides verified in browser (title, code, table, CTA slides)
- [x] Pre-commit hooks pass (yaml, deny, audit)
- [x] `DOCS_DEPLOY` repo variable set to `true`

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)