### PR TITLE
feat(verify): expose the reputation→capital standing in @coproduct/verify

### DIFF
--- a/crates/nucleus-econ-kernels/lean/Nucleus.lean
+++ b/crates/nucleus-econ-kernels/lean/Nucleus.lean
@@ -9,3 +9,4 @@ import Nucleus.Auctions.SettlementDecision
 import Nucleus.Auctions.VcgPigouTruthful
 import Nucleus.Auctions.VcgRevenueNonMonotone
 import Nucleus.WitnessOlog
+import Nucleus.ReputationCapital

--- a/crates/nucleus-econ-kernels/lean/Nucleus/ReputationCapital.lean
+++ b/crates/nucleus-econ-kernels/lean/Nucleus/ReputationCapital.lean
@@ -1,0 +1,116 @@
+/-
+  Nucleus / ReputationCapital  (the reputation↔capital flywheel — soundness)
+
+  **STATUS: PROVED (0 `sorry`).** Mathlib-free: pure `Nat` arithmetic discharged by
+  `omega` + `split` on the one branch. Mirrors the proof style of
+  `Nucleus.Auctions.SettlementDecision` and builds directly on
+  `Nucleus.WitnessOlog.ForkCost` (the single-stake fork-cost inequality).
+
+  # What this file specifies
+
+  The economic flywheel: **proven history substitutes for posted capital.** A
+  bonder's deterrent against a one-shot defection is not just its posted `bond`,
+  but `bond + rep`, where `rep` is the *reputation value at risk* — the future
+  business it would forfeit if a defection were caught (and it IS caught: recompute
+  is the fraud proof). So the more verifiable clean history an agent has, the less
+  collateral it must lock to remain honest — and that compounds.
+
+  This file proves the flywheel is **sound and bounded**, not merely optimistic:
+
+  1. `requiredBond_deters`        — posting `requiredBond gain rep` deters a gain.
+  2. `requiredBond_le_gain`       — reputation never *increases* the capital required.
+  3. `sybil_no_discount`          — a fresh identity (`rep = 0`) must post the FULL
+                                    bond; splitting into new identities buys nothing.
+  4. `requiredBond_antitone`      — more reputation ⇒ no more bond (the substitution).
+  5. `requiredBond_strict_saving` — positive reputation STRICTLY lowers the bond.
+  6. `under_collateralized_not_deterred` — below `gain - rep` the agent is NOT
+                                    deterred (tightness: you cannot under-collateralize
+                                    and stay sound).
+  7. `deters_implies_unprofitable`— bridge to the `ForkCost` payoff view: a deterred
+                                    defection has net payoff ≤ 0 over the COMBINED
+                                    stake `bond + rep` — the same inequality as
+                                    `ForkCost.staying_dominates`, with reputation
+                                    counted into the forfeiture.
+
+  # Honest scope boundary (read this)
+
+  These theorems prove the *capital arithmetic* of the flywheel: how far reputation
+  can substitute for a posted bond while preserving one-shot deterrence. They DO
+  NOT prove that `rep` is *real* — that the claimed reputation value is backed by
+  actual verifiable clean history. That backing is the recompute + pinning layer
+  (`nucleus-witness-olog`): a counterparty must independently re-derive the agent's
+  history and the bond-reduction. The model also assumes a defection, if it occurs,
+  is DETECTED (recompute) and that detection forfeits `rep` (counterparties stop
+  dealing). Detection is mechanised; "detection destroys rep" is the standard
+  reputation assumption, named here, not proven.
+
+  Parity: mirrored value-identically by `nucleus-econ-kernels`'s sibling crate
+  `nucleus-witness-olog::bond::{required_bond, deters}` (u64 µ-amounts), pinned by
+  unit tests there.
+-/
+
+namespace Nucleus.ReputationCapital
+
+/-- A bonder is **deterred** from a one-shot defection worth `gain` when the total
+    it forfeits on detection — posted `bond` collateral PLUS reputation value at
+    risk `rep` — is at least the gain. -/
+def deters (bond rep gain : Nat) : Prop := gain ≤ bond + rep
+
+/-- The **minimum bond** that still deters, given reputation `rep`: zero once
+    reputation alone covers the gain, otherwise the shortfall `gain - rep`. -/
+def requiredBond (gain rep : Nat) : Nat :=
+  if gain ≤ rep then 0 else gain - rep
+
+/-- **(1)** Posting `requiredBond gain rep` deters a defection of `gain`. -/
+theorem requiredBond_deters (gain rep : Nat) :
+    deters (requiredBond gain rep) rep gain := by
+  unfold deters requiredBond
+  split <;> omega
+
+/-- **(2)** Reputation never *increases* the capital required:
+    `requiredBond ≤ gain` always (rep = 0 is the worst case). -/
+theorem requiredBond_le_gain (gain rep : Nat) : requiredBond gain rep ≤ gain := by
+  unfold requiredBond
+  split <;> omega
+
+/-- **(3) Sybil gets no discount.** A fresh identity with no reputation must post
+    the full bond — so splitting into new identities to dodge collateral buys
+    nothing. (This is the one-shot mitigation of the unavoidable Sybil exposure:
+    discounts accrue only to a *persistent* identity that accumulated real history.) -/
+theorem sybil_no_discount (gain : Nat) : requiredBond gain 0 = gain := by
+  unfold requiredBond
+  split <;> omega
+
+/-- **(4) Capital substitution (the flywheel).** More reputation requires no more
+    bond: `requiredBond` is antitone in `rep`. -/
+theorem requiredBond_antitone (gain : Nat) {r1 r2 : Nat} (h : r1 ≤ r2) :
+    requiredBond gain r2 ≤ requiredBond gain r1 := by
+  unfold requiredBond
+  split <;> split <;> omega
+
+/-- **(5) Strict capital saving.** Positive reputation (up to the gain) *strictly*
+    lowers the required bond below the no-reputation case — the compounding edge. -/
+theorem requiredBond_strict_saving (gain rep : Nat) (hpos : 0 < rep) (hle : rep ≤ gain) :
+    requiredBond gain rep < requiredBond gain 0 := by
+  rw [sybil_no_discount]
+  unfold requiredBond
+  split <;> omega
+
+/-- **(6) Tightness / no under-collateralisation.** If `bond + rep < gain` the
+    agent is NOT deterred — capital cannot be reduced past `gain - rep` and remain
+    sound. The substitution has a proven floor. -/
+theorem under_collateralized_not_deterred (bond rep gain : Nat) (h : bond + rep < gain) :
+    ¬ deters bond rep gain := by
+  unfold deters
+  omega
+
+/-- **(7) Bridge to the fork-cost payoff.** A deterred defection has net payoff
+    `gain - (bond + rep) ≤ 0` over the COMBINED stake — i.e. reputation enters the
+    exact same deterrence inequality as the bond in
+    `Nucleus.WitnessOlog.ForkCost.staying_dominates`. -/
+theorem deters_implies_unprofitable (bond rep gain : Nat) (hd : deters bond rep gain) :
+    (gain : Int) - ((bond : Int) + (rep : Int)) ≤ 0 := by
+  unfold deters at hd
+  omega
+
+end Nucleus.ReputationCapital

