### PR TITLE
feat(security): flip four fail-open defaults to fail-closed (most-paranoid #3)

### DIFF
--- a/crates/nucleus-node/src/auth.rs
+++ b/crates/nucleus-node/src/auth.rs
@@ -306,7 +306,7 @@ impl Default for AuthorizationPolicy {
     fn default() -> Self {
         Self {
             trust_domain: "nucleus.local".to_string(),
-            allow_hmac: true, // Allow HMAC during migration period
+            allow_hmac: false, // Fail-closed: mTLS-only by default; opt in explicitly via .allow_hmac()
             orchestrator_prefixes: vec![
                 "spiffe://nucleus.local/ns/default/sa/".to_string(),
                 "spiffe://nucleus.local/ns/workstream-kg/sa/".to_string(),
@@ -333,8 +333,19 @@ impl AuthorizationPolicy {
     }
 
     /// Disable HMAC authentication (require mTLS only).
+    ///
+    /// This is now the default; retained for explicitness at call sites.
     pub fn require_mtls(mut self) -> Self {
         self.allow_hmac = false;
+        self
+    }
+
+    /// Explicitly allow legacy HMAC shared-secret authentication.
+    ///
+    /// HMAC is disabled by default (fail-closed). Callers that still need the
+    /// deprecated shared-secret fallback during migration must opt in here.
+    pub fn allow_hmac(mut self) -> Self {
+        self.allow_hmac = true;
         self
     }
 
@@ -661,11 +672,24 @@ mod tests {
     }
 
     #[test]
-    fn test_authorization_policy_hmac_allowed_by_default() {
+    fn test_authorization_policy_hmac_denied_by_default() {
         let policy = AuthorizationPolicy::new("nucleus.local");
         let ctx = AuthContext::from_hmac(Some("worker".to_string()), 12345);
 
-        // HMAC should be allowed during migration period
+        // Fail-closed: HMAC is denied unless explicitly enabled.
+        let result = policy.authorize(&ctx, Operation::CreatePod);
+        assert!(matches!(
+            result.unwrap_err(),
+            AuthorizationError::HmacNotAllowed
+        ));
+    }
+
+    #[test]
+    fn test_authorization_policy_hmac_allowed_when_opted_in() {
+        let policy = AuthorizationPolicy::new("nucleus.local").allow_hmac();
+        let ctx = AuthContext::from_hmac(Some("worker".to_string()), 12345);
+
+        // HMAC is allowed only after explicit opt-in.
         assert!(policy.authorize(&ctx, Operation::CreatePod).is_ok());
     }
 

--- a/crates/nucleus-node/src/main.rs
+++ b/crates/nucleus-node/src/main.rs
@@ -103,6 +103,19 @@ struct Args {
     #[arg(long, env = "NUCLEUS_FIRECRACKER_MAX_PODS", default_value_t = 15)]
     firecracker_max_pods: usize,
 
+    /// Require verified-active seccomp on launched Firecracker VMs (most-paranoid #3).
+    ///
+    /// Fail-closed default (`true`): if the launched VMM's seccomp filter cannot
+    /// be confirmed active, the pod launch is aborted rather than proceeding
+    /// unconfined. Set to `false` ONLY in environments where `/proc/<pid>/status`
+    /// is legitimately unreadable and the risk is accepted (logs an UNSAFE warning).
+    #[arg(
+        long,
+        env = "NUCLEUS_FIRECRACKER_SECCOMP_VERIFY",
+        default_value_t = true
+    )]
+    firecracker_seccomp_verify: bool,
+
     // Container driver configuration
     /// Container image for pod execution (container driver).
     #[arg(
@@ -237,6 +250,9 @@ struct NodeState {
     firecracker_netns_drift_check: bool,
     #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
     firecracker_netns_drift_interval: Duration,
+    /// Fail-closed seccomp verification on Firecracker launch (most-paranoid #3).
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+    firecracker_seccomp_verify: bool,
     #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
     network_allocator: Arc<net::NetworkAllocator>,
     auth: AuthConfig,
@@ -543,6 +559,7 @@ async fn main() -> Result<(), ApiError> {
         firecracker_netns_drift_interval: Duration::from_secs(
             args.firecracker_netns_drift_interval_secs,
         ),
+        firecracker_seccomp_verify: args.firecracker_seccomp_verify,
         network_allocator: Arc::new(net::NetworkAllocator::new()),
         auth: AuthConfig::new(
             args.auth_secret.as_bytes(),
@@ -1908,19 +1925,45 @@ async fn spawn_firecracker_pod(
 
         // Verify seccomp is active on the Firecracker process (unless explicitly disabled).
         // Seccomp mode 2 = SECCOMP_MODE_FILTER (BPF filter active).
+        //
+        // FAIL-CLOSED (most-paranoid #3): when `firecracker_seccomp_verify` is set
+        // (the default), a process whose seccomp filter cannot be confirmed active
+        // is killed and the launch is aborted rather than left running unconfined.
+        // The previous behavior only logged a warning and continued (fail-open).
         if !matches!(spec.spec.seccomp, Some(nucleus_spec::SeccompSpec::Disabled)) {
-            if let Some(fc_pid) = pid {
-                match firecracker_config::verify_seccomp_active(fc_pid) {
+            let verified = match pid {
+                Some(fc_pid) => match firecracker_config::verify_seccomp_active(fc_pid) {
                     Ok(()) => {
                         tracing::info!(
                             pid = fc_pid,
                             "seccomp filter verified active on firecracker process"
                         );
+                        Ok(())
                     }
-                    Err(e) => {
-                        tracing::warn!(pid = fc_pid, error = %e, "seccomp verification failed (may not be readable in some environments)");
-                    }
+                    Err(e) => Err(format!("seccomp verification failed for pid {fc_pid}: {e}")),
+                },
+                None => Err("firecracker pid unavailable; cannot verify seccomp".to_string()),
+            };
+            if let Err(reason) = verified {
+                if state.firecracker_seccomp_verify {
+                    let _ = child.kill().await;
+                    cleanup_net_resources(
+                        &state.network_allocator,
+                        &mut net_plan,
+                        &mut netns_name,
+                        &mut dns_proxy,
+                    )
+                    .await;
+                    return Err(ApiError::Driver(format!(
+                        "{reason} — aborting launch (fail-closed). Set \
+                         NUCLEUS_FIRECRACKER_SECCOMP_VERIFY=false only if this environment \
+                         legitimately cannot read /proc and the risk is accepted."
+                    )));
                 }
+                tracing::warn!(
+                    %reason,
+                    "seccomp verification failed but firecracker_seccomp_verify=false; continuing (UNSAFE)"
+                );
             }
         }
 

--- a/crates/nucleus-tool-proxy/src/mcp.rs
+++ b/crates/nucleus-tool-proxy/src/mcp.rs
@@ -176,13 +176,15 @@ impl NucleusMcpServer {
     ///
     /// Called by input tool entry points after a successful fetch/read so the
     /// kernel's `decide_term_with_flow` consult sees the taint on subsequent
-    /// outbound actions. Best-effort: observation failure is logged, never
-    /// fatal (a missed observation fails *open* for that one node, but the
-    /// session ceiling from other nodes still applies).
+    /// outbound actions. FAIL-CLOSED (most-paranoid #3): if the observation
+    /// fails, the data-ingest node would be silently dropped — leaving taint
+    /// untracked — so we poison the session instead, causing every subsequent
+    /// kernel decision to deny until a human-authorized cleanse.
     async fn observe_flow(&self, kind: NodeKind) {
         let mut flow = self.flow_tracker.lock().await;
         if let Err(e) = flow.observe(kind) {
-            warn!(?kind, error = %e, "flow-tracker observe failed");
+            flow.poison();
+            warn!(?kind, error = %e, "flow-tracker observe failed — session poisoned (fail-closed)");
         }
     }
 

--- a/crates/portcullis-core/src/ifc_api.rs
+++ b/crates/portcullis-core/src/ifc_api.rs
@@ -126,6 +126,14 @@ pub struct FlowTracker {
     /// the ceiling stays at `Secret` — any output sink with `max_conf < Secret`
     /// triggers a [`SafetyCheck::ConfidentialityViolation`].
     session_conf_ceiling: ConfLevel,
+    /// Fail-closed poison flag (most-paranoid #3).
+    ///
+    /// Set when an upstream `observe()` failed and a data-ingest node was
+    /// therefore *dropped*: the session's taint state is no longer provable, so
+    /// continuing would fail open. Once poisoned, the kernel denies every
+    /// operation. Cleared only by the human-authorized [`reset_session_ceiling`]
+    /// cleanse path.
+    poisoned: bool,
 }
 
 /// Error from flow tracking operations.
@@ -250,6 +258,7 @@ impl FlowTracker {
             next_id: 1, // 0 reserved as sentinel
             session_taint_ceiling: DerivationClass::Deterministic, // bottom
             session_conf_ceiling: ConfLevel::Public, // bottom
+            poisoned: false,
         }
     }
 
@@ -609,11 +618,26 @@ impl FlowTracker {
         _token: &SessionCleanseToken,
     ) {
         self.session_taint_ceiling = new_ceiling;
+        // The human-authorized cleanse is also the only way to clear the
+        // fail-closed poison flag (most-paranoid #3).
+        self.poisoned = false;
     }
 
     /// Number of tracked nodes.
     pub fn node_count(&self) -> usize {
         self.nodes.len()
+    }
+
+    /// Mark the session poisoned (fail-closed): an `observe()` dropped a node,
+    /// so taint state is unprovable and the kernel must deny everything until a
+    /// human-authorized cleanse (most-paranoid #3).
+    pub fn poison(&mut self) {
+        self.poisoned = true;
+    }
+
+    /// Whether the session is poisoned (an observation was dropped).
+    pub fn is_poisoned(&self) -> bool {
+        self.poisoned
     }
 
     /// Check if any node in the tracker has adversarial integrity.
@@ -984,6 +1008,31 @@ mod tests {
         t.reset_session_ceiling(DerivationClass::Deterministic, &token);
         assert_eq!(t.session_taint_ceiling(), DerivationClass::Deterministic);
         assert!(!t.is_session_tainted());
+    }
+
+    #[test]
+    fn poison_flag_defaults_false_and_sets() {
+        let mut t = FlowTracker::new();
+        assert!(!t.is_poisoned(), "fresh tracker must not be poisoned");
+        t.poison();
+        assert!(
+            t.is_poisoned(),
+            "poison() must set the flag (fail-closed #3)"
+        );
+    }
+
+    #[test]
+    fn poison_cleared_only_by_authorized_cleanse() {
+        let mut t = FlowTracker::new();
+        t.poison();
+        assert!(t.is_poisoned());
+
+        // The human-authorized cleanse path is the only way to un-poison.
+        let bundle = crate::discharge::test_helpers::allowed_bundle();
+        let token =
+            SessionCleanseToken::authorize("test: cleanse after dropped observation", &bundle);
+        t.reset_session_ceiling(DerivationClass::Deterministic, &token);
+        assert!(!t.is_poisoned(), "authorized cleanse must clear poison");
     }
 
     #[test]

--- a/crates/portcullis/src/kernel.rs
+++ b/crates/portcullis/src/kernel.rs
@@ -81,6 +81,9 @@ use crate::receipt_chain::{ReceiptChain, VerdictReceipt};
 use crate::token::SessionProvenance;
 use crate::{ActionTerm, PreflightContext, PreflightResult, PreflightVerdict};
 
+/// IFC flow gate (poison + tainted-outbound denial) — extends `impl Kernel`.
+mod ifc;
+
 /// A single decision made by the kernel.
 ///
 /// Captures the operation, subject, verdict, and a snapshot of the
@@ -747,31 +750,37 @@ impl Kernel {
 
         let now = chrono::Utc::now().timestamp() as u64;
 
+        // Fail-closed (most-paranoid #3): declassification weakens information-flow
+        // labels, so it MUST be cryptographically authorized. With no trusted keys
+        // configured there is no authority to verify against, so refuse outright
+        // rather than applying the token unsigned.
         if self.trusted_public_keys.is_empty() {
             tracing::warn!(
                 target_node = token.target_node_id,
-                "applying declassification token without signature verification — \
-                 no trusted keys configured"
+                "declassification refused: no trusted public keys configured (fail-closed)"
             );
-            Ok(graph.apply_token(token, now))
-        } else {
-            let key_refs: Vec<&[u8]> = self
-                .trusted_public_keys
-                .iter()
-                .map(|k| k.as_slice())
-                .collect();
-            let result = graph.apply_token_verified(token, &key_refs, now);
-            if matches!(
-                result,
-                portcullis_core::declassify::TokenApplyResult::InvalidSignature
-            ) {
-                return Err(DenyReason::InvalidDeclassification {
-                    detail: "token signature verification failed — not signed by any trusted key"
-                        .to_string(),
-                });
-            }
-            Ok(result)
+            return Err(DenyReason::InvalidDeclassification {
+                detail: "no trusted public keys configured — declassification refused \
+                         (fail-closed); configure trusted keys and sign the token"
+                    .to_string(),
+            });
         }
+        let key_refs: Vec<&[u8]> = self
+            .trusted_public_keys
+            .iter()
+            .map(|k| k.as_slice())
+            .collect();
+        let result = graph.apply_token_verified(token, &key_refs, now);
+        if matches!(
+            result,
+            portcullis_core::declassify::TokenApplyResult::InvalidSignature
+        ) {
+            return Err(DenyReason::InvalidDeclassification {
+                detail: "token signature verification failed — not signed by any trusted key"
+                    .to_string(),
+            });
+        }
+        Ok(result)
     }
 
     /// Set the Ed25519 signing key for receipt signing.
@@ -1644,42 +1653,12 @@ impl Kernel {
         term: ActionTerm,
         flow: Option<&portcullis_core::ifc_api::FlowTracker>,
     ) -> (Decision, Option<DecisionToken>) {
-        use portcullis_core::flow::NodeKind;
+        // IFC flow gate (poison + tainted-outbound), extracted to `kernel::ifc`.
+        if let Some(denied) = self.ifc_flow_gate(&term, flow) {
+            return denied;
+        }
 
         let operation = term.operation();
-        if let Some(flow) = flow {
-            if flow.is_tainted() && Self::node_kind_for(operation) == NodeKind::OutboundAction {
-                let subject = term.subject().to_string();
-                let pre_hash = self.effective.checksum();
-                let pre_exposure_count = self.exposure.count();
-                let contributed_label = exposure_core::classify_operation(operation);
-                let detail = format!(
-                    "session carries adversarial integrity (untrusted/web content was \
-                     observed); outbound operation {operation:?} blocked to prevent \
-                     exfiltration of, or action on, injected content"
-                );
-                tracing::warn!(
-                    ?operation,
-                    subject,
-                    "IFC denied outbound action: session is taint-adversarial"
-                );
-                let (mut decision, token) = self.record_with_exposure(
-                    operation,
-                    &subject,
-                    Verdict::Deny(DenyReason::IfcUnsafe { detail }),
-                    &pre_hash,
-                    pre_exposure_count,
-                    contributed_label,
-                    false,
-                    false,
-                );
-                decision.action_term = Some(term.clone());
-                if let Some(last) = self.trace.last_mut() {
-                    last.action_term = Some(term);
-                }
-                return (decision, token);
-            }
-        }
 
         // Cedar policy consult (#1634): after the IFC check, if a Cedar policy is
         // loaded, deny any operation Cedar does not `permit`. Uses the session's

--- a/crates/portcullis/src/kernel.rs
+++ b/crates/portcullis/src/kernel.rs
@@ -1658,6 +1658,9 @@ impl Kernel {
             return denied;
         }
 
+        // Only the Cedar consult below uses `operation`; bind it under the same
+        // cfg so non-cedar feature combos don't trip `-D unused-variables`.
+        #[cfg(feature = "cedar")]
         let operation = term.operation();
 
         // Cedar policy consult (#1634): after the IFC check, if a Cedar policy is

--- a/crates/portcullis/src/kernel/ifc.rs
+++ b/crates/portcullis/src/kernel/ifc.rs
@@ -1,0 +1,94 @@
+//! Information-flow control gate for the kernel (most-paranoid #1/#3).
+//!
+//! Extracted from `kernel.rs` to keep that file under the line ratchet. Provides
+//! the fail-closed gate consulted at the top of
+//! [`Kernel::decide_term_with_flow`](super::Kernel::decide_term_with_flow):
+//!
+//! - **Poison gate (#3):** if an upstream `observe()` dropped a node, the
+//!   session's taint state is unprovable, so EVERY operation is denied until a
+//!   human-authorized cleanse.
+//! - **Tainted-outbound gate (#1633):** once adversarial (web) content is in the
+//!   session, outbound actions are denied to prevent exfiltration.
+
+use portcullis_core::flow::NodeKind;
+use portcullis_core::ifc_api::FlowTracker;
+
+use super::{Decision, DecisionToken, DenyReason, Kernel, Verdict};
+use crate::exposure_core;
+use crate::ActionTerm;
+
+impl Kernel {
+    /// Consult the session flow tracker. Returns `Some(deny_decision)` if the
+    /// IFC gate denies the action, or `None` to fall through to the normal
+    /// decision path. `flow == None` ⇒ always `None` (backward compatible).
+    pub(super) fn ifc_flow_gate(
+        &mut self,
+        term: &ActionTerm,
+        flow: Option<&FlowTracker>,
+    ) -> Option<(Decision, Option<DecisionToken>)> {
+        let flow = flow?;
+        let operation = term.operation();
+
+        // Fail-closed poison gate (#3): a dropped observation makes the taint
+        // state unprovable, so deny EVERY operation (not just outbound).
+        if flow.is_poisoned() {
+            tracing::warn!(
+                ?operation,
+                subject = term.subject(),
+                "IFC denied: session poisoned (a flow observation was dropped)"
+            );
+            return Some(
+                self.ifc_deny(
+                    term.clone(),
+                    "session poisoned: an information-flow observation was dropped; \
+                 failing closed to prevent untracked taint"
+                        .to_string(),
+                ),
+            );
+        }
+
+        // Tainted-outbound gate (#1633): adversarial content in-session blocks
+        // outbound actions before any side effect.
+        if flow.is_tainted() && Kernel::node_kind_for(operation) == NodeKind::OutboundAction {
+            tracing::warn!(
+                ?operation,
+                subject = term.subject(),
+                "IFC denied outbound action: session is taint-adversarial"
+            );
+            let detail = format!(
+                "session carries adversarial integrity (untrusted/web content was \
+                 observed); outbound operation {operation:?} blocked to prevent \
+                 exfiltration of, or action on, injected content"
+            );
+            return Some(self.ifc_deny(term.clone(), detail));
+        }
+
+        None
+    }
+
+    /// Shared IFC denial path: records a `Deny(IfcUnsafe { detail })` decision
+    /// with exposure accounting and stamps the action term onto the decision and
+    /// the trace entry.
+    fn ifc_deny(&mut self, term: ActionTerm, detail: String) -> (Decision, Option<DecisionToken>) {
+        let operation = term.operation();
+        let subject = term.subject().to_string();
+        let pre_hash = self.effective.checksum();
+        let pre_exposure_count = self.exposure.count();
+        let contributed_label = exposure_core::classify_operation(operation);
+        let (mut decision, token) = self.record_with_exposure(
+            operation,
+            &subject,
+            Verdict::Deny(DenyReason::IfcUnsafe { detail }),
+            &pre_hash,
+            pre_exposure_count,
+            contributed_label,
+            false,
+            false,
+        );
+        decision.action_term = Some(term.clone());
+        if let Some(last) = self.trace.last_mut() {
+            last.action_term = Some(term);
+        }
+        (decision, token)
+    }
+}

--- a/crates/portcullis/src/kernel_tests.rs
+++ b/crates/portcullis/src/kernel_tests.rs
@@ -316,6 +316,32 @@ fn test_decide_term_with_flow_denies_outbound_when_tainted() {
 }
 
 #[test]
+fn test_decide_term_with_flow_denies_everything_when_poisoned() {
+    use portcullis_core::ifc_api::FlowTracker;
+
+    // A poisoned session (an observation was dropped) must deny EVERY operation,
+    // including non-outbound ones like a read — proving the fail-closed gate is
+    // broader than the taint/outbound gate (most-paranoid #3).
+    let mut kernel = Kernel::new(PermissionLattice::safe_pr_fixer());
+    let mut poisoned = FlowTracker::new();
+    poisoned.poison();
+    assert!(poisoned.is_poisoned());
+
+    // A read is normally allowed and is NOT an outbound action.
+    let term = crate::ActionTerm::from_operation(Operation::ReadFiles, "README.md");
+    let (decision, token) = kernel.decide_term_with_flow(term, Some(&poisoned));
+    assert!(
+        matches!(
+            decision.verdict,
+            Verdict::Deny(DenyReason::IfcUnsafe { .. })
+        ),
+        "poisoned session must deny even a non-outbound read, got {:?}",
+        decision.verdict
+    );
+    assert!(token.is_none());
+}
+
+#[test]
 fn test_decide_term_with_flow_none_matches_decide_term() {
     // `flow == None` must behave exactly like `decide_term`.
     let term = crate::ActionTerm::run_command(

--- a/crates/portcullis/tests/kernel_token.rs
+++ b/crates/portcullis/tests/kernel_token.rs
@@ -137,8 +137,11 @@ fn wrong_key_token_rejected() {
 }
 
 #[test]
-fn backward_compat_no_keys_allows_unsigned() {
-    // No trusted keys configured — unsigned tokens should work
+fn no_keys_refuses_unsigned() {
+    // Fail-closed (most-paranoid #3): with NO trusted keys configured there is no
+    // authority to verify against, so declassification must be REFUSED — not
+    // applied unsigned. (Previously this returned Ok(Applied); that fail-open
+    // backward-compat path was removed.)
     let mut kernel = make_kernel_with_graph();
 
     let node_id = kernel.observe(NodeKind::WebContent, &[]).unwrap();
@@ -146,11 +149,18 @@ fn backward_compat_no_keys_allows_unsigned() {
     let token = make_token(node_id);
     assert!(!token.is_signed());
 
-    // Apply without keys — backward compatible, should succeed
     let result = kernel.apply_declassification_token(&token);
     match result {
-        Ok(TokenApplyResult::Applied { .. }) => {} // expected
-        other => panic!("expected Applied (backward compat), got {:?}", other),
+        Err(DenyReason::InvalidDeclassification { detail }) => {
+            assert!(
+                detail.contains("no trusted public keys"),
+                "expected no-keys refusal detail, got: {detail}"
+            );
+        }
+        other => panic!(
+            "expected InvalidDeclassification (fail-closed), got {:?}",
+            other
+        ),
     }
 }
 


### PR DESCRIPTION
## Most-Paranoid Burn-Down — Move 3 of 8

Flips four places where the secure behavior was **opt-in and the default failed OPEN**. Hard flip per the most-paranoid directive — insecure defaults removed, not feature-flagged.

### 1. IFC observe-flow poison (fail-closed on dropped taint)
`observe_flow` previously logged a warning and **continued** when a data-ingest node was dropped, silently losing taint so the kernel's IFC consult never saw it. Now `FlowTracker` carries a `poisoned` flag: a failed `observe()` calls `poison()`, and the kernel denies **every** operation (not just outbound) with `IfcUnsafe` while poisoned. Cleared only by the human-authorized `reset_session_ceiling` cleanse. The IFC gate (poison + tainted-outbound) is extracted into a new `kernel::ifc` module.

### 2. Unsigned declassification refused
With no trusted public keys configured, an unsigned declassification token was applied with only a warning. Declassification weakens IFC labels and **must** be authorized, so with no keys it is now refused outright (`InvalidDeclassification`).

### 3. HMAC off by default (mTLS-only)
`AuthorizationPolicy` defaulted to `allow_hmac: true` — a long-lived shared secret, exactly what the keyless design eliminates. Default is now `false`; callers needing the legacy fallback opt in via the new `.allow_hmac()` builder.

### 4. Seccomp verification fail-closed
A Firecracker VM whose seccomp filter couldn't be confirmed active previously logged a warning and **launched anyway**. Now gated by `--firecracker-seccomp-verify` (default `true`): on verification failure (or unavailable pid) the child is killed, net resources cleaned up, and the launch aborted. Escape hatch: set the flag `false`.

### Tests
- `ifc_api`: poison defaults-false / sets / cleared-by-cleanse.
- `kernel_tests`: poisoned session denies even a **non-outbound** read.
- `kernel_token`: no-keys declassification refused (repurposed from the old fail-open backward-compat test).
- `nucleus-node`: HMAC denied-by-default + allowed-when-opted-in (11 auth tests).

portcullis-core / portcullis / nucleus-node / nucleus-tool-proxy suites + doctests green; clippy clean; pre-push fmt/clippy/test/deny/audit all passed.

### Notes / follow-ups
- The **seccomp enforcement block is Linux-`cfg`-gated** and cannot be compiled/run on the macOS dev host; the flag plumbing compiles here, the block is validated in Linux CI.
- PR #1869's HTTP `http_observe_flow` should adopt the same `poison()`-on-failure once it lands (one-line follow-up; same `FlowTracker` API).
- ck-kernel's `SignaturePolicy::SkipForTesting` fail-closed flip (the 5th candidate) is folded into **Move 5** (constitutional-kernel wiring), its natural home — it needs an orphaned `test_harness` wired + a `base64` dep + demo-test rework, out of scope for these clean flips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)