### PR TITLE
feat(lineage): economic vocabulary in canonical public crate (Vision 2 keystone)

### DIFF
--- a/crates/nucleus-cli/src/lineage.rs
+++ b/crates/nucleus-cli/src/lineage.rs
@@ -442,6 +442,38 @@ fn format_kind(edge: &LineageEdge) -> String {
             source_class,
             ..
         } => format!("[doc/{:?}/{}]", source_class, source_url),
+        nucleus_lineage::EdgeKind::Bid { market_id } => format!("[bid/{}]", market_id),
+        nucleus_lineage::EdgeKind::Allocation {
+            market_id,
+            mechanism,
+        } => format!("[alloc/{}/{}]", mechanism, market_id),
+        nucleus_lineage::EdgeKind::ContractEvaluation { contract_id, step } => {
+            format!("[contract/{}#{}]", contract_id, step)
+        }
+        nucleus_lineage::EdgeKind::Dispute { dispute_id, .. } => {
+            format!("[dispute/{}]", dispute_id)
+        }
+        nucleus_lineage::EdgeKind::MetricClaim {
+            metric_name,
+            window_id,
+        } => format!("[metric/{}/{}]", metric_name, window_id),
+        nucleus_lineage::EdgeKind::Settlement { tx_ref, rail } => {
+            format!("[settle/{}/{}]", rail, tx_ref)
+        }
+        nucleus_lineage::EdgeKind::Externality {
+            resource,
+            oracle_kid,
+        } => format!("[externality/{}/{}]", resource, oracle_kid),
+        nucleus_lineage::EdgeKind::PigouvianRateUpdate {
+            resource,
+            rate_micro_usd_per_unit,
+            ..
+        } => format!("[pigou_rate/{}/{}µ]", resource, rate_micro_usd_per_unit),
+        nucleus_lineage::EdgeKind::WelfareRebate {
+            recipient_kid,
+            micro_usd,
+            ..
+        } => format!("[rebate/{}/{}µ]", recipient_kid, micro_usd),
         nucleus_lineage::EdgeKind::Other { name } => format!("[{}]", name),
     }
 }
@@ -559,6 +591,7 @@ mod tests {
             ts: chrono::Utc::now(),
             attrs: Default::default(),
             proof: None,
+            verifier_attestation: None,
         };
         let edges = vec![LineageEdge::pod_admit(victim_pod), forged];
         let g = LineageGraph::build(&edges);
@@ -630,6 +663,7 @@ mod tests {
             ts: chrono::Utc::now(),
             attrs: Default::default(),
             proof: None,
+            verifier_attestation: None,
         };
         assert!(!is_structurally_consistent(&edge));
     }
@@ -647,6 +681,7 @@ mod tests {
             ts: chrono::Utc::now(),
             attrs: Default::default(),
             proof: None,
+            verifier_attestation: None,
         };
         assert!(!is_structurally_consistent(&edge_bad));
     }
@@ -667,6 +702,7 @@ mod tests {
             ts: chrono::Utc::now(),
             attrs: Default::default(),
             proof: None,
+            verifier_attestation: None,
         };
         assert!(is_structurally_consistent(&ok));
 
@@ -680,6 +716,7 @@ mod tests {
             ts: chrono::Utc::now(),
             attrs: Default::default(),
             proof: None,
+            verifier_attestation: None,
         };
         assert!(!is_structurally_consistent(&bad));
     }
@@ -698,6 +735,7 @@ mod tests {
             ts: chrono::Utc::now(),
             attrs: Default::default(),
             proof: None,
+            verifier_attestation: None,
         };
         let edges = vec![
             LineageEdge::pod_admit(p.clone()),
@@ -744,6 +782,7 @@ mod tests {
                 ts: chrono::Utc::now(),
                 attrs: Default::default(),
                 proof: None,
+                verifier_attestation: None,
             },
             LineageEdge {
                 child: y.clone(),
@@ -753,6 +792,7 @@ mod tests {
                 ts: chrono::Utc::now(),
                 attrs: Default::default(),
                 proof: None,
+                verifier_attestation: None,
             },
         ];
         let g = LineageGraph::build(&edges);

--- a/crates/nucleus-envelope/src/verify.rs
+++ b/crates/nucleus-envelope/src/verify.rs
@@ -1259,6 +1259,7 @@ mod tests {
             ts: chrono::Utc::now(),
             attrs: Default::default(),
             proof: None,
+            verifier_attestation: None,
         };
         sink.emit(bad_merge).unwrap();
 

--- a/crates/nucleus-lineage/Cargo.toml
+++ b/crates/nucleus-lineage/Cargo.toml
@@ -10,7 +10,14 @@ keywords = ["spiffe", "lineage", "provenance", "ifc", "agents"]
 categories = ["development-tools", "cryptography"]
 
 [features]
-default = []
+default = ["sink-io"]
+# **wasm-compatibility gate**: `sink-io` ships the file-backed `JsonlSink`
+# which depends on `std::fs::{File, OpenOptions}` (unavailable on
+# `wasm32-unknown-unknown`). Default-on so native consumers see no change;
+# disable via `default-features = false` for wasm targets. The `InMemorySink`
+# + `LineageSink` trait + `SinkError` (minus the `Io` variant) remain
+# available unconditionally.
+sink-io = []
 # Demo-only in-process Ed25519 JWT-SVID issuer + edge signer. NOT FOR
 # PRODUCTION USE. Production callers should write a SPIFFE-Workload-API-
 # backed `IdentityFetcher` impl and never enable this feature in release

--- a/crates/nucleus-lineage/src/edge.rs
+++ b/crates/nucleus-lineage/src/edge.rs
@@ -11,11 +11,132 @@ use std::collections::BTreeMap;
 use crate::id::CallSpiffeId;
 use crate::proof::Proof;
 
+/// Pins the verification environment that an edge's claim can be
+/// independently recomputed against. The off-platform verification closure
+/// depends on this metadata being part of the signed surface — without it,
+/// "independently recomputable" is rhetoric (the operator could swap
+/// verifier binaries, Wasmtime versions, VRF parameters, or Lean specs
+/// between claim production and recomputation).
+///
+/// All-`None` is the unattested case (legacy edges, structural-only claims).
+/// Economic-edge variants — `Bid`, `Allocation`, `ContractEvaluation`,
+/// `Dispute`, `MetricClaim` — SHOULD populate the relevant fields when
+/// signed. Each field is its own `Option<String>` so callers can attest
+/// partially (e.g., a `MetricClaim` without VRF dependency leaves
+/// `vrf_params_hash` unset).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VerifierAttestation {
+    /// Identity tag of the verifier binary that recomputes this claim.
+    ///
+    /// **Two accepted forms** (iteration-12 audit fix #6):
+    /// - **Semver-versioned package id**: `"<crate-name>@<semver>"`
+    ///   (e.g. `"nucleus-runner@0.1.0"`). This is what the runner stamps
+    ///   today — sufficient for verifier replay because the source
+    ///   tree at a given semver IS content-addressable via the Cargo
+    ///   ecosystem (Cargo.lock + the source tarball's hash on
+    ///   crates.io).
+    /// - **64-char hex SHA-256**: of the published binary itself, for
+    ///   verifiers that prefer binary-equality over semver-trust.
+    ///
+    /// Both forms are accepted because semver pinning is sufficient
+    /// for the substrate's "rebuild from source at this commit"
+    /// replay model. A future emitter that hashes a sealed,
+    /// reproducible binary may use the hex form; today's emitters
+    /// use the `@` form.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub verifier_binary_hash: Option<String>,
+    /// Wasmtime version + config descriptor (e.g., "44.0.0+nan_canon+fuel=off").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub wasmtime_version: Option<String>,
+    /// Hex hash of the relevant Wasmtime config bundle (host functions,
+    /// resource limits, NaN canonicalization) that affect determinism.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub wasmtime_config_hash: Option<String>,
+    /// Hex hash of VRF public parameters when the claim depends on a VRF
+    /// (e.g., arbitrator panel selection in Primitive 4).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vrf_params_hash: Option<String>,
+    /// Hex Merkle root of external state snapshot (e.g., trust-service
+    /// reputation state) at claim time, for closures that depend on
+    /// stateful external services.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub external_snapshot_root: Option<String>,
+    /// Hex hash of the Lean spec module that pinned the property this claim
+    /// satisfies (e.g., `formal/Nucleus/Auctions/BudgetConservation.lean`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lean_spec_hash: Option<String>,
+}
+
+impl VerifierAttestation {
+    /// Construct an empty attestation; populate fields via builder methods.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Builder: pin the verifier binary hash.
+    pub fn with_verifier_binary_hash(mut self, hex: impl Into<String>) -> Self {
+        self.verifier_binary_hash = Some(hex.into());
+        self
+    }
+
+    /// Builder: pin the Wasmtime version descriptor.
+    pub fn with_wasmtime_version(mut self, version: impl Into<String>) -> Self {
+        self.wasmtime_version = Some(version.into());
+        self
+    }
+
+    /// Builder: pin the Wasmtime config bundle hash.
+    pub fn with_wasmtime_config_hash(mut self, hex: impl Into<String>) -> Self {
+        self.wasmtime_config_hash = Some(hex.into());
+        self
+    }
+
+    /// Builder: pin the VRF public parameters hash.
+    pub fn with_vrf_params_hash(mut self, hex: impl Into<String>) -> Self {
+        self.vrf_params_hash = Some(hex.into());
+        self
+    }
+
+    /// Builder: pin the external-state-snapshot root.
+    pub fn with_external_snapshot_root(mut self, hex: impl Into<String>) -> Self {
+        self.external_snapshot_root = Some(hex.into());
+        self
+    }
+
+    /// Builder: pin the Lean spec module hash.
+    pub fn with_lean_spec_hash(mut self, hex: impl Into<String>) -> Self {
+        self.lean_spec_hash = Some(hex.into());
+        self
+    }
+
+    /// `true` iff every field is `None`. Used by verifiers in strict mode
+    /// to reject edges that claim economic semantics without attestation.
+    pub fn is_empty(&self) -> bool {
+        self.verifier_binary_hash.is_none()
+            && self.wasmtime_version.is_none()
+            && self.wasmtime_config_hash.is_none()
+            && self.vrf_params_hash.is_none()
+            && self.external_snapshot_root.is_none()
+            && self.lean_spec_hash.is_none()
+    }
+}
+
 /// What kind of derivation this edge represents.
 ///
 /// `Other(String)` is reserved for forward-compatible kinds that callers
 /// can introduce without modifying this enum. The string value is shown
 /// verbatim in lineage output.
