### PR TITLE
feat: --init creates .nucleus/config.toml (#540)

### DIFF
--- a/crates/nucleus-claude-hook/src/main.rs
+++ b/crates/nucleus-claude-hook/src/main.rs
@@ -1374,6 +1374,54 @@ fn run_smoke_test() {
     }
 }
 
+fn run_init() {
+    let config_dir = std::path::Path::new(".nucleus");
+    let config_path = config_dir.join("config.toml");
+
+    if config_path.exists() {
+        println!("  \x1b[33m!\x1b[0m .nucleus/config.toml already exists");
+        println!("    Edit it directly or delete to regenerate.");
+        return;
+    }
+
+    std::fs::create_dir_all(config_dir).ok();
+
+    let config = r#"# Nucleus security configuration
+# See: nucleus-claude-hook --help
+
+# Permission profile (run --show-profile <name> to preview)
+profile = "safe_pr_fixer"
+
+# Compartment (research/draft/execute/breakglass)
+# compartment = "research"
+
+# Deny MCP tools without manifests in .nucleus/manifests/
+require_manifests = false
+
+# Block all tool calls on hook infrastructure errors
+fail_closed = false
+"#;
+
+    match std::fs::write(&config_path, config) {
+        Ok(()) => {
+            println!("  \x1b[32m\u{2713}\x1b[0m Created .nucleus/config.toml");
+            println!();
+            println!("  Next steps:");
+            println!("    1. Edit .nucleus/config.toml to customize");
+            println!("    2. Run nucleus-claude-hook --doctor to verify");
+            println!("    3. Restart Claude Code");
+        }
+        Err(e) => {
+            println!("  \x1b[31m\u{2717}\x1b[0m Failed to create config: {e}");
+        }
+    }
+
+    // Also create manifests dir
+    let manifests_dir = config_dir.join("manifests");
+    std::fs::create_dir_all(&manifests_dir).ok();
+    println!("  \x1b[32m\u{2713}\x1b[0m Created .nucleus/manifests/");
+}
+
 fn run_uninstall() {
     println!("Removing nucleus-claude-hook from Claude Code...\n");
 
@@ -1656,7 +1704,10 @@ fn main() {
         }
         return;
     }
-    // Doctor: diagnostic check (#555)
+    if args.iter().any(|a| a == "--init") {
+        run_init();
+        return;
+    }
     if args.iter().any(|a| a == "--uninstall") {
         run_uninstall();
         return;


### PR DESCRIPTION
Project setup in one command:

```
$ nucleus-claude-hook --init
✓ Created .nucleus/config.toml
✓ Created .nucleus/manifests/
```

Generates config with documented defaults. Closes #540.

🤖 Generated with [Claude Code](https://claude.com/claude-code)