### PR TITLE
feat(verify): recompute the cleared price (VCG+Pigou) + settlement + commons

### DIFF
--- a/crates/nucleus-econ-kernels/src/vcg_pigou.rs
+++ b/crates/nucleus-econ-kernels/src/vcg_pigou.rs
@@ -75,7 +75,7 @@ impl PigouvianRates {
 ///
 /// Wraps the kernel `Clearing` with the per-bidder Pigouvian
 /// discounts and the resulting rebate pool (T1).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PigouvianClearing {
     /// The underlying VCG clearing — winners, payments,
     /// totals — computed on the *adjusted* bids.

--- a/sdks/verifier-js/Cargo.lock
+++ b/sdks/verifier-js/Cargo.lock
@@ -41,10 +41,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "block-buffer"
@@ -109,6 +124,12 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
@@ -139,6 +160,16 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "crypto-common"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
@@ -152,10 +183,26 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ed89bf5e2d6dfa1762dcd00e1ef68f1f6070a67e217ce280ab6b53971c3a60d"
 dependencies = [
- "digest",
+ "digest 0.11.3",
  "hybrid-array",
  "serde",
  "subtle",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto 0.2.9",
+ "rustc_version",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -167,8 +214,8 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
- "fiat-crypto",
+ "digest 0.11.3",
+ "fiat-crypto 0.3.0",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -186,14 +233,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid 0.9.6",
+ "zeroize",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
 name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.12.0",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature 2.2.0",
 ]
 
 [[package]]
@@ -202,7 +279,21 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
 dependencies = [
- "signature",
+ "signature 3.0.0",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek 4.1.3",
+ "ed25519 2.2.3",
+ "serde",
+ "sha2 0.10.9",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -211,9 +302,9 @@ version = "3.0.0-pre.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20449acd54b660981ae5caa2bcb56d1fe7f25f2e37a38ec507400fab034d4bb6"
 dependencies = [
- "curve25519-dalek",
- "ed25519",
- "sha2",
+ "curve25519-dalek 5.0.0-pre.6",
+ "ed25519 3.0.0",
+ "sha2 0.11.0",
  "subtle",
  "zeroize",
 ]
@@ -223,6 +314,12 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "fiat-crypto"
@@ -264,6 +361,16 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -439,17 +546,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "nucleus-econ-kernels"
+version = "1.0.0"
+dependencies = [
+ "hex",
+ "nucleus-econ-types",
+ "nucleus-externality",
+ "serde",
+ "sha2 0.11.0",
+ "thiserror",
+]
+
+[[package]]
+name = "nucleus-econ-types"
+version = "1.0.0"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "nucleus-envelope"
 version = "1.0.0"
 dependencies = [
  "base64",
  "chrono",
- "ed25519-dalek",
+ "ed25519-dalek 3.0.0-pre.7",
  "hex",
  "nucleus-lineage",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
+ "thiserror",
+]
+
+[[package]]
+name = "nucleus-externality"
+version = "1.0.0"
+dependencies = [
+ "base64",
+ "ed25519-dalek 2.2.0",
+ "hex",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
  "thiserror",
 ]
 
@@ -468,11 +607,11 @@ dependencies = [
  "base64",
  "chrono",
  "ct-merkle",
- "ed25519-dalek",
+ "ed25519-dalek 3.0.0-pre.7",
  "hex",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "thiserror",
  "tracing",
  "uuid",
@@ -486,7 +625,9 @@ dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",
  "hex",
+ "nucleus-econ-kernels",
  "nucleus-envelope",
+ "nucleus-externality",
  "nucleus-ifc",
  "nucleus-lineage",
  "serde",
@@ -526,6 +667,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "portcullis-core"
 version = "1.0.0"
 
@@ -562,6 +713,15 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "rustc_version"
@@ -649,13 +809,24 @@ dependencies = [
 
 [[package]]
 name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "digest",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -663,6 +834,15 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core",
+]
 
 [[package]]
 name = "signature"
@@ -675,6 +855,16 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
 
 [[package]]
 name = "subtle"
@@ -772,6 +962,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"

--- a/sdks/verifier-js/Cargo.toml
+++ b/sdks/verifier-js/Cargo.toml
@@ -20,6 +20,10 @@ nucleus-lineage = { path = "../../crates/nucleus-lineage" }
 # The IFC decision (wasm-safe, feature-gated) — lets the SDK RE-DERIVE the
 # in-bounds verdict, not just check signatures. Same code the production gate runs.
 nucleus-ifc = { path = "../../crates/nucleus-ifc", features = ["decision"] }
+# Proven clearing/settlement/commons kernels — lets the SDK RE-DERIVE the cleared
+# price (VCG + Pigou), the settlement split, and the externality→commons routing.
+nucleus-econ-kernels = { path = "../../crates/nucleus-econ-kernels" }
+nucleus-externality = { path = "../../crates/nucleus-externality" }
 wasm-bindgen = "0.2"
 serde-wasm-bindgen = "0.6"
 serde = { version = "1", features = ["derive"] }

--- a/sdks/verifier-js/index.d.ts
+++ b/sdks/verifier-js/index.d.ts
@@ -115,3 +115,33 @@ export function checkVerdict(
   claimedAllow: boolean,
   opts?: RecomputeOptions,
 ): Promise<boolean>;
+
+// ── Economic recompute (proven nucleus-econ-kernels; u64 fields are bigint) ────
+
+/** Re-derive the truthful VCG clearing (winners + Clarke-pivot payments). */
+export function recomputeVcg(
+  bids: object[],
+  proposals: object[],
+  budgetMicroUsd: number | bigint,
+): Promise<object>;
+
+/** Re-derive the Pigouvian-VCG clearing — cleared price incl. the externality charge. */
+export function recomputeVcgPigou(
+  bids: object[],
+  proposals: object[],
+  budgetMicroUsd: number | bigint,
+  externalities: object[],
+  rates: object,
+): Promise<object>;
+
+/** Re-derive the settlement split (`seller_gross + refund == price`). */
+export function recomputeSettlement(
+  priceMicro: number | bigint,
+  deliveredBps: number | bigint,
+): Promise<{ verdict: "reverse" | "partial" | "release"; seller_gross: bigint; refund: bigint }>;
+
+/** Re-derive the externality→commons routing (no-skim; sum equals the pool). */
+export function recomputeCommons(
+  poolMicro: number | bigint,
+  shares: object[],
+): Promise<Array<{ destination: string; amount_micro: bigint }>>;

--- a/sdks/verifier-js/index.js
+++ b/sdks/verifier-js/index.js
@@ -304,3 +304,65 @@ export async function checkVerdict(declaredInputs, claimedAllow, opts = {}) {
     claimedAllow,
   );
 }
+
+// ── RECOMPUTE THE ECONOMICS: cleared price (VCG + Pigou), settlement, commons ──
+// All run the EXACT proven `nucleus-econ-kernels` functions in-process — a
+// counterparty re-derives the price, the externality charge, the payout split,
+// and where the externality revenue is routed, trusting no server. `u64` fields
+// cross the wasm boundary as BigInt.
+
+const big = (x) => (typeof x === "bigint" ? x : BigInt(x));
+
+/**
+ * Re-derive the truthful VCG clearing (winners + Clarke-pivot payments).
+ * @param {object[]} bids `IntegerBid[]` `{bidder, proposal_id, effective_value_micro_usd}`
+ * @param {object[]} proposals `IntegerProposal[]` `{id, cost_micro_usd}`
+ * @param {number|bigint} budgetMicroUsd
+ * @returns {Promise<object>} the `Clearing` (winners/losers/totals).
+ */
+export async function recomputeVcg(bids, proposals, budgetMicroUsd) {
+  const mod = await initWasm();
+  return mod.recomputeVcg(JSON.stringify(bids), JSON.stringify(proposals), big(budgetMicroUsd));
+}
+
+/**
+ * Re-derive the Pigouvian-VCG clearing — the cleared price INCLUDING the
+ * internalised externality charge + the resulting rebate pool.
+ * @param {object[]} bids @param {object[]} proposals @param {number|bigint} budgetMicroUsd
+ * @param {object[]} externalities `ExternalityProfile[]` (signed claims per resource dim)
+ * @param {object} rates `PigouvianRates` `{lambdas:{<dim>:<u64>}}`
+ * @returns {Promise<object>} the `PigouvianClearing` `{clearing, rebate_pool_micro_usd}`.
+ */
+export async function recomputeVcgPigou(bids, proposals, budgetMicroUsd, externalities, rates) {
+  const mod = await initWasm();
+  return mod.recomputeVcgPigou(
+    JSON.stringify(bids),
+    JSON.stringify(proposals),
+    big(budgetMicroUsd),
+    JSON.stringify(externalities),
+    JSON.stringify(rates),
+  );
+}
+
+/**
+ * Re-derive the settlement split for a cleared price at a delivery score (bps):
+ * `{ verdict, seller_gross, refund }` with `seller_gross + refund == price`.
+ * @param {number|bigint} priceMicro @param {number|bigint} deliveredBps
+ * @returns {Promise<{verdict:"reverse"|"partial"|"release", seller_gross:bigint, refund:bigint}>}
+ */
+export async function recomputeSettlement(priceMicro, deliveredBps) {
+  const mod = await initWasm();
+  return mod.recomputeSettlement(big(priceMicro), big(deliveredBps));
+}
+
+/**
+ * Re-derive the externality→commons routing (no-skim conservation; sum equals
+ * the pool). The social-good audit: watch the money fund the fix.
+ * @param {number|bigint} poolMicro
+ * @param {object[]} shares `CommonsShare[]` `{destination, bps}` (must sum to 10000)
+ * @returns {Promise<object[]>} `CommonsAllocation[]` `{destination, amount_micro}`.
+ */
+export async function recomputeCommons(poolMicro, shares) {
+  const mod = await initWasm();
+  return mod.recomputeCommons(big(poolMicro), JSON.stringify(shares));
+}

--- a/sdks/verifier-js/src/lib.rs
+++ b/sdks/verifier-js/src/lib.rs
@@ -87,8 +87,8 @@ struct VerifyReport {
 pub fn verify_bundle_js(bundle_json: &str, trust_anchor_json: &str) -> Result<JsValue, JsError> {
     set_panic_hook();
 
-    let bundle: Bundle =
-        serde_json::from_str(bundle_json).map_err(|e| JsError::new(&format!("bundle JSON: {e}")))?;
+    let bundle: Bundle = serde_json::from_str(bundle_json)
+        .map_err(|e| JsError::new(&format!("bundle JSON: {e}")))?;
     let input: TrustAnchorInput = serde_json::from_str(trust_anchor_json)
         .map_err(|e| JsError::new(&format!("trust anchor JSON: {e}")))?;
 
@@ -252,4 +252,99 @@ pub fn check_verdict_js(
     )
     .ok_or_else(|| JsError::new("unknown declared-input token (recompute fails closed)"))?;
     Ok(decl.decide().allow == claimed_allow)
+}
+
+// ── RECOMPUTE THE CLEARED PRICE (+ Pigou) + settlement + commons routing ──────
+//
+// The recompute extended from the IFC verdict to the *economics*: re-derive the
+// VCG clearing + truthful prices, the Pigouvian-VCG clearing (price incl. the
+// externality charge), the settlement split, and where the externality pool is
+// routed — all running the EXACT proven `nucleus-econ-kernels` functions
+// (parity-pinned to the Lean), in the caller's process. A counterparty verifies
+// the price, the externality charge, the payout, AND that the externality revenue
+// reaches the commons — not a vendor's word for any of it.
+
+/// Re-derive the truthful VCG clearing (winners + Clarke-pivot payments) from a
+/// bid set. Inputs are JSON arrays of `IntegerBid` / `IntegerProposal` + a budget.
+#[wasm_bindgen(js_name = recomputeVcg)]
+pub fn recompute_vcg_js(
+    bids_json: &str,
+    proposals_json: &str,
+    budget_micro_usd: u64,
+) -> Result<JsValue, JsError> {
+    set_panic_hook();
+    let bids: Vec<nucleus_econ_kernels::IntegerBid> =
+        serde_json::from_str(bids_json).map_err(|e| JsError::new(&format!("bids JSON: {e}")))?;
+    let proposals: Vec<nucleus_econ_kernels::IntegerProposal> =
+        serde_json::from_str(proposals_json)
+            .map_err(|e| JsError::new(&format!("proposals JSON: {e}")))?;
+    let clearing = nucleus_econ_kernels::run_vcg(&bids, &proposals, budget_micro_usd)
+        .map_err(|e| JsError::new(&format!("vcg: {e}")))?;
+    serde_wasm_bindgen::to_value(&clearing).map_err(|e| JsError::new(&e.to_string()))
+}
+
+/// Re-derive the **Pigouvian-VCG** clearing — the cleared price *including* the
+/// internalised externality charge + the resulting rebate pool. `externalities`
+/// is a JSON array of `ExternalityProfile`; `rates` is `PigouvianRates` JSON.
+#[wasm_bindgen(js_name = recomputeVcgPigou)]
+pub fn recompute_vcg_pigou_js(
+    bids_json: &str,
+    proposals_json: &str,
+    budget_micro_usd: u64,
+    externalities_json: &str,
+    rates_json: &str,
+) -> Result<JsValue, JsError> {
+    set_panic_hook();
+    let bids: Vec<nucleus_econ_kernels::IntegerBid> =
+        serde_json::from_str(bids_json).map_err(|e| JsError::new(&format!("bids JSON: {e}")))?;
+    let proposals: Vec<nucleus_econ_kernels::IntegerProposal> =
+        serde_json::from_str(proposals_json)
+            .map_err(|e| JsError::new(&format!("proposals JSON: {e}")))?;
+    let externalities: Vec<nucleus_externality::ExternalityProfile> =
+        serde_json::from_str(externalities_json)
+            .map_err(|e| JsError::new(&format!("externalities JSON: {e}")))?;
+    let rates: nucleus_econ_kernels::PigouvianRates =
+        serde_json::from_str(rates_json).map_err(|e| JsError::new(&format!("rates JSON: {e}")))?;
+    let clearing = nucleus_econ_kernels::run_vcg_with_externalities(
+        &bids,
+        &proposals,
+        budget_micro_usd,
+        &externalities,
+        &rates,
+    )
+    .map_err(|e| JsError::new(&format!("pigou-vcg: {e}")))?;
+    serde_wasm_bindgen::to_value(&clearing).map_err(|e| JsError::new(&e.to_string()))
+}
+
+/// Re-derive the settlement split for a cleared `price_micro` at a delivery score
+/// (basis points): `{ verdict, seller_gross, refund }` with `seller_gross +
+/// refund == price` (the Lean conservation theorem).
+#[wasm_bindgen(js_name = recomputeSettlement)]
+pub fn recompute_settlement_js(price_micro: u64, delivered_bps: u64) -> Result<JsValue, JsError> {
+    set_panic_hook();
+    #[derive(Serialize)]
+    struct SettlementReport {
+        verdict: nucleus_econ_kernels::Verdict,
+        seller_gross: u64,
+        refund: u64,
+    }
+    let report = SettlementReport {
+        verdict: nucleus_econ_kernels::classify(delivered_bps),
+        seller_gross: nucleus_econ_kernels::seller_gross(price_micro, delivered_bps),
+        refund: nucleus_econ_kernels::refund(price_micro, delivered_bps),
+    };
+    serde_wasm_bindgen::to_value(&report).map_err(|e| JsError::new(&e.to_string()))
+}
+
+/// Re-derive the externality→commons routing: given the Pigouvian `pool` and a
+/// JSON array of `CommonsShare`, return the allocations. Conservation (no skim) is
+/// guaranteed by the kernel; the caller can sum and check it equals the pool.
+#[wasm_bindgen(js_name = recomputeCommons)]
+pub fn recompute_commons_js(pool_micro: u64, shares_json: &str) -> Result<JsValue, JsError> {
+    set_panic_hook();
+    let shares: Vec<nucleus_econ_kernels::CommonsShare> = serde_json::from_str(shares_json)
+        .map_err(|e| JsError::new(&format!("shares JSON: {e}")))?;
+    let allocations = nucleus_econ_kernels::route_to_commons(pool_micro, &shares)
+        .map_err(|e| JsError::new(&format!("commons: {e}")))?;
+    serde_wasm_bindgen::to_value(&allocations).map_err(|e| JsError::new(&e.to_string()))
 }

--- a/sdks/verifier-js/tests/web.rs
+++ b/sdks/verifier-js/tests/web.rs
@@ -17,7 +17,10 @@ use wasm_bindgen_test::*;
 #[wasm_bindgen_test]
 fn sdk_version_returns_non_empty_string() {
     let v = sdk_version();
-    assert!(!v.is_empty(), "sdk_version must return a populated version string");
+    assert!(
+        !v.is_empty(),
+        "sdk_version must return a populated version string"
+    );
 }
 
 #[wasm_bindgen_test]


### PR DESCRIPTION
Extends `@coproduct/verify` recompute from the IFC verdict to the **economics**: `recomputeVcg` / `recomputeVcgPigou` (cleared price incl. the Pigouvian externality charge) / `recomputeSettlement` (conserves) / `recomputeCommons` (no-skim) — all running the proven `nucleus-econ-kernels` in-process. The recompute is the fraud-proof verifier for Bet B. Verified in Node; wasm-pack builds; clippy clean. Honesty: re-derives price from (signed) inputs; doesn't verify the externality *measurement* (oracle problem).

🤖 Generated with [Claude Code](https://claude.com/claude-code)