### PR TITLE
De-vendor crate `nucleus-mcp` ONLY (c5-vendor-neutrality) — this is NOT…

### DIFF
--- a/crates/nucleus-mcp/Cargo.toml
+++ b/crates/nucleus-mcp/Cargo.toml
@@ -5,10 +5,10 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 description = "MCP server that bridges an MCP client (any AI-agent runtime) to nucleus-tool-proxy"
-repository = "https://github.com/coproduct-opensource/nucleus"
+repository = "https://github.com/coproduct-opensource/nucleus"  # vendor-allow: project repo URL
 documentation = "https://docs.rs/nucleus-mcp"
 readme = "README.md"
-keywords = ["mcp", "claude", "tools", "security", "sandbox"]
+keywords = ["mcp", "ai-agent", "tools", "security", "sandbox"]
 categories = ["command-line-utilities", "development-tools"]
 
 [[bin]]


### PR DESCRIPTION
persona certified dispatch (iter 0).

De-vendor crate `nucleus-mcp` ONLY (c5-vendor-neutrality) — this is NOT c20-consistency; do NOT invoke `persona consistency`. Envelope is crates/nucleus-mcp/; the single flagged file is crates/nucleus-mcp/Cargo.toml. First OPEN the file and identify the exact matched vendor token. Decide honestly: (a) if it is a load-bearing external dependency/crate name or upstream package that literally cannot be renamed without breaking the build, add that path to .vendor-neutrality-allowlist with a one-line written rationale — do NOT mutilate a real dependency name; (b) if it is a gratuitous vendor reference in author/description/metadata that carries no build meaning, neutralize it to a generic form. Prefer meaning-preserving fixes over grep-appeasing deletions (see the vcg/github and api.anthropic.com pull-ups). Verify with `cargo check -p nucleus-mcp` and re-run the actual c5 gate to confirm the token clears. Touch ONLY crates/nucleus-mcp/.
