### PR TITLE
feat(agent-card): verified cards travel as a signed Capability projection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6378,9 +6378,11 @@ name = "nucleus-agent-card"
 version = "1.0.0"
 dependencies = [
  "base64 0.22.1",
+ "ed25519-dalek 3.0.0-pre.7",
  "nucleus-envelope",
  "nucleus-identity",
  "nucleus-lineage",
+ "nucleus-receipt",
  "p256",
  "ring",
  "serde",

--- a/crates/nucleus-agent-card/Cargo.toml
+++ b/crates/nucleus-agent-card/Cargo.toml
@@ -32,6 +32,13 @@ p256 = { version = "0.13", default-features = false, features = ["ecdsa"] }
 nucleus-identity = { path = "../nucleus-identity", optional = true }
 nucleus-lineage = { path = "../nucleus-lineage" }
 nucleus-envelope = { path = "../nucleus-envelope" }
+# `envelope` feature only: lift a VERIFIED card's claims into nucleus-receipt's
+# signed colimit envelope (`Projection::Capability`) and narrow them back out.
+# Optional so the default build keeps the dependency closure exactly as before
+# (no dalek/blake3 in the default closure). nucleus-receipt itself is
+# wasm-clean, so turning the feature on does not break wasm consumers of the
+# always-on verify path.
+nucleus-receipt = { path = "../nucleus-receipt", optional = true }
 
 [features]
 default = []
@@ -39,6 +46,14 @@ default = []
 # signing primitive. NEVER enable in a WASM / browser build — verify is
 # always available without it and is secret-free.
 sign = ["dep:nucleus-identity"]
+
+# Travel as a signed receipt: `to_capability_projection` /
+# `card_claims_from_projection` bridge VerifiedCard claims <->
+# nucleus-receipt's `Projection::Capability`, so a counterparty's
+# discovery-time guarantees (RuntimeGuaranteeProfile et al.) ride along,
+# signed, with every receipt the agent later emits. Only a VerifiedCard can
+# be lifted — verify-before-you-project is type-enforced. OFF by default.
+envelope = ["dep:nucleus-receipt"]
 
 # The `agent-sign` example calls sign_card, so it only builds with `sign`
 # (keeps default builds + CI free of the signing path).
@@ -52,6 +67,8 @@ required-features = ["sign"]
 nucleus-lineage = { path = "../nucleus-lineage", features = ["insecure-local-issuer"] }
 # P-256 keypair generation for the sign/verify unit + integration tests.
 ring = { workspace = true }
+# Fixed-key signing of the receipt envelope in the end-to-end + tamper tests.
+ed25519-dalek = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/nucleus-agent-card/src/envelope.rs
+++ b/crates/nucleus-agent-card/src/envelope.rs
@@ -1,0 +1,334 @@
+//! Lift a [`VerifiedCard`]'s claims into `nucleus-receipt`'s signed colimit
+//! envelope (feature `envelope`, off by default).
+//!
+//! An agent's card is its *discovery-time* capability claim: who it is
+//! (`spiffe_id`, `did`), what it speaks
+//! (`supported_envelope_schema_versions`), which keys it claims sign its
+//! provenance (`trust_jwks` kids), and — the load-bearing part — its declared
+//! [`RuntimeGuaranteeProfile`](crate::RuntimeGuaranteeProfile). Putting those
+//! claims into [`Projection::Capability`] means the guarantees a counterparty
+//! checked at discovery time ride along, signed, inside every
+//! [`Receipt`](nucleus_receipt::Receipt) the agent later emits — the receipt's
+//! Ed25519/BLAKE3 envelope makes the carried claims tamper-evident end to end.
+//!
+//! ## Verify before you project (type-enforced)
+//!
+//! [`to_capability_projection`] takes a [`VerifiedCard`] — the output of
+//! [`verify_card`](crate::verify_card) — and deliberately NOT a raw
+//! [`SignedAgentCard`](crate::SignedAgentCard). A raw signed card is an
+//! unverified blob: lifting it would let an agent embed claims nobody ever
+//! checked against an out-of-band key. Requiring the `VerifiedCard` witness
+//! makes "this card verified" a precondition the type system discharges —
+//! you cannot project a card you did not verify.
+//!
+//! ## The asymmetry is the point
+//!
+//! Narrowing goes to [`CardClaims`], a plain data struct — NOT back to a
+//! [`VerifiedCard`]. Reconstructing a `VerifiedCard` from a projection body
+//! would forge the verification witness: the projection carries what a
+//! verified card *claimed*, not the proof that anyone verified it. The
+//! enclosing [`Receipt`](nucleus_receipt::Receipt) signature proves the
+//! *issuer* vouched for these claims at signing time; a consumer who needs
+//! the card-level guarantee re-verifies the card itself.
+//!
+//! ## Wire shape (stable)
+//!
+//! The `Projection::Capability` body produced by [`to_capability_projection`]
+//! is:
+//!
+//! ```json
+//! { "kind": "agent-card", "card": { "spiffe_id": "...", ... } }
+//! ```
+//!
+//! - outer `"kind"` is always [`CAPABILITY_AGENT_CARD_KIND`] (`"agent-card"`)
+//!   — the discriminant *within* the capability projection, so other
+//!   capability bodies (e.g. Portcullis lattice points) can coexist under the
+//!   same projection kind;
+//! - `"card"` is the [`CardClaims`] JSON — the lifted subset of the verified
+//!   card's fields.
+
+use serde::{Deserialize, Serialize};
+
+use crate::card::RuntimeGuaranteeProfile;
+use crate::verify::VerifiedCard;
+
+pub use nucleus_receipt::Projection;
+
+/// The `"kind"` discriminant inside a `Projection::Capability` body that
+/// marks it as carrying agent-card claims. Stable wire constant.
+pub const CAPABILITY_AGENT_CARD_KIND: &str = "agent-card";
+
+/// The claims lifted out of a [`VerifiedCard`] — what travels inside the
+/// signed receipt.
+///
+/// This is deliberately a plain deserializable struct, not a
+/// [`VerifiedCard`]: deserializing claims off the wire must never mint a
+/// verification witness (see the module docs on the asymmetry).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CardClaims {
+    /// SPIFFE identity the verified card declared.
+    pub spiffe_id: String,
+
+    /// Decentralized identifier the verified card declared.
+    pub did: String,
+
+    /// Envelope/bundle schema versions the agent declared it speaks.
+    pub supported_envelope_schema_versions: Vec<String>,
+
+    /// The declared runtime IFC guarantee profile, if any — the discovery-time
+    /// guarantee that now rides along with every receipt. Attestation, not
+    /// enforcement (see [`RuntimeGuaranteeProfile`]).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime_guarantees: Option<RuntimeGuaranteeProfile>,
+
+    /// `kid`s of the JWKS the card advertised as authoritative for its
+    /// provenance bundles. Kids only — the keys themselves stay out-of-band,
+    /// so a projection consumer can correlate but never treat the projection
+    /// as key material.
+    pub advertised_jwks_kids: Vec<String>,
+}
+
+impl From<&VerifiedCard> for CardClaims {
+    fn from(verified: &VerifiedCard) -> Self {
+        CardClaims {
+            spiffe_id: verified.card.spiffe_id.clone(),
+            did: verified.card.did.clone(),
+            supported_envelope_schema_versions: verified
+                .card
+                .supported_envelope_schema_versions
+                .clone(),
+            runtime_guarantees: verified.card.runtime_guarantees.clone(),
+            advertised_jwks_kids: verified
+                .advertised_jwks()
+                .keys
+                .iter()
+                .map(|k| k.kid.clone())
+                .collect(),
+        }
+    }
+}
+
+/// Why a [`Projection`] could not be narrowed to [`CardClaims`].
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum NarrowError {
+    /// The projection is not `Projection::Capability` at all.
+    #[error("projection kind is `{found}`, expected `capability`")]
+    NotCapability {
+        /// The wire discriminant of the projection that was supplied.
+        found: &'static str,
+    },
+    /// The capability body's `kind` is not `"agent-card"` (or is missing) —
+    /// some other capability record travels under this projection.
+    #[error("capability body kind is `{found}`, expected `agent-card`")]
+    NotAgentCard {
+        /// The inner `kind` found, or `<missing>`.
+        found: String,
+    },
+    /// The body claimed to be an agent card but its `card` field is absent
+    /// or does not deserialize as [`CardClaims`].
+    #[error("agent-card capability body is malformed: {0}")]
+    MalformedBody(String),
+}
+
+/// Lift a [`VerifiedCard`]'s claims into the [`Projection::Capability`] body
+/// they travel as inside a signed [`Receipt`](nucleus_receipt::Receipt).
+/// See the module docs for the stable inner shape.
+///
+/// Only a [`VerifiedCard`] can be lifted — verify-before-you-project is
+/// enforced by the type system, not by convention (see the module docs).
+pub fn to_capability_projection(verified: &VerifiedCard) -> Projection {
+    Projection::Capability(serde_json::json!({
+        "kind": CAPABILITY_AGENT_CARD_KIND,
+        "card": CardClaims::from(verified),
+    }))
+}
+
+/// Narrow a [`Projection`] back to the typed [`CardClaims`].
+///
+/// Rejects, with distinct errors: non-`Capability` projections
+/// ([`NarrowError::NotCapability`]), capability bodies that are not agent
+/// cards ([`NarrowError::NotAgentCard`]), and agent-card bodies whose `card`
+/// is missing or malformed ([`NarrowError::MalformedBody`]).
+///
+/// Narrowing does NOT verify anything — and it cannot return a
+/// [`VerifiedCard`], because that would forge the verification witness. Call
+/// [`Receipt::verify`](nucleus_receipt::Receipt::verify) on the envelope
+/// *before* narrowing to establish the issuer vouched for these claims; if
+/// you need the card-level guarantee itself, re-verify the card with
+/// [`verify_card`](crate::verify_card) against an out-of-band key.
+pub fn card_claims_from_projection(projection: &Projection) -> Result<CardClaims, NarrowError> {
+    let Projection::Capability(body) = projection else {
+        return Err(NarrowError::NotCapability {
+            found: projection.kind(),
+        });
+    };
+    match body.get("kind").and_then(serde_json::Value::as_str) {
+        Some(CAPABILITY_AGENT_CARD_KIND) => {}
+        Some(other) => {
+            return Err(NarrowError::NotAgentCard {
+                found: other.to_string(),
+            })
+        }
+        None => {
+            return Err(NarrowError::NotAgentCard {
+                found: "<missing>".to_string(),
+            })
+        }
+    }
+    let card = body
+        .get("card")
+        .ok_or_else(|| NarrowError::MalformedBody("missing `card` field".to_string()))?;
+    serde_json::from_value(card.clone()).map_err(|e| NarrowError::MalformedBody(e.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::card::{AgentCard, EnforcementRule};
+
+    fn sample_profile() -> RuntimeGuaranteeProfile {
+        RuntimeGuaranteeProfile {
+            profile_version: "1.0".to_string(),
+            tracked_sources: vec!["web_content".to_string(), "secret".to_string()],
+            enforcement_rules: vec![EnforcementRule {
+                name: "no_adversarial_to_outbound".to_string(),
+                description:
+                    "deny outbound actions whose ancestry includes adversarial-integrity content"
+                        .to_string(),
+            }],
+            attestation_reference: None,
+        }
+    }
+
+    fn sample_card() -> AgentCard {
+        AgentCard {
+            spiffe_id: "spiffe://prod.example.com/ns/agents/sa/coder".to_string(),
+            did: "did:web:coder.prod.example.com".to_string(),
+            security_schemes: serde_json::json!({"bearer": {"type": "http"}}),
+            supported_envelope_schema_versions: vec!["1".to_string(), "2".to_string()],
+            jwks_uri: None,
+            trust_jwks: nucleus_lineage::Jwks {
+                keys: vec![nucleus_lineage::Jwk {
+                    kty: "OKP".to_string(),
+                    crv: Some("Ed25519".to_string()),
+                    kid: "k1".to_string(),
+                    x: Some("AAAA_AAAAAA-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA".to_string()),
+                    alg: Some("EdDSA".to_string()),
+                    use_: Some("sig".to_string()),
+                    not_before: None,
+                    not_after: None,
+                }],
+            },
+            runtime_guarantees: Some(sample_profile()),
+        }
+    }
+
+    /// In-crate test shortcut: `VerifiedCard`'s field is public within the
+    /// crate's API, but the END-TO-END test (sign_verify path, feature
+    /// `sign`) is the one that goes through `verify_card` for real.
+    fn verified() -> VerifiedCard {
+        VerifiedCard {
+            card: sample_card(),
+        }
+    }
+
+    /// The round-trip law: narrow ∘ lift = id on the lifted claims.
+    #[test]
+    fn lift_then_narrow_is_identity_on_claims() {
+        let v = verified();
+        let expected = CardClaims::from(&v);
+        let p = to_capability_projection(&v);
+        assert_eq!(p.kind(), "capability");
+        let back = card_claims_from_projection(&p).expect("lifted projection narrows back");
+        assert_eq!(back, expected);
+        // Spot-check the load-bearing fields explicitly.
+        assert_eq!(
+            back.spiffe_id,
+            "spiffe://prod.example.com/ns/agents/sa/coder"
+        );
+        assert_eq!(back.advertised_jwks_kids, vec!["k1".to_string()]);
+        assert_eq!(
+            back.runtime_guarantees.unwrap().enforcement_rules[0].name,
+            "no_adversarial_to_outbound"
+        );
+    }
+
+    #[test]
+    fn capability_body_shape_is_stable() {
+        // Wire pin: {"kind": "agent-card", "card": {...}} — downstream
+        // consumers dispatch on the inner kind, so drift fails here.
+        let Projection::Capability(body) = to_capability_projection(&verified()) else {
+            panic!("lift must produce a capability projection");
+        };
+        assert_eq!(body["kind"], CAPABILITY_AGENT_CARD_KIND);
+        assert_eq!(body["card"]["did"], "did:web:coder.prod.example.com");
+        assert_eq!(body["card"]["advertised_jwks_kids"][0], "k1");
+    }
+
+    #[test]
+    fn absent_profile_is_omitted_from_the_wire() {
+        let mut v = verified();
+        v.card.runtime_guarantees = None;
+        let Projection::Capability(body) = to_capability_projection(&v) else {
+            panic!("lift must produce a capability projection");
+        };
+        assert!(
+            body["card"].get("runtime_guarantees").is_none(),
+            "a None profile must be omitted from the claims JSON"
+        );
+        let back = card_claims_from_projection(&to_capability_projection(&v)).unwrap();
+        assert!(back.runtime_guarantees.is_none());
+    }
+
+    #[test]
+    fn narrowing_rejects_non_capability_projection() {
+        let p = Projection::Identity(serde_json::json!({"sub": "spiffe://test/agent"}));
+        assert_eq!(
+            card_claims_from_projection(&p),
+            Err(NarrowError::NotCapability { found: "identity" })
+        );
+    }
+
+    #[test]
+    fn narrowing_rejects_other_capability_bodies() {
+        // A different capability record under the same projection kind.
+        let p = Projection::Capability(serde_json::json!({
+            "kind": "portcullis-lattice-point",
+            "card": {"anything": true},
+        }));
+        assert_eq!(
+            card_claims_from_projection(&p),
+            Err(NarrowError::NotAgentCard {
+                found: "portcullis-lattice-point".into()
+            })
+        );
+        // Missing inner kind entirely.
+        let p = Projection::Capability(serde_json::json!({"card": {}}));
+        assert_eq!(
+            card_claims_from_projection(&p),
+            Err(NarrowError::NotAgentCard {
+                found: "<missing>".into()
+            })
+        );
+    }
+
+    #[test]
+    fn narrowing_rejects_malformed_agent_card_bodies() {
+        // `card` field absent.
+        let p = Projection::Capability(serde_json::json!({"kind": "agent-card"}));
+        assert!(matches!(
+            card_claims_from_projection(&p),
+            Err(NarrowError::MalformedBody(_))
+        ));
+        // `card` present but not CardClaims.
+        let p = Projection::Capability(serde_json::json!({
+            "kind": "agent-card",
+            "card": {"spiffe_id": 42},
+        }));
+        assert!(matches!(
+            card_claims_from_projection(&p),
+            Err(NarrowError::MalformedBody(_))
+        ));
+    }
+}

--- a/crates/nucleus-agent-card/src/envelope_e2e_tests.rs
+++ b/crates/nucleus-agent-card/src/envelope_e2e_tests.rs
@@ -1,0 +1,137 @@
+//! End-to-end: a REAL signed card goes through [`crate::verify_card`], is
+//! lifted into `Projection::Capability`, travels inside a signed
+//! [`nucleus_receipt::Receipt`], and narrows back to matching claims —
+//! plus the tamper test on the signed envelope.
+//!
+//! Gated on `sign` (to produce a genuinely signed card) AND `envelope`
+//! (the lift/narrow seam under test).
+
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine as _;
+use ring::rand::SystemRandom;
+use ring::signature::{EcdsaKeyPair, KeyPair, ECDSA_P256_SHA256_FIXED_SIGNING};
+
+use crate::card::{AgentCard, EnforcementRule, RuntimeGuaranteeProfile};
+use crate::envelope::{card_claims_from_projection, to_capability_projection, CardClaims};
+use crate::jwk::JsonWebKey;
+use crate::sign::sign_card;
+use crate::verify::verify_card;
+use nucleus_receipt::{Projection, Receipt, ReceiptError, Session};
+
+/// Generate a fresh P-256 keypair: returns (PKCS#8 DER, matching public JWK).
+fn p256_keypair() -> (Vec<u8>, JsonWebKey) {
+    let rng = SystemRandom::new();
+    let pkcs8 = EcdsaKeyPair::generate_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, &rng).unwrap();
+    let der = pkcs8.as_ref().to_vec();
+    let key_pair = EcdsaKeyPair::from_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, &der, &rng).unwrap();
+    let pk = key_pair.public_key().as_ref();
+    assert_eq!(pk.len(), 65, "uncompressed P-256 point");
+    assert_eq!(pk[0], 0x04);
+    let x = URL_SAFE_NO_PAD.encode(&pk[1..33]);
+    let y = URL_SAFE_NO_PAD.encode(&pk[33..65]);
+    (der, JsonWebKey::ec_p256(x, y))
+}
+
+fn sample_card() -> AgentCard {
+    let issuer = nucleus_lineage::LocalIssuer::random().unwrap();
+    AgentCard {
+        spiffe_id: "spiffe://prod.example.com/ns/agents/sa/coder".to_string(),
+        did: "did:web:coder.prod.example.com".to_string(),
+        security_schemes: serde_json::json!({"bearer": {"type": "http"}}),
+        supported_envelope_schema_versions: vec!["1".to_string()],
+        jwks_uri: None,
+        trust_jwks: serde_json::from_value(issuer.publish_jwks()).unwrap(),
+        runtime_guarantees: Some(RuntimeGuaranteeProfile {
+            profile_version: "1.0".to_string(),
+            tracked_sources: vec!["web_content".to_string(), "secret".to_string()],
+            enforcement_rules: vec![EnforcementRule {
+                name: "no_adversarial_to_outbound".to_string(),
+                description:
+                    "deny outbound actions whose ancestry includes adversarial-integrity content"
+                        .to_string(),
+            }],
+            attestation_reference: None,
+        }),
+    }
+}
+
+fn session() -> Session {
+    Session {
+        session_id: "spiffe://prod.example.com/ns/agents/sa/coder".into(),
+        issuer_kid: "test-kid".into(),
+        issued_at_micros: 1_717_000_000_000_000,
+        parent_chain: vec![],
+    }
+}
+
+/// The full discovery→receipt path: sign a card, verify it (the only way to
+/// obtain the `VerifiedCard` witness), lift it, sign the envelope, verify the
+/// envelope, narrow — and the claims match what the card declared.
+#[test]
+fn verified_card_travels_inside_a_signed_receipt_end_to_end() {
+    // Discovery time: a real signed card, verified against the out-of-band key.
+    let (der, pub_jwk) = p256_keypair();
+    let signed_card = sign_card(sample_card(), &der).unwrap();
+    let verified = verify_card(&signed_card, &pub_jwk).expect("freshly-signed card verifies");
+    let expected = CardClaims::from(&verified);
+
+    // Receipt time: the verified claims ride along inside the signed envelope.
+    let sk = ed25519_dalek::SigningKey::from_bytes(&[7u8; 32]);
+    let vk: [u8; 32] = sk.verifying_key().to_bytes();
+    let receipt = Receipt::sign(session(), vec![to_capability_projection(&verified)], &sk);
+
+    // The envelope signature binds the issuer to the carried claims.
+    receipt
+        .verify(&vk)
+        .expect("freshly signed envelope verifies");
+
+    // Narrow back to typed claims — they match the verified card exactly.
+    let back =
+        card_claims_from_projection(&receipt.projections[0]).expect("capability narrows back");
+    assert_eq!(back, expected);
+    assert_eq!(
+        back.spiffe_id,
+        "spiffe://prod.example.com/ns/agents/sa/coder"
+    );
+    assert_eq!(back.did, "did:web:coder.prod.example.com");
+    assert_eq!(
+        back.runtime_guarantees.as_ref().unwrap().enforcement_rules[0].name,
+        "no_adversarial_to_outbound"
+    );
+    // The advertised kids are exactly the card's trust_jwks kids.
+    let kids: Vec<String> = verified
+        .advertised_jwks()
+        .keys
+        .iter()
+        .map(|k| k.kid.clone())
+        .collect();
+    assert_eq!(back.advertised_jwks_kids, kids);
+}
+
+/// Tampering with a declared guarantee INSIDE the signed envelope is caught
+/// by the receipt's signature check (`RootHashMismatch`) — the discovery-time
+/// guarantee cannot be quietly rewritten in transit.
+#[test]
+fn tampered_guarantee_inside_signed_envelope_fails_root_hash() {
+    let (der, pub_jwk) = p256_keypair();
+    let signed_card = sign_card(sample_card(), &der).unwrap();
+    let verified = verify_card(&signed_card, &pub_jwk).unwrap();
+
+    let sk = ed25519_dalek::SigningKey::from_bytes(&[7u8; 32]);
+    let vk: [u8; 32] = sk.verifying_key().to_bytes();
+    let mut receipt = Receipt::sign(session(), vec![to_capability_projection(&verified)], &sk);
+
+    // Rewrite the declared enforcement rule inside the signed body.
+    let Projection::Capability(body) = &mut receipt.projections[0] else {
+        panic!("envelope holds a capability projection");
+    };
+    body["card"]["runtime_guarantees"]["enforcement_rules"][0]["name"] =
+        serde_json::json!("allow_everything");
+
+    // The envelope check fails FIRST: the re-canonicalized bytes no longer
+    // match the signed root hash.
+    assert!(matches!(
+        receipt.verify(&vk),
+        Err(ReceiptError::RootHashMismatch { .. })
+    ));
+}

