### PR TITLE
De-vendor crate `ctf-engine` ONLY (c5-vendor-neutrality)

### DIFF
--- a/crates/ctf-engine/src/level.rs
+++ b/crates/ctf-engine/src/level.rs
@@ -86,7 +86,7 @@ impl Level {
     /// Construct an agent-safe variant of a level.
     ///
     /// Identical lattice logic but with sanitized filesystem content that
-    /// won't trigger host safety layers (OpenAI content filters, etc.).
+    /// won't trigger host safety layers (LLM provider content filters, etc.).
     pub fn new_agent_safe(number: u8) -> Self {
         let mut level = Self::new(number);
         level.filesystem = Self::agent_safe_filesystem();
@@ -115,8 +115,8 @@ impl Level {
         fs.insert(
             "/vault/secrets/api-keys.json".into(),
             serde_json::json!({
-                "anthropic": "sk-ant-FAKE-CTF-KEY-do-not-use",
-                "openai": "sk-FAKE-CTF-KEY-do-not-use",
+                "llm_provider_a": "llm-api-FAKE-CTF-KEY-do-not-use",
+                "llm_provider_b": "llm-api-FAKE-CTF-KEY-2-do-not-use",
                 "github": "ghp_FAKECTFKEY000000000000000000000000"
             })
             .to_string(),
@@ -133,7 +133,7 @@ impl Level {
     }
 
     /// Agent-safe filesystem: same structure but with sanitized content
-    /// that won't trigger host safety layers (OpenAI, Claude, etc.).
+    /// that won't trigger host safety layers (LLM provider content filters, etc.).
     /// Provides both canonical paths (/vault/flag.txt) and agent-friendly
     /// aliases (/vault/mock_private.txt) so agents can use either.
     fn agent_safe_filesystem() -> BTreeMap<String, String> {
@@ -297,7 +297,7 @@ impl Level {
                 tagline: "You have bash. But every network command is caught.",
                 cve: Some("CVE-2025-43563"),
                 cve_description: Some(
-                    "Claude Code prompt injection via git commit messages. \
+                    "AI coding-agent prompt injection via git commit messages. \
                      With bash but no network, command exfil detection blocks curl/wget/nc.",
                 ),
                 available_tools: vec!["read_file", "write_file", "run_bash", "glob", "grep"],

--- a/crates/ctf-engine/src/takeaways.rs
+++ b/crates/ctf-engine/src/takeaways.rs
@@ -18,7 +18,7 @@ pub fn build_takeaways(defenses: &[String]) -> Vec<String> {
             "Command Exfil Detection: Even with bash access, the CommandLattice performs \
              sink analysis on every command before execution. curl, wget, nc, python \
              urllib — all caught. This blocks the exact attack from CVE-2025-43563 \
-             (Claude Code prompt injection via git commit messages)."
+             (AI coding-agent prompt injection via git commit messages)."
                 .into(),
         );
     }


### PR DESCRIPTION
persona certified dispatch (iter 0).

De-vendor crate `ctf-engine` ONLY (c5-vendor-neutrality). Envelope: crates/ctf-engine/ — 2 flagged source files: crates/ctf-engine/src/level.rs, crates/ctf-engine/src/takeaways.rs. For each vendor name in product code, extract it behind a neutral term/const/trait (prefer renaming to a generic 'LLM'/'AI agent' equivalent — this is CTF educational content, so the vendor name is almost certainly narrative text, not a real dependency). Do NOT touch .vendor-neutrality-allowlist (adding paths there is unauthorized for this envelope and has been rejected on prior runs — a config file outside crates/ctf-engine/). Touch ONLY files under crates/ctf-engine/. VERIFY in-worktree: `cargo build -p ctf-engine` stays green AND `grep -rin <vendor> crates/ctf-engine/` returns nothing. Do NOT run any ci/ script — the authoritative no-vendor gate runs in nucleus CI post-landing; it is not your local gate.
