### PR TITLE
deps: bump spin off yanked versions (unblocks the audit gate)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2603,7 +2603,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5"
 dependencies = [
  "digest 0.10.7",
- "spin 0.10.0",
+ "spin 0.10.1",
 ]
 
 [[package]]
@@ -3668,7 +3668,7 @@ checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
 dependencies = [
  "futures-core",
  "futures-sink",
- "spin 0.9.8",
+ "spin 0.9.9",
 ]
 
 [[package]]
@@ -3798,7 +3798,7 @@ dependencies = [
  "diatomic-waker",
  "futures-core",
  "pin-project-lite",
- "spin 0.10.0",
+ "spin 0.10.1",
 ]
 
 [[package]]
@@ -4238,7 +4238,7 @@ dependencies = [
  "hash32",
  "rustc_version",
  "serde",
- "spin 0.9.8",
+ "spin 0.9.9",
  "stable_deref_trait",
 ]
 
@@ -5575,7 +5575,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin 0.9.8",
+ "spin 0.9.9",
 ]
 
 [[package]]
@@ -10765,18 +10765,18 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]
 
 [[package]]
 name = "spin"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 
 [[package]]
 name = "spinning_top"


### PR DESCRIPTION
## Problem

`main` is **red on a required check**. `spin` 0.9.8 and 0.10.0 were **yanked from crates.io**, and the `audit` job runs with `denyWarnings: true`:

```
Crate:     spin
Version:   0.9.8
Warning:   yanked
Crate:     spin
Version:   0.10.0
Warning:   yanked
error: 2 denied warnings found!
```

Reproduced on clean `main` — this is caused by no PR.

## Why every open PR is stuck

`audit` is one of the 25 required checks, so nothing can merge. Worse, the PR pages **lie**: a PR whose CI ran *before* the yank still shows `audit: SUCCESS` and `mergeStateStatus: CLEAN`. It only fails once the merge queue re-runs `audit` against the merged result — at which point it is silently **dequeued and auto-merge is switched off**. #2016 did exactly this while its own page still read CLEAN.

## Fix

Both are deep transitive deps, so there is nothing to change in a manifest:

```
spin 0.9.8   <- flume <- sqlx-sqlite <- sqlx <- nucleus-verifier-service
spin 0.10.0  <- futures-buffered <- irpc <- iroh-blobs <- nucleus-bundle-cas
```

`0.9.9` and `0.10.1` are the non-yanked, semver-compatible releases. **`Cargo.lock` only**, 9 lines.

## Verification

- `cargo audit --deny warnings` → **exit 0** (fails on `main`)
- `cargo check -p nucleus-bundle-cas` → clean
- `nucleus-verifier-service` can't be checked locally: it `include_str!`s wasm artifacts that CI generates via wasm-pack. Unrelated to this bump; CI covers it.

## After this lands

Dependabot PRs #2015–#2020 should be **re-enqueued**, not trusted on their stale green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)