### PR TITLE
docs(portcullis-effects): add README for the sealed effect traits

### DIFF
--- a/crates/portcullis-effects/Cargo.toml
+++ b/crates/portcullis-effects/Cargo.toml
@@ -6,6 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 description = "Sealed effect traits — I/O only through policy-enforced channels"
 repository = "https://github.com/coproduct-opensource/nucleus"
+readme = "README.md"
 keywords = ["ai", "security", "effects", "permissions", "agents"]
 categories = ["development-tools", "authentication"]
 

--- a/crates/portcullis-effects/README.md
+++ b/crates/portcullis-effects/README.md
@@ -1,0 +1,61 @@
+# portcullis-effects
+
+Sealed effect traits — the primary surface for all I/O in nucleus, where every
+operation goes through a policy-enforced channel.
+
+[![docs.rs](https://img.shields.io/docsrs/portcullis-effects)](https://docs.rs/portcullis-effects)
+
+Effect types replace the raw capability lattice as the *primary* public surface.
+Instead of building a `CapabilityLattice` and remembering to call preflight,
+callers receive a concrete effect handler whose only public constructor,
+`production_effects`, **requires a policy**. Bypassing policy is structurally
+impossible: the real handler is unconstructible outside this crate, so policy is
+checked at every method call before any I/O occurs.
+
+```text
+Old surface:  caller builds CapabilityLattice, calls preflight, manually enforces
+New surface:  caller receives impl FileEffect + WebEffect + …,
+              policy is checked at every method call before I/O occurs
+```
+
+## Effect traits
+
+| Trait | I/O |
+|---|---|
+| `FileEffect` | read / write / search the filesystem |
+| `WebEffect` | outbound fetch / search |
+| `ShellEffect` | command execution (`ShellOutput`) |
+| `GitEffect` | git operations |
+| `AgentSpawnEffect` | spawn sub-agents |
+
+## Usage
+
+```rust,ignore
+use portcullis_effects::{production_effects, FileEffect, WebEffect};
+use portcullis_core::{CapabilityLattice, CapabilityLevel};
+
+let policy = CapabilityLattice {
+    read_files: CapabilityLevel::Always,
+    web_fetch: CapabilityLevel::LowRisk,
+    ..CapabilityLattice::bottom()
+};
+let fx = production_effects(policy);
+
+// Policy is checked here — no separate preflight call.
+let contents = fx.read(std::path::Path::new("src/main.rs"))?;
+fx.fetch("https://example.com")?;
+```
+
+## Test doubles
+
+| Handler | Use |
+|---|---|
+| `DenyAllEffects` | rejects everything — exercise deny paths |
+| `RecordingEffects` | records every call (`calls()`) — assert what was invoked |
+| `AllowListEffects` | allow a fixed set — targeted positive tests |
+
+Async variants live in the `async_traits` module.
+
+## License
+
+MIT


### PR DESCRIPTION
## What

`portcullis-effects` (capability-by-construction I/O surface) had no README.
Adds one:
- the sealed-handler design (`production_effects` requires a policy; the real
  handler is unconstructible outside the crate → policy enforced at every call)
- the effect-trait table (File/Web/Shell/Git/AgentSpawn)
- usage example + the test doubles (DenyAll / Recording / AllowList) + the
  `async_traits` module

Adds `readme = "README.md"`.

## Verification

Doc-only; no source change. `cargo build -p portcullis-effects` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)