### PR TITLE
fix(ifc): stale certify() confidentiality_axis test assertion (red on main since #1906)

### DIFF
--- a/crates/nucleus-ifc/src/decision.rs
+++ b/crates/nucleus-ifc/src/decision.rs
@@ -467,10 +467,14 @@ mod tests {
             cert.proof_scope.integrity_axis,
             ProofStatus::ExtractedKernelChecked
         );
-        // The confidentiality leg must be honestly marked hand-model, never unified.
+        // Both legs are Aeneas-extracted + Lean-proven: #1906 flipped the
+        // confidentiality axis from hand-model to ExtractedKernelChecked (the
+        // order-dual of integrity), but this test assertion wasn't updated — it
+        // has been red on main since. The honest residuals below carry the
+        // remaining caveats.
         assert_eq!(
             cert.proof_scope.confidentiality_axis,
-            ProofStatus::HandModelKernelChecked
+            ProofStatus::ExtractedKernelChecked
         );
         assert!(
             !cert.proof_scope.open_residuals.is_empty(),


### PR DESCRIPTION
## What
`#1906` flipped `certify()`'s `confidentiality_axis` from `HandModelKernelChecked` → `ExtractedKernelChecked` (the order-dual of the integrity leg, proven over the Aeneas-extracted `ifc_confidentiality` defs) but didn't update `certify_carries_backing_theorem_and_honest_scope`. So the **`Tests` check has been red on `main`**, inheriting to every branch off it (surfaced by the autodrive PR sweep: #1909, #1897 both fail `Tests` on this exact assertion).

One-line root fix: assert the value `certify()` actually produces. Decoupled from the larger in-flight PRs (#1908) that also carry it, so it can land fast and green everyone.

## Verify
`cargo test -p nucleus-ifc --features decision certify_carries` → ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)