### PR TITLE
feat(machine): MachineDriver substrate abstraction (mock + Fly skeleton)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6658,6 +6658,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nucleus-machine"
+version = "1.0.0"
+dependencies = [
+ "async-trait",
+ "serde",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
 name = "nucleus-mcp"
 version = "1.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ members = [
     "crates/nucleus-agent-card",         # Verify-before-you-act: signed Agent Card → TrustAnchor
     "crates/nucleus-trust-registry",     # "Let's Encrypt for agents": PR-rooted, OIDC-attested, transparency-logged SPIFFE federation enrollment
     "crates/xtask",                      # Rust-native dev/CI task runner (cargo xtask <cmd>); migrating scripts/*.sh
+    "crates/nucleus-machine",            # MachineDriver: microVM execution-substrate abstraction (mock + Fly skeleton)
 ]
 # nucleus-claude-hook moved to nucleus-code (private product repo)
 # exposure-web is WASM-only (wasm32-unknown-unknown); build with: cd crates/exposure-web && trunk build

--- a/crates/nucleus-machine/Cargo.toml
+++ b/crates/nucleus-machine/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "nucleus-machine"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "MachineDriver: a microVM execution-substrate abstraction for agent runtimes (mock + Fly.io skeleton)"
+repository = "https://github.com/coproduct-opensource/nucleus"
+
+[lints]
+workspace = true
+
+[dependencies]
+async-trait = { workspace = true }
+thiserror = { workspace = true }
+serde = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/nucleus-machine/src/lib.rs
+++ b/crates/nucleus-machine/src/lib.rs
@@ -1,0 +1,406 @@
+//! `nucleus-machine` — an execution-substrate abstraction for agent runtimes.
+//!
+//! A [`MachineDriver`] is a microVM lifecycle backend: `create → start →
+//! suspend → start → stop → destroy`. The agent control plane's reconciler
+//! depends only on this trait, so the substrate is swappable and never
+//! load-bearing lock-in (see `docs/rfcs/agent-control-plane-on-fly.md`):
+//!
+//! - [`MockMachineDriver`] — an in-memory state machine for tests and local
+//!   orchestration development. Fully implemented.
+//! - [`FlyMachineDriver`] — a **skeleton** backend for [Fly.io
+//!   Machines](https://fly.io/docs/machines/) (Firecracker microVMs with native
+//!   `suspend`/`start`, i.e. memory snapshot/restore). The Machines-API
+//!   *endpoint mapping* is implemented and tested; the HTTP transport is a
+//!   documented P0 TODO and currently returns [`MachineError::NotWired`] — it
+//!   does **not** fake calls.
+//!
+//! The key primitive is [`MachineDriver::suspend`]: on Fly this snapshots VM
+//! memory to disk so an idle agent costs ~nothing and resumes in ~ms on the next
+//! message — the efficiency win that is structurally impossible on Kubernetes.
+
+use std::collections::BTreeMap;
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+/// Opaque backend identifier for a machine.
+pub type MachineId = String;
+
+/// Lifecycle state of a machine.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MachineState {
+    /// Created but not started.
+    Created,
+    /// Running.
+    Active,
+    /// Memory snapshotted to disk (Fly `suspend`); compute stopped, resumable.
+    Frozen,
+    /// Fully stopped (no memory snapshot); a cold start is required to resume.
+    Stopped,
+    /// Destroyed — terminal.
+    Destroyed,
+}
+
+/// Desired configuration for a new machine.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MachineSpec {
+    /// OCI image / rootfs reference.
+    pub image: String,
+    /// Preferred region (backend-specific code, e.g. a Fly region); `None` =
+    /// let the backend choose.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub region: Option<String>,
+    /// vCPUs.
+    pub cpus: u16,
+    /// Memory in MiB.
+    pub memory_mb: u32,
+    /// Environment variables for the guest.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub env: BTreeMap<String, String>,
+}
+
+/// Errors a [`MachineDriver`] may surface.
+#[derive(Debug, thiserror::Error)]
+pub enum MachineError {
+    /// No machine with this id is known to the backend.
+    #[error("machine not found: {0}")]
+    NotFound(MachineId),
+    /// The requested operation is not valid from the machine's current state.
+    #[error("invalid transition for {id}: cannot {op} from {from:?}")]
+    InvalidTransition {
+        /// The machine id.
+        id: MachineId,
+        /// Its current state.
+        from: MachineState,
+        /// The attempted operation.
+        op: &'static str,
+    },
+    /// A skeleton backend whose transport has not been wired yet.
+    #[error("driver transport not yet wired: {0}")]
+    NotWired(&'static str),
+    /// A backend (transport / API) error.
+    #[error("backend error: {0}")]
+    Backend(String),
+}
+
+/// A microVM lifecycle backend.
+///
+/// Implementations must be cheap to clone/share (`Send + Sync`) so the
+/// reconciler can hold one behind an `Arc`.
+#[async_trait]
+pub trait MachineDriver: Send + Sync {
+    /// Create a machine in [`MachineState::Created`] and return its id.
+    async fn create(&self, spec: &MachineSpec) -> Result<MachineId, MachineError>;
+    /// Start (or resume from `Frozen`/`Stopped`) → [`MachineState::Active`].
+    async fn start(&self, id: &str) -> Result<(), MachineError>;
+    /// Snapshot memory to disk → [`MachineState::Frozen`] (resume via `start`).
+    async fn suspend(&self, id: &str) -> Result<(), MachineError>;
+    /// Stop without a memory snapshot → [`MachineState::Stopped`].
+    async fn stop(&self, id: &str) -> Result<(), MachineError>;
+    /// Destroy the machine (terminal).
+    async fn destroy(&self, id: &str) -> Result<(), MachineError>;
+    /// Current lifecycle state.
+    async fn status(&self, id: &str) -> Result<MachineState, MachineError>;
+}
+
+// ── MockMachineDriver ────────────────────────────────────────────────────────
+
+/// In-memory [`MachineDriver`] for tests and orchestration development.
+///
+/// Enforces the same lifecycle transitions a real backend would, so reconciler
+/// logic can be exercised without any infrastructure.
+#[derive(Default)]
+pub struct MockMachineDriver {
+    // (next_id_counter, id → state). std Mutex is fine: no `.await` is held
+    // across the lock in any method.
+    inner: std::sync::Mutex<(u64, BTreeMap<MachineId, MachineState>)>,
+}
+
+impl MockMachineDriver {
+    /// A fresh, empty mock driver.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn transition(
+        &self,
+        id: &str,
+        op: &'static str,
+        allowed_from: &[MachineState],
+        to: MachineState,
+    ) -> Result<(), MachineError> {
+        let mut guard = self.inner.lock().expect("mock driver mutex poisoned");
+        let state = guard
+            .1
+            .get_mut(id)
+            .ok_or_else(|| MachineError::NotFound(id.to_string()))?;
+        if !allowed_from.contains(state) {
+            return Err(MachineError::InvalidTransition {
+                id: id.to_string(),
+                from: *state,
+                op,
+            });
+        }
+        *state = to;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl MachineDriver for MockMachineDriver {
+    async fn create(&self, _spec: &MachineSpec) -> Result<MachineId, MachineError> {
+        let mut guard = self.inner.lock().expect("mock driver mutex poisoned");
+        guard.0 += 1;
+        let id = format!("mock-{}", guard.0);
+        guard.1.insert(id.clone(), MachineState::Created);
+        Ok(id)
+    }
+
+    async fn start(&self, id: &str) -> Result<(), MachineError> {
+        self.transition(
+            id,
+            "start",
+            &[
+                MachineState::Created,
+                MachineState::Frozen,
+                MachineState::Stopped,
+                MachineState::Active, // idempotent
+            ],
+            MachineState::Active,
+        )
+    }
+
+    async fn suspend(&self, id: &str) -> Result<(), MachineError> {
+        self.transition(id, "suspend", &[MachineState::Active], MachineState::Frozen)
+    }
+
+    async fn stop(&self, id: &str) -> Result<(), MachineError> {
+        self.transition(
+            id,
+            "stop",
+            &[MachineState::Active, MachineState::Frozen],
+            MachineState::Stopped,
+        )
+    }
+
+    async fn destroy(&self, id: &str) -> Result<(), MachineError> {
+        self.transition(
+            id,
+            "destroy",
+            &[
+                MachineState::Created,
+                MachineState::Active,
+                MachineState::Frozen,
+                MachineState::Stopped,
+            ],
+            MachineState::Destroyed,
+        )
+    }
+
+    async fn status(&self, id: &str) -> Result<MachineState, MachineError> {
+        let guard = self.inner.lock().expect("mock driver mutex poisoned");
+        guard
+            .1
+            .get(id)
+            .copied()
+            .ok_or_else(|| MachineError::NotFound(id.to_string()))
+    }
+}
+
+// ── FlyMachineDriver (skeleton) ──────────────────────────────────────────────
+
+/// A Fly.io Machines API operation, used to map a [`MachineDriver`] call to its
+/// REST endpoint (method + path).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FlyOp {
+    /// Create a machine.
+    Create,
+    /// Start / resume.
+    Start,
+    /// Suspend (memory snapshot).
+    Suspend,
+    /// Stop (no snapshot).
+    Stop,
+    /// Destroy.
+    Destroy,
+    /// Read state.
+    Status,
+}
+
+/// Skeleton [`MachineDriver`] backend for Fly.io Machines.
+///
+/// The endpoint mapping ([`FlyMachineDriver::endpoint`]) is implemented and
+/// tested; the HTTP transport is a P0 TODO — the trait methods currently return
+/// [`MachineError::NotWired`] rather than faking calls. Wiring is intentionally
+/// kept out of this crate so the dependency stays transport-free until the
+/// control plane needs it.
+pub struct FlyMachineDriver {
+    app: String,
+    api_base: String,
+    #[allow(dead_code)] // used once the HTTP transport is wired (P0).
+    token: String,
+}
+
+impl FlyMachineDriver {
+    /// Default Fly Machines API base URL.
+    pub const DEFAULT_API_BASE: &'static str = "https://api.machines.dev/v1";
+
+    /// Construct against `app`, authenticating with `token`
+    /// (a Fly API / OIDC-exchanged token), using the default API base.
+    pub fn new(app: impl Into<String>, token: impl Into<String>) -> Self {
+        Self {
+            app: app.into(),
+            api_base: Self::DEFAULT_API_BASE.to_string(),
+            token: token.into(),
+        }
+    }
+
+    /// Override the API base (e.g. for a mock server in integration tests).
+    pub fn with_api_base(mut self, base: impl Into<String>) -> Self {
+        self.api_base = base.into();
+        self
+    }
+
+    /// Map an operation to its `(HTTP method, full URL)` against the Machines
+    /// API. Pure — the unit of behavior that's testable without a network.
+    pub fn endpoint(&self, op: FlyOp, id: Option<&str>) -> (&'static str, String) {
+        let base = &self.api_base;
+        let app = &self.app;
+        match op {
+            FlyOp::Create => ("POST", format!("{base}/apps/{app}/machines")),
+            FlyOp::Start => (
+                "POST",
+                format!("{base}/apps/{app}/machines/{}/start", id.unwrap_or("")),
+            ),
+            FlyOp::Suspend => (
+                "POST",
+                format!("{base}/apps/{app}/machines/{}/suspend", id.unwrap_or("")),
+            ),
+            FlyOp::Stop => (
+                "POST",
+                format!("{base}/apps/{app}/machines/{}/stop", id.unwrap_or("")),
+            ),
+            FlyOp::Destroy => (
+                "DELETE",
+                format!("{base}/apps/{app}/machines/{}", id.unwrap_or("")),
+            ),
+            FlyOp::Status => (
+                "GET",
+                format!("{base}/apps/{app}/machines/{}", id.unwrap_or("")),
+            ),
+        }
+    }
+}
+
+const FLY_TODO: &str =
+    "FlyMachineDriver: HTTP transport is a P0 TODO (see docs/rfcs/agent-control-plane-on-fly.md)";
+
+#[async_trait]
+impl MachineDriver for FlyMachineDriver {
+    async fn create(&self, _spec: &MachineSpec) -> Result<MachineId, MachineError> {
+        Err(MachineError::NotWired(FLY_TODO))
+    }
+    async fn start(&self, _id: &str) -> Result<(), MachineError> {
+        Err(MachineError::NotWired(FLY_TODO))
+    }
+    async fn suspend(&self, _id: &str) -> Result<(), MachineError> {
+        Err(MachineError::NotWired(FLY_TODO))
+    }
+    async fn stop(&self, _id: &str) -> Result<(), MachineError> {
+        Err(MachineError::NotWired(FLY_TODO))
+    }
+    async fn destroy(&self, _id: &str) -> Result<(), MachineError> {
+        Err(MachineError::NotWired(FLY_TODO))
+    }
+    async fn status(&self, _id: &str) -> Result<MachineState, MachineError> {
+        Err(MachineError::NotWired(FLY_TODO))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn spec() -> MachineSpec {
+        MachineSpec {
+            image: "registry.fly.io/agent:latest".into(),
+            region: Some("sjc".into()),
+            cpus: 1,
+            memory_mb: 512,
+            env: BTreeMap::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn mock_full_lifecycle() {
+        let d = MockMachineDriver::new();
+        let id = d.create(&spec()).await.unwrap();
+        assert_eq!(d.status(&id).await.unwrap(), MachineState::Created);
+        d.start(&id).await.unwrap();
+        assert_eq!(d.status(&id).await.unwrap(), MachineState::Active);
+        // suspend → frozen → resume (the freeze/resume primitive)
+        d.suspend(&id).await.unwrap();
+        assert_eq!(d.status(&id).await.unwrap(), MachineState::Frozen);
+        d.start(&id).await.unwrap();
+        assert_eq!(d.status(&id).await.unwrap(), MachineState::Active);
+        d.stop(&id).await.unwrap();
+        assert_eq!(d.status(&id).await.unwrap(), MachineState::Stopped);
+        d.destroy(&id).await.unwrap();
+        assert_eq!(d.status(&id).await.unwrap(), MachineState::Destroyed);
+    }
+
+    #[tokio::test]
+    async fn mock_rejects_invalid_transition() {
+        let d = MockMachineDriver::new();
+        let id = d.create(&spec()).await.unwrap();
+        // Can't suspend a machine that was never started.
+        let err = d.suspend(&id).await.unwrap_err();
+        assert!(matches!(
+            err,
+            MachineError::InvalidTransition { op: "suspend", .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn mock_unknown_id_is_not_found() {
+        let d = MockMachineDriver::new();
+        assert!(matches!(
+            d.status("nope").await.unwrap_err(),
+            MachineError::NotFound(_)
+        ));
+    }
+
+    #[test]
+    fn fly_endpoint_mapping() {
+        let d = FlyMachineDriver::new("my-app", "tok").with_api_base("https://x/v1");
+        assert_eq!(
+            d.endpoint(FlyOp::Create, None),
+            ("POST", "https://x/v1/apps/my-app/machines".to_string())
+        );
+        assert_eq!(
+            d.endpoint(FlyOp::Suspend, Some("m1")),
+            (
+                "POST",
+                "https://x/v1/apps/my-app/machines/m1/suspend".to_string()
+            )
+        );
+        assert_eq!(
+            d.endpoint(FlyOp::Destroy, Some("m1")),
+            ("DELETE", "https://x/v1/apps/my-app/machines/m1".to_string())
+        );
+        assert_eq!(
+            d.endpoint(FlyOp::Status, Some("m1")),
+            ("GET", "https://x/v1/apps/my-app/machines/m1".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn fly_transport_is_honestly_unwired() {
+        let d = FlyMachineDriver::new("my-app", "tok");
+        assert!(matches!(
+            d.start("m1").await.unwrap_err(),
+            MachineError::NotWired(_)
+        ));
+    }
+}


### PR DESCRIPTION
Implements the `MachineDriver` abstraction from the [Agent-Control-Plane-on-Fly RFC](docs/rfcs/agent-control-plane-on-fly.md) (companion PR #1696): a microVM lifecycle backend (create → start → **suspend** → start → stop → destroy) the reconciler depends on, so the execution substrate is swappable and not load-bearing lock-in.

- `MachineDriver` async trait + `MachineState` / `MachineSpec` / `MachineError`.
- **`MockMachineDriver`** — in-memory state machine enforcing the real lifecycle transitions; exercise reconciler logic with zero infrastructure. Fully implemented.
- **`FlyMachineDriver`** — *skeleton* for Fly.io Machines (Firecracker microVMs with native suspend/restore). The Machines-API **endpoint mapping is implemented + unit-tested**; the HTTP transport is a documented **P0 TODO** returning `MachineError::NotWired` — it does **not** fake calls (honest skeleton).

`suspend` is the freeze/resume primitive (Fly memory snapshot) that makes idle agents ~free and is structurally impossible on k8s.

Tests (5): full mock lifecycle incl. suspend→resume, invalid-transition rejection, not-found, Fly endpoint mapping, honest-unwired Fly transport. clippy clean under `--all-features`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)