### PR TITLE
feat: Cedar policy bridge + multi-agent label wire protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,6 +123,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "ar_archive_writer"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eb93bbb63b9c227414f6eb3a0adfddca591a8ce1e9b60661bb08969b87e340b"
+dependencies = [
+ "object",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -139,9 +148,24 @@ checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
+name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "ascii-canvas"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1e3e699d84ab1b0911a1010c5c106aa34ae89aeac103be5ce0c3859db1e891"
+dependencies = [
+ "term",
+]
 
 [[package]]
 name = "asn1-rs"
@@ -785,7 +809,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e"
 dependencies = [
  "arrayref",
- "arrayvec",
+ "arrayvec 0.7.6",
  "cc",
  "cfg-if",
  "constant_time_eq",
@@ -1018,6 +1042,69 @@ dependencies = [
  "jobserver",
  "libc",
  "shlex",
+]
+
+[[package]]
+name = "cedar-policy"
+version = "4.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50368b44367cd7664627bbee9bfe5721d10ab2433daf77645833645e8eb746da"
+dependencies = [
+ "cedar-policy-core",
+ "cedar-policy-formatter",
+ "itertools",
+ "linked-hash-map",
+ "miette",
+ "ref-cast",
+ "semver",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "smol_str",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "cedar-policy-core"
+version = "4.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9700d95c08701d5e43d30756ab0ec791649c2a93dee1274fac0fe8a17c7b24f"
+dependencies = [
+ "chrono",
+ "educe",
+ "either",
+ "itertools",
+ "lalrpop",
+ "lalrpop-util",
+ "linked-hash-map",
+ "linked_hash_set",
+ "miette",
+ "nonempty",
+ "ref-cast",
+ "regex",
+ "rustc-literal-escaper",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "smol_str",
+ "stacker",
+ "thiserror 2.0.18",
+ "unicode-security",
+]
+
+[[package]]
+name = "cedar-policy-formatter"
+version = "4.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18c03e1d143e1c222d2ea48453ab4f4b11e545ac5a268a15bb163769fe568b90"
+dependencies = [
+ "cedar-policy-core",
+ "itertools",
+ "logos",
+ "miette",
+ "pretty",
+ "regex",
+ "smol_str",
 ]
 
 [[package]]
@@ -1268,7 +1355,7 @@ dependencies = [
  "cookie",
  "document-features",
  "idna",
- "indexmap",
+ "indexmap 2.13.0",
  "log",
  "serde",
  "serde_derive",
@@ -1442,7 +1529,7 @@ version = "1.0.0"
 dependencies = [
  "ctf-engine",
  "rmcp",
- "schemars",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "tokio",
@@ -1582,6 +1669,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+ "serde_core",
 ]
 
 [[package]]
@@ -1767,6 +1855,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "educe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1790,6 +1890,35 @@ dependencies = [
  "sec1",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "ena"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabffdaee24bd1bf95c5ef7cec31260444317e72ea56c4c91750e8b7ee58d5f1"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "enum-ordinalize"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1091a7bb1f8f2c4b28f1fe2cef4980ca2d410a3d727d67ecc3178c9b0800f0"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2097,7 +2226,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap",
+ "indexmap 2.13.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2116,7 +2245,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.4.0",
- "indexmap",
+ "indexmap 2.13.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2549,6 +2678,17 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
@@ -2716,6 +2856,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+dependencies = [
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "lalrpop"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba4ebbd48ce411c1d10fb35185f5a51a7bfa3d8b24b4e330d30c9e3a34129501"
+dependencies = [
+ "ascii-canvas",
+ "bit-set",
+ "ena",
+ "itertools",
+ "lalrpop-util",
+ "petgraph 0.7.1",
+ "pico-args",
+ "regex",
+ "regex-syntax",
+ "sha3",
+ "string_cache",
+ "term",
+ "unicode-xid",
+ "walkdir",
+]
+
+[[package]]
+name = "lalrpop-util"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5baa5e9ff84f1aefd264e6869907646538a52147a755d494517a8007fb48733"
+dependencies = [
+ "regex-automata",
+ "rustversion",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2759,6 +2940,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "linked_hash_set"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "984fb35d06508d1e69fc91050cceba9c0b748f983e6739fa2c7a9237154c52c8"
+dependencies = [
+ "linked-hash-map",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2790,6 +2989,38 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "logos"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2c55a318a87600ea870ff8c2012148b44bf18b74fad48d0f835c38c7d07c5f"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58b3ffaa284e1350d017a57d04ada118c4583cf260c8fb01e0fe28a2e9cf8970"
+dependencies = [
+ "fnv",
+ "proc-macro2",
+ "quote",
+ "regex-automata",
+ "regex-syntax",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d3a9855747c17eaf4383823f135220716ab49bea5fbea7dd42cc9a92f8aa31"
+dependencies = [
+ "logos-codegen",
+]
 
 [[package]]
 name = "lru"
@@ -2844,6 +3075,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "miette"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
+dependencies = [
+ "cfg-if",
+ "miette-derive",
+ "serde",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2916,6 +3170,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
 name = "nix"
 version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2936,6 +3196,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nonempty"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9737e026353e5cd0736f98eddae28665118eb6f6600902a7f50db585621fecb6"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -3249,7 +3518,7 @@ dependencies = [
  "rmcp",
  "rust_decimal",
  "rustls 0.23.37",
- "schemars",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -3332,6 +3601,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
 dependencies = [
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -3534,14 +3812,39 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "petgraph"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+dependencies = [
+ "fixedbitset",
+ "indexmap 2.13.0",
+]
+
+[[package]]
+name = "petgraph"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.13.0",
 ]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pin-project"
@@ -3608,6 +3911,7 @@ dependencies = [
  "aws-config",
  "aws-sdk-s3",
  "base64",
+ "cedar-policy",
  "cel-interpreter",
  "chrono",
  "hex",
@@ -3660,6 +3964,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "pretty"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d22152487193190344590e4f30e219cf3fe140d9e7a3fdb683d82aa2c5f4156"
+dependencies = [
+ "arrayvec 0.5.2",
+ "typed-arena",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -3739,7 +4060,7 @@ dependencies = [
  "itertools",
  "log",
  "multimap",
- "petgraph",
+ "petgraph 0.8.3",
  "prettyplease",
  "prost",
  "prost-types",
@@ -3835,6 +4156,16 @@ name = "protoc-bin-vendored-win32"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95067976aca6421a523e491fce939a3e65249bac4b977adee0ee9771568e8aa3"
+
+[[package]]
+name = "psm"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3852766467df634d74f0b2d7819bf8dc483a0eb2e3b0f50f756f9cfe8b0d18d8"
+dependencies = [
+ "ar_archive_writer",
+ "cc",
+]
 
 [[package]]
 name = "ptr_meta"
@@ -4032,7 +4363,7 @@ dependencies = [
  "thiserror 2.0.18",
  "unicode-segmentation",
  "unicode-truncate",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -4063,7 +4394,7 @@ dependencies = [
  "strum",
  "time",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -4327,7 +4658,7 @@ dependencies = [
  "pin-project-lite",
  "rand 0.10.0",
  "rmcp-macros",
- "schemars",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "sse-stream",
@@ -4359,7 +4690,7 @@ version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ce901f9a19d251159075a4c37af514c3b8ef99c22e02dd8c19161cf397ee94a"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.7.6",
  "borsh",
  "bytes",
  "num-traits",
@@ -4369,6 +4700,12 @@ dependencies = [
  "serde_json",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "rustc-literal-escaper"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be87abb9e40db7466e0681dc8ecd9dcfd40360cb10b4c8fe24a7c4c3669b198"
 
 [[package]]
 name = "rustc_version"
@@ -4553,6 +4890,18 @@ dependencies = [
 
 [[package]]
 name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
@@ -4700,6 +5049,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap 2.13.0",
  "itoa",
  "memchr",
  "serde",
@@ -4751,12 +5101,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+dependencies = [
+ "base64",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.13.0",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "itoa",
  "ryu",
  "serde",
@@ -4807,6 +5188,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "digest 0.11.2",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+dependencies = [
+ "digest 0.10.7",
+ "keccak",
 ]
 
 [[package]]
@@ -4914,6 +5305,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4924,6 +5321,16 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "smol_str"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa7368fcf4852a4c2dd92df0cace6a71f2091ca0a23391ce7f3a31833f1523"
+dependencies = [
+ "borsh",
+ "serde_core",
+]
 
 [[package]]
 name = "socket2"
@@ -5015,10 +5422,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "stacker"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d74a23609d509411d10e2176dc2a4346e3b4aea2e7b1869f19fdedbc71c013"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "string_cache"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
+]
 
 [[package]]
 name = "strsim"
@@ -5111,6 +5543,15 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "term"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
+dependencies = [
  "windows-sys 0.61.2",
 ]
 
@@ -5323,7 +5764,7 @@ version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8195ca05e4eb728f4ba94f3e3291661320af739c4e43779cbdfae82ab239fcc"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "serde_core",
  "serde_spanned",
  "toml_datetime 1.1.0+spec-1.1.0",
@@ -5356,7 +5797,7 @@ version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "winnow 0.7.14",
@@ -5454,7 +5895,7 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap",
+ "indexmap 2.13.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -5633,6 +6074,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-script"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "383ad40bb927465ec0ce7720e033cb4ca06912855fc35db31b5755d0de75b1ee"
+
+[[package]]
+name = "unicode-security"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e4ddba1535dd35ed8b61c52166b7155d7f4e4b8847cec6f48e71dc66d8b5e50"
+dependencies = [
+ "unicode-normalization",
+ "unicode-script",
+]
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5646,8 +6112,14 @@ checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
  "itertools",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -5967,7 +6439,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.13.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -5980,7 +6452,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.13.0",
  "semver",
 ]
 
@@ -6409,7 +6881,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap",
+ "indexmap 2.13.0",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -6440,7 +6912,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap",
+ "indexmap 2.13.0",
  "log",
  "serde",
  "serde_derive",
@@ -6459,7 +6931,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.13.0",
  "log",
  "semver",
  "serde",

--- a/crates/portcullis-core/src/lib.rs
+++ b/crates/portcullis-core/src/lib.rs
@@ -57,6 +57,7 @@ pub mod declassify;
 pub mod flow;
 pub mod manifest;
 pub mod receipt;
+pub mod wire;
 
 /// Tool permission levels in lattice ordering.
 ///
@@ -683,6 +684,12 @@ impl ProvenanceSet {
     /// Raw bitmask value (for serialization/signing).
     pub fn bits(self) -> u8 {
         self.0
+    }
+
+    /// Construct from raw bitmask (for deserialization/wire protocol).
+    /// Only the lower 6 bits are used.
+    pub fn from_bits(bits: u8) -> Self {
+        Self(bits & 0x3F)
     }
 }
 

--- a/crates/portcullis-core/src/wire.rs
+++ b/crates/portcullis-core/src/wire.rs
@@ -1,0 +1,201 @@
+//! Wire format for multi-agent IFC label propagation.
+//!
+//! When Agent A's output is consumed by Agent B, the IFC labels must
+//! propagate across the agent boundary. This module defines the wire
+//! format for encoding labels in HTTP headers, gRPC metadata, or
+//! MCP extension fields.
+//!
+//! ## Wire protocol
+//!
+//! Labels are encoded as a compact header string:
+//!
+//! ```text
+//! X-Nucleus-Label: c=2;i=0;a=0;p=5;t=1711843200;ttl=3600
+//! ```
+//!
+//! Where:
+//! - `c` = confidentiality (0=Public, 1=Internal, 2=Secret)
+//! - `i` = integrity (0=Adversarial, 1=Untrusted, 2=Trusted)
+//! - `a` = authority (0=NoAuthority, 1=Informational, 2=Suggestive, 3=Directive)
+//! - `p` = provenance bitmask (6 bits: USER|TOOL|WEB|MEMORY|MODEL|SYSTEM)
+//! - `t` = observed_at (unix timestamp)
+//! - `ttl` = time-to-live seconds (0 = no expiry)
+//!
+//! The receiving agent's kernel must `observe()` with this label as the
+//! intrinsic label of the incoming data, ensuring taint propagates.
+
+use crate::{AuthorityLevel, ConfLevel, Freshness, IFCLabel, IntegLevel, ProvenanceSet};
+
+/// HTTP header name for IFC label propagation.
+pub const LABEL_HEADER: &str = "x-nucleus-label";
+
+/// Encode an IFC label to the wire format.
+pub fn encode_label(label: &IFCLabel) -> String {
+    format!(
+        "c={};i={};a={};p={};t={};ttl={}",
+        label.confidentiality as u8,
+        label.integrity as u8,
+        label.authority as u8,
+        label.provenance.bits(),
+        label.freshness.observed_at,
+        label.freshness.ttl_secs,
+    )
+}
+
+/// Decode an IFC label from the wire format.
+///
+/// Returns `None` if the format is invalid. Fail-closed: unknown fields
+/// are ignored, missing fields use the most restrictive defaults.
+pub fn decode_label(s: &str) -> Option<IFCLabel> {
+    let mut conf: u8 = 2; // Secret (most restrictive)
+    let mut integ: u8 = 0; // Adversarial (most restrictive)
+    let mut auth: u8 = 0; // NoAuthority (most restrictive)
+    let mut prov: u8 = 0;
+    let mut observed_at: u64 = 0;
+    let mut ttl: u64 = 0;
+
+    for part in s.split(';') {
+        let part = part.trim();
+        if let Some((key, val)) = part.split_once('=') {
+            match key {
+                "c" => conf = val.parse().ok()?,
+                "i" => integ = val.parse().ok()?,
+                "a" => auth = val.parse().ok()?,
+                "p" => prov = val.parse().ok()?,
+                "t" => observed_at = val.parse().ok()?,
+                "ttl" => ttl = val.parse().ok()?,
+                _ => {} // ignore unknown fields
+            }
+        }
+    }
+
+    let confidentiality = match conf {
+        0 => ConfLevel::Public,
+        1 => ConfLevel::Internal,
+        _ => ConfLevel::Secret, // fail-closed: unknown = Secret
+    };
+
+    let integrity = match integ {
+        0 => IntegLevel::Adversarial,
+        1 => IntegLevel::Untrusted,
+        2 => IntegLevel::Trusted,
+        _ => IntegLevel::Adversarial, // fail-closed
+    };
+
+    let authority = match auth {
+        0 => AuthorityLevel::NoAuthority,
+        1 => AuthorityLevel::Informational,
+        2 => AuthorityLevel::Suggestive,
+        3 => AuthorityLevel::Directive,
+        _ => AuthorityLevel::NoAuthority, // fail-closed
+    };
+
+    Some(IFCLabel {
+        confidentiality,
+        integrity,
+        provenance: ProvenanceSet::from_bits(prov & 0x3F),
+        freshness: Freshness {
+            observed_at,
+            ttl_secs: ttl,
+        },
+        authority,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip_public_trusted() {
+        let label = IFCLabel {
+            confidentiality: ConfLevel::Public,
+            integrity: IntegLevel::Trusted,
+            provenance: ProvenanceSet::USER,
+            freshness: Freshness {
+                observed_at: 1711843200,
+                ttl_secs: 3600,
+            },
+            authority: AuthorityLevel::Directive,
+        };
+        let encoded = encode_label(&label);
+        let decoded = decode_label(&encoded).unwrap();
+        assert_eq!(decoded.confidentiality, label.confidentiality);
+        assert_eq!(decoded.integrity, label.integrity);
+        assert_eq!(decoded.authority, label.authority);
+        assert_eq!(decoded.freshness.observed_at, label.freshness.observed_at);
+        assert_eq!(decoded.freshness.ttl_secs, label.freshness.ttl_secs);
+    }
+
+    #[test]
+    fn roundtrip_adversarial_web() {
+        let label = IFCLabel::web_content(1000);
+        let encoded = encode_label(&label);
+        let decoded = decode_label(&encoded).unwrap();
+        assert_eq!(decoded.integrity, IntegLevel::Adversarial);
+        assert_eq!(decoded.authority, AuthorityLevel::NoAuthority);
+    }
+
+    #[test]
+    fn roundtrip_secret() {
+        let label = IFCLabel::secret(2000);
+        let encoded = encode_label(&label);
+        let decoded = decode_label(&encoded).unwrap();
+        assert_eq!(decoded.confidentiality, ConfLevel::Secret);
+        assert_eq!(decoded.authority, AuthorityLevel::NoAuthority);
+    }
+
+    #[test]
+    fn decode_unknown_values_fail_closed() {
+        // Unknown conf=99 → Secret (most restrictive)
+        let decoded = decode_label("c=99;i=0;a=0;p=0;t=0;ttl=0").unwrap();
+        assert_eq!(decoded.confidentiality, ConfLevel::Secret);
+    }
+
+    #[test]
+    fn decode_partial_uses_restrictive_defaults() {
+        // Only integrity specified — everything else defaults to most restrictive
+        let decoded = decode_label("i=2").unwrap();
+        assert_eq!(decoded.integrity, IntegLevel::Trusted);
+        assert_eq!(decoded.confidentiality, ConfLevel::Secret); // default
+        assert_eq!(decoded.authority, AuthorityLevel::NoAuthority); // default
+    }
+
+    #[test]
+    fn decode_empty_returns_restrictive() {
+        let decoded = decode_label("").unwrap();
+        assert_eq!(decoded.confidentiality, ConfLevel::Secret);
+        assert_eq!(decoded.integrity, IntegLevel::Adversarial);
+        assert_eq!(decoded.authority, AuthorityLevel::NoAuthority);
+    }
+
+    #[test]
+    fn decode_invalid_returns_none() {
+        // Non-numeric value
+        assert!(decode_label("c=abc").is_none());
+    }
+
+    #[test]
+    fn header_name_is_lowercase() {
+        assert_eq!(LABEL_HEADER, "x-nucleus-label");
+    }
+
+    #[test]
+    fn provenance_roundtrip() {
+        let label = IFCLabel {
+            confidentiality: ConfLevel::Internal,
+            integrity: IntegLevel::Untrusted,
+            provenance: ProvenanceSet::WEB.union(ProvenanceSet::TOOL),
+            freshness: Freshness {
+                observed_at: 5000,
+                ttl_secs: 0,
+            },
+            authority: AuthorityLevel::Informational,
+        };
+        let encoded = encode_label(&label);
+        let decoded = decode_label(&encoded).unwrap();
+        assert!(decoded.provenance.contains(ProvenanceSet::WEB));
+        assert!(decoded.provenance.contains(ProvenanceSet::TOOL));
+        assert!(!decoded.provenance.contains(ProvenanceSet::USER));
+    }
+}

--- a/crates/portcullis/Cargo.toml
+++ b/crates/portcullis/Cargo.toml
@@ -30,6 +30,9 @@ webhook = ["dep:reqwest", "dep:tokio", "serde"]
 # Remote append-only audit sink (S3-compatible: AWS S3, MinIO, R2, Tigris)
 remote-audit = ["dep:aws-sdk-s3", "dep:aws-config", "dep:tokio", "serde"]
 
+# Cedar policy language integration (CNCF Sandbox project)
+cedar = ["dep:cedar-policy", "serde"]
+
 # SECURITY: Enable this feature ONLY for testing. It exposes methods that
 # bypass security constraints (e.g., disabling uninhabitable state enforcement).
 # DO NOT enable in production builds.
@@ -65,6 +68,9 @@ regex = { workspace = true }
 
 # CEL expression evaluation (optional, for user-defined nuclei)
 cel-interpreter = { version = "0.10", optional = true }
+
+# Cedar policy language (CNCF Sandbox — human-readable, analyzable policies)
+cedar-policy = { version = "4", optional = true }
 
 # Policy specification parsing (optional)
 serde_yaml = { workspace = true, optional = true }

--- a/crates/portcullis/src/cedar_bridge.rs
+++ b/crates/portcullis/src/cedar_bridge.rs
@@ -1,0 +1,243 @@
+//! Cedar policy bridge — evaluate nucleus Operations against Cedar policies.
+//!
+//! Maps the nucleus permission model to Cedar's authorization model:
+//!
+//! ```text
+//! Nucleus                    Cedar
+//! ─────────                  ─────
+//! agent session_id     →     principal  (Agent::"session-uuid")
+//! Operation            →     action     (Action::"write_files")
+//! subject (path/url)   →     resource   (Resource::"path/to/file")
+//! IFC label            →     context    (integrity, authority, provenance)
+//! ```
+//!
+//! Cedar policies are human-readable and analyzable:
+//!
+//! ```cedar
+//! // Allow reads from any path
+//! permit(
+//!     principal is Agent,
+//!     action == Action::"read_files",
+//!     resource
+//! );
+//!
+//! // Block writes when source has adversarial integrity
+//! forbid(
+//!     principal is Agent,
+//!     action == Action::"write_files",
+//!     resource
+//! ) when {
+//!     context.integrity == "adversarial"
+//! };
+//!
+//! // Allow web_fetch but only to approved domains
+//! permit(
+//!     principal is Agent,
+//!     action == Action::"web_fetch",
+//!     resource
+//! ) when {
+//!     resource.domain in ["crates.io", "docs.rs", "github.com"]
+//! };
+//! ```
+//!
+//! The Cedar evaluator runs AFTER the portcullis lattice check — it's an
+//! additional policy layer, not a replacement. The lattice provides formal
+//! monotonicity guarantees; Cedar provides human-readable, auditable rules.
+
+use cedar_policy::{
+    Authorizer, Context, Decision, Entities, EntityUid, PolicySet, Request, Response,
+};
+use portcullis_core::{AuthorityLevel, ConfLevel, IntegLevel, Operation};
+
+/// A Cedar policy evaluator for nucleus operations.
+pub struct CedarEvaluator {
+    policies: PolicySet,
+    authorizer: Authorizer,
+}
+
+/// Result of a Cedar policy evaluation.
+#[derive(Debug)]
+pub struct CedarResult {
+    /// Cedar's decision (Allow or Deny).
+    pub decision: Decision,
+    /// Human-readable explanation of why.
+    pub reasons: Vec<String>,
+}
+
+impl CedarEvaluator {
+    /// Create a new evaluator from Cedar policy source.
+    ///
+    /// Returns an error if the policies fail to parse.
+    pub fn new(policy_src: &str) -> Result<Self, String> {
+        let policies: PolicySet = policy_src
+            .parse()
+            .map_err(|e| format!("Cedar policy parse error: {e}"))?;
+        Ok(Self {
+            policies,
+            authorizer: Authorizer::new(),
+        })
+    }
+
+    /// Evaluate a nucleus operation against Cedar policies.
+    ///
+    /// Maps the operation to a Cedar request with:
+    /// - principal: `Agent::"<session_id>"`
+    /// - action: `Action::"<operation_name>"`
+    /// - resource: `Resource::"<subject>"`
+    /// - context: IFC label dimensions (integrity, authority, confidentiality)
+    pub fn evaluate(
+        &self,
+        session_id: &str,
+        operation: Operation,
+        subject: &str,
+        integrity: IntegLevel,
+        authority: AuthorityLevel,
+        confidentiality: ConfLevel,
+    ) -> CedarResult {
+        let principal: EntityUid = format!("Agent::\"{}\"", session_id)
+            .parse()
+            .unwrap_or_else(|_| "Agent::\"unknown\"".parse().unwrap());
+        let action: EntityUid = format!("Action::\"{}\"", operation)
+            .parse()
+            .unwrap_or_else(|_| "Action::\"unknown\"".parse().unwrap());
+        let resource: EntityUid = format!("Resource::\"{}\"", subject)
+            .parse()
+            .unwrap_or_else(|_| "Resource::\"unknown\"".parse().unwrap());
+
+        let context_json = serde_json::json!({
+            "integrity": format!("{:?}", integrity).to_lowercase(),
+            "authority": format!("{:?}", authority).to_lowercase(),
+            "confidentiality": format!("{:?}", confidentiality).to_lowercase(),
+            "operation": operation.to_string(),
+            "subject": subject,
+        });
+
+        let context =
+            Context::from_json_value(context_json, None).unwrap_or_else(|_| Context::empty());
+
+        let request =
+            Request::new(principal, action, resource, context, None).unwrap_or_else(|_| {
+                // Fallback: empty request that will be denied by default
+                Request::new(
+                    "Agent::\"fallback\"".parse().unwrap(),
+                    "Action::\"unknown\"".parse().unwrap(),
+                    "Resource::\"unknown\"".parse().unwrap(),
+                    Context::empty(),
+                    None,
+                )
+                .unwrap()
+            });
+
+        let entities = Entities::empty();
+        let response: Response = self
+            .authorizer
+            .is_authorized(&request, &self.policies, &entities);
+
+        let reasons: Vec<String> = response
+            .diagnostics()
+            .reason()
+            .map(|id| id.to_string())
+            .collect();
+
+        CedarResult {
+            decision: response.decision(),
+            reasons,
+        }
+    }
+
+    /// Check if an operation is allowed by Cedar policies.
+    pub fn is_allowed(
+        &self,
+        session_id: &str,
+        operation: Operation,
+        subject: &str,
+        integrity: IntegLevel,
+        authority: AuthorityLevel,
+        confidentiality: ConfLevel,
+    ) -> bool {
+        self.evaluate(
+            session_id,
+            operation,
+            subject,
+            integrity,
+            authority,
+            confidentiality,
+        )
+        .decision
+            == Decision::Allow
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const BASIC_POLICY: &str = r#"
+permit(
+    principal,
+    action == Action::"read_files",
+    resource
+);
+
+forbid(
+    principal,
+    action == Action::"write_files",
+    resource
+) when {
+    context.integrity == "adversarial"
+};
+
+permit(
+    principal,
+    action == Action::"write_files",
+    resource
+) when {
+    context.integrity == "trusted"
+};
+"#;
+
+    #[test]
+    fn read_always_allowed() {
+        let eval = CedarEvaluator::new(BASIC_POLICY).unwrap();
+        assert!(eval.is_allowed(
+            "test-session",
+            Operation::ReadFiles,
+            "/workspace/main.rs",
+            IntegLevel::Adversarial,
+            AuthorityLevel::NoAuthority,
+            ConfLevel::Public,
+        ));
+    }
+
+    #[test]
+    fn write_denied_when_adversarial() {
+        let eval = CedarEvaluator::new(BASIC_POLICY).unwrap();
+        assert!(!eval.is_allowed(
+            "test-session",
+            Operation::WriteFiles,
+            "/workspace/output.rs",
+            IntegLevel::Adversarial,
+            AuthorityLevel::NoAuthority,
+            ConfLevel::Public,
+        ));
+    }
+
+    #[test]
+    fn write_allowed_when_trusted() {
+        let eval = CedarEvaluator::new(BASIC_POLICY).unwrap();
+        assert!(eval.is_allowed(
+            "test-session",
+            Operation::WriteFiles,
+            "/workspace/output.rs",
+            IntegLevel::Trusted,
+            AuthorityLevel::Directive,
+            ConfLevel::Internal,
+        ));
+    }
+
+    #[test]
+    fn invalid_policy_returns_error() {
+        let result = CedarEvaluator::new("this is not valid cedar");
+        assert!(result.is_err());
+    }
+}

--- a/crates/portcullis/src/lib.rs
+++ b/crates/portcullis/src/lib.rs
@@ -90,6 +90,8 @@ pub mod audit;
 pub mod audit_backend;
 mod budget;
 mod capability;
+#[cfg(feature = "cedar")]
+pub mod cedar_bridge;
 #[cfg(feature = "crypto")]
 pub mod certificate;
 mod command;


### PR DESCRIPTION
## Summary

Two layer 2 infrastructure components:

**Cedar policy bridge** (`portcullis/src/cedar_bridge.rs`, behind `cedar` feature):
- Integrates [cedar-policy 4.9.1](https://github.com/cedar-policy/cedar) (CNCF Sandbox)
- Maps nucleus Operations to Cedar principal/action/resource model
- IFC labels passed as Cedar context for policy evaluation
- Runs AFTER lattice check — additional human-readable policy layer
- 4 tests covering allow/deny/error paths

```cedar
forbid(principal is Agent, action == Action::"write_files", resource)
when { context.integrity == "adversarial" };
```

**Multi-agent wire protocol** (`portcullis-core/src/wire.rs`):
- `X-Nucleus-Label` header: `c=2;i=0;a=0;p=5;t=1711843200;ttl=3600`
- Encodes all 5 IFC dimensions in one HTTP header / gRPC metadata field
- Fail-closed decoding: unknown values → most restrictive defaults
- 9 tests covering roundtrips, partial decode, provenance bitmask

## Test plan

- [x] 4 Cedar bridge tests pass (with `--features cedar`)
- [x] 9 wire protocol tests pass
- [x] Full workspace compiles clean
- [x] Default feature set unchanged (cedar is optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)