### PR TITLE
fix: add merge_group trigger to unblock merge queue

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -8,6 +8,7 @@ on:
       - Cargo.toml
       - crates/**/Cargo.toml
   pull_request:
+  merge_group:
   schedule:
     - cron: "0 6 * * 1"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: ["main"]
   pull_request:
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/coverage-matrix.yml
+++ b/.github/workflows/coverage-matrix.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: ["main"]
   pull_request:
+  merge_group:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -9,6 +9,7 @@ on:
       - crates/**/Cargo.toml
       - deny.toml
   pull_request:
+  merge_group:
   schedule:
     - cron: "0 7 * * 1"
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  merge_group:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
The merge queue was enabled but none of the CI workflows had the `merge_group` trigger. PRs were queued but CI never ran on the merge-group branches, so checks never passed and PRs sat in limbo.

## Change
Added `merge_group:` to the `on:` block of all 5 workflows that produce the 12 required status checks:
- `ci.yml` (Clippy, Tests, Rustfmt, Fuzz, OWASP, Mutation Testing)
- `coverage-matrix.yml` (Code Coverage)
- `audit.yml` (audit)
- `deny.yml` (deny advisories/bans/licenses/sources)
- `scan.yml` (Scan PodSpecs)

## Impact
This unblocks 5 PRs currently stuck in the merge queue (#285, #284, #277, #274, #272).

🤖 Generated with [Claude Code](https://claude.com/claude-code)