### PR TITLE
ci: no-op twins make the verification gates required-safe + CodeQL merge_group

### DIFF
--- a/.github/workflows/aeneas-ifc-scoped-noop.yml
+++ b/.github/workflows/aeneas-ifc-scoped-noop.yml
@@ -1,0 +1,31 @@
+name: Aeneas IFC (scoped extraction + noninterference)
+
+# NO-OP TWIN of aeneas-ifc-scoped.yml, so its job can be a REQUIRED status
+# check. Branch protection evaluates required contexts on the PR itself; the
+# real workflow is path-filtered on pull_request, so a PR not touching its
+# paths would never report the context and block forever. This twin has the
+# SAME workflow name and SAME job name, with `paths-ignore` exactly mirroring
+# the original's `paths`: exactly one of the twins reports the context on
+# every PR. (merge_group is NOT twinned — the real workflow already runs
+# unconditionally there.)
+
+on:
+  pull_request:
+    paths-ignore:
+      - "crates/portcullis-core/src/extracted/**"
+      - "crates/portcullis-core/lean/generated-ifc/**"
+      - "crates/portcullis-core/lean/IntegrityNoninterferenceExtracted.lean"
+      - "crates/portcullis-core/lean/lakefile.lean"
+      - ".github/workflows/aeneas-ifc-scoped.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  aeneas-ifc-scoped:
+    name: Scoped Aeneas (Rust → Lean 4) + parity tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: No-op (paths not touched)
+        run: echo "no relevant paths changed — gate vacuously green"

--- a/.github/workflows/aeneas-oidc-spiffe-noop.yml
+++ b/.github/workflows/aeneas-oidc-spiffe-noop.yml
@@ -1,0 +1,31 @@
+name: Aeneas OIDC→SPIFFE (scoped extraction + derivation properties)
+
+# NO-OP TWIN of aeneas-oidc-spiffe.yml, so its job can be a REQUIRED status
+# check. Branch protection evaluates required contexts on the PR itself; the
+# real workflow is path-filtered on pull_request, so a PR not touching its
+# paths would never report the context and block forever. This twin has the
+# SAME workflow name and SAME job name, with `paths-ignore` exactly mirroring
+# the original's `paths`: exactly one of the twins reports the context on
+# every PR. (merge_group is NOT twinned — the real workflow already runs
+# unconditionally there.)
+
+on:
+  pull_request:
+    paths-ignore:
+      - "crates/nucleus-github-oidc/src/extracted/**"
+      - "crates/nucleus-github-oidc/lean/generated/**"
+      - "crates/nucleus-github-oidc/lean/OidcSpiffeProofs.lean"
+      - "crates/nucleus-github-oidc/lean/lakefile.lean"
+      - ".github/workflows/aeneas-oidc-spiffe.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  aeneas-oidc-spiffe:
+    name: Scoped Aeneas (Rust → Lean 4) + parity tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: No-op (paths not touched)
+        run: echo "no relevant paths changed — gate vacuously green"

--- a/.github/workflows/ck-policy-aeneas-noop.yml
+++ b/.github/workflows/ck-policy-aeneas-noop.yml
@@ -1,0 +1,30 @@
+name: CK Policy Aeneas (extracted-core soundness)
+
+# NO-OP TWIN of ck-policy-aeneas.yml, so its job can be a REQUIRED status
+# check. Branch protection evaluates required contexts on the PR itself; the
+# real workflow is path-filtered on pull_request, so a PR not touching its
+# paths would never report the context and block forever. This twin has the
+# SAME workflow name and SAME job name, with `paths-ignore` exactly mirroring
+# the original's `paths`: exactly one of the twins reports the context on
+# every PR. (merge_group is NOT twinned — the real workflow already runs
+# unconditionally there.)
+
+on:
+  pull_request:
+    paths-ignore:
+      - "crates/ck-policy/lean-aeneas/**"
+      - "crates/ck-policy/src/extracted.rs"
+      - "crates/ck-policy/tests/policy_aeneas_parity.rs"
+      - ".github/workflows/ck-policy-aeneas.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  ck-policy-aeneas:
+    name: charon+aeneas drift + lake build (extracted-core soundness)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: No-op (paths not touched)
+        run: echo "no relevant paths changed — gate vacuously green"

--- a/.github/workflows/ck-policy-lean-noop.yml
+++ b/.github/workflows/ck-policy-lean-noop.yml
@@ -1,0 +1,28 @@
+name: CK Policy Lean Proofs
+
+# NO-OP TWIN of ck-policy-lean.yml, so its job can be a REQUIRED status check.
+# Branch protection evaluates required contexts on the PR itself; the real
+# workflow is path-filtered on pull_request, so a PR not touching its paths
+# would never report the context and block forever. This twin has the SAME
+# workflow name and SAME job name, with `paths-ignore` exactly mirroring the
+# original's `paths`: exactly one of the twins reports the context on every
+# PR. (merge_group is NOT twinned — the real workflow already runs
+# unconditionally there.)
+
+on:
+  pull_request:
+    paths-ignore:
+      - "crates/ck-policy/lean/**"
+      - ".github/workflows/ck-policy-lean.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  ck-policy-lean:
+    name: lake build Ck (monotonicity-gate soundness proofs)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: No-op (paths not touched)
+        run: echo "no relevant paths changed — gate vacuously green"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  merge_group:
   schedule:
     - cron: "30 4 * * 1"
 

