### PR TITLE
fix: receipt chain ID prevents cross-session injection (#492)

### DIFF
--- a/crates/nucleus-claude-hook/src/main.rs
+++ b/crates/nucleus-claude-hook/src/main.rs
@@ -1616,6 +1616,18 @@ fn main() {
                 .as_secs();
             let mut receipt = build_receipt(action_node, &ancestor_refs, flow_verdict, now);
             receipt.set_prev_hash(session.chain_head_hash);
+            // Bind receipt to this session (#492)
+            let chain_id = {
+                use sha2::{Digest, Sha256};
+                let mut h = Sha256::new();
+                h.update(b"nucleus-chain:");
+                h.update(input.session_id.as_bytes());
+                let hash = h.finalize();
+                let mut id = [0u8; 32];
+                id.copy_from_slice(&hash);
+                id
+            };
+            receipt.set_chain_id(chain_id);
             sign_receipt(&mut receipt, &signing_key);
             Some(receipt)
         })

--- a/crates/portcullis-core/src/receipt.rs
+++ b/crates/portcullis-core/src/receipt.rs
@@ -54,6 +54,10 @@ pub struct FlowReceipt {
     /// Included in the signed content — tampering with chain order
     /// invalidates the signature.
     pub(crate) prev_hash: [u8; 32],
+    /// Chain ID — binds the receipt to a specific session.
+    /// Prevents cross-session receipt injection (#492).
+    /// SHA-256 of the session identifier.
+    pub(crate) chain_id: [u8; 32],
 }
 
 /// Read-only accessors.
@@ -91,6 +95,14 @@ impl FlowReceipt {
     /// Set the previous receipt hash (called before signing).
     pub fn set_prev_hash(&mut self, hash: [u8; 32]) {
         self.prev_hash = hash;
+    }
+    /// Chain ID (session binding).
+    pub fn chain_id(&self) -> &[u8; 32] {
+        &self.chain_id
+    }
+    /// Set the chain ID (called before signing).
+    pub fn set_chain_id(&mut self, id: [u8; 32]) {
+        self.chain_id = id;
     }
 }
 
@@ -151,6 +163,7 @@ pub fn build_receipt(
         created_at: now,
         signature: [0; 64], // Unsigned
         prev_hash: [0; 32], // No chain link yet — set via set_prev_hash()
+        chain_id: [0; 32],  // No chain ID yet — set via set_chain_id()
     }
 }
 

--- a/crates/portcullis/src/receipt_sign.rs
+++ b/crates/portcullis/src/receipt_sign.rs
@@ -20,10 +20,13 @@ fn receipt_content_bytes(receipt: &FlowReceipt) -> Vec<u8> {
     let mut buf = Vec::with_capacity(256);
 
     // Version tag
-    buf.extend_from_slice(b"nucleus-receipt-v2\n");
+    buf.extend_from_slice(b"nucleus-receipt-v3\n");
+
+    // Chain ID — binds this receipt to a specific session (#492).
+    // Prevents cross-session receipt injection.
+    buf.extend_from_slice(receipt.chain_id());
 
     // Chain link — hash of the previous receipt.
-    // Included in signed content so chain order is tamper-evident.
     buf.extend_from_slice(receipt.prev_hash());
 
     // Action node


### PR DESCRIPTION
## Summary

**MEDIUM security fix.** Each receipt now includes `chain_id` (SHA-256 of session_id) in the signed content. Prevents cross-session receipt splicing.

Content bytes bumped to v3.

Closes #492

🤖 Generated with [Claude Code](https://claude.com/claude-code)