### PR TITLE
De-vendor crate `portcullis-core` ONLY (c5-vendor-neutrality)

### DIFF
--- a/crates/portcullis-core/examples/cve_defenses.rs
+++ b/crates/portcullis-core/examples/cve_defenses.rs
@@ -16,8 +16,8 @@ fn main() {
     let mut total = 0;
 
     // ═══════════════════════════════════════════════════════════════════
-    // CVE-2025-32711 — EchoLeak: Copilot zero-click exfiltration
-    // CVSS 9.3 — PowerPoint speaker notes exfiltrate email/Teams/OneDrive
+    // CVE-2025-32711 — EchoLeak: enterprise AI assistant zero-click exfiltration
+    // CVSS 9.3 — presentation speaker notes exfiltrate email/chat/file-store data
     // ═══════════════════════════════════════════════════════════════════
     total += 1;
     {
@@ -31,13 +31,13 @@ fn main() {
         assert_eq!(decision, Verdict::Deny);
         assert_eq!(contradiction, Verdict::Conflict);
         passed += 1;
-        println!("  [BLOCKED] CVE-2025-32711 EchoLeak (Copilot zero-click)");
+        println!("  [BLOCKED] CVE-2025-32711 EchoLeak (enterprise assistant zero-click)");
         println!("           truth_meet(ExternalDoc, InternalData) = DENY");
         println!("           info_join detects CONFLICT — two trust levels disagree\n");
     }
 
     // ═══════════════════════════════════════════════════════════════════
-    // CVE-2025-53773 — GitHub Copilot YOLO mode RCE
+    // CVE-2025-53773 — AI coding assistant YOLO mode RCE
     // Prompt injection enables auto-approve, then executes shell commands
     // ═══════════════════════════════════════════════════════════════════
     total += 1;
@@ -53,14 +53,14 @@ fn main() {
         assert_eq!(write_decision, Verdict::Deny);
         assert_eq!(exec_decision, Verdict::Deny);
         passed += 1;
-        println!("  [BLOCKED] CVE-2025-53773 Copilot YOLO RCE");
+        println!("  [BLOCKED] CVE-2025-53773 AI coding assistant YOLO RCE");
         println!("           truth_meet(UntrustedInput, ConfigWrite) = DENY");
         println!("           Agent cannot modify its own security config\n");
     }
 
     // ═══════════════════════════════════════════════════════════════════
-    // CVE-2025-59536 / CVE-2026-21852 — Claude Code hook RCE + API key theft
-    // Malicious .claude/settings.json executes hooks before trust dialog
+    // CVE-2025-59536 / CVE-2026-21852 — coding-agent CLI hook RCE + API key theft
+    // Malicious repo-supplied agent settings.json executes hooks before trust dialog
     // ═══════════════════════════════════════════════════════════════════
     total += 1;
     {
@@ -73,7 +73,7 @@ fn main() {
         assert_eq!(decision, Verdict::Unknown); // requires approval before proceeding
         assert!(!decision.is_allow());
         passed += 1;
-        println!("  [BLOCKED] CVE-2025-59536 Claude Code hook RCE");
+        println!("  [BLOCKED] CVE-2025-59536 coding-agent CLI hook RCE");
         println!("           truth_meet(RepoConfig, ExecuteHook) = UNKNOWN");
         println!("           Unapproved config cannot trigger execution\n");
     }
@@ -137,7 +137,7 @@ fn main() {
     }
 
     // ═══════════════════════════════════════════════════════════════════
-    // GitHub MCP prompt injection via public Issues (May 2025)
+    // Hosted-repo MCP prompt injection via public Issues (May 2025)
     // Issue content exfiltrates private repo source and keys
     // ═══════════════════════════════════════════════════════════════════
     total += 1;
@@ -149,13 +149,13 @@ fn main() {
 
         assert_eq!(decision, Verdict::Deny);
         passed += 1;
-        println!("  [BLOCKED] GitHub MCP Issue injection");
+        println!("  [BLOCKED] Hosted-repo MCP Issue injection");
         println!("           truth_meet(PublicIssue, PrivateRepos) = DENY");
         println!("           Public issue content cannot access private repos\n");
     }
 
     // ═══════════════════════════════════════════════════════════════════
-    // Google Gemini calendar invite attack (Black Hat 2025)
+    // Consumer AI assistant calendar invite attack (Black Hat 2025)
     // Hidden injection in calendar events controls smart home + email
     // ═══════════════════════════════════════════════════════════════════
     total += 1;
@@ -170,7 +170,7 @@ fn main() {
         assert_eq!(home_decision, Verdict::Deny);
         assert_eq!(email_decision, Verdict::Deny);
         passed += 1;
-        println!("  [BLOCKED] Gemini calendar invite attack (Black Hat 2025)");
+        println!("  [BLOCKED] Consumer AI assistant calendar invite attack (Black Hat 2025)");
         println!("           truth_meet(CalendarEvent, SmartHome) = DENY");
         println!("           External invite cannot control smart home or read email\n");
     }

--- a/crates/portcullis-core/lean/CompartmentProofs.lean
+++ b/crates/portcullis-core/lean/CompartmentProofs.lean
@@ -5,7 +5,7 @@ import PortcullisCoreBridge
 # Compartment Ceiling Proofs
 
 Proves properties of the compartment capability ceilings used by
-the nucleus-claude-hook for research/draft/execute/breakglass modes.
+the nucleus hook adapter for research/draft/execute/breakglass modes.
 
 ## What's proved
 

--- a/crates/portcullis-core/src/autonomy.rs
+++ b/crates/portcullis-core/src/autonomy.rs
@@ -13,7 +13,7 @@
 //! - **Confused deputy**: The ceiling prevents destructive operations
 //!   (delete, destroy) from being auto-approved even if the user trusts
 //!   the agent.
-//! - **Trust ratchet**: ~40% of Claude Code users reach full auto-approve
+//! - **Trust ratchet**: ~40% of agentic-CLI users reach full auto-approve
 //!   by 750 sessions. The ceiling bounds the maximum damage.
 //!
 //! ## How it works

--- a/crates/portcullis-core/src/prov_export.rs
+++ b/crates/portcullis-core/src/prov_export.rs
@@ -14,7 +14,7 @@ use crate::flow::NodeKind;
 use crate::{AuthorityLevel, DerivationClass, IntegLevel};
 use std::collections::BTreeMap;
 
-/// Convert a u8 discriminant to NodeKind (matching nucleus-claude-hook's encoding).
+/// Convert a u8 discriminant to NodeKind (matching the hook adapter's encoding).
 fn u8_to_node_kind(v: u8) -> NodeKind {
     match v {
         0 => NodeKind::UserPrompt,

--- a/crates/portcullis-core/src/witness.rs
+++ b/crates/portcullis-core/src/witness.rs
@@ -252,7 +252,7 @@ pub struct AiDerivedWitness {
     /// Allows auditors to verify what the model actually read.
     pub input_context_hash: [u8; 32],
     /// Vendor-agnostic model identifier string.
-    /// e.g., "gpt-4o-2024-05-13" or "llm-v2.1" — just a label.
+    /// e.g., "model-x-2024-05-13" or "llm-v2.1" — just a label.
     pub model_id: String,
     /// Number of independent generations used for consistency check.
     /// 1 = single generation (no consistency check performed).


### PR DESCRIPTION
persona certified dispatch (iter 0).

De-vendor crate `portcullis-core` ONLY (c5-vendor-neutrality). Envelope: crates/portcullis-core/ — 3 flagged files: examples/cve_defenses.rs, src/autonomy.rs, src/prov_export.rs. For each vendor reference, EXTRACT the name behind a neutral constant/trait/adapter or rename to a work-type/generic term IN-CODE. CRITICAL — do NOT modify .vendor-neutrality-allowlist or any file outside crates/portcullis-core/: the last three de-vendor runs (nucleus-audit, portcullis) were REJECTED with receipt_ok=false, unauthorized=[".vendor-neutrality-allowlist"] precisely because they touched that out-of-envelope file. Solve it in-code within the crate instead. VERIFY in the worktree: `cargo build -p portcullis-core` stays green AND `grep -rn <vendor> crates/portcullis-core/` shows the name is gone. Do NOT run any ci/ script — it is not your gate and not present in the worktree; the authoritative no-vendor check runs in nucleus CI post-landing. Touch ONLY files under crates/portcullis-core/.
