### PR TITLE
feat(portcullis): deprecate Kernel::decide() — term path is the only path (#1194)

### DIFF
--- a/crates/nucleus-claude-hook/src/bench.rs
+++ b/crates/nucleus-claude-hook/src/bench.rs
@@ -151,6 +151,7 @@ const TOOL_NAMES: &[&str] = &[
 ];
 
 /// Run a single benchmarked decide() through the full pipeline.
+#[allow(deprecated)] // Migration to decide_term tracked in #1194
 fn bench_single_decide(
     perms: &PermissionLattice,
     tool_name: &str,
@@ -254,6 +255,7 @@ fn build_observations(count: usize) -> (Vec<(u8, String, String)>, Vec<(String, 
 }
 
 /// Main benchmark entry point.
+#[allow(deprecated)] // Migration to decide_term tracked in #1194
 pub(crate) fn run_benchmark(config: BenchConfig) {
     eprintln!(
         "nucleus benchmark — {} iterations per scenario",

--- a/crates/nucleus-claude-hook/src/main.rs
+++ b/crates/nucleus-claude-hook/src/main.rs
@@ -77,6 +77,7 @@ use commands::{run_doctor, run_help, run_init, run_smoke_test, show_profile};
 // Main
 // ---------------------------------------------------------------------------
 
+#[allow(deprecated)] // Migration to decide_term tracked in #1194
 fn main() {
     // Binary self-integrity check (#946) — run once at startup.
     match integrity::verify_binary_integrity() {
@@ -1617,6 +1618,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)] // Migration to decide_term tracked in #1194
     fn test_kernel_allow_read() {
         let perms = PermissionLattice::safe_pr_fixer();
         let mut kernel = Kernel::new(perms);
@@ -1625,6 +1627,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)] // Migration to decide_term tracked in #1194
     fn test_kernel_deny_git_push() {
         let perms = PermissionLattice::read_only();
         let mut kernel = Kernel::new(perms);
@@ -1658,6 +1661,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)] // Migration to decide_term tracked in #1194
     fn test_exposure_accumulation() {
         // safe_pr_fixer: read + web_fetch + bash should trigger exposure gate
         // Use capability_only() to isolate the exposure subsystem from flow control.

--- a/crates/nucleus-mcp/src/main.rs
+++ b/crates/nucleus-mcp/src/main.rs
@@ -1721,6 +1721,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)] // Migration to decide_term tracked in #1194
     fn test_kernel_allows_read_and_records_exposure() {
         let mut kernel = Kernel::new(permissive_no_static_obligations());
         let (d, _token) = kernel.decide(Operation::ReadFiles, "/workspace/main.rs");
@@ -1729,6 +1730,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)] // Migration to decide_term tracked in #1194
     fn test_kernel_allows_web_fetch_and_records_exposure() {
         let mut kernel = Kernel::new(permissive_no_static_obligations());
         let (d, _token) = kernel.decide(Operation::WebFetch, "https://example.com");
@@ -1737,6 +1739,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)] // Migration to decide_term tracked in #1194
     fn test_kernel_exposure_accumulates_monotonically() {
         let mut kernel = Kernel::new(permissive_no_static_obligations());
         let (d1, _token) = kernel.decide(Operation::ReadFiles, "a.rs");
@@ -1749,6 +1752,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)] // Migration to decide_term tracked in #1194
     fn test_kernel_neutral_ops_dont_add_exposure() {
         let mut kernel = Kernel::new(permissive_no_static_obligations());
         let (d, _token) = kernel.decide(Operation::WriteFiles, "out.txt");
@@ -1757,6 +1761,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)] // Migration to decide_term tracked in #1194
     fn test_kernel_dynamic_exposure_gates_exfil() {
         let mut kernel = Kernel::capability_only(permissive_no_static_obligations());
         // Read: private_data
@@ -1770,6 +1775,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)] // Migration to decide_term tracked in #1194
     fn test_kernel_uninhabitable_allows_non_exfil_after_read_and_fetch() {
         // Use capability_only to test the exposure subsystem in isolation,
         // without flow control tainting writes after web fetch.
@@ -1784,6 +1790,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)] // Migration to decide_term tracked in #1194
     fn test_kernel_omnibus_uninhabitable_with_untrusted_content() {
         let mut kernel = Kernel::capability_only(permissive_no_static_obligations());
         // Only untrusted content + RunBash (omnibus) → uninhabitable_state triggers!
@@ -1793,6 +1800,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)] // Migration to decide_term tracked in #1194
     fn test_kernel_no_uninhabitable_with_only_two_legs() {
         let mut kernel = Kernel::capability_only(permissive_no_static_obligations());
         // untrusted_content + GitPush (not omnibus) → only 2/3, no block
@@ -1802,6 +1810,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)] // Migration to decide_term tracked in #1194
     fn test_kernel_denies_when_capability_is_never() {
         let mut kernel = Kernel::new(PermissionLattice::read_only());
         // read_only blocks writes
@@ -1813,6 +1822,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)] // Migration to decide_term tracked in #1194
     fn test_kernel_trace_is_append_only() {
         let mut kernel = Kernel::new(permissive_no_static_obligations());
         kernel.decide(Operation::ReadFiles, "a.rs");
@@ -1826,6 +1836,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)] // Migration to decide_term tracked in #1194
     fn test_kernel_approval_flow() {
         let mut kernel = Kernel::capability_only(permissive_no_static_obligations());
         kernel.decide(Operation::ReadFiles, "data.txt");
@@ -1843,6 +1854,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)] // Migration to decide_term tracked in #1194
     fn test_kernel_static_obligations_on_permissive() {
         // The permissive lattice has all capabilities, so uninhabitable_state normalization
         // adds static obligations on exfil operations (RunBash, GitPush, CreatePr).
@@ -1864,6 +1876,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)] // Migration to decide_term tracked in #1194
     fn test_kernel_glob_grep_contribute_private_data() {
         let mut kernel = Kernel::new(permissive_no_static_obligations());
         let (d, _token) = kernel.decide(Operation::GlobSearch, "**/*.py");
@@ -1873,6 +1886,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)] // Migration to decide_term tracked in #1194
     fn test_kernel_web_search_contributes_untrusted_content() {
         let mut kernel = Kernel::new(permissive_no_static_obligations());
         let (d, _token) = kernel.decide(Operation::WebSearch, "how to exfiltrate");
@@ -1880,6 +1894,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)] // Migration to decide_term tracked in #1194
     fn test_kernel_grep_websearch_run_scenario() {
         // Real scenario: agent greps code, searches web, tries to run a command
         let mut kernel = Kernel::capability_only(permissive_no_static_obligations());
@@ -1946,6 +1961,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)] // Migration to decide_term tracked in #1194
     fn test_budget_exhaustion_denies_next_operation() {
         use portcullis::BudgetLattice;
         // Create a lattice with a tiny budget ($0.05)
@@ -2029,6 +2045,7 @@ mod tests {
     // ── Trace writer tests ──────────────────────────────────────────────
 
     #[test]
+    #[allow(deprecated)] // Migration to decide_term tracked in #1194
     fn test_trace_writer_none_is_noop() {
         let trace = TraceWriter::open(None).unwrap();
         assert!(trace.file.is_none());
@@ -2040,6 +2057,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)] // Migration to decide_term tracked in #1194
     fn test_trace_writer_records_decisions_as_jsonl() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("trace.jsonl");
@@ -2068,6 +2086,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)] // Migration to decide_term tracked in #1194
     fn test_trace_writer_finish_writes_summary() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("trace.jsonl");
