### PR TITLE
fix(ci): ratchet ceilings jump to current actuals; decrement becomes notice-only

### DIFF
--- a/.github/workflows/line-ratchet.yml
+++ b/.github/workflows/line-ratchet.yml
@@ -67,8 +67,9 @@ jobs:
           echo "Ratcheting: $CEILING -> $NEW_CEILING (file: $ACTUAL lines, target: $TARGET)"
           sed -i "s/^ceiling = $CEILING/ceiling = $NEW_CEILING/" "$RATCHET_FILE"
 
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add "$RATCHET_FILE"
-          git commit -m "chore: ratchet line ceiling $CEILING -> $NEW_CEILING [skip ci]"
-          git push
+          # Direct pushes to main are rejected (GH006) under the
+          # 25-required-context branch protection, and a bot push can't
+          # go through the merge queue. The ENFORCING job is "Check
+          # line ceiling" on PRs; this job now only PROPOSES the
+          # decrement — land ceiling updates via an ordinary PR.
+          echo "::notice::Ratchet decrement available: $CEILING -> $NEW_CEILING (file at $ACTUAL lines). Land it via a PR editing $RATCHET_FILE."

--- a/.line-ratchet.toml
+++ b/.line-ratchet.toml
@@ -1,7 +1,7 @@
 # Line-count ratchet — soft ceiling that decreases by 1 on every merge to main.
 
 [ratchet]
-ceiling = 3900
+ceiling = 2479
 target = 2500
 step = 1
 
@@ -9,18 +9,18 @@ step = 1
 
 [[files]]
 path = "crates/portcullis/src/kernel.rs"
-ceiling = 3900
+ceiling = 2479
 target = 2500
 step = 1
 
 [[files]]
 path = "crates/nucleus-tool-proxy/src/main.rs"
-ceiling = 4443
+ceiling = 4118
 target = 2500
 step = 1
 
 [[files]]
 path = "crates/nucleus-node/src/main.rs"
-ceiling = 3304
+ceiling = 3252
 target = 2000
 step = 1


### PR DESCRIPTION
## What

The ratchet-down job direct-pushes to main, which now GH006-fails under the 25-required-context protection — same class as the decide_pure auto-commit (#1846), third bot-push casualty of the hardened gates (working as intended, against our own tooling). The **enforcing** half (`Check line ceiling` on PRs) is untouched; the decrement job now emits a notice, and ceiling updates land via ordinary PRs.

## The headline the failing run surfaced

**`portcullis/src/kernel.rs` is at 2,479 lines — below its 2,500 target.** The 3900-ceiling era is over. Ceilings jump to current actuals: kernel.rs **3900→2479** (target beaten), tool-proxy 4443→4118, node 3304→3252 — locking in all the refactoring gains as the new floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)