### PR TITLE
chore: example configs + CI scan for all formats

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -1,4 +1,4 @@
-name: PodSpec Scan
+name: Config Scan
 
 on:
   push:
@@ -48,6 +48,42 @@ jobs:
           fi
           echo "::endgroup::"
 
+          # Claude Code settings.json
+          echo "::group::safe-restrictive.json (Claude settings)"
+          $SCANNER scan --claude-settings examples/claude-settings/safe-restrictive.json
+          echo "::endgroup::"
+
+          echo "::group::permissive-danger.json (Claude settings, expected FAIL)"
+          if $SCANNER scan --claude-settings examples/claude-settings/permissive-danger.json; then
+            echo "::error::permissive-danger.json should fail the scan but passed"
+            exit 1
+          else
+            echo "Correctly failed — this Claude config is intentionally insecure"
+          fi
+          echo "::endgroup::"
+
+          # MCP configs
+          echo "::group::safe-local.json (MCP config)"
+          $SCANNER scan --mcp-config examples/mcp-configs/safe-local.json
+          echo "::endgroup::"
+
+          echo "::group::permissive-danger.json (MCP config, expected FAIL)"
+          if $SCANNER scan --mcp-config examples/mcp-configs/permissive-danger.json; then
+            echo "::error::permissive-danger.json should fail the scan but passed"
+            exit 1
+          else
+            echo "Correctly failed — this MCP config is intentionally insecure"
+          fi
+          echo "::endgroup::"
+
+          # Combined scan
+          echo "::group::Combined scan (all three formats)"
+          $SCANNER scan \
+            --pod-spec examples/podspecs/safe-pr-fixer.yaml \
+            --claude-settings examples/claude-settings/safe-restrictive.json \
+            --mcp-config examples/mcp-configs/safe-local.json
+          echo "::endgroup::"
+
   # Test the standalone scan action (downloads pre-built binary from releases)
   scan-action:
     name: Scan Action (integration)
@@ -58,7 +94,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Scan safe PodSpec
-        uses: coproduct-opensource/nucleus/scan@v1.0.5
+        uses: coproduct-opensource/nucleus/scan@v1.0.7
         id: safe
         with:
           pod-spec: examples/podspecs/safe-pr-fixer.yaml

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ See [`examples/podspecs/`](examples/podspecs/) for real configurations:
 Add to any CI pipeline — blocks PRs with unsafe agent configs:
 
 ```yaml
-- uses: coproduct-opensource/nucleus/scan@v1.0.5
+- uses: coproduct-opensource/nucleus/scan@v1.0.7
   with:
     pod-spec: path/to/podspec.yaml
     # claude-settings: .claude/settings.json
@@ -294,7 +294,7 @@ At least one of `pod-spec`, `claude-settings`, or `mcp-config` is required. Outp
 Drop this into any repo to get nucleus-enforced issue fixes:
 
 ```yaml
-- uses: coproduct-opensource/nucleus@v1.0.5
+- uses: coproduct-opensource/nucleus@v1.0.7
   with:
     issue-number: "123"
     api-key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/examples/claude-settings/permissive-danger.json
+++ b/examples/claude-settings/permissive-danger.json
@@ -1,0 +1,24 @@
+{
+  "permissions": {
+    "allow": [
+      "Read",
+      "Write",
+      "Edit",
+      "Glob",
+      "Grep",
+      "Bash",
+      "WebFetch",
+      "WebSearch"
+    ],
+    "deny": [],
+    "ask": []
+  },
+  "skipDangerousModePermissionPrompt": true,
+  "sandbox": {
+    "enabled": false
+  },
+  "env": {
+    "OPENAI_API_KEY": "sk-proj-abc123",
+    "DATABASE_URL": "postgresql://admin:password@db.example.com/prod"
+  }
+}

--- a/examples/claude-settings/safe-restrictive.json
+++ b/examples/claude-settings/safe-restrictive.json
@@ -1,0 +1,31 @@
+{
+  "permissions": {
+    "allow": [
+      "Read",
+      "Glob",
+      "Grep",
+      "Bash(cargo *)",
+      "Bash(git status)",
+      "Bash(git diff *)",
+      "Bash(git log *)"
+    ],
+    "deny": [
+      "Bash(curl *)",
+      "Bash(wget *)",
+      "Bash(nc *)",
+      "Bash(ssh *)",
+      "Read(.env)",
+      "Read(*credentials*)",
+      "Read(*secret*)"
+    ],
+    "ask": [
+      "Write",
+      "Edit",
+      "Bash(git commit *)",
+      "Bash(git push *)"
+    ]
+  },
+  "sandbox": {
+    "enabled": true
+  }
+}

--- a/examples/mcp-configs/permissive-danger.json
+++ b/examples/mcp-configs/permissive-danger.json
@@ -1,0 +1,47 @@
+{
+  "mcpServers": {
+    "external-api": {
+      "type": "sse",
+      "url": "https://untrusted-server.example.com/mcp",
+      "headers": {
+        "Authorization": "Bearer sk-live-abc123def456"
+      }
+    },
+    "shell-runner": {
+      "command": "bash",
+      "args": ["-c", "node server.js"],
+      "env": {
+        "AWS_SECRET_ACCESS_KEY": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+        "DATABASE_PASSWORD": "super-secret-password"
+      }
+    },
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_TOKEN": "ghp_plaintext_token_here"
+      }
+    },
+    "searxng": {
+      "command": "uvx",
+      "args": ["mcp-searxng"],
+      "env": {
+        "SEARXNG_URL": "http://localhost:8080"
+      }
+    },
+    "postgres": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-postgres"],
+      "env": {
+        "DATABASE_URL": "postgresql://admin:password@db.prod.example.com:5432/production"
+      }
+    },
+    "slack": {
+      "command": "npx",
+      "args": ["-y", "@anthropic/mcp-slack"],
+      "env": {
+        "SLACK_API_TOKEN": "xoxb-plaintext-token"
+      }
+    }
+  }
+}

--- a/examples/mcp-configs/safe-local.json
+++ b/examples/mcp-configs/safe-local.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx",
+      "args": ["-y", "@anthropic/mcp-filesystem", "/tmp/workspace"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds example Claude Code settings and MCP config fixtures alongside existing PodSpec examples
- Expands scan CI workflow to test all three formats (including expected-failure negative tests)
- Adds combined multi-format scan step
- Updates action refs to v1.0.7

## Example configs

| Config | Expected Verdict |
|--------|-----------------|
| `claude-settings/safe-restrictive.json` | PASS (medium advisory) |
| `claude-settings/permissive-danger.json` | FAIL (critical trifecta + credentials) |
| `mcp-configs/safe-local.json` | PASS (zero findings) |
| `mcp-configs/permissive-danger.json` | FAIL (5 high — credentials + auth headers) |

## Test plan

- [x] All four configs produce expected exit codes locally
- [x] Combined scan works
- [ ] CI passes


🤖 Generated with [Claude Code](https://claude.com/claude-code)