### PR TITLE
feat(creditworthiness): v1 credit file — verified history → bond-substituting reputation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6538,6 +6538,9 @@ dependencies = [
 name = "nucleus-creditworthiness"
 version = "1.0.0"
 dependencies = [
+ "hex",
+ "nucleus-econ-kernels",
+ "nucleus-recompute",
  "nucleus-witness-olog",
  "proptest",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6535,6 +6535,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nucleus-creditworthiness"
+version = "1.0.0"
+dependencies = [
+ "nucleus-witness-olog",
+ "proptest",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "nucleus-econ-kernels"
 version = "1.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ members = [
     "crates/nucleus-econ-kernels",          # PROVEN integer VCG + Pigou + sealed-bid kernels (parity-pinned to Lean)
     "crates/nucleus-recompute",             # verify_receipt: re-derive every cleared number from declared inputs via the proven kernels
     "crates/nucleus-witness-olog",          # Phase 2 (P2.1): Gov functor (admitted witness → olog fact) + signed accumulation manifest
+    "crates/nucleus-creditworthiness",      # Agent credit file: recompute-verified history → bond-substituting reputation (financial active, externality reserved)
 ]
 # nucleus-claude-hook moved to nucleus-code (private product repo)
 # exposure-web is WASM-only (wasm32-unknown-unknown); build with: cd crates/exposure-web && trunk build

--- a/crates/nucleus-creditworthiness/Cargo.toml
+++ b/crates/nucleus-creditworthiness/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "nucleus-creditworthiness"
+license.workspace = true
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+description = "Agent credit file: aggregate recompute-verified history into bond-substituting reputation. A multi-dimensional, order-independent (recompute-stable) vector — financial-default dimension active, Pigouvian externality dimension reserved-but-dormant — composing the proven nucleus-witness-olog::required_bond kernel."
+
+[lints]
+workspace = true
+
+[dependencies]
+serde = { workspace = true }
+# The PROVEN kernel: required_bond / deters / AmountMicro. Reputation
+# substitutes for capital down to a Sybil-proof floor, value-identical to Lean
+# `requiredBond` (`[propext, Quot.sound]`-only). We COMPOSE it — the money path
+# never re-implements the proven function.
+nucleus-witness-olog = { path = "../nucleus-witness-olog" }
+
+[dev-dependencies]
+serde_json = { workspace = true }
+proptest = { workspace = true }

--- a/crates/nucleus-creditworthiness/Cargo.toml
+++ b/crates/nucleus-creditworthiness/Cargo.toml
@@ -17,7 +17,21 @@ serde = { workspace = true }
 # `requiredBond` (`[propext, Quot.sound]`-only). We COMPOSE it — the money path
 # never re-implements the proven function.
 nucleus-witness-olog = { path = "../nucleus-witness-olog" }
+# `recompute` feature: mint CreditEvents straight from recompute-verified
+# clearing receipts (the receipt→recompute→CreditEvent→CreditFile→bond pipeline).
+nucleus-recompute = { path = "../nucleus-recompute", optional = true }
+hex = { workspace = true, optional = true }
+
+[features]
+default = ["recompute"]
+# The `mint` bridge: derive CreditEvents from recompute-verified ClearingReceipts.
+# On by default (the pipeline is the point); opt out with `default-features =
+# false` for the lean core (e.g. a wasm consumer that supplies its own events).
+recompute = ["dep:nucleus-recompute", "dep:hex"]
 
 [dev-dependencies]
 serde_json = { workspace = true }
 proptest = { workspace = true }
+# Used only by the `mint` tests to construct genuinely-honest receipts (so a
+# Match is real, not asserted) via the same proven kernels recompute uses.
+nucleus-econ-kernels = { path = "../nucleus-econ-kernels" }

--- a/crates/nucleus-creditworthiness/README.md
+++ b/crates/nucleus-creditworthiness/README.md
@@ -1,0 +1,68 @@
+# nucleus-creditworthiness
+
+**Agent creditworthiness — the credit file that turns recompute-verified history into bond-substituting reputation.**
+
+A verified track record should spend like collateral. The proven kernel
+[`nucleus_witness_olog::required_bond(gain, reputation)`] already says clean
+history substitutes for posted capital down to a Sybil-proof floor — but it takes
+`reputation` as a bare number. This crate is what *derives* that number: it folds
+an identity's recompute-verified [`CreditEvent`]s into a **`CreditFile`** — a
+multi-dimensional, deterministic, recompute-stable vector — and composes the
+proven kernel to price the bond. The money path runs the exact proven function;
+nothing here re-implements the math.
+
+## The dimension vector — financial now, externality reserved
+
+Creditworthiness is behaviour over time priced into a number. v1 scores one
+**active** dimension:
+
+- `FinancialDefault` — honest, recompute-matched settlement (credit) vs. a caught
+  defection / recompute mismatch (debit). **Active.**
+- `Externality` — Pigouvian: true-cost dues paid to the commons (credit) vs.
+  uncompensated externalities dumped (debit). **Reserved, dormant.** Its events
+  are accumulated but excluded from the bond-substituting reputation until
+  `CreditDimension::is_active` is flipped — a one-line config change, not a schema
+  migration. The kernels it will need already exist (`nucleus-externality`,
+  `nucleus-econ-kernels` commons routing).
+
+Greed ignites; conscience compounds. Keep the ignition signal pure (lower your
+bond *now* by being honest), and switch on the externality dimension once the
+base flywheel turns.
+
+## What is proven here (property tests, not prose)
+
+- **Commutative monoid** — empty file is the identity, `merge` is associative +
+  commutative ⇒ the credit file is independent of event order ⇒ any verifier
+  recomputes the *same* file from the same receipts (recompute-stable).
+- **Monotone flywheel** — an honest settlement never raises the required bond; a
+  caught defection never lowers it. For an honest agent the wheel turns one way.
+- **Sybil-no-discount** — an empty file yields reputation 0 ⇒ the full bond.
+  Splitting into fresh identities buys no discount (inherited from the kernel's
+  proven floor).
+- **Externality is inert in v1** — while dormant, externality events never move
+  the bond-substituting reputation.
+
+## Usage
+
+```rust
+use nucleus_creditworthiness::{CreditEvent, CreditFile};
+
+let file = CreditFile::from_events(&[
+    CreditEvent::honest_settlement(400_000, receipt_a_hash),
+    CreditEvent::honest_settlement(300_000, receipt_b_hash),
+]);
+
+// 700k of clean history covers 700k of a 1M defection gain → only 300k bond.
+assert_eq!(file.reputation_micro(), 700_000);
+assert_eq!(file.required_bond(1_000_000).0, 300_000);
+```
+
+## Honesty boundary
+
+A `CreditEvent` is only as good as the recompute that justifies it; each carries
+the `receipt_hash` of the verified receipt it came from. This crate does the
+aggregation + pricing — it does **not** itself verify receipts (that is
+`nucleus-recompute` / `nucleus-envelope`). Feed it only events minted from
+receipts that already recomputed.
+
+MIT.

--- a/crates/nucleus-creditworthiness/src/lib.rs
+++ b/crates/nucleus-creditworthiness/src/lib.rs
@@ -1,0 +1,513 @@
+//! Agent creditworthiness — the credit file that turns recompute-verified
+//! history into bond-substituting reputation.
+//!
+//! The proven kernel [`nucleus_witness_olog::required_bond`] says verifiable
+//! clean history substitutes for posted collateral down to a floor (a fresh
+//! identity gets no discount — `sybil_no_discount`). But that kernel takes
+//! `reputation_micro` as a bare number. **This crate is what _derives_ that
+//! number**: it folds an identity's recompute-verified [`CreditEvent`]s into a
+//! [`CreditFile`] — a multi-dimensional, deterministic, recompute-stable vector
+//! — and composes the proven kernel to price the bond. It re-derives the bond
+//! with the EXACT proven function the enforcement path uses; it never
+//! re-implements the math.
+//!
+//! # The dimension vector (financial now, externality reserved)
+//!
+//! Creditworthiness is behaviour over time priced into a number. v1 scores ONE
+//! active dimension — [`CreditDimension::FinancialDefault`] (honest settlement
+//! vs. caught defection). [`CreditDimension::Externality`] is a **first-class
+//! but dormant** dimension (Pigouvian: did the agent pay its true-cost dues to
+//! the commons, or dump them?). Its events are accumulated but excluded from the
+//! bond-substituting reputation while [`CreditDimension::is_active`] returns
+//! `false` — so lighting up externality accounting later (the kernels already
+//! exist in `nucleus-externality` + `nucleus-econ-kernels` commons routing) is a
+//! one-line flip, not a schema migration. Greed ignites; conscience compounds.
+//!
+//! # What is PROVEN here (property tests, not prose)
+//!
+//! * **Commutative monoid.** [`CreditFile::default`] is the identity and
+//!   [`CreditFile::merge`] is associative + commutative ⇒ the credit file is
+//!   independent of event order ⇒ any verifier recomputes the SAME file from the
+//!   same receipts (recompute-stable).
+//! * **Monotone flywheel.** An honest settlement never lowers reputation (never
+//!   RAISES the required bond); a caught defection never raises it. For an honest
+//!   agent the wheel only ever turns one way.
+//! * **Sybil-no-discount.** An empty file yields reputation `0` ⇒ the full bond
+//!   — minting fresh identities buys no discount (inherited from the composed
+//!   kernel's `requiredBond` floor).
+//! * **Externality is inert in v1.** While the dimension is dormant, externality
+//!   events never move the bond-substituting reputation — the socket exists but
+//!   is not wired.
+//!
+//! # Honesty boundary
+//!
+//! A [`CreditEvent`] is only as good as the recompute that justifies it: each
+//! carries the `receipt_hash` of the verified receipt it was derived from, so a
+//! relying party can re-verify provenance. This crate does the *aggregation +
+//! pricing*; it does not itself verify receipts (that is `nucleus-recompute` /
+//! `nucleus-envelope`). Garbage events in, garbage file out — feed it only
+//! events minted from receipts that already recomputed.
+
+#![forbid(unsafe_code)]
+
+use std::collections::BTreeMap;
+
+use nucleus_witness_olog::{deters, required_bond, AmountMicro};
+use serde::{Deserialize, Serialize};
+
+/// A dimension of creditworthiness. Each dimension is scored independently from
+/// recompute-verified events.
+///
+/// v1 activates only [`CreditDimension::FinancialDefault`].
+/// [`CreditDimension::Externality`] is reserved (see crate docs): a first-class
+/// variant whose contribution to the bond-substituting reputation is gated off
+/// by [`CreditDimension::is_active`] until the Pigouvian accounting is wired in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum CreditDimension {
+    /// Financial-default risk: honest, recompute-matched settlement (credit) vs.
+    /// a caught defection / recompute mismatch (debit). **Active in v1.**
+    FinancialDefault,
+    /// Externality internalization (Pigouvian): paying true-cost dues to the
+    /// commons (credit) vs. dumping uncompensated externalities (debit).
+    /// **Reserved — dormant in v1.**
+    Externality,
+}
+
+impl CreditDimension {
+    /// Every defined dimension, in canonical (sorted) order.
+    pub const ALL: [CreditDimension; 2] = [
+        CreditDimension::FinancialDefault,
+        CreditDimension::Externality,
+    ];
+
+    /// Whether this dimension currently contributes to the bond-substituting
+    /// reputation. v1: only [`CreditDimension::FinancialDefault`].
+    ///
+    /// Flipping [`CreditDimension::Externality`] to active here lights up
+    /// Pigouvian accounting across the whole flywheel — the kernels it needs
+    /// already exist in `nucleus-externality` + `nucleus-econ-kernels`. This is
+    /// the deliberate "config flip, not a schema migration" seam.
+    pub const fn is_active(self) -> bool {
+        matches!(self, CreditDimension::FinancialDefault)
+    }
+}
+
+/// Whether an event builds (`Credit`) or destroys (`Debit`) standing on its
+/// dimension.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Polarity {
+    /// Builds standing (e.g. an honest settlement, externality dues paid).
+    Credit,
+    /// Destroys standing (e.g. a caught defection, externality dumped).
+    Debit,
+}
+
+/// One recompute-verified outcome attributable to an identity, scoring a single
+/// dimension.
+///
+/// `weight_micro` is the (already recompute-verified) economic magnitude in
+/// micro-USD; `receipt_hash` binds the event to the verified receipt that
+/// justifies it, so provenance is re-checkable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CreditEvent {
+    /// Which creditworthiness dimension this event scores.
+    pub dimension: CreditDimension,
+    /// Whether it builds or destroys standing.
+    pub polarity: Polarity,
+    /// Recompute-verified economic magnitude, micro-USD.
+    pub weight_micro: u64,
+    /// Content hash of the verified receipt this event was derived from.
+    pub receipt_hash: [u8; 32],
+}
+
+impl CreditEvent {
+    /// An honest, recompute-matched settlement worth `weight_micro` — builds
+    /// financial standing.
+    pub fn honest_settlement(weight_micro: u64, receipt_hash: [u8; 32]) -> Self {
+        Self {
+            dimension: CreditDimension::FinancialDefault,
+            polarity: Polarity::Credit,
+            weight_micro,
+            receipt_hash,
+        }
+    }
+
+    /// A caught defection (recompute mismatch / fraud proof) worth
+    /// `weight_micro` — destroys financial standing.
+    pub fn caught_defection(weight_micro: u64, receipt_hash: [u8; 32]) -> Self {
+        Self {
+            dimension: CreditDimension::FinancialDefault,
+            polarity: Polarity::Debit,
+            weight_micro,
+            receipt_hash,
+        }
+    }
+
+    /// Externality dues paid to the commons worth `weight_micro` — builds
+    /// standing on the **reserved** externality dimension (inert in v1).
+    pub fn externality_internalized(weight_micro: u64, receipt_hash: [u8; 32]) -> Self {
+        Self {
+            dimension: CreditDimension::Externality,
+            polarity: Polarity::Credit,
+            weight_micro,
+            receipt_hash,
+        }
+    }
+
+    /// An uncompensated externality dumped on the commons worth `weight_micro` —
+    /// destroys standing on the **reserved** externality dimension (inert in v1).
+    pub fn externality_dumped(weight_micro: u64, receipt_hash: [u8; 32]) -> Self {
+        Self {
+            dimension: CreditDimension::Externality,
+            polarity: Polarity::Debit,
+            weight_micro,
+            receipt_hash,
+        }
+    }
+}
+
+/// Per-dimension accumulator. Credits and debits are kept separate (not pre-
+/// netted) so the fold is a clean, saturating, commutative monoid.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+struct DimAcc {
+    credit_micro: u128,
+    debit_micro: u128,
+}
+
+impl DimAcc {
+    /// Net standing on this dimension, floored at 0 and clamped into `u64`
+    /// (the input type the proven `required_bond` kernel expects). Standing can
+    /// never go negative: a deeply-defected agent simply has zero reputation,
+    /// not "anti-reputation" that would absurdly *increase* someone else's bond.
+    fn net_micro(self) -> u64 {
+        let net = self.credit_micro.saturating_sub(self.debit_micro);
+        net.min(u128::from(u64::MAX)) as u64
+    }
+
+    fn merge(self, other: Self) -> Self {
+        Self {
+            credit_micro: self.credit_micro.saturating_add(other.credit_micro),
+            debit_micro: self.debit_micro.saturating_add(other.debit_micro),
+        }
+    }
+}
+
+/// An identity's credit file: a deterministic, multi-dimensional aggregation of
+/// recompute-verified [`CreditEvent`]s.
+///
+/// [`CreditFile::default`] (empty) is the monoid identity; [`CreditFile::merge`]
+/// combines two files associatively + commutatively. Build one with
+/// [`CreditFile::from_events`] or by folding with [`CreditFile::observe`].
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CreditFile {
+    /// Per-dimension accumulators. Absent dimension == zero (the empty file is
+    /// the empty map), so equality is canonical regardless of insertion order.
+    dims: BTreeMap<CreditDimension, DimAcc>,
+    /// Number of events folded in (provenance/audit; sums under merge).
+    event_count: u64,
+}
+
+impl CreditFile {
+    /// An empty credit file — the monoid identity and a brand-new identity's
+    /// starting point (reputation 0 ⇒ full bond).
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Fold a single recompute-verified event into the file.
+    pub fn observe(&mut self, event: &CreditEvent) {
+        let acc = self.dims.entry(event.dimension).or_default();
+        match event.polarity {
+            Polarity::Credit => {
+                acc.credit_micro = acc
+                    .credit_micro
+                    .saturating_add(u128::from(event.weight_micro));
+            }
+            Polarity::Debit => {
+                acc.debit_micro = acc
+                    .debit_micro
+                    .saturating_add(u128::from(event.weight_micro));
+            }
+        }
+        self.event_count = self.event_count.saturating_add(1);
+    }
+
+    /// Build a credit file from a slice of events. Order-independent: any
+    /// permutation of `events` yields an equal file (see the `order_independent`
+    /// property test).
+    pub fn from_events(events: &[CreditEvent]) -> Self {
+        let mut file = Self::new();
+        for e in events {
+            file.observe(e);
+        }
+        file
+    }
+
+    /// Combine two credit files — the commutative-monoid operation. Used to
+    /// merge histories accrued in different shards/sessions without caring about
+    /// order.
+    pub fn merge(mut self, other: Self) -> Self {
+        for (dim, acc) in other.dims {
+            let entry = self.dims.entry(dim).or_default();
+            *entry = entry.merge(acc);
+        }
+        self.event_count = self.event_count.saturating_add(other.event_count);
+        self
+    }
+
+    /// Number of events folded into this file.
+    pub fn event_count(&self) -> u64 {
+        self.event_count
+    }
+
+    /// Net standing on a single dimension (floored at 0), **including dormant
+    /// dimensions** — for inspection/forward-compat. This is NOT necessarily
+    /// what prices the bond; see [`CreditFile::reputation_micro`].
+    pub fn dimension_micro(&self, dim: CreditDimension) -> u64 {
+        self.dims.get(&dim).copied().unwrap_or_default().net_micro()
+    }
+
+    /// The bond-substituting reputation: the sum of net standing across the
+    /// **active** dimensions only (v1: financial). Dormant dimensions
+    /// ([`CreditDimension::Externality`]) are excluded until activated.
+    /// Saturating into `u64`, the type the proven kernel consumes.
+    pub fn reputation_micro(&self) -> u64 {
+        self.dims
+            .iter()
+            .filter(|(dim, _)| dim.is_active())
+            .fold(0u128, |acc, (_, dacc)| {
+                acc.saturating_add(u128::from(dacc.net_micro()))
+            })
+            .min(u128::from(u64::MAX)) as u64
+    }
+
+    /// The **minimum bond** this identity must post to deter a one-shot
+    /// defection worth `max_defection_gain_micro`, given the reputation it has
+    /// accrued. Composes the proven [`nucleus_witness_olog::required_bond`]
+    /// (reputation substitutes for capital down to a Sybil-proof floor) — the
+    /// money path runs the exact proven function.
+    pub fn required_bond(&self, max_defection_gain_micro: u64) -> AmountMicro {
+        required_bond(max_defection_gain_micro, self.reputation_micro())
+    }
+
+    /// Whether posting `bond` on top of this identity's accrued reputation
+    /// deters a one-shot defection worth `max_defection_gain_micro`. Composes
+    /// the proven [`nucleus_witness_olog::deters`].
+    pub fn deters(&self, bond: AmountMicro, max_defection_gain_micro: u64) -> bool {
+        deters(bond, self.reputation_micro(), max_defection_gain_micro)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    fn h(seed: u8) -> [u8; 32] {
+        [seed; 32]
+    }
+
+    // ── Worked examples ─────────────────────────────────────────────────────
+
+    #[test]
+    fn empty_file_is_sybil_priced() {
+        let f = CreditFile::new();
+        assert_eq!(f.reputation_micro(), 0);
+        // A fresh identity pays the full bond — no discount for splitting.
+        assert_eq!(f.required_bond(1_000_000), AmountMicro(1_000_000));
+    }
+
+    #[test]
+    fn honest_history_substitutes_for_capital() {
+        let f = CreditFile::from_events(&[
+            CreditEvent::honest_settlement(400_000, h(1)),
+            CreditEvent::honest_settlement(300_000, h(2)),
+        ]);
+        assert_eq!(f.reputation_micro(), 700_000);
+        // 700k of clean history covers 700k of a 1M defection gain → 300k bond.
+        assert_eq!(f.required_bond(1_000_000), AmountMicro(300_000));
+        // Once reputation alone covers the gain, the bond floors at zero.
+        assert_eq!(f.required_bond(700_000), AmountMicro::ZERO);
+    }
+
+    #[test]
+    fn a_caught_defection_burns_standing() {
+        let mut f = CreditFile::from_events(&[CreditEvent::honest_settlement(500_000, h(1))]);
+        assert_eq!(f.reputation_micro(), 500_000);
+        f.observe(&CreditEvent::caught_defection(200_000, h(9)));
+        assert_eq!(f.reputation_micro(), 300_000);
+    }
+
+    #[test]
+    fn standing_floors_at_zero_never_negative() {
+        // More defection than credit ⇒ reputation 0, NOT a negative that would
+        // perversely raise the required bond above the bare gain.
+        let f = CreditFile::from_events(&[
+            CreditEvent::honest_settlement(100_000, h(1)),
+            CreditEvent::caught_defection(900_000, h(2)),
+        ]);
+        assert_eq!(f.reputation_micro(), 0);
+        assert_eq!(f.required_bond(1_000_000), AmountMicro(1_000_000));
+    }
+
+    #[test]
+    fn externality_dimension_is_reserved_but_dormant() {
+        // Externality events accumulate on their dimension...
+        let f = CreditFile::from_events(&[
+            CreditEvent::externality_internalized(1_000_000, h(1)),
+            CreditEvent::externality_dumped(250_000, h(2)),
+        ]);
+        assert_eq!(f.dimension_micro(CreditDimension::Externality), 750_000);
+        // ...but contribute NOTHING to the bond-substituting reputation in v1.
+        assert_eq!(f.reputation_micro(), 0);
+        assert_eq!(f.required_bond(1_000_000), AmountMicro(1_000_000));
+        // The day CreditDimension::Externality::is_active() flips true, this
+        // same file prices a discount — config flip, no schema change.
+        assert!(!CreditDimension::Externality.is_active());
+        assert!(CreditDimension::FinancialDefault.is_active());
+    }
+
+    #[test]
+    fn serde_round_trips() {
+        let f = CreditFile::from_events(&[
+            CreditEvent::honest_settlement(123, h(1)),
+            CreditEvent::caught_defection(45, h(2)),
+            CreditEvent::externality_internalized(9, h(3)),
+        ]);
+        let json = serde_json::to_string(&f).unwrap();
+        let back: CreditFile = serde_json::from_str(&json).unwrap();
+        assert_eq!(f, back);
+    }
+
+    // ── Property tests: the credit file is a commutative monoid ──────────────
+    //
+    // Order-independence is the load-bearing property: a verifier who replays
+    // the same receipts in ANY order must recompute the SAME file (and thus the
+    // same bond). That is exactly the commutative-monoid laws on `merge` + the
+    // empty-file identity.
+
+    prop_compose! {
+        fn any_event()(
+            dim_sel in 0usize..2,
+            pol in any::<bool>(),
+            weight in 0u64..2_000_000,
+            seed in any::<u8>(),
+        ) -> CreditEvent {
+            CreditEvent {
+                dimension: CreditDimension::ALL[dim_sel],
+                polarity: if pol { Polarity::Credit } else { Polarity::Debit },
+                weight_micro: weight,
+                receipt_hash: [seed; 32],
+            }
+        }
+    }
+
+    fn events() -> impl Strategy<Value = Vec<CreditEvent>> {
+        proptest::collection::vec(any_event(), 0..24)
+    }
+
+    proptest! {
+        /// Identity: merging with the empty file changes nothing (both sides).
+        #[test]
+        fn monoid_identity(evs in events()) {
+            let f = CreditFile::from_events(&evs);
+            prop_assert_eq!(f.clone().merge(CreditFile::new()), f.clone());
+            prop_assert_eq!(CreditFile::new().merge(f.clone()), f);
+        }
+
+        /// Commutativity: merge order of two files does not matter.
+        #[test]
+        fn monoid_commutative(a in events(), b in events()) {
+            let fa = CreditFile::from_events(&a);
+            let fb = CreditFile::from_events(&b);
+            prop_assert_eq!(fa.clone().merge(fb.clone()), fb.merge(fa));
+        }
+
+        /// Associativity: regrouping three merges does not matter.
+        #[test]
+        fn monoid_associative(a in events(), b in events(), c in events()) {
+            let fa = CreditFile::from_events(&a);
+            let fb = CreditFile::from_events(&b);
+            let fc = CreditFile::from_events(&c);
+            let left = fa.clone().merge(fb.clone()).merge(fc.clone());
+            let right = fa.merge(fb.merge(fc));
+            prop_assert_eq!(left, right);
+        }
+
+        /// Recompute-stability: any permutation of the events yields an equal
+        /// file. (Follows from the monoid laws; proved directly because it is
+        /// the property a third-party verifier actually relies on.)
+        #[test]
+        fn order_independent(evs in events(), seed in any::<u64>()) {
+            let forward = CreditFile::from_events(&evs);
+            // A cheap deterministic shuffle: rotate by a seed-derived offset.
+            let mut shuffled = evs.clone();
+            if !shuffled.is_empty() {
+                let k = (seed as usize) % shuffled.len();
+                shuffled.rotate_left(k);
+                // plus a reversal so it isn't merely a rotation
+                shuffled.reverse();
+            }
+            prop_assert_eq!(forward, CreditFile::from_events(&shuffled));
+        }
+
+        /// Monotone flywheel (up): an honest settlement never RAISES the bond.
+        #[test]
+        fn honest_settlement_never_raises_bond(
+            evs in events(),
+            extra in 0u64..2_000_000,
+            gain in 0u64..4_000_000,
+            seed in any::<u8>(),
+        ) {
+            let before = CreditFile::from_events(&evs);
+            let mut after = before.clone();
+            after.observe(&CreditEvent::honest_settlement(extra, [seed; 32]));
+            prop_assert!(after.reputation_micro() >= before.reputation_micro());
+            prop_assert!(after.required_bond(gain).0 <= before.required_bond(gain).0);
+        }
+
+        /// Monotone flywheel (down): a caught defection never LOWERS the bond.
+        #[test]
+        fn caught_defection_never_lowers_bond(
+            evs in events(),
+            extra in 0u64..2_000_000,
+            gain in 0u64..4_000_000,
+            seed in any::<u8>(),
+        ) {
+            let before = CreditFile::from_events(&evs);
+            let mut after = before.clone();
+            after.observe(&CreditEvent::caught_defection(extra, [seed; 32]));
+            prop_assert!(after.reputation_micro() <= before.reputation_micro());
+            prop_assert!(after.required_bond(gain).0 >= before.required_bond(gain).0);
+        }
+
+        /// The reserved dimension is inert: externality events never change the
+        /// bond-substituting reputation while the dimension is dormant.
+        #[test]
+        fn externality_events_do_not_move_reputation(
+            evs in events(),
+            ext_weight in 0u64..2_000_000,
+            ext_pol in any::<bool>(),
+            seed in any::<u8>(),
+        ) {
+            let before = CreditFile::from_events(&evs);
+            let mut after = before.clone();
+            let ext = if ext_pol {
+                CreditEvent::externality_internalized(ext_weight, [seed; 32])
+            } else {
+                CreditEvent::externality_dumped(ext_weight, [seed; 32])
+            };
+            after.observe(&ext);
+            prop_assert_eq!(after.reputation_micro(), before.reputation_micro());
+        }
+
+        /// Sybil-no-discount: a fresh (empty) identity always pays the full bond.
+        #[test]
+        fn fresh_identity_pays_full_bond(gain in 0u64..4_000_000) {
+            prop_assert_eq!(CreditFile::new().required_bond(gain), AmountMicro(gain));
+        }
+    }
+}

--- a/crates/nucleus-creditworthiness/src/lib.rs
+++ b/crates/nucleus-creditworthiness/src/lib.rs
@@ -55,6 +55,9 @@ use std::collections::BTreeMap;
 use nucleus_witness_olog::{deters, required_bond, AmountMicro};
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "recompute")]
+pub mod mint;
+
 /// A dimension of creditworthiness. Each dimension is scored independently from
 /// recompute-verified events.
 ///

