### PR TITLE
feat(sdk): Python SDK taint tracking with trifecta gate

### DIFF
--- a/sdk/python/nucleus_sdk/__init__.py
+++ b/sdk/python/nucleus_sdk/__init__.py
@@ -3,12 +3,14 @@ from .models import PodInfo, PodSpec
 from .intent import Intent, IntentSession, IntentProfile
 from .auth import MtlsConfig, HmacAuth
 from .session import Session
+from .taint import TaintGuard, TaintLabel, TaintSet
 from .trace import Trace, TraceEntry
 from .errors import (
     NucleusError,
     ApprovalRequired,
     AccessDenied,
     PolicyDenied,
+    TrifectaBlocked,
     BudgetExceeded,
     AuthError,
     RequestError,
@@ -27,12 +29,16 @@ __all__ = [
     "MtlsConfig",
     "HmacAuth",
     "Session",
+    "TaintGuard",
+    "TaintLabel",
+    "TaintSet",
     "Trace",
     "TraceEntry",
     "NucleusError",
     "ApprovalRequired",
     "AccessDenied",
     "PolicyDenied",
+    "TrifectaBlocked",
     "BudgetExceeded",
     "AuthError",
     "RequestError",

--- a/sdk/python/nucleus_sdk/errors.py
+++ b/sdk/python/nucleus_sdk/errors.py
@@ -37,6 +37,17 @@ class PolicyDenied(AccessDenied):
     pass
 
 
+class TrifectaBlocked(AccessDenied):
+    """Raised when an operation would complete the taint trifecta.
+
+    The taint trifecta fires when a session has accumulated all three
+    taint labels (private_data + untrusted_content + exfil_vector) and
+    an exfiltration-capable operation is attempted without approval.
+    """
+
+    pass
+
+
 class BudgetExceeded(NucleusError):
     """Raised when a session or pod exceeds its budget limit."""
 
@@ -61,11 +72,13 @@ def from_error_payload(payload: dict, status: int) -> NucleusError:
     if kind == "budget_exceeded":
         return BudgetExceeded(message, kind=kind, status=status, operation=operation)
 
+    if kind == "trifecta_blocked":
+        return TrifectaBlocked(message, kind=kind, status=status, operation=operation)
+
     if kind in {
         "path_denied",
         "command_denied",
         "sandbox_escape",
-        "trifecta_blocked",
         "insufficient_capability",
         "dns_not_allowed",
     }:

--- a/sdk/python/nucleus_sdk/session.py
+++ b/sdk/python/nucleus_sdk/session.py
@@ -6,6 +6,7 @@ from typing import Any, Callable, Dict, Optional, TypeVar
 
 from .client import ProxyClient
 from .errors import AccessDenied, ApprovalRequired
+from .taint import TaintGuard
 from .trace import Trace
 from .tools.fs import FileHandle
 from .tools.net import NetHandle
@@ -15,14 +16,19 @@ T = TypeVar("T")
 
 
 class Session:
-    """High-level session that wraps a ProxyClient with typed tool handles
-    and automatic trace recording.
+    """High-level session that wraps a ProxyClient with typed tool handles,
+    automatic trace recording, and taint tracking.
+
+    The session tracks taint across tool calls using a monotone 3-bool
+    semilattice. When all three taint labels co-occur (the "trifecta"),
+    exfiltration-capable operations raise ``TrifectaBlocked`` unless
+    explicitly approved.
 
     Usage::
 
         with Session(profile="codegen") as s:
-            readme = s.fs.read("README.md")
-            s.fs.write("out.txt", readme.upper())
+            readme = s.fs.read("README.md")          # adds private_data taint
+            s.fs.write("out.txt", readme.upper())     # neutral
             result = s.approve("fetch", lambda: s.net.fetch("https://example.com"))
 
     On exit the session exports its trace.  The trace is available
@@ -35,12 +41,14 @@ class Session:
         proxy_url: Optional[str] = None,
         proxy: Optional[ProxyClient] = None,
         timeout: float = 30.0,
+        trifecta_enabled: bool = True,
     ) -> None:
         self.profile = profile
         self._proxy_url = proxy_url or os.environ.get("NUCLEUS_PROXY_URL", "")
         self._timeout = timeout
         self._trace = Trace()
         self._external_proxy = proxy
+        self._taint_guard = TaintGuard(trifecta_enabled=trifecta_enabled)
 
         # These are initialised lazily in __enter__
         self._proxy: Optional[ProxyClient] = None
@@ -60,9 +68,9 @@ class Session:
                 )
             self._proxy = ProxyClient(self._proxy_url, timeout=self._timeout)
 
