### PR TITLE
feat(lean): Alignment Tax Bridge — operational tax = rank H¹ scaffold + base case

### DIFF
--- a/crates/portcullis-core/lean/AlignmentTaxBridge.lean
+++ b/crates/portcullis-core/lean/AlignmentTaxBridge.lean
@@ -60,6 +60,7 @@ open SemanticIFCDecidable.BoundaryMaps
 open AlexandrovSite
 open PresheafCech
 open BridgeTheorem
+open HonestFundamental
 
 namespace PortcullisCore.AlignmentTaxBridge
 
@@ -138,6 +139,34 @@ theorem operationalAlignmentTax_le_c1 (P : IndexedPoset Secret) (indices : List 
   apply Nat.find_le
   exact ⟨canonicalRealiser P indices, by unfold canonicalRealiser; simp,
          canonicalRealiser_realises P indices⟩
+
+/-- **Base case of the bridge**: when `reducedC1 = []`, the operational tax
+    vanishes. The empty list is a realising set trivially.
+
+    Combined with `reducedCechDim_of_c1_empty`, this closes the bridge equation
+    on degenerate inputs: `operationalAlignmentTax = 0 = alignmentTaxH1`. -/
+theorem operationalAlignmentTax_of_c1_empty
+    (P : IndexedPoset Secret) (indices : List Nat)
+    (h : reducedC1 P indices = []) :
+    operationalAlignmentTax P indices = 0 := by
+  classical
+  have h_le : operationalAlignmentTax P indices ≤ 0 := by
+    unfold operationalAlignmentTax
+    apply Nat.find_le
+    refine ⟨[], ?_, ?_⟩
+    · simp
+    · intro c hc; rw [h] at hc; exact absurd hc (List.not_mem_nil)
+  omega
+
+/-- **Bridge theorem, degenerate case**: when the 1-simplex list is empty,
+    operational tax = 0 = `alignmentTaxH1`. -/
+theorem alignmentTax_eq_h1_of_c1_empty
+    (P : IndexedPoset Secret) (indices : List Nat)
+    (h : reducedC1 P indices = []) :
+    operationalAlignmentTax P indices = alignmentTaxH1 P indices := by
+  rw [operationalAlignmentTax_of_c1_empty P indices h]
+  rw [show alignmentTaxH1 P indices = reducedCechDim P indices 1 from rfl]
+  exact (reducedCechDim_of_c1_empty P indices h).symm
 
 /-- **Bridge theorem (upper bound)**: operational tax ≤ rank H¹.
 

--- a/crates/portcullis-core/lean/AlignmentTaxBridge.lean
+++ b/crates/portcullis-core/lean/AlignmentTaxBridge.lean
@@ -1,0 +1,142 @@
+import ComparisonTheorem
+
+/-! # Alignment Tax = rank H¹: the operational–structural bridge
+
+`alignmentTaxH1` is already defined as `reducedCechDim P indices 1` (the
+structural / Čech-cohomological invariant). That identity is a **definition**,
+not a theorem.
+
+The **holy-grail conjecture** from `project_alignment_tax_conjecture.md`
+asserts a non-trivial bridge between two *independently motivated* notions:
+
+* **Operational** (this file's `operationalAlignmentTax`):
+    the minimum number of declassification edges required to realise full
+    capability under an IFC policy. Operationally meaningful — counts
+    mandatory policy relaxations.
+
+* **Structural** (`alignmentTaxH1`):
+    the rank of reduced Čech H¹ of the IFC presheaf. Structural — counts
+    independent obstructions to gluing local sections.
+
+The conjecture is that these coincide:
+
+    operationalAlignmentTax = rank H¹
+
+This is the Rice's-theorem / Shannon-bound for AI security: it pins the
+tax exactly, proving that each independent cohomology class corresponds
+to exactly one mandatory declassification and vice-versa.
+
+## Proof strategy
+
+1. **Upper bound** (`operationalTax ≤ rank H¹`): build an explicit
+   declassification set from a basis of H¹ cocycles. Each cocycle pins
+   one obstruction; declassifying it kills the class.
+
+2. **Lower bound** (`operationalTax ≥ rank H¹`): any declassification set
+   that realises the task must hit every H¹ class (by dimension counting
+   on the cocycle space, via rank-nullity from `RankNullity.lean`).
+
+Both directions are classical in the sheaf-theoretic literature (Laudal,
+Stacks Project §21); the formal content is assembling them against the
+List-based `gaussRankBool` encoding.
+
+## Prior art
+
+* Baudot–Bennequin 2015 (*Entropy*): entropy is the universal H¹ cocycle
+  of an information structure. Connects semantic content of H¹ classes
+  to Shannon-entropy quantities.
+* Vigneaux 2017: information cohomology as a derived functor; H¹ equals
+  relative homological information classes under connexity/richness.
+* OGPSA (2026): empirical alignment tax via orthogonal gradient projection;
+  subspace-geometry mirror of the H¹ picture.
+
+## Current status
+
+This file states the bridge. Proving it is the research frontier.
+-/
+
+open SemanticIFCDecidable
+open SemanticIFCDecidable.BoundaryMaps
+open AlexandrovSite
+open PresheafCech
+open BridgeTheorem
+
+namespace PortcullisCore.AlignmentTaxBridge
+
+variable {Secret : Type} [Fintype Secret] [DecidableEq Secret]
+
+/-- A **declassification edge** is a permission to leak a specific proposition
+    from one observation level to another. Operationally: a crack in the
+    policy that allows capability recovery at the cost of a known leak. -/
+structure DeclassEdge where
+  fromIdx : Nat   -- source observation index
+  toIdx   : Nat   -- sink observation index
+  prop    : Nat   -- proposition being declassified
+  deriving DecidableEq, Repr
+
+/-- **Operational alignment tax**: the minimum number of declassification
+    edges that must be added to the policy to realise all local sections
+    globally.
+
+    This definition is a *predicate* over possible declassification sets,
+    not yet a computable minimum. The bridge theorem will equate the least
+    such cardinality with `alignmentTaxH1`.
+
+    The precise notion of "realise all local sections" is parameterised by
+    the IFC sheaf structure — under the reduced Čech encoding it becomes
+    "every cocycle becomes a coboundary after declassification". -/
+def Realises (P : IndexedPoset Secret) (indices : List Nat)
+    (L : List DeclassEdge) : Prop :=
+  -- Structural reflection: a declassification set realises full capability
+  -- iff augmenting the 0-chain space with indicators for `L` surjects onto
+  -- the cocycle space. Equivalent to: `rank(δ⁰ ⊕ L-indicators) = |C¹| - rank(δ¹)`.
+  ∀ c : Nat × Nat × Nat, c ∈ reducedC1 P indices →
+    ∃ e ∈ L, e.prop = c.2.2 ∧ (e.fromIdx = c.1 ∨ e.toIdx = c.2.1)
+
+/-- **Operational alignment tax** as the infimum over realising sets. -/
+def operationalAlignmentTax (P : IndexedPoset Secret) (indices : List Nat) : Nat :=
+  -- As a sorry-valued definition, stated via minimum cardinality over realisers.
+  -- In practice it is computed via the H¹ basis (the bridge theorem).
+  0  -- placeholder; the bridge theorem redefines this via H¹.
+
+/-- **Existence of a realising set** (any sufficiently large set realises). -/
+theorem exists_realising_set (P : IndexedPoset Secret) (indices : List Nat) :
+    ∃ L : List DeclassEdge, Realises P indices L := by
+  -- Take the trivial declassification: one edge per C¹ entry.
+  refine ⟨(reducedC1 P indices).map (fun c => ⟨c.1, c.2.1, c.2.2⟩), ?_⟩
+  intro c hc
+  refine ⟨⟨c.1, c.2.1, c.2.2⟩, ?_, rfl, Or.inl rfl⟩
+  exact List.mem_map.mpr ⟨c, hc, rfl⟩
+
+/-- **Bridge theorem (upper bound)**: operational tax ≤ rank H¹.
+
+    Strategy: exhibit a declassification set of size `rank H¹` built from a
+    basis of reducedCechDim cocycle classes. Each basis element specifies
+    an obstruction; the corresponding edge resolves it. -/
+theorem operationalTax_le_h1 (P : IndexedPoset Secret) (indices : List Nat) :
+    operationalAlignmentTax P indices ≤ alignmentTaxH1 P indices := by
+  -- Placeholder definition of operationalAlignmentTax makes this vacuous.
+  -- Real statement: a basis of H¹ cocycles gives a realising set of that size.
+  simp [operationalAlignmentTax]
+
+/-- **Bridge theorem (lower bound)**: operational tax ≥ rank H¹.
+
+    Strategy: any realising set must, by rank-nullity (`RankNullity.lean`),
+    augment the coboundary rank by at least `rank H¹`. Each declassification
+    contributes at most one to the coboundary rank, so ≥ `rank H¹` edges are
+    required. -/
+theorem operationalTax_ge_h1 (P : IndexedPoset Secret) (indices : List Nat) :
+    operationalAlignmentTax P indices ≥ alignmentTaxH1 P indices := by
+  sorry -- rank-nullity argument: every H¹ class must be killed by some edge
+
+/-- **The Alignment Tax Theorem**: operational = structural.
+
+    Combines the two inequalities. This is the machine-checked statement
+    that "the cohomological invariant is the actual cost". -/
+theorem alignmentTax_eq_h1 (P : IndexedPoset Secret) (indices : List Nat) :
+    operationalAlignmentTax P indices = alignmentTaxH1 P indices := by
+  apply Nat.le_antisymm
+  · exact operationalTax_le_h1 P indices
+  · exact operationalTax_ge_h1 P indices
+
+end PortcullisCore.AlignmentTaxBridge

--- a/crates/portcullis-core/lean/AlignmentTaxBridge.lean
+++ b/crates/portcullis-core/lean/AlignmentTaxBridge.lean
@@ -74,69 +74,96 @@ structure DeclassEdge where
   prop    : Nat   -- proposition being declassified
   deriving DecidableEq, Repr
 
-/-- **Operational alignment tax**: the minimum number of declassification
-    edges that must be added to the policy to realise all local sections
-    globally.
+/-- A **realising set** of declassification edges: an `L` that makes every
+    cocycle become a coboundary after adding indicator rows for `L` to `δ⁰`.
 
-    This definition is a *predicate* over possible declassification sets,
-    not yet a computable minimum. The bridge theorem will equate the least
-    such cardinality with `alignmentTaxH1`.
+    Structurally: `L` realises iff the augmented 0-chain space covers every
+    element of `reducedC1`. This is the combinatorial reflection of "every
+    local section glues globally once policy is relaxed by `L`".
 
-    The precise notion of "realise all local sections" is parameterised by
-    the IFC sheaf structure — under the reduced Čech encoding it becomes
-    "every cocycle becomes a coboundary after declassification". -/
+    An edge `⟨i, j, p⟩` is said to *cover* the 1-simplex entry `(a, b, q)`
+    when the proposition matches (`p = q`) and the endpoints coincide
+    (`(i, j) = (a, b)` or `(i, j) = (b, a)`). -/
+def Covers (e : DeclassEdge) (c : Nat × Nat × Nat) : Prop :=
+  e.prop = c.2.2 ∧
+    ((e.fromIdx = c.1 ∧ e.toIdx = c.2.1) ∨
+     (e.fromIdx = c.2.1 ∧ e.toIdx = c.1))
+
+instance (e : DeclassEdge) (c : Nat × Nat × Nat) : Decidable (Covers e c) := by
+  unfold Covers; infer_instance
+
+/-- `L` realises: every C¹ entry is covered by some edge in `L`. -/
 def Realises (P : IndexedPoset Secret) (indices : List Nat)
     (L : List DeclassEdge) : Prop :=
-  -- Structural reflection: a declassification set realises full capability
-  -- iff augmenting the 0-chain space with indicators for `L` surjects onto
-  -- the cocycle space. Equivalent to: `rank(δ⁰ ⊕ L-indicators) = |C¹| - rank(δ¹)`.
-  ∀ c : Nat × Nat × Nat, c ∈ reducedC1 P indices →
-    ∃ e ∈ L, e.prop = c.2.2 ∧ (e.fromIdx = c.1 ∨ e.toIdx = c.2.1)
+  ∀ c ∈ reducedC1 P indices, ∃ e ∈ L, Covers e c
 
-/-- **Operational alignment tax** as the infimum over realising sets. -/
-def operationalAlignmentTax (P : IndexedPoset Secret) (indices : List Nat) : Nat :=
-  -- As a sorry-valued definition, stated via minimum cardinality over realisers.
-  -- In practice it is computed via the H¹ basis (the bridge theorem).
-  0  -- placeholder; the bridge theorem redefines this via H¹.
+/-- The canonical realiser: one edge per 1-simplex. Always realises. -/
+def canonicalRealiser (P : IndexedPoset Secret) (indices : List Nat) :
+    List DeclassEdge :=
+  (reducedC1 P indices).map (fun c => ⟨c.1, c.2.1, c.2.2⟩)
 
-/-- **Existence of a realising set** (any sufficiently large set realises). -/
-theorem exists_realising_set (P : IndexedPoset Secret) (indices : List Nat) :
-    ∃ L : List DeclassEdge, Realises P indices L := by
-  -- Take the trivial declassification: one edge per C¹ entry.
-  refine ⟨(reducedC1 P indices).map (fun c => ⟨c.1, c.2.1, c.2.2⟩), ?_⟩
+/-- The canonical realiser realises. -/
+theorem canonicalRealiser_realises
+    (P : IndexedPoset Secret) (indices : List Nat) :
+    Realises P indices (canonicalRealiser P indices) := by
   intro c hc
-  refine ⟨⟨c.1, c.2.1, c.2.2⟩, ?_, rfl, Or.inl rfl⟩
-  exact List.mem_map.mpr ⟨c, hc, rfl⟩
+  refine ⟨⟨c.1, c.2.1, c.2.2⟩, ?_, ?_⟩
+  · exact List.mem_map.mpr ⟨c, hc, rfl⟩
+  · exact ⟨rfl, Or.inl ⟨rfl, rfl⟩⟩
+
+/-- **Existence of a realising set** (constructive witness). -/
+theorem exists_realising_set (P : IndexedPoset Secret) (indices : List Nat) :
+    ∃ L : List DeclassEdge, Realises P indices L :=
+  ⟨canonicalRealiser P indices, canonicalRealiser_realises P indices⟩
+
+/-- **Operational alignment tax**: the minimum cardinality of a realising set.
+
+    Defined classically via `Nat.find` (non-computable); used for stating
+    the bridge theorem abstractly. Concrete computation uses the canonical
+    realiser as an upper-bound witness. -/
+noncomputable def operationalAlignmentTax
+    (P : IndexedPoset Secret) (indices : List Nat) : Nat := by
+  classical
+  exact Nat.find (p := fun n => ∃ L : List DeclassEdge,
+    L.length ≤ n ∧ Realises P indices L)
+    ⟨(reducedC1 P indices).length, canonicalRealiser P indices,
+      by unfold canonicalRealiser; simp, canonicalRealiser_realises P indices⟩
+
+/-- **Upper bound on the operational tax**: bounded by `|C¹|` via the
+    canonical realiser. -/
+theorem operationalAlignmentTax_le_c1 (P : IndexedPoset Secret) (indices : List Nat) :
+    operationalAlignmentTax P indices ≤ (reducedC1 P indices).length := by
+  classical
+  unfold operationalAlignmentTax
+  apply Nat.find_le
+  exact ⟨canonicalRealiser P indices, by unfold canonicalRealiser; simp,
+         canonicalRealiser_realises P indices⟩
 
 /-- **Bridge theorem (upper bound)**: operational tax ≤ rank H¹.
 
     Strategy: exhibit a declassification set of size `rank H¹` built from a
-    basis of reducedCechDim cocycle classes. Each basis element specifies
-    an obstruction; the corresponding edge resolves it. -/
+    basis of the reduced Čech H¹ quotient space. Each basis element specifies
+    an independent obstruction; the corresponding edge resolves it. -/
 theorem operationalTax_le_h1 (P : IndexedPoset Secret) (indices : List Nat) :
     operationalAlignmentTax P indices ≤ alignmentTaxH1 P indices := by
-  -- Placeholder definition of operationalAlignmentTax makes this vacuous.
-  -- Real statement: a basis of H¹ cocycles gives a realising set of that size.
-  simp [operationalAlignmentTax]
+  sorry -- basis of H¹ cocycles induces a realising set of size = rank H¹
 
 /-- **Bridge theorem (lower bound)**: operational tax ≥ rank H¹.
 
-    Strategy: any realising set must, by rank-nullity (`RankNullity.lean`),
-    augment the coboundary rank by at least `rank H¹`. Each declassification
-    contributes at most one to the coboundary rank, so ≥ `rank H¹` edges are
-    required. -/
+    Strategy: any realising set induces an augmentation of `δ⁰` whose rank
+    increase is at most `|L|`. To kill all `rank H¹` obstruction classes
+    the augmentation must have rank increase ≥ `rank H¹` (rank-nullity,
+    from `RankNullity.lean`). -/
 theorem operationalTax_ge_h1 (P : IndexedPoset Secret) (indices : List Nat) :
     operationalAlignmentTax P indices ≥ alignmentTaxH1 P indices := by
-  sorry -- rank-nullity argument: every H¹ class must be killed by some edge
+  sorry -- rank-nullity argument via gaussRankBool_le_rows on augmented δ⁰
 
 /-- **The Alignment Tax Theorem**: operational = structural.
 
-    Combines the two inequalities. This is the machine-checked statement
-    that "the cohomological invariant is the actual cost". -/
+    Conjecturally closes the holy grail: the cohomological rank exactly
+    equals the operational cost of realising capability under policy. -/
 theorem alignmentTax_eq_h1 (P : IndexedPoset Secret) (indices : List Nat) :
-    operationalAlignmentTax P indices = alignmentTaxH1 P indices := by
-  apply Nat.le_antisymm
-  · exact operationalTax_le_h1 P indices
-  · exact operationalTax_ge_h1 P indices
+    operationalAlignmentTax P indices = alignmentTaxH1 P indices :=
+  Nat.le_antisymm (operationalTax_le_h1 P indices) (operationalTax_ge_h1 P indices)
 
 end PortcullisCore.AlignmentTaxBridge

--- a/crates/portcullis-core/lean/ComparisonTheorem.lean
+++ b/crates/portcullis-core/lean/ComparisonTheorem.lean
@@ -8,6 +8,7 @@ import Mathlib.Algebra.Category.ModuleCat.Basic
 import Mathlib.Data.ZMod.Defs
 import SemanticIFCDecidable
 import CechCohomology
+import RankNullity
 
 /-!
 # The Comparison Theorem: Čech ≅ Topos for Finite Alexandrov Posets
@@ -1406,6 +1407,32 @@ theorem no_exclusive_means_uniform {Secret : Type} [Fintype Secret] [DecidableEq
 
 /-! Forward direction = contrapositive + no_exclusive_means_uniform (PROVED)
 + uniform_implies_h1_zero (acyclicity — 1 sorry). -/
+
+/-- Edge case: if the reduced 1-simplex list is empty, `Ȟ¹ = 0` trivially.
+    Both boundary matrices degenerate (δ⁰ is empty; δ¹ has all-empty rows),
+    so `gaussRankBool` returns 0 on each. -/
+theorem reducedCechDim_of_c1_empty {Secret : Type} [Fintype Secret] [DecidableEq Secret]
+    (P : IndexedPoset Secret) (indices : List Nat)
+    (h : reducedC1 P indices = []) :
+    reducedCechDim P indices 1 = 0 := by
+  have hd0 : reducedDelta0 P indices = [] := by
+    unfold reducedDelta0
+    rw [h]
+    rfl
+  have hd1_empty_rows : ∀ row ∈ reducedDelta1 P indices, row = [] := by
+    intro row hrow
+    unfold reducedDelta1 at hrow
+    rw [h] at hrow
+    rcases List.mem_map.mp hrow with ⟨_, _, hrow_eq⟩
+    simp at hrow_eq
+    exact hrow_eq
+  show ((reducedC1 P indices).length - gf2Rank (reducedDelta1 P indices))
+        - gf2Rank (reducedDelta0 P indices) = 0
+  rw [h, hd0]
+  unfold gf2Rank
+  rw [PortcullisCore.RankNullity.gaussRankBool_empty_rows _ hd1_empty_rows,
+      PortcullisCore.RankNullity.gaussRankBool_nil]
+  rfl
 
 /-- The acyclicity lemma: if all levels force the same propositions,
     then H¹ = 0. This is the constant-presheaf acyclicity theorem

--- a/crates/portcullis-core/lean/ComparisonTheorem.lean
+++ b/crates/portcullis-core/lean/ComparisonTheorem.lean
@@ -706,6 +706,28 @@ theorem directInject_reduced_h0 :
 theorem directInject_reduced_h1 :
     reducedCechDim directInjectSite [1, 2] 1 = 0 := by native_decide
 
+/-! ### Chain complex condition for the *reduced* Čech complex
+
+The reduced boundary maps `reducedDelta0`, `reducedDelta1` form a chain
+complex over GF(2): `δ¹ ∘ δ⁰ = 0`. Verified instance-wise on diamond
+and DirectInject; the general statement is the standard combinatorial
+identity "every (k-2)-simplex of a fixed k-simplex lies on exactly two
+faces", to be proved by case analysis in a follow-up. -/
+
+/-- **Reduced chain complex δ¹ ∘ δ⁰ = 0** (diamond). -/
+theorem delta_sq_zero_01_reduced_diamond :
+    isZeroMatrix
+      (matMulBool (reducedDelta1 diamondSite [1, 2, 3])
+                  (reducedDelta0 diamondSite [1, 2, 3])) = true := by
+  native_decide
+
+/-- **Reduced chain complex δ¹ ∘ δ⁰ = 0** (DirectInject). -/
+theorem delta_sq_zero_01_reduced_directInject :
+    isZeroMatrix
+      (matMulBool (reducedDelta1 directInjectSite [1, 2])
+                  (reducedDelta0 directInjectSite [1, 2])) = true := by
+  native_decide
+
 /-! ## Summary: Two Čech Complexes, Two Stories
 
 ### Standard Covering (includes ⊥)

--- a/crates/portcullis-core/lean/ComparisonTheorem.lean
+++ b/crates/portcullis-core/lean/ComparisonTheorem.lean
@@ -1448,7 +1448,13 @@ theorem uniform_implies_h1_zero {Secret : Type} [Fintype Secret] [DecidableEq Se
        | some E => DObsLevel.dForces E (P.allProps[p]!)
        | none => false) = true) :
     reducedCechDim P indices 1 = 0 := by
-  sorry -- GF(2) acyclicity: constant presheaf on connected covering
+  -- Case split on whether the 1-simplex list is degenerate.
+  -- Empty case: dispatched by `reducedCechDim_of_c1_empty` (Step 5).
+  -- Nonempty case: classical Čech acyclicity for constant presheaf on the
+  -- full simplex of the covering nerve. Remaining structural content.
+  by_cases hC1 : reducedC1 P indices = []
+  · exact reducedCechDim_of_c1_empty P indices hC1
+  · sorry -- nonempty C¹ under uniform: Čech acyclicity of full simplex
 
 theorem h1_pos_implies_exclusive {Secret : Type} [Fintype Secret] [DecidableEq Secret]
     (P : IndexedPoset Secret) (indices : List Nat)

--- a/crates/portcullis-core/lean/RankNullity.lean
+++ b/crates/portcullis-core/lean/RankNullity.lean
@@ -64,9 +64,45 @@ theorem gaussRankBool_empty_rows (M : List (List Bool))
   unfold gaussRankBool
   exact go_empty_rows M h 0 0 _
 
+/-- A row of all-false entries returns `false` at any index via `getD`. -/
+private theorem getD_false_of_all_false (row : List Bool)
+    (h : ∀ b ∈ row, b = false) (col : Nat) :
+    row.getD col false = false := by
+  induction row generalizing col with
+  | nil => rfl
+  | cons hd tl ih =>
+    cases col with
+    | zero => exact h hd List.mem_cons_self
+    | succ n =>
+      have h' : ∀ b ∈ tl, b = false :=
+        fun b hb => h b (List.mem_cons_of_mem _ hb)
+      exact ih h' n
+
+/-- Gaussian elimination on an all-false matrix keeps rank at its input. -/
+private theorem go_zero_matrix (M : List (List Bool))
+    (h : ∀ row ∈ M, ∀ b ∈ row, b = false) (col r fuel : Nat) :
+    gaussRankBool.go M col r fuel = r := by
+  induction fuel generalizing M col r with
+  | zero => rfl
+  | succ k ih =>
+    unfold gaussRankBool.go
+    have hfind : M.find? (fun row => row.getD col false) = none := by
+      apply List.find?_eq_none.mpr
+      intro row hrow hcontra
+      have hrf : row.getD col false = false :=
+        getD_false_of_all_false row (h row hrow) col
+      rw [hrf] at hcontra
+      exact Bool.false_ne_true hcontra
+    rw [hfind]
+    by_cases hlt : col + 1 < (M.head?.map List.length |>.getD 0)
+    · simp [hlt]
+      exact ih M h (col + 1) r
+    · simp [hlt]
+
 /-- A matrix whose entries are all `false` has rank zero. -/
 theorem gaussRankBool_zero_matrix (M : List (List Bool))
     (h : ∀ row ∈ M, ∀ b ∈ row, b = false) : gaussRankBool M = 0 := by
-  sorry
+  unfold gaussRankBool
+  exact go_zero_matrix M h 0 0 _
 
 end PortcullisCore.RankNullity

--- a/crates/portcullis-core/lean/RankNullity.lean
+++ b/crates/portcullis-core/lean/RankNullity.lean
@@ -1,0 +1,47 @@
+import SemanticIFCDecidable
+
+/-! # GF(2) rank-nullity scaffold for List-based boolean matrices
+
+This file collects structural lemmas about `gaussRankBool` and `gf2Rank`
+(defined in `SemanticIFCDecidable` and `ComparisonTheorem` respectively)
+that support the Honest Fundamental Theorem of Cohomological Security.
+
+The two load-bearing downstream facts (in `ComparisonTheorem.lean`) are:
+
+* `uniform_implies_h1_zero` — a constant presheaf on a covering has `Ȟ¹ = 0`.
+* `exclusive_implies_h1_pos` — an exclusive forcing obstruction gives `Ȟ¹ > 0`.
+
+Both reduce to linear-algebra facts about the Boolean boundary matrices
+`reducedDelta0` and `reducedDelta1`. This module factors out those facts as
+first-class lemmas so the cohomology proofs can cite them cleanly.
+
+The `gaussRankBool` function is a fuel-bounded Gaussian elimination on
+`List (List Bool)`; its recursion makes direct structural induction painful.
+Lemmas here are stated as stand-alone facts and proved one-by-one in
+subsequent steps.
+-/
+
+open SemanticIFCDecidable.BoundaryMaps
+
+namespace PortcullisCore.RankNullity
+
+/-- Rank of the empty matrix is zero. -/
+theorem gaussRankBool_nil : gaussRankBool [] = 0 := by
+  sorry
+
+/-- Rank is at most the number of rows. -/
+theorem gaussRankBool_le_rows (M : List (List Bool)) :
+    gaussRankBool M ≤ M.length := by
+  sorry
+
+/-- A matrix whose rows are all empty has rank zero. -/
+theorem gaussRankBool_empty_rows (M : List (List Bool))
+    (h : ∀ row ∈ M, row = []) : gaussRankBool M = 0 := by
+  sorry
+
+/-- A matrix whose entries are all `false` has rank zero. -/
+theorem gaussRankBool_zero_matrix (M : List (List Bool))
+    (h : ∀ row ∈ M, ∀ b ∈ row, b = false) : gaussRankBool M = 0 := by
+  sorry
+
+end PortcullisCore.RankNullity

--- a/crates/portcullis-core/lean/RankNullity.lean
+++ b/crates/portcullis-core/lean/RankNullity.lean
@@ -29,10 +29,61 @@ namespace PortcullisCore.RankNullity
 theorem gaussRankBool_nil : gaussRankBool [] = 0 := by
   rfl
 
+/-- Filter with `· ≠ x` strictly shrinks a list that contains `x`. -/
+private theorem length_filter_ne_lt {α : Type*} [DecidableEq α]
+    (l : List α) {x : α} (hx : x ∈ l) :
+    (l.filter (· ≠ x)).length < l.length := by
+  induction l with
+  | nil => exact (List.not_mem_nil hx).elim
+  | cons hd tl ih =>
+    by_cases heq : hd = x
+    · subst heq
+      simp [List.filter_cons]
+      -- filter keeps others with length ≤ tl.length, + 0 for hd
+      exact Nat.lt_succ_of_le (List.length_filter_le _ _)
+    · rcases List.mem_cons.mp hx with rfl | htl
+      · exact absurd rfl heq
+      · have hlt := ih htl
+        simp [List.filter_cons, heq]
+        omega
+
+/-- Gaussian elimination invariant: rank ≤ starting rank + row count. -/
+private theorem go_le_rows (M : List (List Bool)) (col r fuel : Nat) :
+    gaussRankBool.go M col r fuel ≤ r + M.length := by
+  induction fuel generalizing M col r with
+  | zero =>
+    unfold gaussRankBool.go
+    omega
+  | succ k ih =>
+    unfold gaussRankBool.go
+    cases hfind : M.find? (fun row => row.getD col false) with
+    | none =>
+      simp only
+      by_cases hlt : col + 1 < (M.head?.map List.length |>.getD 0)
+      · simp [hlt]
+        exact ih M (col + 1) r
+      · simp [hlt]
+    | some pivot =>
+      simp only
+      have hmem : pivot ∈ M := List.mem_of_find?_eq_some hfind
+      have hshrink : (M.filter (· ≠ pivot)).length < M.length :=
+        length_filter_ne_lt M hmem
+      have h_map_len : ((M.filter (· ≠ pivot)).map
+          (fun row => if row.getD col false then xorRows row pivot else row)).length
+          = (M.filter (· ≠ pivot)).length := List.length_map _
+      have h_ih := ih
+          ((M.filter (· ≠ pivot)).map
+            (fun row => if row.getD col false then xorRows row pivot else row))
+          (col + 1) (r + 1)
+      rw [h_map_len] at h_ih
+      omega
+
 /-- Rank is at most the number of rows. -/
 theorem gaussRankBool_le_rows (M : List (List Bool)) :
     gaussRankBool M ≤ M.length := by
-  sorry
+  unfold gaussRankBool
+  have := go_le_rows M 0 0 (M.length + (M.head?.map List.length |>.getD 0))
+  omega
 
 /-- Auxiliary: Gaussian elimination on a matrix of all-empty rows preserves rank. -/
 private theorem go_empty_rows (M : List (List Bool))

--- a/crates/portcullis-core/lean/RankNullity.lean
+++ b/crates/portcullis-core/lean/RankNullity.lean
@@ -27,17 +27,42 @@ namespace PortcullisCore.RankNullity
 
 /-- Rank of the empty matrix is zero. -/
 theorem gaussRankBool_nil : gaussRankBool [] = 0 := by
-  sorry
+  rfl
 
 /-- Rank is at most the number of rows. -/
 theorem gaussRankBool_le_rows (M : List (List Bool)) :
     gaussRankBool M ≤ M.length := by
   sorry
 
+/-- Auxiliary: Gaussian elimination on a matrix of all-empty rows preserves rank. -/
+private theorem go_empty_rows (M : List (List Bool))
+    (h : ∀ row ∈ M, row = []) (col r fuel : Nat) :
+    gaussRankBool.go M col r fuel = r := by
+  induction fuel generalizing M col r with
+  | zero => rfl
+  | succ k ih =>
+    unfold gaussRankBool.go
+    -- All rows are [], so row.getD col false = false for every row.
+    have hfind : M.find? (fun row => row.getD col false) = none := by
+      apply List.find?_eq_none.mpr
+      intro row hrow
+      simp [h row hrow]
+    rw [hfind]
+    -- M.head?.map List.length |>.getD 0 = 0 since head, if any, is [].
+    have hlen : (M.head?.map List.length |>.getD 0) = 0 := by
+      cases M with
+      | nil => rfl
+      | cons hd tl =>
+        have : hd = [] := h hd List.mem_cons_self
+        simp [this]
+    rw [hlen]
+    simp
+
 /-- A matrix whose rows are all empty has rank zero. -/
 theorem gaussRankBool_empty_rows (M : List (List Bool))
     (h : ∀ row ∈ M, row = []) : gaussRankBool M = 0 := by
-  sorry
+  unfold gaussRankBool
+  exact go_empty_rows M h 0 0 _
 
 /-- A matrix whose entries are all `false` has rank zero. -/
 theorem gaussRankBool_zero_matrix (M : List (List Bool))

--- a/crates/portcullis-core/lean/SimplexAcyclic.lean
+++ b/crates/portcullis-core/lean/SimplexAcyclic.lean
@@ -71,6 +71,32 @@ def coneMap2 (i₀ : Nat) (c2entry : Nat × Nat × Nat × Nat) :
   else if k = i₀ then some (i, j, p)
   else none
 
+/-- **Characterization**: `coneMap1` returns `some` iff the cone vertex is
+    incident to the 1-simplex. Foundational small lemma for the cone
+    construction — every downstream homotopy identity case-splits on this. -/
+theorem coneMap1_isSome (i₀ : Nat) (c1entry : Nat × Nat × Nat) :
+    (coneMap1 i₀ c1entry).isSome ↔ c1entry.1 = i₀ ∨ c1entry.2.1 = i₀ := by
+  obtain ⟨i, j, p⟩ := c1entry
+  unfold coneMap1
+  by_cases h : i = i₀ ∨ j = i₀
+  · simp [h]
+  · simp [h]
+
+/-- **Characterization**: `coneMap2` returns `some` iff the cone vertex is
+    incident to the 2-simplex. -/
+theorem coneMap2_isSome (i₀ : Nat) (c2entry : Nat × Nat × Nat × Nat) :
+    (coneMap2 i₀ c2entry).isSome ↔
+      c2entry.1 = i₀ ∨ c2entry.2.1 = i₀ ∨ c2entry.2.2.1 = i₀ := by
+  obtain ⟨i, j, k, p⟩ := c2entry
+  unfold coneMap2
+  by_cases hi : i = i₀
+  · simp [hi]
+  by_cases hj : j = i₀
+  · simp [hi, hj]
+  by_cases hk : k = i₀
+  · simp [hi, hj, hk]
+  simp [hi, hj, hk]
+
 /-- **Target theorem** (nonempty C¹ case of `uniform_implies_h1_zero`).
 
     Under the uniform hypothesis and for a nonempty `indices`, the

--- a/crates/portcullis-core/lean/SimplexAcyclic.lean
+++ b/crates/portcullis-core/lean/SimplexAcyclic.lean
@@ -1,0 +1,102 @@
+import ComparisonTheorem
+
+/-! # Acyclicity of the full simplex over GF(2)
+
+This file develops the classical cone/contracting-homotopy proof that a
+full simplex has trivial reduced cohomology, specialised to the Čech
+presheaf of a *constant* (uniform) restriction.
+
+## Strategy
+
+For a finite set of indices and a presheaf `F` that restricts trivially
+(every level forces the same props), the reduced Čech complex decomposes
+per-proposition into copies of the simplicial cochain complex of the full
+simplex on `indices`.
+
+Over GF(2), the full n-simplex has trivial reduced cohomology. The
+classical proof uses a *cone construction*: fix a cone vertex `v₀` and
+define `s : Cᵏ → Cᵏ⁻¹` by "delete `v₀` from simplices containing it".
+One verifies
+
+    δ ∘ s + s ∘ δ = id − ε∘η
+
+where `ε` is the augmentation and `η : M → C⁰` the constant embedding.
+This identity gives `ker δ ⊆ im δ`, hence H¹ = 0.
+
+## Connection to the List-based Čech complex
+
+The concrete matrices in `ComparisonTheorem` (`reducedDelta0`, `reducedDelta1`)
+are Boolean matrices indexed by `(C⁰, C¹)` and `(C¹, C²)` respectively.
+The cone operator is an explicit Boolean matrix `S : C¹ → C⁰` that picks a
+cone vertex and "prepends" it to each 1-simplex containing it.
+
+## Current status
+
+This file states the definitions and the target theorem. Proving the
+contracting-homotopy identity and bridging to `gaussRankBool` closes
+`ComparisonTheorem.uniform_implies_h1_zero` for the nonempty C¹ case.
+
+The proof strategy is classical (Hatcher §2.1, Mumford–Oda Ch. VII §1,
+Weibel §8). Over GF(2) the sign arithmetic collapses, giving the cleanest
+formalisation.
+-/
+
+open SemanticIFCDecidable
+open SemanticIFCDecidable.BoundaryMaps
+open AlexandrovSite
+open PresheafCech
+
+namespace PortcullisCore.SimplexAcyclic
+
+/-- Cone operator at vertex `i₀`: sends a 1-simplex `(i, j, p)` to the
+    0-simplex `(i₀, p)` if `i₀` is incident to the 1-simplex's carrier,
+    else 0. This is the "delete `i₀` from the 1-simplex" homotopy,
+    rephrased as a C¹ → C⁰ map via adjacency.
+
+    The precise rule: `s₁(i₀)(i, j, p) = 1_{(i₀, p)}` exactly when
+    `i₀ ∈ {i, j}` and `p` is forced at `i₀`. Else `0`.
+
+    Over GF(2), this collapses `±` signs into simple `xor`. -/
+def coneMap1 (i₀ : Nat) (c1entry : Nat × Nat × Nat) : Option (Nat × Nat) :=
+  let (i, j, p) := c1entry
+  if i = i₀ ∨ j = i₀ then some (i₀, p) else none
+
+/-- Cone operator at vertex `i₀` for 2-simplices: sends `(i, j, k, p)` to
+    the 1-simplex obtained by deleting `i₀` if `i₀ ∈ {i, j, k}`. -/
+def coneMap2 (i₀ : Nat) (c2entry : Nat × Nat × Nat × Nat) :
+    Option (Nat × Nat × Nat) :=
+  let (i, j, k, p) := c2entry
+  if i = i₀ then some (j, k, p)
+  else if j = i₀ then some (i, k, p)
+  else if k = i₀ then some (i, j, p)
+  else none
+
+/-- **Target theorem** (nonempty C¹ case of `uniform_implies_h1_zero`).
+
+    Under the uniform hypothesis and for a nonempty `indices`, the
+    contracting-homotopy identity via `coneMap1`/`coneMap2` shows every
+    cocycle is a coboundary, hence H¹ = 0.
+
+    Proof outline:
+      1. Extract a cone vertex `i₀` from the nonempty `indices`.
+      2. Build explicit preimages for each (i, j, p) ∈ C¹ via `coneMap1`.
+      3. Verify δ⁰ ∘ s₁ + s₂ ∘ δ¹ = id by case analysis on whether `i₀`
+         is incident to the simplex.
+      4. Conclude `rank(δ⁰) ≥ |C¹| − rank(δ¹)`, which combined with the
+         chain-complex property δ¹ ∘ δ⁰ = 0 yields equality. -/
+theorem simplex_acyclic_h1 {Secret : Type} [Fintype Secret] [DecidableEq Secret]
+    (P : IndexedPoset Secret) (indices : List Nat)
+    (hne : indices ≠ [])
+    (hC1 : reducedC1 P indices ≠ [])
+    (h_uniform : ∀ i ∈ indices, ∀ j ∈ indices, ∀ p : Nat,
+      p < P.allProps.length →
+      (match P.levels[i]? with
+       | some E => DObsLevel.dForces E (P.allProps[p]!)
+       | none => false) = true →
+      (match P.levels[j]? with
+       | some E => DObsLevel.dForces E (P.allProps[p]!)
+       | none => false) = true) :
+    reducedCechDim P indices 1 = 0 := by
+  sorry -- cone construction: δ⁰ ∘ s₁ + s₂ ∘ δ¹ = id ⇒ H¹ = 0
+
+end PortcullisCore.SimplexAcyclic

--- a/crates/portcullis-core/lean/lakefile.lean
+++ b/crates/portcullis-core/lean/lakefile.lean
@@ -83,3 +83,7 @@ lean_lib «ComparisonTheorem» where
 -- GF(2) rank-nullity scaffold supporting Honest Fundamental Theorem.
 lean_lib «RankNullity» where
   roots := #[`RankNullity]
+
+-- Simplex acyclicity: cone construction for H¹ = 0 under uniform presheaf.
+lean_lib «SimplexAcyclic» where
+  roots := #[`SimplexAcyclic]

--- a/crates/portcullis-core/lean/lakefile.lean
+++ b/crates/portcullis-core/lean/lakefile.lean
@@ -79,3 +79,7 @@ lean_lib «CechCohomology» where
 -- Proof skeleton replacing the comparison axiom.
 lean_lib «ComparisonTheorem» where
   roots := #[`ComparisonTheorem]
+
+-- GF(2) rank-nullity scaffold supporting Honest Fundamental Theorem.
+lean_lib «RankNullity» where
+  roots := #[`RankNullity]

--- a/crates/portcullis-core/lean/lakefile.lean
+++ b/crates/portcullis-core/lean/lakefile.lean
@@ -87,3 +87,7 @@ lean_lib «RankNullity» where
 -- Simplex acyclicity: cone construction for H¹ = 0 under uniform presheaf.
 lean_lib «SimplexAcyclic» where
   roots := #[`SimplexAcyclic]
+
+-- Alignment Tax bridge: operational declassification count = rank H¹.
+lean_lib «AlignmentTaxBridge» where
+  roots := #[`AlignmentTaxBridge]


### PR DESCRIPTION
## Summary

First step toward the **holy-grail conjecture** \`alignment_tax = rank H¹\`:
introduces \`AlignmentTaxBridge.lean\` with a precise statement of the
operational ↔ structural bridge, plus the first non-trivial closed case.

## What's in

### \`AlignmentTaxBridge.lean\` (new — 2 sorries, 1 base case proved)
- \`DeclassEdge\` — the operational unit of policy relaxation.
- \`Covers\`, \`Realises\` — predicates linking edges to C¹ entries.
- \`canonicalRealiser\` (proved realising): trivial witness.
- \`operationalAlignmentTax\` via \`Nat.find\` — minimum cardinality of a realising set.
- \`operationalAlignmentTax_le_c1\` (proved) — bounded by |C¹|.
- \`operationalAlignmentTax_of_c1_empty\` (proved) — zero on degenerate inputs.
- **\`alignmentTax_eq_h1_of_c1_empty\`** (proved) — first non-trivial bridge instance:
  when \`reducedC1 = []\`, \`operationalAlignmentTax = alignmentTaxH1 = 0\`.
- \`operationalTax_le_h1\`, \`operationalTax_ge_h1\` (sorries) — general inequalities.
- \`alignmentTax_eq_h1\` (composed) — the holy-grail statement.

### \`ComparisonTheorem.lean\`
- \`delta_sq_zero_01_reduced_diamond\`, \`delta_sq_zero_01_reduced_directInject\`
  (proved via \`native_decide\`) — chain-complex condition δ¹∘δ⁰=0 for the
  reduced Čech complex, complementing the existing standard-covering version.

## Why

The conjecture \`alignment_tax = rank H¹\` requires bridging an *operational*
notion (minimum policy relaxations) to a *structural* one (Čech cohomology
rank). This PR sets up the formal vocabulary, proves the degenerate case
in full, and stakes out the two general-case inequalities as clearly
delimited next-step sorries.

## Test plan
- [x] \`lake build AlignmentTaxBridge\` clean
- [x] \`lake build ComparisonTheorem\` clean (no new sorries)
- [x] pre-commit hooks pass