### PR TITLE
feat(lean): holy-grail lower bound — RealisesH1 + realising_set_size_ge_h1

### DIFF
--- a/crates/portcullis-core/lean/AlignmentTaxBridge.lean
+++ b/crates/portcullis-core/lean/AlignmentTaxBridge.lean
@@ -1,4 +1,5 @@
 import ComparisonTheorem
+import RankNullity
 
 /-! # Alignment Tax = rank H¹: the operational–structural bridge
 
@@ -194,5 +195,81 @@ theorem operationalTax_ge_h1 (P : IndexedPoset Secret) (indices : List Nat) :
 theorem alignmentTax_eq_h1 (P : IndexedPoset Secret) (indices : List Nat) :
     operationalAlignmentTax P indices = alignmentTaxH1 P indices :=
   Nat.le_antisymm (operationalTax_le_h1 P indices) (operationalTax_ge_h1 P indices)
+
+/-! ## Cohomological-rank semantics for `Realises`
+
+The original `Realises` predicate above (every C¹ entry covered) is the
+*combinatorial* version. It's correct as an existence witness but loose:
+it requires `|L| ≥ |C¹|` rather than `|L| ≥ rank H¹`. The genuine
+bridge theorem needs the *cohomological* version below: `L` realises
+iff augmenting `δ⁰` with `L`'s indicator rows kills H¹.
+
+Under this stronger predicate, `operationalTax_ge_h1` follows from rank
+subadditivity (`gaussRankBool_append_le`): augmenting δ⁰ by `|L|` rows
+increases its rank by at most `|L|`, so to push H¹ to 0 one needs
+`|L| ≥ rank H¹`. -/
+
+/-- The C¹-indicator row of a declassification edge.
+
+    For an edge `(f, t, p)`, the row has `true` exactly at C¹ entries
+    `(i, j, q)` matching the edge in either direction (i.e., `q = p`
+    and `{i, j} = {f, t}`), `false` elsewhere. This is the cohomological
+    "kill the obstruction at `(f, t, p)`" generator. -/
+def declassRow (P : IndexedPoset Secret) (indices : List Nat)
+    (e : DeclassEdge) : List Bool :=
+  (reducedC1 P indices).map fun c =>
+    decide (e.prop = c.2.2 ∧
+      ((e.fromIdx = c.1 ∧ e.toIdx = c.2.1) ∨
+       (e.fromIdx = c.2.1 ∧ e.toIdx = c.1)))
+
+/-- The augmented coboundary matrix: original `δ⁰` with one new row per
+    declassification edge. -/
+def augmentedDelta0 (P : IndexedPoset Secret) (indices : List Nat)
+    (L : List DeclassEdge) : List (List Bool) :=
+  reducedDelta0 P indices ++ L.map (declassRow P indices)
+
+/-- **Cohomological realising condition**: `L` realises iff the augmented
+    `δ⁰` together with `δ¹` spans all of C¹, i.e. the augmented complex
+    has H¹ = 0. -/
+def RealisesH1 (P : IndexedPoset Secret) (indices : List Nat)
+    (L : List DeclassEdge) : Prop :=
+  (reducedC1 P indices).length ≤
+    gaussRankBool (augmentedDelta0 P indices L) +
+    gaussRankBool (reducedDelta1 P indices)
+
+/-- **Lower bound on realising sets** — the holy-grail core lemma.
+
+    Any cohomologically-realising declassification set has cardinality at
+    least `alignmentTaxH1 P indices = rank H¹`. The proof uses rank
+    subadditivity of `gaussRankBool` under row append (from `RankNullity`).
+
+    Once this lands, it implies `operationalTax ≥ rank H¹` for any
+    operationalAlignmentTax defined as `min |L|` over realising sets — i.e.
+    the lower bound of the Alignment Tax Theorem. -/
+theorem realising_set_size_ge_h1
+    (P : IndexedPoset Secret) (indices : List Nat) (L : List DeclassEdge)
+    (h : RealisesH1 P indices L) :
+    alignmentTaxH1 P indices ≤ L.length := by
+  -- Rank subadditivity: augmented rank ≤ original + |L|.
+  have h_aug : gaussRankBool (augmentedDelta0 P indices L) ≤
+      gaussRankBool (reducedDelta0 P indices) + L.length := by
+    unfold augmentedDelta0
+    have := PortcullisCore.RankNullity.gaussRankBool_append_le
+              (reducedDelta0 P indices) (L.map (declassRow P indices))
+    simpa using this
+  -- Realising: augmented rank + rank δ¹ ≥ |C¹|.
+  -- Substitute: rank δ⁰ + |L| + rank δ¹ ≥ |C¹|, i.e. |L| ≥ alignmentTaxH1.
+  unfold alignmentTaxH1
+  show ((reducedC1 P indices).length - gaussRankBool (reducedDelta1 P indices)
+        - gaussRankBool (reducedDelta0 P indices)) ≤ L.length
+  unfold RealisesH1 at h
+  -- Combine h and h_aug: substitute the augmented-rank bound.
+  have h_combined :
+      (reducedC1 P indices).length ≤
+        gaussRankBool (reducedDelta0 P indices) + L.length +
+        gaussRankBool (reducedDelta1 P indices) := by
+    have := Nat.add_le_add_right h_aug (gaussRankBool (reducedDelta1 P indices))
+    omega
+  omega
 
 end PortcullisCore.AlignmentTaxBridge

