### PR TITLE
feat(identity): cross-agent receipt chain linking

### DIFF
--- a/crates/nucleus-identity/src/cross_agent.rs
+++ b/crates/nucleus-identity/src/cross_agent.rs
@@ -15,6 +15,8 @@
 //! handshake provides the peer certificate. This module implements the core
 //! join logic as a pure library function, independent of transport.
 
+use sha2::{Digest, Sha256};
+
 use portcullis_core::{DerivationClass, IFCLabel, IntegLevel};
 
 /// Record of a cross-agent label join, preserving both original labels for audit.
@@ -73,6 +75,129 @@ impl CrossAgentExchange {
     pub fn requires_reduction(&self) -> bool {
         self.remote_label.integrity == IntegLevel::Adversarial
             || self.remote_label.derivation == DerivationClass::OpaqueExternal
+    }
+}
+
+/// Receipt linking two agents' receipt chains for a cross-agent interaction.
+///
+/// When Agent A calls Agent B, both agents record a `CrossAgentReceipt` in their
+/// respective receipt chains. The receipt captures both SPIFFE IDs, the underlying
+/// label exchange, and SHA-256 hashes of the request and response payloads. The
+/// `receipt_hash` field is a deterministic hash over all other fields, enabling
+/// both chains to independently verify the same interaction.
+#[derive(Debug, Clone)]
+pub struct CrossAgentReceipt {
+    /// SPIFFE ID of the local agent (the one recording this receipt).
+    pub local_spiffe_id: String,
+    /// SPIFFE ID of the remote agent (the peer in this interaction).
+    pub remote_spiffe_id: String,
+    /// The IFC label exchange record from the interaction.
+    pub exchange: CrossAgentExchange,
+    /// SHA-256 hash of the outbound request payload.
+    pub request_hash: [u8; 32],
+    /// SHA-256 hash of the inbound response payload.
+    pub response_hash: [u8; 32],
+    /// Deterministic SHA-256 hash of all fields above.
+    pub receipt_hash: [u8; 32],
+}
+
+impl CrossAgentReceipt {
+    /// Create a new receipt from an exchange and raw request/response payloads.
+    ///
+    /// Hashes the request and response, then computes the deterministic
+    /// `receipt_hash` covering all fields.
+    pub fn new(
+        exchange: CrossAgentExchange,
+        local_spiffe_id: &str,
+        remote_spiffe_id: &str,
+        request: &[u8],
+        response: &[u8],
+    ) -> Self {
+        let request_hash: [u8; 32] = Sha256::digest(request).into();
+        let response_hash: [u8; 32] = Sha256::digest(response).into();
+        let receipt_hash = Self::compute_hash(
+            local_spiffe_id,
+            remote_spiffe_id,
+            &exchange,
+            &request_hash,
+            &response_hash,
+        );
+        Self {
+            local_spiffe_id: local_spiffe_id.to_string(),
+            remote_spiffe_id: remote_spiffe_id.to_string(),
+            exchange,
+            request_hash,
+            response_hash,
+            receipt_hash,
+        }
+    }
+
+    /// Compute the deterministic receipt hash.
+    ///
+    /// The hash covers, in order:
+    /// 1. `local_spiffe_id` (length-prefixed UTF-8)
+    /// 2. `remote_spiffe_id` (length-prefixed UTF-8)
+    /// 3. Exchange timestamp (big-endian u64)
+    /// 4. Exchange local label (binary encoding)
+    /// 5. Exchange remote label (binary encoding)
+    /// 6. Exchange joined label (binary encoding)
+    /// 7. Exchange remote_spiffe_id (length-prefixed UTF-8)
+    /// 8. Request hash (32 bytes)
+    /// 9. Response hash (32 bytes)
+    fn compute_hash(
+        local_id: &str,
+        remote_id: &str,
+        exchange: &CrossAgentExchange,
+        request_hash: &[u8; 32],
+        response_hash: &[u8; 32],
+    ) -> [u8; 32] {
+        let mut hasher = Sha256::new();
+
+        // Length-prefixed strings for domain separation
+        Self::hash_string(&mut hasher, local_id);
+        Self::hash_string(&mut hasher, remote_id);
+
+        // Exchange fields
+        hasher.update(exchange.timestamp.to_be_bytes());
+        Self::hash_label(&mut hasher, &exchange.local_label);
+        Self::hash_label(&mut hasher, &exchange.remote_label);
+        Self::hash_label(&mut hasher, &exchange.joined_label);
+        Self::hash_string(&mut hasher, &exchange.remote_spiffe_id);
+
+        // Payload hashes
+        hasher.update(request_hash);
+        hasher.update(response_hash);
+
+        hasher.finalize().into()
+    }
+
+    /// Hash a length-prefixed UTF-8 string into the hasher.
+    fn hash_string(hasher: &mut Sha256, s: &str) {
+        hasher.update((s.len() as u32).to_be_bytes());
+        hasher.update(s.as_bytes());
+    }
+
+    /// Hash an IFC label in deterministic binary form.
+    fn hash_label(hasher: &mut Sha256, label: &IFCLabel) {
+        hasher.update([label.confidentiality as u8]);
+        hasher.update([label.integrity as u8]);
+        hasher.update([label.provenance.bits()]);
+        hasher.update(label.freshness.observed_at.to_be_bytes());
+        hasher.update(label.freshness.ttl_secs.to_be_bytes());
+        hasher.update([label.authority as u8]);
+        hasher.update([label.derivation as u8]);
+    }
+
+    /// Verify that the `receipt_hash` matches a fresh computation over all fields.
+    pub fn verify(&self) -> bool {
+        let expected = Self::compute_hash(
+            &self.local_spiffe_id,
+            &self.remote_spiffe_id,
+            &self.exchange,
+            &self.request_hash,
+            &self.response_hash,
+        );
+        self.receipt_hash == expected
     }
 }
 
