### PR TITLE
fix: verify DeclassificationToken Ed25519 signatures (#731)

### DIFF
--- a/crates/portcullis-core/src/declassify.rs
+++ b/crates/portcullis-core/src/declassify.rs
@@ -161,6 +161,8 @@ pub enum TokenApplyResult {
     Expired { valid_until: u64, now: u64 },
     /// The underlying rule's precondition didn't match the node's label.
     PreconditionUnmet,
+    /// Ed25519 signature is missing (all zeros) or failed verification.
+    InvalidSignature,
 }
 
 impl DeclassificationToken {
@@ -180,6 +182,16 @@ impl DeclassificationToken {
             justification,
             signature: [0u8; 64],
         }
+    }
+
+    /// Check if the token has been signed (signature is not all zeros).
+    pub fn is_signed(&self) -> bool {
+        self.signature != [0u8; 64]
+    }
+
+    /// Set the signature bytes (called by the signing layer).
+    pub fn set_signature(&mut self, sig: [u8; 64]) {
+        self.signature = sig;
     }
 
     /// Check if the token has expired.

--- a/crates/portcullis/src/flow_graph.rs
+++ b/crates/portcullis/src/flow_graph.rs
@@ -362,7 +362,18 @@ impl FlowGraph {
         id
     }
 
-    /// Apply a scoped declassification token to a specific node.
+    /// Apply a scoped declassification token to a specific node **without
+    /// signature verification**.
+    ///
+    /// # Security Warning
+    ///
+    /// This method does **not** verify the token's Ed25519 signature.
+    /// In production, use [`apply_token_verified()`](Self::apply_token_verified)
+    /// which cryptographically verifies the signature against trusted keys
+    /// before applying the declassification.
+    ///
+    /// This unverified method is retained for backward compatibility and
+    /// testing scenarios where signature infrastructure is not available.
     ///
     /// Validates that:
     /// 1. The target node exists in the graph
@@ -404,6 +415,40 @@ impl FlowGraph {
             original_label: result.original,
             new_label: result.label,
         }
+    }
+
+    /// Apply a declassification token with Ed25519 signature verification.
+    ///
+    /// Unlike `apply_token()`, this method **requires** a valid signature
+    /// verified against at least one of the provided trusted public keys.
+    /// Unsigned or tampered tokens are rejected with `InvalidSignature`.
+    ///
+    /// This is the recommended method for production use. The unverified
+    /// `apply_token()` should only be used in tests.
+    ///
+    /// # Arguments
+    ///
+    /// * `token` — The declassification token to apply.
+    /// * `trusted_keys` — Ed25519 public keys (32 bytes each) that may
+    ///   have signed this token. Supports key rotation by accepting
+    ///   multiple keys.
+    /// * `now` — Current unix timestamp for expiry checking.
+    #[cfg(feature = "crypto")]
+    pub fn apply_token_verified(
+        &mut self,
+        token: &portcullis_core::declassify::DeclassificationToken,
+        trusted_keys: &[&[u8]],
+        now: u64,
+    ) -> portcullis_core::declassify::TokenApplyResult {
+        use portcullis_core::declassify::TokenApplyResult;
+
+        // Verify signature FIRST — before any other checks
+        if crate::token_sign::verify_token_any_key(token, trusted_keys).is_err() {
+            return TokenApplyResult::InvalidSignature;
+        }
+
+        // Delegate to the existing apply logic
+        self.apply_token(token, now)
     }
 
     // ── Trusted ancestry check (#515) ────────────────────────────────
@@ -1648,6 +1693,181 @@ mod tests {
                 );
             }
             other => panic!("Expected Untrusted, got {other:?}"),
