### PR TITLE
chore(publish): version-pin internal deps for crates.io (reversible PREP)

### DIFF
--- a/crates/nucleus-creditworthiness/Cargo.toml
+++ b/crates/nucleus-creditworthiness/Cargo.toml
@@ -16,10 +16,10 @@ serde = { workspace = true }
 # substitutes for capital down to a Sybil-proof floor, value-identical to Lean
 # `requiredBond` (`[propext, Quot.sound]`-only). We COMPOSE it — the money path
 # never re-implements the proven function.
-nucleus-witness-olog = { path = "../nucleus-witness-olog" }
+nucleus-witness-olog = { path = "../nucleus-witness-olog", version = "1.0.0" }
 # `recompute` feature: mint CreditEvents straight from recompute-verified
 # clearing receipts (the receipt→recompute→CreditEvent→CreditFile→bond pipeline).
-nucleus-recompute = { path = "../nucleus-recompute", optional = true }
+nucleus-recompute = { path = "../nucleus-recompute", version = "1.0.0", optional = true }
 hex = { workspace = true, optional = true }
 # Hash chain for the append-only ledger (`ledger` module, ALWAYS compiled).
 # WASM-safe and already transitively in the default closure via

--- a/crates/nucleus-econ-kernels/Cargo.toml
+++ b/crates/nucleus-econ-kernels/Cargo.toml
@@ -24,8 +24,8 @@ serde = { workspace = true }
 sha2 = { workspace = true }
 hex = { workspace = true }
 thiserror = { workspace = true }
-nucleus-externality = { path = "../nucleus-externality" }
-nucleus-econ-types = { path = "../nucleus-econ-types" }
+nucleus-externality = { path = "../nucleus-externality", version = "1.0.0" }
+nucleus-econ-types = { path = "../nucleus-econ-types", version = "1.0.0" }
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/crates/nucleus-recompute/Cargo.toml
+++ b/crates/nucleus-recompute/Cargo.toml
@@ -13,7 +13,7 @@ serde_json = { workspace = true }
 sha2 = { workspace = true }
 hex = { workspace = true }
 thiserror = { workspace = true }
-nucleus-econ-kernels = { path = "../nucleus-econ-kernels" }
+nucleus-econ-kernels = { path = "../nucleus-econ-kernels", version = "1.0.0" }
 
 [lints]
 workspace = true

--- a/crates/nucleus-witness-olog/Cargo.toml
+++ b/crates/nucleus-witness-olog/Cargo.toml
@@ -19,11 +19,11 @@ hex = { workspace = true }
 thiserror = { workspace = true }
 # AssuranceRung — the rung Gov must carry through WITHOUT upgrading (the
 # load-bearing honesty invariant).
-nucleus-externality = { path = "../nucleus-externality" }
+nucleus-externality = { path = "../nucleus-externality", version = "1.0.0" }
 # route_to_commons — slashed collateral routes to the commons (no-skim
 # conservation), never to an operator. The bonding layer reuses this so the
 # no-skim guarantee is shared, not re-implemented.
-nucleus-econ-kernels = { path = "../nucleus-econ-kernels" }
+nucleus-econ-kernels = { path = "../nucleus-econ-kernels", version = "1.0.0" }
 # RFC 6962 / RFC 9162-style Merkle inclusion + consistency VERIFICATION for the
 # relying-party trust-pinning layer (light client: verify a fact against a pinned
 # root, no full tree). Same crate nucleus-lineage uses; carries no signature dep


### PR DESCRIPTION
Reversible prep so the econ/credit closure can be published to crates.io. **No crate is published by this PR.**

Adds `version = "1.0.0"` alongside the `path` on every **normal** internal dependency in the publish closure, so `cargo publish` can substitute path→version. Dev-dependency path deps (the `externality ↔ econ-kernels` dev cycle, and `creditworthiness`'s dev-dep on `econ-kernels`) are deliberately left **path-only** — cargo strips unversioned dev-deps on publish, which is exactly what lets the dev cycle publish without a chicken-and-egg.

Path takes precedence locally, so the workspace build is unchanged (verified). `cargo publish -p nucleus-econ-types --dry-run` packages + verifies clean.

### Publish closure + topological order (all six currently **unpublished**)
1. `nucleus-econ-types` (leaf)
2. `nucleus-externality` (dev-dep on econ-kernels stripped on publish)
3. `nucleus-econ-kernels`
4. `nucleus-recompute`
5. `nucleus-witness-olog`
6. `nucleus-creditworthiness`

🤖 Generated with [Claude Code](https://claude.com/claude-code)