### PR TITLE
fix(portcullis-core): TaskScopePolicy closed-world default for unknown ops (#1231)

### DIFF
--- a/crates/portcullis-core/src/task_shield.rs
+++ b/crates/portcullis-core/src/task_shield.rs
@@ -286,8 +286,17 @@ impl PolicyCheck for TaskScopePolicy {
         // Resolve the concrete operation from the request string.
         let op = match op_from_str(&req.operation) {
             Some(o) => o,
-            // Unknown operation string → abstain; let the next check decide.
-            None => return CheckResult::Abstain,
+            // Closed-world default (#1231): unknown operations require approval
+            // rather than silently passing through. An unrecognized operation
+            // string means either a new tool was added without updating op_from_str,
+            // or the caller is probing for bypass vectors.
+            None => {
+                return CheckResult::RequiresApproval(format!(
+                    "task-shield[{:?}]: unrecognized operation '{}' — \
+                     not in scope, requires approval",
+                    self.kind, req.operation
+                ));
+            }
         };
 
         // DocsEdit path-sensitive rule: writing outside docs paths → approval.
@@ -570,10 +579,18 @@ mod tests {
     }
 
     #[test]
-    fn unknown_operation_abstains() {
+    fn unknown_operation_requires_approval() {
+        // #1231: closed-world default — unknown ops require approval, not abstain.
         let policy = TaskScopePolicy::new(TaskKind::BugFix);
         let result = policy.check(&req("unknown_op"));
-        assert_eq!(result, CheckResult::Abstain);
+        assert!(
+            matches!(result, CheckResult::RequiresApproval(_)),
+            "unknown op should require approval, got: {result:?}"
+        );
+        if let CheckResult::RequiresApproval(msg) = &result {
+            assert!(msg.contains("unrecognized"));
+            assert!(msg.contains("unknown_op"));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Changes `TaskScopePolicy` from open-world (unknown ops → Abstain) to closed-world (unknown ops → RequiresApproval).

## Bug

Any operation string not in `op_from_str` silently abstained, letting it pass through the pipeline unchecked. New operations added to the system without updating `op_from_str` bypassed task-scope enforcement entirely.

## Fix

Unknown operations now return `RequiresApproval` with a message naming the unrecognized operation and requiring human approval. This is the defense-in-depth posture: unknown = untrusted.

## Test plan

- [x] Updated test `unknown_operation_requires_approval` verifies closed-world behavior
- [x] 25 task_shield tests pass
- [x] Pre-push hooks all pass

Closes #1231

🤖 Generated with [Claude Code](https://claude.com/claude-code)