### PR TITLE
feat(ifc): wire FlowTracker into the Rust MCP runtime (#1633)

### DIFF
--- a/crates/nucleus-ifc/src/lib.rs
+++ b/crates/nucleus-ifc/src/lib.rs
@@ -4,6 +4,14 @@
 //! through your agent, detect taint from untrusted sources, and block
 //! unsafe actions at the data level — not just the capability level.
 //!
+//! As of #1633 this is wired into the live Rust runtime: the
+//! `nucleus-tool-proxy` MCP server holds a session [`FlowTracker`], observes
+//! the data each tool brings in (`web_fetch` ⇒ `WebContent`, file reads ⇒
+//! `FileRead`), and the kernel consults it via
+//! `Kernel::decide_term_with_flow` — once adversarial (web) content is in the
+//! session, outbound actions are denied with `IfcUnsafe`. This matches the
+//! Python SDK's `observe → check → execute` behavior.
+//!
 //! ## Quick Start
 //!
 //! ```rust

--- a/crates/nucleus-mcp/src/main.rs
+++ b/crates/nucleus-mcp/src/main.rs
@@ -559,6 +559,9 @@ fn format_deny_reason(reason: &DenyReason) -> String {
         } => {
             format!("sink scope denied ({dimension}): {detail}")
         }
+        DenyReason::IfcUnsafe { detail } => {
+            format!("information-flow unsafe: {detail}")
+        }
     }
 }
 

--- a/crates/nucleus-tool-proxy/src/mcp.rs
+++ b/crates/nucleus-tool-proxy/src/mcp.rs
@@ -15,7 +15,9 @@ use std::sync::Arc;
 use portcullis::action_term::ActionTerm;
 use portcullis::kernel::{Kernel, Verdict};
 use portcullis::verdict_sink::{ActorIdentity, VerdictContext, VerdictOutcome, VerdictSink};
-use portcullis::{CapabilityLevel, GradedExposureGuard, Operation, ToolCallGuard};
+use portcullis::{
+    CapabilityLevel, FlowTracker, GradedExposureGuard, NodeKind, Operation, ToolCallGuard,
+};
 use rmcp::{
     handler::server::router::tool::ToolRouter, handler::server::wrapper::Parameters, model::*,
     tool, tool_handler, tool_router, ErrorData as McpError, ServerHandler, ServiceExt,
@@ -127,6 +129,13 @@ pub struct NucleusMcpServer {
     sink: Arc<dyn VerdictSink>,
     /// Kernel decision engine for complete mediation.
     kernel: Arc<tokio::sync::Mutex<Kernel>>,
+    /// Session-scoped information-flow tracker (#1633). Tool entry points
+    /// `observe` the data they bring in (`web_fetch` ⇒ `WebContent`,
+    /// `read`/`glob`/`grep` ⇒ `FileRead`); the kernel consults it via
+    /// `decide_term_with_flow` so that once adversarial (web) content is in the
+    /// session, outbound actions are denied with `IfcUnsafe` — the lethal
+    /// trifecta, enforced in the live Rust runtime (parity with the Python SDK).
+    flow_tracker: Arc<tokio::sync::Mutex<FlowTracker>>,
 }
 
 /// Convert a tool-level error into a CallToolResult error.
@@ -159,6 +168,21 @@ impl NucleusMcpServer {
             guard,
             sink,
             kernel,
+            flow_tracker: Arc::new(tokio::sync::Mutex::new(FlowTracker::new())),
+        }
+    }
+
+    /// Observe a data-ingest node in the session flow tracker (#1633).
+    ///
+    /// Called by input tool entry points after a successful fetch/read so the
+    /// kernel's `decide_term_with_flow` consult sees the taint on subsequent
+    /// outbound actions. Best-effort: observation failure is logged, never
+    /// fatal (a missed observation fails *open* for that one node, but the
+    /// session ceiling from other nodes still applies).
+    async fn observe_flow(&self, kind: NodeKind) {
+        let mut flow = self.flow_tracker.lock().await;
+        if let Err(e) = flow.observe(kind) {
+            warn!(?kind, error = %e, "flow-tracker observe failed");
         }
     }
 
