### PR TITLE
feat: auto-discovery mode for agent config scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,12 @@ cargo install --git https://github.com/coproduct-opensource/nucleus nucleus-audi
 
 # Or download a pre-built binary from GitHub Releases
 
-# Scan a PodSpec for security issues
+# Auto-discover and scan all agent configs in the current repo
+nucleus-audit scan --auto
+
+# Or specify paths explicitly
 nucleus-audit scan --pod-spec your-agent.yaml
-
-# Scan a Claude Code settings.json
 nucleus-audit scan --claude-settings .claude/settings.json
-
-# Scan an MCP config
 nucleus-audit scan --mcp-config .mcp.json
 
 # Scan everything at once — findings are merged and deduplicated
@@ -279,15 +278,21 @@ See [`examples/podspecs/`](examples/podspecs/) for real configurations:
 Add to any CI pipeline — blocks PRs with unsafe agent configs:
 
 ```yaml
+# Auto-discover all agent configs in the repo
 - uses: coproduct-opensource/nucleus/scan@v1.0.8
   with:
-    pod-spec: path/to/podspec.yaml
-    # claude-settings: .claude/settings.json
-    # mcp-config: .mcp.json
+    auto: true
+
+# Or specify paths explicitly
+- uses: coproduct-opensource/nucleus/scan@v1.0.8
+  with:
+    claude-settings: .claude/settings.json
+    mcp-config: .mcp.json
+    # pod-spec: path/to/podspec.yaml
     # format: text          # or json
 ```
 
-At least one of `pod-spec`, `claude-settings`, or `mcp-config` is required. Outputs `verdict` (PASS/WARN/FAIL) and `findings-json`. Non-zero exit code on critical or high findings.
+Use `auto: true` to discover configs automatically, or provide explicit paths. Outputs `verdict` (PASS/WARN/FAIL) and `findings-json`. Non-zero exit code on critical or high findings.
 
 ### Safe PR Fixer (LLM-powered, lattice-enforced)
 

