### PR TITLE
#1 verify-before-act: nucleus-agent-card (signed A2A card → TrustAnchor)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5398,6 +5398,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "nucleus-agent-card"
+version = "1.0.0"
+dependencies = [
+ "base64 0.22.1",
+ "nucleus-envelope",
+ "nucleus-identity",
+ "nucleus-lineage",
+ "ring",
+ "serde",
+ "serde_jcs",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "nucleus-audit"
 version = "1.0.0"
 dependencies = [
@@ -5927,11 +5942,14 @@ dependencies = [
  "http-body-util",
  "metrics",
  "metrics-exporter-prometheus",
+ "nucleus-agent-card",
  "nucleus-control-plane",
  "nucleus-envelope",
+ "nucleus-identity",
  "nucleus-lineage",
  "nucleus-otel-bootstrap",
  "rand 0.9.3",
+ "ring",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -8261,6 +8279,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "ryu-js"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6518fc26bced4d53678a22d6e423e9d8716377def84545fe328236e3af070e7f"
+
+[[package]]
 name = "rzup"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8523,6 +8547,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_jcs"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3a60f3fda61525e439ef6d67422118f11e986566997d9021c56867ad814a0aa"
+dependencies = [
+ "ryu-js",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ members = [
     "crates/nucleus-oidc-core",          # Provider-agnostic OIDC primitives (JWKS, JtiCache, federation)
     "crates/nucleus-fly-oidc",           # Per-provider validator: Fly.io machine OIDC → SPIFFE
     "crates/nucleus-github-oidc",        # Per-provider validator: GitHub Actions OIDC → SPIFFE
+    "crates/nucleus-agent-card",         # Verify-before-you-act: signed Agent Card → TrustAnchor
 ]
 # nucleus-claude-hook moved to nucleus-code (private product repo)
 # exposure-web is WASM-only (wasm32-unknown-unknown); build with: cd crates/exposure-web && trunk build

--- a/crates/nucleus-agent-card/Cargo.toml
+++ b/crates/nucleus-agent-card/Cargo.toml
@@ -1,0 +1,44 @@
+[package]
+name = "nucleus-agent-card"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "Verify-before-you-act identity layer: sign/verify an A2A-style signed Agent Card and derive a TrustAnchor for the bundle verifier"
+repository = "https://github.com/coproduct-opensource/nucleus"
+keywords = ["agent", "identity", "a2a", "did", "provenance"]
+categories = ["authentication", "cryptography"]
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+base64 = { workspace = true }
+thiserror = { workspace = true }
+# RFC 8785 JSON Canonicalization Scheme. Pinned to the latest published
+# release (confirmed on crates.io 2026-06).
+serde_jcs = "0.2.0"
+
+# Path deps. nucleus-identity supplies JsonWebKey + did_crypto::jws_*.
+# nucleus-lineage supplies the Jwks type the card advertises.
+# nucleus-envelope supplies the TrustAnchor the verifier consumes.
+nucleus-identity = { path = "../nucleus-identity" }
+nucleus-lineage = { path = "../nucleus-lineage" }
+nucleus-envelope = { path = "../nucleus-envelope" }
+
+[features]
+default = []
+# Server/dev only: the card-signing path. Pulls in nucleus-identity's
+# signing primitive. NEVER enable in a WASM / browser build — verify is
+# always available without it and is secret-free.
+sign = []
+
+[dev-dependencies]
+# `dev` feature on nucleus-lineage gives the integration test the
+# in-process LocalIssuer + InMemorySink it needs to build a real Bundle.
+nucleus-lineage = { path = "../nucleus-lineage", features = ["dev"] }
+# P-256 keypair generation for the sign/verify unit + integration tests.
+ring = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/nucleus-agent-card/src/anchor.rs
+++ b/crates/nucleus-agent-card/src/anchor.rs
@@ -1,0 +1,23 @@
+//! Bridge a [`VerifiedCard`] to the existing bundle verifier's
+//! [`nucleus_envelope::TrustAnchor`].
+//!
+//! This is the join point: once a card is verified (the WHO question is
+//! answered), its advertised JWKS becomes the out-of-band trust anchor the
+//! recipient uses to decide whether to ACT on a provenance bundle (the
+//! WHAT question). A bundle that doesn't verify against this anchor MUST be
+//! refused even though the card was perfectly valid — see the negative
+//! handshake integration test.
+
+use crate::verify::VerifiedCard;
+
+/// Build a [`nucleus_envelope::TrustAnchor`] from a verified card's
+/// advertised JWKS.
+///
+/// The anchor is the *only* JWKS the recipient will accept bundle
+/// signatures against; the bundle's own embedded JWKS is ignored by
+/// [`nucleus_envelope::verify_bundle`]. This is what closes the loop: the
+/// card said "trust these keys," the card is authentic, so a bundle that
+/// doesn't match those keys is not from this agent.
+pub fn trust_anchor_from_card(v: &VerifiedCard) -> nucleus_envelope::TrustAnchor {
+    nucleus_envelope::TrustAnchor::from_jwks(v.advertised_jwks().clone())
+}

--- a/crates/nucleus-agent-card/src/card.rs
+++ b/crates/nucleus-agent-card/src/card.rs
@@ -1,0 +1,162 @@
+//! Agent Card types — an A2A-style identity document plus its detached
+//! RFC 7515 JWS-JSON signatures.
+//!
+//! These are pure data; signing lives in [`crate::sign`] (feature-gated)
+//! and verification in [`crate::verify`] (always available).
+//!
+//! # Forward-compat
+//!
+//! None of these structs use `deny_unknown_fields`. A newer producer may
+//! add fields this verifier doesn't know about; unknown fields are
+//! ignored on parse so an older verifier still works against a newer
+//! card. The canonicalization in [`crate::jcs`] covers exactly the
+//! fields defined here — what we sign is what we know.
+
+use serde::{Deserialize, Serialize};
+
+/// The self-describing identity document an agent publishes (typically at
+/// `/.well-known/agent-card.json`).
+///
+/// The card advertises WHO the agent is (`spiffe_id`, `did`), how to talk
+/// to it (`security_schemes`, `supported_envelope_schema_versions`), and —
+/// critically for the verify-before-you-act flow — the JWKS the agent
+/// claims its provenance bundles are signed under (`trust_jwks`).
+///
+/// **The advertised `trust_jwks` is a CLAIM, not an anchor.** It only
+/// becomes load-bearing once the card itself has been verified against an
+/// out-of-band-resolved key (see [`crate::verify::verify_card`]) AND the
+/// recipient refuses to act on any bundle that doesn't verify against it.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentCard {
+    /// SPIFFE identity of the agent (e.g. `spiffe://prod.example.com/ns/agents/sa/coder`).
+    pub spiffe_id: String,
+
+    /// Decentralized identifier for the agent (e.g. `did:web:coder.prod.example.com`).
+    pub did: String,
+
+    /// A2A-style security schemes describing how callers authenticate to
+    /// the agent. Opaque JSON — this crate does not interpret it.
+    pub security_schemes: serde_json::Value,
+
+    /// Envelope/bundle schema versions this agent can produce or consume.
+    pub supported_envelope_schema_versions: Vec<String>,
+
+    /// Optional URI where the agent's JWKS is published out-of-band. A
+    /// recipient MAY resolve this to obtain the verification key for the
+    /// card; it is NOT trusted material on its own.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub jwks_uri: Option<String>,
+
+    /// The JWKS the agent advertises as authoritative for its provenance
+    /// bundles. Becomes a [`nucleus_envelope::TrustAnchor`] only after the
+    /// card is verified.
+    pub trust_jwks: nucleus_lineage::Jwks,
+}
+
+/// One detached RFC 7515 JWS-JSON signature over the JCS-canonicalized
+/// [`AgentCard`].
+///
+/// "Detached" means the JWS payload segment is dropped on the wire: the
+/// recipient reconstructs it by canonicalizing the `card` itself. This is
+/// what binds the signature to the exact card content without duplicating
+/// the bytes.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AgentCardSignature {
+    /// Base64url-encoded protected JWS header (e.g. `{"alg":"ES256"}`).
+    pub protected: String,
+
+    /// Base64url-encoded signature over `protected || "." || base64url(JCS(card))`.
+    pub signature: String,
+
+    /// Optional unprotected JWS header (RFC 7515 §7.2.1). Not covered by
+    /// the signature; carry hints like `kid` here at the producer's risk.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub header: Option<serde_json::Value>,
+}
+
+/// An [`AgentCard`] plus one or more detached signatures.
+///
+/// The verifier uses the FIRST signature (see [`crate::verify::verify_card`]).
+/// Multiple signatures are permitted for key-rotation / co-signing but the
+/// trust decision is made against the caller's out-of-band-resolved key,
+/// not against any `kid` the card or signature claims.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SignedAgentCard {
+    /// The identity document.
+    pub card: AgentCard,
+
+    /// Detached JWS-JSON signatures over the JCS of `card`.
+    pub signatures: Vec<AgentCardSignature>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_card() -> AgentCard {
+        AgentCard {
+            spiffe_id: "spiffe://prod.example.com/ns/agents/sa/coder".to_string(),
+            did: "did:web:coder.prod.example.com".to_string(),
+            security_schemes: serde_json::json!({
+                "bearer": {"type": "http", "scheme": "bearer"}
+            }),
+            supported_envelope_schema_versions: vec!["1".to_string(), "2".to_string()],
+            jwks_uri: Some("https://coder.prod.example.com/.well-known/jwks.json".to_string()),
+            trust_jwks: nucleus_lineage::Jwks {
+                keys: vec![nucleus_lineage::Jwk {
+                    kty: "OKP".to_string(),
+                    crv: Some("Ed25519".to_string()),
+                    kid: "k1".to_string(),
+                    x: Some("AAAA_AAAAAA-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA".to_string()),
+                    alg: Some("EdDSA".to_string()),
+                    use_: Some("sig".to_string()),
+                }],
+            },
+        }
+    }
+
+    #[test]
+    fn agent_card_serde_round_trip() {
+        let card = sample_card();
+        let json = serde_json::to_string(&card).unwrap();
+        let back: AgentCard = serde_json::from_str(&json).unwrap();
+        // Jwks has no PartialEq, so compare via canonical JSON value.
+        assert_eq!(
+            serde_json::to_value(&card).unwrap(),
+            serde_json::to_value(&back).unwrap()
+        );
+    }
+
+    #[test]
+    fn signed_agent_card_serde_round_trip() {
+        let signed = SignedAgentCard {
+            card: sample_card(),
+            signatures: vec![AgentCardSignature {
+                protected: "eyJhbGciOiJFUzI1NiJ9".to_string(),
+                signature: "c2lnbmF0dXJl".to_string(),
+                header: Some(serde_json::json!({"kid": "k1"})),
+            }],
+        };
+        let json = serde_json::to_string(&signed).unwrap();
+        let back: SignedAgentCard = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            serde_json::to_value(&signed).unwrap(),
+            serde_json::to_value(&back).unwrap()
+        );
+    }
+
+    #[test]
+    fn unknown_fields_are_ignored_forward_compat() {
+        // A newer producer adds a field this verifier doesn't model.
+        let json = serde_json::json!({
+            "spiffe_id": "spiffe://prod.example.com/ns/agents/sa/coder",
+            "did": "did:web:coder.prod.example.com",
+            "security_schemes": {},
+            "supported_envelope_schema_versions": ["1"],
+            "trust_jwks": {"keys": []},
+            "future_field_we_dont_know": {"nested": true}
+        });
+        let card: AgentCard = serde_json::from_value(json).unwrap();
+        assert_eq!(card.did, "did:web:coder.prod.example.com");
+    }
+}

