### PR TITLE
ci(verifier): in-browser tamper demo + real fixtures, published at /verify/

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,6 +9,8 @@ on:
       - "slides/**"
       - "blog/**"
       - "book.toml"
+      - "sdks/verifier-js/**"
+      - "crates/nucleus-envelope/**"
       - ".github/workflows/docs.yml"
 
 permissions:
@@ -42,6 +44,26 @@ jobs:
         run: |
           mkdir -p book/blog
           cp blog/*.md book/blog/
+      # --- In-browser verifier demo, published at /verify/ ---
+      # Real fixtures (generated + self-verified by the example) + the Rust
+      # verifier compiled to WASM. No fake data; reproducible from source.
+      - name: Build verifier WASM + real fixtures
+        run: |
+          rustup target add wasm32-unknown-unknown
+          cargo install wasm-pack --locked --version 0.13.1
+          cargo run -p nucleus-envelope --example emit_demo_bundle -- sdks/verifier-js/demo-fixtures
+          wasm-pack build sdks/verifier-js --target web --release
+      - name: Assemble /verify into the docs site
+        run: |
+          mkdir -p book/verify/pkg book/verify/demo-fixtures
+          cp sdks/verifier-js/demo.html book/verify/index.html
+          cp sdks/verifier-js/demo.js   book/verify/demo.js
+          cp sdks/verifier-js/pkg/nucleus_verifier_wasm.js \
+             sdks/verifier-js/pkg/nucleus_verifier_wasm_bg.wasm \
+             sdks/verifier-js/pkg/*.d.ts \
+             book/verify/pkg/
+          cp sdks/verifier-js/demo-fixtures/*.json book/verify/demo-fixtures/
+          touch book/.nojekyll
       - name: Upload artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:

--- a/crates/nucleus-envelope/examples/emit_demo_bundle.rs
+++ b/crates/nucleus-envelope/examples/emit_demo_bundle.rs
@@ -1,0 +1,208 @@
+//! Emit REAL signed bundles + matching trust anchors for the in-browser
+//! verifier demo (`sdks/verifier-js/demo.html`). No fake data: every edge is
+//! Ed25519-signed and hash-chained, the Merkle anchor is witness-cosigned, and
+//! this binary asserts the bundles verify (and that a one-byte tamper is
+//! rejected) before writing them — so the committed fixtures are exactly what
+//! the demo claims.
+//!
+//! Usage: `cargo run -p nucleus-envelope --example emit_demo_bundle -- <out_dir>`
+//! (defaults to `sdks/verifier-js/demo-fixtures`).
+
+use std::path::{Path, PathBuf};
+
+use nucleus_envelope::{verify_bundle, Bundle, BundleBuilder, TrustAnchor};
+use nucleus_lineage::{
+    edge_content_hash, CallSpiffeId, Ed25519Witness, EdgeKind, EdgeSigner, Jwks, LineageEdge,
+    LineageSink, LocalIssuer, MerkleConfig, MerkleSink, Proof,
+};
+
+fn pod() -> CallSpiffeId {
+    CallSpiffeId::pod("prod.example.com", "agents", "summarizer").unwrap()
+}
+
+/// Sign `edge` with `issuer`, chaining against `prev` (mirrors the e2e test).
+fn signed_edge(
+    issuer: &LocalIssuer,
+    mut edge: LineageEdge,
+    prev: Option<&[u8; 32]>,
+) -> LineageEdge {
+    let bytes = nucleus_lineage::canonical_edge_bytes(&edge, prev);
+    let sig = issuer.sign(&bytes).unwrap();
+    let mut proof = Proof::new(issuer.kid(), issuer.alg(), sig);
+    if let Some(h) = prev {
+        proof = proof.with_prev_hash(*h);
+    }
+    edge.proof = Some(proof);
+    edge
+}
+
+/// Emit a fully-signed 3-edge session: pod_admit -> ToolCall(Read) -> ArtifactProduced.
+fn populate_session(sink: &dyn LineageSink, issuer: &LocalIssuer) {
+    let p = pod();
+
+    let e1 = signed_edge(issuer, LineageEdge::pod_admit(p.clone()), None);
+    let h1 = edge_content_hash(&e1, None);
+    sink.emit(e1).unwrap();
+
+    let tool = p.derive_tool("Read", Some(b"input bytes")).unwrap();
+    let e2 = signed_edge(
+        issuer,
+        LineageEdge::from_parent(
+            tool.clone(),
+            p,
+            EdgeKind::ToolCall {
+                tool: "Read".to_string(),
+            },
+        ),
+        Some(&h1),
+    );
+    let h2 = edge_content_hash(&e2, Some(&h1));
+    sink.emit(e2).unwrap();
+
+    let leaf = tool.derive_artifact(b"summarized output").unwrap();
+    let e3 = signed_edge(
+        issuer,
+        LineageEdge::from_parent(leaf, tool, EdgeKind::ArtifactProduced),
+        Some(&h2),
+    );
+    sink.emit(e3).unwrap();
+}
+
+/// Flip one hex nibble in the serialized bundle and assert it no longer
+/// verifies — the demo's core claim, checked at generation time.
+fn assert_tamper_rejected(bundle_json: &str, anchor: &TrustAnchor) {
+    // Find a long hex run (a signature / hash) and flip its first nibble.
+    let bytes = bundle_json.as_bytes();
+    let mut run_start = None;
+    let mut run_len = 0usize;
+    let mut flip_at = None;
+    for (i, &b) in bytes.iter().enumerate() {
+        let is_hex = b.is_ascii_hexdigit();
+        if is_hex {
+            if run_start.is_none() {
+                run_start = Some(i);
+                run_len = 1;
+            } else {
+                run_len += 1;
+            }
+            if run_len >= 40 {
+                flip_at = run_start;
+                break;
+            }
+        } else {
+            run_start = None;
+            run_len = 0;
+        }
+    }
+    let flip_at = flip_at.expect("bundle JSON must contain a long hex signature/hash run");
+    let mut tampered: Vec<u8> = bundle_json.bytes().collect();
+    // 'a' <-> 'b' is always a real change for a hex nibble.
+    tampered[flip_at] = if tampered[flip_at] == b'a' {
+        b'b'
+    } else {
+        b'a'
+    };
+    let tampered = String::from_utf8(tampered).unwrap();
+    let parsed: Result<Bundle, _> = serde_json::from_str(&tampered);
+    match parsed {
+        Ok(b) => assert!(
+            verify_bundle(&b, anchor).is_err(),
+            "TAMPERED bundle MUST be rejected — demo claim would be false otherwise"
+        ),
+        Err(_) => { /* tamper broke JSON shape; that is also a rejection */ }
+    }
+}
+
+fn write(out: &Path, name: &str, contents: &str) {
+    let path = out.join(name);
+    std::fs::write(&path, contents).unwrap_or_else(|e| panic!("write {path:?}: {e}"));
+    println!("  wrote {} ({} bytes)", path.display(), contents.len());
+}
+
+fn main() {
+    let out = std::env::args()
+        .nth(1)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("sdks/verifier-js/demo-fixtures"));
+    std::fs::create_dir_all(&out).unwrap();
+
+    // ---- Fixture A: basic signed bundle (chain + JWKS only). ----
+    {
+        let issuer = LocalIssuer::random().unwrap();
+        let sink = nucleus_lineage::InMemorySink::new();
+        populate_session(&sink, &issuer);
+        let jwks: Jwks = serde_json::from_value(issuer.publish_jwks()).unwrap();
+        let bundle = BundleBuilder::new(pod())
+            .payload(serde_json::json!({
+                "stats": {"input_bytes": 11, "output_bytes": 17},
+                "summary": "summarized output"
+            }))
+            .sink(&sink)
+            .jwks(jwks)
+            .require_signed()
+            .build()
+            .expect("basic bundle must build");
+
+        let anchor = TrustAnchor::from_jwks(serde_json::from_value(issuer.publish_jwks()).unwrap());
+        let report = verify_bundle(&bundle, &anchor).expect("basic bundle must verify");
+        assert_eq!(report.edge_count, 3);
+        let bundle_json = serde_json::to_string_pretty(&bundle).unwrap();
+        assert_tamper_rejected(&bundle_json, &anchor);
+
+        let anchor_json = serde_json::to_string_pretty(&serde_json::json!({
+            "trust_jwks": issuer.publish_jwks(),
+            "allow_empty": false,
+            "cosignature_threshold": 0
+        }))
+        .unwrap();
+        write(&out, "bundle.basic.json", &bundle_json);
+        write(&out, "trust-anchor.basic.json", &anchor_json);
+    }
+
+    // ---- Fixture B: Merkle bundle witness-cosigned (the lead demo). ----
+    {
+        let dir = std::env::temp_dir().join("nucleus-demo-merkle");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let inner = nucleus_lineage::InMemorySink::new();
+        let witness = Ed25519Witness::from_seed([42u8; 32]);
+        let witness_pub = witness.verifying_key_bytes();
+        let cfg = MerkleConfig::new(&dir).with_interval(1000);
+        let sink = MerkleSink::new(inner, witness, cfg).unwrap();
+
+        let issuer = LocalIssuer::random().unwrap();
+        populate_session(&sink, &issuer);
+        let jwks: Jwks = serde_json::from_value(issuer.publish_jwks()).unwrap();
+        let bundle = BundleBuilder::new(pod())
+            .payload(serde_json::json!({"demo": "agent execution lineage", "v2": true}))
+            .sink(&sink)
+            .jwks(jwks)
+            .require_signed()
+            .with_merkle_prover(&sink)
+            .build()
+            .expect("cosigned bundle must build");
+        assert!(bundle.envelope.merkle_anchor.is_some());
+
+        let witness_hex = hex::encode(witness_pub);
+        let anchor = TrustAnchor::from_jwks(serde_json::from_value(issuer.publish_jwks()).unwrap())
+            .with_witness_pubkey(witness_pub);
+        let report = verify_bundle(&bundle, &anchor).expect("cosigned bundle must verify");
+        assert!(report.merkle_verified, "merkle_verified must hold");
+
+        let bundle_json = serde_json::to_string_pretty(&bundle).unwrap();
+        assert_tamper_rejected(&bundle_json, &anchor);
+
+        let anchor_json = serde_json::to_string_pretty(&serde_json::json!({
+            "trust_jwks": issuer.publish_jwks(),
+            "trust_witness_pubkey_hex": witness_hex,
+            "allow_empty": false,
+            "cosignature_threshold": 0
+        }))
+        .unwrap();
+        write(&out, "bundle.json", &bundle_json);
+        write(&out, "trust-anchor.json", &anchor_json);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    println!("OK — real fixtures emitted and self-verified (incl. tamper-rejection).");
+}

