### PR TITLE
feat(creditworthiness): externality dimension ON by default (regenerative substrate)

### DIFF
--- a/crates/nucleus-creditworthiness/src/lib.rs
+++ b/crates/nucleus-creditworthiness/src/lib.rs
@@ -11,17 +11,21 @@
 //! with the EXACT proven function the enforcement path uses; it never
 //! re-implements the math.
 //!
-//! # The dimension vector (financial now, externality reserved)
+//! # The dimension vector (regenerative by default)
 //!
-//! Creditworthiness is behaviour over time priced into a number. v1 scores ONE
-//! active dimension — [`CreditDimension::FinancialDefault`] (honest settlement
-//! vs. caught defection). [`CreditDimension::Externality`] is a **first-class
-//! but dormant** dimension (Pigouvian: did the agent pay its true-cost dues to
-//! the commons, or dump them?). Its events are accumulated but excluded from the
-//! bond-substituting reputation while [`CreditDimension::is_active`] returns
-//! `false` — so lighting up externality accounting later (the kernels already
-//! exist in `nucleus-externality` + `nucleus-econ-kernels` commons routing) is a
-//! one-line flip, not a schema migration. Greed ignites; conscience compounds.
+//! Creditworthiness is behaviour over time priced into a number, over TWO active
+//! dimensions:
+//! * [`CreditDimension::FinancialDefault`] — honest settlement vs. caught
+//!   defection (recompute-verified Settlement/VCG receipts);
+//! * [`CreditDimension::Externality`] — Pigouvian: did the agent pay its
+//!   true-cost dues to the commons, or dump them? (recompute-verified `Commons` /
+//!   `route_to_commons` receipts).
+//!
+//! Both are load-bearing on the bond-substituting reputation
+//! ([`CreditDimension::is_active`]) — the substrate is **regenerative by
+//! default**: routing true-cost dues to the commons builds standing exactly as
+//! honest settlement does, and only ever from a receipt that already recomputed.
+//! Greed ignites; conscience compounds.
 //!
 //! # What is PROVEN here (property tests, not prose)
 //!
@@ -35,9 +39,10 @@
 //! * **Sybil-no-discount.** An empty file yields reputation `0` ⇒ the full bond
 //!   — minting fresh identities buys no discount (inherited from the composed
 //!   kernel's `requiredBond` floor).
-//! * **Externality is inert in v1.** While the dimension is dormant, externality
-//!   events never move the bond-substituting reputation — the socket exists but
-//!   is not wired.
+//! * **Provenance-gated, both dimensions.** An externality credit moves
+//!   reputation only when minted from a recompute-verified `Commons` receipt
+//!   (same discipline as the financial dimension) — activating externality does
+//!   not let an unverified claim move money-gating standing.
 //!
 //! # Honesty boundary
 //!
@@ -72,20 +77,21 @@ pub mod store;
 /// A dimension of creditworthiness. Each dimension is scored independently from
 /// recompute-verified events.
 ///
-/// v1 activates only [`CreditDimension::FinancialDefault`].
-/// [`CreditDimension::Externality`] is reserved (see crate docs): a first-class
-/// variant whose contribution to the bond-substituting reputation is gated off
-/// by [`CreditDimension::is_active`] until the Pigouvian accounting is wired in.
+/// Both [`CreditDimension::FinancialDefault`] and
+/// [`CreditDimension::Externality`] are active (see [`CreditDimension::is_active`])
+/// — the substrate is regenerative by default. Each contributes to the
+/// bond-substituting reputation only from recompute-verified events.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum CreditDimension {
     /// Financial-default risk: honest, recompute-matched settlement (credit) vs.
-    /// a caught defection / recompute mismatch (debit). **Active in v1.**
+    /// a caught defection / recompute mismatch (debit). **Active.**
     FinancialDefault,
     /// Externality internalization (Pigouvian): paying true-cost dues to the
     /// commons (credit) vs. dumping uncompensated externalities (debit).
-    /// **Reserved — dormant in v1.**
+    /// **Active** — fed by recompute-verified `Commons` (`route_to_commons`)
+    /// receipts; regenerative by default.
     Externality,
 }
 
@@ -96,15 +102,25 @@ impl CreditDimension {
         CreditDimension::Externality,
     ];
 
-    /// Whether this dimension currently contributes to the bond-substituting
-    /// reputation. v1: only [`CreditDimension::FinancialDefault`].
+    /// Whether this dimension contributes to the bond-substituting reputation.
     ///
