### PR TITLE
chore: cargo-metadata + vendor-neutrality manifest guards (dedicated job)

### DIFF
--- a/.github/workflows/manifest-guards.yml
+++ b/.github/workflows/manifest-guards.yml
@@ -1,0 +1,58 @@
+name: Manifest Guards
+
+# Fast, repo-wide guards that gate every PR independently of the heavy Test
+# Suite (fmt / clippy / build / test / fuzz). Two proof obligations:
+#
+#   1. cargo-metadata smoke — the WHOLE workspace parses: no duplicate
+#      [dependencies] tables, no malformed manifests, no broken path deps.
+#      Asserts exit 0 AND empty stderr (Cargo prints manifest warnings there).
+#      Unlike oidc-gates.yml (which is path-scoped to the OIDC crates), this
+#      runs on every PR so a manifest regression anywhere is caught.
+#
+#   2. vendor neutrality — public nucleus source stays free of vendor-specific
+#      identifiers (claude / anthropic / openai / ...). Delegates to
+#      ci/no-vendor-strings.sh so the allowlist logic (`# vendor-allow:`) has a
+#      single source of truth. Scoped to the same crates oidc-gates enforces;
+#      a future change can widen SCAN_PATHS once a tree-wide allowlist baseline
+#      is curated (a naive tree-wide scan floods on boundary-describing docs).
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+  merge_group:
+
+permissions:
+  contents: read
+
+jobs:
+  manifest-guards:
+    name: Manifest Guards
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      CARGO_TERM_COLOR: never
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1
+        with:
+          cache: true
+
+      - name: Cargo metadata smoke (whole workspace parses, empty stderr)
+        run: |
+          set -euo pipefail
+          if ! cargo metadata --format-version 1 --no-deps >/dev/null 2>meta.err; then
+            echo "::error::cargo metadata failed — manifest corruption, duplicate table, or bad path dep"
+            cat meta.err >&2
+            exit 1
+          fi
+          if [ -s meta.err ]; then
+            echo "::error::cargo metadata emitted warnings/errors on stderr"
+            cat meta.err >&2
+            exit 1
+          fi
+          echo "cargo metadata OK (empty stderr)"
+
+      - name: Vendor neutrality (no claude/anthropic/openai in source)
+        run: bash ci/no-vendor-strings.sh


### PR DESCRIPTION
## Summary

Adds a dedicated, fast **Manifest Guards** CI workflow (`.github/workflows/manifest-guards.yml`) that gates every PR independently of the heavy Test Suite (fmt / clippy / build / test / fuzz):

1. **cargo-metadata smoke** — `cargo metadata --format-version 1 --no-deps` must exit 0 **and** emit empty stderr. This catches manifest corruption, duplicate `[dependencies]` tables, malformed manifests, and broken path deps anywhere in the workspace. The existing `oidc-gates.yml` is path-scoped to the OIDC crates, so a manifest break elsewhere is currently ungated — this closes that gap.
2. **vendor neutrality** — delegates to the existing `ci/no-vendor-strings.sh` so the allowlist logic (`# vendor-allow:` escape hatch) stays a single source of truth. Keeps the public, vendor-neutral slice of nucleus free of claude / anthropic / openai identifiers.

Uses the repo's pinned-SHA action convention (`actions/checkout`, `actions-rust-lang/setup-rust-toolchain`) and the `push`/`pull_request`/`merge_group` triggers used by the other workflows.

## On the proposal's "manifest dup-table corruption" (#4)

Investigated and **confirmed NOT a real defect**. `crates/nucleus/Cargo.toml` and `crates/nucleus-ifc/Cargo.toml` are clean single-table manifests, and a workspace-wide scan found **zero** duplicate `[dependencies]` tables. `cargo metadata --no-deps` parses with empty stderr. No manifest edits were necessary — the value here is the guard that would catch such corruption if it ever appears.

## Vendor-neutrality scope (follow-up, not in this PR)

`ci/no-vendor-strings.sh` currently scans only `crates/nucleus-oidc-core` + `crates/nucleus-oidc-provider` by default (it runs green there). A tree-wide scan surfaces ~600 hits that are almost entirely legitimate (boundary-describing docs, security threat-model examples, GitHub/Fly.io infra URLs, CTF fake-token fixtures, vendor-neutrality comments). Widening `SCAN_PATHS` repo-wide requires curating an allowlist baseline first, so it is deliberately deferred rather than shipped as a red gate.

## Verification (run locally in the worktree)

- `cargo metadata --format-version 1 --no-deps` → exit 0, **0-byte stderr**
- `bash ci/no-vendor-strings.sh` → exit 0 ("vendor-neutrality CI gate clean")
- YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`)

---

DRAFT — held for stakeholder review. Part of the constellation cleanup. Do not merge without sign-off.
