### PR TITLE
cleanup: replace String error with C2paOutputError enum

### DIFF
--- a/crates/nucleus-claude-hook/src/c2pa_output.rs
+++ b/crates/nucleus-claude-hook/src/c2pa_output.rs
@@ -17,6 +17,30 @@ use portcullis_core::c2pa_manifest::C2paManifestBuilder;
 use portcullis_core::c2pa_signer::C2paSignerConfig;
 use portcullis_core::provenance_output::ProvenanceOutput;
 
+/// Error type for C2PA sidecar emission.
+#[derive(Debug)]
+pub enum C2paOutputError {
+    /// Signer configuration is invalid (not missing — that's a silent skip).
+    SignerConfig(String),
+    /// Manifest construction failed.
+    ManifestBuild(String),
+    /// Signing operation failed.
+    Sign(String),
+    /// Failed to write sidecar file.
+    Write(std::io::Error),
+}
+
+impl core::fmt::Display for C2paOutputError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::SignerConfig(msg) => write!(f, "C2PA signer config: {msg}"),
+            Self::ManifestBuild(msg) => write!(f, "C2PA manifest build: {msg}"),
+            Self::Sign(msg) => write!(f, "C2PA sign: {msg}"),
+            Self::Write(e) => write!(f, "C2PA write sidecar: {e}"),
+        }
+    }
+}
+
 /// Attempt to emit a C2PA sidecar manifest alongside provenance output.
 ///
 /// Returns `Ok(Some(path))` if sidecar was written, `Ok(None)` if signer
@@ -25,27 +49,28 @@ pub fn try_emit_c2pa_sidecar(
     output: &ProvenanceOutput,
     witness_digest: Option<&str>,
     output_dir: &Path,
-) -> Result<Option<std::path::PathBuf>, String> {
+) -> Result<Option<std::path::PathBuf>, C2paOutputError> {
     // Load signer config from env — silent no-op if not configured.
     let signer_config = match C2paSignerConfig::from_env() {
         Ok(config) => config,
         Err(portcullis_core::c2pa_signer::SignerConfigError::MissingEnv(_)) => return Ok(None),
-        Err(e) => return Err(format!("C2PA signer config error: {e}")),
+        Err(e) => return Err(C2paOutputError::SignerConfig(e.to_string())),
     };
 
     // Build the C2PA manifest with all nucleus assertions.
     let manifest_builder = C2paManifestBuilder::new(output, witness_digest);
     let mut builder = manifest_builder
         .build()
-        .map_err(|e| format!("C2PA manifest build error: {e}"))?;
+        .map_err(|e| C2paOutputError::ManifestBuild(e.to_string()))?;
 
     // Create the signer.
     let signer = signer_config
         .create_signer()
-        .map_err(|e| format!("C2PA signer error: {e}"))?;
+        .map_err(|e| C2paOutputError::SignerConfig(e.to_string()))?;
 
     // Serialize provenance output as the "asset" for the sidecar.
-    let asset_json = serde_json::to_vec(output).map_err(|e| format!("JSON error: {e}"))?;
+    let asset_json =
+        serde_json::to_vec(output).map_err(|e| C2paOutputError::ManifestBuild(e.to_string()))?;
 
     // Sign and produce sidecar: write manifest to .c2pa file.
     let sidecar_path = output_dir.join("provenance-output.c2pa");
@@ -54,9 +79,9 @@ pub fn try_emit_c2pa_sidecar(
 
     builder
         .sign(signer.as_ref(), "application/json", &mut source, &mut dest)
-        .map_err(|e| format!("C2PA sign error: {e}"))?;
+        .map_err(|e| C2paOutputError::Sign(e.to_string()))?;
 
-    std::fs::write(&sidecar_path, dest.into_inner()).map_err(|e| format!("write sidecar: {e}"))?;
+    std::fs::write(&sidecar_path, dest.into_inner()).map_err(C2paOutputError::Write)?;
 
     Ok(Some(sidecar_path))
 }


### PR DESCRIPTION
## Summary
- Replace `Result<_, String>` with typed `C2paOutputError` enum
- 4 variants: `SignerConfig`, `ManifestBuild`, `Sign`, `Write`
- `Write` preserves `std::io::Error` directly (no `.to_string()` erasure)
- Caller in main.rs unchanged (uses Display via `{e}`)

## Test plan
- [x] `skips_when_no_signer_configured` test passes
- [x] Compiles with and without `c2pa` feature
- [x] clippy/deny/audit clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)