### PR TITLE
feat(externality): cube + rebate modules in canonical public crate (Vision 2, step 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6623,6 +6623,7 @@ dependencies = [
  "ed25519-dalek 3.0.0-pre.7",
  "hex",
  "nucleus-econ-kernels",
+ "nucleus-lineage",
  "proptest",
  "serde",
  "serde_json",

--- a/crates/nucleus-cli/src/lineage.rs
+++ b/crates/nucleus-cli/src/lineage.rs
@@ -442,6 +442,38 @@ fn format_kind(edge: &LineageEdge) -> String {
             source_class,
             ..
         } => format!("[doc/{:?}/{}]", source_class, source_url),
+        nucleus_lineage::EdgeKind::Bid { market_id } => format!("[bid/{}]", market_id),
+        nucleus_lineage::EdgeKind::Allocation {
+            market_id,
+            mechanism,
+        } => format!("[alloc/{}/{}]", mechanism, market_id),
+        nucleus_lineage::EdgeKind::ContractEvaluation { contract_id, step } => {
+            format!("[contract/{}#{}]", contract_id, step)
+        }
+        nucleus_lineage::EdgeKind::Dispute { dispute_id, .. } => {
+            format!("[dispute/{}]", dispute_id)
+        }
+        nucleus_lineage::EdgeKind::MetricClaim {
+            metric_name,
+            window_id,
+        } => format!("[metric/{}/{}]", metric_name, window_id),
+        nucleus_lineage::EdgeKind::Settlement { tx_ref, rail } => {
+            format!("[settle/{}/{}]", rail, tx_ref)
+        }
+        nucleus_lineage::EdgeKind::Externality {
+            resource,
+            oracle_kid,
+        } => format!("[externality/{}/{}]", resource, oracle_kid),
+        nucleus_lineage::EdgeKind::PigouvianRateUpdate {
+            resource,
+            rate_micro_usd_per_unit,
+            ..
+        } => format!("[pigou_rate/{}/{}µ]", resource, rate_micro_usd_per_unit),
+        nucleus_lineage::EdgeKind::WelfareRebate {
+            recipient_kid,
+            micro_usd,
+            ..
+        } => format!("[rebate/{}/{}µ]", recipient_kid, micro_usd),
         nucleus_lineage::EdgeKind::Other { name } => format!("[{}]", name),
     }
 }
@@ -559,6 +591,7 @@ mod tests {
             ts: chrono::Utc::now(),
             attrs: Default::default(),
             proof: None,
+            verifier_attestation: None,
         };
         let edges = vec![LineageEdge::pod_admit(victim_pod), forged];
         let g = LineageGraph::build(&edges);
@@ -630,6 +663,7 @@ mod tests {
             ts: chrono::Utc::now(),
             attrs: Default::default(),
             proof: None,
+            verifier_attestation: None,
         };
         assert!(!is_structurally_consistent(&edge));
     }
@@ -647,6 +681,7 @@ mod tests {
             ts: chrono::Utc::now(),
             attrs: Default::default(),
             proof: None,
+            verifier_attestation: None,
         };
         assert!(!is_structurally_consistent(&edge_bad));
     }
@@ -667,6 +702,7 @@ mod tests {
             ts: chrono::Utc::now(),
             attrs: Default::default(),
             proof: None,
+            verifier_attestation: None,
         };
         assert!(is_structurally_consistent(&ok));
 
@@ -680,6 +716,7 @@ mod tests {
             ts: chrono::Utc::now(),
             attrs: Default::default(),
             proof: None,
+            verifier_attestation: None,
         };
         assert!(!is_structurally_consistent(&bad));
     }
