### PR TITLE
feat: resolve DeterministicBindRecord field names from schema (#987)

### DIFF
--- a/crates/nucleus-claude-hook/src/main.rs
+++ b/crates/nucleus-claude-hook/src/main.rs
@@ -1236,6 +1236,8 @@ fn main() {
         // Load schema from .provenance.yaml in cwd (if present).
         let cwd = std::env::current_dir().unwrap_or_default();
         load_provenance_schema(&cwd).and_then(|schema| {
+            // Resolve bind field names from schema (#987).
+            session::resolve_bind_field_names(&mut session, &schema);
             session::check_deterministic_field_write(&session, &schema, &subject)
         })
     } else {

--- a/crates/nucleus-claude-hook/src/session.rs
+++ b/crates/nucleus-claude-hook/src/session.rs
@@ -1204,7 +1204,7 @@ pub(crate) fn record_post_tool(
                 String::new(),
             ));
             s.deterministic_binds.push(DeterministicBindRecord {
-                field_name: String::new(), // populated when schema is loaded
+                field_name: String::new(), // resolved by resolve_bind_field_names()
                 output_hash: step.output_hash,
                 parser_id: step.parser_id.clone(),
                 node_kind_u8: node_kind_to_u8(portcullis_core::flow::NodeKind::DeterministicBind),
@@ -1499,6 +1499,32 @@ pub(crate) fn check_deterministic_field_write(
              Apply a registered parser first, then the DeterministicBind will populate this field automatically.",
             field_name
         ))
+    }
+}
+
+/// Resolve field names on DeterministicBindRecords from a schema (#987).
+///
+/// Matches bind records (which have parser_id but empty field_name) to
+/// schema fields that declare the same parser. Called after schema is loaded.
+pub(crate) fn resolve_bind_field_names(
+    s: &mut SessionState,
+    schema: &portcullis_core::provenance_schema::ProvenanceSchema,
+) {
+    use portcullis_core::provenance_schema::DerivationKind;
+
+    for bind in &mut s.deterministic_binds {
+        if !bind.field_name.is_empty() {
+            continue; // already resolved
+        }
+        // Find a deterministic field whose parser matches this bind's parser_id.
+        for (name, field) in &schema.fields {
+            if field.derivation == DerivationKind::Deterministic
+                && field.parser.as_deref() == Some(&bind.parser_id)
+            {
+                bind.field_name = name.clone();
+                break;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

`resolve_bind_field_names()` matches bind records (parser_id) to schema fields that declare the same parser. Called on each PreToolUse when a provenance schema is present.

This enables `check_deterministic_field_write()` to find binds by field name, completing the schema → bind → enforcement chain.

## Test plan

- [x] 218 tests pass
- [x] All pre-commit hooks pass

Closes #987

🤖 Generated with [Claude Code](https://claude.com/claude-code)