--- a/crates/nucleus-creditworthiness/src/mint.rs
+++ b/crates/nucleus-creditworthiness/src/mint.rs
@@ -1,0 +1,185 @@
+//! Mint [`CreditEvent`]s directly from recompute-verified clearing receipts —
+//! the bridge that closes the pipeline
+//! `receipt → recompute → CreditEvent → CreditFile → required_bond`.
+//!
+//! The rule is the whole thesis in three lines:
+//! * a receipt that **recomputes** ([`RecomputeOutcome::Match`]) is an honest
+//!   outcome → a financial **credit**;
+//! * a receipt that **diverges** ([`RecomputeOutcome::Mismatch`]) is a caught
+//!   defection — the recompute IS the fraud proof → a financial **debit**;
+//! * a malformed/un-recomputable receipt ([`RecomputeOutcome::Invalid`]) mints
+//!   **nothing** — there is no established baseline to attribute, so it neither
+//!   builds nor burns standing.
+//!
+//! The event's `weight_micro` is the receipt's economic magnitude taken from its
+//! **declared inputs** (price / pool / budget), never a claimed output — so the
+//! weight itself can't be inflated by the very lie being caught.
+
+use nucleus_recompute::{content_hash_hex, verify_receipt, ClearingReceipt, RecomputeOutcome};
+
+use crate::{CreditEvent, CreditFile};
+
+/// The economic magnitude of a receipt, micro-USD, taken from its declared
+/// inputs (sound regardless of any claimed-output lie).
+pub fn economic_magnitude(receipt: &ClearingReceipt) -> u64 {
+    match receipt {
+        ClearingReceipt::Settlement(c) => c.price_micro,
+        ClearingReceipt::Commons(c) => c.pool_micro,
+        ClearingReceipt::Vcg(c) => c.budget_micro_usd,
+    }
+}
+
+/// The receipt's content hash as raw bytes — the same `sha256` the lineage
+/// edge's `content_hash_hex` commits to — used as the
+/// [`CreditEvent::receipt_hash`] provenance binding.
+pub fn receipt_hash(receipt: &ClearingReceipt) -> [u8; 32] {
+    let hex_str = content_hash_hex(receipt);
+    let mut out = [0u8; 32];
+    // `content_hash_hex` is a sha256 hex digest → exactly 32 bytes. Decode
+    // defensively: fail closed to all-zero rather than panic on the impossible.
+    let _ = hex::decode_to_slice(hex_str.as_bytes(), &mut out);
+    out
+}
+
+/// Mint a [`CreditEvent`] from one receipt by recomputing it. Returns `None`
+/// for an [`RecomputeOutcome::Invalid`] receipt (nothing to attribute).
+pub fn mint_event(receipt: &ClearingReceipt) -> Option<CreditEvent> {
+    let weight = economic_magnitude(receipt);
+    let hash = receipt_hash(receipt);
+    match verify_receipt(receipt) {
+        RecomputeOutcome::Match => Some(CreditEvent::honest_settlement(weight, hash)),
+        RecomputeOutcome::Mismatch { .. } => Some(CreditEvent::caught_defection(weight, hash)),
+        RecomputeOutcome::Invalid(_) => None,
+    }
+}
+
+/// Mint events from a batch of receipts, skipping `Invalid` ones.
+pub fn mint_events(receipts: &[ClearingReceipt]) -> Vec<CreditEvent> {
+    receipts.iter().filter_map(mint_event).collect()
+}
+
+/// Build a [`CreditFile`] directly from recompute-verified receipts — the whole
+/// pipeline in one call. Order-independent (inherited from [`CreditFile`]).
+pub fn credit_file_from_receipts(receipts: &[ClearingReceipt]) -> CreditFile {
+    CreditFile::from_events(&mint_events(receipts))
+}
+
+#[cfg(test)]
+mod tests {
+    use nucleus_econ_kernels::{classify, refund, route_to_commons, seller_gross, CommonsShare};
+    use nucleus_recompute::{ClearingReceipt, CommonsClaim, SettlementClaim};
+    use nucleus_witness_olog::AmountMicro;
+
+    use super::*;
+    use crate::CreditDimension;
+
+    /// A genuinely-honest settlement receipt: outputs computed by the SAME proven
+    /// kernels recompute checks against, so the Match is real, not asserted.
+    fn honest_settlement(price_micro: u64, delivered_bps: u64) -> ClearingReceipt {
+        ClearingReceipt::Settlement(SettlementClaim {
+            price_micro,
+            delivered_bps,
+            verdict: classify(delivered_bps),
+            seller_gross: seller_gross(price_micro, delivered_bps),
+            refund: refund(price_micro, delivered_bps),
+        })
+    }
+
+    fn honest_commons(pool_micro: u64) -> ClearingReceipt {
+        let shares = vec![
+            CommonsShare {
+                destination: "commons".into(),
+                bps: 7_000,
+            },
+            CommonsShare {
+                destination: "ops".into(),
+                bps: 3_000,
+            },
+        ];
+        let allocations = route_to_commons(pool_micro, &shares).unwrap();
+        ClearingReceipt::Commons(CommonsClaim {
+            pool_micro,
+            shares,
+            allocations,
+        })
+    }
+
+    #[test]
+    fn honest_receipt_mints_a_financial_credit() {
+        let r = honest_settlement(1_000_000, 10_000);
+        let e = mint_event(&r).expect("honest receipt mints an event");
+        assert_eq!(e.dimension, CreditDimension::FinancialDefault);
+        assert_eq!(e.weight_micro, 1_000_000); // from price_micro (declared input)
+        assert_eq!(e.receipt_hash, receipt_hash(&r));
+        // It builds standing: a file of just this event has positive reputation.
+        let f = CreditFile::from_events(&[e]);
+        assert_eq!(f.reputation_micro(), 1_000_000);
+    }
+
+    #[test]
+    fn a_mismatched_receipt_mints_a_caught_defection() {
+        // Tamper the seller_gross — recompute will catch it.
+        let mut r = honest_settlement(1_000_000, 10_000);
+        if let ClearingReceipt::Settlement(ref mut c) = r {
+            c.seller_gross += 1;
+        }
+        assert!(!verify_receipt(&r).is_match());
+        let e = mint_event(&r).expect("a caught lie still mints an event (a debit)");
+        // Weight is the DECLARED price, not the inflated claim — the lie can't
+        // inflate its own penalty's magnitude.
+        assert_eq!(e.weight_micro, 1_000_000);
+        // It burns standing: stacked on prior honest history it lowers reputation.
+        let f = CreditFile::from_events(&[CreditEvent::honest_settlement(1_000_000, [0u8; 32]), e]);
+        assert_eq!(f.reputation_micro(), 0); // 1M credit − 1M debit
+    }
+
+    #[test]
+    fn an_invalid_receipt_mints_nothing() {
+        // Commons shares that don't sum to 10_000 → Invalid (no baseline).
+        let bad = ClearingReceipt::Commons(CommonsClaim {
+            pool_micro: 1_000,
+            shares: vec![CommonsShare {
+                destination: "x".into(),
+                bps: 9_999,
+            }],
+            allocations: vec![],
+        });
+        assert!(matches!(verify_receipt(&bad), RecomputeOutcome::Invalid(_)));
+        assert_eq!(mint_event(&bad), None);
+    }
+
+    #[test]
+    fn full_pipeline_receipts_to_required_bond() {
+        // Three honest receipts (settlement + commons) → credit file → bond.
+        let receipts = vec![
+            honest_settlement(400_000, 10_000),
+            honest_commons(300_000),
+            honest_settlement(0, 5_000), // a low-delivery settlement, price 0
+        ];
+        let file = credit_file_from_receipts(&receipts);
+        // reputation = 400k (settle) + 300k (commons pool) + 0 = 700k.
+        assert_eq!(file.reputation_micro(), 700_000);
+        // 700k of recompute-verified history covers 700k of a 1M defection gain.
+        assert_eq!(file.required_bond(1_000_000), AmountMicro(300_000));
+        assert_eq!(file.event_count(), 3);
+    }
+
+    #[test]
+    fn invalid_receipts_are_skipped_in_a_batch() {
+        let bad = ClearingReceipt::Commons(CommonsClaim {
+            pool_micro: 1,
+            shares: vec![CommonsShare {
+                destination: "x".into(),
+                bps: 1,
+            }],
+            allocations: vec![],
+        });
+        let receipts = vec![honest_settlement(500_000, 10_000), bad];
+        let evs = mint_events(&receipts);
+        assert_eq!(evs.len(), 1); // the Invalid one is dropped
+        assert_eq!(
+            credit_file_from_receipts(&receipts).reputation_micro(),
+            500_000
+        );
+    }
+}

