### PR TITLE
fix(lineage): gate the Mutex import behind sink-io — last red in the feature matrix

### DIFF
--- a/crates/nucleus-lineage/src/sink.rs
+++ b/crates/nucleus-lineage/src/sink.rs
@@ -18,7 +18,11 @@ use std::fs::{File, OpenOptions};
 use std::io::{BufRead, BufReader, BufWriter, Write};
 #[cfg(feature = "sink-io")]
 use std::path::PathBuf;
-use std::sync::{Mutex, RwLock};
+// Mutex guards the sink-io JsonlSink's writer; without that feature
+// only the RwLock-backed InMemorySink remains.
+#[cfg(feature = "sink-io")]
+use std::sync::Mutex;
+use std::sync::RwLock;
 
 use thiserror::Error;
 


### PR DESCRIPTION
One-liner follow-up to #1832: `Mutex` only guards the `sink-io` `JsonlSink` writer, so the no-default-features build flags it unused under CI's `-D warnings`. With this, `cargo hack --each-feature` is green across all 8 gated crates on current main.

(Found on the merge ref — CI checks branch+main merged while local pre-flight checks the branch. Reminder that **Feature Matrix still isn't a required check**: #1827 and #1832 both queued past it.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)