### PR TITLE
feat(marketplace): P0 dashboard backend — SSE orchestrator over the IFC gate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6668,6 +6668,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "nucleus-marketplace-dashboard"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "axum",
+ "futures",
+ "nucleus-verify-commerce",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-test",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "nucleus-mcp"
 version = "1.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ members = [
     "crates/xtask",                      # Rust-native dev/CI task runner (cargo xtask <cmd>); migrating scripts/*.sh
     "crates/nucleus-machine",            # MachineDriver: microVM execution-substrate abstraction (mock + Fly skeleton)
     "crates/nucleus-verify-commerce",    # Seller-side verify→serve→receipt middleware for x402/A2A (scaffold)
+    "crates/nucleus-marketplace-dashboard", # Real-time verified-agent-marketplace: axum SSE orchestrator over the IFC gate (network-free core)
 ]
 # nucleus-claude-hook moved to nucleus-code (private product repo)
 # exposure-web is WASM-only (wasm32-unknown-unknown); build with: cd crates/exposure-web && trunk build

--- a/crates/nucleus-marketplace-dashboard/Cargo.toml
+++ b/crates/nucleus-marketplace-dashboard/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "nucleus-marketplace-dashboard"
+version = "0.1.0"
+edition = "2021"
+rust-version.workspace = true
+license = "MIT"
+description = "Real-time verified-agent-marketplace dashboard: an axum SSE orchestrator that runs N agent loops through the nucleus IFC gate, emitting allow/deny/settlement/receipt events. Network-free, deterministic core; real Base Sepolia settlement lives in a separate example workspace."
+
+[features]
+default = ["server"]
+# The thin axum SSE edge + the live binary. The pure decision/event/state core
+# does NOT need this — `cargo test` exercises the whole core with it on but no
+# network is touched (settlement is abstracted behind the `Facilitator` trait,
+# and the real x402/alloy impl lives in a SEPARATE workspace, never here).
+server = ["dep:axum", "dep:tokio-stream", "dep:futures"]
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+async-trait = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+anyhow = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "time", "signal"] }
+tokio-util = "0.7"
+nucleus-verify-commerce = { path = "../nucleus-verify-commerce" }
+
+# `server` feature only — the SSE edge.
+axum = { workspace = true, optional = true }
+tokio-stream = { version = "0.1", features = ["sync"], optional = true }
+futures = { version = "0.3", optional = true }
+
+[dev-dependencies]
+tokio-test = { workspace = true }
+
+[[bin]]
+name = "marketplace-orchestrator"
+path = "src/bin/orchestrator.rs"
+required-features = ["server"]

--- a/crates/nucleus-marketplace-dashboard/README.md
+++ b/crates/nucleus-marketplace-dashboard/README.md
@@ -1,0 +1,71 @@
+# nucleus-marketplace-dashboard
+
+A real-time **verified-agent-marketplace** dashboard: an axum SSE orchestrator
+that runs N agent loops making paid calls through the nucleus IFC gate
+([`nucleus-verify-commerce`](../nucleus-verify-commerce)), emitting
+allow / deny / settlement / receipt events to a broadcast hub. A frontend
+renders the live feed and verifies receipts in the browser.
+
+The point it makes concrete: **a plain x402 paywall charges first and asks
+questions never; nucleus refuses dangerous calls before money moves** — and you
+can watch it happen, live, across a marketplace of agents.
+
+## Architecture: a network-free, deterministic core + a thin SSE edge
+
+```
+ AgentLoop × N ─▶ Orchestrator.step_once ─▶ Hub.emit ─▶ broadcast ─▶ /api/events (SSE)
+   │  flow.decide() (IFC gate)              │  seq + ts (Clock)        snapshot ─▶ /api/snapshot
+   │  Facilitator.settle() (abstracted)     │  replay ring             receipt  ─▶ /api/receipt/{id}
+   └─ deny ⇒ STOP (settle never called)     └─ MarketState.apply (pure reducer)
+```
+
+- **`event.rs`** — the `MarketEvent` wire contract (serde-tagged); shared verbatim
+  with the wasm frontend (serde-only deps → compiles to wasm unchanged).
+- **`reducer.rs`** — pure `MarketState::apply`; state is `fold(apply, default,
+  events)`, so `/api/snapshot` and the live feed can never diverge.
+- **`clock.rs` / `facilitator.rs`** — `Clock` + `Facilitator` traits, with
+  `FixedClock` + `FakeFacilitator` so the **whole core tests with no network, no
+  real clock, no alloy**.
+- **`orchestrator.rs`** — runs the agent loops; mirrors
+  `serve_verified_ifc`'s ordering (deny ⇒ settlement never attempted).
+- **`hub.rs`** — tokio broadcast + monotonic seq + bounded replay ring
+  (`Last-Event-ID` resume) + receipt store.
+- **`http.rs`** (feature `server`) — the thin SSE edge; no business logic.
+
+## Run the live (SIMULATED) demo
+
+```bash
+BIND=127.0.0.1:4040 cargo run -p nucleus-marketplace-dashboard --bin marketplace-orchestrator
+# then:
+curl -s http://127.0.0.1:4040/api/snapshot | jq
+curl -N  http://127.0.0.1:4040/api/events
+```
+
+## Honesty
+
+- **Testnet only.** The real settlement path targets Base Sepolia
+  (`eip155:84532`) — never mainnet, never real funds.
+- **Simulated money is labelled.** The default binary uses `FakeFacilitator`:
+  every settlement is tagged `BalanceSource::Simulated` with a `0xsimulated…`
+  reference. There is **no code path** that produces an `OnChainTestnet` number
+  without a real confirmed tx — a reducer invariant test asserts this. The UI
+  must surface the source as a visible badge.
+- **The IFC verdict is model-level over _declared_ inputs** (coverage-limited,
+  per-call; no cross-session taint ratchet) — see `nucleus-verify-commerce`'s
+  `ifc` module. An `IfcAllow` is **not** an end-to-end exfiltration proof; the
+  event carries `declared_inputs` so a viewer can judge coverage.
+- **Real settlement lives elsewhere.** The `X402Facilitator` (driving
+  `x402-reqwest` against Base Sepolia with a keystore-backed signer) lives in a
+  **separate workspace** under `examples/`, exactly like `examples/x402-sepolia`,
+  so the heavy alloy/x402 dependency tree never enters this crate or the main CI.
+
+## Tests
+
+```bash
+cargo test -p nucleus-marketplace-dashboard            # core + SSE edge, no network
+```
+
+The load-bearing isolation tests (`tests/orchestrator_isolation.rs`) assert the
+exact event sequence per iteration, that **a denied flow never reaches
+settlement** (`settle_calls() == 0`), that a timeout yields no receipt and no
+re-settle, and that the whole core is byte-for-byte reproducible.

--- a/crates/nucleus-marketplace-dashboard/src/agent.rs
+++ b/crates/nucleus-marketplace-dashboard/src/agent.rs
@@ -1,0 +1,45 @@
+//! An agent loop's static configuration: who it is, what it buys, the IFC flow
+//! its calls declare, the price, and how often it acts.
+
+use crate::event::{AgentId, MicroUsd};
+use nucleus_verify_commerce::FlowDeclaration;
+
+/// One simulated buyer agent in the marketplace.
+pub struct AgentLoop {
+    /// Stable agent handle.
+    pub agent: AgentId,
+    /// The resource it purchases.
+    pub resource: String,
+    /// The IFC data-flow each of its calls declares (drives allow/deny).
+    pub flow: FlowDeclaration,
+    /// Price per call.
+    pub price: MicroUsd,
+    /// Pacing between attempts (milliseconds) for the live `run` loop. Ignored by
+    /// the deterministic `step_once` test path.
+    pub interval_ms: u64,
+}
+
+impl AgentLoop {
+    /// Construct an agent loop.
+    pub fn new(
+        agent: impl Into<String>,
+        resource: impl Into<String>,
+        flow: FlowDeclaration,
+        price: MicroUsd,
+        interval_ms: u64,
+    ) -> Self {
+        Self {
+            agent: AgentId(agent.into()),
+            resource: resource.into(),
+            flow,
+            price,
+            interval_ms,
+        }
+    }
+
+    /// The sorted+deduped declared-input tokens this agent exposes (the same set
+    /// the IFC verdict reports), for the `AgentRegistered` coverage surface.
+    pub fn declared_inputs(&self) -> Vec<String> {
+        self.flow.decide().declared_inputs
+    }
+}

