### PR TITLE
feat(rubric): validate the money path + checked rank/winner + wasm32 CI proof

### DIFF
--- a/.github/workflows/wasm-pure-crates.yml
+++ b/.github/workflows/wasm-pure-crates.yml
@@ -1,0 +1,76 @@
+name: WASM Pure Crates
+
+# Proves the pure, integer/byte-only economic + verification crates compile to
+# wasm32-unknown-unknown — the property their docs claim ("WASM-safe", no
+# ring/tokio/redb/native deps). A regression (e.g. a stray std-only or native
+# dependency creeping into the closure) breaks the build here instead of silently
+# invalidating the in-browser / edge story. Path-isolated; mirrors rubric-lean.yml.
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "crates/nucleus-rubric/**"
+      - "crates/nucleus-rubric-olog/**"
+      - "crates/nucleus-eval/**"
+      - "crates/nucleus-oracle/**"
+      - "crates/nucleus-recompute/**"
+      - "crates/nucleus-creditworthiness/**"
+      - "crates/nucleus-witness-olog/**"
+      - "crates/nucleus-econ-kernels/**"
+      - "crates/nucleus-externality/**"
+      - "Cargo.lock"
+      - ".github/workflows/wasm-pure-crates.yml"
+  pull_request:
+    paths:
+      - "crates/nucleus-rubric/**"
+      - "crates/nucleus-rubric-olog/**"
+      - "crates/nucleus-eval/**"
+      - "crates/nucleus-oracle/**"
+      - "crates/nucleus-recompute/**"
+      - "crates/nucleus-creditworthiness/**"
+      - "crates/nucleus-witness-olog/**"
+      - "crates/nucleus-econ-kernels/**"
+      - "crates/nucleus-externality/**"
+      - "Cargo.lock"
+      - ".github/workflows/wasm-pure-crates.yml"
+  merge_group:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: never
+
+jobs:
+  wasm-build:
+    name: cargo build --target wasm32-unknown-unknown (pure crates)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Add wasm32 target
+        run: rustup target add wasm32-unknown-unknown
+
+      - name: Cache cargo + target
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: wasm-pure-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            wasm-pure-${{ runner.os }}-
+
+      - name: Build pure crates for wasm32
+        run: |
+          cargo build --locked --target wasm32-unknown-unknown \
+            -p nucleus-rubric \
+            -p nucleus-rubric-olog \
+            -p nucleus-eval \
+            -p nucleus-oracle \
+            -p nucleus-recompute \
+            -p nucleus-creditworthiness

--- a/crates/nucleus-oracle/Cargo.toml
+++ b/crates/nucleus-oracle/Cargo.toml
@@ -28,6 +28,5 @@ nucleus-eval = { path = "../nucleus-eval" }
 # AttestationOnly) + Criterion / Rubric / Scorecard the mint emits. Composed by
 # PATH. Default features OFF keeps the closure lean + WASM-safe.
 nucleus-rubric = { path = "../nucleus-rubric" }
-
-[dev-dependencies]
-serde_json = { workspace = true }
+# serde_json is a normal dependency (used by `canonical_bytes` for the receipt
+# hash), so tests + examples reuse it — no separate [dev-dependencies] entry.

--- a/crates/nucleus-rubric/src/lib.rs
+++ b/crates/nucleus-rubric/src/lib.rs
@@ -419,6 +419,26 @@ pub fn winner(rubric: &Rubric, scorecards: &[Scorecard]) -> Option<usize> {
     ranked_order(rubric, scorecards).into_iter().next()
 }
 
+/// Validate-then-[`rank`]: rejects malformed scorecards (wrong grade count,
+/// out-of-range grade) before ranking, instead of relying on
+/// [`faithful_total`]'s defensive missing-grade-as-`0`. Use this on any path
+/// where the scorecards are untrusted; the infallible [`rank`] keeps the
+/// documented "validate first" contract for already-validated inputs.
+pub fn rank_checked(rubric: &Rubric, scorecards: &[Scorecard]) -> Result<Vec<Ranked>, RubricError> {
+    rubric.validate_all(scorecards)?;
+    Ok(rank(rubric, scorecards))
+}
+
+/// Validate-then-[`winner`]: same guarantee as [`rank_checked`]. Returns
+/// `Ok(None)` for an empty (but valid) slice.
+pub fn winner_checked(
+    rubric: &Rubric,
+    scorecards: &[Scorecard],
+) -> Result<Option<usize>, RubricError> {
+    rubric.validate_all(scorecards)?;
+    Ok(winner(rubric, scorecards))
+}
+
 /// The single-winner VCG-marginal: `winner_total - runner_up_total`, derived
 /// purely from the recorded integer RV scores. Requires `>= 2` artifacts (a
 /// marginal is a contribution *over the next-best*; with no runner-up it is
@@ -430,6 +450,12 @@ pub fn marginal(rubric: &Rubric, scorecards: &[Scorecard]) -> Result<u128, Rubri
             got: scorecards.len(),
         });
     }
