### PR TITLE
feat(marketplace): ERC-8004 anchoring — on-chain receipt validation (pillar 4)

### DIFF
--- a/crates/nucleus-marketplace-dashboard-frontend/src/main.rs
+++ b/crates/nucleus-marketplace-dashboard-frontend/src/main.rs
@@ -136,6 +136,19 @@ fn describe(ev: &MarketEvent) -> (String, &'static str, String) {
                 source_label(source)
             ),
         ),
+        MarketEvent::ReceiptAnchored {
+            agent_id,
+            response,
+            validation_tx,
+            ..
+        } => (
+            "anchored ⛓".into(),
+            "chip chip-proof",
+            format!(
+                "ERC-8004 agent #{agent_id}  ·  validation {response}  ·  tx {}",
+                short(validation_tx)
+            ),
+        ),
     }
 }
 

--- a/crates/nucleus-marketplace-dashboard/src/event.rs
+++ b/crates/nucleus-marketplace-dashboard/src/event.rs
@@ -197,6 +197,25 @@ pub enum MarketEvent {
         balance: MicroUsd,
         source: BalanceSource,
     },
+    /// A receipt was anchored on-chain via the ERC-8004 Validation Registry
+    /// (Base Sepolia testnet) — the in-bounds decision is now checkable from
+    /// chain reads. Emitted by the real-settlement path (see
+    /// `examples/marketplace-live`); never present in the simulated feed.
+    ReceiptAnchored {
+        id: u64,
+        ts_unix_ms: i64,
+        agent: AgentId,
+        /// Seq of the [`MarketEvent::Settlement`] this anchor binds (UI join key).
+        for_settlement_id: u64,
+        /// The ERC-8004 `agentId` (Identity Registry tokenId).
+        agent_id: u64,
+        /// `keccak256(receipt)` committed on-chain (hex `0x…`).
+        request_hash: String,
+        /// The `validationResponse` tx hash (hex `0x…`; link to Basescan).
+        validation_tx: String,
+        /// The 0–100 validation score posted (100 = in-bounds).
+        response: u8,
+    },
 }
 
 /// How a [`MarketEvent::ReceiptVerified`] was checked — so the UI never
@@ -222,7 +241,8 @@ impl MarketEvent {
             | MarketEvent::IfcDeny { id, .. }
             | MarketEvent::Settlement { id, .. }
             | MarketEvent::ReceiptVerified { id, .. }
-            | MarketEvent::BalanceUpdate { id, .. } => *id,
+            | MarketEvent::BalanceUpdate { id, .. }
+            | MarketEvent::ReceiptAnchored { id, .. } => *id,
         }
     }
 
@@ -235,7 +255,8 @@ impl MarketEvent {
             | MarketEvent::IfcDeny { agent, .. }
             | MarketEvent::Settlement { agent, .. }
             | MarketEvent::ReceiptVerified { agent, .. }
-            | MarketEvent::BalanceUpdate { agent, .. } => agent,
+            | MarketEvent::BalanceUpdate { agent, .. }
+            | MarketEvent::ReceiptAnchored { agent, .. } => agent,
         }
     }
 
@@ -247,7 +268,9 @@ impl MarketEvent {
             | MarketEvent::Settlement { .. }
             | MarketEvent::BalanceUpdate { .. } => Lane::Commerce,
             MarketEvent::IfcAllow { .. } | MarketEvent::IfcDeny { .. } => Lane::Security,
-            MarketEvent::ReceiptVerified { .. } => Lane::Proof,
+            MarketEvent::ReceiptVerified { .. } | MarketEvent::ReceiptAnchored { .. } => {
+                Lane::Proof
+            }
         }
     }
 
