### PR TITLE
ci(lean): fetch prebuilt Mathlib cache + lake-manifest in key

### DIFF
--- a/.github/workflows/aeneas.yml
+++ b/.github/workflows/aeneas.yml
@@ -129,9 +129,18 @@ jobs:
           path: |
             crates/portcullis-core/lean/.lake
             ~/.elan
-          key: lean-aeneas-${{ runner.os }}-${{ hashFiles('crates/portcullis-core/lean/lean-toolchain', 'crates/portcullis-core/lean/lakefile.lean') }}
+            ~/.cache/mathlib
+          # Include lake-manifest.json so dep commit bumps invalidate the cache.
+          key: lean-aeneas-${{ runner.os }}-${{ hashFiles('crates/portcullis-core/lean/lean-toolchain', 'crates/portcullis-core/lean/lakefile.lean', 'crates/portcullis-core/lean/lake-manifest.json') }}
           restore-keys: |
             lean-aeneas-${{ runner.os }}-
+
+      # Fetch prebuilt Mathlib .olean artifacts from Azure. Without this step
+      # a cold cache triggers a ~1 hour full Mathlib compile; with it, the
+      # Mathlib layer downloads in ~5 minutes.
+      - name: Fetch Mathlib cache (prebuilt oleans)
+        working-directory: crates/portcullis-core/lean
+        run: lake exe cache get || true
 
       - name: lake build (type-check proofs)
         working-directory: crates/portcullis-core/lean

--- a/.github/workflows/lean-build.yml
+++ b/.github/workflows/lean-build.yml
@@ -40,9 +40,18 @@ jobs:
           path: |
             crates/portcullis-core/lean/.lake
             ~/.elan
-          key: lean-core-${{ runner.os }}-${{ hashFiles('crates/portcullis-core/lean/lean-toolchain', 'crates/portcullis-core/lean/lakefile.lean') }}
+            ~/.cache/mathlib
+          # Include lake-manifest.json so dep commit bumps invalidate the cache.
+          key: lean-core-${{ runner.os }}-${{ hashFiles('crates/portcullis-core/lean/lean-toolchain', 'crates/portcullis-core/lean/lakefile.lean', 'crates/portcullis-core/lean/lake-manifest.json') }}
           restore-keys: |
             lean-core-${{ runner.os }}-
+
+      # Fetch prebuilt Mathlib .olean artifacts from Azure. Without this step
+      # a cold cache triggers a ~1 hour full Mathlib compile; with it, the
+      # Mathlib layer downloads in ~5 minutes.
+      - name: Fetch Mathlib cache (prebuilt oleans)
+        working-directory: crates/portcullis-core/lean
+        run: lake exe cache get || true
 
       - name: lake build PortcullisCoreBridge
         working-directory: crates/portcullis-core/lean


### PR DESCRIPTION
## Summary
Two CI optimizations to both Lean workflows (`lean-build.yml`, `aeneas.yml`):

1. **`lake exe cache get`**: fetches prebuilt Mathlib `.olean` artifacts from Azure. Without this, cold cache = ~1 hour Mathlib recompile. With it, ~5 min download.
2. **`lake-manifest.json` in cache key**: dep commit bumps via `lake update` that don't touch `lakefile.lean` previously reused stale caches silently. Now invalidates properly.

Also caches `~/.cache/mathlib` where `lake exe cache` writes.

## Why audit now
The #1562 Lean 4.29 bump surprise revealed that local builds were succeeding due to stale `.olean` caches, while CI rebuilt from scratch and exposed real toolchain issues. While that specific issue is aeneas-side, the broader lesson is: we were doing too much redundant Mathlib work on every CI run.

## Impact
- Cold-cache CI: ~45 min → ~10 min estimated
- Warm-cache CI: unchanged
- Local: unaffected (devs run `lake exe cache get` manually)

## References
- [mathlib4 CI pattern](https://github.com/leanprover-community/mathlib4)
- [leanprover/lean-action](https://github.com/leanprover/lean-action) — standardized action (future consolidation path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)