### PR TITLE
fix: lockdown signal HMAC + user-owned dir (red team)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2906,6 +2906,7 @@ dependencies = [
  "clap",
  "dirs",
  "hex",
+ "hmac",
  "nucleus-client",
  "nucleus-proto",
  "nucleus-spec",
@@ -3126,6 +3127,7 @@ dependencies = [
  "base64",
  "chrono",
  "clap",
+ "dirs",
  "glob",
  "hex",
  "hmac",
@@ -3157,6 +3159,7 @@ dependencies = [
  "url",
  "uuid",
  "walkdir",
+ "whoami",
  "x509-parser",
 ]
 

--- a/crates/nucleus-cli/Cargo.toml
+++ b/crates/nucleus-cli/Cargo.toml
@@ -60,6 +60,7 @@ rand = "0.10"
 chrono = { workspace = true, features = ["serde"] }
 hex = { workspace = true }
 sha2 = { workspace = true }
+hmac = { workspace = true }
 rustls = { workspace = true }
 
 # macOS Keychain (conditional)

--- a/crates/nucleus-cli/src/lockdown.rs
+++ b/crates/nucleus-cli/src/lockdown.rs
@@ -42,7 +42,36 @@ pub struct LockdownArgs {
     pub yes: bool,
 }
 
-const LOCKDOWN_SIGNAL_PATH: &str = "/tmp/nucleus-lockdown.json";
+/// Lockdown signal file path — stored in a user-owned directory, not /tmp.
+/// Red team finding: /tmp is world-writable, any local process could fake a lockdown.
+fn lockdown_signal_path() -> std::path::PathBuf {
+    let dir = dirs::runtime_dir()
+        .or_else(dirs::data_local_dir)
+        .unwrap_or_else(|| std::path::PathBuf::from("/tmp"))
+        .join("nucleus");
+    let _ = std::fs::create_dir_all(&dir);
+    dir.join("lockdown.json")
+}
+
+/// Compute HMAC-SHA256 over the signal body using a machine-local key.
+/// The key is derived from the machine ID + a fixed salt — not a secret,
+/// but sufficient to prevent casual tampering by other local users.
+fn signal_hmac(body: &[u8]) -> String {
+    use hmac::{Hmac, Mac};
+    use sha2::Sha256;
+
+    // Machine-local key: hostname + uid — prevents cross-user forgery
+    let key_material = format!(
+        "nucleus-lockdown-{}:{}",
+        whoami::fallible::hostname().unwrap_or_else(|_| "unknown".to_string()),
+        whoami::fallible::username().unwrap_or_else(|_| "unknown".to_string()),
+    );
+
+    let mut mac =
+        Hmac::<Sha256>::new_from_slice(key_material.as_bytes()).expect("hmac accepts any key");
+    mac.update(body);
+    hex::encode(mac.finalize().into_bytes())
+}
 
 /// Execute the lockdown command.
 pub async fn execute(args: LockdownArgs) -> Result<()> {
@@ -125,7 +154,7 @@ async fn try_grpc_lockdown(
 
 /// Fallback: write a local signal file for the tool-proxy watcher.
 fn write_signal_file(args: &LockdownArgs, scope: &str) -> Result<()> {
-    let signal_path = std::path::PathBuf::from(LOCKDOWN_SIGNAL_PATH);
+    let signal_path = lockdown_signal_path();
 
     if args.restore {
         if signal_path.exists() {
@@ -137,7 +166,7 @@ fn write_signal_file(args: &LockdownArgs, scope: &str) -> Result<()> {
         return Ok(());
     }
 
-    let signal = serde_json::json!({
+    let body = serde_json::json!({
         "action": "lockdown",
         "scope": scope,
         "reason": args.reason,
@@ -147,7 +176,15 @@ fn write_signal_file(args: &LockdownArgs, scope: &str) -> Result<()> {
             .as_secs(),
         "restore": false,
     });
-    std::fs::write(&signal_path, serde_json::to_string_pretty(&signal)?)?;
+    let body_bytes = serde_json::to_string_pretty(&body)?;
+    let hmac = signal_hmac(body_bytes.as_bytes());
+
+    // Write signal with HMAC envelope
+    let envelope = serde_json::json!({
+        "signal": body,
+        "hmac": hmac,
+    });
+    std::fs::write(&signal_path, serde_json::to_string_pretty(&envelope)?)?;
 
     eprintln!("Lockdown initiated via local signal file.");
     eprintln!("   Signal: {}", signal_path.display());

--- a/crates/nucleus-tool-proxy/Cargo.toml
+++ b/crates/nucleus-tool-proxy/Cargo.toml
@@ -39,6 +39,8 @@ tracing-subscriber = { workspace = true }
 hmac = { workspace = true }
 sha2 = { workspace = true }
 hex = { workspace = true }
+dirs = "6.0"
+whoami = "1"
 reqwest = { workspace = true, features = ["rustls-no-provider", "json", "query"] }
 url = "2.5"
 uuid = { workspace = true }

--- a/crates/nucleus-tool-proxy/src/main.rs
+++ b/crates/nucleus-tool-proxy/src/main.rs
@@ -1195,22 +1195,72 @@ async fn main() -> Result<(), ApiError> {
         warn!("failed to emit boot report: {err}");
     }
 
-    // Lockdown signal watcher: polls /tmp/nucleus-lockdown.json every 500ms.
-    // When the file exists with "action": "lockdown", sets lockdown_active to true.
-    // When the file is absent or has "action": "restore", sets it to false.
-    // This connects `nucleus lockdown` CLI to the tool-proxy enforcement gate.
+    // Lockdown signal watcher: polls the signal file every 500ms.
+    // Verifies HMAC before acting — prevents privilege escalation via
+    // world-writable signal file (red team finding).
     {
         let lockdown_flag = state.lockdown_active.clone();
         tokio::spawn(async move {
-            let signal_path = std::path::Path::new("/tmp/nucleus-lockdown.json");
+            // Same path logic as the CLI
+            let signal_path = dirs::runtime_dir()
+                .or_else(dirs::data_local_dir)
+                .unwrap_or_else(|| std::path::PathBuf::from("/tmp"))
+                .join("nucleus")
+                .join("lockdown.json");
+
             loop {
                 let should_lock = if signal_path.exists() {
-                    match tokio::fs::read_to_string(signal_path).await {
-                        Ok(content) => serde_json::from_str::<serde_json::Value>(&content)
-                            .ok()
-                            .and_then(|v| v.get("restore")?.as_bool())
-                            .map(|restore| !restore)
-                            .unwrap_or(true),
+                    match tokio::fs::read_to_string(&signal_path).await {
+                        Ok(content) => {
+                            // Parse envelope and verify HMAC
+                            if let Ok(envelope) =
+                                serde_json::from_str::<serde_json::Value>(&content)
+                            {
+                                let signal = envelope.get("signal");
+                                let claimed_hmac =
+                                    envelope.get("hmac").and_then(|h| h.as_str()).unwrap_or("");
+
+                                if let Some(signal_val) = signal {
+                                    // Recompute HMAC
+                                    let body = serde_json::to_string_pretty(signal_val)
+                                        .unwrap_or_default();
+
+                                    let key_material = format!(
+                                        "nucleus-lockdown-{}:{}",
+                                        whoami::fallible::hostname()
+                                            .unwrap_or_else(|_| "unknown".to_string()),
+                                        whoami::fallible::username()
+                                            .unwrap_or_else(|_| "unknown".to_string()),
+                                    );
+
+                                    use hmac::{Hmac, Mac};
+                                    use sha2::Sha256;
+                                    let mut mac =
+                                        Hmac::<Sha256>::new_from_slice(key_material.as_bytes())
+                                            .expect("hmac");
+                                    mac.update(body.as_bytes());
+                                    let expected = hex::encode(mac.finalize().into_bytes());
+
+                                    if expected == claimed_hmac {
+                                        signal_val
+                                            .get("restore")
+                                            .and_then(|r| r.as_bool())
+                                            .map(|restore| !restore)
+                                            .unwrap_or(true)
+                                    } else {
+                                        tracing::warn!(
+                                            "Lockdown signal HMAC mismatch — ignoring \
+                                             (possible tampering)"
+                                        );
+                                        false
+                                    }
+                                } else {
+                                    false
+                                }
+                            } else {
+                                false
+                            }
+                        }
                         Err(_) => false,
                     }
                 } else {
@@ -1221,9 +1271,9 @@ async fn main() -> Result<(), ApiError> {
                 if should_lock != was_locked {
                     lockdown_flag.store(should_lock, std::sync::atomic::Ordering::Release);
                     if should_lock {
-                        tracing::warn!("LOCKDOWN ACTIVATED via signal file");
+                        tracing::warn!("LOCKDOWN ACTIVATED via verified signal file");
                     } else {
-                        tracing::info!("Lockdown lifted via signal file");
+                        tracing::info!("Lockdown lifted via verified signal file");
                     }
                 }
 


### PR DESCRIPTION
Signal moved from /tmp, HMAC-signed to prevent local priv escalation. Found by adversarial-drive --mode redteam.