### PR TITLE
Extract run_doctor() into doctor.rs module

### DIFF
--- a/.line-ratchet.toml
+++ b/.line-ratchet.toml
@@ -9,7 +9,7 @@
 
 [ratchet]
 # Current maximum allowed line count for each file.
-ceiling = 2032
+ceiling = 1941
 # The target we're ratcheting toward.
 target = 1000
 # How many lines to reduce per merge to main.

--- a/crates/nucleus-claude-hook/src/doctor.rs
+++ b/crates/nucleus-claude-hook/src/doctor.rs
@@ -1,0 +1,100 @@
+//! `--doctor` diagnostic command — checks hook installation health.
+
+use crate::session::session_dir;
+use crate::{default_profile_name, resolve_profile};
+
+pub(crate) fn run_doctor() {
+    let mut ok = true;
+
+    // 1. Check settings.json
+    let home = dirs_next::home_dir();
+    let settings_path = home
+        .as_ref()
+        .map(|h| h.join(".claude").join("settings.json"));
+
+    if let Some(ref path) = settings_path {
+        if path.exists() {
+            if let Ok(content) = std::fs::read_to_string(path) {
+                if content.contains("nucleus-claude-hook") {
+                    println!(
+                        "\x1b[32m\u{2713}\x1b[0m Hook configured in {}",
+                        path.display()
+                    );
+                } else {
+                    println!(
+                        "\x1b[31m\u{2717}\x1b[0m Hook NOT configured in {} — run --setup",
+                        path.display()
+                    );
+                    ok = false;
+                }
+            }
+        } else {
+            println!(
+                "\x1b[31m\u{2717}\x1b[0m Settings file not found: {} — run --setup",
+                path.display()
+            );
+            ok = false;
+        }
+    }
+
+    // 2. Check session directory
+    let sess_dir = session_dir();
+    if sess_dir.exists() {
+        let count = std::fs::read_dir(&sess_dir)
+            .map(|entries| entries.count())
+            .unwrap_or(0);
+        println!(
+            "\x1b[32m\u{2713}\x1b[0m Session directory: {} ({count} files)",
+            sess_dir.display()
+        );
+    } else {
+        println!("\x1b[33m-\x1b[0m Session directory not yet created (first run pending)");
+    }
+
+    // 3. Check profile
+    let profile = default_profile_name();
+    if resolve_profile(&profile).is_some() {
+        println!("\x1b[32m\u{2713}\x1b[0m Active profile: {profile}");
+    } else {
+        println!(
+            "\x1b[31m\u{2717}\x1b[0m Unknown profile: {profile} — will fall back to safe_pr_fixer"
+        );
+        ok = false;
+    }
+
+    // 4. Check compartment env
+    if let Ok(comp) = std::env::var("NUCLEUS_COMPARTMENT") {
+        if portcullis_core::compartment::Compartment::from_str_opt(&comp).is_some() {
+            println!("\x1b[32m\u{2713}\x1b[0m Compartment: {comp}");
+        } else {
+            println!("\x1b[31m\u{2717}\x1b[0m Invalid NUCLEUS_COMPARTMENT: {comp}");
+            ok = false;
+        }
+    } else {
+        println!("\x1b[33m-\x1b[0m No compartment set (using profile defaults)");
+    }
+
+    // 5. Check receipt directory
+    let receipt_dir = sess_dir.join("receipts");
+    if receipt_dir.exists() {
+        let count = std::fs::read_dir(&receipt_dir)
+            .map(|entries| entries.count())
+            .unwrap_or(0);
+        println!("\x1b[32m\u{2713}\x1b[0m Receipt chains: {count} sessions");
+    } else {
+        println!("\x1b[33m-\x1b[0m No receipt chains yet");
+    }
+
+    // 6. Version
+    println!(
+        "\x1b[32m\u{2713}\x1b[0m Version: {}",
+        env!("CARGO_PKG_VERSION")
+    );
+
+    println!();
+    if ok {
+        println!("\x1b[32mAll checks passed.\x1b[0m");
+    } else {
+        println!("\x1b[31mSome checks failed.\x1b[0m Run --setup to configure.");
+    }
+}

--- a/crates/nucleus-claude-hook/src/main.rs
+++ b/crates/nucleus-claude-hook/src/main.rs
@@ -25,6 +25,7 @@ mod color;
 mod completions;
 mod context;
 mod denial;
