### PR TITLE
fix(pca): audit fixes — fail-closed timestamp, a real gate helper (is_positive), publish-readiness

### DIFF
--- a/crates/nucleus-pca/Cargo.toml
+++ b/crates/nucleus-pca/Cargo.toml
@@ -15,17 +15,17 @@ workspace = true
 [dependencies]
 # The recompute-verifiable certificate envelope + verify() (crypto on) and the
 # portcullis delegation projection (portcullis bridge on).
-nucleus-policy-cert = { path = "../nucleus-policy-cert", features = ["crypto", "portcullis"] }
+nucleus-policy-cert = { path = "../nucleus-policy-cert", version = "1.0.0", features = ["crypto", "portcullis"] }
 # The reference monitor types (Policy/Request/Decision) re-exported in the prelude.
-nucleus-policy-kernel = { path = "../nucleus-policy-kernel" }
+nucleus-policy-kernel = { path = "../nucleus-policy-kernel", version = "0.2.0" }
 # Capability delegation (LatticeCertificate/verify_certificate) + the isolation
 # lattice + the enforcement gate. default-features off drops ring/cedar.
 # `crypto` (ring) is needed for verify_certificate (Ed25519 chain check). This is
 # the NATIVE facade crate, so ring is fine; the wasm façade lives elsewhere and
 # uses the crypto-free recompute path.
-portcullis = { path = "../portcullis", default-features = false, features = ["serde", "crypto"] }
+portcullis = { path = "../portcullis", version = "1.0.0", default-features = false, features = ["serde", "crypto"] }
 # Model-level information-flow decision (FlowDeclaration → IfcVerdict).
-nucleus-ifc = { path = "../nucleus-ifc", features = ["decision"] }
+nucleus-ifc = { path = "../nucleus-ifc", version = "1.0.0", features = ["decision"] }
 chrono = { workspace = true }
 thiserror = { workspace = true }
 

--- a/crates/nucleus-pca/src/lib.rs
+++ b/crates/nucleus-pca/src/lib.rs
@@ -84,6 +84,44 @@ pub enum Verified {
     Isolation(EnforcedIsolation),
 }
 
+impl Verified {
+    /// **The gate.** The authorization signal where it is well-defined:
+    /// `Some(true)` for a positive verdict, `Some(false)` for a negative one,
+    /// `None` where the result is not a yes/no authorization on its own.
+    ///
+    /// Gate on THIS — never on `verify(..).is_ok()`. `Ok` only means "the check
+    /// ran and the subject verified", **not** "authorized": a validly-verified
+    /// `Deny` decision, and a fail-closed `Flow`, are `Ok(..)` with
+    /// `is_positive() == Some(false)`. (The arms are deliberately asymmetric:
+    /// PolicyCert/Flow carry a negative verdict *in the payload* as `Ok`, while
+    /// Delegation/Isolation surface a hard failure as `Err` — so `is_ok()` is
+    /// the wrong gate.)
+    ///
+    /// - `Decision`   → `Some(allow)`.
+    /// - `Governance` → `Some(monotone)` (the amendment is non-weakening).
+    /// - `Flow`       → `Some(allow)` (the model-level IFC verdict).
+    /// - `Delegation` → `None`: a verified chain proves the leaf holds an
+    ///   *attenuated* capability, but the effective permissions + sink scope are
+    ///   intentionally not projected into the outcome (see
+    ///   [`AuthorityOutcome::Delegation`] — `PermissionLattice` has no canonical
+    ///   digest here). Consult the raw `LatticeCertificate` to gate a specific
+    ///   action; do not treat a verified delegation as unscoped authorization.
+    /// - `Isolation`  → `None`: an enforceable posture, not a yes/no authorization.
+    pub fn is_positive(&self) -> Option<bool> {
+        match self {
+            Verified::Authority(a) => match &a.outcome {
+                AuthorityOutcome::Decision { decision, .. } => {
+                    Some(*decision == nucleus_policy_kernel::Decision::Allow)
+                }
+                AuthorityOutcome::Governance { monotone, .. } => Some(*monotone),
+                AuthorityOutcome::Delegation { .. } => None,
+            },
+            Verified::Flow(v) => Some(v.allow),
+            Verified::Isolation(_) => None,
+        }
+    }
+}
+
 /// Why a [`verify`] call failed. Wraps each subject's native error.
 #[derive(Debug, thiserror::Error)]
 pub enum VerifyError {
@@ -114,8 +152,13 @@ pub fn verify(token: AuthorizationToken, ctx: &VerifyCtx) -> Result<Verified, Ve
             root_pubkey,
             max_depth,
         } => {
+            // Fail CLOSED on an out-of-range timestamp: `now_unix as i64` would
+            // WRAP for now_unix > i64::MAX into a negative (1969) time that
+            // chrono accepts, silently disabling the chain's expiry checks so an
+            // expired delegation would verify. `try_from` rejects it instead.
+            let secs = i64::try_from(ctx.now_unix).map_err(|_| VerifyError::Time(ctx.now_unix))?;
             let now = Utc
-                .timestamp_opt(ctx.now_unix as i64, 0)
+                .timestamp_opt(secs, 0)
                 .single()
                 .ok_or(VerifyError::Time(ctx.now_unix))?;
             let verified = verify_certificate(&cert, &root_pubkey, now, max_depth)
@@ -233,5 +276,31 @@ mod tests {
             }
             _ => panic!("expected an Isolation result"),
         }
