### PR TITLE
ci: add Verus SMT verification workflow

### DIFF
--- a/.github/workflows/verus.yml
+++ b/.github/workflows/verus.yml
@@ -1,0 +1,78 @@
+name: Verus
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "crates/lattice-guard-verified/**"
+      - ".verus-version"
+      - ".github/workflows/verus.yml"
+  pull_request:
+    paths:
+      - "crates/lattice-guard-verified/**"
+      - ".verus-version"
+      - ".github/workflows/verus.yml"
+  schedule:
+    # Nightly: catch regressions from Verus toolchain updates
+    - cron: "42 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Verus SMT Proofs
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Read Verus version
+        id: verus-version
+        run: echo "version=$(cat .verus-version | tr -d '[:space:]')" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Verus binary
+        uses: actions/cache@v4
+        id: cache-verus
+        with:
+          path: .verus/verus-x86-linux
+          key: verus-linux-${{ steps.verus-version.outputs.version }}
+
+      - name: Download Verus
+        if: steps.cache-verus.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p .verus
+          VERUS_TAG="${{ steps.verus-version.outputs.version }}"
+          VERUS_FILE="verus-${VERUS_TAG#release/}-x86-linux.zip"
+          gh release download "$VERUS_TAG" \
+            -R verus-lang/verus \
+            -p "$VERUS_FILE" \
+            -D .verus/
+          cd .verus && unzip "$VERUS_FILE" && rm "$VERUS_FILE"
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Install Verus Rust toolchain
+        run: |
+          REQUIRED=$(.verus/verus-x86-linux/verus --version 2>&1 | grep -oP 'Toolchain: \K\S+' || true)
+          if [ -z "$REQUIRED" ]; then
+            REQUIRED=$(.verus/verus-x86-linux/verus 2>&1 | grep -oP "toolchain '\K[^']+")
+          fi
+          echo "Installing Rust toolchain: $REQUIRED"
+          rustup install "$REQUIRED"
+          rustup default "$REQUIRED"
+
+      - name: Verify lattice-guard-verified
+        run: |
+          echo "::group::Verus verification"
+          .verus/verus-x86-linux/verus crates/lattice-guard-verified/src/lib.rs
+          echo "::endgroup::"
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "## Verus Verification Results" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Verus version:** ${{ steps.verus-version.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Target:** \`crates/lattice-guard-verified/src/lib.rs\`" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/verus.yml` — runs Verus SMT proofs in CI
- Downloads and caches Verus binary from GitHub releases
- Reads pinned version from `.verus-version` for reproducibility
- Writes job summary with verification results

## Triggers

- **PR/push**: when `crates/lattice-guard-verified/**`, `.verus-version`, or the workflow itself changes
- **Nightly** (03:42 UTC): catches regressions from Verus toolchain updates
- **Manual dispatch**: for ad-hoc verification runs

## How it works

1. Reads `.verus-version` to determine which Verus release to download
2. Caches the Verus binary (keyed on version) to avoid re-downloading
3. Installs the required Rust toolchain (Verus pins a specific rustc version)
4. Runs `verus crates/lattice-guard-verified/src/lib.rs`
5. Writes a summary to the GitHub Actions job summary

## Test plan

- [ ] Workflow runs on this PR (path trigger matches)
- [ ] Verus downloads and caches correctly on ubuntu-22.04
- [ ] All 37 proofs verify in CI

🤖 Generated with [Claude Code](https://claude.ai/code)