### PR TITLE
Reduce behavioural-consistency gaps in crate `nucleus-oidc-provider`

### DIFF
--- a/crates/nucleus-oidc-provider/Cargo.toml
+++ b/crates/nucleus-oidc-provider/Cargo.toml
@@ -46,8 +46,10 @@ nucleus-otel-bootstrap = { path = "../nucleus-otel-bootstrap" }
 clap = { workspace = true }
 
 # Crypto — explicit zeroize feature (closes #31 GA-8: never rely on
-# transitive default-features for key-material zeroization).
-ed25519-dalek = { version = "=3.0.0-pre.7", features = ["zeroize", "rand_core", "pkcs8"] }
+# transitive default-features for key-material zeroization). Version is
+# centralized in [workspace.dependencies] (the exact `=3.0.0-pre.7` pin that
+# forces single-version resolution across the workspace); features stay local.
+ed25519-dalek = { workspace = true, features = ["zeroize", "rand_core", "pkcs8"] }
 
 # Encoding
 hex = { workspace = true }
@@ -80,8 +82,8 @@ subtle = "2"
 [dev-dependencies]
 tower = { version = "0.5", features = ["util", "limit"] }
 http-body-util = "0.1"
-tempfile = "3"
-proptest = "1"
+tempfile = { workspace = true }
+proptest = { workspace = true }
 
 [lints]
 workspace = true


### PR DESCRIPTION
persona certified dispatch (iter 0).

Reduce behavioural-consistency gaps in crate `nucleus-oidc-provider` ONLY. Touch ONLY files under crates/nucleus-oidc-provider/. Fix GENUINE offenders in these classes only: tau_panic (replace .unwrap()/.expect() with `?` in fns returning Result/Option — LEAVE provably-safe unwraps), gamma_bound (add timeout/kill guard to blocking subprocess/socket/lock calls that lack one), sigma_manifest (align edition + shared dep versions to the workspace). NEVER touch authorization / capability-guard / access-control paths — δ_authz and ifc_leak are advisory only. Make the smallest correct change. VERIFY it stays green: `cargo build -p nucleus-oidc-provider` and, if the crate has tests, `cargo test -p nucleus-oidc-provider`. Report each offender you fixed (fn + gap class) and each you LEFT with a one-line reason. Do not claim a fix you did not make — closure is re-measured after landing, so no-ops are caught.
