### PR TITLE
fix(ci): ck-aeneas ban-grep no longer matches its own documentation

### DIFF
--- a/.github/workflows/ck-policy-aeneas.yml
+++ b/.github/workflows/ck-policy-aeneas.yml
@@ -179,15 +179,24 @@ jobs:
         run: lake build CkPolicyAeneas
 
       # --- Ban proof holes in OUR file (NOT the Aeneas stdlib) ---
+      # Comments are stripped first: the file's own status docstrings say
+      # "0 native_decide" / describe the ban, and the previous bare
+      # `native_decide` alternation matched those comment lines (latent —
+      # this job only runs when its own paths change, so the self-match
+      # only surfaced via an actions-bump PR touching all workflows). The
+      # kernel-level backstop is the #print-axioms step below; this grep
+      # is the fast human-readable layer.
       - name: Ban sorry / admit / native_decide in our proof file
         run: |
-          if grep -rnE \
+          stripped="$(sed -e '/\/-/,/-\//d' -e 's/--.*$//' \
+               crates/ck-policy/lean-aeneas/CkPolicyAeneas.lean)"
+          if grep -nE \
                '(:=[[:space:]]*by[[:space:]]+sorry|:=[[:space:]]*sorry|^[[:space:]]*sorry$|:=[[:space:]]*by[[:space:]]+admit|^[[:space:]]*admit$|native_decide)' \
-               crates/ck-policy/lean-aeneas/CkPolicyAeneas.lean; then
+               <<<"$stripped"; then
             echo "ERROR: CkPolicyAeneas.lean uses 'sorry'/'admit'/'native_decide' (banned)."
             exit 1
           fi
-          echo "No sorry / admit / native_decide in CkPolicyAeneas.lean."
+          echo "No sorry / admit / native_decide in CkPolicyAeneas.lean (comments stripped)."
 
       - name: Assert theorems are sorryAx-free (#print axioms)
         working-directory: crates/ck-policy/lean-aeneas


### PR DESCRIPTION
The `native_decide` alternation in the ban-grep had no context anchor (the `sorry`/`admit` branches do), so it matched `CkPolicyAeneas.lean`'s own status docstrings ("**0 `native_decide`**", the ban description at lines 5/53/259/321) inside block comments. Latent because `ck-policy-aeneas.yml` only runs when its own paths change — it surfaced when dependabot's actions-bump #1820 touched every workflow and woke the job.

Fix: strip block (`/- … -/`) and line (`--`) comments before grepping. Verified locally: clean on the real file, and a genuine tactic use still matches. The `#print axioms` step remains the kernel-level backstop, so this grep is only the fast human-readable layer.

Unblocks #1820.

🤖 Generated with [Claude Code](https://claude.com/claude-code)