### PR TITLE
De-vendor crate `nucleus-mcp` ONLY (c5-vendor-neutrality)

### DIFF
--- a/crates/nucleus-mcp/Cargo.toml
+++ b/crates/nucleus-mcp/Cargo.toml
@@ -8,7 +8,7 @@ description = "MCP server that bridges an MCP client (any AI-agent runtime) to n
 repository = "https://github.com/coproduct-opensource/nucleus"
 documentation = "https://docs.rs/nucleus-mcp"
 readme = "README.md"
-keywords = ["mcp", "claude", "tools", "security", "sandbox"]
+keywords = ["mcp", "agent", "tools", "security", "sandbox"]
 categories = ["command-line-utilities", "development-tools"]
 
 [[bin]]


### PR DESCRIPTION
persona certified dispatch (iter 0).

De-vendor crate `nucleus-mcp` ONLY (c5-vendor-neutrality). Envelope: crates/nucleus-mcp/ — single flagged file crates/nucleus-mcp/Cargo.toml names a specific vendor in product code. Remove the vendor reference (neutralize the package name/description/keyword/metadata that names the vendor), OR — if the reference is load-bearing (e.g. an unavoidable dependency crate name) — add crates/nucleus-mcp/Cargo.toml to .vendor-neutrality-allowlist with a one-line rationale. VERIFY in the worktree: `cargo build -p nucleus-mcp` stays green AND `grep -rn -iE 'claude|anthropic' crates/nucleus-mcp/` shows the name is gone (or now lives only in the allowlisted path). Do NOT run any `ci/` script — it is not in the worktree and is not your gate; the authoritative no-vendor check runs in nucleus CI post-landing. Touch ONLY crates/nucleus-mcp/ (and, if used, the top-level .vendor-neutrality-allowlist). A run is a fix if the vendor reference is removed/allowlisted and the crate builds — do not block on a gate you cannot execute here.
