### PR TITLE
feat: CapabilityLattice HeytingAlgebra on Aeneas-generated types

### DIFF
--- a/crates/portcullis-core/lean/PortcullisCoreBridge.lean
+++ b/crates/portcullis-core/lean/PortcullisCoreBridge.lean
@@ -168,4 +168,338 @@ theorem implies_eq_himp (a b : CapabilityLevel) :
     portcullis_core.CapabilityLevel.implies a b = .ok (a ⇨ b) := by
   cases a <;> cases b <;> rfl
 
+-- ═══════════════════════════════════════════════════════════════════════
+-- Complement correspondence
+-- ═══════════════════════════════════════════════════════════════════════
+
+/-- The Aeneas-generated `complement` never fails. -/
+theorem complement_never_fails (a : CapabilityLevel) :
+    ∃ r, portcullis_core.CapabilityLevel.complement a = .ok r := by
+  cases a <;> exact ⟨_, rfl⟩
+
+/-- The Aeneas-generated `complement` computes the lattice complement. -/
+theorem complement_eq_compl (a : CapabilityLevel) :
+    portcullis_core.CapabilityLevel.complement a = .ok aᶜ := by
+  cases a <;> rfl
+
+/-- The Aeneas-generated `leq` never fails. -/
+theorem leq_never_fails (a b : CapabilityLevel) :
+    ∃ r, portcullis_core.CapabilityLevel.leq a b = .ok r := by
+  cases a <;> cases b <;> exact ⟨_, rfl⟩
+
+/-- The Aeneas-generated `leq` computes the lattice ≤. -/
+theorem leq_eq_le (a b : CapabilityLevel) :
+    portcullis_core.CapabilityLevel.leq a b = .ok (decide (a ≤ b)) := by
+  cases a <;> cases b <;> rfl
+
+-- ═══════════════════════════════════════════════════════════════════════
+-- Product lattice: CapabilityLattice is a HeytingAlgebra
+--
+-- CapabilityLattice is a structure of 12 CapabilityLevel fields.
+-- Since CapabilityLevel is a HeytingAlgebra, the product inherits the
+-- structure pointwise. We build up the full Mathlib typeclass chain:
+--
+--   LE → Preorder → PartialOrder
+--   Inf → SemilatticeInf ─┐
+--   Sup → SemilatticeSup ─┴→ Lattice
+--   Bot → OrderBot ─┐
+--   Top → OrderTop ─┴→ BoundedOrder
+--   HImp → GeneralizedHeytingAlgebra
+--   Compl → HeytingAlgebra
+--
+-- Every axiom reduces to the component-level CapabilityLevel proof.
+-- No SMT oracle, no Z3 — all kernel-checked by Lean 4.
+-- ═══════════════════════════════════════════════════════════════════════
+
+namespace ProductLattice
+
+-- ─── Pointwise operations (as raw functions) ─────────────────────────
+
+private def latticeLE (a b : CapabilityLattice) : Prop :=
+  a.read_files ≤ b.read_files ∧ a.write_files ≤ b.write_files ∧
+  a.edit_files ≤ b.edit_files ∧ a.run_bash ≤ b.run_bash ∧
+  a.glob_search ≤ b.glob_search ∧ a.grep_search ≤ b.grep_search ∧
+  a.web_search ≤ b.web_search ∧ a.web_fetch ≤ b.web_fetch ∧
+  a.git_commit ≤ b.git_commit ∧ a.git_push ≤ b.git_push ∧
+  a.create_pr ≤ b.create_pr ∧ a.manage_pods ≤ b.manage_pods
+
+private def latticeInf (a b : CapabilityLattice) : CapabilityLattice := {
+  read_files := a.read_files ⊓ b.read_files
+  write_files := a.write_files ⊓ b.write_files
+  edit_files := a.edit_files ⊓ b.edit_files
+  run_bash := a.run_bash ⊓ b.run_bash
+  glob_search := a.glob_search ⊓ b.glob_search
+  grep_search := a.grep_search ⊓ b.grep_search
+  web_search := a.web_search ⊓ b.web_search
+  web_fetch := a.web_fetch ⊓ b.web_fetch
+  git_commit := a.git_commit ⊓ b.git_commit
+  git_push := a.git_push ⊓ b.git_push
+  create_pr := a.create_pr ⊓ b.create_pr
+  manage_pods := a.manage_pods ⊓ b.manage_pods
+}
+
+private def latticeSup (a b : CapabilityLattice) : CapabilityLattice := {
+  read_files := a.read_files ⊔ b.read_files
+  write_files := a.write_files ⊔ b.write_files
+  edit_files := a.edit_files ⊔ b.edit_files
+  run_bash := a.run_bash ⊔ b.run_bash
+  glob_search := a.glob_search ⊔ b.glob_search
+  grep_search := a.grep_search ⊔ b.grep_search
+  web_search := a.web_search ⊔ b.web_search
+  web_fetch := a.web_fetch ⊔ b.web_fetch
+  git_commit := a.git_commit ⊔ b.git_commit
+  git_push := a.git_push ⊔ b.git_push
+  create_pr := a.create_pr ⊔ b.create_pr
+  manage_pods := a.manage_pods ⊔ b.manage_pods
+}
+
+private def latticeBot : CapabilityLattice := {
+  read_files := ⊥, write_files := ⊥, edit_files := ⊥,
+  run_bash := ⊥, glob_search := ⊥, grep_search := ⊥,
+  web_search := ⊥, web_fetch := ⊥, git_commit := ⊥,
+  git_push := ⊥, create_pr := ⊥, manage_pods := ⊥
+}
+
+private def latticeTop : CapabilityLattice := {
+  read_files := ⊤, write_files := ⊤, edit_files := ⊤,
+  run_bash := ⊤, glob_search := ⊤, grep_search := ⊤,
+  web_search := ⊤, web_fetch := ⊤, git_commit := ⊤,
+  git_push := ⊤, create_pr := ⊤, manage_pods := ⊤
+}
+
+private def latticeHImp (a b : CapabilityLattice) : CapabilityLattice := {
+  read_files := a.read_files ⇨ b.read_files
+  write_files := a.write_files ⇨ b.write_files
+  edit_files := a.edit_files ⇨ b.edit_files
+  run_bash := a.run_bash ⇨ b.run_bash
+  glob_search := a.glob_search ⇨ b.glob_search
+  grep_search := a.grep_search ⇨ b.grep_search
+  web_search := a.web_search ⇨ b.web_search
+  web_fetch := a.web_fetch ⇨ b.web_fetch
+  git_commit := a.git_commit ⇨ b.git_commit
+  git_push := a.git_push ⇨ b.git_push
+  create_pr := a.create_pr ⇨ b.create_pr
+  manage_pods := a.manage_pods ⇨ b.manage_pods
+}
+
+private def latticeCompl (a : CapabilityLattice) : CapabilityLattice := {
+  read_files := a.read_filesᶜ, write_files := a.write_filesᶜ,
+  edit_files := a.edit_filesᶜ, run_bash := a.run_bashᶜ,
+  glob_search := a.glob_searchᶜ, grep_search := a.grep_searchᶜ,
+  web_search := a.web_searchᶜ, web_fetch := a.web_fetchᶜ,
+  git_commit := a.git_commitᶜ, git_push := a.git_pushᶜ,
+  create_pr := a.create_prᶜ, manage_pods := a.manage_podsᶜ
+}
+
+-- ─── Full HeytingAlgebra instance (single definition) ────────────────
+--
+-- We define the entire HeytingAlgebra in one `where` block to avoid
+-- instance chain mismatches between LE, PartialOrder, SemilatticeInf.
+
+instance instHeytingAlgebra : HeytingAlgebra CapabilityLattice where
+  le := latticeLE
+  lt a b := latticeLE a b ∧ ¬latticeLE b a
+  inf := latticeInf
+  sup := latticeSup
+  bot := latticeBot
+  top := latticeTop
+  himp := latticeHImp
+  compl := latticeCompl
+  le_refl a :=
+    ⟨le_refl _, le_refl _, le_refl _, le_refl _, le_refl _, le_refl _,
+     le_refl _, le_refl _, le_refl _, le_refl _, le_refl _, le_refl _⟩
+  le_trans a b c hab hbc :=
+    ⟨le_trans hab.1 hbc.1, le_trans hab.2.1 hbc.2.1,
+     le_trans hab.2.2.1 hbc.2.2.1, le_trans hab.2.2.2.1 hbc.2.2.2.1,
+     le_trans hab.2.2.2.2.1 hbc.2.2.2.2.1,
+     le_trans hab.2.2.2.2.2.1 hbc.2.2.2.2.2.1,
+     le_trans hab.2.2.2.2.2.2.1 hbc.2.2.2.2.2.2.1,
+     le_trans hab.2.2.2.2.2.2.2.1 hbc.2.2.2.2.2.2.2.1,
+     le_trans hab.2.2.2.2.2.2.2.2.1 hbc.2.2.2.2.2.2.2.2.1,
+     le_trans hab.2.2.2.2.2.2.2.2.2.1 hbc.2.2.2.2.2.2.2.2.2.1,
+     le_trans hab.2.2.2.2.2.2.2.2.2.2.1 hbc.2.2.2.2.2.2.2.2.2.2.1,
+     le_trans hab.2.2.2.2.2.2.2.2.2.2.2 hbc.2.2.2.2.2.2.2.2.2.2.2⟩
+  lt_iff_le_not_ge _ _ := Iff.rfl
+  le_antisymm a b hab hba := by
+    have e1 := le_antisymm hab.1 hba.1
+    have e2 := le_antisymm hab.2.1 hba.2.1
+    have e3 := le_antisymm hab.2.2.1 hba.2.2.1
+    have e4 := le_antisymm hab.2.2.2.1 hba.2.2.2.1
+    have e5 := le_antisymm hab.2.2.2.2.1 hba.2.2.2.2.1
+    have e6 := le_antisymm hab.2.2.2.2.2.1 hba.2.2.2.2.2.1
+    have e7 := le_antisymm hab.2.2.2.2.2.2.1 hba.2.2.2.2.2.2.1
+    have e8 := le_antisymm hab.2.2.2.2.2.2.2.1 hba.2.2.2.2.2.2.2.1
+    have e9 := le_antisymm hab.2.2.2.2.2.2.2.2.1 hba.2.2.2.2.2.2.2.2.1
+    have e10 := le_antisymm hab.2.2.2.2.2.2.2.2.2.1 hba.2.2.2.2.2.2.2.2.2.1
+    have e11 := le_antisymm hab.2.2.2.2.2.2.2.2.2.2.1 hba.2.2.2.2.2.2.2.2.2.2.1
+    have e12 := le_antisymm hab.2.2.2.2.2.2.2.2.2.2.2 hba.2.2.2.2.2.2.2.2.2.2.2
+    cases a; cases b; simp_all
+  inf_le_left a b :=
+    ⟨inf_le_left, inf_le_left, inf_le_left, inf_le_left,
+     inf_le_left, inf_le_left, inf_le_left, inf_le_left,
+     inf_le_left, inf_le_left, inf_le_left, inf_le_left⟩
+  inf_le_right a b :=
+    ⟨inf_le_right, inf_le_right, inf_le_right, inf_le_right,
+     inf_le_right, inf_le_right, inf_le_right, inf_le_right,
+     inf_le_right, inf_le_right, inf_le_right, inf_le_right⟩
+  le_inf a b c hab hac :=
+    ⟨le_inf hab.1 hac.1, le_inf hab.2.1 hac.2.1,
+     le_inf hab.2.2.1 hac.2.2.1, le_inf hab.2.2.2.1 hac.2.2.2.1,
+     le_inf hab.2.2.2.2.1 hac.2.2.2.2.1,
+     le_inf hab.2.2.2.2.2.1 hac.2.2.2.2.2.1,
+     le_inf hab.2.2.2.2.2.2.1 hac.2.2.2.2.2.2.1,
+     le_inf hab.2.2.2.2.2.2.2.1 hac.2.2.2.2.2.2.2.1,
+     le_inf hab.2.2.2.2.2.2.2.2.1 hac.2.2.2.2.2.2.2.2.1,
+     le_inf hab.2.2.2.2.2.2.2.2.2.1 hac.2.2.2.2.2.2.2.2.2.1,
+     le_inf hab.2.2.2.2.2.2.2.2.2.2.1 hac.2.2.2.2.2.2.2.2.2.2.1,
+     le_inf hab.2.2.2.2.2.2.2.2.2.2.2 hac.2.2.2.2.2.2.2.2.2.2.2⟩
+  le_sup_left a b :=
+    ⟨le_sup_left, le_sup_left, le_sup_left, le_sup_left,
+     le_sup_left, le_sup_left, le_sup_left, le_sup_left,
+     le_sup_left, le_sup_left, le_sup_left, le_sup_left⟩
+  le_sup_right a b :=
+    ⟨le_sup_right, le_sup_right, le_sup_right, le_sup_right,
+     le_sup_right, le_sup_right, le_sup_right, le_sup_right,
+     le_sup_right, le_sup_right, le_sup_right, le_sup_right⟩
+  sup_le a b c hab hbc :=
+    ⟨sup_le hab.1 hbc.1, sup_le hab.2.1 hbc.2.1,
+     sup_le hab.2.2.1 hbc.2.2.1, sup_le hab.2.2.2.1 hbc.2.2.2.1,
+     sup_le hab.2.2.2.2.1 hbc.2.2.2.2.1,
+     sup_le hab.2.2.2.2.2.1 hbc.2.2.2.2.2.1,
+     sup_le hab.2.2.2.2.2.2.1 hbc.2.2.2.2.2.2.1,
+     sup_le hab.2.2.2.2.2.2.2.1 hbc.2.2.2.2.2.2.2.1,
+     sup_le hab.2.2.2.2.2.2.2.2.1 hbc.2.2.2.2.2.2.2.2.1,
+     sup_le hab.2.2.2.2.2.2.2.2.2.1 hbc.2.2.2.2.2.2.2.2.2.1,
+     sup_le hab.2.2.2.2.2.2.2.2.2.2.1 hbc.2.2.2.2.2.2.2.2.2.2.1,
+     sup_le hab.2.2.2.2.2.2.2.2.2.2.2 hbc.2.2.2.2.2.2.2.2.2.2.2⟩
+  bot_le a :=
+    ⟨bot_le, bot_le, bot_le, bot_le, bot_le, bot_le,
+     bot_le, bot_le, bot_le, bot_le, bot_le, bot_le⟩
+  le_top a :=
+    ⟨le_top, le_top, le_top, le_top, le_top, le_top,
+     le_top, le_top, le_top, le_top, le_top, le_top⟩
+  le_himp_iff a b c := by
+    show latticeLE a (latticeHImp b c) ↔ latticeLE (latticeInf a b) c
+    simp only [latticeLE, latticeHImp, latticeInf]
+    constructor
+    · intro ⟨h1,h2,h3,h4,h5,h6,h7,h8,h9,h10,h11,h12⟩
+      exact ⟨(PortcullisCoreBridge.le_himp_iff _ _ _).mp h1,
+             (PortcullisCoreBridge.le_himp_iff _ _ _).mp h2,
+             (PortcullisCoreBridge.le_himp_iff _ _ _).mp h3,
+             (PortcullisCoreBridge.le_himp_iff _ _ _).mp h4,
+             (PortcullisCoreBridge.le_himp_iff _ _ _).mp h5,
+             (PortcullisCoreBridge.le_himp_iff _ _ _).mp h6,
+             (PortcullisCoreBridge.le_himp_iff _ _ _).mp h7,
+             (PortcullisCoreBridge.le_himp_iff _ _ _).mp h8,
+             (PortcullisCoreBridge.le_himp_iff _ _ _).mp h9,
+             (PortcullisCoreBridge.le_himp_iff _ _ _).mp h10,
+             (PortcullisCoreBridge.le_himp_iff _ _ _).mp h11,
+             (PortcullisCoreBridge.le_himp_iff _ _ _).mp h12⟩
+    · intro ⟨h1,h2,h3,h4,h5,h6,h7,h8,h9,h10,h11,h12⟩
+      exact ⟨(PortcullisCoreBridge.le_himp_iff _ _ _).mpr h1,
+             (PortcullisCoreBridge.le_himp_iff _ _ _).mpr h2,
+             (PortcullisCoreBridge.le_himp_iff _ _ _).mpr h3,
+             (PortcullisCoreBridge.le_himp_iff _ _ _).mpr h4,
+             (PortcullisCoreBridge.le_himp_iff _ _ _).mpr h5,
+             (PortcullisCoreBridge.le_himp_iff _ _ _).mpr h6,
+             (PortcullisCoreBridge.le_himp_iff _ _ _).mpr h7,
+             (PortcullisCoreBridge.le_himp_iff _ _ _).mpr h8,
+             (PortcullisCoreBridge.le_himp_iff _ _ _).mpr h9,
+             (PortcullisCoreBridge.le_himp_iff _ _ _).mpr h10,
+             (PortcullisCoreBridge.le_himp_iff _ _ _).mpr h11,
+             (PortcullisCoreBridge.le_himp_iff _ _ _).mpr h12⟩
+  himp_bot a := by
+    show latticeHImp a latticeBot = latticeCompl a
+    simp only [latticeHImp, latticeBot, latticeCompl]
+    congr 1 <;> exact PortcullisCoreBridge.himp_bot _
+
+end ProductLattice
+
+-- ═══════════════════════════════════════════════════════════════════════
+-- Product lattice function correspondence
+--
+-- The Aeneas-generated CapabilityLattice.meet/join/implies call
+-- CapabilityLevel.meet/join/implies pointwise. Since we proved those
+-- equal the lattice inf/sup/himp, the product operations compose.
+-- ═══════════════════════════════════════════════════════════════════════
+
+open ProductLattice in
+/-- The Aeneas-generated `CapabilityLattice.meet` computes pointwise inf.
+    Connects the Rust implementation to the algebraic structure. -/
+theorem lattice_meet_eq_inf (a b : CapabilityLattice) :
+    portcullis_core.CapabilityLattice.meet a b = .ok (a ⊓ b) := by
+  show _ = Result.ok (latticeInf a b)
+  simp [portcullis_core.CapabilityLattice.meet, meet_eq_inf, latticeInf]
+
+open ProductLattice in
+/-- The Aeneas-generated `CapabilityLattice.join` computes pointwise sup. -/
+theorem lattice_join_eq_sup (a b : CapabilityLattice) :
+    portcullis_core.CapabilityLattice.join a b = .ok (a ⊔ b) := by
+  show _ = Result.ok (latticeSup a b)
+  simp [portcullis_core.CapabilityLattice.join, join_eq_sup, latticeSup]
+
+open ProductLattice in
+/-- The Aeneas-generated `CapabilityLattice.implies` computes pointwise himp. -/
+theorem lattice_implies_eq_himp (a b : CapabilityLattice) :
+    portcullis_core.CapabilityLattice.implies a b = .ok (a ⇨ b) := by
+  show _ = Result.ok (latticeHImp a b)
+  simp [portcullis_core.CapabilityLattice.implies, implies_eq_himp, latticeHImp]
+
+open ProductLattice in
+/-- The Aeneas-generated `CapabilityLattice.bottom` is the lattice ⊥. -/
+theorem lattice_bottom_eq_bot :
+    portcullis_core.CapabilityLattice.bottom = .ok ⊥ := by
+  show _ = Result.ok latticeBot
+  simp [portcullis_core.CapabilityLattice.bottom, latticeBot]
+  constructor <;> rfl
+
+open ProductLattice in
+/-- The Aeneas-generated `CapabilityLattice.top` is the lattice ⊤. -/
+theorem lattice_top_eq_top :
+    portcullis_core.CapabilityLattice.top = .ok ⊤ := by
+  show _ = Result.ok latticeTop
+  simp [portcullis_core.CapabilityLattice.top, latticeTop]
+  constructor <;> rfl
+
+-- ═══════════════════════════════════════════════════════════════════════
+-- MONOTONICITY — the core safety claim (VC-001)
+--
+-- Authority can only tighten: meet(current, restriction) ≤ current.
+-- This is the mathematical foundation of "permissions never escalate."
+-- ═══════════════════════════════════════════════════════════════════════
+
+/-- Meet is deflationary on CapabilityLevel: a ⊓ b ≤ a. -/
+theorem meet_deflationary (a b : CapabilityLevel) : a ⊓ b ≤ a := inf_le_left
+
+open ProductLattice in
+/-- **The 12-dimensional proof that permissions never escalate.**
+    For all 12 capability dimensions: (policy ⊓ session).field ≤ policy.field. -/
+theorem lattice_meet_deflationary_left (a b : CapabilityLattice) :
+    (a ⊓ b) ≤ a := by
+  show latticeLE (latticeInf a b) a
+  simp only [latticeLE, latticeInf]
+  exact ⟨inf_le_left, inf_le_left, inf_le_left, inf_le_left,
+         inf_le_left, inf_le_left, inf_le_left, inf_le_left,
+         inf_le_left, inf_le_left, inf_le_left, inf_le_left⟩
+
+open ProductLattice in
+/-- Meet is deflationary on the right. -/
+theorem lattice_meet_deflationary_right (a b : CapabilityLattice) :
+    (a ⊓ b) ≤ b := by
+  show latticeLE (latticeInf a b) b
+  simp only [latticeLE, latticeInf]
+  exact ⟨inf_le_right, inf_le_right, inf_le_right, inf_le_right,
+         inf_le_right, inf_le_right, inf_le_right, inf_le_right,
+         inf_le_right, inf_le_right, inf_le_right, inf_le_right⟩
+
+open ProductLattice in
+/-- Meet is idempotent: a ⊓ a = a. Applying the same policy twice is a no-op. -/
+theorem lattice_meet_idempotent (a : CapabilityLattice) : a ⊓ a = a := by
+  have h1 : (a ⊓ a) ≤ a := lattice_meet_deflationary_left a a
+  have h2 : a ≤ (a ⊓ a) := by
+    show latticeLE a (latticeInf a a)
+    simp only [latticeLE, latticeInf]
+    refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩ <;> exact le_inf (le_refl _) (le_refl _)
+  exact le_antisymm h1 h2
+
 end PortcullisCoreBridge

