### PR TITLE
feat(sdk): add ProfileRegistry with canonical profiles

### DIFF
--- a/sdk/python/nucleus_sdk/__init__.py
+++ b/sdk/python/nucleus_sdk/__init__.py
@@ -1,6 +1,14 @@
 from .client import Nucleus, NodeClient, ProxyClient
 from .models import PodInfo, PodSpec
 from .intent import Intent, IntentSession, IntentProfile
+from .profiles import (
+    CapabilityLevel,
+    Capabilities,
+    ProfileSpec,
+    ProfileRegistry,
+    BudgetSpec,
+    TimeSpec,
+)
 from .auth import MtlsConfig, HmacAuth
 from .session import Session
 from .taint import TaintGuard, TaintLabel, TaintSet
@@ -35,6 +43,12 @@ __all__ = [
     "Intent",
     "IntentSession",
     "IntentProfile",
+    "CapabilityLevel",
+    "Capabilities",
+    "ProfileSpec",
+    "ProfileRegistry",
+    "BudgetSpec",
+    "TimeSpec",
     "MtlsConfig",
     "HmacAuth",
     "Session",

--- a/sdk/python/nucleus_sdk/profiles.py
+++ b/sdk/python/nucleus_sdk/profiles.py
@@ -1,0 +1,462 @@
+"""Canonical profile registry mirroring portcullis ProfileRegistry.
+
+Provides the 10 built-in profiles from the Rust ``portcullis`` crate as
+Python dataclasses, with name normalization and lookup.  This lets Python
+SDK users validate and inspect profile names before sending them to the
+tool-proxy.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Dict, FrozenSet, List, Optional
+
+
+class CapabilityLevel(str, Enum):
+    """Three-level capability state matching Rust ``CapabilityLevel``."""
+
+    NEVER = "never"
+    LOW_RISK = "low_risk"
+    ALWAYS = "always"
+
+
+@dataclass(frozen=True)
+class Capabilities:
+    """Capability levels for all 12 operations."""
+
+    read_files: CapabilityLevel = CapabilityLevel.ALWAYS
+    write_files: CapabilityLevel = CapabilityLevel.LOW_RISK
+    edit_files: CapabilityLevel = CapabilityLevel.LOW_RISK
+    run_bash: CapabilityLevel = CapabilityLevel.NEVER
+    glob_search: CapabilityLevel = CapabilityLevel.ALWAYS
+    grep_search: CapabilityLevel = CapabilityLevel.ALWAYS
+    web_search: CapabilityLevel = CapabilityLevel.LOW_RISK
+    web_fetch: CapabilityLevel = CapabilityLevel.LOW_RISK
+    git_commit: CapabilityLevel = CapabilityLevel.LOW_RISK
+    git_push: CapabilityLevel = CapabilityLevel.NEVER
+    create_pr: CapabilityLevel = CapabilityLevel.LOW_RISK
+    manage_pods: CapabilityLevel = CapabilityLevel.NEVER
+
+    def allowed_operations(self) -> List[str]:
+        """Return operations that are not ``NEVER``."""
+        ops = []
+        for op in (
+            "read_files",
+            "write_files",
+            "edit_files",
+            "run_bash",
+            "glob_search",
+            "grep_search",
+            "web_search",
+            "web_fetch",
+            "git_commit",
+            "git_push",
+            "create_pr",
+            "manage_pods",
+        ):
+            if getattr(self, op) != CapabilityLevel.NEVER:
+                ops.append(op)
+        return ops
+
+    def denied_operations(self) -> List[str]:
+        """Return operations that are ``NEVER``."""
+        ops = []
+        for op in (
+            "read_files",
+            "write_files",
+            "edit_files",
+            "run_bash",
+            "glob_search",
+            "grep_search",
+            "web_search",
+            "web_fetch",
+            "git_commit",
+            "git_push",
+            "create_pr",
+            "manage_pods",
+        ):
+            if getattr(self, op) == CapabilityLevel.NEVER:
+                ops.append(op)
+        return ops
+
+
+@dataclass(frozen=True)
+class BudgetSpec:
+    """Budget limits for a profile."""
+
+    max_cost_usd: str = "5.00"
+    max_input_tokens: int = 100000
+    max_output_tokens: int = 10000
+
+
+@dataclass(frozen=True)
+class TimeSpec:
+    """Time bounds for a profile."""
+
+    duration_minutes: Optional[int] = None
+    duration_hours: Optional[int] = None
+
+
+@dataclass(frozen=True)
+class ProfileSpec:
+    """A complete profile specification mirroring the Rust ``ProfileSpec``.
+
+    Each profile fully declares capability levels, blocked paths, budget
+    limits, and time bounds.
+    """
+
+    name: str
+    description: str
+    capabilities: Capabilities
+    obligations: FrozenSet[str] = frozenset()
+    blocked_paths: FrozenSet[str] = frozenset()
+    budget: Optional[BudgetSpec] = None
+    time: Optional[TimeSpec] = None
+
+    @property
+    def trifecta_components(self) -> int:
+        """Count how many trifecta components are present.
+
+        - private_data: read_files != NEVER
+        - untrusted_content: web_search or web_fetch != NEVER
+        - exfil_vector: git_push, create_pr, or run_bash != NEVER
+
+        Returns 0-3.
+        """
+        count = 0
+        if self.capabilities.read_files != CapabilityLevel.NEVER:
+            count += 1
+        if (
+            self.capabilities.web_search != CapabilityLevel.NEVER
+            or self.capabilities.web_fetch != CapabilityLevel.NEVER
+        ):
+            count += 1
+        if (
+            self.capabilities.git_push != CapabilityLevel.NEVER
+            or self.capabilities.create_pr != CapabilityLevel.NEVER
+            or self.capabilities.run_bash != CapabilityLevel.NEVER
+        ):
+            count += 1
+        return count
+
+    @property
+    def trifecta_safe(self) -> bool:
+        """True if the trifecta can never fire (< 3 components present)."""
+        return self.trifecta_components < 3
+
+
+# Standard blocked paths shared by all canonical profiles.
+_STANDARD_BLOCKED: FrozenSet[str] = frozenset(
+    [
+        "**/.ssh/**",
+        "**/.aws/**",
+        "**/.env",
+        "**/.env.*",
+        "**/credentials*",
+        "/etc/shadow",
+        "/etc/passwd",
+    ]
+)
+
+_STANDARD_BLOCKED_SHORT: FrozenSet[str] = frozenset(
+    [
+        "**/.ssh/**",
+        "**/.aws/**",
+        "**/.env",
+        "**/.env.*",
+        "**/credentials*",
+    ]
+)
+
+# -- Canonical profiles -------------------------------------------------------
+
+SAFE_PR_FIXER = ProfileSpec(
+    name="safe-pr-fixer",
+    description="Safe PR fixer \u2014 no push, no PR creation. CI wrapper pushes.",
+    capabilities=Capabilities(
+        read_files=CapabilityLevel.ALWAYS,
+        write_files=CapabilityLevel.LOW_RISK,
+        edit_files=CapabilityLevel.LOW_RISK,
+        run_bash=CapabilityLevel.LOW_RISK,
+        glob_search=CapabilityLevel.ALWAYS,
+        grep_search=CapabilityLevel.ALWAYS,
+        web_search=CapabilityLevel.NEVER,
+        web_fetch=CapabilityLevel.LOW_RISK,
+        git_commit=CapabilityLevel.LOW_RISK,
+        git_push=CapabilityLevel.NEVER,
+        create_pr=CapabilityLevel.NEVER,
+        manage_pods=CapabilityLevel.NEVER,
+    ),
+    blocked_paths=_STANDARD_BLOCKED,
+    budget=BudgetSpec(max_cost_usd="5.00", max_input_tokens=100000, max_output_tokens=10000),
+    time=TimeSpec(duration_hours=2),
+)
+
+DOC_EDITOR = ProfileSpec(
+    name="doc-editor",
+    description="Documentation editor \u2014 read all, write docs only, no network",
+    capabilities=Capabilities(
+        read_files=CapabilityLevel.ALWAYS,
+        write_files=CapabilityLevel.LOW_RISK,
+        edit_files=CapabilityLevel.LOW_RISK,
+        run_bash=CapabilityLevel.NEVER,
+        glob_search=CapabilityLevel.ALWAYS,
+        grep_search=CapabilityLevel.ALWAYS,
+        web_search=CapabilityLevel.NEVER,
+        web_fetch=CapabilityLevel.NEVER,
+        git_commit=CapabilityLevel.LOW_RISK,
+        git_push=CapabilityLevel.NEVER,
+        create_pr=CapabilityLevel.NEVER,
+        manage_pods=CapabilityLevel.NEVER,
+    ),
+    blocked_paths=frozenset(
+        ["**/.ssh/**", "**/.aws/**", "**/.env", "**/.env.*", "**/credentials*", "/etc/shadow"]
+    ),
+    budget=BudgetSpec(max_cost_usd="2.00", max_input_tokens=50000, max_output_tokens=10000),
+    time=TimeSpec(duration_hours=1),
+)
+
+TEST_RUNNER = ProfileSpec(
+    name="test-runner",
+    description="Test runner \u2014 read source, execute tests, no source writes",
+    capabilities=Capabilities(
+        read_files=CapabilityLevel.ALWAYS,
+        write_files=CapabilityLevel.NEVER,
+        edit_files=CapabilityLevel.NEVER,
+        run_bash=CapabilityLevel.LOW_RISK,
+        glob_search=CapabilityLevel.ALWAYS,
+        grep_search=CapabilityLevel.ALWAYS,
+        web_search=CapabilityLevel.NEVER,
+        web_fetch=CapabilityLevel.NEVER,
+        git_commit=CapabilityLevel.NEVER,
+        git_push=CapabilityLevel.NEVER,
+        create_pr=CapabilityLevel.NEVER,
+        manage_pods=CapabilityLevel.NEVER,
+    ),
+    blocked_paths=_STANDARD_BLOCKED_SHORT,
+    budget=BudgetSpec(max_cost_usd="1.00", max_input_tokens=50000, max_output_tokens=5000),
+    time=TimeSpec(duration_minutes=30),
+)
+
+TRIAGE_BOT = ProfileSpec(
+    name="triage-bot",
+    description="Triage bot \u2014 read, search, fetch context. No code changes.",
+    capabilities=Capabilities(
+        read_files=CapabilityLevel.ALWAYS,
+        write_files=CapabilityLevel.NEVER,
+        edit_files=CapabilityLevel.NEVER,
+        run_bash=CapabilityLevel.NEVER,
+        glob_search=CapabilityLevel.ALWAYS,
+        grep_search=CapabilityLevel.ALWAYS,
+        web_search=CapabilityLevel.LOW_RISK,
+        web_fetch=CapabilityLevel.LOW_RISK,
+        git_commit=CapabilityLevel.NEVER,
+        git_push=CapabilityLevel.NEVER,
+        create_pr=CapabilityLevel.NEVER,
+        manage_pods=CapabilityLevel.NEVER,
+    ),
+    blocked_paths=_STANDARD_BLOCKED_SHORT,
+    budget=BudgetSpec(max_cost_usd="1.00", max_input_tokens=50000, max_output_tokens=5000),
+    time=TimeSpec(duration_minutes=30),
+)
+
+CODE_REVIEW = ProfileSpec(
+    name="code-review",
+    description="Code review \u2014 read source, search web for context, no modifications",
+    capabilities=Capabilities(
+        read_files=CapabilityLevel.ALWAYS,
+        write_files=CapabilityLevel.NEVER,
+        edit_files=CapabilityLevel.NEVER,
+        run_bash=CapabilityLevel.NEVER,
+        glob_search=CapabilityLevel.ALWAYS,
+        grep_search=CapabilityLevel.ALWAYS,
+        web_search=CapabilityLevel.LOW_RISK,
+        web_fetch=CapabilityLevel.NEVER,
+        git_commit=CapabilityLevel.NEVER,
+        git_push=CapabilityLevel.NEVER,
+        create_pr=CapabilityLevel.NEVER,
+        manage_pods=CapabilityLevel.NEVER,
+    ),
+    obligations=frozenset(["web_search"]),
+    blocked_paths=_STANDARD_BLOCKED,
+    budget=BudgetSpec(max_cost_usd="1.00", max_input_tokens=50000, max_output_tokens=5000),
+    time=TimeSpec(duration_minutes=30),
+)
+
+CODEGEN = ProfileSpec(
+    name="codegen",
+    description="Code generation \u2014 read/write/edit/run, network-isolated, no push",
+    capabilities=Capabilities(
+        read_files=CapabilityLevel.ALWAYS,
+        write_files=CapabilityLevel.LOW_RISK,
+        edit_files=CapabilityLevel.LOW_RISK,
+        run_bash=CapabilityLevel.LOW_RISK,
+        glob_search=CapabilityLevel.ALWAYS,
+        grep_search=CapabilityLevel.ALWAYS,
+        web_search=CapabilityLevel.NEVER,
+        web_fetch=CapabilityLevel.NEVER,
+        git_commit=CapabilityLevel.LOW_RISK,
+        git_push=CapabilityLevel.NEVER,
+        create_pr=CapabilityLevel.NEVER,
+        manage_pods=CapabilityLevel.NEVER,
+    ),
+    blocked_paths=_STANDARD_BLOCKED,
+    budget=BudgetSpec(max_cost_usd="5.00", max_input_tokens=100000, max_output_tokens=10000),
+    time=TimeSpec(duration_hours=1),
+)
+
+RELEASE = ProfileSpec(
+    name="release",
+    description="Release \u2014 full capabilities, approval required for push and PR",
+    capabilities=Capabilities(
+        read_files=CapabilityLevel.ALWAYS,
+        write_files=CapabilityLevel.LOW_RISK,
+        edit_files=CapabilityLevel.LOW_RISK,
+        run_bash=CapabilityLevel.LOW_RISK,
+        glob_search=CapabilityLevel.ALWAYS,
+        grep_search=CapabilityLevel.ALWAYS,
+        web_search=CapabilityLevel.LOW_RISK,
+        web_fetch=CapabilityLevel.LOW_RISK,
+        git_commit=CapabilityLevel.LOW_RISK,
+        git_push=CapabilityLevel.LOW_RISK,
+        create_pr=CapabilityLevel.LOW_RISK,
+        manage_pods=CapabilityLevel.NEVER,
+    ),
+    obligations=frozenset(["git_push", "create_pr"]),
+    blocked_paths=_STANDARD_BLOCKED,
+    budget=BudgetSpec(max_cost_usd="5.00", max_input_tokens=100000, max_output_tokens=10000),
+    time=TimeSpec(duration_hours=2),
+)
+
+RESEARCH_WEB = ProfileSpec(
+    name="research-web",
+    description="Web research \u2014 read files, search/fetch web, no writes or execution",
+    capabilities=Capabilities(
+        read_files=CapabilityLevel.LOW_RISK,
+        write_files=CapabilityLevel.NEVER,
+        edit_files=CapabilityLevel.NEVER,
+        run_bash=CapabilityLevel.NEVER,
+        glob_search=CapabilityLevel.ALWAYS,
+        grep_search=CapabilityLevel.ALWAYS,
+        web_search=CapabilityLevel.LOW_RISK,
+        web_fetch=CapabilityLevel.LOW_RISK,
+        git_commit=CapabilityLevel.NEVER,
+        git_push=CapabilityLevel.NEVER,
+        create_pr=CapabilityLevel.NEVER,
+        manage_pods=CapabilityLevel.NEVER,
+    ),
+    blocked_paths=_STANDARD_BLOCKED,
+    budget=BudgetSpec(max_cost_usd="1.50", max_input_tokens=50000, max_output_tokens=5000),
+    time=TimeSpec(duration_minutes=45),
+)
+
+READ_ONLY = ProfileSpec(
+    name="read-only",
+    description="Read only \u2014 read files and search, no writes or network",
+    capabilities=Capabilities(
+        read_files=CapabilityLevel.ALWAYS,
+        write_files=CapabilityLevel.NEVER,
+        edit_files=CapabilityLevel.NEVER,
+        run_bash=CapabilityLevel.NEVER,
+        glob_search=CapabilityLevel.ALWAYS,
+        grep_search=CapabilityLevel.ALWAYS,
+        web_search=CapabilityLevel.NEVER,
+        web_fetch=CapabilityLevel.NEVER,
+        git_commit=CapabilityLevel.NEVER,
+        git_push=CapabilityLevel.NEVER,
+        create_pr=CapabilityLevel.NEVER,
+        manage_pods=CapabilityLevel.NEVER,
+    ),
+    blocked_paths=_STANDARD_BLOCKED,
+    budget=BudgetSpec(max_cost_usd="1.00", max_input_tokens=50000, max_output_tokens=5000),
+    time=TimeSpec(duration_minutes=30),
+)
+
+LOCAL_DEV = ProfileSpec(
+    name="local-dev",
+    description="Local dev \u2014 read/write/edit/run/commit, no network, no push",
+    capabilities=Capabilities(
+        read_files=CapabilityLevel.ALWAYS,
+        write_files=CapabilityLevel.LOW_RISK,
+        edit_files=CapabilityLevel.LOW_RISK,
+        run_bash=CapabilityLevel.LOW_RISK,
+        glob_search=CapabilityLevel.ALWAYS,
+        grep_search=CapabilityLevel.ALWAYS,
+        web_search=CapabilityLevel.NEVER,
+        web_fetch=CapabilityLevel.NEVER,
+        git_commit=CapabilityLevel.LOW_RISK,
+        git_push=CapabilityLevel.NEVER,
+        create_pr=CapabilityLevel.NEVER,
+        manage_pods=CapabilityLevel.NEVER,
+    ),
+    blocked_paths=_STANDARD_BLOCKED,
+    budget=BudgetSpec(max_cost_usd="3.00", max_input_tokens=100000, max_output_tokens=10000),
+    time=TimeSpec(duration_hours=2),
+)
+
+
+class ProfileRegistry:
+    """Registry of named profiles, mirroring the Rust ``ProfileRegistry``.
+
+    Provides lookup by name with case-insensitive, hyphen/underscore-
+    normalized matching.
+    """
+
+    def __init__(self) -> None:
+        self._profiles: Dict[str, ProfileSpec] = {}
+
+    def register(self, spec: ProfileSpec) -> None:
+        """Add or replace a profile."""
+        self._profiles[self._normalize(spec.name)] = spec
+
+    def resolve(self, name: str) -> ProfileSpec:
+        """Look up a profile by name.
+
+        Raises ``KeyError`` if not found.
+        """
+        normalized = self._normalize(name)
+        if normalized not in self._profiles:
+            available = ", ".join(sorted(self.names()))
+            raise KeyError(f"unknown profile {name!r}; available: {available}")
+        return self._profiles[normalized]
+
+    def names(self) -> List[str]:
+        """Return all registered profile names (original casing)."""
+        return [p.name for p in self._profiles.values()]
+
+    def get(self, name: str) -> Optional[ProfileSpec]:
+        """Look up a profile, returning ``None`` if not found."""
+        return self._profiles.get(self._normalize(name))
+
+    def __contains__(self, name: str) -> bool:
+        return self._normalize(name) in self._profiles
+
+    def __len__(self) -> int:
+        return len(self._profiles)
+
+    @staticmethod
+    def _normalize(name: str) -> str:
+        return name.lower().replace("_", "-")
+
+    @classmethod
+    def canonical(cls) -> ProfileRegistry:
+        """Create a registry with the 10 built-in canonical profiles."""
+        registry = cls()
+        for profile in _CANONICAL_PROFILES:
+            registry.register(profile)
+        return registry
+
+
+_CANONICAL_PROFILES: List[ProfileSpec] = [
+    SAFE_PR_FIXER,
+    DOC_EDITOR,
+    TEST_RUNNER,
+    TRIAGE_BOT,
+    CODE_REVIEW,
+    CODEGEN,
+    RELEASE,
+    RESEARCH_WEB,
+    READ_ONLY,
+    LOCAL_DEV,
+]

--- a/sdk/python/nucleus_sdk/session.py
+++ b/sdk/python/nucleus_sdk/session.py
@@ -6,6 +6,7 @@ from typing import Any, Callable, Dict, Optional, TypeVar
 
 from .client import ProxyClient
 from .errors import AccessDenied, ApprovalRequired
+from .profiles import ProfileRegistry, ProfileSpec
 from .taint import TaintGuard
 from .trace import Trace
 from .tools.fs import FileHandle
@@ -35,6 +36,8 @@ class Session:
     via :attr:`trace` during and after the session lifetime.
     """
 
+    _canonical_registry: Optional[ProfileRegistry] = None
+
     def __init__(
         self,
         profile: str = "default",
@@ -42,6 +45,7 @@ class Session:
         proxy: Optional[ProxyClient] = None,
         timeout: float = 30.0,
         trifecta_enabled: bool = True,
+        validate_profile: bool = False,
     ) -> None:
         self.profile = profile
         self._proxy_url = proxy_url or os.environ.get("NUCLEUS_PROXY_URL", "")
@@ -49,6 +53,15 @@ class Session:
         self._trace = Trace()
         self._external_proxy = proxy
         self._taint_guard = TaintGuard(trifecta_enabled=trifecta_enabled)
+
+        # Resolve profile spec from canonical registry.
+        if Session._canonical_registry is None:
+            Session._canonical_registry = ProfileRegistry.canonical()
+        self._profile_spec: Optional[ProfileSpec] = (
+            Session._canonical_registry.get(profile)
+        )
+        if validate_profile and self._profile_spec is None:
+            Session._canonical_registry.resolve(profile)  # raises KeyError
 
         # These are initialised lazily in __enter__
         self._proxy: Optional[ProxyClient] = None
@@ -109,6 +122,11 @@ class Session:
     @property
     def trace(self) -> Trace:
         return self._trace
+
+    @property
+    def profile_spec(self) -> Optional[ProfileSpec]:
+        """The resolved profile spec, or ``None`` for custom profiles."""
+        return self._profile_spec
 
     @property
     def taint_summary(self) -> str:

--- a/sdk/python/tests/test_profiles.py
+++ b/sdk/python/tests/test_profiles.py
@@ -1,0 +1,306 @@
+"""Tests for the Python SDK profile registry."""
+
+from __future__ import annotations
+
+import pytest
+
+from nucleus_sdk.profiles import (
+    BudgetSpec,
+    Capabilities,
+    CapabilityLevel,
+    ProfileRegistry,
+    ProfileSpec,
+    TimeSpec,
+    SAFE_PR_FIXER,
+    DOC_EDITOR,
+    TEST_RUNNER,
+    TRIAGE_BOT,
+    CODE_REVIEW,
+    CODEGEN,
+    RELEASE,
+    RESEARCH_WEB,
+    READ_ONLY,
+    LOCAL_DEV,
+    _CANONICAL_PROFILES,
+)
+
+
+class TestCapabilityLevel:
+    def test_values(self):
+        assert CapabilityLevel.NEVER.value == "never"
+        assert CapabilityLevel.LOW_RISK.value == "low_risk"
+        assert CapabilityLevel.ALWAYS.value == "always"
+
+    def test_string_identity(self):
+        assert CapabilityLevel.NEVER == "never"
+        assert CapabilityLevel.ALWAYS == "always"
+
+
+class TestCapabilities:
+    def test_defaults_match_rust(self):
+        caps = Capabilities()
+        assert caps.read_files == CapabilityLevel.ALWAYS
+        assert caps.write_files == CapabilityLevel.LOW_RISK
+        assert caps.run_bash == CapabilityLevel.NEVER
+        assert caps.git_push == CapabilityLevel.NEVER
+        assert caps.manage_pods == CapabilityLevel.NEVER
+
+    def test_allowed_operations(self):
+        caps = Capabilities(
+            read_files=CapabilityLevel.ALWAYS,
+            write_files=CapabilityLevel.NEVER,
+            edit_files=CapabilityLevel.NEVER,
+            run_bash=CapabilityLevel.NEVER,
+            glob_search=CapabilityLevel.ALWAYS,
+            grep_search=CapabilityLevel.ALWAYS,
+            web_search=CapabilityLevel.NEVER,
+            web_fetch=CapabilityLevel.NEVER,
+            git_commit=CapabilityLevel.NEVER,
+            git_push=CapabilityLevel.NEVER,
+            create_pr=CapabilityLevel.NEVER,
+            manage_pods=CapabilityLevel.NEVER,
+        )
+        allowed = caps.allowed_operations()
+        assert allowed == ["read_files", "glob_search", "grep_search"]
+
+    def test_denied_operations(self):
+        caps = READ_ONLY.capabilities
+        denied = caps.denied_operations()
+        assert "write_files" in denied
+        assert "run_bash" in denied
+        assert "git_push" in denied
+        assert "read_files" not in denied
+
+    def test_frozen(self):
+        caps = Capabilities()
+        with pytest.raises(AttributeError):
+            caps.read_files = CapabilityLevel.NEVER  # type: ignore[misc]
+
+
+class TestProfileSpec:
+    def test_frozen(self):
+        with pytest.raises(AttributeError):
+            CODEGEN.name = "something-else"  # type: ignore[misc]
+
+    def test_trifecta_components_one(self):
+        # read-only: only private_data (read_files=always)
+        assert READ_ONLY.trifecta_components == 1
+        assert READ_ONLY.trifecta_safe is True
+
+    def test_trifecta_components_two(self):
+        # triage-bot: private_data + untrusted_content (web_fetch=low_risk)
+        assert TRIAGE_BOT.trifecta_components == 2
+        assert TRIAGE_BOT.trifecta_safe is True
+
+    def test_trifecta_components_three(self):
+        # release: all three (read + web + push)
+        assert RELEASE.trifecta_components == 3
+        assert RELEASE.trifecta_safe is False
+
+    def test_safe_pr_fixer_trifecta(self):
+        # safe-pr-fixer: private_data + untrusted (web_fetch) + exfil (run_bash)
+        assert SAFE_PR_FIXER.trifecta_components == 3
+        assert SAFE_PR_FIXER.trifecta_safe is False
+
+    def test_codegen_trifecta(self):
+        # codegen: private_data + exfil (run_bash), no untrusted
+        assert CODEGEN.trifecta_components == 2
+        assert CODEGEN.trifecta_safe is True
+
+    def test_doc_editor_trifecta(self):
+        # doc-editor: only private_data
+        assert DOC_EDITOR.trifecta_components == 1
+        assert DOC_EDITOR.trifecta_safe is True
+
+
+class TestCanonicalProfiles:
+    def test_exactly_10_canonical(self):
+        assert len(_CANONICAL_PROFILES) == 10
+
+    def test_all_have_names(self):
+        names = {p.name for p in _CANONICAL_PROFILES}
+        expected = {
+            "safe-pr-fixer",
+            "doc-editor",
+            "test-runner",
+            "triage-bot",
+            "code-review",
+            "codegen",
+            "release",
+            "research-web",
+            "read-only",
+            "local-dev",
+        }
+        assert names == expected
+
+    def test_all_have_descriptions(self):
+        for p in _CANONICAL_PROFILES:
+            assert p.description, f"{p.name} has no description"
+
+    def test_all_have_budgets(self):
+        for p in _CANONICAL_PROFILES:
+            assert p.budget is not None, f"{p.name} has no budget"
+
+    def test_all_have_time_bounds(self):
+        for p in _CANONICAL_PROFILES:
+            assert p.time is not None, f"{p.name} has no time bounds"
+            assert (
+                p.time.duration_minutes is not None or p.time.duration_hours is not None
+            ), f"{p.name} has no duration"
+
+    def test_all_block_sensitive_paths(self):
+        for p in _CANONICAL_PROFILES:
+            assert "**/.ssh/**" in p.blocked_paths, f"{p.name} doesn't block .ssh"
+            assert "**/.aws/**" in p.blocked_paths, f"{p.name} doesn't block .aws"
+            assert "**/.env" in p.blocked_paths, f"{p.name} doesn't block .env"
+
+    def test_no_profile_allows_manage_pods(self):
+        for p in _CANONICAL_PROFILES:
+            assert (
+                p.capabilities.manage_pods == CapabilityLevel.NEVER
+            ), f"{p.name} allows manage_pods"
+
+    def test_release_has_obligations(self):
+        assert "git_push" in RELEASE.obligations
+        assert "create_pr" in RELEASE.obligations
+
+    def test_code_review_has_obligations(self):
+        assert "web_search" in CODE_REVIEW.obligations
+
+
+class TestProfileRegistry:
+    def test_canonical_has_10(self):
+        registry = ProfileRegistry.canonical()
+        assert len(registry) == 10
+
+    def test_canonical_names(self):
+        registry = ProfileRegistry.canonical()
+        names = set(registry.names())
+        assert "safe-pr-fixer" in names
+        assert "codegen" in names
+        assert "release" in names
+
+    def test_resolve_exact(self):
+        registry = ProfileRegistry.canonical()
+        spec = registry.resolve("codegen")
+        assert spec.name == "codegen"
+        assert spec is CODEGEN
+
+    def test_resolve_case_insensitive(self):
+        registry = ProfileRegistry.canonical()
+        spec = registry.resolve("CODEGEN")
+        assert spec.name == "codegen"
+
+    def test_resolve_underscore_normalization(self):
+        registry = ProfileRegistry.canonical()
+        spec = registry.resolve("safe_pr_fixer")
+        assert spec.name == "safe-pr-fixer"
+
+    def test_resolve_mixed_normalization(self):
+        registry = ProfileRegistry.canonical()
+        spec = registry.resolve("Code_Review")
+        assert spec.name == "code-review"
+
+    def test_resolve_unknown_raises(self):
+        registry = ProfileRegistry.canonical()
+        with pytest.raises(KeyError, match="unknown profile"):
+            registry.resolve("nonexistent")
+
+    def test_get_returns_none(self):
+        registry = ProfileRegistry.canonical()
+        assert registry.get("nonexistent") is None
+
+    def test_get_returns_spec(self):
+        registry = ProfileRegistry.canonical()
+        spec = registry.get("release")
+        assert spec is RELEASE
+
+    def test_contains(self):
+        registry = ProfileRegistry.canonical()
+        assert "codegen" in registry
+        assert "Code_Review" in registry
+        assert "nonexistent" not in registry
+
+    def test_register_custom(self):
+        registry = ProfileRegistry.canonical()
+        custom = ProfileSpec(
+            name="custom-profile",
+            description="A custom profile",
+            capabilities=Capabilities(),
+        )
+        registry.register(custom)
+        assert len(registry) == 11
+        assert registry.resolve("custom-profile") is custom
+
+    def test_register_overrides_existing(self):
+        registry = ProfileRegistry.canonical()
+        replacement = ProfileSpec(
+            name="codegen",
+            description="Replaced codegen",
+            capabilities=Capabilities(),
+        )
+        registry.register(replacement)
+        assert len(registry) == 10
+        assert registry.resolve("codegen").description == "Replaced codegen"
+
+
+class TestSessionProfileValidation:
+    """Test Session integration with profile registry."""
+
+    def test_session_accepts_canonical_profile(self):
+        from nucleus_sdk.session import Session
+
+        s = Session(profile="codegen", validate_profile=True)
+        assert s.profile_spec is not None
+        assert s.profile_spec.name == "codegen"
+
+    def test_session_accepts_normalized_name(self):
+        from nucleus_sdk.session import Session
+
+        s = Session(profile="safe_pr_fixer", validate_profile=True)
+        assert s.profile_spec is not None
+        assert s.profile_spec.name == "safe-pr-fixer"
+
+    def test_session_rejects_unknown_when_validating(self):
+        from nucleus_sdk.session import Session
+
+        with pytest.raises(KeyError, match="unknown profile"):
+            Session(profile="nonexistent", validate_profile=True)
+
+    def test_session_allows_unknown_without_validation(self):
+        from nucleus_sdk.session import Session
+
+        s = Session(profile="custom-thing", validate_profile=False)
+        assert s.profile_spec is None
+
+    def test_session_default_no_validation(self):
+        from nucleus_sdk.session import Session
+
+        # Default validate_profile=False, so arbitrary names are allowed
+        s = Session(profile="anything-goes")
+        assert s.profile_spec is None
+
+
+class TestBudgetSpec:
+    def test_frozen(self):
+        b = BudgetSpec()
+        with pytest.raises(AttributeError):
+            b.max_cost_usd = "99.99"  # type: ignore[misc]
+
+    def test_defaults(self):
+        b = BudgetSpec()
+        assert b.max_cost_usd == "5.00"
+        assert b.max_input_tokens == 100000
+        assert b.max_output_tokens == 10000
+
+
+class TestTimeSpec:
+    def test_minutes(self):
+        t = TimeSpec(duration_minutes=30)
+        assert t.duration_minutes == 30
+        assert t.duration_hours is None
+
+    def test_hours(self):
+        t = TimeSpec(duration_hours=2)
+        assert t.duration_hours == 2
+        assert t.duration_minutes is None


### PR DESCRIPTION
## Summary
- Add `ProfileRegistry` to Python SDK mirroring Rust `portcullis::ProfileRegistry`
- All 10 canonical profiles defined as frozen dataclasses: safe-pr-fixer, doc-editor, test-runner, triage-bot, code-review, codegen, release, research-web, read-only, local-dev
- Each profile includes capabilities (12 operations), blocked paths, budget limits, time bounds, and obligations
- `CapabilityLevel` enum (Never/LowRisk/Always) matches Rust 3-level capability states
- `ProfileSpec.trifecta_components` and `trifecta_safe` for safety analysis
- Case-insensitive, hyphen/underscore-normalized name lookup (matching Rust behavior)
- Session gains `validate_profile` parameter and `profile_spec` property
- 43 new tests, all 159 SDK tests pass

## Test plan
- [x] All 43 new profile registry tests pass
- [x] All 116 existing SDK tests pass (no regressions)
- [x] All Rust tests pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.ai/code)