### PR TITLE
feat(agent-card): just agent-sign — sign + verify a card declaring an IFC profile

### DIFF
--- a/crates/nucleus-agent-card/Cargo.toml
+++ b/crates/nucleus-agent-card/Cargo.toml
@@ -34,6 +34,12 @@ default = []
 # always available without it and is secret-free.
 sign = []
 
+# The `agent-sign` example calls sign_card, so it only builds with `sign`
+# (keeps default builds + CI free of the signing path).
+[[example]]
+name = "agent_sign"
+required-features = ["sign"]
+
 [dev-dependencies]
 # `dev` feature on nucleus-lineage gives the integration test the
 # in-process LocalIssuer + InMemorySink it needs to build a real Bundle.

--- a/crates/nucleus-agent-card/examples/agent_sign.rs
+++ b/crates/nucleus-agent-card/examples/agent_sign.rs
@@ -1,0 +1,113 @@
+//! `agent-sign` — sign an Agent Card that declares an IFC runtime-guarantee
+//! profile, then verify it (incl. tamper-detection of the profile).
+//!
+//! Run with:
+//!
+//! ```bash
+//! just agent-sign
+//! # or: cargo run -p nucleus-agent-card --example agent_sign --features sign
+//! ```
+//!
+//! This uses an **ephemeral** P-256 key for self-containment. In production the
+//! key is obtained keyless via OIDC→SPIFFE (`nucleus-github-oidc` /
+//! `nucleus-fly-oidc`); the signing + verification are identical. The profile is
+//! ATTESTATION, not enforcement — see `RuntimeGuaranteeProfile`.
+
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine as _;
+use ring::rand::SystemRandom;
+use ring::signature::{EcdsaKeyPair, KeyPair, ECDSA_P256_SHA256_FIXED_SIGNING};
+
+use nucleus_agent_card::{
+    sign_card, verify_card, AgentCard, EnforcementRule, RuntimeGuaranteeProfile,
+};
+use nucleus_identity::JsonWebKey;
+use nucleus_lineage::{Jwks, LocalIssuer};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Ephemeral P-256 signer (production: OIDC-keyless → SPIFFE).
+    let rng = SystemRandom::new();
+    let pkcs8 =
+        EcdsaKeyPair::generate_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, &rng).expect("keygen");
+    let kp = EcdsaKeyPair::from_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, pkcs8.as_ref(), &rng)
+        .expect("load key");
+    let pk = kp.public_key().as_ref();
+    let resolved_key = JsonWebKey::ec_p256(
+        URL_SAFE_NO_PAD.encode(&pk[1..33]),
+        URL_SAFE_NO_PAD.encode(&pk[33..65]),
+    );
+
+    // The agent's card, declaring the IFC guarantee it enforces at runtime.
+    let trust_jwks: Jwks = serde_json::from_value(LocalIssuer::random()?.publish_jwks())?;
+    let card = AgentCard {
+        spiffe_id: "spiffe://prod.example.com/ns/agents/sa/summarizer".to_string(),
+        did: "did:web:summarizer.prod.example.com".to_string(),
+        security_schemes: serde_json::json!({}),
+        supported_envelope_schema_versions: vec!["1".to_string()],
+        jwks_uri: None,
+        trust_jwks,
+        runtime_guarantees: Some(RuntimeGuaranteeProfile {
+            profile_version: "1.0".to_string(),
+            tracked_sources: vec![
+                "user_prompt".to_string(),
+                "web_content".to_string(),
+                "secret".to_string(),
+            ],
+            enforcement_rules: vec![
+                EnforcementRule {
+                    name: "no_adversarial_to_outbound".to_string(),
+                    description: "deny outbound actions whose ancestry includes \
+                                  adversarial-integrity content (web/tool)"
+                        .to_string(),
+                },
+                EnforcementRule {
+                    name: "no_secret_to_public_sink".to_string(),
+                    description: "deny secret-confidentiality data flowing to a public sink"
+                        .to_string(),
+                },
+            ],
+            // Advisory: point at an external policy (e.g. an MS ACS policy id).
+            attestation_reference: None,
+        }),
+    };
+
+    // Sign → verify.
+    let signed = sign_card(card, pkcs8.as_ref())?;
+    println!(
+        "signed agent card:\n{}",
+        serde_json::to_string_pretty(&signed)?
+    );
+
+    let verified = verify_card(&signed, &resolved_key)?;
+    let profile = verified
+        .card
+        .runtime_guarantees
+        .as_ref()
+        .expect("the verified card carries its IFC profile");
+    println!("\nverified ✓  — IFC profile is authentic + untampered:");
+    println!("  spiffe_id        = {}", verified.card.spiffe_id);
+    println!("  tracked_sources  = {:?}", profile.tracked_sources);
+    for rule in &profile.enforcement_rules {
+        println!("  rule             = {} — {}", rule.name, rule.description);
+    }
+
+    // Tamper-detection: flip a declared rule after signing → verify must fail.
+    let mut tampered = signed;
+    tampered
+        .card
+        .runtime_guarantees
+        .as_mut()
+        .unwrap()
+        .enforcement_rules[0]
+        .name = "allow_everything".to_string();
+    match verify_card(&tampered, &resolved_key) {
+        Err(_) => println!("\ntamper check ✓  — flipping a declared rule breaks the signature"),
+        Ok(_) => panic!("BUG: a tampered profile must not verify"),
+    }
+
+    println!(
+        "\nNote: a verified profile is ATTESTATION, not enforcement — the client \
+         verifies the declaration + receipts; the host enforces (coverage-limited)."
+    );
+    Ok(())
+}