--- a/crates/portcullis-core/lean/generated/PortcullisCore/CoreFuns.lean
+++ b/crates/portcullis-core/lean/generated/PortcullisCore/CoreFuns.lean
@@ -68,4 +68,207 @@ def CapabilityLevel.leq
   (self : CapabilityLevel) (other : CapabilityLevel) : Result Bool := do
   CapabilityLevel.Insts.CoreCmpPartialOrdCapabilityLevel.le self other
 
+-- ═══════════════════════════════════════════════════════════════════════
+-- Product lattice operations (extracted from Aeneas-generated Funs.lean)
+-- Function bodies are UNMODIFIED from Aeneas output.
+-- ═══════════════════════════════════════════════════════════════════════
+
+/-- [portcullis_core::{portcullis_core::CapabilityLattice}::bottom]:
+    Source: 'crates/portcullis-core/src/lib.rs', lines 134:4-149:5
+    Visibility: public -/
+def CapabilityLattice.bottom : Result CapabilityLattice := do
+  ok
+    {
+      read_files := CapabilityLevel.Never,
+      write_files := CapabilityLevel.Never,
+      edit_files := CapabilityLevel.Never,
+      run_bash := CapabilityLevel.Never,
+      glob_search := CapabilityLevel.Never,
+      grep_search := CapabilityLevel.Never,
+      web_search := CapabilityLevel.Never,
+      web_fetch := CapabilityLevel.Never,
+      git_commit := CapabilityLevel.Never,
+      git_push := CapabilityLevel.Never,
+      create_pr := CapabilityLevel.Never,
+      manage_pods := CapabilityLevel.Never
+    }
+
+/-- [portcullis_core::{portcullis_core::CapabilityLattice}::top]:
+    Source: 'crates/portcullis-core/src/lib.rs', lines 152:4-167:5
+    Visibility: public -/
+def CapabilityLattice.top : Result CapabilityLattice := do
+  ok
+    {
+      read_files := CapabilityLevel.Always,
+      write_files := CapabilityLevel.Always,
+      edit_files := CapabilityLevel.Always,
+      run_bash := CapabilityLevel.Always,
+      glob_search := CapabilityLevel.Always,
+      grep_search := CapabilityLevel.Always,
+      web_search := CapabilityLevel.Always,
+      web_fetch := CapabilityLevel.Always,
+      git_commit := CapabilityLevel.Always,
+      git_push := CapabilityLevel.Always,
+      create_pr := CapabilityLevel.Always,
+      manage_pods := CapabilityLevel.Always
+    }
+
+/-- [portcullis_core::{portcullis_core::CapabilityLattice}::meet]:
+    Source: 'crates/portcullis-core/src/lib.rs', lines 170:4-185:5
+    Visibility: public -/
+def CapabilityLattice.meet
+  (self : CapabilityLattice) (other : CapabilityLattice) :
+  Result CapabilityLattice
+  := do
+  let cl ← CapabilityLevel.meet self.read_files other.read_files
+  let cl1 ← CapabilityLevel.meet self.write_files other.write_files
+  let cl2 ← CapabilityLevel.meet self.edit_files other.edit_files
+  let cl3 ← CapabilityLevel.meet self.run_bash other.run_bash
+  let cl4 ← CapabilityLevel.meet self.glob_search other.glob_search
+  let cl5 ← CapabilityLevel.meet self.grep_search other.grep_search
+  let cl6 ← CapabilityLevel.meet self.web_search other.web_search
+  let cl7 ← CapabilityLevel.meet self.web_fetch other.web_fetch
+  let cl8 ← CapabilityLevel.meet self.git_commit other.git_commit
+  let cl9 ← CapabilityLevel.meet self.git_push other.git_push
+  let cl10 ← CapabilityLevel.meet self.create_pr other.create_pr
+  let cl11 ← CapabilityLevel.meet self.manage_pods other.manage_pods
+  ok
+    {
+      read_files := cl,
+      write_files := cl1,
+      edit_files := cl2,
+      run_bash := cl3,
+      glob_search := cl4,
+      grep_search := cl5,
+      web_search := cl6,
+      web_fetch := cl7,
+      git_commit := cl8,
+      git_push := cl9,
+      create_pr := cl10,
+      manage_pods := cl11
+    }
+
+/-- [portcullis_core::{portcullis_core::CapabilityLattice}::join]:
+    Source: 'crates/portcullis-core/src/lib.rs', lines 188:4-203:5
+    Visibility: public -/
+def CapabilityLattice.join
+  (self : CapabilityLattice) (other : CapabilityLattice) :
+  Result CapabilityLattice
+  := do
+  let cl ← CapabilityLevel.join self.read_files other.read_files
+  let cl1 ← CapabilityLevel.join self.write_files other.write_files
+  let cl2 ← CapabilityLevel.join self.edit_files other.edit_files
+  let cl3 ← CapabilityLevel.join self.run_bash other.run_bash
+  let cl4 ← CapabilityLevel.join self.glob_search other.glob_search
+  let cl5 ← CapabilityLevel.join self.grep_search other.grep_search
+  let cl6 ← CapabilityLevel.join self.web_search other.web_search
+  let cl7 ← CapabilityLevel.join self.web_fetch other.web_fetch
+  let cl8 ← CapabilityLevel.join self.git_commit other.git_commit
+  let cl9 ← CapabilityLevel.join self.git_push other.git_push
+  let cl10 ← CapabilityLevel.join self.create_pr other.create_pr
+  let cl11 ← CapabilityLevel.join self.manage_pods other.manage_pods
+  ok
+    {
+      read_files := cl,
+      write_files := cl1,
+      edit_files := cl2,
+      run_bash := cl3,
+      glob_search := cl4,
+      grep_search := cl5,
+      web_search := cl6,
+      web_fetch := cl7,
+      git_commit := cl8,
+      git_push := cl9,
+      create_pr := cl10,
+      manage_pods := cl11
+    }
+
+/-- [portcullis_core::{portcullis_core::CapabilityLattice}::leq]:
+    Source: 'crates/portcullis-core/src/lib.rs', lines 206:4-219:5
+    Visibility: public -/
+def CapabilityLattice.leq
+  (self : CapabilityLattice) (other : CapabilityLattice) : Result Bool := do
+  let b ← CapabilityLevel.leq self.read_files other.read_files
+  if b
+  then
+    let b1 ← CapabilityLevel.leq self.write_files other.write_files
+    if b1
+    then
+      let b2 ← CapabilityLevel.leq self.edit_files other.edit_files
+      if b2
+      then
+        let b3 ← CapabilityLevel.leq self.run_bash other.run_bash
+        if b3
+        then
+          let b4 ← CapabilityLevel.leq self.glob_search other.glob_search
+          if b4
+          then
+            let b5 ← CapabilityLevel.leq self.grep_search other.grep_search
+            if b5
+            then
+              let b6 ← CapabilityLevel.leq self.web_search other.web_search
+              if b6
+              then
+                let b7 ← CapabilityLevel.leq self.web_fetch other.web_fetch
+                if b7
+                then
+                  let b8 ←
+                    CapabilityLevel.leq self.git_commit other.git_commit
+                  if b8
+                  then
+                    let b9 ← CapabilityLevel.leq self.git_push other.git_push
+                    if b9
+                    then
+                      let b10 ←
+                        CapabilityLevel.leq self.create_pr other.create_pr
+                      if b10
+                      then
+                        CapabilityLevel.leq self.manage_pods other.manage_pods
+                      else ok false
+                    else ok false
+                  else ok false
+                else ok false
+              else ok false
+            else ok false
+          else ok false
+        else ok false
+      else ok false
+    else ok false
+  else ok false
+
+/-- [portcullis_core::{portcullis_core::CapabilityLattice}::implies]:
+    Source: 'crates/portcullis-core/src/lib.rs', lines 222:4-237:5
+    Visibility: public -/
+def CapabilityLattice.implies
+  (self : CapabilityLattice) (other : CapabilityLattice) :
+  Result CapabilityLattice
+  := do
+  let cl ← CapabilityLevel.implies self.read_files other.read_files
+  let cl1 ← CapabilityLevel.implies self.write_files other.write_files
+  let cl2 ← CapabilityLevel.implies self.edit_files other.edit_files
+  let cl3 ← CapabilityLevel.implies self.run_bash other.run_bash
+  let cl4 ← CapabilityLevel.implies self.glob_search other.glob_search
+  let cl5 ← CapabilityLevel.implies self.grep_search other.grep_search
+  let cl6 ← CapabilityLevel.implies self.web_search other.web_search
+  let cl7 ← CapabilityLevel.implies self.web_fetch other.web_fetch
+  let cl8 ← CapabilityLevel.implies self.git_commit other.git_commit
+  let cl9 ← CapabilityLevel.implies self.git_push other.git_push
+  let cl10 ← CapabilityLevel.implies self.create_pr other.create_pr
+  let cl11 ← CapabilityLevel.implies self.manage_pods other.manage_pods
+  ok
+    {
+      read_files := cl,
+      write_files := cl1,
+      edit_files := cl2,
+      run_bash := cl3,
+      glob_search := cl4,
+      grep_search := cl5,
+      web_search := cl6,
+      web_fetch := cl7,
+      git_commit := cl8,
+      git_push := cl9,
+      create_pr := cl10,
+      manage_pods := cl11
+    }
+
 end portcullis_core


