### PR TITLE
ci(kani): pin kani-version + key toolchain cache on it (audit fix #1)

### DIFF
--- a/.github/workflows/kani-nightly.yml
+++ b/.github/workflows/kani-nightly.yml
@@ -40,10 +40,18 @@ jobs:
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ~/.kani
-          key: kani-toolchain-${{ runner.os }}-${{ hashFiles('.github/workflows/kani-nightly.yml') }}
+          # Key on the PINNED Kani version, NOT the workflow file: hashing the
+          # whole file re-downloaded the ~1 GB toolchain on every unrelated edit.
+          # Bump this suffix together with the `kani-version` input below when
+          # upgrading Kani.
+          key: kani-toolchain-${{ runner.os }}-kani-0.67.0
       - name: Run Kani (fast harnesses)
         uses: model-checking/kani-github-action@f838096619a707b0f6b2118cf435eaccfa33e51f # v1.1
         with:
+          # Pin the verifier version for reproducible proofs (default is
+          # "latest", which silently changes what Kani checks) and to make the
+          # toolchain cache key above stable. Bump both together.
+          kani-version: "0.67.0"
           args: >-
             -p portcullis
             --solver cadical
@@ -96,10 +104,18 @@ jobs:
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ~/.kani
-          key: kani-toolchain-${{ runner.os }}-${{ hashFiles('.github/workflows/kani-nightly.yml') }}
+          # Key on the PINNED Kani version, NOT the workflow file: hashing the
+          # whole file re-downloaded the ~1 GB toolchain on every unrelated edit.
+          # Bump this suffix together with the `kani-version` input below when
+          # upgrading Kani.
+          key: kani-toolchain-${{ runner.os }}-kani-0.67.0
       - name: Run Kani (constitutional kernel — fast tier)
         uses: model-checking/kani-github-action@f838096619a707b0f6b2118cf435eaccfa33e51f # v1.1
         with:
+          # Pin the verifier version for reproducible proofs (default is
+          # "latest", which silently changes what Kani checks) and to make the
+          # toolchain cache key above stable. Bump both together.
+          kani-version: "0.67.0"
           args: >-
             -p ck-kernel
             --solver cadical
@@ -134,10 +150,18 @@ jobs:
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ~/.kani
-          key: kani-toolchain-${{ runner.os }}-${{ hashFiles('.github/workflows/kani-nightly.yml') }}
+          # Key on the PINNED Kani version, NOT the workflow file: hashing the
+          # whole file re-downloaded the ~1 GB toolchain on every unrelated edit.
+          # Bump this suffix together with the `kani-version` input below when
+          # upgrading Kani.
+          key: kani-toolchain-${{ runner.os }}-kani-0.67.0
       - name: Run Kani (constitutional kernel — all harnesses)
         uses: model-checking/kani-github-action@f838096619a707b0f6b2118cf435eaccfa33e51f # v1.1
         with:
+          # Pin the verifier version for reproducible proofs (default is
+          # "latest", which silently changes what Kani checks) and to make the
+          # toolchain cache key above stable. Bump both together.
+          kani-version: "0.67.0"
           args: "-p ck-kernel --solver cadical"
       - name: Summary
         if: always()
@@ -164,10 +188,18 @@ jobs:
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ~/.kani
-          key: kani-toolchain-${{ runner.os }}-${{ hashFiles('.github/workflows/kani-nightly.yml') }}
+          # Key on the PINNED Kani version, NOT the workflow file: hashing the
+          # whole file re-downloaded the ~1 GB toolchain on every unrelated edit.
+          # Bump this suffix together with the `kani-version` input below when
+          # upgrading Kani.
+          key: kani-toolchain-${{ runner.os }}-kani-0.67.0
       - name: Run Kani (all harnesses)
         uses: model-checking/kani-github-action@f838096619a707b0f6b2118cf435eaccfa33e51f # v1.1
         with:
+          # Pin the verifier version for reproducible proofs (default is
+          # "latest", which silently changes what Kani checks) and to make the
+          # toolchain cache key above stable. Bump both together.
+          kani-version: "0.67.0"
           args: "-p portcullis --solver cadical"
       - name: Proof count regression gate
         run: |


### PR DESCRIPTION
**CI-efficiency audit fix #1 (top ROI).** The 4 Kani jobs in `kani-nightly.yml` cached `~/.kani` with key `hashFiles('.github/workflows/kani-nightly.yml')` — so *any* edit to the file (even a comment) invalidated the cache and re-downloaded the **~1 GB Kani toolchain** (~5–10 min/PR).

- **Cache key → pinned version:** `kani-toolchain-<os>-kani-0.67.0` instead of the workflow-file hash. Unrelated edits no longer bust it; an intentional Kani bump does.
- **Pin `kani-version: "0.67.0"`** on all 4 `kani-github-action` steps. The action defaulted to `latest`, which (a) silently changes what the verification gate checks (bad for a *proof* gate) and (b) makes a version-keyed cache meaningless. Pinning makes the proofs **reproducible**. Bump the version input + the cache-key suffix together when upgrading.

No behavior change today (`latest` == 0.67.0); first run on the new key is a one-time re-download, then warm. CI-config only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)