### PR TITLE
feat: wire OTLP permission telemetry into every tool call verdict

### DIFF
--- a/crates/nucleus-tool-proxy/src/main.rs
+++ b/crates/nucleus-tool-proxy/src/main.rs
@@ -285,6 +285,10 @@ pub(crate) struct AppState {
     /// ExecutionBlocked. Checked on every tool invocation before permission
     /// evaluation. Set via the lockdown signal file or gRPC Lockdown RPC.
     lockdown_active: Arc<std::sync::atomic::AtomicBool>,
+    /// SHA-256 checksum of the permission lattice for telemetry correlation.
+    policy_checksum: String,
+    /// Session ID (policy UUID) for telemetry grouping.
+    session_id: String,
 }
 
 #[derive(Default)]
@@ -948,10 +952,23 @@ async fn main() -> Result<(), ApiError> {
     // Install rustls crypto provider before any TLS connections (web_fetch, etc.).
     let _ = rustls::crypto::ring::default_provider().install_default();
 
-    tracing_subscriber::fmt()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-        .json()
-        .init();
+    {
+        use tracing_subscriber::prelude::*;
+
+        #[cfg(feature = "otel")]
+        let otel_layer = telemetry::init_otel_layer();
+        #[cfg(not(feature = "otel"))]
+        let otel_layer: Option<tracing_subscriber::layer::Identity> = None;
+
+        tracing_subscriber::registry()
+            .with(otel_layer)
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .json()
+                    .with_filter(tracing_subscriber::EnvFilter::from_default_env()),
+            )
+            .init();
+    }
 
     let args = Args::parse();
 
@@ -1164,6 +1181,9 @@ async fn main() -> Result<(), ApiError> {
         creds
     };
 