### PR DESCRIPTION
## Summary

- Extract `CapabilityLattice.{meet,join,leq,implies,bottom,top}` from Aeneas-generated `Funs.lean` into `CoreFuns.lean` (function bodies unmodified from Aeneas output)
- Prove the full Mathlib `HeytingAlgebra` instance on the 12-dimensional product lattice
- Prove function correspondence: every Aeneas-generated Rust function computes the same result as the corresponding lattice operation
- Prove VC-001 monotonicity: `(a ⊓ b) ≤ a` for all 12 capability dimensions

## What's proven (all kernel-checked, no sorry/SMT/Z3)

| Theorem | What it proves |
|---------|---------------|
| `instHeytingAlgebra` | Full HeytingAlgebra instance on 12-dim product |
| `lattice_meet_eq_inf` | Rust `meet()` = lattice `⊓` (product) |
| `lattice_join_eq_sup` | Rust `join()` = lattice `⊔` (product) |
| `lattice_implies_eq_himp` | Rust `implies()` = lattice `⇨` (product) |
| `lattice_meet_deflationary_left` | **VC-001**: permissions never escalate |
| `lattice_meet_idempotent` | Same policy twice = no-op |
| `complement_eq_compl` / `leq_eq_le` | CapabilityLevel fn correspondence |

## Test plan

- [x] `lake build PortcullisCoreBridge` — 1627 jobs, all pass
- [ ] CI lean-build workflow
- [ ] Kani proofs still pass (orthogonal, no Rust changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)