### PR TITLE
feat(kernel): wire Cedar into the decision path, default-on (#1634)

### DIFF
--- a/crates/nucleus-mcp/src/main.rs
+++ b/crates/nucleus-mcp/src/main.rs
@@ -562,6 +562,9 @@ fn format_deny_reason(reason: &DenyReason) -> String {
         DenyReason::IfcUnsafe { detail } => {
             format!("information-flow unsafe: {detail}")
         }
+        DenyReason::CedarDenied { detail } => {
+            format!("cedar policy denied: {detail}")
+        }
     }
 }
 

--- a/crates/portcullis/Cargo.toml
+++ b/crates/portcullis/Cargo.toml
@@ -12,7 +12,12 @@ keywords = ["ai", "security", "permissions", "agents", "lattice"]
 categories = ["authentication", "development-tools"]
 
 [features]
-default = ["serde", "crypto"]
+# `cedar` is default-on (#1634): the kernel consults Cedar in
+# `decide_term_with_flow` when a policy is loaded. With no policy loaded the
+# evaluator is `None` and Cedar is inert, so default-on changes no behavior for
+# sessions that don't opt in. WASM consumers build with `default-features =
+# false` (cedar-policy can't target wasm), so they are unaffected.
+default = ["serde", "crypto", "cedar"]
 serde = ["dep:serde", "dep:serde_json", "rust_decimal/serde", "chrono/serde", "uuid/serde"]
 
 # Ed25519 signing (ring) — disable for WASM targets where ring can't compile

--- a/crates/portcullis/src/cedar_bridge.rs
+++ b/crates/portcullis/src/cedar_bridge.rs
@@ -64,6 +64,14 @@ pub struct CedarResult {
     pub reasons: Vec<String>,
 }
 
+impl CedarResult {
+    /// Whether Cedar permitted the operation. Lets callers (e.g. the kernel)
+    /// branch on the decision without importing `cedar_policy::Decision`.
+    pub fn is_allowed(&self) -> bool {
+        self.decision == Decision::Allow
+    }
+}
+
 impl CedarEvaluator {
     /// Create a new evaluator from Cedar policy source.
     ///

--- a/crates/portcullis/src/kernel.rs
+++ b/crates/portcullis/src/kernel.rs
@@ -305,6 +305,14 @@ pub enum DenyReason {
         /// Human-readable explanation of the unsafe flow.
         detail: String,
     },
+    /// Operation denied by the Cedar policy evaluator (#1634). Present only when
+    /// a Cedar policy is loaded; Cedar default-denies operations no `permit`
+    /// rule covers. The variant is always defined (independent of the `cedar`
+    /// feature) so `DenyReason`'s wire format is stable across builds.
+    CedarDenied {
+        /// Cedar's diagnostic reasons (policy ids), joined for display.
+        detail: String,
+    },
 }
 
 /// The source of a RequiresApproval verdict.
