### PR TITLE
feat(bundle-cas): extract generic artifact CAS (publish_bytes/fetch_bytes)

### DIFF
--- a/crates/nucleus-bundle-cas/src/fetch.rs
+++ b/crates/nucleus-bundle-cas/src/fetch.rs
@@ -18,6 +18,25 @@ use nucleus_envelope::Bundle;
 
 use crate::BundleHash;
 
+/// Errors from [`fetch_bytes`] (generic artifact fetching).
+#[derive(Debug, thiserror::Error)]
+pub enum FetchBytesError {
+    /// Could not open a QUIC connection to the peer (offline, wrong addr,
+    /// ALPN refused, …). An availability failure, NOT a content failure.
+    #[error("connecting to peer over iroh: {0}")]
+    Connect(#[source] anyhow::Error),
+    /// The bao-verified get stream failed. The load-bearing case: the peer
+    /// served bytes that do NOT hash to the requested [`BundleHash`], so
+    /// verification rejected them. Also covers truncated/corrupted streams.
+    /// A peer CANNOT substitute content under this error.
+    #[error("bao-verified fetch failed (content mismatch, truncation, or transport error): {0}")]
+    Get(#[source] anyhow::Error),
+    /// The verified bytes were retrieved but are not present locally after the
+    /// get (should not happen on success).
+    #[error("reading fetched bytes from store: {0}")]
+    Read(#[source] anyhow::Error),
+}
+
 /// Errors from [`fetch_bundle`].
 #[derive(Debug, thiserror::Error)]
 pub enum FetchError {
@@ -42,19 +61,27 @@ pub enum FetchError {
     Deserialize(#[source] serde_json::Error),
 }
 
-/// Connect to `node_addr` (an [`EndpointAddr`] obtained out-of-band — iroh's
-/// "node ticket"), fetch the blob identified by `hash` over a bao-verified
-/// iroh-blobs stream into `store`, and deserialize it to a [`Bundle`].
+/// Fetch a blob identified by `hash` from `node_addr` over a bao-verified
+/// iroh-blobs stream into `store`, returning the verified bytes.
+///
+/// The transfer rides iroh-blobs' bao-verified get stream: the requested
+/// [`BundleHash`] is the verification root, so a peer serving bytes whose
+/// BLAKE3 root is not exactly that hash causes the fetch to FAIL. A peer
+/// cannot substitute content.
 ///
 /// On success the returned bytes are guaranteed to BLAKE3-hash to exactly
-/// `hash` (the bao stream enforces it). This is byte-integrity ONLY — run
-/// [`nucleus_envelope::verify_bundle`] afterwards for provenance.
-pub async fn fetch_bundle(
+/// `hash` (the bao stream enforces it). This is byte-integrity ONLY — the
+/// caller must validate the contents (e.g., deserialize and verify provenance).
+/// fetched != trusted.
+///
+/// This is the generic artifact layer; [`fetch_bundle`] is a thin caller that
+/// calls this and deserializes to a [`Bundle`].
+pub async fn fetch_bytes(
     endpoint: &Endpoint,
     store: &MemStore,
     node_addr: EndpointAddr,
     hash: BundleHash,
-) -> Result<Bundle, FetchError> {
+) -> Result<Vec<u8>, FetchBytesError> {
     let iroh_hash: iroh_blobs::Hash = hash.into();
 
     // Out-of-band addressing: connect directly using the supplied NodeAddr
@@ -62,7 +89,7 @@ pub async fn fetch_bundle(
     let conn = endpoint
         .connect(node_addr, iroh_blobs::ALPN)
         .await
-        .map_err(|e| FetchError::Connect(e.into()))?;
+        .map_err(|e| FetchBytesError::Connect(e.into()))?;
 
     // Bao-verified get: `hash` is the verification root. Anything that does
     // not reproduce this BLAKE3 root is rejected before it reaches us.
@@ -70,13 +97,40 @@ pub async fn fetch_bundle(
         .remote()
         .fetch(conn, iroh_hash)
         .await
-        .map_err(|e| FetchError::Get(e.into()))?;
+        .map_err(|e| FetchBytesError::Get(e.into()))?;
 
     // The verified bytes now live in `store`; read them back.
     let bytes = store
         .get_bytes(iroh_hash)
         .await
-        .map_err(|e| FetchError::Read(e.into()))?;
+        .map_err(|e| FetchBytesError::Read(e.into()))?;
+
+    Ok(bytes.to_vec())
+}
+
+/// Connect to `node_addr` (an [`EndpointAddr`] obtained out-of-band — iroh's
+/// "node ticket"), fetch the blob identified by `hash` over a bao-verified
+/// iroh-blobs stream into `store`, and deserialize it to a [`Bundle`].
+///
+/// On success the returned bytes are guaranteed to BLAKE3-hash to exactly
+/// `hash` (the bao stream enforces it). This is byte-integrity ONLY — run
+/// [`nucleus_envelope::verify_bundle`] afterwards for provenance.
+///
+/// Internally calls [`fetch_bytes`] and maps its errors back to [`FetchError`]
+/// for backward compatibility.
+pub async fn fetch_bundle(
+    endpoint: &Endpoint,
+    store: &MemStore,
+    node_addr: EndpointAddr,
+    hash: BundleHash,
+) -> Result<Bundle, FetchError> {
+    let bytes = fetch_bytes(endpoint, store, node_addr, hash)
+        .await
+        .map_err(|e| match e {
+            FetchBytesError::Connect(err) => FetchError::Connect(err),
+            FetchBytesError::Get(err) => FetchError::Get(err),
+            FetchBytesError::Read(err) => FetchError::Read(err),
+        })?;
 
     serde_json::from_slice(&bytes).map_err(FetchError::Deserialize)
 }

--- a/crates/nucleus-bundle-cas/src/hash.rs
+++ b/crates/nucleus-bundle-cas/src/hash.rs
@@ -46,7 +46,22 @@ use crate::BundleHash;
 /// case as an empty input rather than panicking.
 pub fn blake3_bundle_hash(bundle: &Bundle) -> BundleHash {
     let bytes = serde_json::to_vec(bundle).unwrap_or_default();
-    let digest = blake3::hash(&bytes);
+    // Delegate to the generic byte hasher: the bundle path is just one caller
+    // of the generic artifact CAS. No algorithm change.
+    blake3_hash(&bytes)
+}
+
+/// Compute the BLAKE3-256 digest of arbitrary bytes (transport addressing only).
+///
+/// This is the low-level hash shared by [`blake3_bundle_hash`] and the generic
+/// [`crate::publish::publish_bytes`]. Deterministic: the same bytes always
+/// yield the same hash, and a single-byte change changes the hash.
+///
+/// Like [`blake3_bundle_hash`], the result is a bare BLAKE3-256 digest — a
+/// TRANSPORT id, **NOT** [`nucleus_envelope::canonical_bundle_hash`] (SHA-256
+/// over selected fields) and **NOT** a CID.
+pub fn blake3_hash(data: &[u8]) -> BundleHash {
+    let digest = blake3::hash(data);
     BundleHash(*digest.as_bytes())
 }
 
@@ -108,5 +123,54 @@ mod tests {
         let transport = blake3_bundle_hash(&b);
         let canonical = nucleus_envelope::canonical_bundle_hash(&b);
         assert_ne!(transport.as_bytes(), &canonical);
+    }
+
+    #[test]
+    fn three_distinct_ids_invariant_blake3_vs_sha256() {
+        // Load-bearing invariant: BLAKE3-256 (transport) and SHA-256
+        // (canonical) are computed independently via distinct algorithms and
+        // never conflated. This encodes the "three distinct ids" discipline:
+        //   1. BLAKE3-256 transport hash (over the FULL serialized bytes, here)
+        //   2. SHA-256 canonical hash (over selected fields, nucleus-envelope)
+        //   3. No CID (no multihash/multicodec/multibase framing)
+        //
+        // Consequence: if either algorithm is mutated or wrongly shared, this
+        // test catches the divergence. Byte-integrity != provenance.
+        let bundle = fixture_bundle("three_ids");
+
+        // (1) BLAKE3 transport hash over the full serialized bytes.
+        let transport_blake3 = blake3_bundle_hash(&bundle);
+
+        // (2) SHA-256 canonical hash over selected fields (excludes attestation).
+        let canonical_sha256 = nucleus_envelope::canonical_bundle_hash(&bundle);
+
+        // Independently computed => the byte sequences differ.
+        assert_ne!(
+            transport_blake3.as_bytes().as_slice(),
+            canonical_sha256.as_slice(),
+            "BLAKE3 transport hash (full bytes) must differ from \
+             SHA-256 canonical hash (selected fields)"
+        );
+
+        // Both are 32 bytes, but from different algorithms over different inputs.
+        assert_eq!(transport_blake3.as_bytes().len(), 32);
+        assert_eq!(canonical_sha256.len(), 32);
+
+        // (3) BundleHash is NOT a CID — no multihash, multicodec, or multibase.
+        let hex = transport_blake3.to_hex();
+        assert_eq!(hex.len(), 64, "raw 32-byte BLAKE3 -> 64 hex chars");
+        assert!(
+            !hex.starts_with('z'),
+            "BundleHash must not be multibase-encoded"
+        );
+    }
+
+    #[test]
+    fn blake3_hash_matches_bundle_hash_over_same_bytes() {
+        // The generic byte hasher and the bundle hasher agree byte-for-byte
+        // (the bundle path is a thin caller). No algorithm divergence.
+        let b = fixture_bundle("hi");
+        let bytes = serde_json::to_vec(&b).unwrap();
+        assert_eq!(blake3_hash(&bytes), blake3_bundle_hash(&b));
     }
 }

--- a/crates/nucleus-bundle-cas/src/lib.rs
+++ b/crates/nucleus-bundle-cas/src/lib.rs
@@ -81,9 +81,9 @@ pub mod fetch;
 pub mod hash;
 pub mod publish;
 
-pub use fetch::{fetch_bundle, FetchError};
-pub use hash::blake3_bundle_hash;
-pub use publish::{publish_bundle, PublishError};
+pub use fetch::{fetch_bundle, fetch_bytes, FetchBytesError, FetchError};
+pub use hash::{blake3_bundle_hash, blake3_hash};
+pub use publish::{publish_bundle, publish_bytes, PublishBytesError, PublishError};
 
 /// Length, in bytes, of a [`BundleHash`] (BLAKE3-256 digest).
 pub const BUNDLE_HASH_LEN: usize = 32;

--- a/crates/nucleus-bundle-cas/src/publish.rs
+++ b/crates/nucleus-bundle-cas/src/publish.rs
@@ -10,6 +10,25 @@ use nucleus_envelope::Bundle;
 
 use crate::{blake3_bundle_hash, BundleHash};
 
+/// Errors from [`publish_bytes`] (generic artifact publishing).
+#[derive(Debug, thiserror::Error)]
+pub enum PublishBytesError {
+    /// The iroh-blobs store rejected the add.
+    #[error("iroh-blobs add_bytes failed: {0}")]
+    Store(#[source] anyhow::Error),
+    /// The store hashed the bytes with a different BLAKE3 root than we computed
+    /// locally. This should be impossible (both use BLAKE3-256 over the same
+    /// bytes) — surfaced loudly so a future hashing divergence fails closed
+    /// instead of silently shipping a wrong id.
+    #[error("store hash {store} != locally-computed blake3 hash {local}")]
+    HashMismatch {
+        /// Hash reported by iroh-blobs.
+        store: BundleHash,
+        /// Hash we computed via [`crate::blake3_hash`].
+        local: BundleHash,
+    },
+}
+
 /// Errors from [`publish_bundle`].
 #[derive(Debug, thiserror::Error)]
 pub enum PublishError {
@@ -32,27 +51,58 @@ pub enum PublishError {
     },
 }
 
+/// Publish arbitrary bytes to `store`, returning their BLAKE3-256 transport
+/// hash.
+///
+/// The bytes are hashed locally via [`crate::blake3_hash`], added to the store,
+/// and the store's returned hash is validated against the local hash to fail
+/// closed on divergence. The returned hash satisfies [`crate::blake3_hash`] of
+/// the same bytes.
+///
+/// This is the generic artifact layer; [`publish_bundle`] is a thin caller that
+/// serializes a [`Bundle`] then calls this. Like the bundle path, this is
+/// transport addressing only — byte-integrity, NOT provenance.
+pub async fn publish_bytes(
+    store: &MemStore,
+    bytes: &[u8],
+) -> Result<BundleHash, PublishBytesError> {
+    let local = crate::hash::blake3_hash(bytes);
+
+    let tag = store
+        .add_bytes(bytes.to_vec())
+        .await
+        .map_err(|e| PublishBytesError::Store(e.into()))?;
+    let store_hash: BundleHash = tag.hash.into();
+
+    if store_hash != local {
+        return Err(PublishBytesError::HashMismatch {
+            store: store_hash,
+            local,
+        });
+    }
+    Ok(local)
+}
+
 /// Serialize `bundle` to JSON, add it to `store`, and return its
 /// [`BundleHash`] (BLAKE3-256 root).
 ///
 /// The returned hash equals [`blake3_bundle_hash`] of the same bundle; we
 /// assert this against the store's own computed hash to fail closed on any
 /// divergence.
+///
+/// Internally calls [`publish_bytes`] and maps its errors back to
+/// [`PublishError`] for backward compatibility.
 pub async fn publish_bundle(store: &MemStore, bundle: &Bundle) -> Result<BundleHash, PublishError> {
     let bytes = serde_json::to_vec(bundle).map_err(PublishError::Serialize)?;
-    let local = blake3_bundle_hash(bundle);
 
-    let tag = store
-        .add_bytes(bytes)
-        .await
-        .map_err(|e| PublishError::Store(e.into()))?;
-    let store_hash: BundleHash = tag.hash.into();
+    // Defensive consistency check: the bundle hasher and the generic byte
+    // hasher must agree over the same bytes (they share `blake3_hash`).
+    debug_assert_eq!(crate::hash::blake3_hash(&bytes), blake3_bundle_hash(bundle));
 
-    if store_hash != local {
-        return Err(PublishError::HashMismatch {
-            store: store_hash,
-            local,
-        });
-    }
-    Ok(local)
+    publish_bytes(store, &bytes).await.map_err(|e| match e {
+        PublishBytesError::Store(err) => PublishError::Store(err),
+        PublishBytesError::HashMismatch { store, local } => {
+            PublishError::HashMismatch { store, local }
+        }
+    })
 }


### PR DESCRIPTION
## Summary

Extracts the bundle-specific iroh-blobs transport in `nucleus-bundle-cas` into a **generic, byte-level content-addressed store**, so future artifact kinds (attestations, metadata, …) can reuse the bao-verified path. This is a **fully additive, non-breaking refactor** of working code — no new iroh-blobs API, no dep bumps.

### New generic layer
- `hash::blake3_hash(&[u8]) -> BundleHash` — low-level BLAKE3-256 over arbitrary bytes. `blake3_bundle_hash` now delegates to it (no algorithm change).
- `publish::publish_bytes(store, &[u8]) -> Result<BundleHash, PublishBytesError>` — add arbitrary bytes, validate the store's returned hash against the locally-computed one (fail closed on divergence).
- `fetch::fetch_bytes(endpoint, store, node_addr, hash) -> Result<Vec<u8>, FetchBytesError>` — bao-verified get of arbitrary bytes.

### Existing bundle path is now a thin caller
- `publish_bundle` serializes the `Bundle` then calls `publish_bytes`, mapping errors back to `PublishError`.
- `fetch_bundle` calls `fetch_bytes` then deserializes, mapping errors back to `FetchError`.
- Signatures, error types, and observable behavior of `publish_bundle` / `fetch_bundle` are **unchanged**.

## Load-bearing invariants preserved

- **THREE distinct ids, never conflated** — BLAKE3-256 transport hash (over the full serialized bytes) vs SHA-256 canonical hash (over selected fields, `nucleus_envelope::canonical_bundle_hash`, excludes attestation) vs **NO CID** (bare 32-byte digest, no multihash/multicodec/multibase). New test `three_distinct_ids_invariant_blake3_vs_sha256` pins all three; `blake3_hash_matches_bundle_hash_over_same_bytes` pins that the generic and bundle hashers agree byte-for-byte (so the extraction introduced no divergence).
- **fetched != trusted** — the generic functions guarantee byte-integrity only; provenance still comes from a later `verify_bundle` against an out-of-band trust anchor. Docs reiterate this on `fetch_bytes`.
- **All data real** — `blake3_hash` is the real BLAKE3 of the real bytes; no stubs/placeholders.
- **No overclaiming** — the crate's existing scoping (no discovery / no NAT traversal in this slice / native-only / metering seam dormant) is untouched.

## Build / verification note

Not built locally (iroh-blobs is heavy; this box has an OOM hazard) — relying on CI, which compiles iroh-blobs and runs the crate's tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)