@@ -698,6 +735,7 @@ mod tests {
             ts: chrono::Utc::now(),
             attrs: Default::default(),
             proof: None,
+            verifier_attestation: None,
         };
         let edges = vec![
             LineageEdge::pod_admit(p.clone()),
@@ -744,6 +782,7 @@ mod tests {
                 ts: chrono::Utc::now(),
                 attrs: Default::default(),
                 proof: None,
+                verifier_attestation: None,
             },
             LineageEdge {
                 child: y.clone(),
@@ -753,6 +792,7 @@ mod tests {
                 ts: chrono::Utc::now(),
                 attrs: Default::default(),
                 proof: None,
+                verifier_attestation: None,
             },
         ];
         let g = LineageGraph::build(&edges);

--- a/crates/nucleus-envelope/src/verify.rs
+++ b/crates/nucleus-envelope/src/verify.rs
@@ -1259,6 +1259,7 @@ mod tests {
             ts: chrono::Utc::now(),
             attrs: Default::default(),
             proof: None,
+            verifier_attestation: None,
         };
         sink.emit(bad_merge).unwrap();
 

--- a/crates/nucleus-externality/Cargo.toml
+++ b/crates/nucleus-externality/Cargo.toml
@@ -12,7 +12,10 @@ description = "Coproduct Pigouvian externality layer: signed externality envelop
 workspace = true
 
 [dependencies]
-nucleus-lineage = { path = "../nucleus-lineage" }
+# default-features = false: the wasm-pure-crates gate builds this crate for
+# wasm32, and lineage's default sink-io (std::fs) + uuid-without-js only
+# compile natively — exactly the consumption mode lineage's own docs call for.
+nucleus-lineage = { path = "../nucleus-lineage", default-features = false }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/nucleus-externality/Cargo.toml
+++ b/crates/nucleus-externality/Cargo.toml
@@ -12,6 +12,7 @@ description = "Coproduct Pigouvian externality layer: signed externality envelop
 workspace = true
 
 [dependencies]
+nucleus-lineage = { path = "../nucleus-lineage" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/nucleus-externality/src/cube.rs
+++ b/crates/nucleus-externality/src/cube.rs
@@ -1,0 +1,554 @@
+//! `ExternalityCube` — OLAP-style rollup over signed externality
+//! claims.
+//!
+//! **Pigouvian Q1-Q4.** The cube is the substrate's "marginal rate"
+//! oracle: it ingests every `EdgeKind::Externality` edge into
+//! `(ResourceDim, WindowId)` buckets and surfaces the slice-derivative
+//! that the Pigouvian rate-setter uses to update `λ_k`.
+//!
+//! Borrows the tomato sibling repo's `Aggregate.fs` pattern: nested
+//! map `windowKey -> dimensionKey -> accumulated values`, tumbling
+//! (non-overlapping) windows of size `window_micros`. State is in-
+//! memory + append-only per window — eviction past
+//! `retention_windows` keeps the cube bounded.
+//!
+//! ## Slice semantics
+//!
+//! ```text
+//! cube.slice(GpuSeconds, w)         — sum / count / mean for this bucket
+//! cube.marginal_rate(GpuSeconds, w) — finite-difference slope vs prior window
+//! ```
+//!
+//! Marginal-rate computation matches the Pigouvian principle: the
+//! rate `λ_k` for resource `k` in window `w` is the discrete slope of
+//! (welfare loss imposed) vs (consumption units), proxied here by
+//! `(Δ consumption) / (Δ time)` — a first-order Pigouvian rate-setter.
+//! Higher-order rate-setters (using cube-slice derivatives over
+//! multiple windows) are a follow-on.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::dim::ResourceDim;
+
+/// Errors from cube operations.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum PullbackError {
+    /// Pull-back requires matching `window_micros`. Federations
+    /// using different window sizes need to re-bucket first.
+    #[error("window_micros mismatch: lhs={lhs}, rhs={rhs}")]
+    WindowMicrosMismatch { lhs: u64, rhs: u64 },
+}
+
+/// Tumbling-window identifier — units of `window_micros` since
+/// unix epoch. `WindowId(0)` is the first window after epoch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct WindowId(pub u64);
+
+impl WindowId {
+    /// Compute the window id containing a given timestamp.
+    pub fn from_unix_micros(ts_unix_micros: u64, window_micros: u64) -> Self {
+        WindowId(ts_unix_micros / window_micros.max(1))
+    }
+
+    /// The starting timestamp (inclusive) of this window.
+    pub fn start_unix_micros(self, window_micros: u64) -> u64 {
+        self.0.saturating_mul(window_micros.max(1))
+    }
+}
+
+/// Aggregated bucket for one `(ResourceDim, WindowId)` cell.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AggregateBucket {
+    /// Sum of `units_micro` over all claims in this bucket. `u128`
+    /// so a 32-bit-overflow doesn't wreck the rollup.
+    pub total_units_micro: u128,
+    /// Count of claims that landed in this bucket.
+    pub count: u64,
+}
+
+impl AggregateBucket {
+    /// Mean units per claim in this bucket, integer (saturating to
+    /// `u64`). Returns 0 if no claims.
+    pub fn mean_units_micro(&self) -> u64 {
+        if self.count == 0 {
+            return 0;
+        }
+        let m = self.total_units_micro / u128::from(self.count);
+        u64::try_from(m).unwrap_or(u64::MAX)
+    }
+}
+
+/// The cube itself — OLAP rollup over signed externality claims.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExternalityCube {
+    /// Window size in micros. 1_000_000 = 1 s; 60_000_000 = 1 min;
+    /// 3_600_000_000 = 1 h.
+    pub window_micros: u64,
+    /// Keep this many trailing windows. Older buckets evict on
+    /// `ingest_at`. Set to `u64::MAX` for unbounded retention.
+    pub retention_windows: u64,
+    /// `(ResourceDim, WindowId) -> AggregateBucket`. BTreeMap keeps
+    /// iteration order deterministic.
+    buckets: BTreeMap<(ResourceDim, WindowId), AggregateBucket>,
+    /// Most recent window observed; used for retention eviction.
+    latest_window: Option<WindowId>,
+}
+
+impl ExternalityCube {
+    /// Construct a cube with the given window size + retention.
+    pub fn new(window_micros: u64, retention_windows: u64) -> Self {
+        Self {
+            window_micros: window_micros.max(1),
+            retention_windows,
+            buckets: BTreeMap::new(),
+            latest_window: None,
+        }
+    }
+
+    /// Number of `(dim, window)` cells currently in the cube.
+    pub fn cell_count(&self) -> usize {
+        self.buckets.len()
+    }
+
+    /// Ingest a raw `(dim, units_micro, ts_unix_micros)` triple. Used
+    /// when the caller has already extracted the claim from the
+    /// signed envelope. The Q2 wrapper `ingest_edge` walks an
+    /// `EdgeKind::Externality` edge into this.
+    pub fn ingest_at(&mut self, dim: ResourceDim, units_micro: u64, ts_unix_micros: u64) {
+        let w = WindowId::from_unix_micros(ts_unix_micros, self.window_micros);
+        let entry = self.buckets.entry((dim, w)).or_default();
+        entry.total_units_micro = entry
+            .total_units_micro
+            .saturating_add(u128::from(units_micro));
+        entry.count = entry.count.saturating_add(1);
+        self.latest_window = Some(match self.latest_window {
+            Some(prev) => prev.max(w),
+            None => w,
+        });
+        self.evict_stale();
+    }
+
+    /// Bucket for one `(dim, window)` cell, if present.
+    pub fn slice(&self, dim: ResourceDim, window: WindowId) -> Option<&AggregateBucket> {
+        self.buckets.get(&(dim, window))
+    }
+
+    /// First-order marginal rate for `dim` at `window`: integer
+    /// finite difference `Δ_total_units / Δ_window_count` against
+    /// the *immediately previous* window. Returns 0 if either
+    /// window is empty (no consumption ⇒ no marginal rate).
+    pub fn marginal_rate(&self, dim: ResourceDim, window: WindowId) -> u64 {
+        let curr = self
+            .slice(dim, window)
+            .map(|b| b.total_units_micro)
+            .unwrap_or(0);
+        // No prior window exists at window 0 — the marginal rate is
+        // just the current consumption (rate-setter sees the cold-
+        // start signal directly). For window N>0, use the
+        // finite-difference against window N-1.
+        let prev = if window.0 == 0 {
+            0
+        } else {
+            self.slice(dim, WindowId(window.0 - 1))
+                .map(|b| b.total_units_micro)
+                .unwrap_or(0)
+        };
+        // First-order Pigouvian rate: change in consumption per
+        // window. Higher-order rate-setters (cube-slice derivatives
+        // across multiple windows + welfare-loss model) follow on.
+        let delta = curr.abs_diff(prev);
+        u64::try_from(delta).unwrap_or(u64::MAX)
+    }
+
+    /// **Pigouvian Q2.** Ingest an `EdgeKind::Externality`
+    /// `LineageEdge` into the cube. Expects:
+    ///   - `edge.kind = EdgeKind::Externality { resource, .. }`
+    ///   - `edge.attrs["units_micro"]` carries the unsigned integer
+    ///     consumption as a base-10 string (the runner emits this
+    ///     when constructing the edge)
+    ///   - `edge.ts` is the claim timestamp (already chrono-typed
+    ///     on the edge)
+    ///
+    /// Returns `true` if the edge was ingested, `false` if it was
+    /// skipped because it didn't match the contract above (wrong
+    /// kind, missing/malformed attr, unknown resource tag). The
+    /// caller may also feed `SignedExternalityClaim` records
+    /// directly via [`Self::ingest_at`].
+    pub fn ingest_edge(&mut self, edge: &nucleus_lineage::LineageEdge) -> bool {
+        let resource_tag = match &edge.kind {
+            nucleus_lineage::EdgeKind::Externality { resource, .. } => resource.as_str(),
+            _ => return false,
+        };
+        let dim = match ResourceDim::all()
+            .iter()
+            .find(|d| d.as_canonical_tag() == resource_tag.as_bytes())
+        {
+            Some(d) => *d,
+            None => return false,
+        };
+        let units_str = match edge.attrs.get("units_micro") {
+            Some(s) => s,
+            None => return false,
+        };
+        let units: u64 = match units_str.parse() {
+            Ok(u) => u,
+            Err(_) => return false,
+        };
+        // Convert chrono UTC timestamp → unix micros (signed → u64
+        // saturating for pre-epoch defensive case).
+        let ts_micros = edge.ts.timestamp_micros();
+        let ts_unsigned = u64::try_from(ts_micros).unwrap_or(0);
+        self.ingest_at(dim, units, ts_unsigned);
+        true
+    }
+
+    /// **Pigouvian Q4 — federation pullback.** Compose two cubes
+    /// into a single cube whose buckets are the *sum* over
+    /// overlapping `(dim, window)` cells and the *union* of cells
+    /// present in either.
+    ///
+    /// This is the categorical pullback of the externality functor
+    /// along a federation map (interpreted as the identity here —
+    /// non-identity federation maps that rewrite SPIFFE id namespaces
+    /// would compose with this pullback at the edge-ingestion layer).
+    /// Two federation members aggregating their externalities yield
+    /// the same total cube as one federation member with both
+    /// streams ingested.
+    ///
+    /// `window_micros` MUST match; mismatched windowing produces an
+    /// `Err`. `retention_windows` of `self` is preserved; the
+    /// result is evicted to that horizon.
+    pub fn pull_back(&self, other: &ExternalityCube) -> Result<ExternalityCube, PullbackError> {
+        if self.window_micros != other.window_micros {
+            return Err(PullbackError::WindowMicrosMismatch {
+                lhs: self.window_micros,
+                rhs: other.window_micros,
+            });
+        }
+        let mut out = ExternalityCube::new(self.window_micros, self.retention_windows);
+        // Sum overlapping cells; union the rest.
+        for (key, b) in self.buckets.iter().chain(other.buckets.iter()) {
+            let entry = out.buckets.entry(*key).or_default();
+            entry.total_units_micro = entry.total_units_micro.saturating_add(b.total_units_micro);
+            entry.count = entry.count.saturating_add(b.count);
+        }
+        out.latest_window = match (self.latest_window, other.latest_window) {
+            (Some(a), Some(b)) => Some(WindowId(a.0.max(b.0))),
+            (a, None) => a,
+            (None, b) => b,
+        };
+        out.evict_stale();
+        Ok(out)
+    }
+
+    /// Sum across all windows for a single dimension. Useful for
+    /// release-notes "total carbon this quarter" surfacing.
+    pub fn total(&self, dim: ResourceDim) -> u128 {
+        self.buckets
+            .iter()
+            .filter(|((d, _), _)| *d == dim)
+            .map(|(_, b)| b.total_units_micro)
+            .sum()
+    }
+
+    /// Evict buckets older than `retention_windows` behind
+    /// `latest_window`.
+    fn evict_stale(&mut self) {
+        if self.retention_windows == u64::MAX {
+            return;
+        }
+        let Some(latest) = self.latest_window else {
+            return;
+        };
+        if latest.0 < self.retention_windows {
+            return;
+        }
+        let cutoff = WindowId(latest.0 - self.retention_windows + 1);
+        self.buckets.retain(|(_, w), _| *w >= cutoff);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn window_id_buckets_correctly() {
+        let w = WindowId::from_unix_micros(150, 100);
+        assert_eq!(w, WindowId(1));
+        assert_eq!(w.start_unix_micros(100), 100);
+        // Boundary: ts == window_start belongs to that window.
+        assert_eq!(WindowId::from_unix_micros(100, 100), WindowId(1));
+        assert_eq!(WindowId::from_unix_micros(99, 100), WindowId(0));
+    }
+
+    #[test]
+    fn aggregate_bucket_mean_handles_empty() {
+        let b = AggregateBucket::default();
+        assert_eq!(b.mean_units_micro(), 0);
+    }
+
+    #[test]
+    fn ingest_aggregates_three_claims_correctly() {
+        let mut c = ExternalityCube::new(100, u64::MAX);
+        c.ingest_at(ResourceDim::GpuSeconds, 1_000, 50);
+        c.ingest_at(ResourceDim::GpuSeconds, 2_000, 75);
+        c.ingest_at(ResourceDim::GpuSeconds, 4_000, 95);
+        let bucket = c
+            .slice(ResourceDim::GpuSeconds, WindowId(0))
+            .expect("bucket exists");
+        assert_eq!(bucket.count, 3);
+        assert_eq!(bucket.total_units_micro, 7_000);
+        assert_eq!(bucket.mean_units_micro(), 2_333);
+        assert_eq!(c.cell_count(), 1);
+    }
+
+    #[test]
+    fn ingest_distributes_across_windows() {
+        let mut c = ExternalityCube::new(100, u64::MAX);
+        c.ingest_at(ResourceDim::GpuSeconds, 1_000, 50);
+        c.ingest_at(ResourceDim::GpuSeconds, 2_000, 150);
+        c.ingest_at(ResourceDim::GpuSeconds, 4_000, 250);
+        assert_eq!(c.cell_count(), 3);
+        assert_eq!(
+            c.slice(ResourceDim::GpuSeconds, WindowId(0)).unwrap().count,
+            1
+        );
+        assert_eq!(
+            c.slice(ResourceDim::GpuSeconds, WindowId(1)).unwrap().count,
+            1
+        );
+        assert_eq!(
+            c.slice(ResourceDim::GpuSeconds, WindowId(2)).unwrap().count,
+            1
+        );
+    }
+
+    #[test]
+    fn distinct_dims_dont_collide() {
+        let mut c = ExternalityCube::new(100, u64::MAX);
+        c.ingest_at(ResourceDim::GpuSeconds, 1_000, 50);
+        c.ingest_at(ResourceDim::GridCarbonGramsCo2, 500, 50);
+        assert_eq!(c.cell_count(), 2);
+        assert_eq!(
+            c.slice(ResourceDim::GpuSeconds, WindowId(0))
+                .unwrap()
+                .total_units_micro,
+            1_000
+        );
+        assert_eq!(
+            c.slice(ResourceDim::GridCarbonGramsCo2, WindowId(0))
+                .unwrap()
+                .total_units_micro,
+            500
+        );
+    }
+
+    #[test]
+    fn marginal_rate_finite_difference() {
+        let mut c = ExternalityCube::new(100, u64::MAX);
+        // Window 0: total 1000
+        c.ingest_at(ResourceDim::GpuSeconds, 1_000, 50);
+        // Window 1: total 3500
+        c.ingest_at(ResourceDim::GpuSeconds, 1_500, 150);
+        c.ingest_at(ResourceDim::GpuSeconds, 2_000, 175);
+        // Marginal rate at window 1 = |3500 - 1000| = 2500.
+        assert_eq!(c.marginal_rate(ResourceDim::GpuSeconds, WindowId(1)), 2_500);
+        // Window 0 has no prior window → rate = curr - 0 = 1000.
+        assert_eq!(c.marginal_rate(ResourceDim::GpuSeconds, WindowId(0)), 1_000);
+    }
+
+    #[test]
+    fn marginal_rate_handles_consumption_decrease() {
+        let mut c = ExternalityCube::new(100, u64::MAX);
+        c.ingest_at(ResourceDim::GpuSeconds, 5_000, 50);
+        c.ingest_at(ResourceDim::GpuSeconds, 1_000, 150);
+        // |1000 - 5000| = 4000 — magnitude of change. Sign would
+        // matter in a real rate-setter (negative rate = subsidy);
+        // for now we surface magnitude and let the rate-setter
+        // assign sign based on resource direction.
+        assert_eq!(c.marginal_rate(ResourceDim::GpuSeconds, WindowId(1)), 4_000);
+    }
+
+    #[test]
+    fn total_sums_across_windows() {
+        let mut c = ExternalityCube::new(100, u64::MAX);
+        c.ingest_at(ResourceDim::GpuSeconds, 1_000, 50);
+        c.ingest_at(ResourceDim::GpuSeconds, 2_000, 150);
+        c.ingest_at(ResourceDim::GpuSeconds, 4_000, 250);
+        c.ingest_at(ResourceDim::GridCarbonGramsCo2, 500, 50);
+        assert_eq!(c.total(ResourceDim::GpuSeconds), 7_000);
+        assert_eq!(c.total(ResourceDim::GridCarbonGramsCo2), 500);
+        assert_eq!(c.total(ResourceDim::PeerVerifierMillis), 0);
+    }
+
+    #[test]
+    fn retention_evicts_old_windows() {
+        let mut c = ExternalityCube::new(100, 2);
+        c.ingest_at(ResourceDim::GpuSeconds, 1_000, 50); // window 0
+        c.ingest_at(ResourceDim::GpuSeconds, 2_000, 150); // window 1
+        c.ingest_at(ResourceDim::GpuSeconds, 3_000, 250); // window 2 — evicts 0
+        assert!(
+            c.slice(ResourceDim::GpuSeconds, WindowId(0)).is_none(),
+            "window 0 should be evicted"
+        );
+        assert!(c.slice(ResourceDim::GpuSeconds, WindowId(1)).is_some());
+        assert!(c.slice(ResourceDim::GpuSeconds, WindowId(2)).is_some());
+    }
+
+    #[test]
+    fn unbounded_retention_keeps_everything() {
+        let mut c = ExternalityCube::new(100, u64::MAX);
+        for i in 0..50 {
+            c.ingest_at(ResourceDim::GpuSeconds, 1_000, i * 100 + 50);
+        }
+        assert_eq!(c.cell_count(), 50);
+    }
+
+    #[test]
+    fn empty_cube_marginal_is_zero() {
+        let c = ExternalityCube::new(100, u64::MAX);
+        assert_eq!(c.marginal_rate(ResourceDim::GpuSeconds, WindowId(42)), 0);
+    }
+
+    // ── Q2 — ingest_edge from LineageEdge ──────────────────────────────
+
+    fn mk_externality_edge(
+        resource_tag: &str,
+        units_micro: u64,
+        ts_unix_micros: u64,
+    ) -> nucleus_lineage::LineageEdge {
+        use chrono::TimeZone as _;
+        let pod = nucleus_lineage::CallSpiffeId::pod("test.example.com", "agents", "a1").unwrap();
+        let child = pod
+            .derive_artifact(format!("{resource_tag}-{units_micro}").as_bytes())
+            .unwrap();
+        let mut edge = nucleus_lineage::LineageEdge::from_parent(
+            child,
+            pod,
+            nucleus_lineage::EdgeKind::Externality {
+                resource: resource_tag.to_string(),
+                oracle_kid: "test-oracle".to_string(),
+            },
+        )
+        .with_attr("units_micro", units_micro.to_string());
+        // Override ts so the cube buckets the edge into a known
+        // window.
+        edge.ts = chrono::Utc.timestamp_micros(ts_unix_micros as i64).unwrap();
+        edge
+    }
+
+    #[test]
+    fn ingest_edge_walks_externality_into_cube() {
+        let mut c = ExternalityCube::new(100, u64::MAX);
+        let edge = mk_externality_edge("gpu_s", 4_242_000, 50);
+        assert!(c.ingest_edge(&edge));
+        let bucket = c
+            .slice(ResourceDim::GpuSeconds, WindowId(0))
+            .expect("ingested bucket exists");
+        assert_eq!(bucket.count, 1);
+        assert_eq!(bucket.total_units_micro, 4_242_000);
+    }
+
+    #[test]
+    fn ingest_edge_rejects_non_externality() {
+        let mut c = ExternalityCube::new(100, u64::MAX);
+        let pod = nucleus_lineage::CallSpiffeId::pod("test.example.com", "agents", "a1").unwrap();
+        let edge = nucleus_lineage::LineageEdge::pod_admit(pod);
+        assert!(!c.ingest_edge(&edge));
+        assert_eq!(c.cell_count(), 0);
+    }
+
+    #[test]
+    fn ingest_edge_rejects_unknown_resource_tag() {
+        let mut c = ExternalityCube::new(100, u64::MAX);
+        let edge = mk_externality_edge("unknown_dim", 1_000, 50);
+        assert!(!c.ingest_edge(&edge));
+        assert_eq!(c.cell_count(), 0);
+    }
+
+    #[test]
+    fn ingest_edge_rejects_missing_units_attr() {
+        let mut c = ExternalityCube::new(100, u64::MAX);
+        let mut edge = mk_externality_edge("gpu_s", 1_000, 50);
+        edge.attrs.clear();
+        assert!(!c.ingest_edge(&edge));
+        assert_eq!(c.cell_count(), 0);
+    }
+
+    // ── Q4 — federation pullback ──────────────────────────────────────
+
+    #[test]
+    fn pullback_sums_overlapping_cells_and_unions_others() {
+        let mut a = ExternalityCube::new(100, u64::MAX);
+        a.ingest_at(ResourceDim::GpuSeconds, 1_000, 50); // (gpu, 0)
+        a.ingest_at(ResourceDim::GpuSeconds, 500, 150); // (gpu, 1)
+        let mut b = ExternalityCube::new(100, u64::MAX);
+        b.ingest_at(ResourceDim::GpuSeconds, 2_000, 75); // (gpu, 0) — overlap
+        b.ingest_at(ResourceDim::GridCarbonGramsCo2, 300, 50); // (co2, 0) — new
+        let pulled = a.pull_back(&b).unwrap();
+        // Overlap: (gpu, 0) summed.
+        let gpu0 = pulled.slice(ResourceDim::GpuSeconds, WindowId(0)).unwrap();
+        assert_eq!(gpu0.total_units_micro, 3_000);
+        assert_eq!(gpu0.count, 2);
+        // (gpu, 1) carried from a only.
+        let gpu1 = pulled.slice(ResourceDim::GpuSeconds, WindowId(1)).unwrap();
+        assert_eq!(gpu1.total_units_micro, 500);
+        // (co2, 0) carried from b only.
+        let co2 = pulled
+            .slice(ResourceDim::GridCarbonGramsCo2, WindowId(0))
+            .unwrap();
+        assert_eq!(co2.total_units_micro, 300);
+    }
+
+    #[test]
+    fn pullback_associative_with_three_cubes() {
+        // (a ⊕ b) ⊕ c = a ⊕ (b ⊕ c) — the categorical pullback is
+        // associative when window_micros matches across all three.
+        let mut a = ExternalityCube::new(100, u64::MAX);
+        let mut b = ExternalityCube::new(100, u64::MAX);
+        let mut c = ExternalityCube::new(100, u64::MAX);
+        a.ingest_at(ResourceDim::GpuSeconds, 1_000, 50);
+        b.ingest_at(ResourceDim::GpuSeconds, 2_000, 50);
+        c.ingest_at(ResourceDim::GpuSeconds, 3_000, 50);
+
+        let lhs = a.pull_back(&b).unwrap().pull_back(&c).unwrap();
+        let rhs = a.pull_back(&b.pull_back(&c).unwrap()).unwrap();
+
+        assert_eq!(
+            lhs.slice(ResourceDim::GpuSeconds, WindowId(0))
+                .unwrap()
+                .total_units_micro,
+            6_000
+        );
+        assert_eq!(
+            rhs.slice(ResourceDim::GpuSeconds, WindowId(0))
+                .unwrap()
+                .total_units_micro,
+            6_000
+        );
+    }
+
+    #[test]
+    fn pullback_rejects_window_micros_mismatch() {
+        let a = ExternalityCube::new(100, u64::MAX);
+        let b = ExternalityCube::new(1_000, u64::MAX);
+        let err = a.pull_back(&b).unwrap_err();
+        assert!(matches!(err, PullbackError::WindowMicrosMismatch { .. }));
+    }
+
+    #[test]
+    fn pullback_with_empty_cube_is_identity() {
+        // Categorical identity element of pullback: empty cube.
+        let mut a = ExternalityCube::new(100, u64::MAX);
+        a.ingest_at(ResourceDim::GpuSeconds, 1_500, 50);
+        let empty = ExternalityCube::new(100, u64::MAX);
+        let pulled = a.pull_back(&empty).unwrap();
+        let original = a.slice(ResourceDim::GpuSeconds, WindowId(0)).unwrap();
+        let after = pulled.slice(ResourceDim::GpuSeconds, WindowId(0)).unwrap();
+        assert_eq!(original, after);
+    }
+}

--- a/crates/nucleus-externality/src/lib.rs
+++ b/crates/nucleus-externality/src/lib.rs
@@ -43,14 +43,17 @@
 
 mod assurance;
 mod claim;
+mod cube;
 mod dim;
 mod oracle;
 mod profile;
+mod rebate;
 
 pub use assurance::{assess_rung, AssuranceRung};
 pub use claim::{
     canonical_claim_bytes, sign_claim, verify_claim, ClaimError, SignedExternalityClaim,
 };
+pub use cube::{AggregateBucket, ExternalityCube, PullbackError, WindowId};
 pub use dim::{ResourceDim, RESOURCE_DIM_DOMAIN};
 pub use oracle::{
     verify_vca_claim, verify_vca_claim_rung, OracleError, OracleRegistry, TeeAttestation,
@@ -58,4 +61,7 @@ pub use oracle::{
 };
 pub use profile::{
     canonical_externality_bytes, externality_digest, ExternalityProfile, PROFILE_DOMAIN,
+};
+pub use rebate::{
+    emit_rebates, RebateError, WitnessFederation, WitnessShare, TOTAL_SHARE_BASIS_POINTS,
 };

--- a/crates/nucleus-externality/src/rebate.rs
+++ b/crates/nucleus-externality/src/rebate.rs
@@ -1,0 +1,362 @@
+//! Welfare-rebate distribution — the budget-balance fix.
+//!
+//! **Pigouvian T1-T4.** Classical VCG collects more than it
+//! redistributes; the surplus normally exits the auction without
+//! economic purpose. We close that gap by piping the Pigouvian
+//! collection (R5's `rebate_pool_micro_usd`) to the witness
+//! federation as a "victim-compensation" pool — peers who VERIFIED
+//! the externality claims get paid proportional to their
+//! verification share.
+//!
+//! ## Why this is the right party to pay
+//!
+//! The witness federation is the substrate's verification layer
+//! (closes K5 with ≥ 3 distinct peers). Each peer absorbs CPU + I/O
+//! time verifying signed claims — itself an externality the auction
+//! imposes on the federation. Paying peers from the Pigouvian pool
+//! turns K5 from a security gate into a sustainable revenue model:
+//! the federation peers have economic reason to join AND to verify
+//! claims correctly.
+//!
+//! Compare to the SOTA "Faltings mechanism" (excludes one agent at
+//! random and makes them the residual claimant). Our scheme is
+//! cleaner because the residual claimant set is *external* to the
+//! auction (the witness federation, not a bidder), which removes
+//! the truthfulness perturbation Faltings introduces.
+//!
+//! ## Math
+//!
+//! Each witness's rebate is computed via integer basis points:
+//! ```text
+//! rebate_i := pool_micro_usd * share_basis_points_i / 10_000
+//! ```
+//! With `Σ share_basis_points_i == 10_000` as the invariant, the
+//! total rebated equals the pool exactly (modulo integer
+//! rounding — see [`emit_rebates`] for the exact-balance
+//! reconciliation).
+
+use nucleus_lineage::{CallSpiffeId, EdgeKind, LineageEdge};
+use thiserror::Error;
+
+/// Total basis-point sum invariant for a witness federation. Sum of
+/// all `share_basis_points` MUST equal this exactly.
+pub const TOTAL_SHARE_BASIS_POINTS: u32 = 10_000;
+
+/// One witness federation peer's share of the rebate pool.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WitnessShare {
+    /// Peer's signing-key id (resolves to a `VerifyingKey` via
+    /// the federation's published JWKS).
+    pub witness_kid: String,
+    /// Basis-point share. Sum across all witnesses MUST equal
+    /// [`TOTAL_SHARE_BASIS_POINTS`].
+    pub share_basis_points: u32,
+}
+
+/// The witness federation membership snapshot used as the rebate
+/// distribution key.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WitnessFederation {
+    /// Witness shares — order is the canonical distribution order
+    /// (used to break exact-balance reconciliation ties).
+    pub witnesses: Vec<WitnessShare>,
+}
+
+impl WitnessFederation {
+    /// Build a federation with equal shares for `n` witnesses.
+    /// Convenience for tests + the common-case bootstrap path.
+    pub fn equal_shares(witness_kids: &[&str]) -> Self {
+        let n = witness_kids.len() as u32;
+        if n == 0 {
+            return Self {
+                witnesses: Vec::new(),
+            };
+        }
+        let base = TOTAL_SHARE_BASIS_POINTS / n;
+        let remainder = TOTAL_SHARE_BASIS_POINTS - base * n;
+        let witnesses = witness_kids
+            .iter()
+            .enumerate()
+            .map(|(i, kid)| {
+                // First `remainder` witnesses absorb the +1 bps so
+                // the total is exact.
+                let bonus = if (i as u32) < remainder { 1 } else { 0 };
+                WitnessShare {
+                    witness_kid: (*kid).to_string(),
+                    share_basis_points: base + bonus,
+                }
+            })
+            .collect();
+        Self { witnesses }
+    }
+
+    /// Sum of all share basis points. Must equal
+    /// [`TOTAL_SHARE_BASIS_POINTS`] for the federation to be valid.
+    pub fn total_share_basis_points(&self) -> u32 {
+        self.witnesses.iter().map(|w| w.share_basis_points).sum()
+    }
+}
+
+/// Errors from rebate emission.
+#[derive(Debug, Error)]
+pub enum RebateError {
+    /// Federation's share-basis-point sum doesn't equal
+    /// [`TOTAL_SHARE_BASIS_POINTS`]. Caller is using an invalid
+    /// federation snapshot.
+    #[error(
+        "federation basis-point sum {got} ≠ {expected}",
+        expected = TOTAL_SHARE_BASIS_POINTS,
+    )]
+    InvalidFederationShareSum { got: u32 },
+    /// SPIFFE-id derivation failed when building a rebate edge.
+    #[error("spiffe derivation: {0}")]
+    Spiffe(nucleus_lineage::IdError),
+    /// Tried to emit a rebate against an externality edge that
+    /// was already rebated. Defends V4 (double-claim).
+    #[error("source_externality_edge_hash {hash} already rebated")]
+    DoubleClaim { hash: String },
+}
+
+/// **T1+T2+T3+T4.** Emit one `WelfareRebate` edge per witness,
+/// distributing the entire `pool_micro_usd` proportionally to
+/// each witness's `share_basis_points`. The reconciliation step
+/// hands any integer-division rounding remainder to the first
+/// witness in declaration order so the sum of emitted rebates
+/// equals the pool *exactly*.
+///
+/// `parent` is the parent SPIFFE id the rebate edges chain off
+/// (typically the parent call edge or the auction's Allocation
+/// edge). `source_externality_edge_hash` is the SHA-256 hex of
+/// the `EdgeKind::Externality` edge that funded this rebate —
+/// the V4 no-double-claim defense uses this to deduplicate.
+pub fn emit_rebates(
+    pool_micro_usd: u64,
+    federation: &WitnessFederation,
+    parent: CallSpiffeId,
+    source_externality_edge_hash: &str,
+) -> Result<Vec<LineageEdge>, RebateError> {
+    if federation.total_share_basis_points() != TOTAL_SHARE_BASIS_POINTS {
+        return Err(RebateError::InvalidFederationShareSum {
+            got: federation.total_share_basis_points(),
+        });
+    }
+
+    // Compute each share via u128 to avoid the 32-bit
+    // multiplication overflow on extreme pool values.
+    let mut amounts: Vec<u64> = federation
+        .witnesses
+        .iter()
+        .map(|w| {
+            let pool128 = u128::from(pool_micro_usd);
+            let bps128 = u128::from(w.share_basis_points);
+            let share = pool128.saturating_mul(bps128) / u128::from(TOTAL_SHARE_BASIS_POINTS);
+            u64::try_from(share).unwrap_or(u64::MAX)
+        })
+        .collect();
+
+    // **Exact-balance reconciliation.** Integer division rounds
+    // down; the remainder goes to the first witness so the sum is
+    // exact.
+    let sum: u64 = amounts.iter().sum();
+    let remainder = pool_micro_usd.saturating_sub(sum);
+    if remainder > 0 && !amounts.is_empty() {
+        amounts[0] = amounts[0].saturating_add(remainder);
+    }
+
+    let mut edges = Vec::with_capacity(federation.witnesses.len());
+    for (w, amount) in federation.witnesses.iter().zip(amounts.iter()) {
+        // Distinct child id per witness for the same source so
+        // the chain stays unambiguous.
+        let child_seed = format!(
+            "rebate:{}:{}:{amount}",
+            w.witness_kid, source_externality_edge_hash
+        );
+        let child = parent
+            .derive_artifact(child_seed.as_bytes())
+            .map_err(RebateError::Spiffe)?;
+        let edge = LineageEdge::from_parent(
+            child,
+            parent.clone(),
+            EdgeKind::WelfareRebate {
+                recipient_kid: w.witness_kid.clone(),
+                micro_usd: *amount,
+                source_externality_edge_hash: source_externality_edge_hash.to_string(),
+            },
+        );
+        edges.push(edge);
+    }
+    Ok(edges)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nucleus_lineage::CallSpiffeId;
+
+    fn pod_parent() -> CallSpiffeId {
+        CallSpiffeId::pod("test.example.com", "agents", "auctioneer").unwrap()
+    }
+
+    fn fed3() -> WitnessFederation {
+        WitnessFederation::equal_shares(&["w-a", "w-b", "w-c"])
+    }
+
+    #[test]
+    fn equal_shares_sums_to_ten_thousand() {
+        let f = fed3();
+        assert_eq!(f.total_share_basis_points(), TOTAL_SHARE_BASIS_POINTS);
+        // 10_000 / 3 = 3333 r 1 → first witness gets the +1 bonus.
+        assert_eq!(f.witnesses[0].share_basis_points, 3_334);
+        assert_eq!(f.witnesses[1].share_basis_points, 3_333);
+        assert_eq!(f.witnesses[2].share_basis_points, 3_333);
+    }
+
+    #[test]
+    fn equal_shares_split_evenly_for_divisor() {
+        let f = WitnessFederation::equal_shares(&["a", "b", "c", "d", "e"]);
+        // 10_000 / 5 = 2000 exactly.
+        for w in &f.witnesses {
+            assert_eq!(w.share_basis_points, 2_000);
+        }
+    }
+
+    // ── T3 — Proportional-to-verifier-share math ───────────────────────
+
+    #[test]
+    fn equal_shares_split_pool_evenly() {
+        let f = WitnessFederation::equal_shares(&["a", "b", "c", "d"]);
+        let edges = emit_rebates(4_000, &f, pod_parent(), &"f".repeat(64)).unwrap();
+        let total: u64 = edges
+            .iter()
+            .map(|e| match &e.kind {
+                EdgeKind::WelfareRebate { micro_usd, .. } => *micro_usd,
+                _ => 0,
+            })
+            .sum();
+        assert_eq!(total, 4_000);
+        for e in &edges {
+            match &e.kind {
+                EdgeKind::WelfareRebate { micro_usd, .. } => {
+                    assert_eq!(*micro_usd, 1_000);
+                }
+                _ => panic!("expected WelfareRebate"),
+            }
+        }
+    }
+
+    #[test]
+    fn unequal_shares_match_bps() {
+        let f = WitnessFederation {
+            witnesses: vec![
+                WitnessShare {
+                    witness_kid: "lead".into(),
+                    share_basis_points: 6_000, // 60%
+                },
+                WitnessShare {
+                    witness_kid: "second".into(),
+                    share_basis_points: 3_000, // 30%
+                },
+                WitnessShare {
+                    witness_kid: "third".into(),
+                    share_basis_points: 1_000, // 10%
+                },
+            ],
+        };
+        let edges = emit_rebates(10_000, &f, pod_parent(), &"a".repeat(64)).unwrap();
+        let amounts: Vec<u64> = edges
+            .iter()
+            .map(|e| match &e.kind {
+                EdgeKind::WelfareRebate { micro_usd, .. } => *micro_usd,
+                _ => 0,
+            })
+            .collect();
+        assert_eq!(amounts, vec![6_000, 3_000, 1_000]);
+    }
+
+    // ── T4 — Budget balance round-trip ────────────────────────────────
+
+    #[test]
+    fn budget_balanced_when_pigou_collected_equals_rebated() {
+        // The named acceptance: rebate emission sums EXACTLY to
+        // the pool (integer-division remainder folded back).
+        let f = fed3();
+        let pool = 1_000_001u64; // odd amount: 1_000_001 / 3 = 333_333 r 2.
+        let edges = emit_rebates(pool, &f, pod_parent(), &"b".repeat(64)).unwrap();
+        let total: u64 = edges
+            .iter()
+            .map(|e| match &e.kind {
+                EdgeKind::WelfareRebate { micro_usd, .. } => *micro_usd,
+                _ => 0,
+            })
+            .sum();
+        assert_eq!(total, pool, "rebate sum must equal pool exactly");
+    }
+
+    #[test]
+    fn rebate_edges_chain_off_parent() {
+        let f = fed3();
+        let parent = pod_parent();
+        let edges = emit_rebates(900, &f, parent.clone(), &"c".repeat(64)).unwrap();
+        for edge in &edges {
+            assert_eq!(edge.parents.len(), 1);
+            assert_eq!(edge.parents[0], parent);
+            // Each child must descend from the parent's URI.
+            assert!(
+                edge.child.as_str().starts_with(parent.as_str()),
+                "child {} not a descendant of {}",
+                edge.child.as_str(),
+                parent.as_str()
+            );
+        }
+    }
+
+    #[test]
+    fn rebate_edges_carry_source_externality_hash() {
+        let f = fed3();
+        let source_hash = "d".repeat(64);
+        let edges = emit_rebates(900, &f, pod_parent(), &source_hash).unwrap();
+        for edge in &edges {
+            match &edge.kind {
+                EdgeKind::WelfareRebate {
+                    source_externality_edge_hash,
+                    ..
+                } => {
+                    assert_eq!(source_externality_edge_hash, &source_hash);
+                }
+                _ => panic!("expected WelfareRebate"),
+            }
+        }
+    }
+
+    #[test]
+    fn invalid_federation_share_sum_rejected() {
+        let bad = WitnessFederation {
+            witnesses: vec![WitnessShare {
+                witness_kid: "only".into(),
+                share_basis_points: 5_000, // half — invalid
+            }],
+        };
+        let err = emit_rebates(1_000, &bad, pod_parent(), &"e".repeat(64)).unwrap_err();
+        match err {
+            RebateError::InvalidFederationShareSum { got } => {
+                assert_eq!(got, 5_000);
+            }
+            other => panic!("expected InvalidFederationShareSum, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn zero_pool_emits_zero_value_edges() {
+        // Edge case: cube reports no Pigouvian collection in this
+        // window. Rebate emission still produces edges (so the
+        // chain is uniform across windows) but each amount is 0.
+        let f = fed3();
+        let edges = emit_rebates(0, &f, pod_parent(), &"e".repeat(64)).unwrap();
+        for edge in &edges {
+            match &edge.kind {
+                EdgeKind::WelfareRebate { micro_usd, .. } => assert_eq!(*micro_usd, 0),
+                _ => panic!("expected WelfareRebate"),
+            }
+        }
+    }
+}

--- a/crates/nucleus-lineage/Cargo.toml
+++ b/crates/nucleus-lineage/Cargo.toml
@@ -10,7 +10,14 @@ keywords = ["spiffe", "lineage", "provenance", "ifc", "agents"]
 categories = ["development-tools", "cryptography"]
 
 [features]
-default = []
+default = ["sink-io"]
+# **wasm-compatibility gate**: `sink-io` ships the file-backed `JsonlSink`
+# which depends on `std::fs::{File, OpenOptions}` (unavailable on
+# `wasm32-unknown-unknown`). Default-on so native consumers see no change;
+# disable via `default-features = false` for wasm targets. The `InMemorySink`
+# + `LineageSink` trait + `SinkError` (minus the `Io` variant) remain
+# available unconditionally.
+sink-io = []
 # Demo-only in-process Ed25519 JWT-SVID issuer + edge signer. NOT FOR
 # PRODUCTION USE. Production callers should write a SPIFFE-Workload-API-
 # backed `IdentityFetcher` impl and never enable this feature in release

--- a/crates/nucleus-lineage/src/edge.rs
+++ b/crates/nucleus-lineage/src/edge.rs
@@ -11,11 +11,132 @@ use std::collections::BTreeMap;
 use crate::id::CallSpiffeId;
 use crate::proof::Proof;
 
+/// Pins the verification environment that an edge's claim can be
+/// independently recomputed against. The off-platform verification closure
+/// depends on this metadata being part of the signed surface — without it,
+/// "independently recomputable" is rhetoric (the operator could swap
+/// verifier binaries, Wasmtime versions, VRF parameters, or Lean specs
+/// between claim production and recomputation).
+///
+/// All-`None` is the unattested case (legacy edges, structural-only claims).
+/// Economic-edge variants — `Bid`, `Allocation`, `ContractEvaluation`,
+/// `Dispute`, `MetricClaim` — SHOULD populate the relevant fields when
+/// signed. Each field is its own `Option<String>` so callers can attest
+/// partially (e.g., a `MetricClaim` without VRF dependency leaves
+/// `vrf_params_hash` unset).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VerifierAttestation {
+    /// Identity tag of the verifier binary that recomputes this claim.
+    ///
+    /// **Two accepted forms** (iteration-12 audit fix #6):
+    /// - **Semver-versioned package id**: `"<crate-name>@<semver>"`
+    ///   (e.g. `"nucleus-runner@0.1.0"`). This is what the runner stamps
+    ///   today — sufficient for verifier replay because the source
+    ///   tree at a given semver IS content-addressable via the Cargo
+    ///   ecosystem (Cargo.lock + the source tarball's hash on
+    ///   crates.io).
+    /// - **64-char hex SHA-256**: of the published binary itself, for
+    ///   verifiers that prefer binary-equality over semver-trust.
+    ///
+    /// Both forms are accepted because semver pinning is sufficient
+    /// for the substrate's "rebuild from source at this commit"
+    /// replay model. A future emitter that hashes a sealed,
+    /// reproducible binary may use the hex form; today's emitters
+    /// use the `@` form.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub verifier_binary_hash: Option<String>,
+    /// Wasmtime version + config descriptor (e.g., "44.0.0+nan_canon+fuel=off").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub wasmtime_version: Option<String>,
+    /// Hex hash of the relevant Wasmtime config bundle (host functions,
+    /// resource limits, NaN canonicalization) that affect determinism.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub wasmtime_config_hash: Option<String>,
+    /// Hex hash of VRF public parameters when the claim depends on a VRF
+    /// (e.g., arbitrator panel selection in Primitive 4).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub vrf_params_hash: Option<String>,
+    /// Hex Merkle root of external state snapshot (e.g., trust-service
+    /// reputation state) at claim time, for closures that depend on
+    /// stateful external services.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub external_snapshot_root: Option<String>,
+    /// Hex hash of the Lean spec module that pinned the property this claim
+    /// satisfies (e.g., `formal/Nucleus/Auctions/BudgetConservation.lean`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lean_spec_hash: Option<String>,
+}
+
+impl VerifierAttestation {
+    /// Construct an empty attestation; populate fields via builder methods.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Builder: pin the verifier binary hash.
+    pub fn with_verifier_binary_hash(mut self, hex: impl Into<String>) -> Self {
+        self.verifier_binary_hash = Some(hex.into());
+        self
+    }
+
+    /// Builder: pin the Wasmtime version descriptor.
+    pub fn with_wasmtime_version(mut self, version: impl Into<String>) -> Self {
+        self.wasmtime_version = Some(version.into());
+        self
+    }
+
+    /// Builder: pin the Wasmtime config bundle hash.
+    pub fn with_wasmtime_config_hash(mut self, hex: impl Into<String>) -> Self {
+        self.wasmtime_config_hash = Some(hex.into());
+        self
+    }
+
+    /// Builder: pin the VRF public parameters hash.
+    pub fn with_vrf_params_hash(mut self, hex: impl Into<String>) -> Self {
+        self.vrf_params_hash = Some(hex.into());
+        self
+    }
+
+    /// Builder: pin the external-state-snapshot root.
+    pub fn with_external_snapshot_root(mut self, hex: impl Into<String>) -> Self {
+        self.external_snapshot_root = Some(hex.into());
+        self
+    }
+
+    /// Builder: pin the Lean spec module hash.
+    pub fn with_lean_spec_hash(mut self, hex: impl Into<String>) -> Self {
+        self.lean_spec_hash = Some(hex.into());
+        self
+    }
+
+    /// `true` iff every field is `None`. Used by verifiers in strict mode
+    /// to reject edges that claim economic semantics without attestation.
+    pub fn is_empty(&self) -> bool {
+        self.verifier_binary_hash.is_none()
+            && self.wasmtime_version.is_none()
+            && self.wasmtime_config_hash.is_none()
+            && self.vrf_params_hash.is_none()
+            && self.external_snapshot_root.is_none()
+            && self.lean_spec_hash.is_none()
+    }
+}
+
 /// What kind of derivation this edge represents.
 ///
 /// `Other(String)` is reserved for forward-compatible kinds that callers
 /// can introduce without modifying this enum. The string value is shown
 /// verbatim in lineage output.
+///
+/// # Economic-edge variants
+///
+/// The `Bid`, `Allocation`, `ContractEvaluation`, `Dispute`, and `MetricClaim`
+/// variants are the substrate's economic primitives. They follow the same
+/// signed-binding contract as `ToolCall` / `LlmCall`: payload fields shown
+/// here are descriptive metadata, while the cryptographic binding to specific
+/// values (bid amounts, allocation outcomes, metric values) happens via the
+/// edge's `content_hash_hex` over a deterministic serialization of the
+/// underlying record. Producers MUST set `content_hash_hex` for economic
+/// edges; verifiers MUST treat absent `content_hash_hex` as unsigned.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum EdgeKind {
@@ -45,6 +166,102 @@ pub enum EdgeKind {
         retrieval_ts: DateTime<Utc>,
         /// Trust class of the source.
         source_class: SourceClass,
+    },
+    /// A bid submitted into a market mechanism. `market_id` identifies the
+    /// auction; the bidder is the edge's first parent. The bid record
+    /// (amount, side-attributes, sealed-or-open) is bound via `content_hash_hex`.
+    Bid { market_id: String },
+    /// An allocation produced by a market mechanism. `market_id` identifies
+    /// the auction; `mechanism` names the rule ("vcg", "second_price",
+    /// "posted_price", "gale_shapley", "double_auction"). Parents are the
+    /// bid edges that fed into this allocation. The allocation record
+    /// (winners, payments, integer-rounded micro-USD amounts) is bound via
+    /// `content_hash_hex`.
+    Allocation {
+        market_id: String,
+        mechanism: String,
+    },
+    /// One evaluation step of a programmable-contract state machine.
+    /// `contract_id` identifies the contract; `step` is the monotonic step
+    /// counter. The evaluated transition (input event, output obligations,
+    /// payment flows, reputation effects) is bound via `content_hash_hex`.
+    ContractEvaluation { contract_id: String, step: u32 },
+    /// A dispute filed against a prior edge. `dispute_id` identifies the
+    /// dispute; `target_edge_hash` is the hex SHA-256 of the disputed edge's
+    /// canonical bytes. The claim record (evidence references, requested
+    /// remedy) is bound via `content_hash_hex`.
+    Dispute {
+        dispute_id: String,
+        target_edge_hash: String,
+    },
+    /// A signed welfare/economic-introspection metric claim over a specific
+    /// window. `metric_name` identifies the metric (e.g. "producer_surplus",
+    /// "gini", "time_to_clear"); `window_id` identifies the aggregation
+    /// window. The metric value (with any differential-privacy noise
+    /// parameters) is bound via `content_hash_hex`.
+    MetricClaim {
+        metric_name: String,
+        window_id: String,
+    },
+    /// A settlement transaction on an external payment rail.
+    /// `tx_ref` is the rail-side transaction id (Stripe `ch_…`, x402
+    /// onchain tx hash, ACH trace number, …); `rail` names the
+    /// settlement protocol ("stripe-connect", "x402-evm", "ach").
+    /// Parents are the Allocation / ContractEvaluation edges that
+    /// produced the obligation being settled. The payment record
+    /// (amount, payee SPIFFE id, integer micro-USD) is bound via
+    /// `content_hash_hex`.
+    ///
+    /// **Refund / chargeback semantics** (Close-to-Highest D4):
+    /// a compensating refund is itself a `Settlement` edge whose
+    /// `attrs["amount_micro_usd_signed"]` is *negative* (string-encoded
+    /// `i64`) and whose `parents` include the original Settlement
+    /// edge being reversed. The signed-sum of the two settlement
+    /// edges over a charge is zero exactly when the refund is full.
+    Settlement { tx_ref: String, rail: String },
+    /// **Pigouvian P4.** An externality claim signed by a designated
+    /// resource oracle. `resource` is the short stable tag from
+    /// `nucleus_externality::ResourceDim::as_canonical_tag()` (e.g.
+    /// "gpu_s", "co2_g"). `oracle_kid` is the signing-key id used to
+    /// resolve the oracle's verifying key. The amount + freshness
+    /// window + subject identity binding live in the
+    /// `nucleus_externality::SignedExternalityClaim` whose
+    /// canonical SHA-256 is bound via `content_hash_hex`. Parents
+    /// chain back to the call edge the externality is attributed
+    /// to.
+    Externality {
+        resource: String,
+        oracle_kid: String,
+    },
+    /// **Pigouvian P5.** A rate-setter update to the Pigouvian λ_k
+    /// for a given resource dimension, applicable over a clearing
+    /// window. `resource` is the same short tag used by
+    /// `Externality`; `rate_micro_usd_per_unit` is the marginal
+    /// social cost per micro-unit of consumption, integer-only;
+    /// `window_unix_micros` names the application window. The full
+    /// rate record (full rate vector, cube slice the rate was
+    /// derived from, signature) is bound via `content_hash_hex`.
+    /// Rate updates are themselves signed edges so the rate timeline
+    /// is auditable and replayable in the browser verifier.
+    PigouvianRateUpdate {
+        resource: String,
+        rate_micro_usd_per_unit: u64,
+        window_unix_micros: u64,
+    },
+    /// **Pigouvian P6.** A welfare-rebate disbursement to a witness-
+    /// federation peer (or Pigouvian victim), funded from the VCG
+    /// surplus collected through the Pigouvian re-weighting. Solves
+    /// the classical VCG budget-balance gap: the federation peer
+    /// who VERIFIED the externality claim gets paid proportional
+    /// to their verification share. `recipient_kid` identifies the
+    /// peer's signing key; `micro_usd` is the rebate amount (integer
+    /// per ECON-PRECISION); `source_externality_edge_hash` is the
+    /// content_hash_hex of the `Externality` edge that funded this
+    /// rebate (used to enforce no-double-claim).
+    WelfareRebate {
+        recipient_kid: String,
+        micro_usd: u64,
+        source_externality_edge_hash: String,
     },
     /// Forward-compatible escape hatch. `name` is the caller-defined kind label.
     Other { name: String },
@@ -99,6 +316,14 @@ pub struct LineageEdge {
     /// mode.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub proof: Option<Proof>,
+    /// Pins the verification environment for this edge's claim (verifier
+    /// binary, Wasmtime version + config, VRF parameters, external-snapshot
+    /// root, Lean spec). `None` for legacy / structural-only edges. Economic
+    /// edges (`Bid`, `Allocation`, `ContractEvaluation`, `Dispute`,
+    /// `MetricClaim`) SHOULD populate the relevant fields when signed so
+    /// that off-platform recomputation is genuinely closed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub verifier_attestation: Option<VerifierAttestation>,
 }
 
 impl LineageEdge {
@@ -112,6 +337,7 @@ impl LineageEdge {
             ts: Utc::now(),
             attrs: BTreeMap::new(),
             proof: None,
+            verifier_attestation: None,
         }
     }
 
@@ -139,6 +365,7 @@ impl LineageEdge {
             ts: Utc::now(),
             attrs: BTreeMap::new(),
             proof: None,
+            verifier_attestation: None,
         }
     }
 
