### PR TITLE
docs: classify tool-proxy I/O — 6 exempt, 1 migration target (#1276)

### DIFF
--- a/crates/nucleus-tool-proxy/src/exit_report.rs
+++ b/crates/nucleus-tool-proxy/src/exit_report.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::disallowed_types)] // #1216: migration pending
+#![allow(clippy::disallowed_types)] // #1216 exempt: exit report collection is post-decision infrastructure
 //! Exit report generation for execution receipts.
 //!
 //! Before shutdown, the tool-proxy computes a workspace content hash and

--- a/crates/nucleus-tool-proxy/src/main.rs
+++ b/crates/nucleus-tool-proxy/src/main.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::disallowed_types)] // #1216: migration pending
+#![allow(clippy::disallowed_types)] // #1216 exempt: pod setup, web client init, spec loading (infrastructure)
 use std::collections::{BTreeMap, HashMap};
 use std::io::{Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};

--- a/crates/nucleus-tool-proxy/src/mcp.rs
+++ b/crates/nucleus-tool-proxy/src/mcp.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::disallowed_types)] // #1216: migration pending
+#![allow(clippy::disallowed_types)] // #1216 MIGRATION TARGET: agent-facing file/glob I/O (#1273)
 //! MCP server mode for nucleus-tool-proxy.
 //!
 //! When `--mcp` is passed, the tool-proxy serves the Model Context Protocol

--- a/crates/nucleus-tool-proxy/src/node_client.rs
+++ b/crates/nucleus-tool-proxy/src/node_client.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::disallowed_types)] // #1216: migration pending
+#![allow(clippy::disallowed_types)] // #1216 exempt: node management HTTP client (infrastructure, not agent I/O)
 //! HTTP client for nucleus-node pod management.
 //!
 //! Used by orchestrator pods to create and manage sub-pods via

--- a/crates/nucleus-tool-proxy/src/pod_mgmt.rs
+++ b/crates/nucleus-tool-proxy/src/pod_mgmt.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::disallowed_types)] // #1216: migration pending
+#![allow(clippy::disallowed_types)] // #1216 exempt: vsock endpoint setup (infrastructure)
                                     // =============================================================================
                                     // Pod Management Handlers (orchestrator mode)
                                     // =============================================================================

--- a/crates/nucleus-tool-proxy/src/policy.rs
+++ b/crates/nucleus-tool-proxy/src/policy.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::disallowed_types)] // #1216: migration pending
+#![allow(clippy::disallowed_types)] // #1216 exempt: reads policy config before kernel exists
 //! Identity-based policy enforcement for tool-proxy.
 //!
 //! This module integrates SPIFFE workload identity with the portcullis

--- a/crates/nucleus-tool-proxy/src/sandbox_proof.rs
+++ b/crates/nucleus-tool-proxy/src/sandbox_proof.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::disallowed_types)] // #1216: migration pending
+#![allow(clippy::disallowed_types)] // #1216 exempt: TLS cert loading at startup
 //! Cryptographic sandbox proof verification.
 //!
 //! Tool-proxy refuses to start unless it can cryptographically prove it's


### PR DESCRIPTION
## Summary

Classifies tool-proxy I/O into permanent exemptions vs migration targets:

| File | Classification | Reason |
|---|---|---|
| exit_report.rs | Exempt | Post-decision infrastructure |
| main.rs | Exempt | Pod setup, web client init |
| node_client.rs | Exempt | Node management HTTP client |
| pod_mgmt.rs | Exempt | vsock endpoint setup |
| policy.rs | Exempt | Policy config before kernel |
| sandbox_proof.rs | Exempt | TLS cert loading at startup |
| **mcp.rs** | **Migration target** | Agent-facing file/glob I/O (#1273) |

## Key insight

The real enforcement surface is **~5 call sites in mcp.rs**, not 33. The other 28 calls are infrastructure that can't be policy-gated without circular dependencies (reading policy to check policy, etc.).

Closes #1276

🤖 Generated with [Claude Code](https://claude.com/claude-code)