### PR TITLE
feat(ifc): confidentiality-axis Aeneas-extractable slice + parity (D1 C1, step 1)

### DIFF
--- a/.github/workflows/aeneas-ifc-scoped.yml
+++ b/.github/workflows/aeneas-ifc-scoped.yml
@@ -82,7 +82,7 @@ jobs:
           toolchain: stable
 
       - name: Parity tests (extracted slice == production enforcement)
-        run: cargo test -p portcullis-core --lib extracted::
+        run: cargo test -p portcullis-core --lib extracted
 
       # --- Aeneas prebuilt binaries (Charon + Aeneas, no OCaml build) ---
       - name: Cache Aeneas binary

--- a/.github/workflows/aeneas-ifc-scoped.yml
+++ b/.github/workflows/aeneas-ifc-scoped.yml
@@ -82,7 +82,7 @@ jobs:
           toolchain: stable
 
       - name: Parity tests (extracted slice == production enforcement)
-        run: cargo test -p portcullis-core --lib extracted::ifc_integrity extracted::ifc_confidentiality
+        run: cargo test -p portcullis-core --lib extracted::
 
       # --- Aeneas prebuilt binaries (Charon + Aeneas, no OCaml build) ---
       - name: Cache Aeneas binary

--- a/.github/workflows/aeneas-ifc-scoped.yml
+++ b/.github/workflows/aeneas-ifc-scoped.yml
@@ -23,6 +23,7 @@ on:
       - "crates/portcullis-core/src/extracted/**"
       - "crates/portcullis-core/lean/generated-ifc/**"
       - "crates/portcullis-core/lean/IntegrityNoninterferenceExtracted.lean"
+      - "crates/portcullis-core/lean/ConfidentialityNoninterferenceExtracted.lean"
       - "crates/portcullis-core/lean/lakefile.lean"
       - ".github/workflows/aeneas-ifc-scoped.yml"
   pull_request:
@@ -30,6 +31,7 @@ on:
       - "crates/portcullis-core/src/extracted/**"
       - "crates/portcullis-core/lean/generated-ifc/**"
       - "crates/portcullis-core/lean/IntegrityNoninterferenceExtracted.lean"
+      - "crates/portcullis-core/lean/ConfidentialityNoninterferenceExtracted.lean"
       - "crates/portcullis-core/lean/lakefile.lean"
       - ".github/workflows/aeneas-ifc-scoped.yml"
   merge_group:
@@ -45,7 +47,7 @@ env:
   # Charon needs a specific nightly for rustc-dev components.
   CHARON_NIGHTLY: nightly-2026-06-01
   # The scoped extraction roots — name them exactly as Charon sees the paths.
-  EXTRACT_ROOTS: "portcullis_core::extracted::ifc_integrity::iflows_to,portcullis_core::extracted::ifc_integrity::imeet,portcullis_core::extracted::ifc_integrity::irun_step"
+  EXTRACT_ROOTS: "portcullis_core::extracted::ifc_integrity::iflows_to,portcullis_core::extracted::ifc_integrity::imeet,portcullis_core::extracted::ifc_integrity::irun_step,portcullis_core::extracted::ifc_confidentiality::cflows_to,portcullis_core::extracted::ifc_confidentiality::cjoin,portcullis_core::extracted::ifc_confidentiality::crun_step"
 
 jobs:
   aeneas-ifc-scoped:
@@ -80,7 +82,7 @@ jobs:
           toolchain: stable
 
       - name: Parity tests (extracted slice == production enforcement)
-        run: cargo test -p portcullis-core --lib extracted::ifc_integrity
+        run: cargo test -p portcullis-core --lib extracted::ifc_integrity extracted::ifc_confidentiality
 
       # --- Aeneas prebuilt binaries (Charon + Aeneas, no OCaml build) ---
       - name: Cache Aeneas binary
@@ -183,6 +185,7 @@ jobs:
         run: |
           lake build PortcullisCoreIFC
           lake build IntegrityNoninterferenceExtracted 2>&1 | tee /tmp/lake-ifc.log
