### PR TITLE
Reduce behavioural-consistency gaps in crate nucleus-cli

### DIFF
--- a/crates/nucleus-cli/src/run.rs
+++ b/crates/nucleus-cli/src/run.rs
@@ -780,7 +780,16 @@ fn create_pod_via_node(
 ) -> Result<String> {
     let url = format!("{}/v1/pods", node_url.trim_end_matches('/'));
     let body = serde_yaml::to_string(spec)?;
-    let mut request = ureq::post(&url).header("content-type", "application/yaml");
+    // Bound the request: the top-level `ureq::post` helper uses a default agent
+    // with no timeout, so a hung/unresponsive node would block the CLI forever.
+    // Mirror the 30s global timeout used by node.rs::create_agent().
+    let agent: ureq::Agent = ureq::Agent::config_builder()
+        .timeout_global(Some(Duration::from_secs(30)))
+        .build()
+        .into();
+    let mut request = agent
+        .post(&url)
+        .header("content-type", "application/yaml");
 
     let signed = sign_http_headers(auth_secret.as_bytes(), Some(actor), body.as_bytes());
     for (key, value) in signed.headers {

--- a/crates/nucleus-cli/src/setup.rs
+++ b/crates/nucleus-cli/src/setup.rs
@@ -716,7 +716,16 @@ async fn download_artifacts_linux(artifacts_dir: &std::path::Path) -> Result<()>
 }
 
 async fn download_file(url: &str, path: &PathBuf) -> Result<()> {
-    let response = ureq::get(url)
+    // The top-level `ureq::get` helper uses a default agent with no timeouts,
+    // so an unresponsive host would hang the connect phase forever. Bound the
+    // connect (and idle read) phases while leaving overall duration unbounded —
+    // a global timeout would wrongly abort legitimately large kernel downloads.
+    let agent: ureq::Agent = ureq::Agent::config_builder()
+        .timeout_connect(Some(std::time::Duration::from_secs(30)))
+        .build()
+        .into();
+    let response = agent
+        .get(url)
         .call()
         .map_err(|e| anyhow!("Download failed: {}", e))?;
 


### PR DESCRIPTION
persona certified dispatch (iter 0).

Reduce behavioural-consistency gaps in crate nucleus-cli ONLY. Touch ONLY files under crates/nucleus-cli/. CRITICAL — the `persona consistency` binary is permission-gated and CANNOT be self-approved by the generator (this exact gate wall rejected/escalated two prior consistency runs on nucleus-node/nucleus-oidc-provider). Do NOT treat `persona consistency` as your verification gate and do NOT block on it. Instead: (1) grep the crate yourself for genuine offenders — `grep -rn '\.unwrap()\|\.expect(' crates/nucleus-cli/src` for tau_panic (replace with `?` ONLY inside fns returning Result/Option; LEAVE provably-safe unwraps like on a just-inserted map key or a compile-time-constant regex), and look for unguarded blocking subprocess/socket/lock calls for gamma_bound (add a timeout/kill guard). Optionally align edition + shared dep versions to the workspace (sigma_manifest). (2) Make the SMALLEST correct change — a handful of genuine fixes beats a broad sweep. Do NOT touch any authorization/capability-guard/access-control path (δ_authz/ifc_leak are advisory, human-only). Do NOT modify .vendor-neutrality-allowlist or anything outside the crate (a prior run was rejected for touching an out-of-envelope file). VERIFY strictly with cargo, which IS runnable: `cargo build -p nucleus-cli` then `cargo test -p nucleus-cli` — both MUST stay green. Report exactly which offenders you fixed (fn + gap class) and which you deliberately LEFT as false positives with a one-line reason each. Do not claim a fix you did not make — closure is re-measured after landing.
