### PR TITLE
feat(lean): RankNullity scaffold + SimplexAcyclic roadmap for Honest Fundamental

### DIFF
--- a/crates/portcullis-core/lean/ComparisonTheorem.lean
+++ b/crates/portcullis-core/lean/ComparisonTheorem.lean
@@ -8,6 +8,7 @@ import Mathlib.Algebra.Category.ModuleCat.Basic
 import Mathlib.Data.ZMod.Defs
 import SemanticIFCDecidable
 import CechCohomology
+import RankNullity
 
 /-!
 # The Comparison Theorem: Čech ≅ Topos for Finite Alexandrov Posets
@@ -1406,6 +1407,32 @@ theorem no_exclusive_means_uniform {Secret : Type} [Fintype Secret] [DecidableEq
 
 /-! Forward direction = contrapositive + no_exclusive_means_uniform (PROVED)
 + uniform_implies_h1_zero (acyclicity — 1 sorry). -/
+
+/-- Edge case: if the reduced 1-simplex list is empty, `Ȟ¹ = 0` trivially.
+    Both boundary matrices degenerate (δ⁰ is empty; δ¹ has all-empty rows),
+    so `gaussRankBool` returns 0 on each. -/
+theorem reducedCechDim_of_c1_empty {Secret : Type} [Fintype Secret] [DecidableEq Secret]
+    (P : IndexedPoset Secret) (indices : List Nat)
+    (h : reducedC1 P indices = []) :
+    reducedCechDim P indices 1 = 0 := by
+  have hd0 : reducedDelta0 P indices = [] := by
+    unfold reducedDelta0
+    rw [h]
+    rfl
+  have hd1_empty_rows : ∀ row ∈ reducedDelta1 P indices, row = [] := by
+    intro row hrow
+    unfold reducedDelta1 at hrow
+    rw [h] at hrow
+    rcases List.mem_map.mp hrow with ⟨_, _, hrow_eq⟩
+    simp at hrow_eq
+    exact hrow_eq
+  show ((reducedC1 P indices).length - gf2Rank (reducedDelta1 P indices))
+        - gf2Rank (reducedDelta0 P indices) = 0
+  rw [h, hd0]
+  unfold gf2Rank
+  rw [PortcullisCore.RankNullity.gaussRankBool_empty_rows _ hd1_empty_rows,
+      PortcullisCore.RankNullity.gaussRankBool_nil]
+  rfl
 
 /-- The acyclicity lemma: if all levels force the same propositions,
     then H¹ = 0. This is the constant-presheaf acyclicity theorem

--- a/crates/portcullis-core/lean/ComparisonTheorem.lean
+++ b/crates/portcullis-core/lean/ComparisonTheorem.lean
@@ -1448,7 +1448,13 @@ theorem uniform_implies_h1_zero {Secret : Type} [Fintype Secret] [DecidableEq Se
        | some E => DObsLevel.dForces E (P.allProps[p]!)
        | none => false) = true) :
     reducedCechDim P indices 1 = 0 := by
-  sorry -- GF(2) acyclicity: constant presheaf on connected covering
+  -- Case split on whether the 1-simplex list is degenerate.
+  -- Empty case: dispatched by `reducedCechDim_of_c1_empty` (Step 5).
+  -- Nonempty case: classical Čech acyclicity for constant presheaf on the
+  -- full simplex of the covering nerve. Remaining structural content.
+  by_cases hC1 : reducedC1 P indices = []
+  · exact reducedCechDim_of_c1_empty P indices hC1
+  · sorry -- nonempty C¹ under uniform: Čech acyclicity of full simplex
 
 theorem h1_pos_implies_exclusive {Secret : Type} [Fintype Secret] [DecidableEq Secret]
     (P : IndexedPoset Secret) (indices : List Nat)

--- a/crates/portcullis-core/lean/RankNullity.lean
+++ b/crates/portcullis-core/lean/RankNullity.lean
@@ -64,9 +64,45 @@ theorem gaussRankBool_empty_rows (M : List (List Bool))
   unfold gaussRankBool
   exact go_empty_rows M h 0 0 _
 
