### PR TITLE
fix(portcullis-core): three security audit fixes — UTF-8 truncate, path traversal, IFC off-by-one (#1184 #1185 #1186)

### DIFF
--- a/crates/portcullis-core/src/ifc_api.rs
+++ b/crates/portcullis-core/src/ifc_api.rs
@@ -121,7 +121,7 @@ impl FlowTracker {
             return Err(FlowError::TooManyParents(parents.len()));
         }
         for &pid in parents {
-            if pid == 0 || pid > self.next_id {
+            if pid == 0 || pid >= self.next_id {
                 return Err(FlowError::ParentNotFound(pid));
             }
         }
@@ -400,5 +400,29 @@ mod tests {
         let result = t.check_safety(&[file, 9999], false);
         assert!(result.is_denied());
         assert!(matches!(result, SafetyCheck::UnknownNode { node_id: 9999 }));
+    }
+
+    // ── Off-by-one fix: next_id is not yet assigned (#1186) ──────────────
+
+    #[test]
+    fn observe_rejects_next_id_as_parent() {
+        // next_id is the ID that will be assigned to the *next* node — it
+        // does not exist yet. Before the fix, `pid > next_id` let it through;
+        // after the fix, `pid >= next_id` correctly rejects it.
+        let mut t = FlowTracker::new();
+        // next_id == 1 before any observe
+        let err = t
+            .observe_with_parents(NodeKind::ModelPlan, &[1])
+            .unwrap_err();
+        assert!(matches!(err, FlowError::ParentNotFound(1)));
+    }
+
+    #[test]
+    fn observe_accepts_valid_prior_node_as_parent() {
+        let mut t = FlowTracker::new();
+        let file = t.observe(NodeKind::FileRead).unwrap(); // id == 1, next_id now == 2
+        // id 1 is valid; next_id (2) is not yet assigned
+        let plan = t.observe_with_parents(NodeKind::ModelPlan, &[file]);
+        assert!(plan.is_ok());
     }
 }

--- a/crates/portcullis-core/src/structured_prompt.rs
+++ b/crates/portcullis-core/src/structured_prompt.rs
@@ -368,7 +368,12 @@ impl StructuredPrompt {
 // ── helpers ───────────────────────────────────────────────────────────────
 
 fn truncate(s: &str, max: usize) -> &str {
-    if s.len() <= max { s } else { &s[..max] }
+    if s.len() <= max {
+        s
+    } else {
+        // Use char boundary-safe slicing to avoid panics on multi-byte UTF-8.
+        s.char_indices().nth(max).map_or(s, |(i, _)| &s[..i])
+    }
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -489,5 +494,36 @@ mod tests {
             .with_payload(PayloadRef::mcp_tool("t", "", b"a".to_vec())) // Untrusted
             .with_payload(PayloadRef::web_fetch("https://x.com", b"b".to_vec())); // Adversarial
         assert_eq!(prompt.min_payload_integrity(), IntegLevel::Adversarial);
+    }
+
+    // ── truncate UTF-8 safety (#1184) ────────────────────────────────────
+
+    #[test]
+    fn truncate_ascii_exact_limit() {
+        assert_eq!(truncate("hello", 5), "hello");
+    }
+
+    #[test]
+    fn truncate_ascii_under_limit() {
+        assert_eq!(truncate("hi", 10), "hi");
+    }
+
+    #[test]
+    fn truncate_ascii_over_limit() {
+        assert_eq!(truncate("hello world", 5), "hello");
+    }
+
+    #[test]
+    fn truncate_multibyte_does_not_panic() {
+        // Each '日' is 3 bytes; slicing at byte index 1 or 2 would panic.
+        let s = "日本語テスト";
+        let result = truncate(s, 2); // 2 chars = first 2 characters
+        assert_eq!(result, "日本");
+    }
+
+    #[test]
+    fn truncate_multibyte_at_char_boundary() {
+        let s = "αβγδε"; // each char is 2 bytes
+        assert_eq!(truncate(s, 3), "αβγ");
     }
 }

--- a/crates/portcullis-core/src/task_shield.rs
+++ b/crates/portcullis-core/src/task_shield.rs
@@ -368,7 +368,29 @@ fn op_from_str(s: &str) -> Option<Operation> {
 /// - Starts with `docs/`, `doc/`, `documentation/`, or `README`
 /// - Ends with `.md`, `.rst`, `.txt`, `.adoc`
 fn is_docs_path(path: &str) -> bool {
-    let lower = path.to_lowercase();
+    use std::path::{Component, Path};
+
+    // Normalize the path by resolving `.` and `..` components before checking
+    // prefixes, so that `docs/../src/main.rs` is not classified as a docs path.
+    let mut components: Vec<&str> = Vec::new();
+    for component in Path::new(path).components() {
+        match component {
+            Component::ParentDir => {
+                components.pop();
+            }
+            Component::CurDir => {}
+            Component::Normal(s) => {
+                if let Some(s) = s.to_str() {
+                    components.push(s);
+                }
+            }
+            // Preserve prefix/root for absolute paths (rare in our context).
+            _ => {}
+        }
+    }
+    let normalized = components.join("/");
+    let lower = normalized.to_lowercase();
+
     // Prefix heuristics
     let doc_prefixes = ["docs/", "doc/", "documentation/", "readme", "changelog"];
     if doc_prefixes.iter().any(|p| lower.starts_with(p)) {
@@ -584,5 +606,30 @@ mod tests {
         // No witness attached — git_commit is in BugFix.allowed_operations
         let req = PolicyRequest::new("git_commit", CapabilityLevel::Always);
         assert!(policy.check(&req).is_allow());
+    }
+
+    // ── is_docs_path path traversal (#1185) ─────────────────────────────
+
+    #[test]
+    fn docs_path_traversal_not_classified_as_docs() {
+        // `docs/../src/main.rs` must not be classified as a docs path after
+        // normalization — the resolved path is `src/main.rs`.
+        assert!(!is_docs_path("docs/../src/main.rs"));
+        assert!(!is_docs_path("docs/../../etc/passwd"));
+        assert!(!is_docs_path("doc/../lib.rs"));
+    }
+
+    #[test]
+    fn legitimate_docs_paths_still_classified() {
+        assert!(is_docs_path("docs/getting-started.md"));
+        assert!(is_docs_path("doc/README.rst"));
+        assert!(is_docs_path("README.md"));
+        assert!(is_docs_path("changelog.txt"));
+    }
+
+    #[test]
+    fn double_dot_in_docs_subdir_still_docs() {
+        // docs/api/../guide.md normalizes to docs/guide.md — still docs.
+        assert!(is_docs_path("docs/api/../guide.md"));
     }
 }


### PR DESCRIPTION
## Summary

- **#1184** `structured_prompt::truncate` panicked on multi-byte UTF-8 via raw `&s[..max]` byte slicing — fixed with `char_indices().nth(max)` char-boundary-safe slicing
- **#1185** `task_shield::is_docs_path` classified `docs/../src/main.rs` as a docs path (path traversal bypass) — fixed by normalizing `..`/`.` components before prefix-checking
- **#1186** `ifc_api::observe_with_parents` off-by-one: `pid > self.next_id` allowed the not-yet-assigned next ID as a parent, creating a taint-laundering window — fixed to `pid >= self.next_id` (fail-closed)

All three fixes include regression tests. 476 lib tests pass.

## Test plan

- [ ] `cargo test -p portcullis-core --lib` passes (476 tests)
- [ ] New tests: `truncate_multibyte_does_not_panic`, `docs_path_traversal_not_classified_as_docs`, `observe_rejects_next_id_as_parent`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)