### PR TITLE
feat(econ): Bet B settlement decision + social-good commons routing (B1)

### DIFF
--- a/crates/nucleus-econ-kernels/src/commons.rs
+++ b/crates/nucleus-econ-kernels/src/commons.rs
@@ -1,0 +1,145 @@
+//! Commons routing — where the Pigouvian externality revenue *goes*.
+//!
+//! A Pigouvian-VCG clearing collects a tax pool ([`crate::vcg_pigou::PigouvianClearing::rebate_pool_micro_usd`])
+//! that internalises the social/environmental cost of the cleared transactions
+//! (carbon, congestion, data pollution — see [`crate::vcg_pigou`] /
+//! `nucleus-externality`'s `ResourceDim`). This module routes that pool to
+//! **remediation + the commons** (e.g. carbon removal, affected-party rebates,
+//! public verifier infrastructure) with a **no-skim conservation** guarantee:
+//! every micro-USD collected is accounted for in the allocations, so the flow is
+//! transparent and independently auditable ("watch the money fund the fix").
+//!
+//! This is the social-good steering: the marketplace prices the true cost AND
+//! routes the revenue to fixing it, non-extractively. Pure + deterministic, so a
+//! settlement contract can run it on-chain and anyone can recompute the split.
+//!
+//! HONESTY: this routes the pool faithfully; it does NOT verify that a
+//! `destination` actually *performs* the remediation (that the carbon-removal
+//! address really removes carbon). That last-mile attestation is an oracle
+//! problem, the same open frontier as measuring the externality itself.
+
+use serde::{Deserialize, Serialize};
+
+/// Basis-point scale (100% = 10_000).
+pub const COMMONS_BPS_SCALE: u64 = 10_000;
+
+/// A destination share of the commons pool, in basis points.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CommonsShare {
+    /// Where this slice goes (a chain address, a remediation program id, …).
+    pub destination: String,
+    /// Share of the pool in basis points; all shares must sum to 10_000.
+    pub bps: u64,
+}
+
+/// A concrete allocation of pool funds to a destination.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CommonsAllocation {
+    /// The destination this allocation funds.
+    pub destination: String,
+    /// Amount in micro-USD.
+    pub amount_micro: u64,
+}
+
+/// Routing errors.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum CommonsError {
+    /// No shares were supplied.
+    #[error("no commons shares supplied")]
+    NoShares,
+    /// Shares did not sum to exactly 10_000 bps (would skim or over-allocate).
+    #[error("commons shares must sum to 10000 bps, got {got}")]
+    SharesMustSumTo10000 { got: u64 },
+}
+
+/// Route `pool_micro` across `shares`, returning one [`CommonsAllocation`] per
+/// share (in order). Integer-division dust is assigned to the first share so the
+/// allocations sum to **exactly** `pool_micro` — nothing is skimmed or lost.
+///
+/// Errors if shares are empty or do not sum to 10_000 bps.
+pub fn route_to_commons(
+    pool_micro: u64,
+    shares: &[CommonsShare],
+) -> Result<Vec<CommonsAllocation>, CommonsError> {
+    if shares.is_empty() {
+        return Err(CommonsError::NoShares);
+    }
+    let sum_bps: u64 = shares.iter().map(|s| s.bps).sum();
+    if sum_bps != COMMONS_BPS_SCALE {
+        return Err(CommonsError::SharesMustSumTo10000 { got: sum_bps });
+    }
+
+    let mut allocations: Vec<CommonsAllocation> = shares
+        .iter()
+        .map(|s| CommonsAllocation {
+            destination: s.destination.clone(),
+            amount_micro: ((pool_micro as u128 * s.bps as u128) / COMMONS_BPS_SCALE as u128) as u64,
+        })
+        .collect();
+
+    // Conservation: assign integer-division dust to the first share so the
+    // allocations sum to exactly the pool (no skim).
+    let allocated: u64 = allocations.iter().map(|a| a.amount_micro).sum();
+    let dust = pool_micro - allocated; // allocated ≤ pool since Σbps == scale
+    if let Some(first) = allocations.first_mut() {
+        first.amount_micro += dust;
+    }
+    Ok(allocations)
+}
+
+/// Total routed (for audit assertions): should always equal the input pool.
+pub fn total_routed(allocations: &[CommonsAllocation]) -> u64 {
+    allocations.iter().map(|a| a.amount_micro).sum()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn share(dest: &str, bps: u64) -> CommonsShare {
+        CommonsShare {
+            destination: dest.into(),
+            bps,
+        }
+    }
+
+    fn example_splits() -> Vec<CommonsShare> {
+        vec![
+            share("carbon-removal", 6_000),          // 60% to drawdown
+            share("affected-party-rebate", 2_500),   // 25% back to those harmed
+            share("public-verifier-commons", 1_500), // 15% to keep the mesh honest
+        ]
+    }
+
+    #[test]
+    fn conservation_no_skim() {
+        // Every micro-USD of the pool is accounted for — the auditable property.
+        for &pool in &[0u64, 1, 7, 1_000_000, 9_999_999, u64::MAX / 4] {
+            let allocs = route_to_commons(pool, &example_splits()).unwrap();
+            assert_eq!(total_routed(&allocs), pool, "skim/loss at pool={pool}");
+        }
+    }
+
+    #[test]
+    fn proportional_split_with_dust_to_first() {
+        let allocs = route_to_commons(1_000_000, &example_splits()).unwrap();
+        assert_eq!(allocs[0].amount_micro, 600_000); // 60%
+        assert_eq!(allocs[1].amount_micro, 250_000); // 25%
+        assert_eq!(allocs[2].amount_micro, 150_000); // 15%
+                                                     // dusty pool: 100 µ over 60/25/15 → 60/25/15, dust 0 here; test a dusty one
+        let d = route_to_commons(7, &example_splits()).unwrap();
+        assert_eq!(total_routed(&d), 7);
+        // 7*6000/10000=4, 7*2500/10000=1, 7*1500/10000=1 → 6; dust 1 → first=5
+        assert_eq!(d[0].amount_micro, 5);
+    }
+
+    #[test]
+    fn rejects_bad_shares() {
+        assert_eq!(route_to_commons(100, &[]), Err(CommonsError::NoShares));
+        let bad = vec![share("a", 5_000), share("b", 4_000)]; // sums 9000
+        assert_eq!(
+            route_to_commons(100, &bad),
+            Err(CommonsError::SharesMustSumTo10000 { got: 9_000 })
+        );
+    }
+}