--- a/sdks/verifier-js/Cargo.lock
+++ b/sdks/verifier-js/Cargo.lock
@@ -439,6 +439,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nucleus-creditworthiness"
+version = "1.0.0"
+dependencies = [
+ "hex",
+ "nucleus-recompute",
+ "nucleus-witness-olog",
+ "serde",
+]
+
+[[package]]
 name = "nucleus-econ-kernels"
 version = "1.0.0"
 dependencies = [
@@ -530,6 +540,7 @@ dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",
  "hex",
+ "nucleus-creditworthiness",
  "nucleus-econ-kernels",
  "nucleus-envelope",
  "nucleus-externality",

--- a/sdks/verifier-js/Cargo.toml
+++ b/sdks/verifier-js/Cargo.toml
@@ -31,6 +31,11 @@ nucleus-externality = { path = "../../crates/nucleus-externality" }
 # agent's defection exposure + its verified reputation (the proven
 # reputation↔capital substitution). No new trust — pure proven arithmetic.
 nucleus-witness-olog = { path = "../../crates/nucleus-witness-olog" }
+# Creditworthiness: fold an agent's recompute-verified receipts into a credit
+# file (honest builds standing, a caught lie burns it) and price its bond — the
+# whole receipt→recompute→credit-file→bond flywheel, in-browser. Default
+# features include the `recompute` mint bridge.
+nucleus-creditworthiness = { path = "../../crates/nucleus-creditworthiness" }
 wasm-bindgen = "0.2"
 serde-wasm-bindgen = "0.6"
 serde = { version = "1", features = ["derive"] }

--- a/sdks/verifier-js/index.d.ts
+++ b/sdks/verifier-js/index.d.ts
@@ -201,3 +201,23 @@ export function recomputeDeters(
   reputationMicro: number | bigint,
   maxDefectionGainMicro: number | bigint,
 ): Promise<boolean>;
+
+/**
+ * Re-derive an agent's bond-substituting reputation (micro) from its clearing
+ * receipts: each is recomputed; a Match builds standing, a Mismatch (caught
+ * defection) burns it, an Invalid receipt is ignored. Financial dimension only
+ * (the reserved Pigouvian dimension is dormant). No server trust.
+ */
+export function creditReputationFromReceipts(
+  receipts: object[] | string,
+): Promise<bigint>;
+
+/**
+ * Re-derive the minimum bond an agent must post to deter a defection worth
+ * `maxDefectionGainMicro`, given the reputation its receipts earn — the flywheel
+ * end-to-end (receipt → recompute → credit file → bond), in-process, no trust.
+ */
+export function requiredBondFromReceipts(
+  receipts: object[] | string,
+  maxDefectionGainMicro: number | bigint,
+): Promise<bigint>;

--- a/sdks/verifier-js/index.js
+++ b/sdks/verifier-js/index.js
@@ -436,3 +436,41 @@ export async function recomputeDeters(bondMicro, reputationMicro, maxDefectionGa
   const mod = await initWasm();
   return mod.recomputeDeters(big(bondMicro), big(reputationMicro), big(maxDefectionGainMicro));
 }
+
+// ── CREDITWORTHINESS: an agent's whole history → its required bond ─────────────
+// recomputeRequiredBond takes a bare reputation number; these take the agent's
+// RECEIPTS and run the whole pipeline — recompute each, fold the honest ones up
+// (a caught lie burns standing), price the bond — in-process, no server trust.
+
+/**
+ * Re-derive an agent's bond-substituting reputation (micro) from its clearing
+ * receipts. Each is recomputed against the proven kernels: a Match builds
+ * standing, a Mismatch (a caught defection) burns it, an Invalid receipt is
+ * ignored. Returns the financial-dimension reputation (the reserved Pigouvian
+ * dimension is dormant). No server trust.
+ * @param {object[]|string} receipts a `ClearingReceipt[]` (array or JSON string)
+ * @returns {Promise<bigint>} reputation in micro-units
+ */
+export async function creditReputationFromReceipts(receipts) {
+  const mod = await initWasm();
+  return mod.creditReputationFromReceipts(
+    typeof receipts === "string" ? receipts : JSON.stringify(receipts),
+  );
+}
+
+/**
+ * Re-derive the minimum bond an agent must post to deter a defection worth
+ * `maxDefectionGainMicro`, given the reputation its receipts earn it — the
+ * flywheel end-to-end (receipt → recompute → credit file → bond), in-process,
+ * trusting no server. More verified clean history ⇒ a lower bond.
+ * @param {object[]|string} receipts a `ClearingReceipt[]` (array or JSON string)
+ * @param {number|bigint} maxDefectionGainMicro
+ * @returns {Promise<bigint>} the minimum bond in micro-units
+ */
+export async function requiredBondFromReceipts(receipts, maxDefectionGainMicro) {
+  const mod = await initWasm();
+  return mod.requiredBondFromReceipts(
+    typeof receipts === "string" ? receipts : JSON.stringify(receipts),
+    big(maxDefectionGainMicro),
+  );
+}

--- a/sdks/verifier-js/src/lib.rs
+++ b/sdks/verifier-js/src/lib.rs
@@ -495,3 +495,44 @@ pub fn recompute_deters_js(
         max_defection_gain_micro,
     )
 }
