### PR TITLE
De-vendor crate `ctf-mcp` ONLY (c5-vendor-neutrality)

### DIFF
--- a/crates/ctf-mcp/src/main.rs
+++ b/crates/ctf-mcp/src/main.rs
@@ -1,7 +1,7 @@
 //! MCP server for The Vault CTF.
 //!
-//! Exposes the CTF engine as MCP tools so any AI agent (ChatGPT, Claude,
-//! Gemini, etc.) can play the security challenge via the Model Context
+//! Exposes the CTF engine as MCP tools so any AI agent (LLM-based or
+//! otherwise) can play the security challenge via the Model Context
 //! Protocol.
 //!
 //! Tools:
@@ -62,7 +62,7 @@ struct ToolCallParam {
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 struct ChallengeParams {
-    #[schemars(description = "Who is playing (e.g. 'chatgpt-4o', 'claude-opus', 'human')")]
+    #[schemars(description = "Who is playing (e.g. 'llm-agent', 'ai-model', 'human')")]
     player: String,
     #[schemars(
         description = "Array of attacks, one per level. Each: {\"level\": 5, \"tool_calls\": [...]}"


### PR DESCRIPTION
persona certified dispatch (iter 0).

De-vendor crate `ctf-mcp` ONLY (c5-vendor-neutrality). Envelope: crates/ctf-mcp/ — single flagged file crates/ctf-mcp/src/main.rs. Neutralize the vendor name IN CODE via the neutral-constant RENAME/EXTRACT pattern (replace the literal with a generic term like 'LLM'/'AI agent', or hoist behind a neutral const/trait). Do NOT modify .vendor-neutrality-allowlist — every recent run that touched that file was Rejected (receipt_ok=false, unauthorized=[".vendor-neutrality-allowlist"]); stay entirely within crates/ctf-mcp/. Touch ONLY crates/ctf-mcp/. VERIFY in-worktree: `cargo build -p ctf-mcp` stays green AND `grep -rn <vendor> crates/ctf-mcp/` shows the name is gone. Do NOT run any ci/ script — the authoritative no-vendor gate runs in nucleus CI post-landing, not here; do not block on or claim failure for a gate you cannot execute.
