### PR TITLE
feat: support http/protobuf OTLP transport for Grafana Cloud

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 # OpenTelemetry (opt-in via feature flags)
 opentelemetry = "0.31"
 opentelemetry_sdk = { version = "0.31", features = ["rt-tokio"] }
-opentelemetry-otlp = { version = "0.31", features = ["grpc-tonic", "trace"] }
+opentelemetry-otlp = { version = "0.31", features = ["grpc-tonic", "http-proto", "trace"] }
 tracing-opentelemetry = "0.32"
 
 # Crypto/signing

--- a/crates/nucleus-tool-proxy/src/telemetry.rs
+++ b/crates/nucleus-tool-proxy/src/telemetry.rs
@@ -163,12 +163,23 @@ pub fn init_otel_layer() -> Option<
     use opentelemetry_otlp::WithExportConfig as _;
 
     let endpoint = std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT").ok()?;
+    let protocol =
+        std::env::var("OTEL_EXPORTER_OTLP_PROTOCOL").unwrap_or_else(|_| "grpc".to_string());
 
-    let exporter = opentelemetry_otlp::SpanExporter::builder()
-        .with_tonic()
-        .with_endpoint(&endpoint)
-        .build()
-        .ok()?;
+    // Support both gRPC (default) and http/protobuf (Grafana Cloud).
+    // Set OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf for Grafana Cloud.
+    let exporter = match protocol.as_str() {
+        "http/protobuf" => opentelemetry_otlp::SpanExporter::builder()
+            .with_http()
+            .with_endpoint(&endpoint)
+            .build()
+            .ok()?,
+        _ => opentelemetry_otlp::SpanExporter::builder()
+            .with_tonic()
+            .with_endpoint(&endpoint)
+            .build()
+            .ok()?,
+    };
 
     let provider = opentelemetry_sdk::trace::SdkTracerProvider::builder()
         .with_batch_exporter(exporter)


### PR DESCRIPTION
## Summary

The OTLP exporter now auto-selects transport based on `OTEL_EXPORTER_OTLP_PROTOCOL`:
- `grpc` (default) — existing tonic/gRPC transport
- `http/protobuf` — HTTP transport for Grafana Cloud

Grafana Cloud's OTLP gateway only accepts http/protobuf. This enables dogfooding.

## Test plan

- [x] `cargo build -p nucleus-tool-proxy --features otel`
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)