### PR TITLE
docs: honesty pass on SPIFFE/lineage claims (audit findings 1-4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ assert!(!state.flows_to(SinkClass::GitPush));  // can't push tainted data
 ## Quick Start
 
 ```bash
-cargo install --git https://github.com/coproduct-opensource/nucleus nucleus-claude-hook
-nucleus-claude-hook --setup    # wires into your AI coding assistant
-nucleus-claude-hook --smoke-test
+cargo install --git https://github.com/coproduct-opensource/nucleus nucleus-cli
+nucleus audit                       # scan agent configs (Tier 0, no runtime)
+nucleus run --local "your task"     # run with enforced permissions (Tier 1)
 ```
 
-Every tool call now flows through the permission kernel. The hook tracks data provenance and blocks dangerous combinations — like writing code derived from untrusted web content.
+Every tool call flows through the permission kernel. `nucleus run` tracks data provenance and blocks dangerous combinations — like writing code derived from untrusted web content. The hook for AI coding assistants previously bundled here (`nucleus-claude-hook`) is now part of [nucleus-code](https://github.com/coproduct-opensource/nucleus-code), the private orchestrator built on this runtime.
 
 ## What Gets Proved
 
@@ -46,9 +46,9 @@ Full inventory: 165 Lean 4 theorems (zero `sorry`), 112 Kani BMC proofs, 297 Ver
 | `a ⊔ a = a` | Join is idempotent | Provably safe caching |
 | `a ≤ a ⊔ b` | Join is monotone | Taint never decreases |
 
-## Per-Call SPIFFE Provenance
+## Per-Call SPIFFE Provenance (preview)
 
-Every tool call gets a SPIFFE identity. Every byte of output has a verifiable provenance chain back to its sources.
+> **Status:** alpha. The crate ships a per-call SPIFFE-ID derivation library, an in-process Ed25519 demo issuer, an append-mode JSONL log, and a `nucleus lineage` walker. The demo is not yet wired into the runtime, edges are not yet signed, and no SPIRE-backed `IdentityFetcher` impl exists in this repo. See [`crates/nucleus-lineage/README.md`](crates/nucleus-lineage/README.md) for the honest scope and [the audit findings](#known-gaps) for what's still missing.
 
 `nucleus-lineage` extends [SPIFFE](https://spiffe.io/) workload identity from the *pod* level down to the *individual call* level. Each tool invocation, LLM call, or derived artifact mints a child SPIFFE ID whose path encodes its lineage and whose suffix is a content hash:
 
@@ -60,9 +60,9 @@ spiffe://<trust>/ns/<ns>/sa/<sa>                                   ← pod (root
   /call/<uuid>/derived/sha256:<hex>                                ← downstream artifact
 ```
 
-Identical content → identical content-hash suffix, regardless of derivation path. The full path doubles as a human-readable witness; the JWT-SVIDs minted at boundaries are cryptographic witnesses of the same chain.
+Identical content → identical content-hash suffix, regardless of derivation path. The full path is a human-readable witness of the derivation chain.
 
-Try it end-to-end (Bash → Write → mock-LLM with JWT verification):
+Try it end-to-end (Bash → Write → mock-LLM with self-loop JWT verification — the mock LLM uses the same in-process key the issuer minted with, so this proves the JWT format, not cross-trust federation):
 
 ```bash
 cargo run -p nucleus-lineage --example three_step_demo
@@ -71,13 +71,14 @@ nucleus lineage <leaf-spiffe-id> --log ./nucleus-lineage.jsonl
 
 Output formats: `--format tree` (default), `json`, or `dot` (for Graphviz).
 
-| What it gives you | What it doesn't |
+| Today | Roadmap |
 |---|---|
-| Cryptographically-signed identity per call (Ed25519 JWT-SVIDs) | Replace IFC labeling — composes with portcullis, doesn't replace it |
-| Content-addressed lineage that survives across pods and providers | Echo-back from external relying parties (e.g. Anthropic records `sub`, doesn't return it on responses) |
-| `nucleus lineage` walks the full DAG (ancestors or descendants) | A SPIRE Workload API client by default — the demo uses a `LocalIssuer`; production wiring lives in `nucleus-identity`'s `spire` feature |
+| SPIFFE-format ID per call, content-addressed | Edge signing + hash chain so the JSONL log is tamper-evident |
+| `LocalIssuer` (in-process Ed25519, demo-only) | SPIRE Workload API `IdentityFetcher` impl |
+| `nucleus lineage` walker (graph traversal) | Walker verifies edge signatures + JWKS-backed federation |
+| Composes with portcullis IFC labels (does not replace them) | `nucleus-tool-proxy` auto-emits edges per HTTP handler |
 
-Categorically: per-call SPIFFE IDs lift the workload category to a bicategory where morphisms (calls) carry identities, making end-to-end IFC sheaves measurable rather than only inferable. See [`crates/nucleus-lineage/README.md`](crates/nucleus-lineage/README.md) for the longer story.
+Treat the categorical framing — "per-call SPIFFE IDs lift the workload category to a bicategory; cocycle condition becomes verifiable" — as a roadmap, not as currently load-bearing. See [`crates/nucleus-lineage/README.md`](crates/nucleus-lineage/README.md) for the longer story and the explicit limitations.
 
 ## How Nucleus Stops Real Exploits
 
@@ -121,13 +122,12 @@ Agent → MCP → tool-proxy (inside VM) → portcullis check → OS operation
 ## Crates
 
 <details>
-<summary>User-facing tools (5 crates)</summary>
+<summary>User-facing tools (4 crates)</summary>
 
 | Crate | Purpose |
 |-------|---------|
-| [**nucleus-claude-hook**](crates/nucleus-claude-hook/) | Hook for AI coding assistants: IFC kernel, compartments, provenance |
+| [**nucleus-cli**](crates/nucleus-cli/) | Run AI agents under enforced permissions; ships the `nucleus` binary |
 | [**nucleus-audit**](crates/nucleus-audit/) | Scan agent configs, verify audit trails, inspect provenance |
-| [**nucleus-cli**](crates/nucleus-cli/) | Run AI agents under enforced permissions |
 | [**nucleus-sdk**](crates/nucleus-sdk/) | Rust SDK for building sandboxed AI agents |
 | [**exposure-playground**](crates/exposure-playground/) | Interactive TUI for exploring the permission lattice |
 

--- a/crates/nucleus-lineage/README.md
+++ b/crates/nucleus-lineage/README.md
@@ -1,8 +1,8 @@
 # nucleus-lineage
 
-> Every tool call gets a SPIFFE identity. Every byte of output has a verifiable provenance chain back to its sources.
+> **Status: alpha.** A per-call SPIFFE-ID derivation library with an `O_APPEND`-mode JSONL log and a `LocalIssuer` for demos. Edge signing, hash chaining, and a SPIRE-backed `IdentityFetcher` impl are roadmap, not shipped. Read [Honest constraints](#honest-constraints) before depending on this for anything you care about.
 
-`nucleus-lineage` extends [SPIFFE](https://spiffe.io/) workload identity from the *pod* level down to the *individual call* level. Each tool invocation, LLM call, or derived artifact mints a child SPIFFE ID whose path encodes its lineage and whose suffix is a content hash. The result: a cryptographically-signed, content-addressed DAG that lets you answer **"where did this data come from?"** with concrete evidence rather than inference.
+`nucleus-lineage` extends [SPIFFE](https://spiffe.io/) workload identity from the *pod* level down to the *individual call* level. Each tool invocation, LLM call, or derived artifact mints a child SPIFFE ID whose path encodes its lineage and whose suffix is a content hash. With signing landed (roadmap), the result will be a tamper-evident, content-addressed DAG that answers **"where did this data come from?"** with cryptographic evidence rather than inference. Today it answers it with content hashes plus a parent pointer — useful, but not adversary-resistant on its own.
 
 ## The path scheme
 
@@ -14,7 +14,7 @@ spiffe://<trust>/ns/<ns>/sa/<sa>                                   ← pod (root
   /call/<uuid>/derived/sha256:<hex>                                ← downstream artifact
 ```
 
-Identical content → identical content-hash suffix (regardless of derivation path), so re-deriving the same value from the same parents is recognizable. The full path doubles as a human-readable witness of how this byte-string came to exist.
+Identical content → identical content-hash suffix (regardless of derivation path), so re-deriving the same value from the same parents is recognizable. The full path is a human-readable witness of how this byte-string came to exist.
 
 ## Quick demo
 
@@ -30,13 +30,15 @@ admitted pod: spiffe://demo.nucleus.local/ns/agents/sa/lineage-demo
 step 1 ✔ Bash → spiffe://…/call/cca7fa46…/tool/Bash/sha256:b534e3bf… (25 bytes)
 step 2 ✔ Write → spiffe://…/call/bde8f048…/tool/Write/sha256:b534e3bf… (/tmp/...)
 step 3a ✔ LLM prompt → spiffe://…/call/388064f0…/llm/anthropic/prompt/sha256:b534e3bf…
-    mock-llm: verified JWT, sub=spiffe://…, jti=684ee954…, exp_in=300s
+    mock-llm: verified JWT (self-loop), sub=spiffe://…, jti=684ee954…, exp_in=300s
 step 3b ✔ LLM response → spiffe://…/call/63b43cec…/llm/anthropic/response/sha256:2a6f4cc9… (476 bytes)
 
 done. lineage log written to ./nucleus-lineage.jsonl
 walk it with:
   nucleus lineage 'spiffe://…/llm/anthropic/response/sha256:2a6f4cc9…' --log ./nucleus-lineage.jsonl
 ```
+
+The "mock-llm: verified JWT" line is honest about what's verified: the JWT was minted by the `LocalIssuer` and verified using the **same in-process key** the issuer mints with. This proves JWT well-formedness, not cross-trust federation. A real relying party would fetch a JWKS from a separate trust anchor — that's roadmap.
 
 Then walk the chain back to its source:
 
@@ -60,24 +62,31 @@ For Graphviz output: `--format dot`. For machine-readable JSON: `--format json`.
 
 | Module | Purpose |
 |---|---|
-| `id::CallSpiffeId` | SPIFFE-format identity with strict path grammar. Constructors for pod-root + tool / LLM / artifact derivations. Round-trips through serde. |
-| `edge::LineageEdge` | One immutable record in the DAG: `(child, parents[], kind, content_hash, ts, attrs)`. Wire format is JSON, kept stable. |
-| `sink::LineageSink` | Trait for append-only persistence. `InMemorySink` (tests) + `JsonlSink` (file-backed) ship in this crate. |
-| `issuer::IdentityFetcher` | Trait for JWT-SVID minting. `LocalIssuer` (Ed25519, in-process, demo-only) ships here; a SPIRE Workload API impl lives in `nucleus-identity`. |
+| `id::CallSpiffeId` | SPIFFE-format identity. Validates `/call/<uuid>/...` suffix structure and content-hash format; full SPIFFE ID grammar enforcement is roadmap. Round-trips through serde. |
+| `edge::LineageEdge` | One record in the DAG: `(child, parents[], kind, content_hash, ts, attrs)`. JSON wire format. **Edges are not yet signed.** |
+| `sink::LineageSink` | Trait for persistence. `InMemorySink` (tests) + `JsonlSink` (file-backed, `O_APPEND` mode — not tamper-evident, see below) ship in this crate. |
+| `issuer::IdentityFetcher` | Trait for JWT-SVID minting. `LocalIssuer` (Ed25519, in-process, demo-only) ships here. **No SPIRE-backed impl exists in this repo yet.** |
 
 ## Honest constraints
 
-`LocalIssuer` is **demo-only**. It signs with an ephemeral in-process Ed25519 key and is not what you should use in production. For real deployments you want a SPIRE Agent (or any SPIFFE-conformant issuer) backing the `IdentityFetcher` trait — see `nucleus-identity`'s `spire` feature for the production path.
+The list below is what's missing today. Most items are tracked for follow-up PRs; this README will be updated as each lands.
 
-The Anthropic side of the lineage is **unidirectional**. When a JWT-SVID is presented to the Anthropic API, the `sub` claim appears in their audit log — but the response payload doesn't carry a SPIFFE ID we can attach to derived data. Lineage from prompt → response is established on the nucleus side from the timing + content hashes; it is not echoed back by the relying party. This is an inherent property of the WIF protocol, not a defect of this implementation.
-
-The default `LineageSink` is process-local. Cross-process / cross-host lineage requires a remote sink — straightforward extension via the trait, not yet implemented in this crate.
+- **`LocalIssuer` is demo-only.** It signs with an ephemeral in-process Ed25519 key, has no JWKS publication, no key rotation, no persistence. It is exported publicly and currently has no programmatic guard against being wired into production code. Do not use it as a production `IdentityFetcher`. (Tracked: feature-gate behind a `dev` cargo feature.)
+- **No SPIRE-backed `IdentityFetcher`.** `nucleus-identity`'s existing `spire` feature handles X.509 SVIDs only; the JWT-SVID API surface is not yet wired in. The trait is the integration point; the impl has to be written.
+- **Edges are not signed.** `LineageEdge` carries the child/parents/kind/content_hash/ts/attrs but no `Proof { kid, alg, sig }` field. Anyone with write access to the JSONL log can fabricate parent relationships — including claiming a victim pod's SPIFFE ID as the parent of an attacker artifact. The walker (`nucleus lineage`) trusts edge-claimed parents; it does not perform structural reconciliation against `CallSpiffeId::parent()`. (Tracked: add `Proof` field; sign edges; walker verifies.)
+- **`JsonlSink` is `O_APPEND`-mode, not tamper-evident.** No hash chain (`prev_hash`), no signatures, no truncation detection. The file is process-local; concurrent multi-process writes can interleave bytes. The existing `nucleus-audit` crate has the receipt-chain pattern this crate should adopt.
+- **`--real-claude` mode does not exercise SPIFFE WIF.** It uses the long-lived `ANTHROPIC_API_KEY` for wire auth and only *records* the SPIFFE ID locally. The recorded edge attributes (`audience=https://api.anthropic.com`, `jwt_jti=...`) imply that a JWT-SVID was on the wire; the JWT was not. (Tracked: rename the recorded attrs to `wire_auth=api_key, recorded_subject=...`.)
+- **`CallSpiffeId::parse` accepts malformed inputs.** Currently passes: NUL bytes, RTL Unicode overrides, double slashes, uppercase `/CALL/`, query/fragment/userinfo, and several other forms forbidden by the SPIFFE ID spec. Negative tests are not yet present. (Tracked: parser hardening + negative test suite.)
+- **Anthropic-side echo-back is unidirectional and inherent.** When a JWT-SVID is presented to the Anthropic API, the `sub` claim appears in their audit log — but the response payload does not carry a SPIFFE ID we can attach to derived data. This is a property of WIF, not a fix-it-here issue.
+- **Process-local sink only.** Cross-process / cross-host lineage requires a remote sink — straightforward extension via the trait, not yet written.
 
 **This crate binds *who called*, not *what data was in the call*.** Prompt-body taint still requires the existing portcullis IFC machinery. SPIFFE lineage and IFC labels compose; they do not replace each other.
 
-## Categorical framing (for the curious)
+## Categorical framing (roadmap, not load-bearing)
 
-Per-call SPIFFE IDs lift the workload category to a bicategory where morphisms (calls) carry identities. Each child SVID's parent reference is a restriction map; the cocycle condition (gluing of sections across overlap) becomes verifiable from JWT signatures. This is the structure that makes end-to-end IFC sheaves measurable rather than only inferable. See `project_per_call_spiffe_lineage.md` in the project memory for the longer argument.
+Per-call SPIFFE IDs *will* lift the workload category to a bicategory where morphisms (calls) carry identities — once edges are signed and the walker actually verifies the cocycle condition (signed restriction maps, gluing across overlap). Today the structure exists in the path scheme but is not enforced computationally. The connection to the `alignment_tax = rank(H¹(IFC_sheaf))` line of work in `portcullis-core/lean/` is suggestive, not formal: those Lean theorems are about IFC posets, not about per-call SPIFFE provenance graphs. Treat this section as design intent until the `verify_glue` function lands.
+
+See `project_per_call_spiffe_lineage.md` in the project memory for the longer argument.
 
 ## License
 

--- a/crates/nucleus-spec/src/lib.rs
+++ b/crates/nucleus-spec/src/lib.rs
@@ -480,9 +480,17 @@ impl CredentialsSpec {
 
 /// A single OIDC workload-identity binding.
 ///
-/// At pod start, the runtime fetches a JWT from `source` with the configured
-/// `audience`, writes it to `token_path` on a memory-backed tmpfs, and refreshes
-/// before expiry per `refresh`. The workload reads the file path via `env_var`.
+/// **Status: draft RFC, no runtime consumer in this repo today.** This type
+/// parses and serializes; nothing in `nucleus`, `nucleus-tool-proxy`,
+/// `nucleus-node`, or `nucleus-mcp` reads `credentials.workload_identity` yet.
+/// A `PodSpec` that sets this field will start the pod normally — but no token
+/// file appears, no env var is set, and no audit record is emitted. Wait for
+/// the runtime PR before depending on the documented behavior below.
+///
+/// **Intended (not yet implemented) behavior:** at pod start, the runtime
+/// fetches a JWT from `source` with the configured `audience`, writes it to
+/// `token_path` on a memory-backed tmpfs, and refreshes before expiry per
+/// `refresh`. The workload reads the file path via `env_var`.
 ///
 /// This type is provider-agnostic. The orchestrator (or operator) chooses the
 /// `audience` value for whichever relying party the workload calls.
@@ -491,7 +499,10 @@ pub struct WorkloadIdentitySpec {
     /// Logical name (e.g. "anthropic", "openai-prod"). Used in audit records.
     pub name: String,
 
-    /// OIDC audience to request. Provider-defined; nucleus does not validate.
+    /// OIDC audience to request. Provider-defined; **nucleus does not yet
+    /// validate** that this is a well-formed URL or coordinate against an
+    /// allow-list. A typo here will silently produce a JWT no relying party
+    /// accepts. Validation is tracked for the runtime PR.
     /// Examples: `https://api.anthropic.com`, `https://api.openai.com`.
     pub audience: String,
 
@@ -549,8 +560,11 @@ pub enum IdentitySource {
         /// Requested token lifetime in seconds.
         expiration_seconds: u64,
     },
-    /// Read a pre-provisioned static JWT from disk. For testing or for issuers
-    /// that do not support online refresh.
+    /// Read a pre-provisioned static JWT from disk. For **testing** or for
+    /// issuers that do not support online refresh. Production deployments
+    /// should not use this variant: the (planned) runtime will not validate
+    /// the JWT's signature or expiry before serving it, and there is no
+    /// path-canonicalization or symlink restriction.
     StaticFile { path: PathBuf },
 }
 


### PR DESCRIPTION
## Summary

A skeptical-code-auditor pass on the recently-landed SPIFFE/lineage code (#1602, #1605, #1608) found that the README/docs significantly oversold what's in the implementation. **No code changes** in this PR — it brings the prose back in line with the implementation.

## Audit findings addressed

| Finding | Fix |
|---|---|
| **CRIT-2:** "Production wiring lives in nucleus-identity's spire feature" — that wiring does NOT exist (spire feature handles X.509 SVIDs only) | Removed from both READMEs; replaced with "no SPIRE-backed `IdentityFetcher` impl exists in this repo yet" + tracking note |
| **CRIT-3:** WorkloadIdentitySpec has zero runtime consumers but docstring describes runtime behavior | Added "Status: draft RFC, no runtime consumer in this repo today" warning at the top of the docstring; warned that PodSpecs setting this field will silently no-op |
| **CRIT-4:** "Verifiable provenance" claim is undefensible (edges aren't signed, JWT not stored on edge) | Dropped "verifiable" from root README + crate README headlines; replaced with Today/Roadmap split |
| **DEMO-2:** Mock-LLM "verifies the JWT" using the issuer's own decoding key — self-loop, not federation | Demo transcript and crate README now explicitly call out "verified JWT (self-loop)" and explain it proves JWT well-formedness, not federation |
| **Adjacent:** Root README Quick Start — `cargo install --git ... nucleus-claude-hook` failed because the crate moved to a private repo | Replaced with `nucleus-cli` install + pointer to private nucleus-code repo for the hook |
| **ARCH-2:** Categorical/IFC sheaf framing is presented as load-bearing but isn't | Both READMEs now label it "roadmap, not load-bearing" with explicit note that the H¹ Lean theorems are about IFC posets, not SPIFFE provenance graphs |

Plus: tightened `WorkloadIdentitySpec.audience` and `IdentitySource::StaticFile` docs to flag missing validation that the (planned) runtime will need.

## Test plan

- [x] `cargo test -p nucleus-spec` — 32 passed (no test changes; doc-only)
- [x] Markdown renders cleanly
- [ ] CI

## Tracking the rest of the audit

This is the first of four planned PRs:

- **PR-B:** parser hardening + negative tests (CallSpiffeId::parse currently accepts NUL/RTL/double-slash/uppercase-CALL/query/fragment)
- **PR-C:** LocalIssuer behind a `dev` cargo feature + `Proof { kid, alg, sig }` field on `LineageEdge` + walker structural-parent verify
- **PR-D:** signed edges + JWKS publication + walker signature verify + demo honesty (`--real-claude` recorded attrs, mock-LLM cross-process JWKS fetch, drop `bash -c` interpolation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)