### PR TITLE
feat(portcullis): make flow_graph always present in Kernel (#753)

### DIFF
--- a/crates/nucleus-claude-hook/src/bench.rs
+++ b/crates/nucleus-claude-hook/src/bench.rs
@@ -163,7 +163,6 @@ fn bench_single_decide(
     let build_start = Instant::now();
     let operation = map_tool(tool_name);
     let mut kernel = Kernel::new(perms.clone());
-    kernel.enable_flow_graph();
     let kernel_build = build_start.elapsed();
 
     // Phase 2: Replay flow observations
@@ -193,7 +192,8 @@ fn bench_single_decide(
     // Phase 4: Receipt build (simulate the signing overhead)
     let receipt_start = Instant::now();
     if let Some(node_id) = decision.flow_node_id {
-        if let Some(graph) = kernel.flow_graph() {
+        {
+            let graph = kernel.flow_graph();
             if let Some(action_node) = graph.get(node_id) {
                 let ancestor_refs: Vec<&_> =
                     parents.iter().filter_map(|&pid| graph.get(pid)).collect();
@@ -411,8 +411,7 @@ pub(crate) fn run_benchmark(config: BenchConfig) {
     let kernel_start = Instant::now();
     for _ in 0..100 {
         let p = PermissionLattice::safe_pr_fixer();
-        let mut k = Kernel::new(p);
-        k.enable_flow_graph();
+        let _k = Kernel::new(p);
     }
     let kernel_avg = kernel_start.elapsed() / 100;
     eprintln!(
@@ -428,7 +427,6 @@ pub(crate) fn run_benchmark(config: BenchConfig) {
         let start = Instant::now();
         for _ in 0..10 {
             let mut k = Kernel::new(perms.clone());
-            k.enable_flow_graph();
             let mut lv = LeafTracker::default();
             for (op_str, subj) in &ops {
                 if let Ok(op) = portcullis::Operation::try_from(op_str.as_str()) {

--- a/crates/nucleus-claude-hook/src/main.rs
+++ b/crates/nucleus-claude-hook/src/main.rs
@@ -1161,7 +1161,6 @@ fn main() {
 
     let t_kernel_start = std::time::Instant::now();
     let mut kernel = Kernel::new(effective_perms);
-    kernel.enable_flow_graph();
 
     // Load egress policy from .nucleus/egress.toml (if present).
     // SECURITY: Fail-closed — malformed policy denies all egress.
@@ -1367,39 +1366,38 @@ fn main() {
     // The receipt captures the causal chain and verdict.
     let t_receipt_start = std::time::Instant::now();
     let flow_receipt = decision.flow_node_id.and_then(|node_id| {
-        kernel.flow_graph().and_then(|graph| {
-            let action_node = graph.get(node_id)?;
-            let ancestor_refs: Vec<&_> = parents.iter().filter_map(|&pid| graph.get(pid)).collect();
-            let flow_verdict = if decision.verdict.is_denied() {
-                portcullis_core::flow::FlowVerdict::Deny(
-                    portcullis_core::flow::FlowDenyReason::AuthorityEscalation,
-                )
-            } else {
-                portcullis_core::flow::FlowVerdict::Allow
-            };
-            let now = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs();
-            let mut receipt = build_receipt(action_node, &ancestor_refs, flow_verdict, now);
-            receipt.set_prev_hash(session.chain_head_hash);
-            // Bind receipt to this session (#492)
-            let chain_id = {
-                use sha2::{Digest, Sha256};
-                let mut h = Sha256::new();
-                h.update(b"nucleus-chain:");
-                h.update(input.session_id.as_bytes());
-                let hash = h.finalize();
-                let mut id = [0u8; 32];
-                id.copy_from_slice(&hash);
-                id
-            };
-            receipt.set_chain_id(chain_id);
-            if let Some(ref key) = signing_key {
-                sign_receipt(&mut receipt, key);
-            }
-            Some(receipt)
-        })
+        let graph = kernel.flow_graph();
+        let action_node = graph.get(node_id)?;
+        let ancestor_refs: Vec<&_> = parents.iter().filter_map(|&pid| graph.get(pid)).collect();
+        let flow_verdict = if decision.verdict.is_denied() {
+            portcullis_core::flow::FlowVerdict::Deny(
+                portcullis_core::flow::FlowDenyReason::AuthorityEscalation,
+            )
+        } else {
+            portcullis_core::flow::FlowVerdict::Allow
+        };
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let mut receipt = build_receipt(action_node, &ancestor_refs, flow_verdict, now);
+        receipt.set_prev_hash(session.chain_head_hash);
+        // Bind receipt to this session (#492)
+        let chain_id = {
+            use sha2::{Digest, Sha256};
+            let mut h = Sha256::new();
+            h.update(b"nucleus-chain:");
+            h.update(input.session_id.as_bytes());
+            let hash = h.finalize();
+            let mut id = [0u8; 32];
+            id.copy_from_slice(&hash);
+            id
+        };
+        receipt.set_chain_id(chain_id);
+        if let Some(ref key) = signing_key {
+            sign_receipt(&mut receipt, key);
+        }
+        Some(receipt)
     });
 
     let t_receipt = t_receipt_start.elapsed();
@@ -1453,7 +1451,8 @@ fn main() {
             // its receipt chain links back to the parent's.
             if operation == Operation::SpawnAgent {
                 let safe_id = sanitize_session_id(&input.session_id);
-                if let Some(graph) = kernel.flow_graph() {
+                {
+                    let graph = kernel.flow_graph();
                     if let Some(node_id) = decision.flow_node_id {
                         if let Some(node) = graph.get(node_id) {
                             let label_str = portcullis_core::wire::encode_label(&node.label);
@@ -1698,7 +1697,6 @@ mod tests {
         // subsequent writes are blocked by flow control (authority escalation).
         let perms = PermissionLattice::safe_pr_fixer();
         let mut kernel = Kernel::new(perms);
-        kernel.enable_flow_graph();
 
         // Observe web content
         let web_id = kernel.observe(NodeKind::WebContent, &[]).unwrap();
@@ -1719,7 +1717,6 @@ mod tests {
         // Clean file read → write should be allowed
         let perms = PermissionLattice::safe_pr_fixer();
         let mut kernel = Kernel::new(perms);
-        kernel.enable_flow_graph();
 
         let file_id = kernel.observe(NodeKind::FileRead, &[]).unwrap();
 
@@ -1744,7 +1741,6 @@ mod tests {
         // — they don't depend on web content.
         let perms = PermissionLattice::safe_pr_fixer();
         let mut kernel = Kernel::new(perms);
-        kernel.enable_flow_graph();
 
         let mut leaves = LeafTracker::default();
 
@@ -1802,7 +1798,6 @@ mod tests {
         // model doesn't break this fundamental property.
         let perms = PermissionLattice::safe_pr_fixer();
         let mut kernel = Kernel::new(perms);
-        kernel.enable_flow_graph();
 
         let mut leaves = LeafTracker::default();
 
@@ -1871,7 +1866,6 @@ mod tests {
         // causal links so taint propagates through tool outputs.
         let perms = PermissionLattice::permissive();
         let mut kernel = Kernel::new(perms);
-        kernel.enable_flow_graph();
 
         let mut leaves = LeafTracker::default();
 

--- a/crates/nucleus-mcp/src/main.rs
+++ b/crates/nucleus-mcp/src/main.rs
@@ -671,7 +671,6 @@ fn main() -> Result<()> {
     // state. Otherwise, use a permissive lattice (proxy handles enforcement).
     let kernel_lattice = policy.clone().unwrap_or_else(PermissionLattice::permissive);
     let mut kernel = Kernel::new(kernel_lattice);
-    kernel.enable_flow_graph();
 
     // Track the last flow graph node ID for causal chaining.
     // Each allowed operation produces an observation node; the next operation's

--- a/crates/portcullis/src/flow_graph.rs
+++ b/crates/portcullis/src/flow_graph.rs
@@ -36,8 +36,6 @@ pub enum FlowGraphError {
     },
     /// Parent ID 0 (sentinel) is not a valid parent reference.
     SentinelParent,
-    /// The flow graph has not been enabled via `enable_flow_graph()`.
-    GraphNotEnabled,
     /// A referenced parent was a denied action — denied actions did not
     /// execute and cannot be causal ancestors.
     DeniedParent(
@@ -60,7 +58,6 @@ impl std::fmt::Display for FlowGraphError {
                 write!(f, "too many parents: {provided} > {max}")
             }
             FlowGraphError::SentinelParent => write!(f, "sentinel (0) is not a valid parent"),
-            FlowGraphError::GraphNotEnabled => write!(f, "flow graph not enabled"),
             FlowGraphError::DeniedParent(id) => {
                 write!(f, "parent {id} was denied — cannot be a causal ancestor")
             }

--- a/crates/portcullis/src/kernel.rs
+++ b/crates/portcullis/src/kernel.rs
@@ -408,12 +408,12 @@ pub struct Kernel {
     /// taint: once web content is read, the session label gains `Adversarial`
     /// integrity and `NoAuthority` authority.
     flow_label: Option<portcullis_core::IFCLabel>,
-    /// Optional causal DAG for precise per-action flow tracking.
+    /// Causal DAG for precise per-action flow tracking.
     ///
-    /// When enabled via `enable_flow_graph()`, `decide_with_parents()`
-    /// checks flow against actual causal dependencies instead of the
-    /// flat session-level label. This eliminates over-tainting.
-    flow_graph: Option<crate::flow_graph::FlowGraph>,
+    /// Always present. `decide_with_parents()` checks flow against actual
+    /// causal dependencies instead of the flat session-level label. This
+    /// eliminates over-tainting.
+    flow_graph: crate::flow_graph::FlowGraph,
     /// Declassification rules applied to flow labels before checking.
     ///
     /// Must be declared before the session starts (monotonicity of rule set).
@@ -485,9 +485,8 @@ impl Kernel {
     /// prevention) out of the box. This is secure-by-default: callers
     /// get IFC enforcement without remembering to opt in.
     ///
-    /// The causal flow graph is NOT enabled by default — call
-    /// [`Kernel::enable_flow_graph`] for precise per-action tracking
-    /// via `decide_with_parents()`.
+    /// The causal flow graph is always present, providing precise
+    /// per-action tracking via `decide_with_parents()`.
     ///
     /// The initial permissions set the ceiling — effective permissions
     /// can only stay the same or decrease from here. Uses localhost
@@ -526,7 +525,7 @@ impl Kernel {
             exposure: ExposureSet::empty(),
             provenance: None,
             flow_label: Some(portcullis_core::IFCLabel::user_prompt(now)),
-            flow_graph: None,
+            flow_graph: crate::flow_graph::FlowGraph::new(),
             declassification_rules: Vec::new(),
             egress_policy: None,
             policy_rules: None,
@@ -575,7 +574,7 @@ impl Kernel {
             exposure: ExposureSet::empty(),
             provenance: None,
             flow_label: None,
-            flow_graph: None,
+            flow_graph: crate::flow_graph::FlowGraph::new(),
             declassification_rules: Vec::new(),
             egress_policy: None,
             policy_rules: None,
@@ -607,16 +606,6 @@ impl Kernel {
     /// Enable the causal DAG for precise per-action flow tracking.
     ///
     /// When enabled, `decide_with_parents()` tracks actual data dependencies
-    /// instead of using the flat session-level label. This eliminates
-    /// over-tainting: actions that don't causally depend on untrusted data
-    /// are unaffected by it.
-    ///
-    /// The flat `decide()` still works as before — the DAG is only used
-    /// when callers explicitly provide parent node IDs.
-    pub fn enable_flow_graph(&mut self) {
-        self.flow_graph = Some(crate::flow_graph::FlowGraph::new());
-    }
-
     /// Enable the receipt chain for verdict attestation.
     ///
     /// When enabled, every `decide()` call appends a [`VerdictReceipt`] to an
@@ -687,9 +676,8 @@ impl Kernel {
     /// before applying. If no trusted keys are configured, the token is
     /// applied without verification (backward compatibility) with a warning.
     ///
-    /// Returns `Err(DenyReason::InvalidDeclassification)` if:
-    /// - The flow graph is not enabled
-    /// - Trusted keys are set and signature verification fails
+    /// Returns `Err(DenyReason::InvalidDeclassification)` if trusted keys
+    /// are set and signature verification fails.
     ///
     /// Returns `Ok(TokenApplyResult)` on success (or if the token was
     /// expired / precondition unmet — those are non-error rejections).
@@ -698,12 +686,7 @@ impl Kernel {
         &mut self,
         token: &portcullis_core::declassify::DeclassificationToken,
     ) -> Result<portcullis_core::declassify::TokenApplyResult, DenyReason> {
-        let graph = self
-            .flow_graph
-            .as_mut()
-            .ok_or(DenyReason::InvalidDeclassification {
-                detail: "flow graph not enabled".to_string(),
-            })?;
+        let graph = &mut self.flow_graph;
 
         let now = chrono::Utc::now().timestamp() as u64;
 
@@ -747,25 +730,22 @@ impl Kernel {
     ///
     /// Returns the `NodeId` for use as a parent in subsequent `observe()`
     /// Read-only access to the flow graph (for receipt construction).
-    pub fn flow_graph(&self) -> Option<&crate::flow_graph::FlowGraph> {
-        self.flow_graph.as_ref()
+    pub fn flow_graph(&self) -> &crate::flow_graph::FlowGraph {
+        &self.flow_graph
     }
 
     /// or `decide_with_parents()` calls. Observations are not flow-checked —
     /// they just record what data entered the session.
     ///
-    /// Returns `Err` if the flow graph is not enabled or if parent validation
-    /// fails. Callers must handle the error — do not use `.unwrap_or(0)` as
-    /// node ID 0 is the sentinel and will be rejected.
+    /// Returns `Err` if parent validation fails. Callers must handle the
+    /// error — do not use `.unwrap_or(0)` as node ID 0 is the sentinel
+    /// and will be rejected.
     pub fn observe(
         &mut self,
         kind: portcullis_core::flow::NodeKind,
         parents: &[u64],
     ) -> Result<u64, crate::flow_graph::FlowGraphError> {
-        let graph = self
-            .flow_graph
-            .as_mut()
-            .ok_or(crate::flow_graph::FlowGraphError::GraphNotEnabled)?;
+        let graph = &mut self.flow_graph;
         let now = chrono::Utc::now().timestamp() as u64;
         let node_id = graph.insert_observation(kind, parents, now)?;
 
@@ -810,17 +790,15 @@ impl Kernel {
     /// an action depending only on local files won't be blocked by web
     /// content read elsewhere in the session.
     ///
-    /// Falls back to `decide()` if the flow graph is not enabled.
+    /// The flow graph is always active; this method provides precise
+    /// per-action flow checking via causal parents.
     pub fn decide_with_parents(
         &mut self,
         operation: Operation,
         subject: &str,
         parents: &[u64],
     ) -> (Decision, Option<DecisionToken>) {
-        let graph = match self.flow_graph.as_mut() {
-            Some(g) => g,
-            None => return self.decide(operation, subject),
-        };
+        let graph = &mut self.flow_graph;
 
         let now = chrono::Utc::now().timestamp() as u64;
 
@@ -956,7 +934,7 @@ impl Kernel {
             exposure: ExposureSet::empty(),
             provenance: Some(provenance),
             flow_label: Some(portcullis_core::IFCLabel::user_prompt(now)),
-            flow_graph: None,
+            flow_graph: crate::flow_graph::FlowGraph::new(),
             declassification_rules: Vec::new(),
             egress_policy: None,
             policy_rules: None,
@@ -1011,7 +989,7 @@ impl Kernel {
             exposure: ExposureSet::empty(),
             provenance: Some(provenance),
             flow_label: Some(portcullis_core::IFCLabel::user_prompt(now)),
-            flow_graph: None,
+            flow_graph: crate::flow_graph::FlowGraph::new(),
             declassification_rules: Vec::new(),
             egress_policy: None,
             policy_rules: None,
@@ -1401,52 +1379,15 @@ impl Kernel {
         // precise per-action causal labels via `decide_with_parents()`, which
         // eliminates the over-tainting problem. The flat label is still updated
         // for audit/reporting purposes, but only `decide_with_parents()` enforces
-        // flow policy when the graph is active.
-        //
-        // Without a FlowGraph, the flat label remains the enforcement mechanism
-        // (backward-compatible for callers that don't use the DAG).
+        // flow policy. The flow graph is always active — callers should use
+        // `decide_with_parents()` for flow-checked decisions.
         if let Some(ref mut flow_label) = self.flow_label {
             use portcullis_core::flow;
 
             let now_unix = now.timestamp() as u64;
 
-            // When the flow graph is enabled, skip the flat label gate.
-            // Callers must use decide_with_parents() for flow-checked decisions.
-            // The flat label is still updated below for audit purposes.
-            let flow_graph_active = self.flow_graph.is_some();
-
-            if !flow_graph_active {
-                // Phase A: check the action against the current (pre-taint) label
-                let node = flow::FlowNode {
-                    id: self.next_seq,
-                    kind: flow::NodeKind::OutboundAction,
-                    label: *flow_label,
-                    parent_count: 0,
-                    parents: [0; flow::MAX_PARENTS],
-                    operation: Some(operation),
-                    sink_class: Some(portcullis_core::default_sink_class(operation)),
-                    effect_kind: None,
-                };
-
-                if let flow::FlowVerdict::Deny(reason) = flow::check_flow(&node, now_unix) {
-                    return self.record_with_exposure(
-                        operation,
-                        subject,
-                        Verdict::Deny(DenyReason::FlowViolation {
-                            rule: format!("{:?}", reason),
-                            receipt: None,
-                        }),
-                        &pre_hash,
-                        pre_exposure_count,
-                        contributed_label,
-                        false,
-                        false,
-                    );
-                }
-            }
-
             // Phase B: taint the session label with the operation's intrinsic
-            // (always, regardless of flow_graph — for audit/reporting)
+            // (for audit/reporting — the DAG handles enforcement)
             let intrinsic = flow::intrinsic_label(Self::node_kind_for(operation), now_unix);
             *flow_label = flow_label.join(intrinsic);
         }
@@ -1903,7 +1844,7 @@ impl Kernel {
             // Causal parent node IDs and effect kind from the flow graph.
             let flow_node = decision
                 .flow_node_id
-                .and_then(|nid| self.flow_graph.as_ref().and_then(|g| g.get(nid)));
+                .and_then(|nid| self.flow_graph.get(nid));
             let causal_parents: Vec<portcullis_core::flow::NodeId> = flow_node
                 .map(|node| node.parents[..node.parent_count as usize].to_vec())
                 .unwrap_or_default();
@@ -3264,14 +3205,18 @@ mod tests {
     fn flow_enabled_by_default() {
         let perms = PermissionLattice::permissive();
         let mut kernel = Kernel::new(perms);
-        // Flow control is on by default — web fetch taints the session,
-        // then write is blocked by flow violation (NoAuthority < Suggestive).
-        let (d1, _) = kernel.decide(Operation::WebFetch, "https://example.com");
-        assert!(matches!(d1.verdict, Verdict::Allow));
-        let (d2, _) = kernel.decide(Operation::WriteFiles, "/tmp/test.txt");
+        // Flow graph is always on. Flat decide() no longer gates — use
+        // decide_with_parents() for flow enforcement via the causal DAG.
+        //
+        // Observe web content (this is the data source, not an action).
+        let web = kernel
+            .observe(portcullis_core::flow::NodeKind::WebContent, &[])
+            .unwrap();
+        // Write depending on web content is blocked by DAG flow check
+        let (d2, _) = kernel.decide_with_parents(Operation::WriteFiles, "/tmp/test.txt", &[web]);
         assert!(
             matches!(d2.verdict, Verdict::Deny(DenyReason::FlowViolation { .. })),
-            "Flow control should be on by default, got {:?}",
+            "Flow control should enforce via DAG, got {:?}",
             d2.verdict
         );
     }
@@ -3293,12 +3238,13 @@ mod tests {
         let mut kernel = Kernel::new(perms);
         kernel.enable_flow_control();
 
-        // WebFetch taints the session with Adversarial + NoAuthority
-        let (d1, _) = kernel.decide(Operation::WebFetch, "https://example.com");
-        assert!(matches!(d1.verdict, Verdict::Allow));
+        // Observe web content — this is the data source node
+        let web = kernel
+            .observe(portcullis_core::flow::NodeKind::WebContent, &[])
+            .unwrap();
 
-        // WriteFiles now blocked — NoAuthority < Suggestive
-        let (d2, _) = kernel.decide(Operation::WriteFiles, "/tmp/test.txt");
+        // WriteFiles depending on web content is blocked by DAG flow check
+        let (d2, _) = kernel.decide_with_parents(Operation::WriteFiles, "/tmp/test.txt", &[web]);
         assert!(
             matches!(d2.verdict, Verdict::Deny(DenyReason::FlowViolation { .. })),
             "Expected FlowViolation, got {:?}",
@@ -3357,12 +3303,14 @@ mod tests {
         // Pre-grant approval for GitPush
         kernel.grant_approval(Operation::GitPush, 1);
 
-        // Taint session with web content
-        let (d1, _) = kernel.decide(Operation::WebFetch, "https://evil.com");
-        assert!(matches!(d1.verdict, Verdict::Allow));
+        // Observe web content (data source)
+        let web = kernel
+            .observe(portcullis_core::flow::NodeKind::WebContent, &[])
+            .unwrap();
 
-        // GitPush should be DENIED by flow check even with pre-granted approval
-        let (d2, _) = kernel.decide(Operation::GitPush, "origin main");
+        // GitPush depending on web node should be DENIED by DAG flow check
+        // even with pre-granted approval
+        let (d2, _) = kernel.decide_with_parents(Operation::GitPush, "origin main", &[web]);
         assert!(
             matches!(d2.verdict, Verdict::Deny(DenyReason::FlowViolation { .. })),
             "Flow check must run before approval path! Got {:?}",
@@ -3376,7 +3324,6 @@ mod tests {
     fn dag_independent_branches_no_overtaint() {
         let perms = PermissionLattice::safe_pr_fixer();
         let mut kernel = Kernel::new(perms);
-        kernel.enable_flow_graph();
 
         // Task A: web content (adversarial)
         let web_id = kernel
@@ -3413,7 +3360,6 @@ mod tests {
     fn dag_transitive_taint_propagation() {
         let perms = PermissionLattice::safe_pr_fixer();
         let mut kernel = Kernel::new(perms);
-        kernel.enable_flow_graph();
 
         let web = kernel
             .observe(portcullis_core::flow::NodeKind::WebContent, &[])
@@ -3436,7 +3382,6 @@ mod tests {
     fn dag_clean_chain_allowed() {
         let perms = PermissionLattice::safe_pr_fixer();
         let mut kernel = Kernel::new(perms);
-        kernel.enable_flow_graph();
 
         let user = kernel
             .observe(portcullis_core::flow::NodeKind::UserPrompt, &[])
@@ -3459,7 +3404,6 @@ mod tests {
     fn dag_denied_action_produces_receipt() {
         let perms = PermissionLattice::safe_pr_fixer();
         let mut kernel = Kernel::new(perms);
-        kernel.enable_flow_graph();
 
         let web = kernel
             .observe(portcullis_core::flow::NodeKind::WebContent, &[])
@@ -3483,21 +3427,23 @@ mod tests {
     }
 
     #[test]
-    fn dag_fallback_without_enable() {
+    fn dag_always_on_even_capability_only() {
         let perms = PermissionLattice::safe_pr_fixer();
         let mut kernel = Kernel::capability_only(perms);
-        // capability_only() has no flow graph — decide_with_parents should fall back to decide()
+        // capability_only() still has a flow graph — decide_with_parents uses the DAG
 
         let (d, _) = kernel.decide_with_parents(Operation::ReadFiles, "/workspace/main.rs", &[]);
         assert!(d.verdict.is_allowed());
-        assert!(d.flow_node_id.is_none(), "No DAG → no flow_node_id");
+        assert!(
+            d.flow_node_id.is_some(),
+            "DAG always on → should have flow_node_id"
+        );
     }
 
     #[test]
     fn dag_capability_check_still_applies() {
         let perms = PermissionLattice::safe_pr_fixer();
         let mut kernel = Kernel::new(perms);
-        kernel.enable_flow_graph();
 
         let user = kernel
             .observe(portcullis_core::flow::NodeKind::UserPrompt, &[])
@@ -3523,7 +3469,6 @@ mod tests {
         let perms = PermissionLattice::safe_pr_fixer();
         let mut kernel = Kernel::new(perms);
         kernel.enable_flow_control(); // flat label
-        kernel.enable_flow_graph(); // DAG
 
         // Read web content — taints the flat session label
         let _web = kernel
@@ -3547,12 +3492,15 @@ mod tests {
     }
 
     #[test]
-    fn dag_observe_returns_error_without_enable() {
-        // Issue #364: observe() should return Err, not panic
+    fn dag_observe_works_on_capability_only() {
+        // #753: flow graph is always present, even on capability_only kernels
         let perms = PermissionLattice::safe_pr_fixer();
         let mut kernel = Kernel::capability_only(perms);
         let result = kernel.observe(portcullis_core::flow::NodeKind::FileRead, &[]);
-        assert!(result.is_err());
+        assert!(
+            result.is_ok(),
+            "observe() should succeed — DAG is always on"
+        );
     }
 
     #[test]
@@ -3562,7 +3510,6 @@ mod tests {
 
         let perms = PermissionLattice::safe_pr_fixer();
         let mut kernel = Kernel::new(perms);
-        kernel.enable_flow_graph();
 
         // Add declassification rule: search API output gets Adversarial → Untrusted
         kernel.add_declassification_rule(DeclassificationRule {
@@ -3598,7 +3545,6 @@ mod tests {
 
         let perms = PermissionLattice::safe_pr_fixer();
         let mut kernel = Kernel::new(perms);
-        kernel.enable_flow_graph();
 
         // Raise authority: Informational → Suggestive (for curated tool output)
         // ToolResponse starts at Informational authority
@@ -3647,7 +3593,6 @@ mod tests {
         let perms = PermissionLattice::permissive();
         let mut kernel = Kernel::new(perms);
         kernel.enable_flow_control();
-        kernel.enable_flow_graph();
 
         // WebFetch taints the flat session label
         let (d, _) = kernel.decide(Operation::WebFetch, "https://example.com");
@@ -3664,21 +3609,21 @@ mod tests {
     }
 
     #[test]
-    fn causal_decide_flat_label_still_gates_without_graph() {
-        // Backward compat: without enable_flow_graph(), the flat label
-        // still gates operations (pre-#654 behavior preserved).
+    fn dag_always_on_flat_decide_does_not_gate() {
+        // #753: flow graph is always present — flat decide() never gates
+        // on the session label. Use decide_with_parents() for flow enforcement.
         let perms = PermissionLattice::permissive();
         let mut kernel = Kernel::new(perms);
         kernel.enable_flow_control();
-        // NOTE: no enable_flow_graph()
 
         let (d, _) = kernel.decide(Operation::WebFetch, "https://example.com");
         assert!(d.verdict.is_allowed());
 
+        // With flow graph always on, flat decide() skips the label gate
         let (d, _) = kernel.decide(Operation::WriteFiles, "/tmp/test.txt");
         assert!(
-            matches!(d.verdict, Verdict::Deny(DenyReason::FlowViolation { .. })),
-            "Without flow graph, flat label should still gate. Got {:?}",
+            d.verdict.is_allowed(),
+            "With flow graph always on, flat decide() should not gate on session label. Got {:?}",
             d.verdict
         );
     }
@@ -3690,7 +3635,6 @@ mod tests {
         let perms = PermissionLattice::permissive();
         let mut kernel = Kernel::new(perms);
         kernel.enable_flow_control();
-        kernel.enable_flow_graph();
 
         // Fetch web content
         let (d, _) = kernel.decide(Operation::WebFetch, "https://example.com");
@@ -3714,7 +3658,6 @@ mod tests {
         // "adversarial read + independent clean write → clean write ALLOWED"
         let perms = PermissionLattice::safe_pr_fixer();
         let mut kernel = Kernel::new(perms);
-        kernel.enable_flow_graph();
 
         // Adversarial content observed
         let _web = kernel
@@ -3742,7 +3685,6 @@ mod tests {
         // "write that depends on adversarial content → still DENIED"
         let perms = PermissionLattice::safe_pr_fixer();
         let mut kernel = Kernel::new(perms);
-        kernel.enable_flow_graph();
 
         // Adversarial content observed
         let web = kernel
@@ -3790,7 +3732,6 @@ mod tests {
 
         let mut kernel = Kernel::new(perms);
         kernel.enable_flow_control();
-        kernel.enable_flow_graph();
 
         // Read private data
         let (d, _) = kernel.decide(Operation::ReadFiles, "/etc/passwd");

--- a/crates/portcullis/tests/kernel_red_team.rs
+++ b/crates/portcullis/tests/kernel_red_team.rs
@@ -1,7 +1,7 @@
 //! Kernel-integration red team tests.
 //!
 //! These tests exercise the FULL enforcement path:
-//!   Kernel::new() → enable_flow_graph() → observe() → decide_with_parents()
+//!   Kernel::new() → observe() → decide_with_parents()
 //!
 //! Unlike `portcullis-core/tests/flow_red_team.rs` which constructs FlowNode
 //! structs manually and calls check_flow() directly, these tests go through
@@ -30,7 +30,6 @@ use portcullis_core::flow::NodeKind;
 fn kernel_web_content_blocks_git_push() {
     let perms = PermissionLattice::permissive();
     let mut kernel = Kernel::new(perms);
-    kernel.enable_flow_graph();
 
     // Step 1: Observe web content (reading is fine — no action, no check)
     let web_node = kernel
@@ -96,7 +95,6 @@ fn kernel_web_content_blocks_git_push() {
 fn kernel_clean_write_allowed_alongside_tainted_session() {
     let perms = PermissionLattice::permissive();
     let mut kernel = Kernel::new(perms);
-    kernel.enable_flow_graph();
 
     // Step 1: Observe web content — taints the session-level label
     let _web_node = kernel
@@ -147,7 +145,6 @@ fn kernel_clean_write_allowed_alongside_tainted_session() {
 fn kernel_ai_derived_blocked_from_git_push() {
     let perms = PermissionLattice::permissive();
     let mut kernel = Kernel::new(perms);
-    kernel.enable_flow_graph();
 
     // Step 1: Observe a model plan step (AI-derived content)
     let model_node = kernel
@@ -191,7 +188,6 @@ fn kernel_ai_derived_blocked_from_git_push() {
 fn kernel_web_content_blocks_create_pr() {
     let perms = PermissionLattice::permissive();
     let mut kernel = Kernel::new(perms);
-    kernel.enable_flow_graph();
 
     let web_node = kernel
         .observe(NodeKind::WebContent, &[])
@@ -226,7 +222,6 @@ fn kernel_web_content_blocks_create_pr() {
 fn kernel_transitive_web_taint_through_model_plan() {
     let perms = PermissionLattice::permissive();
     let mut kernel = Kernel::new(perms);
-    kernel.enable_flow_graph();
 
     // Step 1: Observe web content
     let web_node = kernel
@@ -270,7 +265,6 @@ fn kernel_transitive_web_taint_through_model_plan() {
 fn kernel_clean_chain_allows_git_commit() {
     let perms = PermissionLattice::permissive();
     let mut kernel = Kernel::new(perms);
-    kernel.enable_flow_graph();
 
     // User prompt → file read → model plan → git commit
     let user = kernel
@@ -306,7 +300,6 @@ fn kernel_clean_chain_allows_git_commit() {
 fn kernel_secret_exfil_blocked() {
     let perms = PermissionLattice::permissive();
     let mut kernel = Kernel::new(perms);
-    kernel.enable_flow_graph();
 
     // Observe a secret (environment variable)
     let secret_node = kernel
@@ -374,7 +367,6 @@ fn flagship_demo_b_poisoned_memory_delegated_agent() {
 
     let perms_a = PermissionLattice::permissive();
     let mut kernel_a = Kernel::new(perms_a);
-    kernel_a.enable_flow_graph();
 
     // Step 1: Observe the malicious web content (reading is fine)
     let _web_node = kernel_a
@@ -413,7 +405,6 @@ fn flagship_demo_b_poisoned_memory_delegated_agent() {
 
     let perms_b = PermissionLattice::permissive();
     let mut kernel_b = Kernel::new(perms_b);
-    kernel_b.enable_flow_graph();
 
     // Step 3: Read the poisoned memory entry's IFC label.
     // read_label() maps MayNotAuthorize → AuthorityLevel::NoAuthority
@@ -659,7 +650,6 @@ fn flagship_demo_b_poisoned_memory_delegated_agent() {
 fn flagship_demo_c_mcp_skill_remote_instruction_attack() {
     let perms = PermissionLattice::permissive();
     let mut kernel = Kernel::new(perms);
-    kernel.enable_flow_graph();
 
     // ─── Phase 1: MCP skill fetches remote instructions ────────────
     //

--- a/crates/portcullis/tests/kernel_token.rs
+++ b/crates/portcullis/tests/kernel_token.rs
@@ -30,9 +30,7 @@ fn public_key_bytes(key: &Ed25519KeyPair) -> [u8; 32] {
 
 fn make_kernel_with_graph() -> Kernel {
     let perms = PermissionLattice::safe_pr_fixer();
-    let mut kernel = Kernel::new(perms);
-    kernel.enable_flow_graph();
-    kernel
+    Kernel::new(perms)
 }
 
 fn make_token(node_id: u64) -> DeclassificationToken {
@@ -179,27 +177,21 @@ fn key_rotation_accepts_old_key() {
 }
 
 #[test]
-fn apply_token_without_flow_graph_returns_error() {
+fn apply_token_for_nonexistent_node_returns_not_found() {
+    // #753: flow graph is always present. Applying a token for a
+    // nonexistent node returns NodeNotFound (not GraphNotEnabled).
     let key = test_key();
     let perms = PermissionLattice::safe_pr_fixer();
     let mut kernel = Kernel::new(perms);
-    // Do NOT enable flow graph
     kernel.set_trusted_keys(vec![public_key_bytes(&key)]);
 
     let mut token = make_token(42);
     token_sign::sign_token(&mut token, &key);
 
     let result = kernel.apply_declassification_token(&token);
-    match result {
-        Err(DenyReason::InvalidDeclassification { detail }) => {
-            assert!(
-                detail.contains("flow graph not enabled"),
-                "expected flow graph error, got: {detail}"
-            );
-        }
-        other => panic!(
-            "expected InvalidDeclassification (flow graph), got {:?}",
-            other
-        ),
-    }
+    assert!(
+        matches!(result, Ok(TokenApplyResult::NodeNotFound)),
+        "expected NodeNotFound for nonexistent node, got {:?}",
+        result
+    );
 }

--- a/crates/portcullis/tests/signed_demo.rs
+++ b/crates/portcullis/tests/signed_demo.rs
@@ -24,7 +24,6 @@ fn invariant_exploit_blocked_with_signed_receipt() {
     // Create kernel with flow graph and signing key
     let perms = PermissionLattice::safe_pr_fixer();
     let mut kernel = Kernel::new(perms);
-    kernel.enable_flow_graph();
     kernel.set_signing_key(std::sync::Arc::new(signing_key));
 
     // ── Simulate the Invariant exploit scenario ──


### PR DESCRIPTION
## Summary

- **Phase 1 of #753**: Remove `Option<FlowGraph>` wrapper — `flow_graph` is now a plain `FlowGraph` field, initialized in every `Kernel` constructor (`new`, `capability_only`, `from_certificate` variants)
- Remove `enable_flow_graph()` method, `GraphNotEnabled` error variant, and all call sites across portcullis, nucleus-mcp, and nucleus-claude-hook
- Flat `decide()` no longer gates on the session-level flow label (the DAG handles enforcement); callers use `decide_with_parents()` for flow-checked decisions

## Changes

**portcullis/src/kernel.rs** (net -50 lines):
- `flow_graph: Option<FlowGraph>` → `flow_graph: FlowGraph`
- All 4 constructors initialize with `FlowGraph::new()` instead of `None`
- Removed `enable_flow_graph()` method
- `flow_graph()` accessor returns `&FlowGraph` instead of `Option<&FlowGraph>`
- `observe()` no longer returns `GraphNotEnabled` — operates directly on `&mut self.flow_graph`
- `decide_with_parents()` no longer falls back to `decide()` — DAG is always active
- `decide()` flow label block simplified: removed `flow_graph_active` check and flat gate
- Receipt chain code simplified: no more `.as_ref().and_then()` on flow graph

**portcullis/src/flow_graph.rs**: Removed `GraphNotEnabled` variant and its `Display` arm

**Tests updated**:
- 5 kernel.rs tests adapted to DAG-primary semantics (flow enforcement via `decide_with_parents`)
- External tests (kernel_red_team, kernel_token, signed_demo) — removed all `enable_flow_graph()` calls
- Backward-compat test renamed to `dag_always_on_flat_decide_does_not_gate`

**Callers updated**: nucleus-mcp, nucleus-claude-hook (main.rs + bench.rs)

## Test plan

- [x] `cargo check -p portcullis -p nucleus-mcp -p nucleus-claude-hook` — clean
- [x] `cargo test -p portcullis --lib` — 859 passed
- [x] Integration tests (kernel_token, kernel_red_team, signed_demo) — 16 passed
- [x] All pre-commit hooks pass (fmt, clippy, deny, audit)
- [x] All pre-push hooks pass (including cargo test)
- [x] kernel.rs at 3847 lines (under 3900 ceiling)

Closes phase 1 of #753

🤖 Generated with [Claude Code](https://claude.com/claude-code)