### PR TITLE
De-vendor crate `nucleus-tool-proxy` ONLY — c5-vendor-neutrality

### DIFF
--- a/.vendor-neutrality-allowlist
+++ b/.vendor-neutrality-allowlist
@@ -1,0 +1,13 @@
+# .vendor-neutrality-allowlist
+#
+# Paths listed here are exempt from the vendor-neutrality closure. A path
+# belongs here only when its vendor reference is legitimately integration-
+# specific — an opt-in test fixture that drives a real vendor API and cannot
+# be neutralized without destroying its function. Each entry needs a one-line
+# rationale. This is a last resort; prefer rename/extract in product code.
+
+# Opt-in (feature = "red-team"), network-gated (skipped unless ANTHROPIC_API_KEY
+# is set) integration test that drives a live vendor LLM as an adversarial
+# red-team agent against Portcullis. The vendor endpoint/headers/model id ARE
+# the system under test here, so they cannot be genericized without voiding it.
+crates/nucleus-tool-proxy/tests/red_team_harness.rs

--- a/crates/nucleus-tool-proxy/Cargo.toml
+++ b/crates/nucleus-tool-proxy/Cargo.toml
@@ -21,7 +21,7 @@ default = []
 spire = ["nucleus-identity/spire"]
 # MCP server mode (stdio transport)
 mcp = ["dep:rmcp", "dep:schemars"]
-# Red-team harness: Claude vs. Portcullis (requires ANTHROPIC_API_KEY)
+# Red-team harness: adversarial LLM agent vs. Portcullis (see tests/red_team_harness.rs)
 red-team = []
 # Remote append-only audit sink (S3-compatible: AWS S3, MinIO, R2, Tigris)
 remote-audit = ["dep:aws-sdk-s3", "dep:aws-config"]

--- a/crates/nucleus-tool-proxy/src/mtls.rs
+++ b/crates/nucleus-tool-proxy/src/mtls.rs
@@ -404,7 +404,7 @@ mod tests {
         let trust_domain = "test.nucleus.local";
         let ca = SelfSignedCa::new(trust_domain).unwrap();
 
-        let identity = Identity::new(trust_domain, "agents", "claude");
+        let identity = Identity::new(trust_domain, "agents", "agent");
         let csr = CsrOptions::new(identity.to_spiffe_uri())
             .generate()
             .unwrap();
@@ -424,7 +424,7 @@ mod tests {
         assert!(spiffe_id.is_some());
         assert_eq!(
             spiffe_id.unwrap(),
-            "spiffe://test.nucleus.local/ns/agents/sa/claude"
+            "spiffe://test.nucleus.local/ns/agents/sa/agent"
         );
     }
 

--- a/crates/nucleus-tool-proxy/tests/mtls_integration.rs
+++ b/crates/nucleus-tool-proxy/tests/mtls_integration.rs
@@ -41,7 +41,7 @@ async fn create_test_certs(
         .unwrap();
 
     // Create client certificate
-    let client_identity = Identity::new(trust_domain, "agents", "claude");
+    let client_identity = Identity::new(trust_domain, "agents", "agent");
     let client_csr = CsrOptions::new(client_identity.to_spiffe_uri())
         .generate()
         .unwrap();
@@ -265,7 +265,7 @@ async fn test_client_spiffe_id_extraction() {
         assert!(spiffe_id.is_some(), "client cert should have SPIFFE ID");
         assert_eq!(
             spiffe_id.unwrap(),
-            "spiffe://spiffe.nucleus.local/ns/agents/sa/claude"
+            "spiffe://spiffe.nucleus.local/ns/agents/sa/agent"
         );
     });
 


### PR DESCRIPTION
persona certified dispatch (iter 0).

De-vendor crate `nucleus-tool-proxy` ONLY — c5-vendor-neutrality. Offender files: crates/nucleus-tool-proxy/Cargo.toml, crates/nucleus-tool-proxy/src/mtls.rs, crates/nucleus-tool-proxy/tests/mtls_integration.rs, crates/nucleus-tool-proxy/tests/red_team_harness.rs. Apply the same proven RENAME/EXTRACT pattern that landed for nucleus-cli and nucleus-identity: for each vendor string in product code, either (a) rename to a neutral constant / extract behind a neutral trait/adapter, or (b) if the reference is legitimately integration-specific (e.g. a red-team test fixture asserting on a real vendor tool name), add that exact path to .vendor-neutrality-allowlist with a one-line rationale. Do NOT touch authorization/capability-guard/mTLS trust logic — only rename identifiers/strings, never change auth behaviour. Touch ONLY files under crates/nucleus-tool-proxy/ (plus the repo-root .vendor-neutrality-allowlist if you allowlist a path). VERIFY (must stay green): `cargo build -p nucleus-tool-proxy`, `cargo test -p nucleus-tool-proxy`, and `bash ci/no-vendor-strings.sh` (the closure is re-measured on landing — the offender count for this crate MUST drop to 0). Report which files you neutralized vs. allowlisted, with the rationale for each allowlist entry.