--- a/crates/nucleus-agent-card/src/card.rs
+++ b/crates/nucleus-agent-card/src/card.rs
@@ -51,6 +51,55 @@ pub struct AgentCard {
     /// bundles. Becomes a [`nucleus_envelope::TrustAnchor`] only after the
     /// card is verified.
     pub trust_jwks: nucleus_lineage::Jwks,
+
+    /// Optional declared runtime information-flow-control guarantee profile.
+    /// Covered by the card's JCS signature, so a verifier knows the declaration
+    /// is authentic and untampered. **Attestation, not enforcement** — see
+    /// [`RuntimeGuaranteeProfile`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime_guarantees: Option<RuntimeGuaranteeProfile>,
+}
+
+/// A declared runtime information-flow-control (IFC) guarantee profile, carried
+/// inside a signed [`AgentCard`].
+///
+/// # What a verified profile proves — and does not
+///
+/// Because the profile is part of the card's JCS-canonical bytes, the card
+/// signature makes it **authentic and tamper-evident**: a counterparty can
+/// confirm *the agent issued this exact declaration*. It does **NOT** prove the
+/// declared rules are enforced, sound, or sufficient — attestation is not
+/// enforcement. The agent's `nucleus-envelope` receipts are the behavioural
+/// evidence that the declared rules were actually evaluated at runtime; a
+/// verifier checks them post-hoc, client-side. Enforcement remains host-side.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeGuaranteeProfile {
+    /// Profile schema version (e.g. `"1.0"`), versioned independently of the card.
+    pub profile_version: String,
+
+    /// Data-flow source kinds the agent declares it labels/tracks — the
+    /// lethal-trifecta surface (e.g. `"web_content"`, `"secret"`, `"file_read"`).
+    /// Tokens match `nucleus-verify-commerce`'s `DeclaredInput` serde names.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tracked_sources: Vec<String>,
+
+    /// Named IFC enforcement rules the agent declares it applies at runtime.
+    pub enforcement_rules: Vec<EnforcementRule>,
+
+    /// Advisory pointer to external policy evidence (e.g. a Microsoft Agent
+    /// Control Specification policy id, or a Sigstore bundle URL). Advisory
+    /// only — a verifier with no out-of-band knowledge cannot confirm it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attestation_reference: Option<String>,
+}
+
+/// One named IFC enforcement rule a [`RuntimeGuaranteeProfile`] declares.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EnforcementRule {
+    /// Stable rule identifier (e.g. `"no_adversarial_to_outbound"`).
+    pub name: String,
+    /// Human-readable description of what the rule denies.
+    pub description: String,
 }
 
 /// One detached RFC 7515 JWS-JSON signature over the JCS-canonicalized