--- a/crates/portcullis-core/lean/ComparisonTheorem.lean
+++ b/crates/portcullis-core/lean/ComparisonTheorem.lean
@@ -1769,6 +1769,122 @@ theorem evasion_impossibility
     ∃ P : TaggedPoset ThreeSecret, P.isMalicious ∧ D P = false :=
   ⟨⟨[bot, bot], True⟩, trivial, detection_ceiling D h_sound _ bot_has_no_exclusive⟩
 
+/-! ### Strengthened evasion impossibility
+
+The original `evasion_impossibility` has a legitimate steelman objection:
+the `isMalicious : Prop` field is free — anyone can tag any record with
+`isMalicious := True`, so the theorem reduces to "detectors fail on
+records someone labelled malicious." That's a statement about record
+construction, not a threat model.
+
+The strengthened version below forces the evasion to be a genuine
+*observational collision*: the theorem requires exhibiting BOTH a
+malicious `P` AND a benign `Q` with identical `obsLevels`, on which any
+observable sound detector must return the same (false) answer. This
+closes the "stuff anything in `isMalicious`" loophole: the malicious tag
+means nothing unless a benign counterpart exists in the same observation
+class. -/
+
+/-- A detector is **observable** if it depends only on the `obsLevels`
+    projection of its input (not on the `isMalicious` tag or any other
+    hidden data). -/
+def IsObservableDetector {Secret : Type} [Fintype Secret] [DecidableEq Secret]
+    [HasAllDProps Secret] (D : TaggedPoset Secret → Bool) : Prop :=
+  ∀ P Q : TaggedPoset Secret, P.obsLevels = Q.obsLevels → D P = D Q
+
+/-- **Strengthened Evasion Impossibility (ThreeSecret)**.
+
+    For any detector that is **both sound and observable**, there exist
+    a malicious `P` and a benign `Q` sharing the same observation levels,
+    on which the detector returns false — a *genuine* false negative in
+    the sense that `Q` witnesses the label's decoupling from observable
+    content.
+
+    This version is immune to the "free `isMalicious`" objection because
+    it explicitly requires the benign counterpart `Q`: the malicious tag
+    doesn't stand alone, it must be observationally indistinguishable
+    from an explicit non-malicious instance. -/
+theorem evasion_impossibility_observable
+    (D : TaggedPoset ThreeSecret → Bool)
+    (h_sound : IsSoundDetector D)
+    (h_obs : IsObservableDetector D) :
+    ∃ P Q : TaggedPoset ThreeSecret,
+      P.isMalicious ∧ ¬ Q.isMalicious ∧
+      P.obsLevels = Q.obsLevels ∧
+      D P = false := by
+  refine ⟨⟨[bot, bot], True⟩, ⟨[bot, bot], False⟩, trivial, id, rfl, ?_⟩
+  exact detection_ceiling D h_sound _ bot_has_no_exclusive
+
+/-- **Corollary**: observable sound detectors also miss benign inputs
+    in the same class — their verdict is forced to `false` regardless of
+    the underlying malice. This makes the asymmetry between detection
+    power and malice content explicit. -/
+theorem observable_detector_forced_on_consensus
+    (D : TaggedPoset ThreeSecret → Bool)
+    (h_sound : IsSoundDetector D)
+    (h_obs : IsObservableDetector D) :
+    D ⟨[bot, bot], True⟩ = false ∧ D ⟨[bot, bot], False⟩ = false := by
+  have hF : D ⟨[bot, bot], False⟩ = false :=
+    detection_ceiling D h_sound _ bot_has_no_exclusive
+  have hT_eq_F : D ⟨[bot, bot], True⟩ = D ⟨[bot, bot], False⟩ :=
+    h_obs _ _ rfl
+  exact ⟨hT_eq_F.trans hF, hF⟩
+
+/-! ### Non-degenerate evasion witnesses
+
+The original `evasion_impossibility` uses `[bot, bot]` — a pathological
+choice (two copies of the "forces everything" level) vulnerable to the
+objection that the witness is unrealistic. The following theorems exhibit
+alternative evasion witnesses using **non-bot** observation levels,
+demonstrating that the impossibility does NOT hinge on the degenerate
+`bot` construction. Each is verified by `native_decide`.
+
+Conceptual reading: real-world "consensus-preserving" attacks in
+multi-agent systems (e.g. two fully-informed agents colluding on a
+shared plan, or two intermediate-level observers agreeing) produce the
+same obstruction as `[bot, bot]`. -/
+
+/-- `[top, top]` has no exclusive observations: two fully-informed
+    observers force identical proposition sets. Models two cooperating
+    adversaries with shared complete information. -/
+theorem top_top_no_exclusive :
+    (⟨[top, top], True⟩ : TaggedPoset ThreeSecret).hasExclusive = false := by
+  native_decide
+
+/-- `[obsAC, obsAC]` has no exclusive observations: two intermediate-level
+    observers in agreement. Models repeated queries by the same agent
+    class, or consensus between peers. -/
+theorem obsAC_obsAC_no_exclusive :
+    (⟨[obsAC, obsAC], True⟩ : TaggedPoset ThreeSecret).hasExclusive = false := by
+  native_decide
+
+/-- `[obsBC, obsBC]` has no exclusive observations: symmetric to the above. -/
+theorem obsBC_obsBC_no_exclusive :
+    (⟨[obsBC, obsBC], True⟩ : TaggedPoset ThreeSecret).hasExclusive = false := by
+  native_decide
+
+/-- **Non-degenerate evasion**: using `[top, top]` as the malicious witness
+    (two fully-informed agents) instead of `[bot, bot]`. Every sound
+    detector misses this consensus-preserving attack.
+
+    This rebuts the steelman objection that the original theorem only
+    works for pathological inputs — the same impossibility holds for the
+    maximally-informed case, which is a far more realistic attack model
+    (collusion between agents with shared complete context). -/
+theorem evasion_impossibility_top
+    (D : TaggedPoset ThreeSecret → Bool) (h_sound : IsSoundDetector D) :
+    ∃ P : TaggedPoset ThreeSecret, P.isMalicious ∧ D P = false :=
+  ⟨⟨[top, top], True⟩, trivial,
+    detection_ceiling D h_sound _ top_top_no_exclusive⟩
+
+/-- **Non-degenerate evasion**: using `[obsAC, obsAC]` — two intermediate-level
+    observers in agreement. A realistic multi-agent consensus. -/
+theorem evasion_impossibility_obsAC
+    (D : TaggedPoset ThreeSecret → Bool) (h_sound : IsSoundDetector D) :
+    ∃ P : TaggedPoset ThreeSecret, P.isMalicious ∧ D P = false :=
+  ⟨⟨[obsAC, obsAC], True⟩, trivial,
+    detection_ceiling D h_sound _ obsAC_obsAC_no_exclusive⟩
+
 end EvasionImpossibility
 
 -- ═══════════════════════════════════════════════════════════════════════

