### PR TITLE
feat: compartment transitions reset flow graph

### DIFF
--- a/crates/nucleus-claude-hook/src/main.rs
+++ b/crates/nucleus-claude-hook/src/main.rs
@@ -995,6 +995,25 @@ fn main() {
                     .unwrap_or_else(|| "none".to_string()),
                 new_comp,
             );
+
+            // COMPARTMENT FLOW RESET: On transition, clear flow observations
+            // so the new compartment starts with a clean flow graph.
+            //
+            // This is the key insight: research mode can read web content,
+            // but when you switch to draft mode, the web taint doesn't carry
+            // over — draft blocks web entirely, so the new compartment's
+            // flow graph has no adversarial nodes. You can write freely.
+            //
+            // The exposure accumulator (allowed_ops) is NOT cleared — it
+            // tracks what happened across the entire session for audit.
+            // Only the flow graph observations are reset.
+            if prev_compartment.is_some() {
+                eprintln!(
+                    "nucleus: flow graph reset for compartment transition ({} observations cleared)",
+                    session.flow_observations.len()
+                );
+                session.flow_observations.clear();
+            }
         }
         session.active_compartment = compartment.map(|c| c.to_string());
     }


### PR DESCRIPTION
## Summary

On compartment transition, the flow graph resets so the new compartment starts clean. This enables the research → draft → execute workflow:

```
RESEARCH MODE
  ✓ Read file       → allowed
  ✓ WebFetch        → allowed (session tainted)
  ✗ Write file      → BLOCKED (web taint)

research → draft (ESCALATION)
  Flow graph reset: web taint cleared

DRAFT MODE
  ✓ Write file      → ALLOWED (clean flow graph!)
  ✗ WebFetch        → BLOCKED (draft ceiling)

draft → execute (ESCALATION)

EXECUTE MODE
  ✓ Bash: cargo test → ALLOWED
```

The exposure accumulator (audit trail) is NOT cleared — only flow observations.

## Test plan
- [x] 26 hook tests pass
- [x] Manual 5-step compartment workflow verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)