### PR TITLE
feat(hook): emit C2PA sidecar on provenance output (#1017)

### DIFF
--- a/crates/nucleus-claude-hook/Cargo.toml
+++ b/crates/nucleus-claude-hook/Cargo.toml
@@ -29,6 +29,8 @@ libc = "0.2"
 # Enable WASM parser execution in PostToolUse reduction pipeline (#915).
 # Adds wasmtime dependency (~2MB). Without this, parser steps are skipped.
 wasm-sandbox = ["portcullis-core/wasm-sandbox"]
+# Enable C2PA content credential sidecar emission at SessionEnd (#1017).
+c2pa = ["portcullis-core/c2pa-manifest"]
 
 [lints]
 workspace = true

--- a/crates/nucleus-claude-hook/src/c2pa_output.rs
+++ b/crates/nucleus-claude-hook/src/c2pa_output.rs
@@ -1,0 +1,84 @@
+//! C2PA sidecar emission for provenance output (#1017).
+//!
+//! After `provenance-output.json` is written at SessionEnd, this module
+//! optionally generates a `.c2pa` sidecar manifest if a signer is configured.
+//!
+//! ## Configuration
+//!
+//! Set `NUCLEUS_C2PA_CERT` and `NUCLEUS_C2PA_KEY` environment variables
+//! with PEM-encoded X.509 certificate chain and private key.
+//! Optionally set `NUCLEUS_C2PA_ALG` (default: `ps256`) and `NUCLEUS_C2PA_TSA`.
+//!
+//! When these are absent, C2PA emission is silently skipped.
+
+use std::path::Path;
+
+use portcullis_core::c2pa_manifest::C2paManifestBuilder;
+use portcullis_core::c2pa_signer::C2paSignerConfig;
+use portcullis_core::provenance_output::ProvenanceOutput;
+
+/// Attempt to emit a C2PA sidecar manifest alongside provenance output.
+///
+/// Returns `Ok(Some(path))` if sidecar was written, `Ok(None)` if signer
+/// not configured (normal case), or `Err` on failure.
+pub fn try_emit_c2pa_sidecar(
+    output: &ProvenanceOutput,
+    witness_digest: Option<&str>,
+    output_dir: &Path,
+) -> Result<Option<std::path::PathBuf>, String> {
+    // Load signer config from env — silent no-op if not configured.
+    let signer_config = match C2paSignerConfig::from_env() {
+        Ok(config) => config,
+        Err(portcullis_core::c2pa_signer::SignerConfigError::MissingEnv(_)) => return Ok(None),
+        Err(e) => return Err(format!("C2PA signer config error: {e}")),
+    };
+
+    // Build the C2PA manifest with all nucleus assertions.
+    let manifest_builder = C2paManifestBuilder::new(output, witness_digest);
+    let mut builder = manifest_builder
+        .build()
+        .map_err(|e| format!("C2PA manifest build error: {e}"))?;
+
+    // Create the signer.
+    let signer = signer_config
+        .create_signer()
+        .map_err(|e| format!("C2PA signer error: {e}"))?;
+
+    // Serialize provenance output as the "asset" for the sidecar.
+    let asset_json = serde_json::to_vec(output).map_err(|e| format!("JSON error: {e}"))?;
+
+    // Sign and produce sidecar: write manifest to .c2pa file.
+    let sidecar_path = output_dir.join("provenance-output.c2pa");
+    let mut source = std::io::Cursor::new(&asset_json);
+    let mut dest = std::io::Cursor::new(Vec::new());
+
+    builder
+        .sign(signer.as_ref(), "application/json", &mut source, &mut dest)
+        .map_err(|e| format!("C2PA sign error: {e}"))?;
+
+    std::fs::write(&sidecar_path, dest.into_inner()).map_err(|e| format!("write sidecar: {e}"))?;
+
+    Ok(Some(sidecar_path))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use portcullis_core::provenance_output::ProvenanceHeader;
+
+    #[test]
+    fn skips_when_no_signer_configured() {
+        let output = ProvenanceOutput::new(ProvenanceHeader {
+            schema_hash: "sha256:test".into(),
+            schema_version: 1,
+            completed_at: "2026-04-03T18:00:00Z".into(),
+            receipt_chain_head: "sha256:chain".into(),
+            nucleus_version: "1.0.0".into(),
+            contains_ai_derived: false,
+        });
+        let dir = std::env::temp_dir();
+        let result = try_emit_c2pa_sidecar(&output, None, &dir);
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_none());
+    }
+}

--- a/crates/nucleus-claude-hook/src/main.rs
+++ b/crates/nucleus-claude-hook/src/main.rs
@@ -19,6 +19,8 @@ use ring::signature::Ed25519KeyPair;
 
 mod bench;
 mod build;
+#[cfg(feature = "c2pa")]
+mod c2pa_output;
 mod classify;
 mod cli;
 mod color;
@@ -340,6 +342,13 @@ fn main() {
                                 out_path.display(),
                                 schema.fields.len()
                             );
+                            // Emit C2PA sidecar if signer is configured (#1017).
+                            #[cfg(feature = "c2pa")]
+                            match c2pa_output::try_emit_c2pa_sidecar(&output, None, &cwd) {
+                                Ok(Some(p)) => nucleus_info!("C2PA sidecar: {}", p.display()),
+                                Ok(None) => {} // no signer configured, normal
+                                Err(e) => nucleus_info!("C2PA sidecar skipped: {e}"),
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- New `c2pa_output` module in nucleus-claude-hook with `try_emit_c2pa_sidecar()`
- Wired into SessionEnd: after `provenance-output.json`, emits `provenance-output.c2pa` sidecar
- Feature-gated behind `c2pa` flag — zero overhead when disabled
- Silent no-op when signer env vars not configured (normal case)

## Test plan
- [x] `skips_when_no_signer_configured` test passes
- [x] Compiles with and without `c2pa` feature
- [x] main.rs at 1892 lines (ceiling 1941)
- [x] 14/14 kernel red team tests pass

Closes #1017

🤖 Generated with [Claude Code](https://claude.com/claude-code)