### PR TITLE
feat: wire provenance output into SessionEnd (#991)

### DIFF
--- a/crates/nucleus-claude-hook/src/main.rs
+++ b/crates/nucleus-claude-hook/src/main.rs
@@ -294,6 +294,22 @@ fn main() {
                     "finalized",
                 );
 
+                // Generate provenance output if schema exists (#991).
+                let cwd = std::env::current_dir().unwrap_or_default();
+                if let Some(schema) = load_provenance_schema(&cwd) {
+                    let output = session::build_provenance_output(&session, &schema);
+                    if let Ok(json) = output.to_json() {
+                        let out_path = cwd.join("provenance-output.json");
+                        if std::fs::write(&out_path, &json).is_ok() {
+                            nucleus_info!(
+                                "provenance output written: {} ({} fields)",
+                                out_path.display(),
+                                schema.fields.len()
+                            );
+                        }
+                    }
+                }
+
                 // Clean up session state (keep receipts for audit)
                 let state_path = session_state_path(&input.session_id);
                 let hwm_path = session_hwm_path(&input.session_id);

--- a/crates/nucleus-claude-hook/src/session.rs
+++ b/crates/nucleus-claude-hook/src/session.rs
@@ -1533,7 +1533,6 @@ pub(crate) fn resolve_bind_field_names(
 /// For each schema field, constructs the per-field provenance attestation:
 /// - Deterministic fields with DeterministicBind: full hash chain
 /// - AI-derived fields: honest labeling
-#[allow(dead_code)]
 pub(crate) fn build_provenance_output(
     s: &SessionState,
     schema: &portcullis_core::provenance_schema::ProvenanceSchema,


### PR DESCRIPTION
## Summary

On SessionEnd, if a provenance schema exists, automatically build `ProvenanceOutput` and write `provenance-output.json`. This completes the live pipeline.

## E2E chain: **7/8 complete**

\`#985 ✅ → #986 ✅ → #987 ✅ → #988 ✅ → #992 ✅ → #991 ✅ → #990 (E2E test)\`

Only the crown jewel integration test (#990) remains.

Closes #991

🤖 Generated with [Claude Code](https://claude.com/claude-code)