--- a/crates/nucleus-agent-card/src/jcs.rs
+++ b/crates/nucleus-agent-card/src/jcs.rs
@@ -1,0 +1,96 @@
+//! RFC 8785 JSON Canonicalization Scheme (JCS) for [`AgentCard`].
+//!
+//! Both the signer and the verifier MUST canonicalize the card the exact
+//! same way, or a valid signature would fail to verify. This module is the
+//! single source of that canonicalization, built on the [`serde_jcs`]
+//! crate (RFC 8785 compliant).
+
+use crate::card::AgentCard;
+use crate::{Error, Result};
+
+/// Canonicalize an [`AgentCard`] to RFC 8785 (JCS) bytes.
+///
+/// The output is deterministic: lexicographically-sorted object keys,
+/// no insignificant whitespace, and canonical number/string formatting.
+/// These are exactly the bytes the JWS signature covers.
+pub fn canonicalize(card: &AgentCard) -> Result<Vec<u8>> {
+    serde_jcs::to_vec(card).map_err(|e| Error::Canonicalize(e.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// RFC 8785 Appendix B reference vector. Pins our JCS implementation
+    /// against the spec's own example so a future dependency swap that
+    /// silently changes canonicalization is caught immediately.
+    // The RFC 8785 vector intentionally feeds a float with more digits
+    // than an f64 can hold — that excess precision is the POINT (JCS must
+    // round it to the shortest round-trippable form). Allow the lint here.
+    #[allow(clippy::excessive_precision)]
+    #[test]
+    fn jcs_matches_rfc8785_reference_vector() {
+        // The `string` value is the exact char sequence from the spec:
+        // €, $, U+000F, newline, A, ', B, ", \, ", / — built from char
+        // escapes so no stray bytes sneak in via the source file.
+        let string_value: String = [
+            '\u{20ac}', '$', '\u{000F}', '\n', 'A', '\'', 'B', '"', '\\', '"', '/',
+        ]
+        .iter()
+        .collect();
+        let value = serde_json::json!({
+            "numbers": [333333333.33333329, 1E30, 4.50, 2e-3, 0.000000000000000000000000001],
+            "string": string_value,
+            "literals": [null, true, false]
+        });
+
+        // Expected canonical output per RFC 8785: keys sorted, whitespace
+        // stripped, numbers in shortest round-trippable form, control chars
+        // below 0x20 as lowercase `\u00xx` (U+000F here), `\n` short escape,
+        // and `"`/`\` backslash-escaped.
+        let expected = concat!(
+            r#"{"literals":[null,true,false],"#,
+            r#""numbers":[333333333.3333333,1e+30,4.5,0.002,1e-27],"#,
+            "\"string\":\"\u{20ac}$\\u000f\\nA'B\\\"\\\\\\\"/\"}"
+        );
+
+        let got = serde_jcs::to_string(&value).unwrap();
+        assert_eq!(got, expected, "JCS output must match RFC 8785 reference");
+    }
+
+    /// The smaller, independently-checkable invariant the signer/verifier
+    /// rely on: key ordering is normalized regardless of input order.
+    #[test]
+    fn jcs_sorts_keys_independent_of_insertion_order() {
+        let a = serde_json::json!({"b": 1, "a": 2, "c": 3});
+        let b = serde_json::json!({"c": 3, "a": 2, "b": 1});
+        assert_eq!(
+            serde_jcs::to_vec(&a).unwrap(),
+            serde_jcs::to_vec(&b).unwrap()
+        );
+        assert_eq!(serde_jcs::to_string(&a).unwrap(), r#"{"a":2,"b":1,"c":3}"#);
+    }
+
+    /// `canonicalize(card)` is stable across clones and re-serialization —
+    /// the property the whole sign/verify contract depends on.
+    #[test]
+    fn canonicalize_is_deterministic() {
+        let card = AgentCard {
+            spiffe_id: "spiffe://prod.example.com/ns/agents/sa/coder".to_string(),
+            did: "did:web:coder.prod.example.com".to_string(),
+            security_schemes: serde_json::json!({"b": 1, "a": 2}),
+            supported_envelope_schema_versions: vec!["1".to_string()],
+            jwks_uri: None,
+            trust_jwks: nucleus_lineage::Jwks { keys: vec![] },
+        };
+        let first = canonicalize(&card).unwrap();
+        let second = canonicalize(&card.clone()).unwrap();
+        assert_eq!(first, second);
+        // Keys inside the nested object are sorted.
+        let s = String::from_utf8(first).unwrap();
+        assert!(
+            s.contains(r#""security_schemes":{"a":2,"b":1}"#),
+            "got: {s}"
+        );
+    }
+}

--- a/crates/nucleus-agent-card/src/lib.rs
+++ b/crates/nucleus-agent-card/src/lib.rs
@@ -1,0 +1,91 @@
+//! Verify-before-you-act identity layer for nucleus agents.
+//!
+//! An [`AgentCard`] is the A2A-style document an agent publishes to say WHO
+//! it is and which JWKS its provenance bundles are signed under. This crate
+//! signs ([`sign_card`], feature `sign`) and verifies ([`verify_card`]) a
+//! [`SignedAgentCard`], then derives a [`nucleus_envelope::TrustAnchor`]
+//! ([`trust_anchor_from_card`]) so the EXISTING bundle verifier can decide
+//! whether to ACT on a bundle.
+//!
+//! # Trust model — read this before using
+//!
+//! - **Verify needs no secret.** [`verify_card`] is always compiled and is
+//!   secret-free; a browser/WASM verifier can use it directly. Only
+//!   [`sign_card`] (behind the non-default `sign` feature) touches a
+//!   private key, and it MUST stay server/dev-side — never ship it to a
+//!   client.
+//!
+//! - **NEVER trust a key embedded in the card.** [`verify_card`] reads its
+//!   verification key ONLY from the caller's out-of-band-resolved
+//!   `resolved_key` argument (DID resolution, a pinned JWKS, an operator
+//!   file). It does not read any key — or `kid` — from the card or the
+//!   signature. The card's `jwks_uri` is a *hint* for where to resolve the
+//!   key, not the key itself.
+//!
+//! - **This is the WHO-layer, not the WHAT-layer.** Verifying a card
+//!   establishes the agent's identity and the JWKS it claims. It does NOT
+//!   verify any payload or provenance bundle — that is
+//!   [`nucleus_envelope::verify_bundle`]'s job, anchored by the
+//!   [`TrustAnchor`](nucleus_envelope::TrustAnchor) this crate derives. A
+//!   recipient must do BOTH: verify the card, then refuse to act on any
+//!   bundle that doesn't verify against the card's advertised anchor.
+//!
+//! - **A card verified against an attacker-supplied key is "verified
+//!   garbage."** The signature math passes, but it proves nothing about
+//!   the agent's identity. The whole guarantee rests on `resolved_key`
+//!   coming from a trustworthy out-of-band channel. If the caller resolves
+//!   the key from the same place the attacker controls, there is no
+//!   security here — by construction, and by design (we refuse to hide that
+//!   decision inside the card).
+//!
+//! # End-to-end shape
+//!
+//! ```ignore
+//! // server side (feature = "sign"):
+//! let signed = sign_card(card, &pkcs8_der)?;
+//!
+//! // recipient side (secret-free):
+//! let resolved = resolve_key_out_of_band(&signed.card.did)?; // YOUR job
+//! let verified = verify_card(&signed, &resolved)?;
+//! let anchor = trust_anchor_from_card(&verified);
+//! let report = nucleus_envelope::verify_bundle(&bundle, &anchor)?; // ACT only if this succeeds
+//! ```
+
+pub mod anchor;
+pub mod card;
+pub mod jcs;
+pub mod verify;
+
+#[cfg(feature = "sign")]
+pub mod sign;
+
+#[cfg(all(test, feature = "sign"))]
+mod sign_verify_tests;
+
+pub use anchor::trust_anchor_from_card;
+pub use card::{AgentCard, AgentCardSignature, SignedAgentCard};
+pub use jcs::canonicalize;
+pub use verify::{verify_card, VerifiedCard};
+
+#[cfg(feature = "sign")]
+pub use sign::sign_card;
+
+/// Convenience result alias for this crate.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Errors produced by the agent-card layer.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// RFC 8785 JCS canonicalization of the card failed.
+    #[error("agent-card canonicalization failed: {0}")]
+    Canonicalize(String),
+
+    /// Card verification failed (no signatures, bad signature, payload
+    /// mismatch, or unusable advertised JWKS).
+    #[error("agent-card verification failed: {0}")]
+    Verify(String),
+
+    /// Card signing failed (only reachable with feature `sign`).
+    #[error("agent-card signing failed: {0}")]
+    Sign(String),
+}

--- a/crates/nucleus-agent-card/src/sign.rs
+++ b/crates/nucleus-agent-card/src/sign.rs
@@ -1,0 +1,59 @@
+//! Sign an [`AgentCard`] into a [`SignedAgentCard`] (server/dev only).
+//!
+//! This module is behind the non-default `sign` feature. It needs a
+//! private key and therefore MUST NOT be compiled into a WASM / browser
+//! verifier — verification ([`crate::verify`]) is always available and
+//! secret-free.
+//!
+//! The signature produced is a DETACHED RFC 7515 JWS-JSON over the JCS
+//! canonicalization of the card: the payload segment is dropped, so the
+//! recipient reconstructs it by canonicalizing the card they received.
+
+use crate::card::{AgentCard, AgentCardSignature, SignedAgentCard};
+use crate::jcs::canonicalize;
+use crate::{Error, Result};
+
+/// Sign an [`AgentCard`] with a PKCS#8-DER P-256 private key, producing a
+/// [`SignedAgentCard`] with a single detached ES256 JWS-JSON signature.
+///
+/// The signature covers `base64url(protected) || "." || base64url(JCS(card))`
+/// per RFC 7515, but the payload segment is omitted from the wire form
+/// (detached). Header `alg` is `ES256`.
+///
+/// # Errors
+///
+/// Returns [`Error`] if canonicalization fails, the key is invalid /
+/// signing fails, or the underlying JWS is not the expected three-part
+/// compact form.
+pub fn sign_card(card: AgentCard, private_key_pkcs8_der: &[u8]) -> Result<SignedAgentCard> {
+    // Canonicalize first — this is the exact byte string the verifier will
+    // reconstruct and check against.
+    let jcs_bytes = canonicalize(&card)?;
+
+    // jws_sign_es256 produces a COMPACT "header.payload.signature" JWS with
+    // alg=ES256. We sign the JCS bytes, then strip the payload to make the
+    // signature detached.
+    let compact = nucleus_identity::did_crypto::jws_sign_es256(&jcs_bytes, private_key_pkcs8_der)
+        .map_err(|e| Error::Sign(format!("ES256 signing failed: {e}")))?;
+
+    let parts: Vec<&str> = compact.splitn(3, '.').collect();
+    if parts.len() != 3 {
+        return Err(Error::Sign(format!(
+            "expected a 3-part compact JWS, got {} part(s)",
+            parts.len()
+        )));
+    }
+
+    // parts[0] = protected header, parts[1] = payload (DROPPED — detached),
+    // parts[2] = signature.
+    let signature = AgentCardSignature {
+        protected: parts[0].to_string(),
+        signature: parts[2].to_string(),
+        header: None,
+    };
+
+    Ok(SignedAgentCard {
+        card,
+        signatures: vec![signature],
+    })
+}

--- a/crates/nucleus-agent-card/src/sign_verify_tests.rs
+++ b/crates/nucleus-agent-card/src/sign_verify_tests.rs
@@ -1,0 +1,128 @@
+//! Sign↔verify round-trip + negative tests. Gated on `feature = "sign"`
+//! because they exercise [`crate::sign::sign_card`]; verification itself
+//! is always available.
+
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine as _;
+use ring::rand::SystemRandom;
+use ring::signature::{EcdsaKeyPair, KeyPair, ECDSA_P256_SHA256_FIXED_SIGNING};
+
+use nucleus_identity::JsonWebKey;
+
+use crate::card::AgentCard;
+use crate::jcs::canonicalize;
+use crate::sign::sign_card;
+use crate::verify::verify_card;
+
+/// Generate a fresh P-256 keypair: returns (PKCS#8 DER, matching public JWK).
+fn p256_keypair() -> (Vec<u8>, JsonWebKey) {
+    let rng = SystemRandom::new();
+    let pkcs8 = EcdsaKeyPair::generate_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, &rng).unwrap();
+    let der = pkcs8.as_ref().to_vec();
+    let key_pair = EcdsaKeyPair::from_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, &der, &rng).unwrap();
+
+    // public_key() is the uncompressed EC point: 0x04 || x[32] || y[32].
+    let pk = key_pair.public_key().as_ref();
+    assert_eq!(pk.len(), 65, "uncompressed P-256 point");
+    assert_eq!(pk[0], 0x04);
+    let x = URL_SAFE_NO_PAD.encode(&pk[1..33]);
+    let y = URL_SAFE_NO_PAD.encode(&pk[33..65]);
+    (der, JsonWebKey::ec_p256(x, y))
+}
+
+/// A real, well-formed Ed25519 JWKS produced by an in-process issuer
+/// (the `dev` feature is active during test builds via the dev-dependency).
+fn good_jwks() -> nucleus_lineage::Jwks {
+    let issuer = nucleus_lineage::LocalIssuer::random().unwrap();
+    serde_json::from_value(issuer.publish_jwks()).unwrap()
+}
+
+fn sample_card() -> AgentCard {
+    AgentCard {
+        spiffe_id: "spiffe://prod.example.com/ns/agents/sa/coder".to_string(),
+        did: "did:web:coder.prod.example.com".to_string(),
+        security_schemes: serde_json::json!({"bearer": {"type": "http"}}),
+        supported_envelope_schema_versions: vec!["1".to_string()],
+        jwks_uri: None,
+        trust_jwks: good_jwks(),
+    }
+}
+
+#[test]
+fn sign_then_verify_happy_path() {
+    let (der, pub_jwk) = p256_keypair();
+    let signed = sign_card(sample_card(), &der).unwrap();
+    let verified = verify_card(&signed, &pub_jwk).expect("freshly-signed card must verify");
+    assert_eq!(verified.card.did, "did:web:coder.prod.example.com");
+    assert_eq!(verified.advertised_jwks().keys.len(), 1);
+}
+
+#[test]
+fn sign_and_verify_canonicalize_identically() {
+    // The signature is over JCS(card); the verifier reconstructs JCS(card).
+    // Confirm both sides agree on the exact bytes — the contract that makes
+    // the detached JWS verifiable at all.
+    let (der, pub_jwk) = p256_keypair();
+    let card = sample_card();
+    let jcs_at_sign = canonicalize(&card).unwrap();
+    let signed = sign_card(card, &der).unwrap();
+    let jcs_at_verify = canonicalize(&signed.card).unwrap();
+    assert_eq!(
+        jcs_at_sign, jcs_at_verify,
+        "sign and verify must JCS identically"
+    );
+    verify_card(&signed, &pub_jwk).unwrap();
+}
+
+#[test]
+fn flipping_one_byte_of_card_body_fails_verification() {
+    let (der, pub_jwk) = p256_keypair();
+    let mut signed = sign_card(sample_card(), &der).unwrap();
+    // Mutate the card AFTER signing — the detached signature was over the
+    // original JCS, so the reconstructed payload no longer matches.
+    signed.card.did = "did:web:attacker.example.com".to_string();
+    let err = verify_card(&signed, &pub_jwk).unwrap_err();
+    assert!(matches!(err, crate::Error::Verify(_)), "got {err:?}");
+}
+
+#[test]
+fn card_signed_by_key_a_fails_under_key_b() {
+    // Proves the out-of-band resolved key is load-bearing: a perfectly
+    // valid signature by A is worthless when verified against B's key.
+    let (der_a, _pub_a) = p256_keypair();
+    let (_der_b, pub_b) = p256_keypair();
+    let signed = sign_card(sample_card(), &der_a).unwrap();
+    let err = verify_card(&signed, &pub_b).unwrap_err();
+    assert!(matches!(err, crate::Error::Verify(_)), "got {err:?}");
+}
+
+#[test]
+fn empty_trust_jwks_is_rejected() {
+    let (der, pub_jwk) = p256_keypair();
+    let mut card = sample_card();
+    card.trust_jwks = nucleus_lineage::Jwks { keys: vec![] };
+    let signed = sign_card(card, &der).unwrap();
+    let err = verify_card(&signed, &pub_jwk).unwrap_err();
+    assert!(matches!(err, crate::Error::Verify(_)), "got {err:?}");
+}
+
+#[test]
+fn malformed_trust_jwks_is_rejected() {
+    let (der, pub_jwk) = p256_keypair();
+    let mut card = sample_card();
+    // A key with an undecodable `x` is malformed — can't become a
+    // verifying key, so it can't anchor any bundle.
+    card.trust_jwks = nucleus_lineage::Jwks {
+        keys: vec![nucleus_lineage::Jwk {
+            kty: "OKP".to_string(),
+            crv: Some("Ed25519".to_string()),
+            kid: "broken".to_string(),
+            x: Some("!!! not base64url !!!".to_string()),
+            alg: Some("EdDSA".to_string()),
+            use_: Some("sig".to_string()),
+        }],
+    };
+    let signed = sign_card(card, &der).unwrap();
+    let err = verify_card(&signed, &pub_jwk).unwrap_err();
+    assert!(matches!(err, crate::Error::Verify(_)), "got {err:?}");
+}

--- a/crates/nucleus-agent-card/src/verify.rs
+++ b/crates/nucleus-agent-card/src/verify.rs
@@ -1,0 +1,190 @@
+//! Verify a [`SignedAgentCard`] against an OUT-OF-BAND-resolved key.
+//!
+//! This module is ALWAYS compiled (no feature gate) and is secret-free —
+//! a browser/WASM verifier can use it without ever touching a private key.
+//!
+//! # The one rule that makes this safe
+//!
+//! The verification key comes ONLY from the caller's `resolved_key`
+//! argument — a key the caller obtained out-of-band (DID resolution, a
+//! pinned JWKS, an operator file). It is NEVER read from the card or from
+//! any `kid` the signature advertises. A card verified against a key the
+//! *attacker* supplied is "verified garbage": the math passes but it
+//! proves nothing about who the agent is.
+
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine as _;
+
+use nucleus_identity::JsonWebKey;
+
+use crate::card::{AgentCard, SignedAgentCard};
+use crate::jcs::canonicalize;
+use crate::{Error, Result};
+
+/// A card whose signature verified against the caller's out-of-band key.
+///
+/// Holding a `VerifiedCard` is the proof obligation: you may only call
+/// [`Self::advertised_jwks`] (and thence build a TrustAnchor) once the
+/// card's authenticity has been established.
+#[derive(Debug, Clone)]
+pub struct VerifiedCard {
+    /// The verified identity document.
+    pub card: AgentCard,
+}
+
+impl VerifiedCard {
+    /// The JWKS the (now-verified) card advertises as authoritative for
+    /// its provenance bundles. Feed this to
+    /// [`crate::anchor::trust_anchor_from_card`].
+    pub fn advertised_jwks(&self) -> &nucleus_lineage::Jwks {
+        &self.card.trust_jwks
+    }
+}
+
+/// Verify a [`SignedAgentCard`] using a key the caller resolved
+/// out-of-band.
+///
+/// Steps:
+///
+/// 1. Take the FIRST signature.
+/// 2. Recompute the JCS canonical bytes of `card` and the detached JWS
+///    payload segment `base64url_nopad(JCS(card))`.
+/// 3. Reconstruct the compact JWS `protected.payload.signature` and verify
+///    it via [`nucleus_identity::did_crypto::jws_verify_es256`] against
+///    `resolved_key`.
+/// 4. Assert the payload `jws_verify_es256` returns equals JCS(card) — so
+///    the signature is bound to *this* card, not some other payload.
+/// 5. Reject if the card's advertised `trust_jwks` is empty or malformed
+///    (an advertised-but-unusable JWKS can't anchor anything downstream).
+///
+/// # Errors
+///
+/// Returns [`Error`] on: no signatures, signature/JWS verification
+/// failure, payload mismatch, or empty/malformed `trust_jwks`.
+pub fn verify_card(signed: &SignedAgentCard, resolved_key: &JsonWebKey) -> Result<VerifiedCard> {
+    // 1) First signature. Multiple signatures are allowed on the wire, but
+    //    the trust decision is made against the caller's resolved key over
+    //    the first one — we never iterate looking for "a kid that matches"
+    //    because that would re-introduce card-controlled key selection.
+    let sig = signed
+        .signatures
+        .first()
+        .ok_or(Error::Verify("signed card has no signatures".to_string()))?;
+
+    // 2) Canonicalize the card and form the detached JWS payload segment.
+    let jcs_bytes = canonicalize(&signed.card)?;
+    let payload_b64 = URL_SAFE_NO_PAD.encode(&jcs_bytes);
+
+    // 3) Reconstruct the COMPACT JWS string the detached signature implies:
+    //    protected "." base64url(JCS(card)) "." signature.
+    let compact = format!("{}.{}.{}", sig.protected, payload_b64, sig.signature);
+
+    // 4) Verify against the OUT-OF-BAND-resolved key ONLY. Never the card's
+    //    own material. `jws_verify_es256` returns the decoded payload.
+    let recovered = nucleus_identity::did_crypto::jws_verify_es256(&compact, resolved_key)
+        .map_err(|e| Error::Verify(format!("JWS verification failed: {e}")))?;
+
+    // 5) Defense in depth: the recovered payload MUST equal the JCS we
+    //    canonicalized. With the reconstruction above this is structurally
+    //    guaranteed, but asserting it pins the contract so a future change
+    //    to the JWS reconstruction can't silently verify a different
+    //    payload than the card.
+    if recovered != jcs_bytes {
+        return Err(Error::Verify(
+            "verified JWS payload does not equal the card's JCS bytes".to_string(),
+        ));
+    }
+
+    // 6) Reject an unusable advertised JWKS up front. An empty or malformed
+    //    trust_jwks can't anchor any bundle, so a card carrying one is
+    //    useless for verify-before-you-act — fail loudly here rather than
+    //    let the caller build a TrustAnchor that rejects everything.
+    reject_unusable_jwks(&signed.card.trust_jwks)?;
+
+    Ok(VerifiedCard {
+        card: signed.card.clone(),
+    })
+}
+
+/// Reject an empty or malformed advertised JWKS.
+///
+/// Malformed = a key entry that can't be turned into a verifying key
+/// (caught by [`nucleus_lineage::Jwks::verifying_key`]).
+fn reject_unusable_jwks(jwks: &nucleus_lineage::Jwks) -> Result<()> {
+    if jwks.keys.is_empty() {
+        return Err(Error::Verify(
+            "card advertises an empty trust_jwks (anchors nothing)".to_string(),
+        ));
+    }
+    for key in &jwks.keys {
+        // verifying_key() validates kty/crv/alg and decodes `x`. Any error
+        // means this advertised key is unusable as a trust anchor.
+        jwks.verifying_key(&key.kid).map_err(|e| {
+            Error::Verify(format!(
+                "card advertises a malformed trust_jwks key (kid {:?}): {e}",
+                key.kid
+            ))
+        })?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::card::{AgentCard, AgentCardSignature, SignedAgentCard};
+
+    fn ed25519_jwks() -> nucleus_lineage::Jwks {
+        nucleus_lineage::Jwks {
+            keys: vec![nucleus_lineage::Jwk {
+                kty: "OKP".to_string(),
+                crv: Some("Ed25519".to_string()),
+                kid: "k1".to_string(),
+                x: Some("AAAA_AAAAAA-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA".to_string()),
+                alg: Some("EdDSA".to_string()),
+                use_: Some("sig".to_string()),
+            }],
+        }
+    }
+
+    fn card_with(jwks: nucleus_lineage::Jwks) -> AgentCard {
+        AgentCard {
+            spiffe_id: "spiffe://prod.example.com/ns/agents/sa/coder".to_string(),
+            did: "did:web:coder.prod.example.com".to_string(),
+            security_schemes: serde_json::json!({}),
+            supported_envelope_schema_versions: vec!["1".to_string()],
+            jwks_uri: None,
+            trust_jwks: jwks,
+        }
+    }
+
+    #[test]
+    fn no_signatures_is_rejected() {
+        let signed = SignedAgentCard {
+            card: card_with(ed25519_jwks()),
+            signatures: vec![],
+        };
+        let key = JsonWebKey::ec_p256("x", "y");
+        let err = verify_card(&signed, &key).unwrap_err();
+        assert!(matches!(err, Error::Verify(_)));
+    }
+
+    #[test]
+    fn garbage_signature_is_rejected() {
+        let signed = SignedAgentCard {
+            card: card_with(ed25519_jwks()),
+            signatures: vec![AgentCardSignature {
+                protected: "eyJhbGciOiJFUzI1NiJ9".to_string(),
+                signature: "bm90LWEtcmVhbC1zaWc".to_string(),
+                header: None,
+            }],
+        };
+        // A syntactically-valid P-256 JWK that did not sign this card.
+        let key = JsonWebKey::ec_p256(
+            "f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",
+            "x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",
+        );
+        let err = verify_card(&signed, &key).unwrap_err();
+        assert!(matches!(err, Error::Verify(_)));
+    }
+}

--- a/crates/nucleus-agent-card/tests/handshake.rs
+++ b/crates/nucleus-agent-card/tests/handshake.rs
@@ -1,0 +1,173 @@
+//! The verify-before-you-act handshake, end to end.
+//!
+//! HEADLINE: an agent signs a card advertising its bundle-issuer's JWKS;
+//! the recipient verifies the card against an out-of-band P-256 key,
+//! derives a TrustAnchor, and `verify_bundle` SUCCEEDS for a real Bundle
+//! from that issuer.
+//!
+//! THE NEGATIVE TEST (the point): if the bundle is from a DIFFERENT issuer
+//! than the card advertises, the card still verifies (it is validly
+//! signed) BUT the recipient REFUSES TO ACT — `verify_bundle` against the
+//! card-derived anchor FAILS.
+//!
+//! Requires `--features sign` for the card-signing helper.
+#![cfg(feature = "sign")]
+
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine as _;
+use ring::rand::SystemRandom;
+use ring::signature::{EcdsaKeyPair, KeyPair, ECDSA_P256_SHA256_FIXED_SIGNING};
+
+use nucleus_agent_card::{sign_card, trust_anchor_from_card, verify_card, AgentCard};
+use nucleus_envelope::{verify_bundle, Bundle, BundleBuilder};
+use nucleus_identity::JsonWebKey;
+use nucleus_lineage::{
+    edge_content_hash, CallSpiffeId, EdgeKind, EdgeSigner, InMemorySink, Jwks, LineageEdge,
+    LineageSink, LocalIssuer, Proof,
+};
+
+/// Generate a P-256 keypair: (PKCS#8 DER, matching public JWK).
+fn p256_keypair() -> (Vec<u8>, JsonWebKey) {
+    let rng = SystemRandom::new();
+    let pkcs8 = EcdsaKeyPair::generate_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, &rng).unwrap();
+    let der = pkcs8.as_ref().to_vec();
+    let kp = EcdsaKeyPair::from_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, &der, &rng).unwrap();
+    let pk = kp.public_key().as_ref();
+    let x = URL_SAFE_NO_PAD.encode(&pk[1..33]);
+    let y = URL_SAFE_NO_PAD.encode(&pk[33..65]);
+    (der, JsonWebKey::ec_p256(x, y))
+}
+
+fn pod() -> CallSpiffeId {
+    CallSpiffeId::pod("prod.example.com", "agents", "summarizer").unwrap()
+}
+
+/// Sign `edge` with `issuer`, chaining against `prev`.
+fn signed_edge(
+    issuer: &LocalIssuer,
+    mut edge: LineageEdge,
+    prev: Option<&[u8; 32]>,
+) -> LineageEdge {
+    let bytes = nucleus_lineage::canonical_edge_bytes(&edge, prev);
+    let sig = issuer.sign(&bytes).unwrap();
+    let mut proof = Proof::new(issuer.kid(), issuer.alg(), sig);
+    if let Some(h) = prev {
+        proof = proof.with_prev_hash(*h);
+    }
+    edge.proof = Some(proof);
+    edge
+}
+
+/// Build a real, fully-signed 3-edge Bundle from `issuer`.
+fn build_bundle(issuer: &LocalIssuer) -> Bundle {
+    let sink = InMemorySink::new();
+    let p = pod();
+
+    let e1 = signed_edge(issuer, LineageEdge::pod_admit(p.clone()), None);
+    let h1 = edge_content_hash(&e1, None);
+    sink.emit(e1).unwrap();
+
+    let tool = p.derive_tool("Read", Some(b"input bytes")).unwrap();
+    let e2 = signed_edge(
+        issuer,
+        LineageEdge::from_parent(
+            tool.clone(),
+            p.clone(),
+            EdgeKind::ToolCall {
+                tool: "Read".to_string(),
+            },
+        ),
+        Some(&h1),
+    );
+    let h2 = edge_content_hash(&e2, Some(&h1));
+    sink.emit(e2).unwrap();
+
+    let leaf = tool.derive_artifact(b"summarized output").unwrap();
+    let e3 = signed_edge(
+        issuer,
+        LineageEdge::from_parent(leaf, tool, EdgeKind::ArtifactProduced),
+        Some(&h2),
+    );
+    sink.emit(e3).unwrap();
+
+    let jwks: Jwks = serde_json::from_value(issuer.publish_jwks()).unwrap();
+    BundleBuilder::new(pod())
+        .payload(serde_json::json!({"summary": "summarized output"}))
+        .sink(&sink)
+        .jwks(jwks)
+        .require_signed()
+        .build()
+        .unwrap()
+}
+
+/// A card advertising `issuer`'s `publish_jwks()` as its trust anchor.
+fn card_for(issuer: &LocalIssuer) -> AgentCard {
+    let jwks: Jwks = serde_json::from_value(issuer.publish_jwks()).unwrap();
+    AgentCard {
+        spiffe_id: "spiffe://prod.example.com/ns/agents/sa/summarizer".to_string(),
+        did: "did:web:summarizer.prod.example.com".to_string(),
+        security_schemes: serde_json::json!({}),
+        supported_envelope_schema_versions: vec!["1".to_string(), "2".to_string()],
+        jwks_uri: Some("https://summarizer.prod.example.com/.well-known/jwks.json".to_string()),
+        trust_jwks: jwks,
+    }
+}
+
+#[test]
+fn headline_card_anchored_bundle_verifies() {
+    // Out-of-band card-signing key (resolved by the recipient via DID/JWKS).
+    let (card_der, card_pub) = p256_keypair();
+
+    // The agent's bundle-signing issuer (Ed25519 lineage).
+    let issuer = LocalIssuer::random().unwrap();
+
+    // 1) Agent signs a card advertising issuer's JWKS.
+    let card = card_for(&issuer);
+    let signed = sign_card(card, &card_der).unwrap();
+
+    // 2) Recipient verifies the card against the OUT-OF-BAND key.
+    let verified = verify_card(&signed, &card_pub).expect("card must verify");
+
+    // 3) Derive the TrustAnchor and verify a REAL bundle from that issuer.
+    let anchor = trust_anchor_from_card(&verified);
+    let bundle = build_bundle(&issuer);
+    let report = verify_bundle(&bundle, &anchor)
+        .expect("bundle from the card's advertised issuer MUST verify");
+    assert_eq!(report.edge_count, 3);
+    assert_eq!(report.trust_domain, "prod.example.com");
+    assert!(!report.trust_mode_self_check_only);
+}
+
+#[test]
+fn negative_mismatched_issuer_bundle_is_refused() {
+    // Out-of-band card-signing key.
+    let (card_der, card_pub) = p256_keypair();
+
+    // Issuer A: the issuer the card HONESTLY advertises.
+    let issuer_a = LocalIssuer::random().unwrap();
+    // Issuer B: a DIFFERENT issuer that actually produced the bundle.
+    let issuer_b = LocalIssuer::random().unwrap();
+
+    // The card advertises issuer A's JWKS and is validly signed.
+    let card = card_for(&issuer_a);
+    let signed = sign_card(card, &card_der).unwrap();
+
+    // The card STILL VERIFIES — it is genuinely signed by the resolved key.
+    let verified =
+        verify_card(&signed, &card_pub).expect("validly-signed card must verify regardless");
+
+    // But the bundle is from issuer B, not the advertised issuer A.
+    let anchor = trust_anchor_from_card(&verified);
+    let bundle_from_b = build_bundle(&issuer_b);
+
+    // THE POINT: the recipient REFUSES TO ACT. verify_bundle FAILS because
+    // the bundle's edges are signed by B's kid, which is not in the card's
+    // advertised (A's) JWKS.
+    let err = verify_bundle(&bundle_from_b, &anchor).expect_err(
+        "bundle NOT from the card's advertised issuer MUST be refused (verify_bundle fails)",
+    );
+    assert!(
+        matches!(err, nucleus_envelope::VerifyBundleError::Chain { .. }),
+        "expected a Chain verification failure (UnknownKid inside), got {err:?}"
+    );
+}