+///
+/// # Economic-edge variants
+///
+/// The `Bid`, `Allocation`, `ContractEvaluation`, `Dispute`, and `MetricClaim`
+/// variants are the substrate's economic primitives. They follow the same
+/// signed-binding contract as `ToolCall` / `LlmCall`: payload fields shown
+/// here are descriptive metadata, while the cryptographic binding to specific
+/// values (bid amounts, allocation outcomes, metric values) happens via the
+/// edge's `content_hash_hex` over a deterministic serialization of the
+/// underlying record. Producers MUST set `content_hash_hex` for economic
+/// edges; verifiers MUST treat absent `content_hash_hex` as unsigned.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum EdgeKind {
@@ -45,6 +166,102 @@ pub enum EdgeKind {
         retrieval_ts: DateTime<Utc>,
         /// Trust class of the source.
         source_class: SourceClass,
+    },
+    /// A bid submitted into a market mechanism. `market_id` identifies the
+    /// auction; the bidder is the edge's first parent. The bid record
+    /// (amount, side-attributes, sealed-or-open) is bound via `content_hash_hex`.
+    Bid { market_id: String },
+    /// An allocation produced by a market mechanism. `market_id` identifies
+    /// the auction; `mechanism` names the rule ("vcg", "second_price",
+    /// "posted_price", "gale_shapley", "double_auction"). Parents are the
+    /// bid edges that fed into this allocation. The allocation record
+    /// (winners, payments, integer-rounded micro-USD amounts) is bound via
+    /// `content_hash_hex`.
+    Allocation {
+        market_id: String,
+        mechanism: String,
+    },
+    /// One evaluation step of a programmable-contract state machine.
+    /// `contract_id` identifies the contract; `step` is the monotonic step
+    /// counter. The evaluated transition (input event, output obligations,
+    /// payment flows, reputation effects) is bound via `content_hash_hex`.
+    ContractEvaluation { contract_id: String, step: u32 },
+    /// A dispute filed against a prior edge. `dispute_id` identifies the
+    /// dispute; `target_edge_hash` is the hex SHA-256 of the disputed edge's
+    /// canonical bytes. The claim record (evidence references, requested
+    /// remedy) is bound via `content_hash_hex`.
+    Dispute {
+        dispute_id: String,
+        target_edge_hash: String,
+    },
+    /// A signed welfare/economic-introspection metric claim over a specific
+    /// window. `metric_name` identifies the metric (e.g. "producer_surplus",
+    /// "gini", "time_to_clear"); `window_id` identifies the aggregation
+    /// window. The metric value (with any differential-privacy noise
+    /// parameters) is bound via `content_hash_hex`.
+    MetricClaim {
+        metric_name: String,
+        window_id: String,
+    },
+    /// A settlement transaction on an external payment rail.
+    /// `tx_ref` is the rail-side transaction id (Stripe `ch_…`, x402
+    /// onchain tx hash, ACH trace number, …); `rail` names the
+    /// settlement protocol ("stripe-connect", "x402-evm", "ach").
+    /// Parents are the Allocation / ContractEvaluation edges that
+    /// produced the obligation being settled. The payment record
+    /// (amount, payee SPIFFE id, integer micro-USD) is bound via
+    /// `content_hash_hex`.
+    ///
+    /// **Refund / chargeback semantics** (Close-to-Highest D4):
+    /// a compensating refund is itself a `Settlement` edge whose
+    /// `attrs["amount_micro_usd_signed"]` is *negative* (string-encoded
+    /// `i64`) and whose `parents` include the original Settlement
+    /// edge being reversed. The signed-sum of the two settlement
+    /// edges over a charge is zero exactly when the refund is full.
+    Settlement { tx_ref: String, rail: String },
+    /// **Pigouvian P4.** An externality claim signed by a designated
+    /// resource oracle. `resource` is the short stable tag from
+    /// `nucleus_externality::ResourceDim::as_canonical_tag()` (e.g.
+    /// "gpu_s", "co2_g"). `oracle_kid` is the signing-key id used to
+    /// resolve the oracle's verifying key. The amount + freshness
+    /// window + subject identity binding live in the
+    /// `nucleus_externality::SignedExternalityClaim` whose
+    /// canonical SHA-256 is bound via `content_hash_hex`. Parents
+    /// chain back to the call edge the externality is attributed
+    /// to.
+    Externality {
+        resource: String,
+        oracle_kid: String,
+    },
+    /// **Pigouvian P5.** A rate-setter update to the Pigouvian λ_k
+    /// for a given resource dimension, applicable over a clearing
+    /// window. `resource` is the same short tag used by
+    /// `Externality`; `rate_micro_usd_per_unit` is the marginal
+    /// social cost per micro-unit of consumption, integer-only;
+    /// `window_unix_micros` names the application window. The full
+    /// rate record (full rate vector, cube slice the rate was
+    /// derived from, signature) is bound via `content_hash_hex`.
+    /// Rate updates are themselves signed edges so the rate timeline
+    /// is auditable and replayable in the browser verifier.
+    PigouvianRateUpdate {
+        resource: String,
+        rate_micro_usd_per_unit: u64,
+        window_unix_micros: u64,
+    },
+    /// **Pigouvian P6.** A welfare-rebate disbursement to a witness-
+    /// federation peer (or Pigouvian victim), funded from the VCG
+    /// surplus collected through the Pigouvian re-weighting. Solves
+    /// the classical VCG budget-balance gap: the federation peer
+    /// who VERIFIED the externality claim gets paid proportional
+    /// to their verification share. `recipient_kid` identifies the
+    /// peer's signing key; `micro_usd` is the rebate amount (integer
+    /// per ECON-PRECISION); `source_externality_edge_hash` is the
+    /// content_hash_hex of the `Externality` edge that funded this
+    /// rebate (used to enforce no-double-claim).
+    WelfareRebate {
+        recipient_kid: String,
+        micro_usd: u64,
+        source_externality_edge_hash: String,
     },
     /// Forward-compatible escape hatch. `name` is the caller-defined kind label.
     Other { name: String },
