### PR TITLE
fix(lineage): uuid js feature for wasm32 targets — un-reds the wasm-pure-crates gate

### DIFF
--- a/crates/nucleus-lineage/Cargo.toml
+++ b/crates/nucleus-lineage/Cargo.toml
@@ -77,3 +77,12 @@ required-features = ["insecure-local-issuer"]
 
 [lints]
 workspace = true
+
+# wasm32 needs an explicit randomness source for Uuid::new_v4 (the
+# v4 feature alone does not compile on wasm32-unknown-unknown). The
+# `js` feature routes through wasm-bindgen/getrandom for wasm builds
+# ONLY — native builds are unchanged. This keeps the downstream
+# wasm-pure-crates gate green now that nucleus-externality (and via it
+# nucleus-econ-kernels) consume this crate.
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+uuid = { workspace = true, features = ["js"] }


### PR DESCRIPTION
Since #1805 wired `nucleus-externality → nucleus-lineage`, lineage's unconditional `uuid` (workspace, `v4`) reaches the **wasm-pure-crates** closure via econ-kernels — and `Uuid::new_v4` needs an explicit randomness source on `wasm32-unknown-unknown`, so the gate has been red on main since that merge (runs 27253930437 / 27254353947; also the only red on #1839).

Fix: a target-scoped dependency enabling `uuid/js` for wasm builds only — native dependency closure unchanged. Verified locally with the gate's own command: `cargo build --locked --target wasm32-unknown-unknown` green for econ-kernels, recompute, and externality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)