+        }
+    }
+
+    // ── apply_token_verified integration tests (#731) ───────────────
+
+    #[cfg(feature = "crypto")]
+    mod apply_token_verified_tests {
+        use super::*;
+        use portcullis_core::declassify::*;
+        use ring::rand::SystemRandom;
+        use ring::signature::{Ed25519KeyPair, KeyPair};
+
+        fn test_key() -> Ed25519KeyPair {
+            let rng = SystemRandom::new();
+            let pkcs8 = Ed25519KeyPair::generate_pkcs8(&rng).unwrap();
+            Ed25519KeyPair::from_pkcs8(pkcs8.as_ref()).unwrap()
+        }
+
+        fn make_graph_with_web_node() -> (FlowGraph, u64) {
+            let mut g = FlowGraph::new();
+            let now = 1000;
+            let web = g
+                .insert_observation(NodeKind::WebContent, &[], now)
+                .unwrap();
+            assert_eq!(
+                g.get(web).unwrap().label.integrity,
+                portcullis_core::IntegLevel::Adversarial
+            );
+            (g, web)
+        }
+
+        fn make_token_for(node_id: u64) -> DeclassificationToken {
+            DeclassificationToken::new(
+                node_id,
+                DeclassificationRule {
+                    action: DeclassifyAction::RaiseIntegrity {
+                        from: portcullis_core::IntegLevel::Adversarial,
+                        to: portcullis_core::IntegLevel::Untrusted,
+                    },
+                    justification: "Validated search results",
+                },
+                vec![Operation::WriteFiles, Operation::GitCommit],
+                2000, // valid_until
+                "Curated API output".to_string(),
+            )
+        }
+
+        #[test]
+        fn apply_token_verified_signed_token_succeeds() {
+            let key = test_key();
+            let (mut g, web) = make_graph_with_web_node();
+            let mut token = make_token_for(web);
+
+            crate::token_sign::sign_token(&mut token, &key);
+            assert!(token.is_signed());
+
+            let pk = key.public_key().as_ref();
+            let result = g.apply_token_verified(&token, &[pk], 1000);
+
+            match result {
+                TokenApplyResult::Applied {
+                    original_label,
+                    new_label,
+                } => {
+                    assert_eq!(
+                        original_label.integrity,
+                        portcullis_core::IntegLevel::Adversarial
+                    );
+                    assert_eq!(new_label.integrity, portcullis_core::IntegLevel::Untrusted);
+                }
+                other => panic!("Expected Applied, got {other:?}"),
+            }
+
+            // Verify the graph node was actually modified
+            assert_eq!(
+                g.get(web).unwrap().label.integrity,
+                portcullis_core::IntegLevel::Untrusted
+            );
+        }
+
+        #[test]
+        fn apply_token_verified_tampered_signature_rejected() {
+            let key = test_key();
+            let (mut g, web) = make_graph_with_web_node();
+            let mut token = make_token_for(web);
+
+            crate::token_sign::sign_token(&mut token, &key);
+
+            // Tamper: change the target node ID after signing
+            token.target_node_id = web; // keep same so node exists, but tamper justification
+            token.justification = "malicious override".to_string();
+
+            let pk = key.public_key().as_ref();
+            let result = g.apply_token_verified(&token, &[pk], 1000);
+            assert_eq!(result, TokenApplyResult::InvalidSignature);
+
+            // Verify the graph node was NOT modified
+            assert_eq!(
+                g.get(web).unwrap().label.integrity,
+                portcullis_core::IntegLevel::Adversarial
+            );
+        }
+
+        #[test]
+        fn apply_token_verified_unsigned_token_rejected() {
+            let key = test_key();
+            let (mut g, web) = make_graph_with_web_node();
+            let token = make_token_for(web); // unsigned
+
+            assert!(!token.is_signed());
+
+            let pk = key.public_key().as_ref();
+            let result = g.apply_token_verified(&token, &[pk], 1000);
+            assert_eq!(result, TokenApplyResult::InvalidSignature);
+
+            // Verify the graph node was NOT modified
+            assert_eq!(
+                g.get(web).unwrap().label.integrity,
+                portcullis_core::IntegLevel::Adversarial
+            );
+        }
+
+        #[test]
+        fn apply_token_verified_wrong_key_rejected() {
+            let sign_key = test_key();
+            let wrong_key = test_key();
+            let (mut g, web) = make_graph_with_web_node();
+            let mut token = make_token_for(web);
+
+            crate::token_sign::sign_token(&mut token, &sign_key);
+
+            let wrong_pk = wrong_key.public_key().as_ref();
+            let result = g.apply_token_verified(&token, &[wrong_pk], 1000);
+            assert_eq!(result, TokenApplyResult::InvalidSignature);
+        }
+
+        #[test]
+        fn apply_token_verified_with_key_rotation() {
+            let old_key = test_key();
+            let new_key = test_key();
+            let (mut g, web) = make_graph_with_web_node();
+            let mut token = make_token_for(web);
+
+            // Sign with old key
+            crate::token_sign::sign_token(&mut token, &old_key);
+
+            // Verify with both keys (rotation scenario)
+            let old_pk = old_key.public_key().as_ref();
+            let new_pk = new_key.public_key().as_ref();
+            let result = g.apply_token_verified(&token, &[new_pk, old_pk], 1000);
+
+            assert!(
+                matches!(result, TokenApplyResult::Applied { .. }),
+                "Should accept token signed by rotated-out key: {result:?}"
+            );
+        }
+
+        #[test]
+        fn apply_token_verified_expired_after_sig_check() {
+            let key = test_key();
+            let (mut g, web) = make_graph_with_web_node();
+            let mut token = make_token_for(web);
+            token.valid_until = 500; // expired
+
+            // Re-sign with the updated valid_until
+            crate::token_sign::sign_token(&mut token, &key);
+
+            let pk = key.public_key().as_ref();
+            let result = g.apply_token_verified(&token, &[pk], 1000);
+
+            // Signature is valid, but token is expired
+            assert!(
+                matches!(result, TokenApplyResult::Expired { .. }),
+                "Expected Expired after valid signature, got {result:?}"
+            );
         }
     }
 }

