### PR TITLE
De-vendor crates/exposure-playground/ ONLY (single file: src/ui/delegati…

### DIFF
--- a/crates/exposure-playground/src/ui/delegation_forest.rs
+++ b/crates/exposure-playground/src/ui/delegation_forest.rs
@@ -179,7 +179,7 @@ fn draw_comparison_sidebar(f: &mut Frame, area: Rect) {
         .borders(Borders::ALL)
         .title(" Model Comparison ");
 
-    // Vendor-neutral comparison (this is in nucleus, no Anthropic references)
+    // Vendor-neutral comparison — generic flat vs hierarchical models, no vendor-specific names.
     let lines = vec![
         Line::from(Span::styled(
             "╔═══════════════════╗",


### PR DESCRIPTION
persona certified dispatch (iter 0).

De-vendor crates/exposure-playground/ ONLY (single file: src/ui/delegation_forest.rs). First read the file and locate the vendor-specific name(s). Resolve by ONE of: (a) rename to a neutral term / extract behind a neutral trait or constant if it's product-facing code or a display string, OR (b) if the reference is load-bearing (an external dependency name, an interop-required identifier, or a factual test fixture that cannot be neutralized), append the path to .vendor-neutrality-allowlist with a one-line rationale. Do NOT touch any other crate. Verify: `cargo build -p exposure-playground` stays green, `cargo test -p exposure-playground` passes, and the c5-vendor-neutrality check no longer flags this crate. Keep the diff minimal and self-contained.
