### PR TITLE
chore(docs): honest Lean census script + counting methodology

### DIFF
--- a/docs/PROOFS.md
+++ b/docs/PROOFS.md
@@ -12,6 +12,19 @@
 > Gap-tracking tags (`G1`–`G7`) refer to the chariot punch-list; this file is
 > updated as each gap lands.
 
+> **Counting methodology — how to read any Lean count in this repo.** All
+> first-party Lean totals come from `scripts/lean-census.sh` (run from the repo
+> root), which **excludes** vendored Mathlib/std (`.lake/`, `lake-packages/`),
+> transient git worktrees (`.claude/`), vendored libraries (`external/`,
+> `vendor/`), and codegen (`generated/`). A raw `find . -name '*.lean'` sweeps
+> `.lake/` and worktrees and will report ~an order of magnitude too many files
+> (and "thousands of sorries") — those are Mathlib's, **not ours**; never cite
+> them. Honest first-party snapshot (census, 2026-06-25): **nucleus 84 files /
+> 891 thm+lemma / 35 `sorry` (11 files) / 1 decorative**; platform 44 / 152 / 1;
+> olog 156 / 465 / 46 `sorry`. A theorem count is not a strength claim — a file
+> can be load-bearing, `sorry`-fenced research, or a `:= by trivial` stub; the
+> tiers below are what actually distinguish them.
+
 ---
 
 ## The three tiers (what the words mean)

--- a/scripts/lean-census.sh
+++ b/scripts/lean-census.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# lean-census.sh — honest first-party Lean proof census.
+#
+# Counts ONLY first-party authored Lean. Excludes, by construction:
+#   .lake/, lake-packages/  — vendored Mathlib/std (NOT ours; the "9K files /
+#                             7500 sorries" overclaim came from counting these)
+#   .claude/                — transient git worktrees (working copies, not source)
+#   external/, vendor/      — vendored third-party Lean libraries
+#   generated/              — codegen output (reported separately, not as proofs)
+#
+# Run from a repo root: scripts/lean-census.sh
+# Purpose: give docs ONE honest source of truth for Lean counts. Any doc citing
+# Lean file/theorem/sorry totals should match this, NOT a raw find/grep that
+# sweeps .lake/ and .claude/worktrees.
+set -uo pipefail
+
+EX=(--include='*.lean'
+    --exclude-dir=.lake --exclude-dir=lake-packages
+    --exclude-dir=.claude --exclude-dir=external
+    --exclude-dir=vendor --exclude-dir=generated)
+
+fp=$(grep -rlI '' "${EX[@]}" . 2>/dev/null | wc -l | tr -d ' ')
+gen=$(find . -path '*/generated/*' -name '*.lean' \
+        -not -path '*/.lake/*' -not -path '*/.claude/*' 2>/dev/null | wc -l | tr -d ' ')
+thm=$(grep -rhcE '^[[:space:]]*(theorem|lemma) ' "${EX[@]}" . 2>/dev/null | awk '{s+=$1} END{print s+0}')
+sf=$(grep -rlE '^[[:space:]]*sorry' "${EX[@]}" . 2>/dev/null | wc -l | tr -d ' ')
+sc=$(grep -rhcE '^[[:space:]]*sorry' "${EX[@]}" . 2>/dev/null | awk '{s+=$1} END{print s+0}')
+dec=$(grep -rlE ':=[[:space:]]*by[[:space:]]+trivial' "${EX[@]}" . 2>/dev/null | wc -l | tr -d ' ')
+
+echo "lean census — $(basename "$(pwd)")  (first-party only)"
+echo "  first-party lean files            : $fp"
+echo "  generated lean files (excluded)   : $gen"
+echo "  theorems + lemmas                 : $thm"
+echo "  sorry-bearing files               : $sf  ($sc sorries)"
+echo "  decorative (:= by trivial) files  : $dec"


### PR DESCRIPTION
Closes the aggregate-count overclaim risk from the substrate-maturity audit. A raw `find . -name '*.lean'` sweeps vendored Mathlib (`.lake/`) + transient `.claude/worktrees` → ~9K files / ~7500 sorries that are **Mathlib's, not ours**. New `scripts/lean-census.sh` excludes `.lake`/`lake-packages`/`.claude`/`external`/`vendor`/`generated`; `PROOFS.md` documents the methodology + snapshot (**nucleus 84 files / 891 thm / 35 sorries · platform 44/152/1 · olog 156/465/46**). A theorem count is not a strength claim — the PROOFS tiers distinguish load-bearing from sorry-fenced from decorative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013SAANNkRAS6PLum3YXjBkH