### PR TITLE
fix(portcullis-core): reject TestOnly in promote_integrity (#1363)

### DIFF
--- a/crates/portcullis-core/src/labeled.rs
+++ b/crates/portcullis-core/src/labeled.rs
@@ -336,8 +336,12 @@ pub fn promote_integrity<T, C: ConfTag>(
     match reason {
         DeclassifyReason::HumanReview
         | DeclassifyReason::DeterministicVerification
-        | DeclassifyReason::Sanitization
-        | DeclassifyReason::TestOnly => Ok(Labeled::new(value.into_inner())),
+        | DeclassifyReason::Sanitization => Ok(Labeled::new(value.into_inner())),
+        DeclassifyReason::TestOnly => Err(DeclassifyError::InsufficientReason(
+            "TestOnly cannot promote integrity — use HumanReview, \
+             DeterministicVerification, or Sanitization"
+                .to_string(),
+        )),
     }
 }
 
@@ -546,6 +550,13 @@ mod tests {
     fn declassify_secret_rejects_test_only() {
         let secret: Labeled<String, Trusted, Secret> = Labeled::new("api-key".to_string());
         let err = declassify_to_internal(secret, DeclassifyReason::TestOnly).unwrap_err();
+        assert!(matches!(err, DeclassifyError::InsufficientReason(_)));
+    }
+
+    #[test]
+    fn promote_integrity_rejects_test_only() {
+        let adv: Labeled<String, Adversarial, Public> = Labeled::new("web data".to_string());
+        let err = promote_integrity(adv, DeclassifyReason::TestOnly).unwrap_err();
         assert!(matches!(err, DeclassifyError::InsufficientReason(_)));
     }
 


### PR DESCRIPTION
## Summary
- `promote_integrity()` now rejects `DeclassifyReason::TestOnly` with `InsufficientReason` error
- Previously, TestOnly could bypass the Adversarial→Untrusted integrity gate in production code
- `promote_to_trusted()` already rejected TestOnly; this makes both functions consistent

## Test plan
- [x] New test: `promote_integrity_rejects_test_only`
- [x] All 23 labeled tests pass
- [x] Full workspace `cargo test` green

Closes #1363

🤖 Generated with [Claude Code](https://claude.com/claude-code)