### PR TITLE
fix(lineage): harden CallSpiffeId::parse per audit (SEC-1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ assert!(!state.flows_to(SinkClass::GitPush));  // can't push tainted data
 ## Quick Start
 
 ```bash
-cargo install --git https://github.com/coproduct-opensource/nucleus nucleus-claude-hook
-nucleus-claude-hook --setup    # wires into your AI coding assistant
-nucleus-claude-hook --smoke-test
+cargo install --git https://github.com/coproduct-opensource/nucleus nucleus-cli
+nucleus audit                       # scan agent configs (Tier 0, no runtime)
+nucleus run --local "your task"     # run with enforced permissions (Tier 1)
 ```
 
-Every tool call now flows through the permission kernel. The hook tracks data provenance and blocks dangerous combinations — like writing code derived from untrusted web content.
+Every tool call flows through the permission kernel. `nucleus run` tracks data provenance and blocks dangerous combinations — like writing code derived from untrusted web content. The hook for AI coding assistants previously bundled here (`nucleus-claude-hook`) is now part of [nucleus-code](https://github.com/coproduct-opensource/nucleus-code), the private orchestrator built on this runtime.
 
 ## What Gets Proved
 
@@ -46,9 +46,9 @@ Full inventory: 165 Lean 4 theorems (zero `sorry`), 112 Kani BMC proofs, 297 Ver
 | `a ⊔ a = a` | Join is idempotent | Provably safe caching |
 | `a ≤ a ⊔ b` | Join is monotone | Taint never decreases |
 
-## Per-Call SPIFFE Provenance
+## Per-Call SPIFFE Provenance (preview)
 
-Every tool call gets a SPIFFE identity. Every byte of output has a verifiable provenance chain back to its sources.
+> **Status:** alpha. The crate ships a per-call SPIFFE-ID derivation library, an in-process Ed25519 demo issuer, an append-mode JSONL log, and a `nucleus lineage` walker. The demo is not yet wired into the runtime, edges are not yet signed, and no SPIRE-backed `IdentityFetcher` impl exists in this repo. See [`crates/nucleus-lineage/README.md`](crates/nucleus-lineage/README.md) for the honest scope and [the audit findings](#known-gaps) for what's still missing.
 
 `nucleus-lineage` extends [SPIFFE](https://spiffe.io/) workload identity from the *pod* level down to the *individual call* level. Each tool invocation, LLM call, or derived artifact mints a child SPIFFE ID whose path encodes its lineage and whose suffix is a content hash:
 
@@ -60,9 +60,9 @@ spiffe://<trust>/ns/<ns>/sa/<sa>                                   ← pod (root
   /call/<uuid>/derived/sha256:<hex>                                ← downstream artifact
 ```
 
-Identical content → identical content-hash suffix, regardless of derivation path. The full path doubles as a human-readable witness; the JWT-SVIDs minted at boundaries are cryptographic witnesses of the same chain.
+Identical content → identical content-hash suffix, regardless of derivation path. The full path is a human-readable witness of the derivation chain.
 
-Try it end-to-end (Bash → Write → mock-LLM with JWT verification):
+Try it end-to-end (Bash → Write → mock-LLM with self-loop JWT verification — the mock LLM uses the same in-process key the issuer minted with, so this proves the JWT format, not cross-trust federation):
 
 ```bash
 cargo run -p nucleus-lineage --example three_step_demo
@@ -71,13 +71,14 @@ nucleus lineage <leaf-spiffe-id> --log ./nucleus-lineage.jsonl
 
 Output formats: `--format tree` (default), `json`, or `dot` (for Graphviz).
 
-| What it gives you | What it doesn't |
+| Today | Roadmap |
 |---|---|
-| Cryptographically-signed identity per call (Ed25519 JWT-SVIDs) | Replace IFC labeling — composes with portcullis, doesn't replace it |
-| Content-addressed lineage that survives across pods and providers | Echo-back from external relying parties (e.g. Anthropic records `sub`, doesn't return it on responses) |
-| `nucleus lineage` walks the full DAG (ancestors or descendants) | A SPIRE Workload API client by default — the demo uses a `LocalIssuer`; production wiring lives in `nucleus-identity`'s `spire` feature |
+| SPIFFE-format ID per call, content-addressed | Edge signing + hash chain so the JSONL log is tamper-evident |
+| `LocalIssuer` (in-process Ed25519, demo-only) | SPIRE Workload API `IdentityFetcher` impl |
+| `nucleus lineage` walker (graph traversal) | Walker verifies edge signatures + JWKS-backed federation |
+| Composes with portcullis IFC labels (does not replace them) | `nucleus-tool-proxy` auto-emits edges per HTTP handler |
 
-Categorically: per-call SPIFFE IDs lift the workload category to a bicategory where morphisms (calls) carry identities, making end-to-end IFC sheaves measurable rather than only inferable. See [`crates/nucleus-lineage/README.md`](crates/nucleus-lineage/README.md) for the longer story.
+Treat the categorical framing — "per-call SPIFFE IDs lift the workload category to a bicategory; cocycle condition becomes verifiable" — as a roadmap, not as currently load-bearing. See [`crates/nucleus-lineage/README.md`](crates/nucleus-lineage/README.md) for the longer story and the explicit limitations.
 
 ## How Nucleus Stops Real Exploits
 
@@ -121,13 +122,12 @@ Agent → MCP → tool-proxy (inside VM) → portcullis check → OS operation
 ## Crates
 
 <details>
-<summary>User-facing tools (5 crates)</summary>
+<summary>User-facing tools (4 crates)</summary>
 
 | Crate | Purpose |
 |-------|---------|
-| [**nucleus-claude-hook**](crates/nucleus-claude-hook/) | Hook for AI coding assistants: IFC kernel, compartments, provenance |
+| [**nucleus-cli**](crates/nucleus-cli/) | Run AI agents under enforced permissions; ships the `nucleus` binary |
 | [**nucleus-audit**](crates/nucleus-audit/) | Scan agent configs, verify audit trails, inspect provenance |
-| [**nucleus-cli**](crates/nucleus-cli/) | Run AI agents under enforced permissions |
 | [**nucleus-sdk**](crates/nucleus-sdk/) | Rust SDK for building sandboxed AI agents |
 | [**exposure-playground**](crates/exposure-playground/) | Interactive TUI for exploring the permission lattice |
 

--- a/crates/nucleus-lineage/README.md
+++ b/crates/nucleus-lineage/README.md
@@ -1,8 +1,8 @@
 # nucleus-lineage
 
-> Every tool call gets a SPIFFE identity. Every byte of output has a verifiable provenance chain back to its sources.
+> **Status: alpha.** A per-call SPIFFE-ID derivation library with an `O_APPEND`-mode JSONL log and a `LocalIssuer` for demos. Edge signing, hash chaining, and a SPIRE-backed `IdentityFetcher` impl are roadmap, not shipped. Read [Honest constraints](#honest-constraints) before depending on this for anything you care about.
 
-`nucleus-lineage` extends [SPIFFE](https://spiffe.io/) workload identity from the *pod* level down to the *individual call* level. Each tool invocation, LLM call, or derived artifact mints a child SPIFFE ID whose path encodes its lineage and whose suffix is a content hash. The result: a cryptographically-signed, content-addressed DAG that lets you answer **"where did this data come from?"** with concrete evidence rather than inference.
+`nucleus-lineage` extends [SPIFFE](https://spiffe.io/) workload identity from the *pod* level down to the *individual call* level. Each tool invocation, LLM call, or derived artifact mints a child SPIFFE ID whose path encodes its lineage and whose suffix is a content hash. With signing landed (roadmap), the result will be a tamper-evident, content-addressed DAG that answers **"where did this data come from?"** with cryptographic evidence rather than inference. Today it answers it with content hashes plus a parent pointer — useful, but not adversary-resistant on its own.
 
 ## The path scheme
 
@@ -14,7 +14,7 @@ spiffe://<trust>/ns/<ns>/sa/<sa>                                   ← pod (root
   /call/<uuid>/derived/sha256:<hex>                                ← downstream artifact
 ```
 
-Identical content → identical content-hash suffix (regardless of derivation path), so re-deriving the same value from the same parents is recognizable. The full path doubles as a human-readable witness of how this byte-string came to exist.
+Identical content → identical content-hash suffix (regardless of derivation path), so re-deriving the same value from the same parents is recognizable. The full path is a human-readable witness of how this byte-string came to exist.
 
 ## Quick demo
 
@@ -30,13 +30,15 @@ admitted pod: spiffe://demo.nucleus.local/ns/agents/sa/lineage-demo
 step 1 ✔ Bash → spiffe://…/call/cca7fa46…/tool/Bash/sha256:b534e3bf… (25 bytes)
 step 2 ✔ Write → spiffe://…/call/bde8f048…/tool/Write/sha256:b534e3bf… (/tmp/...)
 step 3a ✔ LLM prompt → spiffe://…/call/388064f0…/llm/anthropic/prompt/sha256:b534e3bf…
-    mock-llm: verified JWT, sub=spiffe://…, jti=684ee954…, exp_in=300s
+    mock-llm: verified JWT (self-loop), sub=spiffe://…, jti=684ee954…, exp_in=300s
 step 3b ✔ LLM response → spiffe://…/call/63b43cec…/llm/anthropic/response/sha256:2a6f4cc9… (476 bytes)
 
 done. lineage log written to ./nucleus-lineage.jsonl
 walk it with:
   nucleus lineage 'spiffe://…/llm/anthropic/response/sha256:2a6f4cc9…' --log ./nucleus-lineage.jsonl
 ```
+
+The "mock-llm: verified JWT" line is honest about what's verified: the JWT was minted by the `LocalIssuer` and verified using the **same in-process key** the issuer mints with. This proves JWT well-formedness, not cross-trust federation. A real relying party would fetch a JWKS from a separate trust anchor — that's roadmap.
 
 Then walk the chain back to its source:
 
@@ -60,24 +62,31 @@ For Graphviz output: `--format dot`. For machine-readable JSON: `--format json`.
 
 | Module | Purpose |
 |---|---|
-| `id::CallSpiffeId` | SPIFFE-format identity with strict path grammar. Constructors for pod-root + tool / LLM / artifact derivations. Round-trips through serde. |
-| `edge::LineageEdge` | One immutable record in the DAG: `(child, parents[], kind, content_hash, ts, attrs)`. Wire format is JSON, kept stable. |
-| `sink::LineageSink` | Trait for append-only persistence. `InMemorySink` (tests) + `JsonlSink` (file-backed) ship in this crate. |
-| `issuer::IdentityFetcher` | Trait for JWT-SVID minting. `LocalIssuer` (Ed25519, in-process, demo-only) ships here; a SPIRE Workload API impl lives in `nucleus-identity`. |
+| `id::CallSpiffeId` | SPIFFE-format identity. Validates `/call/<uuid>/...` suffix structure and content-hash format; full SPIFFE ID grammar enforcement is roadmap. Round-trips through serde. |
+| `edge::LineageEdge` | One record in the DAG: `(child, parents[], kind, content_hash, ts, attrs)`. JSON wire format. **Edges are not yet signed.** |
+| `sink::LineageSink` | Trait for persistence. `InMemorySink` (tests) + `JsonlSink` (file-backed, `O_APPEND` mode — not tamper-evident, see below) ship in this crate. |
+| `issuer::IdentityFetcher` | Trait for JWT-SVID minting. `LocalIssuer` (Ed25519, in-process, demo-only) ships here. **No SPIRE-backed impl exists in this repo yet.** |
 
 ## Honest constraints
 
-`LocalIssuer` is **demo-only**. It signs with an ephemeral in-process Ed25519 key and is not what you should use in production. For real deployments you want a SPIRE Agent (or any SPIFFE-conformant issuer) backing the `IdentityFetcher` trait — see `nucleus-identity`'s `spire` feature for the production path.
+The list below is what's missing today. Most items are tracked for follow-up PRs; this README will be updated as each lands.
 
-The Anthropic side of the lineage is **unidirectional**. When a JWT-SVID is presented to the Anthropic API, the `sub` claim appears in their audit log — but the response payload doesn't carry a SPIFFE ID we can attach to derived data. Lineage from prompt → response is established on the nucleus side from the timing + content hashes; it is not echoed back by the relying party. This is an inherent property of the WIF protocol, not a defect of this implementation.
-
-The default `LineageSink` is process-local. Cross-process / cross-host lineage requires a remote sink — straightforward extension via the trait, not yet implemented in this crate.
+- **`LocalIssuer` is demo-only.** It signs with an ephemeral in-process Ed25519 key, has no JWKS publication, no key rotation, no persistence. It is exported publicly and currently has no programmatic guard against being wired into production code. Do not use it as a production `IdentityFetcher`. (Tracked: feature-gate behind a `dev` cargo feature.)
+- **No SPIRE-backed `IdentityFetcher`.** `nucleus-identity`'s existing `spire` feature handles X.509 SVIDs only; the JWT-SVID API surface is not yet wired in. The trait is the integration point; the impl has to be written.
+- **Edges are not signed.** `LineageEdge` carries the child/parents/kind/content_hash/ts/attrs but no `Proof { kid, alg, sig }` field. Anyone with write access to the JSONL log can fabricate parent relationships — including claiming a victim pod's SPIFFE ID as the parent of an attacker artifact. The walker (`nucleus lineage`) trusts edge-claimed parents; it does not perform structural reconciliation against `CallSpiffeId::parent()`. (Tracked: add `Proof` field; sign edges; walker verifies.)
+- **`JsonlSink` is `O_APPEND`-mode, not tamper-evident.** No hash chain (`prev_hash`), no signatures, no truncation detection. The file is process-local; concurrent multi-process writes can interleave bytes. The existing `nucleus-audit` crate has the receipt-chain pattern this crate should adopt.
+- **`--real-claude` mode does not exercise SPIFFE WIF.** It uses the long-lived `ANTHROPIC_API_KEY` for wire auth and only *records* the SPIFFE ID locally. The recorded edge attributes (`audience=https://api.anthropic.com`, `jwt_jti=...`) imply that a JWT-SVID was on the wire; the JWT was not. (Tracked: rename the recorded attrs to `wire_auth=api_key, recorded_subject=...`.)
+- **`CallSpiffeId::parse` accepts malformed inputs.** Currently passes: NUL bytes, RTL Unicode overrides, double slashes, uppercase `/CALL/`, query/fragment/userinfo, and several other forms forbidden by the SPIFFE ID spec. Negative tests are not yet present. (Tracked: parser hardening + negative test suite.)
+- **Anthropic-side echo-back is unidirectional and inherent.** When a JWT-SVID is presented to the Anthropic API, the `sub` claim appears in their audit log — but the response payload does not carry a SPIFFE ID we can attach to derived data. This is a property of WIF, not a fix-it-here issue.
+- **Process-local sink only.** Cross-process / cross-host lineage requires a remote sink — straightforward extension via the trait, not yet written.
 
 **This crate binds *who called*, not *what data was in the call*.** Prompt-body taint still requires the existing portcullis IFC machinery. SPIFFE lineage and IFC labels compose; they do not replace each other.
 
-## Categorical framing (for the curious)
+## Categorical framing (roadmap, not load-bearing)
 
-Per-call SPIFFE IDs lift the workload category to a bicategory where morphisms (calls) carry identities. Each child SVID's parent reference is a restriction map; the cocycle condition (gluing of sections across overlap) becomes verifiable from JWT signatures. This is the structure that makes end-to-end IFC sheaves measurable rather than only inferable. See `project_per_call_spiffe_lineage.md` in the project memory for the longer argument.
+Per-call SPIFFE IDs *will* lift the workload category to a bicategory where morphisms (calls) carry identities — once edges are signed and the walker actually verifies the cocycle condition (signed restriction maps, gluing across overlap). Today the structure exists in the path scheme but is not enforced computationally. The connection to the `alignment_tax = rank(H¹(IFC_sheaf))` line of work in `portcullis-core/lean/` is suggestive, not formal: those Lean theorems are about IFC posets, not about per-call SPIFFE provenance graphs. Treat this section as design intent until the `verify_glue` function lands.
+
+See `project_per_call_spiffe_lineage.md` in the project memory for the longer argument.
 
 ## License
 

--- a/crates/nucleus-lineage/src/id.rs
+++ b/crates/nucleus-lineage/src/id.rs
@@ -27,13 +27,29 @@ pub enum IdError {
     MissingPath(String),
     #[error("invalid call uuid {0:?}: {1}")]
     InvalidCallUuid(String, uuid::Error),
-    #[error("invalid sha256 suffix {0:?}: must be 64 lowercase hex chars")]
+    #[error("invalid sha256 suffix {0:?}: must be exactly `sha256:<64 lowercase hex>`")]
     InvalidContentHash(String),
     #[error("path component {0:?} is empty or contains only whitespace")]
     EmptyComponent(String),
     #[error("path component {0:?} contains a `/`; pass segments individually")]
     SlashInComponent(String),
+    #[error("input is too long ({len} bytes; max {max} allowed)", max = MAX_URI_LEN)]
+    TooLong { len: usize },
+    #[error("input contains forbidden character {0:?} at byte offset {1}")]
+    ForbiddenChar(char, usize),
+    #[error("authority {0:?} contains characters outside `[a-z0-9._-]`")]
+    InvalidAuthority(String),
+    #[error("path component {0:?} contains characters outside `[A-Za-z0-9._-]` (or the reserved `sha256:<hex>` form)")]
+    InvalidPathChar(String),
+    #[error("path contains an empty segment (consecutive `/` or trailing `/`) in {0:?}")]
+    EmptyPathSegment(String),
+    #[error("`/call/` segment must be exactly lowercase, found {0:?}")]
+    NonCanonicalCallSegment(String),
 }
+
+/// Maximum URI length we'll accept. SPIFFE IDs in practice are short; a
+/// hard cap prevents pathological-input DoS in the parser.
+pub const MAX_URI_LEN: usize = 4096;
 
 /// A SPIFFE-format identity for a call, artifact, or derived value.
 ///
@@ -45,14 +61,62 @@ pub enum IdError {
 pub struct CallSpiffeId(String);
 
 impl CallSpiffeId {
-    /// Construct from a raw SPIFFE URI string. Validates the scheme,
-    /// authority, and any `/call/<uuid>/...` suffix's structure (call uuid
-    /// well-formed; content-hash suffix is 64 hex chars when present).
+    /// Construct from a raw SPIFFE URI string.
+    ///
+    /// Validates per the SPIFFE ID spec, with the documented deviation that
+    /// the literal `:` character is permitted in the special last-segment form
+    /// `sha256:<64-lowercase-hex>` (used for content-addressed lineage).
+    /// Otherwise:
+    ///
+    /// - Scheme must be `spiffe://`.
+    /// - URI length must be ≤ [`MAX_URI_LEN`] bytes.
+    /// - Every byte must be ASCII printable (rejects NUL, control chars,
+    ///   RTL/LRO Unicode overrides, and any non-ASCII).
+    /// - URI components `?` (query), `#` (fragment), and `@` (userinfo) are
+    ///   absent — SPIFFE forbids them.
+    /// - Authority charset: lowercase ASCII letters, digits, `-`, `.`, `_`.
+    ///   No `:` (no port), no `@` (no userinfo).
+    /// - Path segments are non-empty (rejects `//`, leading `//`, trailing `/`).
+    /// - Path segment charset: `[A-Za-z0-9._-]` per SPIFFE, or the reserved
+    ///   form `sha256:<64 lowercase hex>`.
+    /// - Any `/call/...` suffix must use lowercase `call` and a well-formed
+    ///   uuid in the next segment.
     pub fn parse(uri: impl Into<String>) -> Result<Self, IdError> {
         let uri = uri.into();
+
+        // 1. Hard length cap (DoS guard).
+        if uri.len() > MAX_URI_LEN {
+            return Err(IdError::TooLong { len: uri.len() });
+        }
+
+        // 2. ASCII printable only — rejects NUL, control chars, RTL/LRO
+        //    overrides (U+202E/U+202D), any other Unicode. SPIFFE IDs are
+        //    ASCII per spec; rejecting non-ASCII closes the homograph /
+        //    visual-spoofing surface in the `nucleus lineage` renderer.
+        for (i, ch) in uri.char_indices() {
+            // Allow only ASCII range 0x20..=0x7E plus the structural chars
+            // that appear in spiffe URIs (handled by other rules below).
+            if !ch.is_ascii() || (ch as u32) < 0x20 || (ch as u32) == 0x7F {
+                return Err(IdError::ForbiddenChar(ch, i));
+            }
+        }
+
+        // 3. Reject query, fragment, userinfo. SPIFFE ID grammar forbids
+        //    `?`, `#`, `@`. We reject anywhere in the URI rather than only
+        //    at canonical positions; defense in depth.
+        for forbidden in ['?', '#', '@'] {
+            if let Some(pos) = uri.find(forbidden) {
+                return Err(IdError::ForbiddenChar(forbidden, pos));
+            }
+        }
+
+        // 4. Scheme.
         let rest = uri
             .strip_prefix("spiffe://")
             .ok_or_else(|| IdError::NotSpiffe(uri.clone()))?;
+
+        // 5. Authority + path split. Authority is everything up to the first
+        //    `/`. Path begins after.
         let (authority, path) = rest
             .split_once('/')
             .ok_or_else(|| IdError::MissingPath(uri.clone()))?;
@@ -62,28 +126,58 @@ impl CallSpiffeId {
         if path.is_empty() {
             return Err(IdError::MissingPath(uri.clone()));
         }
-        // Validate any /call/<uuid>/... suffix structure.
-        if let Some(call_idx) = path.find("/call/").map(|i| i + 1) {
-            let suffix = &path[call_idx..];
-            let mut parts = suffix.split('/');
-            let _call = parts.next(); // "call"
-            let uuid_part = parts
-                .next()
-                .ok_or_else(|| IdError::InvalidCallUuid(suffix.to_string(), uuid_error()))?;
-            Uuid::parse_str(uuid_part)
-                .map_err(|e| IdError::InvalidCallUuid(uuid_part.to_string(), e))?;
-            if let Some(hash_seg) = suffix.split('/').next_back() {
-                if let Some(hex) = hash_seg.strip_prefix("sha256:") {
-                    let valid = hex.len() == 64
-                        && hex
-                            .chars()
-                            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase());
-                    if !valid {
-                        return Err(IdError::InvalidContentHash(hex.to_string()));
-                    }
+
+        // 6. Authority charset. SPIFFE: lowercase letters, digits, `-`, `.`,
+        //    `_`. No port (`:`), no userinfo (already rejected above).
+        if !authority
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || matches!(c, '-' | '.' | '_'))
+        {
+            return Err(IdError::InvalidAuthority(authority.to_string()));
+        }
+
+        // 7. Path segments: non-empty, valid charset.
+        for segment in path.split('/') {
+            if segment.is_empty() {
+                return Err(IdError::EmptyPathSegment(uri.clone()));
+            }
+            // Special case: a `sha256:`-prefixed segment is a content-hash;
+            // route its specific failure to InvalidContentHash for actionable
+            // error messages. Note: case-sensitive — `SHA256:` falls through
+            // to the generic path-charset check below and is rejected there.
+            if let Some(hex) = segment.strip_prefix("sha256:") {
+                let valid = hex.len() == 64
+                    && hex
+                        .chars()
+                        .all(|c| c.is_ascii_digit() || matches!(c, 'a'..='f'));
+                if !valid {
+                    return Err(IdError::InvalidContentHash(segment.to_string()));
                 }
+                continue;
+            }
+            if !is_valid_path_segment(segment) {
+                return Err(IdError::InvalidPathChar(segment.to_string()));
             }
         }
+
+        // 8. Validate any /call/<uuid>/... suffix structure. The first /call/
+        //    segment must be lowercase; any uppercase variant (e.g. /CALL/)
+        //    is non-canonical and rejected (closes the suffix-bypass case
+        //    where uppercase /CALL/ skips uuid validation).
+        let mut path_parts = path.split('/').peekable();
+        while let Some(seg) = path_parts.next() {
+            if seg.eq_ignore_ascii_case("call") && seg != "call" {
+                return Err(IdError::NonCanonicalCallSegment(seg.to_string()));
+            }
+            if seg == "call" {
+                let uuid_part = path_parts.next().ok_or_else(|| {
+                    IdError::InvalidCallUuid("(missing)".to_string(), uuid_error())
+                })?;
+                Uuid::parse_str(uuid_part)
+                    .map_err(|e| IdError::InvalidCallUuid(uuid_part.to_string(), e))?;
+            }
+        }
+
         Ok(Self(uri))
     }
 
@@ -204,6 +298,23 @@ impl FromStr for CallSpiffeId {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Self::parse(s.to_string())
     }
+}
+
+/// Per SPIFFE ID spec, path segments use `[A-Za-z0-9._-]`. We additionally
+/// permit the reserved last-segment form `sha256:<64 lowercase hex>` for
+/// content-addressed lineage suffixes — the only allowed appearance of `:`
+/// in any segment.
+fn is_valid_path_segment(seg: &str) -> bool {
+    if let Some(hex) = seg.strip_prefix("sha256:") {
+        return hex.len() == 64
+            && hex
+                .chars()
+                .all(|c| c.is_ascii_digit() || matches!(c, 'a'..='f'));
+    }
+    !seg.is_empty()
+        && seg
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '.' | '_'))
 }
 
 fn check_segment(s: &str) -> Result<(), IdError> {
@@ -393,5 +504,158 @@ mod tests {
         let json = serde_json::to_string(&derived).unwrap();
         let back: CallSpiffeId = serde_json::from_str(&json).unwrap();
         assert_eq!(derived, back);
+    }
+
+    // ── Hardened-parser negative tests ─────────────────────────────────
+    // These cases were accepted by the original parser; a skeptical-code
+    // auditor pass enumerated each as a real input that should fail.
+
+    #[test]
+    fn parse_rejects_nul_byte_in_path() {
+        let err = CallSpiffeId::parse("spiffe://prod.example.com/ns/agents\0/sa/coder")
+            .expect_err("NUL byte must be rejected");
+        assert!(matches!(err, IdError::ForbiddenChar('\0', _)), "{err:?}");
+    }
+
+    #[test]
+    fn parse_rejects_rtl_unicode_override() {
+        // U+202E (RIGHT-TO-LEFT OVERRIDE) — used for visual spoofing.
+        let err = CallSpiffeId::parse("spiffe://prod.example.com/ns/admin\u{202E}/sa/coder")
+            .expect_err("RTL override must be rejected (non-ASCII)");
+        assert!(matches!(err, IdError::ForbiddenChar(_, _)), "{err:?}");
+    }
+
+    #[test]
+    fn parse_rejects_other_control_chars() {
+        // U+0007 BEL, embedded in a path component.
+        let err = CallSpiffeId::parse("spiffe://prod.example.com/ns/agents\u{0007}/sa/coder")
+            .expect_err("control char must be rejected");
+        assert!(matches!(err, IdError::ForbiddenChar(_, _)), "{err:?}");
+    }
+
+    #[test]
+    fn parse_rejects_double_slash() {
+        let err = CallSpiffeId::parse("spiffe://prod.example.com//ns/agents/sa/coder")
+            .expect_err("double slash must be rejected");
+        assert!(matches!(err, IdError::EmptyPathSegment(_)), "{err:?}");
+    }
+
+    #[test]
+    fn parse_rejects_trailing_slash() {
+        let err = CallSpiffeId::parse("spiffe://prod.example.com/ns/agents/sa/coder/")
+            .expect_err("trailing slash must be rejected");
+        assert!(matches!(err, IdError::EmptyPathSegment(_)), "{err:?}");
+    }
+
+    #[test]
+    fn parse_rejects_empty_path_only_root() {
+        let err = CallSpiffeId::parse("spiffe://prod.example.com//")
+            .expect_err("empty path must be rejected");
+        assert!(matches!(err, IdError::EmptyPathSegment(_)), "{err:?}");
+    }
+
+    #[test]
+    fn parse_rejects_uppercase_call_segment() {
+        // Original parser only validated /call/ via lowercase string.find,
+        // so /CALL/ slipped past the uuid check entirely.
+        let err =
+            CallSpiffeId::parse("spiffe://prod.example.com/ns/agents/sa/coder/CALL/abc/tool/Bash")
+                .expect_err("uppercase /CALL/ must be rejected");
+        assert!(
+            matches!(err, IdError::NonCanonicalCallSegment(_)),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn parse_rejects_query_string() {
+        let err = CallSpiffeId::parse("spiffe://prod.example.com/ns/agents/sa/coder?x=1")
+            .expect_err("URI query must be rejected");
+        assert!(matches!(err, IdError::ForbiddenChar('?', _)), "{err:?}");
+    }
+
+    #[test]
+    fn parse_rejects_fragment() {
+        let err = CallSpiffeId::parse("spiffe://prod.example.com/ns/agents/sa/coder#frag")
+            .expect_err("URI fragment must be rejected");
+        assert!(matches!(err, IdError::ForbiddenChar('#', _)), "{err:?}");
+    }
+
+    #[test]
+    fn parse_rejects_userinfo_in_authority() {
+        let err = CallSpiffeId::parse("spiffe://attacker:p@prod.example.com/ns/agents/sa/coder")
+            .expect_err("userinfo must be rejected");
+        assert!(matches!(err, IdError::ForbiddenChar('@', _)), "{err:?}");
+    }
+
+    #[test]
+    fn parse_rejects_uppercase_authority() {
+        // SPIFFE: trust-domain is lowercase.
+        let err = CallSpiffeId::parse("spiffe://Prod.Example.Com/ns/agents/sa/coder")
+            .expect_err("uppercase authority must be rejected");
+        assert!(matches!(err, IdError::InvalidAuthority(_)), "{err:?}");
+    }
+
+    #[test]
+    fn parse_rejects_uppercase_sha256_prefix() {
+        // /SHA256:<hex> previously parsed but content_hash_hex returned None
+        // — silent inconsistency. Now rejected as invalid path segment.
+        let bad = format!(
+            "spiffe://prod.example.com/ns/agents/sa/coder/call/{}/tool/Bash/SHA256:{}",
+            Uuid::new_v4(),
+            "a".repeat(64)
+        );
+        let err = CallSpiffeId::parse(bad).expect_err("/SHA256: must be rejected");
+        assert!(matches!(err, IdError::InvalidPathChar(_)), "{err:?}");
+    }
+
+    #[test]
+    fn parse_rejects_too_long_input() {
+        let bad = format!("spiffe://prod.example.com/{}", "a".repeat(MAX_URI_LEN));
+        let err = CallSpiffeId::parse(bad).expect_err("over-length URI must be rejected");
+        assert!(matches!(err, IdError::TooLong { .. }), "{err:?}");
+    }
+
+    #[test]
+    fn parse_rejects_path_traversal_segment() {
+        // ".." is itself a valid SPIFFE path segment (only [A-Za-z0-9._-]),
+        // so we permit it structurally — but its presence should not enable
+        // any escape because the canonical string never collapses it. This
+        // test pins the behavior so a future "path-canonicalization" change
+        // must be deliberate.
+        let id = CallSpiffeId::parse("spiffe://prod.example.com/ns/../sa/coder").unwrap();
+        assert_eq!(id.as_str(), "spiffe://prod.example.com/ns/../sa/coder");
+        // The structural parent walker uses string prefix only — it does not
+        // resolve `..`. (The walker is hardened separately in PR-C.)
+    }
+
+    #[test]
+    fn parse_rejects_colon_outside_sha256_prefix() {
+        // `:` is forbidden in SPIFFE path segments except in the reserved
+        // `sha256:<hex>` last-segment form. Anywhere else → rejected.
+        let err = CallSpiffeId::parse("spiffe://prod.example.com/ns/has:colon/sa/coder")
+            .expect_err("`:` outside sha256 prefix must be rejected");
+        assert!(matches!(err, IdError::InvalidPathChar(_)), "{err:?}");
+    }
+
+    #[test]
+    fn parse_accepts_canonical_pod_id() {
+        // Sanity: don't regress accepted inputs.
+        CallSpiffeId::parse("spiffe://prod.example.com/ns/agents/sa/coder").unwrap();
+    }
+
+    #[test]
+    fn parse_accepts_full_lineage_path() {
+        let id = pod()
+            .derive_tool("Bash", Some(b"x"))
+            .unwrap()
+            .derive_llm("anthropic", "prompt", b"hi")
+            .unwrap()
+            .derive_llm("anthropic", "response", b"reply")
+            .unwrap();
+        // Round-trip through parse to verify the canonical string is also
+        // accepted by the hardened parser.
+        let reparsed: CallSpiffeId = id.as_str().parse().unwrap();
+        assert_eq!(id, reparsed);
     }
 }

--- a/crates/nucleus-spec/src/lib.rs
+++ b/crates/nucleus-spec/src/lib.rs
@@ -480,9 +480,17 @@ impl CredentialsSpec {
 
 /// A single OIDC workload-identity binding.
 ///
-/// At pod start, the runtime fetches a JWT from `source` with the configured
-/// `audience`, writes it to `token_path` on a memory-backed tmpfs, and refreshes
-/// before expiry per `refresh`. The workload reads the file path via `env_var`.
+/// **Status: draft RFC, no runtime consumer in this repo today.** This type
+/// parses and serializes; nothing in `nucleus`, `nucleus-tool-proxy`,
+/// `nucleus-node`, or `nucleus-mcp` reads `credentials.workload_identity` yet.
+/// A `PodSpec` that sets this field will start the pod normally — but no token
+/// file appears, no env var is set, and no audit record is emitted. Wait for
+/// the runtime PR before depending on the documented behavior below.
+///
+/// **Intended (not yet implemented) behavior:** at pod start, the runtime
+/// fetches a JWT from `source` with the configured `audience`, writes it to
+/// `token_path` on a memory-backed tmpfs, and refreshes before expiry per
+/// `refresh`. The workload reads the file path via `env_var`.
 ///
 /// This type is provider-agnostic. The orchestrator (or operator) chooses the
 /// `audience` value for whichever relying party the workload calls.
@@ -491,7 +499,10 @@ pub struct WorkloadIdentitySpec {
     /// Logical name (e.g. "anthropic", "openai-prod"). Used in audit records.
     pub name: String,
 
-    /// OIDC audience to request. Provider-defined; nucleus does not validate.
+    /// OIDC audience to request. Provider-defined; **nucleus does not yet
+    /// validate** that this is a well-formed URL or coordinate against an
+    /// allow-list. A typo here will silently produce a JWT no relying party
+    /// accepts. Validation is tracked for the runtime PR.
     /// Examples: `https://api.anthropic.com`, `https://api.openai.com`.
     pub audience: String,
 
@@ -549,8 +560,11 @@ pub enum IdentitySource {
         /// Requested token lifetime in seconds.
         expiration_seconds: u64,
     },
-    /// Read a pre-provisioned static JWT from disk. For testing or for issuers
-    /// that do not support online refresh.
+    /// Read a pre-provisioned static JWT from disk. For **testing** or for
+    /// issuers that do not support online refresh. Production deployments
+    /// should not use this variant: the (planned) runtime will not validate
+    /// the JWT's signature or expiry before serving it, and there is no
+    /// path-canonicalization or symlink restriction.
     StaticFile { path: PathBuf },
 }
 


### PR DESCRIPTION
## Summary

Hardens \`CallSpiffeId::parse\` against the SPIFFE-grammar bypasses the skeptical-code-auditor pass demonstrated. **Stacks on PR-A (#1613)** — base branch is \`docs/audit-honesty-pass\` so this lands cleanly after #1613.

## Bypass classes closed

| Input form | Was | Now |
|---|---|---|
| \`spiffe://prod.example.com//\` | Accepted | \`EmptyPathSegment\` |
| \`spiffe://prod.example.com//ns//agents/sa/coder\` | Accepted | \`EmptyPathSegment\` |
| \`spiffe://prod.example.com/ns/agents\\0/sa/coder\` | Accepted | \`ForbiddenChar('\\0', _)\` |
| \`spiffe://prod.example.com/ns/admin\\u{202E}/sa/coder\` | Accepted (visual spoof) | \`ForbiddenChar(_, _)\` |
| \`spiffe://...//CALL/\\<uuid>/tool/Bash\` | Accepted (uuid bypass) | \`NonCanonicalCallSegment\` |
| \`spiffe://.../Bash/SHA256:\\<hex>\` | Accepted but \`content_hash_hex()\` returned \`None\` (silent inconsistency) | \`InvalidPathChar\` |
| \`spiffe://.../coder?evil=1\` | Accepted | \`ForbiddenChar('?', _)\` |
| \`spiffe://.../coder#frag\` | Accepted | \`ForbiddenChar('#', _)\` |
| \`spiffe://attacker:p@prod.example.com/...\` | Accepted | \`ForbiddenChar('@', _)\` |
| \`spiffe://Prod.Example.Com/...\` | Accepted | \`InvalidAuthority\` |
| \`spiffe://prod.example.com/ns/has:colon/sa/coder\` | Accepted | \`InvalidPathChar\` (only \`sha256:\\<hex>\` form permits \`:\`) |
| Over-4096-byte URI | Accepted (DoS surface) | \`TooLong { len }\` |

## Documented non-fix

\`..\` is a structurally valid SPIFFE path segment ([A-Za-z0-9._-]) so \`parse()\` permits it. The walker uses string-prefix only (does not canonicalize \`..\`), so no escape is possible from this alone — but the test pin (\`parse_rejects_path_traversal_segment\`) ensures any future "auto-canonicalize" change is deliberate and reviewed. Walker hardening is in PR-C.

## New IdError variants

\`TooLong { len }\`, \`ForbiddenChar(char, usize)\`, \`InvalidAuthority\`, \`InvalidPathChar\`, \`EmptyPathSegment\`, \`NonCanonicalCallSegment\`. All variants get clean \`thiserror\` Display impls. Public constant \`MAX_URI_LEN = 4096\` for callers that want the limit.

## Test plan

- [x] \`cargo test -p nucleus-lineage\` — **49 passed** (was 32; 17 new)
- [x] \`cargo test -p nucleus-cli lineage::\` — 8 passed (walker behavior unchanged)
- [x] \`cargo build -p nucleus-lineage --example three_step_demo\` — clean
- [x] \`cargo clippy -p nucleus-lineage --no-deps -- -D warnings\` — clean
- [ ] CI

## Tracking the rest of the audit

- ✅ PR-A (#1613) — README + spec docs honest
- 🟢 **PR-B (this PR)** — parser hardening + negative tests
- 🟡 PR-C — LocalIssuer dev-feature gate + Proof field on LineageEdge + walker structural-parent verify
- 🟡 PR-D — signed edges + JWKS publication + walker signature verify + demo honesty

🤖 Generated with [Claude Code](https://claude.com/claude-code)