### PR TITLE
fix: implement FlowReceipt signature verification (#732)

### DIFF
--- a/crates/portcullis-core/examples/flow_kernel_demo.rs
+++ b/crates/portcullis-core/examples/flow_kernel_demo.rs
@@ -130,17 +130,15 @@ fn main() {
     println!("╚══════════════════════════════════════════════════════════════╝");
     println!("{}", receipt.display_chain());
 
-    // Verify signature (should fail — unsigned)
-    match verify_signature(&receipt) {
-        Ok(()) => println!("  Signature: ✅ verified"),
+    // Verify signature (should fail — unsigned in this demo)
+    // In production, use portcullis::verify_receipt() with Ed25519 keys.
+    match verify_signature(&receipt, |_content, _sig| false) {
+        Ok(()) => println!("  Signature: verified"),
         Err(SignatureError::Unsigned) => {
-            println!("  Signature: ⚠ unsigned (Ed25519 signing not yet wired in)")
-        }
-        Err(SignatureError::VerificationNotImplemented) => {
-            println!("  Signature: ❌ verification not implemented")
+            println!("  Signature: unsigned (use portcullis::sign_receipt to sign)")
         }
         Err(SignatureError::InvalidSignature) => {
-            println!("  Signature: ❌ invalid (tampered or wrong key)")
+            println!("  Signature: invalid (tampered or wrong key)")
         }
     }
 

--- a/crates/portcullis-core/src/receipt.rs
+++ b/crates/portcullis-core/src/receipt.rs
@@ -5,18 +5,20 @@
 //! - The labeled observations that were causally sufficient
 //! - Which policy rule fired (for blocks)
 //!
-//! ## Honest status
+//! ## Signing and verification
 //!
-//! Types and construction only. **Unsigned** — real Ed25519 signing
-//! requires the `ed25519-dalek` crate (in `portcullis`, not here).
-//! Not yet wired into `Kernel::decide()` or `check_flow()`.
+//! Receipts are unsigned at construction time. The `portcullis` crate
+//! provides `sign_receipt()` and `verify_receipt()` using Ed25519 via
+//! `ring` (behind the `crypto` feature).
+//!
+//! This core crate provides `verify_signature()` which accepts a
+//! caller-provided verifier function, keeping `portcullis-core`
+//! dependency-free for Aeneas verification.
 //!
 //! ## Trust model
 //!
 //! Receipts are constructed by `build_receipt()` from trusted inputs
 //! (the flow graph). They are NOT tamper-proof without signing.
-//! The `verify_signature()` stub always returns `Err(Unsigned)` to
-//! force callers to handle the unsigned case explicitly.
 //!
 //! The causal ancestors are assembled by the caller from the flow
 //! graph — there is no binding between the receipt and the graph.
@@ -35,8 +37,9 @@ pub const MAX_RECEIPT_ANCESTORS: usize = 16;
 
 /// A flow receipt — evidence of a flow decision.
 ///
-/// **NOT signed.** The `signature` field is a placeholder. Use
-/// `verify_signature()` which currently always returns `Err(Unsigned)`.
+/// Unsigned at construction. Use `portcullis::receipt_sign::sign_receipt()`
+/// to sign, and `portcullis::receipt_sign::verify_receipt()` or
+/// `verify_signature()` with a custom verifier to verify.
 ///
 /// Fields are `pub(crate)` to prevent external forgery. Use
 /// `build_receipt()` to construct.
@@ -168,7 +171,61 @@ pub fn build_receipt(
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// Signature verification (stub)
+// Canonical content bytes (for signing/verification)
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Serialize receipt content to canonical bytes for signing/verification.
+///
+/// The canonical form includes all security-relevant fields in a
+/// deterministic order. Changes to any field invalidate the signature.
+///
+/// This is the same byte sequence signed by `sign_receipt()` in the
+/// `portcullis` crate. Verifiers must reconstruct this to check signatures.
+pub fn receipt_canonical_bytes(receipt: &FlowReceipt) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(256);
+
+    // Version tag
+    buf.extend_from_slice(b"nucleus-receipt-v3\n");
+
+    // Chain ID — binds this receipt to a specific session (#492).
+    buf.extend_from_slice(receipt.chain_id());
+
+    // Chain link — hash of the previous receipt.
+    buf.extend_from_slice(receipt.prev_hash());
+
+    // Action node
+    append_receipt_node_bytes(&mut buf, receipt.action());
+
+    // Verdict + rule
+    buf.extend_from_slice(format!("verdict:{:?}\n", receipt.verdict()).as_bytes());
+    buf.extend_from_slice(format!("rule:{}\n", receipt.rule_name()).as_bytes());
+
+    // Timestamp
+    buf.extend_from_slice(&receipt.created_at().to_le_bytes());
+
+    // Ancestors (ordered — receipt construction preserves BFS order)
+    buf.extend_from_slice(&(receipt.ancestors().len() as u32).to_le_bytes());
+    for ancestor in receipt.ancestors() {
+        append_receipt_node_bytes(&mut buf, ancestor);
+    }
+
+    buf
+}
+
+/// Serialize a receipt node to canonical bytes.
+fn append_receipt_node_bytes(buf: &mut Vec<u8>, node: &ReceiptNode) {
+    buf.extend_from_slice(&node.id.to_le_bytes());
+    buf.extend_from_slice(&(node.kind as u8).to_le_bytes());
+    buf.extend_from_slice(&(node.label.confidentiality as u8).to_le_bytes());
+    buf.extend_from_slice(&(node.label.integrity as u8).to_le_bytes());
+    buf.extend_from_slice(&(node.label.authority as u8).to_le_bytes());
+    buf.extend_from_slice(&node.label.provenance.bits().to_le_bytes());
+    buf.extend_from_slice(&node.label.freshness.observed_at.to_le_bytes());
+    buf.extend_from_slice(&node.label.freshness.ttl_secs.to_le_bytes());
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Signature verification
 // ═══════════════════════════════════════════════════════════════════════════
 
 /// Signature verification errors.
@@ -176,22 +233,36 @@ pub fn build_receipt(
 pub enum SignatureError {
     /// Receipt has not been signed (signature is all zeros).
     Unsigned,
-    /// Signature verification not yet implemented.
-    VerificationNotImplemented,
     /// Ed25519 signature is invalid (wrong key or tampered content).
     InvalidSignature,
 }
 
-/// Verify the receipt's signature.
+/// Verify a receipt's signature using a caller-provided verification function.
 ///
-/// **Currently always returns `Err`.** This forces callers to handle
-/// the unsigned case explicitly rather than silently trusting receipts.
-/// Real Ed25519 verification will be added in the `portcullis` crate.
-pub fn verify_signature(_receipt: &FlowReceipt) -> Result<(), SignatureError> {
-    if _receipt.signature == [0; 64] {
+/// The `verifier` receives `(canonical_content_bytes, signature_bytes)` and
+/// returns `true` if the signature is valid.
+///
+/// This design allows `portcullis-core` to remain dependency-free (no `ring`)
+/// while still providing signature verification. The `portcullis` crate
+/// provides `verify_receipt()` which wraps this with Ed25519 via `ring`.
+///
+/// Returns `Ok(())` if the signature is valid, `Err(Unsigned)` if the
+/// receipt has no signature, or `Err(InvalidSignature)` if the verifier
+/// rejects the signature.
+pub fn verify_signature(
+    receipt: &FlowReceipt,
+    verifier: impl FnOnce(&[u8], &[u8; 64]) -> bool,
+) -> Result<(), SignatureError> {
+    if !receipt.is_signed() {
         return Err(SignatureError::Unsigned);
     }
-    Err(SignatureError::VerificationNotImplemented)
+
+    let content = receipt_canonical_bytes(receipt);
+    if verifier(&content, receipt.signature_bytes()) {
+        Ok(())
+    } else {
+        Err(SignatureError::InvalidSignature)
+    }
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -360,8 +431,50 @@ mod tests {
         );
         let receipt = build_receipt(&action, &[], FlowVerdict::Allow, 2000);
 
-        assert_eq!(verify_signature(&receipt), Err(SignatureError::Unsigned));
+        // Any verifier should not be called — Unsigned is returned first
+        assert_eq!(
+            verify_signature(&receipt, |_, _| panic!("should not be called")),
+            Err(SignatureError::Unsigned)
+        );
         assert!(!receipt.is_signed());
+    }
+
+    #[test]
+    fn verify_signature_with_verifier_ok() {
+        let label = IFCLabel::user_prompt(1000);
+        let action = make_node(
+            1,
+            NodeKind::OutboundAction,
+            label,
+            Some(Operation::WriteFiles),
+        );
+        let mut receipt = build_receipt(&action, &[], FlowVerdict::Allow, 2000);
+        // Fake a non-zero signature so is_signed() returns true
+        receipt.set_signature([0xAA; 64]);
+
+        // Verifier that accepts
+        assert_eq!(verify_signature(&receipt, |_, _| true), Ok(()));
+        // Verifier that rejects
+        assert_eq!(
+            verify_signature(&receipt, |_, _| false),
+            Err(SignatureError::InvalidSignature)
+        );
+    }
+
+    #[test]
+    fn canonical_bytes_deterministic() {
+        let label = IFCLabel::user_prompt(1000);
+        let action = make_node(
+            1,
+            NodeKind::OutboundAction,
+            label,
+            Some(Operation::WriteFiles),
+        );
+        let receipt = build_receipt(&action, &[], FlowVerdict::Allow, 2000);
+        let bytes1 = receipt_canonical_bytes(&receipt);
+        let bytes2 = receipt_canonical_bytes(&receipt);
+        assert_eq!(bytes1, bytes2);
+        assert!(!bytes1.is_empty());
     }
 
     #[test]

--- a/crates/portcullis/src/lib.rs
+++ b/crates/portcullis/src/lib.rs
@@ -153,6 +153,8 @@ pub mod profile;
 pub mod receipt_chain;
 #[cfg(feature = "crypto")]
 pub mod receipt_sign;
+#[cfg(feature = "crypto")]
+pub use receipt_sign::{receipt_hash, sign_receipt, verify_receipt};
 #[cfg(feature = "remote-audit")]
 pub mod s3_audit_backend;
 #[cfg(feature = "crypto")]

--- a/crates/portcullis/src/receipt_sign.rs
+++ b/crates/portcullis/src/receipt_sign.rs
@@ -10,53 +10,14 @@
 #[cfg(feature = "crypto")]
 use ring::signature::{self, Ed25519KeyPair, UnparsedPublicKey};
 
-use portcullis_core::receipt::{FlowReceipt, ReceiptNode, SignatureError};
+use portcullis_core::receipt::{receipt_canonical_bytes, FlowReceipt, SignatureError};
 
 /// Serialize receipt content to canonical bytes for signing.
 ///
-/// The canonical form includes all security-relevant fields in a
-/// deterministic order. Changes to any field invalidate the signature.
+/// Delegates to `portcullis_core::receipt::receipt_canonical_bytes()` —
+/// the single source of truth for the canonical byte representation.
 fn receipt_content_bytes(receipt: &FlowReceipt) -> Vec<u8> {
-    let mut buf = Vec::with_capacity(256);
-
-    // Version tag
-    buf.extend_from_slice(b"nucleus-receipt-v3\n");
-
-    // Chain ID — binds this receipt to a specific session (#492).
-    // Prevents cross-session receipt injection.
-    buf.extend_from_slice(receipt.chain_id());
-
-    // Chain link — hash of the previous receipt.
-    buf.extend_from_slice(receipt.prev_hash());
-
-    // Action node
-    append_receipt_node(&mut buf, receipt.action());
-
-    // Verdict + rule
-    buf.extend_from_slice(format!("verdict:{:?}\n", receipt.verdict()).as_bytes());
-    buf.extend_from_slice(format!("rule:{}\n", receipt.rule_name()).as_bytes());
-
-    // Timestamp
-    buf.extend_from_slice(&receipt.created_at().to_le_bytes());
-
-    // Ancestors (ordered — receipt construction preserves BFS order)
-    buf.extend_from_slice(&(receipt.ancestors().len() as u32).to_le_bytes());
-    for ancestor in receipt.ancestors() {
-        append_receipt_node(&mut buf, ancestor);
-    }
-
-    buf
-}
-
-fn append_receipt_node(buf: &mut Vec<u8>, node: &ReceiptNode) {
-    buf.extend_from_slice(&node.id.to_le_bytes());
-    buf.extend_from_slice(&(node.kind as u8).to_le_bytes());
-    buf.extend_from_slice(&(node.label.confidentiality as u8).to_le_bytes());
-    buf.extend_from_slice(&(node.label.integrity as u8).to_le_bytes());
-    buf.extend_from_slice(&(node.label.authority as u8).to_le_bytes());
-    buf.extend_from_slice(&node.label.provenance.bits().to_le_bytes());
-    buf.extend_from_slice(&node.label.freshness.observed_at.to_le_bytes());
-    buf.extend_from_slice(&node.label.freshness.ttl_secs.to_le_bytes());
+    receipt_canonical_bytes(receipt)
 }
 
 /// Compute the SHA-256 hash of a receipt's canonical content + signature.
@@ -353,6 +314,55 @@ mod tests {
             verify_receipt(&tampered, pk),
             Err(SignatureError::InvalidSignature),
             "Tampering with prev_hash must invalidate signature"
+        );
+    }
+
+    #[test]
+    fn verify_rejects_forged_signature() {
+        let key = test_key();
+        let label = IFCLabel::user_prompt(1000);
+        let action = make_node(
+            1,
+            NodeKind::OutboundAction,
+            label,
+            Some(Operation::WriteFiles),
+        );
+        let mut receipt = build_receipt(&action, &[], FlowVerdict::Allow, 2000);
+
+        // Set a fake signature (non-zero but not valid Ed25519)
+        receipt.set_signature([0xDE; 64]);
+        assert!(receipt.is_signed());
+
+        let pk = key.public_key().as_ref();
+        assert_eq!(
+            verify_receipt(&receipt, pk),
+            Err(SignatureError::InvalidSignature),
+            "Forged signature bytes must be rejected"
+        );
+    }
+
+    #[test]
+    fn verify_rejects_tampered_chain_id() {
+        let key = test_key();
+        let label = IFCLabel::user_prompt(1000);
+        let action = make_node(
+            1,
+            NodeKind::OutboundAction,
+            label,
+            Some(Operation::WriteFiles),
+        );
+        let mut receipt = build_receipt(&action, &[], FlowVerdict::Allow, 2000);
+        receipt.set_chain_id([0x42; 32]);
+        sign_receipt(&mut receipt, &key);
+
+        // Tamper with chain_id after signing
+        let mut tampered = receipt.clone();
+        tampered.set_chain_id([0xFF; 32]);
+        let pk = key.public_key().as_ref();
+        assert_eq!(
+            verify_receipt(&tampered, pk),
+            Err(SignatureError::InvalidSignature),
+            "Tampering with chain_id must invalidate signature"
         );
     }
 }


### PR DESCRIPTION
## Summary

- Replaced the permanent `verify_signature()` stub that always returned `Err(VerificationNotImplemented)` with a working callback-based implementation
- Moved canonical byte serialization to `portcullis-core` as `receipt_canonical_bytes()` (single source of truth, eliminates duplication between core and portcullis)
- Re-exported `sign_receipt`, `verify_receipt`, `receipt_hash` from the `portcullis` crate's public API
- Removed the `VerificationNotImplemented` variant from `SignatureError`

## Design

`portcullis-core` must remain dependency-free for Aeneas verification, so it cannot use `ring` directly. The solution: `verify_signature()` now accepts a `verifier: impl FnOnce(&[u8], &[u8; 64]) -> bool` callback. The `portcullis` crate's `verify_receipt()` provides the concrete Ed25519 implementation via `ring`.

## Test plan

- [x] `verify_signature_rejects_unsigned` - unsigned receipts return `Err(Unsigned)` without calling verifier
- [x] `verify_signature_with_verifier_ok` - accepts/rejects based on verifier callback
- [x] `canonical_bytes_deterministic` - same receipt produces identical bytes
- [x] `verify_rejects_forged_signature` - fabricated signature bytes rejected
- [x] `verify_rejects_tampered_chain_id` - post-signing chain_id mutation detected
- [x] All 27 existing receipt tests pass (sign/verify roundtrip, wrong key, tampered prev_hash, hash chain integrity)
- [x] Full workspace `cargo check` clean
- [x] All pre-commit hooks pass (fmt, clippy, deny, audit, tests)

Closes #732

Generated with [Claude Code](https://claude.com/claude-code)