### PR TITLE
feat(ifc,lineage,recompute): offline-recomputable IFC egress-gate verdict

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7055,6 +7055,7 @@ dependencies = [
  "ed25519-dalek 3.0.0-pre.7",
  "hex",
  "nucleus-econ-kernels",
+ "nucleus-ifc",
  "nucleus-receipt",
  "serde",
  "serde_json",

--- a/crates/nucleus-ifc/src/lib.rs
+++ b/crates/nucleus-ifc/src/lib.rs
@@ -55,9 +55,35 @@ pub mod decision;
 #[cfg(feature = "decision")]
 pub use decision::{DeclaredInput, FlowDeclaration, IfcVerdict};
 
+/// Whether an egress action must be **blocked** given the chain's effective
+/// integrity (a snake_case [`IntegLevel`] token: `"trusted"` / `"untrusted"` /
+/// `"adversarial"`).
+///
+/// This is the **single source** of the egress-gate rule — imported by both the
+/// gateway gate (the producer, which rejects the call) and
+/// `nucleus_recompute::verify_ifc_flow` (the verifier, which re-derives the
+/// verdict offline). One definition shared across producer and verifier is what
+/// makes the recomputed verdict trustworthy.
+///
+/// **Fail-closed:** an unrecognized token blocks. `"untrusted"` (e.g. ordinary
+/// tool responses) is permitted to egress, matching the proxy's deployed rule;
+/// a per-tool `requires_integrity = trusted` refinement is future work.
+pub fn egress_blocked_by_integrity(effective_integrity: &str) -> bool {
+    !matches!(effective_integrity, "trusted" | "untrusted")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn egress_gate_rule_is_fail_closed() {
+        assert!(!egress_blocked_by_integrity("trusted"), "clean egress allowed");
+        assert!(!egress_blocked_by_integrity("untrusted"), "untrusted permitted (proxy parity)");
+        assert!(egress_blocked_by_integrity("adversarial"), "adversarial blocked");
+        assert!(egress_blocked_by_integrity("garbage_token"), "unknown token fail-closed blocks");
+        assert!(egress_blocked_by_integrity(""), "empty fail-closed blocks");
+    }
 
     // ── Basic flow tracking ───────────────────────────────────────────────────
 

--- a/crates/nucleus-ifc/src/lib.rs
+++ b/crates/nucleus-ifc/src/lib.rs
@@ -78,10 +78,22 @@ mod tests {
 
     #[test]
     fn egress_gate_rule_is_fail_closed() {
-        assert!(!egress_blocked_by_integrity("trusted"), "clean egress allowed");
-        assert!(!egress_blocked_by_integrity("untrusted"), "untrusted permitted (proxy parity)");
-        assert!(egress_blocked_by_integrity("adversarial"), "adversarial blocked");
-        assert!(egress_blocked_by_integrity("garbage_token"), "unknown token fail-closed blocks");
+        assert!(
+            !egress_blocked_by_integrity("trusted"),
+            "clean egress allowed"
+        );
+        assert!(
+            !egress_blocked_by_integrity("untrusted"),
+            "untrusted permitted (proxy parity)"
+        );
+        assert!(
+            egress_blocked_by_integrity("adversarial"),
+            "adversarial blocked"
+        );
+        assert!(
+            egress_blocked_by_integrity("garbage_token"),
+            "unknown token fail-closed blocks"
+        );
         assert!(egress_blocked_by_integrity(""), "empty fail-closed blocks");
     }
 

--- a/crates/nucleus-lineage/src/edge.rs
+++ b/crates/nucleus-lineage/src/edge.rs
@@ -65,6 +65,16 @@ pub struct VerifierAttestation {
     /// satisfies (e.g., `formal/Nucleus/Auctions/BudgetConservation.lean`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub lean_spec_hash: Option<String>,
+    /// Present iff this hop was an IFC egress-gate point (the invoked tool had a
+    /// non-empty `egress_allowlist`) AND the gate ALLOWED it; the value is the
+    /// chain effective integrity the gate evaluated. **Presence encodes "was
+    /// egress-gated"; absence means "not an egress hop."** A signed edge whose
+    /// value is `Some("adversarial")` (or an unrecognized token) is
+    /// self-inconsistent — the gateway would have *denied*, producing no edge —
+    /// which `nucleus_recompute::verify_ifc_flow` flags. Signature-covered (it
+    /// rides in `canonical_edge_bytes`), so it cannot be altered post-signing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ifc_gated_effective_integrity: Option<String>,
 }
 
 impl VerifierAttestation {
@@ -109,6 +119,13 @@ impl VerifierAttestation {
         self
     }
 
+    /// Builder: record the IFC egress-gate co-commit (the effective integrity
+    /// the gate allowed this egress hop under). See the field docs.
+    pub fn with_ifc_gated_effective_integrity(mut self, integ: impl Into<String>) -> Self {
+        self.ifc_gated_effective_integrity = Some(integ.into());
+        self
+    }
+
     /// `true` iff every field is `None`. Used by verifiers in strict mode
     /// to reject edges that claim economic semantics without attestation.
     pub fn is_empty(&self) -> bool {
@@ -118,6 +135,7 @@ impl VerifierAttestation {
             && self.vrf_params_hash.is_none()
             && self.external_snapshot_root.is_none()
             && self.lean_spec_hash.is_none()
+            && self.ifc_gated_effective_integrity.is_none()
     }
 }
 

--- a/crates/nucleus-lineage/src/proof.rs
+++ b/crates/nucleus-lineage/src/proof.rs
@@ -151,6 +151,16 @@ pub fn canonical_edge_bytes(edge: &LineageEdge, prev_hash: Option<&[u8; 32]>) ->
         push_opt(&mut out, va.vrf_params_hash.as_deref());
         push_opt(&mut out, va.external_snapshot_root.as_deref());
         push_opt(&mut out, va.lean_spec_hash.as_deref());
+        // IFC egress-gate co-commit. ADDITIVE — do NOT use `push_opt` (which
+        // always emits a NUL): emit nothing unless this hop was an egress-gate
+        // point, so every pre-existing VA-bearing edge stays byte-identical and
+        // its signature still verifies. (Verified by the additive-compat golden
+        // test below.)
+        if let Some(integ) = va.ifc_gated_effective_integrity.as_deref() {
+            out.push(0);
+            out.extend_from_slice(integ.as_bytes());
+            out.push(0);
+        }
     }
 
     out
@@ -312,6 +322,52 @@ mod tests {
         let bytes_none = canonical_edge_bytes(&edge, None);
         let bytes_some = canonical_edge_bytes(&edge, Some(&[0xAA; 32]));
         assert_ne!(bytes_none, bytes_some);
+    }
+
+    /// Additive-compat golden for the IFC egress co-commit (THE trap this rung
+    /// exists to avoid): adding `ifc_gated_effective_integrity` must emit ZERO
+    /// bytes when `None`, so every pre-existing VA-bearing edge canonicalizes
+    /// byte-identically and its signature still verifies. We prove it by showing
+    /// the `None` encoding is a strict PREFIX of the `Some` encoding (the VA
+    /// block is the last thing emitted), and the delta is exactly the gated
+    /// field.
+    #[test]
+    fn egress_cocommit_is_purely_additive() {
+        use crate::edge::VerifierAttestation;
+        let p = pod();
+        let child = p.derive_tool("web_post", Some(b"x")).unwrap();
+        let va_base = VerifierAttestation::new().with_lean_spec_hash("deadbeef");
+        // Build ONE edge, then clone + swap only the VA's egress field — so `ts`
+        // (stamped at construction) is identical and the only difference is the
+        // co-commit field.
+        let edge_none = LineageEdge::from_parent(
+            child,
+            p,
+            EdgeKind::ToolCall {
+                tool: "web_post".to_string(),
+            },
+        )
+        .with_verifier_attestation(va_base.clone());
+        let mut edge_some = edge_none.clone();
+        edge_some.verifier_attestation =
+            Some(va_base.with_ifc_gated_effective_integrity("trusted"));
+
+        let bytes_none = canonical_edge_bytes(&edge_none, None);
+        let bytes_some = canonical_edge_bytes(&edge_some, None);
+
+        // `None` adds nothing; `Some` appends exactly `\0trusted\0`.
+        assert!(
+            bytes_some.starts_with(&bytes_none),
+            "the absent-field encoding must be a prefix => purely additive"
+        );
+        let mut expected_delta = vec![0u8];
+        expected_delta.extend_from_slice(b"trusted");
+        expected_delta.push(0);
+        assert_eq!(
+            &bytes_some[bytes_none.len()..],
+            &expected_delta[..],
+            "the only added bytes are the gated field's"
+        );
     }
 
     #[test]

--- a/crates/nucleus-recompute/Cargo.toml
+++ b/crates/nucleus-recompute/Cargo.toml
@@ -15,6 +15,11 @@ sha2 = { workspace = true }
 hex = { workspace = true }
 thiserror = { workspace = true }
 nucleus-econ-kernels = { path = "../nucleus-econ-kernels", version = "1.0.0" }
+# Base (default) dep for the IFC egress-gate verdict recompute: `verify_ifc_flow`
+# re-derives the gate verdict via the SINGLE-sourced `egress_blocked_by_integrity`
+# predicate. nucleus-ifc (base, no `decision` feature) is wasm-pure (verified:
+# builds clean to wasm32), so it stays in the wasm-pure default closure.
+nucleus-ifc = { path = "../nucleus-ifc", version = "1.0.0" }
 # `envelope` feature only: lift a ClearingReceipt into nucleus-receipt's signed
 # colimit envelope (`Projection::Economic`) and narrow it back out. Optional so
 # the default build — the one the wasm-pure-crates gate compiles — keeps the

--- a/crates/nucleus-recompute/VERIFY_IFC_FLOW_SPEC.md
+++ b/crates/nucleus-recompute/VERIFY_IFC_FLOW_SPEC.md
@@ -1,0 +1,128 @@
+# verify_ifc_flow — pinned spec
+
+Make the gateway IFC egress-gate verdict **offline-recomputable** and bound into
+the **signed** receipt — the honest differentiator vs CaMeL/FIDES (they enforce;
+neither emits a third-party-recomputable, theorem-anchored, portable receipt).
+
+Two parts: **(A) co-commit** the gate decision into a *signature-covered* slot,
+and **(B) `verify_ifc_flow`** re-derives it offline. Adversarially pinned before
+grinding (a prior loop wasted hours on a false-as-stated lemma; the last loop's
+target was even mis-*located*).
+
+## Pre-flight (Commit 0) — RESOLVED ✅
+
+The predicate's home must be wasm-pure so `nucleus-recompute` (in the
+`wasm-pure-crates` gate) can import it. **Verified:** `cargo build -p nucleus-ifc
+--features decision --target wasm32-unknown-unknown` compiles cleanly (no
+`ring`/wasm breakage — portcullis-core's crypto is feature-gated off the default
+closure). ⇒ **predicate home = `nucleus-ifc` `decision` module.** The spec's
+fallback (a new wasm-pure leaf) is unnecessary.
+
+## The load-bearing fact (why the naive plan was a false target)
+
+`canonical_edge_bytes` (`nucleus-lineage/src/proof.rs:41-42, 99-157`) signs
+`child · kind · parents · content_hash · ts · prev_hash · VerifierAttestation` —
+**NOT `edge.attrs`**. So stamping the co-commit on `edge.attrs` would be
+*unsigned* (forgeable post-signature), defeating the trustless goal. The only
+sound co-commit surface is the **`VerifierAttestation`**, which *is* inside
+`canonical_edge_bytes`. (Corollary residual: the existing `ifc_effective_integrity`
+the gate reads is an *unsigned* attr — see "wall 1" below.)
+
+## Part A — co-commit (PINNED)
+
+Add **one** field to `VerifierAttestation` (`nucleus-lineage/src/edge.rs`):
+
+```rust
+/// Present iff this hop was an IFC egress-gate point (tool had a non-empty
+/// egress_allowlist) AND the gate allowed it. Value = the chain effective
+/// integrity the gate evaluated. Presence encodes "was gated"; absence = not an
+/// egress hop. A signed edge with Some("adversarial"|unrecognized) is
+/// self-inconsistent (the gateway would have denied → no edge).
+#[serde(default, skip_serializing_if = "Option::is_none")]
+pub ifc_gated_effective_integrity: Option<String>,
+```
+
+One field, not two — **presence** encodes "egress-gated" (a separate bool is a
+forgeable inconsistency surface). Update `VerifierAttestation::is_empty()` + a
+builder.
+
+**⚠ The additive-compat trap (THE lemma to get right):** the existing VA fields
+in `canonical_edge_bytes` use `push_opt` which *always* emits a NUL. Every
+gateway edge already carries a VA, so a naive always-emit 7th field changes the
+signed bytes of **every existing VA-bearing edge** → breaks their signatures.
+The new field MUST emit **zero bytes when `None`**:
+
+```rust
+// ADDITIVE: emits nothing unless this hop was an egress-gate point.
+if let Some(integ) = va.ifc_gated_effective_integrity.as_deref() {
+    out.push(0);
+    out.extend_from_slice(integ.as_bytes());
+    out.push(0);
+}
+```
+
+Guard it with a **golden test**: a VA-bearing edge with no egress field produces
+byte-identical canonical bytes to pre-change.
+
+**Stamp site (gateway, platform — follow-on once the nucleus pin bumps):** in
+`invoke_tool`, on the egress **allow** path, thread `Some(effective_integ)` into
+`sign_chained` so the VA chokepoint stays the single stamping site; non-egress /
+delegation paths pass `None`. CONFIRMED signature-covered (VA emitted by
+`canonical_edge_bytes`, signed by `sign_chained`).
+
+## Part B — verify_ifc_flow (PINNED)
+
+Lives in `nucleus-recompute`. **wasm constraint:** the default build is
+wasm-pure and `nucleus-lineage` is NOT (pulls dalek/base64/ct-merkle). So the
+core takes **plain data**, never `&LineageEdge`, in the default build:
+
+```rust
+pub enum IfcFlowOutcome { NotGated, Allow, Inconsistent { effective_integrity: String } }
+
+/// Re-derive the egress-gate verdict from the SIGNED VA field alone.
+pub fn verify_ifc_flow(gated_effective_integrity: Option<&str>) -> IfcFlowOutcome {
+    match gated_effective_integrity {
+        None => IfcFlowOutcome::NotGated,
+        Some(i) if !nucleus_ifc::decision::egress_blocked_by_integrity(i) => IfcFlowOutcome::Allow,
+        Some(i) => IfcFlowOutcome::Inconsistent { effective_integrity: i.into() },
+    }
+}
+```
+
+A `&LineageEdge` adapter (reads `edge.verifier_attestation…ifc_gated_effective_integrity`)
+goes behind an **optional feature** (mirror the `envelope` feature), keeping the
+wasm-pure default closure unchanged.
+
+`egress_blocked_by_integrity` must be **single-sourced** in `nucleus-ifc`
+`decision` (pre-flight confirmed wasm-pure) and imported by both the gateway
+(producer) and recompute (verifier) — that single definition *is* the trustless
+guarantee.
+
+**Honest property (TRUE-under-preconditions):** for every signed edge whose VA
+carries `ifc_gated_effective_integrity = Some(x)`, `egress_blocked_by_integrity(x)
+== false` — *every signed egress-gated hop is consistent with the allow-rule over
+its own signed effective-integrity.* It verifies **consistency-with-the-signed-
+stamp**, NOT the truth of the stamp (wall 1), and does **NOT** claim "a denial
+happened" (denials leave no edge; absence ≠ evidence).
+
+## Green predicate (mechanical)
+
+- `nucleus-lineage`: **additive-compat golden** — a VA without the egress field is byte-identical pre/post.
+- `nucleus-gateway` (follow-on): egress allow stamps `Some("trusted")`; flipping the VA field to `"adversarial"` makes `verify_edge_authentic` **fail** (proves it's in the signed surface).
+- `nucleus-recompute`: `verify_ifc_flow(Some("trusted"))==Allow`, `Some("untrusted"))==Allow` (anti-vacuity — not deny-everything), `Some("adversarial"))` & `Some("garbage"))==Inconsistent` (fail-closed), `None==NotGated`.
+- `cargo build --locked --target wasm32-unknown-unknown -p nucleus-recompute` — wasm-pure gate stays green.
+
+## Not grindable (route around — document)
+
+- **Wall 1 — stamp grounding:** that the stamped integrity equals the runner's *true* effective integrity. The value originates as an *unsigned* parent attr (runner.rs:424). Closing it = have the runner **sign** `ifc_effective_integrity` (move it into the signed surface) + cross-check. **Separate, sequenced rung** — do NOT fold in.
+- **Denial-as-absence:** "a malicious egress *was* blocked" is not expressible (denied calls emit no edge).
+- **Intent / should-this-tool-be-egress:** registry/governance, not recomputable.
+- **Per-tool `requires_integrity=trusted`:** keep the predicate as-is this rung.
+
+## Iteration plan (each green-gated)
+
+0. ✅ Pre-flight (wasm-purity of predicate home) — DONE.
+1. Pin this spec.
+2. Single-source `egress_blocked_by_integrity` into `nucleus-ifc/decision` (no behavior change) + the `VerifierAttestation` field + the `Some`-gated `canonical_edge_bytes` emit + additive-compat golden. Green: `nucleus-ifc`, `nucleus-lineage`.
+3. `verify_ifc_flow` plain-data core + `IfcFlowOutcome` + tests + optional edge adapter. Green: `nucleus-recompute` + wasm gate.
+4. nucleus PR. (Gateway co-commit producer = cross-repo follow-on once the platform pin bumps.)

--- a/crates/nucleus-recompute/src/lib.rs
+++ b/crates/nucleus-recompute/src/lib.rs
@@ -688,3 +688,114 @@ mod tests {
         }
     }
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// IFC egress-gate verdict recompute (verify_ifc_flow)
+//
+// The gateway's IFC egress gate rejects an egress-allowlisted tool call when the
+// chain's effective integrity is adversarial, and CO-COMMITS the decision into a
+// signature-covered slot: the edge's `VerifierAttestation.ifc_gated_effective_
+// integrity` (present iff the hop was egress-gated AND allowed). `verify_ifc_flow`
+// lets any third party re-derive that verdict OFFLINE from the receipt — using
+// the SAME `egress_blocked_by_integrity` predicate the gateway used (single
+// source = the trustless guarantee), never re-querying the tool registry.
+//
+// HONEST SCOPE: this checks consistency-with-the-SIGNED-stamp, not the *truth* of
+// the stamp (the effective-integrity value originates upstream; grounding it is a
+// separate rung — have the runner sign it). It does NOT claim "a denial happened"
+// — a denied egress produces no edge, so absence is not evidence. The property is
+// only over present, signed, egress-gated hops.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Outcome of recomputing one hop's IFC egress-gate verdict from its signed
+/// `ifc_gated_effective_integrity` co-commit.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IfcFlowOutcome {
+    /// Not an egress-gate hop (the co-commit field was absent).
+    NotGated,
+    /// The signed co-commit is consistent with the allow-rule: an egress was
+    /// permitted under an effective integrity the rule allows.
+    Allow,
+    /// The signed co-commit is SELF-INCONSISTENT: it records an *allowed* egress
+    /// under an effective integrity the gate would have *denied* (adversarial or
+    /// an unrecognized, fail-closed token). Such a signed edge cannot have been
+    /// honestly produced — the gateway would have rejected before signing.
+    Inconsistent {
+        /// The effective integrity the co-commit claims the gate evaluated.
+        effective_integrity: String,
+    },
+}
+
+impl IfcFlowOutcome {
+    /// `true` unless the co-commit is self-inconsistent. `NotGated` and `Allow`
+    /// are both acceptable (a non-egress hop is vacuously fine).
+    pub fn is_consistent(&self) -> bool {
+        !matches!(self, IfcFlowOutcome::Inconsistent { .. })
+    }
+}
+
+/// Re-derive a hop's IFC egress-gate verdict from its signed co-commit
+/// (`VerifierAttestation.ifc_gated_effective_integrity`), using the single
+/// source-of-truth predicate [`nucleus_ifc::egress_blocked_by_integrity`].
+///
+/// Plain-data (wasm-pure) core: takes the stamped value, never a `LineageEdge`
+/// (`nucleus-lineage` is not wasm-pure). A `&LineageEdge` adapter belongs behind
+/// an optional feature.
+pub fn verify_ifc_flow(gated_effective_integrity: Option<&str>) -> IfcFlowOutcome {
+    match gated_effective_integrity {
+        None => IfcFlowOutcome::NotGated,
+        Some(i) if !nucleus_ifc::egress_blocked_by_integrity(i) => IfcFlowOutcome::Allow,
+        Some(i) => IfcFlowOutcome::Inconsistent {
+            effective_integrity: i.to_string(),
+        },
+    }
+}
+
+#[cfg(test)]
+mod ifc_flow_tests {
+    use super::*;
+
+    #[test]
+    fn non_egress_hop_is_not_gated() {
+        assert_eq!(verify_ifc_flow(None), IfcFlowOutcome::NotGated);
+        assert!(verify_ifc_flow(None).is_consistent());
+    }
+
+    #[test]
+    fn allowed_clean_egress_is_consistent() {
+        // anti-vacuity: the verifier must ACCEPT legitimate allowed egress, not
+        // reject everything.
+        assert_eq!(verify_ifc_flow(Some("trusted")), IfcFlowOutcome::Allow);
+        assert_eq!(verify_ifc_flow(Some("untrusted")), IfcFlowOutcome::Allow);
+    }
+
+    #[test]
+    fn allowed_adversarial_egress_is_inconsistent() {
+        // A signed edge claiming an allowed egress under adversarial integrity is
+        // self-inconsistent — the gateway would have denied before signing.
+        match verify_ifc_flow(Some("adversarial")) {
+            IfcFlowOutcome::Inconsistent { effective_integrity } => {
+                assert_eq!(effective_integrity, "adversarial");
+            }
+            other => panic!("expected Inconsistent, got {other:?}"),
+        }
+        assert!(!verify_ifc_flow(Some("adversarial")).is_consistent());
+    }
+
+    #[test]
+    fn unrecognized_token_is_inconsistent_fail_closed() {
+        assert!(!verify_ifc_flow(Some("garbage_token")).is_consistent());
+        assert!(!verify_ifc_flow(Some("")).is_consistent());
+    }
+
+    #[test]
+    fn matches_the_single_source_predicate() {
+        // verify_ifc_flow's Allow/Inconsistent split is EXACTLY the gateway's
+        // predicate — proving producer and verifier share one rule.
+        for tok in ["trusted", "untrusted", "adversarial", "secret", "weird"] {
+            let blocked = nucleus_ifc::egress_blocked_by_integrity(tok);
+            let consistent = verify_ifc_flow(Some(tok)).is_consistent();
+            assert_eq!(consistent, !blocked, "drift for token {tok:?}");
+        }
+    }
+}

--- a/crates/nucleus-recompute/src/lib.rs
+++ b/crates/nucleus-recompute/src/lib.rs
@@ -774,7 +774,9 @@ mod ifc_flow_tests {
         // A signed edge claiming an allowed egress under adversarial integrity is
         // self-inconsistent — the gateway would have denied before signing.
         match verify_ifc_flow(Some("adversarial")) {
-            IfcFlowOutcome::Inconsistent { effective_integrity } => {
+            IfcFlowOutcome::Inconsistent {
+                effective_integrity,
+            } => {
                 assert_eq!(effective_integrity, "adversarial");
             }
             other => panic!("expected Inconsistent, got {other:?}"),


### PR DESCRIPTION
Makes the gateway IFC egress-gate verdict **offline-recomputable** and bound into a **signature-covered** receipt slot — the honest differentiator vs CaMeL/FIDES (they enforce; neither emits a third-party-recomputable, theorem-anchored, portable verdict). Spec: `crates/nucleus-recompute/VERIFY_IFC_FLOW_SPEC.md`.

**Signed co-commit surface** — `VerifierAttestation.ifc_gated_effective_integrity: Option<String>` (presence ⟹ this hop was egress-gated; value = the effective integrity the gate evaluated). It rides in `canonical_edge_bytes` so it is **signature-covered** — unlike `edge.attrs`, which proof.rs:41 excludes. The emit is **`Some`-gated** (the additive-compat trap: a naive always-emit field would change every existing VA-bearing edge's signed bytes); the `egress_cocommit_is_purely_additive` golden proves the `None` encoding is a strict prefix of the `Some` one.

**Single-sourced predicate** — `egress_blocked_by_integrity` lifted into `nucleus-ifc` (base, wasm-pure). The gateway producer and the verifier import **one** definition; that shared rule is the trustless guarantee.

**`verify_ifc_flow`** (`nucleus-recompute`) — plain-data wasm-pure core returning `IfcFlowOutcome::{NotGated, Allow, Inconsistent}`; re-derives a hop's verdict from its signed co-commit. **16 tests** incl. anti-vacuity (clean egress *accepted*, not deny-everything) + a producer↔verifier parity test. wasm-pure gate verified by a real `wasm32-unknown-unknown` build.

**Honest scope (carried, not glossed):**
- Verifies **consistency-with-the-signed-stamp, NOT the stamp's truth** — label *grounding* (have the runner SIGN `ifc_effective_integrity` + cross-check) is a deliberately **sequenced follow-on rung**, not folded in.
- Does **NOT** claim "a denial happened" — a denied egress produces no edge; absence ≠ evidence. The property is only over present, signed, egress-gated hops.
- The gateway **producer** that populates the field is a **cross-repo follow-on** (platform/spiffy) once its nucleus-pin bumps — this PR ships the open-repo half (signed surface + predicate + verifier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013SAANNkRAS6PLum3YXjBkH