### PR TITLE
Fix the failing `musl type-check` CI job on nucleus

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,7 @@ jobs:
     # build scripts (e.g. ring) need to cross-compile.
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
-      - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
           targets: x86_64-unknown-linux-musl
           cache: true


### PR DESCRIPTION
persona certified dispatch (iter 0).

Fix the failing `musl type-check` CI job on nucleus. Edit ONLY .github/workflows/ci.yml, and ONLY the musl-check job's toolchain setup.

FAILURE CONTEXT (the live error — you can re-fetch it yourself with `gh run view 28730025691 --repo coproduct-opensource/nucleus --log-failed`, or the latest run via `gh pr checks` on any open PR): the job `musl type-check (nucleus-node, nucleus-tool-proxy)` runs `cargo check -p nucleus-node -p nucleus-tool-proxy --target x86_64-unknown-linux-musl` and fails with rustc E0463 — "can't find crate for `core` / the `x86_64-unknown-linux-musl` target may not be installed". Root cause: the job's Rust toolchain setup does NOT install the musl target. Other jobs in this same file install their targets via `targets:` on the `actions-rust-lang/setup-rust-toolchain` step (e.g. `targets: wasm32-unknown-unknown`), but the musl-check job does not add `x86_64-unknown-linux-musl`, so on a toolchain cache hit the target is missing and the cross-check cannot find `core`.

FIX: In the `musl type-check` job specifically (the job whose step runs `cargo check ... --target x86_64-unknown-linux-musl`), add the musl target to its `actions-rust-lang/setup-rust-toolchain` step:
    with:
      targets: x86_64-unknown-linux-musl
(merge into the existing `with:` if present). If that job does not use setup-rust-toolchain's `targets:` mechanism, instead add an explicit step `- run: rustup target add x86_64-unknown-linux-musl` immediately BEFORE the `cargo check ... --target x86_64-unknown-linux-musl` step.

Do NOT modify any other job (not the wasm jobs, not test/owasp/fuzz, not the changed-crates job, not any safety workflow). Do NOT touch any file other than .github/workflows/ci.yml. Verify the YAML parses — run `actionlint .github/workflows/ci.yml` if available, else confirm it loads as YAML. The change should be a 1-3 line addition to exactly one job.
