### PR TITLE
tool-proxy: bound upstream body reads so the monitor can't be OOM-killed (audit H-1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7300,6 +7300,7 @@ dependencies = [
  "uuid",
  "walkdir",
  "whoami 2.1.2",
+ "wiremock",
  "x509-parser",
 ]
 

--- a/SECURITY_TODO.md
+++ b/SECURITY_TODO.md
@@ -214,3 +214,27 @@ DoD (guarantees)
 
 Status
 - Partial: the spawn-call-site bypass is closed and regression-tested; the intra-process fresh-tracker leg and the ceiling-wiring defense-in-depth remain open. The "complete mediation now holds" claim is intentionally NOT asserted in README/FORMAL_METHODS until those legs close.
+## 12) Tool-proxy could be OOM-killed by an attacker-controlled response body (audit H-1)
+
+Deficiency
+- `web_fetch`, the MCP fetch path, and `web_search` buffered the ENTIRE upstream body (`response.bytes()/.json()`) before applying `web_fetch_max_bytes`, which only truncated what was already allocated. A malicious upstream (the untrusted-content leg of the lethal-trifecta threat model) streaming a huge/Content-Length-lying body caused unbounded allocation → OOM-kill of the tool-proxy. Because the tool-proxy IS the enforcement point, its death runs the agent unmonitored (fail-open).
+Refs: `crates/nucleus-tool-proxy/src/main.rs` (`read_body_capped`, web_fetch, web_search), `crates/nucleus-tool-proxy/src/mcp.rs`
+
+TODO
+- [DONE] Stream every attacker-influenced body through `read_body_capped`, which stops at `web_fetch_max_bytes` and never retains more than the cap (+ one chunk) regardless of upstream size / Content-Length.
+- [OPEN] H-3 panic/poison leg: add a `CatchPanicLayer` (fail-closed) on the tool-proxy + verifier routers and replace `.expect("...poisoned")` on enforcement locks with `unwrap_or_else(|e| e.into_inner())`. (OOM is not catchable by `catch_unwind`; that leg is bounded allocation, done here.)
+
+DoD (guarantees)
+- [DONE] `read_body_capped_tests` (wiremock): a 4 MiB upstream body against a 64 KiB cap yields exactly the cap with `truncated=true`; a small body round-trips untruncated. Fails if reverted to whole-body buffering.
+
+Status
+- Partial: the OOM/allocation leg is closed and regression-tested; the panic/poison (H-3) leg remains open. Does NOT claim "monitor is un-killable".
+
+## 13) Transparency-log cosignature not enforced on the production trust path (audit C-3) — ESCALATED, DEFERRED
+
+Deficiency
+- `verify_binding_in_log` (witness-cosigned STH + inclusion proof) is called only in tests; the production `federation.rs` path (`apply_to_store`) authenticates inbound JWT-SVIDs directly from the on-disk `FederationSet` with no cosignature check. Anyone who can write the registry tree gets keys served for identity verification (forged foreign identities authenticate). This is the highest-severity remaining finding.
+Refs: `crates/nucleus-trust-registry/src/federation.rs:25-48`, `tlog.rs` (`verify_binding_in_log`)
+
+Status
+- DEFERRED by owner decision (2026-07-17). Enforcement establishes a NEW TRUST ROOT (which pinned witness cosigner(s), out-of-band key distribution) and a BREAKING CHANGE (deployments lacking a `SealedLog` must be rejected). Both the witness model (single vs k-of-n) and the rollout (hard fail-closed vs warn-then-enforce) are open owner decisions; do not wire enforcement until decided. Kept as the top open critical.

--- a/crates/nucleus-tool-proxy/Cargo.toml
+++ b/crates/nucleus-tool-proxy/Cargo.toml
@@ -94,6 +94,9 @@ tokio-vsock = "0.7"
 [dev-dependencies]
 tempfile = { workspace = true }
 ed25519-dalek = { workspace = true }
