### PR TITLE
fix: close FlowGraph audit issues #364, #365, #366

### DIFF
--- a/crates/portcullis/src/flow_graph.rs
+++ b/crates/portcullis/src/flow_graph.rs
@@ -29,6 +29,16 @@ pub enum FlowGraphError {
         /// Maximum allowed.
         max: usize,
     },
+    /// Parent ID 0 (sentinel) is not a valid parent reference.
+    SentinelParent,
+    /// The flow graph has not been enabled via `enable_flow_graph()`.
+    GraphNotEnabled,
+    /// A referenced parent was a denied action — denied actions did not
+    /// execute and cannot be causal ancestors.
+    DeniedParent(
+        /// The denied node ID.
+        NodeId,
+    ),
 }
 
 /// Result of inserting an action node (atomic check-and-insert).
@@ -46,9 +56,14 @@ pub struct FlowDecision {
 ///
 /// Nodes are indexed by sequential `NodeId` (u64). Index 0 is the sentinel
 /// (no parent). Real nodes start at 1.
+///
+/// Denied action nodes are tracked but cannot be referenced as parents —
+/// a denied action did not execute, so it has no causal effect.
 pub struct FlowGraph {
     nodes: Vec<Option<FlowNode>>,
     next_id: u64,
+    /// Node IDs of denied actions — cannot be used as parents.
+    denied: std::collections::BTreeSet<NodeId>,
 }
 
 impl FlowGraph {
@@ -57,6 +72,7 @@ impl FlowGraph {
         Self {
             nodes: vec![None], // index 0 = sentinel
             next_id: 1,
+            denied: std::collections::BTreeSet::new(),
         }
     }
 
@@ -105,6 +121,10 @@ impl FlowGraph {
         let id = self.next_id;
         self.nodes.push(Some(node));
         self.next_id += 1;
+        // Denied actions are inscribed for receipt/audit but cannot be parents
+        if matches!(verdict, FlowVerdict::Deny(_)) {
+            self.denied.insert(id);
+        }
         Ok(FlowDecision {
             verdict,
             node_id: id,
@@ -164,8 +184,14 @@ impl FlowGraph {
             });
         }
         for &pid in parents {
-            if pid > 0 && self.get(pid).is_none() {
+            if pid == 0 {
+                return Err(FlowGraphError::SentinelParent);
+            }
+            if self.get(pid).is_none() {
                 return Err(FlowGraphError::ParentNotFound(pid));
+            }
+            if self.denied.contains(&pid) {
+                return Err(FlowGraphError::DeniedParent(pid));
             }
         }
         Ok(())
@@ -351,6 +377,41 @@ mod tests {
         assert!(matches!(r.verdict, FlowVerdict::Deny(_)));
         let receipt = g.build_receipt_for(r.node_id, now).unwrap();
         assert!(receipt.display_chain().contains("BLOCKED"));
+    }
+
+    #[test]
+    fn sentinel_parent_rejected() {
+        let mut g = FlowGraph::new();
+        assert_eq!(
+            g.insert_observation(NodeKind::FileRead, &[0], 1000),
+            Err(FlowGraphError::SentinelParent)
+        );
+    }
+
+    #[test]
+    fn denied_action_cannot_be_parent() {
+        let mut g = FlowGraph::new();
+        let now = 1000;
+        let web = g
+            .insert_observation(NodeKind::WebContent, &[], now)
+            .unwrap();
+        // This write is denied (web taint)
+        let denied = g.insert_action(Operation::WriteFiles, &[web], now).unwrap();
+        assert!(matches!(denied.verdict, FlowVerdict::Deny(_)));
+        // Trying to reference the denied node as a parent should fail
+        assert_eq!(
+            g.insert_observation(NodeKind::FileRead, &[denied.node_id], now),
+            Err(FlowGraphError::DeniedParent(denied.node_id))
+        );
+    }
+
+    #[test]
+    fn sentinel_parent_rejected_in_action() {
+        let mut g = FlowGraph::new();
+        assert!(matches!(
+            g.insert_action(Operation::WriteFiles, &[0], 1000),
+            Err(FlowGraphError::SentinelParent)
+        ));
     }
 
     // THE KEY TEST

--- a/crates/portcullis/src/kernel.rs
+++ b/crates/portcullis/src/kernel.rs
@@ -424,18 +424,20 @@ impl Kernel {
     /// or `decide_with_parents()` calls. Observations are not flow-checked —
     /// they just record what data entered the session.
     ///
-    /// Panics if `enable_flow_graph()` was not called.
+    /// Returns `Err` if the flow graph is not enabled or if parent validation
+    /// fails. Callers must handle the error — do not use `.unwrap_or(0)` as
+    /// node ID 0 is the sentinel and will be rejected.
     pub fn observe(
         &mut self,
         kind: portcullis_core::flow::NodeKind,
         parents: &[u64],
-    ) -> Option<u64> {
+    ) -> Result<u64, crate::flow_graph::FlowGraphError> {
         let graph = self
             .flow_graph
             .as_mut()
-            .expect("enable_flow_graph() not called");
+            .ok_or(crate::flow_graph::FlowGraphError::GraphNotEnabled)?;
         let now = chrono::Utc::now().timestamp() as u64;
-        graph.insert_observation(kind, parents, now).ok()
+        graph.insert_observation(kind, parents, now)
     }
 
     /// Decide an operation with explicit causal parents from the DAG.
@@ -509,8 +511,14 @@ impl Kernel {
         }
 
         // DAG says allow — delegate to standard decide() for remaining checks
-        // (budget, capability, path, command, exposure, approvals)
+        // (budget, capability, path, command, exposure, approvals).
+        //
+        // Temporarily disable the flat flow_label so decide() doesn't re-check
+        // flow with the session-level accumulator. The DAG's per-action verdict
+        // supersedes the flat label — that's the whole point of the DAG.
+        let saved_flow_label = self.flow_label.take();
         let mut result = self.decide(operation, subject);
+        self.flow_label = saved_flow_label;
         result.0.flow_node_id = Some(flow_decision.node_id);
         result
     }
@@ -2379,5 +2387,44 @@ mod tests {
             d.verdict,
             Verdict::Deny(DenyReason::InsufficientCapability)
         ));
+    }
+
+    #[test]
+    fn dag_bypasses_flat_flow_label() {
+        // Issue #365: when both flow systems are enabled, the DAG should
+        // supersede the flat label — not double-deny.
+        let perms = PermissionLattice::safe_pr_fixer();
+        let mut kernel = Kernel::new(perms);
+        kernel.enable_flow_control(); // flat label
+        kernel.enable_flow_graph(); // DAG
+
+        // Read web content — taints the flat session label
+        let _web = kernel
+            .observe(portcullis_core::flow::NodeKind::WebContent, &[])
+            .unwrap();
+        // Also taint the flat label via a regular decide()
+        let (d, _) = kernel.decide(Operation::WebFetch, "https://example.com");
+        assert!(d.verdict.is_allowed());
+
+        // Now use the DAG with clean parents — should be allowed
+        // even though the flat label is tainted
+        let file = kernel
+            .observe(portcullis_core::flow::NodeKind::FileRead, &[])
+            .unwrap();
+        let (d, _) = kernel.decide_with_parents(Operation::WriteFiles, "/clean.txt", &[file]);
+        assert!(
+            d.verdict.is_allowed(),
+            "DAG clean parents should override flat taint, got {:?}",
+            d.verdict
+        );
+    }
+
+    #[test]
+    fn dag_observe_returns_error_without_enable() {
+        // Issue #364: observe() should return Err, not panic
+        let perms = PermissionLattice::safe_pr_fixer();
+        let mut kernel = Kernel::new(perms);
+        let result = kernel.observe(portcullis_core::flow::NodeKind::FileRead, &[]);
+        assert!(result.is_err());
     }
 }


### PR DESCRIPTION
## Summary

Fixes three critical/high issues found by skeptical code audit of the causal DAG (PR #363):

- **#364 — observe() error-swallowing + sentinel bypass**: `observe()` now returns `Result<u64, FlowGraphError>` instead of `Option<u64>`. Sentinel parent ID 0 is rejected with `FlowGraphError::SentinelParent`, closing the taint-bypass chain where `unwrap_or(0)` would produce a clean label.

- **#365 — dual flow systems contradiction**: `decide_with_parents()` temporarily disables the flat `flow_label` before delegating to `decide()`, preventing the session-level accumulator from re-denying actions the DAG already approved with clean parents. The DAG supersedes the flat label.

- **#366 — denied actions as DAG parents**: Denied action nodes are tracked in a `BTreeSet` and rejected as parents with `FlowGraphError::DeniedParent`. Denied actions did not execute and cannot be causal ancestors.

## Test plan

- [x] `sentinel_parent_rejected` — parent ID 0 returns `Err(SentinelParent)`
- [x] `sentinel_parent_rejected_in_action` — same for `insert_action`
- [x] `denied_action_cannot_be_parent` — denied write node rejected as parent
- [x] `dag_bypasses_flat_flow_label` — both flow systems enabled, DAG clean parents override flat taint
- [x] `dag_observe_returns_error_without_enable` — `observe()` returns `Err` instead of panicking
- [x] All 601 existing tests pass

Closes #364, closes #365, closes #366.

🤖 Generated with [Claude Code](https://claude.com/claude-code)