### PR TITLE
ci(security): fix high-severity zizmor findings + add zizmor gate

### DIFF
--- a/.github/workflows/action-smoke-test.yml
+++ b/.github/workflows/action-smoke-test.yml
@@ -179,12 +179,15 @@ jobs:
 
       - name: Summary
         if: always()
+        env:
+          ISSUE_NUMBER: ${{ inputs.issue-number }}
+          PROFILE: ${{ inputs.profile }}
         run: |
           echo "## Action E2E Test — Live" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           if [ "${{ steps.gate.outputs.has_key }}" = "true" ]; then
-            echo "- **Issue:** #${{ inputs.issue-number }}" >> "$GITHUB_STEP_SUMMARY"
-            echo "- **Profile:** ${{ inputs.profile }}" >> "$GITHUB_STEP_SUMMARY"
+            echo "- **Issue:** #${ISSUE_NUMBER}" >> "$GITHUB_STEP_SUMMARY"
+            echo "- **Profile:** ${PROFILE}" >> "$GITHUB_STEP_SUMMARY"
             echo "- **Status:** Completed" >> "$GITHUB_STEP_SUMMARY"
           else
             echo "- **Status:** Skipped (no ANTHROPIC_API_KEY secret)" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/aeneas.yml
+++ b/.github/workflows/aeneas.yml
@@ -49,8 +49,10 @@ jobs:
       # --- Cache cargo registry + target for Charon's MIR extraction ---
       # Without this, Charon recompiles the portcullis_core crate and its
       # dependencies from scratch every run (~5-10 min).
+      # Cache-poisoning ignored: this workflow only checks formal proofs and
+      # publishes no artifacts (it merely also runs on `release published`).
       - name: Rust / cargo cache (Charon target dir)
-        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2.9.1
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2.9.1 # zizmor: ignore[cache-poisoning]
         with:
           workspaces: crates/portcullis-core
           key: charon-${{ env.CHARON_NIGHTLY }}-${{ env.AENEAS_RELEASE }}
@@ -58,9 +60,10 @@ jobs:
 
       # --- Cache the Aeneas pre-built binary tarball by release tag ---
       # The tarball is ~100 MB. Without caching, every run re-downloads it.
+      # Cache-poisoning ignored: formal-proof build only, no published artifacts.
       - name: Cache Aeneas binary
         id: cache-aeneas-bin
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5 # zizmor: ignore[cache-poisoning]
         with:
           path: /tmp/aeneas-bin
           key: aeneas-bin-${{ runner.os }}-${{ env.AENEAS_RELEASE }}
@@ -145,8 +148,9 @@ jobs:
             | sh -s -- -y --no-modify-path
           echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
 
+      # Cache-poisoning ignored: formal-proof build only, no published artifacts.
       - name: Cache Lake / Mathlib build artifacts
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5 # zizmor: ignore[cache-poisoning]
         with:
           path: |
             crates/portcullis-core/lean/.lake

--- a/.github/workflows/crates-publish.yml
+++ b/.github/workflows/crates-publish.yml
@@ -38,9 +38,11 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      # No cache restore here: this job publishes to crates.io, so it must
+      # build from scratch to avoid cache-poisoning of trust-bearing artifacts.
       - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1
         with:
-          cache: true
+          cache: false
       - name: Mint short-lived crates.io token (OIDC, no stored secret)
         uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4
         id: auth

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -8,7 +8,11 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
+    # github.actor is spoofable (it reflects the last actor, not the PR author).
+    # Per https://docs.zizmor.sh/audits/#bot-conditions, check the PR author and
+    # require the head repo to be this repo (no forks). Trigger is `pull_request`
+    # (not `pull_request_target`), per GitHub's automation guidance.
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == github.event.pull_request.head.repo.full_name
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,9 +26,11 @@ jobs:
             target: aarch64-apple-darwin
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      # No cache restore here: this job publishes release binaries, so it must
+      # build from scratch to avoid cache-poisoning of trust-bearing artifacts.
       - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1
         with:
-          cache: true
+          cache: false
       - name: Add cross-compilation target
         if: matrix.target == 'x86_64-apple-darwin'
         run: rustup target add x86_64-apple-darwin
