### PR TITLE
fix(lean): remove 'sorry' from docstrings to fix Aeneas CI grep

### DIFF
--- a/crates/portcullis-core/lean/CompartmentProofs.lean
+++ b/crates/portcullis-core/lean/CompartmentProofs.lean
@@ -16,7 +16,7 @@ the nucleus-claude-hook for research/draft/execute/breakglass modes.
 5. **Research blocks writes**: `meet(perms, research_ceiling).write_files = ⊥`
 
 All proofs discharge via `decide`/`simp` over the 3-element CapabilityLevel type.
-No sorry. No SMT oracle.
+No proof holes. No SMT oracle.
 -/
 
 open portcullis_core

--- a/crates/portcullis-core/lean/DecidePureProofs.lean
+++ b/crates/portcullis-core/lean/DecidePureProofs.lean
@@ -12,7 +12,7 @@ Hand-written Lean model mirroring `portcullis-core/src/lib.rs:959`.
 NOT Aeneas-generated — Aeneas cannot translate `==` on enums or the
 `should_gate` function (which uses `bool` fields and `Option` returns).
 
-## What's proved (all kernel-checked, no sorry)
+## What's proved (all kernel-checked, no proof holes)
 
 - **Never always denies**: regardless of exposure or operation
 - **LowRisk always requires approval**: regardless of exposure or operation

--- a/crates/portcullis-core/lean/DeclassifyProofs.lean
+++ b/crates/portcullis-core/lean/DeclassifyProofs.lean
@@ -11,7 +11,7 @@ Proves that declassification rules cannot escalate privileges:
 - Applying a rule twice is idempotent
 
 Hand-written Lean models mirroring `portcullis-core/src/declassify.rs`.
-All proofs fully checked, no sorry.
+All proofs fully checked, no proof holes.
 -/
 
 namespace DeclassifyProofs

--- a/crates/portcullis-core/lean/DelegationProofs.lean
+++ b/crates/portcullis-core/lean/DelegationProofs.lean
@@ -6,7 +6,7 @@ a child delegation can never exceed its parent's permissions on any
 dimension. This is the core safety property of the delegation plane.
 
 Hand-written Lean models mirroring `portcullis-core/src/delegation.rs`.
-All proofs fully checked by Lean 4, no sorry.
+All proofs fully checked by Lean 4, no proof holes.
 
 ## Properties proved
 

--- a/crates/portcullis-core/lean/ExposureProofs.lean
+++ b/crates/portcullis-core/lean/ExposureProofs.lean
@@ -15,7 +15,7 @@ Correspondence is enforced by compile-time `include_str!` assertions in
 Aeneas-generated), these are hand-written models — Aeneas does not yet
 translate `bool`-field structs or 13-variant enums.
 
-## Properties proved (all kernel-checked, no sorry)
+## Properties proved (all kernel-checked, no proof holes)
 
 - **Monotonicity**: exposure count never decreases under `union`
 - **Idempotency**: `union(s, s) = s`

--- a/crates/portcullis-core/lean/FlowGraphProofs.lean
+++ b/crates/portcullis-core/lean/FlowGraphProofs.lean
@@ -7,7 +7,7 @@ Proves that label propagation through the causal DAG preserves
 information flow invariants. Hand-written Lean models mirroring
 `portcullis-core/src/flow.rs` and `portcullis/src/flow_graph.rs`.
 
-No sorry. No SMT. All proofs fully checked by Lean 4.
+No proof holes. No SMT. All proofs fully checked by Lean 4.
 -/
 
 namespace FlowGraphProofs

--- a/crates/portcullis-core/lean/FlowProofs.lean
+++ b/crates/portcullis-core/lean/FlowProofs.lean
@@ -21,7 +21,7 @@ added to the Rust enum will NOT cause a Lean build failure.
 - **Confidentiality monotonicity**: joining with secret data produces secret output
 - **Quotient soundness**: `ifc_to_exposure` is a monotone homomorphism
 
-All proofs discharge via `decide` over finite types. No sorry, no SMT.
+All proofs discharge via `decide` over finite types. No proof holes, no SMT.
 -/
 
 namespace FlowProofs


### PR DESCRIPTION
## Summary

The Aeneas CI workflow greps for the literal string \`sorry\` in proof files to detect proof holes. Comments like "no sorry" were matching, causing a false-positive failure.

This was a latent bug masked by earlier build failures (#1476 DeclassifyProofs, #1497 CompartmentProofs, #1501 DelegationProofs). Once those were fixed, the workflow progressed to the "Reject sorry" step and hit these comment matches.

## Fix

Replace "no sorry" → "no proof holes" in docstrings of 7 files. No proof logic changed. All 7 still build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)