### PR TITLE
feat: labeling oracle correctness verification — 9 critical invariant tests (#980)

### DIFF
--- a/crates/nucleus-claude-hook/src/classify.rs
+++ b/crates/nucleus-claude-hook/src/classify.rs
@@ -973,4 +973,115 @@ mod tests {
             "default-fallback"
         );
     }
+
+    // -----------------------------------------------------------------
+    // Labeling oracle correctness verification (#980)
+    //
+    // These tests verify that the label assignment functions are correct
+    // — if any of these fail, the entire IFC defense is compromised.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn oracle_web_content_is_adversarial() {
+        use portcullis_core::flow::{intrinsic_label, NodeKind};
+        use portcullis_core::IntegLevel;
+
+        let label = intrinsic_label(NodeKind::WebContent, 0);
+        assert_eq!(
+            label.integrity,
+            IntegLevel::Adversarial,
+            "CRITICAL: WebContent must be Adversarial — if this fails, prompt injection defense is broken"
+        );
+    }
+
+    #[test]
+    fn oracle_web_fetch_maps_to_web_content() {
+        let kind = classify_tool_output(Operation::WebFetch);
+        assert_eq!(
+            kind,
+            portcullis_core::flow::NodeKind::WebContent,
+            "CRITICAL: WebFetch must produce WebContent — if this fails, web taint tracking is broken"
+        );
+    }
+
+    #[test]
+    fn oracle_web_search_maps_to_web_content() {
+        let kind = classify_tool_output(Operation::WebSearch);
+        assert_eq!(
+            kind,
+            portcullis_core::flow::NodeKind::WebContent,
+            "CRITICAL: WebSearch must produce WebContent"
+        );
+    }
+
+    #[test]
+    fn oracle_file_read_is_trusted() {
+        use portcullis_core::flow::{intrinsic_label, NodeKind};
+        use portcullis_core::IntegLevel;
+
+        let label = intrinsic_label(NodeKind::FileRead, 0);
+        assert_eq!(label.integrity, IntegLevel::Trusted);
+    }
+
+    #[test]
+    fn oracle_user_prompt_is_directive() {
+        use portcullis_core::flow::{intrinsic_label, NodeKind};
+        use portcullis_core::AuthorityLevel;
+
+        let label = intrinsic_label(NodeKind::UserPrompt, 0);
+        assert_eq!(label.authority, AuthorityLevel::Directive);
+    }
+
+    #[test]
+    fn oracle_deterministic_bind_is_deterministic() {
+        use portcullis_core::flow::{intrinsic_label, NodeKind};
+        use portcullis_core::DerivationClass;
+
+        let label = intrinsic_label(NodeKind::DeterministicBind, 0);
+        assert_eq!(label.derivation, DerivationClass::Deterministic);
+    }
+
+    #[test]
+    fn oracle_model_plan_is_ai_derived() {
+        use portcullis_core::flow::{intrinsic_label, NodeKind};
+        use portcullis_core::DerivationClass;
+
+        let label = intrinsic_label(NodeKind::ModelPlan, 0);
+        assert_eq!(label.derivation, DerivationClass::AIDerived);
+    }
+
+    #[test]
+    fn oracle_all_node_kinds_have_u8_roundtrip() {
+        // Every NodeKind must survive u8 → NodeKind → u8 roundtrip.
+        for i in 0u8..=16 {
+            let kind = u8_to_node_kind(i);
+            let back = node_kind_to_u8(kind);
+            assert_eq!(
+                back, i,
+                "NodeKind roundtrip failed for discriminant {i}: {kind:?} → {back}"
+            );
+        }
+    }
+
+    #[test]
+    fn oracle_adversarial_sources_never_trusted() {
+        // No source classified as adversarial should have Trusted integrity.
+        use portcullis_core::flow::{intrinsic_label, NodeKind};
+        use portcullis_core::IntegLevel;
+
+        let adversarial_kinds = [
+            NodeKind::WebContent,
+            NodeKind::HTTPResponse,
+            NodeKind::CachedDatum,
+        ];
+
+        for kind in &adversarial_kinds {
+            let label = intrinsic_label(*kind, 0);
+            assert_ne!(
+                label.integrity,
+                IntegLevel::Trusted,
+                "CRITICAL: {kind:?} must NOT be Trusted — adversarial sources cannot be trusted"
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary

9 exhaustive tests verifying the IFC label assignment functions are correct. These are the foundation all IFC defenses depend on — if labeling is wrong, flow graph enforcement is meaningless.

Each test is named with the pattern it guards:
- `oracle_web_content_is_adversarial` — prompt injection defense
- `oracle_web_fetch_maps_to_web_content` — taint tracking
- `oracle_adversarial_sources_never_trusted` — no adversarial source can be labeled Trusted
- `oracle_all_node_kinds_have_u8_roundtrip` — serialization correctness

## Why this matters

The EchoLeak attack (CVE-2025-32711) succeeded because Copilot treated PowerPoint speaker notes as trusted input. A single labeling bug in nucleus would have the same effect.

## Test plan

- [x] 9 new oracle tests pass
- [x] 209 total tests pass

Closes #980

Sources:
- [IFC Label Assignment Correctness](https://link.springer.com/article/10.1134/S0361768822040053)

🤖 Generated with [Claude Code](https://claude.com/claude-code)