-    /// Flipping [`CreditDimension::Externality`] to active here lights up
-    /// Pigouvian accounting across the whole flywheel — the kernels it needs
-    /// already exist in `nucleus-externality` + `nucleus-econ-kernels`. This is
-    /// the deliberate "config flip, not a schema migration" seam.
+    /// **Both dimensions are active: the substrate is regenerative by default.**
+    /// `FinancialDefault` is fed by recompute-verified settlement/VCG receipts;
+    /// `Externality` is fed by recompute-verified `Commons` (`route_to_commons`)
+    /// receipts — paying true-cost dues to the commons builds standing exactly as
+    /// honest settlement does. Both move reputation ONLY from events minted off a
+    /// receipt that already recomputed (see [`crate::mint`]), so activating
+    /// externality does not let an unverified claim move money-gating standing.
+    ///
+    /// Note: this lights up commons-routing *accounting* (did the dues actually
+    /// reach the commons, verified). The Pigouvian *rate-setting* — what the dues
+    /// should be — remains a governed, contestable frontier (see
+    /// `docs/rfcs/regenerative-default-substrate.md` and `externality-oracle.md`).
     pub const fn is_active(self) -> bool {
-        matches!(self, CreditDimension::FinancialDefault)
+        matches!(
+            self,
+            CreditDimension::FinancialDefault | CreditDimension::Externality
+        )
     }
 }
 
@@ -161,7 +177,7 @@ impl CreditEvent {
     }
 
     /// Externality dues paid to the commons worth `weight_micro` — builds
