### PR TITLE
fix(nucleus-claude-hook): reset IFC state on compartment transition (#1359)

### DIFF
--- a/crates/nucleus-claude-hook/src/main.rs
+++ b/crates/nucleus-claude-hook/src/main.rs
@@ -983,6 +983,11 @@ fn main() {
                     session.flow_observations.len()
                 );
                 session.flow_observations.clear();
+                // Also reset IFC discharge state to match flow graph reset (#1359).
+                // Without this, the discharge gate (preflight_action) disagrees
+                // with the kernel (which sees a clean flow graph).
+                session.web_tainted = false;
+                session.ifc_label_ratchet = None;
             }
         }
         session.active_compartment = compartment.map(|c| c.to_string());


### PR DESCRIPTION
## Summary
- Resets `web_tainted` and `ifc_label_ratchet` on compartment transition alongside `flow_observations`
- Fixes disagreement between kernel (clean graph → allow) and discharge gate (stale taint → deny)
- The research→draft workflow now works correctly for both decision systems

## Test plan
- [x] All 223 hook tests pass
- [x] All pre-commit/pre-push hooks pass

Closes #1359

🤖 Generated with [Claude Code](https://claude.com/claude-code)