### PR TITLE
hotfix(notebook): fix incorrect GF(2) rank sanity assert

### DIFF
--- a/notebooks/build_empirical_rank_h1.py
+++ b/notebooks/build_empirical_rank_h1.py
@@ -165,14 +165,17 @@ code(
     "    return rank\n",
     "\n",
     "# --- sanity check against known Lean values ---\n",
-    "# Diamond poset: alignmentTaxH1 = 2 (proved in ComparisonTheorem.lean).\n",
-    "# We don't rebuild the full diamond here; instead we verify the Gaussian\n",
-    "# routine on a small known matrix.\n",
-    "test = [[1,1,0,1],[0,1,1,0],[1,0,1,1]]\n",
-    "assert gauss_rank_gf2(test) == 3, 'GF(2) rank sanity check failed'\n",
+    "# Three independent rows → rank 3 over GF(2).\n",
+    "assert gauss_rank_gf2([[1,0,0],[0,1,0],[0,0,1]]) == 3, 'rank(I_3) should be 3'\n",
+    "# Three dependent rows over GF(2): r3 = r1 XOR r2.\n",
+    "assert gauss_rank_gf2([[1,1,0,1],[0,1,1,0],[1,0,1,1]]) == 2, 'r3=r1+r2 so rank=2'\n",
+    "# Duplicate rows collapse to rank 1.\n",
     "assert gauss_rank_gf2([[1,1],[1,1]]) == 1, 'rank(dup rows)=1'\n",
+    "# All-zero matrix has rank 0.\n",
     "assert gauss_rank_gf2([[0,0,0]]) == 0, 'rank(zero row)=0'\n",
-    "print('✓ gauss_rank_gf2 passes known-value tests')\n",
+    "# Empty matrix has rank 0.\n",
+    "assert gauss_rank_gf2([]) == 0, 'rank(empty)=0'\n",
+    "print('✓ gauss_rank_gf2 passes 5 known-value tests')\n",
 )
 
 # --- Attention → IFC poset ---

--- a/notebooks/empirical_rank_h1_gpt2.ipynb
+++ b/notebooks/empirical_rank_h1_gpt2.ipynb
@@ -131,14 +131,17 @@
     "    return rank\n",
     "\n",
     "# --- sanity check against known Lean values ---\n",
-    "# Diamond poset: alignmentTaxH1 = 2 (proved in ComparisonTheorem.lean).\n",
-    "# We don't rebuild the full diamond here; instead we verify the Gaussian\n",
-    "# routine on a small known matrix.\n",
-    "test = [[1,1,0,1],[0,1,1,0],[1,0,1,1]]\n",
-    "assert gauss_rank_gf2(test) == 3, 'GF(2) rank sanity check failed'\n",
+    "# Three independent rows \u2192 rank 3 over GF(2).\n",
+    "assert gauss_rank_gf2([[1,0,0],[0,1,0],[0,0,1]]) == 3, 'rank(I_3) should be 3'\n",
+    "# Three dependent rows over GF(2): r3 = r1 XOR r2.\n",
+    "assert gauss_rank_gf2([[1,1,0,1],[0,1,1,0],[1,0,1,1]]) == 2, 'r3=r1+r2 so rank=2'\n",
+    "# Duplicate rows collapse to rank 1.\n",
     "assert gauss_rank_gf2([[1,1],[1,1]]) == 1, 'rank(dup rows)=1'\n",
+    "# All-zero matrix has rank 0.\n",
     "assert gauss_rank_gf2([[0,0,0]]) == 0, 'rank(zero row)=0'\n",
-    "print('\u2713 gauss_rank_gf2 passes known-value tests')\n"
+    "# Empty matrix has rank 0.\n",
+    "assert gauss_rank_gf2([]) == 0, 'rank(empty)=0'\n",
+    "print('\u2713 gauss_rank_gf2 passes 5 known-value tests')\n"
    ]
   },
   {


### PR DESCRIPTION
## Bug
The matrix `[[1,1,0,1],[0,1,1,0],[1,0,1,1]]` has rank **2**, not 3: row₃ = row₁ ⊕ row₂ over GF(2), so the rows are linearly dependent. My previous assertion was mathematically wrong — the algorithm was correct all along.

## Trace
```
row1 = [1,1,0,1]
row2 = [0,1,1,0]
row1 XOR row2 = [1,0,1,1]  ← this IS row3, so rank = 2
```

## Fix
Replace single wrong assertion with **five targeted tests**:
- `rank(I_3)` = 3 (identity, new)
- `rank([[1,1,0,1],[0,1,1,0],[1,0,1,1]])` = **2** (corrected)
- `rank(dup rows)` = 1
- `rank(zero row)` = 0
- `rank(empty)` = 0 (new)

All five verified locally.

## Reproducer
Before this fix, anyone running Section 2 of the Colab notebook hit an `AssertionError` at the `gauss_rank_gf2` sanity cell.

Reported by user running the notebook end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)