### PR TITLE
fix: session state in ~/.local/share/nucleus/ (#552)

### DIFF
--- a/crates/nucleus-claude-hook/src/main.rs
+++ b/crates/nucleus-claude-hook/src/main.rs
@@ -174,7 +174,17 @@ enum SessionLoad {
 }
 
 fn session_dir() -> PathBuf {
-    let dir = std::env::temp_dir().join("nucleus-hook");
+    // Use XDG-compliant path: ~/.local/share/nucleus/sessions/ (#552)
+    // Falls back to /tmp/nucleus-hook if home dir unavailable.
+    // This survives reboots (unlike /tmp on some systems).
+    let dir = if let Some(home) = dirs_next::home_dir() {
+        home.join(".local")
+            .join("share")
+            .join("nucleus")
+            .join("sessions")
+    } else {
+        std::env::temp_dir().join("nucleus-hook")
+    };
     std::fs::create_dir_all(&dir).ok();
     // Restrict directory permissions: owner-only (0700)
     #[cfg(unix)]


### PR DESCRIPTION
Session state moved from `/tmp/nucleus-hook/` to `~/.local/share/nucleus/sessions/` (XDG-compliant). Survives reboots. Falls back to /tmp if needed.

Closes #552

🤖 Generated with [Claude Code](https://claude.com/claude-code)