@@ -114,6 +163,7 @@ mod tests {
                     not_after: None,
                 }],
             },
+            runtime_guarantees: None,
         }
     }
 

--- a/crates/nucleus-agent-card/src/jcs.rs
+++ b/crates/nucleus-agent-card/src/jcs.rs
@@ -82,6 +82,7 @@ mod tests {
             supported_envelope_schema_versions: vec!["1".to_string()],
             jwks_uri: None,
             trust_jwks: nucleus_lineage::Jwks { keys: vec![] },
+            runtime_guarantees: None,
         };
         let first = canonicalize(&card).unwrap();
         let second = canonicalize(&card.clone()).unwrap();

--- a/crates/nucleus-agent-card/src/lib.rs
+++ b/crates/nucleus-agent-card/src/lib.rs
@@ -63,7 +63,9 @@ pub mod sign;
 mod sign_verify_tests;
 
 pub use anchor::trust_anchor_from_card;
-pub use card::{AgentCard, AgentCardSignature, SignedAgentCard};
+pub use card::{
+    AgentCard, AgentCardSignature, EnforcementRule, RuntimeGuaranteeProfile, SignedAgentCard,
+};
 pub use jcs::canonicalize;
 pub use verify::{verify_card, VerifiedCard};
 

--- a/crates/nucleus-agent-card/src/sign_verify_tests.rs
+++ b/crates/nucleus-agent-card/src/sign_verify_tests.rs
@@ -45,6 +45,7 @@ fn sample_card() -> AgentCard {
         supported_envelope_schema_versions: vec!["1".to_string()],
         jwks_uri: None,
         trust_jwks: good_jwks(),
+        runtime_guarantees: None,
     }
 }
 
@@ -127,4 +128,66 @@ fn malformed_trust_jwks_is_rejected() {
     let signed = sign_card(card, &der).unwrap();
     let err = verify_card(&signed, &pub_jwk).unwrap_err();
     assert!(matches!(err, crate::Error::Verify(_)), "got {err:?}");
+}
+
+fn sample_profile() -> crate::RuntimeGuaranteeProfile {
+    crate::RuntimeGuaranteeProfile {
+        profile_version: "1.0".to_string(),
+        tracked_sources: vec!["web_content".to_string(), "secret".to_string()],
+        enforcement_rules: vec![crate::EnforcementRule {
+            name: "no_adversarial_to_outbound".to_string(),
+            description:
+                "deny outbound actions whose ancestry includes adversarial-integrity content"
+                    .to_string(),
+        }],
+        attestation_reference: None,
+    }
+}
+
+#[test]
+fn sign_and_verify_with_runtime_guarantees_roundtrip() {
+    let (der, pub_jwk) = p256_keypair();
+    let mut card = sample_card();
+    card.runtime_guarantees = Some(sample_profile());
+    let signed = sign_card(card, &der).unwrap();
+    let verified = verify_card(&signed, &pub_jwk).expect("card with profile must verify");
+    let prof = verified
+        .card
+        .runtime_guarantees
+        .as_ref()
+        .expect("profile present");
+    assert_eq!(prof.enforcement_rules[0].name, "no_adversarial_to_outbound");
+}
+
+#[test]
+fn tampering_runtime_guarantees_breaks_signature() {
+    let (der, pub_jwk) = p256_keypair();
+    let mut card = sample_card();
+    card.runtime_guarantees = Some(sample_profile());
+    let mut signed = sign_card(card, &der).unwrap();
+    // Flip a declared rule name AFTER signing → JCS changes → signature must fail.
+    signed
+        .card
+        .runtime_guarantees
+        .as_mut()
+        .unwrap()
+        .enforcement_rules[0]
+        .name = "allow_everything".to_string();
+    assert!(
+        verify_card(&signed, &pub_jwk).is_err(),
+        "a tampered runtime-guarantee profile must fail verification"
+    );
+}
+
+#[test]
+fn backward_compat_card_without_profile_omits_field_and_verifies() {
+    let (der, pub_jwk) = p256_keypair();
+    let card = sample_card(); // runtime_guarantees: None
+    let json = serde_json::to_value(&card).unwrap();
+    assert!(
+        json.get("runtime_guarantees").is_none(),
+        "a None profile must be omitted from the card JSON (backward compatible)"
+    );
+    let signed = sign_card(card, &der).unwrap();
+    assert!(verify_card(&signed, &pub_jwk).is_ok());
 }

