### PR TITLE
feat(ci): exemplar scoreboard — mechanical cross-domain gap ratchet

### DIFF
--- a/.github/workflows/exemplar-scoreboard.yml
+++ b/.github/workflows/exemplar-scoreboard.yml
@@ -1,0 +1,71 @@
+name: exemplar-scoreboard
+
+# The MECHANICAL layer of the "top-1% exemplar" instrument. Computes exact,
+# greppable cross-domain metrics (formal verification / Rust craft / sandboxing /
+# category theory) and RATCHETS them against a committed baseline:
+#   - lower-is-better metrics may not increase (no new permissive verify, no new
+#     vacuous Lean, no new mediation drift, ...);
+#   - higher-is-better metrics may not decrease (extraction, lints adoption);
+#   - *_GUARD metrics may not drop — the anti-Goodhart pairing (you can't cut
+#     `permissive_verify` by deleting the verifier: `verify_calls_GUARD` would
+#     fall; you can't cut `vacuous_lean` by deleting theorems: `lean_theorems_GUARD`
+#     would fall).
+# Fast (grep only, no cargo/lake build). The judgment-level gaps grep can't see
+# (real-vs-decorative, overclaim) are caught by the periodic adversarial workflow,
+# which also RECALIBRATES these metrics — grep measures, the panel re-tunes the ruler.
+
+on:
+  push:
+    branches: [main]
+    paths: ['**/*.rs', '**/*.lean', '**/Cargo.toml', 'scripts/exemplar-scoreboard.sh', 'scripts/exemplar-baseline.json']
+  pull_request:
+    paths: ['**/*.rs', '**/*.lean', '**/Cargo.toml', 'scripts/exemplar-scoreboard.sh', 'scripts/exemplar-baseline.json']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  scoreboard:
+    name: exemplar metrics ratchet
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Compute scoreboard
+        run: bash scripts/exemplar-scoreboard.sh scoreboard.json
+
+      - name: Ratchet against baseline (with anti-Goodhart guards)
+        run: |
+          python3 - <<'PY'
+          import json, sys
+          cur  = json.load(open("scoreboard.json"))
+          base = json.load(open("scripts/exemplar-baseline.json"))
+          def flat(d, p=""):
+              o = {}
+              for k, v in d.items():
+                  if isinstance(v, dict): o.update(flat(v, p+k+"."))
+                  elif isinstance(v, (int, float)) and not isinstance(v, bool): o[p+k] = v
+              return o
+          c, b = flat(cur), flat(base)
+          LOWER  = {"permissive_verify","vacuous_lean","sorry_admit","mediation_drift",
+                    "effect_stubs","unsafe_blocks","stale_verus_dirs"}
+          HIGHER = {"extracted_proofs","crates_lints_workspace","extraction_ratio_pct","lints_adoption_pct"}
+          fail, improved = [], []
+          for k, cv in c.items():
+              name, bv = k.split(".")[-1], b.get(k)
+              if bv is None: continue
+              if name in LOWER:
+                  if cv > bv: fail.append(f"{name} regressed {bv}->{cv} (lower is better)")
+                  elif cv < bv: improved.append(f"{name} {bv}->{cv}")
+              elif name in HIGHER:
+                  if cv < bv: fail.append(f"{name} regressed {bv}->{cv} (higher is better)")
+                  elif cv > bv: improved.append(f"{name} {bv}->{cv}")
+              elif name.endswith("_GUARD"):
+                  if cv < bv: fail.append(f"anti-gaming GUARD {name} dropped {bv}->{cv} (verifier/theorems deleted?)")
+          for i in improved: print(f"::notice::improved {i} — lower scripts/exemplar-baseline.json to ratchet it in")
+          if fail:
+              for f in fail: print(f"::error::{f}")
+              sys.exit(1)
+          print("exemplar scoreboard: no regressions vs baseline")
+          PY

--- a/scripts/exemplar-baseline.json
+++ b/scripts/exemplar-baseline.json
@@ -1,0 +1,19 @@
+{
+  "formal_verification": {
+    "extracted_proofs": 3, "handmodel_proofs": 3,
+    "extraction_ratio_pct": 50,
+    "sorry_admit": 38, "vacuous_lean": 3,
+    "lean_theorems_GUARD": 891, "clean_axiom_footprint": "n/a"
+  },
+  "rust_craft": {
+    "permissive_verify": 48, "verify_calls_GUARD": 54,
+    "unsafe_blocks": 4,
+    "crates_total": 67, "crates_lints_workspace": 41,
+    "lints_adoption_pct": 61
+  },
+  "sandboxing": {
+    "mediation_drift": 2, "bypass_sites": 3,
+    "disallow_sites": 1, "effect_stubs": 9
+  },
+  "hygiene": { "stale_verus_dirs": 1 }
+}

