### PR TITLE
feat: VerdictSink — shared audit convergence for HTTP + MCP

### DIFF
--- a/crates/nucleus-tool-proxy/src/main.rs
+++ b/crates/nucleus-tool-proxy/src/main.rs
@@ -43,6 +43,7 @@ mod telemetry;
 #[allow(dead_code)]
 mod unicode_audit;
 mod validation;
+mod verdict_sink;
 mod web_fetch_policy;
 
 use attestation::{AttestationConfig, AttestationVerifier};
@@ -294,6 +295,8 @@ pub(crate) struct AppState {
     policy_checksum: String,
     /// Session ID (policy UUID) for telemetry grouping.
     session_id: String,
+    /// Shared verdict sink for lockdown + telemetry convergence (HTTP + MCP).
+    pub(crate) verdict_sink: Arc<dyn portcullis::verdict_sink::VerdictSink>,
 }
 
 /// OR-semantics: locked if EITHER signal file OR gRPC stream says locked.
@@ -1200,6 +1203,22 @@ async fn main() -> Result<(), ApiError> {
     let policy_checksum = runtime.policy().checksum();
     let session_id = runtime.policy().id.to_string();
 
+    // Pre-create shared state for lockdown + exposure so VerdictSink can share them.
+    let file_lockdown = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let stream_lockdown = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let exposure_guard: Arc<std::sync::RwLock<Option<Arc<portcullis::GradedExposureGuard>>>> =
+        Arc::new(std::sync::RwLock::new(None));
+
+    let verdict_sink: Arc<dyn portcullis::verdict_sink::VerdictSink> =
+        Arc::new(verdict_sink::ToolProxyVerdictSink::new(
+            file_lockdown.clone(),
+            stream_lockdown.clone(),
+            runtime.policy().capabilities.clone(),
+            exposure_guard.clone(),
+            policy_checksum.clone(),
+            session_id.clone(),
+        ));
+
     let state = AppState {
         runtime: Arc::new(runtime),
         approvals,
@@ -1224,11 +1243,12 @@ async fn main() -> Result<(), ApiError> {
             .as_deref()
             .and_then(|hex_str| hex::decode(hex_str).ok())
             .map(Arc::new),
-        exposure_guard: Arc::new(std::sync::RwLock::new(None)),
-        file_lockdown: Arc::new(std::sync::atomic::AtomicBool::new(false)),
-        stream_lockdown: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        exposure_guard,
+        file_lockdown,
+        stream_lockdown,
         policy_checksum,
         session_id,
+        verdict_sink,
     };
 
     if let Err(err) = emit_boot_report(&state).await {

--- a/crates/nucleus-tool-proxy/src/mcp.rs
+++ b/crates/nucleus-tool-proxy/src/mcp.rs
@@ -8,8 +8,10 @@
 //! Auth: stdio transport implies the client is the pod's guest process —
 //! already authenticated by sandbox proof. HMAC auth is skipped.
 
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
+use portcullis::verdict_sink::{ActorIdentity, VerdictContext, VerdictOutcome, VerdictSink};
 use portcullis::{CapabilityLevel, GradedExposureGuard, Operation, ToolCallGuard};
 use rmcp::{
     handler::server::router::tool::ToolRouter, handler::server::wrapper::Parameters, model::*,
@@ -115,6 +117,8 @@ pub struct NucleusMcpServer {
     tool_router: ToolRouter<Self>,
     /// Session-scoped exposure-tracking guard (graded monad).
     guard: Arc<GradedExposureGuard>,
+    /// Shared verdict sink for lockdown enforcement + telemetry.
+    sink: Arc<dyn VerdictSink>,
 }
 
 /// Convert a tool-level error into a CallToolResult error.
@@ -125,7 +129,7 @@ fn err_result(msg: impl std::fmt::Display) -> CallToolResult {
 #[tool_router]
 impl NucleusMcpServer {
     /// Create a new MCP server with session-scoped security enforcement.
-    pub fn new(state: Arc<AppState>) -> Self {
+    pub fn new(state: Arc<AppState>, sink: Arc<dyn VerdictSink>) -> Self {
         let tool_router = Self::tool_router();
 
         // Schema pinning: hash the tool list at session start for rug-pull detection
@@ -143,7 +147,20 @@ impl NucleusMcpServer {
             state,
             tool_router,
             guard,
+            sink,
         }
+    }
+
+    /// Record a verdict through the sink (best-effort -- never panics).
+    fn record_verdict(&self, operation: Operation, subject: &str, outcome: VerdictOutcome) {
+        let _ = self.sink.record(VerdictContext {
+            operation,
+            subject: subject.to_string(),
+            outcome,
+            actor: ActorIdentity::StdioGuest,
+            policy_rule: None,
+            extensions: BTreeMap::new(),
+        });
     }
 
     // -----------------------------------------------------------------------
@@ -155,9 +172,29 @@ impl NucleusMcpServer {
         &self,
         Parameters(params): Parameters<ReadParams>,
     ) -> Result<CallToolResult, McpError> {
+        if let Err(e) = self.sink.preflight(Operation::ReadFiles) {
+            self.record_verdict(
+                Operation::ReadFiles,
+                &params.path,
+                VerdictOutcome::Deny {
+                    reason: e.to_string(),
+                },
+            );
+            return Ok(err_result(e));
+        }
+
         let proof = match self.guard.check(Operation::ReadFiles) {
             Ok(p) => p,
-            Err(e) => return Ok(err_result(e)),
+            Err(e) => {
+                self.record_verdict(
+                    Operation::ReadFiles,
+                    &params.path,
+                    VerdictOutcome::Deny {
+                        reason: format!("{e}"),
+                    },
+                );
+                return Ok(err_result(e));
+            }
         };
 
         match self.guard.execute_and_record(proof, || {
@@ -165,8 +202,20 @@ impl NucleusMcpServer {
                 self.state.runtime.sandbox().read_to_string(&params.path)
             })
         }) {
-            Ok(contents) => Ok(CallToolResult::success(vec![Content::text(contents)])),
-            Err(e) => Ok(err_result(e)),
+            Ok(contents) => {
+                self.record_verdict(Operation::ReadFiles, &params.path, VerdictOutcome::Allow);
+                Ok(CallToolResult::success(vec![Content::text(contents)]))
+            }
+            Err(e) => {
+                self.record_verdict(
+                    Operation::ReadFiles,
+                    &params.path,
+                    VerdictOutcome::Error {
+                        error: format!("{e}"),
+                    },
+                );
+                Ok(err_result(e))
+            }
         }
     }
 
@@ -179,9 +228,29 @@ impl NucleusMcpServer {
         &self,
         Parameters(params): Parameters<WriteParams>,
     ) -> Result<CallToolResult, McpError> {
+        if let Err(e) = self.sink.preflight(Operation::WriteFiles) {
+            self.record_verdict(
+                Operation::WriteFiles,
+                &params.path,
+                VerdictOutcome::Deny {
+                    reason: e.to_string(),
+                },
+            );
+            return Ok(err_result(e));
+        }
+
         let proof = match self.guard.check(Operation::WriteFiles) {
             Ok(p) => p,
-            Err(e) => return Ok(err_result(e)),
+            Err(e) => {
+                self.record_verdict(
+                    Operation::WriteFiles,
+                    &params.path,
+                    VerdictOutcome::Deny {
+                        reason: format!("{e}"),
+                    },
+                );
+                return Ok(err_result(e));
+            }
         };
 
         match self.guard.execute_and_record(proof, || {
@@ -192,8 +261,20 @@ impl NucleusMcpServer {
                     .write(&params.path, params.contents.as_bytes())
             })
         }) {
-            Ok(()) => Ok(CallToolResult::success(vec![Content::text("ok")])),
-            Err(e) => Ok(err_result(e)),
+            Ok(()) => {
+                self.record_verdict(Operation::WriteFiles, &params.path, VerdictOutcome::Allow);
+                Ok(CallToolResult::success(vec![Content::text("ok")]))
+            }
+            Err(e) => {
+                self.record_verdict(
+                    Operation::WriteFiles,
+                    &params.path,
+                    VerdictOutcome::Error {
+                        error: format!("{e}"),
+                    },
+                );
+                Ok(err_result(e))
+            }
         }
     }
 
@@ -208,13 +289,42 @@ impl NucleusMcpServer {
         &self,
         Parameters(params): Parameters<RunParams>,
     ) -> Result<CallToolResult, McpError> {
+        let subject = params.args.join(" ");
+
+        if let Err(e) = self.sink.preflight(Operation::RunBash) {
+            self.record_verdict(
+                Operation::RunBash,
+                &subject,
+                VerdictOutcome::Deny {
+                    reason: e.to_string(),
+                },
+            );
+            return Ok(err_result(e));
+        }
+
         if params.args.is_empty() {
+            self.record_verdict(
+                Operation::RunBash,
+                &subject,
+                VerdictOutcome::Deny {
+                    reason: "args must not be empty".to_string(),
+                },
+            );
             return Ok(err_result("args must not be empty"));
         }
 
         let proof = match self.guard.check(Operation::RunBash) {
             Ok(p) => p,
-            Err(e) => return Ok(err_result(e)),
+            Err(e) => {
+                self.record_verdict(
+                    Operation::RunBash,
+                    &subject,
+                    VerdictOutcome::Deny {
+                        reason: format!("{e}"),
+                    },
+                );
+                return Ok(err_result(e));
+            }
         };
 
         match self.guard.execute_and_record(proof, || {
@@ -227,6 +337,7 @@ impl NucleusMcpServer {
             })
         }) {
             Ok(output) => {
+                self.record_verdict(Operation::RunBash, &subject, VerdictOutcome::Allow);
                 let run_result = RunResult {
                     exit_code: output.status.code().unwrap_or(-1),
                     stdout: String::from_utf8_lossy(&output.stdout).to_string(),
@@ -235,7 +346,16 @@ impl NucleusMcpServer {
                 let json = serde_json::to_string_pretty(&run_result).unwrap_or_default();
                 Ok(CallToolResult::success(vec![Content::text(json)]))
             }
-            Err(e) => Ok(err_result(e)),
+            Err(e) => {
+                self.record_verdict(
+                    Operation::RunBash,
+                    &subject,
+                    VerdictOutcome::Error {
+                        error: format!("{e}"),
+                    },
+                );
+                Ok(err_result(e))
+            }
         }
     }
 
@@ -248,14 +368,43 @@ impl NucleusMcpServer {
         &self,
         Parameters(params): Parameters<GlobParams>,
     ) -> Result<CallToolResult, McpError> {
+        let subject = params.pattern.clone();
+
+        if let Err(e) = self.sink.preflight(Operation::GlobSearch) {
+            self.record_verdict(
+                Operation::GlobSearch,
+                &subject,
+                VerdictOutcome::Deny {
+                    reason: e.to_string(),
+                },
+            );
+            return Ok(err_result(e));
+        }
+
         let proof = match self.guard.check(Operation::GlobSearch) {
             Ok(p) => p,
-            Err(e) => return Ok(err_result(e)),
+            Err(e) => {
+                self.record_verdict(
+                    Operation::GlobSearch,
+                    &subject,
+                    VerdictOutcome::Deny {
+                        reason: format!("{e}"),
+                    },
+                );
+                return Ok(err_result(e));
+            }
         };
 
         // Check capability level
         let level = self.state.runtime.policy().capabilities.glob_search;
         if level == CapabilityLevel::Never {
+            self.record_verdict(
+                Operation::GlobSearch,
+                &subject,
+                VerdictOutcome::Deny {
+                    reason: "glob_search capability is disabled".to_string(),
+                },
+            );
             return Ok(err_result("glob_search capability is disabled"));
         }
 
@@ -309,10 +458,22 @@ impl NucleusMcpServer {
                 Ok(results)
             })
         }) {
-            Ok(paths) => Ok(CallToolResult::success(vec![Content::text(
-                paths.join("\n"),
-            )])),
-            Err(e) => Ok(err_result(e)),
+            Ok(paths) => {
+                self.record_verdict(Operation::GlobSearch, &subject, VerdictOutcome::Allow);
+                Ok(CallToolResult::success(vec![Content::text(
+                    paths.join("\n"),
+                )]))
+            }
+            Err(e) => {
+                self.record_verdict(
+                    Operation::GlobSearch,
+                    &subject,
+                    VerdictOutcome::Error {
+                        error: format!("{e}"),
+                    },
+                );
+                Ok(err_result(e))
+            }
         }
     }
 
@@ -325,13 +486,42 @@ impl NucleusMcpServer {
         &self,
         Parameters(params): Parameters<GrepParams>,
     ) -> Result<CallToolResult, McpError> {
+        let subject = params.pattern.clone();
+
+        if let Err(e) = self.sink.preflight(Operation::GrepSearch) {
+            self.record_verdict(
+                Operation::GrepSearch,
+                &subject,
+                VerdictOutcome::Deny {
+                    reason: e.to_string(),
+                },
+            );
+            return Ok(err_result(e));
+        }
+
         let proof = match self.guard.check(Operation::GrepSearch) {
             Ok(p) => p,
-            Err(e) => return Ok(err_result(e)),
+            Err(e) => {
+                self.record_verdict(
+                    Operation::GrepSearch,
+                    &subject,
+                    VerdictOutcome::Deny {
+                        reason: format!("{e}"),
+                    },
+                );
+                return Ok(err_result(e));
+            }
         };
 
         let level = self.state.runtime.policy().capabilities.grep_search;
         if level == CapabilityLevel::Never {
+            self.record_verdict(
+                Operation::GrepSearch,
+                &subject,
+                VerdictOutcome::Deny {
+                    reason: "grep_search capability is disabled".to_string(),
+                },
+            );
             return Ok(err_result("grep_search capability is disabled"));
         }
 
@@ -448,8 +638,20 @@ impl NucleusMcpServer {
                 Ok(output)
             })
         }) {
-            Ok(matches) => Ok(CallToolResult::success(vec![Content::text(matches)])),
-            Err(e) => Ok(err_result(e)),
+            Ok(matches) => {
+                self.record_verdict(Operation::GrepSearch, &subject, VerdictOutcome::Allow);
+                Ok(CallToolResult::success(vec![Content::text(matches)]))
+            }
+            Err(e) => {
+                self.record_verdict(
+                    Operation::GrepSearch,
+                    &subject,
+                    VerdictOutcome::Error {
+                        error: format!("{e}"),
+                    },
+                );
+                Ok(err_result(e))
+            }
         }
     }
 
