### PR TITLE
policy: add [dependabot_sla] amendment for the dependabot reconciler

### DIFF
--- a/PolicyManifest.toml
+++ b/PolicyManifest.toml
@@ -60,6 +60,18 @@ config_patch = []                              # Config changes: no extra proofs
 controller_patch = ["build_pass", "test_pass"] # Source changes: must build + test
 evaluator_patch = ["build_pass"]               # Test changes: must build
 
+# ── Dependency-update SLA ────────────────────────────────────────────────
+# Read by the merge-gate dependabot reconciler (a level-triggered loop that
+# drives open dependabot PRs toward "merged within the budget"). Orthogonal to
+# the monotonicity checks below — ck-types ignores this table, so it does not
+# affect admission. Auto-merge stays bounded to patch/minor; majors escalate to
+# a human, and a PR the constitutional gate rejected is never auto-merged.
+[dependabot_sla]
+enabled = true
+max_open_hours = 48          # budget: a dependabot PR older than this has breached
+escalate_after_hours = 36    # warn band for PRs that can't auto-merge
+auto_merge = "patch_minor"   # none | patch | patch_minor | all
+
 # ── Rules for amending this constitution ─────────────────────────────────
 [amendment_rules]
 may_modify = ["crates/", "examples/", "docs/", "benchmarks/", "README.md"]


### PR DESCRIPTION
## Amendment: dependency-update SLA

Adds a `[dependabot_sla]` table to the constitution, read by the
**level-triggered dependabot reconciler** in `merge-gate` — a control loop that
drives open dependabot PRs toward "merged within budget".

```toml
[dependabot_sla]
enabled = true
max_open_hours = 48          # budget: older than this = breached
escalate_after_hours = 36    # warn band for PRs that can't auto-merge
auto_merge = "patch_minor"   # none | patch | patch_minor | all
```

### Why it's safe for the gate
- `ck-types::PolicyManifest` has **no `#[serde(deny_unknown_fields)]`**, so
  `ck-admit` ignores this table — `capabilities` / `io_surface` / `budget_bounds`
  / `proof_requirements` are untouched and the monotonicity invariants still hold.
- It grants no capability and widens no I/O surface; it only configures an
  **external** reconciler service.

### How it composes
- Complements the existing edge-triggered `dependabot-automerge.yml`: that enables
  auto-merge when a patch/minor PR opens; this is the **level-triggered safety
  net** that re-checks every tick, enforces the SLA with escalation for majors /
  failing CI, and emits breach metrics (L⁰ count / L¹ Lyapunov / L∞ worst).
- A PR the constitutional gate **rejected is never auto-merged**, even past the
  SLA — pressure routes to a human.

As a `PolicyManifest.toml` amendment this requires the **one human co-sign** the
constitution mandates (`constitutional_human_signatures = 1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N4nuVTkkEpemieYfnJuvuz