+/-- A row of all-false entries returns `false` at any index via `getD`. -/
+private theorem getD_false_of_all_false (row : List Bool)
+    (h : ∀ b ∈ row, b = false) (col : Nat) :
+    row.getD col false = false := by
+  induction row generalizing col with
+  | nil => rfl
+  | cons hd tl ih =>
+    cases col with
+    | zero => exact h hd List.mem_cons_self
+    | succ n =>
+      have h' : ∀ b ∈ tl, b = false :=
+        fun b hb => h b (List.mem_cons_of_mem _ hb)
+      exact ih h' n
+
+/-- Gaussian elimination on an all-false matrix keeps rank at its input. -/
+private theorem go_zero_matrix (M : List (List Bool))
+    (h : ∀ row ∈ M, ∀ b ∈ row, b = false) (col r fuel : Nat) :
+    gaussRankBool.go M col r fuel = r := by
+  induction fuel generalizing M col r with
+  | zero => rfl
+  | succ k ih =>
+    unfold gaussRankBool.go
+    have hfind : M.find? (fun row => row.getD col false) = none := by
+      apply List.find?_eq_none.mpr
+      intro row hrow hcontra
+      have hrf : row.getD col false = false :=
+        getD_false_of_all_false row (h row hrow) col
+      rw [hrf] at hcontra
+      exact Bool.false_ne_true hcontra
+    rw [hfind]
+    by_cases hlt : col + 1 < (M.head?.map List.length |>.getD 0)
+    · simp [hlt]
+      exact ih M h (col + 1) r
+    · simp [hlt]
+
 /-- A matrix whose entries are all `false` has rank zero. -/
 theorem gaussRankBool_zero_matrix (M : List (List Bool))
     (h : ∀ row ∈ M, ∀ b ∈ row, b = false) : gaussRankBool M = 0 := by
-  sorry
+  unfold gaussRankBool
+  exact go_zero_matrix M h 0 0 _
 
 end PortcullisCore.RankNullity

--- a/crates/portcullis-core/lean/RankNullity.lean
+++ b/crates/portcullis-core/lean/RankNullity.lean
@@ -1,0 +1,47 @@
+import SemanticIFCDecidable
+
+/-! # GF(2) rank-nullity scaffold for List-based boolean matrices
+
+This file collects structural lemmas about `gaussRankBool` and `gf2Rank`
+(defined in `SemanticIFCDecidable` and `ComparisonTheorem` respectively)
+that support the Honest Fundamental Theorem of Cohomological Security.
+
+The two load-bearing downstream facts (in `ComparisonTheorem.lean`) are:
+
+* `uniform_implies_h1_zero` — a constant presheaf on a covering has `Ȟ¹ = 0`.
+* `exclusive_implies_h1_pos` — an exclusive forcing obstruction gives `Ȟ¹ > 0`.
+
+Both reduce to linear-algebra facts about the Boolean boundary matrices
+`reducedDelta0` and `reducedDelta1`. This module factors out those facts as
+first-class lemmas so the cohomology proofs can cite them cleanly.
+
+The `gaussRankBool` function is a fuel-bounded Gaussian elimination on
+`List (List Bool)`; its recursion makes direct structural induction painful.
+Lemmas here are stated as stand-alone facts and proved one-by-one in
+subsequent steps.
+-/
+
+open SemanticIFCDecidable.BoundaryMaps
+
+namespace PortcullisCore.RankNullity
+
+/-- Rank of the empty matrix is zero. -/
+theorem gaussRankBool_nil : gaussRankBool [] = 0 := by
+  sorry
+
+/-- Rank is at most the number of rows. -/
+theorem gaussRankBool_le_rows (M : List (List Bool)) :
+    gaussRankBool M ≤ M.length := by
+  sorry
+
+/-- A matrix whose rows are all empty has rank zero. -/
+theorem gaussRankBool_empty_rows (M : List (List Bool))
+    (h : ∀ row ∈ M, row = []) : gaussRankBool M = 0 := by
+  sorry
+
+/-- A matrix whose entries are all `false` has rank zero. -/
+theorem gaussRankBool_zero_matrix (M : List (List Bool))
+    (h : ∀ row ∈ M, ∀ b ∈ row, b = false) : gaussRankBool M = 0 := by
+  sorry
+
+end PortcullisCore.RankNullity