+    let policy_checksum = runtime.policy().checksum();
+    let session_id = runtime.policy().id.to_string();
+
     let state = AppState {
         runtime: Arc::new(runtime),
         approvals,
@@ -1190,6 +1210,8 @@ async fn main() -> Result<(), ApiError> {
             .map(Arc::new),
         exposure_guard: Arc::new(std::sync::RwLock::new(None)),
         lockdown_active: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        policy_checksum,
+        session_id,
     };
 
     if let Err(err) = emit_boot_report(&state).await {
@@ -3746,6 +3768,19 @@ async fn audit_event_with_context(
     result: &str,
     ctx: AuditContext,
 ) -> Result<(), ApiError> {
+    telemetry::emit_verdict(
+        event,
+        subject,
+        result,
+        &state.runtime.policy().capabilities,
+        &state.exposure_guard,
+        state
+            .lockdown_active
+            .load(std::sync::atomic::Ordering::Acquire),
+        &state.policy_checksum,
+        ctx.spiffe_id.as_deref(),
+        &state.session_id,
+    );
     let actor = headers
         .get("x-nucleus-actor")
         .and_then(|v| v.to_str().ok())

--- a/crates/nucleus-tool-proxy/src/telemetry.rs
+++ b/crates/nucleus-tool-proxy/src/telemetry.rs
@@ -6,6 +6,65 @@
 //!
 //! Enable with `--features otel` and set `OTEL_EXPORTER_OTLP_ENDPOINT`.
 
+use std::sync::Arc;
+
+/// Emit a tool call verdict from the converged audit point.
+///
+/// Parses the result string to extract verdict (allow/deny) and deny reason,
+/// reads capability levels and exposure state, then delegates to `record_verdict`.
+#[allow(clippy::too_many_arguments)]
+pub fn emit_verdict(
+    operation: &str,
+    subject: &str,
+    result: &str,
+    capabilities: &portcullis::CapabilityLattice,
+    exposure_guard: &std::sync::RwLock<Option<Arc<portcullis::GradedExposureGuard>>>,
+    lockdown_active: bool,
+    lattice_checksum: &str,
+    agent_identity: Option<&str>,
+    session_id: &str,
+) {
+    let (verdict, deny_reason) = if let Some(reason) = result.strip_prefix("denied:") {
+        ("deny", Some(reason))
+    } else {
+        ("allow", None)
+    };
+    let caps = VerdictCapabilities::from(capabilities);
+    let exposure = if let Ok(guard_opt) = exposure_guard.read() {
+        if let Some(ref guard) = *guard_opt {
+            let exp = guard.exposure();
+            VerdictExposure {
+                private_data: exp.contains(portcullis::guard::ExposureLabel::PrivateData),
+                untrusted_content: exp.contains(portcullis::guard::ExposureLabel::UntrustedContent),
+                exfil_vector: exp.contains(portcullis::guard::ExposureLabel::ExfilVector),
+                is_uninhabitable: exp.is_uninhabitable(),
+            }
+        } else {
+            VerdictExposure::default()
+        }
+    } else {
+        tracing::error!("exposure_guard RwLock poisoned — reporting uninhabitable");
+        VerdictExposure {
+            private_data: true,
+            untrusted_content: true,
+            exfil_vector: true,
+            is_uninhabitable: true,
+        }
+    };
+    record_verdict(
+        operation,
+        subject,
+        verdict,
+        deny_reason,
+        &caps,
+        &exposure,
+        lattice_checksum,
+        agent_identity,
+        session_id,
+        lockdown_active,
+    );
+}
+
 /// Record a tool call verdict as a tracing event with structured attributes.
 ///
 /// This function emits a tracing event (not a span) with all permission
@@ -14,8 +73,8 @@
 ///
 /// Without the `otel` feature, this still emits structured JSON via the
 /// standard `tracing` subscriber — useful for local debugging and JSONL logs.
-#[allow(dead_code, clippy::too_many_arguments)]
-pub fn record_verdict(
+#[allow(clippy::too_many_arguments)]
+fn record_verdict(
     operation: &str,
     subject: &str,
     verdict: &str,
@@ -54,7 +113,6 @@ pub fn record_verdict(
 
 /// Flattened capability levels for telemetry emission.
 /// Uses u8 values (0=Never, 1=LowRisk, 2=Always) for metrics aggregation.
-#[allow(dead_code)]
 pub struct VerdictCapabilities {
     pub read_files: u8,
     pub write_files: u8,
@@ -80,7 +138,7 @@ impl From<&portcullis::CapabilityLattice> for VerdictCapabilities {
 }
 
 /// Flattened exposure state for telemetry emission.
-#[allow(dead_code)]
+#[derive(Default)]
 pub struct VerdictExposure {
     pub private_data: bool,
     pub untrusted_content: bool,
@@ -130,13 +188,11 @@ pub fn init_otel_layer() -> Option<
 }
 
 /// Shutdown OpenTelemetry (flush pending spans).
-/// In opentelemetry 0.31+, shutdown happens when the provider is dropped.
-/// Call this to force a flush before process exit.
+/// Replaces the global provider with a noop, dropping the real one which
+/// triggers flush of all pending spans.
 #[cfg(feature = "otel")]
 #[allow(dead_code)]
 pub fn shutdown_otel() {
-    // The provider is held globally via set_tracer_provider.
-    // Dropping it triggers flush. For explicit shutdown, we'd need
-    // to store the provider handle — for now, this is a no-op and
-    // the provider flushes on process exit.
+    let noop = opentelemetry::trace::noop::NoopTracerProvider::new();
+    opentelemetry::global::set_tracer_provider(noop);
 }


### PR DESCRIPTION
## Summary

- Every tool call verdict (allow/deny) now emits structured telemetry via `tracing::info!` with target `nucleus_permission`
- When the `otel` feature is enabled with `OTEL_EXPORTER_OTLP_ENDPOINT`, events flow to any OTLP-compatible backend (Grafana, Datadog, Splunk)
- Telemetry includes: verdict, operation, subject, all 7 capability levels, exposure state, lattice checksum, agent SPIFFE identity, session ID, lockdown status
- Wired into `audit_event_with_context()` — the single convergence point all HTTP handlers funnel through
- Switched tracing subscriber from `fmt().init()` to layered `Registry` with conditional OTel layer
- Fixed `shutdown_otel()` to actually flush pending spans
- Poisoned exposure guard lock reports worst-case (uninhabitable) instead of silent degradation

## Known Gaps (tracked for follow-up)

- MCP code path does not go through `audit_event_with_context` and has zero telemetry coverage — requires rearchitecting audit as a cross-cutting concern
- `subject` field passes raw file paths/commands to OTLP without sanitization
- No unit tests for telemetry emission yet

## Test plan

- [x] `cargo build -p nucleus-tool-proxy` (default features)
- [x] `cargo build -p nucleus-tool-proxy --features otel`
- [x] `cargo test -p nucleus-tool-proxy` — all tests pass
- [ ] Manual: start proxy with `RUST_LOG=nucleus_permission=info`, make tool call, verify JSON log contains verdict/capabilities/exposure fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)