### PR TITLE
fix(security): ignore RUSTSEC-2026-0098/0099 pending AWS SDK migration

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -34,4 +34,11 @@ ignore = [
     # rand 0.8.5 via rust_decimal/ruint — upstream has no patched 0.8.x.
     # Not exploitable: no custom logger in these deps calls rand::rng().
     "RUSTSEC-2026-0097",
+
+    # rustls-webpki 0.101.x URI name-constraint / wildcard-name vulns (2026-04-14).
+    # Transitive via aws-smithy-http-client 1.1.12 → rustls 0.21 → rustls-webpki 0.101.
+    # AWS SDK fix path: BehaviorVersion v2025_01_17+ (hyper 1.x + rustls 0.23).
+    # Tracked separately; AWS path does not process attacker-controlled certs.
+    "RUSTSEC-2026-0098",
+    "RUSTSEC-2026-0099",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -16,6 +16,13 @@ ignore = [
   # rand 0.8.5 via rust_decimal/ruint — upstream has not released a patched
   # version. Not exploitable here: no custom logger in these deps calls rand::rng().
   "RUSTSEC-2026-0097",
+
+  # rustls-webpki 0.101.x URI name-constraint / wildcard-name vulns (2026-04-14).
+  # Transitive via aws-smithy-http-client 1.1.12 → rustls 0.21 → rustls-webpki 0.101.
+  # AWS SDK fix path: BehaviorVersion v2025_01_17+ (hyper 1.x + rustls 0.23).
+  # Tracked separately; AWS path does not process attacker-controlled certs.
+  "RUSTSEC-2026-0098",
+  "RUSTSEC-2026-0099",
 ]
 # These are informational; scope to workspace dependencies.
 unmaintained = "workspace"


### PR DESCRIPTION
## Summary
- Both advisories (dropped 2026-04-14) land on \`rustls-webpki 0.101.x\`, transitively pulled via \`aws-smithy-http-client 1.1.12 → rustls 0.21\`.
- Real fix: migrate AWS SDK path to BehaviorVersion v2025_01_17+ (hyper 1.x + rustls 0.23). Tracked separately.
- AWS SDK code path does not process attacker-controlled certs — we only talk to AWS endpoints.

## Unblocks
All open PRs currently RED on \`audit\` / \`deny (advisories)\`: #1587, #1588, #1565, plus all future dependabot merges.

## Test plan
- [x] \`cargo audit\` clean locally
- [x] \`cargo deny check advisories\` clean locally (pre-commit hook)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)