### PR TITLE
feat(x402): IFC deny variant — refuse unsafe flow before payment

### DIFF
--- a/examples/x402-sepolia/README.md
+++ b/examples/x402-sepolia/README.md
@@ -24,13 +24,31 @@ just x402-seller
 
 # 3) in another shell, pay it (TESTNET key holding bUSDC)
 export X402_PRIVATE_KEY=0x<testnet private key>
-just x402-pay
+just x402-pay        # → 200, result + allow verdict, ~0.01 USDC settles
+
+# 4) watch the gate refuse an unsafe flow — BEFORE any payment
+just x402-deny       # → 403 ifc_denied, you are NOT charged
 ```
 
+## Two routes: allow vs. deny
+
+The IFC gate runs **in front of** the x402 payment layer, so the data-flow
+decision happens *before money moves*:
+
+| Route | Declared flow | Gate | Result |
+|-------|---------------|------|--------|
+| `GET /paid` | trusted prompt + internal DB row | **allow** | `402` → pay → `200` + result + receipt |
+| `GET /paid-unsafe` | trusted prompt + adversarial **web content** | **deny** | `403` `ifc_denied` — **no `402`, not charged** |
+
 `GET /paid` returns `402 Payment Required` until the buyer pays; the
-`x402-reqwest` client auto-pays and retries. On success the handler runs the
-nucleus model-level IFC decision over the call's declared data-flow and returns
-the result with the (allow) verdict.
+`x402-reqwest` client auto-pays and retries, then the handler returns the result
+with the (allow) verdict.
+
+`GET /paid-unsafe` declares a lethal-trifecta flow (untrusted web content
+reaching an outbound action). The gate returns `403` with the deny verdict
+(`reason: AdversarialAncestry …`) *before* the payment layer runs — so the buyer
+never even sees a `402`. The differentiator over a plain paywall: **dangerous
+calls are refused before payment, not after.**
 
 ## Config (env)
 
@@ -38,8 +56,9 @@ the result with the (allow) verdict.
 (default `https://facilitator.x402.rs`), `PRICE_USDC` (default `0.01`), `BIND`
 (default `0.0.0.0:4021`).
 
-**Buyer** (`just x402-pay [url]`): `X402_PRIVATE_KEY` (required, **testnet**),
-`TARGET_URL` (default `http://127.0.0.1:4021/paid`).
+**Buyer** (`just x402-pay [url]` / `just x402-deny [url]`): `X402_PRIVATE_KEY`
+(required, **testnet**), `TARGET_URL` (default `http://127.0.0.1:4021/paid`,
+or `…/paid-unsafe` for the deny path).
 
 ## What's nucleus vs. what's x402
 

