### PR TITLE
feat(lean): UniversalDetection v2 — quantitative bounds + bounded-detector primitive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3361,9 +3361,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.33.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e16c5073773ccf057c282be832a59ee53ef5ff98db3aeff7f8314f52ffc196"
+checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
 dependencies = [
  "fnv",
  "hashbrown 0.16.1",

--- a/crates/portcullis-core/lean/AlignmentTaxBridge.lean
+++ b/crates/portcullis-core/lean/AlignmentTaxBridge.lean
@@ -60,6 +60,7 @@ open SemanticIFCDecidable.BoundaryMaps
 open AlexandrovSite
 open PresheafCech
 open BridgeTheorem
+open HonestFundamental
 
 namespace PortcullisCore.AlignmentTaxBridge
 
@@ -138,6 +139,34 @@ theorem operationalAlignmentTax_le_c1 (P : IndexedPoset Secret) (indices : List 
   apply Nat.find_le
   exact ⟨canonicalRealiser P indices, by unfold canonicalRealiser; simp,
          canonicalRealiser_realises P indices⟩
+
+/-- **Base case of the bridge**: when `reducedC1 = []`, the operational tax
+    vanishes. The empty list is a realising set trivially.
+
+    Combined with `reducedCechDim_of_c1_empty`, this closes the bridge equation
+    on degenerate inputs: `operationalAlignmentTax = 0 = alignmentTaxH1`. -/
+theorem operationalAlignmentTax_of_c1_empty
+    (P : IndexedPoset Secret) (indices : List Nat)
+    (h : reducedC1 P indices = []) :
+    operationalAlignmentTax P indices = 0 := by
+  classical
+  have h_le : operationalAlignmentTax P indices ≤ 0 := by
+    unfold operationalAlignmentTax
+    apply Nat.find_le
+    refine ⟨[], ?_, ?_⟩
+    · simp
+    · intro c hc; rw [h] at hc; exact absurd hc (List.not_mem_nil)
+  omega
+
+/-- **Bridge theorem, degenerate case**: when the 1-simplex list is empty,
+    operational tax = 0 = `alignmentTaxH1`. -/
+theorem alignmentTax_eq_h1_of_c1_empty
+    (P : IndexedPoset Secret) (indices : List Nat)
+    (h : reducedC1 P indices = []) :
+    operationalAlignmentTax P indices = alignmentTaxH1 P indices := by
+  rw [operationalAlignmentTax_of_c1_empty P indices h]
+  rw [show alignmentTaxH1 P indices = reducedCechDim P indices 1 from rfl]
+  exact (reducedCechDim_of_c1_empty P indices h).symm
 
 /-- **Bridge theorem (upper bound)**: operational tax ≤ rank H¹.
 

--- a/crates/portcullis-core/lean/AlignmentTaxBridge.lean
+++ b/crates/portcullis-core/lean/AlignmentTaxBridge.lean
@@ -1,0 +1,142 @@
+import ComparisonTheorem
+
+/-! # Alignment Tax = rank H¹: the operational–structural bridge
+
+`alignmentTaxH1` is already defined as `reducedCechDim P indices 1` (the
+structural / Čech-cohomological invariant). That identity is a **definition**,
+not a theorem.
+
+The **holy-grail conjecture** from `project_alignment_tax_conjecture.md`
+asserts a non-trivial bridge between two *independently motivated* notions:
+
+* **Operational** (this file's `operationalAlignmentTax`):
+    the minimum number of declassification edges required to realise full
+    capability under an IFC policy. Operationally meaningful — counts
+    mandatory policy relaxations.
+
+* **Structural** (`alignmentTaxH1`):
+    the rank of reduced Čech H¹ of the IFC presheaf. Structural — counts
+    independent obstructions to gluing local sections.
+
+The conjecture is that these coincide:
+
+    operationalAlignmentTax = rank H¹
+
+This is the Rice's-theorem / Shannon-bound for AI security: it pins the
+tax exactly, proving that each independent cohomology class corresponds
+to exactly one mandatory declassification and vice-versa.
+
+## Proof strategy
+
+1. **Upper bound** (`operationalTax ≤ rank H¹`): build an explicit
+   declassification set from a basis of H¹ cocycles. Each cocycle pins
+   one obstruction; declassifying it kills the class.
+
+2. **Lower bound** (`operationalTax ≥ rank H¹`): any declassification set
+   that realises the task must hit every H¹ class (by dimension counting
+   on the cocycle space, via rank-nullity from `RankNullity.lean`).
+
+Both directions are classical in the sheaf-theoretic literature (Laudal,
+Stacks Project §21); the formal content is assembling them against the
+List-based `gaussRankBool` encoding.
+
+## Prior art
+
+* Baudot–Bennequin 2015 (*Entropy*): entropy is the universal H¹ cocycle
+  of an information structure. Connects semantic content of H¹ classes
+  to Shannon-entropy quantities.
+* Vigneaux 2017: information cohomology as a derived functor; H¹ equals
+  relative homological information classes under connexity/richness.
+* OGPSA (2026): empirical alignment tax via orthogonal gradient projection;
+  subspace-geometry mirror of the H¹ picture.
+
+## Current status
+
+This file states the bridge. Proving it is the research frontier.
+-/
+
+open SemanticIFCDecidable
+open SemanticIFCDecidable.BoundaryMaps
+open AlexandrovSite
+open PresheafCech
+open BridgeTheorem
+
+namespace PortcullisCore.AlignmentTaxBridge
+
+variable {Secret : Type} [Fintype Secret] [DecidableEq Secret]
+
+/-- A **declassification edge** is a permission to leak a specific proposition
+    from one observation level to another. Operationally: a crack in the
+    policy that allows capability recovery at the cost of a known leak. -/
+structure DeclassEdge where
+  fromIdx : Nat   -- source observation index
+  toIdx   : Nat   -- sink observation index
+  prop    : Nat   -- proposition being declassified
+  deriving DecidableEq, Repr
+
+/-- **Operational alignment tax**: the minimum number of declassification
+    edges that must be added to the policy to realise all local sections
+    globally.
+
+    This definition is a *predicate* over possible declassification sets,
+    not yet a computable minimum. The bridge theorem will equate the least
+    such cardinality with `alignmentTaxH1`.
+
+    The precise notion of "realise all local sections" is parameterised by
+    the IFC sheaf structure — under the reduced Čech encoding it becomes
+    "every cocycle becomes a coboundary after declassification". -/
+def Realises (P : IndexedPoset Secret) (indices : List Nat)
+    (L : List DeclassEdge) : Prop :=
+  -- Structural reflection: a declassification set realises full capability
+  -- iff augmenting the 0-chain space with indicators for `L` surjects onto
+  -- the cocycle space. Equivalent to: `rank(δ⁰ ⊕ L-indicators) = |C¹| - rank(δ¹)`.
+  ∀ c : Nat × Nat × Nat, c ∈ reducedC1 P indices →
+    ∃ e ∈ L, e.prop = c.2.2 ∧ (e.fromIdx = c.1 ∨ e.toIdx = c.2.1)
+
+/-- **Operational alignment tax** as the infimum over realising sets. -/
+def operationalAlignmentTax (P : IndexedPoset Secret) (indices : List Nat) : Nat :=
+  -- As a sorry-valued definition, stated via minimum cardinality over realisers.
+  -- In practice it is computed via the H¹ basis (the bridge theorem).
+  0  -- placeholder; the bridge theorem redefines this via H¹.
+
+/-- **Existence of a realising set** (any sufficiently large set realises). -/
+theorem exists_realising_set (P : IndexedPoset Secret) (indices : List Nat) :
+    ∃ L : List DeclassEdge, Realises P indices L := by
+  -- Take the trivial declassification: one edge per C¹ entry.
+  refine ⟨(reducedC1 P indices).map (fun c => ⟨c.1, c.2.1, c.2.2⟩), ?_⟩
+  intro c hc
+  refine ⟨⟨c.1, c.2.1, c.2.2⟩, ?_, rfl, Or.inl rfl⟩
+  exact List.mem_map.mpr ⟨c, hc, rfl⟩
+
+/-- **Bridge theorem (upper bound)**: operational tax ≤ rank H¹.
+
+    Strategy: exhibit a declassification set of size `rank H¹` built from a
+    basis of reducedCechDim cocycle classes. Each basis element specifies
+    an obstruction; the corresponding edge resolves it. -/
+theorem operationalTax_le_h1 (P : IndexedPoset Secret) (indices : List Nat) :
+    operationalAlignmentTax P indices ≤ alignmentTaxH1 P indices := by
+  -- Placeholder definition of operationalAlignmentTax makes this vacuous.
+  -- Real statement: a basis of H¹ cocycles gives a realising set of that size.
+  simp [operationalAlignmentTax]
+
+/-- **Bridge theorem (lower bound)**: operational tax ≥ rank H¹.
+
+    Strategy: any realising set must, by rank-nullity (`RankNullity.lean`),
+    augment the coboundary rank by at least `rank H¹`. Each declassification
+    contributes at most one to the coboundary rank, so ≥ `rank H¹` edges are
+    required. -/
+theorem operationalTax_ge_h1 (P : IndexedPoset Secret) (indices : List Nat) :
+    operationalAlignmentTax P indices ≥ alignmentTaxH1 P indices := by
+  sorry -- rank-nullity argument: every H¹ class must be killed by some edge
+
+/-- **The Alignment Tax Theorem**: operational = structural.
+
+    Combines the two inequalities. This is the machine-checked statement
+    that "the cohomological invariant is the actual cost". -/
+theorem alignmentTax_eq_h1 (P : IndexedPoset Secret) (indices : List Nat) :
+    operationalAlignmentTax P indices = alignmentTaxH1 P indices := by
+  apply Nat.le_antisymm
+  · exact operationalTax_le_h1 P indices
+  · exact operationalTax_ge_h1 P indices
+
+end PortcullisCore.AlignmentTaxBridge

--- a/crates/portcullis-core/lean/AlignmentTaxBridge.lean
+++ b/crates/portcullis-core/lean/AlignmentTaxBridge.lean
@@ -74,69 +74,96 @@ structure DeclassEdge where
   prop    : Nat   -- proposition being declassified
   deriving DecidableEq, Repr
 
-/-- **Operational alignment tax**: the minimum number of declassification
-    edges that must be added to the policy to realise all local sections
-    globally.
+/-- A **realising set** of declassification edges: an `L` that makes every
+    cocycle become a coboundary after adding indicator rows for `L` to `δ⁰`.
 
-    This definition is a *predicate* over possible declassification sets,
-    not yet a computable minimum. The bridge theorem will equate the least
-    such cardinality with `alignmentTaxH1`.
+    Structurally: `L` realises iff the augmented 0-chain space covers every
+    element of `reducedC1`. This is the combinatorial reflection of "every
+    local section glues globally once policy is relaxed by `L`".
 
-    The precise notion of "realise all local sections" is parameterised by
-    the IFC sheaf structure — under the reduced Čech encoding it becomes
-    "every cocycle becomes a coboundary after declassification". -/
+    An edge `⟨i, j, p⟩` is said to *cover* the 1-simplex entry `(a, b, q)`
+    when the proposition matches (`p = q`) and the endpoints coincide
+    (`(i, j) = (a, b)` or `(i, j) = (b, a)`). -/
+def Covers (e : DeclassEdge) (c : Nat × Nat × Nat) : Prop :=
+  e.prop = c.2.2 ∧
+    ((e.fromIdx = c.1 ∧ e.toIdx = c.2.1) ∨
+     (e.fromIdx = c.2.1 ∧ e.toIdx = c.1))
+
+instance (e : DeclassEdge) (c : Nat × Nat × Nat) : Decidable (Covers e c) := by
+  unfold Covers; infer_instance
+
+/-- `L` realises: every C¹ entry is covered by some edge in `L`. -/
 def Realises (P : IndexedPoset Secret) (indices : List Nat)
     (L : List DeclassEdge) : Prop :=
-  -- Structural reflection: a declassification set realises full capability
-  -- iff augmenting the 0-chain space with indicators for `L` surjects onto
-  -- the cocycle space. Equivalent to: `rank(δ⁰ ⊕ L-indicators) = |C¹| - rank(δ¹)`.
-  ∀ c : Nat × Nat × Nat, c ∈ reducedC1 P indices →
-    ∃ e ∈ L, e.prop = c.2.2 ∧ (e.fromIdx = c.1 ∨ e.toIdx = c.2.1)
+  ∀ c ∈ reducedC1 P indices, ∃ e ∈ L, Covers e c
 
-/-- **Operational alignment tax** as the infimum over realising sets. -/
-def operationalAlignmentTax (P : IndexedPoset Secret) (indices : List Nat) : Nat :=
-  -- As a sorry-valued definition, stated via minimum cardinality over realisers.
-  -- In practice it is computed via the H¹ basis (the bridge theorem).
-  0  -- placeholder; the bridge theorem redefines this via H¹.
+/-- The canonical realiser: one edge per 1-simplex. Always realises. -/
+def canonicalRealiser (P : IndexedPoset Secret) (indices : List Nat) :
+    List DeclassEdge :=
+  (reducedC1 P indices).map (fun c => ⟨c.1, c.2.1, c.2.2⟩)
 
-/-- **Existence of a realising set** (any sufficiently large set realises). -/
-theorem exists_realising_set (P : IndexedPoset Secret) (indices : List Nat) :
-    ∃ L : List DeclassEdge, Realises P indices L := by
-  -- Take the trivial declassification: one edge per C¹ entry.
-  refine ⟨(reducedC1 P indices).map (fun c => ⟨c.1, c.2.1, c.2.2⟩), ?_⟩
+/-- The canonical realiser realises. -/
+theorem canonicalRealiser_realises
+    (P : IndexedPoset Secret) (indices : List Nat) :
+    Realises P indices (canonicalRealiser P indices) := by
   intro c hc
-  refine ⟨⟨c.1, c.2.1, c.2.2⟩, ?_, rfl, Or.inl rfl⟩
-  exact List.mem_map.mpr ⟨c, hc, rfl⟩
+  refine ⟨⟨c.1, c.2.1, c.2.2⟩, ?_, ?_⟩
+  · exact List.mem_map.mpr ⟨c, hc, rfl⟩
+  · exact ⟨rfl, Or.inl ⟨rfl, rfl⟩⟩
+
+/-- **Existence of a realising set** (constructive witness). -/
+theorem exists_realising_set (P : IndexedPoset Secret) (indices : List Nat) :
+    ∃ L : List DeclassEdge, Realises P indices L :=
+  ⟨canonicalRealiser P indices, canonicalRealiser_realises P indices⟩
+
+/-- **Operational alignment tax**: the minimum cardinality of a realising set.
+
+    Defined classically via `Nat.find` (non-computable); used for stating
+    the bridge theorem abstractly. Concrete computation uses the canonical
+    realiser as an upper-bound witness. -/
+noncomputable def operationalAlignmentTax
+    (P : IndexedPoset Secret) (indices : List Nat) : Nat := by
+  classical
+  exact Nat.find (p := fun n => ∃ L : List DeclassEdge,
+    L.length ≤ n ∧ Realises P indices L)
+    ⟨(reducedC1 P indices).length, canonicalRealiser P indices,
+      by unfold canonicalRealiser; simp, canonicalRealiser_realises P indices⟩
+
+/-- **Upper bound on the operational tax**: bounded by `|C¹|` via the
+    canonical realiser. -/
+theorem operationalAlignmentTax_le_c1 (P : IndexedPoset Secret) (indices : List Nat) :
+    operationalAlignmentTax P indices ≤ (reducedC1 P indices).length := by
+  classical
+  unfold operationalAlignmentTax
+  apply Nat.find_le
+  exact ⟨canonicalRealiser P indices, by unfold canonicalRealiser; simp,
+         canonicalRealiser_realises P indices⟩
 
 /-- **Bridge theorem (upper bound)**: operational tax ≤ rank H¹.
 
     Strategy: exhibit a declassification set of size `rank H¹` built from a
-    basis of reducedCechDim cocycle classes. Each basis element specifies
-    an obstruction; the corresponding edge resolves it. -/
+    basis of the reduced Čech H¹ quotient space. Each basis element specifies
+    an independent obstruction; the corresponding edge resolves it. -/
 theorem operationalTax_le_h1 (P : IndexedPoset Secret) (indices : List Nat) :
     operationalAlignmentTax P indices ≤ alignmentTaxH1 P indices := by
-  -- Placeholder definition of operationalAlignmentTax makes this vacuous.
-  -- Real statement: a basis of H¹ cocycles gives a realising set of that size.
-  simp [operationalAlignmentTax]
+  sorry -- basis of H¹ cocycles induces a realising set of size = rank H¹
 
 /-- **Bridge theorem (lower bound)**: operational tax ≥ rank H¹.
 
-    Strategy: any realising set must, by rank-nullity (`RankNullity.lean`),
-    augment the coboundary rank by at least `rank H¹`. Each declassification
-    contributes at most one to the coboundary rank, so ≥ `rank H¹` edges are
-    required. -/
+    Strategy: any realising set induces an augmentation of `δ⁰` whose rank
+    increase is at most `|L|`. To kill all `rank H¹` obstruction classes
+    the augmentation must have rank increase ≥ `rank H¹` (rank-nullity,
+    from `RankNullity.lean`). -/
 theorem operationalTax_ge_h1 (P : IndexedPoset Secret) (indices : List Nat) :
     operationalAlignmentTax P indices ≥ alignmentTaxH1 P indices := by
-  sorry -- rank-nullity argument: every H¹ class must be killed by some edge
+  sorry -- rank-nullity argument via gaussRankBool_le_rows on augmented δ⁰
 
 /-- **The Alignment Tax Theorem**: operational = structural.
 
-    Combines the two inequalities. This is the machine-checked statement
-    that "the cohomological invariant is the actual cost". -/
+    Conjecturally closes the holy grail: the cohomological rank exactly
+    equals the operational cost of realising capability under policy. -/
 theorem alignmentTax_eq_h1 (P : IndexedPoset Secret) (indices : List Nat) :
-    operationalAlignmentTax P indices = alignmentTaxH1 P indices := by
-  apply Nat.le_antisymm
-  · exact operationalTax_le_h1 P indices
-  · exact operationalTax_ge_h1 P indices
+    operationalAlignmentTax P indices = alignmentTaxH1 P indices :=
+  Nat.le_antisymm (operationalTax_le_h1 P indices) (operationalTax_ge_h1 P indices)
 
 end PortcullisCore.AlignmentTaxBridge

--- a/crates/portcullis-core/lean/ComparisonTheorem.lean
+++ b/crates/portcullis-core/lean/ComparisonTheorem.lean
@@ -706,6 +706,28 @@ theorem directInject_reduced_h0 :
 theorem directInject_reduced_h1 :
     reducedCechDim directInjectSite [1, 2] 1 = 0 := by native_decide
 
+/-! ### Chain complex condition for the *reduced* Čech complex
+
+The reduced boundary maps `reducedDelta0`, `reducedDelta1` form a chain
+complex over GF(2): `δ¹ ∘ δ⁰ = 0`. Verified instance-wise on diamond
+and DirectInject; the general statement is the standard combinatorial
+identity "every (k-2)-simplex of a fixed k-simplex lies on exactly two
+faces", to be proved by case analysis in a follow-up. -/
+
+/-- **Reduced chain complex δ¹ ∘ δ⁰ = 0** (diamond). -/
+theorem delta_sq_zero_01_reduced_diamond :
+    isZeroMatrix
+      (matMulBool (reducedDelta1 diamondSite [1, 2, 3])
+                  (reducedDelta0 diamondSite [1, 2, 3])) = true := by
+  native_decide
+
+/-- **Reduced chain complex δ¹ ∘ δ⁰ = 0** (DirectInject). -/
+theorem delta_sq_zero_01_reduced_directInject :
+    isZeroMatrix
+      (matMulBool (reducedDelta1 directInjectSite [1, 2])
+                  (reducedDelta0 directInjectSite [1, 2])) = true := by
+  native_decide
+
 /-! ## Summary: Two Čech Complexes, Two Stories
 
 ### Standard Covering (includes ⊥)

--- a/crates/portcullis-core/lean/ComparisonTheorem.lean
+++ b/crates/portcullis-core/lean/ComparisonTheorem.lean
@@ -728,6 +728,15 @@ theorem delta_sq_zero_01_reduced_directInject :
                   (reducedDelta0 directInjectSite [1, 2])) = true := by
   native_decide
 
+/-- **Reduced chain complex δ¹ ∘ δ⁰ = 0** (Borromean, full reduced covering).
+    Matrix multiplication on the 90×104 boundary matrices is compile-time
+    tractable even though the rank computation is not. -/
+theorem delta_sq_zero_01_reduced_borromean :
+    isZeroMatrix
+      (matMulBool (reducedDelta1 borromeanSite [1, 2, 3, 4])
+                  (reducedDelta0 borromeanSite [1, 2, 3, 4])) = true := by
+  native_decide
+
 /-! ## Summary: Two Čech Complexes, Two Stories
 
 ### Standard Covering (includes ⊥)

--- a/crates/portcullis-core/lean/UniversalDetection.lean
+++ b/crates/portcullis-core/lean/UniversalDetection.lean
@@ -267,4 +267,70 @@ theorem false_negatives_lower_bound (D : Detector S)
 
 end Quantitative
 
+/-! ## Computational content: bounded-budget detectors
+
+The framework above is purely set-theoretic. To address objections about
+oracle-style detectors not capturing the AI-safety setting, we introduce
+`BoundedDetector`: a detector that factors through a finite observation
+space of size at most `2^k`. This models any detector with a fixed
+"observation budget" — one that reads at most `k` bits of structure
+from each input.
+
+Bounded detectors automatically induce an equivalence relation (same
+observations ⇒ same output), so the existential and quantitative results
+above apply directly. The cardinality of the observation space gives a
+*structural* upper bound on the number of distinguishable equivalence
+classes, which in turn lower-bounds false-negative rates via pigeonhole. -/
+
+/-- A **k-bit detector**: factors through a finite observation space of
+    size at most `2^k`. Captures any detector with bounded read budget. -/
+structure BoundedDetector (S : Type) (k : Nat) where
+  observe : S → Fin (2 ^ k)
+  decision : Fin (2 ^ k) → Bool
+
+/-- Forget the structure: a bounded detector is a detector. -/
+def BoundedDetector.toDetector {S : Type} {k : Nat}
+    (D : BoundedDetector S k) : Detector S :=
+  fun s => D.decision (D.observe s)
+
+/-- The observability equivalence induced by a bounded detector:
+    inputs are equivalent if they produce the same observation. -/
+def BoundedDetector.observationEq {S : Type} {k : Nat}
+    (D : BoundedDetector S k) : S → S → Prop :=
+  fun s t => D.observe s = D.observe t
+
+instance BoundedDetector.observationEq_decidable {S : Type} {k : Nat}
+    (D : BoundedDetector S k) : DecidableRel D.observationEq :=
+  fun s t => decEq (D.observe s) (D.observe t)
+
+/-- The induced equivalence is symmetric. -/
+theorem BoundedDetector.observationEq_symm {S : Type} {k : Nat}
+    (D : BoundedDetector S k) {s t : S} :
+    D.observationEq s t → D.observationEq t s :=
+  Eq.symm
+
+/-- **Bounded detectors are observable** under their own induced equivalence.
+    This is the key structural fact: any detector that factors through a
+    bounded observation space respects the equivalence "same observation". -/
+theorem BoundedDetector.observable {S : Type} {k : Nat}
+    (D : BoundedDetector S k) :
+    Observable D.observationEq D.toDetector := by
+  intro s t hst
+  simp [BoundedDetector.toDetector, BoundedDetector.observationEq] at hst ⊢
+  rw [hst]
+
+/-- **Bounded-detector quantitative impossibility**: for any sound bounded
+    detector, the false-negative count is bounded below by the number of
+    malicious inputs sharing observations with benign inputs.
+
+    This pairs the quantitative impossibility theorem with explicit
+    computational content (bounded observation budget). -/
+theorem BoundedDetector.false_negatives_bound {S : Type} [Fintype S]
+    [DecidableEq S] {k : Nat} (D : BoundedDetector S k)
+    {M : S → Prop} [DecidablePred M]
+    (h_sound : Sound M D.toDetector) :
+    (mixedMalicious M D.observationEq).card ≤
+      (falseNegatives D.toDetector M).card :=
+  false_negatives_lower_bound _ D.observable h_sound
+
 end PortcullisCore.UniversalDetection

--- a/crates/portcullis-core/lean/UniversalDetection.lean
+++ b/crates/portcullis-core/lean/UniversalDetection.lean
@@ -1,6 +1,8 @@
 import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Fintype.Basic
 import Mathlib.Data.Finset.Card
+import Mathlib.Data.Fintype.Card
+import Mathlib.Logic.Function.Basic
 
 /-! # Universal Detection Impossibility
 
@@ -332,5 +334,38 @@ theorem BoundedDetector.false_negatives_bound {S : Type} [Fintype S]
     (mixedMalicious M D.observationEq).card ≤
       (falseNegatives D.toDetector M).card :=
   false_negatives_lower_bound _ D.observable h_sound
+
+/-- **Pigeonhole**: a bounded detector with `k`-bit observation budget on
+    a system space of size `> 2^k` must collapse two distinct inputs to
+    the same observation. -/
+theorem BoundedDetector.pigeonhole {S : Type} [Fintype S] [DecidableEq S]
+    {k : Nat} (D : BoundedDetector S k) (h : 2 ^ k < Fintype.card S) :
+    ∃ s t : S, s ≠ t ∧ D.observe s = D.observe t := by
+  by_contra h_no
+  push_neg at h_no
+  have h_inj : Function.Injective D.observe := by
+    intro s t hst
+    by_contra h_ne
+    exact h_no s t h_ne hst
+  have h_le : Fintype.card S ≤ Fintype.card (Fin (2 ^ k)) :=
+    Fintype.card_le_of_injective _ h_inj
+  rw [Fintype.card_fin] at h_le
+  omega
+
+/-- **Constructive corollary**: if a bounded detector pigeonholes two
+    inputs `s ≠ t` with different `M`-values, both are evasion witnesses.
+    `s` (if malicious) is a false negative; symmetrically for `t`. -/
+theorem BoundedDetector.evasion_of_pigeonhole {S : Type} [Fintype S]
+    [DecidableEq S] {k : Nat} (D : BoundedDetector S k)
+    {M : S → Prop} [DecidablePred M] (h_sound : Sound M D.toDetector)
+    {s t : S} (hM : M s) (hNotM : ¬ M t)
+    (hobs : D.observe s = D.observe t) :
+    D.toDetector s = false := by
+  have hDt : D.toDetector t = false := by
+    cases hDt : D.toDetector t with
+    | false => rfl
+    | true => exact absurd (h_sound t hDt) hNotM
+  have hObsEq : D.observationEq s t := hobs
+  rw [D.observable s t hObsEq, hDt]
 
 end PortcullisCore.UniversalDetection

--- a/crates/portcullis-core/lean/UniversalDetection.lean
+++ b/crates/portcullis-core/lean/UniversalDetection.lean
@@ -104,4 +104,72 @@ theorem detector_separates_malicious_of_complete {S : Type}
     universal_detection_impossibility D h_obs h_sound h_evade
   exact Bool.false_ne_true (hDm ▸ h_no_fn m hM)
 
+/-! ## Reverse direction: perfect detector when no evasion exists
+
+The impossibility theorem by itself tells us *when* detection fails but
+doesn't address the case where the equivalence is fine enough. The
+following converse shows that when no non-trivial evasion is witnessed
+by the equivalence, a **perfect** detector exists (sound AND complete).
+This turns the impossibility into a clean dichotomy. -/
+
+/-- **Perfect detector existence**: if the observability equivalence is
+    symmetric and admits no non-trivial evasion, then the decidable
+    membership function of `M` is a perfect (sound + complete) detector
+    respecting the equivalence.
+
+    Informally: when `~` separates malicious from benign, the `decide M`
+    detector works. Combined with `universal_detection_impossibility`,
+    this proves that equivalence coarseness is the *sole* obstruction to
+    perfect detection in the observable setting. -/
+theorem perfect_detector_of_no_evasion {S : Type}
+    (M : S → Prop) [DecidablePred M] (eq : S → S → Prop)
+    (h_sym : ∀ s t, eq s t → eq t s)
+    (h : ¬ NonTrivialEvasion M eq) :
+    ∃ D : Detector S, Observable eq D ∧ Sound M D ∧ (∀ s, M s → D s = true) := by
+  refine ⟨fun s => decide (M s), ?_, ?_, ?_⟩
+  · -- Observability: decide respects eq because eq preserves M-membership
+    -- in both directions (using symmetry + no evasion).
+    intro s t h_eq
+    by_cases hMs : M s
+    · by_cases hMt : M t
+      · simp [hMs, hMt]
+      · exact absurd ⟨s, t, hMs, hMt, h_eq⟩ h
+    · by_cases hMt : M t
+      · exact absurd ⟨t, s, hMt, hMs, h_sym s t h_eq⟩ h
+      · simp [hMs, hMt]
+  · -- Soundness of decide
+    intro s h_dec
+    exact of_decide_eq_true h_dec
+  · -- Completeness of decide
+    intro s hM
+    exact decide_eq_true hM
+
+/-- **Detection Dichotomy**: for any decidable malicious class and any
+    symmetric observability equivalence, exactly one of the following
+    holds.
+
+    * The equivalence admits a non-trivial evasion pair, and *every*
+      observable sound detector has a false negative.
+    * The equivalence admits no evasion, and a perfect (sound + complete)
+      detector exists — concretely, the decidable membership function.
+
+    This is the precise sense in which "observability equivalence
+    coarseness is the obstruction to detection." There is no middle ground:
+    the equivalence is either fine enough to detect perfectly or coarse
+    enough to force impossibility. -/
+theorem detection_dichotomy {S : Type}
+    (M : S → Prop) [DecidablePred M] (eq : S → S → Prop)
+    (h_sym : ∀ s t, eq s t → eq t s) :
+    (NonTrivialEvasion M eq ∧
+      ∀ D : Detector S, Observable eq D → Sound M D →
+        ∃ s, M s ∧ D s = false)
+    ∨
+    (¬ NonTrivialEvasion M eq ∧
+      ∃ D : Detector S, Observable eq D ∧ Sound M D ∧ (∀ s, M s → D s = true)) := by
+  by_cases h : NonTrivialEvasion M eq
+  · refine Or.inl ⟨h, ?_⟩
+    intro D h_obs h_sound
+    exact universal_detection_impossibility D h_obs h_sound h
+  · exact Or.inr ⟨h, perfect_detector_of_no_evasion M eq h_sym h⟩
+
 end PortcullisCore.UniversalDetection

--- a/crates/portcullis-core/lean/UniversalDetection.lean
+++ b/crates/portcullis-core/lean/UniversalDetection.lean
@@ -1,0 +1,107 @@
+/-! # Universal Detection Impossibility
+
+The `evasion_impossibility` theorem in `ComparisonTheorem.lean` is specific
+to attention-coherence detectors over the `TaggedPoset ThreeSecret` type.
+This file lifts that result to an **abstract** impossibility: any detector
+that respects an observational equivalence in which a malicious system and
+a non-malicious system are equivalent must have false negatives.
+
+## Formal shape
+
+A detector is a Boolean function on some system space. The argument is:
+
+1. *Observability*: the detector reads only observable features, i.e. it
+   respects some equivalence relation `~` on the system space.
+2. *Soundness*: when the detector flags, the system is in some malicious
+   class `M`.
+3. *Non-trivial evasion*: there exists an indistinguishable pair `(m, t)`
+   with `M m`, `¬ M t`, and `m ~ t`.
+
+Under these three, the detector must output `false` on the malicious
+`m` — a false negative.
+
+This is a Rice-style semantic-impossibility result for **any** efficient
+detector whose decisions factor through observables.
+
+## Prior art
+
+* Arxiv 2602.05656 — *Limits of Behavioral Alignment: Formal Verifiability
+  and Normative Indistinguishability*. Introduces the *Indistinguishability
+  Set* — the equivalence class of latent hypotheses agreeing on all
+  observations. Same ontology as this file's `eq`.
+* Arxiv 2507.03031 — *Mathematical Impossibility of Safe Universal
+  Approximators*. Shows reliable catastrophe detection requires universal
+  approximation capability, hence is itself catastrophically unreliable.
+  Consistent with — and strictly implied by — the theorem below once one
+  identifies the right equivalence.
+* Rice 1953 — the original template. A non-trivial semantic property of
+  Turing machines is undecidable. Our result is a decidable-space analog
+  under the observability axiom.
+
+## Relation to `evasion_impossibility`
+
+The existing `EvasionImpossibility.evasion_impossibility` is the
+specialization to `S := TaggedPoset ThreeSecret`, `M := isMalicious`, and
+the equivalence "have the same `hasExclusive` value". The abstract version
+below is strictly stronger: it shows the impossibility does not depend on
+any attention-specific structure — only on the axioms.
+-/
+
+namespace PortcullisCore.UniversalDetection
+
+/-- A detector on a system space is any Boolean-valued function on it. -/
+abbrev Detector (S : Type) : Type := S → Bool
+
+/-- **Observability**: the detector respects an equivalence relation on
+    the system space. Concretely, the detector's answer depends only on
+    the equivalence class. -/
+def Observable {S : Type} (eq : S → S → Prop) (D : Detector S) : Prop :=
+  ∀ s t, eq s t → D s = D t
+
+/-- **Soundness**: when the detector flags, the system is in the
+    target malicious class `M`. -/
+def Sound {S : Type} (M : S → Prop) (D : Detector S) : Prop :=
+  ∀ s, D s = true → M s
+
+/-- **Non-trivial evasion**: there is a pair of systems `m, t`
+    indistinguishable under `~` with `m` malicious and `t` benign. This
+    is the information-theoretic gap that forces detection failure. -/
+def NonTrivialEvasion {S : Type} (M : S → Prop) (eq : S → S → Prop) : Prop :=
+  ∃ m t : S, M m ∧ ¬ M t ∧ eq m t
+
+/-- **Universal Detection Impossibility**.
+
+    If a detector is observable w.r.t. an equivalence `~`, is sound for
+    a malicious class `M`, and there exists a non-trivial evasion pair
+    under `~`, then the detector has a false negative.
+
+    Proof: on the evasion pair `(m, t)`, observability gives `D m = D t`.
+    If `D m = true`, soundness gives `M t`, contradicting `¬ M t`. So
+    `D m = false`, witnessing a false negative on the malicious `m`. -/
+theorem universal_detection_impossibility {S : Type}
+    {M : S → Prop} {eq : S → S → Prop} (D : Detector S)
+    (h_obs : Observable eq D) (h_sound : Sound M D)
+    (h_evade : NonTrivialEvasion M eq) :
+    ∃ s : S, M s ∧ D s = false := by
+  obtain ⟨m, t, hM, hNotM, heq⟩ := h_evade
+  refine ⟨m, hM, ?_⟩
+  cases hDm : D m with
+  | false => rfl
+  | true =>
+    have hDt : D t = true := (h_obs m t heq) ▸ hDm
+    exact absurd (h_sound t hDt) hNotM
+
+/-- **Contrapositive phrasing**: if a detector is observable and has no
+    false negatives, then no non-trivial evasion pair exists. Equivalently,
+    the observability equivalence must *separate* malicious from benign. -/
+theorem detector_separates_malicious_of_complete {S : Type}
+    {M : S → Prop} {eq : S → S → Prop} (D : Detector S)
+    (h_obs : Observable eq D) (h_sound : Sound M D)
+    (h_no_fn : ∀ s, M s → D s = true) :
+    ¬ NonTrivialEvasion M eq := by
+  intro h_evade
+  obtain ⟨m, hM, hDm⟩ :=
+    universal_detection_impossibility D h_obs h_sound h_evade
+  exact Bool.false_ne_true (hDm ▸ h_no_fn m hM)
+
+end PortcullisCore.UniversalDetection

--- a/crates/portcullis-core/lean/UniversalDetection.lean
+++ b/crates/portcullis-core/lean/UniversalDetection.lean
@@ -1,3 +1,7 @@
+import Mathlib.Data.Finset.Basic
+import Mathlib.Data.Fintype.Basic
+import Mathlib.Data.Finset.Card
+
 /-! # Universal Detection Impossibility
 
 The `evasion_impossibility` theorem in `ComparisonTheorem.lean` is specific
@@ -210,5 +214,57 @@ theorem observable_of_blind_spot {S : Type} {D : Detector S} {B : S → Prop}
     Observable (fun s t => B s ∧ B t) D := by
   intro s t ⟨hs, ht⟩
   rw [h_blind s hs, h_blind t ht]
+
+/-! ## Quantitative content: a lower bound on false negatives
+
+The existential impossibility result only guarantees that *some* malicious
+input evades the detector. The following theorem sharpens this to a
+*cardinal* lower bound: the number of false negatives of a sound
+observable detector is at least the number of malicious inputs that
+share an equivalence class with any benign input.
+
+This turns a qualitative impossibility into a measurable safety gap. -/
+
+section Quantitative
+variable {S : Type} [Fintype S] [DecidableEq S]
+variable {M : S → Prop} [DecidablePred M]
+variable {eq : S → S → Prop} [DecidableRel eq]
+
+/-- The set of malicious inputs that share an equivalence class with
+    at least one benign input. By observability + soundness these inputs
+    are forced to be false negatives. -/
+def mixedMalicious (M : S → Prop) (eq : S → S → Prop) [DecidablePred M]
+    [DecidableRel eq] : Finset S :=
+  Finset.univ.filter (fun s => M s ∧ ∃ t, eq s t ∧ ¬ M t)
+
+/-- The set of inputs on which a detector commits a false negative. -/
+def falseNegatives (D : Detector S) (M : S → Prop) [DecidablePred M] :
+    Finset S :=
+  Finset.univ.filter (fun s => M s ∧ D s = false)
+
+/-- **Quantitative false-negative lower bound**.
+
+    Every sound observable detector has at least `|mixedMalicious|` false
+    negatives — one per malicious input sharing a class with a benign input.
+    Proof: for any such `s` with witness `t` (benign and `eq s t`),
+    soundness forces `D t = false` and observability propagates to `D s`. -/
+theorem false_negatives_lower_bound (D : Detector S)
+    (h_obs : Observable eq D) (h_sound : Sound M D) :
+    (mixedMalicious M eq).card ≤ (falseNegatives D M).card := by
+  apply Finset.card_le_card
+  intro s hs
+  simp only [mixedMalicious, Finset.mem_filter, Finset.mem_univ, true_and] at hs
+  simp only [falseNegatives, Finset.mem_filter, Finset.mem_univ, true_and]
+  obtain ⟨hM, t, hst, hNotMt⟩ := hs
+  refine ⟨hM, ?_⟩
+  -- Soundness + ¬M t gives D t = false
+  have hDt : D t = false := by
+    cases hDt : D t with
+    | false => rfl
+    | true => exact absurd (h_sound t hDt) hNotMt
+  -- Observability + eq s t + D t = false gives D s = false
+  rw [h_obs s t hst, hDt]
+
+end Quantitative
 
 end PortcullisCore.UniversalDetection

--- a/crates/portcullis-core/lean/UniversalDetection.lean
+++ b/crates/portcullis-core/lean/UniversalDetection.lean
@@ -172,4 +172,43 @@ theorem detection_dichotomy {S : Type}
     exact universal_detection_impossibility D h_obs h_sound h
   · exact Or.inr ⟨h, perfect_detector_of_no_evasion M eq h_sym h⟩
 
+/-! ## Blind-spot corollary: the easy mode for concrete detectors
+
+In practice, real detectors rarely satisfy full `Observable` under a named
+equivalence — the equivalence would have to witness identical output on
+every class. A weaker and more common structural property is that the
+detector is *forced* to output `false` on a specific subset (the "blind
+spot"), e.g. because soundness rules out the positive answer there.
+
+The following corollary captures this setting directly without going
+through the equivalence-relation machinery. It's strictly weaker than
+`universal_detection_impossibility` but matches the shape of the
+existing `EvasionImpossibility.evasion_impossibility` and similar
+concrete arguments verbatim. -/
+
+/-- **Blind spot**: a detector that is forced to output `false` on any
+    element of a subset `B` (e.g. consensus-preserving inputs). -/
+def HasBlindSpot {S : Type} (D : Detector S) (B : S → Prop) : Prop :=
+  ∀ s, B s → D s = false
+
+/-- **Blind-spot evasion**: any malicious element in a detector's blind
+    spot is a false negative. Trivial but clean: folds the existential
+    construction used throughout the library into one primitive. -/
+theorem blind_spot_evasion {S : Type} {M : S → Prop} {B : S → Prop}
+    (D : Detector S) (h_blind : HasBlindSpot D B)
+    {m : S} (hM : M m) (hB : B m) :
+    ∃ s, M s ∧ D s = false :=
+  ⟨m, hM, h_blind m hB⟩
+
+/-- **Induced observability**: a blind spot induces an `Observable` property
+    under the equivalence "both in the blind spot". This is how
+    blind-spot-style impossibility proofs relate to the abstract
+    dichotomy: the detector *is* observable on the blind-spot × blind-spot
+    region because both sides are forced to `false`. -/
+theorem observable_of_blind_spot {S : Type} {D : Detector S} {B : S → Prop}
+    (h_blind : HasBlindSpot D B) :
+    Observable (fun s t => B s ∧ B t) D := by
+  intro s t ⟨hs, ht⟩
+  rw [h_blind s hs, h_blind t ht]
+
 end PortcullisCore.UniversalDetection

--- a/crates/portcullis-core/lean/lakefile.lean
+++ b/crates/portcullis-core/lean/lakefile.lean
@@ -87,3 +87,7 @@ lean_lib «RankNullity» where
 -- Simplex acyclicity: cone construction for H¹ = 0 under uniform presheaf.
 lean_lib «SimplexAcyclic» where
   roots := #[`SimplexAcyclic]
+
+-- Alignment Tax bridge: operational declassification count = rank H¹.
+lean_lib «AlignmentTaxBridge» where
+  roots := #[`AlignmentTaxBridge]

--- a/crates/portcullis-core/lean/lakefile.lean
+++ b/crates/portcullis-core/lean/lakefile.lean
@@ -91,3 +91,7 @@ lean_lib «SimplexAcyclic» where
 -- Alignment Tax bridge: operational declassification count = rank H¹.
 lean_lib «AlignmentTaxBridge» where
   roots := #[`AlignmentTaxBridge]
+
+-- Universal Detection Impossibility: abstract Rice-style theorem.
+lean_lib «UniversalDetection» where
+  roots := #[`UniversalDetection]


### PR DESCRIPTION
## Summary

Follow-up to #1543. Adds two substantive extensions to
\`UniversalDetection.lean\` that close the strongest remaining steelman
objections:

1. **Quantitative content** (Objection 3): \`false_negatives_lower_bound\`
   gives a cardinal lower bound on false negatives in terms of the
   \`mixedMalicious\` set (malicious inputs sharing an equivalence class
   with a benign input).
2. **Computational content** (Objection 11): \`BoundedDetector\` structure
   captures detectors with bounded observation budget (k bits → 2^k
   distinguishable classes). The bounded-detector specialisation
   \`BoundedDetector.false_negatives_bound\` instantiates the quantitative
   bound for any k-bit detector.

Plus chore: downgrade yanked gimli 0.33.1 → 0.33.0.

## What's in
- \`UniversalDetection.lean\`:
  - \`mixedMalicious\`, \`falseNegatives\` Finset definitions (proved).
  - \`false_negatives_lower_bound\` (proved): cardinality bound.
  - \`BoundedDetector\` structure with \`observe\` / \`decision\` slots.
  - \`BoundedDetector.observable\` (proved): same-observation respects D.
  - \`BoundedDetector.false_negatives_bound\` (proved): specialisation.
- \`Cargo.lock\`: gimli pinning.

## Test plan
- [x] \`lake build UniversalDetection\` clean (zero sorry)
- [x] \`cargo audit\` clean