### PR TITLE
fix(portcullis): make narrow builds real — recover the lost #1827 fix + -D warnings gates

### DIFF
--- a/.github/workflows/feature-matrix.yml
+++ b/.github/workflows/feature-matrix.yml
@@ -58,5 +58,9 @@ jobs:
           # Must match [workspace.package] rust-version — the Kani
           # floor (cargo kani has no --ignore-rust-version escape).
           toolchain: "1.93"
+      # nucleus-verifier-service include_str!s the wasm-pack artifact
+      # (sdks/verifier-js/pkg/) that only the Tests job builds first;
+      # it is excluded here so the MSRV floor checks source, not
+      # generated-artifact presence.
       - name: Check workspace on the MSRV toolchain
-        run: cargo +1.93 check --workspace --all-features --locked
+        run: cargo +1.93 check --workspace --all-features --locked --exclude nucleus-verifier-service

--- a/crates/portcullis/src/certificate.rs
+++ b/crates/portcullis/src/certificate.rs
@@ -488,6 +488,7 @@ pub fn canonical_permissions_hash(perms: &PermissionLattice) -> Vec<u8> {
 
 impl AuthorityBlock {
     /// Compute the canonical payload for signing.
+    #[cfg(feature = "crypto")]
     fn signing_payload(&self) -> Vec<u8> {
         let mut payload = Vec::new();
         payload.extend_from_slice(b"lattice-cert-authority-v1:");
@@ -500,6 +501,7 @@ impl AuthorityBlock {
     }
 
     /// Compute the SHA-256 hash of this block (including the signature).
+    #[cfg(feature = "crypto")]
     fn block_hash(&self) -> Vec<u8> {
         let mut hasher = Sha256::new();
         hasher.update(self.signing_payload());
@@ -510,6 +512,7 @@ impl AuthorityBlock {
 
 impl DelegationBlock {
     /// Compute the canonical payload for signing.
+    #[cfg(feature = "crypto")]
     fn signing_payload(&self) -> Vec<u8> {
         let mut payload = Vec::new();
         payload.extend_from_slice(b"lattice-cert-delegation-v2:");
@@ -542,6 +545,7 @@ impl DelegationBlock {
     }
 
     /// Compute the SHA-256 hash of this block (including the signature).
+    #[cfg(feature = "crypto")]
     fn block_hash(&self) -> Vec<u8> {
         let mut hasher = Sha256::new();
         hasher.update(self.signing_payload());
@@ -798,6 +802,7 @@ impl LatticeCertificate {
     }
 
     /// Compute the proof-of-possession payload from a block hash.
+    #[cfg(feature = "crypto")]
     fn pop_payload_for_block_hash(block_hash: &[u8]) -> Vec<u8> {
         let mut payload = Vec::new();
         payload.extend_from_slice(b"lattice-cert-pop-v1:");

--- a/crates/portcullis/src/kernel.rs
+++ b/crates/portcullis/src/kernel.rs
@@ -895,12 +895,18 @@ impl Kernel {
         if let portcullis_core::flow::FlowVerdict::Deny(reason) = flow_decision.verdict {
             let receipt_str = graph
                 .build_receipt_for(flow_decision.node_id, now)
-                .map(|mut r| {
-                    // Sign the receipt if a signing key is available
+                .map(|r| {
+                    // Sign the receipt if a signing key is available.
+                    // (Rebound inside the cfg block so the non-crypto
+                    // build has no unused `mut` under -D warnings.)
                     #[cfg(feature = "crypto")]
-                    if let Some(ref key) = self.signing_key {
-                        crate::receipt_sign::sign_receipt(&mut r, key);
-                    }
+                    let r = {
+                        let mut r = r;
+                        if let Some(ref key) = self.signing_key {
+                            crate::receipt_sign::sign_receipt(&mut r, key);
+                        }
+                        r
+                    };
                     r.display_chain()
                 });
             let pre_hash = self.effective.checksum();

--- a/crates/portcullis/src/lattice.rs
+++ b/crates/portcullis/src/lattice.rs
@@ -215,6 +215,7 @@ impl<'de> Deserialize<'de> for PermissionLattice {
     }
 }
 
+#[cfg(feature = "serde")]
 fn default_uninhabitable_constraint() -> bool {
     true
 }

--- a/crates/portcullis/src/lib.rs
+++ b/crates/portcullis/src/lib.rs
@@ -103,7 +103,6 @@ pub mod constraint;
 pub mod uninhabitable_state;
 
 /// Kernel decision engine — complete mediation with monotone session state.
-#[cfg(feature = "serde")]
 pub mod delegation;
 pub mod dropout;
 /// Bash command egress analysis — detect network exfiltration.
@@ -158,7 +157,6 @@ pub mod receipt_sign;
 pub use receipt_sign::{receipt_hash, sign_receipt, verify_receipt};
 #[cfg(feature = "remote-audit")]
 pub mod s3_audit_backend;
-#[cfg(feature = "serde")]
 pub mod token;
 #[cfg(feature = "crypto")]
 /// Ed25519 signing and verification for declassification tokens.

--- a/crates/portcullis/src/token.rs
+++ b/crates/portcullis/src/token.rs
@@ -74,6 +74,9 @@
 //! assert_eq!(verified.chain_depth, 1);
 //! ```
 
+// chrono is only consumed by the crypto-gated verify path (and unit
+// tests, which exercise it); the token DATA type itself is time-free.
+#[cfg(any(test, feature = "crypto"))]
 use chrono::{DateTime, Utc};
 
 #[cfg(feature = "serde")]
@@ -83,9 +86,11 @@ use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "crypto")]
 use crate::certificate::verify_certificate;
-use crate::certificate::{
-    CertificateError, LatticeCertificate, VerifiedPermissions, DEFAULT_MAX_CHAIN_DEPTH,
-};
+use crate::certificate::{CertificateError, LatticeCertificate};
+// Sealed verification output + chain-depth default exist only on the
+// crypto-gated verify path.
+#[cfg(feature = "crypto")]
+use crate::certificate::{VerifiedPermissions, DEFAULT_MAX_CHAIN_DEPTH};
 
 /// A compact, self-contained attenuation token for wire transport.
 ///


### PR DESCRIPTION
## What happened

The merge queue took #1827 with **only its first commit** (the workflow file): the feature-matrix checks aren't *required* checks, so the armed auto-merge fired on the base commit while the portcullis fix commit was still being pushed — the push then silently recreated the just-deleted branch on a closed PR. Result: main has a feature-matrix gate that fails on every PR (currently failing #1831, which is Lean-only).

## What this PR does

Re-lands the lost fix and completes it under CI's `RUSTFLAGS=-D warnings` (which the earlier local verification omitted — the second gap):

- `delegation`/`token` module decls ungated from serde (kernel/certificate import them unconditionally; the modules are already internally `cfg_attr`-disciplined)
- receipt-signing closure rebinds inside `cfg(crypto)` (no unused `mut` in non-crypto builds)
- crypto-only imports/helpers gated at item level: chrono + `VerifiedPermissions`/`DEFAULT_MAX_CHAIN_DEPTH` (token.rs), `signing_payload`/`block_hash`/`pop_payload_for_block_hash` (certificate.rs)
- `default_uninhabitable_constraint` gated `cfg(serde)` (exists only for a `serde(default)` attribute)
- MSRV job excludes `nucleus-verifier-service` (it `include_str!`s the CI-built wasm artifact)

## Verification

`cargo hack --each-feature --no-dev-deps` with `RUSTFLAGS=-D warnings` green across all 8 gated crates; `portcullis --all-features` tests green (1009 + suites).

## Operator follow-up

Consider making `Feature Matrix` a **required check** so the queue can't outrun a fix again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)