@@ -465,38 +667,100 @@ impl NucleusMcpServer {
         &self,
         Parameters(params): Parameters<WebFetchParams>,
     ) -> Result<CallToolResult, McpError> {
+        let subject = params.url.clone();
+
+        if let Err(e) = self.sink.preflight(Operation::WebFetch) {
+            self.record_verdict(
+                Operation::WebFetch,
+                &subject,
+                VerdictOutcome::Deny {
+                    reason: e.to_string(),
+                },
+            );
+            return Ok(err_result(e));
+        }
+
         let proof = match self.guard.check(Operation::WebFetch) {
             Ok(p) => p,
-            Err(e) => return Ok(err_result(e)),
+            Err(e) => {
+                self.record_verdict(
+                    Operation::WebFetch,
+                    &subject,
+                    VerdictOutcome::Deny {
+                        reason: format!("{e}"),
+                    },
+                );
+                return Ok(err_result(e));
+            }
         };
 
         let level = self.state.runtime.policy().capabilities.web_fetch;
         if level == CapabilityLevel::Never {
+            self.record_verdict(
+                Operation::WebFetch,
+                &subject,
+                VerdictOutcome::Deny {
+                    reason: "web_fetch capability is disabled".to_string(),
+                },
+            );
             return Ok(err_result("web_fetch capability is disabled"));
         }
 
         // Input validation (scheme, length, null bytes) — shared with HTTP path
         if let Err(e) = crate::web_fetch_policy::validate_url(&params.url) {
+            self.record_verdict(
+                Operation::WebFetch,
+                &subject,
+                VerdictOutcome::Deny {
+                    reason: e.to_string(),
+                },
+            );
             return Ok(err_result(e));
         }
 
         // Parse URL
         let parsed_url = match url::Url::parse(&params.url) {
             Ok(u) => u,
-            Err(e) => return Ok(err_result(format!("invalid URL: {e}"))),
+            Err(e) => {
+                let msg = format!("invalid URL: {e}");
+                self.record_verdict(
+                    Operation::WebFetch,
+                    &subject,
+                    VerdictOutcome::Deny {
+                        reason: msg.clone(),
+                    },
+                );
+                return Ok(err_result(msg));
+            }
         };
 
         // DNS allowlist — shared with HTTP path (fixed port-matching logic)
         {
             let host = match parsed_url.host_str() {
                 Some(h) => h,
-                None => return Ok(err_result("URL has no host")),
+                None => {
+                    self.record_verdict(
+                        Operation::WebFetch,
+                        &subject,
+                        VerdictOutcome::Deny {
+                            reason: "URL has no host".to_string(),
+                        },
+                    );
+                    return Ok(err_result("URL has no host"));
+                }
             };
             let port = parsed_url.port_or_known_default().unwrap_or(443);
             if let Err(e) =
                 crate::web_fetch_policy::check_dns_allowlist(&self.state.dns_allow, host, port)
             {
                 warn!(host = host, port = port, "DNS not in allow-list");
+                self.record_verdict(
+                    Operation::WebFetch,
+                    &subject,
+                    VerdictOutcome::Deny {
+                        reason: e.to_string(),
+                    },
+                );
                 return Ok(err_result(e));
             }
         }
@@ -505,6 +769,13 @@ impl NucleusMcpServer {
         if let Err(e) =
             crate::web_fetch_policy::check_url_allowlist(&self.state.url_allow, parsed_url.as_str())
         {
+            self.record_verdict(
+                Operation::WebFetch,
+                &subject,
+                VerdictOutcome::Deny {
+                    reason: e.to_string(),
+                },
+            );
             return Ok(err_result(e));
         }
 
@@ -516,7 +787,17 @@ impl NucleusMcpServer {
             "POST" => client.post(&params.url),
             "PUT" => client.put(&params.url),
             "DELETE" => client.delete(&params.url),
-            _ => return Ok(err_result(format!("unsupported method: {method}"))),
+            _ => {
+                let msg = format!("unsupported method: {method}");
+                self.record_verdict(
+                    Operation::WebFetch,
+                    &subject,
+                    VerdictOutcome::Deny {
+                        reason: msg.clone(),
+                    },
+                );
+                return Ok(err_result(msg));
+            }
         };
 
         // Perform async fetch with full security controls.
@@ -559,8 +840,20 @@ impl NucleusMcpServer {
         .await;
 
         match self.guard.execute_and_record(proof, || fetch_result) {
-            Ok(response) => Ok(CallToolResult::success(vec![Content::text(response)])),
-            Err(e) => Ok(err_result(e)),
+            Ok(response) => {
+                self.record_verdict(Operation::WebFetch, &subject, VerdictOutcome::Allow);
+                Ok(CallToolResult::success(vec![Content::text(response)]))
+            }
+            Err(e) => {
+                self.record_verdict(
+                    Operation::WebFetch,
+                    &subject,
+                    VerdictOutcome::Error {
+                        error: format!("{e}"),
+                    },
+                );
+                Ok(err_result(e))
+            }
         }
     }
 }
@@ -584,7 +877,8 @@ impl ServerHandler for NucleusMcpServer {
 pub async fn run_mcp_server(state: Arc<AppState>) -> Result<(), crate::ApiError> {
     info!("starting MCP server mode (stdio transport)");
 
-    let server = NucleusMcpServer::new(state);
+    let sink = state.verdict_sink.clone();
+    let server = NucleusMcpServer::new(state, sink);
     let service = server
         .serve(rmcp::transport::stdio())
         .await

--- a/crates/nucleus-tool-proxy/src/verdict_sink.rs
+++ b/crates/nucleus-tool-proxy/src/verdict_sink.rs
@@ -1,0 +1,305 @@
+//! Concrete VerdictSink for the tool-proxy process.
+//!
+//! Bridges the portcullis `VerdictSink` trait to the tool-proxy's existing
+//! lockdown flags and telemetry infrastructure. PR 1 covers lockdown
+//! enforcement and telemetry emission; audit log integration follows in PR 2.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use portcullis::verdict_sink::{
+    ActorIdentity, SinkError, VerdictContext, VerdictOutcome, VerdictSink,
+};
+use portcullis::{CapabilityLattice, GradedExposureGuard, Operation};
+
+use crate::telemetry;
+
+/// Concrete VerdictSink wired to tool-proxy lockdown + telemetry.
+///
+/// Holds the same lockdown flags and policy fields as `AppState`, but
+/// without requiring the full `AppState` (keeps the trait decoupled).
+pub struct ToolProxyVerdictSink {
+    file_lockdown: Arc<AtomicBool>,
+    stream_lockdown: Arc<AtomicBool>,
+    capabilities: CapabilityLattice,
+    exposure_guard: Arc<std::sync::RwLock<Option<Arc<GradedExposureGuard>>>>,
+    policy_checksum: String,
+    session_id: String,
+}
+
+impl ToolProxyVerdictSink {
+    /// Build from the same fields already present on `AppState`.
+    pub fn new(
+        file_lockdown: Arc<AtomicBool>,
+        stream_lockdown: Arc<AtomicBool>,
+        capabilities: CapabilityLattice,
+        exposure_guard: Arc<std::sync::RwLock<Option<Arc<GradedExposureGuard>>>>,
+        policy_checksum: String,
+        session_id: String,
+    ) -> Self {
+        Self {
+            file_lockdown,
+            stream_lockdown,
+            capabilities,
+            exposure_guard,
+            policy_checksum,
+            session_id,
+        }
+    }
+
+    /// OR-semantics: locked if EITHER signal file OR gRPC stream says locked.
+    /// Mirrors `is_locked()` in main.rs.
+    fn is_locked(&self) -> bool {
+        self.file_lockdown.load(Ordering::Acquire) || self.stream_lockdown.load(Ordering::Acquire)
+    }
+
+    /// Map Operation to the short string names used by emit_verdict / audit log.
+    fn operation_name(op: Operation) -> &'static str {
+        match op {
+            Operation::ReadFiles => "read",
+            Operation::WriteFiles => "write",
+            Operation::EditFiles => "edit",
+            Operation::RunBash => "run",
+            Operation::GlobSearch => "glob",
+            Operation::GrepSearch => "grep",
+            Operation::WebSearch => "web_search",
+            Operation::WebFetch => "web_fetch",
+            Operation::GitCommit => "git_commit",
+            Operation::GitPush => "git_push",
+            Operation::CreatePr => "create_pr",
+            Operation::ManagePods => "manage_pods",
+        }
+    }
+
+    /// Map a VerdictOutcome to the result string expected by emit_verdict.
+    fn outcome_to_result(outcome: &VerdictOutcome) -> String {
+        match outcome {
+            VerdictOutcome::Allow => "ok".to_string(),
+            VerdictOutcome::Deny { reason } => format!("denied:{reason}"),
+            VerdictOutcome::Error { error } => format!("denied:{error}"),
+        }
+    }
+
+    /// Extract the agent identity string for telemetry, if available.
+    fn actor_identity(actor: &ActorIdentity) -> Option<&str> {
+        match actor {
+            ActorIdentity::Authenticated { spiffe_id } => Some(spiffe_id.as_str()),
+            ActorIdentity::StdioGuest => Some("stdio-guest"),
+            ActorIdentity::Unknown => None,
+        }
+    }
+}
+
+impl VerdictSink for ToolProxyVerdictSink {
+    fn record(&self, ctx: VerdictContext) -> Result<(), SinkError> {
+        // 1. Check lockdown (may have been activated between preflight and now)
+        if self.is_locked() {
+            // Still emit telemetry so the late-lockdown event is visible
+            telemetry::emit_verdict(
+                Self::operation_name(ctx.operation),
+                &ctx.subject,
+                "denied:LOCKDOWN ACTIVE",
+                &self.capabilities,
+                &self.exposure_guard,
+                true, // lockdown_active
+                &self.policy_checksum,
+                Self::actor_identity(&ctx.actor),
+                &self.session_id,
+            );
+            return Err(SinkError::Locked);
+        }
+
+        // 2. Emit telemetry for the actual outcome
+        let result_str = Self::outcome_to_result(&ctx.outcome);
+        telemetry::emit_verdict(
+            Self::operation_name(ctx.operation),
+            &ctx.subject,
+            &result_str,
+            &self.capabilities,
+            &self.exposure_guard,
+            false, // not locked
+            &self.policy_checksum,
+            Self::actor_identity(&ctx.actor),
+            &self.session_id,
+        );
+
+        // 3. Audit log integration deferred to PR 2 (requires async + AuditLog)
+        Ok(())
+    }
+
+    fn preflight(&self, _operation: Operation) -> Result<(), SinkError> {
+        if self.is_locked() {
+            Err(SinkError::Locked)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    fn make_sink(file_locked: bool, stream_locked: bool) -> ToolProxyVerdictSink {
+        ToolProxyVerdictSink::new(
+            Arc::new(AtomicBool::new(file_locked)),
+            Arc::new(AtomicBool::new(stream_locked)),
+            CapabilityLattice::default(),
+            Arc::new(std::sync::RwLock::new(None)),
+            "test-checksum".to_string(),
+            "test-session".to_string(),
+        )
+    }
+
+    #[test]
+    fn preflight_passes_when_unlocked() {
+        let sink = make_sink(false, false);
+        assert!(sink.preflight(Operation::ReadFiles).is_ok());
+    }
+
+    #[test]
+    fn preflight_fails_when_file_locked() {
+        let sink = make_sink(true, false);
+        assert!(matches!(
+            sink.preflight(Operation::ReadFiles).unwrap_err(),
+            SinkError::Locked
+        ));
+    }
+
+    #[test]
+    fn preflight_fails_when_stream_locked() {
+        let sink = make_sink(false, true);
+        assert!(matches!(
+            sink.preflight(Operation::RunBash).unwrap_err(),
+            SinkError::Locked
+        ));
+    }
+
+    #[test]
+    fn preflight_fails_when_both_locked() {
+        let sink = make_sink(true, true);
+        assert!(matches!(
+            sink.preflight(Operation::WebFetch).unwrap_err(),
+            SinkError::Locked
+        ));
+    }
+
+    #[test]
+    fn record_passes_when_unlocked() {
+        let sink = make_sink(false, false);
+        let ctx = VerdictContext {
+            operation: Operation::WriteFiles,
+            subject: "/workspace/test.txt".to_string(),
+            outcome: VerdictOutcome::Allow,
+            actor: ActorIdentity::StdioGuest,
+            policy_rule: None,
+            extensions: BTreeMap::new(),
+        };
+        assert!(sink.record(ctx).is_ok());
+    }
+
+    #[test]
+    fn record_denied_when_locked() {
+        let sink = make_sink(true, false);
+        let ctx = VerdictContext {
+            operation: Operation::ReadFiles,
+            subject: "/workspace/secret.txt".to_string(),
+            outcome: VerdictOutcome::Allow,
+            actor: ActorIdentity::StdioGuest,
+            policy_rule: None,
+            extensions: BTreeMap::new(),
+        };
+        assert!(matches!(sink.record(ctx).unwrap_err(), SinkError::Locked));
+    }
+
+    #[test]
+    fn operation_name_mapping() {
+        assert_eq!(
+            ToolProxyVerdictSink::operation_name(Operation::ReadFiles),
+            "read"
+        );
+        assert_eq!(
+            ToolProxyVerdictSink::operation_name(Operation::WriteFiles),
+            "write"
+        );
+        assert_eq!(
+            ToolProxyVerdictSink::operation_name(Operation::EditFiles),
+            "edit"
+        );
+        assert_eq!(
+            ToolProxyVerdictSink::operation_name(Operation::RunBash),
+            "run"
+        );
+        assert_eq!(
+            ToolProxyVerdictSink::operation_name(Operation::GlobSearch),
+            "glob"
+        );
+        assert_eq!(
+            ToolProxyVerdictSink::operation_name(Operation::GrepSearch),
+            "grep"
+        );
+        assert_eq!(
+            ToolProxyVerdictSink::operation_name(Operation::WebSearch),
+            "web_search"
+        );
+        assert_eq!(
+            ToolProxyVerdictSink::operation_name(Operation::WebFetch),
+            "web_fetch"
+        );
+        assert_eq!(
+            ToolProxyVerdictSink::operation_name(Operation::GitCommit),
+            "git_commit"
+        );
+        assert_eq!(
+            ToolProxyVerdictSink::operation_name(Operation::GitPush),
+            "git_push"
+        );
+        assert_eq!(
+            ToolProxyVerdictSink::operation_name(Operation::CreatePr),
+            "create_pr"
+        );
+        assert_eq!(
+            ToolProxyVerdictSink::operation_name(Operation::ManagePods),
+            "manage_pods"
+        );
+    }
+
+    #[test]
+    fn outcome_to_result_mapping() {
+        assert_eq!(
+            ToolProxyVerdictSink::outcome_to_result(&VerdictOutcome::Allow),
+            "ok"
+        );
+        assert_eq!(
+            ToolProxyVerdictSink::outcome_to_result(&VerdictOutcome::Deny {
+                reason: "lockdown".into()
+            }),
+            "denied:lockdown"
+        );
+        assert_eq!(
+            ToolProxyVerdictSink::outcome_to_result(&VerdictOutcome::Error {
+                error: "I/O timeout".into()
+            }),
+            "denied:I/O timeout"
+        );
+    }
+
+    #[test]
+    fn actor_identity_extraction() {
+        assert_eq!(
+            ToolProxyVerdictSink::actor_identity(&ActorIdentity::Authenticated {
+                spiffe_id: "spiffe://test".into()
+            }),
+            Some("spiffe://test")
+        );
+        assert_eq!(
+            ToolProxyVerdictSink::actor_identity(&ActorIdentity::StdioGuest),
+            Some("stdio-guest")
+        );
+        assert_eq!(
+            ToolProxyVerdictSink::actor_identity(&ActorIdentity::Unknown),
+            None
+        );
+    }
+}

--- a/crates/portcullis/src/lib.rs
+++ b/crates/portcullis/src/lib.rs
@@ -145,6 +145,7 @@ pub mod progress;
 pub mod region;
 mod time;
 pub mod trust;
+pub mod verdict_sink;
 pub mod weakening;
 pub mod workspace;
 
@@ -224,6 +225,7 @@ pub use metrics::{
 #[cfg(feature = "crypto")]
 pub use token::{AttenuationToken, SessionProvenance, TokenError};
 pub use uninhabitable_state::{ConstraintNucleus, CoreExposureRequirement, UninhabitableState};
+pub use verdict_sink::{ActorIdentity, SinkError, VerdictContext, VerdictOutcome, VerdictSink};
 
 /// Check if a glob pattern matches a path.
 pub fn glob_match(pattern: &str, path: &str) -> bool {

--- a/crates/portcullis/src/verdict_sink.rs
+++ b/crates/portcullis/src/verdict_sink.rs
@@ -1,0 +1,231 @@
+//! VerdictSink -- single convergence point for all tool call outcomes.
+//!
+//! Every tool call in every transport (HTTP, MCP, future gRPC) MUST flow
+//! through a VerdictSink before returning. This trait is the security audit
+//! boundary -- it enforces lockdown, records audit entries, and emits telemetry.
+//!
+//! # Design
+//!
+//! The trait is intentionally synchronous (`&self` + `Result`) so that it can
+//! be called from both async handlers (HTTP) and synchronous closures (MCP
+//! `execute_and_record`). Async audit backends (S3, webhook) should buffer
+//! internally and flush on a background task.
+//!
+//! # Lockdown semantics
+//!
+//! `preflight()` checks whether a fleet lockdown is active *before* any
+//! capability guard or sandbox I/O. If locked, the caller MUST short-circuit
+//! with a deny verdict and never touch the filesystem or network.
+
+use std::collections::BTreeMap;
+
+use crate::capability::Operation;
+
+/// Outcome of a single tool call (before audit recording).
+#[derive(Debug, Clone)]
+pub enum VerdictOutcome {
+    /// The operation was permitted and completed successfully.
+    Allow,
+    /// The operation was denied by policy, lockdown, or capability guard.
+    Deny {
+        /// Human-readable reason for the denial.
+        reason: String,
+    },
+    /// The operation failed due to a runtime error (I/O, timeout, etc.).
+    Error {
+        /// Human-readable error description.
+        error: String,
+    },
+}
+
+/// Identity of the actor requesting the tool call.
+#[derive(Debug, Clone)]
+pub enum ActorIdentity {
+    /// Authenticated via SPIFFE SVID or mTLS certificate.
+    Authenticated {
+        /// SPIFFE ID string (e.g. `spiffe://nucleus.local/pod/abc`).
+        spiffe_id: String,
+    },
+    /// Stdio guest process inside the pod (MCP transport).
+    StdioGuest,
+    /// Identity could not be determined.
+    Unknown,
+}
+
+/// Full context for a single verdict to be recorded.
+#[derive(Debug)]
+pub struct VerdictContext {
+    /// The operation that was attempted (e.g. `ReadFiles`, `RunBash`).
+    pub operation: Operation,
+    /// Subject of the operation (file path, command, URL, etc.).
+    pub subject: String,
+    /// Outcome of the operation.
+    pub outcome: VerdictOutcome,
+    /// Identity of the requesting actor.
+    pub actor: ActorIdentity,
+    /// Optional policy rule that governed this decision.
+    pub policy_rule: Option<String>,
+    /// Arbitrary key-value extensions for domain-specific metadata.
+    pub extensions: BTreeMap<String, String>,
+}
+
+/// Errors from the verdict sink.
+#[derive(Debug)]
+pub enum SinkError {
+    /// Fleet lockdown is active -- all tool calls must be blocked.
+    Locked,
+    /// Audit recording failed (should not block the caller in most impls).
+    AuditFailed(String),
+}
+
+impl std::fmt::Display for SinkError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SinkError::Locked => write!(f, "LOCKDOWN ACTIVE: all tool calls are blocked"),
+            SinkError::AuditFailed(e) => write!(f, "audit recording failed: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for SinkError {}
+
+/// Single mandatory convergence point for all tool call outcomes.
+///
+/// Implementations MUST:
+/// 1. Check fleet lockdown state and return `SinkError::Locked` if active.
+/// 2. Emit telemetry (tracing event / OTLP span) for observability.
+/// 3. (Future) Record an audit entry in the append-only log.
+///
+/// The trait is object-safe and synchronous so it can be used behind
+/// `Arc<dyn VerdictSink>` from both async and sync call sites.
+pub trait VerdictSink: Send + Sync {
+    /// Record a completed tool call verdict.
+    ///
+    /// Called after the operation has finished (or been denied). Returns
+    /// `Err(SinkError::Locked)` if lockdown was activated between preflight
+    /// and completion -- the caller should treat this as a late deny.
+    fn record(&self, ctx: VerdictContext) -> Result<(), SinkError>;
+
+    /// Pre-flight lockdown check before any I/O.
+    ///
+    /// Call this at the very top of every tool handler. If it returns
+    /// `Err(SinkError::Locked)`, skip all capability checks and I/O.
+    fn preflight(&self, operation: Operation) -> Result<(), SinkError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A no-op sink for testing -- never locked, always succeeds.
+    struct NoopSink;
+
+    impl VerdictSink for NoopSink {
+        fn record(&self, _ctx: VerdictContext) -> Result<(), SinkError> {
+            Ok(())
+        }
+        fn preflight(&self, _operation: Operation) -> Result<(), SinkError> {
+            Ok(())
+        }
+    }
+
+    /// A sink that always reports locked.
+    struct LockedSink;
+
+    impl VerdictSink for LockedSink {
+        fn record(&self, _ctx: VerdictContext) -> Result<(), SinkError> {
+            Err(SinkError::Locked)
+        }
+        fn preflight(&self, _operation: Operation) -> Result<(), SinkError> {
+            Err(SinkError::Locked)
+        }
+    }
+
+    #[test]
+    fn noop_sink_allows_preflight() {
+        let sink = NoopSink;
+        assert!(sink.preflight(Operation::ReadFiles).is_ok());
+    }
+
+    #[test]
+    fn noop_sink_records_verdict() {
+        let sink = NoopSink;
+        let ctx = VerdictContext {
+            operation: Operation::WriteFiles,
+            subject: "/workspace/test.txt".to_string(),
+            outcome: VerdictOutcome::Allow,
+            actor: ActorIdentity::StdioGuest,
+            policy_rule: None,
+            extensions: BTreeMap::new(),
+        };
+        assert!(sink.record(ctx).is_ok());
+    }
+
+    #[test]
+    fn locked_sink_denies_preflight() {
+        let sink = LockedSink;
+        let err = sink.preflight(Operation::RunBash).unwrap_err();
+        assert!(matches!(err, SinkError::Locked));
+    }
+
+    #[test]
+    fn locked_sink_denies_record() {
+        let sink = LockedSink;
+        let ctx = VerdictContext {
+            operation: Operation::WebFetch,
+            subject: "https://example.com".to_string(),
+            outcome: VerdictOutcome::Allow,
+            actor: ActorIdentity::Unknown,
+            policy_rule: None,
+            extensions: BTreeMap::new(),
+        };
+        let err = sink.record(ctx).unwrap_err();
+        assert!(matches!(err, SinkError::Locked));
+    }
+
+    #[test]
+    fn sink_error_display() {
+        let locked = SinkError::Locked;
+        assert_eq!(
+            locked.to_string(),
+            "LOCKDOWN ACTIVE: all tool calls are blocked"
+        );
+
+        let audit = SinkError::AuditFailed("disk full".to_string());
+        assert_eq!(audit.to_string(), "audit recording failed: disk full");
+    }
+
+    #[test]
+    fn verdict_context_deny_and_error_variants() {
+        let deny = VerdictOutcome::Deny {
+            reason: "lockdown".to_string(),
+        };
+        assert!(matches!(deny, VerdictOutcome::Deny { .. }));
+
+        let error = VerdictOutcome::Error {
+            error: "I/O timeout".to_string(),
+        };
+        assert!(matches!(error, VerdictOutcome::Error { .. }));
+    }
+
+    #[test]
+    fn actor_identity_variants() {
+        let auth = ActorIdentity::Authenticated {
+            spiffe_id: "spiffe://nucleus.local/pod/test".to_string(),
+        };
+        assert!(matches!(auth, ActorIdentity::Authenticated { .. }));
+
+        let guest = ActorIdentity::StdioGuest;
+        assert!(matches!(guest, ActorIdentity::StdioGuest));
+
+        let unknown = ActorIdentity::Unknown;
+        assert!(matches!(unknown, ActorIdentity::Unknown));
+    }
+
+    #[test]
+    fn trait_object_safety() {
+        // VerdictSink must be object-safe for Arc<dyn VerdictSink>.
+        let sink: Box<dyn VerdictSink> = Box::new(NoopSink);
+        assert!(sink.preflight(Operation::ReadFiles).is_ok());
+    }
+}


### PR DESCRIPTION
## Summary

Stacked on the lockdown streaming branch.

Introduces the `VerdictSink` trait as the **single mandatory convergence point** for all tool call outcomes across both HTTP and MCP transports. This is the rearchitecture that closes the #1 gap from three adversarial audit loops: the MCP path (primary Claude Code integration) had zero observability and zero lockdown enforcement.

### What changed

- **`portcullis/src/verdict_sink.rs`** (NEW) — Trait definition: `VerdictSink`, `VerdictContext`, `VerdictOutcome`, `ActorIdentity`, `SinkError`. 8 unit tests.
- **`nucleus-tool-proxy/src/verdict_sink.rs`** (NEW) — `ToolProxyVerdictSink` concrete implementation with lockdown OR-semantics + telemetry emission. 9 unit tests.
- **`nucleus-tool-proxy/src/mcp.rs`** — All 6 MCP tool handlers now have `preflight()` lockdown check + `record()` verdict at every return path.
- **`nucleus-tool-proxy/src/main.rs`** — `verdict_sink` field on AppState, shared Arc references for lockdown flags.

### MCP path now has

| Capability | Before | After |
|-----------|--------|-------|
| Lockdown enforcement | None | `preflight()` at top of every handler |
| Telemetry emission | None | `record()` calls `emit_verdict()` |
| Audit logging | None | Wired (audit log integration in PR 2) |

### Architecture

```
VerdictSink (portcullis trait)
    │
    ├── ToolProxyVerdictSink (impl)
    │       ├── preflight(): lockdown check (OR-semantics)
    │       └── record(): lockdown + emit_verdict()
    │
    ├── HTTP handlers (existing audit, migrates in PR 2)
    └── MCP handlers (NOW wired via sink)
```

### Next PRs in this series

- PR 2: Migrate HTTP handlers from scattered audit calls to `sink.record()`
- PR 3: Switch from `tracing::info!` events to `tracing::info_span!` (proper OTel spans)
- PR 4: Cleanup — remove old audit functions, add property tests

## Test plan

- [x] `cargo build -p portcullis -p nucleus-tool-proxy`
- [x] `cargo build -p nucleus-tool-proxy --features otel`
- [x] `cargo build -p nucleus-tool-proxy --features mcp`
- [x] `cargo test -p portcullis --lib` — 548 tests pass
- [x] `cargo test -p nucleus-tool-proxy` — 14 tests pass (9 new)
- [x] All pre-commit hooks pass (fmt, clippy, deny, audit)
- [ ] Manual: start proxy with `--mcp`, activate lockdown, verify MCP tool calls rejected
- [ ] Manual: verify `RUST_LOG=nucleus_permission=info` shows verdict entries from MCP calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)