### PR TITLE
chore: bump version to 1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2088,7 +2088,7 @@ dependencies = [
 
 [[package]]
 name = "nucleus"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "cap-std",
  "cap-tempfile",
@@ -2104,7 +2104,7 @@ dependencies = [
 
 [[package]]
 name = "nucleus-audit"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "clap",
  "hex",
@@ -2121,7 +2121,7 @@ dependencies = [
 
 [[package]]
 name = "nucleus-cli"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2150,7 +2150,7 @@ dependencies = [
 
 [[package]]
 name = "nucleus-client"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "drand-verify",
  "hex",
@@ -2166,7 +2166,7 @@ dependencies = [
 
 [[package]]
 name = "nucleus-guest-init"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "nix 0.31.2",
  "serde",
@@ -2176,7 +2176,7 @@ dependencies = [
 
 [[package]]
 name = "nucleus-identity"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -2208,7 +2208,7 @@ dependencies = [
 
 [[package]]
 name = "nucleus-mcp"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2224,11 +2224,11 @@ dependencies = [
 
 [[package]]
 name = "nucleus-net-probe"
-version = "0.1.0"
+version = "1.0.0"
 
 [[package]]
 name = "nucleus-node"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "axum",
  "base64",
@@ -2271,7 +2271,7 @@ dependencies = [
 
 [[package]]
 name = "nucleus-permission-market"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "proptest",
  "serde",
@@ -2281,7 +2281,7 @@ dependencies = [
 
 [[package]]
 name = "nucleus-proto"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "prost",
  "prost-types",
@@ -2293,7 +2293,7 @@ dependencies = [
 
 [[package]]
 name = "nucleus-sdk"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "nucleus-client",
  "nucleus-identity",
@@ -2314,7 +2314,7 @@ dependencies = [
 
 [[package]]
 name = "nucleus-spec"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "hex",
  "portcullis",
@@ -2327,7 +2327,7 @@ dependencies = [
 
 [[package]]
 name = "nucleus-tool-proxy"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "axum",
  "base64",
@@ -2679,7 +2679,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portcullis"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "cel-interpreter",
  "chrono",
@@ -4533,7 +4533,7 @@ dependencies = [
 
 [[package]]
 name = "trifecta-playground"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "crossterm",
  "portcullis",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ exclude = ["crates/portcullis-verified"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0"
+version = "1.0.0"
 edition = "2021"
 rust-version = "1.80"
 license = "MIT OR Apache-2.0"

--- a/crates/portcullis-verified/Cargo.toml
+++ b/crates/portcullis-verified/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "portcullis-verified"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Formally verified lattice proofs for portcullis (Verus SMT proofs)"

--- a/crates/portcullis/Cargo.toml
+++ b/crates/portcullis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "portcullis"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2021"
 rust-version = "1.80"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary
- Bumps workspace version from `0.1.0` to `1.0.0` across all 18 crates
- `portcullis` and `portcullis-verified` (non-workspace versions) bumped separately
- `Cargo.lock` updated to reflect new versions

## Context
Prerequisite for cutting the `v1.0.0` tag and triggering the release workflow. Should merge after PR #160 (v1.0 contract surface extension points).

## Test plan
- [x] `cargo check --workspace` passes
- [x] No hardcoded `0.1.0` references remain outside `Cargo.lock` deps
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
via [Happy](https://happy.engineering)