### PR TITLE
feat(agent-card)!: conform to the A2A v1.0 Agent Card schema

### DIFF
--- a/crates/nucleus-agent-card/README.md
+++ b/crates/nucleus-agent-card/README.md
@@ -1,14 +1,21 @@
 # nucleus-agent-card
 
 Verify-before-you-act identity layer for nucleus agents — sign/verify an
-A2A-style signed Agent Card and derive a `TrustAnchor` for the bundle verifier.
+**A2A protocol v1.0** Agent Card and derive a `TrustAnchor` for the bundle
+verifier.
 
 [![docs.rs](https://img.shields.io/docsrs/nucleus-agent-card)](https://docs.rs/nucleus-agent-card)
 
-An `AgentCard` is the [A2A](https://a2a-protocol.org/)-style document an agent
-publishes to say **who** it is and which JWKS its provenance bundles are signed
-under. This crate signs (`sign_card`, feature `sign`) and verifies
-(`verify_card`) a `SignedAgentCard`, then derives a
+An `AgentCard` is the [A2A v1.0](https://a2a-protocol.org/) manifest an agent
+publishes to say **who** it is. Nucleus claims — SPIFFE/DID identity, envelope
+schema versions, and the JWKS its provenance bundles are signed under — travel
+inside the spec's extension mechanism (`capabilities.extensions[]`) as the
+registered extension `https://coproduct.one/a2a/ext/runtime-guarantees/v1`
+(`NucleusClaims`). This crate signs (`sign_card`, feature `sign`) and verifies
+(`verify_card`) cards per spec §8.4 — a detached RFC 7515 JWS over the RFC 8785
+(JCS) canonicalization of the card with its `signatures` field excluded,
+protected header `{alg, typ: "JOSE", kid}`, carried in the card's own
+`signatures` array — then derives a
 [`nucleus_envelope::TrustAnchor`](../nucleus-envelope) (`trust_anchor_from_card`)
 so the existing bundle verifier can decide whether to **act** on a bundle.
 
@@ -21,8 +28,10 @@ so the existing bundle verifier can decide whether to **act** on a bundle.
 - **Never trust a key embedded in the card.** `verify_card` reads its
   verification key *only* from the caller's out-of-band-resolved `resolved_key`
   argument (DID resolution, a pinned JWKS, an operator file). It does not read
-  any key — or `kid` — from the card or signature. The card's `jwks_uri` is a
-  *hint* for where to resolve the key, not the key itself.
+  any key — or the protected header's `kid`/`jku` — from the card or signature.
+  The claims' `jwks_uri` is a *hint* for where to resolve the key, not the key
+  itself. (A2A §8.4.3 permits resolving "from a trusted key store"; that is the
+  only mode implemented here.)
 - **This is the WHO-layer, not the WHAT-layer.** Verifying a card establishes
   identity and the claimed JWKS. It does **not** verify any payload or bundle —
   that's `nucleus_envelope::verify_bundle`'s job, anchored by the `TrustAnchor`
@@ -36,17 +45,19 @@ so the existing bundle verifier can decide whether to **act** on a bundle.
 
 ```rust,ignore
 // server side (feature = "sign"):
-let signed = sign_card(card, &pkcs8_der)?;
+let card   = base_card.with_nucleus_claims(&claims)?;
+let signed = sign_card(card, &pkcs8_der, "card-key-1")?;
 
 // recipient side (secret-free):
-let resolved = resolve_key_out_of_band(&signed.card.did)?; // YOUR job
+let resolved = resolve_key_out_of_band(did)?; // YOUR job
 let verified = verify_card(&signed, &resolved)?;
 let anchor   = trust_anchor_from_card(&verified);
 let report   = nucleus_envelope::verify_bundle(&bundle, &anchor)?; // ACT only if this succeeds
 ```
 
-Cards are canonicalized with JCS (`canonicalize`) before signing/verifying so the
-signature is over a deterministic byte representation.
+Cards are canonicalized with RFC 8785 JCS (`canonicalize`, `signatures`
+excluded per A2A §8.4.1) before signing/verifying so the signature is over a
+deterministic byte representation.
 
 ## Feature flags
 

--- a/crates/nucleus-agent-card/examples/agent_sign.rs
+++ b/crates/nucleus-agent-card/examples/agent_sign.rs
@@ -1,5 +1,6 @@
-//! `agent-sign` — sign an Agent Card that declares an IFC runtime-guarantee
-//! profile, then verify it (incl. tamper-detection of the profile).
+//! `agent-sign` — sign an A2A v1.0 Agent Card whose nucleus extension
+//! declares an IFC runtime-guarantee profile, then verify it (incl.
+//! tamper-detection of the profile).
 //!
 //! Run with:
 //!
@@ -19,7 +20,9 @@ use ring::rand::SystemRandom;
 use ring::signature::{EcdsaKeyPair, KeyPair, ECDSA_P256_SHA256_FIXED_SIGNING};
 
 use nucleus_agent_card::{
-    sign_card, verify_card, AgentCard, EnforcementRule, JsonWebKey, RuntimeGuaranteeProfile,
+    sign_card, verify_card, AgentCapabilities, AgentCard, AgentInterface, EnforcementRule,
+    JsonWebKey, NucleusClaims, RuntimeGuaranteeProfile, A2A_PROTOCOL_VERSION,
+    NUCLEUS_EXTENSION_URI,
 };
 use nucleus_lineage::{Jwks, LocalIssuer};
 
@@ -36,12 +39,34 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         URL_SAFE_NO_PAD.encode(&pk[33..65]),
     );
 
-    // The agent's card, declaring the IFC guarantee it enforces at runtime.
+    // The agent's A2A v1.0 card. Nucleus claims (identity, trust JWKS, and
+    // the IFC guarantee the agent declares it enforces at runtime) travel
+    // in the registered extension NUCLEUS_EXTENSION_URI.
     let trust_jwks: Jwks = serde_json::from_value(LocalIssuer::random()?.publish_jwks())?;
-    let card = AgentCard {
+    let base_card = AgentCard {
+        name: "Summarizer Agent".to_string(),
+        description: "Summarizes documents and emits provenance receipts.".to_string(),
+        supported_interfaces: vec![AgentInterface {
+            url: "https://summarizer.prod.example.com/a2a/v1".to_string(),
+            protocol_binding: "JSONRPC".to_string(),
+            tenant: None,
+            protocol_version: A2A_PROTOCOL_VERSION.to_string(),
+        }],
+        provider: None,
+        version: "1.0.0".to_string(),
+        documentation_url: None,
+        capabilities: AgentCapabilities::default(),
+        security_schemes: serde_json::Map::new(),
+        security_requirements: vec![],
+        default_input_modes: vec!["application/json".to_string()],
+        default_output_modes: vec!["application/json".to_string()],
+        skills: vec![],
+        signatures: vec![],
+        icon_url: None,
+    };
+    let card = base_card.with_nucleus_claims(&NucleusClaims {
         spiffe_id: "spiffe://prod.example.com/ns/agents/sa/summarizer".to_string(),
         did: "did:web:summarizer.prod.example.com".to_string(),
-        security_schemes: serde_json::json!({}),
         supported_envelope_schema_versions: vec!["1".to_string()],
         jwks_uri: None,
         trust_jwks,
@@ -68,10 +93,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             // Advisory: point at an external policy (e.g. an MS ACS policy id).
             attestation_reference: None,
         }),
-    };
+    })?;
 
-    // Sign → verify.
-    let signed = sign_card(card, pkcs8.as_ref())?;
+    // Sign → verify. The §8.4.2 protected header carries alg/typ/kid.
+    let signed = sign_card(card, pkcs8.as_ref(), "card-key-1")?;
     println!(
         "signed agent card:\n{}",
         serde_json::to_string_pretty(&signed)?
@@ -79,26 +104,28 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let verified = verify_card(&signed, &resolved_key)?;
     let profile = verified
-        .card
+        .claims
         .runtime_guarantees
         .as_ref()
         .expect("the verified card carries its IFC profile");
     println!("\nverified ✓  — IFC profile is authentic + untampered:");
-    println!("  spiffe_id        = {}", verified.card.spiffe_id);
+    println!("  spiffe_id        = {}", verified.claims.spiffe_id);
     println!("  tracked_sources  = {:?}", profile.tracked_sources);
     for rule in &profile.enforcement_rules {
         println!("  rule             = {} — {}", rule.name, rule.description);
     }
 
-    // Tamper-detection: flip a declared rule after signing → verify must fail.
+    // Tamper-detection: flip a declared rule (inside the signed extension
+    // params) after signing → verify must fail.
     let mut tampered = signed;
-    tampered
-        .card
-        .runtime_guarantees
-        .as_mut()
-        .unwrap()
-        .enforcement_rules[0]
-        .name = "allow_everything".to_string();
+    let ext = tampered
+        .capabilities
+        .extensions
+        .iter_mut()
+        .find(|e| e.uri == NUCLEUS_EXTENSION_URI)
+        .expect("nucleus extension present");
+    ext.params.as_mut().unwrap()["runtimeGuarantees"]["enforcementRules"][0]["name"] =
+        serde_json::json!("allow_everything");
     match verify_card(&tampered, &resolved_key) {
         Err(_) => println!("\ntamper check ✓  — flipping a declared rule breaks the signature"),
         Ok(_) => panic!("BUG: a tampered profile must not verify"),

--- a/crates/nucleus-agent-card/src/card.rs
+++ b/crates/nucleus-agent-card/src/card.rs
@@ -1,5 +1,19 @@
-//! Agent Card types — an A2A-style identity document plus its detached
-//! RFC 7515 JWS-JSON signatures.
+//! Agent Card types — the A2A protocol **v1.0** `AgentCard` plus its
+//! embedded RFC 7515 JWS signatures.
+//!
+//! Conformance target: the A2A v1.0.1 specification, whose
+//! `specification/a2a.proto` is the *single authoritative normative
+//! definition* of the data objects, serialized to JSON per ProtoJSON
+//! (A2A ADR-001): lowerCamelCase wire names, optional/default fields
+//! omitted when unset. Signing is §8.4: detached JWS over the RFC 8785
+//! JCS canonicalization of the card with the `signatures` field excluded.
+//!
+//! Nucleus-specific claims (SPIFFE/DID identity, the trust JWKS, envelope
+//! schema versions, the [`RuntimeGuaranteeProfile`]) do NOT live as
+//! top-level card fields — v1.0 has no such fields. They travel inside the
+//! spec's extension mechanism (`capabilities.extensions[]`) as the
+//! registered extension [`NUCLEUS_EXTENSION_URI`], typed here as
+//! [`NucleusClaims`].
 //!
 //! These are pure data; signing lives in [`crate::sign`] (feature-gated)
 //! and verification in [`crate::verify`] (always available).
@@ -12,39 +26,336 @@
 //! card. The canonicalization in [`crate::jcs`] covers exactly the
 //! fields defined here — what we sign is what we know.
 
+use std::collections::BTreeMap;
+
 use serde::{Deserialize, Serialize};
 
-/// The self-describing identity document an agent publishes (typically at
-/// `/.well-known/agent-card.json`).
+use crate::{Error, Result};
+
+/// The A2A protocol version this crate's [`AgentCard`] conforms to, as
+/// advertised per-interface in [`AgentInterface::protocol_version`].
+pub const A2A_PROTOCOL_VERSION: &str = "1.0";
+
+/// The registered extension URI under which nucleus's verify-before-you-act
+/// claims ([`NucleusClaims`]) travel inside `capabilities.extensions[]`.
 ///
-/// The card advertises WHO the agent is (`spiffe_id`, `did`), how to talk
-/// to it (`security_schemes`, `supported_envelope_schema_versions`), and —
-/// critically for the verify-before-you-act flow — the JWKS the agent
-/// claims its provenance bundles are signed under (`trust_jwks`).
+/// Versioned independently of the card: a breaking change to
+/// [`NucleusClaims`] bumps the trailing `/v1`.
+pub const NUCLEUS_EXTENSION_URI: &str = "https://coproduct.one/a2a/ext/runtime-guarantees/v1";
+
+/// `skip_serializing_if` helper: omit a `bool` field when `false` (the
+/// ProtoJSON default-omission rule for proto3 implicit-presence fields).
+#[allow(clippy::trivially_copy_pass_by_ref)] // serde requires `&T`
+fn is_false(b: &bool) -> bool {
+    !*b
+}
+
+/// The self-describing A2A **v1.0** identity manifest an agent publishes
+/// (typically at `/.well-known/agent-card.json`).
+///
+/// Field set and wire names follow `a2a.proto` `message AgentCard`
+/// (Next ID: 20) under ProtoJSON serialization. Fields the proto marks
+/// `REQUIRED` are non-optional here; optional/default-omitted fields are
+/// `Option`/empty-skipped so our serialization matches the §8.4.1
+/// presence rules a signer and verifier must agree on.
+///
+/// **Nucleus claims live in the extension, not here.** Use
+/// [`AgentCard::nucleus_claims`] to extract them and
+/// [`AgentCard::with_nucleus_claims`] to attach them. The advertised
+/// trust JWKS inside those claims is a CLAIM, not an anchor — it only
+/// becomes load-bearing once the card itself has been verified against an
+/// out-of-band-resolved key (see [`crate::verify::verify_card`]).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentCard {
+    /// Human-readable agent name (REQUIRED). Example: `"Recipe Agent"`.
+    pub name: String,
+
+    /// Human-readable description of the agent (REQUIRED).
+    pub description: String,
+
+    /// Ordered list of supported interfaces; the first entry is preferred
+    /// (REQUIRED).
+    pub supported_interfaces: Vec<AgentInterface>,
+
+    /// The service provider of the agent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider: Option<AgentProvider>,
+
+    /// The version of the agent (REQUIRED). Example: `"1.0.0"`.
+    pub version: String,
+
+    /// URL providing additional documentation about the agent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub documentation_url: Option<String>,
+
+    /// A2A capability set supported by the agent (REQUIRED). Nucleus's
+    /// extension rides in `capabilities.extensions`.
+    pub capabilities: AgentCapabilities,
+
+    /// Security scheme details for authenticating with this agent
+    /// (`map<string, SecurityScheme>` in the proto). Opaque JSON — this
+    /// crate does not interpret it.
+    #[serde(default, skip_serializing_if = "serde_json::Map::is_empty")]
+    pub security_schemes: serde_json::Map<String, serde_json::Value>,
+
+    /// Security requirements for contacting the agent.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub security_requirements: Vec<SecurityRequirement>,
+
+    /// Interaction media types the agent supports across all skills
+    /// (REQUIRED). Overridable per skill.
+    pub default_input_modes: Vec<String>,
+
+    /// Output media types supported across all skills (REQUIRED).
+    pub default_output_modes: Vec<String>,
+
+    /// Skills — the agent's distinct abilities (REQUIRED; may be empty).
+    pub skills: Vec<AgentSkill>,
+
+    /// JSON Web Signatures computed for this card (§8.4). EXCLUDED from
+    /// the signed/canonicalized content — see [`crate::jcs::canonicalize`].
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub signatures: Vec<AgentCardSignature>,
+
+    /// URL to an icon for the agent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub icon_url: Option<String>,
+}
+
+impl AgentCard {
+    /// The nucleus extension entry, if this card declares one.
+    pub fn nucleus_extension(&self) -> Option<&AgentExtension> {
+        self.capabilities
+            .extensions
+            .iter()
+            .find(|e| e.uri == NUCLEUS_EXTENSION_URI)
+    }
+
+    /// Extract the typed [`NucleusClaims`] from the card's
+    /// [`NUCLEUS_EXTENSION_URI`] extension.
+    ///
+    /// Returns `Ok(None)` when the card does not declare the extension at
+    /// all (a plain A2A card from a non-nucleus agent).
+    ///
+    /// # Errors
+    ///
+    /// [`Error::Extension`] when the extension is declared but its
+    /// `params` are missing or do not deserialize as [`NucleusClaims`] —
+    /// a declared-but-malformed claim set is an error, not an absence.
+    pub fn nucleus_claims(&self) -> Result<Option<NucleusClaims>> {
+        let Some(ext) = self.nucleus_extension() else {
+            return Ok(None);
+        };
+        let params = ext.params.as_ref().ok_or_else(|| {
+            Error::Extension("nucleus extension is declared but has no params".to_string())
+        })?;
+        let claims: NucleusClaims = serde_json::from_value(params.clone())
+            .map_err(|e| Error::Extension(format!("nucleus extension params: {e}")))?;
+        Ok(Some(claims))
+    }
+
+    /// Attach (or replace) the nucleus extension carrying `claims`.
+    ///
+    /// The extension is declared `required: false` — a non-nucleus A2A
+    /// client can still talk to the agent; the claims matter to
+    /// counterparties running the verify-before-you-act flow.
+    ///
+    /// # Errors
+    ///
+    /// [`Error::Extension`] if the claims fail to serialize (practically
+    /// unreachable for well-formed claims).
+    pub fn with_nucleus_claims(mut self, claims: &NucleusClaims) -> Result<Self> {
+        let params = serde_json::to_value(claims)
+            .map_err(|e| Error::Extension(format!("serialize nucleus claims: {e}")))?;
+        let ext = AgentExtension {
+            uri: NUCLEUS_EXTENSION_URI.to_string(),
+            description: "nucleus verify-before-you-act claims: SPIFFE/DID identity, \
+                          trust JWKS, envelope schema versions, runtime-guarantee profile"
+                .to_string(),
+            required: false,
+            params: Some(params),
+        };
+        if let Some(existing) = self
+            .capabilities
+            .extensions
+            .iter_mut()
+            .find(|e| e.uri == NUCLEUS_EXTENSION_URI)
+        {
+            *existing = ext;
+        } else {
+            self.capabilities.extensions.push(ext);
+        }
+        Ok(self)
+    }
+}
+
+/// One target URL + protocol binding + protocol version the agent serves
+/// (`a2a.proto` `message AgentInterface`).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentInterface {
+    /// Where this interface is available (REQUIRED). Absolute HTTPS URL in
+    /// production.
+    pub url: String,
+
+    /// Protocol binding at this URL (REQUIRED). Open string; the core
+    /// official values are `"JSONRPC"`, `"GRPC"` and `"HTTP+JSON"`.
+    pub protocol_binding: String,
+
+    /// Opaque routing identifier for multi-tenant endpoints.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tenant: Option<String>,
+
+    /// The A2A protocol version this interface exposes (REQUIRED), e.g.
+    /// [`A2A_PROTOCOL_VERSION`].
+    pub protocol_version: String,
+}
+
+/// The service provider of an agent (`a2a.proto` `message AgentProvider`).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentProvider {
+    /// URL for the provider's website or relevant documentation (REQUIRED).
+    pub url: String,
+
+    /// Name of the provider's organization (REQUIRED).
+    pub organization: String,
+}
+
+/// Optional capabilities supported by an agent
+/// (`a2a.proto` `message AgentCapabilities`).
+///
+/// The three booleans are `optional bool` in the proto (explicit
+/// presence): when set — even to `false` — they appear on the wire; when
+/// unset they are omitted. `Option<bool>` reproduces exactly that.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentCapabilities {
+    /// Supports streaming responses.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub streaming: Option<bool>,
+
+    /// Supports push notifications for asynchronous task updates.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub push_notifications: Option<bool>,
+
+    /// Protocol extensions supported by the agent. Nucleus's claims travel
+    /// here under [`NUCLEUS_EXTENSION_URI`].
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub extensions: Vec<AgentExtension>,
+
+    /// Supports an extended agent card when authenticated.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extended_agent_card: Option<bool>,
+}
+
+/// A declaration of a protocol extension supported by an agent
+/// (`a2a.proto` `message AgentExtension`).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentExtension {
+    /// The unique URI identifying the extension.
+    pub uri: String,
+
+    /// Human-readable description of how this agent uses the extension.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub description: String,
+
+    /// If true, the client must understand and comply with the extension's
+    /// requirements.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub required: bool,
+
+    /// Extension-specific configuration parameters (`google.protobuf.Struct`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub params: Option<serde_json::Value>,
+}
+
+/// Security requirements for an agent
+/// (`a2a.proto` `message SecurityRequirement`): a map of security-scheme
+/// names to required scopes.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SecurityRequirement {
+    /// Scheme name → required scopes.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub schemes: BTreeMap<String, StringList>,
+}
+
+/// A list of strings (`a2a.proto` `message StringList`) — the scope list
+/// inside a [`SecurityRequirement`].
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct StringList {
+    /// The individual string values.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub list: Vec<String>,
+}
+
+/// A distinct capability or function an agent can perform
+/// (`a2a.proto` `message AgentSkill`).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentSkill {
+    /// Unique identifier for the skill (REQUIRED).
+    pub id: String,
+
+    /// Human-readable skill name (REQUIRED).
+    pub name: String,
+
+    /// Detailed description of the skill (REQUIRED).
+    pub description: String,
+
+    /// Keywords describing the skill's capabilities (REQUIRED).
+    pub tags: Vec<String>,
+
+    /// Example prompts or scenarios this skill can handle.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub examples: Vec<String>,
+
+    /// Supported input media types, overriding the agent's defaults.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub input_modes: Vec<String>,
+
+    /// Supported output media types, overriding the agent's defaults.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub output_modes: Vec<String>,
+
+    /// Security schemes necessary for this skill.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub security_requirements: Vec<SecurityRequirement>,
+}
+
+/// The nucleus verify-before-you-act claim set carried as the `params` of
+/// the [`NUCLEUS_EXTENSION_URI`] extension.
+///
+/// This is everything nucleus needs beyond the base A2A card: WHO the
+/// agent is (`spiffe_id`, `did`), what it speaks
+/// (`supported_envelope_schema_versions`), and — critically — the JWKS the
+/// agent claims its provenance bundles are signed under (`trust_jwks`).
 ///
 /// **The advertised `trust_jwks` is a CLAIM, not an anchor.** It only
 /// becomes load-bearing once the card itself has been verified against an
 /// out-of-band-resolved key (see [`crate::verify::verify_card`]) AND the
 /// recipient refuses to act on any bundle that doesn't verify against it.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AgentCard {
