### PR TITLE
dx: /provenance skill + provenance status line (#954)

### DIFF
--- a/crates/nucleus-claude-hook/src/init.rs
+++ b/crates/nucleus-claude-hook/src/init.rs
@@ -419,6 +419,49 @@ const SKILL_TEMPLATES: &[(&str, &str)] = &[
          \n\
          Clearance is auditable and cannot be revoked.\n",
     ),
+    (
+        "provenance",
+        "---\n\
+         name: provenance\n\
+         description: Show per-field provenance metadata for the current session\n\
+         ---\n\
+         \n\
+         The user wants to see provenance information for the current session.\n\
+         \n\
+         ## What to report\n\
+         \n\
+         1. **Session taint status**: Is the session web-tainted? How many flow observations?\n\
+         2. **Pending source hashes**: List all captured content hashes (from WebFetch, etc.)\n\
+         3. **Parser steps**: List completed WASM parser reductions with input/output hashes\n\
+         4. **Deterministic binds**: List fields populated via DeterministicBind (model-free)\n\
+         5. **Derivation summary**: For each data source used in this session:\n\
+         \n\
+         ```\n\
+         Source: https://example.com/data.json\n\
+           Captured: sha256:abc1... at 2026-04-02T17:00:00Z\n\
+           Parser: jq (sha256:def2...)\n\
+           Output: sha256:ghi3...\n\
+           Derivation: Deterministic\n\
+         \n\
+         Source: (model reasoning)\n\
+           Derivation: AIDerived — no verification possible\n\
+         ```\n\
+         \n\
+         ## How to get the data\n\
+         \n\
+         Read the nucleus session state from the status line output.\n\
+         The session file at ~/.nucleus/sessions/{session_id}.json contains:\n\
+         - pending_source_hashes: [{content_hash, tool_name, captured_at, witnessed}]\n\
+         - pending_parser_steps: [{input_hash, parser_id, parser_hash, output_hash}]\n\
+         - deterministic_binds: [{field_name, output_hash, parser_id}]\n\
+         - web_tainted: bool\n\
+         - flow_observations: [(kind, label, subject)]\n\
+         \n\
+         ## Tone\n\
+         \n\
+         Be precise and factual. Use the hash prefixes (first 8 hex chars) for readability.\n\
+         Clearly distinguish Deterministic (provable) from AIDerived (honest label only).\n",
+    ),
 ];
 
 /// Scaffold `.claude/skills/` with Nucleus compartment management skills.
@@ -816,7 +859,7 @@ mod tests {
         fs::create_dir_all(&claude_dir).unwrap();
 
         let (created, skipped) = scaffold_claude_skills(&claude_dir);
-        assert_eq!(created, 3);
+        assert_eq!(created, SKILL_TEMPLATES.len() as u32);
         assert_eq!(skipped, 0);
 
         // All skill directories and SKILL.md files exist.
@@ -846,7 +889,7 @@ mod tests {
         fs::write(skill_dir.join("SKILL.md"), "custom skill").unwrap();
 
         let (created, skipped) = scaffold_claude_skills(&claude_dir);
-        assert_eq!(created, 2);
+        assert_eq!(created, SKILL_TEMPLATES.len() as u32 - 1);
         assert_eq!(skipped, 1);
 
         // Original content preserved.

--- a/crates/nucleus-claude-hook/src/status.rs
+++ b/crates/nucleus-claude-hook/src/status.rs
@@ -64,6 +64,12 @@ pub(crate) struct SessionSummary {
     pub taint: String,
     /// Flow graph observations count.
     pub flow_observations: usize,
+    /// Number of pending source hashes (web content captured but not yet witnessed).
+    pub pending_sources: usize,
+    /// Number of completed WASM parser steps.
+    pub parser_steps: usize,
+    /// Number of deterministic binds (model-free field populations).
+    pub deterministic_binds: usize,
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -175,6 +181,9 @@ fn collect_sessions(session_dir: &Path) -> Vec<SessionSummary> {
                     receipt_chain_intact,
                     taint,
                     flow_observations: state.flow_observations.len(),
+                    pending_sources: state.pending_source_hashes.len(),
+                    parser_steps: state.pending_parser_steps.len(),
+                    deterministic_binds: state.deterministic_binds.len(),
                 });
             }
         }
@@ -403,6 +412,12 @@ fn print_human(s: &NucleusStatus) {
             };
             eprintln!("    Receipts:     {chain_display}");
             eprintln!("    Flow nodes:   {}", sess.flow_observations);
+            if sess.pending_sources > 0 || sess.parser_steps > 0 || sess.deterministic_binds > 0 {
+                eprintln!(
+                    "    Provenance:   {} sources, {} parser steps, {} binds",
+                    sess.pending_sources, sess.parser_steps, sess.deterministic_binds
+                );
+            }
         }
     }
 }
@@ -487,6 +502,9 @@ mod tests {
             receipt_chain_intact: true,
             taint: "CLEAN".into(),
             flow_observations: 3,
+            pending_sources: 0,
+            parser_steps: 0,
+            deterministic_binds: 0,
         };
         let json = serde_json::to_string(&summary).unwrap();
         assert!(json.contains("\"taint\":\"CLEAN\""));


### PR DESCRIPTION
## Summary

- `/provenance` skill: instructs the model to report per-field derivation metadata with hash chain details
- Status line: shows pending sources, parser steps, and deterministic binds when provenance pipeline is active
- Skill scaffold tests use `SKILL_TEMPLATES.len()` instead of hardcoded counts

## Test plan

- [x] 198 tests pass
- [x] All pre-commit hooks pass

Closes #954

Sources:
- [Claude Code Skills](https://code.claude.com/docs/en/skills)
- [Skill Authoring Best Practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices)

🤖 Generated with [Claude Code](https://claude.com/claude-code)