### PR TITLE
Wire sink_class into FlowGraph and Kernel node creation

### DIFF
--- a/crates/portcullis/src/flow_graph.rs
+++ b/crates/portcullis/src/flow_graph.rs
@@ -14,7 +14,7 @@ use portcullis_core::flow::{
     QuarantineVerdict, TrustAncestryResult, MAX_PARENTS,
 };
 use portcullis_core::receipt::{build_receipt, FlowReceipt, MAX_RECEIPT_ANCESTORS};
-use portcullis_core::{IFCLabel, Operation};
+use portcullis_core::{default_sink_class, IFCLabel, Operation, SinkClass};
 
 /// Errors during graph operations.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -232,7 +232,14 @@ impl FlowGraph {
             &self.gather_labels(parents),
             intrinsic_label(NodeKind::OutboundAction, now),
         );
-        let node = self.build_node(NodeKind::OutboundAction, label, parents, Some(operation));
+        let sink_class = Some(default_sink_class(operation));
+        let node = self.build_node(
+            NodeKind::OutboundAction,
+            label,
+            parents,
+            Some(operation),
+            sink_class,
+        );
         let verdict = check_flow(&node, now);
         self.maybe_compact();
         let id = self.next_id;
@@ -353,6 +360,7 @@ impl FlowGraph {
         label: IFCLabel,
         parents: &[NodeId],
         operation: Option<Operation>,
+        sink_class: Option<SinkClass>,
     ) -> FlowNode {
         let mut parent_array = [0u64; MAX_PARENTS];
         for (i, &pid) in parents.iter().take(MAX_PARENTS).enumerate() {
@@ -365,7 +373,7 @@ impl FlowGraph {
             parent_count: parents.len().min(MAX_PARENTS) as u8,
             parents: parent_array,
             operation,
-            sink_class: None,
+            sink_class,
         }
     }
 
@@ -377,7 +385,7 @@ impl FlowGraph {
         operation: Option<Operation>,
     ) -> NodeId {
         self.maybe_compact();
-        let node = self.build_node(kind, label, parents, operation);
+        let node = self.build_node(kind, label, parents, operation, None);
         let id = self.next_id;
         self.nodes.push(Some(node));
         self.next_id += 1;
@@ -2061,6 +2069,42 @@ mod tests {
         assert!(
             g.get(recent_id).is_some(),
             "recent node (id={recent_id}) should survive compaction"
+        );
+    }
+
+    #[test]
+    fn insert_action_populates_sink_class() {
+        let mut g = FlowGraph::new();
+        let now = 1000;
+        let user = g
+            .insert_observation(NodeKind::UserPrompt, &[], now)
+            .unwrap();
+        let file = g
+            .insert_observation(NodeKind::FileRead, &[user], now)
+            .unwrap();
+
+        let r = g.insert_action(Operation::GitPush, &[file], now).unwrap();
+        let node = g.get(r.node_id).unwrap();
+        assert_eq!(
+            node.sink_class,
+            Some(SinkClass::GitPush),
+            "insert_action must populate sink_class from operation"
+        );
+    }
+
+    #[test]
+    fn insert_action_sink_class_enables_sink_based_rules() {
+        // Secret data flowing to GitPush (an exfil vector) must be denied.
+        // This only works when sink_class is populated on the node.
+        let mut g = FlowGraph::new();
+        let now = 1000;
+        let secret = g.insert_observation(NodeKind::Secret, &[], now).unwrap();
+
+        let r = g.insert_action(Operation::GitPush, &[secret], now).unwrap();
+        assert_eq!(
+            r.verdict,
+            FlowVerdict::Deny(FlowDenyReason::Exfiltration),
+            "secret data to GitPush (exfil sink) must be denied"
         );
     }
 }

--- a/crates/portcullis/src/kernel.rs
+++ b/crates/portcullis/src/kernel.rs
@@ -1136,7 +1136,7 @@ impl Kernel {
                     parent_count: 0,
                     parents: [0; flow::MAX_PARENTS],
                     operation: Some(operation),
-                    sink_class: None,
+                    sink_class: Some(portcullis_core::default_sink_class(operation)),
                 };
 
                 if let flow::FlowVerdict::Deny(reason) = flow::check_flow(&node, now_unix) {


### PR DESCRIPTION
## Summary
- **Fixes #780**: `FlowGraph::build_node()` hardcoded `sink_class: None`, making SinkClass-based flow rules dead code in the production path
- `insert_action()` now computes `sink_class` via `default_sink_class(operation)` and passes it to `build_node()`
- Kernel flat flow path also sets `sink_class` from the operation, ensuring consistent enforcement

## Context
This is a prerequisite for #784 (derivation-sink compatibility Rule 6). Without this fix, `check_flow()` always falls back to legacy per-Operation thresholds because `sink_class` is always `None`. The SinkClass-based authority, integrity, and exfil vector checks were effectively dead code in any path through `FlowGraph::insert_action()` or `Kernel::decide()`.

## Changes
- `flow_graph.rs`: `build_node()` accepts `sink_class` parameter; `insert_action()` computes it via `default_sink_class()`; `alloc_node()` passes `None` for non-action nodes
- `kernel.rs`: Flat flow path sets `sink_class: Some(default_sink_class(operation))`
- Two new tests: `insert_action_populates_sink_class` and `insert_action_sink_class_enables_sink_based_rules`

## Test plan
- [x] `insert_action_populates_sink_class` -- verifies GitPush operation produces `SinkClass::GitPush` on the node
- [x] `insert_action_sink_class_enables_sink_based_rules` -- verifies secret data to GitPush is DENIED via Exfiltration rule
- [x] All 801 portcullis lib tests pass (799 existing + 2 new)
- [x] All 239 portcullis-core lib tests pass
- [x] Pre-commit hooks pass (fmt, clippy, deny, audit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)