### PR TITLE
ci(deps): version-ceiling ratchet + wasm-closure gate (G1)

### DIFF
--- a/.github/workflows/dep-hygiene.yml
+++ b/.github/workflows/dep-hygiene.yml
@@ -1,0 +1,64 @@
+name: Dependency Hygiene Gates
+
+# Closes gap G1 (chariot punch-list): two SAFE, non-breaking dependency gates.
+#
+#  1. Version-duplication ceiling — caps the number of distinct versions of
+#     security-critical crates (ed25519-dalek, sha2) at a documented baseline so
+#     NEW drift fails CI. A ratchet, not a single-version claim: the dalek 2→3
+#     unification is deliberately HELD for a separate tested pass. Lowering a
+#     ceiling (paying down the debt) is itself enforced — a crate that drops
+#     below its ceiling fails until the ceiling is tightened.
+#
+#  2. WASM closure — asserts the recompute SDK's (nucleus-verifier-wasm) wasm32
+#     dependency closure contains no native-only crate (`ring`), which would
+#     break the in-browser recompute that is the whole point of the SDK.
+#
+# Both run today GREEN (see scripts); they exist to catch regressions.
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "crates/**/Cargo.toml"
+      - "sdks/**/Cargo.toml"
+      - "scripts/check-dep-ceiling.sh"
+      - "scripts/check-wasm-closure.sh"
+      - ".github/workflows/dep-hygiene.yml"
+  pull_request:
+    paths:
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "crates/**/Cargo.toml"
+      - "sdks/**/Cargo.toml"
+      - "scripts/check-dep-ceiling.sh"
+      - "scripts/check-wasm-closure.sh"
+      - ".github/workflows/dep-hygiene.yml"
+  merge_group:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  dep-hygiene:
+    name: version ceiling + wasm closure
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install Rust (with wasm32 target for the closure resolve)
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: stable
+          targets: wasm32-unknown-unknown
+
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2.9.1
+
+      - name: Version-duplication ceiling (ed25519-dalek, sha2)
+        run: bash scripts/check-dep-ceiling.sh
+
+      - name: WASM closure (no native-only crates in the recompute SDK)
+        run: bash scripts/check-wasm-closure.sh