--- a/crates/nucleus-verifier-service/Cargo.toml
+++ b/crates/nucleus-verifier-service/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/main.rs"
 [dependencies]
 nucleus-envelope = { path = "../nucleus-envelope" }
 nucleus-lineage = { path = "../nucleus-lineage" }
+nucleus-agent-card = { path = "../nucleus-agent-card" }
 axum = { version = "0.8", features = ["macros", "json"] }
 tokio = { workspace = true, features = ["full"] }
 tower = { version = "0.5", features = ["util", "limit"] }
@@ -46,6 +47,10 @@ tower = { version = "0.5", features = ["util", "limit"] }
 http-body-util = "0.1"
 nucleus-lineage = { path = "../nucleus-lineage", features = ["dev"] }
 nucleus-control-plane = { path = "../nucleus-control-plane" }
+# `sign` lets the route test mint a SignedAgentCard to seed AppState.
+nucleus-agent-card = { path = "../nucleus-agent-card", features = ["sign"] }
+nucleus-identity = { path = "../nucleus-identity" }
+ring = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/nucleus-verifier-service/src/app.rs
+++ b/crates/nucleus-verifier-service/src/app.rs
@@ -79,6 +79,12 @@ pub struct AppState {
     /// peers and `/v1/witness/peers` exposes the ring. When `None`,
     /// both endpoints return 503.
     pub witness: Option<crate::witness::WitnessFederation>,
+    /// Signed Agent Card published at `/.well-known/agent-card.json`. When
+    /// `Some`, the service serves its own verify-before-you-act identity
+    /// document (an A2A-style card whose detached JWS verifies against the
+    /// operator's out-of-band-resolved key). When `None`, the endpoint
+    /// returns 404 — the service makes no identity claim.
+    pub agent_card: Option<Arc<nucleus_agent_card::SignedAgentCard>>,
 }
 
 /// Max request body size in bytes. Provenance bundles are bounded by
