### PR TITLE
De-vendor crates/ctf-mcp/ — the single offending file is crates/ctf-mcp/…

### DIFF
--- a/crates/ctf-mcp/src/main.rs
+++ b/crates/ctf-mcp/src/main.rs
@@ -1,8 +1,7 @@
 //! MCP server for The Vault CTF.
 //!
-//! Exposes the CTF engine as MCP tools so any AI agent (ChatGPT, Claude,
-//! Gemini, etc.) can play the security challenge via the Model Context
-//! Protocol.
+//! Exposes the CTF engine as MCP tools so any AI agent can play the
+//! security challenge via the Model Context Protocol.
 //!
 //! Tools:
 //!   - list_levels: Get metadata for all 7 CTF levels
@@ -62,7 +61,7 @@ struct ToolCallParam {
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 struct ChallengeParams {
-    #[schemars(description = "Who is playing (e.g. 'chatgpt-4o', 'claude-opus', 'human')")]
+    #[schemars(description = "Who is playing (e.g. 'agent-a', 'model-x', 'human')")]
     player: String,
     #[schemars(
         description = "Array of attacks, one per level. Each: {\"level\": 5, \"tool_calls\": [...]}"


### PR DESCRIPTION
persona certified dispatch (iter 0).

De-vendor crates/ctf-mcp/ — the single offending file is crates/ctf-mcp/src/main.rs. First `grep -n` it for the vendor name (Claude/Anthropic/OpenAI). Then choose the SMALLEST correct fix: if the mention is product/behavioral code, extract it behind a neutral trait/adapter or replace with a vendor-agnostic token (e.g. LLM_API_TOKEN, 'AI agent'); if it is an inherent CTF-scenario/demo string that must name a real vendor to be meaningful, add `crates/ctf-mcp/src/main.rs` to .vendor-neutrality-allowlist with a one-line rationale. Do NOT touch auth/capability/access-control logic. Touch ONLY files under crates/ctf-mcp/ (plus the repo-root .vendor-neutrality-allowlist if you take the allowlist path). VERIFY: `cargo check -p ctf-mcp` stays green AND re-run the c5 vendor-neutrality scan to confirm crates/ctf-mcp/ reports 0 offenders; report before/after offender count.
