### PR TITLE
fix: SignatureVerifier requires distinct keys per role (#292)

### DIFF
--- a/crates/ck-types/src/witness.rs
+++ b/crates/ck-types/src/witness.rs
@@ -125,6 +125,9 @@ impl SignatureVerifier {
         let mut errors = Vec::new();
         let mut valid_roles = std::collections::HashSet::new();
         let mut valid_count = 0;
+        // Track distinct public keys used for valid signatures.
+        // Role separation requires distinct keys — one key can't satisfy multiple roles.
+        let mut distinct_keys = std::collections::HashSet::<Vec<u8>>::new();
 
         for sig in &bundle.signatures {
             if sig.algorithm != "ed25519" {
@@ -165,6 +168,7 @@ impl SignatureVerifier {
             match public_key.verify(&payload, &sig_bytes) {
                 Ok(()) => {
                     valid_count += 1;
+                    distinct_keys.insert(pub_key_bytes.clone());
                     if let Some(role) = sig.role {
                         valid_roles.insert(role);
                     }
@@ -187,6 +191,19 @@ impl SignatureVerifier {
                 .collect();
             if !missing.is_empty() {
                 errors.push(format!("Missing required role signatures: {:?}", missing));
+                return Err(errors);
+            }
+
+            // Distinct key check: a single key registered under multiple signer
+            // names must not satisfy multiple required roles. The number of
+            // distinct public keys must be >= the number of required roles.
+            if distinct_keys.len() < self.required_roles.len() {
+                errors.push(format!(
+                    "Role separation violation: {} required roles but only {} distinct \
+                     signing keys used. Each role must be signed by a different key.",
+                    self.required_roles.len(),
+                    distinct_keys.len()
+                ));
                 return Err(errors);
             }
         }


### PR DESCRIPTION
Role separation: distinct_keys.len() must be >= required_roles.len(). Found by adversarial-drive.