### PR TITLE
chore(deps): bump anyhow 1.0.102 → 1.0.103 (RUSTSEC-2026-0190)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,9 +251,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "approx"


### PR DESCRIPTION
## Why

`RUSTSEC-2026-0190` — *"Unsoundness in `Error::downcast_mut()`"* — was newly published against **anyhow 1.0.102**, so `cargo deny check advisories` + `cargo audit` now fail **repo-wide**.

Because the **merge queue runs `deny`/`audit` as required checks on its merge branch**, this single advisory wedged the *entire* queue — nothing was draining (#1912, #1914–1918 sat enqueued) and every fresh PR (#1920) went `BLOCKED`.

## Fix

`anyhow 1.0.103` is the patched release. Bumping resolves the advisory in **both** tools — no `deny.toml` / `audit.toml` ignore-list entry needed (cleaner than suppressing). Patch-level, semver-compatible, lock-only change.

Merging this first should unblock the queue for the rest of the open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)