--- a/crates/nucleus-agent-card/src/verify.rs
+++ b/crates/nucleus-agent-card/src/verify.rs
@@ -157,6 +157,7 @@ mod tests {
             supported_envelope_schema_versions: vec!["1".to_string()],
             jwks_uri: None,
             trust_jwks: jwks,
+            runtime_guarantees: None,
         }
     }
 

--- a/crates/nucleus-agent-card/tests/handshake.rs
+++ b/crates/nucleus-agent-card/tests/handshake.rs
@@ -110,6 +110,7 @@ fn card_for(issuer: &LocalIssuer) -> AgentCard {
         supported_envelope_schema_versions: vec!["1".to_string(), "2".to_string()],
         jwks_uri: Some("https://summarizer.prod.example.com/.well-known/jwks.json".to_string()),
         trust_jwks: jwks,
+        runtime_guarantees: None,
     }
 }
 

--- a/crates/nucleus-verifier-service/tests/integration.rs
+++ b/crates/nucleus-verifier-service/tests/integration.rs
@@ -826,6 +826,7 @@ async fn well_known_agent_card_verifies_against_matching_key() {
         supported_envelope_schema_versions: vec!["1".to_string()],
         jwks_uri: None,
         trust_jwks: advertised,
+        runtime_guarantees: None,
     };
     let signed = sign_card(card, &der).unwrap();
 

--- a/crates/nucleus-verify-commerce/examples/quickstart.rs
+++ b/crates/nucleus-verify-commerce/examples/quickstart.rs
@@ -49,6 +49,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         supported_envelope_schema_versions: vec!["1".to_string()],
         jwks_uri: None,
         trust_jwks: buyer_trust_jwks,
+        runtime_guarantees: None,
     };
     let signed_card = sign_card(buyer_card, pkcs8.as_ref())?;
 

--- a/crates/nucleus-verify-commerce/src/card_verifier.rs
+++ b/crates/nucleus-verify-commerce/src/card_verifier.rs
@@ -78,6 +78,7 @@ mod tests {
             supported_envelope_schema_versions: vec!["1".to_string()],
             jwks_uri: None,
             trust_jwks: jwks,
+            runtime_guarantees: None,
         }
     }
 

--- a/justfile
+++ b/justfile
@@ -20,6 +20,13 @@ vault port="8799":
 vault-fresh:
     cd crates/ctf-engine && trunk serve --open
 
+# ── Signed, IFC-attested agents ──────────────────────────────────────────────
+
+# Sign an Agent Card that declares an IFC runtime-guarantee profile, then verify
+# it (incl. tamper-detection). Ephemeral key; production uses OIDC-keyless.
+agent-sign:
+    cargo run -q -p nucleus-agent-card --example agent_sign --features sign
+
 # ── x402 on Base Sepolia (TESTNET only — never mainnet / real funds) ──────────
 
 # Print the Base Sepolia x402 bootstrap config + faucet links (instant).


### PR DESCRIPTION
Adds a feature-gated `agent_sign` example + `just agent-sign`: signs an AgentCard carrying a RuntimeGuaranteeProfile, verifies it, prints the recovered profile, and demonstrates tamper-detection (flip a rule → signature breaks). Ephemeral key for self-containment; production signs keyless via OIDC→SPIFFE. Output reinforces ATTESTATION-not-enforcement.

**Stacked on #1735** (the RuntimeGuaranteeProfile field); base will retarget to main when #1735 merges. Verified: `cargo run -p nucleus-agent-card --example agent_sign --features sign` runs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)