### PR TITLE
docs(rfcs): reputation-weighted clearing + receipt-provenance/defection gate

### DIFF
--- a/docs/rfcs/receipt-provenance-defection.md
+++ b/docs/rfcs/receipt-provenance-defection.md
@@ -1,0 +1,89 @@
+# RFC: Receipt provenance + authenticated defection — the real money-safe-standing gate
+
+**Status:** design / scoping. **Depends on:** `nucleus-recompute`, `nucleus-eval`,
+`nucleus-oracle` (recompute-verified receipts), `nucleus-creditworthiness` (the
+ledger), the Ed25519 detached-signature identity (`canonical_id = hex(vk)`).
+This is the gate that must hold **before standing is allowed to touch real funds**.
+
+## The question this answers
+
+Standing only deserves to gate money if two things are true:
+
+1. **Provenance** — a credit (or debit) is bound to a *real, recomputable
+   outcome*, not to a self-report. "I delivered" must be re-derivable by anyone.
+2. **Attribution** — a *defection* (non-delivery, or a caught lie) is
+   cryptographically pinned to a real identity that cannot repudiate it or cheaply
+   shed it via a fresh Sybil.
+
+Without (1), standing is just an unverifiable scoreboard. Without (2), the
+slashing/bond that makes standing *cost* anything has nothing to bite. Money
+behind a standing that lacks either is unsafe. Today the system is deliberately
+reputation-only / testnet precisely because this gate is not fully closed.
+
+## Part 1 — Receipt provenance (bind credit to recompute)
+
+A `CreditEvent` must reference a **receipt** whose provenance tier is known, and
+only `RecomputeVerified` receipts may move money-gating standing:
+
+| Receipt source | Provenance | May gate money? |
+|---|---|---|
+| `nucleus-recompute` clearing receipt (settlement/VCG/commons) | RecomputeVerified | yes |
+| `nucleus-eval` deterministic check / `nucleus-oracle` exact held-out pass | RecomputeVerified | yes |
+| `nucleus-oracle` MR-coverage, mutation-kill | Attested (statistical) | no — carried only |
+| LLM-judge / self-reported | AttestationOnly | no — carried only |
+
+This is the existing three-tier discipline (`nucleus-rubric` / `nucleus-oracle`)
+applied to the **money** boundary: the load-bearing credit is exactly the part a
+third party can re-derive byte-for-byte from declared inputs. The adversarial
+pressure-test (`nucleus-oracle/docs/oracle-adversarial-pressure-test.md`) is the
+empirical evidence this holds against real agents: a claim ("I solved it") that
+doesn't recompute earns credit only for what it actually achieved.
+
+**Concrete requirement:** a money-gating `CreditEvent` carries the
+domain-separated receipt hash and the provenance tag; an accrual path that would
+mint load-bearing credit from a non-RV receipt must refuse (mirrors
+`grade_rubric_inputs` omitting the RV criterion on quarantine).
+
+## Part 2 — Authenticated defection (make the consequence land)
+
+A defection must be **detected** and **attributed**:
+
+- **Detected by recompute, not by trust.** Non-delivery against a settled
+  obligation, or a caught lie, surfaces as a recompute mismatch
+  (`RecomputeOutcome::Mismatch`) or an oracle quarantine — a *deductive* signal,
+  not a complaint.
+- **Attributed to an authenticated identity.** The bid/obligation is signed
+  (Ed25519 detached signature; `canonical_id = hex(vk)`), so the resulting debit
+  lands on the exact key that committed. The confused-deputy guard (identity comes
+  from the verified signature, never from request-body fields) is the load-bearing
+  property here: no wire-level identity binding means no real authentication, no
+  matter how strong the signature scheme looks on paper.
+- **Sybil-resistant by construction, not by detection.** We do *not* try to detect
+  Sybils. A fresh identity simply has zero standing, hence the maximum anti-grief
+  bond (`reputation-weighted-clearing.md`). Shedding a bad identity means forfeiting
+  accrued standing and re-collateralizing from scratch — the cost *is* the defense.
+
+## The gate (when standing may touch real money)
+
+Standing may gate real funds **only** when, for the accrual path in question, ALL
+hold:
+
+1. every money-gating `CreditEvent` derives from a `RecomputeVerified` receipt
+   (Part 1), enforced in code (not by review);
+2. obligations are signed and debits are attributed to the signing key (Part 2);
+3. the anti-grief bond is posted/substituted and **slashable** on an authenticated
+   defection;
+4. the ledger is durable + transparency-logged (so neither credits nor debits can
+   be quietly rewritten) — `nucleus-creditworthiness` hash-chained store.
+
+Until all four hold for a given path, that path stays **reputation-only**.
+
+## Honesty boundary / hard stop
+
+This RFC describes the *gate*, not a green light. Real funds / signing keys /
+mainnet remain a **hard stop** regardless of this gate being closed in code:
+crossing it additionally requires external security audit and legal/regulatory
+counsel (the custody posture — non-custodial vs. custodial — decides licensing).
+Closing the gate
+is **necessary, not sufficient**. Nothing here authorizes moving real money; it
+specifies what would have to be true, and verifiable, first.

