### PR TITLE
feat(portcullis-core): capability marker traits (#1119)

### DIFF
--- a/crates/portcullis-core/src/capability_traits.rs
+++ b/crates/portcullis-core/src/capability_traits.rs
@@ -1,0 +1,140 @@
+//! Compile-time capability marker traits (#1119, part of #1103).
+//!
+//! Sealed marker traits for each capability dimension. When combined with
+//! a phantom-typed `Context<Caps>`, these enable compile-time enforcement:
+//! a function requiring `HasWebFetch` won't compile if called from a
+//! context that doesn't include that capability.
+//!
+//! ```rust,ignore
+//! fn fetch_url<C: HasWebFetch>(ctx: &Context<C>) -> String { ... }
+//!
+//! // Compiles: codegen profile includes WebFetch
+//! fetch_url(&codegen_ctx);
+//!
+//! // ERROR: code_review profile does not include WebFetch
+//! fetch_url(&review_ctx);
+//! ```
+
+/// Sealed trait module — prevents external implementations.
+mod sealed {
+    pub trait Sealed {}
+}
+
+/// Marker: capability set includes file read access.
+pub trait HasFileRead: sealed::Sealed {}
+
+/// Marker: capability set includes file write access.
+pub trait HasFileWrite: sealed::Sealed {}
+
+/// Marker: capability set includes file edit access.
+pub trait HasFileEdit: sealed::Sealed {}
+
+/// Marker: capability set includes bash execution.
+pub trait HasBashExec: sealed::Sealed {}
+
+/// Marker: capability set includes glob search.
+pub trait HasGlobSearch: sealed::Sealed {}
+
+/// Marker: capability set includes grep search.
+pub trait HasGrepSearch: sealed::Sealed {}
+
+/// Marker: capability set includes web search.
+pub trait HasWebSearch: sealed::Sealed {}
+
+/// Marker: capability set includes web fetch.
+pub trait HasWebFetch: sealed::Sealed {}
+
+/// Marker: capability set includes git commit.
+pub trait HasGitCommit: sealed::Sealed {}
+
+/// Marker: capability set includes git push.
+pub trait HasGitPush: sealed::Sealed {}
+
+/// Marker: capability set includes PR creation.
+pub trait HasCreatePr: sealed::Sealed {}
+
+/// Marker: capability set includes pod management.
+pub trait HasManagePods: sealed::Sealed {}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Concrete capability sets — these implement the marker traits
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Read-only capability set.
+pub struct ReadOnly;
+impl sealed::Sealed for ReadOnly {}
+impl HasFileRead for ReadOnly {}
+impl HasGlobSearch for ReadOnly {}
+impl HasGrepSearch for ReadOnly {}
+
+/// Code review capability set (read + web).
+pub struct CodeReview;
+impl sealed::Sealed for CodeReview {}
+impl HasFileRead for CodeReview {}
+impl HasGlobSearch for CodeReview {}
+impl HasGrepSearch for CodeReview {}
+impl HasWebFetch for CodeReview {}
+impl HasWebSearch for CodeReview {}
+
+/// Code generation capability set (read + write + bash, no network).
+pub struct Codegen;
+impl sealed::Sealed for Codegen {}
+impl HasFileRead for Codegen {}
+impl HasFileWrite for Codegen {}
+impl HasFileEdit for Codegen {}
+impl HasBashExec for Codegen {}
+impl HasGlobSearch for Codegen {}
+impl HasGrepSearch for Codegen {}
+impl HasGitCommit for Codegen {}
+
+/// Full capability set (all capabilities).
+pub struct FullAccess;
+impl sealed::Sealed for FullAccess {}
+impl HasFileRead for FullAccess {}
+impl HasFileWrite for FullAccess {}
+impl HasFileEdit for FullAccess {}
+impl HasBashExec for FullAccess {}
+impl HasGlobSearch for FullAccess {}
+impl HasGrepSearch for FullAccess {}
+impl HasWebSearch for FullAccess {}
+impl HasWebFetch for FullAccess {}
+impl HasGitCommit for FullAccess {}
+impl HasGitPush for FullAccess {}
+impl HasCreatePr for FullAccess {}
+impl HasManagePods for FullAccess {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // These are compile-time tests — if they compile, the constraints work.
+    fn requires_read<C: HasFileRead>(_cap: &C) {}
+    fn requires_web_fetch<C: HasWebFetch>(_cap: &C) {}
+    fn requires_bash<C: HasBashExec>(_cap: &C) {}
+    fn requires_push<C: HasGitPush>(_cap: &C) {}
+
+    #[test]
+    fn read_only_has_read() {
+        requires_read(&ReadOnly);
+    }
+
+    #[test]
+    fn code_review_has_read_and_web() {
+        requires_read(&CodeReview);
+        requires_web_fetch(&CodeReview);
+    }
+
+    #[test]
+    fn codegen_has_bash_no_web() {
+        requires_bash(&Codegen);
+        // requires_web_fetch(&Codegen);  // Would NOT compile — correct!
+    }
+
+    #[test]
+    fn full_access_has_everything() {
+        requires_read(&FullAccess);
+        requires_web_fetch(&FullAccess);
+        requires_bash(&FullAccess);
+        requires_push(&FullAccess);
+    }
+}

--- a/crates/portcullis-core/src/lib.rs
+++ b/crates/portcullis-core/src/lib.rs
@@ -64,6 +64,7 @@ pub mod c2pa_assertions;
 pub mod c2pa_manifest;
 #[cfg(feature = "c2pa-manifest")]
 pub mod c2pa_signer;
+pub mod capability_traits;
 pub mod category;
 pub mod compartment;
 #[cfg(feature = "serde")]


### PR DESCRIPTION
## Summary
- 12 sealed marker traits: `HasFileRead`, `HasWebFetch`, `HasBashExec`, `HasGitPush`, etc.
- 4 concrete capability sets: `ReadOnly`, `CodeReview`, `Codegen`, `FullAccess`
- Compile-time enforcement: `fn fetch<C: HasWebFetch>(ctx: &C)` won't compile without capability
- Zero runtime cost — pure type system enforcement

## Example
```rust
fn fetch_url<C: HasWebFetch>(_cap: &C) -> String { ... }
fetch_url(&Codegen);      // ERROR: Codegen doesn't include HasWebFetch
fetch_url(&CodeReview);   // OK: CodeReview includes HasWebFetch
```

## Test plan
- [x] 4 compile-time tests pass
- [x] clippy/deny/audit clean

Closes #1119

🤖 Generated with [Claude Code](https://claude.com/claude-code)