### PR TITLE
feat(provenance-memory): recompute-verified, taint-labeled, CRDT-mergeable agent memory (next-bet #1, v1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7007,6 +7007,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "nucleus-provenance-memory"
+version = "1.0.0"
+dependencies = [
+ "chrono",
+ "ed25519-dalek 3.0.0-pre.7",
+ "hex",
+ "nucleus-lineage",
+ "portcullis-core",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "nucleus-receipt"
 version = "1.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ members = [
     "crates/ck-policy",                 # Constitutional Kernel: monotonicity checker
     "crates/ck-kernel",                 # Constitutional Kernel: admission engine + lineage
     "crates/nucleus-lineage",            # Per-call SPIFFE-derived data lineage
+    "crates/nucleus-provenance-memory",  # Provenance-backed, taint-labeled, recompute-verified, CRDT-mergeable agent memory
     "crates/nucleus-envelope",           # Portable provenance bundle: payload + IFC envelope
     "crates/nucleus-receipt",            # Colimit receipt envelope: Session + Projection[] + Ed25519/BLAKE3 Receipt (upstream home of platform's substrate-core envelope)
     "crates/nucleus-bundle-cas",         # Content-addressed bundle transport: BLAKE3 root + iroh-blobs

--- a/crates/nucleus-provenance-memory/Cargo.toml
+++ b/crates/nucleus-provenance-memory/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "nucleus-provenance-memory"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+description = "Provenance-backed, taint-labeled, recompute-verified, CRDT-mergeable persistent memory for AI agents"
+repository = "https://github.com/coproduct-opensource/nucleus"
+keywords = ["ai", "security", "memory", "provenance", "ifc"]
+categories = ["development-tools"]
+
+[dependencies]
+portcullis-core = { version = "1.0.0", path = "../portcullis-core", features = ["serde"] }
+nucleus-lineage = { path = "../nucleus-lineage" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
+hex = { workspace = true }
+thiserror = { workspace = true }
+chrono = { workspace = true }
+ed25519-dalek = { workspace = true }
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/nucleus-provenance-memory/src/crdt.rs
+++ b/crates/nucleus-provenance-memory/src/crdt.rs
@@ -1,0 +1,301 @@
+//! [`ProvenanceMemorySet`] — a recompute-gated, conflict-free replicated set of
+//! memory records, keyed by [`ContentHash`].
+//!
+//! Ported in structure from the proven `nucleus_creditworthiness::ReputationSet`:
+//! the same join-semilattice discipline (idempotent / commutative / associative)
+//! and the same principle — **trust is the recompute, never set membership**. A
+//! record joins only through [`ProvenanceMemorySet::verified_admit`], which
+//! re-derives it from its cited parents via [`verify_admission`]; a forged record
+//! (one whose value or label does not follow from its lineage) never joins.
+//!
+//! Difference from `ReputationSet`: records carry an IFC [`MemoryLabel`] that is
+//! *excluded* from the content hash, so two correctly-admitted replicas of the
+//! same content always carry the same (recomputed) label. Should two labels ever
+//! diverge for one content hash, [`ProvenanceMemorySet::join`] resolves
+//! **fail-closed** to the most-restrictive label (conf-join, integ-meet,
+//! derivation-join) — a deterministic, convergent lattice merge — rather than
+//! converging on the more-trusting of the two.
+
+use std::collections::BTreeMap;
+
+use portcullis_core::memory::MemoryLabel;
+
+use crate::hash::ContentHash;
+use crate::recompute::{
+    conf_join, integ_meet, verify_admission, RecomputeMemory, RecomputeVerdict,
+};
+use crate::record::MemoryRecord;
+
+/// Fail-closed label merge for the same content under divergent labels: the
+/// most-restrictive label — confidentiality joined up, integrity met down,
+/// derivation class joined (so an AIDerived/OpaqueExternal ancestry is never
+/// laundered away). This is a proper lattice op, so the set stays a
+/// join-semilattice.
+fn most_restrictive(a: MemoryLabel, b: MemoryLabel) -> MemoryLabel {
+    MemoryLabel::from_levels_with_derivation(
+        conf_join(a.conf_level(), b.conf_level()),
+        integ_meet(a.integ_level(), b.integ_level()),
+        a.derivation.join(b.derivation),
+    )
+}
+
+/// A conflict-free replicated set of recompute-verified [`MemoryRecord`]s, keyed
+/// by [`ContentHash`]. Replicas that admitted the same records converge on the
+/// same set regardless of gossip order or duplication.
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct ProvenanceMemorySet {
+    /// Records keyed by content hash. `BTreeMap` gives a canonical, order-free
+    /// layout (structural equality is order-independent) and a stable fold order.
+    records: BTreeMap<ContentHash, MemoryRecord>,
+}
+
+impl ProvenanceMemorySet {
+    /// The empty set — the join-semilattice identity.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Number of distinct admitted records.
+    pub fn len(&self) -> usize {
+        self.records.len()
+    }
+
+    /// Whether the set is empty.
+    pub fn is_empty(&self) -> bool {
+        self.records.is_empty()
+    }
+
+    /// Whether a record with this content hash is admitted.
+    pub fn contains(&self, hash: &ContentHash) -> bool {
+        self.records.contains_key(hash)
+    }
+
+    /// Look up an admitted record by content hash.
+    pub fn get(&self, hash: &ContentHash) -> Option<&MemoryRecord> {
+        self.records.get(hash)
+    }
+
+    /// Iterate admitted records in canonical (content-hash-sorted) order.
+    pub fn iter(&self) -> impl Iterator<Item = &MemoryRecord> {
+        self.records.values()
+    }
+
+    /// Merge two sets — the **join-semilattice** operation: idempotent,
+    /// commutative, associative. On a shared content hash with divergent labels,
+    /// resolves fail-closed to [`most_restrictive`].
+    pub fn join(&self, other: &Self) -> Self {
+        let mut merged = self.records.clone();
+        for (hash, incoming) in &other.records {
+            match merged.get(hash) {
+                Some(existing) if existing == incoming => { /* idempotent */ }
+                Some(existing) => {
+                    let label = most_restrictive(existing.label.clone(), incoming.label.clone());
+                    // value/schema/derivation are identical (same content hash);
+                    // only the label could differ, and we take the safe one.
+                    let mut resolved = incoming.clone();
+                    resolved.label = label;
+                    merged.insert(*hash, resolved);
+                }
+                None => {
+                    merged.insert(*hash, incoming.clone());
+                }
+            }
+        }
+        Self { records: merged }
+    }
+
+    /// **Fail-closed admission gate.** Re-derive `record` from its cited parents
+    /// (which must already be in the set) via [`verify_admission`] and admit it
+    /// ONLY on [`RecomputeVerdict::Match`]. Returns the verdict either way; the
+    /// set is unchanged unless the verdict is `Match`.
+    ///
+    /// A missing cited parent yields [`RecomputeVerdict::Invalid`] — lineage must
+    /// be present to be verified.
+    pub fn verified_admit(
+        &mut self,
+        record: &MemoryRecord,
+        registry: &dyn RecomputeMemory,
+    ) -> RecomputeVerdict {
+        let verdict = {
+            let inputs = record.derivation.input_record_hashes();
+            let mut parents = Vec::with_capacity(inputs.len());
+            for h in &inputs {
+                match self.records.get(h) {
+                    Some(p) => parents.push(p),
+                    None => {
+                        return RecomputeVerdict::Invalid {
+                            reason: format!("missing cited parent {}", h.to_hex()),
+                        }
+                    }
+                }
+            }
+            verify_admission(record, &parents, registry)
+        };
+        if verdict.is_match() {
+            self.insert_verified(record.clone());
+        }
+        verdict
+    }
+
+    /// Insert an already-verified record, keyed by content hash. Idempotent;
+    /// fail-closed (most-restrictive) on label divergence for identical content.
+    fn insert_verified(&mut self, record: MemoryRecord) {
+        let key = record.content_hash();
+        match self.records.get(&key) {
+            Some(existing) if *existing == record => { /* idempotent */ }
+            Some(existing) => {
+                let label = most_restrictive(existing.label.clone(), record.label.clone());
+                let mut resolved = record;
+                resolved.label = label;
+                self.records.insert(key, resolved);
+            }
+            None => {
+                self.records.insert(key, record);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::record::{MemoryDerivation, TransformId};
+    use nucleus_lineage::SourceClass;
+    use portcullis_core::memory::SchemaType;
+    use portcullis_core::{ConfLevel, DerivationClass, IntegLevel};
+
+    fn registry() -> crate::recompute::TransformRegistry {
+        let mut r = crate::recompute::TransformRegistry::new();
+        r.register(TransformId::new("concat"), |inputs| {
+            Ok(inputs
+                .iter()
+                .map(|i| i.value.as_str())
+                .collect::<Vec<_>>()
+                .join(""))
+        });
+        r
+    }
+
+    fn raw(value: &str, sc: SourceClass) -> MemoryRecord {
+        let d = MemoryDerivation::RawIngest {
+            source_class: sc,
+            source_hash: ContentHash::of_canonical_bytes(value.as_bytes()),
+        };
+        let label = crate::recompute::derive_label(&d, &[]);
+        MemoryRecord::new(value, SchemaType::String, label, d)
+    }
+
+    #[test]
+    fn verified_admit_accepts_valid_and_dedups() {
+        let mut set = ProvenanceMemorySet::new();
+        let r = raw("hello", SourceClass::LocalFile);
+        assert!(set.verified_admit(&r, &registry()).is_match());
+        assert_eq!(set.len(), 1);
+        // Idempotent: admitting again is a no-op.
+        assert!(set.verified_admit(&r, &registry()).is_match());
+        assert_eq!(set.len(), 1);
+    }
+
+    #[test]
+    fn verified_admit_rejects_missing_parent() {
+        let mut set = ProvenanceMemorySet::new();
+        let a = raw("foo", SourceClass::LocalFile);
+        // Deterministic record cites `a` but `a` was never admitted.
+        let d = MemoryDerivation::Deterministic {
+            input_hashes: vec![a.content_hash()],
+            transform: TransformId::new("concat"),
+        };
+        let label = crate::recompute::derive_label(&d, &[&a]);
+        let rec = MemoryRecord::new("foo", SchemaType::String, label, d);
+        assert!(matches!(
+            set.verified_admit(&rec, &registry()),
+            RecomputeVerdict::Invalid { .. }
+        ));
+        assert_eq!(set.len(), 0);
+    }
+
+    #[test]
+    fn verified_admit_rejects_forged_derived_value() {
+        let mut set = ProvenanceMemorySet::new();
+        let a = raw("foo", SourceClass::LocalFile);
+        let b = raw("bar", SourceClass::LocalFile);
+        set.verified_admit(&a, &registry());
+        set.verified_admit(&b, &registry());
+        let d = MemoryDerivation::Deterministic {
+            input_hashes: vec![a.content_hash(), b.content_hash()],
+            transform: TransformId::new("concat"),
+        };
+        let label = crate::recompute::derive_label(&d, &[&a, &b]);
+        let forged = MemoryRecord::new("evil", SchemaType::String, label, d);
+        assert!(matches!(
+            set.verified_admit(&forged, &registry()),
+            RecomputeVerdict::Mismatch { .. }
+        ));
+        assert_eq!(set.len(), 2); // forged record NOT admitted
+    }
+
+    #[test]
+    fn join_is_idempotent_commutative_associative() {
+        let mut a = ProvenanceMemorySet::new();
+        a.verified_admit(&raw("a", SourceClass::LocalFile), &registry());
+        let mut b = ProvenanceMemorySet::new();
+        b.verified_admit(&raw("b", SourceClass::LocalFile), &registry());
+        let mut c = ProvenanceMemorySet::new();
+        c.verified_admit(&raw("c", SourceClass::LocalFile), &registry());
+
+        // idempotent
+        assert_eq!(a.join(&a), a);
+        // commutative
+        assert_eq!(a.join(&b), b.join(&a));
+        // associative
+        assert_eq!(a.join(&b).join(&c), a.join(&b.join(&c)));
+        // duplication-insensitive: a ⊔ b ⊔ a == a ⊔ b
+        assert_eq!(a.join(&b).join(&a), a.join(&b));
+    }
+
+    #[test]
+    fn join_resolves_divergent_label_fail_closed() {
+        // Two replicas hold the same content with different (hand-forced) labels.
+        // The join must take the most-restrictive (adversarial integrity wins).
+        let d = MemoryDerivation::RawIngest {
+            source_class: SourceClass::Web,
+            source_hash: ContentHash::of_canonical_bytes(b"s"),
+        };
+        let trusting = MemoryRecord::new(
+            "v",
+            SchemaType::String,
+            MemoryLabel::from_levels_with_derivation(
+                ConfLevel::Public,
+                IntegLevel::Trusted,
+                DerivationClass::Deterministic,
+            ),
+            d.clone(),
+        );
+        let restrictive = MemoryRecord::new(
+            "v",
+            SchemaType::String,
+            MemoryLabel::from_levels_with_derivation(
+                ConfLevel::Secret,
+                IntegLevel::Adversarial,
+                DerivationClass::OpaqueExternal,
+            ),
+            d,
+        );
+        assert_eq!(trusting.content_hash(), restrictive.content_hash());
+
+        let mut s1 = ProvenanceMemorySet::new();
+        s1.insert_verified(trusting);
+        let mut s2 = ProvenanceMemorySet::new();
+        s2.insert_verified(restrictive);
+
+        let merged = s1.join(&s2);
+        let rec = merged
+            .get(&merged.iter().next().unwrap().content_hash())
+            .unwrap();
+        assert_eq!(rec.label.integ_level(), IntegLevel::Adversarial);
+        assert_eq!(rec.label.conf_level(), ConfLevel::Secret);
+        assert_eq!(rec.label.derivation, DerivationClass::OpaqueExternal);
+        // and commutative even under divergence
+        assert_eq!(s1.join(&s2), s2.join(&s1));
+    }
+}

--- a/crates/nucleus-provenance-memory/src/declassify.rs
+++ b/crates/nucleus-provenance-memory/src/declassify.rs
@@ -1,0 +1,391 @@
+//! Signed declassification — the headline gate.
+//!
+//! A record whose authority is `MayNotAuthorize` (adversarial / AI-derived) can
+//! only be promoted into actionable, informing context through a
+//! [`SignedDeclassify`]: a [`DeclassifyWitness`] cosigned by a **k-of-n** quorum
+//! of trusted Ed25519 keys (the same threshold discipline as
+//! `nucleus_envelope::cosignature_threshold` and the move-7 witness quorum),
+//! gated through the monotone `DerivationClass` lattice so that **promotion does
+//! not cleanse**: an `OpaqueExternal` / `AIDerived` ancestry survives promotion
+//! (becomes `Mixed` / `HumanPromoted`, never `Deterministic`), and integrity is
+//! raised only to `Untrusted` (usable/informing), never to `Trusted`.
+//!
+//! Fail-closed: a zero threshold is a configuration error, not "no witness
+//! required" — it is rejected outright.
+
+use std::collections::BTreeSet;
+
+use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
+use portcullis_core::memory::{MemoryAuthority, MemoryLabel};
+use portcullis_core::{DerivationClass, IntegLevel};
+use serde::{Deserialize, Serialize};
+
+use crate::hash::ContentHash;
+use crate::recompute::RecomputeVerdict;
+use crate::record::{MemoryDerivation, MemoryRecord};
+
+/// Domain tag for declassify-witness signatures (separate from record hashing).
+const WITNESS_DOMAIN: &[u8] = b"nucleus-provenance-memory/declassify-witness/v1\0";
+
+/// The claim a witness cosigns: "I attest that record `record_hash` may be
+/// promoted to `to_authority` with derivation class `to_derivation`, given the
+/// recompute verdict `recompute_verdict`."
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeclassifyWitness {
+    /// Content hash of the record being declassified (binds the witness to it).
+    pub record_hash: ContentHash,
+    /// The recompute verdict the witness observed. For a deterministic record
+    /// this MUST be [`RecomputeVerdict::Match`] for the gate to pass.
+    pub recompute_verdict: RecomputeVerdict,
+    /// Target authority (normally [`MemoryAuthority::MayInform`]).
+    pub to_authority: MemoryAuthority,
+    /// Target derivation class. Promoting an adversarial/AI-derived record
+    /// requires [`DerivationClass::HumanPromoted`].
+    pub to_derivation: DerivationClass,
+}
+
+impl DeclassifyWitness {
+    /// Domain-tagged canonical bytes the quorum signs over.
+    pub fn canonical_bytes(&self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(WITNESS_DOMAIN.len() + 128);
+        out.extend_from_slice(WITNESS_DOMAIN);
+        serde_json::to_writer(&mut out, self).expect("witness serialization is infallible");
+        out
+    }
+
+    /// Sign this witness with `key`, returning the `(verifying_key, signature)`
+    /// pair to attach to a [`SignedDeclassify`]. (`SigningKey` is constructed by
+    /// the caller — e.g. from a SPIRE-issued key — never generated here.)
+    pub fn sign(&self, key: &SigningKey) -> ([u8; 32], Vec<u8>) {
+        let sig = key.sign(&self.canonical_bytes());
+        (key.verifying_key().to_bytes(), sig.to_bytes().to_vec())
+    }
+}
+
+/// A [`DeclassifyWitness`] plus its cosignatures.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SignedDeclassify {
+    /// The cosigned claim.
+    pub witness: DeclassifyWitness,
+    /// `(verifying_key_bytes, signature_bytes)` cosignature pairs.
+    pub signatures: Vec<([u8; 32], Vec<u8>)>,
+}
+
+impl SignedDeclassify {
+    /// Start a signed declassification with no cosignatures yet.
+    pub fn new(witness: DeclassifyWitness) -> Self {
+        Self {
+            witness,
+            signatures: Vec::new(),
+        }
+    }
+
+    /// Attach a cosignature from `key`.
+    pub fn cosign(mut self, key: &SigningKey) -> Self {
+        self.signatures.push(self.witness.sign(key));
+        self
+    }
+}
+
+/// Why a declassification was refused.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum DeclassifyError {
+    /// The threshold was zero — a misconfiguration that would mean "no witness
+    /// required". Rejected fail-closed.
+    #[error("declassify threshold must be >= 1 (zero would be fail-open)")]
+    ThresholdTooLow,
+    /// The witness is bound to a different record than the one presented.
+    #[error("witness record_hash {witness} != record content hash {record}")]
+    HashMismatch {
+        /// Hash named in the witness.
+        witness: String,
+        /// Hash of the presented record.
+        record: String,
+    },
+    /// Fewer than `need` distinct trusted keys cosigned.
+    #[error("insufficient quorum: {got} distinct trusted cosignatures, need {need}")]
+    InsufficientWitnesses {
+        /// Distinct trusted cosignatures collected.
+        got: usize,
+        /// Threshold required.
+        need: usize,
+    },
+    /// A deterministic record was presented but the witnessed recompute verdict
+    /// was not [`RecomputeVerdict::Match`].
+    #[error("deterministic record requires a Match recompute verdict to declassify")]
+    RecomputeNotMatched,
+    /// An adversarial / AI-derived record requires an explicit
+    /// [`DerivationClass::HumanPromoted`] target to be declassified.
+    #[error("adversarial/AI-derived record requires HumanPromoted declassification")]
+    RequiresHumanPromotion,
+}
+
+/// **The declassification gate.** Given a record, a signed witness, the set of
+/// trusted verifying keys, and a k-of-n `threshold`, return the *promoted*
+/// [`MemoryLabel`] the record may carry at a sink — or a [`DeclassifyError`].
+///
+/// Checks, all fail-closed:
+/// 1. `threshold >= 1` (zero is a misconfiguration);
+/// 2. the witness binds to this exact record (`record_hash`);
+/// 3. at least `threshold` **distinct trusted** keys cosigned the witness;
+/// 4. a [`MemoryDerivation::Deterministic`] record's witnessed verdict is
+///    [`RecomputeVerdict::Match`] (the value actually re-derives);
+/// 5. a record whose current authority is [`MemoryAuthority::MayNotAuthorize`]
+///    (adversarial / AI-derived) is promoted only with a
+///    [`DerivationClass::HumanPromoted`] target.
+///
+/// The promoted label raises integrity to at most [`IntegLevel::Untrusted`]
+/// (informing, never kernel-trusted), keeps confidentiality, and sets derivation
+/// to `old.join(to_derivation)` — so ancestry is never laundered.
+pub fn declassify(
+    record: &MemoryRecord,
+    signed: &SignedDeclassify,
+    trusted_keys: &[[u8; 32]],
+    threshold: usize,
+) -> Result<MemoryLabel, DeclassifyError> {
+    if threshold == 0 {
+        return Err(DeclassifyError::ThresholdTooLow);
+    }
+
+    let record_hash = record.content_hash();
+    if signed.witness.record_hash != record_hash {
+        return Err(DeclassifyError::HashMismatch {
+            witness: signed.witness.record_hash.to_hex(),
+            record: record_hash.to_hex(),
+        });
+    }
+
+    // Count DISTINCT trusted keys with a valid signature over the witness bytes.
+    let trusted: BTreeSet<[u8; 32]> = trusted_keys.iter().copied().collect();
+    let msg = signed.witness.canonical_bytes();
+    let mut verified: BTreeSet<[u8; 32]> = BTreeSet::new();
+    for (pk_bytes, sig_bytes) in &signed.signatures {
+        if !trusted.contains(pk_bytes) || verified.contains(pk_bytes) {
+            continue;
+        }
+        let Ok(vk) = VerifyingKey::from_bytes(pk_bytes) else {
+            continue;
+        };
+        let Ok(sig) = Signature::from_slice(sig_bytes) else {
+            continue;
+        };
+        if vk.verify(&msg, &sig).is_ok() {
+            verified.insert(*pk_bytes);
+        }
+    }
+    if verified.len() < threshold {
+        return Err(DeclassifyError::InsufficientWitnesses {
+            got: verified.len(),
+            need: threshold,
+        });
+    }
+
+    // Deterministic records must have re-derived (Match) per the witness.
+    if matches!(record.derivation, MemoryDerivation::Deterministic { .. })
+        && !signed.witness.recompute_verdict.is_match()
+    {
+        return Err(DeclassifyError::RecomputeNotMatched);
+    }
+
+    // Adversarial / AI-derived records need an explicit human promotion.
+    if record.authority() == MemoryAuthority::MayNotAuthorize
+        && signed.witness.to_derivation != DerivationClass::HumanPromoted
+    {
+        return Err(DeclassifyError::RequiresHumanPromotion);
+    }
+
+    // Build the promoted label: integrity raised only to Untrusted (informing,
+    // never Trusted), confidentiality preserved, derivation = old.join(target)
+    // so ancestry survives ("promotion does not cleanse").
+    let promoted_integ = match record.label.integ_level() {
+        IntegLevel::Trusted => IntegLevel::Trusted,
+        _ => IntegLevel::Untrusted,
+    };
+    Ok(MemoryLabel::from_levels_with_derivation(
+        record.label.conf_level(),
+        promoted_integ,
+        record.label.derivation.join(signed.witness.to_derivation),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::recompute::derive_label;
+    use crate::record::MemoryDerivation;
+    use nucleus_lineage::SourceClass;
+    use portcullis_core::memory::SchemaType;
+    use portcullis_core::ConfLevel;
+
+    fn key(seed: u8) -> SigningKey {
+        // from_bytes is decode-only — no CSPRNG (production keys come from SPIRE).
+        SigningKey::from_bytes(&[seed; 32])
+    }
+
+    fn web_record() -> MemoryRecord {
+        let d = MemoryDerivation::RawIngest {
+            source_class: SourceClass::Web,
+            source_hash: ContentHash::of_canonical_bytes(b"evil-instruction"),
+        };
+        let label = derive_label(&d, &[]);
+        MemoryRecord::new("evil-instruction", SchemaType::String, label, d)
+    }
+
+    fn human_witness(rec: &MemoryRecord) -> DeclassifyWitness {
+        DeclassifyWitness {
+            record_hash: rec.content_hash(),
+            recompute_verdict: RecomputeVerdict::Match,
+            to_authority: MemoryAuthority::MayInform,
+            to_derivation: DerivationClass::HumanPromoted,
+        }
+    }
+
+    #[test]
+    fn quorum_met_promotes_adversarial_record() {
+        let rec = web_record();
+        assert_eq!(rec.authority(), MemoryAuthority::MayNotAuthorize);
+        let trusted = [
+            key(1).verifying_key().to_bytes(),
+            key(2).verifying_key().to_bytes(),
+        ];
+        let signed = SignedDeclassify::new(human_witness(&rec))
+            .cosign(&key(1))
+            .cosign(&key(2));
+        let label = declassify(&rec, &signed, &trusted, 2).unwrap();
+        // Promoted to informing (Untrusted), but ancestry preserved (not Deterministic).
+        assert_eq!(label.integ_level(), IntegLevel::Untrusted);
+        assert_ne!(label.derivation, DerivationClass::Deterministic);
+    }
+
+    #[test]
+    fn below_threshold_is_refused() {
+        let rec = web_record();
+        let trusted = [
+            key(1).verifying_key().to_bytes(),
+            key(2).verifying_key().to_bytes(),
+        ];
+        let signed = SignedDeclassify::new(human_witness(&rec)).cosign(&key(1));
+        assert!(matches!(
+            declassify(&rec, &signed, &trusted, 2),
+            Err(DeclassifyError::InsufficientWitnesses { got: 1, need: 2 })
+        ));
+    }
+
+    #[test]
+    fn untrusted_signer_does_not_count() {
+        let rec = web_record();
+        let trusted = [key(1).verifying_key().to_bytes()];
+        // key(9) is not trusted; only key(1) counts → 1 < 2.
+        let signed = SignedDeclassify::new(human_witness(&rec))
+            .cosign(&key(1))
+            .cosign(&key(9));
+        assert!(matches!(
+            declassify(&rec, &signed, &trusted, 2),
+            Err(DeclassifyError::InsufficientWitnesses { got: 1, need: 2 })
+        ));
+    }
+
+    #[test]
+    fn duplicate_signature_counts_once() {
+        let rec = web_record();
+        let trusted = [
+            key(1).verifying_key().to_bytes(),
+            key(2).verifying_key().to_bytes(),
+        ];
+        // key(1) signs twice; must count as one distinct witness.
+        let signed = SignedDeclassify::new(human_witness(&rec))
+            .cosign(&key(1))
+            .cosign(&key(1));
+        assert!(matches!(
+            declassify(&rec, &signed, &trusted, 2),
+            Err(DeclassifyError::InsufficientWitnesses { got: 1, need: 2 })
+        ));
+    }
+
+    #[test]
+    fn zero_threshold_is_fail_closed() {
+        let rec = web_record();
+        let signed = SignedDeclassify::new(human_witness(&rec));
+        assert_eq!(
+            declassify(&rec, &signed, &[], 0),
+            Err(DeclassifyError::ThresholdTooLow)
+        );
+    }
+
+    #[test]
+    fn witness_for_other_record_is_rejected() {
+        let rec = web_record();
+        let trusted = [key(1).verifying_key().to_bytes()];
+        let mut w = human_witness(&rec);
+        w.record_hash = ContentHash::of_canonical_bytes(b"some-other-record");
+        let signed = SignedDeclassify::new(w).cosign(&key(1));
+        assert!(matches!(
+            declassify(&rec, &signed, &trusted, 1),
+            Err(DeclassifyError::HashMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn adversarial_record_requires_human_promotion() {
+        let rec = web_record();
+        let trusted = [key(1).verifying_key().to_bytes()];
+        let mut w = human_witness(&rec);
+        w.to_derivation = DerivationClass::Deterministic; // not HumanPromoted
+        let signed = SignedDeclassify::new(w).cosign(&key(1));
+        assert!(matches!(
+            declassify(&rec, &signed, &trusted, 1),
+            Err(DeclassifyError::RequiresHumanPromotion)
+        ));
+    }
+
+    #[test]
+    fn tampered_witness_body_fails_signature() {
+        let rec = web_record();
+        let trusted = [key(1).verifying_key().to_bytes()];
+        let mut signed = SignedDeclassify::new(human_witness(&rec)).cosign(&key(1));
+        // Tamper the witness AFTER signing → signature no longer verifies.
+        signed.witness.to_authority = MemoryAuthority::MayNotAuthorize;
+        assert!(matches!(
+            declassify(&rec, &signed, &trusted, 1),
+            Err(DeclassifyError::InsufficientWitnesses { got: 0, need: 1 })
+        ));
+    }
+
+    #[test]
+    fn deterministic_record_requires_match_verdict() {
+        // A deterministic record whose witness carries a non-Match verdict.
+        let a = {
+            let d = MemoryDerivation::RawIngest {
+                source_class: SourceClass::LocalFile,
+                source_hash: ContentHash::of_canonical_bytes(b"a"),
+            };
+            MemoryRecord::new("a", SchemaType::String, derive_label(&d, &[]), d)
+        };
+        let d = MemoryDerivation::Deterministic {
+            input_hashes: vec![a.content_hash()],
+            transform: crate::record::TransformId::new("id"),
+        };
+        let label = derive_label(&d, &[&a]);
+        let rec = MemoryRecord::new("a", SchemaType::String, label, d);
+        let trusted = [key(1).verifying_key().to_bytes()];
+        let mut w = DeclassifyWitness {
+            record_hash: rec.content_hash(),
+            recompute_verdict: RecomputeVerdict::Invalid {
+                reason: "did not recompute".into(),
+            },
+            to_authority: MemoryAuthority::MayInform,
+            to_derivation: DerivationClass::HumanPromoted,
+        };
+        // ensure conf carries through unchanged
+        let _ = ConfLevel::Public;
+        let signed = SignedDeclassify::new(w.clone()).cosign(&key(1));
+        assert!(matches!(
+            declassify(&rec, &signed, &trusted, 1),
+            Err(DeclassifyError::RecomputeNotMatched)
+        ));
+        // and with a Match verdict it passes
+        w.recompute_verdict = RecomputeVerdict::Match;
+        let signed_ok = SignedDeclassify::new(w).cosign(&key(1));
+        assert!(declassify(&rec, &signed_ok, &trusted, 1).is_ok());
+    }
+}

--- a/crates/nucleus-provenance-memory/src/hash.rs
+++ b/crates/nucleus-provenance-memory/src/hash.rs
@@ -1,0 +1,109 @@
+//! [`ContentHash`] — a 32-byte content address over a record's canonical bytes.
+//!
+//! Same discipline as `nucleus_recompute::content_hash_hex` and a
+//! `nucleus_lineage` edge's `content_hash_hex`: a domain-tagged `sha256` over a
+//! deterministic serialization. Keying a [`crate::MemoryRecord`] by this hash
+//! makes set membership idempotent and makes any tampering invalidate the key.
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use sha2::{Digest, Sha256};
+
+/// Domain separation tag, so a memory-record hash can never collide with a hash
+/// computed over the same bytes in another nucleus context.
+pub(crate) const MEMORY_RECORD_DOMAIN: &[u8] = b"nucleus-provenance-memory/record/v1\0";
+
+/// A 32-byte content address. Serialized as lowercase hex for legible,
+/// stable wire/JSON form.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ContentHash(pub [u8; 32]);
+
+impl ContentHash {
+    /// Compute the content hash of already-canonicalized bytes (domain-tagged).
+    pub fn of_canonical_bytes(canonical: &[u8]) -> Self {
+        let mut h = Sha256::new();
+        h.update(MEMORY_RECORD_DOMAIN);
+        h.update(canonical);
+        let digest = h.finalize();
+        let mut out = [0u8; 32];
+        out.copy_from_slice(&digest);
+        Self(out)
+    }
+
+    /// Lowercase-hex rendering (64 chars).
+    pub fn to_hex(&self) -> String {
+        hex::encode(self.0)
+    }
+
+    /// Parse from lowercase/uppercase hex; errors on wrong length / non-hex.
+    pub fn from_hex(s: &str) -> Result<Self, String> {
+        let bytes = hex::decode(s).map_err(|e| format!("content hash hex decode: {e}"))?;
+        let arr: [u8; 32] = bytes
+            .try_into()
+            .map_err(|_| "content hash must be 32 bytes".to_string())?;
+        Ok(Self(arr))
+    }
+
+    /// Raw bytes.
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+impl Serialize for ContentHash {
+    fn serialize<S: Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+        ser.serialize_str(&self.to_hex())
+    }
+}
+
+impl<'de> Deserialize<'de> for ContentHash {
+    fn deserialize<D: Deserializer<'de>>(de: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(de)?;
+        ContentHash::from_hex(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hex_round_trip() {
+        let h = ContentHash::of_canonical_bytes(b"hello");
+        let s = h.to_hex();
+        assert_eq!(s.len(), 64);
+        assert_eq!(ContentHash::from_hex(&s).unwrap(), h);
+    }
+
+    #[test]
+    fn domain_tag_changes_hash() {
+        // The same payload under a raw sha256 must differ from our domain-tagged
+        // hash, proving the tag is actually applied.
+        let ours = ContentHash::of_canonical_bytes(b"x");
+        let mut plain = Sha256::new();
+        plain.update(b"x");
+        let plain: [u8; 32] = plain.finalize().into();
+        assert_ne!(ours.0, plain);
+    }
+
+    #[test]
+    fn distinct_inputs_distinct_hashes() {
+        assert_ne!(
+            ContentHash::of_canonical_bytes(b"a"),
+            ContentHash::of_canonical_bytes(b"b")
+        );
+    }
+
+    #[test]
+    fn from_hex_rejects_bad_length() {
+        assert!(ContentHash::from_hex("deadbeef").is_err());
+    }
+
+    #[test]
+    fn serde_is_hex_string() {
+        let h = ContentHash::of_canonical_bytes(b"z");
+        let json = serde_json::to_string(&h).unwrap();
+        assert_eq!(json, format!("\"{}\"", h.to_hex()));
+        let back: ContentHash = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, h);
+    }
+}

--- a/crates/nucleus-provenance-memory/src/lib.rs
+++ b/crates/nucleus-provenance-memory/src/lib.rs
@@ -1,0 +1,86 @@
+//! Provenance-backed, taint-labeled, recompute-verified, CRDT-mergeable
+//! persistent memory for AI agents.
+//!
+//! This crate closes the **memory-poisoning** gap (AgentPoison NeurIPS'24, MINJA
+//! NeurIPS'25, MemoryGraft Dec'25): an attacker who plants a record into an
+//! agent's long-term memory — often via query-only interaction, with no write
+//! access — can steer the agent's later actions across sessions. Capability-first
+//! memory frameworks (MemGPT/Letta, mem0, A-MEM) treat stored memory as
+//! trusted-by-default; this crate treats it as **untrusted until a record both
+//! re-derives from its cited sources AND is declassified by a signed witness**.
+//!
+//! # The one object
+//!
+//! A [`MemoryRecord`](record::MemoryRecord) is, simultaneously:
+//! 1. **content-hash-idempotent** — keyed by a [`ContentHash`](hash::ContentHash)
+//!    over its canonical bytes, so the same value derived the same way is the
+//!    same record (dedup is free, tampering invalidates the key);
+//! 2. **taint-labeled** — carries a `portcullis_core::memory::MemoryLabel`
+//!    (confidentiality × integrity × derivation class), reusing the IFC lattice;
+//! 3. **signed-lineage-anchored** — every write/read emits a
+//!    `nucleus_lineage::EdgeKind::DocumentRetrieved{source_class: Memory}` edge
+//!    (the documented-but-previously-unwired memory↔lineage binding);
+//! 4. **recompute-verified** — its [`MemoryLabel`] and (for deterministic
+//!    derivations) its very value are *re-derived* from its cited source records
+//!    via a generic [`RecomputeMemory`](recompute::RecomputeMemory) transform and
+//!    admitted only on a [`RecomputeVerdict::Match`](recompute::RecomputeVerdict);
+//! 5. **CRDT-mergeable** — held in a [`ProvenanceMemorySet`](crdt::ProvenanceMemorySet),
+//!    a recompute-gated join-semilattice (idempotent/commutative/associative,
+//!    fail-closed on divergence) ported from the proven
+//!    `nucleus_creditworthiness::ReputationSet`.
+//!
+//! Using a record at a sensitive sink requires a
+//! [`SignedDeclassify`](declassify::SignedDeclassify): a k-of-n Ed25519-witnessed
+//! [`DeclassifyWitness`](declassify::DeclassifyWitness) gated through the monotone
+//! `DerivationClass` lattice ("promotion does not cleanse").
+//!
+//! # Differentiation vs the 2026 prior art (honest)
+//!
+//! Two 2026 preprints overlap this thesis: **MemLineage** (arXiv 2605.14421 —
+//! lineage-DAG taint propagation + Ed25519 + RFC6962 Merkle log + sensitive-action
+//! gate) and **Portable Agent Memory** (arXiv 2605.11032 — BLAKE3 content-hash +
+//! recompute-of-hashes + capability tokens). This crate deliberately occupies the
+//! territory **neither** of them does:
+//!
+//! - **Recompute of the DERIVATION step, not just the hash.** MemLineage tags
+//!   ancestry but never proves a stored memory is a faithful *function* of its
+//!   cited sources; Portable Memory recomputes only that the content *hashes*
+//!   match. We re-run the declared transform over the cited source records and
+//!   require the result to hash-match — closing the exact MINJA/MemoryGraft seam
+//!   (a planted "summary" that doesn't actually follow from its sources is
+//!   rejected). Honest scope: only *deterministic* derivations are recomputable;
+//!   free-form LLM summaries are quarantined as
+//!   [`MemoryDerivation::OpaqueLlm`](record::MemoryDerivation) and can never reach
+//!   `MayInform` without an explicit `HumanPromoted` witness.
+//! - **Recompute-gated CRDT merge.** Neither paper merges signed taint-labeled
+//!   lineage as a CRDT. Ours is the only recompute-gated join-semilattice for
+//!   memory: replicas converge on the same *admitted-evidence* set regardless of
+//!   gossip order/duplication, and a forged record never joins.
+//! - **Read-side confidentiality / IFC.** Both papers scope to integrity only.
+//!   We carry `ConfLevel` and feed declassification through the same IFC algebra
+//!   the rest of nucleus uses, so memory has *bidirectional* flow control.
+//!
+//! # Honest scope (v1)
+//!
+//! Deterministic derivations only (extraction / templating / structured
+//! distillation); non-deterministic LLM steps are quarantined, never verified.
+//! Provenance is only as strong as key custody (same assumption as MemLineage /
+//! Portable Memory). Adaptive/laundering adversaries and the quantitative-IFC
+//! lattice upgrade are deferred. No transport here — the CRDT is pure, exactly
+//! like [`ReputationSet`](https://docs.rs/nucleus-creditworthiness).
+
+#![forbid(unsafe_code)]
+
+pub mod crdt;
+pub mod declassify;
+pub mod hash;
+pub mod lineage;
+pub mod recompute;
+pub mod record;
+
+pub use crdt::ProvenanceMemorySet;
+pub use declassify::{DeclassifyError, DeclassifyWitness, SignedDeclassify};
+pub use hash::ContentHash;
+pub use lineage::memory_lineage_edge;
+pub use recompute::{RecomputeMemory, RecomputeVerdict, TransformRegistry};
+pub use record::{MemoryDerivation, MemoryRecord, TransformId};

--- a/crates/nucleus-provenance-memory/src/lineage.rs
+++ b/crates/nucleus-provenance-memory/src/lineage.rs
@@ -1,0 +1,92 @@
+//! Memory → lineage edge emitter.
+//!
+//! Wires the documented-but-previously-unwired binding: every memory write/recall
+//! emits a `nucleus_lineage::EdgeKind::DocumentRetrieved` edge with
+//! `source_class: SourceClass::Memory`, pinning exactly which record was used so a
+//! later poisoning can be traced to this access (the blind spot AgentPoison/eTAMP
+//! exploit). The edge's `content_hash_hex` is the record's [`ContentHash`].
+
+use chrono::Utc;
+use nucleus_lineage::{CallSpiffeId, EdgeKind, IdError, LineageEdge, SourceClass};
+
+use crate::record::MemoryRecord;
+
+/// Emit a lineage edge attributing a memory recall/write of `record` to the
+/// session pod `pod`. The derived child identity is content-addressed by the
+/// record's canonical bytes, and the edge carries the record's content hash so
+/// the lineage DAG can later be queried for "which records fed this action".
+pub fn memory_lineage_edge(
+    record: &MemoryRecord,
+    pod: &CallSpiffeId,
+) -> Result<LineageEdge, IdError> {
+    let bytes = record.canonical_bytes();
+    let child = pod.derive_artifact(&bytes)?;
+    let hash_hex = record.content_hash().to_hex();
+    let kind = EdgeKind::DocumentRetrieved {
+        source_url: format!("memory://{hash_hex}"),
+        content_hash: hash_hex.clone(),
+        retrieval_ts: Utc::now(),
+        source_class: SourceClass::Memory,
+    };
+    let mut edge = LineageEdge::from_parent(child, pod.clone(), kind);
+    edge.content_hash_hex = Some(hash_hex);
+    Ok(edge)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hash::ContentHash;
+    use crate::recompute::derive_label;
+    use crate::record::MemoryDerivation;
+    use portcullis_core::memory::SchemaType;
+
+    fn pod() -> CallSpiffeId {
+        CallSpiffeId::pod("prod.example.com", "agents", "summarizer").unwrap()
+    }
+
+    fn rec() -> MemoryRecord {
+        let d = MemoryDerivation::RawIngest {
+            source_class: SourceClass::Web,
+            source_hash: ContentHash::of_canonical_bytes(b"doc"),
+        };
+        MemoryRecord::new("recalled", SchemaType::String, derive_label(&d, &[]), d)
+    }
+
+    #[test]
+    fn emits_memory_source_class_edge_with_content_hash() {
+        let r = rec();
+        let edge = memory_lineage_edge(&r, &pod()).unwrap();
+        assert_eq!(
+            edge.content_hash_hex.as_deref(),
+            Some(r.content_hash().to_hex().as_str())
+        );
+        match edge.kind {
+            EdgeKind::DocumentRetrieved {
+                source_class,
+                content_hash,
+                source_url,
+                ..
+            } => {
+                assert_eq!(source_class, SourceClass::Memory);
+                assert_eq!(content_hash, r.content_hash().to_hex());
+                assert!(source_url.starts_with("memory://"));
+            }
+            other => panic!("expected DocumentRetrieved, got {other:?}"),
+        }
+        assert_eq!(edge.parents.len(), 1);
+    }
+
+    #[test]
+    fn distinct_records_get_distinct_children() {
+        let p = pod();
+        let e1 = memory_lineage_edge(&rec(), &p).unwrap();
+        let d = MemoryDerivation::RawIngest {
+            source_class: SourceClass::Web,
+            source_hash: ContentHash::of_canonical_bytes(b"other"),
+        };
+        let r2 = MemoryRecord::new("different", SchemaType::String, derive_label(&d, &[]), d);
+        let e2 = memory_lineage_edge(&r2, &p).unwrap();
+        assert_ne!(e1.child, e2.child);
+    }
+}

--- a/crates/nucleus-provenance-memory/src/recompute.rs
+++ b/crates/nucleus-provenance-memory/src/recompute.rs
@@ -1,0 +1,368 @@
+//! Generic recompute-verification, decoupled from any specific kernel.
+//!
+//! This is the differentiator over MemLineage / Portable Agent Memory: we do not
+//! merely check that a record's *hash* matches, we re-derive its **label** (via
+//! the taint-propagation rule [`derive_label`]) and, for deterministic
+//! derivations, its very **value** (via a [`RecomputeMemory`] transform), and
+//! admit only on a [`RecomputeVerdict::Match`]. A planted "summary" that does not
+//! actually follow from its cited sources is rejected — the MINJA/MemoryGraft
+//! seam. Non-deterministic LLM steps are not recomputable and are instead
+//! quarantined by the label rule (`Adversarial` / `AIDerived`).
+
+use std::collections::BTreeMap;
+
+use nucleus_lineage::SourceClass;
+use portcullis_core::memory::MemoryLabel;
+use portcullis_core::{ConfLevel, DerivationClass, IntegLevel};
+use serde::{Deserialize, Serialize};
+
+use crate::record::{MemoryDerivation, MemoryRecord, TransformId};
+
+/// Outcome of re-deriving a record from its sources — same discipline as
+/// `nucleus_recompute::RecomputeOutcome`, kept local so this crate stays
+/// decoupled from the economic kernels.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "verdict")]
+pub enum RecomputeVerdict {
+    /// The record's label (and, for deterministic derivations, its value)
+    /// re-derive exactly from its cited sources.
+    Match,
+    /// A re-derived field diverges from what the record claims.
+    Mismatch {
+        /// Which field diverged (`"label"` or `"value"`).
+        field: String,
+        /// What the record claimed.
+        claimed: String,
+        /// What re-derivation actually produced.
+        recomputed: String,
+    },
+    /// The derivation is not well-formed (missing parent, unknown transform,
+    /// transform error) — the claim cannot stand.
+    Invalid {
+        /// Human-readable reason the derivation could not be verified.
+        reason: String,
+    },
+}
+
+impl RecomputeVerdict {
+    /// Whether this verdict admits the record (only [`RecomputeVerdict::Match`]).
+    pub fn is_match(&self) -> bool {
+        matches!(self, RecomputeVerdict::Match)
+    }
+}
+
+/// A deterministic transform: a pure function from cited source records to the
+/// value it should produce. Boxed so transforms can be registered dynamically.
+pub type TransformFn = Box<dyn Fn(&[&MemoryRecord]) -> Result<String, String> + Send + Sync>;
+
+/// A registry of deterministic transforms. The only recomputable derivation
+/// class names a transform here; re-running it over the cited source records
+/// must reproduce the stored value.
+#[derive(Default)]
+pub struct TransformRegistry {
+    transforms: BTreeMap<TransformId, TransformFn>,
+}
+
+impl TransformRegistry {
+    /// An empty registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a deterministic transform under `id`. It must be a pure function
+    /// of its inputs (same inputs ⇒ same output) for recompute to be meaningful.
+    pub fn register(
+        &mut self,
+        id: TransformId,
+        f: impl Fn(&[&MemoryRecord]) -> Result<String, String> + Send + Sync + 'static,
+    ) {
+        self.transforms.insert(id, Box::new(f));
+    }
+
+    /// Whether a transform is registered.
+    pub fn contains(&self, id: &TransformId) -> bool {
+        self.transforms.contains_key(id)
+    }
+}
+
+/// The transform interface the admission gate calls. Implemented by
+/// [`TransformRegistry`]; callers may provide their own.
+pub trait RecomputeMemory {
+    /// Re-derive the value `transform` should produce from `inputs`. Errors if
+    /// the transform is unknown or fails.
+    fn recompute(
+        &self,
+        transform: &TransformId,
+        inputs: &[&MemoryRecord],
+    ) -> Result<String, String>;
+}
+
+impl RecomputeMemory for TransformRegistry {
+    fn recompute(
+        &self,
+        transform: &TransformId,
+        inputs: &[&MemoryRecord],
+    ) -> Result<String, String> {
+        match self.transforms.get(transform) {
+            Some(f) => f(inputs),
+            None => Err(format!("unknown transform {:?}", transform.0)),
+        }
+    }
+}
+
+/// Confidentiality flows UP: a derived value is at least as confidential as its
+/// most-confidential source (join / max).
+pub(crate) fn conf_join(a: ConfLevel, b: ConfLevel) -> ConfLevel {
+    if (a as u8) >= (b as u8) {
+        a
+    } else {
+        b
+    }
+}
+
+/// Integrity flows DOWN: a derived value is at most as trusted as its
+/// least-trusted source (meet / min).
+pub(crate) fn integ_meet(a: IntegLevel, b: IntegLevel) -> IntegLevel {
+    if (a as u8) <= (b as u8) {
+        a
+    } else {
+        b
+    }
+}
+
+/// Trust class of a raw-ingested source ⇒ integrity level. Untrusted-content
+/// sources (web, RAG index, prior memory) are **adversarial** by default — the
+/// lethal-trifecta "untrusted content" leg.
+fn ingest_integrity(sc: SourceClass) -> IntegLevel {
+    match sc {
+        SourceClass::LocalFile => IntegLevel::Untrusted,
+        SourceClass::Web | SourceClass::RagIndex | SourceClass::Memory => IntegLevel::Adversarial,
+    }
+}
+
+/// **The taint-propagation rule.** Deterministically re-derive the label a record
+/// MUST carry, given its derivation and its (already-admitted) parent records.
+/// This is recomputed on admission and the record's claimed label must equal it
+/// — so a record cannot smuggle in a more-trusting label than its lineage earns.
+pub fn derive_label(derivation: &MemoryDerivation, parents: &[&MemoryRecord]) -> MemoryLabel {
+    match derivation {
+        // Raw ingest: integrity fixed by the source class; not yet derived, so
+        // its derivation class is OpaqueExternal (came from outside the kernel).
+        MemoryDerivation::RawIngest { source_class, .. } => {
+            MemoryLabel::from_levels_with_derivation(
+                ConfLevel::Public,
+                ingest_integrity(*source_class),
+                DerivationClass::OpaqueExternal,
+            )
+        }
+        // Deterministic derivation: conf = max(parents), integ = min(parents),
+        // derivation class = Deterministic joined with every parent's class
+        // (so an AIDerived/OpaqueExternal ancestor is never laundered away —
+        // "promotion does not cleanse").
+        MemoryDerivation::Deterministic { .. } => {
+            let mut conf = ConfLevel::Public;
+            let mut integ = IntegLevel::Trusted;
+            let mut deriv = DerivationClass::Deterministic;
+            for p in parents {
+                conf = conf_join(conf, p.label.conf_level());
+                integ = integ_meet(integ, p.label.integ_level());
+                deriv = deriv.join(p.label.derivation);
+            }
+            MemoryLabel::from_levels_with_derivation(conf, integ, deriv)
+        }
+        // Opaque LLM output: NOT recomputable. Adversarial by default (could be
+        // injected) ⇒ MayNotAuthorize, AIDerived joined with the context lineage.
+        MemoryDerivation::OpaqueLlm { .. } => {
+            let mut conf = ConfLevel::Public;
+            let mut deriv = DerivationClass::AIDerived;
+            for p in parents {
+                conf = conf_join(conf, p.label.conf_level());
+                deriv = deriv.join(p.label.derivation);
+            }
+            MemoryLabel::from_levels_with_derivation(conf, IntegLevel::Adversarial, deriv)
+        }
+    }
+}
+
+/// Re-derive `record` from its `parents` and return the admission verdict.
+///
+/// - **Label** is always re-derived ([`derive_label`]); a claimed label that
+///   exceeds what the lineage earns ⇒ `Mismatch{field:"label"}`.
+/// - **Deterministic** records additionally have their **value** recomputed via
+///   `registry`; a value that does not follow from the sources ⇒
+///   `Mismatch{field:"value"}` (the MINJA/MemoryGraft seam). Missing parents or
+///   unknown/failing transform ⇒ `Invalid`.
+/// - **RawIngest / OpaqueLlm** have no recomputable value; the label check is the
+///   gate (OpaqueLlm is thereby pinned `Adversarial`/`AIDerived`).
+pub fn verify_admission(
+    record: &MemoryRecord,
+    parents: &[&MemoryRecord],
+    registry: &dyn RecomputeMemory,
+) -> RecomputeVerdict {
+    let expected = derive_label(&record.derivation, parents);
+    if record.label != expected {
+        return RecomputeVerdict::Mismatch {
+            field: "label".to_string(),
+            claimed: format!("{:?}", record.label),
+            recomputed: format!("{expected:?}"),
+        };
+    }
+
+    if let MemoryDerivation::Deterministic {
+        transform,
+        input_hashes,
+    } = &record.derivation
+    {
+        // Every cited input must be present among the supplied parents.
+        if parents.len() != input_hashes.len() {
+            return RecomputeVerdict::Invalid {
+                reason: format!(
+                    "deterministic derivation cites {} inputs but {} parents supplied",
+                    input_hashes.len(),
+                    parents.len()
+                ),
+            };
+        }
+        match registry.recompute(transform, parents) {
+            Ok(recomputed_value) => {
+                if recomputed_value != record.value {
+                    return RecomputeVerdict::Mismatch {
+                        field: "value".to_string(),
+                        claimed: record.value.clone(),
+                        recomputed: recomputed_value,
+                    };
+                }
+            }
+            Err(e) => return RecomputeVerdict::Invalid { reason: e },
+        }
+    }
+
+    RecomputeVerdict::Match
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hash::ContentHash;
+    use portcullis_core::memory::SchemaType;
+
+    fn raw(value: &str, sc: SourceClass) -> MemoryRecord {
+        let deriv = MemoryDerivation::RawIngest {
+            source_class: sc,
+            source_hash: ContentHash::of_canonical_bytes(value.as_bytes()),
+        };
+        let label = derive_label(&deriv, &[]);
+        MemoryRecord::new(value, SchemaType::String, label, deriv)
+    }
+
+    fn concat_registry() -> TransformRegistry {
+        let mut r = TransformRegistry::new();
+        r.register(TransformId::new("concat"), |inputs| {
+            Ok(inputs
+                .iter()
+                .map(|i| i.value.as_str())
+                .collect::<Vec<_>>()
+                .join(""))
+        });
+        r
+    }
+
+    #[test]
+    fn raw_web_is_adversarial_opaque() {
+        let r = raw("evil", SourceClass::Web);
+        assert_eq!(r.label.integ_level(), IntegLevel::Adversarial);
+        assert_eq!(r.label.derivation, DerivationClass::OpaqueExternal);
+        assert!(verify_admission(&r, &[], &concat_registry()).is_match());
+    }
+
+    #[test]
+    fn raw_localfile_is_untrusted() {
+        let r = raw("cfg", SourceClass::LocalFile);
+        assert_eq!(r.label.integ_level(), IntegLevel::Untrusted);
+    }
+
+    #[test]
+    fn deterministic_value_recomputes() {
+        let a = raw("foo", SourceClass::LocalFile);
+        let b = raw("bar", SourceClass::LocalFile);
+        let deriv = MemoryDerivation::Deterministic {
+            input_hashes: vec![a.content_hash(), b.content_hash()],
+            transform: TransformId::new("concat"),
+        };
+        let label = derive_label(&deriv, &[&a, &b]);
+        let rec = MemoryRecord::new("foobar", SchemaType::String, label, deriv);
+        assert!(verify_admission(&rec, &[&a, &b], &concat_registry()).is_match());
+    }
+
+    #[test]
+    fn deterministic_forged_value_is_rejected() {
+        // MINJA/MemoryGraft seam: a "summary" that does not follow from sources.
+        let a = raw("foo", SourceClass::LocalFile);
+        let b = raw("bar", SourceClass::LocalFile);
+        let deriv = MemoryDerivation::Deterministic {
+            input_hashes: vec![a.content_hash(), b.content_hash()],
+            transform: TransformId::new("concat"),
+        };
+        let label = derive_label(&deriv, &[&a, &b]);
+        let forged = MemoryRecord::new("attacker-payload", SchemaType::String, label, deriv);
+        match verify_admission(&forged, &[&a, &b], &concat_registry()) {
+            RecomputeVerdict::Mismatch { field, .. } => assert_eq!(field, "value"),
+            other => panic!("expected value mismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn integrity_floors_to_worst_parent() {
+        // Deterministic over a trusted file + an adversarial web source ⇒ adversarial.
+        let trusted = raw("ok", SourceClass::LocalFile);
+        let evil = raw("evil", SourceClass::Web);
+        let deriv = MemoryDerivation::Deterministic {
+            input_hashes: vec![trusted.content_hash(), evil.content_hash()],
+            transform: TransformId::new("concat"),
+        };
+        let label = derive_label(&deriv, &[&trusted, &evil]);
+        assert_eq!(label.integ_level(), IntegLevel::Adversarial);
+    }
+
+    #[test]
+    fn claimed_label_exceeding_lineage_is_rejected() {
+        // Claim Trusted integrity over an adversarial web ingest.
+        let deriv = MemoryDerivation::RawIngest {
+            source_class: SourceClass::Web,
+            source_hash: ContentHash::of_canonical_bytes(b"x"),
+        };
+        let liar = MemoryRecord::new(
+            "x",
+            SchemaType::String,
+            MemoryLabel::from_levels_with_derivation(
+                ConfLevel::Public,
+                IntegLevel::Trusted,
+                DerivationClass::Deterministic,
+            ),
+            deriv,
+        );
+        match verify_admission(&liar, &[], &concat_registry()) {
+            RecomputeVerdict::Mismatch { field, .. } => assert_eq!(field, "label"),
+            other => panic!("expected label mismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn opaque_llm_is_quarantined() {
+        let ctx = raw("context", SourceClass::LocalFile);
+        let deriv = MemoryDerivation::OpaqueLlm {
+            input_hashes: vec![ctx.content_hash()],
+            model_tag: "some-model".to_string(),
+        };
+        let label = derive_label(&deriv, &[&ctx]);
+        let rec = MemoryRecord::new("llm output", SchemaType::String, label, deriv);
+        assert_eq!(rec.label.integ_level(), IntegLevel::Adversarial);
+        // join with the OpaqueExternal parent keeps it tainted (never Deterministic).
+        assert_ne!(rec.label.derivation, DerivationClass::Deterministic);
+        assert_eq!(
+            rec.authority(),
+            portcullis_core::memory::MemoryAuthority::MayNotAuthorize
+        );
+        assert!(verify_admission(&rec, &[&ctx], &concat_registry()).is_match());
+    }
+}

--- a/crates/nucleus-provenance-memory/src/record.rs
+++ b/crates/nucleus-provenance-memory/src/record.rs
@@ -1,0 +1,241 @@
+//! [`MemoryRecord`] — the one content-addressed, taint-labeled, lineage-anchored
+//! memory object, and its [`MemoryDerivation`] (how it was produced).
+
+use nucleus_lineage::SourceClass;
+use portcullis_core::memory::{MemoryAuthority, MemoryLabel, SchemaType};
+use serde::{Deserialize, Serialize};
+
+use crate::hash::ContentHash;
+
+/// Names a registered, deterministic transform (the only kind whose output is
+/// recomputable). Resolved against a [`crate::recompute::TransformRegistry`].
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct TransformId(pub String);
+
+impl TransformId {
+    /// Construct from any string-like name.
+    pub fn new(s: impl Into<String>) -> Self {
+        Self(s.into())
+    }
+}
+
+/// How a record's value was produced — the provenance claim the admission gate
+/// re-derives against.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+pub enum MemoryDerivation {
+    /// Ingested verbatim from an external source. No derivation to recompute;
+    /// the label is fixed by the source's trust class (Web/RagIndex/Memory are
+    /// adversarial). `source_hash` pins exactly what was ingested.
+    RawIngest {
+        /// Trust class of the origin.
+        source_class: SourceClass,
+        /// Content hash of the ingested bytes.
+        source_hash: ContentHash,
+    },
+    /// Produced by a **deterministic** transform over cited source records. This
+    /// is the recomputable class: the admission gate re-runs `transform` over the
+    /// `input_hashes` records and requires the result to hash-match.
+    Deterministic {
+        /// Content hashes of the cited source records (must already be admitted).
+        input_hashes: Vec<ContentHash>,
+        /// The registered transform that maps the inputs to this value.
+        transform: TransformId,
+    },
+    /// Produced by a non-deterministic LLM step. **Not recomputable** — quarantined
+    /// as `AIDerived` / `MayNotAuthorize`; can never reach `MayInform` without an
+    /// explicit `HumanPromoted` declassify witness.
+    OpaqueLlm {
+        /// Content hashes of the records fed to the model (context lineage).
+        input_hashes: Vec<ContentHash>,
+        /// Opaque model identifier (for audit, not trust).
+        model_tag: String,
+    },
+}
+
+impl MemoryDerivation {
+    /// The cited parent hashes (for the lineage DAG), regardless of kind. For
+    /// [`MemoryDerivation::RawIngest`] this is the hash of the ingested bytes —
+    /// a leaf source, NOT an admitted record (see [`Self::input_record_hashes`]).
+    pub fn parent_hashes(&self) -> Vec<ContentHash> {
+        match self {
+            MemoryDerivation::RawIngest { source_hash, .. } => vec![*source_hash],
+            MemoryDerivation::Deterministic { input_hashes, .. }
+            | MemoryDerivation::OpaqueLlm { input_hashes, .. } => input_hashes.clone(),
+        }
+    }
+
+    /// The hashes of cited **admitted records** this derivation depends on (which
+    /// the CRDT must already hold to recompute). Empty for
+    /// [`MemoryDerivation::RawIngest`] — its `source_hash` is raw ingested bytes,
+    /// not a [`MemoryRecord`].
+    pub fn input_record_hashes(&self) -> Vec<ContentHash> {
+        match self {
+            MemoryDerivation::RawIngest { .. } => Vec::new(),
+            MemoryDerivation::Deterministic { input_hashes, .. }
+            | MemoryDerivation::OpaqueLlm { input_hashes, .. } => input_hashes.clone(),
+        }
+    }
+}
+
+/// The identity-bearing fields of a record — everything the [`ContentHash`]
+/// commits to. **Excludes** `label`/`authority`: those are *derived* from the
+/// derivation + parents and *validated* on admission, so a mislabeled record with
+/// otherwise-identical content collides on the same key and is caught fail-closed
+/// by [`crate::ProvenanceMemorySet`] rather than silently coexisting.
+#[derive(Serialize)]
+struct RecordIdentity<'a> {
+    value: &'a str,
+    schema: &'a SchemaType,
+    derivation: &'a MemoryDerivation,
+}
+
+/// A provenance-backed, taint-labeled memory record.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MemoryRecord {
+    /// The stored value.
+    pub value: String,
+    /// Value schema (string / json / binary).
+    pub schema: SchemaType,
+    /// IFC label: confidentiality × integrity × derivation class. Derived from
+    /// the derivation + parents by the admission gate and validated to match.
+    pub label: MemoryLabel,
+    /// How this value was produced — the recompute claim.
+    pub derivation: MemoryDerivation,
+}
+
+impl MemoryRecord {
+    /// Construct a record with an explicit (claimed) label. The label is only
+    /// *trusted* once [`crate::ProvenanceMemorySet::verified_admit`] confirms it
+    /// equals the label recomputed from the derivation + parents.
+    pub fn new(
+        value: impl Into<String>,
+        schema: SchemaType,
+        label: MemoryLabel,
+        derivation: MemoryDerivation,
+    ) -> Self {
+        Self {
+            value: value.into(),
+            schema,
+            label,
+            derivation,
+        }
+    }
+
+    /// Canonical identity bytes: domain-tagged serialization of the
+    /// identity-bearing fields (value, schema, derivation). Label is excluded
+    /// (see [`RecordIdentity`]).
+    pub fn canonical_bytes(&self) -> Vec<u8> {
+        let id = RecordIdentity {
+            value: &self.value,
+            schema: &self.schema,
+            derivation: &self.derivation,
+        };
+        // Infallible for these concrete, map-free types.
+        serde_json::to_vec(&id).expect("record identity serialization is infallible")
+    }
+
+    /// The content address of this record (over its identity bytes).
+    pub fn content_hash(&self) -> ContentHash {
+        ContentHash::of_canonical_bytes(&self.canonical_bytes())
+    }
+
+    /// The authority of this record, derived from its integrity level. Not
+    /// stored: `Adversarial` ⇒ `MayNotAuthorize`, otherwise `MayInform`.
+    pub fn authority(&self) -> MemoryAuthority {
+        MemoryAuthority::from_integrity(self.label.integ_level())
+    }
+
+    /// The cited parent hashes (lineage DAG edges).
+    pub fn parent_hashes(&self) -> Vec<ContentHash> {
+        self.derivation.parent_hashes()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use portcullis_core::{ConfLevel, DerivationClass, IntegLevel};
+
+    fn lbl(c: ConfLevel, i: IntegLevel, d: DerivationClass) -> MemoryLabel {
+        MemoryLabel::from_levels_with_derivation(c, i, d)
+    }
+
+    #[test]
+    fn content_hash_excludes_label() {
+        // Same value+schema+derivation but different labels ⇒ SAME content hash.
+        // (The CRDT then catches the label divergence fail-closed.)
+        let deriv = MemoryDerivation::RawIngest {
+            source_class: SourceClass::Web,
+            source_hash: ContentHash::of_canonical_bytes(b"src"),
+        };
+        let a = MemoryRecord::new(
+            "v",
+            SchemaType::String,
+            lbl(
+                ConfLevel::Public,
+                IntegLevel::Adversarial,
+                DerivationClass::OpaqueExternal,
+            ),
+            deriv.clone(),
+        );
+        let b = MemoryRecord::new(
+            "v",
+            SchemaType::String,
+            lbl(
+                ConfLevel::Secret,
+                IntegLevel::Trusted,
+                DerivationClass::Deterministic,
+            ),
+            deriv,
+        );
+        assert_eq!(a.content_hash(), b.content_hash());
+    }
+
+    #[test]
+    fn content_hash_tracks_value_and_derivation() {
+        let d = MemoryDerivation::RawIngest {
+            source_class: SourceClass::Web,
+            source_hash: ContentHash::of_canonical_bytes(b"s"),
+        };
+        let r1 = MemoryRecord::new(
+            "a",
+            SchemaType::String,
+            lbl(
+                ConfLevel::Public,
+                IntegLevel::Untrusted,
+                DerivationClass::Deterministic,
+            ),
+            d.clone(),
+        );
+        let r2 = MemoryRecord::new(
+            "b",
+            SchemaType::String,
+            lbl(
+                ConfLevel::Public,
+                IntegLevel::Untrusted,
+                DerivationClass::Deterministic,
+            ),
+            d,
+        );
+        assert_ne!(r1.content_hash(), r2.content_hash());
+    }
+
+    #[test]
+    fn authority_follows_integrity() {
+        let adversarial = MemoryRecord::new(
+            "x",
+            SchemaType::String,
+            lbl(
+                ConfLevel::Public,
+                IntegLevel::Adversarial,
+                DerivationClass::OpaqueExternal,
+            ),
+            MemoryDerivation::RawIngest {
+                source_class: SourceClass::Web,
+                source_hash: ContentHash::of_canonical_bytes(b"s"),
+            },
+        );
+        assert_eq!(adversarial.authority(), MemoryAuthority::MayNotAuthorize);
+    }
+}

--- a/crates/portcullis-core/src/memory.rs
+++ b/crates/portcullis-core/src/memory.rs
@@ -136,7 +136,7 @@ impl Default for MemorySourceProvenance {
 /// (#1220). Older serialized entries without this field default to `Deterministic`
 /// for backward compatibility; new entries should set derivation explicitly via
 /// [`MemoryLabel::from_levels_with_derivation`].
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MemoryLabel {
     /// Confidentiality level (public, internal, secret).
     pub confidentiality: ConfLevel,


### PR DESCRIPTION
## Next Bet #1 — provenance-backed memory that closes the poisoning gap

The [2025–26 threat-map](https://github.com/coproduct-opensource/nucleus) flagged **persistent memory poisoning** (AgentPoison NeurIPS'24, MINJA NeurIPS'25, MemoryGraft Dec'25) as the #1 gap Nucleus didn't structurally cover. An attacker who plants a record into an agent's long-term memory — often **query-only, with no write access** — steers its later actions across sessions. Capability-first frameworks (MemGPT/Letta, mem0, A-MEM) trust stored memory by default; this crate treats it as **untrusted until a record re-derives from its cited sources AND is declassified by a signed witness**.

### One object, five properties
New crate `nucleus-provenance-memory` assembles five already-proven nucleus primitives into one `MemoryRecord`: content-hash-idempotent · taint-labeled (`portcullis-core` `MemoryLabel`) · signed-lineage-anchored (`nucleus-lineage` `DocumentRetrieved{source_class: Memory}` — wires the previously documented-but-unwired binding) · recompute-verified · CRDT-mergeable (`ProvenanceMemorySet`, structurally ported from the proven `nucleus_creditworthiness::ReputationSet`).

### Differentiates on the 3 things neither 2026 preprint does
Honest related work: **MemLineage** (arXiv 2605.14421) and **Portable Agent Memory** (arXiv 2605.11032) overlap the thesis. This crate occupies the territory neither does:

1. **Recompute of the DERIVATION step, not just the hash.** `derive_label` re-derives a record's IFC label via the taint-propagation lattice (conf-join, integ-meet, `DerivationClass`-join — "promotion does not cleanse"), and `Deterministic` records have their **value** recomputed via a generic `RecomputeMemory` transform. A planted "summary" that doesn't follow from its sources is **rejected** — the MINJA/MemoryGraft seam. Non-deterministic LLM output is quarantined as `OpaqueLlm` (Adversarial/AIDerived, `MayNotAuthorize`), never auto-promoted.
2. **Recompute-gated CRDT merge.** `verified_admit` re-derives before admitting; `join` is idempotent/commutative/associative and **fail-closed on label divergence** (most-restrictive merge) — a forged record never joins, replicas converge.
3. **Read-side IFC.** Records carry `ConfLevel`, not integrity-only.

### Headline gate — signed declassification
A `MayNotAuthorize` record reaches informing context only via a `SignedDeclassify`: a **k-of-n** Ed25519-cosigned `DeclassifyWitness` (move-7 quorum discipline; **zero threshold rejected fail-closed**), promoting integrity at most to `Untrusted` (never `Trusted`) and joining the target derivation so ancestry survives.

### Reuse vs net-new
The generic recompute trait is **decoupled from the econ kernels** (vs the econ-bound `nucleus-recompute`). Also derives `PartialEq/Eq` on `portcullis-core` `MemoryLabel` (a plain value type that should be comparable).

### Honest v1 scope
Deterministic derivations only; LLM summaries quarantined, not verified. Provenance is only as strong as key custody (same assumption as MemLineage / Portable Memory). Adaptive/laundering adversaries + the quantitative-IFC lattice upgrade deferred. No transport (CRDT is pure).

### Verification (macOS)
31 crate tests + clippy clean; `nucleus-memory` 17+1 and `portcullis-core` memory module 40 tests green with the `MemoryLabel` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)