--- a/crates/nucleus-audit/src/discover.rs
+++ b/crates/nucleus-audit/src/discover.rs
@@ -1,0 +1,199 @@
+//! Auto-discovery of agent configuration files.
+//!
+//! Walks the directory tree to find Claude Code settings, MCP configs,
+//! and PodSpec files. Zero-config entry point for `nucleus-audit scan --auto`.
+
+use std::path::{Path, PathBuf};
+
+/// Known config file patterns to discover.
+const CLAUDE_SETTINGS_NAMES: &[&str] = &[".claude/settings.json", ".claude/settings.local.json"];
+
+const MCP_CONFIG_NAMES: &[&str] = &[".mcp.json", "mcp.json", ".cursor/mcp.json"];
+
+/// Result of auto-discovery scan.
+#[derive(Debug, Default)]
+pub struct DiscoveredConfigs {
+    pub claude_settings: Vec<PathBuf>,
+    pub mcp_configs: Vec<PathBuf>,
+    pub pod_specs: Vec<PathBuf>,
+}
+
+impl DiscoveredConfigs {
+    pub fn is_empty(&self) -> bool {
+        self.claude_settings.is_empty() && self.mcp_configs.is_empty() && self.pod_specs.is_empty()
+    }
+
+    pub fn total(&self) -> usize {
+        self.claude_settings.len() + self.mcp_configs.len() + self.pod_specs.len()
+    }
+}
+
+/// Discover agent config files starting from `root`.
+///
+/// Walks the directory tree up to `max_depth` levels deep, skipping
+/// hidden directories (except `.claude` and `.cursor`), `node_modules`,
+/// `target`, and `.git`.
+pub fn discover_configs(root: &Path, max_depth: usize) -> DiscoveredConfigs {
+    let mut result = DiscoveredConfigs::default();
+    walk_dir(root, 0, max_depth, &mut result);
+    // Sort for deterministic output
+    result.claude_settings.sort();
+    result.mcp_configs.sort();
+    result.pod_specs.sort();
+    result
+}
+
+fn walk_dir(dir: &Path, depth: usize, max_depth: usize, result: &mut DiscoveredConfigs) {
+    if depth > max_depth {
+        return;
+    }
+
+    // Check for known config files at this level
+    for name in CLAUDE_SETTINGS_NAMES {
+        let path = dir.join(name);
+        if path.is_file() {
+            result.claude_settings.push(path);
+        }
+    }
+
+    for name in MCP_CONFIG_NAMES {
+        let path = dir.join(name);
+        if path.is_file() {
+            result.mcp_configs.push(path);
+        }
+    }
+
+    // Check for PodSpec YAML files in known locations
+    if depth == 0 {
+        // Only scan specific dirs for podspecs to avoid false positives
+        for podspec_dir in &["examples/podspecs", "podspecs", "deploy", "k8s", ".nucleus"] {
+            let ps_dir = dir.join(podspec_dir);
+            if ps_dir.is_dir() {
+                scan_podspec_dir(&ps_dir, result);
+            }
+        }
+    }
+
+    // Recurse into subdirectories
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+
+        let name = match path.file_name().and_then(|n| n.to_str()) {
+            Some(n) => n,
+            None => continue,
+        };
+
+        // Skip irrelevant directories
+        if should_skip_dir(name) {
+            continue;
+        }
+
+        walk_dir(&path, depth + 1, max_depth, result);
+    }
+}
+
+fn should_skip_dir(name: &str) -> bool {
+    matches!(
+        name,
+        ".git"
+            | "node_modules"
+            | "target"
+            | "__pycache__"
+            | ".venv"
+            | "venv"
+            | ".tox"
+            | "dist"
+            | "build"
+    ) || (name.starts_with('.') && name != ".claude" && name != ".cursor" && name != ".nucleus")
+}
+
+fn scan_podspec_dir(dir: &Path, result: &mut DiscoveredConfigs) {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
+            if ext == "yaml" || ext == "yml" {
+                // Quick check: does it look like a nucleus PodSpec?
+                if let Ok(content) = std::fs::read_to_string(&path) {
+                    if content.contains("nucleus") && content.contains("Pod") {
+                        result.pod_specs.push(path);
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_discover_claude_settings() {
+        let dir = tempfile::tempdir().unwrap();
+        let claude_dir = dir.path().join(".claude");
+        std::fs::create_dir_all(&claude_dir).unwrap();
+        std::fs::write(claude_dir.join("settings.json"), "{}").unwrap();
+
+        let result = discover_configs(dir.path(), 3);
+        assert_eq!(result.claude_settings.len(), 1);
+        assert!(result.claude_settings[0].ends_with(".claude/settings.json"));
+    }
+
+    #[test]
+    fn test_discover_mcp_config() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(".mcp.json"), "{}").unwrap();
+
+        let result = discover_configs(dir.path(), 3);
+        assert_eq!(result.mcp_configs.len(), 1);
+    }
+
+    #[test]
+    fn test_discover_podspec() {
+        let dir = tempfile::tempdir().unwrap();
+        let ps_dir = dir.path().join("examples/podspecs");
+        std::fs::create_dir_all(&ps_dir).unwrap();
+        std::fs::write(
+            ps_dir.join("agent.yaml"),
+            "apiVersion: nucleus/v1\nkind: Pod\n",
+        )
+        .unwrap();
+
+        let result = discover_configs(dir.path(), 3);
+        assert_eq!(result.pod_specs.len(), 1);
+    }
+
+    #[test]
+    fn test_discover_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let result = discover_configs(dir.path(), 3);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_skip_node_modules() {
+        let dir = tempfile::tempdir().unwrap();
+        let nm_dir = dir.path().join("node_modules/.claude");
+        std::fs::create_dir_all(&nm_dir).unwrap();
+        std::fs::write(nm_dir.join("settings.json"), "{}").unwrap();
+
+        let result = discover_configs(dir.path(), 3);
+        assert!(result.claude_settings.is_empty());
+    }
+}

--- a/crates/nucleus-audit/src/main.rs
+++ b/crates/nucleus-audit/src/main.rs
@@ -1,3 +1,4 @@
+mod discover;
 mod finding;
 mod report;
 mod scan_claude_settings;
@@ -69,8 +70,14 @@ enum Command {
     /// Scan agent configurations for security posture and vulnerabilities.
     ///
     /// Supports PodSpec YAML, Claude Code settings.json, and MCP config files.
-    /// At least one input source must be provided.
+    /// Use --auto to discover configs in the current directory, or provide paths explicitly.
     Scan {
+        /// Auto-discover config files in the current directory tree.
+        #[arg(long)]
+        auto: bool,
+        /// Directory to scan when using --auto (defaults to current directory).
+        #[arg(long, default_value = ".")]
+        dir: PathBuf,
         /// Path to a PodSpec YAML/JSON file.
         #[arg(long)]
         pod_spec: Option<PathBuf>,
@@ -166,32 +173,84 @@ fn main() -> Result<(), AuditError> {
             export_log(&log, &format)?;
         }
         Command::Scan {
+            auto,
+            dir,
             pod_spec,
             claude_settings,
             mcp_config,
             audit_log,
             format,
         } => {
-            if pod_spec.is_none() && claude_settings.is_none() && mcp_config.is_none() {
+            // Collect all config paths to scan
+            let mut pod_specs: Vec<PathBuf> = pod_spec.into_iter().collect();
+            let mut claude_settings_paths: Vec<PathBuf> = claude_settings.into_iter().collect();
+            let mut mcp_configs: Vec<PathBuf> = mcp_config.into_iter().collect();
+
+            if auto {
+                let discovered = discover::discover_configs(&dir, 3);
+                if discovered.is_empty()
+                    && pod_specs.is_empty()
+                    && claude_settings_paths.is_empty()
+                    && mcp_configs.is_empty()
+                {
+                    eprintln!("No agent config files found in {}", dir.display());
+                    eprintln!(
+                        "Looked for: .claude/settings.json, .mcp.json, \
+                         and PodSpec YAML in examples/podspecs/"
+                    );
+                    std::process::exit(2);
+                }
+
+                // Print discovery results
+                if !discovered.is_empty() {
+                    eprintln!(
+                        "Discovered {} config file{}:",
+                        discovered.total(),
+                        if discovered.total() == 1 { "" } else { "s" }
+                    );
+                    for p in &discovered.claude_settings {
+                        eprintln!("  Claude settings: {}", p.display());
+                    }
+                    for p in &discovered.mcp_configs {
+                        eprintln!("  MCP config:      {}", p.display());
+                    }
+                    for p in &discovered.pod_specs {
+                        eprintln!("  PodSpec:         {}", p.display());
+                    }
+                    eprintln!();
+                }
+
+                pod_specs.extend(discovered.pod_specs);
+                claude_settings_paths.extend(discovered.claude_settings);
+                mcp_configs.extend(discovered.mcp_configs);
+            }
+
+            if pod_specs.is_empty() && claude_settings_paths.is_empty() && mcp_configs.is_empty() {
                 eprintln!(
                     "Error: at least one of --pod-spec, --claude-settings, \
-                     or --mcp-config is required"
+                     --mcp-config, or --auto is required"
                 );
                 std::process::exit(2);
             }
 
             let mut report = ScanReport::default();
+            let mut has_pod_spec = false;
 
-            // Scan PodSpec if provided
-            if let Some(ps_path) = &pod_spec {
-                report = scan_podspec::scan_pod_spec(ps_path, audit_log.as_deref())?;
+            // Scan PodSpecs
+            for ps_path in &pod_specs {
+                let ps_report = scan_podspec::scan_pod_spec(ps_path, audit_log.as_deref())?;
+                if !has_pod_spec {
+                    report = ps_report;
+                    has_pod_spec = true;
+                } else {
+                    report.findings.extend(ps_report.findings);
+                }
             }
 
-            // Scan Claude settings if provided
-            if let Some(cs_path) = &claude_settings {
+            // Scan Claude settings
+            for cs_path in &claude_settings_paths {
                 let (findings, summary) = scan_claude_settings::scan_claude_settings(cs_path)?;
-                // If no PodSpec, derive trifecta info from settings findings
-                if pod_spec.is_none() {
+                if !has_pod_spec {
                     let has_trifecta = findings
                         .iter()
                         .any(|f| f.category == "trifecta" && f.severity == Severity::Critical);
@@ -202,15 +261,15 @@ fn main() -> Result<(), AuditError> {
                     } else {
                         "None".to_string()
                     };
-                    report.trifecta_enforced = false; // settings.json has no enforcement
+                    report.trifecta_enforced = false;
                     report.has_credentials = findings.iter().any(|f| f.category == "credentials");
                 }
                 report.findings.extend(findings);
                 report.claude_settings_summary = Some(summary);
             }
 
-            // Scan MCP config if provided
-            if let Some(mc_path) = &mcp_config {
+            // Scan MCP configs
+            for mc_path in &mcp_configs {
                 let (findings, summary) = scan_mcp_config::scan_mcp_config(mc_path)?;
                 if findings.iter().any(|f| f.category == "credentials") {
                     report.has_credentials = true;

--- a/scan/action.yml
+++ b/scan/action.yml
@@ -18,6 +18,9 @@ inputs:
   audit-log:
     description: 'Optional audit log to cross-reference against declared policy'
     required: false
+  auto:
+    description: 'Auto-discover config files in the repository (ignores pod-spec/claude-settings/mcp-config)'
+    default: 'false'
   format:
     description: 'Output format (text or json)'
     default: 'text'
@@ -74,25 +77,29 @@ runs:
 
         ARGS=""
 
-        if [ -n "${{ inputs.pod-spec }}" ]; then
-          ARGS="${ARGS} --pod-spec ${{ inputs.pod-spec }}"
-        fi
+        if [ "${{ inputs.auto }}" = "true" ]; then
+          ARGS="--auto"
+        else
+          if [ -n "${{ inputs.pod-spec }}" ]; then
+            ARGS="${ARGS} --pod-spec ${{ inputs.pod-spec }}"
+          fi
 
-        if [ -n "${{ inputs.claude-settings }}" ]; then
-          ARGS="${ARGS} --claude-settings ${{ inputs.claude-settings }}"
-        fi
+          if [ -n "${{ inputs.claude-settings }}" ]; then
+            ARGS="${ARGS} --claude-settings ${{ inputs.claude-settings }}"
+          fi
 
-        if [ -n "${{ inputs.mcp-config }}" ]; then
-          ARGS="${ARGS} --mcp-config ${{ inputs.mcp-config }}"
-        fi
+          if [ -n "${{ inputs.mcp-config }}" ]; then
+            ARGS="${ARGS} --mcp-config ${{ inputs.mcp-config }}"
+          fi
 
-        if [ -n "${{ inputs.audit-log }}" ]; then
-          ARGS="${ARGS} --audit-log ${{ inputs.audit-log }}"
-        fi
+          if [ -n "${{ inputs.audit-log }}" ]; then
+            ARGS="${ARGS} --audit-log ${{ inputs.audit-log }}"
+          fi
 
-        if [ -z "${ARGS}" ]; then
-          echo "::error::At least one of pod-spec, claude-settings, or mcp-config is required"
-          exit 1
+          if [ -z "${ARGS}" ]; then
+            echo "::error::At least one of pod-spec, claude-settings, mcp-config, or auto is required"
+            exit 1
+          fi
         fi
 
         # Always capture JSON for the output


### PR DESCRIPTION
## Summary

- Adds `--auto` flag to `nucleus-audit scan` that discovers agent configs automatically
- Walks directory tree finding `.claude/settings.json`, `.mcp.json`, and PodSpec YAML
- Skips irrelevant directories (node_modules, target, .git, .venv, etc.)
- All discovered configs scanned and findings merged into a unified report
- Adds `auto: true` input to `scan/action.yml` for zero-config CI

## Usage

```bash
# Zero-config — just run it in any repo
nucleus-audit scan --auto

# GitHub Action
- uses: coproduct-opensource/nucleus/scan@v1.0.9
  with:
    auto: true
```

## Discovery targets

| Pattern | Type |
|---------|------|
| `.claude/settings.json` | Claude Code settings |
| `.claude/settings.local.json` | Claude Code local settings |
| `.mcp.json`, `mcp.json` | MCP config |
| `.cursor/mcp.json` | Cursor MCP config |
| `examples/podspecs/*.yaml` | PodSpec (with nucleus+Pod content check) |
| `podspecs/*.yaml`, `deploy/*.yaml`, `k8s/*.yaml` | PodSpec |

## Test plan

- [x] 29 tests (5 new discovery tests), all passing
- [x] Tested on nucleus repo itself — discovered 5 configs
- [x] clippy/fmt/deny/audit clean
- [ ] CI passes


🤖 Generated with [Claude Code](https://claude.com/claude-code)