### PR TITLE
Extract receipt functions from main.rs into receipts.rs

### DIFF
--- a/.line-ratchet.toml
+++ b/.line-ratchet.toml
@@ -9,7 +9,7 @@
 
 [ratchet]
 # Current maximum allowed line count for each file.
-ceiling = 2406
+ceiling = 2201
 # The target we're ratcheting toward.
 target = 1000
 # How many lines to reduce per merge to main.

--- a/crates/nucleus-claude-hook/src/main.rs
+++ b/crates/nucleus-claude-hook/src/main.rs
@@ -16,7 +16,6 @@ use portcullis_core::flow::NodeKind;
 use portcullis_core::receipt::build_receipt;
 use ring::rand::SystemRandom;
 use ring::signature::Ed25519KeyPair;
-use serde::Serialize;
 
 mod bench;
 mod build;
@@ -30,6 +29,7 @@ mod exit_codes;
 mod help;
 mod init;
 mod protocol;
+mod receipts;
 mod session;
 mod status;
 mod web_taint;
@@ -38,156 +38,13 @@ use classify::*;
 use color::{nucleus_allow, nucleus_deny, nucleus_info, nucleus_warn};
 use denial::format_denial_for_user;
 use protocol::{HookInput, HookOutput};
+use receipts::{persist_receipt, persist_transition_receipt, show_receipts};
 use session::{
     compartment_file_path, gc_stale_sessions, generate_compartment_token, keyed_compartment_name,
     load_session, resolve_compartment, run_gc, sanitize_session_id, save_session, session_dir,
     session_hwm_path, session_state_path, SessionLoad, MANIFEST_VIOLATION_REVOKE_THRESHOLD,
     SESSION_GC_TTL_SECS,
 };
