### PR TITLE
feat(cli): add --prompt flag for non-interactive nucleus shell

### DIFF
--- a/crates/nucleus-cli/src/shell.rs
+++ b/crates/nucleus-cli/src/shell.rs
@@ -342,7 +342,9 @@ fn build_shell_pod_spec(
 fn resolve_binary_path(path: &str) -> Result<PathBuf> {
     let candidate = PathBuf::from(path);
     if candidate.exists() {
-        return Ok(candidate);
+        return candidate
+            .canonicalize()
+            .context("failed to canonicalize binary path");
     }
 
     if !candidate.is_absolute()


### PR DESCRIPTION
## Summary
- Add `-P / --prompt` flag to `nucleus shell` for single-shot, non-interactive mode
- When set, runs `claude -p <prompt> --output-format json` instead of launching interactive session
- No TTY required — works from within Claude Code for sandboxed sub-sessions
- Enables patterns like: testing dangerous operations under a restricted profile from a parent session

## Test plan
- [x] `nucleus shell --prompt "list files" --profile code_review` returns JSON result
- [x] Write attempts denied under code_review profile (no write tools exposed)
- [x] Pre-commit hooks pass (fmt, clippy, deny, audit)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)