### PR TITLE
fix: repair release builds for macOS x86_64 and aarch64 rootfs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-          - os: macos-13
+          - os: macos-14
             target: x86_64-apple-darwin
           - os: macos-14
             target: aarch64-apple-darwin
@@ -29,18 +29,22 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache: true
+      - name: Add cross-compilation target
+        if: matrix.target == 'x86_64-apple-darwin'
+        run: rustup target add x86_64-apple-darwin
       - name: Build
-        run: cargo build -p nucleus-node -p nucleus-cli -p nucleus-mcp -p nucleus-audit --release
+        run: cargo build -p nucleus-node -p nucleus-cli -p nucleus-mcp -p nucleus-audit --release --target ${{ matrix.target }}
       - name: Package
         run: |
           TAG="${GITHUB_REF_NAME}"
           VERSION="${TAG#nucleus-node-v}"
           VERSION="${VERSION#v}"
+          RELEASE_DIR="target/${{ matrix.target }}/release"
           mkdir -p dist
-          tar -C target/release -czf "dist/nucleus-node-${VERSION}-${{ matrix.target }}.tar.gz" nucleus-node
-          tar -C target/release -czf "dist/nucleus-cli-${VERSION}-${{ matrix.target }}.tar.gz" nucleus
-          tar -C target/release -czf "dist/nucleus-mcp-${VERSION}-${{ matrix.target }}.tar.gz" nucleus-mcp
-          tar -C target/release -czf "dist/nucleus-audit-${VERSION}-${{ matrix.target }}.tar.gz" nucleus-audit
+          tar -C "$RELEASE_DIR" -czf "dist/nucleus-node-${VERSION}-${{ matrix.target }}.tar.gz" nucleus-node
+          tar -C "$RELEASE_DIR" -czf "dist/nucleus-cli-${VERSION}-${{ matrix.target }}.tar.gz" nucleus
+          tar -C "$RELEASE_DIR" -czf "dist/nucleus-mcp-${VERSION}-${{ matrix.target }}.tar.gz" nucleus-mcp
+          tar -C "$RELEASE_DIR" -czf "dist/nucleus-audit-${VERSION}-${{ matrix.target }}.tar.gz" nucleus-audit
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:

--- a/scripts/firecracker/build-rootfs.sh
+++ b/scripts/firecracker/build-rootfs.sh
@@ -277,8 +277,14 @@ else
         echo "Docker not found. Set DEBIAN_TARBALL to a Debian rootfs tarball instead." >&2
         exit 1
     fi
-    echo "Extracting base from Docker image: $DEBIAN_IMAGE"
-    CID=$(docker create "$DEBIAN_IMAGE" /bin/sh)
+    # Map ARCH to Docker platform for cross-architecture builds (e.g., aarch64 on x86_64 CI)
+    case "$ARCH" in
+        aarch64) DOCKER_PLATFORM="linux/arm64" ;;
+        x86_64)  DOCKER_PLATFORM="linux/amd64" ;;
+        *)       DOCKER_PLATFORM="linux/amd64" ;;
+    esac
+    echo "Extracting base from Docker image: $DEBIAN_IMAGE (platform: $DOCKER_PLATFORM)"
+    CID=$(docker create --platform "$DOCKER_PLATFORM" "$DEBIAN_IMAGE" /bin/sh)
     docker export "$CID" -o "$TMP_TAR"
     docker rm "$CID" >/dev/null
     tar -xf "$TMP_TAR" -C "$ROOTFS_DIR"


### PR DESCRIPTION
## Summary
- **#173**: Replace deprecated `macos-13` with `macos-14` + cross-compile for `x86_64-apple-darwin`
- **#174**: Add `--platform linux/arm64` to `docker create` for cross-arch rootfs builds

## Root causes
- `macos-13` runners removed from GitHub Actions — "configuration not supported"
- `docker create arm64v8/debian:bookworm-slim` on x86_64 runner fails with "no matching manifest for linux/amd64" because Docker doesn't auto-use QEMU for `docker create` (only for buildx)

## Changes
| File | Change |
|------|--------|
| `release.yml` | `macos-13` → `macos-14`, add `rustup target add`, use `--target` consistently, fix Package paths |
| `build-rootfs.sh` | Map ARCH to Docker `--platform` flag |

## Test plan
- [ ] Tag v1.0.5 after merge and verify all 4 native targets build
- [ ] Verify aarch64 rootfs artifact appears in release

Closes #173, closes #174.

🤖 Generated with [Claude Code](https://claude.ai/code)