### PR TITLE
feat(lineage): signed ifc_effective_confidentiality VA field (conf-axis grounding)

### DIFF
--- a/crates/nucleus-lineage/src/edge.rs
+++ b/crates/nucleus-lineage/src/edge.rs
@@ -88,6 +88,15 @@ pub struct VerifierAttestation {
     /// sign a false label. Grounding truth is a separate (Level-2) rung.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ifc_effective_integrity: Option<String>,
+    /// The chain's **running effective confidentiality** as the runner (or the
+    /// gateway, on a delegation hop) attests it — the *input* the confidentiality
+    /// ceiling check evaluates. Signing it here (it rides in `canonical_edge_bytes`)
+    /// makes it **tamper-evident + attested** instead of an unsigned `attrs` entry
+    /// an attacker could downgrade `secret`→`public`. Same honest scope as
+    /// [`Self::ifc_effective_integrity`]: grounds *who attested*, not the label's
+    /// truth/completeness (Level-2).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ifc_effective_confidentiality: Option<String>,
 }
 
 impl VerifierAttestation {
@@ -146,6 +155,13 @@ impl VerifierAttestation {
         self
     }
 
+    /// Builder: attest the chain's running effective confidentiality (the ceiling
+    /// check's input). See the field docs.
+    pub fn with_ifc_effective_confidentiality(mut self, conf: impl Into<String>) -> Self {
+        self.ifc_effective_confidentiality = Some(conf.into());
+        self
+    }
+
     /// `true` iff every field is `None`. Used by verifiers in strict mode
     /// to reject edges that claim economic semantics without attestation.
     pub fn is_empty(&self) -> bool {
@@ -157,6 +173,7 @@ impl VerifierAttestation {
             && self.lean_spec_hash.is_none()
             && self.ifc_gated_effective_integrity.is_none()
             && self.ifc_effective_integrity.is_none()
+            && self.ifc_effective_confidentiality.is_none()
     }
 }
 

--- a/crates/nucleus-lineage/src/proof.rs
+++ b/crates/nucleus-lineage/src/proof.rs
@@ -169,6 +169,14 @@ pub fn canonical_edge_bytes(edge: &LineageEdge, prev_hash: Option<&[u8; 32]>) ->
             out.extend_from_slice(integ.as_bytes());
             out.push(0);
         }
+        // Runner/gateway-attested running effective confidentiality. Same additive
+        // discipline (emit nothing unless `Some`, appended last) so pre-existing VA
+        // edges stay byte-identical.
+        if let Some(conf) = va.ifc_effective_confidentiality.as_deref() {
+            out.push(0);
+            out.extend_from_slice(conf.as_bytes());
+            out.push(0);
+        }
     }
 
     out
@@ -406,6 +414,38 @@ mod tests {
         );
         let mut expected_delta = vec![0u8];
         expected_delta.extend_from_slice(b"adversarial");
+        expected_delta.push(0);
+        assert_eq!(&bytes_some[bytes_none.len()..], &expected_delta[..]);
+    }
+
+    /// Same additive-compat guarantee for the signed `ifc_effective_confidentiality`
+    /// field (the conf-axis grounding): `None` emits zero bytes; `Some` appends
+    /// exactly the field.
+    #[test]
+    fn effective_confidentiality_is_purely_additive() {
+        use crate::edge::VerifierAttestation;
+        let p = pod();
+        let child = p.derive_tool("web_post", Some(b"x")).unwrap();
+        let va_base = VerifierAttestation::new().with_lean_spec_hash("deadbeef");
+        let edge_none = LineageEdge::from_parent(
+            child,
+            p,
+            EdgeKind::ToolCall {
+                tool: "web_post".to_string(),
+            },
+        )
+        .with_verifier_attestation(va_base.clone());
+        let mut edge_some = edge_none.clone();
+        edge_some.verifier_attestation = Some(va_base.with_ifc_effective_confidentiality("secret"));
+
+        let bytes_none = canonical_edge_bytes(&edge_none, None);
+        let bytes_some = canonical_edge_bytes(&edge_some, None);
+        assert!(
+            bytes_some.starts_with(&bytes_none),
+            "absent field => prefix => purely additive"
+        );
+        let mut expected_delta = vec![0u8];
+        expected_delta.extend_from_slice(b"secret");
         expected_delta.push(0);
         assert_eq!(&bytes_some[bytes_none.len()..], &expected_delta[..]);
     }


### PR DESCRIPTION
Mirrors the integrity field (#1890) for the **confidentiality axis** — the nucleus half that unblocks the platform conf-axis wiring (closes the identical unsigned-attr `secret→public` downgrade gap the conf-ceiling check has today).

- New signed `VerifierAttestation.ifc_effective_confidentiality` + builder + `is_empty` + **Some-gated** `canonical_edge_bytes` emit (appended last, not `push_opt`) + `effective_confidentiality_is_purely_additive` golden (None ⇒ byte-identical). nucleus-lineage **143 green**.

Platform follow-on (after this merges + the pin bumps): runner **and gateway** stamp conf into the signed VA — note the gateway *is* a genuine **2nd stamper** for confidentiality (it stamps conf on delegation edges, unlike integrity) — and the conf-ceiling check reads VA-first. Same honest scope: tamper-evident + attested, **not** truth (Level-2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013SAANNkRAS6PLum3YXjBkH