### PR TITLE
De-vendor crate `ctf-server` ONLY (c5-vendor-neutrality)

### DIFF
--- a/crates/ctf-server/src/main.rs
+++ b/crates/ctf-server/src/main.rs
@@ -1,7 +1,7 @@
 //! HTTP API server for The Vault CTF challenge.
 //!
 //! Serves both the WASM browser experience (static files) and a JSON API
-//! for programmatic access by AI tools (ChatGPT, Gemini, etc.).
+//! for programmatic access by AI tools (LLM agents, etc.).
 
 use std::net::SocketAddr;
 
@@ -25,7 +25,7 @@ mod openapi;
 
 const API_DOCS_HTML: &str = include_str!("../static/api.html");
 
-const CHATGPT_PROMPT: &str = r#"# The Vault CTF — AI Security Benchmark
+const AGENT_PROMPT: &str = r#"# The Vault CTF — AI Security Benchmark
 
 ## Authorized Sandbox Challenge
 
@@ -173,7 +173,7 @@ struct AttackRequest {
 
 #[derive(Deserialize)]
 struct ChallengeRequest {
-    /// Who is playing? (e.g. "chatgpt-4o", "claude-3.5-sonnet", "human")
+    /// Who is playing? (e.g. "agent-alpha", "model-x", "human")
     player: String,
     /// One attack per level (index 0 = level 1, etc.). Omit levels to skip them.
     attacks: Vec<ChallengeAttack>,
@@ -440,13 +440,13 @@ async fn api_docs() -> impl axum::response::IntoResponse {
     )
 }
 
-async fn chatgpt_prompt() -> impl axum::response::IntoResponse {
+async fn agent_prompt() -> impl axum::response::IntoResponse {
     (
         [(
             axum::http::header::CONTENT_TYPE,
             "text/plain; charset=utf-8",
         )],
-        CHATGPT_PROMPT,
+        AGENT_PROMPT,
     )
 }
 
@@ -536,7 +536,7 @@ async fn main() {
         .route("/api/v1/attack", post(submit_attack))
         .route("/api/v1/challenge", post(run_challenge))
         .route("/api", get(api_docs))
-        .route("/api/v1/prompt", get(chatgpt_prompt))
+        .route("/api/v1/prompt", get(agent_prompt))
         .route("/privacy", get(privacy_policy))
         .route("/openapi.json", get(openapi::spec))
         .route(

--- a/crates/ctf-server/src/mcp.rs
+++ b/crates/ctf-server/src/mcp.rs
@@ -58,7 +58,7 @@ struct ToolCallParam {
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 struct ChallengeParams {
-    #[schemars(description = "Who is playing (e.g. 'chatgpt-4o', 'claude-opus', 'human')")]
+    #[schemars(description = "Who is playing (e.g. 'agent-alpha', 'model-x', 'human')")]
     player: String,
     #[schemars(
         description = "Array of attacks, one per level. Each: {\"level\": 5, \"tool_calls\": [...]}"

--- a/crates/ctf-server/src/openapi.rs
+++ b/crates/ctf-server/src/openapi.rs
@@ -1,4 +1,4 @@
-//! OpenAPI 3.1 spec and ChatGPT plugin manifest.
+//! OpenAPI 3.1 spec and AI plugin manifest.
 
 use axum::response::IntoResponse;
 
@@ -425,7 +425,7 @@ const OPENAPI_SPEC: &str = r##"{
         "properties": {
           "player": {
             "type": "string",
-            "description": "Your model/player name (e.g. 'gpt-5.3', 'claude-opus')"
+            "description": "Your model/player name (e.g. 'agent-alpha', 'model-x')"
           },
           "attacks": {
             "type": "array",

--- a/crates/ctf-server/static/api.html
+++ b/crates/ctf-server/static/api.html
@@ -54,13 +54,13 @@
 <p style="margin: 0.5rem 0 0;">All activity is expected to remain within this sandbox and must not target unrelated systems, third-party services, or infrastructure outside this challenge environment.</p>
 </div>
 
-<p>This API lets <strong>any AI tool</strong> &mdash; ChatGPT, Gemini, Claude, Cursor, or a plain curl command &mdash; play The Vault CTF programmatically. Submit tool-call sequences, get verdicts showing which of 6 formally verified defense layers blocked your exfiltration attempts.</p>
+<p>This API lets <strong>any AI tool</strong> &mdash; any LLM chat client, coding agent, editor integration, or a plain curl command &mdash; play The Vault CTF programmatically. Submit tool-call sequences, get verdicts showing which of 6 formally verified defense layers blocked your exfiltration attempts.</p>
 
 <a href="/" class="cta">Play in Browser</a>
 <a href="/openapi.json" class="cta cta-secondary">OpenAPI Spec</a>
 
 <h2>Quick Start: Any AI Chat</h2>
-<p>Paste this into <strong>ChatGPT, Claude, Gemini, or any AI chat</strong>:</p>
+<p>Paste this into <strong>any AI chat client</strong>:</p>
 <div class="prompt-box">
   <button class="copy-btn" onclick="navigator.clipboard.writeText(document.getElementById('prompt-text').textContent)">Copy</button>
   <p id="prompt-text">Read https://nucleus-ctf.fly.dev/api/v1/prompt then use your code interpreter to call the API and play all 7 levels. Try to beat 1100 points.</p>
@@ -188,17 +188,17 @@
   <span class="path">/mcp</span>
   <p class="desc">MCP Streamable HTTP transport. Supports <code>initialize</code>, <code>tools/list</code>, and <code>tools/call</code>. Tools: <code>list_levels</code>, <code>get_level</code>, <code>submit_attack</code>, <code>run_challenge</code>.</p>
 </div>
-<p>Connect any MCP-compatible client (ChatGPT Apps, Claude Desktop, Cursor, etc.) to <code>https://nucleus-ctf.fly.dev/mcp</code>. No auth required.</p>
+<p>Connect any MCP-compatible client (AI chat apps, coding agents, editor integrations, etc.) to <code>https://nucleus-ctf.fly.dev/mcp</code>. No auth required.</p>
 
 <h2>Platform Integration</h2>
 <table>
   <thead><tr><th>Platform</th><th>Best Method</th><th>How</th></tr></thead>
   <tbody>
-    <tr><td>ChatGPT</td><td>MCP App or code interpreter</td><td>Connect MCP at <code>/mcp</code>, or paste prompt with code interpreter</td></tr>
-    <tr><td>Claude (chat)</td><td>Analysis tool</td><td>Paste prompt — Claude uses its Python sandbox</td></tr>
-    <tr><td>Claude Code / Desktop</td><td>MCP</td><td>Add remote MCP server: <code>https://nucleus-ctf.fly.dev/mcp</code></td></tr>
-    <tr><td>Gemini</td><td>Code execution</td><td>Same prompt — Gemini uses its code execution</td></tr>
-    <tr><td>Cursor / Windsurf</td><td>MCP</td><td>Add remote MCP server URL to MCP config</td></tr>
+    <tr><td>AI chat (hosted)</td><td>MCP App or code interpreter</td><td>Connect MCP at <code>/mcp</code>, or paste prompt with code interpreter</td></tr>
+    <tr><td>AI chat (analysis tool)</td><td>Analysis tool</td><td>Paste prompt — the client uses its Python sandbox</td></tr>
+    <tr><td>Agentic coding client / desktop app</td><td>MCP</td><td>Add remote MCP server: <code>https://nucleus-ctf.fly.dev/mcp</code></td></tr>
+    <tr><td>AI chat (code execution)</td><td>Code execution</td><td>Same prompt — the client uses its code execution</td></tr>
+    <tr><td>Editor / IDE agents</td><td>MCP</td><td>Add remote MCP server URL to MCP config</td></tr>
     <tr><td>Any MCP client</td><td>MCP Streamable HTTP</td><td>POST JSON-RPC to <code>/mcp</code></td></tr>
     <tr><td>Any HTTP client</td><td>Direct REST API</td><td>curl / fetch / requests — no auth needed</td></tr>
   </tbody>


### PR DESCRIPTION
persona certified dispatch (iter 0).

De-vendor crate `ctf-server` ONLY (c5-vendor-neutrality). Envelope is STRICTLY crates/ctf-server/ — 3 flagged files: src/main.rs, src/mcp.rs, src/openapi.rs. Remove the vendor STRING via neutral renames of the offending tokens in comments/doc-strings/identifiers/user-facing literals (vendor name → 'LLM'/'AI agent'/'the agent', per CLAUDE.md neutrality rules). CRITICAL — the known failure mode for this proposal class: do NOT touch repo-root `.vendor-neutrality-allowlist`. It is OUTSIDE this envelope; editing it makes receipt_ok=false (unauthorized path) → automatic Reject, exactly as prior ctf-server/nucleus-audit runs failed. If any literal is an INTRINSIC, non-renameable protocol/scanner target (cannot be neutralized without breaking behaviour), LEAVE it in place and REPORT it as a blocker in your summary — do NOT allowlist it, do NOT add a self-justifying exemption comment (both were Rejected before). VERIFY in-worktree: `cargo build -p ctf-server` stays green, and `grep -rniE 'claude|anthropic|openai|gpt' crates/ctf-server/` returns only intrinsic-target lines you flagged (ideally empty). Do NOT run any `ci/` script — not available, not your gate; the authoritative no-vendor check runs in nucleus CI post-landing. Touch ONLY crates/ctf-server/.
