### PR TITLE
feat(lineage,recompute): signed budget figures + verify_budget_* (budget node, nucleus half)

### DIFF
--- a/crates/nucleus-lineage/src/edge.rs
+++ b/crates/nucleus-lineage/src/edge.rs
@@ -97,6 +97,27 @@ pub struct VerifierAttestation {
     /// truth/completeness (Level-2).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ifc_effective_confidentiality: Option<String>,
+    /// Budget node — the per-hop **charge** (micro-USD decimal string), the gate
+    /// *output*. Signed here (rides in `canonical_edge_bytes`) so the spend ledger
+    /// is tamper-evident + gateway-attested instead of an unsigned `attrs` entry an
+    /// attacker could lower. Recompute: `verify_budget_permit`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub budget_charged_micro_usd: Option<String>,
+    /// Budget node — the **effective remaining** budget the permit check evaluated
+    /// (micro-USD), the gate *input*. A signed edge whose charge exceeds this is
+    /// self-inconsistent (the gateway would have returned `PaymentRequired`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub budget_effective_remaining_micro_usd: Option<String>,
+    /// Budget node — the runner-attested **running total spent** at hop start
+    /// (micro-USD); the 2nd-stamper running input (mirror of
+    /// [`Self::ifc_effective_integrity`]). `verify_budget_flow_consistent`
+    /// cross-checks `child.spent == parent.spent + parent.charged`.
+    ///
+    /// HONEST SCOPE (all three): grounds the spend FIGURES as a tamper-evident,
+    /// attested, internally-consistent ledger — NOT that a charge is *fair* or the
+    /// work happened (PoTE), nor that every hop is present (completeness).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub budget_spent_so_far_micro_usd: Option<String>,
 }
 
 impl VerifierAttestation {
@@ -162,6 +183,29 @@ impl VerifierAttestation {
         self
     }
 
+    /// Builder: stamp the per-hop budget charge (gate output). See field docs.
+    pub fn with_budget_charged_micro_usd(mut self, micro_usd: impl Into<String>) -> Self {
+        self.budget_charged_micro_usd = Some(micro_usd.into());
+        self
+    }
+
+    /// Builder: stamp the effective remaining budget the permit check evaluated
+    /// (gate input). See field docs.
+    pub fn with_budget_effective_remaining_micro_usd(
+        mut self,
+        micro_usd: impl Into<String>,
+    ) -> Self {
+        self.budget_effective_remaining_micro_usd = Some(micro_usd.into());
+        self
+    }
+
+    /// Builder: attest the running total spent at hop start (2nd-stamper input).
+    /// See field docs.
+    pub fn with_budget_spent_so_far_micro_usd(mut self, micro_usd: impl Into<String>) -> Self {
+        self.budget_spent_so_far_micro_usd = Some(micro_usd.into());
+        self
+    }
+
     /// `true` iff every field is `None`. Used by verifiers in strict mode
     /// to reject edges that claim economic semantics without attestation.
     pub fn is_empty(&self) -> bool {
@@ -174,6 +218,9 @@ impl VerifierAttestation {
             && self.ifc_gated_effective_integrity.is_none()
             && self.ifc_effective_integrity.is_none()
             && self.ifc_effective_confidentiality.is_none()
+            && self.budget_charged_micro_usd.is_none()
+            && self.budget_effective_remaining_micro_usd.is_none()
+            && self.budget_spent_so_far_micro_usd.is_none()
     }
 }
 

--- a/crates/nucleus-lineage/src/proof.rs
+++ b/crates/nucleus-lineage/src/proof.rs
@@ -177,6 +177,24 @@ pub fn canonical_edge_bytes(edge: &LineageEdge, prev_hash: Option<&[u8; 32]>) ->
             out.extend_from_slice(conf.as_bytes());
             out.push(0);
         }
+        // Budget node — charge / effective-remaining / spent-so-far. Same additive
+        // discipline (emit nothing unless `Some`, appended last, in declared field
+        // order) so pre-existing VA edges stay byte-identical.
+        if let Some(v) = va.budget_charged_micro_usd.as_deref() {
+            out.push(0);
+            out.extend_from_slice(v.as_bytes());
+            out.push(0);
+        }
+        if let Some(v) = va.budget_effective_remaining_micro_usd.as_deref() {
+            out.push(0);
+            out.extend_from_slice(v.as_bytes());
+            out.push(0);
+        }
+        if let Some(v) = va.budget_spent_so_far_micro_usd.as_deref() {
+            out.push(0);
+            out.extend_from_slice(v.as_bytes());
+            out.push(0);
+        }
     }
 
     out
@@ -446,6 +464,38 @@ mod tests {
         );
         let mut expected_delta = vec![0u8];
         expected_delta.extend_from_slice(b"secret");