+mod doctor;
 mod exit_codes;
 mod help;
 mod init;
@@ -297,99 +298,7 @@ fn run_init() {
 // (--uninstall handler moved to setup.rs)
 
 fn run_doctor() {
-    let mut ok = true;
-
-    // 1. Check settings.json
-    let home = dirs_next::home_dir();
-    let settings_path = home
-        .as_ref()
-        .map(|h| h.join(".claude").join("settings.json"));
-
-    if let Some(ref path) = settings_path {
-        if path.exists() {
-            if let Ok(content) = std::fs::read_to_string(path) {
-                if content.contains("nucleus-claude-hook") {
-                    println!(
-                        "\x1b[32m\u{2713}\x1b[0m Hook configured in {}",
-                        path.display()
-                    );
-                } else {
-                    println!(
-                        "\x1b[31m\u{2717}\x1b[0m Hook NOT configured in {} — run --setup",
-                        path.display()
-                    );
-                    ok = false;
-                }
-            }
-        } else {
-            println!(
-                "\x1b[31m\u{2717}\x1b[0m Settings file not found: {} — run --setup",
-                path.display()
-            );
-            ok = false;
-        }
-    }
-
-    // 2. Check session directory
-    let sess_dir = session_dir();
-    if sess_dir.exists() {
-        let count = std::fs::read_dir(&sess_dir)
-            .map(|entries| entries.count())
-            .unwrap_or(0);
-        println!(
-            "\x1b[32m\u{2713}\x1b[0m Session directory: {} ({count} files)",
-            sess_dir.display()
-        );
-    } else {
-        println!("\x1b[33m-\x1b[0m Session directory not yet created (first run pending)");
-    }
-
-    // 3. Check profile
-    let profile = default_profile_name();
-    if resolve_profile(&profile).is_some() {
-        println!("\x1b[32m\u{2713}\x1b[0m Active profile: {profile}");
-    } else {
-        println!(
-            "\x1b[31m\u{2717}\x1b[0m Unknown profile: {profile} — will fall back to safe_pr_fixer"
-        );
-        ok = false;
-    }
-
-    // 4. Check compartment env
-    if let Ok(comp) = std::env::var("NUCLEUS_COMPARTMENT") {
-        if portcullis_core::compartment::Compartment::from_str_opt(&comp).is_some() {
-            println!("\x1b[32m\u{2713}\x1b[0m Compartment: {comp}");
-        } else {
-            println!("\x1b[31m\u{2717}\x1b[0m Invalid NUCLEUS_COMPARTMENT: {comp}");
-            ok = false;
-        }
-    } else {
-        println!("\x1b[33m-\x1b[0m No compartment set (using profile defaults)");
-    }
-
-    // 5. Check receipt directory
-    let receipt_dir = sess_dir.join("receipts");
-    if receipt_dir.exists() {
-        let count = std::fs::read_dir(&receipt_dir)
-            .map(|entries| entries.count())
-            .unwrap_or(0);
-        println!("\x1b[32m\u{2713}\x1b[0m Receipt chains: {count} sessions");
-    } else {
-        println!("\x1b[33m-\x1b[0m No receipt chains yet");
-    }
-
-    // 6. Version
-    println!(
-        "\x1b[32m\u{2713}\x1b[0m Version: {}",
-        env!("CARGO_PKG_VERSION")
-    );
-
-    println!();
-    if ok {
-        println!("\x1b[32mAll checks passed.\x1b[0m");
-    } else {
-        println!("\x1b[31mSome checks failed.\x1b[0m Run --setup to configure.");
-    }
+    doctor::run_doctor();
 }
 
 fn show_profile(name: &str) {


### PR DESCRIPTION
## Summary
- Extracts the ~95-line `run_doctor()` function from `main.rs` into a new `crates/nucleus-claude-hook/src/doctor.rs` module
- Reduces `main.rs` from 2,032 to 1,940 lines (92 net lines removed)
- Updates `.line-ratchet.toml` ceiling from 2032 to 1941

## Test plan
- [x] `cargo build -p nucleus-claude-hook` succeeds
- [x] `cargo test -p nucleus-claude-hook` — all 163 tests pass
- [x] All pre-commit hooks pass (fmt, clippy, deny, audit, line-ratchet)
- [x] All pre-push hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)