### PR TITLE
ci: gate examples/a2a-server; add advisory A2A TCK conformance harness

### DIFF
--- a/.github/workflows/a2a-tck.yml
+++ b/.github/workflows/a2a-tck.yml
@@ -33,7 +33,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+
+  # ADVISORY (continue-on-error): the harness currently surfaces four MUST
+  # violations that live in the upstream a2a-server-lf DefaultRequestHandler,
+  # not in this repo's code:
+  #   CORE-ERR-002   malformed request must return an error
+  #   CORE-MULTI-004 missing TaskNotFoundError for unknown task ids
+  #   CORE-SEND-002  SendMessage to a terminal task must error
+  #   CORE-MULTI-006 mismatched contextId must error
+  # The job stays green so the signal is visible without blocking; flip to
+  # blocking once the upstream fixes land and these four pass.
   tck:
+    continue-on-error: true
     name: a2a-tck --level must (jsonrpc + http_json)
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -49,8 +60,9 @@ jobs:
     #     CORE-ERR-002, CORE-MULTI-004, CORE-MULTI-006, CORE-SEND-002
     #   * SDK serialization: DM-SERIAL-003 (timestamps emit "+00:00"; the
     #     TCK requires the "Z" suffix)
-    # Drop continue-on-error once these pass.
-    continue-on-error: true
+    # The run step below is continue-on-error so the JOB (and the PR check)
+    # stays green while the signal lands in the step summary + artifacts;
+    # make the step blocking once these pass.
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1
@@ -82,12 +94,24 @@ jobs:
           persist-credentials: false
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       - name: Run the TCK (MUST level)
+        id: tck
+        continue-on-error: true
         working-directory: a2a-tck
         run: |
           uv venv
           uv pip install -e .
           uv run ./run_tck.py --sut-host http://127.0.0.1:9999 \
             --level must --transport jsonrpc,http_json
+      - name: Surface TCK outcome (advisory)
+        run: |
+          if [ "${{ steps.tck.outcome }}" = "failure" ]; then
+            echo "::warning::a2a-tck MUST level not fully passing (known triage in this workflow's header comment); see the a2a-tck-reports artifact"
+            echo "## a2a-tck: MUST level FAILING (advisory)" >> "$GITHUB_STEP_SUMMARY"
+            echo "Known-failure triage lives in the header comment of this workflow; full report in the a2a-tck-reports artifact." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "## a2a-tck: MUST level PASSING" >> "$GITHUB_STEP_SUMMARY"
+            echo "Make the TCK run step blocking (remove continue-on-error) to lock this in." >> "$GITHUB_STEP_SUMMARY"
+          fi
       - name: Upload conformance reports (JUnit XML + compatibility JSON/HTML)
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a

