### PR TITLE
dx: add version pinning for crates.io publishing (#1128)

### DIFF
--- a/crates/nucleus-ifc/Cargo.toml
+++ b/crates/nucleus-ifc/Cargo.toml
@@ -10,4 +10,4 @@ keywords = ["ai", "security", "ifc", "information-flow", "provenance"]
 categories = ["development-tools", "command-line-utilities"]
 
 [dependencies]
-portcullis-core = { path = "../portcullis-core" }
+portcullis-core = { version = "1.0.0", path = "../portcullis-core" }

--- a/crates/nucleus-memory/Cargo.toml
+++ b/crates/nucleus-memory/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["ai", "security", "memory", "poisoning", "ifc"]
 categories = ["development-tools"]
 
 [dependencies]
-portcullis-core = { path = "../portcullis-core", features = ["serde"] }
+portcullis-core = { version = "1.0.0", path = "../portcullis-core", features = ["serde"] }
 
 [features]
 serde = ["portcullis-core/serde"]


### PR DESCRIPTION
## Summary
- Add `version = "1.0.0"` to portcullis-core dependency in nucleus-ifc and nucleus-memory
- Cargo uses local `path =` for workspace builds, `version =` for external consumers
- Prerequisite for `cargo publish` of standalone crates

## Test plan
- [x] Both crates compile
- [x] All hooks pass

Closes #1128

🤖 Generated with [Claude Code](https://claude.com/claude-code)