### PR TITLE
feat(node-binding): signed NodeId <-> passport principal binding (iroh transport #4, slice 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6894,6 +6894,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "nucleus-node-binding"
+version = "1.0.0"
+dependencies = [
+ "ed25519-dalek 3.0.0-pre.7",
+ "hex",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "nucleus-oidc-core"
 version = "1.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ members = [
     "crates/nucleus-verifier-service",   # Public verifier-as-a-service for provenance bundles
     "crates/nucleus-witness",            # C2SP tlog-witness server: mints cosignatures with the spec status matrix
     "crates/nucleus-witness-gossip",     # Slice 1: best-effort gossip message layer + fail-closed head verification (no iroh; transport is slice 2)
+    "crates/nucleus-node-binding",       # Signed transport-identity binding (NodeId <-> passport principal); domain-separated ed25519, no iroh (conversions are a later slice)
     "crates/nucleus-oidc-provider",      # OIDC OP: JWT-SVID issuance + RFC 8693 token exchange
     "crates/nucleus-oidc-core",          # Provider-agnostic OIDC primitives (JWKS, JtiCache, federation)
     "crates/nucleus-fly-oidc",           # Per-provider validator: Fly.io machine OIDC → SPIFFE

--- a/crates/nucleus-node-binding/Cargo.toml
+++ b/crates/nucleus-node-binding/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "nucleus-node-binding"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "Signed binding layer unifying an agent's transport identity (NodeId) with its passport principal — domain-separated ed25519 verification, pure and iroh-free"
+repository = "https://github.com/coproduct-opensource/nucleus"
+keywords = ["node-binding", "identity", "ed25519", "transport", "cryptography"]
+categories = ["cryptography"]
+
+[dependencies]
+serde = { workspace = true }
+ed25519-dalek = { workspace = true }
+hex = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/crates/nucleus-node-binding/README.md
+++ b/crates/nucleus-node-binding/README.md
@@ -1,0 +1,60 @@
+# nucleus-node-binding
+
+A signed binding layer that unifies an agent's **transport identity** — an
+iroh `NodeId`, i.e. a 32-byte ed25519 transport public key — with its
+**passport principal**, so you can *dial an agent by its proven identity*.
+
+This is the pure binding slice of the iroh trust-fabric transport RFC
+(integration #4). It deliberately has **no iroh dependency**: the
+`NodeId <-> [u8; 32]` conversions are a later, feature-gated slice.
+
+## What a binding asserts (and what it does not)
+
+A `NodeBinding` asserts exactly:
+
+> **"this passport controls this transport key"**
+
+It does **not** assert that the agent is well-behaved, attested, sandboxed, or
+otherwise trustworthy. Possessing a `NodeId` only proves control of a
+transport key. Binding it to a passport principal requires a *signed
+statement* — the passport key vouches for the `NodeId`. Co-location or
+self-assertion is not enough. Attested capabilities/behaviour live in other
+layers and are out of scope here.
+
+## Invariants
+
+- **Fail-closed.** A forged, tampered, unsigned, or wrong-key binding verifies
+  to `Err(..)` and contributes no trust.
+- **No key smuggling.** Verification trusts a passport public key the
+  **caller** supplies (keyed by the principal in their own identity system).
+  The binding carries no passport public key that verification trusts.
+- **Domain separation.** The signed bytes are prefixed with
+  `nucleus-node-binding/v1\n:`, so a passport signature minted for another
+  purpose cannot be replayed as a node binding, and vice versa.
+- **Pure.** Depends only on `ed25519-dalek` (workspace-pinned) plus
+  `serde`/`hex`/`thiserror`. No iroh / iroh-gossip / QUIC.
+
+## Usage
+
+```rust
+use ed25519_dalek::SigningKey;
+use nucleus_node_binding::{sign_binding, verify_binding};
+
+let passport_sk = SigningKey::from_bytes(&[7u8; 32]);
+let passport_pk = passport_sk.verifying_key().to_bytes();
+let node_id = [42u8; 32]; // an iroh NodeId is exactly these 32 bytes
+
+let binding = sign_binding(&node_id, "spiffe://example/agent-x", &passport_sk);
+
+// A verifier that already trusts `passport_pk` (keyed by the principal in its
+// own system) confirms the passport vouches for this transport key.
+verify_binding(&binding, &passport_pk).expect("binding verifies");
+```
+
+## Test
+
+```bash
+cargo test -p nucleus-node-binding
+```
+
+Licensed under MIT OR Apache-2.0.

--- a/crates/nucleus-node-binding/src/lib.rs
+++ b/crates/nucleus-node-binding/src/lib.rs
@@ -1,0 +1,335 @@
+//! # nucleus-node-binding
+//!
+//! A signed binding layer that unifies an agent's **transport identity**
+//! (an iroh `NodeId`, i.e. a 32-byte ed25519 transport public key) with its
+//! **passport principal** (the subject the agent is known by in an attestation
+//! / identity system). The goal it serves is "dial an agent by its proven
+//! identity": given a binding, a verifier can be confident that a particular
+//! passport principal vouches for control of a particular transport key.
+//!
+//! ## Scope — read this carefully
+//!
+//! A [`NodeBinding`] asserts exactly one thing:
+//!
+//! > **"this passport controls this transport key"**
+//!
+//! It does **NOT** assert that the agent is well-behaved, attested,
+//! sandboxed, or otherwise trustworthy. Merely possessing a `NodeId` proves
+//! control of a *transport key*, nothing more. Binding the `NodeId` to a
+//! passport principal requires a *signed statement* (this struct) where the
+//! passport key vouches for the `NodeId` — co-location or self-assertion is
+//! not enough. Attested properties (capabilities, behaviour, policy
+//! compliance) live in other layers and are out of scope here.
+//!
+//! ## Invariants
+//!
+//! - **Fail-closed.** A forged, tampered, unsigned, or wrong-key binding
+//!   verifies to `Err(..)` and contributes no trust. There is no
+//!   success-by-default path.
+//! - **No key smuggling.** Verification trusts a passport public key that the
+//!   **caller** supplies, keyed by the principal in their own identity system.
+//!   The binding message carries no passport public key that verification
+//!   trusts — an attacker cannot ship their own key inside the binding.
+//! - **Domain separation.** The signed bytes are prefixed with
+//!   `b"nucleus-node-binding/v1\n:"`, so a passport signature minted for some
+//!   other purpose cannot be replayed as a node binding, and vice versa.
+//! - **Pure.** This slice depends only on `ed25519-dalek` (workspace-pinned)
+//!   plus `serde`/`hex`/`thiserror`. There is **no** iroh / iroh-gossip / QUIC
+//!   dependency. The `NodeId <-> [u8; 32]` conversions are a later,
+//!   feature-gated slice.
+//!
+//! ## Example
+//!
+//! ```
+//! use ed25519_dalek::SigningKey;
+//! use nucleus_node_binding::{sign_binding, verify_binding};
+//!
+//! // The agent's passport signing key (lives in the identity system).
+//! let passport_sk = SigningKey::from_bytes(&[7u8; 32]);
+//! let passport_pk = passport_sk.verifying_key().to_bytes();
+//!
+//! // The agent's transport key (an iroh NodeId is exactly these 32 bytes).
+//! let node_id = [42u8; 32];
+//!
+//! let binding = sign_binding(&node_id, "spiffe://example/agent-x", &passport_sk);
+//!
+//! // A verifier that already trusts `passport_pk` (keyed by the principal in
+//! // its own system) confirms the passport vouches for this transport key.
+//! verify_binding(&binding, &passport_pk).expect("binding verifies");
+//! ```
+
+use ed25519_dalek::{Signer, Verifier};
+use serde::{Deserialize, Serialize};
+
+/// Domain-separation prefix for the signed binding message.
+///
+/// The trailing `\n:` keeps the version token unambiguous and delimits the
+/// prefix from the payload. Future protocol versions use `/v2`, `/v3`, ...,
+/// so a signature minted under one version never verifies under another.
+const DOMAIN_PREFIX: &[u8] = b"nucleus-node-binding/v1\n:";
+
+/// A signed statement that a passport principal controls a transport key.
+///
+/// The struct deliberately carries **only** the bound data plus the
+/// signature — never a passport public key that verification trusts. The
+/// caller supplies the trusted key to [`verify_binding`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct NodeBinding {
+    /// 32-byte ed25519 transport public key (an iroh `NodeId`).
+    pub node_id: [u8; 32],
+
+    /// Principal identifier (e.g. SPIFFE subject, agent name, or any string)
+    /// the passport is known by in the verifier's identity system.
+    pub principal: String,
+
+    /// Ed25519 signature over [`binding_message`]`(node_id, principal)`,
+    /// produced by the passport signing key. Serialized as hex on the wire
+    /// (serde cannot derive `[u8; 64]` directly).
+    #[serde(with = "sig_hex")]
+    pub sig: [u8; 64],
+}
+
+/// Compute the domain-separated message that is signed for a binding.
+///
+/// Framing (all concatenated, in order):
+/// 1. Domain prefix `b"nucleus-node-binding/v1\n:"`.
+/// 2. The 32-byte `node_id` (raw bytes).
+/// 3. A single `b":"` separator.
+/// 4. The `principal` string (UTF-8 bytes, as-is; it terminates the message).
+///
+/// This is a total, deterministic function of its inputs: the same
+/// `(node_id, principal)` pair always yields identical bytes.
+pub fn binding_message(node_id: &[u8; 32], principal: &str) -> Vec<u8> {
+    let mut msg = Vec::with_capacity(DOMAIN_PREFIX.len() + 32 + 1 + principal.len());
+    msg.extend_from_slice(DOMAIN_PREFIX);
+    msg.extend_from_slice(node_id);
+    msg.push(b':');
+    msg.extend_from_slice(principal.as_bytes());
+    msg
+}
+
+/// Sign a binding with the supplied passport signing key.
+///
+/// Intended for agents minting their own bindings (and for tests). The
+/// resulting [`NodeBinding`] asserts that this passport controls `node_id` —
+/// nothing about the agent's behaviour or attested properties.
+pub fn sign_binding(
+    node_id: &[u8; 32],
+    principal: &str,
+    passport_signing_key: &ed25519_dalek::SigningKey,
+) -> NodeBinding {
+    let msg = binding_message(node_id, principal);
+    let sig = passport_signing_key.sign(&msg);
+    NodeBinding {
+        node_id: *node_id,
+        principal: principal.to_string(),
+        sig: sig.to_bytes(),
+    }
+}
+
+/// Verify a binding against a **caller-supplied trusted passport public key**.
+///
+/// The caller keys `trusted_passport_pubkey` by the principal in their own
+/// identity system; the binding itself contributes no trusted key. Returns
+/// `Ok(())` only when the signature over the domain-separated
+/// [`binding_message`] verifies under that key.
+///
+/// Fail-closed: a forged, tampered, unsigned, or wrong-key binding returns
+/// `Err(..)`.
+#[must_use = "the verification result must be checked; a dropped `Err` silently accepts an unverified binding"]
+pub fn verify_binding(
+    binding: &NodeBinding,
+    trusted_passport_pubkey: &[u8; 32],
+) -> Result<(), BindingError> {
+    let msg = binding_message(&binding.node_id, &binding.principal);
+    let vk = ed25519_dalek::VerifyingKey::from_bytes(trusted_passport_pubkey)
+        .map_err(|e| BindingError::InvalidKey(e.to_string()))?;
+    let sig = ed25519_dalek::Signature::from_bytes(&binding.sig);
+    vk.verify(&msg, &sig)
+        .map_err(|e| BindingError::SignatureMismatch(e.to_string()))?;
+    Ok(())
+}
+
+/// Errors returned by [`verify_binding`].
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum BindingError {
+    /// The supplied trusted passport public key bytes are not a valid
+    /// ed25519 point.
+    #[error("verifying key invalid: {0}")]
+    InvalidKey(String),
+
+    /// The signature did not verify against the trusted key over the
+    /// domain-separated binding message.
+    #[error("binding signature did not verify: {0}")]
+    SignatureMismatch(String),
+}
+
+/// Serde with-module: encode the `[u8; 64]` signature as a hex string.
+mod sig_hex {
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(sig: &[u8; 64], s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(&hex::encode(sig))
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<[u8; 64], D::Error> {
+        let hex_str = String::deserialize(d)?;
+        let bytes = hex::decode(&hex_str)
+            .map_err(|e| serde::de::Error::custom(format!("hex decode failed: {e}")))?;
+        let sig: [u8; 64] = bytes.try_into().map_err(|v: Vec<u8>| {
+            serde::de::Error::custom(format!(
+                "signature must be exactly 64 bytes, got {}",
+                v.len()
+            ))
+        })?;
+        Ok(sig)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::SigningKey;
+
+    fn test_sk() -> SigningKey {
+        SigningKey::from_bytes(&[42u8; 32])
+    }
+
+    fn test_sk_alt() -> SigningKey {
+        SigningKey::from_bytes(&[99u8; 32])
+    }
+
+    // TEST 1: round-trip sign -> verify with the correct key returns Ok.
+    #[test]
+    fn binding_round_trip_verifies() {
+        let sk = test_sk();
+        let vk: [u8; 32] = sk.verifying_key().to_bytes();
+
+        let node_id = [123u8; 32];
+        let principal = "spiffe://example/agent-x";
+
+        let binding = sign_binding(&node_id, principal, &sk);
+        assert_eq!(binding.node_id, node_id);
+        assert_eq!(binding.principal, principal);
+
+        verify_binding(&binding, &vk).expect("freshly signed binding must verify");
+    }
+
+    // TEST 2: tampering the node_id fails verification (fail-closed).
+    #[test]
+    fn tampered_node_id_fails_verify() {
+        let sk = test_sk();
+        let vk: [u8; 32] = sk.verifying_key().to_bytes();
+
+        let mut binding = sign_binding(&[1u8; 32], "agent", &sk);
+        binding.node_id[0] ^= 0xFF;
+
+        assert!(verify_binding(&binding, &vk).is_err());
+    }
+
+    // TEST 3: rewriting the principal fails verification (fail-closed).
+    #[test]
+    fn tampered_principal_fails_verify() {
+        let sk = test_sk();
+        let vk: [u8; 32] = sk.verifying_key().to_bytes();
+
+        let mut binding = sign_binding(&[2u8; 32], "alice", &sk);
+        binding.principal = "bob".to_string();
+
+        assert!(verify_binding(&binding, &vk).is_err());
+    }
+
+    // TEST 4: tampering the signature fails verification (fail-closed).
+    #[test]
+    fn tampered_signature_fails_verify() {
+        let sk = test_sk();
+        let vk: [u8; 32] = sk.verifying_key().to_bytes();
+
+        let mut binding = sign_binding(&[3u8; 32], "agent", &sk);
+        binding.sig[0] ^= 0xFF;
+
+        assert!(verify_binding(&binding, &vk).is_err());
+    }
+
+    // TEST 5: verifying against the wrong passport public key fails.
+    #[test]
+    fn wrong_passport_pubkey_fails_verify() {
+        let sk_a = test_sk();
+        let sk_b = test_sk_alt();
+        let vk_b: [u8; 32] = sk_b.verifying_key().to_bytes();
+
+        let binding = sign_binding(&[4u8; 32], "agent", &sk_a);
+
+        assert!(verify_binding(&binding, &vk_b).is_err());
+    }
+
+    // TEST 6: NO KEY SMUGGLING — a binding claiming principal "principal-a"
+    // but actually signed by attacker key B must fail when the verifier
+    // checks it against the genuine A's trusted pubkey.
+    #[test]
+    fn key_smuggling_attempt_fails() {
+        let sk_a = test_sk();
+        let sk_b = test_sk_alt();
+        let vk_a: [u8; 32] = sk_a.verifying_key().to_bytes();
+
+        let binding = sign_binding(&[5u8; 32], "principal-a", &sk_b);
+
+        assert!(verify_binding(&binding, &vk_a).is_err());
+    }
+
+    // TEST 7: DOMAIN SEPARATION — a signature over the raw payload WITHOUT
+    // the domain prefix must not verify as a binding.
+    #[test]
+    fn domain_separation_signature_without_prefix_fails() {
+        let sk = test_sk();
+        let vk: [u8; 32] = sk.verifying_key().to_bytes();
+
+        let node_id = [6u8; 32];
+        let principal = "test-agent";
+
+        let mut attacker_msg = Vec::new();
+        attacker_msg.extend_from_slice(&node_id);
+        attacker_msg.extend_from_slice(principal.as_bytes());
+        let attacker_sig = sk.sign(&attacker_msg);
+
+        let fake_binding = NodeBinding {
+            node_id,
+            principal: principal.to_string(),
+            sig: attacker_sig.to_bytes(),
+        };
+
+        assert!(verify_binding(&fake_binding, &vk).is_err());
+    }
+
+    // TEST 8: serde round-trip preserves the binding exactly.
+    #[test]
+    fn binding_serde_round_trip() {
+        let sk = test_sk();
+        let binding = sign_binding(&[7u8; 32], "serde-test", &sk);
+
+        let json = serde_json::to_string(&binding).expect("serialize");
+        let restored: NodeBinding = serde_json::from_str(&json).expect("deserialize");
+
+        assert_eq!(binding, restored);
+        // The signature travels as hex on the wire.
+        assert!(json.contains(&hex::encode(binding.sig)));
+
+        // A deserialized binding still verifies under the genuine key.
+        let vk: [u8; 32] = sk.verifying_key().to_bytes();
+        verify_binding(&restored, &vk).expect("round-tripped binding must verify");
+    }
+
+    // TEST 9: binding_message is deterministic and domain-tagged.
+    #[test]
+    fn binding_message_is_deterministic() {
+        let node_id = [77u8; 32];
+        let principal = "agent-determinism";
+
+        let msg1 = binding_message(&node_id, principal);
+        let msg2 = binding_message(&node_id, principal);
+
+        assert_eq!(msg1, msg2);
+        assert!(msg1.starts_with(b"nucleus-node-binding/v1\n:"));
+    }
+}


### PR DESCRIPTION
## What

First slice of **iroh trust-fabric transport integration #4** — unify an agent's transport identity with its attestation/passport principal so you can *dial an agent by its proven identity*.

A new pure crate `nucleus-node-binding` providing a signed binding (`NodeBinding`) plus `binding_message` / `sign_binding` / `verify_binding`. An agent's iroh `NodeId` is exactly a 32-byte ed25519 transport public key; this layer lets a passport key sign a statement that it controls that key.

## Scope — honest note

A `NodeBinding` asserts exactly **"this passport controls this transport key"** — **NOT** that the agent is well-behaved or attested. Possessing a `NodeId` only proves control of a *transport key*. Binding it to a principal requires a **signed statement** (the passport key vouches for the NodeId), not mere co-location. Attested capabilities/behaviour live in other layers.

## Invariants (all unit-tested)

- **Fail-closed** — a forged / tampered / unsigned / wrong-key binding verifies to `Err(..)` and contributes no trust.
- **No key smuggling** — `verify_binding` trusts a **caller-supplied** passport pubkey (keyed by the principal in the caller's own identity system). The binding struct carries `{node_id, principal, sig}` only — no embedded pubkey that verification trusts. A binding signed by an attacker's key fails against the genuine principal's key.
- **Domain separation** — the signed bytes are prefixed with `nucleus-node-binding/v1\n:`, so a passport signature minted for another purpose can't be replayed as a node binding (and vice-versa). Future versions use `/v2` etc.

## NO iroh dependency

This slice is **pure**: `ed25519-dalek` (workspace-pinned `=3.0.0-pre.7`) + `serde`/`hex`/`thiserror` only. **No iroh / iroh-gossip / QUIC** — the `NodeId <-> [u8; 32]` conversions are a later, feature-gated slice. Confirmed via `cargo tree` (no iroh node in the graph).

## Tests

`cargo test -p nucleus-node-binding`: **9 unit tests + 1 doctest, all green** (round-trip, tampered node_id/principal/sig, wrong key, key-smuggling, domain-separation, serde round-trip, message determinism).

Additive: adds one workspace member; touches no other crate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)