--- a/.github/workflows/a2a-tck.yml
+++ b/.github/workflows/a2a-tck.yml
@@ -1,0 +1,100 @@
+# External-conformance harness: runs the A2A Technology Compatibility Kit
+# (https://github.com/a2aproject/a2a-tck, pinned) against the example
+# server's transport-conformance target (`tck-target` in
+# examples/a2a-server — same SDK routers and executor as the demo server,
+# without the X-Agent-Card gate the TCK cannot satisfy; the gate keeps its
+# own coverage in the example's e2e suite).
+#
+# Transports: jsonrpc + http_json only — the example does not serve gRPC.
+# Level: --level must (RFC 2119 MUST requirements; the TCK exit code is
+# nonzero on any MUST violation).
+name: A2A TCK
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "examples/a2a-server/**"
+      - "crates/nucleus-agent-card/**"
+      - "crates/nucleus-verify-commerce/**"
+      - "crates/nucleus-envelope/**"
+      - "crates/nucleus-lineage/**"
+      - ".github/workflows/a2a-tck.yml"
+  schedule:
+    # Weekly: the SDK crates resolve from crates.io, so conformance can
+    # drift without any change landing in this repo.
+    - cron: "23 5 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: a2a-tck-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tck:
+    name: a2a-tck --level must (jsonrpc + http_json)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # ADVISORY — the target does not pass --level must yet (79.5% MUST at
+    # a2a-tck@29063fe; full breakdown in the uploaded compatibility report).
+    # Failing requirements by cause:
+    #   * TCK scenario-SUT contract (the demo executor does not implement
+    #     the TCK's canned behaviors: input-required pauses, artifact
+    #     emission, Message-typed replies): CORE-CANCEL-001, CORE-HIST-002,
+    #     CORE-MULTI-005, DM-ART-001, DM-MSG-001, STREAM-ORDER-002,
+    #     STREAM-ORDER-003, STREAM-ORDER-004, STREAM-SUB-001, STREAM-SUB-002
+    #   * SDK (a2a-server-lf DefaultRequestHandler) task semantics:
+    #     CORE-ERR-002, CORE-MULTI-004, CORE-MULTI-006, CORE-SEND-002
+    #   * SDK serialization: DM-SERIAL-003 (timestamps emit "+00:00"; the
+    #     TCK requires the "Z" suffix)
+    # Drop continue-on-error once these pass.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1
+        with:
+          cache: true
+          cache-workspaces: examples/a2a-server
+      - name: Build the transport-conformance target
+        working-directory: examples/a2a-server
+        run: cargo build --bin tck-target
+      - name: Start the target on :9999
+        working-directory: examples/a2a-server
+        run: |
+          ./target/debug/tck-target > tck-target.log 2>&1 &
+          for _ in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:9999/.well-known/agent-card.json > /dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "tck-target did not come up:"
+          cat tck-target.log
+          exit 1
+      - name: Check out the A2A TCK (pinned)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          repository: a2aproject/a2a-tck
+          ref: 29063fe95e903cddac5d8ff811ab94df1ad6ef86
+          path: a2a-tck
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      - name: Run the TCK (MUST level)
+        working-directory: a2a-tck
+        run: |
+          uv venv
+          uv pip install -e .
+          uv run ./run_tck.py --sut-host http://127.0.0.1:9999 \
+            --level must --transport jsonrpc,http_json
+      - name: Upload conformance reports (JUnit XML + compatibility JSON/HTML)
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: a2a-tck-reports
+          path: a2a-tck/reports/
+      - name: Target log
+        if: always()
+        working-directory: examples/a2a-server
+        run: cat tck-target.log

--- a/examples/a2a-server/Cargo.lock
+++ b/examples/a2a-server/Cargo.lock
@@ -1486,6 +1486,8 @@ dependencies = [
  "serde_jcs",
  "serde_json",
  "tokio",
+ "tower",
+ "tower-http",
 ]
 
 [[package]]

--- a/examples/a2a-server/Cargo.toml
+++ b/examples/a2a-server/Cargo.toml
@@ -8,6 +8,10 @@
 name = "nucleus-a2a-server-example"
 version = "0.1.0"
 edition = "2021"
+# Plain `cargo run` stays the gated demo server; the ungated
+# transport-conformance target must be asked for by name
+# (`cargo run --bin tck-target`).
+default-run = "nucleus-a2a-server-example"
 publish = false
 license = "MIT OR Apache-2.0"
 description = "A2A v1.0 server (official Rust SDK) with nucleus card verification and per-response signed receipts"
@@ -16,6 +20,11 @@ description = "A2A v1.0 server (official Rust SDK) with nucleus card verificatio
 a2a = { package = "a2a-lf", version = "0.3" }
 a2a-server = { package = "a2a-server-lf", version = "0.4" }
 axum = "0.8"
+# Trailing-slash normalization: clients that treat the agent card's
+# interface URL as a BASE url (httpx-style join, e.g. the A2A TCK) request
+# `<url>/`; normalize before routing so both spellings hit the binding.
+tower = "0.5"
+tower-http = { version = "0.6", features = ["normalize-path"] }
 http = "1"
 tokio = { version = "1", features = ["full"] }
 futures = "0.3"