--- a/crates/nucleus-witness-olog/src/bond.rs
+++ b/crates/nucleus-witness-olog/src/bond.rs
@@ -614,6 +614,39 @@ pub fn staying_is_rational(forfeiture: AmountMicro, max_defection_gain: AmountMi
     forfeiture.0 >= max_defection_gain.0
 }
 
+// ── Reputation ↔ capital substitution (the flywheel) ────────────────────────
+//
+// The deterrent against a one-shot defection is `bond + reputation_at_risk`
+// (future business forfeited if the defection is caught — and it is caught:
+// recompute is the fraud proof). So verifiable clean history substitutes for
+// posted collateral. PROVED sound + bounded in
+// `nucleus-econ-kernels/lean/Nucleus/ReputationCapital.lean` (`requiredBond_*`,
+// `[propext, Quot.sound]`-only); these functions are the value-identical mirror.
+
+/// Whether `bond` + `reputation_micro` (reputation value at risk) deters a
+/// one-shot defection worth `max_defection_gain_micro`. Mirrors Lean `deters`
+/// (`gain ≤ bond + rep`); `u128` sum avoids overflow.
+pub fn deters(bond: AmountMicro, reputation_micro: u64, max_defection_gain_micro: u64) -> bool {
+    u128::from(max_defection_gain_micro) <= u128::from(bond.0) + u128::from(reputation_micro)
+}
+
+/// The **minimum bond** a bonder must post to deter a one-shot defection worth
+/// `max_defection_gain_micro`, given `reputation_micro` already at risk: zero once
+/// reputation alone covers the gain, otherwise the shortfall. Mirrors Lean
+/// `requiredBond`.
+///
+/// Reputation substitutes for capital — but only down to this floor
+/// (`under_collateralized_not_deterred`), and a fresh identity (`reputation = 0`)
+/// pays the full bond (`sybil_no_discount`), so splitting into new identities buys
+/// no discount.
+pub fn required_bond(max_defection_gain_micro: u64, reputation_micro: u64) -> AmountMicro {
+    if max_defection_gain_micro <= reputation_micro {
+        AmountMicro::ZERO
+    } else {
+        AmountMicro(max_defection_gain_micro - reputation_micro)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -967,6 +1000,67 @@ mod tests {
             prop_assert_eq!(out.bond.slashed_micro.0 + out.returned_micro.0, amount);
             let routed: u64 = out.commons.iter().map(|a| a.amount_micro).sum();
             prop_assert_eq!(routed, out.slashed_this_event.0);
+        }
+    }
+
+    // ── Reputation ↔ capital substitution (parity with ReputationCapital.lean) ──
+
+    #[test]
+    fn required_bond_always_deters() {
+        // Lean `requiredBond_deters`: posting requiredBond + rep always deters.
+        for &(gain, rep) in &[(0u64, 0), (100, 0), (100, 40), (100, 100), (100, 250)] {
+            let rb = required_bond(gain, rep);
+            assert!(deters(rb, rep, gain), "must deter (gain={gain} rep={rep})");
+        }
+    }
+
+    #[test]
+    fn fresh_identity_pays_full_bond_no_sybil_discount() {
+        // Lean `sybil_no_discount`: rep=0 ⇒ full bond. Splitting buys nothing.
+        for &gain in &[0u64, 1, 100, u64::MAX] {
+            assert_eq!(required_bond(gain, 0).0, gain);
+        }
+    }
+
+    #[test]
+    fn reputation_substitutes_for_capital() {
+        // Lean `requiredBond_antitone` + `requiredBond_strict_saving`.
+        let gain = 1_000u64;
+        assert!(required_bond(gain, 600) <= required_bond(gain, 200));
+        assert!(required_bond(gain, 600) < required_bond(gain, 0)); // strict saving
+        assert_eq!(required_bond(gain, 200).0, 800);
+        assert_eq!(required_bond(gain, 1_000).0, 0); // reputation alone covers it
+    }
+
+    #[test]
+    fn required_bond_never_exceeds_gain() {
+        // Lean `requiredBond_le_gain`: reputation never increases required capital.
+        for &(gain, rep) in &[(0u64, 5), (100, 0), (100, 30), (100, 100), (100, 500)] {
+            assert!(required_bond(gain, rep).0 <= gain);
+        }
+    }
+
+    #[test]
+    fn cannot_under_collateralize() {
+        // Lean `under_collateralized_not_deterred`: below the floor, not deterred.
+        assert!(!deters(AmountMicro(300), 200, 1_000)); // 500 < 1000
+        assert!(deters(AmountMicro(800), 200, 1_000)); // 1000 >= 1000 (at the floor)
+    }
+
+    proptest! {
+        /// Parity with ReputationCapital.lean over the full range: requiredBond
+        /// always deters, never exceeds the gain, and is antitone in reputation.
+        #[test]
+        fn required_bond_parity(
+            gain in 0u64..u64::MAX,
+            rep in 0u64..u64::MAX,
+            more in 0u64..u64::MAX,
+        ) {
+            let rb = required_bond(gain, rep);
+            prop_assert!(deters(rb, rep, gain));
+            prop_assert!(rb.0 <= gain);
+            let rep2 = rep.saturating_add(more); // rep2 >= rep
+            prop_assert!(required_bond(gain, rep2) <= required_bond(gain, rep));
         }
     }
 }

