### PR TITLE
fix: block session state directory from file reads (#487)

### DIFF
--- a/crates/portcullis/src/path.rs
+++ b/crates/portcullis/src/path.rs
@@ -267,6 +267,11 @@ impl PathLattice {
                 "**/.nucleus/policy.toml",
                 "**/.nucleus/trust/**",
                 "**/.nucleus/manifests/**",
+                // Nucleus session state — contains ephemeral Ed25519 signing keys (#487).
+                // A tool call like `cat ~/.local/share/nucleus/sessions/*.json`
+                // could exfiltrate the signing key, enabling receipt forgery.
+                "**/.local/share/nucleus/**",
+                "**/nucleus-hook/**",
             ]
             .iter()
             .map(|s| s.to_string())
@@ -461,6 +466,16 @@ mod tests {
         assert!(
             !lattice.can_access(Path::new(".nucleus/trust/author.pub")),
             ".nucleus/trust/ must be blocked"
+        );
+
+        // Nucleus session state — signing key exfiltration (#487)
+        assert!(
+            !lattice.can_access(Path::new(".local/share/nucleus/sessions/abc123.json")),
+            "session state files must be blocked (signing key)"
+        );
+        assert!(
+            !lattice.can_access(Path::new("nucleus-hook/session.json")),
+            "legacy /tmp/nucleus-hook/ must be blocked"
         );
 
         // Normal files still allowed


### PR DESCRIPTION
## Summary

- **Closes #487** — session state directory now blocked by the path lattice
- Added `**/.local/share/nucleus/**` and `**/nucleus-hook/**` to `block_sensitive()` blocked paths
- Prevents model-initiated reads like `cat ~/.local/share/nucleus/sessions/*.json` that could exfiltrate the Ed25519 signing key
- Added test verifying both current and legacy session paths are blocked

## Security Impact

Previously: a tool call could read session state JSON containing the signing key, enabling receipt forgery. Now: the path lattice blocks all reads from the session directory.

## Test plan

- [x] 2 new path assertions (current + legacy session dirs)
- [x] All 21 path tests pass, all 649 portcullis lib tests pass
- [x] clippy clean


🤖 Generated with [Claude Code](https://claude.com/claude-code)