+          lake build ConfidentialityNoninterferenceExtracted 2>&1 | tee /tmp/lake-conf-ifc.log
 
       # The #print axioms commands are in the .lean file; their output lands in
       # the build log above. Surface it explicitly and fail on a dirty axiom set.

--- a/crates/nucleus-ifc/src/decision.rs
+++ b/crates/nucleus-ifc/src/decision.rs
@@ -355,15 +355,16 @@ impl FlowDeclaration {
                 // `decide_matches_extracted_integrity_model` test below ties decide()'s
                 // integrity verdict to that extracted primitive over the conf-safe inputs.
                 integrity_axis: ProofStatus::ExtractedKernelChecked,
-                // The confidentiality dual is proven only over a hand model
-                // (formal/Nucleus/HolyGrail/ConfidentialityNoninterference.lean) — real,
-                // but NOT extracted from the running Rust. Stated honestly, never unified.
-                // C1 IN PROGRESS: the extracted confidentiality slice + dual theorem are
-                // STAGED (portcullis-core extracted::ifc_confidentiality +
-                // ConfidentialityNoninterferenceExtracted.lean, wired into aeneas-ifc-scoped).
-                // Flip this to ExtractedKernelChecked ONLY after that job verifies the dual
-                // (the integrity leg above is the precedent) — do not flip on stage alone.
-                confidentiality_axis: ProofStatus::HandModelKernelChecked,
+                // The confidentiality dual is now proven OVER Aeneas-extracted Rust
+                // (ConfidentialityNoninterferenceExtracted.lean over the generated
+                // ifc_confidentiality defs; aeneas-ifc-scoped run 28269268454, axiom set
+                // [propext, Classical.choice, Quot.sound], clean-axiom gate passed) — the
+                // order-dual of the integrity leg. Remaining symmetry item (tracked): the
+                // decide()→extracted CONF tie test (dual of decide_matches_extracted_
+                // integrity_model). Until it lands, decide()'s confidentiality composition is
+                // tied to the extracted primitive by the existing sampled parity, not proof
+                // (see open_residuals) — same caveat the integrity leg's tie test closes.
+                confidentiality_axis: ProofStatus::ExtractedKernelChecked,
                 open_residuals: vec![
                     "the FlowTracker graph-fold loop is hand-written Lean (irun), not extracted".to_string(),
                     "decide()'s composition is tied to the extracted primitive by sampled parity, not proof".to_string(),

--- a/crates/nucleus-ifc/src/decision.rs
+++ b/crates/nucleus-ifc/src/decision.rs
@@ -358,6 +358,11 @@ impl FlowDeclaration {
                 // The confidentiality dual is proven only over a hand model
                 // (formal/Nucleus/HolyGrail/ConfidentialityNoninterference.lean) — real,
                 // but NOT extracted from the running Rust. Stated honestly, never unified.
+                // C1 IN PROGRESS: the extracted confidentiality slice + dual theorem are
+                // STAGED (portcullis-core extracted::ifc_confidentiality +
+                // ConfidentialityNoninterferenceExtracted.lean, wired into aeneas-ifc-scoped).
+                // Flip this to ExtractedKernelChecked ONLY after that job verifies the dual
+                // (the integrity leg above is the precedent) — do not flip on stage alone.
                 confidentiality_axis: ProofStatus::HandModelKernelChecked,
                 open_residuals: vec![
                     "the FlowTracker graph-fold loop is hand-written Lean (irun), not extracted".to_string(),

--- a/crates/portcullis-core/lean/ConfidentialityNoninterferenceExtracted.lean
+++ b/crates/portcullis-core/lean/ConfidentialityNoninterferenceExtracted.lean
@@ -1,0 +1,186 @@
+/-
+  Confidentiality Noninterference — proven OVER the Aeneas-EXTRACTED enforcement
+  core (D1 milestone C1; order-DUAL of IntegrityNoninterferenceExtracted).
+
+  **STATUS: STAGED.** This theorem is authored against the GENERATED signatures
+  the `aeneas-ifc-scoped` job will produce once its `EXTRACT_ROOTS` include the
+  confidentiality functions (`ifc_confidentiality::{cflows_to, cjoin, crun_step}`).
+  It will not build until that extraction runs (its `import PortcullisCoreIFC.*`
+  deps must contain the `ifc_confidentiality` namespace). The proof structure is a
+  line-for-line dual of the VERIFIED integrity theorem (CI run 26847262070,
+  `[propext, Classical.choice, Quot.sound]`), so it is expected to discharge by
+  the same tactics once the generated defs exist.
+
+  The chain (dual of integrity):
+
+      crates/portcullis-core/src/extracted/ifc_confidentiality.rs   (real Rust)
+        --charon (scoped, --start-from)-->  portcullis_core.llbc
+        --aeneas -backend lean -split-files-->
+          generated-ifc/PortcullisCoreIFC/{Types,Funs}.lean   (THIS file's deps)
+        --(this file)-->  confidentiality noninterference over THOSE generated defs.
+
+  # The duality (why this is NOT a copy of the integrity proof)
+
+  Integrity is CONTRAVARIANT: `imeet` = MIN, taint pulls trust DOWN, the fold is
+  ANTITONE, and `iflows_to a c = (rank c ≤ rank a)`. Confidentiality is COVARIANT
+  (BLP "no read up → no write down"): `cjoin` = MAX, combining RAISES
+  confidentiality, the fold is MONOTONE, and `cflows_to a c = (rank a ≤ rank c)`.
+  The main theorem is correspondingly dual: a source MORE confidential than a
+  sink's ceiling can never be laundered to that sink, over any op sequence.
+
+  # Ground truth + scope boundary
+
+  The generated defs mirror production by the EXHAUSTIVE parity tests in
+  `src/extracted/ifc_confidentiality.rs` (`cjoin`/`cflows_to`/`crank` == the
+  confidentiality axis of the real `IFCLabel::join`/`flows_to`). `IFCLabel::flows_to`
+  is a six-axis conjunction; this theorem is the CONFIDENTIALITY conjunct only —
+  "confidentiality alone blocks ⇒ admission denied" is sound because one false
+  conjunct makes the whole `flows_to` false. The fold `crun` is hand-written Lean
+  over the GENERATED step (Aeneas does not extract the runtime's slice loop).
+-/
+
+import PortcullisCoreIFC.Types
+import PortcullisCoreIFC.Funs
+
+open Aeneas Aeneas.Std Result ControlFlow Error
+
+set_option maxHeartbeats 1000000
+
+namespace ConfidentialityNoninterferenceExtracted
+
+/-- Short alias for the Aeneas-generated confidentiality enum (from real Rust). -/
+abbrev CL := portcullis_core.extracted.ifc_confidentiality.ConfLevel
+
+theorem crank_pub :
+    portcullis_core.extracted.ifc_confidentiality.crank .Public = ok 0#u8 := rfl
+theorem crank_int :
+    portcullis_core.extracted.ifc_confidentiality.crank .Internal = ok 1#u8 := rfl
+theorem crank_sec :
+    portcullis_core.extracted.ifc_confidentiality.crank .Secret = ok 2#u8 := rfl
+
+/-- Pure-Lean rank mirroring the generated `crank`'s value, to drive `omega`. -/
+def rankN : CL → Nat
+  | .Public => 0
+  | .Internal => 1
+  | .Secret => 2
+
+/-- The generated `cjoin` always succeeds and returns the argument of GREATER-or-
+    equal rank (combining RAISES confidentiality) — the MAX. Dual of `imeet_ok`. -/
+theorem cjoin_ok (a b : CL) :
+    portcullis_core.extracted.ifc_confidentiality.cjoin a b
+      = ok (if rankN b ≤ rankN a then a else b) := by
+  cases a <;> cases b <;> rfl
+
+/-- **Local step monotonicity**, over the GENERATED `cjoin`. A single fold step
+    can only RAISE (never lower) the running confidentiality rank. Dual of
+    `istep_antitone`: the result of `cjoin a b` has rank ≥ `rankN a`. -/
+theorem cstep_monotone (a b : CL) :
+    ∀ r, portcullis_core.extracted.ifc_confidentiality.cjoin a b = ok r → rankN a ≤ rankN r := by
+  intro r h
+  rw [cjoin_ok] at h
+  by_cases hba : rankN b ≤ rankN a
+  · simp [hba] at h; subst h; omega
+  · simp [hba] at h; subst h; omega
+
+/-- Fold the GENERATED `crun_step` over an operation list, threading the running
+    effective confidentiality. The fold is hand-written; each step IS the
+    generated-from-Rust `crun_step` (= generated `cjoin`). -/
+def crun : List CL → CL → CL
+  | [], eff => eff
+  | src :: rest, eff =>
+      crun rest
+        (match portcullis_core.extracted.ifc_confidentiality.crun_step eff src with
+         | ok r => r
+         | _ => eff)
+
+/-- The generated `crun_step` reduces to the generated `cjoin` result. -/
+theorem crun_step_ok (eff src : CL) :
+    portcullis_core.extracted.ifc_confidentiality.crun_step eff src
+      = ok (if rankN src ≤ rankN eff then eff else src) := by
+  unfold portcullis_core.extracted.ifc_confidentiality.crun_step
+  rw [cjoin_ok]
+
+/-- One `crun` cons step raises the rank, via the GENERATED step. -/
+theorem crun_cons_step_monotone (eff src : CL) :
+    rankN eff ≤ rankN (match portcullis_core.extracted.ifc_confidentiality.crun_step eff src with
+           | ok r => r | _ => eff) := by
+  rw [crun_step_ok]
+  show rankN eff ≤ rankN (if rankN src ≤ rankN eff then eff else src)
+  split <;> omega
+
+/-- **Global composition** over the GENERATED step. Over ANY operation sequence,
+    the running effective confidentiality rank never drops below the starting
+    rank — confidentiality only ratchets UP. Dual of `irun_antitone`. -/
+theorem crun_monotone :
+    ∀ (ops : List CL) (eff : CL), rankN eff ≤ rankN (crun ops eff) := by
+  intro ops
+  induction ops with
+  | nil => intro eff; simp [crun]
+  | cons src rest ih =>
+      intro eff
+      simp only [crun]
+      have h_tail := ih (match portcullis_core.extracted.ifc_confidentiality.crun_step eff src with
+                         | ok r => r | _ => eff)
+      have h_step := crun_cons_step_monotone eff src
+      omega
+
+/-- Sink admission, over the GENERATED `cflows_to`: the running effective
+    confidentiality flows to the sink's ceiling iff `rankN eff ≤ rankN ceiling`
+    (BLP no-read-up). Dual of `iflows_to_ok`. -/
+theorem cflows_to_ok (a ceiling : CL) :
+    portcullis_core.extracted.ifc_confidentiality.cflows_to a ceiling
+      = ok (decide (rankN a ≤ rankN ceiling)) := by
+  cases a <;> cases ceiling <;> rfl
+
+/-- Admission holds iff the generated `cflows_to` returns `ok true`. -/
+def cadmitted (eff ceiling : CL) : Prop :=
+    portcullis_core.extracted.ifc_confidentiality.cflows_to eff ceiling = ok true
+
+/-- **Confidentiality-axis noninterference (main theorem), over the GENERATED
+    defs.** If the session's effective confidentiality already dominates a
+    joined-in source `L_src` (`rankN L_src ≤ rankN eff`), and that source is
+    strictly MORE confidential than the sink's ceiling allows
+    (`rankN ceiling < rankN L_src`), then over ANY operation sequence the sink is
+    NEVER admitted by the GENERATED `cflows_to`. Dual of
+    `integrity_sink_never_admitted`; closed by `omega` over `crun_monotone`. -/
+theorem confidentiality_sink_never_admitted
+    (L_src eff ceiling : CL) (ops : List CL)
+    (h_joined : rankN L_src ≤ rankN eff)
+    (h_blocked : rankN ceiling < rankN L_src) :
+    ¬ cadmitted (crun ops eff) ceiling := by
+  intro h_admit
+  unfold cadmitted at h_admit
+  rw [cflows_to_ok] at h_admit
+  simp only [Result.ok.injEq, decide_eq_true_eq] at h_admit
+  -- h_admit : rankN (crun ops eff) ≤ rankN ceiling
+  have h_ratchet : rankN eff ≤ rankN (crun ops eff) := crun_monotone ops eff
+  -- ceiling < L_src ≤ eff ≤ crun ≤ ceiling  ⇒  contradiction.
+  omega
+
+/-- **Instantiation: a secret-tainted session can NEVER reach a public sink**,
+    over the GENERATED defs. A session whose effective confidentiality is `Secret`
+    (rank 2 — the label credentials/keys carry) is never admitted at a `Public`
+    ceiling (rank 0; the ceiling true-egress sinks like HTTPEgress impose), over
+    ANY operation sequence. Non-vacuous: `h_joined = 2 ≤ 2`, `h_blocked = 0 < 2`. -/
+theorem secret_tainted_never_flows_public (ops : List CL) :
+    ¬ cadmitted (crun ops .Secret) .Public := by
+  apply confidentiality_sink_never_admitted
+    (L_src := .Secret)
+    (eff := .Secret)
+    (ceiling := .Public)
+    (ops := ops)
+  · decide
+  · decide
+
+end ConfidentialityNoninterferenceExtracted
+
+/-
+  Axiom audit (the aeneas-ifc-scoped `Assert clean axiom set` gate reads these).
+  EXPECTED, as for the integrity dual: [propext, Quot.sound, Classical.choice].
+  Anything else — `sorryAx` (a proof hole) or an Aeneas `*External` opaque axiom
+  — MUST fail review. The `extracted/ifc_confidentiality.rs` uses explicit
+  `crank(a) <= crank(b)` (not a derived `Ord`), so Aeneas emits a translated body
+  with no opaque comparison axiom.
+-/
+#print axioms ConfidentialityNoninterferenceExtracted.confidentiality_sink_never_admitted
+#print axioms ConfidentialityNoninterferenceExtracted.secret_tainted_never_flows_public

--- a/crates/portcullis-core/lean/lakefile.lean
+++ b/crates/portcullis-core/lean/lakefile.lean
@@ -44,6 +44,11 @@ lean_lib «PortcullisCoreIFC» where
 lean_lib «IntegrityNoninterferenceExtracted» where
   roots := #[`IntegrityNoninterferenceExtracted]
 
+-- Confidentiality-axis noninterference over the extracted core (D1/C1; STAGED —
+-- builds once aeneas-ifc-scoped extracts the ifc_confidentiality functions)
+lean_lib «ConfidentialityNoninterferenceExtracted» where
+  roots := #[`ConfidentialityNoninterferenceExtracted]
+
 -- Exposure tracker proofs (uninhabitable state detector)
 lean_lib «ExposureProofs» where
   roots := #[`ExposureProofs]

--- a/crates/portcullis-core/src/extracted/ifc_confidentiality.rs
+++ b/crates/portcullis-core/src/extracted/ifc_confidentiality.rs
@@ -1,0 +1,157 @@
+//! Confidentiality-axis IFC decision — the slice the confidentiality
+//! noninterference theorem is extracted over (D1 milestone C1; dual of
+//! `ifc_integrity.rs`).
+//!
+//! Confidentiality is the BLP ("no read up → no write down") axis. Unlike
+//! integrity (which is contravariant — taint pulls trust *down*), confidentiality
+//! is COVARIANT: combining two sources raises the result to the *more* confidential
+//! of the two. So the join clause is MAX (here `cjoin`), and the flows-to clause is
+//! `≤` (data labeled `a` may leave to a sink whose ceiling is *at least* as
+//! confidential): exactly the dual of integrity's MIN / `≥`.
+//!
+//! Aeneas translates each function to a CONCRETE body (no opaque `Ord` axiom), so
+//! the extracted Lean mirrors the production `IFCLabel` confidentiality clause. The
+//! exhaustive parity tests below pin the mirror to the real `IFCLabel::{join,
+//! flows_to}` confidentiality conjunct.
+
+/// Confidentiality level — mirrors the production `crate::ConfLevel`. The
+/// `#[repr(u8)]` discriminants ARE the confidentiality order.
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConfLevel {
+    /// Public — no confidentiality restriction (the bottom).
+    Public = 0,
+    /// Internal — organisation-confidential.
+    Internal = 1,
+    /// Secret — credentials, keys, private data (the top).
+    Secret = 2,
+}
+
+/// Numeric rank — `Public=0 < Internal=1 < Secret=2`, exactly the `#[repr(u8)]`
+/// discriminants. The rank order IS the confidentiality order; the production
+/// code relies on the same discriminant-derived `Ord`.
+pub fn crank(l: ConfLevel) -> u8 {
+    match l {
+        ConfLevel::Public => 0,
+        ConfLevel::Internal => 1,
+        ConfLevel::Secret => 2,
+    }
+}
+
+/// Confidentiality join — combining data raises confidentiality, so the running
+/// effective confidentiality is the MAX of the two by rank.
+///
+/// Mirrors the confidentiality clause of `IFCLabel::join` (lib.rs):
+/// `confidentiality: if self.confidentiality >= other.confidentiality { self }
+/// else { other }`. The `>=` is the discriminant order, restated here as
+/// `crank(a) >= crank(b)` so Aeneas translates a concrete body.
+pub fn cjoin(a: ConfLevel, b: ConfLevel) -> ConfLevel {
+    if crank(a) >= crank(b) { a } else { b }
+}
+
+/// Confidentiality flows-to: data labeled `a` may flow to a sink whose ceiling is
+/// `ceiling` iff `a` is at most as confidential as `ceiling` (BLP no-read-up).
+///
+/// Mirrors the confidentiality conjunct of `IFCLabel::flows_to` (lib.rs):
+/// `self.confidentiality <= target.confidentiality`, restated as
+/// `crank(a) <= crank(ceiling)`.
+pub fn cflows_to(a: ConfLevel, ceiling: ConfLevel) -> bool {
+    crank(a) <= crank(ceiling)
+}
+
+/// Per-operation fold step: fold a source label's confidentiality into the
+/// running effective confidentiality. This is the step the Lean noninterference
+/// fold (`crun`) applies per operation; it is exactly [`cjoin`].
+pub fn crun_step(eff: ConfLevel, src: ConfLevel) -> ConfLevel {
+    cjoin(eff, src)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// All three points of the confidentiality chain, in rank order.
+    const LEVELS: [ConfLevel; 3] = [ConfLevel::Public, ConfLevel::Internal, ConfLevel::Secret];
+
+    /// Map the local mirror to the production `crate::ConfLevel`.
+    fn to_real(l: ConfLevel) -> crate::ConfLevel {
+        match l {
+            ConfLevel::Public => crate::ConfLevel::Public,
+            ConfLevel::Internal => crate::ConfLevel::Internal,
+            ConfLevel::Secret => crate::ConfLevel::Secret,
+        }
+    }
+
+    /// Build a production `IFCLabel` whose confidentiality axis is `l` and whose
+    /// other axes are fixed (Default) so the confidentiality conjunct is binding.
+    fn label_with_confidentiality(l: ConfLevel) -> crate::IFCLabel {
+        crate::IFCLabel {
+            confidentiality: to_real(l),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn discriminants_match_real_conflevel() {
+        for l in LEVELS {
+            assert_eq!(l as u8, to_real(l) as u8, "discriminant drift for {l:?}");
+            assert_eq!(crank(l), l as u8, "crank != discriminant for {l:?}");
+            assert_eq!(crank(l), to_real(l) as u8, "crank != real discriminant");
+        }
+    }
+
+    #[test]
+    fn cjoin_matches_real_ifclabel_join_confidentiality_axis() {
+        // Exhaustive 3×3: the extracted `cjoin` equals the confidentiality field
+        // of the real `IFCLabel::join` for every pair.
+        for a in LEVELS {
+            for b in LEVELS {
+                let extracted = cjoin(a, b);
+                let real = label_with_confidentiality(a)
+                    .join(label_with_confidentiality(b))
+                    .confidentiality;
+                assert_eq!(
+                    to_real(extracted),
+                    real,
+                    "cjoin parity failed for ({a:?}, {b:?})"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn cflows_to_matches_real_ifclabel_flows_to_confidentiality_axis() {
+        // Exhaustive 3×3: extracted `cflows_to` equals the confidentiality
+        // conjunct of the real `IFCLabel::flows_to`. Source and target share all
+        // non-confidentiality axes (Default), so flows_to == the conf clause.
+        for a in LEVELS {
+            for ceiling in LEVELS {
+                let extracted = cflows_to(a, ceiling);
+                let real =
+                    label_with_confidentiality(a).flows_to(label_with_confidentiality(ceiling));
+                assert_eq!(
+                    extracted, real,
+                    "cflows_to parity failed for a={a:?}, ceiling={ceiling:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn secret_does_not_flow_to_public_but_public_does() {
+        // Non-vacuity + the BLP direction: Secret cannot leave to a Public sink;
+        // Public flows everywhere. (Dual of `gitpush_requires_trusted`.)
+        assert!(
+            !cflows_to(ConfLevel::Secret, ConfLevel::Public),
+            "Secret ⤳ Public must be blocked"
+        );
+        assert!(
+            cflows_to(ConfLevel::Public, ConfLevel::Secret),
+            "Public ⤳ Secret must be allowed"
+        );
+        assert_eq!(
+            crun_step(ConfLevel::Public, ConfLevel::Secret),
+            ConfLevel::Secret
+        );
+    }
+}

--- a/crates/portcullis-core/src/extracted/mod.rs
+++ b/crates/portcullis-core/src/extracted/mod.rs
@@ -16,4 +16,5 @@
 //! The extraction roots live here so the CI extractor can name them with
 //! `charon ... --start-from portcullis_core::extracted::ifc_integrity::<fn>`.
 
+pub mod ifc_confidentiality;
 pub mod ifc_integrity;


### PR DESCRIPTION
First step of **C1** — extract the IFC **confidentiality** axis so `decision.rs:361` can move from `HandModelKernelChecked` (proven over a hand model) to `ExtractedKernelChecked` (proven over Aeneas-extracted Rust), matching the integrity axis.

Dual of `ifc_integrity.rs`: `ConfLevel` + `cjoin` (**MAX** — confidentiality is covariant, combining *raises* it) + `cflows_to` (**BLP** no-read-up: `crank(a) ≤ crank(ceiling)`) + `crun_step`, all concrete-bodied for Aeneas.

Bound to production by **exhaustive parity**: `cjoin` == `IFCLabel::join` conf clause (3×3), `cflows_to` == `IFCLabel::flows_to` conf conjunct (3×3), discriminant match, + BLP non-vacuity. **4 tests green locally.**

**Remaining C1 (Aeneas toolchain, CI/operator-gated):** run `charon --start-from …::ifc_confidentiality::<fn>` → generate the Lean, write `ConfidentialityNoninterferenceExtracted.lean` (theorem over the generated fns, dual of `IntegrityNoninterferenceExtracted`), wire `aeneas-ifc-scoped.yml`, then demote `decision.rs:361`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013SAANNkRAS6PLum3YXjBkH