+# HTTP mock upstream for the H-1 bounded-body-read regression test
+# (read_body_capped). Dev-only; production graph unchanged.
+wiremock = "0.6"
 # Direct access to the IFC gate (flow/flow_algebra/SinkClass) for the attack
 # corpus; already transitive via `portcullis`. Dev-only — production graph
 # unchanged. Used by tests/attack_corpus.rs.

--- a/crates/nucleus-tool-proxy/src/main.rs
+++ b/crates/nucleus-tool-proxy/src/main.rs
@@ -2717,21 +2717,14 @@ async fn web_fetch(
         response_headers.insert("x-nucleus-source-domain".to_string(), host);
     }
 
-    // Read body with size limit
-    let bytes = response
-        .bytes()
+    // Read body with a HARD allocation cap: stream and stop at the limit so a
+    // malicious upstream body cannot OOM-kill the enforcement process, which
+    // would run the agent unmonitored (fail-open). Audit H-1.
+    let (bytes, was_truncated) = read_body_capped(response, state.web_fetch_max_bytes)
         .await
         .map_err(|e| ApiError::WebFetch(format!("failed to read response: {e}")))?;
-
-    let (body, truncated) = if bytes.len() > state.web_fetch_max_bytes {
-        let truncated_bytes = &bytes[..state.web_fetch_max_bytes];
-        (
-            String::from_utf8_lossy(truncated_bytes).to_string(),
-            Some(true),
-        )
-    } else {
-        (String::from_utf8_lossy(&bytes).to_string(), None)
-    };
+    let body = String::from_utf8_lossy(&bytes).to_string();
+    let truncated = if was_truncated { Some(true) } else { None };
 
     if let Err(e) = sink.record(VerdictContext {
         operation,
@@ -3232,9 +3225,10 @@ async fn web_search(
 
     // Parse response - this is a generic JSON structure
     // Real implementations would adapt to specific search APIs
-    let body = response
-        .json::<serde_json::Value>()
+    let (search_bytes, _truncated) = read_body_capped(response, state.web_fetch_max_bytes)
         .await
+        .map_err(|e| ApiError::WebFetch(format!("failed to read search response: {e}")))?;
+    let body: serde_json::Value = serde_json::from_slice(&search_bytes)
         .map_err(|e| ApiError::WebFetch(format!("failed to parse search response: {e}")))?;
 
     // Try to extract results from common formats
@@ -4121,6 +4115,93 @@ fn load_last_hash(path: &Path) -> Option<String> {
         return None;
     }
     Some(entry.hash)
+}
+
+/// Read an HTTP response body while STRICTLY bounding peak retained allocation to
+/// `max_bytes` (+ at most one upstream chunk), independent of the upstream's
+/// Content-Length or true size. Streams via `chunk()` and STOPS at the cap, so a
+/// malicious upstream cannot OOM-kill the tool-proxy (the enforcement point) —
+/// the untrusted-content fail-open of audit H-1. Returns `(body, truncated)`;
+/// `truncated` is true iff the upstream had more than `max_bytes` (the surplus is
+/// never accumulated).
+pub(crate) async fn read_body_capped(
+    mut resp: reqwest::Response,
+    max_bytes: usize,
+) -> Result<(Vec<u8>, bool), reqwest::Error> {
+    let mut buf: Vec<u8> = Vec::new();
+    while buf.len() < max_bytes {
+        match resp.chunk().await? {
+            Some(chunk) => {
+                let remaining = max_bytes - buf.len();
+                if chunk.len() > remaining {
+                    buf.extend_from_slice(&chunk[..remaining]);
+                    return Ok((buf, true)); // hit the cap mid-chunk; stop reading
+                }
+                buf.extend_from_slice(&chunk);
+            }
+            None => return Ok((buf, false)), // upstream ended within the cap
+        }
+    }
+    // Exactly at the cap: peek one more chunk to set the truncation flag. The
+    // surplus chunk is read into reqwest's buffer and immediately dropped — peak
+    // retained allocation stays at `max_bytes`.
+    let truncated = resp.chunk().await?.is_some();
+    Ok((buf, truncated))
+}
+
+#[cfg(test)]
+mod read_body_capped_tests {
+    //! Regression guard for audit H-1: the tool-proxy must not buffer an entire
+    //! attacker-controlled upstream body. `read_body_capped` must stop at the cap
+    //! regardless of upstream size. Fails if reverted to whole-body buffering.
+    use super::read_body_capped;
+    use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[tokio::test]
+    async fn stops_at_cap_on_oversize_body() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let cap = 64 * 1024;
+        let server = MockServer::start().await;
+        // Upstream body two orders of magnitude larger than the cap.
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(vec![b'a'; 4 * 1024 * 1024]))
+            .mount(&server)
+            .await;
+        let resp = reqwest::Client::new()
+            .get(server.uri())
+            .send()
+            .await
+            .expect("send");
+        let (body, truncated) = read_body_capped(resp, cap).await.expect("read");
+        assert_eq!(
+            body.len(),
+            cap,
+            "must retain at most the cap, not the 4 MiB body"
+        );
+        assert!(
+            truncated,
+            "an oversize upstream body must be flagged truncated"
+        );
+    }
+
+    #[tokio::test]
+    async fn returns_full_small_body_untruncated() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(b"hello".to_vec()))
+            .mount(&server)
+            .await;
+        let resp = reqwest::Client::new()
+            .get(server.uri())
+            .send()
+            .await
+            .expect("send");
+        let (body, truncated) = read_body_capped(resp, 64 * 1024).await.expect("read");
+        assert_eq!(body, b"hello");
+        assert!(!truncated);
+    }
 }
 
 #[cfg(test)]

