### PR TITLE
docs(proto): add README explaining the generated-types layout

### DIFF
--- a/crates/nucleus-proto/Cargo.toml
+++ b/crates/nucleus-proto/Cargo.toml
@@ -6,6 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 description = "Generated gRPC/Protobuf types for nucleus-node"
 repository = "https://github.com/coproduct-opensource/nucleus"
+readme = "README.md"
 
 [dependencies]
 tonic = { workspace = true }

--- a/crates/nucleus-proto/README.md
+++ b/crates/nucleus-proto/README.md
@@ -1,0 +1,49 @@
+# nucleus-proto
+
+Generated gRPC / Protobuf types for nucleus's internal services.
+
+[![docs.rs](https://img.shields.io/docsrs/nucleus-proto)](https://docs.rs/nucleus-proto)
+
+Per the repo convention that **`.proto` files are the source of truth** for
+service contracts, this crate compiles those definitions (via `tonic` +
+`prost`) into Rust client and server stubs that the rest of the workspace
+depends on.
+
+## Modules
+
+| Module | Package | Contract |
+|---|---|---|
+| `nucleus_node` | `nucleus.node.v1` | the nucleus-node pod-lifecycle service |
+| `control_plane` | `nucleus.control_plane.v1` | the control-plane `JobService` (iter-1: `Submit` + `Get`; iter-2 adds `StreamEvents` + `Cancel`) |
+
+Both client and server stubs are generated (`build_client(true)` +
+`build_server(true)`).
+
+## Where the `.proto` files live
+
+The schemas are **not** in this crate — they live next to the services that own
+them, and `build.rs` compiles them from there:
+
+- [`crates/nucleus-node/proto/nucleus_node.proto`](../nucleus-node/proto/nucleus_node.proto)
+- [`crates/nucleus-control-plane/proto/job_service.proto`](../nucleus-control-plane/proto/job_service.proto)
+
+Editing either `.proto` triggers a rebuild (the build script emits
+`rerun-if-changed` for both). `protoc` itself is vendored via
+`protoc-bin-vendored`, so no system `protoc` install is required.
+
+## Usage
+
+```rust,ignore
+use nucleus_proto::control_plane::{
+    job_service_client::JobServiceClient,
+    JobSubmission,
+};
+
+// JobService: rpc Submit(JobSubmission) -> SubmittedJob; rpc Get(JobIdMessage) -> JobStatus
+let mut client = JobServiceClient::connect("http://[::1]:50051").await?;
+let submitted = client.submit(JobSubmission { /* … */ }).await?;
+```
+
+## License
+
+MIT


### PR DESCRIPTION
## What

`nucleus-proto` compiles the workspace's gRPC contracts into Rust stubs but had
no README — and its layout is non-obvious: the `.proto` **source of truth lives
in the sibling service crates** (`nucleus-node/proto`,
`nucleus-control-plane/proto`), not here.

Adds a README documenting:
- the two modules + packages (`nucleus.node.v1`, `nucleus.control_plane.v1`)
- the `JobService` rpcs (Submit/Get; iter-2 StreamEvents/Cancel)
- where the `.proto` files live + the `rerun-if-changed` wiring
- the vendored `protoc` (no system install needed)
- a usage example with the real generated names

Adds `readme = "README.md"` to Cargo.toml.

## Verification

Doc-only; no source change.

```
cargo build -p nucleus-proto  →  clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)