### PR TITLE
refactor: deduplicate build_action_term → ActionTerm::from_operation (#1292)

### DIFF
--- a/crates/nucleus-claude-hook/src/term_builder.rs
+++ b/crates/nucleus-claude-hook/src/term_builder.rs
@@ -1,63 +1,11 @@
-//! ActionTerm construction from legacy `(Operation, subject)` pairs (#1187).
+//! ActionTerm construction — delegates to the canonical `ActionTerm::from_operation`.
 
-use portcullis::action_term::{
-    ActionTerm, CapabilityRequest, EffectDisposition, PrimitiveAction, ProposedEffect,
-};
-use portcullis::{CapabilityLevel, Operation};
+pub use portcullis::action_term::ActionTerm;
+use portcullis::Operation;
 
-/// Build an [`ActionTerm`] from an `(Operation, subject)` pair.
+/// Build an ActionTerm from an (Operation, subject) pair.
 ///
-/// Shared helper for converting the legacy `(Operation, &str)` call pattern
-/// to the term-first pipeline.
+/// Thin wrapper around [`ActionTerm::from_operation`] (#1292).
 pub fn build_action_term(operation: Operation, subject: &str) -> ActionTerm {
-    let action = match operation {
-        Operation::ReadFiles => PrimitiveAction::ReadFile {
-            path: subject.to_string(),
-        },
-        Operation::WriteFiles => PrimitiveAction::WriteFile {
-            path: subject.to_string(),
-        },
-        Operation::EditFiles => PrimitiveAction::EditFile {
-            path: subject.to_string(),
-            patch: String::new(),
-        },
-        Operation::RunBash => PrimitiveAction::RunCommand {
-            command: subject.to_string(),
-        },
-        Operation::GlobSearch | Operation::GrepSearch => PrimitiveAction::GlobSearch {
-            pattern: subject.to_string(),
-        },
-        Operation::WebSearch => PrimitiveAction::WebSearch {
-            query: subject.to_string(),
-        },
-        Operation::WebFetch => PrimitiveAction::WebFetch {
-            url: subject.to_string(),
-        },
-        Operation::GitCommit => PrimitiveAction::GitCommit {
-            message: subject.to_string(),
-        },
-        Operation::GitPush => PrimitiveAction::GitPush {
-            remote: subject.to_string(),
-            branch: String::new(),
-        },
-        Operation::CreatePr => PrimitiveAction::CreatePr {
-            title: subject.to_string(),
-        },
-        Operation::ManagePods | Operation::SpawnAgent => PrimitiveAction::SpawnAgent {
-            endpoint: subject.to_string(),
-            payload_bytes: 0,
-        },
-    };
-
-    ActionTerm {
-        task: None,
-        action,
-        inputs: vec![],
-        authority: CapabilityRequest::new(operation, CapabilityLevel::LowRisk),
-        proposed_effect: ProposedEffect::CommandExecution {
-            command: subject.to_string(),
-            disposition: EffectDisposition::Proposed,
-        },
-        obligations: vec![], // derive_obligations() is authoritative
-    }
+    ActionTerm::from_operation(operation, subject)
 }

--- a/crates/nucleus-tool-proxy/src/mcp.rs
+++ b/crates/nucleus-tool-proxy/src/mcp.rs
@@ -12,9 +12,7 @@
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
-use portcullis::action_term::{
-    ActionTerm, CapabilityRequest, EffectDisposition, PrimitiveAction, ProposedEffect,
-};
+use portcullis::action_term::ActionTerm;
 use portcullis::kernel::{Kernel, Verdict};
 use portcullis::verdict_sink::{ActorIdentity, VerdictContext, VerdictOutcome, VerdictSink};
 use portcullis::{CapabilityLevel, GradedExposureGuard, Operation, ToolCallGuard};
@@ -989,60 +987,7 @@ pub async fn run_mcp_server(state: Arc<AppState>) -> Result<(), crate::ApiError>
 
 /// Build an [`ActionTerm`] from an `(Operation, subject)` pair.
 ///
-/// Maps each operation to its corresponding [`PrimitiveAction`] variant
-/// and constructs a minimal term for kernel evaluation (#1187).
+/// Delegates to the canonical [`ActionTerm::from_operation`] (#1292).
 fn build_action_term(operation: Operation, subject: &str) -> ActionTerm {
-    let action = match operation {
-        Operation::ReadFiles => PrimitiveAction::ReadFile {
-            path: subject.to_string(),
-        },
-        Operation::WriteFiles => PrimitiveAction::WriteFile {
-            path: subject.to_string(),
-        },
-        Operation::EditFiles => PrimitiveAction::EditFile {
-            path: subject.to_string(),
-            patch: String::new(),
-        },
-        Operation::RunBash => PrimitiveAction::RunCommand {
-            command: subject.to_string(),
-        },
-        Operation::GlobSearch => PrimitiveAction::GlobSearch {
-            pattern: subject.to_string(),
-        },
-        Operation::GrepSearch => PrimitiveAction::GlobSearch {
-            pattern: subject.to_string(),
-        },
-        Operation::WebSearch => PrimitiveAction::WebSearch {
-            query: subject.to_string(),
-        },
-        Operation::WebFetch => PrimitiveAction::WebFetch {
-            url: subject.to_string(),
-        },
-        Operation::GitCommit => PrimitiveAction::GitCommit {
-            message: subject.to_string(),
-        },
-        Operation::GitPush => PrimitiveAction::GitPush {
-            remote: subject.to_string(),
-            branch: String::new(),
-        },
-        Operation::CreatePr => PrimitiveAction::CreatePr {
-            title: subject.to_string(),
-        },
-        Operation::ManagePods | Operation::SpawnAgent => PrimitiveAction::SpawnAgent {
-            endpoint: subject.to_string(),
-            payload_bytes: 0,
-        },
-    };
-
-    ActionTerm {
-        task: None,
-        action,
-        inputs: vec![],
-        authority: CapabilityRequest::new(operation, CapabilityLevel::LowRisk),
-        proposed_effect: ProposedEffect::CommandExecution {
-            command: subject.to_string(),
-            disposition: EffectDisposition::Proposed,
-        },
-        obligations: vec![], // derive_obligations() is authoritative
-    }
+    ActionTerm::from_operation(operation, subject)
 }

--- a/crates/portcullis/src/action_term.rs
+++ b/crates/portcullis/src/action_term.rs
@@ -398,6 +398,65 @@ impl ActionTerm {
             _ => None,
         }
     }
