### PR TITLE
feat(marketplace): Bet B B2 — optimistic credible-clearing settlement contract

### DIFF
--- a/docs/rfcs/credible-clearing-settlement.md
+++ b/docs/rfcs/credible-clearing-settlement.md
@@ -56,21 +56,32 @@ is gone.
 | Sealed-bid commitment-set root | ✅ `sealed.rs` |
 | Timelock reveal | ✅ `tlock.rs` (drand) |
 | On-chain payment | ✅ x402 (EVM) / Aiken `settlement.ak` seam (Cardano) |
-| **Optimistic settlement contract** (commit-root → reveal → fraud-proof → settle) | ⛳ **net-new — the load-bearing build** |
-| **On-chain bid commitment** (anti-censorship commit phase) | ⛳ net-new |
-| **Bond / challenge / slash** mechanism | ⛳ net-new |
-| **Proof-of-Task-Execution** (did the seller *deliver*?) | ❌ unsolved — stays a named seam |
+| **Optimistic settlement contract** (commit-root → reveal → post+bond → challenge → settle) | ✅ **shipped (B2)** — `examples/marketplace-live/contracts/src/CredibleSettlement.sol` |
+| **Bond / challenge / slash** mechanism | ✅ shipped (B2) — slashed bond routed to commons (anti-grief) |
+| On-chain settlement split runs the **exact proven function** | ✅ shipped — Solidity mirror of `settlement.rs`/`commons.rs`, parity-tested (`test/CredibleSettlement.t.sol`) |
+| **On-chain bid commitment** (anti-censorship commit phase) | ⛳ net-new (B3) |
+| **Clearing-price adjudication** (decide poster-vs-challenger, not just reverse) | ⛳ net-new (B3) — needs interactive proofs / on-chain commit |
+| **Proof-of-Task-Execution** (did the seller *deliver*?) | ❌ unsolved — `deliveredBps` is an arbiter input |
 
 ## Phasing
 
 - **B1 (ready):** port `SettlementDecision` to OSS Rust + a parity test (mirror the
   VCG parity pattern); extend `@coproduct/verify` recompute to the clearing price
   (now possible — the proven kernel is in OSS).
-- **B2:** an EVM **settlement contract** (or Aiken `settlement.ak`): commit root →
-  timelock reveal → optimistic post+bond → recompute fraud proof → settle
-  (release/reverse). Base Sepolia testnet.
-- **B3:** on-chain bid commitment (open submission) + the bond/challenge/slash
-  loop — this is what removes the *coordinator*, not just the *trust*.
+- **B2 (shipped):** an EVM **settlement contract**
+  (`CredibleSettlement.sol`): commit root → timelock reveal → optimistic
+  post+bond → challenge window → settle (release/partial/reverse). The
+  settlement split + commons routing run the **exact** proven functions on-chain
+  (a byte-for-byte Solidity mirror of `settlement.rs`/`commons.rs`, bound by a
+  Foundry parity test against the same vectors as the Rust/Lean tests). A valid
+  `challenge()` slashes the poster's bond **to the commons** and safely reverses
+  (buyer refunded) — cheating is unprofitable without any on-chain VCG. Base
+  Sepolia testnet; native-value escrow for v1. *Not yet:* deciding poster-vs-
+  challenger correctness (always reverses on challenge) — that's B3.
+- **B3:** on-chain bid commitment (open submission) + clearing-price
+  adjudication (interactive fraud proof or on-chain commit so a challenge
+  resolves to the *correct* result, not just a reversal) — this is what removes
+  the *coordinator*, not just the *trust*.
 - **B4 (research):** PoTE — proving the seller actually delivered. Until then, v1
   settles on **clearing-correct + payment**, not on delivery; disputes about
   delivery remain out of scope (pitch to compliance, not as full escrow).

--- a/examples/marketplace-live/README.md
+++ b/examples/marketplace-live/README.md
@@ -75,6 +75,38 @@ on-chain `agentId` + validation tx. Each real txn is then verifiable four ways:
 `response = 100` = "the gate allowed this flow and a receipt was issued" — a
 model-level, declared-input in-bounds attestation, not an end-to-end proof.
 
