### PR TITLE
c20-consistency correctness work on crate `nucleus-oidc-core` ONLY — NOT…

### DIFF
--- a/crates/nucleus-oidc-core/Cargo.toml
+++ b/crates/nucleus-oidc-core/Cargo.toml
@@ -11,9 +11,9 @@ keywords = ["oidc", "oauth", "jwks", "jwt", "federation"]
 categories = ["cryptography", "authentication"]
 
 [dependencies]
-async-trait = "0.1"
+async-trait = { workspace = true }
 base64 = { workspace = true }
-ed25519-dalek = { version = "=3.0.0-pre.7", default-features = false }
+ed25519-dalek = { workspace = true, default-features = false }
 # JWT-SVID signature verification (RS/PS/ES allowlist). Workspace-pinned to
 # the same `rust_crypto` (RustCrypto) backend the rest of the workspace uses,
 # so this adds no new crypto backend to the supply chain.

--- a/crates/nucleus-oidc-core/src/jwks.rs
+++ b/crates/nucleus-oidc-core/src/jwks.rs
@@ -213,7 +213,7 @@ impl DiscoveryKeyResolver {
     }
 
     fn cached(&self, kid: &str) -> Option<Arc<JwkPublicKey>> {
-        let cache = self.cache.lock().expect("key cache mutex not poisoned");
+        let cache = self.cache.lock().ok()?;
         match cache.fetched_at {
             Some(t) if t.elapsed() < self.ttl => cache.keys.get(kid).cloned(),
             _ => None,
@@ -263,7 +263,10 @@ impl DiscoveryKeyResolver {
             ));
         }
 
-        let mut cache = self.cache.lock().expect("key cache mutex not poisoned");
+        let mut cache = self
+            .cache
+            .lock()
+            .map_err(|_| OidcError::Discovery("key cache lock poisoned".into()))?;
         cache.keys = keys;
         cache.fetched_at = Some(Instant::now());
         Ok(())
@@ -285,7 +288,7 @@ impl KeyResolver for DiscoveryKeyResolver {
         self.refresh(issuer).await?;
         self.cache
             .lock()
-            .expect("key cache mutex not poisoned")
+            .map_err(|_| OidcError::KeyNotFound(kid.to_string()))?
             .keys
             .get(kid)
             .cloned()

--- a/crates/nucleus-oidc-core/src/spiffe_federation.rs
+++ b/crates/nucleus-oidc-core/src/spiffe_federation.rs
@@ -352,7 +352,7 @@ impl FederationStore {
     pub fn endpoint_for(&self, trust_domain: &str) -> Option<(String, Profile)> {
         self.domains
             .lock()
-            .expect("federation store mutex")
+            .ok()?
             .get(trust_domain)
             .map(|d| (d.cfg.bundle_endpoint_url.clone(), d.cfg.profile))
     }
@@ -361,7 +361,7 @@ impl FederationStore {
     pub fn refresh_period(&self, trust_domain: &str) -> Option<Duration> {
         self.domains
             .lock()
-            .expect("federation store mutex")
+            .ok()?
             .get(trust_domain)
             .map(|d| d.refresh_period)
     }
@@ -371,7 +371,7 @@ impl FederationStore {
     pub fn served_key_count(&self, trust_domain: &str) -> Option<usize> {
         self.domains
             .lock()
-            .expect("federation store mutex")
+            .ok()?
             .get(trust_domain)
             .map(|d| d.keys.len())
     }
@@ -380,7 +380,7 @@ impl FederationStore {
     pub fn last_accepted_seq(&self, trust_domain: &str) -> Option<u64> {
         self.domains
             .lock()
-            .expect("federation store mutex")
+            .ok()?
             .get(trust_domain)
             .and_then(|d| d.last_accepted_seq)
     }


### PR DESCRIPTION
persona certified dispatch (iter 0).

c20-consistency correctness work on crate `nucleus-oidc-core` ONLY — NOT de-vendoring. Step 1: run `persona consistency --manifest-dir .` and read this crate's offenders. Fix only GENUINE ones: (a) tau_panic — replace .unwrap()/.expect() with `?` in fns returning Result/Option, LEAVE provably-safe unwraps; (b) gamma_bound — add a timeout/kill guard to any blocking subprocess/socket/lock call lacking one; (c) sigma_manifest — align edition + shared dependency versions to the workspace. Do NOT touch any authorization, capability-guard, or access-control logic (δ_authz / ifc_leak are advisory, human-only). Make the smallest correct change. Touch ONLY files under crates/nucleus-oidc-core/. VERIFY: `cargo build -p nucleus-oidc-core` and `cargo test -p nucleus-oidc-core` MUST stay green. Report each offender fixed (fn + gap class) and each deliberately LEFT as a false positive with a one-line reason. The closure is re-measured after landing — the metric must drop, so no-ops/laundered changes are caught.