@@ -2090,6 +2109,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)] // Migration to decide_term tracked in #1194
     fn test_trace_writer_denied_operations_recorded() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("trace.jsonl");
@@ -2106,6 +2126,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)] // Migration to decide_term tracked in #1194
     fn test_trace_writer_appends_to_existing_file() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("trace.jsonl");

--- a/crates/nucleus-tool-proxy/src/main.rs
+++ b/crates/nucleus-tool-proxy/src/main.rs
@@ -2005,6 +2005,7 @@ fn check_identity_policy(
     !requires_approval
 }
 
+#[allow(deprecated)] // Migration to decide_term tracked in #1194
 async fn read_file(
     State(state): State<AppState>,
     _headers: HeaderMap,
@@ -2132,6 +2133,7 @@ async fn read_file(
     Ok(Json(ReadResponse { contents }))
 }
 
+#[allow(deprecated)] // Migration to decide_term tracked in #1194
 async fn write_file(
     State(state): State<AppState>,
     _headers: HeaderMap,
@@ -2262,6 +2264,7 @@ async fn write_file(
     Ok(Json(WriteResponse { ok: true }))
 }
 
+#[allow(deprecated)] // Migration to decide_term tracked in #1194
 async fn run_command(
     State(state): State<AppState>,
     _headers: HeaderMap,
@@ -2438,6 +2441,7 @@ async fn run_command(
     }))
 }
 