--- a/scripts/check-dep-ceiling.sh
+++ b/scripts/check-dep-ceiling.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Dependency-duplication ceiling (gap G1) — a RATCHET, not a single-version claim.
+#
+# The workspace currently carries known duplicate versions of a few
+# security-critical crates. A naive "exactly one version" gate would be both
+# false (there are several) and impossible to satisfy without a risky dependency
+# unification (the ed25519-dalek 2→3 collapse, deliberately HELD for a careful
+# tested pass). So instead this caps the version count per watched crate at a
+# documented ceiling: NEW drift (a PR that introduces another version) fails CI,
+# while the existing debt is visible and paid down by *lowering* a ceiling when a
+# unification lands. Never raise a ceiling without recording why below.
+#
+# Honest framing for PROOFS.md / pitches: dependency hygiene here is RATCHETED,
+# not single-version. See docs/PROOFS.md.
+#
+# Why a count-ceiling script and not cargo-deny's native per-crate
+# `deny-multiple-versions` (EmbarkStudios/cargo-deny#365): that flag enforces
+# EXACTLY ONE version (would fail today, since the dalek collapse is held) and
+# needs exact-version `[[bans.skip]]` allowlists that break spuriously on a
+# transitive patch bump (=2.2.0 → =2.2.1). A count-ceiling is version-agnostic
+# within a line, AND it can enforce the ratchet *down* (fail when a crate drops
+# below its ceiling so the win gets locked in) — neither of which cargo-deny
+# does. The global `[bans] multiple-versions` stays "warn" to avoid breaking
+# main on the many benign transitive dups.
+#
+# Usage: scripts/check-dep-ceiling.sh
+#   Exits non-zero if any watched crate exceeds its ceiling (or — to force the
+#   ratchet down — is strictly *below* it, which means the ceiling should be
+#   lowered in this same commit).
+
+set -euo pipefail
+
+# watched-crate ceilings. Format: "<crate> <max-distinct-versions>".
+#
+# ed25519-dalek = 2
+#   v2.2.0        ← workspace default ("2"): econ-kernels, externality,
+#                   witness-olog, nucleus-node; + transitively via jsonwebtoken v10.
+#   v3.0.0-pre.7  ← pinned by envelope, lineage, oidc-*, verifier-service,
+#                   trust-registry, witness, control-plane-server; + via iroh.
+#   PLAN: collapse to 1 by moving the workspace default to v3 once a tested pass
+#         confirms jsonwebtoken + nucleus-node build on dalek 3 (HELD — risky).
+#
+# sha2 = 3
+#   v0.9.9   ← drand-verify v0.6.2 (nucleus-client → cli/mcp/node/sdk/tool-proxy)
+#   v0.10.9  ← workspace default (econ-kernels, witness-olog, …)
+#   v0.11.0  ← ed25519-dalek v3.0.0-pre.7 / iroh path
+#   PLAN: drops to 2 when drand-verify passes sha2 0.9; to 1 when the dalek
+#         unification settles sha2 on one minor.
+CEILINGS=(
+  "ed25519-dalek 2"
+  "sha2 3"
+)
+
+root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$root"
+
+# Full workspace tree once; count distinct "<crate> vX.Y.Z" lines per crate.
+# `--workspace --all-features` so a feature-gated extra version is still caught.
+tree="$(cargo tree --workspace --all-features 2>/dev/null)"
+
+fail=0
+ratchet=0
+for entry in "${CEILINGS[@]}"; do
+  name="${entry%% *}"
+  ceiling="${entry##* }"
+  # Match the crate name exactly at a tree node, capture its version tokens.
+  versions="$(printf '%s\n' "$tree" \
+    | grep -oE "(^|[│├└─ ])${name} v[0-9][A-Za-z0-9.+-]*" \
+    | grep -oE "v[0-9][A-Za-z0-9.+-]*" \
+    | sort -u || true)"
+  count="$(printf '%s\n' "$versions" | grep -c . || true)"
+
+  echo "── ${name}: ${count} version(s) (ceiling ${ceiling})"
+  printf '%s\n' "$versions" | sed 's/^/     /'
+
+  if [[ "$count" -gt "$ceiling" ]]; then
+    echo "  ✖ VIOLATION: ${name} has ${count} versions, ceiling is ${ceiling}."
+    echo "    A new duplicate slipped in. Unify it, or (only with justification)"
+    echo "    raise the ceiling in scripts/check-dep-ceiling.sh."
+    fail=1
+  elif [[ "$count" -lt "$ceiling" ]]; then
+    echo "  ↓ RATCHET: ${name} is down to ${count} (< ceiling ${ceiling})."
+    echo "    Lower the ceiling to ${count} in this commit to lock the win in."
+    ratchet=1
+  else
+    echo "  ✓ at ceiling"
+  fi
+done
+
+if [[ "$fail" -ne 0 ]]; then
+  exit 1
+fi
+if [[ "$ratchet" -ne 0 ]]; then
+  echo ""
+  echo "A watched crate dropped below its ceiling — tighten the ratchet."
+  exit 1
+fi
+echo ""
+echo "All watched crates within their duplication ceilings."

