### PR TITLE
fix(ci): unblock @coproduct/verify publish + bring Node/actions to current (24, checkout@v5, cache@v5)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ jobs:
           cache: true
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "22"
+          node-version: "24"
       - name: Install mdBook
         run: cargo install mdbook --locked
       - name: Build docs

--- a/.github/workflows/oidc-gates.yml
+++ b/.github/workflows/oidc-gates.yml
@@ -38,7 +38,7 @@ jobs:
     name: Vendor-neutrality gate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Run no-vendor-strings.sh
         id: gate
         run: |
@@ -75,7 +75,7 @@ jobs:
     name: Algorithm-pin gate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Run alg-pin-check.sh
         id: gate
         run: |

--- a/.github/workflows/publish-verifier-sdk.yml
+++ b/.github/workflows/publish-verifier-sdk.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Set up Node.js for publish
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22"
           registry-url: "https://registry.npmjs.org"
 
       - name: Node smoke test (accept real + reject tampered)

--- a/.github/workflows/publish-verifier-sdk.yml
+++ b/.github/workflows/publish-verifier-sdk.yml
@@ -48,7 +48,7 @@ jobs:
       id-token: write  # for npm provenance
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust 1.95+ with wasm32 target
         uses: dtolnay/rust-toolchain@stable
@@ -61,7 +61,7 @@ jobs:
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
       - name: Cache cargo registry + target
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -89,7 +89,7 @@ jobs:
       - name: Set up Node.js for publish
         uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
       - name: Node smoke test (accept real + reject tampered)

--- a/.github/workflows/trust-registry.yml
+++ b/.github/workflows/trust-registry.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR head
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0   # need the base ref for the diff + incumbent compile.
 
@@ -87,4 +87,3 @@ jobs:
             --changed-paths-file changed_paths.txt \
             --oidc-token-file oidc_token.txt \
             --github-jwks-file github_jwks.json
-</content>

--- a/sdks/verifier-js/package.json
+++ b/sdks/verifier-js/package.json
@@ -40,8 +40,8 @@
   ],
   "scripts": {
     "build:wasm": "wasm-pack build --target web --release",
-    "test": "node --test \"test/**/*.test.mjs\"",
-    "test:smoke": "node --test \"test/**/*.test.mjs\""
+    "test": "node --test test/*.test.mjs",
+    "test:smoke": "node --test test/*.test.mjs"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
The publish workflow's smoke-test step failed because `node --test "test/**/*.test.mjs"` (quoted glob) is only expanded by Node ≥21, but the workflow pinned Node 20 → literal-path 'Could not find'. Green on local Node 24.

Fixed two ways: shell-expanded `test/*.test.mjs` in package.json (Node-version-independent) + bump publish workflow to Node 22. Validated: dry-run on this branch is green (run 27074521717), smoke test (accept real + reject tampered) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)