### PR TITLE
docs: update README with accurate capabilities and proof counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **A formally verified permission lattice and security runtime for AI agents.**
 
-Nucleus is a security framework for AI agents that combines a mathematically verified permission algebra with a Firecracker-based enforcement runtime. The permission lattice has 297 SMT verification conditions checked by Z3. The GitHub Action works end-to-end today. This README tries to be honest about what's real and what isn't.
+Nucleus is a security framework for AI agents that combines a mathematically verified permission algebra with a Firecracker-based enforcement runtime. The permission lattice has 297 SMT verification conditions checked by Z3 plus 32 bounded model checking proofs via Kani. The GitHub Action works end-to-end today. This README tries to be honest about what's real and what isn't.
 
 > **Versioning note:** v1.0 means the **interface contract is stable** (see [`STABILITY.md`](STABILITY.md)), not that the system is "production-secure by default." The lattice is heavily verified; the runtime is tested but not yet battle-hardened in production traffic.
 
@@ -140,24 +140,29 @@ Three layers, at different levels of maturity:
 
 2. **Enforce** (working in CI, not production-hardened) — Runtime permission envelopes. The tool proxy intercepts every agent side effect and checks it against the permission lattice. Both HTTP and MCP paths share identical security controls (MIME gating, DNS/URL allowlists, redirect verification). The `--local` path works end-to-end in GitHub Actions. The Firecracker path works on Linux+KVM but has no production deployment.
 
-3. **Audit** (implemented, not production-tested) — Hash-chained, HMAC-signed logs of every agent action with optional S3 append-only remote sink. Local verification tool exists and works on generated test logs. S3 sink compiles into production binaries but has no integration test against real S3. No production audit logs exist yet.
+3. **Audit** (implemented, not production-tested) — Hash-chained, HMAC-signed logs of every agent action with optional S3 append-only remote sink and drand cryptographic time anchoring. Node-side lifecycle events ensure all pods (including direct-task containers) have audit entries. Execution receipts capture workspace hash, audit chain tail, and token usage. Local verification tool works on generated test logs. S3 sink compiles into production binaries but has no integration test against real S3.
 
 ## Current Status
 
 | Component | Maturity | Evidence |
 |-----------|----------|----------|
-| **Permission lattice** (portcullis) | Verified | 43K LOC, 875 tests, 297 Verus VCs, 3 fuzz targets |
-| **Trifecta detection** | Verified | Static scan + runtime guard, monotonicity proven (E1-E3) |
+| **Permission lattice** (portcullis) | Verified | 58K LOC, 942 tests, 297 Verus VCs, 32 Kani BMC proofs, 3 fuzz targets |
+| **Trifecta detection** | Verified | Static scan + runtime guard, monotonicity proven (E1-E3, Kani B1-B9) |
+| **Attenuation tokens** | Verified | Compact delegation credentials with Kani-proven invariants (D1-D7) |
+| **Delegation chains** | Tested | Monotone attenuation with `meet_with_justification`, audit-reconstructable chains |
+| **Unicode injection defense** | Tested | 8-category invisible character detection (bidi, tags, ZWJ); warn/strip/deny policy |
+| **Execution receipts** | Tested | Cryptographic pod execution proof with token usage and cost tracking |
+| **Permission market** | Tested | Lagrangian pricing oracle for multi-dimensional capability constraints |
 | **Web fetch security** | Tested | Unified MCP+HTTP path: MIME gating, DNS/URL allowlist, redirect verification, IPv6 |
-| **Audit log verification** | Tested | HMAC-SHA256 + SHA-256 chain; optional S3 append-only sink (no integration test) |
+| **Audit log verification** | Tested | HMAC-SHA256 + SHA-256 chain; optional S3 append-only sink; node-side lifecycle events |
 | **PodSpec scanner** | Tested | Trifecta, credentials, network, isolation, timeout checks |
 | **Claude Code scanner** | Tested | Trifecta via allow/deny projection, Bash capability propagation, exfil patterns, safety bypasses, credentials |
 | **MCP config scanner** | Tested | Well-known server classification (15 packages), `npx -y` supply chain detection, HTTP servers, credentials |
 | **Permission profiles** | Tested | 14 named profiles backed by lattice constructors |
