### PR TITLE
feat: update Lean proofs for 13-field CapabilityLattice (#479)

### DIFF
--- a/crates/portcullis-core/lean/PortcullisCoreBridge.lean
+++ b/crates/portcullis-core/lean/PortcullisCoreBridge.lean
@@ -221,7 +221,8 @@ private def latticeLE (a b : CapabilityLattice) : Prop :=
   a.glob_search ≤ b.glob_search ∧ a.grep_search ≤ b.grep_search ∧
   a.web_search ≤ b.web_search ∧ a.web_fetch ≤ b.web_fetch ∧
   a.git_commit ≤ b.git_commit ∧ a.git_push ≤ b.git_push ∧
-  a.create_pr ≤ b.create_pr ∧ a.manage_pods ≤ b.manage_pods
+  a.create_pr ≤ b.create_pr ∧ a.manage_pods ≤ b.manage_pods ∧
+  a.spawn_agent ≤ b.spawn_agent
 
 private def latticeInf (a b : CapabilityLattice) : CapabilityLattice := {
   read_files := a.read_files ⊓ b.read_files
@@ -236,6 +237,7 @@ private def latticeInf (a b : CapabilityLattice) : CapabilityLattice := {
   git_push := a.git_push ⊓ b.git_push
   create_pr := a.create_pr ⊓ b.create_pr
   manage_pods := a.manage_pods ⊓ b.manage_pods
+  spawn_agent := a.spawn_agent ⊓ b.spawn_agent
 }
 
 private def latticeSup (a b : CapabilityLattice) : CapabilityLattice := {
@@ -251,20 +253,23 @@ private def latticeSup (a b : CapabilityLattice) : CapabilityLattice := {
   git_push := a.git_push ⊔ b.git_push
   create_pr := a.create_pr ⊔ b.create_pr
   manage_pods := a.manage_pods ⊔ b.manage_pods
+  spawn_agent := a.spawn_agent ⊔ b.spawn_agent
 }
 
 private def latticeBot : CapabilityLattice := {
   read_files := ⊥, write_files := ⊥, edit_files := ⊥,
   run_bash := ⊥, glob_search := ⊥, grep_search := ⊥,
   web_search := ⊥, web_fetch := ⊥, git_commit := ⊥,
-  git_push := ⊥, create_pr := ⊥, manage_pods := ⊥
+  git_push := ⊥, create_pr := ⊥, manage_pods := ⊥,
+  spawn_agent := ⊥
 }
 
 private def latticeTop : CapabilityLattice := {
   read_files := ⊤, write_files := ⊤, edit_files := ⊤,
   run_bash := ⊤, glob_search := ⊤, grep_search := ⊤,
   web_search := ⊤, web_fetch := ⊤, git_commit := ⊤,
-  git_push := ⊤, create_pr := ⊤, manage_pods := ⊤
+  git_push := ⊤, create_pr := ⊤, manage_pods := ⊤,
+  spawn_agent := ⊤
 }
 
 private def latticeHImp (a b : CapabilityLattice) : CapabilityLattice := {
@@ -280,6 +285,7 @@ private def latticeHImp (a b : CapabilityLattice) : CapabilityLattice := {
   git_push := a.git_push ⇨ b.git_push
   create_pr := a.create_pr ⇨ b.create_pr
   manage_pods := a.manage_pods ⇨ b.manage_pods
+  spawn_agent := a.spawn_agent ⇨ b.spawn_agent
 }
 
 private def latticeCompl (a : CapabilityLattice) : CapabilityLattice := {
@@ -288,7 +294,8 @@ private def latticeCompl (a : CapabilityLattice) : CapabilityLattice := {
   glob_search := a.glob_searchᶜ, grep_search := a.grep_searchᶜ,
   web_search := a.web_searchᶜ, web_fetch := a.web_fetchᶜ,
   git_commit := a.git_commitᶜ, git_push := a.git_pushᶜ,
-  create_pr := a.create_prᶜ, manage_pods := a.manage_podsᶜ
+  create_pr := a.create_prᶜ, manage_pods := a.manage_podsᶜ,
+  spawn_agent := a.spawn_agentᶜ
 }
 
 -- ─── Full HeytingAlgebra instance (single definition) ────────────────

--- a/crates/portcullis-core/lean/generated/Funs.lean
+++ b/crates/portcullis-core/lean/generated/Funs.lean
@@ -505,6 +505,7 @@ def CapabilityLattice.meet
   let cl9 ← CapabilityLevel.meet self.git_push other.git_push
   let cl10 ← CapabilityLevel.meet self.create_pr other.create_pr
   let cl11 ← CapabilityLevel.meet self.manage_pods other.manage_pods
+  let cl12 ← CapabilityLevel.meet self.spawn_agent other.spawn_agent
   ok
     {
       read_files := cl,
@@ -518,7 +519,8 @@ def CapabilityLattice.meet
       git_commit := cl8,
       git_push := cl9,
       create_pr := cl10,
-      manage_pods := cl11
+      manage_pods := cl11,
+      spawn_agent := cl12
     }
 
 /-- [portcullis_core::{portcullis_core::CapabilityLattice}::join]:
@@ -540,6 +542,7 @@ def CapabilityLattice.join
   let cl9 ← CapabilityLevel.join self.git_push other.git_push
   let cl10 ← CapabilityLevel.join self.create_pr other.create_pr
   let cl11 ← CapabilityLevel.join self.manage_pods other.manage_pods
+  let cl12 ← CapabilityLevel.join self.spawn_agent other.spawn_agent
   ok
     {
       read_files := cl,
@@ -553,7 +556,8 @@ def CapabilityLattice.join
       git_commit := cl8,
       git_push := cl9,
       create_pr := cl10,
-      manage_pods := cl11
+      manage_pods := cl11,
+      spawn_agent := cl12
     }
 
 /-- [portcullis_core::{portcullis_core::CapabilityLattice}::leq]:
@@ -596,7 +600,11 @@ def CapabilityLattice.leq
                         CapabilityLevel.leq self.create_pr other.create_pr
                       if b10
                       then
-                        CapabilityLevel.leq self.manage_pods other.manage_pods
+                        let b11 ← CapabilityLevel.leq self.manage_pods other.manage_pods
+                        if b11
+                        then
+                          CapabilityLevel.leq self.spawn_agent other.spawn_agent
+                        else ok false
                       else ok false
                     else ok false
                   else ok false

--- a/crates/portcullis-core/lean/generated/Types.lean
+++ b/crates/portcullis-core/lean/generated/Types.lean
@@ -21,8 +21,9 @@ inductive CapabilityLevel where
 | Always : CapabilityLevel
 
 /-- [portcullis_core::CapabilityLattice]
-    Source: 'crates/portcullis-core/src/lib.rs', lines 98:0-111:1
-    Visibility: public -/
+    Source: 'crates/portcullis-core/src/lib.rs', lines 98:0-114:1
+    Visibility: public
+    Note: spawn_agent added manually (Aeneas re-extraction pending) -/
 structure CapabilityLattice where
   read_files : CapabilityLevel
   write_files : CapabilityLevel
@@ -36,5 +37,6 @@ structure CapabilityLattice where
   git_push : CapabilityLevel
   create_pr : CapabilityLevel
   manage_pods : CapabilityLevel
+  spawn_agent : CapabilityLevel
 
 end portcullis_core


### PR DESCRIPTION
## Summary

Closes the Lean-Rust type mismatch — all Lean verification artifacts now match the 13-field `CapabilityLattice` (with `spawn_agent`).

Updated files:
- `generated/Types.lean` — struct gains `spawn_agent : CapabilityLevel`
- `generated/Funs.lean` — `meet`, `join`, `leq` include `spawn_agent`
- `PortcullisCoreBridge.lean` — all 7 lattice operations (leq, inf, sup, bot, top, himp, compl)

Manual updates pending full Aeneas re-extraction. The Aeneas CI will verify on merge.

Closes #479

🤖 Generated with [Claude Code](https://claude.com/claude-code)