### PR TITLE
feat(agent-card): optional signed RuntimeGuaranteeProfile (IFC attestation)

### DIFF
--- a/crates/nucleus-agent-card/src/card.rs
+++ b/crates/nucleus-agent-card/src/card.rs
@@ -51,6 +51,55 @@ pub struct AgentCard {
     /// bundles. Becomes a [`nucleus_envelope::TrustAnchor`] only after the
     /// card is verified.
     pub trust_jwks: nucleus_lineage::Jwks,
+
+    /// Optional declared runtime information-flow-control guarantee profile.
+    /// Covered by the card's JCS signature, so a verifier knows the declaration
+    /// is authentic and untampered. **Attestation, not enforcement** — see
+    /// [`RuntimeGuaranteeProfile`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime_guarantees: Option<RuntimeGuaranteeProfile>,
+}
+
+/// A declared runtime information-flow-control (IFC) guarantee profile, carried
+/// inside a signed [`AgentCard`].
+///
+/// # What a verified profile proves — and does not
+///
+/// Because the profile is part of the card's JCS-canonical bytes, the card
+/// signature makes it **authentic and tamper-evident**: a counterparty can
+/// confirm *the agent issued this exact declaration*. It does **NOT** prove the
+/// declared rules are enforced, sound, or sufficient — attestation is not
+/// enforcement. The agent's `nucleus-envelope` receipts are the behavioural
+/// evidence that the declared rules were actually evaluated at runtime; a
+/// verifier checks them post-hoc, client-side. Enforcement remains host-side.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeGuaranteeProfile {
+    /// Profile schema version (e.g. `"1.0"`), versioned independently of the card.
+    pub profile_version: String,
+
+    /// Data-flow source kinds the agent declares it labels/tracks — the
+    /// lethal-trifecta surface (e.g. `"web_content"`, `"secret"`, `"file_read"`).
+    /// Tokens match `nucleus-verify-commerce`'s `DeclaredInput` serde names.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tracked_sources: Vec<String>,
+
+    /// Named IFC enforcement rules the agent declares it applies at runtime.
+    pub enforcement_rules: Vec<EnforcementRule>,
+
+    /// Advisory pointer to external policy evidence (e.g. a Microsoft Agent
+    /// Control Specification policy id, or a Sigstore bundle URL). Advisory
+    /// only — a verifier with no out-of-band knowledge cannot confirm it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attestation_reference: Option<String>,
+}
+
+/// One named IFC enforcement rule a [`RuntimeGuaranteeProfile`] declares.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EnforcementRule {
+    /// Stable rule identifier (e.g. `"no_adversarial_to_outbound"`).
+    pub name: String,
+    /// Human-readable description of what the rule denies.
+    pub description: String,
 }
 
 /// One detached RFC 7515 JWS-JSON signature over the JCS-canonicalized
@@ -114,6 +163,7 @@ mod tests {
                     not_after: None,
                 }],
             },
+            runtime_guarantees: None,
         }
     }
 

--- a/crates/nucleus-agent-card/src/jcs.rs
+++ b/crates/nucleus-agent-card/src/jcs.rs
@@ -82,6 +82,7 @@ mod tests {
             supported_envelope_schema_versions: vec!["1".to_string()],
             jwks_uri: None,
             trust_jwks: nucleus_lineage::Jwks { keys: vec![] },
+            runtime_guarantees: None,
         };
         let first = canonicalize(&card).unwrap();
         let second = canonicalize(&card.clone()).unwrap();

--- a/crates/nucleus-agent-card/src/lib.rs
+++ b/crates/nucleus-agent-card/src/lib.rs
@@ -63,7 +63,9 @@ pub mod sign;
 mod sign_verify_tests;
 
 pub use anchor::trust_anchor_from_card;
-pub use card::{AgentCard, AgentCardSignature, SignedAgentCard};
+pub use card::{
+    AgentCard, AgentCardSignature, EnforcementRule, RuntimeGuaranteeProfile, SignedAgentCard,
+};
 pub use jcs::canonicalize;
 pub use verify::{verify_card, VerifiedCard};
 

--- a/crates/nucleus-agent-card/src/sign_verify_tests.rs
+++ b/crates/nucleus-agent-card/src/sign_verify_tests.rs
@@ -45,6 +45,7 @@ fn sample_card() -> AgentCard {
         supported_envelope_schema_versions: vec!["1".to_string()],
         jwks_uri: None,
         trust_jwks: good_jwks(),
+        runtime_guarantees: None,
     }
 }
 
