### PR TITLE
docs(portcullis): drop references to the removed Verus / portcullis-verified crate

### DIFF
--- a/crates/portcullis/src/capability.rs
+++ b/crates/portcullis/src/capability.rs
@@ -17,12 +17,13 @@ pub use portcullis_core::CapabilityLevel;
 /// The verified type IS the production type — one type, zero translation layers.
 pub use portcullis_core::{default_sink_class, Operation, OperationParseError, SinkClass};
 
-/// Extension operation not covered by Verus proofs.
+/// Extension operation not covered by the core formal proofs.
 ///
-/// The 12 core operations above are frozen — they have 297 Verus verification
-/// conditions proving lattice laws, exposure monotonicity, and session safety.
+/// The 12 core operations above are frozen — they have Kani + Lean proofs of
+/// lattice laws, exposure monotonicity, and session safety.
 /// Extension operations participate in the same product lattice (meet = pointwise min,
-/// join = pointwise max) but are verified only by property tests, not SMT proofs.
+/// join = pointwise max) but are verified only by property tests, not the core
+/// Kani/Lean proofs.
 ///
 /// Lattice laws hold by the universal property of products in **Lat**: if each
 /// factor is a lattice, the product is a lattice. Since `CapabilityLevel` is a
@@ -141,7 +142,7 @@ pub struct CapabilityLattice {
     #[cfg_attr(feature = "serde", serde(default))]
     pub spawn_agent: CapabilityLevel,
 
-    /// Extension capability dimensions (not covered by Verus proofs).
+    /// Extension capability dimensions (not covered by the core formal proofs).
     ///
     /// Meet = pointwise min, join = pointwise max, leq = pointwise ≤.
     /// Unknown extensions default to `Never` (fail-closed).

--- a/crates/portcullis/src/exposure_core.rs
+++ b/crates/portcullis/src/exposure_core.rs
@@ -7,7 +7,7 @@
 //!
 //! ## Verified Shared Core
 //!
-//! The Verus proofs in `portcullis-verified` verify executable spec
+//! The Kani proofs in `kani.rs` verify executable spec
 //! functions (`exec_guard_check`, `exec_apply_event`, etc.) that are
 //! structurally identical to these production functions. The CI
 //! conformance tests in `verus_conformance.rs` exhaustively verify

--- a/crates/portcullis/src/frame.rs
+++ b/crates/portcullis/src/frame.rs
@@ -24,7 +24,7 @@
 //!
 //! **Note on `UninhabitableQuotient`**: this operator satisfies (1) and (2) but
 //! NOT (3). It is a **kernel operator** (deflationary + idempotent), not a full
-//! frame-theoretic nucleus. The independent Verus prover in `portcullis-verified`
+//! frame-theoretic nucleus. The Kani harness in `portcullis/src/kani.rs`
 //! formally disproves meet-preservation (`proof_nucleus_not_meet_preserving`).
 //! Fixed points remain closed under the **quotient meet** (`PermissionLattice::meet`
 //! which re-normalizes internally), not under the raw lattice meet.
@@ -103,7 +103,7 @@ pub trait Frame: CompleteLattice + DistributiveLattice {}
 /// closure operator). In the frame-theoretic literature a full nucleus also
 /// requires meet-preservation (`j(x ∧ y) = j(x) ∧ j(y)`), but
 /// `UninhabitableQuotient` does **not** satisfy that property — it is
-/// formally disproven by the independent Verus proof in `portcullis-verified`
+/// formally disproven by the Kani proof in `portcullis/src/kani.rs`
 /// (`proof_nucleus_not_meet_preserving`).
 ///
 /// # Properties satisfied by `UninhabitableQuotient`
@@ -114,7 +114,8 @@ pub trait Frame: CompleteLattice + DistributiveLattice {}
 /// # Property NOT satisfied
 ///
 /// 3. **Meet-preserving** `j(x ∧ y) = j(x) ∧ j(y)` — this does **NOT** hold
-///    for `UninhabitableQuotient`. Counterexample (see Verus proof):
+///    for `UninhabitableQuotient`. Counterexample (see the Kani proof
+///    `proof_nucleus_not_meet_preserving` in `portcullis/src/kani.rs`):
 ///    `a` = full caps (uninhabitable-complete), empty obligations;
 ///    `b` = no-private-access caps, empty obligations.
 ///    `j(a∧b)` adds no obligations (meet caps are not uninhabitable),
@@ -284,7 +285,7 @@ impl SafePermissionLattice {
     /// (via `IncompatibilityConstraint::obligations_for`). This is distinct
     /// from the meet-preservation property `j(x∧y) = j(x)∧j(y)`, which does
     /// NOT hold for the raw `UninhabitableQuotient` nucleus operator (see
-    /// `proof_nucleus_not_meet_preserving` in `portcullis-verified`).
+    /// `proof_nucleus_not_meet_preserving` in `portcullis/src/kani.rs`).
     pub fn meet(&self, other: &Self) -> Self {
         Self(self.0.meet(&other.0))
     }
@@ -391,8 +392,8 @@ pub struct NucleusLawViolation {
 ///
 /// **Note on `MeetPreservation`**: the frame-theoretic nucleus axiom
 /// `j(x∧y) = j(x)∧j(y)` is listed here for completeness, but
-/// `UninhabitableQuotient` does **not** satisfy it. The independent Verus
-/// proof `proof_nucleus_not_meet_preserving` in `portcullis-verified`
+/// `UninhabitableQuotient` does **not** satisfy it. The Kani proof
+/// `proof_nucleus_not_meet_preserving` in `portcullis/src/kani.rs`
 /// provides a concrete witness. Do not assert `MeetPreservation` passes for
 /// `UninhabitableQuotient` — see `proof_nucleus_counterexample_witness` in
 /// `portcullis/src/kani.rs` for the regression harness.
@@ -585,8 +586,8 @@ mod tests {
     }
 
     /// Regression test: the raw `UninhabitableQuotient` nucleus does NOT preserve
-    /// meets in general. This is the concrete counterexample from the Verus proof
-    /// `proof_nucleus_not_meet_preserving` in `portcullis-verified`.
+    /// meets in general. This is the concrete counterexample from the Kani proof
+    /// `proof_nucleus_not_meet_preserving` in `portcullis/src/kani.rs`.
     ///
     /// Witness:
     /// - `a` = full caps (uninhabitable-complete), empty obligations
@@ -648,7 +649,7 @@ mod tests {
         assert_ne!(
             j_a_meet_b.obligations, ja_meet_jb.obligations,
             "Counterexample regression: j(a∧b) should NOT equal j(a)∧j(b) in obligations \
-             (UninhabitableQuotient does not preserve meets — Verus proof_nucleus_not_meet_preserving)"
+             (UninhabitableQuotient does not preserve meets — Kani proof_nucleus_not_meet_preserving)"
         );
     }
 
@@ -727,7 +728,7 @@ mod tests {
 
         // Only idempotency and deflation are hard requirements.
         // Meet-preservation does NOT hold for UninhabitableQuotient in general
-        // (see proof_nucleus_not_meet_preserving in portcullis-verified).
+        // (see proof_nucleus_not_meet_preserving in portcullis/src/kani.rs).
         let hard_violations: Vec<_> = violations
             .iter()
             .filter(|v| v.law != NucleusLaw::MeetPreservation)

--- a/crates/portcullis/src/guard.rs
+++ b/crates/portcullis/src/guard.rs
@@ -679,7 +679,7 @@ impl ToolCallGuard for RuntimeStateGuard {
 /// carries as its grade. When the join reaches `{PrivateData, UntrustedContent,
 /// ExfilVector}`, the uninhabitable_state is complete.
 ///
-/// These 3 core labels are FROZEN — they have Verus proofs covering
+/// These 3 core labels are FROZEN — they have Kani + Lean proofs covering
 /// monotonicity, session safety, and irreversibility.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/crates/portcullis/src/kani.rs
+++ b/crates/portcullis/src/kani.rs
@@ -1518,7 +1518,7 @@ fn proof_isolation_at_least_reflexive() {
 // as a *deflationary idempotent kernel operator*, NOT a frame-theoretic
 // nucleus (which would additionally require meet-preservation).
 //
-// The independent Verus prover in `portcullis-verified` formally disproves
+// The Kani harness below formally disproves
 // meet-preservation via `proof_nucleus_not_meet_preserving`. The harness
 // below reproduces that concrete counterexample witness using the production
 // Rust types so that any future code change that accidentally "fixes" meet-
@@ -1559,8 +1559,8 @@ fn proof_nucleus_deflationary() {
 
 /// **N3 — Counterexample witness: nucleus does NOT preserve meets**.
 ///
-/// This is the concrete witness from the Verus proof
-/// `proof_nucleus_not_meet_preserving` in `portcullis-verified`:
+/// This is the concrete witness from the Kani proof
+/// `proof_nucleus_not_meet_preserving` (in this module):
 ///
 /// - `a`: full caps (uninhabitable-complete), empty obligations
 /// - `b`: no private-access caps (read_files/glob/grep=Never), empty obligations


### PR DESCRIPTION
Loop iteration (honest-claims, single crate). The portcullis crate's doc-comments referenced an "independent Verus prover in `portcullis-verified`" — **that crate does not exist** (Verus was removed), and the property is actually proven by the **Kani** harness `proof_nucleus_not_meet_preserving` in `portcullis/src/kani.rs`.

- All `portcullis-verified` references removed → point at the real Kani proof.
- not-meet-preserving counterexample attributed consistently to Kani (frame.rs, kani.rs).
- "frozen core labels/ops have Verus proofs" → "Kani + Lean proofs" (guard.rs, capability.rs).

**Doc-comments only**, no code change. `cargo clippy --all-features` green.

Scoped to unambiguous false claims (nonexistent crate + wrong prover attribution). Left for a reviewed Verus-doc pass (historical/comparative, not false-crate): `exposure_core.rs` "Verus equivalent: <spec fn>" annotations + `kani.rs`'s "Unlike the Verus proofs (SMT)" comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)