--- a/scripts/check-wasm-closure.sh
+++ b/scripts/check-wasm-closure.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# WASM dependency-closure gate (gap G1).
+#
+# `nucleus-verifier-wasm` (sdks/verifier-js) is the recompute SDK: it pulls the
+# proven kernels (envelope, lineage, ifc, econ-kernels, externality, witness-olog)
+# and re-derives the cleared price / settlement split / commons routing / required
+# bond IN THE BROWSER — no trust in the verifier service. It must therefore
+# compile to wasm32-unknown-unknown, which means its ENTIRE dependency closure has
+# to be wasm-compatible. The classic break is a native-only crypto crate
+# (`ring`) sneaking into the closure transitively — it fails to wasm-compile, and
+# a full `wasm-pack build` to discover that is slow. This asserts, at the cargo
+# tree level, that the forbidden native-only crates stay out of the wasm closure.
+#
+# This is a fast pre-flight; it does NOT replace the wasm-pack build, it fails
+# faster and with a clearer message when a dependency bump pulls `ring` in.
+#
+# Usage: scripts/check-wasm-closure.sh
+
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")/.." && pwd)"
+manifest="$root/sdks/verifier-js/Cargo.toml"
+
+# Native-only crates that cannot compile to wasm32-unknown-unknown. `ring` is the
+# one that actually bites (vendored C/asm); the rest are defensive.
+FORBIDDEN=(ring openssl-sys)
+
+echo "WASM closure gate: nucleus-verifier-wasm (target wasm32-unknown-unknown)"
+
+# `--target wasm32-unknown-unknown` resolves cfg(target_arch) deps as they would
+# be for the real wasm build. The crate is workspace-excluded, so use --manifest-path.
+tree="$(cargo tree --manifest-path "$manifest" --target wasm32-unknown-unknown 2>/dev/null)"
+
+fail=0
+for c in "${FORBIDDEN[@]}"; do
+  if printf '%s\n' "$tree" | grep -qE "(^|[│├└─ ])${c} v[0-9]"; then
+    echo "  ✖ VIOLATION: '${c}' is in the wasm32 closure — it will not wasm-compile."
+    echo "    Trace it with:"
+    echo "      cargo tree --manifest-path sdks/verifier-js/Cargo.toml \\"
+    echo "        --target wasm32-unknown-unknown -i ${c}"
+    echo "    Then feature-gate or replace the dependency that pulls it."
+    fail=1
+  else
+    echo "  ✓ '${c}' absent from the wasm closure"
+  fi
+done
+
+if [[ "$fail" -ne 0 ]]; then
+  exit 1
+fi
+echo ""
+echo "WASM closure is clean — no native-only crates."


### PR DESCRIPTION
Closes **G1** of the chariot punch-list — two SAFE, non-breaking dependency-hygiene gates. Both run **green today**; they exist to catch regressions, and deliberately do **not** force the held ed25519-dalek 2→3 unification.

## 1. Version-duplication ceiling — `scripts/check-dep-ceiling.sh`
Caps distinct versions of security-critical crates at a documented baseline:
- **ed25519-dalek ≤ 2** — v2.2.0 (workspace default `"2"`: econ-kernels, externality, witness-olog, node + jsonwebtoken) / v3.0.0-pre.7 (envelope, lineage, oidc-*, verifier-service, trust-registry, witness, control-plane-server + iroh).
- **sha2 ≤ 3** — 0.9.9 (drand-verify), 0.10.9 (workspace), 0.11.0 (dalek-v3/iroh).

A **ratchet**: a *new* duplicate fails CI, and a crate dropping *below* its ceiling also fails (so the win gets locked in by lowering the ceiling in the same commit). Each duplicate's source + collapse plan is inline.

Chosen over cargo-deny's native per-crate `deny-multiple-versions` ([#365](https://github.com/EmbarkStudios/cargo-deny/pull/365)), which enforces *exactly one* (would fail today), needs exact-version `skip` allowlists that break on transitive patch bumps, and can't enforce ratchet-down. The global `[bans] multiple-versions` stays `warn` to avoid breaking main on benign transitive dups.

## 2. WASM closure — `scripts/check-wasm-closure.sh`
Asserts the recompute SDK (`nucleus-verifier-wasm`, sdks/verifier-js) wasm32 closure has **no native-only crate** (`ring`, `openssl-sys`) — those break the in-browser recompute that is the SDK's whole point. Fast pre-flight before `wasm-pack`.

## HELD (not here)
The dalek 2→3 collapse spans the candidate core and needs a careful tested pass, not a loop iteration. Tracked.

Local run: both gates rc=0 (dalek at ceiling 2, sha2 at ceiling 3, wasm closure clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)