### PR TITLE
fix(kani): lower MSRV floor 1.95 → 1.93 to match Kani's bundled rustc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,15 @@ resolver = "2"
 [workspace.package]
 version = "1.0.0"
 edition = "2021"
-rust-version = "1.95"
+# MSRV floor is pinned to the rustc that Kani's bundled toolchain ships
+# (kani-verifier 0.67.0 — latest as of 2026-06 — bundles nightly = rustc
+# 1.93). `cargo kani` has no `--ignore-rust-version`, so a workspace floor
+# above 1.93 makes the Kani BMC job (`-p portcullis`) refuse to compile with
+# "rustc 1.93.0-nightly is not supported … requires rustc 1.95". Nothing in
+# this workspace uses a 1.94/1.95 lang/std feature (edition is 2021/2024,
+# which only need ≤1.85), so 1.93 is the honest floor. Raise this only once
+# Kani's bundled nightly catches up, and bump it together with Kani.
+rust-version = "1.93"
 license = "MIT OR Apache-2.0"
 authors = ["Coproduct <hello@coproduct.dev>"]
 repository = "https://github.com/coproduct-opensource/nucleus"

--- a/crates/ctf-engine/Cargo.toml
+++ b/crates/ctf-engine/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ctf-engine"
 version = "1.0.0"
 edition = "2021"
-rust-version = "1.95"
+rust-version = "1.93"
 license = "MIT OR Apache-2.0"
 description = "Browser-native CTF engine: can your AI agent exfiltrate from a formally verified sandbox?"
 

--- a/crates/ctf-mcp/Cargo.toml
+++ b/crates/ctf-mcp/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ctf-mcp"
 version = "1.0.0"
 edition = "2021"
-rust-version = "1.95"
+rust-version = "1.93"
 license = "MIT OR Apache-2.0"
 description = "MCP server for The Vault CTF — lets any AI agent play the security challenge"
 

--- a/crates/ctf-server/Cargo.toml
+++ b/crates/ctf-server/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ctf-server"
 version = "1.0.0"
 edition = "2021"
-rust-version = "1.95"
+rust-version = "1.93"
 license = "MIT OR Apache-2.0"
 description = "HTTP API server for The Vault CTF challenge"
 

--- a/crates/exposure-web/Cargo.toml
+++ b/crates/exposure-web/Cargo.toml
@@ -2,7 +2,7 @@
 name = "exposure-web"
 version = "1.0.0"
 edition = "2021"
-rust-version = "1.95"
+rust-version = "1.93"
 license = "MIT OR Apache-2.0"
 description = "Web-based interactive playground for the uninhabitable state prevention system"
 repository = "https://github.com/coproduct-opensource/nucleus"

--- a/crates/portcullis/Cargo.toml
+++ b/crates/portcullis/Cargo.toml
@@ -2,7 +2,7 @@
 name = "portcullis"
 version = "1.0.0"
 edition = "2021"
-rust-version = "1.95"
+rust-version = "1.93"
 license = "MIT OR Apache-2.0"
 description = "A quotient lattice for AI agent permissions that prevents the 'uninhabitable state'"
 repository = "https://github.com/coproduct-opensource/nucleus"

--- a/sdks/verifier-js/Cargo.toml
+++ b/sdks/verifier-js/Cargo.toml
@@ -2,7 +2,7 @@
 name = "nucleus-verifier-wasm"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.95"
+rust-version = "1.93"
 license = "MIT OR Apache-2.0"
 description = "WASM bindings for nucleus-envelope verification — runs in browser/Node, no trust in the verifier service"
 repository = "https://github.com/coproduct-opensource/nucleus"

--- a/sdks/verifier-py/Cargo.toml
+++ b/sdks/verifier-py/Cargo.toml
@@ -2,7 +2,7 @@
 name = "nucleus-verifier-py"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.95"
+rust-version = "1.93"
 license = "MIT OR Apache-2.0"
 description = "Python bindings for nucleus-envelope verification — runs in your backend, no trust in the verifier service"
 repository = "https://github.com/coproduct-opensource/nucleus"


### PR DESCRIPTION
## Problem

The **Kani** BMC check (the \`kani-fast\` job in \`.github/workflows/kani-nightly.yml\`, name \`Kani\`, which runs \`cargo kani -p portcullis\`) is **red on every PR and push**. Failure log:

\`\`\`
error: rustc 1.93.0-nightly is not supported by the following packages:
  portcullis@1.0.0 requires rustc 1.95
\`\`\`

## Root cause

\`model-checking/kani-github-action\` installs **kani-verifier 0.67.0** — the latest Kani release as of 2026-06 — whose bundled toolchain is **rustc 1.93-nightly**. The workspace \`Cargo.toml\` and several crates declared \`rust-version = "1.95"\`. \`cargo kani\` has **no \`--ignore-rust-version\`** flag, so cargo refuses to compile the proof crate and the job fails.

Kani is a non-required check (doesn't block merge), but it's red on every run — worth fixing.

## Fix chosen — option (a): lower the MSRV floor to 1.93

Lowered every \`rust-version = "1.95"\` declaration to \`1.93\`, the floor Kani's bundled rustc actually supports. This is honest (it doesn't fake-pass Kani) and minimal:

- Editions in this workspace are 2021 / 2024, which need only ≤ 1.85 — **no 1.94/1.95 lang/std feature is in use**.
- \`cargo check -p portcullis\` is **green** at the new floor locally.
- The sibling repo already runs Kani green at a 1.93 floor for the same reason.

### Options rejected

- **(b) pin a newer Kani whose bundled rustc ≥ 1.95** — impossible: 0.67.0 is the newest Kani release and Kani lags stable rustc by design.
- **(c) override the toolchain for the Kani step** — Kani deliberately uses its own bundled rustc to verify against the toolchain it was built for; there's no supported override, and forcing one would compromise what Kani actually checks.

## Files changed

- \`Cargo.toml\` — workspace \`rust-version\` 1.95 → 1.93, with a comment documenting the Kani-floor constraint.
- \`crates/portcullis/Cargo.toml\`, \`crates/ctf-engine\`, \`crates/ctf-mcp\`, \`crates/ctf-server\`, \`crates/exposure-web\` — hardcoded 1.95 → 1.93.
- \`sdks/verifier-js/Cargo.toml\`, \`sdks/verifier-py/Cargo.toml\` — 1.95 → 1.93 (floor uniformity; not built by Kani).

## Risk

Low. If CI surfaces an MSRV-dependent compile break at 1.93 (none expected — editions only need ≤ 1.85), fall back to scoping the Kani fast job to a dedicated proof crate whose dependency tree is independently floored at ≤ 1.93. This touches the workspace MSRV, so leaving auto-merge **off** for orchestrator review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)