### PR TITLE
ci(kani): pin kani-version + key toolchain cache on it (audit fix #1, clean rebase)

### DIFF
--- a/.github/workflows/kani-nightly.yml
+++ b/.github/workflows/kani-nightly.yml
@@ -40,10 +40,18 @@ jobs:
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ~/.kani
-          key: kani-toolchain-${{ runner.os }}-${{ hashFiles('.github/workflows/kani-nightly.yml') }}
+          # Key on the PINNED Kani version, NOT the workflow file: hashing the
+          # whole file re-downloaded the ~1 GB toolchain on every unrelated edit.
+          # Bump this suffix together with the `kani-version` input below when
+          # upgrading Kani.
+          key: kani-toolchain-${{ runner.os }}-kani-0.67.0
       - name: Run Kani (fast harnesses)
         uses: model-checking/kani-github-action@f838096619a707b0f6b2118cf435eaccfa33e51f # v1.1
         with:
+          # Pin the verifier version for reproducible proofs (default is
+          # "latest", which silently changes what Kani checks) and to make the
+          # toolchain cache key above stable. Bump both together.
+          kani-version: "0.67.0"
           args: >-
             -p portcullis
             --solver cadical
@@ -96,10 +104,18 @@ jobs:
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ~/.kani
-          key: kani-toolchain-${{ runner.os }}-${{ hashFiles('.github/workflows/kani-nightly.yml') }}
+          # Key on the PINNED Kani version, NOT the workflow file: hashing the
+          # whole file re-downloaded the ~1 GB toolchain on every unrelated edit.
+          # Bump this suffix together with the `kani-version` input below when
+          # upgrading Kani.
+          key: kani-toolchain-${{ runner.os }}-kani-0.67.0
       - name: Run Kani (constitutional kernel — fast tier)
         uses: model-checking/kani-github-action@f838096619a707b0f6b2118cf435eaccfa33e51f # v1.1
         with:
+          # Pin the verifier version for reproducible proofs (default is
+          # "latest", which silently changes what Kani checks) and to make the
+          # toolchain cache key above stable. Bump both together.
+          kani-version: "0.67.0"
           args: >-
             -p ck-kernel
             --solver cadical
@@ -134,10 +150,18 @@ jobs:
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ~/.kani
-          key: kani-toolchain-${{ runner.os }}-${{ hashFiles('.github/workflows/kani-nightly.yml') }}
+          # Key on the PINNED Kani version, NOT the workflow file: hashing the
+          # whole file re-downloaded the ~1 GB toolchain on every unrelated edit.
+          # Bump this suffix together with the `kani-version` input below when
+          # upgrading Kani.
+          key: kani-toolchain-${{ runner.os }}-kani-0.67.0
       - name: Run Kani (constitutional kernel — all harnesses)
         uses: model-checking/kani-github-action@f838096619a707b0f6b2118cf435eaccfa33e51f # v1.1
         with:
+          # Pin the verifier version for reproducible proofs (default is
+          # "latest", which silently changes what Kani checks) and to make the
+          # toolchain cache key above stable. Bump both together.
+          kani-version: "0.67.0"
           args: "-p ck-kernel --solver cadical"
       - name: Summary
         if: always()
@@ -164,10 +188,18 @@ jobs:
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ~/.kani
-          key: kani-toolchain-${{ runner.os }}-${{ hashFiles('.github/workflows/kani-nightly.yml') }}
+          # Key on the PINNED Kani version, NOT the workflow file: hashing the
+          # whole file re-downloaded the ~1 GB toolchain on every unrelated edit.
+          # Bump this suffix together with the `kani-version` input below when
+          # upgrading Kani.
+          key: kani-toolchain-${{ runner.os }}-kani-0.67.0
       - name: Run Kani (all harnesses)
         uses: model-checking/kani-github-action@f838096619a707b0f6b2118cf435eaccfa33e51f # v1.1
         with:
+          # Pin the verifier version for reproducible proofs (default is
+          # "latest", which silently changes what Kani checks) and to make the
+          # toolchain cache key above stable. Bump both together.
+          kani-version: "0.67.0"
           args: "-p portcullis --solver cadical"
       - name: Proof count regression gate
         run: |


### PR DESCRIPTION
**CI-efficiency audit fix #1 (re-cut clean off current main).** Supersedes #1813, which was branched before the MSRV-floor fix (#1811) merged and couldn't be updated in place (branch protection blocks force-push + merge-commits).

The 4 Kani jobs cached `~/.kani` keyed on `hashFiles('kani-nightly.yml')` → any edit re-downloaded the ~1 GB toolchain (~5–10 min/PR). Fix:
- Key the cache on the pinned Kani version (`kani-toolchain-<os>-kani-0.67.0`) instead of the file hash.
- Pin `kani-version: "0.67.0"` on all 4 steps (was unpinned `latest` → silently changes what the proof gate verifies; pinning makes proofs reproducible). Bump version + key suffix together on upgrade.

Off current main (MSRV 1.93 floor), so the Kani job now passes too. CI-config only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)