### PR TITLE
fix(release): checkout before asset collection + git identity for floating tag (persona certified dispatch)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,6 +190,7 @@ jobs:
       id-token: write
       attestations: write
     steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: dist
@@ -202,13 +203,14 @@ jobs:
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: release/*
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
       - name: Publish GitHub release
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v2
         with:
           files: release/*
       - name: Update floating v1 tag
         run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           MAJOR="${GITHUB_REF_NAME%%.*}"
           git tag -fa "${MAJOR}" -m "Release ${MAJOR}"
           git push origin "${MAJOR}" --force


### PR DESCRIPTION
Two stacked bugs made every release since v1.0.9 ship empty. (1) In `Create Release`, `actions/checkout` ran AFTER `Collect assets` — checkout wipes the workspace, so `action-gh-release` published releases with zero assets (v1.1.0, v2.0.2). Checkout now runs first. (2) `Update floating v1 tag` ran `git tag -fa` with no committer identity → `fatal: empty ident name` (the visible failure in v1.1.0 and v2.0.2 runs). Identity is now set in-step.

Certified dispatch run-6a461b94-96863: envelope `.github/workflows/`, scope audit clean, verdict Accept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)