### PR TITLE
De-vendor crates/nucleus-mcp/ — the only offending file is crates/nucleu…

### DIFF
--- a/crates/nucleus-mcp/Cargo.toml
+++ b/crates/nucleus-mcp/Cargo.toml
@@ -8,7 +8,7 @@ description = "MCP server that bridges an MCP client (any AI-agent runtime) to n
 repository = "https://github.com/coproduct-opensource/nucleus"
 documentation = "https://docs.rs/nucleus-mcp"
 readme = "README.md"
-keywords = ["mcp", "claude", "tools", "security", "sandbox"]
+keywords = ["mcp", "ai-agent", "tools", "security", "sandbox"]
 categories = ["command-line-utilities", "development-tools"]
 
 [[bin]]


### PR DESCRIPTION
persona certified dispatch (iter 0).

De-vendor crates/nucleus-mcp/ — the only offending file is crates/nucleus-mcp/Cargo.toml. Grep it for the vendor name (Claude/Anthropic/etc.). This is a manifest, not runtime code: the hit is almost certainly a `description`/`keywords`/comment string or a vendor-named dependency. If it is a description/keyword/comment, rewrite to neutral language per CLAUDE.md ('LLM'/'AI agent', never a vendor name). If it is a real dependency whose name legitimately carries the vendor token and cannot be renamed, INSTEAD add `crates/nucleus-mcp/Cargo.toml` to the repo-root `.vendor-neutrality-allowlist` with a one-line rationale — the proposal explicitly permits the allowlist path, so touching that single root file is in scope. Do NOT touch any auth/capability/access-control logic. Verify with `cargo check -p nucleus-mcp` (must stay green). Touch ONLY crates/nucleus-mcp/Cargo.toml (and, if you take the allowlist route, `.vendor-neutrality-allowlist`).
