### PR TITLE
feat: AttestationMode tag — machine-checked Mediated vs Attested

### DIFF
--- a/crates/nucleus-lineage/src/edge.rs
+++ b/crates/nucleus-lineage/src/edge.rs
@@ -118,6 +118,40 @@ pub struct VerifierAttestation {
     /// work happened (PoTE), nor that every hop is present (completeness).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub budget_spent_so_far_micro_usd: Option<String>,
+    /// How this edge's attested claims were obtained — the [`AttestationMode`]
+    /// boundary between a kernel-OBSERVED atom (`Mediated`) and RELABELED trust
+    /// (`Attested`). Signature-covered (rides in `canonical_edge_bytes`).
+    /// `nucleus_recompute::verify_attestation_mode` rejects a `Mediated` whose
+    /// `handler_id` does not match the signer, and rejects `Attested` presented
+    /// where a grounded (observed) claim is required.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attestation_mode: Option<AttestationMode>,
+}
+
+/// How a signed claim came to be — the boundary between a VERIFIED atom (the
+/// kernel observed it) and RELABELED trust (an external party asserted it).
+/// Rides in `canonical_edge_bytes` (signature-covered), so it is tamper-evident.
+///
+/// **`Mediated` is unforgeable by construction.** A sealed handler
+/// (`portcullis-effects::RealEffects`, the gateway egress chokepoint) observes
+/// the real effect and signs the edge; its identity IS the edge's
+/// `verifier_binary_hash`. `nucleus_recompute::verify_attestation_mode` accepts
+/// `Mediated { handler_id }` only when `handler_id == verifier_binary_hash` — so
+/// a tool that writes `Mediated { "RealEffects::read" }` into an edge IT signs
+/// fails the check (its signer hash is the tool, not the handler).
+///
+/// HONEST SCOPE: grounds *who observed / who asserted*, NOT the effect's truth.
+/// `Mediated` still trusts the sealed handler binary; it is not Byzantine-proof
+/// against a compromised handler.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AttestationMode {
+    /// OBSERVED by a sealed handler at the syscall/subprocess/egress boundary.
+    /// `handler_id` MUST equal the edge's `verifier_binary_hash`.
+    Mediated { handler_id: String },
+    /// ASSERTED by an external party the handler could not observe (web fetch,
+    /// LLM output, remote API). The signature proves *who said it*, never *that
+    /// it is true*.
+    Attested { attestor_id: String },
 }
 
 impl VerifierAttestation {
@@ -206,6 +240,13 @@ impl VerifierAttestation {
         self
     }
 
+    /// Builder: tag how this edge's claims were obtained (Mediated/Attested).
+    /// See [`AttestationMode`].
+    pub fn with_attestation_mode(mut self, mode: AttestationMode) -> Self {
+        self.attestation_mode = Some(mode);
+        self
+    }
+
     /// `true` iff every field is `None`. Used by verifiers in strict mode
     /// to reject edges that claim economic semantics without attestation.
     pub fn is_empty(&self) -> bool {
@@ -221,6 +262,7 @@ impl VerifierAttestation {
             && self.budget_charged_micro_usd.is_none()
             && self.budget_effective_remaining_micro_usd.is_none()
             && self.budget_spent_so_far_micro_usd.is_none()
+            && self.attestation_mode.is_none()
     }
 }
 

--- a/crates/nucleus-lineage/src/proof.rs
+++ b/crates/nucleus-lineage/src/proof.rs
@@ -44,7 +44,7 @@
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
-use crate::edge::{EdgeKind, LineageEdge};
+use crate::edge::{AttestationMode, EdgeKind, LineageEdge};
 
 /// A cryptographic proof attached to a [`LineageEdge`].
 ///
@@ -194,6 +194,29 @@ pub fn canonical_edge_bytes(edge: &LineageEdge, prev_hash: Option<&[u8; 32]>) ->
             out.push(0);
             out.extend_from_slice(v.as_bytes());
             out.push(0);
+        }
+        // AttestationMode tag — Mediated{handler_id} vs Attested{attestor_id}.
+        // Same additive discipline (emit nothing unless `Some`, appended last).
+        // The variant discriminant is emitted before the id so the two cases can
+        // never alias, and the whole tag is signature-covered — a tool cannot
+        // self-assert `Mediated`: `verify_attestation_mode` cross-checks
+        // `handler_id == verifier_binary_hash` (the signer).
+        match va.attestation_mode.as_ref() {
+            Some(AttestationMode::Mediated { handler_id }) => {
+                out.push(0);
+                out.extend_from_slice(b"mediated");
+                out.push(0);
+                out.extend_from_slice(handler_id.as_bytes());
+                out.push(0);
+            }
+            Some(AttestationMode::Attested { attestor_id }) => {
+                out.push(0);
+                out.extend_from_slice(b"attested");
+                out.push(0);
+                out.extend_from_slice(attestor_id.as_bytes());
+                out.push(0);
+            }
+            None => {}
         }
     }
 