+        expected_delta.push(0);
+        assert_eq!(&bytes_some[bytes_none.len()..], &expected_delta[..]);
+    }
+
+    /// Additive-compat guarantee for the signed budget fields: `None` emits zero
+    /// bytes; `Some` appends exactly the field. (All three budget fields share the
+    /// same emit discipline; `budget_charged_micro_usd` is the representative.)
+    #[test]
+    fn budget_fields_are_purely_additive() {
+        use crate::edge::VerifierAttestation;
+        let p = pod();
+        let child = p.derive_tool("web_post", Some(b"x")).unwrap();
+        let va_base = VerifierAttestation::new().with_lean_spec_hash("deadbeef");
+        let edge_none = LineageEdge::from_parent(
+            child,
+            p,
+            EdgeKind::ToolCall {
+                tool: "web_post".to_string(),
+            },
+        )
+        .with_verifier_attestation(va_base.clone());
+        let mut edge_some = edge_none.clone();
+        edge_some.verifier_attestation = Some(va_base.with_budget_charged_micro_usd("100"));
+
+        let bytes_none = canonical_edge_bytes(&edge_none, None);
+        let bytes_some = canonical_edge_bytes(&edge_some, None);
+        assert!(
+            bytes_some.starts_with(&bytes_none),
+            "absent field => prefix => purely additive"
+        );
+        let mut expected_delta = vec![0u8];
+        expected_delta.extend_from_slice(b"100");
         expected_delta.push(0);
         assert_eq!(&bytes_some[bytes_none.len()..], &expected_delta[..]);
     }

