### PR TITLE
feat: add exit_codes module with typed ExitCode enum (#557)

### DIFF
--- a/crates/nucleus-claude-hook/src/build.rs
+++ b/crates/nucleus-claude-hook/src/build.rs
@@ -37,14 +37,14 @@ pub fn run_build(args: &[String]) {
                 Ok(j) => j,
                 Err(e) => {
                     eprintln!("error: failed to serialize artifact: {e}");
-                    std::process::exit(1);
+                    crate::exit_codes::ExitCode::Error.exit();
                 }
             };
             match output_path {
                 Some(path) => {
                     if let Err(e) = std::fs::write(path, &json) {
                         eprintln!("error: failed to write {path}: {e}");
-                        std::process::exit(1);
+                        crate::exit_codes::ExitCode::Error.exit();
                     }
                     eprintln!("Built: {} -> {path}", manifest.digest);
                 }
@@ -56,7 +56,7 @@ pub fn run_build(args: &[String]) {
         }
         Err(e) => {
             eprintln!("error: {e}");
-            std::process::exit(1);
+            crate::exit_codes::ExitCode::Error.exit();
         }
     }
 }

--- a/crates/nucleus-claude-hook/src/cli.rs
+++ b/crates/nucleus-claude-hook/src/cli.rs
@@ -42,6 +42,8 @@ pub enum CliCommand {
     Receipts { session_id: Option<String> },
     /// `--completions <shell>` — print shell completion script.
     Completions { shell: String },
+    /// `--exit-codes` — print exit code documentation.
+    ExitCodes,
 }
 
 /// CLI parsing error.
@@ -137,6 +139,7 @@ pub fn parse_args(args: &[String]) -> Result<CliCommand, CliError> {
                 shell: shell.clone(),
             })
         }
+        "--exit-codes" => Ok(CliCommand::ExitCodes),
         other if other.starts_with('-') => Err(CliError::UnknownFlag(other.to_string())),
         // No recognised flag — fall through to stdin hook mode.
         _ => Ok(CliCommand::Hook),
@@ -306,6 +309,14 @@ mod tests {
         assert_eq!(
             parse_args(&args(&["--build", ".", "-o", "out.json"])).unwrap(),
             CliCommand::Build
+        );
+    }
+
+    #[test]
+    fn exit_codes_flag() {
+        assert_eq!(
+            parse_args(&args(&["--exit-codes"])).unwrap(),
+            CliCommand::ExitCodes
         );
     }
 

--- a/crates/nucleus-claude-hook/src/completions.rs
+++ b/crates/nucleus-claude-hook/src/completions.rs
@@ -20,6 +20,7 @@ const FLAGS: &[&str] = &[
     "--show-profile",
     "--receipts",
     "--completions",
+    "--exit-codes",
 ];
 
 /// Generate a shell completion script for the given shell name.
