### PR TITLE
feat: Trifecta Gate — observe-only MCP proxy that flags AI-agent exfiltration risk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6852,6 +6852,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nucleus-mcp-guard"
+version = "1.0.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "nucleus-ifc",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "nucleus-memory"
 version = "1.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "crates/nucleus-proto",  # Generated gRPC/Protobuf types
     "crates/nucleus-node",   # Node daemon (kubelet analogue)
     "crates/nucleus-tool-proxy", # Tool proxy server (runs inside pod)
+    "crates/nucleus-mcp-guard",  # Trifecta Gate: observe-only MCP proxy, flags exfil risk
     "crates/nucleus-guest-init", # Guest init for Firecracker images
     "crates/nucleus-net-probe", # TCP probe for network policy tests
     "crates/nucleus-mcp", # MCP server bridging Claude to tool-proxy

--- a/crates/nucleus-mcp-guard/Cargo.toml
+++ b/crates/nucleus-mcp-guard/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "nucleus-mcp-guard"
+description = "Trifecta Gate: an observe-only MCP proxy that taint-tracks AI-agent dataflow and flags lethal-trifecta exfiltration risk, using the proven nucleus-ifc gate."
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+
+[lib]
+
+[[bin]]
+name = "mcp-guard"
+path = "src/main.rs"
+
+[dependencies]
+# The engine: the model-level lethal-trifecta IFC decision (FlowDeclaration → IfcVerdict).
+nucleus-ifc = { path = "../nucleus-ifc", features = ["decision"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+anyhow = { workspace = true }
+clap = { workspace = true }
+tokio = { workspace = true, features = [
+    "rt-multi-thread",
+    "macros",
+    "io-util",
+    "io-std",
+    "process",
+] }

--- a/crates/nucleus-mcp-guard/README.md
+++ b/crates/nucleus-mcp-guard/README.md
@@ -1,0 +1,89 @@
+# Trifecta Gate (`mcp-guard`)
+
+**See what your AI agent can exfiltrate — before an attacker does.**
+
+`mcp-guard` is a drop-in [MCP](https://modelcontextprotocol.io) proxy that watches
+an agent session and flags every moment the agent holds the **lethal trifecta**:
+
+> **private data** + **exposure to untrusted content** + **an outbound channel**
+
+When those three co-occur, a prompt-injection hidden in the untrusted content can
+turn your agent into an exfiltration tool. `mcp-guard` makes that risk *visible* —
+zero agent changes, runs in dev or CI.
+
+The detection isn't a regex guess. The actual decision is a **formally-modelled
+information-flow gate** (`nucleus-ifc`): the proxy maps each MCP tool to an IFC
+data class, accumulates session taint, and asks the gate whether an outbound call
+is safe given everything the agent has seen.
+
+## Quick start
+
+Wrap your MCP server (stdio) — it's transparent to both the agent and the server:
+
+```bash
+mcp-guard proxy -- npx -y @your/mcp-server
+```
+
+The agent talks to `mcp-guard` exactly as it would the server. On any risky
+egress you get, on **stderr** (stdout stays the clean MCP channel):
+
+```
+[trifecta-gate] /!\ egress flagged: `send_email` while holding [file_read + web_content] — ...
+```
+
+and a session report when the session ends.
+
+### Try it offline (no server needed)
+
+Replay a recorded tool sequence to produce the artifact:
+
+```bash
+mcp-guard analyze examples/exfil_session.json
+```
+
+```
+== Trifecta Gate — MCP session report ==
+
+Tools observed:        3
+Data classes in scope: file_read, web_content
+Egress points flagged: 1
+
+  /!\  EXFILTRATION POSSIBLE
+       This agent reached an external sink while holding the lethal
+       trifecta (private data + untrusted content + outbound channel).
+       ...
+    - via `send_email` (counterparty) over [file_read + web_content]
+      reason: ...
+```
+
+`mcp-guard analyze` (and the proxy) exit **non-zero** when exfiltration is
+possible — drop it into CI as an agent-safety gate. Add `--json` for a
+machine-readable report.
+
+## Customising the tool→risk mapping
+
+Defaults are conservative (an *unknown* tool's output is treated as untrusted, and
+only recognised tools are egress sinks). Override with `--config rules.json`:
+
+```json
+{
+  "rules": [
+    { "contains": "read_customer_record", "role": { "kind": "source", "input": "secret" } },
+    { "contains": "notify_webhook",       "role": { "kind": "sink",   "public": false } }
+  ]
+}
+```
+
+Set `"replace_defaults": true` to start from scratch.
+
+## What this is (and isn't)
+
+- **Free / observe-only.** This tool *reports*; it does not block. The enforcement
+  tier (hard-blocking on a denied verdict + signed, recomputable audit receipts
+  mapped to SOC2 / OWASP LLM Top 10) is the commercial layer above it.
+- **Model-level.** The verdict is over the data classes a session is *observed* to
+  touch via MCP tool traffic. Coverage is the honest limit: a channel the agent
+  uses outside MCP is a channel the gate doesn't see. It does **not** claim to
+  prove exfiltration is impossible — it shows when it's *possible*.
+
+Built on the `nucleus-ifc` lethal-trifecta gate.

--- a/crates/nucleus-mcp-guard/examples/benign_session.json
+++ b/crates/nucleus-mcp-guard/examples/benign_session.json
@@ -1,0 +1,1 @@
+["web_search", "summarize"]

--- a/crates/nucleus-mcp-guard/examples/exfil_session.json
+++ b/crates/nucleus-mcp-guard/examples/exfil_session.json
@@ -1,0 +1,1 @@
+["read_secret", "fetch_url", "send_email"]

--- a/crates/nucleus-mcp-guard/src/classify.rs
+++ b/crates/nucleus-mcp-guard/src/classify.rs
@@ -1,0 +1,225 @@
+//! Map MCP tools to IFC roles.
+//!
+//! The lethal-trifecta decision ([`nucleus_ifc`]) is the proven engine; this
+//! module is the (deliberately simple, fully overridable) *adapter* that decides,
+//! for a given MCP tool, whether its **result** brings a class of data into the
+//! agent's context (a [`ToolRole::Source`]) or its **call** is an outbound action
+//! that could exfiltrate (a [`ToolRole::Sink`]).
+//!
+//! Defaults are conservative: an **unknown** tool's result is treated as untrusted
+//! [`DeclaredInput::ToolResponse`] (taint), and only explicitly-recognised tools
+//! are treated as egress sinks. Override any of this via [`Classifier::with_rule`]
+//! or a loaded [`ClassifierConfig`] — see `README.md`.
+
+use nucleus_ifc::DeclaredInput;
+use serde::{Deserialize, Serialize};
+
+/// What an MCP tool means for information flow.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+pub enum ToolRole {
+    /// The tool's RESULT introduces this data class into the agent's context.
+    Source {
+        /// The IFC input class the tool's output is treated as.
+        input: DeclaredInput,
+    },
+    /// The tool CALL is an outbound action (an egress point). `public = true` when
+    /// the destination is publicly visible (the tightest confidentiality ceiling).
+    Sink {
+        /// Whether the destination is publicly visible (vs. an authenticated peer).
+        public: bool,
+    },
+    /// Local / irrelevant to exfiltration (e.g. a calculator).
+    Neutral,
+}
+
+/// A single name-match rule. `contains` is matched case-insensitively as a
+/// substring of the tool name; first matching rule wins.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Rule {
+    /// Lowercase substring to match against the tool name.
+    pub contains: String,
+    /// The role to assign on a match.
+    pub role: ToolRole,
+}
+
+impl Rule {
+    fn new(contains: &str, role: ToolRole) -> Self {
+        Self {
+            contains: contains.to_string(),
+            role,
+        }
+    }
+}
+
+/// Serializable classifier config (load from JSON to override defaults).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ClassifierConfig {
+    /// Extra rules, evaluated BEFORE the built-in defaults (so they take priority).
+    #[serde(default)]
+    pub rules: Vec<Rule>,
+    /// If `true`, drop the built-in default ruleset entirely.
+    #[serde(default)]
+    pub replace_defaults: bool,
+}
+
+/// The ordered ruleset that turns a tool name into a [`ToolRole`].
+#[derive(Debug, Clone)]
+pub struct Classifier {
+    rules: Vec<Rule>,
+    /// Role for a tool that matches nothing (conservative: untrusted tool output).
+    fallback: ToolRole,
+}
+
+impl Default for Classifier {
+    fn default() -> Self {
+        use DeclaredInput::*;
+        let src = |i| ToolRole::Source { input: i };
+        // Order matters — first match wins. Specific sinks + private sources are
+        // listed before the broad web/http source patterns.
+        let rules = vec![
+            // --- neutral (local, no exfil relevance) ---
+            Rule::new("calculator", ToolRole::Neutral),
+            Rule::new("math", ToolRole::Neutral),
+            // --- egress sinks (outbound actions) ---
+            Rule::new("send_email", ToolRole::Sink { public: false }),
+            Rule::new("sendmail", ToolRole::Sink { public: false }),
+            Rule::new("smtp", ToolRole::Sink { public: false }),
+            Rule::new("email", ToolRole::Sink { public: false }),
+            Rule::new("http_post", ToolRole::Sink { public: false }),
+            Rule::new("webhook", ToolRole::Sink { public: false }),
+            Rule::new("upload", ToolRole::Sink { public: false }),
+            Rule::new("slack", ToolRole::Sink { public: true }),
+            Rule::new("discord", ToolRole::Sink { public: true }),
+            Rule::new("telegram", ToolRole::Sink { public: true }),
+            Rule::new("tweet", ToolRole::Sink { public: true }),
+            Rule::new("publish", ToolRole::Sink { public: true }),
+            Rule::new("post_message", ToolRole::Sink { public: true }),
+            // --- private / sensitive sources ---
+            Rule::new("secret", src(Secret)),
+            Rule::new("credential", src(Secret)),
+            Rule::new("api_key", src(Secret)),
+            Rule::new("apikey", src(Secret)),
+            Rule::new("password", src(Secret)),
+            Rule::new("getenv", src(EnvVar)),
+            Rule::new("env_var", src(EnvVar)),
+            Rule::new("read_file", src(FileRead)),
+            Rule::new("readfile", src(FileRead)),
+            Rule::new("file_read", src(FileRead)),
+            Rule::new("fs_read", src(FileRead)),
+            Rule::new("open_file", src(FileRead)),
+            Rule::new("query", src(DatabaseRow)),
+            Rule::new("sql", src(DatabaseRow)),
+            Rule::new("database", src(DatabaseRow)),
+            Rule::new("recall", src(MemoryRead)),
+            Rule::new("memory", src(MemoryRead)),
+            // --- untrusted external content sources ---
+            Rule::new("fetch", src(WebContent)),
+            Rule::new("browse", src(WebContent)),
+            Rule::new("scrape", src(WebContent)),
+            Rule::new("crawl", src(WebContent)),
+            Rule::new("read_url", src(WebContent)),
+            Rule::new("web", src(WebContent)),
+            Rule::new("http", src(HttpResponse)),
+            Rule::new("request", src(HttpResponse)),
+            Rule::new("api", src(HttpResponse)),
+        ];
+        Self {
+            rules,
+            // Unknown tool → its output is untrusted tool content. Fail safe.
+            fallback: ToolRole::Source {
+                input: DeclaredInput::ToolResponse,
+            },
+        }
+    }
+}
+
+impl Classifier {
+    /// Build a classifier from a config (overrides applied before defaults).
+    pub fn from_config(cfg: &ClassifierConfig) -> Self {
+        let mut c = if cfg.replace_defaults {
+            Self {
+                rules: Vec::new(),
+                fallback: ToolRole::Source {
+                    input: DeclaredInput::ToolResponse,
+                },
+            }
+        } else {
+            Self::default()
+        };
+        // Prepend overrides so they win over defaults.
+        let mut rules = cfg.rules.clone();
+        rules.append(&mut c.rules);
+        c.rules = rules;
+        c
+    }
+
+    /// Add a high-priority override rule (takes precedence over defaults).
+    pub fn with_rule(mut self, contains: &str, role: ToolRole) -> Self {
+        self.rules.insert(0, Rule::new(contains, role));
+        self
+    }
+
+    /// Classify a tool by name (case-insensitive substring match, first wins).
+    pub fn classify(&self, tool_name: &str) -> ToolRole {
+        let name = tool_name.to_ascii_lowercase();
+        for r in &self.rules {
+            if name.contains(&r.contains.to_ascii_lowercase()) {
+                return r.role;
+            }
+        }
+        self.fallback
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_classify_the_trifecta_corners() {
+        let c = Classifier::default();
+        assert_eq!(
+            c.classify("read_file"),
+            ToolRole::Source {
+                input: DeclaredInput::FileRead
+            }
+        );
+        assert_eq!(
+            c.classify("fetch_url"),
+            ToolRole::Source {
+                input: DeclaredInput::WebContent
+            }
+        );
+        assert_eq!(c.classify("send_email"), ToolRole::Sink { public: false });
+        assert_eq!(c.classify("slack_post"), ToolRole::Sink { public: true });
+    }
+
+    #[test]
+    fn unknown_tool_is_untrusted_tool_output() {
+        let c = Classifier::default();
+        assert_eq!(
+            c.classify("some_random_plugin"),
+            ToolRole::Source {
+                input: DeclaredInput::ToolResponse
+            }
+        );
+    }
+
+    #[test]
+    fn overrides_win_over_defaults() {
+        // A site that exposes secrets via a tool literally named "read_file".
+        let c = Classifier::default().with_rule(
+            "read_file",
+            ToolRole::Source {
+                input: DeclaredInput::Secret,
+            },
+        );
+        assert_eq!(
+            c.classify("read_file"),
+            ToolRole::Source {
+                input: DeclaredInput::Secret
+            }
+        );
+    }
+}

--- a/crates/nucleus-mcp-guard/src/lib.rs
+++ b/crates/nucleus-mcp-guard/src/lib.rs
@@ -1,0 +1,33 @@
+//! # Trifecta Gate — `nucleus-mcp-guard`
+//!
+//! An **observe-only MCP proxy** that shows what an AI agent *can* exfiltrate.
+//!
+//! It sits transparently between an agent and its MCP server, taint-tracks the
+//! dataflow of a session, and flags every moment the agent holds the **lethal
+//! trifecta** — private data + exposure to untrusted content + an outbound
+//! channel — at which point a prompt-injection can leak the private data out.
+//!
+//! The detection is not heuristic hand-waving: the actual decision is the proven
+//! model-level IFC gate in [`nucleus_ifc`] (`FlowDeclaration::decide`). This crate
+//! only adapts MCP tool traffic into that gate's inputs ([`classify`]) and
+//! accumulates session taint ([`session`]).
+//!
+//! ## Two ways in
+//! - [`proxy::run_stdio_proxy`] — wrap a live stdio MCP server (zero agent changes).
+//! - [`analyze_session`] — replay a recorded list of tool names offline (great for
+//!   CI and for producing the report artifact without a live server).
+//!
+//! ## Tiers (the product)
+//! - **Free (this crate):** observe + report. Manufactures the "my agent CAN
+//!   exfiltrate" artifact.
+//! - **Enforcement (paid):** the same gate, but block on a denied verdict in the
+//!   proxy, with signed, recomputable audit receipts.
+
+pub mod classify;
+pub mod proxy;
+pub mod report;
+pub mod session;
+
+pub use classify::{Classifier, ClassifierConfig, Rule, ToolRole};
+pub use report::{analyze_session, SessionReport};
+pub use session::{Finding, SessionMonitor, ToolEvent};

--- a/crates/nucleus-mcp-guard/src/main.rs
+++ b/crates/nucleus-mcp-guard/src/main.rs
@@ -1,0 +1,98 @@
+//! `mcp-guard` — Trifecta Gate CLI. See what your AI agent can exfiltrate.
+
+use anyhow::{Context, Result};
+use clap::{Parser, Subcommand};
+use nucleus_mcp_guard::{analyze_session, proxy, Classifier, ClassifierConfig, SessionMonitor};
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+#[derive(Parser)]
+#[command(
+    name = "mcp-guard",
+    about = "Trifecta Gate: see what your AI agent can exfiltrate (observe-only MCP proxy)."
+)]
+struct Cli {
+    #[command(subcommand)]
+    cmd: Cmd,
+    /// Optional classifier-override config (JSON) — extend or replace the defaults.
+    #[arg(long, global = true)]
+    config: Option<PathBuf>,
+    /// Emit machine-readable JSON instead of the human report.
+    #[arg(long, global = true)]
+    json: bool,
+}
+
+#[derive(Subcommand)]
+enum Cmd {
+    /// Wrap a live stdio MCP server and observe the session. The server command
+    /// and its args follow `--`, e.g. `mcp-guard proxy -- npx my-mcp-server`.
+    Proxy {
+        #[arg(last = true, required = true, num_args = 1..)]
+        server: Vec<String>,
+    },
+    /// Replay a recorded session offline and report. The session file is a JSON
+    /// array of tool names (in call order), or `{"tools": [...]}`.
+    Analyze { session: PathBuf },
+}
+
+#[derive(serde::Deserialize)]
+#[serde(untagged)]
+enum SessionFile {
+    List(Vec<String>),
+    Obj { tools: Vec<String> },
+}
+
+fn load_classifier(path: &Option<PathBuf>) -> Result<Classifier> {
+    match path {
+        Some(p) => {
+            let s = std::fs::read_to_string(p)
+                .with_context(|| format!("reading classifier config {}", p.display()))?;
+            let cfg: ClassifierConfig =
+                serde_json::from_str(&s).context("parsing classifier config JSON")?;
+            Ok(Classifier::from_config(&cfg))
+        }
+        None => Ok(Classifier::default()),
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let cli = Cli::parse();
+    let classifier = load_classifier(&cli.config)?;
+
+    let (report, protocol_on_stdout) = match cli.cmd {
+        Cmd::Analyze { session } => {
+            let s = std::fs::read_to_string(&session)
+                .with_context(|| format!("reading session file {}", session.display()))?;
+            let sf: SessionFile = serde_json::from_str(&s).context("parsing session file")?;
+            let tools = match sf {
+                SessionFile::List(v) => v,
+                SessionFile::Obj { tools } => tools,
+            };
+            (analyze_session(&tools, classifier), false)
+        }
+        Cmd::Proxy { server } => {
+            let (cmd, args) = server.split_first().context("missing MCP server command")?;
+            let monitor = Arc::new(Mutex::new(SessionMonitor::new(classifier)));
+            let report = proxy::run_stdio_proxy(monitor, cmd, args).await?;
+            (report, true) // stdout is the MCP channel — report must go to stderr
+        }
+    };
+
+    let rendered = if cli.json {
+        report.to_json()
+    } else {
+        report.render()
+    };
+    if protocol_on_stdout {
+        eprintln!("{rendered}");
+    } else {
+        println!("{rendered}");
+    }
+
+    // Non-zero exit when exfiltration is possible, so CI / assessments can gate.
+    if report.exfiltration_possible {
+        std::process::exit(1);
+    }
+    Ok(())
+}

--- a/crates/nucleus-mcp-guard/src/proxy.rs
+++ b/crates/nucleus-mcp-guard/src/proxy.rs
@@ -1,0 +1,105 @@
+//! Drop-in stdio MCP proxy (observe-only).
+//!
+//! Spawns the real MCP server as a child and relays newline-delimited JSON-RPC in
+//! both directions **byte-verbatim** — so it is transparent to both the agent and
+//! the server (zero agent changes). It intercepts `tools/call` requests (egress
+//! checks) and their responses (taint) to drive a [`SessionMonitor`]. The free
+//! tier only *observes*; the enforcement tier (paid) would block on a denied
+//! verdict here instead of forwarding.
+
+use crate::report::SessionReport;
+use crate::session::SessionMonitor;
+use anyhow::{Context, Result};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::Command;
+
+/// Run the proxy: wrap `cmd args` (the real MCP server), relay JSON-RPC, and feed
+/// the shared monitor. Returns the session report when the streams close.
+pub async fn run_stdio_proxy(
+    monitor: Arc<Mutex<SessionMonitor>>,
+    cmd: &str,
+    args: &[String],
+) -> Result<SessionReport> {
+    let mut child = Command::new(cmd)
+        .args(args)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::inherit())
+        .spawn()
+        .with_context(|| format!("failed to spawn MCP server: {cmd}"))?;
+
+    let mut child_stdin = child.stdin.take().context("child has no stdin")?;
+    let child_stdout = child.stdout.take().context("child has no stdout")?;
+
+    // Maps a JSON-RPC request id -> the tool name, so a response can be attributed.
+    let pending: Arc<Mutex<HashMap<String, String>>> = Arc::new(Mutex::new(HashMap::new()));
+
+    // Agent -> server: intercept `tools/call` requests (the egress points).
+    let mon_a = monitor.clone();
+    let pend_a = pending.clone();
+    let up = tokio::spawn(async move {
+        let mut lines = BufReader::new(tokio::io::stdin()).lines();
+        while let Ok(Some(line)) = lines.next_line().await {
+            if let Ok(v) = serde_json::from_str::<serde_json::Value>(&line) {
+                if v.get("method").and_then(|m| m.as_str()) == Some("tools/call") {
+                    if let Some(name) = v.pointer("/params/name").and_then(|n| n.as_str()) {
+                        if let Some(id) = v.get("id") {
+                            pend_a
+                                .lock()
+                                .unwrap()
+                                .insert(id.to_string(), name.to_string());
+                        }
+                        let finding = mon_a.lock().unwrap().observe_call(name);
+                        if let Some(f) = finding {
+                            eprintln!(
+                                "[trifecta-gate] /!\\ egress flagged: `{}` while holding [{}] — {}",
+                                f.sink_tool,
+                                f.verdict.declared_inputs.join(" + "),
+                                f.verdict.reason
+                            );
+                        }
+                    }
+                }
+            }
+            if child_stdin.write_all(line.as_bytes()).await.is_err()
+                || child_stdin.write_all(b"\n").await.is_err()
+            {
+                break;
+            }
+            let _ = child_stdin.flush().await;
+        }
+        drop(child_stdin); // EOF to the server
+    });
+
+    // Server -> agent: attribute `tools/call` responses (the taint).
+    let mon_b = monitor.clone();
+    let pend_b = pending.clone();
+    let down = tokio::spawn(async move {
+        let mut lines = BufReader::new(child_stdout).lines();
+        let mut out = tokio::io::stdout();
+        while let Ok(Some(line)) = lines.next_line().await {
+            if let Ok(v) = serde_json::from_str::<serde_json::Value>(&line) {
+                if let Some(id) = v.get("id") {
+                    let name = pend_b.lock().unwrap().remove(&id.to_string());
+                    if let Some(name) = name {
+                        mon_b.lock().unwrap().observe_result(&name);
+                    }
+                }
+            }
+            if out.write_all(line.as_bytes()).await.is_err() || out.write_all(b"\n").await.is_err()
+            {
+                break;
+            }
+            let _ = out.flush().await;
+        }
+    });
+
+    let _ = up.await;
+    let _ = down.await;
+    let _ = child.wait().await;
+
+    let report = SessionReport::from_monitor(&monitor.lock().unwrap());
+    Ok(report)
+}

