### PR TITLE
docs: drop residual portcullis-verified refs (ctf-exfil example + portcullis-core comment)

### DIFF
--- a/crates/portcullis-core/Cargo.toml
+++ b/crates/portcullis-core/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/coproduct-opensource/nucleus"
 # This crate is the single source of truth for CapabilityLevel.
 # The verification target: Aeneas (Rust MIR → Lean 4) translates this crate
 # into pure functional Lean code, where we prove HeytingAlgebra properties
-# against the same Mathlib instance used by portcullis-verified.
+# against Mathlib (the Lean proofs live in `lean/`).
 #
 # By default this crate is dependency-free for Aeneas translation.
 # The optional `serde` feature enables serialization support when used

--- a/examples/ctf-exfil/README.md
+++ b/examples/ctf-exfil/README.md
@@ -91,7 +91,7 @@ nucleus shell --profile web_research --dir examples/ctf-exfil \
 | 5 | **Network policy** | DNS/URL allowlists, default-deny egress (Firecracker) |
 | 6 | **Audit trail** | Every tool call logged with hash chain for forensics |
 
-Nucleus ensures that **even if layers 1-3 fail, layer 4 catches it.** The uninhabitable state guard's monotonicity is formally proven: once an operation is denied, it stays denied for the rest of the session (proofs E1-E3 in `portcullis-verified`).
+Nucleus ensures that **even if layers 1-3 fail, layer 4 catches it.** The uninhabitable state guard's monotonicity is formally proven: once an operation is denied, it stays denied for the rest of the session (monotonicity proofs E1-E3, machine-checked by Kani in `portcullis`).
 
 ## Running All Rounds
 


### PR DESCRIPTION
Loop iteration (honest-claims). Two more references to the **nonexistent `portcullis-verified` crate**:

- `examples/ctf-exfil/README.md`: E1-E3 monotonicity proofs are Kani-checked in `portcullis` (kani.rs), not "in portcullis-verified".
- `crates/portcullis-core/Cargo.toml`: HeytingAlgebra proofs verify against Mathlib with Lean sources in `lean/`; dropped the dead crate mention.

Narrative/comment only; no behavior change. Comment-only Cargo.toml edit (cargo deny/clippy green).

Remaining `portcullis-verified` refs: `for-openclaw-users.md` (in-flight #1703), the dated blog post (historical, leave), and `coverage-matrix.yml` (CI — already notes the removal; careful edit if at all).

🤖 Generated with [Claude Code](https://claude.com/claude-code)