### PR TITLE
feat(marketplace): Clearing seam — VCG / externality roadmap

### DIFF
--- a/crates/nucleus-marketplace-dashboard-frontend/src/main.rs
+++ b/crates/nucleus-marketplace-dashboard-frontend/src/main.rs
@@ -14,7 +14,9 @@ use leptos_use::{
     use_event_source_with_options, ReconnectLimit, UseEventSourceOptions, UseEventSourceReturn,
 };
 
-use nucleus_marketplace_dashboard::{AgentSummary, BalanceSource, Lane, MarketEvent, MarketState};
+use nucleus_marketplace_dashboard::{
+    AgentSummary, BalanceSource, ClearingMethod, Lane, MarketEvent, MarketState,
+};
 
 fn main() {
     console_error_panic_hook::set_once();
@@ -85,6 +87,8 @@ fn describe(ev: &MarketEvent) -> (String, &'static str, String) {
         ),
         MarketEvent::Settlement {
             amount,
+            cleared_method,
+            externality,
             outcome,
             source,
             ..
@@ -96,10 +100,15 @@ fn describe(ev: &MarketEvent) -> (String, &'static str, String) {
                 nucleus_marketplace_dashboard::SettlementOutcome::Timeout => "timeout".into(),
                 nucleus_marketplace_dashboard::SettlementOutcome::Orphaned => "orphaned".into(),
             };
+            let method = match cleared_method {
+                ClearingMethod::FixedPrice => "fixed".to_string(),
+                ClearingMethod::Pigouvian => format!("pigou +{}", usdc(externality.micros())),
+                ClearingMethod::Vcg => format!("vcg +{}", usdc(externality.micros())),
+            };
             (
                 format!("settle {}", usdc(amount.micros())),
                 "chip chip-commerce",
-                format!("{st}  ·  {}", source_label(source)),
+                format!("{st}  ·  {}  ·  {method}", source_label(source)),
             )
         }
         MarketEvent::ReceiptVerified {

--- a/crates/nucleus-marketplace-dashboard/ROADMAP.md
+++ b/crates/nucleus-marketplace-dashboard/ROADMAP.md
@@ -1,0 +1,59 @@
+# Marketplace dashboard — roadmap
+
+Three independently-verifiable properties of agent commerce. Each lands behind a
+**trait seam**, so the real implementation drops in without reshaping the core.
+
+| Pillar | Property | Seam | Status |
+|--------|----------|------|--------|
+| **Safe** | dangerous flows refused before money moves | `FlowDeclaration::decide` (IFC gate) | ✅ shipped |
+| **Verifiable** | portable receipts anyone can re-check | `ReceiptIssuer` | ✅ shipped (hash-rebind); ⛳ signed-bundle on the real path |
+| **Real** | actual on-chain settlement | [`Facilitator`](src/facilitator.rs) | ⛳ `FakeFacilitator` today; `X402Facilitator` next |
+| **Efficient & truthful** | truthful price discovery + priced externalities | [`Clearing`](src/clearing.rs) | ⛳ `FixedPriceClearing` today; Pigouvian / VCG next |
+
+Everything tagged ⛳ is a future *implementation of an existing trait* — the wire
+contract (`MarketEvent`) and the orchestrator already carry it.
+
+## 1. Real settlement — `Facilitator`
+
+`X402Facilitator` (drives `x402-reqwest` against Base Sepolia with a
+keystore-backed signer) lands in a **separate example workspace**, so the
+alloy/x402 tree never enters this crate or main CI. The orchestrator is already
+generic over `Facilitator`; settlements then carry
+`BalanceSource::OnChainTestnet` (a reducer invariant forbids on-chain numbers
+without a confirmed tx). The keystore signer (encrypted-at-rest, Keychain/KMS) is
+sequenced here.
+
+## 2. Verified clearing — `Clearing` (the VCG / externality pillar)
+
+The [`Clearing`](src/clearing.rs) trait takes a **batch of bids** and returns one
+outcome per bid (allocation + price + externality), so a real mechanism that
+needs the whole bid profile drops in directly:
+
+- **`PigouvianClearing`** — turns the IFC gate's binary allow/deny into a *priced
+  gradient*: a call on the safe slope pays a surcharge that internalises the
+  externality (risk / congestion) it imposes, derived from the bid's
+  `externality_signal` (today: declared-input count; future: a defined,
+  ideally-proven risk measure). `MarketEvent::Settlement` already carries
+  `cleared_method` + `externality`.
+- **`VcgClearing`** — clears a *contended* resource truthfully. VCG needs the
+  full bid profile, hence the slice-based `clear(&[Bid])`. The current per-call
+  loop passes a single-element slice (no contention); a future round-batching
+  orchestrator passes the full profile. The clearing rule runs the **exact**
+  sorry-free Lean-proven VCG function (mind the verified-spec / unverified-impl
+  hazard — add a parity proptest binding the money-path to the theorem).
+- The cleared price is folded into the **receipt** so price truthfulness is
+  independently re-derivable: the "provably-honest clearing" artifact, the
+  verified-clearing layer above x402 / AP2 / ERC-8004.
+
+## 3. Identity & reputation — ERC-8004 anchoring
+
+Register seller agents in the Identity Registry; write each receipt's hash to the
+Validation Registry; derive a per-agent reputation surfaced in the feed. Base
+Sepolia testnet; in the same separate-workspace pattern as real settlement.
+
+## Honesty line (applies to every pillar)
+
+Testnet only. The IFC verdict is model-level over *declared* inputs
+(coverage-limited, per-call). Simulated money is source-badged and can never
+appear as on-chain money. A verdict/price is only "verified" to the extent the
+money-path runs the exact proven function — otherwise it is a claim, not a proof.

--- a/crates/nucleus-marketplace-dashboard/src/clearing.rs
+++ b/crates/nucleus-marketplace-dashboard/src/clearing.rs
@@ -1,0 +1,120 @@
+//! The pricing / allocation seam — the third pillar (efficient & truthful
+//! commerce), alongside the [`crate::Facilitator`] settlement seam.
+//!
+//! Today the marketplace is fixed-price: each call pays a static base price. This
+//! trait is where **verified mechanism design** drops in later, exactly the way
+//! the real `X402Facilitator` drops into [`crate::Facilitator`]:
+//!
+//! - **`FixedPriceClearing`** (here, the honest default) — price = base, no
+//!   externality. No price discovery.
+//! - **`PigouvianClearing`** (future) — adds a surcharge that internalises the
+//!   externality a call imposes (risk / congestion), derived from the IFC
+//!   verdict's `externality_signal`. Turns the gate's binary allow/deny into a
+//!   *priced* gradient on the safe slope.
+//! - **`VcgClearing`** (future) — clears a *contended* resource truthfully. VCG
+//!   needs the whole bid profile, which is why [`Clearing::clear`] takes a
+//!   **slice of bids** and returns one outcome per bid. The current per-call
+//!   loop passes a single-element slice (the degenerate no-contention case); a
+//!   future round-batching orchestrator passes the full profile. The clearing
+//!   rule will run the **exact** sorry-free Lean-proven VCG function, and the
+//!   price is folded into the receipt so truthfulness is independently
+//!   re-derivable (the "provably-honest clearing" artifact).
+//!
+//! Honesty: only `FixedPriceClearing` is implemented today; the others are the
+//! roadmap. The [`crate::event::MarketEvent::Settlement`] carries the
+//! [`crate::event::ClearingMethod`] so the UI never implies VCG/Pigou pricing
+//! that isn't actually running.
+
+use crate::event::{AgentId, ClearingMethod, MicroUsd};
+
+/// One agent's bid for a (possibly contended) resource.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Bid {
+    /// The bidding agent.
+    pub agent: AgentId,
+    /// The resource being bid for.
+    pub resource: String,
+    /// The agent's base / reserve price.
+    pub base_price: MicroUsd,
+    /// A measure of the externality this call imposes on the shared system
+    /// (e.g. derived from the IFC verdict — number/sensitivity of declared
+    /// inputs, shared-budget congestion). `FixedPriceClearing` ignores it; a
+    /// Pigouvian/VCG mechanism prices it.
+    pub externality_signal: u32,
+}
+
+/// The cleared result for one bid: what the agent pays, the Pigouvian component
+/// of that price, and which mechanism produced it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClearingOutcome {
+    /// The price the agent pays (settled amount).
+    pub price: MicroUsd,
+    /// The externality (Pigouvian) component of `price`. `0` for fixed-price.
+    pub externality: MicroUsd,
+    /// The mechanism that priced this bid.
+    pub method: ClearingMethod,
+}
+
+/// Prices and allocates a set of bids. Implementations range from the trivial
+/// fixed-price pass-through to a verified VCG clearing rule.
+pub trait Clearing: Send + Sync {
+    /// Clear `bids`, returning exactly one [`ClearingOutcome`] per input bid (in
+    /// order). A single-element slice is the degenerate no-contention case used
+    /// by the current per-call loop; VCG/Pigou mechanisms use the full profile.
+    fn clear(&self, bids: &[Bid]) -> Vec<ClearingOutcome>;
+
+    /// The mechanism this clearing implements.
+    fn method(&self) -> ClearingMethod;
+}
+
+/// The honest default: every bid pays its own base price; no externality, no
+/// price discovery. Behaviourally identical to the pre-clearing fixed-price flow.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct FixedPriceClearing;
+
+impl Clearing for FixedPriceClearing {
+    fn clear(&self, bids: &[Bid]) -> Vec<ClearingOutcome> {
+        bids.iter()
+            .map(|b| ClearingOutcome {
+                price: b.base_price,
+                externality: MicroUsd(0),
+                method: ClearingMethod::FixedPrice,
+            })
+            .collect()
+    }
+
+    fn method(&self) -> ClearingMethod {
+        ClearingMethod::FixedPrice
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn bid(agent: &str, price: i64, ext: u32) -> Bid {
+        Bid {
+            agent: AgentId::from(agent),
+            resource: "/v1/x".into(),
+            base_price: MicroUsd(price),
+            externality_signal: ext,
+        }
+    }
+
+    #[test]
+    fn fixed_price_passes_base_through_with_zero_externality() {
+        let c = FixedPriceClearing;
+        let out = c.clear(&[bid("a", 10_000, 3), bid("b", 20_000, 1)]);
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0].price, MicroUsd(10_000));
+        assert_eq!(out[0].externality, MicroUsd(0));
+        assert_eq!(out[0].method, ClearingMethod::FixedPrice);
+        assert_eq!(out[1].price, MicroUsd(20_000));
+        assert_eq!(c.method(), ClearingMethod::FixedPrice);
+    }
+
+    #[test]
+    fn empty_profile_clears_to_nothing() {
+        assert!(FixedPriceClearing.clear(&[]).is_empty());
+    }
+}

