### PR TITLE
ci: cache efficiency — warm rust-cache for the security audit job

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2.9.1
       - uses: actions-rust-lang/audit@72c09e02f132669d52284a3323acdb503cfc1a24 # v1
         with:
           denyWarnings: true


### PR DESCRIPTION
## Summary

CI-efficiency pass over the Rust workflows. Audited three candidate fixes; **only one was safe to apply** — the other two would have altered gate semantics or broken a compile-time dependency, so they were intentionally skipped (details below).

## Applied

### `audit.yml` — cache the audit tool build
The `audit` job (`actions-rust-lang/audit`) cold-builds `cargo-audit` on every run. Added a `Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2.9.1` step (the SHA pin already used by `dep-hygiene.yml`, `aeneas.yml`, `ck-policy-aeneas.yml`, `aeneas-oidc-spiffe.yml`, `aeneas-ifc-scoped.yml`) before the audit action.

- **Rationale:** the tool build is the dominant cost of this short job; restoring it from cache avoids a full recompile each run.
- **Est. savings:** ~1–3 min per audit run (cold cargo-audit build), across push/PR/merge_group/weekly-cron triggers.
- **Semantics:** unchanged — `denyWarnings: true` is preserved; same advisory gate.

## Skipped (for safety)

### `coverage-matrix.yml` — NOT merged into a single `cargo llvm-cov` run
The two coverage invocations are **not unifiable without changing the gate**:
- Run 1: `cargo llvm-cov --all-features` over the **whole workspace**, `--fail-under-lines 85`.
- Run 2: `cargo llvm-cov --all-features -p portcullis` (security-critical), `--fail-under-lines 87`.

`cargo llvm-cov` accepts only one `--fail-under-*` per invocation, applied to the merged scope. A single run cannot simultaneously enforce 85% workspace-wide AND 87% on portcullis specifically — collapsing them would weaken or alter both numeric gates. Per the conservative rule, left as-is. Caching is already warm via `setup-rust-toolchain` `cache: true`, and the second `-p portcullis` run reuses build artifacts from the first run's shared target dir.

### `ci.yml` clippy job — wasm-pack step NOT removed
The clippy job DOES depend on the wasm output. `crates/nucleus-verifier-service/src/routes.rs` resolves the artifacts at **compile time**:
```
const WASM_JS_SHIM: &str = include_str!("../../../sdks/verifier-js/pkg/nucleus_verifier_wasm.js");
... = include_bytes!("../../../sdks/verifier-js/pkg/nucleus_verifier_wasm_bg.wasm");
```
`cargo clippy --all-targets --all-features` compiles that crate, so the `sdks/verifier-js/pkg/` artifacts must exist or clippy fails with a file-not-found macro error. Removing the `wasm-pack build` step would break the clippy job. Left in place per the "if it depends on the wasm output, leave it" guard.

## Validation
YAML-only change; `audit.yml` parses as valid YAML. No local builds (per task) — CI will exercise the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)