### PR TITLE
ci(publish): keyless trusted-publishing workflow + repository metadata

### DIFF
--- a/.github/workflows/crates-publish.yml
+++ b/.github/workflows/crates-publish.yml
@@ -1,0 +1,70 @@
+name: Publish crates (trusted publishing)
+
+# KEYLESS publishing of the economic / credit crate closure to crates.io via
+# crates.io Trusted Publishing (GitHub OIDC) — NO stored CARGO_REGISTRY_TOKEN.
+# rust-lang/crates-io-auth-action exchanges this workflow's OIDC identity for a
+# short-lived token (auto-revoked at job end).
+#
+# PREREQUISITE (one-time, per crate, in the crates.io UI → crate → Settings →
+# Trusted Publishing): register repo `coproduct-opensource/nucleus`, workflow
+# `crates-publish.yml`. crates.io cannot do a NEW crate's FIRST publish via OIDC
+# (unlike PyPI pending publishers) — every crate below was first published
+# manually; this workflow handles all SUBSEQUENT releases keylessly.
+#
+# Only crates already on crates.io are listed. nucleus-node is NOT yet published,
+# so it cannot go keyless until its first manual publish (then add it here).
+#
+# Trigger: manual (workflow_dispatch) or pushing a `crates-v*` tag. The publish is
+# idempotent — a crate whose current version is already on crates.io is skipped,
+# so a re-run after a partial/rate-limited run is safe.
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "crates-v*"
+
+permissions:
+  contents: read
+  id-token: write # required for the crates.io OIDC token exchange
+
+env:
+  CARGO_TERM_COLOR: never
+
+jobs:
+  publish:
+    name: cargo publish (keyless, dependency order)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1
+        with:
+          cache: true
+      - name: Mint short-lived crates.io token (OIDC, no stored secret)
+        uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4
+        id: auth
+      - name: Publish in dependency order (idempotent)
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+        run: |
+          set -uo pipefail
+          # Topological order: each crate's normal deps appear before it.
+          crates="nucleus-econ-types nucleus-externality nucleus-econ-kernels \
+                  nucleus-recompute nucleus-witness-olog nucleus-creditworthiness"
+          for c in $crates; do
+            echo "::group::publish $c"
+            if out=$(cargo publish -p "$c" --locked 2>&1); then
+              echo "$out"
+              echo "published $c"
+            else
+              echo "$out"
+              if echo "$out" | grep -qiE "already (uploaded|exists)|is already uploaded"; then
+                echo "skip $c — this version is already on crates.io"
+              else
+                echo "::error::publish failed for $c"
+                exit 1
+              fi
+            fi
+            echo "::endgroup::"
+          done

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ edition = "2021"
 rust-version = "1.95"
 license = "MIT OR Apache-2.0"
 authors = ["Coproduct <hello@coproduct.dev>"]
+repository = "https://github.com/coproduct-opensource/nucleus"
 
 [workspace.lints.clippy]
 type_complexity = "allow"

--- a/crates/nucleus-creditworthiness/Cargo.toml
+++ b/crates/nucleus-creditworthiness/Cargo.toml
@@ -5,6 +5,7 @@ version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
+repository.workspace = true
 description = "Agent credit file: aggregate recompute-verified history into bond-substituting reputation. A multi-dimensional, order-independent (recompute-stable) vector — financial-default dimension active, Pigouvian externality dimension reserved-but-dormant — composing the proven nucleus-witness-olog::required_bond kernel."
 
 [lints]

--- a/crates/nucleus-econ-kernels/Cargo.toml
+++ b/crates/nucleus-econ-kernels/Cargo.toml
@@ -5,6 +5,7 @@ version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
+repository.workspace = true
 description = "Integer-only economic kernels (VCG, Ring 0 budget, Lagrangian) lifted from sibling repos with per-file provenance comments. No f64 — see docs/ECON-PRECISION.md."
 
 [lints.rust]

--- a/crates/nucleus-econ-types/Cargo.toml
+++ b/crates/nucleus-econ-types/Cargo.toml
@@ -5,6 +5,7 @@ version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
+repository.workspace = true
 description = "Financially load-bearing newtypes (MicroUsd, AuctionId/AgentId/ProposalId) shared across the Nucleus economic surface. Zero-dependency beyond serde so every money/ID crate can depend on it without pulling in heavy transitive graphs. Wire shape is byte-identical to the bare primitive via serde(transparent)."
 
 [lints]

--- a/crates/nucleus-externality/Cargo.toml
+++ b/crates/nucleus-externality/Cargo.toml
@@ -5,6 +5,7 @@ version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
+repository.workspace = true
 description = "Coproduct Pigouvian externality layer: signed externality envelopes, OLAP rollup cube, and rate-setter glue between nucleus-econ-kernels VCG clearing and the witness-federation rebate path. SOTA-inspired by arXiv 2106.06060 + 2601.03451 + 2305.01477; ZK/TEE oracle envelopes per Verifiable Carbon Accounting."
 
 [lints]

--- a/crates/nucleus-recompute/Cargo.toml
+++ b/crates/nucleus-recompute/Cargo.toml
@@ -5,6 +5,7 @@ version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
+repository.workspace = true
 description = "verify_receipt — re-derive every cleared number (settlement / commons / VCG) from a receipt's DECLARED inputs using the proven nucleus-econ-kernels, and compare to the claimed outputs. The money-path-runs-the-proven-function check, runnable by anyone."
 
 [dependencies]

--- a/crates/nucleus-witness-olog/Cargo.toml
+++ b/crates/nucleus-witness-olog/Cargo.toml
@@ -5,6 +5,7 @@ version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
+repository.workspace = true
 description = "Phase 2 contract (P2.1): the Gov functor (admitted witness → olog fact) and the signed, transparency-loggable accumulation manifest. Types + the no-upgrade invariant only — wiring to the real olog/merge-gate archive is P2.2. See docs/rfcs/witness-olog-functor.md."
 
 [lints]


### PR DESCRIPTION
Now that the six econ/credit crates are live on crates.io `v1.0.0`, this wires their **future** releases to publish **keylessly** via crates.io Trusted Publishing (GitHub OIDC) — no stored `CARGO_REGISTRY_TOKEN`. The one manual token used to bootstrap the first publish can be revoked.

### `.github/workflows/crates-publish.yml`
- `rust-lang/crates-io-auth-action@v1.0.4` (SHA-pinned) mints a short-lived, auto-revoked token via OIDC.
- Publishes the closure in **dependency order**, **idempotently** — a crate whose current version is already on crates.io is skipped, so re-running after a rate-limited/partial run is safe.
- Trigger: `workflow_dispatch` or a `crates-v*` tag. `permissions: id-token: write` + `contents: read`.

### `repository` metadata
Added `repository = "https://github.com/coproduct-opensource/nucleus"` to `[workspace.package]` + `repository.workspace = true` on all six crates. The manual publish warned this was missing (so the crates.io pages have no repo link); fixed from the next version on.

### One-time prerequisite before this can run
Register each crate's **Trusted Publisher** on crates.io (crate → Settings → Trusted Publishing): repo `coproduct-opensource/nucleus`, workflow `crates-publish.yml`.

> `nucleus-node` is intentionally excluded — it hasn't had a first manual publish, and crates.io OIDC cannot bootstrap a brand-new crate. Add it here after its first manual publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)