### PR TITLE
fix: suppress dead_code warning for validate_url in non-mcp builds

### DIFF
--- a/crates/nucleus-tool-proxy/src/web_fetch_policy.rs
+++ b/crates/nucleus-tool-proxy/src/web_fetch_policy.rs
@@ -26,6 +26,7 @@ pub const ALLOWED_MIME_PREFIXES: &[&str] = &[
 ];
 
 /// Validate a URL for web_fetch (length, scheme, null bytes).
+#[cfg_attr(not(feature = "mcp"), allow(dead_code))]
 pub fn validate_url(url: &str) -> Result<(), String> {
     validation::validate_url(url).map_err(|e| format!("validation error: {e}"))
 }


### PR DESCRIPTION
## Summary
- Adds `#[cfg_attr(not(feature = "mcp"), allow(dead_code))]` to `validate_url` in `web_fetch_policy.rs`
- This function is called from `mcp.rs` which is gated behind `#[cfg(feature = "mcp")]`
- Without the feature, `-D warnings` in release builds treats the unused function as a compile error

## Context
The v1.0.0 release workflow failed on musl builds because `nucleus-tool-proxy` is built without `--features mcp` for guest binaries. This fix unblocks the release.

## Test plan
- [x] `cargo check -p nucleus-tool-proxy` passes (no warnings)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
via [Happy](https://happy.engineering)