### PR TITLE
De-vendor crate `nucleus` ONLY (c5-vendor-neutrality)

### DIFF
--- a/crates/nucleus/src/sandbox.rs
+++ b/crates/nucleus/src/sandbox.rs
@@ -803,7 +803,7 @@ mod tests {
         // Use issue_approved_token to bypass the kernel's PathLattice check.
         // The kernel's can_access() resolves relative paths via the CWD, which
         // on macOS case-insensitive FS may canonicalize to existing files whose
-        // absolute path matches blocked patterns like `**/.claude/**` when
+        // absolute path matches blocked patterns like `**/.ssh/**` when
         // running inside a git worktree. This test exercises the *sandbox*'s
         // path policy, not the kernel's.
         let wt = kernel.issue_approved_token(Operation::WriteFiles, "test: write normal file");


### PR DESCRIPTION
persona certified dispatch (iter 0).

De-vendor crate `nucleus` ONLY (c5-vendor-neutrality). Envelope: crates/nucleus/ — the single flagged file is crates/nucleus/src/sandbox.rs. STEP 1: `grep -rn -iE 'claude|anthropic|openai' crates/nucleus/src/sandbox.rs` to see the exact vendor token and its context. STEP 2: choose the right remedy per the [[nucleus-devendor-gate]] RENAME/EXTRACT pattern — if it is a comment or user-facing string, rewrite to the neutral vocabulary ('LLM'/'AI agent'/'orchestrator' per CLAUDE.md); if it is a semantically-load-bearing identifier (e.g. an interop path or upstream tool name that MUST stay), instead add `crates/nucleus/src/sandbox.rs` to .vendor-neutrality-allowlist with a one-line rationale. Prefer removal over allowlisting. STEP 3 VERIFY (only what runs in the worktree): `cargo build -p nucleus` stays green, and `grep -rn -iE 'claude|anthropic|openai' crates/nucleus/` shows the name is gone (or only in the allowlisted path). Paste both outputs. Do NOT run `bash ci/no-vendor-strings.sh` or any ci/ script — it is NOT in the worktree and NOT your gate; the authoritative check runs in nucleus CI post-landing. A green cargo build + clean grep IS the completion criterion — do not surface a gate-blocked escalation. Touch ONLY crates/nucleus/ (plus .vendor-neutrality-allowlist if you allowlist).
