### PR TITLE
docs(zkvm-guest): add README for the RISC-V proof-carrying parser guest

### DIFF
--- a/crates/portcullis-zkvm-guest/Cargo.toml
+++ b/crates/portcullis-zkvm-guest/Cargo.toml
@@ -4,6 +4,7 @@ version = "1.0.0"
 edition = "2021"
 description = "RISC-V guest program for zkVM-verified WASM parser execution"
 license = "MIT"
+readme = "README.md"
 
 # Guest binary — compiled to RISC-V ELF via risc0-build.
 # Host crates embed the ELF via `risc0_build::embed_methods_recursive()`.

--- a/crates/portcullis-zkvm-guest/README.md
+++ b/crates/portcullis-zkvm-guest/README.md
@@ -1,0 +1,57 @@
+# portcullis-zkvm-guest
+
+RISC-V zkVM guest program for proof-carrying WASM parser execution.
+
+This binary is compiled to a RISC-V ELF by `risc0-build` and embedded in
+[`portcullis-core`](../portcullis-core) (behind the `zkvm` feature). The host
+invokes the prover with this ELF and receives a `risc0_zkvm::Receipt` proving:
+
+> "Parser with hash H, when executed on input I, produced output O."
+
+## Journal layout
+
+The guest commits exactly **96 bytes** to the proof journal:
+
+| Bytes | Field | Meaning |
+|---|---|---|
+| `0..32` | `parser_hash` | SHA-256 of the WASM parser binary |
+| `32..64` | `input_hash` | SHA-256 of the raw input bytes |
+| `64..96` | `output_hash` | SHA-256 of the parser's output bytes |
+
+A verifier that trusts the receipt therefore learns the parser/input/output
+binding without re-executing the parser.
+
+## Host usage
+
+```rust,ignore
+use risc0_zkvm::{default_prover, ExecutorEnv};
+
+let env = ExecutorEnv::builder()
+    .write(&parser_wasm)?
+    .write(&input_bytes)?
+    .build()?;
+let receipt = default_prover().prove(env, PORTCULLIS_PARSER_EXEC_ELF)?;
+let journal: [u8; 96] = receipt.journal.decode()?;
+// journal[0..32] = parser_hash, [32..64] = input_hash, [64..96] = output_hash
+```
+
+## Building & testing
+
+This crate declares its **own `[workspace]`** so it can be compiled
+independently with the RISC-V target — it is intentionally **not** a member of
+the main nucleus workspace.
+
+- The `wasmi`-based execution logic lives in the **library** and is host-testable:
+
+  ```bash
+  cargo test --lib   # from this crate's directory
+  ```
+
+- The **binary** target links only for the zkVM target (it uses the risc0
+  `guest::entry!` macro); building the bin on the host is expected to fail at
+  link time. It is produced via `risc0-build` during a `zkvm`-feature build of
+  `portcullis-core`.
+
+## License
+
+MIT


### PR DESCRIPTION
## What

`portcullis-zkvm-guest` (risc0 guest proving parser/input/output hash binding)
had no README. Adds one:
- the proof statement + the 96-byte journal layout
  (parser_hash / input_hash / output_hash)
- host prover usage
- the build/test reality: it declares its **own `[workspace]`** (not a
  main-workspace member); the lib is host-testable; the **bin links only for the
  zkVM target** (host link failure by design; produced via `risc0-build` under
  portcullis-core's `zkvm` feature)

Adds `readme = "README.md"`.

## Verification

Doc-only; no source change. Verified host lib: `cargo test --lib` → 8/8 green.
(The bin is RISC-V-target-only, as documented.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)