--- a/crates/nucleus-witness-olog/src/lib.rs
+++ b/crates/nucleus-witness-olog/src/lib.rs
@@ -26,8 +26,8 @@ pub mod manifest;
 
 pub use bond::{
     canonical_bond_bytes, canonical_ownership_bytes, canonical_root_attestation_bytes,
-    canonical_signed_recompute_bytes, canonical_witness_claim_bytes, forfeiture_amount,
-    forfeiture_on_fork, mint_bond, release_bond, sign_ownership, sign_recompute,
+    canonical_signed_recompute_bytes, canonical_witness_claim_bytes, deters, forfeiture_amount,
+    forfeiture_on_fork, mint_bond, release_bond, required_bond, sign_ownership, sign_recompute,
     sign_root_attestation, sign_witness_claim, slash, staying_is_rational,
     total_canonical_collateral, verify_bond, verify_ownership, verify_root_attestation,
     verify_signed_recompute, verify_witness_claim, AmountMicro, Bond, BondError, BondStanding,

--- a/sdks/verifier-js/Cargo.toml
+++ b/sdks/verifier-js/Cargo.toml
@@ -24,6 +24,10 @@ nucleus-ifc = { path = "../../crates/nucleus-ifc", features = ["decision"] }
 # price (VCG + Pigou), the settlement split, and the externality→commons routing.
 nucleus-econ-kernels = { path = "../../crates/nucleus-econ-kernels" }
 nucleus-externality = { path = "../../crates/nucleus-externality" }
+# Bonding: lets the SDK compute the recompute-slashed required bond from an
+# agent's defection exposure + its verified reputation (the proven
+# reputation↔capital substitution). No new trust — pure proven arithmetic.
+nucleus-witness-olog = { path = "../../crates/nucleus-witness-olog" }
 wasm-bindgen = "0.2"
 serde-wasm-bindgen = "0.6"
 serde = { version = "1", features = ["derive"] }

--- a/sdks/verifier-js/index.d.ts
+++ b/sdks/verifier-js/index.d.ts
@@ -181,3 +181,23 @@ export function recomputeAssuranceRung(
   overall_rung: AssuranceRung | null;
   dimensions: Array<{ dimension: string; rung: AssuranceRung }>;
 }>;
+
+/**
+ * Re-derive the minimum bond a counterparty should require, given an agent's
+ * one-shot defection exposure and its verified reputation value at risk. The
+ * reputation↔capital flywheel made actionable: more clean history ⇒ less bond.
+ * Runs the proven `required_bond` (antitone in reputation; fresh identity pays the
+ * full bond; floored so you cannot under-collateralize). Returns micro-units.
+ */
+export function recomputeRequiredBond(
+  maxDefectionGainMicro: number | bigint,
+  reputationMicro: number | bigint,
+): Promise<bigint>;
+
+/** Re-derive whether `bond + reputation` deters a defection of the given gain
+ *  (proven `deters`: `gain ≤ bond + rep`). */
+export function recomputeDeters(
+  bondMicro: number | bigint,
+  reputationMicro: number | bigint,
+  maxDefectionGainMicro: number | bigint,
+): Promise<boolean>;

--- a/sdks/verifier-js/index.js
+++ b/sdks/verifier-js/index.js
@@ -386,3 +386,36 @@ export async function recomputeAssuranceRung(layers) {
   const mod = await initWasm();
   return mod.recomputeAssuranceRung(JSON.stringify(layers));
 }
+
+/**
+ * Re-derive the **minimum bond** a counterparty should require of an agent, given
+ * its worst-case one-shot defection exposure and its (verified) reputation value
+ * at risk. The flywheel made actionable: more verifiable clean history ⇒ a lower
+ * bond to lock — recomputable by anyone, no server trust. Runs the proven
+ * `required_bond` (antitone in reputation; a fresh identity pays the full bond;
+ * floored so you can't under-collateralize).
+ *
+ * SCOPE: the capital arithmetic only — it does not attest that `reputationMicro`
+ * is real (that's the recompute+pinning layer re-deriving the agent's history).
+ *
+ * @param {number|bigint} maxDefectionGainMicro
+ * @param {number|bigint} reputationMicro
+ * @returns {Promise<bigint>} the minimum bond in micro-units.
+ */
+export async function recomputeRequiredBond(maxDefectionGainMicro, reputationMicro) {
+  const mod = await initWasm();
+  return mod.recomputeRequiredBond(big(maxDefectionGainMicro), big(reputationMicro));
+}
+
+/**
+ * Re-derive whether `bondMicro` + `reputationMicro` deters a one-shot defection
+ * worth `maxDefectionGainMicro` (proven `deters`: `gain ≤ bond + rep`).
+ * @param {number|bigint} bondMicro
+ * @param {number|bigint} reputationMicro
+ * @param {number|bigint} maxDefectionGainMicro
+ * @returns {Promise<boolean>}
+ */
+export async function recomputeDeters(bondMicro, reputationMicro, maxDefectionGainMicro) {
+  const mod = await initWasm();
+  return mod.recomputeDeters(big(bondMicro), big(reputationMicro), big(maxDefectionGainMicro));
+}

--- a/sdks/verifier-js/src/lib.rs
+++ b/sdks/verifier-js/src/lib.rs
@@ -415,3 +415,36 @@ pub fn recompute_assurance_rung_js(layers_json: &str) -> Result<JsValue, JsError
     .serialize(&serializer)
     .map_err(|e| JsError::new(&e.to_string()))
 }
