### PR TITLE
feat: add DerivationClass enum — 6th dimension of IFC label

### DIFF
--- a/crates/portcullis-core/examples/flow_kernel_demo.rs
+++ b/crates/portcullis-core/examples/flow_kernel_demo.rs
@@ -60,6 +60,7 @@ fn main() {
                 ttl_secs: 0,
             },
             authority: AuthorityLevel::Directive,
+            derivation: portcullis_core::DerivationClass::Deterministic,
         },
     );
     print_node("Private file", &private_file);

--- a/crates/portcullis-core/src/declassify.rs
+++ b/crates/portcullis-core/src/declassify.rs
@@ -268,6 +268,19 @@ mod kani_declassify_proofs {
         }
     }
 
+    /// Generate a symbolic DerivationClass.
+    fn any_derivation() -> crate::DerivationClass {
+        let v: u8 = kani::any();
+        kani::assume(v <= 4);
+        match v {
+            0 => crate::DerivationClass::Deterministic,
+            1 => crate::DerivationClass::AIDerived,
+            2 => crate::DerivationClass::Mixed,
+            3 => crate::DerivationClass::HumanPromoted,
+            _ => crate::DerivationClass::OpaqueExternal,
+        }
+    }
+
     /// Generate a symbolic IFCLabel.
     fn any_label() -> IFCLabel {
         IFCLabel {
@@ -279,6 +292,7 @@ mod kani_declassify_proofs {
                 ttl_secs: kani::any(),
             },
             authority: any_auth(),
+            derivation: any_derivation(),
         }
     }
 
@@ -364,6 +378,7 @@ mod tests {
                 ttl_secs: 0,
             },
             authority: AuthorityLevel::NoAuthority,
+            derivation: crate::DerivationClass::OpaqueExternal,
         }
     }
 
@@ -377,6 +392,7 @@ mod tests {
                 ttl_secs: 0,
             },
             authority: AuthorityLevel::Directive,
+            derivation: crate::DerivationClass::Deterministic,
         }
     }
 

--- a/crates/portcullis-core/src/flow.rs
+++ b/crates/portcullis-core/src/flow.rs
@@ -10,7 +10,10 @@
 //! **Current status**: types + pure functions + tests. Not yet wired into
 //! `Kernel::decide()` — integration is Phase 3 of the Flow Kernel plan.
 
-use crate::{AuthorityLevel, ConfLevel, IFCLabel, IntegLevel, Operation, ProvenanceSet, SinkClass};
+use crate::{
+    AuthorityLevel, ConfLevel, DerivationClass, IFCLabel, IntegLevel, Operation, ProvenanceSet,
+    SinkClass,
+};
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Node types
@@ -70,6 +73,7 @@ pub fn intrinsic_label(kind: NodeKind, now: u64) -> IFCLabel {
                 ttl_secs: 0,
             },
             authority: AuthorityLevel::Informational,
+            derivation: DerivationClass::AIDerived,
         },
         NodeKind::FileRead => IFCLabel {
             confidentiality: ConfLevel::Internal,
@@ -80,6 +84,7 @@ pub fn intrinsic_label(kind: NodeKind, now: u64) -> IFCLabel {
                 ttl_secs: 0,
             },
             authority: AuthorityLevel::Directive,
+            derivation: DerivationClass::Deterministic,
         },
         NodeKind::EnvVar => IFCLabel {
             confidentiality: ConfLevel::Secret,
@@ -90,6 +95,7 @@ pub fn intrinsic_label(kind: NodeKind, now: u64) -> IFCLabel {
                 ttl_secs: 0,
             },
             authority: AuthorityLevel::NoAuthority,
+            derivation: DerivationClass::Deterministic,
         },
         NodeKind::ModelPlan => IFCLabel {
             confidentiality: ConfLevel::Internal,
@@ -100,6 +106,7 @@ pub fn intrinsic_label(kind: NodeKind, now: u64) -> IFCLabel {
                 ttl_secs: 0,
             },
             authority: AuthorityLevel::Directive,
+            derivation: DerivationClass::AIDerived,
         },
         NodeKind::Secret => IFCLabel::secret(now),
         NodeKind::OutboundAction => IFCLabel {
@@ -111,6 +118,7 @@ pub fn intrinsic_label(kind: NodeKind, now: u64) -> IFCLabel {
                 ttl_secs: 0,
             },
             authority: AuthorityLevel::Directive,
+            derivation: DerivationClass::Deterministic,
         },
         // Summarization inherits from parents via propagation.
         // The intrinsic label is neutral — the join with parent labels
@@ -124,6 +132,7 @@ pub fn intrinsic_label(kind: NodeKind, now: u64) -> IFCLabel {
                 ttl_secs: 0,
             },
             authority: AuthorityLevel::Directive,
+            derivation: DerivationClass::AIDerived,
         },
         // Retry has the same neutral intrinsic as Summarization.
         // The taint comes from parents (the original attempt's data).
@@ -136,6 +145,7 @@ pub fn intrinsic_label(kind: NodeKind, now: u64) -> IFCLabel {
                 ttl_secs: 0,
             },
             authority: AuthorityLevel::Directive,