--- a/crates/nucleus-tool-proxy/src/mcp.rs
+++ b/crates/nucleus-tool-proxy/src/mcp.rs
@@ -983,12 +983,12 @@ impl NucleusMcpServer {
                 .unwrap_or("");
             crate::web_fetch_policy::check_mime_type(content_type)?;
 
-            let bytes = resp
-                .bytes()
+            // Bounded streaming read: never allocate the whole upstream body, so a
+            // malicious page cannot OOM-kill the enforcement process (audit H-1).
+            let (bytes, truncated) = crate::read_body_capped(resp, max_bytes)
                 .await
                 .map_err(|e| format!("body read failed: {e}"))?;
-            let truncated = bytes.len() > max_bytes;
-            let body = String::from_utf8_lossy(&bytes[..std::cmp::min(bytes.len(), max_bytes)]);
+            let body = String::from_utf8_lossy(&bytes);
             let suffix = if truncated { "\n(truncated)" } else { "" };
             Ok(format!("HTTP {status}\n\n{body}{suffix}"))
         }


### PR DESCRIPTION
## What
`web_fetch`, the MCP fetch path, and `web_search` buffered the **entire** upstream body before applying `web_fetch_max_bytes` (truncate-after-allocate). A malicious upstream — the untrusted-content leg of nucleus's own lethal-trifecta threat model — streaming a huge or Content-Length-lying body caused unbounded allocation and **OOM-killed the tool-proxy**. The tool-proxy *is* the enforcement point, so its death runs the agent unmonitored (**fail-open**) — the worst class of bug for a monitor (audit **H-1**).

## Fix
New `read_body_capped(resp, max)` streams via `chunk()` and **stops at the cap**, never retaining more than `max_bytes` (+ one chunk) regardless of upstream size or Content-Length. Replaces the three whole-body buffers. Honest upstreams behave identically (first `max_bytes` kept, truncation flagged); oversize is fail-closed by bound.

## Regression guard
`read_body_capped_tests` (wiremock): a 4 MiB body against a 64 KiB cap yields exactly the cap + `truncated=true`; a small body round-trips untruncated. Fails if reverted to whole-body buffering.

## Scope (honest)
Closes the OOM/allocation leg of H-1. The panic/poison leg (**H-3**: `CatchPanicLayer` + de-poison enforcement locks) remains open (`SECURITY_TODO.md` item 12). Item 13 records **C-3** (cosigned-log enforcement) as escalated + deferred pending the trust-root/rollout decision. Does **not** claim "monitor is un-killable".

🤖 Generated with [Claude Code](https://claude.com/claude-code)