--- a/crates/nucleus-marketplace-dashboard/src/bin/orchestrator.rs
+++ b/crates/nucleus-marketplace-dashboard/src/bin/orchestrator.rs
@@ -1,0 +1,109 @@
+//! The live marketplace orchestrator binary — **SIMULATED settlement**.
+//!
+//! This binary runs the agent fleet against the deterministic
+//! [`FakeFacilitator`]: every settlement is simulated (tagged
+//! `BalanceSource::Simulated`, with a `0xsimulated…` reference) — NO real funds
+//! move. It exists to drive the live SSE feed for frontend development and a
+//! safe, repeatable demo.
+//!
+//! The REAL Base Sepolia (testnet) settlement path lives in a separate workspace
+//! under `examples/` (keystore-backed signer over `x402-reqwest`), so the heavy
+//! alloy/x402 tree never enters this crate or the main CI.
+//!
+//! Run: `BIND=127.0.0.1:4040 cargo run -p nucleus-marketplace-dashboard --bin marketplace-orchestrator`
+
+use std::sync::Arc;
+
+use nucleus_marketplace_dashboard::{
+    http, AgentLoop, FakeFacilitator, Hub, MicroUsd, Orchestrator, SystemClock,
+};
+use nucleus_verify_commerce::{DeclaredInput, FlowDeclaration};
+use tokio_util::sync::CancellationToken;
+
+/// A small, readable fleet: four agents whose declared flows are SAFE (the gate
+/// ALLOWS) plus one "compromised" agent whose flow pulls in adversarial web
+/// content (the gate DENIES) on a slower cadence — the periodic red accent.
+fn default_fleet() -> Vec<AgentLoop> {
+    let usdc = |x: i64| MicroUsd(x);
+    vec![
+        AgentLoop::new(
+            "summarizer-agent",
+            "/v1/summarize",
+            FlowDeclaration::new([DeclaredInput::UserPrompt, DeclaredInput::DatabaseRow]),
+            usdc(10_000),
+            1_700,
+        ),
+        AgentLoop::new(
+            "pricing-agent",
+            "/v1/price-quote",
+            FlowDeclaration::new([DeclaredInput::DatabaseRow]),
+            usdc(20_000),
+            2_300,
+        ),
+        AgentLoop::new(
+            "qa-agent",
+            "/v1/answer",
+            FlowDeclaration::new([DeclaredInput::UserPrompt]),
+            usdc(5_000),
+            1_300,
+        ),
+        AgentLoop::new(
+            "research-agent",
+            "/v1/research",
+            FlowDeclaration::new([DeclaredInput::UserPrompt, DeclaredInput::DatabaseRow]),
+            usdc(15_000),
+            1_900,
+        ),
+        // Compromised: a paid call whose ancestry includes adversarial web
+        // content reaching an outbound action — the lethal trifecta. DENIED.
+        AgentLoop::new(
+            "compromised-agent",
+            "/v1/exfiltrate",
+            FlowDeclaration::new([DeclaredInput::UserPrompt, DeclaredInput::WebContent]),
+            usdc(10_000),
+            5_000,
+        ),
+    ]
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    eprintln!("┌────────────────────────────────────────────────────────────────┐");
+    eprintln!("│  nucleus marketplace dashboard — SIMULATED SETTLEMENT           │");
+    eprintln!("│  No real funds move. Balances are tagged `simulated`.           │");
+    eprintln!("│  Real Base Sepolia settlement lives in examples/ (separate WS). │");
+    eprintln!("└────────────────────────────────────────────────────────────────┘");
+
+    let hub = Hub::new(Arc::new(SystemClock), 1_024, 500);
+    let facilitator = Arc::new(FakeFacilitator::always_confirm(MicroUsd(20_000_000)));
+    let orchestrator = Arc::new(Orchestrator::new(
+        Arc::clone(&hub),
+        facilitator,
+        default_fleet(),
+    ));
+
+    let cancel = CancellationToken::new();
+    let run_handle = tokio::spawn({
+        let orch = Arc::clone(&orchestrator);
+        let cancel = cancel.clone();
+        async move { orch.run(cancel).await }
+    });
+
+    let app = http::router(Arc::clone(&hub));
+    let bind = std::env::var("BIND").unwrap_or_else(|_| "127.0.0.1:4040".into());
+    let listener = tokio::net::TcpListener::bind(&bind).await?;
+    println!("marketplace dashboard (SIMULATED) → http://{bind}");
+    println!("  GET /api/events    (SSE live feed)");
+    println!("  GET /api/snapshot  (cold-start state)");
+    println!("  GET /api/receipt/{{settlement_id}}");
+
+    axum::serve(listener, app)
+        .with_graceful_shutdown(async move {
+            let _ = tokio::signal::ctrl_c().await;
+            cancel.cancel();
+        })
+        .await?;
+
+    run_handle.abort();
+    Ok(())
+}

