### PR TITLE
chore(devx): CI-faithful 'just preflight' + worktree bootstrap script

### DIFF
--- a/justfile
+++ b/justfile
@@ -133,3 +133,13 @@ test:
 check:
     cargo fmt --all -- --check
     cargo clippy --all-targets --all-features -- -D warnings
+
+# CI-faithful preflight: `check` plus the Feature Matrix gate, under the SAME
+# env CI uses (actions-rust-lang/setup-rust-toolchain exports
+# RUSTFLAGS=-D warnings by default — a local run without it misses promoted
+# warnings and only finds out in CI). Crate list mirrors
+# .github/workflows/feature-matrix.yml; keep the two in sync.
+preflight: check
+    RUSTFLAGS="-D warnings" cargo hack check --each-feature --no-dev-deps \
+        -p portcullis -p portcullis-core -p nucleus-lineage -p nucleus-tool-proxy \
+        -p nucleus-ifc -p nucleus-envelope -p nucleus-identity -p nucleus-creditworthiness

--- a/scripts/new-worktree.sh
+++ b/scripts/new-worktree.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Bootstrap a git worktree that actually builds — fresh worktrees are missing
+# two things the long-lived checkout has, and both failure modes look like
+# unrelated errors hours later:
+#
+#   1. sdks/verifier-js/pkg/ (wasm-pack artifact): nucleus-verifier-service
+#      include_str!s it, so any workspace-wide build/hook fails without it.
+#   2. A warm target/: the pre-push hook's full-workspace test otherwise
+#      builds a fresh ~4.5G target/ per worktree (one disk-full incident on
+#      record).
+#
+# Usage: scripts/new-worktree.sh <branch> [base]   (base defaults to origin/main)
+set -euo pipefail
+
+branch="${1:?usage: scripts/new-worktree.sh <branch> [base]}"
+base="${2:-origin/main}"
+root="$(git rev-parse --show-toplevel)"
+wt_root="${WORKTREE_ROOT:-$(dirname "$root")/.worktrees}"
+wt_dir="$wt_root/$(basename "$root")-${branch//\//-}"
+
+git -C "$root" fetch origin --quiet
+git -C "$root" worktree add "$wt_dir" -b "$branch" "$base"
+
+if [ -d "$root/sdks/verifier-js/pkg" ]; then
+    cp -R "$root/sdks/verifier-js/pkg" "$wt_dir/sdks/verifier-js/pkg"
+else
+    echo "warn: $root/sdks/verifier-js/pkg not found — workspace-wide builds in the" >&2
+    echo "      worktree will fail until you run: wasm-pack build sdks/verifier-js" >&2
+fi
+
+cat <<DONE
+Worktree ready: $wt_dir
+
+Reminders (each learned the hard way):
+  - Share the warm build cache instead of growing a fresh 4.5G target/:
+        export CARGO_TARGET_DIR=$root/target
+    (or push with --no-verify after 'just preflight' — CI is authoritative)
+  - If the PR is auto-merge-armed, DISARM before pushing follow-up commits
+    (gh pr merge --disable-auto), then re-arm — the merge queue can take the
+    PR without them, and the late push silently recreates a dead branch.
+  - Never pipe 'git commit' through tail/head: the pipe eats the hook's
+    exit code and a failed commit looks like a success.
+  - When done: git worktree remove $wt_dir   (deletes its target/ too)
+DONE


### PR DESCRIPTION
Two structural fixes from today's retrospective:

1. **`just preflight`** — `check` plus the Feature Matrix cargo-hack run under `RUSTFLAGS=-D warnings`, matching what `actions-rust-lang/setup-rust-toolchain` exports in CI. Today this exact mismatch cost two CI round-trips (the portcullis narrow-build warnings passed locally, failed in CI). Crate list mirrors `feature-matrix.yml` with a keep-in-sync note.

2. **`scripts/new-worktree.sh`** — bootstraps a worktree that actually builds: copies the wasm-pack `pkg/` artifact (`nucleus-verifier-service` `include_str!`s it; fresh worktrees fail workspace-wide builds without it) and prints the operational reminders learned the hard way today (shared `CARGO_TARGET_DIR` vs a fresh 4.5G `target/` per worktree, disarm auto-merge before follow-up pushes, never pipe `git commit`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)