### PR TITLE
feat(lineage,recompute): sign the IFC effective-integrity label (Level-1 grounding)

### DIFF
--- a/crates/nucleus-lineage/src/edge.rs
+++ b/crates/nucleus-lineage/src/edge.rs
@@ -75,6 +75,19 @@ pub struct VerifierAttestation {
     /// rides in `canonical_edge_bytes`), so it cannot be altered post-signing.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ifc_gated_effective_integrity: Option<String>,
+    /// The chain's **running effective integrity** as the runner attests it on a
+    /// summary edge — the *input* the egress gate evaluates (distinct from
+    /// [`Self::ifc_gated_effective_integrity`], which is the gate's *output*).
+    /// Signing it here (it rides in `canonical_edge_bytes`) makes the label
+    /// **tamper-evident + runner-attested** instead of an unsigned `attrs` entry
+    /// an attacker could downgrade. `nucleus_recompute::verify_ifc_flow_consistent`
+    /// cross-checks a child's gate-output against the parent's signed value here.
+    ///
+    /// HONEST SCOPE: this grounds *who attested the label* (non-repudiable), NOT
+    /// the label's *truth/completeness* — a compromised/under-declaring runner can
+    /// sign a false label. Grounding truth is a separate (Level-2) rung.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ifc_effective_integrity: Option<String>,
 }
 
 impl VerifierAttestation {
@@ -126,6 +139,13 @@ impl VerifierAttestation {
         self
     }
 
+    /// Builder: attest the chain's running effective integrity (the gate input).
+    /// See the field docs.
+    pub fn with_ifc_effective_integrity(mut self, integ: impl Into<String>) -> Self {
+        self.ifc_effective_integrity = Some(integ.into());
+        self
+    }
+
     /// `true` iff every field is `None`. Used by verifiers in strict mode
     /// to reject edges that claim economic semantics without attestation.
     pub fn is_empty(&self) -> bool {
@@ -136,6 +156,7 @@ impl VerifierAttestation {
             && self.external_snapshot_root.is_none()
             && self.lean_spec_hash.is_none()
             && self.ifc_gated_effective_integrity.is_none()
+            && self.ifc_effective_integrity.is_none()
     }
 }
 

--- a/crates/nucleus-lineage/src/proof.rs
+++ b/crates/nucleus-lineage/src/proof.rs
@@ -161,6 +161,14 @@ pub fn canonical_edge_bytes(edge: &LineageEdge, prev_hash: Option<&[u8; 32]>) ->
             out.extend_from_slice(integ.as_bytes());
             out.push(0);
         }
+        // Runner-attested running effective integrity (the gate INPUT). Same
+        // additive discipline — emit nothing unless `Some`, appended after the
+        // gated-co-commit block — so pre-existing VA edges stay byte-identical.
+        if let Some(integ) = va.ifc_effective_integrity.as_deref() {
+            out.push(0);
+            out.extend_from_slice(integ.as_bytes());
+            out.push(0);
+        }
     }
 
     out
@@ -368,6 +376,38 @@ mod tests {
             &expected_delta[..],
             "the only added bytes are the gated field's"
         );
+    }
+
+    /// Same additive-compat guarantee for the runner-attested
+    /// `ifc_effective_integrity` (the gate-INPUT label): `None` emits zero bytes;
+    /// `Some` appends exactly the field. Guards the same signature-breaking trap.
+    #[test]
+    fn effective_integrity_is_purely_additive() {
+        use crate::edge::VerifierAttestation;
+        let p = pod();
+        let child = p.derive_tool("web_post", Some(b"x")).unwrap();
+        let va_base = VerifierAttestation::new().with_lean_spec_hash("deadbeef");
+        let edge_none = LineageEdge::from_parent(
+            child,
+            p,
+            EdgeKind::ToolCall {
+                tool: "web_post".to_string(),
+            },
+        )
+        .with_verifier_attestation(va_base.clone());
+        let mut edge_some = edge_none.clone();
+        edge_some.verifier_attestation = Some(va_base.with_ifc_effective_integrity("adversarial"));
+
+        let bytes_none = canonical_edge_bytes(&edge_none, None);
+        let bytes_some = canonical_edge_bytes(&edge_some, None);
+        assert!(
+            bytes_some.starts_with(&bytes_none),
+            "absent field => prefix => purely additive"
+        );
+        let mut expected_delta = vec![0u8];
+        expected_delta.extend_from_slice(b"adversarial");
+        expected_delta.push(0);
+        assert_eq!(&bytes_some[bytes_none.len()..], &expected_delta[..]);
     }
 
     #[test]

