### PR TITLE
docs(control-plane): add README for the job orchestrator

### DIFF
--- a/crates/nucleus-control-plane/Cargo.toml
+++ b/crates/nucleus-control-plane/Cargo.toml
@@ -6,6 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 description = "Job orchestrator: typed JobSpec → agent execution → provenance Bundle"
 repository = "https://github.com/coproduct-opensource/nucleus"
+readme = "README.md"
 keywords = ["control-plane", "orchestrator", "provenance", "ifc", "agents"]
 categories = ["development-tools"]
 

--- a/crates/nucleus-control-plane/README.md
+++ b/crates/nucleus-control-plane/README.md
@@ -1,0 +1,43 @@
+# nucleus-control-plane
+
+Job orchestrator: typed `JobSpec` → agent execution → provenance `Bundle`.
+
+[![docs.rs](https://img.shields.io/docsrs/nucleus-control-plane)](https://docs.rs/nucleus-control-plane)
+
+Given a typed `JobSpec` (input reference, task, destination, agent driver) and a
+`JobRunner` implementation, `execute_job` runs the agent inside a fresh
+SPIFFE-rooted session, captures every lineage edge it emits, and produces a
+verified provenance [`Bundle`](../nucleus-envelope) via `nucleus-envelope`.
+
+## Flow
+
+```text
+JobSpec ──► execute_job ──► (fresh SPIFFE session)
+                              │  run JobRunner
+                              │  capture lineage edges
+                              ▼
+                           provenance Bundle  ──► Destination
+```
+
+## Public surface
+
+| Item | Role |
+|---|---|
+| `JobSpec`, `InputRef`, `Destination`, `AgentDriverRef` | the typed job description |
+| `JobRunner` (+ `MockJobRunner`) | the agent-execution trait (mock for tests) |
+| `execute_job` | orchestrates a single job end-to-end |
+| `SessionWriter` | captures the lineage subgraph during a session |
+| `JobId`, `JobState`, `JobOutcome` | job lifecycle/result types |
+
+## Vendor neutrality
+
+`JobRunner` is a **trait**. The orchestrator core knows only "run agent X, collect
+lineage Y, package result Z" — it does not know which model does the work, what it
+costs, or how its credentials are formatted. Concrete agent integrations and any
+vendor-specific cost models / credential handling live in **downstream** crates
+(e.g. the proprietary `workstream-kg` platform), never here. A `MockJobRunner` is
+provided so the orchestration logic is fully testable with no external agent.
+
+## License
+
+MIT


### PR DESCRIPTION
## What

`nucleus-control-plane` (typed `JobSpec` → agent execution → provenance
`Bundle`) had no README. Adds one condensed from the lib docs:
- the `execute_job` flow
- the public-surface table (JobSpec / JobRunner / execute_job / SessionWriter /
  lifecycle types)
- the **vendor-neutrality contract**: `JobRunner` is a trait; concrete agent
  integrations + vendor cost models live downstream (e.g. workstream-kg), never
  here. `MockJobRunner` keeps orchestration fully testable.

Written vendor-agnostically per the OSS repo policy. Adds `readme = "README.md"`.

## Note

`crates/nucleus-policy` was skipped this round — it's a hollow crate (only a
`Cargo.toml`, no `src/`); a README there would overclaim a non-existent surface.
Flagging separately.

## Verification

Doc-only; no source change.

```
cargo build -p nucleus-control-plane  →  clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)