### PR TITLE
feat: extract portcullis-profiles crate — TaskKind presets (#1287)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5781,6 +5781,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "portcullis-profiles"
+version = "1.0.0"
+dependencies = [
+ "portcullis-core",
+]
+
+[[package]]
 name = "postcard"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
     "crates/ctf-mcp",                  # MCP server: lets any AI agent play The Vault CTF
     "crates/portcullis-core",            # Aeneas verification target: dependency-free lattice types
     "crates/portcullis-effects",         # Sealed effect traits — I/O only through policy-enforced channels
+    "crates/portcullis-profiles",        # Application-specific task profiles (plugin, not kernel)
     "crates/ck-types",                  # Constitutional Kernel: core types, manifests, digests
     "crates/ck-policy",                 # Constitutional Kernel: monotonicity checker
     "crates/ck-kernel",                 # Constitutional Kernel: admission engine + lineage

--- a/crates/portcullis-profiles/Cargo.toml
+++ b/crates/portcullis-profiles/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "portcullis-profiles"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+description = "Application-specific task profiles for the portcullis policy engine"
+repository = "https://github.com/coproduct-opensource/nucleus"
+keywords = ["ai", "security", "policy", "profiles", "agents"]
+categories = ["development-tools"]
+
+[dependencies]
+portcullis-core = { path = "../portcullis-core" }
+
+[lints]
+workspace = true

--- a/crates/portcullis-profiles/src/lib.rs
+++ b/crates/portcullis-profiles/src/lib.rs
@@ -1,0 +1,178 @@
+//! Application-specific task profiles for the portcullis policy engine.
+//!
+//! This crate provides pre-built task profiles (CodeReview, BugFix, DocsEdit,
+//! Research) that map work categories to operation allowlists. These are
+//! **application-specific presets**, not security primitives — they belong in
+//! a plugin crate, not in the formal kernel (`portcullis-core`).
+//!
+//! ## Relationship to portcullis-core
+//!
+//! `portcullis-core` provides the generic `TaskScopePolicy` that accepts any
+//! operation allowlist. This crate provides the named presets that map
+//! human-meaningful task categories to those allowlists.
+//!
+//! ```text
+//! portcullis-core:    TaskScopePolicy (generic, formal kernel)
+//! portcullis-profiles: TaskKind presets (application-specific, plugin)
+//! ```
+//!
+//! ## Usage
+//!
+//! ```rust
+//! use portcullis_profiles::TaskKind;
+//!
+//! let kind = TaskKind::CodeReview;
+//! let allowed = kind.allowed_operations();
+//! let needs_approval = kind.approval_required_operations();
+//! ```
+
+pub use portcullis_core::Operation;
+
+/// Application-specific task categories.
+///
+/// Each variant maps to a set of allowed and approval-required operations.
+/// These are presets for common AI agent work patterns — integrators can
+/// define their own task kinds by constructing `TaskScopePolicy` directly
+/// with custom operation allowlists.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TaskKind {
+    /// Reviewing a PR or diff: read + search only; no pushes, no shell exec.
+    CodeReview,
+    /// Fixing a bug: broad access, but infra/deploy operations need approval.
+    BugFix,
+    /// Editing documentation: write allowed in docs paths; elsewhere needs approval.
+    DocsEdit,
+    /// Research / summarization: read and web access only; no mutations.
+    Research,
+}
+
+impl TaskKind {
+    /// Operations that are always allowed for this task kind.
+    pub fn allowed_operations(&self) -> &'static [Operation] {
+        match self {
+            Self::CodeReview => &[
+                Operation::ReadFiles,
+                Operation::GlobSearch,
+                Operation::GrepSearch,
+                Operation::WebFetch,
+                Operation::WebSearch,
+            ],
+            Self::BugFix => &[
+                Operation::ReadFiles,
+                Operation::WriteFiles,
+                Operation::EditFiles,
+                Operation::RunBash,
+                Operation::GlobSearch,
+                Operation::GrepSearch,
+                Operation::WebFetch,
+                Operation::WebSearch,
+                Operation::GitCommit,
+            ],
+            Self::DocsEdit => &[
+                Operation::ReadFiles,
+                Operation::WriteFiles,
+                Operation::EditFiles,
+                Operation::GlobSearch,
+                Operation::GrepSearch,
+                Operation::WebFetch,
+                Operation::WebSearch,
+            ],
+            Self::Research => &[
+                Operation::ReadFiles,
+                Operation::GlobSearch,
+                Operation::GrepSearch,
+                Operation::WebFetch,
+                Operation::WebSearch,
+            ],
+        }
+    }
+
+    /// Operations that require explicit human approval for this task kind.
+    pub fn approval_required_operations(&self) -> &'static [Operation] {
+        match self {
+            Self::CodeReview => &[
+                Operation::EditFiles,
+                Operation::WriteFiles,
+                Operation::RunBash,
+                Operation::GitCommit,
+                Operation::GitPush,
+                Operation::CreatePr,
+                Operation::ManagePods,
+                Operation::SpawnAgent,
+            ],
+            Self::BugFix => &[
+                Operation::GitPush,
+                Operation::CreatePr,
+                Operation::ManagePods,
+                Operation::SpawnAgent,
+            ],
+            Self::DocsEdit => &[
+                Operation::RunBash,
+                Operation::GitCommit,
+                Operation::GitPush,
+                Operation::CreatePr,
+                Operation::ManagePods,
+                Operation::SpawnAgent,
+            ],
+            Self::Research => &[
+                Operation::WriteFiles,
+                Operation::EditFiles,
+                Operation::RunBash,
+                Operation::GitCommit,
+                Operation::GitPush,
+                Operation::CreatePr,
+                Operation::ManagePods,
+                Operation::SpawnAgent,
+            ],
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn code_review_allows_read_not_write() {
+        let ops = TaskKind::CodeReview.allowed_operations();
+        assert!(ops.contains(&Operation::ReadFiles));
+        assert!(!ops.contains(&Operation::WriteFiles));
+        assert!(!ops.contains(&Operation::RunBash));
+    }
+
+    #[test]
+    fn bugfix_allows_bash_and_commit() {
+        let ops = TaskKind::BugFix.allowed_operations();
+        assert!(ops.contains(&Operation::RunBash));
+        assert!(ops.contains(&Operation::GitCommit));
+        assert!(!ops.contains(&Operation::GitPush));
+    }
+
+    #[test]
+    fn research_is_read_plus_web_only() {
+        let ops = TaskKind::Research.allowed_operations();
+        assert!(ops.contains(&Operation::ReadFiles));
+        assert!(ops.contains(&Operation::WebFetch));
+        assert!(!ops.contains(&Operation::WriteFiles));
+        assert!(!ops.contains(&Operation::RunBash));
+    }
+
+    #[test]
+    fn allowed_and_approval_are_disjoint() {
+        for kind in [
+            TaskKind::CodeReview,
+            TaskKind::BugFix,
+            TaskKind::DocsEdit,
+            TaskKind::Research,
+        ] {
+            let allowed = kind.allowed_operations();
+            let approval = kind.approval_required_operations();
+            for op in allowed {
+                assert!(
+                    !approval.contains(op),
+                    "{kind:?}: {op:?} is in both allowed and approval-required"
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Creates \`crates/portcullis-profiles/\` — the first kernel/plugin extraction from #1200.

\`\`\`text
portcullis-core:     TaskScopePolicy (generic, formal kernel)
portcullis-profiles: TaskKind presets (application-specific, plugin)
\`\`\`

\`TaskKind\` (CodeReview, BugFix, DocsEdit, Research) and their operation allowlists are application-specific presets, not security primitives. Per the [Cargo workspace pattern](https://doc.rust-lang.org/book/ch14-03-cargo-workspaces.html), they belong in a plugin crate that depends on the kernel, not in the kernel itself.

## What moved

| Type | From | To |
|---|---|---|
| \`TaskKind\` enum + impls | (duplicated, not yet removed from core) | \`portcullis-profiles\` |
| Operation allowlists per kind | (duplicated) | \`portcullis-profiles\` |

Note: the original \`TaskKind\` in \`portcullis-core/task_shield.rs\` is NOT removed in this PR — callers still reference it. A follow-up PR will migrate callers to \`portcullis_profiles::TaskKind\` and deprecate the core version.

## Test plan

- [x] 4 unit tests + 1 doc test
- [x] Pre-push hooks all pass

Closes #1287

🤖 Generated with [Claude Code](https://claude.com/claude-code)