### PR TITLE
feat: connect kernel trace to nucleus observe pipeline

### DIFF
--- a/crates/nucleus-cli/src/observe.rs
+++ b/crates/nucleus-cli/src/observe.rs
@@ -18,6 +18,7 @@ pub struct ObserveArgs {
     pub name: String,
 
     /// Path to JSONL audit log file. Use "-" or omit for stdin.
+    /// Accepts both simple format and kernel Decision JSONL from --kernel-trace.
     #[arg(short, long)]
     pub input: Option<PathBuf>,
 

--- a/crates/nucleus-cli/src/run.rs
+++ b/crates/nucleus-cli/src/run.rs
@@ -202,6 +202,12 @@ pub struct RunArgs {
     /// Mount rootfs read-only (recommended).
     #[arg(long, env = "NUCLEUS_FIRECRACKER_READ_ONLY", default_value_t = true)]
     pub rootfs_read_only: bool,
+
+    /// Path to write kernel decision trace in JSONL format.
+    /// Each tool call decision (allow/deny/requires_approval) is recorded.
+    /// Feed the output into `nucleus observe` to synthesize a minimal policy.
+    #[arg(long, env = "NUCLEUS_KERNEL_TRACE")]
+    pub kernel_trace: Option<PathBuf>,
 }
 
 /// Execute the run command
@@ -449,6 +455,7 @@ async fn run_local(
         Some(&auth_secret),
         Some(&approval_secret),
         &spec_path,
+        args.kernel_trace.as_deref(),
     )?;
 
     let allowed_tools = build_mcp_allowed_tools(policy);
@@ -456,6 +463,10 @@ async fn run_local(
         return Err(anyhow!(
             "no allowed MCP tools for this profile (policy is too restrictive)"
         ));
+    }
+
+    if let Some(ref trace_path) = args.kernel_trace {
+        info!(trace_path = %trace_path.display(), "Kernel trace enabled");
     }
 
     info!(
@@ -590,6 +601,7 @@ async fn run_enforced(
         None,
         None,
         &spec_path,
+        args.kernel_trace.as_deref(),
     )?;
 
     let allowed_tools = build_mcp_allowed_tools(policy);
@@ -718,6 +730,7 @@ fn write_mcp_config(
     auth_secret: Option<&str>,
     approval_secret: Option<&str>,
     spec_path: &Path,
+    kernel_trace: Option<&Path>,
 ) -> Result<()> {
     #[derive(Serialize)]
     struct McpServer {
@@ -751,6 +764,12 @@ fn write_mcp_config(
         "NUCLEUS_MCP_SPEC".to_string(),
         spec_path.display().to_string(),
     );
+    if let Some(trace_path) = kernel_trace {
+        env.insert(
+            "NUCLEUS_MCP_KERNEL_TRACE".to_string(),
+            trace_path.display().to_string(),
+        );
+    }
 
     let server = McpServer {
         server_type: "stdio".to_string(),

--- a/crates/portcullis/src/observe.rs
+++ b/crates/portcullis/src/observe.rs
@@ -373,16 +373,31 @@ impl ObserveSession {
 
 /// Parse JSONL audit log lines into observations.
 ///
-/// Each line should be a JSON object with at minimum:
+/// Accepts two formats:
+///
+/// **Simple format** (manual audit logs):
 /// ```json
 /// {"operation": "read_files", "subject": "src/main.rs", "succeeded": true}
 /// ```
+///
+/// **Kernel Decision format** (from `--kernel-trace` JSONL):
+/// ```json
+/// {"operation": "read_files", "subject": "/src/main.rs", "verdict": {"type": "allow"}, "timestamp": "..."}
+/// ```
+///
+/// Lines with `"type": "session_summary"` are skipped (not tool call observations).
 pub fn parse_jsonl_observations(input: &str) -> Vec<Observation> {
     input
         .lines()
         .filter(|line| !line.trim().is_empty())
         .filter_map(|line| {
             let v: serde_json::Value = serde_json::from_str(line).ok()?;
+
+            // Skip session_summary lines from kernel trace
+            if v.get("type").and_then(|t| t.as_str()) == Some("session_summary") {
+                return None;
+            }
+
             let op_str = v.get("operation")?.as_str()?;
             let operation = parse_operation(op_str)?;
             let subject = v
@@ -390,7 +405,20 @@ pub fn parse_jsonl_observations(input: &str) -> Vec<Observation> {
                 .and_then(|s| s.as_str())
                 .unwrap_or("")
                 .to_string();
-            let succeeded = v.get("succeeded").and_then(|s| s.as_bool()).unwrap_or(true);
+
+            // Determine success: check "succeeded" field first (simple format),
+            // then fall back to "verdict.type" (kernel Decision format).
+            let succeeded = if let Some(s) = v.get("succeeded").and_then(|s| s.as_bool()) {
+                s
+            } else if let Some(verdict_type) = v
+                .get("verdict")
+                .and_then(|vv| vv.get("type"))
+                .and_then(|t| t.as_str())
+            {
+                verdict_type == "allow"
+            } else {
+                true
+            };
 
             let timestamp = v
                 .get("timestamp")
@@ -644,6 +672,56 @@ mod tests {
 
         let observations = parse_jsonl_observations(input);
         assert_eq!(observations.len(), 2);
+    }
+
+    #[test]
+    fn test_parse_kernel_decision_format() {
+        // Kernel Decision JSONL format with verdict.type
+        let input = r#"{"id":"abc","sequence":0,"operation":"read_files","subject":"src/main.rs","verdict":{"type":"allow"},"timestamp":"2026-03-12T00:00:00Z","pre_permissions_hash":"a","post_permissions_hash":"b","taint_transition":{"pre_count":0,"post_count":1,"contributed_label":"private_data","trifecta_completed":false,"dynamic_gate_applied":false}}
+{"id":"def","sequence":1,"operation":"write_files","subject":"out.txt","verdict":{"type":"deny","reason":"insufficient_capability"},"timestamp":"2026-03-12T00:01:00Z","pre_permissions_hash":"a","post_permissions_hash":"a","taint_transition":{"pre_count":1,"post_count":1,"contributed_label":null,"trifecta_completed":false,"dynamic_gate_applied":false}}
+{"id":"ghi","sequence":2,"operation":"web_fetch","subject":"https://example.com","verdict":{"type":"requires_approval"},"timestamp":"2026-03-12T00:02:00Z","pre_permissions_hash":"a","post_permissions_hash":"a","taint_transition":{"pre_count":1,"post_count":1,"contributed_label":null,"trifecta_completed":false,"dynamic_gate_applied":true}}
+"#;
+
+        let observations = parse_jsonl_observations(input);
+        assert_eq!(observations.len(), 3);
+
+        // allow → succeeded
+        assert_eq!(observations[0].operation, Operation::ReadFiles);
+        assert!(observations[0].succeeded);
+
+        // deny → not succeeded
+        assert_eq!(observations[1].operation, Operation::WriteFiles);
+        assert!(!observations[1].succeeded);
+
+        // requires_approval → not succeeded
+        assert_eq!(observations[2].operation, Operation::WebFetch);
+        assert!(!observations[2].succeeded);
+    }
+
+    #[test]
+    fn test_parse_kernel_decision_skips_session_summary() {
+        let input = r#"{"id":"abc","sequence":0,"operation":"read_files","subject":"a.txt","verdict":{"type":"allow"},"timestamp":"2026-03-12T00:00:00Z","pre_permissions_hash":"a","post_permissions_hash":"b","taint_transition":{"pre_count":0,"post_count":1,"contributed_label":"private_data","trifecta_completed":false,"dynamic_gate_applied":false}}
+{"type":"session_summary","session_id":"123","decisions":1,"consumed_usd":"0.01","remaining_usd":"9.99","initial_hash":"abc"}
+"#;
+
+        let observations = parse_jsonl_observations(input);
+        assert_eq!(observations.len(), 1);
+        assert_eq!(observations[0].operation, Operation::ReadFiles);
+    }
+
+    #[test]
+    fn test_parse_mixed_formats() {
+        // Both simple and kernel Decision formats in the same input
+        let input = r#"{"operation":"read_files","subject":"a.txt","succeeded":true}
+{"id":"abc","sequence":0,"operation":"web_fetch","subject":"https://example.com","verdict":{"type":"allow"},"timestamp":"2026-03-12T00:00:00Z","pre_permissions_hash":"a","post_permissions_hash":"b","taint_transition":{"pre_count":0,"post_count":1,"contributed_label":null,"trifecta_completed":false,"dynamic_gate_applied":false}}
+{"operation":"git_push","subject":"origin main","succeeded":false}
+"#;
+
+        let observations = parse_jsonl_observations(input);
+        assert_eq!(observations.len(), 3);
+        assert!(observations[0].succeeded);
+        assert!(observations[1].succeeded); // verdict.type == "allow"
+        assert!(!observations[2].succeeded);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Extends `parse_jsonl_observations` in portcullis to accept kernel `Decision` JSONL format alongside the existing simple format
- Adds `--kernel-trace <path>` flag to `nucleus run`, passed through to the MCP bridge via `NUCLEUS_MCP_KERNEL_TRACE` env var
- Enables the end-to-end pipeline: run agent → collect trace → synthesize policy

## Why
PR #225 added `--kernel-trace` to `nucleus-mcp` for JSONL decision export, but there was no way to:
1. Trigger it from `nucleus run` (the flag wasn't wired through)
2. Feed the output into `nucleus observe` (different JSONL formats)

This PR closes both gaps, completing the progressive discovery pipeline from the North Star (PR7: `nucleus observe`).

## Usage
```bash
# Record what an agent does
nucleus run --local --kernel-trace trace.jsonl --profile codegen "implement feature X"

# Synthesize a minimal policy from the trace
nucleus observe --input trace.jsonl --output policy.yaml

# Use the synthesized policy for future runs
nucleus run --local --config policy.yaml "implement feature Y"
```

## Format compatibility
The parser now accepts both formats in the same file:
- **Simple**: `{"operation":"read_files","subject":"src/main.rs","succeeded":true}`
- **Kernel Decision**: `{"operation":"read_files","subject":"src/main.rs","verdict":{"type":"allow"},...}`
- **Session summary** lines (`{"type":"session_summary",...}`) are automatically skipped

## Test plan
- [x] `cargo test -p portcullis --features spec -- observe` — 15 tests pass (3 new)
- [x] `cargo test -p nucleus-cli` — 19 tests pass
- [x] `cargo clippy` — clean
- [ ] CI checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)