-    /// SPIFFE identity of the agent (e.g. `spiffe://prod.example.com/ns/agents/sa/coder`).
+#[serde(rename_all = "camelCase")]
+pub struct NucleusClaims {
+    /// SPIFFE identity of the agent
+    /// (e.g. `spiffe://prod.example.com/ns/agents/sa/coder`).
     pub spiffe_id: String,
 
-    /// Decentralized identifier for the agent (e.g. `did:web:coder.prod.example.com`).
+    /// Decentralized identifier for the agent
+    /// (e.g. `did:web:coder.prod.example.com`).
     pub did: String,
 
-    /// A2A-style security schemes describing how callers authenticate to
-    /// the agent. Opaque JSON — this crate does not interpret it.
-    pub security_schemes: serde_json::Value,
-
     /// Envelope/bundle schema versions this agent can produce or consume.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub supported_envelope_schema_versions: Vec<String>,
 
     /// Optional URI where the agent's JWKS is published out-of-band. A
     /// recipient MAY resolve this to obtain the verification key for the
     /// card; it is NOT trusted material on its own.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub jwks_uri: Option<String>,
 
     /// The JWKS the agent advertises as authoritative for its provenance
@@ -60,8 +371,8 @@ pub struct AgentCard {
     pub runtime_guarantees: Option<RuntimeGuaranteeProfile>,
 }
 
-/// A declared runtime information-flow-control (IFC) guarantee profile, carried
-/// inside a signed [`AgentCard`].
+/// A declared runtime information-flow-control (IFC) guarantee profile,
+/// carried inside the signed card's [`NucleusClaims`].
 ///
 /// # What a verified profile proves — and does not
 ///
@@ -73,6 +384,7 @@ pub struct AgentCard {
 /// evidence that the declared rules were actually evaluated at runtime; a
 /// verifier checks them post-hoc, client-side. Enforcement remains host-side.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
 pub struct RuntimeGuaranteeProfile {
     /// Profile schema version (e.g. `"1.0"`), versioned independently of the card.
     pub profile_version: String,
@@ -102,53 +414,40 @@ pub struct EnforcementRule {
     pub description: String,
 }
 
-/// One detached RFC 7515 JWS-JSON signature over the JCS-canonicalized
-/// [`AgentCard`].
+/// One JWS signature of an [`AgentCard`] (`a2a.proto`
+/// `message AgentCardSignature`, spec §8.4.2): the JSON form of an RFC
+/// 7515 JWS with the payload detached.
 ///
 /// "Detached" means the JWS payload segment is dropped on the wire: the
-/// recipient reconstructs it by canonicalizing the `card` itself. This is
-/// what binds the signature to the exact card content without duplicating
-/// the bytes.
+/// recipient reconstructs it as the JCS canonicalization of the card with
+/// the `signatures` field excluded (§8.4.1). This binds the signature to
+/// the exact card content without duplicating the bytes.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AgentCardSignature {
-    /// Base64url-encoded protected JWS header (e.g. `{"alg":"ES256"}`).
+    /// Base64url-encoded protected JWS header. Per §8.4.2 the header MUST
+    /// include `alg` and `kid` (and SHOULD set `typ: "JOSE"`); it MAY
+    /// include `jku`.
     pub protected: String,
 
-    /// Base64url-encoded signature over `protected || "." || base64url(JCS(card))`.
+    /// Base64url-encoded signature over
+    /// `protected || "." || base64url(JCS(card minus signatures))`.
     pub signature: String,
 
-    /// Optional unprotected JWS header (RFC 7515 §7.2.1). Not covered by
-    /// the signature; carry hints like `kid` here at the producer's risk.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Optional unprotected JWS header (RFC 7515 §7.2.1), as a plain JSON
+    /// object (not base64url-encoded). Not covered by the signature; carry
+    /// hints here at the producer's risk.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub header: Option<serde_json::Value>,
-}
-
-/// An [`AgentCard`] plus one or more detached signatures.
-///
-/// The verifier uses the FIRST signature (see [`crate::verify::verify_card`]).
-/// Multiple signatures are permitted for key-rotation / co-signing but the
-/// trust decision is made against the caller's out-of-band-resolved key,
-/// not against any `kid` the card or signature claims.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SignedAgentCard {
-    /// The identity document.
-    pub card: AgentCard,
-
-    /// Detached JWS-JSON signatures over the JCS of `card`.
-    pub signatures: Vec<AgentCardSignature>,
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn sample_card() -> AgentCard {
-        AgentCard {
+    fn sample_claims() -> NucleusClaims {
+        NucleusClaims {
             spiffe_id: "spiffe://prod.example.com/ns/agents/sa/coder".to_string(),
             did: "did:web:coder.prod.example.com".to_string(),
-            security_schemes: serde_json::json!({
-                "bearer": {"type": "http", "scheme": "bearer"}
-            }),
             supported_envelope_schema_versions: vec!["1".to_string(), "2".to_string()],
             jwks_uri: Some("https://coder.prod.example.com/.well-known/jwks.json".to_string()),
             trust_jwks: nucleus_lineage::Jwks {
@@ -167,12 +466,40 @@ mod tests {
         }
     }
 
+    fn sample_card() -> AgentCard {
+        AgentCard {
+            name: "Coder Agent".to_string(),
+            description: "Writes and reviews code with provenance receipts.".to_string(),
+            supported_interfaces: vec![AgentInterface {
+                url: "https://coder.prod.example.com/a2a/v1".to_string(),
+                protocol_binding: "JSONRPC".to_string(),
+                tenant: None,
+                protocol_version: A2A_PROTOCOL_VERSION.to_string(),
+            }],
+            provider: Some(AgentProvider {
+                url: "https://coproduct.one".to_string(),
+                organization: "Coproduct".to_string(),
+            }),
+            version: "1.0.0".to_string(),
+            documentation_url: None,
+            capabilities: AgentCapabilities::default(),
+            security_schemes: serde_json::Map::new(),
+            security_requirements: vec![],
+            default_input_modes: vec!["application/json".to_string()],
+            default_output_modes: vec!["application/json".to_string()],
+            skills: vec![],
+            signatures: vec![],
+            icon_url: None,
+        }
+        .with_nucleus_claims(&sample_claims())
+        .unwrap()
+    }
+
     #[test]
     fn agent_card_serde_round_trip() {
         let card = sample_card();
         let json = serde_json::to_string(&card).unwrap();
         let back: AgentCard = serde_json::from_str(&json).unwrap();
-        // Jwks has no PartialEq, so compare via canonical JSON value.
         assert_eq!(
             serde_json::to_value(&card).unwrap(),
             serde_json::to_value(&back).unwrap()
@@ -180,35 +507,185 @@ mod tests {
     }
 
     #[test]
-    fn signed_agent_card_serde_round_trip() {
-        let signed = SignedAgentCard {
-            card: sample_card(),
-            signatures: vec![AgentCardSignature {
-                protected: "eyJhbGciOiJFUzI1NiJ9".to_string(),
-                signature: "c2lnbmF0dXJl".to_string(),
-                header: Some(serde_json::json!({"kid": "k1"})),
-            }],
-        };
-        let json = serde_json::to_string(&signed).unwrap();
-        let back: SignedAgentCard = serde_json::from_str(&json).unwrap();
+    fn wire_names_are_a2a_v1_camel_case() {
+        // Pin the ProtoJSON wire names from a2a.proto — drift here breaks
+        // interop with every conformant A2A v1.0 implementation.
+        let json = serde_json::to_value(sample_card()).unwrap();
+        let obj = json.as_object().unwrap();
+        for key in [
+            "name",
+            "description",
+            "supportedInterfaces",
+            "provider",
+            "version",
+            "capabilities",
+            "defaultInputModes",
+            "defaultOutputModes",
+            "skills",
+        ] {
+            assert!(obj.contains_key(key), "missing v1.0 wire key `{key}`");
+        }
+        // snake_case must NOT leak onto the wire.
+        for key in [
+            "supported_interfaces",
+            "default_input_modes",
+            "spiffe_id",
+            "trust_jwks",
+        ] {
+            assert!(!obj.contains_key(key), "non-v1.0 wire key `{key}` present");
+        }
+        let iface = &json["supportedInterfaces"][0];
+        assert_eq!(iface["protocolBinding"], "JSONRPC");
+        assert_eq!(iface["protocolVersion"], "1.0");
+    }
+
+    #[test]
+    fn nucleus_claims_round_trip_through_the_extension() {
+        let card = sample_card();
+        let ext = card.nucleus_extension().expect("extension attached");
+        assert_eq!(ext.uri, NUCLEUS_EXTENSION_URI);
+        assert!(!ext.required, "nucleus extension must not gate A2A clients");
+
+        let claims = card.nucleus_claims().unwrap().expect("claims present");
         assert_eq!(
-            serde_json::to_value(&signed).unwrap(),
+            claims.spiffe_id,
+            "spiffe://prod.example.com/ns/agents/sa/coder"
+        );
+        assert_eq!(claims.did, "did:web:coder.prod.example.com");
+        assert_eq!(claims.trust_jwks.keys[0].kid, "k1");
+
+        // Claims serialize camelCase inside the params.
+        let params = ext.params.as_ref().unwrap();
+        assert!(params.get("spiffeId").is_some());
+        assert!(params.get("trustJwks").is_some());
+        assert!(params.get("spiffe_id").is_none());
+    }
+
+    #[test]
+    fn card_without_nucleus_extension_yields_no_claims() {
+        let mut card = sample_card();
+        card.capabilities.extensions.clear();
+        assert!(card.nucleus_claims().unwrap().is_none());
+    }
+
+    #[test]
+    fn declared_but_malformed_nucleus_extension_is_an_error() {
+        let mut card = sample_card();
+        // Declared with no params at all.
+        card.capabilities.extensions[0].params = None;
+        assert!(matches!(card.nucleus_claims(), Err(Error::Extension(_))));
+        // Declared with params that are not NucleusClaims.
+        card.capabilities.extensions[0].params = Some(serde_json::json!({"spiffeId": 42}));
+        assert!(matches!(card.nucleus_claims(), Err(Error::Extension(_))));
+    }
+
+    #[test]
+    fn with_nucleus_claims_replaces_an_existing_extension() {
+        let card = sample_card();
+        let mut claims = card.nucleus_claims().unwrap().unwrap();
+        claims.did = "did:web:rotated.example.com".to_string();
+        let card = card.with_nucleus_claims(&claims).unwrap();
+        assert_eq!(
+            card.capabilities
+                .extensions
+                .iter()
+                .filter(|e| e.uri == NUCLEUS_EXTENSION_URI)
+                .count(),
+            1,
+            "re-attaching must replace, not duplicate"
+        );
+        assert_eq!(
+            card.nucleus_claims().unwrap().unwrap().did,
+            "did:web:rotated.example.com"
+        );
+    }
+
+    #[test]
+    fn optional_and_default_fields_are_omitted_per_8_4_1() {
+        // §8.4.1: unset optional fields and default-valued fields MUST be
+        // omitted — our serde skips are the implementation of that rule.
+        let mut card = sample_card();
+        card.capabilities.extensions.clear();
+        card.provider = None;
+        let json = serde_json::to_value(&card).unwrap();
+        let obj = json.as_object().unwrap();
+        for absent in [
+            "provider",
+            "documentationUrl",
+            "securitySchemes",
+            "securityRequirements",
+            "signatures",
+            "iconUrl",
+        ] {
+            assert!(!obj.contains_key(absent), "`{absent}` must be omitted");
+        }
+        // capabilities is REQUIRED → present even when everything inside
+        // is unset (it serializes as the empty object).
+        assert_eq!(json["capabilities"], serde_json::json!({}));
+        // skills is REQUIRED → present even when empty.
+        assert_eq!(json["skills"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn explicitly_set_false_capabilities_stay_on_the_wire() {
+        // `optional bool` = explicit presence: Some(false) is serialized.
+        let mut card = sample_card();
+        card.capabilities.streaming = Some(false);
+        let json = serde_json::to_value(&card).unwrap();
+        assert_eq!(json["capabilities"]["streaming"], serde_json::json!(false));
+    }
+
+    #[test]
+    fn security_requirement_wire_shape_matches_protojson() {
+        // ProtoJSON of `SecurityRequirement{schemes: map<string,StringList>}`.
+        let req = SecurityRequirement {
+            schemes: BTreeMap::from([(
+                "oauth".to_string(),
+                StringList {
+                    list: vec!["openid".to_string()],
+                },
+            )]),
+        };
+        assert_eq!(
+            serde_json::to_value(&req).unwrap(),
+            serde_json::json!({"schemes": {"oauth": {"list": ["openid"]}}})
+        );
+    }
+
+    #[test]
+    fn signed_card_serde_round_trip() {
+        let mut card = sample_card();
+        card.signatures = vec![AgentCardSignature {
+            protected: "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpPU0UiLCJraWQiOiJrZXktMSJ9".to_string(),
+            signature: "c2lnbmF0dXJl".to_string(),
+            header: Some(serde_json::json!({"hint": "rotation-2026"})),
+        }];
+        let json = serde_json::to_string(&card).unwrap();
+        let back: AgentCard = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            serde_json::to_value(&card).unwrap(),
             serde_json::to_value(&back).unwrap()
         );
+        assert_eq!(back.signatures.len(), 1);
     }
 
     #[test]
     fn unknown_fields_are_ignored_forward_compat() {
         // A newer producer adds a field this verifier doesn't model.
         let json = serde_json::json!({
-            "spiffe_id": "spiffe://prod.example.com/ns/agents/sa/coder",
-            "did": "did:web:coder.prod.example.com",
-            "security_schemes": {},
-            "supported_envelope_schema_versions": ["1"],
-            "trust_jwks": {"keys": []},
+            "name": "Future Agent",
+            "description": "from a newer producer",
+            "supportedInterfaces": [
+                {"url": "https://x.example.com/a2a/v1", "protocolBinding": "JSONRPC", "protocolVersion": "1.1"}
+            ],
+            "version": "2.0.0",
+            "capabilities": {},
+            "defaultInputModes": ["application/json"],
+            "defaultOutputModes": ["application/json"],
+            "skills": [],
             "future_field_we_dont_know": {"nested": true}
         });
         let card: AgentCard = serde_json::from_value(json).unwrap();
-        assert_eq!(card.did, "did:web:coder.prod.example.com");
+        assert_eq!(card.name, "Future Agent");
     }
 }

--- a/crates/nucleus-agent-card/src/envelope.rs
+++ b/crates/nucleus-agent-card/src/envelope.rs
@@ -5,7 +5,10 @@
 //! (`spiffe_id`, `did`), what it speaks
 //! (`supported_envelope_schema_versions`), which keys it claims sign its
 //! provenance (`trust_jwks` kids), and — the load-bearing part — its declared
-//! [`RuntimeGuaranteeProfile`](crate::RuntimeGuaranteeProfile). Putting those
+//! [`RuntimeGuaranteeProfile`](crate::RuntimeGuaranteeProfile). On the A2A
+//! v1.0 card those claims travel as the
+//! [`NucleusClaims`](crate::NucleusClaims) extension; here the verified
+//! subset is lifted into the receipt envelope. Putting those
 //! claims into [`Projection::Capability`] means the guarantees a counterparty
 //! checked at discovery time ride along, signed, inside every
 //! [`Receipt`](nucleus_receipt::Receipt) the agent later emits — the receipt's
@@ -14,8 +17,8 @@
 //! ## Verify before you project (type-enforced)
 //!
 //! [`to_capability_projection`] takes a [`VerifiedCard`] — the output of
-//! [`verify_card`](crate::verify_card) — and deliberately NOT a raw
-//! [`SignedAgentCard`](crate::SignedAgentCard). A raw signed card is an
+//! [`verify_card`](crate::verify_card) — and deliberately NOT a raw signed
+//! [`AgentCard`](crate::AgentCard). A raw signed card is an
 //! unverified blob: lifting it would let an agent embed claims nobody ever
 //! checked against an out-of-band key. Requiring the `VerifiedCard` witness
 //! makes "this card verified" a precondition the type system discharges —
@@ -77,7 +80,8 @@ pub struct CardClaims {
 
     /// The declared runtime IFC guarantee profile, if any — the discovery-time
     /// guarantee that now rides along with every receipt. Attestation, not
-    /// enforcement (see [`RuntimeGuaranteeProfile`]).
+    /// enforcement (see [`RuntimeGuaranteeProfile`]). Serializes in the
+    /// profile's A2A camelCase wire form (`profileVersion`, …).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub runtime_guarantees: Option<RuntimeGuaranteeProfile>,
 
@@ -91,13 +95,13 @@ pub struct CardClaims {
 impl From<&VerifiedCard> for CardClaims {
     fn from(verified: &VerifiedCard) -> Self {
         CardClaims {
-            spiffe_id: verified.card.spiffe_id.clone(),
-            did: verified.card.did.clone(),
+            spiffe_id: verified.claims.spiffe_id.clone(),
+            did: verified.claims.did.clone(),
             supported_envelope_schema_versions: verified
-                .card
+                .claims
                 .supported_envelope_schema_versions
                 .clone(),
-            runtime_guarantees: verified.card.runtime_guarantees.clone(),
+            runtime_guarantees: verified.claims.runtime_guarantees.clone(),
             advertised_jwks_kids: verified
                 .advertised_jwks()
                 .keys
@@ -185,7 +189,10 @@ pub fn card_claims_from_projection(projection: &Projection) -> Result<CardClaims
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::card::{AgentCard, EnforcementRule};
+    use crate::card::{
+        AgentCapabilities, AgentCard, AgentInterface, EnforcementRule, NucleusClaims,
+        A2A_PROTOCOL_VERSION,
+    };
 
     fn sample_profile() -> RuntimeGuaranteeProfile {
         RuntimeGuaranteeProfile {
@@ -201,11 +208,10 @@ mod tests {
         }
     }
 
-    fn sample_card() -> AgentCard {
-        AgentCard {
+    fn sample_claims() -> NucleusClaims {
+        NucleusClaims {
             spiffe_id: "spiffe://prod.example.com/ns/agents/sa/coder".to_string(),
             did: "did:web:coder.prod.example.com".to_string(),
-            security_schemes: serde_json::json!({"bearer": {"type": "http"}}),
             supported_envelope_schema_versions: vec!["1".to_string(), "2".to_string()],
             jwks_uri: None,
             trust_jwks: nucleus_lineage::Jwks {
@@ -224,12 +230,39 @@ mod tests {
         }
     }
 
-    /// In-crate test shortcut: `VerifiedCard`'s field is public within the
-    /// crate's API, but the END-TO-END test (sign_verify path, feature
+    fn sample_card() -> AgentCard {
+        AgentCard {
+            name: "Coder Agent".to_string(),
+            description: "lift/narrow tests".to_string(),
+            supported_interfaces: vec![AgentInterface {
+                url: "https://coder.prod.example.com/a2a/v1".to_string(),
+                protocol_binding: "JSONRPC".to_string(),
+                tenant: None,
+                protocol_version: A2A_PROTOCOL_VERSION.to_string(),
+            }],
+            provider: None,
+            version: "1.0.0".to_string(),
+            documentation_url: None,
+            capabilities: AgentCapabilities::default(),
+            security_schemes: serde_json::Map::new(),
+            security_requirements: vec![],
+            default_input_modes: vec!["application/json".to_string()],
+            default_output_modes: vec!["application/json".to_string()],
+            skills: vec![],
+            signatures: vec![],
+            icon_url: None,
+        }
+        .with_nucleus_claims(&sample_claims())
+        .unwrap()
+    }
+
+    /// In-crate test shortcut: `VerifiedCard`'s fields are public within
+    /// the crate's API, but the END-TO-END test (sign_verify path, feature
     /// `sign`) is the one that goes through `verify_card` for real.
     fn verified() -> VerifiedCard {
         VerifiedCard {
             card: sample_card(),
+            claims: sample_claims(),
         }
     }
 
@@ -269,7 +302,7 @@ mod tests {
     #[test]
     fn absent_profile_is_omitted_from_the_wire() {
         let mut v = verified();
-        v.card.runtime_guarantees = None;
+        v.claims.runtime_guarantees = None;
         let Projection::Capability(body) = to_capability_projection(&v) else {
             panic!("lift must produce a capability projection");
         };

--- a/crates/nucleus-agent-card/src/envelope_e2e_tests.rs
+++ b/crates/nucleus-agent-card/src/envelope_e2e_tests.rs
@@ -11,7 +11,10 @@ use base64::Engine as _;
 use ring::rand::SystemRandom;
 use ring::signature::{EcdsaKeyPair, KeyPair, ECDSA_P256_SHA256_FIXED_SIGNING};
 
-use crate::card::{AgentCard, EnforcementRule, RuntimeGuaranteeProfile};
+use crate::card::{
+    AgentCapabilities, AgentCard, AgentInterface, EnforcementRule, NucleusClaims,
+    RuntimeGuaranteeProfile, A2A_PROTOCOL_VERSION,
+};
 use crate::envelope::{card_claims_from_projection, to_capability_projection, CardClaims};
 use crate::jwk::JsonWebKey;
 use crate::sign::sign_card;
@@ -35,9 +38,29 @@ fn p256_keypair() -> (Vec<u8>, JsonWebKey) {
 fn sample_card() -> AgentCard {
     let issuer = nucleus_lineage::LocalIssuer::random().unwrap();
     AgentCard {
+        name: "Coder Agent".to_string(),
+        description: "envelope end-to-end tests".to_string(),
+        supported_interfaces: vec![AgentInterface {
+            url: "https://coder.prod.example.com/a2a/v1".to_string(),
+            protocol_binding: "JSONRPC".to_string(),
+            tenant: None,
+            protocol_version: A2A_PROTOCOL_VERSION.to_string(),
+        }],
+        provider: None,
+        version: "1.0.0".to_string(),
+        documentation_url: None,
+        capabilities: AgentCapabilities::default(),
+        security_schemes: serde_json::Map::new(),
+        security_requirements: vec![],
+        default_input_modes: vec!["application/json".to_string()],
+        default_output_modes: vec!["application/json".to_string()],
+        skills: vec![],
+        signatures: vec![],
+        icon_url: None,
+    }
+    .with_nucleus_claims(&NucleusClaims {
         spiffe_id: "spiffe://prod.example.com/ns/agents/sa/coder".to_string(),
         did: "did:web:coder.prod.example.com".to_string(),
-        security_schemes: serde_json::json!({"bearer": {"type": "http"}}),
         supported_envelope_schema_versions: vec!["1".to_string()],
         jwks_uri: None,
         trust_jwks: serde_json::from_value(issuer.publish_jwks()).unwrap(),
@@ -52,7 +75,8 @@ fn sample_card() -> AgentCard {
             }],
             attestation_reference: None,
         }),
-    }
+    })
+    .unwrap()
 }
 
 fn session() -> Session {
@@ -71,7 +95,7 @@ fn session() -> Session {
 fn verified_card_travels_inside_a_signed_receipt_end_to_end() {
     // Discovery time: a real signed card, verified against the out-of-band key.
     let (der, pub_jwk) = p256_keypair();
-    let signed_card = sign_card(sample_card(), &der).unwrap();
+    let signed_card = sign_card(sample_card(), &der, "card-key-1").unwrap();
     let verified = verify_card(&signed_card, &pub_jwk).expect("freshly-signed card verifies");
     let expected = CardClaims::from(&verified);
 
@@ -98,7 +122,7 @@ fn verified_card_travels_inside_a_signed_receipt_end_to_end() {
         back.runtime_guarantees.as_ref().unwrap().enforcement_rules[0].name,
         "no_adversarial_to_outbound"
     );
-    // The advertised kids are exactly the card's trust_jwks kids.
+    // The advertised kids are exactly the claimed trust_jwks kids.
     let kids: Vec<String> = verified
         .advertised_jwks()
         .keys
@@ -114,18 +138,19 @@ fn verified_card_travels_inside_a_signed_receipt_end_to_end() {
 #[test]
 fn tampered_guarantee_inside_signed_envelope_fails_root_hash() {
     let (der, pub_jwk) = p256_keypair();
-    let signed_card = sign_card(sample_card(), &der).unwrap();
+    let signed_card = sign_card(sample_card(), &der, "card-key-1").unwrap();
     let verified = verify_card(&signed_card, &pub_jwk).unwrap();
 
     let sk = ed25519_dalek::SigningKey::from_bytes(&[7u8; 32]);
     let vk: [u8; 32] = sk.verifying_key().to_bytes();
     let mut receipt = Receipt::sign(session(), vec![to_capability_projection(&verified)], &sk);
 
-    // Rewrite the declared enforcement rule inside the signed body.
+    // Rewrite the declared enforcement rule inside the signed body. (The
+    // profile serializes in its A2A camelCase wire form.)
     let Projection::Capability(body) = &mut receipt.projections[0] else {
         panic!("envelope holds a capability projection");
     };
-    body["card"]["runtime_guarantees"]["enforcement_rules"][0]["name"] =
+    body["card"]["runtime_guarantees"]["enforcementRules"][0]["name"] =
         serde_json::json!("allow_everything");
 
     // The envelope check fails FIRST: the re-canonicalized bytes no longer

--- a/crates/nucleus-agent-card/src/jcs.rs
+++ b/crates/nucleus-agent-card/src/jcs.rs
@@ -1,25 +1,50 @@
-//! RFC 8785 JSON Canonicalization Scheme (JCS) for [`AgentCard`].
+//! RFC 8785 JSON Canonicalization Scheme (JCS) for [`AgentCard`] —
+//! A2A v1.0 §8.4.1.
 //!
 //! Both the signer and the verifier MUST canonicalize the card the exact
 //! same way, or a valid signature would fail to verify. This module is the
 //! single source of that canonicalization, built on the [`serde_jcs`]
 //! crate (RFC 8785 compliant).
+//!
+//! Spec rules implemented here (§8.4.1):
+//!
+//! 1. **Presence**: unset optional fields and default-valued fields are
+//!    omitted — enforced by the serde `skip_serializing_if` attributes on
+//!    [`AgentCard`], so serialization already reflects field presence.
+//! 2. **RFC 8785**: lexicographic key order, canonical number/string
+//!    forms, no insignificant whitespace — `serde_jcs`.
+//! 3. **Signature exclusion**: the `signatures` field MUST be excluded
+//!    from the content being signed — removed here, structurally, for
+//!    both signer and verifier.
 
 use crate::card::AgentCard;
 use crate::{Error, Result};
 
-/// Canonicalize an [`AgentCard`] to RFC 8785 (JCS) bytes.
+/// Canonicalize an [`AgentCard`] to its A2A §8.4.1 signing payload: the
+/// RFC 8785 (JCS) bytes of the card **with the `signatures` field
+/// excluded**.
 ///
 /// The output is deterministic: lexicographically-sorted object keys,
 /// no insignificant whitespace, and canonical number/string formatting.
-/// These are exactly the bytes the JWS signature covers.
+/// These are exactly the bytes the JWS signature covers — for an unsigned
+/// and a signed copy of the same card they are identical, which is what
+/// makes the detached signature verifiable at all.
 pub fn canonicalize(card: &AgentCard) -> Result<Vec<u8>> {
-    serde_jcs::to_vec(card).map_err(|e| Error::Canonicalize(e.to_string()))
+    let mut value = serde_json::to_value(card).map_err(|e| Error::Canonicalize(e.to_string()))?;
+    if let Some(obj) = value.as_object_mut() {
+        // §8.4.1 rule 3: the signatures field itself MUST be excluded from
+        // the content being signed (avoids the circular dependency).
+        obj.remove("signatures");
+    }
+    serde_jcs::to_vec(&value).map_err(|e| Error::Canonicalize(e.to_string()))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::card::{
+        AgentCapabilities, AgentCardSignature, AgentInterface, A2A_PROTOCOL_VERSION,
+    };
 
     /// RFC 8785 Appendix B reference vector. Pins our JCS implementation
     /// against the spec's own example so a future dependency swap that
@@ -71,27 +96,63 @@ mod tests {
         assert_eq!(serde_jcs::to_string(&a).unwrap(), r#"{"a":2,"b":1,"c":3}"#);
     }
 
+    fn minimal_card() -> AgentCard {
+        AgentCard {
+            name: "Minimal Agent".to_string(),
+            description: "canonicalization test".to_string(),
+            supported_interfaces: vec![AgentInterface {
+                url: "https://min.example.com/a2a/v1".to_string(),
+                protocol_binding: "JSONRPC".to_string(),
+                tenant: None,
+                protocol_version: A2A_PROTOCOL_VERSION.to_string(),
+            }],
+            provider: None,
+            version: "0.1.0".to_string(),
+            documentation_url: None,
+            capabilities: AgentCapabilities::default(),
+            security_schemes: {
+                let mut m = serde_json::Map::new();
+                m.insert("b".to_string(), serde_json::json!(1));
+                m.insert("a".to_string(), serde_json::json!(2));
+                m
+            },
+            security_requirements: vec![],
+            default_input_modes: vec!["application/json".to_string()],
+            default_output_modes: vec!["application/json".to_string()],
+            skills: vec![],
+            signatures: vec![],
+            icon_url: None,
+        }
+    }
+
     /// `canonicalize(card)` is stable across clones and re-serialization —
     /// the property the whole sign/verify contract depends on.
     #[test]
     fn canonicalize_is_deterministic() {
-        let card = AgentCard {
-            spiffe_id: "spiffe://prod.example.com/ns/agents/sa/coder".to_string(),
-            did: "did:web:coder.prod.example.com".to_string(),
-            security_schemes: serde_json::json!({"b": 1, "a": 2}),
-            supported_envelope_schema_versions: vec!["1".to_string()],
-            jwks_uri: None,
-            trust_jwks: nucleus_lineage::Jwks { keys: vec![] },
-            runtime_guarantees: None,
-        };
+        let card = minimal_card();
         let first = canonicalize(&card).unwrap();
         let second = canonicalize(&card.clone()).unwrap();
         assert_eq!(first, second);
-        // Keys inside the nested object are sorted.
+        // Keys inside the nested securitySchemes map are sorted.
         let s = String::from_utf8(first).unwrap();
-        assert!(
-            s.contains(r#""security_schemes":{"a":2,"b":1}"#),
-            "got: {s}"
-        );
+        assert!(s.contains(r#""securitySchemes":{"a":2,"b":1}"#), "got: {s}");
+    }
+
+    /// §8.4.1 rule 3: the signatures field is excluded — an unsigned card
+    /// and the same card carrying signatures canonicalize to the SAME
+    /// bytes, which is what lets a verifier reconstruct the signed payload.
+    #[test]
+    fn signatures_field_is_excluded_from_canonical_bytes() {
+        let unsigned = minimal_card();
+        let mut signed = unsigned.clone();
+        signed.signatures = vec![AgentCardSignature {
+            protected: "eyJhbGciOiJFUzI1NiJ9".to_string(),
+            signature: "c2ln".to_string(),
+            header: None,
+        }];
+        let a = canonicalize(&unsigned).unwrap();
+        let b = canonicalize(&signed).unwrap();
+        assert_eq!(a, b, "signatures must not be part of the signed content");
+        assert!(!String::from_utf8(b).unwrap().contains("signatures"));
     }
 }

--- a/crates/nucleus-agent-card/src/jwk.rs
+++ b/crates/nucleus-agent-card/src/jwk.rs
@@ -21,7 +21,7 @@ use p256::ecdsa::{Signature, VerifyingKey};
 use serde::{Deserialize, Serialize};
 
 /// A JSON Web Key carrying the out-of-band-resolved public key a caller
-/// verifies a [`crate::SignedAgentCard`] against.
+/// verifies a signed [`crate::AgentCard`] against.
 ///
 /// Wire-compatible with `nucleus_identity::JsonWebKey` — same field names
 /// and optionality — but defined here so the verify path stays wasm-clean.
@@ -67,10 +67,11 @@ impl JsonWebKey {
 /// against a P-256 [`JsonWebKey`], returning the decoded payload bytes.
 ///
 /// Semantics mirror `nucleus_identity::did_crypto::jws_verify_es256`
-/// exactly (same checks, same order): 3-part shape, `ES256` in the header,
-/// EC/P-256 key type, uncompressed-point reconstruction from `x`/`y`,
-/// fixed-width (r||s) signature, ECDSA-P256-SHA256 over
-/// `header_b64.payload_b64`.
+/// (same checks, same order): 3-part shape, `alg: "ES256"` in the header
+/// (parsed as JSON here, so additional A2A §8.4.2 protected-header members
+/// like `typ`/`kid`/`jku` are accepted and ignored), EC/P-256 key type,
+/// uncompressed-point reconstruction from `x`/`y`, fixed-width (r||s)
+/// signature, ECDSA-P256-SHA256 over `header_b64.payload_b64`.
 pub(crate) fn jws_verify_es256(jws: &str, public_key: &JsonWebKey) -> Result<Vec<u8>, String> {
     // Split the compact JWS into its three parts.
     let parts: Vec<&str> = jws.splitn(3, '.').collect();
@@ -79,14 +80,17 @@ pub(crate) fn jws_verify_es256(jws: &str, public_key: &JsonWebKey) -> Result<Vec
     }
     let [header_b64, payload_b64, sig_b64] = [parts[0], parts[1], parts[2]];
 
-    // Validate the header declares ES256.
+    // Validate the header declares alg=ES256. Parsed as JSON (not a
+    // substring scan) so extra protected-header members — the A2A v1.0
+    // §8.4.2 `typ`/`kid`/`jku` — can never be confused for the algorithm.
     let header_bytes = URL_SAFE_NO_PAD
         .decode(header_b64)
         .map_err(|e| format!("invalid base64url header: {e}"))?;
-    let header_str = std::str::from_utf8(&header_bytes)
-        .map_err(|e| format!("header is not valid UTF-8: {e}"))?;
-    if !header_str.contains("\"ES256\"") {
-        return Err(format!("unsupported JWS algorithm: {header_str}"));
+    let header: serde_json::Value = serde_json::from_slice(&header_bytes)
+        .map_err(|e| format!("protected header is not valid JSON: {e}"))?;
+    match header.get("alg").and_then(serde_json::Value::as_str) {
+        Some("ES256") => {}
+        other => return Err(format!("unsupported JWS algorithm: {other:?}")),
     }
 
     // Reconstruct the public key from the JWK coordinates.

--- a/crates/nucleus-agent-card/src/lib.rs
+++ b/crates/nucleus-agent-card/src/lib.rs
@@ -1,11 +1,14 @@
-//! Verify-before-you-act identity layer for nucleus agents.
+//! Verify-before-you-act identity layer for nucleus agents, on the
+//! **A2A protocol v1.0** Agent Card.
 //!
-//! An [`AgentCard`] is the A2A-style document an agent publishes to say WHO
-//! it is and which JWKS its provenance bundles are signed under. This crate
-//! signs ([`sign_card`], feature `sign`) and verifies ([`verify_card`]) a
-//! [`SignedAgentCard`], then derives a [`nucleus_envelope::TrustAnchor`]
-//! ([`trust_anchor_from_card`]) so the EXISTING bundle verifier can decide
-//! whether to ACT on a bundle.
+//! An [`AgentCard`] is the A2A v1.0 manifest an agent publishes to say WHO
+//! it is; nucleus's claims — including which JWKS its provenance bundles
+//! are signed under — travel inside the card's extension mechanism as
+//! [`NucleusClaims`] (extension URI [`NUCLEUS_EXTENSION_URI`]). This crate
+//! signs ([`sign_card`], feature `sign`) and verifies ([`verify_card`])
+//! cards per spec §8.4 (detached JWS over RFC 8785 JCS), then derives a
+//! [`nucleus_envelope::TrustAnchor`] ([`trust_anchor_from_card`]) so the
+//! EXISTING bundle verifier can decide whether to ACT on a bundle.
 //!
 //! # Trust model — read this before using
 //!
@@ -18,9 +21,11 @@
 //! - **NEVER trust a key embedded in the card.** [`verify_card`] reads its
 //!   verification key ONLY from the caller's out-of-band-resolved
 //!   `resolved_key` argument (DID resolution, a pinned JWKS, an operator
-//!   file). It does not read any key — or `kid` — from the card or the
-//!   signature. The card's `jwks_uri` is a *hint* for where to resolve the
-//!   key, not the key itself.
+//!   file). It does not read any key — or the protected header's
+//!   `kid`/`jku` — from the card or the signature. The claims' `jwks_uri`
+//!   is a *hint* for where to resolve the key, not the key itself. (A2A
+//!   §8.4.3 permits resolving "from a trusted key store"; that is the only
+//!   mode implemented here.)
 //!
 //! - **This is the WHO-layer, not the WHAT-layer.** Verifying a card
 //!   establishes the agent's identity and the JWKS it claims. It does NOT
@@ -42,10 +47,11 @@
 //!
 //! ```ignore
 //! // server side (feature = "sign"):
-//! let signed = sign_card(card, &pkcs8_der)?;
+//! let card = base_card.with_nucleus_claims(&claims)?;
+//! let signed = sign_card(card, &pkcs8_der, "card-key-1")?;
 //!
 //! // recipient side (secret-free):
-//! let resolved = resolve_key_out_of_band(&signed.card.did)?; // YOUR job
+//! let resolved = resolve_key_out_of_band(did)?; // YOUR job
 //! let verified = verify_card(&signed, &resolved)?;
 //! let anchor = trust_anchor_from_card(&verified);
 //! let report = nucleus_envelope::verify_bundle(&bundle, &anchor)?; // ACT only if this succeeds
@@ -70,7 +76,9 @@ mod envelope_e2e_tests;
 
 pub use anchor::trust_anchor_from_card;
 pub use card::{
-    AgentCard, AgentCardSignature, EnforcementRule, RuntimeGuaranteeProfile, SignedAgentCard,
+    AgentCapabilities, AgentCard, AgentCardSignature, AgentExtension, AgentInterface,
+    AgentProvider, AgentSkill, EnforcementRule, NucleusClaims, RuntimeGuaranteeProfile,
+    SecurityRequirement, StringList, A2A_PROTOCOL_VERSION, NUCLEUS_EXTENSION_URI,
 };
 pub use jcs::canonicalize;
 pub use jwk::JsonWebKey;
@@ -90,9 +98,15 @@ pub enum Error {
     Canonicalize(String),
 
     /// Card verification failed (no signatures, bad signature, payload
-    /// mismatch, or unusable advertised JWKS).
+    /// mismatch, missing nucleus extension, or unusable advertised JWKS).
     #[error("agent-card verification failed: {0}")]
     Verify(String),
+
+    /// The nucleus extension is declared but malformed (missing params or
+    /// params that do not deserialize as [`NucleusClaims`]), or the claims
+    /// failed to serialize when attaching them.
+    #[error("agent-card nucleus extension error: {0}")]
+    Extension(String),
 
     /// Card signing failed (only reachable with feature `sign`).
     #[error("agent-card signing failed: {0}")]

--- a/crates/nucleus-agent-card/src/sign.rs
+++ b/crates/nucleus-agent-card/src/sign.rs
@@ -1,40 +1,77 @@
-//! Sign an [`AgentCard`] into a [`SignedAgentCard`] (server/dev only).
+//! Sign an [`AgentCard`] per A2A v1.0 §8.4 (server/dev only).
 //!
 //! This module is behind the non-default `sign` feature. It needs a
 //! private key and therefore MUST NOT be compiled into a WASM / browser
 //! verifier — verification ([`crate::verify`]) is always available and
 //! secret-free.
 //!
-//! The signature produced is a DETACHED RFC 7515 JWS-JSON over the JCS
-//! canonicalization of the card: the payload segment is dropped, so the
-//! recipient reconstructs it by canonicalizing the card they received.
+//! The signature produced is a DETACHED RFC 7515 JWS over the §8.4.1
+//! canonical payload (RFC 8785 JCS of the card with `signatures`
+//! excluded), appended to the card's own `signatures` array — the v1.0
+//! wire placement. The protected header carries `alg`, `typ: "JOSE"` and
+//! `kid` as §8.4.2 requires.
 
-use crate::card::{AgentCard, AgentCardSignature, SignedAgentCard};
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine as _;
+
+use crate::card::{AgentCard, AgentCardSignature};
 use crate::jcs::canonicalize;
 use crate::{Error, Result};
 
-/// Sign an [`AgentCard`] with a PKCS#8-DER P-256 private key, producing a
-/// [`SignedAgentCard`] with a single detached ES256 JWS-JSON signature.
+/// Sign an [`AgentCard`] with a PKCS#8-DER P-256 private key, appending a
+/// detached ES256 JWS signature to the card's `signatures` array (§8.4).
 ///
-/// The signature covers `base64url(protected) || "." || base64url(JCS(card))`
-/// per RFC 7515, but the payload segment is omitted from the wire form
-/// (detached). Header `alg` is `ES256`.
+/// The signature covers `base64url(protected) || "." || base64url(JCS(card
+/// minus signatures))` per RFC 7515; the payload segment is omitted from
+/// the wire form (detached) — a recipient reconstructs it from the card
+/// they received. The protected header is
+/// `{"alg":"ES256","typ":"JOSE","kid":<kid>}` per §8.4.2 (`alg` and `kid`
+/// MUST be present; `typ` SHOULD be `"JOSE"`).
+///
+/// `kid` identifies the signing key for recipients who resolve keys from a
+/// JWKS — but note the verify-side trust model: [`crate::verify_card`]
+/// never selects a key by `kid`; the verification key is always the
+/// caller's out-of-band-resolved key.
+///
+/// Signing is append-only: any signatures already on the card are kept
+/// (§8.4.3 allows multiple signatures for key rotation / co-signing), and
+/// the canonical payload excludes them all, so earlier signatures stay
+/// valid.
 ///
 /// # Errors
 ///
 /// Returns [`Error`] if canonicalization fails, the key is invalid /
 /// signing fails, or the underlying JWS is not the expected three-part
 /// compact form.
-pub fn sign_card(card: AgentCard, private_key_pkcs8_der: &[u8]) -> Result<SignedAgentCard> {
+pub fn sign_card(
+    mut card: AgentCard,
+    private_key_pkcs8_der: &[u8],
+    kid: &str,
+) -> Result<AgentCard> {
     // Canonicalize first — this is the exact byte string the verifier will
-    // reconstruct and check against.
+    // reconstruct and check against (signatures excluded, §8.4.1 rule 3).
     let jcs_bytes = canonicalize(&card)?;
 
-    // jws_sign_es256 produces a COMPACT "header.payload.signature" JWS with
-    // alg=ES256. We sign the JCS bytes, then strip the payload to make the
-    // signature detached.
-    let compact = nucleus_identity::did_crypto::jws_sign_es256(&jcs_bytes, private_key_pkcs8_der)
-        .map_err(|e| Error::Sign(format!("ES256 signing failed: {e}")))?;
+    // §8.4.2 protected header: alg + kid REQUIRED, typ SHOULD be "JOSE".
+    // serde_json::to_string escapes the kid correctly; the header bytes are
+    // carried verbatim in `protected`, so key order here is irrelevant to
+    // verification.
+    let protected_header = serde_json::to_string(&serde_json::json!({
+        "alg": "ES256",
+        "typ": "JOSE",
+        "kid": kid,
+    }))
+    .map_err(|e| Error::Sign(format!("serialize protected header: {e}")))?;
+
+    // jws_sign_es256_with_protected_header produces a COMPACT
+    // "header.payload.signature" JWS. We sign the JCS bytes, then strip the
+    // payload to make the signature detached.
+    let compact = nucleus_identity::did_crypto::jws_sign_es256_with_protected_header(
+        &protected_header,
+        &jcs_bytes,
+        private_key_pkcs8_der,
+    )
+    .map_err(|e| Error::Sign(format!("ES256 signing failed: {e}")))?;
 
     let parts: Vec<&str> = compact.splitn(3, '.').collect();
     if parts.len() != 3 {
@@ -44,16 +81,17 @@ pub fn sign_card(card: AgentCard, private_key_pkcs8_der: &[u8]) -> Result<Signed
         )));
     }
 
+    // Sanity-pin the detached payload to the canonical bytes we computed —
+    // a drift here would produce signatures nobody can verify.
+    debug_assert_eq!(parts[1], URL_SAFE_NO_PAD.encode(&jcs_bytes));
+
     // parts[0] = protected header, parts[1] = payload (DROPPED — detached),
     // parts[2] = signature.
-    let signature = AgentCardSignature {
+    card.signatures.push(AgentCardSignature {
         protected: parts[0].to_string(),
         signature: parts[2].to_string(),
         header: None,
-    };
+    });
 
-    Ok(SignedAgentCard {
-        card,
-        signatures: vec![signature],
-    })
+    Ok(card)
 }

--- a/crates/nucleus-agent-card/src/sign_verify_tests.rs
+++ b/crates/nucleus-agent-card/src/sign_verify_tests.rs
@@ -7,7 +7,9 @@ use base64::Engine as _;
 use ring::rand::SystemRandom;
 use ring::signature::{EcdsaKeyPair, KeyPair, ECDSA_P256_SHA256_FIXED_SIGNING};
 
-use crate::card::AgentCard;
+use crate::card::{
+    AgentCapabilities, AgentCard, AgentInterface, NucleusClaims, A2A_PROTOCOL_VERSION,
+};
 use crate::jcs::canonicalize;
 use crate::jwk::JsonWebKey;
 use crate::sign::sign_card;
@@ -36,37 +38,81 @@ fn good_jwks() -> nucleus_lineage::Jwks {
     serde_json::from_value(issuer.publish_jwks()).unwrap()
 }
 
-fn sample_card() -> AgentCard {
-    AgentCard {
+fn claims_with(jwks: nucleus_lineage::Jwks) -> NucleusClaims {
+    NucleusClaims {
         spiffe_id: "spiffe://prod.example.com/ns/agents/sa/coder".to_string(),
         did: "did:web:coder.prod.example.com".to_string(),
-        security_schemes: serde_json::json!({"bearer": {"type": "http"}}),
         supported_envelope_schema_versions: vec!["1".to_string()],
         jwks_uri: None,
-        trust_jwks: good_jwks(),
+        trust_jwks: jwks,
         runtime_guarantees: None,
     }
+}
+
+fn base_card() -> AgentCard {
+    AgentCard {
+        name: "Coder Agent".to_string(),
+        description: "sign/verify round-trip tests".to_string(),
+        supported_interfaces: vec![AgentInterface {
+            url: "https://coder.prod.example.com/a2a/v1".to_string(),
+            protocol_binding: "JSONRPC".to_string(),
+            tenant: None,
+            protocol_version: A2A_PROTOCOL_VERSION.to_string(),
+        }],
+        provider: None,
+        version: "1.0.0".to_string(),
+        documentation_url: None,
+        capabilities: AgentCapabilities::default(),
+        security_schemes: serde_json::Map::new(),
+        security_requirements: vec![],
+        default_input_modes: vec!["application/json".to_string()],
+        default_output_modes: vec!["application/json".to_string()],
+        skills: vec![],
+        signatures: vec![],
+        icon_url: None,
+    }
+}
+
+fn sample_card() -> AgentCard {
+    base_card()
+        .with_nucleus_claims(&claims_with(good_jwks()))
+        .unwrap()
 }
 
 #[test]
 fn sign_then_verify_happy_path() {
     let (der, pub_jwk) = p256_keypair();
-    let signed = sign_card(sample_card(), &der).unwrap();
+    let signed = sign_card(sample_card(), &der, "card-key-1").unwrap();
     let verified = verify_card(&signed, &pub_jwk).expect("freshly-signed card must verify");
-    assert_eq!(verified.card.did, "did:web:coder.prod.example.com");
+    assert_eq!(verified.claims.did, "did:web:coder.prod.example.com");
     assert_eq!(verified.advertised_jwks().keys.len(), 1);
 }
 
 #[test]
+fn protected_header_carries_alg_typ_kid_per_8_4_2() {
+    // §8.4.2: the protected header MUST include alg, typ (SHOULD "JOSE")
+    // and kid.
+    let (der, _pub_jwk) = p256_keypair();
+    let signed = sign_card(sample_card(), &der, "card-key-1").unwrap();
+    let protected = URL_SAFE_NO_PAD
+        .decode(&signed.signatures[0].protected)
+        .unwrap();
+    let header: serde_json::Value = serde_json::from_slice(&protected).unwrap();
+    assert_eq!(header["alg"], "ES256");
+    assert_eq!(header["typ"], "JOSE");
+    assert_eq!(header["kid"], "card-key-1");
+}
+
+#[test]
 fn sign_and_verify_canonicalize_identically() {
-    // The signature is over JCS(card); the verifier reconstructs JCS(card).
-    // Confirm both sides agree on the exact bytes — the contract that makes
-    // the detached JWS verifiable at all.
+    // The signature is over JCS(card minus signatures); the verifier
+    // reconstructs the same bytes FROM THE SIGNED CARD — the §8.4.1
+    // signature-exclusion rule is what makes these equal.
     let (der, pub_jwk) = p256_keypair();
     let card = sample_card();
     let jcs_at_sign = canonicalize(&card).unwrap();
-    let signed = sign_card(card, &der).unwrap();
-    let jcs_at_verify = canonicalize(&signed.card).unwrap();
+    let signed = sign_card(card, &der, "card-key-1").unwrap();
+    let jcs_at_verify = canonicalize(&signed).unwrap();
     assert_eq!(
         jcs_at_sign, jcs_at_verify,
         "sign and verify must JCS identically"
@@ -75,12 +121,39 @@ fn sign_and_verify_canonicalize_identically() {
 }
 
 #[test]
+fn second_signature_keeps_the_first_valid() {
+    // §8.4.3: multiple signatures MAY be present (key rotation). Because
+    // the canonical payload excludes ALL signatures, appending a second
+    // one must not invalidate the first — which is the one verify_card
+    // checks.
+    let (der_a, pub_a) = p256_keypair();
+    let (der_b, _pub_b) = p256_keypair();
+    let signed_once = sign_card(sample_card(), &der_a, "key-a").unwrap();
+    let signed_twice = sign_card(signed_once, &der_b, "key-b").unwrap();
+    assert_eq!(signed_twice.signatures.len(), 2);
+    verify_card(&signed_twice, &pub_a).expect("first signature still verifies");
+}
+
+#[test]
 fn flipping_one_byte_of_card_body_fails_verification() {
     let (der, pub_jwk) = p256_keypair();
-    let mut signed = sign_card(sample_card(), &der).unwrap();
+    let mut signed = sign_card(sample_card(), &der, "card-key-1").unwrap();
     // Mutate the card AFTER signing — the detached signature was over the
     // original JCS, so the reconstructed payload no longer matches.
-    signed.card.did = "did:web:attacker.example.com".to_string();
+    signed.name = "Imposter Agent".to_string();
+    let err = verify_card(&signed, &pub_jwk).unwrap_err();
+    assert!(matches!(err, crate::Error::Verify(_)), "got {err:?}");
+}
+
+#[test]
+fn tampering_the_nucleus_claims_fails_verification() {
+    // The claims travel inside capabilities.extensions — part of the
+    // signed content, so identity swaps are caught.
+    let (der, pub_jwk) = p256_keypair();
+    let mut signed = sign_card(sample_card(), &der, "card-key-1").unwrap();
+    let mut claims = signed.nucleus_claims().unwrap().unwrap();
+    claims.did = "did:web:attacker.example.com".to_string();
+    signed = signed.with_nucleus_claims(&claims).unwrap();
     let err = verify_card(&signed, &pub_jwk).unwrap_err();
     assert!(matches!(err, crate::Error::Verify(_)), "got {err:?}");
 }
@@ -91,17 +164,28 @@ fn card_signed_by_key_a_fails_under_key_b() {
     // valid signature by A is worthless when verified against B's key.
     let (der_a, _pub_a) = p256_keypair();
     let (_der_b, pub_b) = p256_keypair();
-    let signed = sign_card(sample_card(), &der_a).unwrap();
+    let signed = sign_card(sample_card(), &der_a, "card-key-1").unwrap();
     let err = verify_card(&signed, &pub_b).unwrap_err();
+    assert!(matches!(err, crate::Error::Verify(_)), "got {err:?}");
+}
+
+#[test]
+fn card_without_nucleus_extension_is_rejected() {
+    // A validly signed plain A2A card with no nucleus claims cannot anchor
+    // anything — verify_card refuses it.
+    let (der, pub_jwk) = p256_keypair();
+    let signed = sign_card(base_card(), &der, "card-key-1").unwrap();
+    let err = verify_card(&signed, &pub_jwk).unwrap_err();
     assert!(matches!(err, crate::Error::Verify(_)), "got {err:?}");
 }
 
 #[test]
 fn empty_trust_jwks_is_rejected() {
     let (der, pub_jwk) = p256_keypair();
-    let mut card = sample_card();
-    card.trust_jwks = nucleus_lineage::Jwks { keys: vec![] };
-    let signed = sign_card(card, &der).unwrap();
+    let card = base_card()
+        .with_nucleus_claims(&claims_with(nucleus_lineage::Jwks { keys: vec![] }))
+        .unwrap();
+    let signed = sign_card(card, &der, "card-key-1").unwrap();
     let err = verify_card(&signed, &pub_jwk).unwrap_err();
     assert!(matches!(err, crate::Error::Verify(_)), "got {err:?}");
 }
@@ -109,10 +193,9 @@ fn empty_trust_jwks_is_rejected() {
 #[test]
 fn malformed_trust_jwks_is_rejected() {
     let (der, pub_jwk) = p256_keypair();
-    let mut card = sample_card();
     // A key with an undecodable `x` is malformed — can't become a
     // verifying key, so it can't anchor any bundle.
-    card.trust_jwks = nucleus_lineage::Jwks {
+    let bad = nucleus_lineage::Jwks {
         keys: vec![nucleus_lineage::Jwk {
             kty: "OKP".to_string(),
             crv: Some("Ed25519".to_string()),
@@ -124,7 +207,8 @@ fn malformed_trust_jwks_is_rejected() {
             not_after: None,
         }],
     };
-    let signed = sign_card(card, &der).unwrap();
+    let card = base_card().with_nucleus_claims(&claims_with(bad)).unwrap();
+    let signed = sign_card(card, &der, "card-key-1").unwrap();
     let err = verify_card(&signed, &pub_jwk).unwrap_err();
     assert!(matches!(err, crate::Error::Verify(_)), "got {err:?}");
 }
@@ -146,12 +230,13 @@ fn sample_profile() -> crate::RuntimeGuaranteeProfile {
 #[test]
 fn sign_and_verify_with_runtime_guarantees_roundtrip() {
     let (der, pub_jwk) = p256_keypair();
-    let mut card = sample_card();
-    card.runtime_guarantees = Some(sample_profile());
-    let signed = sign_card(card, &der).unwrap();
+    let mut claims = claims_with(good_jwks());
+    claims.runtime_guarantees = Some(sample_profile());
+    let card = base_card().with_nucleus_claims(&claims).unwrap();
+    let signed = sign_card(card, &der, "card-key-1").unwrap();
     let verified = verify_card(&signed, &pub_jwk).expect("card with profile must verify");
     let prof = verified
-        .card
+        .claims
         .runtime_guarantees
         .as_ref()
         .expect("profile present");
@@ -161,32 +246,74 @@ fn sign_and_verify_with_runtime_guarantees_roundtrip() {
 #[test]
 fn tampering_runtime_guarantees_breaks_signature() {
     let (der, pub_jwk) = p256_keypair();
-    let mut card = sample_card();
-    card.runtime_guarantees = Some(sample_profile());
-    let mut signed = sign_card(card, &der).unwrap();
-    // Flip a declared rule name AFTER signing → JCS changes → signature must fail.
-    signed
-        .card
-        .runtime_guarantees
-        .as_mut()
-        .unwrap()
-        .enforcement_rules[0]
-        .name = "allow_everything".to_string();
+    let mut claims = claims_with(good_jwks());
+    claims.runtime_guarantees = Some(sample_profile());
+    let card = base_card().with_nucleus_claims(&claims).unwrap();
+    let mut signed = sign_card(card, &der, "card-key-1").unwrap();
+    // Flip a declared rule name AFTER signing → JCS changes → signature
+    // must fail. Mutate the raw extension params in place.
+    let ext = signed
+        .capabilities
+        .extensions
+        .iter_mut()
+        .find(|e| e.uri == crate::NUCLEUS_EXTENSION_URI)
+        .unwrap();
+    ext.params.as_mut().unwrap()["runtimeGuarantees"]["enforcementRules"][0]["name"] =
+        serde_json::json!("allow_everything");
     assert!(
         verify_card(&signed, &pub_jwk).is_err(),
         "a tampered runtime-guarantee profile must fail verification"
     );
 }
 
+/// Regenerates `sdks/verifier-js/test/fixtures/agent-card.json`.
+///
+/// Run manually after any wire-shape change:
+///
+/// ```bash
+/// cargo test -p nucleus-agent-card --features sign \
+///   print_verifier_js_fixture -- --ignored --nocapture
+/// ```
+///
+/// and paste the JSON between the BEGIN/END markers into the fixture.
 #[test]
-fn backward_compat_card_without_profile_omits_field_and_verifies() {
+#[ignore = "fixture generator — run with --ignored --nocapture to regenerate"]
+fn print_verifier_js_fixture() {
     let (der, pub_jwk) = p256_keypair();
-    let card = sample_card(); // runtime_guarantees: None
-    let json = serde_json::to_value(&card).unwrap();
-    assert!(
-        json.get("runtime_guarantees").is_none(),
-        "a None profile must be omitted from the card JSON (backward compatible)"
-    );
-    let signed = sign_card(card, &der).unwrap();
-    assert!(verify_card(&signed, &pub_jwk).is_ok());
+    let (_other_der, wrong_jwk) = p256_keypair();
+
+    let mut claims = claims_with(nucleus_lineage::Jwks {
+        keys: vec![nucleus_lineage::Jwk {
+            kty: "OKP".to_string(),
+            crv: Some("Ed25519".to_string()),
+            kid: "issuer-k1".to_string(),
+            x: Some("6kpsY-KcUgq-9VB7Ey7F-ZVHdq6-vnuSQh7qaRRG0iw".to_string()),
+            alg: Some("EdDSA".to_string()),
+            use_: Some("sig".to_string()),
+            not_before: None,
+            not_after: None,
+        }],
+    });
+    claims.runtime_guarantees = Some(crate::RuntimeGuaranteeProfile {
+        profile_version: "1.0".to_string(),
+        tracked_sources: vec!["web_content".to_string(), "secret".to_string()],
+        enforcement_rules: vec![crate::EnforcementRule {
+            name: "no_adversarial_to_outbound".to_string(),
+            description: "deny outbound actions tainted by adversarial content".to_string(),
+        }],
+        attestation_reference: None,
+    });
+    let card = base_card().with_nucleus_claims(&claims).unwrap();
+    let signed = sign_card(card, &der, "card-key-1").unwrap();
+    verify_card(&signed, &pub_jwk).expect("fixture card must verify before shipping");
+
+    let fixture = serde_json::json!({
+        "_generated_by": "nucleus-agent-card print_verifier_js_fixture (sign_card with an ephemeral ring P-256 key — a TEST key; resolved_jwk is the matching public key a recipient would resolve out-of-band; wrong_jwk is a second, unrelated P-256 key). A2A v1.0 card shape.",
+        "resolved_jwk": pub_jwk,
+        "signed_card": signed,
+        "wrong_jwk": wrong_jwk,
+    });
+    println!("BEGIN-FIXTURE");
+    println!("{}", serde_json::to_string_pretty(&fixture).unwrap());
+    println!("END-FIXTURE");
 }

--- a/crates/nucleus-agent-card/src/verify.rs
+++ b/crates/nucleus-agent-card/src/verify.rs
@@ -1,4 +1,5 @@
-//! Verify a [`SignedAgentCard`] against an OUT-OF-BAND-resolved key.
+//! Verify a signed [`AgentCard`] against an OUT-OF-BAND-resolved key
+//! (A2A v1.0 §8.4.3).
 //!
 //! This module is ALWAYS compiled (no feature gate) and is secret-free —
 //! a browser/WASM verifier can use it without ever touching a private key.
@@ -8,27 +9,35 @@
 //! The verification key comes ONLY from the caller's `resolved_key`
 //! argument — a key the caller obtained out-of-band (DID resolution, a
 //! pinned JWKS, an operator file). It is NEVER read from the card or from
-//! any `kid` the signature advertises. A card verified against a key the
+//! the `kid`/`jku` the signature's protected header advertises. §8.4.3
+//! permits resolving the key "from a trusted key store" — that is the only
+//! mode this verifier implements, because a card verified against a key the
 //! *attacker* supplied is "verified garbage": the math passes but it
 //! proves nothing about who the agent is.
 
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine as _;
 
-use crate::card::{AgentCard, SignedAgentCard};
+use crate::card::{AgentCard, NucleusClaims};
 use crate::jcs::canonicalize;
 use crate::jwk::JsonWebKey;
 use crate::{Error, Result};
 
-/// A card whose signature verified against the caller's out-of-band key.
+/// A card whose signature verified against the caller's out-of-band key,
+/// together with its extracted [`NucleusClaims`].
 ///
 /// Holding a `VerifiedCard` is the proof obligation: you may only call
 /// [`Self::advertised_jwks`] (and thence build a TrustAnchor) once the
 /// card's authenticity has been established.
 #[derive(Debug, Clone)]
 pub struct VerifiedCard {
-    /// The verified identity document.
+    /// The verified identity document (v1.0 card, signatures included).
     pub card: AgentCard,
+
+    /// The nucleus claims extracted from the card's
+    /// [`NUCLEUS_EXTENSION_URI`](crate::card::NUCLEUS_EXTENSION_URI)
+    /// extension — covered by the verified signature.
+    pub claims: NucleusClaims,
 }
 
 impl VerifiedCard {
@@ -36,51 +45,60 @@ impl VerifiedCard {
     /// its provenance bundles. Feed this to
     /// [`crate::anchor::trust_anchor_from_card`].
     pub fn advertised_jwks(&self) -> &nucleus_lineage::Jwks {
-        &self.card.trust_jwks
+        &self.claims.trust_jwks
     }
 }
 
-/// Verify a [`SignedAgentCard`] using a key the caller resolved
-/// out-of-band.
+/// Verify a signed [`AgentCard`] using a key the caller resolved
+/// out-of-band, and extract its [`NucleusClaims`].
 ///
-/// Steps:
+/// Steps (§8.4.3, with the nucleus trust model on top):
 ///
-/// 1. Take the FIRST signature.
-/// 2. Recompute the JCS canonical bytes of `card` and the detached JWS
-///    payload segment `base64url_nopad(JCS(card))`.
+/// 1. Take the FIRST entry of the card's `signatures` array.
+/// 2. Recompute the §8.4.1 canonical payload — the JCS bytes of the card
+///    with `signatures` excluded — and the detached JWS payload segment
+///    `base64url_nopad(JCS)`.
 /// 3. Reconstruct the compact JWS `protected.payload.signature` and verify
 ///    it via the wasm-clean ES256 verifier in [`crate::jwk`] against
 ///    `resolved_key`.
-/// 4. Assert the payload `jws_verify_es256` returns equals JCS(card) — so
-///    the signature is bound to *this* card, not some other payload.
-/// 5. Reject if the card's advertised `trust_jwks` is empty or malformed
-///    (an advertised-but-unusable JWKS can't anchor anything downstream).
+/// 4. Assert the payload `jws_verify_es256` returns equals the canonical
+///    bytes — so the signature is bound to *this* card, not some other
+///    payload.
+/// 5. Extract the [`NucleusClaims`] from the card's nucleus extension —
+///    REQUIRED here: this verifier exists for the verify-before-you-act
+///    flow, and a card with no claims (or a malformed claim set) cannot
+///    anchor anything downstream.
+/// 6. Reject if the claimed `trust_jwks` is empty or malformed (an
+///    advertised-but-unusable JWKS can't anchor anything either).
 ///
 /// # Errors
 ///
 /// Returns [`Error`] on: no signatures, signature/JWS verification
-/// failure, payload mismatch, or empty/malformed `trust_jwks`.
-pub fn verify_card(signed: &SignedAgentCard, resolved_key: &JsonWebKey) -> Result<VerifiedCard> {
-    // 1) First signature. Multiple signatures are allowed on the wire, but
-    //    the trust decision is made against the caller's resolved key over
-    //    the first one — we never iterate looking for "a kid that matches"
-    //    because that would re-introduce card-controlled key selection.
-    let sig = signed
+/// failure, payload mismatch, missing/malformed nucleus extension, or
+/// empty/malformed `trust_jwks`.
+pub fn verify_card(card: &AgentCard, resolved_key: &JsonWebKey) -> Result<VerifiedCard> {
+    // 1) First signature. Multiple signatures are allowed on the wire
+    //    (§8.4.3, key rotation), but the trust decision is made against the
+    //    caller's resolved key over the first one — we never iterate
+    //    looking for "a kid that matches" because that would re-introduce
+    //    card-controlled key selection.
+    let sig = card
         .signatures
         .first()
-        .ok_or(Error::Verify("signed card has no signatures".to_string()))?;
+        .ok_or(Error::Verify("card has no signatures".to_string()))?;
 
-    // 2) Canonicalize the card and form the detached JWS payload segment.
-    let jcs_bytes = canonicalize(&signed.card)?;
+    // 2) Canonical payload (signatures excluded) + detached JWS segment.
+    let jcs_bytes = canonicalize(card)?;
     let payload_b64 = URL_SAFE_NO_PAD.encode(&jcs_bytes);
 
     // 3) Reconstruct the COMPACT JWS string the detached signature implies:
-    //    protected "." base64url(JCS(card)) "." signature.
+    //    protected "." base64url(JCS) "." signature.
     let compact = format!("{}.{}.{}", sig.protected, payload_b64, sig.signature);
 
     // 4) Verify against the OUT-OF-BAND-resolved key ONLY. Never the card's
-    //    own material. `jws_verify_es256` (wasm-clean, pure-Rust p256 —
-    //    see crate::jwk) returns the decoded payload.
+    //    own material, never the protected header's kid/jku.
+    //    `jws_verify_es256` (wasm-clean, pure-Rust p256 — see crate::jwk)
+    //    returns the decoded payload.
     let recovered = crate::jwk::jws_verify_es256(&compact, resolved_key)
         .map_err(|e| Error::Verify(format!("JWS verification failed: {e}")))?;
 
@@ -95,14 +113,23 @@ pub fn verify_card(signed: &SignedAgentCard, resolved_key: &JsonWebKey) -> Resul
         ));
     }
 
-    // 6) Reject an unusable advertised JWKS up front. An empty or malformed
+    // 6) Extract the nucleus claims — required for verify-before-you-act.
+    let claims = card.nucleus_claims()?.ok_or_else(|| {
+        Error::Verify(format!(
+            "card does not declare the nucleus extension ({}) — nothing to anchor on",
+            crate::card::NUCLEUS_EXTENSION_URI
+        ))
+    })?;
+
+    // 7) Reject an unusable advertised JWKS up front. An empty or malformed
     //    trust_jwks can't anchor any bundle, so a card carrying one is
     //    useless for verify-before-you-act — fail loudly here rather than
     //    let the caller build a TrustAnchor that rejects everything.
-    reject_unusable_jwks(&signed.card.trust_jwks)?;
+    reject_unusable_jwks(&claims.trust_jwks)?;
 
     Ok(VerifiedCard {
-        card: signed.card.clone(),
+        card: card.clone(),
+        claims,
     })
 }
 
@@ -132,7 +159,9 @@ fn reject_unusable_jwks(jwks: &nucleus_lineage::Jwks) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::card::{AgentCard, AgentCardSignature, SignedAgentCard};
+    use crate::card::{
+        AgentCapabilities, AgentCardSignature, AgentInterface, A2A_PROTOCOL_VERSION,
+    };
 
     fn ed25519_jwks() -> nucleus_lineage::Jwks {
         nucleus_lineage::Jwks {
@@ -151,43 +180,59 @@ mod tests {
 
     fn card_with(jwks: nucleus_lineage::Jwks) -> AgentCard {
         AgentCard {
+            name: "Coder Agent".to_string(),
+            description: "verify tests".to_string(),
+            supported_interfaces: vec![AgentInterface {
+                url: "https://coder.prod.example.com/a2a/v1".to_string(),
+                protocol_binding: "JSONRPC".to_string(),
+                tenant: None,
+                protocol_version: A2A_PROTOCOL_VERSION.to_string(),
+            }],
+            provider: None,
+            version: "1.0.0".to_string(),
+            documentation_url: None,
+            capabilities: AgentCapabilities::default(),
+            security_schemes: serde_json::Map::new(),
+            security_requirements: vec![],
+            default_input_modes: vec!["application/json".to_string()],
+            default_output_modes: vec!["application/json".to_string()],
+            skills: vec![],
+            signatures: vec![],
+            icon_url: None,
+        }
+        .with_nucleus_claims(&NucleusClaims {
             spiffe_id: "spiffe://prod.example.com/ns/agents/sa/coder".to_string(),
             did: "did:web:coder.prod.example.com".to_string(),
-            security_schemes: serde_json::json!({}),
             supported_envelope_schema_versions: vec!["1".to_string()],
             jwks_uri: None,
             trust_jwks: jwks,
             runtime_guarantees: None,
-        }
+        })
+        .unwrap()
     }
 
     #[test]
     fn no_signatures_is_rejected() {
-        let signed = SignedAgentCard {
-            card: card_with(ed25519_jwks()),
-            signatures: vec![],
-        };
+        let card = card_with(ed25519_jwks());
         let key = JsonWebKey::ec_p256("x", "y");
-        let err = verify_card(&signed, &key).unwrap_err();
+        let err = verify_card(&card, &key).unwrap_err();
         assert!(matches!(err, Error::Verify(_)));
     }
 
     #[test]
     fn garbage_signature_is_rejected() {
-        let signed = SignedAgentCard {
-            card: card_with(ed25519_jwks()),
-            signatures: vec![AgentCardSignature {
-                protected: "eyJhbGciOiJFUzI1NiJ9".to_string(),
-                signature: "bm90LWEtcmVhbC1zaWc".to_string(),
-                header: None,
-            }],
-        };
+        let mut card = card_with(ed25519_jwks());
+        card.signatures = vec![AgentCardSignature {
+            protected: "eyJhbGciOiJFUzI1NiJ9".to_string(),
+            signature: "bm90LWEtcmVhbC1zaWc".to_string(),
+            header: None,
+        }];
         // A syntactically-valid P-256 JWK that did not sign this card.
         let key = JsonWebKey::ec_p256(
             "f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",
             "x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",
         );
-        let err = verify_card(&signed, &key).unwrap_err();
+        let err = verify_card(&card, &key).unwrap_err();
         assert!(matches!(err, Error::Verify(_)));
     }
 }

--- a/crates/nucleus-agent-card/tests/handshake.rs
+++ b/crates/nucleus-agent-card/tests/handshake.rs
@@ -18,7 +18,10 @@ use base64::Engine as _;
 use ring::rand::SystemRandom;
 use ring::signature::{EcdsaKeyPair, KeyPair, ECDSA_P256_SHA256_FIXED_SIGNING};
 
-use nucleus_agent_card::{sign_card, trust_anchor_from_card, verify_card, AgentCard, JsonWebKey};
+use nucleus_agent_card::{
+    sign_card, trust_anchor_from_card, verify_card, AgentCapabilities, AgentCard, AgentInterface,
+    JsonWebKey, NucleusClaims, A2A_PROTOCOL_VERSION,
+};
 use nucleus_envelope::{verify_bundle, Bundle, BundleBuilder};
 use nucleus_lineage::{
     edge_content_hash, CallSpiffeId, EdgeKind, EdgeSigner, InMemorySink, Jwks, LineageEdge,
@@ -99,18 +102,40 @@ fn build_bundle(issuer: &LocalIssuer) -> Bundle {
         .unwrap()
 }
 
-/// A card advertising `issuer`'s `publish_jwks()` as its trust anchor.
+/// A v1.0 card whose nucleus extension advertises `issuer`'s
+/// `publish_jwks()` as its trust anchor.
 fn card_for(issuer: &LocalIssuer) -> AgentCard {
     let jwks: Jwks = serde_json::from_value(issuer.publish_jwks()).unwrap();
     AgentCard {
+        name: "Summarizer Agent".to_string(),
+        description: "handshake integration test agent".to_string(),
+        supported_interfaces: vec![AgentInterface {
+            url: "https://summarizer.prod.example.com/a2a/v1".to_string(),
+            protocol_binding: "JSONRPC".to_string(),
+            tenant: None,
+            protocol_version: A2A_PROTOCOL_VERSION.to_string(),
+        }],
+        provider: None,
+        version: "1.0.0".to_string(),
+        documentation_url: None,
+        capabilities: AgentCapabilities::default(),
+        security_schemes: serde_json::Map::new(),
+        security_requirements: vec![],
+        default_input_modes: vec!["application/json".to_string()],
+        default_output_modes: vec!["application/json".to_string()],
+        skills: vec![],
+        signatures: vec![],
+        icon_url: None,
+    }
+    .with_nucleus_claims(&NucleusClaims {
         spiffe_id: "spiffe://prod.example.com/ns/agents/sa/summarizer".to_string(),
         did: "did:web:summarizer.prod.example.com".to_string(),
-        security_schemes: serde_json::json!({}),
         supported_envelope_schema_versions: vec!["1".to_string(), "2".to_string()],
         jwks_uri: Some("https://summarizer.prod.example.com/.well-known/jwks.json".to_string()),
         trust_jwks: jwks,
         runtime_guarantees: None,
-    }
+    })
+    .unwrap()
 }
 
 #[test]
@@ -123,7 +148,7 @@ fn headline_card_anchored_bundle_verifies() {
 
     // 1) Agent signs a card advertising issuer's JWKS.
     let card = card_for(&issuer);
-    let signed = sign_card(card, &card_der).unwrap();
+    let signed = sign_card(card, &card_der, "card-key-1").unwrap();
 
     // 2) Recipient verifies the card against the OUT-OF-BAND key.
     let verified = verify_card(&signed, &card_pub).expect("card must verify");
@@ -150,7 +175,7 @@ fn negative_mismatched_issuer_bundle_is_refused() {
 
     // The card advertises issuer A's JWKS and is validly signed.
     let card = card_for(&issuer_a);
-    let signed = sign_card(card, &card_der).unwrap();
+    let signed = sign_card(card, &card_der, "card-key-1").unwrap();
 
     // The card STILL VERIFIES — it is genuinely signed by the resolved key.
     let verified =

--- a/crates/nucleus-identity/src/did_crypto.rs
+++ b/crates/nucleus-identity/src/did_crypto.rs
@@ -6,6 +6,7 @@
 //! - [`extract_ec_p256_jwk`] — Extract an EC P-256 public key from a certificate as a JWK
 //! - [`cert_fingerprint`] — SHA-256 fingerprint of a certificate in `SHA256:<base64url>` format
 //! - [`jws_sign_es256`] — Create a JWS compact serialization (ES256) over a payload
+//! - [`jws_sign_es256_with_protected_header`] — Same, with a caller-supplied protected header
 //! - [`jws_verify_es256`] — Verify a JWS compact serialization against a JWK
 //! - [`chain_to_base64url`] — Encode a certificate chain as base64url DER strings
 
@@ -102,9 +103,39 @@ pub fn cert_fingerprint(cert: &Certificate) -> String {
 ///
 /// Returns an error if the private key is invalid or signing fails.
 pub fn jws_sign_es256(payload: &[u8], private_key_pkcs8_der: &[u8]) -> Result<String> {
-    // Construct the protected header
-    let header = r#"{"alg":"ES256"}"#;
-    let header_b64 = URL_SAFE_NO_PAD.encode(header.as_bytes());
+    jws_sign_es256_with_protected_header(r#"{"alg":"ES256"}"#, payload, private_key_pkcs8_der)
+}
+
+/// Create a JWS compact serialization (ES256) over a payload with a
+/// caller-supplied protected header.
+///
+/// Like [`jws_sign_es256`] but the caller controls the protected-header
+/// JSON — needed by consumers whose specs mandate additional protected
+/// header parameters (e.g. the A2A v1.0 Agent Card §8.4.2 requires `alg`,
+/// `typ` and `kid`). The header is carried verbatim into the JWS.
+///
+/// # Errors
+///
+/// Returns an error if the header is not a JSON object declaring
+/// `"alg":"ES256"` (anything else would sign a JWS every ES256 verifier
+/// rejects), the private key is invalid, or signing fails.
+pub fn jws_sign_es256_with_protected_header(
+    protected_header_json: &str,
+    payload: &[u8],
+    private_key_pkcs8_der: &[u8],
+) -> Result<String> {
+    // Guard against signing a header the ES256 verifier will reject.
+    let header_declares_es256 = serde_json::from_str::<serde_json::Value>(protected_header_json)
+        .ok()
+        .and_then(|v| v.get("alg").and_then(|a| a.as_str().map(String::from)))
+        .is_some_and(|alg| alg == "ES256");
+    if !header_declares_es256 {
+        return Err(Error::Internal(
+            "protected header must be a JSON object with alg=ES256".to_string(),
+        ));
+    }
+
+    let header_b64 = URL_SAFE_NO_PAD.encode(protected_header_json.as_bytes());
     let payload_b64 = URL_SAFE_NO_PAD.encode(payload);
 
     // The signing input is: base64url(header) || '.' || base64url(payload)

--- a/crates/nucleus-verifier-service/src/app.rs
+++ b/crates/nucleus-verifier-service/src/app.rs
@@ -81,10 +81,11 @@ pub struct AppState {
     pub witness: Option<crate::witness::WitnessFederation>,
     /// Signed Agent Card published at `/.well-known/agent-card.json`. When
     /// `Some`, the service serves its own verify-before-you-act identity
-    /// document (an A2A-style card whose detached JWS verifies against the
-    /// operator's out-of-band-resolved key). When `None`, the endpoint
-    /// returns 404 — the service makes no identity claim.
-    pub agent_card: Option<Arc<nucleus_agent_card::SignedAgentCard>>,
+    /// document (an A2A v1.0 card whose detached JWS — embedded in the
+    /// card's `signatures` field — verifies against the operator's
+    /// out-of-band-resolved key). When `None`, the endpoint returns 404 —
+    /// the service makes no identity claim.
+    pub agent_card: Option<Arc<nucleus_agent_card::AgentCard>>,
     /// Durable, append-only, per-identity credit ledger (set via
     /// `--credit-db` / `NUCLEUS_CREDIT_DB_PATH`). When `Some`, the stateful
     /// credit endpoints — `POST /v1/credit/{agent_id}/accrue` and

--- a/crates/nucleus-verifier-service/src/routes.rs
+++ b/crates/nucleus-verifier-service/src/routes.rs
@@ -724,14 +724,15 @@ pub async fn well_known_jwks(State(state): State<AppState>) -> Json<serde_json::
     })
 }
 
-/// `GET /.well-known/agent-card.json` — the service's own A2A-style
-/// signed Agent Card (verify-before-you-act identity document).
+/// `GET /.well-known/agent-card.json` — the service's own signed A2A
+/// v1.0 Agent Card (verify-before-you-act identity document).
 ///
-/// Returns the [`nucleus_agent_card::SignedAgentCard`] configured in
-/// [`AppState::agent_card`]. The card's detached RFC 7515 JWS-JSON
-/// signature verifies against the operator's out-of-band-resolved key —
-/// NEVER against a key embedded in the card. Returns 404 when no card is
-/// configured (the service makes no identity claim in that mode).
+/// Returns the [`nucleus_agent_card::AgentCard`] configured in
+/// [`AppState::agent_card`]. The card's detached RFC 7515 JWS (carried in
+/// the card's own `signatures` field per A2A §8.4) verifies against the
+/// operator's out-of-band-resolved key — NEVER against a key embedded in
+/// the card. Returns 404 when no card is configured (the service makes no
+/// identity claim in that mode).
 pub async fn well_known_agent_card(
     State(state): State<AppState>,
 ) -> Result<Json<serde_json::Value>, VerifyApiError> {

--- a/crates/nucleus-verifier-service/tests/integration.rs
+++ b/crates/nucleus-verifier-service/tests/integration.rs
@@ -801,7 +801,10 @@ async fn well_known_agent_card_returns_404_without_card() {
 
 #[tokio::test]
 async fn well_known_agent_card_verifies_against_matching_key() {
-    use nucleus_agent_card::{sign_card, verify_card, AgentCard, JsonWebKey, SignedAgentCard};
+    use nucleus_agent_card::{
+        sign_card, verify_card, AgentCapabilities, AgentCard, AgentInterface, JsonWebKey,
+        NucleusClaims, A2A_PROTOCOL_VERSION,
+    };
     use ring::rand::SystemRandom;
     use ring::signature::{EcdsaKeyPair, KeyPair, ECDSA_P256_SHA256_FIXED_SIGNING};
     use std::sync::Arc;
@@ -822,15 +825,36 @@ async fn well_known_agent_card_verifies_against_matching_key() {
     let advertised: Jwks = serde_json::from_value(issuer.publish_jwks()).unwrap();
 
     let card = AgentCard {
+        name: "Nucleus Verifier".to_string(),
+        description: "verifier-service integration test card".to_string(),
+        supported_interfaces: vec![AgentInterface {
+            url: "https://verifier.test.nucleus.local/a2a/v1".to_string(),
+            protocol_binding: "HTTP+JSON".to_string(),
+            tenant: None,
+            protocol_version: A2A_PROTOCOL_VERSION.to_string(),
+        }],
+        provider: None,
+        version: "1.0.0".to_string(),
+        documentation_url: None,
+        capabilities: AgentCapabilities::default(),
+        security_schemes: serde_json::Map::new(),
+        security_requirements: vec![],
+        default_input_modes: vec!["application/json".to_string()],
+        default_output_modes: vec!["application/json".to_string()],
+        skills: vec![],
+        signatures: vec![],
+        icon_url: None,
+    }
+    .with_nucleus_claims(&NucleusClaims {
         spiffe_id: "spiffe://test.nucleus.local/ns/verifier/sa/svc".to_string(),
         did: "did:web:verifier.test.nucleus.local".to_string(),
-        security_schemes: json!({}),
         supported_envelope_schema_versions: vec!["1".to_string()],
         jwks_uri: None,
         trust_jwks: advertised,
         runtime_guarantees: None,
-    };
-    let signed = sign_card(card, &der).unwrap();
+    })
+    .unwrap();
+    let signed = sign_card(card, &der, "verifier-card-key-1").unwrap();
 
     let state = AppState {
         agent_card: Some(Arc::new(signed)),
@@ -850,10 +874,10 @@ async fn well_known_agent_card_verifies_against_matching_key() {
 
     // The returned card MUST verify against the matching resolved key.
     let body = read_json(resp.into_body()).await;
-    let returned: SignedAgentCard = serde_json::from_value(body).unwrap();
+    let returned: AgentCard = serde_json::from_value(body).unwrap();
     let verified = verify_card(&returned, &resolved_key)
         .expect("served agent card must verify against the matching out-of-band key");
-    assert_eq!(verified.card.did, "did:web:verifier.test.nucleus.local");
+    assert_eq!(verified.claims.did, "did:web:verifier.test.nucleus.local");
 }
 
 #[tokio::test]

--- a/crates/nucleus-verify-commerce/examples/quickstart.rs
+++ b/crates/nucleus-verify-commerce/examples/quickstart.rs
@@ -17,7 +17,10 @@ use base64::Engine as _;
 use ring::rand::SystemRandom;
 use ring::signature::{EcdsaKeyPair, KeyPair, ECDSA_P256_SHA256_FIXED_SIGNING};
 
-use nucleus_agent_card::{sign_card, AgentCard, JsonWebKey};
+use nucleus_agent_card::{
+    sign_card, AgentCapabilities, AgentCard, AgentInterface, JsonWebKey, NucleusClaims,
+    A2A_PROTOCOL_VERSION,
+};
 use nucleus_envelope::{Bundle, TrustAnchor};
 use nucleus_lineage::{CallSpiffeId, Jwks, LocalIssuer};
 use nucleus_verify_commerce::{
@@ -41,16 +44,37 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     let buyer_trust_jwks: Jwks = serde_json::from_value(LocalIssuer::random()?.publish_jwks())?;
+    // A2A v1.0 card; the nucleus claims travel in the registered extension.
     let buyer_card = AgentCard {
+        name: "Shopper Agent".to_string(),
+        description: "Buys summaries and verifies the receipts.".to_string(),
+        supported_interfaces: vec![AgentInterface {
+            url: "https://shopper.buyer.example.com/a2a/v1".to_string(),
+            protocol_binding: "JSONRPC".to_string(),
+            tenant: None,
+            protocol_version: A2A_PROTOCOL_VERSION.to_string(),
+        }],
+        provider: None,
+        version: "1.0.0".to_string(),
+        documentation_url: None,
+        capabilities: AgentCapabilities::default(),
+        security_schemes: serde_json::Map::new(),
+        security_requirements: vec![],
+        default_input_modes: vec!["application/json".to_string()],
+        default_output_modes: vec!["application/json".to_string()],
+        skills: vec![],
+        signatures: vec![],
+        icon_url: None,
+    }
+    .with_nucleus_claims(&NucleusClaims {
         spiffe_id: "spiffe://buyer.example.com/ns/agents/sa/shopper".to_string(),
         did: "did:web:shopper.buyer.example.com".to_string(),
-        security_schemes: serde_json::json!({}),
         supported_envelope_schema_versions: vec!["1".to_string()],
         jwks_uri: None,
         trust_jwks: buyer_trust_jwks,
         runtime_guarantees: None,
-    };
-    let signed_card = sign_card(buyer_card, pkcs8.as_ref())?;
+    })?;
+    let signed_card = sign_card(buyer_card, pkcs8.as_ref(), "buyer-card-key-1")?;
 
     // ── Seller side: signing identity + published JWKS (production: real signer)
     let seller_signer = LocalIssuer::random()?;

--- a/crates/nucleus-verify-commerce/src/card_verifier.rs
+++ b/crates/nucleus-verify-commerce/src/card_verifier.rs
@@ -1,12 +1,14 @@
-//! [`AgentCardVerifier`] — verify a signed A2A-style Agent Card.
+//! [`AgentCardVerifier`] — verify a signed A2A v1.0 Agent Card.
 
 use async_trait::async_trait;
-use nucleus_agent_card::{verify_card, JsonWebKey, SignedAgentCard};
+use nucleus_agent_card::{verify_card, AgentCard, JsonWebKey};
 
 use crate::{CallerClaims, CallerVerifier, CommerceError, VerifiedCaller};
 
 /// A [`CallerVerifier`] that treats the caller's credential as a JSON
-/// [`SignedAgentCard`] and verifies it against an **out-of-band-resolved** key.
+/// signed [`AgentCard`] (A2A v1.0: the JWS signatures ride in the card's
+/// own `signatures` field) and verifies it against an
+/// **out-of-band-resolved** key.
 ///
 /// The one rule that makes this safe (inherited from
 /// [`nucleus_agent_card::verify_card`]): the verification key comes ONLY from
@@ -14,8 +16,9 @@ use crate::{CallerClaims, CallerVerifier, CommerceError, VerifiedCaller};
 /// pinned JWKS, an operator file). It is never read from the card. A card
 /// verified against an attacker-supplied key is "verified garbage".
 ///
-/// On success the verified caller's identity is the card's `spiffe_id` — the
-/// verified truth, not the caller-asserted [`CallerClaims::agent_id`].
+/// On success the verified caller's identity is the `spiffe_id` from the
+/// card's nucleus extension claims — the verified truth, not the
+/// caller-asserted [`CallerClaims::agent_id`].
 pub struct AgentCardVerifier {
     resolved_key: JsonWebKey,
 }
@@ -30,14 +33,14 @@ impl AgentCardVerifier {
 #[async_trait]
 impl CallerVerifier for AgentCardVerifier {
     async fn verify(&self, claims: &CallerClaims) -> Result<VerifiedCaller, CommerceError> {
-        let signed: SignedAgentCard = serde_json::from_str(&claims.credential)
+        let signed: AgentCard = serde_json::from_str(&claims.credential)
             .map_err(|e| CommerceError::Unverified(format!("malformed signed agent card: {e}")))?;
 
         let verified = verify_card(&signed, &self.resolved_key)
             .map_err(|e| CommerceError::Unverified(format!("agent card did not verify: {e}")))?;
 
         Ok(VerifiedCaller {
-            spiffe_id: verified.card.spiffe_id.clone(),
+            spiffe_id: verified.claims.spiffe_id.clone(),
         })
     }
 }
@@ -47,7 +50,9 @@ mod tests {
     use super::*;
     use base64::engine::general_purpose::URL_SAFE_NO_PAD;
     use base64::Engine as _;
-    use nucleus_agent_card::{sign_card, AgentCard};
+    use nucleus_agent_card::{
+        sign_card, AgentCapabilities, AgentInterface, NucleusClaims, A2A_PROTOCOL_VERSION,
+    };
     use ring::rand::SystemRandom;
     use ring::signature::{EcdsaKeyPair, KeyPair, ECDSA_P256_SHA256_FIXED_SIGNING};
 
@@ -71,19 +76,40 @@ mod tests {
         )
         .unwrap();
         AgentCard {
+            name: "Buyer Agent".to_string(),
+            description: "card-verifier tests".to_string(),
+            supported_interfaces: vec![AgentInterface {
+                url: "https://buyer.prod.example.com/a2a/v1".to_string(),
+                protocol_binding: "JSONRPC".to_string(),
+                tenant: None,
+                protocol_version: A2A_PROTOCOL_VERSION.to_string(),
+            }],
+            provider: None,
+            version: "1.0.0".to_string(),
+            documentation_url: None,
+            capabilities: AgentCapabilities::default(),
+            security_schemes: serde_json::Map::new(),
+            security_requirements: vec![],
+            default_input_modes: vec!["application/json".to_string()],
+            default_output_modes: vec!["application/json".to_string()],
+            skills: vec![],
+            signatures: vec![],
+            icon_url: None,
+        }
+        .with_nucleus_claims(&NucleusClaims {
             spiffe_id: "spiffe://prod.example.com/ns/agents/sa/buyer".to_string(),
             did: "did:web:buyer.prod.example.com".to_string(),
-            security_schemes: serde_json::json!({}),
             supported_envelope_schema_versions: vec!["1".to_string()],
             jwks_uri: None,
             trust_jwks: jwks,
             runtime_guarantees: None,
-        }
+        })
+        .unwrap()
     }
 
-    fn claims_for(signed: &SignedAgentCard) -> CallerClaims {
+    fn claims_for(signed: &AgentCard) -> CallerClaims {
         CallerClaims {
-            agent_id: signed.card.did.clone(),
+            agent_id: signed.nucleus_claims().unwrap().unwrap().did,
             credential: serde_json::to_string(signed).unwrap(),
         }
     }
@@ -91,7 +117,7 @@ mod tests {
     #[tokio::test]
     async fn verifies_a_genuinely_signed_card_to_its_spiffe_id() {
         let (der, pub_jwk) = p256_keypair();
-        let signed = sign_card(sample_card(), &der).unwrap();
+        let signed = sign_card(sample_card(), &der, "card-key-1").unwrap();
         let verifier = AgentCardVerifier::new(pub_jwk);
 
         let caller = verifier.verify(&claims_for(&signed)).await.unwrap();
@@ -105,7 +131,7 @@ mod tests {
     async fn rejects_a_card_verified_against_the_wrong_key() {
         let (der, _pub_jwk) = p256_keypair();
         let (_other_der, attacker_view_key) = p256_keypair(); // unrelated key
-        let signed = sign_card(sample_card(), &der).unwrap();
+        let signed = sign_card(sample_card(), &der, "card-key-1").unwrap();
         // Resolve to a key that did NOT sign the card → must reject.
         let verifier = AgentCardVerifier::new(attacker_view_key);
 

--- a/crates/nucleus-verify-commerce/src/lib.rs
+++ b/crates/nucleus-verify-commerce/src/lib.rs
@@ -23,7 +23,7 @@
 //!
 //! - [`AllowlistVerifier`] / [`HashingReceiptIssuer`] — in-memory, dependency-
 //!   light; for tests, local dev, and minimal deployments.
-//! - [`AgentCardVerifier`] — verifies a signed [A2A-style Agent
+//! - [`AgentCardVerifier`] — verifies a signed [A2A v1.0 Agent
 //!   Card](nucleus_agent_card) against an **out-of-band-resolved** key.
 //! - [`EnvelopeReceiptIssuer`] — emits a real [`nucleus_envelope`] provenance
 //!   `Bundle` (signed by a seller-provided [`EdgeSigner`](nucleus_lineage::EdgeSigner))

--- a/docs/rfcs/signed-ifc-attested-agents.md
+++ b/docs/rfcs/signed-ifc-attested-agents.md
@@ -42,7 +42,7 @@ that *prevents* (vs. detects) violations, and it is host-side.
 ## `just agent-sign` / `agent-ship` (next PR)
 
 ```text
-just agent-sign     # OIDC-keyless-sign a card (incl. its runtime_guarantees), → SignedAgentCard
+just agent-sign     # OIDC-keyless-sign an A2A v1.0 card (incl. its runtime-guarantee claims), → signed AgentCard
 just agent-ship     # publish the signed card to /.well-known + the transparency log
 ```
 

--- a/sdks/verifier-js/index.d.ts
+++ b/sdks/verifier-js/index.d.ts
@@ -157,7 +157,8 @@ export type AgentCardVerdict =
  * A cryptographic rejection is returned as a value (branch on `outcome`);
  * throws only on malformed input (bad card JSON, bad JWK JSON).
  *
- * @param signedCard A `SignedAgentCard` — JSON string or parsed object.
+ * @param signedCard A signed A2A v1.0 `AgentCard` — JSON string or parsed
+ *   object (flat card; JWS signatures embedded in its `signatures` field).
  * @param resolvedJwk The out-of-band-resolved key — JWK JSON string or object.
  */
 export function verifyAgentCard(

--- a/sdks/verifier-js/index.js
+++ b/sdks/verifier-js/index.js
@@ -309,7 +309,9 @@ export async function verifyReceipt(receipt, verifyingKey) {
  * proof of enforcement.
  *
  * @param {string | object} signedCard
- *   A `SignedAgentCard` — JSON string or parsed object (`{card, signatures}`).
+ *   A signed A2A v1.0 `AgentCard` — JSON string or parsed object (flat
+ *   card; JWS signatures embedded in its `signatures` field, nucleus
+ *   claims in its `capabilities.extensions`).
  * @param {string | object} resolvedJwk
  *   The out-of-band-resolved verification key — JWK JSON string or object
  *   (`{"kty":"EC","crv":"P-256","x":"...","y":"..."}`). NEVER from the card.

--- a/sdks/verifier-js/src/lib.rs
+++ b/sdks/verifier-js/src/lib.rs
@@ -319,16 +319,16 @@ fn agent_card_verdict(
     signed_card_json: &str,
     resolved_jwk_json: &str,
 ) -> Result<CardVerdict, String> {
-    let signed: nucleus_agent_card::SignedAgentCard =
+    let signed: nucleus_agent_card::AgentCard =
         serde_json::from_str(signed_card_json).map_err(|e| format!("signed card JSON: {e}"))?;
     let jwk: nucleus_agent_card::JsonWebKey =
         serde_json::from_str(resolved_jwk_json).map_err(|e| format!("resolved JWK JSON: {e}"))?;
     match nucleus_agent_card::verify_card(&signed, &jwk) {
         Ok(verified) => Ok(CardVerdict::Verified {
-            spiffe_id: verified.card.spiffe_id.clone(),
-            did: verified.card.did.clone(),
+            spiffe_id: verified.claims.spiffe_id.clone(),
+            did: verified.claims.did.clone(),
             supported_envelope_schema_versions: verified
-                .card
+                .claims
                 .supported_envelope_schema_versions
                 .clone(),
             trust_jwks_kids: verified
@@ -337,7 +337,7 @@ fn agent_card_verdict(
                 .iter()
                 .map(|k| k.kid.clone())
                 .collect(),
-            runtime_guarantees: verified.card.runtime_guarantees.as_ref().map(|p| {
+            runtime_guarantees: verified.claims.runtime_guarantees.as_ref().map(|p| {
                 RuntimeGuaranteeSummary {
                     profile_version: p.profile_version.clone(),
                     tracked_sources: p.tracked_sources.clone(),
@@ -358,8 +358,9 @@ fn agent_card_verdict(
 /// in the caller's browser/Node process, trusting no server.
 ///
 /// # Arguments
-/// * `signed_card_json` — a `SignedAgentCard` serialized as JSON
-///   (`{card, signatures}`).
+/// * `signed_card_json` — a signed A2A v1.0 `AgentCard` serialized as JSON
+///   (flat card object; JWS signatures embedded in its `signatures` field,
+///   nucleus claims in its `capabilities.extensions`).
 /// * `resolved_jwk_json` — the out-of-band-resolved verification key as a
 ///   JWK JSON (`{"kty":"EC","crv":"P-256","x":"...","y":"..."}`). NEVER
 ///   taken from the card itself.
@@ -868,7 +869,8 @@ mod agent_card_tests {
     use base64::engine::general_purpose::URL_SAFE_NO_PAD;
     use base64::Engine as _;
     use nucleus_agent_card::{
-        sign_card, AgentCard, EnforcementRule, RuntimeGuaranteeProfile, SignedAgentCard,
+        sign_card, AgentCapabilities, AgentCard, AgentInterface, EnforcementRule, NucleusClaims,
+        RuntimeGuaranteeProfile, A2A_PROTOCOL_VERSION,
     };
     use ring::rand::SystemRandom;
     use ring::signature::{EcdsaKeyPair, KeyPair, ECDSA_P256_SHA256_FIXED_SIGNING};
@@ -908,11 +910,10 @@ mod agent_card_tests {
         }
     }
 
-    fn sample_card() -> AgentCard {
-        AgentCard {
+    fn sample_claims() -> NucleusClaims {
+        NucleusClaims {
             spiffe_id: "spiffe://prod.example.com/ns/agents/sa/coder".to_string(),
             did: "did:web:coder.prod.example.com".to_string(),
-            security_schemes: serde_json::json!({}),
             supported_envelope_schema_versions: vec!["1".to_string(), "2".to_string()],
             jwks_uri: None,
             trust_jwks: usable_jwks(),
@@ -928,8 +929,34 @@ mod agent_card_tests {
         }
     }
 
+    fn sample_card() -> AgentCard {
+        AgentCard {
+            name: "Coder Agent".to_string(),
+            description: "SDK verdict-core tests".to_string(),
+            supported_interfaces: vec![AgentInterface {
+                url: "https://coder.prod.example.com/a2a/v1".to_string(),
+                protocol_binding: "JSONRPC".to_string(),
+                tenant: None,
+                protocol_version: A2A_PROTOCOL_VERSION.to_string(),
+            }],
+            provider: None,
+            version: "1.0.0".to_string(),
+            documentation_url: None,
+            capabilities: AgentCapabilities::default(),
+            security_schemes: serde_json::Map::new(),
+            security_requirements: vec![],
+            default_input_modes: vec!["application/json".to_string()],
+            default_output_modes: vec!["application/json".to_string()],
+            skills: vec![],
+            signatures: vec![],
+            icon_url: None,
+        }
+        .with_nucleus_claims(&sample_claims())
+        .unwrap()
+    }
+
     fn signed_card_json(der: &[u8]) -> String {
-        let signed = sign_card(sample_card(), der).unwrap();
+        let signed = sign_card(sample_card(), der, "card-key-1").unwrap();
         serde_json::to_string(&signed).unwrap()
     }
 
@@ -963,9 +990,10 @@ mod agent_card_tests {
     #[test]
     fn card_without_profile_verifies_with_none_summary() {
         let (der, jwk_json) = p256_keypair();
-        let mut card = sample_card();
-        card.runtime_guarantees = None;
-        let signed = sign_card(card, &der).unwrap();
+        let mut claims = sample_claims();
+        claims.runtime_guarantees = None;
+        let card = sample_card().with_nucleus_claims(&claims).unwrap();
+        let signed = sign_card(card, &der, "card-key-1").unwrap();
         let json = serde_json::to_string(&signed).unwrap();
         match agent_card_verdict(&json, &jwk_json).expect("well-formed input") {
             CardVerdict::Verified {
@@ -978,9 +1006,11 @@ mod agent_card_tests {
     #[test]
     fn tampered_card_is_rejected() {
         let (der, jwk_json) = p256_keypair();
-        let mut signed: SignedAgentCard = serde_json::from_str(&signed_card_json(&der)).unwrap();
-        // Mutate the card AFTER signing — the detached JWS no longer matches.
-        signed.card.did = "did:web:attacker.example.com".to_string();
+        let mut signed: AgentCard = serde_json::from_str(&signed_card_json(&der)).unwrap();
+        // Mutate the claims AFTER signing — the detached JWS no longer matches.
+        let mut claims = signed.nucleus_claims().unwrap().unwrap();
+        claims.did = "did:web:attacker.example.com".to_string();
+        signed = signed.with_nucleus_claims(&claims).unwrap();
         let json = serde_json::to_string(&signed).unwrap();
         assert!(matches!(
             agent_card_verdict(&json, &jwk_json).expect("well-formed input"),
@@ -1003,10 +1033,7 @@ mod agent_card_tests {
     #[test]
     fn card_with_no_signatures_is_rejected() {
         let (_der, jwk_json) = p256_keypair();
-        let unsigned = SignedAgentCard {
-            card: sample_card(),
-            signatures: vec![],
-        };
+        let unsigned = sample_card(); // signatures: []
         let json = serde_json::to_string(&unsigned).unwrap();
         match agent_card_verdict(&json, &jwk_json).expect("well-formed input") {
             CardVerdict::Rejected { reason } => {

--- a/sdks/verifier-js/test/card.test.mjs
+++ b/sdks/verifier-js/test/card.test.mjs
@@ -1,6 +1,8 @@
-// Node test for verifyAgentCard — the signed A2A Agent Card (detached ES256
-// JWS over the RFC 8785 JCS of the card) verified through the SAME
-// `nucleus_agent_card::verify_card` every native recipient runs.
+// Node test for verifyAgentCard — the signed A2A v1.0 Agent Card (detached
+// ES256 JWS over the RFC 8785 JCS of the card minus its `signatures` field,
+// per spec §8.4) verified through the SAME `nucleus_agent_card::verify_card`
+// every native recipient runs. Nucleus claims (spiffe_id/did/trust JWKS/
+// runtime guarantees) ride in the card's `capabilities.extensions` entry.
 //
 // The fixture is REAL: signed by `nucleus-agent-card`'s sign_card with a ring
 // P-256 key (see fixtures/agent-card.json `_generated_by`); `resolved_jwk` is
@@ -23,6 +25,17 @@ const fixtureUrl = new URL("./fixtures/agent-card.json", import.meta.url);
 async function readFixture() {
   const text = await readFile(fileURLToPath(fixtureUrl), "utf8");
   return JSON.parse(text);
+}
+
+const NUCLEUS_EXT_URI = "https://coproduct.one/a2a/ext/runtime-guarantees/v1";
+
+/** The nucleus extension params of a v1.0 card (where the claims live). */
+function nucleusParams(card) {
+  const ext = card.capabilities.extensions.find(
+    (e) => e.uri === NUCLEUS_EXT_URI,
+  );
+  assert.ok(ext, "fixture card declares the nucleus extension");
+  return ext.params;
 }
 
 test("accepts the real, untampered fixture card with its profile summary", async () => {
@@ -56,14 +69,21 @@ test("accepts JSON-string inputs identically", async () => {
 
 test("a card tampered after signing is rejected (verdict, not throw)", async () => {
   const { signed_card, resolved_jwk } = await readFixture();
-  signed_card.card.did = "did:web:attacker.example.com";
+  nucleusParams(signed_card).did = "did:web:attacker.example.com";
+  const v = await verifyAgentCard(signed_card, resolved_jwk);
+  assert.equal(v.outcome, "rejected");
+});
+
+test("tampering a base v1.0 card field also breaks the signature", async () => {
+  const { signed_card, resolved_jwk } = await readFixture();
+  signed_card.name = "Imposter Agent";
   const v = await verifyAgentCard(signed_card, resolved_jwk);
   assert.equal(v.outcome, "rejected");
 });
 
 test("a tampered runtime-guarantee declaration breaks the signature", async () => {
   const { signed_card, resolved_jwk } = await readFixture();
-  signed_card.card.runtime_guarantees.enforcement_rules[0].name =
+  nucleusParams(signed_card).runtimeGuarantees.enforcementRules[0].name =
     "allow_everything";
   const v = await verifyAgentCard(signed_card, resolved_jwk);
   assert.equal(v.outcome, "rejected");

--- a/sdks/verifier-js/test/fixtures/agent-card.json
+++ b/sdks/verifier-js/test/fixtures/agent-card.json
@@ -1,56 +1,80 @@
 {
-  "_generated_by": "nucleus-agent-card sign_card with an ephemeral ring P-256 key — a TEST key; the JWK is the matching public key a recipient would resolve out-of-band. wrong_jwk is a second, unrelated P-256 key.",
+  "_generated_by": "nucleus-agent-card print_verifier_js_fixture (sign_card with an ephemeral ring P-256 key — a TEST key; resolved_jwk is the matching public key a recipient would resolve out-of-band; wrong_jwk is a second, unrelated P-256 key). A2A v1.0 card shape.",
   "resolved_jwk": {
     "crv": "P-256",
     "kty": "EC",
-    "x": "9isxwtcA68nIOId1WnltnknPsbNq47QvmEBj0ft0-pQ",
-    "y": "mwrZCN6mpdyx0OGD2GbMdNvYmKXf2YzzOCgzXksH-ns"
+    "x": "5RrwLcssCbluBtmbvoVLn11nH_Qz65f9qWL0KXE9t5o",
+    "y": "3BFjxELxCEdDDOOmRF0FHbEZa4tYqyBLrfeky01Zwjs"
   },
   "signed_card": {
-    "card": {
-      "did": "did:web:coder.prod.example.com",
-      "runtime_guarantees": {
-        "enforcement_rules": [
-          {
-            "description": "deny outbound actions tainted by adversarial content",
-            "name": "no_adversarial_to_outbound"
-          }
-        ],
-        "profile_version": "1.0",
-        "tracked_sources": [
-          "web_content",
-          "secret"
-        ]
-      },
-      "security_schemes": {},
-      "spiffe_id": "spiffe://prod.example.com/ns/agents/sa/coder",
-      "supported_envelope_schema_versions": [
-        "1"
-      ],
-      "trust_jwks": {
-        "keys": [
-          {
-            "alg": "EdDSA",
-            "crv": "Ed25519",
-            "kid": "issuer-k1",
-            "kty": "OKP",
-            "use": "sig",
-            "x": "6kpsY-KcUgq-9VB7Ey7F-ZVHdq6-vnuSQh7qaRRG0iw"
-          }
-        ]
-      }
+    "capabilities": {
+      "extensions": [
+        {
+          "description": "nucleus verify-before-you-act claims: SPIFFE/DID identity, trust JWKS, envelope schema versions, runtime-guarantee profile",
+          "params": {
+            "did": "did:web:coder.prod.example.com",
+            "runtimeGuarantees": {
+              "enforcementRules": [
+                {
+                  "description": "deny outbound actions tainted by adversarial content",
+                  "name": "no_adversarial_to_outbound"
+                }
+              ],
+              "profileVersion": "1.0",
+              "trackedSources": [
+                "web_content",
+                "secret"
+              ]
+            },
+            "spiffeId": "spiffe://prod.example.com/ns/agents/sa/coder",
+            "supportedEnvelopeSchemaVersions": [
+              "1"
+            ],
+            "trustJwks": {
+              "keys": [
+                {
+                  "alg": "EdDSA",
+                  "crv": "Ed25519",
+                  "kid": "issuer-k1",
+                  "kty": "OKP",
+                  "use": "sig",
+                  "x": "6kpsY-KcUgq-9VB7Ey7F-ZVHdq6-vnuSQh7qaRRG0iw"
+                }
+              ]
+            }
+          },
+          "uri": "https://coproduct.one/a2a/ext/runtime-guarantees/v1"
+        }
+      ]
     },
+    "defaultInputModes": [
+      "application/json"
+    ],
+    "defaultOutputModes": [
+      "application/json"
+    ],
+    "description": "sign/verify round-trip tests",
+    "name": "Coder Agent",
     "signatures": [
       {
-        "protected": "eyJhbGciOiJFUzI1NiJ9",
-        "signature": "dv2aCw-aMUC6V1A0H2oQojdoh4z_ww6CanP1LSNDmwkipPZuGGx7BPVzuNzL0FeoYO81F7WSgkgBwXny5atD4A"
+        "protected": "eyJhbGciOiJFUzI1NiIsImtpZCI6ImNhcmQta2V5LTEiLCJ0eXAiOiJKT1NFIn0",
+        "signature": "uzB49cF13g-oNBQ-hJ5687zai_VaGRaR0cJOYpiCb6X2Gm0TSTQpi-9jQgMACZw-sb16mkRJBsFa5dNLbB949Q"
       }
-    ]
+    ],
+    "skills": [],
+    "supportedInterfaces": [
+      {
+        "protocolBinding": "JSONRPC",
+        "protocolVersion": "1.0",
+        "url": "https://coder.prod.example.com/a2a/v1"
+      }
+    ],
+    "version": "1.0.0"
   },
   "wrong_jwk": {
     "crv": "P-256",
     "kty": "EC",
-    "x": "DBjbzVl6cou3QHISAVbbQWegaqqoE6If88z3ad8X6lU",
-    "y": "L9u1h0MG3N9x-1xl-pO9knyNcyWjUbgRIAvVNC_jNi8"
+    "x": "CxImsLlwCuxfgyUy08vzgyIVjH6jj-Wcv3_kEUScB-c",
+    "y": "4om1tjFHkOGWLTV1hwZI_PuLtHZmUwYDkLnSJebHmdM"
   }
 }

--- a/sdks/verifier-js/tests/web.rs
+++ b/sdks/verifier-js/tests/web.rs
@@ -125,26 +125,45 @@ fn verify_receipt_rejects_wrong_key_length() {
 // wasm boundary tests pin the input-error and rejected-verdict paths; the full
 // sign→verify round-trip is pinned by the native tests in src/lib.rs.
 
-/// A structurally well-formed SignedAgentCard whose signature is garbage.
+/// A structurally well-formed signed A2A v1.0 AgentCard whose signature
+/// is garbage.
 fn garbage_signed_card_json() -> String {
-    let card = nucleus_agent_card::AgentCard {
+    let mut card = nucleus_agent_card::AgentCard {
+        name: "Coder Agent".to_string(),
+        description: "wasm boundary tests".to_string(),
+        supported_interfaces: vec![nucleus_agent_card::AgentInterface {
+            url: "https://coder.prod.example.com/a2a/v1".to_string(),
+            protocol_binding: "JSONRPC".to_string(),
+            tenant: None,
+            protocol_version: nucleus_agent_card::A2A_PROTOCOL_VERSION.to_string(),
+        }],
+        provider: None,
+        version: "1.0.0".to_string(),
+        documentation_url: None,
+        capabilities: nucleus_agent_card::AgentCapabilities::default(),
+        security_schemes: serde_json::Map::new(),
+        security_requirements: vec![],
+        default_input_modes: vec!["application/json".to_string()],
+        default_output_modes: vec!["application/json".to_string()],
+        skills: vec![],
+        signatures: vec![],
+        icon_url: None,
+    }
+    .with_nucleus_claims(&nucleus_agent_card::NucleusClaims {
         spiffe_id: "spiffe://prod.example.com/ns/agents/sa/coder".to_string(),
         did: "did:web:coder.prod.example.com".to_string(),
-        security_schemes: serde_json::json!({}),
         supported_envelope_schema_versions: vec!["1".to_string()],
         jwks_uri: None,
         trust_jwks: nucleus_lineage::Jwks { keys: vec![] },
         runtime_guarantees: None,
-    };
-    let signed = nucleus_agent_card::SignedAgentCard {
-        card,
-        signatures: vec![nucleus_agent_card::AgentCardSignature {
-            protected: "eyJhbGciOiJFUzI1NiJ9".to_string(),
-            signature: "bm90LWEtcmVhbC1zaWc".to_string(),
-            header: None,
-        }],
-    };
-    serde_json::to_string(&signed).unwrap()
+    })
+    .unwrap();
+    card.signatures = vec![nucleus_agent_card::AgentCardSignature {
+        protected: "eyJhbGciOiJFUzI1NiJ9".to_string(),
+        signature: "bm90LWEtcmVhbC1zaWc".to_string(),
+        header: None,
+    }];
+    serde_json::to_string(&card).unwrap()
 }
 
 /// A syntactically valid P-256 JWK (RFC 7515 A.3 test vector point).


### PR DESCRIPTION
## What v1.0 requires (spec citations)

The A2A v1.0.1 spec declares `specification/a2a.proto` the **single authoritative normative definition** of all data objects, with JSON serialization per ProtoJSON (ADR-001: lowerCamelCase names, defaults omitted). The normative `message AgentCard` (Next ID: 20) and signing rules:

- **§8.4.1 Canonicalization**: "Before signing, the Agent Card content **MUST** be canonicalized using the JSON Canonicalization Scheme (JCS) as defined in RFC 8785" + proto3 presence rules (unset optional / default-valued fields **MUST** be omitted) + "the `signatures` field itself **MUST** be excluded from the content being signed."
- **§8.4.2 Signature format**: RFC 7515 JWS; `AgentCardSignature` = `{protected (b64url JSON header, REQUIRED), signature (b64url, REQUIRED), header (unprotected JSON object, optional)}`; the protected header **MUST** include `alg`, `typ` (SHOULD be `"JOSE"`), `kid`; MAY include `jku`. Signing input is `ASCII(BASE64URL(header) || '.' || BASE64URL(payload))` — i.e. a **detached** JWS, reconstructed from the card.
- **§8.4.3 Verification**: extract from the `signatures` array, resolve the key (`kid`+`jku` **or a trusted key store**), strip defaults + `signatures`, JCS, verify. We implement the trusted-key-store mode only (out-of-band `resolved_key`), preserving the crate's verify-before-you-act trust model.
- **protocolVersion**: v1.0 has **no card-level protocol version**; it is advertised per interface (`AgentInterface.protocol_version`, REQUIRED, e.g. `"1.0"`), and at transport level via the `A2A-Version` service parameter (§3.6). We export `A2A_PROTOCOL_VERSION = "1.0"`.

## Old field → new field mapping

| old (bespoke) | new (A2A v1.0) |
|---|---|
| `SignedAgentCard { card, signatures }` | gone — `AgentCard.signatures` (spec field 13) |
| `card.spiffe_id` | `capabilities.extensions[uri=…/runtime-guarantees/v1].params.spiffeId` |
| `card.did` | extension `params.did` |
| `card.trust_jwks` | extension `params.trustJwks` |
| `card.jwks_uri` | extension `params.jwksUri` |
| `card.supported_envelope_schema_versions` | extension `params.supportedEnvelopeSchemaVersions` |
| `card.runtime_guarantees` | extension `params.runtimeGuarantees` (camelCase profile) |
| `card.security_schemes` (opaque) | `securitySchemes` (proto field 8, opaque map) |
| — (new, REQUIRED by v1.0) | `name`, `description`, `supportedInterfaces[]`, `version`, `capabilities`, `defaultInputModes`, `defaultOutputModes`, `skills` |
| — (new, optional) | `provider`, `documentationUrl`, `securityRequirements`, `iconUrl` |

**Extension URI (documented, versioned independently):** `https://coproduct.one/a2a/ext/runtime-guarantees/v1`, declared `required: false`, typed as `NucleusClaims`.

## What breaks (migration note)

- **Wire**: cards are now flat v1.0 objects (camelCase, signatures embedded). Any stored/published old-shape card must be re-issued: build the v1.0 base card, attach claims via `AgentCard::with_nucleus_claims(&NucleusClaims{…})`, re-sign.
- **API**: `SignedAgentCard` removed; `sign_card(card, key)` → `sign_card(card, key, kid) -> AgentCard` (kid is now REQUIRED in the protected header per §8.4.2); `verify_card(&card, &jwk) -> VerifiedCard { card, claims }` — identity fields read from `verified.claims.*`; `verify_card` requires the nucleus extension (same posture as the old required `trust_jwks`).
- **Signatures**: old signatures cannot verify against the new canonical payload (different fields, camelCase, signature-field exclusion). This is the point of the breaking change.
- `nucleus-identity` gains `jws_sign_es256_with_protected_header` (additive, non-breaking).
- JS SDK surface (`verifyAgentCard`) verdict shape is **unchanged** (`spiffe_id`, `did`, `trust_jwks_kids`, `runtime_guarantees`, …); only the accepted card JSON shape changes. Fixture regenerated via the new `print_verifier_js_fixture` ignored test.

## Ambiguities found (implemented per the normative proto; documented here)

1. **§8.5 sample card vs proto**: the spec's sample shows `"security": [{"google": ["openid", …]}]` (OpenAPI-style), but the v1.0.0/v1.0.1 proto field is `security_requirements` (`repeated SecurityRequirement`, `schemes: map<string, StringList>`), whose ProtoJSON is `"securityRequirements": [{"schemes": {"google": {"list": […]}}}]`. The a2a-python v1.1.0 SDK builds `SecurityRequirement{schemes{…StringList}}`, confirming the proto. We implement the proto/ProtoJSON shape; the §8.5 sample appears stale.
2. **`AgentExtension.uri` REQUIRED-ness**: the proto carries no `REQUIRED` annotation on extension fields; we treat `uri` as practically required (it is the identity of the extension) and omit empty `description`/`required:false`/absent `params` per the default-omission rules.
3. **Spec markdown vs rendered site drift**: the rendered a2a-protocol.org page describes fields (e.g. card-level `id`) that do not exist in the normative proto; we followed the proto.

## Gates (all green locally)

- `cargo test -p nucleus-agent-card --all-features` — 41 + 2 handshake tests
- `RUSTFLAGS="-D warnings" cargo hack check --each-feature --no-dev-deps -p nucleus-agent-card` (5/5)
- `cargo check --target wasm32-unknown-unknown -p nucleus-agent-card --features envelope` + verifier-js wasm check (incl. `--tests`) + `wasm-pack build --target web --release`
- verifier-js native (13) + Node tests (37, incl. 8 card tests on the regenerated fixture)
- `nucleus-verify-commerce` (19+60+7), `nucleus-verifier-service` (39+12), `nucleus-identity` (249)
- fmt + clippy (`--all-features --all-targets`) clean on every touched crate
- `agent_sign` + `quickstart` examples run end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)