--- a/crates/nucleus-marketplace-dashboard/src/event.rs
+++ b/crates/nucleus-marketplace-dashboard/src/event.rs
@@ -96,6 +96,20 @@ impl SettlementOutcome {
     }
 }
 
+/// The mechanism that priced a settled call. Carried on the wire so the UI never
+/// implies price discovery that isn't actually running.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ClearingMethod {
+    /// Static base price; no externality, no discovery (today's default).
+    #[default]
+    FixedPrice,
+    /// Base price + an internalised externality surcharge (Pigouvian) — future.
+    Pigouvian,
+    /// Truthful clearing of a contended resource (Vickrey–Clarke–Groves) — future.
+    Vcg,
+}
+
 /// One marketplace event. `id` (monotonic seq) and `ts_unix_ms` are stamped by
 /// the [`crate::Hub`] on emit via the injected [`crate::Clock`], so producers
 /// construct events with `0` placeholders and never set wall-clock time directly.
@@ -144,7 +158,16 @@ pub enum MarketEvent {
         id: u64,
         ts_unix_ms: i64,
         agent: AgentId,
+        /// The cleared price actually settled (= base price under `FixedPrice`).
         amount: MicroUsd,
+        /// The mechanism that priced this call. `serde(default)` keeps the wire
+        /// backward-compatible as new mechanisms land.
+        #[serde(default)]
+        cleared_method: ClearingMethod,
+        /// The Pigouvian (externality) component of `amount`; `0` under fixed
+        /// pricing. `serde(default)` for backward compatibility.
+        #[serde(default)]
+        externality: MicroUsd,
         /// CAIP-2 chain id; Base Sepolia is `eip155:84532` — testnet only.
         chain: String,
         outcome: SettlementOutcome,
@@ -312,6 +335,8 @@ mod tests {
             ts_unix_ms: 2,
             agent: AgentId::from("a"),
             amount: MicroUsd(10_000),
+            cleared_method: ClearingMethod::FixedPrice,
+            externality: MicroUsd(0),
             chain: "eip155:84532".into(),
             outcome: SettlementOutcome::Confirmed {
                 tx_hash: "0xabc".into(),
@@ -322,6 +347,17 @@ mod tests {
         assert_eq!(s["type"], "settlement");
         assert_eq!(s["outcome"]["state"], "confirmed");
         assert_eq!(s["source"], "simulated");
+        assert_eq!(s["cleared_method"], "fixed_price");
+
+        // Backward-compat: an old Settlement JSON without the clearing fields
+        // still deserializes (serde defaults), proving the wire stays stable.
+        let legacy = serde_json::json!({
+            "type": "settlement", "id": 1, "ts_unix_ms": 2, "agent": "a",
+            "amount": 10_000, "chain": "eip155:84532",
+            "outcome": {"state": "confirmed", "tx_hash": "0xabc"}, "source": "simulated"
+        });
+        let back: MarketEvent = serde_json::from_value(legacy).unwrap();
+        assert_eq!(back, settled);
 
         // Round-trip every variant shape we just built.
         for ev in [sample("registered"), sample("deny"), settled] {

--- a/crates/nucleus-marketplace-dashboard/src/lib.rs
+++ b/crates/nucleus-marketplace-dashboard/src/lib.rs
@@ -42,6 +42,8 @@ pub mod reducer;
 #[cfg(feature = "runtime")]
 pub mod agent;
 #[cfg(feature = "runtime")]
+pub mod clearing;
+#[cfg(feature = "runtime")]
 pub mod clock;
 #[cfg(feature = "runtime")]
 pub mod facilitator;
@@ -55,12 +57,15 @@ pub mod orchestrator;
 pub mod http;
 
 pub use event::{
-    AgentId, BalanceSource, Lane, MarketEvent, MicroUsd, SettlementOutcome, VerifyMethod,
+    AgentId, BalanceSource, ClearingMethod, Lane, MarketEvent, MicroUsd, SettlementOutcome,
+    VerifyMethod,
 };
 pub use reducer::{AgentSummary, MarketState, DEFAULT_RECENT_CAP};
 
 #[cfg(feature = "runtime")]
 pub use agent::AgentLoop;
+#[cfg(feature = "runtime")]
+pub use clearing::{Bid, Clearing, ClearingOutcome, FixedPriceClearing};
 #[cfg(feature = "runtime")]
 pub use clock::{Clock, FixedClock, SystemClock};
 #[cfg(feature = "runtime")]

--- a/crates/nucleus-marketplace-dashboard/src/orchestrator.rs
+++ b/crates/nucleus-marketplace-dashboard/src/orchestrator.rs
@@ -14,6 +14,7 @@ use std::time::Duration;
 use tokio_util::sync::CancellationToken;
 
 use crate::agent::AgentLoop;
+use crate::clearing::{Bid, Clearing, FixedPriceClearing};
 use crate::event::{MarketEvent, SettlementOutcome, VerifyMethod};
 use crate::facilitator::{Facilitator, SettleRequest};
 use crate::hub::Hub;
@@ -29,19 +30,30 @@ pub const BASE_SEPOLIA_CAIP2: &str = "eip155:84532";
 pub struct Orchestrator<F: Facilitator> {
     hub: Arc<Hub>,
     facilitator: Arc<F>,
+    clearing: Arc<dyn Clearing>,
     agents: Vec<AgentLoop>,
     chain: String,
 }
 
 impl<F: Facilitator + 'static> Orchestrator<F> {
     /// Build an orchestrator over a hub, a facilitator, and an agent fleet.
+    /// Pricing defaults to [`FixedPriceClearing`]; swap in a Pigouvian/VCG
+    /// mechanism with [`Orchestrator::with_clearing`].
     pub fn new(hub: Arc<Hub>, facilitator: Arc<F>, agents: Vec<AgentLoop>) -> Self {
         Self {
             hub,
             facilitator,
+            clearing: Arc::new(FixedPriceClearing),
             agents,
             chain: BASE_SEPOLIA_CAIP2.to_string(),
         }
+    }
+
+    /// Replace the pricing mechanism (the seam where verified VCG / Pigouvian
+    /// clearing drops in — see [`crate::clearing`]).
+    pub fn with_clearing(mut self, clearing: Arc<dyn Clearing>) -> Self {
+        self.clearing = clearing;
+        self
     }
 
     /// The agent fleet.
@@ -102,12 +114,34 @@ impl<F: Facilitator + 'static> Orchestrator<F> {
             canonical: verdict.canonical(),
         });
 
+        // Price the call through the clearing seam. Under `FixedPriceClearing`
+        // this returns the base price with zero externality; a future
+        // Pigouvian/VCG mechanism prices the externality (declared-input risk)
+        // and clears contended resources. The per-call loop passes a
+        // single-element bid profile (the degenerate no-contention case).
+        let bid = Bid {
+            agent: a.agent.clone(),
+            resource: a.resource.clone(),
+            base_price: a.price,
+            externality_signal: verdict.declared_inputs.len() as u32,
+        };
+        let cleared = self
+            .clearing
+            .clear(std::slice::from_ref(&bid))
+            .into_iter()
+            .next()
+            .unwrap_or(crate::clearing::ClearingOutcome {
+                price: a.price,
+                externality: crate::event::MicroUsd(0),
+                method: crate::event::ClearingMethod::FixedPrice,
+            });
+
         let payment_reference = format!("{}-{}", a.agent.as_str(), attempt);
         let outcome = self
             .facilitator
             .settle(&SettleRequest {
                 agent: a.agent.clone(),
-                amount: a.price,
+                amount: cleared.price,
                 resource: a.resource.clone(),
                 payment_reference: payment_reference.clone(),
             })
@@ -118,7 +152,9 @@ impl<F: Facilitator + 'static> Orchestrator<F> {
             id: 0,
             ts_unix_ms: 0,
             agent: a.agent.clone(),
-            amount: a.price,
+            amount: cleared.price,
+            cleared_method: cleared.method,
+            externality: cleared.externality,
             chain: self.chain.clone(),
             outcome: outcome.clone(),
             source,

--- a/crates/nucleus-marketplace-dashboard/src/reducer.rs
+++ b/crates/nucleus-marketplace-dashboard/src/reducer.rs
@@ -50,6 +50,10 @@ pub struct MarketState {
     /// Cumulative micro-USD settled on-chain (Base Sepolia testnet) — only ever
     /// incremented by a `Confirmed` settlement tagged `OnChainTestnet`.
     pub onchain_settled_micros: i64,
+    /// Cumulative Pigouvian (externality) micro-USD across confirmed settlements.
+    /// `0` while pricing is `FixedPrice`; grows once a Pigouvian/VCG mechanism
+    /// is wired in (see [`crate::clearing`]).
+    pub externality_micros: i64,
     /// Highest event id applied (the snapshot's `Last-Event-ID`).
     pub last_id: u64,
     /// Bounded recent-event ring (newest last).
@@ -100,12 +104,14 @@ impl MarketState {
             MarketEvent::Settlement {
                 agent,
                 amount,
+                externality,
                 outcome,
                 source,
                 ..
             } => {
                 if outcome.is_confirmed() {
                     self.agent_mut(agent).settlements += 1;
+                    self.externality_micros += externality.micros();
                     match source {
                         BalanceSource::Simulated => {
                             self.simulated_settled_micros += amount.micros()
@@ -189,6 +195,8 @@ mod tests {
                 ts_unix_ms: 13,
                 agent: a.clone(),
                 amount: MicroUsd(10_000),
+                cleared_method: crate::event::ClearingMethod::FixedPrice,
+                externality: MicroUsd(0),
                 chain: "eip155:84532".into(),
                 outcome: SettlementOutcome::Confirmed {
                     tx_hash: "0xsimulated0".into(),


### PR DESCRIPTION
## What

Lays the **third pillar** of verified agent commerce — *efficient & truthful* — as a trait seam, so verified mechanism design drops in exactly the way real settlement drops into `Facilitator`. No behaviour change today (fixed pricing); this is the architecture + roadmap the VCG/externality work plugs into.

## The seam

`Clearing::clear(&[Bid]) -> Vec<ClearingOutcome>` takes a **batch of bids** — because VCG needs the whole bid profile — and returns price + Pigouvian externality + method per bid.

- **`FixedPriceClearing`** (today, honest default): base price, zero externality, no discovery.
- **`PigouvianClearing`** (roadmap): prices the externality a call imposes (the IFC `externality_signal`) — turns the gate's binary allow/deny into a *priced gradient*.
- **`VcgClearing`** (roadmap): truthful clearing of a contended resource; runs the sorry-free Lean-proven VCG function (with a money-path↔theorem parity test). The cleared price folds into the receipt → "provably-honest clearing."

## Changes

- `clearing.rs` (new): trait + `Bid`/`ClearingOutcome` + `FixedPriceClearing` (+ tests).
- `event.rs`: `ClearingMethod` enum; `Settlement` gains `cleared_method` + `externality`, both `serde(default)` → **wire stays backward-compatible** (legacy-JSON round-trip test added).
- `orchestrator.rs`: prices each call through the seam (single-element bid = degenerate no-contention case today); `Orchestrator::with_clearing` swaps the mechanism.
- `reducer.rs`: cumulative `externality_micros` (0 under fixed pricing).
- frontend: settlement row shows the clearing method.
- `ROADMAP.md`: the four seams (IFC / receipts / `Facilitator` / `Clearing`) + ERC-8004.

## Verified

21 tests green; clippy `--all-features` + fmt clean; wasm-safe minimal build intact; trunk build clean; live SSE carries `cleared_method=fixed_price`, `externality=0`.

## Honesty

Only `FixedPriceClearing` exists today; VCG/Pigou are the roadmap. A price is "verified" only to the extent the money-path runs the exact proven function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)