--- a/crates/nucleus-recompute/SIGN_EFFECTIVE_INTEGRITY_SPEC.md
+++ b/crates/nucleus-recompute/SIGN_EFFECTIVE_INTEGRITY_SPEC.md
@@ -1,0 +1,101 @@
+# Sign the IFC effective-integrity label — pinned spec (Level-1 grounding)
+
+The moonshot rung that turns the egress verdict from *recompute-able* into
+*recompute-able **and tamper-evident***: move the chain's effective integrity
+from an **unsigned `edge.attrs` entry** into the **signed `VerifierAttestation`**,
+so the gate and `verify_ifc_flow` read signed data, and the verifier can
+cross-check the gate's input against what was signed upstream.
+
+Adversarially pinned before grinding (spec workflow `w6u535z3e`).
+
+## 1. The gap is REAL (very high confidence)
+
+- `canonical_edge_bytes` **excludes `edge.attrs`** (`nucleus-lineage/src/proof.rs:41-42`) — signs child/kind/parents/content-hash/ts/prev-hash/VA only.
+- The runner stamps the label as an **unsigned attr**: `nucleus-runner/src/runner.rs:424` `.with_attr("ifc_effective_integrity", …)`, then signs `canonical_edge_bytes` (runner.rs:431) — signature does **not** cover it. The summary edge currently carries **no** VA at all.
+- The egress gate **trusts that unsigned attr**: `nucleus-gateway/src/gateway.rs:282` reads `parent_edge.attrs["ifc_effective_integrity"]`.
+
+**Attack today:** take a validly-signed summary edge with `attrs[ifc_effective_integrity]="adversarial"`, edit it to `"trusted"` — the edge signature still verifies, the gate reads `"trusted"`, egress is permitted. (Even the gateway test helper at gateway.rs:1029 *claims* it "stamps before signing" but uses `.with_attr` — the comment is false.)
+
+## 2. What signing EARNS / what it does NOT (state verbatim)
+
+**EARNS (Level-1):** moving the label into the signed `VerifierAttestation` makes
+it **tamper-evident** (any post-signing edit invalidates the Ed25519 signature),
+**runner-attested + non-repudiable** (the runner's key commits the runner to this
+label), and reduces label trust to **trust in the runner's signer** — which the
+gateway already verifies against. **No new trust assumption.**
+
+**DOES NOT EARN (Level-2, sequenced separately):** signing does **not** ground the
+label's **truth or completeness**. An under-declaring, buggy, or compromised
+runner can sign a false-but-valid label (`"trusted"` over a flow that carried
+adversarial data). The signature proves *the runner said it*, not *that it is
+correct*. Grounding truth needs **mediated observation** (independent monitor
+cross-checking the label against observed tool outcomes), quorum, or a formal
+proof of label-derivation soundness. **Do not conflate signature-coverage with
+correctness.** (Standard signed-provenance boundary: SLSA/sigstore — signed ≠
+verified; DIFC — endorsed ≠ grounded.)
+
+## 3. Spec — PINNED
+
+### (A) Producer: stamp into the signed VA
+- **NEW** field `ifc_effective_integrity: Option<String>` on `VerifierAttestation`
+  (`nucleus-lineage/src/edge.rs`, alongside `ifc_gated_effective_integrity`) +
+  `with_ifc_effective_integrity` builder + extend `is_empty()`.
+  - **FLAG — do NOT reuse `ifc_gated_effective_integrity`.** That is the gateway's
+    egress **co-commit** (gate *output*: "egress-gated AND allowed"). The new
+    field is the runner's running-chain integrity (the gate *input*). The
+    cross-check (C) compares the two — reusing one field collapses it.
+- **`canonical_edge_bytes` emit (proof.rs):** **Some-gated** additive emit
+  (`out.push(0); bytes; out.push(0)` only when `Some`), appended **after** the
+  `ifc_gated_effective_integrity` block.
+  - **FLAG — do NOT use `push_opt`** (always writes a NUL → shifts bytes of every
+    existing VA-bearing economic edge → breaks their signatures). Follow the
+    existing additive precedent.
+- **Runner (platform, runner.rs:408-439):** replace the `.with_attr` at :424 with
+  `.with_verifier_attestation(VerifierAttestation::new().with_ifc_effective_integrity(integ_name(label.integrity)))`
+  before the `canonical_edge_bytes` sign. **Dual-emit** the attr too for one
+  release (migration). Signer unchanged (runner's identity key).
+
+### (B) Consumer migration: VA-first, attr-fallback for one release
+- **Egress gate (gateway.rs:276-298):** read
+  `parent_edge.verifier_attestation…ifc_effective_integrity`, **fall back** to the
+  attr if VA-absent (legacy edges), then `unwrap_or("trusted")`. Drop the fallback
+  after one release.
+- **FLAG — gateway is a SECOND stamper:** the gateway writes
+  `ifc_effective_confidentiality` (and integrity) as **attrs** on delegation edges
+  (gateway.rs:455) and signs via `sign_chained`. Runner-only is **incomplete** —
+  gateway-stamped parents stay unsigned unless the gateway stamp also moves to the
+  VA it already signs. A *sound* gate needs both stampers migrated.
+- **FLAG — confidentiality parity:** `ifc_effective_confidentiality` has the
+  identical unsigned-attr gap (gateway.rs:250-254). Either fix in the same PR or
+  explicitly document it remains Level-0 unsigned.
+- **UI:** `nucleus-control/static/js/holy-grail.js` `panelIfc` — read VA-first.
+
+### (C) Verifier cross-check (nucleus-recompute)
+- Keep `verify_ifc_flow(Option<&str>)` (consistency-of-stamp). **Add** a wasm-pure
+  `verify_ifc_flow_consistent(child_gated: Option<&str>, parent_effective: Option<&str>)`:
+  on an egress-allowed hop (`child_gated == Some`), require
+  `child_gated == parent_effective`; mismatch ⇒ reject (the gate evaluated a value
+  different from what was signed upstream). `&LineageEdge` parent/child adapter
+  stays behind the optional non-wasm feature. Honest scope unchanged: binds
+  gate-input(runner-signed) to gate-output(gateway-signed); does **not** ground
+  either value's truth.
+
+## 4. Green predicate (mechanical)
+
+1. **Tamper no longer downgrades the gate** (platform): edit `attrs` "adversarial"→"trusted" on an edge whose VA says "adversarial"; VA-first gate still **denies**.
+2. **Forged signed label breaks the edge** (nucleus-lineage): mutate `va.ifc_effective_integrity` post-signing ⇒ signature verification **fails**.
+3. **Cross-check rejects contradiction** (nucleus-recompute): child `ifc_gated_effective_integrity` ≠ parent `ifc_effective_integrity` ⇒ reject.
+4. **Anti-vacuity (honest chain passes):** signed `"trusted"` parent → matching `"trusted"` gated child → gate allows, cross-check consistent. (Guards deny-everything.)
+5. **Additive-compat golden** (nucleus-lineage): a pre-existing VA-bearing edge **without** the new field canonicalizes **byte-identically**; dual-emit edge (attr + VA) verifies and gate prefers VA.
+
+## 5. Cross-repo ordering
+
+- **nucleus (open) FIRST — loopable now:** VA field + builder + `is_empty` (edge.rs); Some-gated emit (proof.rs); additive golden; `verify_ifc_flow_consistent` + tests (nucleus-recompute). Green predicate items 2, 3, 5, recompute-half of 4.
+- **THEN nucleus-platform — gated on the nucleus version/pin bump:** runner stamp→VA, gateway VA-first read, gateway delegation stamp→VA (+ conf parity), UI. Green items 1, 4 (gate behavior). Platform edits compile-fail until the pin bumps — do **not** start them this loop.
+
+## 6. Not grindable / Level-2 (route around)
+
+- **Label completeness** (runner misses a flow) — needs mediated observation.
+- **Compromised / under-declaring runner** — signs a false-but-valid label.
+- **Intent / truth of the flow** — not expressible by a signature (wall-1/Rice).
+- Sequence a distinct Level-2 rung (independent monitor cross-checks the signed label against observed egress, or Lean soundness of label derivation) with its own honesty claim. Do not let it leak into this rung's language.

--- a/crates/nucleus-recompute/src/lib.rs
+++ b/crates/nucleus-recompute/src/lib.rs
@@ -751,6 +751,46 @@ pub fn verify_ifc_flow(gated_effective_integrity: Option<&str>) -> IfcFlowOutcom
     }
 }
 