@@ -166,6 +172,10 @@ pub fn build_app(state: AppState) -> Router {
         )
         .route("/v1/witness/peers", get(routes::witness_list_peers))
         .route("/.well-known/jwks.json", get(routes::well_known_jwks))
+        .route(
+            "/.well-known/agent-card.json",
+            get(routes::well_known_agent_card),
+        )
         .route(
             "/.well-known/nucleus-verifier-configuration",
             get(routes::well_known_configuration),

--- a/crates/nucleus-verifier-service/src/main.rs
+++ b/crates/nucleus-verifier-service/src/main.rs
@@ -121,7 +121,8 @@ async fn main() -> Result<()> {
         signer,
         metrics,
         merkle,
-        witness: None, // iter-1: configurable via CLI in iter-2
+        witness: None,    // iter-1: configurable via CLI in iter-2
+        agent_card: None, // configurable via CLI in a later iteration
     };
 
     // Retention sweeper — spawned only when persistence is enabled.

--- a/crates/nucleus-verifier-service/src/routes.rs
+++ b/crates/nucleus-verifier-service/src/routes.rs
@@ -724,6 +724,25 @@ pub async fn well_known_jwks(State(state): State<AppState>) -> Json<serde_json::
     })
 }
 
+/// `GET /.well-known/agent-card.json` — the service's own A2A-style
+/// signed Agent Card (verify-before-you-act identity document).
+///
+/// Returns the [`nucleus_agent_card::SignedAgentCard`] configured in
+/// [`AppState::agent_card`]. The card's detached RFC 7515 JWS-JSON
+/// signature verifies against the operator's out-of-band-resolved key —
+/// NEVER against a key embedded in the card. Returns 404 when no card is
+/// configured (the service makes no identity claim in that mode).
+pub async fn well_known_agent_card(
+    State(state): State<AppState>,
+) -> Result<Json<serde_json::Value>, VerifyApiError> {
+    let card = state.agent_card.as_ref().ok_or_else(|| {
+        VerifyApiError::NotFound("no agent card configured for this service".into())
+    })?;
+    let value = serde_json::to_value(card.as_ref())
+        .map_err(|e| VerifyApiError::Internal(format!("serialize agent card: {e}")))?;
+    Ok(Json(value))
+}
+
 /// `GET /.well-known/nucleus-verifier-configuration` — service
 /// description document, modeled on RFC 8414 (OAuth Authorization
 /// Server Metadata) and OIDC discovery conventions. SDKs read this