--- a/crates/nucleus-agent-card/src/lib.rs
+++ b/crates/nucleus-agent-card/src/lib.rs
@@ -53,6 +53,8 @@
 
 pub mod anchor;
 pub mod card;
+#[cfg(feature = "envelope")]
+pub mod envelope;
 pub mod jcs;
 pub mod jwk;
 pub mod verify;
@@ -62,6 +64,9 @@ pub mod sign;
 
 #[cfg(all(test, feature = "sign"))]
 mod sign_verify_tests;
+
+#[cfg(all(test, feature = "sign", feature = "envelope"))]
+mod envelope_e2e_tests;
 
 pub use anchor::trust_anchor_from_card;
 pub use card::{


### PR DESCRIPTION
## What

Mirror of #1839's `envelope` seam, for A2A agent cards: a **verified** card's claims travel as the body of `Projection::Capability` inside a signed `nucleus-receipt::Receipt`. The card's `RuntimeGuaranteeProfile` IS a capability claim — lifting it into the receipt envelope means a counterparty's discovery-time guarantees ride along, signed and tamper-evident, with every receipt the agent later emits.

New feature on `nucleus-agent-card`: `envelope = ["dep:nucleus-receipt"]`, **default-OFF** — the default (wasm-pure) dependency closure is unchanged.

## Verify before you project (type-enforced)

`envelope::to_capability_projection(&VerifiedCard) -> Projection` takes ONLY a `VerifiedCard` — the output of `verify_card` against an out-of-band-resolved key — and deliberately NOT a raw `SignedAgentCard`. A raw signed card is an unverified blob; requiring the `VerifiedCard` witness makes "this card verified" a precondition the type system discharges. You cannot project a card you did not verify.

The narrow direction is deliberately asymmetric: `envelope::card_claims_from_projection(&Projection) -> Result<CardClaims, NarrowError>` returns a plain claims struct (`spiffe_id`, `did`, `supported_envelope_schema_versions`, `runtime_guarantees`, `advertised_jwks_kids`), NOT a reconstructed `VerifiedCard` — that would forge the verification witness. The receipt signature proves the issuer vouched for the claims; the card-level guarantee requires re-verifying the card itself. Distinct narrow errors: `NotCapability` / `NotAgentCard` / `MalformedBody`.

## The discovery→receipt story

At discovery time a counterparty verifies the agent's card and checks its declared IFC guarantee profile. With this seam, those exact verified claims are embedded under the stable inner shape `{"kind": "agent-card", "card": {…}}` inside `Projection::Capability`, then sealed by the receipt's Ed25519/BLAKE3 envelope — so every later receipt carries the guarantees that were in force when the relationship was established, and any in-transit rewrite of a declared guarantee fails the envelope's root-hash check before anything else is consulted.

## Tests

- `lift_then_narrow_is_identity_on_claims` — the round-trip law (narrow ∘ lift = id)
- `capability_body_shape_is_stable` — wire pin on `{"kind": "agent-card", "card": {…}}`
- `absent_profile_is_omitted_from_the_wire`
- `narrowing_rejects_non_capability_projection` / `narrowing_rejects_other_capability_bodies` / `narrowing_rejects_malformed_agent_card_bodies`
- `verified_card_travels_inside_a_signed_receipt_end_to_end` — real `sign_card` → `verify_card` → lift → `Receipt::sign` → `verify` → narrow → claims match
- `tampered_guarantee_inside_signed_envelope_fails_root_hash` — mutate an enforcement rule inside the signed body → `RootHashMismatch`

## Gates

- `cargo test -p nucleus-agent-card --all-features` — 29 passed
- `cargo clippy -p nucleus-agent-card --all-features --all-targets` — clean
- `cargo check --target wasm32-unknown-unknown -p nucleus-agent-card --features envelope` — green (PR #1841's wasm-portable verify path intact)
- `RUSTFLAGS="-D warnings" cargo hack check --each-feature --no-dev-deps -p nucleus-agent-card` — 5/5 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)