--- a/sdks/verifier-js/README.md
+++ b/sdks/verifier-js/README.md
@@ -175,3 +175,39 @@ cd pkg && npm publish --access public --tag next
 
 The maintainer's local credentials sign the publish; never check the
 npm token in.
+
+## In-browser tamper demo (`demo.html`)
+
+A self-contained, install-nothing page that verifies a **real** agent
+execution-lineage bundle entirely in your browser — then lets you corrupt it
+and watch the local verifier reject it. The verifier is this crate compiled to
+WASM; the bundle + trust anchor are generated and self-verified (including a
+tamper-rejection assertion) by
+`crates/nucleus-envelope/examples/emit_demo_bundle.rs` — no fake data.
+
+Run it locally:
+
+```sh
+# 1. real fixtures -> sdks/verifier-js/demo-fixtures/
+cargo run -p nucleus-envelope --example emit_demo_bundle
+
+# 2. build the WASM verifier -> sdks/verifier-js/pkg/
+wasm-pack build sdks/verifier-js --target web --release
+
+# 3. serve (file:// can't fetch the wasm/fixtures) and open /demo.html
+python3 -m http.server -d sdks/verifier-js 8000
+# -> http://localhost:8000/demo.html
+```
+
+To prove there is no server round-trip: open DevTools → Network, toggle
+**Offline**, then click Verify — it still works.
+
+Hosted: the CI `Docs` workflow builds the WASM + fixtures and publishes the demo
+at `/verify/` on the docs site (only when the `DOCS_DEPLOY` repo variable is
+`true`).
+
+**Scope (honest):** the verifier proves the lineage is tamper-evident (hash
+chain + Merkle inclusion) and authentic (signed/cosigned by the keys in *your*
+trust anchor). It does **not** prove the agent behaved well, that
+information-flow policy held, or that any computation was correct — those are
+separate guarantees (see the IFC gateway and the Lean noninterference theorem).

