### PR TITLE
feat: Claude Code settings + MCP config scanners

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,24 +25,27 @@ cargo install --git https://github.com/coproduct-opensource/nucleus nucleus-audi
 # Scan a PodSpec for security issues
 nucleus-audit scan --pod-spec your-agent.yaml
 
-# Example output:
-# ╔══════════════════════════════════════════════════════════════╗
-# ║  Nucleus PodSpec Security Scan                              ║
-# ╠══════════════════════════════════════════════════════════════╣
-# ║  Pod: yolo-agent                                            ║
-# ║  Policy: permissive                                         ║
-# ║  Findings: 4 critical, 2 high, 1 medium                    ║
-# ╠══════════════════════════════════════════════════════════════╣
-# ║  [CRITICAL] Lethal trifecta: private data + untrusted       ║
-# ║             content + exfiltration all at autonomous levels  ║
-# ║  [CRITICAL] 7 credentials exposed — exceeds safe threshold  ║
-# ║  [HIGH]     No network restrictions (full egress)           ║
-# ║  [HIGH]     No VM isolation (no Firecracker/seccomp)        ║
-# ╚══════════════════════════════════════════════════════════════╝
-# Exit code: 1 (critical or high findings)
+# Scan a Claude Code settings.json
+nucleus-audit scan --claude-settings .claude/settings.json
+
+# Scan an MCP config
+nucleus-audit scan --mcp-config .mcp.json
+
+# Scan everything at once — findings are merged and deduplicated
+nucleus-audit scan --pod-spec agent.yaml --claude-settings settings.json --mcp-config .mcp.json
 ```
 
-The scan checks for trifecta risk, permission surface area, network posture, isolation level, credential exposure, and timeout hygiene. Exit code is non-zero when critical or high findings exist — drop it into CI and block unsafe deployments.
+**Supported formats:**
+
+| Format | File | What It Checks |
+|--------|------|----------------|
+| PodSpec | `*.yaml` | Trifecta, credentials, network, isolation, timeout, permissions |
+| Claude Code settings | `settings.json` | Trifecta via allow/deny rules, unrestricted Bash, exfil patterns, safety bypasses, inline credentials, hooks |
+| MCP config | `.mcp.json` | External HTTP servers, plaintext credentials, auth headers in config, dangerous commands, surface area |
+
+The Claude Code scanner projects `allow`/`deny` rules onto the portcullis `CapabilityLattice` and runs the same trifecta analysis used for PodSpecs. A deny rule like `"Bash"` (bare, no pattern) demotes the exfiltration leg back to `Never`, breaking the trifecta.
+
+Exit code is non-zero when critical or high findings exist — drop it into CI and block unsafe deployments.
 
 ```bash
 # JSON output for CI pipelines
@@ -72,7 +75,7 @@ The trifecta guard's monotonicity is formally proven: once an operation is denie
 
 Three layers, at different levels of maturity:
 
-1. **Scan** (usable today) — Static analysis of agent PodSpecs. Catches dangerous permission combinations before deployment. Works as a standalone CLI tool.
+1. **Scan** (usable today) — Static analysis of agent PodSpecs, Claude Code `settings.json`, and MCP configs. Catches dangerous permission combinations before deployment. Works as a standalone CLI tool and GitHub Action.
 
 2. **Enforce** (working in CI, not production-hardened) — Runtime permission envelopes. The tool proxy intercepts every agent side effect and checks it against the permission lattice. Both HTTP and MCP paths share identical security controls (MIME gating, DNS/URL allowlists, redirect verification). The `--local` path works end-to-end in GitHub Actions. The Firecracker path works on Linux+KVM but has no production deployment.
 
@@ -87,6 +90,8 @@ Three layers, at different levels of maturity:
 | **Web fetch security** | Tested | Unified MCP+HTTP path: MIME gating, DNS/URL allowlist, redirect verification, IPv6 |
 | **Audit log verification** | Tested | HMAC-SHA256 + SHA-256 chain; optional S3 append-only sink (no integration test) |
 | **PodSpec scanner** | Tested | Trifecta, credentials, network, isolation, timeout checks |
+| **Claude Code scanner** | Tested | Trifecta via allow/deny projection, exfil patterns, safety bypasses, credentials |
+| **MCP config scanner** | Tested | HTTP servers, plaintext credentials, auth headers, dangerous commands |
 | **Permission profiles** | Tested | 14 named profiles backed by lattice constructors |
 | **Tool proxy** (MCP enforcement) | Tested | 9,500 LOC, 119 tests; enforces agent sessions in GitHub Actions |
 | **Firecracker isolation** | Tested | Real jailer invocation + iptables; Linux+KVM only |
@@ -198,7 +203,7 @@ The enforcement path: Agent → MCP → tool-proxy (inside VM) → portcullis ch
 |-------|---------|-------|
 | **portcullis** | Permission lattice: 9 algebraic modules | 875 |
 | **portcullis-verified** | Verus SMT proofs for portcullis | 297 VCs |
-| **nucleus-audit** | `scan` PodSpecs; `verify` hash-chained audit logs | 14 |
+| **nucleus-audit** | `scan` PodSpecs, Claude Code settings, MCP configs; `verify` audit logs | 24 |
 | **nucleus** | Enforcement: sandbox, executor, budget | 89 |
 | **nucleus-node** | Node daemon managing Firecracker microVMs | 26 |
 | **nucleus-tool-proxy** | MCP tool proxy running inside pods | 119 |
@@ -277,10 +282,12 @@ Add to any CI pipeline — blocks PRs with unsafe agent configs:
 - uses: coproduct-opensource/nucleus/scan@v1.0.5
   with:
     pod-spec: path/to/podspec.yaml
