### PR TITLE
feat: --doctor diagnostic command (#555)

### DIFF
--- a/crates/nucleus-claude-hook/src/main.rs
+++ b/crates/nucleus-claude-hook/src/main.rs
@@ -1034,6 +1034,102 @@ fn run_status() {
 // --help
 // ---------------------------------------------------------------------------
 
+fn run_doctor() {
+    let mut ok = true;
+
+    // 1. Check settings.json
+    let home = dirs_next::home_dir();
+    let settings_path = home
+        .as_ref()
+        .map(|h| h.join(".claude").join("settings.json"));
+
+    if let Some(ref path) = settings_path {
+        if path.exists() {
+            if let Ok(content) = std::fs::read_to_string(path) {
+                if content.contains("nucleus-claude-hook") {
+                    println!(
+                        "\x1b[32m\u{2713}\x1b[0m Hook configured in {}",
+                        path.display()
+                    );
+                } else {
+                    println!(
+                        "\x1b[31m\u{2717}\x1b[0m Hook NOT configured in {} — run --setup",
+                        path.display()
+                    );
+                    ok = false;
+                }
+            }
+        } else {
+            println!(
+                "\x1b[31m\u{2717}\x1b[0m Settings file not found: {} — run --setup",
+                path.display()
+            );
+            ok = false;
+        }
+    }
+
+    // 2. Check session directory
+    let sess_dir = session_dir();
+    if sess_dir.exists() {
+        let count = std::fs::read_dir(&sess_dir)
+            .map(|entries| entries.count())
+            .unwrap_or(0);
+        println!(
+            "\x1b[32m\u{2713}\x1b[0m Session directory: {} ({count} files)",
+            sess_dir.display()
+        );
+    } else {
+        println!("\x1b[33m-\x1b[0m Session directory not yet created (first run pending)");
+    }
+
+    // 3. Check profile
+    let profile = default_profile_name();
+    if resolve_profile(&profile).is_some() {
+        println!("\x1b[32m\u{2713}\x1b[0m Active profile: {profile}");
+    } else {
+        println!(
+            "\x1b[31m\u{2717}\x1b[0m Unknown profile: {profile} — will fall back to safe_pr_fixer"
+        );
+        ok = false;
+    }
+
+    // 4. Check compartment env
+    if let Ok(comp) = std::env::var("NUCLEUS_COMPARTMENT") {
+        if portcullis_core::compartment::Compartment::from_str_opt(&comp).is_some() {
+            println!("\x1b[32m\u{2713}\x1b[0m Compartment: {comp}");
+        } else {
+            println!("\x1b[31m\u{2717}\x1b[0m Invalid NUCLEUS_COMPARTMENT: {comp}");
+            ok = false;
+        }
+    } else {
+        println!("\x1b[33m-\x1b[0m No compartment set (using profile defaults)");
+    }
+
+    // 5. Check receipt directory
+    let receipt_dir = sess_dir.join("receipts");
+    if receipt_dir.exists() {
+        let count = std::fs::read_dir(&receipt_dir)
+            .map(|entries| entries.count())
+            .unwrap_or(0);
+        println!("\x1b[32m\u{2713}\x1b[0m Receipt chains: {count} sessions");
+    } else {
+        println!("\x1b[33m-\x1b[0m No receipt chains yet");
+    }
+
+    // 6. Version
+    println!(
+        "\x1b[32m\u{2713}\x1b[0m Version: {}",
+        env!("CARGO_PKG_VERSION")
+    );
+
+    println!();
+    if ok {
+        println!("\x1b[32mAll checks passed.\x1b[0m");
+    } else {
+        println!("\x1b[31mSome checks failed.\x1b[0m Run --setup to configure.");
+    }
+}
+
 fn show_profile(name: &str) {
     let perms = match resolve_profile(name) {
         Some(p) => p,
@@ -1156,6 +1252,11 @@ fn main() {
         } else {
             println!("usage: nucleus-claude-hook --reset-session <session-id>");
         }
+        return;
+    }
+    // Doctor: diagnostic check (#555)
+    if args.iter().any(|a| a == "--doctor") {
+        run_doctor();
         return;
     }
     // Show what a profile allows (#556)


### PR DESCRIPTION
## Summary

Diagnostic tool for troubleshooting:

```
$ nucleus-claude-hook --doctor
✓ Hook configured in ~/.claude/settings.json
✓ Session directory: /tmp/nucleus-hook (3 files)
✓ Active profile: safe_pr_fixer
- No compartment set (using profile defaults)
✓ Receipt chains: 2 sessions
✓ Version: 1.0.0

All checks passed.
```

Checks: settings.json, session dir, profile, compartment, receipts, version.

Closes #555

🤖 Generated with [Claude Code](https://claude.com/claude-code)