### PR TITLE
chore(dependabot): hold wasmtime at major 45 (MSRV floor is Kani's 1.93)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,17 @@ updates:
           - "*"
         exclude-patterns:
           - "security-framework*"
+    ignore:
+      # wasmtime 46+ requires rustc 1.94.0, but our workspace MSRV floor is
+      # pinned to Kani's toolchain (`cargo kani` has no --ignore-rust-version).
+      # The latest Kani (0.67.0, nightly-2025-11-21) and even Kani `main`
+      # (nightly-2025-12-03) are still ~rustc 1.93, so we cannot raise the
+      # floor to 1.94 without breaking verification. Hold wasmtime at major 45
+      # (the last 1.93-compatible line) until a Kani release supports 1.94+.
+      # This recurred via #1919 and #1922; remove this entry once Kani ships a
+      # >=1.94 toolchain and the workspace `rust-version` is bumped to match.
+      - dependency-name: "wasmtime"
+        update-types: ["version-update:semver-major"]
     commit-message:
       prefix: "deps(rust)"
 


### PR DESCRIPTION
## Why

The rust dependabot group has been **BLOCKED on `MSRV floor`** twice now (#1919, then #1922) by the same crate: **wasmtime 46+ requires `rust-version = 1.94.0`**.

But our workspace `rust-version` (**1.93**) is not a free choice — it's pinned to **Kani's toolchain**, because `cargo kani` has no `--ignore-rust-version` escape. And:
- latest Kani release **0.67.0** → `nightly-2025-11-21` (≈ rustc 1.93)
- even Kani **`main`** → `nightly-2025-12-03` (still ≈ rustc 1.93)

So **no Kani build supports 1.94** yet — raising the floor would break verification. The wasmtime major bump simply can't be taken until Kani catches up.

## Fix

Ignore `wasmtime` **semver-major** updates so the rest of the rust group flows normally (wasmtime stays at the 1.93-compatible `45` line; cranelift/wasmparser ride along transitively). Clearly commented with the exact removal condition: drop the ignore + bump `rust-version` once a Kani release ships a ≥1.94 toolchain.

Once this lands, dependabot will re-create the rust group PR (superseding #1922) without the wasmtime bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)