--- a/examples/x402-sepolia/README.md
+++ b/examples/x402-sepolia/README.md
@@ -30,6 +30,15 @@ just x402-pay        # → 200, result + allow verdict, ~0.01 USDC settles
 just x402-deny       # → 403 ifc_denied, you are NOT charged
 ```
 
+Or run the whole contrast in one shot (starts the seller, runs both buyer
+paths, and — if `cast` is installed — prints the on-chain balance delta):
+
+```bash
+export SELLER_ADDRESS=0x<your base-sepolia address>
+export X402_PRIVATE_KEY=0x<testnet private key>
+just x402-demo
+```
+
 ## Two routes: allow vs. deny
 
 The IFC gate runs **in front of** the x402 payment layer, so the data-flow

--- a/examples/x402-sepolia/src/bin/seller.rs
+++ b/examples/x402-sepolia/src/bin/seller.rs
@@ -1,5 +1,5 @@
-//! x402 seller on **Base Sepolia (testnet)** with the nucleus IFC gate +
-//! receipt on the paid route.
+//! x402 seller on **Base Sepolia (testnet)** with the nucleus IFC gate in
+//! front of the x402 payment layer.
 //!
 //! Testnet only. Reads config from env; no keys are stored here:
 //! - `SELLER_ADDRESS`   — Base Sepolia address that receives the USDC (required)
@@ -7,21 +7,36 @@
 //! - `PRICE_USDC`       — price per call (default: 0.01)
 //! - `BIND`             — listen address (default: 0.0.0.0:4021)
 //!
-//! `GET /paid` is x402-protected. After payment, the handler runs the nucleus
-//! model-level IFC decision over the call's declared data-flow and returns the
-//! result alongside the (allow) verdict — so a paid call is *also* gated on an
-//! information-flow check. See `crates/nucleus-verify-commerce`.
+//! Two paid routes share one price and one IFC pre-gate, differing only in the
+//! data-flow they declare:
+//!
+//! - `GET /paid`         declares a **safe** flow (trusted prompt + local DB
+//!   row). The gate ALLOWS → x402 collects payment → the handler serves the
+//!   result + the (allow) verdict.
+//! - `GET /paid-unsafe`  declares an **unsafe** flow (trusted prompt +
+//!   adversarial **web content** — the indirect prompt-injection vector reaching
+//!   an outbound action). The gate DENIES → it returns `403` **before** the
+//!   x402 layer runs, so the buyer is **never charged**.
+//!
+//! That ordering is the point: the gate refuses dangerous flows *before money
+//! moves*. The decision is model-level over the **declared** inputs (a real
+//! deployment derives the declaration from the request); see
+//! `crates/nucleus-verify-commerce`.
 
 use std::str::FromStr;
 
 use alloy_primitives::Address;
-use axum::{routing::get, Json, Router};
+use axum::extract::{Request, State};
+use axum::http::StatusCode;
+use axum::middleware::{from_fn_with_state, Next};
+use axum::response::{IntoResponse, Response};
+use axum::{routing::get, Extension, Json, Router};
 use x402_axum::X402Middleware;
 // `KnownNetworkEip155` is the trait that provides `USDC::base_sepolia()`.
 use x402_chain_eip155::{KnownNetworkEip155, V1Eip155Exact};
 use x402_types::networks::USDC;
 
-use nucleus_verify_commerce::{body_sha256_hex, DeclaredInput, FlowDeclaration};
+use nucleus_verify_commerce::{body_sha256_hex, DeclaredInput, FlowDeclaration, IfcVerdict};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -33,37 +48,72 @@ async fn main() -> anyhow::Result<()> {
     let price = std::env::var("PRICE_USDC").unwrap_or_else(|_| "0.01".into());
     let bind = std::env::var("BIND").unwrap_or_else(|_| "0.0.0.0:4021".into());
 
-    let x402 = X402Middleware::new(&facilitator);
-    let price_tag =
-        V1Eip155Exact::price_tag(seller, USDC::base_sepolia().parse(price.as_str())?);
+    // Same price + recipient on both routes; a fresh `X402Middleware` /
+    // `price_tag` per route since the layer consumes them.
+    let make_paywall = || -> anyhow::Result<_> {
+        let tag = V1Eip155Exact::price_tag(seller, USDC::base_sepolia().parse(price.as_str())?);
+        Ok(X402Middleware::new(&facilitator).with_price_tag(tag))
+    };
 
-    let app: Router = Router::new().route(
-        "/paid",
-        get(paid_handler).layer(x402.with_price_tag(price_tag)),
-    );
+    // Safe flow: trusted prompt + internal DB row → ALLOW.
+    let safe_decl = FlowDeclaration::new([DeclaredInput::UserPrompt, DeclaredInput::DatabaseRow]);
+    let safe_route = Router::new()
+        .route("/paid", get(paid_handler).layer(make_paywall()?))
+        .layer(from_fn_with_state(safe_decl, ifc_pregate));
+
+    // Unsafe flow: trusted prompt + adversarial web content reaching an
+    // outbound action (the lethal trifecta) → DENY before payment.
+    let unsafe_decl = FlowDeclaration::new([DeclaredInput::UserPrompt, DeclaredInput::WebContent]);
+    let unsafe_route = Router::new()
+        .route("/paid-unsafe", get(paid_handler).layer(make_paywall()?))
+        .layer(from_fn_with_state(unsafe_decl, ifc_pregate));
+
+    let app: Router = safe_route.merge(unsafe_route);
 
     println!("x402 seller on Base Sepolia (TESTNET)");
     println!("  receive USDC → {seller}");
     println!("  facilitator   = {facilitator}");
-    println!("  price         = {price} USDC  on  GET /paid");
-    println!("  listening     = http://{bind}/paid");
-    println!("  (the paid route is also IFC-gated by nucleus-verify-commerce)");
+    println!("  price         = {price} USDC");
+    println!("  GET /paid         safe flow   → IFC ALLOW → pay → result");
+    println!("  GET /paid-unsafe  unsafe flow → IFC DENY  → 403 (NOT charged)");
+    println!("  listening     = http://{bind}");
 
     let listener = tokio::net::TcpListener::bind(&bind).await?;
     axum::serve(listener, app).await?;
     Ok(())
 }
 
-/// The paid work. x402 has already verified payment by the time we get here;
-/// we then run the nucleus IFC gate over the call's declared data-flow and
-/// fold the verdict into the response.
-async fn paid_handler() -> Json<serde_json::Value> {
-    // Declared data-flow for this paid call: a trusted prompt + a local DB row,
-    // served to the authenticated buyer. (A real deployment derives this from
-    // the request; an untrusted-content input here would DENY before serving.)
-    let verdict = FlowDeclaration::new([DeclaredInput::UserPrompt, DeclaredInput::DatabaseRow])
-        .decide();
+/// The nucleus IFC pre-gate. Runs **before** the x402 payment layer: it makes
+/// the model-level information-flow decision over this route's declared inputs
+/// and, on a deny, short-circuits with `403` so the payment layer never runs and
+/// the buyer is never charged. On an allow it stashes the verdict for the
+/// handler to fold into its response.
+async fn ifc_pregate(
+    State(decl): State<FlowDeclaration>,
+    mut req: Request,
+    next: Next,
+) -> Response {
+    let verdict = decl.decide();
+    if !verdict.is_allow() {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({
+                "error": "ifc_denied",
+                "detail": "the declared data-flow for this call would exfiltrate; \
+                           refused by the nucleus IFC gate BEFORE payment — you were not charged",
+                "ifc_verdict": verdict,
+            })),
+        )
+            .into_response();
+    }
+    req.extensions_mut().insert(verdict);
+    next.run(req).await
+}
 
+/// The paid work. By the time we get here the IFC gate has ALLOWED (and stashed
+/// the verdict) and x402 has verified payment. We echo the result + the verdict
+/// the gate made the call under.
+async fn paid_handler(Extension(verdict): Extension<IfcVerdict>) -> Json<serde_json::Value> {
     let body = b"{\"summary\":\"<paid result>\"}";
     Json(serde_json::json!({
         "result": "paid result delivered",

--- a/justfile
+++ b/justfile
@@ -58,6 +58,32 @@ x402-pay url="http://127.0.0.1:4021/paid":
 x402-deny url="http://127.0.0.1:4021/paid-unsafe":
     cd examples/x402-sepolia && TARGET_URL={{url}} cargo run --quiet --bin buyer
 
+# One-shot contrast: starts the seller, runs BOTH buyer paths (pay-allow + deny),
+# proves the on-chain balance delta (if `cast` is present), then stops the seller.
+# Needs SELLER_ADDRESS + X402_PRIVATE_KEY (TESTNET only — never mainnet/real funds).
+x402-demo:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    : "${SELLER_ADDRESS:?set SELLER_ADDRESS (your Base Sepolia receiving address)}"
+    : "${X402_PRIVATE_KEY:?set X402_PRIVATE_KEY (a TESTNET key holding Base Sepolia USDC)}"
+    RPC="https://sepolia.base.org"; USDC="0x036CbD53842c5426634e7929541eC2318f3dCF7e"
+    cd examples/x402-sepolia
+    echo "building seller + buyer…"; cargo build --quiet --bin seller --bin buyer
+    BIND=127.0.0.1:4021 ./target/debug/seller >/tmp/x402-demo-seller.log 2>&1 &
+    SELLER_PID=$!; trap 'kill $SELLER_PID 2>/dev/null || true' EXIT
+    for _ in $(seq 1 40); do curl -fsS -o /dev/null "http://127.0.0.1:4021/paid-unsafe" 2>/dev/null && break || true; sleep 0.25; done
+    bal() { cast call "$USDC" "balanceOf(address)(uint256)" "$1" --rpc-url "$RPC" 2>/dev/null | sed 's/ .*//'; }
+    HAVE_CAST=0; command -v cast >/dev/null 2>&1 && HAVE_CAST=1
+    if [ "$HAVE_CAST" = 1 ]; then BUYER=$(cast wallet address --private-key "$X402_PRIVATE_KEY"); B0=$(bal "$BUYER"); fi
+    echo; echo "── 1) SAFE flow: GET /paid  (gate ALLOWS → buyer pays → 200) ─────────────"
+    TARGET_URL=http://127.0.0.1:4021/paid ./target/debug/buyer
+    if [ "$HAVE_CAST" = 1 ]; then B1=$(bal "$BUYER"); fi
+    echo; echo "── 2) UNSAFE flow: GET /paid-unsafe  (gate DENIES → 403, NOT charged) ────"
+    TARGET_URL=http://127.0.0.1:4021/paid-unsafe ./target/debug/buyer
+    if [ "$HAVE_CAST" = 1 ]; then B2=$(bal "$BUYER"); echo; \
+      python3 -c "print(f'on-chain buyer USDC:  start={int(\"$B0\")/1e6:.6f}  after pay={int(\"$B1\")/1e6:.6f} (Δ {(int(\"$B1\")-int(\"$B0\"))/1e6:+.6f})  after deny={int(\"$B2\")/1e6:.6f} (Δ {(int(\"$B2\")-int(\"$B1\"))/1e6:+.6f})')"; fi
+    echo; echo "same gate, same price, opposite outcome — decided by the declared data-flow."
+
 # ── Everyday ─────────────────────────────────────────────────────────────────
 
 # Rust-native task runner. `just xtask <command>` (e.g. `just xtask scripts`).

--- a/justfile
+++ b/justfile
@@ -38,8 +38,12 @@ x402-info:
     @echo ""
     @echo "Seller (30s):  export SELLER_ADDRESS=0x<your base-sepolia address> && just x402-seller"
     @echo "Pay it:        export X402_PRIVATE_KEY=0x<TESTNET key w/ bUSDC>      && just x402-pay"
+    @echo "See it deny:   just x402-deny    # IFC gate refuses an unsafe flow (403) BEFORE payment"
     @echo ""
-    @echo "The paid route is also IFC-gated + receipted by nucleus-verify-commerce."
+    @echo "GET /paid        safe flow   → IFC ALLOW → pay → result + receipt"
+    @echo "GET /paid-unsafe unsafe flow → IFC DENY  → 403, you are NOT charged"
+    @echo ""
+    @echo "Both routes are IFC-gated + receipted by nucleus-verify-commerce."
 
 # Run an x402 seller on Base Sepolia (needs SELLER_ADDRESS). Paid route is IFC-gated.
 x402-seller:
@@ -47,6 +51,11 @@ x402-seller:
 
 # Pay an x402 endpoint on Base Sepolia (needs X402_PRIVATE_KEY; TESTNET only).
 x402-pay url="http://127.0.0.1:4021/paid":
+    cd examples/x402-sepolia && TARGET_URL={{url}} cargo run --quiet --bin buyer
+
+# Hit the IFC-UNSAFE route: the gate DENIES (403) before payment — you are NOT
+# charged. Shows the nucleus IFC gate refusing a lethal-trifecta flow up front.
+x402-deny url="http://127.0.0.1:4021/paid-unsafe":
     cd examples/x402-sepolia && TARGET_URL={{url}} cargo run --quiet --bin buyer
 
 # ── Everyday ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

Demonstrates the nucleus differentiator over a plain x402 paywall: the **IFC gate runs in front of the payment layer**, so a dangerous data-flow is refused *before money moves*.

The Base Sepolia example seller now exposes two paid routes sharing one price + one IFC pre-gate, differing only in declared data-flow:

| Route | Declared flow | Gate | Result |
|-------|---------------|------|--------|
| `GET /paid` | trusted prompt + internal DB row | **allow** | `402` → pay → `200` + result + receipt |
| `GET /paid-unsafe` | trusted prompt + adversarial **web content** | **deny** | `403` `ifc_denied` — no `402`, **not charged** |

## How

An axum `from_fn_with_state` pre-gate carries the route's `FlowDeclaration`, runs `decide()`, and on deny short-circuits with `403` + the verdict so the x402 layer never runs. On allow it stashes the verdict in request extensions for the handler to fold into the response.

## Verified (Base Sepolia testnet)

- `GET /paid` → `402 Payment Required`
- `GET /paid-unsafe` → `403` with `allow:false`, `reason: AdversarialAncestry { tainted_node: 3 }`, `declared_inputs: [user_prompt, web_content]`
- buyer balance unchanged by the deny (deny costs nothing); earlier paid run settled 0.01 USDC on-chain

Adds `just x402-deny`, updates `just x402-info` + example README.

## Honesty boundary

Model-level decision over **declared** inputs, coverage-limited, per-call (unchanged from `nucleus-verify-commerce`). The example's per-route declaration is illustrative; a real deployment derives it from the request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)