### PR TITLE
feat: DPI formal invariant proofs — Kani + Lean (#719, #721)

### DIFF
--- a/.github/workflows/aeneas.yml
+++ b/.github/workflows/aeneas.yml
@@ -144,11 +144,12 @@ jobs:
           lake build FlowGraphProofs
           lake build CompartmentProofs
           lake build DelegationProofs
+          lake build DerivationProofs
 
       - name: Reject sorry (proof holes)
         working-directory: crates/portcullis-core/lean
         run: |
-          if grep -rn 'sorry' PortcullisCoreBridge.lean ExposureProofs.lean DecidePureProofs.lean DeclassifyProofs.lean FlowProofs.lean FlowGraphProofs.lean CompartmentProofs.lean DelegationProofs.lean generated/PortcullisCore/FunsExternal.lean generated/PortcullisCore/CoreFuns.lean; then
+          if grep -rn 'sorry' PortcullisCoreBridge.lean ExposureProofs.lean DecidePureProofs.lean DeclassifyProofs.lean FlowProofs.lean FlowGraphProofs.lean CompartmentProofs.lean DelegationProofs.lean DerivationProofs.lean generated/PortcullisCore/FunsExternal.lean generated/PortcullisCore/CoreFuns.lean; then
             echo "ERROR: Lean proofs contain 'sorry' — proof has holes."
             exit 1
           fi

--- a/.github/workflows/lean-build.yml
+++ b/.github/workflows/lean-build.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Reject sorry (proof holes)
         working-directory: crates/portcullis-core/lean
         run: |
-          if grep -rn 'sorry' PortcullisCoreBridge.lean generated/PortcullisCore/ --include='*.lean'; then
+          if grep -rn 'sorry' PortcullisCoreBridge.lean DerivationProofs.lean generated/PortcullisCore/ --include='*.lean'; then
             echo "ERROR: Lean proofs contain 'sorry' — proof has holes."
             exit 1
           fi

--- a/crates/portcullis-core/lean/DerivationProofs.lean
+++ b/crates/portcullis-core/lean/DerivationProofs.lean
@@ -1,0 +1,213 @@
+/-!
+# DerivationClass Lattice Proofs — DPI Formal Invariants
+
+Proves that the DerivationClass diamond lattice satisfies the Data
+Provenance Integrity (DPI) invariants:
+
+1. **No silent cleansing**: `join(AIDerived, x) != Deterministic` for all x
+2. **Monotone join**: `taint_level(join(a, b)) >= max(taint_level(a), taint_level(b))`
+
+## Model correspondence
+
+These types are HAND-WRITTEN Lean models mirroring the Rust source in
+`portcullis-core/src/lib.rs`. The diamond lattice:
+
+```text
+      OpaqueExternal  (top)
+           |
+         Mixed
+        /     \
+  AIDerived  HumanPromoted
+        \     /
+      Deterministic  (bottom)
+```
+
+## Key theorems
+
+- **join_comm**: join is commutative
+- **join_assoc**: join is associative
+- **join_idempotent**: join is idempotent
+- **no_silent_cleansing**: AIDerived.join(x) != Deterministic for all x
+- **join_monotone**: join result >= both inputs in taint ordering
+
+All proofs discharge via `decide` over finite types. No sorry, no SMT.
+-/
+
+namespace DerivationProofs
+
+-- ═══════════════════════════════════════════════════════════════════════
+-- DerivationClass (mirroring portcullis-core/src/lib.rs)
+-- ═══════════════════════════════════════════════════════════════════════
+
+inductive DerivationClass where
+  | Deterministic
+  | AIDerived
+  | Mixed
+  | HumanPromoted
+  | OpaqueExternal
+deriving DecidableEq, Repr
+
+-- ═══════════════════════════════════════════════════════════════════════
+-- Join — least upper bound in the diamond lattice
+-- ═══════════════════════════════════════════════════════════════════════
+
+/-- Join (least upper bound) matching the Rust implementation exactly.
+    Deterministic is bottom, OpaqueExternal is top, incomparable elements
+    (AIDerived, HumanPromoted) join to Mixed. -/
+def DerivationClass.join (a b : DerivationClass) : DerivationClass :=
+  match a, b with
+  -- Deterministic is bottom — identity for join
+  | .Deterministic, x => x
+  | x, .Deterministic => x
+  -- OpaqueExternal is top — absorbs everything
+  | .OpaqueExternal, _ => .OpaqueExternal
+  | _, .OpaqueExternal => .OpaqueExternal
+  -- Same class: idempotent
+  | .AIDerived, .AIDerived => .AIDerived
+  | .HumanPromoted, .HumanPromoted => .HumanPromoted
+  | .Mixed, .Mixed => .Mixed
+  -- Different non-bottom, non-top classes -> Mixed
+  | _, _ => .Mixed
+
+-- ═══════════════════════════════════════════════════════════════════════
+-- Taint level — height in the Hasse diagram
+-- ═══════════════════════════════════════════════════════════════════════
+
+/-- Map each variant to its height in the Hasse diagram.
+    Deterministic = 0, AIDerived = HumanPromoted = 1, Mixed = 2, OpaqueExternal = 3. -/
+def DerivationClass.taintLevel : DerivationClass → Nat
+  | .Deterministic => 0
+  | .AIDerived => 1
+  | .HumanPromoted => 1
+  | .Mixed => 2
+  | .OpaqueExternal => 3
+
+-- ═══════════════════════════════════════════════════════════════════════
+-- Lattice algebraic properties
+-- ═══════════════════════════════════════════════════════════════════════
+
+/-- Join is commutative: a join b = b join a. -/
+theorem join_comm (a b : DerivationClass) :
+    DerivationClass.join a b = DerivationClass.join b a := by
+  cases a <;> cases b <;> decide
+
+/-- Join is associative: (a join b) join c = a join (b join c). -/
+theorem join_assoc (a b c : DerivationClass) :
+    DerivationClass.join (DerivationClass.join a b) c =
+    DerivationClass.join a (DerivationClass.join b c) := by
+  cases a <;> cases b <;> cases c <;> decide
+
+/-- Join is idempotent: a join a = a. -/
+theorem join_idempotent (a : DerivationClass) :
+    DerivationClass.join a a = a := by
+  cases a <;> decide
+
+-- ═══════════════════════════════════════════════════════════════════════
+-- Bottom and top identity
+-- ═══════════════════════════════════════════════════════════════════════
+
+/-- Deterministic is the identity for join (bottom element). -/
+theorem join_deterministic_left (a : DerivationClass) :
+    DerivationClass.join .Deterministic a = a := by
+  cases a <;> decide
+
+theorem join_deterministic_right (a : DerivationClass) :
+    DerivationClass.join a .Deterministic = a := by
+  cases a <;> decide
+
+/-- OpaqueExternal absorbs everything in join (top element). -/
+theorem join_opaque_left (a : DerivationClass) :
+    DerivationClass.join .OpaqueExternal a = .OpaqueExternal := by
+  cases a <;> decide
+
+theorem join_opaque_right (a : DerivationClass) :
+    DerivationClass.join a .OpaqueExternal = .OpaqueExternal := by
+  cases a <;> decide
+
+-- ═══════════════════════════════════════════════════════════════════════
+-- DPI-1: No silent cleansing
+-- ═══════════════════════════════════════════════════════════════════════
+
+/-- **DPI Invariant #1 — No silent cleansing.**
+    AIDerived joined with ANY DerivationClass never produces Deterministic.
+    AI-generated data carries its taint irreversibly through all joins. -/
+theorem no_silent_cleansing (x : DerivationClass) :
+    DerivationClass.join .AIDerived x ≠ .Deterministic := by
+  cases x <;> decide
+
+-- ═══════════════════════════════════════════════════════════════════════
+-- DPI-2: Monotone join — joins never reduce taint level
+-- ═══════════════════════════════════════════════════════════════════════
+
+/-- **DPI Invariant #2 — Join is monotone in taint level.**
+    taint_level(join(a, b)) >= taint_level(a) for all a, b. -/
+theorem join_monotone_left (a b : DerivationClass) :
+    (DerivationClass.join a b).taintLevel ≥ a.taintLevel := by
+  cases a <;> cases b <;> decide
+
+/-- taint_level(join(a, b)) >= taint_level(b) for all a, b. -/
+theorem join_monotone_right (a b : DerivationClass) :
+    (DerivationClass.join a b).taintLevel ≥ b.taintLevel := by
+  cases a <;> cases b <;> decide
+
+/-- Combined: taint_level(join(a, b)) >= max(taint_level(a), taint_level(b)). -/
+theorem join_monotone (a b : DerivationClass) :
+    (DerivationClass.join a b).taintLevel ≥
+    max a.taintLevel b.taintLevel := by
+  cases a <;> cases b <;> decide
+
+-- ═══════════════════════════════════════════════════════════════════════
+-- Meet — greatest lower bound (dual of join)
+-- ═══════════════════════════════════════════════════════════════════════
+
+/-- Meet (greatest lower bound) matching the Rust implementation. -/
+def DerivationClass.meet (a b : DerivationClass) : DerivationClass :=
+  match a, b with
+  -- OpaqueExternal is top — identity for meet
+  | .OpaqueExternal, x => x
+  | x, .OpaqueExternal => x
+  -- Deterministic is bottom — absorber for meet
+  | .Deterministic, _ => .Deterministic
+  | _, .Deterministic => .Deterministic
+  -- Same class: idempotent
+  | .AIDerived, .AIDerived => .AIDerived
+  | .HumanPromoted, .HumanPromoted => .HumanPromoted
+  | .Mixed, .Mixed => .Mixed
+  -- Mixed meets AIDerived or HumanPromoted = the lower element
+  | .Mixed, x => x
+  | x, .Mixed => x
+  -- AIDerived meets HumanPromoted = Deterministic (their GLB)
+  | .AIDerived, .HumanPromoted => .Deterministic
+  | .HumanPromoted, .AIDerived => .Deterministic
+
+/-- Meet is commutative. -/
+theorem meet_comm (a b : DerivationClass) :
+    DerivationClass.meet a b = DerivationClass.meet b a := by
+  cases a <;> cases b <;> decide
+
+/-- Meet is associative. -/
+theorem meet_assoc (a b c : DerivationClass) :
+    DerivationClass.meet (DerivationClass.meet a b) c =
+    DerivationClass.meet a (DerivationClass.meet b c) := by
+  cases a <;> cases b <;> cases c <;> decide
+
+/-- Meet is idempotent. -/
+theorem meet_idempotent (a : DerivationClass) :
+    DerivationClass.meet a a = a := by
+  cases a <;> decide
+
+-- ═══════════════════════════════════════════════════════════════════════
+-- Absorption laws — confirms join/meet form a lattice
+-- ═══════════════════════════════════════════════════════════════════════
+
+/-- Absorption: a join (a meet b) = a. -/
+theorem absorption_join_meet (a b : DerivationClass) :
+    DerivationClass.join a (DerivationClass.meet a b) = a := by
+  cases a <;> cases b <;> decide
+
+/-- Absorption: a meet (a join b) = a. -/
+theorem absorption_meet_join (a b : DerivationClass) :
+    DerivationClass.meet a (DerivationClass.join a b) = a := by
+  cases a <;> cases b <;> decide
+
+end DerivationProofs

--- a/crates/portcullis-core/lean/lakefile.lean
+++ b/crates/portcullis-core/lean/lakefile.lean
@@ -52,3 +52,7 @@ lean_lib «CompartmentProofs» where
 -- Delegation narrowing proofs (monotone attenuation, scope subset)
 lean_lib «DelegationProofs» where
   roots := #[`DelegationProofs]
+
+-- DerivationClass DPI invariant proofs (no silent cleansing, monotone join)
+lean_lib «DerivationProofs» where
+  roots := #[`DerivationProofs]

--- a/crates/portcullis-core/src/lib.rs
+++ b/crates/portcullis-core/src/lib.rs
@@ -1743,6 +1743,62 @@ mod kani_ifc_label_proofs {
             assert!(a.leq(b));
         }
     }
