### PR TITLE
test(agent-card): A2A v1.0 §8.4 conformance suite + kid enforcement

### DIFF
--- a/crates/nucleus-agent-card/src/conformance_tests.rs
+++ b/crates/nucleus-agent-card/src/conformance_tests.rs
@@ -1,0 +1,290 @@
+//! A2A v1.0 §8.4 conformance suite — pins this crate's signing surface to
+//! the SPEC's own worked examples and MUSTs, not merely to itself.
+//!
+//! Spec ground truth: docs/specification.md @ a2aproject/A2A v1.0.1
+//! (normative data shapes: specification/a2a.proto, package lf.a2a.v1).
+//! Gated on `feature = "sign"` like the round-trip suite — the negative
+//! cases hand-craft signatures.
+
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine as _;
+use ring::rand::SystemRandom;
+use ring::signature::{EcdsaKeyPair, KeyPair, ECDSA_P256_SHA256_FIXED_SIGNING};
+
+use crate::card::{
+    AgentCapabilities, AgentCard, AgentCardSignature, AgentInterface, NucleusClaims,
+    A2A_PROTOCOL_VERSION,
+};
+use crate::jcs::canonicalize;
+use crate::jwk::JsonWebKey;
+use crate::sign::sign_card;
+use crate::verify::verify_card;
+
+fn p256_keypair() -> (Vec<u8>, JsonWebKey) {
+    let rng = SystemRandom::new();
+    let pkcs8 = EcdsaKeyPair::generate_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, &rng).unwrap();
+    let der = pkcs8.as_ref().to_vec();
+    let key_pair = EcdsaKeyPair::from_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, &der, &rng).unwrap();
+    let pk = key_pair.public_key().as_ref();
+    let x = URL_SAFE_NO_PAD.encode(&pk[1..33]);
+    let y = URL_SAFE_NO_PAD.encode(&pk[33..65]);
+    (der, JsonWebKey::ec_p256(x, y))
+}
+
+/// A FIXED (non-random) advertised JWKS so canonical bytes can be golden
+/// -pinned. The verify path only requires it to be well-formed Ed25519.
+fn fixed_jwks() -> nucleus_lineage::Jwks {
+    serde_json::from_value(serde_json::json!({
+        "keys": [{
+            "kty": "OKP",
+            "crv": "Ed25519",
+            "alg": "EdDSA",
+            "kid": "conformance-k1",
+            // 32 zero bytes, base64url — a valid point encoding for
+            // parsing purposes (never used to verify anything here).
+            "x": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        }]
+    }))
+    .unwrap()
+}
+
+fn fixed_claims() -> NucleusClaims {
+    NucleusClaims {
+        spiffe_id: "spiffe://conformance.example.com/ns/agents/sa/golden".to_string(),
+        did: "did:web:golden.conformance.example.com".to_string(),
+        supported_envelope_schema_versions: vec!["1".to_string()],
+        jwks_uri: None,
+        trust_jwks: fixed_jwks(),
+        runtime_guarantees: None,
+    }
+}
+
+/// The §8.4.1 worked example's card fragment, completed into a full card
+/// (the spec fragment omits fields that are REQUIRED on the wire).
+fn spec_example_card() -> AgentCard {
+    AgentCard {
+        name: "Example Agent".to_string(),
+        description: "".to_string(),
+        supported_interfaces: vec![AgentInterface {
+            url: "https://agent.example.com/a2a/v1".to_string(),
+            protocol_binding: "JSONRPC".to_string(),
+            tenant: None,
+            protocol_version: A2A_PROTOCOL_VERSION.to_string(),
+        }],
+        provider: None,
+        version: "1.0.0".to_string(),
+        documentation_url: None,
+        capabilities: AgentCapabilities {
+            // Explicitly set to their defaults — §8.4.1 says explicitly-set
+            // optionals MUST be included.
+            streaming: Some(false),
+            push_notifications: Some(false),
+            extensions: vec![],
+            extended_agent_card: None,
+        },
+        security_schemes: serde_json::Map::new(),
+        security_requirements: vec![],
+        default_input_modes: vec!["application/json".to_string()],
+        default_output_modes: vec!["application/json".to_string()],
+        skills: vec![],
+        signatures: vec![],
+        icon_url: None,
+    }
+}
+
+/// §8.4.1 worked example, decision by decision. The spec's expected output
+/// for the fragment is
+/// `{"capabilities":{"pushNotifications":false,"streaming":false},"description":"","name":"Example Agent","skills":[]}`
+/// — we assert each of its decisions on the completed card's canonical
+/// bytes.
+#[test]
+fn spec_8_4_1_worked_example_decisions_hold() {
+    let canon = String::from_utf8(canonicalize(&spec_example_card()).unwrap()).unwrap();
+
+    // Explicitly-set optional defaults are INCLUDED; empty repeated
+    // `extensions` is OMITTED; keys are lexicographic — this exact
+    // substring is the spec's own expected capabilities object.
+    assert!(
+        canon.contains(r#""capabilities":{"pushNotifications":false,"streaming":false}"#),
+        "{canon}"
+    );
+    // REQUIRED empty string is INCLUDED.
+    assert!(canon.contains(r#""description":"""#), "{canon}");
+    // REQUIRED empty array is INCLUDED.
+    assert!(canon.contains(r#""skills":[]"#), "{canon}");
+    // Unset optionals are absent entirely.
+    for absent in ["extendedAgentCard", "extensions", "provider", "iconUrl"] {
+        assert!(!canon.contains(absent), "{absent} must be omitted: {canon}");
+    }
+    // RFC 8785 lexicographic top-level ordering.
+    let order = [
+        "capabilities",
+        "defaultInputModes",
+        "defaultOutputModes",
+        "description",
+        "name",
+    ];
+    let idx: Vec<usize> = order
+        .iter()
+        .map(|k| canon.find(&format!("\"{k}\"")).unwrap())
+        .collect();
+    assert!(idx.windows(2).all(|w| w[0] < w[1]), "{canon}");
+}
+
+/// GOLDEN PIN: the exact canonical bytes of a fully deterministic card
+/// (fixed claims, fixed JWKS). Any change to field naming, presence rules,
+/// extension layout, or JCS behavior breaks this byte string — that is the
+/// point. Regenerate ONLY for a deliberate, spec-cited wire change.
+#[test]
+fn golden_canonical_bytes_are_pinned() {
+    let card = spec_example_card()
+        .with_nucleus_claims(&fixed_claims())
+        .unwrap();
+    let canon = String::from_utf8(canonicalize(&card).unwrap()).unwrap();
+    let expected = concat!(
+        r#"{"capabilities":{"extensions":[{"description":"nucleus verify-before-you-act claims: SPIFFE/DID identity, trust JWKS, envelope schema versions, runtime-guarantee profile","params":{"did":"did:web:golden.conformance.example.com","spiffeId":"spiffe://conformance.example.com/ns/agents/sa/golden","supportedEnvelopeSchemaVersions":["1"],"trustJwks":{"keys":[{"alg":"EdDSA","crv":"Ed25519","kid":"conformance-k1","kty":"OKP","x":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"}]}},"uri":"https://coproduct.one/a2a/ext/runtime-guarantees/v1"}],"pushNotifications":false,"streaming":false},"#,
+        r#""defaultInputModes":["application/json"],"defaultOutputModes":["application/json"],"description":"","name":"Example Agent","#,
+        r#""skills":[],"supportedInterfaces":[{"protocolBinding":"JSONRPC","protocolVersion":"1.0","url":"https://agent.example.com/a2a/v1"}],"version":"1.0.0"}"#
+    );
+    assert_eq!(canon, expected);
+}
+
+/// §8.4.2: the protected header is exactly `{alg, typ, kid}` with the
+/// spec-required values — the same parameter set as the spec's own
+/// example header.
+#[test]
+fn protected_header_is_spec_shaped() {
+    let (der, _) = p256_keypair();
+    let signed = sign_card(
+        spec_example_card()
+            .with_nucleus_claims(&fixed_claims())
+            .unwrap(),
+        &der,
+        "key-1",
+    )
+    .unwrap();
+    let header_bytes = URL_SAFE_NO_PAD
+        .decode(&signed.signatures[0].protected)
+        .unwrap();
+    let header: serde_json::Value = serde_json::from_slice(&header_bytes).unwrap();
+    assert_eq!(header["alg"], "ES256");
+    assert_eq!(header["typ"], "JOSE");
+    assert_eq!(header["kid"], "key-1");
+    assert_eq!(header.as_object().unwrap().len(), 3, "{header}");
+}
+
+/// §8.4.1 rule 1 exists so cards can be RECONSTRUCTED: a signed card that
+/// travels through serde (wire JSON -> struct) must still verify,
+/// including explicit-default presence.
+#[test]
+fn reconstruction_round_trip_preserves_signature() {
+    let (der, jwk) = p256_keypair();
+    let signed = sign_card(
+        spec_example_card()
+            .with_nucleus_claims(&fixed_claims())
+            .unwrap(),
+        &der,
+        "key-1",
+    )
+    .unwrap();
+    let wire = serde_json::to_string(&signed).unwrap();
+    let reconstructed: AgentCard = serde_json::from_str(&wire).unwrap();
+    verify_card(&reconstructed, &jwk).expect("reconstructed card verifies");
+}
+
+/// Presence is SIGNATURE-BOUND: a card signed with `streaming` unset must
+/// not verify after someone "helpfully" materializes the default.
+#[test]
+fn explicit_default_materialization_breaks_the_signature() {
+    let (der, jwk) = p256_keypair();
+    let mut card = spec_example_card()
+        .with_nucleus_claims(&fixed_claims())
+        .unwrap();
+    card.capabilities.streaming = None;
+    let mut signed = sign_card(card, &der, "key-1").unwrap();
+    verify_card(&signed, &jwk).expect("baseline verifies");
+    signed.capabilities.streaming = Some(false);
+    assert!(verify_card(&signed, &jwk).is_err());
+}
+
+/// §8.4.1 rule 3 + §8.4.3 co-signing: `signatures` never enters the signed
+/// content, so (a) canonical bytes are identical before/after signing and
+/// (b) appending a second signature keeps the first valid.
+#[test]
+fn signatures_are_excluded_and_append_only() {
+    let (der1, jwk1) = p256_keypair();
+    let (der2, _) = p256_keypair();
+    let card = spec_example_card()
+        .with_nucleus_claims(&fixed_claims())
+        .unwrap();
+    let before = canonicalize(&card).unwrap();
+    let signed_once = sign_card(card, &der1, "key-1").unwrap();
+    assert_eq!(before, canonicalize(&signed_once).unwrap());
+    let signed_twice = sign_card(signed_once, &der2, "key-2").unwrap();
+    assert_eq!(before, canonicalize(&signed_twice).unwrap());
+    // verify_card checks the FIRST signature — still key-1's.
+    verify_card(&signed_twice, &jwk1).expect("first signature survives co-signing");
+}
+
+/// §8.4.2: a protected header missing `kid` (or carrying an empty one) is
+/// nonconformant and must be rejected — even when the signature itself
+/// would cryptographically verify.
+#[test]
+fn missing_or_empty_kid_is_rejected() {
+    let (der, jwk) = p256_keypair();
+    let card = spec_example_card()
+        .with_nucleus_claims(&fixed_claims())
+        .unwrap();
+    let jcs = canonicalize(&card).unwrap();
+
+    for header in [
+        r#"{"alg":"ES256","typ":"JOSE"}"#,
+        r#"{"alg":"ES256","typ":"JOSE","kid":""}"#,
+    ] {
+        let compact =
+            nucleus_identity::did_crypto::jws_sign_es256_with_protected_header(header, &jcs, &der)
+                .unwrap();
+        let parts: Vec<&str> = compact.splitn(3, '.').collect();
+        let mut bad = card.clone();
+        bad.signatures = vec![AgentCardSignature {
+            protected: parts[0].to_string(),
+            signature: parts[2].to_string(),
+            header: None,
+        }];
+        let err = verify_card(&bad, &jwk).unwrap_err();
+        assert!(format!("{err}").contains("kid"), "{err}");
+    }
+}
+
+/// Tampering with ANY field after signing — including inside the nucleus
+/// extension params — must fail verification.
+#[test]
+fn any_post_signing_tamper_is_rejected() {
+    let (der, jwk) = p256_keypair();
+    let signed = sign_card(
+        spec_example_card()
+            .with_nucleus_claims(&fixed_claims())
+            .unwrap(),
+        &der,
+        "key-1",
+    )
+    .unwrap();
+
+    let mut t1 = signed.clone();
+    t1.name = "Renamed Agent".to_string();
+    assert!(verify_card(&t1, &jwk).is_err());
+
+    let mut t2 = signed.clone();
+    t2.capabilities.extensions[0]
+        .params
+        .as_mut()
+        .unwrap()
+        .as_object_mut()
+        .unwrap()
+        .insert("spiffeId".to_string(), "spiffe://evil/sa/mallory".into());
+    assert!(verify_card(&t2, &jwk).is_err());
+
+    let mut t3 = signed;
+    t3.supported_interfaces[0].url = "https://evil.example.com/a2a/v1".to_string();
+    assert!(verify_card(&t3, &jwk).is_err());
+}

--- a/crates/nucleus-agent-card/src/lib.rs
+++ b/crates/nucleus-agent-card/src/lib.rs
@@ -71,6 +71,9 @@ pub mod sign;
 #[cfg(all(test, feature = "sign"))]
 mod sign_verify_tests;
 
+#[cfg(all(test, feature = "sign"))]
+mod conformance_tests;
+
 #[cfg(all(test, feature = "sign", feature = "envelope"))]
 mod envelope_e2e_tests;
 

--- a/crates/nucleus-agent-card/src/verify.rs
+++ b/crates/nucleus-agent-card/src/verify.rs
@@ -73,9 +73,9 @@ impl VerifiedCard {
 ///
 /// # Errors
 ///
-/// Returns [`Error`] on: no signatures, signature/JWS verification
-/// failure, payload mismatch, missing/malformed nucleus extension, or
-/// empty/malformed `trust_jwks`.
+/// Returns [`Error`] on: no signatures, a protected header missing `kid`
+/// (§8.4.2), signature/JWS verification failure, payload mismatch,
+/// missing/malformed nucleus extension, or empty/malformed `trust_jwks`.
 pub fn verify_card(card: &AgentCard, resolved_key: &JsonWebKey) -> Result<VerifiedCard> {
     // 1) First signature. Multiple signatures are allowed on the wire
     //    (§8.4.3, key rotation), but the trust decision is made against the
@@ -86,6 +86,13 @@ pub fn verify_card(card: &AgentCard, resolved_key: &JsonWebKey) -> Result<Verifi
         .signatures
         .first()
         .ok_or(Error::Verify("card has no signatures".to_string()))?;
+
+    // 1b) §8.4.2 format conformance: the protected header MUST carry `kid`
+    //     (and `alg`, which jws_verify_es256 pins to ES256 below). We
+    //     REQUIRE kid's presence without ever using its value for key
+    //     selection — the verification key stays the caller's
+    //     out-of-band-resolved one.
+    require_kid(&sig.protected)?;
 
     // 2) Canonical payload (signatures excluded) + detached JWS segment.
     let jcs_bytes = canonicalize(card)?;
@@ -131,6 +138,26 @@ pub fn verify_card(card: &AgentCard, resolved_key: &JsonWebKey) -> Result<Verifi
         card: card.clone(),
         claims,
     })
+}
+
+/// §8.4.2: the JWS protected header MUST include `kid`. Presence-only —
+/// the value is never used to resolve a key (see the trust model note on
+/// [`verify_card`]).
+fn require_kid(protected_b64: &str) -> Result<()> {
+    let bytes = URL_SAFE_NO_PAD
+        .decode(protected_b64)
+        .map_err(|e| Error::Verify(format!("protected header is not valid base64url: {e}")))?;
+    let header: serde_json::Value = serde_json::from_slice(&bytes)
+        .map_err(|e| Error::Verify(format!("protected header is not valid JSON: {e}")))?;
+    match header.get("kid").and_then(serde_json::Value::as_str) {
+        Some(kid) if !kid.is_empty() => Ok(()),
+        Some(_) => Err(Error::Verify(
+            "protected header carries an empty kid (\u{a7}8.4.2 requires a key id)".to_string(),
+        )),
+        None => Err(Error::Verify(
+            "protected header is missing kid (\u{a7}8.4.2 requires it)".to_string(),
+        )),
+    }
 }
 
 /// Reject an empty or malformed advertised JWKS.

--- a/crates/nucleus-lineage/src/verify.rs
+++ b/crates/nucleus-lineage/src/verify.rs
@@ -48,15 +48,15 @@ pub struct Jwks {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Jwk {
     pub kty: String,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub crv: Option<String>,
     pub kid: String,
     /// Base64url-encoded public-key bytes (32 bytes for Ed25519).
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub x: Option<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub alg: Option<String>,
-    #[serde(default, rename = "use")]
+    #[serde(default, rename = "use", skip_serializing_if = "Option::is_none")]
     pub use_: Option<String>,
     /// Optional validity-window start. If present, an edge signed before this
     /// instant is rejected for this key. Non-standard per RFC 7517 but


### PR DESCRIPTION
## What

Pins `nucleus-agent-card` to the **spec's own** §8.4 requirements (A2A v1.0.1, normative `specification/a2a.proto`), not merely to itself:

- **§8.4.1 decision table** reproduced from the spec's worked example: explicitly-set optional defaults INCLUDED (`"capabilities":{"pushNotifications":false,"streaming":false}` — the spec's exact expected object), empty repeated fields OMITTED, REQUIRED-but-empty INCLUDED (`"description":""`, `"skills":[]`), RFC 8785 lexicographic ordering.
- **Golden-bytes pin** of a fully deterministic card's canonical form — any drift in field naming, presence rules, extension layout, or JCS behavior breaks the byte string by design.
- **§8.4.2 protected header**: exactly `{alg: ES256, typ: JOSE, kid}`.
- **Reconstruction property** (§8.4.1 rule 1's purpose): wire JSON → struct → verify still passes, presence preserved.
- **Presence is signature-bound**: materializing a default (`streaming: None` → `Some(false)`) after signing breaks verification.
- **§8.4.1 rule 3 + §8.4.3**: `signatures` never enters signed content; co-signing is append-only and keeps earlier signatures valid.
- **Tamper rejection** at three depths: top-level field, extension `params`, interface `url`.

## Behavior changes

1. `verify_card` now **rejects a protected header missing or carrying an empty `kid`** (§8.4.2 MUST). Presence-only enforcement — the verification key remains the caller's out-of-band-resolved key; `kid` is still never used for key selection.
2. `nucleus-lineage::Jwk`: unset optional fields (`crv`/`x`/`alg`/`use`) are now **omitted instead of serialized as `null`**. The conformance golden surfaced this: a `None` `use` leaked `"use":null` into the signed canonical bytes of any card advertising that JWKS — fragile and inconsistent with presence discipline everywhere else. Wire-breaking only for cards whose advertised JWKS embedded nulls at signing time; the checked-in signed fixture carries `"use":"sig"` and still verifies (Node suite green).

## Test evidence

- `nucleus-agent-card --features sign`: 41 passed (7 new conformance tests + golden)
- all 18 `nucleus-lineage` dependents `--all-features`: green
- `sdks/verifier-js`: 13 native + Node suite 0 failures; `wasm-pack build --target web --release` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)