### PR TITLE
ci: auto-merge dependabot PRs (patch/minor + all Actions)

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,34 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Auto-merge patch and minor updates
+        if: >-
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Auto-merge GitHub Actions updates (all versions)
+        if: steps.metadata.outputs.package-ecosystem == 'github_actions'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Adds a workflow that auto-merges dependabot PRs after CI passes:

| Ecosystem | Auto-merge | Manual review |
|---|---|---|
| Rust (cargo) | Patch + minor | Major (breaking) |
| GitHub Actions | All versions | — |

Uses [`dependabot/fetch-metadata@v2`](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions) per GitHub docs. The merge queue's required status checks still gate everything — auto-merge only queues the PR, [CI must pass first](https://carlosbecker.com/posts/dependabot-automerge/).

## Why

Three dependabot PRs are currently sitting open waiting for manual merge. The Actions bumps are zero-risk infrastructure. Rust patch/minor updates are low-risk with our 16 CI checks catching regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)