### PR TITLE
feat: Ed25519 receipt signing + declassification rules

### DIFF
--- a/crates/portcullis-core/examples/flow_kernel_demo.rs
+++ b/crates/portcullis-core/examples/flow_kernel_demo.rs
@@ -137,6 +137,9 @@ fn main() {
         Err(SignatureError::VerificationNotImplemented) => {
             println!("  Signature: ❌ verification not implemented")
         }
+        Err(SignatureError::InvalidSignature) => {
+            println!("  Signature: ❌ invalid (tampered or wrong key)")
+        }
     }
 
     println!();

--- a/crates/portcullis-core/src/declassify.rs
+++ b/crates/portcullis-core/src/declassify.rs
@@ -1,0 +1,277 @@
+//! Declassification rules — controlled, auditable label downgrading.
+//!
+//! Labels are monotone by default: once data is tainted, the taint cannot
+//! be removed. Declassification provides a controlled exception: specific
+//! label dimensions can be downgraded under explicit, auditable conditions.
+//!
+//! # Trust model
+//!
+//! Declassification rules are policy-level declarations, not runtime escapes.
+//! They must be declared before the session starts and cannot be added later
+//! (monotonicity of the rule set). Each declassification produces an audit
+//! entry recording what was downgraded, from what, to what, and why.
+//!
+//! # Example
+//!
+//! A web search tool returns public results. The results are web-sourced
+//! (Adversarial integrity, NoAuthority) but the tool operator has verified
+//! that the search API only returns curated content. A declassification
+//! rule can upgrade integrity from Adversarial to Untrusted for output
+//! from this specific tool.
+
+use crate::{AuthorityLevel, ConfLevel, IFCLabel, IntegLevel};
+
+/// A declassification rule — permits controlled label downgrading.
+///
+/// Each rule specifies:
+/// - Which dimension to modify
+/// - What the source level must be (precondition)
+/// - What the target level becomes (postcondition)
+/// - A human-readable justification (for audit)
+///
+/// Rules are checked against the CURRENT label. If the precondition
+/// matches, the label is modified. If not, the rule has no effect.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeclassificationRule {
+    /// What dimension and direction to modify.
+    pub action: DeclassifyAction,
+    /// Human-readable justification for this declassification.
+    /// Included in audit records.
+    pub justification: &'static str,
+}
+
+/// The specific label modification a declassification performs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DeclassifyAction {
+    /// Lower confidentiality (e.g., Secret → Internal for sanitized output).
+    /// Precondition: label.confidentiality >= from.
+    LowerConfidentiality { from: ConfLevel, to: ConfLevel },
+    /// Raise integrity (e.g., Adversarial → Untrusted for validated input).
+    /// Precondition: label.integrity <= from.
+    RaiseIntegrity { from: IntegLevel, to: IntegLevel },
+    /// Raise authority (e.g., NoAuthority → Informational for curated content).
+    /// Precondition: label.authority <= from.
+    RaiseAuthority {
+        from: AuthorityLevel,
+        to: AuthorityLevel,
+    },
+}
+
+/// Result of applying a declassification rule.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeclassifyResult {
+    /// The label after declassification (unchanged if precondition didn't match).
+    pub label: IFCLabel,
+    /// Whether the rule was actually applied.
+    pub applied: bool,
+    /// The rule that was checked.
+    pub rule: DeclassificationRule,
+    /// Label before declassification (for audit).
+    pub original: IFCLabel,
+}
+
+impl DeclassificationRule {
+    /// Apply this rule to a label. Returns the modified label and audit info.
+    ///
+    /// The rule only fires if the precondition matches. If not, the label
+    /// is returned unchanged with `applied: false`.
+    pub fn apply(&self, label: IFCLabel) -> DeclassifyResult {
+        let original = label;
+        let mut modified = label;
+        let applied = match &self.action {
+            DeclassifyAction::LowerConfidentiality { from, to } => {
+                if modified.confidentiality >= *from && to < from {
+                    modified.confidentiality = *to;
+                    true
+                } else {
+                    false
+                }
+            }
+            DeclassifyAction::RaiseIntegrity { from, to } => {
+                if modified.integrity <= *from && to > from {
+                    modified.integrity = *to;
+                    true
+                } else {
+                    false
+                }
+            }
+            DeclassifyAction::RaiseAuthority { from, to } => {
+                if modified.authority <= *from && to > from {
+                    modified.authority = *to;
+                    true
+                } else {
+                    false
+                }
+            }
+        };
+
+        DeclassifyResult {
+            label: modified,
+            applied,
+            rule: self.clone(),
+            original,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Freshness, ProvenanceSet};
+
+    fn web_label() -> IFCLabel {
+        IFCLabel {
+            confidentiality: ConfLevel::Public,
+            integrity: IntegLevel::Adversarial,
+            provenance: ProvenanceSet::WEB,
+            freshness: Freshness {
+                observed_at: 1000,
+                ttl_secs: 0,
+            },
+            authority: AuthorityLevel::NoAuthority,
+        }
+    }
+
+    fn secret_label() -> IFCLabel {
+        IFCLabel {
+            confidentiality: ConfLevel::Secret,
+            integrity: IntegLevel::Trusted,
+            provenance: ProvenanceSet::SYSTEM,
+            freshness: Freshness {
+                observed_at: 1000,
+                ttl_secs: 0,
+            },
+            authority: AuthorityLevel::Directive,
+        }
+    }
+
+    #[test]
+    fn raise_integrity_for_validated_input() {
+        let rule = DeclassificationRule {
+            action: DeclassifyAction::RaiseIntegrity {
+                from: IntegLevel::Adversarial,
+                to: IntegLevel::Untrusted,
+            },
+            justification: "Search API returns curated content",
+        };
+        let result = rule.apply(web_label());
+        assert!(result.applied);
+        assert_eq!(result.label.integrity, IntegLevel::Untrusted);
+        // Other dimensions unchanged
+        assert_eq!(result.label.authority, AuthorityLevel::NoAuthority);
+        assert_eq!(result.label.confidentiality, ConfLevel::Public);
+    }
+
+    #[test]
+    fn raise_authority_for_curated_content() {
+        let rule = DeclassificationRule {
+            action: DeclassifyAction::RaiseAuthority {
+                from: AuthorityLevel::NoAuthority,
+                to: AuthorityLevel::Informational,
+            },
+            justification: "Tool output is informational only",
+        };
+        let result = rule.apply(web_label());
+        assert!(result.applied);
+        assert_eq!(result.label.authority, AuthorityLevel::Informational);
+    }
+
+    #[test]
+    fn lower_confidentiality_for_sanitized_output() {
+        let rule = DeclassificationRule {
+            action: DeclassifyAction::LowerConfidentiality {
+                from: ConfLevel::Secret,
+                to: ConfLevel::Internal,
+            },
+            justification: "Output sanitized by redaction filter",
+        };
+        let result = rule.apply(secret_label());
+        assert!(result.applied);
+        assert_eq!(result.label.confidentiality, ConfLevel::Internal);
+    }
+
+    #[test]
+    fn rule_does_not_fire_if_precondition_unmet() {
+        let rule = DeclassificationRule {
+            action: DeclassifyAction::RaiseIntegrity {
+                from: IntegLevel::Adversarial,
+                to: IntegLevel::Untrusted,
+            },
+            justification: "N/A",
+        };
+        // Label already has Trusted integrity — precondition (<=Adversarial) doesn't match
+        let result = rule.apply(secret_label());
+        assert!(!result.applied);
+        assert_eq!(result.label, secret_label());
+    }
+
+    #[test]
+    fn cannot_raise_beyond_target() {
+        // Rule says Adversarial → Untrusted, not Adversarial → Trusted
+        let rule = DeclassificationRule {
+            action: DeclassifyAction::RaiseIntegrity {
+                from: IntegLevel::Adversarial,
+                to: IntegLevel::Untrusted,
+            },
+            justification: "Partial trust",
+        };
+        let result = rule.apply(web_label());
+        assert!(result.applied);
+        assert_eq!(
+            result.label.integrity,
+            IntegLevel::Untrusted,
+            "Must not exceed target"
+        );
+    }
+
+    #[test]
+    fn cannot_lower_below_target() {
+        let rule = DeclassificationRule {
+            action: DeclassifyAction::LowerConfidentiality {
+                from: ConfLevel::Secret,
+                to: ConfLevel::Internal,
+            },
+            justification: "Sanitized",
+        };
+        let result = rule.apply(secret_label());
+        assert!(result.applied);
+        assert_eq!(
+            result.label.confidentiality,
+            ConfLevel::Internal,
+            "Must not go below target"
+        );
+    }
+
+    #[test]
+    fn audit_trail_preserved() {
+        let rule = DeclassificationRule {
+            action: DeclassifyAction::RaiseAuthority {
+                from: AuthorityLevel::NoAuthority,
+                to: AuthorityLevel::Informational,
+            },
+            justification: "Curated search results",
+        };
+        let original = web_label();
+        let result = rule.apply(original);
+        assert_eq!(result.original, original);
+        assert_eq!(result.rule.justification, "Curated search results");
+    }
+
+    #[test]
+    fn wrong_direction_rejected() {
+        // Trying to "lower" confidentiality with to > from — should not apply
+        let rule = DeclassificationRule {
+            action: DeclassifyAction::LowerConfidentiality {
+                from: ConfLevel::Internal,
+                to: ConfLevel::Secret, // to > from — wrong direction
+            },
+            justification: "Invalid",
+        };
+        let label = IFCLabel {
+            confidentiality: ConfLevel::Internal,
+            ..web_label()
+        };
+        let result = rule.apply(label);
+        assert!(!result.applied, "Cannot escalate via declassification");
+    }
+}

--- a/crates/portcullis-core/src/lib.rs
+++ b/crates/portcullis-core/src/lib.rs
@@ -53,6 +53,7 @@
 //!   proof verifies algebraic structure of the type. Together they provide
 //!   complementary assurance.
 
+pub mod declassify;
 pub mod flow;
 pub mod manifest;
 pub mod receipt;
@@ -677,6 +678,11 @@ impl ProvenanceSet {
     /// Subset check (for lattice ordering).
     pub fn is_subset_of(self, other: Self) -> bool {
         (self.0 & other.0) == self.0
+    }
+
+    /// Raw bitmask value (for serialization/signing).
+    pub fn bits(self) -> u8 {
+        self.0
     }
 }
 

--- a/crates/portcullis-core/src/receipt.rs
+++ b/crates/portcullis-core/src/receipt.rs
@@ -71,6 +71,14 @@ impl FlowReceipt {
     pub fn is_signed(&self) -> bool {
         self.signature != [0; 64]
     }
+    /// Raw signature bytes (for verification).
+    pub fn signature_bytes(&self) -> &[u8; 64] {
+        &self.signature
+    }
+    /// Set the signature (called by signing code in `portcullis` crate).
+    pub fn set_signature(&mut self, sig: [u8; 64]) {
+        self.signature = sig;
+    }
 }
 
 /// A node summary for inclusion in a receipt.
@@ -143,6 +151,8 @@ pub enum SignatureError {
     Unsigned,
     /// Signature verification not yet implemented.
     VerificationNotImplemented,
+    /// Ed25519 signature is invalid (wrong key or tampered content).
+    InvalidSignature,
 }
 
 /// Verify the receipt's signature.

--- a/crates/portcullis/src/lib.rs
+++ b/crates/portcullis/src/lib.rs
@@ -125,11 +125,13 @@ pub mod observe;
 /// Requires the `spec` feature (includes `serde`, `cel`, `serde_yaml`, `toml`).
 #[cfg(feature = "spec")]
 pub mod profile;
-#[cfg(feature = "remote-audit")]
-pub mod s3_audit_backend;
 /// Attenuation tokens — compact delegation credentials for wire transport.
 ///
 /// Requires the `serde` feature for serialization.
+#[cfg(feature = "crypto")]
+pub mod receipt_sign;
+#[cfg(feature = "remote-audit")]
+pub mod s3_audit_backend;
 #[cfg(feature = "crypto")]
 pub mod token;
 /// MCP tool schema pinning: rug-pull detection for MCP servers.

--- a/crates/portcullis/src/receipt_sign.rs
+++ b/crates/portcullis/src/receipt_sign.rs
@@ -1,0 +1,238 @@
+//! Ed25519 receipt signing and verification.
+//!
+//! Signs flow receipts so that downstream consumers (audit systems,
+//! compliance dashboards) can verify that a receipt was produced by
+//! a trusted kernel and has not been tampered with.
+//!
+//! The signing key is held by the kernel operator. The public key is
+//! distributed to verifiers.
+
+#[cfg(feature = "crypto")]
+use ring::signature::{self, Ed25519KeyPair, UnparsedPublicKey};
+
+use portcullis_core::receipt::{FlowReceipt, ReceiptNode, SignatureError};
+
+/// Serialize receipt content to canonical bytes for signing.
+///
+/// The canonical form includes all security-relevant fields in a
+/// deterministic order. Changes to any field invalidate the signature.
+fn receipt_content_bytes(receipt: &FlowReceipt) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(256);
+
+    // Version tag
+    buf.extend_from_slice(b"nucleus-receipt-v1\n");
+
+    // Action node
+    append_receipt_node(&mut buf, receipt.action());
+
+    // Verdict + rule
+    buf.extend_from_slice(format!("verdict:{:?}\n", receipt.verdict()).as_bytes());
+    buf.extend_from_slice(format!("rule:{}\n", receipt.rule_name()).as_bytes());
+
+    // Timestamp
+    buf.extend_from_slice(&receipt.created_at().to_le_bytes());
+
+    // Ancestors (ordered — receipt construction preserves BFS order)
+    buf.extend_from_slice(&(receipt.ancestors().len() as u32).to_le_bytes());
+    for ancestor in receipt.ancestors() {
+        append_receipt_node(&mut buf, ancestor);
+    }
+
+    buf
+}
+
+fn append_receipt_node(buf: &mut Vec<u8>, node: &ReceiptNode) {
+    buf.extend_from_slice(&node.id.to_le_bytes());
+    buf.extend_from_slice(&(node.kind as u8).to_le_bytes());
+    buf.extend_from_slice(&(node.label.confidentiality as u8).to_le_bytes());
+    buf.extend_from_slice(&(node.label.integrity as u8).to_le_bytes());
+    buf.extend_from_slice(&(node.label.authority as u8).to_le_bytes());
+    buf.extend_from_slice(&node.label.provenance.bits().to_le_bytes());
+    buf.extend_from_slice(&node.label.freshness.observed_at.to_le_bytes());
+    buf.extend_from_slice(&node.label.freshness.ttl_secs.to_le_bytes());
+}
+
+/// Sign a flow receipt with an Ed25519 key.
+///
+/// Mutates the receipt's signature field in place. The signature covers
+/// all security-relevant fields in canonical byte order.
+#[cfg(feature = "crypto")]
+pub fn sign_receipt(receipt: &mut FlowReceipt, signing_key: &Ed25519KeyPair) {
+    let content = receipt_content_bytes(receipt);
+    let sig = signing_key.sign(&content);
+    let sig_bytes: [u8; 64] = sig
+        .as_ref()
+        .try_into()
+        .expect("Ed25519 signature is 64 bytes");
+    receipt.set_signature(sig_bytes);
+}
+
+/// Verify a receipt's Ed25519 signature against a public key.
+///
+/// Returns `Ok(())` if the signature is valid, or an appropriate error.
+#[cfg(feature = "crypto")]
+pub fn verify_receipt(
+    receipt: &FlowReceipt,
+    public_key_bytes: &[u8],
+) -> Result<(), SignatureError> {
+    if !receipt.is_signed() {
+        return Err(SignatureError::Unsigned);
+    }
+
+    let content = receipt_content_bytes(receipt);
+    let public_key = UnparsedPublicKey::new(&signature::ED25519, public_key_bytes);
+
+    public_key
+        .verify(&content, receipt.signature_bytes())
+        .map_err(|_| SignatureError::InvalidSignature)
+}
+
+#[cfg(test)]
+#[cfg(feature = "crypto")]
+mod tests {
+    use super::*;
+    use portcullis_core::flow::{FlowDenyReason, FlowNode, FlowVerdict, NodeKind, MAX_PARENTS};
+    use portcullis_core::receipt::build_receipt;
+    use portcullis_core::{
+        AuthorityLevel, ConfLevel, Freshness, IFCLabel, IntegLevel, Operation, ProvenanceSet,
+    };
+    use ring::rand::SystemRandom;
+    use ring::signature::KeyPair;
+
+    fn test_key() -> Ed25519KeyPair {
+        let rng = SystemRandom::new();
+        let pkcs8 = Ed25519KeyPair::generate_pkcs8(&rng).unwrap();
+        Ed25519KeyPair::from_pkcs8(pkcs8.as_ref()).unwrap()
+    }
+
+    fn make_node(id: u64, kind: NodeKind, label: IFCLabel, op: Option<Operation>) -> FlowNode {
+        FlowNode {
+            id,
+            kind,
+            label,
+            parent_count: 0,
+            parents: [0; MAX_PARENTS],
+            operation: op,
+        }
+    }
+
+    #[test]
+    fn sign_and_verify_roundtrip() {
+        let key = test_key();
+        let label = IFCLabel::user_prompt(1000);
+        let action = make_node(
+            1,
+            NodeKind::OutboundAction,
+            label,
+            Some(Operation::WriteFiles),
+        );
+        let mut receipt = build_receipt(&action, &[], FlowVerdict::Allow, 2000);
+
+        assert!(!receipt.is_signed());
+        sign_receipt(&mut receipt, &key);
+        assert!(receipt.is_signed());
+
+        let public_key = key.public_key().as_ref();
+        assert!(verify_receipt(&receipt, public_key).is_ok());
+    }
+
+    #[test]
+    fn verify_rejects_unsigned() {
+        let key = test_key();
+        let label = IFCLabel::user_prompt(1000);
+        let action = make_node(
+            1,
+            NodeKind::OutboundAction,
+            label,
+            Some(Operation::WriteFiles),
+        );
+        let receipt = build_receipt(&action, &[], FlowVerdict::Allow, 2000);
+
+        let public_key = key.public_key().as_ref();
+        assert_eq!(
+            verify_receipt(&receipt, public_key),
+            Err(SignatureError::Unsigned)
+        );
+    }
+
+    #[test]
+    fn verify_rejects_wrong_key() {
+        let sign_key = test_key();
+        let wrong_key = test_key();
+
+        let label = IFCLabel::web_content(1000);
+        let action = make_node(1, NodeKind::OutboundAction, label, Some(Operation::GitPush));
+        let mut receipt = build_receipt(
+            &action,
+            &[],
+            FlowVerdict::Deny(FlowDenyReason::AuthorityEscalation),
+            2000,
+        );
+
+        sign_receipt(&mut receipt, &sign_key);
+
+        let wrong_public = wrong_key.public_key().as_ref();
+        assert_eq!(
+            verify_receipt(&receipt, wrong_public),
+            Err(SignatureError::InvalidSignature)
+        );
+    }
+
+    #[test]
+    fn signed_receipt_display_no_warning() {
+        let key = test_key();
+        let label = IFCLabel::user_prompt(1000);
+        let action = make_node(
+            1,
+            NodeKind::OutboundAction,
+            label,
+            Some(Operation::WriteFiles),
+        );
+        let mut receipt = build_receipt(&action, &[], FlowVerdict::Allow, 2000);
+        sign_receipt(&mut receipt, &key);
+
+        let display = receipt.display_chain();
+        assert!(!display.contains("UNSIGNED"));
+    }
+
+    #[test]
+    fn sign_receipt_with_ancestors() {
+        let key = test_key();
+        let now = 1000;
+        let web = make_node(10, NodeKind::WebContent, IFCLabel::web_content(now), None);
+        let file = make_node(
+            20,
+            NodeKind::FileRead,
+            IFCLabel {
+                confidentiality: ConfLevel::Internal,
+                integrity: IntegLevel::Trusted,
+                provenance: ProvenanceSet::USER,
+                freshness: Freshness {
+                    observed_at: now,
+                    ttl_secs: 0,
+                },
+                authority: AuthorityLevel::Directive,
+            },
+            None,
+        );
+        let action = make_node(
+            30,
+            NodeKind::OutboundAction,
+            IFCLabel::web_content(now),
+            Some(Operation::CreatePr),
+        );
+
+        let mut receipt = build_receipt(
+            &action,
+            &[&web, &file],
+            FlowVerdict::Deny(FlowDenyReason::AuthorityEscalation),
+            now + 10,
+        );
+
+        sign_receipt(&mut receipt, &key);
+        assert!(receipt.is_signed());
+
+        let public_key = key.public_key().as_ref();
+        assert!(verify_receipt(&receipt, public_key).is_ok());
+    }
+}


