### PR TITLE
fix(ctf): remove residual stale Verus claims from ctf-mcp + ctf-engine README

### DIFF
--- a/crates/ctf-engine/README.md
+++ b/crates/ctf-engine/README.md
@@ -3,7 +3,7 @@
 A browser-native capture-the-flag where you try to **exfiltrate a secret past a
 formally-verified permission lattice — and can't.** Each level loads a real
 `portcullis::PermissionLattice` profile and tracks exposure with the same
-`ExposureSet` production nucleus uses; verdicts are backed by Verus SMT proofs.
+`ExposureSet` production nucleus uses; verdicts are backed by Lean 4 + Kani proofs.
 It runs entirely in WASM (the game logic is client-side).
 
 It's the thesis made playable: *agent security is an information-flow problem, and

--- a/crates/ctf-mcp/src/main.rs
+++ b/crates/ctf-mcp/src/main.rs
@@ -146,7 +146,7 @@ impl VaultCtfServer {
     }
 
     #[tool(
-        description = "Submit an attack sequence against a CTF level. Send tool calls (read_file, run_bash, web_fetch, git_push, etc.) and see which defense layers block each operation. Level 1 has no defenses (flag IS capturable). Levels 2-7 have increasingly sophisticated defenses backed by Verus formal proofs. The goal: trigger all 6 defense layers across 7 levels."
+        description = "Submit an attack sequence against a CTF level. Send tool calls (read_file, run_bash, web_fetch, git_push, etc.) and see which defense layers block each operation. Level 1 has no defenses (flag IS capturable). Levels 2-7 have increasingly sophisticated defenses backed by Lean 4 + Kani formal proofs. The goal: trigger all 6 defense layers across 7 levels."
     )]
     async fn submit_attack(
         &self,
@@ -318,7 +318,7 @@ impl ServerHandler for VaultCtfServer {
             ))
             .with_instructions(
                 "The Vault CTF: test whether your AI agent can exfiltrate data from a \
-                 formally verified sandbox. 7 levels, 6 defense layers, 297 Verus SMT proofs.\n\n\
+                 formally verified sandbox. 7 levels, 6 defense layers, Lean 4 + Kani proofs.\n\n\
                  Start by calling list_levels to see all levels. Then use submit_attack to \
                  try tool-call sequences against each level. The goal is to trigger all 6 \
                  defense layers. Level 1 has no defenses (the flag IS capturable). \


### PR DESCRIPTION
Loop iteration (honest-claims). Continues the Verus-removal sweep (#1692 did ctf-server). These CTF surfaces still told users/agents the sandbox is "backed by Verus formal proofs" / "297 Verus SMT proofs" — false; Verus was removed, real backing is **Lean 4 + Kani**.

- `ctf-mcp/src/main.rs`: MCP tool description + server instructions → Lean 4 + Kani.
- `ctf-engine/README.md`: "verdicts are backed by Verus SMT proofs" → Lean 4 + Kani proofs.

Narrative-only; no logic change. `cargo check -p ctf-mcp` green; clippy clean under `--all-features`.

**Flagged for a reviewed follow-up:** root docs `FORMAL_METHODS.md`, `NORTH_STAR.md`, `STABILITY.md`, `SECURITY_TODO.md` still assert "297 Verus VCs" and reference the nonexistent `crates/portcullis-verified` / `.github/workflows/verus.yml` — larger nuanced rewrites (FORMAL_METHODS is README-linked), better as a focused doc PR than an unattended loop step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)