### PR TITLE
feat: require ReductionWitness for clearance (#860)

### DIFF
--- a/crates/portcullis-core/src/envelope.rs
+++ b/crates/portcullis-core/src/envelope.rs
@@ -394,6 +394,7 @@ impl RowEnvelope {
         &mut self,
         field_name: &str,
         request: &crate::promotion::PromotionRequest,
+        witness: Option<&crate::witness::ReductionWitness>,
         now: u64,
     ) -> Result<crate::promotion::PromotionResult, PromotionApiError> {
         let field = self
@@ -401,8 +402,8 @@ impl RowEnvelope {
             .get_mut(field_name)
             .ok_or_else(|| PromotionApiError::FieldNotFound(field_name.to_string()))?;
 
-        let result =
-            crate::promotion::promote(field, request, now).map_err(PromotionApiError::Promotion)?;
+        let result = crate::promotion::promote(field, request, witness, now)
+            .map_err(PromotionApiError::Promotion)?;
 
         // Re-derive row-level derivation class after mutation.
         self.row_derivation_class = self.compute_derivation_class();
@@ -429,6 +430,7 @@ impl RowEnvelope {
     pub fn promote_all(
         &mut self,
         request: &crate::promotion::PromotionRequest,
+        witness: Option<&crate::witness::ReductionWitness>,
         now: u64,
     ) -> Result<Vec<(String, crate::promotion::PromotionResult)>, PromotionApiError> {
         // Collect field names and their current derivation classes to avoid
@@ -453,7 +455,7 @@ impl RowEnvelope {
             per_field_request.target_field = name.clone();
             per_field_request.from_derivation = current_derivation;
 
-            let result = crate::promotion::promote(field, &per_field_request, now)
+            let result = crate::promotion::promote(field, &per_field_request, witness, now)
                 .map_err(PromotionApiError::Promotion)?;
             results.push((name, result));
         }
@@ -999,6 +1001,33 @@ mod tests {
     // ═══════════════════════════════════════════════════════════════════
 
     use crate::promotion::{PromotionRequest, PromotionScope};
+    use crate::witness::{ParserStep, ReductionWitness, ValidationResult};
+
+    fn envelope_sha256(data: &[u8]) -> [u8; 32] {
+        use sha2::{Digest, Sha256};
+        Sha256::digest(data).into()
+    }
+
+    fn make_valid_witness() -> ReductionWitness {
+        let source = envelope_sha256(b"raw web content");
+        let parsed = envelope_sha256(b"parsed json");
+        ReductionWitness {
+            source_hash: source,
+            parser_steps: vec![ParserStep {
+                parser_id: "json_parser".to_string(),
+                parser_version: "1.0.0".to_string(),
+                parser_hash: envelope_sha256(b"json_parser_binary"),
+                input_hash: source,
+                output_hash: parsed,
+            }],
+            validation_steps: vec![ValidationResult {
+                validator_id: "schema_check".to_string(),
+                version: "1.0.0".to_string(),
+                passed: true,
+            }],
+            output_hash: parsed,
+        }
+    }
 
     fn base_promotion_request(field: &str, from: DerivationClass) -> PromotionRequest {
         PromotionRequest {
@@ -1030,8 +1059,9 @@ mod tests {
         assert_eq!(row.row_derivation_class, DerivationClass::AIDerived);
 
         let req = base_promotion_request("gen", DerivationClass::AIDerived);
+        let witness = make_valid_witness();
         let result = row
-            .promote_field("gen", &req, 2000)
+            .promote_field("gen", &req, Some(&witness), 2000)
             .expect("should succeed");
 
         assert!(result.promoted);
@@ -1062,7 +1092,9 @@ mod tests {
         let mut row = RowEnvelope::new("r1".into(), "t".into(), fields, None, "v1".into(), 1000);
 
         let req = base_promotion_request("nonexistent", DerivationClass::AIDerived);
-        let err = row.promote_field("nonexistent", &req, 2000).unwrap_err();
+        let err = row
+            .promote_field("nonexistent", &req, None, 2000)
+            .unwrap_err();
         assert_eq!(err, PromotionApiError::FieldNotFound("nonexistent".into()),);
     }
 
@@ -1084,7 +1116,10 @@ mod tests {
         assert_eq!(row.row_derivation_class, DerivationClass::Mixed);
 
         let req = base_promotion_request("ignored", DerivationClass::AIDerived);
-        let results = row.promote_all(&req, 3000).expect("should succeed");
+        let witness = make_valid_witness();
+        let results = row
+            .promote_all(&req, Some(&witness), 3000)
+            .expect("should succeed");
 
         // Two fields promoted (AIDerived and Mixed); Deterministic skipped.
         assert_eq!(results.len(), 2);
@@ -1135,7 +1170,8 @@ mod tests {
         assert!(row.is_verified_ready());
 
         let req = base_promotion_request("gen", DerivationClass::AIDerived);
-        row.promote_field("gen", &req, 2000)
+        let witness = make_valid_witness();
+        row.promote_field("gen", &req, Some(&witness), 2000)
             .expect("should succeed");
 
         // After promotion: HumanPromoted with witness_bundle_id + promoted_by => verified-ready.
@@ -1160,7 +1196,9 @@ mod tests {
         let mut row = RowEnvelope::new("r4".into(), "t".into(), fields, None, "v1".into(), 1000);
 
         let req = base_promotion_request("ignored", DerivationClass::AIDerived);
-        row.promote_all(&req, 4000).expect("should succeed");
+        let witness = make_valid_witness();
+        row.promote_all(&req, Some(&witness), 4000)
+            .expect("should succeed");
 
         // All promoted fields now have witness_bundle_id + promoted_by.
         assert!(row.is_verified_ready());
@@ -1182,7 +1220,7 @@ mod tests {
         let mut row = RowEnvelope::new("r5".into(), "t".into(), fields, None, "v1".into(), 1000);
 
         let req = base_promotion_request("ignored", DerivationClass::HumanPromoted);
-        let results = row.promote_all(&req, 5000).expect("should succeed");
+        let results = row.promote_all(&req, None, 5000).expect("should succeed");
 
         // No fields to promote.
         assert!(results.is_empty());

--- a/crates/portcullis-core/src/promotion.rs
+++ b/crates/portcullis-core/src/promotion.rs
@@ -27,6 +27,7 @@
 use crate::DerivationClass;
 use crate::SinkClass;
 use crate::envelope::FieldEnvelope;
+use crate::witness::ReductionWitness;
 
 // ═══════════════════════════════════════════════════════════════════════════
 // PromotionScope — where promoted data may flow
@@ -117,6 +118,13 @@ pub enum PromotionError {
     /// Cannot promote `Deterministic` data — it is already the strongest
     /// reproducibility class and does not need human attestation.
     CannotPromoteDeterministic,
+    /// Content was evacuated from the airlock. A valid `ReductionWitness`
+    /// is required to promote non-deterministic data, but was missing or
+    /// invalid.
+    AirlockEvacuated {
+        /// Human-readable explanation of why the content was evacuated.
+        reason: String,
+    },
 }
 
 impl core::fmt::Display for PromotionError {
@@ -139,6 +147,9 @@ impl core::fmt::Display for PromotionError {
             Self::AlreadyPromoted => write!(f, "field is already HumanPromoted"),
             Self::CannotPromoteDeterministic => {
                 write!(f, "deterministic data does not need promotion")
+            }
+            Self::AirlockEvacuated { reason } => {
+                write!(f, "airlock evacuated: {reason}")
             }
         }
     }
@@ -163,6 +174,7 @@ impl core::fmt::Display for PromotionError {
 pub fn promote(
     envelope: &mut FieldEnvelope,
     request: &PromotionRequest,
+    witness: Option<&ReductionWitness>,
     now: u64,
 ) -> Result<PromotionResult, PromotionError> {
     // --- validation ---
@@ -194,6 +206,35 @@ pub fn promote(
         });
     }
 
+    // --- reduction witness gate ---
+    //
+    // Non-deterministic derivation classes require a valid ReductionWitness.
+    // This ensures raw content cannot be promoted without being processed
+    // through a deterministic parser chain first.
+    match envelope.derivation_class {
+        DerivationClass::AIDerived | DerivationClass::Mixed | DerivationClass::OpaqueExternal => {
+            match witness {
+                None => {
+                    return Err(PromotionError::AirlockEvacuated {
+                        reason: format!(
+                            "{:?} content requires a ReductionWitness for promotion",
+                            envelope.derivation_class
+                        ),
+                    });
+                }
+                Some(w) if !w.is_valid() => {
+                    return Err(PromotionError::AirlockEvacuated {
+                        reason: "ReductionWitness is invalid: chain broken or validation failed"
+                            .to_string(),
+                    });
+                }
+                Some(_) => { /* valid witness, proceed */ }
+            }
+        }
+        // Deterministic and HumanPromoted are handled above (early returns).
+        _ => {}
+    }
+
     // --- apply promotion ---
 
     let original = envelope.derivation_class;
@@ -219,7 +260,14 @@ mod tests {
     use super::*;
     use crate::IFCLabel;
     use crate::effect::EffectKind;
+    use crate::witness::{ParserStep, ValidationResult};
     use sha2::{Digest, Sha256};
+
+    fn sha256(data: &[u8]) -> [u8; 32] {
+        let mut hasher = Sha256::new();
+        hasher.update(data);
+        hasher.finalize().into()
+    }
 
     /// Helper: build a minimal `FieldEnvelope` with the given derivation class.
     fn make_envelope(derivation: DerivationClass) -> FieldEnvelope {
@@ -254,11 +302,34 @@ mod tests {
         }
     }
 
+    fn make_valid_witness() -> ReductionWitness {
+        let source = sha256(b"raw web content");
+        let parsed = sha256(b"parsed json");
+        ReductionWitness {
+            source_hash: source,
+            parser_steps: vec![ParserStep {
+                parser_id: "json_parser".to_string(),
+                parser_version: "1.0.0".to_string(),
+                parser_hash: sha256(b"json_parser_binary"),
+                input_hash: source,
+                output_hash: parsed,
+            }],
+            validation_steps: vec![ValidationResult {
+                validator_id: "schema_check".to_string(),
+                version: "1.0.0".to_string(),
+                passed: true,
+            }],
+            output_hash: parsed,
+        }
+    }
+
     #[test]
     fn successful_promotion() {
         let mut env = make_envelope(DerivationClass::AIDerived);
         let req = base_request();
-        let result = promote(&mut env, &req, 2000).expect("promotion should succeed");
+        let witness = make_valid_witness();
+        let result =
+            promote(&mut env, &req, Some(&witness), 2000).expect("promotion should succeed");
 
         assert!(result.promoted);
         assert_eq!(result.new_derivation, DerivationClass::HumanPromoted);
@@ -284,7 +355,9 @@ mod tests {
         let mut env = make_envelope(DerivationClass::Mixed);
         let mut req = base_request();
         req.from_derivation = DerivationClass::Mixed;
-        let result = promote(&mut env, &req, 2000).expect("mixed promotion should succeed");
+        let witness = make_valid_witness();
+        let result =
+            promote(&mut env, &req, Some(&witness), 2000).expect("mixed promotion should succeed");
 
         assert_eq!(result.original_derivation, DerivationClass::Mixed);
         assert_eq!(env.derivation_class, DerivationClass::HumanPromoted);
@@ -296,9 +369,8 @@ mod tests {
         let mut req = base_request();
         req.principal = String::new();
 
-        let err = promote(&mut env, &req, 2000).unwrap_err();
+        let err = promote(&mut env, &req, None, 2000).unwrap_err();
         assert_eq!(err, PromotionError::EmptyPrincipal);
-        // Envelope unchanged
         assert_eq!(env.derivation_class, DerivationClass::AIDerived);
     }
 
@@ -308,17 +380,16 @@ mod tests {
         let mut req = base_request();
         req.reason = String::new();
 
-        let err = promote(&mut env, &req, 2000).unwrap_err();
+        let err = promote(&mut env, &req, None, 2000).unwrap_err();
         assert_eq!(err, PromotionError::EmptyReason);
     }
 
     #[test]
     fn derivation_mismatch_rejected() {
         let mut env = make_envelope(DerivationClass::Mixed);
-        // Request claims AIDerived but envelope is Mixed
         let req = base_request();
 
-        let err = promote(&mut env, &req, 2000).unwrap_err();
+        let err = promote(&mut env, &req, None, 2000).unwrap_err();
         assert_eq!(
             err,
             PromotionError::DerivationMismatch {
@@ -326,7 +397,6 @@ mod tests {
                 actual: DerivationClass::Mixed,
             }
         );
-        // Envelope unchanged
         assert_eq!(env.derivation_class, DerivationClass::Mixed);
     }
 
@@ -336,7 +406,7 @@ mod tests {
         let mut req = base_request();
         req.expires_at = Some(1500);
 
-        let err = promote(&mut env, &req, 2000).unwrap_err();
+        let err = promote(&mut env, &req, None, 2000).unwrap_err();
         assert_eq!(
             err,
             PromotionError::Expired {
@@ -351,8 +421,10 @@ mod tests {
         let mut env = make_envelope(DerivationClass::AIDerived);
         let mut req = base_request();
         req.expires_at = Some(3000);
+        let witness = make_valid_witness();
 
-        let result = promote(&mut env, &req, 2000).expect("should succeed before expiry");
+        let result =
+            promote(&mut env, &req, Some(&witness), 2000).expect("should succeed before expiry");
         assert!(result.promoted);
     }
 
@@ -362,7 +434,7 @@ mod tests {
         let mut req = base_request();
         req.from_derivation = DerivationClass::HumanPromoted;
 
-        let err = promote(&mut env, &req, 2000).unwrap_err();
+        let err = promote(&mut env, &req, None, 2000).unwrap_err();
         assert_eq!(err, PromotionError::AlreadyPromoted);
     }
 
@@ -372,7 +444,7 @@ mod tests {
         let mut req = base_request();
         req.from_derivation = DerivationClass::Deterministic;
 
-        let err = promote(&mut env, &req, 2000).unwrap_err();
+        let err = promote(&mut env, &req, None, 2000).unwrap_err();
         assert_eq!(err, PromotionError::CannotPromoteDeterministic);
     }
 
@@ -382,8 +454,10 @@ mod tests {
         let mut req = base_request();
         req.scope =
             PromotionScope::SpecificSinks(vec![SinkClass::WorkspaceWrite, SinkClass::GitCommit]);
+        let witness = make_valid_witness();
 
-        let result = promote(&mut env, &req, 2000).expect("scoped promotion should succeed");
+        let result =
+            promote(&mut env, &req, Some(&witness), 2000).expect("scoped promotion should succeed");
         assert!(result.promoted);
     }
 
@@ -392,8 +466,10 @@ mod tests {
         let mut env = make_envelope(DerivationClass::AIDerived);
         let mut req = base_request();
         req.scope = PromotionScope::SingleField;
+        let witness = make_valid_witness();
 
-        let result = promote(&mut env, &req, 2000).expect("single-field promotion should succeed");
+        let result = promote(&mut env, &req, Some(&witness), 2000)
+            .expect("single-field promotion should succeed");
         assert!(result.promoted);
     }
 
@@ -402,10 +478,116 @@ mod tests {
         let mut env = make_envelope(DerivationClass::OpaqueExternal);
         let mut req = base_request();
         req.from_derivation = DerivationClass::OpaqueExternal;
+        let witness = make_valid_witness();
 
-        let result =
-            promote(&mut env, &req, 2000).expect("opaque external promotion should succeed");
+        let result = promote(&mut env, &req, Some(&witness), 2000)
+            .expect("opaque external promotion should succeed");
         assert_eq!(result.original_derivation, DerivationClass::OpaqueExternal);
         assert_eq!(env.derivation_class, DerivationClass::HumanPromoted);
+    }
+
+    // ReductionWitness gate tests (issue #860)
+
+    #[test]
+    fn raw_content_without_witness_evacuated() {
+        let mut env = make_envelope(DerivationClass::AIDerived);
+        let req = base_request();
+
+        let err = promote(&mut env, &req, None, 2000).unwrap_err();
+        match &err {
+            PromotionError::AirlockEvacuated { reason } => {
+                assert!(reason.contains("ReductionWitness"));
+            }
+            other => panic!("expected AirlockEvacuated, got {other:?}"),
+        }
+        assert_eq!(env.derivation_class, DerivationClass::AIDerived);
+    }
+
+    #[test]
+    fn opaque_external_without_witness_evacuated() {
+        let mut env = make_envelope(DerivationClass::OpaqueExternal);
+        let mut req = base_request();
+        req.from_derivation = DerivationClass::OpaqueExternal;
+
+        let err = promote(&mut env, &req, None, 2000).unwrap_err();
+        match &err {
+            PromotionError::AirlockEvacuated { reason } => {
+                assert!(reason.contains("ReductionWitness"));
+            }
+            other => panic!("expected AirlockEvacuated, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn mixed_without_witness_evacuated() {
+        let mut env = make_envelope(DerivationClass::Mixed);
+        let mut req = base_request();
+        req.from_derivation = DerivationClass::Mixed;
+
+        let err = promote(&mut env, &req, None, 2000).unwrap_err();
+        match &err {
+            PromotionError::AirlockEvacuated { reason } => {
+                assert!(reason.contains("ReductionWitness"));
+            }
+            other => panic!("expected AirlockEvacuated, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn web_content_with_valid_witness_cleared() {
+        let mut env = make_envelope(DerivationClass::AIDerived);
+        let req = base_request();
+        let witness = make_valid_witness();
+
+        let result = promote(&mut env, &req, Some(&witness), 2000)
+            .expect("promotion with valid witness should succeed");
+        assert!(result.promoted);
+        assert_eq!(env.derivation_class, DerivationClass::HumanPromoted);
+    }
+
+    #[test]
+    fn invalid_witness_broken_chain_evacuated() {
+        let mut env = make_envelope(DerivationClass::AIDerived);
+        let req = base_request();
+
+        let mut witness = make_valid_witness();
+        witness.parser_steps[0].input_hash = [0xDE; 32];
+        assert!(!witness.is_valid());
+
+        let err = promote(&mut env, &req, Some(&witness), 2000).unwrap_err();
+        match &err {
+            PromotionError::AirlockEvacuated { reason } => {
+                assert!(reason.contains("invalid"));
+            }
+            other => panic!("expected AirlockEvacuated, got {other:?}"),
+        }
+        assert_eq!(env.derivation_class, DerivationClass::AIDerived);
+    }
+
+    #[test]
+    fn invalid_witness_failed_validation_evacuated() {
+        let mut env = make_envelope(DerivationClass::AIDerived);
+        let req = base_request();
+
+        let mut witness = make_valid_witness();
+        witness.validation_steps[0].passed = false;
+
+        let err = promote(&mut env, &req, Some(&witness), 2000).unwrap_err();
+        match &err {
+            PromotionError::AirlockEvacuated { reason } => {
+                assert!(reason.contains("invalid"));
+            }
+            other => panic!("expected AirlockEvacuated, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn deterministic_without_witness_ok() {
+        let mut env = make_envelope(DerivationClass::Deterministic);
+        let mut req = base_request();
+        req.from_derivation = DerivationClass::Deterministic;
+
+        let err = promote(&mut env, &req, None, 2000).unwrap_err();
+        assert_eq!(err, PromotionError::CannotPromoteDeterministic);
     }
 }

--- a/crates/portcullis-core/src/witness.rs
+++ b/crates/portcullis-core/src/witness.rs
@@ -407,6 +407,52 @@ impl WitnessBundle {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
+// ReductionWitness - proof that content was processed through a parser chain
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Proof that raw content was reduced through a deterministic parser chain
+/// before promotion to the verified lane.
+///
+/// Without a valid `ReductionWitness`, promotion of non-deterministic data
+/// (AIDerived, Mixed, OpaqueExternal) is denied.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReductionWitness {
+    /// SHA-256 hash of the raw input content (content-addressed).
+    pub source_hash: [u8; 32],
+    /// Parser steps applied to reduce the raw input.
+    pub parser_steps: Vec<ParserStep>,
+    /// Validation results from all validators applied to the output.
+    pub validation_steps: Vec<ValidationResult>,
+    /// SHA-256 hash of the final reduced output.
+    pub output_hash: [u8; 32],
+}
+
+impl ReductionWitness {
+    /// Check whether this reduction witness is valid.
+    ///
+    /// A witness is valid when:
+    /// 1. The parser chain is intact (each step's output feeds the next input).
+    /// 2. The last parser step's output matches `output_hash`.
+    /// 3. All validation results passed.
+    pub fn is_valid(&self) -> bool {
+        let mut current_hash = self.source_hash;
+        for step in &self.parser_steps {
+            if step.input_hash != current_hash {
+                return false;
+            }
+            current_hash = step.output_hash;
+        }
+        if current_hash != self.output_hash {
+            return false;
+        }
+        if self.validation_steps.iter().any(|v| !v.passed) {
+            return false;
+        }
+        true
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
 // Tests
 // ═══════════════════════════════════════════════════════════════════════════
 
@@ -909,5 +955,104 @@ mod tests {
         assert!(msg.contains("evil"));
         assert!(msg.contains("step 0"));
         assert!(msg.contains("known input hash"));
+    }
+
+    // ReductionWitness tests (issue #860)
+
+    fn make_valid_reduction_witness() -> ReductionWitness {
+        let source = sha256(b"raw web content");
+        let parsed = sha256(b"parsed json");
+        ReductionWitness {
+            source_hash: source,
+            parser_steps: vec![ParserStep {
+                parser_id: "json_parser".to_string(),
+                parser_version: "1.0.0".to_string(),
+                parser_hash: sha256(b"json_parser_binary"),
+                input_hash: source,
+                output_hash: parsed,
+            }],
+            validation_steps: vec![ValidationResult {
+                validator_id: "schema_check".to_string(),
+                version: "1.0.0".to_string(),
+                passed: true,
+            }],
+            output_hash: parsed,
+        }
+    }
+
+    #[test]
+    fn valid_reduction_witness() {
+        let w = make_valid_reduction_witness();
+        assert!(w.is_valid());
+    }
+
+    #[test]
+    fn reduction_witness_broken_chain() {
+        let mut w = make_valid_reduction_witness();
+        w.parser_steps[0].input_hash = [0xDE; 32];
+        assert!(!w.is_valid());
+    }
+
+    #[test]
+    fn reduction_witness_wrong_output() {
+        let mut w = make_valid_reduction_witness();
+        w.output_hash = [0xFF; 32];
+        assert!(!w.is_valid());
+    }
+
+    #[test]
+    fn reduction_witness_failed_validation() {
+        let mut w = make_valid_reduction_witness();
+        w.validation_steps[0].passed = false;
+        assert!(!w.is_valid());
+    }
+
+    #[test]
+    fn reduction_witness_passthrough_no_parsers() {
+        let source = sha256(b"already structured");
+        let w = ReductionWitness {
+            source_hash: source,
+            parser_steps: vec![],
+            validation_steps: vec![ValidationResult {
+                validator_id: "noop".to_string(),
+                version: "1.0.0".to_string(),
+                passed: true,
+            }],
+            output_hash: source,
+        };
+        assert!(w.is_valid());
+    }
+
+    #[test]
+    fn reduction_witness_multi_step_chain() {
+        let source = sha256(b"raw html");
+        let stage1 = sha256(b"stage 1");
+        let stage2 = sha256(b"stage 2");
+        let w = ReductionWitness {
+            source_hash: source,
+            parser_steps: vec![
+                ParserStep {
+                    parser_id: "html_parser".to_string(),
+                    parser_version: "1.0.0".to_string(),
+                    parser_hash: sha256(b"html_parser_binary"),
+                    input_hash: source,
+                    output_hash: stage1,
+                },
+                ParserStep {
+                    parser_id: "text_extractor".to_string(),
+                    parser_version: "1.0.0".to_string(),
+                    parser_hash: sha256(b"text_extractor_binary"),
+                    input_hash: stage1,
+                    output_hash: stage2,
+                },
+            ],
+            validation_steps: vec![ValidationResult {
+                validator_id: "schema_check".to_string(),
+                version: "1.0.0".to_string(),
+                passed: true,
+            }],
+            output_hash: stage2,
+        };
+        assert!(w.is_valid());
     }
 }


### PR DESCRIPTION
## Summary

- Add `ReductionWitness` struct to `witness.rs` with `source_hash`, `parser_steps`, `validation_steps`, `output_hash`, and `is_valid()` chain verification
- Update `promote()` to require `Option<&ReductionWitness>` parameter -- non-deterministic derivation classes (AIDerived, Mixed, OpaqueExternal) are evacuated without a valid witness
- Add `PromotionError::AirlockEvacuated { reason }` variant for missing/invalid witness
- Update `RowEnvelope::promote_field()` and `promote_all()` to thread witness through

## Test plan

- [x] Raw web content promote without witness returns EVACUATED (3 tests: AIDerived, Mixed, OpaqueExternal)
- [x] Web content with valid witness promotes to CLEARED
- [x] Invalid witness (broken chain) returns EVACUATED
- [x] Invalid witness (failed validation) returns EVACUATED
- [x] Deterministic content without witness returns CannotPromoteDeterministic (not AirlockEvacuated)
- [x] All 18 existing WitnessBundle tests still pass
- [x] All 31 envelope tests still pass
- [x] All pre-commit hooks pass (fmt, clippy, deny, audit, test)

Closes #860

Generated with [Claude Code](https://claude.com/claude-code)