### PR TITLE
ci(oidc): live keyless E2E workflow + correct exp/nbf overstatement

### DIFF
--- a/.github/workflows/oidc-keyless-prototype.yml
+++ b/.github/workflows/oidc-keyless-prototype.yml
@@ -1,0 +1,55 @@
+name: OIDC Keyless Prototype (live E2E)
+
+# GENUINE end-to-end proof for the keyless GitHub Actions OIDC -> SPIFFE path.
+#
+# A live GitHub OIDC token can ONLY be minted inside a job that opted into
+# `permissions: id-token: write`. This workflow requests a real token
+# (audience = nucleus.io, the audience the validator pins) and runs the REAL
+# nucleus-github-oidc validator against GitHub's REAL JWKS via the
+# DiscoveryKeyResolver. The synthetic StaticKeyResolver / localhost-discovery
+# tests prove the logic offline; THIS proves it against live GitHub.
+#
+# Triggered on push to main + manual dispatch only. Deliberately NOT
+# pull_request_target / workflow_run: those run with the base repo's id-token
+# while checking out attacker-controlled head code, which would let a fork PR
+# mint a real OIDC identity.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read       # checkout
+  id-token: write      # opt-in: lets the job FETCH+USE an OIDC token (not repo write)
+
+jobs:
+  keyless-oidc-e2e:
+    name: live keyless OIDC validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Rust toolchain (pinned via rust-toolchain.toml)
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1
+        with:
+          cache: true
+
+      - name: Confirm the OIDC request env vars are present
+        # Sanity check that id-token: write took effect on this runner. We do
+        # NOT print the request token (it is a short-lived bearer secret).
+        run: |
+          if [ -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]; then
+            echo "::error::ACTIONS_ID_TOKEN_REQUEST_URL is not set — id-token: write did not take effect"
+            exit 1
+          fi
+          echo "ACTIONS_ID_TOKEN_REQUEST_URL is present (token request endpoint available)."
+
+      - name: Run the keyless OIDC prototype against GitHub's real JWKS
+        # The example reimplements core.getIDToken("nucleus.io"):
+        #   GET ${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=nucleus.io
+        #   Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}
+        # then validates the returned JWT with the REAL GitHubOidcValidator +
+        # DiscoveryKeyResolver (RS256 sig vs GitHub JWKS, iss/aud/exp, allowlist,
+        # replay, SPIFFE derivation). Exits non-zero on any validation failure.
+        run: cargo run -p nucleus-github-oidc --example keyless_oidc_prototype --locked

--- a/crates/nucleus-github-oidc/KEYLESS_OIDC_PROTOTYPE.md
+++ b/crates/nucleus-github-oidc/KEYLESS_OIDC_PROTOTYPE.md
@@ -2,7 +2,7 @@
 
 A buildable, tested prototype that takes a **GitHub Actions OIDC JWT**, validates
 it through the **real** `nucleus-github-oidc` validator (RS256 signature via
-JWKS, issuer/audience/exp/nbf, repo/org allowlist, replay), and derives the
+JWKS, issuer/audience/exp, repo/org allowlist, replay), and derives the
 **SPIFFE caller id** — with **no long-lived secret anywhere**.
 
 This is an *honest spike* (the zk-spike rule): a live GitHub OIDC token can


### PR DESCRIPTION
Upstreams two refinements from the private platform's keyless-OIDC spike so the public canonical `nucleus-github-oidc` is a **strict superset** — the prerequisite for converging the private fork onto it (upstream-first, then converge).

## Changes
1. **`.github/workflows/oidc-keyless-prototype.yml` — live E2E proof.** A real GitHub Actions OIDC token (mintable only inside a job with `permissions: id-token: write`) is requested at audience `nucleus.io` and run through the **real** `GitHubOidcValidator` + `DiscoveryKeyResolver` against GitHub's **real** JWKS — RS256 signature, iss/aud/exp, repo/org allowlist, replay, SPIFFE derivation. The synthetic `StaticKeyResolver` / localhost-discovery tests prove the logic offline; this proves it against live GitHub. Runs `cargo run -p nucleus-github-oidc --example keyless_oidc_prototype` (the example is already gated `[[example]]` with dev-only `reqwest`/`tokio`, so the default `cargo build --workspace` stays green). Triggers: push-to-main + `workflow_dispatch` only — deliberately **not** `pull_request_target` / `workflow_run` (those run base-repo `id-token` while checking out head code, which would let a fork PR mint a real OIDC identity).

2. **`KEYLESS_OIDC_PROTOTYPE.md` — correct an exp/nbf overstatement (honesty fix).** `validator.rs` sets `validate_exp = true` but **not** `validate_nbf` (jsonwebtoken defaults `validate_nbf = false`), so it enforces `exp`, not `nbf`. The doc claimed "issuer/audience/exp/nbf"; corrected to "issuer/audience/exp". (Enforcing `nbf` is a possible future hardening — intentionally not claimed until it's true.)

## Why
The private platform carries a fork of these OIDC crates that's being converged onto this public canonical. The private fork had a live E2E workflow + this honesty fix; landing them here first means deleting the private fork loses nothing, and the live workflow lives where the crate is a workspace member (so `cargo run -p … --example` works).

No functional code change to the validator; no AI-vendor strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)