### PR TITLE
De-vendor crate `nucleus-control-plane` ONLY (c5-vendor-neutrality)

### DIFF
--- a/crates/nucleus-control-plane/src/lib.rs
+++ b/crates/nucleus-control-plane/src/lib.rs
@@ -8,8 +8,8 @@
 //!
 //! # Vendor neutrality
 //!
-//! `JobRunner` is a trait — every concrete agent integration (Claude
-//! Code, OpenHands, Goose, …) lives outside this crate as a separate
+//! `JobRunner` is a trait — every concrete agent integration (a CLI-agent
+//! adapter, OpenHands, Goose, …) lives outside this crate as a separate
 //! implementation. The orchestrator core knows only: "run agent X,
 //! collect lineage Y, package result Z." It does not know which LLM
 //! is doing the work, what its API costs, or how its credentials are

--- a/crates/nucleus-control-plane/src/runner.rs
+++ b/crates/nucleus-control-plane/src/runner.rs
@@ -5,8 +5,8 @@
 //! agent does that should appear in the provenance envelope MUST be
 //! emitted as a [`LineageEdge`] through the writer.
 //!
-//! Concrete drivers (claude-code, openhands, …) live OUTSIDE this crate
-//! to keep nucleus vendor-neutral. The mock driver lives here because
+//! Concrete drivers (CLI-agent adapters, openhands, …) live OUTSIDE this
+//! crate to keep nucleus vendor-neutral. The mock driver lives here because
 //! it's part of the orchestrator's test surface, not a vendor adapter.
 
 use nucleus_lineage::{CallSpiffeId, EdgeKind, LineageEdge};

--- a/crates/nucleus-control-plane/src/spec.rs
+++ b/crates/nucleus-control-plane/src/spec.rs
@@ -23,7 +23,7 @@ pub struct JobSpec {
     /// (e.g. "codegen", "review", "report-extraction").
     pub policy_profile: String,
     /// Which agent driver to run. Indirected to keep nucleus
-    /// vendor-neutral; the actual Claude/OpenAI/etc. adapters live
+    /// vendor-neutral; the actual vendor adapters live
     /// outside this crate.
     pub agent_driver: AgentDriverRef,
 }
@@ -65,7 +65,7 @@ pub enum Destination {
 /// vendor SDKs.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentDriverRef {
-    /// Driver identifier (e.g. "mock", "claude-code", "openhands"). The
+    /// Driver identifier (e.g. "mock", "cli-agent", "openhands"). The
     /// orchestrator looks this up against a registry of available
     /// [`crate::runner::JobRunner`] implementations.
     pub name: String,


### PR DESCRIPTION
persona certified dispatch (iter 0).

De-vendor crate `nucleus-control-plane` ONLY (c5-vendor-neutrality). Envelope: crates/nucleus-control-plane/ — the 3 flagged files are src/lib.rs, src/runner.rs, src/spec.rs. For each vendor mention: if it is product behavior, extract behind a neutral trait/adapter or rename to a neutral constant; if it is an unavoidable interop string (external tool/protocol name), add the specific path to .vendor-neutrality-allowlist with a one-line rationale. Touch ONLY crates/nucleus-control-plane/ (plus the allowlist line if used). VERIFY in-worktree: `cargo build -p nucleus-control-plane` stays green AND `grep -rn -iE 'claude|anthropic' crates/nucleus-control-plane/src/` shows the name is gone or only in an allowlisted path. Do NOT run `bash ci/no-vendor*` or any ci/ script — it is not your gate; the authoritative check runs in nucleus CI post-landing. A run is a fix if the reference is removed/allowlisted and the crate builds.
