### PR TITLE
test(nucleus-ifc): property-prove the gate is monotone-restrictive in declared inputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6684,6 +6684,7 @@ name = "nucleus-ifc"
 version = "1.0.0"
 dependencies = [
  "portcullis-core",
+ "proptest",
  "serde",
  "serde_json",
 ]

--- a/crates/nucleus-ifc/Cargo.toml
+++ b/crates/nucleus-ifc/Cargo.toml
@@ -18,6 +18,8 @@ serde = { version = "1", features = ["derive"], optional = true }
 # decision vectors shared with the WASM recomputeVerdict binding.
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+# Monotonicity property: adding a declared input never loosens the verdict.
+proptest = { workspace = true }
 
 [features]
 # The model-level IFC `decision` module (FlowDeclaration → IfcVerdict). Pulls

--- a/crates/nucleus-ifc/src/decision.rs
+++ b/crates/nucleus-ifc/src/decision.rs
@@ -329,4 +329,55 @@ mod tests {
         // Unknown token fails closed.
         assert!(FlowDeclaration::from_tokens(["bogus"], false, false).is_none());
     }
+
+    // ── Safety monotonicity (property-based) ───────────────────────────
+
+    use proptest::prelude::*;
+
+    fn any_input() -> impl Strategy<Value = DeclaredInput> {
+        prop_oneof![
+            Just(DeclaredInput::UserPrompt),
+            Just(DeclaredInput::WebContent),
+            Just(DeclaredInput::ToolResponse),
+            Just(DeclaredInput::FileRead),
+            Just(DeclaredInput::EnvVar),
+            Just(DeclaredInput::Secret),
+            Just(DeclaredInput::DatabaseRow),
+            Just(DeclaredInput::MemoryRead),
+            Just(DeclaredInput::HttpResponse),
+        ]
+    }
+
+    proptest! {
+        /// **The gate is monotone-restrictive in its declared inputs.** Adding an
+        /// input can only make the verdict *more* restrictive (flip allow→deny),
+        /// never *less* (deny→allow): more declared sources mean the outbound sink
+        /// is at least as tainted, so the lethal-trifecta gate is at most as
+        /// permissive. Equivalently, if a SUPERSET of inputs is allowed, every
+        /// subset is too. This is the core safety property — a caller can't earn an
+        /// `allow` by *declaring more* exposure — and it held only on hand-picked
+        /// cases before; here it's checked over arbitrary declarations.
+        #[test]
+        fn adding_an_input_never_loosens_the_verdict(
+            inputs in proptest::collection::vec(any_input(), 0..6),
+            extra in any_input(),
+            requires_authority in any::<bool>(),
+            sink_public in any::<bool>(),
+        ) {
+            let mut base = FlowDeclaration::new(inputs.clone());
+            base.requires_authority = requires_authority;
+            base.sink_public = sink_public;
+
+            let mut more = base.clone();
+            more.inputs.push(extra);
+
+            if more.decide().is_allow() {
+                prop_assert!(
+                    base.decide().is_allow(),
+                    "adding {extra:?} loosened deny→allow (base inputs={inputs:?}, \
+                     sink_public={sink_public}, requires_authority={requires_authority})"
+                );
+            }
+        }
+    }
 }


### PR DESCRIPTION
**Quality loop 4/51: `nucleus-ifc`** (light-pass — golden-hardened this session via #1774).

The lethal-trifecta gate `FlowDeclaration::decide` was golden-tested on fixed cases, but its **core safety property** was unchecked: **adding a declared input must only make the verdict more restrictive** (allow→deny), never less (deny→allow). Otherwise a caller could earn an `allow` by *declaring more exposure* — a monotonicity break that defeats the gate.

Adds `adding_an_input_never_loosens_the_verdict` (proptest): over arbitrary declarations + a random extra input + both flags, if the superset is allowed the subset must be too. 23 tests green (`--features decision`), clippy clean.

This was the one genuine gap in an otherwise already-hardened crate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)