### PR TITLE
De-vendor crate `nucleus` ONLY — envelope crates/nucleus/, the single fl…

### DIFF
--- a/crates/nucleus/src/sandbox.rs
+++ b/crates/nucleus/src/sandbox.rs
@@ -803,7 +803,7 @@ mod tests {
         // Use issue_approved_token to bypass the kernel's PathLattice check.
         // The kernel's can_access() resolves relative paths via the CWD, which
         // on macOS case-insensitive FS may canonicalize to existing files whose
-        // absolute path matches blocked patterns like `**/.claude/**` when
+        // absolute path matches blocked patterns like `**/.ssh/**` when
         // running inside a git worktree. This test exercises the *sandbox*'s
         // path policy, not the kernel's.
         let wt = kernel.issue_approved_token(Operation::WriteFiles, "test: write normal file");


### PR DESCRIPTION
persona certified dispatch (iter 0).

De-vendor crate `nucleus` ONLY — envelope crates/nucleus/, the single flagged file is crates/nucleus/src/sandbox.rs. This is c5-vendor-neutrality, NOT c20-consistency; do NOT invoke `persona consistency`. Neutralize ONLY genuine LLM-vendor references (Anthropic/Claude/OpenAI names, vendor OAuth/API-key formats, hardcoded vendor model-API egress hosts). Hard-won constraints from recent pull-ups, obey them: (1) `github` is a code host, NOT an LLM vendor — do NOT mutilate canonical upstream URLs or CI paths; leave them verbatim. (2) Do NOT hardcode-then-allowlist a vendor model-API egress host — if one is baked as a default, EXTRACT it so the caller/policy supplies it, don't paper over with an allowlist line. (3) Prefer the REAL gate (ci/no-vendor-strings.sh) over a hand-replicated grep — confirm a token is actually matched before touching a file. If a reference is genuinely generic build infra, add it to .vendor-neutrality-allowlist with a written rationale line rather than destroying information. Verify: run ci/no-vendor-strings.sh clean, then `cargo check -p nucleus` and `cargo test -p nucleus`. Touch ONLY crates/nucleus/.
