### PR TITLE
fix: bypass Claude permission checks in non-interactive mode

### DIFF
--- a/crates/nucleus-cli/src/run.rs
+++ b/crates/nucleus-cli/src/run.rs
@@ -789,6 +789,12 @@ fn run_claude_mcp(
 
     if has_approval_obligations(policy) {
         cmd.arg("--permission-mode").arg("plan");
+    } else {
+        // No approval obligations → bypass Claude's built-in permission checks.
+        // Security is enforced by the nucleus tool-proxy lattice, not Claude's
+        // permission system. Without this flag, --print (non-interactive) mode
+        // falls back to plan-only and the agent never implements.
+        cmd.arg("--dangerously-skip-permissions");
     }
 
     cmd.output().context("failed to spawn claude")


### PR DESCRIPTION
## Summary

- In `--print` (non-interactive) mode, Claude defaults to plan-only since it can't prompt for permission approval
- The nucleus tool-proxy already enforces the permission lattice via HMAC-signed MCP
- Pass `--dangerously-skip-permissions` when no approval obligations exist, since the tool-proxy IS the security boundary
- When obligations require approvals, still use `--permission-mode plan`

## Problem

Both dotenv-linter and lark live tests produced detailed implementation plans but never wrote code:
```
Duration: 351.87s
Yes, I'm ready to exit plan mode. The plan is complete...
```

The agent analyzed the issue, designed a solution, but couldn't execute it.

## Test plan

- [x] `cargo check -p nucleus-cli` passes
- [ ] Re-run live e2e tests on forked repos after merge + v1.0.2 release

🤖 Generated with [Claude Code](https://claude.com/claude-code)