### PR TITLE
feat(guarantee-lint): ed25519-signed per-hash guarantee receipts (v0 screen) [HELD — review]

### DIFF
--- a/tools/nucleus-guarantee-lint/.gitignore
+++ b/tools/nucleus-guarantee-lint/.gitignore
@@ -1,0 +1,5 @@
+/target
+/receipt/target
+# Generated receipts + per-run sample artifacts (contain freshly-generated keys/sigs).
+/receipt/testdata
+**/guarantee-receipts/

--- a/tools/nucleus-guarantee-lint/Cargo.lock
+++ b/tools/nucleus-guarantee-lint/Cargo.lock
@@ -74,10 +74,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bitflags"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "camino"
@@ -170,10 +185,82 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "dirs-next"
@@ -279,6 +366,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -330,6 +442,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
 name = "filetime"
 version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -358,6 +476,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -446,6 +574,12 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "home"
@@ -739,6 +873,22 @@ dependencies = [
  "clippy_utils",
  "dylint_linting",
  "dylint_testing",
+ "hex",
+ "nucleus_guarantee_receipt",
+ "serde",
+]
+
+[[package]]
+name = "nucleus_guarantee_receipt"
+version = "0.1.0"
+dependencies = [
+ "ed25519-dalek",
+ "hex",
+ "rand_core",
+ "serde",
+ "serde_jcs",
+ "serde_json",
+ "sha2",
 ]
 
 [[package]]
@@ -798,6 +948,16 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
 
 [[package]]
 name = "pkg-config"
@@ -870,6 +1030,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -920,6 +1089,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustfix"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -949,6 +1127,12 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu-js"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6518fc26bced4d53678a22d6e423e9d8716377def84545fe328236e3af070e7f"
 
 [[package]]
 name = "semver"
@@ -991,6 +1175,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_jcs"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cacecf649bc1a7c5f0e299cc813977c6a78116abda2b93b1ee01735b71ead9a8"
+dependencies = [
+ "ryu-js",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1013,10 +1208,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core",
+]
 
 [[package]]
 name = "smallvec"
@@ -1025,10 +1240,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1209,6 +1440,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1255,6 +1492,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"
@@ -1583,6 +1826,12 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/tools/nucleus-guarantee-lint/Cargo.toml
+++ b/tools/nucleus-guarantee-lint/Cargo.toml
@@ -12,7 +12,11 @@ edition = "2024"
 publish = false
 
 [lib]
-# Mandatory: Dylint loads a dynamic library (Research 1, §2).
+# Mandatory and ONLY this: Dylint loads a dynamic library (Research 1, §2). A crate that
+# links rustc_driver via `#![feature(rustc_private)]` CANNOT also emit an `rlib`/`bin`
+# (the sysroot crates ship dylib-only -> "X only shows up once"). So the PURE receipt
+# logic + the verify bin + the receipt unit tests all live in the sibling `receipt`
+# crate, which has NO rustc dependency and IS rlib/bin-buildable on stable-or-nightly.
 crate-type = ["cdylib"]
 
 [dependencies]
@@ -20,12 +24,18 @@ crate-type = ["cdylib"]
 # The rev and the nightly are mutually consistent — they are what `cargo dylint new` emits.
 clippy_utils = { git = "https://github.com/rust-lang/rust-clippy", rev = "f6d310692116e9a527ce6d0b3526c965d9c5d7b9" }
 dylint_linting = "6.0.1"
+# Pure receipt logic (hash / canonicalize / sign / verify) — NO rustc dependency.
+nucleus_guarantee_receipt = { path = "receipt" }
+serde = { version = "1", features = ["derive"] }
+hex = "0.4"
 
 [dev-dependencies]
 dylint_testing = "6.0.1"
 
-# Standalone crate — explicitly NOT part of any parent workspace.
+# A self-contained two-crate workspace, explicitly NOT part of any PARENT workspace.
+# `receipt` is the pure (no-rustc) member that hosts the verifier bin + receipt tests.
 [workspace]
+members = ["receipt"]
 
 [package.metadata.rust-analyzer]
 rustc_private = true

--- a/tools/nucleus-guarantee-lint/README.md
+++ b/tools/nucleus-guarantee-lint/README.md
@@ -47,14 +47,79 @@ does **not** cover them — see the `// TODO(deny-set)` markers in `src/lib.rs`:
 - non-`Vec` std collections (`HashMap`, `BTreeMap`, …) — only `Vec` ships an Aeneas model
 - iterator-combinator chains (`.map`/`.filter`/`.collect`) (aeneas#1053/#1043/#464)
 
-## Future hook: signed per-hash guarantee receipt (NOT in this scaffold)
+## Signed per-hash guarantee receipts (IMPLEMENTED — v0)
 
-This crate is the **screen only**. A future pass would, for each function that passes,
-compute a stable digest and emit a *signed per-hash guarantee receipt* binding
-`hash(StableMIR body OR rustfmt-normalized source) + toolchain + profile`. The receipt
-would certify only "passed the screen under `<toolchain, profile>`" — never "is
-extractable" and never "is correct". See the `// TODO(guarantee-receipt)` block in
-`src/lib.rs`.
+When configured (see below), the lint emits a **signed per-hash GUARANTEE RECEIPT** for
+each screened function. The pure receipt logic (hash / canonicalize / sign / verify)
+lives in the sibling crate [`receipt/`](receipt/) (`nucleus_guarantee_receipt`), which has
+**no rustc dependency** and is unit-testable without the compiler.
+
+### A receipt is a SCREEN RESULT, NOT a proof
+
+> A guarantee receipt attests **exactly one thing**: that the `aeneas_eligible` *screen*
+> produced a particular `result` for a particular function, at one exact
+> `(normalized_source, toolchain, profile_id)` triple, identified by `anchor_hash`. It is
+> **NOT** a proof that the function is extractable, **NOT** a proof that any extracted
+> model is correct, and **NOT** a guarantee of anything beyond "the screen returned this
+> result for this hash". A `result = "clean"` receipt is the output of a
+> **necessary-condition** screen — the unscreened deny-set rows (floats, nested loops,
+> non-`Vec` collections, iterator combinators) are carried as `"not_screened"`, never
+> `"pass"`. **Change the source → the hash changes → the receipt is void (fail-closed).**
+> The guarantee is **toolchain-relative**: it holds only for the exact rustc recorded in
+> `toolchain`.
+
+### Receipt JSON (schema_version = 0)
+
+Canonicalized with RFC 8785 / JCS (sorted keys, no insignificant whitespace) and
+ed25519-signed over those canonical bytes:
+
+```json
+{"anchor_hash":"…hex sha256…","guarantees":{"no_async":"pass","no_closures":"pass","no_dyn_in_sig":"pass","no_ffi_call":"pass","no_floats":"not_screened","no_inline_asm":"pass","no_iterator_combinators":"not_screened","no_nested_loops":"not_screened","no_non_vec_collections":"not_screened","no_raw_ptr":"pass","no_unsafe":"pass"},"ineligible_reasons":[],"item_kind":"fn","item_path":"crate::clean_add","profile_id":"aeneas-eligible-v1","result":"clean","schema_version":0,"toolchain":"nightly-2026-04-16"}
+```
+
+`anchor_hash = SHA-256( b"nucleus.guarantee-receipt.v0" ‖ normalized_source ‖ toolchain ‖ profile_id )`,
+lowercase hex.
+
+- **v0 `normalized_source`** = the raw source snippet of the function from its HIR span
+  (`clippy_utils::source::snippet_opt`). This is **whitespace- and comment-sensitive**:
+  reformatting voids the receipt. **v1 TODO**: switch to a reformat-robust anchor
+  (rustfmt-normalized source, or a StableMIR-body hash).
+- **`toolchain`** is read from `RUSTUP_TOOLCHAIN` (falls back to the pinned
+  `nightly-2026-04-16`).
+- **`profile_id`** is the constant `aeneas-eligible-v1`.
+
+Written to `<receipt_dir>/<anchor_hash>.json` and `<receipt_dir>/<anchor_hash>.sig`
+(signature as lowercase hex).
+
+### Config (`dylint.toml`)
+
+See [`dylint.toml.example`](dylint.toml.example). In a *linted* workspace's root:
+
+```toml
+[nucleus_guarantee_lint]
+emit_receipts = true
+receipt_dir = "target/guarantee-receipts"
+signing_key_path = "secrets/guarantee-witness.key"   # 32-byte ed25519 secret, raw OR hex
+```
+
+**Fail-loud honesty:** if `emit_receipts = true` but the key is empty/missing/invalid,
+the pass ABORTS with an error. It never substitutes a zero/fake key.
+
+### Verifying a receipt (holder side)
+
+```sh
+# Build the verifier (pure crate — no rustc-dev / dylint needed):
+cargo build -p nucleus_guarantee_receipt --bin verify-guarantee-receipt
+
+# Verify signature against the witness PUBLIC key (hex or file):
+verify-guarantee-receipt --json <h>.json --sig <h>.sig --pubkey-hex <64hex>
+
+# Optionally bind-check the anchor to a source file (fail-closed if it differs):
+verify-guarantee-receipt --json <h>.json --sig <h>.sig --pubkey-hex <64hex> --source fn.txt
+```
+
+Or call `nucleus_guarantee_receipt::verify_receipt(json, sig, &pubkey)` / the
+fail-closed `verify_receipt_bound_to(...)` directly.
 
 ## Version pins (a lockstep triple)
 
@@ -78,13 +143,32 @@ cargo install cargo-dylint dylint-link
 rustup toolchain install nightly-2026-04-16 \
   --component rustc-dev --component llvm-tools-preview
 
-# Build the cdylib and run the UI test (from this crate root):
-cargo build
-cargo test            # runs the dylint_testing UI snapshot test
+# Build the cdylib (the lint pass):
+cargo build -p nucleus_guarantee_lint
+
+# Run the dylint_testing UI snapshot test (needs the macOS DYLD env below):
+cargo test -p nucleus_guarantee_lint --test ui
 
 # Run the lint against a target project:
 cargo dylint --lib nucleus_guarantee_lint
 ```
+
+### Receipt crate (PURE — no rustc/dylint needed)
+
+The `receipt/` member builds and tests as a normal crate (no `rustc-dev`, no
+`cargo-dylint`, no `DYLD_*`):
+
+```sh
+cd receipt
+cargo test                                   # 11 unit + 2 integration tests
+cargo build --bin verify-guarantee-receipt   # holder-side verifier
+cargo run --example emit_sample_receipt -- testdata/sample   # demo: emit + sign a receipt
+```
+
+(It is a separate crate because a `#![feature(rustc_private)]` cdylib that links
+`rustc_driver` **cannot** also emit an `rlib`/`bin` — the sysroot crates ship dylib-only,
+producing `error: X only shows up once`. Splitting the pure logic out keeps it
+rlib/bin-buildable AND unit-testable without the compiler.)
 
 ### macOS: `DYLD_FALLBACK_LIBRARY_PATH` (verified blocker + fix)
 