--- a/sdks/verifier-js/demo-fixtures/bundle.basic.json
+++ b/sdks/verifier-js/demo-fixtures/bundle.basic.json
@@ -1,0 +1,71 @@
+{
+  "payload": {
+    "stats": {
+      "input_bytes": 11,
+      "output_bytes": 17
+    },
+    "summary": "summarized output"
+  },
+  "envelope": {
+    "session_root": "spiffe://prod.example.com/ns/agents/sa/summarizer",
+    "edges": [
+      {
+        "child": "spiffe://prod.example.com/ns/agents/sa/summarizer",
+        "parents": [],
+        "kind": "pod_admit",
+        "ts": "2026-06-02T22:34:55.102938Z",
+        "proof": {
+          "kid": "0XLRa1I622CSeni9",
+          "alg": "EdDSA",
+          "sig": "0MEr5BEdPOmPdy4DUm4xborKGkwiS83bCHgOevBfPv3MxUMGd5lKuGYooNS7fcxlbWzoUyMoT251qhBlWzA3Aw=="
+        }
+      },
+      {
+        "child": "spiffe://prod.example.com/ns/agents/sa/summarizer/call/09c74409-5e99-455d-82ea-1931129fac43/tool/Read/sha256:f7c39aa7e478d51b7d49669703d94df49f158ea1d73b58760601f9c1857c4bdf",
+        "parents": [
+          "spiffe://prod.example.com/ns/agents/sa/summarizer"
+        ],
+        "kind": "tool_call",
+        "tool": "Read",
+        "ts": "2026-06-02T22:34:55.103236Z",
+        "proof": {
+          "kid": "0XLRa1I622CSeni9",
+          "alg": "EdDSA",
+          "sig": "jK5f9Yw+aBgXdaGHQmpWjbXmaaV7heXYRikv5nwm6FAYSGP4HKVLwRBthBre/YWVPQlcZsWUYOXmIz8pcqMeAw==",
+          "prev_hash": "2cdf4583cbd3b0473ae80d344cea030a1850af02b54d6964358b9d154053f331"
+        }
+      },
+      {
+        "child": "spiffe://prod.example.com/ns/agents/sa/summarizer/call/09c74409-5e99-455d-82ea-1931129fac43/tool/Read/sha256:f7c39aa7e478d51b7d49669703d94df49f158ea1d73b58760601f9c1857c4bdf/call/6e42568b-2e1a-4272-816d-ec5b38535d5b/derived/sha256:c0725d90980c6551fb9cede618e33b0fea19613278df950aee10f72b334572ed",
+        "parents": [
+          "spiffe://prod.example.com/ns/agents/sa/summarizer/call/09c74409-5e99-455d-82ea-1931129fac43/tool/Read/sha256:f7c39aa7e478d51b7d49669703d94df49f158ea1d73b58760601f9c1857c4bdf"
+        ],
+        "kind": "artifact_produced",
+        "ts": "2026-06-02T22:34:55.103531Z",
+        "proof": {
+          "kid": "0XLRa1I622CSeni9",
+          "alg": "EdDSA",
+          "sig": "WNuUfiNtKgm6YYRhZxF0u/Jo/y8MwP5IXFcLkuFR7xE67W8aWpX3KLUit8/Mb53KRmIvsItcBxzpAvVBaC5/Bg==",
+          "prev_hash": "7c47cb4021f1ac5674b38d43ba93b66c25d43b6e6d2de4b62e22d522f34c0b9f"
+        }
+      }
+    ],
+    "jwks": {
+      "keys": [
+        {
+          "kty": "OKP",
+          "crv": "Ed25519",
+          "kid": "0XLRa1I622CSeni9",
+          "x": "JpvG_RLe8o5IU8ArVr2DglJa1oVgTEinUgssgLfQlcM",
+          "alg": "EdDSA",
+          "use": "sig"
+        }
+      ]
+    },
+    "checkpoints": [],
+    "meta": {
+      "schema_version": 1,
+      "created_at": "2026-06-02T22:34:55.103912Z"
+    }
+  }
+}