+## Credible settlement contract (Bet B / B2)
+
+`contracts/src/CredibleSettlement.sol` is the **optimistic credible-clearing
+settlement** contract — it removes the *trusted auctioneer* by letting the
+verified settlement self-execute on-chain. Lifecycle: buyer `openRound` (escrows
+the cleared price) → an untrusted poster `postClearing` (+bond, after the reveal
+deadline) → a challenge window → `settle` (the arbiter supplies `deliveredBps`).
+
+What makes the money path trustworthy: the settlement split (`classify` /
+`sellerGross` / `refund`) and the commons routing (`routeToCommons`) are a
+**byte-for-byte Solidity mirror** of `nucleus-econ-kernels::settlement` /
+`::commons`, which are themselves parity-pinned to `SettlementDecision.lean`. The
+load-bearing invariant `sellerGross + refund == price` holds by construction. A
+valid `challenge()` slashes the poster's bond **to the commons** (anti-grief,
+non-extractive) and safely reverses (buyer refunded) — so cheating is
+unprofitable *without* running VCG on-chain.
+
+Honesty boundary: the *cleared price* is posted optimistically (off-chain
+recompute is the fraud proof; a challenge reverses, it does not yet adjudicate
+poster-vs-challenger — that's B3). `deliveredBps` is an arbiter input — the
+unsolved PoTE seam. See `docs/rfcs/credible-clearing-settlement.md`.
+
+```bash
+# forge-std is not vendored (/lib is gitignored); fetch it once:
+cd contracts && forge install foundry-rs/forge-std --no-git   # or: git clone --depth 1 https://github.com/foundry-rs/forge-std lib/forge-std
+forge test --match-contract CredibleSettlementTest            # 17 tests: parity + lifecycle + fuzz
+```
+
+The `test_parity_*` cases mirror the SAME vectors as the Rust `settlement.rs` /
+`commons.rs` tests — they are what bind the on-chain split to the Lean proof. If
+the Solidity drifts from the proven function, they fail.
+
 ## Secure key handling
 
 The signing key lives in a foundry-format encrypted keystore; the decryption

--- a/examples/marketplace-live/contracts/src/CredibleSettlement.sol
+++ b/examples/marketplace-live/contracts/src/CredibleSettlement.sol
@@ -1,0 +1,277 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/// @title CredibleSettlement — optimistic credible-clearing settlement (Bet B, B2)
+/// @notice Removes the *trusted auctioneer* from an off-chain VCG/Pigou auction:
+/// the verified settlement **self-executes on-chain** so no one must be trusted to
+/// *act* on the outcome. Base Sepolia testnet only.
+///
+/// ## What is proven on-chain (the trustless core)
+/// The settlement split — `classify` / `sellerGross` / `refund` — is a byte-for-
+/// byte mirror of `nucleus-econ-kernels::settlement` (itself parity-pinned to
+/// `lean/Nucleus/Auctions/SettlementDecision.lean`). The load-bearing invariant
+/// `sellerGross + refund == price` holds by construction (`refund` is the
+/// residual) and is re-checked by the Foundry parity test against the SAME vectors
+/// the Rust test uses. The commons routing (`routeToCommons`) likewise mirrors
+/// `nucleus-econ-kernels::commons` with no-skim conservation. So the money path
+/// runs the EXACT proven functions — not an approximation of them.
+///
+/// ## What is optimistic (the documented seam)
+/// The *cleared price* itself is posted optimistically: the contract does NOT run
+/// VCG on-chain (too expensive). Instead the poster bonds the claim, and during a
+/// challenge window any watcher who runs the coproduct/verify SDK's recompute off-chain
+/// and finds `claimed != recompute` can `challenge()` → the poster's bond is
+/// slashed to the commons and the round safely **reverses** (buyer refunded). This
+/// makes cheating unprofitable and gives a safe fallback WITHOUT on-chain
+/// adjudication. Deciding *who is right* between poster and challenger (vs. always
+/// reversing) needs interactive fraud proofs / on-chain commit — that is B3, and
+/// is intentionally NOT claimed here.
+///
+/// ## What is NOT solved
+/// `deliveredBps` (did the seller actually deliver?) is an INPUT supplied by the
+/// round's `arbiter` — the Proof-of-Task-Execution (PoTE) seam, the one unsolved
+/// part of Bet B. The proof says nothing about whether delivery truly occurred.
+/// See `docs/rfcs/credible-clearing-settlement.md`.
+contract CredibleSettlement {
+    // ── Proven constants (mirror Lean `bpsScale` / Rust `BPS_SCALE`) ────────
+    uint64 internal constant BPS_SCALE = 10_000;
+
+    enum Verdict {
+        Reverse, // deliveredBps == 0
+        Partial, // 0 < deliveredBps < 10_000
+        Release // deliveredBps >= 10_000
+    }
+
+    enum Phase {
+        None,
+        Open, // funds escrowed, awaiting reveal + post
+        Posted, // clearing posted + bonded, challenge window open
+        Settled, // split executed to seller + buyer
+        Reversed // challenged or arbiter-reversed: buyer fully refunded
+    }
+
+    struct Round {
+        address buyer; // escrowed the cleared price
+        address seller; // paid `sellerGross` on delivery
+        address arbiter; // supplies `deliveredBps` (the PoTE oracle seam)
+        uint256 price; // escrowed cleared price (native wei, testnet)
+        bytes32 commitmentSetRoot; // anchored sealed-bid set (completeness)
+        uint64 revealDeadline; // bids open (off-chain drand timelock) after this
+        address poster; // posted the optimistic clearing claim
+        uint256 bond; // poster's bond, slashed to commons on a valid challenge
+        bytes32 revealedBidsHash; // hash of the revealed bids the poster claims
+        uint256 clearedPriceMicro; // claimed cleared price (audit; must == price)
+        uint64 challengeDeadline; // settle allowed only after this, if unchallenged
+        Phase phase;
+    }
+
+    // Immutable commons split (set at construction; sum MUST be 10_000 bps).
+    address[] public commonsDestinations;
+    uint64[] public commonsBps;
+
+    mapping(bytes32 => Round) private _rounds;
+
+    event RoundOpened(
+        bytes32 indexed roundId,
+        address indexed buyer,
+        address indexed seller,
+        uint256 price,
+        bytes32 commitmentSetRoot,
+        uint64 revealDeadline
+    );
+    event ClearingPosted(
+        bytes32 indexed roundId,
+        address indexed poster,
+        bytes32 revealedBidsHash,
+        uint256 clearedPriceMicro,
+        uint256 bond,
+        uint64 challengeDeadline
+    );
+    event Challenged(bytes32 indexed roundId, address indexed challenger, uint256 slashedToCommons);
+    event Settled(
+        bytes32 indexed roundId, Verdict verdict, uint64 deliveredBps, uint256 sellerGrossPaid, uint256 refundPaid
+    );
+    event CommonsAllocated(bytes32 indexed roundId, address indexed destination, uint256 amount);
+
+    error BadCommonsShares(uint64 sumBps);
+    error WrongPhase();
+    error NotArbiter();
+    error RevealNotReached();
+    error ChallengeWindowOpen();
+    error ChallengeWindowClosed();
+    error ZeroPrice();
+    error InsufficientBond();
+    error TransferFailed();
+
+    /// @param destinations commons payout addresses (carbon removal, affected-party, verifier commons, …)
+    /// @param bps          their basis-point shares; MUST sum to exactly 10_000
+    constructor(address[] memory destinations, uint64[] memory bps) {
+        if (destinations.length == 0 || destinations.length != bps.length) {
+            revert BadCommonsShares(0);
+        }
+        uint64 sum;
+        for (uint256 i = 0; i < bps.length; i++) {
+            sum += bps[i];
+        }
+        if (sum != BPS_SCALE) revert BadCommonsShares(sum);
+        commonsDestinations = destinations;
+        commonsBps = bps;
+    }
+
+    // ── Proven decision core (mirror of settlement.rs / SettlementDecision.lean) ──
+
+    /// Mirror of Rust `classify` / Lean `classify`.
+    function classify(uint64 deliveredBps) public pure returns (Verdict) {
+        if (deliveredBps == 0) return Verdict.Reverse;
+        if (deliveredBps < BPS_SCALE) return Verdict.Partial;
+        return Verdict.Release;
+    }
+
+    /// Mirror of Rust `seller_gross` / Lean `sellerGross`: `price * min(bps,10000) / 10000`.
+    /// Solidity `uint256` arithmetic gives the same value as the Rust `u128` intermediate.
+    function sellerGross(uint256 priceMicro, uint64 deliveredBps) public pure returns (uint256) {
+        uint256 bps = deliveredBps < BPS_SCALE ? deliveredBps : BPS_SCALE;
+        return (priceMicro * bps) / BPS_SCALE;
+    }
+
+    /// Mirror of Rust `refund` / Lean: the residual, so `sellerGross + refund == price` exactly.
+    function refund(uint256 priceMicro, uint64 deliveredBps) public pure returns (uint256) {
+        return priceMicro - sellerGross(priceMicro, deliveredBps);
+    }
+
+    /// Mirror of Rust `route_to_commons` / `nucleus-econ-kernels::commons`: proportional
+    /// split with integer-division dust assigned to the FIRST destination, so the
+    /// allocations sum to EXACTLY `pool` (no skim). Pure/auditable.
+    function routeToCommons(uint256 pool) public view returns (uint256[] memory amounts) {
+        uint256 n = commonsBps.length;
+        amounts = new uint256[](n);
+        uint256 allocated;
+        for (uint256 i = 0; i < n; i++) {
+            amounts[i] = (pool * commonsBps[i]) / BPS_SCALE;
+            allocated += amounts[i];
+        }
+        amounts[0] += pool - allocated; // dust → first (Σ == pool)
+    }
+
+    // ── Optimistic settlement lifecycle ────────────────────────────────────
+
+    /// Buyer opens a round and escrows the cleared price (`msg.value`).
+    function openRound(
+        bytes32 roundId,
+        address seller,
+        address arbiter,
+        bytes32 commitmentSetRoot,
+        uint64 revealDeadline
+    ) external payable {
+        if (_rounds[roundId].phase != Phase.None) revert WrongPhase();
+        if (msg.value == 0) revert ZeroPrice();
+        _rounds[roundId] = Round({
+            buyer: msg.sender,
+            seller: seller,
+            arbiter: arbiter,
+            price: msg.value,
+            commitmentSetRoot: commitmentSetRoot,
+            revealDeadline: revealDeadline,
+            poster: address(0),
+            bond: 0,
+            revealedBidsHash: bytes32(0),
+            clearedPriceMicro: 0,
+            challengeDeadline: 0,
+            phase: Phase.Open
+        });
+        emit RoundOpened(roundId, msg.sender, seller, msg.value, commitmentSetRoot, revealDeadline);
+    }
+
+    /// Anyone (an untrusted "sequencer") posts the revealed bids + claimed clearing,
+    /// bonding `msg.value`. Allowed only after the reveal deadline. Opens a
+    /// challenge window of `challengeWindowSecs`.
+    function postClearing(
+        bytes32 roundId,
+        bytes32 revealedBidsHash,
+        uint256 clearedPriceMicro,
+        uint64 challengeWindowSecs
+    ) external payable {
+        Round storage r = _rounds[roundId];
+        if (r.phase != Phase.Open) revert WrongPhase();
+        if (block.timestamp < r.revealDeadline) revert RevealNotReached();
+        if (msg.value == 0) revert InsufficientBond();
+        r.poster = msg.sender;
+        r.bond = msg.value;
+        r.revealedBidsHash = revealedBidsHash;
+        r.clearedPriceMicro = clearedPriceMicro;
+        r.challengeDeadline = uint64(block.timestamp) + challengeWindowSecs;
+        r.phase = Phase.Posted;
+        emit ClearingPosted(roundId, msg.sender, revealedBidsHash, clearedPriceMicro, msg.value, r.challengeDeadline);
+    }
+
+    /// A watcher who ran the off-chain recompute and found the posted clearing
+    /// wrong challenges within the window: the poster's bond is routed to the
+    /// commons (anti-grief, non-extractive) and the round safely REVERSES — the
+    /// buyer is fully refunded. (Adjudicating poster-vs-challenger instead of
+    /// always reversing is B3; not claimed here.)
+    function challenge(bytes32 roundId) external {
+        Round storage r = _rounds[roundId];
+        if (r.phase != Phase.Posted) revert WrongPhase();
+        if (block.timestamp >= r.challengeDeadline) revert ChallengeWindowClosed();
+        uint256 slashed = r.bond;
+        r.bond = 0;
+        r.phase = Phase.Reversed;
+        // Slashed bond → commons; buyer refunded the full escrowed price.
+        _payCommons(roundId, slashed);
+        _send(r.buyer, r.price);
+        emit Challenged(roundId, msg.sender, slashed);
+    }
+
+    /// After an unchallenged window, the arbiter supplies `deliveredBps` (the PoTE
+    /// seam) and the contract executes the PROVEN split on-chain: `sellerGross` to
+    /// the seller, `refund` to the buyer, and returns the poster's bond. The split
+    /// runs the exact mirrored functions — conservation (`sellerGross + refund ==
+    /// price`) holds by construction.
+    function settle(bytes32 roundId, uint64 deliveredBps) external {
+        Round storage r = _rounds[roundId];
+        if (r.phase != Phase.Posted) revert WrongPhase();
+        if (block.timestamp < r.challengeDeadline) revert ChallengeWindowOpen();
+        if (msg.sender != r.arbiter) revert NotArbiter();
+
+        Verdict v = classify(deliveredBps);
+        uint256 toSeller = sellerGross(r.price, deliveredBps);
+        uint256 toBuyer = refund(r.price, deliveredBps);
+        uint256 bond = r.bond;
+        r.bond = 0;
+        r.phase = Phase.Settled;
+
+        if (toSeller > 0) _send(r.seller, toSeller);
+        if (toBuyer > 0) _send(r.buyer, toBuyer);
+        if (bond > 0) _send(r.poster, bond); // honest poster reclaims bond
+
+        emit Settled(roundId, v, deliveredBps, toSeller, toBuyer);
+    }
+
+    // ── Views ───────────────────────────────────────────────────────────────
+
+    function phaseOf(bytes32 roundId) external view returns (Phase) {
+        return _rounds[roundId].phase;
+    }
+
+    function roundOf(bytes32 roundId) external view returns (Round memory) {
+        return _rounds[roundId];
+    }
+
+    // ── Internals ─────────────────────────────────────────────────────────────
+
+    function _payCommons(bytes32 roundId, uint256 pool) internal {
+        if (pool == 0) return;
+        uint256[] memory amounts = routeToCommons(pool);
+        for (uint256 i = 0; i < amounts.length; i++) {
+            if (amounts[i] > 0) {
+                _send(commonsDestinations[i], amounts[i]);
+                emit CommonsAllocated(roundId, commonsDestinations[i], amounts[i]);
+            }
+        }
+    }
+
+    function _send(address to, uint256 amount) internal {
+        (bool ok,) = payable(to).call{value: amount}("");
+        if (!ok) revert TransferFailed();
+    }
+}

--- a/examples/marketplace-live/contracts/test/CredibleSettlement.t.sol
+++ b/examples/marketplace-live/contracts/test/CredibleSettlement.t.sol
@@ -1,0 +1,258 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+import {CredibleSettlement} from "../src/CredibleSettlement.sol";
+
+/// Parity + lifecycle tests for the optimistic credible-clearing settlement.
+///
+/// The `parity_*` tests mirror, vector-for-vector, the Rust parity tests in
+/// `crates/nucleus-econ-kernels/src/settlement.rs` and `::commons.rs` (themselves
+/// parity-pinned to `SettlementDecision.lean`). They are what BIND the on-chain
+/// money path to the Lean proof: if the Solidity diverges from the proven
+/// function, these fail.
+contract CredibleSettlementTest is Test {
+    CredibleSettlement settlement;
+
+    // Mirror of commons.rs `example_splits()`: 60% carbon / 25% affected / 15% commons.
+    address constant CARBON = address(0xC0);
+    address constant AFFECTED = address(0xA1);
+    address constant COMMONS = address(0xC5);
+
+    address constant BUYER = address(0xB0);
+    address constant SELLER = address(0x5E);
+    address constant ARBITER = address(0xA2);
+    address constant POSTER = address(0x90);
+    address constant WATCHER = address(0x77);
+
+    function setUp() public {
+        address[] memory dests = new address[](3);
+        dests[0] = CARBON;
+        dests[1] = AFFECTED;
+        dests[2] = COMMONS;
+        uint64[] memory bps = new uint64[](3);
+        bps[0] = 6_000;
+        bps[1] = 2_500;
+        bps[2] = 1_500;
+        settlement = new CredibleSettlement(dests, bps);
+    }
+
+    // ── Parity: classify (settlement.rs::classify_matches_lean_total) ──────────
+
+    function test_parity_classify() public view {
+        assertEq(uint8(settlement.classify(0)), uint8(CredibleSettlement.Verdict.Reverse));
+        assertEq(uint8(settlement.classify(1)), uint8(CredibleSettlement.Verdict.Partial));
+        assertEq(uint8(settlement.classify(9_999)), uint8(CredibleSettlement.Verdict.Partial));
+        assertEq(uint8(settlement.classify(10_000)), uint8(CredibleSettlement.Verdict.Release));
+        assertEq(uint8(settlement.classify(50_000)), uint8(CredibleSettlement.Verdict.Release));
+    }
+
+    // ── Parity: release/reverse extremes (release_is_full_payout_reverse…) ─────
+
+    function test_parity_release_and_reverse_extremes() public view {
+        assertEq(settlement.sellerGross(1_000_000, 10_000), 1_000_000);
+        assertEq(settlement.refund(1_000_000, 10_000), 0);
+        assertEq(settlement.sellerGross(1_000_000, 0), 0);
+        assertEq(settlement.refund(1_000_000, 0), 1_000_000);
+    }
+
+    // ── Parity: conservation battery (conservation_holds_for_a_battery_of_inputs) ─
+
+    function test_parity_conservation_battery() public view {
+        uint256[6] memory prices =
+            [uint256(0), 1, 999, 1_000_000, 7_654_321, uint256(type(uint64).max) / 2];
+        uint64[7] memory bpsCases = [uint64(0), 1, 2_500, 5_000, 9_999, 10_000, 25_000];
+        for (uint256 i = 0; i < prices.length; i++) {
+            for (uint256 j = 0; j < bpsCases.length; j++) {
+                uint256 g = settlement.sellerGross(prices[i], bpsCases[j]);
+                uint256 r = settlement.refund(prices[i], bpsCases[j]);
+                assertEq(g + r, prices[i], "conservation violated");
+                assertLe(g, prices[i], "sellerGross <= price");
+            }
+        }
+    }
+
+    // ── Parity: monotone gross / antitone refund (seller_gross_monotone…) ──────
+
+    function test_parity_monotone_gross_antitone_refund() public view {
+        uint256 price = 1_000_000;
+        uint64[5] memory bpsCases = [uint64(0), 1_000, 5_000, 9_000, 10_000];
+        uint256 lastGross;
+        uint256 lastRefund = price;
+        for (uint256 i = 0; i < bpsCases.length; i++) {
+            uint256 g = settlement.sellerGross(price, bpsCases[i]);
+            uint256 r = settlement.refund(price, bpsCases[i]);
+            assertGe(g, lastGross, "gross must be monotone");
+            assertLe(r, lastRefund, "refund must be antitone");
+            lastGross = g;
+            lastRefund = r;
+        }
+    }
+
+    // ── Parity: commons routing (commons.rs::proportional_split + conservation) ─
+
+    function test_parity_commons_proportional_and_dust() public view {
+        uint256[] memory a = settlement.routeToCommons(1_000_000);
+        assertEq(a[0], 600_000); // 60%
+        assertEq(a[1], 250_000); // 25%
+        assertEq(a[2], 150_000); // 15%
+
+        // Dusty pool=7: 4/1/1 = 6, dust 1 → first = 5 (matches the Rust test).
+        uint256[] memory d = settlement.routeToCommons(7);
+        assertEq(d[0], 5);
+        assertEq(d[1], 1);
+        assertEq(d[2], 1);
+        assertEq(d[0] + d[1] + d[2], 7, "commons no-skim");
+    }
+
+    function test_parity_commons_no_skim_battery() public view {
+        uint256[5] memory pools = [uint256(0), 1, 7, 1_000_000, 9_999_999];
+        for (uint256 i = 0; i < pools.length; i++) {
+            uint256[] memory a = settlement.routeToCommons(pools[i]);
+            assertEq(a[0] + a[1] + a[2], pools[i], "skim/loss");
+        }
+    }
+
+    function test_constructor_rejects_bad_shares() public {
+        address[] memory dests = new address[](2);
+        dests[0] = CARBON;
+        dests[1] = AFFECTED;
+        uint64[] memory bps = new uint64[](2);
+        bps[0] = 5_000;
+        bps[1] = 4_000; // sums to 9_000
+        vm.expectRevert(abi.encodeWithSelector(CredibleSettlement.BadCommonsShares.selector, uint64(9_000)));
+        new CredibleSettlement(dests, bps);
+    }
+
+    // ── Lifecycle: happy path (release) self-executes the proven split ─────────
+
+    function _open(bytes32 id, uint256 price) internal {
+        vm.deal(BUYER, price);
+        vm.prank(BUYER);
+        settlement.openRound{value: price}(id, SELLER, ARBITER, keccak256("root"), uint64(block.timestamp + 100));
+    }
+
+    function _post(bytes32 id, uint256 bond, uint256 priceMicro) internal {
+        vm.warp(block.timestamp + 101); // past reveal deadline
+        vm.deal(POSTER, bond);
+        vm.prank(POSTER);
+        settlement.postClearing{value: bond}(id, keccak256("bids"), priceMicro, 50);
+    }
+
+    function test_lifecycle_release_pays_seller_in_full() public {
+        bytes32 id = keccak256("r1");
+        uint256 price = 1 ether;
+        _open(id, price);
+        _post(id, 0.1 ether, 1_000_000);
+        vm.warp(block.timestamp + 51); // past challenge window
+
+        vm.prank(ARBITER);
+        settlement.settle(id, 10_000); // fully delivered
+
+        assertEq(SELLER.balance, price, "seller paid full price");
+        assertEq(POSTER.balance, 0.1 ether, "honest poster reclaims bond");
+        assertEq(uint8(settlement.phaseOf(id)), uint8(CredibleSettlement.Phase.Settled));
+    }
+
+    function test_lifecycle_partial_splits_seller_and_buyer() public {
+        bytes32 id = keccak256("r2");
+        uint256 price = 1 ether;
+        _open(id, price);
+        _post(id, 0.1 ether, 1_000_000);
+        vm.warp(block.timestamp + 51);
+
+        vm.prank(ARBITER);
+        settlement.settle(id, 2_500); // 25% delivered
+
+        assertEq(SELLER.balance, price / 4, "seller gets 25%");
+        assertEq(BUYER.balance, price - price / 4, "buyer refunded 75%");
+    }
+
+    function test_lifecycle_reverse_refunds_buyer_fully() public {
+        bytes32 id = keccak256("r3");
+        uint256 price = 1 ether;
+        _open(id, price);
+        _post(id, 0.1 ether, 1_000_000);
+        vm.warp(block.timestamp + 51);
+
+        vm.prank(ARBITER);
+        settlement.settle(id, 0); // nothing delivered
+
+        assertEq(BUYER.balance, price, "buyer fully refunded");
+        assertEq(SELLER.balance, 0, "seller gets nothing");
+    }
+
+    // ── Lifecycle: challenge slashes bond to commons + reverses ────────────────
+
+    function test_challenge_slashes_bond_to_commons_and_refunds_buyer() public {
+        bytes32 id = keccak256("r4");
+        uint256 price = 1 ether;
+        uint256 bond = 0.1 ether;
+        _open(id, price);
+        _post(id, bond, 1_000_000);
+
+        vm.prank(WATCHER);
+        settlement.challenge(id); // within window
+
+        // Buyer refunded the full escrowed price.
+        assertEq(BUYER.balance, price, "buyer refunded on reversal");
+        // Bond routed to commons 60/25/15 with no skim.
+        assertEq(CARBON.balance, (bond * 6_000) / 10_000);
+        assertEq(AFFECTED.balance, (bond * 2_500) / 10_000);
+        assertEq(COMMONS.balance, (bond * 1_500) / 10_000);
+        assertEq(CARBON.balance + AFFECTED.balance + COMMONS.balance, bond, "commons no-skim");
+        assertEq(uint8(settlement.phaseOf(id)), uint8(CredibleSettlement.Phase.Reversed));
+    }
+
+    function test_challenge_after_window_reverts() public {
+        bytes32 id = keccak256("r5");
+        _open(id, 1 ether);
+        _post(id, 0.1 ether, 1_000_000);
+        vm.warp(block.timestamp + 51); // window closed
+        vm.expectRevert(CredibleSettlement.ChallengeWindowClosed.selector);
+        vm.prank(WATCHER);
+        settlement.challenge(id);
+    }
+
+    function test_settle_before_window_closes_reverts() public {
+        bytes32 id = keccak256("r6");
+        _open(id, 1 ether);
+        _post(id, 0.1 ether, 1_000_000);
+        vm.expectRevert(CredibleSettlement.ChallengeWindowOpen.selector);
+        vm.prank(ARBITER);
+        settlement.settle(id, 10_000);
+    }
+
+    function test_settle_only_by_arbiter() public {
+        bytes32 id = keccak256("r7");
+        _open(id, 1 ether);
+        _post(id, 0.1 ether, 1_000_000);
+        vm.warp(block.timestamp + 51);
+        vm.expectRevert(CredibleSettlement.NotArbiter.selector);
+        vm.prank(WATCHER);
+        settlement.settle(id, 10_000);
+    }
+
+    function test_post_before_reveal_reverts() public {
+        bytes32 id = keccak256("r8");
+        _open(id, 1 ether);
+        vm.deal(POSTER, 0.1 ether);
+        vm.expectRevert(CredibleSettlement.RevealNotReached.selector);
+        vm.prank(POSTER);
+        settlement.postClearing{value: 0.1 ether}(id, keccak256("bids"), 1_000_000, 50);
+    }
+
+    // Fuzz: conservation must hold on-chain for arbitrary price × delivery.
+    function testFuzz_conservation(uint128 price, uint64 bps) public view {
+        uint256 g = settlement.sellerGross(price, bps);
+        uint256 r = settlement.refund(price, bps);
+        assertEq(g + r, uint256(price));
+        assertLe(g, uint256(price));
+    }
+
+    // Fuzz: commons routing never skims or over-allocates.
+    function testFuzz_commons_no_skim(uint128 pool) public view {
+        uint256[] memory a = settlement.routeToCommons(pool);
+        assertEq(a[0] + a[1] + a[2], uint256(pool));
+    }
+}


### PR DESCRIPTION
## What

`examples/marketplace-live/contracts/src/CredibleSettlement.sol` — the **Bet B
B2** optimistic credible-clearing settlement contract. It removes the *trusted
auctioneer*: the verified settlement **self-executes on-chain**, so no one must be
trusted to *act* on the outcome.

**Lifecycle:** buyer `openRound` (escrows the cleared price) → an untrusted poster
`postClearing` (+bond, after the reveal deadline) → challenge window → `settle`
(the arbiter supplies `deliveredBps`).

## The load-bearing property — the money path runs the *exact* proven function

`classify` / `sellerGross` / `refund` and `routeToCommons` are a **byte-for-byte
Solidity mirror** of `nucleus-econ-kernels::settlement` / `::commons`, which are
parity-pinned to `SettlementDecision.lean`. `sellerGross + refund == price` holds
by construction. `test/CredibleSettlement.t.sol`'s `test_parity_*` cases mirror
the **same vectors** as the Rust tests — they bind the on-chain split to the Lean
proof; if the Solidity drifts, they fail.

```
17 tests: parity (classify / conservation battery / monotone / commons no-skim +
dust) + lifecycle (release / partial / reverse / challenge→commons) + fuzz — all green.
```

## Social-good wiring

A valid `challenge()` slashes the poster's bond **to the commons** (60/25/15
carbon-removal / affected-party / verifier-commons, the same proven `routeToCommons`
split) — anti-grief, non-extractive. Cheating is unprofitable *without* running VCG
on-chain.

## Honesty boundary (NatSpec + RFC)

- The cleared **price** is posted **optimistically** — off-chain recompute is the
  fraud proof. A challenge **reverses** (safe fallback); it does not yet adjudicate
  poster-vs-challenger (that's B3, needs interactive proofs / on-chain commit).
- `deliveredBps` is an **arbiter input** — the unsolved **PoTE** seam. The proof
  says nothing about whether delivery truly happened.
- **Testnet only**; native-value escrow for v1. Mainnet needs the custody posture
  + audit.

## Notes

- `forge-std` is not vendored (`/lib` is gitignored); the README documents the
  one-line fetch + `forge test`.
- Independent of #1748 / #1749 — only mirrors `settlement.rs`/`commons.rs` already
  in `main` (#1747).

Updates `docs/rfcs/credible-clearing-settlement.md` (B2 → shipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)