--- a/tools/nucleus-guarantee-lint/dylint.toml.example
+++ b/tools/nucleus-guarantee-lint/dylint.toml.example
@@ -1,0 +1,15 @@
+# Example dylint.toml for enabling per-hash GUARANTEE RECEIPTS.
+#
+# Copy to a LINTED workspace's root (the project you run `cargo dylint` against), NOT this
+# crate's root, and remove the `.example` suffix. The table key is this lint library's
+# crate name.
+#
+# HONESTY / fail-loud: with emit_receipts = true, a missing/invalid signing key is a HARD
+# ERROR — the lint NEVER substitutes a zero/fake key (an unsigned attestation would be
+# dishonest). The signing key is a 32-byte ed25519 SECRET key, raw (32 bytes) or hex
+# (64 chars). Keep it out of version control.
+
+[nucleus_guarantee_lint]
+emit_receipts = true
+receipt_dir = "target/guarantee-receipts"
+signing_key_path = "secrets/guarantee-witness.key"

--- a/tools/nucleus-guarantee-lint/receipt/Cargo.toml
+++ b/tools/nucleus-guarantee-lint/receipt/Cargo.toml
@@ -1,0 +1,33 @@
+# PURE receipt logic — NO rustc dependency, so it builds as a normal rlib/bin on the
+# pinned nightly (or any stable/nightly) and is unit-testable WITHOUT cargo-dylint or the
+# rustc-dev sysroot. The cdylib lint crate (../) depends on this for receipt construction;
+# this crate never depends back on the lint.
+[package]
+name = "nucleus_guarantee_receipt"
+version = "0.1.0"
+authors = ["Nucleus Platform"]
+description = "Per-hash ed25519-signed Aeneas-eligibility guarantee receipts (v0 screen result). NOT a proof."
+edition = "2024"
+publish = false
+
+[[bin]]
+name = "verify-guarantee-receipt"
+path = "src/bin/verify_guarantee_receipt.rs"
+
+# Projects a receipt dir -> CSV for olog ingestion (olog has no JSON source kind).
+[[bin]]
+name = "receipts-to-csv"
+path = "src/bin/receipts_to_csv.rs"
+
+[dependencies]
+# ed25519-dalek 2.x (latest 2.x). sha2 0.10. serde_jcs = RFC 8785 (JCS) canonical JSON.
+# `rand_core` feature enables SigningKey::generate (used only in tests, but it's a
+# crate-level feature). `std` for std error types.
+ed25519-dalek = { version = "2.2", default-features = false, features = ["std", "rand_core"] }
+sha2 = "0.10"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+serde_jcs = "0.1"
+hex = "0.4"
+# rand_core 0.6 matches ed25519-dalek 2.x's re-exported rand_core (SigningKey::generate).
+rand_core = { version = "0.6", features = ["getrandom"] }

--- a/tools/nucleus-guarantee-lint/receipt/examples/emit_sample_receipt.rs
+++ b/tools/nucleus-guarantee-lint/receipt/examples/emit_sample_receipt.rs
@@ -1,0 +1,45 @@
+//! Emit a sample guarantee receipt + detached signature + the witness PUBLIC key, for a
+//! CLI smoke test of `verify-guarantee-receipt`.
+//!
+//! HONESTY: the signing key here is GENERATED FRESH at runtime and written to the OUTPUT
+//! dir only. No real/private key is read or committed. This is example/test plumbing.
+//!
+//! Usage: cargo run --example emit_sample_receipt -- <out_dir>
+//!
+//! Writes into <out_dir>:
+//!   <anchor_hash>.json   — canonical receipt
+//!   <anchor_hash>.sig    — hex ed25519 signature
+//!   witness.pub          — hex 32-byte verifying key (PUBLIC)
+//!   anchor_hash.txt      — the anchor hash (convenience)
+
+use nucleus_guarantee_receipt::{PROFILE_ID, Receipt};
+use rand_core::OsRng;
+
+fn main() {
+    let out = std::env::args().nth(1).unwrap_or_else(|| "testdata/sample".to_string());
+    std::fs::create_dir_all(&out).unwrap();
+
+    let key = ed25519_dalek::SigningKey::generate(&mut OsRng);
+    let pubkey = key.verifying_key();
+
+    let source = "fn clean_add(a: u64, b: u64) -> u64 {\n    a + b\n}";
+    let receipt = Receipt::build(
+        "crate::clean_add".into(),
+        "fn".into(),
+        source,
+        "nightly-2026-04-16",
+        PROFILE_ID,
+        &[],   // clean
+        vec![],
+    );
+    let (json, sig) = receipt.sign(&key).unwrap();
+
+    let base = std::path::Path::new(&out).join(&receipt.anchor_hash);
+    std::fs::write(base.with_extension("json"), &json).unwrap();
+    std::fs::write(base.with_extension("sig"), hex::encode(sig.to_bytes())).unwrap();
+    std::fs::write(std::path::Path::new(&out).join("witness.pub"), hex::encode(pubkey.to_bytes())).unwrap();
+    std::fs::write(std::path::Path::new(&out).join("anchor_hash.txt"), &receipt.anchor_hash).unwrap();
+
+    println!("anchor_hash={}", receipt.anchor_hash);
+    println!("wrote receipt + sig + witness.pub to {out}");
+}

--- a/tools/nucleus-guarantee-lint/receipt/src/bin/receipts_to_csv.rs
+++ b/tools/nucleus-guarantee-lint/receipt/src/bin/receipts_to_csv.rs
@@ -1,0 +1,100 @@
+//! `receipts-to-csv` — project a directory of signed guarantee-receipt JSON files into a
+//! single CSV that the olog (`ologs/nucleus_security.toml`) can ingest via a
+//! `source = { type = "csv", ... }` block.
+//!
+//! WHY a generator: the olog runtime supports only `csv` and `rustsec` source kinds
+//! (see olog `src/olog_runtime.rs::generate_import_pipeline`) — there is no JSON/glob
+//! source. So receipts are flattened to CSV here, deterministically, and the olog points
+//! a CSV source at the output.
+//!
+//! HONESTY: this is a PURE data projection — it reads receipts, verifies NOTHING, and
+//! writes a row per receipt. A row's presence means "a receipt file existed", which is
+//! the `lint_attested` (screen) tier — STRICTLY WEAKER than `parity_tested`/`extracted`.
+//! It is NOT a proof and the CSV carries no signature; signature verification is the
+//! holder's job via `verify-guarantee-receipt`.
+//!
+//! Usage: receipts-to-csv <receipt_dir> [out.csv]
+//!   default out = <receipt_dir>/../guarantee-receipts.csv
+//!
+//! CSV columns (header row written), id_col = 0:
+//!   anchor_hash,item_path,item_kind,result,toolchain,profile_id,schema_version,ineligible_reasons
+//! `ineligible_reasons` is `;`-joined (empty when clean).
+
+use nucleus_guarantee_receipt::Receipt;
+use std::path::{Path, PathBuf};
+
+fn main() -> std::process::ExitCode {
+    let mut args = std::env::args().skip(1);
+    let Some(dir) = args.next() else {
+        eprintln!("usage: receipts-to-csv <receipt_dir> [out.csv]");
+        return std::process::ExitCode::FAILURE;
+    };
+    let dir = PathBuf::from(dir);
+    let out = args
+        .next()
+        .map(PathBuf::from)
+        .unwrap_or_else(|| dir.join("..").join("guarantee-receipts.csv"));
+
+    match run(&dir, &out) {
+        Ok(n) => {
+            eprintln!("wrote {n} receipt row(s) to {}", out.display());
+            std::process::ExitCode::SUCCESS
+        }
+        Err(e) => {
+            eprintln!("error: {e}");
+            std::process::ExitCode::FAILURE
+        }
+    }
+}
+
+fn run(dir: &Path, out: &Path) -> Result<usize, String> {
+    let mut rows: Vec<Receipt> = Vec::new();
+    let entries = std::fs::read_dir(dir).map_err(|e| format!("read_dir {}: {e}", dir.display()))?;
+    for entry in entries {
+        let path = entry.map_err(|e| e.to_string())?.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("json") {
+            continue;
+        }
+        let bytes = std::fs::read(&path).map_err(|e| format!("read {}: {e}", path.display()))?;
+        let receipt: Receipt =
+            serde_json::from_slice(&bytes).map_err(|e| format!("parse {}: {e}", path.display()))?;
+        rows.push(receipt);
+    }
+    // Deterministic order by anchor_hash so the CSV is reproducible.
+    rows.sort_by(|a, b| a.anchor_hash.cmp(&b.anchor_hash));
+
+    let mut csv = String::new();
+    csv.push_str(
+        "anchor_hash,item_path,item_kind,result,toolchain,profile_id,schema_version,ineligible_reasons\n",
+    );
+    for r in &rows {
+        let result = match r.result {
+            nucleus_guarantee_receipt::ScreenResult::Clean => "clean",
+            nucleus_guarantee_receipt::ScreenResult::Ineligible => "ineligible",
+        };
+        let reasons = r.ineligible_reasons.join(";");
+        csv.push_str(&format!(
+            "{},{},{},{},{},{},{},{}\n",
+            csv_field(&r.anchor_hash),
+            csv_field(&r.item_path),
+            csv_field(&r.item_kind),
+            result,
+            csv_field(&r.toolchain),
+            csv_field(&r.profile_id),
+            r.schema_version,
+            csv_field(&reasons),
+        ));
+    }
+    std::fs::write(out, csv).map_err(|e| format!("write {}: {e}", out.display()))?;
+    Ok(rows.len())
+}
+
+/// Minimal CSV escaping: quote + double inner quotes when the field contains a comma,
+/// quote, or newline.
+fn csv_field(s: &str) -> String {
+    if s.contains(',') || s.contains('"') || s.contains('\n') {
+        format!("\"{}\"", s.replace('"', "\"\""))
+    } else {
+        s.to_string()
+    }
+}