@@ -266,7 +289,8 @@ impl MarketEvent {
             | MarketEvent::IfcDeny { id, ts_unix_ms, .. }
             | MarketEvent::Settlement { id, ts_unix_ms, .. }
             | MarketEvent::ReceiptVerified { id, ts_unix_ms, .. }
-            | MarketEvent::BalanceUpdate { id, ts_unix_ms, .. } => {
+            | MarketEvent::BalanceUpdate { id, ts_unix_ms, .. }
+            | MarketEvent::ReceiptAnchored { id, ts_unix_ms, .. } => {
                 *id = new_id;
                 *ts_unix_ms = ts;
             }

--- a/crates/nucleus-marketplace-dashboard/src/reducer.rs
+++ b/crates/nucleus-marketplace-dashboard/src/reducer.rs
@@ -32,6 +32,12 @@ pub struct AgentSummary {
     pub balance: Option<MicroUsd>,
     /// Provenance of `balance` (so the UI badges Simulated vs OnChainTestnet).
     pub balance_source: Option<BalanceSource>,
+    /// ERC-8004 `agentId` (Identity Registry tokenId), once registered on-chain.
+    pub agent_id: Option<u64>,
+    /// Receipts anchored on-chain (ERC-8004 Validation Registry) for this agent.
+    pub anchored: u64,
+    /// Latest on-chain validation score (0–100; 100 = in-bounds).
+    pub last_validation: Option<u8>,
 }
 
 /// The reduced marketplace state — the ground truth a cold client receives.
@@ -45,6 +51,8 @@ pub struct MarketState {
     pub deny_count: u64,
     /// Total receipts that verified.
     pub receipts_verified: u64,
+    /// Total receipts anchored on-chain (ERC-8004 Validation Registry).
+    pub receipts_anchored: u64,
     /// Cumulative micro-USD settled via the SIMULATED facilitator.
     pub simulated_settled_micros: i64,
     /// Cumulative micro-USD settled on-chain (Base Sepolia testnet) — only ever
@@ -136,6 +144,18 @@ impl MarketState {
                 let a = self.agent_mut(agent);
                 a.balance = Some(*balance);
                 a.balance_source = Some(*source);
+            }
+            MarketEvent::ReceiptAnchored {
+                agent,
+                agent_id,
+                response,
+                ..
+            } => {
+                self.receipts_anchored += 1;
+                let a = self.agent_mut(agent);
+                a.agent_id = Some(*agent_id);
+                a.anchored += 1;
+                a.last_validation = Some(*response);
             }
         }
 

--- a/crates/nucleus-marketplace-dashboard/tests/orchestrator_isolation.rs
+++ b/crates/nucleus-marketplace-dashboard/tests/orchestrator_isolation.rs
@@ -34,6 +34,7 @@ fn tags(hub: &Hub) -> Vec<&'static str> {
             MarketEvent::Settlement { .. } => "settlement",
             MarketEvent::ReceiptVerified { .. } => "receipt_verified",
             MarketEvent::BalanceUpdate { .. } => "balance_update",
+            MarketEvent::ReceiptAnchored { .. } => "receipt_anchored",
         })
         .collect()
 }

--- a/examples/marketplace-live/README.md
+++ b/examples/marketplace-live/README.md
@@ -46,6 +46,35 @@ Open the dashboard UI against it with `just marketplace-ui` (it proxies `/api` t
 `https://sepolia.basescan.org/tx/<hash>`), and per-agent balances carry the
 green **`testnet`** badge.
 
