### PR TITLE
feat: cross-session receipt chain linking (#942)

### DIFF
--- a/crates/nucleus-claude-hook/src/main.rs
+++ b/crates/nucleus-claude-hook/src/main.rs
@@ -1199,6 +1199,21 @@ fn main() {
             }
         }
 
+        // Cross-session chain linking (#942): if no parent session (not a
+        // sub-agent), link to the most recent prior session's chain head.
+        if session.parent_session_id.is_none() {
+            if let Some((prior_sid, prior_hash)) =
+                session::find_prior_session_chain(&input.session_id)
+            {
+                session.parent_session_id = Some(prior_sid.clone());
+                session.parent_chain_hash = Some(prior_hash.clone());
+                eprintln!(
+                    "nucleus: continuation chain: prior={prior_sid} hash={}...",
+                    &prior_hash[..16.min(prior_hash.len())]
+                );
+            }
+        }
+
         // Inherit parent compartment (#461).
         // The child's compartment is capped at the parent's level:
         // child ≤ parent (can only narrow, never escalate).

--- a/crates/nucleus-claude-hook/src/session.rs
+++ b/crates/nucleus-claude-hook/src/session.rs
@@ -1510,6 +1510,63 @@ pub(crate) fn handle_user_prompt_submit(input: &crate::protocol::HookInput) {
 // ---------------------------------------------------------------------------
 
 // ---------------------------------------------------------------------------
+// Cross-session chain linking (#942)
+// ---------------------------------------------------------------------------
+
+/// Find the most recent prior session and return its chain head hash (#942).
+///
+/// Creates a timeline-linked chain across independent sessions (not spawned
+/// sub-agents, which use NUCLEUS_PARENT_SESSION instead).
+pub(crate) fn find_prior_session_chain(current_session_id: &str) -> Option<(String, String)> {
+    let dir = session_dir();
+    let entries = std::fs::read_dir(&dir).ok()?;
+
+    let current_safe = sanitize_session_id(current_session_id);
+    let mut best: Option<(String, u64, [u8; 32])> = None;
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        let filename = path.file_stem().and_then(|s| s.to_str()).unwrap_or("");
+        if filename == current_safe {
+            continue;
+        }
+
+        let mtime = entry
+            .metadata()
+            .ok()
+            .and_then(|m| m.modified().ok())
+            .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+
+        let contents = match std::fs::read_to_string(&path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        let state: SessionState = match serde_json::from_str(&contents) {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+
+        if state.chain_head_hash == [0u8; 32] {
+            continue;
+        }
+
+        match &best {
+            Some((_, best_mtime, _)) if mtime <= *best_mtime => {}
+            _ => {
+                best = Some((filename.to_string(), mtime, state.chain_head_hash));
+            }
+        }
+    }
+
+    best.map(|(sid, _, hash)| (sid, hex::encode(hash)))
+}
+
+// ---------------------------------------------------------------------------
 // Child provenance verification (#955)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

On session start, auto-link to the most recent prior session's receipt chain head, creating a timeline-linked chain across independent sessions.

- `find_prior_session_chain()`: scans session dir for most recent non-zero chain head
- Session init: auto-populate `parent_session_id` + `parent_chain_hash` for continuation
- Only fires when no `NUCLEUS_PARENT_SESSION` is set (doesn't override sub-agent linking)

## Test plan

- [x] 198 tests pass
- [x] main.rs at 1918 (ceiling: 1941)
- [x] All pre-commit hooks pass

Closes #942

Sources:
- [Immutable Audit Trails Guide](https://www.hubifi.com/blog/immutable-audit-log-basics)
- [Append-Only Audit Log Pipeline](https://oneuptime.com/blog/post/2026-02-06-immutable-audit-log-pipeline-otel/view)

🤖 Generated with [Claude Code](https://claude.com/claude-code)