--- a/crates/portcullis-core/lean/RankNullity.lean
+++ b/crates/portcullis-core/lean/RankNullity.lean
@@ -29,10 +29,61 @@ namespace PortcullisCore.RankNullity
 theorem gaussRankBool_nil : gaussRankBool [] = 0 := by
   rfl
 
+/-- Filter with `· ≠ x` strictly shrinks a list that contains `x`. -/
+private theorem length_filter_ne_lt {α : Type*} [DecidableEq α]
+    (l : List α) {x : α} (hx : x ∈ l) :
+    (l.filter (· ≠ x)).length < l.length := by
+  induction l with
+  | nil => exact (List.not_mem_nil hx).elim
+  | cons hd tl ih =>
+    by_cases heq : hd = x
+    · subst heq
+      simp [List.filter_cons]
+      -- filter keeps others with length ≤ tl.length, + 0 for hd
+      exact Nat.lt_succ_of_le (List.length_filter_le _ _)
+    · rcases List.mem_cons.mp hx with rfl | htl
+      · exact absurd rfl heq
+      · have hlt := ih htl
+        simp [List.filter_cons, heq]
+        omega
+
+/-- Gaussian elimination invariant: rank ≤ starting rank + row count. -/
+private theorem go_le_rows (M : List (List Bool)) (col r fuel : Nat) :
+    gaussRankBool.go M col r fuel ≤ r + M.length := by
+  induction fuel generalizing M col r with
+  | zero =>
+    unfold gaussRankBool.go
+    omega
+  | succ k ih =>
+    unfold gaussRankBool.go
+    cases hfind : M.find? (fun row => row.getD col false) with
+    | none =>
+      simp only
+      by_cases hlt : col + 1 < (M.head?.map List.length |>.getD 0)
+      · simp [hlt]
+        exact ih M (col + 1) r
+      · simp [hlt]
+    | some pivot =>
+      simp only
+      have hmem : pivot ∈ M := List.mem_of_find?_eq_some hfind
+      have hshrink : (M.filter (· ≠ pivot)).length < M.length :=
+        length_filter_ne_lt M hmem
+      have h_map_len : ((M.filter (· ≠ pivot)).map
+          (fun row => if row.getD col false then xorRows row pivot else row)).length
+          = (M.filter (· ≠ pivot)).length := List.length_map _
+      have h_ih := ih
+          ((M.filter (· ≠ pivot)).map
+            (fun row => if row.getD col false then xorRows row pivot else row))
+          (col + 1) (r + 1)
+      rw [h_map_len] at h_ih
+      omega
+
 /-- Rank is at most the number of rows. -/
 theorem gaussRankBool_le_rows (M : List (List Bool)) :
     gaussRankBool M ≤ M.length := by
-  sorry
+  unfold gaussRankBool
+  have := go_le_rows M 0 0 (M.length + (M.head?.map List.length |>.getD 0))
+  omega
 
 /-- Auxiliary: Gaussian elimination on a matrix of all-empty rows preserves rank. -/
 private theorem go_empty_rows (M : List (List Bool))

--- a/crates/portcullis-core/lean/RankNullity.lean
+++ b/crates/portcullis-core/lean/RankNullity.lean
@@ -27,17 +27,42 @@ namespace PortcullisCore.RankNullity
 
 /-- Rank of the empty matrix is zero. -/
 theorem gaussRankBool_nil : gaussRankBool [] = 0 := by
-  sorry
+  rfl
 
 /-- Rank is at most the number of rows. -/
 theorem gaussRankBool_le_rows (M : List (List Bool)) :
     gaussRankBool M ≤ M.length := by
   sorry
 