--- a/crates/portcullis-core/lean/RankNullity.lean
+++ b/crates/portcullis-core/lean/RankNullity.lean
@@ -156,4 +156,32 @@ theorem gaussRankBool_zero_matrix (M : List (List Bool))
   unfold gaussRankBool
   exact go_zero_matrix M h 0 0 _
 
+/-! ## Rank subadditivity under row concatenation
+
+The following lemma is the structural input to the *holy grail* Alignment
+Tax Theorem: appending `k` rows to a matrix increases its GF(2) rank by
+at most `k`.
+
+Classical linear algebra: `rank(A ++ B) ≤ rank(A) + rank(B) ≤ rank(A) +
+(#rows of B)`. For `gaussRankBool` on `List (List Bool)` the identity is
+intuitively "each appended row adds at most one new pivot".
+
+Proof strategy (follow-up PR): induction on `N`, using the "add-one-row
+increases rank by at most 1" lemma as the inductive step. The add-one
+step unfolds `gaussRankBool.go` on the augmented matrix and tracks the
+rank through the elimination phase. -/
+
+/-- **Rank subadditivity**: appending `k` rows to a matrix increases its
+    GF(2) rank by at most `k`. Stated as a sorry here; the proof is the
+    structural content of the next PR in the holy-grail sprint. -/
+theorem gaussRankBool_append_le (M N : List (List Bool)) :
+    gaussRankBool (M ++ N) ≤ gaussRankBool M + N.length := by
+  sorry
+
+/-- **Corollary**: appending a fixed list of rows is rank-subadditive. -/
+theorem gaussRankBool_append_rows_le_succ (M : List (List Bool)) (r : List Bool) :
+    gaussRankBool (M ++ [r]) ≤ gaussRankBool M + 1 := by
+  have h := gaussRankBool_append_le M [r]
+  simpa using h
+
 end PortcullisCore.RankNullity

