### PR TITLE
feat: add --statusline for Claude Code status line (#841)

### DIFF
--- a/crates/nucleus-claude-hook/src/cli.rs
+++ b/crates/nucleus-claude-hook/src/cli.rs
@@ -47,6 +47,8 @@ pub enum CliCommand {
     ExitCodes,
     /// `--benchmark [--iterations N]` — measure hook latency (#522).
     Benchmark { iterations: usize },
+    /// `--statusline` — output a short status string for Claude Code's status line.
+    StatusLine,
 }
 
 /// CLI parsing error.
@@ -155,6 +157,7 @@ pub fn parse_args(args: &[String]) -> Result<CliCommand, CliError> {
             }
             Ok(CliCommand::Benchmark { iterations })
         }
+        "--statusline" => Ok(CliCommand::StatusLine),
         other if other.starts_with('-') => Err(CliError::UnknownFlag(other.to_string())),
         // No recognised flag — fall through to stdin hook mode.
         _ => Ok(CliCommand::Hook),
@@ -354,6 +357,14 @@ mod tests {
         assert_eq!(
             parse_args(&args(&["--benchmark", "--iterations", "500"])).unwrap(),
             CliCommand::Benchmark { iterations: 500 }
+        );
+    }
+
+    #[test]
+    fn statusline_flag() {
+        assert_eq!(
+            parse_args(&args(&["--statusline"])).unwrap(),
+            CliCommand::StatusLine
         );
     }
 

--- a/crates/nucleus-claude-hook/src/completions.rs
+++ b/crates/nucleus-claude-hook/src/completions.rs
@@ -22,6 +22,7 @@ const FLAGS: &[&str] = &[
     "--completions",
     "--exit-codes",
     "--benchmark",
+    "--statusline",
 ];
 
 /// Generate a shell completion script for the given shell name.