+
+    /// Construct an ActionTerm from a legacy `(Operation, subject)` pair (#1292).
+    ///
+    /// Maps each Operation variant to its corresponding PrimitiveAction and
+    /// builds a minimal term for kernel evaluation. This is the canonical
+    /// conversion used by all call sites migrating from `Kernel::decide()`
+    /// to `Kernel::decide_term()`.
+    pub fn from_operation(operation: Operation, subject: &str) -> Self {
+        let action = match operation {
+            Operation::ReadFiles => PrimitiveAction::ReadFile {
+                path: subject.to_string(),
+            },
+            Operation::WriteFiles => PrimitiveAction::WriteFile {
+                path: subject.to_string(),
+            },
+            Operation::EditFiles => PrimitiveAction::EditFile {
+                path: subject.to_string(),
+                patch: String::new(),
+            },
+            Operation::RunBash => PrimitiveAction::RunCommand {
+                command: subject.to_string(),
+            },
+            Operation::GlobSearch | Operation::GrepSearch => PrimitiveAction::GlobSearch {
+                pattern: subject.to_string(),
+            },
+            Operation::WebSearch => PrimitiveAction::WebSearch {
+                query: subject.to_string(),
+            },
+            Operation::WebFetch => PrimitiveAction::WebFetch {
+                url: subject.to_string(),
+            },
+            Operation::GitCommit => PrimitiveAction::GitCommit {
+                message: subject.to_string(),
+            },
+            Operation::GitPush => PrimitiveAction::GitPush {
+                remote: subject.to_string(),
+                branch: String::new(),
+            },
+            Operation::CreatePr => PrimitiveAction::CreatePr {
+                title: subject.to_string(),
+            },
+            Operation::ManagePods | Operation::SpawnAgent => PrimitiveAction::SpawnAgent {
+                endpoint: subject.to_string(),
+                payload_bytes: 0,
+            },
+        };
+
+        Self {
+            task: None,
+            action,
+            inputs: vec![],
+            authority: CapabilityRequest::new(operation, CapabilityLevel::LowRisk),
+            proposed_effect: ProposedEffect::CommandExecution {
+                command: subject.to_string(),
+                disposition: EffectDisposition::Proposed,
+            },
+            obligations: vec![],
+        }
+    }
 }
 
 /// Pure preflight context used to validate an [`ActionTerm`].


### PR DESCRIPTION
## Summary

Moves the `Operation → PrimitiveAction` mapping from two duplicate 50-line functions to a single `ActionTerm::from_operation()` method on the canonical type.

**Before**: same match block in `nucleus-claude-hook/src/term_builder.rs` and `nucleus-tool-proxy/src/mcp.rs`. Changes to one required mirroring in the other.

**After**: one source of truth in `portcullis::action_term::ActionTerm::from_operation()`. Both callers delegate to it.

Net: -48 lines of duplicated code.

## Test plan

- [x] 18 action_term + 223 hook + 1 tool-proxy tests pass
- [x] Pre-push hooks all pass

Closes #1292

🤖 Generated with [Claude Code](https://claude.com/claude-code)