### PR TITLE
fix(audit): ensure audit.log receives events for all pod types

### DIFF
--- a/crates/nucleus-node/src/main.rs
+++ b/crates/nucleus-node/src/main.rs
@@ -878,6 +878,16 @@ async fn create_pod_internal(
         }
     };
 
+    // Write lifecycle audit event so even direct-task pods have an audit trail.
+    let audit_path = pod_dir.join("audit.log");
+    write_lifecycle_audit(
+        &audit_path,
+        "pod_started",
+        &id.to_string(),
+        &format!("driver={:?}", state.driver),
+    )
+    .await;
+
     let handle = Arc::new(PodHandle {
         id,
         spec,
@@ -2238,6 +2248,44 @@ fn now_unix() -> u64 {
         .as_secs()
 }
 
+/// Write a lifecycle audit event to a pod's audit.log from the node side.
+///
+/// This ensures every pod (including direct-task pods that don't run a tool-proxy)
+/// has at least start/stop audit entries in its audit.log file.
+async fn write_lifecycle_audit(audit_path: &Path, event: &str, pod_id: &str, detail: &str) {
+    let entry = serde_json::json!({
+        "timestamp_unix": now_unix(),
+        "actor": "nucleus-node",
+        "event": event,
+        "subject": format!("pod:{}", pod_id),
+        "result": detail,
+    });
+    let line = match serde_json::to_string(&entry) {
+        Ok(l) => l,
+        Err(e) => {
+            error!("failed to serialize lifecycle audit entry: {e}");
+            return;
+        }
+    };
+    match tokio::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(audit_path)
+        .await
+    {
+        Ok(mut file) => {
+            let _ = file.write_all(line.as_bytes()).await;
+            let _ = file.write_all(b"\n").await;
+        }
+        Err(e) => {
+            error!(
+                "failed to write lifecycle audit to {}: {e}",
+                audit_path.display()
+            );
+        }
+    }
+}
+
 fn build_firecracker_pool(args: &Args) -> Option<Arc<Semaphore>> {
     if !matches!(&args.driver, DriverKind::Firecracker) || args.firecracker_max_pods == 0 {
         return None;
@@ -2298,6 +2346,24 @@ fn start_pod_reaper(state: NodeState) {
             for pod in &pods {
                 let pod_state = pod.status().await;
                 if matches!(pod_state, PodState::Exited { .. } | PodState::Error { .. }) {
+                    // Write lifecycle audit for pod exit
+                    let detail = match &pod_state {
+                        PodState::Exited { code } => {
+                            format!("exit_code={}", code.unwrap_or(-1))
+                        }
+                        PodState::Error { message } => {
+                            format!("error={}", message)
+                        }
+                        _ => "unknown".to_string(),
+                    };
+                    let audit_path = pod
+                        .log_path
+                        .parent()
+                        .unwrap_or(Path::new("."))
+                        .join("audit.log");
+                    write_lifecycle_audit(&audit_path, "pod_exited", &pod.id.to_string(), &detail)
+                        .await;
+
                     exited_ids.push(pod.id);
                     pod.cleanup_after_exit().await;
                 }

--- a/crates/nucleus-tool-proxy/src/main.rs
+++ b/crates/nucleus-tool-proxy/src/main.rs
@@ -3409,6 +3409,20 @@ async fn build_audit_log(args: &Args, auth: &AuthConfig) -> Result<Arc<AuditLog>
     use nucleus_client::drand::{DrandClient, DrandConfig, DrandFailMode};
 
     let path = args.audit_log.clone();
+
+    // Ensure parent directory exists (e.g., /var/log/nucleus/ or the pod state dir).
+    // Without this, the first write silently fails when the parent is missing.
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            tokio::fs::create_dir_all(parent).await.map_err(|e| {
+                ApiError::Spec(format!(
+                    "failed to create audit log directory {}: {e}",
+                    parent.display()
+                ))
+            })?;
+        }
+    }
+
     let secret = if let Some(secret) = args.audit_secret.as_ref() {
         secret.as_bytes().to_vec()
     } else {
@@ -3601,14 +3615,16 @@ async fn audit_event_with_context(
 }
 
 async fn emit_boot_report(state: &AppState) -> Result<(), ApiError> {
-    let report = match std::env::var("NUCLEUS_TOOL_PROXY_BOOT_REPORT") {
-        Ok(value) if !value.trim().is_empty() => value,
-        _ => return Ok(()),
-    };
+    // Always emit boot report — this is the first entry in the audit chain.
+    // Optional env var adds a custom message; otherwise use a default.
+    let message = std::env::var("NUCLEUS_TOOL_PROXY_BOOT_REPORT")
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+        .unwrap_or_else(|| "tool-proxy started".to_string());
     let actor = std::env::var("NUCLEUS_TOOL_PROXY_BOOT_ACTOR").ok();
     let report = format!(
         "{} [sandbox_proof={}]",
-        report,
+        message,
         state.sandbox_proof.tier_label()
     );
 


### PR DESCRIPTION
## Summary

- **Boot report always fires**: Removed env var gate on `emit_boot_report()` — nucleus-node never set `NUCLEUS_TOOL_PROXY_BOOT_REPORT`, so the boot event was silently skipped. Now always emits with optional custom message.
- **Parent directory creation**: `build_audit_log()` now creates the audit log's parent directory before first write, preventing silent failures when the path doesn't exist yet.
- **Node-side lifecycle audit**: Added `write_lifecycle_audit()` in nucleus-node that writes `pod_started` and `pod_exited` JSONL entries to each pod's `audit.log`. This ensures even direct-task container pods (which don't run a tool-proxy) have an audit trail.

Fixes #121

## Test plan

- [ ] Verify `cargo clippy -p nucleus-node -p nucleus-tool-proxy` passes
- [ ] Verify `cargo test -p nucleus-tool-proxy` passes
- [ ] Run `nucleus-node --driver container` with a direct-task pod and confirm `audit.log` is non-empty
- [ ] Run a proxy-mode pod and confirm boot report appears as first audit entry
- [ ] Verify pod exit events appear in audit.log after pod completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)