### PR TITLE
De-vendor crate `nucleus-verifier-service` ONLY (c5-vendor-neutrality)

### DIFF
--- a/crates/nucleus-verifier-service/fly.toml
+++ b/crates/nucleus-verifier-service/fly.toml
@@ -4,7 +4,7 @@
 # verification report. Now also persists every result + maintains the
 # append-only transparency log (#69) and serves a signed STH (#94).
 #
-# Per workspace CLAUDE.md conventions:
+# Per workspace guidelines:
 #   - HTTPS on the edge (Fly handles TLS termination)
 #   - min_machines_running = 1 so the public endpoint is always warm
 #   - Persistent volume mounted at /data for sqlite + chain head

--- a/crates/nucleus-verifier-service/src/routes.rs
+++ b/crates/nucleus-verifier-service/src/routes.rs
@@ -46,8 +46,8 @@ const WASM_JS_SHIM: &str = include_str!("../../../sdks/verifier-js/pkg/nucleus_v
 const WASM_BINARY: &[u8] =
     include_bytes!("../../../sdks/verifier-js/pkg/nucleus_verifier_wasm_bg.wasm");
 
-/// Strict CSP for the landing page. No `unsafe-inline` per project
-/// CLAUDE.md — only same-origin resources, no remote scripts/styles,
+/// Strict CSP for the landing page. No `unsafe-inline` per the project
+/// guidelines — only same-origin resources, no remote scripts/styles,
 /// no inline JS.
 const LANDING_CSP: &str = "default-src 'self'; \
                            script-src 'self'; \


### PR DESCRIPTION
persona certified dispatch (iter 0).

De-vendor crate `nucleus-verifier-service` ONLY (c5-vendor-neutrality). Envelope: crates/nucleus-verifier-service/ — single flagged file is src/routes.rs. Remove or neutralize the vendor name IN the source (rename constants/strings/comments to neutral terms like 'LLM'/'AI agent'/generic identifiers, or extract behind a neutral trait). Do NOT edit .vendor-neutrality-allowlist or any file outside the envelope — the recent portcullis run was REJECTED for touching .vendor-neutrality-allowlist (receipt_ok=false, unauthorized path). Touch ONLY files under crates/nucleus-verifier-service/. VERIFY: `cargo build -p nucleus-verifier-service` stays green AND `grep -rn -iE 'anthropic|claude|openai' crates/nucleus-verifier-service/` returns nothing. Do NOT run any ci/ script — it is not your gate and not in the worktree.
