### PR TITLE
De-vendor nucleus-econ-kernels/src/vcg.rs

### DIFF
--- a/crates/nucleus-econ-kernels/src/vcg.rs
+++ b/crates/nucleus-econ-kernels/src/vcg.rs
@@ -116,8 +116,7 @@ pub struct IntegerBid {
 /// a `value_micro_usd` field that the welfare computation summed; that
 /// design admitted a hidden two-utility-function bug (IR could fail
 /// whenever bid ≠ proposal value, which is precisely when separate
-/// proposal values exist). The Week 6 Option A fix from
-/// `/Users/bcrisp/.claude/plans/let-s-web-search-look-modular-rivest.md`
+/// proposal values exist). The Week 6 Option A fix
 /// collapsed welfare to bid effective value, restoring theoretical
 /// honesty under `docs/ECON-PRECISION.md`'s "bid is the canonical
 /// economic primitive" principle.


### PR DESCRIPTION
Certified autonomous dispatch (c5-vendor-neutrality). Verdict Accept, AUDIT GREEN.

**Directive:**
De-vendor crates/nucleus-econ-kernels/src/vcg.rs ONLY. First read the file and locate the vendor-specific name(s). Resolve IN-CRATE (the allowlist file lives at repo root, OUTSIDE this envelope, so do NOT use it): replace the hard-coded vendor string with a neutral term, a crate-local const, or a small neutral trait/adapter — whichever is minimal and reads like the surrounding code. Do not change behavior. Verify: `cargo build -p nucleus-econ-kernels` stays green, run `cargo test -p nucleus-econ-kernels` if tests exist, and re-run the c5 vendor-neutrality check to confirm the finding clears. Touch ONLY files under crates/nucleus-econ-kernels/.