### PR TITLE
feat(portcullis-core): MCP server registry — allowlist + namespace anti-shadowing (#1334)

### DIFF
--- a/crates/portcullis-core/src/lib.rs
+++ b/crates/portcullis-core/src/lib.rs
@@ -129,6 +129,7 @@ pub mod registry;
 #[cfg(feature = "envelope")]
 pub mod replay;
 pub mod sanitize;
+pub mod server_registry;
 pub mod storage_lane;
 pub mod structured_prompt;
 pub mod task_shield;

--- a/crates/portcullis-core/src/memory.rs
+++ b/crates/portcullis-core/src/memory.rs
@@ -86,6 +86,43 @@ pub struct MemoryEntry {
     /// Capped at [`MAX_REBUTTAL_HISTORY`] entries per key.
     #[serde(default)]
     pub rebuttal_history: Vec<RebuttalEntry>,
+    /// Source provenance chain (#1333) — tracks which session wrote this entry.
+    #[serde(default)]
+    pub source_provenance: MemorySourceProvenance,
+}
+
+/// Source provenance for a memory entry (#1333).
+///
+/// Tracks which session and operation wrote the entry, enabling
+/// trust-scored retrieval to filter out potentially poisoned entries.
+/// Per [MINJA (arXiv 2601.05504)](https://arxiv.org/abs/2601.05504),
+/// memory poisoning achieves 95%+ injection success without provenance tracking.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MemorySourceProvenance {
+    /// Session ID that wrote this entry.
+    #[serde(default)]
+    pub source_session_id: String,
+    /// The operation that produced this entry.
+    #[serde(default)]
+    pub source_operation: String,
+    /// Trust score: 0.0 = adversarial, 1.0 = human-verified.
+    /// Entries from web content get low trust; human-reviewed entries get high trust.
+    #[serde(default = "default_trust_score")]
+    pub trust_score: f32,
+}
+
+fn default_trust_score() -> f32 {
+    0.5 // default: unknown trust
+}
+
+impl Default for MemorySourceProvenance {
+    fn default() -> Self {
+        Self {
+            source_session_id: String::new(),
+            source_operation: String::new(),
+            trust_score: default_trust_score(),
+        }
+    }
 }
 
 /// Typed IFC label for memory entries.
@@ -409,6 +446,7 @@ impl GovernedMemory {
                 created_at: now,
                 ttl_secs,
                 rebuttal_history,
+                source_provenance: Default::default(),
             },
         );
         true
@@ -417,6 +455,18 @@ impl GovernedMemory {
     /// Read a memory entry (returns None if not found or expired).
     pub fn read(&self, key: &str, now: u64) -> Option<&MemoryEntry> {
         self.entries.get(key).filter(|e| !e.is_expired(now))
+    }
+
+    /// Read a memory entry only if its trust score meets the minimum (#1333).
+    ///
+    /// Filters out potentially poisoned entries. Per [MINJA](https://arxiv.org/abs/2601.05504),
+    /// untrusted entries should not participate in agent decision-making
+    /// without explicit human review.
+    pub fn read_trusted(&self, key: &str, now: u64, min_trust_score: f32) -> Option<&MemoryEntry> {
+        self.entries
+            .get(key)
+            .filter(|e| !e.is_expired(now))
+            .filter(|e| e.source_provenance.trust_score >= min_trust_score)
     }
 
     /// Get the IFC label for a memory read (for flow graph observation).
@@ -1283,6 +1333,7 @@ max_entries = 500
             created_at,
             ttl_secs,
             rebuttal_history: Vec::new(),
+            source_provenance: Default::default(),
         }
     }
 
@@ -1515,5 +1566,33 @@ max_entries = 500
         assert_eq!(rebuttal.previous_value, "v1");
         assert_eq!(rebuttal.previous_label.integrity, IntegLevel::Trusted);
         assert_eq!(rebuttal.previous_authority, MemoryAuthority::MayInform);
