### PR TITLE
feat(mcp): adversarial McpToolResult taint kind — close the run-output taint gap (next-bet #2, phase 2)

### DIFF
--- a/crates/nucleus-tool-proxy/src/mcp.rs
+++ b/crates/nucleus-tool-proxy/src/mcp.rs
@@ -188,6 +188,25 @@ impl NucleusMcpServer {
         }
     }
 
+    /// Taint a tool RESULT as adversarial (most-paranoid next-bet #2): an
+    /// embedded instruction in the result then cannot drive a subsequent
+    /// privileged action (the next `run`/`git push`/`write`/`create_pr` hits the
+    /// IFC egress gate, since `McpToolResult` is `Adversarial` ⇒ `is_tainted`).
+    ///
+    /// **Opt-in** via `NUCLEUS_PARANOID_TOOL_IO=1`. Off by default because
+    /// blanket-tainting the proxy's own command output makes a session
+    /// "one privileged action then locked" (run-tests → can't commit) — a policy
+    /// choice an operator should make deliberately. The human-authorized
+    /// `cleanse` path clears the taint when on.
+    async fn observe_tool_result(&self) {
+        let paranoid = std::env::var("NUCLEUS_PARANOID_TOOL_IO")
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false);
+        if paranoid {
+            self.observe_flow(NodeKind::McpToolResult).await;
+        }
+    }
+
     /// Check the kernel for a decision on the given operation/subject.
     ///
     /// Constructs an [`ActionTerm`] and routes through [`Kernel::decide_term`],