--- a/sdks/verifier-js/demo-fixtures/bundle.json
+++ b/sdks/verifier-js/demo-fixtures/bundle.json
@@ -1,0 +1,91 @@
+{
+  "payload": {
+    "demo": "agent execution lineage",
+    "v2": true
+  },
+  "envelope": {
+    "session_root": "spiffe://prod.example.com/ns/agents/sa/summarizer",
+    "edges": [
+      {
+        "child": "spiffe://prod.example.com/ns/agents/sa/summarizer",
+        "parents": [],
+        "kind": "pod_admit",
+        "ts": "2026-06-02T22:34:55.138260Z",
+        "proof": {
+          "kid": "JWSz7UcSQxFpS-wn",
+          "alg": "EdDSA",
+          "sig": "5/c/quEQ9Msymny0ztz/pN3MjwaaJvpOGnr8Eg1ZWo+zezOXk4Gt+h7xjCLPSO02SVVFY/MFD4Z5lIw/+IkyBQ=="
+        }
+      },
+      {
+        "child": "spiffe://prod.example.com/ns/agents/sa/summarizer/call/1489a9d6-d2bd-4bca-811c-cdaf0b307d29/tool/Read/sha256:f7c39aa7e478d51b7d49669703d94df49f158ea1d73b58760601f9c1857c4bdf",
+        "parents": [
+          "spiffe://prod.example.com/ns/agents/sa/summarizer"
+        ],
+        "kind": "tool_call",
+        "tool": "Read",
+        "ts": "2026-06-02T22:34:55.138557Z",
+        "proof": {
+          "kid": "JWSz7UcSQxFpS-wn",
+          "alg": "EdDSA",
+          "sig": "vzHVPoXeakbWEEryPGzY4qWNslfFt2x9r4iXY4G62UElf+mZ/r/9SL2NcAA8m9JdFvMgBxBm8FPLc3/jiuO9Bg==",
+          "prev_hash": "113741fa50f4a0191849dbb72a72ba815d9dda5646595b43667df53235fbc67a"
+        }
+      },
+      {
+        "child": "spiffe://prod.example.com/ns/agents/sa/summarizer/call/1489a9d6-d2bd-4bca-811c-cdaf0b307d29/tool/Read/sha256:f7c39aa7e478d51b7d49669703d94df49f158ea1d73b58760601f9c1857c4bdf/call/8abbdaec-9db4-4ae4-91ef-ae35ebf38b1b/derived/sha256:c0725d90980c6551fb9cede618e33b0fea19613278df950aee10f72b334572ed",
+        "parents": [
+          "spiffe://prod.example.com/ns/agents/sa/summarizer/call/1489a9d6-d2bd-4bca-811c-cdaf0b307d29/tool/Read/sha256:f7c39aa7e478d51b7d49669703d94df49f158ea1d73b58760601f9c1857c4bdf"
+        ],
+        "kind": "artifact_produced",
+        "ts": "2026-06-02T22:34:55.138891Z",
+        "proof": {
+          "kid": "JWSz7UcSQxFpS-wn",
+          "alg": "EdDSA",
+          "sig": "Y3ICDWuX03dl/5REcvmLqdEe00eJkrS8iHxQW6+bV6wK2FUnsuBssw3juafGhU3IDUyzoxoH+U/tpC+flwECDw==",
+          "prev_hash": "9b26767046acbcce956e501a294cbce090c51f6971eb079709d27a6d694e0326"
+        }
+      }
+    ],
+    "jwks": {
+      "keys": [
+        {
+          "kty": "OKP",
+          "crv": "Ed25519",
+          "kid": "JWSz7UcSQxFpS-wn",
+          "x": "8bukfUIodlJAArVI4nszL8i8v9tmjOfjJ_1hJlaM2wk",
+          "alg": "EdDSA",
+          "use": "sig"
+        }
+      ]
+    },
+    "checkpoints": [],
+    "merkle_anchor": {
+      "sth": {
+        "tree_size": 3,
+        "timestamp_ms": 1780439695139,
+        "root_hash_hex": "dc27833d299ec13ba623235ffa57c5ca22b28e660389d0ac262fe2ea22dcd67a",
+        "witness_kid": "tgAwbPp2cj_ew5Xl",
+        "witness_sig": "TdXHZkF6Hb0V7me7mZ9884VnrGtEBuizVlOVc7NULy+0D4SFzcZ/V7mWdeJ2ovoGP4bxxpJwiMTvh37eQr+JAQ=="
+      },
+      "inclusion_proofs": [
+        {
+          "leaf_index": 0,
+          "audit_path_hex": "339d80d1c6ec69010ee101882964489d3f47295b4da854aa5616dff9eff7a18498db1d8d55ebba9efc1536990b4b5835d9e543286fc6adc113e5eea40fc7b66e"
+        },
+        {
+          "leaf_index": 1,
+          "audit_path_hex": "a72d9963ee2d7c6870056c0c6f1d7939c1a8970a41514a6373da55391fde7e9398db1d8d55ebba9efc1536990b4b5835d9e543286fc6adc113e5eea40fc7b66e"
+        },
+        {
+          "leaf_index": 2,
+          "audit_path_hex": "6dca290f59f64f236fd93b6755adfe2278accef2578ccbe82e1fd13da3e79298"
+        }
+      ]
+    },
+    "meta": {
+      "schema_version": 1,
+      "created_at": "2026-06-02T22:34:55.139529Z"
+    }
+  }
+}