-        self._fs = FileHandle(self._proxy, self._trace)
-        self._net = NetHandle(self._proxy, self._trace)
-        self._git = GitHandle(self._proxy, self._trace)
+        self._fs = FileHandle(self._proxy, self._trace, self._taint_guard)
+        self._net = NetHandle(self._proxy, self._trace, self._taint_guard)
+        self._git = GitHandle(self._proxy, self._trace, self._taint_guard)
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:  # type: ignore[no-untyped-def]
@@ -101,6 +109,11 @@ class Session:
     @property
     def trace(self) -> Trace:
         return self._trace
+
+    @property
+    def taint_summary(self) -> str:
+        """Human-readable summary of the current session taint state."""
+        return self._taint_guard.summary()
 
     # -- approval helper ---------------------------------------------------
 

--- a/sdk/python/nucleus_sdk/taint.py
+++ b/sdk/python/nucleus_sdk/taint.py
@@ -1,0 +1,215 @@
+"""Session-scoped taint tracking with trifecta gate.
+
+Mirrors the Verus-verified taint_core decision kernel from portcullis.
+The three taint labels form a 3-bool semilattice — taint can only increase
+(monotone union), never decrease within a session.
+
+When all three labels co-occur (the "trifecta"), exfiltration-capable
+operations require explicit approval before proceeding.
+"""
+
+from __future__ import annotations
+
+from enum import Enum, auto
+from typing import FrozenSet, Optional
+
+
+class TaintLabel(Enum):
+    """The three legs of the taint trifecta."""
+
+    PRIVATE_DATA = auto()
+    """Private data was accessed (read, glob, grep)."""
+
+    UNTRUSTED_CONTENT = auto()
+    """Untrusted external content was ingested (web_fetch, web_search)."""
+
+    EXFIL_VECTOR = auto()
+    """An exfiltration-capable operation was performed (run, git_push, create_pr)."""
+
+
+# Map SDK operation names to their taint contribution.
+# None means the operation is taint-neutral (no contribution).
+_OPERATION_TAINT: dict[str, Optional[TaintLabel]] = {
+    "fs.read": TaintLabel.PRIVATE_DATA,
+    "fs.write": None,
+    "fs.glob": TaintLabel.PRIVATE_DATA,
+    "fs.grep": TaintLabel.PRIVATE_DATA,
+    "net.fetch": TaintLabel.UNTRUSTED_CONTENT,
+    "net.search": TaintLabel.UNTRUSTED_CONTENT,
+    "git.push": TaintLabel.EXFIL_VECTOR,
+    "git.create_pr": TaintLabel.EXFIL_VECTOR,
+    "git.commit": None,
+    "git.add": None,
+    "run": TaintLabel.EXFIL_VECTOR,
+}
+
+# Operations where RunBash-style omnibus projection applies.
+# These conservatively project PRIVATE_DATA + EXFIL_VECTOR because
+# a shell command can both read files and exfiltrate data.
+_OMNIBUS_OPERATIONS = frozenset({"run"})
+
+# Operations that require approval when trifecta would complete.
+_EXFIL_OPERATIONS = frozenset({"run", "git.push", "git.create_pr"})
+
+
+class TaintSet:
+    """Monotone 3-bool taint accumulator.
+
+    Mirrors portcullis::guard::TaintSet. The set can only grow via union —
+    there is no way to remove a label once added.
+    """
+
+    __slots__ = ("_labels",)
+
+    def __init__(self, labels: Optional[FrozenSet[TaintLabel]] = None) -> None:
+        self._labels: FrozenSet[TaintLabel] = labels or frozenset()
+
+    @classmethod
+    def empty(cls) -> TaintSet:
+        return cls()
+
+    def union(self, other: TaintSet) -> TaintSet:
+        return TaintSet(self._labels | other._labels)
+
+    def with_label(self, label: TaintLabel) -> TaintSet:
+        return TaintSet(self._labels | {label})
+
+    def contains(self, label: TaintLabel) -> bool:
+        return label in self._labels
+
+    def is_trifecta_complete(self) -> bool:
+        return (
+            TaintLabel.PRIVATE_DATA in self._labels
+            and TaintLabel.UNTRUSTED_CONTENT in self._labels
+            and TaintLabel.EXFIL_VECTOR in self._labels
+        )
+
+    @property
+    def labels(self) -> FrozenSet[TaintLabel]:
+        return self._labels
+
+    def summary(self) -> str:
+        if not self._labels:
+            return "clean"
+        parts = []
+        if TaintLabel.PRIVATE_DATA in self._labels:
+            parts.append("private_data")
+        if TaintLabel.UNTRUSTED_CONTENT in self._labels:
+            parts.append("untrusted_content")
+        if TaintLabel.EXFIL_VECTOR in self._labels:
+            parts.append("exfil_vector")
+        return "+".join(parts)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, TaintSet):
+            return NotImplemented
+        return self._labels == other._labels
+
+    def __repr__(self) -> str:
+        return f"TaintSet({self.summary()})"
+
+
+def classify_operation(operation: str) -> Optional[TaintLabel]:
+    """Map an operation name to its taint label.
+
+    Mirrors portcullis::taint_core::classify_operation.
+    """
+    return _OPERATION_TAINT.get(operation)
+
+
+def project_taint(current: TaintSet, operation: str) -> TaintSet:
+    """Project what the taint set WOULD be if this operation executes.
+
+    Mirrors portcullis::taint_core::project_taint. RunBash-style operations
+    are treated as omnibus (conservatively project both PRIVATE_DATA and
+    EXFIL_VECTOR).
+    """
+    if operation in _OMNIBUS_OPERATIONS:
+        return (
+            current.with_label(TaintLabel.PRIVATE_DATA).with_label(
+                TaintLabel.EXFIL_VECTOR
+            )
+        )
+    label = classify_operation(operation)
+    if label is not None:
+        return current.with_label(label)
+    return current
+
+
+def should_deny(
+    current: TaintSet,
+    operation: str,
+    trifecta_enabled: bool = True,
+) -> bool:
+    """Pure denial decision: should this operation be blocked?
+
+    Mirrors portcullis::taint_core::should_deny.
+    Returns True if the operation would complete the trifecta and
+    the operation is exfiltration-capable.
+    """
+    if not trifecta_enabled:
+        return False
+    requires_approval = operation in _EXFIL_OPERATIONS
+    if not requires_approval:
+        return False
+    projected = project_taint(current, operation)
+    return projected.is_trifecta_complete()
+
+
+def apply_record(current: TaintSet, operation: str) -> TaintSet:
+    """Record a successful operation's taint contribution.
+
+    Mirrors portcullis::taint_core::apply_record. Unlike project_taint,
+    this does NOT use omnibus projection — it records what actually happened.
+    """
+    label = classify_operation(operation)
+    if label is not None:
+        return current.with_label(label)
+    return current
+
+
+class TaintGuard:
+    """Session-scoped taint guard that tool handles call before/after operations.
+
+    This is the Python equivalent of SessionTaint in nucleus-mcp's Rust code.
+    Tool handles call ``check()`` before executing and ``record()`` after
+    a successful execution.
+    """
+
+    def __init__(self, trifecta_enabled: bool = True) -> None:
+        self._taint = TaintSet.empty()
+        self._trifecta_enabled = trifecta_enabled
+
+    @property
+    def taint(self) -> TaintSet:
+        return self._taint
+
+    def check(self, operation: str) -> None:
+        """Raise TrifectaBlocked if the operation would complete the trifecta.
+
+        Must be called BEFORE the operation executes. This is the pre-call
+        gate that blocks exfiltration when private data and untrusted content
+        have both been accessed.
+        """
+        if should_deny(self._taint, operation, self._trifecta_enabled):
+            from .errors import TrifectaBlocked
+
+            raise TrifectaBlocked(
+                f"trifecta blocked: {operation} would complete taint trifecta "
+                f"({self._taint.summary()}). The session has accessed private data "
+                f"and untrusted content -- this exfiltration-capable operation "
+                f"requires explicit approval.",
+                kind="trifecta_blocked",
+                operation=operation,
+            )
+
+    def record(self, operation: str) -> None:
+        """Record a successful operation's taint contribution.
+
+        Must be called AFTER the operation succeeds. Taint accumulation
+        is monotone — it can only increase.
+        """
+        self._taint = apply_record(self._taint, operation)
+
+    def summary(self) -> str:
+        return self._taint.summary()

