### PR TITLE
feat(agent-card): spec-faithful A2A v1.0.1 §8.4.3 verification — received document, all signatures, signature/policy split

### DIFF
--- a/crates/nucleus-agent-card/README.md
+++ b/crates/nucleus-agent-card/README.md
@@ -19,6 +19,26 @@ protected header `{alg, typ: "JOSE", kid}`, carried in the card's own
 [`nucleus_envelope::TrustAnchor`](../nucleus-envelope) (`trust_anchor_from_card`)
 so the existing bundle verifier can decide whether to **act** on a bundle.
 
+## Verification surface — pick the right entry point
+
+- `verify_card_signature` / `verify_card_signature_json` — **pure A2A §8.4.3
+  signature verification**, no nucleus policy. A validly signed *plain* A2A
+  card (no nucleus extension — e.g. one published by any other A2A
+  implementation) verifies here.
+- `verify_card` / `verify_card_json` — the §8.4.3 check **plus the nucleus
+  claims policy** (extension required, usable `trust_jwks`), yielding a
+  `VerifiedCard` for the verify-before-you-act flow. Policy rejections are
+  labelled as policy, never as signature failures.
+- The `*_json` variants verify **the received document** (§8.4.3 steps 3–6
+  operate on "the received Agent Card"): canonicalization keeps every received
+  member, so an injected unknown member is rejected and a card signed by a
+  newer implementation over an unmodeled member still verifies. Prefer them
+  whenever the card reached you as raw JSON.
+- Every entry of the `signatures` array is checked against the caller's
+  resolved key (§8.4.3 allows multiple signatures for key rotation); any one
+  verifying suffices, and the key is always the caller's — iterating entries
+  introduces no card-controlled key selection.
+
 ## Trust model — read this before using
 
 - **Verify needs no secret.** `verify_card` is always compiled and secret-free;

--- a/crates/nucleus-agent-card/src/card.rs
+++ b/crates/nucleus-agent-card/src/card.rs
@@ -23,8 +23,12 @@
 //! None of these structs use `deny_unknown_fields`. A newer producer may
 //! add fields this verifier doesn't know about; unknown fields are
 //! ignored on parse so an older verifier still works against a newer
-//! card. The canonicalization in [`crate::jcs`] covers exactly the
-//! fields defined here — what we sign is what we know.
+//! card. [`crate::jcs::canonicalize`] (the signer's path) covers exactly
+//! the fields defined here — what we sign is what we know. On receive,
+//! [`crate::jcs::canonicalize_received`] canonicalizes the document AS
+//! RECEIVED, so a signature a newer producer made over fields this
+//! version does not model still verifies through
+//! [`crate::verify::verify_card_json`].
 
 use std::collections::BTreeMap;
 

--- a/crates/nucleus-agent-card/src/conformance_tests.rs
+++ b/crates/nucleus-agent-card/src/conformance_tests.rs
@@ -15,10 +15,10 @@ use crate::card::{
     AgentCapabilities, AgentCard, AgentCardSignature, AgentInterface, NucleusClaims,
     A2A_PROTOCOL_VERSION,
 };
-use crate::jcs::canonicalize;
+use crate::jcs::{canonicalize, canonicalize_received};
 use crate::jwk::JsonWebKey;
 use crate::sign::sign_card;
