### PR TITLE
feat(creditworthiness): Tier-1 airdrop-optionality math — non-transferable recomputable standing

### DIFF
--- a/crates/nucleus-creditworthiness/src/eligibility.rs
+++ b/crates/nucleus-creditworthiness/src/eligibility.rs
@@ -1,0 +1,766 @@
+//! Airdrop **optionality** math — a pure, deterministic, recomputable projection
+//! of an identity's recompute-verified track record into a HYPOTHETICAL
+//! basis-point [`Allocation`].
+//!
+//! # What this IS
+//!
+//! A pure function ([`eligibility_snapshot`]) over the EXISTING recompute-gated
+//! credit hash chain ([`crate::ledger::LedgerEntry`]). For each identity it folds
+//! the [`CreditEvent`](crate::CreditEvent)s already sealed on the append-only
+//! chain into a single net **eligibility weight** (credits minus debits, floored
+//! at zero, optionally per-dimension-weighted, and time-rooted so earlier
+//! verified contribution roots a larger share). Eligible identities' weights are
+//! then normalized to integer basis points (summing to at most `10_000`) by exact
+//! largest-remainder apportionment — the same deterministic integer discipline as
+//! the Shapley split elsewhere in the substrate. Anyone can recompute the
+//! identical [`Allocation`] in the browser over the public chain (this module is
+//! WASM-pure: integer-only, no `std`-only or native dependencies beyond what
+//! `ledger.rs` already pulls in).
+//!
+//! It makes the statement *"early verifiable contribution MAY be recognized
+//! later"* **credible via recomputable math** — nothing more.
+//!
+//! # What this IS NOT — read this before reasoning about it as value
+//!
+//! This is **NOT a token**. It is **NOT a transferable balance**. It is **NOT a
+//! security**. It is **NOT for sale**. It is **NOT a promise, right, or claim** to
+//! any future distribution of anything. An [`Allocation`] **confers nothing**: it
+//! is identity-bound, **non-transferable**, consumptive / reputational standing
+//! only. There is deliberately **no transfer / move / mint API** on
+//! [`Allocation`] — it is a plain, read-only data structure (`identity -> bps`).
+//!
+//! The basis points are **abstract units** (math, not money). No price, no
+//! appreciation, no profit, no distribution is promised or implied anywhere. The
+//! *exercise* of any optionality — any actual distribution of value, any
+//! transferable token, any on-chain mint, any sale — is an explicit,
+//! securities-counsel-gated **one-way door that is OUT OF SCOPE here and is NOT
+//! built**. This module builds ONLY the optionality math.
+//!
+//! # Why the math is the anti-farming guarantee
+//!
+//! Eligibility derives ONLY from recompute-gated [`CreditEvent`]s already on the
+//! append-only chain — there is **no new accrual path**. The economic magnitude
+//! (`weight_micro`) of every event was already recompute-verified from DECLARED
+//! inputs (so it cannot be inflated by the very lie that the recompute catches),
+//! and a [`SnapshotParams::min_distinct_receipts`] **Sybil-floor** requires an
+//! identity to carry at least that many *distinct* receipt hashes before it is
+//! eligible at all — one replayed receipt cannot farm standing. Greed is therefore
+//! satisfiable ONLY by doing real, recompute-verified work: greed pulls agents in,
+//! proof keeps them honest.
+//!
+//! # Honesty boundary (TCB / do NOT overclaim)
+//!
+//! This is a **recomputable projection** over already-verified events, not a
+//! guarantee of anything. Garbage events in, garbage projection out — feed it only
+//! chains whose entries were minted from receipts that already recomputed (see
+//! [`crate::mint`]) and verified with [`crate::ledger::verify_chain`]. This module
+//! does the *projection*; it does not itself verify receipts or chains. The chain
+//! is tamper-EVIDENT, not a non-equivocating transparency log (see the
+//! [`crate::ledger`] honesty boundary). The time-rooting curve and per-dimension
+//! weights are governed parameters, not theorems: they shape *which* recomputable
+//! projection is taken, and the projection is reproducible byte-for-byte given the
+//! same chain and the same [`SnapshotParams`].
+
+use crate::{CreditDimension, Polarity};
+
+use crate::ledger::LedgerEntry;
+use std::collections::{BTreeMap, BTreeSet};
+
+/// The number of basis points in a whole (100% = `10_000` bps). An
+/// [`Allocation`] sums to at most this value.
+pub const BPS_DENOMINATOR: u32 = 10_000;
+
+/// Per-dimension multiplier applied to an event's `weight_micro` before it is
+/// summed into the eligibility weight. Fixed-point: the multiplier is
+/// `numer / DIM_WEIGHT_DENOM`, so `DIM_WEIGHT_DENOM` itself means "×1".
+///
+/// Integer fixed-point keeps the whole computation deterministic and WASM-pure;
+/// there is no floating point anywhere in this module.
+pub const DIM_WEIGHT_DENOM: u64 = 1_000;
+
+/// Parameters that pin down *which* recomputable projection [`eligibility_snapshot`]
+/// takes. The snapshot is a pure function of `(chains, params)`: the same inputs
+/// always yield the identical [`Allocation`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SnapshotParams {
+    /// Sybil-floor: an identity is eligible only if its chain carries at least
+    /// this many **distinct** recompute receipt hashes. `1` admits any identity
+    /// with a single verified receipt; raising it makes one-replayed-receipt
+    /// farming impossible. A value of `0` is treated as `1` (a non-empty,
+    /// recompute-verified history is always required — empty never qualifies).
+    pub min_distinct_receipts: u32,
+
+    /// Per-dimension fixed-point multiplier (`numer / DIM_WEIGHT_DENOM`) applied
+    /// to each event's `weight_micro`. A dimension absent from this map defaults
+    /// to `DIM_WEIGHT_DENOM` (×1). Lets governance weight, e.g., externality
+    /// internalization differently from financial settlement when projecting
+    /// standing — without changing how the events themselves were verified.
+    pub dimension_weight: BTreeMap<CreditDimension, u64>,
+
+    /// Time-rooting half-life, in chain positions (`seq`). The event at the head
+    /// of the curve (the earliest *eligible-relative* position, see below) gets
+    /// full weight; an event `half_life` positions later gets ~half; `2 *
+    /// half_life` later ~a quarter; and so on. `0` disables time-rooting (every
+    /// position weighted equally). Earlier verified contribution — the
+    /// time-scarce, backdated-unforgeable track record — therefore roots a
+    /// larger share.
+    pub time_root_half_life: u64,
+}
+
+impl Default for SnapshotParams {
+    /// A conservative default: require 2 distinct receipts (kills the cheapest
+    /// single-receipt-replay Sybil), weight every dimension ×1, and root time at
+    /// a 64-position half-life.
+    fn default() -> Self {
+        Self {
+            min_distinct_receipts: 2,
+            dimension_weight: BTreeMap::new(),
+            time_root_half_life: 64,
+        }
+    }
+}
+
+impl SnapshotParams {
+    /// The effective Sybil-floor (`min_distinct_receipts`, but never below 1: an
+    /// empty / zero-receipt identity is never eligible).
+    fn effective_floor(&self) -> u32 {
+        self.min_distinct_receipts.max(1)
+    }
+
+    /// The fixed-point dimension multiplier for `dim` (defaults to ×1).
+    fn dim_mult(&self, dim: CreditDimension) -> u64 {
+        self.dimension_weight
+            .get(&dim)
+            .copied()
+            .unwrap_or(DIM_WEIGHT_DENOM)
+    }
+}
+
+/// A HYPOTHETICAL, NON-TRANSFERABLE allocation of abstract basis points across
+/// identities.
+///
+/// # NOT a token — read [the module docs](self)
+///
+/// This is a plain, read-only mapping `identity -> bps`. It is **not** a token,
+/// **not** a transferable balance, **not** a security, **not** for sale, and
+/// confers **no right, claim, or promise** to any distribution of value. There is
+/// deliberately no transfer / move / mint method. The basis points are abstract
+/// math (sum ≤ [`BPS_DENOMINATOR`]); they are a recomputable projection of
+/// recompute-verified standing, nothing more.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Allocation {
+    /// Eligible identity → basis points. Identities below the Sybil-floor, or
+    /// with zero net eligibility weight, are absent (not present with `0`), so
+    /// the structure is canonical regardless of input order. `BTreeMap` keeps the
+    /// iteration order deterministic for any consumer.
+    bps: BTreeMap<String, u32>,
+}
+
+impl Allocation {
+    /// Basis points apportioned to `identity` (`0` if absent / ineligible).
+    pub fn bps_of(&self, identity: &str) -> u32 {
+        self.bps.get(identity).copied().unwrap_or(0)
+    }
+
+    /// Iterate `(identity, bps)` in deterministic (sorted-by-identity) order.
+    pub fn iter(&self) -> impl Iterator<Item = (&str, u32)> {
+        self.bps.iter().map(|(k, v)| (k.as_str(), *v))
+    }
+
+    /// Number of eligible identities (those with non-zero bps).
+    pub fn len(&self) -> usize {
+        self.bps.len()
+    }
+
+    /// Whether no identity is eligible (e.g. empty / all-debit / all below the
+    /// Sybil-floor input).
+    pub fn is_empty(&self) -> bool {
+        self.bps.is_empty()
+    }
+
+    /// Total apportioned basis points (≤ [`BPS_DENOMINATOR`]). Less than the full
+    /// denominator only when there are zero eligible identities (then it is `0`).
+    pub fn total_bps(&self) -> u32 {
+        self.bps.values().copied().sum()
+    }
+}
+
+/// Saturating fixed-point product `weight_micro * (mult / DIM_WEIGHT_DENOM)`,
+/// in `u128` to keep headroom; saturates rather than wrapping.
+fn apply_dim_weight(weight_micro: u64, mult: u64) -> u128 {
+    (u128::from(weight_micro)).saturating_mul(u128::from(mult)) / u128::from(DIM_WEIGHT_DENOM)
+}
+
+/// The integer time-rooting factor for an event at relative position `rel`
+/// (0 = earliest eligible position) given `half_life`, as a fixed-point value
+/// over [`DIM_WEIGHT_DENOM`].
+///
+/// Non-increasing in `rel`: `factor(0) = DIM_WEIGHT_DENOM` (×1) and it halves
+/// every `half_life` positions via integer right-shifts plus a linear
+/// interpolation within a half-life window. `half_life == 0` returns
+/// `DIM_WEIGHT_DENOM` for every position (time-rooting disabled). Pure integer
+/// math — identical on every platform, including wasm32.
+fn time_root_factor(rel: u64, half_life: u64) -> u128 {
+    if half_life == 0 {
+        return u128::from(DIM_WEIGHT_DENOM);
+    }
+    let full_halvings = rel / half_life;
+    let within = rel % half_life;
+    // Base after `full_halvings` halvings: DENOM >> full_halvings (saturates to 0
+    // once we've shifted past the integer precision — deep-history events
+    // contribute a vanishing, non-negative share, never a larger one).
+    let base = if full_halvings >= 64 {
+        0u128
+    } else {
+        u128::from(DIM_WEIGHT_DENOM) >> full_halvings
+    };
+    if base == 0 {
+        return 0;
+    }
+    // Linearly interpolate down toward base/2 across the current half-life
+    // window, so the factor is monotone non-increasing *within* a window too
+    // (not a step function). step = (base - base/2) * within / half_life.
+    let next = base >> 1;
+    let span = base - next;
+    let dec = span.saturating_mul(u128::from(within)) / u128::from(half_life);
+    base - dec
+}
+
+/// One identity's raw, pre-normalization eligibility computation.
+struct RawStanding {
+    /// Net eligibility weight (credits − debits, floored at 0), after
+    /// per-dimension and time-rooting weighting.
+    weight: u128,
+    /// Count of DISTINCT recompute receipt hashes seen on the chain.
+    distinct_receipts: usize,
+}
+
+/// Fold one identity's contiguous, `seq`-ordered chain into its raw standing.
+///
+/// `entries` MUST be that identity's chain in `seq` order (as produced and
+/// verified by [`crate::ledger`]); the relative position used for time-rooting is
+/// the index within the supplied slice, so the **earliest** entry is rooted
+/// strongest. Distinct receipt hashes are counted for the Sybil-floor.
+fn fold_identity(entries: &[LedgerEntry], params: &SnapshotParams) -> RawStanding {
+    let mut receipts: BTreeSet<[u8; 32]> = BTreeSet::new();
+    let mut credit: u128 = 0;
+    let mut debit: u128 = 0;
+    for (rel, entry) in entries.iter().enumerate() {
+        let ev = &entry.event;
+        receipts.insert(ev.receipt_hash);
+        let dim_weighted = apply_dim_weight(ev.weight_micro, params.dim_mult(ev.dimension));
+        let factor = time_root_factor(rel as u64, params.time_root_half_life);
+        // weighted = dim_weighted * factor / DENOM (fixed-point), saturating.
+        let weighted = dim_weighted.saturating_mul(factor) / u128::from(DIM_WEIGHT_DENOM);
+        match ev.polarity {
+            Polarity::Credit => credit = credit.saturating_add(weighted),
+            Polarity::Debit => debit = debit.saturating_add(weighted),
+        }
+    }
+    RawStanding {
+        weight: credit.saturating_sub(debit),
+        distinct_receipts: receipts.len(),
+    }
+}
+
+/// Compute the HYPOTHETICAL, non-transferable basis-point [`Allocation`] over a
+/// set of identities' recompute-verified credit chains.
+///
+/// `identities` pairs each identity key with **its own** contiguous, `seq`-ordered
+/// [`crate::ledger::LedgerEntry`] chain (the same chains [`crate::ledger::verify_chain`]
+/// validates). For each identity this:
+///
+/// 1. counts DISTINCT receipt hashes and drops the identity if it carries fewer
+///    than the [`SnapshotParams`] Sybil-floor (one replayed receipt can't farm
+///    standing);
+/// 2. folds its events into a net eligibility weight = Σ(credit) − Σ(debit),
+///    floored at 0, with each event scaled by its per-dimension multiplier and a
+///    non-increasing time-rooting factor (earlier verified contribution roots a
+///    larger share);
+/// 3. drops identities whose net weight is 0 (all-debit / empty);
+/// 4. normalizes the surviving weights to exact integer basis points
+///    (sum ≤ [`BPS_DENOMINATOR`]) via largest-remainder apportionment.
+///
+/// The result is a **pure function** of `(identities, params)` and is invariant to
+/// the order in which identities are supplied — any verifier recomputes the
+/// identical [`Allocation`] from the same public chains.
+///
+/// # This is NOT a token / not a security / not for sale
+///
+/// See [the module docs](self): the returned [`Allocation`] confers no right,
+/// claim, or promise; it is non-transferable, abstract-unit standing only.
+pub fn eligibility_snapshot(
+    identities: &[(&str, &[LedgerEntry])],
+    params: &SnapshotParams,
+) -> Allocation {
+    let floor = params.effective_floor() as usize;
+
+    // Collect eligible (identity, raw weight) in deterministic key order so the
+    // apportionment tie-breaking is itself order-independent. Dedup by identity
+    // key: if the same key appears twice, the later slice replaces the earlier
+    // (callers should pass one chain per identity; this keeps the fn total).
+    let mut eligible: BTreeMap<String, u128> = BTreeMap::new();
+    for (id, entries) in identities {
+        let raw = fold_identity(entries, params);
+        if raw.distinct_receipts < floor {
+            continue; // below Sybil-floor
+        }
+        if raw.weight == 0 {
+            continue; // all-debit / empty net standing
+        }
+        eligible.insert((*id).to_string(), raw.weight);
+    }
+
+    apportion_bps(&eligible)
+}
+
+/// Largest-remainder (Hamilton) apportionment of `weights` into integer basis
+/// points summing to exactly [`BPS_DENOMINATOR`] (or `0` when there are no
+/// eligible identities / total weight is 0). Deterministic: remainders tie-break
+/// by descending remainder then ascending identity key, so the result is a pure
+/// function of the `(identity -> weight)` map.
+fn apportion_bps(weights: &BTreeMap<String, u128>) -> Allocation {
+    let total: u128 = weights
+        .values()
+        .copied()
+        .fold(0u128, |a, w| a.saturating_add(w));
+    if total == 0 || weights.is_empty() {
+        return Allocation::default();
+    }
+
+    let denom = u128::from(BPS_DENOMINATOR);
+
+    // Floor share + fractional remainder for each identity.
+    struct Share {
+        id: String,
+        floor_bps: u32,
+        // remainder numerator = (weight * denom) mod total, in [0, total).
+        rem: u128,
+    }
+    let mut shares: Vec<Share> = Vec::with_capacity(weights.len());
+    let mut allocated: u32 = 0;
+    for (id, &w) in weights {
+        let scaled = w.saturating_mul(denom);
+        let floor_bps = (scaled / total) as u32;
+        let rem = scaled % total;
+        allocated = allocated.saturating_add(floor_bps);
+        shares.push(Share {
+            id: id.clone(),
+            floor_bps,
+            rem,
+        });
+    }
+
+    // Distribute the leftover bps (denominator − allocated) one each to the
+    // largest remainders. Tie-break: larger remainder first, then smaller
+    // identity key (BTreeMap already gave us ascending key order; a stable sort
+    // by descending remainder preserves that as the secondary key).
+    let mut leftover = BPS_DENOMINATOR.saturating_sub(allocated);
+    let mut order: Vec<usize> = (0..shares.len()).collect();
+    order.sort_by(|&a, &b| {
+        shares[b]
+            .rem
+            .cmp(&shares[a].rem)
+            .then_with(|| shares[a].id.cmp(&shares[b].id))
+    });
+    for &i in &order {
+        if leftover == 0 {
+            break;
+        }
+        shares[i].floor_bps = shares[i].floor_bps.saturating_add(1);
+        leftover -= 1;
+    }
+
+    let mut bps = BTreeMap::new();
+    for s in shares {
+        if s.floor_bps > 0 {
+            bps.insert(s.id, s.floor_bps);
+        }
+    }
+    Allocation { bps }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::CreditEvent;
+    use proptest::prelude::*;
+
+    fn rh(seed: u8) -> [u8; 32] {
+        [seed; 32]
+    }
+
+    /// Build a well-formed `seq`-ordered chain for `id` from `(event)` list,
+    /// linking each entry to its predecessor exactly as the ledger does.
+    fn chain(id: &str, events: &[CreditEvent]) -> Vec<LedgerEntry> {
+        let mut out: Vec<LedgerEntry> = Vec::new();
+        for (seq, ev) in events.iter().enumerate() {
+            let prev = out.last().map(|e| e.this_hash);
+            out.push(LedgerEntry::new(
+                id.to_string(),
+                seq as u64,
+                *ev,
+                100 + seq as i64,
+                prev,
+            ));
+        }
+        out
+    }
+
+    /// Params with time-rooting disabled (so raw weights are easy to reason
+    /// about) and a Sybil-floor of 1.
+    fn flat_params(min_distinct: u32) -> SnapshotParams {
+        SnapshotParams {
+            min_distinct_receipts: min_distinct,
+            dimension_weight: BTreeMap::new(),
+            time_root_half_life: 0,
+        }
+    }
+
+    // ── Worked examples ─────────────────────────────────────────────────────
+
+    #[test]
+    fn empty_input_is_empty_allocation() {
+        let alloc = eligibility_snapshot(&[], &SnapshotParams::default());
+        assert!(alloc.is_empty());
+        assert_eq!(alloc.total_bps(), 0);
+    }
+
+    #[test]
+    fn all_debit_identity_is_not_eligible() {
+        let a = chain(
+            "a",
+            &[
+                CreditEvent::caught_defection(500, rh(1)),
+                CreditEvent::caught_defection(500, rh(2)),
+            ],
+        );
+        let alloc = eligibility_snapshot(&[("a", &a)], &flat_params(1));
+        assert!(alloc.is_empty());
+        assert_eq!(alloc.bps_of("a"), 0);
+    }
+
+    #[test]
+    fn single_eligible_identity_gets_full_allocation() {
+        let a = chain(
+            "a",
+            &[
+                CreditEvent::honest_settlement(1000, rh(1)),
+                CreditEvent::honest_settlement(1000, rh(2)),
+            ],
+        );
+        let alloc = eligibility_snapshot(&[("a", &a)], &flat_params(1));
+        assert_eq!(alloc.bps_of("a"), BPS_DENOMINATOR);
+        assert_eq!(alloc.total_bps(), BPS_DENOMINATOR);
+    }
+
+    #[test]
+    fn two_equal_identities_split_evenly() {
+        let a = chain(
+            "a",
+            &[
+                CreditEvent::honest_settlement(1000, rh(1)),
+                CreditEvent::honest_settlement(1000, rh(2)),
+            ],
+        );
+        let b = chain(
+            "b",
+            &[
+                CreditEvent::honest_settlement(1000, rh(3)),
+                CreditEvent::honest_settlement(1000, rh(4)),
+            ],
+        );
+        let alloc = eligibility_snapshot(&[("a", &a), ("b", &b)], &flat_params(1));
+        assert_eq!(alloc.bps_of("a"), 5000);
+        assert_eq!(alloc.bps_of("b"), 5000);
+        assert_eq!(alloc.total_bps(), BPS_DENOMINATOR);
+    }
+
+    #[test]
+    fn sybil_floor_excludes_single_distinct_receipt() {
+        // Two events but the SAME receipt hash replayed → 1 distinct receipt.
+        let a = chain(
+            "a",
+            &[
+                CreditEvent::honest_settlement(1000, rh(7)),
+                CreditEvent::honest_settlement(1000, rh(7)),
+            ],
+        );
+        // floor=2 excludes it; floor=1 admits it.
+        let excluded = eligibility_snapshot(&[("a", &a)], &flat_params(2));
+        assert!(excluded.is_empty());
+        let admitted = eligibility_snapshot(&[("a", &a)], &flat_params(1));
+        assert_eq!(admitted.bps_of("a"), BPS_DENOMINATOR);
+    }
+
+    #[test]
+    fn debit_reduces_eligibility_share() {
+        // a has a debit eating into its credit; b is clean. b should get more.
+        let a = chain(
+            "a",
+            &[
+                CreditEvent::honest_settlement(1000, rh(1)),
+                CreditEvent::caught_defection(800, rh(2)),
+            ],
+        );
+        let b = chain(
+            "b",
+            &[
+                CreditEvent::honest_settlement(1000, rh(3)),
+                CreditEvent::honest_settlement(0, rh(4)),
+            ],
+        );
+        let alloc = eligibility_snapshot(&[("a", &a), ("b", &b)], &flat_params(1));
+        // a net = 200, b net = 1000 → b > a.
+        assert!(alloc.bps_of("b") > alloc.bps_of("a"));
+        assert_eq!(alloc.total_bps(), BPS_DENOMINATOR);
+    }
+
+    #[test]
+    fn time_rooting_favors_earlier_contribution() {
+        // Same total credit, but identity `early` did its work at the head of the
+        // chain (positions 0..) and `late` padded the head with tiny events so its
+        // big credit lands at a later position. With time-rooting on, `early`'s
+        // big early credit should root a strictly larger share.
+        let early = chain(
+            "early",
+            &[
+                CreditEvent::honest_settlement(1_000_000, rh(1)),
+                CreditEvent::honest_settlement(1, rh(2)),
+            ],
+        );
+        let late = chain(
+            "late",
+            &[
+                CreditEvent::honest_settlement(1, rh(3)),
+                CreditEvent::honest_settlement(1_000_000, rh(4)),
+            ],
+        );
+        let params = SnapshotParams {
+            min_distinct_receipts: 1,
+            dimension_weight: BTreeMap::new(),
+            time_root_half_life: 1, // aggressive decay so position matters a lot
+        };
+        let alloc = eligibility_snapshot(&[("early", &early), ("late", &late)], &params);
+        assert!(
+            alloc.bps_of("early") > alloc.bps_of("late"),
+            "early={} late={}",
+            alloc.bps_of("early"),
+            alloc.bps_of("late")
+        );
+    }
+
+    #[test]
+    fn dimension_weight_scales_contribution() {
+        // Weight externality at 2x; an externality-credit identity then outranks
+        // an otherwise-equal financial-credit identity.
+        let fin = chain(
+            "fin",
+            &[
+                CreditEvent::honest_settlement(1000, rh(1)),
+                CreditEvent::honest_settlement(1000, rh(2)),
+            ],
+        );
+        let ext = chain(
+            "ext",
+            &[
+                CreditEvent::externality_internalized(1000, rh(3)),
+                CreditEvent::externality_internalized(1000, rh(4)),
+            ],
+        );
+        let mut dim = BTreeMap::new();
+        dim.insert(CreditDimension::Externality, 2 * DIM_WEIGHT_DENOM); // 2x
+        let params = SnapshotParams {
+            min_distinct_receipts: 1,
+            dimension_weight: dim,
+            time_root_half_life: 0,
+        };
+        let alloc = eligibility_snapshot(&[("fin", &fin), ("ext", &ext)], &params);
+        assert!(alloc.bps_of("ext") > alloc.bps_of("fin"));
+    }
+
+    #[test]
+    fn allocation_has_no_transfer_api() {
+        // Compile-time documentation: Allocation exposes only read accessors.
+        // (If a transfer/move/mint method were ever added, this test's intent —
+        // and the module's Howey-clean contract — would be violated.)
+        let a = chain(
+            "a",
+            &[
+                CreditEvent::honest_settlement(1, rh(1)),
+                CreditEvent::honest_settlement(1, rh(2)),
+            ],
+        );
+        let alloc = eligibility_snapshot(&[("a", &a)], &flat_params(1));
+        let _ = alloc.bps_of("a");
+        let _ = alloc.iter().count();
+        let _ = alloc.total_bps();
+        let _ = alloc.len();
+        let _ = alloc.is_empty();
+    }
+
+    // ── Property tests ───────────────────────────────────────────────────────
+
+    prop_compose! {
+        fn any_event()(
+            dim_sel in 0usize..2,
+            pol in any::<bool>(),
+            weight in 0u64..1_000_000,
+            seed in any::<u8>(),
+        ) -> CreditEvent {
+            CreditEvent {
+                dimension: CreditDimension::ALL[dim_sel],
+                polarity: if pol { Polarity::Credit } else { Polarity::Debit },
+                weight_micro: weight,
+                receipt_hash: [seed; 32],
+            }
+        }
+    }
+
+    fn events() -> impl Strategy<Value = Vec<CreditEvent>> {
+        proptest::collection::vec(any_event(), 0..16)
+    }
+
+    /// A small set of identities, each with its own event list.
+    fn identity_events() -> impl Strategy<Value = Vec<(String, Vec<CreditEvent>)>> {
+        proptest::collection::vec(("[a-e]{1,3}", events()), 0..6)
+    }
+
+    proptest! {
+        /// Determinism: same input → byte-identical Allocation.
+        #[test]
+        fn deterministic(ids in identity_events()) {
+            let chains: Vec<(String, Vec<LedgerEntry>)> =
+                ids.iter().map(|(id, evs)| (id.clone(), chain(id, evs))).collect();
+            let refs: Vec<(&str, &[LedgerEntry])> =
+                chains.iter().map(|(id, c)| (id.as_str(), c.as_slice())).collect();
+            let p = SnapshotParams::default();
+            let a1 = eligibility_snapshot(&refs, &p);
+            let a2 = eligibility_snapshot(&refs, &p);
+            prop_assert_eq!(a1, a2);
+        }
+
+        /// Permutation-invariance: shuffling the identity order yields an equal
+        /// Allocation. (Dedup by key, so we use distinct identity keys.)
+        #[test]
+        fn permutation_invariant(n in 0usize..6, seed in any::<u64>()) {
+            // Build n identities with distinct keys and fixed deterministic chains.
+            let mut chains: Vec<(String, Vec<LedgerEntry>)> = Vec::new();
+            for i in 0..n {
+                let id = format!("id{i}");
+                let evs = vec![
+                    CreditEvent::honest_settlement(100 * (i as u64 + 1), rh(i as u8)),
+                    CreditEvent::honest_settlement(50, rh((i as u8).wrapping_add(100))),
+                ];
+                chains.push((id.clone(), chain(&id, &evs)));
+            }
+            let refs: Vec<(&str, &[LedgerEntry])> =
+                chains.iter().map(|(id, c)| (id.as_str(), c.as_slice())).collect();
+            let p = SnapshotParams::default();
+            let base = eligibility_snapshot(&refs, &p);
+
+            // Deterministic shuffle: rotate + reverse.
+            let mut shuffled = refs.clone();
+            if !shuffled.is_empty() {
+                let k = (seed as usize) % shuffled.len();
+                shuffled.rotate_left(k);
+                shuffled.reverse();
+            }
+            let shuf = eligibility_snapshot(&shuffled, &p);
+            prop_assert_eq!(base, shuf);
+        }
+
+        /// Normalization: total bps is always ≤ BPS_DENOMINATOR, and equals it
+        /// whenever at least one identity is eligible.
+        #[test]
+        fn normalization_sums_to_denominator_or_zero(ids in identity_events()) {
+            let chains: Vec<(String, Vec<LedgerEntry>)> =
+                ids.iter().map(|(id, evs)| (id.clone(), chain(id, evs))).collect();
+            let refs: Vec<(&str, &[LedgerEntry])> =
+                chains.iter().map(|(id, c)| (id.as_str(), c.as_slice())).collect();
+            let alloc = eligibility_snapshot(&refs, &SnapshotParams::default());
+            prop_assert!(alloc.total_bps() <= BPS_DENOMINATOR);
+            if !alloc.is_empty() {
+                prop_assert_eq!(alloc.total_bps(), BPS_DENOMINATOR);
+            } else {
+                prop_assert_eq!(alloc.total_bps(), 0);
+            }
+        }
+
+        /// Sybil-floor: any identity with fewer than `floor` distinct receipts is
+        /// never present in the Allocation.
+        #[test]
+        fn sybil_floor_excludes_below_threshold(
+            evs in events(),
+            floor in 1u32..6,
+        ) {
+            let c = chain("solo", &evs);
+            let p = SnapshotParams {
+                min_distinct_receipts: floor,
+                dimension_weight: BTreeMap::new(),
+                time_root_half_life: 0,
+            };
+            let distinct: std::collections::BTreeSet<[u8;32]> =
+                evs.iter().map(|e| e.receipt_hash).collect();
+            let alloc = eligibility_snapshot(&[("solo", c.as_slice())], &p);
+            if distinct.len() < floor as usize {
+                prop_assert!(alloc.is_empty());
+            }
+        }
+
+        /// Monotonicity (raw weight): appending a CREDIT event to an identity's
+        /// chain never DECREASES its raw eligibility weight, ceteris paribus.
+        /// (Measured on raw fold weight — normalization is relative, so we test
+        /// the pre-normalization quantity the spec names.)
+        #[test]
+        fn adding_credit_never_decreases_raw_weight(
+            evs in events(),
+            extra in 0u64..1_000_000,
+            seed in any::<u8>(),
+        ) {
+            let p = SnapshotParams::default();
+            let before = fold_identity(&chain("x", &evs), &p).weight;
+            let mut evs2 = evs.clone();
+            evs2.push(CreditEvent::honest_settlement(extra, [seed; 32]));
+            let after = fold_identity(&chain("x", &evs2), &p).weight;
+            prop_assert!(after >= before);
+        }
+
+        /// Debit-reduces: appending a DEBIT event never INCREASES raw weight.
+        #[test]
+        fn adding_debit_never_increases_raw_weight(
+            evs in events(),
+            extra in 0u64..1_000_000,
+            seed in any::<u8>(),
+        ) {
+            let p = SnapshotParams::default();
+            let before = fold_identity(&chain("x", &evs), &p).weight;
+            let mut evs2 = evs.clone();
+            evs2.push(CreditEvent::caught_defection(extra, [seed; 32]));
+            let after = fold_identity(&chain("x", &evs2), &p).weight;
+            prop_assert!(after <= before);
+        }
+
+        /// Time-root factor is non-increasing in position (the early-mover
+        /// guarantee at the curve level).
+        #[test]
+        fn time_root_factor_non_increasing(a in 0u64..256, b in 0u64..256, hl in 0u64..64) {
+            let (lo, hi) = if a <= b { (a, b) } else { (b, a) };
+            prop_assert!(time_root_factor(lo, hl) >= time_root_factor(hi, hl));
+        }
+
+        /// All-debit / empty chains yield zero net weight (and thus no
+        /// allocation).
+        #[test]
+        fn all_debit_yields_zero_weight(weights in proptest::collection::vec(0u64..1_000_000, 0..12)) {
+            let evs: Vec<CreditEvent> = weights
+                .iter()
+                .enumerate()
+                .map(|(i, w)| CreditEvent::caught_defection(*w, rh(i as u8)))
+                .collect();
+            let p = SnapshotParams::default();
+            let raw = fold_identity(&chain("x", &evs), &p);
+            prop_assert_eq!(raw.weight, 0);
+        }
+    }
+}