--- a/sdk/python/nucleus_sdk/tools/fs.py
+++ b/sdk/python/nucleus_sdk/tools/fs.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ..client import ProxyClient
+    from ..taint import TaintGuard
     from ..trace import Trace
 
 
@@ -12,15 +13,24 @@ class FileHandle:
     """Typed accessor for filesystem operations.
 
     All calls delegate to a ProxyClient and record each operation
-    in the session trace.
+    in the session trace. An optional TaintGuard enforces the
+    trifecta gate before each operation.
     """
 
-    def __init__(self, proxy: ProxyClient, trace: Trace) -> None:
+    def __init__(
+        self,
+        proxy: ProxyClient,
+        trace: Trace,
+        taint_guard: Optional[TaintGuard] = None,
+    ) -> None:
         self._proxy = proxy
         self._trace = trace
+        self._guard = taint_guard
 
     def read(self, path: str) -> str:
         """Read a file and return its contents."""
+        if self._guard:
+            self._guard.check("fs.read")
         start = time.monotonic()
         result = self._proxy.read(path)
         elapsed = (time.monotonic() - start) * 1000
@@ -30,10 +40,14 @@ class FileHandle:
             result_summary=f"{len(result)} bytes",
             duration_ms=round(elapsed, 2),
         )
+        if self._guard:
+            self._guard.record("fs.read")
         return result
 
     def write(self, path: str, contents: str) -> None:
         """Write contents to a file."""
