### PR TITLE
feat: auto-detect compartment from tool usage patterns (#472)

### DIFF
--- a/crates/nucleus-claude-hook/src/main.rs
+++ b/crates/nucleus-claude-hook/src/main.rs
@@ -972,6 +972,17 @@ fn main() {
         &session.compartment_token,
         prev_compartment,
     );
+
+    // Auto-compartment detection (#472).
+    let compartment = session::auto_detect_compartment(
+        compartment,
+        prev_compartment,
+        &operation.to_string(),
+        &input.tool_name,
+        &input.session_id,
+        &session.compartment_token,
+    );
+
     // Detect compartment transition
     if compartment != prev_compartment {
         if let Some(ref new_comp) = compartment {
@@ -1624,6 +1635,8 @@ fn main() {
 
 // ---------------------------------------------------------------------------
 // Tests
+// ---------------------------------------------------------------------------
+
 // ---------------------------------------------------------------------------
 
 #[cfg(test)]

--- a/crates/nucleus-claude-hook/src/session.rs
+++ b/crates/nucleus-claude-hook/src/session.rs
@@ -1014,6 +1014,51 @@ pub(crate) fn deny_pending_transition(error: &TransitionError) -> String {
 }
 
 // ---------------------------------------------------------------------------
+// Auto-compartment detection (#472)
+// ---------------------------------------------------------------------------
+
+/// Infer compartment from tool usage when no compartment is set.
+///
+/// When `NUCLEUS_AUTO_COMPARTMENT=1` and no compartment is active, maps:
+/// WebSearch/WebFetch → Research, Write/Edit → Draft, RunBash/GitPush → Execute.
+/// Never auto-escalates — only sets the initial compartment.
+pub(crate) fn auto_detect_compartment(
+    current: Option<portcullis_core::compartment::Compartment>,
+    prev: Option<portcullis_core::compartment::Compartment>,
+    operation_name: &str,
+    tool_name: &str,
+    session_id: &str,
+    token: &str,
+) -> Option<portcullis_core::compartment::Compartment> {
+    if current.is_some() || prev.is_some() {
+        return current;
+    }
+    if !std::env::var("NUCLEUS_AUTO_COMPARTMENT")
+        .map(|v| v == "1")
+        .unwrap_or(false)
+    {
+        return current;
+    }
+    let inferred = match operation_name {
+        "WebSearch" | "WebFetch" => Some(portcullis_core::compartment::Compartment::Research),
+        "WriteFiles" | "EditFiles" | "NotebookEdit" => {
+            Some(portcullis_core::compartment::Compartment::Draft)
+        }
+        "RunBash" | "GitPush" | "GitCommit" => {
+            Some(portcullis_core::compartment::Compartment::Execute)
+        }
+        _ => None,
+    };
+    if let Some(ref comp) = inferred {
+        let keyed_name = keyed_compartment_name(session_id, token);
+        let comp_path = session_dir().join(format!("{keyed_name}.compartment"));
+        std::fs::write(&comp_path, comp.to_string()).ok();
+        eprintln!("nucleus: auto-compartment detected from {tool_name}: {comp}");
+    }
+    inferred
+}
+
+// ---------------------------------------------------------------------------
 // Garbage collection
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- When `NUCLEUS_AUTO_COMPARTMENT=1`, infer compartment from first tool call
- WebSearch/WebFetch → Research, Write/Edit → Draft, RunBash/GitPush → Execute
- Never auto-escalates — only sets initial compartment
- Closes #472

## Test plan

- [x] `cargo test -p nucleus-claude-hook` — 184 pass
- [x] main.rs at 1934 lines (under 1941 ceiling)
- [x] All hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)