--- a/crates/nucleus-marketplace-dashboard/src/clock.rs
+++ b/crates/nucleus-marketplace-dashboard/src/clock.rs
@@ -1,0 +1,74 @@
+//! Injectable clock so emitted timestamps are deterministic under test.
+
+use std::sync::atomic::{AtomicI64, Ordering};
+
+/// A source of wall-clock time (Unix milliseconds).
+pub trait Clock: Send + Sync {
+    /// Current time in Unix milliseconds.
+    fn now_unix_ms(&self) -> i64;
+}
+
+/// Real wall clock.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct SystemClock;
+
+impl Clock for SystemClock {
+    fn now_unix_ms(&self) -> i64 {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_millis() as i64)
+            .unwrap_or(0)
+    }
+}
+
+/// A deterministic, advanceable clock for tests. Every read returns the current
+/// fixed value; [`FixedClock::advance`] moves it forward.
+#[derive(Debug)]
+pub struct FixedClock(AtomicI64);
+
+impl FixedClock {
+    /// Start at `start_ms`.
+    pub fn new(start_ms: i64) -> Self {
+        FixedClock(AtomicI64::new(start_ms))
+    }
+
+    /// Advance the clock by `delta_ms` and return the new value.
+    pub fn advance(&self, delta_ms: i64) -> i64 {
+        self.0.fetch_add(delta_ms, Ordering::SeqCst) + delta_ms
+    }
+}
+
+impl Default for FixedClock {
+    fn default() -> Self {
+        FixedClock::new(1_700_000_000_000)
+    }
+}
+
+impl Clock for FixedClock {
+    fn now_unix_ms(&self) -> i64 {
+        self.0.load(Ordering::SeqCst)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fixed_clock_is_deterministic_and_advanceable() {
+        let c = FixedClock::new(1000);
+        assert_eq!(c.now_unix_ms(), 1000);
+        assert_eq!(c.now_unix_ms(), 1000); // stable until advanced
+        assert_eq!(c.advance(500), 1500);
+        assert_eq!(c.now_unix_ms(), 1500);
+    }
+
+    #[test]
+    fn system_clock_is_monotonic_ish_and_positive() {
+        let c = SystemClock;
+        let a = c.now_unix_ms();
+        let b = c.now_unix_ms();
+        assert!(a > 0 && b >= a);
+    }
+}

--- a/crates/nucleus-marketplace-dashboard/src/event.rs
+++ b/crates/nucleus-marketplace-dashboard/src/event.rs
@@ -1,0 +1,333 @@
+//! THE wire contract. `serde` internally-tagged so the same enum (de)serializes
+//! identically in the axum backend and a wasm32 frontend — this module has ONLY
+//! serde as a dependency, so it compiles to wasm unchanged.
+//!
+//! # Honesty
+//!
+//! [`MarketEvent::Settlement`] and [`MarketEvent::BalanceUpdate`] carry a
+//! [`BalanceSource`]. A number derived from the deterministic, network-free
+//! [`crate::FakeFacilitator`] is tagged [`BalanceSource::Simulated`]; a number
+//! derived from a confirmed Base Sepolia (testnet) transaction is tagged
+//! [`BalanceSource::OnChainTestnet`]. There is no code path that produces an
+//! `OnChainTestnet` number without a real confirmed tx — the reducer asserts
+//! this invariant in tests. The UI must surface the source as a visible badge so
+//! a simulated balance can never masquerade as real money.
+
+use serde::{Deserialize, Serialize};
+
+/// Integer micro-USD (`1 USDC = 1_000_000`). Newtype to avoid float money and
+/// unit confusion (per the Paragon audit note on `MicroUsd`).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct MicroUsd(pub i64);
+
+impl MicroUsd {
+    /// USDC from whole + 6-decimal fractional micro units.
+    pub const fn from_micros(m: i64) -> Self {
+        MicroUsd(m)
+    }
+    /// The raw micro-USD value.
+    pub const fn micros(self) -> i64 {
+        self.0
+    }
+}
+
+/// A marketplace participant identifier (an agent's stable handle).
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct AgentId(pub String);
+
+impl AgentId {
+    /// Borrow the inner string.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<&str> for AgentId {
+    fn from(s: &str) -> Self {
+        AgentId(s.to_string())
+    }
+}
+
+/// The colour lanes the UI groups events by (always paired with a text label —
+/// never colour alone, for accessibility).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Lane {
+    /// Commerce: calls, settlements, balances.
+    Commerce,
+    /// Security: the IFC allow/deny decisions.
+    Security,
+    /// Trust: identity / registration.
+    Trust,
+    /// Proof: receipts + verification.
+    Proof,
+}
+
+/// Provenance of a money number — keeps the UI honest.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BalanceSource {
+    /// Derived from a confirmed on-chain Base Sepolia (testnet) settlement.
+    OnChainTestnet,
+    /// Derived from the deterministic [`crate::FakeFacilitator`] — NOT real money.
+    Simulated,
+}
+
+/// How a settlement attempt resolved (mirrors the x402 timeout state machine;
+/// the real failure mode is a facilitator timeout, not a nonce collision).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum SettlementOutcome {
+    /// Settled; carries the (real or clearly-synthetic-simulated) tx reference.
+    Confirmed {
+        /// On-chain tx hash, or a `0xsimulated…` reference in the simulated path.
+        tx_hash: String,
+    },
+    /// Facilitator timed out; the tx may still confirm later — UI shows "unresolved".
+    Timeout,
+    /// Polled past the deadline without on-chain confirmation.
+    Orphaned,
+}
+
+impl SettlementOutcome {
+    /// `true` only for [`SettlementOutcome::Confirmed`].
+    pub fn is_confirmed(&self) -> bool {
+        matches!(self, SettlementOutcome::Confirmed { .. })
+    }
+}
+
+/// One marketplace event. `id` (monotonic seq) and `ts_unix_ms` are stamped by
+/// the [`crate::Hub`] on emit via the injected [`crate::Clock`], so producers
+/// construct events with `0` placeholders and never set wall-clock time directly.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum MarketEvent {
+    /// An agent joined the fleet (carries its declared IFC flow surface).
+    AgentRegistered {
+        id: u64,
+        ts_unix_ms: i64,
+        agent: AgentId,
+        resource: String,
+        /// The `DeclaredInput` tokens this agent's calls expose (coverage audit).
+        declared_inputs: Vec<String>,
+        price: MicroUsd,
+    },
+    /// An agent began one paid-call attempt.
+    CallStarted {
+        id: u64,
+        ts_unix_ms: i64,
+        agent: AgentId,
+        resource: String,
+        attempt: u64,
+    },
+    /// The model-level IFC gate ALLOWED the call (payment + handler may run).
+    IfcAllow {
+        id: u64,
+        ts_unix_ms: i64,
+        agent: AgentId,
+        /// Sorted + deduped declared inputs the verdict was made over.
+        declared_inputs: Vec<String>,
+        /// Verdict canonical string (`allow\0inputs`) for independent re-derivation.
+        canonical: String,
+    },
+    /// The IFC gate DENIED — the demo's peak; no payment, no handler.
+    IfcDeny {
+        id: u64,
+        ts_unix_ms: i64,
+        agent: AgentId,
+        reason: String,
+        declared_inputs: Vec<String>,
+        canonical: String,
+    },
+    /// A settlement attempt resolved (real testnet tx OR simulated).
+    Settlement {
+        id: u64,
+        ts_unix_ms: i64,
+        agent: AgentId,
+        amount: MicroUsd,
+        /// CAIP-2 chain id; Base Sepolia is `eip155:84532` — testnet only.
+        chain: String,
+        outcome: SettlementOutcome,
+        /// `OnChainTestnet` vs `Simulated` — never faked.
+        source: BalanceSource,
+    },
+    /// A receipt for a settled call was issued AND checked.
+    ReceiptVerified {
+        id: u64,
+        ts_unix_ms: i64,
+        agent: AgentId,
+        resource: String,
+        payment_reference: String,
+        body_sha256: String,
+        /// Seq of the [`MarketEvent::Settlement`] this receipt binds (UI join key).
+        for_settlement_id: u64,
+        /// What kind of check produced `verified` (hash re-derivation vs signed bundle).
+        method: VerifyMethod,
+        /// True iff the check accepted the receipt.
+        verified: bool,
+    },
+    /// A running balance changed (always tagged with its source).
+    BalanceUpdate {
+        id: u64,
+        ts_unix_ms: i64,
+        agent: AgentId,
+        balance: MicroUsd,
+        source: BalanceSource,
+    },
+}
+
+/// How a [`MarketEvent::ReceiptVerified`] was checked — so the UI never
+/// overclaims a hash re-derivation as a signature verification.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum VerifyMethod {
+    /// Re-derived the receipt's content binding (body SHA-256) and compared.
+    /// Used in the simulated core (the `HashingReceiptIssuer` has no signature).
+    HashRebind,
+    /// Verified a full signed `nucleus-envelope` provenance bundle
+    /// (`verify_receipt_bundle`). Used on the real settlement path.
+    SignedBundle,
+}
+
+impl MarketEvent {
+    /// Monotonic seq id (the SSE `Event` id / `Last-Event-ID` join key).
+    pub fn id(&self) -> u64 {
+        match self {
+            MarketEvent::AgentRegistered { id, .. }
+            | MarketEvent::CallStarted { id, .. }
+            | MarketEvent::IfcAllow { id, .. }
+            | MarketEvent::IfcDeny { id, .. }
+            | MarketEvent::Settlement { id, .. }
+            | MarketEvent::ReceiptVerified { id, .. }
+            | MarketEvent::BalanceUpdate { id, .. } => *id,
+        }
+    }
+
+    /// The agent this event concerns.
+    pub fn agent(&self) -> &AgentId {
+        match self {
+            MarketEvent::AgentRegistered { agent, .. }
+            | MarketEvent::CallStarted { agent, .. }
+            | MarketEvent::IfcAllow { agent, .. }
+            | MarketEvent::IfcDeny { agent, .. }
+            | MarketEvent::Settlement { agent, .. }
+            | MarketEvent::ReceiptVerified { agent, .. }
+            | MarketEvent::BalanceUpdate { agent, .. } => agent,
+        }
+    }
+
+    /// UI lane (drives colour + icon; always paired with a label, never colour-only).
+    pub fn lane(&self) -> Lane {
+        match self {
+            MarketEvent::AgentRegistered { .. } => Lane::Trust,
+            MarketEvent::CallStarted { .. }
+            | MarketEvent::Settlement { .. }
+            | MarketEvent::BalanceUpdate { .. } => Lane::Commerce,
+            MarketEvent::IfcAllow { .. } | MarketEvent::IfcDeny { .. } => Lane::Security,
+            MarketEvent::ReceiptVerified { .. } => Lane::Proof,
+        }
+    }
+
+    /// The deny is the demo's peak; the UI flashes + pins it.
+    pub fn is_peak(&self) -> bool {
+        matches!(self, MarketEvent::IfcDeny { .. })
+    }
+
+    /// Set the monotonic `id` and wall-clock `ts_unix_ms`. Called once by the
+    /// [`crate::Hub`] on emit; producers leave these `0`.
+    pub fn stamp(&mut self, new_id: u64, ts: i64) {
+        match self {
+            MarketEvent::AgentRegistered { id, ts_unix_ms, .. }
+            | MarketEvent::CallStarted { id, ts_unix_ms, .. }
+            | MarketEvent::IfcAllow { id, ts_unix_ms, .. }
+            | MarketEvent::IfcDeny { id, ts_unix_ms, .. }
+            | MarketEvent::Settlement { id, ts_unix_ms, .. }
+            | MarketEvent::ReceiptVerified { id, ts_unix_ms, .. }
+            | MarketEvent::BalanceUpdate { id, ts_unix_ms, .. } => {
+                *id = new_id;
+                *ts_unix_ms = ts;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample(variant: &str) -> MarketEvent {
+        let agent = AgentId::from("agent-a");
+        match variant {
+            "registered" => MarketEvent::AgentRegistered {
+                id: 0,
+                ts_unix_ms: 0,
+                agent,
+                resource: "/v1/summarize".into(),
+                declared_inputs: vec!["user_prompt".into()],
+                price: MicroUsd(10_000),
+            },
+            "deny" => MarketEvent::IfcDeny {
+                id: 0,
+                ts_unix_ms: 0,
+                agent,
+                reason: "AdversarialAncestry".into(),
+                declared_inputs: vec!["user_prompt".into(), "web_content".into()],
+                canonical: "deny\0user_prompt,web_content".into(),
+            },
+            _ => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn stamp_sets_id_and_ts() {
+        let mut ev = sample("registered");
+        assert_eq!(ev.id(), 0);
+        ev.stamp(42, 1_700_000_000_000);
+        assert_eq!(ev.id(), 42);
+        if let MarketEvent::AgentRegistered { ts_unix_ms, .. } = ev {
+            assert_eq!(ts_unix_ms, 1_700_000_000_000);
+        } else {
+            panic!("variant changed");
+        }
+    }
+
+    #[test]
+    fn lanes_and_peak() {
+        assert_eq!(sample("registered").lane(), Lane::Trust);
+        assert_eq!(sample("deny").lane(), Lane::Security);
+        assert!(sample("deny").is_peak());
+        assert!(!sample("registered").is_peak());
+    }
+
+    #[test]
+    fn wire_tags_are_snake_case_and_stable() {
+        // Lock the wire contract the frontend depends on.
+        let v = serde_json::to_value(sample("deny")).unwrap();
+        assert_eq!(v["type"], "ifc_deny");
+        assert_eq!(v["agent"], "agent-a");
+        assert_eq!(v["declared_inputs"][1], "web_content");
+
+        let settled = MarketEvent::Settlement {
+            id: 1,
+            ts_unix_ms: 2,
+            agent: AgentId::from("a"),
+            amount: MicroUsd(10_000),
+            chain: "eip155:84532".into(),
+            outcome: SettlementOutcome::Confirmed {
+                tx_hash: "0xabc".into(),
+            },
+            source: BalanceSource::Simulated,
+        };
+        let s = serde_json::to_value(&settled).unwrap();
+        assert_eq!(s["type"], "settlement");
+        assert_eq!(s["outcome"]["state"], "confirmed");
+        assert_eq!(s["source"], "simulated");
+
+        // Round-trip every variant shape we just built.
+        for ev in [sample("registered"), sample("deny"), settled] {
+            let json = serde_json::to_string(&ev).unwrap();
+            let back: MarketEvent = serde_json::from_str(&json).unwrap();
+            assert_eq!(ev, back);
+        }
+    }
+}

--- a/crates/nucleus-marketplace-dashboard/src/facilitator.rs
+++ b/crates/nucleus-marketplace-dashboard/src/facilitator.rs
@@ -1,0 +1,195 @@
+//! The settlement seam. The orchestrator is generic over [`Facilitator`], so the
+//! entire core tests against [`FakeFacilitator`] with NO network and NO alloy.
+//!
+//! The real Base Sepolia implementation (`X402Facilitator`, driving
+//! `x402-reqwest` against the testnet with a keystore-backed signer) lives in a
+//! SEPARATE workspace (`examples/`), exactly like `examples/x402-sepolia`, so the
+//! heavy alloy/x402 dependency tree never enters this crate or the main CI.
+
+use std::collections::VecDeque;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+
+use crate::event::{AgentId, BalanceSource, MicroUsd, SettlementOutcome};
+
+/// One settlement request handed to a [`Facilitator`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SettleRequest {
+    /// The paying agent.
+    pub agent: AgentId,
+    /// Amount to settle.
+    pub amount: MicroUsd,
+    /// The resource being paid for.
+    pub resource: String,
+    /// The payment reference the call is bound to.
+    pub payment_reference: String,
+}
+
+/// Settles a paid call. Implementations decide whether settlement is real
+/// (on-chain testnet) or simulated, reported via [`Facilitator::source`].
+#[async_trait]
+pub trait Facilitator: Send + Sync {
+    /// Attempt to settle; resolves to a terminal [`SettlementOutcome`].
+    async fn settle(&self, req: &SettleRequest) -> SettlementOutcome;
+
+    /// The current balance of `agent`, if known. The orchestrator emits this as a
+    /// [`crate::event::MarketEvent::BalanceUpdate`] tagged with [`Self::source`].
+    async fn balance_of(&self, agent: &AgentId) -> Option<MicroUsd>;
+
+    /// Provenance of every number this facilitator produces. A
+    /// [`BalanceSource::Simulated`] facilitator can never report real money.
+    fn source(&self) -> BalanceSource;
+}
+
+/// A deterministic, network-free facilitator for tests and the live SIMULATED
+/// demo binary. Outcomes can be scripted; balances are tracked as simple
+/// arithmetic. Every number it reports is [`BalanceSource::Simulated`].
+pub struct FakeFacilitator {
+    scripted: Mutex<VecDeque<SettlementOutcome>>,
+    default_outcome: SettlementOutcome,
+    initial_balance: i64,
+    balances: Mutex<std::collections::BTreeMap<AgentId, i64>>,
+    calls: AtomicU64,
+}
+
+impl FakeFacilitator {
+    /// Always confirm, starting every agent at `initial_balance`.
+    pub fn always_confirm(initial_balance: MicroUsd) -> Self {
+        Self {
+            scripted: Mutex::new(VecDeque::new()),
+            default_outcome: SettlementOutcome::Confirmed {
+                tx_hash: String::new(), // filled per-call with a clearly-synthetic ref
+            },
+            initial_balance: initial_balance.micros(),
+            balances: Mutex::new(std::collections::BTreeMap::new()),
+            calls: AtomicU64::new(0),
+        }
+    }
+
+    /// Return the scripted outcomes in order; once exhausted, fall back to
+    /// `default_outcome`.
+    pub fn scripted(
+        initial_balance: MicroUsd,
+        outcomes: impl IntoIterator<Item = SettlementOutcome>,
+        default_outcome: SettlementOutcome,
+    ) -> Self {
+        Self {
+            scripted: Mutex::new(outcomes.into_iter().collect()),
+            default_outcome,
+            initial_balance: initial_balance.micros(),
+            balances: Mutex::new(std::collections::BTreeMap::new()),
+            calls: AtomicU64::new(0),
+        }
+    }
+
+    /// How many times [`Facilitator::settle`] has been invoked — the test probe
+    /// that proves the deny path NEVER reaches settlement.
+    pub fn settle_calls(&self) -> u64 {
+        self.calls.load(Ordering::SeqCst)
+    }
+
+    /// A clearly-synthetic, deterministic "tx hash" so a simulated settlement can
+    /// never be mistaken for an on-chain one.
+    fn simulated_ref(call_index: u64) -> String {
+        format!("0xsimulated{call_index:056x}")
+    }
+}
+
+#[async_trait]
+impl Facilitator for FakeFacilitator {
+    async fn settle(&self, req: &SettleRequest) -> SettlementOutcome {
+        let call_index = self.calls.fetch_add(1, Ordering::SeqCst);
+        let outcome = {
+            let mut q = self.scripted.lock().unwrap();
+            q.pop_front()
+                .unwrap_or_else(|| self.default_outcome.clone())
+        };
+        // Materialise a synthetic confirmed ref + debit the simulated balance.
+        let outcome = match outcome {
+            SettlementOutcome::Confirmed { tx_hash } => {
+                let tx_hash = if tx_hash.is_empty() {
+                    Self::simulated_ref(call_index)
+                } else {
+                    tx_hash
+                };
+                let mut bals = self.balances.lock().unwrap();
+                let bal = bals
+                    .entry(req.agent.clone())
+                    .or_insert(self.initial_balance);
+                *bal -= req.amount.micros();
+                SettlementOutcome::Confirmed { tx_hash }
+            }
+            other => other, // Timeout / Orphaned do not move the balance
+        };
+        outcome
+    }
+
+    async fn balance_of(&self, agent: &AgentId) -> Option<MicroUsd> {
+        let bals = self.balances.lock().unwrap();
+        Some(MicroUsd(
+            bals.get(agent).copied().unwrap_or(self.initial_balance),
+        ))
+    }
+
+    fn source(&self) -> BalanceSource {
+        BalanceSource::Simulated
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn req(agent: &str, amount: i64) -> SettleRequest {
+        SettleRequest {
+            agent: AgentId::from(agent),
+            amount: MicroUsd(amount),
+            resource: "/v1/x".into(),
+            payment_reference: "ref-1".into(),
+        }
+    }
+
+    #[tokio::test]
+    async fn always_confirm_debits_and_is_simulated() {
+        let f = FakeFacilitator::always_confirm(MicroUsd(20_000_000));
+        assert_eq!(f.source(), BalanceSource::Simulated);
+        let out = f.settle(&req("a", 10_000)).await;
+        assert!(out.is_confirmed());
+        if let SettlementOutcome::Confirmed { tx_hash } = out {
+            assert!(tx_hash.starts_with("0xsimulated"));
+        }
+        assert_eq!(
+            f.balance_of(&AgentId::from("a")).await,
+            Some(MicroUsd(19_990_000))
+        );
+        assert_eq!(f.settle_calls(), 1);
+    }
+
+    #[tokio::test]
+    async fn scripted_outcomes_return_in_order_then_default() {
+        let f = FakeFacilitator::scripted(
+            MicroUsd(1_000_000),
+            [
+                SettlementOutcome::Confirmed {
+                    tx_hash: String::new(),
+                },
+                SettlementOutcome::Timeout,
+                SettlementOutcome::Orphaned,
+            ],
+            SettlementOutcome::Timeout,
+        );
+        assert!(f.settle(&req("a", 1)).await.is_confirmed());
+        assert_eq!(f.settle(&req("a", 1)).await, SettlementOutcome::Timeout);
+        assert_eq!(f.settle(&req("a", 1)).await, SettlementOutcome::Orphaned);
+        // exhausted → default
+        assert_eq!(f.settle(&req("a", 1)).await, SettlementOutcome::Timeout);
+        assert_eq!(f.settle_calls(), 4);
+        // Timeout/Orphaned never debited: only the single confirm did.
+        assert_eq!(
+            f.balance_of(&AgentId::from("a")).await,
+            Some(MicroUsd(999_999))
+        );
+    }
+}

--- a/crates/nucleus-marketplace-dashboard/src/http.rs
+++ b/crates/nucleus-marketplace-dashboard/src/http.rs
@@ -1,0 +1,86 @@
+//! The thin axum SSE edge (feature `server`). It only maps the already-tested
+//! [`Hub`] stream onto Server-Sent Events — no business logic lives here.
+//!
+//! Routes:
+//! - `GET /api/events` — SSE stream. Honours `Last-Event-ID` (replays buffered
+//!   events newer than that id, then the live feed). One-way fan-out ⇒ SSE, not
+//!   WebSocket: native browser reconnect, plain HTTP, no upgrade handshake.
+//! - `GET /api/snapshot` — the reduced [`MarketState`] for a cold client.
+//! - `GET /api/receipt/{settlement_id}` — the receipt bound to a settlement, for
+//!   one-click in-browser verification.
+
+use std::convert::Infallible;
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::extract::{Path, State};
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::sse::{Event, KeepAlive, Sse};
+use axum::response::IntoResponse;
+use axum::routing::get;
+use axum::{Json, Router};
+use futures::stream::{self, Stream, StreamExt};
+use tokio_stream::wrappers::BroadcastStream;
+
+use crate::event::MarketEvent;
+use crate::hub::Hub;
+
+/// Build the dashboard router over a shared [`Hub`].
+pub fn router(hub: Arc<Hub>) -> Router {
+    Router::new()
+        .route("/api/events", get(events))
+        .route("/api/snapshot", get(snapshot))
+        .route("/api/receipt/{settlement_id}", get(receipt))
+        .with_state(hub)
+}
+
+async fn snapshot(State(hub): State<Arc<Hub>>) -> impl IntoResponse {
+    Json(hub.snapshot())
+}
+
+async fn receipt(State(hub): State<Arc<Hub>>, Path(settlement_id): Path<u64>) -> impl IntoResponse {
+    match hub.receipt(settlement_id) {
+        Some(r) => Json(r).into_response(),
+        None => (StatusCode::NOT_FOUND, "no receipt for that settlement id").into_response(),
+    }
+}
+
+async fn events(
+    State(hub): State<Arc<Hub>>,
+    headers: HeaderMap,
+) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
+    let last_id = headers
+        .get("last-event-id")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.trim().parse::<u64>().ok())
+        .unwrap_or(0);
+
+    // Subscribe FIRST so no event slips between replay and live; the replay may
+    // overlap the live buffer, so the client dedups by id (it tracks max id).
+    let live = BroadcastStream::new(hub.subscribe());
+    let replay = hub.replay_since(last_id);
+
+    let replay_stream = stream::iter(replay).map(|ev| to_event(&ev));
+    let live_stream = live.filter_map(|res| async move {
+        match res {
+            Ok(ev) => Some(to_event(&ev)),
+            // A lagged subscriber drops the gap here; it recovers via the
+            // snapshot + Last-Event-ID replay on reconnect.
+            Err(_lagged) => None,
+        }
+    });
+
+    let merged = replay_stream
+        .chain(live_stream)
+        .map(Ok::<Event, Infallible>);
+    Sse::new(merged).keep_alive(KeepAlive::new().interval(Duration::from_secs(15)))
+}
+
+/// Serialise a [`MarketEvent`] to an SSE frame, carrying its id as the SSE event
+/// id so `Last-Event-ID` resume works.
+fn to_event(ev: &MarketEvent) -> Event {
+    Event::default()
+        .id(ev.id().to_string())
+        .json_data(ev)
+        .unwrap_or_else(|_| Event::default())
+}

--- a/crates/nucleus-marketplace-dashboard/src/hub.rs
+++ b/crates/nucleus-marketplace-dashboard/src/hub.rs
@@ -1,0 +1,192 @@
+//! The fan-out hub: a tokio broadcast channel with a monotonic seq, a bounded
+//! replay ring (for `Last-Event-ID` resume), the reduced [`MarketState`], and a
+//! receipt store (for one-click `/api/receipt/{seq}` verification).
+//!
+//! Emit is serialised under one lock so id assignment, ring/state updates, and
+//! the broadcast all happen in id order — a slow subscriber that lags can still
+//! recover via the snapshot + replay ring.
+
+use std::collections::{BTreeMap, VecDeque};
+use std::sync::{Arc, Mutex};
+
+use tokio::sync::broadcast;
+
+use crate::clock::Clock;
+use crate::event::MarketEvent;
+use crate::reducer::MarketState;
+use nucleus_verify_commerce::Receipt;
+
+struct Inner {
+    seq: u64,
+    ring: VecDeque<MarketEvent>,
+    state: MarketState,
+    receipts: BTreeMap<u64, Receipt>,
+}
+
+/// The marketplace event hub.
+pub struct Hub {
+    tx: broadcast::Sender<MarketEvent>,
+    clock: Arc<dyn Clock>,
+    ring_cap: usize,
+    inner: Mutex<Inner>,
+}
+
+impl Hub {
+    /// Create a hub. `channel_cap` bounds the live broadcast buffer (a slow
+    /// subscriber past this lags and must recover via replay); `ring_cap` bounds
+    /// the replay ring and the snapshot's recent-event list.
+    pub fn new(clock: Arc<dyn Clock>, channel_cap: usize, ring_cap: usize) -> Arc<Self> {
+        let (tx, _rx) = broadcast::channel(channel_cap);
+        Arc::new(Self {
+            tx,
+            clock,
+            ring_cap,
+            inner: Mutex::new(Inner {
+                seq: 0,
+                ring: VecDeque::new(),
+                state: MarketState::with_cap(ring_cap),
+                receipts: BTreeMap::new(),
+            }),
+        })
+    }
+
+    /// Stamp `ev` with the next id + current time, record it (ring + reduced
+    /// state), broadcast it, and return the assigned id. Ids start at 1.
+    pub fn emit(&self, mut ev: MarketEvent) -> u64 {
+        let ts = self.clock.now_unix_ms();
+        let mut inner = self.inner.lock().unwrap();
+        inner.seq += 1;
+        let id = inner.seq;
+        ev.stamp(id, ts);
+
+        inner.ring.push_back(ev.clone());
+        while inner.ring.len() > self.ring_cap {
+            inner.ring.pop_front();
+        }
+        inner.state.apply(&ev);
+        // Send under the lock so subscribers observe strict id order. `send`
+        // errors only when there are no receivers — fine for a fan-out hub.
+        let _ = self.tx.send(ev);
+        id
+    }
+
+    /// Associate a [`Receipt`] with the settlement event it binds, for retrieval
+    /// by `/api/receipt/{settlement_id}`.
+    pub fn store_receipt(&self, settlement_id: u64, receipt: Receipt) {
+        self.inner
+            .lock()
+            .unwrap()
+            .receipts
+            .insert(settlement_id, receipt);
+    }
+
+    /// Fetch a stored receipt by its settlement id.
+    pub fn receipt(&self, settlement_id: u64) -> Option<Receipt> {
+        self.inner
+            .lock()
+            .unwrap()
+            .receipts
+            .get(&settlement_id)
+            .cloned()
+    }
+
+    /// Subscribe to the live event stream.
+    pub fn subscribe(&self) -> broadcast::Receiver<MarketEvent> {
+        self.tx.subscribe()
+    }
+
+    /// Replay buffered events with id strictly greater than `last_id` (for
+    /// `Last-Event-ID` resume). Bounded by `ring_cap`; very old gaps are
+    /// unrecoverable by design (the client falls back to the snapshot).
+    pub fn replay_since(&self, last_id: u64) -> Vec<MarketEvent> {
+        self.inner
+            .lock()
+            .unwrap()
+            .ring
+            .iter()
+            .filter(|e| e.id() > last_id)
+            .cloned()
+            .collect()
+    }
+
+    /// A consistent snapshot of the reduced state (the cold-client baseline).
+    pub fn snapshot(&self) -> MarketState {
+        self.inner.lock().unwrap().state.clone()
+    }
+
+    /// The highest id emitted so far.
+    pub fn last_id(&self) -> u64 {
+        self.inner.lock().unwrap().seq
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::clock::FixedClock;
+    use crate::event::{AgentId, MarketEvent};
+
+    fn call(agent: &str) -> MarketEvent {
+        MarketEvent::CallStarted {
+            id: 0,
+            ts_unix_ms: 0,
+            agent: AgentId::from(agent),
+            resource: "/x".into(),
+            attempt: 0,
+        }
+    }
+
+    #[tokio::test]
+    async fn emit_stamps_monotonic_ids_and_fixed_ts() {
+        let hub = Hub::new(Arc::new(FixedClock::new(5000)), 16, 16);
+        assert_eq!(hub.emit(call("a")), 1);
+        assert_eq!(hub.emit(call("a")), 2);
+        let snap = hub.snapshot();
+        assert_eq!(snap.last_id, 2);
+        assert!(snap.recent.iter().all(|e| {
+            matches!(e, MarketEvent::CallStarted { ts_unix_ms, .. } if *ts_unix_ms == 5000)
+        }));
+    }
+
+    #[tokio::test]
+    async fn replay_since_returns_only_newer_ids() {
+        let hub = Hub::new(Arc::new(FixedClock::default()), 16, 16);
+        for _ in 0..5 {
+            hub.emit(call("a"));
+        }
+        let ids: Vec<u64> = hub.replay_since(2).iter().map(|e| e.id()).collect();
+        assert_eq!(ids, vec![3, 4, 5]);
+        assert!(hub.replay_since(5).is_empty());
+    }
+
+    #[tokio::test]
+    async fn subscriber_sees_only_post_subscribe_events_in_order() {
+        let hub = Hub::new(Arc::new(FixedClock::default()), 16, 16);
+        hub.emit(call("before"));
+        let mut rx = hub.subscribe();
+        let id_a = hub.emit(call("a"));
+        let id_b = hub.emit(call("b"));
+        let first = rx.recv().await.unwrap();
+        let second = rx.recv().await.unwrap();
+        assert_eq!(first.id(), id_a);
+        assert_eq!(second.id(), id_b);
+    }
+
+    #[tokio::test]
+    async fn slow_subscriber_lags_but_replay_recovers() {
+        // channel cap 2: a subscriber that never reads will lag once we emit >2.
+        let hub = Hub::new(Arc::new(FixedClock::default()), 2, 64);
+        let mut rx = hub.subscribe();
+        for _ in 0..5 {
+            hub.emit(call("a"));
+        }
+        // The first recv reports the lag (events were dropped from the channel)…
+        let err = rx.recv().await.unwrap_err();
+        assert!(matches!(
+            err,
+            tokio::sync::broadcast::error::RecvError::Lagged(_)
+        ));
+        // …but the replay ring (cap 64) still has everything for recovery.
+        assert_eq!(hub.replay_since(0).len(), 5);
+    }
+}

--- a/crates/nucleus-marketplace-dashboard/src/lib.rs
+++ b/crates/nucleus-marketplace-dashboard/src/lib.rs
@@ -1,0 +1,54 @@
+//! Real-time **verified-agent-marketplace** dashboard.
+//!
+//! An axum SSE orchestrator that runs N agent loops making paid calls through
+//! the nucleus IFC gate ([`nucleus_verify_commerce`]), emitting
+//! allow/deny/settlement/receipt events to a broadcast [`Hub`]. A Leptos
+//! frontend renders the live feed and verifies receipts in-browser.
+//!
+//! # Design: a network-free, deterministic core
+//!
+//! The decision/event/state core is exercised with **no network, no real
+//! clock, and no alloy**:
+//!
+//! - [`Clock`] (with [`FixedClock`]) makes timestamps deterministic.
+//! - [`Facilitator`] (with [`FakeFacilitator`]) abstracts settlement; the real
+//!   Base Sepolia (testnet) implementation lives in a **separate workspace**
+//!   under `examples/`, so the heavy x402/alloy tree never enters this crate or
+//!   the main CI.
+//! - The IFC decision is [`nucleus_verify_commerce::FlowDeclaration::decide`] — a
+//!   pure function with its own tests.
+//! - [`MarketState::apply`] is a pure synchronous fold; state is exactly
+//!   `fold(apply, default, events)`, so `/api/snapshot` and the live feed can
+//!   never diverge.
+//! - [`Orchestrator::step_once`] runs one agent iteration synchronously for
+//!   deterministic assertions.
+//!
+//! # Honesty
+//!
+//! Testnet only. The IFC verdict is **model-level over declared inputs**
+//! (coverage-limited, per-call). Simulated money is tagged
+//! [`event::BalanceSource::Simulated`] and can never appear as on-chain money —
+//! see [`event`].
+
+#![forbid(unsafe_code)]
+
+pub mod agent;
+pub mod clock;
+pub mod event;
+pub mod facilitator;
+pub mod hub;
+pub mod orchestrator;
+pub mod reducer;
+
+#[cfg(feature = "server")]
+pub mod http;
+
+pub use agent::AgentLoop;
+pub use clock::{Clock, FixedClock, SystemClock};
+pub use event::{
+    AgentId, BalanceSource, Lane, MarketEvent, MicroUsd, SettlementOutcome, VerifyMethod,
+};
+pub use facilitator::{Facilitator, FakeFacilitator, SettleRequest};
+pub use hub::Hub;
+pub use orchestrator::{Orchestrator, BASE_SEPOLIA_CAIP2};
+pub use reducer::{AgentSummary, MarketState, DEFAULT_RECENT_CAP};

--- a/crates/nucleus-marketplace-dashboard/src/orchestrator.rs
+++ b/crates/nucleus-marketplace-dashboard/src/orchestrator.rs
@@ -1,0 +1,222 @@
+//! The orchestrator: runs N [`AgentLoop`]s, each one iteration emitting the
+//! marketplace event sequence into the [`Hub`]. Generic over [`Facilitator`] so
+//! tests drive it with [`crate::FakeFacilitator`] — no network, no alloy.
+//!
+//! The per-iteration ordering mirrors
+//! [`nucleus_verify_commerce::serve_verified_ifc`] exactly: the IFC gate runs
+//! before settlement, and a DENY stops the iteration — settlement is never
+//! attempted. That guarantee is asserted in `tests/orchestrator_isolation.rs`
+//! via the facilitator's `settle_calls()` probe.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio_util::sync::CancellationToken;
+
+use crate::agent::AgentLoop;
+use crate::event::{MarketEvent, SettlementOutcome, VerifyMethod};
+use crate::facilitator::{Facilitator, SettleRequest};
+use crate::hub::Hub;
+use nucleus_verify_commerce::{
+    body_sha256_hex, CallerClaims, CommerceRequest, PaymentProof, ReceiptContext, ReceiptIssuer,
+    VerifiedCaller,
+};
+
+/// CAIP-2 chain id for Base Sepolia (testnet).
+pub const BASE_SEPOLIA_CAIP2: &str = "eip155:84532";
+
+/// Drives the marketplace.
+pub struct Orchestrator<F: Facilitator> {
+    hub: Arc<Hub>,
+    facilitator: Arc<F>,
+    agents: Vec<AgentLoop>,
+    chain: String,
+}
+
+impl<F: Facilitator + 'static> Orchestrator<F> {
+    /// Build an orchestrator over a hub, a facilitator, and an agent fleet.
+    pub fn new(hub: Arc<Hub>, facilitator: Arc<F>, agents: Vec<AgentLoop>) -> Self {
+        Self {
+            hub,
+            facilitator,
+            agents,
+            chain: BASE_SEPOLIA_CAIP2.to_string(),
+        }
+    }
+
+    /// The agent fleet.
+    pub fn agents(&self) -> &[AgentLoop] {
+        &self.agents
+    }
+
+    /// Emit an `AgentRegistered` for every agent (call once at startup).
+    pub fn register_all(&self) {
+        for a in &self.agents {
+            self.hub.emit(MarketEvent::AgentRegistered {
+                id: 0,
+                ts_unix_ms: 0,
+                agent: a.agent.clone(),
+                resource: a.resource.clone(),
+                declared_inputs: a.declared_inputs(),
+                price: a.price,
+            });
+        }
+    }
+
+    /// Run exactly one iteration for `agents[idx]` synchronously, emitting the
+    /// full event sequence. The deterministic test entry point.
+    ///
+    /// Sequence on ALLOW: `CallStarted → IfcAllow → Settlement → [Confirmed ⇒
+    /// ReceiptVerified → BalanceUpdate]`. On DENY: `CallStarted → IfcDeny` and
+    /// nothing else (settlement is never attempted).
+    pub async fn step_once(&self, idx: usize, attempt: u64) {
+        let a = &self.agents[idx];
+
+        self.hub.emit(MarketEvent::CallStarted {
+            id: 0,
+            ts_unix_ms: 0,
+            agent: a.agent.clone(),
+            resource: a.resource.clone(),
+            attempt,
+        });
+
+        // IFC gate — strictly before settlement.
+        let verdict = a.flow.decide();
+        if !verdict.is_allow() {
+            self.hub.emit(MarketEvent::IfcDeny {
+                id: 0,
+                ts_unix_ms: 0,
+                agent: a.agent.clone(),
+                reason: verdict.reason.clone(),
+                declared_inputs: verdict.declared_inputs.clone(),
+                canonical: verdict.canonical(),
+            });
+            return; // deny ⇒ no settlement, no handler, no receipt
+        }
+
+        self.hub.emit(MarketEvent::IfcAllow {
+            id: 0,
+            ts_unix_ms: 0,
+            agent: a.agent.clone(),
+            declared_inputs: verdict.declared_inputs.clone(),
+            canonical: verdict.canonical(),
+        });
+
+        let payment_reference = format!("{}-{}", a.agent.as_str(), attempt);
+        let outcome = self
+            .facilitator
+            .settle(&SettleRequest {
+                agent: a.agent.clone(),
+                amount: a.price,
+                resource: a.resource.clone(),
+                payment_reference: payment_reference.clone(),
+            })
+            .await;
+        let source = self.facilitator.source();
+
+        let settlement_id = self.hub.emit(MarketEvent::Settlement {
+            id: 0,
+            ts_unix_ms: 0,
+            agent: a.agent.clone(),
+            amount: a.price,
+            chain: self.chain.clone(),
+            outcome: outcome.clone(),
+            source,
+        });
+
+        // Only a confirmed settlement yields a receipt + balance update.
+        let SettlementOutcome::Confirmed { tx_hash } = &outcome else {
+            return;
+        };
+
+        // Issue the receipt through the REAL verify-commerce issuer, binding the
+        // delivered bytes + the IFC verdict. (The simulated path uses the
+        // hash-binding issuer; the real settlement path swaps in the signed
+        // EnvelopeReceiptIssuer + verify_receipt_bundle.)
+        let caller = VerifiedCaller {
+            spiffe_id: format!("spiffe://marketplace.local/agent/{}", a.agent.as_str()),
+        };
+        let request = CommerceRequest::new(
+            a.resource.clone(),
+            CallerClaims {
+                agent_id: a.agent.0.clone(),
+                credential: "simulated".into(),
+            },
+            PaymentProof {
+                scheme: "x402".into(),
+                reference: payment_reference.clone(),
+            },
+        );
+        let body =
+            format!("{{\"resource\":\"{}\",\"tx\":\"{}\"}}", a.resource, tx_hash).into_bytes();
+
+        let issuer = nucleus_verify_commerce::HashingReceiptIssuer;
+        let (receipt, verified) = match issuer.issue(&ReceiptContext {
+            caller: &caller,
+            request: &request,
+            body: &body,
+            ifc_verdict: Some(&verdict),
+        }) {
+            // HashRebind verification: re-derive the content binding and compare.
+            Ok(r) => {
+                let ok = r.body_sha256 == body_sha256_hex(&body);
+                (Some(r), ok)
+            }
+            Err(_) => (None, false),
+        };
+
+        let body_sha256 = receipt
+            .as_ref()
+            .map(|r| r.body_sha256.clone())
+            .unwrap_or_default();
+        if let Some(r) = receipt {
+            self.hub.store_receipt(settlement_id, r);
+        }
+        self.hub.emit(MarketEvent::ReceiptVerified {
+            id: 0,
+            ts_unix_ms: 0,
+            agent: a.agent.clone(),
+            resource: a.resource.clone(),
+            payment_reference,
+            body_sha256,
+            for_settlement_id: settlement_id,
+            method: VerifyMethod::HashRebind,
+            verified,
+        });
+
+        if let Some(balance) = self.facilitator.balance_of(&a.agent).await {
+            self.hub.emit(MarketEvent::BalanceUpdate {
+                id: 0,
+                ts_unix_ms: 0,
+                agent: a.agent.clone(),
+                balance,
+                source,
+            });
+        }
+    }
+
+    /// Run all agent loops until `cancel` fires. Each loop paces off its
+    /// `interval_ms`. Consumes `self` (wrapped in `Arc`) so loops can share it.
+    pub async fn run(self: Arc<Self>, cancel: CancellationToken) {
+        self.register_all();
+        let mut set = tokio::task::JoinSet::new();
+        for idx in 0..self.agents.len() {
+            let this = Arc::clone(&self);
+            let cancel = cancel.clone();
+            let interval = self.agents[idx].interval_ms.max(1);
+            set.spawn(async move {
+                let mut attempt: u64 = 0;
+                loop {
+                    tokio::select! {
+                        _ = cancel.cancelled() => break,
+                        _ = tokio::time::sleep(Duration::from_millis(interval)) => {
+                            attempt += 1;
+                            this.step_once(idx, attempt).await;
+                        }
+                    }
+                }
+            });
+        }
+        while set.join_next().await.is_some() {}
+    }
+}

--- a/crates/nucleus-marketplace-dashboard/src/reducer.rs
+++ b/crates/nucleus-marketplace-dashboard/src/reducer.rs
@@ -1,0 +1,277 @@
+//! The pure reducer: `MarketState` + [`MarketState::apply`]. State is exactly
+//! `fold(apply, default, events)`, so a fresh SSE client's `/api/snapshot` and
+//! the live feed can never diverge — they are the same function over the same
+//! events. No tokio, no network: a plain synchronous fold tested with
+//! hand-injected event vectors.
+
+use std::collections::{BTreeMap, VecDeque};
+
+use serde::Serialize;
+
+use crate::event::{AgentId, BalanceSource, MarketEvent, MicroUsd};
+
+/// Default cap on the recent-event ring carried in a snapshot.
+pub const DEFAULT_RECENT_CAP: usize = 200;
+
+/// Per-agent rollup.
+#[derive(Debug, Clone, Default, PartialEq, Serialize)]
+pub struct AgentSummary {
+    /// The resource this agent buys.
+    pub resource: String,
+    /// Declared IFC input tokens (coverage audit surface).
+    pub declared_inputs: Vec<String>,
+    /// Price per call (micro-USD).
+    pub price: MicroUsd,
+    /// IFC allows / denies seen for this agent.
+    pub allows: u64,
+    /// IFC denies seen for this agent.
+    pub denies: u64,
+    /// Confirmed settlements for this agent.
+    pub settlements: u64,
+    /// Latest known balance, if any.
+    pub balance: Option<MicroUsd>,
+    /// Provenance of `balance` (so the UI badges Simulated vs OnChainTestnet).
+    pub balance_source: Option<BalanceSource>,
+}
+
+/// The reduced marketplace state — the ground truth a cold client receives.
+#[derive(Debug, Clone, Default, PartialEq, Serialize)]
+pub struct MarketState {
+    /// Per-agent rollups, keyed by agent id.
+    pub agents: BTreeMap<String, AgentSummary>,
+    /// Total IFC allows across the marketplace.
+    pub allow_count: u64,
+    /// Total IFC denies across the marketplace.
+    pub deny_count: u64,
+    /// Total receipts that verified.
+    pub receipts_verified: u64,
+    /// Cumulative micro-USD settled via the SIMULATED facilitator.
+    pub simulated_settled_micros: i64,
+    /// Cumulative micro-USD settled on-chain (Base Sepolia testnet) — only ever
+    /// incremented by a `Confirmed` settlement tagged `OnChainTestnet`.
+    pub onchain_settled_micros: i64,
+    /// Highest event id applied (the snapshot's `Last-Event-ID`).
+    pub last_id: u64,
+    /// Bounded recent-event ring (newest last).
+    pub recent: VecDeque<MarketEvent>,
+    /// Cap for `recent`.
+    pub recent_cap: usize,
+}
+
+impl MarketState {
+    /// A fresh state with a given recent-ring cap.
+    pub fn with_cap(recent_cap: usize) -> Self {
+        Self {
+            recent_cap,
+            ..Default::default()
+        }
+    }
+
+    fn agent_mut(&mut self, id: &AgentId) -> &mut AgentSummary {
+        self.agents.entry(id.0.clone()).or_default()
+    }
+
+    /// Fold one event into the state. Pure and total.
+    pub fn apply(&mut self, ev: &MarketEvent) {
+        self.last_id = self.last_id.max(ev.id());
+
+        match ev {
+            MarketEvent::AgentRegistered {
+                agent,
+                resource,
+                declared_inputs,
+                price,
+                ..
+            } => {
+                let a = self.agent_mut(agent);
+                a.resource = resource.clone();
+                a.declared_inputs = declared_inputs.clone();
+                a.price = *price;
+            }
+            MarketEvent::CallStarted { .. } => {}
+            MarketEvent::IfcAllow { agent, .. } => {
+                self.allow_count += 1;
+                self.agent_mut(agent).allows += 1;
+            }
+            MarketEvent::IfcDeny { agent, .. } => {
+                self.deny_count += 1;
+                self.agent_mut(agent).denies += 1;
+            }
+            MarketEvent::Settlement {
+                agent,
+                amount,
+                outcome,
+                source,
+                ..
+            } => {
+                if outcome.is_confirmed() {
+                    self.agent_mut(agent).settlements += 1;
+                    match source {
+                        BalanceSource::Simulated => {
+                            self.simulated_settled_micros += amount.micros()
+                        }
+                        BalanceSource::OnChainTestnet => {
+                            self.onchain_settled_micros += amount.micros()
+                        }
+                    }
+                }
+            }
+            MarketEvent::ReceiptVerified { verified, .. } => {
+                if *verified {
+                    self.receipts_verified += 1;
+                }
+            }
+            MarketEvent::BalanceUpdate {
+                agent,
+                balance,
+                source,
+                ..
+            } => {
+                let a = self.agent_mut(agent);
+                a.balance = Some(*balance);
+                a.balance_source = Some(*source);
+            }
+        }
+
+        self.recent.push_back(ev.clone());
+        let cap = if self.recent_cap == 0 {
+            DEFAULT_RECENT_CAP
+        } else {
+            self.recent_cap
+        };
+        while self.recent.len() > cap {
+            self.recent.pop_front();
+        }
+    }
+
+    /// Fold a whole sequence — the canonical way to build state from events.
+    pub fn fold(events: &[MarketEvent], recent_cap: usize) -> Self {
+        let mut s = MarketState::with_cap(recent_cap);
+        for ev in events {
+            s.apply(ev);
+        }
+        s
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::event::{SettlementOutcome, VerifyMethod};
+
+    fn ev_seq() -> Vec<MarketEvent> {
+        let a = AgentId::from("agent-a");
+        vec![
+            MarketEvent::AgentRegistered {
+                id: 1,
+                ts_unix_ms: 10,
+                agent: a.clone(),
+                resource: "/v1/summarize".into(),
+                declared_inputs: vec!["user_prompt".into(), "database_row".into()],
+                price: MicroUsd(10_000),
+            },
+            MarketEvent::CallStarted {
+                id: 2,
+                ts_unix_ms: 11,
+                agent: a.clone(),
+                resource: "/v1/summarize".into(),
+                attempt: 1,
+            },
+            MarketEvent::IfcAllow {
+                id: 3,
+                ts_unix_ms: 12,
+                agent: a.clone(),
+                declared_inputs: vec!["database_row".into(), "user_prompt".into()],
+                canonical: "allow\0database_row,user_prompt".into(),
+            },
+            MarketEvent::Settlement {
+                id: 4,
+                ts_unix_ms: 13,
+                agent: a.clone(),
+                amount: MicroUsd(10_000),
+                chain: "eip155:84532".into(),
+                outcome: SettlementOutcome::Confirmed {
+                    tx_hash: "0xsimulated0".into(),
+                },
+                source: BalanceSource::Simulated,
+            },
+            MarketEvent::ReceiptVerified {
+                id: 5,
+                ts_unix_ms: 14,
+                agent: a.clone(),
+                resource: "/v1/summarize".into(),
+                payment_reference: "ref-1".into(),
+                body_sha256: "deadbeef".into(),
+                for_settlement_id: 4,
+                method: VerifyMethod::HashRebind,
+                verified: true,
+            },
+            MarketEvent::BalanceUpdate {
+                id: 6,
+                ts_unix_ms: 15,
+                agent: a,
+                balance: MicroUsd(19_990_000),
+                source: BalanceSource::Simulated,
+            },
+        ]
+    }
+
+    #[test]
+    fn reducer_counts_and_balances() {
+        let s = MarketState::fold(&ev_seq(), 200);
+        assert_eq!(s.allow_count, 1);
+        assert_eq!(s.deny_count, 0);
+        assert_eq!(s.receipts_verified, 1);
+        assert_eq!(s.simulated_settled_micros, 10_000);
+        assert_eq!(s.onchain_settled_micros, 0); // honesty: nothing on-chain
+        assert_eq!(s.last_id, 6);
+        let a = &s.agents["agent-a"];
+        assert_eq!(a.allows, 1);
+        assert_eq!(a.settlements, 1);
+        assert_eq!(a.balance, Some(MicroUsd(19_990_000)));
+        assert_eq!(a.balance_source, Some(BalanceSource::Simulated));
+    }
+
+    #[test]
+    fn snapshot_equals_replay_of_all_events() {
+        // Folding the same events from scratch twice yields identical state —
+        // the property that makes /api/snapshot == live feed.
+        let events = ev_seq();
+        let a = MarketState::fold(&events, 200);
+        let mut b = MarketState::with_cap(200);
+        for e in &events {
+            b.apply(e);
+        }
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn honesty_invariant_onchain_requires_onchain_settlement() {
+        // A reducer fed only Simulated settlements must NEVER show on-chain money.
+        let s = MarketState::fold(&ev_seq(), 200);
+        assert_eq!(s.onchain_settled_micros, 0);
+        assert!(s
+            .agents
+            .values()
+            .all(|a| a.balance_source != Some(BalanceSource::OnChainTestnet)));
+    }
+
+    #[test]
+    fn recent_ring_is_bounded() {
+        let a = AgentId::from("a");
+        let mut s = MarketState::with_cap(3);
+        for i in 0..10 {
+            s.apply(&MarketEvent::CallStarted {
+                id: i,
+                ts_unix_ms: i as i64,
+                agent: a.clone(),
+                resource: "/x".into(),
+                attempt: i,
+            });
+        }
+        assert_eq!(s.recent.len(), 3);
+        assert_eq!(s.recent.front().unwrap().id(), 7);
+        assert_eq!(s.recent.back().unwrap().id(), 9);
+        assert_eq!(s.last_id, 9);
+    }
+}

--- a/crates/nucleus-marketplace-dashboard/tests/orchestrator_isolation.rs
+++ b/crates/nucleus-marketplace-dashboard/tests/orchestrator_isolation.rs
@@ -1,0 +1,168 @@
+//! The load-bearing milestone: the orchestrator + event model proven IN
+//! ISOLATION — deterministic, no network, no alloy (FakeFacilitator + FixedClock).
+
+use std::sync::Arc;
+
+use nucleus_marketplace_dashboard::{
+    FakeFacilitator, FixedClock, Hub, MarketEvent, MicroUsd, Orchestrator, SettlementOutcome,
+};
+use nucleus_verify_commerce::{DeclaredInput, FlowDeclaration};
+
+fn agent(
+    id: &str,
+    inputs: impl IntoIterator<Item = DeclaredInput>,
+) -> nucleus_marketplace_dashboard::AgentLoop {
+    nucleus_marketplace_dashboard::AgentLoop::new(
+        id,
+        "/v1/summarize",
+        FlowDeclaration::new(inputs),
+        MicroUsd(10_000),
+        1000,
+    )
+}
+
+/// Variant tags of the events in the hub's snapshot, in order.
+fn tags(hub: &Hub) -> Vec<&'static str> {
+    hub.snapshot()
+        .recent
+        .iter()
+        .map(|e| match e {
+            MarketEvent::AgentRegistered { .. } => "agent_registered",
+            MarketEvent::CallStarted { .. } => "call_started",
+            MarketEvent::IfcAllow { .. } => "ifc_allow",
+            MarketEvent::IfcDeny { .. } => "ifc_deny",
+            MarketEvent::Settlement { .. } => "settlement",
+            MarketEvent::ReceiptVerified { .. } => "receipt_verified",
+            MarketEvent::BalanceUpdate { .. } => "balance_update",
+        })
+        .collect()
+}
+
+#[tokio::test]
+async fn allow_path_emits_full_sequence() {
+    let hub = Hub::new(Arc::new(FixedClock::new(1000)), 64, 64);
+    let fac = Arc::new(FakeFacilitator::always_confirm(MicroUsd(20_000_000)));
+    let orch = Orchestrator::new(
+        Arc::clone(&hub),
+        Arc::clone(&fac),
+        // safe flow: trusted prompt + internal DB row → ALLOW
+        vec![agent(
+            "agent-a",
+            [DeclaredInput::UserPrompt, DeclaredInput::DatabaseRow],
+        )],
+    );
+
+    orch.step_once(0, 1).await;
+
+    assert_eq!(
+        tags(&hub),
+        vec![
+            "call_started",
+            "ifc_allow",
+            "settlement",
+            "receipt_verified",
+            "balance_update",
+        ]
+    );
+    let snap = hub.snapshot();
+    assert_eq!(snap.allow_count, 1);
+    assert_eq!(snap.deny_count, 0);
+    assert_eq!(snap.receipts_verified, 1);
+    assert_eq!(snap.simulated_settled_micros, 10_000);
+    assert_eq!(snap.onchain_settled_micros, 0); // honesty: nothing on-chain
+    assert_eq!(fac.settle_calls(), 1);
+    assert_eq!(
+        snap.agents["agent-a"].balance,
+        Some(MicroUsd(20_000_000 - 10_000))
+    );
+}
+
+#[tokio::test]
+async fn deny_path_stops_before_settlement() {
+    let hub = Hub::new(Arc::new(FixedClock::new(1000)), 64, 64);
+    let fac = Arc::new(FakeFacilitator::always_confirm(MicroUsd(20_000_000)));
+    let orch = Orchestrator::new(
+        Arc::clone(&hub),
+        Arc::clone(&fac),
+        // unsafe flow: trusted prompt + adversarial web content → DENY
+        vec![agent(
+            "agent-x",
+            [DeclaredInput::UserPrompt, DeclaredInput::WebContent],
+        )],
+    );
+
+    orch.step_once(0, 1).await;
+
+    // The seller.rs ordering guarantee, proven in isolation: nothing after IfcDeny.
+    assert_eq!(tags(&hub), vec!["call_started", "ifc_deny"]);
+    assert_eq!(
+        fac.settle_calls(),
+        0,
+        "settlement must NEVER be attempted on a denied flow"
+    );
+    let snap = hub.snapshot();
+    assert_eq!(snap.deny_count, 1);
+    assert_eq!(snap.simulated_settled_micros, 0);
+}
+
+#[tokio::test]
+async fn timeout_path_yields_no_receipt_and_no_resettle() {
+    let hub = Hub::new(Arc::new(FixedClock::new(1000)), 64, 64);
+    let fac = Arc::new(FakeFacilitator::scripted(
+        MicroUsd(20_000_000),
+        [SettlementOutcome::Timeout],
+        SettlementOutcome::Timeout,
+    ));
+    let orch = Orchestrator::new(
+        Arc::clone(&hub),
+        Arc::clone(&fac),
+        vec![agent("agent-a", [DeclaredInput::UserPrompt])],
+    );
+
+    orch.step_once(0, 1).await;
+
+    // Allowed, settlement attempted once, timed out → no receipt, no balance,
+    // and crucially the iteration does NOT re-settle (double-spend trap avoided).
+    assert_eq!(tags(&hub), vec!["call_started", "ifc_allow", "settlement"]);
+    assert_eq!(fac.settle_calls(), 1);
+    let snap = hub.snapshot();
+    assert_eq!(snap.receipts_verified, 0);
+    assert_eq!(snap.simulated_settled_micros, 0);
+}
+
+#[tokio::test]
+async fn whole_core_is_reproducible_with_no_network() {
+    // Two identical runs (FixedClock + scripted FakeFacilitator) produce
+    // byte-identical event JSON — the entire core is deterministic.
+    async fn run() -> String {
+        let hub = Hub::new(Arc::new(FixedClock::new(42)), 128, 128);
+        let fac = Arc::new(FakeFacilitator::scripted(
+            MicroUsd(20_000_000),
+            [
+                SettlementOutcome::Confirmed {
+                    tx_hash: String::new(),
+                },
+                SettlementOutcome::Confirmed {
+                    tx_hash: String::new(),
+                },
+            ],
+            SettlementOutcome::Confirmed {
+                tx_hash: String::new(),
+            },
+        ));
+        let orch = Orchestrator::new(
+            Arc::clone(&hub),
+            fac,
+            vec![
+                agent("a", [DeclaredInput::UserPrompt, DeclaredInput::DatabaseRow]),
+                agent("b", [DeclaredInput::UserPrompt, DeclaredInput::WebContent]),
+            ],
+        );
+        orch.register_all();
+        orch.step_once(0, 1).await;
+        orch.step_once(1, 1).await;
+        serde_json::to_string(&hub.snapshot().recent).unwrap()
+    }
+
+    assert_eq!(run().await, run().await);
+}


### PR DESCRIPTION
## What

New crate `nucleus-marketplace-dashboard`: a real-time verified-agent-marketplace backend. An axum **SSE orchestrator** runs N agent loops making paid calls through the nucleus **IFC gate**, emitting allow/deny/settlement/receipt events to a broadcast hub. The frontend (next PR) renders the live feed + one-click in-browser receipt verify.

This is **P0 step 1–8**: backend + event model, proven **in isolation**.

## Design — network-free deterministic core + thin SSE edge

| File | Role |
|---|---|
| `event.rs` | `MarketEvent` serde-tagged wire contract (shared verbatim with the wasm frontend). `BalanceSource{OnChainTestnet,Simulated}` so simulated money can't masquerade as real. |
| `reducer.rs` | pure `MarketState::apply`; state == `fold(apply, default, events)` ⇒ `/api/snapshot` and the live feed can't diverge. |
| `clock.rs` / `facilitator.rs` | `Clock` + `Facilitator` traits w/ `FixedClock` + `FakeFacilitator` ⇒ whole core tests with **no network, no clock, no alloy**. |
| `orchestrator.rs` | mirrors `serve_verified_ifc` ordering — a **DENY stops the iteration; settlement is never attempted**. |
| `hub.rs` | tokio broadcast + monotonic seq + bounded replay ring (`Last-Event-ID`) + receipt store. |
| `http.rs` (feat `server`) | thin SSE edge: `/api/events`, `/api/snapshot`, `/api/receipt/{id}`. |
| `bin/` | live **SIMULATED** orchestrator (loud banner; 4 safe agents + 1 compromised). |

## Verified

- **19 tests** green (unit + `tests/orchestrator_isolation.rs`): exact event sequence per iteration; **deny ⇒ `settle_calls() == 0`**; timeout ⇒ no receipt, no re-settle; whole core byte-for-byte reproducible.
- `clippy --all-targets --all-features -D warnings` + `fmt` clean.
- Live smoke: SSE feed streams (107 frames/3s), deny fires on cadence, `onchain_settled_micros` stays **0** (honesty invariant).

## Isolation of the heavy deps

The real Base Sepolia settlement (`X402Facilitator` + keystore signer) will live in a **separate example workspace** — same pattern as `examples/x402-sepolia` — so the alloy/x402 tree never enters this crate or `clippy --all-features` CI. The `Facilitator` trait is the seam.

## Honesty

Testnet-only; model-level/declared IFC (coverage-limited, per-call); simulated balances labelled; **no faked on-chain money** (reducer invariant test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)