--- a/crates/portcullis/src/lib.rs
+++ b/crates/portcullis/src/lib.rs
@@ -157,6 +157,9 @@ pub mod receipt_sign;
 pub mod s3_audit_backend;
 #[cfg(feature = "crypto")]
 pub mod token;
+#[cfg(feature = "crypto")]
+/// Ed25519 signing and verification for declassification tokens.
+pub mod token_sign;
 /// MCP tool schema pinning: rug-pull detection for MCP servers.
 ///
 /// Stores SHA-256 hashes of approved tool schemas and detects silent

--- a/crates/portcullis/src/token_sign.rs
+++ b/crates/portcullis/src/token_sign.rs
@@ -1,0 +1,258 @@
+//! Ed25519 signing and verification for declassification tokens.
+//!
+//! Declassification tokens permit controlled label downgrading on specific
+//! flow graph nodes. Without cryptographic verification, any code that can
+//! construct a `DeclassificationToken` can declassify arbitrary nodes.
+//!
+//! This module provides:
+//! - `sign_token()` — signs a token's canonical bytes with an Ed25519 key
+//! - `verify_token()` — verifies the signature against a trusted public key
+//!
+//! The signing/verification follows the same pattern as `receipt_sign.rs`.
+
+#[cfg(feature = "crypto")]
+use ring::signature::{self, Ed25519KeyPair, UnparsedPublicKey};
+
+use portcullis_core::declassify::DeclassificationToken;
+use portcullis_core::receipt::SignatureError;
+
+/// Sign a declassification token with an Ed25519 key.
+///
+/// Mutates the token's signature field in place. The signature covers
+/// all security-relevant fields via `canonical_bytes()`.
+#[cfg(feature = "crypto")]
+pub fn sign_token(token: &mut DeclassificationToken, signing_key: &Ed25519KeyPair) {
+    let content = token.canonical_bytes();
+    let sig = signing_key.sign(&content);
+    let sig_bytes: [u8; 64] = sig
+        .as_ref()
+        .try_into()
+        .expect("Ed25519 signature is 64 bytes");
+    token.set_signature(sig_bytes);
+}
+
+/// Verify a declassification token's Ed25519 signature against a public key.
+///
+/// Returns `Ok(())` if the signature is valid, or an appropriate error.
+#[cfg(feature = "crypto")]
+pub fn verify_token(
+    token: &DeclassificationToken,
+    public_key_bytes: &[u8],
+) -> Result<(), SignatureError> {
+    if !token.is_signed() {
+        return Err(SignatureError::Unsigned);
+    }
+
+    let content = token.canonical_bytes();
+    let public_key = UnparsedPublicKey::new(&signature::ED25519, public_key_bytes);
+
+    public_key
+        .verify(&content, &token.signature)
+        .map_err(|_| SignatureError::InvalidSignature)
+}
+
+/// Verify a declassification token against a set of trusted public keys.
+///
+/// Returns `Ok(())` if the signature verifies against ANY of the trusted keys.
+/// This supports key rotation: callers can provide both the current and
+/// previous public keys.
+///
+/// Returns `Err(SignatureError::Unsigned)` if the token has no signature.
+/// Returns `Err(SignatureError::InvalidSignature)` if no key matches.
+#[cfg(feature = "crypto")]
+pub fn verify_token_any_key(
+    token: &DeclassificationToken,
+    trusted_keys: &[&[u8]],
+) -> Result<(), SignatureError> {
+    if !token.is_signed() {
+        return Err(SignatureError::Unsigned);
+    }
+    if trusted_keys.is_empty() {
+        return Err(SignatureError::InvalidSignature);
+    }
+    for key in trusted_keys {
+        if verify_token(token, key).is_ok() {
+            return Ok(());
+        }
+    }
+    Err(SignatureError::InvalidSignature)
+}
+
+#[cfg(test)]
+#[cfg(feature = "crypto")]
+mod tests {
+    use super::*;
+    use portcullis_core::declassify::{DeclassificationRule, DeclassifyAction};
+    use portcullis_core::{IntegLevel, Operation};
+    use ring::rand::SystemRandom;
+    use ring::signature::KeyPair;
+
+    fn test_key() -> Ed25519KeyPair {
+        let rng = SystemRandom::new();
+        let pkcs8 = Ed25519KeyPair::generate_pkcs8(&rng).unwrap();
+        Ed25519KeyPair::from_pkcs8(pkcs8.as_ref()).unwrap()
+    }
+
+    fn make_token() -> DeclassificationToken {
+        DeclassificationToken::new(
+            42,
+            DeclassificationRule {
+                action: DeclassifyAction::RaiseIntegrity {
+                    from: IntegLevel::Adversarial,
+                    to: IntegLevel::Untrusted,
+                },
+                justification: "Validated search results",
+            },
+            vec![Operation::WriteFiles, Operation::GitCommit],
+            u64::MAX,
+            "Curated API output".to_string(),
+        )
+    }
+
+    #[test]
+    fn sign_and_verify_roundtrip() {
+        let key = test_key();
+        let mut token = make_token();
+
+        assert!(!token.is_signed());
+        sign_token(&mut token, &key);
+        assert!(token.is_signed());
+
+        let public_key = key.public_key().as_ref();
+        assert!(verify_token(&token, public_key).is_ok());
+    }
+
+    #[test]
+    fn verify_rejects_unsigned() {
+        let key = test_key();
+        let token = make_token();
+
+        assert!(!token.is_signed());
+        let public_key = key.public_key().as_ref();
+        assert_eq!(
+            verify_token(&token, public_key),
+            Err(SignatureError::Unsigned)
+        );
+    }
+
+    #[test]
+    fn verify_rejects_wrong_key() {
+        let sign_key = test_key();
+        let wrong_key = test_key();
+        let mut token = make_token();
+
+        sign_token(&mut token, &sign_key);
+
+        let wrong_public = wrong_key.public_key().as_ref();
+        assert_eq!(
+            verify_token(&token, wrong_public),
+            Err(SignatureError::InvalidSignature)
+        );
+    }
+
+    #[test]
+    fn tampered_token_rejected() {
+        let key = test_key();
+        let mut token = make_token();
+        sign_token(&mut token, &key);
+
+        // Tamper: change the target node ID
+        token.target_node_id = 999;
+
+        let public_key = key.public_key().as_ref();
+        assert_eq!(
+            verify_token(&token, public_key),
+            Err(SignatureError::InvalidSignature),
+            "Tampering with target_node_id must invalidate signature"
+        );
+    }
+
+    #[test]
+    fn tampered_justification_rejected() {
+        let key = test_key();
+        let mut token = make_token();
+        sign_token(&mut token, &key);
+
+        // Tamper: change the justification
+        token.justification = "malicious override".to_string();
+
+        let public_key = key.public_key().as_ref();
+        assert_eq!(
+            verify_token(&token, public_key),
+            Err(SignatureError::InvalidSignature),
+            "Tampering with justification must invalidate signature"
+        );
+    }
+
+    #[test]
+    fn tampered_valid_until_rejected() {
+        let key = test_key();
+        let mut token = make_token();
+        sign_token(&mut token, &key);
+
+        // Tamper: change validity
+        token.valid_until = 1;
+
+        let public_key = key.public_key().as_ref();
+        assert_eq!(
+            verify_token(&token, public_key),
+            Err(SignatureError::InvalidSignature),
+            "Tampering with valid_until must invalidate signature"
+        );
+    }
+
+    #[test]
+    fn verify_any_key_accepts_correct() {
+        let key1 = test_key();
+        let key2 = test_key();
+        let mut token = make_token();
+        sign_token(&mut token, &key1);
+
+        let pk1 = key1.public_key().as_ref();
+        let pk2 = key2.public_key().as_ref();
+
+        // Verify against a set containing the correct key
+        assert!(verify_token_any_key(&token, &[pk2, pk1]).is_ok());
+    }
+
+    #[test]
+    fn verify_any_key_rejects_none_matching() {
+        let sign_key = test_key();
+        let wrong1 = test_key();
+        let wrong2 = test_key();
+        let mut token = make_token();
+        sign_token(&mut token, &sign_key);
+
+        let wpk1 = wrong1.public_key().as_ref();
+        let wpk2 = wrong2.public_key().as_ref();
+
+        assert_eq!(
+            verify_token_any_key(&token, &[wpk1, wpk2]),
+            Err(SignatureError::InvalidSignature)
+        );
+    }
+
+    #[test]
+    fn verify_any_key_rejects_empty_keys() {
+        let key = test_key();
+        let mut token = make_token();
+        sign_token(&mut token, &key);
+
+        assert_eq!(
+            verify_token_any_key(&token, &[]),
+            Err(SignatureError::InvalidSignature)
+        );
+    }
+
+    #[test]
+    fn verify_any_key_rejects_unsigned() {
+        let token = make_token();
+        let key = test_key();
+        let pk = key.public_key().as_ref();
+
+        assert_eq!(
+            verify_token_any_key(&token, &[pk]),
+            Err(SignatureError::Unsigned)
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- **Security fix**: `DeclassificationToken` signatures were never verified -- any code that could construct a token could declassify arbitrary flow graph nodes without cryptographic authorization
- Adds `token_sign` module (`sign_token`, `verify_token`, `verify_token_any_key`) following the same pattern as `receipt_sign.rs`
- Adds `FlowGraph::apply_token_verified()` that checks Ed25519 signature against trusted public keys before applying declassification
- Existing `apply_token()` is unchanged (backward compat); documented with security warning pointing to the verified path

## Changes

| File | Change |
|------|--------|
| `portcullis-core/src/declassify.rs` | `InvalidSignature` variant, `is_signed()`, `set_signature()` |
| `portcullis/src/token_sign.rs` | New module: sign/verify/verify-any-key with key rotation support |
| `portcullis/src/flow_graph.rs` | `apply_token_verified()` + 6 integration tests |
| `portcullis/src/lib.rs` | Feature-gated `token_sign` module declaration |

## Test plan

- [x] `cargo test -p portcullis --lib -- token_sign` (10 tests: roundtrip, unsigned rejected, wrong key, tampered fields, key rotation)
- [x] `cargo test -p portcullis --lib -- flow_graph::tests::apply_token` (10 tests: 4 existing + 6 new verified-path tests)
- [x] Clippy clean, all pre-commit and pre-push hooks pass

Closes #731

🤖 Generated with [Claude Code](https://claude.com/claude-code)