+            derivation: DerivationClass::Deterministic,
         },
     }
 }
@@ -169,7 +179,7 @@ pub struct FlowNode {
 
 /// Propagate labels through the DAG: join all parent labels with intrinsic.
 ///
-/// This is Denning's fundamental lemma generalized to our 5-dimensional
+/// This is Denning's fundamental lemma generalized to our 6-dimensional
 /// product lattice. The result is always ≥ each input (monotone).
 pub fn propagate_label(parent_labels: &[IFCLabel], intrinsic: IFCLabel) -> IFCLabel {
     let mut result = intrinsic;
@@ -404,6 +414,19 @@ mod kani_proofs {
         }
     }
 
+    /// Generate a symbolic DerivationClass.
+    fn any_derivation() -> crate::DerivationClass {
+        let v: u8 = kani::any();
+        kani::assume(v <= 4);
+        match v {
+            0 => crate::DerivationClass::Deterministic,
+            1 => crate::DerivationClass::AIDerived,
+            2 => crate::DerivationClass::Mixed,
+            3 => crate::DerivationClass::HumanPromoted,
+            _ => crate::DerivationClass::OpaqueExternal,
+        }
+    }
+
     /// Generate a symbolic Operation.
     fn any_operation() -> Operation {
         let v: u8 = kani::any();
@@ -422,6 +445,7 @@ mod kani_proofs {
                 ttl_secs: kani::any(),
             },
             authority: any_auth(),
+            derivation: any_derivation(),
         }
     }
 
@@ -616,6 +640,7 @@ mod kani_proofs {
                 ttl_secs: 0,
             },
             authority: AuthorityLevel::Directive,
+            derivation: DerivationClass::Deterministic,
         };
 
         let node = FlowNode {
@@ -780,6 +805,7 @@ mod tests {
                 ttl_secs: 0,
             },
             authority: AuthorityLevel::Directive,
+            derivation: DerivationClass::Deterministic,
         };
 
         // Step 3: Agent's plan node combines both (propagation)
@@ -912,6 +938,7 @@ mod tests {
                 ttl_secs: 0,
             },
             authority: AuthorityLevel::NoAuthority,