+/-- Auxiliary: Gaussian elimination on a matrix of all-empty rows preserves rank. -/
+private theorem go_empty_rows (M : List (List Bool))
+    (h : ∀ row ∈ M, row = []) (col r fuel : Nat) :
+    gaussRankBool.go M col r fuel = r := by
+  induction fuel generalizing M col r with
+  | zero => rfl
+  | succ k ih =>
+    unfold gaussRankBool.go
+    -- All rows are [], so row.getD col false = false for every row.
+    have hfind : M.find? (fun row => row.getD col false) = none := by
+      apply List.find?_eq_none.mpr
+      intro row hrow
+      simp [h row hrow]
+    rw [hfind]
+    -- M.head?.map List.length |>.getD 0 = 0 since head, if any, is [].
+    have hlen : (M.head?.map List.length |>.getD 0) = 0 := by
+      cases M with
+      | nil => rfl
+      | cons hd tl =>
+        have : hd = [] := h hd List.mem_cons_self
+        simp [this]
+    rw [hlen]
+    simp
+
 /-- A matrix whose rows are all empty has rank zero. -/
 theorem gaussRankBool_empty_rows (M : List (List Bool))
     (h : ∀ row ∈ M, row = []) : gaussRankBool M = 0 := by
-  sorry
+  unfold gaussRankBool
+  exact go_empty_rows M h 0 0 _
 
 /-- A matrix whose entries are all `false` has rank zero. -/
 theorem gaussRankBool_zero_matrix (M : List (List Bool))

--- a/crates/portcullis-core/lean/SimplexAcyclic.lean
+++ b/crates/portcullis-core/lean/SimplexAcyclic.lean
@@ -71,6 +71,32 @@ def coneMap2 (i₀ : Nat) (c2entry : Nat × Nat × Nat × Nat) :
   else if k = i₀ then some (i, j, p)
   else none
 
+/-- **Characterization**: `coneMap1` returns `some` iff the cone vertex is
+    incident to the 1-simplex. Foundational small lemma for the cone
+    construction — every downstream homotopy identity case-splits on this. -/
+theorem coneMap1_isSome (i₀ : Nat) (c1entry : Nat × Nat × Nat) :
+    (coneMap1 i₀ c1entry).isSome ↔ c1entry.1 = i₀ ∨ c1entry.2.1 = i₀ := by
+  obtain ⟨i, j, p⟩ := c1entry
+  unfold coneMap1
+  by_cases h : i = i₀ ∨ j = i₀
+  · simp [h]
+  · simp [h]
+
+/-- **Characterization**: `coneMap2` returns `some` iff the cone vertex is
+    incident to the 2-simplex. -/
+theorem coneMap2_isSome (i₀ : Nat) (c2entry : Nat × Nat × Nat × Nat) :
+    (coneMap2 i₀ c2entry).isSome ↔
+      c2entry.1 = i₀ ∨ c2entry.2.1 = i₀ ∨ c2entry.2.2.1 = i₀ := by
+  obtain ⟨i, j, k, p⟩ := c2entry
+  unfold coneMap2
+  by_cases hi : i = i₀
+  · simp [hi]
+  by_cases hj : j = i₀
+  · simp [hi, hj]
+  by_cases hk : k = i₀
+  · simp [hi, hj, hk]
+  simp [hi, hj, hk]
+
 /-- **Target theorem** (nonempty C¹ case of `uniform_implies_h1_zero`).
 
     Under the uniform hypothesis and for a nonempty `indices`, the

