### PR TITLE
docs: add Known Gaps section to Verified Claims page (#1252)

### DIFF
--- a/docs/verified-claims.md
+++ b/docs/verified-claims.md
@@ -206,6 +206,40 @@ No code that breaks a verified claim can reach `main`.
 
 ---
 
+## Known Gaps
+
+The claims above hold for code paths that go through `PolicyEnforced` or
+`NucleusRuntime`. The following gaps mean they do not hold universally:
+
+### Enforcement completeness ([#1216](https://github.com/coproduct-opensource/nucleus/issues/1216))
+
+146 call sites in `nucleus-claude-hook` and `nucleus-mcp` call `std::fs`,
+`std::process::Command`, and `reqwest` directly, bypassing the `PolicyEnforced`
+effect layer. The effect layer exists and is verified, but is not structurally
+required at every I/O site. Migration is tracked in #1216.
+
+**Impact:** An operation routed through these 146 call sites gets capability
+checking via `Kernel::decide_term()` (which runs obligation discharge), but does
+NOT get the `PolicyEnforced` effect wrapper. A bug in the call site code could
+perform I/O without any policy gate.
+
+### NucleusRuntime escape hatch ([#1248](https://github.com/coproduct-opensource/nucleus/issues/1248))
+
+`NucleusRuntime::effects()` returns a raw `PolicyEnforced` bundle that checks
+capabilities but does NOT run obligation discharge or update the FlowTracker.
+The mediated methods (`read_file`, `write_file`, etc.) compose all three layers.
+A developer who discovers `.effects()` first uses the weaker path.
+
+### Type-level IFC not composed into runtime ([#1249](https://github.com/coproduct-opensource/nucleus/issues/1249))
+
+`NucleusRuntime::read_file()` returns `Vec<u8>`, not `Labeled<Vec<u8>, Trusted,
+Internal>`. The compile-time IFC layer (`Labeled<T, I, C>`) and the runtime IFC
+layer (`FlowTracker`) are independently correct but not composed at the API
+boundary. Agents using `NucleusRuntime` get runtime tracking but not compile-time
+enforcement of IFC constraints.
+
+---
+
 ## Verification coverage summary
 
 | Layer | Tool | Harnesses | Scope |


### PR DESCRIPTION
## Summary

Adds a "Known Gaps" section to `docs/verified-claims.md` documenting three areas where the verified claims do not hold universally:

1. **Enforcement completeness (#1216)** — 146 direct I/O call sites bypass `PolicyEnforced`
2. **NucleusRuntime escape hatch (#1248)** — `.effects()` skips discharge + IFC
3. **Type-level IFC not composed (#1249)** — mediated methods return bare types

Each gap links to its tracking issue and explains the concrete impact.

## Why

An auditor reading the Verified Claims page might reasonably conclude the safety properties hold end-to-end. This section makes the boundaries explicit.

## Test plan

- [x] No code changes — pre-push hooks pass

Closes #1252

🤖 Generated with [Claude Code](https://claude.com/claude-code)