### PR TITLE
fix: use pre-built Aeneas binaries (no OCaml)

### DIFF
--- a/.github/workflows/aeneas.yml
+++ b/.github/workflows/aeneas.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Aeneas Lean 4 translation
         run: |
           mkdir -p crates/portcullis-core/lean/ci-generated
-          aeneas -backend lean portcullis_core.llbc \
+          aeneas -backend lean -split-files portcullis_core.llbc \
             -dest crates/portcullis-core/lean/ci-generated
 
       # --- Verify generated code matches committed code ---


### PR DESCRIPTION
## Summary

- Replace the flaky OCaml build-from-source with pre-built Aeneas binaries from GitHub releases
- Aeneas publishes `aeneas` + `charon` + `charon-driver` for linux-x86_64, macos-aarch64, macos-x86_64 on every commit
- Fix the diff check to compare only Aeneas-generated files, skipping curated CoreFuns.lean/FunsExternal.lean
- Timeout reduced from 30min → 15min

## Why

The Aeneas CI job has been red on main for weeks due to OCaml build flakiness (opam dependency resolution, dune version mismatches, missing make targets). Pre-built binaries eliminate all of this.

## Test plan

- [ ] CI `Aeneas (Rust → Lean 4)` job passes (this PR tests itself)

🤖 Generated with [Claude Code](https://claude.com/claude-code)