### PR TITLE
feat(verifier-js): verify nucleus-receipt envelopes in the WASM SDK

### DIFF
--- a/sdks/verifier-js/Cargo.lock
+++ b/sdks/verifier-js/Cargo.lock
@@ -18,6 +18,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -45,6 +57,20 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "blake3"
+version = "1.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures 0.3.0",
+]
 
 [[package]]
 name = "block-buffer"
@@ -112,6 +138,12 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "core-foundation-sys"
@@ -443,6 +475,7 @@ name = "nucleus-creditworthiness"
 version = "1.0.0"
 dependencies = [
  "hex",
+ "nucleus-econ-kernels",
  "nucleus-recompute",
  "nucleus-witness-olog",
  "serde",
@@ -522,6 +555,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "nucleus-receipt"
+version = "1.0.0"
+dependencies = [
+ "base64",
+ "blake3",
+ "ed25519-dalek",
+ "hex",
+ "serde",
+ "serde_json",
+ "serde_json_canonicalizer",
+ "thiserror",
+]
+
+[[package]]
 name = "nucleus-recompute"
 version = "1.0.0"
 dependencies = [
@@ -539,6 +586,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "console_error_panic_hook",
+ "ed25519-dalek",
  "getrandom 0.2.17",
  "hex",
  "nucleus-creditworthiness",
@@ -547,6 +595,7 @@ dependencies = [
  "nucleus-externality",
  "nucleus-ifc",
  "nucleus-lineage",
+ "nucleus-receipt",
  "nucleus-recompute",
  "nucleus-witness-olog",
  "serde",
@@ -654,6 +703,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu-js"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd29631678d6fb0903b69223673e122c32e9ae559d0960a38d574695ebc0ea15"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -720,6 +775,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_json_canonicalizer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe52319a927259afbfa5180c5157cd8167edfd3e8c254f9558c7fef44c5649f2"
+dependencies = [
+ "ryu-js",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/sdks/verifier-js/Cargo.toml
+++ b/sdks/verifier-js/Cargo.toml
@@ -36,6 +36,10 @@ nucleus-witness-olog = { path = "../../crates/nucleus-witness-olog" }
 # whole receipt→recompute→credit-file→bond flywheel, in-browser. Default
 # features include the `recompute` mint bridge.
 nucleus-creditworthiness = { path = "../../crates/nucleus-creditworthiness" }
+# The colimit receipt envelope (Session + Projection[] + Ed25519/BLAKE3 over
+# RFC 8785 canonical bytes). verifyReceipt runs the SAME Receipt::verify the
+# rest of the stack runs — one verifier code path for every receipt kind.
+nucleus-receipt = { path = "../../crates/nucleus-receipt" }
 wasm-bindgen = "0.2"
 serde-wasm-bindgen = "0.6"
 serde = { version = "1", features = ["derive"] }
@@ -61,3 +65,7 @@ default = ["console_error_panic_hook"]
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"
+# Test-only signing for receipt round-trips. Pinned to the single
+# workspace-wide dalek line so the test signer and the SDK verifier
+# share one ed25519 implementation.
+ed25519-dalek = "=3.0.0-pre.7"

--- a/sdks/verifier-js/README.md
+++ b/sdks/verifier-js/README.md
@@ -44,6 +44,34 @@ can never drift from enforcement. Fails closed on an unknown input token.
 **Scope (honest):** model-level over the **declared** inputs (coverage-limited,
 per-call) — the same boundary as the gate itself.
 
+### `verifyReceipt()` — the colimit receipt envelope
+
+`verify()` covers the lineage **bundle**; `verifyReceipt()` covers the other
+signed artifact — the **colimit receipt** (`nucleus-receipt`: a `Session` +
+its `Projection[]`, Ed25519-signed over the BLAKE3 hash of the RFC 8785
+canonical bytes). The WASM runs the *same* `Receipt::verify` every upstream
+signer and verifier runs, so there is **one verifier code path for every
+receipt kind**: a receipt signed by any nucleus binary verifies
+byte-for-byte identically in your process.
+
+```ts
+import { verifyReceipt } from "@coproduct/verify";
+
+const v = await verifyReceipt(receipt, issuerVerifyingKeyHex); // hex or Uint8Array
+switch (v.outcome) {
+  case "verified":            /* v.session_id, v.projection_kinds, v.root_hash_hex */ break;
+  case "root_hash_mismatch":  /* content tampered AFTER signing */ break;
+  case "signature_mismatch":  /* wrong issuer key or forged signature */ break;
+}
+```
+
+A cryptographic rejection is a **value** you branch on — and it tells you
+*which* property failed: `root_hash_mismatch` (the session or a projection was
+altered after signing) vs `signature_mismatch` (intact content, wrong/forged
+key). Only malformed *input* throws (bad JSON, wrong key length, a key that is
+not a curve point). The verifying key is yours to pin — typically the issuer's
+JWKS `x` field, decoded.
+
 ### What it checks
 
 A receipt is a portable **bundle** of an agent's execution lineage. `verify()`

--- a/sdks/verifier-js/index.d.ts
+++ b/sdks/verifier-js/index.d.ts
@@ -73,6 +73,49 @@ export function verifierVersion(): Promise<string>;
 /** Envelope-schema version this build can verify. Auto-inits. */
 export function supportedSchemaVersion(): Promise<number>;
 
+// ── Colimit receipt (nucleus-receipt envelope) ─────────────────────────────────
+
+/** Structured verdict from {@link verifyReceipt} — mirrors the Rust `ReceiptVerdict`. */
+export type ReceiptVerdict =
+  | {
+      outcome: "verified";
+      version: number;
+      session_id: string;
+      issuer_kid: string;
+      /** Wire `kind` of every projection the signature covers, in order. */
+      projection_kinds: string[];
+      /** BLAKE3 of the canonical signing bytes (independently recomputed). */
+      root_hash_hex: string;
+    }
+  | {
+      /** Content tampered after signing — does not hash to `root_hash_hex`. */
+      outcome: "root_hash_mismatch";
+      expected: string;
+      actual: string;
+    }
+  | {
+      /** Content self-consistent, but the signature fails under this key. */
+      outcome: "signature_mismatch";
+      reason: string;
+    };
+
+/**
+ * Verify a colimit receipt (`nucleus-receipt`: Session + Projection[] signed
+ * Ed25519 over BLAKE3 of the RFC 8785 canonical bytes) against the issuer's
+ * 32-byte verifying key. Runs the exact upstream `Receipt::verify` — one
+ * verifier code path for every receipt kind, no server trust.
+ *
+ * A cryptographic rejection is returned as a value (branch on `outcome`);
+ * throws only on malformed input (bad JSON, wrong key length).
+ *
+ * @param receipt A `Receipt` — JSON string or parsed object.
+ * @param verifyingKey The issuer's raw 32-byte Ed25519 public key — hex or bytes.
+ */
+export function verifyReceipt(
+  receipt: string | object,
+  verifyingKey: string | Uint8Array,
+): Promise<ReceiptVerdict>;
+
 /** The recomputed IFC verdict — mirrors the Rust `RecomputeReport`. */
 export interface RecomputeReport {
   /** Whether the action is permitted by the re-derived decision. */

--- a/sdks/verifier-js/index.js
+++ b/sdks/verifier-js/index.js
@@ -231,6 +231,63 @@ export async function supportedSchemaVersion() {
   return mod.supportedEnvelopeSchemaVersion();
 }
 
+// ── COLIMIT RECEIPT: verify the nucleus-receipt envelope ──────────────────────
+// `verify()` covers the lineage bundle; `verifyReceipt()` covers the OTHER
+// signed artifact — the colimit receipt (Session + Projection[] signed Ed25519
+// over BLAKE3 of the RFC 8785 canonical bytes). The WASM runs the SAME
+// `Receipt::verify` everything upstream runs: one verifier code path for every
+// receipt kind, in your process, trusting no server.
+
+/**
+ * Decode a hex string into bytes for the 32-byte Ed25519 key input.
+ * @param {string} hex
+ * @returns {Uint8Array}
+ */
+function hexToBytes(hex) {
+  const clean = hex.trim();
+  if (clean.length % 2 !== 0 || /[^0-9a-fA-F]/.test(clean)) {
+    throw new VerifyError("INPUT", `verifying key hex is malformed: "${hex}"`);
+  }
+  const out = new Uint8Array(clean.length / 2);
+  for (let i = 0; i < out.length; i++) {
+    out[i] = parseInt(clean.slice(2 * i, 2 * i + 2), 16);
+  }
+  return out;
+}
+
+/**
+ * Verify a colimit receipt (`nucleus-receipt` envelope) against the issuer's
+ * 32-byte Ed25519 verifying key. Re-canonicalizes (RFC 8785), recomputes the
+ * BLAKE3 root hash, and re-verifies the signature — the exact upstream
+ * `Receipt::verify`, compiled to this WASM.
+ *
+ * Returns a structured verdict the caller branches on: a cryptographic
+ * rejection is a VALUE (`outcome`), distinguishing content tampered after
+ * signing (`root_hash_mismatch`) from a wrong/forged key (`signature_mismatch`).
+ * Throws only on malformed input (bad JSON, wrong key length).
+ *
+ * @param {string | object} receipt
+ *   A `Receipt` — JSON string or parsed object
+ *   (`{version, session, projections, root_hash_hex, signature_b64}`).
+ * @param {string | Uint8Array} verifyingKey
+ *   The issuer's raw 32-byte Ed25519 public key — hex string or bytes.
+ * @returns {Promise<
+ *   | { outcome: "verified", version: number, session_id: string,
+ *       issuer_kid: string, projection_kinds: string[], root_hash_hex: string }
+ *   | { outcome: "root_hash_mismatch", expected: string, actual: string }
+ *   | { outcome: "signature_mismatch", reason: string }
+ * >}
+ */
+export async function verifyReceipt(receipt, verifyingKey) {
+  const mod = await initWasm();
+  const keyBytes =
+    typeof verifyingKey === "string" ? hexToBytes(verifyingKey) : verifyingKey;
+  return mod.verifyReceipt(
+    typeof receipt === "string" ? receipt : JSON.stringify(receipt),
+    keyBytes,
+  );
+}
+
 // ── RECOMPUTE: re-derive the decision, don't just check the signature ─────────
 // `verify()` proves a receipt was *signed*; `recompute()` proves the in-bounds
 // IFC *decision* was correct by re-running the EXACT same gate function the

--- a/sdks/verifier-js/src/lib.rs
+++ b/sdks/verifier-js/src/lib.rs
@@ -172,6 +172,102 @@ pub fn sdk_version() -> String {
     env!("CARGO_PKG_VERSION").to_string()
 }
 
+// ── COLIMIT RECEIPT: verify the nucleus-receipt envelope ──────────────────────
+//
+// `verifyBundle` covers the lineage envelope; this covers the OTHER signed
+// artifact — the colimit receipt (`nucleus-receipt`: Session + Projection[]
+// signed Ed25519 over BLAKE3 of the RFC 8785 canonical bytes). The SDK runs the
+// EXACT `Receipt::verify` everything upstream runs, so there is one verifier
+// code path for every receipt kind: a receipt signed by any nucleus binary
+// verifies byte-for-byte identically in the caller's browser/Node process.
+
+/// Wire shape returned by `verifyReceipt`. A *structured verdict*: a
+/// cryptographic rejection is an ordinary value the caller branches on
+/// (`outcome`), not a thrown exception — only malformed *inputs* throw.
+#[derive(Debug, Serialize)]
+#[serde(tag = "outcome", rename_all = "snake_case")]
+enum ReceiptVerdict {
+    /// Signature + root hash verified against the supplied key.
+    Verified {
+        version: u32,
+        session_id: String,
+        issuer_kid: String,
+        /// Wire `kind` of every projection the signature covers, in order.
+        projection_kinds: Vec<&'static str>,
+        /// BLAKE3 of the canonical signing bytes (independently recomputed).
+        root_hash_hex: String,
+    },
+    /// The envelope content does not hash to its claimed `root_hash_hex` —
+    /// the session or a projection was tampered after signing.
+    RootHashMismatch { expected: String, actual: String },
+    /// Content is self-consistent but the Ed25519 signature does not verify
+    /// under the supplied key — wrong issuer key or forged signature.
+    SignatureMismatch { reason: String },
+}
+
+/// Pure core behind `verifyReceipt` — no wasm types, so native `cargo test`
+/// exercises the exact logic the wasm export ships.
+fn receipt_verdict(
+    receipt_json: &str,
+    verifying_key_bytes: &[u8],
+) -> Result<ReceiptVerdict, String> {
+    let receipt: nucleus_receipt::Receipt =
+        serde_json::from_str(receipt_json).map_err(|e| format!("receipt JSON: {e}"))?;
+    let key: [u8; 32] = verifying_key_bytes.try_into().map_err(|_| {
+        format!(
+            "verifying key must be 32 bytes, got {}",
+            verifying_key_bytes.len()
+        )
+    })?;
+    match receipt.verify(&key) {
+        Ok(()) => Ok(ReceiptVerdict::Verified {
+            version: receipt.version,
+            session_id: receipt.session.session_id.clone(),
+            issuer_kid: receipt.session.issuer_kid.clone(),
+            projection_kinds: receipt.projections.iter().map(|p| p.kind()).collect(),
+            root_hash_hex: receipt.root_hash_hex.clone(),
+        }),
+        Err(nucleus_receipt::ReceiptError::RootHashMismatch { expected, actual }) => {
+            Ok(ReceiptVerdict::RootHashMismatch { expected, actual })
+        }
+        Err(nucleus_receipt::ReceiptError::SignatureMismatch(reason)) => {
+            Ok(ReceiptVerdict::SignatureMismatch { reason })
+        }
+        // InvalidKey / InvalidSignatureEncoding (+ any future variant of the
+        // non_exhaustive error): structurally unusable input → input error.
+        Err(other) => Err(other.to_string()),
+    }
+}
+
+/// Verify a **colimit receipt** (`nucleus-receipt` envelope) against the
+/// issuer's 32-byte Ed25519 verifying key. Runs the SAME `Receipt::verify`
+/// every upstream signer/verifier runs: re-canonicalizes (RFC 8785),
+/// recomputes the BLAKE3 root hash, and re-verifies the signature — in the
+/// caller's process, trusting no server.
+///
+/// # Arguments
+/// * `receipt_json` — a `Receipt` serialized as JSON
+///   (`{version, session, projections, root_hash_hex, signature_b64}`).
+/// * `verifying_key_bytes` — the issuer's raw 32-byte Ed25519 public key
+///   (as found in the issuer's JWKS `x` field, decoded).
+///
+/// # Returns
+/// A structured verdict: `{ outcome: "verified", ... }`,
+/// `{ outcome: "root_hash_mismatch", expected, actual }` (content tampered
+/// after signing), or `{ outcome: "signature_mismatch", reason }` (wrong key
+/// or forged signature). Throws only on malformed input (bad JSON, wrong key
+/// length, undecodable signature encoding).
+#[wasm_bindgen(js_name = verifyReceipt)]
+pub fn verify_receipt_js(
+    receipt_json: &str,
+    verifying_key_bytes: &[u8],
+) -> Result<JsValue, JsError> {
+    set_panic_hook();
+    let verdict =
+        receipt_verdict(receipt_json, verifying_key_bytes).map_err(|e| JsError::new(&e))?;
+    serde_wasm_bindgen::to_value(&verdict).map_err(|e| JsError::new(&e.to_string()))
+}
+
 // ── RECOMPUTE: re-derive the IFC verdict, don't just trust the signature ──────
 //
 // `verifyBundle` proves a receipt was *signed*; `recomputeVerdict` proves the
@@ -535,4 +631,109 @@ pub fn required_bond_from_receipts_js(
             .required_bond(max_defection_gain_micro)
             .0,
     )
+}
+
+// ── Native tests for the receipt-verdict core ─────────────────────────────────
+// The crate is also an rlib, so the wasm-free `receipt_verdict` core runs under
+// plain `cargo test` on the host — sign with the real `nucleus-receipt` crate,
+// verify through the SDK path. (The JsValue boundary is pinned separately by
+// tests/web.rs + the Node tests against the built pkg.)
+#[cfg(test)]
+mod receipt_tests {
+    use super::*;
+    use nucleus_receipt::{Projection, Receipt, Session};
+
+    fn signing_key() -> ed25519_dalek::SigningKey {
+        ed25519_dalek::SigningKey::from_bytes(&[7u8; 32])
+    }
+
+    fn signed_receipt() -> Receipt {
+        let session = Session {
+            session_id: "spiffe://test/agent-x".into(),
+            issuer_kid: "test-kid".into(),
+            issued_at_micros: 1_717_000_000_000_000,
+            parent_chain: vec![],
+        };
+        let projections = vec![
+            Projection::Identity(serde_json::json!({"sub": "spiffe://test/agent-x"})),
+            Projection::Economic(serde_json::json!({"price_micro_usd": 1_250_000})),
+        ];
+        Receipt::sign(session, projections, &signing_key())
+    }
+
+    #[test]
+    fn round_trip_signed_receipt_is_verified() {
+        let receipt = signed_receipt();
+        let vk = signing_key().verifying_key().to_bytes();
+        let json = serde_json::to_string(&receipt).unwrap();
+        match receipt_verdict(&json, &vk).expect("well-formed input") {
+            ReceiptVerdict::Verified {
+                version,
+                session_id,
+                issuer_kid,
+                projection_kinds,
+                root_hash_hex,
+            } => {
+                assert_eq!(version, nucleus_receipt::RECEIPT_VERSION);
+                assert_eq!(session_id, "spiffe://test/agent-x");
+                assert_eq!(issuer_kid, "test-kid");
+                assert_eq!(projection_kinds, vec!["identity", "economic"]);
+                assert_eq!(root_hash_hex, receipt.root_hash_hex);
+            }
+            other => panic!("expected Verified, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn tampered_projection_is_root_hash_mismatch() {
+        let mut receipt = signed_receipt();
+        // Inflate the claimed price after signing — the classic tamper.
+        receipt.projections[1] =
+            Projection::Economic(serde_json::json!({"price_micro_usd": 9_999_999}));
+        let vk = signing_key().verifying_key().to_bytes();
+        let json = serde_json::to_string(&receipt).unwrap();
+        assert!(matches!(
+            receipt_verdict(&json, &vk).expect("well-formed input"),
+            ReceiptVerdict::RootHashMismatch { .. }
+        ));
+    }
+
+    #[test]
+    fn wrong_key_is_signature_mismatch() {
+        let receipt = signed_receipt();
+        let wrong_vk = ed25519_dalek::SigningKey::from_bytes(&[8u8; 32])
+            .verifying_key()
+            .to_bytes();
+        let json = serde_json::to_string(&receipt).unwrap();
+        assert!(matches!(
+            receipt_verdict(&json, &wrong_vk).expect("well-formed input"),
+            ReceiptVerdict::SignatureMismatch { .. }
+        ));
+    }
+
+    #[test]
+    fn malformed_json_is_a_clean_input_error() {
+        let vk = signing_key().verifying_key().to_bytes();
+        let err = receipt_verdict("not valid json", &vk).unwrap_err();
+        assert!(err.starts_with("receipt JSON:"), "got: {err}");
+    }
+
+    #[test]
+    fn wrong_key_length_is_a_clean_input_error() {
+        let receipt = signed_receipt();
+        let json = serde_json::to_string(&receipt).unwrap();
+        let err = receipt_verdict(&json, &[0u8; 31]).unwrap_err();
+        assert!(err.contains("32 bytes"), "got: {err}");
+        let err = receipt_verdict(&json, &[0u8; 33]).unwrap_err();
+        assert!(err.contains("32 bytes"), "got: {err}");
+    }
+
+    #[test]
+    fn undecodable_signature_encoding_is_an_input_error_not_a_verdict() {
+        let mut receipt = signed_receipt();
+        receipt.signature_b64 = "%%% not base64 %%%".into();
+        let vk = signing_key().verifying_key().to_bytes();
+        let json = serde_json::to_string(&receipt).unwrap();
+        assert!(receipt_verdict(&json, &vk).is_err());
+    }
 }

--- a/sdks/verifier-js/test/fixtures/receipt.json
+++ b/sdks/verifier-js/test/fixtures/receipt.json
@@ -1,0 +1,29 @@
+{
+  "_generated_by": "nucleus-receipt Receipt::sign with SigningKey::from_bytes([7u8; 32]) — a TEST key; the same deterministic envelope the crate's own doc example signs",
+  "receipt": {
+    "projections": [
+      {
+        "body": {
+          "sub": "spiffe://test/agent-x"
+        },
+        "kind": "identity"
+      },
+      {
+        "body": {
+          "price_micro_usd": 1250000
+        },
+        "kind": "economic"
+      }
+    ],
+    "root_hash_hex": "e6f9f04a975afd938ec043058f049b027268e666725fb88fdfec647a1916804a",
+    "session": {
+      "issued_at_micros": 1717000000000000,
+      "issuer_kid": "test-kid",
+      "parent_chain": [],
+      "session_id": "spiffe://test/agent-x"
+    },
+    "signature_b64": "sjWkPAWbo4QoiqasWEpeyZZKNXVSpbNIBpg8FmCxeeogEHROAMqct5emWHsFSq8/k6m2s+2vp0huVq3m64BhCQ==",
+    "version": 1
+  },
+  "verifying_key_hex": "ea4a6c63e29c520abef5507b132ec5f9954776aebebe7b92421eea691446d22c"
+}

--- a/sdks/verifier-js/test/receipt.test.mjs
+++ b/sdks/verifier-js/test/receipt.test.mjs
@@ -1,0 +1,94 @@
+// Node test for verifyReceipt — the colimit receipt envelope (nucleus-receipt:
+// Session + Projection[] signed Ed25519 over BLAKE3 of the RFC 8785 canonical
+// bytes) verified through the SAME `Receipt::verify` everything upstream runs.
+//
+// The fixture is REAL: signed by `nucleus-receipt` itself with the
+// deterministic test key `SigningKey::from_bytes([7u8; 32])` (see
+// fixtures/receipt.json `_generated_by`). Tamper variants are derived here from
+// the genuine fixture, so a pass means the WASM path reproduces the upstream
+// canonical bytes exactly — one verifier code path for every receipt kind.
+//
+// Requires ./pkg to exist — run `npm run build:wasm` first (CI builds it).
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+import { verifyReceipt } from "../index.js";
+
+const fixtureUrl = new URL("./fixtures/receipt.json", import.meta.url);
+
+async function readFixture() {
+  const text = await readFile(fileURLToPath(fixtureUrl), "utf8");
+  return JSON.parse(text);
+}
+
+test("accepts the real, untampered fixture receipt (hex key)", async () => {
+  const { receipt, verifying_key_hex } = await readFixture();
+  const v = await verifyReceipt(receipt, verifying_key_hex);
+  assert.equal(v.outcome, "verified");
+  assert.equal(v.version, 1);
+  assert.equal(v.session_id, "spiffe://test/agent-x");
+  assert.equal(v.issuer_kid, "test-kid");
+  assert.deepEqual(v.projection_kinds, ["identity", "economic"]);
+  assert.equal(v.root_hash_hex, receipt.root_hash_hex);
+});
+
+test("accepts the fixture receipt with a Uint8Array key and a string receipt", async () => {
+  const { receipt, verifying_key_hex } = await readFixture();
+  const keyBytes = Uint8Array.from(
+    verifying_key_hex.match(/.{2}/g).map((b) => parseInt(b, 16)),
+  );
+  const v = await verifyReceipt(JSON.stringify(receipt), keyBytes);
+  assert.equal(v.outcome, "verified");
+});
+
+test("a projection tampered after signing is a root_hash_mismatch", async () => {
+  const { receipt, verifying_key_hex } = await readFixture();
+  // Inflate the claimed price — the classic post-signing tamper.
+  receipt.projections[1].body.price_micro_usd = 9_999_999;
+  const v = await verifyReceipt(receipt, verifying_key_hex);
+  assert.equal(v.outcome, "root_hash_mismatch");
+  assert.equal(v.expected, receipt.root_hash_hex);
+  assert.notEqual(v.actual, v.expected);
+});
+
+test("the wrong issuer key is a signature_mismatch (content untouched)", async () => {
+  const { receipt } = await readFixture();
+  // A VALID Ed25519 key that simply isn't the issuer's — the verifying key of
+  // `SigningKey::from_bytes([8u8; 32])`. (A bit-flipped key would not decode
+  // to a curve point at all and is rejected as malformed input instead.)
+  // Content still hashes correctly, so the failure must be attributed to the
+  // signature, not the root hash.
+  const wrongKey =
+    "1398f62c6d1a457c51ba6a4b5f3dbd2f69fca93216218dc8997e416bd17d93ca";
+  const v = await verifyReceipt(receipt, wrongKey);
+  assert.equal(v.outcome, "signature_mismatch");
+  assert.ok(v.reason.length > 0, "rejection should carry a reason");
+});
+
+test("an undecodable issuer key (not a curve point) throws a clean input error", async () => {
+  const { receipt, verifying_key_hex } = await readFixture();
+  // Flip the first nibble of the fixture key — still 32 bytes, but no longer
+  // a valid compressed Edwards point for THIS key (verified empirically).
+  const broken =
+    (verifying_key_hex[0] === "0" ? "1" : "0") + verifying_key_hex.slice(1);
+  await assert.rejects(verifyReceipt(receipt, broken), /verifying key invalid/);
+});
+
+test("malformed receipt JSON throws a clean input error", async () => {
+  const { verifying_key_hex } = await readFixture();
+  await assert.rejects(
+    verifyReceipt("not valid json", verifying_key_hex),
+    /receipt JSON/,
+  );
+});
+
+test("a wrong-length key throws a clean input error", async () => {
+  const { receipt } = await readFixture();
+  await assert.rejects(
+    verifyReceipt(receipt, "deadbeef"), // 4 bytes, not 32
+    /32 bytes/,
+  );
+});

--- a/sdks/verifier-js/tests/web.rs
+++ b/sdks/verifier-js/tests/web.rs
@@ -6,7 +6,9 @@
 //! verifyBundle's JSON-in / JsValue-out boundary is the surface
 //! these tests pin.
 
-use nucleus_verifier_wasm::{sdk_version, supported_envelope_schema_version, verify_bundle_js};
+use nucleus_verifier_wasm::{
+    sdk_version, supported_envelope_schema_version, verify_bundle_js, verify_receipt_js,
+};
 use wasm_bindgen_test::*;
 
 // Default: tests run in Node.js (the wasm-bindgen-test default
@@ -44,6 +46,76 @@ fn verify_bundle_rejects_malformed_trust_anchor_json() {
     assert!(
         result.is_err(),
         "malformed trust anchor JSON must surface as JsError"
+    );
+}
+
+// ── verifyReceipt: the colimit receipt envelope across the wasm boundary ─────
+
+fn signed_receipt_and_key() -> (nucleus_receipt::Receipt, [u8; 32]) {
+    let sk = ed25519_dalek::SigningKey::from_bytes(&[7u8; 32]);
+    let session = nucleus_receipt::Session {
+        session_id: "spiffe://test/agent-x".into(),
+        issuer_kid: "test-kid".into(),
+        issued_at_micros: 1_717_000_000_000_000,
+        parent_chain: vec![],
+    };
+    let projections = vec![nucleus_receipt::Projection::Identity(serde_json::json!({
+        "sub": "spiffe://test/agent-x"
+    }))];
+    let receipt = nucleus_receipt::Receipt::sign(session, projections, &sk);
+    (receipt, sk.verifying_key().to_bytes())
+}
+
+fn outcome_of(verdict: wasm_bindgen::JsValue) -> String {
+    let v: serde_json::Value =
+        serde_wasm_bindgen::from_value(verdict).expect("verdict deserializes");
+    v["outcome"].as_str().expect("outcome is a string").into()
+}
+
+#[wasm_bindgen_test]
+fn verify_receipt_round_trips_a_freshly_signed_receipt() {
+    let (receipt, vk) = signed_receipt_and_key();
+    let json = serde_json::to_string(&receipt).unwrap();
+    let verdict = verify_receipt_js(&json, &vk).expect("well-formed input");
+    assert_eq!(outcome_of(verdict), "verified");
+}
+
+#[wasm_bindgen_test]
+fn verify_receipt_reports_tamper_as_root_hash_mismatch() {
+    let (mut receipt, vk) = signed_receipt_and_key();
+    receipt.session.session_id = "spiffe://attacker/imposter".into();
+    let json = serde_json::to_string(&receipt).unwrap();
+    let verdict = verify_receipt_js(&json, &vk).expect("well-formed input");
+    assert_eq!(outcome_of(verdict), "root_hash_mismatch");
+}
+
+#[wasm_bindgen_test]
+fn verify_receipt_reports_wrong_key_as_signature_mismatch() {
+    let (receipt, _vk) = signed_receipt_and_key();
+    let wrong_vk = ed25519_dalek::SigningKey::from_bytes(&[8u8; 32])
+        .verifying_key()
+        .to_bytes();
+    let json = serde_json::to_string(&receipt).unwrap();
+    let verdict = verify_receipt_js(&json, &wrong_vk).expect("well-formed input");
+    assert_eq!(outcome_of(verdict), "signature_mismatch");
+}
+
+#[wasm_bindgen_test]
+fn verify_receipt_rejects_malformed_json() {
+    let (_receipt, vk) = signed_receipt_and_key();
+    assert!(
+        verify_receipt_js("not valid json", &vk).is_err(),
+        "malformed receipt JSON must surface as JsError"
+    );
+}
+
+#[wasm_bindgen_test]
+fn verify_receipt_rejects_wrong_key_length() {
+    let (receipt, _vk) = signed_receipt_and_key();
+    let json = serde_json::to_string(&receipt).unwrap();
+    assert!(
+        verify_receipt_js(&json, &[0u8; 31]).is_err(),
+        "a 31-byte key must surface as JsError"
     );
 }
 


### PR DESCRIPTION
## What

Adds colimit-receipt verification to `sdks/verifier-js` (the WASM verifier SDK). The SDK could already verify lineage bundles (`verifyBundle`), recompute IFC verdicts, and recompute clearing economics — but it could not verify the `nucleus-receipt` envelope (#1826's Session + Projection[] signed Ed25519 over BLAKE3 of the RFC 8785/JCS canonical bytes). Now it can:

- **`verifyReceipt` wasm export** — parses the `Receipt` JSON, takes the issuer's raw 32-byte Ed25519 verifying key, and runs the **exact upstream `Receipt::verify`** (path dep on `crates/nucleus-receipt`, same convention as every other in-repo dep): re-canonicalize (RFC 8785), recompute the BLAKE3 root hash, re-verify the signature.
- **Structured verdict, not a throw**: `{ outcome: "verified", version, session_id, issuer_kid, projection_kinds, root_hash_hex }` | `{ outcome: "root_hash_mismatch", expected, actual }` (content tampered after signing) | `{ outcome: "signature_mismatch", reason }` (intact content, wrong/forged key). Only malformed *input* throws: bad JSON, wrong key length, a key that isn't a curve point, undecodable signature encoding.
- **`verifyReceipt()` facade** in `index.js` / `index.d.ts` (hex string or `Uint8Array` key; string or object receipt), mirroring the existing `recomputeReceipt` facade style. README section added.

## Why one code path

`nucleus-receipt` v1.0.0 made the RFC 8785 canonical bytes the single signing surface so a receipt signed by any nucleus binary verifies in every other binary (#1826). This PR extends that to the last verifier surface: the browser/Node SDK now links the same crate and calls the same `Receipt::verify` — no re-implementation, so the SDK can never drift from the upstream canonicalization or hash/signature semantics.

## Tests

Three layers:
- **Native `cargo test`** (the SDK crate is also an rlib; the verdict core is wasm-free): round-trip signed with the real `nucleus-receipt` crate, tampered projection → `root_hash_mismatch`, wrong key → `signature_mismatch`, malformed JSON / 31- and 33-byte keys / undecodable signature encoding → clean input errors. 6/6 pass.
- **wasm-bindgen tests** (`tests/web.rs`, existing convention): same cases across the JsValue boundary.
- **Node tests against the built pkg** (`test/receipt.test.mjs`, runs in CI's `npm test`): a real fixture signed by `nucleus-receipt` with the deterministic test key `SigningKey::from_bytes([7u8;32])`; tamper/wrong-key/invalid-key variants derived from it in JS. 29/29 Node tests pass, including the 7 new ones.

## Build validation

`wasm-pack build sdks/verifier-js --target web --release` succeeds locally (wasm-opt included); `cargo fmt` + `cargo clippy --all-targets -- -D warnings` clean in the SDK's own workspace; pre-commit hooks (fmt/clippy/deny/audit) green. `pkg/` is gitignored — CI rebuilds it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)