### PR TITLE
feat(proto): add token usage and cost fields to ExecutionReceipt

### DIFF
--- a/crates/nucleus-node/proto/nucleus_node.proto
+++ b/crates/nucleus-node/proto/nucleus_node.proto
@@ -113,6 +113,16 @@ message ExecutionReceipt {
   string v1_content_hash = 10;
   // Forward-compatible extension data
   map<string, string> extensions = 11;
+
+  // === v1.1 Token usage and cost fields ===
+  // Input tokens consumed during execution
+  uint64 input_tokens = 12;
+  // Output tokens generated during execution
+  uint64 output_tokens = 13;
+  // Cache read tokens (hits from prompt caching)
+  uint64 cache_read_tokens = 14;
+  // Estimated cost in USD (IEEE 754 double)
+  double cost_usd = 15;
 }
 
 message GetReceiptRequest {

--- a/crates/nucleus-node/src/main.rs
+++ b/crates/nucleus-node/src/main.rs
@@ -2694,6 +2694,10 @@ impl NodeService for GrpcService {
                 version: 1,
                 v1_content_hash,
                 extensions: std::collections::HashMap::new(),
+                input_tokens: report.input_tokens,
+                output_tokens: report.output_tokens,
+                cache_read_tokens: report.cache_read_tokens,
+                cost_usd: report.cost_usd,
             }),
         }))
     }

--- a/crates/nucleus-spec/src/lib.rs
+++ b/crates/nucleus-spec/src/lib.rs
@@ -490,6 +490,18 @@ pub struct ExitReport {
     pub audit_entry_count: u64,
     /// Unix timestamp when the report was generated.
     pub timestamp_unix: u64,
+    /// Input tokens consumed during execution.
+    #[serde(default)]
+    pub input_tokens: u64,
+    /// Output tokens generated during execution.
+    #[serde(default)]
+    pub output_tokens: u64,
+    /// Cache read tokens (prompt caching hits).
+    #[serde(default)]
+    pub cache_read_tokens: u64,
+    /// Estimated cost in USD.
+    #[serde(default)]
+    pub cost_usd: f64,
 }
 
 /// Errors resolving policies.

--- a/crates/nucleus-tool-proxy/src/exit_report.rs
+++ b/crates/nucleus-tool-proxy/src/exit_report.rs
@@ -67,22 +67,42 @@ async fn collect_file_hashes(
     Ok(())
 }
 
+/// Token usage statistics collected during execution.
+#[derive(Debug, Clone, Default)]
+pub struct TokenUsage {
+    /// Input tokens consumed.
+    pub input_tokens: u64,
+    /// Output tokens generated.
+    pub output_tokens: u64,
+    /// Cache read tokens (prompt caching hits).
+    pub cache_read_tokens: u64,
+    /// Estimated cost in USD.
+    pub cost_usd: f64,
+}
+
 /// Build an exit report from the current state.
 pub fn build_exit_report(
     workspace_hash: String,
     audit_tail_hash: String,
     audit_entry_count: u64,
+    token_usage: Option<TokenUsage>,
 ) -> ExitReport {
     let timestamp_unix = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs();
 
+    let usage = token_usage.unwrap_or_default();
+
     ExitReport {
         workspace_hash,
         audit_tail_hash,
         audit_entry_count,
         timestamp_unix,
+        input_tokens: usage.input_tokens,
+        output_tokens: usage.output_tokens,
+        cache_read_tokens: usage.cache_read_tokens,
+        cost_usd: usage.cost_usd,
     }
 }
 
@@ -148,10 +168,32 @@ mod tests {
 
     #[test]
     fn test_build_exit_report() {
-        let report = build_exit_report("workspace_hash".to_string(), "audit_hash".to_string(), 10);
+        let report = build_exit_report(
+            "workspace_hash".to_string(),
+            "audit_hash".to_string(),
+            10,
+            None,
+        );
         assert_eq!(report.workspace_hash, "workspace_hash");
         assert_eq!(report.audit_tail_hash, "audit_hash");
         assert_eq!(report.audit_entry_count, 10);
         assert!(report.timestamp_unix > 0);
+        assert_eq!(report.input_tokens, 0);
+        assert_eq!(report.cost_usd, 0.0);
+    }
+
+    #[test]
+    fn test_build_exit_report_with_usage() {
+        let usage = TokenUsage {
+            input_tokens: 1500,
+            output_tokens: 500,
+            cache_read_tokens: 200,
+            cost_usd: 0.42,
+        };
+        let report = build_exit_report("hash".to_string(), "tail".to_string(), 5, Some(usage));
+        assert_eq!(report.input_tokens, 1500);
+        assert_eq!(report.output_tokens, 500);
+        assert_eq!(report.cache_read_tokens, 200);
+        assert!((report.cost_usd - 0.42).abs() < f64::EPSILON);
     }
 }

--- a/crates/nucleus-tool-proxy/src/main.rs
+++ b/crates/nucleus-tool-proxy/src/main.rs
@@ -1280,7 +1280,7 @@ async fn write_exit_report(audit: &AuditLog, work_dir_path: &Path) {
     };
 
     let (tail_hash, count) = audit.tail_hash_and_count();
-    let report = exit_report::build_exit_report(workspace_hash, tail_hash, count);
+    let report = exit_report::build_exit_report(workspace_hash, tail_hash, count, None);
 
     let report_path = work_dir_path.join(".nucleus-exit-report.json");
     match serde_json::to_string_pretty(&report) {


### PR DESCRIPTION
## Summary
- Add `input_tokens`, `output_tokens`, `cache_read_tokens`, and `cost_usd` fields to `ExecutionReceipt` proto (fields 12-15, backward-compatible)
- Add matching fields to `ExitReport` in nucleus-spec with `#[serde(default)]` for backward compatibility
- Add `TokenUsage` struct to tool-proxy's exit_report module for clean API
- Wire fields through from tool-proxy exit report to nucleus-node gRPC receipt

Fixes #122

## Test plan
- [x] `cargo build -p nucleus-node` compiles with new proto fields
- [x] `cargo test -p nucleus-tool-proxy` — exit_report tests pass (7 tests including new `test_build_exit_report_with_usage`)
- [x] Backward compatible: existing callers pass `None` for token usage, serde defaults handle missing fields in JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)