### PR TITLE
perf(ci): optimize Kani BMC — CaDiCaL solver, fast/full tier split

### DIFF
--- a/.github/workflows/kani-nightly.yml
+++ b/.github/workflows/kani-nightly.yml
@@ -20,17 +20,32 @@ permissions:
   contents: read
 
 jobs:
-  kani:
+  # Fast tier: 4 lightweight harnesses — runs on every PR and push
+  kani-fast:
     name: Kani
-    runs-on: ubuntu-20.04
-    timeout-minutes: 30
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    if: github.event_name != 'schedule'
     steps:
       - uses: actions/checkout@v6
       - uses: Swatinem/rust-cache@v2
-      - name: Run Kani
+        with:
+          cache-on-failure: true
+      - name: Cache Kani toolchain
+        uses: actions/cache@v4
+        with:
+          path: ~/.kani
+          key: kani-toolchain-${{ runner.os }}-${{ hashFiles('.github/workflows/kani-nightly.yml') }}
+      - name: Run Kani (fast harnesses)
         uses: model-checking/kani-github-action@v1
         with:
-          args: "-p lattice-guard"
+          args: >-
+            -p lattice-guard
+            --solver cadical
+            --harness proof_normalize_idempotent
+            --harness proof_normalize_deflationary
+            --harness proof_normalize_monotone
+            --harness proof_capability_distributive
       - name: Proof count regression gate
         run: |
           PROOF_COUNT=$(grep -c '#\[kani::proof\]' crates/lattice-guard/src/kani.rs)
@@ -45,8 +60,49 @@ jobs:
         run: |
           PROOF_COUNT=$(grep -c '#\[kani::proof\]' crates/lattice-guard/src/kani.rs)
           MINIMUM=$(cat .kani-minimum-proofs | tr -d '[:space:]')
-          echo "## Kani BMC Results" >> "$GITHUB_STEP_SUMMARY"
+          echo "## Kani BMC Results (fast tier)" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Proof harnesses:** $PROOF_COUNT" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Harnesses verified:** 4 / $PROOF_COUNT (fast tier)" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Solver:** CaDiCaL" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Minimum required:** $MINIMUM" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Target:** lattice-guard" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Full suite:** nightly + workflow_dispatch" >> "$GITHUB_STEP_SUMMARY"
+
+  # Full tier: all 6 harnesses — nightly and on-demand only
+  kani-full:
+    name: Kani (full)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@v6
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+      - name: Cache Kani toolchain
+        uses: actions/cache@v4
+        with:
+          path: ~/.kani
+          key: kani-toolchain-${{ runner.os }}-${{ hashFiles('.github/workflows/kani-nightly.yml') }}
+      - name: Run Kani (all harnesses)
+        uses: model-checking/kani-github-action@v1
+        with:
+          args: "-p lattice-guard --solver cadical"
+      - name: Proof count regression gate
+        run: |
+          PROOF_COUNT=$(grep -c '#\[kani::proof\]' crates/lattice-guard/src/kani.rs)
+          MINIMUM=$(cat .kani-minimum-proofs | tr -d '[:space:]')
+          echo "Kani proof harnesses: $PROOF_COUNT (minimum: $MINIMUM)"
+          if [ "$PROOF_COUNT" -lt "$MINIMUM" ]; then
+            echo "::error::Kani proof count regression: $PROOF_COUNT < $MINIMUM"
+            exit 1
+          fi
+      - name: Summary
+        if: always()
+        run: |
+          PROOF_COUNT=$(grep -c '#\[kani::proof\]' crates/lattice-guard/src/kani.rs)
+          MINIMUM=$(cat .kani-minimum-proofs | tr -d '[:space:]')
+          echo "## Kani BMC Results (full suite)" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Harnesses verified:** $PROOF_COUNT / $PROOF_COUNT (all)" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Solver:** CaDiCaL" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Minimum required:** $MINIMUM" >> "$GITHUB_STEP_SUMMARY"

