### PR TITLE
fix: release gates on musl builds only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,8 +172,8 @@ jobs:
   release:
     name: Create Release
     runs-on: ubuntu-latest
-    needs: [build, build-musl, upload-lima-templates]
-    if: always() && needs.build.result == 'success' && needs.build-musl.result == 'success'
+    needs: [build, build-musl, build-rootfs, upload-lima-templates]
+    if: always() && needs.build-musl.result == 'success'
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
## Summary
- Release job now only requires `build-musl` success to proceed
- macOS native builds and rootfs are included when available but non-blocking
- Unblocks v1.0.0 release (macOS x86_64 runners are intermittently unavailable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
via [Happy](https://happy.engineering)