@@ -127,4 +128,66 @@ fn malformed_trust_jwks_is_rejected() {
     let signed = sign_card(card, &der).unwrap();
     let err = verify_card(&signed, &pub_jwk).unwrap_err();
     assert!(matches!(err, crate::Error::Verify(_)), "got {err:?}");
+}
+
+fn sample_profile() -> crate::RuntimeGuaranteeProfile {
+    crate::RuntimeGuaranteeProfile {
+        profile_version: "1.0".to_string(),
+        tracked_sources: vec!["web_content".to_string(), "secret".to_string()],
+        enforcement_rules: vec![crate::EnforcementRule {
+            name: "no_adversarial_to_outbound".to_string(),
+            description:
+                "deny outbound actions whose ancestry includes adversarial-integrity content"
+                    .to_string(),
+        }],
+        attestation_reference: None,
+    }
+}
+
+#[test]
+fn sign_and_verify_with_runtime_guarantees_roundtrip() {
+    let (der, pub_jwk) = p256_keypair();
+    let mut card = sample_card();
+    card.runtime_guarantees = Some(sample_profile());
+    let signed = sign_card(card, &der).unwrap();
+    let verified = verify_card(&signed, &pub_jwk).expect("card with profile must verify");
+    let prof = verified
+        .card
+        .runtime_guarantees
+        .as_ref()
+        .expect("profile present");
+    assert_eq!(prof.enforcement_rules[0].name, "no_adversarial_to_outbound");
+}
+
+#[test]
+fn tampering_runtime_guarantees_breaks_signature() {
+    let (der, pub_jwk) = p256_keypair();
+    let mut card = sample_card();
+    card.runtime_guarantees = Some(sample_profile());
+    let mut signed = sign_card(card, &der).unwrap();
+    // Flip a declared rule name AFTER signing → JCS changes → signature must fail.
+    signed
+        .card
+        .runtime_guarantees
+        .as_mut()
+        .unwrap()
+        .enforcement_rules[0]
+        .name = "allow_everything".to_string();
+    assert!(
+        verify_card(&signed, &pub_jwk).is_err(),
+        "a tampered runtime-guarantee profile must fail verification"
+    );
+}
+
+#[test]
+fn backward_compat_card_without_profile_omits_field_and_verifies() {
+    let (der, pub_jwk) = p256_keypair();
+    let card = sample_card(); // runtime_guarantees: None
+    let json = serde_json::to_value(&card).unwrap();
+    assert!(
+        json.get("runtime_guarantees").is_none(),
+        "a None profile must be omitted from the card JSON (backward compatible)"
+    );
+    let signed = sign_card(card, &der).unwrap();
+    assert!(verify_card(&signed, &pub_jwk).is_ok());
 }

--- a/crates/nucleus-agent-card/src/verify.rs
+++ b/crates/nucleus-agent-card/src/verify.rs
@@ -157,6 +157,7 @@ mod tests {
             supported_envelope_schema_versions: vec!["1".to_string()],
             jwks_uri: None,
             trust_jwks: jwks,
+            runtime_guarantees: None,
         }
     }
 

--- a/crates/nucleus-agent-card/tests/handshake.rs
+++ b/crates/nucleus-agent-card/tests/handshake.rs
@@ -110,6 +110,7 @@ fn card_for(issuer: &LocalIssuer) -> AgentCard {
         supported_envelope_schema_versions: vec!["1".to_string(), "2".to_string()],
         jwks_uri: Some("https://summarizer.prod.example.com/.well-known/jwks.json".to_string()),
         trust_jwks: jwks,
+        runtime_guarantees: None,
     }
 }
 

--- a/crates/nucleus-verifier-service/tests/integration.rs
+++ b/crates/nucleus-verifier-service/tests/integration.rs
@@ -826,6 +826,7 @@ async fn well_known_agent_card_verifies_against_matching_key() {
         supported_envelope_schema_versions: vec!["1".to_string()],
         jwks_uri: None,
         trust_jwks: advertised,
+        runtime_guarantees: None,
     };
     let signed = sign_card(card, &der).unwrap();
 

--- a/crates/nucleus-verify-commerce/examples/quickstart.rs
+++ b/crates/nucleus-verify-commerce/examples/quickstart.rs
@@ -49,6 +49,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         supported_envelope_schema_versions: vec!["1".to_string()],
         jwks_uri: None,
         trust_jwks: buyer_trust_jwks,
+        runtime_guarantees: None,
     };
     let signed_card = sign_card(buyer_card, pkcs8.as_ref())?;
 

--- a/crates/nucleus-verify-commerce/src/card_verifier.rs
+++ b/crates/nucleus-verify-commerce/src/card_verifier.rs
@@ -78,6 +78,7 @@ mod tests {
             supported_envelope_schema_versions: vec!["1".to_string()],
             jwks_uri: None,
             trust_jwks: jwks,
+            runtime_guarantees: None,
         }
     }
 


### PR DESCRIPTION
Adds an optional, signature-covered `runtime_guarantees: Option<RuntimeGuaranteeProfile>` to AgentCard so an agent can DECLARE the IFC enforcement it applies (tracked sources + named enforcement rules + advisory external-policy ref e.g. MS ACS / Sigstore). The profile is inside the card's JCS bytes, so the existing ES256 signature covers it — authentic + tamper-evident.

Honest boundary (on the type): ATTESTATION, not enforcement. A verified profile proves the agent issued this exact declaration; NOT that rules are enforced/sound/sufficient. Receipts are the behavioural evidence (post-hoc, client-side); enforcement stays host-side.

Backward compatible (optional + skip_serializing_if); all AgentCard construction sites updated. Tests: roundtrip / tamper-breaks-signature / backward-compat — 17/17 pass; clippy --all-features clean.

First of a series toward signed, IFC-attested, receipt-bearing agents (RFC + just agent-sign to follow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)