+
+    // ── DPI-1: No silent cleansing — AIDerived ⊔ x ≠ Deterministic ───
+
+    /// **DPI-1 — AIDerived can never be laundered back to Deterministic.**
+    ///
+    /// For all DerivationClass values x, `AIDerived.join(x) != Deterministic`.
+    /// This is the foundational DPI invariant: AI-generated data carries its
+    /// taint irreversibly through all join operations.
+    #[kani::proof]
+    #[kani::solver(cadical)]
+    fn proof_derivation_no_silent_cleansing() {
+        let x = any_derivation();
+        let result = DerivationClass::AIDerived.join(x);
+        assert!(result != DerivationClass::Deterministic);
+    }
+
+    // ── DPI-2: Monotone join — join never reduces taint level ─────────
+
+    /// Map DerivationClass to its height in the Hasse diagram (taint level).
+    ///
+    /// ```text
+    ///       OpaqueExternal  = 3 (top)
+    ///            |
+    ///          Mixed         = 2
+    ///         /     \
+    ///   AIDerived  HumanPromoted  = 1
+    ///         \     /
+    ///       Deterministic    = 0 (bottom)
+    /// ```
+    fn taint_level(d: DerivationClass) -> u8 {
+        match d {
+            DerivationClass::Deterministic => 0,
+            DerivationClass::AIDerived => 1,
+            DerivationClass::HumanPromoted => 1,
+            DerivationClass::Mixed => 2,
+            DerivationClass::OpaqueExternal => 3,
+        }
+    }
+
+    /// **DPI-2 — DerivationClass join is monotone in taint level.**
+    ///
+    /// For all a, b: `taint_level(join(a, b)) >= max(taint_level(a), taint_level(b))`.
+    /// Joining data can only increase (or maintain) the taint level, never reduce it.
+    #[kani::proof]
+    #[kani::solver(cadical)]
+    fn proof_derivation_join_monotone() {
+        let a = any_derivation();
+        let b = any_derivation();
+        let result = a.join(b);
+        let max_input = if taint_level(a) >= taint_level(b) {
+            taint_level(a)
+        } else {
+            taint_level(b)
+        };
+        assert!(taint_level(result) >= max_input);
+    }
 }
 
 #[cfg(test)]
