### PR TITLE
feat(verifier-js): verifySignedClearing — browser-side recompute enforcement (recompute-e2e R3)

### DIFF
--- a/sdks/verifier-js/Cargo.lock
+++ b/sdks/verifier-js/Cargo.lock
@@ -120,6 +120,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bit-vec"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -364,6 +370,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+dependencies = [
+ "const-oid 0.10.2",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "der-parser"
 version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -432,7 +449,7 @@ version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der",
+ "der 0.7.10",
  "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
@@ -445,6 +462,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
 dependencies = [
+ "pkcs8",
  "signature 3.0.0",
 ]
 
@@ -456,7 +474,9 @@ checksum = "20449acd54b660981ae5caa2bcb56d1fe7f25f2e37a38ec507400fab034d4bb6"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
+ "serde",
  "sha2 0.11.0",
+ "signature 3.0.0",
  "subtle",
  "zeroize",
 ]
@@ -962,6 +982,8 @@ version = "1.0.0"
 dependencies = [
  "hex",
  "nucleus-econ-kernels",
+ "nucleus-ifc",
+ "nucleus-receipt",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -1091,10 +1113,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
+dependencies = [
+ "der 0.8.0",
+ "spki",
+]
 
 [[package]]
 name = "portcullis-core"
@@ -1311,7 +1352,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
- "der",
+ "der 0.7.10",
  "generic-array",
  "subtle",
  "zeroize",
@@ -1457,6 +1498,16 @@ checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "base64ct",
+ "der 0.8.0",
 ]
 
 [[package]]

--- a/sdks/verifier-js/Cargo.toml
+++ b/sdks/verifier-js/Cargo.toml
@@ -25,7 +25,7 @@ nucleus-ifc = { path = "../../crates/nucleus-ifc", features = ["decision"] }
 nucleus-econ-kernels = { path = "../../crates/nucleus-econ-kernels" }
 # verify_receipt: re-derive every cleared number from a receipt's declared inputs
 # via the proven kernels, in-browser. The keystone recompute, callable by anyone.
-nucleus-recompute = { path = "../../crates/nucleus-recompute" }
+nucleus-recompute = { path = "../../crates/nucleus-recompute", features = ["envelope"] }
 nucleus-externality = { path = "../../crates/nucleus-externality" }
 # Bonding: lets the SDK compute the recompute-slashed required bond from an
 # agent's defection exposure + its verified reputation (the proven

--- a/sdks/verifier-js/src/lib.rs
+++ b/sdks/verifier-js/src/lib.rs
@@ -268,6 +268,59 @@ pub fn verify_receipt_js(
     serde_wasm_bindgen::to_value(&verdict).map_err(|e| JsError::new(&e.to_string()))
 }
 
+/// Structured result of [`verify_signed_clearing_js`].
+#[derive(serde::Serialize)]
+struct SignedClearingReport {
+    /// `true` iff the signature verified AND every cleared number re-derives from
+    /// the proven kernels — the only "fully verified" state.
+    verified: bool,
+    /// `verified` | `bad_signature` | `malformed:<e>` | `mismatch:<field>` | `invalid:<e>`.
+    verdict: String,
+}
+
+/// Core (natively testable) of [`verify_signed_clearing_js`].
+fn signed_clearing_verdict(
+    receipt_json: &str,
+    verifying_key_bytes: &[u8],
+) -> Result<SignedClearingReport, String> {
+    use nucleus_recompute::envelope::{verify_signed_clearing, SignedClearingVerdict};
+    use nucleus_recompute::RecomputeOutcome;
+
+    let receipt: nucleus_receipt::Receipt =
+        serde_json::from_str(receipt_json).map_err(|e| format!("receipt JSON: {e}"))?;
+    let vk: [u8; 32] = verifying_key_bytes
+        .try_into()
+        .map_err(|_| "verifying key must be 32 bytes".to_string())?;
+    let (verified, verdict) = match verify_signed_clearing(&receipt, &vk) {
+        SignedClearingVerdict::Recomputed(RecomputeOutcome::Match) => (true, "verified".to_string()),
+        SignedClearingVerdict::Recomputed(RecomputeOutcome::Mismatch { field, .. }) => {
+            (false, format!("mismatch:{field}"))
+        }
+        SignedClearingVerdict::Recomputed(RecomputeOutcome::Invalid(m)) => {
+            (false, format!("invalid:{m}"))
+        }
+        SignedClearingVerdict::BadSignature => (false, "bad_signature".to_string()),
+        SignedClearingVerdict::Malformed(e) => (false, format!("malformed:{e}")),
+    };
+    Ok(SignedClearingReport { verified, verdict })
+}
+
+/// Verify a SIGNED clearing receipt end-to-end IN THE BROWSER: the Ed25519
+/// signature THEN a RECOMPUTE of every cleared number via the proven kernels.
+/// Unlike [`verify_receipt_js`] (signature + root hash), this catches a FORGED
+/// output under a VALID signature — the recompute moat, now client-side. Returns
+/// `{ verified, verdict }`. (recompute-e2e R3: the public SDK surface.)
+#[wasm_bindgen(js_name = verifySignedClearing)]
+pub fn verify_signed_clearing_js(
+    receipt_json: &str,
+    verifying_key_bytes: &[u8],
+) -> Result<JsValue, JsError> {
+    set_panic_hook();
+    let report =
+        signed_clearing_verdict(receipt_json, verifying_key_bytes).map_err(|e| JsError::new(&e))?;
+    serde_wasm_bindgen::to_value(&report).map_err(|e| JsError::new(&e.to_string()))
+}
+
 // ── AGENT CARD: verify the counterparty's signed identity BEFORE acting ───────
 //
 // `verifyBundle` answers WHAT happened (provenance), `verifyReceipt` answers
