### PR TITLE
cleanup: gate hex_decode behind serde feature

### DIFF
--- a/crates/portcullis-core/src/parser_registry.rs
+++ b/crates/portcullis-core/src/parser_registry.rs
@@ -498,6 +498,7 @@ fn hex_encode(bytes: &[u8; 32]) -> String {
 }
 
 /// Decode a hex string into a 32-byte array.
+#[cfg(any(feature = "serde", test))]
 fn hex_decode(s: &str) -> Result<[u8; 32], String> {
     if s.len() != 64 {
         return Err(format!("expected 64 hex chars, got {}", s.len()));


### PR DESCRIPTION
## Summary
- Add `#[cfg(any(feature = "serde", test))]` to `hex_decode()` in parser_registry.rs
- Fixes pre-existing dead_code warning when building without serde feature
- 1 line change

## Test plan
- [x] No warnings with or without serde feature
- [x] hex_decode tests pass with serde feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)