+    // The marginal feeds the credit/money path (VCG-marginal → CreditEvent), so it
+    // must reject malformed scorecards rather than let `faithful_total`'s
+    // missing-grade-as-0 / out-of-range grades silently distort the total (and the
+    // minted credit). The infallible `rank`/`winner` keep the documented
+    // validate-first contract; `marginal` validates here because it is load-bearing.
+    rubric.validate_all(scorecards)?;
     let order = ranked_order(rubric, scorecards);
     let winner_total = faithful_total(rubric, &scorecards[order[0]]);
     let runner_up_total = faithful_total(rubric, &scorecards[order[1]]);
@@ -987,5 +1013,58 @@ mod tests {
         };
         // 2 of 3 cases actually pass on recompute — that's the grade.
         assert_eq!(grade_from_eval(&run), 2);
+    }
+
+    // ── Kernel hardening: validate the money path ─────────────────────────────
+
+    #[test]
+    fn marginal_rejects_out_of_range_grade() {
+        // An out-of-range RV grade would inflate faithful_total (and thus the
+        // VCG-marginal → minted credit) if left unvalidated. marginal must reject.
+        let r = fixed_rubric();
+        let good = sc("a", [10, 10, 10, 0, 0]);
+        let cheat = sc("b", [99, 0, 0, 0, 0]); // 99 > max_grade 10 on an RV column
+        assert!(matches!(
+            marginal(&r, &[good, cheat]),
+            Err(RubricError::GradeExceedsMax { .. })
+        ));
+    }
+
+    #[test]
+    fn marginal_rejects_wrong_grade_count() {
+        let r = fixed_rubric();
+        let good = sc("a", [1, 1, 1, 0, 0]);
+        let short = Scorecard {
+            artifact_id: "b".into(),
+            grades: vec![1, 2, 3], // wrong length
+        };
+        assert!(matches!(
+            marginal(&r, &[good, short]),
+            Err(RubricError::GradeCountMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn marginal_accepts_valid_and_matches_unchecked_path() {
+        let r = fixed_rubric();
+        let cards = [sc("a", [10, 10, 10, 0, 0]), sc("b", [1, 1, 1, 0, 0])];
+        // winner_total - runner_up = (5*10+3*10+2*10) - (5+3+2) = 100 - 10 = 90.
+        assert_eq!(marginal(&r, &cards).unwrap(), 90);
+    }
+
+    #[test]
+    fn rank_checked_and_winner_checked_reject_malformed() {
+        let r = fixed_rubric();
+        let cheat = sc("b", [99, 0, 0, 0, 0]);
+        assert!(rank_checked(&r, std::slice::from_ref(&cheat)).is_err());
+        assert!(winner_checked(&r, &[cheat]).is_err());
+    }
+
+    #[test]
+    fn checked_variants_agree_with_unchecked_on_valid_input() {
+        let r = fixed_rubric();
+        let cards = [sc("a", [10, 0, 0, 0, 0]), sc("b", [1, 1, 1, 0, 0])];
+        assert_eq!(rank_checked(&r, &cards).unwrap(), rank(&r, &cards));
+        assert_eq!(winner_checked(&r, &cards).unwrap(), winner(&r, &cards));
     }
 }


### PR DESCRIPTION
## What
Hardening for the scoring kernel, plus a CI proof of the WASM claim.

### `marginal()` now validates — the money-path fix
`marginal` computes the VCG-marginal that feeds a real `CreditEvent`. But `faithful_total` deliberately treats missing grades as `0` and does not bound grades (it documents "validate first"). So an **out-of-range or wrong-length scorecard could silently inflate a total — and thus minted credit**. `marginal` already returns `Result`, so adding `rubric.validate_all(scorecards)?` is a **non-breaking** safety fix on the one path where it's load-bearing. `rank`/`winner` stay infallible per their documented validate-first contract.

### `rank_checked` / `winner_checked`
Result-returning variants that `validate_all` before delegating, for untrusted-input paths. Non-breaking additions.

### wasm32 CI proof
New `wasm-pure-crates.yml` builds the pure integer/byte-only crates (`nucleus-rubric`, `-rubric-olog`, `-eval`, `-oracle`, `-recompute`, `-creditworthiness`) for `wasm32-unknown-unknown`. The crates *claim* "WASM-safe" in their docs; this makes a regression (a stray native/std-only dep creeping into the closure) fail CI instead of silently invalidating the in-browser/edge story. Verified building locally.

### Cleanup
`nucleus-oracle` listed `serde_json` in **both** `[dependencies]` and `[dev-dependencies]`; it's a real lib dep (`canonical_bytes`), so the redundant dev entry is removed.

## Tests
5 new: `marginal` rejects out-of-range grade + wrong count, accepts valid (`90 = 100 − 10`), checked variants reject malformed input and agree with unchecked on valid input. `cargo test -p nucleus-rubric` = 19 passed; clippy/fmt/deny/audit clean; wasm32 `--locked` build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)