-
-// ---------------------------------------------------------------------------
-// Receipt persistence — append-only JSONL audit trail
-// ---------------------------------------------------------------------------
-
-/// Serializable receipt entry for the JSONL audit file.
-#[derive(Serialize)]
-struct ReceiptEntry {
-    /// Unix timestamp
-    timestamp: u64,
-    /// Operation name
-    operation: String,
-    /// Subject (file path, URL, command, etc.)
-    subject: String,
-    /// "allow", "deny", or "ask"
-    verdict: String,
-    /// Flow rule that fired (for denials)
-    rule: String,
-    /// Action node label
-    action_label: String,
-    /// Causal ancestors (node kind + label summary)
-    ancestors: Vec<String>,
-    /// Ed25519 signature (hex)
-    signature: String,
-    /// Previous receipt hash (hex) — chain link
-    prev_hash: String,
-    /// This receipt's hash (hex) — for the next receipt's prev_hash
-    receipt_hash: String,
-    /// Parent agent's session ID (if this is a child session)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    parent_session_id: Option<String>,
-    /// Parent agent's chain hash at spawn time (if child session)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    parent_chain_hash: Option<String>,
-    /// Active compartment when this decision was made
-    #[serde(skip_serializing_if = "Option::is_none")]
-    compartment: Option<String>,
-    /// Previous compartment (if this entry records a transition)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    compartment_transition_from: Option<String>,
-}
-
-/// Persist a signed receipt to `.nucleus/receipts/<session-id>.jsonl`.
-///
-/// Append-only JSONL — one receipt per line. Creates the directory
-/// and file if they don't exist. Failures are silent (audit is
-/// best-effort, not on the critical path).
-fn persist_receipt(
-    session_id: &str,
-    receipt: &portcullis_core::receipt::FlowReceipt,
-    operation: Operation,
-    subject: &str,
-    parent_session_id: &Option<String>,
-    parent_chain_hash: &Option<String>,
-    compartment: Option<&str>,
-) {
-    let safe_id = sanitize_session_id(session_id);
-    let receipts_dir = session_dir().join("receipts");
-    std::fs::create_dir_all(&receipts_dir).ok();
-    let path = receipts_dir.join(format!("{safe_id}.jsonl"));
-
-    let entry = ReceiptEntry {
-        timestamp: receipt.created_at(),
-        operation: operation.to_string(),
-        subject: subject.to_string(),
-        verdict: format!("{:?}", receipt.verdict()),
-        rule: receipt.rule_name().to_string(),
-        action_label: format!(
-            "conf={:?} integ={:?} auth={:?}",
-            receipt.action().label.confidentiality,
-            receipt.action().label.integrity,
-            receipt.action().label.authority,
-        ),
-        ancestors: receipt
-            .ancestors()
-            .iter()
-            .map(|a| {
-                format!(
-                    "{:?} conf={:?} integ={:?} auth={:?}",
-                    a.kind, a.label.confidentiality, a.label.integrity, a.label.authority,
-                )
-            })
-            .collect(),
-        signature: hex::encode(receipt.signature_bytes()),
-        prev_hash: hex::encode(receipt.prev_hash()),
-        receipt_hash: hex::encode(receipt_hash(receipt)),
-        parent_session_id: parent_session_id.clone(),
-        parent_chain_hash: parent_chain_hash.clone(),
-        compartment: compartment.map(|s| s.to_string()),
-        compartment_transition_from: None,
-    };
-
-    if let Ok(json) = serde_json::to_string(&entry) {
-        use std::io::Write;
-        if let Ok(mut file) = std::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&path)
-        {
-            writeln!(file, "{json}").ok();
-        }
-    }
-}
-
-/// Emit a synthetic receipt for a compartment transition.
-fn persist_transition_receipt(session_id: &str, from: Option<&str>, to: &str, direction: &str) {
-    let safe_id = sanitize_session_id(session_id);
-    let receipts_dir = session_dir().join("receipts");
-    std::fs::create_dir_all(&receipts_dir).ok();
-    let path = receipts_dir.join(format!("{safe_id}.jsonl"));
-
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
-
-    let entry = ReceiptEntry {
-        timestamp: now,
-        operation: "compartment_transition".to_string(),
-        subject: format!("{} -> {} ({direction})", from.unwrap_or("none"), to),
-        verdict: "Allow".to_string(),
-        rule: "compartment_transition".to_string(),
-        action_label: String::new(),
-        ancestors: vec![],
-        signature: String::new(),
-        prev_hash: String::new(),
-        receipt_hash: String::new(),
-        parent_session_id: None,
-        parent_chain_hash: None,
-        compartment: Some(to.to_string()),
-        compartment_transition_from: from.map(|s| s.to_string()),
-    };
-
-    if let Ok(json) = serde_json::to_string(&entry) {
-        use std::io::Write;
-        if let Ok(mut file) = std::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&path)
-        {
-            writeln!(file, "{json}").ok();
-        }
-    }
-}
 
 use context::{current_fingerprint, maybe_build_context};
 
