### PR TITLE
Envelope-scoped CI, increment 1 — add change-detection + gate the heavy…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           if [ "$EVENT_NAME" = "merge_group" ] || [ "$EVENT_NAME" = "push" ]; then
             all=true
           else
-            git fetch origin "$BASE" --depth=1 || true
+            git fetch origin "$BASE" || true
             changed="$(git diff --name-only "origin/$BASE...HEAD")"
             if printf '%s\n' "$changed" | grep -qE '^Cargo\.toml$|^Cargo\.lock$|^\.github/'; then
               all=true
@@ -47,7 +47,7 @@ jobs:
 
           crates=""
           if [ -n "$changed" ]; then
-            crates="$(printf '%s\n' "$changed" | grep -oE '^crates/[^/]+' | sed 's#^crates/##' | sort -u | paste -sd' ' -)"
+            crates="$(printf '%s\n' "$changed" | grep -oE '^crates/[^/]+' | sed 's#^crates/##' | sort -u | paste -sd' ' - || true)"
           fi
 
           echo "all=$all" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,61 @@ permissions:
   contents: read
 
 jobs:
+  changed-crates:
+    name: Detect changed crates
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      all: ${{ steps.detect.outputs.all }}
+      crates: ${{ steps.detect.outputs.crates }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        with:
+          fetch-depth: 0
+      - name: Determine changed crates
+        id: detect
+        # Pass event/base data via env (never interpolate ${{ }} directly into
+        # the run script — zizmor template-injection / code-injection
+        # hardening, matching ck-admit.yml).
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -euo pipefail
+
+          all=false
+          changed=""
+
+          if [ "$EVENT_NAME" = "merge_group" ] || [ "$EVENT_NAME" = "push" ]; then
+            all=true
+          else
+            git fetch origin "$BASE" --depth=1 || true
+            changed="$(git diff --name-only "origin/$BASE...HEAD")"
+            if printf '%s\n' "$changed" | grep -qE '^Cargo\.toml$|^Cargo\.lock$|^\.github/'; then
+              all=true
+            fi
+          fi
+
+          crates=""
+          if [ -n "$changed" ]; then
+            crates="$(printf '%s\n' "$changed" | grep -oE '^crates/[^/]+' | sed 's#^crates/##' | sort -u | paste -sd' ' -)"
+          fi
+
+          echo "all=$all" >> "$GITHUB_OUTPUT"
+          echo "crates=$crates" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "### Changed-crate detection"
+            echo ""
+            echo "- Event: \`$EVENT_NAME\`"
+            echo "- Full run forced: \`$all\`"
+            if [ -n "$crates" ]; then
+              echo "- Changed crates: \`$crates\`"
+            else
+              echo "- Changed crates: (none)"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest
@@ -45,6 +100,8 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    needs: changed-crates
+    if: ${{ needs.changed-crates.outputs.all == 'true' || needs.changed-crates.outputs.crates != '' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
@@ -96,6 +153,8 @@ jobs:
     name: OWASP LLM Security Gauntlet
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    needs: changed-crates
+    if: ${{ needs.changed-crates.outputs.all == 'true' || needs.changed-crates.outputs.crates != '' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
@@ -152,6 +211,8 @@ jobs:
     name: Fuzz
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    needs: changed-crates
+    if: ${{ needs.changed-crates.outputs.all == 'true' || needs.changed-crates.outputs.crates != '' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1


### PR DESCRIPTION
persona certified dispatch (iter 0).

Envelope-scoped CI, increment 1 — add change-detection + gate the heavy whole-workspace jobs to skip on no-crate-change PRs, keeping ALL safety checks always-on. Edit ONLY .github/workflows/ci.yml.

Add a `changed-crates` job at the top of ci.yml (before the heavy jobs), that the heavy jobs then depend on:
- runs-on ubuntu-latest; `actions/checkout` with `fetch-depth: 0`.
- Determine the changed files. For `pull_request`: pass the base ref through an ENV var (e.g. `env: BASE: ${{ github.event.pull_request.base.ref }}`) and run `git fetch origin "$BASE" --depth=1 || true; git diff --name-only "origin/$BASE...HEAD"` — inject BASE via env, never interpolate `${{ }}` directly into the run script (shell-injection hardening, exactly as ck-admit.yml already does). For `merge_group` and `push`, treat as force-full.
- Set two `outputs`:
  - `all`: "true" when the event is `merge_group` or `push`, OR any changed path is `Cargo.toml`, `Cargo.lock`, or under `.github/` (a workspace-wide or CI change → must run everything); else "false".
  - `crates`: the set of changed crate names, derived by mapping each changed path matching `crates/<name>/...` to `<name>` (space-separated is fine).
- Write a GitHub Step Summary (`$GITHUB_STEP_SUMMARY`) listing the derived crates and whether a full run was forced — this is the auditable record of what was scoped.

Then gate ONLY the heavy WHOLE-WORKSPACE jobs so they SKIP when a PR changed no crate at all (docs/markdown/config-only PRs), and otherwise run exactly as today. Apply to the expensive jobs `test`, `owasp-gauntlet`, and `fuzz` (leave `fmt`, `clippy`, and any already crate-scoped `-p` jobs untouched):
- add `needs: changed-crates` to each, and
- `if: ${{ needs.changed-crates.outputs.all == 'true' || needs.changed-crates.outputs.crates != '' }}`
This runs the job whenever any crate changed or a full run is forced, and skips it only on no-crate-change PRs. A skipped required job reports "skipped", which GitHub counts as success for branch protection, so required status checks stay satisfiable — do NOT add any `*-noop.yml` twin and do NOT change branch-protection.

Constraints: touch ONLY .github/workflows/ci.yml. Do NOT gate or modify any safety/supply-chain workflow (zizmor, scorecard, deny, audit, scan, codeql, manifest-guards, line-ratchet, trust-registry) — those stay unconditional. On `merge_group` everything still runs (all==true). Preserve every existing job's steps; only add the `changed-crates` job + the `needs:`/`if:` guards on the three named jobs.

Verify before finishing: `actionlint .github/workflows/ci.yml` if available, else `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` must parse. This is increment 1; scoping coverage-matrix.yml and feature-matrix.yml, and per-crate test partitioning, are deliberate separate follow-ups — do NOT attempt them here.
