### PR TITLE
fix(portcullis-core): audit fixes — CAS reservation, AllOf Abstain identity, UnknownNode variant (#1196 #1197 #1198)

### DIFF
--- a/crates/portcullis-core/src/builtin_checks.rs
+++ b/crates/portcullis-core/src/builtin_checks.rs
@@ -277,12 +277,12 @@ impl PolicyCheck for RequireTrustedSource {
 /// Budget is tracked atomically — safe for concurrent policy evaluation.
 /// The budget is shared across all clones of this check.
 ///
-/// ## Atomic reservation (eliminates TOCTOU window, #1179)
+/// ## Atomic reservation (eliminates TOCTOU window, #1179 / #1196)
 ///
 /// When the caller passes `cost_micro_usd` in the [`PolicyRequest`] context,
-/// `check()` atomically reserves that amount using `fetch_add` + rollback. This
-/// eliminates the time-of-check-to-time-of-use window where concurrent calls can
-/// each pass the check before any of them records the cost.
+/// `check()` atomically reserves that amount using a compare-and-swap loop.
+/// This eliminates both the TOCTOU window and the wrapping-arithmetic race that
+/// affects fetch_add + rollback under high concurrency.
 ///
 /// ```rust,ignore
 /// let req = PolicyRequest::new("web_fetch", CapabilityLevel::LowRisk)
@@ -338,15 +338,26 @@ impl BudgetGate {
 
     /// Atomically try to reserve `cost` µUSD, returning `true` if successful.
     ///
-    /// On success the budget is debited. On failure the debit is rolled back.
-    /// This is the TOCTOU-safe alternative to a separate `check()`+`record_cost()`.
+    /// Uses a compare-and-swap loop to avoid the wrapping-arithmetic race in
+    /// fetch_add + rollback: under concurrent pressure, a wrapping fetch_add
+    /// could temporarily expose a small counter value to a racing thread before
+    /// the rollback fires, allowing the racing thread to bypass the limit (#1196).
     pub fn try_reserve(&self, cost: u64) -> bool {
-        let prev = self.spent_micro_usd.fetch_add(cost, Ordering::AcqRel);
-        if prev.saturating_add(cost) > self.max_micro_usd {
-            self.spent_micro_usd.fetch_sub(cost, Ordering::Release);
-            false
-        } else {
-            true
+        let mut current = self.spent_micro_usd.load(Ordering::Acquire);
+        loop {
+            let new = match current.checked_add(cost) {
+                Some(n) if n <= self.max_micro_usd => n,
+                _ => return false,
+            };
+            match self.spent_micro_usd.compare_exchange_weak(
+                current,
+                new,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => return true,
+                Err(actual) => current = actual,
+            }
         }
     }
 }
@@ -406,11 +417,11 @@ impl PolicyCheck for BudgetGate {
 ///
 /// This is a simple counter-based rate limiter (not time-windowed).
 ///
-/// ## Atomic slot reservation (eliminates TOCTOU window, #1179)
+/// ## Atomic slot reservation (eliminates TOCTOU window, #1179 / #1196)
 ///
-/// `check()` atomically reserves a call slot via `fetch_add` + rollback. This
-/// eliminates the time-of-check-to-time-of-use window where concurrent calls can
-/// each pass the check before any increments the counter.
+/// `check()` atomically reserves a call slot via a compare-and-swap loop.
+/// This eliminates both the TOCTOU window and the wrapping-arithmetic race that
+/// affects fetch_add + rollback under high concurrency.
 ///
 /// `record_call()` is kept for backward compatibility but is a no-op when the
 /// caller uses `check()` — slots are consumed by `check()` itself.
@@ -461,20 +472,25 @@ impl Clone for RateLimit {
 
 impl PolicyCheck for RateLimit {
     fn check(&self, req: &PolicyRequest) -> CheckResult {
-        // Atomically try to reserve one call slot, eliminating the TOCTOU window
-        // where concurrent threads can each pass the check before any increments.
-        let prev = self.call_count.fetch_add(1, Ordering::AcqRel);
-        if prev >= self.max_calls {
-            // Over limit — roll back the reservation.
-            self.call_count.fetch_sub(1, Ordering::Release);
-            CheckResult::Deny(format!(
-                "{}: rate limit exceeded ({}/{} calls)",
-                req.operation,
-                self.count(),
-                self.max_calls
-            ))
-        } else {
-            CheckResult::Abstain
+        // CAS loop: atomically reserve one call slot without the wrapping-arithmetic
+        // race that fetch_add + rollback has under high concurrency (#1196).
+        let mut current = self.call_count.load(Ordering::Acquire);
+        loop {
+            if current >= self.max_calls {
+                return CheckResult::Deny(format!(
+                    "{}: rate limit exceeded ({}/{} calls)",
+                    req.operation, current, self.max_calls
+                ));
+            }
+            match self.call_count.compare_exchange_weak(
+                current,
+                current + 1,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => return CheckResult::Abstain,
+                Err(actual) => current = actual,
+            }
         }
     }
 
@@ -733,9 +749,9 @@ mod tests {
             Box::new(RequireApprovalFor::new(["git_push"])),
         ]);
 
-        // Low-risk read: ReadOnly allows, RequireApprovalFor abstains → AllOf abstains
-        // (AllOf short-circuits on Abstain — no constituent declared an opinion)
-        assert_eq!(policy.check(&req("read_files")), CheckResult::Abstain);
+        // Low-risk read: ReadOnly allows, RequireApprovalFor abstains (no opinion).
+        // AllOf treats Abstain as identity, so the Allow from ReadOnly wins (#1197).
+        assert_eq!(policy.check(&req("read_files")), CheckResult::Allow);
 
         // Always-level write: deny (ReadOnly short-circuits before RequireApprovalFor)
         assert!(policy.check(&req_always("run_bash")).is_deny());

--- a/crates/portcullis-core/src/combinators.rs
+++ b/crates/portcullis-core/src/combinators.rs
@@ -146,7 +146,13 @@ impl PolicyCheck for FirstMatch {
     }
 }
 
-/// All-of: all checks must allow. If any denies, deny. If any abstains, abstain.
+/// All-of: all checks must allow. If any denies, deny.
+///
+/// `Abstain` is treated as the identity element (no opinion) — checks that
+/// abstain are skipped and do not affect the result. If **all** checks abstain,
+/// the combinator returns `Abstain`. This mirrors the lattice identity: a check
+/// with no opinion should not change the outcome of the conjunction (#1197).
+///
 /// This is the meet-combinator on the truth ordering.
 pub struct AllOf {
     checks: Vec<Box<dyn PolicyCheck>>,
@@ -161,13 +167,23 @@ impl AllOf {
 impl PolicyCheck for AllOf {
     fn check(&self, req: &PolicyRequest) -> CheckResult {
         let mut saw_approval = false;
+        let mut saw_decisive = false;
         for c in &self.checks {
             match c.check(req) {
                 CheckResult::Deny(reason) => return CheckResult::Deny(reason),
-                CheckResult::RequiresApproval(_) => saw_approval = true,
-                CheckResult::Allow => {}
-                CheckResult::Abstain => return CheckResult::Abstain,
+                CheckResult::RequiresApproval(_) => {
+                    saw_approval = true;
+                    saw_decisive = true;
+                }
+                CheckResult::Allow => {
+                    saw_decisive = true;
+                }
+                // Abstain = identity: this check has no opinion; skip it.
+                CheckResult::Abstain => {}
             }
+        }
+        if !saw_decisive {
+            return CheckResult::Abstain;
         }
         if saw_approval {
             CheckResult::RequiresApproval("multiple checks require approval".into())
@@ -325,6 +341,47 @@ mod tests {
     fn all_of_one_deny_denies() {
         let combo = all_of(vec![Box::new(AlwaysAllow), Box::new(AlwaysDeny)]);
         assert!(combo.check(&req()).is_deny());
+    }
+
+    // ── AllOf Abstain identity semantics (#1197) ─────────────────────────
+
+    #[test]
+    fn all_of_abstain_is_identity_not_absorber() {
+        // Abstaining check should be skipped; the Allow still wins.
+        let combo = all_of(vec![Box::new(AlwaysAbstain), Box::new(AlwaysAllow)]);
+        assert!(
+            combo.check(&req()).is_allow(),
+            "Abstain must not absorb Allow"
+        );
+    }
+
+    #[test]
+    fn all_of_abstain_does_not_hide_deny() {
+        // Deny must still win even when another check abstains.
+        let combo = all_of(vec![Box::new(AlwaysAbstain), Box::new(AlwaysDeny)]);
+        assert!(
+            combo.check(&req()).is_deny(),
+            "Deny must not be hidden by Abstain"
+        );
+    }
+
+    #[test]
+    fn all_of_abstain_before_deny_does_not_short_circuit() {
+        // The critical regression: Abstain before Deny must not short-circuit.
+        // Old bug: AllOf returned Abstain immediately on first Abstain, hiding Deny.
+        let combo = all_of(vec![
+            Box::new(AlwaysAbstain),
+            Box::new(AlwaysAbstain),
+            Box::new(AlwaysDeny),
+        ]);
+        assert!(combo.check(&req()).is_deny());
+    }
+
+    #[test]
+    fn all_of_all_abstain_returns_abstain() {
+        // When every check abstains, AllOf itself should abstain.
+        let combo = all_of(vec![Box::new(AlwaysAbstain), Box::new(AlwaysAbstain)]);
+        assert_eq!(combo.check(&req()), CheckResult::Abstain);
     }
 
     #[test]

--- a/crates/portcullis-core/src/ifc_api.rs
+++ b/crates/portcullis-core/src/ifc_api.rs
@@ -167,10 +167,9 @@ impl FlowTracker {
     /// ```
     pub fn check_action_safety(&self, node_id: u64, requires_authority: bool) -> SafetyCheck {
         let Some((_, label, _)) = self.nodes.get((node_id - 1) as usize) else {
-            // Unknown node — deny by default (fail-closed)
-            return SafetyCheck::AdversarialAncestry {
-                tainted_node: node_id,
-            };
+            // Unknown node — fail-closed with the correct variant so callers
+            // can distinguish a tracking bug from actual adversarial taint (#1198).
+            return SafetyCheck::UnknownNode { node_id };
         };
         if label.integrity == IntegLevel::Adversarial {
             return SafetyCheck::AdversarialAncestry {
@@ -351,8 +350,13 @@ mod tests {
     #[test]
     fn action_safety_unknown_node_denied() {
         let t = FlowTracker::new();
-        // Node 999 doesn't exist — fail-closed
-        assert!(t.check_action_safety(999, false).is_denied());
+        // Node 999 doesn't exist — fail-closed with UnknownNode, not AdversarialAncestry (#1198).
+        let result = t.check_action_safety(999, false);
+        assert!(result.is_denied());
+        assert!(
+            matches!(result, SafetyCheck::UnknownNode { node_id: 999 }),
+            "expected UnknownNode(999), got {result:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **#1198** `check_action_safety` returned `AdversarialAncestry` for unknown node IDs — callers couldn't distinguish a taint event from a tracking bug. Now returns `UnknownNode`, consistent with `check_safety`.
- **#1197** `AllOf` treated `Abstain` as absorbing (short-circuited), silently dropping subsequent policy checks. `Abstain` is the lattice identity for conjunction — it should be skipped. Fixed; updated one test that was asserting the old wrong behavior.
- **#1196** `BudgetGate::try_reserve` and `RateLimit::check` used `fetch_add` + rollback, which under concurrent pressure can expose a wrapped counter value to a racing thread before rollback fires. Replaced both with CAS loops — no intermediate invalid state.

## Test plan

- [ ] `cargo test -p portcullis-core --lib` passes (480 tests, 4 new)
- [ ] New tests: `all_of_abstain_is_identity_not_absorber`, `all_of_abstain_before_deny_does_not_short_circuit`, `all_of_all_abstain_returns_abstain`, `action_safety_unknown_node_denied` (stricter assertion)
- [ ] CI green

Closes #1196, #1197, #1198

🤖 Generated with [Claude Code](https://claude.com/claude-code)