### PR TITLE
feat: nucleus-audit release + github-token input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           cache: true
       - name: Build
-        run: cargo build -p nucleus-node -p nucleus-cli -p nucleus-mcp --release
+        run: cargo build -p nucleus-node -p nucleus-cli -p nucleus-mcp -p nucleus-audit --release
       - name: Package
         run: |
           TAG="${GITHUB_REF_NAME}"
@@ -40,6 +40,7 @@ jobs:
           tar -C target/release -czf "dist/nucleus-node-${VERSION}-${{ matrix.target }}.tar.gz" nucleus-node
           tar -C target/release -czf "dist/nucleus-cli-${VERSION}-${{ matrix.target }}.tar.gz" nucleus
           tar -C target/release -czf "dist/nucleus-mcp-${VERSION}-${{ matrix.target }}.tar.gz" nucleus-mcp
+          tar -C target/release -czf "dist/nucleus-audit-${VERSION}-${{ matrix.target }}.tar.gz" nucleus-audit
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
@@ -72,10 +73,11 @@ jobs:
           cross build -p nucleus-guest-init --release --target ${{ matrix.target }}
           cross build -p nucleus-tool-proxy --release --features remote-audit --target ${{ matrix.target }}
           cross build -p nucleus-net-probe --release --target ${{ matrix.target }}
-      - name: Build CLI + MCP (musl)
+      - name: Build CLI + MCP + Audit (musl)
         run: |
           cross build -p nucleus-cli --release --target ${{ matrix.target }}
           cross build -p nucleus-mcp --release --target ${{ matrix.target }}
+          cross build -p nucleus-audit --release --target ${{ matrix.target }}
       - name: Package all binaries
         run: |
           TAG="${GITHUB_REF_NAME}"
@@ -85,6 +87,7 @@ jobs:
           tar -C target/${{ matrix.target }}/release -czf "dist/nucleus-node-${VERSION}-${{ matrix.target }}.tar.gz" nucleus-node
           tar -C target/${{ matrix.target }}/release -czf "dist/nucleus-cli-${VERSION}-${{ matrix.target }}.tar.gz" nucleus
           tar -C target/${{ matrix.target }}/release -czf "dist/nucleus-mcp-${VERSION}-${{ matrix.target }}.tar.gz" nucleus-mcp
+          tar -C target/${{ matrix.target }}/release -czf "dist/nucleus-audit-${VERSION}-${{ matrix.target }}.tar.gz" nucleus-audit
           tar -C target/${{ matrix.target }}/release -czf "dist/nucleus-tool-proxy-${VERSION}-${{ matrix.target }}.tar.gz" nucleus-tool-proxy
       - name: Upload packaged artifacts
         uses: actions/upload-artifact@v7

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,9 @@ inputs:
   nucleus-version:
     description: 'Nucleus CLI version to install (or "latest")'
     default: 'latest'
+  github-token:
+    description: 'GitHub token for PR creation (defaults to github.token)'
+    default: ''
 
 outputs:
   branch:
@@ -84,5 +87,5 @@ runs:
         LLM_API_TOKEN: ${{ inputs.api-key }}
         NUCLEUS_TIMEOUT: ${{ inputs.timeout }}
         LLM_MODEL: ${{ inputs.model }}
-        GH_TOKEN: ${{ github.token }}
+        GH_TOKEN: ${{ inputs.github-token || github.token }}
       run: ${{ github.action_path }}/scripts/action-entrypoint.sh

--- a/scan/action.yml
+++ b/scan/action.yml
@@ -1,0 +1,86 @@
+name: 'Nucleus Scan'
+description: 'Deterministic security scan for AI agent PodSpecs. No LLM required.'
+branding:
+  icon: 'search'
+  color: 'orange'
+
+inputs:
+  pod-spec:
+    description: 'Path to PodSpec YAML file to scan'
+    required: true
+  audit-log:
+    description: 'Optional audit log to cross-reference against declared policy'
+    required: false
+  format:
+    description: 'Output format (text or json)'
+    default: 'text'
+  nucleus-version:
+    description: 'Nucleus version to install (or "latest")'
+    default: 'latest'
+
+outputs:
+  verdict:
+    description: 'Scan verdict (PASS, WARN, FAIL)'
+    value: ${{ steps.scan.outputs.verdict }}
+  findings-json:
+    description: 'Findings in JSON format'
+    value: ${{ steps.scan.outputs.findings_json }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Install nucleus-audit
+      shell: bash
+      run: |
+        set -euo pipefail
+        REPO="coproduct-opensource/nucleus"
+        if [ "${{ inputs.nucleus-version }}" = "latest" ]; then
+          VERSION=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | jq -r '.tag_name')
+        else
+          VERSION="${{ inputs.nucleus-version }}"
+        fi
+        VERSION_NUM="${VERSION#v}"
+
+        ARCH=$(uname -m)
+        case "$ARCH" in
+          x86_64)  TARGET="x86_64-unknown-linux-musl" ;;
+          aarch64) TARGET="aarch64-unknown-linux-musl" ;;
+          *)       echo "::error::Unsupported architecture: $ARCH"; exit 1 ;;
+        esac
+
+        ARTIFACT="nucleus-audit-${VERSION_NUM}-${TARGET}.tar.gz"
+        BASE_URL="https://github.com/${REPO}/releases/download/${VERSION}"
+
+        mkdir -p "$HOME/.nucleus/bin"
+        echo "::group::Installing nucleus-audit ${VERSION_NUM}"
+        curl -fsSL "${BASE_URL}/${ARTIFACT}" | tar -xz -C "$HOME/.nucleus/bin/"
+        echo "::endgroup::"
+
+        chmod +x "$HOME/.nucleus/bin/"*
+        echo "$HOME/.nucleus/bin" >> "$GITHUB_PATH"
+
+    - name: Run scan
+      id: scan
+      shell: bash
+      run: |
+        set -uo pipefail
+
+        ARGS="--pod-spec ${{ inputs.pod-spec }}"
+
+        if [ -n "${{ inputs.audit-log }}" ]; then
+          ARGS="${ARGS} --audit-log ${{ inputs.audit-log }}"
+        fi
+
+        # Always capture JSON for the output
+        JSON_OUTPUT=$(nucleus-audit scan ${ARGS} --format json 2>&1) || true
+        echo "findings_json<<NUCLEUS_EOF" >> "$GITHUB_OUTPUT"
+        echo "${JSON_OUTPUT}" >> "$GITHUB_OUTPUT"
+        echo "NUCLEUS_EOF" >> "$GITHUB_OUTPUT"
+
+        # Run again with requested format for display
+        if nucleus-audit scan ${ARGS} --format ${{ inputs.format }}; then
+          echo "verdict=PASS" >> "$GITHUB_OUTPUT"
+        else
+          echo "verdict=FAIL" >> "$GITHUB_OUTPUT"
+          exit 1
+        fi


### PR DESCRIPTION
Adds nucleus-audit to release builds, scan action, github-token input for org-restricted repos