### PR TITLE
docs(otel-bootstrap): add README for the shared OTLP setup helper

### DIFF
--- a/crates/nucleus-otel-bootstrap/Cargo.toml
+++ b/crates/nucleus-otel-bootstrap/Cargo.toml
@@ -6,6 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 description = "Shared OpenTelemetry OTLP bootstrap helper for nucleus server binaries"
 repository = "https://github.com/coproduct-opensource/nucleus"
+readme = "README.md"
 keywords = ["opentelemetry", "tracing", "observability"]
 categories = ["development-tools::profiling"]
 

--- a/crates/nucleus-otel-bootstrap/README.md
+++ b/crates/nucleus-otel-bootstrap/README.md
@@ -1,0 +1,51 @@
+# nucleus-otel-bootstrap
+
+Shared OpenTelemetry OTLP bootstrap for nucleus server binaries.
+
+[![docs.rs](https://img.shields.io/docsrs/nucleus-otel-bootstrap)](https://docs.rs/nucleus-otel-bootstrap)
+
+Wires `tracing` → `tracing-opentelemetry` → `opentelemetry-otlp` so every server
+(verifier, control-plane, OIDC OP, …) emits trace spans to a collector when
+configured, and falls through to stderr-only logging when not. One helper, called
+once in `main`, so the observability setup is identical across binaries.
+
+## Usage
+
+```rust,ignore
+use nucleus_otel_bootstrap::{init, OtelGuard};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // Hold the guard for the whole process: dropping it flushes pending spans.
+    let _otel: OtelGuard = init("nucleus-verifier-service")?;
+    // ...your server here; spans propagate to the collector...
+    Ok(())
+}
+```
+
+The returned `OtelGuard` must live until the server finishes serving — dropping
+it flushes spans emitted near shutdown, which would otherwise be lost.
+
+## Activation
+
+OTLP export turns on when `OTEL_EXPORTER_OTLP_ENDPOINT` is set (the canonical
+[OTel env var][envs]); with no endpoint, the subscriber still installs
+`fmt` + `EnvFilter` logging and the OTel pieces are no-ops.
+
+| Env var | Effect |
+|---|---|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | collector endpoint; **presence enables export** |
+| `OTEL_SERVICE_NAME` | overrides the `service_name` argument |
+| `OTEL_PROPAGATORS` | defaults to `tracecontext,baggage` (W3C) |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | `grpc` (default) or `http/protobuf` |
+
+[envs]: https://opentelemetry.io/docs/languages/sdk-configuration/general/
+
+## Scope
+
+This crate sets up **trace** export (spans). It is the single place server
+binaries call so trace context propagates uniformly via W3C Trace Context.
+
+## License
+
+MIT


### PR DESCRIPTION
## What

`nucleus-otel-bootstrap` is the single place server binaries call to wire
`tracing` → OTLP span export, but had no README.

Adds one condensed from the lib docs:
- `init` / `OtelGuard` usage (hold the guard so spans flush on shutdown)
- env-var activation table (`OTEL_EXPORTER_OTLP_ENDPOINT` presence enables
  export; service-name / propagators / protocol knobs)
- honest scope note: this sets up **trace** export (spans)

Adds `readme = "README.md"` to Cargo.toml.

## Verification

Doc-only; no source change.

```
cargo build -p nucleus-otel-bootstrap  →  clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)