### PR TITLE
fix: honest Aeneas claims — compile-time sync, accurate docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3490,6 +3490,7 @@ dependencies = [
  "hex",
  "hmac",
  "kani",
+ "portcullis-core",
  "proptest",
  "regex",
  "reqwest 0.13.2",

--- a/crates/portcullis-core/Cargo.toml
+++ b/crates/portcullis-core/Cargo.toml
@@ -13,7 +13,8 @@ repository = "https://github.com/coproduct-opensource/nucleus"
 #
 # DO NOT add dependencies. External crate types (serde, BTreeMap, etc.)
 # are not supported by Aeneas's Lean backend. If you need serde, use
-# the full `portcullis` crate which re-exports these types with serde support.
+# the full `portcullis` crate which defines its own CapabilityLevel with
+# serde support and a compile-time assertion that the discriminants match.
 
 [dependencies]
 # None — intentionally dependency-free for Aeneas translation

--- a/crates/portcullis-core/src/lib.rs
+++ b/crates/portcullis-core/src/lib.rs
@@ -13,8 +13,17 @@
 //! - [`CapabilityLattice`] — product of 12 capability dimensions
 //! - `meet`, `join`, `leq` — lattice operations (pointwise min/max/≤)
 //!
-//! The full `portcullis` crate re-exports these types and adds serde,
-//! extension dimensions, and the exposure guard.
+//! ## Relationship to the production `portcullis` crate
+//!
+//! The production `portcullis` crate defines its own `CapabilityLevel` with
+//! serde support, and depends on this crate. A compile-time assertion in
+//! `portcullis::capability` checks that the two enums have identical size,
+//! alignment, and discriminant values. If someone changes either enum without
+//! updating the other, the build fails.
+//!
+//! They are separate types (not re-exported) because `portcullis-core` is
+//! intentionally zero-dependency for Aeneas translation, while the production
+//! `CapabilityLevel` needs `#[derive(Serialize, Deserialize)]`.
 //!
 //! ## Aeneas pipeline
 //!
@@ -26,12 +35,24 @@
 //!     → Mathlib HeytingAlgebra proof (connects to generated types)
 //! ```
 //!
-//! ## Correspondence with hand-written Lean model
+//! ## What the proof covers (and does not cover)
 //!
-//! The existing proof in `portcullis-verified/lean/` uses a hand-written
-//! Lean model of these types. The Aeneas pipeline replaces that model with
-//! machine-generated code, ensuring the proof covers production Rust —
-//! not a manually maintained mirror that could drift.
+//! The Aeneas pipeline generates the Lean **type** from this Rust crate and
+//! keeps it in sync via CI. The HeytingAlgebra proof is on the generated type
+//! (kernel-checked, no `sorry`). This means:
+//!
+//! - **Covered**: The type definition (`CapabilityLevel`, `CapabilityLattice`)
+//!   is machine-translated from Rust to Lean. The proof that these types form
+//!   a HeytingAlgebra is kernel-checked against the generated code.
+//!
+//! - **Not yet covered**: Function-level correspondence (proving that the Rust
+//!   `meet()` implementation equals the lattice meet in the Lean proof) requires
+//!   completing the `FunsExternal.lean` stubs. This is tracked as future work.
+//!
+//! - **Defense in depth**: 62 Kani proofs verify the production lattice operations
+//!   (meet monotonicity, Heyting adjunction, etc.) in CI on every PR. The Lean
+//!   proof verifies algebraic structure of the type. Together they provide
+//!   complementary assurance.
 
 /// Tool permission levels in lattice ordering.
 ///

--- a/crates/portcullis/Cargo.toml
+++ b/crates/portcullis/Cargo.toml
@@ -36,6 +36,7 @@ remote-audit = ["dep:aws-sdk-s3", "dep:aws-config", "dep:tokio", "serde"]
 testing = []
 
 [dependencies]
+portcullis-core = { path = "../portcullis-core" }
 chrono = { workspace = true }
 hex = { workspace = true }
 hmac = { workspace = true }

--- a/crates/portcullis/src/capability.rs
+++ b/crates/portcullis/src/capability.rs
@@ -25,6 +25,23 @@ pub enum CapabilityLevel {
     Always = 2,
 }
 
+// Compile-time correspondence check: portcullis-core CapabilityLevel must
+// match production CapabilityLevel (catches drift between verified and production).
+const _: () = {
+    assert!(
+        std::mem::size_of::<CapabilityLevel>()
+            == std::mem::size_of::<portcullis_core::CapabilityLevel>()
+    );
+    assert!(
+        std::mem::align_of::<CapabilityLevel>()
+            == std::mem::align_of::<portcullis_core::CapabilityLevel>()
+    );
+    // Discriminant correspondence: Never=0, LowRisk=1, Always=2
+    assert!(CapabilityLevel::Never as u8 == portcullis_core::CapabilityLevel::Never as u8);
+    assert!(CapabilityLevel::LowRisk as u8 == portcullis_core::CapabilityLevel::LowRisk as u8);
+    assert!(CapabilityLevel::Always as u8 == portcullis_core::CapabilityLevel::Always as u8);
+};
+
 impl std::fmt::Display for CapabilityLevel {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/docs/for-openclaw-users.md
+++ b/docs/for-openclaw-users.md
@@ -20,7 +20,7 @@ Nucleus replaces the YAML policy file with a **permission lattice** — a mathem
 | **Enforcement** | Kernel-level sandbox | Kernel-level sandbox + lattice intercept |
 | **Can agent modify policy?** | Yes (if it has filesystem access) | No (lattice is immutable, meet is monotonically decreasing) |
 | **Formal verification** | None | 62 Kani proofs + Lean 4 HeytingAlgebra instance |
-| **Proof covers production code?** | N/A | Yes — Aeneas translates Rust MIR to Lean, proof is against generated code |
+| **Proof covers production code?** | N/A | Type-level: Aeneas translates Rust type to Lean, proof is on generated type. Function-level: tracked as future work (Kani covers operations in CI) |
 | **Permission granularity** | Binary (allow/deny per endpoint) | 12 dimensions with 3 levels each (Never/LowRisk/Always) |
 | **Real-time observability** | Logs | OTLP spans with all 12 capability dimensions per verdict |
 | **Fleet lockdown** | Per-container restart | Sub-second gRPC broadcast to all agents |
@@ -130,7 +130,7 @@ lake build PortcullisVerified  # kernel-checks all theorems
 
 ### Aeneas Pipeline (Rust → Lean 4, machine-translated)
 
-The proof doesn't verify a hand-written model — it verifies the actual production Rust code via [Aeneas](https://github.com/AeneasVerif/aeneas):
+The Aeneas pipeline translates the Rust **type definitions** into Lean 4 via [Aeneas](https://github.com/AeneasVerif/aeneas):
 
 ```
 portcullis-core (Rust source)
@@ -140,6 +140,10 @@ portcullis-core (Rust source)
 ```
 
 If someone changes the Rust `CapabilityLevel` enum, the Aeneas pipeline regenerates the Lean code, and the proof either still type-checks or CI fails.
+
+**What this covers today**: The generated Lean type is proven to satisfy HeytingAlgebra axioms (kernel-checked, no `sorry`). A compile-time assertion in the production `portcullis` crate verifies that the core and production `CapabilityLevel` enums have matching discriminants — if they drift, the build fails.
+
+**What this does NOT yet cover**: Function-level correspondence (proving that the Rust `meet()` implementation equals the lattice meet from the proof) requires completing the `FunsExternal.lean` stubs. This is tracked as future work. In the meantime, 62 Kani proofs verify the production lattice operations (meet monotonicity, Heyting adjunction, etc.) on every PR.
 
 ## Architecture
 
@@ -197,7 +201,7 @@ NemoClaw's YAML policy becomes the *outer* boundary. Nucleus's lattice becomes t
 - **Fleet lockdown**: Sub-second via gRPC streaming, signal file fallback
 - **OTLP telemetry**: Every verdict as an OTel span, compatible with Grafana/Datadog/Splunk
 - **Compliance export**: SOC 2 format from the witness chain
-- **Aeneas pipeline**: Proof covers production Rust (not a hand-written model)
+- **Aeneas pipeline**: Type correspondence verified (Rust type → Lean type via Aeneas); function correspondence tracked as future work; 62 Kani proofs cover production operations in CI
 
 ## Learn More
 


### PR DESCRIPTION
## Summary

- **portcullis now depends on portcullis-core** with compile-time `const` assertions that verify `CapabilityLevel` size, alignment, and discriminant values match between the verified (zero-dep) and production (serde-enabled) enums. If either enum drifts, the build fails.
- **Updated docs** (`for-openclaw-users.md`, `portcullis-core` doc comments, Cargo.toml comments) to accurately describe what the Aeneas proof covers: type correspondence (Rust type → Lean type, kernel-checked), not function correspondence (requires completing `FunsExternal.lean` stubs, tracked as future work).
- **No code changes to lattice operations** — 541 portcullis tests and 10 portcullis-core tests pass unchanged.

## What changed

| File | Change |
|------|--------|
| `crates/portcullis/Cargo.toml` | Added `portcullis-core` dependency |
| `crates/portcullis/src/capability.rs` | Added compile-time correspondence assertion |
| `crates/portcullis-core/Cargo.toml` | Fixed comment (was "re-exports", now accurately describes assertion) |
| `crates/portcullis-core/src/lib.rs` | Rewrote doc comment with honest coverage description |
| `docs/for-openclaw-users.md` | Updated 3 claims about proof coverage |
| `Cargo.lock` | Updated for new dependency edge |

## Test plan

- [x] `cargo build -p portcullis -p portcullis-core` succeeds
- [x] `cargo test -p portcullis --lib` — 541 tests pass
- [x] `cargo test -p portcullis-core` — 10 tests pass
- [x] All pre-commit hooks pass (fmt, clippy, deny, audit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)