### PR TITLE
De-vendor crate `nucleus-lineage` ONLY (c5-vendor-neutrality)

### DIFF
--- a/crates/nucleus-lineage/README.md
+++ b/crates/nucleus-lineage/README.md
@@ -29,13 +29,13 @@ external:    mock LLM (default)
 admitted pod: spiffe://demo.nucleus.local/ns/agents/sa/lineage-demo
 step 1 ✔ Bash → spiffe://…/call/cca7fa46…/tool/Bash/sha256:b534e3bf… (25 bytes)
 step 2 ✔ Write → spiffe://…/call/bde8f048…/tool/Write/sha256:b534e3bf… (/tmp/...)
-step 3a ✔ LLM prompt → spiffe://…/call/388064f0…/llm/anthropic/prompt/sha256:b534e3bf…
+step 3a ✔ LLM prompt → spiffe://…/call/388064f0…/llm/example-llm/prompt/sha256:b534e3bf…
     mock-llm: verified JWT (self-loop), sub=spiffe://…, jti=684ee954…, exp_in=300s
-step 3b ✔ LLM response → spiffe://…/call/63b43cec…/llm/anthropic/response/sha256:2a6f4cc9… (476 bytes)
+step 3b ✔ LLM response → spiffe://…/call/63b43cec…/llm/example-llm/response/sha256:2a6f4cc9… (476 bytes)
 
 done. lineage log written to ./nucleus-lineage.jsonl
 walk it with:
-  nucleus lineage 'spiffe://…/llm/anthropic/response/sha256:2a6f4cc9…' --log ./nucleus-lineage.jsonl
+  nucleus lineage 'spiffe://…/llm/example-llm/response/sha256:2a6f4cc9…' --log ./nucleus-lineage.jsonl
 ```
 
 The "mock-llm: verified JWT" line is honest about what's verified: the JWT was minted by the `LocalIssuer` and verified using the **same in-process key** the issuer mints with. This proves JWT well-formedness, not cross-trust federation. A real relying party would fetch a JWKS from a separate trust anchor — that's roadmap.
@@ -45,9 +45,9 @@ Then walk the chain back to its source:
 ```bash
 $ nucleus lineage 'spiffe://…/sha256:2a6f4cc9…' --log ./nucleus-lineage.jsonl
 lineage ↑ to spiffe://…/sha256:2a6f4cc9…
-  [llm/anthropic/response] spiffe://…/sha256:2a6f4cc9… sha256=2a6f4cc91f3d…
-    ← spiffe://…/llm/anthropic/prompt/sha256:b534e3bf…
-  [llm/anthropic/prompt]   spiffe://…/sha256:b534e3bf… sha256=b534e3bfc97b…
+  [llm/example-llm/response] spiffe://…/sha256:2a6f4cc9… sha256=2a6f4cc91f3d…
+    ← spiffe://…/llm/example-llm/prompt/sha256:b534e3bf…
+  [llm/example-llm/prompt]   spiffe://…/sha256:b534e3bf… sha256=b534e3bfc97b…
     ← spiffe://…/tool/Write/sha256:b534e3bf…
   [tool/Write]             spiffe://…/sha256:b534e3bf… sha256=b534e3bfc97b…
     ← spiffe://…/tool/Bash/sha256:b534e3bf…
@@ -75,9 +75,9 @@ The list below is what's missing today. Most items are tracked for follow-up PRs
 - **No SPIRE-backed `IdentityFetcher`.** `nucleus-identity`'s existing `spire` feature handles X.509 SVIDs only; the JWT-SVID API surface is not yet wired in. The trait is the integration point; the impl has to be written.
 - **Edges are not signed.** `LineageEdge` carries the child/parents/kind/content_hash/ts/attrs but no `Proof { kid, alg, sig }` field. Anyone with write access to the JSONL log can fabricate parent relationships — including claiming a victim pod's SPIFFE ID as the parent of an attacker artifact. The walker (`nucleus lineage`) trusts edge-claimed parents; it does not perform structural reconciliation against `CallSpiffeId::parent()`. (Tracked: add `Proof` field; sign edges; walker verifies.)
 - **`JsonlSink` is `O_APPEND`-mode, not tamper-evident.** No hash chain (`prev_hash`), no signatures, no truncation detection. The file is process-local; concurrent multi-process writes can interleave bytes. The existing `nucleus-audit` crate has the receipt-chain pattern this crate should adopt.