### PR DESCRIPTION
## Summary

Two moonshot gap items in one PR:

**#4 — Ed25519 receipt signing** (`portcullis/src/receipt_sign.rs`):
- `sign_receipt()` produces Ed25519 signatures over canonical receipt bytes (version tag + action node + verdict + rule + timestamp + ancestors in deterministic order)
- `verify_receipt()` validates against a public key, returns `Err(InvalidSignature)` for tampering
- Receipts are no longer forgeable — downstream audit systems can verify provenance

**#5 — Declassification rules** (`portcullis-core/src/declassify.rs`):
- `DeclassificationRule` with 3 actions: `LowerConfidentiality`, `RaiseIntegrity`, `RaiseAuthority`
- Direction-safe: `LowerConfidentiality` requires `to < from`, `RaiseIntegrity` requires `to > from` — cannot escalate via declassification
- Every application produces `DeclassifyResult` with original label for audit trail
- Precondition checking: rules only fire if the label matches the source level

## Test plan

- [x] 5 receipt signing tests: roundtrip, unsigned rejection, wrong key rejection, display without warning, ancestors
- [x] 8 declassification tests: raise integrity, raise authority, lower confidentiality, precondition mismatch, bounded target, audit trail, wrong-direction rejection
- [x] Full workspace compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)