### PR TITLE
feat(portcullis-core): policy pipeline combinators (#1148)

### DIFF
--- a/crates/portcullis-core/src/combinators.rs
+++ b/crates/portcullis-core/src/combinators.rs
@@ -1,0 +1,350 @@
+//! Policy pipeline combinators — composable decision chains (#1148).
+//!
+//! Replace monolithic decision functions with composable policy checks.
+//! Each check is independently testable, Kani-provable, and composes
+//! via algebraic combinators (FirstMatch, AllOf, AnyOf, Not).
+//!
+//! ## Example
+//!
+//! ```rust,ignore
+//! use portcullis_core::combinators::*;
+//!
+//! let pipeline = first_match(vec![
+//!     Box::new(DenyIfBudgetExhausted),
+//!     Box::new(DenyIfAdversarialAncestry),
+//!     Box::new(AllowIfCapabilitySufficient),
+//! ]);
+//! let result = pipeline.check(&request);
+//! ```
+
+/// Result of a single policy check.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CheckResult {
+    /// Definitive allow — this check approves the operation.
+    Allow,
+    /// Definitive deny with reason.
+    Deny(String),
+    /// Requires human approval before proceeding.
+    RequiresApproval(String),
+    /// This check has no opinion — pass to the next check in the pipeline.
+    Abstain,
+}
+
+impl CheckResult {
+    /// Whether this result is definitive (not Abstain).
+    pub fn is_decided(&self) -> bool {
+        !matches!(self, Self::Abstain)
+    }
+
+    /// Whether this result allows the operation.
+    pub fn is_allow(&self) -> bool {
+        matches!(self, Self::Allow)
+    }
+
+    /// Whether this result denies the operation.
+    pub fn is_deny(&self) -> bool {
+        matches!(self, Self::Deny(_))
+    }
+}
+
+/// A composable policy check.
+///
+/// Implement this trait for each independent policy concern (delegation,
+/// IFC flow, budget, egress, etc.). Checks compose via combinators.
+pub trait PolicyCheck: Send + Sync {
+    /// Evaluate this check against a request context.
+    fn check(&self, req: &PolicyRequest) -> CheckResult;
+
+    /// Human-readable name for diagnostics.
+    fn name(&self) -> &str;
+}
+
+/// Request context passed to policy checks.
+///
+/// Contains the operation being requested and relevant context
+/// for making a decision.
+#[derive(Debug, Clone)]
+pub struct PolicyRequest {
+    /// The operation being requested (e.g., "read_files", "web_fetch").
+    pub operation: String,
+    /// The capability level required for this operation.
+    pub required_level: crate::CapabilityLevel,
+    /// Additional context as key-value pairs.
+    pub context: std::collections::BTreeMap<String, String>,
+}
+
+impl PolicyRequest {
+    /// Create a new request for an operation.
+    pub fn new(operation: &str, level: crate::CapabilityLevel) -> Self {
+        Self {
+            operation: operation.to_string(),
+            required_level: level,
+            context: std::collections::BTreeMap::new(),
+        }
+    }
+
+    /// Add a context value.
+    pub fn with_context(mut self, key: &str, value: &str) -> Self {
+        self.context.insert(key.to_string(), value.to_string());
+        self
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Combinators
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// First-match: try each check in order, return the first decisive result.
+/// If all abstain, returns Abstain.
+pub struct FirstMatch {
+    checks: Vec<Box<dyn PolicyCheck>>,
+}
+
+impl FirstMatch {
+    pub fn new(checks: Vec<Box<dyn PolicyCheck>>) -> Self {
+        Self { checks }
+    }
+}
+
+impl PolicyCheck for FirstMatch {
+    fn check(&self, req: &PolicyRequest) -> CheckResult {
+        for c in &self.checks {
+            let result = c.check(req);
+            if result.is_decided() {
+                return result;
+            }
+        }
+        CheckResult::Abstain
+    }
+
+    fn name(&self) -> &str {
+        "FirstMatch"
+    }
+}
+
+/// All-of: all checks must allow. If any denies, deny. If any abstains, abstain.
+/// This is the meet-combinator on the truth ordering.
+pub struct AllOf {
+    checks: Vec<Box<dyn PolicyCheck>>,
+}
+
+impl AllOf {
+    pub fn new(checks: Vec<Box<dyn PolicyCheck>>) -> Self {
+        Self { checks }
+    }
+}
+
+impl PolicyCheck for AllOf {
+    fn check(&self, req: &PolicyRequest) -> CheckResult {
+        let mut saw_approval = false;
+        for c in &self.checks {
+            match c.check(req) {
+                CheckResult::Deny(reason) => return CheckResult::Deny(reason),
+                CheckResult::RequiresApproval(_) => saw_approval = true,
+                CheckResult::Allow => {}
+                CheckResult::Abstain => return CheckResult::Abstain,
+            }
+        }
+        if saw_approval {
+            CheckResult::RequiresApproval("multiple checks require approval".into())
+        } else {
+            CheckResult::Allow
+        }
+    }
+
+    fn name(&self) -> &str {
+        "AllOf"
+    }
+}
+
+/// Any-of: if any check allows, allow. Only deny if all deny.
+/// This is the join-combinator on the truth ordering.
+pub struct AnyOf {
+    checks: Vec<Box<dyn PolicyCheck>>,
+}
+
+impl AnyOf {
+    pub fn new(checks: Vec<Box<dyn PolicyCheck>>) -> Self {
+        Self { checks }
+    }
+}
+
+impl PolicyCheck for AnyOf {
+    fn check(&self, req: &PolicyRequest) -> CheckResult {
+        let mut last_deny = None;
+        for c in &self.checks {
+            match c.check(req) {
+                CheckResult::Allow => return CheckResult::Allow,
+                CheckResult::RequiresApproval(_) => {
+                    return CheckResult::RequiresApproval("any-of escalation".into());
+                }
+                CheckResult::Deny(reason) => last_deny = Some(reason),
+                CheckResult::Abstain => {}
+            }
+        }
+        match last_deny {
+            Some(reason) => CheckResult::Deny(reason),
+            None => CheckResult::Abstain,
+        }
+    }
+
+    fn name(&self) -> &str {
+        "AnyOf"
+    }
+}
+
+/// Not: flip Allow <-> Deny, leave RequiresApproval and Abstain unchanged.
+pub struct Not<T: PolicyCheck> {
+    inner: T,
+}
+
+impl<T: PolicyCheck> Not<T> {
+    pub fn new(inner: T) -> Self {
+        Self { inner }
+    }
+}
+
+impl<T: PolicyCheck + Send + Sync> PolicyCheck for Not<T> {
+    fn check(&self, req: &PolicyRequest) -> CheckResult {
+        match self.inner.check(req) {
+            CheckResult::Allow => CheckResult::Deny("negated: inner allowed".into()),
+            CheckResult::Deny(_) => CheckResult::Allow,
+            other => other,
+        }
+    }
+
+    fn name(&self) -> &str {
+        "Not"
+    }
+}
+
+/// Convenience: create a FirstMatch pipeline.
+pub fn first_match(checks: Vec<Box<dyn PolicyCheck>>) -> FirstMatch {
+    FirstMatch::new(checks)
+}
+
+/// Convenience: create an AllOf combinator.
+pub fn all_of(checks: Vec<Box<dyn PolicyCheck>>) -> AllOf {
+    AllOf::new(checks)
+}
+
+/// Convenience: create an AnyOf combinator.
+pub fn any_of(checks: Vec<Box<dyn PolicyCheck>>) -> AnyOf {
+    AnyOf::new(checks)
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct AlwaysAllow;
+    impl PolicyCheck for AlwaysAllow {
+        fn check(&self, _: &PolicyRequest) -> CheckResult {
+            CheckResult::Allow
+        }
+        fn name(&self) -> &str {
+            "AlwaysAllow"
+        }
+    }
+
+    struct AlwaysDeny;
+    impl PolicyCheck for AlwaysDeny {
+        fn check(&self, _: &PolicyRequest) -> CheckResult {
+            CheckResult::Deny("denied".into())
+        }
+        fn name(&self) -> &str {
+            "AlwaysDeny"
+        }
+    }
+
+    struct AlwaysAbstain;
+    impl PolicyCheck for AlwaysAbstain {
+        fn check(&self, _: &PolicyRequest) -> CheckResult {
+            CheckResult::Abstain
+        }
+        fn name(&self) -> &str {
+            "AlwaysAbstain"
+        }
+    }
+
+    fn req() -> PolicyRequest {
+        PolicyRequest::new("test_op", crate::CapabilityLevel::LowRisk)
+    }
+
+    #[test]
+    fn first_match_returns_first_decisive() {
+        let pipeline = first_match(vec![
+            Box::new(AlwaysAbstain),
+            Box::new(AlwaysDeny),
+            Box::new(AlwaysAllow),
+        ]);
+        assert!(pipeline.check(&req()).is_deny());
+    }
+
+    #[test]
+    fn first_match_all_abstain() {
+        let pipeline = first_match(vec![Box::new(AlwaysAbstain), Box::new(AlwaysAbstain)]);
+        assert_eq!(pipeline.check(&req()), CheckResult::Abstain);
+    }
+
+    #[test]
+    fn all_of_requires_all_allow() {
+        let combo = all_of(vec![Box::new(AlwaysAllow), Box::new(AlwaysAllow)]);
+        assert!(combo.check(&req()).is_allow());
+    }
+
+    #[test]
+    fn all_of_one_deny_denies() {
+        let combo = all_of(vec![Box::new(AlwaysAllow), Box::new(AlwaysDeny)]);
+        assert!(combo.check(&req()).is_deny());
+    }
+
+    #[test]
+    fn any_of_one_allow_allows() {
+        let combo = any_of(vec![Box::new(AlwaysDeny), Box::new(AlwaysAllow)]);
+        assert!(combo.check(&req()).is_allow());
+    }
+
+    #[test]
+    fn any_of_all_deny() {
+        let combo = any_of(vec![Box::new(AlwaysDeny), Box::new(AlwaysDeny)]);
+        assert!(combo.check(&req()).is_deny());
+    }
+
+    #[test]
+    fn not_flips_allow_deny() {
+        let n = Not::new(AlwaysAllow);
+        assert!(n.check(&req()).is_deny());
+
+        let n = Not::new(AlwaysDeny);
+        assert!(n.check(&req()).is_allow());
+    }
+
+    #[test]
+    fn not_preserves_abstain() {
+        let n = Not::new(AlwaysAbstain);
+        assert_eq!(n.check(&req()), CheckResult::Abstain);
+    }
+
+    #[test]
+    fn nested_combinators() {
+        // AllOf(AnyOf(deny, allow), Not(deny)) = AllOf(allow, allow) = allow
+        let inner_any: Box<dyn PolicyCheck> =
+            Box::new(any_of(vec![Box::new(AlwaysDeny), Box::new(AlwaysAllow)]));
+        let inner_not: Box<dyn PolicyCheck> = Box::new(Not::new(AlwaysDeny));
+        let combo = all_of(vec![inner_any, inner_not]);
+        assert!(combo.check(&req()).is_allow());
+    }
+
+    #[test]
+    fn request_context() {
+        let r = PolicyRequest::new("web_fetch", crate::CapabilityLevel::LowRisk)
+            .with_context("url", "https://example.com")
+            .with_context("session_id", "sess_1");
+        assert_eq!(r.context.get("url").unwrap(), "https://example.com");
+    }
+}

--- a/crates/portcullis-core/src/lib.rs
+++ b/crates/portcullis-core/src/lib.rs
@@ -66,6 +66,7 @@ pub mod c2pa_manifest;
 pub mod c2pa_signer;
 pub mod capability_traits;
 pub mod category;
+pub mod combinators;
 pub mod compartment;
 #[cfg(feature = "serde")]
 pub mod compartmentfile;


### PR DESCRIPTION
## Summary
- \`PolicyCheck\` trait: composable unit of policy decision
- \`CheckResult\`: Allow, Deny(reason), RequiresApproval, Abstain
- \`FirstMatch\`: sequential pipeline (first decisive wins)
- \`AllOf\`: conjunction (all must allow, meet on truth)
- \`AnyOf\`: disjunction (any may allow, join on truth)
- \`Not\`: negation (flip Allow/Deny)
- Nested composition proven via test

## Test plan
- [x] 10/10 combinator tests pass
- [x] clippy/deny/audit clean

Partial fix for #1148

🤖 Generated with [Claude Code](https://claude.com/claude-code)