### PR TITLE
De-vendor crate `nucleus-cli` ONLY (c5-vendor-neutrality)

### DIFF
--- a/crates/nucleus-cli/src/audit.rs
+++ b/crates/nucleus-cli/src/audit.rs
@@ -86,6 +86,11 @@ impl std::fmt::Display for Severity {
 // ── MCP config scanning ─────────────────────────────────────────────
 
 /// Known MCP config file locations to scan.
+///
+/// Intrinsic interop: real, non-neutralizable on-disk config paths written by
+/// external agent/editor tooling (e.g. `.claude/mcp.json`,
+/// `claude_desktop_config.json`). These are detection targets the scanner must
+/// match verbatim, not nucleus-owned names.
 const MCP_CONFIG_LOCATIONS: &[&str] = &[
     ".mcp.json",
     "mcp.json",

--- a/crates/nucleus-cli/src/constants.rs
+++ b/crates/nucleus-cli/src/constants.rs
@@ -26,6 +26,21 @@ pub const FIRECRACKER_VERSION: &str = "1.14.1";
 pub const DISALLOWED_BUILTIN_TOOLS: &str =
     "Bash,Read,Write,Edit,Glob,Grep,WebFetch,WebSearch,NotebookEdit,Agent";
 
+/// Intrinsic interop — the external agent CLI executable that nucleus wraps and
+/// launches under enforcement. This is a genuine third-party binary name looked
+/// up on the user's `PATH` (NOT a nucleus component), so it is kept verbatim as
+/// a real interop identifier rather than neutralized. Centralized here so the
+/// single source of truth is explicit; the launch sites (`run`, `shell`)
+/// reference this constant instead of hardcoding the name.
+pub const AGENT_CLI_BIN: &str = "claude";
+
+/// Intrinsic provenance — the sibling in-repo hook binary/crate name that
+/// `nucleus guard` and `nucleus run --hook` resolve and invoke
+/// (`crates/nucleus-claude-hook`). Kept verbatim because it is the real
+/// crate/binary name on disk; renaming the crate itself is out of scope for
+/// this module.
+pub const HOOK_BINARY_NAME: &str = "nucleus-claude-hook";
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/nucleus-cli/src/guard.rs
+++ b/crates/nucleus-cli/src/guard.rs
@@ -33,7 +33,7 @@ pub enum GuardCommand {
         #[arg(default_value = ".")]
         dir: String,
     },
-    /// Install nucleus-claude-hook for enforcement
+    /// Install the agent hook binary for enforcement
     Enable,
     /// Show active guard sessions and exposure state
     Status,
@@ -140,6 +140,10 @@ enum Risk {
 }
 
 fn find_mcp_configs(dir: &Path) -> Vec<PathBuf> {
+    // Intrinsic interop: real, non-neutralizable on-disk config paths written by
+    // external agent/editor tooling (e.g. `.claude/settings.json`,
+    // `claude_desktop_config.json`). These are detection targets the scanner must
+    // match verbatim, not nucleus-owned names.
     let candidates = [
         ".claude/settings.json",
         ".mcp.json",
@@ -163,7 +167,7 @@ fn extract_mcp_servers(content: &str) -> Vec<(String, serde_json::Value)> {
         return servers;
     };
 
-    // Check mcpServers (Claude Code / MCP config format)
+    // Check mcpServers (agent / MCP config format)
     if let Some(mcp) = json.get("mcpServers").and_then(|v| v.as_object()) {
         for (name, config) in mcp {
             servers.push((name.clone(), config.clone()));
@@ -233,6 +237,8 @@ fn assess_server_risk(name: &str, config: &serde_json::Value) -> Risk {
 }
 
 fn is_known_safe_package(pkg: &str) -> bool {
+    // Intrinsic interop: real npm scopes/package names published by third
+    // parties, matched verbatim as an allowlist of vetted MCP packages.
     let safe = [
         "@anthropic-ai/",
         "@modelcontextprotocol/",
@@ -394,7 +400,12 @@ fn enable() -> Result<()> {
     let output = std::process::Command::new(&hook_bin)
         .arg("--setup")
         .output()
-        .context("failed to run nucleus-claude-hook --setup")?;
+        .with_context(|| {
+            format!(
+                "failed to run {} --setup",
+                crate::constants::HOOK_BINARY_NAME
+            )
+        })?;
 
     if output.status.success() {
         println!("  Status: enabled");
@@ -420,7 +431,7 @@ fn which_hook() -> Result<PathBuf> {
     // Check same directory as nucleus binary
     if let Ok(exe) = std::env::current_exe() {
         if let Some(dir) = exe.parent() {
-            let sibling = dir.join("nucleus-claude-hook");
+            let sibling = dir.join(crate::constants::HOOK_BINARY_NAME);
             if sibling.exists() {
                 return Ok(sibling);
             }
@@ -429,7 +440,7 @@ fn which_hook() -> Result<PathBuf> {
 
     // Check PATH
     if let Ok(output) = std::process::Command::new("which")
-        .arg("nucleus-claude-hook")
+        .arg(crate::constants::HOOK_BINARY_NAME)
         .output()
     {
         if output.status.success() {
@@ -441,8 +452,8 @@ fn which_hook() -> Result<PathBuf> {
     }
 
     anyhow::bail!(
-        "nucleus-claude-hook not found. Install with:\n  \
-         cargo install --path crates/nucleus-claude-hook"
+        "{name} not found. Install with:\n  cargo install --path crates/{name}",
+        name = crate::constants::HOOK_BINARY_NAME,
     )
 }
 

--- a/crates/nucleus-cli/src/main.rs
+++ b/crates/nucleus-cli/src/main.rs
@@ -1,6 +1,6 @@
 //! Nucleus CLI - Run AI agents with policy-aware defaults
 //!
-//! `nucleus-cli` runs Claude with MCP + nucleus-tool-proxy for tool enforcement.
+//! `nucleus-cli` runs an agent CLI with MCP + nucleus-tool-proxy for tool enforcement.
 //! Use `nucleus-node` (Firecracker) for all execution.
 //!
 //! # Examples
@@ -78,7 +78,7 @@ enum Commands {
     /// Execute a task with enforced permissions
     Run(Box<run::RunArgs>),
 
-    /// Launch interactive Claude Code with nucleus security context
+    /// Launch an interactive agent session with nucleus security context
     Shell(shell::ShellArgs),
 
     /// Set up nucleus environment (Lima VM, artifacts, secrets)

--- a/crates/nucleus-cli/src/run.rs
+++ b/crates/nucleus-cli/src/run.rs
@@ -137,7 +137,9 @@ pub struct RunArgs {
     #[arg(long, default_value = "3600")]
     pub timeout: u64,
 
-    /// Claude model to use
+    /// Model identifier to pass to the agent CLI.
+    // Intrinsic interop: the default is a real, non-neutralizable model id
+    // consumed verbatim by the external agent binary's `--model` flag.
     #[arg(long, default_value = "claude-sonnet-4-20250514")]
     pub model: String,
 
@@ -154,8 +156,8 @@ pub struct RunArgs {
     #[arg(long)]
     pub local: bool,
 
-    /// Run with Claude Code hook enforcement (lightest weight).
-    /// Uses nucleus-claude-hook as a PreToolUse hook — no tool-proxy or MCP
+    /// Run with agent-hook enforcement (lightest weight).
+    /// Uses the sibling hook binary as a PreToolUse hook — no tool-proxy or MCP
     /// server needed. Provides IFC flow labels, exposure tracking, and
     /// capability gating with zero infrastructure.
     #[arg(long)]
@@ -382,10 +384,10 @@ impl Drop for TmpDirGuard {
     }
 }
 
-/// Run with Claude Code hook enforcement (lightest weight).
+/// Run with agent-hook enforcement (lightest weight).
 ///
-/// Writes a temporary settings.json that registers nucleus-claude-hook as
-/// the PreToolUse hook, then runs claude with that config. No tool-proxy
+/// Writes a temporary settings.json that registers the sibling hook binary as
+/// the PreToolUse hook, then runs the agent CLI with that config. No tool-proxy
 /// or MCP server needed — the hook intercepts every tool call and runs it
 /// through the portcullis kernel with IFC flow labels.
 async fn run_hook(
@@ -400,11 +402,11 @@ async fn run_hook(
     let _tmp_guard = TmpDirGuard::new(tmp_dir.clone());
 
     // Resolve hook binary
-    let hook_bin = resolve_binary_path("nucleus-claude-hook")?;
+    let hook_bin = resolve_binary_path(crate::constants::HOOK_BINARY_NAME)?;
     if !hook_bin.exists() {
         bail!(
-            "nucleus-claude-hook not found at {:?}. Install with: cargo install --path crates/nucleus-claude-hook",
-            hook_bin
+            "{name} not found at {hook_bin:?}. Install with: cargo install --path crates/{name}",
+            name = crate::constants::HOOK_BINARY_NAME,
         );
     }
 
@@ -424,12 +426,12 @@ async fn run_hook(
     info!(
         hook_bin = %hook_bin.display(),
         profile = %profile_name,
-        "Running Claude with nucleus-claude-hook enforcement"
+        "Running agent CLI under nucleus hook enforcement"
     );
 
     let start = Instant::now();
 
-    let mut cmd = Command::new("claude");
+    let mut cmd = Command::new(crate::constants::AGENT_CLI_BIN);
     cmd.arg("--print")
         .arg("--model")
         .arg(&args.model)
@@ -441,7 +443,9 @@ async fn run_hook(
         .current_dir(work_dir)
         .env("NUCLEUS_PROFILE", profile_name);
 
-    let output = cmd.output().context("failed to spawn claude")?;
+    let output = cmd
+        .output()
+        .with_context(|| format!("failed to spawn {}", crate::constants::AGENT_CLI_BIN))?;
     let duration = start.elapsed();
 
     render_output(&output, duration, args.output.as_str())
@@ -522,7 +526,7 @@ async fn run_local(
 
     info!(proxy_url = %proxy_url, "Tool-proxy ready");
 
-    // Build MCP config and spawn Claude
+    // Build MCP config and spawn the agent CLI
     let mcp_config_path = tmp_dir.join("mcp.json");
     let mcp_command_path = resolve_binary_path(&args.mcp_path)?;
 
@@ -553,11 +557,11 @@ async fn run_local(
     info!(
         allowed_tools = %allowed_tools.join(","),
         model = %args.model,
-        "Spawning Claude Code (local enforced mode)"
+        "Spawning agent CLI (local enforced mode)"
     );
 
     let start = Instant::now();
-    let output = run_claude_mcp(
+    let output = run_agent_mcp(
         args,
         policy,
         &mcp_config_path,
@@ -701,11 +705,11 @@ async fn run_enforced(
     info!(
         allowed_tools = %allowed_tools.join(","),
         model = %args.model,
-        "Spawning Claude Code (enforced MCP mode)"
+        "Spawning agent CLI (enforced MCP mode)"
     );
 
     let start = Instant::now();
-    let output = match run_claude_mcp(
+    let output = match run_agent_mcp(
         args,
         policy,
         &mcp_config_path,
@@ -885,7 +889,7 @@ pub fn write_mcp_config(
     Ok(())
 }
 
-fn run_claude_mcp(
+fn run_agent_mcp(
     args: &RunArgs,
     policy: &PermissionLattice,
     mcp_config_path: &Path,
@@ -893,7 +897,7 @@ fn run_claude_mcp(
     prompt: &str,
     work_dir: &Path,
 ) -> Result<std::process::Output> {
-    let mut cmd = Command::new("claude");
+    let mut cmd = Command::new(crate::constants::AGENT_CLI_BIN);
     cmd.arg("--print")
         .arg("--model")
         .arg(&args.model)
@@ -914,18 +918,19 @@ fn run_claude_mcp(
         .arg(prompt)
         .current_dir(work_dir);
 
-    // Bypass Claude's built-in *interactive approval* in local enforced mode —
-    // SAFE ONLY because `--disallowedTools` above already removed every built-in
-    // tool, so the agent's only remaining tools are the nucleus MCP tools, and
-    // each of THOSE routes through the PermissionLattice. (Bypassing approval
-    // without the disallow list would let the built-in Bash/WebFetch/etc. run
-    // ungated — see the disallow comment.) Claude's interactive approval can't
-    // function in non-interactive `--print` mode anyway (it falls back to
-    // plan-only without a human), so the lattice IS the security boundary.
+    // Bypass the agent's built-in *interactive approval* in local enforced mode
+    // — SAFE ONLY because `--disallowedTools` above already removed every
+    // built-in tool, so the agent's only remaining tools are the nucleus MCP
+    // tools, and each of THOSE routes through the PermissionLattice. (Bypassing
+    // approval without the disallow list would let the built-in Bash/WebFetch/
+    // etc. run ungated — see the disallow comment.) The agent's interactive
+    // approval can't function in non-interactive `--print` mode anyway (it falls
+    // back to plan-only without a human), so the lattice IS the security boundary.
     cmd.arg("--dangerously-skip-permissions");
     cmd.arg("--permission-mode").arg("bypassPermissions");
 
-    cmd.output().context("failed to spawn claude")
+    cmd.output()
+        .with_context(|| format!("failed to spawn {}", crate::constants::AGENT_CLI_BIN))
 }
 
 pub fn build_mcp_allowed_tools(policy: &PermissionLattice) -> Vec<String> {

--- a/crates/nucleus-cli/src/shell.rs
+++ b/crates/nucleus-cli/src/shell.rs
@@ -1,7 +1,7 @@
-//! Shell command - Launch interactive Claude Code with nucleus security context
+//! Shell command - Launch an interactive agent session with nucleus security context
 //!
 //! Spawns nucleus-tool-proxy and nucleus-mcp as the security boundary,
-//! then launches `claude` in interactive mode with only sandboxed tools
+//! then launches the agent CLI in interactive mode with only sandboxed tools
 //! visible. All tool calls flow through the permission lattice.
 
 use anyhow::{anyhow, bail, Context, Result};
@@ -21,9 +21,9 @@ use uuid::Uuid;
 use crate::profiles;
 use crate::run::{build_mcp_allowed_tools, write_mcp_config, McpEnvConfig};
 
-/// Launch interactive Claude Code with nucleus as the security context.
+/// Launch an interactive agent session with nucleus as the security context.
 ///
-/// All built-in Claude tools are replaced by sandboxed equivalents that
+/// All built-in agent tools are replaced by sandboxed equivalents that
 /// flow through the nucleus permission lattice. The tool-proxy enforces
 /// capabilities, budget, command restrictions, and exposure tracking.
 #[derive(Args, Debug)]
@@ -70,17 +70,17 @@ pub struct ShellArgs {
     pub kernel_trace: Option<PathBuf>,
 
     /// Run a single prompt non-interactively instead of launching an interactive session.
-    /// Output is printed to stdout as JSON. No TTY required — works from within Claude Code.
+    /// Output is printed to stdout as JSON. No TTY required — works from within an agent session.
     #[arg(short = 'P', long)]
     pub prompt: Option<String>,
 
-    /// Print the MCP config and exit (useful for manual claude invocation)
+    /// Print the MCP config and exit (useful for manual agent-CLI invocation)
     #[arg(long)]
     pub print_config: bool,
 
-    /// Additional arguments to pass to claude
+    /// Additional arguments to pass to the agent CLI
     #[arg(last = true)]
-    pub claude_args: Vec<String>,
+    pub agent_args: Vec<String>,
 }
 
 /// Execute the shell command
@@ -201,11 +201,13 @@ pub async fn execute(args: ShellArgs) -> Result<()> {
         println!();
         println!("Allowed tools: {}", allowed_tools.join(","));
         println!();
-        println!("Launch claude with:");
+        println!("Launch the agent CLI with:");
         println!(
-            "  claude --mcp-config {} --allowedTools {} --disallowedTools Bash,Read,Write,Edit,Glob,Grep,WebFetch,WebSearch,NotebookEdit,Agent",
+            "  {} --mcp-config {} --allowedTools {} --disallowedTools {}",
+            crate::constants::AGENT_CLI_BIN,
             mcp_config_path.display(),
-            allowed_tools.join(",")
+            allowed_tools.join(","),
+            crate::constants::DISALLOWED_BUILTIN_TOOLS,
         );
         println!();
         println!("Tool-proxy: {proxy_url}");
@@ -213,7 +215,7 @@ pub async fn execute(args: ShellArgs) -> Result<()> {
         if let Some(ref trace_path) = args.kernel_trace {
             println!("Kernel trace: {}", trace_path.display());
         }
-        // Keep proxy alive - user will launch claude manually
+        // Keep proxy alive - user will launch the agent CLI manually
         println!("\nProxy running. Press Ctrl+C to stop.");
         tokio::signal::ctrl_c().await?;
         let _ = proxy_child.kill().await;
@@ -239,16 +241,17 @@ pub async fn execute(args: ShellArgs) -> Result<()> {
     }
     eprintln!();
 
-    // Launch claude with nucleus MCP tools.
+    // Launch the agent CLI with nucleus MCP tools.
     //
     // --allowedTools: only nucleus MCP tools are auto-approved
-    // --disallowedTools: explicitly block built-in tools so Claude doesn't
+    // --disallowedTools: explicitly block built-in tools so the agent doesn't
     //   attempt to use them (they'd fail anyway, but this prevents wasted tokens
     //   on tool definitions and failed invocations).
     //
-    // CLAUDECODE env var must be removed to allow launching claude from within
-    // an existing Claude Code session (e.g. testing nucleus shell from claude).
-    let mut cmd = Command::new("claude");
+    // The agent CLI's session env var (intrinsic interop: `CLAUDECODE`) must be
+    // removed to allow launching the agent CLI from within an existing agent
+    // session (e.g. testing nucleus shell from inside one).
+    let mut cmd = Command::new(crate::constants::AGENT_CLI_BIN);
     cmd.arg("--mcp-config")
         .arg(&mcp_config_path)
         .arg("--allowedTools")
@@ -263,8 +266,8 @@ pub async fn execute(args: ShellArgs) -> Result<()> {
         cmd.arg("-p").arg(prompt).arg("--output-format").arg("json");
     }
 
-    // Pass through any additional claude args
-    for arg in &args.claude_args {
+    // Pass through any additional agent-CLI args
+    for arg in &args.agent_args {
         cmd.arg(arg);
     }
 
@@ -273,7 +276,7 @@ pub async fn execute(args: ShellArgs) -> Result<()> {
         .stdout(std::process::Stdio::inherit())
         .stderr(std::process::Stdio::inherit())
         .status()
-        .context("failed to spawn claude")?;
+        .with_context(|| format!("failed to spawn {}", crate::constants::AGENT_CLI_BIN))?;
 
     // Kill tool-proxy
     let _ = proxy_child.kill().await;
@@ -287,7 +290,11 @@ pub async fn execute(args: ShellArgs) -> Result<()> {
     if status.success() {
         Ok(())
     } else {
-        bail!("claude exited with code {:?}", status.code())
+        bail!(
+            "{} exited with code {:?}",
+            crate::constants::AGENT_CLI_BIN,
+            status.code()
+        )
     }
 }
 


### PR DESCRIPTION
persona certified dispatch (iter 0).

De-vendor crate `nucleus-cli` ONLY (c5-vendor-neutrality). Envelope is STRICTLY crates/nucleus-cli/ — 5 flagged files: src/audit.rs, src/guard.rs, src/main.rs, src/run.rs, src/shell.rs. CRITICAL — learn from the recurring failure mode: EVERY prior de-vendor run on sibling crates (nucleus-audit x2, portcullis, ctf-server) was REJECTED with `unauthorized=[.vendor-neutrality-allowlist]` because they reached OUT of envelope to edit the repo-root allowlist. That path is NOT in your envelope — DO NOT touch, create, or edit `.vendor-neutrality-allowlist`; doing so is an automatic mechanical reject. Fix entirely IN-ENVELOPE: rename gratuitous vendor names to neutral equivalents (e.g. Claude/Anthropic/claude-* → generic 'LLM'/'agent'/'AI'), extract behind a neutral trait/adapter where a rename would break structure. If a literal is a GENUINE non-renameable interop/provenance string (a real protocol field, URL, or CVE attribution), leave it in place and note it inline as intrinsic — do NOT reassemble it via placeholder-substitution or per-request string-replace to dodge the grep (that soft-gaming was rejected before); an honest intrinsic-keep that builds is acceptable here. VERIFY only with what runs in the worktree: `cargo build -p nucleus-cli` stays green, and `grep -rniE 'claude|anthropic|openai' crates/nucleus-cli/src/` shows only intrinsic keeps remain. Do NOT run any ci/ script — that gate runs post-landing in nucleus CI and is not your gate.
