### PR TITLE
De-vendor crate `nucleus-econ-kernels` ONLY (c5-vendor-neutrality)

### DIFF
--- a/crates/nucleus-econ-kernels/src/vcg.rs
+++ b/crates/nucleus-econ-kernels/src/vcg.rs
@@ -116,8 +116,7 @@ pub struct IntegerBid {
 /// a `value_micro_usd` field that the welfare computation summed; that
 /// design admitted a hidden two-utility-function bug (IR could fail
 /// whenever bid ≠ proposal value, which is precisely when separate
-/// proposal values exist). The Week 6 Option A fix from
-/// `/Users/bcrisp/.claude/plans/let-s-web-search-look-modular-rivest.md`
+/// proposal values exist). The Week 6 Option A design fix
 /// collapsed welfare to bid effective value, restoring theoretical
 /// honesty under `docs/ECON-PRECISION.md`'s "bid is the canonical
 /// economic primitive" principle.


### PR DESCRIPTION
persona certified dispatch (iter 0).

De-vendor crate `nucleus-econ-kernels` ONLY (c5-vendor-neutrality). Envelope: crates/nucleus-econ-kernels/ — the single flagged file is crates/nucleus-econ-kernels/src/vcg.rs. Replace the vendor name with a neutral term (generic LLM/AI-agent/orchestrator phrasing per CLAUDE.md), OR if the reference is load-bearing add crates/nucleus-econ-kernels/src/vcg.rs to .vendor-neutrality-allowlist with a one-line rationale. Touch ONLY files under crates/nucleus-econ-kernels/ (plus the allowlist file if that path is taken). VERIFY in-worktree: `cargo build -p nucleus-econ-kernels` stays green, and `grep -rn <vendor> crates/nucleus-econ-kernels/` shows the name is gone (or only in the allowlisted path) — paste both. Do NOT run any `ci/` script and do NOT block on the no-vendor gate; that runs in nucleus CI post-landing. A run is a fix if the vendor ref is removed/allowlisted and the crate builds. No scratch tooling, .gitignore, or stray files in the committed diff.