+
+// ── CREDITWORTHINESS: an agent's whole history → its required bond ─────────────
+// `recomputeRequiredBond` above takes a bare `reputation_micro`. These close the
+// loop: hand the SDK an agent's clearing RECEIPTS and it (1) recomputes each one
+// against the proven kernels, (2) folds the honest ones up — a caught lie BURNS
+// standing instead of building it — and (3) prices the bond. The full
+// receipt→recompute→credit-file→bond pipeline, in-browser, trusting no server.
+
+/// Re-derive an agent's bond-substituting **reputation** (micro-USD) from its
+/// clearing receipts: each is recomputed; a Match builds standing, a Mismatch (a
+/// caught defection — the recompute is the fraud proof) burns it, an Invalid
+/// receipt is ignored. Returns the financial-dimension reputation (the reserved
+/// Pigouvian dimension is dormant). `receipts_json` is a JSON array of
+/// `ClearingReceipt`.
+#[wasm_bindgen(js_name = creditReputationFromReceipts)]
+pub fn credit_reputation_from_receipts_js(receipts_json: &str) -> Result<u64, JsError> {
+    set_panic_hook();
+    let receipts: Vec<nucleus_recompute::ClearingReceipt> = serde_json::from_str(receipts_json)
+        .map_err(|e| JsError::new(&format!("receipts JSON: {e}")))?;
+    Ok(nucleus_creditworthiness::mint::credit_file_from_receipts(&receipts).reputation_micro())
+}
+
+/// Re-derive the **minimum bond** an agent must post to deter a one-shot
+/// defection worth `max_defection_gain_micro`, GIVEN the reputation its receipts
+/// earn it. The flywheel end-to-end: more recompute-verified clean history ⇒ a
+/// lower bond — computed in your process, no server trust. `receipts_json` is a
+/// JSON array of `ClearingReceipt`. Composes the proven `required_bond`.
+#[wasm_bindgen(js_name = requiredBondFromReceipts)]
+pub fn required_bond_from_receipts_js(
+    receipts_json: &str,
+    max_defection_gain_micro: u64,
+) -> Result<u64, JsError> {
+    set_panic_hook();
+    let receipts: Vec<nucleus_recompute::ClearingReceipt> = serde_json::from_str(receipts_json)
+        .map_err(|e| JsError::new(&format!("receipts JSON: {e}")))?;
+    Ok(
+        nucleus_creditworthiness::mint::credit_file_from_receipts(&receipts)
+            .required_bond(max_defection_gain_micro)
+            .0,
+    )
+}