@@ -174,7 +198,12 @@ impl NucleusMcpServer {
     ) -> Result<portcullis::kernel::DecisionToken, CallToolResult> {
         let term = build_action_term(operation, subject);
         let mut kernel = self.kernel.lock().await;
-        let (decision, token) = kernel.decide_term(term);
+        // Consult the session information-flow tracker (#1633): once the
+        // session has ingested adversarial (web) content, outbound operations
+        // are denied with `IfcUnsafe` before the normal decision path.
+        let flow = self.flow_tracker.lock().await;
+        let (decision, token) = kernel.decide_term_with_flow(term, Some(&flow));
+        drop(flow);
         match decision.verdict {
             Verdict::Allow => Ok(token.expect("Allow verdict always produces token")),
             Verdict::Deny(ref reason) => {
@@ -268,6 +297,10 @@ impl NucleusMcpServer {
         }) {
             Ok(contents) => {
                 self.record_verdict(Operation::ReadFiles, &params.path, VerdictOutcome::Allow);
+                // IFC: a file read brings data into the session (Trusted
+                // integrity — does not by itself taint, but contributes to the
+                // confidentiality ceiling). (#1633)
+                self.observe_flow(NodeKind::FileRead).await;
                 Ok(CallToolResult::success(vec![Content::text(contents)]))
             }
             Err(e) => {
@@ -544,6 +577,7 @@ impl NucleusMcpServer {
         }) {
             Ok(paths) => {
                 self.record_verdict(Operation::GlobSearch, &subject, VerdictOutcome::Allow);
+                self.observe_flow(NodeKind::FileRead).await; // (#1633)
                 Ok(CallToolResult::success(vec![Content::text(
                     paths.join("\n"),
                 )]))
@@ -731,6 +765,7 @@ impl NucleusMcpServer {
         }) {
             Ok(matches) => {
                 self.record_verdict(Operation::GrepSearch, &subject, VerdictOutcome::Allow);
+                self.observe_flow(NodeKind::FileRead).await; // (#1633)
                 Ok(CallToolResult::success(vec![Content::text(matches)]))
             }
             Err(e) => {
@@ -938,6 +973,10 @@ impl NucleusMcpServer {
         match self.guard.execute_and_record(proof, || fetch_result) {
             Ok(response) => {
                 self.record_verdict(Operation::WebFetch, &subject, VerdictOutcome::Allow);
+                // IFC: web content is adversarial-integrity — observing it
+                // taints the session, so subsequent outbound actions are denied
+                // with `IfcUnsafe` (lethal-trifecta guard). (#1633)
+                self.observe_flow(NodeKind::WebContent).await;
                 Ok(CallToolResult::success(vec![Content::text(response)]))
             }
             Err(e) => {

--- a/crates/portcullis/src/kernel.rs
+++ b/crates/portcullis/src/kernel.rs
@@ -297,6 +297,14 @@ pub enum DenyReason {
         /// Human-readable detail from the failed preflight obligations.
         detail: String,
     },
+    /// Operation denied by information-flow control: the session has ingested
+    /// adversarial (untrusted/web) content, and this is an outbound action that
+    /// could exfiltrate or act on the injected data. This is the lethal-trifecta
+    /// guard wired through the live MCP `FlowTracker` (#1633).
+    IfcUnsafe {
+        /// Human-readable explanation of the unsafe flow.
+        detail: String,
+    },
 }
 
 /// The source of a RequiresApproval verdict.
@@ -1586,6 +1594,65 @@ impl Kernel {
         }
 
         (decision, token)
+    }
+
+    /// [`decide_term`] with an information-flow consult against a live
+    /// [`FlowTracker`] (#1633).
+    ///
+    /// This is the kernel-side enforcement point for the lethal trifecta: when
+    /// `flow` has observed any node with **adversarial** integrity (e.g.
+    /// `web_fetch` ⇒ `NodeKind::WebContent`), the session is tainted, and any
+    /// **outbound action** (write/edit/run/git/PR/spawn/pods — the operations
+    /// `node_kind_for` classifies as [`NodeKind::OutboundAction`]) is denied
+    /// with [`DenyReason::IfcUnsafe`] *before* the normal decision path. A clean
+    /// session, or a non-outbound operation, falls through to [`decide_term`]
+    /// unchanged.
+    ///
+    /// `flow == None` ⇒ behaves exactly like [`decide_term`] (callers without a
+    /// tracker are unaffected — backward compatible).
+    pub fn decide_term_with_flow(
+        &mut self,
+        term: ActionTerm,
+        flow: Option<&portcullis_core::ifc_api::FlowTracker>,
+    ) -> (Decision, Option<DecisionToken>) {
+        use portcullis_core::flow::NodeKind;
+
+        let operation = term.operation();
+        if let Some(flow) = flow {
+            if flow.is_tainted() && Self::node_kind_for(operation) == NodeKind::OutboundAction {
+                let subject = term.subject().to_string();
+                let pre_hash = self.effective.checksum();
+                let pre_exposure_count = self.exposure.count();
+                let contributed_label = exposure_core::classify_operation(operation);
+                let detail = format!(
+                    "session carries adversarial integrity (untrusted/web content was \
+                     observed); outbound operation {operation:?} blocked to prevent \
+                     exfiltration of, or action on, injected content"
+                );
+                tracing::warn!(
+                    ?operation,
+                    subject,
+                    "IFC denied outbound action: session is taint-adversarial"
+                );
+                let (mut decision, token) = self.record_with_exposure(
+                    operation,
+                    &subject,
+                    Verdict::Deny(DenyReason::IfcUnsafe { detail }),
+                    &pre_hash,
+                    pre_exposure_count,
+                    contributed_label,
+                    false,
+                    false,
+                );
+                decision.action_term = Some(term.clone());
+                if let Some(last) = self.trace.last_mut() {
+                    last.action_term = Some(term);
+                }
+                return (decision, token);
+            }
+        }
+
+        self.decide_term(term)
     }
 
     /// Map an Operation to the most appropriate FlowNode kind.

--- a/crates/portcullis/src/kernel_tests.rs
+++ b/crates/portcullis/src/kernel_tests.rs
@@ -262,6 +262,102 @@ fn test_decide_term_denies_when_preflight_rejects() {
 }
 
 #[test]
+fn test_decide_term_with_flow_denies_outbound_when_tainted() {
+    use portcullis_core::flow::NodeKind;
+    use portcullis_core::ifc_api::FlowTracker;
+
+    // An edit that the kernel would normally ALLOW (within task scope), so the
+    // IFC gate — not a capability/scope failure — is what differs.
+    let make_term = || {
+        let task = crate::TaskRef::new(
+            "pr-241",
+            "fix auth regression",
+            vec![Operation::EditFiles],
+            vec!["src/auth/".to_string()],
+        );
+        crate::ActionTerm::edit_file(
+            Some(task),
+            "src/auth/session.rs",
+            "@@ -1 +1 @@",
+            vec![trusted_term_input("session")],
+            crate::EffectDisposition::Proposed,
+        )
+    };
+
+    // Clean session → falls through to the normal decision (allowed).
+    let mut kernel = Kernel::new(PermissionLattice::safe_pr_fixer());
+    let clean = FlowTracker::new();
+    let (decision, token) = kernel.decide_term_with_flow(make_term(), Some(&clean));
+    assert!(
+        decision.verdict.is_allowed(),
+        "clean session must allow the edit, got {:?}",
+        decision.verdict
+    );
+    assert!(token.is_some());
+
+    // Tainted session (web content observed) → outbound action denied IfcUnsafe,
+    // even though capability/scope would otherwise allow it.
+    let mut kernel = Kernel::new(PermissionLattice::safe_pr_fixer());
+    let mut tainted = FlowTracker::new();
+    tainted
+        .observe(NodeKind::WebContent)
+        .expect("observe web content");
+    assert!(tainted.is_tainted());
+    let (decision, token) = kernel.decide_term_with_flow(make_term(), Some(&tainted));
+    assert!(
+        matches!(
+            decision.verdict,
+            Verdict::Deny(DenyReason::IfcUnsafe { .. })
+        ),
+        "tainted session must deny outbound action with IfcUnsafe, got {:?}",
+        decision.verdict
+    );
+    assert!(token.is_none());
+}
+
+#[test]
+fn test_decide_term_with_flow_none_matches_decide_term() {
+    // `flow == None` must behave exactly like `decide_term`.
+    let term = crate::ActionTerm::run_command(
+        None,
+        "cargo test",
+        vec![trusted_term_input("tests")],
+        crate::EffectDisposition::Proposed,
+    );
+    let mut a = Kernel::new(PermissionLattice::safe_pr_fixer());
+    let mut b = Kernel::new(PermissionLattice::safe_pr_fixer());
+    let (d_plain, _) = a.decide_term(term.clone());
+    let (d_flow, _) = b.decide_term_with_flow(term, None);
+    assert_eq!(
+        std::mem::discriminant(&d_plain.verdict),
+        std::mem::discriminant(&d_flow.verdict),
+        "decide_term_with_flow(None) must match decide_term"
+    );
+}
+
+#[test]
+fn test_decide_term_with_flow_allows_input_op_even_when_tainted() {
+    // Input operations (read) are NOT outbound — they must not be IFC-denied
+    // even when the session is tainted (you can keep reading after web fetch).
+    use portcullis_core::flow::NodeKind;
+    use portcullis_core::ifc_api::FlowTracker;
+
+    let mut kernel = Kernel::new(PermissionLattice::safe_pr_fixer());
+    let mut tainted = FlowTracker::new();
+    tainted.observe(NodeKind::WebContent).unwrap();
+    let term = crate::ActionTerm::from_operation(Operation::ReadFiles, "src/auth/session.rs");
+    let (decision, _) = kernel.decide_term_with_flow(term, Some(&tainted));
+    assert!(
+        !matches!(
+            decision.verdict,
+            Verdict::Deny(DenyReason::IfcUnsafe { .. })
+        ),
+        "input op must not be IFC-denied, got {:?}",
+        decision.verdict
+    );
+}
+
+#[test]
 fn test_decision_with_action_term_serializes() {
     let perms = PermissionLattice::safe_pr_fixer();
     let mut kernel = Kernel::new(perms);

--- a/crates/portcullis/src/lib.rs
+++ b/crates/portcullis/src/lib.rs
@@ -288,6 +288,12 @@ pub use verdict_sink::{ActorIdentity, SinkError, VerdictContext, VerdictOutcome,
 pub use portcullis_core::envelope::{FieldEnvelope, RowEnvelope, SourceRef, TransformRef};
 pub use portcullis_core::witness::{ChainVerifyError as WitnessChainVerifyError, WitnessBundle};
 
+// Re-export the information-flow tracker so downstream runtimes (e.g. the MCP
+// server in nucleus-tool-proxy) can drive `Kernel::decide_term_with_flow`
+// without depending on portcullis-core directly (#1633).
+pub use portcullis_core::flow::NodeKind;
+pub use portcullis_core::ifc_api::{FlowTracker, SafetyCheck};
+
 /// Check if a glob pattern matches a path.
 pub fn glob_match(pattern: &str, path: &str) -> bool {
     path::glob_match(pattern, path)


### PR DESCRIPTION
**Tier 2 / CRIT-1** ([#1626](https://github.com/coproduct-opensource/nucleus/issues/1626) / roadmap [#1624](https://github.com/coproduct-opensource/nucleus/issues/1624)).

The Rust MCP runtime called `kernel_decide()` but never observed `NodeKind` nodes or checked `SafetyCheck` — only the Python SDK wired IFC. The lethal trifecta (web content → outbound action) was unenforced in the live Rust path.

**Kernel (complete mediation):**
- `Kernel::decide_term_with_flow(term, Option<&FlowTracker>)` — if the session is tainted (any adversarial-integrity node, e.g. `WebContent` from `web_fetch`) **and** the op is an `OutboundAction` (write/edit/run/git/PR/spawn/pods), deny with the new `DenyReason::IfcUnsafe` before the normal path. `flow == None` ⇒ identical to `decide_term` (**backward compatible**; 4 existing callers untouched).
- Re-export `FlowTracker`/`NodeKind`/`SafetyCheck` from `portcullis`.

**MCP runtime:** `NucleusMcpServer` gains a session `FlowTracker`; `kernel_decide` routes through `decide_term_with_flow`; `web_fetch` observes `WebContent` (taints), `read`/`glob`/`grep` observe `FileRead` (trusted — legit read→write still works).

**Result:** after a successful `web_fetch`, a subsequent `write`/`run`/git/PR is denied `IfcUnsafe` — parity with the Python SDK's observe→check→execute.

Tests: 3 deterministic kernel-level IFC tests (no network). clippy clean under `--all-features`. nucleus-ifc crate doc updated (no longer aspirational).

Note: the `web_fetch→write` acceptance scenario is enforced by this gate and covered deterministically at the kernel level rather than a flaky network-dependent MCP integration test.

Closes #1633. (#1634 Cedar consult stacks on this same `decide_term_with_flow`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)