### PR TITLE
chore(deps): land safe c2pa 0.89; hold rmcp/sha2 majors (salvage of broken #1940)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,17 @@ updates:
       # >=1.94 toolchain and the workspace `rust-version` is bumped to match.
       - dependency-name: "wasmtime"
         update-types: ["version-update:semver-major"]
+      # rmcp 2.0 is a breaking API change (removed the `Content` type used by
+      # nucleus-tool-proxy / ctf-mcp / ctf-server); the migration is deliberate,
+      # not a dependabot auto-bump. Hold at major 1 until migrated (tracked
+      # separately). Recurred via #1940.
+      - dependency-name: "rmcp"
+        update-types: ["version-update:semver-major"]
+      # sha2 is DELIBERATELY pinned to the 0.10 line in nucleus-policy-cert: the
+      # cert layer compiles into the SP1 zkVM guest, whose sha2 acceleration
+      # patch targets 0.10.8 — 0.11 panics the guest. Never auto-bump the major.
+      - dependency-name: "sha2"
+        update-types: ["version-update:semver-major"]
     commit-message:
       prefix: "deps(rust)"
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1714,9 +1714,9 @@ dependencies = [
 
 [[package]]
 name = "c2pa"
-version = "0.88.0"
+version = "0.89.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d79e0cbac49fecc86ba739878c1b0e16a1c77b2cdee9157de724fb534dedf9d"
+checksum = "51fa794035513d5e89b14f37ddee22d0ba545962bd0e7a3caaf68fef70674317"
 dependencies = [
  "asn1-rs",
  "async-generic",
@@ -1784,7 +1784,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sha1 0.10.6",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "spki 0.7.3",
  "static-iref",
  "tempfile",
@@ -2953,7 +2953,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -10489,7 +10489,6 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
- "sha2-asm",
 ]
 
 [[package]]
@@ -10501,15 +10500,6 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "digest 0.11.3",
-]
-
-[[package]]
-name = "sha2-asm"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b845214d6175804686b2bd482bcffe96651bb2d1200742b712003504a2dac1ab"
-dependencies = [
- "cc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,7 @@ serde_yaml = "0.9"
 toml = "1.1"
 
 # Content provenance (EU AI Act)
-c2pa = "0.88"
+c2pa = "0.89"
 
 # Error handling
 thiserror = "2.0"

--- a/crates/nucleus-envelope/Cargo.toml
+++ b/crates/nucleus-envelope/Cargo.toml
@@ -28,7 +28,7 @@ hex = { workspace = true }
 # the lean dep tree is preserved for callers who don't need EU AI Act
 # Article 50 interop. `rust_native_crypto` swaps OpenSSL for pure-Rust
 # signing to keep our supply chain consistent with the rest of nucleus.
-c2pa = { version = "0.88", default-features = false, features = ["rust_native_crypto"], optional = true }
+c2pa = { version = "0.89", default-features = false, features = ["rust_native_crypto"], optional = true }
 
 [features]
 default = []


### PR DESCRIPTION
The dependabot **rust-dependencies group (#1940)** bundled three bumps — two breaking. Splitting so the safe one lands:

| bump | verdict |
|---|---|
| **rmcp 1.7 → 2.0** | ❌ **breaks** — removed the `Content` type used by `nucleus-tool-proxy`/`ctf-mcp`/`ctf-server` (`E0433`). Deliberate API migration, tracked separately. |
| **sha2 0.10 → 0.11** | ❌ **held** — compiles, but `nucleus-policy-cert` pins 0.10 on purpose (compiles into the SP1 zkVM guest; 0.11 panics it). |
| **c2pa 0.88 → 0.89** | ✅ **safe** — compiles clean, landed here. |

Also adds **dependabot ignores** for `rmcp` + `sha2` majors so the group stops re-bundling the breakers (like the existing wasmtime hold). **Supersedes #1940.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VBCzHpVFVBqSzRAaMUm95v
