### PR TITLE
docs: 90-second hooks (just demo + The Vault) + ctf-engine README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,29 @@ On top of that core, Nucleus adds three newer pillars — a **Constitutional Ker
 
 ---
 
+## See it in 90 seconds
+
+Two runnable hooks, nothing to configure ([`just`](https://github.com/casey/just), or run the commands directly):
+
+```sh
+just demo     # 30s, in your terminal — information-flow control, 4 scenarios
+just vault    # play "The Vault" in your browser
+```
+
+**`just demo`** (`cargo run -p nucleus-ifc --example ifc_demo`) — a prompt-injection write is **denied by adversarial *ancestry***, not by a classifier guessing at strings; a clean flow is allowed; a compartment transition clears taint; a deterministic bind excludes the model from the trust decision:
+
+```
+─ Scenario 1: Web injection blocked ─
+  ModelPlan inherits Adversarial from WebContent
+  ✗ Write DENIED — adversarial ancestry detected
+─ Scenario 2: Clean workflow allowed ─
+  ✓ Write ALLOWED — clean ancestry
+```
+
+**`just vault`** launches [**The Vault**](crates/ctf-engine/README.md) — a browser CTF where you try to exfiltrate a secret past a formally-verified permission lattice (Verus-proof-backed verdicts). Hosted at **https://nucleus-ctf.fly.dev**; point an LLM at its JSON/MCP API and watch it fail too.
+
+---
+
 ## Quick Start
 
 ```bash

--- a/crates/ctf-engine/README.md
+++ b/crates/ctf-engine/README.md
@@ -1,0 +1,62 @@
+# The Vault — Nucleus CTF
+
+A browser-native capture-the-flag where you try to **exfiltrate a secret past a
+formally-verified permission lattice — and can't.** Each level loads a real
+`portcullis::PermissionLattice` profile and tracks exposure with the same
+`ExposureSet` production nucleus uses; verdicts are backed by Verus SMT proofs.
+It runs entirely in WASM (the game logic is client-side).
+
+It's the thesis made playable: *agent security is an information-flow problem, and
+the boundary can be **proven**, not guessed.*
+
+## Play it locally (90 seconds)
+
+```sh
+just vault              # serves the pre-built WASM and opens your browser
+# or, without `just`:
+cd crates/ctf-engine/dist && python3 -m http.server 8799   # → http://127.0.0.1:8799
+```
+
+Hosted instance: **https://nucleus-ctf.fly.dev**
+
+## Point an AI at it (the fun part)
+
+`ctf-server` exposes a JSON API + an MCP endpoint so an LLM (ChatGPT, Gemini, an
+agent) can attempt the challenge programmatically — and fail the same way:
+
+```
+GET  /api/v1/levels            list levels
+GET  /api/v1/levels/{level}    level detail
+POST /api/v1/attack            submit an exfiltration attempt
+POST /api/v1/challenge         run a full challenge
+GET  /api                      API docs   ·   GET /openapi.json
+/mcp                           MCP (streamable-http) for agent clients
+```
+
+`ctf-server` serves the built site from `/public` (a container path) — that path
+is for the Docker/Fly deployment, **not** local dev. For local play use `just
+vault` (pre-built) or `trunk serve` (fresh, once the build below is fixed).
+
+## Building from source
+
+⚠️ **A fresh `trunk build` / `trunk serve` currently fails.** Honest root cause:
+`portcullis::kernel` is always compiled (`pub mod kernel`, ungated) but imports
+the `crypto`-feature-gated modules `certificate`, `token`, and `delegation`
+(`portcullis/src/kernel.rs`), while this crate depends on portcullis with
+`default-features = false, features = ["serde"]` (no `crypto`) to keep the WASM
+build clean. So `cargo build --target wasm32-unknown-unknown --features wasm`
+errors with `unresolved import crate::certificate / crate::token / delegation`.
+
+Fix options (a real portcullis change, not a CTF change — pick one):
+1. **cfg-gate the kernel's crypto deps** — make `kernel`'s `certificate`/`token`/
+   `delegation` uses `#[cfg(feature = "crypto")]`, or split a crypto-free kernel
+   path, so portcullis builds without `crypto`. (Cleanest; keeps the WASM small.)
+2. **Enable `crypto` for the wasm build** in this crate — requires wiring
+   `getrandom`'s `js` feature and confirming ed25519 deps compile to
+   `wasm32-unknown-unknown`. (Heavier WASM; may surface more wasm-compat work.)
+
+Until that lands, the committed `dist/` is the source of truth for the playable
+build, and `just vault` serves it. **Do not assume `dist/` is in sync with `src/`
+until the fresh build is restored.**
+
+Prereqs once fixed: `cargo install trunk` + `rustup target add wasm32-unknown-unknown`.

--- a/justfile
+++ b/justfile
@@ -1,0 +1,32 @@
+# nucleus — dev recipes.  `just <recipe>`  (https://github.com/casey/just)
+
+# List recipes.
+default:
+    @just --list
+
+# ── The 90-second hooks ──────────────────────────────────────────────────────
+
+# 30s: IFC in 4 scenarios — watch a prompt-injection write get DENIED by ancestry.
+demo:
+    cargo run -q -p nucleus-ifc --example ifc_demo
+
+# Play "The Vault": exfiltrate a secret past a formally-verified lattice (browser/WASM).
+vault port="8799":
+    @echo "The Vault → http://127.0.0.1:{{port}}   (serving pre-built WASM; Ctrl-C to stop)"
+    @( sleep 1 ; command -v open >/dev/null 2>&1 && open "http://127.0.0.1:{{port}}" || command -v xdg-open >/dev/null 2>&1 && xdg-open "http://127.0.0.1:{{port}}" || true ) &
+    cd crates/ctf-engine/dist && python3 -m http.server {{port}}
+
+# Rebuild The Vault WASM from source then serve (needs the wasm build fix — see ctf-engine/README).
+vault-fresh:
+    cd crates/ctf-engine && trunk serve --open
+
+# ── Everyday ─────────────────────────────────────────────────────────────────
+
+# Run the test suite.
+test:
+    cargo test --all-features
+
+# Format + lint gate (matches CI).
+check:
+    cargo fmt --all -- --check
+    cargo clippy --all-targets --all-features -- -D warnings


### PR DESCRIPTION
Makes the thesis runnable in 90 seconds.

- **`justfile`** — `just demo` (`cargo run -p nucleus-ifc --example ifc_demo`; verified: a prompt-injection write is **denied by adversarial ancestry**, +3 scenarios) and `just vault` (serves the pre-built WASM CTF + opens the browser; verified: HTTP 200, "The Vault — Nucleus CTF"). Plus `test`/`check`.
- **`crates/ctf-engine/README.md`** — how to play The Vault locally, the hosted fly.dev instance, and the JSON/MCP API for pointing an LLM at it.
- **README** — a "See it in 90 seconds" section with both hooks + sample output.

**Honest note (documented, not hidden):** a fresh `trunk build` of `ctf-engine` currently fails — `portcullis::kernel` (ungated `pub mod kernel`) imports the `crypto`-gated `certificate`/`token`/`delegation` modules while `ctf-engine` builds portcullis without `crypto`. The ctf-engine README gives the two real fix options; `just vault` serves the committed pre-built `dist/` meanwhile. No security-core code changed here.