--- a/docs/rfcs/reputation-weighted-clearing.md
+++ b/docs/rfcs/reputation-weighted-clearing.md
@@ -1,0 +1,87 @@
+# RFC: Reputation-weighted clearing — standing that matters without breaking truthfulness
+
+**Status:** design / scoping. **Depends on:** `nucleus-econ-kernels` (VCG /
+sealed-bid / tlock, in OSS), `nucleus-creditworthiness` (the credit file +
+`required_bond`), `nucleus-oracle` (recompute-verified grades that feed standing).
+Complements `credible-clearing-settlement.md` (which removes the *auctioneer*;
+this RFC is about how *reputation* enters the clearing).
+
+## The question this answers
+
+A pure VCG auction is **reputation-blind**: a brand-new Sybil and a long-trusted
+agent with a thousand recompute-verified deliveries are treated identically if
+they bid the same number. We want standing to *matter* — but **naively** folding
+reputation into the mechanism destroys the one property that makes the auction
+worth running.
+
+## The trap: do NOT weight the bid
+
+The tempting move — multiply each bid by the bidder's reputation, then run VCG on
+the weighted bids — **breaks truthfulness.** Once the payment an agent faces
+depends on a reputation multiplier applied to its own bid, its dominant strategy
+is no longer to bid true value; it shades its bid to game the multiplier. The
+existing truthfulness results (and the zero-axiom VCG non-monotonicity Lean proof
+in `nucleus-econ-kernels/lean/`) hold *because the allocation + payment rule is a
+function of the bids alone*. Weighting the bids forfeits them.
+
+**Design rule:** the allocation and payment rule stays a function of bids only.
+Reputation enters everywhere *except* the valuation.
+
+## Where reputation enters (truthfulness-preserving channels)
+
+1. **Bond, not bid (the primary channel).** Every winner must post a slashable
+   anti-grief bond. The *size* of the required bond is a decreasing function of
+   standing — this is exactly `nucleus-creditworthiness`'s bond-substituting
+   reputation (`required_bond(standing)`). A trusted agent locks little or no
+   collateral; a newcomer locks the full uniform bond. The bid is untouched, so
+   VCG truthfulness survives; reputation changes only the *cost of capital* to
+   participate. A Sybil cannot shed this: a fresh identity has zero standing →
+   maximum bond.
+2. **Admission / eligibility.** A minimum standing (or a posted bond in lieu) to
+   *enter* a given auction tier. This is a participation predicate evaluated
+   before bids are read — again independent of the valuation, so it cannot distort
+   truthful bidding among the admitted set.
+3. **Deterministic tie-break.** When `faithful_total` (or the VCG outcome) ties,
+   break toward higher standing. Ties are measure-zero in price terms, so this
+   cannot move equilibrium bidding; it only resolves indifference.
+
+What reputation must **never** do: scale the bid, scale the VCG payment, or enter
+the allocation argmax. Those are the truthfulness-load-bearing computations.
+
+## The uniform anti-grief bond
+
+"Griefing" = win the clearing, then fail to deliver, denying the slot to the
+runner-up. The defense is a **uniform** bond `B` posted by every winner, slashed
+on authenticated defection (see `receipt-provenance-defection.md`). Uniform (not
+bid-proportional) keeps it outside the payment rule. Reputation substitutes for
+*posting* `B` in cash — `required_bond(standing) ∈ [0, B]` — but the *slashable
+liability* remains `B` regardless, so a trusted agent that defects still loses `B`
+of standing-or-cash. Reputation buys cheaper capital, never cheaper consequences.
+
+## Bid privacy
+
+Reputation is public (the credit file is a transparency-logged ledger); **bids
+must not be.** Otherwise a public reputation ranking plus open bids lets agents
+infer and shade. Bids are sealed via the existing commitment + timelock path
+(`sealed.rs` commitment-set roots + `tlock.rs`/drand reveal): commit sealed →
+anchor the set root → timelock reveal → recompute. Reputation gates admission and
+bond *at commit time* (on identity + standing, not on the sealed value), so the
+valuation stays hidden until reveal.
+
+## What is proven vs proposed
+
+- **Proven / built:** VCG truthfulness with bid-only payment; the non-monotonicity
+  Lean proof; sealed-bid commitment + timelock reveal; `required_bond(standing)`
+  in `nucleus-creditworthiness`; recompute-verified standing inputs.
+- **Proposed (this RFC):** the exact `required_bond` schedule and admission-tier
+  thresholds (policy parameters, not theorems); the claim that channels (1)–(3)
+  are jointly truthfulness-preserving — this needs a Lean statement
+  (*payment rule is independent of standing ⟹ truthful-bidding equilibrium is
+  unchanged*), which is the natural next proof obligation, **not yet discharged**.
+
+## Honesty boundary
+
+This RFC keeps reputation out of the deductive truthfulness core on purpose. Any
+implementation must preserve that separation, and the "channels are
+truthfulness-preserving" claim is an **analogy to the existing proof until it has
+its own Lean theorem** — do not describe it as proven before then.