--- a/crates/nucleus-econ-kernels/src/lib.rs
+++ b/crates/nucleus-econ-kernels/src/lib.rs
@@ -29,14 +29,19 @@
 // section); callers that want the newtypes can reach them here.
 pub use nucleus_econ_types::{AgentId, AuctionId, MicroUsd, ProposalId};
 
+pub mod commons;
 pub mod extracted;
 pub mod rational;
 pub mod sealed;
+pub mod settlement;
 pub mod tlock;
 pub mod vcg;
 pub mod vcg_combo;
 pub mod vcg_hetero;
 pub mod vcg_pigou;
+
+pub use commons::{route_to_commons, CommonsAllocation, CommonsError, CommonsShare};
+pub use settlement::{classify, refund, seller_gross, Verdict};
 
 pub use rational::Rational;
 pub use sealed::{

--- a/crates/nucleus-econ-kernels/src/settlement.rs
+++ b/crates/nucleus-econ-kernels/src/settlement.rs
@@ -1,0 +1,116 @@
+//! Verified settlement decision (Bet B) — a Rust port of
+//! `lean/Nucleus/Auctions/SettlementDecision.lean`, parity-pinned to it.
+//!
+//! Given a delivery score in basis points, decide how a cleared price splits
+//! between the seller and a refund to the bidder:
+//!
+//! - `reverse`  — `delivered_bps == 0`            → full refund, seller gets 0.
+//! - `partial`  — `0 < delivered_bps < 10_000`    → split.
+//! - `release`  — `delivered_bps >= 10_000`        → full payout to seller (v1).
+//!
+//! The load-bearing invariant (Lean `theorem conservation`): `seller_gross +
+//! refund == price`, exactly — no value is created or destroyed in settlement.
+//! Integer micro-USD; `refund` is defined as the residual so conservation holds
+//! by construction and the parity test confirms it matches the proof.
+//!
+//! HONESTY: `delivered_bps` is an INPUT — the proof says nothing about whether
+//! the seller *actually delivered* that fraction. Producing a trustworthy
+//! `delivered_bps` is the Proof-of-Task-Execution (PoTE) seam, which is the one
+//! unsolved part of Bet B (see `docs/rfcs/credible-clearing-settlement.md`).
+
+use serde::{Deserialize, Serialize};
+
+/// Basis-point scale (100% = 10_000 bps). Mirrors Lean `bpsScale`.
+pub const BPS_SCALE: u64 = 10_000;
+
+/// The settlement verdict (mirrors Lean `Verdict`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Verdict {
+    /// `delivered_bps == 0`: full refund to the bidder, nothing to the seller.
+    Reverse,
+    /// `0 < delivered_bps < 10_000`: split between seller and refund.
+    Partial,
+    /// `delivered_bps >= 10_000`: full payout to the seller (the v1 happy path).
+    Release,
+}
+
+/// Classify a delivery score into a [`Verdict`] (mirrors Lean `classify`).
+pub fn classify(delivered_bps: u64) -> Verdict {
+    if delivered_bps == 0 {
+        Verdict::Reverse
+    } else if delivered_bps < BPS_SCALE {
+        Verdict::Partial
+    } else {
+        Verdict::Release
+    }
+}
+
+/// The seller's payout for a cleared `price_micro` at `delivered_bps` (clamped to
+/// 100%). Mirrors Lean `sellerGross`; `u128` math avoids overflow.
+pub fn seller_gross(price_micro: u64, delivered_bps: u64) -> u64 {
+    let bps = delivered_bps.min(BPS_SCALE) as u128;
+    ((price_micro as u128 * bps) / BPS_SCALE as u128) as u64
+}
+
+/// The bidder's refund: the residual after the seller's payout. Defined as
+/// `price - seller_gross` so `seller_gross + refund == price` holds exactly
+/// (Lean `theorem conservation`).
+pub fn refund(price_micro: u64, delivered_bps: u64) -> u64 {
+    price_micro - seller_gross(price_micro, delivered_bps)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_matches_lean_total() {
+        assert_eq!(classify(0), Verdict::Reverse);
+        assert_eq!(classify(1), Verdict::Partial);
+        assert_eq!(classify(9_999), Verdict::Partial);
+        assert_eq!(classify(10_000), Verdict::Release);
+        assert_eq!(classify(50_000), Verdict::Release); // clamped to release
+    }
+
+    #[test]
+    fn release_is_full_payout_reverse_is_full_refund() {
+        // Lean: release_is_full_payout / reverse_is_full_refund.
+        assert_eq!(seller_gross(1_000_000, 10_000), 1_000_000);
+        assert_eq!(refund(1_000_000, 10_000), 0);
+        assert_eq!(seller_gross(1_000_000, 0), 0);
+        assert_eq!(refund(1_000_000, 0), 1_000_000);
+    }
+
+    #[test]
+    fn conservation_holds_for_a_battery_of_inputs() {
+        // Lean `theorem conservation`: seller_gross + refund == price, exactly,
+        // for every price × delivery-score. Parity-checked here at runtime.
+        for &price in &[0u64, 1, 999, 1_000_000, 7_654_321, u64::MAX / 2] {
+            for &bps in &[0u64, 1, 2_500, 5_000, 9_999, 10_000, 25_000] {
+                assert_eq!(
+                    seller_gross(price, bps) + refund(price, bps),
+                    price,
+                    "conservation violated: price={price} bps={bps}"
+                );
+                assert!(seller_gross(price, bps) <= price, "sellerGross ≤ price");
+            }
+        }
+    }
+
+    #[test]
+    fn seller_gross_monotone_refund_antitone() {
+        // Lean sellerGross_mono / refund_antitone over the delivery score.
+        let price = 1_000_000;
+        let mut last_gross = 0u64;
+        let mut last_refund = price;
+        for bps in [0u64, 1_000, 5_000, 9_000, 10_000] {
+            let g = seller_gross(price, bps);
+            let r = refund(price, bps);
+            assert!(g >= last_gross, "sellerGross must be monotone in bps");
+            assert!(r <= last_refund, "refund must be antitone in bps");
+            last_gross = g;
+            last_refund = r;
+        }
+    }
+}