+## ERC-8004 anchoring (optional)
+
+Anchor each verified receipt on-chain so the in-bounds decision is checkable from
+chain reads. **Identity** (`0x8004A818…BD9e`) and **Reputation** (`0x8004B663…8713`)
+are canonical on Base Sepolia; the **Validation Registry** is not, so we deploy a
+minimal selector-compatible one (`contracts/src/ValidationRegistry.sol`).
+
+> These writes are **gasful** — the wallet needs **Base Sepolia ETH** (not just
+> bUSDC). x402 settlement is gasless; ERC-8004 writes are not.
+
+```bash
+# 1) deploy the ValidationRegistry (one-time; prompts for the keystore password):
+just marketplace-live-deploy-validation        # prints: Deployed to: 0x<addr>
+
+# 2) run with anchoring on (registers each agent on Identity, anchors each
+#    verified receipt on Validation):
+SELLER_ADDRESS=0x<recv> just marketplace-live --validation-registry 0x<addr>
+```
+
+Per verified receipt the anchor task: computes `requestHash = keccak256(receipt)`,
+calls `validationRequest(validator, agentId, requestURI, requestHash)`, then (as
+the validator) `validationResponse(requestHash, 100, …, "clearing/in-bounds")`,
+and emits a `ReceiptAnchored` event → the dashboard shows `anchored ⛓` with the
+on-chain `agentId` + validation tx. Each real txn is then verifiable four ways:
+**dashboard → Basescan settlement → portable receipt → ERC-8004 validation anchor.**
+
+`response = 100` = "the gate allowed this flow and a receipt was issued" — a
+model-level, declared-input in-bounds attestation, not an end-to-end proof.
+
 ## Secure key handling
 
 The signing key lives in a foundry-format encrypted keystore; the decryption

--- a/examples/marketplace-live/contracts/.gitignore
+++ b/examples/marketplace-live/contracts/.gitignore
@@ -1,0 +1,4 @@
+/out
+/cache
+/broadcast
+/lib

--- a/examples/marketplace-live/contracts/foundry.toml
+++ b/examples/marketplace-live/contracts/foundry.toml
@@ -1,0 +1,7 @@
+[profile.default]
+src = "src"
+out = "out"
+libs = ["lib"]
+solc = "0.8.24"
+optimizer = true
+optimizer_runs = 200

--- a/examples/marketplace-live/contracts/src/ValidationRegistry.sol
+++ b/examples/marketplace-live/contracts/src/ValidationRegistry.sol
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/// @title Minimal ERC-8004 Validation Registry (self-deploy for Base Sepolia)
+/// @notice The canonical ERC-8004 ValidationRegistry is NOT published on Base
+/// Sepolia (84532) and the spec is still in flux, so we deploy a minimal,
+/// selector-compatible implementation of the v1.x Validation interface. The
+/// Identity (0x8004A818…BD9e) and Reputation (0x8004B663…8713) registries ARE
+/// canonical on Base Sepolia and are used as-is.
+///
+/// Selectors match the v1.x spec:
+///   validationRequest(address,uint256,string,bytes32)  -> 0xaaf400c4
+///   validationResponse(bytes32,uint8,string,bytes32,string) -> 0x3d659a96
+///   getValidationStatus(bytes32) -> 0xff2febfc
+///
+/// Anchoring model: the requester commits a request keyed by `requestHash`
+/// (keccak256 of the off-chain receipt/bundle pointed to by `requestURI`); only
+/// the named validator may post the `validationResponse` (a bounded 0–100 score
+/// + a tag, e.g. "clearing/in-bounds"). Third parties verify entirely from
+/// on-chain reads.
+contract ValidationRegistry {
+    struct Validation {
+        address validator;
+        uint256 agentId;
+        uint8 response;
+        bool requested;
+        bool responded;
+    }
+
+    mapping(bytes32 => Validation) private _validations;
+
+    event ValidationRequest(
+        address indexed validatorAddress,
+        uint256 indexed agentId,
+        string requestURI,
+        bytes32 indexed requestHash
+    );
+
+    event ValidationResponse(
+        address indexed validatorAddress,
+        uint256 indexed agentId,
+        bytes32 indexed requestHash,
+        uint8 response,
+        string responseURI,
+        bytes32 responseHash,
+        string tag
+    );
+
+    error AlreadyRequested();
+    error UnknownRequest();
+    error NotValidator();
+    error ResponseOutOfRange();
+
+    /// Commit a validation request: bind `requestHash` to the chosen validator +
+    /// agent, pointing at the off-chain payload via `requestURI`.
+    function validationRequest(
+        address validatorAddress,
+        uint256 agentId,
+        string calldata requestURI,
+        bytes32 requestHash
+    ) external {
+        if (_validations[requestHash].requested) revert AlreadyRequested();
+        _validations[requestHash] = Validation({
+            validator: validatorAddress,
+            agentId: agentId,
+            response: 0,
+            requested: true,
+            responded: false
+        });
+        emit ValidationRequest(validatorAddress, agentId, requestURI, requestHash);
+    }
+
+    /// Post the validator's verdict for a prior request. Only the named
+    /// validator may call this; `response` is a bounded 0–100 score.
+    function validationResponse(
+        bytes32 requestHash,
+        uint8 response,
+        string calldata responseURI,
+        bytes32 responseHash,
+        string calldata tag
+    ) external {
+        Validation storage v = _validations[requestHash];
+        if (!v.requested) revert UnknownRequest();
+        if (msg.sender != v.validator) revert NotValidator();
+        if (response > 100) revert ResponseOutOfRange();
+        v.response = response;
+        v.responded = true;
+        emit ValidationResponse(
+            msg.sender,
+            v.agentId,
+            requestHash,
+            response,
+            responseURI,
+            responseHash,
+            tag
+        );
+    }
+
+    /// The bounded 0–100 score for a responded request. Reverts if no response.
+    function getValidationStatus(bytes32 requestHash) external view returns (uint8) {
+        Validation storage v = _validations[requestHash];
+        if (!v.responded) revert UnknownRequest();
+        return v.response;
+    }
+
+    /// Whether a request has a posted response (non-reverting probe).
+    function isValidated(bytes32 requestHash) external view returns (bool) {
+        return _validations[requestHash].responded;
+    }
+}

