### PR TITLE
fix(nucleus-claude-hook): default fail-closed (#1361)

### DIFF
--- a/crates/nucleus-claude-hook/src/exit_codes.rs
+++ b/crates/nucleus-claude-hook/src/exit_codes.rs
@@ -21,9 +21,9 @@
 //! - **Hook ran, operation denied** (exit 2): valid JSON on stdout with
 //!   `permissionDecision: "deny"` and a `permissionDecisionReason`.
 //! - **Hook ran, but hit an internal error** (exit 1): stderr has a diagnostic
-//!   message.  No valid decision JSON on stdout (or a deny if `NUCLEUS_FAIL_CLOSED=1`).
+//!   message.  No valid decision JSON on stdout (or a deny if `NUCLEUS_FAIL_OPEN=1`).
 //!
-//! ## `NUCLEUS_FAIL_CLOSED=1`
+//! ## `NUCLEUS_FAIL_OPEN=1`
 //!
 //! When set, infrastructure errors (no stdin, bad JSON, etc.) are promoted
 //! from exit 1 to exit 2 with a deny JSON, ensuring the tool call is blocked.
@@ -50,7 +50,7 @@ pub enum ExitCode {
     /// Operation denied — JSON on stdout contains a deny with reason.
     ///
     /// This covers both policy denials (capability violations, flow rules,
-    /// tamper detection) and infrastructure failures when `NUCLEUS_FAIL_CLOSED=1`.
+    /// tamper detection) and infrastructure failures when `NUCLEUS_FAIL_OPEN=1`.
     Deny = 2,
 }
 
@@ -97,7 +97,7 @@ impl ExitCode {
         println!("  1          Error    Internal error, no valid decision made");
         println!("  2          Deny     Operation blocked (JSON on stdout with reason)");
         println!();
-        println!("When NUCLEUS_FAIL_CLOSED=1, infrastructure errors use exit 2 (deny)");
+        println!("When NUCLEUS_FAIL_OPEN=1, infrastructure errors use exit 2 (deny)");
         println!("instead of exit 1, ensuring tool calls are blocked on any failure.");
         println!();
         println!("Integration notes:");

--- a/crates/nucleus-claude-hook/src/help.rs
+++ b/crates/nucleus-claude-hook/src/help.rs
@@ -79,7 +79,7 @@ pub fn print_help() {
     println!("ENVIRONMENT VARIABLES:");
     println!("  NUCLEUS_PROFILE            Permission profile (default: safe_pr_fixer)");
     println!("  NUCLEUS_COMPARTMENT        Compartment: research, draft, execute, breakglass");
-    println!("  NUCLEUS_FAIL_CLOSED        Set to 1: deny on infrastructure errors (CISO mode)");
+    println!("  NUCLEUS_FAIL_OPEN        Unset (default): deny on infrastructure errors. Set to 1 to allow fallthrough");
     println!("  NUCLEUS_REQUIRE_MANIFESTS  Set to 1: deny MCP tools without manifests");
     println!("  NUCLEUS_TIMING             Set to 1: emit phase latency breakdown to stderr");
     println!("  NUCLEUS_AUTONOMY_CEILING   Org cap: production, sandbox (default: unrestricted)");
@@ -222,7 +222,7 @@ pub fn print_help_flow() {
     println!("     Exit code 0 = allow, 2 = deny. See --exit-codes for the full protocol.");
     println!();
     println!("FAIL-CLOSED MODE:");
-    println!("  Set NUCLEUS_FAIL_CLOSED=1 to deny on any infrastructure error (missing");
+    println!("  Set NUCLEUS_FAIL_OPEN=1 to deny on any infrastructure error (missing");
     println!("  session dir, parse failure, etc.). Default is fail-open with a warning.");
     println!();
     println!("TIMING:");

--- a/crates/nucleus-claude-hook/src/main.rs
+++ b/crates/nucleus-claude-hook/src/main.rs
@@ -281,11 +281,12 @@ fn main() {
     // This means a broken/crashing hook doesn't brick the session — it gracefully
     // degrades to standard Claude Code permission prompts.
     //
-    // For production/CISO mode: set NUCLEUS_FAIL_CLOSED=1 to make infrastructure
-    // errors blocking (exit 2). This is the paranoid setting.
-    let fail_closed = std::env::var("NUCLEUS_FAIL_CLOSED")
-        .map(|v| v == "1")
-        .unwrap_or(false);
+    // Default: fail-closed. Infrastructure errors block the operation (#1361).
+    // Set NUCLEUS_FAIL_OPEN=1 to gracefully degrade to Claude Code prompts
+    // in development environments where a broken hook shouldn't brick the session.
+    let fail_closed = std::env::var("NUCLEUS_FAIL_OPEN")
+        .map(|v| v != "1")
+        .unwrap_or(true);
 
     let stdin = io::stdin();
     let line = match stdin.lock().lines().next() {
@@ -294,7 +295,7 @@ fn main() {
             eprintln!("nucleus: no input on stdin — falling through to Claude Code defaults");
             if fail_closed {
                 let out = HookOutput::deny(
-                    "nucleus: no hook input — failing closed (NUCLEUS_FAIL_CLOSED=1)",
+                    "nucleus: no hook input — failing closed (set NUCLEUS_FAIL_OPEN=1 to override)",
                 );
                 println!("{}", serde_json::to_string(&out).unwrap());
                 exit_codes::ExitCode::Deny.exit();


### PR DESCRIPTION
Defaults to fail-closed. NUCLEUS_FAIL_OPEN=1 opts into graceful degradation. Closes #1361