### PR TITLE
refactor(lineage): rename `dev` feature to `insecure-local-issuer` (#1635)

### DIFF
--- a/crates/nucleus-agent-card/Cargo.toml
+++ b/crates/nucleus-agent-card/Cargo.toml
@@ -36,7 +36,7 @@ sign = []
 [dev-dependencies]
 # `dev` feature on nucleus-lineage gives the integration test the
 # in-process LocalIssuer + InMemorySink it needs to build a real Bundle.
-nucleus-lineage = { path = "../nucleus-lineage", features = ["dev"] }
+nucleus-lineage = { path = "../nucleus-lineage", features = ["insecure-local-issuer"] }
 # P-256 keypair generation for the sign/verify unit + integration tests.
 ring = { workspace = true }
 

--- a/crates/nucleus-bundle-cas/Cargo.toml
+++ b/crates/nucleus-bundle-cas/Cargo.toml
@@ -35,7 +35,7 @@ anyhow = { workspace = true }
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 # `dev` enables LocalIssuer/InMemorySink for building real signed test bundles.
-nucleus-lineage = { path = "../nucleus-lineage", features = ["dev"] }
+nucleus-lineage = { path = "../nucleus-lineage", features = ["insecure-local-issuer"] }
 nucleus-envelope = { path = "../nucleus-envelope" }
 
 [lints]

--- a/crates/nucleus-control-plane-server/Cargo.toml
+++ b/crates/nucleus-control-plane-server/Cargo.toml
@@ -14,7 +14,7 @@ name = "nucleus-control-plane-server"
 path = "src/main.rs"
 
 [dependencies]
-nucleus-lineage = { path = "../nucleus-lineage", features = ["dev"] }
+nucleus-lineage = { path = "../nucleus-lineage", features = ["insecure-local-issuer"] }
 nucleus-envelope = { path = "../nucleus-envelope" }
 nucleus-control-plane = { path = "../nucleus-control-plane" }
 nucleus-oidc-core = { path = "../nucleus-oidc-core" }

--- a/crates/nucleus-control-plane/Cargo.toml
+++ b/crates/nucleus-control-plane/Cargo.toml
@@ -19,7 +19,7 @@ chrono = { workspace = true, features = ["serde"] }
 uuid = { workspace = true, features = ["v4", "serde"] }
 
 [dev-dependencies]
-nucleus-lineage = { path = "../nucleus-lineage", features = ["dev"] }
+nucleus-lineage = { path = "../nucleus-lineage", features = ["insecure-local-issuer"] }
 tempfile = { workspace = true }
 
 [lints]

--- a/crates/nucleus-envelope-adversarial-corpus/Cargo.toml
+++ b/crates/nucleus-envelope-adversarial-corpus/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/lib.rs"
 
 [dependencies]
 nucleus-envelope = { path = "../nucleus-envelope" }
-nucleus-lineage = { path = "../nucleus-lineage", features = ["dev"] }
+nucleus-lineage = { path = "../nucleus-lineage", features = ["insecure-local-issuer"] }
 ed25519-dalek = "=3.0.0-pre.7"
 serde_json = { workspace = true }
 hex = { workspace = true }

--- a/crates/nucleus-envelope/Cargo.toml
+++ b/crates/nucleus-envelope/Cargo.toml
@@ -34,7 +34,7 @@ default = []
 c2pa = ["dep:c2pa"]
 
 [dev-dependencies]
-nucleus-lineage = { path = "../nucleus-lineage", features = ["dev"] }
+nucleus-lineage = { path = "../nucleus-lineage", features = ["insecure-local-issuer"] }
 tempfile = { workspace = true }
 
 [lints]

--- a/crates/nucleus-lineage/Cargo.toml
+++ b/crates/nucleus-lineage/Cargo.toml
@@ -15,7 +15,14 @@ default = []
 # PRODUCTION USE. Production callers should write a SPIFFE-Workload-API-
 # backed `IdentityFetcher` impl and never enable this feature in release
 # builds. Verification (always-on) does NOT need this feature.
-dev = ["dep:jsonwebtoken", "dep:rand", "ed25519-dalek/alloc", "ed25519-dalek/pkcs8", "ed25519-dalek/rand_core"]
+#
+# Named `insecure-local-issuer` so the footgun is visible at every consumer's
+# `[dependencies]` line (the old ergonomic name `dev` invited "just for tests"
+# enablement that could ship). `dev` is kept as a transitional alias for one
+# release — see CHANGELOG; remove after downstreams migrate.
+insecure-local-issuer = ["dep:jsonwebtoken", "dep:rand", "ed25519-dalek/alloc", "ed25519-dalek/pkcs8", "ed25519-dalek/rand_core"]
+# DEPRECATED alias for `insecure-local-issuer`. Remove next release.
+dev = ["insecure-local-issuer"]
 # HTTP-backed WitnessClient (nucleus-native cosign protocol + C2SP
 # tlog-witness adapter for federation with the external ecosystem).
 # Off by default to keep the lib's dep tree lean.
@@ -59,7 +66,7 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [[example]]
 name = "three_step_demo"
-required-features = ["dev"]
+required-features = ["insecure-local-issuer"]
 
 [lints]
 workspace = true

--- a/crates/nucleus-lineage/src/lib.rs
+++ b/crates/nucleus-lineage/src/lib.rs
@@ -21,10 +21,11 @@
 //!
 //! # Cargo features
 //!
-//! - `dev` *(non-default)* — enables the in-process [`LocalIssuer`]
-//!   demo JWT-SVID minter + edge signer. Pulls in `jsonwebtoken`, `rand`, and
-//!   the `pkcs8` + `rand_core` features of `ed25519-dalek`. **Do not enable
-//!   in production.**
+//! - `insecure-local-issuer` *(non-default)* — enables the in-process
+//!   [`LocalIssuer`] demo JWT-SVID minter + edge signer. Pulls in
+//!   `jsonwebtoken`, `rand`, and the `pkcs8` + `rand_core` features of
+//!   `ed25519-dalek`. **Do not enable in production.** (`dev` is a deprecated
+//!   alias kept for one release.)
 //!
 //! Verification (the [`verify`] module) is always available — production
 //! callers reading lineage logs need exactly this surface.
@@ -48,7 +49,7 @@ pub mod verify;
 // crates (nucleus-envelope) don't need to depend on ct-merkle directly.
 pub use ct_merkle::{ConsistencyProof, InclusionProof, InclusionVerifError, RootHash};
 
-#[cfg(feature = "dev")]
+#[cfg(feature = "insecure-local-issuer")]
 pub mod local_issuer;
 
 pub use checkpoint::{
@@ -73,5 +74,5 @@ pub use signed_note::{
 pub use sink::{InMemorySink, JsonlSink, LineageSink, SinkError};
 pub use verify::{verify_chain, verify_proof, Jwk, Jwks, StaticKeyResolver, VerifyError};
 
-#[cfg(feature = "dev")]
+#[cfg(feature = "insecure-local-issuer")]
 pub use local_issuer::LocalIssuer;

--- a/crates/nucleus-lineage/src/local_issuer.rs
+++ b/crates/nucleus-lineage/src/local_issuer.rs
@@ -1,7 +1,8 @@
 //! [`LocalIssuer`] — in-process Ed25519 JWT-SVID issuer for tests and demos.
 //!
-//! **NOT FOR PRODUCTION USE.** This module is gated behind the `dev` cargo
-//! feature (`nucleus-lineage = { features = ["dev"] }`) so production
+//! **NOT FOR PRODUCTION USE.** This module is gated behind the
+//! `insecure-local-issuer` cargo feature
+//! (`nucleus-lineage = { features = ["insecure-local-issuer"] }`) so production
 //! binaries cannot link or re-export it. Constructing an instance also logs
 //! a one-time `tracing::warn!` so any accidental use is immediately visible
 //! in logs.

--- a/crates/nucleus-lineage/src/verify.rs
+++ b/crates/nucleus-lineage/src/verify.rs
@@ -243,7 +243,7 @@ impl Default for StaticKeyResolver {
 }
 
 #[cfg(test)]
-#[cfg(feature = "dev")]
+#[cfg(feature = "insecure-local-issuer")]
 mod tests {
     use super::*;
     use crate::edge::{EdgeKind, LineageEdge};

--- a/crates/nucleus-lineage/tests/c2sp_http_witness.rs
+++ b/crates/nucleus-lineage/tests/c2sp_http_witness.rs
@@ -9,7 +9,7 @@
 //!
 //! Requires `--features http,dev`.
 
-#![cfg(all(feature = "http", feature = "dev"))]
+#![cfg(all(feature = "http", feature = "insecure-local-issuer"))]
 
 use std::sync::Arc;
 use std::time::Duration;

--- a/crates/nucleus-lineage/tests/http_witness.rs
+++ b/crates/nucleus-lineage/tests/http_witness.rs
@@ -5,7 +5,7 @@
 //!
 //! Requires `--features http,dev`.
 
-#![cfg(all(feature = "http", feature = "dev"))]
+#![cfg(all(feature = "http", feature = "insecure-local-issuer"))]
 
 use std::time::Duration;
 

--- a/crates/nucleus-verifier-service/Cargo.toml
+++ b/crates/nucleus-verifier-service/Cargo.toml
@@ -45,7 +45,7 @@ tokio-util = { version = "0.7", features = ["rt"] }
 [dev-dependencies]
 tower = { version = "0.5", features = ["util", "limit"] }
 http-body-util = "0.1"
-nucleus-lineage = { path = "../nucleus-lineage", features = ["dev"] }
+nucleus-lineage = { path = "../nucleus-lineage", features = ["insecure-local-issuer"] }
 nucleus-control-plane = { path = "../nucleus-control-plane" }
 # `sign` lets the route test mint a SignedAgentCard to seed AppState.
 nucleus-agent-card = { path = "../nucleus-agent-card", features = ["sign"] }


### PR DESCRIPTION
**Tier 2 / MED-1** ([#1626](https://github.com/coproduct-opensource/nucleus/issues/1626) / roadmap [#1624](https://github.com/coproduct-opensource/nucleus/issues/1624)).

The `dev` feature gates the in-process `LocalIssuer` (demo JWT-SVID minter + edge signer) — **not for production**. The ergonomic name invited "just for tests" enablement that could ship.

- `insecure-local-issuer = [...]` is now the real feature; `dev = ["insecure-local-issuer"]` is a deprecated transitional alias (one release).
- Internal `#[cfg(feature = "dev")]` gates + docstrings updated to the new name.
- All 7 internal consumers + the example `required-features` switched over. External consumers keep working via the alias.

Verified: builds with the new name, the `dev` alias, and a downstream consumer. Closes #1635.

🤖 Generated with [Claude Code](https://claude.com/claude-code)