### PR TITLE
fix: v1_content_hash commits exposure labels + risk tier

### DIFF
--- a/crates/nucleus-node/src/main.rs
+++ b/crates/nucleus-node/src/main.rs
@@ -2762,6 +2762,13 @@ impl NodeService for GrpcService {
             hasher.update(report.audit_entry_count.to_le_bytes());
             hasher.update(report.timestamp_unix.to_le_bytes());
             hasher.update(manifest_hash.as_bytes());
+            // Commit exposure labels into the hash — without this, the hash
+            // can be valid while the labels are tampered with, defeating the
+            // content-hash binding that the SandboxAttested upgrade path relies on.
+            for label in &report.observed_exposure_labels {
+                hasher.update(label.as_bytes());
+            }
+            hasher.update(report.observed_risk_tier.as_bytes());
             format!("{:x}", hasher.finalize())
         };
 


### PR DESCRIPTION
## Summary
The content hash now includes `observed_exposure_labels` and `observed_risk_tier` in the SHA-256 computation, preventing label tampering without hash invalidation.

## The gap (from adversarial loop)
> "The v1_content_hash does not commit to exposure labels, completely invalidating the claimed tamper-detection binding. An attacker could substitute labels (e.g., ["Safe"] instead of ["NetworkEgress"]) without invalidating the hash."

This was the one gap the adversarial loop couldn't close in 3 attempts — it needed a one-line architectural fix in `main.rs`, not a patch in `trust_gate.rs`.

## Change
Added 4 lines to the `v1_content_hash` computation block: iterate over exposure labels and hash the risk tier string.

## Test plan
- [x] cargo test passes
- [x] cargo clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)