### PR TITLE
Enforce derivation-sink compatibility in check_flow()

### DIFF
--- a/crates/portcullis-core/src/flow.rs
+++ b/crates/portcullis-core/src/flow.rs
@@ -10,6 +10,7 @@
 //! **Current status**: types + pure functions + tests. Not yet wired into
 //! `Kernel::decide()` — integration is Phase 3 of the Flow Kernel plan.
 
+use crate::storage_lane::StorageLane;
 use crate::{
     AuthorityLevel, ConfLevel, DerivationClass, IFCLabel, IntegLevel, Operation, ProvenanceSet,
     SinkClass,
@@ -204,6 +205,14 @@ pub enum FlowDenyReason {
     IntegrityViolation,
     /// Expired data used in a decision.
     FreshnessExpired,
+    /// AI-derived or mixed-derivation data flowing to a verified sink.
+    ///
+    /// Verified sinks (e.g., `GitPush`, `GitCommit`, `PRCommentWrite`)
+    /// require data that passes the [`StorageLane::Verified`] gate —
+    /// only `Deterministic` and `HumanPromoted` derivations are accepted.
+    /// This prevents AI-generated content from reaching publish vectors
+    /// without explicit human promotion.
+    DerivationViolation,
 }
 
 /// Result of checking a flow.
@@ -300,13 +309,14 @@ pub fn required_integrity(op: Operation) -> IntegLevel {
 
 /// Check whether a flow node's action is permitted by the flow policy.
 ///
-/// Enforces 6 rules:
+/// Enforces 7 rules:
 /// 1. No-exfil: secret data cannot flow to external sinks (incl. WebFetch)
 /// 2. No-authority-escalation: NoAuthority data cannot steer privileged actions
 /// 3. No-integrity-laundering: untrusted data cannot reach trusted-required sinks
 /// 4. No-web-exfil: web-provenance data cannot reach exfil sinks
 /// 5. Freshness: expired data cannot be used in decisions
-/// 6. Monotonicity: implicit (enforced by propagate_label's join)
+/// 6. Derivation-sink compatibility: AI-derived data cannot reach verified sinks
+/// 7. Monotonicity: implicit (enforced by propagate_label's join)
 ///
 /// When a [`SinkClass`] is present on the node, authority and integrity
 /// requirements come from the sink class. Otherwise, the legacy per-Operation
@@ -366,6 +376,17 @@ pub fn check_flow(node: &FlowNode, now: u64) -> FlowVerdict {
     // Rule 5: Freshness check
     if label.freshness.is_expired_at(now) {
         return FlowVerdict::Deny(FlowDenyReason::FreshnessExpired);
+    }
+
+    // Rule 6: Derivation-sink compatibility — AI-derived data cannot reach
+    // verified sinks (GitPush, GitCommit, PRCommentWrite) without human
+    // promotion. Uses the StorageLane::Verified gate as the acceptance
+    // predicate: only Deterministic and HumanPromoted derivations pass.
+    if let Some(sink) = node.sink_class
+        && sink.requires_verified_derivation()
+        && !StorageLane::Verified.accepts(label.derivation)
+    {
+        return FlowVerdict::Deny(FlowDenyReason::DerivationViolation);
     }
 
     FlowVerdict::Allow

--- a/crates/portcullis-core/src/lib.rs
+++ b/crates/portcullis-core/src/lib.rs
@@ -664,6 +664,21 @@ impl SinkClass {
                 | SinkClass::CloudMutation
         )
     }
+
+    /// Whether this sink class requires verified-lane derivation.
+    ///
+    /// Verified sinks are publish vectors where AI-derived data must not
+    /// land without explicit human promotion. Only `Deterministic` and
+    /// `HumanPromoted` derivations pass the [`StorageLane::Verified`] gate.
+    ///
+    /// This covers sinks that produce externally-visible, hard-to-revoke
+    /// artifacts: git pushes, git commits, and PR comments.
+    pub fn requires_verified_derivation(self) -> bool {
+        matches!(
+            self,
+            SinkClass::GitPush | SinkClass::GitCommit | SinkClass::PRCommentWrite
+        )
+    }
 }
 
 impl std::fmt::Display for SinkClass {

--- a/crates/portcullis-core/src/receipt.rs
+++ b/crates/portcullis-core/src/receipt.rs
@@ -150,6 +150,9 @@ pub fn build_receipt(
         FlowVerdict::Deny(FlowDenyReason::FreshnessExpired) => {
             "freshness: expired data in decision"
         }
+        FlowVerdict::Deny(FlowDenyReason::DerivationViolation) => {
+            "derivation-violation: AI-derived data to verified sink"
+        }
     };
 
     let ancestors: Vec<ReceiptNode> = ancestors

--- a/crates/portcullis-core/tests/flow_red_team.rs
+++ b/crates/portcullis-core/tests/flow_red_team.rs
@@ -1997,3 +1997,283 @@ fn exploit_owasp_ag02_memory_authority_prevents_action() {
         "MayNotAuthorize memory entry MUST NOT authorize even WriteFiles"
     );
 }
+
+// ═════════════════════════════════════════════════════════════════════════
+// Derivation-sink compatibility — AI-derived data cannot reach verified sinks
+//
+// Issue #777: DerivationClass enforcement gate. When a sink requires
+// verified-lane derivation (GitPush, GitCommit, PRCommentWrite), only
+// Deterministic and HumanPromoted data may pass. AIDerived and Mixed
+// derivations are denied with DerivationViolation.
+//
+// This prevents LLM-generated content from being pushed to git or
+// published as PR comments without explicit human review/promotion.
+// ═════════════════════════════════════════════════════════════════════════
+
+use portcullis_core::storage_lane::StorageLane;
+
+// ── Red team: LLM output → verified sink → DENIED ─────────────────────
+//
+// Attack: An LLM generates code (AIDerived derivation) and the agent
+// attempts to push it directly to a remote repository via GitPush.
+// The derivation gate blocks this — AIDerived data cannot reach the
+// Verified storage lane that GitPush requires.
+
+#[test]
+fn derivation_ai_derived_blocked_at_git_push() {
+    let now = 1000u64;
+
+    // LLM output: trusted integrity, suggestive authority, but AIDerived
+    let label = IFCLabel {
+        confidentiality: ConfLevel::Internal,
+        integrity: IntegLevel::Trusted,
+        provenance: ProvenanceSet::EMPTY,
+        freshness: Freshness {
+            observed_at: now,
+            ttl_secs: 3600,
+        },
+        authority: AuthorityLevel::Suggestive,
+        derivation: DerivationClass::AIDerived,
+    };
+
+    let push = FlowNode {
+        id: 0,
+        kind: NodeKind::OutboundAction,
+        label,
+        parent_count: 0,
+        parents: [0; MAX_PARENTS],
+        operation: Some(Operation::GitPush),
+        sink_class: Some(SinkClass::GitPush),
+    };
+
+    // Confirm StorageLane::Verified rejects AIDerived
+    assert!(!StorageLane::Verified.accepts(DerivationClass::AIDerived));
+
+    // BLOCKED: derivation violation — AIDerived cannot reach GitPush
+    assert_eq!(
+        check_flow(&push, now + 1),
+        FlowVerdict::Deny(FlowDenyReason::DerivationViolation),
+        "AIDerived data MUST NOT reach GitPush sink without human promotion"
+    );
+}
+
+#[test]
+fn derivation_mixed_blocked_at_git_commit() {
+    let now = 1000u64;
+
+    // Mixed derivation: human + AI combined output
+    let label = IFCLabel {
+        confidentiality: ConfLevel::Internal,
+        integrity: IntegLevel::Trusted,
+        provenance: ProvenanceSet::EMPTY,
+        freshness: Freshness {
+            observed_at: now,
+            ttl_secs: 3600,
+        },
+        authority: AuthorityLevel::Suggestive,
+        derivation: DerivationClass::Mixed,
+    };
+
+    let commit = FlowNode {
+        id: 0,
+        kind: NodeKind::OutboundAction,
+        label,
+        parent_count: 0,
+        parents: [0; MAX_PARENTS],
+        operation: Some(Operation::GitCommit),
+        sink_class: Some(SinkClass::GitCommit),
+    };
+
+    // BLOCKED: Mixed derivation also rejected by Verified lane
+    assert!(!StorageLane::Verified.accepts(DerivationClass::Mixed));
+    assert_eq!(
+        check_flow(&commit, now + 1),
+        FlowVerdict::Deny(FlowDenyReason::DerivationViolation),
+        "Mixed derivation MUST NOT reach GitCommit sink"
+    );
+}
+
+#[test]
+fn derivation_ai_derived_blocked_at_pr_comment() {
+    let now = 1000u64;
+
+    let label = IFCLabel {
+        confidentiality: ConfLevel::Internal,
+        integrity: IntegLevel::Trusted,
+        provenance: ProvenanceSet::EMPTY,
+        freshness: Freshness {
+            observed_at: now,
+            ttl_secs: 3600,
+        },
+        authority: AuthorityLevel::Suggestive,
+        derivation: DerivationClass::AIDerived,
+    };
+
+    let pr = FlowNode {
+        id: 0,
+        kind: NodeKind::OutboundAction,
+        label,
+        parent_count: 0,
+        parents: [0; MAX_PARENTS],
+        operation: Some(Operation::CreatePr),
+        sink_class: Some(SinkClass::PRCommentWrite),
+    };
+
+    assert_eq!(
+        check_flow(&pr, now + 1),
+        FlowVerdict::Deny(FlowDenyReason::DerivationViolation),
+        "AIDerived data MUST NOT reach PRCommentWrite sink"
+    );
+}
+
+// ── Control: deterministic output → verified sink → ALLOWED ────────────
+//
+// A deterministic tool (compiler, linter, parser) produces output with
+// Deterministic derivation. This data IS allowed to reach verified sinks
+// because it passes the StorageLane::Verified gate.
+
+#[test]
+fn derivation_deterministic_allowed_at_git_push() {
+    let now = 1000u64;
+
+    let label = IFCLabel {
+        confidentiality: ConfLevel::Internal,
+        integrity: IntegLevel::Trusted,
+        provenance: ProvenanceSet::EMPTY,
+        freshness: Freshness {
+            observed_at: now,
+            ttl_secs: 3600,
+        },
+        authority: AuthorityLevel::Suggestive,
+        derivation: DerivationClass::Deterministic,
+    };
+
+    let push = FlowNode {
+        id: 0,
+        kind: NodeKind::OutboundAction,
+        label,
+        parent_count: 0,
+        parents: [0; MAX_PARENTS],
+        operation: Some(Operation::GitPush),
+        sink_class: Some(SinkClass::GitPush),
+    };
+
+    // Confirm StorageLane::Verified accepts Deterministic
+    assert!(StorageLane::Verified.accepts(DerivationClass::Deterministic));
+
+    // ALLOWED: deterministic data can reach verified sinks
+    assert_eq!(
+        check_flow(&push, now + 1),
+        FlowVerdict::Allow,
+        "Deterministic data MUST be allowed to reach GitPush sink"
+    );
+}
+
+#[test]
+fn derivation_human_promoted_allowed_at_git_push() {
+    let now = 1000u64;
+
+    let label = IFCLabel {
+        confidentiality: ConfLevel::Internal,
+        integrity: IntegLevel::Trusted,
+        provenance: ProvenanceSet::EMPTY,
+        freshness: Freshness {
+            observed_at: now,
+            ttl_secs: 3600,
+        },
+        authority: AuthorityLevel::Suggestive,
+        derivation: DerivationClass::HumanPromoted,
+    };
+
+    let push = FlowNode {
+        id: 0,
+        kind: NodeKind::OutboundAction,
+        label,
+        parent_count: 0,
+        parents: [0; MAX_PARENTS],
+        operation: Some(Operation::GitPush),
+        sink_class: Some(SinkClass::GitPush),
+    };
+
+    // Confirm StorageLane::Verified accepts HumanPromoted
+    assert!(StorageLane::Verified.accepts(DerivationClass::HumanPromoted));
+
+    // ALLOWED: human-promoted data can reach verified sinks
+    assert_eq!(
+        check_flow(&push, now + 1),
+        FlowVerdict::Allow,
+        "HumanPromoted data MUST be allowed to reach GitPush sink"
+    );
+}
+
+// ── Control: AIDerived → non-verified sink → ALLOWED ───────────────────
+//
+// AIDerived data CAN reach non-verified sinks like WorkspaceWrite.
+// The derivation gate only applies to verified sinks.
+
+#[test]
+fn derivation_ai_derived_allowed_at_workspace_write() {
+    let now = 1000u64;
+
+    let label = IFCLabel {
+        confidentiality: ConfLevel::Internal,
+        integrity: IntegLevel::Untrusted,
+        provenance: ProvenanceSet::EMPTY,
+        freshness: Freshness {
+            observed_at: now,
+            ttl_secs: 3600,
+        },
+        authority: AuthorityLevel::Suggestive,
+        derivation: DerivationClass::AIDerived,
+    };
+
+    let write = FlowNode {
+        id: 0,
+        kind: NodeKind::OutboundAction,
+        label,
+        parent_count: 0,
+        parents: [0; MAX_PARENTS],
+        operation: Some(Operation::WriteFiles),
+        sink_class: Some(SinkClass::WorkspaceWrite),
+    };
+
+    // WorkspaceWrite does NOT require verified derivation
+    assert!(!SinkClass::WorkspaceWrite.requires_verified_derivation());
+
+    assert_eq!(
+        check_flow(&write, now + 1),
+        FlowVerdict::Allow,
+        "AIDerived data MUST be allowed to reach WorkspaceWrite (non-verified sink)"
+    );
+}
+
+// ── Control: no sink_class set → derivation check skipped ──────────────
+//
+// When sink_class is None (legacy path), the derivation check is not
+// applied. This preserves backward compatibility.
+
+#[test]
+fn derivation_check_skipped_without_sink_class() {
+    let now = 1000u64;
+
+    let label = IFCLabel {
+        confidentiality: ConfLevel::Internal,
+        integrity: IntegLevel::Trusted,
+        provenance: ProvenanceSet::EMPTY,
+        freshness: Freshness {
+            observed_at: now,
+            ttl_secs: 3600,
+        },
+        authority: AuthorityLevel::Suggestive,
+        derivation: DerivationClass::AIDerived,
+    };
+
+    // GitPush without sink_class — derivation check NOT applied
+    let push = node(0, NodeKind::OutboundAction, label, Some(Operation::GitPush));
+
+    assert_eq!(
+        check_flow(&push, now + 1),
+        FlowVerdict::Allow,
+        "Without sink_class, derivation check is skipped (backward compat)"
+    );
+}

--- a/crates/portcullis/src/kernel.rs
+++ b/crates/portcullis/src/kernel.rs
@@ -1661,6 +1661,8 @@ fn verdict_to_flow_verdict(verdict: &Verdict) -> portcullis_core::flow::FlowVerd
                         FlowDenyReason::IntegrityViolation
                     } else if rule.contains("FreshnessExpired") {
                         FlowDenyReason::FreshnessExpired
+                    } else if rule.contains("DerivationViolation") {
+                        FlowDenyReason::DerivationViolation
                     } else {
                         FlowDenyReason::Exfiltration
                     }