--- a/sdks/verifier-js/demo-fixtures/trust-anchor.basic.json
+++ b/sdks/verifier-js/demo-fixtures/trust-anchor.basic.json
@@ -1,0 +1,16 @@
+{
+  "allow_empty": false,
+  "cosignature_threshold": 0,
+  "trust_jwks": {
+    "keys": [
+      {
+        "alg": "EdDSA",
+        "crv": "Ed25519",
+        "kid": "0XLRa1I622CSeni9",
+        "kty": "OKP",
+        "use": "sig",
+        "x": "JpvG_RLe8o5IU8ArVr2DglJa1oVgTEinUgssgLfQlcM"
+      }
+    ]
+  }
+}

--- a/sdks/verifier-js/demo-fixtures/trust-anchor.json
+++ b/sdks/verifier-js/demo-fixtures/trust-anchor.json
@@ -1,0 +1,17 @@
+{
+  "allow_empty": false,
+  "cosignature_threshold": 0,
+  "trust_jwks": {
+    "keys": [
+      {
+        "alg": "EdDSA",
+        "crv": "Ed25519",
+        "kid": "JWSz7UcSQxFpS-wn",
+        "kty": "OKP",
+        "use": "sig",
+        "x": "8bukfUIodlJAArVI4nszL8i8v9tmjOfjJ_1hJlaM2wk"
+      }
+    ]
+  },
+  "trust_witness_pubkey_hex": "197f6b23e16c8532c6abc838facd5ea789be0c76b2920334039bfa8b3d368d61"
+}

--- a/sdks/verifier-js/demo.html
+++ b/sdks/verifier-js/demo.html
@@ -3,120 +3,141 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>nucleus-verifier — drop-in browser verifier</title>
+    <title>nucleus — verify an agent's execution lineage in your browser</title>
     <style>
       :root {
-        --bg: #0b0d10;
-        --fg: #e8eaed;
-        --muted: #8a9098;
-        --accent: #6dd0ff;
-        --ok: #4ade80;
-        --fail: #f87171;
-        --border: #1f2329;
-        --code-bg: #11151a;
+        --bg: #0b0d10; --fg: #e8eaed; --muted: #8a9098; --accent: #6dd0ff;
+        --ok: #4ade80; --fail: #f87171; --border: #1f2329; --code-bg: #11151a;
+        --warn-bg: #14110a; --warn-border: #3a2f10;
       }
       * { box-sizing: border-box; }
       html, body {
         background: var(--bg); color: var(--fg);
         font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace;
-        margin: 0; padding: 0; min-height: 100vh;
+        margin: 0; padding: 0; min-height: 100vh; line-height: 1.5;
       }
-      main { max-width: 940px; margin: 0 auto; padding: 2.5rem 1.25rem 4rem; }
+      main { max-width: 980px; margin: 0 auto; padding: 2.5rem 1.25rem 4rem; }
       h1 { font-size: 1.5rem; margin: 0 0 0.25rem; letter-spacing: -0.02em; }
-      .subtitle { color: var(--muted); margin: 0 0 2rem; font-size: 0.9rem; }
-      label { display: block; margin: 1.25rem 0 0.4rem; font-size: 0.85rem; color: var(--muted); }
-      textarea {
-        width: 100%; min-height: 9rem;
-        background: var(--code-bg); color: var(--fg);
-        border: 1px solid var(--border); border-radius: 6px;
-        padding: 0.75rem; font-family: inherit; font-size: 0.85rem; line-height: 1.4;
-        resize: vertical;
-      }
-      textarea:focus { outline: none; border-color: var(--accent); }
-      button {
-        margin-top: 1rem; background: var(--accent); color: #0b0d10;
-        border: 0; border-radius: 6px; padding: 0.6rem 1.1rem;
-        font-family: inherit; font-weight: 600; cursor: pointer; font-size: 0.9rem;
-      }
-      button:disabled { opacity: 0.5; cursor: not-allowed; }
-      #result {
-        margin-top: 1.5rem; padding: 1rem 1.1rem;
-        background: var(--code-bg); border: 1px solid var(--border); border-radius: 6px;
-        white-space: pre-wrap; font-size: 0.85rem; line-height: 1.5; min-height: 3rem;
-      }
-      .ok { color: var(--ok); }
-      .fail { color: var(--fail); }
-      .info { color: var(--muted); }
+      h2 { font-size: 1rem; margin: 2rem 0 0.5rem; color: var(--fg); }
+      .subtitle { color: var(--muted); margin: 0 0 1.5rem; font-size: 0.9rem; max-width: 70ch; }
       .pill {
         display: inline-block; padding: 0.15rem 0.5rem; border-radius: 999px;
         background: var(--border); color: var(--muted); font-size: 0.7rem;
-        margin-left: 0.5rem; vertical-align: middle;
+        margin-left: 0.4rem; vertical-align: middle;
       }