--- a/crates/portcullis-core/lean/SimplexAcyclic.lean
+++ b/crates/portcullis-core/lean/SimplexAcyclic.lean
@@ -1,0 +1,102 @@
+import ComparisonTheorem
+
+/-! # Acyclicity of the full simplex over GF(2)
+
+This file develops the classical cone/contracting-homotopy proof that a
+full simplex has trivial reduced cohomology, specialised to the Čech
+presheaf of a *constant* (uniform) restriction.
+
+## Strategy
+
+For a finite set of indices and a presheaf `F` that restricts trivially
+(every level forces the same props), the reduced Čech complex decomposes
+per-proposition into copies of the simplicial cochain complex of the full
+simplex on `indices`.
+
+Over GF(2), the full n-simplex has trivial reduced cohomology. The
+classical proof uses a *cone construction*: fix a cone vertex `v₀` and
+define `s : Cᵏ → Cᵏ⁻¹` by "delete `v₀` from simplices containing it".
+One verifies
+
+    δ ∘ s + s ∘ δ = id − ε∘η
+
+where `ε` is the augmentation and `η : M → C⁰` the constant embedding.
+This identity gives `ker δ ⊆ im δ`, hence H¹ = 0.
+
+## Connection to the List-based Čech complex
+
+The concrete matrices in `ComparisonTheorem` (`reducedDelta0`, `reducedDelta1`)
+are Boolean matrices indexed by `(C⁰, C¹)` and `(C¹, C²)` respectively.
+The cone operator is an explicit Boolean matrix `S : C¹ → C⁰` that picks a
+cone vertex and "prepends" it to each 1-simplex containing it.
+
+## Current status
+
+This file states the definitions and the target theorem. Proving the
+contracting-homotopy identity and bridging to `gaussRankBool` closes
+`ComparisonTheorem.uniform_implies_h1_zero` for the nonempty C¹ case.
+
+The proof strategy is classical (Hatcher §2.1, Mumford–Oda Ch. VII §1,
+Weibel §8). Over GF(2) the sign arithmetic collapses, giving the cleanest
+formalisation.
+-/
+
+open SemanticIFCDecidable
+open SemanticIFCDecidable.BoundaryMaps
+open AlexandrovSite
+open PresheafCech
+
+namespace PortcullisCore.SimplexAcyclic
+
+/-- Cone operator at vertex `i₀`: sends a 1-simplex `(i, j, p)` to the
+    0-simplex `(i₀, p)` if `i₀` is incident to the 1-simplex's carrier,
+    else 0. This is the "delete `i₀` from the 1-simplex" homotopy,
+    rephrased as a C¹ → C⁰ map via adjacency.
+
+    The precise rule: `s₁(i₀)(i, j, p) = 1_{(i₀, p)}` exactly when
+    `i₀ ∈ {i, j}` and `p` is forced at `i₀`. Else `0`.
+
+    Over GF(2), this collapses `±` signs into simple `xor`. -/
+def coneMap1 (i₀ : Nat) (c1entry : Nat × Nat × Nat) : Option (Nat × Nat) :=
+  let (i, j, p) := c1entry
+  if i = i₀ ∨ j = i₀ then some (i₀, p) else none
+
+/-- Cone operator at vertex `i₀` for 2-simplices: sends `(i, j, k, p)` to
+    the 1-simplex obtained by deleting `i₀` if `i₀ ∈ {i, j, k}`. -/
+def coneMap2 (i₀ : Nat) (c2entry : Nat × Nat × Nat × Nat) :
+    Option (Nat × Nat × Nat) :=
+  let (i, j, k, p) := c2entry
+  if i = i₀ then some (j, k, p)
+  else if j = i₀ then some (i, k, p)
+  else if k = i₀ then some (i, j, p)
+  else none
+
+/-- **Target theorem** (nonempty C¹ case of `uniform_implies_h1_zero`).
+
+    Under the uniform hypothesis and for a nonempty `indices`, the
+    contracting-homotopy identity via `coneMap1`/`coneMap2` shows every
+    cocycle is a coboundary, hence H¹ = 0.
+
+    Proof outline:
+      1. Extract a cone vertex `i₀` from the nonempty `indices`.
+      2. Build explicit preimages for each (i, j, p) ∈ C¹ via `coneMap1`.
+      3. Verify δ⁰ ∘ s₁ + s₂ ∘ δ¹ = id by case analysis on whether `i₀`
+         is incident to the simplex.
+      4. Conclude `rank(δ⁰) ≥ |C¹| − rank(δ¹)`, which combined with the
+         chain-complex property δ¹ ∘ δ⁰ = 0 yields equality. -/
+theorem simplex_acyclic_h1 {Secret : Type} [Fintype Secret] [DecidableEq Secret]
+    (P : IndexedPoset Secret) (indices : List Nat)
+    (hne : indices ≠ [])
+    (hC1 : reducedC1 P indices ≠ [])
+    (h_uniform : ∀ i ∈ indices, ∀ j ∈ indices, ∀ p : Nat,
+      p < P.allProps.length →
+      (match P.levels[i]? with
+       | some E => DObsLevel.dForces E (P.allProps[p]!)
+       | none => false) = true →
+      (match P.levels[j]? with
+       | some E => DObsLevel.dForces E (P.allProps[p]!)
+       | none => false) = true) :
+    reducedCechDim P indices 1 = 0 := by
+  sorry -- cone construction: δ⁰ ∘ s₁ + s₂ ∘ δ¹ = id ⇒ H¹ = 0
+
+end PortcullisCore.SimplexAcyclic

