### PR TITLE
feat: detect provenance schema + activate provenance mode (#1020)

### DIFF
--- a/crates/nucleus-claude-hook/src/main.rs
+++ b/crates/nucleus-claude-hook/src/main.rs
@@ -702,6 +702,19 @@ fn main() {
         );
     }
 
+    // Provenance mode detection (#1020): on first invocation, check for schema.
+    if is_first_invocation && !session.provenance_mode {
+        let cwd = std::env::current_dir().unwrap_or_default();
+        if let Some(schema) = load_provenance_schema(&cwd) {
+            session.provenance_mode = true;
+            nucleus_info!(
+                "provenance mode activated — {} deterministic, {} AI-derived fields",
+                schema.deterministic_field_count(),
+                schema.ai_derived_field_count()
+            );
+        }
+    }
+
     if session.compartment_token.is_empty() {
         session.compartment_token = generate_compartment_token();
     }

--- a/crates/nucleus-claude-hook/src/session.rs
+++ b/crates/nucleus-claude-hook/src/session.rs
@@ -134,6 +134,10 @@ pub(crate) struct SessionState {
     /// observations into the flow graph.
     #[serde(default)]
     pub(crate) deterministic_binds: Vec<DeterministicBindRecord>,
+    /// Whether provenance mode is active (#1020).
+    /// Set on first PreToolUse when a .provenance.json schema is detected.
+    #[serde(default)]
+    pub(crate) provenance_mode: bool,
 }
 
 /// A content hash captured from a tool output during PostToolUse (#873).

--- a/crates/nucleus-claude-hook/src/status.rs
+++ b/crates/nucleus-claude-hook/src/status.rs
@@ -453,6 +453,7 @@ mod tests {
             pending_source_hashes: vec![],
             pending_parser_steps: vec![],
             deterministic_binds: vec![],
+            provenance_mode: false,
         }
     }
 


### PR DESCRIPTION
On first PreToolUse, detect .provenance.json and set provenance_mode flag.
Part 1/4 of #924 (headless pipeline).

Closes #1020

🤖 Generated with [Claude Code](https://claude.com/claude-code)