### PR TITLE
fix: install Claude Code CLI in GitHub Action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -69,6 +69,12 @@ runs:
         chmod +x "$HOME/.nucleus/bin/"*
         echo "$HOME/.nucleus/bin" >> "$GITHUB_PATH"
 
+    - name: Install Claude Code CLI
+      shell: bash
+      run: |
+        npm install -g @anthropic-ai/claude-code
+        claude --version
+
     - name: Run safe PR fixer
       id: fix
       shell: bash


### PR DESCRIPTION
## Summary

- The nucleus CLI spawns `claude` as a subprocess via `run_claude_mcp()`
- The action was installing nucleus binaries but not the Claude CLI itself
- Adds `npm install -g @anthropic-ai/claude-code` step to action.yml

## Error this fixes

```
Error: failed to spawn claude
Caused by: No such file or directory (os error 2)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)