-- **`--real-claude` mode does not exercise SPIFFE WIF.** It uses the long-lived `ANTHROPIC_API_KEY` for wire auth and only *records* the SPIFFE ID locally. The recorded edge attributes (`audience=https://api.anthropic.com`, `jwt_jti=...`) imply that a JWT-SVID was on the wire; the JWT was not. (Tracked: rename the recorded attrs to `wire_auth=api_key, recorded_subject=...`.)
+- **`--real-llm` mode does not exercise SPIFFE WIF.** It uses the long-lived `LLM_API_TOKEN` for wire auth and only *records* the SPIFFE ID locally. The recorded edge attributes (`audience=https://api.example-llm.local`, `jwt_jti=...`) imply that a JWT-SVID was on the wire; the JWT was not. (Tracked: rename the recorded attrs to `wire_auth=api_key, recorded_subject=...`.)
 - **`CallSpiffeId::parse` accepts malformed inputs.** Currently passes: NUL bytes, RTL Unicode overrides, double slashes, uppercase `/CALL/`, query/fragment/userinfo, and several other forms forbidden by the SPIFFE ID spec. Negative tests are not yet present. (Tracked: parser hardening + negative test suite.)
-- **Anthropic-side echo-back is unidirectional and inherent.** When a JWT-SVID is presented to the Anthropic API, the `sub` claim appears in their audit log — but the response payload does not carry a SPIFFE ID we can attach to derived data. This is a property of WIF, not a fix-it-here issue.
+- **Provider-side echo-back is unidirectional and inherent.** When a JWT-SVID is presented to the LLM provider's API, the `sub` claim appears in their audit log — but the response payload does not carry a SPIFFE ID we can attach to derived data. This is a property of WIF, not a fix-it-here issue.
 - **Process-local sink only.** Cross-process / cross-host lineage requires a remote sink — straightforward extension via the trait, not yet written.
 
 **This crate binds *who called*, not *what data was in the call*.** Prompt-body taint still requires the existing portcullis IFC machinery. SPIFFE lineage and IFC labels compose; they do not replace each other.

--- a/crates/nucleus-lineage/examples/three_step_demo.rs
+++ b/crates/nucleus-lineage/examples/three_step_demo.rs
@@ -6,7 +6,7 @@
 //!      input"). Uses `Command::new("tr").stdin(...)` — never `bash -c` with
 //!      string interpolation; this is a security demo, no shell injection.
 //!   2. Write: persist a derived file from step 1's output.
-//!   3. LLM call (mock by default; `--real-claude` for live mode): sends
+//!   3. LLM call (mock by default; `--real-llm` for live mode): sends
 //!      the file content to a relying party. The mock LLM verifies the
 //!      JWT-SVID by loading the issuer's JWKS from disk (cross-process
 //!      verification, not a same-process self-loop).
@@ -19,10 +19,12 @@
 //!
 //! to walk the chain with cryptographic verification.
 //!
-//! `--real-claude` mode honestly records `wire_auth=api_key` because we
-//! don't have a registered federation issuer at Anthropic for our demo
-//! trust domain. The SPIFFE ID is recorded locally to show what a real
-//! WIF call WOULD attribute.
+//! `--real-llm` mode honestly records `wire_auth=api_key` because we
+//! don't have a registered federation issuer at the LLM provider for our
+//! demo trust domain. The SPIFFE ID is recorded locally to show what a
+//! real WIF call WOULD attribute. The real endpoint, token, and model are
+//! supplied by the operator via the `LLM_API_URL`, `LLM_API_TOKEN`, and
+//! `LLM_MODEL` environment variables — nucleus stays vendor-agnostic.
 
 use std::env;
 use std::path::PathBuf;