+        if self._guard:
+            self._guard.check("fs.write")
         start = time.monotonic()
         self._proxy.write(path, contents)
         elapsed = (time.monotonic() - start) * 1000
@@ -43,6 +57,8 @@ class FileHandle:
             result_summary=f"{len(contents)} bytes written",
             duration_ms=round(elapsed, 2),
         )
+        if self._guard:
+            self._guard.record("fs.write")
 
     def glob(
         self,
@@ -51,6 +67,8 @@ class FileHandle:
         max_results: Optional[int] = None,
     ) -> Dict[str, Any]:
         """Search for files matching a glob pattern."""
+        if self._guard:
+            self._guard.check("fs.glob")
         start = time.monotonic()
         result = self._proxy.glob(
             pattern=pattern, directory=directory, max_results=max_results
@@ -63,6 +81,8 @@ class FileHandle:
             result_summary=f"{len(matches)} matches",
             duration_ms=round(elapsed, 2),
         )
+        if self._guard:
+            self._guard.record("fs.glob")
         return result
 
     def grep(
@@ -75,6 +95,8 @@ class FileHandle:
         case_insensitive: Optional[bool] = None,
     ) -> Dict[str, Any]:
         """Search file contents with a regex pattern."""
+        if self._guard:
+            self._guard.check("fs.grep")
         start = time.monotonic()
         result = self._proxy.grep(
             pattern=pattern,
@@ -92,4 +114,6 @@ class FileHandle:
             result_summary=f"{len(matches)} matches",
             duration_ms=round(elapsed, 2),
         )
+        if self._guard:
+            self._guard.record("fs.grep")
         return result

--- a/sdk/python/nucleus_sdk/tools/git.py
+++ b/sdk/python/nucleus_sdk/tools/git.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ..client import ProxyClient
+    from ..taint import TaintGuard
     from ..trace import Trace
 
 
@@ -12,12 +13,19 @@ class GitHandle:
     """Typed accessor for git operations.
 
     Git commands are executed via ProxyClient.run() with appropriate
-    arguments.  All calls are recorded in the session trace.
+    arguments.  All calls are recorded in the session trace. An optional
+    TaintGuard enforces the trifecta gate before each operation.
     """
 
-    def __init__(self, proxy: ProxyClient, trace: Trace) -> None:
+    def __init__(
+        self,
+        proxy: ProxyClient,
+        trace: Trace,
+        taint_guard: Optional[TaintGuard] = None,
+    ) -> None:
         self._proxy = proxy
         self._trace = trace
