### PR TITLE
docs(readme): lead with the tagline — "Don't trust the agent. Verify it."

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Nucleus
 
+### Don't trust the agent. Verify it.
+
+*Signed identity, declared guarantees, receipts anyone can check.*
+
 [![CI](https://github.com/coproduct-opensource/nucleus/actions/workflows/ci.yml/badge.svg)](https://github.com/coproduct-opensource/nucleus/actions/workflows/ci.yml)
 [![Security Audit](https://github.com/coproduct-opensource/nucleus/actions/workflows/audit.yml/badge.svg)](https://github.com/coproduct-opensource/nucleus/actions/workflows/audit.yml)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/coproduct-opensource/nucleus/badge)](https://securityscorecards.dev/viewer/?uri=github.com/coproduct-opensource/nucleus)


### PR DESCRIPTION
Adds the marketing tagline + sub-line as the lead hook under the README title. Honest by construction (promises verifiability, not safety). Doc-only; RFC framing deferred until #1736 merges to avoid a conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)