--- a/docs/rfcs/social-good-externality-routing.md
+++ b/docs/rfcs/social-good-externality-routing.md
@@ -1,0 +1,93 @@
+# RFC: Social-good steering — verifiable externality accounting + commons routing
+
+**Status:** active (North Star lens). **Ships:** `nucleus-econ-kernels::commons`
+(routing) + `::settlement` (Bet B decision); RFC for the routing destination + the
+non-extractive structure.
+
+## The directive
+
+Steer this commerce toward **social good — it should benefit people and the
+planet** — and make that the lens for everything (now in the vision North Star).
+
+## The thesis
+
+**Verifiable externality accounting for the agent economy.** As agents do more
+economic work, the externalities scale (compute → carbon, congestion, data
+pollution). Today carbon/ESG accounting is *self-reported and unverifiable* — the
+greenwashing problem. nucleus already prices these as first-class externality
+dimensions (`ResourceDim`: `GridCarbonGramsCo2`, `PeerVerifierMillis`,
+`CorpusBitsAdded`, the positive `KnowledgeSpillover`, …), Pigouvian-priced,
+oracle-attested, on-chain anchored. The differentiator is **provable** externality
+receipts — the anti-greenwashing primitive carbon/ESG markets lack.
+
+## Monetization without betraying trustlessness
+
+A trustless credible auction has **no rent chokepoint** — you can't tax the trade
+(forkable). So:
+
+- **Don't tax the trade.** The clearing is a public good.
+- **Charge for proven work** — verification / witnessing / recompute-as-a-service,
+  metered over x402 (a service station beside the road, not a toll booth).
+- **Charge for the compliance / ESG control plane** — enterprises pay to *prove*
+  their agent commerce is clean (verifiable externality receipts for regulatory /
+  ESG reporting).
+- **Route the externality pool to the commons, not to rent** (below). The org takes
+  a *bounded, governance-capped* operations fee at most.
+
+Verifiability is what makes the social-good claim **credible instead of
+greenwashing**: the system's own receipts let anyone audit that the money went
+where claimed. Trustlessness is the enabler, not the obstacle.
+
+## What ships now: `commons` routing (the "watch the money fund the fix" primitive)
+
+`nucleus_econ_kernels::commons::route_to_commons(pool_micro, &shares)` routes the
+Pigouvian pool (`PigouvianClearing::rebate_pool_micro_usd`) across remediation
+destinations with a **no-skim conservation guarantee**: the allocations sum to
+**exactly** the pool (integer-division dust assigned, nothing lost or skimmed).
+Pure + deterministic, so a settlement contract can run it on-chain and anyone can
+recompute the split. Example default split (governance-set):
+
+| destination | share |
+|---|---|
+| carbon-removal / drawdown | 60% |
+| affected-party rebate | 25% |
+| public-verifier commons | 15% |
+
+And `::settlement` (Bet B decision, ported from `SettlementDecision.lean`):
+`classify → reverse / partial / release`, with `seller_gross + refund == price`
+(Lean `conservation`, parity-tested) — value is never created or destroyed in
+settlement.
+
+## Structure: the right vessel
+
+A rent-maximizing company is the wrong vessel for a trust-fabric commons. Fit =
+**steward-owned / public-benefit / foundation-core**: protocol = commons; the org
+sustains on verification + compliance + a bounded fee; externality revenue
+transparently → remediation. **The org's own verifiable receipts audit its own
+treasury** — you can prove you're non-extractive.
+
+## Honesty boundary (load-bearing)
+
+- **The oracle problem is the open frontier.** A Pigouvian price is only "true" if
+  the externality *measurement* (e.g. grams CO₂) is honest. The `commons` router
+  faithfully routes the pool; it does **not** verify a destination actually performs
+  the remediation. Both are oracle/attestation problems — mitigated by the zk/TEE
+  upper-envelope proofs the externality layer cites, **not eliminated**.
+- **Demand is still the bottleneck.** ESG/carbon markets are real but fraught;
+  verifiability is the wedge, not a demand generator.
+- **No testnet overclaiming.** The honest claim today: *the mechanism to price and
+  route externalities verifiably exists and is proven* (parity-pinned to Lean);
+  planetary impact is downstream of adoption.
+- **Routing needs governance + legal structure** — who sets λ rates, who audits the
+  oracle, what counts as remediation, who controls the commons addresses.
+
+## Next
+
+- Extend `@coproduct/verify` `recompute()` to the cleared price **including** the
+  Pigouvian component, so a counterparty re-derives both the price *and* the
+  externality charge.
+- Wire `commons` + `settlement` into the Bet B settlement contract (the on-chain
+  destination = a transparent commons address), per
+  `docs/rfcs/credible-clearing-settlement.md`.
+- Tackle the externality oracle (the honest hard part) — verifiable measurement,
+  not just verifiable routing.