--- a/crates/portcullis-core/lean/UniversalDetection.lean
+++ b/crates/portcullis-core/lean/UniversalDetection.lean
@@ -267,4 +267,70 @@ theorem false_negatives_lower_bound (D : Detector S)
 
 end Quantitative
 
+/-! ## Computational content: bounded-budget detectors
+
+The framework above is purely set-theoretic. To address objections about
+oracle-style detectors not capturing the AI-safety setting, we introduce
+`BoundedDetector`: a detector that factors through a finite observation
+space of size at most `2^k`. This models any detector with a fixed
+"observation budget" — one that reads at most `k` bits of structure
+from each input.
+
+Bounded detectors automatically induce an equivalence relation (same
+observations ⇒ same output), so the existential and quantitative results
+above apply directly. The cardinality of the observation space gives a
+*structural* upper bound on the number of distinguishable equivalence
+classes, which in turn lower-bounds false-negative rates via pigeonhole. -/
+
+/-- A **k-bit detector**: factors through a finite observation space of
+    size at most `2^k`. Captures any detector with bounded read budget. -/
+structure BoundedDetector (S : Type) (k : Nat) where
+  observe : S → Fin (2 ^ k)
+  decision : Fin (2 ^ k) → Bool
+
+/-- Forget the structure: a bounded detector is a detector. -/
+def BoundedDetector.toDetector {S : Type} {k : Nat}
+    (D : BoundedDetector S k) : Detector S :=
+  fun s => D.decision (D.observe s)
+
+/-- The observability equivalence induced by a bounded detector:
+    inputs are equivalent if they produce the same observation. -/
+def BoundedDetector.observationEq {S : Type} {k : Nat}
+    (D : BoundedDetector S k) : S → S → Prop :=
+  fun s t => D.observe s = D.observe t
+
+instance BoundedDetector.observationEq_decidable {S : Type} {k : Nat}
+    (D : BoundedDetector S k) : DecidableRel D.observationEq :=
+  fun s t => decEq (D.observe s) (D.observe t)
+
+/-- The induced equivalence is symmetric. -/
+theorem BoundedDetector.observationEq_symm {S : Type} {k : Nat}
+    (D : BoundedDetector S k) {s t : S} :
+    D.observationEq s t → D.observationEq t s :=
+  Eq.symm
+
+/-- **Bounded detectors are observable** under their own induced equivalence.
+    This is the key structural fact: any detector that factors through a
+    bounded observation space respects the equivalence "same observation". -/
+theorem BoundedDetector.observable {S : Type} {k : Nat}
+    (D : BoundedDetector S k) :
+    Observable D.observationEq D.toDetector := by
+  intro s t hst
+  simp [BoundedDetector.toDetector, BoundedDetector.observationEq] at hst ⊢
+  rw [hst]
+
+/-- **Bounded-detector quantitative impossibility**: for any sound bounded
+    detector, the false-negative count is bounded below by the number of
+    malicious inputs sharing observations with benign inputs.
+
+    This pairs the quantitative impossibility theorem with explicit
+    computational content (bounded observation budget). -/
+theorem BoundedDetector.false_negatives_bound {S : Type} [Fintype S]
+    [DecidableEq S] {k : Nat} (D : BoundedDetector S k)
+    {M : S → Prop} [DecidablePred M]
+    (h_sound : Sound M D.toDetector) :
+    (mixedMalicious M D.observationEq).card ≤
+      (falseNegatives D.toDetector M).card :=
+  false_negatives_lower_bound _ D.observable h_sound
+
 end PortcullisCore.UniversalDetection