+            derivation: DerivationClass::Deterministic,
         };
         let node = make_node_with_sink(
             NodeKind::OutboundAction,
@@ -935,6 +962,7 @@ mod tests {
                 ttl_secs: 0,
             },
             authority: AuthorityLevel::Directive,
+            derivation: DerivationClass::Deterministic,
         };
         let node = make_node_with_sink(
             NodeKind::OutboundAction,
@@ -975,6 +1003,7 @@ mod tests {
                 ttl_secs: 0,
             },
             authority: AuthorityLevel::Directive,
+            derivation: DerivationClass::OpaqueExternal,
         };
         let node = make_node_with_sink(
             NodeKind::OutboundAction,

--- a/crates/portcullis-core/src/lib.rs
+++ b/crates/portcullis-core/src/lib.rs
@@ -856,7 +856,7 @@ pub fn should_gate(current: &ExposureSet, op: Operation) -> bool {
 // ═══════════════════════════════════════════════════════════════════════════
 // Information Flow Control labels — the Flow Kernel foundation
 //
-// A product lattice of 5 dimensions that tracks data provenance, trust,
+// A product lattice of 6 dimensions that tracks data provenance, trust,
 // and authority through agent execution. This is the formal substrate
 // for defending against trust-boundary exploits (indirect prompt injection,
 // memory poisoning, confused-deputy attacks).
@@ -1035,16 +1035,120 @@ impl Freshness {
     }
 }
 
-/// Information flow control label — 5-dimensional product lattice.
+/// Derivation class — determinism-aware integrity classification.
+///
+/// Tracks whether a datum was produced by a deterministic computation,
+/// AI generation, or some combination. This is the 6th dimension of
+/// the IFC product lattice and the core DPI primitive: it determines
+/// whether data can be auto-verified or requires human attestation.
+///
+/// Lattice order (bottom to top): `Deterministic < AIDerived < Mixed < OpaqueExternal`
+/// `HumanPromoted` sits beside `Mixed` — promotion does not cleanse.
+///
+/// Key invariant ("no silent cleansing"): `AIDerived.join(x) != Deterministic`
+/// for any `x` — AI-derived data cannot become deterministic without explicit
+/// human promotion, and even then the result is `Mixed`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
+#[repr(u8)]
+pub enum DerivationClass {
+    /// Reproducible: pure transform, deterministic fetch, parser output.
+    #[default]
+    Deterministic = 0,
+    /// LLM-generated, not reproducible (classification, extraction, generation).
+    AIDerived = 1,
+    /// Combination of deterministic and AI-derived inputs.
+    Mixed = 2,
+    /// AI-derived data explicitly approved by a human. Preserves ancestry
+    /// but signals attestation — joining with anything produces Mixed.
+    HumanPromoted = 3,
+    /// External system with unknown determinism profile. Top element.
+    OpaqueExternal = 4,
+}
+
+impl DerivationClass {
+    /// Join (least upper bound) of two derivation classes.
+    ///
+    /// Lattice structure (Hasse diagram):
+    /// ```text
+    ///       OpaqueExternal  (top)
+    ///            |
+    ///          Mixed
+    ///         /     \
+    ///   AIDerived  HumanPromoted
+    ///         \     /
+    ///       Deterministic  (bottom)
+    /// ```
+    ///
+    /// - Deterministic is bottom: `Deterministic ⊔ x = x`
+    /// - OpaqueExternal is top: `x ⊔ OpaqueExternal = OpaqueExternal`
+    /// - AIDerived ⊔ HumanPromoted = Mixed
+    /// - Mixed ⊔ {AIDerived, HumanPromoted} = Mixed
+    ///
+    /// Key invariant ("no silent cleansing"): `AIDerived.join(x) != Deterministic`
+    /// for any x — AI-derived data can never be laundered back to deterministic.
+    pub fn join(self, other: Self) -> Self {
+        use DerivationClass::*;
+        match (self, other) {
+            // Deterministic is bottom — identity for join
+            (Deterministic, x) | (x, Deterministic) => x,
+            // OpaqueExternal is top — absorbs everything
+            (OpaqueExternal, _) | (_, OpaqueExternal) => OpaqueExternal,
+            // Same class: idempotent
+            (AIDerived, AIDerived) => AIDerived,
+            (HumanPromoted, HumanPromoted) => HumanPromoted,
+            (Mixed, Mixed) => Mixed,
+            // Different non-bottom, non-top classes → Mixed
+            // AIDerived + HumanPromoted, AIDerived + Mixed, HumanPromoted + Mixed
+            _ => Mixed,
+        }
+    }
+
+    /// Meet (greatest lower bound) of two derivation classes.
+    ///
+    /// Dual of join:
+    /// - OpaqueExternal is top — identity for meet: `meet(x, OpaqueExternal) = x`
+    /// - Deterministic is bottom — absorber for meet: `meet(x, Deterministic) = Deterministic`
+    /// - `meet(AIDerived, HumanPromoted) = Deterministic` (greatest lower bound of incomparables)
+    /// - `meet(Mixed, x) = x` when x is AIDerived or HumanPromoted
+    pub fn meet(self, other: Self) -> Self {
+        use DerivationClass::*;
+        match (self, other) {
+            // OpaqueExternal is top — identity for meet
+            (OpaqueExternal, x) | (x, OpaqueExternal) => x,
+            // Deterministic is bottom — absorber for meet
+            (Deterministic, _) | (_, Deterministic) => Deterministic,
+            // Same class: idempotent
+            (AIDerived, AIDerived) => AIDerived,
+            (HumanPromoted, HumanPromoted) => HumanPromoted,
+            (Mixed, Mixed) => Mixed,
+            // Mixed meets AIDerived or HumanPromoted = the lower element
+            (Mixed, x) | (x, Mixed) => x,
+            // AIDerived meets HumanPromoted = Deterministic (their GLB)
+            (AIDerived, HumanPromoted) | (HumanPromoted, AIDerived) => Deterministic,
+        }
+    }
+
+    /// Lattice partial order: `self ≤ other`.
+    ///
+    /// `a.leq(b)` iff `a.join(b) == b` (standard lattice definition).
+    pub fn leq(self, other: Self) -> bool {
+        self.join(other) == other
+    }
+}
+
+/// Information flow control label — 6-dimensional product lattice.
 ///
 /// The lattice order follows BLP (confidentiality) + Biba (integrity)
-/// composition with authority confinement:
+/// composition with authority confinement and derivation tracking:
 ///
 /// - Confidentiality: covariant — join = max (most secret wins)
 /// - Integrity: CONTRAVARIANT — join = min (least trusted wins)
 /// - Provenance: covariant — join = union (all sources tracked)
 /// - Freshness: covariant — join = oldest, shortest TTL
 /// - Authority: CONTRAVARIANT — join = min (least authority wins)
+/// - Derivation: covariant — join per DerivationClass rules (Mixed absorbs)
 ///
 /// Key property: combining a trusted user prompt with web content produces
 /// `integrity = Adversarial, authority = NoAuthority`. This data cannot
@@ -1057,6 +1161,9 @@ pub struct IFCLabel {
     pub provenance: ProvenanceSet,
     pub freshness: Freshness,
     pub authority: AuthorityLevel,
+    /// Derivation class — tracks whether this datum was deterministically
+    /// computed, AI-generated, mixed, human-promoted, or from an opaque source.
+    pub derivation: DerivationClass,
 }
 
 impl Default for IFCLabel {
@@ -1072,6 +1179,7 @@ impl Default for IFCLabel {
             provenance: ProvenanceSet::EMPTY,
             freshness: Freshness::default(),
             authority: AuthorityLevel::NoAuthority,
+            derivation: DerivationClass::Deterministic,
         }
     }
 }
@@ -1102,6 +1210,7 @@ impl IFCLabel {
             } else {
                 other.authority
             },
+            derivation: self.derivation.join(other.derivation),
         }
     }
 
@@ -1120,6 +1229,7 @@ impl IFCLabel {
             && self.integrity >= target.integrity
             && self.authority >= target.authority
             && self.provenance.is_subset_of(target.provenance)
+            && self.derivation.leq(target.derivation)
     }
 
     /// Bottom label (least restrictive): public, trusted, no provenance, full authority.
