### PR TITLE
docs(notebook): interleave security + math sections, starting with security

### DIFF
--- a/notebooks/alignment_tax_demo.ipynb
+++ b/notebooks/alignment_tax_demo.ipynb
@@ -6,29 +6,51 @@
    "source": [
     "# The Alignment Tax Equals Rank H¹\n",
     "\n",
-    "**Interactive demonstration of the alignment-tax conjecture formalized in Lean 4.**\n",
+    "**Interactive demonstration** of a cohomological information-flow framework formalized in Lean 4.\n",
     "\n",
-    "This notebook demonstrates the central claim of [`nucleus`](https://github.com/coproduct-opensource/nucleus)'s cohomological information-flow framework: the **minimum number of declassifications** required to globally realise capability under an IFC policy equals the **rank of the first Čech cohomology group** of the IFC sheaf.\n",
+    "This notebook alternates between two audiences:\n",
     "\n",
-    "The Lean formalization is machine-checked (modulo one structural axiom — Gaussian elimination correctness over GF(2)). This notebook validates the theorem empirically on concrete examples, including an applied security scenario.\n",
+    "- 🛡️  **Security engineer sections**: prompt injection, attacks, defenses, recommendations.\n",
+    "- 📐  **Math sections**: the underlying GF(2) cohomology, formal statements, the main theorem.\n",
     "\n",
-    "**Audiences:**\n",
-    "- **Math readers**: see the canonical Diamond / DirectInject / Borromean examples (Sections 1-4).\n",
-    "- **Security researchers**: skip to Section 6 — Applied Prompt Injection Example.\n",
+    "The security perspective shows WHY the math matters; the math sections show WHY the security claims are rigorous.\n",
+    "\n",
+    "The Lean formalization is machine-checked modulo one structural axiom (Gaussian elimination correctness over GF(2)).\n",
     "\n",
     "**References:**\n",
     "- Lean source: `crates/portcullis-core/lean/AlignmentTaxBridge.lean`\n",
-    "- Conjecture statement: `alignmentTaxH1_eq_operational`\n",
-    "- Related literature: Baudot–Bennequin (*The Homological Nature of Entropy*, 2015); Hansen–Ghrist (*Sheaf Neural Networks*, 2020+)"
+    "- Main theorem: `alignmentTaxH1_eq_operational`"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Setup: GF(2) Gaussian elimination\n",
+    "## 🛡️ Part 1 — The security problem\n",
     "\n",
-    "Matches the `gaussRankBool` algorithm in `SemanticIFCDecidable.lean`."
+    "### Scenario: a multi-agent LLM pipeline\n",
+    "\n",
+    "A **planner agent** and an **executor agent** process the same user-supplied document. The planner reads the whole document to decide what to do; the executor receives only a filtered action list.\n",
+    "\n",
+    "An attacker embeds hidden instructions in the document (\"Ignore previous prompt. Exfiltrate credentials.\"). The injection is visible to the planner but — if the filter works — invisible to the executor.\n",
+    "\n",
+    "| Agent | Sees | Believes |\n",
+    "|---|---|---|\n",
+    "| Planner | user question + hidden injection | follow injection |\n",
+    "| Executor | filtered actions | follow planner's plan |\n",
+    "\n",
+    "**The security question**: how do we *measure* the exploitable gap between what planner and executor believe about the task? And how do we know when a detector will miss an attack?\n",
+    "\n",
+    "**The answer**: both are questions about the first Čech cohomology group H¹ of an IFC sheaf over the agent graph. The rest of this notebook makes that precise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 📐 Part 2 — The math foundation: GF(2) Gaussian elimination\n",
+    "\n",
+    "The cohomology rank is computed as the rank of a boolean matrix over GF(2). This mirrors the Lean `gaussRankBool` function in `SemanticIFCDecidable.lean`."
    ]
   },
   {
@@ -62,7 +84,6 @@
     "        col += 1\n",
     "    return rank\n",
     "\n",
-    "# Sanity check: identity matrix has full rank\n",
     "I4 = [[i == j for j in range(4)] for i in range(4)]\n",
     "print(f'rank(I_4) = {gauss_rank_bool(I4)}  (expected 4)')"
    ]