@@ -496,6 +519,41 @@ mod tests {
         );
         let mut expected_delta = vec![0u8];
         expected_delta.extend_from_slice(b"100");
+        expected_delta.push(0);
+        assert_eq!(&bytes_some[bytes_none.len()..], &expected_delta[..]);
+    }
+
+    #[test]
+    fn attestation_mode_is_purely_additive() {
+        use crate::edge::{AttestationMode, VerifierAttestation};
+        let p = pod();
+        let child = p.derive_tool("web_post", Some(b"x")).unwrap();
+        let va_base = VerifierAttestation::new().with_lean_spec_hash("deadbeef");
+        let edge_none = LineageEdge::from_parent(
+            child,
+            p,
+            EdgeKind::ToolCall {
+                tool: "web_post".to_string(),
+            },
+        )
+        .with_verifier_attestation(va_base.clone());
+        let mut edge_some = edge_none.clone();
+        edge_some.verifier_attestation =
+            Some(va_base.with_attestation_mode(AttestationMode::Mediated {
+                handler_id: "h".to_string(),
+            }));
+
+        let bytes_none = canonical_edge_bytes(&edge_none, None);
+        let bytes_some = canonical_edge_bytes(&edge_some, None);
+        assert!(
+            bytes_some.starts_with(&bytes_none),
+            "absent field => prefix => purely additive"
+        );
+        // variant discriminant + id, each NUL-delimited.
+        let mut expected_delta = vec![0u8];
+        expected_delta.extend_from_slice(b"mediated");
+        expected_delta.push(0);
+        expected_delta.extend_from_slice(b"h");
         expected_delta.push(0);
         assert_eq!(&bytes_some[bytes_none.len()..], &expected_delta[..]);
     }

--- a/crates/nucleus-recompute/src/lib.rs
+++ b/crates/nucleus-recompute/src/lib.rs
@@ -897,6 +897,113 @@ pub fn verify_budget_flow_consistent(
     }
 }
 
