### PR TITLE
feat(witness-olog): WitnessSource read contract + accumulate (P2.2 scaffold)

### DIFF
--- a/crates/nucleus-witness-olog/src/functor.rs
+++ b/crates/nucleus-witness-olog/src/functor.rs
@@ -148,6 +148,71 @@ impl Gov for NoUpgradeGov {
     }
 }
 
+// ── P2.2: reading admitted witnesses (the source `Gov` folds over) ───────────
+
+/// A read-only source of admitted witnesses + their lineage — the contract
+/// [`Gov`] folds over to accumulate facts. Defined in OSS so the witness→olog
+/// mapping stays independently **recomputable**: an archive (e.g. merge-gate's
+/// content-addressed store) implements this trait, and any relying party can
+/// re-derive the same facts from the same source. (P2.2.)
+///
+/// Returns owned `Vec`s for the scaffold; a streaming variant for very large
+/// archives is a later refinement.
+pub trait WitnessSource {
+    /// The admitted witness nodes, in a deterministic order.
+    fn admitted(&self) -> Vec<WitnessNode>;
+    /// The admitted lineage edges (parent → child) among those nodes.
+    fn lineage(&self) -> Vec<LineageEdge>;
+}
+
+/// Fold `gov` over every admitted witness, producing one [`OlogFact`] per node
+/// (in source order) — the accumulation step where proof-of-work becomes a
+/// categorical fact. By the no-upgrade invariant, every produced fact carries its
+/// witness's rung/tier unchanged.
+pub fn accumulate<G: Gov, S: WitnessSource>(gov: &G, source: &S) -> Vec<OlogFact> {
+    source
+        .admitted()
+        .iter()
+        .map(|n| gov.map_witness(n))
+        .collect()
+}
+
+/// An in-memory [`WitnessSource`] for tests and the Fake-backed demo path (no
+/// real archive). Mirrors the `FakeFacilitator` honesty pattern — clearly not the
+/// production store; the real one is merge-gate's archive (P2.2 step 4).
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct FakeWitnessSource {
+    pub nodes: Vec<WitnessNode>,
+    pub edges: Vec<LineageEdge>,
+}
+
+impl FakeWitnessSource {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add an admitted node (builder style).
+    pub fn with_node(mut self, n: WitnessNode) -> Self {
+        self.nodes.push(n);
+        self
+    }
+
+    /// Add a lineage edge (builder style).
+    pub fn with_edge(mut self, e: LineageEdge) -> Self {
+        self.edges.push(e);
+        self
+    }
+}
+
+impl WitnessSource for FakeWitnessSource {
+    fn admitted(&self) -> Vec<WitnessNode> {
+        self.nodes.clone()
+    }
+    fn lineage(&self) -> Vec<LineageEdge> {
+        self.edges.clone()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -208,5 +273,29 @@ mod tests {
         let g = NoUpgradeGov;
         let n = node(AssuranceRung::ZkUpperEnvelope, Tier::Proven);
         assert_eq!(g.map_witness(&n).task_spec_hash, n.task_spec_hash);
+    }
+
+    #[test]
+    fn accumulate_folds_gov_over_the_source_preserving_rung() {
+        let mut a = node(AssuranceRung::OracleSigned, Tier::Modeled);
+        let mut b = node(AssuranceRung::ZkUpperEnvelope, Tier::Proven);
+        a.digest = WitnessDigest([1u8; 32]);
+        b.digest = WitnessDigest([2u8; 32]);
+        let src = FakeWitnessSource::new()
+            .with_node(a.clone())
+            .with_node(b.clone());
+        let facts = accumulate(&NoUpgradeGov, &src);
+        assert_eq!(facts.len(), 2, "one fact per admitted witness, in order");
+        // No-upgrade carries through the accumulation, per node.
+        assert_eq!(facts[0].rung, a.rung);
+        assert_eq!(facts[1].rung, b.rung);
+        assert_eq!(facts[0].tier, a.tier);
+        // Distinct witnesses → distinct accumulated facts.
+        assert_ne!(facts[0].instance_digest, facts[1].instance_digest);
+    }
+
+    #[test]
+    fn empty_source_accumulates_to_nothing() {
+        assert!(accumulate(&NoUpgradeGov, &FakeWitnessSource::new()).is_empty());
     }
 }

--- a/crates/nucleus-witness-olog/src/lib.rs
+++ b/crates/nucleus-witness-olog/src/lib.rs
@@ -35,7 +35,8 @@ pub use bond::{
     SlashOutcome, BOND_BPS_SCALE, BOND_DOMAIN, FORK_COST_THEOREM_MODELED,
 };
 pub use functor::{
-    AdmissionVerdict, Gov, LineageEdge, NoUpgradeGov, OlogFact, Tier, WitnessDigest, WitnessNode,
+    accumulate, AdmissionVerdict, FakeWitnessSource, Gov, LineageEdge, NoUpgradeGov, OlogFact,
+    Tier, WitnessDigest, WitnessNode, WitnessSource,
 };
 pub use manifest::{
     canonical_manifest_bytes, manifest_from_fact, sign_manifest, verify_manifest,

--- a/docs/rfcs/p2.2-olog-core-dependency.md
+++ b/docs/rfcs/p2.2-olog-core-dependency.md
@@ -1,0 +1,126 @@
+# RFC: P2.2 — wiring `Gov` to real witnesses + olog instances (the dependency plan)
+
+**Status:** active (scaffold landing). **Depends on:** P2.1 (`nucleus-witness-olog`
+— `Gov`, manifest, pinning, all merged) + the discharged functoriality/fork-cost
+Lean (`#1759`). **Companion:** [`witness-olog-functor.md`](./witness-olog-functor.md).
+
+## What P2.2 connects
+
+P2.1 shipped the *contract* (the `Gov` functor + signed manifest + pinning) with
+stand-in digests and no live data source. P2.2 wires it to reality:
+
+- the **olog instance digest** (so a fact's `instance_digest` is the real
+  content-address of an olog instance, not the P2.1 SHA-256 stand-in), and
+- the **admitted-witness source** (so `Gov` folds over real merge-gate-admitted
+  witnesses, not test fixtures).
+
+## Repo topology decision (Option 1, recorded)
+
+Three topologies were weighed (published thin crates / git-deps / private-side).
+**Decision: publish a thin library crate + keep `Gov` in OSS** — because the whole
+accumulation moat rests on the witness→olog mapping being **independently
+recomputable** by a relying party, which requires `Gov` to live in the neutral OSS
+core. Git-deps were rejected (they block publishing `nucleus-witness-olog` to
+crates.io). A full monorepo consolidation is the eventual destination, not a
+prerequisite for P2.2.
+
+The inventory made this cheap: **`olog-core` already exists** as a zero-dependency,
+`#![no_std]`, Aeneas-translatable crate carrying exactly the types `Gov`'s target
+needs (`OlogInstance`, `RowId`, `MorphismEndpoint`, `Provenance`). So "extract a
+thin crate" is really "publish the thin crate that's already there + add one
+function."
+
+## The two net-new pieces
+
+### 1. `olog-core::instance_digest` (the only new dependency surface)
+
+Neither repo currently has a canonical olog-instance digest. Add:
+
+```rust
+// olog-core, behind an off-by-default `digest` feature (keeps the crate
+// zero-dep + no_std by default; nucleus turns it on).
+pub fn instance_digest(inst: &OlogInstance) -> [u8; 32]
+```
+
+**Decisions (recommended, now adopted):**
+- **Hash = BLAKE3**, to match `ck-types::ArtifactDigest`'s content-addressing
+  family (`"blake3:<hex>"`). The olog instance is a *content-address field* inside
+  `OlogFact`/`AccumulationManifest`; it is **not** the transparency-log leaf. The
+  log leaf is the manifest's canonical bytes, hashed by `ct-merkle` (SHA-256, RFC
+  6962). The two hash families coexist by role — BLAKE3 names artifacts, SHA-256 is
+  the Merkle accumulator — and must **not** be "unified."
+- **Structural content only.** Digest the rows + action (morphism graph) + fields,
+  over a **canonical sorted serialization** (domain-tagged, length-prefixed, the
+  same discipline as the rest of the crate). **Exclude wall-clock provenance**
+  (`timestamp_ms`, `fetch_ts`, …) so the *same logical fact* has a *stable*
+  digest across runs — otherwise re-deriving a fact would never reproduce its
+  address, defeating recomputability.
+- Flips the P2.1 stand-in (SHA-256, `…/instance-standin/v1`) to BLAKE3 — a v1 wire
+  change, safe since nothing is anchored yet.
+
+### 2. `WitnessSource` (the OSS read contract) — *shipped in this PR*
+
+A read-only trait an archive implements; `Gov` folds over it.
+
+```rust
+pub trait WitnessSource {
+    fn admitted(&self) -> Vec<WitnessNode>;
+    fn lineage(&self) -> Vec<LineageEdge>;
+}
+pub fn accumulate<G: Gov, S: WitnessSource>(gov: &G, src: &S) -> Vec<OlogFact>;
+```
+
+Defined in OSS `nucleus-witness-olog` (with a `FakeWitnessSource` for tests/demo)
+so the mapping stays recomputable. merge-gate's ReDB archive — which has **no
+public read API today** — implements it in P2.2 step 4.
+
+## Dependency-version alignment (smaller than it looked)
+
+`olog-core` brings **no `ed25519-dalek`, no `ct-merkle`, no `sha2`** — it's
+zero-dep. So the `dalek 2 vs 3.0-pre.7` clash is **not** introduced by this
+dependency; it is an *internal* nucleus issue (`nucleus-lineage` pins
+`=3.0.0-pre.7`).
+
+| Dep | Plan |
+|---|---|
+| `ed25519-dalek` | `olog-core` adds none. **Invariant:** `nucleus-witness-olog` must **not** depend on `nucleus-lineage` (that's what would drag in `3.0-pre.7`); it already avoids this (pinning uses `ct-merkle` directly). Stay on workspace dalek `2`. |
+| `blake3` | add `blake3 = "1"` to `olog-core` **only** under the `digest` feature (ck-types already uses `1.x`; olog has none → no clash). Crate stays zero-dep / `no_std` by default. |
+| `sha2` | nucleus `0.11`; `olog-core` doesn't use it (instance_digest is BLAKE3; SHA-256 enters only via `ct-merkle`). No action. |
+
+Net new third-party dep entering the verifiable core: **`blake3` only, behind a
+feature** (and already present transitively via `ck-types`).
+
+## What lands where (the recompute line)
+
+- **OSS, published:** `coproduct-olog-core` (types + `instance_digest`); `Gov` +
+  manifest + pin + `WitnessSource` (`nucleus-witness-olog`); `ck-types`.
+- **Stays as a service (not a dep):** the olog runtime/server, ReDB, the live
+  archive — read through `WitnessSource`, never vendored.
+- **Result:** the witness→olog mapping is recomputable by any relying party from
+  published crates.
+
+## PR sequence
+
+1. **`coproduct-olog-core`:** add `instance_digest` (BLAKE3, `digest` feature);
+   publish to crates.io. *(olog repo; publish gated on name confirmation.)*
+2. **`WitnessSource` trait + `FakeWitnessSource` + `accumulate`** — *this PR*
+   (OSS contract; no external dep yet).
+3. **Wire `Gov`:** depend on published `coproduct-olog-core`, replace the SHA-256
+   stand-in with `instance_digest`, drive `Gov` over a `WitnessSource`, emit + sign
+   + pin manifests. **Lift functoriality to the full lineage DAG** (the remaining
+   `MODELED` piece — the real edges now exist).
+4. **merge-gate:** implement `WitnessSource` over the ReDB archive. *(merge-gate
+   repo.)*
+
+Steps 1–3 are OSS and unblock the full-DAG functoriality proof; step 4 is the
+live-data hookup.
+
+## Honest boundary
+
+- `instance_digest` excluding provenance timestamps means two facts with identical
+  structure but different capture times share a digest — *intended* (logical-fact
+  identity), but it means the digest is **not** a uniqueness key over capture
+  events; the manifest's `ci_run_id` / `commit_sha` carry that.
+- Publishing a crate name is a commitment (crates.io names are not reclaimable);
+  `coproduct-olog-core` is the proposed name, gated on confirmation before the
+  actual `cargo publish`.


### PR DESCRIPTION
## What

The OSS read-contract `Gov` folds over — the P2.2 scaffold that keeps the
witness→olog mapping **independently recomputable** (an archive implements the
trait; any relying party re-derives the same facts).

- `WitnessSource` trait: `admitted() -> Vec<WitnessNode>` + `lineage() -> Vec<LineageEdge>`.
- `accumulate(gov, source) -> Vec<OlogFact>` — the accumulation fold; by the
  no-upgrade invariant each fact carries its witness's rung/tier unchanged.
- `FakeWitnessSource` (builder) for tests/demo — the honesty pattern, clearly not
  the production store (merge-gate's archive, P2.2 step 4).

Tests: `accumulate` folds Gov over the source preserving rung per node; empty
source → no facts. 6 functor tests green, clippy clean.

Lives in `functor.rs` (the natural home — it's the functor folding over witnesses),
so it touches only the functor re-export block in `lib.rs` — no collision with the
in-flight pinning PR.

Includes `docs/rfcs/p2.2-olog-core-dependency.md` (the dependency plan: thin
`olog-core` + the `instance_digest` design). Note: the cross-repo execution
(publishing `olog-core`, wiring merge-gate) is **deferred** — this PR lands only the
nucleus-internal contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)