### PR TITLE
feat: single source of truth for CapabilityLevel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3515,6 +3515,9 @@ dependencies = [
 [[package]]
 name = "portcullis-core"
 version = "1.0.0"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "potential_utf"

--- a/crates/portcullis-core/Cargo.toml
+++ b/crates/portcullis-core/Cargo.toml
@@ -6,18 +6,21 @@ license = "MIT"
 description = "Core capability lattice types — dependency-free for Aeneas verification"
 repository = "https://github.com/coproduct-opensource/nucleus"
 
-# This crate is intentionally dependency-free. The types here are the
-# verification target: Aeneas (Rust MIR → Lean 4) translates this crate
+# This crate is the single source of truth for CapabilityLevel.
+# The verification target: Aeneas (Rust MIR → Lean 4) translates this crate
 # into pure functional Lean code, where we prove HeytingAlgebra properties
 # against the same Mathlib instance used by portcullis-verified.
 #
-# DO NOT add dependencies. External crate types (serde, BTreeMap, etc.)
-# are not supported by Aeneas's Lean backend. If you need serde, use
-# the full `portcullis` crate which defines its own CapabilityLevel with
-# serde support and a compile-time assertion that the discriminants match.
+# By default this crate is dependency-free for Aeneas translation.
+# The optional `serde` feature enables serialization support when used
+# by the production `portcullis` crate (Aeneas ignores feature flags).
+
+[features]
+default = []
+serde = ["dep:serde"]
 
 [dependencies]
-# None — intentionally dependency-free for Aeneas translation
+serde = { version = "1", features = ["derive"], optional = true }
 
 [lints.rust]
 unexpected_cfgs = { level = "allow", check-cfg = ['cfg(kani)'] }

--- a/crates/portcullis-core/src/lib.rs
+++ b/crates/portcullis-core/src/lib.rs
@@ -15,15 +15,14 @@
 //!
 //! ## Relationship to the production `portcullis` crate
 //!
-//! The production `portcullis` crate defines its own `CapabilityLevel` with
-//! serde support, and depends on this crate. A compile-time assertion in
-//! `portcullis::capability` checks that the two enums have identical size,
-//! alignment, and discriminant values. If someone changes either enum without
-//! updating the other, the build fails.
+//! The production `portcullis` crate re-exports `CapabilityLevel` from this
+//! crate — there is ONE type, one source of truth, zero translation layers.
+//! The verified type IS the production type.
 //!
-//! They are separate types (not re-exported) because `portcullis-core` is
-//! intentionally zero-dependency for Aeneas translation, while the production
-//! `CapabilityLevel` needs `#[derive(Serialize, Deserialize)]`.
+//! Serde support is gated behind the optional `serde` feature flag.
+//! When `portcullis` depends on `portcullis-core` with `features = ["serde"]`,
+//! the type gains `Serialize`/`Deserialize`. Without the feature, the crate
+//! remains dependency-free for Aeneas translation.
 //!
 //! ## Aeneas pipeline
 //!
@@ -63,6 +62,8 @@
 /// - `Always` is the top element (⊤)
 /// - `meet` = min, `join` = max
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[repr(u8)]
 pub enum CapabilityLevel {
     /// Never allow — bottom element (⊥)
@@ -72,6 +73,16 @@ pub enum CapabilityLevel {
     LowRisk = 1,
     /// Always auto-approve — top element (⊤)
     Always = 2,
+}
+
+impl std::fmt::Display for CapabilityLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CapabilityLevel::Never => write!(f, "never"),
+            CapabilityLevel::LowRisk => write!(f, "low_risk"),
+            CapabilityLevel::Always => write!(f, "always"),
+        }
+    }
 }
 
 impl CapabilityLevel {

--- a/crates/portcullis/Cargo.toml
+++ b/crates/portcullis/Cargo.toml
@@ -36,7 +36,7 @@ remote-audit = ["dep:aws-sdk-s3", "dep:aws-config", "dep:tokio", "serde"]
 testing = []
 
 [dependencies]
-portcullis-core = { path = "../portcullis-core" }
+portcullis-core = { path = "../portcullis-core", features = ["serde"] }
 chrono = { workspace = true }
 hex = { workspace = true }
 hmac = { workspace = true }

--- a/crates/portcullis/src/capability.rs
+++ b/crates/portcullis/src/capability.rs
@@ -7,50 +7,9 @@ use serde::{Deserialize, Serialize};
 
 /// Tool permission levels in lattice ordering.
 ///
-/// The ordering is: `Never < LowRisk < Always`
-///
-/// - `Never`: Never allow
-/// - `LowRisk`: Auto-approve for low-risk operations
-/// - `Always`: Always auto-approve
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
-pub enum CapabilityLevel {
-    /// Never allow
-    #[default]
-    Never = 0,
-    /// Auto-approve for low-risk operations
-    LowRisk = 1,
-    /// Always auto-approve
-    Always = 2,
-}
-
-// Compile-time correspondence check: portcullis-core CapabilityLevel must
-// match production CapabilityLevel (catches drift between verified and production).
-const _: () = {
-    assert!(
-        std::mem::size_of::<CapabilityLevel>()
-            == std::mem::size_of::<portcullis_core::CapabilityLevel>()
-    );
-    assert!(
-        std::mem::align_of::<CapabilityLevel>()
-            == std::mem::align_of::<portcullis_core::CapabilityLevel>()
-    );
-    // Discriminant correspondence: Never=0, LowRisk=1, Always=2
-    assert!(CapabilityLevel::Never as u8 == portcullis_core::CapabilityLevel::Never as u8);
-    assert!(CapabilityLevel::LowRisk as u8 == portcullis_core::CapabilityLevel::LowRisk as u8);
-    assert!(CapabilityLevel::Always as u8 == portcullis_core::CapabilityLevel::Always as u8);
-};
-
-impl std::fmt::Display for CapabilityLevel {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            CapabilityLevel::Never => write!(f, "never"),
-            CapabilityLevel::LowRisk => write!(f, "low_risk"),
-            CapabilityLevel::Always => write!(f, "always"),
-        }
-    }
-}
+/// Single source of truth: re-exported from `portcullis-core`.
+/// The verified type IS the production type — one type, zero translation layers.
+pub use portcullis_core::CapabilityLevel;
 
 /// Operations that can be gated by approval.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]


### PR DESCRIPTION
## Summary

- portcullis now re-exports `CapabilityLevel` from `portcullis-core` instead of defining its own independent copy
- Added optional `serde` feature to `portcullis-core` with `cfg_attr`-gated `Serialize`/`Deserialize` derives
- Moved `Display` impl to `portcullis-core` so it travels with the type
- Removed the compile-time size/discriminant assertion block (no longer needed — it's literally the same type)

The verified type IS the production type. One type, one source of truth, zero translation layers.

## Test plan

- [x] `cargo build -p portcullis-core` — builds with serde feature
- [x] `cargo build -p portcullis` — re-export compiles, all impl blocks work
- [x] `cargo test -p portcullis-core` — 10 tests pass
- [x] `cargo test -p portcullis --lib` — 549 tests pass (including Lean correspondence tests)
- [x] `cargo build` — full workspace builds clean
- [x] All pre-commit hooks pass (fmt, clippy, deny, audit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)