### PR TITLE
test(verify): WASM golden reader now covers VCG (G3 seal)

### DIFF
--- a/sdks/verifier-js/test/golden.test.mjs
+++ b/sdks/verifier-js/test/golden.test.mjs
@@ -1,9 +1,10 @@
 // WASM reader of the cross-language golden seal (gap G3b).
 //
 // The SAME JSON vectors in crates/nucleus-econ-kernels/tests/golden/ pin the
-// settlement + commons kernels across Lean (Nucleus/Golden.lean `decide`), Rust
-// (tests/golden.rs), and — here — the @coproduct/verify WASM bindings. This test
-// asserts recomputeSettlement / recomputeCommons reproduce the golden bytes
+// settlement + commons + VCG kernels across Lean (Nucleus/Golden.lean `decide`,
+// settlement + commons), Rust (tests/golden.rs, all three), and — here — the
+// @coproduct/verify WASM bindings (settlement + commons + VCG). This test asserts
+// recomputeSettlement / recomputeCommons / recomputeVcg reproduce the golden bytes
 // exactly, so the u64↔BigInt marshaling and serde_wasm_bindgen layer can't drift
 // from the proven kernels without turning CI red.
 //
@@ -14,7 +15,7 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 
-import { recomputeSettlement, recomputeCommons } from "../index.js";
+import { recomputeSettlement, recomputeCommons, recomputeVcg } from "../index.js";
 
 // test/ -> verifier-js/ -> sdks/ -> repo root -> crates/...
 const goldenDir = new URL(
@@ -68,5 +69,32 @@ test("recomputeCommons matches every golden commons vector (no skim)", async () 
     // No-skim: allocations sum to exactly the pool (matches Lean routed_conserves).
     const sum = got.reduce((acc, x) => acc + x, 0n);
     assert.equal(sum, BigInt(v.pool_micro), `conservation pool=${v.pool_micro}`);
+  }
+});
+
+test("recomputeVcg matches every golden VCG vector (winners + Clarke pivots)", async () => {
+  const g = await readGolden("vcg.json");
+  for (const v of g.vectors) {
+    const c = await recomputeVcg(v.bids, v.proposals, v.budget_micro_usd);
+    // Winners: same count, same (bidder, proposal_id, vcg_payment) in order.
+    assert.equal(c.winners.length, v.winners.length, `winner count ${v._name}`);
+    for (let i = 0; i < v.winners.length; i++) {
+      assert.equal(c.winners[i].bidder, v.winners[i].bidder, `winner bidder ${v._name}`);
+      assert.equal(
+        c.winners[i].proposal_id,
+        v.winners[i].proposal_id,
+        `winner proposal ${v._name}`,
+      );
+      assert.equal(
+        BigInt(c.winners[i].vcg_payment_micro_usd),
+        BigInt(v.winners[i].vcg_payment_micro_usd),
+        `vcg payment ${v._name}/${v.winners[i].bidder}`,
+      );
+    }
+    assert.equal(
+      BigInt(c.total_payments_micro_usd),
+      BigInt(v.total_payments_micro_usd),
+      `total payments ${v._name}`,
+    );
   }
 });


### PR DESCRIPTION
Extends the WASM arm of the golden seal to **VCG**, matching Rust's coverage.

`vcg.json` already named `recomputeVcg` as its intended WASM reader, but the WASM golden test (`golden.test.mjs`) only exercised settlement + commons. This adds the VCG case: for each golden vector, `recomputeVcg(bids, proposals, budget)` must reproduce the winners (bidder, proposal_id, Clarke-pivot payment) and total payments exactly.

| reader | settlement | commons | VCG |
|---|---|---|---|
| Lean `decide` | ✅ | ✅ | property-level |
| Rust | ✅ | ✅ | ✅ |
| WASM | ✅ | ✅ | ✅ **(new)** |
| Solidity | ✅ (#1772) | — | — |

Local: `wasm-pack build` + `node --test` → **3/3 golden suites pass**. PROOFS.md seal-row update deferred to avoid a conflict with the in-flight Solidity-arm PR (#1772).

🤖 Generated with [Claude Code](https://claude.com/claude-code)