### PR TITLE
chore(lean): register catkb-cited proof libs as build targets (DoD B4/B5)

### DIFF
--- a/crates/portcullis-core/lean/lakefile.lean
+++ b/crates/portcullis-core/lean/lakefile.lean
@@ -80,6 +80,19 @@ lean_lib «DerivationProofs» where
 lean_lib «IFCSemilatticeProofs» where
   roots := #[`IFCSemilatticeProofs]
 
+-- Register the remaining categorical-proof modules as build targets so the
+-- olog catkb audit can resolve `#print axioms` and run the leanchecker
+-- second-kernel re-check against their built oleans (DoD B4/B5). These hold
+-- PROVEN theorems the KB cites (category / delegation-category / Galois).
+lean_lib «CategoryProofs» where
+  roots := #[`CategoryProofs]
+
+lean_lib «DelegationCategoryProofs» where
+  roots := #[`DelegationCategoryProofs]
+
+lean_lib «GaloisConnectionProofs» where
+  roots := #[`GaloisConnectionProofs]
+
 -- Semantic IFC: Galois connection on propositions, channel model, soundness
 lean_lib «SemanticIFC» where
   roots := #[`SemanticIFC]


### PR DESCRIPTION
Registers `CategoryProofs`, `DelegationCategoryProofs`, `GaloisConnectionProofs` as `lean_lib` build targets in `crates/portcullis-core/lean/lakefile.lean`.

These hold PROVEN theorems the olog catkb cites (entries CD03/DG41/GC55). Without a registered target, the catkb audit can't build their oleans, so the leanchecker second-kernel re-check + `#print axioms` can't run against them — they'd fail the new `--strict` B4/B5 gate. Mirrors the existing `IFCSemilatticeProofs` stanza; **no proof changes**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)