### PR TITLE
test(ck-types): lock witness-digest identity invariants (signature-invariant + content-sensitive)

### DIFF
--- a/crates/ck-types/src/witness.rs
+++ b/crates/ck-types/src/witness.rs
@@ -500,6 +500,72 @@ mod tests {
     }
 
     #[test]
+    fn digest_is_invariant_under_resigning() {
+        // The witness's content-address IDENTITY excludes `signatures` (that is
+        // the whole point of `signing_payload`): re-signing, adding a cosignature,
+        // or reordering signatures must NOT change `digest()`. Otherwise the same
+        // logical witness would get a new identity every time it's countersigned,
+        // breaking dedup, the archive's content-addressing, and any anchored
+        // reference to it.
+        let base = test_bundle();
+        let original = base.digest();
+
+        let mut more_sigs = base.clone();
+        more_sigs.signatures.push(BundleSignature {
+            signer: "second-witness".into(),
+            algorithm: "ed25519".into(),
+            signature: "cafebabe".into(),
+            role: None,
+        });
+        assert_eq!(
+            more_sigs.digest(),
+            original,
+            "adding a cosignature changed identity"
+        );
+
+        let mut different_sig = base.clone();
+        different_sig.signatures[0].signature = "deadc0de".into();
+        assert_eq!(
+            different_sig.digest(),
+            original,
+            "re-signing changed identity"
+        );
+
+        let mut no_sigs = base.clone();
+        no_sigs.signatures.clear();
+        assert_eq!(
+            no_sigs.digest(),
+            original,
+            "clearing signatures changed identity"
+        );
+    }
+
+    #[test]
+    fn digest_is_content_sensitive() {
+        // The flip side: changing any CONTENT field MUST change the identity, so a
+        // witness can't be silently swapped under a fixed address. (`digest()`
+        // binds the artifact, not just the commit — see the struct docs.)
+        let base = test_bundle();
+        let original = base.digest();
+
+        let mut changed_candidate = base.clone();
+        changed_candidate.candidate_digest = ArtifactDigest::from_bytes(b"a different candidate");
+        assert_ne!(
+            changed_candidate.digest(),
+            original,
+            "candidate change not bound"
+        );
+
+        let mut changed_version = base.clone();
+        changed_version.bundle_version += 1;
+        assert_ne!(
+            changed_version.digest(),
+            original,
+            "version change not bound"
+        );
+    }
+
+    #[test]
     fn test_bundle_structurally_complete() {
         let b = test_bundle();
         assert!(b.is_structurally_complete().is_ok());


### PR DESCRIPTION
**Quality loop 2/51: `ck-types`.**

`WitnessBundle::digest()` clears the `signatures` field (via `signing_payload`) so a witness's content-address **identity is signature-independent** — the property the whole archive/dedup/anchoring story relies on. Only *determinism* was tested; the actual security invariant wasn't. Adds:

- **`digest_is_invariant_under_resigning`** — adding a cosignature, re-signing, or clearing signatures must **not** change `digest()` (else every countersignature mints a new identity).
- **`digest_is_content_sensitive`** — changing any content field (`candidate_digest`, `bundle_version`) **must** change `digest()` (a witness can't be swapped under a fixed address).

Uses the existing `test_bundle()` fixture; no new deps. 17 tests green, clippy clean.

Skipped this iteration as **already world-class** (no churn): `nucleus-externality` (rung chain is Ord==level-locked; canonical digest has determinism/order-independence/sensitivity/domain-separation tests) and `nucleus-recompute` (built + 11-test-covered this session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)