@@ -145,6 +146,7 @@ mod tests {
             "--show-profile",
             "--receipts",
             "--completions",
+            "--exit-codes",
         ];
         for flag in expected {
             assert!(FLAGS.contains(&flag), "missing flag in completions: {flag}");

--- a/crates/nucleus-claude-hook/src/exit_codes.rs
+++ b/crates/nucleus-claude-hook/src/exit_codes.rs
@@ -1,0 +1,152 @@
+//! Well-defined exit code contract for `nucleus-claude-hook`.
+//!
+//! # Exit Code Protocol
+//!
+//! The hook communicates its decision to Claude Code via both JSON on stdout
+//! **and** its process exit code.  The exit code is the authoritative signal:
+//!
+//! | Code | Name    | Meaning                                              |
+//! |------|---------|------------------------------------------------------|
+//! |  0   | Allow   | Operation permitted. JSON on stdout with decision.    |
+//! |  1   | Error   | Internal/infrastructure error — no valid decision.    |
+//! |  2   | Deny    | Operation blocked. JSON on stdout with deny reason.   |
+//!
+//! ## Distinguishing "hook didn't run" from "hook allowed"
+//!
+//! - **Hook not installed / crashed before output**: no JSON on stdout, exit
+//!   code depends on OS (likely signal-killed → non-zero, or 0 if the shell
+//!   ate it).  Claude Code falls through to its default behavior.
+//! - **Hook ran, operation allowed** (exit 0): valid JSON on stdout with
+//!   `permissionDecision: "allow"`.
+//! - **Hook ran, operation denied** (exit 2): valid JSON on stdout with
+//!   `permissionDecision: "deny"` and a `permissionDecisionReason`.
+//! - **Hook ran, but hit an internal error** (exit 1): stderr has a diagnostic
+//!   message.  No valid decision JSON on stdout (or a deny if `NUCLEUS_FAIL_CLOSED=1`).
+//!
+//! ## `NUCLEUS_FAIL_CLOSED=1`
+//!
+//! When set, infrastructure errors (no stdin, bad JSON, etc.) are promoted
+//! from exit 1 to exit 2 with a deny JSON, ensuring the tool call is blocked.
+
+use portcullis::kernel::Verdict;
+
+/// Process exit codes with well-defined semantics.
+///
+/// These values match the Claude Code hook protocol:
+/// - exit 0 → allow / passthrough
+/// - exit 2 → deny (block the tool call)
+///
+/// Exit 1 is reserved for internal errors where no policy decision was made.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(i32)]
+pub enum ExitCode {
+    /// Operation permitted — JSON on stdout contains an allow decision.
+    Allow = 0,
+    /// Internal error — no valid policy decision was made.
+    ///
+    /// Examples: CLI parse error, stdin read failure (non-fail-closed mode),
+    /// JSON deserialization error.
+    Error = 1,
+    /// Operation denied — JSON on stdout contains a deny with reason.
+    ///
+    /// This covers both policy denials (capability violations, flow rules,
+    /// tamper detection) and infrastructure failures when `NUCLEUS_FAIL_CLOSED=1`.
+    Deny = 2,
+}
+
+impl ExitCode {
+    /// Map a kernel [`Verdict`] to the corresponding exit code.
+    ///
+    /// - `Verdict::Allow` → `ExitCode::Allow`
+    /// - `Verdict::RequiresApproval` → `ExitCode::Allow` (the "ask" decision
+    ///   is communicated via JSON; the exit code is 0 so Claude Code doesn't
+    ///   block outright)
+    /// - `Verdict::Deny(_)` → `ExitCode::Deny`
+    pub fn from_verdict(verdict: &Verdict) -> Self {
+        match verdict {
+            Verdict::Allow => Self::Allow,
+            Verdict::RequiresApproval => Self::Allow,
+            Verdict::Deny(_) => Self::Deny,
+        }
+    }
+
+    /// Terminate the process with this exit code.
+    ///
+    /// This is the single point where `std::process::exit()` should be called
+    /// from hook logic, making exit behavior auditable and grep-friendly.
+    pub fn exit(self) -> ! {
+        std::process::exit(self as i32)
+    }
+
+    /// The raw integer value (used by tests and diagnostics).
+    #[cfg(test)]
+    pub fn code(self) -> i32 {
+        self as i32
+    }
+
+    /// Print the exit code documentation table to stdout.
+    ///
+    /// Intended for `--exit-codes` flag so integration developers can
+    /// programmatically discover the contract.
+    pub fn print_docs() {
+        println!("nucleus-claude-hook exit codes:");
+        println!();
+        println!("  EXIT CODE  NAME     MEANING");
+        println!("  ---------  -------  ------------------------------------------------");
+        println!("  0          Allow    Operation permitted (JSON on stdout)");
+        println!("  1          Error    Internal error, no valid decision made");
+        println!("  2          Deny     Operation blocked (JSON on stdout with reason)");
+        println!();
+        println!("When NUCLEUS_FAIL_CLOSED=1, infrastructure errors use exit 2 (deny)");
+        println!("instead of exit 1, ensuring tool calls are blocked on any failure.");
+        println!();
+        println!("Integration notes:");
+        println!("  - Exit 0 with no stdout JSON = hook passthrough (Claude Code defaults)");
+        println!("  - Exit 0 with JSON           = explicit allow decision");
+        println!("  - Exit 2 with JSON           = explicit deny with reason");
+        println!("  - Exit 1                     = hook error (check stderr)");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use portcullis::kernel::{DenyReason, Verdict};
+
+    #[test]
+    fn allow_verdict_maps_to_zero() {
+        assert_eq!(ExitCode::from_verdict(&Verdict::Allow), ExitCode::Allow);
+        assert_eq!(ExitCode::Allow.code(), 0);
+    }
+
+    #[test]
+    fn requires_approval_maps_to_zero() {
+        assert_eq!(
+            ExitCode::from_verdict(&Verdict::RequiresApproval),
+            ExitCode::Allow
+        );
+    }
+
+    #[test]
+    fn deny_verdict_maps_to_two() {
+        let verdict = Verdict::Deny(DenyReason::InsufficientCapability);
+        assert_eq!(ExitCode::from_verdict(&verdict), ExitCode::Deny);
+        assert_eq!(ExitCode::Deny.code(), 2);
+    }
+
+    #[test]
+    fn error_code_is_one() {
+        assert_eq!(ExitCode::Error.code(), 1);
+    }
+
+    #[test]
+    fn repr_values_match_protocol() {
+        assert_eq!(ExitCode::Allow as i32, 0);
+        assert_eq!(ExitCode::Error as i32, 1);
+        assert_eq!(ExitCode::Deny as i32, 2);
+    }
+}

--- a/crates/nucleus-claude-hook/src/main.rs
+++ b/crates/nucleus-claude-hook/src/main.rs
@@ -22,6 +22,7 @@ mod build;
 mod classify;
 mod cli;
 mod completions;
+mod exit_codes;
 mod init;
 mod protocol;
 mod session;
@@ -810,7 +811,7 @@ fn run_smoke_test() {
             "\x1b[31m{passed}/{} tests passed, {failed} failed.\x1b[0m",
             passed + failed
         );
-        std::process::exit(1);
+        exit_codes::ExitCode::Error.exit();
     }
 }
 
