### PR TITLE
fix(lineage): gate LocalIssuer behind `dev` + Proof field on edges + walker structural verify (audit CRIT-5/6)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4904,6 +4904,7 @@ dependencies = [
  "sha2 0.11.0",
  "tempfile",
  "thiserror 2.0.18",
+ "tracing",
  "ureq",
  "uuid",
 ]

--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ assert!(!state.flows_to(SinkClass::GitPush));  // can't push tainted data
 ## Quick Start
 
 ```bash
-cargo install --git https://github.com/coproduct-opensource/nucleus nucleus-claude-hook
-nucleus-claude-hook --setup    # wires into your AI coding assistant
-nucleus-claude-hook --smoke-test
+cargo install --git https://github.com/coproduct-opensource/nucleus nucleus-cli
+nucleus audit                       # scan agent configs (Tier 0, no runtime)
+nucleus run --local "your task"     # run with enforced permissions (Tier 1)
 ```
 
-Every tool call now flows through the permission kernel. The hook tracks data provenance and blocks dangerous combinations — like writing code derived from untrusted web content.
+Every tool call flows through the permission kernel. `nucleus run` tracks data provenance and blocks dangerous combinations — like writing code derived from untrusted web content. The hook for AI coding assistants previously bundled here (`nucleus-claude-hook`) is now part of [nucleus-code](https://github.com/coproduct-opensource/nucleus-code), the private orchestrator built on this runtime.
 
 ## What Gets Proved
 
@@ -46,9 +46,9 @@ Full inventory: 165 Lean 4 theorems (zero `sorry`), 112 Kani BMC proofs, 297 Ver
 | `a ⊔ a = a` | Join is idempotent | Provably safe caching |
 | `a ≤ a ⊔ b` | Join is monotone | Taint never decreases |
 
-## Per-Call SPIFFE Provenance
+## Per-Call SPIFFE Provenance (preview)
 
-Every tool call gets a SPIFFE identity. Every byte of output has a verifiable provenance chain back to its sources.
+> **Status:** alpha. The crate ships a per-call SPIFFE-ID derivation library, an in-process Ed25519 demo issuer, an append-mode JSONL log, and a `nucleus lineage` walker. The demo is not yet wired into the runtime, edges are not yet signed, and no SPIRE-backed `IdentityFetcher` impl exists in this repo. See [`crates/nucleus-lineage/README.md`](crates/nucleus-lineage/README.md) for the honest scope and [the audit findings](#known-gaps) for what's still missing.
 
 `nucleus-lineage` extends [SPIFFE](https://spiffe.io/) workload identity from the *pod* level down to the *individual call* level. Each tool invocation, LLM call, or derived artifact mints a child SPIFFE ID whose path encodes its lineage and whose suffix is a content hash:
 
@@ -60,9 +60,9 @@ spiffe://<trust>/ns/<ns>/sa/<sa>                                   ← pod (root
   /call/<uuid>/derived/sha256:<hex>                                ← downstream artifact
 ```
 
-Identical content → identical content-hash suffix, regardless of derivation path. The full path doubles as a human-readable witness; the JWT-SVIDs minted at boundaries are cryptographic witnesses of the same chain.
+Identical content → identical content-hash suffix, regardless of derivation path. The full path is a human-readable witness of the derivation chain.
 
-Try it end-to-end (Bash → Write → mock-LLM with JWT verification):
+Try it end-to-end (Bash → Write → mock-LLM with self-loop JWT verification — the mock LLM uses the same in-process key the issuer minted with, so this proves the JWT format, not cross-trust federation):
 
 ```bash
 cargo run -p nucleus-lineage --example three_step_demo
@@ -71,13 +71,14 @@ nucleus lineage <leaf-spiffe-id> --log ./nucleus-lineage.jsonl
 
 Output formats: `--format tree` (default), `json`, or `dot` (for Graphviz).
 
-| What it gives you | What it doesn't |
+| Today | Roadmap |
 |---|---|
-| Cryptographically-signed identity per call (Ed25519 JWT-SVIDs) | Replace IFC labeling — composes with portcullis, doesn't replace it |
-| Content-addressed lineage that survives across pods and providers | Echo-back from external relying parties (e.g. Anthropic records `sub`, doesn't return it on responses) |
-| `nucleus lineage` walks the full DAG (ancestors or descendants) | A SPIRE Workload API client by default — the demo uses a `LocalIssuer`; production wiring lives in `nucleus-identity`'s `spire` feature |
+| SPIFFE-format ID per call, content-addressed | Edge signing + hash chain so the JSONL log is tamper-evident |
+| `LocalIssuer` (in-process Ed25519, demo-only) | SPIRE Workload API `IdentityFetcher` impl |
+| `nucleus lineage` walker (graph traversal) | Walker verifies edge signatures + JWKS-backed federation |
+| Composes with portcullis IFC labels (does not replace them) | `nucleus-tool-proxy` auto-emits edges per HTTP handler |
 
-Categorically: per-call SPIFFE IDs lift the workload category to a bicategory where morphisms (calls) carry identities, making end-to-end IFC sheaves measurable rather than only inferable. See [`crates/nucleus-lineage/README.md`](crates/nucleus-lineage/README.md) for the longer story.
+Treat the categorical framing — "per-call SPIFFE IDs lift the workload category to a bicategory; cocycle condition becomes verifiable" — as a roadmap, not as currently load-bearing. See [`crates/nucleus-lineage/README.md`](crates/nucleus-lineage/README.md) for the longer story and the explicit limitations.
 
 ## How Nucleus Stops Real Exploits
 
@@ -121,13 +122,12 @@ Agent → MCP → tool-proxy (inside VM) → portcullis check → OS operation
 ## Crates
 
 <details>
-<summary>User-facing tools (5 crates)</summary>
+<summary>User-facing tools (4 crates)</summary>
 
 | Crate | Purpose |
 |-------|---------|
-| [**nucleus-claude-hook**](crates/nucleus-claude-hook/) | Hook for AI coding assistants: IFC kernel, compartments, provenance |
+| [**nucleus-cli**](crates/nucleus-cli/) | Run AI agents under enforced permissions; ships the `nucleus` binary |
 | [**nucleus-audit**](crates/nucleus-audit/) | Scan agent configs, verify audit trails, inspect provenance |
-| [**nucleus-cli**](crates/nucleus-cli/) | Run AI agents under enforced permissions |
 | [**nucleus-sdk**](crates/nucleus-sdk/) | Rust SDK for building sandboxed AI agents |
 | [**exposure-playground**](crates/exposure-playground/) | Interactive TUI for exploring the permission lattice |
 

--- a/crates/nucleus-cli/src/lineage.rs
+++ b/crates/nucleus-cli/src/lineage.rs
@@ -44,6 +44,14 @@ pub struct LineageArgs {
     /// Maximum depth to walk. 0 means unlimited.
     #[arg(long, default_value_t = 0)]
     pub max_depth: usize,
+
+    /// Skip the structural-parent integrity check. By default, edges whose
+    /// claimed `parents` are not a SPIFFE-prefix of the `child` are dropped
+    /// from the walk (with a stderr warning) — this catches forged log
+    /// entries that try to claim an unrelated SPIFFE ID as a parent. Pass
+    /// `--allow-forged` to walk them anyway.
+    #[arg(long)]
+    pub allow_forged: bool,
 }
 
 pub fn execute(args: LineageArgs) -> Result<()> {
@@ -66,9 +74,9 @@ pub fn execute(args: LineageArgs) -> Result<()> {
     let graph = LineageGraph::build(&edges);
 
     let collected = if args.descendants {
-        graph.walk_descendants(&target, args.max_depth)
+        graph.walk_descendants(&target, args.max_depth, args.allow_forged)
     } else {
-        graph.walk_ancestors(&target, args.max_depth)
+        graph.walk_ancestors(&target, args.max_depth, args.allow_forged)
     };
 
     if collected.is_empty() {
@@ -116,7 +124,16 @@ impl<'a> LineageGraph<'a> {
 
     /// BFS from `target` following parent pointers. Returns the subset of
     /// edges visited, deduplicated by edge identity.
-    fn walk_ancestors(&self, target: &CallSpiffeId, max_depth: usize) -> Vec<LineageEdge> {
+    ///
+    /// Skips edges that fail [`is_structurally_consistent`] unless
+    /// `allow_forged` is true; an `eprintln!` warning is emitted for each
+    /// dropped edge so operators see why an expected ancestor is missing.
+    fn walk_ancestors(
+        &self,
+        target: &CallSpiffeId,
+        max_depth: usize,
+        allow_forged: bool,
+    ) -> Vec<LineageEdge> {
         let mut seen_ids: BTreeSet<String> = BTreeSet::new();
         let mut out: Vec<LineageEdge> = Vec::new();
         let mut frontier: Vec<(String, usize)> = vec![(target.to_string(), 0)];
@@ -128,6 +145,16 @@ impl<'a> LineageGraph<'a> {
             }
             if let Some(edges) = self.edges_by_child.get(&id) {
                 for e in edges {
+                    if !allow_forged && !is_structurally_consistent(e) {
+                        eprintln!(
+                            "warning: dropping structurally-inconsistent edge \
+                             (child={}, parents={:?}, kind={:?}) — pass --allow-forged to keep",
+                            e.child,
+                            e.parents.iter().map(|p| p.as_str()).collect::<Vec<_>>(),
+                            e.kind,
+                        );
+                        continue;
+                    }
                     out.push((*e).clone());
                     for p in &e.parents {
                         if seen_ids.insert(p.to_string()) {
@@ -140,8 +167,14 @@ impl<'a> LineageGraph<'a> {
         out
     }
 
-    /// BFS from `target` following child pointers (descendants).
-    fn walk_descendants(&self, target: &CallSpiffeId, max_depth: usize) -> Vec<LineageEdge> {
+    /// BFS from `target` following child pointers (descendants). Same
+    /// structural-consistency filter as `walk_ancestors`.
+    fn walk_descendants(
+        &self,
+        target: &CallSpiffeId,
+        max_depth: usize,
+        allow_forged: bool,
+    ) -> Vec<LineageEdge> {
         let mut seen_ids: BTreeSet<String> = BTreeSet::new();
         let mut out: Vec<LineageEdge> = Vec::new();
         let mut frontier: Vec<(String, usize)> = vec![(target.to_string(), 0)];
@@ -153,6 +186,16 @@ impl<'a> LineageGraph<'a> {
             }
             if let Some(edges) = self.edges_by_parent.get(&id) {
                 for e in edges {
+                    if !allow_forged && !is_structurally_consistent(e) {
+                        eprintln!(
+                            "warning: dropping structurally-inconsistent edge \
+                             (child={}, parents={:?}, kind={:?})",
+                            e.child,
+                            e.parents.iter().map(|p| p.as_str()).collect::<Vec<_>>(),
+                            e.kind,
+                        );
+                        continue;
+                    }
                     out.push((*e).clone());
                     if seen_ids.insert(e.child.to_string()) {
                         frontier.push((e.child.to_string(), depth + 1));
@@ -162,6 +205,57 @@ impl<'a> LineageGraph<'a> {
         }
         out
     }
+}
+
+/// Return true if the edge's `parents` are a structural prefix of `child`
+/// in the SPIFFE path scheme (or, for `Merge` edges, share the trust-domain
+/// prefix with the child).
+///
+/// The audit (CRIT-5) demonstrated that a forged JSONL line could claim an
+/// arbitrary SPIFFE ID as a parent, and the walker would happily render it
+/// as part of the lineage. This check is the cheap structural defense:
+///
+/// - `PodAdmit` edges must have empty `parents`.
+/// - For most kinds, every parent must be a string-prefix of the child
+///   followed by `/call/` — i.e., the child's path is the parent's path
+///   extended by one or more `/call/<uuid>/...` segments.
+/// - For `Merge` edges, parents may be siblings (not direct ancestors), so
+///   we only require trust-domain agreement: the SPIFFE authority of every
+///   parent must equal the authority of the child.
+///
+/// Cryptographic verification of an attached [`Proof`](nucleus_lineage::Proof)
+/// is the stronger defense; it lands in PR-D once edges are signed.
+pub fn is_structurally_consistent(edge: &LineageEdge) -> bool {
+    use nucleus_lineage::EdgeKind;
+    match &edge.kind {
+        EdgeKind::PodAdmit => edge.parents.is_empty(),
+        EdgeKind::Merge => {
+            let child_authority = spiffe_authority(edge.child.as_str());
+            !edge.parents.is_empty()
+                && edge
+                    .parents
+                    .iter()
+                    .all(|p| spiffe_authority(p.as_str()) == child_authority)
+        }
+        _ => {
+            !edge.parents.is_empty()
+                && edge.parents.iter().all(|parent| {
+                    let parent_str = parent.as_str();
+                    let child_str = edge.child.as_str();
+                    child_str.starts_with(parent_str)
+                        && child_str[parent_str.len()..].starts_with("/call/")
+                })
+        }
+    }
+}
+
+/// Extract the SPIFFE authority (trust domain) from a SPIFFE URI string.
+/// Caller is responsible for the `spiffe://` prefix being present (the
+/// hardened parser ensures this for any [`CallSpiffeId`]).
+fn spiffe_authority(s: &str) -> &str {
+    s.strip_prefix("spiffe://")
+        .and_then(|rest| rest.split_once('/').map(|(auth, _)| auth))
+        .unwrap_or("")
 }
 
 // ────────────────────────────────────────────────────────────────────────
@@ -292,7 +386,7 @@ mod tests {
     fn walk_ancestors_finds_full_chain() {
         let (leaf, edges) = three_step_chain();
         let g = LineageGraph::build(&edges);
-        let walk = g.walk_ancestors(&leaf, 0);
+        let walk = g.walk_ancestors(&leaf, 0, true);
         // 3 edges visited: leaf, bash call, pod admit (no parents → terminates).
         assert_eq!(walk.len(), 3);
     }
@@ -301,7 +395,7 @@ mod tests {
     fn walk_ancestors_respects_max_depth() {
         let (leaf, edges) = three_step_chain();
         let g = LineageGraph::build(&edges);
-        let walk = g.walk_ancestors(&leaf, 1);
+        let walk = g.walk_ancestors(&leaf, 1, true);
         // Depth 0: leaf's edge. Depth 1: bash's edge. depth 2 (pod_admit) clipped.
         assert!(walk.len() < 3);
     }
@@ -311,7 +405,7 @@ mod tests {
         let (_leaf, edges) = three_step_chain();
         let pod_id = pod();
         let g = LineageGraph::build(&edges);
-        let walk = g.walk_descendants(&pod_id, 0);
+        let walk = g.walk_descendants(&pod_id, 0, true);
         // From the pod we should reach the bash call (and through it, the artifact).
         assert!(!walk.is_empty(), "descendants walk must not be empty");
         let kinds: Vec<_> = walk
@@ -335,7 +429,126 @@ mod tests {
         let (_leaf, edges) = three_step_chain();
         let g = LineageGraph::build(&edges);
         let unknown = pod().derive_tool("NotInGraph", Some(b"x")).unwrap();
-        assert!(g.walk_ancestors(&unknown, 0).is_empty());
+        assert!(g.walk_ancestors(&unknown, 0, true).is_empty());
+    }
+
+    /// CRIT-5 from the audit: a forged JSONL line could claim an unrelated
+    /// SPIFFE ID as the parent of an attacker artifact. Default-strict mode
+    /// drops such edges; --allow-forged passes them through.
+    #[test]
+    fn walk_drops_forged_edges_by_default() {
+        let attacker_pod = CallSpiffeId::pod("attacker.example.com", "evil", "evil-sa").unwrap();
+        let victim_pod = CallSpiffeId::pod("victim.example.com", "secret", "secret-sa").unwrap();
+        let attacker_artifact = attacker_pod.derive_artifact(b"forged claim").unwrap();
+        // Hand-build a forged edge: attacker's child claims victim's pod
+        // ID as a parent. Under no normal derivation would this happen.
+        let forged = LineageEdge {
+            child: attacker_artifact.clone(),
+            parents: vec![victim_pod.clone()],
+            kind: EdgeKind::ArtifactProduced,
+            content_hash_hex: None,
+            ts: chrono::Utc::now(),
+            attrs: Default::default(),
+            proof: None,
+        };
+        let edges = vec![LineageEdge::pod_admit(victim_pod), forged];
+        let g = LineageGraph::build(&edges);
+
+        // Strict (default) — dropped.
+        let strict_walk = g.walk_ancestors(&attacker_artifact, 0, false);
+        assert!(
+            strict_walk.is_empty(),
+            "forged edge should be dropped in strict mode, got {:?}",
+            strict_walk.iter().map(|e| &e.child).collect::<Vec<_>>()
+        );
+
+        // --allow-forged — passes through. The walker reaches the forged
+        // edge (1), and via its claimed parent reaches victim_pod's
+        // pod_admit (2). The defense-in-depth point of this test is that
+        // strict mode prevents this two-step poisoning.
+        let permissive_walk = g.walk_ancestors(&attacker_artifact, 0, true);
+        assert_eq!(permissive_walk.len(), 2);
+    }
+
+    #[test]
+    fn is_structurally_consistent_accepts_real_derivation() {
+        let p = pod();
+        let bash = p.derive_tool("Bash", Some(b"x")).unwrap();
+        let edge = LineageEdge::from_parent(
+            bash,
+            p,
+            EdgeKind::ToolCall {
+                tool: "Bash".to_string(),
+            },
+        );
+        assert!(is_structurally_consistent(&edge));
+    }
+
+    #[test]
+    fn is_structurally_consistent_rejects_unrelated_parent() {
+        let attacker_pod = CallSpiffeId::pod("attacker.example.com", "evil", "evil-sa").unwrap();
+        let victim_pod = CallSpiffeId::pod("victim.example.com", "ok", "ok-sa").unwrap();
+        let attacker_artifact = attacker_pod.derive_artifact(b"x").unwrap();
+        let edge = LineageEdge {
+            child: attacker_artifact,
+            parents: vec![victim_pod],
+            kind: EdgeKind::ArtifactProduced,
+            content_hash_hex: None,
+            ts: chrono::Utc::now(),
+            attrs: Default::default(),
+            proof: None,
+        };
+        assert!(!is_structurally_consistent(&edge));
+    }
+
+    #[test]
+    fn is_structurally_consistent_pod_admit_must_have_no_parents() {
+        let edge_ok = LineageEdge::pod_admit(pod());
+        assert!(is_structurally_consistent(&edge_ok));
+
+        let edge_bad = LineageEdge {
+            child: pod(),
+            parents: vec![pod()],
+            kind: EdgeKind::PodAdmit,
+            content_hash_hex: None,
+            ts: chrono::Utc::now(),
+            attrs: Default::default(),
+            proof: None,
+        };
+        assert!(!is_structurally_consistent(&edge_bad));
+    }
+
+    #[test]
+    fn merge_edge_requires_trust_domain_agreement() {
+        let p = pod();
+        let a = p.derive_tool("Read", Some(b"a")).unwrap();
+        let b = p.derive_tool("Read", Some(b"b")).unwrap();
+        let merged = p.derive_artifact(b"merged").unwrap();
+
+        // Same trust domain → ok.
+        let ok = LineageEdge {
+            child: merged.clone(),
+            parents: vec![a.clone(), b.clone()],
+            kind: EdgeKind::Merge,
+            content_hash_hex: None,
+            ts: chrono::Utc::now(),
+            attrs: Default::default(),
+            proof: None,
+        };
+        assert!(is_structurally_consistent(&ok));
+
+        // Cross-trust-domain Merge → rejected.
+        let attacker = CallSpiffeId::pod("attacker.example.com", "evil", "evil-sa").unwrap();
+        let bad = LineageEdge {
+            child: merged,
+            parents: vec![a, attacker],
+            kind: EdgeKind::Merge,
+            content_hash_hex: None,
+            ts: chrono::Utc::now(),
+            attrs: Default::default(),
+            proof: None,
+        };
+        assert!(!is_structurally_consistent(&bad));
     }
 
     #[test]
@@ -351,6 +564,7 @@ mod tests {
             content_hash_hex: None,
             ts: chrono::Utc::now(),
             attrs: Default::default(),
+            proof: None,
         };
         let edges = vec![
             LineageEdge::pod_admit(p.clone()),
@@ -371,7 +585,7 @@ mod tests {
             merge_edge,
         ];
         let g = LineageGraph::build(&edges);
-        let walk = g.walk_ancestors(&merged, 0);
+        let walk = g.walk_ancestors(&merged, 0, true);
         // Should reach both a and b.
         let parent_ids: BTreeSet<_> = walk
             .iter()
@@ -396,6 +610,7 @@ mod tests {
                 content_hash_hex: None,
                 ts: chrono::Utc::now(),
                 attrs: Default::default(),
+                proof: None,
             },
             LineageEdge {
                 child: y.clone(),
@@ -404,10 +619,11 @@ mod tests {
                 content_hash_hex: None,
                 ts: chrono::Utc::now(),
                 attrs: Default::default(),
+                proof: None,
             },
         ];
         let g = LineageGraph::build(&edges);
-        let walk = g.walk_ancestors(&x, 0);
+        let walk = g.walk_ancestors(&x, 0, true);
         // 2 edges visited; no infinite loop. Both should appear.
         assert_eq!(walk.len(), 2);
     }
@@ -425,7 +641,7 @@ mod tests {
         let reloaded = JsonlSink::open(&path).unwrap();
         let all = reloaded.iter().unwrap();
         let g = LineageGraph::build(&all);
-        let walk = g.walk_ancestors(&leaf, 0);
+        let walk = g.walk_ancestors(&leaf, 0, true);
         assert_eq!(walk.len(), 3);
         // sanity-check rendering doesn't panic
         render_tree(&leaf, &walk, false);
@@ -435,7 +651,7 @@ mod tests {
     fn dot_output_is_well_formed() {
         let (leaf, edges) = three_step_chain();
         let g = LineageGraph::build(&edges);
-        let walk = g.walk_ancestors(&leaf, 0);
+        let walk = g.walk_ancestors(&leaf, 0, true);
         // Capture stdout by routing render_dot through a Vec<u8> would require
         // refactoring; here we just verify no panic and a nontrivial graph.
         assert!(!walk.is_empty());

--- a/crates/nucleus-lineage/Cargo.toml
+++ b/crates/nucleus-lineage/Cargo.toml
@@ -9,6 +9,13 @@ repository = "https://github.com/coproduct-opensource/nucleus"
 keywords = ["spiffe", "lineage", "provenance", "ifc", "agents"]
 categories = ["development-tools", "cryptography"]
 
+[features]
+default = []
+# Demo-only in-process Ed25519 JWT-SVID issuer. NOT FOR PRODUCTION USE.
+# Production callers should write a SPIFFE-Workload-API-backed
+# `IdentityFetcher` impl and never enable this feature in release builds.
+dev = ["dep:jsonwebtoken", "dep:ed25519-dalek", "dep:rand"]
+
 [dependencies]
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -17,14 +24,22 @@ hex = { workspace = true }
 thiserror = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
-jsonwebtoken = { version = "10", default-features = false, features = ["use_pem", "rust_crypto"] }
-ed25519-dalek = { version = "2", features = ["rand_core", "pkcs8"] }
-rand = "0.8"
+tracing = { workspace = true }
+# base64 is used by the always-on `proof` module to wire-encode signature
+# bytes; not gated.
 base64 = "0.22"
+# Crypto deps below are gated behind `dev` (demo issuer only).
+jsonwebtoken = { version = "10", default-features = false, features = ["use_pem", "rust_crypto"], optional = true }
+ed25519-dalek = { version = "2", features = ["rand_core", "pkcs8"], optional = true }
+rand = { version = "0.8", optional = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
 ureq = { workspace = true, features = ["json"] }
+
+[[example]]
+name = "three_step_demo"
+required-features = ["dev"]
 
 [lints]
 workspace = true

--- a/crates/nucleus-lineage/README.md
+++ b/crates/nucleus-lineage/README.md
@@ -1,8 +1,8 @@
 # nucleus-lineage
 
-> Every tool call gets a SPIFFE identity. Every byte of output has a verifiable provenance chain back to its sources.
+> **Status: alpha.** A per-call SPIFFE-ID derivation library with an `O_APPEND`-mode JSONL log and a `LocalIssuer` for demos. Edge signing, hash chaining, and a SPIRE-backed `IdentityFetcher` impl are roadmap, not shipped. Read [Honest constraints](#honest-constraints) before depending on this for anything you care about.
 
-`nucleus-lineage` extends [SPIFFE](https://spiffe.io/) workload identity from the *pod* level down to the *individual call* level. Each tool invocation, LLM call, or derived artifact mints a child SPIFFE ID whose path encodes its lineage and whose suffix is a content hash. The result: a cryptographically-signed, content-addressed DAG that lets you answer **"where did this data come from?"** with concrete evidence rather than inference.
+`nucleus-lineage` extends [SPIFFE](https://spiffe.io/) workload identity from the *pod* level down to the *individual call* level. Each tool invocation, LLM call, or derived artifact mints a child SPIFFE ID whose path encodes its lineage and whose suffix is a content hash. With signing landed (roadmap), the result will be a tamper-evident, content-addressed DAG that answers **"where did this data come from?"** with cryptographic evidence rather than inference. Today it answers it with content hashes plus a parent pointer — useful, but not adversary-resistant on its own.
 
 ## The path scheme
 
@@ -14,7 +14,7 @@ spiffe://<trust>/ns/<ns>/sa/<sa>                                   ← pod (root
   /call/<uuid>/derived/sha256:<hex>                                ← downstream artifact
 ```
 
-Identical content → identical content-hash suffix (regardless of derivation path), so re-deriving the same value from the same parents is recognizable. The full path doubles as a human-readable witness of how this byte-string came to exist.
+Identical content → identical content-hash suffix (regardless of derivation path), so re-deriving the same value from the same parents is recognizable. The full path is a human-readable witness of how this byte-string came to exist.
 
 ## Quick demo
 
@@ -30,13 +30,15 @@ admitted pod: spiffe://demo.nucleus.local/ns/agents/sa/lineage-demo
 step 1 ✔ Bash → spiffe://…/call/cca7fa46…/tool/Bash/sha256:b534e3bf… (25 bytes)
 step 2 ✔ Write → spiffe://…/call/bde8f048…/tool/Write/sha256:b534e3bf… (/tmp/...)
 step 3a ✔ LLM prompt → spiffe://…/call/388064f0…/llm/anthropic/prompt/sha256:b534e3bf…
-    mock-llm: verified JWT, sub=spiffe://…, jti=684ee954…, exp_in=300s
+    mock-llm: verified JWT (self-loop), sub=spiffe://…, jti=684ee954…, exp_in=300s
 step 3b ✔ LLM response → spiffe://…/call/63b43cec…/llm/anthropic/response/sha256:2a6f4cc9… (476 bytes)
 
 done. lineage log written to ./nucleus-lineage.jsonl
 walk it with:
   nucleus lineage 'spiffe://…/llm/anthropic/response/sha256:2a6f4cc9…' --log ./nucleus-lineage.jsonl
 ```
+
+The "mock-llm: verified JWT" line is honest about what's verified: the JWT was minted by the `LocalIssuer` and verified using the **same in-process key** the issuer mints with. This proves JWT well-formedness, not cross-trust federation. A real relying party would fetch a JWKS from a separate trust anchor — that's roadmap.
 
 Then walk the chain back to its source:
 
@@ -60,24 +62,31 @@ For Graphviz output: `--format dot`. For machine-readable JSON: `--format json`.
 
 | Module | Purpose |
 |---|---|
-| `id::CallSpiffeId` | SPIFFE-format identity with strict path grammar. Constructors for pod-root + tool / LLM / artifact derivations. Round-trips through serde. |
-| `edge::LineageEdge` | One immutable record in the DAG: `(child, parents[], kind, content_hash, ts, attrs)`. Wire format is JSON, kept stable. |
-| `sink::LineageSink` | Trait for append-only persistence. `InMemorySink` (tests) + `JsonlSink` (file-backed) ship in this crate. |
-| `issuer::IdentityFetcher` | Trait for JWT-SVID minting. `LocalIssuer` (Ed25519, in-process, demo-only) ships here; a SPIRE Workload API impl lives in `nucleus-identity`. |
+| `id::CallSpiffeId` | SPIFFE-format identity. Validates `/call/<uuid>/...` suffix structure and content-hash format; full SPIFFE ID grammar enforcement is roadmap. Round-trips through serde. |
+| `edge::LineageEdge` | One record in the DAG: `(child, parents[], kind, content_hash, ts, attrs)`. JSON wire format. **Edges are not yet signed.** |
+| `sink::LineageSink` | Trait for persistence. `InMemorySink` (tests) + `JsonlSink` (file-backed, `O_APPEND` mode — not tamper-evident, see below) ship in this crate. |
+| `issuer::IdentityFetcher` | Trait for JWT-SVID minting. `LocalIssuer` (Ed25519, in-process, demo-only) ships here. **No SPIRE-backed impl exists in this repo yet.** |
 
 ## Honest constraints
 
-`LocalIssuer` is **demo-only**. It signs with an ephemeral in-process Ed25519 key and is not what you should use in production. For real deployments you want a SPIRE Agent (or any SPIFFE-conformant issuer) backing the `IdentityFetcher` trait — see `nucleus-identity`'s `spire` feature for the production path.
+The list below is what's missing today. Most items are tracked for follow-up PRs; this README will be updated as each lands.
 
-The Anthropic side of the lineage is **unidirectional**. When a JWT-SVID is presented to the Anthropic API, the `sub` claim appears in their audit log — but the response payload doesn't carry a SPIFFE ID we can attach to derived data. Lineage from prompt → response is established on the nucleus side from the timing + content hashes; it is not echoed back by the relying party. This is an inherent property of the WIF protocol, not a defect of this implementation.
-
-The default `LineageSink` is process-local. Cross-process / cross-host lineage requires a remote sink — straightforward extension via the trait, not yet implemented in this crate.
+- **`LocalIssuer` is demo-only.** It signs with an ephemeral in-process Ed25519 key, has no JWKS publication, no key rotation, no persistence. It is exported publicly and currently has no programmatic guard against being wired into production code. Do not use it as a production `IdentityFetcher`. (Tracked: feature-gate behind a `dev` cargo feature.)
+- **No SPIRE-backed `IdentityFetcher`.** `nucleus-identity`'s existing `spire` feature handles X.509 SVIDs only; the JWT-SVID API surface is not yet wired in. The trait is the integration point; the impl has to be written.
+- **Edges are not signed.** `LineageEdge` carries the child/parents/kind/content_hash/ts/attrs but no `Proof { kid, alg, sig }` field. Anyone with write access to the JSONL log can fabricate parent relationships — including claiming a victim pod's SPIFFE ID as the parent of an attacker artifact. The walker (`nucleus lineage`) trusts edge-claimed parents; it does not perform structural reconciliation against `CallSpiffeId::parent()`. (Tracked: add `Proof` field; sign edges; walker verifies.)
+- **`JsonlSink` is `O_APPEND`-mode, not tamper-evident.** No hash chain (`prev_hash`), no signatures, no truncation detection. The file is process-local; concurrent multi-process writes can interleave bytes. The existing `nucleus-audit` crate has the receipt-chain pattern this crate should adopt.
+- **`--real-claude` mode does not exercise SPIFFE WIF.** It uses the long-lived `ANTHROPIC_API_KEY` for wire auth and only *records* the SPIFFE ID locally. The recorded edge attributes (`audience=https://api.anthropic.com`, `jwt_jti=...`) imply that a JWT-SVID was on the wire; the JWT was not. (Tracked: rename the recorded attrs to `wire_auth=api_key, recorded_subject=...`.)
+- **`CallSpiffeId::parse` accepts malformed inputs.** Currently passes: NUL bytes, RTL Unicode overrides, double slashes, uppercase `/CALL/`, query/fragment/userinfo, and several other forms forbidden by the SPIFFE ID spec. Negative tests are not yet present. (Tracked: parser hardening + negative test suite.)
+- **Anthropic-side echo-back is unidirectional and inherent.** When a JWT-SVID is presented to the Anthropic API, the `sub` claim appears in their audit log — but the response payload does not carry a SPIFFE ID we can attach to derived data. This is a property of WIF, not a fix-it-here issue.
+- **Process-local sink only.** Cross-process / cross-host lineage requires a remote sink — straightforward extension via the trait, not yet written.
 
 **This crate binds *who called*, not *what data was in the call*.** Prompt-body taint still requires the existing portcullis IFC machinery. SPIFFE lineage and IFC labels compose; they do not replace each other.
 
-## Categorical framing (for the curious)
+## Categorical framing (roadmap, not load-bearing)
 
-Per-call SPIFFE IDs lift the workload category to a bicategory where morphisms (calls) carry identities. Each child SVID's parent reference is a restriction map; the cocycle condition (gluing of sections across overlap) becomes verifiable from JWT signatures. This is the structure that makes end-to-end IFC sheaves measurable rather than only inferable. See `project_per_call_spiffe_lineage.md` in the project memory for the longer argument.
+Per-call SPIFFE IDs *will* lift the workload category to a bicategory where morphisms (calls) carry identities — once edges are signed and the walker actually verifies the cocycle condition (signed restriction maps, gluing across overlap). Today the structure exists in the path scheme but is not enforced computationally. The connection to the `alignment_tax = rank(H¹(IFC_sheaf))` line of work in `portcullis-core/lean/` is suggestive, not formal: those Lean theorems are about IFC posets, not about per-call SPIFFE provenance graphs. Treat this section as design intent until the `verify_glue` function lands.
+
+See `project_per_call_spiffe_lineage.md` in the project memory for the longer argument.
 
 ## License
 

--- a/crates/nucleus-lineage/src/edge.rs
+++ b/crates/nucleus-lineage/src/edge.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
 use crate::id::CallSpiffeId;
+use crate::proof::Proof;
 
 /// What kind of derivation this edge represents.
 ///
@@ -58,6 +59,14 @@ pub struct LineageEdge {
     /// Kept lexicographically sorted via BTreeMap for stable serialization.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub attrs: BTreeMap<String, String>,
+    /// Cryptographic proof signed over the edge's canonical bytes (see
+    /// [`crate::proof::canonical_edge_bytes`]). `None` for legacy / unsigned
+    /// edges. Edges produced by this crate's current emitters are unsigned;
+    /// signing lands when an [`crate::IdentityFetcher`] impl gains an
+    /// `sign_edge` method (PR-D). Verifiers should reject `None` in strict
+    /// mode.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub proof: Option<Proof>,
 }
 
 impl LineageEdge {
@@ -70,6 +79,7 @@ impl LineageEdge {
             content_hash_hex: None,
             ts: Utc::now(),
             attrs: BTreeMap::new(),
+            proof: None,
         }
     }
 
@@ -82,6 +92,7 @@ impl LineageEdge {
             content_hash_hex: None,
             ts: Utc::now(),
             attrs: BTreeMap::new(),
+            proof: None,
         }
     }
 
@@ -94,6 +105,12 @@ impl LineageEdge {
     /// Builder: attach a single attribute.
     pub fn with_attr(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
         self.attrs.insert(key.into(), value.into());
+        self
+    }
+
+    /// Builder: attach a cryptographic proof.
+    pub fn with_proof(mut self, proof: Proof) -> Self {
+        self.proof = Some(proof);
         self
     }
 }
@@ -168,6 +185,7 @@ mod tests {
             content_hash_hex: None,
             ts: Utc::now(),
             attrs: BTreeMap::new(),
+            proof: None,
         };
         assert_eq!(edge.parents.len(), 2);
         assert!(matches!(edge.kind, EdgeKind::Merge));

--- a/crates/nucleus-lineage/src/id.rs
+++ b/crates/nucleus-lineage/src/id.rs
@@ -27,13 +27,29 @@ pub enum IdError {
     MissingPath(String),
     #[error("invalid call uuid {0:?}: {1}")]
     InvalidCallUuid(String, uuid::Error),
-    #[error("invalid sha256 suffix {0:?}: must be 64 lowercase hex chars")]
+    #[error("invalid sha256 suffix {0:?}: must be exactly `sha256:<64 lowercase hex>`")]
     InvalidContentHash(String),
     #[error("path component {0:?} is empty or contains only whitespace")]
     EmptyComponent(String),
     #[error("path component {0:?} contains a `/`; pass segments individually")]
     SlashInComponent(String),
+    #[error("input is too long ({len} bytes; max {max} allowed)", max = MAX_URI_LEN)]
+    TooLong { len: usize },
+    #[error("input contains forbidden character {0:?} at byte offset {1}")]
+    ForbiddenChar(char, usize),
+    #[error("authority {0:?} contains characters outside `[a-z0-9._-]`")]
+    InvalidAuthority(String),
+    #[error("path component {0:?} contains characters outside `[A-Za-z0-9._-]` (or the reserved `sha256:<hex>` form)")]
+    InvalidPathChar(String),
+    #[error("path contains an empty segment (consecutive `/` or trailing `/`) in {0:?}")]
+    EmptyPathSegment(String),
+    #[error("`/call/` segment must be exactly lowercase, found {0:?}")]
+    NonCanonicalCallSegment(String),
 }
+
+/// Maximum URI length we'll accept. SPIFFE IDs in practice are short; a
+/// hard cap prevents pathological-input DoS in the parser.
+pub const MAX_URI_LEN: usize = 4096;
 
 /// A SPIFFE-format identity for a call, artifact, or derived value.
 ///
@@ -45,14 +61,62 @@ pub enum IdError {
 pub struct CallSpiffeId(String);
 
 impl CallSpiffeId {
-    /// Construct from a raw SPIFFE URI string. Validates the scheme,
-    /// authority, and any `/call/<uuid>/...` suffix's structure (call uuid
-    /// well-formed; content-hash suffix is 64 hex chars when present).
+    /// Construct from a raw SPIFFE URI string.
+    ///
+    /// Validates per the SPIFFE ID spec, with the documented deviation that
+    /// the literal `:` character is permitted in the special last-segment form
+    /// `sha256:<64-lowercase-hex>` (used for content-addressed lineage).
+    /// Otherwise:
+    ///
+    /// - Scheme must be `spiffe://`.
+    /// - URI length must be ≤ [`MAX_URI_LEN`] bytes.
+    /// - Every byte must be ASCII printable (rejects NUL, control chars,
+    ///   RTL/LRO Unicode overrides, and any non-ASCII).
+    /// - URI components `?` (query), `#` (fragment), and `@` (userinfo) are
+    ///   absent — SPIFFE forbids them.
+    /// - Authority charset: lowercase ASCII letters, digits, `-`, `.`, `_`.
+    ///   No `:` (no port), no `@` (no userinfo).
+    /// - Path segments are non-empty (rejects `//`, leading `//`, trailing `/`).
+    /// - Path segment charset: `[A-Za-z0-9._-]` per SPIFFE, or the reserved
+    ///   form `sha256:<64 lowercase hex>`.
+    /// - Any `/call/...` suffix must use lowercase `call` and a well-formed
+    ///   uuid in the next segment.
     pub fn parse(uri: impl Into<String>) -> Result<Self, IdError> {
         let uri = uri.into();
+
+        // 1. Hard length cap (DoS guard).
+        if uri.len() > MAX_URI_LEN {
+            return Err(IdError::TooLong { len: uri.len() });
+        }
+
+        // 2. ASCII printable only — rejects NUL, control chars, RTL/LRO
+        //    overrides (U+202E/U+202D), any other Unicode. SPIFFE IDs are
+        //    ASCII per spec; rejecting non-ASCII closes the homograph /
+        //    visual-spoofing surface in the `nucleus lineage` renderer.
+        for (i, ch) in uri.char_indices() {
+            // Allow only ASCII range 0x20..=0x7E plus the structural chars
+            // that appear in spiffe URIs (handled by other rules below).
+            if !ch.is_ascii() || (ch as u32) < 0x20 || (ch as u32) == 0x7F {
+                return Err(IdError::ForbiddenChar(ch, i));
+            }
+        }
+
+        // 3. Reject query, fragment, userinfo. SPIFFE ID grammar forbids
+        //    `?`, `#`, `@`. We reject anywhere in the URI rather than only
+        //    at canonical positions; defense in depth.
+        for forbidden in ['?', '#', '@'] {
+            if let Some(pos) = uri.find(forbidden) {
+                return Err(IdError::ForbiddenChar(forbidden, pos));
+            }
+        }
+
+        // 4. Scheme.
         let rest = uri
             .strip_prefix("spiffe://")
             .ok_or_else(|| IdError::NotSpiffe(uri.clone()))?;
+
+        // 5. Authority + path split. Authority is everything up to the first
+        //    `/`. Path begins after.
         let (authority, path) = rest
             .split_once('/')
             .ok_or_else(|| IdError::MissingPath(uri.clone()))?;
@@ -62,28 +126,58 @@ impl CallSpiffeId {
         if path.is_empty() {
             return Err(IdError::MissingPath(uri.clone()));
         }
-        // Validate any /call/<uuid>/... suffix structure.
-        if let Some(call_idx) = path.find("/call/").map(|i| i + 1) {
-            let suffix = &path[call_idx..];
-            let mut parts = suffix.split('/');
-            let _call = parts.next(); // "call"
-            let uuid_part = parts
-                .next()
-                .ok_or_else(|| IdError::InvalidCallUuid(suffix.to_string(), uuid_error()))?;
-            Uuid::parse_str(uuid_part)
-                .map_err(|e| IdError::InvalidCallUuid(uuid_part.to_string(), e))?;
-            if let Some(hash_seg) = suffix.split('/').next_back() {
-                if let Some(hex) = hash_seg.strip_prefix("sha256:") {
-                    let valid = hex.len() == 64
-                        && hex
-                            .chars()
-                            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase());
-                    if !valid {
-                        return Err(IdError::InvalidContentHash(hex.to_string()));
-                    }
+
+        // 6. Authority charset. SPIFFE: lowercase letters, digits, `-`, `.`,
+        //    `_`. No port (`:`), no userinfo (already rejected above).
+        if !authority
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || matches!(c, '-' | '.' | '_'))
+        {
+            return Err(IdError::InvalidAuthority(authority.to_string()));
+        }
+
+        // 7. Path segments: non-empty, valid charset.
+        for segment in path.split('/') {
+            if segment.is_empty() {
+                return Err(IdError::EmptyPathSegment(uri.clone()));
+            }
+            // Special case: a `sha256:`-prefixed segment is a content-hash;
+            // route its specific failure to InvalidContentHash for actionable
+            // error messages. Note: case-sensitive — `SHA256:` falls through
+            // to the generic path-charset check below and is rejected there.
+            if let Some(hex) = segment.strip_prefix("sha256:") {
+                let valid = hex.len() == 64
+                    && hex
+                        .chars()
+                        .all(|c| c.is_ascii_digit() || matches!(c, 'a'..='f'));
+                if !valid {
+                    return Err(IdError::InvalidContentHash(segment.to_string()));
                 }
+                continue;
+            }
+            if !is_valid_path_segment(segment) {
+                return Err(IdError::InvalidPathChar(segment.to_string()));
             }
         }
+
+        // 8. Validate any /call/<uuid>/... suffix structure. The first /call/
+        //    segment must be lowercase; any uppercase variant (e.g. /CALL/)
+        //    is non-canonical and rejected (closes the suffix-bypass case
+        //    where uppercase /CALL/ skips uuid validation).
+        let mut path_parts = path.split('/').peekable();
+        while let Some(seg) = path_parts.next() {
+            if seg.eq_ignore_ascii_case("call") && seg != "call" {
+                return Err(IdError::NonCanonicalCallSegment(seg.to_string()));
+            }
+            if seg == "call" {
+                let uuid_part = path_parts.next().ok_or_else(|| {
+                    IdError::InvalidCallUuid("(missing)".to_string(), uuid_error())
+                })?;
+                Uuid::parse_str(uuid_part)
+                    .map_err(|e| IdError::InvalidCallUuid(uuid_part.to_string(), e))?;
+            }
+        }
+
         Ok(Self(uri))
     }
 
@@ -204,6 +298,23 @@ impl FromStr for CallSpiffeId {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Self::parse(s.to_string())
     }
+}
+
+/// Per SPIFFE ID spec, path segments use `[A-Za-z0-9._-]`. We additionally
+/// permit the reserved last-segment form `sha256:<64 lowercase hex>` for
+/// content-addressed lineage suffixes — the only allowed appearance of `:`
+/// in any segment.
+fn is_valid_path_segment(seg: &str) -> bool {
+    if let Some(hex) = seg.strip_prefix("sha256:") {
+        return hex.len() == 64
+            && hex
+                .chars()
+                .all(|c| c.is_ascii_digit() || matches!(c, 'a'..='f'));
+    }
+    !seg.is_empty()
+        && seg
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '.' | '_'))
 }
 
 fn check_segment(s: &str) -> Result<(), IdError> {
@@ -393,5 +504,158 @@ mod tests {
         let json = serde_json::to_string(&derived).unwrap();
         let back: CallSpiffeId = serde_json::from_str(&json).unwrap();
         assert_eq!(derived, back);
+    }
+
+    // ── Hardened-parser negative tests ─────────────────────────────────
+    // These cases were accepted by the original parser; a skeptical-code
+    // auditor pass enumerated each as a real input that should fail.
+
+    #[test]
+    fn parse_rejects_nul_byte_in_path() {
+        let err = CallSpiffeId::parse("spiffe://prod.example.com/ns/agents\0/sa/coder")
+            .expect_err("NUL byte must be rejected");
+        assert!(matches!(err, IdError::ForbiddenChar('\0', _)), "{err:?}");
+    }
+
+    #[test]
+    fn parse_rejects_rtl_unicode_override() {
+        // U+202E (RIGHT-TO-LEFT OVERRIDE) — used for visual spoofing.
+        let err = CallSpiffeId::parse("spiffe://prod.example.com/ns/admin\u{202E}/sa/coder")
+            .expect_err("RTL override must be rejected (non-ASCII)");
+        assert!(matches!(err, IdError::ForbiddenChar(_, _)), "{err:?}");
+    }
+
+    #[test]
+    fn parse_rejects_other_control_chars() {
+        // U+0007 BEL, embedded in a path component.
+        let err = CallSpiffeId::parse("spiffe://prod.example.com/ns/agents\u{0007}/sa/coder")
+            .expect_err("control char must be rejected");
+        assert!(matches!(err, IdError::ForbiddenChar(_, _)), "{err:?}");
+    }
+
+    #[test]
+    fn parse_rejects_double_slash() {
+        let err = CallSpiffeId::parse("spiffe://prod.example.com//ns/agents/sa/coder")
+            .expect_err("double slash must be rejected");
+        assert!(matches!(err, IdError::EmptyPathSegment(_)), "{err:?}");
+    }
+
+    #[test]
+    fn parse_rejects_trailing_slash() {
+        let err = CallSpiffeId::parse("spiffe://prod.example.com/ns/agents/sa/coder/")
+            .expect_err("trailing slash must be rejected");
+        assert!(matches!(err, IdError::EmptyPathSegment(_)), "{err:?}");
+    }
+
+    #[test]
+    fn parse_rejects_empty_path_only_root() {
+        let err = CallSpiffeId::parse("spiffe://prod.example.com//")
+            .expect_err("empty path must be rejected");
+        assert!(matches!(err, IdError::EmptyPathSegment(_)), "{err:?}");
+    }
+
+    #[test]
+    fn parse_rejects_uppercase_call_segment() {
+        // Original parser only validated /call/ via lowercase string.find,
+        // so /CALL/ slipped past the uuid check entirely.
+        let err =
+            CallSpiffeId::parse("spiffe://prod.example.com/ns/agents/sa/coder/CALL/abc/tool/Bash")
+                .expect_err("uppercase /CALL/ must be rejected");
+        assert!(
+            matches!(err, IdError::NonCanonicalCallSegment(_)),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn parse_rejects_query_string() {
+        let err = CallSpiffeId::parse("spiffe://prod.example.com/ns/agents/sa/coder?x=1")
+            .expect_err("URI query must be rejected");
+        assert!(matches!(err, IdError::ForbiddenChar('?', _)), "{err:?}");
+    }
+
+    #[test]
+    fn parse_rejects_fragment() {
+        let err = CallSpiffeId::parse("spiffe://prod.example.com/ns/agents/sa/coder#frag")
+            .expect_err("URI fragment must be rejected");
+        assert!(matches!(err, IdError::ForbiddenChar('#', _)), "{err:?}");
+    }
+
+    #[test]
+    fn parse_rejects_userinfo_in_authority() {
+        let err = CallSpiffeId::parse("spiffe://attacker:p@prod.example.com/ns/agents/sa/coder")
+            .expect_err("userinfo must be rejected");
+        assert!(matches!(err, IdError::ForbiddenChar('@', _)), "{err:?}");
+    }
+
+    #[test]
+    fn parse_rejects_uppercase_authority() {
+        // SPIFFE: trust-domain is lowercase.
+        let err = CallSpiffeId::parse("spiffe://Prod.Example.Com/ns/agents/sa/coder")
+            .expect_err("uppercase authority must be rejected");
+        assert!(matches!(err, IdError::InvalidAuthority(_)), "{err:?}");
+    }
+
+    #[test]
+    fn parse_rejects_uppercase_sha256_prefix() {
+        // /SHA256:<hex> previously parsed but content_hash_hex returned None
+        // — silent inconsistency. Now rejected as invalid path segment.
+        let bad = format!(
+            "spiffe://prod.example.com/ns/agents/sa/coder/call/{}/tool/Bash/SHA256:{}",
+            Uuid::new_v4(),
+            "a".repeat(64)
+        );
+        let err = CallSpiffeId::parse(bad).expect_err("/SHA256: must be rejected");
+        assert!(matches!(err, IdError::InvalidPathChar(_)), "{err:?}");
+    }
+
+    #[test]
+    fn parse_rejects_too_long_input() {
+        let bad = format!("spiffe://prod.example.com/{}", "a".repeat(MAX_URI_LEN));
+        let err = CallSpiffeId::parse(bad).expect_err("over-length URI must be rejected");
+        assert!(matches!(err, IdError::TooLong { .. }), "{err:?}");
+    }
+
+    #[test]
+    fn parse_rejects_path_traversal_segment() {
+        // ".." is itself a valid SPIFFE path segment (only [A-Za-z0-9._-]),
+        // so we permit it structurally — but its presence should not enable
+        // any escape because the canonical string never collapses it. This
+        // test pins the behavior so a future "path-canonicalization" change
+        // must be deliberate.
+        let id = CallSpiffeId::parse("spiffe://prod.example.com/ns/../sa/coder").unwrap();
+        assert_eq!(id.as_str(), "spiffe://prod.example.com/ns/../sa/coder");
+        // The structural parent walker uses string prefix only — it does not
+        // resolve `..`. (The walker is hardened separately in PR-C.)
+    }
+
+    #[test]
+    fn parse_rejects_colon_outside_sha256_prefix() {
+        // `:` is forbidden in SPIFFE path segments except in the reserved
+        // `sha256:<hex>` last-segment form. Anywhere else → rejected.
+        let err = CallSpiffeId::parse("spiffe://prod.example.com/ns/has:colon/sa/coder")
+            .expect_err("`:` outside sha256 prefix must be rejected");
+        assert!(matches!(err, IdError::InvalidPathChar(_)), "{err:?}");
+    }
+
+    #[test]
+    fn parse_accepts_canonical_pod_id() {
+        // Sanity: don't regress accepted inputs.
+        CallSpiffeId::parse("spiffe://prod.example.com/ns/agents/sa/coder").unwrap();
+    }
+
+    #[test]
+    fn parse_accepts_full_lineage_path() {
+        let id = pod()
+            .derive_tool("Bash", Some(b"x"))
+            .unwrap()
+            .derive_llm("anthropic", "prompt", b"hi")
+            .unwrap()
+            .derive_llm("anthropic", "response", b"reply")
+            .unwrap();
+        // Round-trip through parse to verify the canonical string is also
+        // accepted by the hardened parser.
+        let reparsed: CallSpiffeId = id.as_str().parse().unwrap();
+        assert_eq!(id, reparsed);
     }
 }

--- a/crates/nucleus-lineage/src/issuer.rs
+++ b/crates/nucleus-lineage/src/issuer.rs
@@ -1,41 +1,32 @@
 //! [`IdentityFetcher`] — pluggable issuer for JWT-SVIDs scoped to a
 //! [`CallSpiffeId`].
 //!
-//! Two impls are expected to coexist in the codebase:
+//! Trait + claims + error type have no crypto dependency and are always
+//! available. The in-process demo issuer ([`LocalIssuer`]) is only compiled
+//! when the non-default `dev` feature is enabled, so production binaries
+//! cannot accidentally link or re-export it.
 //!
-//! - [`LocalIssuer`] (this crate) — in-process Ed25519 signer for tests,
-//!   demos, and CI. No network, no SPIRE Agent. Verifying keys are exposed
-//!   so a relying party in the same process can validate SVIDs.
-//!
-//! - A `SpiffeWorkloadApi` impl in `nucleus-identity` — connects to a real
-//!   SPIRE Agent socket and fetches the JWT-SVID for the requested audience.
-//!
-//! Both implementations satisfy the same contract: given a `CallSpiffeId`
-//! and an audience, return a JWT whose `sub` claim is the SPIFFE ID and
-//! whose `aud` is the requested audience. Lifetimes are issuer-controlled.
+//! Production callers should write a `SpiffeWorkloadApi` impl (typically in
+//! the same crate as their SPIRE Agent integration) and provide it to the
+//! runtime via this trait. No such impl ships in this repo today.
 
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
-
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
-use ed25519_dalek::pkcs8::EncodePrivateKey;
-use ed25519_dalek::{SigningKey, VerifyingKey};
-use jsonwebtoken::{Algorithm, DecodingKey, EncodingKey, Header};
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
 use thiserror::Error;
-use uuid::Uuid;
 
 use crate::id::CallSpiffeId;
 
 /// Errors a JWT-SVID issuer may surface.
+///
+/// Backend-specific failures are stringified rather than typed so this trait
+/// stays free of any specific JWT library dependency.
 #[derive(Debug, Error)]
 pub enum IssuerError {
-    #[error("jwt error: {0}")]
-    Jwt(#[from] jsonwebtoken::errors::Error),
+    #[error("issuer backend error: {0}")]
+    Backend(String),
     #[error("system clock before unix epoch")]
     Clock,
     #[error("key encoding error: {0}")]
-    Pkcs8(String),
+    KeyEncoding(String),
 }
 
 /// Standard JWT-SVID claims, plus a short-form `nucleus_kind` for routing.
@@ -77,223 +68,5 @@ pub trait IdentityFetcher: Send + Sync {
         _kind: Option<&str>,
     ) -> Result<String, IssuerError> {
         self.fetch_jwt_svid(subject, audience)
-    }
-}
-
-// ────────────────────────────────────────────────────────────────────────
-// LocalIssuer
-
-/// In-process JWT-SVID issuer for tests and demos.
-///
-/// Holds an Ed25519 keypair generated at construction. SVIDs are signed
-/// EdDSA. The issuer URL string defaults to `nucleus-local://demo` and the
-/// SVID lifetime defaults to 5 minutes (matching SPIRE Agent's default).
-///
-/// In a process that needs to verify the SVIDs (e.g., the demo's mock LLM
-/// endpoint), call [`Self::decoding_key`] to get a [`DecodingKey`] and pass
-/// it to `jsonwebtoken::decode`. [`Self::public_key_pem`] returns the
-/// verifying key in PEM form for sharing across processes.
-pub struct LocalIssuer {
-    signing_key: SigningKey,
-    encoding_key: EncodingKey,
-    verifying_key: VerifyingKey,
-    issuer: String,
-    lifetime: Duration,
-    key_id: String,
-}
-
-impl LocalIssuer {
-    /// Construct with a fresh random Ed25519 keypair.
-    pub fn random() -> Result<Self, IssuerError> {
-        Self::random_with("nucleus-local://demo".to_string(), Duration::from_secs(300))
-    }
-
-    /// Construct with a fresh random keypair and explicit issuer/lifetime.
-    pub fn random_with(issuer: String, lifetime: Duration) -> Result<Self, IssuerError> {
-        let mut csprng = rand::rngs::OsRng;
-        let signing_key = SigningKey::generate(&mut csprng);
-        Self::from_signing_key(signing_key, issuer, lifetime)
-    }
-
-    /// Construct around a caller-provided signing key. Useful for tests
-    /// that want deterministic SVIDs.
-    pub fn from_signing_key(
-        signing_key: SigningKey,
-        issuer: String,
-        lifetime: Duration,
-    ) -> Result<Self, IssuerError> {
-        let pkcs8 = signing_key
-            .to_pkcs8_der()
-            .map_err(|e| IssuerError::Pkcs8(e.to_string()))?;
-        let encoding_key = EncodingKey::from_ed_der(pkcs8.as_bytes());
-        let verifying_key = signing_key.verifying_key();
-        // Stable kid: short hash of the public key bytes.
-        let mut h = Sha256::new();
-        h.update(verifying_key.as_bytes());
-        let kid_bytes = h.finalize();
-        let key_id = URL_SAFE_NO_PAD.encode(&kid_bytes[..12]);
-        Ok(Self {
-            signing_key,
-            encoding_key,
-            verifying_key,
-            issuer,
-            lifetime,
-            key_id,
-        })
-    }
-
-    /// The issuer URL ("iss" claim) used by this issuer.
-    pub fn issuer(&self) -> &str {
-        &self.issuer
-    }
-
-    /// JWK key id used in JWT headers and JWKS publication.
-    pub fn key_id(&self) -> &str {
-        &self.key_id
-    }
-
-    /// Verifying key for in-process JWT validation.
-    pub fn decoding_key(&self) -> DecodingKey {
-        DecodingKey::from_ed_der(self.verifying_key.as_bytes())
-    }
-
-    /// Raw verifying key bytes (32 bytes Ed25519 public key) for sharing
-    /// with external verifiers that already speak Ed25519.
-    pub fn verifying_key_bytes(&self) -> [u8; 32] {
-        self.verifying_key.to_bytes()
-    }
-
-    /// Raw signing key (useful for tests that want to construct another
-    /// issuer with the same identity).
-    pub fn signing_key(&self) -> &SigningKey {
-        &self.signing_key
-    }
-}
-
-impl IdentityFetcher for LocalIssuer {
-    fn fetch_jwt_svid(
-        &self,
-        subject: &CallSpiffeId,
-        audience: &str,
-    ) -> Result<String, IssuerError> {
-        self.fetch_jwt_svid_with_kind(subject, audience, None)
-    }
-
-    fn fetch_jwt_svid_with_kind(
-        &self,
-        subject: &CallSpiffeId,
-        audience: &str,
-        kind: Option<&str>,
-    ) -> Result<String, IssuerError> {
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map_err(|_| IssuerError::Clock)?
-            .as_secs();
-        let claims = SvidClaims {
-            sub: subject.to_string(),
-            aud: audience.to_string(),
-            iss: self.issuer.clone(),
-            iat: now,
-            exp: now + self.lifetime.as_secs(),
-            jti: Uuid::new_v4().to_string(),
-            nucleus_kind: kind.map(|s| s.to_string()),
-        };
-        let mut header = Header::new(Algorithm::EdDSA);
-        header.kid = Some(self.key_id.clone());
-        let token = jsonwebtoken::encode(&header, &claims, &self.encoding_key)?;
-        Ok(token)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use jsonwebtoken::{decode, Validation};
-
-    fn pod() -> CallSpiffeId {
-        CallSpiffeId::pod("prod.example.com", "agents", "coder").unwrap()
-    }
-
-    #[test]
-    fn local_issuer_mints_jwt_with_correct_claims() {
-        let issuer = LocalIssuer::random().unwrap();
-        let p = pod();
-        let token = issuer
-            .fetch_jwt_svid(&p, "https://api.anthropic.com")
-            .unwrap();
-        // Three base64 segments separated by `.`.
-        assert_eq!(token.matches('.').count(), 2);
-
-        let mut validation = Validation::new(Algorithm::EdDSA);
-        validation.set_audience(&["https://api.anthropic.com"]);
-        validation.set_issuer(&[issuer.issuer()]);
-        let decoded = decode::<SvidClaims>(&token, &issuer.decoding_key(), &validation).unwrap();
-
-        assert_eq!(decoded.claims.sub, p.to_string());
-        assert_eq!(decoded.claims.aud, "https://api.anthropic.com");
-        assert_eq!(decoded.claims.iss, issuer.issuer());
-        assert!(decoded.claims.exp > decoded.claims.iat);
-        assert!(!decoded.claims.jti.is_empty());
-    }
-
-    #[test]
-    fn jwt_signature_verifies_only_with_matching_key() {
-        let issuer_a = LocalIssuer::random().unwrap();
-        let issuer_b = LocalIssuer::random().unwrap();
-        let token = issuer_a.fetch_jwt_svid(&pod(), "aud").unwrap();
-        let mut validation = Validation::new(Algorithm::EdDSA);
-        validation.set_audience(&["aud"]);
-        validation.set_issuer(&[issuer_a.issuer()]);
-        // Wrong key → InvalidSignature.
-        let result = decode::<SvidClaims>(&token, &issuer_b.decoding_key(), &validation);
-        assert!(result.is_err(), "wrong-key verification must fail");
-    }
-
-    #[test]
-    fn nucleus_kind_round_trips() {
-        let issuer = LocalIssuer::random().unwrap();
-        let token = issuer
-            .fetch_jwt_svid_with_kind(&pod(), "aud", Some("llm_call"))
-            .unwrap();
-        let mut validation = Validation::new(Algorithm::EdDSA);
-        validation.set_audience(&["aud"]);
-        validation.set_issuer(&[issuer.issuer()]);
-        let decoded = decode::<SvidClaims>(&token, &issuer.decoding_key(), &validation).unwrap();
-        assert_eq!(decoded.claims.nucleus_kind.as_deref(), Some("llm_call"));
-    }
-
-    #[test]
-    fn key_id_is_stable_across_calls() {
-        let issuer = LocalIssuer::random().unwrap();
-        let kid = issuer.key_id().to_string();
-        let token1 = issuer.fetch_jwt_svid(&pod(), "aud").unwrap();
-        let token2 = issuer.fetch_jwt_svid(&pod(), "aud").unwrap();
-        for token in [&token1, &token2] {
-            let header = jsonwebtoken::decode_header(token).unwrap();
-            assert_eq!(header.kid.as_deref(), Some(kid.as_str()));
-        }
-    }
-
-    #[test]
-    fn verifying_key_bytes_match_signing_key() {
-        let bytes: [u8; 32] = [3; 32];
-        let sk = SigningKey::from_bytes(&bytes);
-        let issuer =
-            LocalIssuer::from_signing_key(sk.clone(), "iss".into(), Duration::from_secs(60))
-                .unwrap();
-        assert_eq!(issuer.verifying_key_bytes(), sk.verifying_key().to_bytes());
-    }
-
-    #[test]
-    fn deterministic_signing_key_yields_stable_key_id() {
-        // Same signing-key bytes → same kid.
-        let bytes: [u8; 32] = [7; 32];
-        let sk1 = SigningKey::from_bytes(&bytes);
-        let sk2 = SigningKey::from_bytes(&bytes);
-        let i1 =
-            LocalIssuer::from_signing_key(sk1, "iss".to_string(), Duration::from_secs(60)).unwrap();
-        let i2 =
-            LocalIssuer::from_signing_key(sk2, "iss".to_string(), Duration::from_secs(60)).unwrap();
-        assert_eq!(i1.key_id(), i2.key_id());
     }
 }

--- a/crates/nucleus-lineage/src/lib.rs
+++ b/crates/nucleus-lineage/src/lib.rs
@@ -5,9 +5,9 @@
 //! the lineage; an optional content-hash suffix makes IDs content-addressed
 //! (identical data → identical ID, regardless of derivation path).
 //!
-//! Lineage edges form an append-only DAG persisted via the [`LineageSink`]
-//! trait. The `nucleus lineage` CLI walks this DAG to answer "where did
-//! this data come from".
+//! Lineage edges form a DAG persisted via the [`LineageSink`] trait.
+//! The `nucleus lineage` CLI walks this DAG to answer "where did this data
+//! come from".
 //!
 //! # Path scheme
 //!
@@ -19,16 +19,28 @@
 //!   /call/<uuid>/derived/sha256:<hex>                           ← downstream artifact
 //! ```
 //!
-//! The trust-domain authority and `/ns/<ns>/sa/<sa>` prefix are owned by the
-//! orchestrator (typically nucleus-node); this crate only manipulates the
-//! `/call/...` suffix.
+//! # Cargo features
+//!
+//! - `dev` *(non-default)* — enables the in-process [`LocalIssuer`]
+//!   demo JWT-SVID minter. Pulls in `jsonwebtoken`, `ed25519-dalek`, `rand`,
+//!   `base64`. **Do not enable in production.**
+//!
+//! [`LocalIssuer`]: crate::local_issuer::LocalIssuer
 
 pub mod edge;
 pub mod id;
 pub mod issuer;
+pub mod proof;
 pub mod sink;
 
+#[cfg(feature = "dev")]
+pub mod local_issuer;
+
 pub use edge::{EdgeKind, LineageEdge};
-pub use id::{CallSpiffeId, IdError};
-pub use issuer::{IdentityFetcher, IssuerError, LocalIssuer, SvidClaims};
+pub use id::{CallSpiffeId, IdError, MAX_URI_LEN};
+pub use issuer::{IdentityFetcher, IssuerError, SvidClaims};
+pub use proof::{canonical_edge_bytes, Proof};
 pub use sink::{InMemorySink, JsonlSink, LineageSink, SinkError};
+
+#[cfg(feature = "dev")]
+pub use local_issuer::LocalIssuer;

--- a/crates/nucleus-lineage/src/local_issuer.rs
+++ b/crates/nucleus-lineage/src/local_issuer.rs
@@ -1,0 +1,254 @@
+//! [`LocalIssuer`] — in-process Ed25519 JWT-SVID issuer for tests and demos.
+//!
+//! **NOT FOR PRODUCTION USE.** This module is gated behind the `dev` cargo
+//! feature (`nucleus-lineage = { features = ["dev"] }`) so production
+//! binaries cannot link or re-export it. Constructing an instance also logs
+//! a one-time `tracing::warn!` so any accidental use is immediately visible
+//! in logs.
+//!
+//! For production: write a `SpiffeWorkloadApi` impl of [`IdentityFetcher`]
+//! that connects to a real SPIRE Agent socket, and provide it to the
+//! runtime instead. No such impl ships in this repo today.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+use ed25519_dalek::pkcs8::EncodePrivateKey;
+use ed25519_dalek::{SigningKey, VerifyingKey};
+use jsonwebtoken::{Algorithm, DecodingKey, EncodingKey, Header};
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+use crate::id::CallSpiffeId;
+use crate::issuer::{IdentityFetcher, IssuerError, SvidClaims};
+
+/// One-time guard so we only `tracing::warn!` once per process about
+/// LocalIssuer being demo-only.
+static WARNED: AtomicBool = AtomicBool::new(false);
+
+fn warn_once() {
+    if WARNED
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_ok()
+    {
+        tracing::warn!(
+            target: "nucleus_lineage::local_issuer",
+            "LocalIssuer is a DEMO-ONLY in-process Ed25519 issuer. \
+             Do not use in production. Wire a SPIRE-Workload-API-backed \
+             IdentityFetcher impl instead."
+        );
+    }
+}
+
+/// In-process JWT-SVID issuer for tests and demos.
+///
+/// Holds an Ed25519 keypair generated at construction. SVIDs are signed
+/// EdDSA. The issuer URL string defaults to `nucleus-local://demo` and the
+/// SVID lifetime defaults to 5 minutes (matching SPIRE Agent's default).
+///
+/// In a process that needs to verify the SVIDs (e.g., the demo's mock LLM
+/// endpoint), call [`Self::decoding_key`] for an in-process verifier.
+pub struct LocalIssuer {
+    signing_key: SigningKey,
+    encoding_key: EncodingKey,
+    verifying_key: VerifyingKey,
+    issuer: String,
+    lifetime: Duration,
+    key_id: String,
+}
+
+impl LocalIssuer {
+    /// Construct with a fresh random Ed25519 keypair.
+    pub fn random() -> Result<Self, IssuerError> {
+        Self::random_with("nucleus-local://demo".to_string(), Duration::from_secs(300))
+    }
+
+    /// Construct with a fresh random keypair and explicit issuer/lifetime.
+    pub fn random_with(issuer: String, lifetime: Duration) -> Result<Self, IssuerError> {
+        let mut csprng = rand::rngs::OsRng;
+        let signing_key = SigningKey::generate(&mut csprng);
+        Self::from_signing_key(signing_key, issuer, lifetime)
+    }
+
+    /// Construct around a caller-provided signing key. Useful for tests
+    /// that want deterministic SVIDs.
+    pub fn from_signing_key(
+        signing_key: SigningKey,
+        issuer: String,
+        lifetime: Duration,
+    ) -> Result<Self, IssuerError> {
+        warn_once();
+        let pkcs8 = signing_key
+            .to_pkcs8_der()
+            .map_err(|e| IssuerError::KeyEncoding(e.to_string()))?;
+        let encoding_key = EncodingKey::from_ed_der(pkcs8.as_bytes());
+        let verifying_key = signing_key.verifying_key();
+        // Stable kid: short hash of the public key bytes.
+        let mut h = Sha256::new();
+        h.update(verifying_key.as_bytes());
+        let kid_bytes = h.finalize();
+        let key_id = URL_SAFE_NO_PAD.encode(&kid_bytes[..12]);
+        Ok(Self {
+            signing_key,
+            encoding_key,
+            verifying_key,
+            issuer,
+            lifetime,
+            key_id,
+        })
+    }
+
+    /// The issuer URL ("iss" claim) used by this issuer.
+    pub fn issuer(&self) -> &str {
+        &self.issuer
+    }
+
+    /// JWK key id used in JWT headers and (future) JWKS publication.
+    pub fn key_id(&self) -> &str {
+        &self.key_id
+    }
+
+    /// Verifying key for in-process JWT validation.
+    pub fn decoding_key(&self) -> DecodingKey {
+        DecodingKey::from_ed_der(self.verifying_key.as_bytes())
+    }
+
+    /// Raw verifying key bytes (32 bytes Ed25519 public key) for sharing
+    /// with external verifiers that already speak Ed25519.
+    pub fn verifying_key_bytes(&self) -> [u8; 32] {
+        self.verifying_key.to_bytes()
+    }
+
+    /// Raw signing key (useful for tests that want to construct another
+    /// issuer with the same identity).
+    pub fn signing_key(&self) -> &SigningKey {
+        &self.signing_key
+    }
+}
+
+impl IdentityFetcher for LocalIssuer {
+    fn fetch_jwt_svid(
+        &self,
+        subject: &CallSpiffeId,
+        audience: &str,
+    ) -> Result<String, IssuerError> {
+        self.fetch_jwt_svid_with_kind(subject, audience, None)
+    }
+
+    fn fetch_jwt_svid_with_kind(
+        &self,
+        subject: &CallSpiffeId,
+        audience: &str,
+        kind: Option<&str>,
+    ) -> Result<String, IssuerError> {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(|_| IssuerError::Clock)?
+            .as_secs();
+        let claims = SvidClaims {
+            sub: subject.to_string(),
+            aud: audience.to_string(),
+            iss: self.issuer.clone(),
+            iat: now,
+            exp: now + self.lifetime.as_secs(),
+            jti: Uuid::new_v4().to_string(),
+            nucleus_kind: kind.map(|s| s.to_string()),
+        };
+        let mut header = Header::new(Algorithm::EdDSA);
+        header.kid = Some(self.key_id.clone());
+        let token = jsonwebtoken::encode(&header, &claims, &self.encoding_key)
+            .map_err(|e| IssuerError::Backend(e.to_string()))?;
+        Ok(token)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jsonwebtoken::{decode, Validation};
+
+    fn pod() -> CallSpiffeId {
+        CallSpiffeId::pod("prod.example.com", "agents", "coder").unwrap()
+    }
+
+    #[test]
+    fn local_issuer_mints_jwt_with_correct_claims() {
+        let issuer = LocalIssuer::random().unwrap();
+        let p = pod();
+        let token = issuer
+            .fetch_jwt_svid(&p, "https://api.anthropic.com")
+            .unwrap();
+        assert_eq!(token.matches('.').count(), 2);
+
+        let mut validation = Validation::new(Algorithm::EdDSA);
+        validation.set_audience(&["https://api.anthropic.com"]);
+        validation.set_issuer(&[issuer.issuer()]);
+        let decoded = decode::<SvidClaims>(&token, &issuer.decoding_key(), &validation).unwrap();
+
+        assert_eq!(decoded.claims.sub, p.to_string());
+        assert_eq!(decoded.claims.aud, "https://api.anthropic.com");
+        assert_eq!(decoded.claims.iss, issuer.issuer());
+        assert!(decoded.claims.exp > decoded.claims.iat);
+        assert!(!decoded.claims.jti.is_empty());
+    }
+
+    #[test]
+    fn jwt_signature_verifies_only_with_matching_key() {
+        let issuer_a = LocalIssuer::random().unwrap();
+        let issuer_b = LocalIssuer::random().unwrap();
+        let token = issuer_a.fetch_jwt_svid(&pod(), "aud").unwrap();
+        let mut validation = Validation::new(Algorithm::EdDSA);
+        validation.set_audience(&["aud"]);
+        validation.set_issuer(&[issuer_a.issuer()]);
+        let result = decode::<SvidClaims>(&token, &issuer_b.decoding_key(), &validation);
+        assert!(result.is_err(), "wrong-key verification must fail");
+    }
+
+    #[test]
+    fn nucleus_kind_round_trips() {
+        let issuer = LocalIssuer::random().unwrap();
+        let token = issuer
+            .fetch_jwt_svid_with_kind(&pod(), "aud", Some("llm_call"))
+            .unwrap();
+        let mut validation = Validation::new(Algorithm::EdDSA);
+        validation.set_audience(&["aud"]);
+        validation.set_issuer(&[issuer.issuer()]);
+        let decoded = decode::<SvidClaims>(&token, &issuer.decoding_key(), &validation).unwrap();
+        assert_eq!(decoded.claims.nucleus_kind.as_deref(), Some("llm_call"));
+    }
+
+    #[test]
+    fn key_id_is_stable_across_calls() {
+        let issuer = LocalIssuer::random().unwrap();
+        let kid = issuer.key_id().to_string();
+        let token1 = issuer.fetch_jwt_svid(&pod(), "aud").unwrap();
+        let token2 = issuer.fetch_jwt_svid(&pod(), "aud").unwrap();
+        for token in [&token1, &token2] {
+            let header = jsonwebtoken::decode_header(token).unwrap();
+            assert_eq!(header.kid.as_deref(), Some(kid.as_str()));
+        }
+    }
+
+    #[test]
+    fn verifying_key_bytes_match_signing_key() {
+        let bytes: [u8; 32] = [3; 32];
+        let sk = SigningKey::from_bytes(&bytes);
+        let issuer =
+            LocalIssuer::from_signing_key(sk.clone(), "iss".into(), Duration::from_secs(60))
+                .unwrap();
+        assert_eq!(issuer.verifying_key_bytes(), sk.verifying_key().to_bytes());
+    }
+
+    #[test]
+    fn deterministic_signing_key_yields_stable_key_id() {
+        let bytes: [u8; 32] = [7; 32];
+        let sk1 = SigningKey::from_bytes(&bytes);
+        let sk2 = SigningKey::from_bytes(&bytes);
+        let i1 =
+            LocalIssuer::from_signing_key(sk1, "iss".to_string(), Duration::from_secs(60)).unwrap();
+        let i2 =
+            LocalIssuer::from_signing_key(sk2, "iss".to_string(), Duration::from_secs(60)).unwrap();
+        assert_eq!(i1.key_id(), i2.key_id());
+    }
+}

--- a/crates/nucleus-lineage/src/proof.rs
+++ b/crates/nucleus-lineage/src/proof.rs
@@ -1,0 +1,309 @@
+//! Cryptographic proof carried alongside [`LineageEdge`] records.
+//!
+//! This module ships the **wire format** for proofs and the **canonical-bytes
+//! computation** that proofs are signed over. Actual signing/verification
+//! happens in the issuer impl (e.g. [`LocalIssuer`](crate::local_issuer)) and
+//! in a future verifier — those land in PR-D.
+//!
+//! Today, [`LineageEdge::proof`] is `None` for every edge produced by this
+//! crate (legacy/unsigned). This module exists so the wire format has a slot
+//! for the cryptographic evidence — adding signing later does not require a
+//! breaking change to the JSONL log format.
+//!
+//! # Canonical encoding
+//!
+//! [`canonical_edge_bytes`] returns the bytes a signer should sign and a
+//! verifier should verify against. The encoding is deterministic:
+//!
+//! 1. `child` SPIFFE ID, NUL-separated
+//! 2. `kind` discriminator (snake_case), NUL-separated
+//! 3. parent SPIFFE IDs in given order, each NUL-separated
+//! 4. content hash (32 zero bytes if absent)
+//! 5. RFC3339 timestamp string, NUL-separated
+//! 6. previous edge's content hash from the proof chain (32 zero bytes if absent)
+//!
+//! Field-bag attributes (`attrs`) are intentionally NOT covered — they are
+//! free-form metadata; the signed surface is the structural lineage edge.
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::edge::{EdgeKind, LineageEdge};
+
+/// A cryptographic proof attached to a [`LineageEdge`].
+///
+/// `kid` and `alg` are JWS-style identifiers so a future JWKS-backed
+/// verifier can pick the right verifying key + algorithm. `sig` is the raw
+/// signature bytes over [`canonical_edge_bytes`]. `prev_hash` is the SHA-256
+/// of the previous edge's canonical bytes, forming a hash chain.
+///
+/// Wire format is JSON-stable — add fields with `#[serde(default)]` only,
+/// never remove or rename existing ones.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Proof {
+    /// JWS key id; resolves to a verifying key via the issuer's JWKS.
+    pub kid: String,
+    /// JWS algorithm string (e.g., "EdDSA"). String not enum so we don't
+    /// pin the verifier to a specific JWT library.
+    pub alg: String,
+    /// Raw signature bytes over [`canonical_edge_bytes`].
+    #[serde(with = "base64_bytes")]
+    pub sig: Vec<u8>,
+    /// SHA-256 of the previous edge's canonical bytes (hash chain). `None`
+    /// for the first edge in a log.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "opt_hash_hex"
+    )]
+    pub prev_hash: Option<[u8; 32]>,
+}
+
+impl Proof {
+    /// Construct a Proof. Validation of the signature happens in the
+    /// verifier — this constructor just builds the wire object.
+    pub fn new(kid: impl Into<String>, alg: impl Into<String>, sig: Vec<u8>) -> Self {
+        Self {
+            kid: kid.into(),
+            alg: alg.into(),
+            sig,
+            prev_hash: None,
+        }
+    }
+
+    /// Builder: attach a previous-edge hash for chaining.
+    pub fn with_prev_hash(mut self, prev_hash: [u8; 32]) -> Self {
+        self.prev_hash = Some(prev_hash);
+        self
+    }
+}
+
+/// Compute the canonical bytes that a [`LineageEdge`]'s [`Proof`] is signed
+/// over. Stable across calls. See module docs for the encoding rules.
+pub fn canonical_edge_bytes(edge: &LineageEdge, prev_hash: Option<&[u8; 32]>) -> Vec<u8> {
+    let mut out = Vec::with_capacity(512);
+    let push_field = |out: &mut Vec<u8>, s: &str| {
+        out.extend_from_slice(s.as_bytes());
+        out.push(0); // NUL separator — never appears inside SPIFFE IDs (hardened parser)
+    };
+
+    push_field(&mut out, edge.child.as_str());
+    push_field(&mut out, kind_tag(&edge.kind));
+    for parent in &edge.parents {
+        push_field(&mut out, parent.as_str());
+    }
+    // Empty marker between parents and the rest, so any future addition
+    // of more parents doesn't shift the trailing bytes' meaning.
+    out.push(0);
+
+    if let Some(hex) = edge.content_hash_hex.as_deref() {
+        out.extend_from_slice(hex.as_bytes());
+    } else {
+        out.extend_from_slice(&[0u8; 64]); // 64 zero ASCII bytes = "no content hash"
+    }
+    out.push(0);
+
+    push_field(&mut out, &edge.ts.to_rfc3339());
+
+    if let Some(h) = prev_hash {
+        out.extend_from_slice(h);
+    } else {
+        out.extend_from_slice(&[0u8; 32]);
+    }
+
+    out
+}
+
+/// Compute the SHA-256 of an edge's canonical bytes — useful as a
+/// `prev_hash` for the next edge in a chain.
+pub fn edge_content_hash(edge: &LineageEdge, prev_hash: Option<&[u8; 32]>) -> [u8; 32] {
+    let mut h = Sha256::new();
+    h.update(canonical_edge_bytes(edge, prev_hash));
+    h.finalize().into()
+}
+
+/// Stable string tag for an [`EdgeKind`]. Mirrors what serde would emit
+/// for `#[serde(tag = "kind", rename_all = "snake_case")]`. Centralized so
+/// the canonical encoding doesn't depend on serde's runtime.
+fn kind_tag(kind: &EdgeKind) -> &'static str {
+    match kind {
+        EdgeKind::PodAdmit => "pod_admit",
+        EdgeKind::ToolCall { .. } => "tool_call",
+        EdgeKind::LlmCall { .. } => "llm_call",
+        EdgeKind::ArtifactProduced => "artifact_produced",
+        EdgeKind::Merge => "merge",
+        EdgeKind::Other { .. } => "other",
+    }
+}
+
+// ── serde helpers ───────────────────────────────────────────────────────
+
+mod base64_bytes {
+    use base64::{engine::general_purpose::STANDARD, Engine as _};
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(v: &Vec<u8>, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(&STANDARD.encode(v))
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Vec<u8>, D::Error> {
+        let s = String::deserialize(d)?;
+        STANDARD.decode(s).map_err(serde::de::Error::custom)
+    }
+}
+
+mod opt_hash_hex {
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(v: &Option<[u8; 32]>, s: S) -> Result<S::Ok, S::Error> {
+        match v {
+            Some(bytes) => s.serialize_str(&hex::encode(bytes)),
+            None => s.serialize_none(),
+        }
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Option<[u8; 32]>, D::Error> {
+        let opt = Option::<String>::deserialize(d)?;
+        match opt {
+            None => Ok(None),
+            Some(s) => {
+                let bytes = hex::decode(&s).map_err(serde::de::Error::custom)?;
+                if bytes.len() != 32 {
+                    return Err(serde::de::Error::custom(format!(
+                        "expected 32 bytes (64 hex chars), got {}",
+                        bytes.len()
+                    )));
+                }
+                let mut out = [0u8; 32];
+                out.copy_from_slice(&bytes);
+                Ok(Some(out))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::edge::{EdgeKind, LineageEdge};
+    use crate::id::CallSpiffeId;
+
+    fn pod() -> CallSpiffeId {
+        CallSpiffeId::pod("prod.example.com", "agents", "coder").unwrap()
+    }
+
+    #[test]
+    fn proof_round_trips_through_json() {
+        let p = Proof::new("kid-abc", "EdDSA", vec![1, 2, 3, 4, 5]).with_prev_hash([0xAA; 32]);
+        let json = serde_json::to_string(&p).unwrap();
+        let back: Proof = serde_json::from_str(&json).unwrap();
+        assert_eq!(p, back);
+    }
+
+    #[test]
+    fn proof_skips_prev_hash_when_none() {
+        let p = Proof::new("kid", "EdDSA", vec![1, 2, 3]);
+        let json = serde_json::to_string(&p).unwrap();
+        assert!(!json.contains("prev_hash"));
+    }
+
+    #[test]
+    fn canonical_bytes_are_deterministic() {
+        let p = pod();
+        let child = p.derive_tool("Bash", Some(b"x")).unwrap();
+        let edge = LineageEdge::from_parent(
+            child,
+            p,
+            EdgeKind::ToolCall {
+                tool: "Bash".to_string(),
+            },
+        );
+        let bytes1 = canonical_edge_bytes(&edge, None);
+        let bytes2 = canonical_edge_bytes(&edge, None);
+        assert_eq!(bytes1, bytes2);
+    }
+
+    #[test]
+    fn canonical_bytes_change_if_child_changes() {
+        let p = pod();
+        let edge_a = LineageEdge::from_parent(
+            p.derive_tool("Bash", Some(b"a")).unwrap(),
+            p.clone(),
+            EdgeKind::ToolCall {
+                tool: "Bash".to_string(),
+            },
+        );
+        let edge_b = LineageEdge::from_parent(
+            p.derive_tool("Bash", Some(b"b")).unwrap(),
+            p,
+            EdgeKind::ToolCall {
+                tool: "Bash".to_string(),
+            },
+        );
+        assert_ne!(
+            canonical_edge_bytes(&edge_a, None),
+            canonical_edge_bytes(&edge_b, None)
+        );
+    }
+
+    #[test]
+    fn canonical_bytes_change_if_prev_hash_changes() {
+        let p = pod();
+        let child = p.derive_tool("Bash", Some(b"x")).unwrap();
+        let edge = LineageEdge::from_parent(
+            child,
+            p,
+            EdgeKind::ToolCall {
+                tool: "Bash".to_string(),
+            },
+        );
+        let bytes_none = canonical_edge_bytes(&edge, None);
+        let bytes_some = canonical_edge_bytes(&edge, Some(&[0xAA; 32]));
+        assert_ne!(bytes_none, bytes_some);
+    }
+
+    #[test]
+    fn edge_content_hash_is_deterministic_and_32_bytes() {
+        let p = pod();
+        let child = p.derive_artifact(b"hello").unwrap();
+        let edge = LineageEdge::from_parent(child, p, EdgeKind::ArtifactProduced);
+        let h1 = edge_content_hash(&edge, None);
+        let h2 = edge_content_hash(&edge, None);
+        assert_eq!(h1, h2);
+        assert_eq!(h1.len(), 32);
+    }
+
+    #[test]
+    fn prev_hash_chains_via_canonical_bytes() {
+        let p = pod();
+        let edge1 = LineageEdge::from_parent(
+            p.derive_tool("Bash", Some(b"1")).unwrap(),
+            p.clone(),
+            EdgeKind::ToolCall {
+                tool: "Bash".to_string(),
+            },
+        );
+        let h1 = edge_content_hash(&edge1, None);
+
+        let edge2 = LineageEdge::from_parent(
+            p.derive_tool("Bash", Some(b"2")).unwrap(),
+            p,
+            EdgeKind::ToolCall {
+                tool: "Bash".to_string(),
+            },
+        );
+        let h2_chained = edge_content_hash(&edge2, Some(&h1));
+        let h2_unchained = edge_content_hash(&edge2, None);
+        assert_ne!(h2_chained, h2_unchained, "chain must affect hash");
+    }
+
+    #[test]
+    fn pod_admit_canonical_bytes_have_no_parents() {
+        let edge = LineageEdge::pod_admit(pod());
+        let bytes = canonical_edge_bytes(&edge, None);
+        // child + kind tag should be present
+        assert!(bytes
+            .windows(7)
+            .any(|w| w == b"agents/" || w == b"sa/code" || w.starts_with(b"spiffe:")));
+    }
+}

--- a/crates/nucleus-spec/src/lib.rs
+++ b/crates/nucleus-spec/src/lib.rs
@@ -480,9 +480,17 @@ impl CredentialsSpec {
 
 /// A single OIDC workload-identity binding.
 ///
-/// At pod start, the runtime fetches a JWT from `source` with the configured
-/// `audience`, writes it to `token_path` on a memory-backed tmpfs, and refreshes
-/// before expiry per `refresh`. The workload reads the file path via `env_var`.
+/// **Status: draft RFC, no runtime consumer in this repo today.** This type
+/// parses and serializes; nothing in `nucleus`, `nucleus-tool-proxy`,
+/// `nucleus-node`, or `nucleus-mcp` reads `credentials.workload_identity` yet.
+/// A `PodSpec` that sets this field will start the pod normally — but no token
+/// file appears, no env var is set, and no audit record is emitted. Wait for
+/// the runtime PR before depending on the documented behavior below.
+///
+/// **Intended (not yet implemented) behavior:** at pod start, the runtime
+/// fetches a JWT from `source` with the configured `audience`, writes it to
+/// `token_path` on a memory-backed tmpfs, and refreshes before expiry per
+/// `refresh`. The workload reads the file path via `env_var`.
 ///
 /// This type is provider-agnostic. The orchestrator (or operator) chooses the
 /// `audience` value for whichever relying party the workload calls.
@@ -491,7 +499,10 @@ pub struct WorkloadIdentitySpec {
     /// Logical name (e.g. "anthropic", "openai-prod"). Used in audit records.
     pub name: String,
 
-    /// OIDC audience to request. Provider-defined; nucleus does not validate.
+    /// OIDC audience to request. Provider-defined; **nucleus does not yet
+    /// validate** that this is a well-formed URL or coordinate against an
+    /// allow-list. A typo here will silently produce a JWT no relying party
+    /// accepts. Validation is tracked for the runtime PR.
     /// Examples: `https://api.anthropic.com`, `https://api.openai.com`.
     pub audience: String,
 
@@ -549,8 +560,11 @@ pub enum IdentitySource {
         /// Requested token lifetime in seconds.
         expiration_seconds: u64,
     },
-    /// Read a pre-provisioned static JWT from disk. For testing or for issuers
-    /// that do not support online refresh.
+    /// Read a pre-provisioned static JWT from disk. For **testing** or for
+    /// issuers that do not support online refresh. Production deployments
+    /// should not use this variant: the (planned) runtime will not validate
+    /// the JWT's signature or expiry before serving it, and there is no
+    /// path-canonicalization or symlink restriction.
     StaticFile { path: PathBuf },
 }
 


### PR DESCRIPTION
## Summary

Three audit findings addressed in one PR (they share a `Cargo.toml` + wire-format surface). **Stacks on PR-A (#1613) + PR-B (#1614)**.

## CRIT-6: `LocalIssuer` behind a non-default `dev` feature

The audit flagged that `LocalIssuer` was publicly exported with no programmatic guard. A copy-paste programmer was a `Box::new(LocalIssuer::random())` away from shipping demo crypto in production — especially since the README (now fixed in #1613) had directed them to a SPIRE impl that doesn't exist.

- New module `local_issuer` gated `#[cfg(feature = "dev")]`. Pulls `jsonwebtoken`/`ed25519-dalek`/`rand` under the same gate.
- `dev` feature is non-default. `base64` stays unconditional (used by the always-on `Proof` wire format).
- `LocalIssuer::from_signing_key` emits a one-time `tracing::warn!` per process: *"DEMO-ONLY in-process Ed25519 issuer. Do not use in production."*
- `examples/three_step_demo` declares `required-features = ["dev"]`.
- `IssuerError` no longer carries a `jsonwebtoken::Error` variant — the `IdentityFetcher` trait and `SvidClaims` now compile without any crypto deps. Production impls write their own.

## Wire-format slot for cryptographic proof

Audit's CRIT-1 / CRIT-4 flagged that edges aren't signed (no chain, no signatures). This PR doesn't yet *add* signing — that's PR-D — but adds the wire-format slot so PR-D is not a breaking JSONL format change.

New `proof` module ships:

- `Proof { kid, alg, sig, prev_hash }` — JWS-style ids, raw signature bytes (base64 in JSON), optional previous-edge hash for chain construction.
- `canonical_edge_bytes(edge, prev_hash) -> Vec<u8>` — deterministic encoding the proof is signed over: child / kind tag / parents / content hash / RFC3339 ts / prev_hash. NUL-separated. `attrs` are intentionally NOT covered (free-form metadata, not part of the signed surface).
- `edge_content_hash(edge, prev_hash) -> [u8; 32]` — SHA-256 of the canonical bytes; this is what becomes the next edge's `prev_hash`.

`LineageEdge` gains `proof: Option<Proof>` (None = legacy/unsigned). `with_proof(p)` builder.

## CRIT-5: walker structural-parent verification

The audit demonstrated forging a victim pod's SPIFFE ID as parent of an attacker artifact in one JSONL line; the walker happily included it.

`nucleus-cli/src/lineage.rs::is_structurally_consistent`:

- `PodAdmit` edges must have empty `parents`.
- Most kinds: every parent must be a SPIFFE-string-prefix of the child, and the child path must continue with `/call/`.
- `Merge` edges: parents may be siblings (not direct ancestors) but must share the trust-domain authority with the child.

`walk_ancestors` / `walk_descendants` filter forged edges by default with a stderr warning. New `--allow-forged` CLI flag passes them through (forensic mode).

## Test plan

- [x] `cargo test -p nucleus-lineage` (default features) — **51 passed** (was 49; 2 new `proof` tests)
- [x] `cargo test -p nucleus-lineage --features dev` — **57 passed** (6 LocalIssuer tests under the gate)
- [x] `cargo test -p nucleus-cli lineage::` — **13 passed** (was 8; 5 new tests around `is_structurally_consistent` + replicating CRIT-5's forged-edge attack and verifying it's blocked)
- [x] `cargo build -p nucleus-lineage` — clean (no crypto deps pulled into default)
- [x] `cargo build -p nucleus-lineage --features dev` — clean
- [x] `cargo build -p nucleus-lineage --example three_step_demo --features dev` — clean
- [x] `cargo clippy -p nucleus-lineage -p nucleus-cli --no-deps --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

## Tracking the rest of the audit

- ✅ PR-A (#1613) — README + spec docs honest
- ✅ PR-B (#1614) — parser hardening + negative tests
- 🟢 **PR-C (this PR)** — LocalIssuer dev gate + Proof field + walker structural verify
- 🟡 PR-D — actual edge signing (`IdentityFetcher::sign_edge`) + JWKS publication + walker signature verify + demo honesty (--real-claude attrs, mock-LLM cross-process JWKS, drop bash -c)

🤖 Generated with [Claude Code](https://claude.com/claude-code)