### PR TITLE
feat: manifest registry + MCP admission control

### DIFF
--- a/crates/nucleus-claude-hook/Cargo.toml
+++ b/crates/nucleus-claude-hook/Cargo.toml
@@ -14,7 +14,7 @@ name = "nucleus-claude-hook"
 path = "src/main.rs"
 
 [dependencies]
-portcullis = { path = "../portcullis", features = ["serde", "crypto"] }
+portcullis = { path = "../portcullis", features = ["serde", "crypto", "spec"] }
 portcullis-core = { path = "../portcullis-core" }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/nucleus-claude-hook/src/main.rs
+++ b/crates/nucleus-claude-hook/src/main.rs
@@ -10,6 +10,7 @@ use std::io::{self, BufRead, Write};
 use std::path::PathBuf;
 
 use portcullis::kernel::{Kernel, Verdict};
+use portcullis::manifest_registry::ManifestRegistry;
 use portcullis::{Operation, PermissionLattice};
 use portcullis_core::flow::NodeKind;
 use serde::{Deserialize, Serialize};
@@ -511,6 +512,33 @@ fn main() {
             return;
         }
     };
+
+    // Check MCP tools against manifest registry (admission control).
+    // Loads manifests from .nucleus/manifests/*.toml in the working directory.
+    if input.tool_name.starts_with("mcp__") {
+        let cwd = std::env::current_dir().unwrap_or_default();
+        let registry = ManifestRegistry::load_from_dir(&cwd);
+        // Extract tool name: mcp__server__tool → server__tool
+        let mcp_tool_name = input
+            .tool_name
+            .strip_prefix("mcp__")
+            .unwrap_or(&input.tool_name);
+        if let Some(reason) = registry.is_rejected(mcp_tool_name) {
+            let out = HookOutput {
+                decision: "deny".to_string(),
+                reason: Some(format!(
+                    "nucleus: MCP tool '{}' rejected by manifest admission: {:?}",
+                    mcp_tool_name, reason
+                )),
+            };
+            eprintln!(
+                "nucleus: {} rejected by manifest admission: {:?}",
+                input.tool_name, reason
+            );
+            println!("{}", serde_json::to_string(&out).unwrap());
+            std::process::exit(2);
+        }
+    }
 
     let subject = extract_subject(&input.tool_name, &input.tool_input);
     let profile_name = default_profile_name();

--- a/crates/portcullis/src/lib.rs
+++ b/crates/portcullis/src/lib.rs
@@ -114,6 +114,8 @@ pub mod kernel;
 ///
 /// Requires the `spec` feature (includes `serde`, `serde_yaml`, `toml`).
 #[cfg(feature = "spec")]
+pub mod manifest_registry;
+#[cfg(feature = "spec")]
 pub mod mcp_mediation;
 /// Progressive discovery: observe agent behavior and generate minimal policies.
 ///

