### PR TITLE
fix(security): authority escalation, TOCTOU gates, IFC fail-open

### DIFF
--- a/crates/portcullis-core/src/builtin_checks.rs
+++ b/crates/portcullis-core/src/builtin_checks.rs
@@ -277,11 +277,28 @@ impl PolicyCheck for RequireTrustedSource {
 /// Budget is tracked atomically — safe for concurrent policy evaluation.
 /// The budget is shared across all clones of this check.
 ///
+/// ## Atomic reservation (eliminates TOCTOU window, #1179)
+///
+/// When the caller passes `cost_micro_usd` in the [`PolicyRequest`] context,
+/// `check()` atomically reserves that amount using `fetch_add` + rollback. This
+/// eliminates the time-of-check-to-time-of-use window where concurrent calls can
+/// each pass the check before any of them records the cost.
+///
+/// ```rust,ignore
+/// let req = PolicyRequest::new("web_fetch", CapabilityLevel::LowRisk)
+///     .with_context("cost_micro_usd", "1500");
+/// // check() will atomically reserve 1500 µUSD — no separate record_cost() needed.
+/// ```
+///
+/// When `cost_micro_usd` is not in context, `check()` falls back to a snapshot
+/// read (with `Acquire` ordering, so cross-thread writes are visible) and the
+/// caller is responsible for calling `record_cost()` separately.
+///
 /// # Example
 /// ```rust,ignore
 /// let gate = BudgetGate::new(1_000_000); // $1.00 limit
 /// gate.record_cost(500_000);             // $0.50 spent
-/// assert!(gate.check(&req("any_op")).is_allow());
+/// assert!(gate.check(&req("any_op")).is_abstain());
 /// gate.record_cost(600_000);             // now $1.10 total
 /// assert!(gate.check(&req("any_op")).is_deny());
 /// ```
@@ -300,18 +317,37 @@ impl BudgetGate {
     }
 
     /// Record additional cost in micro-USD.
+    ///
+    /// Uses `AcqRel` ordering so the write is immediately visible to
+    /// concurrent `spent()` reads on other threads.
     pub fn record_cost(&self, micro_usd: u64) {
-        self.spent_micro_usd.fetch_add(micro_usd, Ordering::Relaxed);
+        self.spent_micro_usd.fetch_add(micro_usd, Ordering::AcqRel);
     }
 
     /// Current total spend in micro-USD.
+    ///
+    /// Uses `Acquire` ordering so this read sees all preceding `record_cost` writes.
     pub fn spent(&self) -> u64 {
-        self.spent_micro_usd.load(Ordering::Relaxed)
+        self.spent_micro_usd.load(Ordering::Acquire)
     }
 
     /// Remaining budget in micro-USD.
     pub fn remaining(&self) -> u64 {
         self.max_micro_usd.saturating_sub(self.spent())
+    }
+
+    /// Atomically try to reserve `cost` µUSD, returning `true` if successful.
+    ///
+    /// On success the budget is debited. On failure the debit is rolled back.
+    /// This is the TOCTOU-safe alternative to a separate `check()`+`record_cost()`.
+    pub fn try_reserve(&self, cost: u64) -> bool {
+        let prev = self.spent_micro_usd.fetch_add(cost, Ordering::AcqRel);
+        if prev.saturating_add(cost) > self.max_micro_usd {
+            self.spent_micro_usd.fetch_sub(cost, Ordering::Release);
+            false
+        } else {
+            true
+        }
     }
 }
 