@@ -99,6 +316,14 @@ pub struct LineageEdge {
     /// mode.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub proof: Option<Proof>,
+    /// Pins the verification environment for this edge's claim (verifier
+    /// binary, Wasmtime version + config, VRF parameters, external-snapshot
+    /// root, Lean spec). `None` for legacy / structural-only edges. Economic
+    /// edges (`Bid`, `Allocation`, `ContractEvaluation`, `Dispute`,
+    /// `MetricClaim`) SHOULD populate the relevant fields when signed so
+    /// that off-platform recomputation is genuinely closed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub verifier_attestation: Option<VerifierAttestation>,
 }
 
 impl LineageEdge {
@@ -112,6 +337,7 @@ impl LineageEdge {
             ts: Utc::now(),
             attrs: BTreeMap::new(),
             proof: None,
+            verifier_attestation: None,
         }
     }
 
@@ -139,6 +365,7 @@ impl LineageEdge {
             ts: Utc::now(),
             attrs: BTreeMap::new(),
             proof: None,
+            verifier_attestation: None,
         }
     }
 
@@ -152,6 +379,7 @@ impl LineageEdge {
             ts: Utc::now(),
             attrs: BTreeMap::new(),
             proof: None,
+            verifier_attestation: None,
         }
     }
 
@@ -170,6 +398,13 @@ impl LineageEdge {
     /// Builder: attach a cryptographic proof.
     pub fn with_proof(mut self, proof: Proof) -> Self {
         self.proof = Some(proof);
+        self
+    }
+
+    /// Builder: attach a verifier attestation pinning the recomputation
+    /// environment for this edge's claim.
+    pub fn with_verifier_attestation(mut self, va: VerifierAttestation) -> Self {
+        self.verifier_attestation = Some(va);
         self
     }
 }
@@ -278,6 +513,7 @@ mod tests {
             ts: Utc::now(),
             attrs: BTreeMap::new(),
             proof: None,
+            verifier_attestation: None,
         };
         assert_eq!(edge.parents.len(), 2);
         assert!(matches!(edge.kind, EdgeKind::Merge));