+
+// ── Reputation→capital standing (the flywheel, made actionable) ──────────────
+
+/// Re-derive the **minimum bond** a counterparty should require of an agent, given
+/// the agent's worst-case one-shot defection exposure and its (verified) reputation
+/// value at risk. Runs the PROVEN `nucleus-witness-olog::required_bond`
+/// (`ReputationCapital.lean`: antitone in reputation, `sybil_no_discount`, floored
+/// by `under_collateralized_not_deterred`). u64 µ-amounts in/out.
+///
+/// This is the flywheel made actionable: more verifiable clean history ⇒ a lower
+/// bond the agent must lock — recomputable by anyone, no server trust.
+#[wasm_bindgen(js_name = recomputeRequiredBond)]
+pub fn recompute_required_bond_js(max_defection_gain_micro: u64, reputation_micro: u64) -> u64 {
+    set_panic_hook();
+    nucleus_witness_olog::required_bond(max_defection_gain_micro, reputation_micro).0
+}
+
+/// Re-derive whether a posted `bond` plus `reputation_micro` (reputation value at
+/// risk) deters a one-shot defection worth `max_defection_gain_micro`. Runs the
+/// proven `nucleus-witness-olog::deters` (`gain ≤ bond + rep`).
+#[wasm_bindgen(js_name = recomputeDeters)]
+pub fn recompute_deters_js(
+    bond_micro: u64,
+    reputation_micro: u64,
+    max_defection_gain_micro: u64,
+) -> bool {
+    set_panic_hook();
+    nucleus_witness_olog::deters(
+        nucleus_witness_olog::AmountMicro(bond_micro),
+        reputation_micro,
+        max_defection_gain_micro,
+    )
+}