--- a/scripts/exemplar-scoreboard.sh
+++ b/scripts/exemplar-scoreboard.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# exemplar-scoreboard.sh — the MECHANICAL layer of the "top-1% exemplar" probe.
+#
+# Computes exact, greppable metrics across the four domains (formal verification,
+# Rust craft, sandboxing, category theory) that the exemplar audit surfaced, each
+# with a ratchet direction. CI fails on regression; an autonomous loop closes the
+# worst grindable metric one instance at a time and the number moves.
+#
+# ANTI-GOODHART: each "lower-is-better" metric is PAIRED with a guard so it can't
+# be gamed by deletion (you can't cut `permissive_verify` by deleting the verifier
+# — the paired `verify_calls` must not drop; you can't cut `vacuous_lean` by
+# deleting theorems — the paired `lean_theorems` must not drop). The probe prints
+# both; the ratchet checks both. The deepest gaming (cosmetic-but-typechecks) is
+# caught by the periodic ADVERSARIAL workflow, not grep — see docs.
+#
+# Scope: the nucleus repo (run from its root). Lean-heavy metrics (clean axiom
+# footprint) are produced by axiom-audit.sh in its own CI and read here if present.
+set -uo pipefail
+OUT="${1:-scoreboard.json}"
+
+RS=(--include='*.rs' --exclude-dir=target --exclude-dir=.lake --exclude-dir=.claude)
+LN=(--include='*.lean' --exclude-dir=.lake --exclude-dir=.claude)
+nt() { grep -rnE "$1" "${RS[@]}" crates 2>/dev/null | grep -vE '/tests/|_test\.rs|#\[cfg\(test\)\]|//|///'; }
+
+# ── Formal verification ──────────────────────────────────────────────────────
+# extraction frontier: proven-over-EXTRACTED-Rust vs hand-model (the machine-
+# readable ProofStatus split is the honest signal).
+extracted=$(grep -rhoE 'ExtractedKernelChecked' "${RS[@]}" crates 2>/dev/null | wc -l | tr -d ' ')
+handmodel=$(grep -rhoE 'HandModelKernelChecked' "${RS[@]}" crates 2>/dev/null | wc -l | tr -d ' ')
+sorry_admit=$(grep -rhcE '^[[:space:]]*(sorry|admit)' "${LN[@]}" crates 2>/dev/null | awk '{s+=$1} END{print s+0}')
+lean_theorems=$(grep -rhcE '^[[:space:]]*(theorem|lemma) ' "${LN[@]}" crates 2>/dev/null | awk '{s+=$1} END{print s+0}')
+# vacuity: True-typed theorems + axiom:True (worse). Paired guard = lean_theorems.
+vacuous_lean=$(grep -rhcE ':=[[:space:]]*by[[:space:]]+trivial|:[[:space:]]*True[[:space:]]*:=|axiom[[:space:]].*:[[:space:]]*True' "${LN[@]}" crates 2>/dev/null | awk '{s+=$1} END{print s+0}')
+
+# ── Rust craft ───────────────────────────────────────────────────────────────
+# permissive (malleable) signature verify on non-test paths. Scoped to a
+# SIGNATURE context (a bare `.verify(` over all methods over-counts ~2.5x — it
+# catches hash/cert/config verifies). This is a conservative SUPERSET of the
+# real Ed25519 trust sites (greppable typing can't be exact), so it's a
+# don't-INCREASE ratchet, not a target-zero. Paired guard = sig verify_calls,
+# so you can't game it by deleting the verifier (count would drop, guard fails).
+SIGCTX='sig|signature|vk|verifying|pubkey|public_key|ed25519'
+permissive_verify=$(nt '\.verify\(' | grep -v 'verify_strict' | grep -iE "$SIGCTX" | wc -l | tr -d ' ')
+verify_calls=$(nt '\.verify(_strict)?\(' | grep -iE "$SIGCTX" | wc -l | tr -d ' ')
+unsafe_blocks=$(nt '\bunsafe[[:space:]]+(\{|fn|impl)' | wc -l | tr -d ' ')
+crates_total=$(find crates -maxdepth 2 -name Cargo.toml 2>/dev/null | wc -l | tr -d ' ')
+crates_lints_ws=$(grep -rlE '^\s*workspace\s*=\s*true' --include=Cargo.toml crates 2>/dev/null | xargs grep -lE '\[lints\]' 2>/dev/null | wc -l | tr -d ' ')
+
+# ── Sandboxing / hard controls ───────────────────────────────────────────────
+# complete-mediation drift: a claude-launch site that bypasses permissions but
+# omits the built-in disallow list (the gap #1 class). Should be 0.
+bypass_sites=$(grep -rlE 'dangerously-skip-permissions|bypassPermissions' "${RS[@]}" crates 2>/dev/null | wc -l | tr -d ' ')
+disallow_sites=$(grep -rlE 'DISALLOWED_BUILTIN_TOOLS|--disallowedTools' "${RS[@]}" crates 2>/dev/null | wc -l | tr -d ' ')
+mediation_drift=$(( bypass_sites > disallow_sites ? bypass_sites - disallow_sites : 0 ))
+effect_stubs=$(grep -rhcE 'NotImplemented|NotWired' "${RS[@]}" crates/portcullis-effects crates/portcullis-core 2>/dev/null | awk '{s+=$1} END{print s+0}')
+
+# ── Hygiene ──────────────────────────────────────────────────────────────────
+stale_verus=$(find . -type d -name '.verus' -not -path '*/target/*' 2>/dev/null | wc -l | tr -d ' ')
+
+# clean axiom footprint (from axiom-audit.sh badge if present)
+axiom_badge="badges/axiom-footprint.json"
+clean_axioms="$( [ -f "$axiom_badge" ] && grep -oE '"message":"[^"]*"' "$axiom_badge" | sed 's/.*:"//;s/"//' || echo 'n/a' )"
+
+cat > "$OUT" <<JSON
+{
+  "formal_verification": {
+    "extracted_proofs": $extracted, "handmodel_proofs": $handmodel,
+    "extraction_ratio_pct": $(( (extracted+handmodel)>0 ? extracted*100/(extracted+handmodel) : 0 )),
+    "sorry_admit": $sorry_admit, "vacuous_lean": $vacuous_lean,
+    "lean_theorems_GUARD": $lean_theorems, "clean_axiom_footprint": "$clean_axioms"
+  },
+  "rust_craft": {
+    "permissive_verify": $permissive_verify, "verify_calls_GUARD": $verify_calls,
+    "unsafe_blocks": $unsafe_blocks,
+    "crates_total": $crates_total, "crates_lints_workspace": $crates_lints_ws,
+    "lints_adoption_pct": $(( crates_total>0 ? crates_lints_ws*100/crates_total : 0 ))
+  },
+  "sandboxing": {
+    "mediation_drift": $mediation_drift, "bypass_sites": $bypass_sites,
+    "disallow_sites": $disallow_sites, "effect_stubs": $effect_stubs
+  },
+  "hygiene": { "stale_verus_dirs": $stale_verus }
+}
+JSON
+
+echo "exemplar scoreboard — $(basename "$(pwd)")"
+echo "  FV : extraction ${extracted}/$((extracted+handmodel)) | sorry/admit $sorry_admit | vacuous-lean $vacuous_lean (of $lean_theorems thm) | clean-axioms $clean_axioms"
+echo "  RUST: permissive .verify $permissive_verify (of $verify_calls) | unsafe $unsafe_blocks | lints.workspace $crates_lints_ws/$crates_total"
+echo "  SANDBOX: mediation-drift $mediation_drift (bypass $bypass_sites / disallow $disallow_sites) | effect-stubs $effect_stubs"
+echo "  HYGIENE: stale .verus dirs $stale_verus"
+echo "  -> $OUT"


### PR DESCRIPTION
The mechanical layer of the **top-1%-exemplar instrument** — turns the four-domain audit's greppable gaps into a CI-ratcheted scoreboard an autonomous loop can drive down.

`scripts/exemplar-scoreboard.sh` → `scoreboard.json`: extraction ratio, sorry/admit, vacuous-Lean, permissive signature-verify, unsafe blocks, `lints.workspace` adoption, mediation-drift, effect-stubs, stale `.verus`. **Baseline today:** permissive-verify 48/54 · vacuous-Lean 3 · sorry/admit 38 · mediation-drift 2 · effect-stubs 9 · unsafe 4 · lints 41/67 · extraction 3/3.

`exemplar-scoreboard.yml` ratchets vs the committed baseline with **anti-Goodhart guards**: lower-is-better can't rise, higher-is-better can't fall, and `*_GUARD` metrics can't drop — *you can't cut `permissive_verify` by deleting the verifier (`verify_calls_GUARD` would fall) or `vacuous_lean` by deleting theorems.* Tested: passes baseline, catches a vacuity +1 and a guard drop.

This is **Layer 1**. **Layer 2** (the periodic adversarial workflow) catches what grep can't — real-vs-decorative, overclaim — and recalibrates these metrics. The loop grinds the *grindable* column (vacuous→0, stale-verus→0, permissive-verify down via #41, lints→100%); *engineering* metrics (extraction ratio via #43) and *wall* metrics (model↔binary) are tracked, never auto-'closed'.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013SAANNkRAS6PLum3YXjBkH