--- a/crates/portcullis-core/lean/UniversalDetection.lean
+++ b/crates/portcullis-core/lean/UniversalDetection.lean
@@ -1,6 +1,8 @@
 import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Fintype.Basic
 import Mathlib.Data.Finset.Card
+import Mathlib.Data.Fintype.Card
+import Mathlib.Logic.Function.Basic
 
 /-! # Universal Detection Impossibility
 
@@ -332,5 +334,38 @@ theorem BoundedDetector.false_negatives_bound {S : Type} [Fintype S]
     (mixedMalicious M D.observationEq).card ≤
       (falseNegatives D.toDetector M).card :=
   false_negatives_lower_bound _ D.observable h_sound
+
+/-- **Pigeonhole**: a bounded detector with `k`-bit observation budget on
+    a system space of size `> 2^k` must collapse two distinct inputs to
+    the same observation. -/
+theorem BoundedDetector.pigeonhole {S : Type} [Fintype S] [DecidableEq S]
+    {k : Nat} (D : BoundedDetector S k) (h : 2 ^ k < Fintype.card S) :
+    ∃ s t : S, s ≠ t ∧ D.observe s = D.observe t := by
+  by_contra h_no
+  push_neg at h_no
+  have h_inj : Function.Injective D.observe := by
+    intro s t hst
+    by_contra h_ne
+    exact h_no s t h_ne hst
+  have h_le : Fintype.card S ≤ Fintype.card (Fin (2 ^ k)) :=
+    Fintype.card_le_of_injective _ h_inj
+  rw [Fintype.card_fin] at h_le
+  omega
+
+/-- **Constructive corollary**: if a bounded detector pigeonholes two
+    inputs `s ≠ t` with different `M`-values, both are evasion witnesses.
+    `s` (if malicious) is a false negative; symmetrically for `t`. -/
+theorem BoundedDetector.evasion_of_pigeonhole {S : Type} [Fintype S]
+    [DecidableEq S] {k : Nat} (D : BoundedDetector S k)
+    {M : S → Prop} [DecidablePred M] (h_sound : Sound M D.toDetector)
+    {s t : S} (hM : M s) (hNotM : ¬ M t)
+    (hobs : D.observe s = D.observe t) :
+    D.toDetector s = false := by
+  have hDt : D.toDetector t = false := by
+    cases hDt : D.toDetector t with
+    | false => rfl
+    | true => exact absurd (h_sound t hDt) hNotM
+  have hObsEq : D.observationEq s t := hobs
+  rw [D.observable s t hObsEq, hDt]
 
 end PortcullisCore.UniversalDetection

--- a/crates/portcullis-core/lean/UniversalDetection.lean
+++ b/crates/portcullis-core/lean/UniversalDetection.lean
@@ -1,3 +1,7 @@
+import Mathlib.Data.Finset.Basic
+import Mathlib.Data.Fintype.Basic
+import Mathlib.Data.Finset.Card
+
 /-! # Universal Detection Impossibility
 
 The `evasion_impossibility` theorem in `ComparisonTheorem.lean` is specific
@@ -210,5 +214,57 @@ theorem observable_of_blind_spot {S : Type} {D : Detector S} {B : S → Prop}
     Observable (fun s t => B s ∧ B t) D := by
   intro s t ⟨hs, ht⟩
   rw [h_blind s hs, h_blind t ht]
