### PR TITLE
feat: multimodal NodeKind — Image, Audio, PDF (#961)

### DIFF
--- a/crates/nucleus-claude-hook/src/classify.rs
+++ b/crates/nucleus-claude-hook/src/classify.rs
@@ -404,6 +404,9 @@ pub(crate) fn node_kind_to_u8(kind: NodeKind) -> u8 {
         NodeKind::GitBlob => 14,
         NodeKind::CachedDatum => 15,
         NodeKind::DeterministicBind => 16,
+        NodeKind::ImageContent => 17,
+        NodeKind::AudioContent => 18,
+        NodeKind::PDFContent => 19,
     }
 }
 
@@ -426,7 +429,10 @@ pub(crate) fn u8_to_node_kind(v: u8) -> NodeKind {
         13 => NodeKind::DatabaseRow,
         14 => NodeKind::GitBlob,
         15 => NodeKind::CachedDatum,
-        _ => NodeKind::DeterministicBind,
+        16 => NodeKind::DeterministicBind,
+        17 => NodeKind::ImageContent,
+        18 => NodeKind::AudioContent,
+        _ => NodeKind::PDFContent,
     }
 }
 
@@ -502,9 +508,12 @@ impl LeafTracker {
             | NodeKind::DatabaseRow
             | NodeKind::GitBlob
             | NodeKind::DeterministicBind => &mut self.trusted,
-            NodeKind::WebContent | NodeKind::HTTPResponse | NodeKind::CachedDatum => {
-                &mut self.adversarial
-            }
+            NodeKind::WebContent
+            | NodeKind::HTTPResponse
+            | NodeKind::CachedDatum
+            | NodeKind::ImageContent
+            | NodeKind::AudioContent
+            | NodeKind::PDFContent => &mut self.adversarial,
             NodeKind::OutboundAction | NodeKind::MemoryWrite => &mut self.action,
             NodeKind::ModelPlan
             | NodeKind::ToolResponse
@@ -540,7 +549,12 @@ impl LeafTracker {
                 // Source-only: previous trusted node (for ordering) but no adversarial parent
                 self.trusted.clone()
             }
-            NodeKind::WebContent | NodeKind::HTTPResponse | NodeKind::CachedDatum => {
+            NodeKind::WebContent
+            | NodeKind::HTTPResponse
+            | NodeKind::CachedDatum
+            | NodeKind::ImageContent
+            | NodeKind::AudioContent
+            | NodeKind::PDFContent => {
                 // External/untrusted content enters independently
                 self.adversarial.clone()
             }

--- a/crates/portcullis-core/src/flow.rs
+++ b/crates/portcullis-core/src/flow.rs
@@ -74,6 +74,14 @@ pub enum NodeKind {
     /// This is the "air gap" that keeps AI-derived taint out of
     /// deterministic data paths (#922).
     DeterministicBind,
+    /// Image content — adversarial by default (#961).
+    /// Multimodal prompt injection can hide instructions in images.
+    ImageContent,
+    /// Audio content — adversarial by default (#961).
+    AudioContent,
+    /// PDF document — adversarial by default (#961).
+    /// PDFs can contain hidden text, JavaScript, and form fields.
+    PDFContent,
 }
 
 /// Intrinsic label for a node kind — the base label before propagation.
@@ -226,6 +234,11 @@ pub fn intrinsic_label(kind: NodeKind, now: u64) -> IFCLabel {
             authority: AuthorityLevel::NoAuthority,
             derivation: DerivationClass::Deterministic,
         },
+        // Multimodal content (#961) — all adversarial by default.
+        // Prompt injection can hide in images, audio, and PDF documents.
+        NodeKind::ImageContent | NodeKind::AudioContent | NodeKind::PDFContent => {
+            IFCLabel::web_content(now)
+        }
     }
 }
 

--- a/crates/portcullis-core/src/prov_export.rs
+++ b/crates/portcullis-core/src/prov_export.rs
@@ -33,7 +33,10 @@ fn u8_to_node_kind(v: u8) -> NodeKind {
         13 => NodeKind::DatabaseRow,
         14 => NodeKind::GitBlob,
         15 => NodeKind::CachedDatum,
-        _ => NodeKind::DeterministicBind,
+        16 => NodeKind::DeterministicBind,
+        17 => NodeKind::ImageContent,
+        18 => NodeKind::AudioContent,
+        _ => NodeKind::PDFContent,
     }
 }
 
@@ -134,7 +137,10 @@ fn prov_category(kind: NodeKind) -> ProvCategory {
         | NodeKind::DatabaseRow
         | NodeKind::GitBlob
         | NodeKind::CachedDatum
-        | NodeKind::DeterministicBind => ProvCategory::Entity,
+        | NodeKind::DeterministicBind
+        | NodeKind::ImageContent
+        | NodeKind::AudioContent
+        | NodeKind::PDFContent => ProvCategory::Entity,
         // Activities: computations/actions
         NodeKind::OutboundAction
         | NodeKind::MemoryWrite
@@ -199,6 +205,9 @@ fn node_kind_str(kind: NodeKind) -> &'static str {
         NodeKind::GitBlob => "GitBlob",
         NodeKind::CachedDatum => "CachedDatum",
         NodeKind::DeterministicBind => "DeterministicBind",
+        NodeKind::ImageContent => "ImageContent",
+        NodeKind::AudioContent => "AudioContent",
+        NodeKind::PDFContent => "PDFContent",
     }
 }
 

--- a/crates/portcullis/src/hook_adapter.rs
+++ b/crates/portcullis/src/hook_adapter.rs
@@ -146,7 +146,11 @@ pub fn source_category(kind: NodeKind) -> SourceCategory {
         NodeKind::FileRead | NodeKind::UserPrompt | NodeKind::EnvVar | NodeKind::MemoryRead => {
             SourceCategory::Trusted
         }
-        NodeKind::WebContent | NodeKind::CachedDatum => SourceCategory::Adversarial,
+        NodeKind::WebContent
+        | NodeKind::CachedDatum
+        | NodeKind::ImageContent
+        | NodeKind::AudioContent
+        | NodeKind::PDFContent => SourceCategory::Adversarial,
         NodeKind::OutboundAction | NodeKind::MemoryWrite => SourceCategory::Action,
         NodeKind::DatabaseRow | NodeKind::GitBlob | NodeKind::DeterministicBind => {
             SourceCategory::Trusted


### PR DESCRIPTION
Adversarial-by-default NodeKinds for multimodal prompt injection defense.
All match arms updated across 4 files. 975 tests pass.

Closes #961

🤖 Generated with [Claude Code](https://claude.com/claude-code)