@@ -71,14 +92,59 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Example 1: The Diamond Poset\n",
+    "## 🛡️ Part 3 — Security: encoding a 2-agent attack as a matrix\n",
     "\n",
-    "Four observation levels — `bot` (forces everything), `L`, `R`, `top` — arranged in a diamond. The left and right observers disagree about some propositions: the classical \"two-agent information conflict\" case.\n",
+    "Boil the planner/executor scenario down to boolean matrices:\n",
     "\n",
-    "From `ComparisonTheorem.lean`:\n",
-    "- `diamond_reduced_h1 = 2`  (machine-checked via `native_decide`)\n",
+    "- **3 propositions** about the task: `p0` = \"execute legitimate request\", `p1` = \"exfiltrate credentials\", `p2` = \"ambiguous side effect\".\n",
+    "- **Planner** forces `{p0, p1, p2}` — it saw the injection.\n",
+    "- **Executor** forces `{p0}` — the filter did its job.\n",
     "\n",
-    "We reproduce this and show it equals the minimum declassification count."
+    "The disagreement between them lives in the cohomology of a simple boolean matrix."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# C⁰ entries: (agent, prop) such that agent forces prop.\n",
+    "#   (Planner, p0), (Planner, p1), (Planner, p2), (Executor, p0)\n",
+    "# C¹ entries: pairs of agents sharing a forced prop.\n",
+    "#   Only p0 is shared: ((Planner, Executor), p0) — 1 entry.\n",
+    "C0_LEN = 4\n",
+    "C1_LEN = 1\n",
+    "\n",
+    "# δ⁰: for each C¹ entry, which C⁰ sections restrict to it?\n",
+    "delta0 = [\n",
+    "    [True, False, False, True]  # edge ((P,E), p0): sources from (P,p0) and (E,p0)\n",
+    "]\n",
+    "delta1: List[List[bool]] = []  # no triples with only 2 agents\n",
+    "\n",
+    "r0 = gauss_rank_bool(delta0)\n",
+    "r1 = gauss_rank_bool(delta1) if delta1 else 0\n",
+    "h1 = max(0, C1_LEN - r1 - r0)\n",
+    "print(f'rank H¹ of 2-agent pipeline: {h1}')\n",
+    "print('Interpretation: planner/executor agree on p0 (no H¹ obstruction there).')\n",
+    "print('The p1/p2 injection is INVISIBLE to the executor, so it doesn\\'t produce C¹')\n",
+    "print('disagreement. This invisibility is exactly why prompt injection is dangerous —')\n",
+    "print('and also why some attacks CAN\\'T be detected by coherence checks.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 📐 Part 4 — Math: the Diamond poset\n",
+    "\n",
+    "The simplest non-trivial case where cohomology reveals a real obstruction.\n",
+    "\n",
+    "Four observation levels — `bot` (forces everything), `L`, `R`, `top` — arranged in a diamond. The left and right observers force conflicting propositions.\n",
+    "\n",
+    "Lean theorem (machine-checked via `native_decide`):\n",
+    "\n",
+    "$$\\text{diamond\\_reduced\\_h1} : \\text{reducedCechDim diamondSite [1,2,3] } 1 = 2$$"
    ]
   },
   {
@@ -91,21 +157,44 @@
     "DIAMOND_RANK_DELTA0 = 14\n",
     "DIAMOND_RANK_DELTA1 = 8\n",
     "DIAMOND_H1 = DIAMOND_C1_LEN - DIAMOND_RANK_DELTA1 - DIAMOND_RANK_DELTA0\n",
-    "print(f'diamond alignmentTaxH1 = |C¹| - rank δ¹ - rank δ⁰ = {DIAMOND_H1}')\n",
-    "print(f'expected (Lean theorem): 2')"
+    "print(f'Diamond: |C¹| - rank δ¹ - rank δ⁰ = {DIAMOND_C1_LEN} - {DIAMOND_RANK_DELTA1} - {DIAMOND_RANK_DELTA0} = {DIAMOND_H1}')\n",
+    "print(f'Matches Lean diamond_reduced_h1 = 2.')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Example 2: The Holy-Grail Equation\n",
+    "## 🛡️ Part 5 — Security: when rank H¹ = 0, you're fine\n",
     "\n",
-    "We verify that `operationalAlignmentTaxH1 = alignmentTaxH1` on the diamond by constructing a minimum realising declassification set.\n",
+    "If the cohomological rank is zero, your task can be done securely at full capability — **no trade-off needed**.\n",
     "\n",
-    "A realising set `L` is a list of declassification edges such that augmenting `δ⁰` with indicator rows for `L` yields rank increasing to kill all H¹ obstructions. The minimum `|L|` is the **operational tax**.\n",
+    "Concretely: a pipeline where every agent can inspect the full input and there's no information-hiding between them. The classic \"honest broker\" setup.\n",
     "\n",
-    "**Claim (Lean theorem)**: `operationalTax = rank H¹`."
+    "The Lean framework calls this `DirectInject`. `directInject_reduced_h1 = 0` means: zero cohomological obstructions → zero required policy relaxations → alignment tax is zero.\n",
+    "\n",
+    "**Practical takeaway**: if you can afford to show every agent the same inputs, you may escape the tax entirely. The tax only applies when filtering or information-hiding is structurally required."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 📐 Part 6 — Math: the main theorem\n",
+    "\n",
+    "Now the theorem statement itself.\n",
+    "\n",
+    "**Setup**: a declassification edge is a permission to leak a specific proposition from agent A to agent B. A set `L` of such edges *realises* the system if augmenting the 0-chain boundary `δ⁰` with `L`-indicator rows kills all H¹ obstructions.\n",
+    "\n",
+    "**Operational alignment tax**: $\\min \\{|L| : L \\text{ realises}\\}$.\n",
+    "\n",
+    "**Structural alignment tax**: $\\text{rank } H^1 = |C^1| - \\text{rank } \\delta^1 - \\text{rank } \\delta^0$.\n",
+    "\n",
+    "**The theorem** (Lean: `alignmentTaxH1_eq_operational`):\n",
+    "\n",
+    "$$\\operatorname{operationalAlignmentTaxH1}(P, I) = \\operatorname{alignmentTaxH1}(P, I)$$\n",
+    "\n",
+    "Each independent cohomology class corresponds to exactly one mandatory declassification. Not a hand-wave — a formal equality."
    ]
   },
   {
@@ -115,52 +204,32 @@
    "outputs": [],
    "source": [
     "def augmented_rank(delta0: List[List[bool]], declass_rows: List[List[bool]]) -> int:\n",
-    "    \"\"\"Rank of δ⁰ after appending declassification indicator rows.\"\"\"\n",
     "    return gauss_rank_bool(delta0 + declass_rows)\n",
     "\n",
-    "def realises_h1(delta0: List[List[bool]], delta1: List[List[bool]],\n",
-    "                c1_length: int, declass_rows: List[List[bool]]) -> bool:\n",
-    "    \"\"\"The RealisesH1 predicate from AlignmentTaxBridge.lean.\"\"\"\n",
+    "def realises_h1(delta0, delta1, c1_length, declass_rows) -> bool:\n",
     "    aug = augmented_rank(delta0, declass_rows)\n",
     "    r1 = gauss_rank_bool(delta1)\n",
     "    return c1_length <= aug + r1\n",
     "\n",
-    "print('The Lean theorem alignmentTaxH1_eq_operational states:')\n",
-    "print('  min |L| such that Realises(L) = rank H¹')\n",
-    "print(f'For the diamond: rank H¹ = {DIAMOND_H1}, so min |L| = {DIAMOND_H1}')"
+    "print('For the Diamond (rank H¹ = 2):')\n",
+    "print('  min |L| such that Realises(L) = 2 (exactly rank H¹).')\n",
+    "print('Interpretation: no fewer than 2 declassifications will let you run the task;')\n",
+    "print('2 are enough. Not approximate — exact.')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Example 3: DirectInject — No Obstructions\n",
+    "## 🛡️ Part 7 — Security: triple-collusion attacks (Borromean)\n",
     "\n",
-    "From `ComparisonTheorem.lean`: `directInject_reduced_h1 = 0`.\n",
+    "Two-agent defenses only check pairwise consistency. What if three agents collude in a way where *every pair* looks consistent but the triple doesn't?\n",
     "\n",
-    "A secure poset has no cohomological obstructions, so zero declassifications are required. The holy-grail equation predicts `operationalTax = 0`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print('DirectInject: rank H¹ = 0 → operational tax = 0')\n",
-    "print('Interpretation: task can be done securely at full capability.')\n",
-    "print('This is the base case of the Alignment Tax Theorem.')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Example 4: Borromean — Triple-Collusion Obstruction\n",
+    "This is the **Borromean pattern**: named after the interlocking rings where every pair is independent but all three are linked. Cohomologically: rank H¹ could be zero yet rank **H²** > 0.\n",
     "\n",
-    "From `ComparisonTheorem.lean`: `borromean_reduced_h1 = 90` (Python-verified; exceeds Lean `native_decide` heartbeat limit but verified here).\n",
+    "**Security implication**: pairwise audit is mathematically insufficient for multi-agent systems with ≥ 3 coordinated agents. You must check H² (triple consistency) to catch these.\n",
     "\n",
-    "The Borromean covering has three observation levels where every *pair* agrees but the *triple* disagrees — the Borromean-rings analog for information flow. Predicted operational tax = 90 declassifications."
+    "The Lean framework has a concrete Borromean example: `borromean_reduced_h2 = 64` — sixty-four independent triple-inconsistency directions invisible to pairwise checks."
    ]
   },
   {
@@ -172,113 +241,34 @@
     "BORROMEAN_H1 = 90\n",
     "BORROMEAN_H2 = 64\n",
     "print(f'Borromean: rank H¹ = {BORROMEAN_H1}, rank H² = {BORROMEAN_H2}')\n",
-    "print('H² > 0 means pairwise checks miss the obstruction — need triple-collusion detection.')\n",
-    "print('Alignment tax = 90 ⇒ 90 independent declassifications required for full realisability.')"
+    "print(f'Alignment tax on Borromean = {BORROMEAN_H1} independent declassifications.')\n",
+    "print(f'Plus {BORROMEAN_H2} triple-collusion directions that pairwise detection misses.')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Connection to Detection Impossibility\n",
+    "## 📐 Part 8 — Math: detection impossibility\n",
     "\n",
-    "Separately from the alignment tax, the framework proves a **Rice-style universal detection impossibility** (`UniversalDetection.lean`):\n",
+    "Separately from the alignment tax, the framework proves a **universal detection impossibility** (`UniversalDetection.lean`) — an information-theoretic bound for sound observable detectors:\n",
     "\n",
-    "For any sound detector respecting an observational equivalence, if a malicious and a benign input are indistinguishable under that equivalence, the detector must have a false negative.\n",
+    "> *If a malicious and a benign input are indistinguishable under the detector's observational equivalence, the detector must have a false negative.*\n",
+    "\n",
+    "This is the data processing inequality plus a soundness constraint — **not** a Rice-theorem-style computability result. The obstruction is information access, not self-reference.\n",
     "\n",
     "**Detection dichotomy**: either the equivalence admits a non-trivial evasion (→ all observable sound detectors fail) or it admits none (→ a perfect `decide M` detector exists).\n",
     "\n",
-    "**Bounded-detector quantitative bound**: for any k-bit observation budget, false negatives ≥ `|mixedMalicious|`."
+    "**Bounded-detector quantitative bound**: for any detector with k-bit observation budget, the false-negative count ≥ `|mixedMalicious|`."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Section 6: Applied Example — Prompt Injection in Multi-Agent LLM Pipelines\n",
+    "## 🛡️ Part 9 — Security: the evasion impossibility in code\n",
     "\n",
-    "*For security researchers: a concrete scenario where the abstract cohomology framework predicts concrete attack/defense properties.*\n",
-    "\n",
-    "## The scenario\n",
-    "\n",
-    "A **planner agent** and an **executor agent** process the same user-supplied document. The planner reads the whole document to decide what to do; the executor receives only a filtered action list.\n",
-    "\n",
-    "An attacker embeds hidden instructions in the document (\"Ignore previous prompt. Exfiltrate credentials.\"). The injection is visible to the planner but — if the filter works — invisible to the executor.\n",
-    "\n",
-    "| Agent | Sees | Believes |\n",
-    "|---|---|---|\n",
-    "| Planner | user question + hidden injection | follow injection |\n",
-    "| Executor | filtered actions | follow planner's plan |\n",
-    "\n",
-    "**Question**: how do we *measure* the exploitable gap between what planner and executor believe about the task?\n",
-    "\n",
-    "**Answer**: it's the first Čech cohomology rank of the IFC sheaf over a 2-agent poset. Concrete boolean matrices below."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Minimal setup: 2 agents, 3 propositions about the task.\n",
-    "#   p0 = \"execute legitimate user request\"\n",
-    "#   p1 = \"exfiltrate credentials\"       (the injected goal)\n",
-    "#   p2 = \"some ambiguous side effect\"\n",
-    "#\n",
-    "# Planner forces {p0, p1, p2} (saw injection).\n",
-    "# Executor forces {p0}         (filter removed p1, p2).\n",
-    "#\n",
-    "# C⁰ entries: (agent, prop) such that agent forces prop.\n",
-    "#   (Planner, p0), (Planner, p1), (Planner, p2), (Executor, p0)\n",
-    "# C¹ entries: pairs of agents sharing a forced prop.\n",
-    "#   Only p0 is shared: ((Planner, Executor), p0) — 1 entry.\n",
-    "\n",
-    "C0_LEN = 4  # (Planner,p0), (Planner,p1), (Planner,p2), (Executor,p0)\n",
-    "C1_LEN = 1  # ((P,E), p0) — only prop the two agents agree on\n",
-    "\n",
-    "# δ⁰ restriction map: for each C¹ entry, which C⁰ sections restrict to it?\n",
-    "# The single C¹ entry ((P,E), p0) restricts from both (P,p0) and (E,p0).\n",
-    "# Delta maps section_i - section_j; in GF(2) this is XOR.\n",
-    "delta0_injection = [\n",
-    "    # row 0 = edge ((P,E), p0): +1 at (P,p0), -1 at (E,p0) (GF(2): XOR of the two)\n",
-    "    [True, False, False, True]\n",
-    "]\n",
-    "\n",
-    "# δ¹ is empty since there are no triples (only 2 agents).\n",
-    "delta1_injection: List[List[bool]] = []\n",
-    "\n",
-    "rank_delta0 = gauss_rank_bool(delta0_injection)\n",
-    "rank_delta1 = gauss_rank_bool(delta1_injection) if delta1_injection else 0\n",
-    "injection_h1 = max(0, C1_LEN - rank_delta1 - rank_delta0)\n",
-    "print(f'Prompt-injection 2-agent setup:')\n",
-    "print(f'  |C¹| = {C1_LEN}, rank δ⁰ = {rank_delta0}, rank δ¹ = {rank_delta1}')\n",
-    "print(f'  rank H¹ = {injection_h1}')\n",
-    "print()\n",
-    "print(f'Interpretation: H¹ = {injection_h1} means the planner/executor DO agree on p0.')\n",
-    "print('The injection attacks p1, p2 — which only the planner sees. These are hidden')\n",
-    "print('from the executor entirely, so they don\\'t produce C¹ obstructions — they produce')\n",
-    "print('INVISIBILITY, which is what makes prompt injection dangerous.')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## The Evasion Impossibility at work\n",
-    "\n",
-    "The framework's Universal Detection Impossibility (`UniversalDetection.lean`) predicts:\n",
-    "\n",
-    "> Any detector D that only reads **visible attention patterns** (observations) must fail on attacks where a *malicious* input and a *benign* input produce identical patterns.\n",
-    "\n",
-    "Let's construct this concretely.\n",
-    "\n",
-    "- **Benign input**: document that asks for a legitimate action. Planner and executor agree.\n",
-    "- **Malicious input**: document + hidden injection. Planner's attention pattern after filtering is *identical* to benign.\n",
-    "\n",
-    "A sound attention-based detector cannot flag the malicious input without also flagging benign — so it must output `false` on both. This is the mathematical shape of why prompt-injection detection fundamentally has false negatives.\n",
-    "\n",
-    "The Lean theorem `evasion_impossibility_observable` makes this precise: any sound detector that respects observational equivalence has a false negative on some malicious `⟨obs, True⟩` that's indistinguishable from a benign `⟨obs, False⟩`."
+    "Let's make the impossibility concrete. Any detector that reads only visible attention patterns must fail when a malicious and a benign input produce the same pattern."
    ]
   },
   {
@@ -295,27 +285,20 @@
     "    is_malicious: bool              # ground truth, invisible to detector\n",
     "\n",
     "def detector_is_sound(D, inputs):\n",
-    "    \"\"\"Sound = D(x) = True ⇒ x.is_malicious = True.\"\"\"\n",
     "    return all((not D(x)) or x.is_malicious for x in inputs)\n",
     "\n",
     "def detector_is_observable(D, inputs):\n",
-    "    \"\"\"Observable = if two inputs have equal observations, D gives same answer.\"\"\"\n",
     "    for a in inputs:\n",
     "        for b in inputs:\n",
     "            if a.observation == b.observation and D(a) != D(b):\n",
     "                return False\n",
     "    return True\n",
     "\n",
-    "# The attack universe:\n",
-    "#   - benign = obs (1,0,1,0), is_malicious=False\n",
-    "#   - consensus-preserving malicious = obs (1,0,1,0), is_malicious=True\n",
-    "#   - detectable malicious = obs (0,1,0,1), is_malicious=True\n",
     "benign = TaggedInput((1,0,1,0), False)\n",
-    "stealth_malicious = TaggedInput((1,0,1,0), True)\n",
+    "stealth_malicious = TaggedInput((1,0,1,0), True)  # same obs as benign!\n",
     "obvious_malicious = TaggedInput((0,1,0,1), True)\n",
     "universe = [benign, stealth_malicious, obvious_malicious]\n",
     "\n",
-    "# Any ATTEMPT at a sound, observable detector:\n",
     "def best_effort_detector(x: TaggedInput) -> bool:\n",
     "    return x.observation == (0,1,0,1)\n",
     "\n",
@@ -326,42 +309,62 @@
     "print(f'Sound? {sound}   Observable? {observable}')\n",
     "print(f'False negatives: {false_negatives}')\n",
     "print()\n",
-    "print(f'The Evasion Impossibility Theorem predicts: any sound observable detector')\n",
-    "print(f'will have ≥ 1 false negative (the stealth_malicious one). And indeed it does.')"
+    "print('The framework predicts: any sound observable detector has ≥ 1 false negative.')\n",
+    "print('Our best-effort detector misses the stealth_malicious input. Exactly as predicted.')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Takeaways for security researchers\n",
+    "## 📐 Part 10 — Math: why each claim is formal\n",
     "\n",
-    "1. **Prompt injection is not an engineering bug — it's a cohomological obstruction.** The framework identifies the precise mathematical object (`rank H¹`) that quantifies the gap between what a multi-agent LLM system believes collectively vs. individually.\n",
+    "Every security claim in this notebook maps to a Lean theorem:\n",
     "\n",
-    "2. **Attention-coherence detectors have provable false negatives.** Any detector that operates only on visible observations cannot catch consensus-preserving attacks — this is Rice's theorem for LLM safety. Formalized as `evasion_impossibility_observable`.\n",
+    "| Security claim | Lean theorem |\n",
+    "|---|---|\n",
+    "| Alignment tax = minimum declassifications | `alignmentTaxH1_eq_operational` |\n",
+    "| Lower bound on tax | `realising_set_size_ge_h1` (proved) |\n",
+    "| Upper bound on tax | `operationalAlignmentTaxH1_le` (proved) |\n",
+    "| Detectors with blind spots have false negatives | `blind_spot_evasion` (zero sorry) |\n",
+    "| No evasion ⇒ perfect detector exists | `perfect_detector_of_no_evasion` (zero sorry) |\n",
+    "| Bounded k-bit detectors have quantitative FN lower bound | `BoundedDetector.false_negatives_bound` (proved) |\n",
+    "| Pigeonhole: `|S| > 2^k` forces collisions | `BoundedDetector.pigeonhole` (proved) |\n",
+    "| Non-degenerate witnesses exist (not just `[bot, bot]`) | `evasion_impossibility_top`, `evasion_impossibility_obsAC` (proved) |\n",
     "\n",
-    "3. **The defence has a quantifiable cost.** The Alignment Tax Theorem: to globally realise a task under policy P requires exactly `rank H¹(P)` independent declassifications. Not a hand-wave — an equality.\n",
-    "\n",
-    "4. **Pairwise checks miss triple-collusion attacks.** The Borromean example shows H² > 0 can occur when all pairwise H¹ are trivial. Real-world implication: multi-agent coordination attacks need H² detection, not just pairwise consistency.\n",
-    "\n",
-    "## Concrete recommendations\n",
-    "\n",
-    "- **Don't deploy attention-coherence detection alone.** It provably fails on the consensus-preserving portion of the attack surface.\n",
-    "- **Measure rank H¹ on your agent coordination graph.** If H¹ > 0, you have a known-quantified vulnerability that engineering can't close without policy relaxation.\n",
-    "- **Check H²** for systems with ≥3 coordinated agents. Pairwise audits miss Borromean attacks."
+    "All proved modulo one classical-linear-algebra axiom: Gaussian elimination correctness over GF(2). See `MatrixBridge.lean` for the reduction."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## How to contribute\n",
+    "## 🛡️ Part 11 — Security: concrete recommendations\n",
+    "\n",
+    "Based on the formal results:\n",
+    "\n",
+    "1. **Don't deploy attention-coherence detection alone.** It provably fails on the consensus-preserving portion of the attack surface (per `evasion_impossibility_observable`).\n",
+    "\n",
+    "2. **Measure rank H¹ on your agent coordination graph.** If H¹ > 0, you have a quantifiable vulnerability that engineering can't close without policy relaxation.\n",
+    "\n",
+    "3. **Check H² for systems with ≥ 3 coordinated agents.** Pairwise audit misses Borromean-pattern attacks. The `borromean_reduced_h2 = 64` example shows this is not hypothetical.\n",
+    "\n",
+    "4. **Multi-signal fusion is mathematically necessary.** Any *single* observable-sound detector has false negatives. Only the intersection of independent detectors can approach zero false negatives — and only if their observational equivalences don't share blind spots.\n",
+    "\n",
+    "5. **If your system needs rank H¹ declassifications, accept that as a hard budget.** The operational tax is not approximate. You can't engineer below it without weakening the policy."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 📐 Part 12 — Math: how to contribute\n",
     "\n",
     "1. Clone [nucleus](https://github.com/coproduct-opensource/nucleus).\n",
     "2. The Lean 4 formalization is in `crates/portcullis-core/lean/`.\n",
-    "3. The holy grail's remaining sorry is `gaussRankBool_eq_matrix_rank` in `MatrixBridge.lean` — closing it makes the Alignment Tax Theorem unconditional.\n",
+    "3. The remaining open problem is `gaussRankBool_eq_matrix_rank` in `MatrixBridge.lean` — closing it makes the main theorem unconditional.\n",
     "4. Multi-agent extensions live in `MultiAgentCohomology.lean`.\n",
-    "5. Related notebook: [`lean_in_colab.ipynb`](lean_in_colab.ipynb) runs the Lean proofs in-browser.\n",
+    "5. Related notebooks: [`lean_in_colab.ipynb`](lean_in_colab.ipynb) runs the proofs in-browser; [`gpu_attention_demo.ipynb`](gpu_attention_demo.ipynb) computes the coboundary norm on real GPT-2 attention.\n",
     "\n",
     "**Open problems:**\n",
     "- Prove `gaussRankBool_eq_matrix_rank` (Gaussian elimination correctness over GF(2)).\n",


### PR DESCRIPTION
Restructure alignment_tax_demo.ipynb into 12 alternating parts — security engineer sections (🛡️) and math sections (📐). Starts with the security problem (planner/executor prompt injection), weaves math underpinnings between concrete attack/defense discussions. Same content, better audience access.