### PR TITLE
ci: SHA-pin actions + least-privilege token permissions (OpenSSF Scorecard)

### DIFF
--- a/.github/workflows/aeneas-ifc-scoped.yml
+++ b/.github/workflows/aeneas-ifc-scoped.yml
@@ -85,7 +85,7 @@ jobs:
       # --- Aeneas prebuilt binaries (Charon + Aeneas, no OCaml build) ---
       - name: Cache Aeneas binary
         id: cache-aeneas-bin
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: /tmp/aeneas-bin
           key: aeneas-bin-${{ runner.os }}-${{ env.AENEAS_RELEASE }}

--- a/.github/workflows/aeneas-oidc-spiffe.yml
+++ b/.github/workflows/aeneas-oidc-spiffe.yml
@@ -82,7 +82,7 @@ jobs:
       # --- Aeneas prebuilt binaries (Charon + Aeneas, no OCaml build) ---
       - name: Cache Aeneas binary
         id: cache-aeneas-bin
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: /tmp/aeneas-bin
           key: aeneas-bin-${{ runner.os }}-${{ env.AENEAS_RELEASE }}

--- a/.github/workflows/aeneas.yml
+++ b/.github/workflows/aeneas.yml
@@ -60,7 +60,7 @@ jobs:
       # The tarball is ~100 MB. Without caching, every run re-downloads it.
       - name: Cache Aeneas binary
         id: cache-aeneas-bin
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: /tmp/aeneas-bin
           key: aeneas-bin-${{ runner.os }}-${{ env.AENEAS_RELEASE }}
@@ -146,7 +146,7 @@ jobs:
           echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
 
       - name: Cache Lake / Mathlib build artifacts
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
             crates/portcullis-core/lean/.lake

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -3,17 +3,19 @@ name: Dependabot auto-merge
 on: pull_request
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   dependabot:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/econ-lean.yml
+++ b/.github/workflows/econ-lean.yml
@@ -44,7 +44,7 @@ jobs:
           echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
 
       - name: Cache Lake build artifacts
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
             crates/nucleus-econ-kernels/lean/.lake

--- a/.github/workflows/line-ratchet.yml
+++ b/.github/workflows/line-ratchet.yml
@@ -7,7 +7,7 @@ on:
     branches: ["main"]
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   check:
@@ -25,6 +25,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/oidc-gates.yml
+++ b/.github/workflows/oidc-gates.yml
@@ -31,14 +31,16 @@ concurrency:
 
 permissions:
   contents: read
-  pull-requests: write   # for the comment-on-failure step
 
 jobs:
   vendor-neutrality:
     name: Vendor-neutrality gate
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write   # for the comment-on-failure step
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Run no-vendor-strings.sh
         id: gate
         run: |
@@ -49,7 +51,7 @@ jobs:
         continue-on-error: false
       - name: Surface failure as PR comment
         if: failure() && github.event_name == 'pull_request'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const fs = require('fs');
@@ -74,8 +76,11 @@ jobs:
   algorithm-pin:
     name: Algorithm-pin gate
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write   # for the comment-on-failure step
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Run alg-pin-check.sh
         id: gate
         run: |
@@ -86,7 +91,7 @@ jobs:
         continue-on-error: false
       - name: Surface failure as PR comment
         if: failure() && github.event_name == 'pull_request'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/oidc-keyless-prototype.yml
+++ b/.github/workflows/oidc-keyless-prototype.yml
@@ -21,12 +21,14 @@ on:
 
 permissions:
   contents: read       # checkout
-  id-token: write      # opt-in: lets the job FETCH+USE an OIDC token (not repo write)
 
 jobs:
   keyless-oidc-e2e:
     name: live keyless OIDC validate
     runs-on: ubuntu-latest
+    permissions:
+      contents: read       # checkout
+      id-token: write      # opt-in: lets the job FETCH+USE an OIDC token (not repo write)
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/.github/workflows/trust-registry.yml
+++ b/.github/workflows/trust-registry.yml
@@ -18,23 +18,26 @@ on:
     paths:
       - "registry/**"
 
-# Least privilege + the OIDC token request.
+# Least privilege at the top level; the OIDC token request is scoped to the job.
 permissions:
   contents: read
-  id-token: write       # REQUEST a GitHub Actions OIDC proof-of-control token.
-  pull-requests: read
 
 jobs:
   enrollment-gate:
     runs-on: ubuntu-latest
+    # Least privilege + the OIDC token request.
+    permissions:
+      contents: read
+      id-token: write       # REQUEST a GitHub Actions OIDC proof-of-control token.
+      pull-requests: read
     steps:
       - name: Checkout PR head
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0   # need the base ref for the diff + incumbent compile.
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Build the verifier
         run: cargo build -p nucleus-trust-registry --bin nucleus-trust-registry --locked


### PR DESCRIPTION
Two one-shot OpenSSF Scorecard wins (no logic changes):

- **Pinned-Dependencies 7→10** — pin the remaining unpinned GitHub Actions to commit SHAs (cache@v5, fetch-metadata@v3, checkout@v5, github-script@v9, rust-toolchain@stable) with `# version` comments.
- **Token-Permissions 0→~9** — top-level `permissions: contents: read` (or `{}`) on all 26 workflows; writes/id-token relocated to the specific job that needs them, narrowly scoped (dependabot-automerge, line-ratchet, oidc-gates, trust-registry, oidc-keyless-prototype).

Skeptic-reviewed: every prior write is preserved at job level, YAML valid, only `.github/workflows/` touched. Residual: permission relocations only fully validate when each workflow next runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)