### PR TITLE
De-vendor crates/ctf-server/ — 3 offending files: crates/ctf-server/src/…

### DIFF
--- a/.vendor-neutrality-allowlist
+++ b/.vendor-neutrality-allowlist
@@ -1,0 +1,1 @@
+crates/ctf-server/src/openapi.rs — retains the `x-openai-isConsequential` plugin-manifest extension field, a load-bearing OpenAI plugin protocol key (inside a JSON literal, cannot be renamed without breaking the CTF fixture's plugin manifest).

--- a/crates/ctf-server/src/main.rs
+++ b/crates/ctf-server/src/main.rs
@@ -1,7 +1,7 @@
 //! HTTP API server for The Vault CTF challenge.
 //!
 //! Serves both the WASM browser experience (static files) and a JSON API
-//! for programmatic access by AI tools (ChatGPT, Gemini, etc.).
+//! for programmatic access by AI tools (LLM agents, etc.).
 
 use std::net::SocketAddr;
 
@@ -25,7 +25,7 @@ mod openapi;
 
 const API_DOCS_HTML: &str = include_str!("../static/api.html");
 
-const CHATGPT_PROMPT: &str = r#"# The Vault CTF — AI Security Benchmark
+const AI_AGENT_PROMPT: &str = r#"# The Vault CTF — AI Security Benchmark
 
 ## Authorized Sandbox Challenge
 
@@ -173,7 +173,7 @@ struct AttackRequest {
 
 #[derive(Deserialize)]
 struct ChallengeRequest {
-    /// Who is playing? (e.g. "chatgpt-4o", "claude-3.5-sonnet", "human")
+    /// Who is playing? (e.g. "my-model-v1", "human")
     player: String,
     /// One attack per level (index 0 = level 1, etc.). Omit levels to skip them.
     attacks: Vec<ChallengeAttack>,
@@ -440,13 +440,13 @@ async fn api_docs() -> impl axum::response::IntoResponse {
     )
 }
 
-async fn chatgpt_prompt() -> impl axum::response::IntoResponse {
+async fn ai_agent_prompt() -> impl axum::response::IntoResponse {
     (
         [(
             axum::http::header::CONTENT_TYPE,
             "text/plain; charset=utf-8",
         )],
-        CHATGPT_PROMPT,
+        AI_AGENT_PROMPT,
     )
 }
 
@@ -536,7 +536,7 @@ async fn main() {
         .route("/api/v1/attack", post(submit_attack))
         .route("/api/v1/challenge", post(run_challenge))
         .route("/api", get(api_docs))
-        .route("/api/v1/prompt", get(chatgpt_prompt))
+        .route("/api/v1/prompt", get(ai_agent_prompt))
         .route("/privacy", get(privacy_policy))
         .route("/openapi.json", get(openapi::spec))
         .route(

--- a/crates/ctf-server/src/mcp.rs
+++ b/crates/ctf-server/src/mcp.rs
@@ -58,7 +58,7 @@ struct ToolCallParam {
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 struct ChallengeParams {
-    #[schemars(description = "Who is playing (e.g. 'chatgpt-4o', 'claude-opus', 'human')")]
+    #[schemars(description = "Who is playing (e.g. 'my-model-v1', 'human')")]
     player: String,
     #[schemars(
         description = "Array of attacks, one per level. Each: {\"level\": 5, \"tool_calls\": [...]}"

--- a/crates/ctf-server/src/openapi.rs
+++ b/crates/ctf-server/src/openapi.rs
@@ -1,4 +1,4 @@
-//! OpenAPI 3.1 spec and ChatGPT plugin manifest.
+//! OpenAPI 3.1 spec and AI plugin manifest.
 
 use axum::response::IntoResponse;
 
@@ -425,7 +425,7 @@ const OPENAPI_SPEC: &str = r##"{
         "properties": {
           "player": {
             "type": "string",
-            "description": "Your model/player name (e.g. 'gpt-5.3', 'claude-opus')"
+            "description": "Your model/player name (e.g. 'my-model-v1')"
           },
           "attacks": {
             "type": "array",


### PR DESCRIPTION
persona certified dispatch (iter 0).

De-vendor crates/ctf-server/ — 3 offending files: crates/ctf-server/src/main.rs, crates/ctf-server/src/mcp.rs, crates/ctf-server/src/openapi.rs. Workflow: (1) `grep -niE 'claude|anthropic|openai|gpt' crates/ctf-server/src/*.rs` to enumerate every vendor mention. (2) For each hit, apply the CLAUDE.md vendor-neutrality rule: rename to a generic term (LLM / AI agent / LLM_API_TOKEN) or, if the mention is load-bearing for a CTF fixture and cannot be neutralized, add that exact path to .vendor-neutrality-allowlist with a one-line rationale — do NOT touch the allowlist for files you can cleanly neutralize. Do NOT modify any authorization/capability/access-control logic. Make the smallest correct change. Touch ONLY files under crates/ctf-server/ (plus .vendor-neutrality-allowlist if you must allowlist). VERIFY: `cargo build -p ctf-server` and `cargo test -p ctf-server` MUST stay green; re-run the grep and report the AFTER count is strictly lower (or every remaining hit is allowlisted with rationale). Report each file changed and the before/after vendor-hit count.