-| **Tool proxy** (MCP enforcement) | Tested | 9,500 LOC, 119 tests; enforces agent sessions in GitHub Actions |
+| **Tool proxy** (MCP enforcement) | Tested | 149 tests; enforces agent sessions in GitHub Actions |
 | **Firecracker isolation** | Tested | Real jailer invocation + iptables; Linux+KVM only |
 | **Network enforcement** | Tested | Default-deny egress, DNS allowlisting, drift detection |
-| **CI hardening** | Tested | 14 required status checks; mutation testing blocks surviving mutants |
+| **CI hardening** | Tested | 16 required status checks; mutation testing blocks surviving mutants |
 | **Budget tracking** | Partial | AtomicBudget exists; pre-exec reservation works, post-exec accounting incomplete |
 | **SPIFFE identity** | Implemented | mTLS + cert management code exists; no SPIRE deployment |
 | **Command exfiltration detection** | Partial | Program-name matching; `bash -c` bypasses documented |
@@ -167,7 +172,7 @@ Three layers, at different levels of maturity:
 
 ## Permission Lattice
 
-Permissions compose predictably via a mathematical lattice. This is the most mature part of Nucleus — 43K lines of Rust with 297 machine-checked verification conditions.
+Permissions compose predictably via a mathematical lattice. This is the most mature part of Nucleus — 58K lines of Rust with 297 SMT verification conditions (Verus/Z3) and 32 bounded model checking proofs (Kani/CaDiCaL).
 
 | Structure | What It Gives You | Status |
 |-----------|-------------------|--------|
@@ -175,16 +180,22 @@ Permissions compose predictably via a mathematical lattice. This is the most mat
 | **Heyting Algebra** | Conditional permissions with formal semantics | Verified (Verus) |
 | **Galois Connections** | Policy translation across trust domains | Verified (Verus) |
 | **Graded Monad** | Risk accumulation through computation chains | Verified (Verus) |
+| **Attenuation Tokens** | Compact delegation credentials for wire transport | Verified (Kani D1-D7) |
+| **Taint Invariants** | Taint-set monotonicity, trifecta iff count==3 | Verified (Kani B1-B9) |
 | **Modal Operators** | Distinguish "guaranteed safe" (□) from "might be safe" (◇) | Tested |
-| **Delegation Chains** | SPIFFE-backed delegation with ceiling theorem | Tested |
+| **Delegation Chains** | Monotone attenuation with justification trails | Tested |
 
 For the theory: [docs/THEORY.md](docs/THEORY.md).
 
 ## Formal Verification
 
