### PR TITLE
De-vendor crate `nucleus-control-plane-server` ONLY (c5-vendor-neutralit…

### DIFF
--- a/crates/nucleus-control-plane-server/src/main.rs
+++ b/crates/nucleus-control-plane-server/src/main.rs
@@ -45,8 +45,8 @@ struct Cli {
     /// HTTP bind address (host:port).
     #[arg(long, default_value = "127.0.0.1:8080", env = "NUCLEUS_BIND")]
     bind: String,
-    /// gRPC bind address (host:port). Per workspace CLAUDE.md the
-    /// convention is `HTTP port + 1000`. Set to empty string to
+    /// gRPC bind address (host:port). Per workspace convention the
+    /// gRPC port is `HTTP port + 1000`. Set to empty string to
     /// disable the gRPC surface (default: 0.0.0.0:9080).
     #[arg(long, default_value = "0.0.0.0:9080", env = "NUCLEUS_GRPC_BIND")]
     grpc_bind: String,
@@ -195,8 +195,8 @@ async fn main() -> Result<()> {
         }
     };
 
-    // Register agent drivers. Real drivers (claude-code, openhands) register
-    // themselves from downstream crates — keeping nucleus vendor-neutral. The
+    // Register agent drivers. Real drivers register themselves from downstream
+    // crates via the driver registry — keeping nucleus vendor-neutral. The
     // mock driver is dev/test only; a production registry is empty and every job
     // fails closed with "unknown agent driver" until a real driver registers.
     let runners = RunnerRegistry::new();


### PR DESCRIPTION
persona certified dispatch (iter 0).

De-vendor crate `nucleus-control-plane-server` ONLY (c5-vendor-neutrality). Envelope: crates/nucleus-control-plane-server/ — the single flagged file is crates/nucleus-control-plane-server/src/main.rs. Remove the vendor name from product code by extracting it behind a neutral trait/adapter or a generic constant/config value; if it is intrinsic (e.g. an orchestrator-integration example string), add the exact path to .vendor-neutrality-allowlist with a one-line rationale instead. Touch ONLY crates/nucleus-control-plane-server/ (plus .vendor-neutrality-allowlist if you allowlist). VERIFY in-worktree: `cargo build -p nucleus-control-plane-server` stays green AND `grep -rn -iE 'claude|anthropic|openai' crates/nucleus-control-plane-server/src/` shows the name is gone or only in the allowlisted path. Do NOT run `bash ci/no-vendor-strings.sh` or any ci/ script — it is allowlist-blocked and is NOT your gate; the authoritative check runs in nucleus CI post-landing. A run is a fix if the reference is removed/allowlisted and the crate builds.
