### PR TITLE
feat(agent-card): typed SecurityScheme model per the normative a2a.proto oneof

### DIFF
--- a/crates/nucleus-agent-card/examples/agent_sign.rs
+++ b/crates/nucleus-agent-card/examples/agent_sign.rs
@@ -56,7 +56,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         version: "1.0.0".to_string(),
         documentation_url: None,
         capabilities: AgentCapabilities::default(),
-        security_schemes: serde_json::Map::new(),
+        security_schemes: Default::default(),
         security_requirements: vec![],
         default_input_modes: vec!["application/json".to_string()],
         default_output_modes: vec!["application/json".to_string()],

--- a/crates/nucleus-agent-card/src/card.rs
+++ b/crates/nucleus-agent-card/src/card.rs
@@ -94,10 +94,14 @@ pub struct AgentCard {
     pub capabilities: AgentCapabilities,
 
     /// Security scheme details for authenticating with this agent
-    /// (`map<string, SecurityScheme>` in the proto). Opaque JSON — this
-    /// crate does not interpret it.
-    #[serde(default, skip_serializing_if = "serde_json::Map::is_empty")]
-    pub security_schemes: serde_json::Map<String, serde_json::Value>,
+    /// (`map<string, SecurityScheme>` in the proto), keyed by the scheme
+    /// name that [`SecurityRequirement`]s reference. Typed per the
+    /// normative `a2a.proto` so §7.3 client discovery ("the client
+    /// discovers the server's required authentication schemes via the
+    /// `securitySchemes` field") can match on the variant instead of
+    /// poking at opaque JSON.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub security_schemes: BTreeMap<String, SecurityScheme>,
 
     /// Security requirements for contacting the agent.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -289,6 +293,301 @@ pub struct StringList {
     /// The individual string values.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub list: Vec<String>,
+}
+
+/// A security scheme that can be used to secure an agent's endpoints
+/// (`a2a.proto` `message SecurityScheme`) — a discriminated union based on
+/// the OpenAPI 3.2 Security Scheme Object.
+///
+/// # Wire shape (ProtoJSON oneof)
+///
+/// The proto models this message as a single `oneof scheme { ... }`. Under
+/// ProtoJSON, exactly one of a oneof's fields appears, **as a regular field
+/// of the containing message** — i.e. the variant is carried as the field
+/// NAME inside the `SecurityScheme` wrapper object, exactly like the spec's
+/// §8.5 sample card:
+///
+/// ```json
+/// "securitySchemes": {
+///   "google": {
+///     "openIdConnectSecurityScheme": {
+///       "openIdConnectUrl": "https://accounts.google.com/.well-known/openid-configuration"
+///     }
+///   }
+/// }
+/// ```
+///
+/// Serde's *externally tagged* enum representation reproduces that
+/// encoding bit-for-bit (an object with exactly one key naming the set
+/// variant). An *untagged* enum would be WRONG here: it would accept
+/// payloads without the variant key and could not round-trip the wrapper
+/// object protoc/pbjson emit.
+///
+/// The single-key requirement is also load-bearing on parse: an entry
+/// claiming TWO variants at once (illegal for a oneof) or a stale A2A v0.x
+/// `{"type": "oauth2", ...}` discriminator fails deserialization instead
+/// of silently riding along as opaque JSON. Unknown fields *inside* a
+/// variant's payload remain tolerated, matching this crate's
+/// forward-compat posture for ordinary message fields.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum SecurityScheme {
+    /// API key-based authentication
+    /// (`api_key_security_scheme`, oneof field 1).
+    #[serde(rename = "apiKeySecurityScheme")]
+    ApiKey(ApiKeySecurityScheme),
+
+    /// HTTP authentication — Basic, Bearer, etc.
+    /// (`http_auth_security_scheme`, oneof field 2).
+    #[serde(rename = "httpAuthSecurityScheme")]
+    HttpAuth(HttpAuthSecurityScheme),
+
+    /// OAuth 2.0 authentication
+    /// (`oauth2_security_scheme`, oneof field 3).
+    #[serde(rename = "oauth2SecurityScheme")]
+    OAuth2(OAuth2SecurityScheme),
+
+    /// OpenID Connect authentication
+    /// (`open_id_connect_security_scheme`, oneof field 4).
+    #[serde(rename = "openIdConnectSecurityScheme")]
+    OpenIdConnect(OpenIdConnectSecurityScheme),
+
+    /// Mutual TLS authentication (`mtls_security_scheme`, oneof field 5).
+    /// ProtoJSON derives the wire name from the proto FIELD name, so this
+    /// is `mtlsSecurityScheme` — not the message name
+    /// `MutualTlsSecurityScheme`.
+    #[serde(rename = "mtlsSecurityScheme")]
+    MutualTls(MutualTlsSecurityScheme),
+}
+
+/// A security scheme using an API key
+/// (`a2a.proto` `message APIKeySecurityScheme`).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ApiKeySecurityScheme {
+    /// An optional description for the security scheme.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub description: String,
+
+    /// The location of the API key (REQUIRED). Valid values are
+    /// `"query"`, `"header"`, or `"cookie"`.
+    pub location: String,
+
+    /// The name of the header, query, or cookie parameter to be used
+    /// (REQUIRED).
+    pub name: String,
+}
+
+/// A security scheme using HTTP authentication
+/// (`a2a.proto` `message HTTPAuthSecurityScheme`).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct HttpAuthSecurityScheme {
+    /// An optional description for the security scheme.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub description: String,
+
+    /// The HTTP Authentication scheme used in the `Authorization` header,
+    /// as defined in RFC 7235 — e.g. `"Bearer"` (REQUIRED). Should be a
+    /// value registered in the IANA Authentication Scheme registry.
+    pub scheme: String,
+
+    /// A hint to the client for how the bearer token is formatted
+    /// (e.g. `"JWT"`). Documentation only.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub bearer_format: String,
+}
+
+/// A security scheme using OAuth 2.0
+/// (`a2a.proto` `message OAuth2SecurityScheme`).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct OAuth2SecurityScheme {
+    /// An optional description for the security scheme.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub description: String,
+
+    /// Configuration for the supported OAuth 2.0 flow (REQUIRED). An
+    /// oauth2 scheme that does not say which flow to run is unusable, so
+    /// absence is a parse error, not a default.
+    pub flows: OAuthFlows,
+
+    /// URL to the OAuth2 authorization server metadata (RFC 8414).
+    /// TLS is required.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub oauth2_metadata_url: String,
+}
+
+/// A security scheme using OpenID Connect
+/// (`a2a.proto` `message OpenIdConnectSecurityScheme`).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct OpenIdConnectSecurityScheme {
+    /// An optional description for the security scheme.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub description: String,
+
+    /// The OpenID Connect Discovery URL for the OIDC provider's metadata
+    /// (REQUIRED).
+    pub open_id_connect_url: String,
+}
+
+/// A security scheme using mutual TLS authentication
+/// (`a2a.proto` `message MutualTlsSecurityScheme`).
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct MutualTlsSecurityScheme {
+    /// An optional description for the security scheme.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub description: String,
+}
+
+/// Configuration of the supported OAuth 2.0 flow
+/// (`a2a.proto` `message OAuthFlows`).
+///
+/// Like [`SecurityScheme`], the proto models this as a single
+/// `oneof flow { ... }`, so the ProtoJSON wrapper object carries exactly
+/// one key naming the configured flow — e.g.
+/// `{"clientCredentials": {"tokenUrl": "...", "scopes": {}}}` — and serde's
+/// externally tagged representation matches it exactly. (Note this is
+/// narrower than the OpenAPI object it descends from, which allows several
+/// flows side by side; the normative proto allows exactly one.)
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum OAuthFlows {
+    /// The OAuth 2.0 Authorization Code flow
+    /// (`authorization_code`, oneof field 1).
+    #[serde(rename = "authorizationCode")]
+    AuthorizationCode(AuthorizationCodeOAuthFlow),
+
+    /// The OAuth 2.0 Client Credentials flow
+    /// (`client_credentials`, oneof field 2).
+    #[serde(rename = "clientCredentials")]
+    ClientCredentials(ClientCredentialsOAuthFlow),
+
+    /// The OAuth 2.0 Implicit flow (`implicit`, oneof field 3). The proto
+    /// marks this flow deprecated — producers should use Authorization
+    /// Code + PKCE instead — but conformant cards may still carry it, so a
+    /// verifier must keep parsing it.
+    #[serde(rename = "implicit")]
+    Implicit(ImplicitOAuthFlow),
+
+    /// The OAuth 2.0 Resource Owner Password flow
+    /// (`password`, oneof field 4). Deprecated in the proto — use
+    /// Authorization Code + PKCE or Device Code — but still parsed, as for
+    /// [`OAuthFlows::Implicit`].
+    #[serde(rename = "password")]
+    Password(PasswordOAuthFlow),
+
+    /// The OAuth 2.0 Device Code flow, RFC 8628
+    /// (`device_code`, oneof field 5).
+    #[serde(rename = "deviceCode")]
+    DeviceCode(DeviceCodeOAuthFlow),
+}
+
+/// Configuration of the OAuth 2.0 Authorization Code flow
+/// (`a2a.proto` `message AuthorizationCodeOAuthFlow`).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct AuthorizationCodeOAuthFlow {
+    /// The authorization URL to be used for this flow (REQUIRED).
+    pub authorization_url: String,
+
+    /// The token URL to be used for this flow (REQUIRED).
+    pub token_url: String,
+
+    /// The URL to be used for obtaining refresh tokens.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub refresh_url: String,
+
+    /// The available scopes for the OAuth2 security scheme: scope name →
+    /// short description (REQUIRED; may be empty).
+    pub scopes: BTreeMap<String, String>,
+
+    /// Whether PKCE (RFC 7636) is required for this flow. PKCE should
+    /// always be used for public clients and is recommended for all
+    /// clients.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub pkce_required: bool,
+}
+
+/// Configuration of the OAuth 2.0 Client Credentials flow
+/// (`a2a.proto` `message ClientCredentialsOAuthFlow`).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ClientCredentialsOAuthFlow {
+    /// The token URL to be used for this flow (REQUIRED).
+    pub token_url: String,
+
+    /// The URL to be used for obtaining refresh tokens.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub refresh_url: String,
+
+    /// The available scopes for the OAuth2 security scheme: scope name →
+    /// short description (REQUIRED; may be empty).
+    pub scopes: BTreeMap<String, String>,
+}
+
+/// Configuration of the deprecated OAuth 2.0 Implicit flow
+/// (`a2a.proto` `message ImplicitOAuthFlow`). Every field is optional in
+/// the proto (no REQUIRED annotations on the deprecated flows).
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ImplicitOAuthFlow {
+    /// The authorization URL to be used for this flow. The OAuth2
+    /// standard requires the use of TLS.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub authorization_url: String,
+
+    /// The URL to be used for obtaining refresh tokens.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub refresh_url: String,
+
+    /// The available scopes for the OAuth2 security scheme: scope name →
+    /// short description. MAY be empty.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub scopes: BTreeMap<String, String>,
+}
+
+/// Configuration of the deprecated OAuth 2.0 Resource Owner Password flow
+/// (`a2a.proto` `message PasswordOAuthFlow`). Every field is optional in
+/// the proto (no REQUIRED annotations on the deprecated flows).
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct PasswordOAuthFlow {
+    /// The token URL to be used for this flow. The OAuth2 standard
+    /// requires the use of TLS.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub token_url: String,
+
+    /// The URL to be used for obtaining refresh tokens.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub refresh_url: String,
+
+    /// The available scopes for the OAuth2 security scheme: scope name →
+    /// short description. MAY be empty.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub scopes: BTreeMap<String, String>,
+}
+
+/// Configuration of the OAuth 2.0 Device Code flow, RFC 8628
+/// (`a2a.proto` `message DeviceCodeOAuthFlow`) — for input-constrained
+/// devices (IoT, CLI tools) where the user authenticates on a separate
+/// device.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct DeviceCodeOAuthFlow {
+    /// The device authorization endpoint URL (REQUIRED).
+    pub device_authorization_url: String,
+
+    /// The token URL to be used for this flow (REQUIRED).
+    pub token_url: String,
+
+    /// The URL to be used for obtaining refresh tokens.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub refresh_url: String,
+
+    /// The available scopes for the OAuth2 security scheme: scope name →
+    /// short description (REQUIRED; may be empty).
+    pub scopes: BTreeMap<String, String>,
 }
 
 /// A distinct capability or function an agent can perform
