### PR TITLE
feat(ifc): enforce confidentiality on live gate + reclassify local sinks as exfil (most-paranoid #4)

### DIFF
--- a/crates/nucleus-mcp/src/main.rs
+++ b/crates/nucleus-mcp/src/main.rs
@@ -1759,11 +1759,13 @@ mod tests {
 
     #[test]
     #[allow(deprecated)] // Migration to decide_term tracked in #1194
-    fn test_kernel_neutral_ops_dont_add_exposure() {
+    fn test_kernel_local_sink_adds_exfil_leg() {
+        // Local sinks are exfil legs now (most-paranoid #4). A single WriteFiles
+        // on a fresh session adds the ExfilVector leg but is not yet uninhabitable.
         let mut kernel = Kernel::new(permissive_no_static_obligations());
         let (d, _token) = kernel.decide(Operation::WriteFiles, "out.txt");
         assert!(matches!(d.verdict, Verdict::Allow));
-        assert_eq!(d.exposure_transition.post_count, 0);
+        assert_eq!(d.exposure_transition.post_count, 1);
     }
 
     #[test]
@@ -1782,17 +1784,20 @@ mod tests {
 
     #[test]
     #[allow(deprecated)] // Migration to decide_term tracked in #1194
-    fn test_kernel_uninhabitable_allows_non_exfil_after_read_and_fetch() {
+    fn test_kernel_local_sink_gated_after_read_and_fetch() {
         // Use capability_only to test the exposure subsystem in isolation,
         // without flow control tainting writes after web fetch.
         let mut kernel = Kernel::capability_only(permissive_no_static_obligations());
         kernel.decide(Operation::ReadFiles, "data.txt");
         kernel.decide(Operation::WebFetch, "https://example.com");
-        // Non-exfil ops are allowed even with full exposure (capability-only)
+        // A non-exfil read is still allowed (doesn't complete the trifecta).
         let (d, _token) = kernel.decide(Operation::ReadFiles, "more.txt");
         assert!(matches!(d.verdict, Verdict::Allow));
+        // WriteFiles is an exfil leg now (most-paranoid #4) → completes the
+        // uninhabitable trifecta → the dynamic exposure gate fires.
         let (d, _token) = kernel.decide(Operation::WriteFiles, "out.txt");
-        assert!(matches!(d.verdict, Verdict::Allow));
+        assert!(matches!(d.verdict, Verdict::RequiresApproval));
+        assert!(d.exposure_transition.dynamic_gate_applied);
     }
 
     #[test]

--- a/crates/nucleus-tool-proxy/tests/roguepilot_integration.rs
+++ b/crates/nucleus-tool-proxy/tests/roguepilot_integration.rs
@@ -262,10 +262,12 @@ fn test_uninhabitable_blocks_exfiltration_sequence() {
     // Risk stays at Medium (no exfil was recorded)
     assert_eq!(guard.accumulated_risk(), StateRisk::Medium);
 
-    // But neutral operations are still fine
-    assert!(guard.check(Operation::WriteFiles).is_ok());
-    assert!(guard.check(Operation::EditFiles).is_ok());
-    assert!(guard.check(Operation::GitCommit).is_ok());
+    // Local sinks are exfil legs too now (most-paranoid #4): writing/editing/
+    // committing a tainted secret is an exfiltration channel, so they are ALSO
+    // blocked once the private-data + untrusted-content legs are present.
+    assert!(guard.check(Operation::WriteFiles).is_err());
+    assert!(guard.check(Operation::EditFiles).is_err());
+    assert!(guard.check(Operation::GitCommit).is_err());
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/crates/portcullis-core/lean/DecidePureProofs.lean
+++ b/crates/portcullis-core/lean/DecidePureProofs.lean
@@ -69,7 +69,9 @@ def ExposureSet.is_uninhabitable (s : ExposureSet) : Bool :=
 
 def classify_exfil (op : Operation) : Bool :=
   match op with
-  | .RunBash | .GitPush | .CreatePr | .SpawnAgent => true
+  -- Local sinks are exfil legs too (most-paranoid #4).
+  | .RunBash | .GitPush | .CreatePr | .SpawnAgent
+  | .WriteFiles | .EditFiles | .GitCommit | .ManagePods => true
   | _ => false
 
 def project_exposure (current : ExposureSet) (op : Operation) : ExposureSet :=
@@ -78,9 +80,9 @@ def project_exposure (current : ExposureSet) (op : Operation) : ExposureSet :=
     { current with private_data := true }
   | .WebFetch | .WebSearch =>
     { current with untrusted_content := true }
-  | .RunBash | .GitPush | .CreatePr | .SpawnAgent =>
+  | .RunBash | .GitPush | .CreatePr | .SpawnAgent
+  | .WriteFiles | .EditFiles | .GitCommit | .ManagePods =>
     { current with exfil_vector := true }
-  | _ => current
 
 def should_gate (current : ExposureSet) (op : Operation) : Bool :=
   let projected := project_exposure current op
@@ -191,11 +193,11 @@ theorem empty_exposure_no_gate (level : CapabilityLevel) (op : Operation) :
     ExposureSet.is_uninhabitable, classify_exfil]
   cases op <;> decide
 
-/-- Non-exfil operations never trigger the gate, regardless of exposure. -/
+/-- Non-exfil operations never trigger the gate, regardless of exposure.
+    (WriteFiles is no longer a witness — it is an exfil leg now, most-paranoid #4.) -/
 theorem non_exfil_no_gate (level : CapabilityLevel) (exposure : ExposureSet) :
     decide_pure level exposure .ReadFiles ≠ .GateExfil ∧
-    decide_pure level exposure .WebFetch ≠ .GateExfil ∧
-    decide_pure level exposure .WriteFiles ≠ .GateExfil := by
+    decide_pure level exposure .WebFetch ≠ .GateExfil := by
   cases level <;> simp [decide_pure, should_gate, project_exposure,
     ExposureSet.is_uninhabitable, classify_exfil]
   all_goals (cases exposure with | mk pd uc ev => cases pd <;> cases uc <;> cases ev <;> decide)

--- a/crates/portcullis-core/lean/ExposureProofs.lean
+++ b/crates/portcullis-core/lean/ExposureProofs.lean
@@ -81,8 +81,9 @@ def classify_operation (op : Operation) : Option ExposureLabel :=
   match op with
   | .ReadFiles | .GlobSearch | .GrepSearch => some .PrivateData
   | .WebFetch | .WebSearch => some .UntrustedContent
+  -- Local sinks are exfil legs too (most-paranoid #4).
   | .RunBash | .GitPush | .CreatePr | .SpawnAgent => some .ExfilVector
-  | .WriteFiles | .EditFiles | .GitCommit | .ManagePods => none
+  | .WriteFiles | .EditFiles | .GitCommit | .ManagePods => some .ExfilVector
 
 def project_exposure (current : ExposureSet) (op : Operation) : ExposureSet :=
   match classify_operation op with
@@ -163,11 +164,12 @@ theorem classify_exfil_vector :
     classify_operation .CreatePr = some .ExfilVector ∧
     classify_operation .SpawnAgent = some .ExfilVector := by decide
 
-theorem classify_neutral :
-    classify_operation .WriteFiles = none ∧
-    classify_operation .EditFiles = none ∧
-    classify_operation .GitCommit = none ∧
-    classify_operation .ManagePods = none := by decide
+-- Local sinks are exfil legs too now (most-paranoid #4); formerly `classify_neutral`.
+theorem classify_local_sinks_exfil :
+    classify_operation .WriteFiles = some .ExfilVector ∧
+    classify_operation .EditFiles = some .ExfilVector ∧
+    classify_operation .GitCommit = some .ExfilVector ∧
+    classify_operation .ManagePods = some .ExfilVector := by decide
 
 -- ═══════════════════════════════════════════════════════════════════════
 -- should_gate correctness
@@ -190,11 +192,11 @@ theorem should_gate_all_exfil_when_uninhabitable :
     should_gate full .GitPush = true ∧
     should_gate full .CreatePr = true := by decide
 
-/-- Non-exfil ops are never gated, even when uninhabitable. -/
+/-- Non-exfil ops are never gated, even when uninhabitable. (WriteFiles is no
+    longer a witness here — it is an exfil leg now, most-paranoid #4.) -/
 theorem should_gate_non_exfil_never_gated (s : ExposureSet) :
     should_gate s .ReadFiles = false ∧
-    should_gate s .WebFetch = false ∧
-    should_gate s .WriteFiles = false := by
+    should_gate s .WebFetch = false := by
   cases s with | mk pd uc ev =>
   cases pd <;> cases uc <;> cases ev <;> decide
 

--- a/crates/portcullis-core/lean/generated-decide/PortcullisCoreDecide/Funs.lean
+++ b/crates/portcullis-core/lean/generated-decide/PortcullisCoreDecide/Funs.lean
@@ -51,17 +51,17 @@ def ExposureSet.is_uninhabitable (self : ExposureSet) : Result Bool := do
 def classify_operation (op : Operation) : Result (Option ExposureLabel) := do
   match op with
   | Operation.ReadFiles => ok (some ExposureLabel.PrivateData)
-  | Operation.WriteFiles => ok none
-  | Operation.EditFiles => ok none
+  | Operation.WriteFiles => ok (some ExposureLabel.ExfilVector)
+  | Operation.EditFiles => ok (some ExposureLabel.ExfilVector)
   | Operation.RunBash => ok (some ExposureLabel.ExfilVector)
   | Operation.GlobSearch => ok (some ExposureLabel.PrivateData)
   | Operation.GrepSearch => ok (some ExposureLabel.PrivateData)
   | Operation.WebSearch => ok (some ExposureLabel.UntrustedContent)
   | Operation.WebFetch => ok (some ExposureLabel.UntrustedContent)
-  | Operation.GitCommit => ok none
+  | Operation.GitCommit => ok (some ExposureLabel.ExfilVector)
   | Operation.GitPush => ok (some ExposureLabel.ExfilVector)
   | Operation.CreatePr => ok (some ExposureLabel.ExfilVector)
-  | Operation.ManagePods => ok none
+  | Operation.ManagePods => ok (some ExposureLabel.ExfilVector)
   | Operation.SpawnAgent => ok (some ExposureLabel.ExfilVector)
 
 /-- [portcullis_core::project_exposure]:

--- a/crates/portcullis-core/src/flow_algebra.rs
+++ b/crates/portcullis-core/src/flow_algebra.rs
@@ -12,7 +12,7 @@
 //! ```
 
 use crate::{
-    AuthorityLevel, IFCLabel, IntegLevel, Operation, SinkClass,
+    AuthorityLevel, ConfLevel, IFCLabel, IntegLevel, Operation, SinkClass,
     flow::{NodeKind, intrinsic_label},
 };
 
@@ -63,11 +63,28 @@ impl FlowState {
     // ── Primitive 2: flows_to ───────────────────────────────────────
 
     /// Can the current state flow to this sink? THE fundamental check.
+    ///
+    /// Enforces ALL three static axes (most-paranoid #4): integrity and authority
+    /// (must be high enough for the sink) AND confidentiality downflow (the
+    /// state's confidentiality must not exceed what the sink may emit — a Secret
+    /// state cannot flow to a public-egress sink). Previously confidentiality was
+    /// silently dropped, so secret→public exfiltration passed this check.
+    /// Freshness is wall-clock-dependent and is checked separately via
+    /// [`Self::flows_to_at`] to preserve recompute determinism.
     pub fn flows_to(&self, sink: SinkClass) -> bool {
         let req_integ = sink_required_integrity(sink);
         let req_auth = sink_required_authority(sink);
 
-        self.label.integrity >= req_integ && self.label.authority >= req_auth
+        self.label.integrity >= req_integ
+            && self.label.authority >= req_auth
+            && self.label.confidentiality <= sink_max_confidentiality(sink)
+    }
+
+    /// [`Self::flows_to`] plus a freshness check against the supplied wall-clock
+    /// `now` (most-paranoid #4). `now` is injected by the caller so the bare
+    /// `flows_to` stays clock-free and deterministically recomputable.
+    pub fn flows_to_at(&self, sink: SinkClass, now: u64) -> bool {
+        self.flows_to(sink) && !self.label.freshness.is_expired_at(now)
     }
 
     // ── Derived operations (all built from join + flows_to) ─────────
@@ -170,6 +187,29 @@ fn sink_required_authority(sink: SinkClass) -> AuthorityLevel {
         SinkClass::WorkspaceWrite => AuthorityLevel::Suggestive,
         SinkClass::BashExec | SinkClass::HTTPEgress => AuthorityLevel::Suggestive,
         _ => AuthorityLevel::NoAuthority,
+    }
+}
+
+/// The maximum confidentiality a sink may emit (most-paranoid #4).
+///
+/// Publish/egress sinks (data leaves the trust boundary) cap at `Internal`, so a
+/// `Secret`-confidentiality session cannot flow to them. Local sinks (the data
+/// stays inside the sandbox) cap at `Secret` — they impose no confidentiality
+/// restriction. This is the confidentiality (BLP "no read up → no write down")
+/// dimension the `flows_to` check previously dropped.
+fn sink_max_confidentiality(sink: SinkClass) -> ConfLevel {
+    match sink {
+        // True egress: data crosses the boundary. Block Secret.
+        SinkClass::HTTPEgress
+        | SinkClass::GitPush
+        | SinkClass::PRCommentWrite
+        | SinkClass::EmailSend
+        | SinkClass::MCPWrite
+        | SinkClass::CloudMutation
+        | SinkClass::AgentSpawn
+        | SinkClass::SearchIndexWrite => ConfLevel::Internal,
+        // Local sinks: data stays in the sandbox — no confidentiality restriction.
+        _ => ConfLevel::Secret,
     }
 }
 

--- a/crates/portcullis-core/src/ifc_api.rs
+++ b/crates/portcullis-core/src/ifc_api.rs
@@ -604,6 +604,22 @@ impl FlowTracker {
         SafetyCheck::Safe
     }
 
+    /// Session-level confidentiality exfiltration check (most-paranoid #4).
+    ///
+    /// Node-independent: denies when the session's confidentiality ceiling
+    /// exceeds what the sink may emit (e.g. the session observed a `Secret`
+    /// env-var and is now attempting an egress sink capped at `Internal`). This
+    /// is the clause the live kernel gate consults for outbound operations.
+    pub fn session_exfiltration_check(&self, sink_max_conf: ConfLevel) -> SafetyCheck {
+        if self.session_conf_ceiling > sink_max_conf {
+            return SafetyCheck::ConfidentialityViolation {
+                data_conf: self.session_conf_ceiling,
+                sink_max_conf,
+            };
+        }
+        SafetyCheck::Safe
+    }
+
     /// Reset the session taint ceiling to the given value (#1233).
     ///
     /// Requires a [`SessionCleanseToken`] — proof of human authorization.

--- a/crates/portcullis-core/src/lib.rs
+++ b/crates/portcullis-core/src/lib.rs
@@ -1346,21 +1346,25 @@ impl ExposureSet {
 
 /// Classify an operation's exposure contribution.
 ///
-/// Returns the exposure label that this operation contributes to the
-/// session's accumulated exposure, or None for neutral operations.
+/// Returns the exposure label that this operation contributes to the session's
+/// accumulated exposure. Every operation contributes a leg (most-paranoid #4):
+/// local sinks (WriteFiles/EditFiles/GitCommit/ManagePods) are exfiltration
+/// vectors too, since a tainted secret written or committed locally is an
+/// exfiltration channel.
 pub fn classify_operation(op: Operation) -> Option<ExposureLabel> {
     match op {
         Operation::ReadFiles | Operation::GlobSearch | Operation::GrepSearch => {
             Some(ExposureLabel::PrivateData)
         }
         Operation::WebFetch | Operation::WebSearch => Some(ExposureLabel::UntrustedContent),
-        Operation::RunBash | Operation::GitPush | Operation::CreatePr | Operation::SpawnAgent => {
-            Some(ExposureLabel::ExfilVector)
-        }
-        Operation::WriteFiles
+        Operation::RunBash
+        | Operation::GitPush
+        | Operation::CreatePr
+        | Operation::SpawnAgent
+        | Operation::WriteFiles
         | Operation::EditFiles
         | Operation::GitCommit
-        | Operation::ManagePods => None,
+        | Operation::ManagePods => Some(ExposureLabel::ExfilVector),
     }
 }
 
@@ -2984,17 +2988,18 @@ mod tests {
     fn classify_operation_coverage() {
         let expected = [
             (Operation::ReadFiles, Some(ExposureLabel::PrivateData)),
-            (Operation::WriteFiles, None),
-            (Operation::EditFiles, None),
+            // Local sinks are exfil legs now (most-paranoid #4).
+            (Operation::WriteFiles, Some(ExposureLabel::ExfilVector)),
+            (Operation::EditFiles, Some(ExposureLabel::ExfilVector)),
             (Operation::RunBash, Some(ExposureLabel::ExfilVector)),
             (Operation::GlobSearch, Some(ExposureLabel::PrivateData)),
             (Operation::GrepSearch, Some(ExposureLabel::PrivateData)),
             (Operation::WebSearch, Some(ExposureLabel::UntrustedContent)),
             (Operation::WebFetch, Some(ExposureLabel::UntrustedContent)),
-            (Operation::GitCommit, None),
+            (Operation::GitCommit, Some(ExposureLabel::ExfilVector)),
             (Operation::GitPush, Some(ExposureLabel::ExfilVector)),
             (Operation::CreatePr, Some(ExposureLabel::ExfilVector)),
-            (Operation::ManagePods, None),
+            (Operation::ManagePods, Some(ExposureLabel::ExfilVector)),
         ];
         for (op, exp) in expected {
             assert_eq!(classify_operation(op), exp, "mismatch for {:?}", op);
@@ -3011,10 +3016,12 @@ mod tests {
     }
 
     #[test]
-    fn project_exposure_neutral_op_unchanged() {
+    fn project_exposure_local_sink_adds_exfil() {
+        // WriteFiles is an exfil leg now (most-paranoid #4).
         let s = ExposureSet::singleton(ExposureLabel::PrivateData);
         let projected = project_exposure(&s, Operation::WriteFiles);
-        assert_eq!(projected, s);
+        assert!(projected.contains(ExposureLabel::PrivateData));
+        assert!(projected.contains(ExposureLabel::ExfilVector));
     }
 
     #[test]
@@ -3024,7 +3031,9 @@ mod tests {
         assert!(is_exfil_operation(Operation::CreatePr));
         assert!(!is_exfil_operation(Operation::ReadFiles));
         assert!(!is_exfil_operation(Operation::WebFetch));
-        assert!(!is_exfil_operation(Operation::WriteFiles));
+        // Local sinks are exfil vectors now (most-paranoid #4).
+        assert!(is_exfil_operation(Operation::WriteFiles));
+        assert!(is_exfil_operation(Operation::GitCommit));
     }
 
     #[test]
@@ -3036,8 +3045,8 @@ mod tests {
         assert!(should_gate(&exposure, Operation::GitPush));
         // ReadFiles doesn't complete it (already has PrivateData) → not gated
         assert!(!should_gate(&exposure, Operation::ReadFiles));
-        // WriteFiles is neutral → not gated
-        assert!(!should_gate(&exposure, Operation::WriteFiles));
+        // WriteFiles is an exfil leg now → completes the trifecta → gated.
+        assert!(should_gate(&exposure, Operation::WriteFiles));
     }
 
     #[test]

--- a/crates/portcullis/src/exposure_core.rs
+++ b/crates/portcullis/src/exposure_core.rs
@@ -21,6 +21,9 @@
 
 use crate::capability::Operation;
 use crate::guard::{ExposureLabel, ExposureSet};
+use portcullis_core::flow::NodeKind;
+use portcullis_core::ifc_api::FlowTracker;
+use portcullis_core::ConfLevel;
 
 /// Classify an operation into its exposure label.
 ///
@@ -38,16 +41,75 @@ pub fn classify_operation(op: Operation) -> Option<ExposureLabel> {
         }
         // Leg 2: Untrusted content ingestion
         Operation::WebFetch | Operation::WebSearch => Some(ExposureLabel::UntrustedContent),
-        // Leg 3: Exfiltration vectors
-        Operation::RunBash | Operation::GitPush | Operation::CreatePr | Operation::SpawnAgent => {
-            Some(ExposureLabel::ExfilVector)
-        }
-        // Neutral operations (no exposure contribution)
-        Operation::WriteFiles
+        // Leg 3: Exfiltration vectors. Local sinks (WriteFiles/EditFiles/
+        // GitCommit/ManagePods) ARE exfil legs (most-paranoid #4): a tainted
+        // secret written to a file or committed is an exfiltration channel, so
+        // they complete the uninhabitable trifecta rather than being "neutral".
+        Operation::RunBash
+        | Operation::GitPush
+        | Operation::CreatePr
+        | Operation::SpawnAgent
+        | Operation::WriteFiles
         | Operation::EditFiles
         | Operation::GitCommit
-        | Operation::ManagePods => None,
+        | Operation::ManagePods => Some(ExposureLabel::ExfilVector),
     }
+}
+
+/// Whether an operation is an exfiltration vector (single source of truth).
+///
+/// Mirrors the `ExfilVector` arm of [`classify_operation`]; used by the kernel
+/// uninhabitable-state gate (most-paranoid #4).
+#[inline]
+pub fn is_exfil_operation(op: Operation) -> bool {
+    matches!(classify_operation(op), Some(ExposureLabel::ExfilVector))
+}
+
+/// The maximum confidentiality an operation's sink may emit (most-paranoid #4).
+///
+/// True egress operations (data crosses the trust boundary) cap at `Internal`,
+/// so a `Secret`-confidentiality session is blocked from them. Local operations
+/// cap at `Secret` (data stays in the sandbox — no confidentiality restriction).
+/// Calibrated so that, since env-vars/secrets carry `Secret` confidentiality, a
+/// secret-bearing session can still write/edit/commit locally but cannot push,
+/// open a PR, spawn an agent, or manage pods.
+#[inline]
+pub fn sink_max_conf_for(op: Operation) -> ConfLevel {
+    match op {
+        Operation::GitPush
+        | Operation::CreatePr
+        | Operation::SpawnAgent
+        | Operation::ManagePods => ConfLevel::Internal,
+        _ => ConfLevel::Secret,
+    }
+}
+
+/// Clock-free IFC egress denial check for the live kernel gate (most-paranoid
+/// #1/#4). Returns `Some(detail)` when an outbound operation must be denied:
+/// either the session is integrity-tainted (adversarial content observed) or its
+/// confidentiality ceiling exceeds what the sink may emit (secret exfiltration).
+/// `None` ⇒ the gate falls through to the normal decision path.
+pub fn ifc_egress_denial(flow: &FlowTracker, op: Operation, kind: NodeKind) -> Option<String> {
+    if kind != NodeKind::OutboundAction {
+        return None;
+    }
+    if flow.is_tainted() {
+        return Some(format!(
+            "session carries adversarial integrity (untrusted/web content was \
+             observed); outbound operation {op:?} blocked to prevent exfiltration \
+             of, or action on, injected content"
+        ));
+    }
+    if flow
+        .session_exfiltration_check(sink_max_conf_for(op))
+        .is_denied()
+    {
+        return Some(format!(
+            "session confidentiality ceiling exceeds what {op:?} may emit; \
+             outbound operation blocked to prevent secret exfiltration"
+        ));
+    }
+    None
 }
 
 /// Project what the exposure set WOULD be if this operation executes.
@@ -143,17 +205,18 @@ mod tests {
         // Every operation variant maps to something
         let ops = [
             (Operation::ReadFiles, Some(ExposureLabel::PrivateData)),
-            (Operation::WriteFiles, None),
-            (Operation::EditFiles, None),
+            // Local sinks are now exfil legs (most-paranoid #4).
+            (Operation::WriteFiles, Some(ExposureLabel::ExfilVector)),
+            (Operation::EditFiles, Some(ExposureLabel::ExfilVector)),
             (Operation::RunBash, Some(ExposureLabel::ExfilVector)),
             (Operation::GlobSearch, Some(ExposureLabel::PrivateData)),
             (Operation::GrepSearch, Some(ExposureLabel::PrivateData)),
             (Operation::WebSearch, Some(ExposureLabel::UntrustedContent)),
             (Operation::WebFetch, Some(ExposureLabel::UntrustedContent)),
-            (Operation::GitCommit, None),
+            (Operation::GitCommit, Some(ExposureLabel::ExfilVector)),
             (Operation::GitPush, Some(ExposureLabel::ExfilVector)),
             (Operation::CreatePr, Some(ExposureLabel::ExfilVector)),
-            (Operation::ManagePods, None),
+            (Operation::ManagePods, Some(ExposureLabel::ExfilVector)),
             (Operation::SpawnAgent, Some(ExposureLabel::ExfilVector)),
         ];
         for (op, expected) in ops {
@@ -180,10 +243,13 @@ mod tests {
     }
 
     #[test]
-    fn test_project_exposure_neutral_op() {
+    fn test_project_exposure_write_is_exfil() {
+        // WriteFiles is now an exfil leg (most-paranoid #4): projecting it onto a
+        // PrivateData session adds ExfilVector.
         let exposure = ExposureSet::singleton(ExposureLabel::PrivateData);
         let projected = project_exposure(&exposure, Operation::WriteFiles);
-        assert_eq!(projected, exposure);
+        assert!(projected.contains(ExposureLabel::PrivateData));
+        assert!(projected.contains(ExposureLabel::ExfilVector));
     }
 
     #[test]
@@ -220,10 +286,12 @@ mod tests {
     }
 
     #[test]
-    fn test_apply_record_neutral() {
+    fn test_apply_record_write_is_exfil() {
+        // WriteFiles records an ExfilVector leg now (most-paranoid #4).
         let exposure = ExposureSet::singleton(ExposureLabel::PrivateData);
         let recorded = apply_record(&exposure, Operation::WriteFiles);
-        assert_eq!(recorded, exposure);
+        assert!(recorded.contains(ExposureLabel::PrivateData));
+        assert!(recorded.contains(ExposureLabel::ExfilVector));
     }
 
     // ════════════════════════════════════════════════════════════════════

--- a/crates/portcullis/src/guard.rs
+++ b/crates/portcullis/src/guard.rs
@@ -1603,11 +1603,23 @@ mod tests {
             Some(ExposureLabel::ExfilVector)
         );
 
-        // Neutral operations
-        assert_eq!(operation_exposure(Operation::WriteFiles), None);
-        assert_eq!(operation_exposure(Operation::EditFiles), None);
-        assert_eq!(operation_exposure(Operation::GitCommit), None);
-        assert_eq!(operation_exposure(Operation::ManagePods), None);
+        // Local sinks are exfil legs too (most-paranoid #4).
+        assert_eq!(
+            operation_exposure(Operation::WriteFiles),
+            Some(ExposureLabel::ExfilVector)
+        );
+        assert_eq!(
+            operation_exposure(Operation::EditFiles),
+            Some(ExposureLabel::ExfilVector)
+        );
+        assert_eq!(
+            operation_exposure(Operation::GitCommit),
+            Some(ExposureLabel::ExfilVector)
+        );
+        assert_eq!(
+            operation_exposure(Operation::ManagePods),
+            Some(ExposureLabel::ExfilVector)
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -1656,16 +1668,16 @@ mod tests {
     }
 
     #[test]
-    fn test_graded_exposure_guard_neutral_ops_no_exposure() {
+    fn test_graded_exposure_guard_local_sinks_are_exfil() {
         let guard = GradedExposureGuard::new(uninhabitable_perms(), "[]");
 
+        // Local sinks now contribute the ExfilVector leg (most-paranoid #4):
+        // writing/editing/committing is an exfiltration channel.
         check_and_record(&guard, Operation::WriteFiles);
+        assert!(guard.exposure().contains(ExposureLabel::ExfilVector));
         check_and_record(&guard, Operation::EditFiles);
         check_and_record(&guard, Operation::GitCommit);
-
-        // Neutral ops don't contribute to exposure
-        assert_eq!(guard.exposure(), ExposureSet::empty());
-        assert_eq!(guard.accumulated_risk(), StateRisk::Safe);
+        assert!(guard.exposure().contains(ExposureLabel::ExfilVector));
     }
 
     #[test]

--- a/crates/portcullis/src/kani.rs
+++ b/crates/portcullis/src/kani.rs
@@ -458,22 +458,23 @@ fn proof_operation_exposure_completeness() {
             assert!(matches!(op, Operation::WebFetch | Operation::WebSearch));
         }
         Some(ExposureLabel::ExfilVector) => {
+            // Local sinks are exfil legs too now (most-paranoid #4).
             assert!(matches!(
                 op,
                 Operation::RunBash
                     | Operation::GitPush
                     | Operation::CreatePr
                     | Operation::SpawnAgent
-            ));
-        }
-        None => {
-            assert!(matches!(
-                op,
-                Operation::WriteFiles
+                    | Operation::WriteFiles
                     | Operation::EditFiles
                     | Operation::GitCommit
                     | Operation::ManagePods
             ));
+        }
+        None => {
+            // Totality (most-paranoid #4): every operation now contributes an
+            // exposure leg, so this arm is unreachable. Kani verifies it.
+            unreachable!("no operation is neutral after most-paranoid #4");
         }
     }
 }
@@ -497,7 +498,8 @@ fn proof_projected_exposure_correctness() {
     if current.contains(ExposureLabel::ExfilVector) {
         assert!(projected.contains(ExposureLabel::ExfilVector));
     }
-    // 2. Neutral ops don't change exposure
+    // 2. No neutral ops remain after most-paranoid #4 (every op contributes a
+    //    leg); this branch is now vacuous but kept for structural symmetry.
     if operation_exposure(op).is_none() && op != Operation::RunBash {
         assert!(projected == current, "Neutral op changed exposure");
     }

--- a/crates/portcullis/src/kernel.rs
+++ b/crates/portcullis/src/kernel.rs
@@ -1653,7 +1653,8 @@ impl Kernel {
         term: ActionTerm,
         flow: Option<&portcullis_core::ifc_api::FlowTracker>,
     ) -> (Decision, Option<DecisionToken>) {
-        // IFC flow gate (poison + tainted-outbound), extracted to `kernel::ifc`.
+        // IFC flow gate (poison + tainted-outbound + confidentiality egress),
+        // extracted to `kernel::ifc` (most-paranoid #1/#3/#4).
         if let Some(denied) = self.ifc_flow_gate(&term, flow) {
             return denied;
         }
@@ -2166,10 +2167,9 @@ fn is_network_operation(op: Operation) -> bool {
 
 /// Check if an operation is an exfiltration vector.
 fn is_exfil_operation(op: Operation) -> bool {
-    matches!(
-        op,
-        Operation::RunBash | Operation::GitPush | Operation::CreatePr | Operation::SpawnAgent
-    )
+    // Single source of truth (most-paranoid #4): includes the local-sink exfil
+    // legs (WriteFiles/EditFiles/GitCommit/ManagePods).
+    exposure_core::is_exfil_operation(op)
 }
 
 /// Check if an operation is a write-class file operation (sink scope: paths).

--- a/crates/portcullis/src/kernel/ifc.rs
+++ b/crates/portcullis/src/kernel/ifc.rs
@@ -7,10 +7,10 @@
 //! - **Poison gate (#3):** if an upstream `observe()` dropped a node, the
 //!   session's taint state is unprovable, so EVERY operation is denied until a
 //!   human-authorized cleanse.
-//! - **Tainted-outbound gate (#1633):** once adversarial (web) content is in the
-//!   session, outbound actions are denied to prevent exfiltration.
+//! - **Egress gate (#1633 / #4):** once adversarial (web) content is in the
+//!   session, OR the session's confidentiality ceiling exceeds what a sink may
+//!   emit, outbound actions are denied to prevent exfiltration.
 
-use portcullis_core::flow::NodeKind;
 use portcullis_core::ifc_api::FlowTracker;
 
 use super::{Decision, DecisionToken, DenyReason, Kernel, Verdict};
@@ -47,18 +47,17 @@ impl Kernel {
             );
         }
 
-        // Tainted-outbound gate (#1633): adversarial content in-session blocks
-        // outbound actions before any side effect.
-        if flow.is_tainted() && Kernel::node_kind_for(operation) == NodeKind::OutboundAction {
+        // Egress gate (#1633 / most-paranoid #4): deny outbound operations when
+        // the session is integrity-tainted OR its confidentiality ceiling exceeds
+        // what the sink may emit (secret exfiltration). The combined
+        // integrity+confidentiality check lives in `exposure_core`.
+        let kind = Kernel::node_kind_for(operation);
+        if let Some(detail) = exposure_core::ifc_egress_denial(flow, operation, kind) {
             tracing::warn!(
                 ?operation,
                 subject = term.subject(),
-                "IFC denied outbound action: session is taint-adversarial"
-            );
-            let detail = format!(
-                "session carries adversarial integrity (untrusted/web content was \
-                 observed); outbound operation {operation:?} blocked to prevent \
-                 exfiltration of, or action on, injected content"
+                %detail,
+                "IFC denied outbound action"
             );
             return Some(self.ifc_deny(term.clone(), detail));
         }

--- a/crates/portcullis/src/kernel_tests.rs
+++ b/crates/portcullis/src/kernel_tests.rs
@@ -342,6 +342,55 @@ fn test_decide_term_with_flow_denies_everything_when_poisoned() {
 }
 
 #[test]
+fn secret_session_blocks_egress_pure_confidentiality() {
+    // most-paranoid #4: a session that observed Secret data (an env-var) but is
+    // NOT integrity-tainted must still be blocked from an egress sink — pure
+    // secret-exfiltration, which the old integrity-only gate allowed.
+    use portcullis_core::flow::NodeKind;
+    use portcullis_core::ifc_api::FlowTracker;
+
+    let mut secret = FlowTracker::new();
+    secret.observe(NodeKind::EnvVar).expect("observe env var");
+    assert!(
+        !secret.is_tainted(),
+        "env-var is Trusted integrity, not tainted"
+    );
+
+    let mut kernel = Kernel::new(PermissionLattice::permissive());
+    let term = crate::ActionTerm::from_operation(Operation::GitPush, "origin main");
+    let (decision, token) = kernel.decide_term_with_flow(term, Some(&secret));
+    assert!(
+        matches!(
+            decision.verdict,
+            Verdict::Deny(DenyReason::IfcUnsafe { .. })
+        ),
+        "secret session must be denied egress (confidentiality), got {:?}",
+        decision.verdict
+    );
+    assert!(token.is_none());
+}
+
+#[test]
+fn secret_session_allows_local_edit() {
+    // The confidentiality block is egress-scoped, not blanket: a secret-bearing
+    // session may still write/edit locally (local sinks cap at Secret).
+    use portcullis_core::flow::NodeKind;
+    use portcullis_core::ifc_api::FlowTracker;
+
+    let mut secret = FlowTracker::new();
+    secret.observe(NodeKind::EnvVar).expect("observe env var");
+
+    let mut kernel = Kernel::new(PermissionLattice::permissive());
+    let term = crate::ActionTerm::from_operation(Operation::EditFiles, "src/main.rs");
+    let (decision, _token) = kernel.decide_term_with_flow(term, Some(&secret));
+    assert!(
+        decision.verdict.is_allowed(),
+        "secret session should still allow a local edit, got {:?}",
+        decision.verdict
+    );
+}
+
+#[test]
 fn test_decide_term_with_flow_none_matches_decide_term() {
     // `flow == None` must behave exactly like `decide_term`.
     let term = crate::ActionTerm::run_command(
@@ -854,7 +903,7 @@ fn test_dynamic_exposure_gate_with_pre_approval() {
 }
 
 #[test]
-fn test_dynamic_exposure_gate_does_not_affect_non_exfil() {
+fn test_dynamic_exposure_gate_now_gates_local_sinks() {
     use crate::capability::CapabilityLattice;
     let mut perms = PermissionLattice::builder()
         .description("everything-allowed")
@@ -881,19 +930,21 @@ fn test_dynamic_exposure_gate_does_not_affect_non_exfil() {
     // Use capability_only() to isolate the exposure gating subsystem.
     let mut kernel = Kernel::capability_only(perms);
 
-    // Accumulate two legs
+    // Accumulate the first two legs of the uninhabitable trifecta.
     kernel.decide(Operation::ReadFiles, "/etc/passwd");
     kernel.decide(Operation::WebFetch, "https://evil.com");
 
-    // Neutral ops should still be allowed even with high exposure
+    // Local sinks are now exfil legs (most-paranoid #4): WriteFiles completes the
+    // trifecta (private data + untrusted content + exfil vector), so the dynamic
+    // exposure gate fires — writing tainted secrets locally is an exfil channel.
     let (d, _token) = kernel.decide(Operation::WriteFiles, "/workspace/out.txt");
-    assert!(d.verdict.is_allowed());
-    assert!(!d.exposure_transition.dynamic_gate_applied);
+    assert!(!d.verdict.is_allowed(), "WriteFiles should now be gated");
+    assert!(d.exposure_transition.dynamic_gate_applied);
 
-    // git_commit is not an exfil op — should be allowed
+    // GitCommit is likewise an exfil leg now and is gated.
     let (d, _token) = kernel.decide(Operation::GitCommit, "fix: stuff");
-    assert!(d.verdict.is_allowed());
-    assert!(!d.exposure_transition.dynamic_gate_applied);
+    assert!(!d.verdict.is_allowed(), "GitCommit should now be gated");
+    assert!(d.exposure_transition.dynamic_gate_applied);
 }
 
 #[test]

--- a/crates/portcullis/src/observe.rs
+++ b/crates/portcullis/src/observe.rs
@@ -34,10 +34,13 @@
 //! let yaml = profile.to_yaml().unwrap();
 //! println!("{}", yaml);
 //!
-//! // Exposure analysis is included in the summary
+//! // Exposure analysis is included in the summary. Note (most-paranoid #4):
+//! // EditFiles and GitCommit are now exfiltration legs (a tainted secret
+//! // written/committed locally is an exfil channel), so observing
+//! // read + web + edit + commit reveals the full uninhabitable trifecta.
 //! let summary = session.summary();
-//! assert_eq!(summary.exposure_count, 2); // PrivateData + UntrustedContent
-//! assert!(!summary.state_uninhabitable);
+//! assert_eq!(summary.exposure_count, 3); // PrivateData + UntrustedContent + ExfilVector
+//! assert!(summary.state_uninhabitable);
 //! ```
 
 use std::collections::{BTreeMap, BTreeSet};

--- a/crates/portcullis/src/weakening.rs
+++ b/crates/portcullis/src/weakening.rs
@@ -449,10 +449,9 @@ impl WeakeningCostConfig {
 
     /// Check if an operation is an exfiltration vector.
     fn is_exfil_operation(op: Operation) -> bool {
-        matches!(
-            op,
-            Operation::GitPush | Operation::CreatePr | Operation::RunBash
-        )
+        // Single source of truth (most-paranoid #4): includes the local-sink exfil
+        // legs (WriteFiles/EditFiles/GitCommit/ManagePods) and SpawnAgent.
+        crate::exposure_core::is_exfil_operation(op)
     }
 
     /// Compute the uninhabitable_state multiplier.

--- a/crates/portcullis/tests/kernel_executable_spec.rs
+++ b/crates/portcullis/tests/kernel_executable_spec.rs
@@ -44,13 +44,15 @@ fn spec_classify(op: Operation) -> Option<ExposureLabel> {
             Some(ExposureLabel::PrivateData)
         }
         Operation::WebFetch | Operation::WebSearch => Some(ExposureLabel::UntrustedContent),
-        Operation::RunBash | Operation::GitPush | Operation::CreatePr | Operation::SpawnAgent => {
-            Some(ExposureLabel::ExfilVector)
-        }
-        Operation::WriteFiles
+        // Local sinks are exfil legs too (most-paranoid #4).
+        Operation::RunBash
+        | Operation::GitPush
+        | Operation::CreatePr
+        | Operation::SpawnAgent
+        | Operation::WriteFiles
         | Operation::EditFiles
         | Operation::GitCommit
-        | Operation::ManagePods => None,
+        | Operation::ManagePods => Some(ExposureLabel::ExfilVector),
     }
 }
 
@@ -650,9 +652,11 @@ fn spec_pre_approval_consumed_exactly() {
     );
 }
 
-/// Spec: neutral operations don't trigger dynamic gate even at high exposure.
+/// Spec: local-sink operations are exfil legs and DO trigger the dynamic gate at
+/// high exposure (most-paranoid #4) — writing/committing tainted secrets is an
+/// exfiltration channel that completes the uninhabitable trifecta.
 #[test]
-fn spec_neutral_ops_unaffected_by_exposure() {
+fn spec_local_sinks_gated_at_high_exposure() {
     let mut perms = PermissionLattice::builder()
         .description("neutral-test")
         .capabilities(CapabilityLattice {
@@ -683,24 +687,25 @@ fn spec_neutral_ops_unaffected_by_exposure() {
     kernel.decide(Operation::WebFetch, "https://docs.example.com");
     assert_eq!(kernel.exposure().count(), 2);
 
-    // Neutral operations should be allowed regardless of exposure
-    let neutral_ops = [
+    // Local-sink operations are exfil legs now: each completes the uninhabitable
+    // trifecta (private data + untrusted content + exfil vector) and is gated.
+    let exfil_local_ops = [
         Operation::WriteFiles,
         Operation::EditFiles,
         Operation::GitCommit,
         Operation::ManagePods,
     ];
-    for op in neutral_ops {
+    for op in exfil_local_ops {
         let (d, _token) = kernel.decide(op, "test-subject");
         assert!(
-            d.verdict.is_allowed(),
-            "neutral op {:?} should be allowed at exposure count 2, got {:?}",
+            !d.verdict.is_allowed(),
+            "local-sink exfil op {:?} should be gated at exposure count 2, got {:?}",
             op,
             d.verdict,
         );
         assert!(
-            !d.exposure_transition.dynamic_gate_applied,
-            "neutral op {:?} should not trigger dynamic gate",
+            d.exposure_transition.dynamic_gate_applied,
+            "local-sink exfil op {:?} should trigger the dynamic gate",
             op,
         );
     }

--- a/crates/portcullis/tests/verus_conformance.rs
+++ b/crates/portcullis/tests/verus_conformance.rs
@@ -1206,19 +1206,20 @@ proptest! {
         prop_assert!(after.count() >= before.count(), "count decreased");
     }
 
-    /// CONFORMANCE J4: Neutral operations produce no exposure label.
+    /// CONFORMANCE J4: Local-sink operations are exfil legs (most-paranoid #4).
     ///
-    /// Mirrors Verus proof_neutral_ops_no_exposure.
+    /// Mirrors Verus proof_local_sinks_are_exfil. (Formerly asserted these were
+    /// neutral; they now contribute the ExfilVector leg.)
     #[test]
-    fn conformance_neutral_ops_no_exposure(op in prop_oneof![
+    fn conformance_local_sinks_are_exfil(op in prop_oneof![
         Just(Operation::WriteFiles),
         Just(Operation::EditFiles),
         Just(Operation::GitCommit),
         Just(Operation::ManagePods),
     ]) {
         prop_assert_eq!(
-            operation_exposure(op), None,
-            "neutral op {:?} should produce no exposure", op
+            operation_exposure(op), Some(ExposureLabel::ExfilVector),
+            "local-sink op {:?} should be an exfil vector", op
         );
     }
 
@@ -1352,11 +1353,12 @@ proptest! {
         prop_assert_eq!(after, before, "failed event changed exposure for {:?}", op);
     }
 
-    /// CONFORMANCE M5: Neutral ops don't change exposure.
+    /// CONFORMANCE M5: Local-sink ops add the ExfilVector leg (most-paranoid #4).
     ///
-    /// Mirrors Verus proof_neutral_op_preserves_exposure.
+    /// Mirrors Verus proof_local_sink_adds_exfil. (Formerly asserted these ops
+    /// preserved exposure; they now contribute ExfilVector on success.)
     #[test]
-    fn conformance_neutral_op_preserves(
+    fn conformance_local_sink_adds_exfil(
         before in arb_exposure_set(),
         op in prop_oneof![
             Just(Operation::WriteFiles),
@@ -1365,9 +1367,10 @@ proptest! {
             Just(Operation::ManagePods),
         ],
     ) {
-        // Even if succeeded, neutral ops don't add exposure
         let after = apply_event(&before, op, true);
-        prop_assert_eq!(after, before, "neutral op {:?} changed exposure", op);
+        // Monotone: exposure never shrinks, and now includes ExfilVector.
+        prop_assert!(after.contains(ExposureLabel::ExfilVector),
+            "local-sink op {:?} should add ExfilVector", op);
     }
 
     /// CONFORMANCE M6:  UninhabitableState irreversibility — once latched, always latched.
@@ -1785,10 +1788,12 @@ mod structural_bisimulation {
             0 // PrivateData
         } else if op == 6 || op == 7 {
             1 // UntrustedContent
-        } else if op == 3 || op == 9 || op == 10 {
-            2 // ExfilVector
+        } else if op == 3 || op == 9 || op == 10 || op == 1 || op == 2 || op == 8 || op == 11 {
+            // ExfilVector — local sinks (WriteFiles=1, EditFiles=2, GitCommit=8,
+            // ManagePods=11) are exfil legs too now (most-paranoid #4).
+            2
         } else {
-            3 // Neutral
+            3 // Neutral (no op in ALL_OPS maps here after #4)
         }
     }
 
@@ -2762,16 +2767,32 @@ mod enforcement_monotonicity {
             "RunBash should be denied with ReadFiles + WebFetch exposure"
         );
 
-        // Record more neutral operations
+        // Grow exposure further with NON-exfil ops (more private-data / untrusted
+        // reads). Local sinks (Write/Edit/Commit) are now exfil legs themselves
+        // and would be DENIED here (they'd complete the trifecta), so we can no
+        // longer use them to "grow exposure" — they're asserted denied below.
         for &op in &[
-            Operation::WriteFiles,
-            Operation::EditFiles,
-            Operation::GitCommit,
+            Operation::GlobSearch,
+            Operation::GrepSearch,
+            Operation::WebSearch,
         ] {
             let proof = guard.check(op).unwrap();
             guard
                 .execute_and_record(proof, || Ok::<_, String>(()))
                 .unwrap();
+        }
+
+        // The local-sink exfil ops are denied now (most-paranoid #4).
+        for &op in &[
+            Operation::WriteFiles,
+            Operation::EditFiles,
+            Operation::GitCommit,
+        ] {
+            assert!(
+                guard.check(op).is_err(),
+                "local-sink exfil op {:?} should be denied at uninhabitable exposure",
+                op
+            );
         }
 
         // RunBash should STILL be denied (exposure only grew)


### PR DESCRIPTION
## Most-Paranoid Burn-Down — Move 4 of 8

Two related IFC holes from the audit, both hard-flipped to fail-closed. **Verified across Rust + Lean + Kani** (both toolchains available locally).

### A. Confidentiality enforced on the LIVE decide path
`FlowState::flows_to` — *"THE fundamental check"* — only ANDed integrity + authority and **silently dropped confidentiality**. So a session that read a `Secret` (e.g. an env-var: conf=`Secret`, integrity=`Trusted`) could still `git push` / open a PR / spawn — clean **secret-exfiltration** the integrity-only gate allowed.
- `flows_to` now enforces confidentiality downflow via `sink_max_confidentiality(sink)`; `flows_to_at(sink, now)` adds freshness (clock injected by caller → preserves recompute determinism).
- The live `Kernel::decide_term_with_flow` now denies outbound ops when the session confidentiality ceiling exceeds what the sink may emit, via `FlowTracker::session_exfiltration_check` + `exposure_core::ifc_egress_denial` (combined integrity+confidentiality check, kept out of `kernel.rs` to respect the line ratchet).
- **Calibration:** egress sinks (push/PR/spawn/pods) cap at `Internal` (block `Secret`); local sinks cap at `Secret` — a secret-bearing session can still edit locally but cannot exfiltrate (preserves the safe-PR-fixer workflow).

### B. Local sinks are exfil legs
`classify_operation` mapped `WriteFiles`/`EditFiles`/`GitCommit`/`ManagePods` to `None` ("neutral") — so writing/committing a tainted secret never completed the uninhabitable trifecta. They're now `ExfilVector` in **both** Rust sites; `is_exfil_operation` consolidated to one source of truth (kernel + weakening delegate).

### Verification
- **Rust:** portcullis-core, portcullis, nucleus-ifc, nucleus-tool-proxy suites + doctests green; clippy clean. New proving tests (`secret_session_blocks_egress_pure_confidentiality`, `secret_session_allows_local_edit`); **8** tests that encoded the old "neutral" mapping updated (exposure_core, guard, kernel_tests, executable-spec, verus_conformance, observe doctest, roguepilot integration).
- **Lean (`lake build`):** `ExposureProofs` + `DecidePureProofs` updated and build; generated `PortcullisCoreDecide/Funs.lean` kept in sync.
- **Kani (`cargo kani`):** `proof_operation_exposure_completeness` now proves **totality** (no op is neutral — an `unreachable!` Kani verifies) and `proof_projected_exposure_correctness` both verify.

### Note (freshness)
The `flows_to_at` primitive is delivered, but session-wide freshness is **not** gated in the recomputed kernel verdict (it would break the wasm-verifier determinism invariant) — left as a clock-injecting entry point for the orchestration layer. Flagged follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)