### PR TITLE
feat(lean): AugmentedBorromean — H³/Euler + S₄ drop-two probe

### DIFF
--- a/crates/portcullis-core/lean/AugmentedBorromean.lean
+++ b/crates/portcullis-core/lean/AugmentedBorromean.lean
@@ -142,6 +142,35 @@ act on **every** cohomology degree. Running the same drop-one test at H²:
 #eval s!"H² [1,2,4,5]   drop obs_ac    = {reducedCechDim augmentedBorromeanSite [1,2,4,5]   2}"
 #eval s!"H² [1,2,3,5]   drop obs3      = {reducedCechDim augmentedBorromeanSite [1,2,3,5]   2}"
 
+/-! ## S₄ discriminator: H² on drop-two coverings
+
+If S₄ acts on {obs1, obs2, obs_ac, obs3} transitively (true S₄ symmetry),
+all C(4,2) = 6 two-observation drops must give equal H².
+
+If only S₃ on letters × Z/2 on sign (semidirect, NOT full S₄), the six
+pairs split 3+3: letter-pairs vs letter-sign-pairs.
+-/
+
+#eval s!"H² [1,2,5]   keep obs1+obs2    = {reducedCechDim augmentedBorromeanSite [1,2,5] 2}"
+#eval s!"H² [1,3,5]   keep obs1+obs_ac  = {reducedCechDim augmentedBorromeanSite [1,3,5] 2}"
+#eval s!"H² [2,3,5]   keep obs2+obs_ac  = {reducedCechDim augmentedBorromeanSite [2,3,5] 2}"
+#eval s!"H² [1,4,5]   keep obs1+obs3    = {reducedCechDim augmentedBorromeanSite [1,4,5] 2}"
+#eval s!"H² [2,4,5]   keep obs2+obs3    = {reducedCechDim augmentedBorromeanSite [2,4,5] 2}"
+#eval s!"H² [3,4,5]   keep obs_ac+obs3  = {reducedCechDim augmentedBorromeanSite [3,4,5] 2}"
+
+/-! ## H³ and Euler characteristic
+
+χ = Σ (−1)ⁱ rank Hⁱ.  So far: rank H⁰ = ? ; H¹ = 138 ; H² = 256.
+Compute H³ and assemble.
+-/
+
+#eval s!"H⁰ [1,2,3,4,5] full           = {reducedCechDim augmentedBorromeanSite [1,2,3,4,5] 0}"
+#eval s!"H³ [1,2,3,4,5] full           = {reducedCechDim augmentedBorromeanSite [1,2,3,4,5] 3}"
+#eval s!"H³ [2,3,4,5]   drop obs1      = {reducedCechDim augmentedBorromeanSite [2,3,4,5]   3}"
+#eval s!"H³ [1,3,4,5]   drop obs2      = {reducedCechDim augmentedBorromeanSite [1,3,4,5]   3}"
+#eval s!"H³ [1,2,4,5]   drop obs_ac    = {reducedCechDim augmentedBorromeanSite [1,2,4,5]   3}"
+#eval s!"H³ [1,2,3,5]   drop obs3      = {reducedCechDim augmentedBorromeanSite [1,2,3,5]   3}"
+
 /-! ## Expected outcomes
 
 1. **All three "drop letter-confuser" give equal H¹** → S₃ symmetry

--- a/crates/portcullis-core/lean/AugmentedBorromean.lean
+++ b/crates/portcullis-core/lean/AugmentedBorromean.lean
@@ -125,6 +125,23 @@ Each value is computed by `native_decide` at build time. Slow
 #eval s!"H¹ [1,2,4,5]   drop obs_ac    = {reducedCechDim augmentedBorromeanSite [1,2,4,5]   1}"
 #eval s!"H¹ [1,2,3,5]   drop obs3      = {reducedCechDim augmentedBorromeanSite [1,2,3,5]   1}"
 
+/-! ## Degree-2 extension: is S₃ a symmetry of the full tower, or H¹-specific?
+
+If the S₃ action on letter-confusers is genuinely cohomological, it must
+act on **every** cohomology degree. Running the same drop-one test at H²:
+
+- Three letter drops EQUAL at H² → S₃ is a real tower-level symmetry;
+  strong positive result beyond the H¹-only coincidence reading.
+- Three letter drops UNEQUAL at H² → H¹ equality was degree-specific;
+  downgrades the previous result to "H¹ numerology, not structural."
+-/
+
+#eval s!"H² [1,2,3,4,5] full           = {reducedCechDim augmentedBorromeanSite [1,2,3,4,5] 2}"
+#eval s!"H² [2,3,4,5]   drop obs1      = {reducedCechDim augmentedBorromeanSite [2,3,4,5]   2}"
+#eval s!"H² [1,3,4,5]   drop obs2      = {reducedCechDim augmentedBorromeanSite [1,3,4,5]   2}"
+#eval s!"H² [1,2,4,5]   drop obs_ac    = {reducedCechDim augmentedBorromeanSite [1,2,4,5]   2}"
+#eval s!"H² [1,2,3,5]   drop obs3      = {reducedCechDim augmentedBorromeanSite [1,2,3,5]   2}"
+
 /-! ## Expected outcomes
 
 1. **All three "drop letter-confuser" give equal H¹** → S₃ symmetry


### PR DESCRIPTION
## Summary
Extends AugmentedBorromean (#1590) with H³, Euler characteristic, and a drop-two S₄ probe. Empirical results below.

## Results

| Value | Covering | Result |
|---|---|---|
| H⁰ | full [1,2,3,4,5] | 2 |
| H¹ | full | 138 |
| H² | full | 256 = 2⁸ |
| H³ | full | **0** |

**Euler characteristic**: χ = 2 − 138 + 256 − 0 = **+120**

Compare unaugmented borromean: χ = −24. Adding \`obs_ac\` flipped χ by **+144**, moving the tower from \"H¹ dominates\" to \"H² dominates.\"

### S₄ drop-two probe (null result)
All six C(4,2) two-observation drops give H² = 0. Expected — 3-level coverings have trivial C². Not a usable discriminator. Documented so we don't repeat the test.

### H³ = 0 universally
Tower terminates at H² for this poset on 5-index coverings.

## What this does NOT prove
- Not the real S₄ action test. That requires constructing the explicit transposition (letter ↔ sign) on C² and checking boundary commutativity — tracked separately.
- The H² = 64 equality across drop-one coverings remains the S₄ hint. This PR doesn't strengthen it.

## Build cost
native_decide on 1 H⁰ + 5 H³ + 6 drop-two H² coverings: ~2429s (~40 min).

## Test plan
- [x] \`lake build AugmentedBorromean\` runs clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)