### PR TITLE
docs: name the lethal trifecta + non-interference in the README hero

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 At its core is a small, dependency-free information-flow algebra. Two primitives — `join` and `flows_to` — enforce information-flow control under four algebraic laws. Once untrusted web content enters a session, it cannot silently reach a privileged sink like `git push`. That property is [machine-checked](FORMAL_METHODS.md), not hoped.
 
+This is the **[lethal trifecta](https://simonwillison.net/2025/Jun/16/the-lethal-trifecta/)** — private data + untrusted content + an exfiltration sink — made safe by **non-interference**: attacker-tainted data cannot reach a consequential action, so a compromised agent cannot be turned into a *confused deputy*. We don't *detect* the prompt injection; we make its consequence impossible — and prove it. (Detection-based guardrails are probabilistic; this is a structural guarantee.)
+
 ```rust
 let mut state = FlowState::bottom();           // clean session
 state.join_operation(Operation::WebFetch);     // tainted by web content


### PR DESCRIPTION
Copy pass (no new claims): the hero already described the mechanism; this names the **lethal trifecta** made safe by **non-interference** (attacker-tainted data can't reach a consequential action → no confused deputy), and frames it against probabilistic detection. Anchors the OSS positioning on the dominant 2026 mental model.