### PR TITLE
feat(verify): surface the assurance rung in @coproduct/verify (O1b)

### DIFF
--- a/sdks/verifier-js/index.d.ts
+++ b/sdks/verifier-js/index.d.ts
@@ -145,3 +145,39 @@ export function recomputeCommons(
   poolMicro: number | bigint,
   shares: object[],
 ): Promise<Array<{ destination: string; amount_micro: bigint }>>;
+
+/** The assurance rung an externality dimension's measurement reached. Derived
+ *  from what verified; ordered weakest→strongest. */
+export type AssuranceRung =
+  | "self_reported"
+  | "oracle_signed"
+  | "tee_attested"
+  | "multi_source_disputed"
+  | "zk_upper_envelope";
+
+/** Per-dimension verification outcomes fed to {@link recomputeAssuranceRung}. */
+export interface AssuranceLayerOutcome {
+  /** The `ResourceDim` tag this outcome is for (e.g. `"grid_carbon_grams_co2"`). */
+  dimension: string;
+  /** The independent oracle Ed25519 signature verified (fresh, bound). */
+  signature_ok?: boolean;
+  /** A TEE attestation over the oracle key verified. */
+  tee_ok?: boolean;
+  /** ≥2 independent sources corroborated under a staked dispute window. */
+  multi_source_disputed?: boolean;
+  /** A zk upper-envelope proof bounded `units_micro` and verified. */
+  zk_envelope_ok?: boolean;
+}
+
+/**
+ * Surface the assurance rung of an externality profile — each dimension's
+ * DERIVED rung (never self-asserted) plus the profile's overall **weakest-link**
+ * rung (`null` for an empty profile). The anti-greenwashing primitive: a receipt
+ * states its own, checkable assurance level.
+ */
+export function recomputeAssuranceRung(
+  layers: AssuranceLayerOutcome[],
+): Promise<{
+  overall_rung: AssuranceRung | null;
+  dimensions: Array<{ dimension: string; rung: AssuranceRung }>;
+}>;

--- a/sdks/verifier-js/index.js
+++ b/sdks/verifier-js/index.js
@@ -366,3 +366,23 @@ export async function recomputeCommons(poolMicro, shares) {
   const mod = await initWasm();
   return mod.recomputeCommons(big(poolMicro), JSON.stringify(shares));
 }
+
+/**
+ * Surface the **assurance rung** of an externality profile — how much trust each
+ * dimension's `units_micro` demands, and the profile's overall (weakest-link)
+ * rung. The rung is DERIVED from what actually verified (an unsigned dimension is
+ * `self_reported` no matter what evidence is attached); the overall is the
+ * MINIMUM across dimensions. This is the anti-greenwashing primitive: a receipt
+ * states its own, checkable assurance level.
+ *
+ * SCOPE: reports the trust LEVEL of the measurement; it does not itself attest
+ * the physical sensor (the irreducible residue — see the externality-oracle RFC).
+ *
+ * @param {object[]} layers per-dimension verification outcomes:
+ *   `{ dimension, signature_ok, tee_ok, multi_source_disputed, zk_envelope_ok }`.
+ * @returns {Promise<{ overall_rung: string|null, dimensions: {dimension: string, rung: string}[] }>}
+ */
+export async function recomputeAssuranceRung(layers) {
+  const mod = await initWasm();
+  return mod.recomputeAssuranceRung(JSON.stringify(layers));
+}

--- a/sdks/verifier-js/src/lib.rs
+++ b/sdks/verifier-js/src/lib.rs
@@ -348,3 +348,70 @@ pub fn recompute_commons_js(pool_micro: u64, shares_json: &str) -> Result<JsValu
         .map_err(|e| JsError::new(&format!("commons: {e}")))?;
     serde_wasm_bindgen::to_value(&allocations).map_err(|e| JsError::new(&e.to_string()))
 }
