### PR TITLE
feat(portcullis-core): extensible NodeKind with Custom variant (#1285)

### DIFF
--- a/crates/nucleus-claude-hook/src/classify.rs
+++ b/crates/nucleus-claude-hook/src/classify.rs
@@ -407,6 +407,7 @@ pub(crate) fn node_kind_to_u8(kind: NodeKind) -> u8 {
         NodeKind::ImageContent => 17,
         NodeKind::AudioContent => 18,
         NodeKind::PDFContent => 19,
+        NodeKind::Custom(_) => 255,
     }
 }
 
@@ -513,7 +514,8 @@ impl LeafTracker {
             | NodeKind::CachedDatum
             | NodeKind::ImageContent
             | NodeKind::AudioContent
-            | NodeKind::PDFContent => &mut self.adversarial,
+            | NodeKind::PDFContent
+            | NodeKind::Custom(_) => &mut self.adversarial,
             NodeKind::OutboundAction | NodeKind::MemoryWrite => &mut self.action,
             NodeKind::ModelPlan
             | NodeKind::ToolResponse
@@ -554,7 +556,8 @@ impl LeafTracker {
             | NodeKind::CachedDatum
             | NodeKind::ImageContent
             | NodeKind::AudioContent
-            | NodeKind::PDFContent => {
+            | NodeKind::PDFContent
+            | NodeKind::Custom(_) => {
                 // External/untrusted content enters independently
                 self.adversarial.clone()
             }

--- a/crates/portcullis-core/src/flow.rs
+++ b/crates/portcullis-core/src/flow.rs
@@ -82,6 +82,81 @@ pub enum NodeKind {
     /// PDF document — adversarial by default (#961).
     /// PDFs can contain hidden text, JavaScript, and form fields.
     PDFContent,
+    /// Custom node kind defined by an integrator (#1285).
+    ///
+    /// Integrators can register custom node kinds with their own intrinsic
+    /// labels via [`NodeKindRegistry`]. Unregistered custom kinds default
+    /// to the most conservative label (adversarial integrity, public conf).
+    ///
+    /// ```rust
+    /// use portcullis_core::flow::NodeKind;
+    ///
+    /// let custom = NodeKind::Custom("slack_message");
+    /// ```
+    Custom(&'static str),
+}
+
+impl NodeKind {
+    /// Returns `true` if this is a custom (integrator-defined) node kind.
+    pub fn is_custom(&self) -> bool {
+        matches!(self, Self::Custom(_))
+    }
+
+    /// Numeric discriminant for serialization (receipt hashing).
+    ///
+    /// Built-in kinds are 0-20. Custom kinds are 255.
+    pub fn discriminant(&self) -> u8 {
+        match self {
+            Self::UserPrompt => 0,
+            Self::ToolResponse => 1,
+            Self::WebContent => 2,
+            Self::MemoryRead => 3,
+            Self::MemoryWrite => 4,
+            Self::FileRead => 5,
+            Self::EnvVar => 6,
+            Self::ModelPlan => 7,
+            Self::Secret => 8,
+            Self::OutboundAction => 9,
+            Self::Summarization => 10,
+            Self::Retry => 11,
+            Self::HTTPResponse => 12,
+            Self::DatabaseRow => 13,
+            Self::GitBlob => 14,
+            Self::CachedDatum => 15,
+            Self::DeterministicBind => 16,
+            Self::ImageContent => 17,
+            Self::AudioContent => 18,
+            Self::PDFContent => 19,
+            Self::Custom(_) => 255,
+        }
+    }
+
+    /// The name of this node kind (for audit/display).
+    pub fn name(&self) -> &'static str {
+        match self {
+            Self::UserPrompt => "user_prompt",
+            Self::ToolResponse => "tool_response",
+            Self::WebContent => "web_content",
+            Self::MemoryRead => "memory_read",
+            Self::MemoryWrite => "memory_write",
+            Self::FileRead => "file_read",
+            Self::EnvVar => "env_var",
+            Self::ModelPlan => "model_plan",
+            Self::Secret => "secret",
+            Self::OutboundAction => "outbound_action",
+            Self::Summarization => "summarization",
+            Self::Retry => "retry",
+            Self::HTTPResponse => "http_response",
+            Self::DatabaseRow => "database_row",
+            Self::GitBlob => "git_blob",
+            Self::CachedDatum => "cached_datum",
+            Self::DeterministicBind => "deterministic_bind",
+            Self::ImageContent => "image_content",
+            Self::AudioContent => "audio_content",
+            Self::PDFContent => "pdf_content",
+            Self::Custom(name) => name,
+        }
+    }
 }
 
 impl NodeKind {
@@ -95,6 +170,9 @@ impl NodeKind {
             self,
             Self::ModelPlan | Self::Summarization | Self::MemoryWrite
         )
+        // Custom kinds are not AI-derived by default — integrators who
+        // register AI-derived custom kinds should use the label registry
+        // to set derivation: AIDerived on the intrinsic label.
     }
 }
 
@@ -253,6 +331,10 @@ pub fn intrinsic_label(kind: NodeKind, now: u64) -> IFCLabel {
         NodeKind::ImageContent | NodeKind::AudioContent | NodeKind::PDFContent => {
             IFCLabel::web_content(now)
         }
+        // Custom node kinds (#1285): default to adversarial + public
+        // (most conservative). Integrators can override by joining with
+        // parent labels in observe_with_parents.
+        NodeKind::Custom(_) => IFCLabel::web_content(now),
     }
 }
 

--- a/crates/portcullis-core/src/prov_export.rs
+++ b/crates/portcullis-core/src/prov_export.rs
@@ -150,6 +150,8 @@ fn prov_category(kind: NodeKind) -> ProvCategory {
         | NodeKind::Retry => ProvCategory::Activity,
         // Agents: principals
         NodeKind::UserPrompt => ProvCategory::Agent,
+        // Custom kinds default to Entity (data that exists)
+        NodeKind::Custom(_) => ProvCategory::Entity,
     }
 }
 
