### PR TITLE
fix: use macos-13 runner and make rootfs non-blocking

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-          - os: macos-15-large
+          - os: macos-13
             target: x86_64-apple-darwin
           - os: macos-14
             target: aarch64-apple-darwin
@@ -172,7 +172,8 @@ jobs:
   release:
     name: Create Release
     runs-on: ubuntu-latest
-    needs: [build, build-musl, build-rootfs, upload-lima-templates]
+    needs: [build, build-musl, upload-lima-templates]
+    if: always() && needs.build.result == 'success' && needs.build-musl.result == 'success'
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
## Summary
- Changes macOS x86_64 runner from `macos-15-large` (unavailable) to `macos-13`
- Makes rootfs builds non-blocking for the release job — rootfs artifacts are included when available
- Unblocks the v1.0.0 release which failed due to infrastructure issues

## Test plan
- [ ] Re-tag v1.0.0 after merge and verify release workflow creates GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)
via [Happy](https://happy.engineering)