@@ -275,5 +400,157 @@ mod tests {
         );
         // But integrity is still downgraded: min(Trusted, Untrusted) = Untrusted
         assert_eq!(exchange.joined_label.integrity, IntegLevel::Untrusted);
+    }
+
+    // ── CrossAgentReceipt tests ──────────────────────────────────────────
+
+    fn make_receipt(request: &[u8], response: &[u8]) -> CrossAgentReceipt {
+        let exchange = join_cross_agent(
+            &trusted_local(),
+            &trusted_remote(),
+            "spiffe://example.org/agent/peer",
+            1711900200,
+        );
+        CrossAgentReceipt::new(
+            exchange,
+            "spiffe://example.org/agent/local",
+            "spiffe://example.org/agent/peer",
+            request,
+            response,
+        )
+    }
+
+    #[test]
+    fn receipt_hash_is_deterministic() {
+        let r1 = make_receipt(b"hello", b"world");
+        let r2 = make_receipt(b"hello", b"world");
+        assert_eq!(r1.receipt_hash, r2.receipt_hash);
+    }
+
+    #[test]
+    fn receipt_hash_changes_with_different_request() {
+        let r1 = make_receipt(b"hello", b"world");
+        let r2 = make_receipt(b"goodbye", b"world");
+        assert_ne!(r1.receipt_hash, r2.receipt_hash);
+    }
+
+    #[test]
+    fn receipt_hash_changes_with_different_response() {
+        let r1 = make_receipt(b"hello", b"world");
+        let r2 = make_receipt(b"hello", b"changed");
+        assert_ne!(r1.receipt_hash, r2.receipt_hash);
+    }
+
+    #[test]
+    fn receipt_hash_changes_with_different_exchange() {
+        let exchange_trusted = join_cross_agent(
+            &trusted_local(),
+            &trusted_remote(),
+            "spiffe://example.org/agent/peer",
+            1711900200,
+        );
+        let exchange_adversarial = join_cross_agent(
+            &trusted_local(),
+            &adversarial_remote(),
+            "spiffe://untrusted.org/agent/evil",
+            1711900300,
+        );
+
+        let r1 = CrossAgentReceipt::new(
+            exchange_trusted,
+            "spiffe://example.org/agent/local",
+            "spiffe://example.org/agent/peer",
+            b"req",
+            b"resp",
+        );
+        let r2 = CrossAgentReceipt::new(
+            exchange_adversarial,
+            "spiffe://example.org/agent/local",
+            "spiffe://untrusted.org/agent/evil",
+            b"req",
+            b"resp",
+        );
+        assert_ne!(r1.receipt_hash, r2.receipt_hash);
+    }
+
+    #[test]
+    fn receipt_hash_changes_with_different_local_id() {
+        let exchange = join_cross_agent(
+            &trusted_local(),
+            &trusted_remote(),
+            "spiffe://example.org/agent/peer",
+            1711900200,
+        );
+        let r1 = CrossAgentReceipt::new(
+            exchange.clone(),
+            "spiffe://example.org/agent/alice",
+            "spiffe://example.org/agent/peer",
+            b"req",
+            b"resp",
+        );
+        let r2 = CrossAgentReceipt::new(
+            exchange,
+            "spiffe://example.org/agent/bob",
+            "spiffe://example.org/agent/peer",
+            b"req",
+            b"resp",
+        );
+        assert_ne!(r1.receipt_hash, r2.receipt_hash);
+    }
+
+    #[test]
+    fn receipt_verify_succeeds_for_valid_receipt() {
+        let r = make_receipt(b"request payload", b"response payload");
+        assert!(r.verify(), "freshly constructed receipt must verify");
+    }
+
+    #[test]
+    fn receipt_verify_fails_when_tampered() {
+        let mut r = make_receipt(b"request payload", b"response payload");
+        // Flip a bit in the request hash
+        r.request_hash[0] ^= 0xFF;
+        assert!(!r.verify(), "tampered receipt must not verify");
+    }
+
+    #[test]
+    fn receipt_stores_correct_payload_hashes() {
+        use sha2::{Digest as _, Sha256};
+        let req = b"the request";
+        let resp = b"the response";
+        let r = make_receipt(req, resp);
+
+        let expected_req: [u8; 32] = Sha256::digest(req).into();
+        let expected_resp: [u8; 32] = Sha256::digest(resp).into();
+
+        assert_eq!(r.request_hash, expected_req);
+        assert_eq!(r.response_hash, expected_resp);
+    }
+
+    #[test]
+    fn receipt_all_fields_included_in_hash() {
+        // Changing timestamp alone must produce a different receipt hash.
+        let local = trusted_local();
+        let remote = trusted_remote();
+        let e1 = join_cross_agent(&local, &remote, "spiffe://example.org/agent/peer", 1000);
+        let e2 = join_cross_agent(&local, &remote, "spiffe://example.org/agent/peer", 2000);
+
+        let r1 = CrossAgentReceipt::new(
+            e1,
+            "spiffe://example.org/agent/local",
+            "spiffe://example.org/agent/peer",
+            b"req",
+            b"resp",
+        );
+        let r2 = CrossAgentReceipt::new(
+            e2,
+            "spiffe://example.org/agent/local",
+            "spiffe://example.org/agent/peer",
+            b"req",
+            b"resp",
+        );
+        assert_ne!(
+            r1.receipt_hash, r2.receipt_hash,
+            "different timestamps must produce different hashes"
+        );
     }
 }