--- a/crates/nucleus-creditworthiness/src/lib.rs
+++ b/crates/nucleus-creditworthiness/src/lib.rs
@@ -68,6 +68,12 @@ pub mod mint;
 /// durable [`store`] commits to and any client can re-verify.
 pub mod ledger;
 
+/// WASM-pure airdrop-**optionality** math: a pure, deterministic, recomputable
+/// projection of recompute-verified [`ledger`] history into a HYPOTHETICAL
+/// basis-point allocation. NOT a token, NOT transferable, NOT a security, NOT
+/// for sale — it confers no right, claim, or promise. See the module docs.
+pub mod eligibility;
+
 /// Durable, append-only, per-identity credit ledger backed by redb. Behind the
 /// off-by-default `persist` feature so the default + wasm32 builds never compile
 /// redb; the verifier service enables it.

--- a/docs/rfcs/standing-airdrop-optionality.md
+++ b/docs/rfcs/standing-airdrop-optionality.md
@@ -1,0 +1,153 @@
+# RFC: Standing airdrop optionality (Tier-1 non-transferable recomputable standing)
+
+**Status:** intent-on-record + shipped primitive (Tier-1 only). **Not a spec for
+any distribution; not a claim that anything will ever be distributed.**
+
+This RFC records the *math* and the *legal posture* of a pure, deterministic,
+recomputable function that projects an identity's already-recompute-verified
+track record into a HYPOTHETICAL basis-point allocation. The function is built
+(`crates/nucleus-creditworthiness/src/eligibility.rs`,
+`eligibility_snapshot`). Nothing downstream of the math — no token, no
+distribution, no sale — is built, and Tiers 2 and 3 below are explicitly
+deferred behind an operator + securities-counsel decision.
+
+Related: `regenerative-default-substrate.md`, `agent-efficiency-credit.md`,
+`receipt-provenance-defection.md`, `reputation-weighted-clearing.md`.
+
+---
+
+## ⚠️ Notice — read this first
+
+**This confers no right, claim, or promise. It is not a security. It is not for
+sale.**
+
+What this RFC describes is a *non-transferable standing* that **MAY** inform some
+future form of recognition. **No promise is made** that any recognition,
+distribution, value, or benefit of any kind will ever follow. The basis points
+are **abstract math** — units of a recomputable projection over a public hash
+chain — **not money, not a token, not a transferable balance, not an investment.**
+
+The implementation deliberately exposes **no transfer, move, or mint API**. An
+`Allocation` is a read-only `identity -> basis-points` map and nothing else.
+
+---
+
+## Why now
+
+"Early verifiable contribution may be recognized later" is a sentence everyone in
+this space says and nobody can make *credible* — it usually reduces to "trust the
+operator's future generosity." The substrate already has the one ingredient that
+makes it credible without a promise: a **recompute-verified, append-only credit
+hash chain** (`nucleus-creditworthiness::ledger`). Every `CreditEvent` on it was
+minted from a receipt that already recomputed, from DECLARED inputs, so its
+economic magnitude cannot be inflated by the very lie the recompute catches.
+
+So instead of *promising* future recognition, we ship the **math** of it: a pure
+function anyone can rerun, in the browser, over the public chain, to see exactly
+what standing each identity has rooted. The credibility comes from
+recomputability, not from a promise — and recomputability is exactly what keeps
+it Howey-clean.
+
+## The incentive logic (greed pulls in, proof keeps honest)
+
+The whole point is that the *only* way to increase your projected standing is to
+do real, recompute-verified work:
+
+- Eligibility derives **only** from recompute-gated `CreditEvent`s already on the
+  append-only chain. There is **no new accrual path** — the snapshot reads the
+  existing ledger, it does not let anyone mint standing a new way.
+- The magnitude of each event was already recompute-verified from declared
+  inputs, so it cannot be inflated by lying.
+- A **Sybil-floor** (`min_distinct_receipts`) requires an identity to carry at
+  least N *distinct* receipt hashes before it is eligible at all — one replayed
+  receipt cannot farm standing, and spinning up empty identities buys nothing
+  (empty / single-receipt → zero allocation).
+
+Therefore greed is satisfiable **only** by honest, verified contribution. Greed
+pulls agents in; proof keeps them honest. If eligibility could be farmed without
+verified work, that would be the extraction vector — so by construction it cannot.
+
+## The math (what the function actually does)
+
+`eligibility_snapshot(identities: &[(&str, &[LedgerEntry])], params: &SnapshotParams) -> Allocation`
+
+Per identity, over its contiguous `seq`-ordered chain:
+
+1. **Sybil-floor.** Count DISTINCT `receipt_hash`es; drop the identity if it has
+   fewer than `params.min_distinct_receipts` (clamped to ≥ 1, so an empty history
+   never qualifies).
+2. **Net verified standing.** Σ(credit `weight_micro`) − Σ(debit `weight_micro`),
+   floored at 0 (a deeply-defected identity has zero standing, never negative).
+3. **Per-dimension weighting.** Each event's weight is scaled by a governed,
+   fixed-point per-dimension multiplier (`params.dimension_weight`, default ×1).
+4. **Time-rooting / early-mover.** Each event is scaled by a factor that is
+   **non-increasing in its position** in the chain (a governed integer half-life,
+   `params.time_root_half_life`; `0` disables it). Earlier verified contribution —
+   the time-scarce, backdated-unforgeable track record — therefore roots a larger
+   share.
+5. **Normalization.** Surviving identities' weights are apportioned to exact
+   integer **basis points** (sum ≤ `10_000`) by largest-remainder (Hamilton)
+   apportionment — the same deterministic integer discipline as the Shapley split
+   elsewhere in the substrate.
+
+Properties proven as tests (`eligibility::tests`): determinism, permutation-
+invariance over identity order, monotonicity (adding a credit never lowers raw
+weight), debit-reduces-eligibility, Sybil-floor exclusion of single-distinct-
+receipt identities, normalization sums to ≤ 10 000 (= 10 000 iff anyone is
+eligible), and all-debit / empty → 0. The function is **integer-only and
+WASM-pure**: it compiles to `wasm32-unknown-unknown` exactly like `ledger.rs`, so
+anyone can recompute the identical allocation client-side over the public chain.
+
+## Honesty boundary (TCB)
+
+This is a **recomputable projection over already-verified events, not a
+guarantee.** The function does not itself verify receipts or chains — feed it
+only chains whose entries were minted from receipts that already recomputed
+(`mint`) and validated by `ledger::verify_chain`. The chain is **tamper-evident,
+not a non-equivocating transparency log** (an operator who controls the store can
+still equivocate; closing that gap — Merkle leaves + signed tree head + C2SP
+witness cosignatures — is tracked in the `ledger` honesty boundary). The
+time-rooting curve and per-dimension weights are **governed parameters, not
+theorems**: they choose *which* recomputable projection is taken; given the same
+chain and the same params the projection is reproducible byte-for-byte.
+
+## Tiered token stance
+
+This RFC ships **Tier 1 only.** Tiers 2 and 3 are recorded as intent/posture and
+are explicitly **not built here.**
+
+- **Tier 1 — non-transferable recomputable standing (THIS, now).** A pure
+  recomputable projection over the verified chain into abstract basis points.
+  Non-transferable, identity-bound, consumptive/reputational only. Confers no
+  right, claim, or promise. Not a security, not for sale. **Built.**
+
+- **Tier 2 — namespace-as-property (deferred).** Treating a claimed agent name /
+  identity as property with history (the ENS/`.com` lane), so reputation has a
+  durable home. Distinct posture; **not built here**; out of scope.
+
+- **Tier 3 — transferable token / actual distribution (deferred; one-way door).**
+  Any TRANSFERABLE token, any actual distribution of value, any on-chain mint,
+  any sale. This is a **securities-counsel + operator one-way door** that is
+  **explicitly out of scope** and **not built**. Exercising any optionality is
+  gated and not implemented; this RFC builds only the optionality math.
+
+## Bright lines (Howey) — never cross
+
+- **No capital raise.** Nothing here raises money or accepts investment.
+- **No sale of standing.** Standing is non-transferable and not for sale.
+- **No marketing of price appreciation.** No "moon," "investment," "buy now,"
+  "profit," "guaranteed," "will be worth," or any price-appreciation language
+  anywhere — in code, docs, or comms.
+- **No promise of distribution.** Standing **may** inform future recognition; no
+  promise is made that it will.
+- **No real funds / keys / mainnet / wallet** are touched. This is pure
+  computation over existing public data only.
+
+Framed strictly: *non-transferable standing that MAY inform future recognition;
+no promise is made; not a security; not for sale.*
+
+## What is deferred (one-way doors, out of scope here)
+
+Any transferable token, any actual distribution of value, any on-chain mint, any
+sale, and the Tier-2 namespace-as-property design. All gated behind an explicit
+operator + securities-counsel decision. None are built by this RFC.


