### PR TITLE
docs(rfc): fold deep-research SOTA into externality-oracle + Bet B RFCs

### DIFF
--- a/docs/rfcs/credible-clearing-settlement.md
+++ b/docs/rfcs/credible-clearing-settlement.md
@@ -79,9 +79,18 @@ is gone.
   Sepolia testnet; native-value escrow for v1. *Not yet:* deciding poster-vs-
   challenger correctness (always reverses on challenge) — that's B3.
 - **B3:** on-chain bid commitment (open submission) + clearing-price
-  adjudication (interactive fraud proof or on-chain commit so a challenge
-  resolves to the *correct* result, not just a reversal) — this is what removes
-  the *coordinator*, not just the *trust*.
+  adjudication so a challenge resolves to the *correct* result, not just a
+  reversal — this is what removes the *coordinator*, not just the *trust*.
+  **Adopt the refereed-delegation tournament** (the **PRT / Dave** family —
+  Cartesi, *peer-reviewed ACM DLT 2025*) rather than designing a bespoke dispute
+  game: bisect the disputed clearing recomputation to a single step and settle it
+  on-chain. Why this exact mechanism: it gives **a single honest challenger a win
+  against an unbounded Sybil adversary**, honest cost only *logarithmic* in
+  adversary loss, **correctness independent of bond calibration**, and finalises
+  in a few challenge periods — i.e. it removes B2's "any challenge just reverses"
+  limitation *and* sidesteps the verifier-independence problem (you need ≥1 honest
+  watcher, not a provably-independent quorum). The recompute we already ship is
+  the referee's per-step check; B3 is wrapping it in the bisection game.
 - **B4 (research):** PoTE — proving the seller actually delivered. Until then, v1
   settles on **clearing-correct + payment**, not on delivery; disputes about
   delivery remain out of scope (pitch to compliance, not as full escrow).

--- a/docs/rfcs/externality-oracle.md
+++ b/docs/rfcs/externality-oracle.md
@@ -60,24 +60,42 @@ from "the operator" to **"the hardware vendor's attestation + the sensor wire in
 the enclave."** The operator can no longer silently alter the number; they can
 only feed a bad input — which rungs 3–4 attack.
 
-### Rung 3 — multi-source aggregation + staked dispute *(feasible now)*
-Don't trust one sensor. For each dimension, take **N independent sources** and
-aggregate:
+> ⚠️ **TEE is not a hard floor — weight it accordingly.** Remote attestation is
+> physically breakable: *TEE.fail* (Nov 2025) showed a **< $1,000 DDR5 bus
+> interposer defeating attestation and extracting keys from Intel SGX/TDX and
+> AMD SEV-SNP** (physical access + root). R2 *raises the cost* of silently
+> altering a number; it does not make it impossible. Do not treat a TEE quote as
+> equivalent to a proof — it is one (breakable) attestation, which is why R3/R4
+> exist above it.
 
-- **Carbon:** GPU-seconds (TEE compute oracle) × **grid carbon intensity** from
-  ≥2 independent grid-intensity feeds (e.g. WattTime / ElectricityMaps-class
-  providers), region- and time-matched. Disagreement beyond a tolerance → the
-  claim is flagged, not silently averaged.
-- **Water:** the same GPU/energy telemetry × a **regional WUE** factor from a
-  published datacenter-water dataset.
+### Rung 3 — refereed dispute over corroborated sources *(feasible now)*
+The naïve framing of this rung — "take **N independent sources** and trust the
+majority" — is **provably weak**, and the 2024–2026 literature is blunt about why:
+genuine verifier independence is hard to *guarantee* and easy to *fake* (the
+Sybil≡collusion "mirror"; proof-of-personhood systems still drift to oligopoly;
+the **Verifier's Dilemma** shows no pure-strategy equilibrium where a costly
+verifier and a prover are *both* honest). **Counting "independent" feeds is not a
+security argument.**
 
-Wrap the aggregate in an **optimistic-oracle dispute layer** (the **UMA**
-pattern): a reporter posts the value with a **bond**; anyone may dispute within a
-window by posting a counter-bond; a disputed value escalates to a slower,
-higher-assurance resolver and the loser is slashed. This is the *same shape* as
-Bet B's settlement challenge (`CredibleSettlement.sol`) — **reuse it.** Trusted
-surface: **"a majority of independent feeds AND no profitable undisputed lie"** —
-i.e. economic, not blind.
+The sound primitive is a **refereed dispute** whose correctness rests on *a single
+honest challenger*, not on the independence of a quorum:
+
+- Corroborate the measurement from multiple feeds where available (carbon:
+  GPU-seconds × grid-intensity from WattTime / ElectricityMaps-class providers,
+  region- and time-matched; water: GPU/energy × a regional WUE factor) — but treat
+  agreement as a *cheap-path heuristic*, not the guarantee.
+- The guarantee comes from an **optimistic post + permissionless challenge**: a
+  reporter posts the value with a **bond**; **anyone** may dispute within a window;
+  a dispute is settled by a **refereed-delegation tournament** (the **PRT / Dave**
+  family — Cartesi, peer-reviewed ACM DLT 2025) in which **one honest challenger
+  prevails against an unbounded Sybil adversary**, with honest cost only
+  *logarithmic* in adversary loss and correctness *independent* of bond
+  calibration. This is the *same machinery* as Bet B's settlement challenge
+  (`CredibleSettlement.sol`) — **reuse it**, and inherit the single-honest-party
+  security model rather than a fragile "majority of independent feeds."
+
+Trusted surface: **"≥1 honest party is watching, and the censorship window
+holds"** — economic + structural, not an unverifiable independence assumption.
 
 ### Rung 4 — zk upper-envelope proof *(feasible, partial)*
 For dimensions where we only need a *bound* (the Pigouvian charge is conservative


### PR DESCRIPTION
Folds the recovered deep-research findings (refereed-delegation / Sybil-independence
/ commons-funding SOTA) into two RFCs, correcting two design choices:

**externality-oracle R3** — reframed from *"N independent sources, trust the
majority"* (provably weak: Sybil≡collusion mirror, the Verifier's Dilemma,
proof-of-personhood→oligopoly drift — counting feeds is not a security argument)
to a **refereed dispute resting on a single honest challenger** (**PRT / Dave**,
peer-reviewed ACM DLT 2025): one honest party beats an unbounded Sybil adversary,
honest cost logarithmic in adversary loss, correctness independent of bond
calibration. Reuse `CredibleSettlement`'s challenge machinery.

**externality-oracle R2** — added the **TEE.fail** caveat (a <\$1k DDR5 bus
interposer defeats SGX/TDX/SEV-SNP attestation): TEE raises cost, is **not** a hard
floor; a quote is not a proof.

**credible-clearing B3** — adopt the refereed-delegation tournament (PRT/Dave) for
clearing-price adjudication instead of a bespoke dispute game; removes B2's "any
challenge reverses" limit *and* sidesteps verifier-independence (need ≥1 honest
watcher, not a provable quorum). The recompute we already ship is the referee's
per-step check.

> Caveat: the funding impossibility (Green–Laffont) + most non-MACI Problem-2
> theory were single-source in the research pass; a targeted re-verification run is
> in flight before we lean on them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)