@@ -148,6 +149,7 @@ mod tests {
             "--receipts",
             "--completions",
             "--exit-codes",
+            "--statusline",
         ];
         for flag in expected {
             assert!(FLAGS.contains(&flag), "missing flag in completions: {flag}");

--- a/crates/nucleus-claude-hook/src/help.rs
+++ b/crates/nucleus-claude-hook/src/help.rs
@@ -54,6 +54,7 @@ pub fn print_help() {
     println!("  --exit-codes           Print the exit code protocol documentation");
     println!("  --benchmark            Measure hook decision latency (p50/p95/p99)");
     println!("    --iterations N         Number of iterations (default: 100)");
+    println!("  --statusline           Output compact status for Claude Code status line");
     println!("  --help, -h             This message");
     println!("  --version, -V          Show version");
     println!();

--- a/crates/nucleus-claude-hook/src/main.rs
+++ b/crates/nucleus-claude-hook/src/main.rs
@@ -1188,6 +1188,10 @@ fn main() {
             bench::run_benchmark(bench::BenchConfig { iterations });
             return;
         }
+        Ok(cli::CliCommand::StatusLine) => {
+            status::run_statusline();
+            return;
+        }
         Err(e) => {
             eprintln!("nucleus-claude-hook: {e}");
             exit_codes::ExitCode::Error.exit();

--- a/crates/nucleus-claude-hook/src/status.rs
+++ b/crates/nucleus-claude-hook/src/status.rs
@@ -271,6 +271,40 @@ pub(crate) fn run_status(json: bool) {
     }
 }
 
+/// Output a compact single-line status string for Claude Code's status line feature.
+///
+/// Format: `compartment | profile | taint | N ops`
+/// Designed to be short enough for an editor status bar.
+pub(crate) fn run_statusline() {
+    let status = collect_status();
+
+    let compartment = status.compartment.as_deref().unwrap_or("default");
+
+    // Aggregate taint across all sessions; show worst case.
+    let mut total_ops: usize = 0;
+    let mut tainted = false;
+    let mut has_flow = false;
+
+    for sess in &status.sessions {
+        total_ops += sess.allowed_ops + sess.denied_ops;
+        if sess.taint == "TAINTED" {
+            tainted = true;
+        }
+        if sess.flow_observations > 0 {
+            has_flow = true;
+        }
+    }
+
+    let taint_str = if tainted { "tainted" } else { "clean" };
+    let flow_str = if has_flow { "yes" } else { "no" };
+
+    // Keep it short: compartment | profile | flow | taint | ops
+    println!(
+        "{compartment} | {profile} | flow:{flow_str} | {taint_str} | {total_ops} ops",
+        profile = status.profile,
+    );
+}
+
 /// Print coloured, human-readable status to stderr.
 fn print_human(s: &NucleusStatus) {
     let bold = "\x1b[1m";

--- a/docs/statusline.md
+++ b/docs/statusline.md
@@ -1,0 +1,70 @@
+# Nucleus Status Line for Claude Code
+
+The `--statusline` flag outputs a compact, single-line summary of the current
+Nucleus security posture. It is designed for integration with Claude Code's
+[status line feature](https://code.claude.com/docs/en/statusline).
+
+## Setup
+
+Add the following to your `.claude/settings.json`:
+
+```json
+{
+  "statusLine": "nucleus-claude-hook --statusline"
+}
+```
+
+If `nucleus-claude-hook` is not on your `PATH`, use the full path:
+
+```json
+{
+  "statusLine": "/path/to/nucleus-claude-hook --statusline"
+}
+```
+
+### Shell script fallback
+
+A lightweight shell script is also available at `scripts/nucleus-statusline.sh`.
+It reads environment variables and counts session files, but does not parse
+session state (no taint or flow detection). Use it only when the Rust binary
+is unavailable:
+
+```json
+{
+  "statusLine": "bash /path/to/nucleus/scripts/nucleus-statusline.sh"
+}
+```
+
+## Output format
+
+```
+<compartment> | <profile> | flow:<yes|no> | <clean|tainted> | <N> ops
+```
+
+Example outputs:
+
+```
+default | safe_pr_fixer | flow:no | clean | 0 ops
+research | read_only | flow:yes | tainted | 42 ops
+draft | fix_issue | flow:yes | clean | 17 ops
+```
+
+### Fields
+
+| Field       | Description                                              |
+|-------------|----------------------------------------------------------|
+| compartment | Active compartment name (`NUCLEUS_COMPARTMENT` or config)|
+| profile     | Active profile (`NUCLEUS_PROFILE` or config default)     |
+| flow        | Whether the flow graph has any observations              |
+| taint       | `clean` or `tainted` (web content detected in flow)      |
+| ops         | Total operations (allowed + denied) across all sessions  |
+
+## How it works
+
+The Rust implementation (`--statusline`) calls the same `collect_status()`
+function used by `--status`, then formats the result into a single line.
+It reads real session state from `~/.local/share/nucleus/sessions/`, so the
+taint and operation counts reflect actual hook activity.
+
+The shell script fallback only reads environment variables and counts session
+files on disk -- it cannot detect taint or flow status.

--- a/scripts/nucleus-statusline.sh
+++ b/scripts/nucleus-statusline.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Nucleus status line for Claude Code
+#
+# Lightweight shell fallback that outputs a compact status string.
+# Prefer `nucleus-claude-hook --statusline` (Rust) when the binary is
+# installed — it reads real session state from disk.
+#
+# Usage in .claude/settings.json:
+#   { "statusLine": "nucleus-claude-hook --statusline" }
+#
+# Or, if the binary is not on PATH:
+#   { "statusLine": "bash /path/to/scripts/nucleus-statusline.sh" }
+
+set -euo pipefail
+
+PROFILE="${NUCLEUS_PROFILE:-safe_pr_fixer}"
+COMPARTMENT="${NUCLEUS_COMPARTMENT:-default}"
+
+# Count active sessions on disk.
+SESSION_DIR="${HOME}/.local/share/nucleus/sessions"
+if [ -d "$SESSION_DIR" ]; then
+    SESSION_COUNT=$(find "$SESSION_DIR" -maxdepth 1 -name '*.json' 2>/dev/null | wc -l | tr -d ' ')
+else
+    SESSION_COUNT=0
+fi
+
+# Check for .nucleus/ project config in cwd.
+if [ -d ".nucleus" ]; then
+    CONFIG="yes"
+else
+    CONFIG="no"
+fi
+
+echo "${COMPARTMENT} | ${PROFILE} | config:${CONFIG} | sessions:${SESSION_COUNT}"


### PR DESCRIPTION
## Summary
- Add `--statusline` flag to `nucleus-claude-hook` that outputs a compact single-line status: `compartment | profile | flow:yes/no | clean/tainted | N ops`
- Add `scripts/nucleus-statusline.sh` as a lightweight shell fallback for environments without the Rust binary
- Add `docs/statusline.md` documenting setup with Claude Code's `statusLine` config

Closes #841

## Test plan
- [x] All 130 existing tests pass, plus new `statusline_flag` CLI parsing test
- [x] All pre-commit hooks pass (fmt, clippy, deny, audit, line ratchet)
- [x] Manual verification: `nucleus-claude-hook --statusline` outputs `default | safe_pr_fixer | flow:no | clean | 0 ops`
- [x] Shell script produces equivalent output: `default | safe_pr_fixer | config:yes | sessions:0`
- [ ] Verify integration with Claude Code by adding to `.claude/settings.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)