### PR TITLE
De-vendor crate `nucleus-control-plane` ONLY (c5-vendor-neutrality) — th…

### DIFF
--- a/crates/nucleus-control-plane/src/lib.rs
+++ b/crates/nucleus-control-plane/src/lib.rs
@@ -8,8 +8,8 @@
 //!
 //! # Vendor neutrality
 //!
-//! `JobRunner` is a trait — every concrete agent integration (Claude
-//! Code, OpenHands, Goose, …) lives outside this crate as a separate
+//! `JobRunner` is a trait — every concrete agent integration (an
+//! agent CLI, OpenHands, Goose, …) lives outside this crate as a separate
 //! implementation. The orchestrator core knows only: "run agent X,
 //! collect lineage Y, package result Z." It does not know which LLM
 //! is doing the work, what its API costs, or how its credentials are

--- a/crates/nucleus-control-plane/src/runner.rs
+++ b/crates/nucleus-control-plane/src/runner.rs
@@ -5,7 +5,7 @@
 //! agent does that should appear in the provenance envelope MUST be
 //! emitted as a [`LineageEdge`] through the writer.
 //!
-//! Concrete drivers (claude-code, openhands, …) live OUTSIDE this crate
+//! Concrete drivers (an agent CLI, openhands, …) live OUTSIDE this crate
 //! to keep nucleus vendor-neutral. The mock driver lives here because
 //! it's part of the orchestrator's test surface, not a vendor adapter.
 

--- a/crates/nucleus-control-plane/src/spec.rs
+++ b/crates/nucleus-control-plane/src/spec.rs
@@ -23,7 +23,7 @@ pub struct JobSpec {
     /// (e.g. "codegen", "review", "report-extraction").
     pub policy_profile: String,
     /// Which agent driver to run. Indirected to keep nucleus
-    /// vendor-neutral; the actual Claude/OpenAI/etc. adapters live
+    /// vendor-neutral; the actual LLM-vendor adapters live
     /// outside this crate.
     pub agent_driver: AgentDriverRef,
 }
@@ -65,7 +65,7 @@ pub enum Destination {
 /// vendor SDKs.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentDriverRef {
-    /// Driver identifier (e.g. "mock", "claude-code", "openhands"). The
+    /// Driver identifier (e.g. "mock", "agent-cli", "openhands"). The
     /// orchestrator looks this up against a registry of available
     /// [`crate::runner::JobRunner`] implementations.
     pub name: String,


### PR DESCRIPTION
persona certified dispatch (iter 0).

De-vendor crate `nucleus-control-plane` ONLY (c5-vendor-neutrality) — this is NOT c20-consistency; do NOT invoke `persona consistency`. Three product files name a specific LLM vendor: crates/nucleus-control-plane/src/lib.rs, src/runner.rs, src/spec.rs. For each hit, prefer the neutral extraction pattern from CLAUDE.md (generic env/credentials, work-type policy names like codegen/review, 'LLM'/'AI agent' phrasing, `LLM_API_TOKEN` not vendor keys) — extract behind a neutral trait/adapter or rename to a neutral constant. Only fall back to appending the path to `.vendor-neutrality-allowlist` with a one-line rationale when the vendor name is genuinely load-bearing (real external endpoint / interop contract), NOT to paper over a fixable default — see the run-6a4c0c88 PullUp: a hardcoded vendor model-API host is a violation to extract, not allowlist. Verify: run the de-vendor gate (`ci/no-vendor-strings.sh` / `ci/no-vendor-strings.sh`) until clean, then `cargo check -p nucleus-control-plane` and `cargo test -p nucleus-control-plane`. Touch ONLY crates/nucleus-control-plane/ (and the shared `.vendor-neutrality-allowlist` iff you allowlist a path).