### PR DESCRIPTION
Ships **Tier-1** of the token-as-adoption stance: a pure, deterministic, **recomputable** `eligibility_snapshot` over the existing recompute-verified credit hash chain that projects each identity's verified track record into a **hypothetical basis-point allocation** — *math, not money*.

## ⚠️ This confers no right, claim, or promise. Not a security. Not for sale.
Non-transferable standing that **MAY** inform future recognition; **no promise** is made. Basis points are abstract units of a recomputable projection over a public hash chain — **not a token, not a transferable balance, not an investment.** The `Allocation` type deliberately exposes **no transfer/move/mint API** (read-only `identity → bps`, private field).

## Why it's the right adoption lever
"Early verifiable contribution may be recognized later" is usually "trust the operator's future generosity." Here it's **recomputable math** anyone can rerun in-browser over the public chain — credible *without a promise*, which is exactly what keeps it Howey-clean. **Greed pulls agents in; proof keeps them honest:**
- Eligibility derives **only** from recompute-gated `CreditEvent`s already on the chain — **no new accrual path**; magnitude is from declared inputs (can't be inflated by the lie recompute catches).
- **Sybil-floor** (`min_distinct_receipts`): one replayed receipt / empty identities → **0 bps**. (Skeptic's adversarial repro: a single-replayed-receipt farm carrying 5M raw weight got 0; the honest 3-receipt identity got 100%.)

## The math
Per identity over its `seq`-ordered chain: Sybil-floor (distinct `receipt_hash` count) → net verified standing (Σcredit − Σdebit, floored at 0) → governed per-dimension weighting → **time-rooting** (non-increasing in chain position → earlier verified work roots a larger share) → largest-remainder apportionment to exact integer bps (sum ≤ 10 000). Integer-only, **WASM-pure** (`wasm32-unknown-unknown` clean, the exact `wasm-pure-crates.yml` invocation).

## Honesty boundary (TCB)
A recomputable **projection over already-verified events, not a guarantee.** It does not itself verify receipts/chains (feed it `mint` + `verify_chain` output); the chain is **tamper-evident, not a non-equivocating transparency log**; time-rooting curve + dimension weights are **governed params, not theorems**.

## Deferred (operator + securities-counsel one-way door — NOT built)
Tier-2 (namespace-as-property) and **Tier-3 (any transferable token / actual distribution / on-chain mint / sale)**. This PR builds only the optionality *math*. No real funds/keys/mainnet touched.

50 tests pass (incl. all eligibility proptests); clippy/fmt clean. Skeptic verdict: **SHIP** (all 8 securities/purity/non-transferability/recompute-gating criteria independently re-verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)