@@ -381,68 +238,6 @@ fn run_setup() {
 // ---------------------------------------------------------------------------
 // --help
 // ---------------------------------------------------------------------------
-
-fn show_receipts(session_id: &str) {
-    let safe_id = sanitize_session_id(session_id);
-    let receipts_dir = session_dir().join("receipts");
-    let path = receipts_dir.join(format!("{safe_id}.jsonl"));
-
-    if !path.exists() {
-        println!("No receipts found for session '{session_id}'");
-        return;
-    }
-
-    let content = match std::fs::read_to_string(&path) {
-        Ok(c) => c,
-        Err(e) => {
-            println!("Failed to read receipts: {e}");
-            return;
-        }
-    };
-
-    let mut count = 0u32;
-    let mut allowed = 0u32;
-    let mut denied = 0u32;
-
-    for line in content.lines() {
-        if line.trim().is_empty() {
-            continue;
-        }
-        if let Ok(entry) = serde_json::from_str::<serde_json::Value>(line) {
-            let op = entry["operation"].as_str().unwrap_or("?");
-            let subject = entry["subject"].as_str().unwrap_or("?");
-            let verdict = entry["verdict"].as_str().unwrap_or("?");
-            let comp = entry["compartment"].as_str().unwrap_or("");
-
-            let icon = if verdict.contains("Deny") {
-                denied += 1;
-                "\x1b[31m\u{2717}\x1b[0m"
-            } else {
-                allowed += 1;
-                "\x1b[32m\u{2713}\x1b[0m"
-            };
-
-            let comp_tag = if comp.is_empty() {
-                String::new()
-            } else {
-                format!(" [{comp}]")
-            };
-
-            let short = if subject.len() > 50 {
-                format!("{}...", &subject[..47])
-            } else {
-                subject.to_string()
-            };
-
-            println!("  {icon} {op:<25} {short}{comp_tag}");
-            count += 1;
-        }
-    }
-
-    println!();
-    println!("Total: {count} receipts ({allowed} allowed, {denied} denied)");
-    println!("Chain file: {}", path.display());
-}
 
 fn run_smoke_test() {
     use std::process::Command;

--- a/crates/nucleus-claude-hook/src/receipts.rs
+++ b/crates/nucleus-claude-hook/src/receipts.rs
@@ -1,0 +1,221 @@
+//! Receipt persistence — append-only JSONL audit trail.
+//!
+//! Extracted from `main.rs` to reduce module size.
+
+use portcullis::receipt_sign::receipt_hash;
+use portcullis::Operation;
+use serde::Serialize;
+
+use crate::session::{sanitize_session_id, session_dir};
+
+// ---------------------------------------------------------------------------
+// Receipt persistence — append-only JSONL audit trail
+// ---------------------------------------------------------------------------
+
+/// Serializable receipt entry for the JSONL audit file.
+#[derive(Serialize)]
+struct ReceiptEntry {
+    /// Unix timestamp
+    timestamp: u64,
+    /// Operation name
+    operation: String,
+    /// Subject (file path, URL, command, etc.)
+    subject: String,
+    /// "allow", "deny", or "ask"
+    verdict: String,
+    /// Flow rule that fired (for denials)
+    rule: String,
+    /// Action node label
+    action_label: String,
+    /// Causal ancestors (node kind + label summary)
+    ancestors: Vec<String>,
+    /// Ed25519 signature (hex)
+    signature: String,
+    /// Previous receipt hash (hex) — chain link
+    prev_hash: String,
+    /// This receipt's hash (hex) — for the next receipt's prev_hash
+    receipt_hash: String,
+    /// Parent agent's session ID (if this is a child session)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    parent_session_id: Option<String>,
+    /// Parent agent's chain hash at spawn time (if child session)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    parent_chain_hash: Option<String>,
+    /// Active compartment when this decision was made
+    #[serde(skip_serializing_if = "Option::is_none")]
+    compartment: Option<String>,
+    /// Previous compartment (if this entry records a transition)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    compartment_transition_from: Option<String>,
+}
+
+/// Persist a signed receipt to `.nucleus/receipts/<session-id>.jsonl`.
+///
+/// Append-only JSONL — one receipt per line. Creates the directory
+/// and file if they don't exist. Failures are silent (audit is
+/// best-effort, not on the critical path).
+pub(crate) fn persist_receipt(
+    session_id: &str,
+    receipt: &portcullis_core::receipt::FlowReceipt,
+    operation: Operation,
+    subject: &str,
+    parent_session_id: &Option<String>,
+    parent_chain_hash: &Option<String>,
+    compartment: Option<&str>,
+) {
+    let safe_id = sanitize_session_id(session_id);
+    let receipts_dir = session_dir().join("receipts");
+    std::fs::create_dir_all(&receipts_dir).ok();
+    let path = receipts_dir.join(format!("{safe_id}.jsonl"));
+
+    let entry = ReceiptEntry {
+        timestamp: receipt.created_at(),
+        operation: operation.to_string(),
+        subject: subject.to_string(),
+        verdict: format!("{:?}", receipt.verdict()),
+        rule: receipt.rule_name().to_string(),
+        action_label: format!(
+            "conf={:?} integ={:?} auth={:?}",
+            receipt.action().label.confidentiality,
+            receipt.action().label.integrity,
+            receipt.action().label.authority,
+        ),
+        ancestors: receipt
+            .ancestors()
+            .iter()
+            .map(|a| {
+                format!(
+                    "{:?} conf={:?} integ={:?} auth={:?}",
+                    a.kind, a.label.confidentiality, a.label.integrity, a.label.authority,
+                )
+            })
+            .collect(),
+        signature: hex::encode(receipt.signature_bytes()),
+        prev_hash: hex::encode(receipt.prev_hash()),
+        receipt_hash: hex::encode(receipt_hash(receipt)),
+        parent_session_id: parent_session_id.clone(),
+        parent_chain_hash: parent_chain_hash.clone(),
+        compartment: compartment.map(|s| s.to_string()),
+        compartment_transition_from: None,
+    };
+
+    if let Ok(json) = serde_json::to_string(&entry) {
+        use std::io::Write;
+        if let Ok(mut file) = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+        {
+            writeln!(file, "{json}").ok();
+        }
+    }
+}
+
+/// Emit a synthetic receipt for a compartment transition.
+pub(crate) fn persist_transition_receipt(
+    session_id: &str,
+    from: Option<&str>,
+    to: &str,
+    direction: &str,
+) {
+    let safe_id = sanitize_session_id(session_id);
+    let receipts_dir = session_dir().join("receipts");
+    std::fs::create_dir_all(&receipts_dir).ok();
+    let path = receipts_dir.join(format!("{safe_id}.jsonl"));
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+
+    let entry = ReceiptEntry {
+        timestamp: now,
+        operation: "compartment_transition".to_string(),
+        subject: format!("{} -> {} ({direction})", from.unwrap_or("none"), to),
+        verdict: "Allow".to_string(),
+        rule: "compartment_transition".to_string(),
+        action_label: String::new(),
+        ancestors: vec![],
+        signature: String::new(),
+        prev_hash: String::new(),
+        receipt_hash: String::new(),
+        parent_session_id: None,
+        parent_chain_hash: None,
+        compartment: Some(to.to_string()),
+        compartment_transition_from: from.map(|s| s.to_string()),
+    };
+
+    if let Ok(json) = serde_json::to_string(&entry) {
+        use std::io::Write;
+        if let Ok(mut file) = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+        {
+            writeln!(file, "{json}").ok();
+        }
+    }
+}
+
+/// Display receipts for a session (`--receipts` CLI handler).
+pub(crate) fn show_receipts(session_id: &str) {
+    let safe_id = sanitize_session_id(session_id);
+    let receipts_dir = session_dir().join("receipts");
+    let path = receipts_dir.join(format!("{safe_id}.jsonl"));
+
+    if !path.exists() {
+        println!("No receipts found for session '{session_id}'");
+        return;
+    }
+
+    let content = match std::fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(e) => {
+            println!("Failed to read receipts: {e}");
+            return;
+        }
+    };
+
+    let mut count = 0u32;
+    let mut allowed = 0u32;
+    let mut denied = 0u32;
+
+    for line in content.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        if let Ok(entry) = serde_json::from_str::<serde_json::Value>(line) {
+            let op = entry["operation"].as_str().unwrap_or("?");
+            let subject = entry["subject"].as_str().unwrap_or("?");
+            let verdict = entry["verdict"].as_str().unwrap_or("?");
+            let comp = entry["compartment"].as_str().unwrap_or("");
+
+            let icon = if verdict.contains("Deny") {
+                denied += 1;
+                "\x1b[31m\u{2717}\x1b[0m"
+            } else {
+                allowed += 1;
+                "\x1b[32m\u{2713}\x1b[0m"
+            };
+
+            let comp_tag = if comp.is_empty() {
+                String::new()
+            } else {
+                format!(" [{comp}]")
+            };
+
+            let short = if subject.len() > 50 {
+                format!("{}...", &subject[..47])
+            } else {
+                subject.to_string()
+            };
+
+            println!("  {icon} {op:<25} {short}{comp_tag}");
+            count += 1;
+        }
+    }
+
+    println!();
+    println!("Total: {count} receipts ({allowed} allowed, {denied} denied)");
+    println!("Chain file: {}", path.display());
+}


### PR DESCRIPTION
## Summary
- Extract `persist_receipt()`, `persist_transition_receipt()`, `show_receipts()`, and `ReceiptEntry` struct from `main.rs` into a new `crates/nucleus-claude-hook/src/receipts.rs` module
- Reduces `main.rs` from 2,405 to 2,200 lines (-205 lines)
- Updates `.line-ratchet.toml` ceiling from 2406 to 2201
- Pure extraction -- no logic changes

## Test plan
- [x] `cargo check -p nucleus-claude-hook` passes
- [x] `cargo clippy -p nucleus-claude-hook` clean
- [x] `cargo test -p nucleus-claude-hook` -- all 163 tests pass
- [x] All pre-commit and pre-push hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)