### PR TITLE
hotfix(aeneas): use real Swatinem/rust-cache@v2.9.1 SHA

### DIFF
--- a/.github/workflows/aeneas.yml
+++ b/.github/workflows/aeneas.yml
@@ -50,7 +50,7 @@ jobs:
       # Without this, Charon recompiles the portcullis_core crate and its
       # dependencies from scratch every run (~5-10 min).
       - name: Rust / cargo cache (Charon target dir)
-        uses: Swatinem/rust-cache@98c8021b550208e51a6a1635b0f6e6f1c3cfc7e0 # v2
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2.9.1
         with:
           workspaces: crates/portcullis-core
           key: charon-${{ env.CHARON_NIGHTLY }}-${{ env.AENEAS_RELEASE }}


### PR DESCRIPTION
## Problem
PR #1570 pinned `Swatinem/rust-cache` to a SHA that doesn't exist:

  `98c8021b550208e51a6a1635b0f6e6f1c3cfc7e0` (LLM-fabricated)

Every Aeneas CI run fails with:
```
Unable to resolve action `Swatinem/rust-cache@...`
```

## Fix
Replaces with verified real v2.9.1 tag SHA:
  `42dc69e1aa15d09112580998cf2ef0119e2e91ae`

Verified via: `curl https://api.github.com/repos/Swatinem/rust-cache/git/refs/tags/v2`

## Lesson (steelman callback)
The earlier steelman noted "bibliographic/SHA fabrication risk" for LLM-proposed citations. This is a live instance. Fix: verify pinned SHAs against the upstream repo before committing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)