+#[allow(deprecated)] // Migration to decide_term tracked in #1194
 async fn web_fetch(
     State(state): State<AppState>,
     _headers: HeaderMap,
@@ -2662,6 +2666,7 @@ async fn web_fetch(
 }
 
 /// Glob pattern search within the sandbox.
+#[allow(deprecated)] // Migration to decide_term tracked in #1194
 async fn glob_search(
     State(state): State<AppState>,
     _headers: HeaderMap,
@@ -2838,6 +2843,7 @@ async fn glob_search(
 }
 
 /// Grep (regex content search) within the sandbox.
+#[allow(deprecated)] // Migration to decide_term tracked in #1194
 async fn grep_search(
     State(state): State<AppState>,
     _headers: HeaderMap,
@@ -3072,6 +3078,7 @@ async fn grep_search(
 }
 
 /// Web search using configured backend.
+#[allow(deprecated)] // Migration to decide_term tracked in #1194
 async fn web_search(
     State(state): State<AppState>,
     _headers: HeaderMap,

--- a/crates/nucleus-tool-proxy/src/mcp.rs
+++ b/crates/nucleus-tool-proxy/src/mcp.rs
@@ -160,6 +160,7 @@ impl NucleusMcpServer {
     /// Check the kernel for a decision on the given operation/subject.
     ///
     /// Returns `Ok(DecisionToken)` if allowed, or an MCP error result for deny/approval.
+    #[allow(deprecated)] // Migration to decide_term tracked in #1194
     async fn kernel_decide(
         &self,
         operation: Operation,

--- a/crates/nucleus-tool-proxy/tests/roguepilot_integration.rs
+++ b/crates/nucleus-tool-proxy/tests/roguepilot_integration.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 //! RoguePilot Integration Tests
 //!
 //! End-to-end tests verifying that the nucleus security stack blocks

--- a/crates/nucleus/src/command.rs
+++ b/crates/nucleus/src/command.rs
@@ -683,6 +683,7 @@ mod tests {
     }
 
     /// Helper: get a DecisionToken for RunBash from a kernel matching the test policy.
+    #[allow(deprecated)] // Migration to decide_term tracked in #1194
     fn run_token(kernel: &mut Kernel, subject: &str) -> DecisionToken {
         let (_decision, tok) = kernel.decide(Operation::RunBash, subject);
         tok.expect("test kernel should allow RunBash")
@@ -747,6 +748,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)] // Migration to decide_term tracked in #1194
     fn test_never_capability() {
         let tmp = tempdir().unwrap();
         let mut policy = test_policy();

--- a/crates/nucleus/src/sandbox.rs
+++ b/crates/nucleus/src/sandbox.rs
@@ -753,6 +753,7 @@ mod tests {
     }
 
     /// Helper: get a DecisionToken from a permissive kernel for a given operation.
+    #[allow(deprecated)] // Migration to decide_term tracked in #1194
     fn token(kernel: &mut Kernel, op: Operation, subject: &str) -> DecisionToken {
         let (_decision, tok) = kernel.decide(op, subject);
         tok.expect("permissive kernel should allow this operation")
@@ -800,6 +801,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)] // Migration to decide_term tracked in #1194
     fn test_write_requires_capability() {
         let tmp = tempdir().unwrap();
         let mut policy = permissive_policy();
@@ -822,6 +824,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)] // Migration to decide_term tracked in #1194
     fn test_write_requires_approval() {
         let tmp = tempdir().unwrap();
         let mut policy = permissive_policy();

--- a/crates/portcullis/src/kani.rs
+++ b/crates/portcullis/src/kani.rs
@@ -1648,6 +1648,7 @@ fn proof_nucleus_counterexample_witness() {
 /// trace entry and update exposure tracking.
 #[kani::proof]
 #[kani::solver(cadical)]
+#[allow(deprecated)] // Migration to decide_term tracked in #1194
 fn proof_decision_token_unforgeable() {
     let perms = PermissionLattice::permissive();
     let mut kernel = Kernel::new(perms);
@@ -1671,6 +1672,7 @@ fn proof_decision_token_unforgeable() {
 /// is Deny then no token is produced.
 #[kani::proof]
 #[kani::solver(cadical)]
+#[allow(deprecated)] // Migration to decide_term tracked in #1194
 fn proof_denied_ops_have_no_token() {
     let perms = PermissionLattice::restrictive();
     let mut kernel = Kernel::new(perms);
@@ -1687,6 +1689,7 @@ fn proof_denied_ops_have_no_token() {
 /// `sequence()` must match the decision's fields exactly.
 #[kani::proof]
 #[kani::solver(cadical)]
+#[allow(deprecated)] // Migration to decide_term tracked in #1194
 fn proof_token_operation_matches_decision() {
     let perms = PermissionLattice::permissive();
     let mut kernel = Kernel::new(perms);
@@ -1733,6 +1736,7 @@ fn proof_issue_approved_token_is_audited() {
 /// audited and exposure-tracked.
 #[kani::proof]
 #[kani::solver(cadical)]
+#[allow(deprecated)] // Migration to decide_term tracked in #1194
 fn proof_approved_token_bypass_is_audited() {
     let perms = PermissionLattice::restrictive();
     let mut kernel = Kernel::new(perms);
@@ -2089,6 +2093,7 @@ fn proof_chain_depth_rejects_deep() {
 /// the I/O surface beyond what the policy permits.
 #[kani::proof]
 #[kani::solver(cadical)]
+#[allow(deprecated)] // Migration to decide_term tracked in #1194
 fn proof_io_confinement_never_capability_blocks() {
     let op_idx: u8 = kani::any();
     kani::assume(op_idx < 13);

--- a/crates/portcullis/src/kernel.rs
+++ b/crates/portcullis/src/kernel.rs
@@ -901,6 +901,7 @@ impl Kernel {
         // intrinsic, so `cache.join(intrinsic)` is a no-op after
         // `cache.join(propagated)`.
         self.recompute_flow_label(flow_decision.label);
+        #[allow(deprecated)] // decide_with_parents delegates to decide; migration via decide_term
         let mut result = self.decide(operation, subject);
 
         result.0.flow_node_id = Some(flow_decision.node_id);
@@ -1050,6 +1051,12 @@ impl Kernel {
     /// only when the verdict is `Allow`, providing a linear proof that the
     /// operation was authorized. The token is non-Clone, non-Copy, and
     /// `#[must_use]` — it must be consumed by executing the authorized operation.
+    #[deprecated(
+        since = "1.1.0",
+        note = "use `decide_term()` instead — it runs obligation discharge, task scope checking, \
+                and causal ancestry validation. `decide()` bypasses all of these. \
+                See #1194 for migration guide."
+    )]
     pub fn decide(
         &mut self,
         operation: Operation,
@@ -1524,6 +1531,7 @@ impl Kernel {
         let preflight =
             crate::action_term::preflight_action(&term, &PreflightContext::new(&self.effective));
 
+        #[allow(deprecated)] // decide_term delegates to decide; this is the migration bridge
         let (mut decision, token) = match preflight.verdict {
             PreflightVerdict::Pass => self.decide(operation, &subject),
             PreflightVerdict::RequiresApproval => {

--- a/crates/portcullis/src/kernel_tests.rs
+++ b/crates/portcullis/src/kernel_tests.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)] // Tests exercise both decide() and decide_term(); migration tracked in #1194
+
 use super::*;
 use crate::{CapabilityLevel, PermissionLattice};
 

--- a/crates/portcullis/tests/attack_landscape.rs
+++ b/crates/portcullis/tests/attack_landscape.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 //! Attack Landscape Integration Tests
 //!
 //! This test suite verifies defense against real-world AI agent attack classes.

--- a/crates/portcullis/tests/kernel_delegation.rs
+++ b/crates/portcullis/tests/kernel_delegation.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 //! Delegation constraint enforcement tests (#779) — extracted from kernel.rs.
 //!
 //! These tests verify that the kernel enforces delegation constraints on

--- a/crates/portcullis/tests/kernel_egress.rs
+++ b/crates/portcullis/tests/kernel_egress.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 //! Egress policy integration tests — extracted from kernel.rs (#825).
 //!
 //! These tests verify that the kernel correctly enforces egress policies

--- a/crates/portcullis/tests/kernel_executable_spec.rs
+++ b/crates/portcullis/tests/kernel_executable_spec.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 //! Executable Specification for the Kernel Decision Engine
 //!
 //! This module defines the kernel's intended behavior as a **reference model**

--- a/crates/portcullis/tests/kernel_policy.rs
+++ b/crates/portcullis/tests/kernel_policy.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 //! PolicyRuleSet integration tests (#657) — extracted from kernel.rs.
 //!
 //! These tests verify that the kernel enforces policy rules: allow, deny,

--- a/crates/portcullis/tests/kernel_receipt.rs
+++ b/crates/portcullis/tests/kernel_receipt.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 //! Receipt chain integration tests — extracted from kernel.rs (#825).
 //!
 //! These tests verify that the kernel correctly produces an append-only

--- a/crates/portcullis/tests/kernel_sink_scope.rs
+++ b/crates/portcullis/tests/kernel_sink_scope.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 //! Sink scope enforcement tests (#809) — extracted from kernel.rs (#825).
 //!
 //! These tests verify that the kernel enforces SinkScope constraints


### PR DESCRIPTION
## Summary

Marks `Kernel::decide(operation, subject)` as `#[deprecated]`, directing all callers to `decide_term()` which runs obligation discharge, task scope checking, and causal ancestry validation that `decide()` bypasses entirely.

## What changes

- `Kernel::decide()` now has `#[deprecated(since = "1.1.0")]` with migration message
- All **existing callers** annotated with `#[allow(deprecated)]` + migration comment:
  - 8 integration test files (file-level inner attribute)
  - Production callers in `nucleus`, `nucleus-claude-hook`, `nucleus-mcp`, `nucleus-tool-proxy`
  - Internal kernel callers (`decide_term`, `decide_with_parents`)
  - 5 kani proof functions
- **New code** calling `decide()` now fails clippy (`-D deprecated`) — enforcement is automatic

## Why this matters

Two mediation paths means the system's security property is the weaker one. While `decide()` exists without a deprecation warning, new contributors will use it — it's simpler and doesn't require constructing an `ActionTerm`. The deprecation makes the risk visible at compile time and guides callers to the secure path.

## Test plan

- [x] 876 portcullis lib tests pass
- [x] Clippy clean across entire workspace
- [x] All pre-push hooks pass

Closes #1194

🤖 Generated with [Claude Code](https://claude.com/claude-code)