+        self._guard = taint_guard
 
     def _run_git(
         self,
@@ -26,17 +34,22 @@ class GitHandle:
         directory: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Run a git subcommand and record it in the trace."""
+        op = f"git.{operation_name}"
+        if self._guard:
+            self._guard.check(op)
         full_args = ["git"] + args
         start = time.monotonic()
         result = self._proxy.run(args=full_args, directory=directory)
         elapsed = (time.monotonic() - start) * 1000
         exit_code = result.get("exit_code", -1)
         self._trace.record(
-            operation=f"git.{operation_name}",
+            operation=op,
             args={"git_args": args},
             result_summary=f"exit_code={exit_code}",
             duration_ms=round(elapsed, 2),
         )
+        if self._guard:
+            self._guard.record(op)
         return result
 
     def commit(

--- a/sdk/python/nucleus_sdk/tools/net.py
+++ b/sdk/python/nucleus_sdk/tools/net.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ..client import ProxyClient
+    from ..taint import TaintGuard
     from ..trace import Trace
 
 
@@ -12,12 +13,19 @@ class NetHandle:
     """Typed accessor for network operations.
 
     All calls delegate to a ProxyClient and record each operation
-    in the session trace.
+    in the session trace. An optional TaintGuard enforces the
+    trifecta gate before each operation.
     """
 
-    def __init__(self, proxy: ProxyClient, trace: Trace) -> None:
+    def __init__(
+        self,
+        proxy: ProxyClient,
+        trace: Trace,
+        taint_guard: Optional[TaintGuard] = None,
+    ) -> None:
         self._proxy = proxy
         self._trace = trace
+        self._guard = taint_guard
 
     def fetch(
         self,
@@ -27,6 +35,8 @@ class NetHandle:
         body: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Fetch a URL through the proxy."""
+        if self._guard:
+            self._guard.check("net.fetch")
         start = time.monotonic()
         result = self._proxy.web_fetch(
             url=url, method=method, headers=headers, body=body
@@ -39,6 +49,8 @@ class NetHandle:
             result_summary=f"status={status}",
             duration_ms=round(elapsed, 2),
         )
+        if self._guard:
+            self._guard.record("net.fetch")
         return result
 
     def search(
@@ -47,6 +59,8 @@ class NetHandle:
         max_results: Optional[int] = None,
     ) -> Dict[str, Any]:
         """Perform a web search through the proxy."""
+        if self._guard:
+            self._guard.check("net.search")
         start = time.monotonic()
         result = self._proxy.web_search(query=query, max_results=max_results)
         elapsed = (time.monotonic() - start) * 1000
@@ -57,4 +71,6 @@ class NetHandle:
             result_summary=f"{results_count} results",
             duration_ms=round(elapsed, 2),
         )
+        if self._guard:
+            self._guard.record("net.search")
         return result

