### PR TITLE
test(econ): Aeneas-subset mirror + differential proptest for settlement & commons (G2c')

### DIFF
--- a/crates/nucleus-econ-kernels/src/extracted/commons_aeneas.rs
+++ b/crates/nucleus-econ-kernels/src/extracted/commons_aeneas.rs
@@ -1,0 +1,80 @@
+//! Aeneas-grade mirror of `lean/Nucleus/Commons.lean`.
+//!
+//! Byte-faithful to the Lean `floorAllocs` / `routed` definitions; the parity
+//! proptests in `tests/settlement_commons_parity.rs` bind these mirrors to the
+//! production kernel (`crate::commons::route_to_commons`) over randomized inputs.
+//!
+//! Same tier as the other `extracted/*` mirrors: hand-transcribed Aeneas-subset
+//! Rust, faithful-by-review + proptest-bound, pending the real Charon pipeline
+//! (docs/PROOFS.md §5). Lean `List Nat` ↔ Rust `Vec<u64>`.
+
+#![deny(clippy::float_arithmetic)]
+
+/// Mirror of Lean `Commons` basis-point scale.
+pub const BPS_SCALE: u64 = 10_000;
+
+/// Rust mirror of `Nucleus.Commons.floorAllocs`.
+///
+/// Lean definition (verbatim):
+///
+/// ```text
+/// def floorAllocs (pool : Nat) (bps : List Nat) : List Nat :=
+///   bps.map (fun b => pool * b / 10000)
+/// ```
+pub fn floor_allocs(pool: u64, bps: &[u64]) -> Vec<u64> {
+    bps.iter()
+        .map(|&b| ((pool as u128 * b as u128) / BPS_SCALE as u128) as u64)
+        .collect()
+}
+
+/// Rust mirror of `Nucleus.Commons.routed`.
+///
+/// Lean definition (verbatim):
+///
+/// ```text
+/// def routed (pool : Nat) (bps : List Nat) : List Nat :=
+///   match floorAllocs pool bps with
+///   | [] => []
+///   | a :: rest => (a + (pool - (a :: rest).sum)) :: rest
+/// ```
+///
+/// The dust `pool - Σfloors` is assigned to the FIRST share, so the result sums
+/// to exactly `pool` (the Lean theorem `routed_conserves`, no-skim). `saturating_*`
+/// mirrors `Nat` arithmetic; `floorAllocs_sum_le` guarantees `Σfloors ≤ pool`.
+pub fn routed(pool: u64, bps: &[u64]) -> Vec<u64> {
+    let mut allocs = floor_allocs(pool, bps);
+    if let Some((first, rest)) = allocs.split_first_mut() {
+        let sum: u64 = first.saturating_add(rest.iter().copied().sum());
+        *first = first.saturating_add(pool.saturating_sub(sum));
+    }
+    allocs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_is_empty() {
+        assert_eq!(routed(1_000_000, &[]), Vec::<u64>::new());
+    }
+
+    #[test]
+    fn proportional_split_with_dust_to_first() {
+        // 60/25/15 of 1_000_000 — exact, no dust.
+        assert_eq!(
+            routed(1_000_000, &[6_000, 2_500, 1_500]),
+            vec![600_000, 250_000, 150_000]
+        );
+        // pool = 7: floors 4/1/1 = 6, dust 1 → first = 5 (matches the kernel + golden).
+        assert_eq!(routed(7, &[6_000, 2_500, 1_500]), vec![5, 1, 1]);
+    }
+
+    #[test]
+    fn no_skim_conservation() {
+        for &pool in &[0u64, 1, 7, 1_000_000, 9_999_999] {
+            let allocs = routed(pool, &[6_000, 2_500, 1_500]);
+            assert_eq!(allocs.iter().sum::<u64>(), pool, "skim/loss at pool={pool}");
+        }
+    }
+}

--- a/crates/nucleus-econ-kernels/src/extracted/mod.rs
+++ b/crates/nucleus-econ-kernels/src/extracted/mod.rs
@@ -39,5 +39,7 @@
 //! `typenum`) — a whole-crate `charon cargo` would fail on those. If you add a
 //! root here, add a matching `--start-from` in `scripts/aeneas-extract.sh`.
 
+pub mod commons_aeneas;
 pub mod pigou_aeneas;
+pub mod settlement_aeneas;
 pub mod vcg_aeneas;

--- a/crates/nucleus-econ-kernels/src/extracted/settlement_aeneas.rs
+++ b/crates/nucleus-econ-kernels/src/extracted/settlement_aeneas.rs
@@ -1,0 +1,114 @@
+//! Aeneas-grade mirror of `lean/Nucleus/Auctions/SettlementDecision.lean`.
+//!
+//! Each function below is byte-faithful to its Lean counterpart; reviewers
+//! comparing changes should diff against the Lean source line-by-line. The parity
+//! proptests in `tests/settlement_commons_parity.rs` exercise the equivalence
+//! between these mirrors and the production kernel (`crate::settlement`) over
+//! randomized inputs — added coverage the fixed golden vectors don't have.
+//!
+//! Status (same tier as `vcg_aeneas` / `pigou_aeneas`): **hand-transcribed**
+//! Aeneas-subset Rust, not yet Charon-extracted. The real Charon → LLBC → Aeneas
+//! → Lean pipeline (live for `portcullis-core`, see `.github/workflows/aeneas.yml`)
+//! extends to these roots once it runs against `nucleus-econ-kernels`; until then
+//! the mirror is faithful-by-review + proptest-bound. See docs/PROOFS.md §5.
+
+#![deny(clippy::float_arithmetic)]
+
+/// Mirror of Lean `bpsScale`.
+pub const BPS_SCALE: u64 = 10_000;
+
+/// Mirror of Lean `Verdict` as a stable integer tag: `0 = reverse`, `1 = partial`,
+/// `2 = release` (the same encoding the golden vectors use). Integer-only keeps
+/// the mirror inside the Aeneas-translatable subset.
+pub const VERDICT_REVERSE: u8 = 0;
+pub const VERDICT_PARTIAL: u8 = 1;
+pub const VERDICT_RELEASE: u8 = 2;
+
+/// Rust mirror of `Nucleus.Auctions.SettlementDecision.classify`.
+///
+/// Lean definition (verbatim):
+///
+/// ```text
+/// def classify (deliveredBps : Nat) : Verdict :=
+///   if deliveredBps = 0 then Verdict.Reverse
+///   else if deliveredBps ≥ bpsScale then Verdict.Release
+///   else Verdict.Partial
+/// ```
+pub fn classify(delivered_bps: u64) -> u8 {
+    if delivered_bps == 0 {
+        VERDICT_REVERSE
+    } else if delivered_bps >= BPS_SCALE {
+        VERDICT_RELEASE
+    } else {
+        VERDICT_PARTIAL
+    }
+}
+
+/// Rust mirror of `Nucleus.Auctions.SettlementDecision.sellerGross`.
+///
+/// Lean definition (verbatim):
+///
+/// ```text
+/// def sellerGross (price deliveredBps : Nat) : Nat :=
+///   price * (min deliveredBps bpsScale) / bpsScale
+/// ```
+///
+/// `u128` intermediate bridges Lean's unbounded `Nat` to `u64` without overflow;
+/// floor division matches `Nat` division exactly.
+pub fn seller_gross(price: u64, delivered_bps: u64) -> u64 {
+    let clamped = if delivered_bps < BPS_SCALE {
+        delivered_bps
+    } else {
+        BPS_SCALE
+    };
+    ((price as u128 * clamped as u128) / BPS_SCALE as u128) as u64
+}
+
+/// Rust mirror of `Nucleus.Auctions.SettlementDecision.refund`.
+///
+/// Lean definition (verbatim):
+///
+/// ```text
+/// def refund (price deliveredBps : Nat) : Nat :=
+///   price - sellerGross price deliveredBps
+/// ```
+///
+/// `saturating_sub` mirrors Lean truncated `Nat` subtraction; the Lean theorem
+/// `sellerGross_le_price` guarantees the subtrahend never exceeds `price`, so
+/// `seller_gross + refund == price` holds by construction (conservation).
+pub fn refund(price: u64, delivered_bps: u64) -> u64 {
+    price.saturating_sub(seller_gross(price, delivered_bps))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_buckets() {
+        assert_eq!(classify(0), VERDICT_REVERSE);
+        assert_eq!(classify(1), VERDICT_PARTIAL);
+        assert_eq!(classify(9_999), VERDICT_PARTIAL);
+        assert_eq!(classify(10_000), VERDICT_RELEASE);
+        assert_eq!(classify(25_000), VERDICT_RELEASE);
+    }
+
+    #[test]
+    fn seller_gross_and_refund_extremes() {
+        assert_eq!(seller_gross(1_000_000, 0), 0);
+        assert_eq!(refund(1_000_000, 0), 1_000_000);
+        assert_eq!(seller_gross(1_000_000, 10_000), 1_000_000);
+        assert_eq!(refund(1_000_000, 10_000), 0);
+        // Clamp above full delivery.
+        assert_eq!(seller_gross(1_000_000, 25_000), 1_000_000);
+    }
+
+    #[test]
+    fn conservation_holds() {
+        for &price in &[0u64, 1, 999, 1_000_000, 7_654_321] {
+            for &bps in &[0u64, 1, 2_500, 9_999, 10_000, 25_000] {
+                assert_eq!(seller_gross(price, bps) + refund(price, bps), price);
+            }
+        }
+    }
+}

--- a/crates/nucleus-econ-kernels/tests/settlement_commons_parity.rs
+++ b/crates/nucleus-econ-kernels/tests/settlement_commons_parity.rs
@@ -1,0 +1,74 @@
+//! Differential parity: production kernels ↔ Aeneas-subset mirrors (gap G2c′).
+//!
+//! Asserts that the kernel functions the money path actually runs
+//! (`crate::settlement::{classify, seller_gross, refund}`,
+//! `crate::commons::route_to_commons`) are byte-identical to the hand-transcribed,
+//! Lean-faithful mirrors in `extracted/{settlement,commons}_aeneas.rs` — over
+//! RANDOMIZED inputs, not just the fixed golden vectors. The Lean theorems certify
+//! the Lean defs; the mirrors are faithful to the Lean (by review); these proptests
+//! bind mirror ↔ kernel. Any drift between the kernel and the proven model turns
+//! CI red. Mirrors the `pigou_parity` / `lean_model_parity` pattern.
+
+use nucleus_econ_kernels::extracted::{commons_aeneas, settlement_aeneas};
+use nucleus_econ_kernels::{
+    classify, refund, route_to_commons, seller_gross, CommonsShare, Verdict,
+};
+use proptest::prelude::*;
+
+/// Kernel `Verdict` → the mirror's integer tag (0=reverse, 1=partial, 2=release).
+fn verdict_tag(v: Verdict) -> u8 {
+    match v {
+        Verdict::Reverse => settlement_aeneas::VERDICT_REVERSE,
+        Verdict::Partial => settlement_aeneas::VERDICT_PARTIAL,
+        Verdict::Release => settlement_aeneas::VERDICT_RELEASE,
+    }
+}
+
+proptest! {
+    /// Settlement: classify / seller_gross / refund agree kernel ↔ mirror.
+    #[test]
+    fn settlement_kernel_matches_mirror(price in any::<u64>(), bps in 0u64..=30_000) {
+        prop_assert_eq!(verdict_tag(classify(bps)), settlement_aeneas::classify(bps));
+        prop_assert_eq!(seller_gross(price, bps), settlement_aeneas::seller_gross(price, bps));
+        prop_assert_eq!(refund(price, bps), settlement_aeneas::refund(price, bps));
+        // Conservation holds on both (the Lean `conservation` theorem).
+        prop_assert_eq!(
+            settlement_aeneas::seller_gross(price, bps) + settlement_aeneas::refund(price, bps),
+            price
+        );
+    }
+
+    /// Commons: route_to_commons amounts agree with the mirror's `routed`, over
+    /// random pools and random valid 3-way splits (bps summing to 10_000).
+    #[test]
+    fn commons_kernel_matches_mirror(
+        // Keep the pool bounded so `pool * bps` stays well within u128.
+        pool in 0u64..=1_000_000_000_000u64,
+        s0 in 0u64..=10_000,
+        split in 0u64..=10_000,
+    ) {
+        // A random valid split: s0 + s1 + s2 == 10_000.
+        let s0 = s0.min(10_000);
+        let rem = 10_000 - s0;
+        let s1 = split % (rem + 1);
+        let s2 = rem - s1;
+        let bps = [s0, s1, s2];
+
+        let shares = vec![
+            CommonsShare { destination: "a".into(), bps: bps[0] },
+            CommonsShare { destination: "b".into(), bps: bps[1] },
+            CommonsShare { destination: "c".into(), bps: bps[2] },
+        ];
+
+        let kernel: Vec<u64> = route_to_commons(pool, &shares)
+            .expect("valid shares sum to 10_000")
+            .iter()
+            .map(|a| a.amount_micro)
+            .collect();
+        let mirror = commons_aeneas::routed(pool, &bps);
+
+        prop_assert_eq!(&kernel, &mirror);
+        // No-skim conservation on both (the Lean `routed_conserves` theorem).
+        prop_assert_eq!(mirror.iter().sum::<u64>(), pool);
+    }
+}

--- a/docs/PROOFS.md
+++ b/docs/PROOFS.md
@@ -115,6 +115,8 @@ The deepest gap is between a *proven Lean model* and the *running Rust*. Two way
 
 So **settlement + commons are extraction-closable** (turning two TESTED rows into PROVEN-about-the-real-code), while **VCG-with-hashmap and crypto stay TESTED + MODELED** — and that boundary is a property of the tool, not a shortcut.
 
+**Three rungs, and where settlement/commons sit today.** The bridge from a proven Lean def to the running Rust has rungs of increasing strength: (1) **golden vectors** — Lean `decide` == Rust on *fixed* inputs (§2); (2) **hand-transcribed Aeneas-subset mirror + differential proptest** — a Rust mirror byte-faithful (by review) to the Lean def, bound to the production kernel over *randomized* inputs (`crates/nucleus-econ-kernels/src/extracted/*_aeneas.rs` + `tests/*_parity.rs`); (3) **Charon-extracted Lean** — the model is *generated from* the Rust and the theorem is proven over it (the strongest; live for IFC). Settlement and commons now sit at rung (2) for `classify`/`seller_gross`/`refund`/`route_to_commons` (alongside pigou/vcg), **plus** the 4-language golden seal at rung (1). They are still at rung (2), not (3): rung (3) needs the Charon/Aeneas Linux toolchain run against `nucleus-econ-kernels` (the pipeline exists for `portcullis-core`; extending it to the econ crate is a Linux-CI bootstrap, not a code change) — so the mirror is honestly TESTED, not yet PROVEN-over-extracted.
+
 Integration cost is bounded: use pre-built Aeneas/Charon binaries + the sibling `aeneas-ci@v1` action, scope Charon with `--start-from`, never build OCaml (see `aeneas.yml` for the established pattern).
 
 ---


### PR DESCRIPTION
Extends the existing econ extraction-prep pattern (pigou/vcg already do this) to the two most load-bearing kernels, adding **randomized differential coverage** the fixed golden vectors lack.

- `extracted/settlement_aeneas.rs` — byte-faithful mirror of `SettlementDecision.lean`'s `classify`/`sellerGross`/`refund` (integer-only, Aeneas subset).
- `extracted/commons_aeneas.rs` — mirror of `Commons.lean`'s `floorAllocs`/`routed` (dust-to-first; Lean `List` ↔ Rust `Vec`).
- `tests/settlement_commons_parity.rs` — proptests binding the **production kernels** (`classify`/`seller_gross`/`refund`/`route_to_commons`) to the mirrors over random inputs + the conservation / no-skim invariants.

Local: parity proptests 2/2, 19 mirror unit tests, clippy clean.

## Honest scope (docs/PROOFS.md §5 — three rungs)
This is **rung (2)**: a mirror faithful-by-review to the proven Lean def + proptest-bound to the kernel = **TESTED** over randomized inputs. It is **not rung (3)** — real Charon-extracted Lean (PROVEN-over-real-code), which is live for `portcullis-core`/IFC. Reaching rung (3) for the econ crate needs the **Charon/Aeneas Linux toolchain** run against `nucleus-econ-kernels` (a Linux-CI bootstrap, not a code change) — not validatable on a macOS host, so deliberately **not overclaimed** as Charon extraction here. The PR documents that frontier precisely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)