@@ -935,6 +988,49 @@ mod receipt_tests {
         let vk = signing_key().verifying_key().to_bytes();
         let json = serde_json::to_string(&receipt).unwrap();
         assert!(receipt_verdict(&json, &vk).is_err());
+    }
+
+    /// R3: the SDK's signed-clearing verifier does signature + RECOMPUTE. An
+    /// honest issued clearing verifies; a forged output under a VALID signature is
+    /// caught by recompute — the moat `verifyReceipt` (signature + root hash)
+    /// cannot provide.
+    #[test]
+    fn signed_clearing_verifies_and_recompute_catches_forgery() {
+        use nucleus_recompute::{
+            envelope::to_economic_projection, issue_settlement, ClearingReceipt,
+        };
+        let session = || Session {
+            session_id: "spiffe://test/clearing".into(),
+            issuer_kid: "test-kid".into(),
+            issued_at_micros: 1_717_000_000_000_000,
+            parent_chain: vec![],
+        };
+        let vk = signing_key().verifying_key().to_bytes();
+
+        // Honest issued clearing → verified (signature + recompute).
+        let honest = Receipt::sign(
+            session(),
+            vec![to_economic_projection(&issue_settlement(1_000_000, 9_500))],
+            &signing_key(),
+        );
+        let r = signed_clearing_verdict(&serde_json::to_string(&honest).unwrap(), &vk).unwrap();
+        assert!(r.verified, "honest clearing must verify, got {}", r.verdict);
+        assert_eq!(r.verdict, "verified");
+
+        // Forged seller_gross under a VALID signature → caught by recompute.
+        let mut claim = match issue_settlement(1_000_000, 9_500) {
+            ClearingReceipt::Settlement(c) => c,
+            _ => unreachable!(),
+        };
+        claim.seller_gross += 1;
+        let forged = Receipt::sign(
+            session(),
+            vec![to_economic_projection(&ClearingReceipt::Settlement(claim))],
+            &signing_key(),
+        );
+        let r = signed_clearing_verdict(&serde_json::to_string(&forged).unwrap(), &vk).unwrap();
+        assert!(!r.verified, "forged clearing must be rejected");
+        assert_eq!(r.verdict, "mismatch:seller_gross");
     }
 }
 


### PR DESCRIPTION
## What
R3 of shipping the recompute layer e2e: exports nucleus-recompute's signed-clearing verifier on the public **WASM SDK**. A browser/Node consumer verifies a signed clearing end-to-end — Ed25519 signature **then** recompute of every cleared number via the proven kernels. Unlike the existing `verifyReceipt` (signature + root hash), `verifySignedClearing` catches a **forged output under a valid signature** — the recompute moat, now client-side.

- `signed_clearing_verdict` (testable core) + `verifySignedClearing` (wasm-bindgen) → `{ verified, verdict }`.
- nucleus-recompute gains the `envelope` feature here — **compiles clean to wasm32** (verification needs no RNG → no getrandom blocker).
- Native test: issued+signed Settlement verifies; forged `seller_gross` under a valid signature → `mismatch:seller_gross`.

## Verify
`cargo test --manifest-path sdks/verifier-js/Cargo.toml signed_clearing` → ok; `cargo build --target wasm32-unknown-unknown` → clean.

## Stacking
Stacked on R1+R2 (#1909, merge queue). Rebases to just-R3 once #1909 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)