### PR TITLE
fix: denied-parent GC tombstones evicted nodes (#480)

### DIFF
--- a/crates/portcullis/src/flow_graph.rs
+++ b/crates/portcullis/src/flow_graph.rs
@@ -158,11 +158,18 @@ impl FlowGraph {
         // Denied actions are inscribed for receipt/audit but cannot be parents
         if matches!(verdict, FlowVerdict::Deny(_)) {
             self.denied.insert(id);
-            // GC: cap the denied set to prevent unbounded growth
+            // GC: cap the denied set to prevent unbounded growth.
+            // SECURITY (#480): When evicting, tombstone the node in the nodes
+            // Vec so it can't be referenced as a parent. Without this, evicted
+            // denied nodes become referenceable, bypassing the denied-parent check.
             while self.denied.len() > MAX_DENIED_NODES {
-                // Remove oldest (lowest ID)
                 if let Some(&oldest) = self.denied.iter().next() {
                     self.denied.remove(&oldest);
+                    // Tombstone: remove the node so get(oldest) returns None,
+                    // which causes validate_parents to return ParentNotFound.
+                    if let Some(slot) = self.nodes.get_mut(oldest as usize) {
+                        *slot = None;
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary

**HIGH severity fix from skeptical audit.** When the denied set evicts nodes after 1024 entries, evicted nodes are now tombstoned (`nodes[id] = None`) so they can't be referenced as parents.

Without this, evicted denied nodes were still in the `nodes` Vec and could be used as parents, bypassing the denied-parent check.

Closes #480

🤖 Generated with [Claude Code](https://claude.com/claude-code)