### PR TITLE
feat(profiles): complete all 10 canonical profiles from North Star

### DIFF
--- a/crates/nucleus-spec/src/lib.rs
+++ b/crates/nucleus-spec/src/lib.rs
@@ -522,7 +522,7 @@ mod tests {
         let profiles = [
             ("pr_review", "PR review permissions"),
             ("pr-review", "PR review permissions"),
-            ("codegen", "Code generation permissions (network-isolated)"),
+            ("codegen", "Code generation"),
             ("pr_approve", "PR approval permissions (CI-gated)"),
             ("pr-approve", "PR approval permissions (CI-gated)"),
             (
@@ -592,6 +592,8 @@ mod tests {
             "test_runner",
             "triage-bot",
             "triage_bot",
+            "research-web",
+            "research_web",
         ];
 
         for name in profile_names {

--- a/crates/portcullis/profiles/code-review.yaml
+++ b/crates/portcullis/profiles/code-review.yaml
@@ -1,0 +1,49 @@
+# Code Review — read source, search for context, no modifications.
+#
+# The agent reads code and searches the web for context (e.g., API docs,
+# CVE databases). Cannot write, edit, execute, push, or create PRs.
+# Web search requires approval because it introduces untrusted content.
+#
+# Trifecta analysis:
+#   - Private data: read_files=always (present)
+#   - Untrusted content: web_search=low_risk (present, with approval)
+#   - Exfiltration: git_push=never, run_bash=never, create_pr=never (absent)
+#   => Two of three components. No exfil vectors, safe by construction.
+
+name: code-review
+description: "Code review — read source, search web for context, no modifications"
+
+capabilities:
+  read_files: always
+  write_files: never
+  edit_files: never
+  run_bash: never
+  glob_search: always
+  grep_search: always
+  web_search: low_risk
+  web_fetch: never
+  git_commit: never
+  git_push: never
+  create_pr: never
+  manage_pods: never
+
+obligations:
+  - web_search
+
+paths:
+  blocked:
+    - "**/.ssh/**"
+    - "**/.aws/**"
+    - "**/.env"
+    - "**/.env.*"
+    - "**/credentials*"
+    - "/etc/shadow"
+    - "/etc/passwd"
+
+budget:
+  max_cost_usd: "1.00"
+  max_input_tokens: 50000
+  max_output_tokens: 5000
+
+time:
+  duration_minutes: 30

--- a/crates/portcullis/profiles/codegen.yaml
+++ b/crates/portcullis/profiles/codegen.yaml
@@ -1,0 +1,47 @@
+# Codegen — network-isolated code generation and editing.
+#
+# The agent can read, write, edit code, run bash (tests, builds), and
+# commit locally. No network access and no push — the generated code
+# stays local until a human reviews and pushes.
+#
+# Trifecta analysis:
+#   - Private data: read_files=always (present)
+#   - Untrusted content: web_search=never, web_fetch=never (absent)
+#   - Exfiltration: git_push=never, create_pr=never (absent)
+#   => One of three components. Safe by construction — no untrusted
+#      content and no exfiltration vectors.
+
+name: codegen
+description: "Code generation — read/write/edit/run, network-isolated, no push"
+
+capabilities:
+  read_files: always
+  write_files: low_risk
+  edit_files: low_risk
+  run_bash: low_risk
+  glob_search: always
+  grep_search: always
+  web_search: never
+  web_fetch: never
+  git_commit: low_risk
+  git_push: never
+  create_pr: never
+  manage_pods: never
+
+paths:
+  blocked:
+    - "**/.ssh/**"
+    - "**/.aws/**"
+    - "**/.env"
+    - "**/.env.*"
+    - "**/credentials*"
+    - "/etc/shadow"
+    - "/etc/passwd"
+
+budget:
+  max_cost_usd: "5.00"
+  max_input_tokens: 100000
+  max_output_tokens: 10000
+
+time:
+  duration_hours: 1

--- a/crates/portcullis/profiles/local-dev.yaml
+++ b/crates/portcullis/profiles/local-dev.yaml
@@ -1,0 +1,47 @@
+# Local Dev — full local development without network or push.
+#
+# The agent can read, write, edit code, run bash commands (tests,
+# builds, linters), and commit locally. No network access and no
+# push — all work stays local until a human reviews and pushes.
+#
+# Trifecta analysis:
+#   - Private data: read_files=always (present)
+#   - Untrusted content: web_search=never, web_fetch=never (absent)
+#   - Exfiltration: git_push=never, create_pr=never (absent)
+#   => One of three components. Safe by construction — network-isolated
+#      with no exfiltration vectors.
+
+name: local-dev
+description: "Local dev — read/write/edit/run/commit, no network, no push"
+
+capabilities:
+  read_files: always
+  write_files: low_risk
+  edit_files: low_risk
+  run_bash: low_risk
+  glob_search: always
+  grep_search: always
+  web_search: never
+  web_fetch: never
+  git_commit: low_risk
+  git_push: never
+  create_pr: never
+  manage_pods: never
+
+paths:
+  blocked:
+    - "**/.ssh/**"
+    - "**/.aws/**"
+    - "**/.env"
+    - "**/.env.*"
+    - "**/credentials*"
+    - "/etc/shadow"
+    - "/etc/passwd"
+
+budget:
+  max_cost_usd: "3.00"
+  max_input_tokens: 100000
+  max_output_tokens: 10000
+
+time:
+  duration_hours: 2

--- a/crates/portcullis/profiles/read-only.yaml
+++ b/crates/portcullis/profiles/read-only.yaml
@@ -1,0 +1,47 @@
+# Read Only — read files and search, nothing else.
+#
+# The most restrictive useful profile. The agent can read files and
+# search with glob/grep. No writes, no edits, no execution, no
+# network, no git operations. Useful for code exploration, analysis,
+# and question-answering tasks.
+#
+# Trifecta analysis:
+#   - Private data: read_files=always (present)
+#   - Untrusted content: absent
+#   - Exfiltration: absent
+#   => One of three components. Safe by construction.
+
+name: read-only
+description: "Read only — read files and search, no writes or network"
+
+capabilities:
+  read_files: always
+  write_files: never
+  edit_files: never
+  run_bash: never
+  glob_search: always
+  grep_search: always
+  web_search: never
+  web_fetch: never
+  git_commit: never
+  git_push: never
+  create_pr: never
+  manage_pods: never
+
+paths:
+  blocked:
+    - "**/.ssh/**"
+    - "**/.aws/**"
+    - "**/.env"
+    - "**/.env.*"
+    - "**/credentials*"
+    - "/etc/shadow"
+    - "/etc/passwd"
+
+budget:
+  max_cost_usd: "1.00"
+  max_input_tokens: 50000
+  max_output_tokens: 5000
+
+time:
+  duration_minutes: 30

--- a/crates/portcullis/profiles/release.yaml
+++ b/crates/portcullis/profiles/release.yaml
@@ -1,0 +1,50 @@
+# Release — full capabilities with approval gates on publishing.
+#
+# The agent can read, write, edit, run tests, fetch web content, and
+# push/create PRs. Push and PR creation require explicit human approval.
+#
+# Trifecta analysis:
+#   - Private data: read_files=always (present)
+#   - Untrusted content: web_fetch=low_risk (present)
+#   - Exfiltration: git_push=low_risk, create_pr=low_risk (present)
+#   => All three components present. Trifecta normalization adds approval
+#      obligations on exfil operations (git_push, create_pr, run_bash).
+
+name: release
+description: "Release — full capabilities, approval required for push and PR"
+
+capabilities:
+  read_files: always
+  write_files: low_risk
+  edit_files: low_risk
+  run_bash: low_risk
+  glob_search: always
+  grep_search: always
+  web_search: low_risk
+  web_fetch: low_risk
+  git_commit: low_risk
+  git_push: low_risk
+  create_pr: low_risk
+  manage_pods: never
+
+obligations:
+  - git_push
+  - create_pr
+
+paths:
+  blocked:
+    - "**/.ssh/**"
+    - "**/.aws/**"
+    - "**/.env"
+    - "**/.env.*"
+    - "**/credentials*"
+    - "/etc/shadow"
+    - "/etc/passwd"
+
+budget:
+  max_cost_usd: "5.00"
+  max_input_tokens: 100000
+  max_output_tokens: 10000
+
+time:
+  duration_hours: 2

--- a/crates/portcullis/profiles/research-web.yaml
+++ b/crates/portcullis/profiles/research-web.yaml
@@ -1,0 +1,47 @@
+# Research Web — read local files and search/fetch web content.
+#
+# The agent can read files (low risk) for context and access the web
+# for research. Cannot write, edit, execute, or push anything.
+# Ideal for research tasks that combine local code context with
+# external documentation, API references, or CVE databases.
+#
+# Trifecta analysis:
+#   - Private data: read_files=low_risk (present)
+#   - Untrusted content: web_search=low_risk, web_fetch=low_risk (present)
+#   - Exfiltration: git_push=never, run_bash=never, create_pr=never (absent)
+#   => Two of three components. No exfil vectors, safe by construction.
+
+name: research-web
+description: "Web research — read files, search/fetch web, no writes or execution"
+
+capabilities:
+  read_files: low_risk
+  write_files: never
+  edit_files: never
+  run_bash: never
+  glob_search: always
+  grep_search: always
+  web_search: low_risk
+  web_fetch: low_risk
+  git_commit: never
+  git_push: never
+  create_pr: never
+  manage_pods: never
+
+paths:
+  blocked:
+    - "**/.ssh/**"
+    - "**/.aws/**"
+    - "**/.env"
+    - "**/.env.*"
+    - "**/credentials*"
+    - "/etc/shadow"
+    - "/etc/passwd"
+
+budget:
+  max_cost_usd: "1.50"
+  max_input_tokens: 50000
+  max_output_tokens: 5000
+
+time:
+  duration_minutes: 45

--- a/crates/portcullis/src/profile.rs
+++ b/crates/portcullis/src/profile.rs
@@ -421,6 +421,12 @@ const SAFE_PR_FIXER_YAML: &str = include_str!("../profiles/safe-pr-fixer.yaml");
 const DOC_EDITOR_YAML: &str = include_str!("../profiles/doc-editor.yaml");
 const TEST_RUNNER_YAML: &str = include_str!("../profiles/test-runner.yaml");
 const TRIAGE_BOT_YAML: &str = include_str!("../profiles/triage-bot.yaml");
+const CODE_REVIEW_YAML: &str = include_str!("../profiles/code-review.yaml");
+const CODEGEN_YAML: &str = include_str!("../profiles/codegen.yaml");
+const RELEASE_YAML: &str = include_str!("../profiles/release.yaml");
+const RESEARCH_WEB_YAML: &str = include_str!("../profiles/research-web.yaml");
+const READ_ONLY_YAML: &str = include_str!("../profiles/read-only.yaml");
+const LOCAL_DEV_YAML: &str = include_str!("../profiles/local-dev.yaml");
 
 /// Registry of named profiles, combining embedded canonical profiles
 /// with optional user-supplied ones.
@@ -437,6 +443,12 @@ impl ProfileRegistry {
             ProfileSpec::from_yaml(DOC_EDITOR_YAML)?,
             ProfileSpec::from_yaml(TEST_RUNNER_YAML)?,
             ProfileSpec::from_yaml(TRIAGE_BOT_YAML)?,
+            ProfileSpec::from_yaml(CODE_REVIEW_YAML)?,
+            ProfileSpec::from_yaml(CODEGEN_YAML)?,
+            ProfileSpec::from_yaml(RELEASE_YAML)?,
+            ProfileSpec::from_yaml(RESEARCH_WEB_YAML)?,
+            ProfileSpec::from_yaml(READ_ONLY_YAML)?,
+            ProfileSpec::from_yaml(LOCAL_DEV_YAML)?,
         ];
         Ok(Self { profiles })
     }
@@ -487,11 +499,17 @@ mod tests {
     #[test]
     fn test_canonical_profiles_parse() {
         let registry = ProfileRegistry::canonical().unwrap();
-        assert_eq!(registry.names().len(), 4);
+        assert_eq!(registry.names().len(), 10);
         assert!(registry.names().contains(&"safe-pr-fixer"));
         assert!(registry.names().contains(&"doc-editor"));
         assert!(registry.names().contains(&"test-runner"));
         assert!(registry.names().contains(&"triage-bot"));
+        assert!(registry.names().contains(&"code-review"));
+        assert!(registry.names().contains(&"codegen"));
+        assert!(registry.names().contains(&"release"));
+        assert!(registry.names().contains(&"research-web"));
+        assert!(registry.names().contains(&"read-only"));
+        assert!(registry.names().contains(&"local-dev"));
     }
 
     #[test]
@@ -575,6 +593,129 @@ mod tests {
         assert_eq!(lattice.capabilities.edit_files, CapabilityLevel::Never);
         assert_eq!(lattice.capabilities.git_push, CapabilityLevel::Never);
         assert_eq!(lattice.capabilities.run_bash, CapabilityLevel::Never);
+    }
+
+    #[test]
+    fn test_code_review_no_modifications() {
+        let registry = ProfileRegistry::canonical().unwrap();
+        let lattice = registry.resolve("code-review").unwrap();
+
+        // Can read and search
+        assert_eq!(lattice.capabilities.read_files, CapabilityLevel::Always);
+        assert_eq!(lattice.capabilities.glob_search, CapabilityLevel::Always);
+        assert_eq!(lattice.capabilities.grep_search, CapabilityLevel::Always);
+
+        // Web search allowed with approval
+        assert_eq!(lattice.capabilities.web_search, CapabilityLevel::LowRisk);
+        assert!(lattice.requires_approval(Operation::WebSearch));
+
+        // No modifications, no execution, no push
+        assert_eq!(lattice.capabilities.write_files, CapabilityLevel::Never);
+        assert_eq!(lattice.capabilities.edit_files, CapabilityLevel::Never);
+        assert_eq!(lattice.capabilities.run_bash, CapabilityLevel::Never);
+        assert_eq!(lattice.capabilities.git_push, CapabilityLevel::Never);
+        assert_eq!(lattice.capabilities.create_pr, CapabilityLevel::Never);
+    }
+
+    #[test]
+    fn test_codegen_network_isolated() {
+        let registry = ProfileRegistry::canonical().unwrap();
+        let lattice = registry.resolve("codegen").unwrap();
+
+        // Full local dev capabilities
+        assert_eq!(lattice.capabilities.read_files, CapabilityLevel::Always);
+        assert_eq!(lattice.capabilities.write_files, CapabilityLevel::LowRisk);
+        assert_eq!(lattice.capabilities.edit_files, CapabilityLevel::LowRisk);
+        assert_eq!(lattice.capabilities.run_bash, CapabilityLevel::LowRisk);
+        assert_eq!(lattice.capabilities.git_commit, CapabilityLevel::LowRisk);
+
+        // Network isolated — no web access
+        assert_eq!(lattice.capabilities.web_search, CapabilityLevel::Never);
+        assert_eq!(lattice.capabilities.web_fetch, CapabilityLevel::Never);
+
+        // No push or PR creation
+        assert_eq!(lattice.capabilities.git_push, CapabilityLevel::Never);
+        assert_eq!(lattice.capabilities.create_pr, CapabilityLevel::Never);
+    }
+
+    #[test]
+    fn test_release_approval_on_publish() {
+        let registry = ProfileRegistry::canonical().unwrap();
+        let lattice = registry.resolve("release").unwrap();
+
+        // Has push and PR capabilities
+        assert_eq!(lattice.capabilities.git_push, CapabilityLevel::LowRisk);
+        assert_eq!(lattice.capabilities.create_pr, CapabilityLevel::LowRisk);
+
+        // But they require approval (trifecta: read + web + exfil)
+        assert!(lattice.requires_approval(Operation::GitPush));
+        assert!(lattice.requires_approval(Operation::CreatePr));
+
+        // Full read/write/edit/run
+        assert_eq!(lattice.capabilities.read_files, CapabilityLevel::Always);
+        assert_eq!(lattice.capabilities.write_files, CapabilityLevel::LowRisk);
+        assert_eq!(lattice.capabilities.run_bash, CapabilityLevel::LowRisk);
+    }
+
+    #[test]
+    fn test_research_web_no_exfil() {
+        let registry = ProfileRegistry::canonical().unwrap();
+        let lattice = registry.resolve("research-web").unwrap();
+
+        // Read (low_risk) + web access
+        assert_eq!(lattice.capabilities.read_files, CapabilityLevel::LowRisk);
+        assert_eq!(lattice.capabilities.web_search, CapabilityLevel::LowRisk);
+        assert_eq!(lattice.capabilities.web_fetch, CapabilityLevel::LowRisk);
+
+        // No write, no edit, no execution, no push
+        assert_eq!(lattice.capabilities.write_files, CapabilityLevel::Never);
+        assert_eq!(lattice.capabilities.edit_files, CapabilityLevel::Never);
+        assert_eq!(lattice.capabilities.run_bash, CapabilityLevel::Never);
+        assert_eq!(lattice.capabilities.git_push, CapabilityLevel::Never);
+        assert_eq!(lattice.capabilities.create_pr, CapabilityLevel::Never);
+    }
+
+    #[test]
+    fn test_read_only_minimal() {
+        let registry = ProfileRegistry::canonical().unwrap();
+        let lattice = registry.resolve("read-only").unwrap();
+
+        // Can read and search
+        assert_eq!(lattice.capabilities.read_files, CapabilityLevel::Always);
+        assert_eq!(lattice.capabilities.glob_search, CapabilityLevel::Always);
+        assert_eq!(lattice.capabilities.grep_search, CapabilityLevel::Always);
+
+        // Everything else is Never
+        assert_eq!(lattice.capabilities.write_files, CapabilityLevel::Never);
+        assert_eq!(lattice.capabilities.edit_files, CapabilityLevel::Never);
+        assert_eq!(lattice.capabilities.run_bash, CapabilityLevel::Never);
+        assert_eq!(lattice.capabilities.web_search, CapabilityLevel::Never);
+        assert_eq!(lattice.capabilities.web_fetch, CapabilityLevel::Never);
+        assert_eq!(lattice.capabilities.git_commit, CapabilityLevel::Never);
+        assert_eq!(lattice.capabilities.git_push, CapabilityLevel::Never);
+        assert_eq!(lattice.capabilities.create_pr, CapabilityLevel::Never);
+        assert_eq!(lattice.capabilities.manage_pods, CapabilityLevel::Never);
+    }
+
+    #[test]
+    fn test_local_dev_no_network() {
+        let registry = ProfileRegistry::canonical().unwrap();
+        let lattice = registry.resolve("local-dev").unwrap();
+
+        // Full local capabilities
+        assert_eq!(lattice.capabilities.read_files, CapabilityLevel::Always);
+        assert_eq!(lattice.capabilities.write_files, CapabilityLevel::LowRisk);
+        assert_eq!(lattice.capabilities.edit_files, CapabilityLevel::LowRisk);
+        assert_eq!(lattice.capabilities.run_bash, CapabilityLevel::LowRisk);
+        assert_eq!(lattice.capabilities.git_commit, CapabilityLevel::LowRisk);
+
+        // No network
+        assert_eq!(lattice.capabilities.web_search, CapabilityLevel::Never);
+        assert_eq!(lattice.capabilities.web_fetch, CapabilityLevel::Never);
+
+        // No push
+        assert_eq!(lattice.capabilities.git_push, CapabilityLevel::Never);
+        assert_eq!(lattice.capabilities.create_pr, CapabilityLevel::Never);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add 6 remaining canonical YAML profiles from the North Star SDK surface: `code-review`, `codegen`, `release`, `research-web`, `read-only`, `local-dev`
- Register all 10 profiles in `ProfileRegistry::canonical()` (compile-time embedded)
- Add 6 new profile-specific tests validating capabilities, trifecta safety, and approval obligations
- Update `nucleus-spec` test expectations to match canonical profile descriptions

## Profile Trifecta Safety Matrix

| Profile | Private Data | Untrusted Content | Exfil Vector | Safe? |
|---|---|---|---|---|
| safe-pr-fixer | read=always | web_fetch=low_risk | push=never | 2/3, safe |
| doc-editor | read=always | none | none | 1/3, safe |
| test-runner | read=always | none | none | 1/3, safe |
| triage-bot | read=always | web=low_risk | none | 2/3, safe |
| **code-review** | read=always | web_search=low_risk | none | 2/3, safe |
| **codegen** | read=always | none | none | 1/3, safe |
| **release** | read=always | web=low_risk | push=low_risk | **3/3, gated** |
| **research-web** | read=low_risk | web=low_risk | none | 2/3, safe |
| **read-only** | read=always | none | none | 1/3, safe |
| **local-dev** | read=always | none | none | 1/3, safe |

Only `release` has a complete trifecta — push/PR require explicit approval.

## Test plan

- [x] All 18 `profile::tests` pass (`cargo test -p portcullis --all-features`)
- [x] All 21 `nucleus-spec` tests pass
- [x] All 66 `nucleus-audit` tests pass
- [x] Pre-commit hooks pass (fmt, clippy, deny, audit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)