### PR TITLE
docs: document budget gate as structurally sound but dormant (#1362)

### DIFF
--- a/crates/nucleus-claude-hook/src/session.rs
+++ b/crates/nucleus-claude-hook/src/session.rs
@@ -1261,6 +1261,9 @@ pub(crate) fn build_discharge_term(
         source_labels,
         artifact_label: state.ifc_label_ratchet.unwrap_or_default(),
         subject: subject.to_string(),
+        // Budget enforcement not yet wired (#1362) — cost estimation requires
+        // integration with an LLM token pricer or API metering service.
+        // The BudgetNotExceeded obligation is structurally sound but dormant.
         estimated_cost_micro_usd: 0,
     }
 }

--- a/crates/portcullis-core/src/discharge.rs
+++ b/crates/portcullis-core/src/discharge.rs
@@ -547,6 +547,11 @@ pub struct ActionTerm {
     /// When non-zero, a budget gate must be wired at the application layer
     /// (in `portcullis-effects`). Passing non-zero cost through `preflight_action`
     /// without a budget gate produces a `Denied` result.
+    ///
+    /// **Known gap (#1362)**: All current callsites pass 0 because no cost
+    /// estimation is wired yet. The `BudgetNotExceeded` obligation is
+    /// structurally sound but operationally dormant until a cost estimator
+    /// is integrated (e.g., LLM token pricing, API call metering).
     pub estimated_cost_micro_usd: u64,
 }
 


### PR DESCRIPTION
## Summary
- Documents that `estimated_cost_micro_usd` is always 0 at all callsites
- `BudgetNotExceeded` obligation is structurally correct but no cost estimator is wired
- Added Known Gap comments on the field definition and at `build_discharge_term`

Closes #1362

🤖 Generated with [Claude Code](https://claude.com/claude-code)