+/// Cross-check a hop's gate **output** against the **input** the runner signed
+/// upstream: the child edge's `ifc_gated_effective_integrity` (the value the
+/// gateway co-committed it gated on) must equal the parent edge's signed
+/// `ifc_effective_integrity` (the running integrity the runner attested). A
+/// mismatch means the gate evaluated a *different* value than was signed upstream
+/// — e.g. someone fed the gate a downgraded label — so the hop is rejected even
+/// if it is internally allow-consistent.
+///
+/// This binds gate-input(runner-signed) to gate-output(gateway-signed) across the
+/// hop. It still does NOT ground either value's *truth* (a compromised runner can
+/// sign a consistent-but-false pair) — that is the separate Level-2 rung.
+///
+/// `child_gated == None` ⇒ [`IfcFlowOutcome::NotGated`] (not an egress hop, the
+/// cross-check is vacuous). Otherwise the egress hop must both be allow-consistent
+/// (via [`verify_ifc_flow`]) AND match the parent's signed integrity.
+pub fn verify_ifc_flow_consistent(
+    child_gated: Option<&str>,
+    parent_effective: Option<&str>,
+) -> IfcFlowOutcome {
+    match child_gated {
+        None => IfcFlowOutcome::NotGated,
+        Some(g) => {
+            // First: the gated value must itself satisfy the allow-rule.
+            match verify_ifc_flow(Some(g)) {
+                IfcFlowOutcome::Allow => {
+                    // Then: it must equal what the runner signed upstream.
+                    if parent_effective == Some(g) {
+                        IfcFlowOutcome::Allow
+                    } else {
+                        IfcFlowOutcome::Inconsistent {
+                            effective_integrity: g.to_string(),
+                        }
+                    }
+                }
+                other => other, // already Inconsistent (adversarial / unknown)
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod ifc_flow_tests {
     use super::*;
@@ -799,5 +839,51 @@ mod ifc_flow_tests {
             let consistent = verify_ifc_flow(Some(tok)).is_consistent();
             assert_eq!(consistent, !blocked, "drift for token {tok:?}");
         }
+    }
+
+    // ── cross-check: gate output (child) vs runner-signed input (parent) ──
+
+    #[test]
+    fn cross_check_non_egress_child_is_not_gated() {
+        assert_eq!(
+            verify_ifc_flow_consistent(None, Some("trusted")),
+            IfcFlowOutcome::NotGated
+        );
+    }
+
+    #[test]
+    fn cross_check_matching_signed_input_is_allow() {
+        // anti-vacuity: an honest hop (gate allowed "trusted", parent signed
+        // "trusted") must be accepted.
+        assert_eq!(
+            verify_ifc_flow_consistent(Some("trusted"), Some("trusted")),
+            IfcFlowOutcome::Allow
+        );
+    }
+
+    #[test]
+    fn cross_check_rejects_input_output_mismatch() {
+        // The gate co-committed "trusted" but the runner signed "adversarial"
+        // upstream — the gate evaluated a downgraded value. Reject.
+        match verify_ifc_flow_consistent(Some("trusted"), Some("adversarial")) {
+            IfcFlowOutcome::Inconsistent {
+                effective_integrity,
+            } => {
+                assert_eq!(effective_integrity, "trusted");
+            }
+            other => panic!("expected Inconsistent, got {other:?}"),
+        }
+        // Also reject when the parent didn't sign an effective integrity at all
+        // (can't confirm the gate input).
+        assert!(!verify_ifc_flow_consistent(Some("trusted"), None).is_consistent());
+    }
+
+    #[test]
+    fn cross_check_inherits_allow_rule() {
+        // A child gated on "adversarial" is rejected by the allow-rule before the
+        // input/output comparison even matters.
+        assert!(
+            !verify_ifc_flow_consistent(Some("adversarial"), Some("adversarial")).is_consistent()
+        );
     }
 }


### PR DESCRIPTION
**Stacked on #1889** (branched off `feat/verify-ifc-flow` for the `ifc_gated` field + `verify_ifc_flow`) — merge after #1889; I'll retarget to `main` once #1889 lands.

Turns the egress verdict from *recompute-able* into *recompute-able **and tamper-evident***. Spec: `crates/nucleus-recompute/SIGN_EFFECTIVE_INTEGRITY_SPEC.md`.

**The gap (confirmed real, high confidence):** `ifc_effective_integrity` is an **unsigned `edge.attrs` entry** (`canonical_edge_bytes` excludes attrs, proof.rs:41) that the egress gate **trusts** (gateway.rs:282). Edit the attr `adversarial→trusted` and the edge signature still verifies → the gate permits egress. (The gateway test helper even *claims* "stamps before signing" but uses `.with_attr` — a false comment.)

**This PR (nucleus / open-repo half):**
- **`VerifierAttestation.ifc_effective_integrity`** — a NEW field (the runner-attested gate *input*; distinct from `ifc_gated_effective_integrity`, the gateway's *output*). It rides in `canonical_edge_bytes`, so it is **signature-covered**.
- **`Some`-gated** additive emit (not `push_opt`) + a golden proving `None` stays byte-identical (no existing edge's signature breaks).
- **`verify_ifc_flow_consistent(child_gated, parent_effective)`** — an egress hop must be allow-consistent **and** `child.gated == parent.signed-integrity`; binds gate-input(runner-signed) to gate-output(gateway-signed). nucleus-lineage 142 + nucleus-recompute 20 green; wasm-pure gate verified.

**What signing EARNS:** tamper-evident + runner-attested + non-repudiable; trust reduces to the runner's signer (no new assumption). **What it does NOT earn:** the label's *truth/completeness* — a compromised/under-declaring runner can sign a false label. That is **Level-2** (mediated observation), a sequenced separate rung. Do not read this as grounding correctness.

**Flags (cross-repo follow-ons, gated on the platform pin bump):**
- The **runner** must stamp `ifc_effective_integrity` into the VA (vs the current unsigned attr) and the **gateway gate** must read VA-first.
- The **gateway is a second stamper** (delegation edges, gateway.rs:455) — runner-only leaves gateway-stamped parents unsigned; both must migrate.
- **Confidentiality** has the identical unsigned-attr gap (gateway.rs:250) — fix alongside or document it remains Level-0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013SAANNkRAS6PLum3YXjBkH