### PR TITLE
feat: line-count ratchet for main.rs monolith (3177 → 1000)

### DIFF
--- a/.github/workflows/line-ratchet.yml
+++ b/.github/workflows/line-ratchet.yml
@@ -1,0 +1,72 @@
+name: Line Ratchet
+
+on:
+  pull_request:
+  merge_group:
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: write
+
+jobs:
+  check:
+    name: Check line ceiling
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Check line ratchet
+        run: scripts/check-line-ratchet.sh --strict
+
+  ratchet-down:
+    name: Ratchet ceiling down
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Ratchet down
+        run: |
+          set -euo pipefail
+
+          RATCHET_FILE=".line-ratchet.toml"
+          if [[ ! -f "$RATCHET_FILE" ]]; then
+            echo "No ratchet file — nothing to do"
+            exit 0
+          fi
+
+          CEILING=$(grep '^ceiling' "$RATCHET_FILE" | head -1 | sed 's/.*= *//')
+          TARGET=$(grep '^target' "$RATCHET_FILE" | head -1 | sed 's/.*= *//')
+          STEP=$(grep '^step' "$RATCHET_FILE" | head -1 | sed 's/.*= *//')
+          FILE_PATH=$(grep '^path' "$RATCHET_FILE" | head -1 | sed 's/.*= *"//' | sed 's/"//')
+
+          ACTUAL=$(wc -l < "$FILE_PATH" | tr -d ' ')
+
+          # New ceiling: max(actual, ceiling - step, target)
+          NEW_CEILING=$((CEILING - STEP))
+          if [[ "$ACTUAL" -lt "$NEW_CEILING" ]]; then
+            # File is already smaller than the ratcheted ceiling — snap to actual
+            NEW_CEILING=$ACTUAL
+          fi
+          if [[ "$NEW_CEILING" -lt "$TARGET" ]]; then
+            NEW_CEILING=$TARGET
+          fi
+
+          if [[ "$NEW_CEILING" -eq "$CEILING" ]]; then
+            echo "Ceiling unchanged at $CEILING (file: $ACTUAL lines)"
+            exit 0
+          fi
+
+          echo "Ratcheting: $CEILING -> $NEW_CEILING (file: $ACTUAL lines, target: $TARGET)"
+          sed -i "s/^ceiling = $CEILING/ceiling = $NEW_CEILING/" "$RATCHET_FILE"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add "$RATCHET_FILE"
+          git commit -m "chore: ratchet line ceiling $CEILING -> $NEW_CEILING [skip ci]"
+          git push

--- a/.line-ratchet.toml
+++ b/.line-ratchet.toml
@@ -1,0 +1,19 @@
+# Line-count ratchet — soft ceiling that decreases by 1 on every merge to main.
+#
+# Goal: drive nucleus-claude-hook/src/main.rs from its current size down to
+# 1000 lines by extracting modules. The ceiling is enforced in CI (warning,
+# not blocking) and automatically tightened by the post-merge workflow.
+#
+# To extract code: move logic into sub-modules under src/, re-export from
+# main.rs, and watch the ceiling drop naturally.
+
+[ratchet]
+# Current maximum allowed line count for the file.
+ceiling = 3177
+# The target we're ratcheting toward.
+target = 1000
+# How many lines to reduce per merge to main.
+step = 1
+
+[[files]]
+path = "crates/nucleus-claude-hook/src/main.rs"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,14 @@ repos:
         stages: [pre-push]
         priority: 30
 
+      # Pre-commit: line ratchet check (instant, no compilation)
+      - id: line-ratchet
+        name: line ratchet
+        entry: scripts/check-line-ratchet.sh --strict
+        language: script
+        pass_filenames: false
+        priority: 5
+
       # Pre-commit: dependency audit (no compilation, fast)
       - id: cargo-deny
         name: cargo deny

--- a/scripts/check-line-ratchet.sh
+++ b/scripts/check-line-ratchet.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Check that monitored files stay within their line-count ratchet ceiling.
+# Called by CI on PRs and by the post-merge ratchet workflow.
+#
+# Usage: scripts/check-line-ratchet.sh [--strict]
+#   --strict: exit 1 on violation (default: warn only)
+
+set -euo pipefail
+
+RATCHET_FILE=".line-ratchet.toml"
+STRICT=false
+
+if [[ "${1:-}" == "--strict" ]]; then
+    STRICT=true
+fi
+
+if [[ ! -f "$RATCHET_FILE" ]]; then
+    echo "No $RATCHET_FILE found — skipping line ratchet check"
+    exit 0
+fi
+
+# Parse the TOML (simple grep — no toml parser needed for this flat structure)
+CEILING=$(grep '^ceiling' "$RATCHET_FILE" | head -1 | sed 's/.*= *//')
+TARGET=$(grep '^target' "$RATCHET_FILE" | head -1 | sed 's/.*= *//')
+FILE_PATH=$(grep '^path' "$RATCHET_FILE" | head -1 | sed 's/.*= *"//' | sed 's/"//')
+
+if [[ -z "$CEILING" || -z "$FILE_PATH" ]]; then
+    echo "ERROR: Could not parse $RATCHET_FILE"
+    exit 1
+fi
+
+if [[ ! -f "$FILE_PATH" ]]; then
+    echo "ERROR: Monitored file not found: $FILE_PATH"
+    exit 1
+fi
+
+ACTUAL=$(wc -l < "$FILE_PATH" | tr -d ' ')
+
+echo "Line ratchet: $FILE_PATH"
+echo "  actual:  $ACTUAL lines"
+echo "  ceiling: $CEILING lines"
+echo "  target:  $TARGET lines"
+echo "  remaining: $((ACTUAL - TARGET)) lines to extract"
+
+if [[ "$ACTUAL" -gt "$CEILING" ]]; then
+    echo ""
+    echo "VIOLATION: $FILE_PATH has $ACTUAL lines (ceiling: $CEILING)"
+    echo "You added $((ACTUAL - CEILING)) lines above the ratchet ceiling."
+    echo "Extract code into sub-modules to stay under the limit."
+    if [[ "$STRICT" == "true" ]]; then
+        exit 1
+    fi
+elif [[ "$ACTUAL" -le "$TARGET" ]]; then
+    echo ""
+    echo "TARGET REACHED: $FILE_PATH is at or below $TARGET lines!"
+else
+    echo ""
+    echo "OK: $ACTUAL <= $CEILING"
+fi


### PR DESCRIPTION
## Summary

- Soft line ceiling on `nucleus-claude-hook/src/main.rs` that decreases by 1 on every merge to main
- Starting at **3177 lines**, targeting **1000 lines** — every merge tightens the constraint
- Three enforcement points: CI check on PRs, pre-commit hook (`prek`), post-merge auto-ratchet

## How it works

1. **`.line-ratchet.toml`** — tracks `ceiling = 3177`, `target = 1000`, `step = 1`
2. **PR check** — `scripts/check-line-ratchet.sh --strict` fails if file exceeds ceiling
3. **Pre-commit hook** — runs at priority 5 (before cargo fmt), instant
4. **Post-merge** — GitHub Actions workflow decrements ceiling by 1, commits `[skip ci]`
5. **Snap-down** — if you extract 200 lines into a module, the ceiling snaps to `actual` instead of decrementing by 1 (giving credit for big refactors)

## Test plan

- [x] Script tested locally: `OK: 3177 <= 3177`
- [x] Pre-commit hook passes via `prek`
- [x] `--strict` mode exits 1 on violation


🤖 Generated with [Claude Code](https://claude.com/claude-code)