--- a/examples/marketplace-live/src/bin/marketplace_live.rs
+++ b/examples/marketplace-live/src/bin/marketplace_live.rs
@@ -19,9 +19,10 @@ use anyhow::{anyhow, Context};
 use clap::Parser;
 use tokio_util::sync::CancellationToken;
 
-use marketplace_live::{seller_router, signer, X402Facilitator};
+use marketplace_live::erc8004::IDENTITY_REGISTRY_BASE_SEPOLIA;
+use marketplace_live::{seller_router, signer, AlloyAnchor, Anchorer, X402Facilitator};
 use nucleus_marketplace_dashboard::{
-    http, AgentId, AgentLoop, Facilitator, Hub, MicroUsd, Orchestrator, SystemClock,
+    http, AgentId, AgentLoop, Facilitator, Hub, MarketEvent, MicroUsd, Orchestrator, SystemClock,
 };
 use nucleus_verify_commerce::{DeclaredInput, FlowDeclaration};
 
@@ -59,6 +60,15 @@ struct Args {
     /// faucet wallet can't be drained.
     #[arg(long, default_value_t = 20)]
     max_settlements: u64,
+    /// ERC-8004 ValidationRegistry address (self-deployed on Base Sepolia). When
+    /// set, enables on-chain anchoring: agents are registered on the canonical
+    /// Identity Registry and each verified receipt is anchored on the Validation
+    /// Registry. These writes are GASFUL — the wallet also needs Base Sepolia ETH.
+    #[arg(long)]
+    validation_registry: Option<String>,
+    /// Base URI for agent registration files (the on-chain agentURI per agent).
+    #[arg(long, default_value = "https://marketplace.local/agents")]
+    agent_uri_base: String,
 }
 
 fn expand_tilde(path: &str) -> String {
@@ -130,6 +140,8 @@ async fn main() -> anyhow::Result<()> {
     eprintln!("loading keystore {} …", args.keystore);
     let signer = signer::load_keystore_signer(expand_tilde(&args.keystore))?;
     let payer = signer.address();
+    // Same key signs x402 (gasless) and ERC-8004 writes (gasful); clone for the anchorer.
+    let anchor_signer = signer.clone();
 
     let seller_base = format!("http://{}", args.bind);
     let facilitator = Arc::new(X402Facilitator::new(
@@ -201,11 +213,83 @@ async fn main() -> anyhow::Result<()> {
         }
     });
 
-    let orchestrator = Arc::new(Orchestrator::new(
-        Arc::clone(&hub),
-        facilitator,
-        conservative_fleet(price),
-    ));
+    let fleet = conservative_fleet(price);
+
+    // ERC-8004 anchoring (opt-in via --validation-registry). Registers each agent
+    // on the canonical Identity Registry, then anchors each verified receipt on
+    // the Validation Registry. GASFUL — needs Base Sepolia ETH.
+    if let Some(vr) = &args.validation_registry {
+        let validation: Address = vr.trim().parse().context("parsing --validation-registry")?;
+        let anchorer = Arc::new(AlloyAnchor::new(
+            anchor_signer,
+            &args.rpc,
+            IDENTITY_REGISTRY_BASE_SEPOLIA,
+            validation,
+        )?);
+        eprintln!("ERC-8004 anchoring ENABLED");
+        eprintln!("  Identity   : {IDENTITY_REGISTRY_BASE_SEPOLIA}");
+        eprintln!("  Validation : {validation}");
+        let mut ids = std::collections::HashMap::new();
+        for a in &fleet {
+            let uri = format!(
+                "{}/{}",
+                args.agent_uri_base.trim_end_matches('/'),
+                a.agent.as_str()
+            );
+            let id = anchorer
+                .register_agent(&uri)
+                .await
+                .with_context(|| format!("ERC-8004 register for {}", a.agent.as_str()))?;
+            eprintln!("  registered {} → agentId {id}", a.agent.as_str());
+            ids.insert(a.agent.as_str().to_string(), id);
+        }
+        let ids = Arc::new(ids);
+        let base = format!("http://{}", args.bind);
+        tokio::spawn({
+            let hub = Arc::clone(&hub);
+            let anchorer = Arc::clone(&anchorer);
+            let ids = Arc::clone(&ids);
+            let cancel = cancel.clone();
+            async move {
+                let mut rx = hub.subscribe();
+                loop {
+                    tokio::select! {
+                        _ = cancel.cancelled() => break,
+                        ev = rx.recv() => match ev {
+                            Ok(MarketEvent::ReceiptVerified { for_settlement_id, agent, verified, .. }) if verified => {
+                                let Some(&agent_id) = ids.get(agent.as_str()) else { continue };
+                                let Some(receipt) = hub.receipt(for_settlement_id) else { continue };
+                                let json = serde_json::to_string(&receipt).unwrap_or_default();
+                                let uri = format!("{base}/api/receipt/{for_settlement_id}");
+                                match anchorer.anchor(agent_id, &uri, &json, true).await {
+                                    Ok(out) => {
+                                        hub.emit(MarketEvent::ReceiptAnchored {
+                                            id: 0,
+                                            ts_unix_ms: 0,
+                                            agent,
+                                            for_settlement_id,
+                                            agent_id,
+                                            request_hash: out.request_hash,
+                                            validation_tx: out.validation_tx,
+                                            response: out.response,
+                                        });
+                                    }
+                                    Err(e) => eprintln!("anchor failed (settlement {for_settlement_id}): {e:#}"),
+                                }
+                            }
+                            Ok(_) => {}
+                            Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                            Err(_) => {} // lagged — recover on the next event
+                        }
+                    }
+                }
+            }
+        });
+    } else {
+        eprintln!("ERC-8004 anchoring disabled (no --validation-registry)");
+    }
+
+    let orchestrator = Arc::new(Orchestrator::new(Arc::clone(&hub), facilitator, fleet));
     let run = tokio::spawn({
         let orch = Arc::clone(&orchestrator);
         let cancel = cancel.clone();

--- a/examples/marketplace-live/src/erc8004.rs
+++ b/examples/marketplace-live/src/erc8004.rs
@@ -1,0 +1,202 @@
+//! ERC-8004 anchoring — bind each verified-clearing receipt to the on-chain
+//! **Validation Registry** so the IFC-in-bounds decision is independently
+//! checkable from chain reads. Identity + Reputation registries are canonical on
+//! Base Sepolia; the Validation Registry is our self-deploy (see
+//! `contracts/src/ValidationRegistry.sol`).
+//!
+//! Flow per receipt: `requestHash = keccak256(receipt JSON)` →
+//! `validationRequest(validator, agentId, requestURI, requestHash)` → (as the
+//! validator) `validationResponse(requestHash, 100, …, "clearing/in-bounds")`.
+//! These are **gasful** writes (need Base Sepolia ETH) — unlike gasless x402.
+//!
+//! Honesty: `response = 100` means "the gate allowed this flow and a receipt was
+//! issued" — a model-level, declared-input in-bounds attestation, not an
+//! end-to-end exfiltration proof. The on-chain record points at the off-chain
+//! receipt; a verifier re-derives the hash and re-checks the receipt.
+
+use alloy::network::EthereumWallet;
+use alloy::primitives::{keccak256, Address, B256, U256};
+use alloy::providers::{DynProvider, Provider, ProviderBuilder};
+use alloy::sol;
+use alloy_signer_local::PrivateKeySigner;
+use anyhow::{anyhow, Context};
+use async_trait::async_trait;
+
+/// Canonical ERC-8004 Identity Registry on Base Sepolia (84532).
+pub const IDENTITY_REGISTRY_BASE_SEPOLIA: Address =
+    alloy::primitives::address!("8004A818BFB912233c491871b3d84c89A494BD9e");
+/// Canonical ERC-8004 Reputation Registry on Base Sepolia (84532).
+pub const REPUTATION_REGISTRY_BASE_SEPOLIA: Address =
+    alloy::primitives::address!("8004B663056A597Dffe9eCcC1965A193B7388713");
+
+sol! {
+    #[sol(rpc)]
+    interface IIdentityRegistry {
+        function register(string agentURI) external returns (uint256);
+        event Registered(uint256 indexed agentId, string agentURI, address indexed owner);
+    }
+
+    #[sol(rpc)]
+    interface IValidationRegistry {
+        function validationRequest(address validatorAddress, uint256 agentId, string requestURI, bytes32 requestHash) external;
+        function validationResponse(bytes32 requestHash, uint8 response, string responseURI, bytes32 responseHash, string tag) external;
+        function getValidationStatus(bytes32 requestHash) external view returns (uint8);
+    }
+}
+
+/// The on-chain anchor result for one receipt.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AnchorOutcome {
+    /// `keccak256(receipt)` committed on-chain (hex `0x…`).
+    pub request_hash: String,
+    /// The `validationResponse` tx hash (hex `0x…`).
+    pub validation_tx: String,
+    /// The 0–100 validation score posted (100 = in-bounds).
+    pub response: u8,
+}
+
+/// Anchors a verified-clearing receipt on-chain. Abstracted so tests can use a
+/// fake and the binary can swap implementations.
+#[async_trait]
+pub trait Anchorer: Send + Sync {
+    /// Register an agent identity (once), returning its ERC-8004 `agentId`.
+    async fn register_agent(&self, agent_uri: &str) -> anyhow::Result<u64>;
+
+    /// Anchor a receipt: commit `keccak256(receipt_json)` to the Validation
+    /// Registry and post the in-bounds verdict.
+    async fn anchor(
+        &self,
+        agent_id: u64,
+        request_uri: &str,
+        receipt_json: &str,
+        in_bounds: bool,
+    ) -> anyhow::Result<AnchorOutcome>;
+}
+
+/// Compute the ERC-8004 `requestHash` for a receipt payload: `keccak256(bytes)`.
+pub fn request_hash(receipt_json: &str) -> B256 {
+    keccak256(receipt_json.as_bytes())
+}
+
+/// Real ERC-8004 anchorer over Base Sepolia (gasful writes via a wallet provider).
+pub struct AlloyAnchor {
+    provider: DynProvider,
+    identity: Address,
+    validation: Address,
+    /// The validator address that posts `validationResponse` (= our signer).
+    validator: Address,
+}
+
+impl AlloyAnchor {
+    /// Build from the (same) keystore signer used for x402. The signer's address
+    /// is the validator + tx sender; writes need Base Sepolia ETH for gas.
+    pub fn new(
+        signer: PrivateKeySigner,
+        rpc_url: &str,
+        identity: Address,
+        validation: Address,
+    ) -> anyhow::Result<Self> {
+        let validator = signer.address();
+        let wallet = EthereumWallet::from(signer);
+        let provider = ProviderBuilder::new()
+            .wallet(wallet)
+            .connect_http(rpc_url.parse()?)
+            .erased();
+        Ok(Self {
+            provider,
+            identity,
+            validation,
+            validator,
+        })
+    }
+}
+
+#[async_trait]
+impl Anchorer for AlloyAnchor {
+    async fn register_agent(&self, agent_uri: &str) -> anyhow::Result<u64> {
+        let registry = IIdentityRegistry::new(self.identity, &self.provider);
+        let receipt = registry
+            .register(agent_uri.to_string())
+            .send()
+            .await
+            .context("sending Identity.register")?
+            .get_receipt()
+            .await
+            .context("awaiting Identity.register receipt")?;
+        // The agentId is emitted in the Registered event.
+        for log in receipt.inner.logs() {
+            if let Ok(decoded) = log.log_decode::<IIdentityRegistry::Registered>() {
+                return Ok(u64::try_from(decoded.inner.agentId).unwrap_or(u64::MAX));
+            }
+        }
+        Err(anyhow!("Identity.register did not emit a Registered event"))
+    }
+
+    async fn anchor(
+        &self,
+        agent_id: u64,
+        request_uri: &str,
+        receipt_json: &str,
+        in_bounds: bool,
+    ) -> anyhow::Result<AnchorOutcome> {
+        let registry = IValidationRegistry::new(self.validation, &self.provider);
+        let rhash = request_hash(receipt_json);
+        let agent = U256::from(agent_id);
+
+        // 1) Commit the request (requestURI points at the off-chain receipt).
+        registry
+            .validationRequest(self.validator, agent, request_uri.to_string(), rhash)
+            .send()
+            .await
+            .context("sending validationRequest")?
+            .get_receipt()
+            .await
+            .context("awaiting validationRequest receipt")?;
+
+        // 2) Post the verdict (we are the named validator). 100 = in-bounds.
+        let response: u8 = if in_bounds { 100 } else { 0 };
+        let resp_receipt = registry
+            .validationResponse(
+                rhash,
+                response,
+                request_uri.to_string(),
+                rhash,
+                "clearing/in-bounds".to_string(),
+            )
+            .send()
+            .await
+            .context("sending validationResponse")?
+            .get_receipt()
+            .await
+            .context("awaiting validationResponse receipt")?;
+
+        Ok(AnchorOutcome {
+            request_hash: format!("{rhash:#x}"),
+            validation_tx: format!("{:#x}", resp_receipt.transaction_hash),
+            response,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_hash_is_deterministic_keccak() {
+        let a = request_hash(r#"{"resource":"/v1/x","tx":"0xabc"}"#);
+        let b = request_hash(r#"{"resource":"/v1/x","tx":"0xabc"}"#);
+        assert_eq!(a, b);
+        // keccak256 of empty differs from non-empty.
+        assert_ne!(request_hash(""), a);
+        // 32-byte digest.
+        assert_eq!(a.len(), 32);
+    }
+
+    #[test]
+    fn canonical_registry_addresses_parse() {
+        // Compile-time `address!` already validates; assert they're non-zero.
+        assert_ne!(IDENTITY_REGISTRY_BASE_SEPOLIA, Address::ZERO);
+        assert_ne!(REPUTATION_REGISTRY_BASE_SEPOLIA, Address::ZERO);
+    }
+}

--- a/examples/marketplace-live/src/lib.rs
+++ b/examples/marketplace-live/src/lib.rs
@@ -8,10 +8,12 @@
 //! - [`seller`] — the local x402 seller route (with the IFC pre-gate) the
 //!   facilitator pays.
 
+pub mod erc8004;
 pub mod facilitator;
 pub mod seller;
 pub mod signer;
 
+pub use erc8004::{AlloyAnchor, AnchorOutcome, Anchorer};
 pub use facilitator::{decode_settlement, X402Facilitator};
 pub use seller::seller_router;
 pub use signer::{load_keystore_signer, resolve_keystore_password, PasswordSource};

--- a/justfile
+++ b/justfile
@@ -52,6 +52,12 @@ marketplace-live-import:
 marketplace-live-check:
     cd examples/marketplace-live && cargo build --bins && cargo test
 
+# Deploy the ERC-8004 ValidationRegistry to Base Sepolia (one-time; GASFUL — the
+# deployer wallet needs Base Sepolia ETH). Prompts for the keystore password (not
+# on argv). Pin the printed address into `just marketplace-live --validation-registry <addr>`.
+marketplace-live-deploy-validation:
+    cd examples/marketplace-live/contracts && forge create src/ValidationRegistry.sol:ValidationRegistry --rpc-url https://sepolia.base.org --account nucleus-x402 --broadcast
+
 # ── x402 on Base Sepolia (TESTNET only — never mainnet / real funds) ──────────
 
 # Print the Base Sepolia x402 bootstrap config + faucet links (instant).


### PR DESCRIPTION
## What

Pillar 4 of the marketplace: anchor each verified-clearing receipt on the **ERC-8004 Validation Registry** (Base Sepolia) so the in-bounds decision is checkable from chain reads. Each real txn becomes verifiable **four ways**: dashboard → Basescan settlement → portable receipt → on-chain ERC-8004 anchor.

## Key finding (drove the design)
Identity (`0x8004A818…BD9e`) + Reputation (`0x8004B663…8713`) are **canonical on Base Sepolia**; the **Validation Registry is not** (spec in flux) — so we deploy a minimal, selector-compatible one. ERC-8004 writes are **gasful** (need Base Sepolia ETH) — unlike gasless x402.

## Dashboard (OSS crate)
- `MarketEvent::ReceiptAnchored { agent, for_settlement_id, agent_id, request_hash, validation_tx, response }` (Lane::Proof).
- `AgentSummary` gains `agent_id`/`anchored`/`last_validation`; `MarketState.receipts_anchored`; reducer `apply` handles it.
- Frontend feed shows `anchored ⛓` with the on-chain agentId + validation tx.

## examples/marketplace-live
- `contracts/src/ValidationRegistry.sol` — minimal v1.x-selector-compatible registry (`validationRequest` `0xaaf400c4`, `validationResponse` `0x3d659a96`, `getValidationStatus` `0xff2febfc`); compiles with solc 0.8.24.
- `erc8004.rs` — `sol!` bindings (Identity/Validation) + `Anchorer` trait + `AlloyAnchor` (gasful write path: register → validationRequest → validationResponse) + canonical addresses + `keccak256` requestHash.
- Binary opt-in `--validation-registry`: registers fleet agents on Identity, spawns an anchor task that anchors each verified receipt and emits `ReceiptAnchored`.
- `just marketplace-live-deploy-validation` (forge create).

## Verified
Dashboard 21 tests green; example builds + clippy clean + **6 no-funds tests** (keystore round-trip, X-PAYMENT-RESPONSE decode, keccak requestHash, address parse); contract compiles. The funded deploy + anchoring run is manual (deployer key + ETH).

## Honesty
Testnet only; `response = 100` = "gate allowed + receipt issued" — a model-level, declared-input in-bounds attestation, **not** an end-to-end proof; the self-deployed ValidationRegistry is minimal (canonical one absent on Base Sepolia, spec in flux).

🤖 Generated with [Claude Code](https://claude.com/claude-code)