### PR TITLE
De-vendor crate `exposure-playground` ONLY (c5-vendor-neutrality)

### DIFF
--- a/crates/exposure-playground/src/ui/delegation_forest.rs
+++ b/crates/exposure-playground/src/ui/delegation_forest.rs
@@ -179,7 +179,7 @@ fn draw_comparison_sidebar(f: &mut Frame, area: Rect) {
         .borders(Borders::ALL)
         .title(" Model Comparison ");
 
-    // Vendor-neutral comparison (this is in nucleus, no Anthropic references)
+    // Vendor-neutral comparison (this is in nucleus, no LLM-vendor references)
     let lines = vec![
         Line::from(Span::styled(
             "╔═══════════════════╗",


### PR DESCRIPTION
persona certified dispatch (iter 0).

De-vendor crate `exposure-playground` ONLY (c5-vendor-neutrality). Envelope: crates/exposure-playground/ — the single flagged file is crates/exposure-playground/src/ui/delegation_forest.rs. Remove/neutralize the vendor name: rename the identifier/string to a neutral term (per CLAUDE.md: 'LLM'/'AI agent'/generic work-type names), or if the reference is load-bearing for a UI label, extract it behind a neutral constant. If genuinely unavoidable, add the path to .vendor-neutrality-allowlist with a one-line rationale. VERIFY in-worktree: `cargo build -p exposure-playground` stays green, and `grep -rni <vendor> crates/exposure-playground/` shows the name is gone (or only in the allowlisted path). Do NOT run any ci/ script — the authoritative no-vendor gate runs in nucleus CI post-landing. Touch ONLY crates/exposure-playground/.
