### PR TITLE
feat: emit ActionTerms from hook and MCP surfaces (#1187)

### DIFF
--- a/crates/nucleus-claude-hook/src/main.rs
+++ b/crates/nucleus-claude-hook/src/main.rs
@@ -12,6 +12,8 @@ use portcullis::kernel::{Kernel, Verdict};
 use portcullis::manifest_registry::ManifestRegistry;
 use portcullis::receipt_sign::{receipt_hash, sign_receipt};
 use portcullis::{Operation, PermissionLattice};
+
+mod term_builder;
 use portcullis_core::flow::NodeKind;
 use portcullis_core::receipt::build_receipt;
 use ring::rand::SystemRandom;
@@ -1234,7 +1236,8 @@ fn main() {
     let mut leaves = LeafTracker::default();
     for (op_str, subj) in &session.allowed_ops {
         if let Ok(op) = Operation::try_from(op_str.as_str()) {
-            kernel.decide(op, subj);
+            let term = term_builder::build_action_term(op, subj);
+            kernel.decide_term(term);
         }
     }
     for &(kind_u8, ref _op_str, ref _subj) in &session.flow_observations {

--- a/crates/nucleus-claude-hook/src/term_builder.rs
+++ b/crates/nucleus-claude-hook/src/term_builder.rs
@@ -1,0 +1,63 @@
+//! ActionTerm construction from legacy `(Operation, subject)` pairs (#1187).
+
+use portcullis::action_term::{
+    ActionTerm, CapabilityRequest, EffectDisposition, PrimitiveAction, ProposedEffect,
+};
+use portcullis::{CapabilityLevel, Operation};
+
+/// Build an [`ActionTerm`] from an `(Operation, subject)` pair.
+///
+/// Shared helper for converting the legacy `(Operation, &str)` call pattern
+/// to the term-first pipeline.
+pub fn build_action_term(operation: Operation, subject: &str) -> ActionTerm {
+    let action = match operation {
+        Operation::ReadFiles => PrimitiveAction::ReadFile {
+            path: subject.to_string(),
+        },
+        Operation::WriteFiles => PrimitiveAction::WriteFile {
+            path: subject.to_string(),
+        },
+        Operation::EditFiles => PrimitiveAction::EditFile {
+            path: subject.to_string(),
+            patch: String::new(),
+        },
+        Operation::RunBash => PrimitiveAction::RunCommand {
+            command: subject.to_string(),
+        },
+        Operation::GlobSearch | Operation::GrepSearch => PrimitiveAction::GlobSearch {
+            pattern: subject.to_string(),
+        },
+        Operation::WebSearch => PrimitiveAction::WebSearch {
+            query: subject.to_string(),
+        },
+        Operation::WebFetch => PrimitiveAction::WebFetch {
+            url: subject.to_string(),
+        },
+        Operation::GitCommit => PrimitiveAction::GitCommit {
+            message: subject.to_string(),
+        },
+        Operation::GitPush => PrimitiveAction::GitPush {
+            remote: subject.to_string(),
+            branch: String::new(),
+        },
+        Operation::CreatePr => PrimitiveAction::CreatePr {
+            title: subject.to_string(),
+        },
+        Operation::ManagePods | Operation::SpawnAgent => PrimitiveAction::SpawnAgent {
+            endpoint: subject.to_string(),
+            payload_bytes: 0,
+        },
+    };
+
+    ActionTerm {
+        task: None,
+        action,
+        inputs: vec![],
+        authority: CapabilityRequest::new(operation, CapabilityLevel::LowRisk),
+        proposed_effect: ProposedEffect::CommandExecution {
+            command: subject.to_string(),
+            disposition: EffectDisposition::Proposed,
+        },
+        obligations: vec![], // derive_obligations() is authoritative
+    }
+}

--- a/crates/nucleus-tool-proxy/src/mcp.rs
+++ b/crates/nucleus-tool-proxy/src/mcp.rs
@@ -11,6 +11,9 @@
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
+use portcullis::action_term::{
+    ActionTerm, CapabilityRequest, EffectDisposition, PrimitiveAction, ProposedEffect,
+};
 use portcullis::kernel::{Kernel, Verdict};
 use portcullis::verdict_sink::{ActorIdentity, VerdictContext, VerdictOutcome, VerdictSink};
 use portcullis::{CapabilityLevel, GradedExposureGuard, Operation, ToolCallGuard};
@@ -159,15 +162,17 @@ impl NucleusMcpServer {
 
     /// Check the kernel for a decision on the given operation/subject.
     ///
-    /// Returns `Ok(DecisionToken)` if allowed, or an MCP error result for deny/approval.
-    #[allow(deprecated)] // Migration to decide_term tracked in #1194
+    /// Constructs an [`ActionTerm`] and routes through [`Kernel::decide_term`],
+    /// which runs obligation discharge, task scope checking, and causal ancestry
+    /// validation (#1187). The old `Kernel::decide()` path is bypassed entirely.
     async fn kernel_decide(
         &self,
         operation: Operation,
         subject: &str,
     ) -> Result<portcullis::kernel::DecisionToken, CallToolResult> {
+        let term = build_action_term(operation, subject);
         let mut kernel = self.kernel.lock().await;
-        let (decision, token) = kernel.decide(operation, subject);
+        let (decision, token) = kernel.decide_term(term);
         match decision.verdict {
             Verdict::Allow => Ok(token.expect("Allow verdict always produces token")),
             Verdict::Deny(ref reason) => {
@@ -977,4 +982,64 @@ pub async fn run_mcp_server(state: Arc<AppState>) -> Result<(), crate::ApiError>
         .map_err(|e| crate::ApiError::Spec(format!("MCP server error: {e}")))?;
 
     Ok(())
+}
+
+/// Build an [`ActionTerm`] from an `(Operation, subject)` pair.
+///
+/// Maps each operation to its corresponding [`PrimitiveAction`] variant
+/// and constructs a minimal term for kernel evaluation (#1187).
+fn build_action_term(operation: Operation, subject: &str) -> ActionTerm {
+    let action = match operation {
+        Operation::ReadFiles => PrimitiveAction::ReadFile {
+            path: subject.to_string(),
+        },
+        Operation::WriteFiles => PrimitiveAction::WriteFile {
+            path: subject.to_string(),
+        },
+        Operation::EditFiles => PrimitiveAction::EditFile {
+            path: subject.to_string(),
+            patch: String::new(),
+        },
+        Operation::RunBash => PrimitiveAction::RunCommand {
+            command: subject.to_string(),
+        },
+        Operation::GlobSearch => PrimitiveAction::GlobSearch {
+            pattern: subject.to_string(),
+        },
+        Operation::GrepSearch => PrimitiveAction::GlobSearch {
+            pattern: subject.to_string(),
+        },
+        Operation::WebSearch => PrimitiveAction::WebSearch {
+            query: subject.to_string(),
+        },
+        Operation::WebFetch => PrimitiveAction::WebFetch {
+            url: subject.to_string(),
+        },
+        Operation::GitCommit => PrimitiveAction::GitCommit {
+            message: subject.to_string(),
+        },
+        Operation::GitPush => PrimitiveAction::GitPush {
+            remote: subject.to_string(),
+            branch: String::new(),
+        },
+        Operation::CreatePr => PrimitiveAction::CreatePr {
+            title: subject.to_string(),
+        },
+        Operation::ManagePods | Operation::SpawnAgent => PrimitiveAction::SpawnAgent {
+            endpoint: subject.to_string(),
+            payload_bytes: 0,
+        },
+    };
+
+    ActionTerm {
+        task: None,
+        action,
+        inputs: vec![],
+        authority: CapabilityRequest::new(operation, CapabilityLevel::LowRisk),
+        proposed_effect: ProposedEffect::CommandExecution {
+            command: subject.to_string(),
+            disposition: EffectDisposition::Proposed,
+        },
+        obligations: vec![], // derive_obligations() is authoritative
+    }
 }


### PR DESCRIPTION
## Summary

Converts the two production call sites from deprecated `Kernel::decide()` to `Kernel::decide_term()`, making the term-first pipeline live in practice:

1. **`nucleus-tool-proxy/src/mcp.rs:kernel_decide()`** — the single choke point for ALL MCP tool calls now builds an `ActionTerm` via `build_action_term()` and routes through `decide_term()`, which runs obligation discharge, task scope, and causal ancestry checks
2. **`nucleus-claude-hook/src/main.rs` replay loop** — session history replay constructs ActionTerms via `term_builder::build_action_term()`

## Impact

Before: `decide_term()` was dead code — the hook and MCP surfaces called `decide()` directly, bypassing obligation discharge.

After: every tool call through the MCP surface and every replayed operation in the hook goes through the term-first pipeline. Audit output now carries `action_term` and `preflight_result` fields.

## Test plan

- [x] 223 nucleus-claude-hook tests pass
- [x] 8 nucleus-tool-proxy tests + 1 sandbox integration test pass
- [x] Pre-push hooks (clippy, fmt, deny, audit, line ratchet) all pass

Closes #1187

🤖 Generated with [Claude Code](https://claude.com/claude-code)