--- a/crates/nucleus-recompute/src/lib.rs
+++ b/crates/nucleus-recompute/src/lib.rs
@@ -791,6 +791,168 @@ pub fn verify_ifc_flow_consistent(
     }
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Budget node verdict recompute (verify_budget_*)
+//
+// The gateway enforces budget as a caveat ceiling + a running accumulator: a hop
+// is permitted iff its charge fits the effective remaining (the `after_spend`
+// deflationary invariant, Aeneas-extracted + `afterSpend_extracted_deflationary`).
+// These fns re-derive that verdict OFFLINE from the SIGNED VA figures
+// (`budget_charged` / `budget_effective_remaining` / `budget_spent_so_far`).
+//
+// HONEST SCOPE: checks the spend ledger is internally consistent + tamper-evident
+// (a signed edge whose charge exceeds the remaining it claims to have evaluated is
+// self-inconsistent). Does NOT check the charge is FAIR / the work happened (PoTE)
+// nor that every hop is present (completeness). NOTE: this is NOT greedy_pack —
+// that theorem models a closed-list auction allocation, the wrong model for an
+// open-ended sequential gate.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Outcome of recomputing a budget permit / flow check from signed figures.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BudgetFlowOutcome {
+    /// Not a budget-grounded hop (the relevant figures were absent).
+    NotGrounded,
+    /// The signed figures satisfy the permit / accumulator rule.
+    Ok,
+    /// Self-inconsistent: a charge exceeds the effective remaining the gate
+    /// claimed to evaluate, or the chain spend-accumulator equation is violated.
+    Inconsistent { reason: String },
+}
+
+impl BudgetFlowOutcome {
+    /// `true` unless the figures are self-inconsistent. `NotGrounded` and `Ok`
+    /// are both acceptable (an ungrounded hop is vacuously fine).
+    pub fn is_consistent(&self) -> bool {
+        !matches!(self, BudgetFlowOutcome::Inconsistent { .. })
+    }
+}
+
+/// Re-derive the per-hop budget permit verdict: the signed charge must not exceed
+/// the signed effective-remaining the gate evaluated (the `after_spend`
+/// deflationary invariant). Plain-data wasm-pure (micro-USD decimal strings).
+pub fn verify_budget_permit(
+    effective_remaining_micro_usd: Option<&str>,
+    charged_micro_usd: Option<&str>,
+) -> BudgetFlowOutcome {
+    match (effective_remaining_micro_usd, charged_micro_usd) {
+        (None, None) => BudgetFlowOutcome::NotGrounded,
+        (Some(rem), Some(chg)) => match (rem.parse::<u128>(), chg.parse::<u128>()) {
+            (Ok(rem), Ok(chg)) if chg <= rem => BudgetFlowOutcome::Ok,
+            (Ok(rem), Ok(chg)) => BudgetFlowOutcome::Inconsistent {
+                reason: format!("charge {chg} exceeds effective remaining {rem}"),
+            },
+            _ => BudgetFlowOutcome::Inconsistent {
+                reason: format!("unparseable budget figures rem={rem:?} chg={chg:?}"),
+            },
+        },
+        _ => BudgetFlowOutcome::Inconsistent {
+            reason: "partial budget grounding (charge xor remaining present)".to_string(),
+        },
+    }
+}
+
+/// Cross-check the chain spend accumulator across a parent→child hop:
+/// `child_spent == parent_spent + parent_charged` and monotone-nondecreasing.
+/// Mirrors [`verify_ifc_flow_consistent`].
+pub fn verify_budget_flow_consistent(
+    parent_spent_micro_usd: Option<&str>,
+    parent_charged_micro_usd: Option<&str>,
+    child_spent_micro_usd: Option<&str>,
+) -> BudgetFlowOutcome {
+    match (
+        parent_spent_micro_usd,
+        parent_charged_micro_usd,
+        child_spent_micro_usd,
+    ) {
+        (None, None, None) => BudgetFlowOutcome::NotGrounded,
+        (Some(ps), Some(pc), Some(cs)) => {
+            match (ps.parse::<u128>(), pc.parse::<u128>(), cs.parse::<u128>()) {
+                (Ok(ps), Ok(pc), Ok(cs)) => {
+                    if cs < ps {
+                        return BudgetFlowOutcome::Inconsistent {
+                            reason: format!("spent went backwards: child {cs} < parent {ps}"),
+                        };
+                    }
+                    match ps.checked_add(pc) {
+                        Some(expected) if expected == cs => BudgetFlowOutcome::Ok,
+                        Some(expected) => BudgetFlowOutcome::Inconsistent {
+                            reason: format!(
+                                "accumulator mismatch: child {cs} != parent_spent {ps} + parent_charged {pc} = {expected}"
+                            ),
+                        },
+                        None => BudgetFlowOutcome::Inconsistent {
+                            reason: "spend overflow".to_string(),
+                        },
+                    }
+                }
+                _ => BudgetFlowOutcome::Inconsistent {
+                    reason: "unparseable spend figures".to_string(),
+                },
+            }
+        }
+        _ => BudgetFlowOutcome::Inconsistent {
+            reason: "partial spend grounding".to_string(),
+        },
+    }
+}
+
+#[cfg(test)]
+mod budget_flow_tests {
+    use super::*;
+
+    #[test]
+    fn permit_ungrounded_is_not_grounded() {
+        assert_eq!(
+            verify_budget_permit(None, None),
+            BudgetFlowOutcome::NotGrounded
+        );
+    }
+
+    #[test]
+    fn permit_charge_within_remaining_is_ok() {
+        // anti-vacuity: a legitimate charge is accepted, not rejected.
+        assert_eq!(
+            verify_budget_permit(Some("1000"), Some("100")),
+            BudgetFlowOutcome::Ok
+        );
+        assert_eq!(
+            verify_budget_permit(Some("100"), Some("100")),
+            BudgetFlowOutcome::Ok
+        );
+    }
+
+    #[test]
+    fn permit_charge_over_remaining_is_inconsistent() {
+        assert!(!verify_budget_permit(Some("100"), Some("101")).is_consistent());
+        assert!(!verify_budget_permit(Some("abc"), Some("1")).is_consistent());
+        assert!(!verify_budget_permit(None, Some("1")).is_consistent());
+    }
+
+    #[test]
+    fn flow_accumulator_consistent() {
+        // parent spent 50, charged 100 => child spent 150.
+        assert_eq!(
+            verify_budget_flow_consistent(Some("50"), Some("100"), Some("150")),
+            BudgetFlowOutcome::Ok
+        );
+    }
+
+    #[test]
+    fn flow_accumulator_mismatch_and_backwards_rejected() {
+        // wrong sum: 50 + 100 != 140
+        assert!(
+            !verify_budget_flow_consistent(Some("50"), Some("100"), Some("140")).is_consistent()
+        );
+        // backwards: child < parent
+        assert!(!verify_budget_flow_consistent(Some("50"), Some("0"), Some("40")).is_consistent());
+        assert_eq!(
+            verify_budget_flow_consistent(None, None, None),
+            BudgetFlowOutcome::NotGrounded
+        );
+    }
+}
+
 #[cfg(test)]
 mod ifc_flow_tests {
     use super::*;


### PR DESCRIPTION
The **2nd grounded node kind** (after IFC), mirroring the proven enforce→scope→recompute→ground pattern — the node that makes PCD composition worthwhile (one edge's VA then carries an IFC verdict *and* a budget verdict, both recompute-checkable).

- 3 signed `VerifierAttestation` fields (micro-USD): `budget_charged` (gate output), `budget_effective_remaining` (gate input), `budget_spent_so_far` (runner-attested running input). Some-gated emit + additive golden.
- `verify_budget_permit` (charge ≤ effective remaining — the `after_spend` deflationary invariant) + `verify_budget_flow_consistent` (child.spent == parent.spent + parent.charged, monotone). 5 tests incl. anti-vacuity. nucleus-lineage **144 green**, wasm-pure gate verified.

**Backing = `after_spend_total`** (Aeneas-extracted + `afterSpend_extracted_deflationary`), **not `greedyPack`** — the spec-pin skeptic caught that greedyPack models a closed-list auction allocation, the wrong model for an open-ended sequential gate (a true theorem about the wrong property).

**Honest scope:** tamper-evident, attested, internally-consistent spend ledger — **not** that a charge is *fair*/the work happened (PoTE), nor completeness. Platform follow-on (after merge + pin bump): gateway stamps charge+remaining into the signed VA via `sign_chained`, runner stamps spent_so_far, budget check reads VA-first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013SAANNkRAS6PLum3YXjBkH