### PR TITLE
crypto: verify_strict on the Ed25519 trust-path re-verify sites (audit M-2)

### DIFF
--- a/SECURITY_TODO.md
+++ b/SECURITY_TODO.md
@@ -205,7 +205,7 @@ Impact
 
 TODO
 - [DONE] Gate `create_sub_pod` on the parent `FlowTracker` via the same egress gate the kernel uses (`portcullis::exposure_core::ifc_egress_denial`, `ManagePods` → `OutboundAction`), failing closed before credential injection or any node call.
-- [OPEN] Intra-process fresh-tracker leg: `mcp.rs:171` constructs a new `FlowTracker` per MCP server; audit whether any path resets/replaces the long-lived tracker mid-session.
+- [WON'T-FIX / not-live] Intra-process fresh-tracker leg: `mcp.rs:171` constructs a new `FlowTracker` per MCP server. Audited: this is NOT a live laundering seam because the MCP-stdio and HTTP front-ends are MUTUALLY EXCLUSIVE within one process. `--mcp` is documented as mutually exclusive with the HTTP server (`crates/nucleus-tool-proxy/src/main.rs:256-260`) and, when set, `main.rs:1427` does `return mcp::run_mcp_server(...)` — an early return that exits `main` before the axum HTTP `Router` (and its long-lived per-session `FlowTracker`) is ever constructed. The two `FlowTracker`s are therefore never co-live in one process; there is no intra-process path that resets/replaces a long-lived HTTP tracker with the MCP one mid-session, so there is no taint-laundering boundary to gate. (If a future change makes both front-ends co-live in one process, this leg must be re-opened.)
 - [OPEN] Defense in depth: consult `session_taint_ceiling` / `check_action_safety_with_ceiling` in the live integrity gate so per-node `is_tainted()` is not the only check.
 
 DoD (guarantees)
@@ -213,7 +213,7 @@ DoD (guarantees)
 - [OPEN] E2E adversarial-corpus test: over HTTP, taint a session (web_fetch) then attempt `create_sub_pod` and assert deny + no node call + no credential forwarding.
 
 Status
-- Partial: the spawn-call-site bypass is closed and regression-tested; the intra-process fresh-tracker leg and the ceiling-wiring defense-in-depth remain open. The "complete mediation now holds" claim is intentionally NOT asserted in README/FORMAL_METHODS until those legs close.
+- Partial: the spawn-call-site bypass is closed and regression-tested; the intra-process fresh-tracker leg is closed as WON'T-FIX / not-live (MCP-stdio and HTTP front-ends are mutually exclusive per process — see the leg above), leaving only the ceiling-wiring defense-in-depth open. The "complete mediation now holds" claim is intentionally NOT asserted in README/FORMAL_METHODS until that leg closes.
 ## 12) Tool-proxy could be OOM-killed by an attacker-controlled response body (audit H-1)
 
 Deficiency
@@ -244,3 +244,25 @@ Refs: `crates/nucleus-trust-registry/src/federation.rs:25-48`, `tlog.rs` (`verif
 
 Status
 - DEFERRED by owner decision (2026-07-17). Enforcement establishes a NEW TRUST ROOT (which pinned witness cosigner(s), out-of-band key distribution) and a BREAKING CHANGE (deployments lacking a `SealedLog` must be rejected). Both the witness model (single vs k-of-n) and the rollout (hard fail-closed vs warn-then-enforce) are open owner decisions; do not wire enforcement until decided. Kept as the top open critical.
+
+## 14) Ed25519 re-verify used non-strict `verify()` on three trust-path sites (audit M-2)
+
+Deficiency
+- Three Ed25519 re-verify sites on the trust path called non-strict `vk.verify(...)` instead of `vk.verify_strict(...)`. Non-strict verification uses the cofactored equation and does not reject small-order / non-canonical public keys, so a single signature can verify under multiple identities (key-substitution / weak binding). The core already used `verify_strict`; these three were the inconsistency.
+Refs: `crates/nucleus-receipt/src/lib.rs:187` (`Receipt::verify`), `crates/nucleus-verifier-service/src/auth.rs:86` (`verify_detached_ed25519`), `crates/nucleus-witness/src/cosign.rs:134` (`verify_cosign_line`).
+
+Impact
+- On the receipt colimit-identity path, the detached-signature agent-auth path, and the witness cosignature path, an attacker presenting the Ed25519 identity/neutral key could get a crafted "identity-triple" signature to verify, breaking strong binding of signature → identity.
+
+TODO
+- [DONE] Swapped all three sites from `vk.verify(msg, &sig)` to `vk.verify_strict(msg, &sig)` (each `vk` is an `ed25519_dalek::VerifyingKey`; same call signature, strictly stronger — rejects small-order/non-canonical A and R). Removed the now-unused `ed25519_dalek::Verifier` trait import from each of the three modules (`verify_strict` is an inherent method).
+
+Strong-binding rationale + tests
+- [DONE] Regression tests prove strong binding at EACH site (one per crate), each with two assertions: (i) an honest dalek keypair still verifies through the site's public path (no regression); (ii) a signature presented against the SMALL-ORDER Ed25519 identity/neutral verifying key (`[1, 0, …, 0]`) with the identity-triple signature (`R` = identity encoding, `s` = 0) is REJECTED. That triple satisfies the cofactored verification equation for every message, so non-strict `verify()` ACCEPTS it while `verify_strict()` rejects it — empirically confirmed under the pinned `ed25519-dalek =3.0.0-pre.7` (a standalone run showed `verify().is_ok() == true` AND `verify_strict().is_err() == true` for the identity triple). Each site test FAILS if the site is reverted to non-strict `verify()` (verified by temporarily reverting `nucleus-receipt`, whose test then panicked on assertion (ii)).
+  - `crates/nucleus-receipt/src/lib.rs` → `tests::small_order_key_is_rejected_by_verify_strict`
+  - `crates/nucleus-verifier-service/src/auth.rs` → `auth::tests::small_order_key_is_rejected_by_verify_strict`
+  - `crates/nucleus-witness/src/cosign.rs` → `cosign::tests::small_order_key_is_rejected_by_verify_strict`
+- Note: the three crates have no dedicated adversarial/small-order corpus module to extend; the small-order case is carried by the per-site unit tests above.
+
+Status
+- [DONE] All three sites use `verify_strict`; new + existing suites pass (`cargo test -p nucleus-receipt -p nucleus-verifier-service -p nucleus-witness`), `cargo fmt` clean, `cargo clippy` on the three crates has no new warnings.

--- a/crates/nucleus-receipt/src/lib.rs
+++ b/crates/nucleus-receipt/src/lib.rs
@@ -63,7 +63,7 @@
 //!   projections; they instantiate this envelope, they don't define it.
 
 use base64::Engine;
-use ed25519_dalek::{Signer, Verifier};
+use ed25519_dalek::Signer;
 use serde::{Deserialize, Serialize};
 
 pub const RECEIPT_VERSION: u32 = 1;
@@ -184,7 +184,7 @@ impl Receipt {
             .try_into()
             .map_err(|_| ReceiptError::InvalidSignatureEncoding("len != 64".into()))?;
         let sig = ed25519_dalek::Signature::from_bytes(&sig_array);
-        vk.verify(&canonical, &sig)
+        vk.verify_strict(&canonical, &sig)
             .map_err(|e| ReceiptError::SignatureMismatch(e.to_string()))?;
         Ok(())
     }
@@ -287,6 +287,57 @@ mod tests {
             receipt.verify(&vk_b),
             Err(ReceiptError::SignatureMismatch(_))
         ));
+    }
+
+    /// Ed25519 identity/neutral-point key encoding: y = 1, x = 0, sign 0.
+    /// A small-order (order-1) verifying key.
+    fn identity_vk_bytes() -> [u8; 32] {
+        let mut id = [0u8; 32];
+        id[0] = 1;
+        id
+    }
+
+    /// The "identity triple" signature: R = identity encoding, s = 0.
+    /// For A = R = identity and s = 0 the cofactored verification
+    /// equation `[s]B == R + [k]A` reduces to `identity == identity` for
+    /// EVERY message, so non-strict `verify()` ACCEPTS it under the
+    /// identity key — a key-substitution / weak-binding forgery. Strict
+    /// `verify_strict()` rejects it because it refuses small-order A/R.
+    fn identity_sig_bytes() -> [u8; 64] {
+        let mut sig = [0u8; 64];
+        sig[..32].copy_from_slice(&identity_vk_bytes()); // R = identity, s = 0
+        sig
+    }
+
+    /// M-2 strong-binding regression (site: `Receipt::verify`, the
+    /// `vk.verify_strict` call). Proves the receipt trust path rejects a
+    /// small-order-key forgery that non-strict `vk.verify` would ACCEPT.
+    /// If line 187 is reverted to `vk.verify(...)`, assertion (ii) fails.
+    #[test]
+    fn small_order_key_is_rejected_by_verify_strict() {
+        // (i) No regression: an honest keypair still verifies end-to-end.
+        let sk = ed25519_dalek::SigningKey::from_bytes(&[42u8; 32]);
+        let honest_vk: [u8; 32] = sk.verifying_key().to_bytes();
+        let honest = Receipt::sign(dummy_session(), dummy_projections(), &sk);
+        honest
+            .verify(&honest_vk)
+            .expect("honest receipt must still verify through verify_strict");
+
+        // (ii) Strong binding: take a well-formed receipt (correct root
+        // hash over session+projections), swap in the identity-triple
+        // signature, and verify against the small-order identity key.
+        // Non-strict `verify` accepts this; `verify_strict` rejects it.
+        let mut forged = Receipt::sign(dummy_session(), dummy_projections(), &sk);
+        forged.signature_b64 =
+            base64::engine::general_purpose::STANDARD.encode(identity_sig_bytes());
+        assert!(
+            matches!(
+                forged.verify(&identity_vk_bytes()),
+                Err(ReceiptError::SignatureMismatch(_))
+            ),
+            "small-order identity key must be REJECTED by verify_strict; \
+             a revert to non-strict verify() would ACCEPT this forgery"
+        );
     }
 
     #[test]

--- a/crates/nucleus-verifier-service/src/auth.rs
+++ b/crates/nucleus-verifier-service/src/auth.rs
@@ -28,7 +28,7 @@
 //! no-op), not replay-PREVENTED. Signature freshness (a signed `issued_at` /
 //! nonce) is a future extension and out of scope for closing the identity gap.
 
-use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+use ed25519_dalek::{Signature, VerifyingKey};
 
 use crate::error::VerifyApiError;
 
@@ -83,7 +83,7 @@ pub fn verify_detached_ed25519(
 
     // The integrity check: the signature must verify over the EXACT bytes the
     // handler will parse. A single flipped body byte fails here.
-    vk.verify(msg, &signature).map_err(|_| {
+    vk.verify_strict(msg, &signature).map_err(|_| {
         VerifyApiError::Unauthorized("signature did not verify over the request body".into())
     })?;
     Ok(vk)
@@ -164,6 +164,40 @@ mod tests {
             verify_detached_ed25519(&attacker_pk, &sig, msg),
             Err(VerifyApiError::Unauthorized(_))
         ));
+    }
+
+    /// M-2 strong-binding regression (site: `verify_detached_ed25519`,
+    /// the `vk.verify_strict` call). The Ed25519 identity/neutral key
+    /// (`[1, 0, ..., 0]`) with the identity-triple signature
+    /// (R = identity encoding, s = 0) satisfies the cofactored
+    /// verification equation for EVERY message, so non-strict `verify()`
+    /// ACCEPTS it — a key-substitution forgery. `verify_strict()` rejects
+    /// small-order keys. If line 86 is reverted to `vk.verify(...)`,
+    /// assertion (ii) below fails.
+    #[test]
+    fn small_order_key_is_rejected_by_verify_strict() {
+        // (i) No regression: an honest detached signature still verifies.
+        let sk = key(7);
+        let msg = b"the exact bytes that were signed";
+        let (pk, sig) = sign(&sk, msg);
+        verify_detached_ed25519(&pk, &sig, msg)
+            .expect("honest signature must still verify through verify_strict");
+
+        // (ii) Strong binding: identity key + identity-triple signature.
+        let mut id = [0u8; 32];
+        id[0] = 1; // identity/neutral point encoding, a small-order key
+        let identity_pk_hex = hex::encode(id);
+        let mut sig_bytes = [0u8; 64];
+        sig_bytes[..32].copy_from_slice(&id); // R = identity, s = 0
+        let identity_sig_b64 = base64::engine::general_purpose::STANDARD.encode(sig_bytes);
+        assert!(
+            matches!(
+                verify_detached_ed25519(&identity_pk_hex, &identity_sig_b64, b"any body"),
+                Err(VerifyApiError::Unauthorized(_))
+            ),
+            "small-order identity key must be REJECTED by verify_strict; \
+             a revert to non-strict verify() would ACCEPT this forgery"
+        );
     }
 
     #[test]

--- a/crates/nucleus-witness/src/cosign.rs
+++ b/crates/nucleus-witness/src/cosign.rs
@@ -24,7 +24,7 @@
 //! [c2sp.org/tlog-cosignature]: https://c2sp.org/tlog-cosignature
 
 use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
-use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
+use ed25519_dalek::{Signature, Signer, SigningKey, VerifyingKey};
 use nucleus_lineage::{ed25519_key_id, SIG_LINE_PREFIX, SIG_TYPE_COSIGNATURE};
 
 /// A witness signing identity: an Ed25519 key plus its C2SP name.
@@ -131,7 +131,7 @@ pub fn verify_cosign_line(
     let signature = Signature::from_bytes(&sig_bytes);
     let vk = VerifyingKey::from_bytes(pubkey).map_err(|_| CosignVerifyError::BadKey)?;
     let msg = WitnessKey::cosignature_message(timestamp, note_body);
-    vk.verify(&msg, &signature)
+    vk.verify_strict(&msg, &signature)
         .map_err(|_| CosignVerifyError::SignatureInvalid)?;
     Ok((timestamp, parsed.key_name))
 }
@@ -187,6 +187,49 @@ mod tests {
         let line = wk.cosign_line(b"body\n", 1234);
         let err = verify_cosign_line(&line, b"body\n", &other.verifying_key_bytes()).unwrap_err();
         assert_eq!(err, CosignVerifyError::SignatureInvalid);
+    }
+
+    /// M-2 strong-binding regression (site: `verify_cosign_line`, the
+    /// `vk.verify_strict` call). Crafts a cosignature line whose payload
+    /// carries the identity-triple signature (R = identity encoding,
+    /// s = 0) and verifies it against the Ed25519 identity/neutral key
+    /// (`[1, 0, ..., 0]`). That triple satisfies the cofactored
+    /// verification equation for EVERY message, so non-strict `verify()`
+    /// ACCEPTS it — a key-substitution forgery — while `verify_strict()`
+    /// rejects small-order keys. If line 134 is reverted to
+    /// `vk.verify(...)`, assertion (ii) below fails.
+    #[test]
+    fn small_order_key_is_rejected_by_verify_strict() {
+        // (i) No regression: an honest cosignature still verifies.
+        let wk = WitnessKey::from_seed([42u8; 32], "nucleus.witness/honest");
+        let note_body = b"nucleus.example/log\n5\ncm9vdA==\n";
+        let honest_line = wk.cosign_line(note_body, 1_700_000_000);
+        verify_cosign_line(&honest_line, note_body, &wk.verifying_key_bytes())
+            .expect("honest cosignature must still verify through verify_strict");
+
+        // (ii) Strong binding: craft a line embedding the identity-triple
+        // signature. `verify_cosign_line` uses the passed pubkey (not the
+        // key_id), so the 4 key_id bytes are arbitrary. Payload layout is
+        // keyID(4) || timestamp(8, big-endian) || sig(64).
+        let mut id = [0u8; 32];
+        id[0] = 1; // identity/neutral point encoding, a small-order key
+        let mut sig_bytes = [0u8; 64];
+        sig_bytes[..32].copy_from_slice(&id); // R = identity, s = 0
+        let timestamp: u64 = 1_700_000_000;
+        let mut payload = Vec::with_capacity(4 + 8 + 64);
+        payload.extend_from_slice(&[0u8; 4]); // arbitrary key_id
+        payload.extend_from_slice(&timestamp.to_be_bytes());
+        payload.extend_from_slice(&sig_bytes);
+        let forged_line = format!(
+            "{SIG_LINE_PREFIX}nucleus.witness/honest {}",
+            B64.encode(&payload)
+        );
+        assert_eq!(
+            verify_cosign_line(&forged_line, note_body, &id).unwrap_err(),
+            CosignVerifyError::SignatureInvalid,
+            "small-order identity key must be REJECTED by verify_strict; \
+             a revert to non-strict verify() would ACCEPT this forgery"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What
Three Ed25519 re-verify sites on the trust path used non-strict `vk.verify(...)`, while the core uses `verify_strict`. Non-strict verification cofactors the check and accepts **small-order / non-canonical public keys**, which enables key-substitution / weak-binding (one signature verifying under multiple identities) — audit **M-2**. This aligns the re-verify paths with the core's discipline (the thing checked on re-verify must match what the core proves/uses).

## Fix
`vk.verify(...)` → `vk.verify_strict(...)` at:
- `nucleus-receipt/src/lib.rs:187` (`Receipt::verify`)
- `nucleus-verifier-service/src/auth.rs:86` (`verify_detached_ed25519`)
- `nucleus-witness/src/cosign.rs:134` (`verify_cosign_line`)

`verify_strict` rejects only a subset no honest dalek keygen ever produces (small-order `A`), so **zero compatibility risk** for legitimate signatures. Pure tightening — same dep, stricter call; no threat-model / TCB / outward-claim change.

## Regression guard (strong)
Per site: (i) an honest signature still verifies; (ii) the Ed25519 **identity/neutral key** (`[1,0,…,0]`) with signature `R=identity ‖ s=0` — which non-strict `verify()` **accepts** for any message but `verify_strict()` **rejects** — is refused through the site's real public verify function. Proven against the pinned `ed25519-dalek =3.0.0-pre.7` (`NON_STRICT_OK=true STRICT_ERR=true`); reverting any site to `verify()` makes its test fail.

## Ledger
`SECURITY_TODO.md`: M-2 → DONE. Also closes the C-1 `mcp.rs:171` fresh-tracker leg as **WON'T-FIX / not-live** — the HTTP and MCP-stdio front-ends are mutually exclusive (`main.rs:255-260`, early `return mcp::run_mcp_server(...)` at `:1426-1427` before the axum Router/tracker is built), so the two `FlowTracker`s are never co-live; no intra-process laundering seam.

Note: two further `VerifyingKey::verify` sites (`verifier-service/src/witness.rs:162`, `nucleus-witness/src/server.rs:249`) are outside M-2's stated three-site scope and left untouched — flagged for a follow-up decision on full-repo strictness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)