@@ -1133,6 +1243,7 @@ impl IFCLabel {
             provenance: ProvenanceSet::EMPTY,
             freshness: Freshness::default(),
             authority: AuthorityLevel::Directive,
+            derivation: DerivationClass::Deterministic,
         }
     }
 
@@ -1150,6 +1261,7 @@ impl IFCLabel {
                 ttl_secs: 1, // expired immediately (observed_at=0, ttl=1 → expired at t=1)
             },
             authority: AuthorityLevel::NoAuthority,
+            derivation: DerivationClass::OpaqueExternal,
         }
     }
 
@@ -1164,6 +1276,7 @@ impl IFCLabel {
                 ttl_secs: 3600,
             },
             authority: AuthorityLevel::NoAuthority,
+            derivation: DerivationClass::OpaqueExternal,
         }
     }
 
@@ -1178,6 +1291,7 @@ impl IFCLabel {
                 ttl_secs: 0,
             },
             authority: AuthorityLevel::Directive,
+            derivation: DerivationClass::Deterministic,
         }
     }
 
@@ -1192,6 +1306,7 @@ impl IFCLabel {
                 ttl_secs: 0,
             },
             authority: AuthorityLevel::NoAuthority,
+            derivation: DerivationClass::Deterministic,
         }
     }
 
@@ -1206,6 +1321,7 @@ impl IFCLabel {
                 ttl_secs: 0,
             },
             authority: AuthorityLevel::Informational,
+            derivation: DerivationClass::Deterministic,
         }
     }
 
@@ -1220,6 +1336,7 @@ impl IFCLabel {
                 ttl_secs: 86400,
             },
             authority: AuthorityLevel::Informational,
+            derivation: DerivationClass::Deterministic,
         }
     }
 
@@ -1251,6 +1368,7 @@ impl IFCLabel {
             } else {
                 other.authority
             },
+            derivation: self.derivation.meet(other.derivation),
         }
     }
 
@@ -1267,6 +1385,7 @@ impl IFCLabel {
             && self.authority >= other.authority
             && self.provenance.is_subset_of(other.provenance)
             && self.freshness.leq(other.freshness)
+            && self.derivation.leq(other.derivation)
     }
 }
 
@@ -1385,6 +1504,19 @@ mod kani_ifc_label_proofs {
         }
     }
 
+    /// Generate a symbolic DerivationClass (5 variants — exhaustive).
+    fn any_derivation() -> DerivationClass {
+        let v: u8 = kani::any();
+        kani::assume(v <= 4);
+        match v {
+            0 => DerivationClass::Deterministic,
+            1 => DerivationClass::AIDerived,
+            2 => DerivationClass::Mixed,
+            3 => DerivationClass::HumanPromoted,
+            _ => DerivationClass::OpaqueExternal,
+        }
+    }
+
     /// Generate a symbolic IFCLabel with bounded provenance (6-bit) and
     /// bounded freshness for tractable verification.
     fn any_label() -> IFCLabel {
@@ -1397,6 +1529,7 @@ mod kani_ifc_label_proofs {
                 ttl_secs: kani::any(),
             },
             authority: any_auth(),
+            derivation: any_derivation(),
         }
     }
 
@@ -2304,11 +2437,362 @@ mod tests {
     }
 
     // ════════════════════════════════════════════════════════════════════
