### PR TITLE
feat: add DeterministicBind NodeKind with flow graph parent validation (#931)

### DIFF
--- a/crates/nucleus-claude-hook/src/classify.rs
+++ b/crates/nucleus-claude-hook/src/classify.rs
@@ -403,6 +403,7 @@ pub(crate) fn node_kind_to_u8(kind: NodeKind) -> u8 {
         NodeKind::DatabaseRow => 13,
         NodeKind::GitBlob => 14,
         NodeKind::CachedDatum => 15,
+        NodeKind::DeterministicBind => 16,
     }
 }
 
@@ -424,7 +425,8 @@ pub(crate) fn u8_to_node_kind(v: u8) -> NodeKind {
         12 => NodeKind::HTTPResponse,
         13 => NodeKind::DatabaseRow,
         14 => NodeKind::GitBlob,
-        _ => NodeKind::CachedDatum,
+        15 => NodeKind::CachedDatum,
+        _ => NodeKind::DeterministicBind,
     }
 }
 
@@ -498,7 +500,8 @@ impl LeafTracker {
             | NodeKind::EnvVar
             | NodeKind::MemoryRead
             | NodeKind::DatabaseRow
-            | NodeKind::GitBlob => &mut self.trusted,
+            | NodeKind::GitBlob
+            | NodeKind::DeterministicBind => &mut self.trusted,
             NodeKind::WebContent | NodeKind::HTTPResponse | NodeKind::CachedDatum => {
                 &mut self.adversarial
             }
@@ -565,6 +568,10 @@ impl LeafTracker {
                 parents.extend_from_slice(&self.model);
                 parents
             }
+            // DeterministicBind: parents are supplied explicitly by the caller,
+            // NOT from the LeafTracker. This ensures no model node sneaks into
+            // the deterministic ancestry chain (#922).
+            NodeKind::DeterministicBind => vec![],
         }
     }
 }

--- a/crates/portcullis-core/src/flow.rs
+++ b/crates/portcullis-core/src/flow.rs
@@ -69,6 +69,11 @@ pub enum NodeKind {
     /// Data retrieved from a cache layer.
     /// Public confidentiality, untrusted integrity (cache can be stale/poisoned).
     CachedDatum,
+    /// Parser output bound to a schema field without model intermediation.
+    /// Parents must be exclusively deterministic (non-model) nodes.
+    /// This is the "air gap" that keeps AI-derived taint out of
+    /// deterministic data paths (#922).
+    DeterministicBind,
 }
 
 /// Intrinsic label for a node kind — the base label before propagation.
@@ -201,6 +206,18 @@ pub fn intrinsic_label(kind: NodeKind, now: u64) -> IFCLabel {
         NodeKind::CachedDatum => IFCLabel {
             confidentiality: ConfLevel::Public,
             integrity: IntegLevel::Untrusted,
+            provenance: ProvenanceSet::TOOL,
+            freshness: crate::Freshness {
+                observed_at: now,
+                ttl_secs: 0,
+            },
+            authority: AuthorityLevel::NoAuthority,
+            derivation: DerivationClass::Deterministic,
+        },
+        // DeterministicBind — parser output bound to schema field, no model touch.
+        NodeKind::DeterministicBind => IFCLabel {
+            confidentiality: ConfLevel::Internal,
+            integrity: IntegLevel::Trusted,
             provenance: ProvenanceSet::TOOL,
             freshness: crate::Freshness {
                 observed_at: now,

--- a/crates/portcullis/src/flow_graph.rs
+++ b/crates/portcullis/src/flow_graph.rs
@@ -48,6 +48,12 @@ pub enum FlowGraphError {
         /// The quarantined node ID.
         NodeId,
     ),
+    /// A DeterministicBind node has a parent with AIDerived/Mixed derivation.
+    /// This would break the deterministic data path invariant (#922).
+    DeterministicBindTainted(
+        /// The tainted parent node ID.
+        NodeId,
+    ),
 }
 
 impl std::fmt::Display for FlowGraphError {
@@ -65,6 +71,12 @@ impl std::fmt::Display for FlowGraphError {
                 write!(
                     f,
                     "parent {id} is quarantined — release quarantine before use"
+                )
+            }
+            FlowGraphError::DeterministicBindTainted(id) => {
+                write!(
+                    f,
+                    "parent {id} has AI-derived taint — DeterministicBind requires clean ancestry"
                 )
             }
         }
@@ -387,6 +399,21 @@ impl FlowGraph {
         now: u64,
     ) -> Result<NodeId, FlowGraphError> {
         self.validate_parents(parents)?;
+
+        // DeterministicBind nodes require all parents to have Deterministic derivation.
+        // This prevents AI-derived taint from entering the deterministic data path (#922).
+        if kind == NodeKind::DeterministicBind {
+            for &pid in parents {
+                if let Some(node) = self.get(pid) {
+                    if !matches!(
+                        node.label.derivation,
+                        portcullis_core::DerivationClass::Deterministic
+                    ) {
+                        return Err(FlowGraphError::DeterministicBindTainted(pid));
+                    }
+                }
+            }
+        }
 
         // Check if any parent is quarantined (directly or transitively)
         let any_parent_quarantined = parents.iter().any(|&pid| self.is_quarantined(pid));

--- a/crates/portcullis/src/hook_adapter.rs
+++ b/crates/portcullis/src/hook_adapter.rs
@@ -148,7 +148,9 @@ pub fn source_category(kind: NodeKind) -> SourceCategory {
         }
         NodeKind::WebContent | NodeKind::CachedDatum => SourceCategory::Adversarial,
         NodeKind::OutboundAction | NodeKind::MemoryWrite => SourceCategory::Action,
-        NodeKind::DatabaseRow | NodeKind::GitBlob => SourceCategory::Trusted,
+        NodeKind::DatabaseRow | NodeKind::GitBlob | NodeKind::DeterministicBind => {
+            SourceCategory::Trusted
+        }
         NodeKind::HTTPResponse => SourceCategory::Adversarial,
         NodeKind::ModelPlan
         | NodeKind::ToolResponse


### PR DESCRIPTION
## Summary

- `NodeKind::DeterministicBind`: parser output bound to schema field, no model in causal chain
- Flow graph rejects insertion if any parent has `AIDerived`/`Mixed` derivation (`DeterministicBindTainted` error)
- Intrinsic label: `Deterministic` derivation, `Trusted` integrity
- LeafTracker: `parents_for()` returns empty — caller supplies explicit parents to keep model out
- kernel.rs: **zero lines added** (stays at 3856, ceiling 3900)

## Part of
#922 (DeterministicBind) — PR 1 of 3. Next: #932 (wire into PostToolUse)

## Test plan

- [x] 527 tests pass across portcullis-core + nucleus-claude-hook
- [x] All pre-commit hooks pass

Closes #931

🤖 Generated with [Claude Code](https://claude.com/claude-code)