### PR TITLE
Reduce behavioural consistency gaps in crate `nucleus-tool-proxy` (c20-c…

### DIFF
--- a/crates/nucleus-tool-proxy/src/main.rs
+++ b/crates/nucleus-tool-proxy/src/main.rs
@@ -3189,15 +3189,9 @@ async fn web_search(
     // Web search requires a configured backend URL
     // For now, return an error indicating the backend must be configured
     // A real implementation would read NUCLEUS_WEB_SEARCH_URL from env/config
-    let search_url = std::env::var("NUCLEUS_WEB_SEARCH_URL").ok();
-
-    if search_url.is_none() {
-        return Err(ApiError::Spec(
-            "web_search requires NUCLEUS_WEB_SEARCH_URL to be configured".to_string(),
-        ));
-    }
-
-    let search_url = search_url.unwrap();
+    let search_url = std::env::var("NUCLEUS_WEB_SEARCH_URL").map_err(|_| {
+        ApiError::Spec("web_search requires NUCLEUS_WEB_SEARCH_URL to be configured".to_string())
+    })?;
 
     // Check DNS allow list
     let url = url::Url::parse(&search_url)


### PR DESCRIPTION
persona certified dispatch (iter 0).

Reduce behavioural consistency gaps in crate `nucleus-tool-proxy` (c20-consistency — this is NOT c5-vendor-neutrality; do NOT de-vendor and do NOT touch mtls.rs vendor strings). First run `persona consistency --manifest-dir .` and read THIS crate's offenders. Fix only GENUINE ones: (a) tau_panic — replace `.unwrap()`/`.expect()` with `?` in fns returning Result/Option, LEAVE provably-safe unwraps (compile-time-constant regex, just-inserted map key); (b) gamma_bound — add a timeout/kill guard to any blocking subprocess/socket/lock call lacking one; (c) sigma_manifest — align edition + shared dep versions to the workspace root. HARD EXCLUSION: do NOT modify any authorization, capability-guard, mTLS, or access-control logic — δ_authz/ifc_leak are advisory, human-only. Make the smallest correct change. Touch ONLY files under crates/nucleus-tool-proxy/. VERIFY: `cargo build -p nucleus-tool-proxy` and `cargo test -p nucleus-tool-proxy` MUST stay green. Report each offender fixed (fn + gap class) and each deliberately LEFT (fn + one-line why-safe). No laundering — closure is re-measured after landing.