--- a/crates/nucleus-mcp-guard/src/report.rs
+++ b/crates/nucleus-mcp-guard/src/report.rs
@@ -1,0 +1,129 @@
+//! The session report — the artifact a developer sees.
+//!
+//! [`SessionReport::render`] produces the visceral, copy-pasteable headline
+//! ("your agent CAN exfiltrate") plus the exact tool chain that proves it;
+//! [`SessionReport::to_json`] gives the machine-readable form for CI / receipts.
+
+use crate::session::{Finding, SessionMonitor, ToolEvent};
+use serde::{Deserialize, Serialize};
+
+/// A finished session's findings, serializable for CI artifacts and (later) for
+/// folding into a signed, recomputable audit receipt.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionReport {
+    /// `true` iff at least one egress sink was reached while holding the trifecta.
+    pub exfiltration_possible: bool,
+    /// Data classes (IFC tokens) the agent was exposed to, in order seen.
+    pub inputs_seen: Vec<String>,
+    /// Every observed tool event.
+    pub events: Vec<ToolEvent>,
+    /// The flagged egress points.
+    pub findings: Vec<Finding>,
+}
+
+impl SessionReport {
+    /// Build a report from a finished [`SessionMonitor`].
+    pub fn from_monitor(m: &SessionMonitor) -> Self {
+        Self {
+            exfiltration_possible: m.exfiltration_possible(),
+            inputs_seen: m
+                .seen_inputs()
+                .iter()
+                .map(|i| i.token().to_string())
+                .collect(),
+            events: m.events().to_vec(),
+            findings: m.findings().to_vec(),
+        }
+    }
+
+    /// Machine-readable JSON (pretty).
+    pub fn to_json(&self) -> String {
+        serde_json::to_string_pretty(self).unwrap_or_else(|e| format!("{{\"error\":\"{e}\"}}"))
+    }
+
+    /// The human-facing artifact.
+    pub fn render(&self) -> String {
+        let mut s = String::new();
+        s.push_str("== Trifecta Gate — MCP session report ==\n\n");
+        s.push_str(&format!("Tools observed:        {}\n", self.events.len()));
+        let seen = if self.inputs_seen.is_empty() {
+            "(none)".to_string()
+        } else {
+            self.inputs_seen.join(", ")
+        };
+        s.push_str(&format!("Data classes in scope: {seen}\n"));
+        s.push_str(&format!(
+            "Egress points flagged: {}\n\n",
+            self.findings.len()
+        ));
+
+        if self.exfiltration_possible {
+            s.push_str("  /!\\  EXFILTRATION POSSIBLE\n");
+            s.push_str("       This agent reached an external sink while holding the lethal\n");
+            s.push_str("       trifecta (private data + untrusted content + outbound channel).\n");
+            s.push_str("       A prompt-injection in the untrusted content can now leak the\n");
+            s.push_str("       private data out. Verdict from the nucleus-ifc gate:\n\n");
+            for f in &self.findings {
+                let dest = if f.public_sink {
+                    "public"
+                } else {
+                    "counterparty"
+                };
+                s.push_str(&format!(
+                    "    - via `{}` ({dest}) over [{}]\n      reason: {}\n",
+                    f.sink_tool,
+                    f.verdict.declared_inputs.join(" + "),
+                    f.verdict.reason,
+                ));
+            }
+        } else {
+            s.push_str("  OK   No lethal-trifecta egress detected in this session.\n");
+            s.push_str("       (Observe-only: this reflects the tools actually exercised.)\n");
+        }
+        s
+    }
+}
+
+/// Replay a recorded session (an ordered list of tool names) offline and report.
+/// This is the zero-dependency way to produce the artifact without a live server.
+pub fn analyze_session(tools: &[String], classifier: crate::classify::Classifier) -> SessionReport {
+    let mut m = SessionMonitor::new(classifier);
+    for t in tools {
+        m.observe_invocation(t);
+    }
+    SessionReport::from_monitor(&m)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::classify::Classifier;
+
+    #[test]
+    fn exfil_report_renders_the_headline_and_chain() {
+        let tools: Vec<String> = ["read_secret", "fetch_url", "send_email"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let rep = analyze_session(&tools, Classifier::default());
+        assert!(rep.exfiltration_possible);
+        let out = rep.render();
+        assert!(out.contains("EXFILTRATION POSSIBLE"), "got:\n{out}");
+        assert!(out.contains("send_email"));
+        // round-trips as JSON
+        let j = rep.to_json();
+        let back: SessionReport = serde_json::from_str(&j).unwrap();
+        assert!(back.exfiltration_possible);
+    }
+
+    #[test]
+    fn benign_report_is_clean() {
+        let tools: Vec<String> = ["web_search", "calculator"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let rep = analyze_session(&tools, Classifier::default());
+        assert!(!rep.exfiltration_possible);
+        assert!(rep.render().contains("No lethal-trifecta egress"));
+    }
+}

--- a/crates/nucleus-mcp-guard/src/session.rs
+++ b/crates/nucleus-mcp-guard/src/session.rs
@@ -1,0 +1,155 @@
+//! Per-session taint tracking + lethal-trifecta detection.
+//!
+//! As an agent session runs, each tool **result** that is a [`ToolRole::Source`]
+//! adds its data class to the accumulated taint set; each tool **call** that is a
+//! [`ToolRole::Sink`] is an egress point, checked against the taint via the proven
+//! [`nucleus_ifc`] lethal-trifecta decision. A denied verdict is a [`Finding`]:
+//! the agent, at that moment, *can* exfiltrate (private data + untrusted content +
+//! an external sink all co-occur).
+
+use crate::classify::{Classifier, ToolRole};
+use nucleus_ifc::{DeclaredInput, FlowDeclaration, IfcVerdict};
+use serde::{Deserialize, Serialize};
+
+/// One observed tool interaction (for the session log / artifact).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolEvent {
+    /// The MCP tool name.
+    pub tool: String,
+    /// How it was classified.
+    pub role: ToolRole,
+}
+
+/// A flagged exfiltration risk: an egress sink reached while the session context
+/// already holds the lethal trifecta. The embedded [`IfcVerdict`] is the proven
+/// gate's output — `allow == false`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Finding {
+    /// The sink tool whose call triggered the check.
+    pub sink_tool: String,
+    /// Whether the sink destination is publicly visible.
+    pub public_sink: bool,
+    /// The model-level IFC verdict (carries `reason` + `declared_inputs`).
+    pub verdict: IfcVerdict,
+}
+
+/// Accumulates session taint and emits findings. Cheap to construct; one per
+/// agent session.
+#[derive(Debug, Default)]
+pub struct SessionMonitor {
+    classifier: Classifier,
+    seen: Vec<DeclaredInput>,
+    events: Vec<ToolEvent>,
+    findings: Vec<Finding>,
+}
+
+impl SessionMonitor {
+    /// New monitor with the given tool classifier.
+    pub fn new(classifier: Classifier) -> Self {
+        Self {
+            classifier,
+            ..Default::default()
+        }
+    }
+
+    /// Observe an outbound tool **call**. Returns a [`Finding`] iff the tool is an
+    /// egress sink AND the proven trifecta gate denies the egress given the taint
+    /// accumulated so far.
+    pub fn observe_call(&mut self, tool: &str) -> Option<Finding> {
+        let role = self.classifier.classify(tool);
+        self.events.push(ToolEvent {
+            tool: tool.to_string(),
+            role,
+        });
+        if let ToolRole::Sink { public } = role {
+            let decl = FlowDeclaration::new(self.seen.clone());
+            let decl = if public { decl.public_sink() } else { decl };
+            let verdict = decl.decide();
+            if !verdict.allow {
+                let finding = Finding {
+                    sink_tool: tool.to_string(),
+                    public_sink: public,
+                    verdict,
+                };
+                self.findings.push(finding.clone());
+                return Some(finding);
+            }
+        }
+        None
+    }
+
+    /// Observe a tool **result**. A [`ToolRole::Source`] adds its data class to the
+    /// session taint (deduped).
+    pub fn observe_result(&mut self, tool: &str) {
+        if let ToolRole::Source { input } = self.classifier.classify(tool) {
+            if !self.seen.contains(&input) {
+                self.seen.push(input);
+            }
+        }
+    }
+
+    /// Convenience for offline replay: a full call+result interaction in order.
+    pub fn observe_invocation(&mut self, tool: &str) -> Option<Finding> {
+        let f = self.observe_call(tool);
+        self.observe_result(tool);
+        f
+    }
+
+    /// Every observed tool event, in order.
+    pub fn events(&self) -> &[ToolEvent] {
+        &self.events
+    }
+
+    /// All findings (egress points where exfiltration is possible).
+    pub fn findings(&self) -> &[Finding] {
+        &self.findings
+    }
+
+    /// The accumulated taint set (data classes the agent has been exposed to).
+    pub fn seen_inputs(&self) -> &[DeclaredInput] {
+        &self.seen
+    }
+
+    /// `true` iff the agent reached at least one egress sink while holding the
+    /// lethal trifecta.
+    pub fn exfiltration_possible(&self) -> bool {
+        !self.findings.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::classify::Classifier;
+
+    #[test]
+    fn benign_session_is_clean() {
+        // Reads only public web, sends nothing externally → no trifecta.
+        let mut m = SessionMonitor::new(Classifier::default());
+        assert!(m.observe_invocation("web_search").is_none());
+        assert!(m.observe_invocation("calculator").is_none());
+        assert!(!m.exfiltration_possible());
+    }
+
+    #[test]
+    fn exfil_session_is_flagged() {
+        // Read a secret + ingest untrusted web content, then send an email out.
+        let mut m = SessionMonitor::new(Classifier::default());
+        assert!(m.observe_invocation("read_secret").is_none()); // private data in
+        assert!(m.observe_invocation("fetch_url").is_none()); // untrusted content in
+        let finding = m.observe_invocation("send_email"); // egress!
+        assert!(finding.is_some(), "trifecta egress must be flagged");
+        let f = finding.unwrap();
+        assert!(!f.verdict.allow);
+        assert_eq!(f.sink_tool, "send_email");
+        assert!(m.exfiltration_possible());
+    }
+
+    #[test]
+    fn egress_before_exposure_is_safe() {
+        // Sending out BEFORE any private/untrusted data is in context is fine.
+        let mut m = SessionMonitor::new(Classifier::default());
+        assert!(m.observe_invocation("send_email").is_none());
+        assert!(!m.exfiltration_possible());
+    }
+}


### PR DESCRIPTION
## What

The **free OSS wedge** for the demand-first monetization pick (AI agent / MCP security): a drop-in MCP proxy that shows what an AI agent *can* exfiltrate. It taint-tracks a session's dataflow and flags every moment the agent holds the **lethal trifecta** — private data + exposure to untrusted content + an outbound channel — where a prompt-injection can leak the private data out. Zero agent changes.

Crucially, detection is the **proven `nucleus-ifc` model-level gate** (`FlowDeclaration::decide`), not heuristics — this crate only adapts MCP tool traffic into that gate.

## The artifact (live output)

```
$ mcp-guard analyze examples/exfil_session.json
== Trifecta Gate — MCP session report ==

Tools observed:        3
Data classes in scope: secret, web_content
Egress points flagged: 1

  /!\  EXFILTRATION POSSIBLE
       This agent reached an external sink while holding the lethal
       trifecta (private data + untrusted content + outbound channel).
    - via `send_email` (counterparty) over [web_content + secret]
      reason: AdversarialAncestry { tainted_node: 3 }
```
(exits non-zero → drop into CI as an agent-safety gate)

## Shape
- `classify.rs` — MCP tool → IFC role (Source/Sink/Neutral); conservative defaults (unknown output = untrusted), fully overridable via JSON config.
- `session.rs` — `SessionMonitor`: taint on Source results, trifecta `decide()` on Sink calls → `Finding`.
- `report.rs` — the human artifact + JSON; `analyze_session()` offline replay.
- `proxy.rs` — drop-in stdio MCP passthrough (byte-verbatim JSON-RPC), observe-only.
- bin `mcp-guard`: `proxy -- <server>` (live) / `analyze <session.json>` (offline).

8/8 tests, clippy + fmt clean.

## Tiers (the product)
- **Free (this crate):** observe + report → manufactures the "my agent CAN exfiltrate" moment.
- **Enforcement (paid, follow-up):** block on a denied verdict in the proxy + signed, recomputable audit receipts mapped to SOC2 / OWASP LLM Top 10.

## Honest scope
Model-level and **coverage-limited** (a channel used outside MCP is unseen). It shows exfiltration is *possible*; it does not claim to prove it impossible. Stated plainly in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)