-      footer { color: var(--muted); margin-top: 3rem; font-size: 0.8rem; }
-      a { color: var(--accent); text-decoration: none; }
-      a:hover { text-decoration: underline; }
+      .callout {
+        background: var(--warn-bg); border: 1px solid var(--warn-border);
+        border-radius: 8px; padding: 0.9rem 1.1rem; margin: 1.25rem 0;
+        font-size: 0.85rem; color: #d9c98c;
+      }
+      .callout b { color: #f0e3a8; }
+      label { display: block; margin: 1.1rem 0 0.4rem; font-size: 0.8rem; color: var(--muted); }
+      textarea {
+        width: 100%; min-height: 9rem; background: var(--code-bg); color: var(--fg);
+        border: 1px solid var(--border); border-radius: 6px; padding: 0.75rem;
+        font-family: inherit; font-size: 0.8rem; line-height: 1.45; resize: vertical;
+      }
+      textarea:focus { outline: none; border-color: var(--accent); }
+      .controls { display: flex; flex-wrap: wrap; gap: 0.6rem; align-items: center; margin-top: 1rem; }
+      button {
+        background: var(--accent); color: #0b0d10; border: 0; border-radius: 6px;
+        padding: 0.55rem 1rem; font-family: inherit; font-weight: 600; cursor: pointer; font-size: 0.85rem;
+      }
+      button.secondary { background: transparent; color: var(--fail); border: 1px solid var(--border); font-weight: 500; }
+      button.ghost { background: transparent; color: var(--muted); border: 1px solid var(--border); font-weight: 500; }
+      button:disabled { opacity: 0.5; cursor: not-allowed; }
+      select {
+        background: var(--code-bg); color: var(--fg); border: 1px solid var(--border);
+        border-radius: 6px; padding: 0.4rem 0.6rem; font-family: inherit; font-size: 0.8rem;
+      }
+      .note { min-height: 1.2rem; margin: 0.75rem 0 0; font-size: 0.82rem; }
+      .note.ok { color: var(--ok); } .note.fail { color: var(--fail); }
+      #result {
+        margin-top: 1rem; padding: 1rem 1.1rem; background: var(--code-bg);
+        border: 1px solid var(--border); border-radius: 6px; white-space: pre-wrap;
+        font-size: 0.82rem; min-height: 3rem;
+      }
+      #result.ok { color: var(--ok); border-color: #1c3b29; }
+      #result.fail { color: var(--fail); border-color: #3b1c1c; }
+      #result.info { color: var(--muted); }
+      .scope { margin-top: 2rem; font-size: 0.83rem; color: var(--muted); }
+      .scope .yes { color: var(--ok); } .scope .no { color: var(--fail); }
+      footer { color: var(--muted); margin-top: 2.5rem; font-size: 0.78rem; border-top: 1px solid var(--border); padding-top: 1rem; }
+      a { color: var(--accent); text-decoration: none; } a:hover { text-decoration: underline; }
+      code { background: var(--code-bg); padding: 0.1rem 0.3rem; border-radius: 4px; }
     </style>
   </head>
   <body>
     <main>
       <h1>
-        nucleus-verifier
-        <span class="pill" id="sdk-version">loading...</span>
+        verify it yourself
+        <span class="pill" id="sdk-version">loading…</span>
+        <span class="pill" id="schema-version"></span>
       </h1>
       <p class="subtitle">
-        Paste a bundle + trust anchor below. Verification runs in this tab,
-        not on any server. The trust JWKS is the producer's published key
-        set; obtain it out of band (not from the bundle).
+        This page checks a nucleus agent's execution lineage — a hash-chained,
+        Ed25519-signed edge log with a witness-cosigned Merkle anchor — entirely
+        in your browser, against a trust anchor <em>you</em> pin. The verifier is
+        the project's Rust code compiled to WebAssembly. Nothing is trusted but
+        the hash function and the keys in your anchor; everything else is
+        recomputed here, not believed.
       </p>
 
-      <label for="bundle">bundle.json</label>
-      <textarea id="bundle" placeholder='{"payload": ..., "envelope": ...}'></textarea>
+      <div class="callout">
+        <b>Don't trust this page — prove it.</b> Open DevTools → Network, toggle
+        <b>Offline</b>, then click Verify. It still works: there is no server
+        round-trip. The bundle below is real (generated and self-verified by
+        <code>examples/emit_demo_bundle.rs</code>), not a screenshot.
+      </div>
 
-      <label for="anchor">trust anchor.json</label>
-      <textarea id="anchor" placeholder='{"trust_jwks": {"keys": [...]}, "allow_empty": false}'></textarea>
+      <label for="fixture-select">fixture</label>
+      <select id="fixture-select">
+        <option value="cosigned">cosigned — Merkle anchor + transparency-log witness</option>
+        <option value="basic">basic — signed edge chain only</option>
+      </select>
 