@@ -152,6 +379,7 @@ impl LineageEdge {
             ts: Utc::now(),
             attrs: BTreeMap::new(),
             proof: None,
+            verifier_attestation: None,
         }
     }
 
@@ -170,6 +398,13 @@ impl LineageEdge {
     /// Builder: attach a cryptographic proof.
     pub fn with_proof(mut self, proof: Proof) -> Self {
         self.proof = Some(proof);
+        self
+    }
+
+    /// Builder: attach a verifier attestation pinning the recomputation
+    /// environment for this edge's claim.
+    pub fn with_verifier_attestation(mut self, va: VerifierAttestation) -> Self {
+        self.verifier_attestation = Some(va);
         self
     }
 }
@@ -278,6 +513,7 @@ mod tests {
             ts: Utc::now(),
             attrs: BTreeMap::new(),
             proof: None,
+            verifier_attestation: None,
         };
         assert_eq!(edge.parents.len(), 2);
         assert!(matches!(edge.kind, EdgeKind::Merge));
@@ -289,5 +525,411 @@ mod tests {
         let edge = LineageEdge::pod_admit(p);
         let json = serde_json::to_string(&edge).unwrap();
         assert!(!json.contains("attrs"));
+    }
+
+    // ── Economic edge variant round-trips ───────────────────────────────
+    // Each economic variant (Bid/Allocation/ContractEvaluation/Dispute/
+    // MetricClaim) must round-trip through JSON identically and emit the
+    // documented snake_case kind discriminator. The cryptographic binding
+    // to specific values (amounts, payments, metric numbers) happens via
+    // `content_hash_hex`, not via the kind payload — these tests only
+    // verify wire-format stability.
+
+    fn bid_child(p: &CallSpiffeId, market: &str) -> CallSpiffeId {
+        p.derive_artifact(format!("bid:{market}").as_bytes())
+            .unwrap()
+    }
+
+    #[test]
+    fn bid_edge_round_trips() {
+        let p = pod();
+        let edge = LineageEdge::from_parent(
+            bid_child(&p, "market-42"),
+            p,
+            EdgeKind::Bid {
+                market_id: "market-42".to_string(),
+            },
+        )
+        .with_content_hash("deadbeef".repeat(8));
+        let json = serde_json::to_string(&edge).unwrap();
+        assert!(json.contains("\"kind\":\"bid\""));
+        assert!(json.contains("\"market_id\":\"market-42\""));
+        let back: LineageEdge = serde_json::from_str(&json).unwrap();
+        assert_eq!(edge, back);
+    }
+
+    #[test]
+    fn allocation_edge_round_trips_with_mechanism() {
+        let p = pod();
+        let edge = LineageEdge::from_parent(
+            p.derive_artifact(b"allocation").unwrap(),
+            p,
+            EdgeKind::Allocation {
+                market_id: "market-42".to_string(),
+                mechanism: "vcg".to_string(),
+            },
+        )
+        .with_content_hash("c0ffee".repeat(10) + "1234");
+        let json = serde_json::to_string(&edge).unwrap();
+        assert!(json.contains("\"kind\":\"allocation\""));
+        assert!(json.contains("\"mechanism\":\"vcg\""));
+        let back: LineageEdge = serde_json::from_str(&json).unwrap();
+        assert_eq!(edge, back);
+    }
+
+    #[test]
+    fn contract_evaluation_edge_round_trips() {
+        let p = pod();
+        let edge = LineageEdge::from_parent(
+            p.derive_artifact(b"contract-step-7").unwrap(),
+            p,
+            EdgeKind::ContractEvaluation {
+                contract_id: "contract-abc".to_string(),
+                step: 7,
+            },
+        );
+        let json = serde_json::to_string(&edge).unwrap();
+        assert!(json.contains("\"kind\":\"contract_evaluation\""));
+        assert!(json.contains("\"step\":7"));
+        let back: LineageEdge = serde_json::from_str(&json).unwrap();
+        assert_eq!(edge, back);
+    }
+
+    #[test]
+    fn dispute_edge_round_trips_with_target_hash() {
+        let p = pod();
+        let target_hash = "a".repeat(64);
+        let edge = LineageEdge::from_parent(
+            p.derive_artifact(b"dispute-claim").unwrap(),
+            p,
+            EdgeKind::Dispute {
+                dispute_id: "dispute-1".to_string(),
+                target_edge_hash: target_hash.clone(),
+            },
+        );
+        let json = serde_json::to_string(&edge).unwrap();
+        assert!(json.contains("\"kind\":\"dispute\""));
+        assert!(json.contains(&target_hash));
+        let back: LineageEdge = serde_json::from_str(&json).unwrap();
+        assert_eq!(edge, back);
+    }
+
+    #[test]
+    fn metric_claim_edge_round_trips() {
+        let p = pod();
+        let edge = LineageEdge::from_parent(
+            p.derive_artifact(b"metric-window-2026-05").unwrap(),
+            p,
+            EdgeKind::MetricClaim {
+                metric_name: "producer_surplus".to_string(),
+                window_id: "2026-05".to_string(),
+            },
+        )
+        .with_content_hash("b".repeat(64));
+        let json = serde_json::to_string(&edge).unwrap();
+        assert!(json.contains("\"kind\":\"metric_claim\""));
+        assert!(json.contains("\"metric_name\":\"producer_surplus\""));
+        let back: LineageEdge = serde_json::from_str(&json).unwrap();
+        assert_eq!(edge, back);
+    }
+
+    // ── VerifierAttestation tests ──────────────────────────────────────
+
+    #[test]
+    fn verifier_attestation_round_trips() {
+        let va = VerifierAttestation::new()
+            .with_verifier_binary_hash("a".repeat(64))
+            .with_wasmtime_version("44.0.0+nan_canon")
+            .with_wasmtime_config_hash("b".repeat(64))
+            .with_vrf_params_hash("c".repeat(64))
+            .with_external_snapshot_root("d".repeat(64))
+            .with_lean_spec_hash("e".repeat(64));
+        assert!(!va.is_empty());
+        let json = serde_json::to_string(&va).unwrap();
+        let back: VerifierAttestation = serde_json::from_str(&json).unwrap();
+        assert_eq!(va, back);
+    }
+
+    #[test]
+    fn verifier_attestation_default_is_empty() {
+        let va = VerifierAttestation::default();
+        assert!(va.is_empty());
+        let json = serde_json::to_string(&va).unwrap();
+        // All fields skip-if-none → empty object
+        assert_eq!(json, "{}");
+    }
+
+    #[test]
+    fn edge_with_verifier_attestation_round_trips() {
+        let p = pod();
+        let va = VerifierAttestation::new()
+            .with_lean_spec_hash("f".repeat(64))
+            .with_verifier_binary_hash("9".repeat(64));
+        let edge = LineageEdge::from_parent(
+            p.derive_artifact(b"alloc").unwrap(),
+            p,
+            EdgeKind::Allocation {
+                market_id: "m1".into(),
+                mechanism: "vcg".into(),
+            },
+        )
+        .with_content_hash("0".repeat(64))
+        .with_verifier_attestation(va.clone());
+        let json = serde_json::to_string(&edge).unwrap();
+        assert!(json.contains("verifier_attestation"));
+        assert!(json.contains("lean_spec_hash"));
+        let back: LineageEdge = serde_json::from_str(&json).unwrap();
+        assert_eq!(edge, back);
+        assert_eq!(back.verifier_attestation, Some(va));
+    }
+
+    #[test]
+    fn edge_without_attestation_skips_field_in_json() {
+        let p = pod();
+        let edge = LineageEdge::pod_admit(p);
+        let json = serde_json::to_string(&edge).unwrap();
+        assert!(!json.contains("verifier_attestation"));
+    }
+
+    #[test]
+    fn canonical_bytes_differ_with_and_without_attestation() {
+        use crate::proof::canonical_edge_bytes;
+        let p = pod();
+        let edge_bare = LineageEdge::from_parent(
+            p.derive_artifact(b"x").unwrap(),
+            p.clone(),
+            EdgeKind::MetricClaim {
+                metric_name: "gini".into(),
+                window_id: "2026-05".into(),
+            },
+        )
+        .with_content_hash("0".repeat(64));
+
+        let va = VerifierAttestation::new().with_lean_spec_hash("a".repeat(64));
+        let edge_attested = edge_bare.clone().with_verifier_attestation(va);
+
+        let bytes_bare = canonical_edge_bytes(&edge_bare, None);
+        let bytes_attested = canonical_edge_bytes(&edge_attested, None);
+        assert_ne!(bytes_bare, bytes_attested);
+    }
+
+    #[test]
+    fn canonical_bytes_differ_per_attestation_field() {
+        use crate::proof::canonical_edge_bytes;
+        let p = pod();
+        let base = LineageEdge::from_parent(
+            p.derive_artifact(b"x").unwrap(),
+            p,
+            EdgeKind::Dispute {
+                dispute_id: "d1".into(),
+                target_edge_hash: "0".repeat(64),
+            },
+        );
+
+        let with_lean = base.clone().with_verifier_attestation(
+            VerifierAttestation::new().with_lean_spec_hash("a".repeat(64)),
+        );
+        let with_vrf = base.clone().with_verifier_attestation(
+            VerifierAttestation::new().with_vrf_params_hash("a".repeat(64)),
+        );
+        let with_both = base.clone().with_verifier_attestation(
+            VerifierAttestation::new()
+                .with_lean_spec_hash("a".repeat(64))
+                .with_vrf_params_hash("a".repeat(64)),
+        );
+
+        let b_lean = canonical_edge_bytes(&with_lean, None);
+        let b_vrf = canonical_edge_bytes(&with_vrf, None);
+        let b_both = canonical_edge_bytes(&with_both, None);
+
+        // Same hex value placed in different fields must produce different
+        // canonical bytes (field positions are binding).
+        assert_ne!(b_lean, b_vrf);
+        // Two fields populated differs from either one alone.
+        assert_ne!(b_lean, b_both);
+        assert_ne!(b_vrf, b_both);
+    }
+
+    #[test]
+    fn economic_kinds_have_distinct_canonical_tags() {
+        // Reach into proof::canonical_edge_bytes via the public re-export to
+        // confirm the discriminators wire up correctly. Each economic kind
+        // must produce a distinct byte sequence purely from the kind tag,
+        // even when child/parents/timestamp/content-hash are identical.
+        use crate::proof::canonical_edge_bytes;
+
+        let p = pod();
+        let child = p.derive_artifact(b"x").unwrap();
+        let ts = Utc::now();
+        let mk = |k: EdgeKind| LineageEdge {
+            child: child.clone(),
+            parents: vec![p.clone()],
+            kind: k,
+            content_hash_hex: None,
+            ts,
+            attrs: BTreeMap::new(),
+            proof: None,
+            verifier_attestation: None,
+        };
+
+        let bid = canonical_edge_bytes(
+            &mk(EdgeKind::Bid {
+                market_id: "m".into(),
+            }),
+            None,
+        );
+        let alloc = canonical_edge_bytes(
+            &mk(EdgeKind::Allocation {
+                market_id: "m".into(),
+                mechanism: "vcg".into(),
+            }),
+            None,
+        );
+        let ce = canonical_edge_bytes(
+            &mk(EdgeKind::ContractEvaluation {
+                contract_id: "c".into(),
+                step: 0,
+            }),
+            None,
+        );
+        let disp = canonical_edge_bytes(
+            &mk(EdgeKind::Dispute {
+                dispute_id: "d".into(),
+                target_edge_hash: "0".repeat(64),
+            }),
+            None,
+        );
+        let mc = canonical_edge_bytes(
+            &mk(EdgeKind::MetricClaim {
+                metric_name: "n".into(),
+                window_id: "w".into(),
+            }),
+            None,
+        );
+
+        // All five must differ from each other and from existing kinds.
+        let pod_admit = canonical_edge_bytes(&LineageEdge::pod_admit(p.clone()), None);
+        let tool_call = canonical_edge_bytes(
+            &mk(EdgeKind::ToolCall {
+                tool: "Bash".into(),
+            }),
+            None,
+        );
+
+        for (i, a) in [&bid, &alloc, &ce, &disp, &mc].iter().enumerate() {
+            for (j, b) in [&bid, &alloc, &ce, &disp, &mc].iter().enumerate() {
+                if i != j {
+                    assert_ne!(a, b, "economic kinds {i} and {j} share canonical bytes");
+                }
+            }
+            assert_ne!(*a, &tool_call, "economic kind {i} collides with tool_call");
+        }
+        // pod_admit has no parents, so it differs structurally anyway.
+        assert_ne!(bid, pod_admit);
+    }
+
+    // ── Pigouvian P4/P5/P6 variants ─────────────────────────────────────
+
+    #[test]
+    fn externality_edge_round_trips_json() {
+        let p = pod();
+        let child = p.derive_artifact(b"co2-claim-1").unwrap();
+        let edge = LineageEdge::from_parent(
+            child,
+            p,
+            EdgeKind::Externality {
+                resource: "co2_g".to_string(),
+                oracle_kid: "co2-oracle-key-1".to_string(),
+            },
+        )
+        .with_content_hash("a".repeat(64))
+        .with_attr("units_micro", "1500000");
+        let json = serde_json::to_string(&edge).unwrap();
+        let back: LineageEdge = serde_json::from_str(&json).unwrap();
+        assert_eq!(edge, back);
+        // Externally tagged: kind:"externality" appears verbatim.
+        assert!(
+            json.contains(r#""kind":"externality""#),
+            "expected externally-tagged Externality, got {json}"
+        );
+    }
+
+    #[test]
+    fn pigouvian_rate_update_edge_round_trips_json() {
+        let p = pod();
+        let child = p.derive_artifact(b"rate-update-window-42").unwrap();
+        let edge = LineageEdge::from_parent(
+            child,
+            p,
+            EdgeKind::PigouvianRateUpdate {
+                resource: "gpu_s".to_string(),
+                rate_micro_usd_per_unit: 5,
+                window_unix_micros: 1_700_000_000_000_000,
+            },
+        );
+        let json = serde_json::to_string(&edge).unwrap();
+        let back: LineageEdge = serde_json::from_str(&json).unwrap();
+        assert_eq!(edge, back);
+        assert!(json.contains(r#""kind":"pigouvian_rate_update""#));
+    }
+
+    #[test]
+    fn welfare_rebate_edge_round_trips_json() {
+        let p = pod();
+        let child = p.derive_artifact(b"rebate-tx-1").unwrap();
+        let edge = LineageEdge::from_parent(
+            child,
+            p,
+            EdgeKind::WelfareRebate {
+                recipient_kid: "witness-peer-1".to_string(),
+                micro_usd: 1_250_000,
+                source_externality_edge_hash: "f".repeat(64),
+            },
+        );
+        let json = serde_json::to_string(&edge).unwrap();
+        let back: LineageEdge = serde_json::from_str(&json).unwrap();
+        assert_eq!(edge, back);
+        assert!(json.contains(r#""kind":"welfare_rebate""#));
+    }
+
+    #[test]
+    fn pigouvian_variants_have_distinct_kind_tags() {
+        // kind_tag distinguishes the variants in canonical signing
+        // bytes — a collision would let a hostile producer swap an
+        // Externality claim for a WelfareRebate of the same shape.
+        use crate::proof::canonical_edge_bytes;
+        let p = pod();
+        let ext = LineageEdge::from_parent(
+            p.derive_artifact(b"ext").unwrap(),
+            p.clone(),
+            EdgeKind::Externality {
+                resource: "gpu_s".to_string(),
+                oracle_kid: "k1".to_string(),
+            },
+        );
+        let rate = LineageEdge::from_parent(
+            p.derive_artifact(b"rate").unwrap(),
+            p.clone(),
+            EdgeKind::PigouvianRateUpdate {
+                resource: "gpu_s".to_string(),
+                rate_micro_usd_per_unit: 5,
+                window_unix_micros: 1_700_000_000_000_000,
+            },
+        );
+        let rebate = LineageEdge::from_parent(
+            p.derive_artifact(b"rebate").unwrap(),
+            p,
+            EdgeKind::WelfareRebate {
+                recipient_kid: "w1".to_string(),
+                micro_usd: 100,
+                source_externality_edge_hash: "0".repeat(64),
+            },
+        );
+        let bytes_ext = canonical_edge_bytes(&ext, None);
+        let bytes_rate = canonical_edge_bytes(&rate, None);
+        let bytes_rebate = canonical_edge_bytes(&rebate, None);
+        assert_ne!(bytes_ext, bytes_rate);
+        assert_ne!(bytes_ext, bytes_rebate);
+        assert_ne!(bytes_rate, bytes_rebate);
     }
 }

--- a/crates/nucleus-lineage/src/lib.rs
+++ b/crates/nucleus-lineage/src/lib.rs
@@ -59,7 +59,7 @@ pub use checkpoint::{
 #[cfg(feature = "http")]
 pub use cosign::{C2spHttpWitnessClient, HttpWitnessClient};
 pub use cosign::{Cosignature, CosignatureKind, InProcessWitness, WitnessClient};
-pub use edge::{EdgeKind, LineageEdge, SourceClass};
+pub use edge::{EdgeKind, LineageEdge, SourceClass, VerifierAttestation};
 pub use id::{CallSpiffeId, IdError, MAX_URI_LEN};
 pub use issuer::{EdgeSigner, IdentityFetcher, IssuerError, SvidClaims};
 pub use merkle::{read_checkpoints, verify_log, MerkleConfig, MerkleError, MerkleSink};
@@ -71,8 +71,13 @@ pub use signed_note::{
     parse_signature_line, validate_key_name, validate_origin, ParsedSignatureLine, SignedNoteError,
     MAX_KEY_NAME_LEN, MAX_ORIGIN_LEN, SIG_LINE_PREFIX, SIG_TYPE_COSIGNATURE, SIG_TYPE_ED25519,
 };
-pub use sink::{InMemorySink, JsonlSink, LineageSink, SinkError};
-pub use verify::{verify_chain, verify_proof, Jwk, Jwks, StaticKeyResolver, VerifyError};
+#[cfg(feature = "sink-io")]
+pub use sink::JsonlSink;
+pub use sink::{InMemorySink, LineageSink, SinkError};
+pub use verify::{
+    total_pigouvian_micro_usd, verify_chain, verify_proof, Jwk, Jwks, StaticKeyResolver,
+    VerifyError,
+};
 
 #[cfg(feature = "insecure-local-issuer")]
 pub use local_issuer::LocalIssuer;

--- a/crates/nucleus-lineage/src/proof.rs
+++ b/crates/nucleus-lineage/src/proof.rs
@@ -21,6 +21,22 @@
 //! 4. content hash (32 zero bytes if absent)
 //! 5. RFC3339 timestamp string, NUL-separated
 //! 6. previous edge's content hash from the proof chain (32 zero bytes if absent)
+//! 7. verifier-attestation block, **emitted only when
+//!    `edge.verifier_attestation` is `Some`**: a single NUL delimiter
+//!    followed by 6 NUL-terminated fields in this order —
+//!    `verifier_binary_hash`, `wasmtime_version`, `wasmtime_config_hash`,
+//!    `vrf_params_hash`, `external_snapshot_root`, `lean_spec_hash`. Absent
+//!    sub-fields emit the empty string (just their NUL terminator).
+//!
+//! **Additive-compatibility invariant.** When `verifier_attestation` is
+//! `None` (every pre-existing edge kind: `PodAdmit` / `ToolCall` /
+//! `LlmCall` / `ArtifactProduced` / `Merge` / `DocumentRetrieved` /
+//! `Other`), step 7 contributes NOTHING — the canonical bytes are
+//! byte-identical to the pre-attestation encoding. This is a deliberate
+//! divergence from the platform fork (which always appends a 7-byte VA
+//! footer): emitting the footer unconditionally would change the signed
+//! bytes of every legacy edge. Gating on `Some` keeps the merge purely
+//! additive while still binding the attestation when it is present.
 //!
 //! Field-bag attributes (`attrs`) are intentionally NOT covered — they are
 //! free-form metadata; the signed surface is the structural lineage edge.
@@ -111,6 +127,32 @@ pub fn canonical_edge_bytes(edge: &LineageEdge, prev_hash: Option<&[u8; 32]>) ->
         out.extend_from_slice(&[0u8; 32]);
     }
 
+    // Verifier-attestation block (added 2026-06). PURELY ADDITIVE: emitted
+    // ONLY when `verifier_attestation` is `Some`. Edges without an
+    // attestation (every pre-existing kind) produce byte-identical
+    // canonical bytes to the pre-attestation encoding — see the module-doc
+    // additive-compat invariant. When present: a single NUL delimiter then
+    // 6 NUL-terminated fields; absent sub-fields emit empty bytes.
+    //
+    // NOTE: this diverges from the platform fork, which appends the 7-byte
+    // footer unconditionally. Adopting that verbatim would change the
+    // signed bytes of legacy edges, breaking the additive invariant.
+    if let Some(va) = edge.verifier_attestation.as_ref() {
+        out.push(0);
+        let push_opt = |out: &mut Vec<u8>, s: Option<&str>| {
+            if let Some(v) = s {
+                out.extend_from_slice(v.as_bytes());
+            }
+            out.push(0);
+        };
+        push_opt(&mut out, va.verifier_binary_hash.as_deref());
+        push_opt(&mut out, va.wasmtime_version.as_deref());
+        push_opt(&mut out, va.wasmtime_config_hash.as_deref());
+        push_opt(&mut out, va.vrf_params_hash.as_deref());
+        push_opt(&mut out, va.external_snapshot_root.as_deref());
+        push_opt(&mut out, va.lean_spec_hash.as_deref());
+    }
+
     out
 }
 
@@ -133,6 +175,15 @@ fn kind_tag(kind: &EdgeKind) -> &'static str {
         EdgeKind::ArtifactProduced => "artifact_produced",
         EdgeKind::Merge => "merge",
         EdgeKind::DocumentRetrieved { .. } => "document_retrieved",
+        EdgeKind::Bid { .. } => "bid",
+        EdgeKind::Allocation { .. } => "allocation",
+        EdgeKind::ContractEvaluation { .. } => "contract_evaluation",
+        EdgeKind::Dispute { .. } => "dispute",
+        EdgeKind::MetricClaim { .. } => "metric_claim",
+        EdgeKind::Settlement { .. } => "settlement",
+        EdgeKind::Externality { .. } => "externality",
+        EdgeKind::PigouvianRateUpdate { .. } => "pigouvian_rate_update",
+        EdgeKind::WelfareRebate { .. } => "welfare_rebate",
         EdgeKind::Other { .. } => "other",
     }
 }
@@ -186,7 +237,7 @@ mod opt_hash_hex {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::edge::{EdgeKind, LineageEdge};
+    use crate::edge::{EdgeKind, LineageEdge, VerifierAttestation};
     use crate::id::CallSpiffeId;
 
     fn pod() -> CallSpiffeId {
@@ -306,5 +357,126 @@ mod tests {
         assert!(bytes
             .windows(7)
             .any(|w| w == b"agents/" || w == b"sa/code" || w.starts_with(b"spiffe:")));
+    }
+
+    // ── Additive-compatibility invariant ────────────────────────────────
+
+    /// **LOAD-BEARING.** The verifier-attestation merge is PURELY ADDITIVE:
+    /// an edge with `verifier_attestation: None` (every pre-existing kind:
+    /// PodAdmit/ToolCall/LlmCall/ArtifactProduced/Merge/DocumentRetrieved/
+    /// Other) MUST produce canonical bytes that END exactly at the 32-byte
+    /// prev_hash slot — i.e. byte-identical to the pre-attestation encoding.
+    ///
+    /// This is verified structurally: a VA=None edge's bytes have NO footer.
+    /// The bytes are reconstructed independently from the documented field
+    /// order (child, kind, parents, marker, content-hash, ts, prev_hash) and
+    /// compared for full equality. If a future change appends a footer to
+    /// VA=None edges, this test fails — that is the regression guard.
+    #[test]
+    fn va_none_edge_has_no_footer_and_matches_legacy_encoding() {
+        use chrono::TimeZone;
+        let p = pod();
+        let mut edge = LineageEdge::pod_admit(p);
+        edge.ts = chrono::Utc.timestamp_opt(1_700_000_000, 0).unwrap();
+        assert!(edge.verifier_attestation.is_none());
+
+        let bytes = canonical_edge_bytes(&edge, None);
+
+        // Recompute the legacy (pre-attestation) encoding by hand and assert
+        // full byte-equality. This pins the exact signed surface for every
+        // pre-existing edge kind.
+        let mut expected: Vec<u8> = Vec::new();
+        // child
+        expected.extend_from_slice(edge.child.as_str().as_bytes());
+        expected.push(0);
+        // kind tag (pod_admit)
+        expected.extend_from_slice(b"pod_admit");
+        expected.push(0);
+        // parents: none → just the empty marker NUL
+        expected.push(0);
+        // content hash: absent → 64 zero ASCII bytes, then NUL
+        expected.extend_from_slice(&[0u8; 64]);
+        expected.push(0);
+        // ts
+        expected.extend_from_slice(edge.ts.to_rfc3339().as_bytes());
+        expected.push(0);
+        // prev_hash: none → 32 zero bytes
+        expected.extend_from_slice(&[0u8; 32]);
+        // NO footer for VA=None.
+
+        assert_eq!(
+            bytes, expected,
+            "VA=None edge must produce byte-identical legacy canonical bytes \
+             (no attestation footer) — the additive-compat invariant"
+        );
+        // And the last 32 bytes are exactly the prev_hash slot (no trailing
+        // footer bytes after it).
+        let len = bytes.len();
+        assert_eq!(&bytes[len - 32..], &[0u8; 32]);
+    }
+
+    /// Toggling `verifier_attestation` from `None` to `Some(empty)` MUST
+    /// change the canonical bytes under the gated encoding (an empty-but-
+    /// present attestation adds the 7-byte footer). This is the deliberate
+    /// divergence from the platform fork's `empty_va_field_equivalent_to_none`
+    /// invariant: in the additive design, presence of the attestation object
+    /// is itself binding.
+    #[test]
+    fn va_some_empty_adds_seven_byte_footer() {
+        use chrono::TimeZone;
+        let p = pod();
+        let mut e_none = LineageEdge::pod_admit(p.clone());
+        e_none.ts = chrono::Utc.timestamp_opt(1_700_000_000, 0).unwrap();
+
+        let e_empty = e_none
+            .clone()
+            .with_verifier_attestation(VerifierAttestation::new());
+
+        let bytes_none = canonical_edge_bytes(&e_none, None);
+        let bytes_empty = canonical_edge_bytes(&e_empty, None);
+
+        assert_ne!(bytes_none, bytes_empty);
+        // Footer = 1 delimiter NUL + 6 empty fields × 1 NUL each = 7 bytes.
+        assert_eq!(bytes_empty.len(), bytes_none.len() + 7);
+        assert_eq!(&bytes_empty[bytes_empty.len() - 7..], &[0u8; 7]);
+        // The prefix (everything before the footer) is byte-identical to the
+        // VA=None encoding — additivity at the byte level.
+        assert_eq!(&bytes_empty[..bytes_none.len()], &bytes_none[..]);
+    }
+
+    /// A populated `VerifierAttestation` binds each field positionally: the
+    /// same hex value in different fields yields different canonical bytes,
+    /// and a populated attestation extends (never rewrites) the VA=None
+    /// prefix.
+    #[test]
+    fn va_some_populated_binds_fields_positionally() {
+        let p = pod();
+        let base = LineageEdge::from_parent(
+            p.derive_artifact(b"x").unwrap(),
+            p,
+            EdgeKind::MetricClaim {
+                metric_name: "gini".into(),
+                window_id: "2026-05".into(),
+            },
+        )
+        .with_content_hash("0".repeat(64));
+
+        let none_bytes = canonical_edge_bytes(&base, None);
+
+        let with_lean = base.clone().with_verifier_attestation(
+            VerifierAttestation::new().with_lean_spec_hash("a".repeat(64)),
+        );
+        let with_vrf = base.clone().with_verifier_attestation(
+            VerifierAttestation::new().with_vrf_params_hash("a".repeat(64)),
+        );
+
+        let b_lean = canonical_edge_bytes(&with_lean, None);
+        let b_vrf = canonical_edge_bytes(&with_vrf, None);
+
+        // Same value, different field → different bytes (positional binding).
+        assert_ne!(b_lean, b_vrf);
+        // Both extend the VA=None prefix verbatim.
+        assert_eq!(&b_lean[..none_bytes.len()], &none_bytes[..]);
+        assert_eq!(&b_vrf[..none_bytes.len()], &none_bytes[..]);
     }
 }

--- a/crates/nucleus-lineage/src/sink.rs
+++ b/crates/nucleus-lineage/src/sink.rs
@@ -4,9 +4,19 @@
 //! local lookup, and a [`JsonlSink`] that appends to a file (one JSON object
 //! per line, no rewrites). Larger deployments will plug in a remote sink
 //! (S3, Tigris, etc.) — the trait is the integration point.
+//!
+//! **Wasm-compatibility note (Nucleus P0 nucleus-wasm)**: `JsonlSink` uses
+//! `std::fs::{File, OpenOptions}` which is unavailable on
+//! `wasm32-unknown-unknown`. It's gated behind the default-on `sink-io`
+//! feature. Build nucleus-lineage with `default-features = false` for wasm
+//! targets; `InMemorySink` + the `LineageSink` trait + `SinkError` remain
+//! available unconditionally.
 
+#[cfg(feature = "sink-io")]
 use std::fs::{File, OpenOptions};
+#[cfg(feature = "sink-io")]
 use std::io::{BufRead, BufReader, BufWriter, Write};
+#[cfg(feature = "sink-io")]
 use std::path::PathBuf;
 use std::sync::{Mutex, RwLock};
 
@@ -18,6 +28,10 @@ use crate::id::CallSpiffeId;
 /// Errors a sink may surface.
 #[derive(Debug, Error)]
 pub enum SinkError {
+    /// `std::io::Error` only reachable when the `sink-io` feature is on
+    /// (i.e. native targets that include the file-backed `JsonlSink`).
+    /// On wasm32 the variant is unconstructable.
+    #[cfg(feature = "sink-io")]
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
     #[error("json error: {0}")]
@@ -87,18 +101,21 @@ impl LineageSink for InMemorySink {
 }
 
 // ────────────────────────────────────────────────────────────────────────
-// JsonlSink
+// JsonlSink — `std::fs`-bound, gated behind the `sink-io` feature so the
+// crate compiles to `wasm32-unknown-unknown` with `default-features = false`.
 
 /// Append-only sink writing one JSON object per line to a file.
 ///
 /// Open with `JsonlSink::open(path)`; the file is created if missing.
 /// Writes are serialized by an internal mutex; reads (`iter`) re-open the
 /// file fresh so they always see the latest contents.
+#[cfg(feature = "sink-io")]
 pub struct JsonlSink {
     path: PathBuf,
     writer: Mutex<BufWriter<File>>,
 }
 
+#[cfg(feature = "sink-io")]
 impl JsonlSink {
     pub fn open(path: impl Into<PathBuf>) -> Result<Self, SinkError> {
         let path = path.into();
@@ -114,6 +131,7 @@ impl JsonlSink {
     }
 }
 
+#[cfg(feature = "sink-io")]
 impl LineageSink for JsonlSink {
     fn emit(&self, edge: LineageEdge) -> Result<(), SinkError> {
         let line = serde_json::to_string(&edge)?;
@@ -197,6 +215,7 @@ mod tests {
         assert_eq!(sink.len().unwrap(), 32);
     }
 
+    #[cfg(feature = "sink-io")]
     #[test]
     fn jsonl_sink_appends_and_reads_back() {
         let dir = tempfile::tempdir().unwrap();
@@ -217,6 +236,7 @@ mod tests {
         assert_eq!(read_back[1].child, derived);
     }
 
+    #[cfg(feature = "sink-io")]
     #[test]
     fn jsonl_sink_re_open_sees_prior_writes() {
         let dir = tempfile::tempdir().unwrap();
@@ -232,6 +252,7 @@ mod tests {
         assert_eq!(edges[0].child, p);
     }
 
+    #[cfg(feature = "sink-io")]
     #[test]
     fn jsonl_sink_skips_blank_lines() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/nucleus-lineage/src/verify.rs
+++ b/crates/nucleus-lineage/src/verify.rs
@@ -304,6 +304,108 @@ impl Default for StaticKeyResolver {
     }
 }
 
+/// **Pigouvian W2 — total Pigouvian micro-USD aggregator.**
+///
+/// Walks a chain of signed lineage edges and sums every
+/// `EdgeKind::WelfareRebate.micro_usd` value (negative — disbursement
+/// outflow) and every `EdgeKind::Externality` attr
+/// `pigou_charge_micro_usd` (positive — tax inflow). The net is what
+/// the substrate's externality layer charged minus what it rebated;
+/// `0` for a chain with no Pigouvian activity.
+///
+/// Verifier SDKs (browser, CLI, agent) call this AFTER `verify_chain`
+/// returns `Ok(())` so the sum is over CRYPTOGRAPHICALLY-VERIFIED
+/// edges only.
+pub fn total_pigouvian_micro_usd(edges: &[crate::LineageEdge]) -> i128 {
+    let mut net: i128 = 0;
+    for edge in edges {
+        match &edge.kind {
+            crate::EdgeKind::Externality { .. } => {
+                if let Some(s) = edge.attrs.get("pigou_charge_micro_usd") {
+                    if let Ok(v) = s.parse::<u64>() {
+                        net = net.saturating_add(i128::from(v));
+                    }
+                }
+            }
+            crate::EdgeKind::WelfareRebate { micro_usd, .. } => {
+                net = net.saturating_sub(i128::from(*micro_usd));
+            }
+            _ => {}
+        }
+    }
+    net
+}
+
+/// Tests for surface that does NOT depend on the demo signer — these run
+/// under default features (the `tests` module below is gated behind
+/// `insecure-local-issuer` because it needs `LocalIssuer`).
+#[cfg(test)]
+mod pigouvian_tests {
+    use crate::edge::{EdgeKind, LineageEdge};
+    use crate::id::CallSpiffeId;
+
+    fn pod() -> CallSpiffeId {
+        CallSpiffeId::pod("prod.example.com", "agents", "coder").unwrap()
+    }
+
+    /// **W2 — total_pigouvian_micro_usd aggregator.**
+    /// Walks a chain with 1 Externality charge (750) and 2
+    /// WelfareRebates (300 + 250). Net = +750 - 300 - 250 = +200.
+    #[test]
+    fn total_pigouvian_micro_usd_sums_charges_minus_rebates() {
+        let p = pod();
+        let ext = LineageEdge::from_parent(
+            p.derive_artifact(b"ext").unwrap(),
+            p.clone(),
+            EdgeKind::Externality {
+                resource: "gpu_s".to_string(),
+                oracle_kid: "k1".to_string(),
+            },
+        )
+        .with_attr("pigou_charge_micro_usd", "750");
+        let rebate1 = LineageEdge::from_parent(
+            p.derive_artifact(b"r1").unwrap(),
+            p.clone(),
+            EdgeKind::WelfareRebate {
+                recipient_kid: "w1".to_string(),
+                micro_usd: 300,
+                source_externality_edge_hash: "f".repeat(64),
+            },
+        );
+        let rebate2 = LineageEdge::from_parent(
+            p.derive_artifact(b"r2").unwrap(),
+            p,
+            EdgeKind::WelfareRebate {
+                recipient_kid: "w2".to_string(),
+                micro_usd: 250,
+                source_externality_edge_hash: "f".repeat(64),
+            },
+        );
+        assert_eq!(
+            super::total_pigouvian_micro_usd(&[ext, rebate1, rebate2]),
+            200
+        );
+    }
+
+    #[test]
+    fn total_pigouvian_micro_usd_zero_on_empty_chain() {
+        assert_eq!(super::total_pigouvian_micro_usd(&[]), 0);
+    }
+
+    #[test]
+    fn total_pigouvian_micro_usd_ignores_unrelated_edges() {
+        let p = pod();
+        let edge = LineageEdge::from_parent(
+            p.derive_artifact(b"x").unwrap(),
+            p,
+            EdgeKind::ToolCall {
+                tool: "Bash".to_string(),
+            },
+        );
+        assert_eq!(super::total_pigouvian_micro_usd(&[edge]), 0);
+    }
+}
+
 #[cfg(test)]
 #[cfg(feature = "insecure-local-issuer")]
 mod tests {


### PR DESCRIPTION
**Consolidation step 2 (stacked on #1804).** Adds the platform fork's `cube` + `rebate` modules to public `nucleus-externality`, making it the canonical superset — additively, no existing public API removed.

- `cube.rs` (ExternalityCube/AggregateBucket/WindowId/PullbackError) + `rebate.rs` (emit_rebates/WitnessFederation/WitnessShare/RebateError + TOTAL_SHARE_BASIS_POINTS), copied verbatim + re-exported.
- `rebate` consumes the economic `EdgeKind` variants (Externality, WelfareRebate) added in #1804 — hence the stack.
- Adds `nucleus-lineage` path dep (externality → lineage; **no cycle** — lineage doesn't depend on externality, verified).
- **Keeps** public's existing-and-ahead surface: `assess_rung`/`AssuranceRung`, `verify_vca_claim_rung`, `min_assurance_rung`, the `WaterLitresConsumed` dim (public's `dim.rs` was already a superset — no port needed).

76 tests pass (default + all-features); clippy `-D warnings` clean; fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)