+    }
+
+    #[test]
+    fn a_valid_deny_verifies_ok_but_is_not_positive() {
+        // The audit trap: a Deny cert validly VERIFIES (Ok), but must NOT read as
+        // authorized. `is_positive()` is the correct gate — `is_ok()` is not.
+        let policy = Policy { rules: vec![] }; // default-deny
+        let signer = Ed25519Signer::from_seed(&[9u8; 32]);
+        let cert = issue_decision_cert(
+            &policy,
+            req(),
+            Binding::new([0u8; 32], u64::MAX, None),
+            ResidualTrust::recompute(),
+            &signer,
+        );
+        let ctx = VerifyCtx {
+            now_unix: 0,
+            expected_context_hash: None,
+        };
+        let out = verify(AuthorizationToken::PolicyCert(Box::new(cert)), &ctx)
+            .expect("a validly-signed Deny cert still VERIFIES (Ok)");
+        assert_eq!(
+            out.is_positive(),
+            Some(false),
+            "a Deny must gate to Some(false)"
+        );
     }
 }

--- a/crates/nucleus-policy-cert/Cargo.toml
+++ b/crates/nucleus-policy-cert/Cargo.toml
@@ -42,7 +42,7 @@ portcullis = ["dep:portcullis"]
 # The verbatim reference monitor. `decide` / `governance_monotone` are
 # re-run at verification time — the recompute that makes the cert checkable.
 # It is itself a leaf (serde-only), which keeps THIS crate wasm/zkVM-friendly.
-nucleus-policy-kernel = { path = "../nucleus-policy-kernel" }
+nucleus-policy-kernel = { path = "../nucleus-policy-kernel", version = "0.2.0" }
 # SHA-256 for the policy commitment. Pinned to the 0.10 line (NOT the
 # workspace's 0.11 pre-release) for the SAME reason `nucleus-snark-codec`
 # documents: this crate is meant to compile into the SP1 zkVM guest (R2), and
@@ -66,7 +66,7 @@ dlc-core = { git = "https://github.com/coproduct-opensource/delegation_calc.git"
 # always-compiled data types — VerifiedPermissions / PermissionLattice). Now an
 # in-repo PATH dep (this crate moved into nucleus alongside portcullis) — no more
 # cross-repo git pin for the bridge.
-portcullis = { path = "../portcullis", default-features = false, features = ["serde"], optional = true }
+portcullis = { path = "../portcullis", version = "1.0.0", default-features = false, features = ["serde"], optional = true }
 
 [dev-dependencies]
 ed25519-dalek = { workspace = true }


### PR DESCRIPTION
Fixes from the skeptical audit of the PCA-SDK unification.

- **#1 (HIGH, fail-open):** the Delegation arm cast `now_unix` (`u64`) to `i64` with `as`, which **wraps** for `now_unix > i64::MAX` into a negative 1969 timestamp chrono accepts — silently disabling the chain's expiry checks so **an expired delegation would verify**. Now `i64::try_from`, failing closed to `VerifyError::Time`.
- **#3/#4 (soundness trap):** callers could gate on `verify(..).is_ok()`, but **`Ok` ≠ authorized** — a validly-verified `Deny` decision and a fail-closed `Flow` are both `Ok`. Added **`Verified::is_positive() -> Option<bool>`** as *the* gate: `Some(allow)` for Decision/Flow, `Some(monotone)` for Governance, **`None` for Delegation** (effective scope is intentionally not projected — consult the raw `LatticeCertificate`) and Isolation. Documented the deliberate Ok/Err asymmetry. Test: a valid **Deny verifies `Ok` but `is_positive() == Some(false)`**.
- **#10:** `nucleus-pca` + `nucleus-policy-cert` path deps now carry `version=` (structurally publishable); the full crates.io publish still awaits the deferred dep-tree campaign.

Tests: nucleus-pca 3 (+1 gate) · nucleus-policy-cert 21 (all features); clippy `-D warnings` + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VBCzHpVFVBqSzRAaMUm95v
