### PR TITLE
test(portcullis-core): exhaustively prove the verdict BILATTICE laws (assoc + absorption)

### DIFF
--- a/crates/portcullis-core/src/bilattice.rs
+++ b/crates/portcullis-core/src/bilattice.rs
@@ -515,6 +515,53 @@ mod tests {
         assert!(v.is_empty(), "Verdict lattice violations: {v:?}");
     }
 
+    #[test]
+    fn bilattice_law_battery_exhaustive() {
+        // The four-valued verdict is a BILATTICE (Belnap/Ginsberg): two
+        // interlocking lattices on the same carrier — the TRUTH lattice
+        // (`truth_meet` ⊓t / `truth_join` ⊔t) and the KNOWLEDGE lattice
+        // (`info_meet` ⊓k / `info_join` ⊔k). The tests above spot-check
+        // commutativity per op and `verdict_lattice_laws` covers the trait
+        // lattice; this proves BOTH named lattices satisfy ALL four defining laws
+        // — commutativity, associativity, idempotency, absorption — exhaustively
+        // over every one of the 4³ = 64 triples (the carrier is finite, so this is
+        // a total check, not a sample). Associativity + absorption had no prior
+        // coverage for these ops.
+        use Verdict::*;
+        let all = [Allow, Deny, Unknown, Conflict];
+        type Op = fn(Verdict, Verdict) -> Verdict;
+        let lattices: [(&str, Op, Op); 2] = [
+            ("truth", Verdict::truth_meet, Verdict::truth_join),
+            ("info", Verdict::info_meet, Verdict::info_join),
+        ];
+
+        for (name, meet, join) in lattices {
+            for a in all {
+                assert_eq!(meet(a, a), a, "{name} meet idempotent: {a}");
+                assert_eq!(join(a, a), a, "{name} join idempotent: {a}");
+                for b in all {
+                    assert_eq!(meet(a, b), meet(b, a), "{name} meet commutative: {a},{b}");
+                    assert_eq!(join(a, b), join(b, a), "{name} join commutative: {a},{b}");
+                    // Absorption — the two ops genuinely interlock into a lattice.
+                    assert_eq!(meet(a, join(a, b)), a, "{name} absorption a⊓(a⊔b): {a},{b}");
+                    assert_eq!(join(a, meet(a, b)), a, "{name} absorption a⊔(a⊓b): {a},{b}");
+                    for c in all {
+                        assert_eq!(
+                            meet(meet(a, b), c),
+                            meet(a, meet(b, c)),
+                            "{name} meet associative: {a},{b},{c}"
+                        );
+                        assert_eq!(
+                            join(join(a, b), c),
+                            join(a, join(b, c)),
+                            "{name} join associative: {a},{b},{c}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
     // ── into_verdict tests ────────────────────────────────────────────
 
     #[test]


### PR DESCRIPTION
**Quality loop 3/51: `portcullis-core`** (the categorical IFC core).

The four-valued verdict is a **Belnap/Ginsberg bilattice** — two interlocking lattices on one carrier: the **truth** lattice (`truth_meet`/`truth_join`) and the **knowledge** lattice (`info_meet`/`info_join`). The existing tests spot-checked commutativity per op, and `verdict_lattice_laws` covers the *trait* lattice — but **associativity** and **absorption** had **zero coverage** for the four named bilattice ops (the laws that make them genuine lattices, not ad-hoc binary functions).

Adds `bilattice_law_battery_exhaustive`: over all **4³ = 64 triples** (finite carrier ⇒ a *total* check, not a sample), proves **both** lattices satisfy commutativity, associativity, idempotency, and absorption. Real categorical rigor — proven, not asserted in prose.

27 bilattice tests green (`--all-features`); clippy clean.

The crate is otherwise **already world-class** (738 Lean theorems, Aeneas-extracted IFC noninterference, lattice-law-tested) — this is the one genuine gap, not a rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)