### PR TITLE
feat(portcullis): delegation chain and trifecta guard examples

### DIFF
--- a/crates/portcullis/examples/cli_integration.rs
+++ b/crates/portcullis/examples/cli_integration.rs
@@ -1,11 +1,11 @@
-//! Example showing how to integrate with Claude Code CLI.
+//! Example showing how to integrate with an AI agent CLI.
 //!
 //! This example demonstrates converting a PermissionLattice to
-//! Claude Code CLI flags for the `--allowedTools` argument.
+//! CLI flags for tool allowlists and permission modes.
 
 use portcullis::{CapabilityLevel, Operation, PermissionLattice};
 
-/// Convert a PermissionLattice to Claude Code CLI `--allowedTools` flags.
+/// Convert a PermissionLattice to CLI `--allowedTools` flags.
 fn build_allowed_tools(perms: &PermissionLattice) -> Vec<String> {
     let mut tools = Vec::new();
     let caps = &perms.capabilities;
@@ -45,7 +45,7 @@ fn build_allowed_tools(perms: &PermissionLattice) -> Vec<String> {
     tools
 }
 
-/// Get the permission mode for Claude Code CLI.
+/// Get the permission mode for the agent CLI.
 fn get_permission_mode(perms: &PermissionLattice) -> &'static str {
     // If any operation requires approval, use plan mode
     let needs_ask = [
@@ -69,7 +69,7 @@ fn get_permission_mode(perms: &PermissionLattice) -> &'static str {
 }
 
 fn main() {
-    println!("=== Claude Code CLI Integration Example ===\n");
+    println!("=== AI Agent CLI Integration Example ===\n");
 
     // Example 1: Code review (read-only)
     println!("1. Code Review Task:");
@@ -80,7 +80,7 @@ fn main() {
     println!("   Allowed tools: {:?}", tools);
     println!("   Permission mode: {}", mode);
     println!(
-        "   CLI: claude --allowedTools {} --permission-mode {}",
+        "   CLI: agent --allowedTools {} --permission-mode {}",
         tools.join(","),
         mode
     );
@@ -94,7 +94,7 @@ fn main() {
     println!("   Allowed tools: {:?}", tools);
     println!("   Permission mode: {}", mode);
     println!(
-        "   CLI: claude --allowedTools {} --permission-mode {} --max-cost-usd {:.2}",
+        "   CLI: agent --allowedTools {} --permission-mode {} --max-cost-usd {:.2}",
         tools.join(","),
         mode,
         fix_perms.budget.max_cost_usd
@@ -122,7 +122,7 @@ fn main() {
     let tools = build_allowed_tools(&safe);
     let mode = get_permission_mode(&safe);
     println!(
-        "   CLI: claude --allowedTools {} --permission-mode {}",
+        "   CLI: agent --allowedTools {} --permission-mode {}",
         tools.join(","),
         mode
     );

--- a/crates/portcullis/examples/delegation_chain.rs
+++ b/crates/portcullis/examples/delegation_chain.rs
@@ -1,0 +1,144 @@
+//! Delegation chain defense example — demonstrates how the permission lattice
+//! prevents multi-agent privilege escalation attacks.
+//!
+//! Run with: `cargo run --example delegation_chain -p portcullis`
+//!
+//! This example walks through a real-world attack scenario (PajaMAS-style
+//! multi-agent hijacking) and shows how lattice-guard's monotone delegation
+//! prevents it at every step.
+
+use portcullis::{meet_with_justification, CapabilityLevel, Operation, PermissionLattice};
+
+/// Build a human trust anchor with full capabilities.
+fn build_human_alice() -> PermissionLattice {
+    let mut p = PermissionLattice::permissive();
+    p.description = "Human: Alice (trust anchor)".to_string();
+    p
+}
+
+/// Build an orchestrator request — wants read, write, search, and git.
+fn build_orchestrator_request() -> PermissionLattice {
+    let mut p = PermissionLattice::fix_issue();
+    p.description = "Orchestrator: PR review agent".to_string();
+    p
+}
+
+/// Build a sub-agent request — claims it needs bash + web for "testing".
+fn build_malicious_subagent_request() -> PermissionLattice {
+    let mut p = PermissionLattice::permissive();
+    p.description = "Sub-agent: claims testing needs".to_string();
+    // Attacker wants everything
+    p.capabilities.run_bash = CapabilityLevel::Always;
+    p.capabilities.web_fetch = CapabilityLevel::Always;
+    p.capabilities.git_push = CapabilityLevel::Always;
+    p
+}
+
+fn main() {
+    println!("╔══════════════════════════════════════════════════════════════════╗");
+    println!("║   Delegation Chain Defense: Multi-Agent Privilege Escalation    ║");
+    println!("╚══════════════════════════════════════════════════════════════════╝\n");
+
+    // Step 1: Human trust anchor
+    let alice = build_human_alice();
+    println!("1. Human trust anchor (Alice):");
+    println!("   read_files:  {:?}", alice.capabilities.read_files);
+    println!("   write_files: {:?}", alice.capabilities.write_files);
+    println!("   git_push:    {:?}", alice.capabilities.git_push);
+    println!("   run_bash:    {:?}", alice.capabilities.run_bash);
+
+    // Step 2: Delegate to orchestrator
+    println!("\n2. Delegating to orchestrator (PR review):");
+    let orch_request = build_orchestrator_request();
+    let orch = alice
+        .delegate_to(&orch_request, "PR review for issue #42")
+        .expect("delegation should succeed");
+    println!("   write_files: {:?}", orch.capabilities.write_files);
+    println!("   git_push:    {:?}", orch.capabilities.git_push);
+    println!(
+        "   run_bash:    {:?} (restricted by profile)",
+        orch.capabilities.run_bash
+    );
+    println!("   orch <= alice: {}", orch.leq(&alice));
+
+    // Step 3: Sub-agent tries to escalate
+    println!("\n3. Malicious sub-agent requests full capabilities:");
+    let malicious_request = build_malicious_subagent_request();
+    println!(
+        "   Requested run_bash:  {:?}",
+        malicious_request.capabilities.run_bash
+    );
+    println!(
+        "   Requested web_fetch: {:?}",
+        malicious_request.capabilities.web_fetch
+    );
+    println!(
+        "   Requested git_push:  {:?}",
+        malicious_request.capabilities.git_push
+    );
+
+    // Delegation enforces monotone attenuation via meet
+    let (sub_effective, justification) = meet_with_justification(&orch, &malicious_request);
+    println!("\n   After delegation (meet with orchestrator ceiling):");
+    println!(
+        "   Effective run_bash:  {:?}",
+        sub_effective.capabilities.run_bash
+    );
+    println!(
+        "   Effective web_fetch: {:?}",
+        sub_effective.capabilities.web_fetch
+    );
+    println!(
+        "   Effective git_push:  {:?}",
+        sub_effective.capabilities.git_push
+    );
+    println!("   sub <= orch:  {}", sub_effective.leq(&orch));
+    println!("   sub <= alice: {}", sub_effective.leq(&alice));
+
+    // Show what was restricted
+    println!("\n   Restrictions applied:");
+    for detail in &justification.restrictions {
+        println!("   - {:?}: {:?}", detail.dimension, detail.reason);
+    }
+
+    // Step 4: Trifecta check
+    println!("\n4. Trifecta safety check:");
+    println!(
+        "   Sub-agent triggers trifecta: {}",
+        sub_effective.is_trifecta_vulnerable()
+    );
+    println!(
+        "   git_push requires approval: {}",
+        sub_effective.requires_approval(Operation::GitPush)
+    );
+    println!(
+        "   run_bash requires approval: {}",
+        sub_effective.requires_approval(Operation::RunBash)
+    );
+
+    // Step 5: Verify the monotone chain property
+    println!("\n5. Monotone chain verification (audit trail):");
+    let chain = [
+        ("Alice (root)", &alice),
+        ("Orchestrator", &orch),
+        ("Sub-agent", &sub_effective),
+    ];
+    for window in chain.windows(2) {
+        let (parent_name, parent) = &window[0];
+        let (child_name, child) = &window[1];
+        println!(
+            "   {} <= {}: {}",
+            child_name,
+            parent_name,
+            child.leq(parent)
+        );
+    }
+
+    // Step 6: Demonstrate the key invariant
+    println!("\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+    println!("KEY INVARIANT: For any delegation chain p0 >= p1 >= ... >= pN,");
+    println!("every agent's effective permissions are bounded by its parent.");
+    println!("A compromised sub-agent CANNOT escalate beyond the orchestrator's");
+    println!("ceiling, which is itself bounded by the human trust anchor.");
+    println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+}

--- a/crates/portcullis/examples/trifecta_guard.rs
+++ b/crates/portcullis/examples/trifecta_guard.rs
@@ -1,0 +1,134 @@
+//! Trifecta guard example — demonstrates how the lethal trifecta
+//! (private data + untrusted content + exfiltration) is detected and mitigated.
+//!
+//! Run with: `cargo run --example trifecta_guard -p portcullis`
+//!
+//! The "lethal trifecta" is:
+//! 1. Access to private data (read_files, read credentials)
+//! 2. Exposure to untrusted content (web_fetch, web_search)
+//! 3. External communication (git_push, run_bash, create_pr)
+//!
+//! When all three are present, prompt injection attacks can exfiltrate
+//! private data. The trifecta guard adds approval obligations to
+//! exfiltration operations when the trifecta is complete.
+
+use portcullis::{
+    BoundedLattice, CapabilityLattice, CapabilityLevel, IncompatibilityConstraint, Operation,
+    PermissionLattice, TrifectaRisk,
+};
+
+fn main() {
+    println!("╔══════════════════════════════════════════════════════════════════╗");
+    println!("║         Trifecta Guard: Lethal Combination Detection            ║");
+    println!("╚══════════════════════════════════════════════════════════════════╝\n");
+
+    let constraint = IncompatibilityConstraint::enforcing();
+
+    // Scenario 1: Safe — read + search (no untrusted content, no exfil)
+    println!("Scenario 1: Read + Search (SAFE)");
+    let safe = CapabilityLattice {
+        read_files: CapabilityLevel::Always,
+        glob_search: CapabilityLevel::Always,
+        grep_search: CapabilityLevel::Always,
+        ..CapabilityLattice::bottom()
+    };
+    let risk = constraint.trifecta_risk(&safe);
+    println!("   Capabilities: read_files, glob_search, grep_search");
+    println!("   Risk: {:?}", risk);
+    println!(
+        "   Trifecta complete: {}\n",
+        constraint.is_trifecta_complete(&safe)
+    );
+
+    // Scenario 2: Partial — read + web (no exfil vector)
+    println!("Scenario 2: Read + Web (PARTIAL — missing exfil)");
+    let partial = CapabilityLattice {
+        read_files: CapabilityLevel::Always,
+        web_fetch: CapabilityLevel::LowRisk,
+        web_search: CapabilityLevel::LowRisk,
+        ..CapabilityLattice::bottom()
+    };
+    let risk = constraint.trifecta_risk(&partial);
+    println!("   Capabilities: read_files, web_fetch, web_search");
+    println!("   Risk: {:?}", risk);
+    println!(
+        "   Trifecta complete: {}\n",
+        constraint.is_trifecta_complete(&partial)
+    );
+
+    // Scenario 3: Complete trifecta — read + web + bash
+    println!("Scenario 3: Read + Web + Bash (COMPLETE TRIFECTA)");
+    let dangerous = CapabilityLattice {
+        read_files: CapabilityLevel::Always,
+        web_fetch: CapabilityLevel::LowRisk,
+        run_bash: CapabilityLevel::LowRisk,
+        ..CapabilityLattice::bottom()
+    };
+    let risk = constraint.trifecta_risk(&dangerous);
+    println!("   Capabilities: read_files, web_fetch, run_bash");
+    println!("   Risk: {:?}", risk);
+    println!(
+        "   Trifecta complete: {}",
+        constraint.is_trifecta_complete(&dangerous)
+    );
+
+    // Show obligations
+    let obligations = constraint.obligations_for(&dangerous);
+    println!("   Obligations added:");
+    for op in [
+        Operation::RunBash,
+        Operation::GitPush,
+        Operation::CreatePr,
+        Operation::WebFetch,
+    ] {
+        if obligations.requires(op) {
+            println!("   - {:?} now requires approval", op);
+        }
+    }
+
+    // Scenario 4: Automatic trifecta enforcement via PermissionLattice
+    println!("\nScenario 4: Automatic enforcement via meet()");
+    let perms = PermissionLattice {
+        capabilities: dangerous.clone(),
+        trifecta_constraint: true,
+        ..Default::default()
+    };
+    let enforced = perms.meet(&perms);
+    println!(
+        "   Before meet: git_push requires approval = {}",
+        perms.requires_approval(Operation::GitPush)
+    );
+    println!(
+        "   After meet:  git_push requires approval = {}",
+        enforced.requires_approval(Operation::GitPush)
+    );
+
+    // Scenario 5: Risk grades across profiles
+    println!("\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+    println!("Risk grades across built-in profiles:\n");
+    let profiles = [
+        ("read_only", PermissionLattice::read_only()),
+        ("code_review", PermissionLattice::code_review()),
+        ("codegen", PermissionLattice::codegen()),
+        ("fix_issue", PermissionLattice::fix_issue()),
+        ("permissive", PermissionLattice::permissive()),
+    ];
+
+    for (name, profile) in &profiles {
+        let risk = constraint.trifecta_risk(&profile.capabilities);
+        let vulnerable = constraint.is_trifecta_complete(&profile.capabilities);
+        let risk_str = match risk {
+            TrifectaRisk::None => "None    ",
+            TrifectaRisk::Low => "Low     ",
+            TrifectaRisk::Medium => "Medium  ",
+            TrifectaRisk::Complete => "Complete",
+        };
+        println!("   {:<14} risk={} trifecta={}", name, risk_str, vulnerable);
+    }
+
+    println!("\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+    println!("The trifecta guard ensures that when an agent has access to private");
+    println!("data AND untrusted content, any exfiltration path requires human");
+    println!("approval — even if each capability was individually authorized.");
+    println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+}


### PR DESCRIPTION
## Summary
- Add `delegation_chain.rs` example: walks through PajaMAS-style multi-agent privilege escalation and shows how monotone delegation prevents it at every step
- Add `trifecta_guard.rs` example: demonstrates lethal trifecta detection across capability profiles with risk grading
- Rename `claude_code_integration.rs` → `cli_integration.rs` and remove vendor-specific references (vendor-neutrality compliance per CLAUDE.md)

Fixes #112

## Test plan
- [x] `cargo run --example delegation_chain -p portcullis` runs and shows chain invariants
- [x] `cargo run --example trifecta_guard -p portcullis` runs and shows risk grades
- [x] `cargo run --example cli_integration -p portcullis` runs (renamed, vendor-neutral)
- [x] `cargo test -p portcullis` — all 22 tests pass
- [x] All examples compile as smoke tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)