+    // DerivationClass lattice tests
+    // ════════════════════════════════════════════════════════════════════
+
+    #[test]
+    fn derivation_join_exhaustive_table() {
+        use DerivationClass::*;
+        // Exhaustive 5x5 join table matching the diamond lattice:
+        //       OpaqueExternal
+        //            |
+        //          Mixed
+        //         /     \
+        //   AIDerived  HumanPromoted
+        //         \     /
+        //       Deterministic
+        let cases = [
+            // Deterministic is bottom — identity for join
+            (Deterministic, Deterministic, Deterministic),
+            (Deterministic, AIDerived, AIDerived),
+            (Deterministic, Mixed, Mixed),
+            (Deterministic, HumanPromoted, HumanPromoted),
+            (Deterministic, OpaqueExternal, OpaqueExternal),
+            // AIDerived joins
+            (AIDerived, Deterministic, AIDerived),
+            (AIDerived, AIDerived, AIDerived),
+            (AIDerived, Mixed, Mixed),
+            (AIDerived, HumanPromoted, Mixed),
+            (AIDerived, OpaqueExternal, OpaqueExternal),
+            // Mixed joins
+            (Mixed, Deterministic, Mixed),
+            (Mixed, AIDerived, Mixed),
+            (Mixed, Mixed, Mixed),
+            (Mixed, HumanPromoted, Mixed),
+            (Mixed, OpaqueExternal, OpaqueExternal),
+            // HumanPromoted joins
+            (HumanPromoted, Deterministic, HumanPromoted),
+            (HumanPromoted, AIDerived, Mixed),
+            (HumanPromoted, Mixed, Mixed),
+            (HumanPromoted, HumanPromoted, HumanPromoted),
+            (HumanPromoted, OpaqueExternal, OpaqueExternal),
+            // OpaqueExternal is top — absorbs everything
+            (OpaqueExternal, Deterministic, OpaqueExternal),
+            (OpaqueExternal, AIDerived, OpaqueExternal),
+            (OpaqueExternal, Mixed, OpaqueExternal),
+            (OpaqueExternal, HumanPromoted, OpaqueExternal),
+            (OpaqueExternal, OpaqueExternal, OpaqueExternal),
+        ];
+        for (a, b, expected) in cases {
+            assert_eq!(
+                a.join(b),
+                expected,
+                "{:?}.join({:?}) should be {:?}",
+                a,
+                b,
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn derivation_join_commutative() {
+        use DerivationClass::*;
+        let all = [
+            Deterministic,
+            AIDerived,
+            Mixed,
+            HumanPromoted,
+            OpaqueExternal,
+        ];
+        for &a in &all {
+            for &b in &all {
+                assert_eq!(
+                    a.join(b),
+                    b.join(a),
+                    "{:?}.join({:?}) not commutative",
+                    a,
+                    b
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn derivation_join_associative() {
+        use DerivationClass::*;
+        let all = [
+            Deterministic,
+            AIDerived,
+            Mixed,
+            HumanPromoted,
+            OpaqueExternal,
+        ];
+        for &a in &all {
+            for &b in &all {
+                for &c in &all {
+                    assert_eq!(
+                        a.join(b).join(c),
+                        a.join(b.join(c)),
+                        "({:?} join {:?}) join {:?} != {:?} join ({:?} join {:?})",
+                        a,
+                        b,
+                        c,
+                        a,
+                        b,
+                        c
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn derivation_join_idempotent() {
+        use DerivationClass::*;
+        for &d in &[
+            Deterministic,
+            AIDerived,
+            Mixed,
+            HumanPromoted,
+            OpaqueExternal,
+        ] {
+            assert_eq!(d.join(d), d, "{:?}.join({:?}) should be idempotent", d, d);
+        }
+    }
+
+    #[test]
+    fn derivation_leq_reflexive() {
+        use DerivationClass::*;
+        for &d in &[
+            Deterministic,
+            AIDerived,
+            Mixed,
+            HumanPromoted,
+            OpaqueExternal,
+        ] {
+            assert!(d.leq(d), "{:?} should be leq itself", d);
+        }
+    }
+
+    #[test]
+    fn derivation_leq_antisymmetric() {
+        use DerivationClass::*;
+        let all = [
+            Deterministic,
+            AIDerived,
+            Mixed,
+            HumanPromoted,
+            OpaqueExternal,
+        ];
+        for &a in &all {
+            for &b in &all {
+                if a.leq(b) && b.leq(a) {
+                    assert_eq!(
+                        a, b,
+                        "{:?} leq {:?} and {:?} leq {:?} but not equal",
+                        a, b, b, a
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn derivation_lattice_ordering() {
+        use DerivationClass::*;
+        // Deterministic is bottom
+        assert!(Deterministic.leq(AIDerived));
+        assert!(Deterministic.leq(HumanPromoted));
+        assert!(Deterministic.leq(Mixed));
+        assert!(Deterministic.leq(OpaqueExternal));
+
+        // AIDerived and HumanPromoted are incomparable
+        assert!(!AIDerived.leq(HumanPromoted));
+        assert!(!HumanPromoted.leq(AIDerived));
+
+        // Both are below Mixed
+        assert!(AIDerived.leq(Mixed));
+        assert!(HumanPromoted.leq(Mixed));
+        assert!(!Mixed.leq(AIDerived));
+        assert!(!Mixed.leq(HumanPromoted));
+
+        // OpaqueExternal is top
+        for &d in &[
+            Deterministic,
+            AIDerived,
+            Mixed,
+            HumanPromoted,
+            OpaqueExternal,
+        ] {
+            assert!(d.leq(OpaqueExternal), "{:?} should be <= OpaqueExternal", d);
+        }
+    }
+
+    #[test]
+    fn derivation_no_silent_cleansing() {
+        use DerivationClass::*;
+        // AIDerived joined with anything that is not HumanPromoted
+        // must never produce Deterministic.
+        for &other in &[
+            Deterministic,
+            AIDerived,
+            Mixed,
+            HumanPromoted,
+            OpaqueExternal,
+        ] {
+            let result = AIDerived.join(other);
+            assert_ne!(
+                result, Deterministic,
+                "AIDerived.join({:?}) = Deterministic violates no-silent-cleansing",
+                other
+            );
+        }
+    }
+
+    #[test]
+    fn derivation_meet_exhaustive() {
+        use DerivationClass::*;
+        // Meet is dual of join — verify key properties
+        let all = [
+            Deterministic,
+            AIDerived,
+            Mixed,
+            HumanPromoted,
+            OpaqueExternal,
+        ];
+        for &a in &all {
+            for &b in &all {
+                let m = a.meet(b);
+                // meet(a,b) <= a and meet(a,b) <= b
+                assert!(
+                    m.leq(a),
+                    "meet({:?},{:?}) = {:?} should be <= {:?}",
+                    a,
+                    b,
+                    m,
+                    a
+                );
+                assert!(
+                    m.leq(b),
+                    "meet({:?},{:?}) = {:?} should be <= {:?}",
+                    a,
+                    b,
+                    m,
+                    b
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn derivation_propagation_through_flow() {
+        // Deterministic file + AIDerived model plan = AIDerived
+        // (Deterministic is bottom, so it's absorbed by AIDerived)
+        let file_label = IFCLabel {
+            derivation: DerivationClass::Deterministic,
+            ..IFCLabel::bottom()
+        };
+        let model_label = IFCLabel {
+            derivation: DerivationClass::AIDerived,
+            ..IFCLabel::bottom()
+        };
+        let result = file_label.join(model_label);
+        assert_eq!(result.derivation, DerivationClass::AIDerived);
+
+        // AIDerived + HumanPromoted = Mixed (incomparable elements)
+        let ai_label = IFCLabel {
+            derivation: DerivationClass::AIDerived,
+            ..IFCLabel::bottom()
+        };
+        let human_label = IFCLabel {
+            derivation: DerivationClass::HumanPromoted,
+            ..IFCLabel::bottom()
+        };
+        let result = ai_label.join(human_label);
+        assert_eq!(result.derivation, DerivationClass::Mixed);
+    }
+
+    #[test]
+    fn derivation_opaque_absorbs_in_join() {
+        // Any label joined with OpaqueExternal produces OpaqueExternal derivation
+        let opaque = IFCLabel {
+            derivation: DerivationClass::OpaqueExternal,
+            ..IFCLabel::bottom()
+        };
+        for &d in &[
+            DerivationClass::Deterministic,
+            DerivationClass::AIDerived,
+            DerivationClass::Mixed,
+            DerivationClass::HumanPromoted,
+        ] {
+            let other = IFCLabel {
+                derivation: d,
+                ..IFCLabel::bottom()
+            };
+            assert_eq!(
+                opaque.join(other).derivation,
+                DerivationClass::OpaqueExternal,
+                "OpaqueExternal should absorb {:?} in IFCLabel join",
+                d
+            );
+        }
+    }
+
+    #[test]
+    fn derivation_intrinsic_labels_correct() {
+        use crate::flow::{NodeKind, intrinsic_label};
+        let now = 1000;
+
+        // Deterministic sources
+        assert_eq!(
+            intrinsic_label(NodeKind::UserPrompt, now).derivation,
+            DerivationClass::Deterministic
+        );
+        assert_eq!(
+            intrinsic_label(NodeKind::FileRead, now).derivation,
+            DerivationClass::Deterministic
+        );
+        assert_eq!(
+            intrinsic_label(NodeKind::EnvVar, now).derivation,
+            DerivationClass::Deterministic
+        );
+        assert_eq!(
+            intrinsic_label(NodeKind::Secret, now).derivation,
+            DerivationClass::Deterministic
+        );
+        assert_eq!(
+            intrinsic_label(NodeKind::ToolResponse, now).derivation,
+            DerivationClass::Deterministic
+        );
+
+        // AI-derived sources
+        assert_eq!(
+            intrinsic_label(NodeKind::ModelPlan, now).derivation,
+            DerivationClass::AIDerived
+        );
+        assert_eq!(
+            intrinsic_label(NodeKind::MemoryWrite, now).derivation,
+            DerivationClass::AIDerived
+        );
+        assert_eq!(
+            intrinsic_label(NodeKind::Summarization, now).derivation,
+            DerivationClass::AIDerived
+        );
+
+        // OpaqueExternal
+        assert_eq!(
+            intrinsic_label(NodeKind::WebContent, now).derivation,
+            DerivationClass::OpaqueExternal
+        );
+    }
+
+    // ════════════════════════════════════════════════════════════════════
     // IFCLabel bounded lattice axiom tests (test-mode mirrors of Kani proofs)
     // ════════════════════════════════════════════════════════════════════
 
-    /// Helper: enumerate all ConfLevel * IntegLevel * AuthorityLevel * ProvenanceSet
-    /// combinations with fixed freshness. 3 * 3 * 4 * 64 = 2304 labels.
+    /// Helper: enumerate all ConfLevel x IntegLevel x AuthorityLevel x DerivationClass
+    /// x ProvenanceSet combinations with fixed freshness (11520 labels).
     fn all_labels() -> Vec<IFCLabel> {
         let confs = [ConfLevel::Public, ConfLevel::Internal, ConfLevel::Secret];
         let integs = [
@@ -2322,6 +2806,13 @@ mod tests {
             AuthorityLevel::Suggestive,
             AuthorityLevel::Directive,
         ];
+        let derivs = [
+            DerivationClass::Deterministic,
+            DerivationClass::AIDerived,
+            DerivationClass::Mixed,
+            DerivationClass::HumanPromoted,
+            DerivationClass::OpaqueExternal,
+        ];
         let fresh = Freshness {
             observed_at: 100,
             ttl_secs: 0,
@@ -2331,14 +2822,17 @@ mod tests {
         for &c in &confs {
             for &i in &integs {
                 for &a in &auths {
-                    for prov_bits in 0..64u8 {
-                        labels.push(IFCLabel {
-                            confidentiality: c,
-                            integrity: i,
-                            provenance: ProvenanceSet::from_bits(prov_bits),
-                            freshness: fresh,
-                            authority: a,
-                        });
+                    for &d in &derivs {
+                        for prov_bits in 0..64u8 {
+                            labels.push(IFCLabel {
+                                confidentiality: c,
+                                integrity: i,
+                                provenance: ProvenanceSet::from_bits(prov_bits),
+                                freshness: fresh,
+                                authority: a,
+                                derivation: d,
+                            });
+                        }
                     }
                 }
             }
@@ -2354,6 +2848,7 @@ mod tests {
             assert_eq!(r.integrity, a.integrity);
             assert_eq!(r.authority, a.authority);
             assert_eq!(r.provenance.bits(), a.provenance.bits());
+            assert_eq!(r.derivation, a.derivation);
         }
     }
 

--- a/crates/portcullis-core/src/memory.rs
+++ b/crates/portcullis-core/src/memory.rs
@@ -348,6 +348,7 @@ impl GovernedMemory {
                     observed_at: entry.created_at,
                     ttl_secs: entry.ttl_secs,
                 },
+                derivation: crate::DerivationClass::Deterministic,
             }
         })
     }

--- a/crates/portcullis-core/src/policy_rules.rs
+++ b/crates/portcullis-core/src/policy_rules.rs
@@ -287,6 +287,7 @@ mod tests {
                 observed_at: 1000,
                 ttl_secs: 0,
             },
+            derivation: crate::DerivationClass::Deterministic,
         }
     }
 
@@ -300,6 +301,7 @@ mod tests {
                 observed_at: 1000,
                 ttl_secs: 0,
             },
+            derivation: crate::DerivationClass::OpaqueExternal,
         }
     }
 
@@ -313,6 +315,7 @@ mod tests {
                 observed_at: 1000,
                 ttl_secs: 0,
             },
+            derivation: crate::DerivationClass::Deterministic,
         }
     }
 

--- a/crates/portcullis-core/src/receipt.rs
+++ b/crates/portcullis-core/src/receipt.rs
@@ -314,6 +314,7 @@ mod tests {
                     ttl_secs: 0,
                 },
                 authority: AuthorityLevel::Directive,
+                derivation: crate::DerivationClass::Deterministic,
             },
             None,
         );

--- a/crates/portcullis-core/src/verdict.rs
+++ b/crates/portcullis-core/src/verdict.rs
@@ -376,6 +376,7 @@ mod tests {
             provenance: ProvenanceSet::EMPTY,
             freshness: Freshness::default(),
             authority: AuthorityLevel::Directive,
+            derivation: crate::DerivationClass::Deterministic,
         };
 
         let evidence = Evidence {

--- a/crates/portcullis-core/src/wire.rs
+++ b/crates/portcullis-core/src/wire.rs
@@ -10,7 +10,7 @@
 //! Labels are encoded as a compact header string:
 //!
 //! ```text
-//! X-Nucleus-Label: c=2;i=0;a=0;p=5;t=1711843200;ttl=3600
+//! X-Nucleus-Label: c=2;i=0;a=0;p=5;t=1711843200;ttl=3600;d=1
 //! ```
 //!
 //! Where:
@@ -20,11 +20,14 @@
 //! - `p` = provenance bitmask (6 bits: USER|TOOL|WEB|MEMORY|MODEL|SYSTEM)
 //! - `t` = observed_at (unix timestamp)
 //! - `ttl` = time-to-live seconds (0 = no expiry)
+//! - `d` = derivation (0=Deterministic, 1=AIDerived, 2=Mixed, 3=HumanPromoted, 4=OpaqueExternal)
 //!
 //! The receiving agent's kernel must `observe()` with this label as the
 //! intrinsic label of the incoming data, ensuring taint propagates.
 
-use crate::{AuthorityLevel, ConfLevel, Freshness, IFCLabel, IntegLevel, ProvenanceSet};
+use crate::{
+    AuthorityLevel, ConfLevel, DerivationClass, Freshness, IFCLabel, IntegLevel, ProvenanceSet,
+};
 
 /// HTTP header name for IFC label propagation.
 pub const LABEL_HEADER: &str = "x-nucleus-label";
@@ -32,13 +35,14 @@ pub const LABEL_HEADER: &str = "x-nucleus-label";
 /// Encode an IFC label to the wire format.
 pub fn encode_label(label: &IFCLabel) -> String {
     format!(
-        "c={};i={};a={};p={};t={};ttl={}",
+        "c={};i={};a={};p={};t={};ttl={};d={}",
         label.confidentiality as u8,
         label.integrity as u8,
         label.authority as u8,
         label.provenance.bits(),
         label.freshness.observed_at,
         label.freshness.ttl_secs,
+        label.derivation as u8,
     )
 }
 
@@ -53,6 +57,7 @@ pub fn decode_label(s: &str) -> Option<IFCLabel> {
     let mut prov: u8 = 0;
     let mut observed_at: u64 = 0;
     let mut ttl: u64 = 0;
+    let mut deriv: u8 = 4; // OpaqueExternal (most restrictive)
 
     for part in s.split(';') {
         let part = part.trim();
@@ -64,6 +69,7 @@ pub fn decode_label(s: &str) -> Option<IFCLabel> {
                 "p" => prov = val.parse().ok()?,
                 "t" => observed_at = val.parse().ok()?,
                 "ttl" => ttl = val.parse().ok()?,
+                "d" => deriv = val.parse().ok()?,
                 _ => {} // ignore unknown fields
             }
         }
@@ -90,6 +96,14 @@ pub fn decode_label(s: &str) -> Option<IFCLabel> {
         _ => AuthorityLevel::NoAuthority, // fail-closed
     };
 
+    let derivation = match deriv {
+        0 => DerivationClass::Deterministic,
+        1 => DerivationClass::AIDerived,
+        2 => DerivationClass::Mixed,
+        3 => DerivationClass::HumanPromoted,
+        _ => DerivationClass::OpaqueExternal, // fail-closed: unknown = most restrictive
+    };
+
     Some(IFCLabel {
         confidentiality,
         integrity,
@@ -99,6 +113,7 @@ pub fn decode_label(s: &str) -> Option<IFCLabel> {
             ttl_secs: ttl,
         },
         authority,
+        derivation,
     })
 }
 
@@ -117,6 +132,7 @@ mod tests {
                 ttl_secs: 3600,
             },
             authority: AuthorityLevel::Directive,
+            derivation: DerivationClass::Deterministic,
         };
         let encoded = encode_label(&label);
         let decoded = decode_label(&encoded).unwrap();
@@ -191,6 +207,7 @@ mod tests {
                 ttl_secs: 0,
             },
             authority: AuthorityLevel::Informational,
+            derivation: DerivationClass::OpaqueExternal,
         };
         let encoded = encode_label(&label);
         let decoded = decode_label(&encoded).unwrap();

--- a/crates/portcullis-core/tests/flow_red_team.rs
+++ b/crates/portcullis-core/tests/flow_red_team.rs
@@ -67,6 +67,7 @@ fn exploit_01_invariant_github_issue_exfil_via_pr() {
                 ttl_secs: 0,
             },
             authority: AuthorityLevel::Directive,
+            derivation: portcullis_core::DerivationClass::Deterministic,
         },
         None,
     );
@@ -120,6 +121,7 @@ fn exploit_01b_invariant_exfil_via_git_push() {
                 ttl_secs: 0,
             },
             authority: AuthorityLevel::Directive,
+            derivation: portcullis_core::DerivationClass::Deterministic,
         },
         None,
     );
@@ -421,6 +423,7 @@ fn legitimate_user_creates_pr_from_own_work() {
                 ttl_secs: 0,
             },
             authority: AuthorityLevel::Directive,
+            derivation: portcullis_core::DerivationClass::Deterministic,
         },
         None,
     );

--- a/crates/portcullis/src/receipt_sign.rs
+++ b/crates/portcullis/src/receipt_sign.rs
@@ -238,6 +238,7 @@ mod tests {
                     ttl_secs: 0,
                 },
                 authority: AuthorityLevel::Directive,
+                derivation: portcullis_core::DerivationClass::Deterministic,
             },
             None,
         );


### PR DESCRIPTION
## Summary

Closes #704.

- Adds `DerivationClass` enum to `portcullis-core` with 5 variants: `Deterministic`, `AIDerived`, `Mixed`, `HumanPromoted`, `OpaqueExternal`
- Adds `derivation` as the 6th dimension of `IFCLabel`, with lattice operations (`join`, `meet`, `leq`) forming a proper bounded diamond lattice
- Updates `propagate_label()`, `intrinsic_label()`, `flows_to()`, wire encode/decode, and all IFCLabel struct literals across 11 files

## Lattice structure

```
      OpaqueExternal  (top)
           |
         Mixed
        /     \
  AIDerived  HumanPromoted
        \     /
      Deterministic  (bottom)
```

**Key invariant (no silent cleansing)**: `AIDerived.join(x) != Deterministic` for any x — AI-derived data can never be laundered back to deterministic without explicit human promotion.

## Intrinsic label assignments

| NodeKind | DerivationClass |
|----------|----------------|
| UserPrompt, FileRead, EnvVar, Secret, ToolResponse | Deterministic |
| ModelPlan, MemoryWrite, Summarization | AIDerived |
| WebContent | OpaqueExternal |
| OutboundAction, Retry | Deterministic (neutral base, inherits from parents) |

## Test plan

- [x] Exhaustive 5x5 join table (all 25 pairs)
- [x] Commutativity, associativity, idempotence of join
- [x] Reflexivity, antisymmetry of leq
- [x] Bottom (Deterministic) and top (OpaqueExternal) element verification
- [x] No-silent-cleansing invariant
- [x] Meet duality (meet(a,b) <= a and meet(a,b) <= b for all pairs)
- [x] IFCLabel propagation through flow graph
- [x] Intrinsic label correctness for all NodeKinds
- [x] Wire format roundtrip with derivation field
- [x] Full workspace compilation and test suite (all 370+ tests pass)
- [x] Kani proof `any_label()` generators updated with `any_derivation()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)