### PR DESCRIPTION
Two design docs closing the economic-design backlog (RFC tasks #4 and #11).

## `reputation-weighted-clearing.md`
How standing enters clearing **without breaking VCG truthfulness**. The trap — weighting the *bid* by reputation — forfeits the truthfulness that makes the auction worth running (it's why the existing non-monotonicity Lean proof holds: payment is a function of bids alone). The design keeps allocation+payment bid-only and routes reputation through truthfulness-preserving channels: the **anti-grief bond size** (`creditworthiness`' bond-substituting reputation), admission/eligibility, and tie-break. Uniform slashable bond; sealed-bid privacy via the existing commitment+timelock path.

> Honesty: the "channels are jointly truthfulness-preserving" claim is an **analogy to the existing VCG proof until it has its own Lean theorem** — flagged as not-yet-discharged.

## `receipt-provenance-defection.md`
The gate that must hold **before standing may touch real money**:
- **Provenance** — only `RecomputeVerified` receipts move money-gating standing (the three-tier discipline applied to the money boundary; the oracle adversarial pressure-test is the empirical evidence).
- **Attribution** — defection detected by recompute (not trust), pinned to the Ed25519 signing key (confused-deputy guard), Sybil-resistant by zero-standing→max-bond rather than by detection.
- A 4-condition gate; until all hold, a path stays reputation-only.

> Hard stop: real funds / keys / mainnet remain off-limits regardless — closing the gate is **necessary, not sufficient** (still needs external audit + counsel).

Both are `Status: design/scoping`, reference real shipped crates/proofs, and keep the proven-vs-proposed line explicit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)