--- a/crates/portcullis/src/manifest_registry.rs
+++ b/crates/portcullis/src/manifest_registry.rs
@@ -1,0 +1,358 @@
+//! Manifest registry — loads, validates, and stores MCP tool manifests.
+//!
+//! Loads manifests from `.nucleus/manifests/*.toml` in the project directory.
+//! Each manifest declares the tool's capabilities, data sources, sinks,
+//! and output labels. Admission control rejects unsafe combinations before
+//! the tool is allowed to serve.
+//!
+//! ## TOML Format
+//!
+//! ```toml
+//! [tool]
+//! name = "github__search_repos"
+//! capabilities = ["read_files", "web_fetch"]
+//! remote_fetch = true
+//! instruction_sources = ["user_prompt", "static"]
+//! admissible_sinks = ["local_memory", "human_visible"]
+//! max_confidentiality = "internal"
+//! output_integrity = "untrusted"
+//! output_authority = "informational"
+//! ```
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use portcullis_core::manifest::{
+    check_admission, AdmissionDenyReason, AdmissionVerdict, InstructionSource, SinkClass,
+    ToolManifest, ToolName,
+};
+use portcullis_core::{AuthorityLevel, ConfLevel, IntegLevel, Operation};
+use serde::Deserialize;
+
+/// A loaded and validated manifest registry.
+#[derive(Debug, Default)]
+pub struct ManifestRegistry {
+    /// Admitted tools: MCP tool name → manifest.
+    tools: BTreeMap<String, ToolManifest>,
+    /// Rejected tools: MCP tool name → reason.
+    rejected: BTreeMap<String, AdmissionDenyReason>,
+}
+
+/// TOML-deserializable manifest format.
+#[derive(Deserialize)]
+struct ManifestFile {
+    tool: ToolEntry,
+}
+
+#[derive(Deserialize)]
+struct ToolEntry {
+    name: String,
+    #[serde(default)]
+    capabilities: Vec<String>,
+    #[serde(default)]
+    remote_fetch: bool,
+    #[serde(default)]
+    instruction_sources: Vec<String>,
+    #[serde(default)]
+    admissible_sinks: Vec<String>,
+    #[serde(default = "default_conf")]
+    max_confidentiality: String,
+    #[serde(default = "default_integ")]
+    output_integrity: String,
+    #[serde(default = "default_auth")]
+    output_authority: String,
+}
+
+fn default_conf() -> String {
+    "public".to_string()
+}
+fn default_integ() -> String {
+    "untrusted".to_string()
+}
+fn default_auth() -> String {
+    "no_authority".to_string()
+}
+
+impl ManifestRegistry {
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Load manifests from `.nucleus/manifests/` in the given directory.
+    ///
+    /// Each `.toml` file is parsed, converted, and run through admission
+    /// control. Admitted tools are stored; rejected tools are logged.
+    pub fn load_from_dir(dir: &Path) -> Self {
+        let mut registry = Self::new();
+        let manifest_dir = dir.join(".nucleus").join("manifests");
+
+        if !manifest_dir.is_dir() {
+            return registry;
+        }
+
+        let entries = match std::fs::read_dir(&manifest_dir) {
+            Ok(e) => e,
+            Err(_) => return registry,
+        };
+
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().is_some_and(|ext| ext == "toml") {
+                if let Ok(content) = std::fs::read_to_string(&path) {
+                    registry.load_toml(&content);
+                }
+            }
+        }
+
+        registry
+    }
+
+    /// Parse and register a single manifest from TOML content.
+    pub fn load_toml(&mut self, content: &str) {
+        let file: ManifestFile = match toml::from_str(content) {
+            Ok(f) => f,
+            Err(_) => return,
+        };
+
+        let manifest = match convert_entry(&file.tool) {
+            Some(m) => m,
+            None => return,
+        };
+
+        let name = file.tool.name.clone();
+
+        match check_admission(&manifest) {
+            AdmissionVerdict::Admit => {
+                self.tools.insert(name, manifest);
+            }
+            AdmissionVerdict::Reject(reason) => {
+                self.rejected.insert(name, reason);
+            }
+        }
+    }
+
+    /// Look up a manifest for an MCP tool.
+    ///
+    /// The tool name should be the full MCP name (e.g., "github__search_repos")
+    /// or just the tool part extracted from "mcp__server__tool".
+    pub fn get(&self, tool_name: &str) -> Option<&ToolManifest> {
+        self.tools.get(tool_name)
+    }
+
+    /// Check if a tool was rejected during admission.
+    pub fn is_rejected(&self, tool_name: &str) -> Option<AdmissionDenyReason> {
+        self.rejected.get(tool_name).copied()
+    }
+
+    /// Number of admitted tools.
+    pub fn admitted_count(&self) -> usize {
+        self.tools.len()
+    }
+
+    /// Number of rejected tools.
+    pub fn rejected_count(&self) -> usize {
+        self.rejected.len()
+    }
+
+    /// Iterate over admitted tools.
+    pub fn admitted(&self) -> impl Iterator<Item = (&str, &ToolManifest)> {
+        self.tools.iter().map(|(k, v)| (k.as_str(), v))
+    }
+}
+
+fn convert_entry(entry: &ToolEntry) -> Option<ToolManifest> {
+    let capabilities: Vec<Operation> = entry
+        .capabilities
+        .iter()
+        .filter_map(|s| Operation::try_from(s.as_str()).ok())
+        .collect();
+
+    let instruction_sources: Vec<InstructionSource> = entry
+        .instruction_sources
+        .iter()
+        .map(|s| match s.as_str() {
+            "static" => InstructionSource::Static,
+            "user_prompt" => InstructionSource::UserPrompt,
+            "remote_url" => InstructionSource::RemoteUrl,
+            "transitive_tool" => InstructionSource::TransitiveTool,
+            _ => InstructionSource::Unlabeled,
+        })
+        .collect();
+
+    let admissible_sinks: Vec<SinkClass> = entry
+        .admissible_sinks
+        .iter()
+        .map(|s| match s.as_str() {
+            "local_memory" => SinkClass::LocalMemory,
+            "local_file" => SinkClass::LocalFile,
+            "external_network" => SinkClass::ExternalNetwork,
+            "version_control" => SinkClass::VersionControl,
+            "human_visible" => SinkClass::HumanVisible,
+            _ => SinkClass::ExternalNetwork, // fail-closed: unknown → most dangerous
+        })
+        .collect();
+
+    let max_confidentiality = match entry.max_confidentiality.as_str() {
+        "public" => ConfLevel::Public,
+        "internal" => ConfLevel::Internal,
+        "secret" => ConfLevel::Secret,
+        _ => ConfLevel::Public,
+    };
+
+    let output_integrity = match entry.output_integrity.as_str() {
+        "adversarial" => IntegLevel::Adversarial,
+        "untrusted" => IntegLevel::Untrusted,
+        "trusted" => IntegLevel::Trusted,
+        _ => IntegLevel::Adversarial, // fail-closed
+    };
+
+    let output_authority = match entry.output_authority.as_str() {
+        "no_authority" => AuthorityLevel::NoAuthority,
+        "informational" => AuthorityLevel::Informational,
+        "suggestive" => AuthorityLevel::Suggestive,
+        "directive" => AuthorityLevel::Directive,
+        _ => AuthorityLevel::NoAuthority, // fail-closed
+    };
+
+    Some(ToolManifest {
+        name: ToolName::new(&entry.name),
+        capabilities,
+        remote_fetch: entry.remote_fetch,
+        instruction_sources,
+        admissible_sinks,
+        max_confidentiality,
+        output_integrity,
+        output_authority,
+        schema_hash: [0; 32], // filled by ToolSchemaRegistry at runtime
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn load_valid_manifest() {
+        let toml = r#"
+[tool]
+name = "github__search_repos"
+capabilities = ["read_files", "web_fetch"]
+remote_fetch = true
+instruction_sources = ["user_prompt", "static"]
+admissible_sinks = ["local_memory", "human_visible"]
+max_confidentiality = "internal"
+output_integrity = "untrusted"
+output_authority = "informational"
+"#;
+        let mut registry = ManifestRegistry::new();
+        registry.load_toml(toml);
+
+        assert_eq!(registry.admitted_count(), 1);
+        let manifest = registry.get("github__search_repos").unwrap();
+        assert_eq!(manifest.capabilities.len(), 2);
+        assert!(manifest.remote_fetch);
+        assert_eq!(manifest.output_integrity, IntegLevel::Untrusted);
+        assert_eq!(manifest.output_authority, AuthorityLevel::Informational);
+    }
+
+    #[test]
+    fn reject_remote_fetch_with_unlabeled_instructions() {
+        let toml = r#"
+[tool]
+name = "evil_tool"
+capabilities = ["web_fetch"]
+remote_fetch = true
+instruction_sources = ["unlabeled"]
+admissible_sinks = ["external_network"]
+output_integrity = "trusted"
+output_authority = "directive"
+"#;
+        let mut registry = ManifestRegistry::new();
+        registry.load_toml(toml);
+
+        assert_eq!(registry.admitted_count(), 0);
+        assert!(registry.is_rejected("evil_tool").is_some());
+    }
+
+    #[test]
+    fn reject_empty_capabilities() {
+        let toml = r#"
+[tool]
+name = "empty_tool"
+capabilities = []
+"#;
+        let mut registry = ManifestRegistry::new();
+        registry.load_toml(toml);
+
+        assert_eq!(registry.admitted_count(), 0);
+        assert_eq!(
+            registry.is_rejected("empty_tool"),
+            Some(AdmissionDenyReason::EmptyCapabilities)
+        );
+    }
+
+    #[test]
+    fn reject_trusted_from_remote() {
+        let toml = r#"
+[tool]
+name = "lying_tool"
+capabilities = ["read_files"]
+remote_fetch = true
+instruction_sources = ["static"]
+admissible_sinks = ["local_memory"]
+output_integrity = "trusted"
+output_authority = "informational"
+"#;
+        let mut registry = ManifestRegistry::new();
+        registry.load_toml(toml);
+
+        assert_eq!(registry.admitted_count(), 0);
+        assert_eq!(
+            registry.is_rejected("lying_tool"),
+            Some(AdmissionDenyReason::TrustedOutputFromRemote)
+        );
+    }
+
+    #[test]
+    fn safe_local_tool_admitted() {
+        let toml = r#"
+[tool]
+name = "file_reader"
+capabilities = ["read_files"]
+remote_fetch = false
+instruction_sources = ["static"]
+admissible_sinks = ["human_visible"]
+output_integrity = "trusted"
+output_authority = "informational"
+"#;
+        let mut registry = ManifestRegistry::new();
+        registry.load_toml(toml);
+
+        assert_eq!(registry.admitted_count(), 1);
+        let m = registry.get("file_reader").unwrap();
+        assert_eq!(m.output_integrity, IntegLevel::Trusted);
+        assert!(!m.remote_fetch);
+    }
+
+    #[test]
+    fn unknown_sinks_fail_closed() {
+        let toml = r#"
+[tool]
+name = "weird_tool"
+capabilities = ["read_files"]
+instruction_sources = ["static"]
+admissible_sinks = ["unknown_sink_type"]
+"#;
+        let mut registry = ManifestRegistry::new();
+        registry.load_toml(toml);
+
+        // Unknown sink maps to ExternalNetwork (most dangerous)
+        // But remote_fetch=false + ExternalNetwork sink → rejected (Rule 3)
+        assert_eq!(registry.admitted_count(), 0);
+        assert_eq!(
+            registry.is_rejected("weird_tool"),
+            Some(AdmissionDenyReason::UndeclaredExternalSink)
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Wires moonshot items #9 (manifest schemas) and #10 (admission control) into production.

**ManifestRegistry** (`portcullis/src/manifest_registry.rs`):
- Loads TOML manifests from `.nucleus/manifests/*.toml` in the project directory
- Each manifest declares: capabilities, remote_fetch, instruction_sources, admissible_sinks, output_integrity, output_authority
- Runs `check_admission()` (5 rules from portcullis-core) on load
- Admitted tools stored for lookup; rejected tools tracked with reason
- Follows CNCF patterns: Gatekeeper-style policy-at-admission, SLSA-style schema hashing

**Claude-hook integration**:
- MCP tools (`mcp__*`) checked against the manifest registry before kernel decision
- Tools whose manifests fail admission are denied immediately with reason
- No manifest = falls through to heuristic classification (existing behavior)

Example manifest (`.nucleus/manifests/github.toml`):
```toml
[tool]
name = "github__search_repos"
capabilities = ["read_files", "web_fetch"]
remote_fetch = true
instruction_sources = ["user_prompt", "static"]
admissible_sinks = ["local_memory", "human_visible"]
output_integrity = "untrusted"
output_authority = "informational"
```

## Test plan

- [x] 6 manifest registry tests (admission, rejection, fail-closed)
- [x] All 21 claude-hook tests pass
- [x] Full workspace compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)