--- a/examples/a2a-server/README.md
+++ b/examples/a2a-server/README.md
@@ -44,6 +44,28 @@ cargo test          # unit + e2e: discover → gate (401s) → negotiate → ser
 cargo run           # interactive server on :3000 with a demo caller card
 ```
 
+## External conformance (A2A TCK)
+
+`cargo run --bin tck-target` serves the **same SDK routers and executor
+without the verification gate**, on port 9999. It exists so external
+transport-conformance tooling (the [A2A TCK]) can exercise the protocol
+bindings — the TCK speaks pure A2A and cannot attach the signed
+`X-Agent-Card` header, so the gated server 401s it before any binding is
+reached. It is **not a deployment mode**: the demo server always gates and
+has no flag to disable its gate; the gate itself is covered by `tests/e2e.rs`.
+CI runs the TCK against this target weekly and on changes here (advisory
+`a2a-tck` workflow):
+
+```bash
+cargo run --bin tck-target &
+git clone https://github.com/a2aproject/a2a-tck && cd a2a-tck
+uv venv && uv pip install -e .
+uv run ./run_tck.py --sut-host http://localhost:9999 \
+  --level must --transport jsonrpc,http_json   # no gRPC: not served here
+```
+
+[A2A TCK]: https://github.com/a2aproject/a2a-tck
+
 The e2e suite also pins **shape interop**: a nucleus-signed card
 round-trips through the official SDK's own `AgentCard` type with exactly
 one pinned deviation (the SDK re-serializes `securityRequirements` as the

--- a/examples/a2a-server/src/bin/tck-target.rs
+++ b/examples/a2a-server/src/bin/tck-target.rs
@@ -1,0 +1,48 @@
+//! Transport-conformance target for external A2A tooling.
+//!
+//! ```bash
+//! cd examples/a2a-server && cargo run --bin tck-target
+//! ```
+//!
+//! Serves the SAME official-SDK routers and executor as the demo server
+//! (`cargo run`), but WITHOUT the nucleus verify→serve→receipt gate, on a
+//! fixed port (9999). It exists for exactly one reason: external
+//! transport-conformance tooling — the [A2A TCK] — speaks pure A2A
+//! (§9 JSON-RPC, §11 HTTP+JSON) and has no way to attach the signed
+//! `X-Agent-Card` header the gated server requires, so the gated server
+//! 401s every TCK request before the protocol binding is ever exercised.
+//!
+//! Scope, stated plainly:
+//!
+//! - **This is not a deployment mode.** The demo server always gates and
+//!   has no flag to disable its gate.
+//! - The verification gate and receipt issuance are covered by the e2e
+//!   suite (`tests/e2e.rs`); this binary covers nothing they cover.
+//! - What runs here is the protocol-binding surface only: discovery
+//!   (§8.2 well-known card), JSON-RPC binding, HTTP+JSON binding. gRPC is
+//!   not served — the example does not implement it.
+//!
+//! [A2A TCK]: https://github.com/a2aproject/a2a-tck
+
+use nucleus_a2a_server_example::{
+    build_transport_conformance_app, serve_normalized, ServerIdentity,
+};
+
+/// Fixed port; conformance harnesses point `--sut-host` here.
+const PORT: u16 = 9999;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let base = format!("http://localhost:{PORT}");
+    let identity = ServerIdentity::generate_demo(&base)?;
+
+    println!("A2A transport-conformance target (UNGATED — not a deployment mode)");
+    println!("  card:      {base}/.well-known/agent-card.json");
+    println!("  JSON-RPC:  {base}/jsonrpc");
+    println!("  REST:      {base}/rest");
+
+    let app = build_transport_conformance_app(identity);
+    let listener = tokio::net::TcpListener::bind(("0.0.0.0", PORT)).await?;
+    serve_normalized(listener, app).await?;
+    Ok(())
+}

