### PR TITLE
fix(portcullis-core): close three security bugs in policy enforcement

### DIFF
--- a/crates/portcullis-core/src/builtin_checks.rs
+++ b/crates/portcullis-core/src/builtin_checks.rs
@@ -257,11 +257,17 @@ pub struct RequireTrustedSource;
 impl PolicyCheck for RequireTrustedSource {
     fn check(&self, req: &PolicyRequest) -> CheckResult {
         match req.context.get("source_trust").map(|s| s.as_str()) {
+            Some("trusted") => CheckResult::Abstain,
             Some("untrusted") => CheckResult::Deny(format!(
                 "{}: denied — operation originates from untrusted source",
                 req.operation
             )),
-            _ => CheckResult::Abstain,
+            // Fail-closed: absent or unrecognized source_trust key is denied (#1211).
+            // An attacker who omits the key must not get a free pass through AllOf.
+            None | Some(_) => CheckResult::Deny(format!(
+                "{}: denied — source_trust context key absent or unrecognized value",
+                req.operation
+            )),
         }
     }
 
@@ -318,10 +324,22 @@ impl BudgetGate {
 
     /// Record additional cost in micro-USD.
     ///
-    /// Uses `AcqRel` ordering so the write is immediately visible to
-    /// concurrent `spent()` reads on other threads.
+    /// Uses a CAS loop with saturating addition so the counter can never wrap
+    /// past `u64::MAX` and silently reopen the budget (#1210).
     pub fn record_cost(&self, micro_usd: u64) {
-        self.spent_micro_usd.fetch_add(micro_usd, Ordering::AcqRel);
+        let mut current = self.spent_micro_usd.load(Ordering::Acquire);
+        loop {
+            let new_val = current.saturating_add(micro_usd);
+            match self.spent_micro_usd.compare_exchange_weak(
+                current,
+                new_val,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => return,
+                Err(actual) => current = actual,
+            }
+        }
     }
 
     /// Current total spend in micro-USD.
@@ -785,11 +803,16 @@ mod tests {
             Box::new(DenyAdversarialTaint),
         ]);
 
-        // Neither triggered: both abstain → abstain
-        assert_eq!(policy.check(&req("op")), CheckResult::Abstain);
+        // Absent source_trust key: fail-closed → deny (#1211).
+        // An attacker who omits the key must not pass through any_of/all_of.
+        assert!(policy.check(&req("op")).is_deny());
 
-        // Untrusted source: first check denies
+        // Explicit untrusted source: also denies.
         let r = req("op").with_context("source_trust", "untrusted");
         assert!(policy.check(&r).is_deny());
+
+        // Explicit trusted source: abstains (passes through to next check).
+        let r = req("op").with_context("source_trust", "trusted");
+        assert_eq!(policy.check(&r), CheckResult::Abstain);
     }
 }

--- a/crates/portcullis-core/src/ifc_api.rs
+++ b/crates/portcullis-core/src/ifc_api.rs
@@ -196,7 +196,8 @@ impl FlowTracker {
     /// Node IDs are 1-based; ID 0 is reserved as a sentinel and must not be
     /// used in arithmetic without first checking for zero (#1203).
     fn node_entry(&self, node_id: u64) -> Option<&(NodeKind, IFCLabel, Vec<u64>)> {
-        let idx = node_id.checked_sub(1)? as usize;
+        // Use try_from to avoid silent truncation on 32-bit targets (#1212).
+        let idx = usize::try_from(node_id.checked_sub(1)?).ok()?;
         self.nodes.get(idx)
     }
 


### PR DESCRIPTION
## Summary

- **#1210 — BudgetGate overflow**: `record_cost` used a bare `fetch_add` that could wrap past `u64::MAX`, silently resetting the budget counter to zero and reopening an exhausted budget. Fixed with a CAS loop using `saturating_add` — the counter now clamps at `u64::MAX`.
- **#1211 — RequireTrustedSource default-open**: A missing `source_trust` context key returned `Abstain`, letting any request without the key silently pass through `AllOf` chains. Fixed to fail-closed: absent or unrecognized values now return `Deny`. Only `"trusted"` abstains.
- **#1212 — node_entry 32-bit truncation**: `node_id.checked_sub(1)? as usize` silently truncated on 32-bit and wasm32 targets, potentially aliasing to a wrong node. Fixed with `usize::try_from(...).ok()?` to fail cleanly.

All 496 portcullis-core unit tests pass.

## Test plan
- [x] `cargo test -p portcullis-core --lib` — 496 passed, 0 failed
- [x] Pre-push hooks pass (fmt, clippy, deny, audit)
- [x] Updated `any_of_trusted_sources` test to assert the correct fail-closed behavior

Closes #1210, Closes #1211, Closes #1212

🤖 Generated with [Claude Code](https://claude.com/claude-code)