--- a/crates/lattice-guard/src/kani.rs
+++ b/crates/lattice-guard/src/kani.rs
@@ -138,6 +138,7 @@ fn build_ordered_permissions() -> (PermissionLattice, PermissionLattice) {
 }
 
 #[kani::proof]
+#[kani::solver(cadical)]
 fn proof_normalize_idempotent() {
     let (lhs, _) = build_ordered_permissions();
     let once = lhs.clone().normalize();
@@ -146,6 +147,7 @@ fn proof_normalize_idempotent() {
 }
 
 #[kani::proof]
+#[kani::solver(cadical)]
 fn proof_normalize_deflationary() {
     let (lhs, _) = build_ordered_permissions();
     let normalized = lhs.clone().normalize();
@@ -153,6 +155,8 @@ fn proof_normalize_deflationary() {
 }
 
 #[kani::proof]
+#[kani::solver(cadical)]
+#[kani::unwind(4)]
 fn proof_normalize_monotone() {
     let (lhs, rhs) = build_ordered_permissions();
     assert!(lhs.leq(&rhs));
@@ -203,6 +207,7 @@ fn perm_lattice_eq(a: &PermissionLattice, b: &PermissionLattice) -> bool {
 /// Kani exhaustively verifies this over all 3^12 * 3^12 * 3^12 = 3^36 combinations
 /// (after modular reduction from u8 inputs).
 #[kani::proof]
+#[kani::solver(cadical)]
 fn proof_capability_distributive() {
     let a = arbitrary_caps();
     let b = arbitrary_caps();
@@ -224,6 +229,8 @@ fn proof_capability_distributive() {
 /// paths, budget, commands, time) distributes meet over join. Equality is checked
 /// via `leq` in both directions to avoid UUID/timestamp mismatches.
 #[kani::proof]
+#[kani::solver(cadical)]
+#[kani::unwind(4)]
 fn proof_permission_distributive() {
     let a = build_arbitrary_permission();
     let b = build_arbitrary_permission();
@@ -246,6 +253,8 @@ fn proof_permission_distributive() {
 /// {b, c, d} as a practical approximation of the infinite frame axiom:
 ///   a /\ (\/_{i} b_i) = \/_{i} (a /\ b_i)
 #[kani::proof]
+#[kani::solver(cadical)]
+#[kani::unwind(4)]
 fn proof_frame_finite_distributivity() {
     let a = build_arbitrary_permission();
     let b = build_arbitrary_permission();


### PR DESCRIPTION
## Summary

- **Runner upgrade**: `ubuntu-20.04` → `ubuntu-24.04` — the 20.04 pool is EOL/shrinking, causing 10+ minute queue times (PR #139 was stuck indefinitely)
- **SAT solver**: MiniSat → CaDiCaL via `#[kani::solver(cadical)]` on all 6 harnesses — [2-200x faster](https://model-checking.github.io//kani-verifier-blog/2023/08/03/turbocharging-rust-code-verification.html) on enum-heavy verification
- **Unwind bounds**: `#[kani::unwind(4)]` on 3 heavy harnesses (`proof_normalize_monotone`, `proof_permission_distributive`, `proof_frame_finite_distributivity`) — prevents CBMC from over-unwinding collection ops
- **Toolchain caching**: `~/.kani` cached via `actions/cache@v4` — saves 2-5 min per run
- **Fast/full split**: PRs run 4 lightweight harnesses (~5 min), nightly runs all 6 (~15 min)

### Expected improvement

| Metric | Before | After |
|--------|--------|-------|
| Runner queue | 10+ min (20.04 scarcity) | ~30s (24.04) |
| SAT solver | MiniSat | CaDiCaL (2-200x faster) |
| PR verification | 6 harnesses, ~30 min | 4 fast harnesses, ~5 min |
| Full suite | Every PR | Nightly + on-demand |

## Test plan

- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] All pre-commit/pre-push hooks pass
- [ ] Verify `kani-fast` job completes in <15 min on this PR
- [ ] Trigger `workflow_dispatch` to verify `kani-full` after merge

🤖 Generated with [Claude Code](https://claude.ai/code)