### PR TITLE
release(policy-kernel): bump to 0.2.0 for the crates.io publish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7038,7 +7038,7 @@ dependencies = [
 
 [[package]]
 name = "nucleus-policy-kernel"
-version = "1.0.0"
+version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/crates/nucleus-policy-kernel/Cargo.toml
+++ b/crates/nucleus-policy-kernel/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "nucleus-policy-kernel"
 license.workspace = true
-version.workspace = true
+# Explicit version (not the workspace 1.0.0): this crate publishes to crates.io
+# on its own cadence. Bumped 0.1.0 → 0.2.0 for the relocation-into-nucleus
+# release (edition 2024, moved from spiffy).
+version = "0.2.0"
 # Latest edition (compatible with the workspace MSRV 1.93 — edition 2024 needs
 # only rustc ≥ 1.85). Set per-crate rather than via the (still-2021) workspace
 # default; a workspace-wide 2021→2024 bump is a separate follow-up.


### PR DESCRIPTION
Prep for publishing the relocated PCA core. Bumps `nucleus-policy-kernel` to **0.2.0** (explicit, was inheriting the workspace 1.0.0). It's a clean leaf crate (serde-only) and `cargo publish --dry-run` packages + verifies + reaches upload cleanly.

**Publish reality (surfaced by dry-runs):**
- `nucleus-policy-kernel@0.2.0` — ✅ publishable. But it's a *first* publish, and crates.io Trusted Publishing (the keyless `crates-publish.yml` path) **cannot do a new crate's first publish** — so it needs a one-time **manual `cargo publish` by a maintainer with a crates.io token**. After that, adding it to `crates-publish.yml` makes future releases keyless.
- `nucleus-policy-cert` — ❌ blocked: optional **`dlc-core` git dep** (crates.io forbids git deps) + needs a version on the kernel path-dep.
- `nucleus-pca` — ❌ blocked: path deps to **`portcullis` / `nucleus-ifc`**, which aren't on crates.io.

Publishing the full PCA family is therefore a **separate dep-tree release campaign** (first-publish portcullis-core → portcullis → nucleus-ifc-kernel → nucleus-ifc → policy-kernel → policy-cert → pca, plus resolving the dlc-core git dep), all requiring the maintainer token for first-publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VBCzHpVFVBqSzRAaMUm95v