-use crate::verify::verify_card;
+use crate::verify::{verify_card, verify_card_json, verify_card_signature};
 
 fn p256_keypair() -> (Vec<u8>, JsonWebKey) {
     let rng = SystemRandom::new();
@@ -222,8 +222,176 @@ fn signatures_are_excluded_and_append_only() {
     assert_eq!(before, canonicalize(&signed_once).unwrap());
     let signed_twice = sign_card(signed_once, &der2, "key-2").unwrap();
     assert_eq!(before, canonicalize(&signed_twice).unwrap());
-    // verify_card checks the FIRST signature — still key-1's.
+    // verify_card checks EVERY signature against the caller's key (§8.4.3
+    // allows multiple for rotation) — key-1's, at index 0, still verifies.
     verify_card(&signed_twice, &jwk1).expect("first signature survives co-signing");
+}
+
+/// §8.4.3 "Multiple signatures MAY be present to support key rotation":
+/// a card co-signed old-key-then-new-key must verify for a holder of
+/// EITHER key. The new-key holder's valid signature sits at index 1 — a
+/// verifier that only ever checked `signatures[0]` would wrongly reject it.
+#[test]
+fn rotation_co_signed_card_verifies_under_either_key() {
+    let (der_old, jwk_old) = p256_keypair();
+    let (der_new, jwk_new) = p256_keypair();
+    let card = spec_example_card()
+        .with_nucleus_claims(&fixed_claims())
+        .unwrap();
+    let co_signed = sign_card(
+        sign_card(card, &der_old, "key-old").unwrap(),
+        &der_new,
+        "key-new",
+    )
+    .unwrap();
+    assert_eq!(co_signed.signatures.len(), 2);
+    verify_card(&co_signed, &jwk_old).expect("old-key holder verifies (signature at index 0)");
+    verify_card(&co_signed, &jwk_new).expect("new-key holder verifies (signature at index 1)");
+}
+
+/// A failing entry at index 0 must not mask a valid signature at index 1 —
+/// and when NO entry verifies, the card is still rejected. Iteration is
+/// bounded by the array and the key is always the caller's resolved one
+/// (no card-controlled key selection).
+#[test]
+fn valid_signature_at_index_1_verifies() {
+    let (der, jwk) = p256_keypair();
+    let signed = sign_card(
+        spec_example_card()
+            .with_nucleus_claims(&fixed_claims())
+            .unwrap(),
+        &der,
+        "key-1",
+    )
+    .unwrap();
+
+    // Prepend a structurally-plausible but cryptographically-garbage entry.
+    let mut shuffled = signed.clone();
+    shuffled.signatures.insert(
+        0,
+        AgentCardSignature {
+            protected: signed.signatures[0].protected.clone(),
+            signature: "bm90LWEtcmVhbC1zaWc".to_string(),
+            header: None,
+        },
+    );
+    verify_card(&shuffled, &jwk).expect("the valid entry at index 1 must be found");
+
+    // Under an unrelated key, neither entry verifies — still rejected.
+    let (_other_der, other_jwk) = p256_keypair();
+    assert!(verify_card(&shuffled, &other_jwk).is_err());
+}
+
+/// §8.4.3 steps 3–6 operate on "the received Agent Card": a signed card
+/// whose received document carries an attacker-INJECTED unknown member
+/// must NOT verify through the received-document path — the signature
+/// does not cover what was received.
+#[test]
+fn injected_unknown_member_is_rejected_on_the_received_document() {
+    let (der, jwk) = p256_keypair();
+    let signed = sign_card(
+        spec_example_card()
+            .with_nucleus_claims(&fixed_claims())
+            .unwrap(),
+        &der,
+        "key-1",
+    )
+    .unwrap();
+
+    // Baseline: the untampered received document verifies.
+    let genuine = serde_json::to_string(&signed).unwrap();
+    verify_card_json(&genuine, &jwk).expect("untampered received document verifies");
+
+    // Inject a member the signature never covered.
+    let mut doc = serde_json::to_value(&signed).unwrap();
+    doc.as_object_mut().unwrap().insert(
+        "injectedByAttacker".to_string(),
+        serde_json::json!("not covered by the signature"),
+    );
+    let tampered = serde_json::to_string(&doc).unwrap();
+    let err = verify_card_json(&tampered, &jwk).unwrap_err();
+    assert!(matches!(err, crate::Error::Verify(_)), "got {err:?}");
+
+    // Contrast (and the reason the JSON path exists): re-typing the
+    // tampered document DROPS the unknown member, so the struct path can
+    // only attest to the fields it models and would accept it. A caller
+    // holding the raw received document must therefore verify through
+    // verify_card_json, never through parse-then-verify_card.
+    let retyped: AgentCard = serde_json::from_str(&tampered).unwrap();
+    verify_card(&retyped, &jwk)
+        .expect("the struct path attests the modeled fields only — by construction");
+}
+
+/// Forward-compat per the crate's own documentation: a card legitimately
+/// signed by a NEWER implementation over a member this version does not
+/// model must still verify through the received-document path (the §8.4.1
+/// canonical payload includes every received member; an older verifier
+/// re-serializing its typed struct would wrongly drop it and fail).
+#[test]
+fn unmodeled_member_signed_by_a_newer_producer_verifies_via_the_json_path() {
+    let (der, jwk) = p256_keypair();
+
+    // The "newer producer": this version's card plus an unmodeled member,
+    // assembled as a raw document.
+    let card = spec_example_card()
+        .with_nucleus_claims(&fixed_claims())
+        .unwrap();
+    let mut doc = serde_json::to_value(&card).unwrap();
+    doc.as_object_mut().unwrap().insert(
+        "futureField".to_string(),
+        serde_json::json!({"introducedIn": "a later A2A revision"}),
+    );
+
+    // Sign the received-document canonical bytes with the SAME JWS
+    // primitive sign_card uses (detached ES256 over §8.4.1 JCS).
+    let canonical = canonicalize_received(&doc).unwrap();
+    let compact = nucleus_identity::did_crypto::jws_sign_es256_with_protected_header(
+        r#"{"alg":"ES256","typ":"JOSE","kid":"future-key-1"}"#,
+        &canonical,
+        &der,
+    )
+    .unwrap();
+    let parts: Vec<&str> = compact.splitn(3, '.').collect();
+    doc.as_object_mut().unwrap().insert(
+        "signatures".to_string(),
+        serde_json::json!([{"protected": parts[0], "signature": parts[2]}]),
+    );
+
+    let raw = serde_json::to_string(&doc).unwrap();
+    let verified =
+        verify_card_json(&raw, &jwk).expect("unmodeled member must not break verification");
+    assert_eq!(
+        verified.claims.did,
+        "did:web:golden.conformance.example.com"
+    );
+
+    // The typed struct path can never verify this card: re-serialization
+    // drops `futureField`, so the reconstructed payload differs from the
+    // one signed — the exact fail-closed defect the JSON path fixes.
+    let retyped: AgentCard = serde_json::from_str(&raw).unwrap();
+    assert!(verify_card(&retyped, &jwk).is_err());
+}
+
+/// The §8.4.3 signature layer and the nucleus claims policy are separate:
+/// a validly signed PLAIN A2A card (no nucleus extension, as any
+/// non-nucleus implementation would publish) passes pure signature
+/// verification, and is then rejected by `verify_card` with an error that
+/// names the policy — never a signature failure.
+#[test]
+fn plain_a2a_card_passes_signature_verification_and_fails_only_policy() {
+    let (der, jwk) = p256_keypair();
+    let plain = sign_card(spec_example_card(), &der, "key-1").unwrap();
+
+    // Layer 1 (§8.4.3) accepts it — struct and received-document paths.
+    verify_card_signature(&plain, &jwk).expect("\u{a7}8.4.3 accepts a signed plain card");
+    crate::verify::verify_card_signature_json(&serde_json::to_value(&plain).unwrap(), &jwk)
+        .expect("received-document path agrees");
+
+    // Layer 2 (nucleus policy) rejects it, saying it is policy.
+    let err = verify_card(&plain, &jwk).unwrap_err();
+    let msg = format!("{err}");
+    assert!(msg.contains("nucleus claims policy"), "{msg}");
+    assert!(msg.contains("not a signature failure"), "{msg}");
 }
 
 /// §8.4.2: a protected header missing `kid` (or carrying an empty one) is

--- a/crates/nucleus-agent-card/src/jcs.rs
+++ b/crates/nucleus-agent-card/src/jcs.rs
@@ -29,14 +29,71 @@ use crate::{Error, Result};
 /// These are exactly the bytes the JWS signature covers — for an unsigned
 /// and a signed copy of the same card they are identical, which is what
 /// makes the detached signature verifiable at all.
+///
+/// This is the SIGNER's path (and the verify path for callers who only
+/// hold a typed struct): it covers exactly the fields [`AgentCard`]
+/// models. A verifier that received the card as raw JSON should
+/// canonicalize the received document instead — see
+/// [`canonicalize_received`] — so the signature is checked over what was
+/// actually received, unknown members included.
 pub fn canonicalize(card: &AgentCard) -> Result<Vec<u8>> {
-    let mut value = serde_json::to_value(card).map_err(|e| Error::Canonicalize(e.to_string()))?;
-    if let Some(obj) = value.as_object_mut() {
-        // §8.4.1 rule 3: the signatures field itself MUST be excluded from
-        // the content being signed (avoids the circular dependency).
-        obj.remove("signatures");
-    }
-    serde_jcs::to_vec(&value).map_err(|e| Error::Canonicalize(e.to_string()))
+    let value = serde_json::to_value(card).map_err(|e| Error::Canonicalize(e.to_string()))?;
+    canonicalize_received(&value)
+}
+
+/// Canonicalize a RECEIVED Agent Card document (raw JSON) to its A2A
+/// §8.4.3 verification payload: remove the `signatures` member (§8.4.1
+/// rule 3), keep **every other member exactly as received**, and RFC 8785
+/// (JCS)-canonicalize the result.
+///
+/// # Why "keep everything as received" satisfies §8.4.1's presence rules
+///
+/// §8.4.3 steps 3–6 operate on "the received Agent Card", and step 3 says
+/// to "remove properties with default values". Read against §8.4.1 rule 1,
+/// that removal is schema-directed: it distinguishes `optional` fields
+/// (explicit presence — include when present, even at a default value)
+/// from non-`optional`, non-`REQUIRED` fields (implicit presence — omit at
+/// the default value). The §8.4.1 worked example shows both:
+/// `capabilities.streaming: false` is *kept* ("optional field, present in
+/// JSON (explicitly set)") while `capabilities.extensions: []` is
+/// *omitted* ("repeated field (not REQUIRED) with empty array").
+///
+/// A verifier of a raw received document cannot apply that distinction to
+/// members it does not model — it has no schema for them. But it does not
+/// need to, because of how conformant producers serialize (A2A ADR-001,
+/// ProtoJSON): an implicit-presence field at its default value is *never
+/// emitted on the wire* in the first place, and the §8.4.2 signing
+/// procedure strips the same members before signing. So for a conformantly
+/// serialized card, presence in the received JSON IS the §8.4.1 rule-1
+/// signal: every member present was either `REQUIRED`, an explicitly-set
+/// `optional`, or non-default — all of which the canonical form INCLUDES —
+/// and every member the canonical form would omit is already absent.
+/// "Remove `signatures`, keep the rest, JCS" therefore computes exactly
+/// the §8.4.1 canonical payload, without needing a schema for unknown
+/// members — which is what makes verifying a card signed by a newer
+/// implementation (over members this version does not model) possible at
+/// all.
+///
+/// For a NON-conformant document that materializes an implicit-presence
+/// default (e.g. a literal `"extensions": []` a conformant signer would
+/// have stripped), this canonicalization yields different bytes than the
+/// signer's and verification fails. That is the fail-closed direction: we
+/// never accept a signature over bytes that differ from what was received.
+///
+/// # Errors
+///
+/// [`Error::Canonicalize`] if the document is not a JSON object or JCS
+/// serialization fails.
+pub fn canonicalize_received(received: &serde_json::Value) -> Result<Vec<u8>> {
+    let obj = received.as_object().ok_or_else(|| {
+        Error::Canonicalize("received Agent Card document is not a JSON object".to_string())
+    })?;
+    let mut stripped = obj.clone();
+    // §8.4.1 rule 3: the signatures member itself MUST be excluded from
+    // the content being signed (avoids the circular dependency).
+    stripped.remove("signatures");
+    serde_jcs::to_vec(&serde_json::Value::Object(stripped))
+        .map_err(|e| Error::Canonicalize(e.to_string()))
 }
 
 #[cfg(test)]
@@ -154,5 +211,52 @@ mod tests {
         let b = canonicalize(&signed).unwrap();
         assert_eq!(a, b, "signatures must not be part of the signed content");
         assert!(!String::from_utf8(b).unwrap().contains("signatures"));
+    }
+
+    /// The typed path and the received-document path agree byte-for-byte
+    /// on a card this version fully models — the equivalence that lets
+    /// `verify_card` (struct) and `verify_card_json` (raw document)
+    /// accept the same signatures.
+    #[test]
+    fn received_document_canonicalization_matches_the_struct_path() {
+        let card = minimal_card();
+        let doc = serde_json::to_value(&card).unwrap();
+        assert_eq!(
+            canonicalize(&card).unwrap(),
+            canonicalize_received(&doc).unwrap()
+        );
+    }
+
+    /// A member present in the received document — modeled or not — is
+    /// part of the canonical payload. This is the §8.4.1 rule-1 reading
+    /// (presence in the received JSON is the explicitly-set signal): an
+    /// unknown member must CHANGE the bytes, so a signature that did not
+    /// cover it cannot verify, and one that did cover it can.
+    #[test]
+    fn received_document_keeps_unknown_members() {
+        let mut doc = serde_json::to_value(minimal_card()).unwrap();
+        let baseline = canonicalize_received(&doc).unwrap();
+        doc.as_object_mut()
+            .unwrap()
+            .insert("futureField".to_string(), serde_json::json!("v1.1"));
+        let with_unknown = canonicalize_received(&doc).unwrap();
+        assert_ne!(baseline, with_unknown);
+        assert!(String::from_utf8(with_unknown)
+            .unwrap()
+            .contains(r#""futureField":"v1.1""#));
+    }
+
+    #[test]
+    fn received_document_must_be_a_json_object() {
+        for not_a_card in [
+            serde_json::json!([1, 2, 3]),
+            serde_json::json!("string"),
+            serde_json::json!(null),
+        ] {
+            assert!(matches!(
+                canonicalize_received(&not_a_card),
+                Err(Error::Canonicalize(_))
+            ));
+        }
     }
 }

--- a/crates/nucleus-agent-card/src/lib.rs
+++ b/crates/nucleus-agent-card/src/lib.rs
@@ -10,6 +10,24 @@
 //! [`nucleus_envelope::TrustAnchor`] ([`trust_anchor_from_card`]) so the
 //! EXISTING bundle verifier can decide whether to ACT on a bundle.
 //!
+//! # Verification surface — pick the right entry point
+//!
+//! - [`verify_card_signature`] / [`verify_card_signature_json`] — PURE A2A
+//!   §8.4.3 signature verification, no nucleus policy. A validly signed
+//!   plain A2A card (no nucleus extension — e.g. from a non-nucleus
+//!   implementation) verifies here.
+//! - [`verify_card`] / [`verify_card_json`] — the §8.4.3 check PLUS the
+//!   nucleus claims policy (extension required, usable `trust_jwks`),
+//!   yielding a [`VerifiedCard`] for the verify-before-you-act flow.
+//!   Policy rejections are labelled as policy, never as signature
+//!   failures.
+//! - The `*_json` variants verify **the received document** (§8.4.3 steps
+//!   3–6 operate on "the received Agent Card"): canonicalization keeps
+//!   every received member, so injected unknown members are rejected and
+//!   cards signed by newer implementations over unmodeled members still
+//!   verify. Prefer them whenever the card reached you as raw JSON; the
+//!   struct variants cover exactly the fields this version models.
+//!
 //! # Trust model — read this before using
 //!
 //! - **Verify needs no secret.** [`verify_card`] is always compiled and is
@@ -83,9 +101,11 @@ pub use card::{
     AgentProvider, AgentSkill, EnforcementRule, NucleusClaims, RuntimeGuaranteeProfile,
     SecurityRequirement, StringList, A2A_PROTOCOL_VERSION, NUCLEUS_EXTENSION_URI,
 };
-pub use jcs::canonicalize;
+pub use jcs::{canonicalize, canonicalize_received};
 pub use jwk::JsonWebKey;
-pub use verify::{verify_card, VerifiedCard};
+pub use verify::{
+    verify_card, verify_card_json, verify_card_signature, verify_card_signature_json, VerifiedCard,
+};
 
 #[cfg(feature = "sign")]
 pub use sign::sign_card;
@@ -100,8 +120,11 @@ pub enum Error {
     #[error("agent-card canonicalization failed: {0}")]
     Canonicalize(String),
 
-    /// Card verification failed (no signatures, bad signature, payload
-    /// mismatch, missing nucleus extension, or unusable advertised JWKS).
+    /// Card verification failed — either at the A2A §8.4.3 signature
+    /// layer (no signatures, bad signature, payload mismatch) or at the
+    /// nucleus claims policy layer (missing nucleus extension, unusable
+    /// advertised JWKS); policy messages say "nucleus claims policy"
+    /// explicitly so the two are never confused.
     #[error("agent-card verification failed: {0}")]
     Verify(String),
 

--- a/crates/nucleus-agent-card/src/sign_verify_tests.rs
+++ b/crates/nucleus-agent-card/src/sign_verify_tests.rs
@@ -124,14 +124,15 @@ fn sign_and_verify_canonicalize_identically() {
 fn second_signature_keeps_the_first_valid() {
     // §8.4.3: multiple signatures MAY be present (key rotation). Because
     // the canonical payload excludes ALL signatures, appending a second
-    // one must not invalidate the first — which is the one verify_card
-    // checks.
+    // one must not invalidate the first — and verify_card checks every
+    // entry against the caller's key, so a holder of EITHER key verifies.
     let (der_a, pub_a) = p256_keypair();
-    let (der_b, _pub_b) = p256_keypair();
+    let (der_b, pub_b) = p256_keypair();
     let signed_once = sign_card(sample_card(), &der_a, "key-a").unwrap();
     let signed_twice = sign_card(signed_once, &der_b, "key-b").unwrap();
     assert_eq!(signed_twice.signatures.len(), 2);
     verify_card(&signed_twice, &pub_a).expect("first signature still verifies");
+    verify_card(&signed_twice, &pub_b).expect("second signature (index 1) verifies too");
 }
 
 #[test]
@@ -172,11 +173,17 @@ fn card_signed_by_key_a_fails_under_key_b() {
 #[test]
 fn card_without_nucleus_extension_is_rejected() {
     // A validly signed plain A2A card with no nucleus claims cannot anchor
-    // anything — verify_card refuses it.
+    // anything — verify_card refuses it, as a POLICY decision: the §8.4.3
+    // signature itself is valid (crate::verify::verify_card_signature
+    // accepts it; pinned in conformance_tests).
     let (der, pub_jwk) = p256_keypair();
     let signed = sign_card(base_card(), &der, "card-key-1").unwrap();
     let err = verify_card(&signed, &pub_jwk).unwrap_err();
     assert!(matches!(err, crate::Error::Verify(_)), "got {err:?}");
+    assert!(
+        format!("{err}").contains("nucleus claims policy"),
+        "got {err}"
+    );
 }
 
 #[test]
@@ -309,6 +316,43 @@ fn print_verifier_js_fixture() {
 
     let fixture = serde_json::json!({
         "_generated_by": "nucleus-agent-card print_verifier_js_fixture (sign_card with an ephemeral ring P-256 key — a TEST key; resolved_jwk is the matching public key a recipient would resolve out-of-band; wrong_jwk is a second, unrelated P-256 key). A2A v1.0 card shape.",
+        "resolved_jwk": pub_jwk,
+        "signed_card": signed,
+        "wrong_jwk": wrong_jwk,
+    });
+    println!("BEGIN-FIXTURE");
+    println!("{}", serde_json::to_string_pretty(&fixture).unwrap());
+    println!("END-FIXTURE");
+}
+
+/// Regenerates `sdks/verifier-js/test/fixtures/plain-agent-card.json` — a
+/// validly signed PLAIN A2A v1.0 card (no nucleus extension), as any
+/// non-nucleus A2A implementation would publish. The pure §8.4.3 path
+/// (`verifyAgentCardSignature`) accepts it; the policy-layered
+/// `verifyAgentCard` rejects it.
+///
+/// Run manually after any wire-shape change:
+///
+/// ```bash
+/// cargo test -p nucleus-agent-card --features sign \
+///   print_verifier_js_plain_fixture -- --ignored --nocapture
+/// ```
+///
+/// and paste the JSON between the BEGIN/END markers into the fixture.
+#[test]
+#[ignore = "fixture generator — run with --ignored --nocapture to regenerate"]
+fn print_verifier_js_plain_fixture() {
+    let (der, pub_jwk) = p256_keypair();
+    let (_other_der, wrong_jwk) = p256_keypair();
+
+    let signed = sign_card(base_card(), &der, "plain-card-key-1").unwrap();
+    crate::verify::verify_card_signature(&signed, &pub_jwk)
+        .expect("fixture card's \u{a7}8.4.3 signature must verify before shipping");
+    verify_card(&signed, &pub_jwk)
+        .expect_err("fixture card must NOT pass the nucleus claims policy");
+
+    let fixture = serde_json::json!({
+        "_generated_by": "nucleus-agent-card print_verifier_js_plain_fixture (sign_card with an ephemeral ring P-256 key — a TEST key; the card carries NO nucleus extension, like any plain A2A v1.0 producer's; resolved_jwk is the matching public key a recipient would resolve out-of-band; wrong_jwk is a second, unrelated P-256 key).",
         "resolved_jwk": pub_jwk,
         "signed_card": signed,
         "wrong_jwk": wrong_jwk,

--- a/crates/nucleus-agent-card/src/verify.rs
+++ b/crates/nucleus-agent-card/src/verify.rs
@@ -4,6 +4,38 @@
 //! This module is ALWAYS compiled (no feature gate) and is secret-free —
 //! a browser/WASM verifier can use it without ever touching a private key.
 //!
+//! # Two layers, kept apart
+//!
+//! 1. **§8.4.3 signature verification** — [`verify_card_signature`] /
+//!    [`verify_card_signature_json`]. Pure spec: canonicalize the card
+//!    minus its `signatures` member (§8.4.1), reconstruct each detached
+//!    JWS, accept if ANY signature verifies against the caller's resolved
+//!    key (§8.4.3 allows multiple signatures for key rotation). A validly
+//!    signed *plain* A2A card — no nucleus extension, e.g. one produced by
+//!    a2a-python — passes this layer.
+//!
+//! 2. **Nucleus claims policy** — layered on top by [`verify_card`] /
+//!    [`verify_card_json`]: the card must carry the nucleus extension with
+//!    well-formed claims and a usable `trust_jwks`, because the
+//!    verify-before-you-act flow anchors bundles on them. Policy failures
+//!    say so explicitly ("nucleus claims policy …") — they are NOT
+//!    signature failures.
+//!
+//! # Verify the received document, not a re-serialization
+//!
+//! §8.4.3 steps 3–6 operate on "the received Agent Card". When the caller
+//! holds the raw JSON it received, it should verify through
+//! [`verify_card_json`] / [`verify_card_signature_json`], which
+//! canonicalize the document AS RECEIVED (see
+//! [`crate::jcs::canonicalize_received`]). Verifying a re-serialized typed
+//! struct instead has two §8.4.3 violations: a member the struct does not
+//! model is silently dropped, so (a) an attacker-injected unknown member
+//! escapes the signature check (fail-open), and (b) a card legitimately
+//! signed by a newer implementation over an unmodeled member can never
+//! verify (fail-closed, contradicting the crate's forward-compat
+//! documentation). The struct-input functions remain for callers who only
+//! have a typed card — for them the struct IS the received artifact.
+//!
 //! # The one rule that makes this safe
 //!
 //! The verification key comes ONLY from the caller's `resolved_key`
@@ -18,8 +50,8 @@
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine as _;
 
-use crate::card::{AgentCard, NucleusClaims};
-use crate::jcs::canonicalize;
+use crate::card::{AgentCard, AgentCardSignature, NucleusClaims};
+use crate::jcs::canonicalize_received;
 use crate::jwk::JsonWebKey;
 use crate::{Error, Result};
 
@@ -49,114 +81,254 @@ impl VerifiedCard {
     }
 }
 
+/// §8.4.3 signature verification ONLY, over a typed [`AgentCard`], using a
+/// key the caller resolved out-of-band.
+///
+/// Steps (§8.4.3):
+///
+/// 1. Canonicalize the card minus its `signatures` member to the §8.4.1
+///    JCS payload, and derive the detached JWS payload segment
+///    `base64url_nopad(JCS)`.
+/// 2. For EACH entry of the `signatures` array (the spec allows multiple
+///    for key rotation / co-signing): require a non-empty `kid` in the
+///    protected header (§8.4.2 format conformance — the value is never
+///    used to select a key), reconstruct the compact JWS
+///    `protected.payload.signature`, and verify it via the wasm-clean
+///    ES256 verifier in [`crate::jwk`] against `resolved_key`.
+/// 3. Succeed if ANY entry verifies. This introduces no card-controlled
+///    key selection — every entry is checked against the same
+///    caller-resolved key, and work is bounded by the array length.
+///
+/// No nucleus policy is applied: a validly signed plain A2A card (no
+/// nucleus extension) passes. Layer [`verify_card`] /
+/// [`verify_card_json`] on top when you need the claims.
+///
+/// Prefer [`verify_card_signature_json`] when you hold the raw received
+/// document — see the module docs on verifying what was received.
+///
+/// # Errors
+///
+/// Returns [`Error::Verify`] on: no signatures, or no entry that both
+/// carries a `kid` (§8.4.2) and verifies against `resolved_key`.
+pub fn verify_card_signature(card: &AgentCard, resolved_key: &JsonWebKey) -> Result<()> {
+    let received = serde_json::to_value(card).map_err(|e| Error::Canonicalize(e.to_string()))?;
+    verify_card_signature_json(&received, resolved_key)
+}
+
+/// §8.4.3 signature verification ONLY, over the RECEIVED Agent Card
+/// document (raw JSON), using a key the caller resolved out-of-band.
+///
+/// Canonicalization is [`canonicalize_received`]: remove the `signatures`
+/// member (§8.4.1 rule 3), keep every other member exactly as received,
+/// JCS-canonicalize — so the signature is checked over what was actually
+/// received, unknown/unmodeled members included. Signature iteration and
+/// the trust model are as in [`verify_card_signature`].
+///
+/// # Errors
+///
+/// Returns [`Error::Verify`] on: a `signatures` member that does not parse
+/// as JWS entries, no signatures, or no entry that both carries a `kid`
+/// (§8.4.2) and verifies against `resolved_key`; [`Error::Canonicalize`]
+/// if the document is not a JSON object.
+pub fn verify_card_signature_json(
+    received: &serde_json::Value,
+    resolved_key: &JsonWebKey,
+) -> Result<()> {
+    let signatures: Vec<AgentCardSignature> = match received.get("signatures") {
+        Some(v) => serde_json::from_value(v.clone()).map_err(|e| {
+            Error::Verify(format!(
+                "the card's signatures member does not parse as AgentCardSignature entries: {e}"
+            ))
+        })?,
+        None => Vec::new(),
+    };
+
+    let canonical = canonicalize_received(received)?;
+    verify_any_signature(&signatures, &canonical, resolved_key)
+}
+
 /// Verify a signed [`AgentCard`] using a key the caller resolved
 /// out-of-band, and extract its [`NucleusClaims`].
 ///
-/// Steps (§8.4.3, with the nucleus trust model on top):
+/// Two layers (see the module docs):
 ///
-/// 1. Take the FIRST entry of the card's `signatures` array.
-/// 2. Recompute the §8.4.1 canonical payload — the JCS bytes of the card
-///    with `signatures` excluded — and the detached JWS payload segment
-///    `base64url_nopad(JCS)`.
-/// 3. Reconstruct the compact JWS `protected.payload.signature` and verify
-///    it via the wasm-clean ES256 verifier in [`crate::jwk`] against
-///    `resolved_key`.
-/// 4. Assert the payload `jws_verify_es256` returns equals the canonical
-///    bytes — so the signature is bound to *this* card, not some other
-///    payload.
-/// 5. Extract the [`NucleusClaims`] from the card's nucleus extension —
-///    REQUIRED here: this verifier exists for the verify-before-you-act
-///    flow, and a card with no claims (or a malformed claim set) cannot
-///    anchor anything downstream.
-/// 6. Reject if the claimed `trust_jwks` is empty or malformed (an
-///    advertised-but-unusable JWKS can't anchor anything either).
+/// 1. Pure §8.4.3 signature verification — [`verify_card_signature`]:
+///    JCS canonicalization minus `signatures`, detached-JWS verification
+///    of EVERY signature entry against `resolved_key`, success if any
+///    verifies.
+/// 2. The nucleus claims policy: the card MUST declare the nucleus
+///    extension with well-formed [`NucleusClaims`] — this function exists
+///    for the verify-before-you-act flow, and a card with no claims
+///    cannot anchor anything downstream — and the claimed `trust_jwks`
+///    MUST be non-empty and well-formed (an advertised-but-unusable JWKS
+///    can't anchor anything either).
+///
+/// Prefer [`verify_card_json`] when you hold the raw received document.
 ///
 /// # Errors
 ///
 /// Returns [`Error`] on: no signatures, a protected header missing `kid`
-/// (§8.4.2), signature/JWS verification failure, payload mismatch,
-/// missing/malformed nucleus extension, or empty/malformed `trust_jwks`.
+/// (§8.4.2), signature/JWS verification failure, payload mismatch (all
+/// from layer 1), or — explicitly labelled as nucleus claims POLICY
+/// failures, not signature failures — a missing/malformed nucleus
+/// extension or an empty/malformed `trust_jwks` (layer 2).
 pub fn verify_card(card: &AgentCard, resolved_key: &JsonWebKey) -> Result<VerifiedCard> {
-    // 1) First signature. Multiple signatures are allowed on the wire
-    //    (§8.4.3, key rotation), but the trust decision is made against the
-    //    caller's resolved key over the first one — we never iterate
-    //    looking for "a kid that matches" because that would re-introduce
-    //    card-controlled key selection.
-    let sig = card
-        .signatures
-        .first()
-        .ok_or(Error::Verify("card has no signatures".to_string()))?;
+    verify_card_signature(card, resolved_key)?;
+    apply_nucleus_policy(card.clone())
+}
 
-    // 1b) §8.4.2 format conformance: the protected header MUST carry `kid`
-    //     (and `alg`, which jws_verify_es256 pins to ES256 below). We
-    //     REQUIRE kid's presence without ever using its value for key
-    //     selection — the verification key stays the caller's
-    //     out-of-band-resolved one.
-    require_kid(&sig.protected)?;
+/// Verify a signed Agent Card from the RAW JSON DOCUMENT the caller
+/// received, using a key resolved out-of-band, and extract its
+/// [`NucleusClaims`].
+///
+/// Same two layers as [`verify_card`], but layer 1 runs over the received
+/// document via [`verify_card_signature_json`] — §8.4.3's "the received
+/// Agent Card", so an attacker-injected unknown member is REJECTED (the
+/// signature does not cover it) and a card legitimately signed by a newer
+/// implementation over an unmodeled member still VERIFIES. Use this
+/// whenever the card reached you as bytes/string (HTTP body, credential
+/// field, well-known fetch).
+///
+/// # Errors
+///
+/// Returns [`Error`] on: invalid JSON, any layer-1 signature failure (see
+/// [`verify_card_signature_json`]), a verified document that does not
+/// parse as an A2A v1.0 [`AgentCard`], or a nucleus claims POLICY failure
+/// (see [`verify_card`]).
+pub fn verify_card_json(received_json: &str, resolved_key: &JsonWebKey) -> Result<VerifiedCard> {
+    let received: serde_json::Value = serde_json::from_str(received_json)
+        .map_err(|e| Error::Verify(format!("received Agent Card is not valid JSON: {e}")))?;
+    verify_card_signature_json(&received, resolved_key)?;
 
-    // 2) Canonical payload (signatures excluded) + detached JWS segment.
-    let jcs_bytes = canonicalize(card)?;
-    let payload_b64 = URL_SAFE_NO_PAD.encode(&jcs_bytes);
+    // The signature verified over the received bytes; now type the card.
+    // Unknown members are ignored on parse (forward-compat) — they were
+    // still covered by the signature check above.
+    let card: AgentCard = serde_json::from_value(received).map_err(|e| {
+        Error::Verify(format!(
+            "signature verified, but the document does not parse as an A2A v1.0 AgentCard: {e}"
+        ))
+    })?;
+    apply_nucleus_policy(card)
+}
 
-    // 3) Reconstruct the COMPACT JWS string the detached signature implies:
-    //    protected "." base64url(JCS) "." signature.
-    let compact = format!("{}.{}.{}", sig.protected, payload_b64, sig.signature);
-
-    // 4) Verify against the OUT-OF-BAND-resolved key ONLY. Never the card's
-    //    own material, never the protected header's kid/jku.
-    //    `jws_verify_es256` (wasm-clean, pure-Rust p256 — see crate::jwk)
-    //    returns the decoded payload.
-    let recovered = crate::jwk::jws_verify_es256(&compact, resolved_key)
-        .map_err(|e| Error::Verify(format!("JWS verification failed: {e}")))?;
-
-    // 5) Defense in depth: the recovered payload MUST equal the JCS we
-    //    canonicalized. With the reconstruction above this is structurally
-    //    guaranteed, but asserting it pins the contract so a future change
-    //    to the JWS reconstruction can't silently verify a different
-    //    payload than the card.
-    if recovered != jcs_bytes {
-        return Err(Error::Verify(
-            "verified JWS payload does not equal the card's JCS bytes".to_string(),
-        ));
-    }
-
-    // 6) Extract the nucleus claims — required for verify-before-you-act.
+/// Layer 2: the nucleus claims policy. Only called AFTER the §8.4.3
+/// signature verified — every rejection here is a POLICY decision about
+/// what nucleus's verify-before-you-act flow can anchor on, and says so.
+fn apply_nucleus_policy(card: AgentCard) -> Result<VerifiedCard> {
+    // The nucleus claims are required for verify-before-you-act.
     let claims = card.nucleus_claims()?.ok_or_else(|| {
         Error::Verify(format!(
-            "card does not declare the nucleus extension ({}) — nothing to anchor on",
+            "nucleus claims policy (the \u{a7}8.4.3 signature verified; this is not a \
+             signature failure): card does not declare the nucleus extension ({}) — \
+             nothing to anchor on",
             crate::card::NUCLEUS_EXTENSION_URI
         ))
     })?;
 
-    // 7) Reject an unusable advertised JWKS up front. An empty or malformed
-    //    trust_jwks can't anchor any bundle, so a card carrying one is
-    //    useless for verify-before-you-act — fail loudly here rather than
-    //    let the caller build a TrustAnchor that rejects everything.
-    reject_unusable_jwks(&claims.trust_jwks)?;
+    // Reject an unusable advertised JWKS up front. An empty or malformed
+    // trust_jwks can't anchor any bundle, so a card carrying one is
+    // useless for verify-before-you-act — fail loudly here rather than
+    // let the caller build a TrustAnchor that rejects everything.
+    reject_unusable_jwks(&claims.trust_jwks).map_err(|e| {
+        Error::Verify(format!(
+            "nucleus claims policy (the \u{a7}8.4.3 signature verified; this is not a \
+             signature failure): {e}"
+        ))
+    })?;
 
-    Ok(VerifiedCard {
-        card: card.clone(),
-        claims,
-    })
+    Ok(VerifiedCard { card, claims })
+}
+
+/// §8.4.3 over the whole `signatures` array: succeed if ANY entry both
+/// conforms to §8.4.2 (non-empty `kid`) and verifies against the caller's
+/// resolved key. Multiple signatures exist for key rotation — a card
+/// co-signed by an old and a new key must verify for a holder of EITHER
+/// key, so a failing entry never masks a later valid one. Work is bounded
+/// by the array length, and the key is always the caller's: iterating
+/// entries introduces no card-controlled key selection.
+fn verify_any_signature(
+    signatures: &[AgentCardSignature],
+    canonical: &[u8],
+    resolved_key: &JsonWebKey,
+) -> Result<()> {
+    if signatures.is_empty() {
+        return Err(Error::Verify("card has no signatures".to_string()));
+    }
+
+    let payload_b64 = URL_SAFE_NO_PAD.encode(canonical);
+    let mut failures: Vec<String> = Vec::with_capacity(signatures.len());
+    for sig in signatures {
+        match verify_one_signature(sig, canonical, &payload_b64, resolved_key) {
+            Ok(()) => return Ok(()),
+            Err(reason) => failures.push(reason),
+        }
+    }
+
+    if failures.len() == 1 {
+        return Err(Error::Verify(failures.remove(0)));
+    }
+    let detail: Vec<String> = failures
+        .iter()
+        .enumerate()
+        .map(|(i, f)| format!("[{i}] {f}"))
+        .collect();
+    Err(Error::Verify(format!(
+        "none of the card's {} signatures verified against the resolved key: {}",
+        failures.len(),
+        detail.join("; ")
+    )))
+}
+
+/// One §8.4.3 signature entry against the caller's resolved key.
+fn verify_one_signature(
+    sig: &AgentCardSignature,
+    canonical: &[u8],
+    payload_b64: &str,
+    resolved_key: &JsonWebKey,
+) -> std::result::Result<(), String> {
+    // §8.4.2 format conformance: the protected header MUST carry `kid`
+    // (and `alg`, which jws_verify_es256 pins to ES256 below). We REQUIRE
+    // kid's presence without ever using its value for key selection — the
+    // verification key stays the caller's out-of-band-resolved one.
+    require_kid(&sig.protected)?;
+
+    // Reconstruct the COMPACT JWS string the detached signature implies:
+    // protected "." base64url(JCS) "." signature.
+    let compact = format!("{}.{}.{}", sig.protected, payload_b64, sig.signature);
+
+    // Verify against the OUT-OF-BAND-resolved key ONLY. Never the card's
+    // own material, never the protected header's kid/jku.
+    // `jws_verify_es256` (wasm-clean, pure-Rust p256 — see crate::jwk)
+    // returns the decoded payload.
+    let recovered = crate::jwk::jws_verify_es256(&compact, resolved_key)
+        .map_err(|e| format!("JWS verification failed: {e}"))?;
+
+    // Defense in depth: the recovered payload MUST equal the canonical
+    // bytes. With the reconstruction above this is structurally
+    // guaranteed, but asserting it pins the contract so a future change
+    // to the JWS reconstruction can't silently verify a different
+    // payload than the card.
+    if recovered != canonical {
+        return Err("verified JWS payload does not equal the card's JCS bytes".to_string());
+    }
+    Ok(())
 }
 
 /// §8.4.2: the JWS protected header MUST include `kid`. Presence-only —
 /// the value is never used to resolve a key (see the trust model note on
 /// [`verify_card`]).
-fn require_kid(protected_b64: &str) -> Result<()> {
+fn require_kid(protected_b64: &str) -> std::result::Result<(), String> {
     let bytes = URL_SAFE_NO_PAD
         .decode(protected_b64)
-        .map_err(|e| Error::Verify(format!("protected header is not valid base64url: {e}")))?;
+        .map_err(|e| format!("protected header is not valid base64url: {e}"))?;
     let header: serde_json::Value = serde_json::from_slice(&bytes)
-        .map_err(|e| Error::Verify(format!("protected header is not valid JSON: {e}")))?;
+        .map_err(|e| format!("protected header is not valid JSON: {e}"))?;
     match header.get("kid").and_then(serde_json::Value::as_str) {
         Some(kid) if !kid.is_empty() => Ok(()),
-        Some(_) => Err(Error::Verify(
-            "protected header carries an empty kid (\u{a7}8.4.2 requires a key id)".to_string(),
-        )),
-        None => Err(Error::Verify(
-            "protected header is missing kid (\u{a7}8.4.2 requires it)".to_string(),
-        )),
+        Some(_) => {
+            Err("protected header carries an empty kid (\u{a7}8.4.2 requires a key id)".to_string())
+        }
+        None => Err("protected header is missing kid (\u{a7}8.4.2 requires it)".to_string()),
     }
 }
 
@@ -164,20 +336,18 @@ fn require_kid(protected_b64: &str) -> Result<()> {
 ///
 /// Malformed = a key entry that can't be turned into a verifying key
 /// (caught by [`nucleus_lineage::Jwks::verifying_key`]).
-fn reject_unusable_jwks(jwks: &nucleus_lineage::Jwks) -> Result<()> {
+fn reject_unusable_jwks(jwks: &nucleus_lineage::Jwks) -> std::result::Result<(), String> {
     if jwks.keys.is_empty() {
-        return Err(Error::Verify(
-            "card advertises an empty trust_jwks (anchors nothing)".to_string(),
-        ));
+        return Err("card advertises an empty trust_jwks (anchors nothing)".to_string());
     }
     for key in &jwks.keys {
         // verifying_key() validates kty/crv/alg and decodes `x`. Any error
         // means this advertised key is unusable as a trust anchor.
         jwks.verifying_key(&key.kid).map_err(|e| {
-            Error::Verify(format!(
+            format!(
                 "card advertises a malformed trust_jwks key (kid {:?}): {e}",
                 key.kid
-            ))
+            )
         })?;
     }
     Ok(())
@@ -247,6 +417,14 @@ mod tests {
     }
 
     #[test]
+    fn no_signatures_is_rejected_on_the_pure_signature_path_too() {
+        let card = card_with(ed25519_jwks());
+        let key = JsonWebKey::ec_p256("x", "y");
+        let err = verify_card_signature(&card, &key).unwrap_err();
+        assert!(format!("{err}").contains("no signatures"), "{err}");
+    }
+
+    #[test]
     fn garbage_signature_is_rejected() {
         let mut card = card_with(ed25519_jwks());
         card.signatures = vec![AgentCardSignature {
@@ -261,5 +439,44 @@ mod tests {
         );
         let err = verify_card(&card, &key).unwrap_err();
         assert!(matches!(err, Error::Verify(_)));
+    }
+
+    #[test]
+    fn two_garbage_signatures_report_every_entrys_failure() {
+        // Iterating the array must not silently report only one entry's
+        // failure when several were tried.
+        let mut card = card_with(ed25519_jwks());
+        let entry = AgentCardSignature {
+            protected: "eyJhbGciOiJFUzI1NiJ9".to_string(),
+            signature: "bm90LWEtcmVhbC1zaWc".to_string(),
+            header: None,
+        };
+        card.signatures = vec![entry.clone(), entry];
+        let key = JsonWebKey::ec_p256(
+            "f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",
+            "x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",
+        );
+        let err = verify_card(&card, &key).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("none of the card's 2 signatures"), "{msg}");
+        assert!(msg.contains("[0]") && msg.contains("[1]"), "{msg}");
+    }
+
+    #[test]
+    fn received_document_that_is_not_json_is_rejected() {
+        let key = JsonWebKey::ec_p256("x", "y");
+        let err = verify_card_json("not json at all", &key).unwrap_err();
+        assert!(format!("{err}").contains("not valid JSON"), "{err}");
+    }
+
+    #[test]
+    fn received_document_with_malformed_signatures_member_is_rejected() {
+        let key = JsonWebKey::ec_p256("x", "y");
+        let received = serde_json::json!({"name": "x", "signatures": "not-an-array"});
+        let err = verify_card_signature_json(&received, &key).unwrap_err();
+        assert!(
+            format!("{err}").contains("does not parse as AgentCardSignature"),
+            "{err}"
+        );
     }
 }

--- a/crates/nucleus-verify-commerce/src/card_verifier.rs
+++ b/crates/nucleus-verify-commerce/src/card_verifier.rs
@@ -1,20 +1,28 @@
 //! [`AgentCardVerifier`] — verify a signed A2A v1.0 Agent Card.
 
 use async_trait::async_trait;
-use nucleus_agent_card::{verify_card, AgentCard, JsonWebKey};
+use nucleus_agent_card::{verify_card_json, JsonWebKey};
 
 use crate::{CallerClaims, CallerVerifier, CommerceError, VerifiedCaller};
 
 /// A [`CallerVerifier`] that treats the caller's credential as a JSON
-/// signed [`AgentCard`] (A2A v1.0: the JWS signatures ride in the card's
+/// signed Agent Card (A2A v1.0: the JWS signatures ride in the card's
 /// own `signatures` field) and verifies it against an
 /// **out-of-band-resolved** key.
 ///
+/// The credential arrives as the RAW JSON document the caller sent, so it
+/// is verified through [`nucleus_agent_card::verify_card_json`] — A2A
+/// §8.4.3 over *the received document*, not a re-serialized struct. A
+/// member injected into the credential after signing changes the
+/// canonical payload and is rejected, even when this version's card type
+/// does not model that member.
+///
 /// The one rule that makes this safe (inherited from
-/// [`nucleus_agent_card::verify_card`]): the verification key comes ONLY from
-/// `resolved_key`, configured here by the seller out-of-band (DID resolution, a
-/// pinned JWKS, an operator file). It is never read from the card. A card
-/// verified against an attacker-supplied key is "verified garbage".
+/// [`nucleus_agent_card::verify_card_json`]): the verification key comes ONLY
+/// from `resolved_key`, configured here by the seller out-of-band (DID
+/// resolution, a pinned JWKS, an operator file). It is never read from the
+/// card. A card verified against an attacker-supplied key is "verified
+/// garbage".
 ///
 /// On success the verified caller's identity is the `spiffe_id` from the
 /// card's nucleus extension claims — the verified truth, not the
@@ -33,10 +41,11 @@ impl AgentCardVerifier {
 #[async_trait]
 impl CallerVerifier for AgentCardVerifier {
     async fn verify(&self, claims: &CallerClaims) -> Result<VerifiedCaller, CommerceError> {
-        let signed: AgentCard = serde_json::from_str(&claims.credential)
-            .map_err(|e| CommerceError::Unverified(format!("malformed signed agent card: {e}")))?;
-
-        let verified = verify_card(&signed, &self.resolved_key)
+        // Verify the credential AS RECEIVED (A2A §8.4.3 operates on "the
+        // received Agent Card") — JSON parsing, canonicalization minus the
+        // signatures member, and JWS verification all happen over the raw
+        // document inside verify_card_json.
+        let verified = verify_card_json(&claims.credential, &self.resolved_key)
             .map_err(|e| CommerceError::Unverified(format!("agent card did not verify: {e}")))?;
 
         Ok(VerifiedCaller {
@@ -51,7 +60,8 @@ mod tests {
     use base64::engine::general_purpose::URL_SAFE_NO_PAD;
     use base64::Engine as _;
     use nucleus_agent_card::{
-        sign_card, AgentCapabilities, AgentInterface, NucleusClaims, A2A_PROTOCOL_VERSION,
+        sign_card, AgentCapabilities, AgentCard, AgentInterface, NucleusClaims,
+        A2A_PROTOCOL_VERSION,
     };
     use ring::rand::SystemRandom;
     use ring::signature::{EcdsaKeyPair, KeyPair, ECDSA_P256_SHA256_FIXED_SIGNING};
@@ -137,6 +147,30 @@ mod tests {
 
         let err = verifier.verify(&claims_for(&signed)).await.unwrap_err();
         assert!(matches!(err, CommerceError::Unverified(_)));
+    }
+
+    #[tokio::test]
+    async fn rejects_a_credential_with_an_injected_unsigned_member() {
+        // The credential is the RECEIVED document: a member injected after
+        // signing is not covered by the signature and must be rejected —
+        // even though the typed AgentCard does not model it (a
+        // parse-then-verify flow would silently drop it and accept).
+        let (der, pub_jwk) = p256_keypair();
+        let signed = sign_card(sample_card(), &der, "card-key-1").unwrap();
+        let mut doc = serde_json::to_value(&signed).unwrap();
+        doc.as_object_mut().unwrap().insert(
+            "injectedByAttacker".to_string(),
+            serde_json::json!("not covered by the signature"),
+        );
+        let claims = CallerClaims {
+            agent_id: "did:web:buyer.prod.example.com".into(),
+            credential: doc.to_string(),
+        };
+        let verifier = AgentCardVerifier::new(pub_jwk);
+        assert!(matches!(
+            verifier.verify(&claims).await.unwrap_err(),
+            CommerceError::Unverified(_)
+        ));
     }
 
     #[tokio::test]

--- a/sdks/verifier-js/index.d.ts
+++ b/sdks/verifier-js/index.d.ts
@@ -151,8 +151,11 @@ export type AgentCardVerdict =
 /**
  * Verify a signed A2A Agent Card against a key YOU resolved out-of-band
  * (DID resolution, a pinned JWKS, an operator file) — never the card's own
- * key material. Runs the exact upstream `verify_card`: verify WHO you are
- * about to act with, in your process, trusting no server.
+ * key material. Runs the exact upstream verifier over the card document AS
+ * RECEIVED (A2A §8.4.3) plus the nucleus claims policy: verify WHO you are
+ * about to act with, in your process, trusting no server. For the pure
+ * §8.4.3 signature check (plain cards, no nucleus policy) see
+ * {@link verifyAgentCardSignature}.
  *
  * A cryptographic rejection is returned as a value (branch on `outcome`);
  * throws only on malformed input (bad card JSON, bad JWK JSON).
@@ -165,6 +168,38 @@ export function verifyAgentCard(
   signedCard: string | object,
   resolvedJwk: string | object,
 ): Promise<AgentCardVerdict>;
+
+/** Structured verdict from {@link verifyAgentCardSignature} — mirrors the Rust `CardSignatureVerdict`. */
+export type AgentCardSignatureVerdict =
+  | {
+      /** At least one signature verified against the resolved key, over the document as received. */
+      outcome: "verified";
+    }
+  | {
+      /** No signatures, or none that conforms to §8.4.2 (`kid`) AND verifies under the resolved key. */
+      outcome: "rejected";
+      reason: string;
+    };
+
+/**
+ * Verify ONLY the A2A v1.0 §8.4.3 signature of an Agent Card against a key
+ * YOU resolved out-of-band — no nucleus claims policy, so a validly signed
+ * plain A2A card (no nucleus extension) verifies. Runs over the document
+ * exactly as received (unknown members stay in the canonical payload) and
+ * checks EVERY entry of the `signatures` array (§8.4.3 key rotation); any
+ * one verifying suffices.
+ *
+ * A cryptographic rejection is returned as a value (branch on `outcome`);
+ * throws only on malformed input (bad card JSON, bad JWK JSON).
+ *
+ * @param signedCard The signed A2A v1.0 `AgentCard` as received — JSON
+ *   string or parsed object.
+ * @param resolvedJwk The out-of-band-resolved key — JWK JSON string or object.
+ */
+export function verifyAgentCardSignature(
+  signedCard: string | object,
+  resolvedJwk: string | object,
+): Promise<AgentCardSignatureVerdict>;
 
 /** The recomputed IFC verdict — mirrors the Rust `RecomputeReport`. */
 export interface RecomputeReport {

--- a/sdks/verifier-js/index.js
+++ b/sdks/verifier-js/index.js
@@ -334,6 +334,43 @@ export async function verifyAgentCard(signedCard, resolvedJwk) {
   );
 }
 
+/**
+ * Verify ONLY the A2A v1.0 §8.4.3 signature of an Agent Card against an
+ * out-of-band-resolved key — no nucleus claims policy. The interop entry
+ * point: a validly signed *plain* A2A card (no nucleus extension, e.g. one
+ * published by any other A2A implementation) verifies here, while
+ * `verifyAgentCard()` additionally requires the nucleus claims.
+ *
+ * Verification runs over the card document exactly as received (§8.4.3
+ * steps 3-6 operate on "the received Agent Card"): the `signatures` member
+ * is removed, everything else — including members this build does not
+ * model — stays in the RFC 8785 canonical payload, and EVERY entry of the
+ * `signatures` array is checked against the resolved key (§8.4.3 allows
+ * multiple signatures for key rotation; any one verifying suffices). The
+ * card's own key material is never trusted.
+ *
+ * Returns a structured verdict (branch on `outcome`); throws only on
+ * malformed input (bad card JSON, bad JWK JSON).
+ *
+ * @param {string | object} signedCard
+ *   The signed A2A v1.0 `AgentCard` as received — JSON string or parsed
+ *   object (JWS signatures embedded in its `signatures` field).
+ * @param {string | object} resolvedJwk
+ *   The out-of-band-resolved verification key — JWK JSON string or object
+ *   (`{"kty":"EC","crv":"P-256","x":"...","y":"..."}`). NEVER from the card.
+ * @returns {Promise<
+ *   | { outcome: "verified" }
+ *   | { outcome: "rejected", reason: string }
+ * >}
+ */
+export async function verifyAgentCardSignature(signedCard, resolvedJwk) {
+  const mod = await initWasm();
+  return mod.verifyAgentCardSignature(
+    asJsonString(signedCard),
+    asJsonString(resolvedJwk),
+  );
+}
+
 // ── RECOMPUTE: re-derive the decision, don't just check the signature ─────────
 // `verify()` proves a receipt was *signed*; `recompute()` proves the in-bounds
 // IFC *decision* was correct by re-running the EXACT same gate function the

--- a/sdks/verifier-js/src/lib.rs
+++ b/sdks/verifier-js/src/lib.rs
@@ -315,15 +315,24 @@ enum CardVerdict {
 
 /// Pure core behind `verifyAgentCard` — no wasm types, so native `cargo test`
 /// exercises the exact logic the wasm export ships.
+///
+/// The caller hands us the card as RAW JSON, so verification goes through
+/// `verify_card_json` — A2A §8.4.3 over *the received document*: a member
+/// injected after signing is rejected even when the typed card does not
+/// model it, and a card signed by a newer producer over an unmodeled
+/// member still verifies.
 fn agent_card_verdict(
     signed_card_json: &str,
     resolved_jwk_json: &str,
 ) -> Result<CardVerdict, String> {
-    let signed: nucleus_agent_card::AgentCard =
+    // Input validation up front: malformed JSON (or JSON that is not an
+    // AgentCard shape) is an input ERROR the caller must fix, not a
+    // cryptographic verdict.
+    let _shape_check: nucleus_agent_card::AgentCard =
         serde_json::from_str(signed_card_json).map_err(|e| format!("signed card JSON: {e}"))?;
     let jwk: nucleus_agent_card::JsonWebKey =
         serde_json::from_str(resolved_jwk_json).map_err(|e| format!("resolved JWK JSON: {e}"))?;
-    match nucleus_agent_card::verify_card(&signed, &jwk) {
+    match nucleus_agent_card::verify_card_json(signed_card_json, &jwk) {
         Ok(verified) => Ok(CardVerdict::Verified {
             spiffe_id: verified.claims.spiffe_id.clone(),
             did: verified.claims.did.clone(),
@@ -386,6 +395,77 @@ pub fn verify_agent_card_js(
     verdict
         .serialize(&serializer)
         .map_err(|e| JsError::new(&e.to_string()))
+}
+
+/// Wire shape returned by `verifyAgentCardSignature`. Same convention as
+/// `CardVerdict`: a cryptographic rejection is a value (`outcome`), not a
+/// thrown exception — only malformed *inputs* throw.
+#[derive(Debug, Serialize)]
+#[serde(tag = "outcome", rename_all = "snake_case")]
+enum CardSignatureVerdict {
+    /// At least one of the card's detached JWS signatures verified against
+    /// the resolved key, over the document exactly as received.
+    Verified,
+    /// No signatures, or no signature that both conforms to A2A §8.4.2
+    /// (non-empty `kid`) and verifies against the resolved key.
+    Rejected { reason: String },
+}
+
+/// Pure core behind `verifyAgentCardSignature` — no wasm types, so native
+/// `cargo test` exercises the exact logic the wasm export ships.
+fn agent_card_signature_verdict(
+    signed_card_json: &str,
+    resolved_jwk_json: &str,
+) -> Result<CardSignatureVerdict, String> {
+    let received: serde_json::Value =
+        serde_json::from_str(signed_card_json).map_err(|e| format!("signed card JSON: {e}"))?;
+    let jwk: nucleus_agent_card::JsonWebKey =
+        serde_json::from_str(resolved_jwk_json).map_err(|e| format!("resolved JWK JSON: {e}"))?;
+    match nucleus_agent_card::verify_card_signature_json(&received, &jwk) {
+        Ok(()) => Ok(CardSignatureVerdict::Verified),
+        Err(e) => Ok(CardSignatureVerdict::Rejected {
+            reason: e.to_string(),
+        }),
+    }
+}
+
+/// Verify ONLY the **A2A v1.0 §8.4.3 signature** of an Agent Card against a
+/// key the caller resolved out-of-band — no nucleus claims policy. This is
+/// the interop entry point: a validly signed *plain* A2A card (no nucleus
+/// extension, e.g. one published by any other A2A implementation) verifies
+/// here, while `verifyAgentCard` additionally requires the nucleus claims
+/// and would reject it as a policy matter.
+///
+/// Verification runs over the card document exactly as received (§8.4.3
+/// steps 3–6 operate on "the received Agent Card"): the `signatures`
+/// member is removed, every other member — including members this build
+/// does not model — stays in the JCS canonical payload, and EVERY entry of
+/// the `signatures` array is checked against the resolved key (§8.4.3
+/// allows multiple signatures for key rotation; any one verifying
+/// suffices). Same pure-Rust p256 core as `verifyAgentCard`; the card's
+/// own key material (and the protected header's `kid`/`jku`) is never used
+/// to select a key.
+///
+/// # Arguments
+/// * `signed_card_json` — the signed A2A v1.0 Agent Card as received
+///   (JSON; JWS signatures embedded in its `signatures` field).
+/// * `resolved_jwk_json` — the out-of-band-resolved verification key as a
+///   JWK JSON (`{"kty":"EC","crv":"P-256","x":"...","y":"..."}`). NEVER
+///   taken from the card itself.
+///
+/// # Returns
+/// A structured verdict: `{ outcome: "verified" }` or
+/// `{ outcome: "rejected", reason }`. Throws only on malformed input —
+/// distinct messages for malformed card JSON vs malformed JWK JSON.
+#[wasm_bindgen(js_name = verifyAgentCardSignature)]
+pub fn verify_agent_card_signature_js(
+    signed_card_json: &str,
+    resolved_jwk_json: &str,
+) -> Result<JsValue, JsError> {
+    set_panic_hook();
+    let verdict = agent_card_signature_verdict(signed_card_json, resolved_jwk_json)
+        .map_err(|e| JsError::new(&e))?;
+    serde_wasm_bindgen::to_value(&verdict).map_err(|e| JsError::new(&e.to_string()))
 }
 
 // ── RECOMPUTE: re-derive the IFC verdict, don't just trust the signature ──────
@@ -1059,6 +1139,79 @@ mod agent_card_tests {
         assert!(err.starts_with("resolved JWK JSON:"), "got: {err}");
         // Valid JSON but not a JWK (missing required fields).
         let err = agent_card_verdict(&card_json, "{}").unwrap_err();
+        assert!(err.starts_with("resolved JWK JSON:"), "got: {err}");
+    }
+
+    /// A plain extension-free A2A card (signed exactly as any non-nucleus
+    /// implementation would): the pure §8.4.3 path accepts it; the
+    /// policy-layered path rejects it AS POLICY, not as a bad signature.
+    fn plain_signed_card_json(der: &[u8]) -> String {
+        let mut card = sample_card();
+        card.capabilities.extensions.clear();
+        let signed = sign_card(card, der, "plain-card-key-1").unwrap();
+        serde_json::to_string(&signed).unwrap()
+    }
+
+    #[test]
+    fn plain_card_signature_verifies_but_policy_path_rejects_it() {
+        let (der, jwk_json) = p256_keypair();
+        let json = plain_signed_card_json(&der);
+
+        assert!(matches!(
+            agent_card_signature_verdict(&json, &jwk_json).expect("well-formed input"),
+            CardSignatureVerdict::Verified
+        ));
+        match agent_card_verdict(&json, &jwk_json).expect("well-formed input") {
+            CardVerdict::Rejected { reason } => {
+                assert!(reason.contains("nucleus claims policy"), "got: {reason}");
+            }
+            other => panic!("expected Rejected, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn plain_card_under_the_wrong_key_is_a_signature_rejection() {
+        let (der, _jwk_json) = p256_keypair();
+        let (_other_der, other_jwk_json) = p256_keypair();
+        let json = plain_signed_card_json(&der);
+        match agent_card_signature_verdict(&json, &other_jwk_json).expect("well-formed input") {
+            CardSignatureVerdict::Rejected { reason } => {
+                assert!(reason.contains("JWS verification failed"), "got: {reason}");
+            }
+            other => panic!("expected Rejected, got {other:?}"),
+        }
+    }
+
+    /// §8.4.3 operates on the RECEIVED document: a member injected into the
+    /// card JSON after signing is rejected by both card paths, even though
+    /// the typed AgentCard does not model the member.
+    #[test]
+    fn injected_unsigned_member_is_rejected_on_both_paths() {
+        let (der, jwk_json) = p256_keypair();
+        let mut doc: serde_json::Value = serde_json::from_str(&signed_card_json(&der)).unwrap();
+        doc.as_object_mut().unwrap().insert(
+            "injectedByAttacker".to_string(),
+            serde_json::json!("not covered by the signature"),
+        );
+        let tampered = doc.to_string();
+
+        assert!(matches!(
+            agent_card_signature_verdict(&tampered, &jwk_json).expect("well-formed input"),
+            CardSignatureVerdict::Rejected { .. }
+        ));
+        assert!(matches!(
+            agent_card_verdict(&tampered, &jwk_json).expect("well-formed input"),
+            CardVerdict::Rejected { .. }
+        ));
+    }
+
+    #[test]
+    fn signature_path_malformed_inputs_are_clean_input_errors() {
+        let (der, jwk_json) = p256_keypair();
+        let err = agent_card_signature_verdict("not valid json", &jwk_json).unwrap_err();
+        assert!(err.starts_with("signed card JSON:"), "got: {err}");
+        let card_json = signed_card_json(&der);
+        let err = agent_card_signature_verdict(&card_json, "{}").unwrap_err();
         assert!(err.starts_with("resolved JWK JSON:"), "got: {err}");
     }
 }

--- a/sdks/verifier-js/test/card.test.mjs
+++ b/sdks/verifier-js/test/card.test.mjs
@@ -18,13 +18,23 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 
-import { verifyAgentCard } from "../index.js";
+import { verifyAgentCard, verifyAgentCardSignature } from "../index.js";
 
 const fixtureUrl = new URL("./fixtures/agent-card.json", import.meta.url);
+// A validly signed PLAIN A2A v1.0 card — NO nucleus extension, exactly what
+// any non-nucleus A2A implementation publishes (see its `_generated_by`).
+const plainFixtureUrl = new URL(
+  "./fixtures/plain-agent-card.json",
+  import.meta.url,
+);
+
+async function readFixtureAt(url) {
+  const text = await readFile(fileURLToPath(url), "utf8");
+  return JSON.parse(text);
+}
 
 async function readFixture() {
-  const text = await readFile(fileURLToPath(fixtureUrl), "utf8");
-  return JSON.parse(text);
+  return readFixtureAt(fixtureUrl);
 }
 
 const NUCLEUS_EXT_URI = "https://coproduct.one/a2a/ext/runtime-guarantees/v1";
@@ -108,6 +118,71 @@ test("malformed JWK JSON throws (input error, not a verdict)", async () => {
   const { signed_card } = await readFixture();
   await assert.rejects(
     () => verifyAgentCard(signed_card, "{}"),
+    /resolved JWK JSON/,
+  );
+});
+
+// ── §8.4.3 over the RECEIVED document ──────────────────────────────────────────
+
+test("a member injected into the received card after signing is rejected", async () => {
+  // The injected member is unknown to the typed card — a verifier that
+  // re-serialized its struct would silently drop it and (wrongly) verify.
+  // §8.4.3 steps 3-6 operate on the received Agent Card: rejected.
+  const { signed_card, resolved_jwk } = await readFixture();
+  signed_card.injectedByAttacker = "not covered by the signature";
+  const v = await verifyAgentCard(signed_card, resolved_jwk);
+  assert.equal(v.outcome, "rejected");
+  const s = await verifyAgentCardSignature(signed_card, resolved_jwk);
+  assert.equal(s.outcome, "rejected");
+});
+
+// ── verifyAgentCardSignature: the pure §8.4.3 layer ────────────────────────────
+
+test("a plain (extension-free) signed A2A card verifies on the signature path", async () => {
+  const { signed_card, resolved_jwk } = await readFixtureAt(plainFixtureUrl);
+  const v = await verifyAgentCardSignature(signed_card, resolved_jwk);
+  assert.equal(v.outcome, "verified");
+});
+
+test("the same plain card is rejected by verifyAgentCard — as policy, not signature", async () => {
+  const { signed_card, resolved_jwk } = await readFixtureAt(plainFixtureUrl);
+  const v = await verifyAgentCard(signed_card, resolved_jwk);
+  assert.equal(v.outcome, "rejected");
+  assert.match(v.reason, /nucleus claims policy/);
+  assert.match(v.reason, /not a signature failure/);
+});
+
+test("the plain card under the wrong key is a signature rejection", async () => {
+  const { signed_card, wrong_jwk } = await readFixtureAt(plainFixtureUrl);
+  const v = await verifyAgentCardSignature(signed_card, wrong_jwk);
+  assert.equal(v.outcome, "rejected");
+  assert.match(v.reason, /JWS verification failed/);
+});
+
+test("tampering the plain card after signing is rejected on the signature path", async () => {
+  const { signed_card, resolved_jwk } = await readFixtureAt(plainFixtureUrl);
+  signed_card.name = "Imposter Agent";
+  const v = await verifyAgentCardSignature(signed_card, resolved_jwk);
+  assert.equal(v.outcome, "rejected");
+});
+
+test("signature path accepts JSON-string inputs identically", async () => {
+  const { signed_card, resolved_jwk } = await readFixtureAt(plainFixtureUrl);
+  const v = await verifyAgentCardSignature(
+    JSON.stringify(signed_card),
+    JSON.stringify(resolved_jwk),
+  );
+  assert.equal(v.outcome, "verified");
+});
+
+test("signature path: malformed inputs throw (input error, not a verdict)", async () => {
+  const { signed_card, resolved_jwk } = await readFixtureAt(plainFixtureUrl);
+  await assert.rejects(
+    () => verifyAgentCardSignature("not valid json", resolved_jwk),
+    /signed card JSON/,
+  );
+  await assert.rejects(
+    () => verifyAgentCardSignature(signed_card, "{}"),
     /resolved JWK JSON/,
   );
 });

--- a/sdks/verifier-js/test/fixtures/plain-agent-card.json
+++ b/sdks/verifier-js/test/fixtures/plain-agent-card.json
@@ -1,0 +1,41 @@
+{
+  "_generated_by": "nucleus-agent-card print_verifier_js_plain_fixture (sign_card with an ephemeral ring P-256 key — a TEST key; the card carries NO nucleus extension, like any plain A2A v1.0 producer's; resolved_jwk is the matching public key a recipient would resolve out-of-band; wrong_jwk is a second, unrelated P-256 key).",
+  "resolved_jwk": {
+    "crv": "P-256",
+    "kty": "EC",
+    "x": "EXreqDvvnRN-zvGVUWInT_5z_b87R9W3aNktA9tc-H0",
+    "y": "j6vU-VTxlUYT824N7u_n7K3U4R5Vt7axvoIdOMTjZJ8"
+  },
+  "signed_card": {
+    "capabilities": {},
+    "defaultInputModes": [
+      "application/json"
+    ],
+    "defaultOutputModes": [
+      "application/json"
+    ],
+    "description": "sign/verify round-trip tests",
+    "name": "Coder Agent",
+    "signatures": [
+      {
+        "protected": "eyJhbGciOiJFUzI1NiIsImtpZCI6InBsYWluLWNhcmQta2V5LTEiLCJ0eXAiOiJKT1NFIn0",
+        "signature": "pJ4lpNaAj-zGPn8cnbCbfsUSM5xZ84eC1-xhxffqnieG3uYmiyqnD7-apN3rCQkbdklL6zzdtkpVR_v5D584-g"
+      }
+    ],
+    "skills": [],
+    "supportedInterfaces": [
+      {
+        "protocolBinding": "JSONRPC",
+        "protocolVersion": "1.0",
+        "url": "https://coder.prod.example.com/a2a/v1"
+      }
+    ],
+    "version": "1.0.0"
+  },
+  "wrong_jwk": {
+    "crv": "P-256",
+    "kty": "EC",
+    "x": "zN3E2Ep2Uo04QN6J4A4yxzg3_D-HRtEDfe3e5PMR-X4",
+    "y": "49MRujVNWbwC9ox8Hrf3WuHPlA10UDxhstl1OjuPym8"
+  }
+}


### PR DESCRIPTION
## What

Makes `nucleus-agent-card`'s verification faithful to **A2A v1.0.1 §8.4.3** (spec text `docs/specification.md`; normative data shapes `specification/a2a.proto` per §1.4). Three tightly-coupled changes:

### 1. Pure §8.4.3 signature path, nucleus policy split out

`verify_card` conflated §8.4.3 signature verification with nucleus trust policy: it hard-required the nucleus extension and a usable Ed25519 `trust_jwks`, so a **validly signed plain A2A card** (no nucleus extension — e.g. one published by a2a-python or any other conformant implementation) was rejected outright, even though its signature is perfectly valid per the spec.

- New `verify_card_signature` / `verify_card_signature_json`: ONLY canonicalize-minus-`signatures` (§8.4.1) + detached-JWS verification (§8.4.3). The §8.4.2 `kid`-presence check is kept, and the out-of-band-key-only trust model is unchanged — `kid`/`jku` are never used for key resolution.
- `verify_card` keeps its exact contract (signature + nucleus claims policy), but policy rejections now say `nucleus claims policy (the §8.4.3 signature verified; this is not a signature failure): …` so interop failures are never misdiagnosed as crypto failures.
- `sdks/verifier-js` gains **`verifyAgentCardSignature`** alongside `verifyAgentCard` (same pure-Rust p256 core, same verdict-as-value wire conventions), with node tests against a real plain-card fixture.

### 2. Verify the RECEIVED document, not a re-serialized struct

§8.4.3 steps 3–6 operate on **"the received Agent Card"**. Canonicalizing a re-serialized typed struct silently drops members the struct does not model, which was wrong in both directions:

- **Fail-open:** a signed card with an attacker-INJECTED unknown member still verified — the member vanished on re-serialization, so the signature was checked over bytes that differ from what was received.
- **Fail-closed:** a card legitimately signed by a newer implementation over a member this version does not model could never verify, contradicting the crate's own forward-compat documentation.

New `canonicalize_received` + `verify_card_json`: remove ONLY the `signatures` member (§8.4.1 rule 3), keep everything else exactly as received, JCS-canonicalize (RFC 8785), verify. The `canonicalize_received` rustdoc derives why this satisfies §8.4.1's presence rules against the spec's own worked example: §8.4.3 step 3's default-removal is schema-directed (`optional` vs implicit-presence fields), but for a ProtoJSON-conformant producer (A2A ADR-001) implicit-presence defaults are never on the wire and §8.4.2 strips the same members before signing — so presence in the received JSON *is* the §8.4.1 rule-1 signal, and keep-as-received computes exactly the signer's payload without needing a schema for unknown members. Non-conformant documents that materialize defaults fail closed (never fail open).

`nucleus-verify-commerce`'s `AgentCardVerifier` (which receives the raw credential string) and the SDK's `verifyAgentCard` (which receives the raw card JSON) now verify through this path.

### 3. All signatures, not `signatures[0]`

§8.4.3: "Multiple signatures MAY be present to support key rotation." Only the first entry was checked, so a holder of the NEW key could not verify a card co-signed old-key-then-new-key. Every entry is now checked against the caller's resolved key — success if ANY verifies, work bounded by the array length. This introduces no card-controlled key selection: the key is still exclusively the caller's out-of-band-resolved one, and an entry without `kid` (§8.4.2) still never counts as verified.

## Tests

- Conformance: injected-unknown-member REJECTED on the received-document path (with the struct-path contrast pinned); unmodeled-member card signed via the same JWS primitive VERIFIES through the JSON path; rotation co-signing verifies under either key; valid signature at index 1 is found; plain-card signature-vs-policy separation.
- `nucleus-verify-commerce`: injected-member credential rejected.
- `verifier-js`: native Rust core tests + node tests for `verifyAgentCardSignature` (plain extension-free fixture, wrong-key, tamper, injected-member, input-error semantics).
- All existing suites (sign_verify, conformance incl. the golden canonical-bytes pin, handshake, verifier-service) pass; **no existing negative test was weakened**.

## Gates

`cargo fmt`, `cargo clippy --all-targets --all-features` (zero warnings, workspace + verifier-js), `cargo test -p nucleus-agent-card -p nucleus-verify-commerce -p nucleus-verifier-service --all-features`, `wasm-pack build sdks/verifier-js --target web --release`, `cargo test` + `npm test` (44/44) in `sdks/verifier-js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)