### PR TITLE
fix(sandbox): close complete-mediation hole in nucleus run

### DIFF
--- a/crates/nucleus-cli/src/constants.rs
+++ b/crates/nucleus-cli/src/constants.rs
@@ -11,3 +11,35 @@
 ///
 /// Update this constant when upgrading to a new Firecracker version.
 pub const FIRECRACKER_VERSION: &str = "1.14.1";
+
+/// The agent's BUILT-IN tools that MUST be disabled when launching the assistant
+/// under nucleus enforcement, so the agent can only act through the nucleus MCP
+/// tools (each routed through the `PermissionLattice`). Passed verbatim as
+/// `--disallowedTools`.
+///
+/// COMPLETE-MEDIATION INVARIANT: every code path that launches the assistant
+/// with `--dangerously-skip-permissions` / `bypassPermissions` (`run`, `shell`)
+/// MUST also pass this list. Omitting it lets the built-in Bash/Write/WebFetch/
+/// etc. run OUTSIDE the kernel — an in-band path that skips the monitor. The
+/// two launch sites referencing this constant keep the boundary identical by
+/// construction; do not inline the list.
+pub const DISALLOWED_BUILTIN_TOOLS: &str =
+    "Bash,Read,Write,Edit,Glob,Grep,WebFetch,WebSearch,NotebookEdit,Agent";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn disallowed_builtins_cover_the_dangerous_effects() {
+        // Regression guard: the built-in effects that would bypass the lattice
+        // must all be in the disallow list. If a new built-in tool appears,
+        // add it here and to the constant in the same change.
+        for t in ["Bash", "Write", "Edit", "WebFetch", "WebSearch", "Read", "Glob", "Grep"] {
+            assert!(
+                DISALLOWED_BUILTIN_TOOLS.split(',').any(|x| x == t),
+                "built-in tool {t} must be disallowed (it bypasses the nucleus kernel)"
+            );
+        }
+    }
+}

--- a/crates/nucleus-cli/src/constants.rs
+++ b/crates/nucleus-cli/src/constants.rs
@@ -35,7 +35,16 @@ mod tests {
         // Regression guard: the built-in effects that would bypass the lattice
         // must all be in the disallow list. If a new built-in tool appears,
         // add it here and to the constant in the same change.
-        for t in ["Bash", "Write", "Edit", "WebFetch", "WebSearch", "Read", "Glob", "Grep"] {
+        for t in [
+            "Bash",
+            "Write",
+            "Edit",
+            "WebFetch",
+            "WebSearch",
+            "Read",
+            "Glob",
+            "Grep",
+        ] {
             assert!(
                 DISALLOWED_BUILTIN_TOOLS.split(',').any(|x| x == t),
                 "built-in tool {t} must be disallowed (it bypasses the nucleus kernel)"

--- a/crates/nucleus-cli/src/run.rs
+++ b/crates/nucleus-cli/src/run.rs
@@ -901,21 +901,27 @@ fn run_claude_mcp(
         .arg(mcp_config_path)
         .arg("--allowedTools")
         .arg(allowed_tools.join(","))
+        // CRITICAL — complete mediation. Block the agent's BUILT-IN tools so it
+        // can act ONLY through the nucleus MCP tools, every one of which routes
+        // through the PermissionLattice. Without this, `--dangerously-skip-permissions`
+        // below lets the built-in Bash/Read/Write/WebFetch/etc. run OUTSIDE the
+        // kernel — an in-band path that skips the monitor entirely. Mirrors
+        // `shell.rs`; the two disallow lists MUST stay identical (regression-tested).
+        .arg("--disallowedTools")
+        .arg(crate::constants::DISALLOWED_BUILTIN_TOOLS)
         .arg("--max-budget-usd")
         .arg(policy.budget.max_cost_usd.to_string())
         .arg(prompt)
         .current_dir(work_dir);
 
-    // Always bypass Claude's built-in permission system in local enforced mode.
-    // Security is enforced by the nucleus tool-proxy lattice, which gates every
-    // tool call through the PermissionLattice. Claude's permission system is
-    // redundant here and prevents the agent from implementing in non-interactive
-    // (--print) mode — it falls back to plan-only without human approval.
-    //
-    // The uninhabitable_state's approval obligations (e.g., bash requires human sign-off)
-    // are meaningful for interactive use, but in CI there's no human to approve.
-    // The tool-proxy's command allowlist and capability levels are the actual
-    // security boundary.
+    // Bypass Claude's built-in *interactive approval* in local enforced mode —
+    // SAFE ONLY because `--disallowedTools` above already removed every built-in
+    // tool, so the agent's only remaining tools are the nucleus MCP tools, and
+    // each of THOSE routes through the PermissionLattice. (Bypassing approval
+    // without the disallow list would let the built-in Bash/WebFetch/etc. run
+    // ungated — see the disallow comment.) Claude's interactive approval can't
+    // function in non-interactive `--print` mode anyway (it falls back to
+    // plan-only without a human), so the lattice IS the security boundary.
     cmd.arg("--dangerously-skip-permissions");
     cmd.arg("--permission-mode").arg("bypassPermissions");
 

--- a/crates/nucleus-cli/src/shell.rs
+++ b/crates/nucleus-cli/src/shell.rs
@@ -254,7 +254,7 @@ pub async fn execute(args: ShellArgs) -> Result<()> {
         .arg("--allowedTools")
         .arg(allowed_tools.join(","))
         .arg("--disallowedTools")
-        .arg("Bash,Read,Write,Edit,Glob,Grep,WebFetch,WebSearch,NotebookEdit,Agent")
+        .arg(crate::constants::DISALLOWED_BUILTIN_TOOLS)
         .env_remove("CLAUDECODE")
         .current_dir(&work_dir);
 


### PR DESCRIPTION
**Blocking security fix** — top-1%-exemplar audit gap #1.

`nucleus run` (the flagship Tier-1 path) launched the assistant with `--allowedTools` + `--dangerously-skip-permissions` + `--permission-mode bypassPermissions` but **no `--disallowedTools`** (run.rs:902/919/920). So the agent's *built-in* Bash/Read/Write/Edit/Glob/Grep/WebFetch/WebSearch/NotebookEdit/Agent ran **outside** the nucleus MCP kernel — an in-band path skipping the `PermissionLattice` entirely. `shell.rs:256` already set the disallow list (with a comment explaining why); `run.rs` had drifted.

**Fix:** both launch sites now reference one shared `constants::DISALLOWED_BUILTIN_TOOLS` (so the boundary stays identical by construction) + a regression test (`disallowed_builtins_cover_the_dangerous_effects`); and run.rs's comment — which falsely claimed the lattice 'gates every tool call' — is corrected to explain the bypass is safe *only because* the built-ins are now disallowed.

`cargo build -p nucleus-cli` green; the regression test passes. (Follow-up Phase-0: `verify_strict` sweep, ratchet-fails-on-`axiom`/`:True`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013SAANNkRAS6PLum3YXjBkH