### PR TITLE
fix: final audit — reconcile counts, fix claims, honest docs

### DIFF
--- a/FORMAL_METHODS.md
+++ b/FORMAL_METHODS.md
@@ -117,12 +117,13 @@ These are important security properties that have NO formal verification:
 |-------|------|-------|-------|----------|-----|
 | Lattice algebra + correspondence | Lean 4 + Mathlib + Aeneas | `CapabilityLevel`, `CapabilityLattice` HeytingAlgebra + Rust fn = lattice op | Unbounded | 23 | Every PR (lean-build) |
 | Exposure tracker | Lean 4 | `ExposureSet`, `classify_operation`, `should_gate` | Unbounded | 14 | Every PR (lean-build) |
+| IFC label lattice (Flow Kernel) | Lean 4 | Authority confinement, integrity taint, Invariant exploit theorem | Unbounded | 18 | Every PR (lean-build) |
 | DecisionToken | Kani BMC | Token issuance, audit, exposure | Bounded | 5 | Every PR (fast), nightly (full) |
 | Permission algebra | Kani BMC | Distributivity, monotonicity, monoid laws | Bounded | 33 | Every PR (fast), nightly (full) |
 | Constitutional kernel | Kani BMC | Budget, capability, I/O invariants | Bounded | 17 | Every PR (fast), nightly (full) |
 | Sandbox/network/crypto | — | — | — | — | Unit tests only |
 
-**Total: 67 Kani BMC harnesses + 37 Lean 4 theorems = 104 verification artifacts.**
+**Total: 67 Kani BMC harnesses + 55 Lean 4 theorems = 122 verification artifacts.**
 
 ## Known Limitations & Honest Caveats
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Nucleus is a security framework for AI agents that combines a mathematically ver
 
 | Layer | Tool | Count | Scope |
 |-------|------|-------|-------|
-| **Proved** (unbounded) | Lean 4 + Mathlib | 37 theorems | HeytingAlgebra on production lattice ([Aeneas](https://github.com/AeneasVerif/aeneas)-generated types), exposure tracker monotonicity/soundness/gate correctness |
+| **Proved** (unbounded) | Lean 4 + Mathlib | 55 theorems | HeytingAlgebra on production lattice ([Aeneas](https://github.com/AeneasVerif/aeneas)-generated types), exposure tracker monotonicity/soundness, IFC label authority confinement |
 | **Bounded-model-checked** | [Kani](https://github.com/model-checking/kani) BMC | 67 harnesses | DecisionToken linearity, lattice distributivity, exposure monoid laws, constitutional kernel invariants |
 | **Tested** | Rust + CI | — | Sandbox isolation, path/command restrictions, network policy, end-to-end |
 

--- a/crates/portcullis-core/examples/flow_kernel_demo.rs
+++ b/crates/portcullis-core/examples/flow_kernel_demo.rs
@@ -143,7 +143,8 @@ fn main() {
     println!("═══════════════════════════════════════════════════════════════");
     println!("The malicious issue body (NoAuthority) could not steer the");
     println!("agent to exfiltrate private data. The information flow control");
-    println!("label lattice formally prevents trust-boundary violations.");
+    println!("label lattice provides the formal substrate to block");
+    println!("trust-boundary violations when labels are correctly applied.");
     println!();
     println!("Key insight: the issue body can be READ (for investigation)");
     println!("but cannot INSTRUCT (its authority level is too low to steer");

--- a/crates/portcullis-core/lean/FlowProofs.lean
+++ b/crates/portcullis-core/lean/FlowProofs.lean
@@ -6,6 +6,14 @@ with the correct variance (confidentiality/provenance covariant,
 integrity/authority contravariant) and that the existing ExposureSet
 is a sound quotient of the full label.
 
+## Model correspondence
+
+These types are HAND-WRITTEN Lean models mirroring the Rust source in
+`portcullis-core/src/lib.rs`. Unlike the CapabilityLevel types (which are
+Aeneas-generated), the IFC types are not yet translatable by Aeneas.
+No structural correspondence test exists for these types — a variant
+added to the Rust enum will NOT cause a Lean build failure.
+
 ## Key theorems
 
 - **Authority confinement**: `NoAuthority` data cannot produce `Directive` output

--- a/crates/portcullis-core/src/lib.rs
+++ b/crates/portcullis-core/src/lib.rs
@@ -630,7 +630,9 @@ pub enum IntegLevel {
 ///
 /// The critical innovation: formal encoding of "can this data steer the agent?"
 /// Web content gets NoAuthority — it can be READ but cannot INSTRUCT.
-/// This kills indirect prompt injection at the type level.
+/// When correctly labeled at runtime, this enables blocking indirect
+/// prompt injection — web content cannot acquire instruction authority
+/// regardless of what the LLM decides to do with it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(u8)]
 pub enum AuthorityLevel {
@@ -798,7 +800,10 @@ impl IFCLabel {
             && self.provenance.is_subset_of(target.provenance)
     }
 
-    /// Bottom label: public, trusted, no provenance, no authority.
+    /// Bottom label (least restrictive): public, trusted, no provenance, full authority.
+    ///
+    /// For contravariant dimensions (integrity, authority), bottom = maximum value
+    /// so that `join(x, bottom) = x` (joining with bottom doesn't restrict).
     pub fn bottom() -> Self {
         Self {
             confidentiality: ConfLevel::Public,


### PR DESCRIPTION
## Summary

Final skeptical audit before HN post. Fixes 4 findings:

1. **Count discrepancy** (the thing an HN commenter finds in 60 seconds): README said 37 Lean theorems, actual is 55 (missed FlowProofs.lean's 18). Fixed everywhere: 67 Kani + 55 Lean = **122 verification artifacts**.

2. **bottom() doc lied**: Said "no authority" but code has `AuthorityLevel::Directive`. Fixed: "full authority (for contravariant dims, bottom = maximum)".

3. **Overstated claims**: "kills indirect prompt injection at the type level" → "enables blocking...when labels are correctly applied". "formally prevents" → "provides the formal substrate to block".

4. **FlowProofs.lean honesty**: Added note that IFC types are hand-written (not Aeneas-generated) with no structural correspondence test.

## Test plan
- [x] 71 lib tests pass
- [x] Demo runs with corrected language
- [x] All hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)