+
+/// Surface the **assurance rung** of an externality profile — *how much trust*
+/// each dimension's `units_micro` demands, and the profile's overall
+/// (weakest-link) rung. `layers_json` is a JSON array of per-dimension
+/// verification outcomes:
+/// `[{ dimension, signature_ok, tee_ok, multi_source_disputed, zk_envelope_ok }]`.
+///
+/// Returns `{ overall_rung, dimensions: [{ dimension, rung }] }`, where each
+/// `rung` is DERIVED from what actually verified (never self-asserted — an
+/// unsigned dimension is `self_reported` no matter what else is attached) and
+/// `overall_rung` is the **minimum** across dimensions (a profile is only as
+/// trustworthy as its weakest-attested dimension). `overall_rung` is `null` for
+/// an empty profile. This is the anti-greenwashing primitive: the receipt states
+/// its own assurance level, checkable by anyone.
+#[wasm_bindgen(js_name = recomputeAssuranceRung)]
+pub fn recompute_assurance_rung_js(layers_json: &str) -> Result<JsValue, JsError> {
+    set_panic_hook();
+
+    #[derive(Deserialize)]
+    struct LayerOutcome {
+        dimension: String,
+        #[serde(default)]
+        signature_ok: bool,
+        #[serde(default)]
+        tee_ok: bool,
+        #[serde(default)]
+        multi_source_disputed: bool,
+        #[serde(default)]
+        zk_envelope_ok: bool,
+    }
+    #[derive(Serialize)]
+    struct DimRung {
+        dimension: String,
+        rung: nucleus_externality::AssuranceRung,
+    }
+    #[derive(Serialize)]
+    struct Report {
+        overall_rung: Option<nucleus_externality::AssuranceRung>,
+        dimensions: Vec<DimRung>,
+    }
+
+    let layers: Vec<LayerOutcome> = serde_json::from_str(layers_json)
+        .map_err(|e| JsError::new(&format!("layers JSON: {e}")))?;
+    let dimensions: Vec<DimRung> = layers
+        .iter()
+        .map(|l| DimRung {
+            dimension: l.dimension.clone(),
+            rung: nucleus_externality::assess_rung(
+                l.signature_ok,
+                l.tee_ok,
+                l.multi_source_disputed,
+                l.zk_envelope_ok,
+            ),
+        })
+        .collect();
+    // Weakest link = the rung a consumer of the receipt should actually trust.
+    let overall_rung = dimensions.iter().map(|d| d.rung).min();
+    // Serialize `None` as JSON `null` (not the default `undefined`) so the empty
+    // profile honours the typed `overall_rung: AssuranceRung | null` contract.
+    let serializer = serde_wasm_bindgen::Serializer::new().serialize_missing_as_null(true);
+    Report {
+        overall_rung,
+        dimensions,
+    }
+    .serialize(&serializer)
+    .map_err(|e| JsError::new(&e.to_string()))
+}

--- a/sdks/verifier-js/test/smoke.test.mjs
+++ b/sdks/verifier-js/test/smoke.test.mjs
@@ -13,7 +13,7 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 
-import { verify, VerifyError } from "../index.js";
+import { verify, VerifyError, recomputeAssuranceRung } from "../index.js";
 
 const fixtureDir = new URL("../demo-fixtures/", import.meta.url);
 
@@ -76,4 +76,41 @@ test("malformed receipt surfaces a typed VERIFICATION error, not a throw", async
   assert.equal(r.ok, false);
   assert.ok(r.error instanceof VerifyError);
   assert.equal(r.error.code, "VERIFICATION");
+});
+
+test("assurance rung is derived from what verified (weakest-link overall)", async () => {
+  // Carbon strongly attested (sig+TEE+envelope → zk_upper_envelope); water only
+  // signed (→ oracle_signed). The profile's overall rung is the WEAKEST link.
+  const r = await recomputeAssuranceRung([
+    {
+      dimension: "grid_carbon_grams_co2",
+      signature_ok: true,
+      tee_ok: true,
+      zk_envelope_ok: true,
+    },
+    { dimension: "water_litres_consumed", signature_ok: true },
+  ]);
+  assert.equal(r.dimensions[0].rung, "zk_upper_envelope");
+  assert.equal(r.dimensions[1].rung, "oracle_signed");
+  assert.equal(r.overall_rung, "oracle_signed", "overall = weakest link");
+});
+
+test("unsigned dimension is self_reported no matter what evidence is attached", async () => {
+  const r = await recomputeAssuranceRung([
+    {
+      dimension: "grid_carbon_grams_co2",
+      signature_ok: false,
+      tee_ok: true,
+      multi_source_disputed: true,
+      zk_envelope_ok: true,
+    },
+  ]);
+  assert.equal(r.dimensions[0].rung, "self_reported");
+  assert.equal(r.overall_rung, "self_reported");
+});
+
+test("empty profile has null overall rung", async () => {
+  const r = await recomputeAssuranceRung([]);
+  assert.equal(r.overall_rung, null);
+  assert.deepEqual(r.dimensions, []);
 });


### PR DESCRIPTION
## What

Completes **O1** of the externality-oracle RFC (#1751): a receipt now states its
own, **checkable** assurance level — the anti-greenwashing primitive. Builds on the
derived-rung core in #1752.

`recomputeAssuranceRung(layers)` (wasm export + JS facade + d.ts):

- **Input** — per-dimension verification outcomes:
  `{ dimension, signature_ok, tee_ok, multi_source_disputed, zk_envelope_ok }`.
- **Output** — `{ overall_rung, dimensions: [{ dimension, rung }] }`.
- Each `rung` is **derived** via the proven `assess_rung` (never self-asserted —
  an unsigned dimension is `self_reported` no matter what evidence is attached).
- `overall_rung` is the **minimum** (weakest-link) across dimensions; `null` for
  an empty profile.

So a consumer can read *"carbon: zk_upper_envelope, water: oracle_signed, overall:
oracle_signed"* and know exactly how much to trust the externality numbers —
checkable by anyone, no server trust.

## Tests

`npm run build:wasm` + `npm test` — **7/7 green**, including the three new cases:
weakest-link overall, unsigned ⇒ `self_reported` regardless of attached evidence,
and empty ⇒ `null` (serializer set to emit JSON `null`, honouring the typed
`AssuranceRung | null` contract).

## Scope / honesty

Reports the trust **level** of the measurement; it does not itself attest the
physical sensor (the irreducible residue — externality-oracle RFC). zkML proves
the computation ran, TEE attests the environment, this reports which of those
actually verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)