--- a/tools/nucleus-guarantee-lint/receipt/src/bin/verify_guarantee_receipt.rs
+++ b/tools/nucleus-guarantee-lint/receipt/src/bin/verify_guarantee_receipt.rs
@@ -1,0 +1,111 @@
+//! `verify-guarantee-receipt` — holder-side verifier for a guarantee receipt.
+//!
+//! Checks that a receipt JSON + detached signature verify against a witness PUBLIC key.
+//! This proves only that the named witness signed *this exact receipt* — and a receipt
+//! attests only the SCREEN RESULT at one `(source, toolchain, profile)` hash, NOT
+//! extractability and NOT correctness (see the `receipt` module docs / README).
+//!
+//! Usage:
+//!   verify-guarantee-receipt --json <receipt.json> --sig <receipt.sig> \
+//!       --pubkey-hex <64-hex> | --pubkey-file <path>
+//!   [--source <file>]   # optional: also bind-check the anchor_hash to this source file
+//!                       #            using the receipt's own toolchain + profile_id
+//!
+//! Exit code 0 = verified; 1 = NOT verified / error.
+//!
+//! The signature file is hex (as written by the lint). The pubkey is a 32-byte ed25519
+//! verifying key, given as 64 hex chars (`--pubkey-hex`) or a raw/hex file
+//! (`--pubkey-file`).
+
+use nucleus_guarantee_receipt::{
+    Receipt, load_verifying_key, verify_receipt, verify_receipt_bound_to,
+};
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(true) => {
+            eprintln!("VERIFIED: signature is valid for this receipt.");
+            ExitCode::SUCCESS
+        }
+        Ok(false) => {
+            eprintln!("NOT VERIFIED: signature does not validate (or anchor bind-check failed).");
+            ExitCode::FAILURE
+        }
+        Err(e) => {
+            eprintln!("error: {e}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn run() -> Result<bool, String> {
+    let mut json_path: Option<String> = None;
+    let mut sig_path: Option<String> = None;
+    let mut pubkey_hex: Option<String> = None;
+    let mut pubkey_file: Option<String> = None;
+    let mut source_file: Option<String> = None;
+
+    let mut args = std::env::args().skip(1);
+    while let Some(arg) = args.next() {
+        let mut take = |name: &str| {
+            args.next()
+                .ok_or_else(|| format!("missing value for {name}"))
+        };
+        match arg.as_str() {
+            "--json" => json_path = Some(take("--json")?),
+            "--sig" => sig_path = Some(take("--sig")?),
+            "--pubkey-hex" => pubkey_hex = Some(take("--pubkey-hex")?),
+            "--pubkey-file" => pubkey_file = Some(take("--pubkey-file")?),
+            "--source" => source_file = Some(take("--source")?),
+            "-h" | "--help" => {
+                print_help();
+                return Ok(true);
+            }
+            other => return Err(format!("unknown argument: {other}")),
+        }
+    }
+
+    let json_path = json_path.ok_or("--json is required")?;
+    let sig_path = sig_path.ok_or("--sig is required")?;
+
+    let json = std::fs::read(&json_path).map_err(|e| format!("read {json_path}: {e}"))?;
+    let sig_text = std::fs::read_to_string(&sig_path).map_err(|e| format!("read {sig_path}: {e}"))?;
+    let sig_bytes = hex::decode(sig_text.trim()).map_err(|e| format!("sig is not hex: {e}"))?;
+
+    let pubkey = match (pubkey_hex, pubkey_file) {
+        (Some(h), None) => load_verifying_key(h.trim().as_bytes()).map_err(|e| e.to_string())?,
+        (None, Some(f)) => {
+            let bytes = std::fs::read(&f).map_err(|e| format!("read {f}: {e}"))?;
+            load_verifying_key(&bytes).map_err(|e| e.to_string())?
+        }
+        (Some(_), Some(_)) => return Err("pass only one of --pubkey-hex / --pubkey-file".into()),
+        (None, None) => return Err("one of --pubkey-hex / --pubkey-file is required".into()),
+    };
+
+    // Optional fail-closed anchor bind-check against a source file, using the receipt's
+    // own declared toolchain + profile_id (so the holder confirms the source matches).
+    if let Some(src_file) = source_file {
+        let src = std::fs::read_to_string(&src_file).map_err(|e| format!("read {src_file}: {e}"))?;
+        let receipt: Receipt =
+            serde_json::from_slice(&json).map_err(|e| format!("parse receipt json: {e}"))?;
+        return verify_receipt_bound_to(
+            &json,
+            &sig_bytes,
+            &pubkey,
+            &src,
+            &receipt.toolchain,
+            &receipt.profile_id,
+        )
+        .map_err(|e| e.to_string());
+    }
+
+    verify_receipt(&json, &sig_bytes, &pubkey).map_err(|e| e.to_string())
+}
+
+fn print_help() {
+    eprintln!(
+        "verify-guarantee-receipt --json <receipt.json> --sig <receipt.sig> \
+         (--pubkey-hex <64hex> | --pubkey-file <path>) [--source <file>]"
+    );
+}

--- a/tools/nucleus-guarantee-lint/receipt/src/lib.rs
+++ b/tools/nucleus-guarantee-lint/receipt/src/lib.rs
@@ -1,0 +1,525 @@
+//! # Per-hash GUARANTEE RECEIPT (schema_version = 0)
+//!
+//! ## HONESTY (read this first — a receipt is a SCREEN result, NOT a proof)
+//!
+//! A guarantee receipt attests **exactly one thing**: that the `aeneas_eligible`
+//! *screen* (a NECESSARY condition for Aeneas-extractability — see the crate-level
+//! docs) produced a particular `result` for a particular function, at one exact
+//! `(normalized_source, toolchain, profile_id)` triple, identified by `anchor_hash`.
+//!
+//! It is **NOT**:
+//! * a proof that the function *is* extractable into a functional model;
+//! * a proof that any extracted model is *correct*;
+//! * a guarantee of anything beyond "the screen returned this `result` for this hash".
+//!
+//! A `result = "clean"` receipt is the output of a **necessary-condition** screen:
+//! the function tripped none of the *implemented* deny-set rules. It does **not** mean
+//! the function is "in the Aeneas subset" — several deny-set rows (floats, nested
+//! loops, non-`Vec` collections, iterator combinators) are **not screened at all** and
+//! are carried in `guarantees` as `"not_screened"`. A clean receipt is necessary, not
+//! sufficient.
+//!
+//! ## Fail-closed binding
+//!
+//! The receipt is bound to its inputs by `anchor_hash`. Change the source by one byte,
+//! change the toolchain, or change the profile, and the hash changes — the old receipt
+//! no longer matches the new function and is **void** (it simply will not be found at
+//! `<receipt_dir>/<new_hash>.json`). There is no "approximately matches": the binding
+//! is fail-closed by construction.
+//!
+//! ## Toolchain-relative
+//!
+//! `toolchain` records the *exact* rustc channel the screen ran under. The Aeneas
+//! subset, and the screen's own decidability at the HIR level, are properties of that
+//! specific compiler. The receipt's guarantee is **toolchain-relative**: it says
+//! nothing about how the same source behaves under a different rustc.
+//!
+//! ## v0 anchor caveat (whitespace-sensitive)
+//!
+//! In v0, `normalized_source` is the raw source snippet of the function taken from its
+//! HIR span (via `clippy_utils::source::snippet_opt`). This is **whitespace- and
+//! comment-sensitive**: reformatting the function (e.g. `rustfmt`) changes the bytes,
+//! hence the hash, hence voids the receipt even though the *meaning* is unchanged.
+//! That is conservative (fail-closed) but noisy.
+//!
+//! v1 TODO: switch `normalized_source` to a reformat-robust anchor — either a
+//! `rustfmt`-normalized source string or, better, a hash of the StableMIR body — so the
+//! anchor tracks *semantics* rather than *bytes*. Until then, treat a v0 receipt as
+//! bound to the literal source text.
+
+use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::BTreeMap;
+
+/// Domain-separation tag prepended to the hash preimage. Bump only on a
+/// breaking change to the preimage construction.
+pub const ANCHOR_DOMAIN_TAG: &[u8] = b"nucleus.guarantee-receipt.v0";
+
+/// The current receipt schema version. Bump on any change to the serialized shape.
+pub const SCHEMA_VERSION: u32 = 0;
+
+/// The screen profile this receipt attests against. A constant for v0: it identifies
+/// *which* screen produced the result. (v1 may fold the aeneas/charon commit + backend
+/// + flags into this string.)
+pub const PROFILE_ID: &str = "aeneas-eligible-v1";
+
+/// The seven deny-set rules this screen actually implements. A `clean` receipt asserts
+/// each of these passed; UNSCREENED rules (floats / nested-loops / non-`Vec` collections
+/// / iterator-combinators) are carried separately as `"not_screened"` — see [`Guarantee`].
+pub const SCREENED_RULES: [&str; 7] = [
+    "no_unsafe",
+    "no_async",
+    "no_closures",
+    "no_dyn_in_sig",
+    "no_raw_ptr",
+    "no_ffi_call",
+    "no_inline_asm",
+];
+
+/// The deny-set rows the screen does NOT implement. Carried in `guarantees` as
+/// `"not_screened"` so a receipt never *silently* implies coverage it does not have.
+pub const NOT_SCREENED_RULES: [&str; 4] = [
+    "no_floats",
+    "no_nested_loops",
+    "no_non_vec_collections",
+    "no_iterator_combinators",
+];
+
+/// The screen result for a function.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ScreenResult {
+    /// Tripped none of the implemented deny-set rules. NECESSARY-condition pass only —
+    /// see the module docs; this is NOT "in the subset" and NOT a proof.
+    Clean,
+    /// Tripped at least one implemented deny-set rule (see `ineligible_reasons`).
+    Ineligible,
+}
+
+/// Per-rule outcome. `Pass`/`Fail` apply only to the seven implemented rules; every
+/// unscreened rule is `NotScreened` — never `Pass` — so a clean receipt cannot be
+/// misread as asserting coverage the screen does not have.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Guarantee {
+    Pass,
+    Fail,
+    NotScreened,
+}
+
+/// A signed-able guarantee receipt. Serializes to canonical JSON (RFC 8785 / JCS) for
+/// signing; the `.json` written to disk is the same canonical form so re-canonicalizing
+/// is idempotent.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Receipt {
+    pub schema_version: u32,
+    /// Fully-qualified item path of the screened function (e.g. `crate::module::f`).
+    pub item_path: String,
+    /// Item kind, e.g. `fn`, `method`.
+    pub item_kind: String,
+    /// Hex SHA-256 of the domain-tagged preimage — see [`compute_anchor_hash`].
+    pub anchor_hash: String,
+    /// Exact rustc channel the screen ran under (toolchain-relative guarantee).
+    pub toolchain: String,
+    /// Screen profile identifier (constant in v0).
+    pub profile_id: String,
+    pub result: ScreenResult,
+    /// Human-readable reasons the function was flagged ineligible; empty when clean.
+    pub ineligible_reasons: Vec<String>,
+    /// Per-rule outcome map. Keys are rule names; values are pass/fail/not_screened.
+    /// Sorted deterministically by `BTreeMap`.
+    pub guarantees: BTreeMap<String, Guarantee>,
+}
+
+impl Receipt {
+    /// Build a receipt for a screened function.
+    ///
+    /// `failed_rules` is the set of implemented-rule names that tripped (subset of
+    /// [`SCREENED_RULES`]). `reasons` is the human-readable hit list. The `guarantees`
+    /// map is filled deterministically: each screened rule → `Pass`/`Fail`, each
+    /// unscreened rule → `NotScreened`.
+    #[allow(clippy::too_many_arguments)]
+    pub fn build(
+        item_path: String,
+        item_kind: String,
+        normalized_source: &str,
+        toolchain: &str,
+        profile_id: &str,
+        failed_rules: &[&str],
+        reasons: Vec<String>,
+    ) -> Self {
+        let anchor_hash = compute_anchor_hash(normalized_source, toolchain, profile_id);
+
+        let result = if failed_rules.is_empty() {
+            ScreenResult::Clean
+        } else {
+            ScreenResult::Ineligible
+        };
+
+        let mut guarantees = BTreeMap::new();
+        for rule in SCREENED_RULES {
+            let g = if failed_rules.contains(&rule) {
+                Guarantee::Fail
+            } else {
+                Guarantee::Pass
+            };
+            guarantees.insert(rule.to_string(), g);
+        }
+        for rule in NOT_SCREENED_RULES {
+            guarantees.insert(rule.to_string(), Guarantee::NotScreened);
+        }
+
+        Receipt {
+            schema_version: SCHEMA_VERSION,
+            item_path,
+            item_kind,
+            anchor_hash,
+            toolchain: toolchain.to_string(),
+            profile_id: profile_id.to_string(),
+            result,
+            ineligible_reasons: reasons,
+            guarantees,
+        }
+    }
+
+    /// Canonical JSON bytes (RFC 8785 / JCS) — the exact bytes that are signed and
+    /// written to `<receipt_dir>/<anchor_hash>.json`.
+    pub fn canonical_json(&self) -> Result<Vec<u8>, ReceiptError> {
+        let value = serde_json::to_value(self).map_err(ReceiptError::Json)?;
+        serde_jcs::to_vec(&value).map_err(ReceiptError::Json)
+    }
+
+    /// Sign the canonical JSON with an ed25519 signing key. Returns the canonical bytes
+    /// and the detached signature (so the caller writes `.json` + `.sig` consistently).
+    pub fn sign(&self, key: &SigningKey) -> Result<(Vec<u8>, Signature), ReceiptError> {
+        let bytes = self.canonical_json()?;
+        let sig = key.sign(&bytes);
+        Ok((bytes, sig))
+    }
+}
+
+/// Compute `anchor_hash = SHA-256( TAG ‖ normalized_source ‖ toolchain ‖ profile_id )`,
+/// returned as lowercase hex.
+///
+/// The preimage is the byte concatenation, in order, of:
+///   1. [`ANCHOR_DOMAIN_TAG`] (`b"nucleus.guarantee-receipt.v0"`)
+///   2. `normalized_source` bytes (v0: the raw HIR-span source snippet)
+///   3. `toolchain` bytes (e.g. `nightly-2026-04-16`)
+///   4. `profile_id` bytes (e.g. `aeneas-eligible-v1`)
+///
+/// NO length-prefixing / separators are used in v0: the domain tag + fixed field order
+/// give a stable preimage for the screen's own use, but note this is NOT collision-proof
+/// across arbitrary field re-splits (a v1 hardening TODO is length-prefixed framing).
+pub fn compute_anchor_hash(normalized_source: &str, toolchain: &str, profile_id: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(ANCHOR_DOMAIN_TAG);
+    hasher.update(normalized_source.as_bytes());
+    hasher.update(toolchain.as_bytes());
+    hasher.update(profile_id.as_bytes());
+    let digest = hasher.finalize();
+    hex::encode(digest)
+}
+
+/// Verify a receipt against a witness PUBLIC key.
+///
+/// Re-canonicalizes the supplied receipt JSON (so a holder need not trust the byte
+/// layout they were handed) and checks the ed25519 signature over those canonical bytes.
+/// Returns `Ok(true)` iff the signature verifies. A holder who *also* wants to confirm
+/// the receipt is bound to a specific source should independently recompute
+/// `compute_anchor_hash` and compare to `receipt.anchor_hash` (see
+/// [`verify_receipt_bound_to`]).
+pub fn verify_receipt(
+    receipt_json: &[u8],
+    sig_bytes: &[u8],
+    pubkey: &VerifyingKey,
+) -> Result<bool, ReceiptError> {
+    let receipt: Receipt = serde_json::from_slice(receipt_json).map_err(ReceiptError::Json)?;
+    let canonical = receipt.canonical_json()?;
+    let sig = signature_from_bytes(sig_bytes)?;
+    Ok(pubkey.verify(&canonical, &sig).is_ok())
+}
+
+/// Stronger check: signature verifies AND `anchor_hash` matches the supplied
+/// `(normalized_source, toolchain, profile_id)`. Use this when a holder has the source in
+/// hand and wants the fail-closed binding (changed source ⇒ false).
+pub fn verify_receipt_bound_to(
+    receipt_json: &[u8],
+    sig_bytes: &[u8],
+    pubkey: &VerifyingKey,
+    normalized_source: &str,
+    toolchain: &str,
+    profile_id: &str,
+) -> Result<bool, ReceiptError> {
+    let receipt: Receipt = serde_json::from_slice(receipt_json).map_err(ReceiptError::Json)?;
+    let expected = compute_anchor_hash(normalized_source, toolchain, profile_id);
+    if receipt.anchor_hash != expected {
+        return Ok(false);
+    }
+    let canonical = receipt.canonical_json()?;
+    let sig = signature_from_bytes(sig_bytes)?;
+    Ok(pubkey.verify(&canonical, &sig).is_ok())
+}
+
+fn signature_from_bytes(sig_bytes: &[u8]) -> Result<Signature, ReceiptError> {
+    let arr: [u8; 64] = sig_bytes
+        .try_into()
+        .map_err(|_| ReceiptError::BadSignatureLength(sig_bytes.len()))?;
+    Ok(Signature::from_bytes(&arr))
+}
+
+/// Load a 32-byte ed25519 secret key from raw (32 bytes) or hex (64 ascii hex chars,
+/// optionally with surrounding whitespace) bytes. Refuses anything else — there is no
+/// fallback to a zero / fake key (honesty: an invalid key is an ERROR, never silently
+/// substituted).
+pub fn load_signing_key(raw_or_hex: &[u8]) -> Result<SigningKey, ReceiptError> {
+    // Raw 32 bytes.
+    if raw_or_hex.len() == 32 {
+        let arr: [u8; 32] = raw_or_hex.try_into().expect("len checked");
+        return Ok(SigningKey::from_bytes(&arr));
+    }
+    // Hex (trim ASCII whitespace such as a trailing newline).
+    let trimmed: Vec<u8> = raw_or_hex
+        .iter()
+        .copied()
+        .filter(|b| !b.is_ascii_whitespace())
+        .collect();
+    if trimmed.len() == 64 {
+        let bytes = hex::decode(&trimmed).map_err(|_| ReceiptError::BadKey)?;
+        let arr: [u8; 32] = bytes.try_into().map_err(|_| ReceiptError::BadKey)?;
+        return Ok(SigningKey::from_bytes(&arr));
+    }
+    Err(ReceiptError::BadKey)
+}
+
+/// Load a 32-byte ed25519 PUBLIC (verifying) key from raw or hex bytes.
+pub fn load_verifying_key(raw_or_hex: &[u8]) -> Result<VerifyingKey, ReceiptError> {
+    if raw_or_hex.len() == 32 {
+        let arr: [u8; 32] = raw_or_hex.try_into().expect("len checked");
+        return VerifyingKey::from_bytes(&arr).map_err(|_| ReceiptError::BadKey);
+    }
+    let trimmed: Vec<u8> = raw_or_hex
+        .iter()
+        .copied()
+        .filter(|b| !b.is_ascii_whitespace())
+        .collect();
+    if trimmed.len() == 64 {
+        let bytes = hex::decode(&trimmed).map_err(|_| ReceiptError::BadKey)?;
+        let arr: [u8; 32] = bytes.try_into().map_err(|_| ReceiptError::BadKey)?;
+        return VerifyingKey::from_bytes(&arr).map_err(|_| ReceiptError::BadKey);
+    }
+    Err(ReceiptError::BadKey)
+}
+
+#[derive(Debug)]
+pub enum ReceiptError {
+    /// JSON (de)serialization or JCS canonicalization failed.
+    Json(serde_json::Error),
+    /// The signing/verifying key bytes were neither raw-32 nor hex-64.
+    BadKey,
+    /// The signature was not 64 bytes.
+    BadSignatureLength(usize),
+}
+
+impl std::fmt::Display for ReceiptError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ReceiptError::Json(e) => write!(f, "receipt JSON/JCS error: {e}"),
+            ReceiptError::BadKey => write!(
+                f,
+                "invalid ed25519 key: expected 32 raw bytes or 64 hex chars (NO zero/fake key fallback)"
+            ),
+            ReceiptError::BadSignatureLength(n) => {
+                write!(f, "invalid signature length: expected 64 bytes, got {n}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ReceiptError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::SigningKey;
+    use rand_core::OsRng;
+
+    // A FRESH key per test, generated in-test only. NO real/private key is ever
+    // committed or read from disk in these unit tests (honesty / HARD STOP).
+    fn test_key() -> SigningKey {
+        SigningKey::generate(&mut OsRng)
+    }
+
+    fn clean_receipt(src: &str) -> Receipt {
+        Receipt::build(
+            "crate::clean_add".into(),
+            "fn".into(),
+            src,
+            "nightly-2026-04-16",
+            PROFILE_ID,
+            &[],
+            vec![],
+        )
+    }
+
+    #[test]
+    fn clean_fn_yields_clean_result_and_verifiable_sig() {
+        let key = test_key();
+        let pubkey = key.verifying_key();
+        let receipt = clean_receipt("fn clean_add(a: u64, b: u64) -> u64 { a + b }");
+
+        assert_eq!(receipt.result, ScreenResult::Clean);
+        assert!(receipt.ineligible_reasons.is_empty());
+        // every screened rule passes; every unscreened rule is NotScreened (never Pass).
+        for rule in SCREENED_RULES {
+            assert_eq!(receipt.guarantees[rule], Guarantee::Pass, "{rule}");
+        }
+        for rule in NOT_SCREENED_RULES {
+            assert_eq!(receipt.guarantees[rule], Guarantee::NotScreened, "{rule}");
+        }
+
+        let (json, sig) = receipt.sign(&key).unwrap();
+        assert!(verify_receipt(&json, &sig.to_bytes(), &pubkey).unwrap());
+    }
+
+    #[test]
+    fn ineligible_fn_records_result_and_reasons() {
+        let key = test_key();
+        let pubkey = key.verifying_key();
+        let receipt = Receipt::build(
+            "crate::ineligible_async".into(),
+            "fn".into(),
+            "async fn ineligible_async() -> u64 { 0 }",
+            "nightly-2026-04-16",
+            PROFILE_ID,
+            &["no_async"],
+            vec!["an `async` function signature".into()],
+        );
+
+        assert_eq!(receipt.result, ScreenResult::Ineligible);
+        assert_eq!(receipt.guarantees["no_async"], Guarantee::Fail);
+        assert_eq!(receipt.guarantees["no_unsafe"], Guarantee::Pass);
+        assert_eq!(receipt.ineligible_reasons.len(), 1);
+
+        let (json, sig) = receipt.sign(&key).unwrap();
+        assert!(verify_receipt(&json, &sig.to_bytes(), &pubkey).unwrap());
+    }
+
+    #[test]
+    fn same_source_yields_same_anchor_hash_determinism() {
+        let src = "fn clean_add(a: u64, b: u64) -> u64 { a + b }";
+        let h1 = compute_anchor_hash(src, "nightly-2026-04-16", PROFILE_ID);
+        let h2 = compute_anchor_hash(src, "nightly-2026-04-16", PROFILE_ID);
+        assert_eq!(h1, h2);
+        // and via the full receipt path
+        assert_eq!(clean_receipt(src).anchor_hash, clean_receipt(src).anchor_hash);
+    }
+
+    #[test]
+    fn changing_source_changes_hash() {
+        let h1 = compute_anchor_hash("fn f() -> u64 { 0 }", "nightly-2026-04-16", PROFILE_ID);
+        let h2 = compute_anchor_hash("fn f() -> u64 { 1 }", "nightly-2026-04-16", PROFILE_ID);
+        assert_ne!(h1, h2);
+        // even a single whitespace byte changes it (v0 is whitespace-sensitive by design)
+        let h3 = compute_anchor_hash("fn f() -> u64 {  0 }", "nightly-2026-04-16", PROFILE_ID);
+        assert_ne!(h1, h3);
+    }
+
+    #[test]
+    fn changing_toolchain_or_profile_changes_hash() {
+        let src = "fn f() -> u64 { 0 }";
+        let base = compute_anchor_hash(src, "nightly-2026-04-16", PROFILE_ID);
+        assert_ne!(base, compute_anchor_hash(src, "nightly-2026-04-17", PROFILE_ID));
+        assert_ne!(base, compute_anchor_hash(src, "nightly-2026-04-16", "other-profile"));
+    }
+
+    #[test]
+    fn tampered_receipt_fails_verification() {
+        let key = test_key();
+        let pubkey = key.verifying_key();
+        let receipt = clean_receipt("fn f() -> u64 { 0 }");
+        let (json, sig) = receipt.sign(&key).unwrap();
+
+        // Flip the result clean -> ineligible in the JSON; signature must reject.
+        let mut tampered: Receipt = serde_json::from_slice(&json).unwrap();
+        tampered.result = ScreenResult::Ineligible;
+        let tampered_json = tampered.canonical_json().unwrap();
+        assert!(!verify_receipt(&tampered_json, &sig.to_bytes(), &pubkey).unwrap());
+    }
+
+    #[test]
+    fn wrong_key_fails_verification() {
+        let key = test_key();
+        let other = test_key();
+        let receipt = clean_receipt("fn f() -> u64 { 0 }");
+        let (json, sig) = receipt.sign(&key).unwrap();
+        assert!(!verify_receipt(&json, &sig.to_bytes(), &other.verifying_key()).unwrap());
+    }
+
+    #[test]
+    fn verify_bound_to_is_fail_closed_on_source_change() {
+        let key = test_key();
+        let pubkey = key.verifying_key();
+        let src = "fn f() -> u64 { 0 }";
+        let receipt = clean_receipt(src);
+        let (json, sig) = receipt.sign(&key).unwrap();
+
+        // Correct source: binds.
+        assert!(
+            verify_receipt_bound_to(&json, &sig.to_bytes(), &pubkey, src, "nightly-2026-04-16", PROFILE_ID)
+                .unwrap()
+        );
+        // Changed source: fail-closed even though the sig itself is valid.
+        assert!(
+            !verify_receipt_bound_to(
+                &json,
+                &sig.to_bytes(),
+                &pubkey,
+                "fn f() -> u64 { 1 }",
+                "nightly-2026-04-16",
+                PROFILE_ID
+            )
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn canonical_json_is_idempotent_and_sorted() {
+        let receipt = clean_receipt("fn f() -> u64 { 0 }");
+        let c1 = receipt.canonical_json().unwrap();
+        // round-trip and re-canonicalize: must be byte-identical (JCS is canonical).
+        let parsed: Receipt = serde_json::from_slice(&c1).unwrap();
+        let c2 = parsed.canonical_json().unwrap();
+        assert_eq!(c1, c2);
+        // top-level keys must be sorted (JCS): schema_version is "s", anchor_hash "a"...
+        let s = String::from_utf8(c1).unwrap();
+        let anchor_pos = s.find("\"anchor_hash\"").unwrap();
+        let schema_pos = s.find("\"schema_version\"").unwrap();
+        assert!(anchor_pos < schema_pos, "JCS sorts keys: anchor_hash before schema_version");
+    }
+
+    #[test]
+    fn load_signing_key_raw_and_hex_agree() {
+        let key = test_key();
+        let raw = key.to_bytes(); // [u8; 32]
+        let hexed = hex::encode(raw);
+
+        let from_raw = load_signing_key(&raw).unwrap();
+        let from_hex = load_signing_key(hexed.as_bytes()).unwrap();
+        let from_hex_nl = load_signing_key(format!("{hexed}\n").as_bytes()).unwrap();
+
+        assert_eq!(from_raw.to_bytes(), key.to_bytes());
+        assert_eq!(from_hex.to_bytes(), key.to_bytes());
+        assert_eq!(from_hex_nl.to_bytes(), key.to_bytes());
+    }
+
+    #[test]
+    fn load_signing_key_rejects_bad_input_no_zero_fallback() {
+        // wrong length raw
+        assert!(load_signing_key(&[0u8; 16]).is_err());
+        // non-hex of right length
+        assert!(load_signing_key(&[b'z'; 64]).is_err());
+        // empty -> error, NOT a zero key
+        assert!(load_signing_key(&[]).is_err());
+    }
+}

--- a/tools/nucleus-guarantee-lint/receipt/tests/on_disk_roundtrip.rs
+++ b/tools/nucleus-guarantee-lint/receipt/tests/on_disk_roundtrip.rs
@@ -1,0 +1,85 @@
+//! On-disk roundtrip: mirror exactly what the lint's `flush_receipts` writes
+//! (`<anchor_hash>.json` canonical bytes + `<anchor_hash>.sig` as lowercase HEX) and
+//! verify it back with the witness PUBLIC key — the same path the
+//! `verify-guarantee-receipt` bin takes. No rustc / dylint needed.
+//!
+//! HONESTY: the signing key is generated FRESH in-test and never leaves the temp dir.
+//! No real/private key is read or committed.
+
+use nucleus_guarantee_receipt::{PROFILE_ID, Receipt, load_verifying_key, verify_receipt};
+use rand_core::OsRng;
+
+fn tmp_dir(tag: &str) -> std::path::PathBuf {
+    let mut d = std::env::temp_dir();
+    d.push(format!(
+        "nucleus-guarantee-receipt-test-{tag}-{}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&d).unwrap();
+    d
+}
+
+#[test]
+fn writes_json_plus_hex_sig_and_verifies_back() {
+    let dir = tmp_dir("roundtrip");
+
+    let key = ed25519_dalek::SigningKey::generate(&mut OsRng);
+    let pubkey_hex = hex::encode(key.verifying_key().to_bytes());
+
+    let receipt = Receipt::build(
+        "crate::clean_add".into(),
+        "fn".into(),
+        "fn clean_add(a: u64, b: u64) -> u64 { a + b }",
+        "nightly-2026-04-16",
+        PROFILE_ID,
+        &[],
+        vec![],
+    );
+    let (json, sig) = receipt.sign(&key).unwrap();
+
+    // Exactly the lint's on-disk format.
+    let json_path = dir.join(format!("{}.json", receipt.anchor_hash));
+    let sig_path = dir.join(format!("{}.sig", receipt.anchor_hash));
+    std::fs::write(&json_path, &json).unwrap();
+    std::fs::write(&sig_path, hex::encode(sig.to_bytes())).unwrap();
+
+    // Holder side: read back, decode the hex sig + hex pubkey, verify.
+    let json_back = std::fs::read(&json_path).unwrap();
+    let sig_hex = std::fs::read_to_string(&sig_path).unwrap();
+    let sig_bytes = hex::decode(sig_hex.trim()).unwrap();
+    let pubkey = load_verifying_key(pubkey_hex.as_bytes()).unwrap();
+
+    assert!(verify_receipt(&json_back, &sig_bytes, &pubkey).unwrap());
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn ineligible_receipt_on_disk_records_failed_rule() {
+    let dir = tmp_dir("ineligible");
+    let key = ed25519_dalek::SigningKey::generate(&mut OsRng);
+    let pubkey = key.verifying_key();
+
+    let receipt = Receipt::build(
+        "crate::ineligible_unsafe".into(),
+        "fn".into(),
+        "unsafe fn ineligible_unsafe() -> u64 { 0 }",
+        "nightly-2026-04-16",
+        PROFILE_ID,
+        &["no_unsafe"],
+        vec!["an `unsafe` function signature".into()],
+    );
+    let (json, sig) = receipt.sign(&key).unwrap();
+    let json_path = dir.join(format!("{}.json", receipt.anchor_hash));
+    std::fs::write(&json_path, &json).unwrap();
+
+    let parsed: Receipt = serde_json::from_slice(&std::fs::read(&json_path).unwrap()).unwrap();
+    assert_eq!(parsed.result, nucleus_guarantee_receipt::ScreenResult::Ineligible);
+    assert_eq!(
+        parsed.guarantees["no_unsafe"],
+        nucleus_guarantee_receipt::Guarantee::Fail
+    );
+    assert!(verify_receipt(&json, &sig.to_bytes(), &pubkey).unwrap());
+
+    std::fs::remove_dir_all(&dir).ok();
+}

--- a/tools/nucleus-guarantee-lint/src/lib.rs
+++ b/tools/nucleus-guarantee-lint/src/lib.rs
@@ -46,8 +46,14 @@ extern crate rustc_ast;
 extern crate rustc_hir;
 extern crate rustc_span;
 
+// The per-hash guarantee receipt (hash / canonicalize / sign / verify) lives in the PURE
+// sibling crate `nucleus_guarantee_receipt` (NO rustc dependency — unit-testable without
+// the compiler, and rlib/bin-buildable, which a rustc_private cdylib is NOT). See its
+// docs for the honesty boundary (a receipt is a SCREEN result, NOT a proof).
 use clippy_utils::diagnostics::span_lint_and_help;
 use clippy_utils::fn_def_id;
+use clippy_utils::source::snippet_opt;
+use nucleus_guarantee_receipt::{PROFILE_ID, Receipt, load_signing_key};
 use rustc_ast::TraitObjectSyntax;
 // `visit_ty_unambig` is provided by the `VisitorExt` extension trait, not `Visitor`
 // itself (Research 2 drift point: the AmbigArg split). It must be in scope to call it.
@@ -59,8 +65,10 @@ use rustc_hir::{
 use rustc_lint::{LateContext, LateLintPass};
 use rustc_span::Span;
 use rustc_span::def_id::LocalDefId;
+use std::cell::RefCell;
+use std::path::PathBuf;
 
-dylint_linting::declare_late_lint! {
+dylint_linting::impl_late_lint! {
     /// ### What it does
     ///
     /// Screens each function for constructs that make it **ineligible** for
@@ -95,7 +103,63 @@ dylint_linting::declare_late_lint! {
     /// ```
     pub AENEAS_ELIGIBLE,
     Warn,
-    "function uses a construct outside the Aeneas-extractable subset (screen, not a proof)"
+    "function uses a construct outside the Aeneas-extractable subset (screen, not a proof)",
+    AeneasEligible::new()
+}
+
+/// Configuration, read from `dylint.toml` under the key `nucleus_guarantee_lint`
+/// (the crate name). Absent ⇒ `Default` ⇒ receipts disabled (the screen still runs).
+///
+/// ```toml
+/// [nucleus_guarantee_lint]
+/// emit_receipts = true
+/// receipt_dir = "target/guarantee-receipts"
+/// signing_key_path = "secrets/guarantee-witness.key"   # 32-byte ed25519, raw OR hex
+/// ```
+///
+/// HONESTY / fail-loud: if `emit_receipts = true` but `signing_key_path` is empty or the
+/// key cannot be loaded as a valid 32-byte ed25519 secret (raw or hex), the lint pass
+/// ABORTS with a hard error. It NEVER substitutes a zero / fake key — an unsigned or
+/// fake-signed receipt would be a dishonest attestation.
+#[derive(Debug, Default, serde::Deserialize)]
+struct Config {
+    #[serde(default)]
+    emit_receipts: bool,
+    #[serde(default)]
+    receipt_dir: String,
+    #[serde(default)]
+    signing_key_path: String,
+}
+
+/// The lint pass. Holds config + a `RefCell` accumulator of receipts gathered during
+/// `check_fn`, flushed (written + signed) once at `check_crate_post`.
+pub struct AeneasEligible {
+    config: Config,
+    pending: RefCell<Vec<Receipt>>,
+}
+
+impl AeneasEligible {
+    pub fn new() -> Self {
+        Self {
+            config: dylint_linting::config_or_default(env!("CARGO_PKG_NAME")),
+            pending: RefCell::new(Vec::new()),
+        }
+    }
+}
+
+impl Default for AeneasEligible {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Resolve the toolchain string the screen is running under. The receipt is
+/// TOOLCHAIN-RELATIVE: the guarantee only holds for this exact rustc. Prefer the
+/// `RUSTUP_TOOLCHAIN` env (set by rustup when a `+toolchain` / `rust-toolchain.toml`
+/// is active); fall back to `nightly-2026-04-16` (this crate's pinned channel) so the
+/// receipt is never silently toolchain-less.
+fn resolve_toolchain() -> String {
+    std::env::var("RUSTUP_TOOLCHAIN").unwrap_or_else(|_| "nightly-2026-04-16".to_string())
 }
 
 impl<'tcx> LateLintPass<'tcx> for AeneasEligible {
@@ -111,12 +175,17 @@ impl<'tcx> LateLintPass<'tcx> for AeneasEligible {
         decl: &'tcx FnDecl<'tcx>,
         body: &'tcx rustc_hir::Body<'tcx>,
         span: Span,
-        _def_id: LocalDefId,
+        def_id: LocalDefId,
     ) {
         // Skip closures-as-fn (the enclosing fn's visitor reports them).
         if matches!(kind, FnKind::Closure) {
             return;
         }
+
+        // Per-fn hit collector. Every `report_and_record` both emits the diagnostic
+        // (unchanged behaviour, so the UI snapshot stays green) AND records the canonical
+        // rule name + reason here, which the receipt then summarizes.
+        let hits: RefCell<Vec<Hit>> = RefCell::new(Vec::new());
 
         // --- (a) signature unsafety -------------------------------------------------
         // FnHeader.safety is HeaderSafety post-refactor; prefer header.is_unsafe(),
@@ -124,7 +193,7 @@ impl<'tcx> LateLintPass<'tcx> for AeneasEligible {
         if let Some(header) = kind.header()
             && header.is_unsafe()
         {
-            report(cx, span, "an `unsafe` function signature");
+            report_and_record(cx, &hits, span, "no_unsafe", "an `unsafe` function signature");
             // keep scanning the body for additional, more specific hits
         }
 
@@ -132,34 +201,145 @@ impl<'tcx> LateLintPass<'tcx> for AeneasEligible {
         if let Some(header) = kind.header()
             && header.is_async()
         {
-            report(cx, span, "an `async` function signature");
+            report_and_record(cx, &hits, span, "no_async", "an `async` function signature");
         }
 
         // --- (d) `dyn Trait` / (f) raw pointers in the SIGNATURE --------------------
         // Walk every Ty in inputs + output. We use a Ty-only visitor so we descend
         // into nested generic positions (e.g. `Box<dyn Trait>`, `&*const T`).
         for input in decl.inputs {
-            check_signature_ty(cx, input);
+            check_signature_ty(cx, &hits, input);
         }
         if let rustc_hir::FnRetTy::Return(ret) = decl.output {
-            check_signature_ty(cx, ret);
+            check_signature_ty(cx, &hits, ret);
         }
 
         // --- body walk: (a) unsafe blocks, (b) async blocks, (c) closures,
         //                 (e) FFI calls, (f) inline asm ----------------------------
-        let mut v = BodyScreen { cx };
+        let mut v = BodyScreen { cx, hits: &hits };
         v.visit_body(body);
+
+        // --- receipt emission (only when configured) --------------------------------
+        if self.config.emit_receipts {
+            self.record_receipt(cx, def_id, span, hits.into_inner());
+        }
+    }
+
+    // Crate-end hook: flush all accumulated receipts to disk, signed. LateLintPass
+    // provides `check_crate_post` as the post-traversal crate-end hook.
+    fn check_crate_post(&mut self, _cx: &LateContext<'tcx>) {
+        if !self.config.emit_receipts {
+            return;
+        }
+        if let Err(e) = self.flush_receipts() {
+            // Fail LOUD: a misconfigured signer must not silently drop receipts.
+            panic!("nucleus_guarantee_lint: failed to flush guarantee receipts: {e}");
+        }
     }
 }
 
+impl AeneasEligible {
+    /// Build a receipt for one screened function and stash it in `pending`. Reads the
+    /// v0 `normalized_source` from the function's HIR span (whitespace-sensitive; see
+    /// `receipt` module docs for the v1 TODO).
+    fn record_receipt(
+        &self,
+        cx: &LateContext<'_>,
+        def_id: LocalDefId,
+        span: Span,
+        hits: Vec<Hit>,
+    ) {
+        let item_path = cx.tcx.def_path_str(def_id.to_def_id());
+        let item_kind = cx.tcx.def_descr(def_id.to_def_id()).to_string();
+
+        // v0 normalized_source = the raw source snippet of the fn from its HIR span.
+        // If the snippet is unavailable (macro-generated, no source map), skip the
+        // receipt rather than hash an empty/placeholder string (no fake anchors).
+        let Some(normalized_source) = snippet_opt(cx, span) else {
+            return;
+        };
+
+        let toolchain = resolve_toolchain();
+        let failed_rules: Vec<&str> = {
+            let mut v: Vec<&str> = hits.iter().map(|h| h.rule).collect();
+            v.sort_unstable();
+            v.dedup();
+            v
+        };
+        let reasons: Vec<String> = hits.iter().map(|h| h.reason.clone()).collect();
+
+        let receipt = Receipt::build(
+            item_path,
+            item_kind,
+            &normalized_source,
+            &toolchain,
+            PROFILE_ID,
+            &failed_rules,
+            reasons,
+        );
+        self.pending.borrow_mut().push(receipt);
+    }
+
+    /// Load the signing key (fail-loud on a bad/missing key — NEVER a zero key), then
+    /// write `<receipt_dir>/<anchor_hash>.{json,sig}` for each pending receipt.
+    fn flush_receipts(&self) -> Result<(), String> {
+        let pending = self.pending.borrow();
+        if pending.is_empty() {
+            return Ok(());
+        }
+
+        if self.config.signing_key_path.trim().is_empty() {
+            return Err(
+                "emit_receipts = true but signing_key_path is empty; refusing to emit \
+                 unsigned receipts (set a 32-byte ed25519 key path)"
+                    .to_string(),
+            );
+        }
+        let key_bytes = std::fs::read(&self.config.signing_key_path).map_err(|e| {
+            format!("could not read signing_key_path '{}': {e}", self.config.signing_key_path)
+        })?;
+        let key = load_signing_key(&key_bytes)
+            .map_err(|e| format!("invalid signing key at '{}': {e}", self.config.signing_key_path))?;
+
+        let dir = if self.config.receipt_dir.trim().is_empty() {
+            PathBuf::from("target/guarantee-receipts")
+        } else {
+            PathBuf::from(&self.config.receipt_dir)
+        };
+        std::fs::create_dir_all(&dir)
+            .map_err(|e| format!("could not create receipt_dir '{}': {e}", dir.display()))?;
+
+        for receipt in pending.iter() {
+            let (json, sig) = receipt
+                .sign(&key)
+                .map_err(|e| format!("failed to sign receipt {}: {e}", receipt.anchor_hash))?;
+            let base = dir.join(&receipt.anchor_hash);
+            std::fs::write(base.with_extension("json"), &json)
+                .map_err(|e| format!("write receipt json failed: {e}"))?;
+            // Signature as lowercase hex (matches the hex anchor_hash convention).
+            std::fs::write(base.with_extension("sig"), hex::encode(sig.to_bytes()))
+                .map_err(|e| format!("write receipt sig failed: {e}"))?;
+        }
+        Ok(())
+    }
+}
+
+/// One screen hit: the canonical rule name (one of `receipt::SCREENED_RULES`) plus the
+/// human-readable reason that is also shown in the diagnostic.
+struct Hit {
+    rule: &'static str,
+    reason: String,
+}
+
 /// Walk a single signature `Ty` for `dyn` and raw pointers (Research 2, §d, §f).
-fn check_signature_ty<'tcx>(cx: &LateContext<'tcx>, ty: &'tcx Ty<'tcx>) {
-    let mut v = SigTyScreen { cx };
+fn check_signature_ty<'tcx>(cx: &LateContext<'tcx>, hits: &RefCell<Vec<Hit>>, ty: &'tcx Ty<'tcx>) {
+    let mut v = SigTyScreen { cx, hits };
     v.visit_ty_unambig(ty);
 }
 
 struct SigTyScreen<'a, 'tcx> {
     cx: &'a LateContext<'tcx>,
+    hits: &'a RefCell<Vec<Hit>>,
 }
 
 impl<'a, 'tcx> Visitor<'tcx> for SigTyScreen<'a, 'tcx> {
@@ -171,12 +351,24 @@ impl<'a, 'tcx> Visitor<'tcx> for SigTyScreen<'a, 'tcx> {
                 // On nightly-2026-04-16, TraitObjectSyntax = { Dyn, None } (no DynStar;
                 // Research 2 listed DynStar but it is absent on this pinned channel).
                 if matches!(tagged.tag(), TraitObjectSyntax::Dyn) {
-                    report(self.cx, ty.span, "a `dyn Trait` trait object in the signature");
+                    report_and_record(
+                        self.cx,
+                        self.hits,
+                        ty.span,
+                        "no_dyn_in_sig",
+                        "a `dyn Trait` trait object in the signature",
+                    );
                 }
             }
             // Raw pointer: TyKind::Ptr(MutTy) — distinct from TyKind::Ref (Research 2, §f).
             TyKind::Ptr(_) => {
-                report(self.cx, ty.span, "a raw pointer (`*const`/`*mut`) in the signature");
+                report_and_record(
+                    self.cx,
+                    self.hits,
+                    ty.span,
+                    "no_raw_ptr",
+                    "a raw pointer (`*const`/`*mut`) in the signature",
+                );
             }
             _ => {}
         }
@@ -186,6 +378,7 @@ impl<'a, 'tcx> Visitor<'tcx> for SigTyScreen<'a, 'tcx> {
 
 struct BodyScreen<'a, 'tcx> {
     cx: &'a LateContext<'tcx>,
+    hits: &'a RefCell<Vec<Hit>>,
 }
 
 impl<'a, 'tcx> Visitor<'tcx> for BodyScreen<'a, 'tcx> {
@@ -197,32 +390,56 @@ impl<'a, 'tcx> Visitor<'tcx> for BodyScreen<'a, 'tcx> {
                     block.rules,
                     BlockCheckMode::UnsafeBlock(UnsafeSource::UserProvided)
                 ) {
-                    report(self.cx, expr.span, "a user-written `unsafe { }` block");
+                    report_and_record(
+                        self.cx,
+                        self.hits,
+                        expr.span,
+                        "no_unsafe",
+                        "a user-written `unsafe { }` block",
+                    );
                 }
             }
             // (b)/(c) closures share ExprKind::Closure; ClosureKind distinguishes
             // plain closures from async/gen-block desugarings (Research 2, §b, §c).
             ExprKind::Closure(closure) => match closure.kind {
                 ClosureKind::Closure => {
-                    report(self.cx, expr.span, "a closure");
+                    report_and_record(self.cx, self.hits, expr.span, "no_closures", "a closure");
                 }
                 ClosureKind::Coroutine(CoroutineKind::Desugared(
                     CoroutineDesugaring::Async,
                     _,
                 )) => {
-                    report(self.cx, expr.span, "an `async` block");
+                    report_and_record(self.cx, self.hits, expr.span, "no_async", "an `async` block");
                 }
                 ClosureKind::CoroutineClosure(CoroutineDesugaring::Async) => {
-                    report(self.cx, expr.span, "an `async` closure");
+                    report_and_record(
+                        self.cx,
+                        self.hits,
+                        expr.span,
+                        "no_async",
+                        "an `async` closure",
+                    );
                 }
                 // Other coroutines (gen / async-gen) — default-deny as out-of-subset.
                 _ => {
-                    report(self.cx, expr.span, "a coroutine (gen/async block or closure)");
+                    report_and_record(
+                        self.cx,
+                        self.hits,
+                        expr.span,
+                        "no_closures",
+                        "a coroutine (gen/async block or closure)",
+                    );
                 }
             },
             // (f) inline assembly — no functional model (Research 2, §f).
             ExprKind::InlineAsm(_) => {
-                report(self.cx, expr.span, "inline assembly (`asm!`)");
+                report_and_record(
+                    self.cx,
+                    self.hits,
+                    expr.span,
+                    "no_inline_asm",
+                    "inline assembly (`asm!`)",
+                );
             }
             // (e) FFI / extern call: resolve callee DefId and test is_foreign_item.
             // fn_def_id covers both Call and MethodCall (Research 2, §e).
@@ -230,7 +447,13 @@ impl<'a, 'tcx> Visitor<'tcx> for BodyScreen<'a, 'tcx> {
                 if let Some(did) = fn_def_id(self.cx, expr)
                     && self.cx.tcx.is_foreign_item(did)
                 {
-                    report(self.cx, expr.span, "a call to an FFI / `extern` foreign item");
+                    report_and_record(
+                        self.cx,
+                        self.hits,
+                        expr.span,
+                        "no_ffi_call",
+                        "a call to an FFI / `extern` foreign item",
+                    );
                 }
             }
             _ => {}
@@ -262,25 +485,38 @@ fn report(cx: &LateContext<'_>, span: Span, what: &str) {
     );
 }
 
+/// Emit the diagnostic AND record the canonical `rule` + `reason` for the enclosing fn's
+/// receipt. The diagnostic text is unchanged from `report`, so the UI snapshot stays
+/// byte-identical whether or not receipts are enabled.
+fn report_and_record(
+    cx: &LateContext<'_>,
+    hits: &RefCell<Vec<Hit>>,
+    span: Span,
+    rule: &'static str,
+    what: &str,
+) {
+    report(cx, span, what);
+    hits.borrow_mut().push(Hit {
+        rule,
+        reason: what.to_string(),
+    });
+}
+
 // ============================================================================
-// TODO(guarantee-receipt): future-pass hook — SCREEN ONLY for now.
+// guarantee-receipt: IMPLEMENTED (v0). See the `receipt` module + `check_fn`/
+// `check_crate_post` above. When `emit_receipts = true` in dylint.toml, each screened
+// fn yields a signed per-hash receipt at `<receipt_dir>/<anchor_hash>.{json,sig}`.
 //
-// This scaffold is the SCREEN. A future LateLintPass (or a post-build StableMIR
-// pass) would, for each function that PASSES the screen, compute a stable digest
-// and emit a *signed per-hash guarantee receipt*:
+//     anchor_hash = SHA-256( b"nucleus.guarantee-receipt.v0"
+//                            ‖ normalized_source ‖ toolchain ‖ profile_id )
 //
-//     receipt = sign(
-//         body_hash   = hash(StableMIR body  OR  rustfmt-normalized source),
-//         toolchain   = "nightly-2026-04-16",          // from rust-toolchain.toml
-//         profile     = <aeneas/charon commit + backend + flags>,
-//         screen      = "aeneas_eligible@<this-crate-version>",
-//     )
+// The receipt certifies ONLY "the screen returned this result for this (source,
+// toolchain, profile) hash" — NOT "is extractable" and NOT "is correct" (see the
+// `receipt` module-level HONESTY docs).
 //
-// The receipt must record that it certifies ONLY "passed the screen under <toolchain,
-// profile>", NOT "is extractable" and NOT "is correct". Hashing options (Research 2,
-// "Span + snippet for hashing"): SpanRangeExt::with_source_text for source hashing, or
-// clippy_utils::hash_expr / SpanlessHash for a reformat-robust structural hash; prefer
-// StableMIR for toolchain-stable semantics once that hook is wired.
+// v0 `normalized_source` = the raw HIR-span source snippet (clippy_utils::source::
+// snippet_opt) — WHITESPACE-SENSITIVE. v1 TODO: switch to a reformat-robust anchor
+// (rustfmt-normalized source, or a StableMIR-body hash) for toolchain-stable semantics.
 // ============================================================================
 
 // TODO(deny-set): the following Research-3 deny-set rows are NOT yet screened and are


### PR DESCRIPTION
## ⛔ HELD — review the signing before merge

Rec B: extends `tools/nucleus-guarantee-lint` to emit **ed25519-signed, per-hash guarantee receipts** for the `aeneas_eligible` screen — the bottom rung of the trust ladder, content-addressed and fail-closed.

## What it adds
- **`receipt/` — a pure, no-rustc crate** (`nucleus_guarantee_receipt`): build / canonicalize (RFC 8785 JCS) / sign / verify, plus `verify-guarantee-receipt` (holder CLI) and `receipts-to-csv` (olog projector). **13/13 tests pass on stable Rust** (verified locally, independent of the nightly lint).
- **Lint wiring** (`src/lib.rs`): `impl_late_lint!` + `Config{emit_receipts, receipt_dir, signing_key_path}` (via `dylint_linting::config_or_default`); collects hits per fn, signs + flushes receipts in `check_crate_post`. Diagnostics unchanged.

## Receipt (schema 0, JCS-canonical, signed)
```
anchor_hash = SHA-256( b"nucleus.guarantee-receipt.v0" ‖ normalized_source ‖ toolchain ‖ profile_id )
{ schema_version, item_path, item_kind, anchor_hash, toolchain, profile_id, result, ineligible_reasons, guarantees }
```
Written as `<receipt_dir>/<anchor_hash>.json` + `.sig`.

## Honesty (enforced, not just documented)
- A receipt attests **the screen result at one exact (source, toolchain, profile) hash — NOT a proof** of extractability or correctness. Change a byte → hash changes → receipt void (fail-closed).
- **Toolchain-relative** (records the exact rustc).
- Unscreened deny-set rows (floats / nested-loops / non-`Vec` collections / iterator-combinators) are carried as `"not_screened"` — **never `"pass"`** — so a clean receipt can't be misread as "in-subset."
- Signing key: read from `signing_key_path` (raw-32 or hex-64); **no zero/fake-key fallback** — invalid key is a hard error. No keys committed (test keys generated in-test only).
- v0 caveat (documented): `normalized_source` is the raw HIR-span snippet (whitespace-sensitive); v1 TODO = rustfmt-normalized or StableMIR-body anchor. Hash preimage isn't length-prefixed (v1 hardening TODO).

## Test status (honest)
- **Green here:** the `receipt` crate (11 unit + 2 integration), the lint cdylib compiles with the wiring, a manual CLI roundtrip (sign → verify ✓ → wrong-source/tampered → reject ✓), olog TOML structural validation.
- **Blocked here:** the `dylint_testing` UI snapshot run (env `dlopen`/dylint-link, pre-existing — a clean copy of the original crate fails identically). Repro commands in the README.

## Companion (not pushed)
olog ingestion is committed locally on `olog@feat/guarantee-receipt-ingestion`: a `GuaranteeReceipt` object (csv source via `receipts-to-csv`) + `attests_function` arrow + `lint_attested` documented as the **weakest** `ExtractionStatus` tier. Shown for review; I'll push it on your word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)