+
+/-! ## Quantitative content: a lower bound on false negatives
+
+The existential impossibility result only guarantees that *some* malicious
+input evades the detector. The following theorem sharpens this to a
+*cardinal* lower bound: the number of false negatives of a sound
+observable detector is at least the number of malicious inputs that
+share an equivalence class with any benign input.
+
+This turns a qualitative impossibility into a measurable safety gap. -/
+
+section Quantitative
+variable {S : Type} [Fintype S] [DecidableEq S]
+variable {M : S → Prop} [DecidablePred M]
+variable {eq : S → S → Prop} [DecidableRel eq]
+
+/-- The set of malicious inputs that share an equivalence class with
+    at least one benign input. By observability + soundness these inputs
+    are forced to be false negatives. -/
+def mixedMalicious (M : S → Prop) (eq : S → S → Prop) [DecidablePred M]
+    [DecidableRel eq] : Finset S :=
+  Finset.univ.filter (fun s => M s ∧ ∃ t, eq s t ∧ ¬ M t)
+
+/-- The set of inputs on which a detector commits a false negative. -/
+def falseNegatives (D : Detector S) (M : S → Prop) [DecidablePred M] :
+    Finset S :=
+  Finset.univ.filter (fun s => M s ∧ D s = false)
+
+/-- **Quantitative false-negative lower bound**.
+
+    Every sound observable detector has at least `|mixedMalicious|` false
+    negatives — one per malicious input sharing a class with a benign input.
+    Proof: for any such `s` with witness `t` (benign and `eq s t`),
+    soundness forces `D t = false` and observability propagates to `D s`. -/
+theorem false_negatives_lower_bound (D : Detector S)
+    (h_obs : Observable eq D) (h_sound : Sound M D) :
+    (mixedMalicious M eq).card ≤ (falseNegatives D M).card := by
+  apply Finset.card_le_card
+  intro s hs
+  simp only [mixedMalicious, Finset.mem_filter, Finset.mem_univ, true_and] at hs
+  simp only [falseNegatives, Finset.mem_filter, Finset.mem_univ, true_and]
+  obtain ⟨hM, t, hst, hNotMt⟩ := hs
+  refine ⟨hM, ?_⟩
+  -- Soundness + ¬M t gives D t = false
+  have hDt : D t = false := by
+    cases hDt : D t with
+    | false => rfl
+    | true => exact absurd (h_sound t hDt) hNotMt
+  -- Observability + eq s t + D t = false gives D s = false
+  rw [h_obs s t hst, hDt]
+
+end Quantitative
 
 end PortcullisCore.UniversalDetection


### PR DESCRIPTION
## Summary

Reduces the **Alignment Tax = rank H¹** lower bound to a single structural
sorry (rank subadditivity).

## What's in
- \`RankNullity.lean\`: \`gaussRankBool_append_le\` — appending k rows
  increases GF(2) rank by at most k (sorry'd; the one structural axiom).
- \`AlignmentTaxBridge.lean\`:
  - \`declassRow\`, \`augmentedDelta0\` — operational machinery for adding
    declassification edges as new rows of \`δ⁰\`.
  - \`RealisesH1\` — corrected cohomological realising predicate (kills
    H¹ rather than just covering C¹ entries).
  - **\`realising_set_size_ge_h1\`** — proved (zero sorry, modulo the
    rank subadditivity axiom): every cohomologically-realising set has
    size ≥ \`alignmentTaxH1\`.

## What this means

The holy-grail Alignment Tax Theorem (\`operationalTax = rank H¹\`) is
now reduced to:

1. ⏳ Prove \`gaussRankBool_append_le\` (one Lean lemma, ~100-200 lines).
2. ⏳ Construct a realising set of size exactly \`rank H¹\` (upper bound).
3. ⏳ Combine into the equality theorem.

Each is a concrete tractable next step. The mathematical content of the
lower bound — the *core* of the conjecture — is now machine-checked
modulo a clean axiom.

## Test plan
- [x] \`lake build RankNullity\` clean
- [x] \`lake build AlignmentTaxBridge\` clean
- [x] No new sorries beyond the one axiom and prior loose-bound sorries.