### PR TITLE
chore(deps): bump arc-swap 1.9.1 → 1.9.2 (persona certified dispatch)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,9 +281,9 @@ checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
 name = "arc-swap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
 dependencies = [
  "rustversion",
 ]


### PR DESCRIPTION
Patch-level lockfile bump: `cargo update -p arc-swap` (1.9.1 → 1.9.2, version + checksum only).

## Certified dispatch (first real run of the persona orchestrator)

This change was produced by an autonomous generator under a signed, attenuated delegation and is fully re-verifiable from one public key:

- **persona root (the only trusted key):** `b9273c0426860903fbc9245a043d4bd49eec071a1e692e5b7dbf33370ce0e774`
- **run:** `run-6a45b533-34778`, envelope = `{Cargo.lock}` on `persona/dep-bump-arc-swap`, commits `62398cb → 58067ff`
- **delegation:** `portcullis::LatticeCertificate` (root-minted, `delegate_with_scope`, sink scope = the envelope)
- **receipt:** `nucleus-policy-cert` recompute certificate per touched file, bound to the lineage hash; kernel re-decides **Allow**
- **scope audit:** observed diff ⊆ envelope ∧ every file attested — clean
- **judge (D, operator persona):** Accept — correctness 1.0 / altitude 1.0 / honesty 1.0
- **`persona audit`:** GREEN — every certificate, receipt, lineage binding, and scope report recomputes from the root pubkey alone

Merge stays human (v1 policy): this PR is the artifact of the loop, not an auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)