### PR TITLE
fix(ci): decide_pure auto-commit sees untracked files

### DIFF
--- a/.github/workflows/aeneas-decide-pure.yml
+++ b/.github/workflows/aeneas-decide-pure.yml
@@ -169,7 +169,11 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          if git diff --quiet crates/portcullis-core/lean/generated-decide/; then
+          # git diff --quiet ignores UNTRACKED files — on the FIRST run
+          # generated-decide/ is brand-new and the old check skipped the
+          # commit while reporting success. status --porcelain sees both
+          # modified and untracked.
+          if [ -z "$(git status --porcelain crates/portcullis-core/lean/generated-decide/)" ]; then
             echo "No changes to generated-decide/ — nothing to commit."
             exit 0
           fi


### PR DESCRIPTION
First dispatch of `aeneas-decide-pure` (run 27283558001) extracted cleanly — the canonical Types/Funs are in the run log — but committed nothing: the `git diff --quiet` guard ignores **untracked** files, and on the first run `generated-decide/` is brand-new. Swap to `git status --porcelain` (sees modified + untracked). Will re-dispatch after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)