### PR TITLE
Block skip-level compartment transitions (#733)

### DIFF
--- a/crates/nucleus-claude-hook/src/session.rs
+++ b/crates/nucleus-claude-hook/src/session.rs
@@ -443,8 +443,16 @@ pub(crate) fn resolve_compartment(
         }
     }
 
-    // Detect escalation (#464)
+    // Enforce single-step escalation (#733) and detect escalation (#464)
     if let Some(from) = current {
+        if !from.can_transition_to(target) {
+            eprintln!(
+                "nucleus: DENIED — skip-level compartment escalation {from} -> {target}. \
+                 Escalation must be single-step (e.g. research -> draft -> execute -> breakglass). \
+                 Transition one level at a time to maintain an audit trail (#733)."
+            );
+            return None;
+        }
         if portcullis_core::compartment::is_escalation(from, target) {
             eprintln!(
                 "nucleus: WARNING — compartment escalation detected: {from} -> {target}. \
@@ -851,7 +859,7 @@ mod tests {
     }
 
     #[test]
-    fn resolve_compartment_escalation_research_to_execute() {
+    fn resolve_compartment_skip_level_research_to_execute_denied() {
         let sid = format!("esc-r2e-{}", std::process::id());
         let token = "test-token-esc-r2e";
         let result = write_and_resolve(
@@ -860,10 +868,61 @@ mod tests {
             "execute",
             Some(portcullis_core::compartment::Compartment::Research),
         );
-        // Should still resolve (warning goes to stderr)
+        // Research -> Execute skips Draft — must be denied (#733)
+        assert_eq!(
+            result, None,
+            "skip-level escalation research -> execute must be denied"
+        );
+    }
+
+    #[test]
+    fn resolve_compartment_single_step_research_to_draft_allowed() {
+        let sid = format!("esc-r2d-{}", std::process::id());
+        let token = "test-token-esc-r2d";
+        let result = write_and_resolve(
+            &sid,
+            token,
+            "draft",
+            Some(portcullis_core::compartment::Compartment::Research),
+        );
         assert_eq!(
             result,
-            Some(portcullis_core::compartment::Compartment::Execute)
+            Some(portcullis_core::compartment::Compartment::Draft),
+            "single-step research -> draft should be allowed"
+        );
+    }
+
+    #[test]
+    fn resolve_compartment_single_step_draft_to_execute_allowed() {
+        let sid = format!("esc-d2e-{}", std::process::id());
+        let token = "test-token-esc-d2e";
+        let result = write_and_resolve(
+            &sid,
+            token,
+            "execute",
+            Some(portcullis_core::compartment::Compartment::Draft),
+        );
+        assert_eq!(
+            result,
+            Some(portcullis_core::compartment::Compartment::Execute),
+            "single-step draft -> execute should be allowed"
+        );
+    }
+
+    #[test]
+    fn resolve_compartment_skip_level_research_to_breakglass_denied() {
+        let sid = format!("esc-r2bg-{}", std::process::id());
+        let token = "test-token-esc-r2bg";
+        let result = write_and_resolve(
+            &sid,
+            token,
+            "breakglass:emergency",
+            Some(portcullis_core::compartment::Compartment::Research),
+        );
+        // Research -> Breakglass skips two levels — must be denied (#733)
+        assert_eq!(
+            result, None,
+            "skip-level escalation research -> breakglass must be denied"
         );
     }
 

--- a/crates/portcullis-core/src/compartment.rs
+++ b/crates/portcullis-core/src/compartment.rs
@@ -102,15 +102,21 @@ impl Compartment {
 
     /// Can the session transition from `self` to `target`?
     ///
-    /// Upward transitions (expanding capabilities) require explicit action.
-    /// Downward transitions (narrowing) are always allowed.
+    /// - Same compartment: allowed (no-op).
+    /// - Downward (narrowing capabilities): always allowed.
+    /// - Single-step upward (e.g. Research → Draft): allowed.
+    /// - Skip-level upward (e.g. Research → Execute): **denied**.
+    ///
+    /// This forces operators to escalate one level at a time, producing
+    /// an audit trail at each step. Breakglass can only be reached from
+    /// Execute, never directly from Research or Draft.
     pub fn can_transition_to(&self, target: Compartment) -> bool {
-        // All transitions are allowed — the compartment system is
-        // policy-enforced, not lattice-enforced. The audit trail
-        // records every transition for compliance review.
-        // Future: require approval for upward transitions.
-        let _ = target;
-        true
+        if target <= *self {
+            // Same or downward — always allowed.
+            return true;
+        }
+        // Upward: only single-step allowed (target discriminant == self + 1).
+        (target as u8) == (*self as u8) + 1
     }
 
     /// Is this the breakglass compartment? (triggers enhanced audit)
@@ -399,6 +405,51 @@ mod tests {
         assert!(
             !Compartment::Draft.requires_trusted_ancestry(),
             "Draft does not require trusted ancestry"
+        );
+    }
+
+    // ── Transition enforcement (#733) ───────────────────────────────
+
+    #[test]
+    fn can_transition_to_same_compartment() {
+        for c in [
+            Compartment::Research,
+            Compartment::Draft,
+            Compartment::Execute,
+            Compartment::Breakglass,
+        ] {
+            assert!(c.can_transition_to(c), "{c} -> {c} should be allowed");
+        }
+    }
+
+    #[test]
+    fn can_transition_downward() {
+        assert!(Compartment::Breakglass.can_transition_to(Compartment::Research));
+        assert!(Compartment::Execute.can_transition_to(Compartment::Draft));
+        assert!(Compartment::Execute.can_transition_to(Compartment::Research));
+        assert!(Compartment::Draft.can_transition_to(Compartment::Research));
+    }
+
+    #[test]
+    fn can_transition_single_step_up() {
+        assert!(Compartment::Research.can_transition_to(Compartment::Draft));
+        assert!(Compartment::Draft.can_transition_to(Compartment::Execute));
+        assert!(Compartment::Execute.can_transition_to(Compartment::Breakglass));
+    }
+
+    #[test]
+    fn cannot_skip_level_upward() {
+        assert!(
+            !Compartment::Research.can_transition_to(Compartment::Execute),
+            "Research -> Execute skips Draft"
+        );
+        assert!(
+            !Compartment::Research.can_transition_to(Compartment::Breakglass),
+            "Research -> Breakglass skips two levels"
+        );
+        assert!(
+            !Compartment::Draft.can_transition_to(Compartment::Breakglass),
+            "Draft -> Breakglass skips Execute"
         );
     }
 }


### PR DESCRIPTION
## Summary
- Enforce single-step escalation in the compartment lattice (Research -> Draft -> Execute -> Breakglass)
- Skip-level transitions (e.g. Research -> Execute, Draft -> Breakglass) are now denied with actionable error messages
- `resolve_compartment()` checks `can_transition_to()` before allowing escalation

Closes #733

## Test plan
- [x] `can_transition_to_same_compartment` — all 4 self-transitions allowed
- [x] `can_transition_downward` — all downward transitions allowed
- [x] `can_transition_single_step_up` — Research->Draft, Draft->Execute, Execute->Breakglass allowed
- [x] `cannot_skip_level_upward` — Research->Execute, Research->Breakglass, Draft->Breakglass denied
- [x] `resolve_compartment_single_step_research_to_draft_allowed` — integration test
- [x] `resolve_compartment_single_step_draft_to_execute_allowed` — integration test
- [x] `resolve_compartment_skip_level_research_to_execute_denied` — integration test
- [x] `resolve_compartment_skip_level_research_to_breakglass_denied` — integration test
- [x] Full workspace `cargo check --all` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)