### PR TITLE
Make incremental Lean proof progress in crates/portcullis-core/lean ONLY…

### DIFF
--- a/crates/portcullis-core/lean/SemanticIFCDecidable.lean
+++ b/crates/portcullis-core/lean/SemanticIFCDecidable.lean
@@ -3862,11 +3862,15 @@ def toPreEquiv {n m : Nat}
   sim_symm i j h := by
     show decide _ = true
     rw [decide_eq_true_iff]
-    have : decide _ = true := h
-    rw [decide_eq_true_iff] at this
+    have hcount : decide _ = true := h
+    rw [decide_eq_true_iff] at hcount
     -- countP (fun k => w j k != w i k) = countP (fun k => w i k != w j k)
-    -- because bne is symmetric for types with lawful BEq
-    sorry -- bne symmetry for Fin m
+    -- because bne is symmetric for types with lawful BEq (Fin m)
+    have hfun : (fun k => A.weights j k != A.weights i k)
+              = (fun k => A.weights i k != A.weights j k) := by
+      funext k; exact bne_comm
+    rw [hfun]
+    exact hcount
 
 /-- At tolerance 0, the PreEquiv's sim agrees with exact row equality.
     If sim(i,j) at tolerance 0, then all weights are equal. -/


### PR DESCRIPTION
persona certified dispatch (iter 0).

Make incremental Lean proof progress in crates/portcullis-core/lean ONLY (c18-lean-proof-maintenance — NOT c5-vendor-neutrality, NOT c20-consistency). 27 sorry/admit + 7 axiom(s) remain; discharge AT LEAST ONE: close a `sorry`, extract-and-prove a lemma, or replace an `axiom` with a real proof. Prefer easy wins — reuse existing lemmas and Mathlib via `exact?`/`apply?`, and `simp`/`omega`/`decide`. HARD RULES: (1) `cd crates/portcullis-core/lean && lake build` MUST stay green; (2) do NOT introduce any NEW sorry/admit/axiom — verify with `grep -rEc 'sorry|admit|axiom' crates/portcullis-core/lean/` before vs after and confirm the total did not rise (that is laundering, not progress). Touch ONLY files under crates/portcullis-core/lean/.
