### PR TITLE
feat(witness): C2SP tlog-witness server + Sigsum k-of-n policy (#2 witness mesh)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5947,6 +5947,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "nucleus-witness"
+version = "1.0.0"
+dependencies = [
+ "anyhow",
+ "axum",
+ "base64 0.22.1",
+ "clap",
+ "ct-merkle",
+ "ed25519-dalek 3.0.0-pre.7",
+ "hex",
+ "http-body-util",
+ "nucleus-lineage",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.18",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber 0.3.23",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ members = [
     "crates/nucleus-control-plane",      # Job orchestrator: typed JobSpec → agent → Bundle
     "crates/nucleus-control-plane-server", # REST API server wrapping nucleus-control-plane
     "crates/nucleus-verifier-service",   # Public verifier-as-a-service for provenance bundles
+    "crates/nucleus-witness",            # C2SP tlog-witness server: mints cosignatures with the spec status matrix
     "crates/nucleus-oidc-provider",      # OIDC OP: JWT-SVID issuance + RFC 8693 token exchange
     "crates/nucleus-oidc-core",          # Provider-agnostic OIDC primitives (JWKS, JtiCache, federation)
     "crates/nucleus-fly-oidc",           # Per-provider validator: Fly.io machine OIDC → SPIFFE

--- a/crates/nucleus-lineage/src/lib.rs
+++ b/crates/nucleus-lineage/src/lib.rs
@@ -37,6 +37,7 @@ pub mod edge;
 pub mod id;
 pub mod issuer;
 pub mod merkle;
+pub mod policy;
 pub mod proof;
 pub mod prover;
 pub mod signed_note;
@@ -61,6 +62,7 @@ pub use edge::{EdgeKind, LineageEdge};
 pub use id::{CallSpiffeId, IdError, MAX_URI_LEN};
 pub use issuer::{EdgeSigner, IdentityFetcher, IssuerError, SvidClaims};
 pub use merkle::{read_checkpoints, verify_log, MerkleConfig, MerkleError, MerkleSink};
+pub use policy::{Group, Log, Policy, PolicyError, Threshold, Witness};
 pub use proof::{canonical_edge_bytes, edge_content_hash, Proof};
 pub use prover::MerkleProver;
 pub use signed_note::{

--- a/crates/nucleus-lineage/src/policy.rs
+++ b/crates/nucleus-lineage/src/policy.rs
@@ -1,0 +1,606 @@
+//! Sigsum-style k-of-n witnessing policy parser + quorum evaluator.
+//!
+//! Implements the grammar from the [sigsum-go policy
+//! documentation](https://git.glasklar.is/sigsum/core/sigsum-go/-/blob/main/doc/policy.md):
+//!
+//! ```text
+//! log     <pubkey-hex>            [url]
+//! witness <name> <pubkey-hex>     [url]
+//! group   <name> all|any|<k>      <member> [member ...]
+//! quorum  <name>
+//! ```
+//!
+//! - `log` declares a trusted log key (recorded but not used by the
+//!   quorum evaluator — present for grammar completeness / future
+//!   submission routing).
+//! - `witness <name> <pubkey>` declares a named witness with a 32-byte
+//!   Ed25519 verifying key (hex-encoded).
+//! - `group <name> <threshold> <members...>` declares a named group.
+//!   `threshold` is `all` (every member), `any` (≥ 1 member), or a
+//!   decimal `k` (≥ k distinct members). Members are witness names or
+//!   other group names — **groups nest**.
+//! - `quorum <name>` names the single top-level group (or witness) that
+//!   the whole policy is satisfied by. Exactly one `quorum` line is
+//!   required.
+//!
+//! # Quorum semantics (the security-load-bearing part)
+//!
+//! [`Policy::is_satisfied`] counts **distinct** witnesses that produced
+//! a valid cosignature, then evaluates the quorum tree:
+//!
+//! - `any`  → satisfied iff ≥ 1 distinct member is satisfied.
+//! - `all`  → satisfied iff EVERY member is satisfied.
+//! - `<k>`  → satisfied iff ≥ k distinct members are satisfied.
+//! - a witness leaf → satisfied iff that witness is in the
+//!   valid-cosigner set.
+//!
+//! A witness that signs twice counts **once** — the caller passes a
+//! set of witness identities, and even if it doesn't de-duplicate,
+//! the evaluator does (it works over the set of names that satisfy
+//! each leaf). Below-threshold ⇒ NOT satisfied. There is no implicit
+//! "fail open" path.
+//!
+//! # What this module does NOT do
+//!
+//! It does not itself verify Ed25519 signatures — that is the caller's
+//! job (e.g. [`crate::cosign::Cosignature`] verification against the
+//! witness's pubkey). The evaluator consumes the SET OF WITNESS NAMES
+//! whose cosignatures already verified, so the trust boundary is: only
+//! pass names whose signatures you cryptographically checked.
+
+use std::collections::{HashMap, HashSet};
+
+use thiserror::Error;
+
+/// Errors raised while parsing or evaluating a Sigsum policy.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum PolicyError {
+    /// A line had too few tokens for its keyword.
+    #[error("line {line}: `{keyword}` needs more arguments")]
+    TooFewArgs { line: usize, keyword: String },
+    /// An unknown leading keyword.
+    #[error("line {line}: unknown keyword `{keyword}`")]
+    UnknownKeyword { line: usize, keyword: String },
+    /// A pubkey hex string didn't decode to 32 bytes.
+    #[error("line {line}: pubkey must be 32-byte hex, got: {value}")]
+    BadPubkey { line: usize, value: String },
+    /// A `group` threshold was neither `all`, `any`, nor a decimal.
+    #[error("line {line}: group threshold must be `all`, `any`, or a decimal, got `{value}`")]
+    BadThreshold { line: usize, value: String },
+    /// A name was declared twice (witness or group).
+    #[error("line {line}: duplicate name `{name}`")]
+    DuplicateName { line: usize, name: String },
+    /// A `group`/`quorum` referenced a name that was never declared.
+    #[error("unknown reference `{name}` (must be a declared witness or group)")]
+    UnknownReference { name: String },
+    /// More than one `quorum` line, or none.
+    #[error("policy must have exactly one `quorum` line, found {found}")]
+    QuorumCount { found: usize },
+    /// A `group` with a decimal threshold larger than its member count
+    /// can never be satisfied — reject at parse time.
+    #[error("line {line}: group `{name}` needs {k} of {members} members — unsatisfiable")]
+    ThresholdExceedsMembers {
+        line: usize,
+        name: String,
+        k: usize,
+        members: usize,
+    },
+    /// A group declared as a member of itself (direct cycle). Indirect
+    /// cycles are caught at evaluation time via the visited-set guard.
+    #[error("group `{name}` is a member of itself")]
+    SelfReference { name: String },
+}
+
+/// A declared witness: a name bound to a 32-byte Ed25519 pubkey.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Witness {
+    pub name: String,
+    pub pubkey: [u8; 32],
+    pub url: Option<String>,
+}
+
+/// A declared log key (grammar completeness; not used by the quorum
+/// evaluator).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Log {
+    pub pubkey: [u8; 32],
+    pub url: Option<String>,
+}
+
+/// The threshold of a [`Group`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Threshold {
+    /// Every member must be satisfied.
+    All,
+    /// At least one member must be satisfied.
+    Any,
+    /// At least `k` distinct members must be satisfied.
+    K(usize),
+}
+
+/// A named group of members (witness names or nested group names) plus
+/// a threshold.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Group {
+    pub name: String,
+    pub threshold: Threshold,
+    pub members: Vec<String>,
+}
+
+/// A fully-parsed Sigsum policy.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Policy {
+    pub logs: Vec<Log>,
+    /// Witnesses by name.
+    pub witnesses: HashMap<String, Witness>,
+    /// Groups by name.
+    pub groups: HashMap<String, Group>,
+    /// The top-level reference (witness or group name) the whole
+    /// policy is satisfied by.
+    pub quorum: String,
+}
+
+impl Policy {
+    /// Parse a policy from its text form. Blank lines and `#` comments
+    /// are ignored. Tokens are whitespace-separated.
+    pub fn parse(text: &str) -> Result<Self, PolicyError> {
+        let mut logs = Vec::new();
+        let mut witnesses: HashMap<String, Witness> = HashMap::new();
+        let mut groups: HashMap<String, Group> = HashMap::new();
+        let mut quorum: Option<String> = None;
+        let mut quorum_count = 0usize;
+
+        for (idx, raw) in text.lines().enumerate() {
+            let line = idx + 1;
+            // Strip comments (everything after an unquoted '#') and trim.
+            let content = match raw.find('#') {
+                Some(pos) => &raw[..pos],
+                None => raw,
+            };
+            let tokens: Vec<&str> = content.split_whitespace().collect();
+            if tokens.is_empty() {
+                continue;
+            }
+            match tokens[0] {
+                "log" => {
+                    // log <pubkey> [url]
+                    if tokens.len() < 2 {
+                        return Err(PolicyError::TooFewArgs {
+                            line,
+                            keyword: "log".into(),
+                        });
+                    }
+                    let pubkey = parse_pubkey(line, tokens[1])?;
+                    let url = tokens.get(2).map(|s| s.to_string());
+                    logs.push(Log { pubkey, url });
+                }
+                "witness" => {
+                    // witness <name> <pubkey> [url]
+                    if tokens.len() < 3 {
+                        return Err(PolicyError::TooFewArgs {
+                            line,
+                            keyword: "witness".into(),
+                        });
+                    }
+                    let name = tokens[1].to_string();
+                    if witnesses.contains_key(&name) || groups.contains_key(&name) {
+                        return Err(PolicyError::DuplicateName { line, name });
+                    }
+                    let pubkey = parse_pubkey(line, tokens[2])?;
+                    let url = tokens.get(3).map(|s| s.to_string());
+                    witnesses.insert(name.clone(), Witness { name, pubkey, url });
+                }
+                "group" => {
+                    // group <name> all|any|<k> <member>...
+                    if tokens.len() < 4 {
+                        return Err(PolicyError::TooFewArgs {
+                            line,
+                            keyword: "group".into(),
+                        });
+                    }
+                    let name = tokens[1].to_string();
+                    if witnesses.contains_key(&name) || groups.contains_key(&name) {
+                        return Err(PolicyError::DuplicateName { line, name });
+                    }
+                    let threshold = match tokens[2] {
+                        "all" => Threshold::All,
+                        "any" => Threshold::Any,
+                        k => {
+                            let parsed =
+                                k.parse::<usize>().map_err(|_| PolicyError::BadThreshold {
+                                    line,
+                                    value: k.to_string(),
+                                })?;
+                            Threshold::K(parsed)
+                        }
+                    };
+                    let members: Vec<String> = tokens[3..].iter().map(|s| s.to_string()).collect();
+                    // Direct self-reference is always a bug.
+                    if members.iter().any(|m| m == &name) {
+                        return Err(PolicyError::SelfReference { name });
+                    }
+                    // A decimal threshold larger than the member count is
+                    // unsatisfiable; reject early so an operator notices
+                    // the typo instead of silently never-quorum-ing.
+                    if let Threshold::K(k) = threshold {
+                        if k > members.len() {
+                            return Err(PolicyError::ThresholdExceedsMembers {
+                                line,
+                                name,
+                                k,
+                                members: members.len(),
+                            });
+                        }
+                    }
+                    groups.insert(
+                        name.clone(),
+                        Group {
+                            name,
+                            threshold,
+                            members,
+                        },
+                    );
+                }
+                "quorum" => {
+                    // quorum <name>
+                    if tokens.len() < 2 {
+                        return Err(PolicyError::TooFewArgs {
+                            line,
+                            keyword: "quorum".into(),
+                        });
+                    }
+                    quorum = Some(tokens[1].to_string());
+                    quorum_count += 1;
+                }
+                other => {
+                    return Err(PolicyError::UnknownKeyword {
+                        line,
+                        keyword: other.to_string(),
+                    });
+                }
+            }
+        }
+
+        if quorum_count != 1 {
+            return Err(PolicyError::QuorumCount {
+                found: quorum_count,
+            });
+        }
+        let quorum = quorum.expect("quorum_count == 1 implies Some");
+
+        let policy = Policy {
+            logs,
+            witnesses,
+            groups,
+            quorum,
+        };
+        // Validate every reference (quorum + each group member) resolves
+        // to a declared witness or group. This turns a typo'd member
+        // name into a hard parse error rather than a silently-false
+        // quorum.
+        policy.validate_references()?;
+        Ok(policy)
+    }
+
+    /// Check that every group member and the quorum target name a
+    /// declared witness or group.
+    fn validate_references(&self) -> Result<(), PolicyError> {
+        let resolves =
+            |name: &str| self.witnesses.contains_key(name) || self.groups.contains_key(name);
+        if !resolves(&self.quorum) {
+            return Err(PolicyError::UnknownReference {
+                name: self.quorum.clone(),
+            });
+        }
+        for group in self.groups.values() {
+            for member in &group.members {
+                if !resolves(member) {
+                    return Err(PolicyError::UnknownReference {
+                        name: member.clone(),
+                    });
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Evaluate the quorum against the SET OF WITNESS NAMES whose
+    /// cosignatures already cryptographically verified.
+    ///
+    /// **The caller MUST only include names whose Ed25519 signatures
+    /// were checked against the witness's pubkey.** This evaluator does
+    /// no crypto; it counts distinct satisfied members against the
+    /// thresholds. A witness appearing twice in `valid_witnesses` is
+    /// counted once (the input is treated as a set).
+    ///
+    /// Returns `true` iff the top-level quorum reference is satisfied.
+    pub fn is_satisfied(&self, valid_witnesses: &HashSet<String>) -> bool {
+        let mut visited = HashSet::new();
+        self.eval(&self.quorum, valid_witnesses, &mut visited)
+    }
+
+    /// Recursive evaluator. `visited` guards against indirect group
+    /// cycles (a group reachable from itself) — a cycle short-circuits
+    /// to `false` rather than recursing forever.
+    fn eval(&self, name: &str, valid: &HashSet<String>, visited: &mut HashSet<String>) -> bool {
+        // A witness leaf: satisfied iff it produced a valid cosig.
+        if self.witnesses.contains_key(name) {
+            return valid.contains(name);
+        }
+        // A group: evaluate members against the threshold.
+        if let Some(group) = self.groups.get(name) {
+            // Cycle guard: if we're already inside this group, treat as
+            // unsatisfiable to avoid infinite recursion.
+            if !visited.insert(name.to_string()) {
+                return false;
+            }
+            // Count DISTINCT satisfied members. De-dup member names so a
+            // group that lists the same member twice can't double-count.
+            let satisfied: usize = {
+                let mut seen = HashSet::new();
+                group
+                    .members
+                    .iter()
+                    .filter(|m| seen.insert((*m).clone()))
+                    .filter(|m| self.eval(m, valid, visited))
+                    .count()
+            };
+            // De-dup member count for the `all` denominator too.
+            let distinct_members = {
+                let mut seen = HashSet::new();
+                group
+                    .members
+                    .iter()
+                    .filter(|m| seen.insert((*m).clone()))
+                    .count()
+            };
+            visited.remove(name);
+            return match group.threshold {
+                Threshold::Any => satisfied >= 1,
+                Threshold::All => satisfied == distinct_members,
+                Threshold::K(k) => satisfied >= k,
+            };
+        }
+        // Dangling reference (should be caught at parse time) → not
+        // satisfied. Fail closed.
+        false
+    }
+}
+
+/// Parse a 32-byte Ed25519 pubkey from hex.
+fn parse_pubkey(line: usize, hex_str: &str) -> Result<[u8; 32], PolicyError> {
+    let bytes = hex::decode(hex_str).map_err(|_| PolicyError::BadPubkey {
+        line,
+        value: hex_str.to_string(),
+    })?;
+    let arr: [u8; 32] = bytes
+        .as_slice()
+        .try_into()
+        .map_err(|_| PolicyError::BadPubkey {
+            line,
+            value: hex_str.to_string(),
+        })?;
+    Ok(arr)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pk(b: u8) -> String {
+        hex::encode([b; 32])
+    }
+
+    fn set(names: &[&str]) -> HashSet<String> {
+        names.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn parses_witnesses_and_quorum() {
+        let text = format!(
+            "witness w1 {}\nwitness w2 {}\ngroup g any w1 w2\nquorum g\n",
+            pk(1),
+            pk(2)
+        );
+        let p = Policy::parse(&text).unwrap();
+        assert_eq!(p.witnesses.len(), 2);
+        assert_eq!(p.groups.len(), 1);
+        assert_eq!(p.quorum, "g");
+        assert_eq!(p.witnesses["w1"].pubkey, [1u8; 32]);
+    }
+
+    #[test]
+    fn parses_log_and_url() {
+        let text = format!(
+            "log {} https://log.example/\nwitness w1 {} https://w1.example/\ngroup g any w1\nquorum g\n",
+            pk(9),
+            pk(1)
+        );
+        let p = Policy::parse(&text).unwrap();
+        assert_eq!(p.logs.len(), 1);
+        assert_eq!(p.logs[0].url.as_deref(), Some("https://log.example/"));
+        assert_eq!(
+            p.witnesses["w1"].url.as_deref(),
+            Some("https://w1.example/")
+        );
+    }
+
+    #[test]
+    fn comments_and_blank_lines_ignored() {
+        let text = format!(
+            "# a policy\n\nwitness w1 {}   # trailing comment\n\nquorum w1\n",
+            pk(1)
+        );
+        let p = Policy::parse(&text).unwrap();
+        assert_eq!(p.quorum, "w1");
+    }
+
+    #[test]
+    fn any_satisfied_with_one() {
+        let text = format!(
+            "witness w1 {}\nwitness w2 {}\ngroup g any w1 w2\nquorum g\n",
+            pk(1),
+            pk(2)
+        );
+        let p = Policy::parse(&text).unwrap();
+        assert!(p.is_satisfied(&set(&["w1"])));
+        assert!(!p.is_satisfied(&set(&[])));
+    }
+
+    #[test]
+    fn all_requires_every_member() {
+        let text = format!(
+            "witness w1 {}\nwitness w2 {}\ngroup g all w1 w2\nquorum g\n",
+            pk(1),
+            pk(2)
+        );
+        let p = Policy::parse(&text).unwrap();
+        assert!(!p.is_satisfied(&set(&["w1"])));
+        assert!(p.is_satisfied(&set(&["w1", "w2"])));
+    }
+
+    // ── NEGATIVE TEST 5: k of n with k-1 → NOT satisfied; k → satisfied;
+    //    duplicate cosig from same witness counts once. ──────────────
+    #[test]
+    fn negative_test_5_k_of_n_threshold_and_dedup() {
+        let text = format!(
+            "witness w1 {}\nwitness w2 {}\nwitness w3 {}\ngroup g 2 w1 w2 w3\nquorum g\n",
+            pk(1),
+            pk(2),
+            pk(3)
+        );
+        let p = Policy::parse(&text).unwrap();
+
+        // (a) k-1 = 1 distinct valid cosig → NOT satisfied.
+        assert!(
+            !p.is_satisfied(&set(&["w1"])),
+            "1 of 2 must NOT satisfy a k=2 group"
+        );
+
+        // (b) positive control: k = 2 distinct → satisfied.
+        assert!(
+            p.is_satisfied(&set(&["w1", "w2"])),
+            "2 of 2 must satisfy a k=2 group"
+        );
+
+        // (c) duplicate cosig from the SAME witness counts once: even if
+        //     the caller's set somehow only has w1, a HashSet input
+        //     already de-dups, so {w1} stays below threshold. Prove the
+        //     evaluator never double-counts a single witness by checking
+        //     that {w1} (one distinct witness) is still below k=2.
+        let mut dup = HashSet::new();
+        dup.insert("w1".to_string());
+        dup.insert("w1".to_string()); // no-op on a set
+        assert_eq!(dup.len(), 1);
+        assert!(!p.is_satisfied(&dup), "one witness can't satisfy k=2");
+    }
+
+    #[test]
+    fn nested_groups_evaluate() {
+        // Top quorum requires both subgroup-a (any of w1,w2) AND w3.
+        let text = format!(
+            "witness w1 {}\nwitness w2 {}\nwitness w3 {}\n\
+             group suba any w1 w2\n\
+             group top all suba w3\n\
+             quorum top\n",
+            pk(1),
+            pk(2),
+            pk(3)
+        );
+        let p = Policy::parse(&text).unwrap();
+        // suba satisfied by w2, but w3 missing → top all fails.
+        assert!(!p.is_satisfied(&set(&["w2"])));
+        // suba via w1 + w3 → top all satisfied.
+        assert!(p.is_satisfied(&set(&["w1", "w3"])));
+    }
+
+    #[test]
+    fn witness_counted_once_even_listed_twice_in_group() {
+        // A group that lists w1 twice must not let w1 satisfy a k=2.
+        let text = format!(
+            "witness w1 {}\nwitness w2 {}\ngroup g 2 w1 w1 w2\nquorum g\n",
+            pk(1),
+            pk(2)
+        );
+        let p = Policy::parse(&text).unwrap();
+        assert!(
+            !p.is_satisfied(&set(&["w1"])),
+            "w1 listed twice must still count once → below k=2"
+        );
+        assert!(p.is_satisfied(&set(&["w1", "w2"])));
+    }
+
+    #[test]
+    fn quorum_can_be_a_single_witness() {
+        let text = format!("witness w1 {}\nquorum w1\n", pk(1));
+        let p = Policy::parse(&text).unwrap();
+        assert!(p.is_satisfied(&set(&["w1"])));
+        assert!(!p.is_satisfied(&set(&["w2"])));
+    }
+
+    #[test]
+    fn rejects_unknown_reference() {
+        let text = format!("witness w1 {}\ngroup g any w1 ghost\nquorum g\n", pk(1));
+        let err = Policy::parse(&text).unwrap_err();
+        assert!(matches!(err, PolicyError::UnknownReference { .. }));
+    }
+
+    #[test]
+    fn rejects_missing_quorum() {
+        let text = format!("witness w1 {}\n", pk(1));
+        let err = Policy::parse(&text).unwrap_err();
+        assert!(matches!(err, PolicyError::QuorumCount { found: 0 }));
+    }
+
+    #[test]
+    fn rejects_two_quorum_lines() {
+        let text = format!("witness w1 {}\nquorum w1\nquorum w1\n", pk(1));
+        let err = Policy::parse(&text).unwrap_err();
+        assert!(matches!(err, PolicyError::QuorumCount { found: 2 }));
+    }
+
+    #[test]
+    fn rejects_bad_pubkey() {
+        let text = "witness w1 deadbeef\nquorum w1\n";
+        let err = Policy::parse(text).unwrap_err();
+        assert!(matches!(err, PolicyError::BadPubkey { .. }));
+    }
+
+    #[test]
+    fn rejects_threshold_exceeding_members() {
+        let text = format!("witness w1 {}\ngroup g 3 w1\nquorum g\n", pk(1));
+        let err = Policy::parse(&text).unwrap_err();
+        assert!(matches!(err, PolicyError::ThresholdExceedsMembers { .. }));
+    }
+
+    #[test]
+    fn rejects_duplicate_name() {
+        let text = format!("witness w1 {}\nwitness w1 {}\nquorum w1\n", pk(1), pk(2));
+        let err = Policy::parse(&text).unwrap_err();
+        assert!(matches!(err, PolicyError::DuplicateName { .. }));
+    }
+
+    #[test]
+    fn rejects_self_referential_group() {
+        let text = format!("witness w1 {}\ngroup g any g w1\nquorum g\n", pk(1));
+        let err = Policy::parse(&text).unwrap_err();
+        assert!(matches!(err, PolicyError::SelfReference { .. }));
+    }
+
+    #[test]
+    fn indirect_cycle_fails_closed_not_infinite_loop() {
+        // a → b → a. validate_references passes (both declared); the
+        // eval-time visited guard must prevent infinite recursion and
+        // return false.
+        let text = format!(
+            "witness w1 {}\ngroup a any b w1\ngroup b any a\nquorum a\n",
+            pk(1)
+        );
+        let p = Policy::parse(&text).unwrap();
+        // a's `any` is satisfied by w1 regardless of the cycle.
+        assert!(p.is_satisfied(&set(&["w1"])));
+        // With no valid witnesses, the cycle must not hang and must be
+        // unsatisfied.
+        assert!(!p.is_satisfied(&set(&[])));
+    }
+}

--- a/crates/nucleus-witness/Cargo.toml
+++ b/crates/nucleus-witness/Cargo.toml
@@ -1,0 +1,45 @@
+[package]
+name = "nucleus-witness"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+description = "C2SP tlog-witness server: mints Ed25519 cosignatures over checkpoints with the spec status matrix"
+repository = "https://github.com/coproduct-opensource/nucleus"
+keywords = ["transparency", "witness", "c2sp", "tlog", "cosignature"]
+categories = ["web-programming::http-server", "cryptography"]
+
+[[bin]]
+name = "nucleus-witness"
+path = "src/main.rs"
+
+[dependencies]
+nucleus-lineage = { path = "../nucleus-lineage" }
+axum = { version = "0.8", features = ["macros"] }
+tokio = { workspace = true, features = ["full"] }
+tower-http = { version = "0.6", features = ["trace", "timeout", "limit"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+anyhow = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+clap = { workspace = true }
+hex = { workspace = true }
+sha2 = { workspace = true }
+base64 = "0.22"
+# RFC 6962 consistency-proof verification on the server side. Same pin
+# as nucleus-lineage / nucleus-verifier-service so the workspace keeps a
+# single ct-merkle version.
+ct-merkle = { version = "0.3", features = ["serde"] }
+# Ed25519 cosignature minting + log-key signature verification. Matches
+# the workspace-wide pin so cargo-deny's duplicate-version ban stays
+# green (nucleus-lineage / nucleus-verifier-service both pin this).
+ed25519-dalek = { version = "=3.0.0-pre.7", features = ["rand_core"] }
+
+[dev-dependencies]
+tower = { version = "0.5", features = ["util"] }
+http-body-util = "0.1"
+
+[lints]
+workspace = true

--- a/crates/nucleus-witness/README.md
+++ b/crates/nucleus-witness/README.md
@@ -1,0 +1,86 @@
+# nucleus-witness
+
+A [C2SP `tlog-witness`](https://c2sp.org/tlog-witness) server. It mints
+Ed25519 **cosignatures** over transparency-log checkpoints, enforcing the
+spec status matrix so it only ever cosigns a checkpoint that is signed by
+a trusted log key, extends the last checkpoint it cosigned (RFC 6962
+consistency proof), and is not a rollback.
+
+This crate is **auth-sensitive**: a cosignature is minted with a witness
+private key. The correctness of the status matrix and the adversarial
+negative tests is the whole point — see `tests/status_matrix.rs`.
+
+## The status matrix (`POST /add-checkpoint`)
+
+| Code | Condition |
+|------|-----------|
+| **404** | checkpoint origin is unknown (not in the trusted-origins set) |
+| **403** | no signature from a trusted key for the origin, OR a sig line whose key name+ID match a trusted key but whose signature fails to verify |
+| **400** | `old` size > checkpoint size |
+| **409** | `old` size ≠ the witness's last-cosigned size for the origin; OR `old` size == checkpoint size but the root hashes differ |
+| **422** | the Merkle consistency proof does not verify (old→new) |
+| **200** | otherwise: update last-cosigned `(size, root)`, return one or more `cosignature/v1` lines |
+
+The pure decision lives in `server::decide` (unit-testable without HTTP);
+the axum handler maps the `Decision` to a status + body.
+
+### Request body
+
+```
+old <N>\n
+<0..=63 base64 consistency-proof-hash lines, each \n-terminated>
+\n                                  ← blank line separator
+<checkpoint signed-note>            ← origin / size / base64(root) / [ext...] / blank / `— <name> <base64>` sig lines
+```
+
+### 200 response
+
+One or more cosignature/v1 lines:
+
+```
+— <witness-name> base64(keyID(4) || timestamp(8, big-endian) || ed25519_sig(64))
+```
+
+where the signed message is `cosignature/v1\ntime <unix>\n<full checkpoint
+note body>` and `keyID = SHA-256(name || 0x0A || 0x04 || pubkey)[:4]`. The
+timestamp is non-zero. (ML-DSA-44 is a future C2SP SHOULD — not
+implemented; Ed25519 only.)
+
+## Deployment model: single-tenant split-trust
+
+Run **your own k-of-n witnesses** across diverse regions / clouds / HSMs.
+The value is **failure-domain diversity**, not federation with other
+organizations: no single region outage, cloud-account compromise, or
+key-store breach can forge or roll back your log, because a quorum of
+independently-hosted witnesses must each cosign. A verifier configured
+with a Sigsum k-of-n policy (see `nucleus_lineage::policy`) then cannot be
+shown a forged or rolled-back log without a threshold compromise.
+
+## Dormant metering seam (documented, NOT implemented)
+
+A valid cosignature over a real checkpoint is a unit of *proven work* —
+the natural meter point for a future **parallel paid tier**: priced by
+VCG/Pigou, settled over x402 / L402. That tier would meter ONLY proven
+cosignatures and run *alongside* (never tax) any volunteer commons — the
+Tor lesson. None of that billing logic exists here; this is a forward
+note so the seam isn't designed shut.
+
+C2SP itself flags **witness sustainability / funding as an unsolved open
+problem**. The paid-tier seam above is one possible answer, not a settled
+one.
+
+## State persistence
+
+The MVP store (`store::InMemoryStore`) is in-memory behind the
+`OriginStore` trait. It is **not persistent** — a restart resets each
+origin's last-cosigned position to "never seen", which would let a
+producer replay an old checkpoint as a first submission. Production MUST
+back the store with durable storage (litewitness uses sqlite); the trait
+boundary makes that a drop-in without touching the status matrix.
+
+## Crypto reuse
+
+No cryptography is reinvented. Signed-note parsing/formatting, key-ID
+derivation, and checkpoint-body bytes come from `nucleus-lineage`;
+RFC 6962 consistency verification comes from `ct-merkle`. The only
+net-new logic is the C2SP status matrix and the cosignature/v1 framing.

--- a/crates/nucleus-witness/src/app.rs
+++ b/crates/nucleus-witness/src/app.rs
@@ -1,0 +1,37 @@
+//! Router assembly for the witness server. Mirrors the axum 0.8 +
+//! shared-state pattern used by `nucleus-verifier-service`.
+
+use std::time::Duration;
+
+use axum::{
+    http::StatusCode,
+    routing::{get, post},
+    Router,
+};
+use tower_http::{limit::RequestBodyLimitLayer, timeout::TimeoutLayer, trace::TraceLayer};
+
+use crate::server::{add_checkpoint_handler, WitnessState};
+
+/// Max request body size. A checkpoint + up to 63 consistency-proof
+/// lines + signatures is a few KiB; 64 KiB is generous while bounding
+/// trivial DoS via giant bodies.
+const MAX_BODY_BYTES: usize = 64 * 1024;
+
+/// `GET /healthz` — liveness.
+async fn healthz() -> &'static str {
+    "ok"
+}
+
+/// Build the witness router.
+pub fn build_app(state: WitnessState) -> Router {
+    Router::new()
+        .route("/healthz", get(healthz))
+        .route("/add-checkpoint", post(add_checkpoint_handler))
+        .layer(TraceLayer::new_for_http())
+        .layer(RequestBodyLimitLayer::new(MAX_BODY_BYTES))
+        .layer(TimeoutLayer::with_status_code(
+            StatusCode::REQUEST_TIMEOUT,
+            Duration::from_secs(30),
+        ))
+        .with_state(state)
+}

--- a/crates/nucleus-witness/src/cosign.rs
+++ b/crates/nucleus-witness/src/cosign.rs
@@ -1,0 +1,207 @@
+//! Witness cosignature minting per [c2sp.org/tlog-cosignature].
+//!
+//! A cosignature/v1 line is:
+//!
+//! ```text
+//! — <witness-name> base64(keyID(4) || timestamp(8, big-endian) || ed25519_sig(64))
+//! ```
+//!
+//! The signed message is:
+//!
+//! ```text
+//! cosignature/v1\n
+//! time <unix>\n
+//! <full checkpoint note body, including its final newline>
+//! ```
+//!
+//! `keyID = SHA-256(name || 0x0A || 0x04 || pubkey)[:4]` — exactly
+//! [`nucleus_lineage::ed25519_key_id`] with the cosignature sig-type
+//! byte ([`nucleus_lineage::SIG_TYPE_COSIGNATURE`]). We REUSE that key-ID
+//! computation and the lineage Ed25519 signing primitive; the only
+//! net-new logic is the cosignature/v1 message framing + the
+//! `keyID||timestamp||sig` payload layout.
+//!
+//! [c2sp.org/tlog-cosignature]: https://c2sp.org/tlog-cosignature
+
+use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
+use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
+use nucleus_lineage::{ed25519_key_id, SIG_LINE_PREFIX, SIG_TYPE_COSIGNATURE};
+
+/// A witness signing identity: an Ed25519 key plus its C2SP name.
+pub struct WitnessKey {
+    signing_key: SigningKey,
+    verifying_key: VerifyingKey,
+    name: String,
+}
+
+impl WitnessKey {
+    /// Construct from a 32-byte Ed25519 seed and a C2SP witness name.
+    pub fn from_seed(seed: [u8; 32], name: impl Into<String>) -> Self {
+        let signing_key = SigningKey::from_bytes(&seed);
+        let verifying_key = signing_key.verifying_key();
+        Self {
+            signing_key,
+            verifying_key,
+            name: name.into(),
+        }
+    }
+
+    /// The witness's C2SP name (the `key_name` in cosignature lines).
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// The 32-byte Ed25519 verifying key — publish out-of-band so
+    /// verifiers can place this witness in a Sigsum policy.
+    pub fn verifying_key_bytes(&self) -> [u8; 32] {
+        self.verifying_key.to_bytes()
+    }
+
+    /// The 4-byte C2SP key ID under the cosignature sig-type byte
+    /// (`SHA-256(name || 0x0A || 0x04 || pubkey)[:4]`).
+    pub fn key_id(&self) -> [u8; 4] {
+        ed25519_key_id(
+            &self.name,
+            SIG_TYPE_COSIGNATURE,
+            &self.verifying_key.to_bytes(),
+        )
+    }
+
+    /// Build the exact cosignature/v1 signed message for a checkpoint
+    /// note body at `timestamp` (unix seconds).
+    ///
+    /// `note_body` MUST be the whole checkpoint note body INCLUDING its
+    /// final newline and EXCLUDING any signature lines — i.e.
+    /// [`crate::parse::Checkpoint::body_bytes`].
+    pub fn cosignature_message(timestamp: u64, note_body: &[u8]) -> Vec<u8> {
+        let mut msg = Vec::with_capacity(note_body.len() + 32);
+        msg.extend_from_slice(b"cosignature/v1\n");
+        msg.extend_from_slice(format!("time {timestamp}\n").as_bytes());
+        msg.extend_from_slice(note_body);
+        msg
+    }
+
+    /// Mint a cosignature/v1 line over `note_body` at `timestamp`.
+    ///
+    /// `timestamp` is unix seconds and MUST be non-zero (the spec
+    /// requires a real time). Returns the full `— <name> <base64>` line
+    /// (no trailing newline).
+    pub fn cosign_line(&self, note_body: &[u8], timestamp: u64) -> String {
+        debug_assert!(timestamp != 0, "cosignature timestamp must be non-zero");
+        let msg = Self::cosignature_message(timestamp, note_body);
+        let sig: Signature = self.signing_key.sign(&msg);
+        let key_id = self.key_id();
+        // Payload: keyID(4) || timestamp(8, big-endian) || sig(64).
+        let mut payload = Vec::with_capacity(4 + 8 + 64);
+        payload.extend_from_slice(&key_id);
+        payload.extend_from_slice(&timestamp.to_be_bytes());
+        payload.extend_from_slice(&sig.to_bytes());
+        format!("{SIG_LINE_PREFIX}{} {}", self.name, B64.encode(&payload))
+    }
+}
+
+/// Verify a cosignature/v1 line minted by a witness with `pubkey`.
+/// Returns the recovered `(timestamp, key_name)` on success. Used by the
+/// 2-of-2 integration test and any policy-side verification.
+///
+/// This is the inverse of [`WitnessKey::cosign_line`]: it re-derives the
+/// signed message from `note_body` + the embedded timestamp and checks
+/// the Ed25519 signature.
+pub fn verify_cosign_line(
+    line: &str,
+    note_body: &[u8],
+    pubkey: &[u8; 32],
+) -> Result<(u64, String), CosignVerifyError> {
+    let parsed = nucleus_lineage::parse_signature_line(line)
+        .map_err(|e| CosignVerifyError::Malformed(e.to_string()))?;
+    // payload after the 4-byte key_id is timestamp(8) || sig(64).
+    if parsed.signature.len() != 8 + 64 {
+        return Err(CosignVerifyError::BadPayloadLen {
+            got: parsed.signature.len(),
+        });
+    }
+    let mut ts_bytes = [0u8; 8];
+    ts_bytes.copy_from_slice(&parsed.signature[..8]);
+    let timestamp = u64::from_be_bytes(ts_bytes);
+    if timestamp == 0 {
+        return Err(CosignVerifyError::ZeroTimestamp);
+    }
+    let mut sig_bytes = [0u8; 64];
+    sig_bytes.copy_from_slice(&parsed.signature[8..]);
+    let signature = Signature::from_bytes(&sig_bytes);
+    let vk = VerifyingKey::from_bytes(pubkey).map_err(|_| CosignVerifyError::BadKey)?;
+    let msg = WitnessKey::cosignature_message(timestamp, note_body);
+    vk.verify(&msg, &signature)
+        .map_err(|_| CosignVerifyError::SignatureInvalid)?;
+    Ok((timestamp, parsed.key_name))
+}
+
+/// Errors from [`verify_cosign_line`].
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum CosignVerifyError {
+    #[error("cosignature line malformed: {0}")]
+    Malformed(String),
+    #[error("cosignature payload after key_id is {got} bytes; expected 72 (8 ts + 64 sig)")]
+    BadPayloadLen { got: usize },
+    #[error("cosignature timestamp is zero")]
+    ZeroTimestamp,
+    #[error("witness public key is not a valid Ed25519 key")]
+    BadKey,
+    #[error("cosignature signature did not verify")]
+    SignatureInvalid,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cosign_round_trip_verifies() {
+        let wk = WitnessKey::from_seed([7u8; 32], "nucleus.witness/a");
+        let note_body = b"nucleus.example/log\n5\ncm9vdA==\n";
+        let line = wk.cosign_line(note_body, 1_700_000_000);
+        let (ts, name) = verify_cosign_line(&line, note_body, &wk.verifying_key_bytes()).unwrap();
+        assert_eq!(ts, 1_700_000_000);
+        assert_eq!(name, "nucleus.witness/a");
+    }
+
+    #[test]
+    fn cosign_line_has_em_dash_and_name() {
+        let wk = WitnessKey::from_seed([8u8; 32], "nucleus.witness/b");
+        let line = wk.cosign_line(b"body\n", 1234);
+        assert!(line.starts_with("\u{2014} nucleus.witness/b "));
+    }
+
+    #[test]
+    fn verify_rejects_wrong_note_body() {
+        let wk = WitnessKey::from_seed([9u8; 32], "w");
+        let line = wk.cosign_line(b"original\n", 1234);
+        let err = verify_cosign_line(&line, b"tampered\n", &wk.verifying_key_bytes()).unwrap_err();
+        assert_eq!(err, CosignVerifyError::SignatureInvalid);
+    }
+
+    #[test]
+    fn verify_rejects_wrong_pubkey() {
+        let wk = WitnessKey::from_seed([10u8; 32], "w");
+        let other = WitnessKey::from_seed([11u8; 32], "w");
+        let line = wk.cosign_line(b"body\n", 1234);
+        let err = verify_cosign_line(&line, b"body\n", &other.verifying_key_bytes()).unwrap_err();
+        assert_eq!(err, CosignVerifyError::SignatureInvalid);
+    }
+
+    #[test]
+    fn key_id_uses_cosignature_sig_type() {
+        let wk = WitnessKey::from_seed([12u8; 32], "name");
+        let expected = ed25519_key_id("name", SIG_TYPE_COSIGNATURE, &wk.verifying_key_bytes());
+        assert_eq!(wk.key_id(), expected);
+    }
+
+    #[test]
+    fn message_framing_is_exact() {
+        let msg = WitnessKey::cosignature_message(1679315147, b"origin\n5\nroot\n");
+        assert_eq!(
+            msg,
+            b"cosignature/v1\ntime 1679315147\norigin\n5\nroot\n".to_vec()
+        );
+    }
+}

--- a/crates/nucleus-witness/src/lib.rs
+++ b/crates/nucleus-witness/src/lib.rs
@@ -1,0 +1,60 @@
+//! `nucleus-witness` — a [C2SP `tlog-witness`] server that mints Ed25519
+//! cosignatures over checkpoints, enforcing the spec status matrix.
+//!
+//! # What this is
+//!
+//! A witness is the "second pair of eyes" in a transparency log: it
+//! cosigns a log's checkpoint only after checking that the new checkpoint
+//! (a) is signed by a trusted log key, (b) extends the last checkpoint
+//! the witness cosigned (RFC 6962 consistency proof), and (c) is not a
+//! rollback to a smaller/different tree. A verifier that requires a
+//! k-of-n witness quorum (see [`nucleus_lineage::policy`]) then cannot be
+//! shown a forged or rolled-back log unless the attacker compromises a
+//! threshold of witnesses across independent failure domains.
+//!
+//! # Single-tenant split-trust (the deployment model)
+//!
+//! This crate is built for **one operator running their own k-of-n
+//! witnesses** across diverse regions / clouds / HSMs — NOT for
+//! federating with other organizations. The value is **failure-domain
+//! diversity**: no single region outage, cloud-account compromise, or
+//! key-store breach can forge or roll back your log, because a quorum of
+//! independently-hosted witnesses must each cosign. You get
+//! transparency-log integrity without depending on a volunteer witness
+//! commons.
+//!
+//! # Dormant metering seam (documented, NOT implemented)
+//!
+//! A valid cosignature over a real checkpoint is a unit of *proven
+//! work* — the natural meter point for a future **parallel paid tier**:
+//! priced by VCG/Pigou and settled over x402 / L402. That tier would
+//! meter ONLY proven cosignatures, never the volunteer commons (Tor's
+//! lesson: run a paid lane in parallel, don't tax the free one). None of
+//! that billing logic exists in this crate today — this is a forward
+//! note so the seam isn't designed shut.
+//!
+//! C2SP itself flags **witness sustainability / funding as an unsolved
+//! open problem**; the paid-tier seam above is one possible answer, not
+//! a settled one.
+//!
+//! # Crypto reuse
+//!
+//! This crate reinvents NO cryptography. It builds on
+//! [`nucleus_lineage`]'s signed-note primitives (signature-line
+//! parse/format, key-ID derivation, checkpoint-body bytes) and on
+//! `ct-merkle` for RFC 6962 consistency verification. The only net-new
+//! logic is the C2SP status matrix ([`server::decide`]) and the
+//! cosignature/v1 message framing ([`cosign::WitnessKey`]).
+//!
+//! [C2SP `tlog-witness`]: https://c2sp.org/tlog-witness
+
+pub mod app;
+pub mod cosign;
+pub mod parse;
+pub mod server;
+pub mod store;
+
+pub use cosign::{verify_cosign_line, CosignVerifyError, WitnessKey};
+pub use parse::{parse_add_checkpoint, AddCheckpointRequest, Checkpoint, ParseError};
+pub use server::{add_checkpoint_handler, decide, Decision, WitnessState};
+pub use store::{CosignedPosition, InMemoryStore, OriginRecord, OriginStore, TrustedLogKey};

--- a/crates/nucleus-witness/src/main.rs
+++ b/crates/nucleus-witness/src/main.rs
@@ -1,0 +1,113 @@
+//! `nucleus-witness` binary: a C2SP `tlog-witness` server.
+//!
+//! MVP wiring: an in-memory origin store seeded from CLI flags, an
+//! Ed25519 witness key from a seed file (or a dev seed), and the axum
+//! router on a bind address. Production deployments should back the
+//! store with durable storage (see `store::InMemoryStore` docs) and
+//! load the witness key from an HSM / KMS rather than a seed file.
+
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use nucleus_witness::{
+    app::build_app, server::WitnessState, InMemoryStore, TrustedLogKey, WitnessKey,
+};
+
+/// C2SP tlog-witness server.
+#[derive(Parser, Debug)]
+#[command(name = "nucleus-witness", version, about)]
+struct Cli {
+    /// Bind address, e.g. 0.0.0.0:8443 (bind to all interfaces for
+    /// 6PN / k8s accessibility).
+    #[arg(long, default_value = "0.0.0.0:8443")]
+    bind: String,
+
+    /// Hex-encoded 32-byte Ed25519 seed for the witness signing key.
+    /// In production, load from a secret manager — NOT a flag.
+    #[arg(long, env = "NUCLEUS_WITNESS_SEED_HEX")]
+    witness_seed_hex: Option<String>,
+
+    /// C2SP witness name (the key_name in cosignature lines).
+    #[arg(long, default_value = "nucleus.witness/local")]
+    witness_name: String,
+
+    /// A trusted origin to cosign for, in the form
+    /// `origin|log_key_name|log_pubkey_hex`. Repeatable.
+    #[arg(long = "origin")]
+    origins: Vec<String>,
+}
+
+fn parse_origin_spec(spec: &str) -> Result<(String, TrustedLogKey)> {
+    let parts: Vec<&str> = spec.split('|').collect();
+    anyhow::ensure!(
+        parts.len() == 3,
+        "origin spec must be `origin|log_key_name|log_pubkey_hex`, got {spec:?}"
+    );
+    let pubkey_bytes = hex::decode(parts[2].trim())
+        .with_context(|| format!("origin {:?}: pubkey hex decode", parts[0]))?;
+    let pubkey: [u8; 32] = pubkey_bytes
+        .as_slice()
+        .try_into()
+        .map_err(|_| anyhow::anyhow!("origin {:?}: pubkey must be 32 bytes", parts[0]))?;
+    Ok((
+        parts[0].to_string(),
+        TrustedLogKey {
+            key_name: parts[1].to_string(),
+            pubkey,
+        },
+    ))
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt::init();
+
+    let cli = Cli::parse();
+
+    let seed: [u8; 32] = match cli.witness_seed_hex {
+        Some(hex_str) => {
+            let bytes = hex::decode(hex_str.trim()).context("witness seed hex decode")?;
+            bytes
+                .as_slice()
+                .try_into()
+                .map_err(|_| anyhow::anyhow!("witness seed must be 32 bytes"))?
+        }
+        None => {
+            tracing::warn!(
+                "no --witness-seed-hex provided; using a non-secret dev seed. \
+                 DO NOT use this in production."
+            );
+            [0x11u8; 32]
+        }
+    };
+    let witness_key = Arc::new(WitnessKey::from_seed(seed, cli.witness_name));
+    tracing::info!(
+        witness_name = witness_key.name(),
+        pubkey_hex = %hex::encode(witness_key.verifying_key_bytes()),
+        "witness key loaded"
+    );
+
+    let store = InMemoryStore::new();
+    for spec in &cli.origins {
+        let (origin, key) = parse_origin_spec(spec)?;
+        tracing::info!(origin = %origin, log_key = %key.key_name, "trusting origin");
+        store.add_origin(origin, vec![key], None);
+    }
+    if cli.origins.is_empty() {
+        tracing::warn!("no --origin configured; every checkpoint will 404 until origins are added");
+    }
+
+    let state = WitnessState {
+        store: Arc::new(store),
+        witness_key,
+    };
+
+    let app = build_app(state);
+    let listener = tokio::net::TcpListener::bind(&cli.bind)
+        .await
+        .with_context(|| format!("binding {}", cli.bind))?;
+    tracing::info!(bind = %cli.bind, "nucleus-witness listening");
+    axum::serve(listener, app).await.context("axum serve")?;
+    Ok(())
+}

--- a/crates/nucleus-witness/src/parse.rs
+++ b/crates/nucleus-witness/src/parse.rs
@@ -1,0 +1,401 @@
+//! Byte-level parsers for the C2SP `POST /add-checkpoint` request body.
+//!
+//! The request body (per [c2sp.org/tlog-witness]) is:
+//!
+//! ```text
+//! old <N>\n
+//! <0..=63 base64 consistency-proof-hash lines, each \n-terminated>
+//! \n                                  ← blank line separator
+//! <checkpoint signed-note>            ← origin / size / base64(root) / [ext...] / blank / sig lines
+//! ```
+//!
+//! The checkpoint itself is a [c2sp.org/signed-note]: a body (origin
+//! line, decimal size, base64 root hash, optional extension lines)
+//! followed by a blank line then one or more `— <name> <base64>`
+//! signature lines.
+//!
+//! We REUSE [`nucleus_lineage::parse_signature_line`] for the signature
+//! lines and [`nucleus_lineage::SIG_LINE_PREFIX`] for the em-dash
+//! detection — no crypto or signed-note logic is reinvented here.
+//!
+//! [c2sp.org/tlog-witness]: https://c2sp.org/tlog-witness
+//! [c2sp.org/signed-note]: https://c2sp.org/signed-note
+
+use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
+use nucleus_lineage::{parse_signature_line, ParsedSignatureLine, SIG_LINE_PREFIX};
+use thiserror::Error;
+
+/// The maximum number of consistency-proof lines a client may send
+/// (C2SP `tlog-witness`: "MUST NOT send more than 63").
+pub const MAX_CONSISTENCY_PROOF_LINES: usize = 63;
+
+/// Errors raised while parsing an add-checkpoint request body. These map
+/// to `400 Bad Request` at the HTTP layer (malformed input) UNLESS the
+/// status matrix assigns a more specific code; see `server::handle`.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum ParseError {
+    #[error("request body is not valid UTF-8")]
+    NotUtf8,
+    #[error("request body is missing the `old <N>` line")]
+    MissingOldLine,
+    #[error("`old` line malformed: expected `old <decimal>`, got {0:?}")]
+    BadOldLine(String),
+    #[error("request body is missing the blank line separating proof from checkpoint")]
+    MissingBlankSeparator,
+    #[error("consistency proof has {got} lines; spec caps at {MAX_CONSISTENCY_PROOF_LINES}")]
+    TooManyProofLines { got: usize },
+    #[error("consistency proof line {line} is not valid base64: {source}")]
+    BadProofBase64 {
+        line: usize,
+        #[source]
+        source: base64::DecodeError,
+    },
+    #[error("consistency proof line {line} decoded to {got} bytes; expected 32")]
+    BadProofHashLen { line: usize, got: usize },
+    #[error("checkpoint is empty")]
+    EmptyCheckpoint,
+    #[error("checkpoint body is missing the blank line before the signature lines")]
+    MissingCheckpointSigSeparator,
+    #[error("checkpoint origin line is empty")]
+    EmptyOrigin,
+    #[error("checkpoint size line is not a decimal: {0:?}")]
+    BadSize(String),
+    #[error("checkpoint root-hash line is not valid base64: {0:?}")]
+    BadRootBase64(String),
+    #[error("checkpoint root hash decoded to {got} bytes; expected 32")]
+    BadRootLen { got: usize },
+    #[error("checkpoint has no signature lines")]
+    NoSignatureLines,
+    #[error("checkpoint signature line malformed: {0}")]
+    BadSignatureLine(String),
+}
+
+/// A parsed add-checkpoint request.
+#[derive(Debug, Clone)]
+pub struct AddCheckpointRequest {
+    /// The `old <N>` size the producer claims the witness last cosigned.
+    pub old_size: u64,
+    /// Consistency-proof hashes (each 32 bytes), in wire order.
+    pub consistency_proof: Vec<[u8; 32]>,
+    /// The parsed checkpoint signed-note.
+    pub checkpoint: Checkpoint,
+}
+
+/// A parsed C2SP checkpoint signed-note.
+#[derive(Debug, Clone)]
+pub struct Checkpoint {
+    /// Origin line (log identifier).
+    pub origin: String,
+    /// Tree size (decimal).
+    pub size: u64,
+    /// 32-byte root hash.
+    pub root: [u8; 32],
+    /// Optional extension lines between the root and the blank/sig
+    /// separator (kept verbatim for completeness; not interpreted).
+    pub extensions: Vec<String>,
+    /// Signature lines parsed into `(key_name, key_id, signature)`.
+    pub signatures: Vec<ParsedSignatureLine>,
+    /// The exact note BODY bytes (origin..=last extension line, INCLUDING
+    /// the final `\n`, EXCLUDING the blank line and signature lines).
+    /// This is what the log key signed AND what the cosignature/v1
+    /// message appends — keep it byte-exact.
+    pub body_bytes: Vec<u8>,
+}
+
+/// Parse a full add-checkpoint request body.
+pub fn parse_add_checkpoint(body: &[u8]) -> Result<AddCheckpointRequest, ParseError> {
+    let text = std::str::from_utf8(body).map_err(|_| ParseError::NotUtf8)?;
+
+    // Split off the first line: `old <N>`.
+    let (old_line, rest) = text.split_once('\n').ok_or(ParseError::MissingOldLine)?;
+    let old_size = parse_old_line(old_line)?;
+
+    // The remainder is: <proof lines>\n<blank>\n<checkpoint>. The blank
+    // line is the FIRST empty line, which separates the (possibly empty)
+    // proof block from the checkpoint. We scan line-by-line until the
+    // first empty line; everything before is a proof line.
+    let mut consistency_proof = Vec::new();
+    let mut checkpoint_start = None;
+    let mut cursor = 0usize;
+    let mut proof_line_no = 0usize;
+    let mut found_blank = false;
+    for line in split_keep_offsets(rest) {
+        let (content, next_offset) = line;
+        if content.is_empty() {
+            // Blank separator found. Checkpoint begins after it.
+            checkpoint_start = Some(next_offset);
+            found_blank = true;
+            break;
+        }
+        proof_line_no += 1;
+        if proof_line_no > MAX_CONSISTENCY_PROOF_LINES {
+            return Err(ParseError::TooManyProofLines { got: proof_line_no });
+        }
+        let raw = B64
+            .decode(content)
+            .map_err(|source| ParseError::BadProofBase64 {
+                line: proof_line_no,
+                source,
+            })?;
+        let hash: [u8; 32] =
+            raw.as_slice()
+                .try_into()
+                .map_err(|_| ParseError::BadProofHashLen {
+                    line: proof_line_no,
+                    got: raw.len(),
+                })?;
+        consistency_proof.push(hash);
+        cursor = next_offset;
+    }
+    let _ = cursor;
+
+    if !found_blank {
+        return Err(ParseError::MissingBlankSeparator);
+    }
+    let checkpoint_text = &rest[checkpoint_start.unwrap()..];
+    if checkpoint_text.trim().is_empty() {
+        return Err(ParseError::EmptyCheckpoint);
+    }
+    let checkpoint = parse_checkpoint(checkpoint_text)?;
+
+    Ok(AddCheckpointRequest {
+        old_size,
+        consistency_proof,
+        checkpoint,
+    })
+}
+
+/// Parse the `old <N>` line.
+fn parse_old_line(line: &str) -> Result<u64, ParseError> {
+    let line = line.trim_end_matches('\r');
+    let rest = line
+        .strip_prefix("old ")
+        .ok_or_else(|| ParseError::BadOldLine(line.to_string()))?;
+    rest.trim()
+        .parse::<u64>()
+        .map_err(|_| ParseError::BadOldLine(line.to_string()))
+}
+
+/// Parse a checkpoint signed-note: body lines, blank separator, sig
+/// lines. The body is `origin\n<size>\n<base64 root>\n[ext\n...]`.
+fn parse_checkpoint(text: &str) -> Result<Checkpoint, ParseError> {
+    // The signed-note body and signature lines are separated by the
+    // FIRST blank line. Everything before is body; everything after is
+    // signature lines.
+    //
+    // We must preserve the EXACT body bytes (including the trailing \n
+    // of the last body line) because the log key + cosignature sign over
+    // them. We reconstruct body_bytes from the original slice rather than
+    // re-joining parsed lines so a stray \r or formatting nuance can't
+    // diverge our reconstruction from the producer's signed bytes.
+
+    let mut lines = Vec::new();
+    let mut blank_at = None;
+    for (content, _next) in split_keep_offsets(text) {
+        if content.is_empty() {
+            blank_at = Some(lines.len());
+            break;
+        }
+        lines.push(content);
+    }
+    let blank_at = blank_at.ok_or(ParseError::MissingCheckpointSigSeparator)?;
+    let (body_lines, _) = lines.split_at(blank_at);
+
+    if body_lines.len() < 3 {
+        // Need at least origin, size, root.
+        return Err(ParseError::EmptyOrigin);
+    }
+    let origin = body_lines[0].to_string();
+    if origin.is_empty() {
+        return Err(ParseError::EmptyOrigin);
+    }
+    let size: u64 = body_lines[1]
+        .parse()
+        .map_err(|_| ParseError::BadSize(body_lines[1].to_string()))?;
+    let root_raw = B64
+        .decode(body_lines[2])
+        .map_err(|_| ParseError::BadRootBase64(body_lines[2].to_string()))?;
+    let root: [u8; 32] = root_raw
+        .as_slice()
+        .try_into()
+        .map_err(|_| ParseError::BadRootLen {
+            got: root_raw.len(),
+        })?;
+    let extensions: Vec<String> = body_lines[3..].iter().map(|s| s.to_string()).collect();
+
+    // Reconstruct the exact body bytes: each body line + its '\n'. The
+    // blank-line scan above stops at the first empty line, so the body
+    // is exactly `origin\nsize\nroot\n[ext\n...]`.
+    let mut body_bytes = Vec::new();
+    for l in body_lines {
+        body_bytes.extend_from_slice(l.as_bytes());
+        body_bytes.push(b'\n');
+    }
+
+    // Signature lines: every line after the blank that begins with the
+    // em-dash prefix. Reuse the lineage parser (handles key_id/sig
+    // split, NBSP/control-char rejection, base64 decode).
+    let sig_block_start = body_bytes.len() + 1; // +1 for the blank line's \n
+    let sig_text = &text[sig_block_start.min(text.len())..];
+    let mut signatures = Vec::new();
+    for line in sig_text.lines() {
+        if !line.starts_with(SIG_LINE_PREFIX) {
+            continue;
+        }
+        let parsed =
+            parse_signature_line(line).map_err(|e| ParseError::BadSignatureLine(e.to_string()))?;
+        signatures.push(parsed);
+    }
+    if signatures.is_empty() {
+        return Err(ParseError::NoSignatureLines);
+    }
+
+    Ok(Checkpoint {
+        origin,
+        size,
+        root,
+        extensions,
+        signatures,
+        body_bytes,
+    })
+}
+
+/// Iterate `\n`-separated lines, yielding `(line_without_newline,
+/// offset_of_next_line)`. A trailing `\r` is stripped. Unlike
+/// [`str::lines`], this lets us recover byte offsets so we can slice the
+/// checkpoint sub-body exactly.
+fn split_keep_offsets(s: &str) -> Vec<(&str, usize)> {
+    let mut out = Vec::new();
+    let mut start = 0usize;
+    let bytes = s.as_bytes();
+    for (i, &b) in bytes.iter().enumerate() {
+        if b == b'\n' {
+            let mut end = i;
+            if end > start && bytes[end - 1] == b'\r' {
+                end -= 1;
+            }
+            out.push((&s[start..end], i + 1));
+            start = i + 1;
+        }
+    }
+    if start < s.len() {
+        let mut end = s.len();
+        if end > start && bytes[end - 1] == b'\r' {
+            end -= 1;
+        }
+        out.push((&s[start..end], s.len()));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nucleus_lineage::{
+        ed25519_key_id, format_checkpoint_body, format_signature_line, Ed25519Witness,
+        SIG_TYPE_ED25519,
+    };
+
+    /// Build a well-formed add-checkpoint body signed by `log_key` under
+    /// `key_name`, with the given old_size + proof lines.
+    pub(crate) fn build_body(
+        log_key: &Ed25519Witness,
+        key_name: &str,
+        origin: &str,
+        size: u64,
+        root: &[u8; 32],
+        old_size: u64,
+        proof: &[[u8; 32]],
+    ) -> Vec<u8> {
+        let cp_body = format_checkpoint_body(origin, size, root).unwrap();
+        let sig = log_key.sign_message(cp_body.as_bytes());
+        let key_id = ed25519_key_id(key_name, SIG_TYPE_ED25519, &log_key.verifying_key_bytes());
+        let sig_line = format_signature_line(key_name, &key_id, &sig).unwrap();
+
+        let mut body = Vec::new();
+        body.extend_from_slice(format!("old {old_size}\n").as_bytes());
+        for h in proof {
+            body.extend_from_slice(B64.encode(h).as_bytes());
+            body.push(b'\n');
+        }
+        body.push(b'\n'); // blank separator
+        body.extend_from_slice(cp_body.as_bytes());
+        body.push(b'\n'); // body/sig separator
+        body.extend_from_slice(sig_line.as_bytes());
+        body.push(b'\n');
+        body
+    }
+
+    #[test]
+    fn parses_minimal_first_submission() {
+        let log_key = Ed25519Witness::from_seed([1u8; 32]);
+        let body = build_body(
+            &log_key,
+            "nucleus.example/log",
+            "nucleus.example/log",
+            5,
+            &[0x42u8; 32],
+            0,
+            &[],
+        );
+        let req = parse_add_checkpoint(&body).unwrap();
+        assert_eq!(req.old_size, 0);
+        assert!(req.consistency_proof.is_empty());
+        assert_eq!(req.checkpoint.origin, "nucleus.example/log");
+        assert_eq!(req.checkpoint.size, 5);
+        assert_eq!(req.checkpoint.root, [0x42u8; 32]);
+        assert_eq!(req.checkpoint.signatures.len(), 1);
+    }
+
+    #[test]
+    fn body_bytes_match_signed_checkpoint_body() {
+        let log_key = Ed25519Witness::from_seed([2u8; 32]);
+        let origin = "nucleus.example/log";
+        let body = build_body(&log_key, origin, origin, 9, &[0x11u8; 32], 0, &[]);
+        let req = parse_add_checkpoint(&body).unwrap();
+        let expected = format_checkpoint_body(origin, 9, &[0x11u8; 32]).unwrap();
+        assert_eq!(req.checkpoint.body_bytes, expected.into_bytes());
+    }
+
+    #[test]
+    fn parses_proof_lines() {
+        let log_key = Ed25519Witness::from_seed([3u8; 32]);
+        let origin = "nucleus.example/log";
+        let proof = [[0xAAu8; 32], [0xBBu8; 32]];
+        let body = build_body(&log_key, origin, origin, 7, &[0x33u8; 32], 4, &proof);
+        let req = parse_add_checkpoint(&body).unwrap();
+        assert_eq!(req.old_size, 4);
+        assert_eq!(req.consistency_proof, proof);
+    }
+
+    #[test]
+    fn rejects_too_many_proof_lines() {
+        let log_key = Ed25519Witness::from_seed([4u8; 32]);
+        let origin = "nucleus.example/log";
+        let proof: Vec<[u8; 32]> = (0..64).map(|i| [i as u8; 32]).collect();
+        let body = build_body(&log_key, origin, origin, 100, &[0u8; 32], 4, &proof);
+        let err = parse_add_checkpoint(&body).unwrap_err();
+        assert!(matches!(err, ParseError::TooManyProofLines { got: 64 }));
+    }
+
+    #[test]
+    fn rejects_missing_old_line() {
+        let err = parse_add_checkpoint(b"").unwrap_err();
+        assert!(matches!(err, ParseError::MissingOldLine));
+    }
+
+    #[test]
+    fn rejects_no_signature_lines() {
+        // old 0\n\norigin\n5\n<root>\n  (no blank+sig)
+        let cp = format_checkpoint_body("origin", 5, &[0u8; 32]).unwrap();
+        let mut body = Vec::new();
+        body.extend_from_slice(b"old 0\n\n");
+        body.extend_from_slice(cp.as_bytes());
+        body.push(b'\n'); // blank, but no sig line follows
+        let err = parse_add_checkpoint(&body).unwrap_err();
+        assert!(matches!(
+            err,
+            ParseError::NoSignatureLines | ParseError::MissingCheckpointSigSeparator
+        ));
+    }
+}

--- a/crates/nucleus-witness/src/server.rs
+++ b/crates/nucleus-witness/src/server.rs
@@ -1,0 +1,330 @@
+//! The C2SP `tlog-witness` status matrix + axum wiring.
+//!
+//! The whole security value of a witness is that it ONLY cosigns a
+//! checkpoint that is (a) signed by a trusted log key, (b) consistent
+//! with the last checkpoint it cosigned, and (c) not a rollback. The
+//! status matrix (per [c2sp.org/tlog-witness]) encodes those rules:
+//!
+//! | Code | Condition |
+//! |------|-----------|
+//! | 404  | checkpoint origin is unknown (not trusted) |
+//! | 403  | no signature from a trusted key for the origin, OR a sig line whose name+ID match a trusted key but fails to verify |
+//! | 400  | old size > checkpoint size |
+//! | 409  | old size ≠ witness's last-cosigned size; OR old size == checkpoint size but roots differ |
+//! | 422  | the Merkle consistency proof does not verify (old→new) |
+//! | 200  | otherwise: update last-cosigned, return cosignature line(s) |
+//!
+//! The pure decision is computed in [`decide`] so it can be unit-tested
+//! without HTTP. The axum handler in [`add_checkpoint_handler`] maps the
+//! [`Decision`] to a status code + body.
+//!
+//! [c2sp.org/tlog-witness]: https://c2sp.org/tlog-witness
+
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use axum::body::Bytes;
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use ct_merkle::{digest::Output, ConsistencyProof, RootHash};
+use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+use nucleus_lineage::{checkpoint_signed_bytes, ed25519_key_id, SIG_TYPE_ED25519};
+use sha2::Sha256;
+
+use crate::cosign::WitnessKey;
+use crate::parse::{parse_add_checkpoint, AddCheckpointRequest, Checkpoint, ParseError};
+use crate::store::{CosignedPosition, OriginRecord, OriginStore};
+
+/// Shared witness state for the axum handler.
+#[derive(Clone)]
+pub struct WitnessState {
+    pub store: Arc<dyn OriginStore>,
+    pub witness_key: Arc<WitnessKey>,
+}
+
+/// The outcome of evaluating an add-checkpoint request against the
+/// status matrix. Each variant maps to exactly one HTTP status.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Decision {
+    /// 200 — cosign. Carries the freshly-minted cosignature line(s).
+    Ok { cosignature_lines: Vec<String> },
+    /// 400 — old size > checkpoint size.
+    BadRequest(String),
+    /// 403 — no trusted-key signature, or a matching-key sig failed to
+    /// verify.
+    Forbidden(String),
+    /// 404 — origin not trusted.
+    NotFound(String),
+    /// 409 — rollback / conflict. Body is the witness's actual
+    /// last-cosigned size (decimal), per spec Content-Type
+    /// `text/x.tlog.size`.
+    Conflict { last_cosigned_size: u64 },
+    /// 422 — consistency proof did not verify.
+    Unprocessable(String),
+    /// 400 — request body was malformed (could not parse).
+    Malformed(ParseError),
+}
+
+impl Decision {
+    pub fn status(&self) -> StatusCode {
+        match self {
+            Decision::Ok { .. } => StatusCode::OK,
+            Decision::BadRequest(_) | Decision::Malformed(_) => StatusCode::BAD_REQUEST,
+            Decision::Forbidden(_) => StatusCode::FORBIDDEN,
+            Decision::NotFound(_) => StatusCode::NOT_FOUND,
+            Decision::Conflict { .. } => StatusCode::CONFLICT,
+            Decision::Unprocessable(_) => StatusCode::UNPROCESSABLE_ENTITY,
+        }
+    }
+}
+
+/// Pure status-matrix evaluation. Parses the body, walks the matrix in
+/// the spec-mandated order, and (on 200) mints the cosignature and
+/// CAS-advances the store. No HTTP types beyond [`Decision`].
+///
+/// `now_unix` is injected so tests can pin the cosignature timestamp;
+/// production passes the real clock via [`add_checkpoint_handler`].
+pub fn decide(state: &WitnessState, body: &[u8], now_unix: u64) -> Decision {
+    let req = match parse_add_checkpoint(body) {
+        Ok(r) => r,
+        Err(e) => return Decision::Malformed(e),
+    };
+    let AddCheckpointRequest {
+        old_size,
+        consistency_proof,
+        checkpoint,
+    } = req;
+
+    // ── 404: origin must be trusted. ──────────────────────────────
+    let record = match state.store.get(&checkpoint.origin) {
+        Some(r) => r,
+        None => {
+            return Decision::NotFound(format!("unknown origin {:?}", checkpoint.origin));
+        }
+    };
+
+    // ── 403: a valid signature from a trusted key for the origin
+    //    MUST be present. A sig line whose key name+ID match a trusted
+    //    key but whose signature fails to verify is ALSO 403 (forgery).
+    if let Err(reason) = check_trusted_signature(&checkpoint, &record) {
+        return Decision::Forbidden(reason);
+    }
+
+    // ── 400: old size MUST be ≤ checkpoint size. ──────────────────
+    if old_size > checkpoint.size {
+        return Decision::BadRequest(format!(
+            "old size {old_size} > checkpoint size {}",
+            checkpoint.size
+        ));
+    }
+
+    // ── 409: old size MUST equal the witness's last-cosigned size for
+    //    the origin. Also: if old size == checkpoint size but the roots
+    //    differ, that's a conflicting view of the same tree → 409.
+    let last = record.last_cosigned;
+    let last_size = last.map(|p| p.size).unwrap_or(0);
+    if old_size != last_size {
+        return Decision::Conflict {
+            last_cosigned_size: last_size,
+        };
+    }
+    if old_size == checkpoint.size {
+        // No extension. The producer is re-presenting a checkpoint at
+        // the same size we already cosigned; the roots MUST match or
+        // it's a split-view conflict.
+        if let Some(prev) = last {
+            if prev.root != checkpoint.root {
+                return Decision::Conflict {
+                    last_cosigned_size: last_size,
+                };
+            }
+        }
+        // old_size == size == last_size with matching root (or
+        // old_size == size == 0 first-submission empty-tree edge case):
+        // idempotent re-cosign, no consistency proof needed.
+    } else {
+        // ── 422: the consistency proof (old→new) MUST verify. Only
+        //    required when there IS an extension (old_size < size).
+        //    For the very first submission (old_size == 0) there is no
+        //    prior root to extend from; per spec, `old 0` carries no
+        //    proof and we simply cosign the new tree.
+        if old_size > 0 {
+            let prev = last.expect("old_size>0 ⇒ last_size==old_size>0 ⇒ Some");
+            if let Err(reason) = verify_consistency(
+                old_size,
+                &prev.root,
+                checkpoint.size,
+                &checkpoint.root,
+                &consistency_proof,
+            ) {
+                return Decision::Unprocessable(reason);
+            }
+        }
+    }
+
+    // ── 200: mint the cosignature over the checkpoint note body and
+    //    CAS-advance the store. The CAS uses the position we read as
+    //    `expected`; if a concurrent writer advanced first, we surface
+    //    409 rather than cosigning over a stale view.
+    let cosig_line = state
+        .witness_key
+        .cosign_line(&checkpoint.body_bytes, now_unix);
+    let new_pos = CosignedPosition {
+        size: checkpoint.size,
+        root: checkpoint.root,
+    };
+    if !state.store.advance(&checkpoint.origin, last, new_pos) {
+        // Lost the race; the store moved under us.
+        let now_last = state
+            .store
+            .get(&checkpoint.origin)
+            .and_then(|r| r.last_cosigned)
+            .map(|p| p.size)
+            .unwrap_or(0);
+        return Decision::Conflict {
+            last_cosigned_size: now_last,
+        };
+    }
+
+    Decision::Ok {
+        cosignature_lines: vec![cosig_line],
+    }
+}
+
+/// Enforce the 403 rule: at least one signature line whose `(key_name,
+/// key_id)` match a trusted log key for the origin, AND whose Ed25519
+/// signature verifies over the checkpoint body.
+///
+/// Returns `Ok(())` if such a signature exists; `Err(reason)` (→ 403)
+/// otherwise. Critically, a line that NAMES a trusted key but carries a
+/// bad signature is a forgery attempt and yields 403 — never a silent
+/// pass.
+fn check_trusted_signature(checkpoint: &Checkpoint, record: &OriginRecord) -> Result<(), String> {
+    // The bytes a log key signs are the C2SP checkpoint body
+    // (origin\nsize\nbase64(root)\n). We recompute them from the parsed
+    // fields rather than trusting the raw body slice so an attacker can't
+    // smuggle a divergent body. For an extension-free checkpoint
+    // body_bytes == this, but recomputing is the defensive choice.
+    let signed_body =
+        match checkpoint_signed_bytes(&checkpoint.origin, checkpoint.size, &checkpoint.root) {
+            Ok(b) => b,
+            Err(e) => return Err(format!("checkpoint body invalid: {e}")),
+        };
+    // If the producer included extension lines, the true signed body is
+    // the parsed body_bytes (which includes extensions). Prefer that
+    // when it differs — it is the exact bytes the producer hashed.
+    let signed_body: Vec<u8> = if checkpoint.extensions.is_empty() {
+        signed_body
+    } else {
+        checkpoint.body_bytes.clone()
+    };
+
+    let mut saw_matching_key_bad_sig = false;
+    for sig in &checkpoint.signatures {
+        for trusted in &record.trusted_log_keys {
+            // Match a trusted key by BOTH name and the C2SP key_id
+            // (derived from name+pubkey under the Ed25519 sig type).
+            if sig.key_name != trusted.key_name {
+                continue;
+            }
+            let expected_id = ed25519_key_id(&trusted.key_name, SIG_TYPE_ED25519, &trusted.pubkey);
+            if sig.key_id != expected_id {
+                continue;
+            }
+            // Name + ID match a trusted key. Now the signature itself
+            // MUST verify, else it's a forgery → 403.
+            let vk = match VerifyingKey::from_bytes(&trusted.pubkey) {
+                Ok(vk) => vk,
+                Err(_) => continue,
+            };
+            let sig_arr: [u8; 64] = match sig.signature.as_slice().try_into() {
+                Ok(a) => a,
+                Err(_) => {
+                    saw_matching_key_bad_sig = true;
+                    continue;
+                }
+            };
+            let signature = Signature::from_bytes(&sig_arr);
+            if vk.verify(&signed_body, &signature).is_ok() {
+                return Ok(()); // a trusted key validly signed.
+            }
+            saw_matching_key_bad_sig = true;
+        }
+    }
+    if saw_matching_key_bad_sig {
+        Err("a signature line matched a trusted key name+ID but failed to verify".to_string())
+    } else {
+        Err("no signature from a trusted key for the origin".to_string())
+    }
+}
+
+/// Verify the RFC 6962 consistency proof from `(old_size, old_root)` to
+/// `(new_size, new_root)`. Returns `Ok(())` on success, `Err(reason)`
+/// (→ 422) otherwise.
+fn verify_consistency(
+    old_size: u64,
+    old_root: &[u8; 32],
+    new_size: u64,
+    new_root: &[u8; 32],
+    proof_hashes: &[[u8; 32]],
+) -> Result<(), String> {
+    let old_rh: RootHash<Sha256> = RootHash::new(Output::<Sha256>::from(*old_root), old_size);
+    let new_rh: RootHash<Sha256> = RootHash::new(Output::<Sha256>::from(*new_root), new_size);
+    let outputs: Vec<Output<Sha256>> = proof_hashes
+        .iter()
+        .map(|h| Output::<Sha256>::from(*h))
+        .collect();
+    let proof: ConsistencyProof<Sha256> = ConsistencyProof::from_digests(outputs.iter());
+    new_rh
+        .verify_consistency(&old_rh, &proof)
+        .map_err(|e| format!("consistency proof did not verify: {e}"))
+}
+
+/// `POST /add-checkpoint` axum handler. Reads the raw body, evaluates
+/// the status matrix via [`decide`], and renders the response.
+pub async fn add_checkpoint_handler(State(state): State<WitnessState>, body: Bytes) -> Response {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(1); // never 0; the spec forbids a zero timestamp.
+    let now = now.max(1);
+    let decision = decide(&state, &body, now);
+    render(decision)
+}
+
+/// Map a [`Decision`] to an axum [`Response`].
+fn render(decision: Decision) -> Response {
+    let status = decision.status();
+    match decision {
+        Decision::Ok { cosignature_lines } => {
+            let mut body = String::new();
+            for line in cosignature_lines {
+                body.push_str(&line);
+                body.push('\n');
+            }
+            (
+                status,
+                [(
+                    axum::http::header::CONTENT_TYPE,
+                    "text/plain; charset=utf-8",
+                )],
+                body,
+            )
+                .into_response()
+        }
+        Decision::Conflict { last_cosigned_size } => (
+            status,
+            // Per spec: 409 body is the witness's last-cosigned size in
+            // decimal, Content-Type text/x.tlog.size.
+            [(axum::http::header::CONTENT_TYPE, "text/x.tlog.size")],
+            format!("{last_cosigned_size}\n"),
+        )
+            .into_response(),
+        Decision::BadRequest(m)
+        | Decision::Forbidden(m)
+        | Decision::NotFound(m)
+        | Decision::Unprocessable(m) => (status, m).into_response(),
+        Decision::Malformed(e) => (status, e.to_string()).into_response(),
+    }
+}

--- a/crates/nucleus-witness/src/store.rs
+++ b/crates/nucleus-witness/src/store.rs
@@ -1,0 +1,175 @@
+//! Per-origin witness state behind a small trait.
+//!
+//! For each origin the witness trusts, it tracks:
+//! - the set of trusted LOG keys (which keys may sign a checkpoint for
+//!   this origin), and
+//! - the last-cosigned `(size, root)` — the witness's monotonic view of
+//!   the log, used to enforce the C2SP rollback/conflict (409) checks
+//!   and to anchor consistency-proof verification.
+//!
+//! The MVP backs this with an in-memory `Mutex<HashMap>`. Litewitness
+//! uses sqlite; a persistent impl would slot in behind [`OriginStore`]
+//! without touching the status-matrix logic in `server.rs`.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+/// A trusted log key for an origin: its C2SP `key_name` plus 32-byte
+/// Ed25519 pubkey. The witness will accept (and require) a valid
+/// signature from one of these on every checkpoint for the origin.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TrustedLogKey {
+    pub key_name: String,
+    pub pubkey: [u8; 32],
+}
+
+/// The witness's last-cosigned position for an origin.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CosignedPosition {
+    pub size: u64,
+    pub root: [u8; 32],
+}
+
+/// Per-origin configuration + mutable state.
+#[derive(Debug, Clone)]
+pub struct OriginRecord {
+    pub trusted_log_keys: Vec<TrustedLogKey>,
+    /// `None` until the first checkpoint is cosigned for this origin.
+    pub last_cosigned: Option<CosignedPosition>,
+}
+
+/// Storage abstraction for per-origin witness state.
+///
+/// All methods take `&self` so the store can sit behind an `Arc` shared
+/// across axum handlers. Implementations hold their own locking.
+pub trait OriginStore: Send + Sync {
+    /// Fetch the origin record, or `None` if the origin is not trusted
+    /// (→ the handler returns 404).
+    fn get(&self, origin: &str) -> Option<OriginRecord>;
+
+    /// Atomically advance the last-cosigned position for `origin` to
+    /// `pos`, but ONLY if the current position matches `expected`
+    /// (compare-and-swap). Returns `true` on success. A `false` return
+    /// means a concurrent writer advanced the state first — the handler
+    /// should surface a 409 rather than mint a cosignature over a stale
+    /// view.
+    ///
+    /// `expected == None` means "the origin has never been cosigned"
+    /// (first submission). This CAS guard is what makes the status
+    /// matrix safe under concurrent `POST /add-checkpoint` for the same
+    /// origin.
+    fn advance(
+        &self,
+        origin: &str,
+        expected: Option<CosignedPosition>,
+        pos: CosignedPosition,
+    ) -> bool;
+}
+
+/// In-memory [`OriginStore`] (MVP). Documented non-persistent: a
+/// process restart resets every origin's last-cosigned position to
+/// `None`, which would let a producer replay an old checkpoint as a
+/// "first submission". A production deployment MUST back this with
+/// durable storage (sqlite, like litewitness) so the monotonicity
+/// guarantee survives restarts.
+#[derive(Default)]
+pub struct InMemoryStore {
+    inner: Mutex<HashMap<String, OriginRecord>>,
+}
+
+impl InMemoryStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register an origin with its trusted log keys and (optionally) a
+    /// starting last-cosigned position.
+    pub fn add_origin(
+        &self,
+        origin: impl Into<String>,
+        trusted_log_keys: Vec<TrustedLogKey>,
+        last_cosigned: Option<CosignedPosition>,
+    ) {
+        self.inner.lock().expect("store mutex").insert(
+            origin.into(),
+            OriginRecord {
+                trusted_log_keys,
+                last_cosigned,
+            },
+        );
+    }
+}
+
+impl OriginStore for InMemoryStore {
+    fn get(&self, origin: &str) -> Option<OriginRecord> {
+        self.inner.lock().expect("store mutex").get(origin).cloned()
+    }
+
+    fn advance(
+        &self,
+        origin: &str,
+        expected: Option<CosignedPosition>,
+        pos: CosignedPosition,
+    ) -> bool {
+        let mut guard = self.inner.lock().expect("store mutex");
+        match guard.get_mut(origin) {
+            Some(rec) if rec.last_cosigned == expected => {
+                rec.last_cosigned = Some(pos);
+                true
+            }
+            _ => false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(b: u8) -> TrustedLogKey {
+        TrustedLogKey {
+            key_name: format!("k{b}"),
+            pubkey: [b; 32],
+        }
+    }
+
+    #[test]
+    fn unknown_origin_returns_none() {
+        let store = InMemoryStore::new();
+        assert!(store.get("ghost").is_none());
+    }
+
+    #[test]
+    fn advance_cas_first_submission() {
+        let store = InMemoryStore::new();
+        store.add_origin("o", vec![key(1)], None);
+        let pos = CosignedPosition {
+            size: 5,
+            root: [1u8; 32],
+        };
+        // CAS from None succeeds.
+        assert!(store.advance("o", None, pos));
+        // Re-attempt from None now fails (state moved).
+        assert!(!store.advance("o", None, pos));
+        // CAS from the real previous position succeeds.
+        let pos2 = CosignedPosition {
+            size: 9,
+            root: [2u8; 32],
+        };
+        assert!(store.advance("o", Some(pos), pos2));
+        assert_eq!(store.get("o").unwrap().last_cosigned, Some(pos2));
+    }
+
+    #[test]
+    fn advance_on_unknown_origin_is_false() {
+        let store = InMemoryStore::new();
+        assert!(!store.advance(
+            "ghost",
+            None,
+            CosignedPosition {
+                size: 1,
+                root: [0u8; 32]
+            }
+        ));
+    }
+}

--- a/crates/nucleus-witness/tests/status_matrix.rs
+++ b/crates/nucleus-witness/tests/status_matrix.rs
@@ -1,0 +1,469 @@
+//! Merge-gate tests for the C2SP `tlog-witness` status matrix.
+//!
+//! These are the security-load-bearing NEGATIVE tests: a witness mints
+//! cosignatures with its private key, so every rejection path must be
+//! exercised. Plus a real 2-of-2 quorum integration test that drives two
+//! in-process witnesses through the actual HTTP handler and feeds their
+//! cosignatures to the Sigsum policy evaluator.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use axum::body::{to_bytes, Body};
+use axum::http::{Request, StatusCode};
+use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
+use ct_merkle::mem_backed_tree::MemoryBackedTree;
+use nucleus_lineage::{
+    ed25519_key_id, format_checkpoint_body, format_signature_line, Ed25519Witness, Policy,
+    SIG_TYPE_ED25519,
+};
+use nucleus_witness::cosign::verify_cosign_line;
+use nucleus_witness::store::CosignedPosition;
+use nucleus_witness::{
+    app::build_app, decide, Decision, InMemoryStore, TrustedLogKey, WitnessKey, WitnessState,
+};
+use sha2::Sha256;
+use tower::ServiceExt; // for oneshot
+
+const ORIGIN: &str = "nucleus.example/log";
+const LOG_KEY_NAME: &str = "nucleus.example/log";
+const NOW: u64 = 1_700_000_000;
+
+// ── Test helpers ────────────────────────────────────────────────────
+
+/// A ct-merkle tree over deterministic leaves; lets us compute real
+/// RFC 6962 roots and consistency proofs.
+fn tree_of(n: u64) -> MemoryBackedTree<Sha256, Vec<u8>> {
+    let mut t = MemoryBackedTree::<Sha256, Vec<u8>>::new();
+    for i in 0..n {
+        t.push(vec![i as u8; 32]);
+    }
+    t
+}
+
+fn root_bytes(t: &MemoryBackedTree<Sha256, Vec<u8>>) -> [u8; 32] {
+    let r = t.root();
+    let mut out = [0u8; 32];
+    out.copy_from_slice(r.as_bytes().as_slice());
+    out
+}
+
+/// Real consistency proof from `old`→current (`old < current`).
+fn consistency_proof(t: &MemoryBackedTree<Sha256, Vec<u8>>, old: u64) -> Vec<[u8; 32]> {
+    let cur = t.len();
+    let proof = t.prove_consistency((cur - old) as usize);
+    proof
+        .as_bytes()
+        .chunks_exact(32)
+        .map(|c| {
+            let mut a = [0u8; 32];
+            a.copy_from_slice(c);
+            a
+        })
+        .collect()
+}
+
+/// Build a well-formed add-checkpoint body signed by `log_key`.
+fn build_body(
+    log_key: &Ed25519Witness,
+    key_name: &str,
+    origin: &str,
+    size: u64,
+    root: &[u8; 32],
+    old_size: u64,
+    proof: &[[u8; 32]],
+) -> Vec<u8> {
+    let cp_body = format_checkpoint_body(origin, size, root).unwrap();
+    let sig = log_key.sign_message(cp_body.as_bytes());
+    let key_id = ed25519_key_id(key_name, SIG_TYPE_ED25519, &log_key.verifying_key_bytes());
+    let sig_line = format_signature_line(key_name, &key_id, &sig).unwrap();
+
+    let mut body = Vec::new();
+    body.extend_from_slice(format!("old {old_size}\n").as_bytes());
+    for h in proof {
+        body.extend_from_slice(B64.encode(h).as_bytes());
+        body.push(b'\n');
+    }
+    body.push(b'\n');
+    body.extend_from_slice(cp_body.as_bytes());
+    body.push(b'\n');
+    body.extend_from_slice(sig_line.as_bytes());
+    body.push(b'\n');
+    body
+}
+
+/// A witness state trusting ORIGIN signed by `log_key` under
+/// LOG_KEY_NAME, with an optional starting last-cosigned position.
+fn state_with(
+    log_key: &Ed25519Witness,
+    witness_seed: u8,
+    last: Option<CosignedPosition>,
+) -> WitnessState {
+    let store = InMemoryStore::new();
+    store.add_origin(
+        ORIGIN,
+        vec![TrustedLogKey {
+            key_name: LOG_KEY_NAME.to_string(),
+            pubkey: log_key.verifying_key_bytes(),
+        }],
+        last,
+    );
+    WitnessState {
+        store: Arc::new(store),
+        witness_key: Arc::new(WitnessKey::from_seed(
+            [witness_seed; 32],
+            "nucleus.witness/test",
+        )),
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════
+//  NEGATIVE TEST 1 — forged/invalid cosignature → 403.
+//  A signature line whose key name+ID match a trusted key but whose
+//  signature fails to verify.
+// ════════════════════════════════════════════════════════════════════
+#[test]
+fn neg1_forged_signature_matching_trusted_key_is_403() {
+    let log_key = Ed25519Witness::from_seed([1u8; 32]);
+    let state = state_with(&log_key, 2, None);
+
+    let t = tree_of(5);
+    let root = root_bytes(&t);
+    // Build a body, then CORRUPT the signature bytes while keeping the
+    // key_name + key_id intact (so it matches the trusted key by
+    // name+ID but fails crypto verification).
+    let cp_body = format_checkpoint_body(ORIGIN, 5, &root).unwrap();
+    let mut sig = log_key.sign_message(cp_body.as_bytes());
+    sig[0] ^= 0xFF; // flip a byte → signature no longer verifies
+    let key_id = ed25519_key_id(
+        LOG_KEY_NAME,
+        SIG_TYPE_ED25519,
+        &log_key.verifying_key_bytes(),
+    );
+    let sig_line = format_signature_line(LOG_KEY_NAME, &key_id, &sig).unwrap();
+    let mut body = Vec::new();
+    body.extend_from_slice(b"old 0\n\n");
+    body.extend_from_slice(cp_body.as_bytes());
+    body.push(b'\n');
+    body.extend_from_slice(sig_line.as_bytes());
+    body.push(b'\n');
+
+    let d = decide(&state, &body, NOW);
+    assert_eq!(d.status(), StatusCode::FORBIDDEN, "got {d:?}");
+    assert!(matches!(d, Decision::Forbidden(_)));
+}
+
+// ════════════════════════════════════════════════════════════════════
+//  NEGATIVE TEST 2a — unknown origin → 404.
+//  NEGATIVE TEST 2b — origin known but no trusted-key signature → 403.
+// ════════════════════════════════════════════════════════════════════
+#[test]
+fn neg2a_unknown_origin_is_404() {
+    let log_key = Ed25519Witness::from_seed([1u8; 32]);
+    // State trusts ORIGIN, but we submit a checkpoint for a DIFFERENT
+    // origin.
+    let state = state_with(&log_key, 2, None);
+    let t = tree_of(3);
+    let root = root_bytes(&t);
+    let body = build_body(&log_key, "other/log", "other/log", 3, &root, 0, &[]);
+
+    let d = decide(&state, &body, NOW);
+    assert_eq!(d.status(), StatusCode::NOT_FOUND, "got {d:?}");
+}
+
+#[test]
+fn neg2b_no_trusted_key_signature_is_403() {
+    let trusted_log = Ed25519Witness::from_seed([1u8; 32]);
+    let state = state_with(&trusted_log, 2, None);
+
+    // Sign the checkpoint with a DIFFERENT (untrusted) key, but the
+    // origin IS trusted. No trusted-key signature present → 403.
+    let attacker = Ed25519Witness::from_seed([99u8; 32]);
+    let t = tree_of(4);
+    let root = root_bytes(&t);
+    // Use a key_name that doesn't match the trusted key's name.
+    let body = build_body(&attacker, "attacker/key", ORIGIN, 4, &root, 0, &[]);
+
+    let d = decide(&state, &body, NOW);
+    assert_eq!(d.status(), StatusCode::FORBIDDEN, "got {d:?}");
+}
+
+// ════════════════════════════════════════════════════════════════════
+//  NEGATIVE TEST 3a — old size > checkpoint size → 400.
+//  NEGATIVE TEST 3b — old size ≠ witness's last-cosigned size → 409.
+// ════════════════════════════════════════════════════════════════════
+#[test]
+fn neg3a_old_size_greater_than_checkpoint_size_is_400() {
+    let log_key = Ed25519Witness::from_seed([1u8; 32]);
+    // Trust origin with last-cosigned size 10 so old=10 passes the 409
+    // gate but old(10) > size(5) trips the 400 gate.
+    let t10 = tree_of(10);
+    let last = Some(CosignedPosition {
+        size: 10,
+        root: root_bytes(&t10),
+    });
+    let state = state_with(&log_key, 2, last);
+
+    let t5 = tree_of(5);
+    let root = root_bytes(&t5);
+    let body = build_body(&log_key, LOG_KEY_NAME, ORIGIN, 5, &root, 10, &[]);
+
+    let d = decide(&state, &body, NOW);
+    assert_eq!(d.status(), StatusCode::BAD_REQUEST, "got {d:?}");
+    assert!(matches!(d, Decision::BadRequest(_)));
+}
+
+#[test]
+fn neg3b_old_size_mismatch_is_409() {
+    let log_key = Ed25519Witness::from_seed([1u8; 32]);
+    // Witness last cosigned size 3.
+    let t3 = tree_of(3);
+    let last = Some(CosignedPosition {
+        size: 3,
+        root: root_bytes(&t3),
+    });
+    let state = state_with(&log_key, 2, last);
+
+    // Producer claims old=2 (≠ witness's 3) → 409 rollback/conflict.
+    let t8 = tree_of(8);
+    let root = root_bytes(&t8);
+    let proof = consistency_proof(&t8, 2);
+    let body = build_body(&log_key, LOG_KEY_NAME, ORIGIN, 8, &root, 2, &proof);
+
+    let d = decide(&state, &body, NOW);
+    assert_eq!(d.status(), StatusCode::CONFLICT, "got {d:?}");
+    assert!(matches!(
+        d,
+        Decision::Conflict {
+            last_cosigned_size: 3
+        }
+    ));
+}
+
+// ════════════════════════════════════════════════════════════════════
+//  NEGATIVE TEST 4a — consistency proof doesn't verify → 422.
+//  NEGATIVE TEST 4b — old size == checkpoint size but different root → 409.
+// ════════════════════════════════════════════════════════════════════
+#[test]
+fn neg4a_bad_consistency_proof_is_422() {
+    let log_key = Ed25519Witness::from_seed([1u8; 32]);
+    // Witness last cosigned size 3 with the REAL root at size 3.
+    let t3 = tree_of(3);
+    let last = Some(CosignedPosition {
+        size: 3,
+        root: root_bytes(&t3),
+    });
+    let state = state_with(&log_key, 2, last);
+
+    // Real new tree at size 8, but send a GARBAGE consistency proof.
+    let t8 = tree_of(8);
+    let root = root_bytes(&t8);
+    let real_proof = consistency_proof(&t8, 3);
+    // Corrupt one proof hash so old→new no longer verifies.
+    let mut bad_proof = real_proof.clone();
+    assert!(!bad_proof.is_empty(), "proof should be non-empty for 3→8");
+    bad_proof[0][0] ^= 0xFF;
+    let body = build_body(&log_key, LOG_KEY_NAME, ORIGIN, 8, &root, 3, &bad_proof);
+
+    let d = decide(&state, &body, NOW);
+    assert_eq!(d.status(), StatusCode::UNPROCESSABLE_ENTITY, "got {d:?}");
+    assert!(matches!(d, Decision::Unprocessable(_)));
+}
+
+#[test]
+fn neg4b_same_size_different_root_is_409() {
+    let log_key = Ed25519Witness::from_seed([1u8; 32]);
+    // Witness last cosigned size 5 with the REAL root.
+    let t5 = tree_of(5);
+    let last = Some(CosignedPosition {
+        size: 5,
+        root: root_bytes(&t5),
+    });
+    let state = state_with(&log_key, 2, last);
+
+    // Producer re-presents size 5 (old==size==5) but with a DIFFERENT
+    // root → split-view conflict → 409.
+    let different_root = [0xABu8; 32];
+    let body = build_body(&log_key, LOG_KEY_NAME, ORIGIN, 5, &different_root, 5, &[]);
+
+    let d = decide(&state, &body, NOW);
+    assert_eq!(d.status(), StatusCode::CONFLICT, "got {d:?}");
+    assert!(matches!(
+        d,
+        Decision::Conflict {
+            last_cosigned_size: 5
+        }
+    ));
+}
+
+// ════════════════════════════════════════════════════════════════════
+//  POSITIVE control: a valid first submission cosigns (200) and the
+//  cosignature line verifies; a valid extension with a real proof also
+//  cosigns and advances state.
+// ════════════════════════════════════════════════════════════════════
+#[test]
+fn positive_first_submission_then_extension_cosign_200() {
+    let log_key = Ed25519Witness::from_seed([1u8; 32]);
+    let state = state_with(&log_key, 2, None);
+    let witness_pubkey = state.witness_key.verifying_key_bytes();
+
+    // First submission: old 0, no proof.
+    let t3 = tree_of(3);
+    let root3 = root_bytes(&t3);
+    let body = build_body(&log_key, LOG_KEY_NAME, ORIGIN, 3, &root3, 0, &[]);
+    let d = decide(&state, &body, NOW);
+    assert_eq!(d.status(), StatusCode::OK, "first submission: got {d:?}");
+    let cosig_line = match d {
+        Decision::Ok { cosignature_lines } => cosignature_lines[0].clone(),
+        other => panic!("expected Ok, got {other:?}"),
+    };
+    // The cosignature must verify against the witness pubkey over the
+    // checkpoint note body.
+    let note_body = format_checkpoint_body(ORIGIN, 3, &root3).unwrap();
+    let (ts, name) =
+        verify_cosign_line(&cosig_line, note_body.as_bytes(), &witness_pubkey).unwrap();
+    assert_eq!(ts, NOW);
+    assert_eq!(name, "nucleus.witness/test");
+
+    // Extension: old 3 → size 8 with a REAL consistency proof.
+    let t8 = tree_of(8);
+    let root8 = root_bytes(&t8);
+    let proof = consistency_proof(&t8, 3);
+    let body2 = build_body(&log_key, LOG_KEY_NAME, ORIGIN, 8, &root8, 3, &proof);
+    let d2 = decide(&state, &body2, NOW + 1);
+    assert_eq!(d2.status(), StatusCode::OK, "extension: got {d2:?}");
+
+    // State advanced to size 8.
+    let rec = state.store.get(ORIGIN).unwrap();
+    assert_eq!(rec.last_cosigned.unwrap().size, 8);
+}
+
+// ════════════════════════════════════════════════════════════════════
+//  Full HTTP path smoke test through the axum router (200).
+// ════════════════════════════════════════════════════════════════════
+#[tokio::test]
+async fn http_add_checkpoint_returns_200_and_cosig_line() {
+    let log_key = Ed25519Witness::from_seed([1u8; 32]);
+    let state = state_with(&log_key, 2, None);
+    let app = build_app(state);
+
+    let t = tree_of(4);
+    let root = root_bytes(&t);
+    let body = build_body(&log_key, LOG_KEY_NAME, ORIGIN, 4, &root, 0, &[]);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/add-checkpoint")
+                .header("content-type", "text/plain")
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let bytes = to_bytes(resp.into_body(), 64 * 1024).await.unwrap();
+    let text = String::from_utf8(bytes.to_vec()).unwrap();
+    assert!(text.starts_with('\u{2014}'), "cosig line: {text:?}");
+}
+
+// ════════════════════════════════════════════════════════════════════
+//  REAL 2-of-2 QUORUM INTEGRATION TEST.
+//  Two in-process witnesses each cosign the SAME real checkpoint via the
+//  actual HTTP handler; the Sigsum policy evaluator (k=2 of 2) accepts.
+// ════════════════════════════════════════════════════════════════════
+#[tokio::test]
+async fn two_of_two_quorum_real_cosignatures_satisfy_policy() {
+    let log_key = Ed25519Witness::from_seed([1u8; 32]);
+
+    // Two independent witnesses (distinct seeds = distinct keys =
+    // distinct failure domains in the deployment model).
+    let w_a_seed = 0x0Au8;
+    let w_b_seed = 0x0Bu8;
+    let wk_a = WitnessKey::from_seed([w_a_seed; 32], "nucleus.witness/a");
+    let wk_b = WitnessKey::from_seed([w_b_seed; 32], "nucleus.witness/b");
+    let pk_a = wk_a.verifying_key_bytes();
+    let pk_b = wk_b.verifying_key_bytes();
+
+    // Build two witness servers, each trusting the same origin+log key.
+    let make_state = |seed: u8, name: &str| {
+        let store = InMemoryStore::new();
+        store.add_origin(
+            ORIGIN,
+            vec![TrustedLogKey {
+                key_name: LOG_KEY_NAME.to_string(),
+                pubkey: log_key.verifying_key_bytes(),
+            }],
+            None,
+        );
+        WitnessState {
+            store: Arc::new(store),
+            witness_key: Arc::new(WitnessKey::from_seed([seed; 32], name.to_string())),
+        }
+    };
+    let state_a = make_state(w_a_seed, "nucleus.witness/a");
+    let state_b = make_state(w_b_seed, "nucleus.witness/b");
+
+    // The SAME real checkpoint at size 6.
+    let t = tree_of(6);
+    let root = root_bytes(&t);
+    let note_body = format_checkpoint_body(ORIGIN, 6, &root).unwrap();
+    let body = build_body(&log_key, LOG_KEY_NAME, ORIGIN, 6, &root, 0, &[]);
+
+    // Drive each witness through the real HTTP handler.
+    async fn cosign_via_http(state: WitnessState, body: Vec<u8>) -> String {
+        let app = build_app(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/add-checkpoint")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = to_bytes(resp.into_body(), 64 * 1024).await.unwrap();
+        String::from_utf8(bytes.to_vec())
+            .unwrap()
+            .lines()
+            .next()
+            .unwrap()
+            .to_string()
+    }
+
+    let line_a = cosign_via_http(state_a, body.clone()).await;
+    let line_b = cosign_via_http(state_b, body.clone()).await;
+
+    // Verify each cosignature cryptographically against its witness key,
+    // then build the SET OF VALID witness names for the policy.
+    let (_, name_a) = verify_cosign_line(&line_a, note_body.as_bytes(), &pk_a).unwrap();
+    let (_, name_b) = verify_cosign_line(&line_b, note_body.as_bytes(), &pk_b).unwrap();
+    let valid: HashSet<String> = [name_a.clone(), name_b.clone()].into_iter().collect();
+    assert_eq!(valid.len(), 2, "two distinct witnesses");
+
+    // Sigsum policy: k=2 of {a, b}.
+    let policy_text = format!(
+        "witness {wn_a} {pk_a_hex}\nwitness {wn_b} {pk_b_hex}\ngroup g 2 {wn_a} {wn_b}\nquorum g\n",
+        wn_a = "nucleus.witness/a",
+        wn_b = "nucleus.witness/b",
+        pk_a_hex = hex::encode(pk_a),
+        pk_b_hex = hex::encode(pk_b),
+    );
+    let policy = Policy::parse(&policy_text).unwrap();
+
+    // Both cosignatures present → k=2 satisfied.
+    assert!(
+        policy.is_satisfied(&valid),
+        "2-of-2 quorum must be satisfied by both real cosignatures"
+    );
+
+    // Negative control: only witness A → below k=2 → NOT satisfied.
+    let only_a: HashSet<String> = [name_a].into_iter().collect();
+    assert!(
+        !policy.is_satisfied(&only_a),
+        "1-of-2 must NOT satisfy a k=2 quorum"
+    );
+}


### PR DESCRIPTION
## #2 federated cosigning witness mesh — `nucleus-witness` (C2SP tlog-witness)

The missing leg of the transparency triangle: a Rust **witness server** (`POST /add-checkpoint`) that cosigns checkpoints per the C2SP tlog-witness protocol, plus a **Sigsum k-of-n policy** parser/evaluator in `nucleus-lineage`. No production Rust witness existed — this is net-new.

### Security properties (personally reviewed, not just self-reported)
- **Spec-exact status matrix**, in order: `404` untrusted origin → `403` no-trusted-sig / forgery → `400` size-shrink → `409` rollback / equal-size-different-root → `422` consistency-proof failure → `200` cosign.
- **Anti-forgery anchor:** the consistency proof verifies old→new against the witness's **stored** `prev.root`, never a request-supplied root — a producer cannot forge the old root.
- **403 path:** a candidate signature must match a trusted key's name+key_id **and** verify under the *trusted* pubkey; both forgery (matching key, bad sig) and absent-sig → 403.
- **Cosignature/v1 crypto:** exact framing (`cosignature/v1\n` + `time <ts>\n` + note body), payload `keyID(4)‖timestamp(8 BE)‖sig(64)`, sig-type `0x04` (cosig) vs `0x01` (log sig). Reuses `nucleus-lineage` key-id/signed-note/checkpoint primitives.
- **Concurrency:** 200 path CAS-advances stored state; a lost race surfaces `409`, never a stale cosign.

### The 5 adversarial reject vectors (merge gate — all pass)
forged-cosig→403 · unknown-origin→404 / no-trusted-sig→403 · size-shrink→400 / rollback→409 · bad-consistency-proof→422 / equal-size-different-root→409 · below-threshold k−1 quorum→policy reject (dup counts once). Plus a real **2-of-2 quorum** test (two in-process witnesses cosign one checkpoint over HTTP; k=2 policy accepts, 1-of-2 rejected).

Tests: 112 lineage + 6 KAT + 15 witness + 10 integration, 0 failures. clippy `-D warnings`, fmt, cargo-deny, cargo-audit all clean.

### Framing
Single-tenant **split-trust** documented (run your own k-of-n witnesses across diverse failure domains — value is failure-domain diversity, not other orgs). **Dormant** per-proven-cosignature metering seam documented (a valid cosig over a real checkpoint is the future paid-tier meter point — *parallel* paid tier, not metering the volunteer commons; no payment wired). Notes that C2SP flags witness sustainability as an unsolved open problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