-    /// standing on the **reserved** externality dimension (inert in v1).
+    /// standing on the **active** externality dimension (regenerative by default).
     pub fn externality_internalized(weight_micro: u64, receipt_hash: [u8; 32]) -> Self {
         Self {
             dimension: CreditDimension::Externality,
@@ -172,7 +188,7 @@ impl CreditEvent {
     }
 
     /// An uncompensated externality dumped on the commons worth `weight_micro` —
-    /// destroys standing on the **reserved** externality dimension (inert in v1).
+    /// destroys standing on the **active** externality dimension.
     pub fn externality_dumped(weight_micro: u64, receipt_hash: [u8; 32]) -> Self {
         Self {
             dimension: CreditDimension::Externality,
@@ -277,9 +293,9 @@ impl CreditFile {
         self.event_count
     }
 
-    /// Net standing on a single dimension (floored at 0), **including dormant
-    /// dimensions** — for inspection/forward-compat. This is NOT necessarily
-    /// what prices the bond; see [`CreditFile::reputation_micro`].
+    /// Net standing on a single dimension (floored at 0) — for per-dimension
+    /// inspection. The bond is priced by the sum over ACTIVE dimensions; see
+    /// [`CreditFile::reputation_micro`].
     pub fn dimension_micro(&self, dim: CreditDimension) -> u64 {
         self.dims.get(&dim).copied().unwrap_or_default().net_micro()
     }
@@ -368,20 +384,31 @@ mod tests {
     }
 
     #[test]
-    fn externality_dimension_is_reserved_but_dormant() {
+    fn externality_dimension_is_active_regenerative_by_default() {
         // Externality events accumulate on their dimension...
         let f = CreditFile::from_events(&[
             CreditEvent::externality_internalized(1_000_000, h(1)),
             CreditEvent::externality_dumped(250_000, h(2)),
         ]);
         assert_eq!(f.dimension_micro(CreditDimension::Externality), 750_000);
-        // ...but contribute NOTHING to the bond-substituting reputation in v1.
-        assert_eq!(f.reputation_micro(), 0);
-        assert_eq!(f.required_bond(1_000_000), AmountMicro(1_000_000));
-        // The day CreditDimension::Externality::is_active() flips true, this
-        // same file prices a discount — config flip, no schema change.
-        assert!(!CreditDimension::Externality.is_active());
+        // ...and now CONTRIBUTE to the bond-substituting reputation: routing
+        // true-cost dues to the commons prices a discount, exactly as honest
+        // settlement does. Regenerative by default.
+        assert_eq!(f.reputation_micro(), 750_000);
+        assert_eq!(f.required_bond(1_000_000), AmountMicro(250_000));
+        assert!(CreditDimension::Externality.is_active());
         assert!(CreditDimension::FinancialDefault.is_active());
+    }
+
+    #[test]
+    fn both_dimensions_sum_into_reputation() {
+        // Financial + externality standing compose into one bond-substituting
+        // reputation — conscience and commerce pulling the same direction.
+        let f = CreditFile::from_events(&[
+            CreditEvent::honest_settlement(400_000, h(1)),
+            CreditEvent::externality_internalized(300_000, h(2)),
+        ]);
+        assert_eq!(f.reputation_micro(), 700_000);
     }
 
     #[test]
@@ -498,24 +525,29 @@ mod tests {
             prop_assert!(after.required_bond(gain).0 >= before.required_bond(gain).0);
         }
 
-        /// The reserved dimension is inert: externality events never change the
-        /// bond-substituting reputation while the dimension is dormant.
+        /// Regenerative monotonicity: an externality CREDIT (true-cost dues routed
+        /// to the commons) never LOWERS reputation; an externality DEBIT (dumped)
+        /// never RAISES it — the same one-way flywheel as the financial dimension,
+        /// now that externality is active.
         #[test]
-        fn externality_events_do_not_move_reputation(
+        fn externality_credit_builds_debit_burns(
             evs in events(),
             ext_weight in 0u64..2_000_000,
             ext_pol in any::<bool>(),
+            gain in 0u64..4_000_000,
             seed in any::<u8>(),
         ) {
             let before = CreditFile::from_events(&evs);
             let mut after = before.clone();
-            let ext = if ext_pol {
-                CreditEvent::externality_internalized(ext_weight, [seed; 32])
+            if ext_pol {
+                after.observe(&CreditEvent::externality_internalized(ext_weight, [seed; 32]));
+                prop_assert!(after.reputation_micro() >= before.reputation_micro());
+                prop_assert!(after.required_bond(gain).0 <= before.required_bond(gain).0);
             } else {
-                CreditEvent::externality_dumped(ext_weight, [seed; 32])
-            };
-            after.observe(&ext);
-            prop_assert_eq!(after.reputation_micro(), before.reputation_micro());
+                after.observe(&CreditEvent::externality_dumped(ext_weight, [seed; 32]));
+                prop_assert!(after.reputation_micro() <= before.reputation_micro());
+                prop_assert!(after.required_bond(gain).0 >= before.required_bond(gain).0);
+            }
         }
 
         /// Sybil-no-discount: a fresh (empty) identity always pays the full bond.

--- a/crates/nucleus-creditworthiness/src/mint.rs
+++ b/crates/nucleus-creditworthiness/src/mint.rs
@@ -43,11 +43,32 @@ pub fn receipt_hash(receipt: &ClearingReceipt) -> [u8; 32] {
 
 /// Mint a [`CreditEvent`] from one receipt by recomputing it. Returns `None`
 /// for an [`RecomputeOutcome::Invalid`] receipt (nothing to attribute).
+///
+/// The receipt KIND chooses the creditworthiness dimension:
+/// * a `Commons` receipt is the Pigouvian / `route_to_commons` path (pinned to
+///   `Commons.lean`'s `routed_conserves`), so a recompute-**Match** is true-cost
+///   dues actually routed to the commons → an **externality credit**, and a
+///   **Mismatch** is a claimed-but-unrouted routing — an externality **dumped**
+///   on the commons → an externality **debit**;
+/// * a `Settlement` / `Vcg` receipt is the financial path → a financial credit on
+///   Match, a caught-defection debit on Mismatch.
+///
+/// Both dimensions are now load-bearing on reputation (see
+/// [`CreditDimension::is_active`]) — the substrate is regenerative by default:
+/// recompute-verified commons-routing builds standing, exactly as honest
+/// settlement does, and only ever from a receipt that already recomputed.
 pub fn mint_event(receipt: &ClearingReceipt) -> Option<CreditEvent> {
     let weight = economic_magnitude(receipt);
     let hash = receipt_hash(receipt);
+    let is_commons = matches!(receipt, ClearingReceipt::Commons(_));
     match verify_receipt(receipt) {
+        RecomputeOutcome::Match if is_commons => {
+            Some(CreditEvent::externality_internalized(weight, hash))
+        }
         RecomputeOutcome::Match => Some(CreditEvent::honest_settlement(weight, hash)),
+        RecomputeOutcome::Mismatch { .. } if is_commons => {
+            Some(CreditEvent::externality_dumped(weight, hash))
+        }
         RecomputeOutcome::Mismatch { .. } => Some(CreditEvent::caught_defection(weight, hash)),
         RecomputeOutcome::Invalid(_) => None,
     }
@@ -134,6 +155,40 @@ mod tests {
     }
 
     #[test]
+    fn an_honest_commons_receipt_mints_an_externality_credit() {
+        // The Pigouvian path: dues actually routed to the commons (recompute-Match)
+        // build standing on the EXTERNALITY dimension — regenerative by default.
+        let r = honest_commons(300_000);
+        let e = mint_event(&r).expect("honest commons mints an event");
+        assert_eq!(e.dimension, CreditDimension::Externality);
+        assert_eq!(e.polarity, crate::Polarity::Credit);
+        assert_eq!(e.weight_micro, 300_000); // pool_micro (declared input)
+                                             // It builds bond-substituting reputation now that externality is active.
+        let f = CreditFile::from_events(&[e]);
+        assert_eq!(f.reputation_micro(), 300_000);
+    }
+
+    #[test]
+    fn a_mismatched_commons_receipt_mints_an_externality_debit() {
+        // Claimed-but-unrouted dues: valid shares, tampered allocations →
+        // recompute (route_to_commons) catches it → an externality DUMPED debit.
+        let mut r = honest_commons(300_000);
+        if let ClearingReceipt::Commons(ref mut c) = r {
+            c.allocations[0].amount_micro += 1; // dumped, not actually routed
+        }
+        assert!(!verify_receipt(&r).is_match());
+        let e = mint_event(&r).expect("a caught dump still mints an event (a debit)");
+        assert_eq!(e.dimension, CreditDimension::Externality);
+        assert_eq!(e.polarity, crate::Polarity::Debit);
+        // Stacked on prior externality credit it lowers standing.
+        let f = CreditFile::from_events(&[
+            CreditEvent::externality_internalized(300_000, [0u8; 32]),
+            e,
+        ]);
+        assert_eq!(f.reputation_micro(), 0); // 300k credit − 300k debit
+    }
+
+    #[test]
     fn an_invalid_receipt_mints_nothing() {
         // Commons shares that don't sum to 10_000 → Invalid (no baseline).
         let bad = ClearingReceipt::Commons(CommonsClaim {
@@ -157,7 +212,8 @@ mod tests {
             honest_settlement(0, 5_000), // a low-delivery settlement, price 0
         ];
         let file = credit_file_from_receipts(&receipts);
-        // reputation = 400k (settle) + 300k (commons pool) + 0 = 700k.
+        // reputation sums BOTH active dimensions: 400k+0 financial (settlements)
+        // + 300k externality (commons pool) = 700k.
         assert_eq!(file.reputation_micro(), 700_000);
         // 700k of recompute-verified history covers 700k of a 1M defection gain.
         assert_eq!(file.required_bond(1_000_000), AmountMicro(300_000));


### PR DESCRIPTION
**Move #1 of the regenerative-default substrate RFC, made real** — flip the default from extractive to regenerative. (`docs/rfcs/regenerative-default-substrate.md`, PR #1801.)

## Two changes, both grounded in already-proven code
1. **`mint_event` routes Commons receipts to the externality dimension.** A recompute-verified `Commons` receipt is the Pigouvian / `route_to_commons` path (pinned to `Commons.lean`'s `routed_conserves`). It now mints `externality_internalized` (credit) on Match and `externality_dumped` (debit) on Mismatch — instead of mis-filing it as `FinancialDefault`. Settlement/VCG stay financial. *(This fixed a real misattribution: the commons receipt is the externality path, but its verified credit was landing in the financial dimension.)*
2. **`is_active` returns true for both dimensions.** Routing true-cost dues to the commons now builds bond-substituting reputation exactly as honest settlement does. **Regenerative by default.**

## Safe by construction
An externality event moves money-gating standing **only** when minted from a recompute-verified Commons receipt — the same provenance discipline as the financial dimension. Activating it does **not** let an unverified claim move standing. This lights up commons-routing *accounting* (were the dues verifiably routed); the Pigouvian *rate-setting* (what the dues should be) remains a governed, contestable frontier (RFC + `externality-oracle.md`).

## Backward-compatible in aggregate
`reputation_micro` sums over active dimensions, so a commons credit that previously counted under `FinancialDefault` now counts under `Externality` — **same total, correctly attributed.**

## Tests
33 pass (default + `recompute` feature). The prior "externality is inert" unit + property tests are **rewritten to the new regenerative invariants** (externality credit builds / debit burns; monotone flywheel; both dimensions sum into reputation). New mint tests: honest Commons → externality credit; tampered Commons → externality debit. clippy clean; all stale "dormant/inert/reserved" docs updated.

> **Behavior change to a published crate** (v1.0.0 had externality dormant) — warrants a minor version bump on the next (now keyless) publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)