### PR TITLE
feat(witness-olog): P2.1 — Gov functor contract + signed accumulation manifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7080,6 +7080,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "nucleus-witness-olog"
+version = "1.0.0"
+dependencies = [
+ "base64 0.22.1",
+ "ed25519-dalek 2.2.0",
+ "hex",
+ "nucleus-externality",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ members = [
     "crates/nucleus-econ-types",            # Financially load-bearing newtypes (MicroUsd, ids); serde-only
     "crates/nucleus-externality",           # Pigouvian externality envelopes + rate-setter
     "crates/nucleus-econ-kernels",          # PROVEN integer VCG + Pigou + sealed-bid kernels (parity-pinned to Lean)
+    "crates/nucleus-witness-olog",          # Phase 2 (P2.1): Gov functor (admitted witness → olog fact) + signed accumulation manifest
 ]
 # nucleus-claude-hook moved to nucleus-code (private product repo)
 # exposure-web is WASM-only (wasm32-unknown-unknown); build with: cd crates/exposure-web && trunk build

--- a/crates/nucleus-witness-olog/Cargo.toml
+++ b/crates/nucleus-witness-olog/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "nucleus-witness-olog"
+license.workspace = true
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+description = "Phase 2 contract (P2.1): the Gov functor (admitted witness → olog fact) and the signed, transparency-loggable accumulation manifest. Types + the no-upgrade invariant only — wiring to the real olog/merge-gate archive is P2.2. See docs/rfcs/witness-olog-functor.md."
+
+[lints]
+workspace = true
+
+[dependencies]
+serde = { workspace = true }
+ed25519-dalek = { workspace = true }
+base64 = { workspace = true }
+sha2 = { workspace = true }
+hex = { workspace = true }
+thiserror = { workspace = true }
+# AssuranceRung — the rung Gov must carry through WITHOUT upgrading (the
+# load-bearing honesty invariant).
+nucleus-externality = { path = "../nucleus-externality" }
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/crates/nucleus-witness-olog/src/functor.rs
+++ b/crates/nucleus-witness-olog/src/functor.rs
@@ -1,0 +1,207 @@
+//! The `Gov` functor contract — admitted witness → olog fact.
+//!
+//! `Gov : 𝓦 → 𝓞` maps an admitted witness (source category 𝓦: objects =
+//! content-addressed witness digests, morphisms = admitted lineage edges) to a
+//! **fact** in the olog (target category 𝓞). See
+//! `docs/rfcs/witness-olog-functor.md`.
+//!
+//! **P2.1 scope:** this is the *contract* — the types, the functor trait, and the
+//! load-bearing **no-upgrade invariant** (Gov carries the witness's assurance
+//! rung through unchanged; it never manufactures or upgrades trust). Wiring to the
+//! real `merge-gate` archive and the live `olog` instance store is **P2.2**;
+//! [`WitnessDigest`]/[`OlogFact::instance_digest`] are 32-byte stand-ins that
+//! P2.2 unifies with `ck-types::ArtifactDigest` and a real olog instance digest.
+//!
+//! ## Why a functor (the property the type system can't state but the law does)
+//!
+//! A functor preserves identity and composition: `Gov(g ∘ f) = Gov(g) ∘ Gov(f)`.
+//! Concretely, a *pipeline* of admitted tasks (a chain of lineage edges) maps to a
+//! *composed* fact — proven work composes, instead of piling up as unrelated
+//! receipts. The full proof is the Lean goal in the RFC; here we encode the
+//! per-object behaviour and the no-upgrade invariant as tests.
+
+use nucleus_externality::AssuranceRung;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+/// Content-addressed identifier of a witness (the source-category object id).
+/// 32 bytes — a BLAKE3/SHA-256-class digest. P2.2 unifies this with
+/// `ck-types::ArtifactDigest`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct WitnessDigest(pub [u8; 32]);
+
+impl WitnessDigest {
+    /// Lowercase-hex rendering for receipts / logs.
+    pub fn to_hex(self) -> String {
+        hex::encode(self.0)
+    }
+}
+
+/// An admitted lineage edge (a morphism in 𝓦): the child's admission points at
+/// its already-admitted parent. The kernel's dual-DAG already enforces this; here
+/// it is the composable arrow `Gov` is functorial over.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LineageEdge {
+    pub parent: WitnessDigest,
+    pub child: WitnessDigest,
+}
+
+/// How well-proven an accumulated fact is — the honesty tier from
+/// `CATEGORICAL-LANDSCAPE.md`. Mandatory: the olog's Lean core is theorem-
+/// incomplete (~1000 tracked `sorry`s), so a fact must never *read* as more proven
+/// than it is.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Tier {
+    /// Backed by a discharged, axiom-audited proof (sorry-free).
+    Proven,
+    /// Structurally modelled; the proof is an obligation, not discharged.
+    Modeled,
+    /// An analogy / informal argument only.
+    Analogy,
+}
+
+/// The kernel's admission decision for the witness.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AdmissionVerdict {
+    Admitted,
+    Rejected,
+}
+
+/// A source-category object: an admitted witness plus the attributes it *proved*.
+/// These attributes are the witness's own — `Gov` may carry them through but must
+/// never strengthen them (the no-upgrade invariant).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WitnessNode {
+    pub digest: WitnessDigest,
+    /// The olog spec this witness claims to satisfy.
+    pub task_spec_hash: [u8; 32],
+    /// The assurance rung the witness's evidence actually reached.
+    pub rung: AssuranceRung,
+    /// How well-proven the witness's claim is.
+    pub tier: Tier,
+    /// The kernel's verdict on this witness.
+    pub verdict: AdmissionVerdict,
+    /// The admitted parent, if any (root nodes have none).
+    pub parent: Option<WitnessDigest>,
+}
+
+/// A target-category object: a categorical **fact** in the olog. The accumulated,
+/// queryable record of one piece of proven work.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OlogFact {
+    /// The olog spec this fact is an instance of.
+    pub task_spec_hash: [u8; 32],
+    /// Digest of the olog instance Gov produced (P2.2: the real instance digest).
+    pub instance_digest: [u8; 32],
+    /// Carried through from the witness — NEVER upgraded.
+    pub rung: AssuranceRung,
+    /// Carried through from the witness — NEVER upgraded.
+    pub tier: Tier,
+}
+
+/// The functor `Gov : 𝓦 → 𝓞`.
+///
+/// Implementors MUST satisfy:
+/// 1. **No-upgrade:** `gov.map_witness(n).rung == n.rung` and
+///    `gov.map_witness(n).tier == n.tier` — Gov carries assurance through, never
+///    strengthens it (trust in, trust out).
+/// 2. **Determinism:** equal inputs map to equal facts (so anyone can recompute
+///    the accumulation from the witness archive).
+/// 3. **Functoriality (the Lean goal):** identity and composition preserved over
+///    [`LineageEdge`]s, so proven pipelines compose. Stated here; proved in Lean.
+pub trait Gov {
+    fn map_witness(&self, node: &WitnessNode) -> OlogFact;
+}
+
+/// The reference functor: carries every attribute through faithfully and derives a
+/// deterministic stand-in instance digest. It is the canonical witness of the
+/// no-upgrade invariant; P2.2 replaces the stand-in digest with the real olog
+/// instance digest while keeping this behaviour.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NoUpgradeGov;
+
+/// Domain prefix for the stand-in instance digest. Versioned so P2.2's real
+/// digest can't be confused with a P2.1 stand-in.
+const INSTANCE_STANDIN_DOMAIN: &[u8] = b"nucleus/witness-olog/instance-standin/v1\0";
+
+impl Gov for NoUpgradeGov {
+    fn map_witness(&self, node: &WitnessNode) -> OlogFact {
+        // Deterministic stand-in: SHA-256(domain || witness_digest || spec_hash).
+        let mut h = Sha256::new();
+        h.update(INSTANCE_STANDIN_DOMAIN);
+        h.update(node.digest.0);
+        h.update(node.task_spec_hash);
+        let instance_digest: [u8; 32] = h.finalize().into();
+        OlogFact {
+            task_spec_hash: node.task_spec_hash,
+            instance_digest,
+            rung: node.rung, // carried through — NOT upgraded
+            tier: node.tier, // carried through — NOT upgraded
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn node(rung: AssuranceRung, tier: Tier) -> WitnessNode {
+        WitnessNode {
+            digest: WitnessDigest([7u8; 32]),
+            task_spec_hash: [9u8; 32],
+            rung,
+            tier,
+            verdict: AdmissionVerdict::Admitted,
+            parent: None,
+        }
+    }
+
+    #[test]
+    fn gov_never_upgrades_the_rung_or_tier() {
+        // The load-bearing honesty invariant: trust in, trust out.
+        let g = NoUpgradeGov;
+        for &rung in &[
+            AssuranceRung::SelfReported,
+            AssuranceRung::OracleSigned,
+            AssuranceRung::TeeAttested,
+            AssuranceRung::MultiSourceDisputed,
+            AssuranceRung::ZkUpperEnvelope,
+        ] {
+            for &tier in &[Tier::Proven, Tier::Modeled, Tier::Analogy] {
+                let fact = g.map_witness(&node(rung, tier));
+                assert_eq!(fact.rung, rung, "Gov must carry the rung through");
+                assert_eq!(fact.tier, tier, "Gov must carry the tier through");
+                assert!(fact.rung <= rung, "Gov must never UPGRADE the rung");
+            }
+        }
+    }
+
+    #[test]
+    fn gov_is_deterministic() {
+        let g = NoUpgradeGov;
+        let n = node(AssuranceRung::TeeAttested, Tier::Modeled);
+        assert_eq!(g.map_witness(&n), g.map_witness(&n));
+    }
+
+    #[test]
+    fn distinct_witnesses_map_to_distinct_facts() {
+        let g = NoUpgradeGov;
+        let mut a = node(AssuranceRung::OracleSigned, Tier::Proven);
+        let mut b = a.clone();
+        a.digest = WitnessDigest([1u8; 32]);
+        b.digest = WitnessDigest([2u8; 32]);
+        assert_ne!(
+            g.map_witness(&a).instance_digest,
+            g.map_witness(&b).instance_digest
+        );
+    }
+
+    #[test]
+    fn fact_is_an_instance_of_the_claimed_spec() {
+        let g = NoUpgradeGov;
+        let n = node(AssuranceRung::ZkUpperEnvelope, Tier::Proven);
+        assert_eq!(g.map_witness(&n).task_spec_hash, n.task_spec_hash);
+    }
+}

--- a/crates/nucleus-witness-olog/src/lib.rs
+++ b/crates/nucleus-witness-olog/src/lib.rs
@@ -1,0 +1,32 @@
+//! `nucleus-witness-olog` — the Phase 2 contract (P2.1): the `Gov` functor that
+//! turns an admitted witness into an accumulated **olog fact**, and the signed
+//! **accumulation manifest** that records it.
+//!
+//! This is the bridge that makes proof-of-work *accumulate and compose* instead of
+//! staying per-transaction: `Gov : 𝓦 → 𝓞` maps admitted [`functor::WitnessNode`]s
+//! (content-addressed, lineage-linked) to [`functor::OlogFact`]s in the categorical
+//! KB, and each is bound into a transparency-loggable [`manifest::AccumulationManifest`].
+//!
+//! **Scope (P2.1):** types + the functor trait + the load-bearing **no-upgrade
+//! invariant** (Gov carries the witness's assurance rung/tier through unchanged —
+//! trust in, trust out — never manufacturing or strengthening trust). The wiring
+//! to the real `merge-gate` witness archive and the live `olog` instance store is
+//! **P2.2**; the [`functor::WitnessDigest`] / instance-digest here are 32-byte
+//! stand-ins P2.2 unifies with `ck-types::ArtifactDigest` and real olog instances.
+//!
+//! The functoriality theorem (`Gov(g ∘ f) = Gov(g) ∘ Gov(f)` ⇒ proven work
+//! composes) is the Lean goal stated in `docs/rfcs/witness-olog-functor.md`; this
+//! crate encodes the per-object behaviour + the no-upgrade invariant as tests.
+
+#![forbid(unsafe_code)]
+
+pub mod functor;
+pub mod manifest;
+
+pub use functor::{
+    AdmissionVerdict, Gov, LineageEdge, NoUpgradeGov, OlogFact, Tier, WitnessDigest, WitnessNode,
+};
+pub use manifest::{
+    canonical_manifest_bytes, manifest_from_fact, sign_manifest, verify_manifest,
+    AccumulationManifest, ManifestError, MANIFEST_DOMAIN,
+};

--- a/crates/nucleus-witness-olog/src/manifest.rs
+++ b/crates/nucleus-witness-olog/src/manifest.rs
@@ -1,0 +1,228 @@
+//! The accumulation manifest — the signed, transparency-loggable record that
+//! binds an admitted witness to the olog fact it became.
+//!
+//! Each internalised witness emits one manifest binding the full provenance chain
+//! so any third party can re-derive it: who did the work, which spec it claims,
+//! the evidence digest, the kernel verdict, the assurance rung + tier (carried
+//! through, never upgraded), the olog fact, and the reproducibility anchors. Ed25519
+//! signed and append-only-log-friendly — the concrete step toward the
+//! self-proving-system north star. See `docs/rfcs/witness-olog-functor.md`.
+
+use base64::{engine::general_purpose::STANDARD, Engine as _};
+use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
+use nucleus_externality::AssuranceRung;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::functor::{AdmissionVerdict, OlogFact, Tier, WitnessDigest, WitnessNode};
+
+/// Domain prefix for the manifest's canonical signing bytes. Bumping invalidates
+/// every prior manifest signature (v1 contract).
+pub const MANIFEST_DOMAIN: &[u8] = b"nucleus/witness-olog/manifest/v1\0";
+
+/// One signed accumulation record: witness ↦ olog fact, with full provenance.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AccumulationManifest {
+    /// Who did the work.
+    pub agent_id: String,
+    /// The olog spec the work claims to satisfy.
+    pub task_spec_hash: [u8; 32],
+    /// Content-addressed evidence.
+    pub witness_digest: WitnessDigest,
+    /// The kernel's admission decision.
+    pub admission_verdict: AdmissionVerdict,
+    /// Assurance rung — carried from the witness, NEVER upgraded.
+    pub assurance_rung: AssuranceRung,
+    /// Honesty tier — carried from the witness, NEVER upgraded.
+    pub tier: Tier,
+    /// Digest of the olog fact `Gov` produced.
+    pub olog_instance_digest: [u8; 32],
+    /// Source-commit anchor.
+    pub commit_sha: String,
+    /// `#print axioms` footprint of the proof backing this fact (empty if none).
+    pub axiom_footprint: String,
+    /// CI run that produced + checked this record.
+    pub ci_run_id: String,
+    /// Ed25519 signature over the canonical bytes, base64.
+    pub sig_b64: String,
+}
+
+/// Errors constructing / verifying a manifest.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum ManifestError {
+    #[error("signature did not verify: {0}")]
+    SignatureInvalid(String),
+    #[error("sig_b64 base64 decode failed: {0}")]
+    Base64(String),
+    #[error("signature is {got} bytes, expected 64")]
+    WrongSignatureLength { got: usize },
+}
+
+fn push_field(out: &mut Vec<u8>, bytes: &[u8]) {
+    out.extend_from_slice(&(bytes.len() as u32).to_be_bytes());
+    out.extend_from_slice(bytes);
+}
+
+/// Canonical signing bytes: domain-tagged, length-prefixed, integer-only — the
+/// same discipline as `nucleus-externality`'s claim bytes. Excludes `sig_b64`
+/// (the signature is computed over this).
+pub fn canonical_manifest_bytes(m: &AccumulationManifest) -> Vec<u8> {
+    let mut out = Vec::with_capacity(256);
+    out.extend_from_slice(MANIFEST_DOMAIN);
+    push_field(&mut out, m.agent_id.as_bytes());
+    push_field(&mut out, &m.task_spec_hash);
+    push_field(&mut out, &m.witness_digest.0);
+    out.push(match m.admission_verdict {
+        AdmissionVerdict::Admitted => 1,
+        AdmissionVerdict::Rejected => 0,
+    });
+    out.push(m.assurance_rung.level());
+    out.push(match m.tier {
+        Tier::Proven => 2,
+        Tier::Modeled => 1,
+        Tier::Analogy => 0,
+    });
+    push_field(&mut out, &m.olog_instance_digest);
+    push_field(&mut out, m.commit_sha.as_bytes());
+    push_field(&mut out, m.axiom_footprint.as_bytes());
+    push_field(&mut out, m.ci_run_id.as_bytes());
+    out
+}
+
+/// Build the unsigned manifest from a witness node, the fact `Gov` produced, and
+/// the provenance anchors. The rung + tier come from the FACT (which `Gov`
+/// carried through from the witness) — so the manifest cannot claim more
+/// assurance than the witness proved.
+#[allow(clippy::too_many_arguments)]
+pub fn manifest_from_fact(
+    agent_id: impl Into<String>,
+    node: &WitnessNode,
+    fact: &OlogFact,
+    commit_sha: impl Into<String>,
+    axiom_footprint: impl Into<String>,
+    ci_run_id: impl Into<String>,
+) -> AccumulationManifest {
+    AccumulationManifest {
+        agent_id: agent_id.into(),
+        task_spec_hash: fact.task_spec_hash,
+        witness_digest: node.digest,
+        admission_verdict: node.verdict,
+        assurance_rung: fact.rung,
+        tier: fact.tier,
+        olog_instance_digest: fact.instance_digest,
+        commit_sha: commit_sha.into(),
+        axiom_footprint: axiom_footprint.into(),
+        ci_run_id: ci_run_id.into(),
+        sig_b64: String::new(),
+    }
+}
+
+/// Sign a manifest shell, filling in `sig_b64`.
+pub fn sign_manifest(sk: &SigningKey, mut m: AccumulationManifest) -> AccumulationManifest {
+    let sig: Signature = sk.sign(&canonical_manifest_bytes(&m));
+    m.sig_b64 = STANDARD.encode(sig.to_bytes());
+    m
+}
+
+/// Verify a manifest's signature under the supplied key.
+pub fn verify_manifest(m: &AccumulationManifest, vk: &VerifyingKey) -> Result<(), ManifestError> {
+    let sig_bytes = STANDARD
+        .decode(&m.sig_b64)
+        .map_err(|e| ManifestError::Base64(e.to_string()))?;
+    if sig_bytes.len() != 64 {
+        return Err(ManifestError::WrongSignatureLength {
+            got: sig_bytes.len(),
+        });
+    }
+    let mut buf = [0u8; 64];
+    buf.copy_from_slice(&sig_bytes);
+    let sig = Signature::from_bytes(&buf);
+    vk.verify(&canonical_manifest_bytes(m), &sig)
+        .map_err(|e| ManifestError::SignatureInvalid(e.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::functor::{Gov, NoUpgradeGov};
+
+    fn signer() -> SigningKey {
+        SigningKey::from_bytes(&[3u8; 32])
+    }
+
+    fn fixture_node() -> WitnessNode {
+        WitnessNode {
+            digest: WitnessDigest([42u8; 32]),
+            task_spec_hash: [1u8; 32],
+            rung: AssuranceRung::TeeAttested,
+            tier: Tier::Modeled,
+            verdict: AdmissionVerdict::Admitted,
+            parent: None,
+        }
+    }
+
+    fn fixture_manifest() -> AccumulationManifest {
+        let node = fixture_node();
+        let fact = NoUpgradeGov.map_witness(&node);
+        sign_manifest(
+            &signer(),
+            manifest_from_fact("agent-1", &node, &fact, "abc123", "[propext]", "ci-99"),
+        )
+    }
+
+    #[test]
+    fn sign_verify_round_trip() {
+        let m = fixture_manifest();
+        verify_manifest(&m, &signer().verifying_key()).expect("fresh manifest must verify");
+    }
+
+    #[test]
+    fn rung_is_bound_into_the_signature() {
+        // Tamper with the rung after signing → signature must fail. This is what
+        // makes "lying about the rung is itself a (failed) signed claim" real.
+        let mut m = fixture_manifest();
+        m.assurance_rung = AssuranceRung::ZkUpperEnvelope; // forge a stronger rung
+        let err = verify_manifest(&m, &signer().verifying_key()).unwrap_err();
+        assert!(matches!(err, ManifestError::SignatureInvalid(_)));
+    }
+
+    #[test]
+    fn manifest_cannot_outrank_its_witness() {
+        // The no-upgrade invariant at the manifest layer: the signed rung equals
+        // the witness's rung (via the fact Gov carried through).
+        let node = fixture_node();
+        let fact = NoUpgradeGov.map_witness(&node);
+        let m = manifest_from_fact("a", &node, &fact, "c", "", "ci");
+        assert_eq!(m.assurance_rung, node.rung);
+        assert_eq!(m.tier, node.tier);
+    }
+
+    #[test]
+    fn tampered_agent_id_fails() {
+        let mut m = fixture_manifest();
+        m.agent_id.push('x');
+        assert!(verify_manifest(&m, &signer().verifying_key()).is_err());
+    }
+
+    #[test]
+    fn wrong_key_rejected() {
+        let m = fixture_manifest();
+        let bogus = SigningKey::from_bytes(&[99u8; 32]).verifying_key();
+        assert!(verify_manifest(&m, &bogus).is_err());
+    }
+
+    #[test]
+    fn canonical_bytes_deterministic_and_domain_tagged() {
+        let m = fixture_manifest();
+        assert_eq!(canonical_manifest_bytes(&m), canonical_manifest_bytes(&m));
+        assert!(canonical_manifest_bytes(&m).starts_with(MANIFEST_DOMAIN));
+    }
+
+    #[test]
+    fn round_trips_json() {
+        let m = fixture_manifest();
+        let j = serde_json::to_string(&m).unwrap();
+        let back: AccumulationManifest = serde_json::from_str(&j).unwrap();
+        assert_eq!(m, back);
+    }
+}


### PR DESCRIPTION
## What

First **code** of Phase 2 (RFC #1754): the `nucleus-witness-olog` crate — the
contract that turns proof-of-work from per-transaction into an **accumulated,
composable, categorical** record.

- **`functor.rs`** — `Gov : 𝓦 → 𝓞`. Source-category types (`WitnessDigest`,
  `LineageEdge`, `WitnessNode`), target `OlogFact`, the `Gov` trait with its three
  laws (no-upgrade, determinism, functoriality), and `NoUpgradeGov`, the reference
  functor. `Tier` (`Proven`/`Modeled`/`Analogy`) is mandatory — the olog Lean is
  theorem-incomplete, so a fact must never *read* as more proven than it is.
- **`manifest.rs`** — `AccumulationManifest`: the signed, transparency-loggable
  record binding agent ↔ task-spec ↔ witness-digest ↔ verdict ↔ rung/tier ↔
  olog-fact ↔ commit/axiom-footprint/ci-run. Domain-tagged canonical bytes +
  Ed25519 sign/verify (same discipline as the externality claim).

## The honesty invariant (enforced by tests)

`Gov` **never upgrades** the rung or tier (trust in, trust out), and the rung is
**bound into the manifest signature** — forging a stronger rung breaks the sig
(*"lying about the rung is itself a failed signed claim"*). **11 tests green,
clippy clean.**

## Scope

P2.1 is the **contract only**. Wiring to the real `merge-gate` witness archive +
live `olog` instance store is **P2.2**; `WitnessDigest` / the instance digest are
32-byte stand-ins P2.2 unifies with `ck-types::ArtifactDigest`. The functoriality
theorem (`Gov(g∘f)=Gov(g)∘Gov(f)` ⇒ proven work composes) is the Lean goal stated
in the RFC; here it's the per-object behaviour + the no-upgrade invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)