### PR TITLE
fix: increase maxHeartbeats for 13-field Heyting algebra proof (#798)

### DIFF
--- a/crates/portcullis-core/lean/PortcullisCoreBridge.lean
+++ b/crates/portcullis-core/lean/PortcullisCoreBridge.lean
@@ -303,6 +303,9 @@ private def latticeCompl (a : CapabilityLattice) : CapabilityLattice := {
 -- We define the entire HeytingAlgebra in one `where` block to avoid
 -- instance chain mismatches between LE, PartialOrder, SemilatticeInf.
 
+-- Increase heartbeats for the 13-field product lattice proofs (#798).
+-- The `simp only` in le_himp_iff needs more reduction steps than the default 200000.
+set_option maxHeartbeats 800000 in
 instance instHeytingAlgebra : HeytingAlgebra CapabilityLattice where
   le := latticeLE
   lt a b := latticeLE a b ∧ ¬latticeLE b a


### PR DESCRIPTION
The CapabilityLattice HeytingAlgebra instance needs more heartbeats than the default 200000 because `simp only` must unfold 13-field struct operations for `le_himp_iff`.

Set to 800000. This has been broken for the entire session (100+ cancelled/failed Aeneas CI runs).

Closes #798

🤖 Generated with [Claude Code](https://claude.com/claude-code)