--- a/sdk/python/tests/test_taint.py
+++ b/sdk/python/tests/test_taint.py
@@ -1,0 +1,368 @@
+"""Tests for the taint tracking module and trifecta gate integration."""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock
+
+from nucleus_sdk import (
+    Session,
+    TaintGuard,
+    TaintLabel,
+    TaintSet,
+    TrifectaBlocked,
+    AccessDenied,
+    NucleusError,
+)
+from nucleus_sdk.client import ProxyClient
+from nucleus_sdk.errors import from_error_payload
+from nucleus_sdk.taint import (
+    classify_operation,
+    project_taint,
+    should_deny,
+    apply_record,
+)
+from nucleus_sdk.tools.fs import FileHandle
+from nucleus_sdk.tools.net import NetHandle
+from nucleus_sdk.tools.git import GitHandle
+from nucleus_sdk.trace import Trace
+
+
+# --- TaintSet unit tests ---
+
+
+class TestTaintSet(unittest.TestCase):
+    def test_empty(self):
+        t = TaintSet.empty()
+        self.assertEqual(t.summary(), "clean")
+        self.assertFalse(t.is_trifecta_complete())
+
+    def test_with_label(self):
+        t = TaintSet.empty().with_label(TaintLabel.PRIVATE_DATA)
+        self.assertTrue(t.contains(TaintLabel.PRIVATE_DATA))
+        self.assertFalse(t.contains(TaintLabel.UNTRUSTED_CONTENT))
+        self.assertEqual(t.summary(), "private_data")
+
+    def test_union(self):
+        a = TaintSet.empty().with_label(TaintLabel.PRIVATE_DATA)
+        b = TaintSet.empty().with_label(TaintLabel.UNTRUSTED_CONTENT)
+        c = a.union(b)
+        self.assertTrue(c.contains(TaintLabel.PRIVATE_DATA))
+        self.assertTrue(c.contains(TaintLabel.UNTRUSTED_CONTENT))
+
+    def test_trifecta_complete(self):
+        t = (
+            TaintSet.empty()
+            .with_label(TaintLabel.PRIVATE_DATA)
+            .with_label(TaintLabel.UNTRUSTED_CONTENT)
+            .with_label(TaintLabel.EXFIL_VECTOR)
+        )
+        self.assertTrue(t.is_trifecta_complete())
+
+    def test_trifecta_incomplete(self):
+        t = (
+            TaintSet.empty()
+            .with_label(TaintLabel.PRIVATE_DATA)
+            .with_label(TaintLabel.UNTRUSTED_CONTENT)
+        )
+        self.assertFalse(t.is_trifecta_complete())
+
+    def test_equality(self):
+        a = TaintSet.empty().with_label(TaintLabel.PRIVATE_DATA)
+        b = TaintSet.empty().with_label(TaintLabel.PRIVATE_DATA)
+        self.assertEqual(a, b)
+
+    def test_idempotent_union(self):
+        t = TaintSet.empty().with_label(TaintLabel.PRIVATE_DATA)
+        t2 = t.with_label(TaintLabel.PRIVATE_DATA)
+        self.assertEqual(t, t2)
+
+
+# --- Pure function tests (mirror Verus-verified taint_core) ---
+
+
+class TestClassifyOperation(unittest.TestCase):
+    def test_private_data_ops(self):
+        for op in ("fs.read", "fs.glob", "fs.grep"):
+            self.assertEqual(classify_operation(op), TaintLabel.PRIVATE_DATA, op)
+
+    def test_untrusted_content_ops(self):
+        for op in ("net.fetch", "net.search"):
+            self.assertEqual(
+                classify_operation(op), TaintLabel.UNTRUSTED_CONTENT, op
+            )
+
+    def test_exfil_ops(self):
+        for op in ("git.push", "git.create_pr", "run"):
+            self.assertEqual(classify_operation(op), TaintLabel.EXFIL_VECTOR, op)
+
+    def test_neutral_ops(self):
+        for op in ("fs.write", "git.commit", "git.add"):
+            self.assertIsNone(classify_operation(op), op)
+
+    def test_unknown_op(self):
+        self.assertIsNone(classify_operation("unknown.op"))
+
+
+class TestProjectTaint(unittest.TestCase):
+    def test_normal_op(self):
+        empty = TaintSet.empty()
+        projected = project_taint(empty, "fs.read")
+        self.assertTrue(projected.contains(TaintLabel.PRIVATE_DATA))
+
+    def test_neutral_op(self):
+        t = TaintSet.empty().with_label(TaintLabel.PRIVATE_DATA)
+        projected = project_taint(t, "fs.write")
+        self.assertEqual(projected, t)
+
+    def test_omnibus_run(self):
+        empty = TaintSet.empty()
+        projected = project_taint(empty, "run")
+        self.assertTrue(projected.contains(TaintLabel.PRIVATE_DATA))
+        self.assertTrue(projected.contains(TaintLabel.EXFIL_VECTOR))
+        self.assertFalse(projected.contains(TaintLabel.UNTRUSTED_CONTENT))
+
+
+class TestShouldDeny(unittest.TestCase):
+    def test_trifecta_blocks_exfil(self):
+        t = (
+            TaintSet.empty()
+            .with_label(TaintLabel.PRIVATE_DATA)
+            .with_label(TaintLabel.UNTRUSTED_CONTENT)
+        )
+        self.assertTrue(should_deny(t, "git.push"))
+        self.assertTrue(should_deny(t, "run"))
+        self.assertTrue(should_deny(t, "git.create_pr"))
+
+    def test_no_block_without_trifecta(self):
+        t = TaintSet.empty().with_label(TaintLabel.PRIVATE_DATA)
+        self.assertFalse(should_deny(t, "git.push"))
+
+    def test_no_block_for_non_exfil(self):
+        t = (
+            TaintSet.empty()
+            .with_label(TaintLabel.PRIVATE_DATA)
+            .with_label(TaintLabel.UNTRUSTED_CONTENT)
+        )
+        self.assertFalse(should_deny(t, "fs.read"))
+
+    def test_disabled(self):
+        t = (
+            TaintSet.empty()
+            .with_label(TaintLabel.PRIVATE_DATA)
+            .with_label(TaintLabel.UNTRUSTED_CONTENT)
+        )
+        self.assertFalse(should_deny(t, "git.push", trifecta_enabled=False))
+
+    def test_omnibus_with_untrusted(self):
+        t = TaintSet.empty().with_label(TaintLabel.UNTRUSTED_CONTENT)
+        # run is omnibus: projects private_data + exfil_vector
+        # with untrusted already present, trifecta completes
+        self.assertTrue(should_deny(t, "run"))
+
+
+class TestApplyRecord(unittest.TestCase):
+    def test_records_label(self):
+        empty = TaintSet.empty()
+        after = apply_record(empty, "fs.read")
+        self.assertTrue(after.contains(TaintLabel.PRIVATE_DATA))
+
+    def test_neutral_no_change(self):
+        t = TaintSet.empty().with_label(TaintLabel.PRIVATE_DATA)
+        after = apply_record(t, "fs.write")
+        self.assertEqual(after, t)
+
+    def test_run_records_exfil_only(self):
+        # Unlike project_taint, apply_record does NOT use omnibus
+        empty = TaintSet.empty()
+        after = apply_record(empty, "run")
+        self.assertTrue(after.contains(TaintLabel.EXFIL_VECTOR))
+        self.assertFalse(after.contains(TaintLabel.PRIVATE_DATA))
+
+
+# --- TaintGuard tests ---
+
+
+class TestTaintGuard(unittest.TestCase):
+    def test_starts_clean(self):
+        guard = TaintGuard()
+        self.assertEqual(guard.summary(), "clean")
+
+    def test_record_accumulates(self):
+        guard = TaintGuard()
+        guard.record("fs.read")
+        self.assertEqual(guard.summary(), "private_data")
+        guard.record("net.fetch")
+        self.assertEqual(guard.summary(), "private_data+untrusted_content")
+
+    def test_check_blocks_trifecta(self):
+        guard = TaintGuard()
+        guard.record("fs.read")
+        guard.record("net.fetch")
+        with self.assertRaises(TrifectaBlocked) as ctx:
+            guard.check("git.push")
+        self.assertIn("trifecta blocked", str(ctx.exception))
+        self.assertEqual(ctx.exception.kind, "trifecta_blocked")
+
+    def test_check_allows_non_exfil(self):
+        guard = TaintGuard()
+        guard.record("fs.read")
+        guard.record("net.fetch")
+        guard.check("fs.read")  # should not raise
+        guard.check("fs.write")  # should not raise
+
+    def test_check_allows_when_disabled(self):
+        guard = TaintGuard(trifecta_enabled=False)
+        guard.record("fs.read")
+        guard.record("net.fetch")
+        guard.check("git.push")  # should not raise
+
+
+# --- TrifectaBlocked exception tests ---
+
+
+class TestTrifectaBlocked(unittest.TestCase):
+    def test_is_subclass_of_access_denied(self):
+        self.assertTrue(issubclass(TrifectaBlocked, AccessDenied))
+
+    def test_is_subclass_of_nucleus_error(self):
+        self.assertTrue(issubclass(TrifectaBlocked, NucleusError))
+
+    def test_from_error_payload(self):
+        payload = {"error": "trifecta blocked", "kind": "trifecta_blocked"}
+        err = from_error_payload(payload, 403)
+        self.assertIsInstance(err, TrifectaBlocked)
+        self.assertEqual(err.status, 403)
+
+
+# --- Integration tests: Session + taint tracking ---
+
+
+class TestSessionTaintIntegration(unittest.TestCase):
+    def _make_session(self, trifecta_enabled=True):
+        mock_proxy = MagicMock(spec=ProxyClient)
+        mock_proxy.read.return_value = "file contents"
+        mock_proxy.web_fetch.return_value = {"status": 200, "body": "ok"}
+        mock_proxy.web_search.return_value = {"results": []}
+        mock_proxy.run.return_value = {"exit_code": 0, "stdout": ""}
+        mock_proxy.glob.return_value = {"files": ["a.py"]}
+        mock_proxy.grep.return_value = {"matches": []}
+        return Session(
+            profile="test",
+            proxy=mock_proxy,
+            trifecta_enabled=trifecta_enabled,
+        )
+
+    def test_taint_summary_clean_on_start(self):
+        s = self._make_session()
+        with s as session:
+            self.assertEqual(session.taint_summary, "clean")
+
+    def test_read_adds_private_data(self):
+        s = self._make_session()
+        with s as session:
+            session.fs.read("file.txt")
+            self.assertEqual(session.taint_summary, "private_data")
+
+    def test_fetch_adds_untrusted_content(self):
+        s = self._make_session()
+        with s as session:
+            session.net.fetch("https://example.com")
+            self.assertEqual(session.taint_summary, "untrusted_content")
+
+    def test_trifecta_blocks_push_after_read_and_fetch(self):
+        s = self._make_session()
+        with s as session:
+            session.fs.read("secrets.txt")
+            session.net.fetch("https://evil.com")
+            with self.assertRaises(TrifectaBlocked):
+                session.git.push("origin", "main")
+
+    def test_trifecta_blocks_run_after_grep_and_search(self):
+        s = self._make_session()
+        with s as session:
+            session.fs.grep("password")
+            session.net.search("how to exfiltrate")
+            with self.assertRaises(TrifectaBlocked):
+                session.git.push("origin")
+
+    def test_write_is_neutral(self):
+        s = self._make_session()
+        with s as session:
+            session.fs.write("out.txt", "data")
+            self.assertEqual(session.taint_summary, "clean")
+
+    def test_commit_is_neutral(self):
+        s = self._make_session()
+        with s as session:
+            session.git.commit("msg")
+            self.assertEqual(session.taint_summary, "clean")
+
+    def test_trifecta_disabled_allows_everything(self):
+        s = self._make_session(trifecta_enabled=False)
+        with s as session:
+            session.fs.read("secrets.txt")
+            session.net.fetch("https://evil.com")
+            session.git.push("origin", "main")  # should NOT raise
+
+    def test_glob_adds_private_data(self):
+        s = self._make_session()
+        with s as session:
+            session.fs.glob("**/*.py")
+            self.assertEqual(session.taint_summary, "private_data")
+
+    def test_taint_survives_after_context_exit(self):
+        s = self._make_session()
+        with s as session:
+            session.fs.read("a.txt")
+            session.net.fetch("https://example.com")
+        self.assertEqual(s.taint_summary, "private_data+untrusted_content")
+
+    def test_trifecta_trace_records_deny(self):
+        s = self._make_session()
+        try:
+            with s as session:
+                session.fs.read("data.txt")
+                session.net.fetch("https://evil.com")
+                session.git.push("origin")
+        except TrifectaBlocked:
+            pass
+        # The session exit should have recorded the TrifectaBlocked
+        exit_entries = [
+            e for e in s.trace.entries if e.operation == "session.exit"
+        ]
+        self.assertEqual(len(exit_entries), 1)
+        self.assertEqual(exit_entries[0].policy_decision, "deny")
+        self.assertIn("TrifectaBlocked", exit_entries[0].result_summary)
+
+
+# --- Tool handle backward compatibility (no guard) ---
+
+
+class TestToolHandlesWithoutGuard(unittest.TestCase):
+    """Verify tool handles work without a TaintGuard (backward compat)."""
+
+    def test_file_handle_no_guard(self):
+        proxy = MagicMock(spec=ProxyClient)
+        proxy.read.return_value = "content"
+        fh = FileHandle(proxy, Trace())
+        result = fh.read("test.txt")
+        self.assertEqual(result, "content")
+
+    def test_net_handle_no_guard(self):
+        proxy = MagicMock(spec=ProxyClient)
+        proxy.web_fetch.return_value = {"status": 200, "body": "ok"}
+        nh = NetHandle(proxy, Trace())
+        result = nh.fetch("https://example.com")
+        self.assertEqual(result["status"], 200)
+
+    def test_git_handle_no_guard(self):
+        proxy = MagicMock(spec=ProxyClient)
+        proxy.run.return_value = {"exit_code": 0, "stdout": ""}
+        gh = GitHandle(proxy, Trace())
+        gh.push("origin")
+        proxy.run.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Mirrors the Verus-verified `taint_core` decision kernel into the Python SDK, giving Python users the same trifecta gate that `nucleus-mcp` (Rust) got in PR #219
- Adds `TaintSet`, `TaintLabel`, `TaintGuard` with monotone 3-bool taint lattice and pure decision functions (`classify_operation`, `project_taint`, `should_deny`, `apply_record`)
- Adds `TrifectaBlocked` exception (subclass of `AccessDenied`) raised when exfiltration-capable operations would complete the taint trifecta
- `TaintGuard` wired into `FileHandle`, `NetHandle`, `GitHandle` via optional parameter (backward compatible — existing code without guards works unchanged)
- `Session` creates `TaintGuard` automatically and exposes `taint_summary` property

## Test plan

- [x] 45 new tests in `test_taint.py` covering TaintSet, pure functions, TaintGuard, TrifectaBlocked, session integration, and backward compatibility
- [x] All 81 Python tests pass (36 existing + 45 new)
- [x] All 48 Rust tests pass (36 nucleus-mcp + 12 nucleus-cli)
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.ai/code)