### PR TITLE
Extract denial formatting from main.rs (-309 lines)

### DIFF
--- a/.line-ratchet.toml
+++ b/.line-ratchet.toml
@@ -9,7 +9,7 @@
 
 [ratchet]
 # Current maximum allowed line count for each file.
-ceiling = 2715
+ceiling = 2406
 # The target we're ratcheting toward.
 target = 1000
 # How many lines to reduce per merge to main.

--- a/crates/nucleus-claude-hook/src/classify.rs
+++ b/crates/nucleus-claude-hook/src/classify.rs
@@ -555,6 +555,70 @@ impl LeafTracker {
 // Tests
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// Subject extraction from tool_input
+// ---------------------------------------------------------------------------
+
+/// Extract a human-readable subject from the tool_input JSON.
+pub(crate) fn extract_subject(tool_name: &str, input: &serde_json::Value) -> String {
+    match tool_name {
+        "Bash" => input
+            .get("command")
+            .and_then(|v| v.as_str())
+            .unwrap_or("(unknown)")
+            .to_string(),
+        "Read" => input
+            .get("file_path")
+            .and_then(|v| v.as_str())
+            .unwrap_or("(unknown)")
+            .to_string(),
+        "Write" => input
+            .get("file_path")
+            .and_then(|v| v.as_str())
+            .unwrap_or("(unknown)")
+            .to_string(),
+        "Edit" => input
+            .get("file_path")
+            .and_then(|v| v.as_str())
+            .unwrap_or("(unknown)")
+            .to_string(),
+        "Glob" => input
+            .get("pattern")
+            .and_then(|v| v.as_str())
+            .unwrap_or("*")
+            .to_string(),
+        "Grep" => input
+            .get("pattern")
+            .and_then(|v| v.as_str())
+            .unwrap_or("(unknown)")
+            .to_string(),
+        "WebFetch" => input
+            .get("url")
+            .and_then(|v| v.as_str())
+            .unwrap_or("(unknown)")
+            .to_string(),
+        "WebSearch" => input
+            .get("query")
+            .and_then(|v| v.as_str())
+            .unwrap_or("(unknown)")
+            .to_string(),
+        _ if tool_name.starts_with("mcp__") => {
+            // For MCP tools, combine tool name + first string argument as subject
+            let tool_part = tool_name.strip_prefix("mcp__").unwrap_or(tool_name);
+            let arg = input
+                .as_object()
+                .and_then(|obj| obj.values().find_map(|v| v.as_str().map(|s| s.to_string())))
+                .unwrap_or_default();
+            if arg.is_empty() {
+                tool_part.to_string()
+            } else {
+                format!("{tool_part}: {arg}")
+            }
+        }
+        _ => "(unknown)".to_string(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -857,6 +921,18 @@ mod tests {
         // Low < Medium < High
         assert!(Confidence::Low < Confidence::Medium);
         assert!(Confidence::Medium < Confidence::High);
+    }
+
+    #[test]
+    fn test_extract_subject_bash() {
+        let input = serde_json::json!({"command": "ls -la"});
+        assert_eq!(extract_subject("Bash", &input), "ls -la");
+    }
+
+    #[test]
+    fn test_extract_subject_read() {
+        let input = serde_json::json!({"file_path": "/etc/passwd"});
+        assert_eq!(extract_subject("Read", &input), "/etc/passwd");
     }
 
     #[test]

--- a/crates/nucleus-claude-hook/src/denial.rs
+++ b/crates/nucleus-claude-hook/src/denial.rs
@@ -1,0 +1,242 @@
+//! Human-readable denial formatting.
+//!
+//! Converts `DenyReason` variants into actionable messages for Claude Code
+//! users, including "How to fix" guidance for each denial type.
+
+use portcullis::Operation;
+
+/// Format a denial reason as a human-readable message for Claude Code users.
+///
+/// Instead of raw Rust Debug output like `FlowViolation { rule: "AuthorityEscalation" }`,
+/// produce actionable messages like "Blocked: this write depends on web content."
+pub(crate) fn format_denial_for_user(
+    reason: &portcullis::kernel::DenyReason,
+    operation: Operation,
+    compartment: Option<&str>,
+) -> String {
+    use portcullis::kernel::DenyReason;
+
+    let comp_hint = compartment
+        .map(|c| format!(" (compartment: {c})"))
+        .unwrap_or_default();
+
+    match reason {
+        DenyReason::InsufficientCapability => {
+            let fix = match compartment {
+                Some("research") => "\n  How to fix:\n  \
+                    - Switch to 'draft' compartment (enables writes) or 'execute' (enables bash)\n  \
+                    - Or change the profile to allow this operation in .nucleus/policy.toml",
+                Some("draft") if operation == Operation::RunBash => "\n  How to fix:\n  \
+                    - Switch to 'execute' compartment to run commands\n  \
+                    - Draft compartment only allows read + write (no execution)",
+                Some("draft") if matches!(operation, Operation::WebFetch | Operation::WebSearch) => {
+                    "\n  How to fix:\n  \
+                    - Switch to 'research' compartment for web access\n  \
+                    - Draft compartment blocks web to prevent taint"
+                }
+                _ => "\n  How to fix:\n  \
+                    - Change the profile's capability for this operation in .nucleus/policy.toml\n  \
+                    - Or use a more permissive profile: NUCLEUS_PROFILE=permissive",
+            };
+            format!("Blocked: {operation} is not allowed in the current profile{comp_hint}.{fix}")
+        }
+        DenyReason::FlowViolation { rule, .. } => {
+            let (explanation, fix) = if rule.contains("AuthorityEscalation") {
+                (
+                    "This operation depends on web content (adversarial/untrusted). \
+                     Web-influenced data cannot steer writes, execution, or git operations.",
+                    if compartment.is_some() {
+                        "\n  How to fix:\n  \
+                        - Switch to 'draft' compartment (resets the flow graph, clears taint)\n  \
+                        - Or use separate sessions: research in one, code in another"
+                    } else {
+                        "\n  How to fix:\n  \
+                        - Restart Claude Code to clear the taint and try again\n  \
+                        - Or use separate sessions: research in one, code in another\n  \
+                        - Or enable compartments: NUCLEUS_COMPARTMENT=research"
+                    },
+                )
+            } else if rule.contains("Exfiltration") {
+                (
+                    "This operation would exfiltrate secret data to an external sink.",
+                    "\n  How to fix:\n  \
+                    - Avoid mixing secret file reads with network operations in the same session\n  \
+                    - Or declassify the data if it's not actually secret",
+                )
+            } else if rule.contains("IntegrityViolation") {
+                (
+                    "This operation would use untrusted data in a trusted-only context.",
+                    "\n  How to fix:\n  \
+                    - Validate or re-derive the data from a trusted source\n  \
+                    - Or switch compartments to reset the flow graph",
+                )
+            } else {
+                (
+                    "Information flow policy prevents this operation.",
+                    "\n  How to fix:\n  \
+                    - Restart the session or switch compartments to clear taint",
+                )
+            };
+            format!("Blocked: {explanation}{comp_hint}{fix}")
+        }
+        DenyReason::CommandBlocked { command } => {
+            let short_cmd = if command.len() > 60 {
+                format!("{}...", &command[..57])
+            } else {
+                command.clone()
+            };
+            format!(
+                "Blocked: command '{short_cmd}' is not allowed by the command policy{comp_hint}.\n  \
+                How to fix:\n  \
+                - Add the command to the allowlist in .nucleus/policy.toml under [profile.commands]\n  \
+                - Or use a more permissive profile"
+            )
+        }
+        DenyReason::PathBlocked { path } => {
+            format!(
+                "Blocked: access to '{path}' is restricted by path policy{comp_hint}.\n  \
+                How to fix:\n  \
+                - Add the path to [profile.paths.allowed] in .nucleus/policy.toml\n  \
+                - Or remove it from [profile.paths.blocked]"
+            )
+        }
+        DenyReason::BudgetExhausted { remaining_usd } => {
+            format!(
+                "Blocked: budget exhausted (remaining: ${remaining_usd}).\n  \
+                How to fix:\n  \
+                - Increase max_cost_usd in .nucleus/policy.toml\n  \
+                - Or start a new session with a fresh budget"
+            )
+        }
+        DenyReason::TimeExpired { expired_at } => {
+            format!(
+                "Blocked: session expired at {expired_at}.\n  \
+                How to fix:\n  \
+                - Start a new session (restart Claude Code)\n  \
+                - Or increase duration_hours in .nucleus/policy.toml"
+            )
+        }
+        DenyReason::IsolationInsufficient { required, actual } => {
+            format!(
+                "Blocked: requires {required} isolation but running in {actual}.\n  \
+                How to fix:\n  \
+                - Run in a container (Docker/Colima) or Firecracker microVM\n  \
+                - Or lower the minimum isolation in the policy"
+            )
+        }
+        DenyReason::IsolationGated { dimension } => {
+            format!(
+                "Blocked: {dimension} is not available in the current isolation level.\n  \
+                How to fix:\n  \
+                - Run in a higher isolation environment (container or microVM)"
+            )
+        }
+        DenyReason::EgressBlocked { policy_reason, .. } => format!(
+            "{policy_reason}\n  How to fix:\n  \
+            - Add the host to allowed_hosts in .nucleus/egress.toml\n  \
+            - Or remove egress.toml to disable egress filtering"
+        ),
+        DenyReason::PolicyDenied {
+            rule_name,
+            sink_class,
+        } => {
+            format!(
+                "Blocked: admissibility rule '{rule_name}' denied this operation (sink: {sink_class}){comp_hint}.\n  \
+                How to fix:\n  \
+                - Review the rule in .nucleus/policy.toml under [[admissibility]]\n  \
+                - Adjust source_predicate or artifact_predicate to match your data labels\n  \
+                - Or change the rule's verdict to 'allow' or 'requires_approval'"
+            )
+        }
+        DenyReason::EnterpriseBlocked { detail } => {
+            format!(
+                "Blocked: enterprise policy denied this operation: {detail}{comp_hint}.\n  \
+                How to fix:\n  \
+                - Ask your organization admin to update .nucleus/enterprise.toml\n  \
+                - Add the sink class to allowed_sinks or remove it from denied_sinks"
+            )
+        }
+        DenyReason::DelegationDenied { detail } => {
+            format!(
+                "Blocked: delegation constraint violated: {detail}{comp_hint}.\n  \
+                How to fix:\n  \
+                - Check that the delegation has not expired\n  \
+                - Ensure the delegation depth has not been exhausted\n  \
+                - Verify AgentSpawn is in the delegation scope's allowed_sinks"
+            )
+        }
+        DenyReason::InvalidDeclassification { detail } => {
+            format!(
+                "Blocked: declassification token rejected: {detail}{comp_hint}.\n  \
+                How to fix:\n  \
+                - Ensure the declassification token is signed by a trusted key\n  \
+                - Check that set_trusted_keys() includes the signing key's public key"
+            )
+        }
+        DenyReason::SinkScopeDenied {
+            dimension, detail, ..
+        } => {
+            format!(
+                "Blocked: certificate sink scope denied ({dimension}): {detail}{comp_hint}.\n  \
+                How to fix:\n  \
+                - Check the delegation certificate's sink_scope restrictions\n  \
+                - Ensure the target {dimension} is in the allowed list"
+            )
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use portcullis::kernel::DenyReason;
+
+    #[test]
+    fn test_denial_messages_include_how_to_fix() {
+        // Capability denial
+        let msg = format_denial_for_user(
+            &DenyReason::InsufficientCapability,
+            Operation::RunBash,
+            Some("draft"),
+        );
+        assert!(msg.contains("How to fix"), "capability denial: {msg}");
+        assert!(
+            msg.contains("execute"),
+            "should suggest execute compartment"
+        );
+
+        // Flow violation (web taint)
+        let msg = format_denial_for_user(
+            &DenyReason::FlowViolation {
+                rule: "AuthorityEscalation".to_string(),
+                receipt: None,
+            },
+            Operation::WriteFiles,
+            Some("research"),
+        );
+        assert!(msg.contains("How to fix"), "flow violation: {msg}");
+        assert!(msg.contains("draft"), "should suggest draft compartment");
+
+        // Budget exhausted
+        let msg = format_denial_for_user(
+            &DenyReason::BudgetExhausted {
+                remaining_usd: "0.00".to_string(),
+            },
+            Operation::ReadFiles,
+            None,
+        );
+        assert!(msg.contains("How to fix"), "budget: {msg}");
+        assert!(msg.contains("max_cost_usd"), "should mention config key");
+
+        // Path blocked
+        let msg = format_denial_for_user(
+            &DenyReason::PathBlocked {
+                path: "/etc/shadow".to_string(),
+            },
+            Operation::ReadFiles,
+            None,
+        );
+        assert!(msg.contains("How to fix"), "path blocked: {msg}");
+        assert!(msg.contains("policy.toml"), "should mention config file");
+    }
+}

--- a/crates/nucleus-claude-hook/src/main.rs
+++ b/crates/nucleus-claude-hook/src/main.rs
@@ -25,6 +25,7 @@ mod cli;
 mod color;
 mod completions;
 mod context;
+mod denial;
 mod exit_codes;
 mod help;
 mod init;
@@ -35,6 +36,7 @@ mod web_taint;
 
 use classify::*;
 use color::{nucleus_allow, nucleus_deny, nucleus_info, nucleus_warn};
+use denial::format_denial_for_user;
 use protocol::{HookInput, HookOutput};
 use session::{
     compartment_file_path, gc_stale_sessions, generate_compartment_token, keyed_compartment_name,
@@ -187,252 +189,7 @@ fn persist_transition_receipt(session_id: &str, from: Option<&str>, to: &str, di
     }
 }
 
-// ---------------------------------------------------------------------------
-// Subject extraction from tool_input
-// ---------------------------------------------------------------------------
-
-/// Extract a human-readable subject from the tool_input JSON.
-/// Format a denial reason as a human-readable message for Claude Code users.
-///
-/// Instead of raw Rust Debug output like `FlowViolation { rule: "AuthorityEscalation" }`,
-/// produce actionable messages like "Blocked: this write depends on web content."
-fn format_denial_for_user(
-    reason: &portcullis::kernel::DenyReason,
-    operation: Operation,
-    compartment: Option<&str>,
-) -> String {
-    use portcullis::kernel::DenyReason;
-
-    let comp_hint = compartment
-        .map(|c| format!(" (compartment: {c})"))
-        .unwrap_or_default();
-
-    match reason {
-        DenyReason::InsufficientCapability => {
-            let fix = match compartment {
-                Some("research") => "\n  How to fix:\n  \
-                    - Switch to 'draft' compartment (enables writes) or 'execute' (enables bash)\n  \
-                    - Or change the profile to allow this operation in .nucleus/policy.toml",
-                Some("draft") if operation == Operation::RunBash => "\n  How to fix:\n  \
-                    - Switch to 'execute' compartment to run commands\n  \
-                    - Draft compartment only allows read + write (no execution)",
-                Some("draft") if matches!(operation, Operation::WebFetch | Operation::WebSearch) => {
-                    "\n  How to fix:\n  \
-                    - Switch to 'research' compartment for web access\n  \
-                    - Draft compartment blocks web to prevent taint"
-                }
-                _ => "\n  How to fix:\n  \
-                    - Change the profile's capability for this operation in .nucleus/policy.toml\n  \
-                    - Or use a more permissive profile: NUCLEUS_PROFILE=permissive",
-            };
-            format!("Blocked: {operation} is not allowed in the current profile{comp_hint}.{fix}")
-        }
-        DenyReason::FlowViolation { rule, .. } => {
-            let (explanation, fix) = if rule.contains("AuthorityEscalation") {
-                (
-                    "This operation depends on web content (adversarial/untrusted). \
-                     Web-influenced data cannot steer writes, execution, or git operations.",
-                    if compartment.is_some() {
-                        "\n  How to fix:\n  \
-                        - Switch to 'draft' compartment (resets the flow graph, clears taint)\n  \
-                        - Or use separate sessions: research in one, code in another"
-                    } else {
-                        "\n  How to fix:\n  \
-                        - Restart Claude Code to clear the taint and try again\n  \
-                        - Or use separate sessions: research in one, code in another\n  \
-                        - Or enable compartments: NUCLEUS_COMPARTMENT=research"
-                    },
-                )
-            } else if rule.contains("Exfiltration") {
-                (
-                    "This operation would exfiltrate secret data to an external sink.",
-                    "\n  How to fix:\n  \
-                    - Avoid mixing secret file reads with network operations in the same session\n  \
-                    - Or declassify the data if it's not actually secret",
-                )
-            } else if rule.contains("IntegrityViolation") {
-                (
-                    "This operation would use untrusted data in a trusted-only context.",
-                    "\n  How to fix:\n  \
-                    - Validate or re-derive the data from a trusted source\n  \
-                    - Or switch compartments to reset the flow graph",
-                )
-            } else {
-                (
-                    "Information flow policy prevents this operation.",
-                    "\n  How to fix:\n  \
-                    - Restart the session or switch compartments to clear taint",
-                )
-            };
-            format!("Blocked: {explanation}{comp_hint}{fix}")
-        }
-        DenyReason::CommandBlocked { command } => {
-            let short_cmd = if command.len() > 60 {
-                format!("{}...", &command[..57])
-            } else {
-                command.clone()
-            };
-            format!(
-                "Blocked: command '{short_cmd}' is not allowed by the command policy{comp_hint}.\n  \
-                How to fix:\n  \
-                - Add the command to the allowlist in .nucleus/policy.toml under [profile.commands]\n  \
-                - Or use a more permissive profile"
-            )
-        }
-        DenyReason::PathBlocked { path } => {
-            format!(
-                "Blocked: access to '{path}' is restricted by path policy{comp_hint}.\n  \
-                How to fix:\n  \
-                - Add the path to [profile.paths.allowed] in .nucleus/policy.toml\n  \
-                - Or remove it from [profile.paths.blocked]"
-            )
-        }
-        DenyReason::BudgetExhausted { remaining_usd } => {
-            format!(
-                "Blocked: budget exhausted (remaining: ${remaining_usd}).\n  \
-                How to fix:\n  \
-                - Increase max_cost_usd in .nucleus/policy.toml\n  \
-                - Or start a new session with a fresh budget"
-            )
-        }
-        DenyReason::TimeExpired { expired_at } => {
-            format!(
-                "Blocked: session expired at {expired_at}.\n  \
-                How to fix:\n  \
-                - Start a new session (restart Claude Code)\n  \
-                - Or increase duration_hours in .nucleus/policy.toml"
-            )
-        }
-        DenyReason::IsolationInsufficient { required, actual } => {
-            format!(
-                "Blocked: requires {required} isolation but running in {actual}.\n  \
-                How to fix:\n  \
-                - Run in a container (Docker/Colima) or Firecracker microVM\n  \
-                - Or lower the minimum isolation in the policy"
-            )
-        }
-        DenyReason::IsolationGated { dimension } => {
-            format!(
-                "Blocked: {dimension} is not available in the current isolation level.\n  \
-                How to fix:\n  \
-                - Run in a higher isolation environment (container or microVM)"
-            )
-        }
-        DenyReason::EgressBlocked { policy_reason, .. } => format!(
-            "{policy_reason}\n  How to fix:\n  \
-            - Add the host to allowed_hosts in .nucleus/egress.toml\n  \
-            - Or remove egress.toml to disable egress filtering"
-        ),
-        DenyReason::PolicyDenied {
-            rule_name,
-            sink_class,
-        } => {
-            format!(
-                "Blocked: admissibility rule '{rule_name}' denied this operation (sink: {sink_class}){comp_hint}.\n  \
-                How to fix:\n  \
-                - Review the rule in .nucleus/policy.toml under [[admissibility]]\n  \
-                - Adjust source_predicate or artifact_predicate to match your data labels\n  \
-                - Or change the rule's verdict to 'allow' or 'requires_approval'"
-            )
-        }
-        DenyReason::EnterpriseBlocked { detail } => {
-            format!(
-                "Blocked: enterprise policy denied this operation: {detail}{comp_hint}.\n  \
-                How to fix:\n  \
-                - Ask your organization admin to update .nucleus/enterprise.toml\n  \
-                - Add the sink class to allowed_sinks or remove it from denied_sinks"
-            )
-        }
-        DenyReason::DelegationDenied { detail } => {
-            format!(
-                "Blocked: delegation constraint violated: {detail}{comp_hint}.\n  \
-                How to fix:\n  \
-                - Check that the delegation has not expired\n  \
-                - Ensure the delegation depth has not been exhausted\n  \
-                - Verify AgentSpawn is in the delegation scope's allowed_sinks"
-            )
-        }
-        DenyReason::InvalidDeclassification { detail } => {
-            format!(
-                "Blocked: declassification token rejected: {detail}{comp_hint}.\n  \
-                How to fix:\n  \
-                - Ensure the declassification token is signed by a trusted key\n  \
-                - Check that set_trusted_keys() includes the signing key's public key"
-            )
-        }
-        DenyReason::SinkScopeDenied {
-            dimension, detail, ..
-        } => {
-            format!(
-                "Blocked: certificate sink scope denied ({dimension}): {detail}{comp_hint}.\n  \
-                How to fix:\n  \
-                - Check the delegation certificate's sink_scope restrictions\n  \
-                - Ensure the target {dimension} is in the allowed list"
-            )
-        }
-    }
-}
-
 use context::{current_fingerprint, maybe_build_context};
-
-fn extract_subject(tool_name: &str, input: &serde_json::Value) -> String {
-    match tool_name {
-        "Bash" => input
-            .get("command")
-            .and_then(|v| v.as_str())
-            .unwrap_or("(unknown)")
-            .to_string(),
-        "Read" => input
-            .get("file_path")
-            .and_then(|v| v.as_str())
-            .unwrap_or("(unknown)")
-            .to_string(),
-        "Write" => input
-            .get("file_path")
-            .and_then(|v| v.as_str())
-            .unwrap_or("(unknown)")
-            .to_string(),
-        "Edit" => input
-            .get("file_path")
-            .and_then(|v| v.as_str())
-            .unwrap_or("(unknown)")
-            .to_string(),
-        "Glob" => input
-            .get("pattern")
-            .and_then(|v| v.as_str())
-            .unwrap_or("*")
-            .to_string(),
-        "Grep" => input
-            .get("pattern")
-            .and_then(|v| v.as_str())
-            .unwrap_or("(unknown)")
-            .to_string(),
-        "WebFetch" => input
-            .get("url")
-            .and_then(|v| v.as_str())
-            .unwrap_or("(unknown)")
-            .to_string(),
-        "WebSearch" => input
-            .get("query")
-            .and_then(|v| v.as_str())
-            .unwrap_or("(unknown)")
-            .to_string(),
-        _ if tool_name.starts_with("mcp__") => {
-            // For MCP tools, combine tool name + first string argument as subject
-            let tool_part = tool_name.strip_prefix("mcp__").unwrap_or(tool_name);
-            let arg = input
-                .as_object()
-                .and_then(|obj| obj.values().find_map(|v| v.as_str().map(|s| s.to_string())))
-                .unwrap_or_default();
-            if arg.is_empty() {
-                tool_part.to_string()
-            } else {
-                format!("{tool_part}: {arg}")
-            }
-        }
-        _ => "(unknown)".to_string(),
-    }
-}
 
 // ---------------------------------------------------------------------------
 // Profile resolution
@@ -2269,18 +2026,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_extract_subject_bash() {
-        let input = serde_json::json!({"command": "ls -la"});
-        assert_eq!(extract_subject("Bash", &input), "ls -la");
-    }
-
-    #[test]
-    fn test_extract_subject_read() {
-        let input = serde_json::json!({"file_path": "/etc/passwd"});
-        assert_eq!(extract_subject("Read", &input), "/etc/passwd");
-    }
-
-    #[test]
     fn test_resolve_all_profiles() {
         for name in PROFILES {
             assert!(
@@ -2656,60 +2401,5 @@ mod tests {
             write_parents.contains(&post_id),
             "Write action should depend on post-tool WebContent observation"
         );
-    }
-
-    // ─────────────────────────────────────────────────────────────────────
-    // Actionable denial message tests (#544)
-    // ─────────────────────────────────────────────────────────────────────
-
-    #[test]
-    fn test_denial_messages_include_how_to_fix() {
-        use portcullis::kernel::DenyReason;
-
-        // Capability denial
-        let msg = format_denial_for_user(
-            &DenyReason::InsufficientCapability,
-            Operation::RunBash,
-            Some("draft"),
-        );
-        assert!(msg.contains("How to fix"), "capability denial: {msg}");
-        assert!(
-            msg.contains("execute"),
-            "should suggest execute compartment"
-        );
-
-        // Flow violation (web taint)
-        let msg = format_denial_for_user(
-            &DenyReason::FlowViolation {
-                rule: "AuthorityEscalation".to_string(),
-                receipt: None,
-            },
-            Operation::WriteFiles,
-            Some("research"),
-        );
-        assert!(msg.contains("How to fix"), "flow violation: {msg}");
-        assert!(msg.contains("draft"), "should suggest draft compartment");
-
-        // Budget exhausted
-        let msg = format_denial_for_user(
-            &DenyReason::BudgetExhausted {
-                remaining_usd: "0.00".to_string(),
-            },
-            Operation::ReadFiles,
-            None,
-        );
-        assert!(msg.contains("How to fix"), "budget: {msg}");
-        assert!(msg.contains("max_cost_usd"), "should mention config key");
-
-        // Path blocked
-        let msg = format_denial_for_user(
-            &DenyReason::PathBlocked {
-                path: "/etc/shadow".to_string(),
-            },
-            Operation::ReadFiles,
-            None,
-        );
-        assert!(msg.contains("How to fix"), "path blocked: {msg}");
-        assert!(msg.contains("policy.toml"), "should mention config file");
     }
 }


### PR DESCRIPTION
## Summary
- Extract `format_denial_for_user()` into new `denial.rs` module with its tests
- Move `extract_subject()` into `classify.rs` where it belongs with other tool classification logic
- Fix misplaced doc comment that was attached to `format_denial_for_user` instead of `extract_subject`
- Update `.line-ratchet.toml` ceiling from 2715 to 2406

## Test plan
- [x] All 163 nucleus-claude-hook tests pass
- [x] All pre-commit hooks pass (fmt, clippy, deny, audit, line-ratchet)
- [x] No logic changes -- pure extraction

🤖 Generated with [Claude Code](https://claude.com/claude-code)