+/// Outcome of re-deriving an `AttestationMode` tag against the signer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AttestationModeOutcome {
+    /// No mode tag present — the edge makes no Mediated/Attested claim.
+    NotGrounded,
+    /// The tag is consistent with the signer and the grounding requirement.
+    Ok,
+    /// A `Mediated` tag whose `handler_id` does not match the signer, OR an
+    /// `Attested` tag presented where a grounded (observed) claim is required,
+    /// OR an unrecognized mode kind.
+    Rejected { reason: String },
+}
+
+/// Re-derive the `AttestationMode` verdict OFFLINE (plain-data, wasm-pure — does
+/// NOT depend on `nucleus-lineage`). The lineage `AttestationMode` is decomposed
+/// to plain data: `mode_kind` is `"mediated"` / `"attested"` / absent, and
+/// `mode_id` is the handler_id / attestor_id.
+///
+/// The honesty invariant: `Mediated { handler_id }` is valid ONLY when
+/// `handler_id == verifier_binary_hash` (the edge's signer) — so a tool cannot
+/// self-assert `Mediated` (its signer hash is the tool, not the sealed handler).
+/// `Attested` (relabeled trust) is REJECTED wherever `grounding_required`, so it
+/// can never masquerade as a kernel-observed atom.
+pub fn verify_attestation_mode(
+    mode_kind: Option<&str>,
+    mode_id: Option<&str>,
+    verifier_binary_hash: Option<&str>,
+    grounding_required: bool,
+) -> AttestationModeOutcome {
+    match mode_kind {
+        None => AttestationModeOutcome::NotGrounded,
+        Some("mediated") => match (mode_id, verifier_binary_hash) {
+            (Some(handler_id), Some(signer)) if handler_id == signer => AttestationModeOutcome::Ok,
+            (handler_id, signer) => AttestationModeOutcome::Rejected {
+                reason: format!("forged Mediated: handler_id {handler_id:?} != signer {signer:?}"),
+            },
+        },
+        Some("attested") if grounding_required => AttestationModeOutcome::Rejected {
+            reason: "Attested claim presented where a Mediated (observed) claim is required"
+                .to_string(),
+        },
+        Some("attested") => AttestationModeOutcome::Ok,
+        Some(other) => AttestationModeOutcome::Rejected {
+            reason: format!("unrecognized attestation mode kind {other:?}"),
+        },
+    }
+}
+
+#[cfg(test)]
+mod attestation_mode_tests {
+    use super::*;
+
+    #[test]
+    fn mediated_matching_signer_is_ok() {
+        // A sealed handler signed the edge; its handler_id IS the signer hash.
+        assert_eq!(
+            verify_attestation_mode(
+                Some("mediated"),
+                Some("portcullis-effects@0.1.0"),
+                Some("portcullis-effects@0.1.0"),
+                true,
+            ),
+            AttestationModeOutcome::Ok,
+        );
+    }
+
+    #[test]
+    fn mediated_forged_by_tool_is_rejected() {
+        // A tool stamps `Mediated{RealEffects::read}` into an edge IT signs.
+        // Its signer hash is the tool, not the handler → forgery caught.
+        assert!(matches!(
+            verify_attestation_mode(
+                Some("mediated"),
+                Some("RealEffects::read"),
+                Some("evil-tool@0.1"),
+                true,
+            ),
+            AttestationModeOutcome::Rejected { .. }
+        ));
+    }
+
+    #[test]
+    fn attested_where_grounding_required_is_rejected() {
+        // Relabeled trust can never masquerade as an observed atom.
+        assert!(matches!(
+            verify_attestation_mode(Some("attested"), Some("web-fetch"), Some("signer"), true),
+            AttestationModeOutcome::Rejected { .. }
+        ));
+    }
+
+    #[test]
+    fn attested_where_grounding_not_required_is_ok() {
+        assert_eq!(
+            verify_attestation_mode(Some("attested"), Some("web-fetch"), Some("signer"), false),
+            AttestationModeOutcome::Ok,
+        );
+    }
+
+    #[test]
+    fn absent_mode_is_not_grounded() {
+        assert_eq!(
+            verify_attestation_mode(None, None, Some("signer"), true),
+            AttestationModeOutcome::NotGrounded,
+        );
+    }
+}
+
 #[cfg(test)]
 mod budget_flow_tests {
     use super::*;


### PR DESCRIPTION
The honesty primitive from the EffectSignature spec-pin (GO-NOW half; the union is deferred to after egress/spawn atoms land). `AttestationMode { Mediated { handler_id }, Attested { attestor_id } }` on `VerifierAttestation`, **signature-covered** (rides in `canonical_edge_bytes`, purely additive — golden proves `None` keeps existing signed edges byte-identical).

`verify_attestation_mode` (`nucleus-recompute`, plain-data **wasm-pure**) re-derives the verdict offline:
- `Mediated` valid **only** when `handler_id == verifier_binary_hash` (the signer) — a tool **cannot self-assert** `Mediated` (its signer hash is the tool, not the sealed handler).
- `Attested` (relabeled trust) is **rejected wherever `grounding_required`** — it can never masquerade as a kernel-observed atom.

Turns "verified atom vs relabeled trust" from a field-name convention into a **checked invariant.** 5 recompute tests + additive golden; **lineage 145 + recompute 30 green.**

**Honest scope:** grounds *who observed / who asserted*, NOT the effect's truth; `Mediated` still trusts the sealed handler binary. Edge-adapter (lineage edge → verify call) is follow-on #24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013SAANNkRAS6PLum3YXjBkH