### PR TITLE
fix(ifc-kernel): repair the red Kani build (ProvenanceSet::from_bits in harness)

### DIFF
--- a/crates/nucleus-ifc-kernel/src/flow.rs
+++ b/crates/nucleus-ifc-kernel/src/flow.rs
@@ -827,7 +827,7 @@ mod kani_proofs {
         IFCLabel {
             confidentiality: any_conf(),
             integrity: any_integ(),
-            provenance: ProvenanceSet(kani::any::<u8>() & 0x3F),
+            provenance: ProvenanceSet::from_bits(kani::any::<u8>() & 0x3F),
             freshness: Freshness {
                 observed_at: kani::any(),
                 ttl_secs: kani::any(),


### PR DESCRIPTION
**`main` is red on the `Kani` check** — this fixes it.

The `#[cfg(kani)]` symbolic-`IFCLabel` generator in `flow.rs:830` constructs `ProvenanceSet(bits)` directly, but `ProvenanceSet(u8)` has a **private field** (defined in `ifc_lattice.rs`), so the tuple constructor isn't visible from `flow.rs`:

```
error[E0423]: cannot initialize a tuple struct which contains private fields
  --> crates/nucleus-ifc-kernel/src/flow.rs:830:25
```

That fails the whole `nucleus-ifc-kernel` compile **under `cfg(kani)`**, taking all 5 fast-tier harnesses (`proof_capability_distributive`, `proof_exposureset_*`, …) down with it. A regression from the MVK M3 carve-out that split the IFC modules out of `portcullis-core` (the field became cross-module-private).

**Fix:** use the public `ProvenanceSet::from_bits`, which is identical — `from_bits(b) = Self(b & 0x3F)`, and the harness already masks with `& 0x3F`, so the symbolic 6-bit provenance set is unchanged. Normal builds are unaffected; only the `cfg(kani)` path is touched. CI's Kani job verifies the harnesses build + pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VBCzHpVFVBqSzRAaMUm95v