@@ -483,7 +782,7 @@ mod tests {
             version: "1.0.0".to_string(),
             documentation_url: None,
             capabilities: AgentCapabilities::default(),
-            security_schemes: serde_json::Map::new(),
+            security_schemes: BTreeMap::new(),
             security_requirements: vec![],
             default_input_modes: vec!["application/json".to_string()],
             default_output_modes: vec!["application/json".to_string()],
@@ -649,6 +948,255 @@ mod tests {
         assert_eq!(
             serde_json::to_value(&req).unwrap(),
             serde_json::json!({"schemes": {"oauth": {"list": ["openid"]}}})
+        );
+    }
+
+    /// One instance of every `SecurityScheme` oneof variant, exercising
+    /// every REQUIRED subfield plus the optional ones.
+    fn one_of_each_scheme() -> Vec<(&'static str, SecurityScheme)> {
+        vec![
+            (
+                "apiKey",
+                SecurityScheme::ApiKey(ApiKeySecurityScheme {
+                    description: "internal service key".to_string(),
+                    location: "header".to_string(),
+                    name: "X-Api-Key".to_string(),
+                }),
+            ),
+            (
+                "bearer",
+                SecurityScheme::HttpAuth(HttpAuthSecurityScheme {
+                    description: String::new(),
+                    scheme: "Bearer".to_string(),
+                    bearer_format: "JWT".to_string(),
+                }),
+            ),
+            (
+                "oauth",
+                SecurityScheme::OAuth2(OAuth2SecurityScheme {
+                    description: String::new(),
+                    flows: OAuthFlows::AuthorizationCode(AuthorizationCodeOAuthFlow {
+                        authorization_url: "https://auth.example.com/authorize".to_string(),
+                        token_url: "https://auth.example.com/token".to_string(),
+                        refresh_url: String::new(),
+                        scopes: BTreeMap::from([("read".to_string(), "Read access".to_string())]),
+                        pkce_required: true,
+                    }),
+                    oauth2_metadata_url: String::new(),
+                }),
+            ),
+            (
+                "oidc",
+                SecurityScheme::OpenIdConnect(OpenIdConnectSecurityScheme {
+                    description: String::new(),
+                    open_id_connect_url:
+                        "https://accounts.example.com/.well-known/openid-configuration".to_string(),
+                }),
+            ),
+            (
+                "mtls",
+                SecurityScheme::MutualTls(MutualTlsSecurityScheme {
+                    description: "client certificate".to_string(),
+                }),
+            ),
+        ]
+    }
+
+    #[test]
+    fn each_security_scheme_variant_round_trips() {
+        for (name, scheme) in one_of_each_scheme() {
+            let json = serde_json::to_value(&scheme).unwrap();
+            // ProtoJSON oneof wrapper: exactly ONE key, naming the variant.
+            assert_eq!(
+                json.as_object().unwrap().len(),
+                1,
+                "{name}: oneof wrapper must carry exactly one variant: {json}"
+            );
+            let back: SecurityScheme = serde_json::from_value(json).unwrap();
+            assert_eq!(scheme, back, "{name} did not round-trip");
+        }
+    }
+
+    #[test]
+    fn security_scheme_wire_names_match_a2a_proto_oneof() {
+        // The wire key is the proto FIELD name in lowerCamelCase — pinned
+        // per variant so a rename never silently breaks interop.
+        let expected = [
+            "apiKeySecurityScheme",
+            "httpAuthSecurityScheme",
+            "oauth2SecurityScheme",
+            "openIdConnectSecurityScheme",
+            "mtlsSecurityScheme",
+        ];
+        for ((name, scheme), key) in one_of_each_scheme().into_iter().zip(expected) {
+            let json = serde_json::to_value(&scheme).unwrap();
+            assert!(json.get(key).is_some(), "{name}: expected `{key}`: {json}");
+        }
+        // Spot-check nested ProtoJSON field names (§8.5 sample card shape).
+        let oidc = serde_json::to_value(&one_of_each_scheme()[3].1).unwrap();
+        assert!(oidc["openIdConnectSecurityScheme"]["openIdConnectUrl"].is_string());
+        let oauth = serde_json::to_value(&one_of_each_scheme()[2].1).unwrap();
+        let flow = &oauth["oauth2SecurityScheme"]["flows"]["authorizationCode"];
+        assert!(flow["authorizationUrl"].is_string());
+        assert!(flow["tokenUrl"].is_string());
+        assert_eq!(flow["pkceRequired"], serde_json::json!(true));
+    }
+
+    #[test]
+    fn each_oauth_flow_variant_round_trips() {
+        let flows = vec![
+            OAuthFlows::AuthorizationCode(AuthorizationCodeOAuthFlow {
+                authorization_url: "https://auth.example.com/authorize".to_string(),
+                token_url: "https://auth.example.com/token".to_string(),
+                refresh_url: "https://auth.example.com/refresh".to_string(),
+                scopes: BTreeMap::new(),
+                pkce_required: false,
+            }),
+            OAuthFlows::ClientCredentials(ClientCredentialsOAuthFlow {
+                token_url: "https://auth.example.com/token".to_string(),
+                refresh_url: String::new(),
+                scopes: BTreeMap::from([("act".to_string(), "Act".to_string())]),
+            }),
+            OAuthFlows::Implicit(ImplicitOAuthFlow {
+                authorization_url: "https://auth.example.com/authorize".to_string(),
+                ..Default::default()
+            }),
+            OAuthFlows::Password(PasswordOAuthFlow {
+                token_url: "https://auth.example.com/token".to_string(),
+                ..Default::default()
+            }),
+            OAuthFlows::DeviceCode(DeviceCodeOAuthFlow {
+                device_authorization_url: "https://auth.example.com/device".to_string(),
+                token_url: "https://auth.example.com/token".to_string(),
+                refresh_url: String::new(),
+                scopes: BTreeMap::new(),
+            }),
+        ];
+        for flow in flows {
+            let json = serde_json::to_value(&flow).unwrap();
+            assert_eq!(json.as_object().unwrap().len(), 1, "{json}");
+            let back: OAuthFlows = serde_json::from_value(json).unwrap();
+            assert_eq!(flow, back);
+        }
+    }
+
+    #[test]
+    fn two_variant_security_scheme_entry_is_rejected() {
+        // A oneof carries AT MOST one field — an entry claiming to be both
+        // an API key scheme and an mTLS scheme is malformed and must not
+        // parse (previously it rode along as opaque JSON and got signed).
+        let json = serde_json::json!({
+            "apiKeySecurityScheme": {"location": "header", "name": "X-Api-Key"},
+            "mtlsSecurityScheme": {}
+        });
+        assert!(serde_json::from_value::<SecurityScheme>(json).is_err());
+    }
+
+    #[test]
+    fn v0_type_discriminated_scheme_is_rejected() {
+        // A2A v0.x used an OpenAPI-style `"type"` discriminator. v1.0's
+        // ProtoJSON carries the variant as the wrapper's field name
+        // instead, so the stale shape must fail to parse.
+        for stale in [
+            serde_json::json!({"type": "oauth2"}),
+            serde_json::json!({"type": "apiKey", "in": "header", "name": "X-Api-Key"}),
+            serde_json::json!({"type": "openIdConnect", "openIdConnectUrl": "https://x"}),
+        ] {
+            assert!(
+                serde_json::from_value::<SecurityScheme>(stale.clone()).is_err(),
+                "v0.x shape must be rejected: {stale}"
+            );
+        }
+    }
+
+    #[test]
+    fn oauth2_scheme_missing_required_flows_is_rejected() {
+        // `flows` is REQUIRED on OAuth2SecurityScheme — an oauth2 scheme
+        // that does not say which flow to run is undiscoverable per §7.3.
+        let json = serde_json::json!({
+            "oauth2SecurityScheme": {"description": "no flows declared"}
+        });
+        let err = serde_json::from_value::<SecurityScheme>(json).unwrap_err();
+        assert!(err.to_string().contains("flows"), "{err}");
+    }
+
+    #[test]
+    fn required_scheme_subfields_are_presence_checked() {
+        // One missing REQUIRED subfield per variant that has any.
+        for (name, bad) in [
+            (
+                "apiKey missing name",
+                serde_json::json!({"apiKeySecurityScheme": {"location": "header"}}),
+            ),
+            (
+                "apiKey missing location",
+                serde_json::json!({"apiKeySecurityScheme": {"name": "X-Api-Key"}}),
+            ),
+            (
+                "http missing scheme",
+                serde_json::json!({"httpAuthSecurityScheme": {"bearerFormat": "JWT"}}),
+            ),
+            (
+                "oidc missing url",
+                serde_json::json!({"openIdConnectSecurityScheme": {"description": "x"}}),
+            ),
+            (
+                "authorizationCode flow missing tokenUrl",
+                serde_json::json!({"oauth2SecurityScheme": {"flows": {"authorizationCode": {
+                    "authorizationUrl": "https://a", "scopes": {}
+                }}}}),
+            ),
+            (
+                "deviceCode flow missing deviceAuthorizationUrl",
+                serde_json::json!({"oauth2SecurityScheme": {"flows": {"deviceCode": {
+                    "tokenUrl": "https://t", "scopes": {}
+                }}}}),
+            ),
+            (
+                "clientCredentials flow missing scopes",
+                serde_json::json!({"oauth2SecurityScheme": {"flows": {"clientCredentials": {
+                    "tokenUrl": "https://t"
+                }}}}),
+            ),
+        ] {
+            assert!(
+                serde_json::from_value::<SecurityScheme>(bad.clone()).is_err(),
+                "{name} must be rejected: {bad}"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_fields_inside_a_variant_are_tolerated() {
+        // Forward-compat: a newer producer may add fields to a scheme
+        // MESSAGE (allowed by proto evolution); the oneof WRAPPER itself
+        // stays single-key. Same posture as the card-level test below.
+        let json = serde_json::json!({
+            "apiKeySecurityScheme": {
+                "location": "header",
+                "name": "X-Api-Key",
+                "futureFieldWeDontKnow": true
+            }
+        });
+        let scheme: SecurityScheme = serde_json::from_value(json).unwrap();
+        assert!(matches!(scheme, SecurityScheme::ApiKey(ref s) if s.name == "X-Api-Key"));
+    }
+
+    #[test]
+    fn populated_security_schemes_round_trip_on_the_card() {
+        let mut card = sample_card();
+        card.security_schemes = one_of_each_scheme()
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v))
+            .collect();
+        let json = serde_json::to_string(&card).unwrap();
+        let back: AgentCard = serde_json::from_str(&json).unwrap();
+        assert_eq!(card.security_schemes, back.security_schemes);
+        // §8.5 sample-card shape: map key → single-variant wrapper object.
+        let value = serde_json::to_value(&card).unwrap();
+        assert!(
+            value["securitySchemes"]["oidc"]["openIdConnectSecurityScheme"]["openIdConnectUrl"]
+                .is_string()
         );
     }
 

--- a/crates/nucleus-agent-card/src/conformance_tests.rs
+++ b/crates/nucleus-agent-card/src/conformance_tests.rs
@@ -11,9 +11,14 @@ use base64::Engine as _;
 use ring::rand::SystemRandom;
 use ring::signature::{EcdsaKeyPair, KeyPair, ECDSA_P256_SHA256_FIXED_SIGNING};
 
+use std::collections::BTreeMap;
+
 use crate::card::{
-    AgentCapabilities, AgentCard, AgentCardSignature, AgentInterface, NucleusClaims,
-    A2A_PROTOCOL_VERSION,
+    AgentCapabilities, AgentCard, AgentCardSignature, AgentInterface, ApiKeySecurityScheme,
+    AuthorizationCodeOAuthFlow, ClientCredentialsOAuthFlow, DeviceCodeOAuthFlow,
+    HttpAuthSecurityScheme, ImplicitOAuthFlow, MutualTlsSecurityScheme, NucleusClaims,
+    OAuth2SecurityScheme, OAuthFlows, OpenIdConnectSecurityScheme, PasswordOAuthFlow,
+    SecurityScheme, A2A_PROTOCOL_VERSION,
 };
 use crate::jcs::canonicalize;
 use crate::jwk::JsonWebKey;
@@ -82,7 +87,7 @@ fn spec_example_card() -> AgentCard {
             extensions: vec![],
             extended_agent_card: None,
         },
-        security_schemes: serde_json::Map::new(),
+        security_schemes: Default::default(),
         security_requirements: vec![],
         default_input_modes: vec!["application/json".to_string()],
         default_output_modes: vec!["application/json".to_string()],
@@ -147,6 +152,169 @@ fn golden_canonical_bytes_are_pinned() {
         r#""skills":[],"supportedInterfaces":[{"protocolBinding":"JSONRPC","protocolVersion":"1.0","url":"https://agent.example.com/a2a/v1"}],"version":"1.0.0"}"#
     );
     assert_eq!(canon, expected);
+}
+
+/// A fully deterministic `securitySchemes` map covering all five
+/// `SecurityScheme` oneof variants AND all five `OAuthFlows` oneof
+/// variants (one oauth2 scheme per flow).
+fn populated_security_schemes() -> BTreeMap<String, SecurityScheme> {
+    let entries = [
+        (
+            "api-key",
+            SecurityScheme::ApiKey(ApiKeySecurityScheme {
+                description: String::new(),
+                location: "header".to_string(),
+                name: "X-Api-Key".to_string(),
+            }),
+        ),
+        (
+            "bearer",
+            SecurityScheme::HttpAuth(HttpAuthSecurityScheme {
+                description: String::new(),
+                scheme: "Bearer".to_string(),
+                bearer_format: "JWT".to_string(),
+            }),
+        ),
+        (
+            "mtls",
+            SecurityScheme::MutualTls(MutualTlsSecurityScheme::default()),
+        ),
+        (
+            "oauth-ac",
+            SecurityScheme::OAuth2(OAuth2SecurityScheme {
+                description: String::new(),
+                flows: OAuthFlows::AuthorizationCode(AuthorizationCodeOAuthFlow {
+                    authorization_url: "https://auth.example.com/authorize".to_string(),
+                    token_url: "https://auth.example.com/token".to_string(),
+                    refresh_url: String::new(),
+                    scopes: BTreeMap::from([("read".to_string(), "Read access".to_string())]),
+                    pkce_required: true,
+                }),
+                oauth2_metadata_url:
+                    "https://auth.example.com/.well-known/oauth-authorization-server".to_string(),
+            }),
+        ),
+        (
+            "oauth-cc",
+            SecurityScheme::OAuth2(OAuth2SecurityScheme {
+                description: String::new(),
+                flows: OAuthFlows::ClientCredentials(ClientCredentialsOAuthFlow {
+                    token_url: "https://auth.example.com/token".to_string(),
+                    refresh_url: String::new(),
+                    scopes: BTreeMap::new(),
+                }),
+                oauth2_metadata_url: String::new(),
+            }),
+        ),
+        (
+            "oauth-dc",
+            SecurityScheme::OAuth2(OAuth2SecurityScheme {
+                description: String::new(),
+                flows: OAuthFlows::DeviceCode(DeviceCodeOAuthFlow {
+                    device_authorization_url: "https://auth.example.com/device".to_string(),
+                    token_url: "https://auth.example.com/token".to_string(),
+                    refresh_url: String::new(),
+                    scopes: BTreeMap::new(),
+                }),
+                oauth2_metadata_url: String::new(),
+            }),
+        ),
+        (
+            "oauth-implicit",
+            SecurityScheme::OAuth2(OAuth2SecurityScheme {
+                description: String::new(),
+                flows: OAuthFlows::Implicit(ImplicitOAuthFlow {
+                    authorization_url: "https://auth.example.com/authorize".to_string(),
+                    ..Default::default()
+                }),
+                oauth2_metadata_url: String::new(),
+            }),
+        ),
+        (
+            "oauth-password",
+            SecurityScheme::OAuth2(OAuth2SecurityScheme {
+                description: String::new(),
+                flows: OAuthFlows::Password(PasswordOAuthFlow {
+                    token_url: "https://auth.example.com/token".to_string(),
+                    ..Default::default()
+                }),
+                oauth2_metadata_url: String::new(),
+            }),
+        ),
+        (
+            "oidc",
+            SecurityScheme::OpenIdConnect(OpenIdConnectSecurityScheme {
+                description: String::new(),
+                open_id_connect_url:
+                    "https://accounts.example.com/.well-known/openid-configuration".to_string(),
+            }),
+        ),
+    ];
+    entries
+        .into_iter()
+        .map(|(k, v)| (k.to_string(), v))
+        .collect()
+}
+
+/// GOLDEN PIN, populated `securitySchemes`: the exact canonical bytes the
+/// typed model signs for every scheme variant and every OAuth flow
+/// variant. The oneof wrapper objects (`{"mtlsSecurityScheme":{}}`, …) are
+/// the ProtoJSON encoding the normative `a2a.proto` prescribes — the same
+/// shape as the spec's §8.5 sample card entry
+/// `{"google":{"openIdConnectSecurityScheme":{...}}}`. Presence decisions
+/// pinned here: REQUIRED `scopes` stays on the wire even when empty;
+/// optional empty strings (`refreshUrl`, `description`,
+/// `oauth2MetadataUrl`) and default `pkceRequired:false` are omitted.
+#[test]
+fn golden_canonical_bytes_with_populated_security_schemes_are_pinned() {
+    let mut card = spec_example_card()
+        .with_nucleus_claims(&fixed_claims())
+        .unwrap();
+    card.security_schemes = populated_security_schemes();
+    let canon = String::from_utf8(canonicalize(&card).unwrap()).unwrap();
+    let expected = concat!(
+        r#"{"capabilities":{"extensions":[{"description":"nucleus verify-before-you-act claims: SPIFFE/DID identity, trust JWKS, envelope schema versions, runtime-guarantee profile","params":{"did":"did:web:golden.conformance.example.com","spiffeId":"spiffe://conformance.example.com/ns/agents/sa/golden","supportedEnvelopeSchemaVersions":["1"],"trustJwks":{"keys":[{"alg":"EdDSA","crv":"Ed25519","kid":"conformance-k1","kty":"OKP","x":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"}]}},"uri":"https://coproduct.one/a2a/ext/runtime-guarantees/v1"}],"pushNotifications":false,"streaming":false},"#,
+        r#""defaultInputModes":["application/json"],"defaultOutputModes":["application/json"],"description":"","name":"Example Agent","#,
+        r#""securitySchemes":{"#,
+        r#""api-key":{"apiKeySecurityScheme":{"location":"header","name":"X-Api-Key"}},"#,
+        r#""bearer":{"httpAuthSecurityScheme":{"bearerFormat":"JWT","scheme":"Bearer"}},"#,
+        r#""mtls":{"mtlsSecurityScheme":{}},"#,
+        r#""oauth-ac":{"oauth2SecurityScheme":{"flows":{"authorizationCode":{"authorizationUrl":"https://auth.example.com/authorize","pkceRequired":true,"scopes":{"read":"Read access"},"tokenUrl":"https://auth.example.com/token"}},"oauth2MetadataUrl":"https://auth.example.com/.well-known/oauth-authorization-server"}},"#,
+        r#""oauth-cc":{"oauth2SecurityScheme":{"flows":{"clientCredentials":{"scopes":{},"tokenUrl":"https://auth.example.com/token"}}}},"#,
+        r#""oauth-dc":{"oauth2SecurityScheme":{"flows":{"deviceCode":{"deviceAuthorizationUrl":"https://auth.example.com/device","scopes":{},"tokenUrl":"https://auth.example.com/token"}}}},"#,
+        r#""oauth-implicit":{"oauth2SecurityScheme":{"flows":{"implicit":{"authorizationUrl":"https://auth.example.com/authorize"}}}},"#,
+        r#""oauth-password":{"oauth2SecurityScheme":{"flows":{"password":{"tokenUrl":"https://auth.example.com/token"}}}},"#,
+        r#""oidc":{"openIdConnectSecurityScheme":{"openIdConnectUrl":"https://accounts.example.com/.well-known/openid-configuration"}}},"#,
+        r#""skills":[],"supportedInterfaces":[{"protocolBinding":"JSONRPC","protocolVersion":"1.0","url":"https://agent.example.com/a2a/v1"}],"version":"1.0.0"}"#
+    );
+    assert_eq!(canon, expected);
+}
+
+/// The schemes are inside the signed content: a card signed with a
+/// populated map verifies after a wire round-trip, and ANY post-signing
+/// mutation of a scheme — even just requiring PKCE — breaks the signature.
+#[test]
+fn security_schemes_are_signature_covered() {
+    let (der, jwk) = p256_keypair();
+    let mut card = spec_example_card()
+        .with_nucleus_claims(&fixed_claims())
+        .unwrap();
+    card.security_schemes = populated_security_schemes();
+    let signed = sign_card(card, &der, "key-1").unwrap();
+
+    let wire = serde_json::to_string(&signed).unwrap();
+    let reconstructed: AgentCard = serde_json::from_str(&wire).unwrap();
+    verify_card(&reconstructed, &jwk).expect("populated card verifies after round-trip");
+
+    let mut tampered = reconstructed;
+    let Some(SecurityScheme::OAuth2(scheme)) = tampered.security_schemes.get_mut("oauth-ac") else {
+        panic!("oauth-ac entry present");
+    };
+    let OAuthFlows::AuthorizationCode(flow) = &mut scheme.flows else {
+        panic!("authorization-code flow present");
+    };
+    flow.pkce_required = false;
+    assert!(verify_card(&tampered, &jwk).is_err());
 }
 
 /// §8.4.2: the protected header is exactly `{alg, typ, kid}` with the

--- a/crates/nucleus-agent-card/src/envelope.rs
+++ b/crates/nucleus-agent-card/src/envelope.rs
@@ -244,7 +244,7 @@ mod tests {
             version: "1.0.0".to_string(),
             documentation_url: None,
             capabilities: AgentCapabilities::default(),
-            security_schemes: serde_json::Map::new(),
+            security_schemes: Default::default(),
             security_requirements: vec![],
             default_input_modes: vec!["application/json".to_string()],
             default_output_modes: vec!["application/json".to_string()],

--- a/crates/nucleus-agent-card/src/envelope_e2e_tests.rs
+++ b/crates/nucleus-agent-card/src/envelope_e2e_tests.rs
@@ -50,7 +50,7 @@ fn sample_card() -> AgentCard {
         version: "1.0.0".to_string(),
         documentation_url: None,
         capabilities: AgentCapabilities::default(),
-        security_schemes: serde_json::Map::new(),
+        security_schemes: Default::default(),
         security_requirements: vec![],
         default_input_modes: vec!["application/json".to_string()],
         default_output_modes: vec!["application/json".to_string()],

--- a/crates/nucleus-agent-card/src/jcs.rs
+++ b/crates/nucleus-agent-card/src/jcs.rs
@@ -42,8 +42,11 @@ pub fn canonicalize(card: &AgentCard) -> Result<Vec<u8>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeMap;
+
     use crate::card::{
-        AgentCapabilities, AgentCardSignature, AgentInterface, A2A_PROTOCOL_VERSION,
+        AgentCapabilities, AgentCardSignature, AgentInterface, MutualTlsSecurityScheme,
+        SecurityScheme, A2A_PROTOCOL_VERSION,
     };
 
     /// RFC 8785 Appendix B reference vector. Pins our JCS implementation
@@ -110,12 +113,18 @@ mod tests {
             version: "0.1.0".to_string(),
             documentation_url: None,
             capabilities: AgentCapabilities::default(),
-            security_schemes: {
-                let mut m = serde_json::Map::new();
-                m.insert("b".to_string(), serde_json::json!(1));
-                m.insert("a".to_string(), serde_json::json!(2));
-                m
-            },
+            security_schemes: BTreeMap::from([
+                (
+                    "b".to_string(),
+                    SecurityScheme::MutualTls(MutualTlsSecurityScheme {
+                        description: "first inserted".to_string(),
+                    }),
+                ),
+                (
+                    "a".to_string(),
+                    SecurityScheme::MutualTls(MutualTlsSecurityScheme::default()),
+                ),
+            ]),
             security_requirements: vec![],
             default_input_modes: vec!["application/json".to_string()],
             default_output_modes: vec!["application/json".to_string()],
@@ -133,9 +142,15 @@ mod tests {
         let first = canonicalize(&card).unwrap();
         let second = canonicalize(&card.clone()).unwrap();
         assert_eq!(first, second);
-        // Keys inside the nested securitySchemes map are sorted.
+        // Keys inside the nested securitySchemes map are sorted ("a"
+        // before "b" despite "b" being listed first above).
         let s = String::from_utf8(first).unwrap();
-        assert!(s.contains(r#""securitySchemes":{"a":2,"b":1}"#), "got: {s}");
+        assert!(
+            s.contains(
+                r#""securitySchemes":{"a":{"mtlsSecurityScheme":{}},"b":{"mtlsSecurityScheme":{"description":"first inserted"}}}"#
+            ),
+            "got: {s}"
+        );
     }
 
     /// §8.4.1 rule 3: the signatures field is excluded — an unsigned card

--- a/crates/nucleus-agent-card/src/lib.rs
+++ b/crates/nucleus-agent-card/src/lib.rs
@@ -80,8 +80,11 @@ mod envelope_e2e_tests;
 pub use anchor::trust_anchor_from_card;
 pub use card::{
     AgentCapabilities, AgentCard, AgentCardSignature, AgentExtension, AgentInterface,
-    AgentProvider, AgentSkill, EnforcementRule, NucleusClaims, RuntimeGuaranteeProfile,
-    SecurityRequirement, StringList, A2A_PROTOCOL_VERSION, NUCLEUS_EXTENSION_URI,
+    AgentProvider, AgentSkill, ApiKeySecurityScheme, AuthorizationCodeOAuthFlow,
+    ClientCredentialsOAuthFlow, DeviceCodeOAuthFlow, EnforcementRule, HttpAuthSecurityScheme,
+    ImplicitOAuthFlow, MutualTlsSecurityScheme, NucleusClaims, OAuth2SecurityScheme, OAuthFlows,
+    OpenIdConnectSecurityScheme, PasswordOAuthFlow, RuntimeGuaranteeProfile, SecurityRequirement,
+    SecurityScheme, StringList, A2A_PROTOCOL_VERSION, NUCLEUS_EXTENSION_URI,
 };
 pub use jcs::canonicalize;
 pub use jwk::JsonWebKey;

--- a/crates/nucleus-agent-card/src/sign_verify_tests.rs
+++ b/crates/nucleus-agent-card/src/sign_verify_tests.rs
@@ -63,7 +63,7 @@ fn base_card() -> AgentCard {
         version: "1.0.0".to_string(),
         documentation_url: None,
         capabilities: AgentCapabilities::default(),
-        security_schemes: serde_json::Map::new(),
+        security_schemes: Default::default(),
         security_requirements: vec![],
         default_input_modes: vec!["application/json".to_string()],
         default_output_modes: vec!["application/json".to_string()],

--- a/crates/nucleus-agent-card/src/verify.rs
+++ b/crates/nucleus-agent-card/src/verify.rs
@@ -219,7 +219,7 @@ mod tests {
             version: "1.0.0".to_string(),
             documentation_url: None,
             capabilities: AgentCapabilities::default(),
-            security_schemes: serde_json::Map::new(),
+            security_schemes: Default::default(),
             security_requirements: vec![],
             default_input_modes: vec!["application/json".to_string()],
             default_output_modes: vec!["application/json".to_string()],

--- a/crates/nucleus-agent-card/tests/handshake.rs
+++ b/crates/nucleus-agent-card/tests/handshake.rs
@@ -119,7 +119,7 @@ fn card_for(issuer: &LocalIssuer) -> AgentCard {
         version: "1.0.0".to_string(),
         documentation_url: None,
         capabilities: AgentCapabilities::default(),
-        security_schemes: serde_json::Map::new(),
+        security_schemes: Default::default(),
         security_requirements: vec![],
         default_input_modes: vec!["application/json".to_string()],
         default_output_modes: vec!["application/json".to_string()],

--- a/crates/nucleus-verifier-service/tests/integration.rs
+++ b/crates/nucleus-verifier-service/tests/integration.rs
@@ -837,7 +837,7 @@ async fn well_known_agent_card_verifies_against_matching_key() {
         version: "1.0.0".to_string(),
         documentation_url: None,
         capabilities: AgentCapabilities::default(),
-        security_schemes: serde_json::Map::new(),
+        security_schemes: Default::default(),
         security_requirements: vec![],
         default_input_modes: vec!["application/json".to_string()],
         default_output_modes: vec!["application/json".to_string()],

--- a/crates/nucleus-verify-commerce/examples/quickstart.rs
+++ b/crates/nucleus-verify-commerce/examples/quickstart.rs
@@ -58,7 +58,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         version: "1.0.0".to_string(),
         documentation_url: None,
         capabilities: AgentCapabilities::default(),
-        security_schemes: serde_json::Map::new(),
+        security_schemes: Default::default(),
         security_requirements: vec![],
         default_input_modes: vec!["application/json".to_string()],
         default_output_modes: vec!["application/json".to_string()],

--- a/crates/nucleus-verify-commerce/src/card_verifier.rs
+++ b/crates/nucleus-verify-commerce/src/card_verifier.rs
@@ -88,7 +88,7 @@ mod tests {
             version: "1.0.0".to_string(),
             documentation_url: None,
             capabilities: AgentCapabilities::default(),
-            security_schemes: serde_json::Map::new(),
+            security_schemes: Default::default(),
             security_requirements: vec![],
             default_input_modes: vec!["application/json".to_string()],
             default_output_modes: vec!["application/json".to_string()],

--- a/sdks/verifier-js/src/lib.rs
+++ b/sdks/verifier-js/src/lib.rs
@@ -943,7 +943,7 @@ mod agent_card_tests {
             version: "1.0.0".to_string(),
             documentation_url: None,
             capabilities: AgentCapabilities::default(),
-            security_schemes: serde_json::Map::new(),
+            security_schemes: Default::default(),
             security_requirements: vec![],
             default_input_modes: vec!["application/json".to_string()],
             default_output_modes: vec!["application/json".to_string()],

--- a/sdks/verifier-js/tests/web.rs
+++ b/sdks/verifier-js/tests/web.rs
@@ -141,7 +141,7 @@ fn garbage_signed_card_json() -> String {
         version: "1.0.0".to_string(),
         documentation_url: None,
         capabilities: nucleus_agent_card::AgentCapabilities::default(),
-        security_schemes: serde_json::Map::new(),
+        security_schemes: Default::default(),
         security_requirements: vec![],
         default_input_modes: vec!["application/json".to_string()],
         default_output_modes: vec!["application/json".to_string()],


### PR DESCRIPTION
## Problem

`AgentCard.security_schemes` is an opaque `serde_json::Map<String, Value>`. The A2A v1.0.1 normative proto (`specification/a2a.proto`, which per spec §1.4 takes precedence over doc samples) defines `message SecurityScheme` as a strict 5-variant `oneof scheme` (`api_key_security_scheme`, `http_auth_security_scheme`, `oauth2_security_scheme`, `open_id_connect_security_scheme`, `mtls_security_scheme`). With the opaque map:

- an entry carrying **two oneof variants at once** (illegal for a oneof) parses, canonicalizes, signs, and verifies;
- a **stale A2A v0.x shape** (`{"type": "oauth2", ...}`) rides along silently even though v1.0 carries the variant as the wrapper object's field name;
- an oauth2 scheme **missing its REQUIRED `flows`** is accepted, leaving a client nothing to run;
- typed §7.3 client discovery ("the client discovers the server's required authentication schemes via the `securitySchemes` field in the AgentCard") is impossible — consumers must poke at raw JSON.

## Change

Replace the map value type with a typed `SecurityScheme` enum plus the full flow model (`OAuthFlows`, `AuthorizationCodeOAuthFlow`, `ClientCredentialsOAuthFlow`, `ImplicitOAuthFlow`, `PasswordOAuthFlow`, `DeviceCodeOAuthFlow`), exactly per the proto:

- **Wire shape = ProtoJSON oneof.** Under ProtoJSON, exactly one oneof field appears as a regular field of the containing message — the variant is the field NAME inside the wrapper object, as in the spec's §8.5 sample card: `{"google": {"openIdConnectSecurityScheme": {"openIdConnectUrl": "..."}}}`. Serde's *externally tagged* enum representation reproduces this bit-for-bit (an object with exactly one key naming the variant). An *untagged* enum would be wrong here — it could not enforce or round-trip the wrapper key. The rustdoc carries the worked example.
- **Wire names derive from proto field names**, so the mTLS variant is `mtlsSecurityScheme` (field `mtls_security_scheme = 5`), not the message name. Pinned by test.
- **REQUIRED subfields are presence-checked at parse time** per the proto's `(google.api.field_behavior) = REQUIRED` annotations: `location`/`name` (apiKey), `scheme` (httpAuth), `flows` (oauth2), `openIdConnectUrl` (oidc), and per-flow `authorizationUrl`/`tokenUrl`/`scopes`/`deviceAuthorizationUrl`. The deprecated `implicit`/`password` flows have no REQUIRED fields in the proto and stay fully optional (still parsed — conformant cards may carry them).
- **Malformed entries now fail deserialization**: two-variant objects, v0.x `{"type": ...}` discriminators, and oauth2-without-flows are serde errors instead of signed opaque payloads.
- **Forward compat preserved where the proto allows**: unknown fields *inside* a variant's message payload are still tolerated (no `deny_unknown_fields`), matching the crate's existing posture; only the oneof wrapper itself is strict, as a oneof must be.

## Signing surface

- **Empty-map serialization is unchanged** (omitted per §8.4.1 default-omission), so the existing `golden_canonical_bytes_are_pinned` byte string holds untouched — no signature breakage for existing cards.
- A second golden (`golden_canonical_bytes_with_populated_security_schemes_are_pinned`) pins the exact JCS canonical bytes of a card whose map covers **all five scheme variants and all five flow variants**, including the presence decisions (REQUIRED `scopes` stays on the wire even when empty; optional empty strings and default `pkceRequired: false` are omitted).
- `security_schemes_are_signature_covered` proves a populated map survives a wire round-trip and that any post-signing mutation of a scheme (e.g. flipping `pkceRequired`) breaks the §8.4 signature.

## Tests

- Round-trip of each of the 5 `SecurityScheme` variants and each of the 5 `OAuthFlows` variants, with single-key wrapper assertions.
- Wire-name pins for every oneof key + nested ProtoJSON field names (§8.5 sample-card shape).
- Rejection: two-variant entry, three v0.x `"type"`-discriminated shapes, oauth2 missing `flows`, and one missing-REQUIRED-subfield case per variant/flow that has any.
- Unknown-field tolerance inside a variant payload.
- JCS test updated to keep asserting nested-map key sorting with typed values.

Consumers that construct cards (agent-card examples/tests, nucleus-verify-commerce quickstart + card verifier, verifier-service integration tests, verifier-js SDK) updated; all built cards previously used empty maps, so their wire output is byte-identical.

Gates: `cargo fmt`, `cargo clippy --all-targets --all-features` (zero warnings), `cargo test -p nucleus-agent-card -p nucleus-verify-commerce -p nucleus-verifier-service --all-features`, `wasm-pack build sdks/verifier-js --target web --release`, verifier-js `cargo test` + `npm test` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