@@ -469,6 +477,13 @@ pub struct Kernel {
     /// Loaded from `.nucleus/policy.toml`. When `None`, no admissibility
     /// filtering is applied (all operations pass through to capability checks).
     policy_rules: Option<portcullis_core::policy_rules::PolicyRuleSet>,
+    /// Optional Cedar policy evaluator — when present, `decide_term_with_flow`
+    /// consults Cedar after the IFC check and denies operations Cedar does not
+    /// permit (#1634). `None` ⇒ no Cedar gating (the default until a policy is
+    /// loaded via [`Kernel::set_cedar_policy`]), so flipping the `cedar` feature
+    /// default-on does not change behavior for sessions without a policy.
+    #[cfg(feature = "cedar")]
+    cedar_evaluator: Option<crate::cedar_bridge::CedarEvaluator>,
     /// Optional enterprise allowlist — when present, `decide()` checks the
     /// operation's sink class against the enterprise policy after admissibility
     /// policy checks and before path/command checks.
@@ -567,6 +582,8 @@ impl Kernel {
             declassification_rules: Vec::new(),
             egress_policy: None,
             policy_rules: None,
+            #[cfg(feature = "cedar")]
+            cedar_evaluator: None,
             enterprise: None,
             delegation: None,
             delegation_depth: 0,
@@ -616,6 +633,8 @@ impl Kernel {
             declassification_rules: Vec::new(),
             egress_policy: None,
             policy_rules: None,
+            #[cfg(feature = "cedar")]
+            cedar_evaluator: None,
             enterprise: None,
             delegation: None,
             delegation_depth: 0,
@@ -975,6 +994,8 @@ impl Kernel {
             declassification_rules: Vec::new(),
             egress_policy: None,
             policy_rules: None,
+            #[cfg(feature = "cedar")]
+            cedar_evaluator: None,
             enterprise: None,
             delegation: None,
             delegation_depth: 0,
@@ -1030,6 +1051,8 @@ impl Kernel {
             declassification_rules: Vec::new(),
             egress_policy: None,
             policy_rules: None,
+            #[cfg(feature = "cedar")]
+            cedar_evaluator: None,
             enterprise: None,
             delegation: None,
             delegation_depth: 0,
@@ -1652,7 +1675,68 @@ impl Kernel {
             }
         }
 
+        // Cedar policy consult (#1634): after the IFC check, if a Cedar policy is
+        // loaded, deny any operation Cedar does not `permit`. Uses the session's
+        // current flow label (integrity/authority/confidentiality) as context.
+        // No policy loaded ⇒ skipped entirely (default-on feature is inert here).
+        #[cfg(feature = "cedar")]
+        if let Some(ref cedar) = self.cedar_evaluator {
+            let label = self.flow_label.unwrap_or_else(|| {
+                portcullis_core::IFCLabel::user_prompt(chrono::Utc::now().timestamp() as u64)
+            });
+            let subject = term.subject().to_string();
+            let result = cedar.evaluate(
+                &self.session_id.to_string(),
+                operation,
+                &subject,
+                label.integrity,
+                label.authority,
+                label.confidentiality,
+            );
+            if !result.is_allowed() {
+                let pre_hash = self.effective.checksum();
+                let pre_exposure_count = self.exposure.count();
+                let contributed_label = exposure_core::classify_operation(operation);
+                let detail = if result.reasons.is_empty() {
+                    "no matching Cedar `permit` rule (default deny)".to_string()
+                } else {
+                    result.reasons.join(", ")
+                };
+                tracing::warn!(?operation, subject, %detail, "Cedar denied operation");
+                let (mut decision, token) = self.record_with_exposure(
+                    operation,
+                    &subject,
+                    Verdict::Deny(DenyReason::CedarDenied { detail }),
+                    &pre_hash,
+                    pre_exposure_count,
+                    contributed_label,
+                    false,
+                    false,
+                );
+                decision.action_term = Some(term.clone());
+                if let Some(last) = self.trace.last_mut() {
+                    last.action_term = Some(term);
+                }
+                return (decision, token);
+            }
+        }
+
         self.decide_term(term)
+    }
+
+    /// Load a Cedar policy that gates every subsequent decision through
+    /// [`decide_term_with_flow`] (#1634).
+    ///
+    /// Cedar runs *after* the portcullis lattice + IFC checks — an additional,
+    /// human-auditable policy layer, never a replacement. Note Cedar's
+    /// default-deny semantics: once a policy is loaded, operations with no
+    /// matching `permit` rule are denied with [`DenyReason::CedarDenied`].
+    ///
+    /// Returns an error if the policy source fails to parse.
+    #[cfg(feature = "cedar")]
+    pub fn set_cedar_policy(&mut self, policy_src: &str) -> Result<(), String> {
+        self.cedar_evaluator = Some(crate::cedar_bridge::CedarEvaluator::new(policy_src)?);
+        Ok(())
     }
 
     /// Map an Operation to the most appropriate FlowNode kind.

--- a/crates/portcullis/src/kernel_tests.rs
+++ b/crates/portcullis/src/kernel_tests.rs
@@ -357,6 +357,75 @@ fn test_decide_term_with_flow_allows_input_op_even_when_tainted() {
     );
 }
 
+#[cfg(feature = "cedar")]
+fn cedar_edit_term() -> crate::ActionTerm {
+    let task = crate::TaskRef::new(
+        "pr-1",
+        "x",
+        vec![Operation::EditFiles],
+        vec!["src/auth/".to_string()],
+    );
+    crate::ActionTerm::edit_file(
+        Some(task),
+        "src/auth/session.rs",
+        "@@ -1 +1 @@",
+        vec![trusted_term_input("s")],
+        crate::EffectDisposition::Proposed,
+    )
+}
+
+#[cfg(feature = "cedar")]
+#[test]
+fn test_cedar_denies_operation_not_permitted() {
+    // Cedar permits only read_files; an edit the lattice would allow is denied
+    // by Cedar's default-deny.
+    let mut kernel = Kernel::new(PermissionLattice::safe_pr_fixer());
+    kernel
+        .set_cedar_policy(r#"permit(principal, action == Action::"read_files", resource);"#)
+        .expect("policy parses");
+    let (decision, token) = kernel.decide_term_with_flow(cedar_edit_term(), None);
+    assert!(
+        matches!(
+            decision.verdict,
+            Verdict::Deny(DenyReason::CedarDenied { .. })
+        ),
+        "Cedar must deny an un-permitted op, got {:?}",
+        decision.verdict
+    );
+    assert!(token.is_none());
+}
+
+#[cfg(feature = "cedar")]
+#[test]
+fn test_cedar_permit_all_falls_through_to_normal_decision() {
+    let mut kernel = Kernel::new(PermissionLattice::safe_pr_fixer());
+    kernel
+        .set_cedar_policy("permit(principal, action, resource);")
+        .expect("policy parses");
+    let (decision, _) = kernel.decide_term_with_flow(cedar_edit_term(), None);
+    assert!(
+        decision.verdict.is_allowed(),
+        "permit-all Cedar must fall through to the lattice (allowed), got {:?}",
+        decision.verdict
+    );
+}
+
+#[cfg(feature = "cedar")]
+#[test]
+fn test_no_cedar_policy_is_inert() {
+    // Default-on feature, but no policy loaded ⇒ Cedar does not gate anything.
+    let mut kernel = Kernel::new(PermissionLattice::safe_pr_fixer());
+    let (decision, _) = kernel.decide_term_with_flow(cedar_edit_term(), None);
+    assert!(
+        !matches!(
+            decision.verdict,
+            Verdict::Deny(DenyReason::CedarDenied { .. })
+        ),
+        "no Cedar policy must not produce CedarDenied, got {:?}",
+        decision.verdict
+    );
+}
+
 #[test]
 fn test_decision_with_action_term_serializes() {
     let perms = PermissionLattice::safe_pr_fixer();


### PR DESCRIPTION
**Tier 2 / CRIT-2** ([#1626](https://github.com/coproduct-opensource/nucleus/issues/1626) / roadmap [#1624](https://github.com/coproduct-opensource/nucleus/issues/1624)). Stacks on #1633 (now merged).

`CedarEvaluator` was defined but only its own tests called it, and the `cedar` feature was default-off — so the buyer-facing "Cedar policy enforcement" claim wasn't wired.

- `Kernel.cedar_evaluator: Option<CedarEvaluator>` + `set_cedar_policy(src)`.
- `decide_term_with_flow` consults Cedar **after** the lattice + IFC checks: when a policy is loaded, any op Cedar doesn't `permit` → `DenyReason::CedarDenied` (uses the session flow label as Cedar context). Additional human-auditable layer, never a replacement.
- `CedarResult::is_allowed()` (kernel branches without importing cedar_policy); `format_deny_reason` arm.
- **`default = […, "cedar"]`**. Safe default-on: with no policy loaded the evaluator is `None` and Cedar is **inert** (zero behavior change). WASM consumers use `default-features = false` (cedar-policy can't target wasm) — **verified ctf-engine pulls no cedar deps**.

Tests: Cedar denies un-permitted op; permit-all falls through to the lattice; no-policy is inert. **Whole workspace builds with cedar default-on.**

Per operator decision (2026-06-05): wire **and** flip default-on.

Closes #1634.

🤖 Generated with [Claude Code](https://claude.com/claude-code)