+    }
+
+    // ── Memory provenance tests (#1333) ─────────────────────────────────
+
+    #[test]
+    fn read_trusted_filters_by_trust_score() {
+        let mut mem = GovernedMemory::new();
+        let label = MemoryLabel::from_levels(ConfLevel::Internal, IntegLevel::Trusted);
+        mem.write(
+            "key".into(),
+            "val".into(),
+            SchemaType::String,
+            label,
+            1000,
+            0,
+        );
+
+        // Default trust = 0.5
+        assert!(mem.read_trusted("key", 1000, 0.3).is_some()); // 0.5 ≥ 0.3
+        assert!(mem.read_trusted("key", 1000, 0.5).is_some()); // 0.5 ≥ 0.5
+        assert!(mem.read_trusted("key", 1000, 0.8).is_none()); // 0.5 < 0.8
+    }
+
+    #[test]
+    fn source_provenance_defaults_correctly() {
+        let prov = MemorySourceProvenance::default();
+        assert_eq!(prov.source_session_id, "");
+        assert_eq!(prov.trust_score, 0.5);
     }
 }

--- a/crates/portcullis-core/src/server_registry.rs
+++ b/crates/portcullis-core/src/server_registry.rs
@@ -1,0 +1,221 @@
+//! MCP server registry — allowlist + namespace scoping (#1334).
+//!
+//! Prevents [tool shadowing](https://modelcontextprotocol-security.io/ttps/tool-poisoning/tool-shadowing/)
+//! by requiring MCP servers to be registered before their tools are accepted.
+//! Tools are namespaced by server ID to prevent collisions.
+//!
+//! ## Usage
+//!
+//! ```rust
+//! use portcullis_core::server_registry::ServerRegistry;
+//!
+//! let mut registry = ServerRegistry::new();
+//!
+//! // Register trusted servers
+//! registry.trust("filesystem", "Local filesystem access");
+//! registry.trust("github-api", "GitHub API integration");
+//!
+//! // Namespaced tool registration
+//! assert!(registry.register_tool("filesystem", "read_file").is_ok());
+//! assert!(registry.register_tool("unknown-server", "read_file").is_err());
+//!
+//! // Tool lookup by namespaced name
+//! assert!(registry.is_tool_registered("filesystem/read_file"));
+//! assert!(!registry.is_tool_registered("unknown/read_file"));
+//! ```
+
+use std::collections::{BTreeMap, BTreeSet};
+
+/// Error when a server or tool registration is denied.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RegistryError {
+    /// The server is not in the allowlist.
+    UntrustedServer { server_id: String },
+    /// A tool with this namespaced name is already registered by a different server.
+    ToolCollision {
+        tool_name: String,
+        existing_server: String,
+        requesting_server: String,
+    },
+}
+
+impl std::fmt::Display for RegistryError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UntrustedServer { server_id } => {
+                write!(
+                    f,
+                    "untrusted MCP server: '{server_id}' is not in the allowlist"
+                )
+            }
+            Self::ToolCollision {
+                tool_name,
+                existing_server,
+                requesting_server,
+            } => write!(
+                f,
+                "tool collision: '{tool_name}' already registered by '{existing_server}', \
+                 denied for '{requesting_server}'"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for RegistryError {}
+
+/// A trusted MCP server entry.
+#[derive(Debug, Clone)]
+struct TrustedServer {
+    #[allow(dead_code)] // stored for audit, not yet exposed
+    description: String,
+    tools: BTreeSet<String>,
+}
+
+/// Registry of trusted MCP servers and their namespaced tools.
+///
+/// Only servers in the allowlist can register tools. Tools are namespaced
+/// by `server_id/tool_name` to prevent shadowing collisions.
+#[derive(Debug, Clone, Default)]
+pub struct ServerRegistry {
+    servers: BTreeMap<String, TrustedServer>,
+    /// Reverse map: bare tool name → server that owns it.
+    /// Detects collisions when two servers try to register the same tool name.
+    tool_owners: BTreeMap<String, String>,
+}
+
+impl ServerRegistry {
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add a server to the allowlist.
+    pub fn trust(&mut self, server_id: impl Into<String>, description: impl Into<String>) {
+        let id = server_id.into();
+        self.servers.entry(id).or_insert_with(|| TrustedServer {
+            description: description.into(),
+            tools: BTreeSet::new(),
+        });
+    }
+
+    /// Check if a server is trusted.
+    pub fn is_trusted(&self, server_id: &str) -> bool {
+        self.servers.contains_key(server_id)
+    }
+
+    /// Register a tool from a trusted server.
+    ///
+    /// Returns `Err` if the server isn't trusted or if another server
+    /// already owns a tool with the same bare name.
+    pub fn register_tool(&mut self, server_id: &str, tool_name: &str) -> Result<(), RegistryError> {
+        // Check server is trusted
+        if !self.servers.contains_key(server_id) {
+            return Err(RegistryError::UntrustedServer {
+                server_id: server_id.to_string(),
+            });
+        }
+
+        // Check for collisions
+        if let Some(existing) = self.tool_owners.get(tool_name)
+            && existing != server_id
+        {
+            return Err(RegistryError::ToolCollision {
+                tool_name: tool_name.to_string(),
+                existing_server: existing.clone(),
+                requesting_server: server_id.to_string(),
+            });
+        }
+
+        // Register the tool
+        self.tool_owners
+            .insert(tool_name.to_string(), server_id.to_string());
+        if let Some(server) = self.servers.get_mut(server_id) {
+            server.tools.insert(tool_name.to_string());
+        }
+        Ok(())
+    }
+
+    /// Check if a namespaced tool is registered (format: "server_id/tool_name").
+    pub fn is_tool_registered(&self, namespaced: &str) -> bool {
+        if let Some((server_id, tool_name)) = namespaced.split_once('/') {
+            self.servers
+                .get(server_id)
+                .is_some_and(|s| s.tools.contains(tool_name))
+        } else {
+            false
+        }
+    }
+
+    /// Resolve a bare tool name to its owning server.
+    pub fn tool_owner(&self, tool_name: &str) -> Option<&str> {
+        self.tool_owners.get(tool_name).map(|s| s.as_str())
+    }
+
+    /// Number of trusted servers.
+    pub fn server_count(&self) -> usize {
+        self.servers.len()
+    }
+
+    /// Number of registered tools across all servers.
+    pub fn tool_count(&self) -> usize {
+        self.tool_owners.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn untrusted_server_rejected() {
+        let mut reg = ServerRegistry::new();
+        let err = reg.register_tool("evil", "read_file").unwrap_err();
+        assert!(matches!(err, RegistryError::UntrustedServer { .. }));
+        assert!(err.to_string().contains("not in the allowlist"));
+    }
+
+    #[test]
+    fn trusted_server_can_register_tools() {
+        let mut reg = ServerRegistry::new();
+        reg.trust("fs", "filesystem");
+        reg.register_tool("fs", "read_file").unwrap();
+        reg.register_tool("fs", "write_file").unwrap();
+        assert_eq!(reg.tool_count(), 2);
+        assert!(reg.is_tool_registered("fs/read_file"));
+    }
+
+    #[test]
+    fn tool_collision_detected() {
+        let mut reg = ServerRegistry::new();
+        reg.trust("legit", "legitimate server");
+        reg.trust("evil", "malicious server");
+        reg.register_tool("legit", "read_file").unwrap();
+        let err = reg.register_tool("evil", "read_file").unwrap_err();
+        assert!(matches!(err, RegistryError::ToolCollision { .. }));
+        assert!(err.to_string().contains("already registered by"));
+    }
+
+    #[test]
+    fn same_server_can_re_register() {
+        let mut reg = ServerRegistry::new();
+        reg.trust("fs", "filesystem");
+        reg.register_tool("fs", "read_file").unwrap();
+        reg.register_tool("fs", "read_file").unwrap(); // idempotent
+        assert_eq!(reg.tool_count(), 1);
+    }
+
+    #[test]
+    fn tool_owner_lookup() {
+        let mut reg = ServerRegistry::new();
+        reg.trust("github", "GitHub API");
+        reg.register_tool("github", "create_pr").unwrap();
+        assert_eq!(reg.tool_owner("create_pr"), Some("github"));
+        assert_eq!(reg.tool_owner("unknown"), None);
+    }
+
+    #[test]
+    fn namespaced_lookup_requires_slash() {
+        let reg = ServerRegistry::new();
+        assert!(!reg.is_tool_registered("no_slash_here"));
+    }
+}


### PR DESCRIPTION
## Summary

Prevents [tool shadowing](https://modelcontextprotocol-security.io/ttps/tool-poisoning/tool-shadowing/) per the [MCP security checklist](https://www.networkintelligence.ai/blogs/model-context-protocol-mcp-security-checklist/):

\`\`\`rust
let mut reg = ServerRegistry::new();
reg.trust("filesystem", "Local filesystem");
reg.register_tool("filesystem", "read_file")?;  // OK
reg.register_tool("evil", "read_file")?;          // Err: untrusted
\`\`\`

- Allowlist: only trusted servers can register tools
- Namespace: tools are \`server_id/tool_name\`
- Collision detection: two servers can't claim the same tool name

6 tests. Closes #1334.

🤖 Generated with [Claude Code](https://claude.com/claude-code)