--- a/sdks/verifier-js/test/smoke.test.mjs
+++ b/sdks/verifier-js/test/smoke.test.mjs
@@ -13,7 +13,13 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 
-import { verify, VerifyError, recomputeAssuranceRung } from "../index.js";
+import {
+  verify,
+  VerifyError,
+  recomputeAssuranceRung,
+  recomputeRequiredBond,
+  recomputeDeters,
+} from "../index.js";
 
 const fixtureDir = new URL("../demo-fixtures/", import.meta.url);
 
@@ -113,4 +119,22 @@ test("empty profile has null overall rung", async () => {
   const r = await recomputeAssuranceRung([]);
   assert.equal(r.overall_rung, null);
   assert.deepEqual(r.dimensions, []);
+});
+
+test("recomputeRequiredBond: reputation substitutes for capital (the flywheel)", async () => {
+  // More reputation ⇒ no more bond; positive reputation strictly less.
+  assert.equal(await recomputeRequiredBond(1_000n, 0n), 1_000n); // fresh: full bond (no Sybil discount)
+  assert.equal(await recomputeRequiredBond(1_000n, 200n), 800n); // 200 reputation → 800 bond
+  assert.equal(await recomputeRequiredBond(1_000n, 1_000n), 0n); // reputation alone covers it
+  const r600 = await recomputeRequiredBond(1_000n, 600n);
+  const r200 = await recomputeRequiredBond(1_000n, 200n);
+  assert.ok(r600 <= r200, "antitone in reputation");
+});
+
+test("recomputeDeters: bond + reputation must cover the defection gain", async () => {
+  assert.equal(await recomputeDeters(300n, 200n, 1_000n), false); // 500 < 1000 — not deterred
+  assert.equal(await recomputeDeters(800n, 200n, 1_000n), true); // 1000 >= 1000 — at the floor
+  // Posting exactly the required bond always deters.
+  const rb = await recomputeRequiredBond(1_000n, 200n);
+  assert.equal(await recomputeDeters(rb, 200n, 1_000n), true);
 });


