### PR TITLE
docs(ck-types): add README for the Constitutional Kernel core types

### DIFF
--- a/crates/ck-types/Cargo.toml
+++ b/crates/ck-types/Cargo.toml
@@ -4,6 +4,7 @@ description = "Constitutional Kernel — core types, manifests, digests, and pol
 version.workspace = true
 edition.workspace = true
 license = "MIT"
+readme = "README.md"
 
 [dependencies]
 base64 = { workspace = true }

--- a/crates/ck-types/README.md
+++ b/crates/ck-types/README.md
@@ -1,0 +1,43 @@
+# ck-types
+
+Constitutional Kernel — core types, manifests, digests, and the policy lattice.
+
+[![docs.rs](https://img.shields.io/docsrs/ck-types)](https://docs.rs/ck-types)
+
+The foundational data structures for **proof-carrying constitutional
+self-amendment**: the schemas a system uses to describe what it is allowed to
+do, to evidence a proposed change, and to record the terminal decision about
+whether that change is admitted.
+
+## Core types
+
+| Type | Role |
+|---|---|
+| `PolicyManifest` | canonical schema for capabilities, I/O surface, budgets, and proof requirements (`CapabilitySet`, `IoSurface`, `BudgetBounds`, `ProofRequirements`, `AmendmentRules`) |
+| `WitnessBundle` | canonical evidence schema for amendment admission (`AdmissionMode`, `SignatureVerifier`) |
+| `PatchClass` | categorization of self-modification danger levels |
+| `ArtifactDigest` | content-addressed artifact references |
+| `AdmissionDecision` | terminal state of the amendment pipeline |
+
+## Patch classes
+
+`PatchClass` determines which proof obligations must be satisfied before a
+self-modification is admitted, in increasing order of danger:
+
+| Class | Covers |
+|---|---|
+| `Config` | config, thresholds, prompts, eval-suite additions |
+| `Controller` | scheduler, routing, work-state transitions, budget-ledger logic |
+| `Evaluator` | proposer, evaluator, search strategy, scoring logic |
+| `Constitutional` | constitutional / kernel-adjacent changes — **requires human approval** |
+
+## Scope
+
+This crate is **types only** — serializable schemas (serde) plus content-address
+digests (BLAKE3). The admission logic that consumes them lives in the sibling
+`ck-policy` / `ck-kernel` crates; keeping the schemas dependency-light lets every
+layer share one source of truth for the manifest and witness formats.
+
+## License
+
+MIT


### PR DESCRIPTION
Adds a README for ck-types (Constitutional Kernel core schemas): core type table (PolicyManifest/WitnessBundle/PatchClass/ArtifactDigest/AdmissionDecision), the PatchClass danger ladder (Config→Controller→Evaluator→Constitutional; last requires human approval), scope note (types-only; logic in sibling ck-policy/ck-kernel). Adds readme= to Cargo.toml. Doc-only; cargo build -p ck-types clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)