+    # claude-settings: .claude/settings.json
+    # mcp-config: .mcp.json
     # format: text          # or json
 ```
 
-Outputs `verdict` (PASS/WARN/FAIL) and `findings-json`. Non-zero exit code on critical or high findings.
+At least one of `pod-spec`, `claude-settings`, or `mcp-config` is required. Outputs `verdict` (PASS/WARN/FAIL) and `findings-json`. Non-zero exit code on critical or high findings.
 
 ### Safe PR Fixer (LLM-powered, lattice-enforced)
 
@@ -309,7 +316,7 @@ The agent **cannot push or create PRs** — only the trusted CI wrapper does tha
 **Trust ladder:**
 | Tier | What | Isolation |
 |------|------|-----------|
-| **Tier 0** | `nucleus-audit scan` in CI | Static analysis, no runtime |
+| **Tier 0** | `nucleus-audit scan` in CI | Static analysis (PodSpec, Claude settings, MCP), no runtime |
 | **Tier 1** | `nucleus run --local` (GitHub Action) | Tool-proxy lattice enforcement, no VM |
 | **Tier 2** | `nucleus run` with Firecracker | microVM + netns + default-deny egress |
 

--- a/crates/nucleus-audit/src/finding.rs
+++ b/crates/nucleus-audit/src/finding.rs
@@ -1,0 +1,109 @@
+//! Shared types for security scan findings.
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Severity {
+    Critical = 0,
+    High = 1,
+    Medium = 2,
+    Low = 3,
+    Info = 4,
+}
+
+impl std::fmt::Display for Severity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Severity::Critical => write!(f, "CRITICAL"),
+            Severity::High => write!(f, "HIGH"),
+            Severity::Medium => write!(f, "MEDIUM"),
+            Severity::Low => write!(f, "LOW"),
+            Severity::Info => write!(f, "INFO"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct Finding {
+    pub severity: Severity,
+    pub category: String,
+    pub title: String,
+    pub description: String,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ScanReport {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pod_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub policy_profile: Option<String>,
+    pub trifecta_risk: String,
+    pub trifecta_enforced: bool,
+    pub permission_surface: PermissionSurface,
+    pub network_posture: String,
+    pub isolation_level: String,
+    pub has_credentials: bool,
+    pub findings: Vec<Finding>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runtime_metrics: Option<RuntimeMetrics>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub claude_settings_summary: Option<ClaudeSettingsSummary>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mcp_config_summary: Option<McpConfigSummary>,
+}
+
+impl Default for ScanReport {
+    fn default() -> Self {
+        Self {
+            pod_name: None,
+            policy_profile: None,
+            trifecta_risk: "None".to_string(),
+            trifecta_enforced: false,
+            permission_surface: PermissionSurface::default(),
+            network_posture: "unspecified".to_string(),
+            isolation_level: "none".to_string(),
+            has_credentials: false,
+            findings: Vec::new(),
+            runtime_metrics: None,
+            claude_settings_summary: None,
+            mcp_config_summary: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, serde::Serialize)]
+pub struct PermissionSurface {
+    pub total_capabilities: usize,
+    pub always_allowed: Vec<String>,
+    pub low_risk: Vec<String>,
+    pub never: Vec<String>,
+    pub approval_required: Vec<String>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct RuntimeMetrics {
+    pub total_entries: usize,
+    pub chain_valid: bool,
+    pub deviations: usize,
+    pub trifecta_completions: usize,
+    pub blocks: usize,
+    pub identities: usize,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ClaudeSettingsSummary {
+    pub total_allow_rules: usize,
+    pub total_deny_rules: usize,
+    pub total_ask_rules: usize,
+    pub mcp_server_count: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sandbox_enabled: Option<bool>,
+    pub safety_bypasses: Vec<String>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct McpConfigSummary {
+    pub server_count: usize,
+    pub command_servers: usize,
+    pub http_servers: usize,
+    pub servers_with_credentials: usize,
+}

--- a/crates/nucleus-audit/src/main.rs
+++ b/crates/nucleus-audit/src/main.rs
@@ -1,3 +1,10 @@
+mod finding;
+mod report;
+mod scan_claude_settings;
+mod scan_mcp_config;
+mod scan_podspec;
+mod tool_pattern;
+
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
@@ -5,13 +12,14 @@ use std::path::{Path, PathBuf};
 
 use clap::{Parser, Subcommand};
 use hmac::{Hmac, Mac};
-use portcullis::CapabilityLevel;
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
 
+use finding::{ScanReport, Severity};
+
 #[derive(Parser, Debug)]
 #[command(name = "nucleus-audit")]
-#[command(about = "Verify, inspect, and scan nucleus audit logs and pod specifications")]
+#[command(about = "Verify, inspect, and scan nucleus audit logs and agent configurations")]
 struct Cli {
     #[command(subcommand)]
     command: Command,
@@ -58,15 +66,20 @@ enum Command {
         #[arg(long, default_value = "json")]
         format: ExportFormat,
     },
-    /// Scan a PodSpec for security posture and potential vulnerabilities.
+    /// Scan agent configurations for security posture and vulnerabilities.
     ///
-    /// Analyzes permission policies, network configuration, credential handling,
-    /// and isolation settings. Optionally cross-references against an audit log
-    /// to detect runtime deviations from declared policy.
+    /// Supports PodSpec YAML, Claude Code settings.json, and MCP config files.
+    /// At least one input source must be provided.
     Scan {
         /// Path to a PodSpec YAML/JSON file.
         #[arg(long)]
-        pod_spec: PathBuf,
+        pod_spec: Option<PathBuf>,
+        /// Path to a Claude Code settings.json file.
+        #[arg(long)]
+        claude_settings: Option<PathBuf>,
+        /// Path to an MCP config file (.mcp.json).
+        #[arg(long)]
+        mcp_config: Option<PathBuf>,
         /// Optional audit log to analyze runtime behavior against declared policy.
         #[arg(long)]
         audit_log: Option<PathBuf>,
@@ -83,7 +96,7 @@ enum ExportFormat {
 }
 
 #[derive(Debug, Clone, clap::ValueEnum)]
-enum ScanOutputFormat {
+pub enum ScanOutputFormat {
     Text,
     Json,
 }
@@ -108,7 +121,7 @@ struct SignedLine {
 }
 
 #[derive(thiserror::Error, Debug)]
-enum AuditError {
+pub enum AuditError {
     #[error("missing audit secret (use --secret, --secret-file, or env)")]
     MissingSecret,
     #[error("io error: {0}")]
@@ -120,7 +133,7 @@ enum AuditError {
     },
     #[error("invalid audit log at line {line}: {message}")]
     Invalid { line: usize, message: String },
-    #[error("portcullis backend error: {0}")]
+    #[error("error: {0}")]
     Backend(String),
 }
 
@@ -154,16 +167,68 @@ fn main() -> Result<(), AuditError> {
         }
         Command::Scan {
             pod_spec,
+            claude_settings,
+            mcp_config,
             audit_log,
             format,
         } => {
-            let report = scan_pod_spec(&pod_spec, audit_log.as_deref())?;
+            if pod_spec.is_none() && claude_settings.is_none() && mcp_config.is_none() {
+                eprintln!(
+                    "Error: at least one of --pod-spec, --claude-settings, \
+                     or --mcp-config is required"
+                );
+                std::process::exit(2);
+            }
+
+            let mut report = ScanReport::default();
+
+            // Scan PodSpec if provided
+            if let Some(ps_path) = &pod_spec {
+                report = scan_podspec::scan_pod_spec(ps_path, audit_log.as_deref())?;
+            }
+
+            // Scan Claude settings if provided
+            if let Some(cs_path) = &claude_settings {
+                let (findings, summary) = scan_claude_settings::scan_claude_settings(cs_path)?;
+                // If no PodSpec, derive trifecta info from settings findings
+                if pod_spec.is_none() {
+                    let has_trifecta = findings
+                        .iter()
+                        .any(|f| f.category == "trifecta" && f.severity == Severity::Critical);
+                    report.trifecta_risk = if has_trifecta {
+                        "Complete".to_string()
+                    } else if findings.iter().any(|f| f.category == "trifecta") {
+                        "Medium".to_string()
+                    } else {
+                        "None".to_string()
+                    };
+                    report.trifecta_enforced = false; // settings.json has no enforcement
+                    report.has_credentials = findings.iter().any(|f| f.category == "credentials");
+                }
+                report.findings.extend(findings);
+                report.claude_settings_summary = Some(summary);
+            }
+
+            // Scan MCP config if provided
+            if let Some(mc_path) = &mcp_config {
+                let (findings, summary) = scan_mcp_config::scan_mcp_config(mc_path)?;
+                if findings.iter().any(|f| f.category == "credentials") {
+                    report.has_credentials = true;
+                }
+                report.findings.extend(findings);
+                report.mcp_config_summary = Some(summary);
+            }
+
+            // Sort all findings by severity
+            report.findings.sort_by(|a, b| a.severity.cmp(&b.severity));
+
             match format {
-                ScanOutputFormat::Text => print_scan_report(&report),
+                ScanOutputFormat::Text => report::print_scan_report(&report),
                 ScanOutputFormat::Json => {
                     println!("{}", serde_json::to_string_pretty(&report).unwrap());
                 }
             }
+
             // Exit with non-zero status if critical or high findings exist
             let worst = report
                 .findings
@@ -272,10 +337,8 @@ fn verify_portcullis_chain(path: &Path, secret: Option<&str>) -> Result<usize, A
         }
         let line_no = idx + 1;
 
-        // Try signed format first (FileAuditBackend), then raw entry
         let entry: portcullis::AuditEntry =
             if let Ok(signed) = serde_json::from_str::<SignedLine>(line) {
-                // Verify HMAC if secret provided
                 if let Some(secret) = secret {
                     let entry_str = serde_json::to_string(&signed.entry)
                         .map_err(|e| AuditError::Backend(e.to_string()))?;
@@ -301,7 +364,6 @@ fn verify_portcullis_chain(path: &Path, secret: Option<&str>) -> Result<usize, A
         entries.push(entry);
     }
 
-    // Verify hash chain linkage
     if !entries.is_empty() {
         if entries[0].prev_hash.is_some() {
             return Err(AuditError::Invalid {
@@ -435,655 +497,6 @@ fn export_log(path: &Path, format: &ExportFormat) -> Result<(), AuditError> {
     Ok(())
 }
 
-// --- scan ---
-
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, serde::Serialize)]
-#[serde(rename_all = "snake_case")]
-enum Severity {
-    Critical = 0,
-    High = 1,
-    Medium = 2,
-    Low = 3,
-    Info = 4,
-}
-
-impl std::fmt::Display for Severity {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Severity::Critical => write!(f, "CRITICAL"),
-            Severity::High => write!(f, "HIGH"),
-            Severity::Medium => write!(f, "MEDIUM"),
-            Severity::Low => write!(f, "LOW"),
-            Severity::Info => write!(f, "INFO"),
-        }
-    }
-}
-
-#[derive(Debug, Clone, serde::Serialize)]
-struct Finding {
-    severity: Severity,
-    category: String,
-    title: String,
-    description: String,
-}
-
-#[derive(Debug, Clone, serde::Serialize)]
-struct ScanReport {
-    pod_name: Option<String>,
-    policy_profile: String,
-    trifecta_risk: String,
-    trifecta_enforced: bool,
-    permission_surface: PermissionSurface,
-    network_posture: String,
-    isolation_level: String,
-    has_credentials: bool,
-    findings: Vec<Finding>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    runtime_metrics: Option<RuntimeMetrics>,
-}
-
-#[derive(Debug, Clone, serde::Serialize)]
-struct PermissionSurface {
-    total_capabilities: usize,
-    always_allowed: Vec<String>,
-    low_risk: Vec<String>,
-    never: Vec<String>,
-    approval_required: Vec<String>,
-}
-
-#[derive(Debug, Clone, serde::Serialize)]
-struct RuntimeMetrics {
-    total_entries: usize,
-    chain_valid: bool,
-    deviations: usize,
-    trifecta_completions: usize,
-    blocks: usize,
-    identities: usize,
-}
-
-fn scan_pod_spec(
-    pod_spec_path: &Path,
-    audit_log_path: Option<&Path>,
-) -> Result<ScanReport, AuditError> {
-    let yaml = std::fs::read_to_string(pod_spec_path)?;
-    let spec: nucleus_spec::PodSpec = serde_yaml::from_str(&yaml)
-        .map_err(|e| AuditError::Backend(format!("failed to parse PodSpec: {}", e)))?;
-
-    let lattice = spec
-        .spec
-        .resolve_policy()
-        .map_err(|e| AuditError::Backend(format!("failed to resolve policy: {}", e)))?;
-
-    let mut findings = Vec::new();
-
-    // --- Policy analysis ---
-
-    let policy_profile = match &spec.spec.policy {
-        nucleus_spec::PolicySpec::Profile { name } => name.clone(),
-        nucleus_spec::PolicySpec::Inline { .. } => "inline".to_string(),
-    };
-
-    let trifecta_config = portcullis::IncompatibilityConstraint::enforcing();
-    let trifecta_risk = trifecta_config.trifecta_risk(&lattice.capabilities);
-    let trifecta_enforced = lattice.trifecta_constraint;
-
-    if !trifecta_enforced {
-        findings.push(Finding {
-            severity: Severity::Critical,
-            category: "trifecta".to_string(),
-            title: "Trifecta enforcement disabled".to_string(),
-            description: "The lethal trifecta constraint is disabled. An agent with \
-                private data access + untrusted content + external communication can \
-                exfiltrate data without approval gates."
-                .to_string(),
-        });
-    }
-
-    let trifecta_str = format!("{:?}", trifecta_risk);
-    if trifecta_risk == portcullis::TrifectaRisk::Complete && trifecta_enforced {
-        findings.push(Finding {
-            severity: Severity::Medium,
-            category: "trifecta".to_string(),
-            title: "Complete trifecta with enforcement".to_string(),
-            description: "All three trifecta components are present. Enforcement is \
-                enabled so exfiltration operations will require approval, but the \
-                attack surface is maximal."
-                .to_string(),
-        });
-    } else if trifecta_risk == portcullis::TrifectaRisk::Complete && !trifecta_enforced {
-        findings.push(Finding {
-            severity: Severity::Critical,
-            category: "trifecta".to_string(),
-            title: "Complete trifecta WITHOUT enforcement".to_string(),
-            description: "All three trifecta components are present and enforcement \
-                is disabled. This agent can read private data, fetch untrusted content, \
-                and push to external systems without any approval gate."
-                .to_string(),
-        });
-    }
-
-    // --- Capability surface analysis ---
-
-    let caps = &lattice.capabilities;
-    let cap_fields: Vec<(&str, CapabilityLevel)> = vec![
-        ("read_files", caps.read_files),
-        ("write_files", caps.write_files),
-        ("edit_files", caps.edit_files),
-        ("run_bash", caps.run_bash),
-        ("glob_search", caps.glob_search),
-        ("grep_search", caps.grep_search),
-        ("web_search", caps.web_search),
-        ("web_fetch", caps.web_fetch),
-        ("git_commit", caps.git_commit),
-        ("git_push", caps.git_push),
-        ("create_pr", caps.create_pr),
-        ("manage_pods", caps.manage_pods),
-    ];
-
-    let always_allowed: Vec<String> = cap_fields
-        .iter()
-        .filter(|(_, l)| *l == CapabilityLevel::Always)
-        .map(|(n, _)| n.to_string())
-        .collect();
-    let low_risk: Vec<String> = cap_fields
-        .iter()
-        .filter(|(_, l)| *l == CapabilityLevel::LowRisk)
-        .map(|(n, _)| n.to_string())
-        .collect();
-    let never: Vec<String> = cap_fields
-        .iter()
-        .filter(|(_, l)| *l == CapabilityLevel::Never)
-        .map(|(n, _)| n.to_string())
-        .collect();
-
-    let approval_required: Vec<String> = lattice
-        .obligations
-        .approvals
-        .iter()
-        .map(|op| format!("{:?}", op).to_lowercase())
-        .collect();
-
-    // High-risk capabilities without approval obligations
-    let dangerous_ops = ["run_bash", "git_push", "create_pr", "manage_pods"];
-    for (name, level) in &cap_fields {
-        if dangerous_ops.contains(name) && *level >= CapabilityLevel::Always {
-            let op_name = format!(
-                "{:?}",
-                match *name {
-                    "run_bash" => portcullis::Operation::RunBash,
-                    "git_push" => portcullis::Operation::GitPush,
-                    "create_pr" => portcullis::Operation::CreatePr,
-                    "manage_pods" => portcullis::Operation::ManagePods,
-                    _ => continue,
-                }
-            );
-            let has_approval = approval_required
-                .iter()
-                .any(|a| a == &op_name.to_lowercase());
-            if !has_approval {
-                findings.push(Finding {
-                    severity: Severity::High,
-                    category: "permissions".to_string(),
-                    title: format!("{} is always-allowed without approval", name),
-                    description: format!(
-                        "The capability '{}' is set to Always with no approval \
-                         obligation. Consider requiring human approval for this \
-                         high-risk operation.",
-                        name
-                    ),
-                });
-            }
-        }
-    }
-
-    if policy_profile == "permissive" {
-        findings.push(Finding {
-            severity: Severity::High,
-            category: "policy".to_string(),
-            title: "Permissive policy profile".to_string(),
-            description: "The 'permissive' profile enables most capabilities. \
-                Use a more restrictive profile like 'fix_issue' or 'code_review' \
-                to enforce least privilege."
-                .to_string(),
-        });
-    }
-
-    // --- Network analysis ---
-
-    let network_posture = match &spec.spec.network {
-        Some(net) if !net.deny.is_empty() && net.dns_allow.is_empty() => "airgapped",
-        Some(net) if !net.dns_allow.is_empty() => "filtered",
-        Some(_) => "permissive",
-        None => "unspecified",
-    };
-
-    if network_posture == "unspecified" {
-        findings.push(Finding {
-            severity: Severity::Medium,
-            category: "network".to_string(),
-            title: "No network policy specified".to_string(),
-            description: "The PodSpec has no network configuration. The agent's \
-                network access depends on the executor's defaults. Specify an \
-                explicit NetworkSpec (deny_all, package_registries, or permissive)."
-                .to_string(),
-        });
-    } else if network_posture == "permissive" {
-        findings.push(Finding {
-            severity: Severity::High,
-            category: "network".to_string(),
-            title: "Unrestricted network egress".to_string(),
-            description: "The agent has unrestricted outbound network access. \
-                This enables data exfiltration to arbitrary destinations. Use \
-                NetworkSpec::package_registries() or deny_all() to restrict egress."
-                .to_string(),
-        });
-    }
-
-    // --- Isolation analysis ---
-
-    let isolation_level = if spec.spec.image.is_some() {
-        "firecracker"
-    } else if spec.spec.seccomp.is_some() || spec.spec.cgroup.is_some() {
-        "container"
-    } else {
-        "none"
-    };
-
-    if isolation_level == "none" {
-        findings.push(Finding {
-            severity: Severity::Medium,
-            category: "isolation".to_string(),
-            title: "No VM/container isolation configured".to_string(),
-            description: "The PodSpec has no image, seccomp, or cgroup configuration. \
-                The agent will run with host-level access unless the executor provides \
-                isolation. Configure ImageSpec for Firecracker VM isolation."
-                .to_string(),
-        });
-    }
-
-    if let Some(nucleus_spec::SeccompSpec::Disabled) = &spec.spec.seccomp {
-        findings.push(Finding {
-            severity: Severity::High,
-            category: "isolation".to_string(),
-            title: "Seccomp disabled".to_string(),
-            description: "Seccomp filtering is explicitly disabled. The agent process \
-                can invoke any system call. Use Default or a custom filter."
-                .to_string(),
-        });
-    }
-
-    // --- Credential analysis ---
-
-    let has_credentials = spec
-        .spec
-        .credentials
-        .as_ref()
-        .is_some_and(|c| !c.is_empty());
-    if has_credentials {
-        let creds = spec.spec.credentials.as_ref().unwrap();
-        let dangerous_patterns = [
-            "ROOT",
-            "ADMIN",
-            "MASTER",
-            "PRIVATE_KEY",
-            "AWS_SECRET",
-            "DATABASE_URL",
-        ];
-        for key in creds.env.keys() {
-            let upper = key.to_uppercase();
-            for pattern in &dangerous_patterns {
-                if upper.contains(pattern) {
-                    findings.push(Finding {
-                        severity: Severity::High,
-                        category: "credentials".to_string(),
-                        title: format!("High-privilege credential: {}", key),
-                        description: format!(
-                            "Credential '{}' matches pattern '{}'. Ensure this \
-                             agent requires this level of access and that the \
-                             credential is scoped to minimum privileges.",
-                            key, pattern
-                        ),
-                    });
-                }
-            }
-        }
-
-        if creds.env.len() > 5 {
-            findings.push(Finding {
-                severity: Severity::Medium,
-                category: "credentials".to_string(),
-                title: format!("{} credentials injected", creds.env.len()),
-                description: "A large number of credentials are injected. Each \
-                    credential increases the blast radius of a compromised agent. \
-                    Review whether all credentials are necessary."
-                    .to_string(),
-            });
-        }
-    }
-
-    // --- Timeout analysis ---
-
-    if spec.spec.timeout_seconds > 7200 {
-        findings.push(Finding {
-            severity: Severity::Low,
-            category: "timeout".to_string(),
-            title: format!("Long timeout: {}s", spec.spec.timeout_seconds),
-            description: "Execution timeout exceeds 2 hours. Long-running agents \
-                have more time to perform unauthorized actions if compromised. \
-                Consider a shorter timeout with resume capability."
-                .to_string(),
-        });
-    }
-
-    // --- Runtime audit log analysis ---
-
-    let runtime_metrics = if let Some(log_path) = audit_log_path {
-        Some(analyze_audit_log(log_path, &mut findings)?)
-    } else {
-        None
-    };
-
-    // Sort findings by severity
-    findings.sort_by(|a, b| a.severity.cmp(&b.severity));
-
-    Ok(ScanReport {
-        pod_name: spec.metadata.name,
-        policy_profile,
-        trifecta_risk: trifecta_str,
-        trifecta_enforced,
-        permission_surface: PermissionSurface {
-            total_capabilities: cap_fields.len(),
-            always_allowed,
-            low_risk,
-            never,
-            approval_required,
-        },
-        network_posture: network_posture.to_string(),
-        isolation_level: isolation_level.to_string(),
-        has_credentials,
-        findings,
-        runtime_metrics,
-    })
-}
-
-fn analyze_audit_log(
-    log_path: &Path,
-    findings: &mut Vec<Finding>,
-) -> Result<RuntimeMetrics, AuditError> {
-    let file = File::open(log_path)?;
-    let reader = BufReader::new(file);
-
-    let log = portcullis::audit::AuditLog::in_memory();
-    let mut identities: std::collections::HashSet<String> = std::collections::HashSet::new();
-    let mut deviations = 0usize;
-    let mut trifecta_completions = 0usize;
-    let mut blocks = 0usize;
-    let mut total = 0usize;
-
-    for (idx, line) in reader.lines().enumerate() {
-        let line = line?;
-        let line = line.trim();
-        if line.is_empty() {
-            continue;
-        }
-
-        // Try portcullis AuditEntry format
-        let entry: portcullis::AuditEntry =
-            if let Ok(signed) = serde_json::from_str::<SignedLine>(line) {
-                serde_json::from_value(signed.entry).map_err(|source| AuditError::Json {
-                    line: idx + 1,
-                    source,
-                })?
-            } else {
-                serde_json::from_str(line).map_err(|source| AuditError::Json {
-                    line: idx + 1,
-                    source,
-                })?
-            };
-
-        identities.insert(entry.identity.clone());
-
-        if entry.is_deviation() {
-            deviations += 1;
-        }
-        if let Some(portcullis::TrifectaRisk::Complete) = entry.trifecta_impact() {
-            trifecta_completions += 1;
-        }
-        if matches!(
-            &entry.event,
-            portcullis::audit::PermissionEvent::ExecutionBlocked { .. }
-        ) {
-            blocks += 1;
-        }
-
-        log.record(entry);
-        total += 1;
-    }
-
-    let chain_valid = log.verify_chain().is_ok();
-
-    if !chain_valid {
-        findings.push(Finding {
-            severity: Severity::Critical,
-            category: "audit_integrity".to_string(),
-            title: "Audit log hash chain broken".to_string(),
-            description: "The audit log's cryptographic hash chain is invalid. \
-                This indicates tampering or corruption. The audit trail cannot \
-                be trusted."
-                .to_string(),
-        });
-    }
-
-    if trifecta_completions > 0 {
-        findings.push(Finding {
-            severity: Severity::High,
-            category: "runtime".to_string(),
-            title: format!(
-                "{} trifecta completion{} detected",
-                trifecta_completions,
-                if trifecta_completions == 1 { "" } else { "s" }
-            ),
-            description: format!(
-                "The audit log contains {} events where all three lethal trifecta \
-                 components were active simultaneously. Review these events for \
-                 potential data exfiltration.",
-                trifecta_completions
-            ),
-        });
-    }
-
-    let deviation_rate = if total > 0 {
-        deviations as f64 / total as f64
-    } else {
-        0.0
-    };
-
-    if deviation_rate > 0.1 {
-        findings.push(Finding {
-            severity: Severity::Medium,
-            category: "runtime".to_string(),
-            title: format!("High deviation rate: {:.1}%", deviation_rate * 100.0),
-            description: format!(
-                "{} of {} audit events ({:.1}%) are deviations from declared \
-                 permissions. This suggests the declared policy is too restrictive \
-                 (agents constantly escalating) or the agent is misbehaving.",
-                deviations,
-                total,
-                deviation_rate * 100.0
-            ),
-        });
-    }
-
-    Ok(RuntimeMetrics {
-        total_entries: total,
-        chain_valid,
-        deviations,
-        trifecta_completions,
-        blocks,
-        identities: identities.len(),
-    })
-}
-
-fn print_scan_report(report: &ScanReport) {
-    println!("╔══════════════════════════════════════════════════════════════╗");
-    println!("║               NUCLEUS SECURITY SCAN REPORT                 ║");
-    println!("╚══════════════════════════════════════════════════════════════╝");
-    println!();
-
-    // --- Overview ---
-    if let Some(name) = &report.pod_name {
-        println!("  Pod:            {}", name);
-    }
-    println!("  Policy:         {}", report.policy_profile);
-    println!("  Trifecta risk:  {}", report.trifecta_risk);
-    println!(
-        "  Trifecta guard: {}",
-        if report.trifecta_enforced {
-            "ENFORCED"
-        } else {
-            "DISABLED"
-        }
-    );
-    println!("  Network:        {}", report.network_posture);
-    println!("  Isolation:      {}", report.isolation_level);
-    println!(
-        "  Credentials:    {}",
-        if report.has_credentials {
-            "present"
-        } else {
-            "none"
-        }
-    );
-    println!();
-
-    // --- Permission surface ---
-    println!("── Permission Surface ──────────────────────────────────────────");
-    if !report.permission_surface.always_allowed.is_empty() {
-        println!(
-            "  Always allowed:    {}",
-            report.permission_surface.always_allowed.join(", ")
-        );
-    }
-    if !report.permission_surface.low_risk.is_empty() {
-        println!(
-            "  Low-risk auto:     {}",
-            report.permission_surface.low_risk.join(", ")
-        );
-    }
-    if !report.permission_surface.never.is_empty() {
-        println!(
-            "  Never allowed:     {}",
-            report.permission_surface.never.join(", ")
-        );
-    }
-    if !report.permission_surface.approval_required.is_empty() {
-        println!(
-            "  Approval required: {}",
-            report.permission_surface.approval_required.join(", ")
-        );
-    }
-    println!();
-
-    // --- Runtime metrics ---
-    if let Some(metrics) = &report.runtime_metrics {
-        println!("── Runtime Analysis ────────────────────────────────────────────");
-        println!("  Audit entries:     {}", metrics.total_entries);
-        println!(
-            "  Chain integrity:   {}",
-            if metrics.chain_valid {
-                "VALID"
-            } else {
-                "BROKEN"
-            }
-        );
-        println!("  Identities:        {}", metrics.identities);
-        println!("  Deviations:        {}", metrics.deviations);
-        println!("  Trifecta events:   {}", metrics.trifecta_completions);
-        println!("  Blocked:           {}", metrics.blocks);
-        println!();
-    }
-
-    // --- Findings ---
-    let critical_count = report
-        .findings
-        .iter()
-        .filter(|f| f.severity == Severity::Critical)
-        .count();
-    let high_count = report
-        .findings
-        .iter()
-        .filter(|f| f.severity == Severity::High)
-        .count();
-    let medium_count = report
-        .findings
-        .iter()
-        .filter(|f| f.severity == Severity::Medium)
-        .count();
-    let low_count = report
-        .findings
-        .iter()
-        .filter(|f| f.severity <= Severity::Low)
-        .count();
-
-    println!(
-        "── Findings ({} critical, {} high, {} medium, {} low) ──────────",
-        critical_count, high_count, medium_count, low_count
-    );
-    println!();
-
-    for finding in &report.findings {
-        let marker = match finding.severity {
-            Severity::Critical => "!!",
-            Severity::High => "! ",
-            Severity::Medium => "~ ",
-            Severity::Low => "- ",
-            Severity::Info => "  ",
-        };
-        println!("  {} [{}] {}", marker, finding.severity, finding.title);
-        // Wrap description at ~70 chars
-        for line in textwrap(&finding.description, 58) {
-            println!("       {}", line);
-        }
-        println!();
-    }
-
-    if report.findings.is_empty() {
-        println!("  No findings. This PodSpec follows security best practices.");
-        println!();
-    }
-
-    // --- Verdict ---
-    let verdict = if critical_count > 0 {
-        "FAIL — critical issues must be resolved"
-    } else if high_count > 0 {
-        "WARN — high-severity issues should be addressed"
-    } else if medium_count > 0 {
-        "PASS with advisories"
-    } else {
-        "PASS"
-    };
-    println!("══ Verdict: {} ══", verdict);
-}
-
-fn textwrap(s: &str, width: usize) -> Vec<String> {
-    let mut lines = Vec::new();
-    let mut current = String::new();
-    for word in s.split_whitespace() {
-        if current.len() + word.len() + 1 > width && !current.is_empty() {
-            lines.push(current.clone());
-            current.clear();
-        }
-        if !current.is_empty() {
-            current.push(' ');
-        }
-        current.push_str(word);
-    }
-    if !current.is_empty() {
-        lines.push(current);
-    }
-    lines
-}
-
 // --- crypto helpers ---
 
 fn sign_message(secret: &[u8], message: &[u8]) -> String {
@@ -1105,11 +518,11 @@ fn sha256_hex(message: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::Write;
 
     fn write_pod_spec(dir: &Path, name: &str, content: &str) -> PathBuf {
         let path = dir.join(name);
         let mut f = File::create(&path).unwrap();
+        use std::io::Write;
         f.write_all(content.as_bytes()).unwrap();
         path
     }
@@ -1141,12 +554,11 @@ spec:
 "#,
         );
 
-        let report = scan_pod_spec(&spec, None).unwrap();
-        assert_eq!(report.policy_profile, "read_only");
+        let report = scan_podspec::scan_pod_spec(&spec, None).unwrap();
+        assert_eq!(report.policy_profile.as_deref(), Some("read_only"));
         assert_eq!(report.network_posture, "airgapped");
         assert_eq!(report.isolation_level, "firecracker");
         assert!(!report.has_credentials);
-        // read_only + airgapped + firecracker = no findings
         assert!(
             report.findings.is_empty(),
             "Expected no findings, got: {:?}",
@@ -1178,7 +590,7 @@ spec:
 "#,
         );
 
-        let report = scan_pod_spec(&spec, None).unwrap();
+        let report = scan_podspec::scan_pod_spec(&spec, None).unwrap();
         assert_eq!(report.trifecta_risk, "Complete");
         assert!(report.trifecta_enforced);
         assert_eq!(report.network_posture, "unspecified");
@@ -1195,8 +607,7 @@ spec:
             "Should have MEDIUM findings"
         );
 
-        // Should flag credential patterns
-        let cred_findings: Vec<&Finding> = report
+        let cred_findings: Vec<_> = report
             .findings
             .iter()
             .filter(|f| f.category == "credentials")
@@ -1205,22 +616,6 @@ spec:
             cred_findings.len() >= 2,
             "Should flag ROOT_PASSWORD and AWS_SECRET_ACCESS_KEY"
         );
-
-        // Should flag timeout
-        let timeout_findings: Vec<&Finding> = report
-            .findings
-            .iter()
-            .filter(|f| f.category == "timeout")
-            .collect();
-        assert_eq!(timeout_findings.len(), 1);
-
-        // Should flag permissive profile
-        let policy_findings: Vec<&Finding> = report
-            .findings
-            .iter()
-            .filter(|f| f.category == "policy")
-            .collect();
-        assert_eq!(policy_findings.len(), 1);
     }
 
     #[test]
@@ -1242,7 +637,7 @@ spec:
 "#,
         );
 
-        let report = scan_pod_spec(&spec, None).unwrap();
+        let report = scan_podspec::scan_pod_spec(&spec, None).unwrap();
         let json = serde_json::to_string(&report).unwrap();
         let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed["policy_profile"], "fix_issue");

--- a/crates/nucleus-audit/src/report.rs
+++ b/crates/nucleus-audit/src/report.rs
@@ -1,0 +1,193 @@
+//! Text and JSON report rendering for scan results.
+
+use crate::finding::{ScanReport, Severity};
+
+pub fn print_scan_report(report: &ScanReport) {
+    println!("╔══════════════════════════════════════════════════════════════╗");
+    println!("║               NUCLEUS SECURITY SCAN REPORT                 ║");
+    println!("╚══════════════════════════════════════════════════════════════╝");
+    println!();
+
+    // --- Overview ---
+    if let Some(name) = &report.pod_name {
+        println!("  Pod:            {}", name);
+    }
+    if let Some(profile) = &report.policy_profile {
+        println!("  Policy:         {}", profile);
+    }
+    println!("  Trifecta risk:  {}", report.trifecta_risk);
+    println!(
+        "  Trifecta guard: {}",
+        if report.trifecta_enforced {
+            "ENFORCED"
+        } else {
+            "DISABLED"
+        }
+    );
+    println!("  Network:        {}", report.network_posture);
+    println!("  Isolation:      {}", report.isolation_level);
+    println!(
+        "  Credentials:    {}",
+        if report.has_credentials {
+            "present"
+        } else {
+            "none"
+        }
+    );
+    println!();
+
+    // --- Permission surface ---
+    println!("── Permission Surface ──────────────────────────────────────────");
+    if !report.permission_surface.always_allowed.is_empty() {
+        println!(
+            "  Always allowed:    {}",
+            report.permission_surface.always_allowed.join(", ")
+        );
+    }
+    if !report.permission_surface.low_risk.is_empty() {
+        println!(
+            "  Low-risk auto:     {}",
+            report.permission_surface.low_risk.join(", ")
+        );
+    }
+    if !report.permission_surface.never.is_empty() {
+        println!(
+            "  Never allowed:     {}",
+            report.permission_surface.never.join(", ")
+        );
+    }
+    if !report.permission_surface.approval_required.is_empty() {
+        println!(
+            "  Approval required: {}",
+            report.permission_surface.approval_required.join(", ")
+        );
+    }
+    println!();
+
+    // --- Claude settings summary ---
+    if let Some(cs) = &report.claude_settings_summary {
+        println!("── Claude Code Settings ────────────────────────────────────────");
+        println!("  Allow rules:       {}", cs.total_allow_rules);
+        println!("  Deny rules:        {}", cs.total_deny_rules);
+        println!("  Ask rules:         {}", cs.total_ask_rules);
+        println!("  MCP servers:       {}", cs.mcp_server_count);
+        if let Some(sandbox) = cs.sandbox_enabled {
+            println!(
+                "  Sandbox:           {}",
+                if sandbox { "enabled" } else { "DISABLED" }
+            );
+        }
+        if !cs.safety_bypasses.is_empty() {
+            println!("  Safety bypasses:   {}", cs.safety_bypasses.join(", "));
+        }
+        println!();
+    }
+
+    // --- MCP config summary ---
+    if let Some(mc) = &report.mcp_config_summary {
+        println!("── MCP Configuration ──────────────────────────────────────────");
+        println!("  Total servers:     {}", mc.server_count);
+        println!("  Command servers:   {}", mc.command_servers);
+        println!("  HTTP servers:      {}", mc.http_servers);
+        println!("  With credentials:  {}", mc.servers_with_credentials);
+        println!();
+    }
+
+    // --- Runtime metrics ---
+    if let Some(metrics) = &report.runtime_metrics {
+        println!("── Runtime Analysis ────────────────────────────────────────────");
+        println!("  Audit entries:     {}", metrics.total_entries);
+        println!(
+            "  Chain integrity:   {}",
+            if metrics.chain_valid {
+                "VALID"
+            } else {
+                "BROKEN"
+            }
+        );
+        println!("  Identities:        {}", metrics.identities);
+        println!("  Deviations:        {}", metrics.deviations);
+        println!("  Trifecta events:   {}", metrics.trifecta_completions);
+        println!("  Blocked:           {}", metrics.blocks);
+        println!();
+    }
+
+    // --- Findings ---
+    let critical_count = report
+        .findings
+        .iter()
+        .filter(|f| f.severity == Severity::Critical)
+        .count();
+    let high_count = report
+        .findings
+        .iter()
+        .filter(|f| f.severity == Severity::High)
+        .count();
+    let medium_count = report
+        .findings
+        .iter()
+        .filter(|f| f.severity == Severity::Medium)
+        .count();
+    let low_count = report
+        .findings
+        .iter()
+        .filter(|f| f.severity <= Severity::Low)
+        .count();
+
+    println!(
+        "── Findings ({} critical, {} high, {} medium, {} low) ──────────",
+        critical_count, high_count, medium_count, low_count
+    );
+    println!();
+
+    for finding in &report.findings {
+        let marker = match finding.severity {
+            Severity::Critical => "!!",
+            Severity::High => "! ",
+            Severity::Medium => "~ ",
+            Severity::Low => "- ",
+            Severity::Info => "  ",
+        };
+        println!("  {} [{}] {}", marker, finding.severity, finding.title);
+        for line in textwrap(&finding.description, 58) {
+            println!("       {}", line);
+        }
+        println!();
+    }
+
+    if report.findings.is_empty() {
+        println!("  No findings. Configuration follows security best practices.");
+        println!();
+    }
+
+    // --- Verdict ---
+    let verdict = if critical_count > 0 {
+        "FAIL — critical issues must be resolved"
+    } else if high_count > 0 {
+        "WARN — high-severity issues should be addressed"
+    } else if medium_count > 0 {
+        "PASS with advisories"
+    } else {
+        "PASS"
+    };
+    println!("══ Verdict: {} ══", verdict);
+}
+
+pub fn textwrap(s: &str, width: usize) -> Vec<String> {
+    let mut lines = Vec::new();
+    let mut current = String::new();
+    for word in s.split_whitespace() {
+        if current.len() + word.len() + 1 > width && !current.is_empty() {
+            lines.push(current.clone());
+            current.clear();
+        }
+        if !current.is_empty() {
+            current.push(' ');
+        }
+        current.push_str(word);
+    }
+    if !current.is_empty() {
+        lines.push(current);
+    }
+    lines
+}

--- a/crates/nucleus-audit/src/scan_claude_settings.rs
+++ b/crates/nucleus-audit/src/scan_claude_settings.rs
@@ -1,0 +1,514 @@
+//! Claude Code settings.json security scanner.
+//!
+//! Parses Claude Code's `settings.json` format and projects permission rules
+//! onto the portcullis CapabilityLattice for trifecta analysis.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use portcullis::{CapabilityLattice, CapabilityLevel, IncompatibilityConstraint};
+use serde::Deserialize;
+
+use crate::finding::{ClaudeSettingsSummary, Finding, Severity};
+use crate::tool_pattern::{
+    is_exfil_bash_pattern, is_sensitive_path_pattern, is_unrestricted_pattern,
+    parse_tool_permission, ToolKind,
+};
+use crate::AuditError;
+
+// --- Serde structs for Claude Code settings.json ---
+
+#[derive(Debug, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ClaudeSettings {
+    #[serde(default)]
+    pub permissions: Option<PermissionRules>,
+    #[serde(default)]
+    pub mcp_servers: Option<HashMap<String, serde_json::Value>>,
+    #[serde(default)]
+    pub sandbox: Option<SandboxConfig>,
+    #[serde(default)]
+    pub hooks: Option<serde_json::Value>,
+    #[serde(default)]
+    pub env: Option<HashMap<String, String>>,
+    #[serde(default)]
+    pub skip_dangerous_mode_permission_prompt: Option<bool>,
+    #[serde(default)]
+    pub api_key_helper: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct PermissionRules {
+    #[serde(default)]
+    pub allow: Vec<String>,
+    #[serde(default)]
+    pub deny: Vec<String>,
+    #[serde(default)]
+    pub ask: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[allow(dead_code)] // Fields used for deserialization tolerance
+pub struct SandboxConfig {
+    pub enabled: Option<bool>,
+    #[serde(default)]
+    pub filesystem: Option<serde_json::Value>,
+    #[serde(default)]
+    pub network: Option<serde_json::Value>,
+}
+
+/// Scan a Claude Code settings.json file for security issues.
+pub fn scan_claude_settings(
+    path: &Path,
+) -> Result<(Vec<Finding>, ClaudeSettingsSummary), AuditError> {
+    let content = std::fs::read_to_string(path)?;
+    let settings: ClaudeSettings = serde_json::from_str(&content)
+        .map_err(|e| AuditError::Backend(format!("failed to parse settings.json: {}", e)))?;
+
+    let mut findings = Vec::new();
+    let mut safety_bypasses = Vec::new();
+
+    let perms = settings.permissions.as_ref();
+    let allow_rules = perms.map_or(0, |p| p.allow.len());
+    let deny_rules = perms.map_or(0, |p| p.deny.len());
+    let ask_rules = perms.map_or(0, |p| p.ask.len());
+    let mcp_server_count = settings.mcp_servers.as_ref().map_or(0, |m| m.len());
+
+    // --- Trifecta analysis via CapabilityLattice projection ---
+
+    if let Some(perms) = perms {
+        let caps = project_to_capability_lattice(perms);
+        let trifecta_config = IncompatibilityConstraint::enforcing();
+        let trifecta_risk = trifecta_config.trifecta_risk(&caps);
+
+        if trifecta_risk == portcullis::TrifectaRisk::Complete {
+            findings.push(Finding {
+                severity: Severity::Critical,
+                category: "trifecta".to_string(),
+                title: "Lethal trifecta in Claude Code settings".to_string(),
+                description: "The allow rules grant private data access (Read/Glob/Grep) + \
+                    untrusted content (WebFetch/WebSearch) + exfiltration (Bash) without \
+                    sufficient deny rules to break the trifecta. A prompt injection attack \
+                    could exfiltrate sensitive data."
+                    .to_string(),
+            });
+        } else if trifecta_risk == portcullis::TrifectaRisk::Medium {
+            findings.push(Finding {
+                severity: Severity::Medium,
+                category: "trifecta".to_string(),
+                title: "Partial trifecta in Claude Code settings".to_string(),
+                description: "Two of three trifecta components are present in allow rules. \
+                    Adding the third would enable data exfiltration. Review deny rules."
+                    .to_string(),
+            });
+        }
+
+        // --- Unrestricted bash ---
+        for rule in &perms.allow {
+            let parsed = parse_tool_permission(rule);
+            if parsed.tool == ToolKind::Bash && is_unrestricted_pattern(parsed.pattern.as_deref()) {
+                // Check if deny rules mitigate this
+                let has_bash_deny = perms.deny.iter().any(|d| {
+                    let dp = parse_tool_permission(d);
+                    dp.tool == ToolKind::Bash
+                });
+                if !has_bash_deny {
+                    findings.push(Finding {
+                        severity: Severity::High,
+                        category: "permissions".to_string(),
+                        title: "Unrestricted Bash access".to_string(),
+                        description: "Bash is allowed without pattern restrictions and no \
+                            deny rules limit it. The agent can execute any shell command \
+                            including data exfiltration via curl, wget, etc."
+                            .to_string(),
+                    });
+                }
+            }
+
+            // Exfiltration patterns in bash allow rules
+            if parsed.tool == ToolKind::Bash {
+                if let Some(pattern) = &parsed.pattern {
+                    if is_exfil_bash_pattern(pattern) {
+                        findings.push(Finding {
+                            severity: Severity::High,
+                            category: "exfiltration".to_string(),
+                            title: format!("Exfiltration command allowed: {}", rule),
+                            description: format!(
+                                "The allow rule '{}' permits a known exfiltration command. \
+                                 If this is intentional, add it to the 'ask' list instead \
+                                 so it requires approval.",
+                                rule
+                            ),
+                        });
+                    }
+                }
+            }
+
+            // Sensitive path access
+            if parsed.tool == ToolKind::Read {
+                if let Some(pattern) = &parsed.pattern {
+                    if is_sensitive_path_pattern(pattern) {
+                        findings.push(Finding {
+                            severity: Severity::Medium,
+                            category: "permissions".to_string(),
+                            title: format!("Sensitive path readable: {}", rule),
+                            description: format!(
+                                "The allow rule '{}' grants read access to a sensitive path \
+                                 (credentials, secrets, SSH keys). Consider adding a deny rule.",
+                                rule
+                            ),
+                        });
+                    }
+                }
+            }
+        }
+
+        // --- No deny rules ---
+        if perms.deny.is_empty() && !perms.allow.is_empty() {
+            findings.push(Finding {
+                severity: Severity::Medium,
+                category: "permissions".to_string(),
+                title: "No deny rules configured".to_string(),
+                description: "Allow rules are present but no deny rules. Without deny rules, \
+                    all allowed tools have unrestricted access. Add deny rules for sensitive \
+                    operations (e.g., Bash(curl *), Read(.env))."
+                    .to_string(),
+            });
+        }
+    }
+
+    // --- Safety bypass flags ---
+
+    if settings.skip_dangerous_mode_permission_prompt == Some(true) {
+        safety_bypasses.push("skipDangerousModePermissionPrompt".to_string());
+        findings.push(Finding {
+            severity: Severity::High,
+            category: "safety_bypass".to_string(),
+            title: "Dangerous mode prompt skipped".to_string(),
+            description: "skipDangerousModePermissionPrompt is true. This suppresses the \
+                safety confirmation when entering dangerous mode, making it easier to \
+                accidentally grant full permissions."
+                .to_string(),
+        });
+    }
+
+    if settings.api_key_helper.is_some() {
+        findings.push(Finding {
+            severity: Severity::Medium,
+            category: "credentials".to_string(),
+            title: "API key helper script configured".to_string(),
+            description: "An apiKeyHelper script is configured. This script runs to generate \
+                API credentials and has access to the environment. Ensure it is trusted and \
+                not subject to injection."
+                .to_string(),
+        });
+    }
+
+    // --- Sandbox configuration ---
+
+    let sandbox_enabled = settings.sandbox.as_ref().and_then(|s| s.enabled);
+    if sandbox_enabled == Some(false) {
+        safety_bypasses.push("sandbox.enabled=false".to_string());
+        findings.push(Finding {
+            severity: Severity::Medium,
+            category: "isolation".to_string(),
+            title: "Sandbox explicitly disabled".to_string(),
+            description: "The sandbox is explicitly disabled. The agent runs without \
+                filesystem or network isolation boundaries."
+                .to_string(),
+        });
+    }
+
+    // --- Hooks ---
+
+    if let Some(hooks) = &settings.hooks {
+        if hooks.is_object() && !hooks.as_object().unwrap().is_empty() {
+            let hook_count = hooks.as_object().unwrap().len();
+            findings.push(Finding {
+                severity: Severity::Medium,
+                category: "hooks".to_string(),
+                title: format!(
+                    "{} hook{} configured",
+                    hook_count,
+                    if hook_count == 1 { "" } else { "s" }
+                ),
+                description: "Hooks can execute arbitrary commands or make HTTP requests in \
+                    response to tool events. Each hook is a potential execution and \
+                    exfiltration vector. Review hook configurations."
+                    .to_string(),
+            });
+        }
+    }
+
+    // --- Inline credentials in env ---
+
+    if let Some(env) = &settings.env {
+        check_credential_env(env, &mut findings, "settings.env");
+    }
+
+    // --- MCP servers embedded in settings ---
+
+    if let Some(servers) = &settings.mcp_servers {
+        for (name, server) in servers {
+            if let Some(env) = server.get("env").and_then(|e| e.as_object()) {
+                let env_map: HashMap<String, String> = env
+                    .iter()
+                    .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                    .collect();
+                check_credential_env(&env_map, &mut findings, &format!("mcpServers.{}", name));
+            }
+        }
+    }
+
+    let summary = ClaudeSettingsSummary {
+        total_allow_rules: allow_rules,
+        total_deny_rules: deny_rules,
+        total_ask_rules: ask_rules,
+        mcp_server_count,
+        sandbox_enabled,
+        safety_bypasses,
+    };
+
+    Ok((findings, summary))
+}
+
+/// Project Claude Code allow/deny rules to a CapabilityLattice for trifecta analysis.
+fn project_to_capability_lattice(perms: &PermissionRules) -> CapabilityLattice {
+    // Start from all-Never (not default, which is permissive)
+    let mut caps = CapabilityLattice {
+        read_files: CapabilityLevel::Never,
+        write_files: CapabilityLevel::Never,
+        edit_files: CapabilityLevel::Never,
+        run_bash: CapabilityLevel::Never,
+        glob_search: CapabilityLevel::Never,
+        grep_search: CapabilityLevel::Never,
+        web_search: CapabilityLevel::Never,
+        web_fetch: CapabilityLevel::Never,
+        git_commit: CapabilityLevel::Never,
+        git_push: CapabilityLevel::Never,
+        create_pr: CapabilityLevel::Never,
+        manage_pods: CapabilityLevel::Never,
+        ..CapabilityLattice::default()
+    };
+
+    // Allow rules raise capabilities to LowRisk
+    for rule in &perms.allow {
+        let parsed = parse_tool_permission(rule);
+        match parsed.tool {
+            ToolKind::Read | ToolKind::Glob | ToolKind::Grep => {
+                caps.read_files = CapabilityLevel::LowRisk;
+                if matches!(parsed.tool, ToolKind::Glob) {
+                    caps.glob_search = CapabilityLevel::LowRisk;
+                }
+                if matches!(parsed.tool, ToolKind::Grep) {
+                    caps.grep_search = CapabilityLevel::LowRisk;
+                }
+            }
+            ToolKind::Write | ToolKind::Edit => {
+                caps.write_files = CapabilityLevel::LowRisk;
+                caps.edit_files = CapabilityLevel::LowRisk;
+            }
+            ToolKind::Bash => {
+                caps.run_bash = CapabilityLevel::LowRisk;
+            }
+            ToolKind::WebSearch => {
+                caps.web_search = CapabilityLevel::LowRisk;
+            }
+            ToolKind::WebFetch => {
+                caps.web_fetch = CapabilityLevel::LowRisk;
+            }
+            ToolKind::McpTool { .. } | ToolKind::Unknown(_) => {}
+        }
+    }
+
+    // Deny rules demote capabilities back to Never (if they fully block the tool)
+    for rule in &perms.deny {
+        let parsed = parse_tool_permission(rule);
+        // Only demote if the deny is unrestricted (blocks all uses of the tool)
+        if is_unrestricted_pattern(parsed.pattern.as_deref()) {
+            match parsed.tool {
+                ToolKind::Read => caps.read_files = CapabilityLevel::Never,
+                ToolKind::Glob => caps.glob_search = CapabilityLevel::Never,
+                ToolKind::Grep => caps.grep_search = CapabilityLevel::Never,
+                ToolKind::Write => caps.write_files = CapabilityLevel::Never,
+                ToolKind::Edit => caps.edit_files = CapabilityLevel::Never,
+                ToolKind::Bash => caps.run_bash = CapabilityLevel::Never,
+                ToolKind::WebSearch => caps.web_search = CapabilityLevel::Never,
+                ToolKind::WebFetch => caps.web_fetch = CapabilityLevel::Never,
+                _ => {}
+            }
+        }
+    }
+
+    caps
+}
+
+/// Check a map of env vars for credential patterns.
+fn check_credential_env(env: &HashMap<String, String>, findings: &mut Vec<Finding>, source: &str) {
+    let credential_patterns = [
+        "API_KEY",
+        "TOKEN",
+        "SECRET",
+        "PASSWORD",
+        "PRIVATE_KEY",
+        "AWS_SECRET",
+        "DATABASE_URL",
+    ];
+
+    for key in env.keys() {
+        let upper = key.to_uppercase();
+        for pattern in &credential_patterns {
+            if upper.contains(pattern) {
+                findings.push(Finding {
+                    severity: Severity::High,
+                    category: "credentials".to_string(),
+                    title: format!("Credential in {}: {}", source, key),
+                    description: format!(
+                        "Environment variable '{}' in {} matches credential pattern '{}'. \
+                         Use a secret manager or environment variable reference (${{VAR}}) \
+                         instead of plaintext values in config files.",
+                        key, source, pattern
+                    ),
+                });
+                break; // One finding per key
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn settings_json(perms: &str) -> String {
+        format!(r#"{{ "permissions": {} }}"#, perms)
+    }
+
+    #[test]
+    fn test_full_trifecta_detection() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+        std::fs::write(
+            &path,
+            settings_json(r#"{ "allow": ["Read", "WebFetch", "Bash"], "deny": [], "ask": [] }"#),
+        )
+        .unwrap();
+
+        let (findings, summary) = scan_claude_settings(&path).unwrap();
+        assert!(
+            findings
+                .iter()
+                .any(|f| f.category == "trifecta" && f.severity == Severity::Critical),
+            "Should detect lethal trifecta. Findings: {:?}",
+            findings
+        );
+        assert_eq!(summary.total_allow_rules, 3);
+        assert_eq!(summary.total_deny_rules, 0);
+    }
+
+    #[test]
+    fn test_trifecta_mitigated_by_deny() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+        // Deny bash entirely → breaks trifecta exfil leg
+        std::fs::write(
+            &path,
+            settings_json(
+                r#"{ "allow": ["Read", "WebFetch", "Bash(cargo *)"], "deny": ["Bash"], "ask": [] }"#,
+            ),
+        )
+        .unwrap();
+
+        let (findings, _) = scan_claude_settings(&path).unwrap();
+        let trifecta_findings: Vec<_> = findings
+            .iter()
+            .filter(|f| f.category == "trifecta" && f.severity == Severity::Critical)
+            .collect();
+        assert!(
+            trifecta_findings.is_empty(),
+            "Trifecta should be mitigated by deny rule. Got: {:?}",
+            trifecta_findings
+        );
+    }
+
+    #[test]
+    fn test_safety_bypass_detection() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+        std::fs::write(&path, r#"{ "skipDangerousModePermissionPrompt": true }"#).unwrap();
+
+        let (findings, summary) = scan_claude_settings(&path).unwrap();
+        assert!(findings
+            .iter()
+            .any(|f| f.category == "safety_bypass" && f.severity == Severity::High),);
+        assert!(summary
+            .safety_bypasses
+            .contains(&"skipDangerousModePermissionPrompt".to_string()));
+    }
+
+    #[test]
+    fn test_clean_restrictive_settings() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+        std::fs::write(
+            &path,
+            settings_json(
+                r#"{
+                    "allow": ["Read", "Bash(cargo *)"],
+                    "deny": ["Bash(curl *)", "Bash(wget *)", "Read(.env)"],
+                    "ask": ["Bash(git push *)"]
+                }"#,
+            ),
+        )
+        .unwrap();
+
+        let (findings, summary) = scan_claude_settings(&path).unwrap();
+        // No trifecta (no WebFetch), has deny rules
+        let critical: Vec<_> = findings
+            .iter()
+            .filter(|f| f.severity == Severity::Critical)
+            .collect();
+        assert!(
+            critical.is_empty(),
+            "Should have no critical findings: {:?}",
+            critical
+        );
+        assert_eq!(summary.total_deny_rules, 3);
+        assert_eq!(summary.total_ask_rules, 1);
+    }
+
+    #[test]
+    fn test_credential_detection_in_env() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+        std::fs::write(&path, r#"{ "env": { "MY_API_KEY": "sk-secret-123" } }"#).unwrap();
+
+        let (findings, _) = scan_claude_settings(&path).unwrap();
+        assert!(
+            findings
+                .iter()
+                .any(|f| f.category == "credentials" && f.severity == Severity::High),
+            "Should flag credential in env"
+        );
+    }
+
+    #[test]
+    fn test_exfil_bash_pattern() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+        std::fs::write(
+            &path,
+            settings_json(r#"{ "allow": ["Bash(curl *)"], "deny": [], "ask": [] }"#),
+        )
+        .unwrap();
+
+        let (findings, _) = scan_claude_settings(&path).unwrap();
+        assert!(
+            findings.iter().any(|f| f.category == "exfiltration"),
+            "Should flag curl as exfiltration: {:?}",
+            findings
+        );
+    }
+}

--- a/crates/nucleus-audit/src/scan_mcp_config.rs
+++ b/crates/nucleus-audit/src/scan_mcp_config.rs
@@ -1,0 +1,352 @@
+//! MCP server configuration security scanner.
+//!
+//! Parses `.mcp.json` or the `mcpServers` section of Claude Code settings
+//! and flags credential exposure, dangerous commands, and attack surface.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use serde::Deserialize;
+
+use crate::finding::{Finding, McpConfigSummary, Severity};
+use crate::AuditError;
+
+// --- Serde structs for MCP config ---
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpConfig {
+    #[serde(default)]
+    pub mcp_servers: HashMap<String, McpServerEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpServerEntry {
+    #[serde(default)]
+    pub command: Option<String>,
+    #[serde(default)]
+    pub args: Option<Vec<String>>,
+    #[serde(default)]
+    pub env: Option<HashMap<String, String>>,
+    #[serde(default, rename = "type")]
+    pub type_: Option<String>,
+    #[serde(default)]
+    pub url: Option<String>,
+    #[serde(default)]
+    pub headers: Option<HashMap<String, String>>,
+}
+
+/// Scan an MCP config file for security issues.
+pub fn scan_mcp_config(path: &Path) -> Result<(Vec<Finding>, McpConfigSummary), AuditError> {
+    let content = std::fs::read_to_string(path)?;
+    let config: McpConfig = serde_json::from_str(&content)
+        .map_err(|e| AuditError::Backend(format!("failed to parse MCP config: {}", e)))?;
+
+    let mut findings = Vec::new();
+    let mut command_servers = 0;
+    let mut http_servers = 0;
+    let mut servers_with_credentials = 0;
+
+    for (name, server) in &config.mcp_servers {
+        let is_http = server.type_.as_deref() == Some("http") || server.url.is_some();
+        if is_http {
+            http_servers += 1;
+        } else {
+            command_servers += 1;
+        }
+
+        let mut has_creds = false;
+
+        // --- HTTP server analysis ---
+        if is_http {
+            if let Some(url) = &server.url {
+                if !url.starts_with("http://localhost")
+                    && !url.starts_with("http://127.0.0.1")
+                    && !url.starts_with("http://[::1]")
+                {
+                    findings.push(Finding {
+                        severity: Severity::Medium,
+                        category: "network".to_string(),
+                        title: format!("External MCP server '{}': {}", name, url),
+                        description: format!(
+                            "MCP server '{}' connects to an external URL. This exposes \
+                             tool calls and context to a remote endpoint. Ensure the \
+                             server is trusted and the connection is encrypted.",
+                            name
+                        ),
+                    });
+                }
+            }
+        }
+
+        // --- Credential analysis in env ---
+        if let Some(env) = &server.env {
+            let credential_patterns = ["API_KEY", "TOKEN", "SECRET", "PASSWORD", "PRIVATE_KEY"];
+            for (key, value) in env {
+                let upper = key.to_uppercase();
+                let is_variable_ref = value.starts_with("${") || value.starts_with("$");
+                for pattern in &credential_patterns {
+                    if upper.contains(pattern) {
+                        has_creds = true;
+                        if !is_variable_ref {
+                            findings.push(Finding {
+                                severity: Severity::High,
+                                category: "credentials".to_string(),
+                                title: format!(
+                                    "Plaintext credential in MCP server '{}': {}",
+                                    name, key
+                                ),
+                                description: format!(
+                                    "MCP server '{}' has env var '{}' containing a credential \
+                                     value. Use an environment variable reference (${{VAR}}) \
+                                     instead of a plaintext value in the config file.",
+                                    name, key
+                                ),
+                            });
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+
+        // --- Auth headers ---
+        if let Some(headers) = &server.headers {
+            for key in headers.keys() {
+                let lower = key.to_lowercase();
+                if lower == "authorization"
+                    || lower.contains("token")
+                    || lower.contains("api-key")
+                    || lower.contains("x-api-key")
+                {
+                    has_creds = true;
+                    findings.push(Finding {
+                        severity: Severity::High,
+                        category: "credentials".to_string(),
+                        title: format!("Auth header in MCP server '{}': {}", name, key),
+                        description: format!(
+                            "MCP server '{}' includes authentication header '{}'. \
+                             Hardcoded auth headers in config files are a security risk. \
+                             Use environment variable references instead.",
+                            name, key
+                        ),
+                    });
+                }
+            }
+        }
+
+        if has_creds {
+            servers_with_credentials += 1;
+        }
+
+        // --- Dangerous commands ---
+        if let Some(cmd) = &server.command {
+            let dangerous_commands = ["sudo", "sh -c", "bash -c", "eval"];
+            for dangerous in &dangerous_commands {
+                if cmd.contains(dangerous) {
+                    findings.push(Finding {
+                        severity: Severity::High,
+                        category: "execution".to_string(),
+                        title: format!("Dangerous command in MCP server '{}': {}", name, cmd),
+                        description: format!(
+                            "MCP server '{}' uses '{}' which enables arbitrary \
+                             code execution. Prefer specific, scoped commands.",
+                            name, dangerous
+                        ),
+                    });
+                }
+            }
+        }
+
+        // --- Suspicious args ---
+        if let Some(args) = &server.args {
+            for arg in args {
+                if arg.contains("eval") || arg.contains("exec(") {
+                    findings.push(Finding {
+                        severity: Severity::Medium,
+                        category: "execution".to_string(),
+                        title: format!("Suspicious arg in MCP server '{}': {}", name, arg),
+                        description: format!(
+                            "MCP server '{}' has argument '{}' that may enable \
+                             dynamic code execution.",
+                            name, arg
+                        ),
+                    });
+                }
+            }
+        }
+    }
+
+    // --- Overall surface area ---
+    if config.mcp_servers.len() > 5 {
+        findings.push(Finding {
+            severity: Severity::Low,
+            category: "surface_area".to_string(),
+            title: format!("{} MCP servers configured", config.mcp_servers.len()),
+            description: "A large number of MCP servers increases the attack \
+                surface. Each server can execute code and access credentials. \
+                Review whether all servers are necessary."
+                .to_string(),
+        });
+    }
+
+    let summary = McpConfigSummary {
+        server_count: config.mcp_servers.len(),
+        command_servers,
+        http_servers,
+        servers_with_credentials,
+    };
+
+    Ok((findings, summary))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_plaintext_credential_detection() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("mcp.json");
+        std::fs::write(
+            &path,
+            r#"{
+                "mcpServers": {
+                    "myserver": {
+                        "command": "npx",
+                        "args": ["-y", "my-mcp"],
+                        "env": {
+                            "API_KEY": "sk-secret-123"
+                        }
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let (findings, summary) = scan_mcp_config(&path).unwrap();
+        assert!(
+            findings
+                .iter()
+                .any(|f| f.category == "credentials" && f.severity == Severity::High),
+            "Should flag plaintext API_KEY: {:?}",
+            findings
+        );
+        assert_eq!(summary.servers_with_credentials, 1);
+    }
+
+    #[test]
+    fn test_variable_ref_credential_no_flag() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("mcp.json");
+        std::fs::write(
+            &path,
+            r#"{
+                "mcpServers": {
+                    "github": {
+                        "command": "npx",
+                        "args": ["-y", "gh-actions-mcp"],
+                        "env": {
+                            "GITHUB_TOKEN": "${GITHUB_TOKEN}"
+                        }
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let (findings, summary) = scan_mcp_config(&path).unwrap();
+        // Variable refs should NOT be flagged as plaintext credentials
+        let plaintext_creds: Vec<_> = findings
+            .iter()
+            .filter(|f| f.category == "credentials" && f.title.contains("Plaintext"))
+            .collect();
+        assert!(
+            plaintext_creds.is_empty(),
+            "Variable ref should not be flagged as plaintext: {:?}",
+            plaintext_creds
+        );
+        // But it should still count as having credentials
+        assert_eq!(summary.servers_with_credentials, 1);
+    }
+
+    #[test]
+    fn test_http_server_detection() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("mcp.json");
+        std::fs::write(
+            &path,
+            r#"{
+                "mcpServers": {
+                    "remote": {
+                        "type": "http",
+                        "url": "https://api.evil.com/mcp",
+                        "headers": { "Authorization": "Bearer token" }
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let (findings, summary) = scan_mcp_config(&path).unwrap();
+        assert_eq!(summary.http_servers, 1);
+        assert!(findings.iter().any(|f| f.category == "network"));
+        assert!(findings.iter().any(|f| f.category == "credentials"));
+    }
+
+    #[test]
+    fn test_dangerous_command() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("mcp.json");
+        std::fs::write(
+            &path,
+            r#"{
+                "mcpServers": {
+                    "danger": {
+                        "command": "sudo npx",
+                        "args": ["-y", "my-mcp"]
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let (findings, _) = scan_mcp_config(&path).unwrap();
+        assert!(
+            findings
+                .iter()
+                .any(|f| f.category == "execution" && f.severity == Severity::High),
+            "Should flag sudo: {:?}",
+            findings
+        );
+    }
+
+    #[test]
+    fn test_clean_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("mcp.json");
+        std::fs::write(
+            &path,
+            r#"{
+                "mcpServers": {
+                    "local": {
+                        "command": "/usr/local/bin/my-tool",
+                        "args": ["--mode", "safe"]
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let (findings, summary) = scan_mcp_config(&path).unwrap();
+        assert!(
+            findings.is_empty(),
+            "Clean config should have no findings: {:?}",
+            findings
+        );
+        assert_eq!(summary.server_count, 1);
+        assert_eq!(summary.command_servers, 1);
+        assert_eq!(summary.servers_with_credentials, 0);
+    }
+}

--- a/crates/nucleus-audit/src/scan_podspec.rs
+++ b/crates/nucleus-audit/src/scan_podspec.rs
@@ -1,0 +1,442 @@
+//! PodSpec security scanner.
+
+use std::collections::HashSet;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+
+use portcullis::CapabilityLevel;
+
+use crate::finding::{Finding, PermissionSurface, RuntimeMetrics, ScanReport, Severity};
+use crate::AuditError;
+
+/// Signed line from FileAuditBackend.
+#[derive(Debug, serde::Deserialize)]
+#[allow(dead_code)] // hmac used for deserialization matching
+struct SignedLine {
+    entry: serde_json::Value,
+    hmac: String,
+}
+
+pub fn scan_pod_spec(
+    pod_spec_path: &Path,
+    audit_log_path: Option<&Path>,
+) -> Result<ScanReport, AuditError> {
+    let yaml = std::fs::read_to_string(pod_spec_path)?;
+    let spec: nucleus_spec::PodSpec = serde_yaml::from_str(&yaml)
+        .map_err(|e| AuditError::Backend(format!("failed to parse PodSpec: {}", e)))?;
+
+    let lattice = spec
+        .spec
+        .resolve_policy()
+        .map_err(|e| AuditError::Backend(format!("failed to resolve policy: {}", e)))?;
+
+    let mut findings = Vec::new();
+
+    // --- Policy analysis ---
+
+    let policy_profile = match &spec.spec.policy {
+        nucleus_spec::PolicySpec::Profile { name } => name.clone(),
+        nucleus_spec::PolicySpec::Inline { .. } => "inline".to_string(),
+    };
+
+    let trifecta_config = portcullis::IncompatibilityConstraint::enforcing();
+    let trifecta_risk = trifecta_config.trifecta_risk(&lattice.capabilities);
+    let trifecta_enforced = lattice.trifecta_constraint;
+
+    if !trifecta_enforced {
+        findings.push(Finding {
+            severity: Severity::Critical,
+            category: "trifecta".to_string(),
+            title: "Trifecta enforcement disabled".to_string(),
+            description: "The lethal trifecta constraint is disabled. An agent with \
+                private data access + untrusted content + external communication can \
+                exfiltrate data without approval gates."
+                .to_string(),
+        });
+    }
+
+    let trifecta_str = format!("{:?}", trifecta_risk);
+    if trifecta_risk == portcullis::TrifectaRisk::Complete && trifecta_enforced {
+        findings.push(Finding {
+            severity: Severity::Medium,
+            category: "trifecta".to_string(),
+            title: "Complete trifecta with enforcement".to_string(),
+            description: "All three trifecta components are present. Enforcement is \
+                enabled so exfiltration operations will require approval, but the \
+                attack surface is maximal."
+                .to_string(),
+        });
+    } else if trifecta_risk == portcullis::TrifectaRisk::Complete && !trifecta_enforced {
+        findings.push(Finding {
+            severity: Severity::Critical,
+            category: "trifecta".to_string(),
+            title: "Complete trifecta WITHOUT enforcement".to_string(),
+            description: "All three trifecta components are present and enforcement \
+                is disabled. This agent can read private data, fetch untrusted content, \
+                and push to external systems without any approval gate."
+                .to_string(),
+        });
+    }
+
+    // --- Capability surface analysis ---
+
+    let caps = &lattice.capabilities;
+    let cap_fields: Vec<(&str, CapabilityLevel)> = vec![
+        ("read_files", caps.read_files),
+        ("write_files", caps.write_files),
+        ("edit_files", caps.edit_files),
+        ("run_bash", caps.run_bash),
+        ("glob_search", caps.glob_search),
+        ("grep_search", caps.grep_search),
+        ("web_search", caps.web_search),
+        ("web_fetch", caps.web_fetch),
+        ("git_commit", caps.git_commit),
+        ("git_push", caps.git_push),
+        ("create_pr", caps.create_pr),
+        ("manage_pods", caps.manage_pods),
+    ];
+
+    let always_allowed: Vec<String> = cap_fields
+        .iter()
+        .filter(|(_, l)| *l == CapabilityLevel::Always)
+        .map(|(n, _)| n.to_string())
+        .collect();
+    let low_risk: Vec<String> = cap_fields
+        .iter()
+        .filter(|(_, l)| *l == CapabilityLevel::LowRisk)
+        .map(|(n, _)| n.to_string())
+        .collect();
+    let never: Vec<String> = cap_fields
+        .iter()
+        .filter(|(_, l)| *l == CapabilityLevel::Never)
+        .map(|(n, _)| n.to_string())
+        .collect();
+
+    let approval_required: Vec<String> = lattice
+        .obligations
+        .approvals
+        .iter()
+        .map(|op| format!("{:?}", op).to_lowercase())
+        .collect();
+
+    // High-risk capabilities without approval obligations
+    let dangerous_ops = ["run_bash", "git_push", "create_pr", "manage_pods"];
+    for (name, level) in &cap_fields {
+        if dangerous_ops.contains(name) && *level >= CapabilityLevel::Always {
+            let op_name = format!(
+                "{:?}",
+                match *name {
+                    "run_bash" => portcullis::Operation::RunBash,
+                    "git_push" => portcullis::Operation::GitPush,
+                    "create_pr" => portcullis::Operation::CreatePr,
+                    "manage_pods" => portcullis::Operation::ManagePods,
+                    _ => continue,
+                }
+            );
+            let has_approval = approval_required
+                .iter()
+                .any(|a| a == &op_name.to_lowercase());
+            if !has_approval {
+                findings.push(Finding {
+                    severity: Severity::High,
+                    category: "permissions".to_string(),
+                    title: format!("{} is always-allowed without approval", name),
+                    description: format!(
+                        "The capability '{}' is set to Always with no approval \
+                         obligation. Consider requiring human approval for this \
+                         high-risk operation.",
+                        name
+                    ),
+                });
+            }
+        }
+    }
+
+    if policy_profile == "permissive" {
+        findings.push(Finding {
+            severity: Severity::High,
+            category: "policy".to_string(),
+            title: "Permissive policy profile".to_string(),
+            description: "The 'permissive' profile enables most capabilities. \
+                Use a more restrictive profile like 'fix_issue' or 'code_review' \
+                to enforce least privilege."
+                .to_string(),
+        });
+    }
+
+    // --- Network analysis ---
+
+    let network_posture = match &spec.spec.network {
+        Some(net) if !net.deny.is_empty() && net.dns_allow.is_empty() => "airgapped",
+        Some(net) if !net.dns_allow.is_empty() => "filtered",
+        Some(_) => "permissive",
+        None => "unspecified",
+    };
+
+    if network_posture == "unspecified" {
+        findings.push(Finding {
+            severity: Severity::Medium,
+            category: "network".to_string(),
+            title: "No network policy specified".to_string(),
+            description: "The PodSpec has no network configuration. The agent's \
+                network access depends on the executor's defaults. Specify an \
+                explicit NetworkSpec (deny_all, package_registries, or permissive)."
+                .to_string(),
+        });
+    } else if network_posture == "permissive" {
+        findings.push(Finding {
+            severity: Severity::High,
+            category: "network".to_string(),
+            title: "Unrestricted network egress".to_string(),
+            description: "The agent has unrestricted outbound network access. \
+                This enables data exfiltration to arbitrary destinations. Use \
+                NetworkSpec::package_registries() or deny_all() to restrict egress."
+                .to_string(),
+        });
+    }
+
+    // --- Isolation analysis ---
+
+    let isolation_level = if spec.spec.image.is_some() {
+        "firecracker"
+    } else if spec.spec.seccomp.is_some() || spec.spec.cgroup.is_some() {
+        "container"
+    } else {
+        "none"
+    };
+
+    if isolation_level == "none" {
+        findings.push(Finding {
+            severity: Severity::Medium,
+            category: "isolation".to_string(),
+            title: "No VM/container isolation configured".to_string(),
+            description: "The PodSpec has no image, seccomp, or cgroup configuration. \
+                The agent will run with host-level access unless the executor provides \
+                isolation. Configure ImageSpec for Firecracker VM isolation."
+                .to_string(),
+        });
+    }
+
+    if let Some(nucleus_spec::SeccompSpec::Disabled) = &spec.spec.seccomp {
+        findings.push(Finding {
+            severity: Severity::High,
+            category: "isolation".to_string(),
+            title: "Seccomp disabled".to_string(),
+            description: "Seccomp filtering is explicitly disabled. The agent process \
+                can invoke any system call. Use Default or a custom filter."
+                .to_string(),
+        });
+    }
+
+    // --- Credential analysis ---
+
+    let has_credentials = spec
+        .spec
+        .credentials
+        .as_ref()
+        .is_some_and(|c| !c.is_empty());
+    if has_credentials {
+        let creds = spec.spec.credentials.as_ref().unwrap();
+        let dangerous_patterns = [
+            "ROOT",
+            "ADMIN",
+            "MASTER",
+            "PRIVATE_KEY",
+            "AWS_SECRET",
+            "DATABASE_URL",
+        ];
+        for key in creds.env.keys() {
+            let upper = key.to_uppercase();
+            for pattern in &dangerous_patterns {
+                if upper.contains(pattern) {
+                    findings.push(Finding {
+                        severity: Severity::High,
+                        category: "credentials".to_string(),
+                        title: format!("High-privilege credential: {}", key),
+                        description: format!(
+                            "Credential '{}' matches pattern '{}'. Ensure this \
+                             agent requires this level of access and that the \
+                             credential is scoped to minimum privileges.",
+                            key, pattern
+                        ),
+                    });
+                }
+            }
+        }
+
+        if creds.env.len() > 5 {
+            findings.push(Finding {
+                severity: Severity::Medium,
+                category: "credentials".to_string(),
+                title: format!("{} credentials injected", creds.env.len()),
+                description: "A large number of credentials are injected. Each \
+                    credential increases the blast radius of a compromised agent. \
+                    Review whether all credentials are necessary."
+                    .to_string(),
+            });
+        }
+    }
+
+    // --- Timeout analysis ---
+
+    if spec.spec.timeout_seconds > 7200 {
+        findings.push(Finding {
+            severity: Severity::Low,
+            category: "timeout".to_string(),
+            title: format!("Long timeout: {}s", spec.spec.timeout_seconds),
+            description: "Execution timeout exceeds 2 hours. Long-running agents \
+                have more time to perform unauthorized actions if compromised. \
+                Consider a shorter timeout with resume capability."
+                .to_string(),
+        });
+    }
+
+    // --- Runtime audit log analysis ---
+
+    let runtime_metrics = if let Some(log_path) = audit_log_path {
+        Some(analyze_audit_log(log_path, &mut findings)?)
+    } else {
+        None
+    };
+
+    // Sort findings by severity
+    findings.sort_by(|a, b| a.severity.cmp(&b.severity));
+
+    Ok(ScanReport {
+        pod_name: spec.metadata.name,
+        policy_profile: Some(policy_profile),
+        trifecta_risk: trifecta_str,
+        trifecta_enforced,
+        permission_surface: PermissionSurface {
+            total_capabilities: cap_fields.len(),
+            always_allowed,
+            low_risk,
+            never,
+            approval_required,
+        },
+        network_posture: network_posture.to_string(),
+        isolation_level: isolation_level.to_string(),
+        has_credentials,
+        findings,
+        runtime_metrics,
+        claude_settings_summary: None,
+        mcp_config_summary: None,
+    })
+}
+
+fn analyze_audit_log(
+    log_path: &Path,
+    findings: &mut Vec<Finding>,
+) -> Result<RuntimeMetrics, AuditError> {
+    let file = std::fs::File::open(log_path)?;
+    let reader = BufReader::new(file);
+
+    let log = portcullis::audit::AuditLog::in_memory();
+    let mut identities: HashSet<String> = HashSet::new();
+    let mut deviations = 0usize;
+    let mut trifecta_completions = 0usize;
+    let mut blocks = 0usize;
+    let mut total = 0usize;
+
+    for (idx, line) in reader.lines().enumerate() {
+        let line = line?;
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        let entry: portcullis::AuditEntry =
+            if let Ok(signed) = serde_json::from_str::<SignedLine>(line) {
+                serde_json::from_value(signed.entry).map_err(|source| AuditError::Json {
+                    line: idx + 1,
+                    source,
+                })?
+            } else {
+                serde_json::from_str(line).map_err(|source| AuditError::Json {
+                    line: idx + 1,
+                    source,
+                })?
+            };
+
+        identities.insert(entry.identity.clone());
+
+        if entry.is_deviation() {
+            deviations += 1;
+        }
+        if let Some(portcullis::TrifectaRisk::Complete) = entry.trifecta_impact() {
+            trifecta_completions += 1;
+        }
+        if matches!(
+            &entry.event,
+            portcullis::audit::PermissionEvent::ExecutionBlocked { .. }
+        ) {
+            blocks += 1;
+        }
+
+        log.record(entry);
+        total += 1;
+    }
+
+    let chain_valid = log.verify_chain().is_ok();
+
+    if !chain_valid {
+        findings.push(Finding {
+            severity: Severity::Critical,
+            category: "audit_integrity".to_string(),
+            title: "Audit log hash chain broken".to_string(),
+            description: "The audit log's cryptographic hash chain is invalid. \
+                This indicates tampering or corruption. The audit trail cannot \
+                be trusted."
+                .to_string(),
+        });
+    }
+
+    if trifecta_completions > 0 {
+        findings.push(Finding {
+            severity: Severity::High,
+            category: "runtime".to_string(),
+            title: format!(
+                "{} trifecta completion{} detected",
+                trifecta_completions,
+                if trifecta_completions == 1 { "" } else { "s" }
+            ),
+            description: format!(
+                "The audit log contains {} events where all three lethal trifecta \
+                 components were active simultaneously. Review these events for \
+                 potential data exfiltration.",
+                trifecta_completions
+            ),
+        });
+    }
+
+    let deviation_rate = if total > 0 {
+        deviations as f64 / total as f64
+    } else {
+        0.0
+    };
+
+    if deviation_rate > 0.1 {
+        findings.push(Finding {
+            severity: Severity::Medium,
+            category: "runtime".to_string(),
+            title: format!("High deviation rate: {:.1}%", deviation_rate * 100.0),
+            description: format!(
+                "{} of {} audit events ({:.1}%) are deviations from declared \
+                 permissions. This suggests the declared policy is too restrictive \
+                 (agents constantly escalating) or the agent is misbehaving.",
+                deviations,
+                total,
+                deviation_rate * 100.0
+            ),
+        });
+    }
+
+    Ok(RuntimeMetrics {
+        total_entries: total,
+        chain_valid,
+        deviations,
+        trifecta_completions,
+        blocks,
+        identities: identities.len(),
+    })
+}

--- a/crates/nucleus-audit/src/tool_pattern.rs
+++ b/crates/nucleus-audit/src/tool_pattern.rs
@@ -1,0 +1,232 @@
+//! Parser for Claude Code tool permission patterns like `Bash(curl *)` or `mcp__server__tool`.
+
+/// A parsed tool permission from Claude Code settings.json.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ToolPermission {
+    pub tool: ToolKind,
+    pub pattern: Option<String>,
+    pub raw: String,
+}
+
+/// Known tool categories that map to lattice operations.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ToolKind {
+    Bash,
+    Read,
+    Write,
+    Edit,
+    Glob,
+    Grep,
+    WebSearch,
+    WebFetch,
+    /// MCP tool: `mcp__<server>__<tool>`
+    McpTool {
+        server: String,
+        tool: String,
+    },
+    /// Unknown tool name
+    Unknown(String),
+}
+
+#[allow(dead_code)] // Public API for trifecta classification
+impl ToolKind {
+    /// Does this tool provide private data access (trifecta leg 1)?
+    pub fn is_private_data_access(&self) -> bool {
+        matches!(self, ToolKind::Read | ToolKind::Glob | ToolKind::Grep)
+    }
+
+    /// Does this tool provide untrusted content exposure (trifecta leg 2)?
+    pub fn is_untrusted_content(&self) -> bool {
+        matches!(self, ToolKind::WebFetch | ToolKind::WebSearch)
+    }
+
+    /// Does this tool provide an exfiltration vector (trifecta leg 3)?
+    pub fn is_exfil_vector(&self) -> bool {
+        matches!(self, ToolKind::Bash)
+    }
+}
+
+/// Parse a tool permission string like `Bash(curl *)` or `mcp__server__tool`.
+pub fn parse_tool_permission(s: &str) -> ToolPermission {
+    let s = s.trim();
+
+    // Try MCP tool format: mcp__server__tool
+    if s.starts_with("mcp__") {
+        let parts: Vec<&str> = s.splitn(3, "__").collect();
+        if parts.len() >= 3 {
+            return ToolPermission {
+                tool: ToolKind::McpTool {
+                    server: parts[1].to_string(),
+                    tool: parts[2].to_string(),
+                },
+                pattern: None,
+                raw: s.to_string(),
+            };
+        }
+    }
+
+    // Try ToolName(pattern) format
+    if let Some(paren_pos) = s.find('(') {
+        if s.ends_with(')') {
+            let tool_name = &s[..paren_pos];
+            let pattern = &s[paren_pos + 1..s.len() - 1];
+            let tool = match_tool_name(tool_name);
+            return ToolPermission {
+                tool,
+                pattern: if pattern.is_empty() {
+                    None
+                } else {
+                    Some(pattern.to_string())
+                },
+                raw: s.to_string(),
+            };
+        }
+    }
+
+    // Bare tool name (e.g., just "Bash" or "Read")
+    let tool = match_tool_name(s);
+    ToolPermission {
+        tool,
+        pattern: None,
+        raw: s.to_string(),
+    }
+}
+
+fn match_tool_name(name: &str) -> ToolKind {
+    match name {
+        "Bash" => ToolKind::Bash,
+        "Read" => ToolKind::Read,
+        "Write" => ToolKind::Write,
+        "Edit" | "MultiEdit" => ToolKind::Edit,
+        "Glob" | "LS" => ToolKind::Glob,
+        "Grep" => ToolKind::Grep,
+        "WebSearch" => ToolKind::WebSearch,
+        "WebFetch" => ToolKind::WebFetch,
+        other => ToolKind::Unknown(other.to_string()),
+    }
+}
+
+/// Check if a bash pattern is unrestricted (matches everything).
+pub fn is_unrestricted_pattern(pattern: Option<&str>) -> bool {
+    match pattern {
+        None => true, // bare `Bash` with no pattern = unrestricted
+        Some("*") => true,
+        _ => false,
+    }
+}
+
+/// Check if a bash pattern targets known exfiltration commands.
+pub fn is_exfil_bash_pattern(pattern: &str) -> bool {
+    let exfil_commands = [
+        "curl",
+        "wget",
+        "nc",
+        "ncat",
+        "ssh",
+        "scp",
+        "rsync",
+        "git push",
+        "git remote",
+    ];
+    let lower = pattern.to_lowercase();
+    exfil_commands.iter().any(|cmd| lower.contains(cmd))
+}
+
+/// Check if a read pattern targets known sensitive paths.
+pub fn is_sensitive_path_pattern(pattern: &str) -> bool {
+    let sensitive = [
+        ".env",
+        ".aws",
+        ".ssh",
+        ".gnupg",
+        "credentials",
+        "secret",
+        "private_key",
+        "id_rsa",
+        ".claude",
+    ];
+    let lower = pattern.to_lowercase();
+    sensitive.iter().any(|s| lower.contains(s))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_bash_with_pattern() {
+        let p = parse_tool_permission("Bash(curl *)");
+        assert_eq!(p.tool, ToolKind::Bash);
+        assert_eq!(p.pattern.as_deref(), Some("curl *"));
+    }
+
+    #[test]
+    fn test_parse_bare_tool() {
+        let p = parse_tool_permission("Read");
+        assert_eq!(p.tool, ToolKind::Read);
+        assert_eq!(p.pattern, None);
+    }
+
+    #[test]
+    fn test_parse_mcp_tool() {
+        let p = parse_tool_permission("mcp__github__create_pr");
+        assert_eq!(
+            p.tool,
+            ToolKind::McpTool {
+                server: "github".to_string(),
+                tool: "create_pr".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_parse_tool_with_path_pattern() {
+        let p = parse_tool_permission("Write(/workspaces/**)");
+        assert_eq!(p.tool, ToolKind::Write);
+        assert_eq!(p.pattern.as_deref(), Some("/workspaces/**"));
+    }
+
+    #[test]
+    fn test_parse_unknown_tool() {
+        let p = parse_tool_permission("Agent");
+        assert_eq!(p.tool, ToolKind::Unknown("Agent".to_string()));
+    }
+
+    #[test]
+    fn test_unrestricted_pattern() {
+        assert!(is_unrestricted_pattern(None));
+        assert!(is_unrestricted_pattern(Some("*")));
+        assert!(!is_unrestricted_pattern(Some("curl *")));
+    }
+
+    #[test]
+    fn test_exfil_detection() {
+        assert!(is_exfil_bash_pattern("curl *"));
+        assert!(is_exfil_bash_pattern("wget https://evil.com"));
+        assert!(is_exfil_bash_pattern("git push *"));
+        assert!(!is_exfil_bash_pattern("cargo test"));
+        assert!(!is_exfil_bash_pattern("npm run *"));
+    }
+
+    #[test]
+    fn test_sensitive_path() {
+        assert!(is_sensitive_path_pattern(".env"));
+        assert!(is_sensitive_path_pattern("~/.aws/**"));
+        assert!(is_sensitive_path_pattern("~/.ssh/id_rsa"));
+        assert!(!is_sensitive_path_pattern("/workspaces/**"));
+    }
+
+    #[test]
+    fn test_trifecta_classification() {
+        assert!(ToolKind::Read.is_private_data_access());
+        assert!(ToolKind::Grep.is_private_data_access());
+        assert!(!ToolKind::Bash.is_private_data_access());
+
+        assert!(ToolKind::WebFetch.is_untrusted_content());
+        assert!(ToolKind::WebSearch.is_untrusted_content());
+        assert!(!ToolKind::Read.is_untrusted_content());
+
+        assert!(ToolKind::Bash.is_exfil_vector());
+        assert!(!ToolKind::Read.is_exfil_vector());
+    }
+}

--- a/scan/action.yml
+++ b/scan/action.yml
@@ -1,6 +1,6 @@
 name: 'Nucleus Scan'
 author: 'coproduct-opensource'
-description: 'Deterministic security scan for AI agent PodSpecs. No LLM required.'
+description: 'Deterministic security scan for AI agent configs. Scans PodSpecs, Claude Code settings, and MCP configs. No LLM required.'
 branding:
   icon: 'search'
   color: 'orange'
@@ -8,7 +8,13 @@ branding:
 inputs:
   pod-spec:
     description: 'Path to PodSpec YAML file to scan'
-    required: true
+    required: false
+  claude-settings:
+    description: 'Path to Claude Code settings.json to scan'
+    required: false
+  mcp-config:
+    description: 'Path to MCP config (.mcp.json) to scan'
+    required: false
   audit-log:
     description: 'Optional audit log to cross-reference against declared policy'
     required: false
@@ -66,10 +72,27 @@ runs:
       run: |
         set -uo pipefail
 
-        ARGS="--pod-spec ${{ inputs.pod-spec }}"
+        ARGS=""
+
+        if [ -n "${{ inputs.pod-spec }}" ]; then
+          ARGS="${ARGS} --pod-spec ${{ inputs.pod-spec }}"
+        fi
+
+        if [ -n "${{ inputs.claude-settings }}" ]; then
+          ARGS="${ARGS} --claude-settings ${{ inputs.claude-settings }}"
+        fi
+
+        if [ -n "${{ inputs.mcp-config }}" ]; then
+          ARGS="${ARGS} --mcp-config ${{ inputs.mcp-config }}"
+        fi
 
         if [ -n "${{ inputs.audit-log }}" ]; then
           ARGS="${ARGS} --audit-log ${{ inputs.audit-log }}"
+        fi
+
+        if [ -z "${ARGS}" ]; then
+          echo "::error::At least one of pod-spec, claude-settings, or mcp-config is required"
+          exit 1
         fi
 
         # Always capture JSON for the output


### PR DESCRIPTION
## Summary

- Extends `nucleus-audit scan` to accept **Claude Code `settings.json`** and **MCP `.mcp.json`** configs alongside PodSpec YAML
- Claude scanner projects `allow`/`deny` rules onto `CapabilityLattice` for trifecta analysis via the verified portcullis algebra
- MCP scanner detects plaintext credentials, external HTTP servers, auth headers, and dangerous commands
- Refactors monolithic `main.rs` (1260 LOC) into 6 focused modules: `finding`, `report`, `scan_podspec`, `scan_claude_settings`, `scan_mcp_config`, `tool_pattern`
- Updates `scan/action.yml` with `claude-settings` and `mcp-config` inputs
- 24 tests, all passing; zero warnings; clippy/deny/audit clean

## Claude Code Scanner Details

The `ToolName(pattern)` permission syntax (e.g. `Bash(curl *)`, `Read(.env)`, `mcp__server__tool`) is parsed and classified into trifecta legs:
- **Private data access**: Read, Glob, Grep
- **Untrusted content**: WebFetch, WebSearch
- **Exfiltration**: Bash

Deny rules that fully block a tool (bare name, no pattern restriction) demote the corresponding `CapabilityLevel` back to `Never`, breaking the trifecta.

## Test plan

- [x] 24 unit tests across all modules
- [x] cargo clippy clean
- [x] cargo fmt clean
- [x] cargo deny + cargo audit clean
- [ ] CI passes
- [ ] Manual test with real `settings.json` and `.mcp.json` files


🤖 Generated with [Claude Code](https://claude.com/claude-code)