### PR TITLE
fix: CI type-checks proofs + discriminant ordering assertion

### DIFF
--- a/.github/workflows/aeneas.yml
+++ b/.github/workflows/aeneas.yml
@@ -107,3 +107,33 @@ jobs:
             exit 1
           fi
           echo "✓ Generated Lean code matches committed version"
+
+      # --- Verify proofs type-check ---
+      - name: Install elan (Lean toolchain)
+        run: |
+          curl -sSf https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
+            | sh -s -- -y --no-modify-path
+          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+
+      - name: Cache Lake / Mathlib build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            crates/portcullis-core/lean/.lake
+            ~/.elan
+          key: lean-aeneas-${{ runner.os }}-${{ hashFiles('crates/portcullis-core/lean/lean-toolchain', 'crates/portcullis-core/lean/lakefile.lean') }}
+          restore-keys: |
+            lean-aeneas-${{ runner.os }}-
+
+      - name: lake build (type-check proofs)
+        working-directory: crates/portcullis-core/lean
+        run: lake build PortcullisCoreBridge
+
+      - name: Reject sorry (proof holes)
+        working-directory: crates/portcullis-core/lean
+        run: |
+          if grep -rn 'sorry' PortcullisCoreBridge.lean generated/PortcullisCore/FunsExternal.lean generated/PortcullisCore/CoreFuns.lean; then
+            echo "ERROR: Lean proofs contain 'sorry' — proof has holes."
+            exit 1
+          fi
+          echo "✓ No sorry found — all proofs complete"

--- a/crates/portcullis-core/src/lib.rs
+++ b/crates/portcullis-core/src/lib.rs
@@ -75,6 +75,16 @@ pub enum CapabilityLevel {
     Always = 2,
 }
 
+// Compile-time invariant: declaration order MUST match discriminant values.
+// The Aeneas-generated Lean code uses `read_discriminant` (declaration-order index)
+// while FunsExternal.lean uses `toNat` (discriminant value). These must be equal.
+// If someone reorders the enum variants, this assertion fails the build.
+const _: () = {
+    assert!(CapabilityLevel::Never as u8 == 0);
+    assert!(CapabilityLevel::LowRisk as u8 == 1);
+    assert!(CapabilityLevel::Always as u8 == 2);
+};
+
 impl std::fmt::Display for CapabilityLevel {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {


### PR DESCRIPTION
## Summary

Closes 2 architect adversarial findings:

1. **CI now type-checks the Lean proofs** — `lake build PortcullisCoreBridge` added to aeneas.yml. The function correspondence theorems (`meet_eq_inf`, `join_eq_sup`, `implies_eq_himp`) are now verified in CI, not just locally.

2. **Discriminant ordering invariant** — compile-time assertion that enum declaration order matches `#[repr(u8)]` values. Aeneas uses declaration-order index, our `FunsExternal.lean` uses discriminant values — they must be equal.

## Test plan

- [x] `cargo build -p portcullis-core -p portcullis`
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)