### PR TITLE
Reduce behavioural-consistency gaps in crate `nucleus-node`

### DIFF
--- a/crates/nucleus-node/Cargo.toml
+++ b/crates/nucleus-node/Cargo.toml
@@ -49,10 +49,12 @@ jsonwebtoken = { workspace = true }
 reqwest = { workspace = true, features = ["json", "rustls-no-provider"] }
 rustls = { workspace = true }
 webpki-roots = "1.0"
-base64 = "0.22"
+base64 = { workspace = true }
 # `alloc` is required (alongside `pkcs8`) for the EncodePrivateKey/DecodePrivateKey
 # (`to_pkcs8_der`/`from_pkcs8_der`) impls — dalek 3 split alloc out of `pkcs8`.
-ed25519-dalek = { version = "=3.0.0-pre.7", features = ["rand_core", "pkcs8", "alloc"] }
+# Version comes from the workspace pin (=3.0.0-pre.7); only the extra features
+# are declared here.
+ed25519-dalek = { workspace = true, features = ["rand_core", "pkcs8", "alloc"] }
 rand_core = { version = "0.6", features = ["getrandom"] }
 
 # X.509 certificate parsing for SPIFFE ID extraction

--- a/crates/nucleus-node/src/main.rs
+++ b/crates/nucleus-node/src/main.rs
@@ -440,7 +440,7 @@ async fn main() -> Result<(), ApiError> {
     // Install the ring crypto provider for rustls (must be done before any TLS operations)
     rustls::crypto::ring::default_provider()
         .install_default()
-        .expect("Failed to install rustls crypto provider");
+        .map_err(|_| ApiError::Driver("failed to install rustls crypto provider".to_string()))?;
 
     tracing_subscriber::fmt()
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())

--- a/crates/nucleus-node/src/net.rs
+++ b/crates/nucleus-node/src/net.rs
@@ -51,7 +51,10 @@ impl NetworkAllocator {
     pub fn allocate(&self, pod_id: Uuid, netns: String) -> Result<NetPlan, ApiError> {
         // Try to reuse a released index first
         let index = {
-            let mut available = self.available.lock().unwrap();
+            let mut available = self
+                .available
+                .lock()
+                .map_err(|_| ApiError::Driver("network allocator lock poisoned".to_string()))?;
             if let Some(idx) = available.pop() {
                 idx
             } else {

--- a/crates/nucleus-node/src/vsock_bridge.rs
+++ b/crates/nucleus-node/src/vsock_bridge.rs
@@ -1,5 +1,12 @@
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+/// Upper bound on the vsock CONNECT handshake (connect + request + `OK` line).
+/// The guest is untrusted, so a hung or unresponsive peer must not be able to
+/// wedge a bridge task forever. The post-handshake `copy_bidirectional` tunnel
+/// is intentionally left unbounded — it is the long-lived data path.
+const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream, UnixStream};
@@ -80,40 +87,50 @@ async fn handle_connection(
     uds_path: &Path,
     guest_port: u32,
 ) -> std::io::Result<()> {
-    let mut vsock = UnixStream::connect(uds_path).await?;
-    let connect_line = format!("CONNECT {guest_port}\n");
-    vsock.write_all(connect_line.as_bytes()).await?;
-    vsock.flush().await?;
+    // Bound the connect + handshake so an unresponsive guest cannot hang the
+    // bridge task indefinitely (γ_bound). Only the handshake is guarded; the
+    // tunnel below is deliberately unbounded.
+    let mut vsock = tokio::time::timeout(HANDSHAKE_TIMEOUT, async {
+        let mut vsock = UnixStream::connect(uds_path).await?;
+        let connect_line = format!("CONNECT {guest_port}\n");
+        vsock.write_all(connect_line.as_bytes()).await?;
+        vsock.flush().await?;
 
-    let mut response = Vec::new();
-    loop {
-        let mut buf = [0u8; 1];
-        let read = vsock.read(&mut buf).await?;
-        if read == 0 {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::UnexpectedEof,
-                "vsock handshake EOF",
-            ));
+        let mut response = Vec::new();
+        loop {
+            let mut buf = [0u8; 1];
+            let read = vsock.read(&mut buf).await?;
+            if read == 0 {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    "vsock handshake EOF",
+                ));
+            }
+            response.push(buf[0]);
+            if buf[0] == b'\n' {
+                break;
+            }
+            if response.len() > 1024 {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "vsock handshake too long",
+                ));
+            }
         }
-        response.push(buf[0]);
-        if buf[0] == b'\n' {
-            break;
-        }
-        if response.len() > 1024 {
+
+        let response_str = String::from_utf8_lossy(&response);
+        if !response_str.starts_with("OK ") {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
-                "vsock handshake too long",
+                format!("vsock handshake failed: {response_str}"),
             ));
         }
-    }
-
-    let response_str = String::from_utf8_lossy(&response);
-    if !response_str.starts_with("OK ") {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidData,
-            format!("vsock handshake failed: {response_str}"),
-        ));
-    }
+        Ok::<UnixStream, std::io::Error>(vsock)
+    })
+    .await
+    .map_err(|_| {
+        std::io::Error::new(std::io::ErrorKind::TimedOut, "vsock handshake timed out")
+    })??;
 
     let _ = tokio::io::copy_bidirectional(&mut inbound, &mut vsock).await?;
     Ok(())


### PR DESCRIPTION
persona certified dispatch (iter 0).

Reduce behavioural-consistency gaps in crate `nucleus-node` ONLY. First run `persona consistency --manifest-dir .` and read the nucleus-node offender list; fix ONLY genuine gaps: tau_panic (.unwrap()/.expect() -> `?` in fns returning Result/Option, LEAVE provably-safe unwraps), gamma_bound (add timeout/kill guard to blocking subprocess/socket/lock calls lacking one), sigma_manifest (align edition + shared dep versions to the workspace). Do NOT touch any authorization/capability-guard/access-control path — δ_authz/ifc_leak are advisory only. Make the smallest correct change. Touch ONLY files under crates/nucleus-node/. VERIFY: `cargo build -p nucleus-node` and `cargo test -p nucleus-node` MUST stay green. Report each offender fixed (fn + gap class) and each deliberately LEFT as a false positive with a one-line reason. The closure is re-measured after landing — no no-ops or laundered changes.
