### PR TITLE
ci: pin Rust toolchain to 1.96.1 — unblock the merge queue (declared input)

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,10 @@
+# Pin the Rust toolchain — a DECLARED, versioned build input (not "latest stable").
+# CI was unpinned and floated to 1.97, which newly fires clippy lints (for_kv_map et al.)
+# under `-D warnings`, red-lighting Clippy on every PR and jamming the merge queue — while
+# the code is clean on 1.96.1 (verified: full-workspace `cargo clippy` passes on 1.96.1).
+# Pinning makes the toolchain reproducible across CI and local dev; bump deliberately +
+# fix any new lints in one PR, rather than being surprised by an auto-upgrade.
+# (The Aeneas/Charon jobs set their own nightly explicitly, overriding this.)
+[toolchain]
+channel = "1.96.1"
+components = ["clippy", "rustfmt"]


### PR DESCRIPTION
## The jam
0 merges, 20+ PRs stacked. **Root cause: CI is unpinned** (no `rust-toolchain.toml` → `setup-rust-toolchain` floats to latest stable), which drifted to **Rust 1.97**, newly firing clippy lints (`for_kv_map` et al.) that under `-D warnings` fail Clippy on *every* PR.

## Verified: the code is clean, the toolchain drifted
Local **1.96.1** runs the exact CI check — `cargo clippy --all-targets --all-features` (after `wasm-pack build`) — with **zero clippy lints**. So this is pure toolchain drift, not a code defect. My earlier PR #2005 chased one lint (`profile.rs`); with `-D warnings` the failures cascade crate-by-crate, so lint-chasing is a losing game against an unpinned toolchain.

## The fix
Pin the toolchain as a **declared, versioned input** (`rust-toolchain.toml`, channel `1.96.1`) — reproducible across CI and local dev. Bumping becomes a deliberate PR that fixes any new lints, not a silent auto-upgrade that jams the queue. This is the hermetic-build move: make the toolchain an explicit input.

**Supersedes #2005** — pinning clears the whole lint chain at once. Unblocks #2003 (the first landed proof) and 20+ others.