### PR TITLE
Thread DerivationClass through Evidence and VerdictReceipt (#776)

### DIFF
--- a/crates/portcullis-core/src/verdict.rs
+++ b/crates/portcullis-core/src/verdict.rs
@@ -19,7 +19,7 @@
 //!    (the Aeneas verification target). It uses only types already defined
 //!    in this crate (`IFCLabel`, `SinkClass`, `Operation`).
 
-use crate::{IFCLabel, Operation, SinkClass};
+use crate::{DerivationClass, IFCLabel, Operation, SinkClass};
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Decision — the kernel's binary-plus-deferred outcome
@@ -127,6 +127,12 @@ pub struct Evidence {
     /// Declassification tokens that were applied (or attempted) during
     /// this decision. Presence of a token means the label was weakened.
     pub declassification_tokens: Vec<String>,
+    /// The derivation class of the data flowing through this decision (#776).
+    ///
+    /// Captures whether the data is deterministic, AI-derived, mixed,
+    /// human-promoted, or from an opaque external source. `None` when
+    /// derivation tracking is not applicable (e.g., capability gates).
+    pub derivation_class: Option<DerivationClass>,
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -385,6 +391,7 @@ mod tests {
             sink_class: Some(SinkClass::HTTPEgress),
             causal_parents: vec![100, 200, 300],
             declassification_tokens: vec!["declass-token-1".to_string()],
+            derivation_class: Some(crate::DerivationClass::Deterministic),
         };
 
         let v = StructuredVerdict::deny(
@@ -409,6 +416,10 @@ mod tests {
         assert_eq!(v.evidence.causal_parents, vec![100, 200, 300]);
         assert_eq!(v.evidence.declassification_tokens.len(), 1);
         assert!(v.evidence.artifact_label.is_some());
+        assert_eq!(
+            v.evidence.derivation_class,
+            Some(crate::DerivationClass::Deterministic)
+        );
     }
 
     #[test]
@@ -436,6 +447,7 @@ mod tests {
         assert!(e.sink_class.is_none());
         assert!(e.causal_parents.is_empty());
         assert!(e.declassification_tokens.is_empty());
+        assert!(e.derivation_class.is_none());
     }
 
     #[test]
@@ -463,5 +475,32 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn evidence_includes_derivation_class() {
+        // #776: Evidence carries derivation provenance for audit trails.
+        let evidence = Evidence {
+            derivation_class: Some(crate::DerivationClass::AIDerived),
+            ..Evidence::default()
+        };
+        assert_eq!(
+            evidence.derivation_class,
+            Some(crate::DerivationClass::AIDerived),
+        );
+
+        // Verify it survives a verdict round-trip via with_evidence.
+        let v = StructuredVerdict::allow(
+            sample_rule(),
+            Mode::Enforce,
+            Operation::WebFetch,
+            "agent-1".to_string(),
+            1_700_000_010,
+        )
+        .with_evidence(evidence);
+        assert_eq!(
+            v.evidence.derivation_class,
+            Some(crate::DerivationClass::AIDerived),
+        );
     }
 }

--- a/crates/portcullis/src/kernel.rs
+++ b/crates/portcullis/src/kernel.rs
@@ -1910,9 +1910,10 @@ impl Kernel {
             let effect_kind_str = flow_node
                 .and_then(|node| node.effect_kind)
                 .map(|ek| ek.as_str().to_string());
+            let derivation_class = flow_node.map(|node| node.label.derivation);
 
             let prev_hash = *chain.head_hash();
-            let receipt = VerdictReceipt::from_verdict_with_effect(
+            let receipt = VerdictReceipt::from_verdict_full(
                 flow_verdict,
                 format!("{:?}", decision.operation),
                 &decision.subject,
@@ -1922,6 +1923,7 @@ impl Kernel {
                 now_unix,
                 prev_hash,
                 effect_kind_str,
+                derivation_class,
             );
 
             // Append should never fail — we computed prev_hash from chain head.

--- a/crates/portcullis/src/receipt_chain.rs
+++ b/crates/portcullis/src/receipt_chain.rs
@@ -15,7 +15,7 @@
 use sha2::{Digest, Sha256};
 
 use portcullis_core::flow::{FlowVerdict, NodeId};
-use portcullis_core::IFCLabel;
+use portcullis_core::{DerivationClass, IFCLabel};
 
 // ═══════════════════════════════════════════════════════════════════════════
 // VerdictReceipt — a single chain entry
@@ -51,6 +51,11 @@ pub struct VerdictReceipt {
     pub receipt_hash: [u8; 32],
     /// Computation-step effect classification (#775).
     pub effect_kind: Option<String>,
+    /// Derivation provenance of the data flowing through this verdict (#776).
+    ///
+    /// Captures whether the data is deterministic, AI-derived, mixed,
+    /// human-promoted, or from an opaque external source.
+    pub derivation_class: Option<DerivationClass>,
 }
 
 impl VerdictReceipt {
@@ -111,6 +116,12 @@ impl VerdictReceipt {
             buf.extend_from_slice(ek.as_bytes());
         }
 
+        // Derivation class (#776)
+        if let Some(dc) = self.derivation_class {
+            buf.extend_from_slice(b"derivation:");
+            buf.push(dc as u8);
+        }
+
         buf
     }
 
@@ -166,6 +177,39 @@ impl VerdictReceipt {
             prev_hash,
             receipt_hash: [0u8; 32],
             effect_kind,
+            derivation_class: None,
+        };
+        receipt.receipt_hash = receipt.compute_hash();
+        receipt
+    }
+
+    /// Like [`from_verdict_with_effect`](Self::from_verdict_with_effect) but with
+    /// an explicit derivation class (#776).
+    #[allow(clippy::too_many_arguments)]
+    pub fn from_verdict_full(
+        verdict: FlowVerdict,
+        operation: impl Into<String>,
+        subject: impl Into<String>,
+        pre_label: IFCLabel,
+        post_label: IFCLabel,
+        causal_parents: Vec<NodeId>,
+        timestamp: u64,
+        prev_hash: [u8; 32],
+        effect_kind: Option<String>,
+        derivation_class: Option<DerivationClass>,
+    ) -> Self {
+        let mut receipt = Self {
+            verdict,
+            operation: operation.into(),
+            subject: subject.into(),
+            pre_label,
+            post_label,
+            causal_parents,
+            timestamp,
+            prev_hash,
+            receipt_hash: [0u8; 32],
+            effect_kind,
+            derivation_class,
         };
         receipt.receipt_hash = receipt.compute_hash();
         receipt
@@ -178,6 +222,7 @@ fn label_bytes(buf: &mut Vec<u8>, label: &IFCLabel) {
     buf.push(label.integrity as u8);
     buf.push(label.authority as u8);
     buf.extend_from_slice(&label.provenance.bits().to_le_bytes());
+    buf.push(label.derivation as u8);
     buf.extend_from_slice(&label.freshness.observed_at.to_le_bytes());
     buf.extend_from_slice(&label.freshness.ttl_secs.to_le_bytes());
 }
@@ -363,6 +408,9 @@ impl ReceiptChain {
                 if let Some(ref ek) = r.effect_kind {
                     obj["effect_kind"] = json!(ek);
                 }
+                if let Some(dc) = r.derivation_class {
+                    obj["derivation_class"] = json!(format!("{:?}", dc));
+                }
                 obj
             })
             .collect();
@@ -539,6 +587,7 @@ fn label_to_json(label: &IFCLabel) -> serde_json::Value {
         "confidentiality": format!("{:?}", label.confidentiality),
         "integrity": format!("{:?}", label.integrity),
         "authority": format!("{:?}", label.authority),
+        "derivation": format!("{:?}", label.derivation),
         "provenance_bits": label.provenance.bits(),
         "freshness": {
             "observed_at": label.freshness.observed_at,
@@ -1105,5 +1154,183 @@ mod tests {
             Some("deterministic_fetch".to_string()),
         );
         assert_eq!(r.effect_kind.as_deref(), Some("deterministic_fetch"));
+    }
+
+    // ── Derivation class tests (#776) ────────────────────────────
+
+    #[test]
+    fn receipt_captures_derivation_class() {
+        let label = test_label(1000);
+        let r = VerdictReceipt::from_verdict_full(
+            FlowVerdict::Allow,
+            "web_fetch",
+            "agent-1",
+            label,
+            label,
+            vec![1],
+            1000,
+            [0u8; 32],
+            Some("deterministic_fetch".to_string()),
+            Some(DerivationClass::AIDerived),
+        );
+        assert_eq!(r.derivation_class, Some(DerivationClass::AIDerived));
+    }
+
+    #[test]
+    fn receipt_derivation_class_affects_hash() {
+        let label = test_label(1000);
+        let without = VerdictReceipt::from_verdict_full(
+            FlowVerdict::Allow,
+            "read_files",
+            "a",
+            label,
+            label,
+            vec![1],
+            1000,
+            [0u8; 32],
+            None,
+            None,
+        );
+        let with_ai = VerdictReceipt::from_verdict_full(
+            FlowVerdict::Allow,
+            "read_files",
+            "a",
+            label,
+            label,
+            vec![1],
+            1000,
+            [0u8; 32],
+            None,
+            Some(DerivationClass::AIDerived),
+        );
+        let with_det = VerdictReceipt::from_verdict_full(
+            FlowVerdict::Allow,
+            "read_files",
+            "a",
+            label,
+            label,
+            vec![1],
+            1000,
+            [0u8; 32],
+            None,
+            Some(DerivationClass::Deterministic),
+        );
+        // All three must produce different hashes
+        assert_ne!(without.receipt_hash, with_ai.receipt_hash);
+        assert_ne!(without.receipt_hash, with_det.receipt_hash);
+        assert_ne!(with_ai.receipt_hash, with_det.receipt_hash);
+    }
+
+    #[test]
+    fn receipt_without_derivation_backward_compatible() {
+        let label = test_label(1000);
+        let old = VerdictReceipt::from_verdict(
+            FlowVerdict::Allow,
+            "r",
+            "a",
+            label,
+            label,
+            vec![1],
+            1000,
+            [0u8; 32],
+        );
+        let new = VerdictReceipt::from_verdict_full(
+            FlowVerdict::Allow,
+            "r",
+            "a",
+            label,
+            label,
+            vec![1],
+            1000,
+            [0u8; 32],
+            None,
+            None,
+        );
+        assert_eq!(old.receipt_hash, new.receipt_hash);
+    }
+
+    #[test]
+    fn chain_with_derivation_verifies() {
+        let mut chain = ReceiptChain::new();
+        let label = test_label(1000);
+        let r1 = VerdictReceipt::from_verdict_full(
+            FlowVerdict::Allow,
+            "web_fetch",
+            "a",
+            label,
+            label,
+            vec![1],
+            1000,
+            *chain.head_hash(),
+            None,
+            Some(DerivationClass::AIDerived),
+        );
+        chain.append(r1).unwrap();
+        let r2 = VerdictReceipt::from_verdict_full(
+            FlowVerdict::Allow,
+            "write",
+            "a",
+            label,
+            label,
+            vec![2],
+            2000,
+            *chain.head_hash(),
+            None,
+            Some(DerivationClass::Mixed),
+        );
+        chain.append(r2).unwrap();
+        assert_eq!(chain.len(), 2);
+        assert!(chain.verify().is_ok());
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn export_includes_derivation_class() {
+        let mut chain = ReceiptChain::new();
+        let label = test_label(1000);
+        let r = VerdictReceipt::from_verdict_full(
+            FlowVerdict::Allow,
+            "web_fetch",
+            "agent-1",
+            label,
+            label,
+            vec![1],
+            1000,
+            *chain.head_hash(),
+            None,
+            Some(DerivationClass::AIDerived),
+        );
+        chain.append(r).unwrap();
+
+        let json = chain.export_json().expect("JSON export should succeed");
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("JSON should parse");
+        let receipts = parsed["receipts"].as_array().unwrap();
+
+        assert_eq!(receipts[0]["derivation_class"], "AIDerived");
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn export_omits_derivation_when_none() {
+        let mut chain = ReceiptChain::new();
+        let label = test_label(1000);
+        let r = VerdictReceipt::from_verdict(
+            FlowVerdict::Allow,
+            "read_files",
+            "agent-1",
+            label,
+            label,
+            vec![1],
+            1000,
+            *chain.head_hash(),
+        );
+        chain.append(r).unwrap();
+
+        let json = chain.export_json().expect("JSON export should succeed");
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("JSON should parse");
+        let receipts = parsed["receipts"].as_array().unwrap();
+
+        // derivation_class should not be present when None
+        assert!(receipts[0].get("derivation_class").is_none());
     }
 }


### PR DESCRIPTION
## Summary
- Adds `derivation_class: Option<DerivationClass>` to `Evidence` (verdict.rs) and `VerdictReceipt` (receipt_chain.rs) so audit trails capture derivation provenance
- Kernel extracts derivation from `flow_node.label.derivation` when building receipts via new `from_verdict_full()` constructor
- Derivation included in canonical preimage (content integrity) and JSON export; `label_to_json` also now includes derivation

## Test plan
- [ ] `cargo test -p portcullis -p portcullis-core --all-features` passes (11 new/updated tests)
- [ ] `evidence_includes_derivation_class` — Evidence carries derivation through verdict round-trip
- [ ] `receipt_captures_derivation_class` — VerdictReceipt stores derivation from `from_verdict_full`
- [ ] `receipt_derivation_class_affects_hash` — different derivation classes produce different hashes
- [ ] `receipt_without_derivation_backward_compatible` — `from_verdict` and `from_verdict_full(None)` produce identical hashes
- [ ] `chain_with_derivation_verifies` — chain with derivation receipts passes `verify()`
- [ ] `export_includes_derivation_class` — JSON export contains `derivation_class` field
- [ ] `export_omits_derivation_when_none` — JSON export omits field when derivation is None

Closes #776

🤖 Generated with [Claude Code](https://claude.com/claude-code)