--- a/crates/portcullis-core/lean/lakefile.lean
+++ b/crates/portcullis-core/lean/lakefile.lean
@@ -83,3 +83,7 @@ lean_lib «ComparisonTheorem» where
 -- GF(2) rank-nullity scaffold supporting Honest Fundamental Theorem.
 lean_lib «RankNullity» where
   roots := #[`RankNullity]
+
+-- Simplex acyclicity: cone construction for H¹ = 0 under uniform presheaf.
+lean_lib «SimplexAcyclic» where
+  roots := #[`SimplexAcyclic]

--- a/crates/portcullis-core/lean/lakefile.lean
+++ b/crates/portcullis-core/lean/lakefile.lean
@@ -79,3 +79,7 @@ lean_lib «CechCohomology» where
 -- Proof skeleton replacing the comparison axiom.
 lean_lib «ComparisonTheorem» where
   roots := #[`ComparisonTheorem]
+
+-- GF(2) rank-nullity scaffold supporting Honest Fundamental Theorem.
+lean_lib «RankNullity» where
+  roots := #[`RankNullity]


### PR DESCRIPTION
## Summary

Lays groundwork for closing the two remaining sorry's in
\`ComparisonTheorem.honest_fundamental\` by introducing a clean algebraic
scaffold (\`RankNullity.lean\`) and a classical-proof roadmap
(\`SimplexAcyclic.lean\`) for the uniform → H¹ = 0 direction.

## What's in

### \`RankNullity.lean\` (zero sorry)
4 proved lemmas about the GF(2) Gaussian-elimination function
\`SemanticIFCDecidable.BoundaryMaps.gaussRankBool\`:
- \`gaussRankBool_nil\` — rank of the empty matrix is 0
- \`gaussRankBool_empty_rows\` — rank of a matrix with all-empty rows is 0
- \`gaussRankBool_zero_matrix\` — rank of an all-false matrix is 0
- \`gaussRankBool_le_rows\` — rank ≤ row count

### \`ComparisonTheorem.lean\`
- \`reducedCechDim_of_c1_empty\` — degenerate edge case: if \`reducedC1 = []\`,
  then Ȟ¹ = 0 via direct reduction through the RankNullity lemmas.
- \`uniform_implies_h1_zero\` refactored to dispatch the empty-C¹ case via the
  new lemma, narrowing the remaining sorry to the nonempty case.

### \`SimplexAcyclic.lean\` (1 target sorry)
Classical Čech acyclicity roadmap via the cone construction over GF(2):
- \`coneMap1\`, \`coneMap2\` — executable cone operators at a vertex.
- \`coneMap1_isSome\`, \`coneMap2_isSome\` — incidence characterizations (proved).
- \`simplex_acyclic_h1\` — target theorem stating H¹ = 0 for nonempty C¹
  under uniform. Sorry with explicit multi-step proof outline (cone-based
  contracting homotopy, δ⁰ ∘ s₁ + s₂ ∘ δ¹ = id).

## Why

\`ComparisonTheorem.honest_fundamental\` currently has 2 load-bearing sorry's:
\`uniform_implies_h1_zero\` and \`exclusive_implies_h1_pos\`. Both reduce to
GF(2) rank-nullity facts. This PR:
1. Ships proven infrastructure that any closure of those sorry's will use.
2. Narrows \`uniform_implies_h1_zero\` to the classical simplex-acyclicity
   case (the nontrivial C¹ branch).
3. Provides a concrete cone-construction scaffold for the remaining work,
   grounded in Hatcher §2.1 / Mumford–Oda / Weibel §8.

## What's NOT in

The remaining \`simplex_acyclic_h1\` proof and the \`exclusive_implies_h1_pos\`
direction. Both are multi-day formalizations deserving their own PRs.

## Test plan

- [x] \`lake build RankNullity\` clean
- [x] \`lake build SimplexAcyclic\` clean
- [x] \`lake build ComparisonTheorem\` clean (1254 jobs, 6 sorry's — same count
      as pre-PR; 4 Borromean unchanged, 2 honest_fundamental narrowed)
- [x] pre-commit hooks pass