### PR TITLE
fix: resolve private field compilation errors in verus_conformance and examples

### DIFF
--- a/crates/portcullis/examples/basic_usage.rs
+++ b/crates/portcullis/examples/basic_usage.rs
@@ -38,11 +38,12 @@ fn main() {
 
     // Using the full permission lattice
     println!("\n3. Using PermissionLattice with automatic uninhabitable_state enforcement:");
-    let perms = PermissionLattice {
-        capabilities: dangerous.clone(),
-        obligations: Default::default(),
-        uninhabitable_constraint: true,
-        ..Default::default()
+    #[allow(clippy::field_reassign_with_default)]
+    let perms = {
+        let mut p = PermissionLattice::default();
+        p.capabilities = dangerous.clone();
+        p.obligations = Default::default();
+        p
     };
 
     // Meet operation automatically applies constraint

--- a/crates/portcullis/examples/exposure_guard.rs
+++ b/crates/portcullis/examples/exposure_guard.rs
@@ -88,10 +88,11 @@ fn main() {
 
     // Scenario 4: Automatic uninhabitable_state enforcement via PermissionLattice
     println!("\nScenario 4: Automatic enforcement via meet()");
-    let perms = PermissionLattice {
-        capabilities: dangerous.clone(),
-        uninhabitable_constraint: true,
-        ..Default::default()
+    #[allow(clippy::field_reassign_with_default)]
+    let perms = {
+        let mut p = PermissionLattice::default();
+        p.capabilities = dangerous.clone();
+        p
     };
     let enforced = perms.meet(&perms);
     println!(

--- a/crates/portcullis/tests/verus_conformance.rs
+++ b/crates/portcullis/tests/verus_conformance.rs
@@ -31,13 +31,13 @@ use proptest::prelude::*;
 /// EditFiles, WebSearch, etc. as baseline safety. The Verus model only models
 /// uninhabitable_state-derived obligations. This helper starts clean so conformance tests
 /// verify the uninhabitable_state model in isolation.
+#[allow(clippy::field_reassign_with_default)]
 fn perms_with_empty_obligations(caps: CapabilityLattice) -> PermissionLattice {
-    PermissionLattice {
-        capabilities: caps,
-        obligations: Obligations::default(), // empty
-        paths: PathLattice::default(),
-        ..Default::default()
-    }
+    let mut perms = PermissionLattice::default();
+    perms.capabilities = caps;
+    perms.obligations = Obligations::default(); // empty
+    perms.paths = PathLattice::default();
+    perms
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- Fix compilation errors in `tests/verus_conformance.rs`, `examples/basic_usage.rs`, and `examples/exposure_guard.rs`
- `PermissionLattice.uninhabitable_constraint` is private, so struct literal syntax with `..Default::default()` fails
- Switch to mutable default construction with `#[allow(clippy::field_reassign_with_default)]`
- 142 verus conformance tests now pass again

## Test plan

- [x] `cargo test -p portcullis --test verus_conformance` — 142 tests pass
- [x] `cargo build -p portcullis --examples` — compiles clean
- [x] All pre-commit/pre-push hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)