@@ -1032,6 +1033,7 @@ fn run_help() {
     println!("  nucleus-claude-hook --gc          Remove stale session files (>24h)");
     println!("  nucleus-claude-hook --help        This message");
     println!("  nucleus-claude-hook --version     Show version");
+    println!("  nucleus-claude-hook --exit-codes  Print exit code protocol documentation");
     println!();
     println!("PROFILES (set NUCLEUS_PROFILE env var):");
     for (name, desc) in PROFILE_DESCRIPTIONS {
@@ -1172,14 +1174,18 @@ fn main() {
                         "nucleus-claude-hook: unsupported shell '{shell}'. \
                          Supported: bash, zsh, fish"
                     );
-                    std::process::exit(1);
+                    exit_codes::ExitCode::Error.exit();
                 }
             }
             return;
         }
+        Ok(cli::CliCommand::ExitCodes) => {
+            exit_codes::ExitCode::print_docs();
+            return;
+        }
         Err(e) => {
             eprintln!("nucleus-claude-hook: {e}");
-            std::process::exit(1);
+            exit_codes::ExitCode::Error.exit();
         }
         Ok(cli::CliCommand::Hook) => {} // fall through to stdin processing
     }
@@ -1208,7 +1214,7 @@ fn main() {
                     "nucleus: no hook input — failing closed (NUCLEUS_FAIL_CLOSED=1)",
                 );
                 println!("{}", serde_json::to_string(&out).unwrap());
-                std::process::exit(2);
+                exit_codes::ExitCode::Deny.exit();
             }
             // Non-blocking: exit 0 with no JSON → Claude Code asks user normally
             return;