@@ -66,9 +68,11 @@ jobs:
             target: x86_64-unknown-linux-musl
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      # No cache restore here: this job publishes release binaries/rootfs, so it
+      # must build from scratch to avoid cache-poisoning of trust-bearing artifacts.
       - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1
         with:
-          cache: true
+          cache: false
       - name: Install cross
         run: cargo install cross --git https://github.com/cross-rs/cross
       - name: Build nucleus-node (musl)
@@ -229,10 +233,12 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         if: ${{ steps.publish_gate.outputs.enabled == 'true' }}
+      # No cache restore here: this job publishes to crates.io, so it must
+      # build from scratch to avoid cache-poisoning of trust-bearing artifacts.
       - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1
         if: ${{ steps.publish_gate.outputs.enabled == 'true' }}
         with:
-          cache: true
+          cache: false
       - name: Publish nucleus-node
         if: ${{ steps.publish_gate.outputs.enabled == 'true' }}
         env:
@@ -288,9 +294,11 @@ jobs:
           path: tap
       - name: Write formula
         if: ${{ steps.brew_gate.outputs.enabled == 'true' }}
+        env:
+          VERSION: ${{ steps.shas.outputs.version }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          VERSION="${{ steps.shas.outputs.version }}"
-          BASE_URL="https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}"
+          BASE_URL="https://github.com/${{ github.repository }}/releases/download/${REF_NAME}"
           FORMULA_PATH="tap/Formula/nucleus-node.rb"
           cat > "${FORMULA_PATH}" <<EOF
           class NucleusNode < Formula

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,25 @@
+name: Zizmor (workflow security)
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+  merge_group:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: zizmor-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  zizmor:
+    name: zizmor (high+ gate)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      - name: Run zizmor (fail on high+ findings)
+        run: uvx zizmor==1.25.2 --min-severity high --no-progress .github/workflows/


### PR DESCRIPTION
Fixes all 11 high-severity [zizmor](https://docs.zizmor.sh/) findings in `.github/workflows/` and adds a CI gate so they cannot regress. Verified locally with zizmor 1.25.2: **11 high findings → 0**.

## Fixes by class

### template-injection → env indirection (3 findings)
- `action-smoke-test.yml` (Summary step): `${{ inputs.issue-number }}` / `${{ inputs.profile }}` interpolated directly into a `run:` block — now passed via `env:` and read as `"$VAR"` in the shell.
- `release.yml` (Write formula step): `${{ github.ref_name }}` (attacker-influenceable via crafted tag/branch names) — now passed via `env:`; `VERSION` moved to `env:` as well.

### cache-poisoning → no cache restore in publishing jobs (7 findings)
- `release.yml` (3 jobs: native binaries, musl/rootfs, crates.io publish) and `crates-publish.yml` (crates.io publish): these jobs produce trust-bearing artifacts, so cache restore is removed (`cache: false` on `setup-rust-toolchain`) — they build from scratch. A poisoned cache entry can otherwise smuggle code into released artifacts.
- `aeneas.yml` (3 cache steps): formal-proof builds that publish **no** artifacts (the workflow merely also runs on `release published`) — kept the caches with inline `# zizmor: ignore[cache-poisoning]` plus a reason comment.

### bot-conditions → unspoofable actor check (1 finding)
- `dependabot-automerge.yml`: `github.actor == 'dependabot[bot]'` is spoofable (last actor, not PR author). Replaced with the audit doc's recommended condition: `github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == github.event.pull_request.head.repo.full_name`. Trigger remains `pull_request` (not `pull_request_target`).

## New gate
- `zizmor.yml`: runs `uvx zizmor==1.25.2 --min-severity high --no-progress .github/workflows/` on `pull_request`, `merge_group`, and `push` to `main` — fails on high+ findings only. SHA-pinned actions, `contents: read`, 10-minute timeout, cancel-in-progress concurrency.

## Verification
- `uvx zizmor --min-severity high --no-progress .github/workflows/` → "No findings to report."
- All workflow YAML re-parsed cleanly (`yaml.safe_load` over `.github/workflows/*.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)