### PR TITLE
feat: capture SHA-256 content hashes for web tool outputs (#873)

### DIFF
--- a/crates/nucleus-claude-hook/src/main.rs
+++ b/crates/nucleus-claude-hook/src/main.rs
@@ -640,7 +640,20 @@ fn main() {
                 let op = map_tool(&input.tool_name);
                 let output_kind = classify_tool_output(op);
                 let taint_tool = input.tool_name.clone();
+                let hash_tool = input.tool_name.clone();
                 let rt = result_text.to_string();
+
+                // Compute SHA-256 of the tool result for witness anchoring (#873).
+                let is_web = detect_web_taint(&hash_tool);
+                let content_hash: [u8; 32] = if is_web {
+                    use sha2::{Digest, Sha256};
+                    let mut hasher = Sha256::new();
+                    hasher.update(rt.as_bytes());
+                    hasher.finalize().into()
+                } else {
+                    [0u8; 32]
+                };
+
                 match with_session(&input.session_id, |s| {
                     s.flow_observations.push((
                         node_kind_to_u8(output_kind),
@@ -648,15 +661,36 @@ fn main() {
                         truncate_subject(&rt, 200),
                     ));
                     s.last_pre_tool_obs_index = None;
-                    if detect_web_taint(&taint_tool) && !s.web_tainted {
-                        s.web_tainted = true;
-                        eprintln!("{}", web_taint_warning(&taint_tool, &rt));
+                    if is_web {
+                        if !s.web_tainted {
+                            s.web_tainted = true;
+                            eprintln!("{}", web_taint_warning(&taint_tool, &rt));
+                        }
+                        // Record content hash as pending source for ReductionWitness (#873).
+                        let now = std::time::SystemTime::now()
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .unwrap_or_default()
+                            .as_secs();
+                        s.pending_source_hashes.push(session::PendingSourceHash {
+                            content_hash,
+                            tool_name: hash_tool.clone(),
+                            captured_at: now,
+                            witnessed: false,
+                        });
                     }
                 }) {
-                    Some(_) => eprintln!(
-                        "nucleus: post-tool {op} {} — inserted {:?} observation into flow graph",
-                        input.tool_name, output_kind
-                    ),
+                    Some(_) => {
+                        eprintln!(
+                            "nucleus: post-tool {op} {} — inserted {:?} observation into flow graph",
+                            input.tool_name, output_kind
+                        );
+                        if is_web {
+                            eprintln!(
+                                "nucleus: captured source hash {:02x}{:02x}{:02x}{:02x}... for witness anchoring (#873)",
+                                content_hash[0], content_hash[1], content_hash[2], content_hash[3]
+                            );
+                        }
+                    }
                     None => nucleus_deny!("post-tool skipped — session tampered"),
                 }
             }

--- a/crates/nucleus-claude-hook/src/session.rs
+++ b/crates/nucleus-claude-hook/src/session.rs
@@ -108,6 +108,30 @@ pub(crate) struct SessionState {
     /// Prevents repeated injection — the model only needs to be told once.
     #[serde(default)]
     pub(crate) web_taint_context_injected: bool,
+    /// Content hashes of web tool outputs, captured at PostToolUse time (#873).
+    /// Each entry records the SHA-256 of the tool result, the tool name, and
+    /// the Unix timestamp. These are the anchors for future `ReductionWitness`
+    /// chains — `/clearance` can reference them as `InputBlob.content_hash`.
+    #[serde(default)]
+    pub(crate) pending_source_hashes: Vec<PendingSourceHash>,
+}
+
+/// A content hash captured from a tool output during PostToolUse (#873).
+///
+/// This is the "record" side of record-and-replay: we record the SHA-256
+/// of untrusted content at capture time so that a future reduction pipeline
+/// can prove it processed *this exact content*.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub(crate) struct PendingSourceHash {
+    /// SHA-256 of the tool result content.
+    pub(crate) content_hash: [u8; 32],
+    /// Tool that produced this content (e.g. "WebFetch", "mcp__server__tool").
+    pub(crate) tool_name: String,
+    /// Unix timestamp (seconds) when the content was captured.
+    pub(crate) captured_at: u64,
+    /// Whether a `ReductionWitness` has been constructed for this content.
+    /// Once true, the hash has been consumed by the reduction pipeline.
+    pub(crate) witnessed: bool,
 }
 
 impl SessionState {
@@ -1021,6 +1045,46 @@ mod tests {
         assert_eq!(restored.flow_observations[1].0, TOOL_RESPONSE);
         assert!(restored.flow_observations[1].1.starts_with("post:"));
         assert!(restored.last_pre_tool_obs_index.is_none());
+    }
+
+    #[test]
+    fn pending_source_hash_round_trip() {
+        let hash = {
+            use sha2::{Digest, Sha256};
+            let mut h = Sha256::new();
+            h.update(b"<html>example</html>");
+            let result: [u8; 32] = h.finalize().into();
+            result
+        };
+        let mut state = SessionState {
+            profile: "test".to_string(),
+            ..Default::default()
+        };
+        state.pending_source_hashes.push(PendingSourceHash {
+            content_hash: hash,
+            tool_name: "WebFetch".to_string(),
+            captured_at: 1711900000,
+            witnessed: false,
+        });
+
+        let json = serde_json::to_string(&state).unwrap();
+        let restored: SessionState = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(restored.pending_source_hashes.len(), 1);
+        assert_eq!(restored.pending_source_hashes[0].content_hash, hash);
+        assert_eq!(restored.pending_source_hashes[0].tool_name, "WebFetch");
+        assert!(!restored.pending_source_hashes[0].witnessed);
+    }
+
+    #[test]
+    fn pending_source_hash_backward_compatible() {
+        // Old session JSON without pending_source_hashes field should deserialize
+        let json = r#"{"schema_version":3,"profile":"test","high_water_mark":0,
+            "allowed_ops":[],"flow_observations":[],"chain_head_hash":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],
+            "signing_key_pkcs8":[],"compartment_token":"","web_tainted":false,
+            "web_taint_context_injected":false}"#;
+        let state: SessionState = serde_json::from_str(json).unwrap();
+        assert!(state.pending_source_hashes.is_empty());
     }
 
     // -----------------------------------------------------------------------

--- a/crates/nucleus-claude-hook/src/status.rs
+++ b/crates/nucleus-claude-hook/src/status.rs
@@ -433,6 +433,7 @@ mod tests {
             last_injected_context_key: None,
             web_tainted: false,
             web_taint_context_injected: false,
+            pending_source_hashes: vec![],
         }
     }
 


### PR DESCRIPTION
## Summary

- Wire the first step of ReductionWitness integration into the hook layer: when a web-taint tool (WebFetch, curl, etc.) returns data in PostToolUse, compute SHA-256 of the result and store it as a `PendingSourceHash` in session state
- Add `PendingSourceHash` type to session.rs with content_hash, tool_name, captured_at, and witnessed flag
- Add `pending_source_hashes` field to `SessionState` with `#[serde(default)]` for backward compatibility
- This creates the content-addressed anchors that `/clearance` can later reference as `InputBlob.content_hash` when constructing a `ReductionWitness` chain

Closes #873 (short-term fix — step 1 of 3)

## Test plan

- [x] `pending_source_hash_round_trip` — serialize/deserialize PendingSourceHash through SessionState
- [x] `pending_source_hash_backward_compatible` — old session JSON without the field deserializes cleanly
- [x] Full hook test suite passes (175 tests)
- [x] Line ratchet: main.rs at 1871 (ceiling 1941)

🤖 Generated with [Claude Code](https://claude.com/claude-code)