### PR TITLE
fix(portcullis): EnforcedIsolation is Serialize-only (audit #9)

### DIFF
--- a/crates/portcullis/src/enforcement.rs
+++ b/crates/portcullis/src/enforcement.rs
@@ -105,8 +105,15 @@ impl BackendCapability {
 /// The outcome of mapping a requested posture onto a backend: what was asked
 /// for, and what will actually be enforced. By construction `enforced` is
 /// at-least-as-strong as `requested` on **every** dimension.
+///
+/// **Construct only via [`require_isolation`]** — that is the sole path that
+/// guarantees the `enforced ≥ requested` invariant. The type is intentionally
+/// `Serialize`-only (no `Deserialize`): a deserialized value would bypass that
+/// constructor and could assert `enforced` *weaker* than `requested`, defeating
+/// the whole point. If wire round-trip is ever needed, add an owned wire type
+/// with a validating `#[serde(try_from)]` rather than re-deriving `Deserialize`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct EnforcedIsolation {
     /// What the decision asked for.
     pub requested: IsolationLattice,


### PR DESCRIPTION
Skeptical-audit finding #9. `EnforcedIsolation`'s `enforced ≥ requested` invariant is enforced only inside `require_isolation`, but the type derived `Deserialize` — so a deserialized value could bypass the constructor and assert `enforced` **weaker** than `requested` (and misreport `was_strengthened`/`strengthenings`).

Fix: drop the `Deserialize` derive (keep `Serialize` for audit/logging). Nothing deserializes it today, and its `backend: &'static str` made faithful untrusted-wire round-trip impractical regardless. Documented that a validating owned wire type + `#[serde(try_from)]` is the path if round-trip is ever needed.

18 enforcement tests pass; clippy `-D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VBCzHpVFVBqSzRAaMUm95v