### PR DESCRIPTION
## What

**Operationalizes the flywheel.** A counterparty can now recompute — with **no
server trust** — the minimum bond an agent must post given its worst-case defection
exposure and its *verified* reputation. Verifiable clean history concretely lowers
the capital the agent locks.

- **`recomputeRequiredBond(maxDefectionGainMicro, reputationMicro) → bigint`** —
  runs the **proven** `nucleus-witness-olog::required_bond`
  (`ReputationCapital.lean`: antitone in reputation, `sybil_no_discount`, floored by
  `under_collateralized_not_deterred`).
- **`recomputeDeters(bond, reputation, gain) → bool`** — the proven `deters`
  (`gain ≤ bond + rep`).

wasm exports + JS facade (BigInt-coerced) + `index.d.ts` types + 2 Node tests (the
flywheel: reputation substitutes for capital, antitone, no-Sybil-discount; deters at
the floor). wasm rebuilt; **9/9 SDK tests green**; clippy clean. Adds
`nucleus-witness-olog` as a verifier-js dep (compiles to wasm32 cleanly, ct-merkle
included).

**Scope:** the capital arithmetic only — it does **not** attest that reputation is
real (that's the recompute + pinning layer re-deriving the agent's history). The
receipt now yields an **actionable standing**.

> Stacked on #1760 (the reputation-capital proofs that add `required_bond`); until
> that merges this PR shows both commits — squash-against-main resolves it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)