### PR TITLE
feat(bundle-cas): content-addressed bundle transfer (#4) — BLAKE3 + iroh-blobs

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -53,4 +53,11 @@ ignore = [
     # Behind portcullis-core's `wasm-sandbox` feature, not in any default build,
     # no production .wasm execution path. Bumping to wasmtime 44+ tracked in PR #1600.
     "RUSTSEC-2026-0114",
+
+    # atomic-polyfill unmaintained (RUSTSEC-2023-0089) — no security impact.
+    # Transitive via iroh-blobs → postcard 1.1.3 → heapless 0.7.17. postcard pins
+    # heapless ^0.7 (the atomic-polyfill era); no escape until postcard adopts
+    # heapless 0.8+. Informational/unmaintained only — same class as the paste/
+    # proc-macro-error/bincode/derivative ignores above.
+    "RUSTSEC-2023-0089",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "age"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -247,9 +272,9 @@ checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
 name = "arc-swap"
-version = "1.9.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a07d1f37ff60921c83bdfc7407723bdefe89b44b98a9b772f225c8f9d67141a6"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
 dependencies = [
  "rustversion",
 ]
@@ -601,12 +626,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "async_io_stream"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d7b9decdf35d8908a7e3ef02f64c5e9b1695e230154c0e8de3969142d9b94c"
+dependencies = [
+ "futures",
+ "pharos",
+ "rustc_version",
+]
+
+[[package]]
 name = "atoi"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
 ]
 
 [[package]]
@@ -620,6 +665,18 @@ name = "atree"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "239d25181cb40f1955529367ee495e35d03aab4e578028f41e7abc8b21c367a8"
+
+[[package]]
+name = "attohttpc"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e2cdb6d5ed835199484bb92bb8b3edd526effe995c61732580439c1a67e2e9"
+dependencies = [
+ "base64 0.22.1",
+ "http 1.4.0",
+ "log",
+ "url",
+]
 
 [[package]]
 name = "autocfg"
@@ -746,7 +803,7 @@ dependencies = [
  "http 0.2.12",
  "http 1.4.0",
  "http-body 1.0.1",
- "lru",
+ "lru 0.16.3",
  "percent-encoding",
  "regex-lite",
  "sha2 0.11.0",
@@ -1160,10 +1217,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "backon"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
+dependencies = [
+ "fastrand",
+ "gloo-timers",
+ "tokio",
+]
+
+[[package]]
+name = "bao-tree"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06384416b1825e6e04fde63262fda2dc408f5b64c02d04e0d8b70ae72c17a52b"
+dependencies = [
+ "blake3",
+ "bytes",
+ "futures-lite",
+ "genawaiter",
+ "iroh-io",
+ "positioned-io",
+ "range-collections",
+ "self_cell 1.2.2",
+ "serde",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base16ct"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
 
 [[package]]
 name = "base64"
@@ -1223,6 +1316,12 @@ name = "better_any"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4372b9543397a4b86050cc5e7ee36953edf4bac9518e8a774c2da694977fb6e4"
+
+[[package]]
+name = "binary-merge"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597bb81c80a54b6a4381b23faba8d7774b144c94cbd1d6fe3f1329bd776554ab"
 
 [[package]]
 name = "bincode"
@@ -1339,6 +1438,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
 ]
 
 [[package]]
@@ -2300,6 +2408,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cordyceps"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "688d7fbb8092b8de775ef2536f36c8c31f2bc4006ece2e8d8ad2d17d00ce0a2a"
+dependencies = [
+ "loom",
+ "tracing",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2552,6 +2670,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2706,6 +2839,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "ctutils"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2741,7 +2883,9 @@ dependencies = [
  "curve25519-dalek-derive",
  "digest 0.11.2",
  "fiat-crypto 0.3.0",
+ "rand_core 0.10.0",
  "rustc_version",
+ "serde",
  "subtle",
  "zeroize",
 ]
@@ -2842,9 +2986,29 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "data-encoding-macro"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3259c913752a86488b501ed8680446a5ed2d5aeac6e596cb23ba3800768ea32c"
+dependencies = [
+ "data-encoding",
+ "data-encoding-macro-internal",
+]
+
+[[package]]
+name = "data-encoding-macro-internal"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
+dependencies = [
+ "data-encoding",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "deadpool"
@@ -2891,7 +3055,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
- "pem-rfc7468",
+ "pem-rfc7468 0.7.0",
  "zeroize",
 ]
 
@@ -2902,6 +3066,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
 dependencies = [
  "const-oid 0.10.2",
+ "pem-rfc7468 1.0.0",
  "zeroize",
 ]
 
@@ -2995,6 +3160,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diatomic-waker"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab03c107fafeb3ee9f5925686dbb7a73bc76e3932abb0d2b365cb64b169cf04c"
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3076,6 +3247,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2",
+ "libc",
+ "objc2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3084,6 +3267,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "dlopen2"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e2c5bd4158e66d1e215c49b837e11d62f3267b30c92f1d171c4d3105e3dc4d4"
+dependencies = [
+ "libc",
+ "once_cell",
+ "winapi",
 ]
 
 [[package]]
@@ -3179,6 +3373,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
 dependencies = [
  "pkcs8 0.11.0",
+ "serdect",
  "signature 3.0.0",
 ]
 
@@ -3247,14 +3442,14 @@ version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
- "base16ct",
+ "base16ct 0.2.0",
  "crypto-bigint",
  "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
  "hkdf",
- "pem-rfc7468",
+ "pem-rfc7468 0.7.0",
  "pkcs8 0.10.2",
  "rand_core 0.6.4",
  "sec1",
@@ -3290,6 +3485,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "enum-assoc"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed8956bd5c1f0415200516e78ff07ec9e16415ade83c056c230d7b7ea0d55b7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3375,6 +3581,18 @@ name = "extfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a61bffc6f807b136c3efeeac295edde2c65b1e345de7ea777e75f63de7436c6"
+
+[[package]]
+name = "fastbloom"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef975e30683b2d965054bb0a836f8973857c4ebf6acf274fe46617cd285060d8"
+dependencies = [
+ "foldhash 0.2.0",
+ "libm",
+ "portable-atomic",
+ "siphasher",
+]
 
 [[package]]
 name = "fastrand"
@@ -3615,6 +3833,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-buffered"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4421cb78ee172b6b06080093479d3c50f058e7c81b7d577bbb8d118d551d4cd5"
+dependencies = [
+ "cordyceps",
+ "diatomic-waker",
+ "futures-core",
+ "pin-project-lite",
+ "spin 0.10.0",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3657,6 +3888,19 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -3719,6 +3963,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "genawaiter"
+version = "0.99.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c86bd0361bcbde39b13475e6e36cb24c329964aa2611be285289d1e4b751c1a0"
+dependencies = [
+ "futures-core",
+ "genawaiter-macro",
+ "genawaiter-proc-macro",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "genawaiter-macro"
+version = "0.99.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b32dfe1fdfc0bbde1f22a5da25355514b5e450c33a6af6770884c8750aedfbc"
+
+[[package]]
+name = "genawaiter-proc-macro"
+version = "0.99.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784f84eebc366e15251c4a8c3acee82a6a6f427949776ecb88377362a9621738"
+dependencies = [
+ "proc-macro-error 0.4.12",
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "generator"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3778,11 +4053,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.0",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -3802,6 +4089,18 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "governor"
@@ -3887,6 +4186,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbag"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3935,6 +4243,8 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.2.0",
  "serde",
  "serde_core",
@@ -3947,6 +4257,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
  "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version",
+ "serde",
+ "spin 0.9.8",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -3978,6 +4302,83 @@ name = "hex_fmt"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b07f60793ff0a4d9cef0f18e63b5357e06209987153a64648c972c1e5aff336f"
+
+[[package]]
+name = "hickory-net"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "cfg-if",
+ "data-encoding",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "h2 0.4.13",
+ "hickory-proto",
+ "http 1.4.0",
+ "idna",
+ "ipnet",
+ "jni 0.22.4",
+ "rand 0.10.1",
+ "rustls 0.23.40",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-proto"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni 0.22.4",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.1",
+ "ring",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-net",
+ "hickory-proto",
+ "ipconfig",
+ "ipnet",
+ "jni 0.22.4",
+ "moka",
+ "ndk-context",
+ "once_cell",
+ "parking_lot",
+ "rand 0.10.1",
+ "resolv-conf",
+ "rustls 0.23.40",
+ "smallvec",
+ "system-configuration",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tracing",
+]
 
 [[package]]
 name = "hkdf"
@@ -4441,6 +4842,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
+name = "identity-hash"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfdd7caa900436d8f13b2346fe10257e0c05c1f1f9e351f4f5d57c03bd5f45da"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4459,6 +4866,26 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "igd-next"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de7238d487a9aff61f81b5ab41c0a841532a115a398b5fa92a2fadd0885e2581"
+dependencies = [
+ "attohttpc",
+ "bytes",
+ "futures",
+ "http 1.4.0",
+ "http-body-util",
+ "hyper 1.9.0",
+ "hyper-util",
+ "log",
+ "rand 0.10.1",
+ "tokio",
+ "url",
+ "xmltree",
 ]
 
 [[package]]
@@ -4517,6 +4944,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "inplace-vec-builder"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf64c2edc8226891a71f127587a2861b132d2b942310843814d5001d99a1d307"
+dependencies = [
+ "smallvec",
 ]
 
 [[package]]
@@ -4580,10 +5016,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b3f7cef34251886990511df1c61443aa928499d598a9473929ab5a90a527304"
 
 [[package]]
+name = "ipconfig"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
+dependencies = [
+ "socket2 0.6.3",
+ "widestring",
+ "windows-registry",
+ "windows-result",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "iref"
@@ -4605,6 +5057,293 @@ dependencies = [
  "smallvec",
  "static-regular-grammar",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "iroh"
+version = "1.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef865dc2d11a19fe670ff217b68ffc3b511bddf473dc3a3e120090b9f691803"
+dependencies = [
+ "backon",
+ "blake3",
+ "bytes",
+ "cfg_aliases",
+ "ctutils",
+ "data-encoding",
+ "derive_more",
+ "ed25519-dalek 3.0.0-pre.7",
+ "futures-util",
+ "getrandom 0.4.2",
+ "hickory-resolver",
+ "http 1.4.0",
+ "ipnet",
+ "iroh-base",
+ "iroh-dns",
+ "iroh-metrics",
+ "iroh-relay",
+ "n0-error",
+ "n0-future",
+ "n0-watcher",
+ "netwatch",
+ "noq",
+ "noq-proto",
+ "noq-udp",
+ "papaya",
+ "pin-project",
+ "portable-atomic",
+ "portmapper",
+ "rand 0.10.1",
+ "reqwest 0.13.3",
+ "rustc-hash 2.1.2",
+ "rustls 0.23.40",
+ "rustls-pki-types",
+ "rustls-webpki 0.103.13",
+ "serde",
+ "smallvec",
+ "strum 0.28.0",
+ "time",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "url",
+ "wasm-bindgen-futures",
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "iroh-base"
+version = "1.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af93d67701c00c504982154569192ad384738c0450ba1196930314b955100552"
+dependencies = [
+ "curve25519-dalek 5.0.0-pre.6",
+ "data-encoding",
+ "data-encoding-macro",
+ "derive_more",
+ "digest 0.11.2",
+ "ed25519-dalek 3.0.0-pre.7",
+ "getrandom 0.4.2",
+ "n0-error",
+ "rand 0.10.1",
+ "serde",
+ "sha2 0.11.0",
+ "url",
+ "zeroize",
+ "zeroize_derive",
+]
+
+[[package]]
+name = "iroh-blobs"
+version = "0.102.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b492c3b44e08605ad1e7fdc6ef35142543fa1b52166067860199b818e0be7d91"
+dependencies = [
+ "arrayvec 0.7.6",
+ "bao-tree",
+ "bytes",
+ "cfg_aliases",
+ "chrono",
+ "constant_time_eq",
+ "data-encoding",
+ "derive_more",
+ "genawaiter",
+ "getrandom 0.4.2",
+ "hex",
+ "iroh",
+ "iroh-base",
+ "iroh-io",
+ "iroh-metrics",
+ "iroh-tickets",
+ "iroh-util",
+ "irpc",
+ "n0-error",
+ "n0-future",
+ "nested_enum_utils",
+ "noq",
+ "postcard",
+ "rand 0.10.1",
+ "range-collections",
+ "redb",
+ "ref-cast",
+ "reflink-copy",
+ "self_cell 1.2.2",
+ "serde",
+ "smallvec",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "iroh-dns"
+version = "1.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de4112c91eb64094d77df9d3112606dcf7ff216421afccd2dc762fda5a7b2879"
+dependencies = [
+ "arc-swap",
+ "cfg_aliases",
+ "derive_more",
+ "hickory-resolver",
+ "iroh-base",
+ "n0-error",
+ "n0-future",
+ "ndk-context",
+ "rand 0.10.1",
+ "reqwest 0.13.3",
+ "rustls 0.23.40",
+ "simple-dns",
+ "strum 0.28.0",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "iroh-io"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a5feb781017b983ff1b155cd1faf8174da2acafd807aa482876da2d7e6577a"
+dependencies = [
+ "bytes",
+ "futures-lite",
+ "pin-project",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
+name = "iroh-metrics"
+version = "1.0.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d102597d0ee523f17fdb672c532395e634dbe945429284c811430d63bacc0d8a"
+dependencies = [
+ "iroh-metrics-derive",
+ "itoa",
+ "n0-error",
+ "portable-atomic",
+ "ryu",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "iroh-metrics-derive"
+version = "1.0.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c8e0c97f1dc787107f388433c349397c565572fe6406d600ff7bb7b7fe3b30"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "iroh-relay"
+version = "1.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a70030b9e71c1183bd4f88fbdbebfa1af2a5be549dd6f20a1e8ac3cd0202ee9d"
+dependencies = [
+ "blake3",
+ "bytes",
+ "cfg_aliases",
+ "data-encoding",
+ "derive_more",
+ "getrandom 0.4.2",
+ "hickory-resolver",
+ "http 1.4.0",
+ "http-body-util",
+ "hyper 1.9.0",
+ "hyper-util",
+ "iroh-base",
+ "iroh-dns",
+ "iroh-metrics",
+ "lru 0.18.0",
+ "n0-error",
+ "n0-future",
+ "noq",
+ "noq-proto",
+ "num_enum",
+ "pin-project",
+ "postcard",
+ "rand 0.10.1",
+ "reqwest 0.13.3",
+ "rustls 0.23.40",
+ "rustls-pki-types",
+ "serde",
+ "serde_bytes",
+ "strum 0.28.0",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tokio-util",
+ "tokio-websockets",
+ "tracing",
+ "url",
+ "vergen-gitcl",
+ "webpki-roots 1.0.7",
+ "ws_stream_wasm",
+]
+
+[[package]]
+name = "iroh-tickets"
+version = "1.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d4051ac9825cd834d88377dab71c1d9d483b65e9740029b2d624cc17ac58d"
+dependencies = [
+ "data-encoding",
+ "derive_more",
+ "iroh-base",
+ "n0-error",
+ "postcard",
+ "serde",
+]
+
+[[package]]
+name = "iroh-util"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c37db3548c6cb18b4d27a6a3ad16a4e6c372c5ff6b2efd680f56db110deebb2"
+dependencies = [
+ "derive_more",
+ "iroh",
+ "n0-error",
+ "n0-future",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "irpc"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a05799eb70acd04843c327ef939233ccf80f607d30e9ca94857ac7f3d8f18b46"
+dependencies = [
+ "futures-buffered",
+ "futures-util",
+ "irpc-derive",
+ "n0-error",
+ "n0-future",
+ "noq",
+ "postcard",
+ "rcgen",
+ "rustls 0.23.40",
+ "serde",
+ "smallvec",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "irpc-derive"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "445d81dbc1eed4dab6379bf7f97d12ac28ce8e6f3f7d6660c9f333b7b5d8d03b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4677,6 +5416,36 @@ dependencies = [
  "thiserror 1.0.69",
  "walkdir",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5009,10 +5778,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
+dependencies = [
+ "hashbrown 0.17.1",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "mac-addr"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d25b0e0b648a86960ac23b7ad4abb9717601dec6f66c165f5b037f3f03065f"
 
 [[package]]
 name = "mach2"
@@ -5265,6 +6049,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "moka"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
+]
+
+[[package]]
 name = "mp4"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5291,6 +6092,197 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a198f9589efc03f544388dfc4a19fe8af4323662b62f598b8dcfdac62c14771c"
 dependencies = [
  "byteorder",
+]
+
+[[package]]
+name = "n0-error"
+version = "1.0.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "223e946a84aa91644507a6b7865cfebbb9a231ace499041c747ab0fd30408212"
+dependencies = [
+ "n0-error-macros",
+ "spez",
+]
+
+[[package]]
+name = "n0-error-macros"
+version = "1.0.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "565305a21e6b3bf26640ad98f05a0fda12d3ab4315394566b52a7bddb8b34828"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "n0-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2ab99dfb861450e68853d34ae665243a88b8c493d01ba957321a1e9b2312bbe"
+dependencies = [
+ "cfg_aliases",
+ "derive_more",
+ "futures-buffered",
+ "futures-lite",
+ "futures-util",
+ "js-sys",
+ "pin-project",
+ "send_wrapper",
+ "tokio",
+ "tokio-util",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-time",
+]
+
+[[package]]
+name = "n0-watcher"
+version = "1.0.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928d8039a66cce5efcfd35e88b32d3defc8eba630b3ac451522997f563956a52"
+dependencies = [
+ "derive_more",
+ "n0-error",
+ "n0-future",
+]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "nested_enum_utils"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d5475271bdd36a4a2769eac1ef88df0f99428ea43e52dfd8b0ee5cb674695f"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "netdev"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57bacaf873ee4eab5646f99b381b271ec75e716902a67cf962c0f328c5eb5bfb"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "dlopen2",
+ "ipnet",
+ "libc",
+ "mac-addr",
+ "netlink-packet-core",
+ "netlink-packet-route 0.29.0",
+ "netlink-sys",
+ "objc2-core-foundation",
+ "objc2-core-wlan",
+ "objc2-foundation",
+ "objc2-system-configuration",
+ "once_cell",
+ "plist",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "netlink-packet-core"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3463cbb78394cb0141e2c926b93fc2197e473394b761986eca3b9da2c63ae0f4"
+dependencies = [
+ "paste",
+]
+
+[[package]]
+name = "netlink-packet-route"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9854ea6ad14e3f4698a7f03b65bce0833dd2d81d594a0e4a984170537146b6"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+ "log",
+ "netlink-packet-core",
+]
+
+[[package]]
+name = "netlink-packet-route"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be8919612f6028ab4eacbbfe1234a9a43e3722c6e0915e7ff519066991905092"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+ "log",
+ "netlink-packet-core",
+]
+
+[[package]]
+name = "netlink-proto"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b65d130ee111430e47eed7896ea43ca693c387f097dd97376bffafbf25812128"
+dependencies = [
+ "bytes",
+ "futures",
+ "log",
+ "netlink-packet-core",
+ "netlink-sys",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "netlink-sys"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd6c30ed10fa69cc491d491b85cc971f6bdeb8e7367b7cde2ee6cc878d583fae"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "libc",
+ "log",
+ "tokio",
+]
+
+[[package]]
+name = "netwatch"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2071e0c2b5b229622c459096b84f1ad51afa150cdeeefdad491ef3704e581d91"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "cfg_aliases",
+ "derive_more",
+ "js-sys",
+ "libc",
+ "n0-error",
+ "n0-future",
+ "n0-watcher",
+ "netdev",
+ "netlink-packet-core",
+ "netlink-packet-route 0.30.0",
+ "netlink-proto",
+ "netlink-sys",
+ "noq-udp",
+ "objc2-core-foundation",
+ "objc2-system-configuration",
+ "pin-project-lite",
+ "serde",
+ "socket2 0.6.3",
+ "time",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "web-sys",
+ "windows",
+ "windows-result",
+ "wmi",
 ]
 
 [[package]]
@@ -5369,6 +6361,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
+name = "noq"
+version = "1.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "198b99fc085a5db1f7d259edb5ede8311e59f28cdd2687920b4313613d21a73f"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "derive_more",
+ "noq-proto",
+ "noq-udp",
+ "pin-project-lite",
+ "rustc-hash 2.1.2",
+ "rustls 0.23.40",
+ "socket2 0.6.3",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "noq-proto"
+version = "1.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ab0ac774795ce1e42a7e61266e71f3be8110210630441169ac8dda403dd23f1"
+dependencies = [
+ "aes-gcm",
+ "bytes",
+ "derive_more",
+ "enum-assoc",
+ "fastbloom",
+ "getrandom 0.4.2",
+ "identity-hash",
+ "lru-slab",
+ "rand 0.10.1",
+ "rand_pcg",
+ "ring",
+ "rustc-hash 2.1.2",
+ "rustls 0.23.40",
+ "rustls-pki-types",
+ "rustls-platform-verifier 0.7.0",
+ "slab",
+ "sorted-index-buffer",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "noq-udp"
+version = "1.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3c1520eacd33fd6b009e2e70116b05508ade51db5e0d315ff8bf6b702148c2b"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "socket2 0.6.3",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5421,6 +6477,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "nucleus-bundle-cas"
+version = "1.0.0"
+dependencies = [
+ "anyhow",
+ "blake3",
+ "iroh",
+ "iroh-blobs",
+ "nucleus-envelope",
+ "nucleus-lineage",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
 name = "nucleus-cli"
 version = "1.0.0"
 dependencies = [
@@ -5431,6 +6502,9 @@ dependencies = [
  "dirs",
  "hex",
  "hmac 0.13.0",
+ "iroh",
+ "iroh-blobs",
+ "nucleus-bundle-cas",
  "nucleus-client",
  "nucleus-envelope",
  "nucleus-lineage",
@@ -6047,6 +7121,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6071,12 +7146,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
 name = "objc2-core-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.11.0",
+ "block2",
+ "dispatch2",
+ "libc",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-wlan"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71e34919aba0d701380d911702455038a8a3587467fe0141d6a71501e7ffe48"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-security",
+ "objc2-security-foundation",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-security"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-security-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef76382e9cedd18123099f17638715cc3d81dba3637d4c0d39ab69df2ef345a5"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -6085,7 +7227,12 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
 dependencies = [
+ "bitflags 2.11.0",
+ "dispatch2",
+ "libc",
+ "objc2",
  "objc2-core-foundation",
+ "objc2-security",
 ]
 
 [[package]]
@@ -6123,6 +7270,10 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "once_cell_polyfill"
@@ -6314,7 +7465,7 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
 dependencies = [
- "base16ct",
+ "base16ct 0.2.0",
  "ecdsa",
  "elliptic-curve",
  "primeorder",
@@ -6329,6 +7480,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
 dependencies = [
  "group",
+]
+
+[[package]]
+name = "papaya"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "997ee03cd38c01469a7046643714f0ad28880bcb9e6679ff0666e24817ca19b7"
+dependencies = [
+ "equivalent",
+ "seize",
 ]
 
 [[package]]
@@ -6421,6 +7582,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6455,6 +7625,16 @@ dependencies = [
  "fixedbitset 0.5.7",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
+]
+
+[[package]]
+name = "pharos"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414"
+dependencies = [
+ "futures",
+ "rustc_version",
 ]
 
 [[package]]
@@ -6554,6 +7734,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "plist"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
+dependencies = [
+ "base64 0.22.1",
+ "indexmap 2.14.0",
+ "quick-xml",
+ "serde",
+ "time",
+]
+
+[[package]]
 name = "png_pong"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6578,10 +7771,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "portcullis"
@@ -6646,6 +7854,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "portmapper"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64959cbabf952c8ffcbaea13745308508f1f825922f4068353f3de08d42cf214"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "derive_more",
+ "hyper-util",
+ "igd-next",
+ "iroh-metrics",
+ "libc",
+ "n0-error",
+ "n0-future",
+ "netwatch",
+ "num_enum",
+ "rand 0.10.1",
+ "serde",
+ "smallvec",
+ "socket2 0.6.3",
+ "time",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "positioned-io"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ec4b80060f033312b99b6874025d9503d2af87aef2dd4c516e253fbfcdada7"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "postcard"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6654,7 +7901,20 @@ dependencies = [
  "cobs",
  "embedded-io 0.4.0",
  "embedded-io 0.6.1",
+ "heapless",
+ "postcard-derive",
  "serde",
+]
+
+[[package]]
+name = "postcard-derive"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0232bd009a197ceec9cc881ba46f727fcd8060a2d8d6a9dde7a69030a6fe2bb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6686,6 +7946,17 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "prefix-trie"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
+]
 
 [[package]]
 name = "pretty"
@@ -6738,14 +8009,40 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-error"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18f33027081eba0a6d8aba6d1b1c3a3be58cbb12106341c2d5759fcd9b5277e7"
+dependencies = [
+ "proc-macro-error-attr 0.4.12",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
- "proc-macro-error-attr",
+ "proc-macro-error-attr 1.0.4",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a5b4b77fdb63c1eca72173d68d24501c54ab1269409f6b672c85deb18af69de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "syn-mid",
  "version_check",
 ]
 
@@ -6781,6 +8078,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.20+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
@@ -7225,6 +8528,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "rand_xorshift"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7240,6 +8552,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
 dependencies = [
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "range-collections"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "861706ea9c4aded7584c5cd1d241cec2ea7f5f50999f236c22b65409a1f1a0d0"
+dependencies = [
+ "binary-merge",
+ "inplace-vec-builder",
+ "ref-cast",
+ "serde",
+ "smallvec",
 ]
 
 [[package]]
@@ -7368,8 +8693,8 @@ dependencies = [
  "indoc",
  "itertools 0.14.0",
  "kasuari",
- "lru",
- "strum",
+ "lru 0.16.3",
+ "strum 0.27.2",
  "thiserror 2.0.18",
  "unicode-segmentation",
  "unicode-truncate",
@@ -7401,7 +8726,7 @@ dependencies = [
  "itertools 0.14.0",
  "line-clipping",
  "ratatui-core",
- "strum",
+ "strum 0.27.2",
  "time",
  "unicode-segmentation",
  "unicode-width 0.2.2",
@@ -7448,6 +8773,15 @@ dependencies = [
  "time",
  "x509-parser",
  "yasna",
+]
+
+[[package]]
+name = "redb"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e925444704b5f17d32bf42f5b6e2df050bceebc3dcd6e71cc73dafe8092e839"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -7508,6 +8842,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "reflink-copy"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13362233b147e57674c37b802d216b7c5e3dcccbed8967c84f0d8d223868ae27"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "rustix",
+ "windows",
 ]
 
 [[package]]
@@ -7606,7 +8952,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.4.2",
  "web-sys",
  "webpki-roots 1.0.7",
 ]
@@ -7635,21 +8981,29 @@ dependencies = [
  "quinn",
  "rustls 0.23.40",
  "rustls-pki-types",
- "rustls-platform-verifier",
+ "rustls-platform-verifier 0.6.2",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls 0.26.4",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams 0.5.0",
  "web-sys",
 ]
+
+[[package]]
+name = "resolv-conf"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "rfc6979"
@@ -8195,7 +9549,28 @@ checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
- "jni",
+ "jni 0.21.1",
+ "log",
+ "once_cell",
+ "rustls 0.23.40",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki 0.103.13",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni 0.22.4",
  "log",
  "once_cell",
  "rustls 0.23.40",
@@ -8272,7 +9647,7 @@ dependencies = [
  "serde",
  "serde_with",
  "sha2 0.10.9",
- "strum",
+ "strum 0.27.2",
  "tempfile",
  "thiserror 2.0.18",
  "toml 0.8.23",
@@ -8389,7 +9764,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
- "base16ct",
+ "base16ct 0.2.0",
  "der 0.7.10",
  "generic-array",
  "pkcs8 0.10.2",
@@ -8430,6 +9805,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "seize"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "self_cell"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8453,6 +9838,12 @@ dependencies = [
  "serde",
  "serde_core",
 ]
+
+[[package]]
+name = "send_wrapper"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
@@ -8636,6 +10027,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serdect"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
+dependencies = [
+ "base16ct 1.0.0",
+ "serde",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8656,6 +10057,12 @@ dependencies = [
  "cpufeatures 0.3.0",
  "digest 0.11.2",
 ]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
 name = "sha2"
@@ -8796,10 +10203,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "simple-dns"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a75cbde1bf934313596a004973e462f9a82caa814dcf1a5f507bdf51597eeb4"
+dependencies = [
+ "bitflags 2.11.0",
+]
 
 [[package]]
 name = "simple_asn1"
@@ -8889,6 +10315,23 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "sorted-index-buffer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea06cc588e43c632923a55450401b8f25e628131571d4e1baea1bdfdb2b5ed06"
+
+[[package]]
+name = "spez"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c87e960f4dca2788eeb86bbdde8dd246be8948790b7618d656e68f9b720a86e8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -9217,7 +10660,7 @@ dependencies = [
  "ciborium",
  "hex_fmt",
  "indoc",
- "proc-macro-error",
+ "proc-macro-error 1.0.4",
  "proc-macro2",
  "quote",
  "serde",
@@ -9267,7 +10710,16 @@ version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.27.2",
+]
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros 0.28.0",
 ]
 
 [[package]]
@@ -9275,6 +10727,18 @@ name = "strum_macros"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -9308,6 +10772,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "syn-mid"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea305d57546cc8cd04feb14b62ec84bf17f50e3f7b12560d7bfa9265f39d9ed"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -9350,6 +10825,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tap"
@@ -9451,6 +10932,7 @@ checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
+ "js-sys",
  "libc",
  "num-conv",
  "num_threads",
@@ -9559,6 +11041,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -9597,6 +11080,29 @@ dependencies = [
  "libc",
  "tokio",
  "vsock",
+]
+
+[[package]]
+name = "tokio-websockets"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dad543404f98bfc969aeb71994105c592acfc6c43323fddcd016bb208d1c65cb"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "getrandom 0.4.2",
+ "http 1.4.0",
+ "httparse",
+ "rand 0.10.1",
+ "ring",
+ "rustls-pki-types",
+ "sha1_smol",
+ "simdutf8",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tokio-util",
 ]
 
 [[package]]
@@ -10197,6 +11703,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -10252,6 +11759,43 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vergen"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b849a1f6d8639e8de261e81ee0fc881e3e3620db1af9f2e0da015d4382ceaf75"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "rustversion",
+ "vergen-lib",
+]
+
+[[package]]
+name = "vergen-gitcl"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ff3b5300a085d6bcd8fc96a507f706a28ae3814693236c9b409db71a1d15b9"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "rustversion",
+ "time",
+ "vergen",
+ "vergen-lib",
+]
+
+[[package]]
+name = "vergen-lib"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b34a29ba7e9c59e62f229ae1932fb1b8fb8a6fdcc99215a641913f5f5a59a569"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "rustversion",
+]
 
 [[package]]
 name = "version_check"
@@ -10500,6 +12044,19 @@ name = "wasm-streams"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -10894,6 +12451,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10944,6 +12507,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10954,6 +12538,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -10983,6 +12578,16 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-registry"
@@ -11102,6 +12707,15 @@ dependencies = [
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -11396,10 +13010,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "wmi"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c81b85c57a57500e56669586496bf2abd5cf082b9d32995251185d105208b64"
+dependencies = [
+ "chrono",
+ "futures",
+ "log",
+ "serde",
+ "thiserror 2.0.18",
+ "windows",
+ "windows-core",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "ws_stream_wasm"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c173014acad22e83f16403ee360115b38846fe754e735c5d9d3803fe70c6abc"
+dependencies = [
+ "async_io_stream",
+ "futures",
+ "js-sys",
+ "log",
+ "pharos",
+ "rustc_version",
+ "send_wrapper",
+ "thiserror 2.0.18",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "wstd"
@@ -11474,10 +13122,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd223bc94c615fc02bf2f4bbc22a4a9bfe489c2add3ec10b1038df3aca44cac7"
 
 [[package]]
+name = "xml-rs"
+version = "0.8.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
+
+[[package]]
 name = "xmlparser"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
+
+[[package]]
+name = "xmltree"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7d8a75eaf6557bb84a65ace8609883db44a29951042ada9b393151532e41fcb"
+dependencies = [
+ "xml-rs",
+]
 
 [[package]]
 name = "yaml-rust2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ members = [
     "crates/ck-kernel",                 # Constitutional Kernel: admission engine + lineage
     "crates/nucleus-lineage",            # Per-call SPIFFE-derived data lineage
     "crates/nucleus-envelope",           # Portable provenance bundle: payload + IFC envelope
+    "crates/nucleus-bundle-cas",         # Content-addressed bundle transport: BLAKE3 root + iroh-blobs
     "crates/nucleus-envelope-adversarial-corpus", # Adversarial bundles every verifier must reject — CI-gated security promise
     "crates/nucleus-otel-bootstrap",     # Shared OpenTelemetry OTLP bootstrap for server binaries
     "crates/nucleus-control-plane",      # Job orchestrator: typed JobSpec → agent → Bundle

--- a/crates/nucleus-bundle-cas/Cargo.toml
+++ b/crates/nucleus-bundle-cas/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "nucleus-bundle-cas"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+description = "Content-addressed transport for nucleus provenance bundles (BLAKE3 root + iroh-blobs)"
+repository = "https://github.com/coproduct-opensource/nucleus"
+documentation = "https://docs.rs/nucleus-bundle-cas"
+readme = "README.md"
+keywords = ["provenance", "content-addressed", "blake3", "iroh", "p2p"]
+categories = ["cryptography", "network-programming"]
+
+[dependencies]
+nucleus-envelope = { path = "../nucleus-envelope" }
+
+# Serialization
+serde_json = { workspace = true }
+
+# Content-addressed transport id (BLAKE3 root over the serialized Bundle).
+# Pinned to the latest stable blake3 — this is a TRANSPORT id, distinct from
+# the SHA-256 canonical_bundle_hash in nucleus-envelope.
+blake3 = "1.8.5"
+
+# Peer-to-peer content-addressed blob transfer. iroh/iroh-blobs are pre-1.0
+# (expect churn): iroh-blobs 0.102.0 pins iroh =1.0.0-rc.1, so both move
+# together. The QUIC/TLS stack rides on rustls 0.23 (already in-workspace).
+iroh = "=1.0.0-rc.1"
+iroh-blobs = "=0.102.0"
+
+# Error handling
+thiserror = { workspace = true }
+anyhow = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+# `dev` enables LocalIssuer/InMemorySink for building real signed test bundles.
+nucleus-lineage = { path = "../nucleus-lineage", features = ["dev"] }
+nucleus-envelope = { path = "../nucleus-envelope" }
+
+[lints]
+workspace = true

--- a/crates/nucleus-bundle-cas/src/fetch.rs
+++ b/crates/nucleus-bundle-cas/src/fetch.rs
@@ -1,0 +1,82 @@
+//! Fetch a [`Bundle`] from an untrusted peer by its BLAKE3 root.
+//!
+//! The transfer rides iroh-blobs' **bao-verified** get stream: the requested
+//! [`BundleHash`] is the verification root, so a peer that serves any bytes
+//! whose BLAKE3 root is not exactly that hash causes the fetch to FAIL. A
+//! peer cannot substitute content.
+//!
+//! What this does NOT do (see crate trust-model docs):
+//!   - no discovery — `node_addr` is supplied out-of-band;
+//!   - no availability guarantee — a peer can be offline or refuse to serve;
+//!   - no provenance — the returned bytes deserialize to a [`Bundle`], but
+//!     you MUST still run [`nucleus_envelope::verify_bundle`] with an
+//!     out-of-band trust anchor. fetched != trusted.
+
+use iroh::{Endpoint, EndpointAddr};
+use iroh_blobs::store::mem::MemStore;
+use nucleus_envelope::Bundle;
+
+use crate::BundleHash;
+
+/// Errors from [`fetch_bundle`].
+#[derive(Debug, thiserror::Error)]
+pub enum FetchError {
+    /// Could not open a QUIC connection to the peer (offline, wrong addr,
+    /// ALPN refused, …). An availability failure, NOT a content failure.
+    #[error("connecting to peer over iroh: {0}")]
+    Connect(#[source] anyhow::Error),
+    /// The bao-verified get stream failed. The load-bearing case: the peer
+    /// served bytes that do NOT hash to the requested [`BundleHash`], so
+    /// verification rejected them. Also covers truncated/corrupted streams.
+    /// A peer CANNOT substitute content under this error.
+    #[error("bao-verified fetch failed (content mismatch, truncation, or transport error): {0}")]
+    Get(#[source] anyhow::Error),
+    /// The verified bytes were retrieved but are not present locally after
+    /// the get (should not happen on success).
+    #[error("reading fetched bytes from store: {0}")]
+    Read(#[source] anyhow::Error),
+    /// The (hash-verified) bytes did not deserialize to a [`Bundle`]. The
+    /// bytes are byte-for-byte what the producer published, but they are not
+    /// a valid bundle — a producer-side bug, not a transport substitution.
+    #[error("fetched bytes are not a valid bundle JSON: {0}")]
+    Deserialize(#[source] serde_json::Error),
+}
+
+/// Connect to `node_addr` (an [`EndpointAddr`] obtained out-of-band — iroh's
+/// "node ticket"), fetch the blob identified by `hash` over a bao-verified
+/// iroh-blobs stream into `store`, and deserialize it to a [`Bundle`].
+///
+/// On success the returned bytes are guaranteed to BLAKE3-hash to exactly
+/// `hash` (the bao stream enforces it). This is byte-integrity ONLY — run
+/// [`nucleus_envelope::verify_bundle`] afterwards for provenance.
+pub async fn fetch_bundle(
+    endpoint: &Endpoint,
+    store: &MemStore,
+    node_addr: EndpointAddr,
+    hash: BundleHash,
+) -> Result<Bundle, FetchError> {
+    let iroh_hash: iroh_blobs::Hash = hash.into();
+
+    // Out-of-band addressing: connect directly using the supplied NodeAddr
+    // over the blobs ALPN. No discovery is consulted.
+    let conn = endpoint
+        .connect(node_addr, iroh_blobs::ALPN)
+        .await
+        .map_err(|e| FetchError::Connect(e.into()))?;
+
+    // Bao-verified get: `hash` is the verification root. Anything that does
+    // not reproduce this BLAKE3 root is rejected before it reaches us.
+    store
+        .remote()
+        .fetch(conn, iroh_hash)
+        .await
+        .map_err(|e| FetchError::Get(e.into()))?;
+
+    // The verified bytes now live in `store`; read them back.
+    let bytes = store
+        .get_bytes(iroh_hash)
+        .await
+        .map_err(|e| FetchError::Read(e.into()))?;
+
+    serde_json::from_slice(&bytes).map_err(FetchError::Deserialize)
+}

--- a/crates/nucleus-bundle-cas/src/hash.rs
+++ b/crates/nucleus-bundle-cas/src/hash.rs
@@ -1,0 +1,112 @@
+//! BLAKE3 transport hashing for bundles.
+//!
+//! # ⚠️  THIS IS A TRANSPORT ID, NOT THE CANONICAL HASH ⚠️
+//!
+//! [`blake3_bundle_hash`] computes a **BLAKE3-256 digest over the FULL
+//! `serde_json::to_vec(&bundle)` bytes**. Its sole purpose is to address
+//! the bundle for content-addressed transfer over iroh-blobs.
+//!
+//! This is **DISTINCT** from [`nucleus_envelope::canonical_bundle_hash`],
+//! which is:
+//!   - a **SHA-256** digest (not BLAKE3),
+//!   - over **selected canonical fields** (session_root, chain head, payload
+//!     hash) — NOT the full serialized bytes,
+//!   - deliberately **excludes** the `attestation` field so an attestation
+//!     can be attached/stripped without changing identity.
+//!
+//! Consequences you must not forget:
+//!   - The two hashes will NEVER be equal and serve different roles. Use the
+//!     canonical hash for attestation/identity; use THIS one only for
+//!     transport addressing.
+//!   - Because this hashes the FULL bytes, attaching an attestation, or any
+//!     other byte-level change, produces a DIFFERENT [`BundleHash`]. That is
+//!     correct for a transport id (it addresses exact bytes) and is exactly
+//!     why it must not be conflated with the canonical identity.
+//!   - The resulting 32 bytes are a **bare BLAKE3 digest — NOT a CID**.
+
+use nucleus_envelope::Bundle;
+
+use crate::BundleHash;
+
+/// Compute the content-addressed transport id of `bundle`: the BLAKE3-256
+/// root of `serde_json::to_vec(&bundle)`.
+///
+/// Deterministic: serde_json serializes struct fields in declaration order,
+/// so the same `Bundle` value always yields the same bytes and therefore the
+/// same hash. A single-byte change anywhere in the serialized form changes
+/// the hash.
+///
+/// See the module docs: this is a TRANSPORT id, NOT
+/// [`nucleus_envelope::canonical_bundle_hash`], and NOT a CID.
+///
+/// # Panics
+///
+/// Never in practice. `Bundle` is a plain `Serialize` tree of JSON-safe
+/// types, so `serde_json::to_vec` cannot fail; we surface the impossible
+/// case as an empty input rather than panicking.
+pub fn blake3_bundle_hash(bundle: &Bundle) -> BundleHash {
+    let bytes = serde_json::to_vec(bundle).unwrap_or_default();
+    let digest = blake3::hash(&bytes);
+    BundleHash(*digest.as_bytes())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nucleus_lineage::{CallSpiffeId, EdgeKind, InMemorySink, Jwks, LineageEdge, LineageSink};
+
+    fn fixture_bundle(summary: &str) -> Bundle {
+        let sink = InMemorySink::new();
+        let p = CallSpiffeId::pod("prod.example.com", "agents", "summarizer").unwrap();
+        sink.emit(LineageEdge::pod_admit(p.clone())).unwrap();
+        sink.emit(LineageEdge::from_parent(
+            p.derive_tool("Read", Some(b"hello")).unwrap(),
+            p.clone(),
+            EdgeKind::ToolCall {
+                tool: "Read".to_string(),
+            },
+        ))
+        .unwrap();
+        nucleus_envelope::BundleBuilder::new(p)
+            .payload(serde_json::json!({ "summary": summary }))
+            .sink(&sink)
+            .jwks(Jwks { keys: vec![] })
+            .build()
+            .unwrap()
+    }
+
+    #[test]
+    fn blake3_bundle_hash_is_deterministic() {
+        let b = fixture_bundle("hi");
+        let h1 = blake3_bundle_hash(&b);
+        let h2 = blake3_bundle_hash(&b);
+        assert_eq!(h1, h2);
+        assert_eq!(h1.as_bytes().len(), 32);
+    }
+
+    #[test]
+    fn one_byte_payload_mutation_changes_the_hash() {
+        let b = fixture_bundle("hi");
+        let h1 = blake3_bundle_hash(&b);
+
+        // Mutate exactly one payload byte ('hi' -> 'hj').
+        let mut b2 = b.clone();
+        b2.payload = serde_json::json!({ "summary": "hj" });
+        let h2 = blake3_bundle_hash(&b2);
+
+        assert_ne!(
+            h1, h2,
+            "a 1-byte payload change must change the BLAKE3 hash"
+        );
+    }
+
+    #[test]
+    fn distinct_from_canonical_sha256_hash() {
+        // Documented invariant: the BLAKE3 transport id is not the SHA-256
+        // canonical hash. Their byte values differ.
+        let b = fixture_bundle("hi");
+        let transport = blake3_bundle_hash(&b);
+        let canonical = nucleus_envelope::canonical_bundle_hash(&b);
+        assert_ne!(transport.as_bytes(), &canonical);
+    }
+}

--- a/crates/nucleus-bundle-cas/src/lib.rs
+++ b/crates/nucleus-bundle-cas/src/lib.rs
@@ -1,0 +1,226 @@
+//! Content-addressed transport for nucleus provenance [`Bundle`]s.
+//!
+//! This crate addresses a serialized [`Bundle`] by the BLAKE3 hash of its
+//! JSON bytes ([`BundleHash`]) and fetches+verifies it from an untrusted
+//! peer over [`iroh-blobs`](iroh_blobs) (a bao-verified blob stream). The
+//! delivered bytes are then piped into the EXISTING
+//! [`nucleus_envelope::verify_bundle`] — content-addressing is a transport
+//! concern and is deliberately ORTHOGONAL to provenance.
+//!
+//! # Trust model — read this before pitching to anyone
+//!
+//! This is the SMALLEST shippable slice of "topology #4": fetch a bundle by
+//! its BLAKE3 root from a peer whose node ticket you already have. The
+//! guarantees are intentionally narrow:
+//!
+//! - **No content DISCOVERY.** The node ticket (a [`iroh::NodeAddr`]) is
+//!   passed OUT-OF-BAND. There is NO DHT, NO content routing, NO provider
+//!   advertisement. "DHT" / discovery is deferred and aspirational — do not
+//!   claim it exists.
+//!
+//! - **No NAT traversal in this slice.** Relays/holepunching are iroh's job
+//!   but are not exercised or guaranteed here; addresses are supplied
+//!   directly.
+//!
+//! - **No availability guarantee.** A peer can be offline, or can lie about
+//!   *having* the bytes (refuse to serve, stall, serve nothing). The only
+//!   thing this crate guarantees is the **CORRECTNESS of delivered bytes**:
+//!   if a peer returns bytes, the bao-verified stream rejects anything whose
+//!   BLAKE3 root is not exactly the requested [`BundleHash`]. A peer cannot
+//!   SUBSTITUTE content.
+//!
+//! - **fetched != trusted.** BLAKE3 byte-integrity is ORTHOGONAL to envelope
+//!   provenance. A perfect-hash fetch can STILL FAIL
+//!   [`nucleus_envelope::verify_bundle`] (e.g. forged/unknown issuer JWKS).
+//!   You MUST run `verify_bundle` with an out-of-band [`TrustAnchor`] after
+//!   fetching. Receiving the exact bytes you asked for says NOTHING about
+//!   who produced them.
+//!
+//! - **A raw 32-byte BLAKE3 hash is NOT a CID.** [`BundleHash`] is a bare
+//!   BLAKE3-256 digest of the bundle's JSON bytes. It carries no multihash
+//!   prefix, no multicodec, no multibase. Do **not** call it a CID, and do
+//!   not interoperate with IPLD/IPFS tooling as if it were one.
+//!
+//! - **This [`BundleHash`] is a TRANSPORT id, DISTINCT from the SHA-256
+//!   [`nucleus_envelope::canonical_bundle_hash`].** The canonical hash is a
+//!   stable, attestation-bearing identity over selected canonical fields
+//!   (and excludes the `attestation` field). This BLAKE3 hash is over the
+//!   FULL `serde_json::to_vec(&bundle)` bytes — any byte change (including
+//!   the attestation field) changes it. They serve different purposes; never
+//!   conflate them.
+//!
+//! - **Not wired into the WASM/browser verifier.** iroh-blobs is a native
+//!   (tokio + QUIC) transport; this crate is server/CLI-side only.
+//!
+//! # Single-tenant value (split-trust across failure domains)
+//!
+//! This is useful to ONE operator with zero counterparties: content-addressed,
+//! bao-verified replication of your own provenance bundles across your own
+//! machines/regions/clouds — resilient, dedup-friendly, tamper-evident archival
+//! and disaster-recovery where any replica's bytes self-validate against the
+//! [`BundleHash`]. The "mesh" value is *failure-domain diversity*, not other
+//! organizations; peer fan-out is additive, not a prerequisite. (Remember:
+//! fetched != trusted — replication integrity is orthogonal to provenance.)
+//!
+//! # Metering seam (dormant; do NOT wire payment here yet)
+//!
+//! [`fetch_bundle`] verifies bytes against the BLAKE3 root — i.e. bytes a peer
+//! *provably* served. That is the natural future metering point for a
+//! pay-per-PROVEN-byte tier (priced by nucleus's verified VCG/Pigou clearing,
+//! settled over x402/L402). It is deliberately NOT implemented: no payment, no
+//! accounting, no token — the seam is documented so the paid tier is additive,
+//! not a rewrite. Meter only proven work (verified bytes), never self-reported.
+//!
+//! [`Bundle`]: nucleus_envelope::Bundle
+//! [`TrustAnchor`]: nucleus_envelope::TrustAnchor
+
+use std::fmt;
+use std::str::FromStr;
+
+pub mod fetch;
+pub mod hash;
+pub mod publish;
+
+pub use fetch::{fetch_bundle, FetchError};
+pub use hash::blake3_bundle_hash;
+pub use publish::{publish_bundle, PublishError};
+
+/// Length, in bytes, of a [`BundleHash`] (BLAKE3-256 digest).
+pub const BUNDLE_HASH_LEN: usize = 32;
+
+/// A content-addressed transport identifier for a serialized
+/// [`nucleus_envelope::Bundle`]: the **BLAKE3-256 root** of its JSON bytes.
+///
+/// # NOT a CID, NOT the canonical hash
+///
+/// - This is a bare 32-byte BLAKE3 digest. It is **NOT a CID** (no
+///   multihash/multicodec/multibase framing).
+/// - It is **DISTINCT** from [`nucleus_envelope::canonical_bundle_hash`]
+///   (SHA-256, over selected canonical fields). This BLAKE3 hash is a
+///   pure transport id over the full serialized bytes.
+///
+/// On the wire to iroh-blobs it maps 1:1 to an [`iroh_blobs::Hash`].
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct BundleHash(pub [u8; BUNDLE_HASH_LEN]);
+
+impl BundleHash {
+    /// Construct from raw bytes.
+    pub const fn from_bytes(bytes: [u8; BUNDLE_HASH_LEN]) -> Self {
+        Self(bytes)
+    }
+
+    /// The raw 32 bytes of the digest.
+    pub const fn as_bytes(&self) -> &[u8; BUNDLE_HASH_LEN] {
+        &self.0
+    }
+
+    /// Lowercase hex encoding (64 chars).
+    pub fn to_hex(&self) -> String {
+        let mut s = String::with_capacity(BUNDLE_HASH_LEN * 2);
+        for b in self.0 {
+            // Two lowercase hex nibbles per byte.
+            s.push(char::from_digit((b >> 4) as u32, 16).unwrap());
+            s.push(char::from_digit((b & 0x0f) as u32, 16).unwrap());
+        }
+        s
+    }
+}
+
+/// Hex (lowercase, 64 chars).
+impl fmt::Display for BundleHash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.to_hex())
+    }
+}
+
+/// Same as [`Display`](fmt::Display) — show the hex so logs are copy-pasteable.
+impl fmt::Debug for BundleHash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "BundleHash({})", self.to_hex())
+    }
+}
+
+/// Error parsing a [`BundleHash`] from a hex string.
+#[derive(Debug, thiserror::Error)]
+pub enum BundleHashParseError {
+    /// The string was not exactly 64 hex characters (32 bytes).
+    #[error("expected 64 hex chars (32-byte BLAKE3 digest), got {0} chars")]
+    BadLength(usize),
+    /// A non-hex character was encountered.
+    #[error("invalid hex digit at position {0}")]
+    BadHexDigit(usize),
+}
+
+impl FromStr for BundleHash {
+    type Err = BundleHashParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s = s.trim();
+        if s.len() != BUNDLE_HASH_LEN * 2 {
+            return Err(BundleHashParseError::BadLength(s.len()));
+        }
+        let mut out = [0u8; BUNDLE_HASH_LEN];
+        let bytes = s.as_bytes();
+        for (i, byte) in out.iter_mut().enumerate() {
+            let hi = (bytes[2 * i] as char)
+                .to_digit(16)
+                .ok_or(BundleHashParseError::BadHexDigit(2 * i))?;
+            let lo = (bytes[2 * i + 1] as char)
+                .to_digit(16)
+                .ok_or(BundleHashParseError::BadHexDigit(2 * i + 1))?;
+            *byte = ((hi << 4) | lo) as u8;
+        }
+        Ok(BundleHash(out))
+    }
+}
+
+/// Map our transport id onto iroh-blobs' [`iroh_blobs::Hash`] (also a raw
+/// BLAKE3-256 digest), so the two are byte-identical on the wire.
+impl From<BundleHash> for iroh_blobs::Hash {
+    fn from(h: BundleHash) -> Self {
+        iroh_blobs::Hash::from_bytes(h.0)
+    }
+}
+
+impl From<iroh_blobs::Hash> for BundleHash {
+    fn from(h: iroh_blobs::Hash) -> Self {
+        BundleHash(*h.as_bytes())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hex_round_trip() {
+        let h = BundleHash([0xABu8; 32]);
+        let s = h.to_hex();
+        assert_eq!(s.len(), 64);
+        assert_eq!(s, "ab".repeat(32));
+        let back: BundleHash = s.parse().unwrap();
+        assert_eq!(back, h);
+    }
+
+    #[test]
+    fn from_str_rejects_bad_length() {
+        let err = BundleHash::from_str("abcd").unwrap_err();
+        assert!(matches!(err, BundleHashParseError::BadLength(4)));
+    }
+
+    #[test]
+    fn from_str_rejects_non_hex() {
+        let bad = "z".repeat(64);
+        let err = BundleHash::from_str(&bad).unwrap_err();
+        assert!(matches!(err, BundleHashParseError::BadHexDigit(0)));
+    }
+
+    #[test]
+    fn iroh_hash_round_trips_bytewise() {
+        let h = BundleHash([7u8; 32]);
+        let iroh: iroh_blobs::Hash = h.into();
+        assert_eq!(iroh.as_bytes(), h.as_bytes());
+        let back: BundleHash = iroh.into();
+        assert_eq!(back, h);
+    }
+}

--- a/crates/nucleus-bundle-cas/src/publish.rs
+++ b/crates/nucleus-bundle-cas/src/publish.rs
@@ -1,0 +1,58 @@
+//! Publish a [`Bundle`] into an iroh-blobs store under its BLAKE3 root.
+//!
+//! "Publish" here means LOCAL availability: the bytes are added to a store so
+//! that a [`crate::fetch::fetch_bundle`] caller (who has the node ticket
+//! out-of-band) can pull them. There is NO advertisement, NO DHT, NO
+//! discovery — see the crate-level trust-model docs.
+
+use iroh_blobs::store::mem::MemStore;
+use nucleus_envelope::Bundle;
+
+use crate::{blake3_bundle_hash, BundleHash};
+
+/// Errors from [`publish_bundle`].
+#[derive(Debug, thiserror::Error)]
+pub enum PublishError {
+    /// Serializing the bundle to JSON failed.
+    #[error("serializing bundle to JSON: {0}")]
+    Serialize(#[source] serde_json::Error),
+    /// The iroh-blobs store rejected the add.
+    #[error("iroh-blobs add_bytes failed: {0}")]
+    Store(#[source] anyhow::Error),
+    /// The store hashed the bytes with a different BLAKE3 root than we
+    /// computed locally. This should be impossible (both use BLAKE3-256 over
+    /// the same bytes) — surfaced loudly so a future hashing divergence in
+    /// either side fails closed instead of silently shipping a wrong id.
+    #[error("store hash {store} != locally-computed bundle hash {local}")]
+    HashMismatch {
+        /// Hash reported by iroh-blobs.
+        store: BundleHash,
+        /// Hash we computed via [`blake3_bundle_hash`].
+        local: BundleHash,
+    },
+}
+
+/// Serialize `bundle` to JSON, add it to `store`, and return its
+/// [`BundleHash`] (BLAKE3-256 root).
+///
+/// The returned hash equals [`blake3_bundle_hash`] of the same bundle; we
+/// assert this against the store's own computed hash to fail closed on any
+/// divergence.
+pub async fn publish_bundle(store: &MemStore, bundle: &Bundle) -> Result<BundleHash, PublishError> {
+    let bytes = serde_json::to_vec(bundle).map_err(PublishError::Serialize)?;
+    let local = blake3_bundle_hash(bundle);
+
+    let tag = store
+        .add_bytes(bytes)
+        .await
+        .map_err(|e| PublishError::Store(e.into()))?;
+    let store_hash: BundleHash = tag.hash.into();
+
+    if store_hash != local {
+        return Err(PublishError::HashMismatch {
+            store: store_hash,
+            local,
+        });
+    }
+    Ok(local)
+}

--- a/crates/nucleus-bundle-cas/tests/integration.rs
+++ b/crates/nucleus-bundle-cas/tests/integration.rs
@@ -1,0 +1,272 @@
+//! Integration tests for content-addressed bundle transfer.
+//!
+//! These exercise the REAL iroh-blobs transport (in-memory store + in-process
+//! QUIC endpoints over loopback — no relay, no discovery). The negative tests
+//! are the point: they prove a peer cannot substitute content, and that
+//! BLAKE3 transport-integrity is INDEPENDENT of envelope provenance.
+
+use iroh::{endpoint::presets, protocol::Router, Endpoint, EndpointAddr, RelayMode};
+use iroh_blobs::{store::mem::MemStore, BlobsProtocol};
+
+use nucleus_bundle_cas::{
+    blake3_bundle_hash, fetch_bundle, publish_bundle, BundleHash, FetchError,
+};
+use nucleus_envelope::{verify_bundle, Bundle, BundleBuilder, TrustAnchor, VerifyBundleError};
+use nucleus_lineage::{
+    canonical_edge_bytes, edge_content_hash, CallSpiffeId, EdgeKind, EdgeSigner, InMemorySink,
+    Jwks, LineageEdge, LineageSink, LocalIssuer, Proof,
+};
+
+fn pod() -> CallSpiffeId {
+    CallSpiffeId::pod("prod.example.com", "agents", "summarizer").unwrap()
+}
+
+/// Sign `edge` with `issuer`, chaining against `prev`. Mirrors the helper in
+/// nucleus-envelope/tests/integration.rs.
+fn signed_edge(
+    issuer: &LocalIssuer,
+    mut edge: LineageEdge,
+    prev: Option<&[u8; 32]>,
+) -> LineageEdge {
+    let bytes = canonical_edge_bytes(&edge, prev);
+    let sig = issuer.sign(&bytes).unwrap();
+    let mut proof = Proof::new(issuer.kid(), issuer.alg(), sig);
+    if let Some(h) = prev {
+        proof = proof.with_prev_hash(*h);
+    }
+    edge.proof = Some(proof);
+    edge
+}
+
+/// A fully-signed 2-edge bundle plus the issuer that signed it (so the test
+/// can build a matching trust anchor).
+fn signed_bundle() -> (Bundle, LocalIssuer) {
+    let issuer = LocalIssuer::random().unwrap();
+    let sink = InMemorySink::new();
+    let p = pod();
+
+    let e1 = signed_edge(&issuer, LineageEdge::pod_admit(p.clone()), None);
+    let h1 = edge_content_hash(&e1, None);
+    sink.emit(e1).unwrap();
+
+    let tool = p.derive_tool("Read", Some(b"input bytes")).unwrap();
+    let e2 = signed_edge(
+        &issuer,
+        LineageEdge::from_parent(
+            tool,
+            p.clone(),
+            EdgeKind::ToolCall {
+                tool: "Read".to_string(),
+            },
+        ),
+        Some(&h1),
+    );
+    sink.emit(e2).unwrap();
+
+    let jwks: Jwks = serde_json::from_value(issuer.publish_jwks()).unwrap();
+    let bundle = BundleBuilder::new(p)
+        .payload(serde_json::json!({"summary": "content-addressed"}))
+        .sink(&sink)
+        .jwks(jwks)
+        .require_signed()
+        .build()
+        .unwrap();
+    (bundle, issuer)
+}
+
+fn anchor_for(issuer: &LocalIssuer) -> TrustAnchor {
+    let jwks: Jwks = serde_json::from_value(issuer.publish_jwks()).unwrap();
+    TrustAnchor::from_jwks(jwks)
+}
+
+/// Bind a relay-less, discovery-less endpoint on loopback. We do NOT call
+/// `online()` (it blocks forever waiting on a relay handshake when relay is
+/// disabled) and we dial via explicit direct addresses (see `direct_addr`).
+async fn local_endpoint() -> Endpoint {
+    Endpoint::builder(presets::Minimal)
+        .relay_mode(RelayMode::Disabled)
+        .clear_address_lookup()
+        .bind_addr("127.0.0.1:0".parse::<std::net::SocketAddr>().unwrap())
+        .expect("valid loopback bind addr")
+        .bind()
+        .await
+        .expect("bind endpoint")
+}
+
+/// Build a dialable `EndpointAddr` from an endpoint's bound loopback sockets.
+/// Unlike `endpoint.addr()`/`online()`, `bound_sockets()` returns immediately
+/// and needs no relay/netcheck — so a peer can connect directly with no hang.
+fn direct_addr(endpoint: &Endpoint) -> EndpointAddr {
+    endpoint
+        .bound_sockets()
+        .into_iter()
+        .fold(EndpointAddr::new(endpoint.id()), |acc, s| {
+            acc.with_ip_addr(s)
+        })
+}
+
+/// Stand up a serving node: a store with the bundle published, behind a
+/// Router that accepts the blobs ALPN. Returns the published hash, the
+/// router (kept alive for the duration of the test), and the serving
+/// endpoint's address.
+async fn serve(bundle: &Bundle) -> (BundleHash, Router, iroh::EndpointAddr) {
+    let endpoint = local_endpoint().await;
+    let store = MemStore::new();
+    let hash = publish_bundle(&store, bundle).await.expect("publish");
+    let blobs = BlobsProtocol::new(&store, None);
+    let addr = direct_addr(&endpoint);
+    let router = Router::builder(endpoint)
+        .accept(iroh_blobs::ALPN, blobs)
+        .spawn();
+    (hash, router, addr)
+}
+
+// ── publish -> get round-trip against in-memory store ──────────────────
+
+#[tokio::test]
+async fn publish_then_fetch_round_trips_to_equal_bundle() {
+    let (bundle, _issuer) = signed_bundle();
+
+    let (hash, _router, addr) = serve(&bundle).await;
+    assert_eq!(
+        hash,
+        blake3_bundle_hash(&bundle),
+        "published hash must equal the locally-computed BLAKE3 root"
+    );
+
+    let client_ep = local_endpoint().await;
+    let client_store = MemStore::new();
+    let fetched = fetch_bundle(&client_ep, &client_store, addr, hash)
+        .await
+        .expect("fetch must succeed for a correct hash");
+
+    // Fetched bytes deserialize to an EQUAL bundle (by canonical hash and
+    // by re-serialization).
+    assert_eq!(
+        serde_json::to_vec(&fetched).unwrap(),
+        serde_json::to_vec(&bundle).unwrap(),
+        "fetched bundle must be byte-identical to the published one"
+    );
+    assert_eq!(blake3_bundle_hash(&fetched), hash);
+}
+
+// ── NEGATIVE: a peer cannot substitute content ─────────────────────────
+
+#[tokio::test]
+async fn fetching_a_wrong_hash_fails_peer_cannot_substitute() {
+    let (bundle, _issuer) = signed_bundle();
+    let (real_hash, _router, addr) = serve(&bundle).await;
+
+    // Ask the peer for a DIFFERENT hash than what it actually serves. The
+    // peer has no blob with this id; even if it tried to substitute its
+    // real bundle, the bao-verified stream is rooted at `wrong_hash` and
+    // would reject the substituted bytes.
+    let mut wrong = *real_hash.as_bytes();
+    wrong[0] ^= 0xFF;
+    let wrong_hash = BundleHash::from_bytes(wrong);
+    assert_ne!(wrong_hash, real_hash);
+
+    let client_ep = local_endpoint().await;
+    let client_store = MemStore::new();
+    let err = fetch_bundle(&client_ep, &client_store, addr, wrong_hash)
+        .await
+        .expect_err("requesting a wrong/different hash must fail");
+
+    // The failure is in the get (bao) stage — a content/transport failure,
+    // NOT a deserialization of substituted bytes.
+    assert!(
+        matches!(err, FetchError::Get(_)),
+        "expected a bao-verified Get failure (no substitution possible), got {err:?}"
+    );
+
+    // And nothing under the wrong id landed in the client store.
+    assert!(
+        client_store.get_bytes(wrong_hash).await.is_err(),
+        "no bytes for a hash the peer never verifiably served"
+    );
+}
+
+// ── INTEGRATION: two-layer independence (transport vs provenance) ──────
+
+#[tokio::test]
+async fn two_in_process_endpoints_transport_and_provenance_are_independent() {
+    let (bundle, issuer) = signed_bundle();
+
+    // Node A publishes + serves.
+    let (hash, _router, addr) = serve(&bundle).await;
+
+    // Node B fetches by hash + address.
+    let client_ep = local_endpoint().await;
+    let client_store = MemStore::new();
+    let fetched = fetch_bundle(&client_ep, &client_store, addr, hash)
+        .await
+        .expect("B fetches the bundle by hash from A");
+
+    // (a) BLAKE3 transport-integrity held: fetched re-hashes to `hash`,
+    //     AND the bundle passes verify_bundle with a MATCHING trust anchor.
+    assert_eq!(blake3_bundle_hash(&fetched), hash);
+    let matching = anchor_for(&issuer);
+    let report =
+        verify_bundle(&fetched, &matching).expect("perfect-hash fetch + matching JWKS must verify");
+    assert_eq!(report.edge_count, 2);
+    assert!(!report.trust_mode_self_check_only);
+
+    // (b) The SAME perfectly-fetched bytes FAIL verify_bundle under a
+    //     MISMATCHED JWKS — proving transport-integrity and envelope-
+    //     provenance are INDEPENDENT layers, both enforced. A correct hash
+    //     does NOT imply a trusted producer.
+    let attacker = LocalIssuer::random().unwrap();
+    let mismatched = anchor_for(&attacker);
+    let err = verify_bundle(&fetched, &mismatched)
+        .expect_err("a perfect-hash fetch must still FAIL against a mismatched JWKS");
+    assert!(
+        matches!(err, VerifyBundleError::Chain { .. }),
+        "expected a Chain (unknown-kid) provenance failure, got {err:?}"
+    );
+}
+
+// ── ADVERSARIAL: corrupted/truncated blob is rejected before deserialize
+
+#[tokio::test]
+async fn truncated_blob_is_rejected_by_bao_before_deserialize() {
+    let (bundle, _issuer) = signed_bundle();
+    let real_hash = blake3_bundle_hash(&bundle);
+
+    // A peer that serves a DIFFERENT (truncated) byte string under the
+    // requested hash. We model this by publishing the truncated bytes into
+    // the serving store under their OWN (correct-for-truncated) id, but then
+    // having the client REQUEST `real_hash`. The serving node does not have
+    // `real_hash`, and crucially even a malicious node that returned the
+    // truncated bytes for `real_hash` would be rejected: bao verification is
+    // rooted at `real_hash`, and the truncated bytes do not reproduce it.
+    let serving_ep = local_endpoint().await;
+    let serving_store = MemStore::new();
+
+    // Truncate the real serialized bundle by one byte (corrupted payload).
+    let mut bytes = serde_json::to_vec(&bundle).unwrap();
+    bytes.pop();
+    serving_store
+        .add_bytes(bytes)
+        .await
+        .expect("add truncated bytes");
+
+    let blobs = BlobsProtocol::new(&serving_store, None);
+    let addr = direct_addr(&serving_ep);
+    let _router = Router::builder(serving_ep)
+        .accept(iroh_blobs::ALPN, blobs)
+        .spawn();
+
+    let client_ep = local_endpoint().await;
+    let client_store = MemStore::new();
+    // Request the REAL hash; the peer only has truncated/corrupted bytes.
+    let err = fetch_bundle(&client_ep, &client_store, addr, real_hash)
+        .await
+        .expect_err("bao verification must reject before any deserialize");
+
+    // The rejection happens at the Get (bao) stage, NOT at Deserialize —
+    // corrupted bytes never reach serde_json.
+    assert!(
+        matches!(err, FetchError::Get(_)),
+        "expected bao rejection at Get stage (not Deserialize), got {err:?}"
+    );
+}

--- a/crates/nucleus-cli/Cargo.toml
+++ b/crates/nucleus-cli/Cargo.toml
@@ -23,6 +23,12 @@ nucleus-client = { path = "../nucleus-client" }
 nucleus-proto = { path = "../nucleus-proto" }
 nucleus-lineage = { path = "../nucleus-lineage" }
 nucleus-envelope = { path = "../nucleus-envelope" }
+nucleus-bundle-cas = { path = "../nucleus-bundle-cas" }
+
+# Content-addressed bundle transport (topology #4). iroh/iroh-blobs are
+# pre-1.0; see nucleus-bundle-cas for version pins + rationale.
+iroh = "=1.0.0-rc.1"
+iroh-blobs = "=0.102.0"
 
 # gRPC client
 tonic = { workspace = true }

--- a/crates/nucleus-cli/src/bundle.rs
+++ b/crates/nucleus-cli/src/bundle.rs
@@ -1,0 +1,169 @@
+//! `nucleus bundle` — content-addressed bundle transfer (topology #4).
+//!
+//! Address a serialized [`Bundle`] by its BLAKE3 root and fetch+verify it
+//! from an untrusted peer over iroh-blobs (a bao-verified stream), then run
+//! the EXISTING [`nucleus_envelope::verify_bundle`].
+//!
+//! # Honest scope (read before relying on this)
+//!
+//! - **No content discovery.** The node ticket is passed OUT-OF-BAND. There
+//!   is NO DHT and no content routing — "DHT" is deferred/aspirational.
+//! - **No availability guarantee.** A peer can be offline or lie about
+//!   having the bytes; only the CORRECTNESS of delivered bytes is
+//!   guaranteed (a peer cannot substitute content).
+//! - **fetched != trusted.** BLAKE3 byte-integrity is ORTHOGONAL to envelope
+//!   provenance: a perfect-hash fetch can STILL FAIL `verify_bundle`. You
+//!   MUST pass `--trust-anchor` (an out-of-band JWKS) to get a provenance
+//!   claim.
+//! - The BLAKE3 hash printed here is a TRANSPORT id — it is **NOT a CID** and
+//!   is DISTINCT from the envelope's SHA-256 canonical hash.
+//! - Not wired into the WASM/browser verifier.
+//!
+//! [`Bundle`]: nucleus_envelope::Bundle
+
+use anyhow::{anyhow, Context, Result};
+use clap::{Args, Subcommand};
+use std::path::PathBuf;
+use std::str::FromStr;
+
+use iroh::{endpoint::presets, protocol::Router, Endpoint};
+use iroh_blobs::{store::mem::MemStore, ticket::BlobTicket, BlobFormat, BlobsProtocol};
+
+use nucleus_bundle_cas::{fetch_bundle, publish_bundle, BundleHash};
+use nucleus_envelope::Bundle;
+
+use crate::envelope_verify::{trust_anchor_from_jwks_file, verify_and_report};
+
+#[derive(Args, Debug)]
+pub struct BundleArgs {
+    #[command(subcommand)]
+    pub command: BundleCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum BundleCommand {
+    /// Publish a bundle: print its BLAKE3 transport hash + a node ticket,
+    /// then SERVE the bytes until interrupted (Ctrl-C).
+    ///
+    /// The node ticket is shared OUT-OF-BAND with the fetcher — there is no
+    /// discovery/DHT. The BLAKE3 hash is a transport id (NOT a CID, NOT the
+    /// envelope canonical hash).
+    Publish(PublishArgs),
+
+    /// Fetch a bundle from a peer by node ticket + BLAKE3 hash over a
+    /// bao-verified stream, then verify provenance with an out-of-band
+    /// trust anchor. A correct hash does NOT imply a trusted producer.
+    Fetch(FetchArgs),
+}
+
+#[derive(Args, Debug)]
+pub struct PublishArgs {
+    /// Path to the bundle JSON file to publish.
+    pub bundle: PathBuf,
+}
+
+#[derive(Args, Debug)]
+pub struct FetchArgs {
+    /// Node ticket (printed by `nucleus bundle publish`) identifying the
+    /// peer to fetch from. Carries the peer's address out-of-band.
+    pub node_ticket: String,
+
+    /// Expected BLAKE3 transport hash (64 hex chars). The bao stream is
+    /// rooted at this hash, so the peer cannot substitute other content.
+    pub blake3_hash: String,
+
+    /// Out-of-band JWKS trust anchor. REQUIRED for a provenance claim:
+    /// byte-integrity alone is not trust. The embedded JWKS is ignored.
+    #[arg(long)]
+    pub trust_anchor: PathBuf,
+
+    /// Print the verification report as JSON.
+    #[arg(long)]
+    pub json: bool,
+
+    /// Print the verified bundle's payload on success.
+    #[arg(long)]
+    pub show_payload: bool,
+}
+
+pub async fn execute(args: BundleArgs) -> Result<()> {
+    match args.command {
+        BundleCommand::Publish(a) => publish(a).await,
+        BundleCommand::Fetch(a) => fetch(a).await,
+    }
+}
+
+async fn bind_endpoint() -> Result<Endpoint> {
+    let endpoint = Endpoint::builder(presets::Minimal)
+        .bind()
+        .await
+        .map_err(|e| anyhow!("binding iroh endpoint: {e}"))?;
+    endpoint.online().await;
+    Ok(endpoint)
+}
+
+async fn publish(args: PublishArgs) -> Result<()> {
+    let bytes = std::fs::read(&args.bundle)
+        .with_context(|| format!("reading bundle from {}", args.bundle.display()))?;
+    let bundle: Bundle = serde_json::from_slice(&bytes)
+        .with_context(|| format!("parsing bundle JSON from {}", args.bundle.display()))?;
+
+    let endpoint = bind_endpoint().await?;
+    let store = MemStore::new();
+    let hash = publish_bundle(&store, &bundle)
+        .await
+        .map_err(|e| anyhow!("publishing bundle to local store: {e}"))?;
+
+    let addr = endpoint.addr();
+    let ticket = BlobTicket::new(addr, hash.into(), BlobFormat::Raw);
+
+    let blobs = BlobsProtocol::new(&store, None);
+    let router = Router::builder(endpoint)
+        .accept(iroh_blobs::ALPN, blobs)
+        .spawn();
+
+    println!("blake3-hash: {hash}");
+    println!("node-ticket: {ticket}");
+    eprintln!(
+        "NOTE: BLAKE3 hash is a TRANSPORT id (not a CID, not the envelope canonical hash). \
+         The fetcher must STILL verify provenance with an out-of-band trust anchor."
+    );
+    eprintln!("serving bundle; press Ctrl-C to stop...");
+
+    tokio::signal::ctrl_c()
+        .await
+        .context("waiting for Ctrl-C")?;
+    router.shutdown().await.ok();
+    Ok(())
+}
+
+async fn fetch(args: FetchArgs) -> Result<()> {
+    let hash = BundleHash::from_str(&args.blake3_hash)
+        .map_err(|e| anyhow!("invalid --blake3-hash: {e}"))?;
+
+    let ticket =
+        BlobTicket::from_str(&args.node_ticket).map_err(|e| anyhow!("invalid node ticket: {e}"))?;
+
+    // Cross-check: the ticket's hash (if it carries one) must match the
+    // explicitly-requested BLAKE3 hash, so a mismatched paste fails loud
+    // rather than silently fetching the wrong content.
+    let ticket_hash: BundleHash = ticket.hash().into();
+    if ticket_hash != hash {
+        return Err(anyhow!(
+            "node ticket hash {ticket_hash} != requested blake3-hash {hash}; refusing to fetch"
+        ));
+    }
+    let node_addr = ticket.addr().clone();
+
+    let endpoint = bind_endpoint().await?;
+    let store = MemStore::new();
+
+    let bundle = fetch_bundle(&endpoint, &store, node_addr, hash)
+        .await
+        .map_err(|e| anyhow!("fetch failed: {e}"))?;
+
+    // Byte-integrity is now guaranteed by the bao stream. Provenance is a
+    // SEPARATE check against the operator-supplied out-of-band trust anchor.
+    let anchor = trust_anchor_from_jwks_file(&args.trust_anchor)?;
+    verify_and_report(&bundle, &anchor, args.json, args.show_payload)
+}

--- a/crates/nucleus-cli/src/envelope_verify.rs
+++ b/crates/nucleus-cli/src/envelope_verify.rs
@@ -93,13 +93,7 @@ pub fn execute(args: EnvelopeVerifyArgs) -> Result<()> {
         .with_context(|| format!("parsing bundle JSON from {}", args.bundle))?;
 
     let anchor = match (&args.trust_jwks, args.self_check) {
-        (Some(path), false) => {
-            let jwks_bytes = std::fs::read(path)
-                .with_context(|| format!("reading trust JWKS from {}", path.display()))?;
-            let jwks = Jwks::parse(&jwks_bytes)
-                .with_context(|| format!("parsing JWKS at {}", path.display()))?;
-            TrustAnchor::from_jwks(jwks)
-        }
+        (Some(path), false) => trust_anchor_from_jwks_file(path)?,
         (None, true) => TrustAnchor::self_check_only(),
         (None, false) => {
             return Err(anyhow!(
@@ -136,19 +130,41 @@ pub fn execute(args: EnvelopeVerifyArgs) -> Result<()> {
         anchor = anchor.require_payload_binding();
     }
 
-    let report =
-        verify_bundle(&bundle, &anchor).map_err(|e| anyhow!("verification failed: {e}"))?;
+    verify_and_report(&bundle, &anchor, args.json, args.show_payload)
+}
 
-    if args.json {
-        emit_json_report(&bundle, &report)?;
+/// Run [`verify_bundle`] against `anchor` and emit the report (JSON or
+/// human-readable). Shared by `nucleus envelope-verify` and
+/// `nucleus bundle fetch` so the verify + report path is defined once.
+pub fn verify_and_report(
+    bundle: &Bundle,
+    anchor: &TrustAnchor,
+    json: bool,
+    show_payload: bool,
+) -> Result<()> {
+    let report = verify_bundle(bundle, anchor).map_err(|e| anyhow!("verification failed: {e}"))?;
+
+    if json {
+        emit_json_report(bundle, &report)?;
     } else {
-        emit_human_report(&bundle, &report);
-        if args.show_payload {
+        emit_human_report(bundle, &report);
+        if show_payload {
             println!("---");
             println!("{}", serde_json::to_string_pretty(&bundle.payload)?);
         }
     }
     Ok(())
+}
+
+/// Load a [`TrustAnchor`] from a JWKS file the verifier obtained out-of-band.
+/// This is the production trust path: the embedded JWKS is ignored. Shared
+/// with `nucleus bundle fetch`.
+pub fn trust_anchor_from_jwks_file(path: &std::path::Path) -> Result<TrustAnchor> {
+    let jwks_bytes = std::fs::read(path)
+        .with_context(|| format!("reading trust JWKS from {}", path.display()))?;
+    let jwks =
+        Jwks::parse(&jwks_bytes).with_context(|| format!("parsing JWKS at {}", path.display()))?;
+    Ok(TrustAnchor::from_jwks(jwks))
 }
 
 fn emit_human_report(bundle: &Bundle, report: &VerificationReport) {

--- a/crates/nucleus-cli/src/main.rs
+++ b/crates/nucleus-cli/src/main.rs
@@ -22,6 +22,7 @@ use tracing::info;
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
 mod audit;
+mod bundle;
 mod config;
 mod constants;
 mod doctor;
@@ -127,6 +128,9 @@ enum Commands {
 
     /// Verify a provenance bundle standalone
     EnvelopeVerify(envelope_verify::EnvelopeVerifyArgs),
+
+    /// Content-addressed bundle transfer over iroh-blobs (publish/fetch)
+    Bundle(bundle::BundleArgs),
 }
 
 fn init_logging(verbose: bool) {
@@ -181,5 +185,6 @@ async fn main() -> Result<()> {
         Commands::LineageVerifyChain(args) => lineage_verify::execute(args),
         Commands::Envelope(args) => envelope::execute(args),
         Commands::EnvelopeVerify(args) => envelope_verify::execute(args),
+        Commands::Bundle(args) => bundle::execute(args).await,
     }
 }

--- a/deny.toml
+++ b/deny.toml
@@ -1,3 +1,20 @@
+# Scope the dependency scan to the platforms nucleus actually builds and ships
+# (native CLI + services). Without this, cargo-deny evaluates ALL targets,
+# including wasm32 — which pulls iroh-relay's browser-only WebSocket shim
+# (ws_stream_wasm/pharos/async_io_stream, licensed "Unlicense"). Those crates
+# are NEVER compiled in any native nucleus artifact (they sit under
+# iroh-relay's `cfg(target_family="wasm")` deps), so this is a scope correction,
+# NOT a license-policy relaxation — "Unlicense" is deliberately NOT added to the
+# [licenses] allow-list below. The WASM verifier (sdks/verifier-js) is a
+# separate crate that does not depend on iroh.
+[graph]
+targets = [
+  "x86_64-unknown-linux-gnu",
+  "aarch64-unknown-linux-gnu",
+  "x86_64-apple-darwin",
+  "aarch64-apple-darwin",
+]
+
 [advisories]
 version = 2
 # See https://github.com/RustSec/advisory-db


### PR DESCRIPTION
## #4 content-addressed bundle transfer — `nucleus-bundle-cas`

Fetch a provenance **Bundle** by its **BLAKE3 root** from an untrusted peer over iroh-blobs (bao-verified stream), then pipe into the existing `verify_bundle`. Transport integrity is **orthogonal** to provenance — *fetched ≠ trusted*.

### What's here
- `crates/nucleus-bundle-cas`: `BundleHash` (BLAKE3 transport id, explicitly *not* a CID, distinct from the SHA-256 `canonical_bundle_hash`), `publish_bundle`/`fetch_bundle` over iroh-blobs.
- `nucleus bundle publish/fetch` CLI (fetch runs `verify_bundle` with an operator-supplied `TrustAnchor`).

### Tests (the security-relevant negatives)
- **wrong-hash fetch rejected** — a peer cannot substitute content.
- **truncated/corrupted bytes rejected by bao before deserialize.**
- **two-endpoint independence** — a perfect-hash fetch still **fails** `verify_bundle` on a mismatched JWKS (the two integrity layers are independent and both enforced).
- 7 unit + 4 integration + CLI green; clippy `-D warnings`, fmt, **cargo-deny** all clean.

### Notes for review
- **cargo-deny scope (deny.toml):** added `[graph].targets` = native (linux/apple × x64/arm64). The `Unlicense` crates (`ws_stream_wasm`/`pharos`/`async_io_stream`) are `wasm32`-only deps of non-optional `iroh-relay`, **never compiled in any native nucleus artifact** — this is a *scope correction*, **not** a license-allowlist change (`Unlicense` is deliberately not allowed). The WASM verifier is a separate crate that doesn't use iroh.
- **iroh relay-less config:** tests bind loopback with `RelayMode::Disabled` + `clear_address_lookup()` + direct-address dialing (`bound_sockets()`); `online()` is never called (it blocks on a relay handshake). This is what fixed the original integration-test hang.
- **Framing:** single-tenant split-trust value documented (replicate your own bundles across your own failure domains); a **dormant** per-proven-byte metering seam is documented at `fetch_bundle` — no payment wired (additive, not a rewrite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