@@ -1222,7 +1228,7 @@ fn main() {
             if fail_closed {
                 let out = HookOutput::deny(format!("nucleus: parse error — failing closed: {e}"));
                 println!("{}", serde_json::to_string(&out).unwrap());
-                std::process::exit(2);
+                exit_codes::ExitCode::Deny.exit();
             }
             // Non-blocking: exit 0 with no JSON → Claude Code asks user normally
             return;
@@ -1470,7 +1476,7 @@ fn main() {
                 input.tool_name, reason
             );
             println!("{}", serde_json::to_string(&out).unwrap());
-            std::process::exit(2);
+            exit_codes::ExitCode::Deny.exit();
         }
 
         // SECURITY (#512): Default-deny unmanifested MCP tools.
@@ -1492,7 +1498,7 @@ fn main() {
                 input.tool_name
             );
             println!("{}", serde_json::to_string(&out).unwrap());
-            std::process::exit(2);
+            exit_codes::ExitCode::Deny.exit();
         }
 
         // SECURITY (#462): Check if the tool is allowed in the current compartment.
@@ -1519,7 +1525,7 @@ fn main() {
                         input.tool_name
                     );
                     println!("{}", serde_json::to_string(&out).unwrap());
-                    std::process::exit(2);
+                    exit_codes::ExitCode::Deny.exit();
                 }
             }
         }
@@ -1548,7 +1554,7 @@ fn main() {
                     input.tool_name, count, MANIFEST_VIOLATION_REVOKE_THRESHOLD
                 );
                 println!("{}", serde_json::to_string(&out).unwrap());
-                std::process::exit(2);
+                exit_codes::ExitCode::Deny.exit();
             }
         }
     }
@@ -1576,7 +1582,7 @@ fn main() {
             eprintln!("{msg}");
             let out = HookOutput::deny(&msg);
             println!("{}", serde_json::to_string(&out).unwrap());
-            std::process::exit(2);
+            exit_codes::ExitCode::Deny.exit();
         }
     };
     if session.profile.is_empty() {
@@ -1653,7 +1659,7 @@ fn main() {
                         println!("{}", serde_json::to_string(&out).unwrap());
                         session.high_water_mark += 1;
                         save_session(&input.session_id, &session);
-                        std::process::exit(2);
+                        exit_codes::ExitCode::Deny.exit();
                     }
                 }
             }
@@ -2178,8 +2184,9 @@ fn main() {
 
     // Exit non-zero on deny to block the tool call via exit code.
     // Claude Code blocks on exit 2 regardless of JSON output.
-    if matches!(decision.verdict, Verdict::Deny(_)) {
-        std::process::exit(2);
+    let code = exit_codes::ExitCode::from_verdict(&decision.verdict);
+    if code != exit_codes::ExitCode::Allow {
+        code.exit();
     }
 }
 

--- a/crates/nucleus-claude-hook/src/status.rs
+++ b/crates/nucleus-claude-hook/src/status.rs
@@ -262,7 +262,7 @@ pub(crate) fn run_status(json: bool) {
         // Machine-parseable JSON on stdout.
         let out = serde_json::to_string_pretty(&status).unwrap_or_else(|e| {
             eprintln!("nucleus: failed to serialize status: {e}");
-            std::process::exit(1);
+            crate::exit_codes::ExitCode::Error.exit();
         });
         println!("{out}");
     } else {


### PR DESCRIPTION
## Summary
- Adds `exit_codes.rs` module with a typed `ExitCode` enum (`Allow=0`, `Error=1`, `Deny=2`) that documents the hook exit code protocol
- Replaces all 15 raw `std::process::exit()` calls across `main.rs`, `build.rs`, and `status.rs` with the structured enum
- Adds `--exit-codes` CLI flag so integration developers can programmatically discover the exit code contract
- Includes `ExitCode::from_verdict()` to map kernel verdicts to exit codes

Closes #557. Replaces #700 (closed due to conflicts).

## Test plan
- [x] All 98 existing tests pass
- [x] Clippy clean with `-D warnings`
- [x] Line ratchet passes (2634 < 2691 ceiling)
- [x] New unit tests for `ExitCode` repr values, verdict mapping, and `--exit-codes` CLI parsing
- [x] No remaining `std::process::exit()` calls outside `exit_codes.rs`
- [x] Shell completions updated with `--exit-codes` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)