### PR TITLE
fix(nucleus-claude-hook): --reset-session preserves HWM for tamper detection (#1364)

### DIFF
--- a/crates/nucleus-claude-hook/src/main.rs
+++ b/crates/nucleus-claude-hook/src/main.rs
@@ -163,12 +163,13 @@ fn main() {
         }
         Ok(cli::CliCommand::ResetSession { session_id }) => {
             let state_path = session_state_path(&session_id);
-            let hwm_path = session_hwm_path(&session_id);
             if state_path.exists() {
                 std::fs::remove_file(&state_path).ok();
-                std::fs::remove_file(&hwm_path).ok();
+                // HWM file intentionally preserved (#1364) — it survives
+                // state deletion for tamper detection. An agent cannot
+                // erase evidence that a session existed.
                 println!("nucleus: session '{session_id}' reset — taint cleared");
-                println!("nucleus: Note: receipt chain preserved for audit");
+                println!("nucleus: Note: HWM and receipt chain preserved for audit");
             } else {
                 println!("nucleus: no session found for '{session_id}'");
             }


### PR DESCRIPTION
## Summary
- `--reset-session` no longer deletes the HWM file
- HWM survives for tamper detection — proves a session existed even after state wipe
- Prevents agents from erasing evidence of taint via bash access

## Test plan
- [x] All 223 hook tests pass

Closes #1364

🤖 Generated with [Claude Code](https://claude.com/claude-code)