--- a/.github/workflows/dep-hygiene-noop.yml
+++ b/.github/workflows/dep-hygiene-noop.yml
@@ -1,0 +1,33 @@
+name: Dependency Hygiene Gates
+
+# NO-OP TWIN of dep-hygiene.yml, so its job can be a REQUIRED status check.
+# Branch protection evaluates required contexts on the PR itself; the real
+# workflow is path-filtered on pull_request, so a PR not touching its paths
+# would never report the context and block forever. This twin has the SAME
+# workflow name and SAME job name, with `paths-ignore` exactly mirroring the
+# original's `paths`: exactly one of the twins reports the context on every
+# PR. (merge_group is NOT twinned — the real workflow already runs
+# unconditionally there.)
+
+on:
+  pull_request:
+    paths-ignore:
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "crates/**/Cargo.toml"
+      - "sdks/**/Cargo.toml"
+      - "scripts/check-dep-ceiling.sh"
+      - "scripts/check-wasm-closure.sh"
+      - ".github/workflows/dep-hygiene.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  dep-hygiene:
+    name: version ceiling + wasm closure
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: No-op (paths not touched)
+        run: echo "no relevant paths changed — gate vacuously green"

--- a/.github/workflows/econ-lean-noop.yml
+++ b/.github/workflows/econ-lean-noop.yml
@@ -1,0 +1,30 @@
+name: Econ Lean Proofs + Golden Seal
+
+# NO-OP TWIN of econ-lean.yml, so its job can be a REQUIRED status check.
+# Branch protection evaluates required contexts on the PR itself; the real
+# workflow is path-filtered on pull_request, so a PR not touching its paths
+# would never report the context and block forever. This twin has the SAME
+# workflow name and SAME job name, with `paths-ignore` exactly mirroring the
+# original's `paths`: exactly one of the twins reports the context on every
+# PR. (merge_group is NOT twinned — the real workflow already runs
+# unconditionally there.)
+
+on:
+  pull_request:
+    paths-ignore:
+      - "crates/nucleus-econ-kernels/lean/**"
+      - "crates/nucleus-econ-kernels/tests/golden/**"
+      - "scripts/gen-golden-lean.sh"
+      - ".github/workflows/econ-lean.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  econ-lean:
+    name: lake build Nucleus (econ proofs + golden seal)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: No-op (paths not touched)
+        run: echo "no relevant paths changed — gate vacuously green"

--- a/.github/workflows/rubric-lean-noop.yml
+++ b/.github/workflows/rubric-lean-noop.yml
@@ -1,0 +1,28 @@
+name: Rubric Lean Proofs
+
+# NO-OP TWIN of rubric-lean.yml, so its job can be a REQUIRED status check.
+# Branch protection evaluates required contexts on the PR itself; the real
+# workflow is path-filtered on pull_request, so a PR not touching its paths
+# would never report the context and block forever. This twin has the SAME
+# workflow name and SAME job name, with `paths-ignore` exactly mirroring the
+# original's `paths`: exactly one of the twins reports the context on every
+# PR. (merge_group is NOT twinned — the real workflow already runs
+# unconditionally there.)
+
+on:
+  pull_request:
+    paths-ignore:
+      - "crates/nucleus-rubric/lean/**"
+      - ".github/workflows/rubric-lean.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  rubric-lean:
+    name: lake build Nucleus (rubric scoring proofs)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: No-op (paths not touched)
+        run: echo "no relevant paths changed — gate vacuously green"


### PR DESCRIPTION
## Why

Branch protection evaluates required status-check contexts on the PR itself. Seven of our verification workflows are **path-filtered on `pull_request`**, so on a PR that doesn't touch their paths the workflow never runs, the context is never reported, and a required check would block the PR **forever**.

## The required-with-paths pattern (no-op twin)

For each path-filtered workflow we add a second workflow with the **same workflow `name:`** and the **same job key + job display name**, triggered on `pull_request` with `paths-ignore` **exactly mirroring** the original's `paths`. On every PR, exactly one of the two twins matches and reports the context:

- PR touches the gated paths → the **real** workflow runs and reports.
- PR doesn't → the **twin** runs (`echo "no relevant paths changed — gate vacuously green"`, ubuntu-latest, 5-min timeout, `contents: read`) and reports the same context name.

`merge_group` is deliberately **not** twinned: all seven originals already run unconditionally in the merge queue (bare `merge_group:`, no path filters — verified per file). All seven originals use `on.pull_request.paths` (none use `paths-ignore`), so all mirrors are the straightforward direction.

## Twinned contexts (safe to mark REQUIRED once this merges)

| Workflow | Required context (check-run name) |
|---|---|
| `aeneas-ifc-scoped.yml` | `Scoped Aeneas (Rust → Lean 4) + parity tests` |
| `aeneas-oidc-spiffe.yml` | `Scoped Aeneas (Rust → Lean 4) + parity tests` (same display name as the IFC job) |
| `ck-policy-lean.yml` | `lake build Ck (monotonicity-gate soundness proofs)` |
| `ck-policy-aeneas.yml` | `charon+aeneas drift + lake build (extracted-core soundness)` |
| `econ-lean.yml` | `lake build Nucleus (econ proofs + golden seal)` |
| `rubric-lean.yml` | `lake build Nucleus (rubric scoring proofs)` |
| `dep-hygiene.yml` | `version ceiling + wasm closure` |

Note: the two Aeneas workflows share one check-run name, so they contribute a single required context covering both.

## CodeQL

`codeql.yml` gains a bare `merge_group:` trigger so its `Analyze` job can report in the merge queue (it previously could not, which would block queued merges if required). Nothing else in it changed.

## Validation

- All changed/created YAML parses (`python3 yaml.safe_load`), and a script asserted each twin's `paths-ignore` list is byte-identical to its original's `paths`, names/job keys match, and the twin's only trigger is `pull_request`.
- `uvx zizmor==1.25.2 --min-severity high --no-progress .github/workflows/` → **0 findings**.

No branch-protection settings are changed by this PR; it only makes the contexts above safe to require.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