--- a/sdks/verifier-js/test/credit.test.mjs
+++ b/sdks/verifier-js/test/credit.test.mjs
@@ -1,0 +1,75 @@
+// WASM bindings for nucleus-creditworthiness: an agent's whole history → its bond.
+//
+// creditReputationFromReceipts / requiredBondFromReceipts run the full pipeline
+// in-process — recompute each receipt against the proven kernels, fold the honest
+// ones up (a caught lie BURNS standing), and price the bond. No server trust.
+//
+// Requires ./pkg (run `npm run build:wasm` first; CI builds it).
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  creditReputationFromReceipts,
+  requiredBondFromReceipts,
+} from "../index.js";
+
+// An honest settlement (recomputes to match — see recompute.test.mjs). Its
+// declared-input magnitude is price_micro = 1_000_000.
+const honestSettlement = {
+  kind: "settlement",
+  price_micro: 1_000_000,
+  delivered_bps: 2_500,
+  verdict: "partial",
+  seller_gross: 250_000,
+  refund: 750_000,
+};
+
+// An honest commons routing (recomputes to match). Magnitude = pool_micro = 1M.
+const honestCommons = {
+  kind: "commons",
+  pool_micro: 1_000_000,
+  shares: [
+    { destination: "carbon", bps: 6_000 },
+    { destination: "affected", bps: 2_500 },
+    { destination: "verifier", bps: 1_500 },
+  ],
+  allocations: [
+    { destination: "carbon", amount_micro: 600_000 },
+    { destination: "affected", amount_micro: 250_000 },
+    { destination: "verifier", amount_micro: 150_000 },
+  ],
+};
+
+// The same settlement, but the seller skimmed — recompute catches it (a caught
+// defection). Magnitude is still the DECLARED price (1M), not the inflated claim.
+const skimmedSettlement = { ...honestSettlement, seller_gross: 250_001 };
+
+test("verified history accrues reputation across receipt types", async () => {
+  const rep = await creditReputationFromReceipts([honestSettlement, honestCommons]);
+  assert.equal(rep, 2_000_000n); // 1M price + 1M pool
+});
+
+test("more clean history lowers the required bond (the flywheel)", async () => {
+  const bond = await requiredBondFromReceipts(
+    [honestSettlement, honestCommons],
+    2_500_000,
+  );
+  assert.equal(bond, 500_000n); // 2.5M gain − 2M reputation
+});
+
+test("a caught lie burns the credit it would have earned", async () => {
+  // honest (+1M) then the same trade skimmed (−1M, caught by recompute) → 0.
+  const rep = await creditReputationFromReceipts([honestSettlement, skimmedSettlement]);
+  assert.equal(rep, 0n);
+});
+
+test("a fresh agent with no history pays the full bond (sybil-no-discount)", async () => {
+  const bond = await requiredBondFromReceipts([], 1_000_000);
+  assert.equal(bond, 1_000_000n);
+});
+
+test("reputation alone can cover the gain → zero bond", async () => {
+  const bond = await requiredBondFromReceipts([honestSettlement, honestCommons], 1_500_000);
+  assert.equal(bond, 0n); // 2M reputation ≥ 1.5M gain
+});


