### PR TITLE
ci: resolve rand RUSTSEC-2026-0097, unblock open research PRs

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -14,7 +14,7 @@ ignore = [
     "RUSTSEC-2023-0071",
 
     # proc-macro-error unmaintained (RUSTSEC-2024-0370) — no security impact.
-    # Transitive dependency via c2pa-rs → iref → static-regular-grammar.
+    # Transitive via c2pa-rs → iref → static-regular-grammar.
     "RUSTSEC-2024-0370",
 
     # tracing-subscriber ANSI escape (RUSTSEC-2025-0055) — transitive via
@@ -28,4 +28,10 @@ ignore = [
     # derivative unmaintained (RUSTSEC-2024-0388) — transitive via
     # risc0-zkvm → ark-crypto-primitives. Feature-gated, no security impact.
     "RUSTSEC-2024-0388",
+
+    # rand unsoundness via custom logger calling rand::rng() (Stacked Borrows).
+    # Direct deps bumped to patched versions; remaining exposure is transitive
+    # rand 0.8.5 via rust_decimal/ruint — upstream has no patched 0.8.x.
+    # Not exploitable: no custom logger in these deps calls rand::rng().
+    "RUSTSEC-2026-0097",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1587,7 +1587,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f22d5c0b1147e8bd9105fa004450f673c139d7e632f7edc3980f94a51f20f3"
 dependencies = [
  "cap-std",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rustix",
  "rustix-linux-procfs",
  "uuid",
@@ -4804,7 +4804,7 @@ dependencies = [
  "nucleus-proto",
  "nucleus-spec",
  "portcullis",
- "rand 0.10.0",
+ "rand 0.10.1",
  "ring",
  "rust_decimal",
  "rustls 0.23.37",
@@ -4865,7 +4865,7 @@ dependencies = [
  "portcullis-core",
  "proptest",
  "prost 0.14.3",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rcgen",
  "reqwest 0.13.2",
  "ring",
@@ -4948,7 +4948,7 @@ dependencies = [
  "portcullis",
  "prost 0.14.3",
  "prost-types",
- "rand 0.8.5",
+ "rand_core 0.6.4",
  "reqwest 0.13.2",
  "rustls 0.23.37",
  "serde",
@@ -5390,7 +5390,7 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand 0.9.2",
+ "rand 0.9.3",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -5908,7 +5908,7 @@ dependencies = [
  "bit-vec",
  "bitflags 2.11.0",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -6189,7 +6189,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ring",
  "rustc-hash",
  "rustls 0.23.37",
@@ -6255,9 +6255,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -6265,9 +6265,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
@@ -6778,7 +6778,7 @@ dependencies = [
  "elf",
  "lazy_static",
  "postcard",
- "rand 0.9.2",
+ "rand 0.9.3",
  "risc0-zkp",
  "risc0-zkvm-platform",
  "ruint",
@@ -7024,7 +7024,7 @@ dependencies = [
  "http-body-util",
  "pastey",
  "pin-project-lite",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rmcp-macros",
  "schemars 1.2.1",
  "serde",
@@ -7092,7 +7092,7 @@ dependencies = [
  "borsh",
  "proptest",
  "rand 0.8.5",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ruint-macro",
  "serde_core",
  "valuable",

--- a/crates/nucleus-node/Cargo.toml
+++ b/crates/nucleus-node/Cargo.toml
@@ -50,7 +50,7 @@ rustls = { workspace = true }
 webpki-roots = "1.0"
 base64 = "0.22"
 ed25519-dalek = { version = "2", features = ["rand_core"] }
-rand = "0.8"
+rand_core = { version = "0.6", features = ["getrandom"] }
 
 # X.509 certificate parsing for SPIFFE ID extraction
 x509-parser = { workspace = true }

--- a/crates/nucleus-node/src/trust_gate.rs
+++ b/crates/nucleus-node/src/trust_gate.rs
@@ -61,7 +61,7 @@ impl Default for TrustGateConfig {
             enforce: false,                   // Log-only by default
             default_bracket: "C".to_string(), // Adequate — tenant profile
             receipt_secret: None,
-            executor_signing_key: Arc::new(SigningKey::generate(&mut rand::rngs::OsRng)),
+            executor_signing_key: Arc::new(SigningKey::generate(&mut rand_core::OsRng)),
             executor_id: format!("nucleus-executor/{}", uuid_hex()),
         }
     }
@@ -93,7 +93,7 @@ impl TrustGateConfig {
         let executor_id = std::env::var("TRUST_EXECUTOR_ID")
             .unwrap_or_else(|_| format!("nucleus-executor/{}", uuid_hex()));
 
-        let executor_signing_key = Arc::new(SigningKey::generate(&mut rand::rngs::OsRng));
+        let executor_signing_key = Arc::new(SigningKey::generate(&mut rand_core::OsRng));
 
         Self {
             trust_api_url: std::env::var("TRUST_API_URL").unwrap_or_default(),

--- a/deny.toml
+++ b/deny.toml
@@ -7,19 +7,15 @@ ignore = [
   # credential assertions, not RSA key operations.
   "RUSTSEC-2023-0071",
 
-  # proc-macro-error unmaintained — no security impact.
-  # Transitive via c2pa-rs → iref → static-regular-grammar.
-  "RUSTSEC-2024-0370",
-
   # tracing-subscriber ANSI escape — transitive via risc0-zkvm → ark-relations.
   # Feature-gated behind `zkvm`, not in default build.
   "RUSTSEC-2025-0055",
 
-  # bincode unmaintained — transitive via risc0-zkvm. Feature-gated.
-  "RUSTSEC-2025-0141",
-
-  # derivative unmaintained — transitive via risc0-zkvm → ark-crypto-primitives.
-  "RUSTSEC-2024-0388",
+  # rand unsoundness via custom logger calling rand::rng() (Stacked Borrows).
+  # Direct deps bumped to patched versions; only remaining usage is transitive
+  # rand 0.8.5 via rust_decimal/ruint — upstream has not released a patched
+  # version. Not exploitable here: no custom logger in these deps calls rand::rng().
+  "RUSTSEC-2026-0097",
 ]
 # These are informational; scope to workspace dependencies.
 unmaintained = "workspace"


### PR DESCRIPTION
## Summary
- Bump rand to patched versions (0.10.1, 0.9.3)
- nucleus-node: drop direct \`rand\` dep, use \`rand_core::OsRng\` (only \`OsRng\` was used anyway)
- \`.cargo/audit.toml\`: ignore RUSTSEC-2026-0097 for unavoidable transitive rand 0.8.5 (via rust_decimal/ruint — upstream has no patched 0.8.x). Advisory requires a custom logger calling \`rand::rng()\`; nothing in our tree does this.

Unblocks failing \`Security Audit\` + \`Cargo Deny\` checks on #1532 and #1533.

## Test plan
- [x] \`cargo audit -D warnings --no-fetch\` clean
- [x] \`cargo deny check\` passes
- [x] \`cargo build --workspace\` clean
- [x] pre-commit hooks pass