@@ -289,5 +525,411 @@ mod tests {
         let edge = LineageEdge::pod_admit(p);
         let json = serde_json::to_string(&edge).unwrap();
         assert!(!json.contains("attrs"));
+    }
+
+    // ── Economic edge variant round-trips ───────────────────────────────
+    // Each economic variant (Bid/Allocation/ContractEvaluation/Dispute/
+    // MetricClaim) must round-trip through JSON identically and emit the
+    // documented snake_case kind discriminator. The cryptographic binding
+    // to specific values (amounts, payments, metric numbers) happens via
+    // `content_hash_hex`, not via the kind payload — these tests only
+    // verify wire-format stability.
+
+    fn bid_child(p: &CallSpiffeId, market: &str) -> CallSpiffeId {
+        p.derive_artifact(format!("bid:{market}").as_bytes())
+            .unwrap()
+    }
+
+    #[test]
+    fn bid_edge_round_trips() {
+        let p = pod();
+        let edge = LineageEdge::from_parent(
+            bid_child(&p, "market-42"),
+            p,
+            EdgeKind::Bid {
+                market_id: "market-42".to_string(),
+            },
+        )
+        .with_content_hash("deadbeef".repeat(8));
+        let json = serde_json::to_string(&edge).unwrap();
+        assert!(json.contains("\"kind\":\"bid\""));
+        assert!(json.contains("\"market_id\":\"market-42\""));
+        let back: LineageEdge = serde_json::from_str(&json).unwrap();
+        assert_eq!(edge, back);
+    }
+
+    #[test]
+    fn allocation_edge_round_trips_with_mechanism() {
+        let p = pod();
+        let edge = LineageEdge::from_parent(
+            p.derive_artifact(b"allocation").unwrap(),
+            p,
+            EdgeKind::Allocation {
+                market_id: "market-42".to_string(),
+                mechanism: "vcg".to_string(),
+            },
+        )
+        .with_content_hash("c0ffee".repeat(10) + "1234");
+        let json = serde_json::to_string(&edge).unwrap();
+        assert!(json.contains("\"kind\":\"allocation\""));
+        assert!(json.contains("\"mechanism\":\"vcg\""));
+        let back: LineageEdge = serde_json::from_str(&json).unwrap();
+        assert_eq!(edge, back);
+    }
+
+    #[test]
+    fn contract_evaluation_edge_round_trips() {
+        let p = pod();
+        let edge = LineageEdge::from_parent(
+            p.derive_artifact(b"contract-step-7").unwrap(),
+            p,
+            EdgeKind::ContractEvaluation {
+                contract_id: "contract-abc".to_string(),
+                step: 7,
+            },
+        );
+        let json = serde_json::to_string(&edge).unwrap();
+        assert!(json.contains("\"kind\":\"contract_evaluation\""));
+        assert!(json.contains("\"step\":7"));
+        let back: LineageEdge = serde_json::from_str(&json).unwrap();
+        assert_eq!(edge, back);
+    }
+
+    #[test]
+    fn dispute_edge_round_trips_with_target_hash() {
+        let p = pod();
+        let target_hash = "a".repeat(64);
+        let edge = LineageEdge::from_parent(
+            p.derive_artifact(b"dispute-claim").unwrap(),
+            p,
+            EdgeKind::Dispute {
+                dispute_id: "dispute-1".to_string(),
+                target_edge_hash: target_hash.clone(),
+            },
+        );
+        let json = serde_json::to_string(&edge).unwrap();
+        assert!(json.contains("\"kind\":\"dispute\""));
+        assert!(json.contains(&target_hash));
+        let back: LineageEdge = serde_json::from_str(&json).unwrap();
+        assert_eq!(edge, back);
+    }
+
+    #[test]
+    fn metric_claim_edge_round_trips() {
+        let p = pod();
+        let edge = LineageEdge::from_parent(
+            p.derive_artifact(b"metric-window-2026-05").unwrap(),
+            p,
+            EdgeKind::MetricClaim {
+                metric_name: "producer_surplus".to_string(),
+                window_id: "2026-05".to_string(),
+            },
+        )
+        .with_content_hash("b".repeat(64));
+        let json = serde_json::to_string(&edge).unwrap();
+        assert!(json.contains("\"kind\":\"metric_claim\""));
+        assert!(json.contains("\"metric_name\":\"producer_surplus\""));
+        let back: LineageEdge = serde_json::from_str(&json).unwrap();
+        assert_eq!(edge, back);
+    }
+
+    // ── VerifierAttestation tests ──────────────────────────────────────
+
+    #[test]
+    fn verifier_attestation_round_trips() {
+        let va = VerifierAttestation::new()
+            .with_verifier_binary_hash("a".repeat(64))
+            .with_wasmtime_version("44.0.0+nan_canon")
+            .with_wasmtime_config_hash("b".repeat(64))
+            .with_vrf_params_hash("c".repeat(64))
+            .with_external_snapshot_root("d".repeat(64))
+            .with_lean_spec_hash("e".repeat(64));
+        assert!(!va.is_empty());
+        let json = serde_json::to_string(&va).unwrap();
+        let back: VerifierAttestation = serde_json::from_str(&json).unwrap();
+        assert_eq!(va, back);
+    }
+
+    #[test]
+    fn verifier_attestation_default_is_empty() {
+        let va = VerifierAttestation::default();
+        assert!(va.is_empty());
+        let json = serde_json::to_string(&va).unwrap();
+        // All fields skip-if-none → empty object
+        assert_eq!(json, "{}");
+    }
+
+    #[test]
+    fn edge_with_verifier_attestation_round_trips() {
+        let p = pod();
+        let va = VerifierAttestation::new()
+            .with_lean_spec_hash("f".repeat(64))
+            .with_verifier_binary_hash("9".repeat(64));
+        let edge = LineageEdge::from_parent(
+            p.derive_artifact(b"alloc").unwrap(),
+            p,
+            EdgeKind::Allocation {
+                market_id: "m1".into(),
+                mechanism: "vcg".into(),
+            },
+        )
+        .with_content_hash("0".repeat(64))
+        .with_verifier_attestation(va.clone());
+        let json = serde_json::to_string(&edge).unwrap();
+        assert!(json.contains("verifier_attestation"));
+        assert!(json.contains("lean_spec_hash"));
+        let back: LineageEdge = serde_json::from_str(&json).unwrap();
+        assert_eq!(edge, back);
+        assert_eq!(back.verifier_attestation, Some(va));
+    }
+
+    #[test]
+    fn edge_without_attestation_skips_field_in_json() {
+        let p = pod();
+        let edge = LineageEdge::pod_admit(p);
+        let json = serde_json::to_string(&edge).unwrap();
+        assert!(!json.contains("verifier_attestation"));
+    }
+
+    #[test]
+    fn canonical_bytes_differ_with_and_without_attestation() {
+        use crate::proof::canonical_edge_bytes;
+        let p = pod();
+        let edge_bare = LineageEdge::from_parent(
+            p.derive_artifact(b"x").unwrap(),
+            p.clone(),
+            EdgeKind::MetricClaim {
+                metric_name: "gini".into(),
+                window_id: "2026-05".into(),
+            },
+        )
+        .with_content_hash("0".repeat(64));
+
+        let va = VerifierAttestation::new().with_lean_spec_hash("a".repeat(64));
+        let edge_attested = edge_bare.clone().with_verifier_attestation(va);
+
+        let bytes_bare = canonical_edge_bytes(&edge_bare, None);
+        let bytes_attested = canonical_edge_bytes(&edge_attested, None);
+        assert_ne!(bytes_bare, bytes_attested);
+    }
+
+    #[test]
+    fn canonical_bytes_differ_per_attestation_field() {
+        use crate::proof::canonical_edge_bytes;
+        let p = pod();
+        let base = LineageEdge::from_parent(
+            p.derive_artifact(b"x").unwrap(),
+            p,
+            EdgeKind::Dispute {
+                dispute_id: "d1".into(),
+                target_edge_hash: "0".repeat(64),
+            },
+        );
+
+        let with_lean = base.clone().with_verifier_attestation(
+            VerifierAttestation::new().with_lean_spec_hash("a".repeat(64)),
+        );
+        let with_vrf = base.clone().with_verifier_attestation(
+            VerifierAttestation::new().with_vrf_params_hash("a".repeat(64)),
+        );
+        let with_both = base.clone().with_verifier_attestation(
+            VerifierAttestation::new()
+                .with_lean_spec_hash("a".repeat(64))
+                .with_vrf_params_hash("a".repeat(64)),
+        );
+
+        let b_lean = canonical_edge_bytes(&with_lean, None);
+        let b_vrf = canonical_edge_bytes(&with_vrf, None);
+        let b_both = canonical_edge_bytes(&with_both, None);
+
+        // Same hex value placed in different fields must produce different
+        // canonical bytes (field positions are binding).
+        assert_ne!(b_lean, b_vrf);
+        // Two fields populated differs from either one alone.
+        assert_ne!(b_lean, b_both);
+        assert_ne!(b_vrf, b_both);
+    }
+
+    #[test]
+    fn economic_kinds_have_distinct_canonical_tags() {
+        // Reach into proof::canonical_edge_bytes via the public re-export to
+        // confirm the discriminators wire up correctly. Each economic kind
+        // must produce a distinct byte sequence purely from the kind tag,
+        // even when child/parents/timestamp/content-hash are identical.
+        use crate::proof::canonical_edge_bytes;
+
+        let p = pod();
+        let child = p.derive_artifact(b"x").unwrap();
+        let ts = Utc::now();
+        let mk = |k: EdgeKind| LineageEdge {
+            child: child.clone(),
+            parents: vec![p.clone()],
+            kind: k,
+            content_hash_hex: None,
+            ts,
+            attrs: BTreeMap::new(),
+            proof: None,
+            verifier_attestation: None,
+        };
+
+        let bid = canonical_edge_bytes(
+            &mk(EdgeKind::Bid {
+                market_id: "m".into(),
+            }),
+            None,
+        );
+        let alloc = canonical_edge_bytes(
+            &mk(EdgeKind::Allocation {
+                market_id: "m".into(),
+                mechanism: "vcg".into(),
+            }),
+            None,
+        );
+        let ce = canonical_edge_bytes(
+            &mk(EdgeKind::ContractEvaluation {
+                contract_id: "c".into(),
+                step: 0,
+            }),
+            None,
+        );
+        let disp = canonical_edge_bytes(
+            &mk(EdgeKind::Dispute {
+                dispute_id: "d".into(),
+                target_edge_hash: "0".repeat(64),
+            }),
+            None,
+        );
+        let mc = canonical_edge_bytes(
+            &mk(EdgeKind::MetricClaim {
+                metric_name: "n".into(),
+                window_id: "w".into(),
+            }),
+            None,
+        );
+
+        // All five must differ from each other and from existing kinds.
+        let pod_admit = canonical_edge_bytes(&LineageEdge::pod_admit(p.clone()), None);
+        let tool_call = canonical_edge_bytes(
+            &mk(EdgeKind::ToolCall {
+                tool: "Bash".into(),
+            }),
+            None,
+        );
+
+        for (i, a) in [&bid, &alloc, &ce, &disp, &mc].iter().enumerate() {
+            for (j, b) in [&bid, &alloc, &ce, &disp, &mc].iter().enumerate() {
+                if i != j {
+                    assert_ne!(a, b, "economic kinds {i} and {j} share canonical bytes");
+                }
+            }
+            assert_ne!(*a, &tool_call, "economic kind {i} collides with tool_call");
+        }
+        // pod_admit has no parents, so it differs structurally anyway.
+        assert_ne!(bid, pod_admit);
+    }
+
+    // ── Pigouvian P4/P5/P6 variants ─────────────────────────────────────
+
+    #[test]
+    fn externality_edge_round_trips_json() {
+        let p = pod();
+        let child = p.derive_artifact(b"co2-claim-1").unwrap();
+        let edge = LineageEdge::from_parent(
+            child,
+            p,
+            EdgeKind::Externality {
+                resource: "co2_g".to_string(),
+                oracle_kid: "co2-oracle-key-1".to_string(),
+            },
+        )
+        .with_content_hash("a".repeat(64))
+        .with_attr("units_micro", "1500000");
+        let json = serde_json::to_string(&edge).unwrap();
+        let back: LineageEdge = serde_json::from_str(&json).unwrap();
+        assert_eq!(edge, back);
+        // Externally tagged: kind:"externality" appears verbatim.
+        assert!(
+            json.contains(r#""kind":"externality""#),
+            "expected externally-tagged Externality, got {json}"
+        );
+    }
+
+    #[test]
+    fn pigouvian_rate_update_edge_round_trips_json() {
+        let p = pod();
+        let child = p.derive_artifact(b"rate-update-window-42").unwrap();
+        let edge = LineageEdge::from_parent(
+            child,
+            p,
+            EdgeKind::PigouvianRateUpdate {
+                resource: "gpu_s".to_string(),
+                rate_micro_usd_per_unit: 5,
+                window_unix_micros: 1_700_000_000_000_000,
+            },
+        );
+        let json = serde_json::to_string(&edge).unwrap();
+        let back: LineageEdge = serde_json::from_str(&json).unwrap();
+        assert_eq!(edge, back);
+        assert!(json.contains(r#""kind":"pigouvian_rate_update""#));
+    }
+
+    #[test]
+    fn welfare_rebate_edge_round_trips_json() {
+        let p = pod();
+        let child = p.derive_artifact(b"rebate-tx-1").unwrap();
+        let edge = LineageEdge::from_parent(
+            child,
+            p,
+            EdgeKind::WelfareRebate {
+                recipient_kid: "witness-peer-1".to_string(),
+                micro_usd: 1_250_000,
+                source_externality_edge_hash: "f".repeat(64),
+            },
+        );
+        let json = serde_json::to_string(&edge).unwrap();
+        let back: LineageEdge = serde_json::from_str(&json).unwrap();
+        assert_eq!(edge, back);
+        assert!(json.contains(r#""kind":"welfare_rebate""#));
+    }
+
+    #[test]
+    fn pigouvian_variants_have_distinct_kind_tags() {
+        // kind_tag distinguishes the variants in canonical signing
+        // bytes — a collision would let a hostile producer swap an
+        // Externality claim for a WelfareRebate of the same shape.
+        use crate::proof::canonical_edge_bytes;
+        let p = pod();
+        let ext = LineageEdge::from_parent(
+            p.derive_artifact(b"ext").unwrap(),
+            p.clone(),
+            EdgeKind::Externality {
+                resource: "gpu_s".to_string(),
+                oracle_kid: "k1".to_string(),
+            },
+        );
+        let rate = LineageEdge::from_parent(
+            p.derive_artifact(b"rate").unwrap(),
+            p.clone(),
+            EdgeKind::PigouvianRateUpdate {
+                resource: "gpu_s".to_string(),
+                rate_micro_usd_per_unit: 5,
+                window_unix_micros: 1_700_000_000_000_000,
+            },
+        );
+        let rebate = LineageEdge::from_parent(
+            p.derive_artifact(b"rebate").unwrap(),
+            p,
+            EdgeKind::WelfareRebate {
+                recipient_kid: "w1".to_string(),
+                micro_usd: 100,
+                source_externality_edge_hash: "0".repeat(64),
+            },
+        );
+        let bytes_ext = canonical_edge_bytes(&ext, None);
+        let bytes_rate = canonical_edge_bytes(&rate, None);
+        let bytes_rebate = canonical_edge_bytes(&rebate, None);
+        assert_ne!(bytes_ext, bytes_rate);
+        assert_ne!(bytes_ext, bytes_rebate);
+        assert_ne!(bytes_rate, bytes_rebate);
     }
 }

--- a/crates/nucleus-lineage/src/lib.rs
+++ b/crates/nucleus-lineage/src/lib.rs
@@ -59,7 +59,7 @@ pub use checkpoint::{
 #[cfg(feature = "http")]
 pub use cosign::{C2spHttpWitnessClient, HttpWitnessClient};
 pub use cosign::{Cosignature, CosignatureKind, InProcessWitness, WitnessClient};
-pub use edge::{EdgeKind, LineageEdge, SourceClass};
+pub use edge::{EdgeKind, LineageEdge, SourceClass, VerifierAttestation};
 pub use id::{CallSpiffeId, IdError, MAX_URI_LEN};
 pub use issuer::{EdgeSigner, IdentityFetcher, IssuerError, SvidClaims};
 pub use merkle::{read_checkpoints, verify_log, MerkleConfig, MerkleError, MerkleSink};
@@ -71,8 +71,13 @@ pub use signed_note::{
     parse_signature_line, validate_key_name, validate_origin, ParsedSignatureLine, SignedNoteError,
     MAX_KEY_NAME_LEN, MAX_ORIGIN_LEN, SIG_LINE_PREFIX, SIG_TYPE_COSIGNATURE, SIG_TYPE_ED25519,
 };
-pub use sink::{InMemorySink, JsonlSink, LineageSink, SinkError};
-pub use verify::{verify_chain, verify_proof, Jwk, Jwks, StaticKeyResolver, VerifyError};
+#[cfg(feature = "sink-io")]
+pub use sink::JsonlSink;
+pub use sink::{InMemorySink, LineageSink, SinkError};
+pub use verify::{
+    total_pigouvian_micro_usd, verify_chain, verify_proof, Jwk, Jwks, StaticKeyResolver,
+    VerifyError,
+};
 
 #[cfg(feature = "insecure-local-issuer")]
 pub use local_issuer::LocalIssuer;

--- a/crates/nucleus-lineage/src/proof.rs
+++ b/crates/nucleus-lineage/src/proof.rs
@@ -21,6 +21,22 @@
 //! 4. content hash (32 zero bytes if absent)
 //! 5. RFC3339 timestamp string, NUL-separated
 //! 6. previous edge's content hash from the proof chain (32 zero bytes if absent)
+//! 7. verifier-attestation block, **emitted only when
+//!    `edge.verifier_attestation` is `Some`**: a single NUL delimiter
+//!    followed by 6 NUL-terminated fields in this order —
+//!    `verifier_binary_hash`, `wasmtime_version`, `wasmtime_config_hash`,
+//!    `vrf_params_hash`, `external_snapshot_root`, `lean_spec_hash`. Absent
+//!    sub-fields emit the empty string (just their NUL terminator).
+//!
+//! **Additive-compatibility invariant.** When `verifier_attestation` is
+//! `None` (every pre-existing edge kind: `PodAdmit` / `ToolCall` /
+//! `LlmCall` / `ArtifactProduced` / `Merge` / `DocumentRetrieved` /
+//! `Other`), step 7 contributes NOTHING — the canonical bytes are
+//! byte-identical to the pre-attestation encoding. This is a deliberate
+//! divergence from the platform fork (which always appends a 7-byte VA
+//! footer): emitting the footer unconditionally would change the signed
+//! bytes of every legacy edge. Gating on `Some` keeps the merge purely
+//! additive while still binding the attestation when it is present.
 //!
 //! Field-bag attributes (`attrs`) are intentionally NOT covered — they are
 //! free-form metadata; the signed surface is the structural lineage edge.
@@ -111,6 +127,32 @@ pub fn canonical_edge_bytes(edge: &LineageEdge, prev_hash: Option<&[u8; 32]>) ->
         out.extend_from_slice(&[0u8; 32]);
     }
 
+    // Verifier-attestation block (added 2026-06). PURELY ADDITIVE: emitted
+    // ONLY when `verifier_attestation` is `Some`. Edges without an
+    // attestation (every pre-existing kind) produce byte-identical
+    // canonical bytes to the pre-attestation encoding — see the module-doc
+    // additive-compat invariant. When present: a single NUL delimiter then
+    // 6 NUL-terminated fields; absent sub-fields emit empty bytes.
+    //
+    // NOTE: this diverges from the platform fork, which appends the 7-byte
+    // footer unconditionally. Adopting that verbatim would change the
+    // signed bytes of legacy edges, breaking the additive invariant.
+    if let Some(va) = edge.verifier_attestation.as_ref() {
+        out.push(0);
+        let push_opt = |out: &mut Vec<u8>, s: Option<&str>| {
+            if let Some(v) = s {
+                out.extend_from_slice(v.as_bytes());
+            }
+            out.push(0);
+        };
+        push_opt(&mut out, va.verifier_binary_hash.as_deref());
+        push_opt(&mut out, va.wasmtime_version.as_deref());
+        push_opt(&mut out, va.wasmtime_config_hash.as_deref());
+        push_opt(&mut out, va.vrf_params_hash.as_deref());
+        push_opt(&mut out, va.external_snapshot_root.as_deref());
+        push_opt(&mut out, va.lean_spec_hash.as_deref());
+    }
+
     out
 }
 
@@ -133,6 +175,15 @@ fn kind_tag(kind: &EdgeKind) -> &'static str {
         EdgeKind::ArtifactProduced => "artifact_produced",
         EdgeKind::Merge => "merge",
         EdgeKind::DocumentRetrieved { .. } => "document_retrieved",
+        EdgeKind::Bid { .. } => "bid",
+        EdgeKind::Allocation { .. } => "allocation",
+        EdgeKind::ContractEvaluation { .. } => "contract_evaluation",
+        EdgeKind::Dispute { .. } => "dispute",
+        EdgeKind::MetricClaim { .. } => "metric_claim",
+        EdgeKind::Settlement { .. } => "settlement",
+        EdgeKind::Externality { .. } => "externality",
+        EdgeKind::PigouvianRateUpdate { .. } => "pigouvian_rate_update",
+        EdgeKind::WelfareRebate { .. } => "welfare_rebate",
         EdgeKind::Other { .. } => "other",
     }
 }
@@ -186,7 +237,7 @@ mod opt_hash_hex {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::edge::{EdgeKind, LineageEdge};
+    use crate::edge::{EdgeKind, LineageEdge, VerifierAttestation};
     use crate::id::CallSpiffeId;
 
     fn pod() -> CallSpiffeId {
@@ -306,5 +357,126 @@ mod tests {
         assert!(bytes
             .windows(7)
             .any(|w| w == b"agents/" || w == b"sa/code" || w.starts_with(b"spiffe:")));
+    }
+
+    // ── Additive-compatibility invariant ────────────────────────────────
+
+    /// **LOAD-BEARING.** The verifier-attestation merge is PURELY ADDITIVE:
+    /// an edge with `verifier_attestation: None` (every pre-existing kind:
+    /// PodAdmit/ToolCall/LlmCall/ArtifactProduced/Merge/DocumentRetrieved/
+    /// Other) MUST produce canonical bytes that END exactly at the 32-byte
+    /// prev_hash slot — i.e. byte-identical to the pre-attestation encoding.
+    ///
+    /// This is verified structurally: a VA=None edge's bytes have NO footer.
+    /// The bytes are reconstructed independently from the documented field
+    /// order (child, kind, parents, marker, content-hash, ts, prev_hash) and
+    /// compared for full equality. If a future change appends a footer to
+    /// VA=None edges, this test fails — that is the regression guard.
+    #[test]
+    fn va_none_edge_has_no_footer_and_matches_legacy_encoding() {
+        use chrono::TimeZone;
+        let p = pod();
+        let mut edge = LineageEdge::pod_admit(p);
+        edge.ts = chrono::Utc.timestamp_opt(1_700_000_000, 0).unwrap();
+        assert!(edge.verifier_attestation.is_none());
+
+        let bytes = canonical_edge_bytes(&edge, None);
+
+        // Recompute the legacy (pre-attestation) encoding by hand and assert
+        // full byte-equality. This pins the exact signed surface for every
+        // pre-existing edge kind.
+        let mut expected: Vec<u8> = Vec::new();
+        // child
+        expected.extend_from_slice(edge.child.as_str().as_bytes());
+        expected.push(0);
+        // kind tag (pod_admit)
+        expected.extend_from_slice(b"pod_admit");
+        expected.push(0);
+        // parents: none → just the empty marker NUL
+        expected.push(0);
+        // content hash: absent → 64 zero ASCII bytes, then NUL
+        expected.extend_from_slice(&[0u8; 64]);
+        expected.push(0);
+        // ts
+        expected.extend_from_slice(edge.ts.to_rfc3339().as_bytes());
+        expected.push(0);
+        // prev_hash: none → 32 zero bytes
+        expected.extend_from_slice(&[0u8; 32]);
+        // NO footer for VA=None.
+
+        assert_eq!(
+            bytes, expected,
+            "VA=None edge must produce byte-identical legacy canonical bytes \
+             (no attestation footer) — the additive-compat invariant"
+        );
+        // And the last 32 bytes are exactly the prev_hash slot (no trailing
+        // footer bytes after it).
+        let len = bytes.len();
+        assert_eq!(&bytes[len - 32..], &[0u8; 32]);
+    }
+
+    /// Toggling `verifier_attestation` from `None` to `Some(empty)` MUST
+    /// change the canonical bytes under the gated encoding (an empty-but-
+    /// present attestation adds the 7-byte footer). This is the deliberate
+    /// divergence from the platform fork's `empty_va_field_equivalent_to_none`
+    /// invariant: in the additive design, presence of the attestation object
+    /// is itself binding.
+    #[test]
+    fn va_some_empty_adds_seven_byte_footer() {
+        use chrono::TimeZone;
+        let p = pod();
+        let mut e_none = LineageEdge::pod_admit(p.clone());
+        e_none.ts = chrono::Utc.timestamp_opt(1_700_000_000, 0).unwrap();
+
+        let e_empty = e_none
+            .clone()
+            .with_verifier_attestation(VerifierAttestation::new());
+
+        let bytes_none = canonical_edge_bytes(&e_none, None);
+        let bytes_empty = canonical_edge_bytes(&e_empty, None);
+
+        assert_ne!(bytes_none, bytes_empty);
+        // Footer = 1 delimiter NUL + 6 empty fields × 1 NUL each = 7 bytes.
+        assert_eq!(bytes_empty.len(), bytes_none.len() + 7);
+        assert_eq!(&bytes_empty[bytes_empty.len() - 7..], &[0u8; 7]);
+        // The prefix (everything before the footer) is byte-identical to the
+        // VA=None encoding — additivity at the byte level.
+        assert_eq!(&bytes_empty[..bytes_none.len()], &bytes_none[..]);
+    }
+
+    /// A populated `VerifierAttestation` binds each field positionally: the
+    /// same hex value in different fields yields different canonical bytes,
+    /// and a populated attestation extends (never rewrites) the VA=None
+    /// prefix.
+    #[test]
+    fn va_some_populated_binds_fields_positionally() {
+        let p = pod();
+        let base = LineageEdge::from_parent(
+            p.derive_artifact(b"x").unwrap(),
+            p,
+            EdgeKind::MetricClaim {
+                metric_name: "gini".into(),
+                window_id: "2026-05".into(),
+            },
+        )
+        .with_content_hash("0".repeat(64));
+
+        let none_bytes = canonical_edge_bytes(&base, None);
+
+        let with_lean = base.clone().with_verifier_attestation(
+            VerifierAttestation::new().with_lean_spec_hash("a".repeat(64)),
+        );
+        let with_vrf = base.clone().with_verifier_attestation(
+            VerifierAttestation::new().with_vrf_params_hash("a".repeat(64)),
+        );
+
+        let b_lean = canonical_edge_bytes(&with_lean, None);
+        let b_vrf = canonical_edge_bytes(&with_vrf, None);
+
+        // Same value, different field → different bytes (positional binding).
+        assert_ne!(b_lean, b_vrf);
+        // Both extend the VA=None prefix verbatim.
+        assert_eq!(&b_lean[..none_bytes.len()], &none_bytes[..]);
+        assert_eq!(&b_vrf[..none_bytes.len()], &none_bytes[..]);
     }
 }

--- a/crates/nucleus-lineage/src/sink.rs
+++ b/crates/nucleus-lineage/src/sink.rs
@@ -4,9 +4,19 @@
 //! local lookup, and a [`JsonlSink`] that appends to a file (one JSON object
 //! per line, no rewrites). Larger deployments will plug in a remote sink
 //! (S3, Tigris, etc.) — the trait is the integration point.
+//!
+//! **Wasm-compatibility note (Nucleus P0 nucleus-wasm)**: `JsonlSink` uses
+//! `std::fs::{File, OpenOptions}` which is unavailable on
+//! `wasm32-unknown-unknown`. It's gated behind the default-on `sink-io`
+//! feature. Build nucleus-lineage with `default-features = false` for wasm
+//! targets; `InMemorySink` + the `LineageSink` trait + `SinkError` remain
+//! available unconditionally.
 
+#[cfg(feature = "sink-io")]
 use std::fs::{File, OpenOptions};
+#[cfg(feature = "sink-io")]
 use std::io::{BufRead, BufReader, BufWriter, Write};
+#[cfg(feature = "sink-io")]
 use std::path::PathBuf;
 use std::sync::{Mutex, RwLock};
 
@@ -18,6 +28,10 @@ use crate::id::CallSpiffeId;
 /// Errors a sink may surface.
 #[derive(Debug, Error)]
 pub enum SinkError {
+    /// `std::io::Error` only reachable when the `sink-io` feature is on
+    /// (i.e. native targets that include the file-backed `JsonlSink`).
+    /// On wasm32 the variant is unconstructable.
+    #[cfg(feature = "sink-io")]
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
     #[error("json error: {0}")]
@@ -87,18 +101,21 @@ impl LineageSink for InMemorySink {
 }
 
 // ────────────────────────────────────────────────────────────────────────
-// JsonlSink
+// JsonlSink — `std::fs`-bound, gated behind the `sink-io` feature so the
+// crate compiles to `wasm32-unknown-unknown` with `default-features = false`.
 
 /// Append-only sink writing one JSON object per line to a file.
 ///
 /// Open with `JsonlSink::open(path)`; the file is created if missing.
 /// Writes are serialized by an internal mutex; reads (`iter`) re-open the
 /// file fresh so they always see the latest contents.
+#[cfg(feature = "sink-io")]
 pub struct JsonlSink {
     path: PathBuf,
     writer: Mutex<BufWriter<File>>,
 }
 
+#[cfg(feature = "sink-io")]
 impl JsonlSink {
     pub fn open(path: impl Into<PathBuf>) -> Result<Self, SinkError> {
         let path = path.into();
@@ -114,6 +131,7 @@ impl JsonlSink {
     }
 }
 
+#[cfg(feature = "sink-io")]
 impl LineageSink for JsonlSink {
     fn emit(&self, edge: LineageEdge) -> Result<(), SinkError> {
         let line = serde_json::to_string(&edge)?;
@@ -197,6 +215,7 @@ mod tests {
         assert_eq!(sink.len().unwrap(), 32);
     }
 
+    #[cfg(feature = "sink-io")]
     #[test]
     fn jsonl_sink_appends_and_reads_back() {
         let dir = tempfile::tempdir().unwrap();
@@ -217,6 +236,7 @@ mod tests {
         assert_eq!(read_back[1].child, derived);
     }
 
+    #[cfg(feature = "sink-io")]
     #[test]
     fn jsonl_sink_re_open_sees_prior_writes() {
         let dir = tempfile::tempdir().unwrap();
@@ -232,6 +252,7 @@ mod tests {
         assert_eq!(edges[0].child, p);
     }
 
+    #[cfg(feature = "sink-io")]
     #[test]
     fn jsonl_sink_skips_blank_lines() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/nucleus-lineage/src/verify.rs
+++ b/crates/nucleus-lineage/src/verify.rs
@@ -304,6 +304,108 @@ impl Default for StaticKeyResolver {
     }
 }
 
+/// **Pigouvian W2 — total Pigouvian micro-USD aggregator.**
+///
+/// Walks a chain of signed lineage edges and sums every
+/// `EdgeKind::WelfareRebate.micro_usd` value (negative — disbursement
+/// outflow) and every `EdgeKind::Externality` attr
+/// `pigou_charge_micro_usd` (positive — tax inflow). The net is what
+/// the substrate's externality layer charged minus what it rebated;
+/// `0` for a chain with no Pigouvian activity.
+///
+/// Verifier SDKs (browser, CLI, agent) call this AFTER `verify_chain`
+/// returns `Ok(())` so the sum is over CRYPTOGRAPHICALLY-VERIFIED
+/// edges only.
+pub fn total_pigouvian_micro_usd(edges: &[crate::LineageEdge]) -> i128 {
+    let mut net: i128 = 0;
+    for edge in edges {
+        match &edge.kind {
+            crate::EdgeKind::Externality { .. } => {
+                if let Some(s) = edge.attrs.get("pigou_charge_micro_usd") {
+                    if let Ok(v) = s.parse::<u64>() {
+                        net = net.saturating_add(i128::from(v));
+                    }
+                }
+            }
+            crate::EdgeKind::WelfareRebate { micro_usd, .. } => {
+                net = net.saturating_sub(i128::from(*micro_usd));
+            }
+            _ => {}
+        }
+    }
+    net
+}
+
+/// Tests for surface that does NOT depend on the demo signer — these run
+/// under default features (the `tests` module below is gated behind
+/// `insecure-local-issuer` because it needs `LocalIssuer`).
+#[cfg(test)]
+mod pigouvian_tests {
+    use crate::edge::{EdgeKind, LineageEdge};
+    use crate::id::CallSpiffeId;
+
+    fn pod() -> CallSpiffeId {
+        CallSpiffeId::pod("prod.example.com", "agents", "coder").unwrap()
+    }
+
+    /// **W2 — total_pigouvian_micro_usd aggregator.**
+    /// Walks a chain with 1 Externality charge (750) and 2
+    /// WelfareRebates (300 + 250). Net = +750 - 300 - 250 = +200.
+    #[test]
+    fn total_pigouvian_micro_usd_sums_charges_minus_rebates() {
+        let p = pod();
+        let ext = LineageEdge::from_parent(
+            p.derive_artifact(b"ext").unwrap(),
+            p.clone(),
+            EdgeKind::Externality {
+                resource: "gpu_s".to_string(),
+                oracle_kid: "k1".to_string(),
+            },
+        )
+        .with_attr("pigou_charge_micro_usd", "750");
+        let rebate1 = LineageEdge::from_parent(
+            p.derive_artifact(b"r1").unwrap(),
+            p.clone(),
+            EdgeKind::WelfareRebate {
+                recipient_kid: "w1".to_string(),
+                micro_usd: 300,
+                source_externality_edge_hash: "f".repeat(64),
+            },
+        );
+        let rebate2 = LineageEdge::from_parent(
+            p.derive_artifact(b"r2").unwrap(),
+            p,
+            EdgeKind::WelfareRebate {
+                recipient_kid: "w2".to_string(),
+                micro_usd: 250,
+                source_externality_edge_hash: "f".repeat(64),
+            },
+        );
+        assert_eq!(
+            super::total_pigouvian_micro_usd(&[ext, rebate1, rebate2]),
+            200
+        );
+    }
+
+    #[test]
+    fn total_pigouvian_micro_usd_zero_on_empty_chain() {
+        assert_eq!(super::total_pigouvian_micro_usd(&[]), 0);
+    }
+
+    #[test]
+    fn total_pigouvian_micro_usd_ignores_unrelated_edges() {
+        let p = pod();
+        let edge = LineageEdge::from_parent(
+            p.derive_artifact(b"x").unwrap(),
+            p,
+            EdgeKind::ToolCall {
+                tool: "Bash".to_string(),
+            },
+        );
+        assert_eq!(super::total_pigouvian_micro_usd(&[edge]), 0);
+    }
+}
+
 #[cfg(test)]
 #[cfg(feature = "insecure-local-issuer")]
 mod tests {


### PR DESCRIPTION
**Consolidation keystone (step 1 of the roll-forward).** Per the Vision-2 decision (#1803), the economic + regenerative lineage vocabulary becomes **canonical-public** instead of a platform fork — unblocking the whole chain (externality → econ-kernels → platform consumes published → forks die).

Merges the platform fork's economic surface into public `nucleus-lineage`, **purely additively**:
- 9 economic `EdgeKind` variants: `Bid`, `Allocation`, `ContractEvaluation`, `Dispute`, `MetricClaim`, `Settlement`, `Externality`, `PigouvianRateUpdate`, `WelfareRebate`.
- `VerifierAttestation` (+ builders + the `verifier_attestation` field on `LineageEdge`) and its re-export.
- `total_pigouvian_micro_usd` aggregator (dependency-free — String attrs + `i128`; **no** `nucleus-externality` dep, so no circular dependency).
- `sink-io` feature gating `JsonlSink`'s `std::fs`.
- Keeps everything public already had (`DocumentRetrieved` + `SourceClass`, the transparency-log stack).

### Recompute back-compat preserved (the load-bearing invariant)
The fork appended the VA footer to canonical bytes **unconditionally** — which would have changed the signing bytes of *every* pre-existing edge. This PR **deviates deliberately**: the footer is gated on `Some(..)`, so an edge with `verifier_attestation: None` (every existing kind) produces **byte-identical** canonical bytes to before. Proven by `va_none_edge_has_no_footer_and_matches_legacy_encoding` (reconstructs the legacy byte sequence and asserts full equality), plus positional-binding tests for the `Some` case.

> Migration note: the platform's older fork-signed edges used the unconditional-footer encoding, so VA=None edges signed by the *fork* won't recompute against this canonical encoding. Acceptable — the platform re-signs under the canonical crate when it adopts published lineage (pre-prod; no durable critical edges depend on the fork encoding).

### Tests
`cargo test -p nucleus-lineage --all-features` → 154 passed; default → 135; clippy `-D warnings` clean; fmt clean. Downstream exhaustive-match arms in `nucleus-cli`/`nucleus-envelope` updated for the new variants + field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)