### PR TITLE
Touch ONLY files under crates/portcullis-core/lean/

### DIFF
--- a/crates/portcullis-core/lean/SemanticIFCDecidable.lean
+++ b/crates/portcullis-core/lean/SemanticIFCDecidable.lean
@@ -3879,7 +3879,20 @@ theorem zero_tolerance_exact {n m : Nat}
     (i j : Fin n)
     (h : (toPreEquiv A 0).sim i j = true) :
     (A.toDObsLevel).rel i j = true := by
-  sorry -- requires: countP (!=) ≤ 0 → countP (!=) = 0 → all (==)
+  -- `sim` at tolerance 0 unfolds to `decide (countP (≠) ≤ 0)`; peel the decide
+  -- exactly as `sim_symm` does just above.
+  have hcount : decide _ = true := h
+  rw [decide_eq_true_iff] at hcount
+  -- `≤ 0` on `Nat` forces the mismatch count to be exactly `0`.
+  have hall := List.countP_eq_zero.mp (Nat.le_zero.mp hcount)
+  -- Zero mismatches ⇒ every column agrees ⇒ the two rows are equal.
+  simp only [Faithfulness.DiscretePattern.toDObsLevel, Faithfulness.DiscretePattern.rowsEq]
+  refine List.all_eq_true.mpr ?_
+  intro k hk
+  have hk' := hall k hk
+  simp only [bne_iff_ne, ne_eq, not_not] at hk'
+  simp only [beq_iff_eq]
+  exact hk'
 
 end ApproxEquiv
 


### PR DESCRIPTION
persona certified dispatch (iter 0).

Touch ONLY files under crates/portcullis-core/lean/. Discharge AT LEAST ONE proof-hole from the 25 sorry/admit + 7 axioms remaining: close a `sorry`, extract+prove a lemma, or replace an `axiom` with a real proof. Pick a DIFFERENT hole than the one just closed by the prior accepted run on this same tree (git-diff HEAD to see what already changed; do not re-touch or revert it). HARD RULES: introduce NO new sorry/admit/axiom (laundering ≠ progress); reuse existing lemmas + Mathlib (`exact?`/`apply?`), prefer `simp`/`omega`/`decide`. NOTE: `lake`/`lean` are allowlist-blocked in dispatch — you CANNOT run `lake build`. Verify by (a) copying proof idioms from an already-certified sibling lemma in the same tree, (b) Grep the final file to confirm no new sorry/admit/axiom tokens, and (c) report the build itself as a permission blocker for the orchestrator to confirm green. Keep the change to a single lemma to minimize break-the-build risk.
