### PR TITLE
fix: zero raw std::fs in agent path — grep handler migrated to sandbox (#1273)

### DIFF
--- a/crates/nucleus-tool-proxy/src/mcp.rs
+++ b/crates/nucleus-tool-proxy/src/mcp.rs
@@ -681,16 +681,18 @@ impl NucleusMcpServer {
                         }
                     }
 
-                    // Read and search
-                    let contents = match std::fs::read_to_string(entry.path()) {
+                    // Read via sandbox cap-std (not raw std::fs) — #1273
+                    let relative = match canonical.strip_prefix(&sandbox_canonical) {
+                        Ok(r) => r,
+                        Err(_) => continue,
+                    };
+                    let contents = match state.runtime.sandbox().read_to_string_for_search(relative)
+                    {
                         Ok(c) => c,
                         Err(_) => continue, // Skip binary/unreadable files
                     };
 
                     let lines: Vec<&str> = contents.lines().collect();
-                    let relative = canonical
-                        .strip_prefix(&sandbox_canonical)
-                        .unwrap_or(&canonical);
 
                     for (i, line) in lines.iter().enumerate() {
                         if re.is_match(line) {

--- a/crates/nucleus/src/sandbox.rs
+++ b/crates/nucleus/src/sandbox.rs
@@ -563,6 +563,23 @@ impl Sandbox {
         &self.root_path
     }
 
+    /// Read a file for search/grep operations (#1273).
+    ///
+    /// Uses the cap-std sandbox directory for I/O, bypassing raw `std::fs`.
+    /// Does NOT require a `DecisionToken` — the caller must have already
+    /// obtained a GrepSearch decision via `kernel_decide`.
+    ///
+    /// Returns `Err` for paths outside the sandbox or unreadable files.
+    pub fn read_to_string_for_search(&self, path: &Path) -> Result<String> {
+        self.check_policy(path)?;
+        self.root
+            .read_to_string(path)
+            .map_err(|e| NucleusError::PathDenied {
+                path: path.to_path_buf(),
+                reason: e.to_string(),
+            })
+    }
+
     /// Check if a path is allowed by the policy.
     fn check_policy(&self, path: &Path) -> Result<()> {
         // First, check for obvious escapes


### PR DESCRIPTION
## Summary

Migrates the **last** raw \`std::fs::read_to_string\` call in any agent-facing tool handler to the cap-std sandbox.

## Before

The grep handler at mcp.rs:685 read file contents via \`std::fs::read_to_string(entry.path())\` — bypassing the cap-std sandbox that all other handlers (read, write, run, glob, web_fetch) already use.

## After

\`sandbox.read_to_string_for_search(relative_path)\` — routes through the same cap-std directory and policy check as every other file operation.

New method \`Sandbox::read_to_string_for_search()\` for search/grep operations: uses cap-std I/O without requiring a ReadFiles DecisionToken (the caller has a GrepSearch decision).

## Impact

**Zero raw \`std::fs\` calls remain in any agent-facing tool handler in the entire codebase.** The "enforcement completeness" gap that was 146 → 33 → 5 → 1 is now **0** for agent-facing code.

## Test plan

- [x] \`cargo build -p nucleus-tool-proxy\` — compiles clean
- [x] 1 tool-proxy test passes
- [x] Pre-push hooks all pass

Closes #1273

🤖 Generated with [Claude Code](https://claude.com/claude-code)