### PR TITLE
fix: Aeneas CI reliability — 100 consecutive cancelled runs

### DIFF
--- a/.github/workflows/aeneas.yml
+++ b/.github/workflows/aeneas.yml
@@ -4,13 +4,20 @@ on:
   push:
     branches: ["main"]
     paths:
-      - "crates/portcullis-core/**"
+      - "crates/portcullis-core/lean/**"
+      - "crates/portcullis-core/src/lib.rs"
       - ".github/workflows/aeneas.yml"
   pull_request:
     paths:
-      - "crates/portcullis-core/**"
+      - "crates/portcullis-core/lean/**"
+      - "crates/portcullis-core/src/lib.rs"
       - ".github/workflows/aeneas.yml"
-  merge_group:
+  # Weekly canary to catch Mathlib/toolchain drift
+  schedule:
+    - cron: "0 8 * * 1"  # Every Monday at 8am UTC
+  # Release gate — always verify before publishing
+  release:
+    types: [published]
   workflow_dispatch:
 
 permissions:
@@ -27,7 +34,7 @@ jobs:
   aeneas-translate:
     name: Aeneas (Rust → Lean 4)
     runs-on: ubuntu-24.04
-    timeout-minutes: 15
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
## Problem

Aeneas verification has had **100 consecutive cancelled runs** with zero completions. Every merge queue entry triggered a 20-minute Lean/Mathlib build that got cancelled by the next commit before it could finish.

## Root cause

1. `merge_group` trigger ran on EVERY merge, even non-Lean changes
2. 15-minute timeout too short for Mathlib cold builds (~20 min)
3. 49 PRs merging in rapid succession = constant cancellation

## Fix

- **Remove `merge_group` trigger** — Aeneas no longer blocks every merge queue entry
- **Narrow path filter** — only `lean/` and `lib.rs` (the Aeneas source), not all of `portcullis-core/`
- **Add weekly canary** — Monday 8am UTC catches toolchain drift
- **Add release trigger** — always verify before publishing
- **Bump timeout** — 15→30 min for Mathlib cold builds

PRs touching Lean files are still gated. Routine Rust-only PRs skip the 20-min Lean build entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)