### PR DESCRIPTION
## What

`nucleus-creditworthiness`: the spine of the reflexive flywheel. A verified track record should *spend like collateral*. The proven kernel `nucleus_witness_olog::required_bond(gain, reputation)` already says clean history substitutes for posted capital down to a Sybil-proof floor — but it takes `reputation` as a bare number. This crate **derives** that number: it folds an identity's recompute-verified `CreditEvent`s into a `CreditFile` (a multi-dimensional, deterministic, recompute-stable vector) and **composes** the proven kernel to price the bond. The money path runs the exact proven function — no re-implementation.

## Dimension vector — financial now, externality reserved
- `FinancialDefault` — honest settlement (credit) vs. caught defection (debit). **Active.**
- `Externality` — Pigouvian dues-to-commons (credit) vs. dumped externality (debit). **Reserved, dormant** — accumulated but excluded from the bond-substituting reputation until `CreditDimension::is_active` flips. A config flip, not a schema migration (kernels already exist in `nucleus-externality` / `nucleus-econ-kernels`). Greed ignites; conscience compounds.

## Proven (property tests, not prose) — 14 green, clippy clean
- **Commutative monoid** (identity + assoc + commutative) ⇒ order-independent ⇒ **recompute-stable** (any verifier replaying the same receipts gets the same file).
- **Monotone flywheel** — honest settlement never raises the bond; caught defection never lowers it.
- **Sybil-no-discount** — empty file → full bond.
- **Externality inert** while dormant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)