### PR TITLE
feat(externality): assurance rung — derive how-much-to-trust a claim (O1)

### DIFF
--- a/crates/nucleus-externality/src/assurance.rs
+++ b/crates/nucleus-externality/src/assurance.rs
@@ -1,0 +1,199 @@
+//! Assurance rung — *how much trust* an externality claim's `units_micro`
+//! demands, as a single machine-readable ordinal.
+//!
+//! The Pigouvian charge is `λ · units_micro / 1e6`. We publish + unit-test `λ`
+//! (verifiable). `units_micro` is the *attested consumption* — exactly as honest
+//! as the oracle behind it. This module turns "how honest is it?" from a footnote
+//! into a checkable field: the **assurance rung**.
+//!
+//! ## Derived, not asserted
+//!
+//! The rung is **derived from what actually verified**, never self-asserted by
+//! the claimant. [`assess_rung`] takes the boolean outcomes of the independent
+//! verification layers (signature, TEE attestation, multi-source dispute, zk
+//! upper-envelope — see [`crate::oracle`]) and returns the highest rung whose
+//! property holds. So a claim cannot *lie* about its rung: a higher rung requires
+//! the corresponding verification to actually pass.
+//!
+//! ## A profile is only as honest as its weakest claim
+//!
+//! An [`crate::ExternalityProfile`] bundles one claim per dimension; its overall
+//! assurance is the **minimum** rung across its claims
+//! ([`crate::ExternalityProfile::min_assurance_rung`]) — the weakest link, the
+//! number a consumer of the receipt should actually trust.
+//!
+//! See `docs/rfcs/externality-oracle.md` for the full trust-residue ladder and
+//! the irreducible rung-5 residue (the physical sensor) that no rung removes.
+
+use serde::{Deserialize, Serialize};
+
+/// The achieved assurance rung for an externality claim — smaller rung = larger
+/// trusted surface. Ordered: `SelfReported < OracleSigned < TeeAttested <
+/// MultiSourceDisputed < ZkUpperEnvelope`.
+///
+/// **Derive this with [`assess_rung`]; do not let a claimant set it directly.**
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AssuranceRung {
+    /// **R0** — self-reported, no independent verification. The greenwashing
+    /// baseline; the trusted surface is the claimant itself. We never emit this
+    /// for a *verified* claim — it is the floor a failed verification falls to.
+    SelfReported,
+    /// **R1** — an independent oracle's Ed25519 signature verified (fresh, bound
+    /// to the subject identity + resource tag). The floor for any verified
+    /// [`crate::SignedExternalityClaim`]. Trusted surface: the oracle operator.
+    OracleSigned,
+    /// **R2** — additionally TEE-attested: the units came out of an attested
+    /// enclave running known code ([`crate::TeeAttestation`]). The operator can
+    /// no longer silently alter the number — only feed a bad input.
+    TeeAttested,
+    /// **R3** — additionally corroborated by multiple independent sources under a
+    /// staked optimistic-oracle dispute window (the UMA pattern; reuse the Bet B
+    /// bond/challenge machinery). Trusted surface: a majority of feeds + no
+    /// profitable undisputed lie. Not derivable from a single claim in isolation
+    /// — the aggregation layer supplies the `multi_source_disputed` flag.
+    MultiSourceDisputed,
+    /// **R4** — additionally bounded above by a verified zk upper-envelope proof
+    /// ([`crate::UpperEnvelopeProof`]): over-claiming is impossible without
+    /// detection. Trusted surface: the public model + its public inputs.
+    ZkUpperEnvelope,
+}
+
+impl AssuranceRung {
+    /// The ordinal level (0..=4). Higher = smaller trusted surface.
+    pub fn level(self) -> u8 {
+        match self {
+            AssuranceRung::SelfReported => 0,
+            AssuranceRung::OracleSigned => 1,
+            AssuranceRung::TeeAttested => 2,
+            AssuranceRung::MultiSourceDisputed => 3,
+            AssuranceRung::ZkUpperEnvelope => 4,
+        }
+    }
+
+    /// A short stable label for receipts / dashboards (matches the serde tag).
+    pub fn label(self) -> &'static str {
+        match self {
+            AssuranceRung::SelfReported => "self_reported",
+            AssuranceRung::OracleSigned => "oracle_signed",
+            AssuranceRung::TeeAttested => "tee_attested",
+            AssuranceRung::MultiSourceDisputed => "multi_source_disputed",
+            AssuranceRung::ZkUpperEnvelope => "zk_upper_envelope",
+        }
+    }
+}
+
+/// Derive the achieved [`AssuranceRung`] from the outcomes of the independent
+/// verification layers. Each argument is "did this layer verify?":
+///
+/// - `signature_ok` — the Ed25519 oracle signature verified (fresh, bound).
+/// - `tee_ok` — a TEE attestation over the oracle key verified.
+/// - `multi_source_disputed` — the value was corroborated by ≥2 independent
+///   sources under a staked dispute window that elapsed unchallenged.
+/// - `zk_envelope_ok` — a zk upper-envelope proof bounded `units_micro` and
+///   verified.
+///
+/// Returns the **highest rung whose property holds**. A higher rung never
+/// implies a lower one mechanically (TEE+envelope without a dispute is genuine
+/// R4), but every rung above R0 requires `signature_ok` — an unsigned claim is
+/// self-reported no matter what else is attached.
+pub fn assess_rung(
+    signature_ok: bool,
+    tee_ok: bool,
+    multi_source_disputed: bool,
+    zk_envelope_ok: bool,
+) -> AssuranceRung {
+    // Without an independent signature there is no independent verification at
+    // all — everything else is attached by the same untrusted party.
+    if !signature_ok {
+        return AssuranceRung::SelfReported;
+    }
+    // Highest satisfied property wins. zk-envelope and multi-source are both
+    // strictly stronger than bare TEE; envelope (over-claim-proof) is the
+    // strongest single guarantee we can derive today.
+    if zk_envelope_ok {
+        AssuranceRung::ZkUpperEnvelope
+    } else if multi_source_disputed {
+        AssuranceRung::MultiSourceDisputed
+    } else if tee_ok {
+        AssuranceRung::TeeAttested
+    } else {
+        AssuranceRung::OracleSigned
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ordering_is_monotone_in_level() {
+        let ladder = [
+            AssuranceRung::SelfReported,
+            AssuranceRung::OracleSigned,
+            AssuranceRung::TeeAttested,
+            AssuranceRung::MultiSourceDisputed,
+            AssuranceRung::ZkUpperEnvelope,
+        ];
+        for w in ladder.windows(2) {
+            assert!(w[0] < w[1], "rung order must match trusted-surface size");
+            assert!(w[0].level() < w[1].level(), "level must agree with Ord");
+        }
+    }
+
+    #[test]
+    fn unsigned_is_always_self_reported() {
+        // No matter what evidence is attached, no independent signature = R0.
+        assert_eq!(
+            assess_rung(false, true, true, true),
+            AssuranceRung::SelfReported
+        );
+    }
+
+    #[test]
+    fn bare_signature_is_r1() {
+        assert_eq!(
+            assess_rung(true, false, false, false),
+            AssuranceRung::OracleSigned
+        );
+    }
+
+    #[test]
+    fn signature_plus_tee_is_r2() {
+        assert_eq!(
+            assess_rung(true, true, false, false),
+            AssuranceRung::TeeAttested
+        );
+    }
+
+    #[test]
+    fn multi_source_outranks_tee() {
+        assert_eq!(
+            assess_rung(true, true, true, false),
+            AssuranceRung::MultiSourceDisputed
+        );
+    }
+
+    #[test]
+    fn zk_envelope_is_the_top_derivable_rung() {
+        // Envelope present → R4 even without a dispute window (genuinely the
+        // strongest single guarantee: over-claiming is detectable).
+        assert_eq!(
+            assess_rung(true, true, false, true),
+            AssuranceRung::ZkUpperEnvelope
+        );
+        assert_eq!(
+            assess_rung(true, true, true, true),
+            AssuranceRung::ZkUpperEnvelope
+        );
+    }
+
+    #[test]
+    fn labels_match_serde_tags() {
+        let v = AssuranceRung::ZkUpperEnvelope;
+        let json = serde_json::to_string(&v).unwrap();
+        assert_eq!(json, format!("\"{}\"", v.label()));
+        let back: AssuranceRung = serde_json::from_str(&json).unwrap();
+        assert_eq!(v, back);
+    }
+}

--- a/crates/nucleus-externality/src/lib.rs
+++ b/crates/nucleus-externality/src/lib.rs
@@ -41,18 +41,20 @@
 
 #![deny(clippy::float_arithmetic)]
 
+mod assurance;
 mod claim;
 mod dim;
 mod oracle;
 mod profile;
 
+pub use assurance::{assess_rung, AssuranceRung};
 pub use claim::{
     canonical_claim_bytes, sign_claim, verify_claim, ClaimError, SignedExternalityClaim,
 };
 pub use dim::{ResourceDim, RESOURCE_DIM_DOMAIN};
 pub use oracle::{
-    verify_vca_claim, OracleError, OracleRegistry, TeeAttestation, TeeVendor, UpperEnvelopeProof,
-    VcaExternalityClaim,
+    verify_vca_claim, verify_vca_claim_rung, OracleError, OracleRegistry, TeeAttestation,
+    TeeVendor, UpperEnvelopeProof, VcaExternalityClaim,
 };
 pub use profile::{
     canonical_externality_bytes, externality_digest, ExternalityProfile, PROFILE_DOMAIN,

--- a/crates/nucleus-externality/src/oracle.rs
+++ b/crates/nucleus-externality/src/oracle.rs
@@ -32,6 +32,7 @@ use ed25519_dalek::VerifyingKey;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+use crate::assurance::{assess_rung, AssuranceRung};
 use crate::claim::{verify_claim, ClaimError, SignedExternalityClaim};
 use crate::dim::ResourceDim;
 
@@ -167,6 +168,31 @@ pub fn verify_vca_claim(
     verify_claim(&vca.claim, oracle_vk, expected_subject, now_unix_micros)
         .map_err(OracleError::Claim)?;
     Ok(())
+}
+
+/// Verify a `VcaExternalityClaim` AND report the [`AssuranceRung`] it achieved.
+///
+/// On success the rung is **derived from what actually verified** (signature +
+/// TEE + zk upper-envelope all passed) — never self-asserted. A bare
+/// [`VcaExternalityClaim`] carries both the TEE quote and the envelope proof, so
+/// a full pass derives [`AssuranceRung::ZkUpperEnvelope`] (R4). Multi-source
+/// dispute (R3) is supplied by the aggregation layer, not a single claim, so it
+/// is `false` here.
+///
+/// Fails closed: any failing layer returns the error (the rung is *not* reported
+/// for an unverified claim — that would be the self-reported floor).
+pub fn verify_vca_claim_rung(
+    vca: &VcaExternalityClaim,
+    oracle_vk: &VerifyingKey,
+    expected_subject: &str,
+    now_unix_micros: u64,
+) -> Result<AssuranceRung, OracleError> {
+    verify_vca_claim(vca, oracle_vk, expected_subject, now_unix_micros)?;
+    // All three layers verified: signature ✓, TEE ✓, zk-envelope ✓.
+    Ok(assess_rung(
+        /* signature_ok */ true, /* tee_ok */ true,
+        /* multi_source_disputed */ false, /* zk_envelope_ok */ true,
+    ))
 }
 
 /// **S4 — Per-dimension oracle key registry.**
@@ -353,6 +379,42 @@ mod tests {
             1_700_000_000_000_001,
         )
         .unwrap();
+    }
+
+    #[test]
+    fn full_vca_derives_rung_r4() {
+        let vca = VcaExternalityClaim {
+            claim: fixture_claim(1_000),
+            tee: fixture_tee(),
+            envelope: fixture_envelope(1_500),
+        };
+        let vk = oracle_sk().verifying_key();
+        let rung = verify_vca_claim_rung(
+            &vca,
+            &vk,
+            "spiffe://nucleus.io/ns/agents/sa/a1",
+            1_700_000_000_000_001,
+        )
+        .unwrap();
+        assert_eq!(rung, AssuranceRung::ZkUpperEnvelope);
+    }
+
+    #[test]
+    fn rung_not_reported_for_failed_verification() {
+        // Over-claim breaks the envelope layer → error, NOT a rung.
+        let vca = VcaExternalityClaim {
+            claim: fixture_claim(2_000),
+            tee: fixture_tee(),
+            envelope: fixture_envelope(1_000),
+        };
+        let vk = oracle_sk().verifying_key();
+        assert!(verify_vca_claim_rung(
+            &vca,
+            &vk,
+            "spiffe://nucleus.io/ns/agents/sa/a1",
+            1_700_000_000_000_001,
+        )
+        .is_err());
     }
 
     #[test]

--- a/crates/nucleus-externality/src/profile.rs
+++ b/crates/nucleus-externality/src/profile.rs
@@ -78,6 +78,24 @@ impl ExternalityProfile {
     pub fn is_empty(&self) -> bool {
         self.dimensions.is_empty()
     }
+
+    /// The profile's overall assurance: the **minimum** rung across its claims —
+    /// a bundle is only as trustworthy as its weakest-attested dimension. The
+    /// caller supplies `rung_of`, which derives each claim's achieved rung from
+    /// its verification outcomes (see [`crate::assess_rung`]); keeping it a
+    /// closure lets the verifier plug in TEE / dispute / envelope checks without
+    /// this crate depending on them.
+    ///
+    /// Returns `None` for an empty profile (no claims → no assurance to report).
+    pub fn min_assurance_rung(
+        &self,
+        rung_of: impl Fn(&crate::dim::ResourceDim, &SignedExternalityClaim) -> crate::AssuranceRung,
+    ) -> Option<crate::AssuranceRung> {
+        self.dimensions
+            .iter()
+            .map(|(dim, claim)| rung_of(dim, claim))
+            .min()
+    }
 }
 
 /// Canonical bytes for the whole profile, used as the digest input
@@ -249,5 +267,43 @@ mod tests {
     #[test]
     fn domain_prefix_is_versioned() {
         assert_eq!(PROFILE_DOMAIN, b"nucleus/externality/profile/v1\0");
+    }
+
+    #[test]
+    fn min_assurance_rung_is_the_weakest_link() {
+        use crate::AssuranceRung;
+        let mut p = ExternalityProfile::new();
+        p.insert(
+            ResourceDim::GpuSeconds,
+            mk_claim(ResourceDim::GpuSeconds, 1_000_000),
+        );
+        p.insert(
+            ResourceDim::GridCarbonGramsCo2,
+            mk_claim(ResourceDim::GridCarbonGramsCo2, 500_000),
+        );
+
+        // Carbon is the strongly-attested one (R4), GPU is only signed (R1):
+        // the profile's overall rung is the MINIMUM = R1.
+        let rung = p
+            .min_assurance_rung(|dim, _claim| match dim {
+                ResourceDim::GridCarbonGramsCo2 => AssuranceRung::ZkUpperEnvelope,
+                _ => AssuranceRung::OracleSigned,
+            })
+            .unwrap();
+        assert_eq!(rung, AssuranceRung::OracleSigned, "weakest link wins");
+
+        // When every claim is strongly attested, the floor rises.
+        let all_strong = p
+            .min_assurance_rung(|_dim, _claim| AssuranceRung::ZkUpperEnvelope)
+            .unwrap();
+        assert_eq!(all_strong, AssuranceRung::ZkUpperEnvelope);
+    }
+
+    #[test]
+    fn min_assurance_rung_none_for_empty_profile() {
+        let p = ExternalityProfile::new();
+        assert!(p
+            .min_assurance_rung(|_, _| crate::AssuranceRung::ZkUpperEnvelope)
+            .is_none());
     }
 }


### PR DESCRIPTION
## What

First phase (**O1**) of the externality-oracle RFC (#1751): turn the honesty
boundary on `units_micro` into a **machine-readable, checkable field** — the
*assurance rung*.

The Pigouvian charge is `λ · units_micro / 1e6`. We already publish + unit-test λ
(#1749). This makes the *other* half — how trustworthy `units_micro` is —
auditable instead of a footnote.

## Derived, not asserted (the soundness point)

`assess_rung(signature_ok, tee_ok, multi_source_disputed, zk_envelope_ok)`
**derives** the rung from what actually verified. A claim **cannot lie** about its
rung — a higher rung requires the corresponding verification to pass. Unsigned ⇒
**R0** regardless of what evidence is attached (fails closed).

| Rung | Property | Trusted surface |
|---|---|---|
| R0 `self_reported` | nothing verified | the claimant |
| R1 `oracle_signed` | Ed25519 sig (fresh, bound) | oracle operator |
| R2 `tee_attested` | + TEE quote | hardware + sensor wire |
| R3 `multi_source_disputed` | + ≥2 feeds under staked dispute | majority + no profitable lie |
| R4 `zk_upper_envelope` | + zk over-claim bound | public model + inputs |

## Wiring

- `verify_vca_claim_rung()` ties `oracle.rs`'s existing 3-layer VCA verification
  (TEE = R2, envelope = R4 — already shipped seams) to the rung: full pass → R4; a
  failing layer returns the error, **not** a rung.
- `ExternalityProfile::min_assurance_rung()` — the **weakest-link** summary (a
  bundle is only as trustworthy as its least-attested dimension); a closure so the
  verifier plugs in checks without this crate depending on them.

46 tests green, clippy clean. Independent of the in-flight #1750/#1751 (touches
only `nucleus-externality`).

**Next:** surface the rung in `@coproduct/verify` so a receipt reports *"rung-4,
envelope checks"* — the anti-greenwashing primitive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)