### PR DESCRIPTION
## What

Steers the marketplace toward **social good** (now the North Star lens): price the true cost (Pigouvian) **and route the revenue to fixing it** — non-extractively + verifiably. Builds on the proven econ stack (#1746).

### `settlement.rs` — Bet B verdict (ported from `SettlementDecision.lean`, parity-tested)
`classify → reverse / partial / release`; `seller_gross + refund == price` **exactly** (Lean `conservation`). `delivered_bps` is an **input** — PoTE (did the seller actually deliver?) stays the one honestly-unsolved seam.

### `commons.rs` — the social-good primitive ("watch the money fund the fix")
`route_to_commons(pool, &shares)` routes the Pigouvian externality pool (`PigouvianClearing::rebate_pool_micro_usd`) to remediation/commons with a **no-skim conservation guarantee** — allocations sum to **exactly** the pool (dust → first; nothing lost or skimmed). Pure + on-chain-runnable + recomputable → independently auditable. Replaces the platform's dropped witness-federation rebate with a **commons** target (e.g. 60% carbon-removal / 25% affected-party / 15% verifier-commons).

### `docs/rfcs/social-good-externality-routing.md`
The thesis (**verifiable externality accounting = the anti-greenwashing primitive**), non-extractive monetization (charge for *proven work* + *compliance*, **not** the trade; the pool funds the commons), the steward/PBC vessel, and the honesty boundary — **the externality-measurement oracle is the open frontier** (verifiable *routing* ≠ verifiable *measurement*).

## Verified
83 `econ-kernels` tests green (incl. settlement-conservation + commons-no-skim); clippy `-D warnings` clean.

## Honesty
A Pigouvian price is only "true" if the externality *measurement* is honest (oracle problem, mitigated by zk/TEE proofs not eliminated). `commons` routes faithfully; it does not verify a destination performs the remediation. No testnet overclaiming — the proven claim is that the mechanism to price + route externalities verifiably *exists*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)