### PR TITLE
test(ifc): golden vectors for the IFC decision gate (seal's IFC arm, G3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6684,6 +6684,7 @@ version = "1.0.0"
 dependencies = [
  "portcullis-core",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/nucleus-ifc/Cargo.toml
+++ b/crates/nucleus-ifc/Cargo.toml
@@ -13,6 +13,12 @@ categories = ["development-tools"]
 portcullis-core = { version = "1.0.0", path = "../portcullis-core" }
 serde = { version = "1", features = ["derive"], optional = true }
 
+[dev-dependencies]
+# Golden-vector reader (tests/golden.rs, gated on `decision`): reads the IFC
+# decision vectors shared with the WASM recomputeVerdict binding.
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
 [features]
 # The model-level IFC `decision` module (FlowDeclaration → IfcVerdict). Pulls
 # serde; kept optional so the base IFC engine stays dependency-light. Enabled by

--- a/crates/nucleus-ifc/tests/golden.rs
+++ b/crates/nucleus-ifc/tests/golden.rs
@@ -1,0 +1,61 @@
+//! Golden-vector reader for the IFC decision gate (the seal's IFC arm, gap G3).
+//!
+//! Pins `FlowDeclaration::decide()` — the model-level lethal-trifecta gate — to a
+//! single-source JSON of (inputs, sink_public) → (allow, declared_inputs). The
+//! SAME vectors feed the WASM `recomputeVerdict` binding, so the Rust gate and the
+//! in-browser recompute cannot drift from each other (or from these verdicts)
+//! without turning CI red. Mirrors the seal pattern used for the econ kernels.
+//!
+//! Gated on the `decision` feature (which `decide()` lives behind); CI's
+//! `cargo test --all-features` exercises it.
+#![cfg(feature = "decision")]
+
+use std::path::PathBuf;
+
+use nucleus_ifc::decision::{DeclaredInput, FlowDeclaration};
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct GoldenFile {
+    vectors: Vec<Vector>,
+}
+
+#[derive(Deserialize)]
+struct Vector {
+    #[serde(rename = "_name", default)]
+    name: String,
+    inputs: Vec<DeclaredInput>,
+    #[serde(default)]
+    requires_authority: bool,
+    #[serde(default)]
+    sink_public: bool,
+    allow: bool,
+    declared_inputs: Vec<String>,
+}
+
+#[test]
+fn ifc_decision_matches_golden_vectors() {
+    let path: PathBuf = [env!("CARGO_MANIFEST_DIR"), "tests", "golden", "ifc.json"]
+        .iter()
+        .collect();
+    let bytes = std::fs::read(&path).unwrap_or_else(|e| panic!("read {path:?}: {e}"));
+    let golden: GoldenFile =
+        serde_json::from_slice(&bytes).unwrap_or_else(|e| panic!("parse {path:?}: {e}"));
+
+    assert!(!golden.vectors.is_empty(), "golden file has no vectors");
+
+    for v in &golden.vectors {
+        let mut decl = FlowDeclaration::new(v.inputs.iter().copied());
+        decl.requires_authority = v.requires_authority;
+        decl.sink_public = v.sink_public;
+
+        let verdict = decl.decide();
+
+        assert_eq!(verdict.is_allow(), v.allow, "allow mismatch: {}", v.name);
+        assert_eq!(
+            verdict.declared_inputs, v.declared_inputs,
+            "declared_inputs mismatch: {}",
+            v.name
+        );
+    }
+}

--- a/crates/nucleus-ifc/tests/golden/ifc.json
+++ b/crates/nucleus-ifc/tests/golden/ifc.json
@@ -1,0 +1,53 @@
+{
+  "_doc": "Golden IFC decision vectors — pins FlowDeclaration::decide() (the model-level lethal-trifecta gate) so the Rust decision matches these exact allow/deny verdicts. The SAME inputs feed the WASM recomputeVerdict binding. declared_inputs is sorted by DeclaredInput declaration order (NOT alphabetical) + deduped. Verdicts mirror the in-crate unit tests; editing decision.rs to diverge turns CI red.",
+  "vectors": [
+    {
+      "_name": "clean flow: trusted prompt + internal row to counterparty",
+      "inputs": ["user_prompt", "database_row"],
+      "requires_authority": false,
+      "sink_public": false,
+      "allow": true,
+      "declared_inputs": ["user_prompt", "database_row"]
+    },
+    {
+      "_name": "adversarial ancestry: web content taints the outbound action",
+      "inputs": ["user_prompt", "web_content"],
+      "requires_authority": false,
+      "sink_public": false,
+      "allow": false,
+      "declared_inputs": ["user_prompt", "web_content"]
+    },
+    {
+      "_name": "secret to a counterparty sink is denied",
+      "inputs": ["secret"],
+      "requires_authority": false,
+      "sink_public": false,
+      "allow": false,
+      "declared_inputs": ["secret"]
+    },
+    {
+      "_name": "private row to an internal (non-public) sink is allowed",
+      "inputs": ["database_row"],
+      "requires_authority": false,
+      "sink_public": false,
+      "allow": true,
+      "declared_inputs": ["database_row"]
+    },
+    {
+      "_name": "same private row to a PUBLIC sink is denied (confidentiality)",
+      "inputs": ["database_row"],
+      "requires_authority": false,
+      "sink_public": true,
+      "allow": false,
+      "declared_inputs": ["database_row"]
+    },
+    {
+      "_name": "declared set is sorted + deduped (order-independent verdict)",
+      "inputs": ["web_content", "user_prompt", "web_content"],
+      "requires_authority": false,
+      "sink_public": false,
+      "allow": false,
+      "declared_inputs": ["user_prompt", "web_content"]
+    }
+  ]
+}


### PR DESCRIPTION
Extends the golden seal to the **security core** — pins `FlowDeclaration::decide()` (the model-level lethal-trifecta gate) to single-source JSON vectors.

`(inputs, sink_public, requires_authority) → (allow, declared_inputs)`. The same vectors feed the WASM `recomputeVerdict` binding, so the Rust gate and the in-browser recompute can't drift from each other or from these verdicts without turning CI red.

- **`tests/golden/ifc.json`** — 6 vectors with verdicts **mirroring the in-crate unit tests** (known-correct, not guessed): clean flow → allow; web-content ancestry → deny; secret→counterparty → deny; private→internal allow vs private→**public** deny; sorted+deduped declared set (order-independent verdict).
- **`tests/golden.rs`** — reader gated on the `decision` feature (CI `--all-features` exercises it); asserts `decide()` reproduces `allow` + `declared_inputs` (sorted by `DeclaredInput` declaration order, not alphabetical).

**Seal coverage now:** settlement = 4 languages; commons = Lean+Rust+WASM; VCG = Rust+WASM; **IFC decision = Rust** (+ shares vectors with the WASM verdict path).

Local: `cargo test -p nucleus-ifc --features decision` → 1/1 (6 vectors); clippy `--all-features` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)