### PR TITLE
fix(ctf-server): bump Docker builder to rust:1-slim (workspace floor is 1.95)

### DIFF
--- a/crates/ctf-server/Dockerfile
+++ b/crates/ctf-server/Dockerfile
@@ -3,7 +3,10 @@
 # The WASM site (crates/ctf-engine/dist/) is built locally with Trunk
 # and committed. This Dockerfile only builds the native API server.
 
-FROM rust:1.88-slim AS builder
+# Builder image must satisfy the workspace `rust-version = 1.95` floor
+# (portcullis et al. reject older toolchains). `rust:1-slim` tracks the
+# latest stable 1.x — bump explicitly if a newer floor is set.
+FROM rust:1-slim AS builder
 WORKDIR /build
 COPY . .
 RUN cargo build --release -p ctf-server


### PR DESCRIPTION
The `ctf-server` Dockerfile builder was pinned to `rust:1.88-slim`, predating the workspace `rust-version = 1.95` bump — a fresh `fly deploy` build would fail portcullis' toolchain check. Track latest stable 1.x.

Already deployed to nucleus-ctf.fly.dev and verified live: the served bundle carries the chrono `wasmbind` fix, the "time not implemented" panic is gone, `/api/v1/levels` is healthy. This PR lands the Dockerfile change so the next deploy reproduces.

The chrono `wasmbind` fix + rebuilt WASM `dist` already merged via #1678.

🤖 Generated with [Claude Code](https://claude.com/claude-code)