--- a/crates/nucleus-identity/src/lib.rs
+++ b/crates/nucleus-identity/src/lib.rs
@@ -55,7 +55,7 @@ pub use attestation::{AttestationRequirements, LaunchAttestation};
 pub use ca::{auto_detect_ca, SpireCaClient, DEFAULT_SPIRE_SOCKET, SPIFFE_ENDPOINT_ENV};
 pub use ca::{CaClient, SelfSignedCa};
 pub use certificate::{TrustBundle, WorkloadCertificate};
-pub use cross_agent::{join_cross_agent, CrossAgentExchange};
+pub use cross_agent::{join_cross_agent, CrossAgentExchange, CrossAgentReceipt};
 pub use csr::{CertSign, CsrOptions};
 pub use did::{did_web_to_url, DidDocument, JsonWebKey, ServiceEndpoint, VerificationMethod};
 pub use did_binding::{BindingProof, BindingVerification, SpiffeDidBinding};


### PR DESCRIPTION
## Summary
- Adds `CrossAgentReceipt` struct to `crates/nucleus-identity/src/cross_agent.rs` that links both agents' receipt chains when Agent A calls Agent B
- Receipt captures both SPIFFE IDs, the IFC label exchange (`CrossAgentExchange`), and SHA-256 hashes of request/response payloads
- Deterministic `receipt_hash` (SHA-256 over all fields with length-prefixed strings) enables independent verification from both chains
- `verify()` method for tamper detection

## Test plan
- [x] Hash determinism: same inputs produce same receipt hash
- [x] Field sensitivity: changing request, response, exchange, local ID, or timestamp each produce different hashes
- [x] Tamper detection: `verify()` returns false when any field is modified
- [x] Payload hash correctness: stored hashes match direct SHA-256 of payloads
- [x] All 14 tests pass (5 existing + 9 new)

Closes #870

🤖 Generated with [Claude Code](https://claude.com/claude-code)