### PR TITLE
Fix RUSTSEC-2026-0204 (crossbeam-epoch invalid-pointer deref in fmt::Poi…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2642,9 +2642,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
persona certified dispatch (iter 0).

Fix RUSTSEC-2026-0204 (crossbeam-epoch invalid-pointer deref in fmt::Pointer). This is almost certainly a TRANSITIVE dep — do NOT add a direct dependency. Run `cargo update -p crossbeam-epoch --precise 0.9.20` (bump to the smallest patched version >=0.9.20). If the workspace pins it below that via another crate's requirement, run plain `cargo update -p crossbeam-epoch` and take the highest resolvable. Verify with: (1) `cargo tree -i crossbeam-epoch` to confirm the resolved version is >=0.9.20 on every path, and (2) `cargo check --workspace` goes green — paste both outputs. If a hard version ceiling forces it to stay <0.9.20, do NOT force it; instead document the rationale inline per latest-with-rationale and surface the ceiling. Touch ONLY Cargo.toml and Cargo.lock. This is a pure dependency bump — the c5 vendor-neutrality gate does NOT apply here, so do not invoke ci/no-vendor-strings.sh.