--- a/examples/a2a-server/src/lib.rs
+++ b/examples/a2a-server/src/lib.rs
@@ -455,12 +455,6 @@ fn sse_issuer(
 /// `caller_verify_jwk` is the public key callers' cards must verify against
 /// — the out-of-band trust decision, made by the operator, not the wire.
 pub fn build_app(identity: ServerIdentity, caller_verify_jwk: JsonWebKey) -> axum::Router {
-    use a2a_server::{DefaultRequestHandler, InMemoryTaskStore};
-
-    let handler = Arc::new(DefaultRequestHandler::new(
-        SummarizeExecutor,
-        InMemoryTaskStore::new(),
-    ));
     let gate = Arc::new(Gate {
         verifier: AgentCardVerifier::new(caller_verify_jwk),
         signer: identity.receipt_signer,
@@ -471,23 +465,52 @@ pub fn build_app(identity: ServerIdentity, caller_verify_jwk: JsonWebKey) -> axu
     // Layer order (outermost first): authenticate (§7.4 says EVERY
     // request) → negotiate A2A-Version (§3.6) → SDK. Responses flow back
     // through the gate, which receipts them — version errors included.
-    let protected = axum::Router::new()
+    let protected =
+        sdk_transport_router().layer(axum::middleware::from_fn_with_state(gate, guard));
+
+    card_route(identity.signed_card).merge(protected)
+}
+
+/// The SAME SDK transports and executor as [`build_app`], but WITHOUT the
+/// verify→serve→receipt gate (and therefore without receipts — receipts
+/// are issued by the gate). A2A-Version negotiation stays on.
+///
+/// This exists solely so external transport-conformance tooling (e.g. the
+/// [A2A TCK](https://github.com/a2aproject/a2a-tck)) can exercise the A2A
+/// protocol bindings (§9 JSON-RPC, §11 HTTP+JSON): such tools speak pure
+/// A2A and cannot present a signed `X-Agent-Card`. The gate itself is
+/// covered by the e2e suite (`tests/e2e.rs`). **This is not a deployment
+/// mode** — the demo server (`cargo run`) always gates, and there is no
+/// flag to disable its gate.
+pub fn build_transport_conformance_app(identity: ServerIdentity) -> axum::Router {
+    card_route(identity.signed_card).merge(sdk_transport_router())
+}
+
+/// Official SDK routers (JSON-RPC + REST) over the demo executor, behind
+/// the `A2A-Version` service-parameter check (§3.6).
+fn sdk_transport_router() -> axum::Router {
+    use a2a_server::{DefaultRequestHandler, InMemoryTaskStore};
+
+    let handler = Arc::new(DefaultRequestHandler::new(
+        SummarizeExecutor,
+        InMemoryTaskStore::new(),
+    ));
+    axum::Router::new()
         .nest(
             "/jsonrpc",
             a2a_server::jsonrpc::jsonrpc_router(handler.clone()),
         )
         .nest("/rest", a2a_server::rest::rest_router(handler))
         .layer(axum::middleware::from_fn(version::negotiate))
-        .layer(axum::middleware::from_fn_with_state(gate, guard));
+}
 
-    let card = identity.signed_card;
-    axum::Router::new()
-        .route(
-            "/.well-known/agent-card.json",
-            axum::routing::get(move || {
-                let card = card.clone();
-                async move { axum::Json(card) }
-            }),
-        )
-        .merge(protected)
+/// The public discovery route: the signed card, served unauthenticated.
+fn card_route(card: serde_json::Value) -> axum::Router {
+    axum::Router::new().route(
+        "/.well-known/agent-card.json",
+        axum::routing::get(move || {
+            let card = card.clone();
+            async move { axum::Json(card) }
+        }),
+    )
 }

--- a/examples/a2a-server/src/lib.rs
+++ b/examples/a2a-server/src/lib.rs
@@ -50,8 +50,8 @@ use ring::signature::{EcdsaKeyPair, KeyPair, ECDSA_P256_SHA256_FIXED_SIGNING};
 
 use nucleus_agent_card::{
     sign_card, AgentCapabilities, AgentCard, AgentExtension, AgentInterface, AgentSkill,
-    EnforcementRule, JsonWebKey, NucleusClaims, RuntimeGuaranteeProfile, SecurityRequirement,
-    StringList, A2A_PROTOCOL_VERSION,
+    ApiKeySecurityScheme, EnforcementRule, JsonWebKey, NucleusClaims, RuntimeGuaranteeProfile,
+    SecurityRequirement, SecurityScheme, StringList, A2A_PROTOCOL_VERSION,
 };
 use nucleus_lineage::{CallSpiffeId, Jwks, LocalIssuer};
 use nucleus_verify_commerce::{
@@ -122,22 +122,18 @@ impl ServerIdentity {
             .map_err(|e| anyhow::anyhow!("session root: {e}"))?;
 
         // §7.3 step 1: DECLARE the authentication the gate enforces, so a
-        // client that only reads the card knows where the credential goes.
-        // `security_schemes` is an opaque ProtoJSON map for now (a typed
-        // model is coming separately), so the proto's
-        // `APIKeySecurityScheme` oneof variant is built as raw JSON here:
-        // oneof key `apiKeySecurityScheme`, fields per `a2a.proto`.
-        let mut security_schemes = serde_json::Map::new();
+        // client that only reads the card knows where the credential goes —
+        // the proto's `APIKeySecurityScheme` oneof variant, typed.
+        let mut security_schemes = std::collections::BTreeMap::new();
         security_schemes.insert(
             SECURITY_SCHEME_NAME.to_string(),
-            serde_json::json!({
-                "apiKeySecurityScheme": {
-                    "description": "The value is the caller's SIGNED A2A v1.0 AgentCard JSON \
-                                    (detached JWS per §8.4). It is verified against a key the \
-                                    operator resolved out-of-band — never the card's own material.",
-                    "location": "header",
-                    "name": "X-Agent-Card",
-                }
+            SecurityScheme::ApiKey(ApiKeySecurityScheme {
+                description: "The value is the caller's SIGNED A2A v1.0 AgentCard JSON \
+                              (detached JWS per §8.4). It is verified against a key the \
+                              operator resolved out-of-band — never the card's own material."
+                    .to_string(),
+                location: "header".to_string(),
+                name: "X-Agent-Card".to_string(),
             }),
         );
         // The matching requirement (§7.3): this scheme on every request.
@@ -465,15 +461,19 @@ pub fn build_app(identity: ServerIdentity, caller_verify_jwk: JsonWebKey) -> axu
     // Layer order (outermost first): authenticate (§7.4 says EVERY
     // request) → negotiate A2A-Version (§3.6) → SDK. Responses flow back
     // through the gate, which receipts them — version errors included.
-    let protected =
-        sdk_transport_router().layer(axum::middleware::from_fn_with_state(gate, guard));
+    let protected = sdk_transport_router()
+        .layer(axum::middleware::from_fn(version::negotiate))
+        .layer(axum::middleware::from_fn_with_state(gate, guard));
 
     card_route(identity.signed_card).merge(protected)
 }
 
 /// The SAME SDK transports and executor as [`build_app`], but WITHOUT the
 /// verify→serve→receipt gate (and therefore without receipts — receipts
-/// are issued by the gate). A2A-Version negotiation stays on.
+/// are issued by the gate), and WITHOUT §3.6 version negotiation — the
+/// TCK does not send the `A2A-Version` header, and a §3.6.1-strict server
+/// would -32009 every TCK request. Strict negotiation is enforced by the
+/// real server ([`build_app`]) and pinned by the e2e negative tests.
 ///
 /// This exists solely so external transport-conformance tooling (e.g. the
 /// [A2A TCK](https://github.com/a2aproject/a2a-tck)) can exercise the A2A
@@ -483,11 +483,84 @@ pub fn build_app(identity: ServerIdentity, caller_verify_jwk: JsonWebKey) -> axu
 /// mode** — the demo server (`cargo run`) always gates, and there is no
 /// flag to disable its gate.
 pub fn build_transport_conformance_app(identity: ServerIdentity) -> axum::Router {
-    card_route(identity.signed_card).merge(sdk_transport_router())
+    card_route(identity.signed_card)
+        .merge(sdk_transport_router().layer(axum::middleware::from_fn(conformance_version_check)))
 }
 
-/// Official SDK routers (JSON-RPC + REST) over the demo executor, behind
-/// the `A2A-Version` service-parameter check (§3.6).
+/// Reject requests whose `A2A-Version` service parameter names a version
+/// this interface does not serve.
+///
+/// §3.6.2: "Agents MUST process requests using the semantics of the
+/// requested `A2A-Version` (matching `Major.Minor`). If the version is not
+/// supported by the interface, agents MUST return a
+/// `VersionNotSupportedError`." Both declared interfaces here are v1.0, so
+/// anything other than `1.0` is rejected with the §5.4 mapping:
+/// JSON-RPC code `-32009`, HTTP+JSON `400` / `FAILED_PRECONDITION`.
+///
+/// The parameter travels as the `A2A-Version` header, or — clients MAY,
+/// §3.6.1 — as an `A2A-Version` query parameter.
+///
+/// CONFORMANCE-TARGET DEVIATION from §3.6.1: requests with NO version
+/// parameter are SERVED rather than treated as 0.3-and-rejected — the A2A
+/// TCK does not send the header, and rejecting absence would -32009 every
+/// TCK request. The real server (`build_app` → `version::negotiate`) is
+/// strict; its behavior is pinned by the e2e negative tests.
+async fn conformance_version_check(req: Request, next: Next) -> Response {
+    let requested = req
+        .headers()
+        .get("a2a-version")
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_owned)
+        .or_else(|| {
+            req.uri().query().and_then(|q| {
+                q.split('&')
+                    .find_map(|kv| kv.strip_prefix("A2A-Version=").map(str::to_owned))
+            })
+        });
+    let Some(requested) = requested else {
+        return next.run(req).await;
+    };
+    if requested.trim() == nucleus_agent_card::A2A_PROTOCOL_VERSION {
+        return next.run(req).await;
+    }
+
+    let message = format!(
+        "A2A-Version {requested} is not supported by this interface (supported: {})",
+        nucleus_agent_card::A2A_PROTOCOL_VERSION
+    );
+    if req.uri().path().starts_with("/jsonrpc") {
+        // JSON-RPC envelope error; echo the request id when the body is
+        // parseable, else null (the request was never dispatched).
+        let id = axum::body::to_bytes(req.into_body(), RECEIPT_BODY_LIMIT)
+            .await
+            .ok()
+            .and_then(|b| serde_json::from_slice::<serde_json::Value>(&b).ok())
+            .and_then(|v| v.get("id").cloned())
+            .unwrap_or(serde_json::Value::Null);
+        axum::Json(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "error": { "code": -32009, "message": message }
+        }))
+        .into_response()
+    } else {
+        // HTTP+JSON: AIP-193 error shape.
+        (
+            StatusCode::BAD_REQUEST,
+            axum::Json(serde_json::json!({
+                "error": {
+                    "code": 400,
+                    "status": "FAILED_PRECONDITION",
+                    "message": message,
+                }
+            })),
+        )
+            .into_response()
+    }
+}
+
+/// Official SDK routers (JSON-RPC + REST) over the demo executor. Version
+/// negotiation and the gate are layered by the callers.
 fn sdk_transport_router() -> axum::Router {
     use a2a_server::{DefaultRequestHandler, InMemoryTaskStore};
 
@@ -501,7 +574,24 @@ fn sdk_transport_router() -> axum::Router {
             a2a_server::jsonrpc::jsonrpc_router(handler.clone()),
         )
         .nest("/rest", a2a_server::rest::rest_router(handler))
-        .layer(axum::middleware::from_fn(version::negotiate))
+}
+
+/// Serve `router` on `listener`, normalizing trailing slashes BEFORE
+/// routing so `<interface-url>/` reaches the binding too. Clients that
+/// treat the agent card's interface URL as a *base* URL (httpx-style RFC
+/// 3986 joins — the A2A TCK, the official Python client) request the
+/// trailing-slash spelling; without normalization those requests 404
+/// before any A2A handler runs.
+pub async fn serve_normalized(
+    listener: tokio::net::TcpListener,
+    router: axum::Router,
+) -> std::io::Result<()> {
+    use axum::ServiceExt;
+    use tower::Layer as _;
+    use tower_http::normalize_path::NormalizePathLayer;
+
+    let app = NormalizePathLayer::trim_trailing_slash().layer(router);
+    axum::serve(listener, ServiceExt::<Request>::into_make_service(app)).await
 }
 
 /// The public discovery route: the signed card, served unauthenticated.

--- a/examples/a2a-server/src/main.rs
+++ b/examples/a2a-server/src/main.rs
@@ -23,7 +23,7 @@ use base64::Engine as _;
 use ring::rand::SystemRandom;
 use ring::signature::{EcdsaKeyPair, KeyPair, ECDSA_P256_SHA256_FIXED_SIGNING};
 
-use nucleus_a2a_server_example::{build_app, ServerIdentity};
+use nucleus_a2a_server_example::{build_app, serve_normalized, ServerIdentity};
 use nucleus_agent_card::{
     sign_card, AgentCapabilities, AgentCard, AgentInterface, JsonWebKey, NucleusClaims,
     A2A_PROTOCOL_VERSION,
@@ -53,7 +53,7 @@ async fn main() -> anyhow::Result<()> {
 
     let app = build_app(identity, caller_verify_jwk);
     let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await?;
-    axum::serve(listener, app).await?;
+    serve_normalized(listener, app).await?;
     Ok(())
 }
 

--- a/examples/a2a-server/src/main.rs
+++ b/examples/a2a-server/src/main.rs
@@ -85,7 +85,7 @@ fn demo_caller() -> anyhow::Result<(String, JsonWebKey)> {
         version: "0.0.1".to_string(),
         documentation_url: None,
         capabilities: AgentCapabilities::default(),
-        security_schemes: serde_json::Map::new(),
+        security_schemes: std::collections::BTreeMap::new(),
         security_requirements: vec![],
         default_input_modes: vec!["text/plain".to_string()],
         default_output_modes: vec!["text/plain".to_string()],

--- a/examples/a2a-server/tests/e2e.rs
+++ b/examples/a2a-server/tests/e2e.rs
@@ -59,7 +59,7 @@ fn caller() -> Caller {
         version: "0.0.1".to_string(),
         documentation_url: None,
         capabilities: AgentCapabilities::default(),
-        security_schemes: serde_json::Map::new(),
+        security_schemes: std::collections::BTreeMap::new(),
         security_requirements: vec![],
         default_input_modes: vec!["text/plain".to_string()],
         default_output_modes: vec!["text/plain".to_string()],

--- a/examples/a2a-server/tests/tck_target.rs
+++ b/examples/a2a-server/tests/tck_target.rs
@@ -1,0 +1,133 @@
+//! Pins the scope of the transport-conformance app (`tck-target`): the SDK
+//! bindings answer WITHOUT the gate header, and — because the gate is what
+//! issues receipts — no receipt header appears. The gated path keeps its own
+//! coverage in `e2e.rs`; nothing here weakens it.
+
+use nucleus_a2a_server_example::{
+    build_transport_conformance_app, serve_normalized, ServerIdentity, RECEIPT_HEADER,
+};
+
+async fn spawn() -> String {
+    let identity = ServerIdentity::generate_demo("http://test.invalid").unwrap();
+    let app = build_transport_conformance_app(identity);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move { serve_normalized(listener, app).await.unwrap() });
+    format!("http://{addr}")
+}
+
+#[tokio::test]
+async fn serves_bindings_without_gate_and_without_receipts() {
+    let base = spawn().await;
+    let http = reqwest::Client::new();
+
+    // Discovery is identical to the gated server: the signed card.
+    let card: serde_json::Value = http
+        .get(format!("{base}/.well-known/agent-card.json"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert!(
+        card["signatures"].as_array().is_some_and(|s| !s.is_empty()),
+        "card stays signed even on the conformance target"
+    );
+
+    // JSON-RPC binding answers with NO X-Agent-Card header — at the
+    // trailing-slash spelling that base-URL-joining clients (httpx: the
+    // A2A TCK, the official Python client) actually request...
+    let resp = http
+        .post(format!("{base}/jsonrpc/"))
+        .json(&serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "SendMessage",
+            "params": {
+                "message": {
+                    "role": "ROLE_USER",
+                    "messageId": "tck-m1",
+                    "parts": [{ "text": "Agents need receipts. Trust needs proofs." }]
+                }
+            }
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200, "no gate on the conformance target");
+
+    // ...and therefore carries NO receipt: receipts are issued by the gate,
+    // and this target must not look like it provides them.
+    assert!(
+        resp.headers().get(RECEIPT_HEADER).is_none(),
+        "ungated target must not emit receipt headers"
+    );
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(
+        body["result"]["task"]["status"]["state"], "TASK_STATE_COMPLETED",
+        "{body}"
+    );
+}
+
+/// §3.6.2: an unsupported `A2A-Version` MUST be rejected with
+/// `VersionNotSupportedError`, mapped per §5.4 — JSON-RPC `-32009`,
+/// HTTP+JSON `400`/`FAILED_PRECONDITION`. A supported version is served.
+#[tokio::test]
+async fn unsupported_a2a_version_is_rejected_per_binding() {
+    let base = spawn().await;
+    let http = reqwest::Client::new();
+    let send = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 7,
+        "method": "SendMessage",
+        "params": {
+            "message": {
+                "role": "ROLE_USER",
+                "messageId": "ver-m1",
+                "parts": [{ "text": "version check" }]
+            }
+        }
+    });
+
+    // JSON-RPC: error envelope, code -32009, id echoed.
+    let resp = http
+        .post(format!("{base}/jsonrpc"))
+        .header("A2A-Version", "99.0")
+        .json(&send)
+        .send()
+        .await
+        .unwrap();
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["error"]["code"], -32009, "{body}");
+    assert_eq!(body["id"], 7, "request id echoed: {body}");
+
+    // HTTP+JSON: 400 with an AIP-193 error object.
+    let resp = http
+        .post(format!("{base}/rest/message:send"))
+        .header("A2A-Version", "99.0")
+        .json(&serde_json::json!({
+            "message": {
+                "role": "ROLE_USER",
+                "messageId": "ver-m2",
+                "parts": [{ "text": "version check" }]
+            }
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["error"]["status"], "FAILED_PRECONDITION", "{body}");
+
+    // The supported version is served normally (header present and valid).
+    let resp = http
+        .post(format!("{base}/jsonrpc"))
+        .header("A2A-Version", "1.0")
+        .json(&send)
+        .send()
+        .await
+        .unwrap();
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert!(body.get("error").is_none(), "{body}");
+}


### PR DESCRIPTION
Two CI additions for the A2A example server (#1851), which today is built and tested by no workflow (it is workspace-excluded, like sdks/verifier-js — this mirrors that pattern):

1. **ci.yml job**: fmt-check + clippy + `cargo test` inside `examples/a2a-server`, triggered when the example or its path-dependencies (nucleus-agent-card, nucleus-verify-commerce, nucleus-envelope, nucleus-lineage) change. This puts the e2e suite — including the official-SDK shape round-trip — behind CI for the first time.

2. **Advisory TCK workflow** (`a2a-tck.yml`, deliberately not a required context): builds the example, starts the transport-conformance target, and runs the official `a2a-tck` (pinned ref, `--level must`, jsonrpc + http_json) with the junit report uploaded as an artifact. The conformance target is a separate, documented test binary that mounts the same SDK routers without the verification gate — it exists because the TCK cannot present a signed caller card; the gate itself is covered by the e2e suite. It is not a deployment mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)