### PR TITLE
feat: breakglass requires reason string (#507)

### DIFF
--- a/crates/nucleus-claude-hook/src/main.rs
+++ b/crates/nucleus-claude-hook/src/main.rs
@@ -1129,9 +1129,44 @@ fn main() {
                 "activated"
             };
 
+            // SECURITY (#507): Breakglass requires a reason string.
+            // Format: "breakglass:emergency fix for production outage"
+            if new_comp.is_breakglass() {
+                // Read the raw compartment file content to extract the reason
+                let reason = if !session.compartment_token.is_empty() {
+                    let keyed_name =
+                        keyed_compartment_name(&input.session_id, &session.compartment_token);
+                    let compartment_file = session_dir().join(format!("{keyed_name}.compartment"));
+                    std::fs::read_to_string(&compartment_file)
+                        .ok()
+                        .and_then(|content| {
+                            portcullis_core::compartment::BreakglassEntry::parse(content.trim())
+                        })
+                } else {
+                    None
+                };
+
+                match reason {
+                    Some(entry) => {
+                        eprintln!(
+                            "nucleus: BREAKGLASS entered — reason: '{}' (enhanced audit active)",
+                            entry.reason
+                        );
+                    }
+                    None => {
+                        let msg = "Blocked: breakglass requires a reason. \
+                                   Write 'breakglass:your reason here' to the compartment file.";
+                        eprintln!("nucleus: {msg}");
+                        let out = HookOutput::deny(msg);
+                        println!("{}", serde_json::to_string(&out).unwrap());
+                        session.high_water_mark += 1;
+                        save_session(&input.session_id, &session);
+                        std::process::exit(2);
+                    }
+                }
+            }
+
             // SECURITY (#457): Upward transitions (escalation) require human approval.
-            // The hook returns "ask" so Claude Code prompts the user.
-            // This prevents a compromised model from silently escalating.
             if is_escalation {
                 let msg = format!(
                     "nucleus: compartment escalation {} -> {} requires human approval",

--- a/crates/portcullis-core/src/compartment.rs
+++ b/crates/portcullis-core/src/compartment.rs
@@ -119,14 +119,48 @@ impl Compartment {
     }
 
     /// Parse from string (for env var / CLI).
+    ///
+    /// For breakglass, accepts `breakglass:reason text` format.
+    /// Plain `breakglass` without a reason is also accepted (reason
+    /// enforcement happens at the hook level).
     pub fn from_str_opt(s: &str) -> Option<Self> {
         match s {
             "research" => Some(Compartment::Research),
             "draft" => Some(Compartment::Draft),
             "execute" => Some(Compartment::Execute),
             "breakglass" => Some(Compartment::Breakglass),
+            s if s.starts_with("breakglass:") => Some(Compartment::Breakglass),
             _ => None,
         }
+    }
+}
+
+/// A breakglass entry with mandatory reason string.
+#[derive(Debug, Clone)]
+pub struct BreakglassEntry {
+    /// Operator-provided reason for entering breakglass.
+    pub reason: String,
+    /// Unix timestamp when breakglass was entered.
+    pub entered_at: u64,
+}
+
+impl BreakglassEntry {
+    /// Parse from the compartment file content.
+    ///
+    /// Format: `breakglass:reason text here`
+    /// Returns None if the reason is missing or empty.
+    pub fn parse(s: &str) -> Option<Self> {
+        let reason = s.strip_prefix("breakglass:")?.trim();
+        if reason.is_empty() {
+            return None;
+        }
+        Some(Self {
+            reason: reason.to_string(),
+            entered_at: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs(),
+        })
     }
 }
 
@@ -239,5 +273,27 @@ mod tests {
         ] {
             assert_eq!(Compartment::from_str_opt(&c.to_string()), Some(c));
         }
+    }
+
+    #[test]
+    fn breakglass_with_reason_parses() {
+        assert_eq!(
+            Compartment::from_str_opt("breakglass:emergency fix"),
+            Some(Compartment::Breakglass)
+        );
+    }
+
+    #[test]
+    fn breakglass_entry_requires_reason() {
+        assert!(BreakglassEntry::parse("breakglass:emergency fix").is_some());
+        assert!(BreakglassEntry::parse("breakglass:").is_none());
+        assert!(BreakglassEntry::parse("breakglass").is_none());
+        assert!(BreakglassEntry::parse("draft").is_none());
+    }
+
+    #[test]
+    fn breakglass_entry_extracts_reason() {
+        let entry = BreakglassEntry::parse("breakglass:production outage P1").unwrap();
+        assert_eq!(entry.reason, "production outage P1");
     }
 }


### PR DESCRIPTION
## Summary

Breakglass compartment now requires a reason string:

```bash
echo "breakglass:production outage P1" > $COMPARTMENT_PATH  # works
echo "breakglass" > $COMPARTMENT_PATH                        # denied
```

Without a reason: `"Blocked: breakglass requires a reason."`

- `BreakglassEntry` type parses `breakglass:reason` format
- Enhanced stderr logging on breakglass entry
- 3 new tests for reason parsing/validation

Closes #507

🤖 Generated with [Claude Code](https://claude.com/claude-code)