### PR TITLE
feat: receipt chain external anchor — file/webhook (#948)

### DIFF
--- a/crates/nucleus-claude-hook/src/main.rs
+++ b/crates/nucleus-claude-hook/src/main.rs
@@ -1323,6 +1323,9 @@ fn main() {
                 start_time.elapsed().as_secs_f64() * 1000.0,
             )),
         );
+        // Anchor chain head to external log (#948).
+        receipts::anchor_chain_head(&input.session_id, &session.chain_head_hash);
+
         if !sign_ok {
             nucleus_warn!(
                 "UNSIGNED RECEIPT — signing key unavailable for {}:{} — receipt chain integrity degraded",

--- a/crates/nucleus-claude-hook/src/receipts.rs
+++ b/crates/nucleus-claude-hook/src/receipts.rs
@@ -369,3 +369,69 @@ pub(crate) fn show_receipts(session_id: &str) {
 
     println!("Chain file: {}", path.display());
 }
+
+// ═══════════════════════════════════════════════════════════════════════════
+// External anchor (#948)
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Publish the receipt chain head hash to an external anchor (#948).
+///
+/// If `NUCLEUS_ANCHOR_WEBHOOK` is set, POST the chain head to that URL.
+/// If `NUCLEUS_ANCHOR_FILE` is set, append to that file.
+/// This creates a tamper-evident external record — even if the signing
+/// key is compromised, the attacker cannot retroactively modify anchored
+/// receipts without detection.
+pub(crate) fn anchor_chain_head(session_id: &str, chain_head: &[u8; 32]) {
+    let head_hex = hex::encode(chain_head);
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+
+    // File anchor: append to a local audit log.
+    if let Ok(anchor_path) = std::env::var("NUCLEUS_ANCHOR_FILE") {
+        use std::io::Write;
+        let entry = format!("{now}\t{session_id}\t{head_hex}\n");
+        if let Ok(mut f) = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&anchor_path)
+        {
+            f.write_all(entry.as_bytes()).ok();
+        }
+    }
+
+    // Webhook anchor: POST to an external transparency service.
+    // Non-blocking: fire-and-forget via a short-lived thread.
+    if let Ok(webhook_url) = std::env::var("NUCLEUS_ANCHOR_WEBHOOK") {
+        let payload = serde_json::json!({
+            "session_id": session_id,
+            "chain_head": head_hex,
+            "timestamp": now,
+            "type": "chain_anchor",
+        });
+        // Best-effort: don't block the hook for network I/O.
+        let _ = std::thread::Builder::new()
+            .name("anchor-webhook".into())
+            .spawn(move || {
+                // Use a simple HTTP POST via a subprocess to avoid
+                // adding an HTTP client dependency.
+                let json = payload.to_string();
+                std::process::Command::new("curl")
+                    .args([
+                        "-s",
+                        "-X",
+                        "POST",
+                        "-H",
+                        "Content-Type: application/json",
+                        "-d",
+                        &json,
+                        "--max-time",
+                        "5",
+                        &webhook_url,
+                    ])
+                    .output()
+                    .ok();
+            });
+    }
+}


### PR DESCRIPTION
Publish chain head to external log via NUCLEUS_ANCHOR_FILE or NUCLEUS_ANCHOR_WEBHOOK.
Tamper-evident even if signing key compromised.

Closes #948

🤖 Generated with [Claude Code](https://claude.com/claude-code)