### PR TITLE
feat: PolicyManifest TOML + Ed25519 witness signing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1105,12 +1105,15 @@ dependencies = [
 name = "ck-types"
 version = "1.0.0"
 dependencies = [
+ "base64",
  "blake3",
  "chrono",
  "pretty_assertions",
+ "ring",
  "serde",
  "serde_json",
  "serde_yaml",
+ "toml 0.8.23",
 ]
 
 [[package]]
@@ -2858,7 +2861,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
- "toml",
+ "toml 1.0.6+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
  "ureq",
@@ -3349,7 +3352,7 @@ dependencies = [
  "shell-words",
  "tempfile",
  "tokio",
- "toml",
+ "toml 1.0.6+spec-1.1.0",
  "tracing",
  "uuid",
 ]
@@ -3404,7 +3407,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.23.10+spec-1.0.0",
 ]
 
 [[package]]
@@ -4425,6 +4428,15 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
@@ -5001,17 +5013,38 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
 version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "399b1124a3c9e16766831c6bba21e50192572cdd98706ea114f9502509686ffc"
 dependencies = [
  "indexmap",
  "serde_core",
- "serde_spanned",
+ "serde_spanned 1.0.4",
  "toml_datetime 1.0.0+spec-1.1.0",
  "toml_parser",
  "toml_writer",
  "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -5034,6 +5067,20 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
@@ -5052,6 +5099,12 @@ checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
 dependencies = [
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"

--- a/crates/ck-types/Cargo.toml
+++ b/crates/ck-types/Cargo.toml
@@ -6,11 +6,14 @@ edition.workspace = true
 license = "MIT"
 
 [dependencies]
+base64 = { workspace = true }
 blake3 = "1"
 chrono = { version = "0.4", features = ["serde"] }
+ring = { workspace = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
+toml = "0.8"
 
 [dev-dependencies]
 pretty_assertions = "1"

--- a/crates/ck-types/src/lib.rs
+++ b/crates/ck-types/src/lib.rs
@@ -17,7 +17,7 @@ pub use digest::ArtifactDigest;
 pub use manifest::{
     AmendmentRules, BudgetBounds, CapabilitySet, IoSurface, PolicyManifest, ProofRequirements,
 };
-pub use witness::WitnessBundle;
+pub use witness::{SignatureVerifier, WitnessBundle};
 
 /// Classification of self-modification by danger level.
 ///

--- a/crates/ck-types/src/manifest.rs
+++ b/crates/ck-types/src/manifest.rs
@@ -32,6 +32,16 @@ impl PolicyManifest {
         let canonical = serde_json::to_vec(self).expect("PolicyManifest is always serializable");
         ArtifactDigest::from_bytes(&canonical)
     }
+
+    /// Deserialize from a TOML string (e.g., `PolicyManifest.toml`).
+    pub fn from_toml(s: &str) -> Result<Self, toml::de::Error> {
+        toml::from_str(s)
+    }
+
+    /// Serialize to a canonical TOML string.
+    pub fn to_toml(&self) -> String {
+        toml::to_string_pretty(self).expect("PolicyManifest is always serializable")
+    }
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -457,5 +467,59 @@ mod tests {
         let d1 = m.digest();
         let d2 = m.digest();
         assert_eq!(d1, d2);
+    }
+
+    #[test]
+    fn test_toml_roundtrip() {
+        let original = PolicyManifest {
+            version: 1,
+            capabilities: base_capabilities(),
+            io_surface: IoSurface {
+                outbound_domains: ["api.github.com".into()].into(),
+                local_file_roots: ["/workspace".into()].into(),
+                env_vars_readable: ["HOME".into()].into(),
+                tool_namespaces: BTreeSet::new(),
+                repo_write_targets: BTreeSet::new(),
+            },
+            budget_bounds: BudgetBounds {
+                max_tokens: 200_000,
+                max_wall_ms: 1_800_000,
+                max_cpu_ms: 1_200_000,
+                max_memory_bytes: 4_000_000_000,
+                max_network_calls: 200,
+                max_files_touched: 50,
+                max_dollar_spend_millicents: 500_000,
+                max_patch_attempts: 3,
+            },
+            proof_requirements: ProofRequirements {
+                config_patch: ["build_pass".into(), "tests_pass".into()].into(),
+                controller_patch: ["build_pass".into(), "kani_pass".into()].into(),
+                evaluator_patch: ["build_pass".into()].into(),
+            },
+            amendment_rules: AmendmentRules {
+                may_modify: ["controller_code".into()].into(),
+                may_not_modify: ["kernel_checker".into()].into(),
+                require_monotone_capabilities: true,
+                require_monotone_io: true,
+                require_monotone_proofreq: true,
+                constitutional_human_signatures: 2,
+            },
+        };
+
+        let toml_str = original.to_toml();
+        let parsed = PolicyManifest::from_toml(&toml_str).unwrap();
+        assert_eq!(original, parsed);
+    }
+
+    #[test]
+    fn test_from_toml_rejects_invalid() {
+        let result = PolicyManifest::from_toml("not valid toml {{{");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_from_toml_rejects_missing_fields() {
+        let result = PolicyManifest::from_toml("[capabilities]\nmax_parallel_tasks = 4\n");
+        assert!(result.is_err());
     }
 }

--- a/crates/ck-types/src/witness.rs
+++ b/crates/ck-types/src/witness.rs
@@ -36,6 +36,17 @@ impl WitnessBundle {
         ArtifactDigest::from_bytes(&canonical)
     }
 
+    /// Compute the canonical signing payload.
+    ///
+    /// This is the deterministic JSON serialization of the bundle with the
+    /// `signatures` field set to an empty array. BTreeSet/BTreeMap ordering
+    /// guarantees determinism.
+    pub fn signing_payload(&self) -> Vec<u8> {
+        let mut for_signing = self.clone();
+        for_signing.signatures = vec![];
+        serde_json::to_vec(&for_signing).expect("WitnessBundle is always serializable")
+    }
+
     /// Check structural completeness: are all required fields present?
     pub fn is_structurally_complete(&self) -> Result<(), Vec<String>> {
         let mut missing = Vec::new();
@@ -49,6 +60,88 @@ impl WitnessBundle {
             Ok(())
         } else {
             Err(missing)
+        }
+    }
+}
+
+/// Verifies Ed25519 signatures on witness bundles.
+///
+/// Holds a set of trusted public keys keyed by signer name.
+/// At least one valid signature from a trusted signer is required.
+pub struct SignatureVerifier {
+    /// Map of signer name → Ed25519 public key bytes (32 bytes).
+    trusted_keys: Vec<(String, Vec<u8>)>,
+}
+
+impl SignatureVerifier {
+    /// Create a verifier with the given trusted public keys.
+    pub fn new(trusted_keys: Vec<(String, Vec<u8>)>) -> Self {
+        Self { trusted_keys }
+    }
+
+    /// Verify that the bundle has at least one valid Ed25519 signature
+    /// from a trusted signer.
+    pub fn verify(&self, bundle: &WitnessBundle) -> Result<(), Vec<String>> {
+        if self.trusted_keys.is_empty() {
+            return Ok(()); // no trusted keys configured = skip verification
+        }
+
+        let payload = bundle.signing_payload();
+        let mut errors = Vec::new();
+        let mut valid_count = 0;
+
+        for sig in &bundle.signatures {
+            if sig.algorithm != "ed25519" {
+                errors.push(format!(
+                    "Signer '{}': unsupported algorithm '{}'",
+                    sig.signer, sig.algorithm
+                ));
+                continue;
+            }
+
+            let trusted_key = self
+                .trusted_keys
+                .iter()
+                .find(|(name, _)| name == &sig.signer);
+
+            let Some((_, pub_key_bytes)) = trusted_key else {
+                errors.push(format!("Signer '{}': not in trusted key set", sig.signer));
+                continue;
+            };
+
+            let sig_bytes = match base64::Engine::decode(
+                &base64::engine::general_purpose::STANDARD,
+                &sig.signature,
+            ) {
+                Ok(b) => b,
+                Err(e) => {
+                    errors.push(format!(
+                        "Signer '{}': base64 decode failed: {}",
+                        sig.signer, e
+                    ));
+                    continue;
+                }
+            };
+
+            let public_key =
+                ring::signature::UnparsedPublicKey::new(&ring::signature::ED25519, pub_key_bytes);
+
+            match public_key.verify(&payload, &sig_bytes) {
+                Ok(()) => valid_count += 1,
+                Err(_) => {
+                    errors.push(format!(
+                        "Signer '{}': Ed25519 signature verification failed",
+                        sig.signer
+                    ));
+                }
+            }
+        }
+
+        if valid_count > 0 {
+            Ok(())
+        } else {
+            errors.push("No valid signatures from trusted signers".into());
+            Err(errors)
         }
     }
 }
@@ -264,5 +357,108 @@ mod tests {
             violated_invariants: vec![ConstitutionalInvariant::CapabilityNonEscalation],
         };
         assert!(!diff.is_clean());
+    }
+
+    fn sign_bundle(
+        bundle: &WitnessBundle,
+        key_pair: &ring::signature::Ed25519KeyPair,
+    ) -> BundleSignature {
+        use base64::Engine;
+        let payload = bundle.signing_payload();
+        let sig = key_pair.sign(&payload);
+        BundleSignature {
+            signer: "test-ci".into(),
+            algorithm: "ed25519".into(),
+            signature: base64::engine::general_purpose::STANDARD.encode(sig.as_ref()),
+        }
+    }
+
+    fn test_keypair() -> (ring::signature::Ed25519KeyPair, Vec<u8>) {
+        use ring::signature::KeyPair;
+        let rng = ring::rand::SystemRandom::new();
+        let seed = ring::signature::Ed25519KeyPair::generate_pkcs8(&rng).unwrap();
+        let key_pair = ring::signature::Ed25519KeyPair::from_pkcs8(seed.as_ref()).unwrap();
+        let pub_key = key_pair.public_key().as_ref().to_vec();
+        (key_pair, pub_key)
+    }
+
+    #[test]
+    fn test_sign_and_verify_roundtrip() {
+        let (key_pair, pub_key) = test_keypair();
+        let mut bundle = test_bundle();
+        bundle.signatures = vec![sign_bundle(&bundle, &key_pair)];
+
+        let verifier = SignatureVerifier::new(vec![("test-ci".into(), pub_key)]);
+        assert!(verifier.verify(&bundle).is_ok());
+    }
+
+    #[test]
+    fn test_reject_tampered_bundle() {
+        let (key_pair, pub_key) = test_keypair();
+        let mut bundle = test_bundle();
+        bundle.signatures = vec![sign_bundle(&bundle, &key_pair)];
+
+        // Tamper with the bundle after signing
+        bundle.bundle_version = 999;
+
+        let verifier = SignatureVerifier::new(vec![("test-ci".into(), pub_key)]);
+        assert!(verifier.verify(&bundle).is_err());
+    }
+
+    #[test]
+    fn test_reject_wrong_key() {
+        let (key_pair, _pub_key) = test_keypair();
+        let (_other_pair, other_pub_key) = test_keypair();
+
+        let mut bundle = test_bundle();
+        bundle.signatures = vec![sign_bundle(&bundle, &key_pair)];
+
+        // Verify with a different key
+        let verifier = SignatureVerifier::new(vec![("test-ci".into(), other_pub_key)]);
+        assert!(verifier.verify(&bundle).is_err());
+    }
+
+    #[test]
+    fn test_reject_unsigned_algorithm_none() {
+        let bundle = test_bundle(); // has algorithm: "ed25519" in test fixture
+        let mut unsigned = bundle;
+        unsigned.signatures = vec![BundleSignature {
+            signer: "test".into(),
+            algorithm: "none".into(),
+            signature: "unsigned".into(),
+        }];
+
+        let (_, pub_key) = test_keypair();
+        let verifier = SignatureVerifier::new(vec![("test".into(), pub_key)]);
+        assert!(verifier.verify(&unsigned).is_err());
+    }
+
+    #[test]
+    fn test_empty_trusted_keys_skips_verification() {
+        let bundle = test_bundle();
+        let verifier = SignatureVerifier::new(vec![]);
+        assert!(verifier.verify(&bundle).is_ok());
+    }
+
+    #[test]
+    fn test_signing_payload_deterministic() {
+        let bundle = test_bundle();
+        let p1 = bundle.signing_payload();
+        let p2 = bundle.signing_payload();
+        assert_eq!(p1, p2);
+    }
+
+    #[test]
+    fn test_signing_payload_excludes_signatures() {
+        let mut bundle = test_bundle();
+        let payload_with_sigs = bundle.signing_payload();
+        bundle.signatures = vec![BundleSignature {
+            signer: "extra".into(),
+            algorithm: "ed25519".into(),
+            signature: "deadbeef".into(),
+        }];
+        let payload_different_sigs = bundle.signing_payload();
+        // Payload should be identical regardless of signatures content
+        assert_eq!(payload_with_sigs, payload_different_sigs);
     }
 }


### PR DESCRIPTION
## Summary
- Add `PolicyManifest::from_toml()`/`to_toml()` for artifact-bound policy extraction from candidate commits
- Add `SignatureVerifier` with Ed25519 verification via `ring::signature`
- Add `WitnessBundle::signing_payload()` for deterministic canonical JSON signing
- Add `toml`, `ring`, `base64` dependencies to ck-types

## Test plan
- [x] `test_toml_roundtrip` — from_toml(to_toml(default)) == default
- [x] `test_sign_and_verify_roundtrip` — Ed25519 sign then verify
- [x] `test_reject_tampered_bundle` — tampered payload fails verification
- [x] `test_reject_wrong_key` — wrong public key fails verification
- [x] `test_signing_payload_excludes_signatures` — signatures field not in payload
- [x] 30 total tests pass across ck-types

🤖 Generated with [Claude Code](https://claude.com/claude-code)