@@ -39,10 +41,10 @@ const POD_NAMESPACE: &str = "agents";
 const POD_SA: &str = "lineage-demo";
 
 const MOCK_LLM_AUDIENCE: &str = "https://mock-llm.local/api";
-const REAL_CLAUDE_AUDIENCE: &str = "https://api.anthropic.com";
+const DEFAULT_LLM_AUDIENCE: &str = "https://api.example-llm.local";
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let real_claude = env::args().any(|a| a == "--real-claude");
+    let real_llm = env::args().any(|a| a == "--real-llm");
     let log_path = env::args()
         .skip_while(|a| a != "--log")
         .nth(1)
@@ -59,8 +61,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("jwks:        {}", jwks_path.display());
     println!(
         "external:    {}",
-        if real_claude {
-            "real Claude API (--real-claude; uses ANTHROPIC_API_KEY for wire auth)"
+        if real_llm {
+            "real LLM API (--real-llm; uses LLM_API_TOKEN for wire auth)"
         } else {
             "mock LLM (default; verifies JWT-SVID against on-disk JWKS)"
         }
@@ -161,10 +163,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("step 2 ✔ Write → {} ({})", write_id, tmp.display());
 
     // ── Step 3: LLM call ──────────────────────────────────────────────
+    // Provider label + audience are operator-supplied so nucleus stays
+    // vendor-agnostic (the orchestrator layer owns vendor specifics).
+    let provider = env::var("LLM_PROVIDER").unwrap_or_else(|_| "example-llm".to_string());
+    let real_llm_audience =
+        env::var("LLM_API_URL").unwrap_or_else(|_| DEFAULT_LLM_AUDIENCE.to_string());
     let prompt_bytes = std::fs::read(&tmp)?;
-    let prompt_id = write_id.derive_llm("anthropic", "prompt", &prompt_bytes)?;
-    let aud = if real_claude {
-        REAL_CLAUDE_AUDIENCE
+    let prompt_id = write_id.derive_llm(&provider, "prompt", &prompt_bytes)?;
+    let aud: &str = if real_llm {
+        real_llm_audience.as_str()
     } else {
         MOCK_LLM_AUDIENCE
     };
@@ -175,15 +182,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         prompt_id.clone(),
         write_id.clone(),
         EdgeKind::LlmCall {
-            provider: "anthropic".to_string(),
+            provider: provider.clone(),
             direction: "prompt".to_string(),
         },
     )
     .with_content_hash(prompt_id.content_hash_hex().unwrap_or_default());
-    if real_claude {
+    if real_llm {
         // The actual wire auth is the API key; the JWT-SVID is recorded but
-        // NOT presented to Anthropic (no federation rule registered for our
-        // demo trust domain). Audit reflects this.
+        // NOT presented to the provider (no federation rule registered for
+        // our demo trust domain). Audit reflects this.
         prompt_edge = prompt_edge
             .with_attr("wire_auth", "api_key")
             .with_attr("audience_intended", aud.to_string())
@@ -198,18 +205,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     emit_signed(prompt_edge)?;
     println!("step 3a ✔ LLM prompt → {}", prompt_id);
 
-    let response_bytes = if real_claude {
-        call_real_claude(&prompt_bytes)?
+    let response_bytes = if real_llm {
+        call_real_llm(&prompt_bytes)?
     } else {
         call_mock_llm_via_jwks(&prompt_bytes, &prompt_jwt, &jwks_path)?
     };
-    let response_id = prompt_id.derive_llm("anthropic", "response", &response_bytes)?;
+    let response_id = prompt_id.derive_llm(&provider, "response", &response_bytes)?;
     emit_signed(
         LineageEdge::from_parent(
             response_id.clone(),
             prompt_id.clone(),
             EdgeKind::LlmCall {
-                provider: "anthropic".to_string(),
+                provider: provider.clone(),
                 direction: "response".to_string(),
             },
         )
@@ -281,35 +288,40 @@ fn call_mock_llm_via_jwks(
     .into_bytes())
 }
 
-/// Real Claude API call. Uses ANTHROPIC_API_KEY for auth — the JWT-SVID is
-/// recorded in the audit log but NOT presented to Anthropic, since we don't
-/// have a registered federation issuer in the Claude Console for our demo
-/// SPIFFE trust domain. The audit `prompt` edge for `--real-claude` records
+/// Real LLM API call. Uses `LLM_API_TOKEN` for auth — the JWT-SVID is
+/// recorded in the audit log but NOT presented to the provider, since we
+/// don't have a registered federation issuer for our demo SPIFFE trust
+/// domain. The audit `prompt` edge for `--real-llm` records
 /// `wire_auth=api_key` to be honest about what was actually on the wire.
-fn call_real_claude(prompt: &[u8]) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
-    let api_key = env::var("ANTHROPIC_API_KEY")
-        .map_err(|_| "ANTHROPIC_API_KEY must be set for --real-claude mode")?;
+///
+/// The endpoint (`LLM_API_URL`), bearer token (`LLM_API_TOKEN`), and model
+/// name (`LLM_MODEL`) are all operator-supplied — nucleus makes no vendor
+/// assumptions. The response is read from either a `content[0].text` or a
+/// `choices[0].message.content` shape, falling back to the raw JSON body.
+fn call_real_llm(prompt: &[u8]) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    let api_key =
+        env::var("LLM_API_TOKEN").map_err(|_| "LLM_API_TOKEN must be set for --real-llm mode")?;
+    let url = env::var("LLM_API_URL").map_err(|_| "LLM_API_URL must be set for --real-llm mode")?;
+    let model = env::var("LLM_MODEL").unwrap_or_else(|_| "default".to_string());
     let body = serde_json::json!({
-        "model": "claude-sonnet-4-6",
+        "model": model,
         "max_tokens": 64,
         "messages": [{
             "role": "user",
             "content": String::from_utf8_lossy(prompt).into_owned(),
         }],
     });
-    let resp = ureq::post("https://api.anthropic.com/v1/messages")
-        .header("x-api-key", &api_key)
-        .header("anthropic-version", "2023-06-01")
+    let resp = ureq::post(&url)
+        .header("authorization", &format!("Bearer {api_key}"))
         .header("content-type", "application/json")
         .send_json(&body)?;
     let body: serde_json::Value = resp.into_body().read_json()?;
     let text = body
-        .get("content")
-        .and_then(|c| c.get(0))
-        .and_then(|c| c.get("text"))
+        .pointer("/content/0/text")
+        .or_else(|| body.pointer("/choices/0/message/content"))
         .and_then(|t| t.as_str())
-        .unwrap_or("(no text in response)")
-        .to_string();
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| body.to_string());
     Ok(text.into_bytes())
 }
 

--- a/crates/nucleus-lineage/src/edge.rs
+++ b/crates/nucleus-lineage/src/edge.rs
@@ -629,18 +629,18 @@ mod tests {
     #[test]
     fn llm_call_edge_carries_provider_and_direction() {
         let p = pod();
-        let prompt = p.derive_llm("anthropic", "prompt", b"hi").unwrap();
+        let prompt = p.derive_llm("example-llm", "prompt", b"hi").unwrap();
         let edge = LineageEdge::from_parent(
             prompt,
             p,
             EdgeKind::LlmCall {
-                provider: "anthropic".to_string(),
+                provider: "example-llm".to_string(),
                 direction: "prompt".to_string(),
             },
         );
         let json = serde_json::to_string(&edge).unwrap();
         assert!(json.contains("\"kind\":\"llm_call\""));
-        assert!(json.contains("\"provider\":\"anthropic\""));
+        assert!(json.contains("\"provider\":\"example-llm\""));
         assert!(json.contains("\"direction\":\"prompt\""));
     }
 

--- a/crates/nucleus-lineage/src/id.rs
+++ b/crates/nucleus-lineage/src/id.rs
@@ -469,11 +469,11 @@ mod tests {
     #[test]
     fn derive_llm_always_content_addressed() {
         let p = pod();
-        let prompt = p.derive_llm("anthropic", "prompt", b"hi claude").unwrap();
-        assert!(prompt.as_str().contains("/llm/anthropic/prompt/sha256:"));
+        let prompt = p.derive_llm("example-llm", "prompt", b"hi agent").unwrap();
+        assert!(prompt.as_str().contains("/llm/example-llm/prompt/sha256:"));
         assert_eq!(
             prompt.content_hash_hex().unwrap(),
-            hex_lower(&sha256(b"hi claude"))
+            hex_lower(&sha256(b"hi agent"))
         );
     }
 
@@ -809,9 +809,9 @@ mod tests {
         let id = pod()
             .derive_tool("Bash", Some(b"x"))
             .unwrap()
-            .derive_llm("anthropic", "prompt", b"hi")
+            .derive_llm("example-llm", "prompt", b"hi")
             .unwrap()
-            .derive_llm("anthropic", "response", b"reply")
+            .derive_llm("example-llm", "response", b"reply")
             .unwrap();
         // Round-trip through parse to verify the canonical string is also
         // accepted by the hardened parser.

--- a/crates/nucleus-lineage/src/local_issuer.rs
+++ b/crates/nucleus-lineage/src/local_issuer.rs
@@ -226,17 +226,17 @@ mod tests {
         let issuer = LocalIssuer::random().unwrap();
         let p = pod();
         let token = issuer
-            .fetch_jwt_svid(&p, "https://api.anthropic.com")
+            .fetch_jwt_svid(&p, "https://api.example-llm.local")
             .unwrap();
         assert_eq!(token.matches('.').count(), 2);
 
         let mut validation = Validation::new(Algorithm::EdDSA);
-        validation.set_audience(&["https://api.anthropic.com"]);
+        validation.set_audience(&["https://api.example-llm.local"]);
         validation.set_issuer(&[issuer.issuer()]);
         let decoded = decode::<SvidClaims>(&token, &issuer.decoding_key(), &validation).unwrap();
 
         assert_eq!(decoded.claims.sub, p.to_string());
-        assert_eq!(decoded.claims.aud, "https://api.anthropic.com");
+        assert_eq!(decoded.claims.aud, "https://api.example-llm.local");
         assert_eq!(decoded.claims.iss, issuer.issuer());
         assert!(decoded.claims.exp > decoded.claims.iat);
         assert!(!decoded.claims.jti.is_empty());


### PR DESCRIPTION
persona certified dispatch (iter 0).

De-vendor crate `nucleus-lineage` ONLY (c5-vendor-neutrality). Envelope: crates/nucleus-lineage/ — the 4 flagged files are examples/three_step_demo.rs, src/edge.rs, src/id.rs, src/local_issuer.rs. For each vendor name in product code: rename to a neutral constant / extract behind a neutral trait or adapter (follow the established RENAME/EXTRACT pattern), OR add the path to .vendor-neutrality-allowlist with a one-line rationale if the reference is legitimately test-only/inherent. Touch ONLY crates/nucleus-lineage/ (plus a single line in .vendor-neutrality-allowlist if used). VERIFY in-worktree: `cargo build -p nucleus-lineage` stays green AND `grep -rn <vendor> crates/nucleus-lineage/` shows the name is gone or only in an allowlisted path. Do NOT run `bash ci/no-vendor` or any ci/ script — it is NOT in the worktree and NOT your gate; the authoritative check runs in nucleus CI post-landing. A run is a fix if the vendor reference is removed/allowlisted and the crate builds — do not block on or claim failure for a gate you cannot execute here.