### PR DESCRIPTION
## Summary
- **New enforcement rule**: `check_flow()` Rule 6 blocks AI-derived (`AIDerived`, `Mixed`) data from reaching verified sinks (`GitPush`, `GitCommit`, `PRCommentWrite`) without human promotion
- **Gate mechanism**: Reuses `StorageLane::Verified.accepts()` as the derivation compatibility predicate — only `Deterministic` and `HumanPromoted` pass
- **New API**: `SinkClass::requires_verified_derivation()` identifies which sinks enforce the gate; `FlowDenyReason::DerivationViolation` is the new deny variant
- **Backward compatible**: Derivation check only fires when `sink_class` is `Some` — legacy paths without sink classification are unaffected

## Changes
- `flow.rs`: Add derivation check as Rule 6 in `check_flow()`, import `StorageLane`
- `lib.rs`: Add `SinkClass::requires_verified_derivation()` method
- `flow.rs`: Add `FlowDenyReason::DerivationViolation` variant
- `receipt.rs`: Add rule name mapping for new variant
- `kernel.rs`: Add string match for `DerivationViolation` in flow violation mapping
- `flow_red_team.rs`: 7 new tests (3 red team + 4 control)

## Test plan
- [x] Red team: AIDerived -> GitPush -> DENIED (DerivationViolation)
- [x] Red team: Mixed -> GitCommit -> DENIED (DerivationViolation)
- [x] Red team: AIDerived -> PRCommentWrite -> DENIED (DerivationViolation)
- [x] Control: Deterministic -> GitPush -> ALLOWED
- [x] Control: HumanPromoted -> GitPush -> ALLOWED
- [x] Control: AIDerived -> WorkspaceWrite -> ALLOWED (non-verified sink)
- [x] Control: AIDerived -> GitPush without sink_class -> ALLOWED (backward compat)
- [x] All 33 portcullis-core tests pass
- [x] All portcullis crate tests pass
- [x] nucleus-claude-hook compiles clean

Closes #777

🤖 Generated with [Claude Code](https://claude.com/claude-code)