### PR TITLE
feat(portcullis-core): wire zkVM receipt into WitnessBundle (#1117)

### DIFF
--- a/crates/nucleus-claude-hook/src/session.rs
+++ b/crates/nucleus-claude-hook/src/session.rs
@@ -1530,6 +1530,7 @@ pub(crate) fn assemble_witness_bundle(s: &mut SessionState) -> ClearanceResult {
         signature: None,
         created_at: now,
         field_witnesses: std::collections::BTreeMap::new(),
+        zkvm_receipt: None,
     };
 
     // Verify the chain.

--- a/crates/portcullis-core/src/replay.rs
+++ b/crates/portcullis-core/src/replay.rs
@@ -293,6 +293,7 @@ mod tests {
             signature: None,
             created_at: 2000,
             field_witnesses: std::collections::BTreeMap::new(),
+            zkvm_receipt: None,
         }
     }
 
@@ -552,6 +553,7 @@ mod tests {
             signature: None,
             created_at: 1000,
             field_witnesses: std::collections::BTreeMap::new(),
+            zkvm_receipt: None,
         };
 
         let input = ReplayInput {

--- a/crates/portcullis-core/src/witness.rs
+++ b/crates/portcullis-core/src/witness.rs
@@ -389,6 +389,12 @@ pub struct WitnessBundle {
     /// has its own independent source → parser → output chain that can
     /// be verified independently. Prevents cross-field contamination.
     pub field_witnesses: std::collections::BTreeMap<String, FieldWitness>,
+    /// Optional zkVM receipt bytes proving parser execution (#1117).
+    /// When present, this is a serialized RISC Zero receipt that
+    /// cryptographically attests the parser execution. Use
+    /// `zkvm_receipt::ZkvmReceipt` (behind `zkvm` feature) to parse
+    /// and verify. Raw bytes stored here to avoid feature coupling.
+    pub zkvm_receipt: Option<Vec<u8>>,
 }
 
 impl WitnessBundle {
@@ -460,7 +466,17 @@ impl WitnessBundle {
         // Created at
         hasher.update(self.created_at.to_le_bytes());
 
+        // zkVM receipt (if present, include in digest for tamper evidence)
+        if let Some(ref receipt) = self.zkvm_receipt {
+            hasher.update(receipt);
+        }
+
         hasher.finalize().into()
+    }
+
+    /// Returns true if this bundle has a zkVM receipt attached.
+    pub fn has_zkvm_receipt(&self) -> bool {
+        self.zkvm_receipt.is_some()
     }
 
     /// Verify the hash chain: each step's output feeds the next step's input.
@@ -999,6 +1015,7 @@ mod tests {
             signature: None,
             created_at: 2000,
             field_witnesses: std::collections::BTreeMap::new(),
+            zkvm_receipt: None,
         }
     }
 
@@ -1115,6 +1132,7 @@ mod tests {
             signature: None,
             created_at: 1000,
             field_witnesses: std::collections::BTreeMap::new(),
+            zkvm_receipt: None,
         };
         assert!(bundle.verify_chain().is_ok());
         assert!(bundle.is_valid());
@@ -1177,6 +1195,7 @@ mod tests {
             signature: None,
             created_at: 2000,
             field_witnesses: std::collections::BTreeMap::new(),
+            zkvm_receipt: None,
         };
         assert!(bundle.verify_chain().is_ok());
         assert!(bundle.is_valid());
@@ -1227,6 +1246,7 @@ mod tests {
             signature: None,
             created_at: 1000,
             field_witnesses: std::collections::BTreeMap::new(),
+            zkvm_receipt: None,
         };
         assert!(bundle.verify_chain().is_err());
     }
@@ -1263,6 +1283,7 @@ mod tests {
             signature: None,
             created_at: 1000,
             field_witnesses: std::collections::BTreeMap::new(),
+            zkvm_receipt: None,
         };
 
         let err = bundle.verify_chain().unwrap_err();
@@ -1313,6 +1334,7 @@ mod tests {
             signature: None,
             created_at: 1000,
             field_witnesses: std::collections::BTreeMap::new(),
+            zkvm_receipt: None,
         };
 
         assert!(bundle.verify_chain().is_ok());
@@ -1357,6 +1379,7 @@ mod tests {
             signature: None,
             created_at: 1000,
             field_witnesses: std::collections::BTreeMap::new(),
+            zkvm_receipt: None,
         };
 
         let err = bundle.verify_chain().unwrap_err();
@@ -1403,6 +1426,7 @@ mod tests {
             signature: None,
             created_at: 1000,
             field_witnesses: std::collections::BTreeMap::new(),
+            zkvm_receipt: None,
         };
 
         let err = bundle.verify_chain().unwrap_err();
@@ -1445,6 +1469,7 @@ mod tests {
             signature: None,
             created_at: 1000,
             field_witnesses: std::collections::BTreeMap::new(),
+            zkvm_receipt: None,
         };
 
         assert!(bundle.verify_chain().is_ok());

--- a/crates/portcullis-core/tests/parser_pipeline.rs
+++ b/crates/portcullis-core/tests/parser_pipeline.rs
@@ -120,6 +120,7 @@ mod wasm_pipeline {
             signature: None,
             created_at: 1000,
             field_witnesses: BTreeMap::new(),
+            zkvm_receipt: None,
         };
 
         assert!(bundle.verify_chain().is_ok());

--- a/crates/portcullis-core/tests/provenance_e2e.rs
+++ b/crates/portcullis-core/tests/provenance_e2e.rs
@@ -133,6 +133,7 @@ fn e2e_provenance_pipeline() {
         signature: None,
         created_at: now,
         field_witnesses: BTreeMap::new(),
+        zkvm_receipt: None,
     };
 
     // ── Step 8: Verify hash chain ────────────────────────────────────

--- a/crates/portcullis/src/lib.rs
+++ b/crates/portcullis/src/lib.rs
@@ -340,6 +340,7 @@ mod tests {
             signature: None,
             created_at: 1_700_000_000,
             field_witnesses: std::collections::BTreeMap::new(),
+            zkvm_receipt: None,
         };
         let digest = wb.compute_digest();
         assert_eq!(digest.len(), 32);


### PR DESCRIPTION
## Summary
- Add `zkvm_receipt: Option<Vec<u8>>` to `WitnessBundle`
- Raw bytes avoid feature coupling — parse with `ZkvmReceipt` when `zkvm` feature enabled
- Included in `compute_digest()` for tamper evidence
- `has_zkvm_receipt()` convenience method
- 15 construction sites updated across 6 files

## Test plan
- [x] 40/40 witness tests pass
- [x] All downstream crates compile (portcullis, nucleus-claude-hook)
- [x] clippy/deny/audit clean

Closes #1117

🤖 Generated with [Claude Code](https://claude.com/claude-code)