-Nucleus uses [Verus](https://verus-lang.github.io/verus/) (SMT-based verification for Rust, SOSP 2025 Best Paper) to prove properties about the permission lattice.
+Nucleus uses two complementary verification tools:
+- [Verus](https://verus-lang.github.io/verus/) (SMT-based, SOSP 2025 Best Paper) — 297 verification conditions checked by Z3
+- [Kani](https://model-checking.github.io/kani/) (bounded model checking) — 32 proofs checked by CaDiCaL SAT solver
 
-**What's proven (297 verification conditions, machine-checked by Z3):**
+**What's proven (297 Verus VCs + 32 Kani proofs):**
+
+*Verus (SMT):*
 - Lattice laws: idempotent, commutative, associative, absorptive for all 12 capability dimensions
 - Nucleus operator: idempotent, deflationary, monotone, meet-preserving
 - Heyting adjunction: a ∧ b ≤ c ⟺ a ≤ b → c
@@ -193,6 +204,12 @@ Nucleus uses [Verus](https://verus-lang.github.io/verus/) (SMT-based verificatio
 - Taint guard: monotonicity (E1), trace monotonicity (E2), denial monotonicity (E3)
 - Trifecta: completeness detection, risk classification, session safety
 - Delegation: transitivity, ceiling theorem, chain composition
+
+*Kani (BMC):*
+- B-series (9 proofs): Taint set monoid identity/associativity, monotonicity, trifecta-iff-count-equals-3, isolation lattice meet/join properties
+- D-series (7 proofs): Attenuation token invariants — token ≤ parent, token ≤ requested cap, chained attenuation, delegation ceiling preservation
+- E-series (3 proofs): Guard denial soundness, Clinejection defense, apply_record monotonicity
+- Structural (13 proofs): Lattice distributivity, frame law, budget monotonicity, capability level ordering
 
 **What's tested but not formally verified:**
 - Modal operators (necessity/possibility, S4 axioms) — 16 property tests
@@ -208,7 +225,7 @@ Nucleus uses [Verus](https://verus-lang.github.io/verus/) (SMT-based verificatio
 
 See the full roadmap: [docs/north-star.md](docs/north-star.md).
 
-The Verus VC count is ratcheted in CI — it can only go up, never down (`.verus-minimum-proofs`). Merging to `main` requires 14 status checks to pass, including security audit, cargo deny, clippy, fmt, and per-crate test suites. Mutation testing (cargo-mutants) blocks merges when surviving mutants are detected.
+Both proof counts are ratcheted in CI — they can only go up, never down (`.verus-minimum-proofs`, `.kani-minimum-proofs`). Merging to `main` requires 16 status checks to pass, including security audit, cargo deny, clippy, fmt, fuzz, mutation testing, and per-crate test suites.
 
 ## v1.0 Contract Surface
 
@@ -218,7 +235,8 @@ The v1.0 interfaces are designed for 15 years of growth. See [`STABILITY.md`](ST
 - 12 core `Operation` variants + taint classifications
 - 3 core `TaintLabel` variants + trifecta predicate
 - `CapabilityLevel` enum (`Never`, `LowRisk`, `Always`)
-- gRPC `NodeService` RPCs, HMAC signing protocol, audit hash chain
+- gRPC `NodeService` RPCs (8 RPCs including streaming), HMAC signing protocol, audit hash chain
+- `ExecutionReceipt` fields 1-8 (v1.0 frozen), with `v1_content_hash` for forward compatibility
 
 **Open for extension** (no version bump needed):
 - New operations via `ExtensionOperation` on `CapabilityLattice` (fail-closed: unknown ops default to `Never`)
@@ -246,7 +264,7 @@ Proofs survive extensions by construction: products of lattices are lattices (un
 ├─────────────────────────────────────────────────────────────────┤
 │                      portcullis                                 │
 │   Capabilities × Obligations × Paths × Commands × Budget × Time │
-│   + Heyting Algebra + Galois Connections + Graded Monad + Modal │
+│   + Heyting Algebra + Galois + Graded Monad + Attenuation Tokens│
 ├─────────────────────────────────────────────────────────────────┤
 │                    nucleus-identity                             │
 │           SPIFFE workload identity + mTLS + cert rotation       │
@@ -262,23 +280,25 @@ The enforcement path: Agent → MCP → tool-proxy (inside VM) → portcullis ch
 
 | Crate | Purpose | Tests |
 |-------|---------|-------|
-| **portcullis** | Permission lattice: 9 algebraic modules | 875 |
+| **portcullis** | Permission lattice: 12 algebraic modules + attenuation tokens | 942 |
 | **portcullis-verified** | Verus SMT proofs for portcullis | 297 VCs |
-| **nucleus-audit** | `scan` PodSpecs, Claude Code settings, MCP configs; `verify` audit logs | 37 |
-| **nucleus** | Enforcement: sandbox, executor, budget | 89 |
-| **nucleus-node** | Node daemon managing Firecracker microVMs | 26 |
-| **nucleus-tool-proxy** | MCP tool proxy running inside pods | 119 |
+| **nucleus-audit** | `scan` PodSpecs, Claude Code settings, MCP configs; `verify` audit logs | 45 |
+| **nucleus** | Enforcement: sandbox, executor, budget | 39 |
+| **nucleus-node** | Node daemon managing Firecracker microVMs + containers | 39 |
+| **nucleus-tool-proxy** | MCP tool proxy running inside pods (+ unicode audit, exit reports) | 149 |
 | **nucleus-mcp** | MCP server bridging to tool-proxy | 4 |
-| **nucleus-identity** | SPIFFE workload identity, mTLS, certs | 44 |
-| **nucleus-spec** | PodSpec definitions (policy, network, creds) | 21 |
+| **nucleus-identity** | SPIFFE workload identity, mTLS, certs | 296 |
+| **nucleus-spec** | PodSpec definitions (policy, network, creds, execution receipts) | 21 |
+| **nucleus-proto** | Generated gRPC/Protobuf types for nucleus-node | — |
+| **nucleus-permission-market** | Lagrangian pricing oracle for capability constraints | 28 |
 | **nucleus-cli** | CLI for running tasks with enforced permissions | 12 |
 | **nucleus-sdk** | Rust SDK for building sandboxed AI agents | 3 |
-| **nucleus-client** | Client signing utilities | 8 |
+| **nucleus-client** | Client signing utilities + drand anchoring | 8 |
 | **nucleus-guest-init** | Guest init for Firecracker rootfs | 2 |
 | **nucleus-net-probe** | TCP probe for network policy tests | 2 |
 | **trifecta-playground** | Interactive TUI for exploring the lattice | — |
 
-Total: ~1,590 test functions across the workspace. Proptest invariants each generate 256 random cases.
+Total: ~1,700 test functions across the workspace (103K LOC Rust). Proptest invariants each generate 256 random cases. 32 Kani BMC proofs run in CI alongside 297 Verus VCs.
 
 ## Permission Profiles
 
@@ -405,7 +425,7 @@ The GitHub Action uses Tier 1 (`--local`). Network enforcement relies on the per
 Documented in detail in [`SECURITY_TODO.md`](SECURITY_TODO.md). Key items:
 
 - **Command exfiltration detection is program-name only.** `bash -c 'curl ...'` can bypass trifecta detection at the command lattice level. The Firecracker network policy is the real defense (default-deny egress), but the command-level check has known bypasses.
-- **Path sandboxing is string-based.** Unicode normalization and symlink race conditions are not exhaustively tested. `cap-std` capability handles provide defense-in-depth.
+- **Path sandboxing is string-based.** Unicode normalization and symlink race conditions are not exhaustively tested. `cap-std` capability handles provide defense-in-depth. Invisible Unicode character injection (Rules File Backdoor) is detected at the tool-proxy gateway layer with configurable policy (warn/strip/deny).
 - **Budget enforcement is partial.** Pre-execution reservation works when timeouts are set. Post-execution cost accounting (output tokens, refunds) is not implemented.
 - **Formal verification covers the lattice algebra, not the full runtime.** The 297 Verus VCs verify portcullis properties. The tool proxy, network enforcement, and Firecracker integration are tested, not verified.
 - **S3 audit sink is fire-and-forget.** Upload failures are logged but don't block the agent. No integration test against real S3 exists. Append-only semantics use `if_none_match("*")` PutObject preconditions — untested against eventual consistency.
@@ -416,12 +436,13 @@ Documented in detail in [`SECURITY_TODO.md`](SECURITY_TODO.md). Key items:
 
 **Protects against:**
 - Prompt injection attempting side effects outside the permission envelope
+- Invisible Unicode injection / Rules File Backdoor attacks (detected at gateway)
 - Misconfigured tool permissions (enforced at runtime, not advisory)
 - Network policy drift inside the runtime (fail-closed)
 - Budget exhaustion attacks (atomic tracking, with caveats above)
-- Privilege escalation via delegation (ceiling theorem)
+- Privilege escalation via delegation (ceiling theorem + attenuation tokens)
 - Trust domain confusion (Galois connections)
-- Audit log tampering (hash chain verification)
+- Audit log tampering (hash chain verification + execution receipts)
 
 **Does not protect against:**
 - Compromised host or kernel (enforcement stack is trusted)


### PR DESCRIPTION
## Summary

- Updated portcullis stats: 58K LOC, 942 tests (was 43K/875)
- Added 32 Kani BMC proofs to verification story (alongside 297 Verus VCs)
- New capabilities documented: attenuation tokens, unicode injection defense, execution receipts, permission market, delegation chains, node-side lifecycle audit
- Updated crate table with new crates (nucleus-proto, nucleus-permission-market)
- Accurate totals: ~1,700 tests, 103K LOC, 16 CI checks, dual proof ratchets

## Test plan

- [ ] Verify markdown renders correctly on GitHub
- [ ] Verify all numbers match `cargo test --workspace` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)