### PR TITLE
feat: TOML loading for admissibility rules + serde on IFC level enums (#656)

### DIFF
--- a/.nucleus/policy.toml.example
+++ b/.nucleus/policy.toml.example
@@ -1,0 +1,74 @@
+# Nucleus Admissibility Policy
+#
+# Rules are evaluated in order (first match wins). If no rule matches,
+# the default verdict is "deny" (fail-closed).
+#
+# Each rule specifies:
+# - source_predicate: bounds on the data source's IFC label
+# - artifact_predicate: bounds on the artifact's propagated label
+# - sink_class: which sink the rule applies to
+# - verdict: "allow", "deny", or "requires_approval"
+#
+# Label predicate fields (all optional, omit = any value):
+# - min_integrity: "adversarial", "untrusted", "trusted"
+# - max_confidentiality: "public", "internal", "secret"
+# - min_authority: "no_authority", "informational", "suggestive", "directive"
+
+# ── Trusted code may be committed and pushed ─────────────────────────
+
+[[admissibility]]
+name = "trusted code may commit"
+sink_class = "git_commit"
+verdict = "allow"
+
+[admissibility.source_predicate]
+min_integrity = "trusted"
+
+[admissibility.artifact_predicate]
+min_integrity = "trusted"
+
+[[admissibility]]
+name = "trusted code may push"
+sink_class = "git_push"
+verdict = "allow"
+
+[admissibility.source_predicate]
+min_integrity = "trusted"
+
+[admissibility.artifact_predicate]
+min_integrity = "trusted"
+max_confidentiality = "internal"
+
+# ── Web content cannot reach privileged sinks without declassification ─
+
+[[admissibility]]
+name = "block web content to git push"
+sink_class = "git_push"
+verdict = "deny"
+
+[admissibility.source_predicate]
+
+[admissibility.artifact_predicate]
+
+# ── Workspace writes allowed for untrusted+ artifacts ────────────────
+
+[[admissibility]]
+name = "allow workspace writes"
+sink_class = "workspace_write"
+verdict = "allow"
+
+[admissibility.source_predicate]
+
+[admissibility.artifact_predicate]
+min_integrity = "untrusted"
+
+# ── HTTP egress requires approval ────────────────────────────────────
+
+[[admissibility]]
+name = "http egress requires approval"
+sink_class = "http_egress"
+verdict = "requires_approval"
+
+[admissibility.source_predicate]
+
+[admissibility.artifact_predicate]

--- a/crates/portcullis-core/src/lib.rs
+++ b/crates/portcullis-core/src/lib.rs
@@ -500,12 +500,14 @@ pub enum SinkClass {
     /// Execute a shell command (no detected network access).
     BashExec = 2,
     /// Outbound HTTP/HTTPS request (data exfiltration vector).
+    #[cfg_attr(feature = "serde", serde(rename = "http_egress"))]
     HTTPEgress = 3,
     /// Create a git commit (local mutation).
     GitCommit = 4,
     /// Push to a remote git repository (publish vector).
     GitPush = 5,
     /// Write a PR comment, review, or create a PR (publish vector).
+    #[cfg_attr(feature = "serde", serde(rename = "pr_comment_write"))]
     PRCommentWrite = 6,
     /// Send an email (publish vector).
     EmailSend = 7,
@@ -514,6 +516,7 @@ pub enum SinkClass {
     /// Spawn a child agent or subprocess (delegation vector).
     AgentSpawn = 9,
     /// Write via an MCP tool (external system mutation).
+    #[cfg_attr(feature = "serde", serde(rename = "mcp_write"))]
     MCPWrite = 10,
     /// Read a secret (API key, credential, env var).
     SecretRead = 11,
@@ -836,6 +839,8 @@ pub fn should_gate(current: &ExposureSet, op: Operation) -> bool {
 /// Combining data from different confidentiality levels produces
 /// a label at the HIGHEST level. Secret data stays secret.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[repr(u8)]
 pub enum ConfLevel {
     /// Publicly available data (web content, public repos, docs).
@@ -852,6 +857,8 @@ pub enum ConfLevel {
 /// Combining trusted data with untrusted data produces UNTRUSTED output.
 /// This is the Biba integrity model, inverted from BLP.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[repr(u8)]
 pub enum IntegLevel {
     /// Adversarially controlled (public issue bodies, web scraping results).
@@ -871,9 +878,12 @@ pub enum IntegLevel {
 /// prompt injection — web content cannot acquire instruction authority
 /// regardless of what the LLM decides to do with it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[repr(u8)]
 pub enum AuthorityLevel {
     /// Cannot instruct the agent in any way (web content, public issues).
+    #[cfg_attr(feature = "serde", serde(rename = "no_authority"))]
     NoAuthority = 0,
     /// Informational only — can provide context but not direct actions.
     Informational = 1,

--- a/crates/portcullis-core/src/policy_rules.rs
+++ b/crates/portcullis-core/src/policy_rules.rs
@@ -17,6 +17,8 @@ use crate::{AuthorityLevel, ConfLevel, IFCLabel, IntegLevel, SinkClass};
 /// Each field is an optional bound. `None` means "any value matches."
 /// All specified bounds must be satisfied for the predicate to match.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(default))]
 pub struct LabelPredicate {
     /// Minimum integrity required (label.integrity >= this).
     pub min_integrity: Option<IntegLevel>,
@@ -65,6 +67,8 @@ impl Default for LabelPredicate {
 
 /// The verdict of an admissibility rule.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 pub enum RuleVerdict {
     /// The flow is allowed.
     Allow,
@@ -76,6 +80,7 @@ pub enum RuleVerdict {
 
 /// A single admissibility rule: source predicate × artifact predicate × sink → verdict.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AdmissibilityRule {
     /// Human-readable name for this rule (for audit/diagnostics).
     pub name: String,
@@ -175,6 +180,95 @@ impl PolicyRuleSet {
     /// Get a reference to the rules (for inspection/serialization).
     pub fn rules(&self) -> &[AdmissibilityRule] {
         &self.rules
+    }
+}
+
+/// TOML file format for `.nucleus/policy.toml`.
+#[cfg(feature = "serde")]
+#[derive(Debug, serde::Deserialize)]
+struct PolicyToml {
+    #[serde(default)]
+    admissibility: Vec<AdmissibilityRule>,
+}
+
+#[cfg(feature = "serde")]
+impl PolicyRuleSet {
+    /// Load admissibility rules from `.nucleus/policy.toml` in the given directory.
+    ///
+    /// Returns `Ok(None)` if no `policy.toml` exists (no policy = no rules).
+    /// Returns `Err` if the file exists but is malformed or has contradictory rules.
+    pub fn load_from_dir(dir: &std::path::Path) -> Result<Option<Self>, PolicyLoadError> {
+        let policy_file = dir.join(".nucleus").join("policy.toml");
+        if !policy_file.exists() {
+            return Ok(None);
+        }
+        let content = std::fs::read_to_string(&policy_file)
+            .map_err(|e| PolicyLoadError::Io(policy_file.display().to_string(), e.to_string()))?;
+        Self::from_toml(&content).map(Some)
+    }
+
+    /// Parse admissibility rules from a TOML string.
+    pub fn from_toml(content: &str) -> Result<Self, PolicyLoadError> {
+        let parsed: PolicyToml =
+            toml::from_str(content).map_err(|e| PolicyLoadError::Parse(e.to_string()))?;
+        let mut rule_set = Self::new();
+        for rule in parsed.admissibility {
+            rule_set.push(rule);
+        }
+        rule_set.validate()?;
+        Ok(rule_set)
+    }
+
+    fn validate(&self) -> Result<(), PolicyLoadError> {
+        for i in 0..self.rules.len() {
+            for j in (i + 1)..self.rules.len() {
+                let a = &self.rules[i];
+                let b = &self.rules[j];
+                if a.sink_class == b.sink_class
+                    && a.source_predicate == b.source_predicate
+                    && a.artifact_predicate == b.artifact_predicate
+                    && a.verdict != b.verdict
+                {
+                    return Err(PolicyLoadError::Contradiction {
+                        rule_a: a.name.clone(),
+                        rule_b: b.name.clone(),
+                        sink: a.sink_class,
+                    });
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Errors from loading policy rules.
+#[cfg(feature = "serde")]
+#[derive(Debug)]
+pub enum PolicyLoadError {
+    Io(String, String),
+    Parse(String),
+    Contradiction {
+        rule_a: String,
+        rule_b: String,
+        sink: SinkClass,
+    },
+}
+
+#[cfg(feature = "serde")]
+impl std::fmt::Display for PolicyLoadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(path, err) => write!(f, "failed to read {path}: {err}"),
+            Self::Parse(err) => write!(f, "TOML parse error: {err}"),
+            Self::Contradiction {
+                rule_a,
+                rule_b,
+                sink,
+            } => write!(
+                f,
+                "contradictory rules for {sink:?}: '{rule_a}' and '{rule_b}'"
+            ),
+        }
     }
 }
 
@@ -447,5 +541,143 @@ mod tests {
         // No sources → vacuously true
         let result = rules.evaluate(&[], &trusted_label(), SinkClass::WorkspaceWrite);
         assert_eq!(result.verdict, RuleVerdict::Allow);
+    }
+
+    // ── TOML loading tests (#656) ────────────────────────────────────
+
+    #[cfg(feature = "serde")]
+    mod toml_tests {
+        use super::*;
+
+        #[test]
+        fn parse_toml_basic() {
+            let toml = r#"
+[[admissibility]]
+name = "trusted code may push"
+sink_class = "git_push"
+verdict = "allow"
+
+[admissibility.source_predicate]
+min_integrity = "trusted"
+
+[admissibility.artifact_predicate]
+min_integrity = "trusted"
+"#;
+            let rules = PolicyRuleSet::from_toml(toml).unwrap();
+            assert_eq!(rules.len(), 1);
+            assert_eq!(rules.rules()[0].name, "trusted code may push");
+            assert_eq!(rules.rules()[0].sink_class, SinkClass::GitPush);
+            assert_eq!(rules.rules()[0].verdict, RuleVerdict::Allow);
+        }
+
+        #[test]
+        fn parse_toml_multiple_rules() {
+            let toml = r#"
+[[admissibility]]
+name = "deny push"
+sink_class = "git_push"
+verdict = "deny"
+[admissibility.source_predicate]
+[admissibility.artifact_predicate]
+
+[[admissibility]]
+name = "allow writes"
+sink_class = "workspace_write"
+verdict = "allow"
+[admissibility.source_predicate]
+[admissibility.artifact_predicate]
+"#;
+            let rules = PolicyRuleSet::from_toml(toml).unwrap();
+            assert_eq!(rules.len(), 2);
+        }
+
+        #[test]
+        fn parse_toml_requires_approval() {
+            let toml = r#"
+[[admissibility]]
+name = "egress needs approval"
+sink_class = "http_egress"
+verdict = "requires_approval"
+[admissibility.source_predicate]
+[admissibility.artifact_predicate]
+"#;
+            let rules = PolicyRuleSet::from_toml(toml).unwrap();
+            assert_eq!(rules.rules()[0].verdict, RuleVerdict::RequiresApproval);
+        }
+
+        #[test]
+        fn parse_toml_empty() {
+            let rules = PolicyRuleSet::from_toml("").unwrap();
+            assert!(rules.is_empty());
+        }
+
+        #[test]
+        fn parse_toml_invalid_rejects() {
+            assert!(PolicyRuleSet::from_toml("not valid [[[ toml").is_err());
+        }
+
+        #[test]
+        fn parse_toml_contradiction_detected() {
+            let toml = r#"
+[[admissibility]]
+name = "allow push"
+sink_class = "git_push"
+verdict = "allow"
+[admissibility.source_predicate]
+[admissibility.artifact_predicate]
+
+[[admissibility]]
+name = "deny push"
+sink_class = "git_push"
+verdict = "deny"
+[admissibility.source_predicate]
+[admissibility.artifact_predicate]
+"#;
+            let err = PolicyRuleSet::from_toml(toml).unwrap_err();
+            assert!(err.to_string().contains("contradictory"));
+        }
+
+        #[test]
+        fn load_missing_dir_returns_none() {
+            let dir = std::env::temp_dir().join("nucleus-test-no-policy");
+            std::fs::create_dir_all(&dir).ok();
+            assert!(PolicyRuleSet::load_from_dir(&dir).unwrap().is_none());
+        }
+
+        #[test]
+        fn toml_predicate_fields() {
+            let toml = r#"
+[[admissibility]]
+name = "full predicate"
+sink_class = "bash_exec"
+verdict = "deny"
+
+[admissibility.source_predicate]
+min_integrity = "untrusted"
+max_confidentiality = "internal"
+min_authority = "informational"
+
+[admissibility.artifact_predicate]
+min_integrity = "trusted"
+"#;
+            let rules = PolicyRuleSet::from_toml(toml).unwrap();
+            let rule = &rules.rules()[0];
+            assert_eq!(
+                rule.source_predicate.min_integrity,
+                Some(IntegLevel::Untrusted)
+            );
+            assert_eq!(
+                rule.source_predicate.max_confidentiality,
+                Some(ConfLevel::Internal)
+            );
+            assert_eq!(
+                rule.source_predicate.min_authority,
+                Some(AuthorityLevel::Informational)
+            );
+            assert_eq!(
+                rule.artifact_predicate.min_integrity,
+                Some(IntegLevel::Trusted)
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

- **PolicyRuleSet::load_from_dir()** and **from_toml()**: load `[[admissibility]]` rules from `.nucleus/policy.toml`
- **Contradiction validation**: rejects rules with same predicates but different verdicts
- **Serde derives** on ConfLevel, IntegLevel, AuthorityLevel (feature-gated behind `serde`)
- **SinkClass serde fix**: HTTPEgress → `http_egress` (was `h_t_t_p_egress`)
- **Example policy.toml** with real-world rules

## Test plan

- [x] `cargo test -p portcullis-core --features serde -- policy_rules` — 21 tests pass (8 new TOML tests)
- [x] `cargo clippy -p portcullis-core --features serde -- -D warnings` — clean
- [x] `cargo clippy -p portcullis-core -- -D warnings` — clean (without serde)
- [x] All pre-commit and pre-push hooks pass

Closes #656

🤖 Generated with [Claude Code](https://claude.com/claude-code)