### PR TITLE
refactor: NucleusRuntime owns effects — one construction, zero per-call clones (#1293)

### DIFF
--- a/crates/portcullis-effects/src/lib.rs
+++ b/crates/portcullis-effects/src/lib.rs
@@ -457,6 +457,13 @@ impl<E: AgentSpawnEffect> AgentSpawnEffect for PolicyEnforced<E> {
 pub fn production_effects(
     policy: CapabilityLattice,
 ) -> impl FileEffect + WebEffect + ShellEffect + GitEffect + AgentSpawnEffect {
+    production_effects_concrete(policy)
+}
+
+/// Crate-internal: returns the concrete type so NucleusRuntime can store it.
+pub(crate) fn production_effects_concrete(
+    policy: CapabilityLattice,
+) -> PolicyEnforced<RealEffects> {
     PolicyEnforced {
         inner: RealEffects::new(),
         policy,

--- a/crates/portcullis-effects/src/runtime.rs
+++ b/crates/portcullis-effects/src/runtime.rs
@@ -439,6 +439,7 @@ impl From<EffectError> for RuntimeError {
 pub struct NucleusRuntime {
     profile: PolicyProfile,
     policy: CapabilityLattice,
+    effects: crate::PolicyEnforced<crate::RealEffects>,
     task: String,
     flow_tracker: FlowTracker,
     allowed_write_paths: Vec<PathBuf>,
@@ -516,7 +517,7 @@ impl NucleusRuntime {
         &self,
         _token: &UnmediatedAccess,
     ) -> impl FileEffect + WebEffect + ShellEffect + GitEffect + AgentSpawnEffect + '_ {
-        production_effects(self.policy.clone())
+        production_effects(self.policy.clone()) // unmediated: fresh instance for isolation
     }
 
     // ═══════════════════════════════════════════════════════════════════
@@ -536,7 +537,7 @@ impl NucleusRuntime {
         let term = self.build_term(Operation::ReadFiles, SinkClass::AuditLogAppend);
         self.discharge(&term)?;
 
-        let fx = production_effects(self.policy.clone());
+        let fx = &self.effects;
         let data = fx
             .read(path)
             .map_err(|e| self.translate_error(e, "read file", path))?;
@@ -563,7 +564,7 @@ impl NucleusRuntime {
         let term = self.build_term(Operation::WriteFiles, SinkClass::WorkspaceWrite);
         self.discharge(&term)?;
 
-        let fx = production_effects(self.policy.clone());
+        let fx = &self.effects;
         fx.write(path, content)
             .map_err(|e| self.translate_error(e, "write file", path))
     }
@@ -581,7 +582,7 @@ impl NucleusRuntime {
         let term = self.build_term(Operation::WebFetch, SinkClass::HTTPEgress);
         self.discharge(&term)?;
 
-        let fx = production_effects(self.policy.clone());
+        let fx = &self.effects;
         let data = fx.fetch(url).map_err(RuntimeError::from)?;
 
         let node_id = self
@@ -603,7 +604,7 @@ impl NucleusRuntime {
         let term = self.build_term(Operation::RunBash, SinkClass::BashExec);
         self.discharge(&term)?;
 
-        let fx = production_effects(self.policy.clone());
+        let fx = &self.effects;
         let output = fx.run(cmd).map_err(RuntimeError::from)?;
         Ok(ShellResult {
             data: Labeled::new(output),
@@ -615,7 +616,7 @@ impl NucleusRuntime {
         let term = self.build_term(Operation::GitCommit, SinkClass::GitCommit);
         self.discharge(&term)?;
 
-        let fx = production_effects(self.policy.clone());
+        let fx = &self.effects;
         let hash = fx.commit(message).map_err(RuntimeError::from)?;
         Ok(CommitOutput {
             hash: Labeled::new(hash),
@@ -627,7 +628,7 @@ impl NucleusRuntime {
         let term = self.build_term(Operation::GitPush, SinkClass::GitPush);
         self.discharge(&term)?;
 
-        let fx = production_effects(self.policy.clone());
+        let fx = &self.effects;
         fx.push(remote, branch).map_err(RuntimeError::from)
     }
 
@@ -880,9 +881,11 @@ impl NucleusRuntimeBuilder {
             .custom_policy
             .unwrap_or_else(|| self.profile.to_lattice());
 
+        let effects = crate::production_effects_concrete(policy.clone());
         NucleusRuntime {
             profile: self.profile,
             policy,
+            effects,
             task: self.task,
             flow_tracker: FlowTracker::new(),
             allowed_write_paths: self.allowed_write_paths,


### PR DESCRIPTION
## Summary

NucleusRuntime now stores \`PolicyEnforced<RealEffects>\` as an owned field, constructed once at build time. Mediated methods use \`&self.effects\` instead of constructing fresh bundles per call.

**Before**: 6 \`production_effects(self.policy.clone())\` calls per session operation.
**After**: 1 construction at build time, 0 clones during operation.

Uses \`production_effects_concrete()\` (new \`pub(crate)\` helper) to return the named type that the struct can store, while the public \`production_effects()\` API continues to return \`impl Trait\`. Per [bennett.dev](https://bennett.dev/dont-use-boxed-trait-objects-for-struct-internals/) — no Box\<dyn\> needed since the concrete type is visible within the crate.

## Test plan

- [x] 55 lib tests pass
- [x] Pre-push hooks all pass

Closes #1293

🤖 Generated with [Claude Code](https://claude.com/claude-code)