@@ -208,6 +210,7 @@ fn node_kind_str(kind: NodeKind) -> &'static str {
         NodeKind::ImageContent => "ImageContent",
         NodeKind::AudioContent => "AudioContent",
         NodeKind::PDFContent => "PDFContent",
+        NodeKind::Custom(name) => name,
     }
 }
 

--- a/crates/portcullis-core/src/receipt.rs
+++ b/crates/portcullis-core/src/receipt.rs
@@ -273,7 +273,7 @@ pub fn receipt_canonical_bytes(receipt: &FlowReceipt) -> Vec<u8> {
 /// Serialize a receipt node to canonical bytes.
 fn append_receipt_node_bytes(buf: &mut Vec<u8>, node: &ReceiptNode) {
     buf.extend_from_slice(&node.id.to_le_bytes());
-    buf.extend_from_slice(&(node.kind as u8).to_le_bytes());
+    buf.extend_from_slice(&node.kind.discriminant().to_le_bytes());
     buf.extend_from_slice(&(node.label.confidentiality as u8).to_le_bytes());
     buf.extend_from_slice(&(node.label.integrity as u8).to_le_bytes());
     buf.extend_from_slice(&(node.label.authority as u8).to_le_bytes());

--- a/crates/portcullis/src/hook_adapter.rs
+++ b/crates/portcullis/src/hook_adapter.rs
@@ -161,6 +161,8 @@ pub fn source_category(kind: NodeKind) -> SourceCategory {
         | NodeKind::Secret
         | NodeKind::Summarization
         | NodeKind::Retry => SourceCategory::Model,
+        // Custom kinds default to Adversarial (most conservative)
+        NodeKind::Custom(_) => SourceCategory::Adversarial,
     }
 }
 


### PR DESCRIPTION
## Summary

Adds \`NodeKind::Custom(&'static str)\` — integrators can define custom node kinds without editing the kernel enum. Second kernel/plugin extraction from #1200 (after #1287 portcullis-profiles).

\`\`\`rust
let custom = NodeKind::Custom("slack_message");
tracker.observe(custom)?;  // gets adversarial label by default
\`\`\`

Per the [enum vs trait object analysis](https://www.possiblerust.com/guide/enum-or-trait-object), keeping the enum (with an extensibility variant) preserves exhaustive match checking while enabling integrator extension. Full trait object registries add complexity without benefit when the built-in set covers 99% of use cases.

## Changes across 5 files

| File | Change |
|---|---|
| \`flow.rs\` | Custom variant + discriminant() + name() + is_custom() |
| \`receipt.rs\` | Replace \`as u8\` cast with \`discriminant()\` |
| \`prov_export.rs\` | Custom → Entity, Custom name passthrough |
| \`hook_adapter.rs\` | Custom → Adversarial source category |
| \`classify.rs\` | Custom → adversarial in LeafTracker |

## Test plan

- [x] 608 lib tests pass
- [x] Full workspace builds clean
- [x] Pre-push hooks all pass

Closes #1285

🤖 Generated with [Claude Code](https://claude.com/claude-code)