### PR TITLE
Add EffectKind enum for computation-step-level effect classification

### DIFF
--- a/crates/portcullis-core/src/effect.rs
+++ b/crates/portcullis-core/src/effect.rs
@@ -1,0 +1,279 @@
+//! Computation-step-level effect classification.
+//!
+//! [`EffectKind`] classifies each computation step by its determinism profile.
+//! This is orthogonal to [`crate::Operation`], which classifies tool-level
+//! actions. `EffectKind` answers *how* a datum was derived — whether by
+//! generative model output, deterministic fetch, pure transformation,
+//! human input, etc.
+//!
+//! This distinction is the foundation of the DPI dual-lane storage model:
+//! deterministic effects can be auto-verified; generative effects require
+//! witness bundles.
+
+// ═══════════════════════════════════════════════════════════════════════════
+// DerivationClass — the coarse derivation bucket an effect implies
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Coarse derivation class that an [`EffectKind`] implies.
+///
+/// Every computation step produces data that falls into one of these
+/// verification categories. Deterministic derivations can be replayed
+/// for bit-exact verification; generative derivations require witness
+/// bundles; human derivations require attestation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
+pub enum DerivationClass {
+    /// Output is reproducible given the same inputs.
+    Deterministic,
+    /// Output depends on a generative model and is not reproducible.
+    Generative,
+    /// Output was provided directly by a human.
+    Human,
+    /// Output was imported from an external system with its own provenance.
+    External,
+    /// Output was replayed from a prior recorded computation.
+    Replayed,
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// EffectKind — computation-step-level effect classification
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Classifies a computation step by its determinism profile.
+///
+/// Unlike [`crate::Operation`] (which classifies which *tool* was invoked),
+/// `EffectKind` classifies *how* the output was derived. A single tool
+/// invocation may involve multiple `EffectKind` steps — for example, a
+/// "research" tool might fetch a URL (`DeterministicFetch`), then
+/// summarize the content (`LLMGenerate`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
+pub enum EffectKind {
+    // -- Generative (non-deterministic model output) --
+    /// Free-form LLM generation (summaries, prose, code).
+    LLMGenerate,
+    /// LLM classification or labeling (sentiment, category).
+    LLMClassify,
+    /// LLM-based extraction from text (entities, fields).
+    LLMExtract,
+
+    // -- Deterministic (reproducible given same inputs) --
+    /// Authenticated HTTP/API fetch — same URL + auth yields same response.
+    DeterministicFetch,
+    /// Registered parser execution (JSON parse, regex, AST parse).
+    DeterministicParse,
+    /// Format or schema validation (JSON Schema, protobuf, etc.).
+    DeterministicValidate,
+    /// Pure function transform (hash, sort, map, filter).
+    PureTransform,
+    /// Database or search query with deterministic parameters.
+    Query,
+
+    // -- Human --
+    /// Human review and approval of a proposed action.
+    HumanApprove,
+    /// Human direct modification of data or content.
+    HumanEdit,
+
+    // -- Writes --
+    /// Write to a verified sink (committed, immutable).
+    VerifiedWrite,
+    /// Write to a proposed sink (draft, reviewable).
+    ProposedWrite,
+
+    // -- External / Replay --
+    /// Import from an external system with its own provenance chain.
+    ExternalImport,
+    /// Replay of a prior recorded computation step.
+    Replay,
+}
+
+impl EffectKind {
+    /// Returns `true` if this effect is deterministic — given the same inputs
+    /// and environment, it will always produce the same output.
+    ///
+    /// Deterministic effects can be auto-verified by re-execution.
+    pub const fn is_deterministic(&self) -> bool {
+        matches!(
+            self,
+            Self::DeterministicFetch
+                | Self::DeterministicParse
+                | Self::DeterministicValidate
+                | Self::PureTransform
+                | Self::Query
+        )
+    }
+
+    /// Returns `true` if this effect involves generative AI model output.
+    ///
+    /// Generative effects are non-deterministic and require witness bundles
+    /// (input snapshot + output + model version) for auditability.
+    pub const fn is_ai_generative(&self) -> bool {
+        matches!(
+            self,
+            Self::LLMGenerate | Self::LLMClassify | Self::LLMExtract
+        )
+    }
+
+    /// Returns the [`DerivationClass`] that this effect kind implies.
+    ///
+    /// This mapping is the bridge between fine-grained effect classification
+    /// and the coarse verification lanes in the DPI storage model.
+    pub const fn implied_derivation(&self) -> DerivationClass {
+        match self {
+            // Generative
+            Self::LLMGenerate | Self::LLMClassify | Self::LLMExtract => DerivationClass::Generative,
+
+            // Deterministic
+            Self::DeterministicFetch
+            | Self::DeterministicParse
+            | Self::DeterministicValidate
+            | Self::PureTransform
+            | Self::Query => DerivationClass::Deterministic,
+
+            // Human
+            Self::HumanApprove | Self::HumanEdit => DerivationClass::Human,
+
+            // Writes inherit from the verification lane of their content,
+            // but structurally they are deterministic operations (the write
+            // itself is a side-effect, not a derivation).
+            Self::VerifiedWrite | Self::ProposedWrite => DerivationClass::Deterministic,
+
+            // External
+            Self::ExternalImport => DerivationClass::External,
+
+            // Replay
+            Self::Replay => DerivationClass::Replayed,
+        }
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every variant that claims to be deterministic must also imply
+    /// `DerivationClass::Deterministic`.
+    #[test]
+    fn deterministic_variants_imply_deterministic_derivation() {
+        let deterministic = [
+            EffectKind::DeterministicFetch,
+            EffectKind::DeterministicParse,
+            EffectKind::DeterministicValidate,
+            EffectKind::PureTransform,
+            EffectKind::Query,
+        ];
+        for kind in deterministic {
+            assert!(kind.is_deterministic(), "{kind:?} should be deterministic");
+            assert!(
+                !kind.is_ai_generative(),
+                "{kind:?} should NOT be ai_generative"
+            );
+            assert_eq!(
+                kind.implied_derivation(),
+                DerivationClass::Deterministic,
+                "{kind:?} should imply Deterministic derivation"
+            );
+        }
+    }
+
+    /// Every variant that claims to be AI generative must also imply
+    /// `DerivationClass::Generative`.
+    #[test]
+    fn ai_generative_variants_imply_generative_derivation() {
+        let generative = [
+            EffectKind::LLMGenerate,
+            EffectKind::LLMClassify,
+            EffectKind::LLMExtract,
+        ];
+        for kind in generative {
+            assert!(kind.is_ai_generative(), "{kind:?} should be ai_generative");
+            assert!(
+                !kind.is_deterministic(),
+                "{kind:?} should NOT be deterministic"
+            );
+            assert_eq!(
+                kind.implied_derivation(),
+                DerivationClass::Generative,
+                "{kind:?} should imply Generative derivation"
+            );
+        }
+    }
+
+    /// Human variants are neither deterministic nor AI generative.
+    #[test]
+    fn human_variants() {
+        let human = [EffectKind::HumanApprove, EffectKind::HumanEdit];
+        for kind in human {
+            assert!(!kind.is_deterministic(), "{kind:?}");
+            assert!(!kind.is_ai_generative(), "{kind:?}");
+            assert_eq!(kind.implied_derivation(), DerivationClass::Human);
+        }
+    }
+
+    /// Write variants are classified as deterministic (the write operation
+    /// itself is a side-effect, not a derivation).
+    #[test]
+    fn write_variants() {
+        let writes = [EffectKind::VerifiedWrite, EffectKind::ProposedWrite];
+        for kind in writes {
+            assert!(!kind.is_ai_generative(), "{kind:?}");
+            assert_eq!(kind.implied_derivation(), DerivationClass::Deterministic);
+        }
+    }
+
+    /// External import implies External derivation class.
+    #[test]
+    fn external_import_variant() {
+        let kind = EffectKind::ExternalImport;
+        assert!(!kind.is_deterministic());
+        assert!(!kind.is_ai_generative());
+        assert_eq!(kind.implied_derivation(), DerivationClass::External);
+    }
+
+    /// Replay implies Replayed derivation class.
+    #[test]
+    fn replay_variant() {
+        let kind = EffectKind::Replay;
+        assert!(!kind.is_deterministic());
+        assert!(!kind.is_ai_generative());
+        assert_eq!(kind.implied_derivation(), DerivationClass::Replayed);
+    }
+
+    /// Exhaustiveness check — every variant is covered by exactly one
+    /// of the classification methods or falls into the "other" bucket.
+    #[test]
+    fn every_variant_has_a_derivation_class() {
+        let all_variants = [
+            EffectKind::LLMGenerate,
+            EffectKind::LLMClassify,
+            EffectKind::LLMExtract,
+            EffectKind::DeterministicFetch,
+            EffectKind::DeterministicParse,
+            EffectKind::DeterministicValidate,
+            EffectKind::PureTransform,
+            EffectKind::Query,
+            EffectKind::HumanApprove,
+            EffectKind::HumanEdit,
+            EffectKind::VerifiedWrite,
+            EffectKind::ProposedWrite,
+            EffectKind::ExternalImport,
+            EffectKind::Replay,
+        ];
+
+        for kind in all_variants {
+            // implied_derivation must not panic — that's the test
+            let _class = kind.implied_derivation();
+        }
+
+        // Verify count matches enum variant count (compile-time guard
+        // via the match in implied_derivation, but belt-and-suspenders).
+        assert_eq!(all_variants.len(), 14);
+    }
+}

--- a/crates/portcullis-core/src/lib.rs
+++ b/crates/portcullis-core/src/lib.rs
@@ -67,6 +67,7 @@ pub mod compose;
 pub mod compose_runner;
 pub mod declassify;
 pub mod delegation;
+pub mod effect;
 #[cfg(feature = "serde")]
 pub mod enterprise;
 pub mod flow;


### PR DESCRIPTION
## Summary

- Adds `EffectKind` enum (14 variants) to `portcullis-core/src/effect.rs`, classifying computation steps by determinism profile: LLM-generative, deterministic, human, write, external, and replay
- Adds `DerivationClass` enum as the coarse verification lane each effect implies (Deterministic, Generative, Human, External, Replayed)
- Implements `is_deterministic()`, `is_ai_generative()`, and `implied_derivation()` methods
- Serde derives gated behind the existing `serde` feature flag
- Full test coverage: 7 tests covering all 14 variants

Closes #703

## Test plan

- [x] `cargo test -p portcullis-core -- effect` — 7/7 pass
- [x] `cargo clippy -p portcullis-core -- -D warnings` — clean
- [x] All pre-commit and pre-push hooks pass (fmt, clippy, deny, audit, test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)