@@ -326,6 +362,27 @@ impl Clone for BudgetGate {
 
 impl PolicyCheck for BudgetGate {
     fn check(&self, req: &PolicyRequest) -> CheckResult {
+        // If caller provides expected cost, use atomic reservation to eliminate TOCTOU.
+        if let Some(cost) = req
+            .context
+            .get("cost_micro_usd")
+            .and_then(|s| s.parse::<u64>().ok())
+        {
+            if !self.try_reserve(cost) {
+                return CheckResult::Deny(format!(
+                    "{}: budget exhausted — cannot reserve {} µUSD ({}/{} µUSD used)",
+                    req.operation,
+                    cost,
+                    self.spent(),
+                    self.max_micro_usd
+                ));
+            }
+            return CheckResult::Abstain;
+        }
+
+        // Fallback: snapshot read (Acquire ensures cross-thread visibility).
+        // Caller must call record_cost() separately — a TOCTOU window remains
+        // but cross-thread write visibility is now correct.
         if self.spent() >= self.max_micro_usd {
             CheckResult::Deny(format!(
                 "{}: budget exhausted ({}/{} µUSD)",
@@ -348,7 +405,15 @@ impl PolicyCheck for BudgetGate {
 /// Deny operations once a counter limit is exceeded within a session.
 ///
 /// This is a simple counter-based rate limiter (not time-windowed).
-/// Use `record_call()` after each allowed operation.
+///
+/// ## Atomic slot reservation (eliminates TOCTOU window, #1179)
+///
+/// `check()` atomically reserves a call slot via `fetch_add` + rollback. This
+/// eliminates the time-of-check-to-time-of-use window where concurrent calls can
+/// each pass the check before any increments the counter.
+///
+/// `record_call()` is kept for backward compatibility but is a no-op when the
+/// caller uses `check()` — slots are consumed by `check()` itself.
 ///
 /// For time-windowed rate limiting, integrate with an external clock.
 pub struct RateLimit {
@@ -364,12 +429,24 @@ impl RateLimit {
         }
     }
 
+    /// No-op: kept for API backward compatibility.
+    ///
+    /// `check()` now atomically consumes a call slot, so separate `record_call()`
+    /// is no longer needed and would double-count. Callers that previously did
+    /// `check()` + `record_call()` should remove the `record_call()` call.
+    #[deprecated(
+        since = "1.0.0",
+        note = "check() now atomically reserves a slot; calling record_call() separately double-counts"
+    )]
     pub fn record_call(&self) {
-        self.call_count.fetch_add(1, Ordering::Relaxed);
+        // Intentional no-op: slot reservation moved into check() (#1179).
     }
 
+    /// Current consumed call count.
+    ///
+    /// Uses `Acquire` ordering so cross-thread writes are visible.
     pub fn count(&self) -> u64 {
-        self.call_count.load(Ordering::Relaxed)
+        self.call_count.load(Ordering::Acquire)
     }
 }
 
@@ -384,7 +461,12 @@ impl Clone for RateLimit {
 
 impl PolicyCheck for RateLimit {
     fn check(&self, req: &PolicyRequest) -> CheckResult {
-        if self.count() >= self.max_calls {
+        // Atomically try to reserve one call slot, eliminating the TOCTOU window
+        // where concurrent threads can each pass the check before any increments.
+        let prev = self.call_count.fetch_add(1, Ordering::AcqRel);
+        if prev >= self.max_calls {
+            // Over limit — roll back the reservation.
+            self.call_count.fetch_sub(1, Ordering::Release);
             CheckResult::Deny(format!(
                 "{}: rate limit exceeded ({}/{} calls)",
                 req.operation,
@@ -583,22 +665,63 @@ mod tests {
         assert_eq!(gate.remaining(), 700_000);
     }
 
+    #[test]
+    fn budget_gate_atomic_reservation_via_context() {
+        // Passing cost_micro_usd in context uses atomic try_reserve (#1179).
+        let gate = BudgetGate::new(1_000_000);
+        let req_with_cost = PolicyRequest::new("web_fetch", CapabilityLevel::LowRisk)
+            .with_context("cost_micro_usd", "400000");
+        assert_eq!(gate.check(&req_with_cost), CheckResult::Abstain);
+        assert_eq!(gate.spent(), 400_000);
+        // Second request that would exceed budget is denied and rolled back.
+        let req2 = PolicyRequest::new("web_fetch", CapabilityLevel::LowRisk)
+            .with_context("cost_micro_usd", "700000");
+        assert!(gate.check(&req2).is_deny());
+        // Spent should still be 400_000 (rollback succeeded).
+        assert_eq!(gate.spent(), 400_000);
+    }
+
+    #[test]
+    fn budget_gate_try_reserve_rollback() {
+        let gate = BudgetGate::new(100);
+        assert!(gate.try_reserve(80));
+        assert!(!gate.try_reserve(30)); // 80+30=110 > 100 → deny + rollback
+        assert_eq!(gate.spent(), 80); // only 80 committed
+    }
+
     // ── RateLimit ────────────────────────────────────────────────────────────
 
     #[test]
     fn rate_limit_allows_under_max() {
+        // check() atomically reserves slots (#1179).
         let rl = RateLimit::new(3);
-        rl.record_call();
-        rl.record_call();
-        assert_eq!(rl.check(&req("op")), CheckResult::Abstain);
+        assert_eq!(rl.check(&req("op")), CheckResult::Abstain); // slot 1
+        assert_eq!(rl.check(&req("op")), CheckResult::Abstain); // slot 2
+        assert_eq!(rl.check(&req("op")), CheckResult::Abstain); // slot 3 (last)
     }
 
     #[test]
     fn rate_limit_denies_at_max() {
         let rl = RateLimit::new(2);
-        rl.record_call();
-        rl.record_call();
-        assert!(rl.check(&req("op")).is_deny());
+        assert_eq!(rl.check(&req("op")), CheckResult::Abstain); // slot 1
+        assert_eq!(rl.check(&req("op")), CheckResult::Abstain); // slot 2
+        assert!(rl.check(&req("op")).is_deny()); // over limit
+    }
+
+    #[test]
+    fn rate_limit_count_reflects_consumed_slots() {
+        let rl = RateLimit::new(5);
+        rl.check(&req("op"));
+        rl.check(&req("op"));
+        assert_eq!(rl.count(), 2);
+    }
+
+    #[test]
+    fn rate_limit_rollback_on_deny_keeps_count_stable() {
+        let rl = RateLimit::new(1);
+        assert_eq!(rl.check(&req("op")), CheckResult::Abstain); // 1 consumed
+        assert!(rl.check(&req("op")).is_deny()); // over limit, rolled back
+        assert_eq!(rl.count(), 1); // still 1, not 2
     }
 
     // ── Composition ──────────────────────────────────────────────────────────

--- a/crates/portcullis-core/src/ifc_api.rs
+++ b/crates/portcullis-core/src/ifc_api.rs
@@ -68,6 +68,16 @@ pub enum SafetyCheck {
         /// The minimum authority required.
         required: AuthorityLevel,
     },
+    /// A referenced parent node ID does not exist in the tracker.
+    ///
+    /// Returned by [`FlowTracker::check_safety`] when a caller supplies a
+    /// node ID that is not tracked. The check fails closed (#1180) — an
+    /// unknown node could be the result of a bug that skipped taint tracking,
+    /// so we treat it as unsafe rather than allowing it silently.
+    UnknownNode {
+        /// The node ID that was not found.
+        node_id: u64,
+    },
 }
 
 impl SafetyCheck {
@@ -188,17 +198,28 @@ impl FlowTracker {
     /// An action is unsafe if any of the provided nodes has:
     /// - `Adversarial` integrity (prompt injection risk)
     /// - `NoAuthority` while the action requires authority
+    ///
+    /// **Fails closed on unknown node IDs** (#1180): if any `pid` is not
+    /// found in the tracker, `SafetyCheck::UnknownNode` is returned. An
+    /// unknown ID may indicate a bug where taint tracking was skipped for
+    /// the ancestor — treating it as safe would silently bypass the IFC check.
     pub fn check_safety(&self, parents: &[u64], requires_authority: bool) -> SafetyCheck {
         for &pid in parents {
-            if let Some((_, label, _)) = self.nodes.get((pid - 1) as usize) {
-                if label.integrity == IntegLevel::Adversarial {
-                    return SafetyCheck::AdversarialAncestry { tainted_node: pid };
+            match self.nodes.get((pid - 1) as usize) {
+                None => {
+                    // Fail closed: unknown node IDs are unsafe (#1180).
+                    return SafetyCheck::UnknownNode { node_id: pid };
                 }
-                if requires_authority && label.authority == AuthorityLevel::NoAuthority {
-                    return SafetyCheck::InsufficientAuthority {
-                        actual: label.authority,
-                        required: AuthorityLevel::Informational,
-                    };
+                Some((_, label, _)) => {
+                    if label.integrity == IntegLevel::Adversarial {
+                        return SafetyCheck::AdversarialAncestry { tainted_node: pid };
+                    }
+                    if requires_authority && label.authority == AuthorityLevel::NoAuthority {
+                        return SafetyCheck::InsufficientAuthority {
+                            actual: label.authority,
+                            required: AuthorityLevel::Informational,
+                        };
+                    }
                 }
             }
         }
@@ -360,5 +381,24 @@ mod tests {
         assert!(t.check_safety(&[trusted], false).is_safe());
         // CORRECT: new API checks plan's own label → correctly denied
         assert!(t.check_action_safety(plan, false).is_denied());
+    }
+
+    #[test]
+    fn check_safety_fails_closed_on_unknown_node() {
+        // #1180: unknown node IDs must not silently pass — fail closed.
+        let t = FlowTracker::new();
+        let result = t.check_safety(&[999], false);
+        assert!(result.is_denied());
+        assert!(matches!(result, SafetyCheck::UnknownNode { node_id: 999 }));
+    }
+
+    #[test]
+    fn check_safety_unknown_node_in_mixed_list() {
+        // If the unknown node comes after a safe known node, still fails closed.
+        let mut t = FlowTracker::new();
+        let file = t.observe(NodeKind::FileRead).unwrap();
+        let result = t.check_safety(&[file, 9999], false);
+        assert!(result.is_denied());
+        assert!(matches!(result, SafetyCheck::UnknownNode { node_id: 9999 }));
     }
 }

--- a/crates/portcullis-core/src/memory.rs
+++ b/crates/portcullis-core/src/memory.rs
@@ -276,6 +276,11 @@ impl GovernedMemory {
     ///
     /// When overwriting an existing key, the previous value is pushed
     /// onto the rebuttal history (capped at [`MAX_REBUTTAL_HISTORY`]).
+    ///
+    /// **Invariant enforcement:** If `label.integrity == IntegLevel::Adversarial`,
+    /// the caller-supplied `authority` is silently overridden to
+    /// `MemoryAuthority::MayNotAuthorize` regardless of what was passed. This
+    /// prevents authority escalation on adversarial entries (#1178).
     #[allow(clippy::too_many_arguments)]
     pub fn write_with_limit(
         &mut self,
@@ -289,6 +294,14 @@ impl GovernedMemory {
         ttl_secs: u64,
         max_entries: usize,
     ) -> bool {
+        // Invariant: adversarial-integrity entries can never hold informational
+        // authority, regardless of what the caller passed (#1178).
+        let authority = if label.integrity == IntegLevel::Adversarial {
+            MemoryAuthority::MayNotAuthorize
+        } else {
+            authority
+        };
+
         // If key already exists, allow overwrite (doesn't increase count)
         if !self.entries.contains_key(&key) && self.entries.len() >= max_entries {
             return false; // Reject: would exceed limit
@@ -1120,5 +1133,59 @@ max_entries = 500
         assert!(row.provenance.contains(ProvenanceSet::WEB));
         assert!(row.provenance.contains(ProvenanceSet::MODEL));
         assert_eq!(row.integrity, IntegLevel::Adversarial);
+    }
+
+    #[test]
+    fn write_governed_cannot_escalate_adversarial_to_inform() {
+        // #1178: write_governed must not let adversarial entries acquire MayInform authority.
+        let mut mem = GovernedMemory::new();
+        let adversarial_label =
+            MemoryLabel::from_levels(ConfLevel::Public, IntegLevel::Adversarial);
+
+        // Caller attempts to escalate by supplying MayInform for adversarial data.
+        let ok = mem.write_governed(
+            "poisoned".into(),
+            "injected content".into(),
+            SchemaType::String,
+            adversarial_label,
+            MemoryAuthority::MayInform, // attempted escalation
+            0,
+            0,
+        );
+        assert!(ok);
+
+        // The stored entry must have MayNotAuthorize, not the caller-supplied MayInform.
+        let entry = mem.read("poisoned", 0).unwrap();
+        assert_eq!(
+            entry.authority,
+            MemoryAuthority::MayNotAuthorize,
+            "adversarial entry must not hold MayInform authority"
+        );
+
+        // It must appear in poisoned_entries().
+        assert_eq!(mem.poisoned_entries(0).len(), 1);
+    }
+
+    #[test]
+    fn write_with_limit_cannot_escalate_adversarial() {
+        // #1178: invariant is enforced at write_with_limit, the lowest write path.
+        let mut mem = GovernedMemory::new();
+        let adversarial_label =
+            MemoryLabel::from_levels(ConfLevel::Public, IntegLevel::Adversarial);
+
+        mem.write_with_limit(
+            "k".into(),
+            "v".into(),
+            SchemaType::String,
+            adversarial_label,
+            MemoryAuthority::MayInform, // attempted escalation
+            crate::ProvenanceSet::EMPTY,
+            0,
+            0,
+            1000,
+        );
+
+        let entry = mem.read("k", 0).unwrap();
+        assert_eq!(entry.authority, MemoryAuthority::MayNotAuthorize);
     }
 }


### PR DESCRIPTION
## Summary

Three security fixes from skeptical-code-auditor:

- **#1178 — Authority escalation in `write_governed`**: `write_with_limit()` now enforces that adversarial-integrity entries always get `MayNotAuthorize`, regardless of caller-supplied authority. Prevents poisoned memory from silently acquiring informational authority (MINJA/MemoryGraft bypass). 2 regression tests added.

- **#1179 — TOCTOU race in `BudgetGate`/`RateLimit`**: All atomics upgraded from `Relaxed` to `AcqRel`/`Acquire`/`Release`. `RateLimit::check()` now atomically reserves a slot via `fetch_add`+rollback — no separate `record_call()` needed. `BudgetGate` gains `try_reserve(cost)` and atomic reservation via `cost_micro_usd` context key.

- **#1180 — `check_safety` fails open on unknown node IDs**: Returns new `SafetyCheck::UnknownNode` variant instead of silently continuing past unknown IDs. Unknown IDs could indicate skipped taint tracking — failing closed prevents silent IFC bypass. 2 regression tests added.

Closes #1178, #1179, #1180

## Test plan

- [ ] All 436 lib tests pass (+ 27 memory tests with `--features serde`)
- [ ] `cargo clippy` clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)