### PR TITLE
fix(nucleus-externality): clippy for_kv_map — unblock the merge queue

### DIFF
--- a/crates/nucleus-externality/src/profile.rs
+++ b/crates/nucleus-externality/src/profile.rs
@@ -113,8 +113,8 @@ pub fn canonical_externality_bytes(p: &ExternalityProfile) -> Vec<u8> {
     out.extend_from_slice(PROFILE_DOMAIN);
     let n = p.dimensions.len() as u32;
     out.extend_from_slice(&n.to_be_bytes());
-    // BTreeMap's iter is in `Ord` order, which is deterministic.
-    for (_dim, claim) in p.dimensions.iter() {
+    // BTreeMap's values() is in key-`Ord` order, which is deterministic.
+    for claim in p.dimensions.values() {
         out.extend_from_slice(&canonical_claim_bytes(claim));
     }
     out


### PR DESCRIPTION
## The problem
CI runs `cargo clippy --all-targets --all-features -- -D warnings`. **Rust 1.97.0 newly fires `clippy::for_kv_map`** on `nucleus-externality/src/profile.rs:117` (a toolchain-drift CI break — the lint was tightened, not the code changed). Under `-D warnings`, that one lint fails Clippy on **every open PR**, jamming the entire merge queue — which is why 0 PRs have landed recently.

## The fix
`for (_dim, claim) in p.dimensions.iter()` uses only the value → `for claim in p.dimensions.values()`. Same deterministic `Ord`-order iteration over the `BTreeMap`, **byte-identical canonical digest**. One line.

## Verified
`RUSTFLAGS="-D warnings" cargo clippy -p nucleus-externality --all-targets --all-features` is clean (the CI log flagged only this one site). Unblocks #2003, #2002, and the rest of the queue.