-      <button id="verify-btn" disabled>verify</button>
+      <label for="bundle">bundle.json &nbsp;<span class="info">(the agent's signed execution lineage)</span></label>
+      <textarea id="bundle" spellcheck="false">loading real fixture…</textarea>
 
-      <pre id="result" class="info">SDK loading...</pre>
+      <label for="anchor">trust-anchor.json &nbsp;<span class="info">(the keys you pin — obtained out of band, not from the bundle)</span></label>
+      <textarea id="anchor" spellcheck="false"></textarea>
+
+      <div class="controls">
+        <button id="verify-btn" disabled>Verify</button>
+        <button id="tamper-edge" class="secondary" disabled>Flip a byte in an edge signature</button>
+        <button id="tamper-witness" class="secondary" disabled>Break the witness cosignature</button>
+        <button id="reset-btn" class="ghost" disabled>Reset</button>
+      </div>
+      <p id="tamper-note" class="note"></p>
+
+      <pre id="result" class="info">loading verifier…</pre>
+
+      <div class="scope">
+        <h2>What this proves — and what it doesn't</h2>
+        <p>
+          <span class="yes">✓ Proves:</span> the lineage is internally consistent
+          and tamper-evident (hash chain + Merkle inclusion), and was signed by the
+          keys + cosigned by the witness in <em>your</em> trust anchor — i.e.
+          integrity and authenticity of the record.
+        </p>
+        <p>
+          <span class="no">✗ Does NOT prove:</span> that the agent behaved well,
+          that information-flow policy held, or that any computation was correct.
+          Tamper-evidence is not good behavior. The IFC enforcement and its
+          machine-checked noninterference theorem are separate guarantees; this
+          verifier does not evaluate them.
+        </p>
+      </div>
 
       <footer>
-        Source: <a href="https://github.com/coproduct-opensource/nucleus">github.com/coproduct-opensource/nucleus</a>
-        &nbsp;·&nbsp; Reproducible build: <code>wasm-pack build --target web --release</code>
+        Source &amp; reproducible build:
+        <a href="https://github.com/coproduct-opensource/nucleus/tree/main/sdks/verifier-js">sdks/verifier-js</a>
+        — rebuild the WASM with <code>wasm-pack build --target web --release</code> and diff it.
+        The fixtures are emitted by
+        <code>cargo run -p nucleus-envelope --example emit_demo_bundle</code>.
+        No analytics, no third-party requests.
       </footer>
     </main>
-
-    <script type="module">
-      import init, { verifyBundle, sdkVersion } from "./pkg/nucleus_verifier_wasm.js";
-
-      const result = document.getElementById("result");
-      const btn = document.getElementById("verify-btn");
-      const bundleEl = document.getElementById("bundle");
-      const anchorEl = document.getElementById("anchor");
-      const sdkVersionPill = document.getElementById("sdk-version");
-
-      try {
-        await init();
-        sdkVersionPill.textContent = "v" + sdkVersion();
-        result.textContent = "ready. paste a bundle + anchor, then click verify.";
-        btn.disabled = false;
-      } catch (e) {
-        result.className = "fail";
-        result.textContent = "SDK failed to load: " + e.message;
-      }
-
-      btn.addEventListener("click", () => {
-        result.className = "info";
-        result.textContent = "verifying...";
-        try {
-          const report = verifyBundle(bundleEl.value, anchorEl.value);
-          result.className = "ok";
-          result.textContent =
-            "VERIFIED\n\n" + JSON.stringify(report, null, 2);
-        } catch (e) {
-          result.className = "fail";
-          result.textContent = "REJECTED\n\n" + e.message;
-        }
-      });
-    </script>
+    <script type="module" src="./demo.js"></script>
   </body>
 </html>

--- a/sdks/verifier-js/demo.js
+++ b/sdks/verifier-js/demo.js
@@ -1,0 +1,172 @@
+// In-browser verifier demo. Everything runs in this tab: the WASM is the
+// nucleus envelope verifier compiled from Rust, the bundle + trust anchor are
+// REAL (generated and self-verified by
+// `crates/nucleus-envelope/examples/emit_demo_bundle.rs`), and `verifyBundle`
+// re-checks Merkle integrity + the witness cosignature against the anchor you
+// pin. No network calls after load — open DevTools → Network → Offline and
+// click Verify; it still works.
+import init, {
+  verifyBundle,
+  sdkVersion,
+  supportedEnvelopeSchemaVersion,
+} from "./pkg/nucleus_verifier_wasm.js";
+
+const $ = (id) => document.getElementById(id);
+const bundleEl = $("bundle");
+const anchorEl = $("anchor");
+const result = $("result");
+const note = $("tamper-note");
+
+// Originals so "reset" restores the pristine, verifying fixtures.
+let original = { bundle: "", anchor: "" };
+
+function setNote(msg, kind) {
+  note.textContent = msg || "";
+  note.className = "note " + (kind || "");
+}
+
+function renderReport(report) {
+  const rows = [
+    ["ok", report.ok],
+    ["trust_mode", report.trust_mode],
+    ["trust_domain", report.trust_domain],
+    ["edge_count", report.edge_count],
+    ["merkle_verified", report.merkle_verified],
+    ["cosignatures_verified", report.cosignatures_verified],
+    ["matched_witness_pubkeys", (report.matched_witness_pubkeys_hex || []).join(", ") || "—"],
+    ["head_edge_hash_hex", report.head_edge_hash_hex],
+    ["kids", (report.kids || []).join(", ")],
+    ["schema_version", report.schema_version],
+  ];
+  return rows.map(([k, v]) => "  " + k.padEnd(24) + String(v)).join("\n");
+}
+
+function doVerify() {
+  result.className = "info";
+  result.textContent = "verifying… (recomputed locally — no server)";
+  try {
+    const report = verifyBundle(bundleEl.value, anchorEl.value);
+    result.className = "ok";
+    result.textContent =
+      "✓ VERIFIED — recomputed in your browser, nothing trusted but the anchor you pinned\n\n" +
+      renderReport(report);
+  } catch (e) {
+    result.className = "fail";
+    result.textContent =
+      "✗ REJECTED — the local verifier refused it\n\n  reason: " + (e && e.message ? e.message : String(e));
+  }
+}
+
+// --- Tamper helpers: mutate one real field, re-render the JSON so the user
+// --- SEES the changed bytes, then they click Verify and watch it reject. ---
+function flipBase64(s) {
+  if (!s || s.length === 0) return s;
+  const c = s[0];
+  const repl = c === "A" ? "B" : "A";
+  return repl + s.slice(1);
+}
+
+function mutateBundle(path, label) {
+  let obj;
+  try {
+    obj = JSON.parse(bundleEl.value);
+  } catch (_e) {
+    setNote("bundle is not valid JSON — click reset", "fail");
+    return;
+  }
+  const target = path(obj);
+  if (!target) {
+    setNote("this field is not present in the loaded bundle", "fail");
+    return;
+  }
+  const ok = target.apply();
+  if (!ok) {
+    setNote("nothing to tamper at that field", "fail");
+    return;
+  }
+  bundleEl.value = JSON.stringify(obj, null, 2);
+  setNote("tampered: " + label + " — now click Verify", "fail");
+}
+
+function tamperEdgeSig() {
+  mutateBundle(
+    (o) => {
+      const p = o.envelope && o.envelope.edges && o.envelope.edges[0] && o.envelope.edges[0].proof;
+      if (!p || !p.sig) return null;
+      return { apply: () => { p.sig = flipBase64(p.sig); return true; } };
+    },
+    "flipped the first byte of envelope.edges[0].proof.sig (Ed25519 edge signature)"
+  );
+}
+
+function tamperWitnessSig() {
+  mutateBundle(
+    (o) => {
+      const sth = o.envelope && o.envelope.merkle_anchor && o.envelope.merkle_anchor.sth;
+      if (!sth || !sth.witness_sig) return null;
+      return { apply: () => { sth.witness_sig = flipBase64(sth.witness_sig); return true; } };
+    },
+    "broke envelope.merkle_anchor.sth.witness_sig (the transparency-log witness cosignature)"
+  );
+}
+
+function resetFixtures() {
+  bundleEl.value = original.bundle;
+  anchorEl.value = original.anchor;
+  setNote("restored the original, untampered fixtures", "ok");
+  result.className = "info";
+  result.textContent = "ready — click Verify, or tamper first and watch it reject.";
+}
+
+async function loadFixtures(which) {
+  const base = which === "basic" ? "bundle.basic.json" : "bundle.json";
+  const anchorName = which === "basic" ? "trust-anchor.basic.json" : "trust-anchor.json";
+  const [b, a] = await Promise.all([
+    fetch(new URL("./demo-fixtures/" + base, import.meta.url)).then((r) => r.text()),
+    fetch(new URL("./demo-fixtures/" + anchorName, import.meta.url)).then((r) => r.text()),
+  ]);
+  // Pretty-print so the structure (and later, the tampered byte) is legible.
+  original.bundle = JSON.stringify(JSON.parse(b), null, 2);
+  original.anchor = JSON.stringify(JSON.parse(a), null, 2);
+  bundleEl.value = original.bundle;
+  anchorEl.value = original.anchor;
+}
+
+async function boot() {
+  try {
+    // GitHub Pages does not reliably serve .wasm as application/wasm, which
+    // breaks instantiateStreaming. Fetch the bytes and instantiate from an
+    // ArrayBuffer so the MIME type is irrelevant.
+    const wasmBytes = await fetch(
+      new URL("./pkg/nucleus_verifier_wasm_bg.wasm", import.meta.url)
+    ).then((r) => r.arrayBuffer());
+    await init({ module_or_path: wasmBytes });
+  } catch (e) {
+    result.className = "fail";
+    result.textContent = "verifier failed to load: " + (e && e.message ? e.message : String(e));
+    return;
+  }
+
+  $("sdk-version").textContent = "v" + sdkVersion();
+  $("schema-version").textContent = "envelope schema v" + supportedEnvelopeSchemaVersion();
+
+  await loadFixtures("cosigned");
+  setNote("", "");
+  result.className = "info";
+  result.textContent = "ready — click Verify, or tamper first and watch it reject.";
+
+  $("verify-btn").addEventListener("click", doVerify);
+  $("tamper-edge").addEventListener("click", tamperEdgeSig);
+  $("tamper-witness").addEventListener("click", tamperWitnessSig);
+  $("reset-btn").addEventListener("click", resetFixtures);
+  $("fixture-select").addEventListener("change", async (ev) => {
+    await loadFixtures(ev.target.value);
+    setNote("loaded the " + ev.target.value + " fixture", "ok");
+    result.className = "info";
+    result.textContent = "ready — click Verify.";
+  });
+  $("verify-btn").disabled = false;
+  for (const id of ["tamper-edge", "tamper-witness", "reset-btn"]) $(id).disabled = false;
+}
+
+boot();


### PR DESCRIPTION
## In-browser tamper demo — "corrupt the receipt, watch the local verifier reject it"

The lead adoption artifact: an **install-nothing** page that verifies a **real**
agent execution-lineage bundle entirely in your browser, then lets you tamper
with it and watch the local verifier reject it. Verification is the project's
Rust (`nucleus-envelope::verify_bundle`) compiled to WASM — zero trust in any
server.

### What's here
- **`examples/emit_demo_bundle.rs`** — generates the fixtures from the real
  builder (a signed 3-edge session: `pod_admit → ToolCall → ArtifactProduced`;
  one basic, one witness-cosigned Merkle bundle) and **asserts they verify and
  that a one-byte tamper is rejected** before writing. No fake data.
- **`demo.html` / `demo.js`** — skeptical-client UX (per a SOTA review of
  Sigstore/Tinfoil/transparency-log demos): recompute-locally, an explicit
  "open DevTools → Offline → still works" challenge, tamper buttons (flip an
  edge signature / break the witness cosignature), typed rejection reasons, and
  a first-class **scope block** (proves tamper-evidence + authenticity; does
  **not** prove correctness / IFC / the Lean theorem). GH-Pages-safe WASM load
  (`fetch → ArrayBuffer → instantiate`, no `instantiateStreaming` MIME trap).
- **`demo-fixtures/*.json`** — committed real reference bundles + anchors.
- **`docs.yml`** — builds the WASM + fixtures and publishes the demo at
  **`/verify/`** on the existing docs Pages site.

### Honesty / safety
- Single GitHub Pages deployment (reuses the docs site); **go-live is gated on
  the `DOCS_DEPLOY` repo variable** — merging this does not publish anything
  until that var is `true`.
- Node smoke (manual): real bundle verifies (`ok`, 3 edges, `merkle_verified`);
  tampered edge sig → *signature/chain verification failed*; tampered witness
  cosig → *Merkle anchor STH signature verification failed*.
- `pkg/` is built in CI, not committed (gitignored; reproducible from source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