--- a/crates/nucleus-verifier-service/tests/integration.rs
+++ b/crates/nucleus-verifier-service/tests/integration.rs
@@ -242,6 +242,7 @@ async fn fresh_db_state() -> AppState {
         metrics: None,
         merkle: None,
         witness: None,
+        agent_card: None,
     }
 }
 
@@ -558,6 +559,7 @@ async fn signed_state() -> AppState {
         metrics: None,
         merkle: None,
         witness: None,
+        agent_card: None,
     }
 }
 
@@ -717,6 +719,7 @@ async fn unsigned_sth_path_still_works_without_signer() {
         metrics: None,
         merkle: None,
         witness: None,
+        agent_card: None,
     };
     let resp = build_app(state)
         .oneshot(
@@ -777,6 +780,77 @@ async fn well_known_configuration_describes_service_correctly() {
     assert_eq!(body["persistence"]["bundle_lookup_supported"], true);
     assert_eq!(body["persistence"]["transparency_log_supported"], true);
     assert_eq!(body["limits"]["max_bundle_bytes"], 2 * 1024 * 1024);
+}
+
+#[tokio::test]
+async fn well_known_agent_card_returns_404_without_card() {
+    let resp = build_app(AppState::default())
+        .oneshot(
+            Request::builder()
+                .uri("/.well-known/agent-card.json")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn well_known_agent_card_verifies_against_matching_key() {
+    use nucleus_agent_card::{sign_card, verify_card, AgentCard, SignedAgentCard};
+    use nucleus_identity::JsonWebKey;
+    use ring::rand::SystemRandom;
+    use ring::signature::{EcdsaKeyPair, KeyPair, ECDSA_P256_SHA256_FIXED_SIGNING};
+    use std::sync::Arc;
+
+    // Out-of-band card-signing key (resolved by the caller separately).
+    let rng = SystemRandom::new();
+    let pkcs8 = EcdsaKeyPair::generate_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, &rng).unwrap();
+    let der = pkcs8.as_ref().to_vec();
+    let kp = EcdsaKeyPair::from_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, &der, &rng).unwrap();
+    let pk = kp.public_key().as_ref();
+    let resolved_key = JsonWebKey::ec_p256(
+        base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(&pk[1..33]),
+        base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(&pk[33..65]),
+    );
+
+    // The bundle issuer whose JWKS the card advertises.
+    let issuer = LocalIssuer::random().unwrap();
+    let advertised: Jwks = serde_json::from_value(issuer.publish_jwks()).unwrap();
+
+    let card = AgentCard {
+        spiffe_id: "spiffe://test.nucleus.local/ns/verifier/sa/svc".to_string(),
+        did: "did:web:verifier.test.nucleus.local".to_string(),
+        security_schemes: json!({}),
+        supported_envelope_schema_versions: vec!["1".to_string()],
+        jwks_uri: None,
+        trust_jwks: advertised,
+    };
+    let signed = sign_card(card, &der).unwrap();
+
+    let state = AppState {
+        agent_card: Some(Arc::new(signed)),
+        ..AppState::default()
+    };
+
+    let resp = build_app(state)
+        .oneshot(
+            Request::builder()
+                .uri("/.well-known/agent-card.json")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // The returned card MUST verify against the matching resolved key.
+    let body = read_json(resp.into_body()).await;
+    let returned: SignedAgentCard = serde_json::from_value(body).unwrap();
+    let verified = verify_card(&returned, &resolved_key)
+        .expect("served agent card must verify against the matching out-of-band key");
+    assert_eq!(verified.card.did, "did:web:verifier.test.nucleus.local");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## #1 verify-before-act — `nucleus-agent-card`

The identity/discovery front-half of "verify the peer, **then** act on its bundle." A new crate that signs/verifies an A2A-style **signed Agent Card** and derives a `TrustAnchor` for the already-shipped bundle verifier — closing the "who do I trust" gap onto the "is this bundle authentic" gap.

### The one rule that makes it safe
`verify_card(signed, resolved_key)` reads the verification key **only** from the caller's out-of-band-resolved key — **never** from the card, and it deliberately does **not** iterate signatures looking for a matching `kid` (that would re-introduce card-controlled key selection). A card verified against an attacker-supplied key is "verified garbage"; the API shape forbids it.

### What's here
- `crates/nucleus-agent-card`: `AgentCard`/`SignedAgentCard` types; RFC 8785 JCS canonicalization (`serde_jcs` 0.2.0); **detached RFC 7515 JWS-JSON** verify (always-on, secret-free) + sign (behind the non-default `sign` feature, server-only, never WASM); `trust_anchor_from_card → TrustAnchor::from_jwks`.
- `GET /.well-known/agent-card.json` in `nucleus-verifier-service` (axum 0.8 AppState).

### Tests (all green)
14 unit + 2 integration in the crate, 26 in the service. The centerpiece negative tests:
- card signed by key A, verified with key B → **fails** (the out-of-band key is load-bearing).
- **the handshake actually constrains trust**: a validly-signed card advertising issuer A's JWKS + a bundle from issuer B → `verify_card` passes but `verify_bundle` **fails** (`Chain`/UnknownKid). The recipient **refuses to act**.

### Honest scope
WHO-layer, not WHAT-layer. Does not verify payload/content provenance (that's #4 CAS), no delegated/attenuable capabilities, no DIDComm, no connection/mTLS. The issuer's ES256 key must still be resolved out-of-band; the API forces the caller to supply it. Signing is dev/server-only. WASM `verifyCard` is a follow-on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