@@ -2653,6 +2709,70 @@ mod tests {
                 "AIDerived.join({:?}) = Deterministic violates no-silent-cleansing",
                 other
             );
+        }
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    // DPI invariant test mirrors (non-Kani mirrors of Kani proofs)
+    // ════════════════════════════════════════════════════════════════════
+
+    /// Taint level height in the Hasse diagram (mirrors Kani taint_level).
+    fn taint_level(d: DerivationClass) -> u8 {
+        match d {
+            DerivationClass::Deterministic => 0,
+            DerivationClass::AIDerived => 1,
+            DerivationClass::HumanPromoted => 1,
+            DerivationClass::Mixed => 2,
+            DerivationClass::OpaqueExternal => 3,
+        }
+    }
+
+    #[test]
+    fn derivation_no_silent_cleansing_exhaustive() {
+        use DerivationClass::*;
+        // DPI-1: For ALL variants, AIDerived.join(x) != Deterministic
+        for &x in &[
+            Deterministic,
+            AIDerived,
+            Mixed,
+            HumanPromoted,
+            OpaqueExternal,
+        ] {
+            let result = AIDerived.join(x);
+            assert_ne!(
+                result, Deterministic,
+                "DPI-1 violated: AIDerived.join({:?}) = Deterministic",
+                x
+            );
+        }
+    }
+
+    #[test]
+    fn derivation_join_monotone_exhaustive() {
+        use DerivationClass::*;
+        // DPI-2: For ALL pairs, taint_level(join(a,b)) >= max(taint_level(a), taint_level(b))
+        let all = [
+            Deterministic,
+            AIDerived,
+            Mixed,
+            HumanPromoted,
+            OpaqueExternal,
+        ];
+        for &a in &all {
+            for &b in &all {
+                let result = a.join(b);
+                let max_input = taint_level(a).max(taint_level(b));
+                assert!(
+                    taint_level(result) >= max_input,
+                    "DPI-2 violated: taint_level({:?}.join({:?})) = {} < max({}, {}) = {}",
+                    a,
+                    b,
+                    taint_level(result),
+                    taint_level(a),
+                    taint_level(b),
+                    max_input
+                );
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- Add Kani BMC harnesses proving DerivationClass DPI invariants: no silent cleansing (AIDerived can never become Deterministic) and monotone join (taint level never decreases through joins)
- Add Lean 4 proof file (`DerivationProofs.lean`) with full lattice algebraic proofs: commutativity, associativity, idempotency, absorption, no_silent_cleansing, and join_monotone — all by `cases`+`decide`, no `sorry`
- Register DerivationProofs in `lakefile.lean` and add to CI sorry-rejection in both `aeneas.yml` and `lean-build.yml`

## Details

**Kani harnesses** (`crates/portcullis-core/src/lib.rs`):
- `proof_derivation_no_silent_cleansing`: for all `x`, `AIDerived.join(x) != Deterministic`
- `proof_derivation_join_monotone`: for all `a, b`, `taint_level(join(a,b)) >= max(taint_level(a), taint_level(b))`
- Test mirrors (`derivation_no_silent_cleansing_exhaustive`, `derivation_join_monotone_exhaustive`) for non-Kani CI

**Lean proofs** (`crates/portcullis-core/lean/DerivationProofs.lean`):
- Models the diamond lattice: Deterministic (bottom) < {AIDerived, HumanPromoted} < Mixed < OpaqueExternal (top)
- 14 theorems covering join/meet algebraic properties + DPI invariants

Closes #719, closes #721.

## Test plan

- [x] `cargo test -p portcullis-core` — all 235 tests pass (including 2 new DPI mirror tests)
- [ ] Kani verification (requires `cargo kani` — runs in CI)
- [ ] `lake build DerivationProofs` (requires Lean toolchain — runs in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)