### PR TITLE
fix(lean): DelegationProofs — bind implicit r, fix split/omega regressions

### DIFF
--- a/crates/portcullis-core/lean/DelegationProofs.lean
+++ b/crates/portcullis-core/lean/DelegationProofs.lean
@@ -64,43 +64,48 @@ def narrow (parent child : Constraints) : Option Constraints :=
 -- ═══════════════════════════════════════════════════════════════════════
 
 theorem narrow_scope_le_parent (p c : Constraints)
-    (h : narrow p c = some r) :
+    {r : Constraints} (h : narrow p c = some r) :
     r.scope_size ≤ p.scope_size := by
-  simp [narrow] at h
-  split at h <;> simp_all
-  omega
+  simp only [narrow] at h
+  split at h
+  · simp only [Option.some.injEq] at h; subst h; simp only [Nat.min_def]; split <;> omega
+  · simp at h
 
 theorem narrow_depth_le_parent (p c : Constraints)
-    (h : narrow p c = some r) :
+    {r : Constraints} (h : narrow p c = some r) :
     r.max_depth ≤ p.max_depth := by
-  simp [narrow] at h
-  split at h <;> simp_all
-  omega
+  simp only [narrow] at h
+  split at h
+  · simp only [Option.some.injEq] at h; subst h; simp only [Nat.min_def]; split <;> omega
+  · simp at h
 
 theorem narrow_expiry_le_parent (p c : Constraints)
-    (h : narrow p c = some r) :
+    {r : Constraints} (h : narrow p c = some r) :
     r.expires_at ≤ p.expires_at := by
-  simp [narrow] at h
-  split at h <;> simp_all
-  omega
+  simp only [narrow] at h
+  split at h
+  · simp only [Option.some.injEq] at h; subst h; simp only [Nat.min_def]; split <;> omega
+  · simp at h
 
 -- ═══════════════════════════════════════════════════════════════════════
 -- Theorem D2: Narrowing is also ≤ child on every dimension
 -- ═══════════════════════════════════════════════════════════════════════
 
 theorem narrow_scope_le_child (p c : Constraints)
-    (h : narrow p c = some r) :
+    {r : Constraints} (h : narrow p c = some r) :
     r.scope_size ≤ c.scope_size := by
-  simp [narrow] at h
-  split at h <;> simp_all
-  omega
+  simp only [narrow] at h
+  split at h
+  · simp only [Option.some.injEq] at h; subst h; simp only [Nat.min_def]; split <;> omega
+  · simp at h
 
 theorem narrow_depth_le_child (p c : Constraints)
-    (h : narrow p c = some r) :
+    {r : Constraints} (h : narrow p c = some r) :
     r.max_depth ≤ c.max_depth := by
-  simp [narrow] at h
-  split at h <;> simp_all
-  omega
+  simp only [narrow] at h
+  split at h
+  · simp only [Option.some.injEq] at h; subst h; simp only [Nat.min_def]; split <;> omega
+  · simp at h
 
 -- ═══════════════════════════════════════════════════════════════════════
 -- Theorem D3: Scope intersection is commutative


### PR DESCRIPTION
## Summary

Third Lean 4.28 proof regression fix (after DeclassifyProofs #1476 and CompartmentProofs #1497). Fixes \`DelegationProofs.lean\` which was breaking the Aeneas CI workflow.

### Issue 1: Unbound \`r\`
5 theorems used \`(h : narrow p c = some r)\` with \`r\` unbound. With \`autoImplicit = false\` this errors. Fixed by adding \`{r : Constraints}\`.

### Issue 2: split/omega regressions
Old proof: \`simp [narrow] at h; split at h <;> simp_all; omega\`
- \`simp [narrow]\` now expands the \`if\` differently
- \`omega\` can't handle \`Nat.min\` directly

New proof: \`simp only [narrow] at h; split at h; · simp only [Option.some.injEq] at h; subst h; simp only [Nat.min_def]; split <;> omega; · simp at h\`

This unfolds \`min\` to an \`if\`, splits on it, and lets \`omega\` handle the resulting linear arithmetic.

\`lake build DelegationProofs\` clean.

Unblocks PRs #1474, #1492 which inherited the Aeneas failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)