### PR TITLE
De-vendor crate `nucleus-identity`

### DIFF
--- a/crates/nucleus-identity/src/manager.rs
+++ b/crates/nucleus-identity/src/manager.rs
@@ -653,7 +653,7 @@ mod tests {
         let ca = Arc::new(SelfSignedCa::new("nucleus.local").unwrap());
         let manager = SecretManager::new(ca, Duration::from_secs(3600));
 
-        let parent = Identity::new("nucleus.local", "agents", "claude");
+        let parent = Identity::new("nucleus.local", "agents", "agent");
         let session = SessionIdentity::new(parent.clone(), Duration::from_secs(3600));
 
         let cert = manager.fetch_session_certificate(&session).await.unwrap();
@@ -661,7 +661,7 @@ mod tests {
         // Session cert identity should contain the session ID
         let cert_identity = cert.identity();
         assert!(
-            cert_identity.service_account().starts_with("claude-"),
+            cert_identity.service_account().starts_with("agent-"),
             "session cert should embed session ID in service account"
         );
         assert!(!cert.is_expired());
@@ -672,7 +672,7 @@ mod tests {
         let ca = Arc::new(SelfSignedCa::new("nucleus.local").unwrap());
         let manager = SecretManager::new(ca, Duration::from_secs(3600));
 
-        let parent = Identity::new("nucleus.local", "agents", "claude");
+        let parent = Identity::new("nucleus.local", "agents", "agent");
         let session = SessionIdentity::new(parent, Duration::from_secs(3600));
 
         let cert1 = manager.fetch_session_certificate(&session).await.unwrap();
@@ -687,7 +687,7 @@ mod tests {
         let ca = Arc::new(SelfSignedCa::new("nucleus.local").unwrap());
         let manager = SecretManager::new(ca, Duration::from_secs(3600));
 
-        let parent = Identity::new("nucleus.local", "agents", "claude");
+        let parent = Identity::new("nucleus.local", "agents", "agent");
         let session1 = SessionIdentity::new(parent.clone(), Duration::from_secs(3600));
         let session2 = SessionIdentity::new(parent, Duration::from_secs(3600));
 
@@ -704,7 +704,7 @@ mod tests {
         let ca = Arc::new(SelfSignedCa::new("nucleus.local").unwrap());
         let manager = SecretManager::new(ca, Duration::from_secs(3600));
 
-        let parent = Identity::new("nucleus.local", "agents", "claude");
+        let parent = Identity::new("nucleus.local", "agents", "agent");
         let session = SessionIdentity::new(parent.clone(), Duration::from_secs(3600));
 
         let cert1 = manager.fetch_session_certificate(&session).await.unwrap();
@@ -722,7 +722,7 @@ mod tests {
         let ca = Arc::new(SelfSignedCa::new("nucleus.local").unwrap());
         let manager = SecretManager::new(ca, Duration::from_secs(3600));
 
-        let parent = Identity::new("nucleus.local", "agents", "claude");
+        let parent = Identity::new("nucleus.local", "agents", "agent");
         let session1 = SessionIdentity::new(parent.clone(), Duration::from_secs(3600));
         let session2 = SessionIdentity::new(parent.clone(), Duration::from_secs(3600));
 
@@ -738,7 +738,7 @@ mod tests {
         let ca = Arc::new(SelfSignedCa::new("nucleus.local").unwrap());
         let manager = SecretManager::new(ca, Duration::from_secs(3600));
 
-        let parent = Identity::new("nucleus.local", "agents", "claude");
+        let parent = Identity::new("nucleus.local", "agents", "agent");
         // Create an already-expired session
         let session = SessionIdentity {
             parent,

--- a/crates/nucleus-identity/src/session.rs
+++ b/crates/nucleus-identity/src/session.rs
@@ -21,11 +21,11 @@
 //! use nucleus_identity::{Identity, SessionIdentity};
 //! use std::time::Duration;
 //!
-//! let parent = Identity::new("nucleus.local", "agents", "claude");
+//! let parent = Identity::new("nucleus.local", "agents", "agent");
 //! let session = SessionIdentity::new(parent, Duration::from_secs(3600));
 //!
 //! println!("Session SPIFFE URI: {}", session.to_spiffe_uri());
-//! // spiffe://nucleus.local/ns/agents/sa/claude/session/01941234-...
+//! // spiffe://nucleus.local/ns/agents/sa/agent/session/01941234-...
 //! ```
 
 use crate::identity::Identity;
@@ -387,17 +387,17 @@ mod tests {
 
     #[test]
     fn test_session_identity_spiffe_uri() {
-        let parent = Identity::new("nucleus.local", "agents", "claude");
+        let parent = Identity::new("nucleus.local", "agents", "agent");
         let session = SessionIdentity::new(parent, Duration::from_secs(3600));
 
         let uri = session.to_spiffe_uri();
-        assert!(uri.starts_with("spiffe://nucleus.local/ns/agents/sa/claude/session/"));
+        assert!(uri.starts_with("spiffe://nucleus.local/ns/agents/sa/agent/session/"));
         assert!(uri.len() > 60); // Base URI + session ID
     }
 
     #[test]
     fn test_session_identity_expiry() {
-        let parent = Identity::new("nucleus.local", "agents", "claude");
+        let parent = Identity::new("nucleus.local", "agents", "agent");
 
         // Short TTL that's already expired
         let session = SessionIdentity {
@@ -418,23 +418,23 @@ mod tests {
 
     #[test]
     fn test_session_identity_to_certificate_identity() {
-        let parent = Identity::new("nucleus.local", "agents", "claude");
+        let parent = Identity::new("nucleus.local", "agents", "agent");
         let session = SessionIdentity::new(parent.clone(), Duration::from_secs(3600));
 
         let cert_id = session.to_certificate_identity();
         assert_eq!(cert_id.trust_domain(), "nucleus.local");
         assert_eq!(cert_id.namespace(), "agents");
-        assert!(cert_id.service_account().starts_with("claude-"));
-        assert!(cert_id.service_account().len() > 40); // claude + hyphen + UUID
+        assert!(cert_id.service_account().starts_with("agent-"));
+        assert!(cert_id.service_account().len() > 40); // agent + hyphen + UUID
     }
 
     #[test]
     fn test_session_identity_display() {
-        let parent = Identity::new("nucleus.local", "agents", "claude");
+        let parent = Identity::new("nucleus.local", "agents", "agent");
         let session = SessionIdentity::new(parent, Duration::from_secs(3600));
 
         let display = format!("{}", session);
-        assert!(display.starts_with("spiffe://nucleus.local/ns/agents/sa/claude/session/"));
+        assert!(display.starts_with("spiffe://nucleus.local/ns/agents/sa/agent/session/"));
     }
 
     #[test]
@@ -505,7 +505,7 @@ mod session_refresh_tests {
 
     #[test]
     fn validate_before_refresh_succeeds_with_sufficient_lifetime() {
-        let parent = Identity::new("nucleus.local", "agents", "claude");
+        let parent = Identity::new("nucleus.local", "agents", "agent");
         let session = SessionIdentity::new(parent, Duration::from_secs(3600));
         let min_remaining = Duration::from_secs(60);
         assert!(session.validate_before_refresh(min_remaining).is_ok());
@@ -513,7 +513,7 @@ mod session_refresh_tests {
 
     #[test]
     fn validate_before_refresh_fails_when_expired() {
-        let parent = Identity::new("nucleus.local", "agents", "claude");
+        let parent = Identity::new("nucleus.local", "agents", "agent");
         // Create session with 0 TTL — already expired
         let session = SessionIdentity::new(parent, Duration::from_secs(0));
         std::thread::sleep(Duration::from_millis(10));
@@ -523,7 +523,7 @@ mod session_refresh_tests {
 
     #[test]
     fn validate_before_refresh_fails_with_insufficient_lifetime() {
-        let parent = Identity::new("nucleus.local", "agents", "claude");
+        let parent = Identity::new("nucleus.local", "agents", "agent");
         // 2 second TTL, require 60 seconds remaining
         let session = SessionIdentity::new(parent, Duration::from_secs(2));
         let result = session.validate_before_refresh(Duration::from_secs(60));

--- a/crates/nucleus-identity/tests/security_gauntlet.rs
+++ b/crates/nucleus-identity/tests/security_gauntlet.rs
@@ -1273,7 +1273,7 @@ mod session_security {
     /// Session identity expiry cannot be bypassed
     #[test]
     fn test_session_expiry_enforced() {
-        let parent = Identity::new("nucleus.local", "agents", "claude");
+        let parent = Identity::new("nucleus.local", "agents", "agent");
 
         // Create already-expired session (created 1 hour ago with 30 min TTL)
         let session = SessionIdentity::new(parent.clone(), Duration::from_secs(1800));
@@ -1303,14 +1303,14 @@ mod session_security {
     /// Session identity SPIFFE URI format validation
     #[test]
     fn test_session_spiffe_uri_format() {
-        let parent = Identity::new("nucleus.local", "agents", "claude");
+        let parent = Identity::new("nucleus.local", "agents", "agent");
         let session = SessionIdentity::new(parent.clone(), Duration::from_secs(3600));
 
         let uri = session.to_spiffe_uri();
 
         // Should have correct prefix
         assert!(
-            uri.starts_with("spiffe://nucleus.local/ns/agents/sa/claude/session/"),
+            uri.starts_with("spiffe://nucleus.local/ns/agents/sa/agent/session/"),
             "Session URI should extend parent URI"
         );
 
@@ -1354,7 +1354,7 @@ mod session_security {
     /// Test that certificate identity maintains uniqueness
     #[test]
     fn test_certificate_identity_uniqueness() {
-        let parent = Identity::new("nucleus.local", "agents", "claude");
+        let parent = Identity::new("nucleus.local", "agents", "agent");
 
         let session1 = SessionIdentity::new(parent.clone(), Duration::from_secs(3600));
         let session2 = SessionIdentity::new(parent.clone(), Duration::from_secs(3600));


### PR DESCRIPTION
persona certified dispatch (iter 0).

De-vendor crate `nucleus-identity` ONLY. Offender files: crates/nucleus-identity/src/manager.rs, crates/nucleus-identity/src/session.rs, crates/nucleus-identity/tests/security_gauntlet.rs. For each specific-vendor reference in product code, either replace with a vendor-agnostic term or extract behind a neutral trait/adapter (per CLAUDE.md vendor-neutrality rules — e.g. generic env/credential/policy naming, no LLM-vendor names). DO NOT add any path to .vendor-neutrality-allowlist — that write is unauthorized in this session and was rejected on a prior run (receipt_ok=false unauthorized=[".vendor-neutrality-allowlist"]); the fix must be a genuine source de-vendoring, not an allowlist entry. DO NOT modify any authorization, capability-guard, or access-control logic — leave auth/identity-verification paths intact; rename/extract only the vendor-naming, not the security semantics. Make the smallest correct change. Touch ONLY files under crates/nucleus-identity/. VERIFY: `cargo build -p nucleus-identity` and `cargo test -p nucleus-identity` MUST stay green. Report exactly which vendor references you neutralized per file.
