### PR TITLE
fix: close 4 Trail of Bits adversarial findings

### DIFF
--- a/crates/nucleus-node/src/main.rs
+++ b/crates/nucleus-node/src/main.rs
@@ -2757,7 +2757,17 @@ impl NodeService for GrpcService {
         let manifest_hash =
             nucleus_identity::approval_bundle::compute_manifest_hash(spec_yaml.as_bytes());
 
-        // Compute v1 content hash: SHA-256 of canonical v1 fields
+        // Compute v1 content hash: SHA-256 of canonical v1 fields.
+        //
+        // Trust model (Trail of Bits finding #4): this hash covers CONTENT
+        // (what happened), not IDENTITY (who attested). The executor's Ed25519
+        // signature is sent separately in the X-Nucleus-Executor-Sig header and
+        // signs the serialized session-complete body (which includes this hash).
+        // Verification is two-phase:
+        //   1. Trust-service validates v1_content_hash was pre-registered.
+        //   2. Trust-service verifies Ed25519 signature against executor's
+        //      registered public key.
+        // See also: AuditEntry::content_hash() in portcullis/src/audit.rs.
         let v1_content_hash = {
             use sha2::{Digest, Sha256};
             let mut hasher = Sha256::new();

--- a/crates/nucleus-tool-proxy/src/main.rs
+++ b/crates/nucleus-tool-proxy/src/main.rs
@@ -2012,7 +2012,7 @@ async fn read_file(
 
     // Validate inputs before any processing
     if let Err(e) = validation::validate_path(&req.path) {
-        let _ = sink.record(VerdictContext {
+        if let Err(e) = sink.record(VerdictContext {
             operation,
             subject: req.path.clone(),
             outcome: VerdictOutcome::Deny {
@@ -2021,7 +2021,9 @@ async fn read_file(
             actor,
             policy_rule: None,
             extensions: BTreeMap::new(),
-        });
+        }) {
+            warn!(error = %e, "verdict recording failed -- audit gap");
+        }
         return Err(ApiError::Validation(e));
     }
 
@@ -2040,7 +2042,7 @@ async fn read_file(
                     .sandbox()
                     .read_to_string_approved(&path, &token)?
             } else {
-                let _ = sink.record(VerdictContext {
+                if let Err(e) = sink.record(VerdictContext {
                     operation,
                     subject: path.clone(),
                     outcome: VerdictOutcome::Deny {
@@ -2049,14 +2051,16 @@ async fn read_file(
                     actor,
                     policy_rule: None,
                     extensions: BTreeMap::new(),
-                });
+                }) {
+                    warn!(error = %e, "verdict recording failed -- audit gap");
+                }
                 return Err(ApiError::Nucleus(NucleusError::ApprovalRequired {
                     operation: op,
                 }));
             }
         }
         Err(err) => {
-            let _ = sink.record(VerdictContext {
+            if let Err(e) = sink.record(VerdictContext {
                 operation,
                 subject: path.clone(),
                 outcome: VerdictOutcome::Error {
@@ -2065,19 +2069,23 @@ async fn read_file(
                 actor,
                 policy_rule: None,
                 extensions: BTreeMap::new(),
-            });
+            }) {
+                warn!(error = %e, "verdict recording failed -- audit gap");
+            }
             return Err(ApiError::Nucleus(err));
         }
     };
 
-    let _ = sink.record(VerdictContext {
+    if let Err(e) = sink.record(VerdictContext {
         operation,
         subject: path,
         outcome: VerdictOutcome::Allow,
         actor,
         policy_rule: None,
         extensions: BTreeMap::new(),
-    });
+    }) {
+        warn!(error = %e, "verdict recording failed -- audit gap");
+    }
     Ok(Json(ReadResponse { contents }))
 }
 
@@ -2094,7 +2102,7 @@ async fn write_file(
 
     // Validate inputs before any processing
     if let Err(e) = validation::validate_path(&req.path) {
-        let _ = sink.record(VerdictContext {
+        if let Err(e) = sink.record(VerdictContext {
             operation,
             subject: req.path.clone(),
             outcome: VerdictOutcome::Deny {
@@ -2103,7 +2111,9 @@ async fn write_file(
             actor,
             policy_rule: None,
             extensions: BTreeMap::new(),
-        });
+        }) {
+            warn!(error = %e, "verdict recording failed -- audit gap");
+        }
         return Err(ApiError::Validation(e));
     }
 
@@ -2123,7 +2133,7 @@ async fn write_file(
                     .sandbox()
                     .write_approved(&path, contents.as_bytes(), &token)?;
             } else {
-                let _ = sink.record(VerdictContext {
+                if let Err(e) = sink.record(VerdictContext {
                     operation,
                     subject: path.clone(),
                     outcome: VerdictOutcome::Deny {
@@ -2132,14 +2142,16 @@ async fn write_file(
                     actor,
                     policy_rule: None,
                     extensions: BTreeMap::new(),
-                });
+                }) {
+                    warn!(error = %e, "verdict recording failed -- audit gap");
+                }
                 return Err(ApiError::Nucleus(NucleusError::ApprovalRequired {
                     operation: op,
                 }));
             }
         }
         Err(err) => {
-            let _ = sink.record(VerdictContext {
+            if let Err(e) = sink.record(VerdictContext {
                 operation,
                 subject: path.clone(),
                 outcome: VerdictOutcome::Error {
@@ -2148,19 +2160,23 @@ async fn write_file(
                 actor,
                 policy_rule: None,
                 extensions: BTreeMap::new(),
-            });
+            }) {
+                warn!(error = %e, "verdict recording failed -- audit gap");
+            }
             return Err(ApiError::Nucleus(err));
         }
     }
 
-    let _ = sink.record(VerdictContext {
+    if let Err(e) = sink.record(VerdictContext {
         operation,
         subject: path,
         outcome: VerdictOutcome::Allow,
         actor,
         policy_rule: None,
         extensions: BTreeMap::new(),
-    });
+    }) {
+        warn!(error = %e, "verdict recording failed -- audit gap");
+    }
     Ok(Json(WriteResponse { ok: true }))
 }
 
@@ -2180,7 +2196,7 @@ async fn run_command(
 
     // Validate inputs before any processing
     if let Err(e) = validation::validate_command_args(&req.args) {
-        let _ = sink.record(VerdictContext {
+        if let Err(e) = sink.record(VerdictContext {
             operation,
             subject: display_command.clone(),
             outcome: VerdictOutcome::Deny {
@@ -2189,11 +2205,13 @@ async fn run_command(
             actor,
             policy_rule: None,
             extensions: BTreeMap::new(),
-        });
+        }) {
+            warn!(error = %e, "verdict recording failed -- audit gap");
+        }
         return Err(ApiError::Validation(e));
     }
     if let Err(e) = validation::validate_stdin(req.stdin.as_deref()) {
-        let _ = sink.record(VerdictContext {
+        if let Err(e) = sink.record(VerdictContext {
             operation,
             subject: display_command.clone(),
             outcome: VerdictOutcome::Deny {
@@ -2202,12 +2220,14 @@ async fn run_command(
             actor,
             policy_rule: None,
             extensions: BTreeMap::new(),
-        });
+        }) {
+            warn!(error = %e, "verdict recording failed -- audit gap");
+        }
         return Err(ApiError::Validation(e));
     }
     if let Some(ref dir) = req.directory {
         if let Err(e) = validation::validate_path(dir) {
-            let _ = sink.record(VerdictContext {
+            if let Err(e) = sink.record(VerdictContext {
                 operation,
                 subject: display_command.clone(),
                 outcome: VerdictOutcome::Deny {
@@ -2216,7 +2236,9 @@ async fn run_command(
                 actor,
                 policy_rule: None,
                 extensions: BTreeMap::new(),
-            });
+            }) {
+                warn!(error = %e, "verdict recording failed -- audit gap");
+            }
             return Err(ApiError::Validation(e));
         }
     }
@@ -2240,7 +2262,7 @@ async fn run_command(
                 let token = executor.request_approval(&op)?;
                 executor.run_args_with_approval(&req.args, stdin, directory, &token)?
             } else {
-                let _ = sink.record(VerdictContext {
+                if let Err(e) = sink.record(VerdictContext {
                     operation,
                     subject: display_command.clone(),
                     outcome: VerdictOutcome::Deny {
@@ -2249,14 +2271,16 @@ async fn run_command(
                     actor,
                     policy_rule: None,
                     extensions: BTreeMap::new(),
-                });
+                }) {
+                    warn!(error = %e, "verdict recording failed -- audit gap");
+                }
                 return Err(ApiError::Nucleus(NucleusError::ApprovalRequired {
                     operation: op,
                 }));
             }
         }
         Err(err) => {
-            let _ = sink.record(VerdictContext {
+            if let Err(e) = sink.record(VerdictContext {
                 operation,
                 subject: display_command.clone(),
                 outcome: VerdictOutcome::Error {
@@ -2265,19 +2289,23 @@ async fn run_command(
                 actor,
                 policy_rule: None,
                 extensions: BTreeMap::new(),
-            });
+            }) {
+                warn!(error = %e, "verdict recording failed -- audit gap");
+            }
             return Err(ApiError::Nucleus(err));
         }
     };
 
-    let _ = sink.record(VerdictContext {
+    if let Err(e) = sink.record(VerdictContext {
         operation,
         subject: display_command,
         outcome: VerdictOutcome::Allow,
         actor,
         policy_rule: None,
         extensions: BTreeMap::new(),
-    });
+    }) {
+        warn!(error = %e, "verdict recording failed -- audit gap");
+    }
     Ok(Json(RunResponse {
         status: output.status.code().unwrap_or(-1),
         success: output.status.success(),
@@ -2300,7 +2328,7 @@ async fn web_fetch(
 
     // Validate inputs before any processing
     if let Err(e) = validation::validate_url(&req.url) {
-        let _ = sink.record(VerdictContext {
+        if let Err(e) = sink.record(VerdictContext {
             operation,
             subject: url_str.clone(),
             outcome: VerdictOutcome::Deny {
@@ -2309,7 +2337,9 @@ async fn web_fetch(
             actor,
             policy_rule: None,
             extensions: BTreeMap::new(),
-        });
+        }) {
+            warn!(error = %e, "verdict recording failed -- audit gap");
+        }
         return Err(ApiError::Validation(e));
     }
 
@@ -2317,7 +2347,7 @@ async fn web_fetch(
     let policy = state.runtime.policy();
     let level = policy.capabilities.web_fetch;
     if level == CapabilityLevel::Never {
-        let _ = sink.record(VerdictContext {
+        if let Err(e) = sink.record(VerdictContext {
             operation,
             subject: url_str.clone(),
             outcome: VerdictOutcome::Deny {
@@ -2326,7 +2356,9 @@ async fn web_fetch(
             actor,
             policy_rule: None,
             extensions: BTreeMap::new(),
-        });
+        }) {
+            warn!(error = %e, "verdict recording failed -- audit gap");
+        }
         return Err(ApiError::Nucleus(NucleusError::InsufficientCapability {
             capability: "web_fetch".into(),
             actual: level,
@@ -2341,7 +2373,7 @@ async fn web_fetch(
             check_identity_policy(&state, auth_ctx.as_ref(), &format!("web_fetch {}", url_str));
 
         if !policy_allows && !state.approvals.consume("web_fetch") {
-            let _ = sink.record(VerdictContext {
+            if let Err(e) = sink.record(VerdictContext {
                 operation,
                 subject: url_str.clone(),
                 outcome: VerdictOutcome::Deny {
@@ -2350,7 +2382,9 @@ async fn web_fetch(
                 actor,
                 policy_rule: None,
                 extensions: BTreeMap::new(),
-            });
+            }) {
+                warn!(error = %e, "verdict recording failed -- audit gap");
+            }
             return Err(ApiError::Nucleus(NucleusError::ApprovalRequired {
                 operation: format!("web_fetch {}", url_str),
             }));
@@ -2456,14 +2490,16 @@ async fn web_fetch(
         (String::from_utf8_lossy(&bytes).to_string(), None)
     };
 
-    let _ = sink.record(VerdictContext {
+    if let Err(e) = sink.record(VerdictContext {
         operation,
         subject: url_str,
         outcome: VerdictOutcome::Allow,
         actor,
         policy_rule: None,
         extensions: BTreeMap::new(),
-    });
+    }) {
+        warn!(error = %e, "verdict recording failed -- audit gap");
+    }
     Ok(Json(WebFetchResponse {
         status,
         headers: response_headers,
@@ -2494,7 +2530,7 @@ async fn glob_search(
     let policy = state.runtime.policy();
     let level = policy.capabilities.glob_search;
     if level == CapabilityLevel::Never {
-        let _ = sink.record(VerdictContext {
+        if let Err(e) = sink.record(VerdictContext {
             operation,
             subject: req.pattern.clone(),
             outcome: VerdictOutcome::Deny {
@@ -2503,7 +2539,9 @@ async fn glob_search(
             actor,
             policy_rule: None,
             extensions: BTreeMap::new(),
-        });
+        }) {
+            warn!(error = %e, "verdict recording failed -- audit gap");
+        }
         return Err(ApiError::Nucleus(NucleusError::InsufficientCapability {
             capability: "glob_search".into(),
             actual: level,
@@ -2516,7 +2554,7 @@ async fn glob_search(
         let policy_allows =
             check_identity_policy(&state, auth_ctx.as_ref(), &format!("glob {}", req.pattern));
         if !policy_allows && !state.approvals.consume("glob_search") {
-            let _ = sink.record(VerdictContext {
+            if let Err(e) = sink.record(VerdictContext {
                 operation,
                 subject: req.pattern.clone(),
                 outcome: VerdictOutcome::Deny {
@@ -2525,7 +2563,9 @@ async fn glob_search(
                 actor,
                 policy_rule: None,
                 extensions: BTreeMap::new(),
-            });
+            }) {
+                warn!(error = %e, "verdict recording failed -- audit gap");
+            }
             return Err(ApiError::Nucleus(NucleusError::ApprovalRequired {
                 operation: format!("glob {}", req.pattern),
             }));
@@ -2599,14 +2639,16 @@ async fn glob_search(
         }
     }
 
-    let _ = sink.record(VerdictContext {
+    if let Err(e) = sink.record(VerdictContext {
         operation,
         subject: req.pattern,
         outcome: VerdictOutcome::Allow,
         actor,
         policy_rule: None,
         extensions: BTreeMap::new(),
-    });
+    }) {
+        warn!(error = %e, "verdict recording failed -- audit gap");
+    }
     Ok(Json(GlobResponse {
         matches,
         truncated: if truncated { Some(true) } else { None },
@@ -2642,7 +2684,7 @@ async fn grep_search(
     let policy = state.runtime.policy();
     let level = policy.capabilities.grep_search;
     if level == CapabilityLevel::Never {
-        let _ = sink.record(VerdictContext {
+        if let Err(e) = sink.record(VerdictContext {
             operation,
             subject: req.pattern.clone(),
             outcome: VerdictOutcome::Deny {
@@ -2651,7 +2693,9 @@ async fn grep_search(
             actor,
             policy_rule: None,
             extensions: BTreeMap::new(),
-        });
+        }) {
+            warn!(error = %e, "verdict recording failed -- audit gap");
+        }
         return Err(ApiError::Nucleus(NucleusError::InsufficientCapability {
             capability: "grep_search".into(),
             actual: level,
@@ -2664,7 +2708,7 @@ async fn grep_search(
         let policy_allows =
             check_identity_policy(&state, auth_ctx.as_ref(), &format!("grep {}", req.pattern));
         if !policy_allows && !state.approvals.consume("grep_search") {
-            let _ = sink.record(VerdictContext {
+            if let Err(e) = sink.record(VerdictContext {
                 operation,
                 subject: req.pattern.clone(),
                 outcome: VerdictOutcome::Deny {
@@ -2673,7 +2717,9 @@ async fn grep_search(
                 actor,
                 policy_rule: None,
                 extensions: BTreeMap::new(),
-            });
+            }) {
+                warn!(error = %e, "verdict recording failed -- audit gap");
+            }
             return Err(ApiError::Nucleus(NucleusError::ApprovalRequired {
                 operation: format!("grep {}", req.pattern),
             }));
@@ -2798,14 +2844,16 @@ async fn grep_search(
         }
     }
 
-    let _ = sink.record(VerdictContext {
+    if let Err(e) = sink.record(VerdictContext {
         operation,
         subject: req.pattern,
         outcome: VerdictOutcome::Allow,
         actor,
         policy_rule: None,
         extensions: BTreeMap::new(),
-    });
+    }) {
+        warn!(error = %e, "verdict recording failed -- audit gap");
+    }
     Ok(Json(GrepResponse {
         matches,
         truncated: if truncated { Some(true) } else { None },
@@ -2831,7 +2879,7 @@ async fn web_search(
     let policy = state.runtime.policy();
     let level = policy.capabilities.web_search;
     if level == CapabilityLevel::Never {
-        let _ = sink.record(VerdictContext {
+        if let Err(e) = sink.record(VerdictContext {
             operation,
             subject: req.query.clone(),
             outcome: VerdictOutcome::Deny {
@@ -2840,7 +2888,9 @@ async fn web_search(
             actor,
             policy_rule: None,
             extensions: BTreeMap::new(),
-        });
+        }) {
+            warn!(error = %e, "verdict recording failed -- audit gap");
+        }
         return Err(ApiError::Nucleus(NucleusError::InsufficientCapability {
             capability: "web_search".into(),
             actual: level,
@@ -2856,7 +2906,7 @@ async fn web_search(
             &format!("web_search {}", req.query),
         );
         if !policy_allows && !state.approvals.consume("web_search") {
-            let _ = sink.record(VerdictContext {
+            if let Err(e) = sink.record(VerdictContext {
                 operation,
                 subject: req.query.clone(),
                 outcome: VerdictOutcome::Deny {
@@ -2865,7 +2915,9 @@ async fn web_search(
                 actor,
                 policy_rule: None,
                 extensions: BTreeMap::new(),
-            });
+            }) {
+                warn!(error = %e, "verdict recording failed -- audit gap");
+            }
             return Err(ApiError::Nucleus(NucleusError::ApprovalRequired {
                 operation: format!("web_search {}", req.query),
             }));
@@ -2949,14 +3001,16 @@ async fn web_search(
         Vec::new()
     };
 
-    let _ = sink.record(VerdictContext {
+    if let Err(e) = sink.record(VerdictContext {
         operation,
         subject: req.query,
         outcome: VerdictOutcome::Allow,
         actor,
         policy_rule: None,
         extensions: BTreeMap::new(),
-    });
+    }) {
+        warn!(error = %e, "verdict recording failed -- audit gap");
+    }
     Ok(Json(WebSearchResponse { results }))
 }
 
@@ -2985,14 +3039,16 @@ async fn approve_operation(
     state
         .approvals
         .approve(&req.operation, req.count, expires_at);
-    let _ = sink.record(VerdictContext {
+    if let Err(e) = sink.record(VerdictContext {
         operation: Operation::ManagePods, // meta-operation: approval grant
         subject: req.operation,
         outcome: VerdictOutcome::Allow,
         actor: ActorIdentity::Unknown,
         policy_rule: None,
         extensions: BTreeMap::new(),
-    });
+    }) {
+        warn!(error = %e, "verdict recording failed -- audit gap");
+    }
     Ok(Json(ApproveResponse { ok: true }))
 }
 
@@ -3150,14 +3206,16 @@ async fn escalate_permissions(
             // Create the grant
             match EscalationGrant::new(&escalation_request, approver_chain, drand_round) {
                 Ok(grant) => {
-                    let _ = sink.record(VerdictContext {
+                    if let Err(e) = sink.record(VerdictContext {
                         operation,
                         subject: escalation_subject,
                         outcome: VerdictOutcome::Allow,
                         actor,
                         policy_rule: None,
                         extensions: BTreeMap::new(),
-                    });
+                    }) {
+                        warn!(error = %e, "verdict recording failed -- audit gap");
+                    }
 
                     tracing::info!(
                         requestor = %requestor_chain.current_spiffe_id().unwrap_or("unknown"),
@@ -3182,7 +3240,7 @@ async fn escalate_permissions(
                 Err(e) => {
                     let error_msg = escalation_error_to_string(&e);
 
-                    let _ = sink.record(VerdictContext {
+                    if let Err(e) = sink.record(VerdictContext {
                         operation,
                         subject: escalation_subject,
                         outcome: VerdictOutcome::Deny {
@@ -3191,7 +3249,9 @@ async fn escalate_permissions(
                         actor,
                         policy_rule: None,
                         extensions: BTreeMap::new(),
-                    });
+                    }) {
+                        warn!(error = %e, "verdict recording failed -- audit gap");
+                    }
 
                     tracing::warn!(
                         requestor = %requestor_chain.current_spiffe_id().unwrap_or("unknown"),
@@ -3215,7 +3275,7 @@ async fn escalate_permissions(
         Err(e) => {
             let error_msg = escalation_error_to_string(&e);
 
-            let _ = sink.record(VerdictContext {
+            if let Err(e) = sink.record(VerdictContext {
                 operation,
                 subject: escalation_subject,
                 outcome: VerdictOutcome::Deny {
@@ -3224,7 +3284,9 @@ async fn escalate_permissions(
                 actor,
                 policy_rule: None,
                 extensions: BTreeMap::new(),
-            });
+            }) {
+                warn!(error = %e, "verdict recording failed -- audit gap");
+            }
 
             tracing::warn!(
                 requestor = %requestor_chain.current_spiffe_id().unwrap_or("unknown"),
@@ -3481,14 +3543,16 @@ async fn create_sub_pod(
         .map_err(|e| ApiError::Spec(format!("node create_pod failed: {e}")))?;
 
     // 7. Record verdict
-    let _ = sink.record(VerdictContext {
+    if let Err(e) = sink.record(VerdictContext {
         operation: Operation::ManagePods,
         subject: format!("sub-pod {} (reason: {})", result.id, req.reason),
         outcome: VerdictOutcome::Allow,
         actor,
         policy_rule: None,
         extensions: BTreeMap::new(),
-    });
+    }) {
+        warn!(error = %e, "verdict recording failed -- audit gap");
+    }
 
     Ok(Json(CreateSubPodResponse {
         pod_id: result.id.to_string(),
@@ -3591,14 +3655,16 @@ async fn cancel_sub_pod(
         .await
         .map_err(|e| ApiError::Spec(format!("node cancel_pod failed: {e}")))?;
 
-    let _ = sink.record(VerdictContext {
+    if let Err(e) = sink.record(VerdictContext {
         operation: Operation::ManagePods,
         subject: format!("sub-pod {}", req.pod_id),
         outcome: VerdictOutcome::Allow,
         actor,
         policy_rule: None,
         extensions: BTreeMap::new(),
-    });
+    }) {
+        warn!(error = %e, "verdict recording failed -- audit gap");
+    }
 
     Ok(Json(
         serde_json::json!({ "status": "cancelled", "pod_id": req.pod_id }),

--- a/crates/nucleus-tool-proxy/src/mcp.rs
+++ b/crates/nucleus-tool-proxy/src/mcp.rs
@@ -152,15 +152,21 @@ impl NucleusMcpServer {
     }
 
     /// Record a verdict through the sink (best-effort -- never panics).
+    ///
+    /// SECURITY: errors are logged at warn level so audit gaps are visible
+    /// in telemetry. Previously errors were silently discarded with `let _ =`,
+    /// making audit backend failures invisible (Trail of Bits finding #3).
     fn record_verdict(&self, operation: Operation, subject: &str, outcome: VerdictOutcome) {
-        let _ = self.sink.record(VerdictContext {
+        if let Err(e) = self.sink.record(VerdictContext {
             operation,
             subject: subject.to_string(),
             outcome,
             actor: ActorIdentity::StdioGuest,
             policy_rule: None,
             extensions: BTreeMap::new(),
-        });
+        }) {
+            warn!(error = %e, ?operation, subject, "verdict recording failed — audit gap");
+        }
     }
 
     // -----------------------------------------------------------------------

--- a/crates/portcullis/src/audit.rs
+++ b/crates/portcullis/src/audit.rs
@@ -142,6 +142,34 @@ impl AuditEntry {
     ///
     /// The hash covers all fields including `prev_hash`, making the chain
     /// tamper-evident: modifying any entry invalidates all subsequent hashes.
+    ///
+    /// ## Trust model: content_hash vs executor_sig (Trail of Bits finding #4)
+    ///
+    /// The `content_hash` and `executor_sig` serve **different trust purposes**
+    /// and are intentionally independent:
+    ///
+    /// - **content_hash** covers WHAT HAPPENED: the canonical event content
+    ///   (sequence, timestamp, identity, event, correlation/session IDs,
+    ///   prev_hash). It forms the tamper-evident chain — modifying any field
+    ///   in any entry breaks all subsequent hashes.
+    ///
+    /// - **executor_sig** (in `extensions`) covers WHO ATTESTED: the Ed25519
+    ///   signature over `content_hash` by the specific executor that observed
+    ///   the event. It provides non-repudiation — only the executor with the
+    ///   private key can produce a valid signature for a given content hash.
+    ///
+    /// The `extensions` map (including `executor_sig`) is deliberately excluded
+    /// from `content_hash` because:
+    /// 1. Extensions are forward-compatible metadata, not canonical content.
+    /// 2. The signature signs the content_hash, creating a separate binding:
+    ///    `executor_sig = Ed25519(signing_key, content_hash)`.
+    /// 3. Including the signature in the hash would create a circular dependency.
+    /// 4. Verification is: check content_hash chain integrity, THEN verify
+    ///    executor_sig against the registered public key independently.
+    ///
+    /// An attacker who replaces executor_sig without the private key produces
+    /// an invalid signature that fails Ed25519 verification. An attacker who
+    /// modifies content breaks the hash chain. Both attack vectors are covered.
     pub fn content_hash(&self) -> String {
         let mut hasher = Sha256::new();
         hasher.update(self.sequence.to_le_bytes());

--- a/crates/portcullis/src/exposure_core.rs
+++ b/crates/portcullis/src/exposure_core.rs
@@ -101,10 +101,28 @@ pub fn should_deny(
 /// Returns the new exposure set after recording this operation.
 /// Only non-neutral operations modify the exposure.
 ///
-/// Note: RunBash records ONLY ExfilVector (its actual exposure label),
-/// NOT the omnibus projection. The omnibus projection is conservative
-/// over-approximation used in `project_exposure`/`should_deny` for
-/// safety. The record reflects what actually happened.
+/// ## Intentional asymmetry with `project_exposure` for RunBash
+///
+/// `project_exposure` conservatively adds `{PrivateData, ExfilVector}` for
+/// RunBash because bash *can* read files and exfiltrate data. This is the
+/// pre-check over-approximation: deny anything that *might* complete the
+/// uninhabitable state.
+///
+/// `apply_record` adds only `ExfilVector` (the actual classification from
+/// `classify_operation`), because the post-check records what the operation
+/// *actually contributed*, not what it theoretically could have done.
+///
+/// This asymmetry is by design (Trail of Bits finding #2):
+/// - **Pre-check (project_exposure)**: conservative for safety — blocks
+///   operations that *could* complete the uninhabitable state.
+/// - **Post-check (apply_record)**: precise for accuracy — records the
+///   actual exposure leg so that subsequent pre-checks start from an
+///   accurate baseline rather than an inflated one.
+///
+/// If `apply_record` used the omnibus projection, a single RunBash call
+/// would inflate the exposure to `{PrivateData, ExfilVector}` even if
+/// the command was `echo hello`. This would make subsequent web_fetch
+/// calls trigger uninhabitable_state warnings incorrectly.
 ///
 /// Verus equivalent: `apply_event_exposure(exposure, McpEvent{op, succeeded: true})`
 #[inline]

--- a/crates/portcullis/src/mcp_mediation.rs
+++ b/crates/portcullis/src/mcp_mediation.rs
@@ -443,9 +443,42 @@ impl McpMediator {
                         tool_name: tool_name.to_string(),
                     };
                 } else {
-                    // Fail-open: allow unclassified tools without mediation
+                    // Fail-open for classification, but still check the permission
+                    // lattice. Unclassified tools are conservatively treated as
+                    // RunBash (highest-privilege operation) so the lattice check
+                    // catches policy violations even for unknown tool names.
+                    // SECURITY: Without this lattice check, unclassified tools
+                    // bypassed the permission lattice entirely when
+                    // deny_unclassified was false (Trail of Bits finding #1).
+                    let conservative_op = Operation::RunBash;
+                    let level = self.get_capability_level(conservative_op);
+                    if level == CapabilityLevel::Never {
+                        return MediationVerdict::Deny {
+                            operation: Some(conservative_op),
+                            reason: format!(
+                                "unclassified tool '{}' mapped to {:?} which is set to Never in policy",
+                                tool_name, conservative_op
+                            ),
+                        };
+                    }
+
+                    // Check uninhabitable_state constraint for the conservative op
+                    let requires_approval = self.policy.requires_approval(conservative_op);
+                    if requires_approval {
+                        let projected = project_exposure(&self.exposure, conservative_op);
+                        if projected.is_uninhabitable() && self.policy.uninhabitable_constraint {
+                            return MediationVerdict::RequiresApproval {
+                                operation: conservative_op,
+                                reason: format!(
+                                    "unclassified tool '{}' (mapped to {:?}) on '{}' would complete the uninhabitable_state — approval required",
+                                    tool_name, conservative_op, subject
+                                ),
+                            };
+                        }
+                    }
+
                     return MediationVerdict::Allow {
-                        operation: Operation::RunBash, // Most conservative classification
+                        operation: conservative_op,
                         exposure_label: Some(ExposureLabel::ExfilVector),
                     };
                 }
@@ -809,13 +842,35 @@ mod tests {
     }
 
     #[test]
-    fn test_mediator_unclassified_allowed_when_configured() {
+    fn test_mediator_unclassified_denied_when_conservative_op_is_never() {
+        // restrictive_policy() sets run_bash = Never, so unclassified tools
+        // (mapped to RunBash) should be denied even with allow_unclassified.
+        // Trail of Bits finding #1: previously this returned Allow, bypassing
+        // the permission lattice entirely.
         let policy = restrictive_policy();
         let mediator = McpMediator::new(policy, ToolClassifier::default()).allow_unclassified();
 
         let verdict = mediator.check_tool("frobnicate", "");
-        // Allowed but classified as RunBash (most conservative)
-        assert!(matches!(verdict, MediationVerdict::Allow { .. }));
+        assert!(
+            matches!(verdict, MediationVerdict::Deny { .. }),
+            "unclassified tool should be denied when RunBash is Never, got {:?}",
+            verdict
+        );
+    }
+
+    #[test]
+    fn test_mediator_unclassified_allowed_when_conservative_op_permitted() {
+        // When RunBash is allowed, unclassified tools pass the lattice check.
+        let mut policy = restrictive_policy();
+        policy.capabilities.run_bash = CapabilityLevel::LowRisk;
+        let mediator = McpMediator::new(policy, ToolClassifier::default()).allow_unclassified();
+
+        let verdict = mediator.check_tool("frobnicate", "");
+        assert!(
+            matches!(verdict, MediationVerdict::Allow { .. }),
+            "unclassified tool should be allowed when RunBash is LowRisk, got {:?}",
+            verdict
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Finding 1 (HIGH)**: MCP mediator unclassified tools now check the permission lattice instead of bypassing it when `deny_unclassified=false`. Previously an unclassified tool name could skip all capability checks.
- **Finding 2 (HIGH)**: Documented the intentional asymmetry between `apply_record` (precise post-check) and `project_exposure` (conservative pre-check) for RunBash in `exposure_core.rs`.
- **Finding 3 (HIGH)**: All 33 `let _ = sink.record()` calls in HTTP handlers and 1 in MCP handlers now log at `warn` level on failure, making audit backend outages visible instead of silently swallowed.
- **Finding 4 (HIGH)**: Documented the content_hash vs executor_sig trust model in both `AuditEntry::content_hash()` and the v1 receipt hash computation, clarifying that they serve different purposes (content integrity vs identity attestation) and are verified independently.

## Test plan

- [x] `cargo build -p portcullis -p nucleus-tool-proxy` -- clean
- [x] `cargo test -p portcullis --lib` -- 549 passed
- [x] `cargo test -p nucleus-tool-proxy` -- 169 passed (155 unit + 14 integration)
- [x] Pre-commit hooks: fmt, clippy, deny, audit all pass
- [x] New test: `test_mediator_unclassified_denied_when_conservative_op_is_never` verifies Finding 1 fix
- [x] New test: `test_mediator_unclassified_allowed_when_conservative_op_permitted` verifies lattice pass-through

🤖 Generated with [Claude Code](https://claude.com/claude-code)