@@ -452,6 +471,9 @@ impl NucleusMcpServer {
         }) {
             Ok(output) => {
                 self.record_verdict(Operation::RunBash, &subject, VerdictOutcome::Allow);
+                // Most-paranoid #2: command output may carry injected instructions;
+                // taint it (opt-in) so it can't drive a later privileged action.
+                self.observe_tool_result().await;
                 let run_result = RunResult {
                     exit_code: output.status.code().unwrap_or(-1),
                     stdout: String::from_utf8_lossy(&output.stdout).to_string(),

--- a/crates/portcullis-core/src/flow.rs
+++ b/crates/portcullis-core/src/flow.rs
@@ -34,6 +34,12 @@ pub enum NodeKind {
     ToolResponse,
     /// Web content — public, adversarial, no authority.
     WebContent,
+    /// MCP tool result from an UPSTREAM / untrusted tool (most-paranoid
+    /// next-bet #2). **Adversarial** integrity (like web content): an embedded
+    /// instruction in a tool result must not be able to drive a subsequent
+    /// privileged action. Distinct from `ToolResponse` (the proxy's own trusted
+    /// tool output, merely `Untrusted`), so it actually trips `is_tainted`.
+    McpToolResult,
     /// Memory entry — internal, untrusted, informational authority.
     MemoryRead,
     /// Memory write — outbound action that persists data.
@@ -146,6 +152,7 @@ impl NodeKind {
             "user_prompt" => Self::UserPrompt,
             "tool_response" => Self::ToolResponse,
             "web_content" => Self::WebContent,
+            "mcp_tool_result" => Self::McpToolResult,
             "memory_read" => Self::MemoryRead,
             "memory_write" => Self::MemoryWrite,
             "file_read" => Self::FileRead,
@@ -175,6 +182,7 @@ impl NodeKind {
             Self::UserPrompt => 0,
             Self::ToolResponse => 1,
             Self::WebContent => 2,
+            Self::McpToolResult => 20,
             Self::MemoryRead => 3,
             Self::MemoryWrite => 4,
             Self::FileRead => 5,
@@ -202,6 +210,7 @@ impl NodeKind {
             Self::UserPrompt => "user_prompt",
             Self::ToolResponse => "tool_response",
             Self::WebContent => "web_content",
+            Self::McpToolResult => "mcp_tool_result",
             Self::MemoryRead => "memory_read",
             Self::MemoryWrite => "memory_write",
             Self::FileRead => "file_read",
@@ -268,6 +277,9 @@ pub fn intrinsic_label(kind: NodeKind, now: u64) -> IFCLabel {
         NodeKind::UserPrompt => IFCLabel::user_prompt(now),
         NodeKind::ToolResponse => IFCLabel::tool_response(now),
         NodeKind::WebContent => IFCLabel::web_content(now),
+        // Upstream/untrusted MCP tool result: adversarial, exactly like web
+        // content (public, adversarial integrity, no authority).
+        NodeKind::McpToolResult => IFCLabel::web_content(now),
         NodeKind::MemoryRead => IFCLabel::memory_entry(now),
         NodeKind::MemoryWrite => IFCLabel {
             confidentiality: ConfLevel::Internal,

--- a/crates/portcullis-core/src/ifc_api.rs
+++ b/crates/portcullis-core/src/ifc_api.rs
@@ -796,6 +796,32 @@ mod tests {
     }
 
     #[test]
+    fn mcp_tool_result_is_adversarial_and_taints() {
+        // most-paranoid #2: an upstream/untrusted MCP tool result is adversarial
+        // (like web content) and taints the session — distinct from the proxy's
+        // own ToolResponse, which is merely Untrusted and does NOT taint.
+        use crate::flow::intrinsic_label;
+        assert_eq!(
+            intrinsic_label(NodeKind::McpToolResult, 0).integrity,
+            IntegLevel::Adversarial
+        );
+        let mut t = FlowTracker::new();
+        t.observe(NodeKind::McpToolResult).unwrap();
+        assert!(
+            t.is_tainted(),
+            "an untrusted tool result must taint the session"
+        );
+
+        // The distinction that motivates the new kind: ToolResponse does NOT taint.
+        let mut clean = FlowTracker::new();
+        clean.observe(NodeKind::ToolResponse).unwrap();
+        assert!(
+            !clean.is_tainted(),
+            "trusted proxy tool output must not taint"
+        );
+    }
+
+    #[test]
     fn parent_not_found_error() {
         let mut t = FlowTracker::new();
         let err = t

--- a/crates/portcullis-core/src/prov_export.rs
+++ b/crates/portcullis-core/src/prov_export.rs
@@ -130,6 +130,7 @@ fn prov_category(kind: NodeKind) -> ProvCategory {
         // Entities: data that exists
         NodeKind::FileRead
         | NodeKind::WebContent
+        | NodeKind::McpToolResult
         | NodeKind::MemoryRead
         | NodeKind::EnvVar
         | NodeKind::Secret
@@ -193,6 +194,7 @@ fn node_kind_str(kind: NodeKind) -> &'static str {
         NodeKind::UserPrompt => "UserPrompt",
         NodeKind::ToolResponse => "ToolResponse",
         NodeKind::WebContent => "WebContent",
+        NodeKind::McpToolResult => "McpToolResult",
         NodeKind::MemoryRead => "MemoryRead",
         NodeKind::MemoryWrite => "MemoryWrite",
         NodeKind::FileRead => "FileRead",

--- a/crates/portcullis/src/exposure_core.rs
+++ b/crates/portcullis/src/exposure_core.rs
@@ -201,6 +201,31 @@ mod tests {
     use super::*;
 
     #[test]
+    fn tainted_mcp_tool_result_blocks_privileged_action() {
+        // most-paranoid #2: a tainted (adversarial) MCP tool result must block a
+        // subsequent privileged outbound action via the live egress gate.
+        use portcullis_core::flow::NodeKind;
+        use portcullis_core::ifc_api::FlowTracker;
+        let mut flow = FlowTracker::new();
+        flow.observe(NodeKind::McpToolResult).unwrap();
+        assert!(
+            ifc_egress_denial(&flow, Operation::GitPush, NodeKind::OutboundAction).is_some(),
+            "tainted tool result must block git push"
+        );
+        assert!(
+            ifc_egress_denial(&flow, Operation::RunBash, NodeKind::OutboundAction).is_some(),
+            "tainted tool result must block a subsequent run"
+        );
+        // Negative control (honest scoping): WebFetch is classified as a SOURCE
+        // (WebContent), not a gated sink, so taint does not block it — web egress
+        // is governed by the DNS/URL allowlist instead.
+        assert!(
+            ifc_egress_denial(&flow, Operation::WebFetch, NodeKind::WebContent).is_none(),
+            "web_fetch is a source, not a taint-gated sink"
+        );
+    }
+
+    #[test]
     fn test_classify_operation_coverage() {
         // Every operation variant maps to something
         let ops = [

--- a/crates/portcullis/src/hook_adapter.rs
+++ b/crates/portcullis/src/hook_adapter.rs
@@ -147,6 +147,7 @@ pub fn source_category(kind: NodeKind) -> SourceCategory {
             SourceCategory::Trusted
         }
         NodeKind::WebContent
+        | NodeKind::McpToolResult
         | NodeKind::CachedDatum
         | NodeKind::ImageContent
         | NodeKind::AudioContent


### PR DESCRIPTION
## Next-Bets Phase 2 — tainted-by-default MCP tool I/O

**Honest scoping first:** `nucleus-tool-proxy` is an **MCP server only** (no upstream MCP client), so the upstream rug-pull / schema-mutation surface doesn't structurally exist in this binary — that defense (persisted schema pin + diff-on-reconnect) is **deferred** until an outbound MCP client lands. This PR ships the part with a **real live gap today**.

### The gap
The IFC egress gate denies an outbound op only when the session `is_tainted()`, and `is_tainted()` fires only on `IntegLevel::Adversarial`. The existing `NodeKind::ToolResponse` is merely `Untrusted` (does **not** taint), and the `run` tool's success arm **never observed its output at all** — so command output entered the session untainted and could carry an injected instruction into a later privileged action.

### The fix
- **`NodeKind::McpToolResult`** (portcullis-core) — `Adversarial` integrity (`intrinsic_label = web_content`), so an untrusted tool result actually trips `is_tainted`, unlike `ToolResponse`. Exhaustive-match arms added across `flow.rs`, `prov_export.rs` (feature-gated entity + `node_kind_str`), and portcullis `hook_adapter.rs` (`source_category → Adversarial`).
- **`observe_tool_result()`** (mcp.rs) taints the `run` success-arm output, **opt-in via `NUCLEUS_PARANOID_TOOL_IO=1`**. Off by default because blanket-tainting the proxy's own command output makes a session *"one privileged action then locked"* (run-tests → can't commit) — an operator policy choice, not a safe unilateral default. On ⇒ an injected instruction in a command's output cannot drive a subsequent `run`/`git push`/`write`/`create_pr`; the human-authorized cleanse path clears it.

### Tests
- portcullis-core: `McpToolResult` is `Adversarial` + taints; `ToolResponse` does **not** (the distinction that motivates the new kind).
- portcullis: tainted `McpToolResult` blocks `GitPush` + `RunBash` via the **live `ifc_egress_denial` gate**; `WebFetch` negative control documents (honestly) that web_fetch is a *source*, not a taint-gated sink (DNS/URL allowlist governs it).

### Verification (macOS)
portcullis-core + portcullis taint tests pass; tool-proxy suites (incl. Phase-1 `memory_ifc_e2e`) green; clippy clean (3 crates); `cargo hack --each-feature` clean.

### Deferred (the build-later half, noted)
(A) persisted cross-restart tool-schema pin + diff (TOFU supply-chain pin of the proxy's own tools; lights up the existing `ToolSchemaRegistry`); the outbound MCP-client integration where `McpToolResult` becomes load-bearing at upstream ingest (`McpMediator` gains a `FlowTracker`); a dedicated `Operation::MemoryRead/Write` axis; treating `WebFetch` as `OutboundAction` if web-exfil must be taint-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)