### PR TITLE
docs: classify hook I/O as permanent exemptions (#1216 chunk 6)

### DIFF
--- a/crates/nucleus-claude-hook/src/build.rs
+++ b/crates/nucleus-claude-hook/src/build.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::disallowed_types)] // #1216: migration pending
+#![allow(clippy::disallowed_types)] // #1216 exempt: manifest compilation runs before kernel initialization
 //! `nucleus-claude-hook --build` — compile `.nucleus/` into a content-addressable artifact.
 //!
 //! Reads the Compartmentfile, optional policy/egress/enterprise TOML files,

--- a/crates/nucleus-claude-hook/src/c2pa_output.rs
+++ b/crates/nucleus-claude-hook/src/c2pa_output.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::disallowed_types)] // #1216: migration pending
+#![allow(clippy::disallowed_types)] // #1216 exempt: C2PA sidecar output is post-decision audit infrastructure
 //! C2PA sidecar emission for provenance output (#1017).
 //!
 //! After `provenance-output.json` is written at SessionEnd, this module

--- a/crates/nucleus-claude-hook/src/commands.rs
+++ b/crates/nucleus-claude-hook/src/commands.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::disallowed_types)] // #1216: migration pending
+#![allow(clippy::disallowed_types)] // #1216 exempt: CLI session reset is operator-initiated, not agent-initiated
 //! CLI subcommand handlers.
 //!
 //! Extracted from main.rs to stay under the line ratchet ceiling.

--- a/crates/nucleus-claude-hook/src/config.rs
+++ b/crates/nucleus-claude-hook/src/config.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::disallowed_types)] // #1216: migration pending
+#![allow(clippy::disallowed_types)] // #1216 exempt: reads policy config before kernel exists
 //! Profile resolution and config loading.
 //!
 //! Extracted from main.rs to stay under the line ratchet ceiling.

--- a/crates/nucleus-claude-hook/src/doctor.rs
+++ b/crates/nucleus-claude-hook/src/doctor.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::disallowed_types)] // #1216: migration pending
+#![allow(clippy::disallowed_types)] // #1216 exempt: diagnostic CLI command, not agent-accessible
 //! `--doctor` diagnostic command — checks hook installation health.
 
 use crate::session::session_dir;

--- a/crates/nucleus-claude-hook/src/integrity.rs
+++ b/crates/nucleus-claude-hook/src/integrity.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::disallowed_types)] // #1216: migration pending
+#![allow(clippy::disallowed_types)] // #1216 exempt: binary validation at startup, before any agent interaction
 //! Binary self-integrity verification (#946).
 //!
 //! At startup, compute SHA-256 of the running binary and compare against

--- a/crates/nucleus-claude-hook/src/main.rs
+++ b/crates/nucleus-claude-hook/src/main.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::disallowed_types)] // #1216: migration pending
+#![allow(clippy::disallowed_types)] // #1216 exempt: session state + receipt persistence (post-decision infrastructure)
 //! Claude Code PreToolUse hook backed by the Nucleus verified permission kernel.
 //!
 //! This binary reads JSON from stdin (Claude Code hook protocol), runs the

--- a/crates/nucleus-claude-hook/src/receipts.rs
+++ b/crates/nucleus-claude-hook/src/receipts.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::disallowed_types)] // #1216: migration pending
+#![allow(clippy::disallowed_types)] // #1216 exempt: audit trail persistence — output of policy decisions, not input
 //! Receipt persistence — append-only JSONL audit trail.
 //!
 //! Extracted from `main.rs` to reduce module size.

--- a/crates/nucleus-claude-hook/src/session.rs
+++ b/crates/nucleus-claude-hook/src/session.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::disallowed_types)] // #1216: migration pending
+#![allow(clippy::disallowed_types)] // #1216 exempt: session state management (lock files, HWM, compartments)
 //! Session state persistence for cross-invocation exposure tracking.
 //!
 //! This module handles all session lifecycle concerns:

--- a/crates/nucleus-claude-hook/src/setup.rs
+++ b/crates/nucleus-claude-hook/src/setup.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::disallowed_types)] // #1216: migration pending
+#![allow(clippy::disallowed_types)] // #1216 exempt: CLI --setup command, operator-initiated
 //! `--setup` and `--uninstall` commands for managing Claude Code integration.
 
 use crate::session::session_dir;

--- a/crates/nucleus-claude-hook/src/status.rs
+++ b/crates/nucleus-claude-hook/src/status.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::disallowed_types)] // #1216: migration pending
+#![allow(clippy::disallowed_types)] // #1216 exempt: diagnostic CLI command, not agent-accessible
 //! `nucleus-claude-hook --status` — rich, parseable session & config summary.
 //!
 //! Replaces the minimal status output with structured information about


### PR DESCRIPTION
## Summary

Replaces all 11 generic "migration pending" comments in nucleus-claude-hook with specific exemption reasons. The hook is the PreToolUse **gate**, not the tool **executor** — its I/O is infrastructure (config loading, receipt persistence, session state), not agent-initiated tool access.

## Key insight

The 104 I/O calls in nucleus-claude-hook were initially counted as "bypass sites" but they are ALL legitimate infrastructure:
- Pre-kernel: config/manifest loading (needed to BUILD the kernel)
- Post-decision: receipt persistence (OUTPUT of policy decisions)
- Session: state management (locks, HWM, compartments)
- CLI: operator commands (setup, doctor, status)

None of these are agent-initiated tool calls that should go through PolicyEnforced.

The real enforcement target is **nucleus-tool-proxy** (33 calls), where actual file reads, shell commands, and web fetches happen on behalf of agents.

## Test plan

- [x] 223 hook tests pass
- [x] Pre-push hooks pass

Partial progress on #1216

🤖 Generated with [Claude Code](https://claude.com/claude-code)