### PR TITLE
fix(portcullis-core): FlowTracker next_id overflow returns error (#1226, #1235)

### DIFF
--- a/crates/portcullis-core/src/ifc_api.rs
+++ b/crates/portcullis-core/src/ifc_api.rs
@@ -65,6 +65,8 @@ pub enum FlowError {
     ParentNotFound(u64),
     /// Too many parents (max 8).
     TooManyParents(usize),
+    /// Node ID space exhausted — cannot allocate more node IDs (#1226, #1235).
+    IdSpaceExhausted,
 }
 
 impl std::fmt::Display for FlowError {
@@ -72,6 +74,7 @@ impl std::fmt::Display for FlowError {
         match self {
             Self::ParentNotFound(id) => write!(f, "parent node {id} not found"),
             Self::TooManyParents(n) => write!(f, "too many parents: {n} (max 8)"),
+            Self::IdSpaceExhausted => write!(f, "node ID space exhausted (u64 overflow)"),
         }
     }
 }
@@ -201,7 +204,10 @@ impl FlowTracker {
         }
 
         let id = self.next_id;
-        self.next_id += 1;
+        self.next_id = self
+            .next_id
+            .checked_add(1)
+            .ok_or(FlowError::IdSpaceExhausted)?;
         // Raise the session taint ceiling: join is monotone so this never decreases.
         self.session_taint_ceiling = self.session_taint_ceiling.join(label.derivation);
         // Raise the session confidentiality ceiling (#1208): max is monotone.
@@ -1080,5 +1086,33 @@ mod tests {
         let secret = t.observe(NodeKind::Secret).unwrap(); // NoAuthority, Secret, Trusted
         let check = t.check_exfiltration_safety(secret, true, ConfLevel::Secret);
         assert!(matches!(check, SafetyCheck::InsufficientAuthority { .. }));
+    }
+
+    // ── FlowTracker next_id overflow tests (#1226, #1235) ───────────────
+
+    #[test]
+    fn next_id_overflow_returns_error_not_wrap() {
+        // #1226/#1235: next_id at u64::MAX should fail, not wrap to 0.
+        let mut t = FlowTracker::new();
+        // Force next_id to u64::MAX (just before overflow)
+        t.next_id = u64::MAX;
+        let result = t.observe(NodeKind::FileRead);
+        assert!(
+            matches!(result, Err(FlowError::IdSpaceExhausted)),
+            "expected IdSpaceExhausted, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn next_id_near_max_still_works() {
+        // ID u64::MAX - 1 is the last valid allocation.
+        let mut t = FlowTracker::new();
+        t.next_id = u64::MAX - 1;
+        // This should succeed — assigns ID = u64::MAX - 1, increments to u64::MAX
+        let result = t.observe(NodeKind::FileRead);
+        assert!(result.is_ok());
+        // Next allocation would overflow — should fail
+        let result2 = t.observe(NodeKind::FileRead);
+        assert!(matches!(result2, Err(FlowError::IdSpaceExhausted)));
     }
 }


### PR DESCRIPTION
## Summary

Replaces `self.next_id += 1` with `checked_add(1).ok_or(FlowError::IdSpaceExhausted)`.

## Bug

At `u64::MAX`, wrapping increment produces:
- **#1226**: wraps to 0 (sentinel) — sentinel ID enters the valid range
- **#1235**: wraps to 1 — collides with the first real node; `node_entry(1)` returns the old node's label, potentially allowing a tainted node to inherit a clean label

## Fix

`checked_add` returns `None` on overflow → `FlowError::IdSpaceExhausted`. While u64 exhaustion is infeasible in practice (~18 quintillion nodes), for a security kernel this class of bug should be impossible by construction.

## Test plan

- [x] 2 new tests: overflow at MAX returns error, near-MAX last valid allocation works
- [x] 50 ifc_api tests pass

Closes #1226, Closes #1235

🤖 Generated with [Claude Code](https://claude.com/claude-code)