### PR TITLE
docs(sdk): add the README that Cargo.toml already declares

### DIFF
--- a/crates/nucleus-sdk/README.md
+++ b/crates/nucleus-sdk/README.md
@@ -1,0 +1,85 @@
+# nucleus-sdk
+
+Rust SDK for building sandboxed AI agents with
+[nucleus](https://github.com/coproduct-opensource/nucleus).
+
+[![docs.rs](https://img.shields.io/docsrs/nucleus-sdk)](https://docs.rs/nucleus-sdk)
+
+A unified client for nucleus services, where every tool call an agent makes is
+enforced by the [portcullis](../portcullis) permission lattice inside the pod.
+
+- **`ProxyClient`** — HTTP client for the tool-proxy (file I/O, execution, web access)
+- **`NodeClient`** — gRPC client for nucleus-node (pod lifecycle, streaming logs)
+- **`Nucleus`** — unified facade combining both clients
+- **`Intent`** — high-level permission profiles mapped to portcullis policies
+
+## Quick start
+
+```rust,no_run
+use nucleus_sdk::{Nucleus, Intent, HmacAuth};
+
+# async fn example() -> nucleus_sdk::Result<()> {
+// Connect to a running tool-proxy
+let nucleus = Nucleus::builder()
+    .proxy_url("http://127.0.0.1:8080")
+    .auth(HmacAuth::new(b"my-secret", Some("agent")))
+    .build()?;
+
+// Open a scoped session with uninhabitable-state-safe permissions
+let session = nucleus.intent(Intent::FixIssue).await?;
+
+// All operations enforced by portcullis inside the pod
+let source = session.read("src/main.rs").await?;
+session.write("src/main.rs", &source.replace("bug", "fix")).await?;
+# Ok(())
+# }
+```
+
+## Intent profiles
+
+An `Intent` is a named permission profile compiled to a portcullis policy, so an
+agent gets exactly the capabilities its task needs and no more:
+
+| Intent | Capabilities |
+|---|---|
+| `ResearchWeb` | read + web_fetch + web_search; no write/exec |
+| `CodeReview` | read + glob + grep; no write, no network |
+| `FixIssue` | full code editing with uninhabitable-state obligations |
+| `GenerateCode` | write files in workspace; network-isolated |
+| `Release` | git push + PR operations; CI-gated |
+| `DatabaseClient` | network to allowed hosts; no file write |
+| `ReadOnly` | observe files; no mutations |
+| `EditOnly` | write files; no execution or network |
+| `LocalDev` | permissive local environment |
+| `NetworkOnly` | web operations; no filesystem access |
+| `Orchestrate` | manage sub-pods; no direct file/network access |
+
+## Architecture
+
+```text
+┌─────────────────────────────────────────┐
+│  nucleus-sdk (this crate)               │
+│  ┌─────────┐  ┌──────────┐  ┌────────┐ │
+│  │ Nucleus  │──│  Intent  │──│ Auth   │ │
+│  │ (facade) │  │ (profile)│  │ (HMAC) │ │
+│  └────┬─────┘  └──────────┘  └────────┘ │
+│       │                                  │
+│  ┌────┴────────┐  ┌────────────────┐    │
+│  │ ProxyClient │  │  NodeClient    │    │
+│  │ (HTTP)      │  │  (gRPC/tonic)  │    │
+│  └─────────────┘  └────────────────┘    │
+└──────────────────────────────────────────┘
+       │                    │
+       ▼                    ▼
+  tool-proxy            nucleus-node
+  (in-pod HTTP)         (gRPC service)
+```
+
+## Feature flags
+
+- **`identity`** — SPIFFE identity support via [`nucleus-identity`](../nucleus-identity):
+  mTLS client configuration and workload certificate management.
+
+## License
+
+MIT


### PR DESCRIPTION
## What

`nucleus-sdk/Cargo.toml` declares `readme = "README.md"` but the file did not
exist — broken packaging metadata. This adds it.

Content is condensed faithfully from the crate's existing lib docs:
- quick start
- the full `Intent` profile → capability table (11 profiles)
- architecture diagram
- the `identity` feature flag

As the primary user-facing crate, this is the first doc an integrator hits.

## Scope / honesty

Fixes **only** the missing-readme reference. The crate has a separate,
pre-existing publish blocker (workspace path deps without version requirements,
surfaced by `cargo package`) that release-plz resolves at publish time — out of
scope here. No claim that the crate is now fully publishable.

## Verification

Doc-only; no source change.

```
cargo build -p nucleus-sdk  →  clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)