### PR TITLE
crypto: verify_strict everywhere on the Ed25519 trust path + CI ratchet-gate (audit M-3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,15 @@ jobs:
       - name: cargo fmt
         run: cargo fmt --all -- --check
 
+  verify-strict:
+    name: Ed25519 verify_strict gate (M-3)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+      - name: Forbid non-strict dalek .verify(...) on trust paths
+        run: scripts/check-verify-strict.sh
+
   clippy:
     name: Clippy
     runs-on: ubuntu-latest

--- a/SECURITY_TODO.md
+++ b/SECURITY_TODO.md
@@ -266,3 +266,61 @@ Strong-binding rationale + tests
 
 Status
 - [DONE] All three sites use `verify_strict`; new + existing suites pass (`cargo test -p nucleus-receipt -p nucleus-verifier-service -p nucleus-witness`), `cargo fmt` clean, `cargo clippy` on the three crates has no new warnings.
+- SUBSUMED by item 15 (audit M-3), which completes the whole class (every remaining dalek trust-path re-verify) and adds a CI grep-gate so the property cannot silently regress. The three M-2 sites and their tests are unchanged and remain covered by the gate.
+
+## 15) Ed25519 non-strict `verify()` — remainder of the class + CI ratchet (audit M-3)
+
+Deficiency
+- Beyond the three M-2 sites, the rest of the codebase still had `ed25519_dalek::VerifyingKey::verify(msg, &sig)` (non-strict, cofactored) on production trust paths. Non-strict verification accepts small-order / non-canonical public keys and `R` points, so the Ed25519 identity/neutral key with an "identity-triple" signature verifies under any message → key-substitution / weak signature-to-identity binding. M-3 finishes the class (converts every remaining dalek site to `verify_strict`) and installs a durable CI gate.
+
+TODO — conversions (all [DONE])
+- Swapped `vk.verify(msg, &sig)` → `vk.verify_strict(msg, &sig)` at every production dalek trust-path re-verify below, and removed the now-unused `ed25519_dalek::Verifier` trait import from each module (`verify_strict` is an inherent method, so the deny-warnings build stays clean). `verify_strict` is strictly stronger — it additionally rejects small-order/non-canonical `A` and `R`.
+  - `crates/nucleus-verifier-service/src/witness.rs:162` (peer STH cosignature verify)
+  - `crates/nucleus-witness/src/server.rs:249` (trusted-key STH signature verify)
+  - `crates/nucleus-oidc-provider/src/token.rs:237` (subject_token / JWT-SVID — identity trust root)
+  - `crates/nucleus-provenance/src/lib.rs:230` (DSSE attestation signature verify)
+  - `crates/nucleus-node-binding/src/lib.rs:148` (node↔principal passport binding verify)
+  - `crates/nucleus-provenance-memory/src/declassify.rs:172` (threshold human-auth declassify cosignature — HIGH value)
+  - `crates/nucleus-control-plane-server/src/auth.rs:259` (control-plane JWT-SVID auth — identity trust root; found by workspace sweep, not in the original M-3 list)
+  - `crates/nucleus-externality/src/claim.rs:137` (oracle claim signature verify; found by sweep)
+  - `crates/nucleus-witness-gossip/src/lib.rs:119` (`verify_head` cosignature/v1 verify; found by sweep)
+  - `crates/nucleus-witness-olog/src/pin.rs:139` (pinned-log checkpoint signature verify; found by sweep)
+  - `crates/nucleus-witness-olog/src/manifest.rs:140` (accumulation-manifest signature verify; found by sweep)
+  - `crates/nucleus-witness-olog/src/bond.rs:200` (bond evidence signature verify; found by sweep)
+
+Wrapper `.verify(...)` methods traced to their inner dalek call — already strict, no change:
+- `nucleus-receipt::Receipt::verify` (`lib.rs:187`, from M-2), reached via `nucleus-recompute::verify_signed_clearing` and `nucleus-agent-card` e2e — inner call is `verify_strict`.
+- `nucleus-lineage::SignedTreeHead::verify` → `Ed25519Witness::verify_canonical` (`checkpoint.rs:273,308`) — `verify_strict`. Reached via `nucleus-lineage::merkle::verify_log` and `nucleus-envelope::verify.rs:904`.
+
+SKIPs (with justification)
+- Every `portcullis` verify site — `certificate.rs` (authority/block/PoP ~923/949/983), `token_sign.rs:50`, `receipt_sign.rs:72`, `manifest_registry.rs:99/141` — and `nucleus-identity::approval_bundle.rs:425` (reached via `nucleus-tool-proxy/src/main.rs:583`): these verify with **`ring` (`UnparsedPublicKey` + `signature::ED25519`), not `ed25519-dalek`**. `ring` exposes no `verify_strict`, so the M-3 mechanism does not apply. NOTE: these are NOT already safe — see the sibling finding below.
+- `crates/nucleus-agent-card/src/jwk.rs:134`: **P-256 ECDSA (ES256)** via `p256::ecdsa` (`VerifyingKey::from_sec1_bytes`), not Ed25519.
+- `portcullis` `galois.rs` / `intent.rs` `connection.verify(l, r)` / `bridge.verify(...)`: Galois-connection lattice check, not a signature verify.
+- `portcullis` `escalation.rs` / `receipt_chain.rs` / `token.rs` `chain.verify()` / `token.verify(now, depth)`: hash-chain + ring signature wrappers, no dalek path.
+- Test-only dalek `.verify(...)`: `nucleus-oidc-provider` `issuer.rs:686`, `keystore/memory.rs:238/275`, `keystore/rotator.rs:240`; `nucleus-lineage/src/file_signer.rs:145`; and all `crates/*/tests/` integration tests. `#[cfg(test)]` / test-dir only — not a production trust path.
+- Signing (not verifying) calls (`.sign(...)`): out of scope by definition.
+
+CI grep-gate (the durable ratchet) — [DONE]
+- `scripts/check-verify-strict.sh` (+ commented allowlist `scripts/verify-strict-allowlist.txt`), wired into `.github/workflows/ci.yml` as job `verify-strict` ("Ed25519 verify_strict gate (M-3)"). It scans only files importing `ed25519_dalek`, strips `#[cfg(test)]` blocks and `tests/`/`benches/` dirs and comment lines, and FAILS (exit 1) on any two-argument `.verify(_, &sig)` that is not `verify_strict` and not in the allowlist. Prefers `rg`, falls back to POSIX `grep`.
+- PROVEN TO BITE: planting `.verify(&canonical_claim_bytes(claim), &sig)` back into `nucleus-externality/src/claim.rs` made the gate exit 1 and print the offending `file:line`; removing the plant returned it to exit 0 / PASSED.
+
+Regression tests (identity-triple, `[1,0,…,0]` key + `R=identity‖s=0`) — [DONE]
+- Three crown-jewel dalek paths, each driven through the site's REAL public function, each with (i) honest signature still verifies and (ii) identity-triple REFUSED; each FAILS if its site is reverted to non-strict (verified by temporary revert → assertion panic):
+  - `crates/nucleus-oidc-provider/src/token.rs` → `token::tests::small_order_key_is_rejected_by_verify_strict` (full token-exchange handler; forged token otherwise valid → 400 invalid_grant under strict, would be 200 under non-strict).
+  - `crates/nucleus-provenance-memory/src/declassify.rs` → `declassify::tests::small_order_key_is_rejected_by_verify_strict` (threshold declassify; forged cosignature must not reach the quorum).
+  - `crates/nucleus-control-plane-server/src/auth.rs` → `auth::tests::small_order_key_is_rejected_by_verify_strict` (JWT-SVID auth; forged principal must be rejected). NOTE: substituted for the originally-suggested "portcullis certificate verify", which is a `ring` path (see sibling finding) with no `verify_strict` to guard.
+
+Status
+- [DONE] All 12 dalek sites use `verify_strict`; CI-gated by `scripts/check-verify-strict.sh`. `cargo test` green on all touched crates (`nucleus-node-binding`, `nucleus-verifier-service`, `nucleus-provenance`, `nucleus-oidc-provider`, `nucleus-provenance-memory`, `nucleus-witness`, `nucleus-witness-gossip`, `nucleus-witness-olog`, `nucleus-control-plane-server`, `nucleus-externality`); `cargo fmt --all --check` clean; `cargo clippy --all-targets -- -D warnings` clean on all touched crates.
+
+## 16) [SIBLING of M-3, NEW — needs owner triage] `ring` Ed25519 trust-path verifies accept small-order/identity-triple signatures
+
+Deficiency
+- The `ring`-backed Ed25519 verifies (portcullis `certificate.rs`, `token_sign.rs`, `receipt_sign.rs`, `manifest_registry.rs`; `nucleus-identity::approval_bundle.rs`) have the SAME weak-binding weakness M-3 fixes for dalek, and it is NOT fixable with `verify_strict` (ring has no such API). Empirically confirmed under the repo's pinned `ring`: `UnparsedPublicKey::new(&signature::ED25519, [1,0,…,0]).verify(b"any message", &identity_triple)` returns `Ok` (`RING_DIRECT_IDENTITY_TRIPLE_ACCEPTED = true`), and `verify_certificate` with the identity root key passed the authority-signature check (it only later failed proof-of-possession because mutating the signature changed the block hash). So a delegation chain whose in-band `next_key` is set to the identity key can have the next hop "signed" by nobody, and any trust anchor pinned to the identity key is forgeable.
+- Exploitability varies by site: certificate DELEGATION `next_key` travels in-band (attacker-influenced) → highest concern; `verify_certificate` root key, `TrustStore`, and token/receipt keys are caller-pinned (lower, but still weak-binding).
+
+TODO
+- [ ] Owner decision required — not fixed here (out of M-3's stated dalek/`verify_strict` scope; it is a load-bearing crypto change). Options: (a) add an explicit small-order/canonical-encoding rejection of the public key and `R` around each ring verify; or (b) migrate these trust-path verifies to `ed25519-dalek::verify_strict`. Either way, extend `scripts/check-verify-strict.sh` to cover the ring paths once a canonical form is chosen.
+
+Status
+- [OPEN] Reported by the M-3 sweep; deliberately left unfixed pending owner triage.

--- a/crates/nucleus-control-plane-server/src/auth.rs
+++ b/crates/nucleus-control-plane-server/src/auth.rs
@@ -37,7 +37,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use axum::extract::FromRequestParts;
 use axum::http::{header, request::Parts, StatusCode};
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD as B64URL, Engine as _};
-use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+use ed25519_dalek::{Signature, VerifyingKey};
 use nucleus_oidc_core::{JwkPublicKey, Jwks};
 use serde::Deserialize;
 use thiserror::Error;
@@ -256,7 +256,7 @@ pub fn verify_jwt_svid(
     let signature = Signature::from_bytes(&sig_array);
 
     let signed_input = format!("{header_b64}.{payload_b64}");
-    vk.verify(signed_input.as_bytes(), &signature)
+    vk.verify_strict(signed_input.as_bytes(), &signature)
         .map_err(|_| AuthError::BadSignature)?;
 
     let payload_bytes = B64URL
@@ -470,6 +470,73 @@ mod tests {
             "spiffe://prod.example.com/ns/agents/sa/coder"
         );
         assert!(principal.authenticated);
+    }
+
+    /// M-3 strong-binding regression for the control-plane JWT-SVID trust
+    /// root (site: `verify_jwt_svid`, the `vk.verify_strict(...)` call). The
+    /// Ed25519 identity/neutral key (`[1, 0, ..., 0]`) with the identity-
+    /// triple signature (R = identity encoding, s = 0) satisfies the
+    /// COFACTORED verification equation for EVERY message, so non-strict
+    /// `verify()` ACCEPTS it. The crafted JWT below is otherwise fully valid
+    /// (matching subject prefix + audience, fresh exp) and the identity key
+    /// is the sole trusted JWKS key, so under non-strict `verify()`
+    /// authentication SUCCEEDS for a FORGED principal. `verify_strict()`
+    /// rejects the small-order key → `BadSignature`. If the site reverts to
+    /// `vk.verify(...)`, assertion (ii) sees `Ok(..)` and fails.
+    #[test]
+    fn small_order_key_is_rejected_by_verify_strict() {
+        // (i) No regression: an honest JWT-SVID still authenticates.
+        let f = Fixture::new();
+        let token = f.mint(
+            "spiffe://prod.example.com/ns/agents/sa/coder",
+            "https://control.nucleus.local/api",
+            600,
+        );
+        verify_jwt_svid(&token, &config(f.jwks()))
+            .expect("honest JWT-SVID must still authenticate through verify_strict");
+
+        // (ii) Strong binding: trust the small-order identity key and present
+        //      a JWT "signed" with the identity triple.
+        let mut id = [0u8; 32];
+        id[0] = 1; // identity/neutral point encoding — a small-order key
+        let kid = "id-key".to_string();
+        let jwks = Jwks {
+            keys: vec![Jwk {
+                kty: "OKP".to_string(),
+                kid: kid.clone(),
+                alg: Some("EdDSA".to_string()),
+                use_: Some("sig".to_string()),
+                crv: Some("Ed25519".to_string()),
+                x: Some(B64URL.encode(id)),
+                y: None,
+                n: None,
+                e: None,
+            }],
+        };
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+        let header_json = format!(r#"{{"alg":"EdDSA","kid":"{kid}"}}"#);
+        let payload = json!({
+            "sub": "spiffe://prod.example.com/ns/agents/sa/coder",
+            "aud": "https://control.nucleus.local/api",
+            "exp": (now + 600) as u64,
+            "iat": now,
+        });
+        let header_b64 = B64URL.encode(header_json.as_bytes());
+        let payload_b64 = B64URL.encode(payload.to_string().as_bytes());
+        let mut sig = [0u8; 64];
+        sig[..32].copy_from_slice(&id); // R = identity, s = 0
+        let sig_b64 = B64URL.encode(sig);
+        let forged = format!("{header_b64}.{payload_b64}.{sig_b64}");
+        let err = verify_jwt_svid(&forged, &config(jwks)).unwrap_err();
+        assert!(
+            matches!(err, AuthError::BadSignature),
+            "identity-triple JWT-SVID must be REFUSED by verify_strict; a \
+             revert to non-strict verify() would authenticate a forged \
+             principal (got {err:?})"
+        );
     }
 
     #[test]

--- a/crates/nucleus-externality/src/claim.rs
+++ b/crates/nucleus-externality/src/claim.rs
@@ -34,7 +34,7 @@
 //! `u64` — no floats anywhere.
 
 use base64::{engine::general_purpose::STANDARD, Engine as _};
-use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
+use ed25519_dalek::{Signature, Signer, SigningKey, VerifyingKey};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -134,7 +134,7 @@ pub fn verify_claim(
     buf.copy_from_slice(&sig_bytes);
     let sig = Signature::from_bytes(&buf);
     oracle_vk
-        .verify(&canonical_claim_bytes(claim), &sig)
+        .verify_strict(&canonical_claim_bytes(claim), &sig)
         .map_err(|e| ClaimError::SignatureInvalid(e.to_string()))?;
 
     // 2. Freshness window.

--- a/crates/nucleus-node-binding/src/lib.rs
+++ b/crates/nucleus-node-binding/src/lib.rs
@@ -58,7 +58,7 @@
 //! verify_binding(&binding, &passport_pk).expect("binding verifies");
 //! ```
 
-use ed25519_dalek::{Signer, Verifier};
+use ed25519_dalek::Signer;
 use serde::{Deserialize, Serialize};
 
 /// Domain-separation prefix for the signed binding message.
@@ -145,7 +145,7 @@ pub fn verify_binding(
     let vk = ed25519_dalek::VerifyingKey::from_bytes(trusted_passport_pubkey)
         .map_err(|e| BindingError::InvalidKey(e.to_string()))?;
     let sig = ed25519_dalek::Signature::from_bytes(&binding.sig);
-    vk.verify(&msg, &sig)
+    vk.verify_strict(&msg, &sig)
         .map_err(|e| BindingError::SignatureMismatch(e.to_string()))?;
     Ok(())
 }

--- a/crates/nucleus-oidc-provider/src/token.rs
+++ b/crates/nucleus-oidc-provider/src/token.rs
@@ -233,11 +233,11 @@ pub async fn handler(
         OidcApiError::InvalidGrant("subject_token sig wrong length (Ed25519 = 64 bytes)".into())
     })?;
     let sig = ed25519_dalek::Signature::from_bytes(&sig_arr);
-    use ed25519_dalek::Verifier;
-    vk.verify(signing_input.as_bytes(), &sig).map_err(|e| {
-        tracing::warn!(error = %e, "subject_token signature verify failed");
-        OidcApiError::InvalidGrant("subject_token signature verify failed".into())
-    })?;
+    vk.verify_strict(signing_input.as_bytes(), &sig)
+        .map_err(|e| {
+            tracing::warn!(error = %e, "subject_token signature verify failed");
+            OidcApiError::InvalidGrant("subject_token signature verify failed".into())
+        })?;
 
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -566,6 +566,110 @@ mod tests {
         assert_eq!(v["token_type"], "Bearer");
         assert!(v["expires_in"].as_u64().unwrap() > 0);
         assert!(v["expires_in"].as_u64().unwrap() <= 300);
+    }
+
+    /// M-3 strong-binding regression for the OIDC subject_token trust root
+    /// (site: subject_token signature check, the `vk.verify_strict(...)`
+    /// call). The Ed25519 identity/neutral key (`[1, 0, ..., 0]`) with the
+    /// identity-triple signature (R = identity encoding, s = 0) satisfies
+    /// the COFACTORED verification equation for EVERY message, so non-strict
+    /// `verify()` ACCEPTS it. The crafted subject_token below is otherwise
+    /// fully valid (valid SPIFFE `sub`, fresh `exp`/`jti`, matching
+    /// `audience`) and the identity key is registered in the trust bundle,
+    /// so under non-strict `verify()` the exchange SUCCEEDS (200) and mints
+    /// an access token bound to a FORGED identity. `verify_strict()` rejects
+    /// the small-order key → 400 invalid_grant. If the site reverts to
+    /// `vk.verify(...)`, assertion (ii) sees 200 OK and fails.
+    #[tokio::test]
+    async fn small_order_key_is_rejected_by_verify_strict() {
+        use ed25519_dalek::VerifyingKey;
+
+        // (i) No regression: an honest token still succeeds.
+        let honest = make_subject_jwt("spiffe://prod.example.com/ns/agents/sa/coder", 300, None);
+        let honest_body = form_body(&[
+            ("grant_type", TOKEN_EXCHANGE_GRANT),
+            ("subject_token", &honest),
+            ("subject_token_type", TOKEN_TYPE_JWT),
+            ("audience", "https://rp-a.example/api"),
+        ]);
+        assert_eq!(
+            post_token(app(), honest_body).await.status(),
+            StatusCode::OK
+        );
+
+        // Build an app whose trust bundle contains the small-order identity
+        // key under the trust domain the federation rule allows.
+        let mut id = [0u8; 32];
+        id[0] = 1; // identity/neutral point encoding — a small-order key
+        let identity_vk =
+            VerifyingKey::from_bytes(&id).expect("identity point is a valid Ed25519 encoding");
+        let identity_kid = crate::keystore::rfc7638_kid(&identity_vk);
+
+        let store: Arc<dyn JwtKeyStore> = Arc::new(InMemoryKeyStore::new());
+        let issuer = Arc::new(
+            JwtIssuer::new(
+                store.clone(),
+                "https://oidc.nucleus.example/".to_string(),
+                Duration::from_secs(300),
+            )
+            .unwrap(),
+        );
+        let rules = crate::federation::FederationRules {
+            rule: vec![crate::federation::FederationRule {
+                id: "test-allow".to_string(),
+                subject_prefix: "spiffe://prod.example.com/*".to_string(),
+                audience: "https://rp-a.example/api".to_string(),
+                allowed_grants: vec![TOKEN_EXCHANGE_GRANT.to_string()],
+                max_token_lifetime_secs: 3600,
+            }],
+        };
+        let federation = Arc::new(crate::federation::FederationRegistry::new(rules));
+        let bundle = crate::spire::StaticBundleProvider::new();
+        bundle.add_key("prod.example.com", identity_kid.clone(), identity_vk);
+        let forged_app = crate::app::build_app(crate::app::AppState {
+            keystore: store,
+            issuer_url: Arc::from("https://oidc.nucleus.example/"),
+            issuer,
+            jti_cache: Arc::new(JtiCache::new()),
+            federation,
+            bundle_provider: Arc::new(bundle),
+        });
+
+        // (ii) Strong binding: a subject_token that is fully valid EXCEPT
+        //      that it carries the identity-triple signature under the
+        //      registered small-order identity key.
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+        let exp = (now + 300) as u64;
+        let jti = Uuid::new_v4().to_string();
+        let header_json = format!(r#"{{"alg":"EdDSA","kid":"{identity_kid}","typ":"JWT"}}"#);
+        let payload_json = format!(
+            r#"{{"sub":"spiffe://prod.example.com/ns/agents/sa/coder","exp":{exp},"jti":"{jti}"}}"#
+        );
+        let header_b64 = URL_SAFE_NO_PAD.encode(header_json.as_bytes());
+        let payload_b64 = URL_SAFE_NO_PAD.encode(payload_json.as_bytes());
+        let mut sig_bytes = [0u8; 64];
+        sig_bytes[..32].copy_from_slice(&id); // R = identity, s = 0
+        let sig_b64 = URL_SAFE_NO_PAD.encode(sig_bytes);
+        let forged = format!("{header_b64}.{payload_b64}.{sig_b64}");
+        let forged_body = form_body(&[
+            ("grant_type", TOKEN_EXCHANGE_GRANT),
+            ("subject_token", &forged),
+            ("subject_token_type", TOKEN_TYPE_JWT),
+            ("audience", "https://rp-a.example/api"),
+        ]);
+        let resp = post_token(forged_app, forged_body).await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "identity-triple subject_token must be REFUSED by verify_strict; a \
+             revert to non-strict verify() would mint an access token for a \
+             forged identity"
+        );
+        let v = body_to_value(resp.into_body()).await;
+        assert_eq!(v["error"], "invalid_grant");
     }
 
     #[tokio::test]

--- a/crates/nucleus-provenance-memory/src/declassify.rs
+++ b/crates/nucleus-provenance-memory/src/declassify.rs
@@ -15,7 +15,7 @@
 
 use std::collections::BTreeSet;
 
-use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
+use ed25519_dalek::{Signature, Signer, SigningKey, VerifyingKey};
 use portcullis_core::memory::{MemoryAuthority, MemoryLabel};
 use portcullis_core::{DerivationClass, IntegLevel};
 use serde::{Deserialize, Serialize};
@@ -169,7 +169,7 @@ pub fn declassify(
         let Ok(sig) = Signature::from_slice(sig_bytes) else {
             continue;
         };
-        if vk.verify(&msg, &sig).is_ok() {
+        if vk.verify_strict(&msg, &sig).is_ok() {
             verified.insert(*pk_bytes);
         }
     }
@@ -255,6 +255,50 @@ mod tests {
         // Promoted to informing (Untrusted), but ancestry preserved (not Deterministic).
         assert_eq!(label.integ_level(), IntegLevel::Untrusted);
         assert_ne!(label.derivation, DerivationClass::Deterministic);
+    }
+
+    /// M-3 strong-binding regression (site: `declassify`, the
+    /// `vk.verify_strict(&msg, &sig)` cosignature check). The Ed25519
+    /// identity/neutral key (`[1, 0, ..., 0]`) with the identity-triple
+    /// signature (R = identity encoding, s = 0) satisfies the COFACTORED
+    /// verification equation for every message, so non-strict `verify()`
+    /// ACCEPTS it — a forged threshold cosignature. `verify_strict()`
+    /// rejects the small-order key. If the site is reverted to non-strict
+    /// `vk.verify(...)`, assertion (ii) counts the forged key and the
+    /// adversarial record is (wrongly) PROMOTED.
+    #[test]
+    fn small_order_key_is_rejected_by_verify_strict() {
+        // (i) No regression: an honest 2-of-2 quorum still promotes.
+        let rec = web_record();
+        let honest_trusted = [
+            key(1).verifying_key().to_bytes(),
+            key(2).verifying_key().to_bytes(),
+        ];
+        let honest = SignedDeclassify::new(human_witness(&rec))
+            .cosign(&key(1))
+            .cosign(&key(2));
+        declassify(&rec, &honest, &honest_trusted, 2)
+            .expect("honest quorum must still promote through verify_strict");
+
+        // (ii) Strong binding: the small-order identity key with the
+        // identity-triple signature must NOT count as a valid witness.
+        let mut id = [0u8; 32];
+        id[0] = 1; // identity/neutral point encoding — a small-order key
+        let mut sig_bytes = [0u8; 64];
+        sig_bytes[..32].copy_from_slice(&id); // R = identity, s = 0
+        let mut forged = SignedDeclassify::new(human_witness(&rec));
+        forged.signatures.push((id, sig_bytes.to_vec()));
+        // Trust the identity key and require just one witness: the only way
+        // to reach the threshold is for the forged cosignature to verify.
+        assert!(
+            matches!(
+                declassify(&rec, &forged, &[id], 1),
+                Err(DeclassifyError::InsufficientWitnesses { got: 0, need: 1 })
+            ),
+            "small-order identity key must be REJECTED by verify_strict; a \
+             revert to non-strict verify() would COUNT this forged cosignature \
+             and promote an adversarial record"
+        );
     }
 
     #[test]

--- a/crates/nucleus-provenance/src/lib.rs
+++ b/crates/nucleus-provenance/src/lib.rs
@@ -28,7 +28,7 @@
 
 use std::collections::BTreeMap;
 
-use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+use ed25519_dalek::{Signature, VerifyingKey};
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
 
@@ -227,7 +227,7 @@ fn signed_by_trusted(att: &SignedAttestation, trusted: &[TrustedKey]) -> bool {
             continue;
         };
         let signature = Signature::from_bytes(&sig_arr);
-        if vk.verify(&msg, &signature).is_ok() {
+        if vk.verify_strict(&msg, &signature).is_ok() {
             return true;
         }
     }

--- a/crates/nucleus-verifier-service/src/witness.rs
+++ b/crates/nucleus-verifier-service/src/witness.rs
@@ -35,7 +35,7 @@ use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::Result;
-use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+use ed25519_dalek::{Signature, VerifyingKey};
 use tokio::sync::RwLock;
 
 /// How many recent peer cosignatures the in-memory ring retains.
@@ -159,7 +159,7 @@ impl WitnessFederation {
             .try_into()
             .map_err(|_| WitnessError::BadSignature)?;
         let signature = Signature::from_bytes(&sig_array);
-        vk.verify(sth_json.as_bytes(), &signature)
+        vk.verify_strict(sth_json.as_bytes(), &signature)
             .map_err(|_| WitnessError::BadSignature)?;
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)

--- a/crates/nucleus-witness-gossip/src/lib.rs
+++ b/crates/nucleus-witness-gossip/src/lib.rs
@@ -46,7 +46,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+use ed25519_dalek::{Signature, VerifyingKey};
 use nucleus_witness::WitnessKey;
 use serde::{Deserialize, Serialize};
 
@@ -116,7 +116,7 @@ pub fn verify_head(head: &SignedWitnessHead, trusted_pubkey: &[u8; 32]) -> bool 
     };
     let msg = WitnessKey::cosignature_message(head.timestamp, &head.note_body);
     let sig = Signature::from_bytes(&head.sig);
-    vk.verify(&msg, &sig).is_ok()
+    vk.verify_strict(&msg, &sig).is_ok()
 }
 
 /// Verify all heads and collect the witness names whose signatures

--- a/crates/nucleus-witness-olog/src/bond.rs
+++ b/crates/nucleus-witness-olog/src/bond.rs
@@ -54,7 +54,7 @@
 //!   axioms `[propext, Quot.sound]`-only) — see [`FORK_COST_THEOREM_MODELED`].
 
 use base64::{engine::general_purpose::STANDARD, Engine as _};
-use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
+use ed25519_dalek::{Signature, Signer, SigningKey, VerifyingKey};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use thiserror::Error;
@@ -197,7 +197,7 @@ fn verify_bytes(vk: &VerifyingKey, msg: &[u8], sig_b64: &str) -> Result<(), Bond
     }
     let mut buf = [0u8; 64];
     buf.copy_from_slice(&sig_bytes);
-    vk.verify(msg, &Signature::from_bytes(&buf))
+    vk.verify_strict(msg, &Signature::from_bytes(&buf))
         .map_err(|e| BondError::SignatureInvalid(e.to_string()))
 }
 

--- a/crates/nucleus-witness-olog/src/manifest.rs
+++ b/crates/nucleus-witness-olog/src/manifest.rs
@@ -9,7 +9,7 @@
 //! self-proving-system north star. See `docs/rfcs/witness-olog-functor.md`.
 
 use base64::{engine::general_purpose::STANDARD, Engine as _};
-use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
+use ed25519_dalek::{Signature, Signer, SigningKey, VerifyingKey};
 use nucleus_externality::AssuranceRung;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -137,7 +137,7 @@ pub fn verify_manifest(m: &AccumulationManifest, vk: &VerifyingKey) -> Result<()
     let mut buf = [0u8; 64];
     buf.copy_from_slice(&sig_bytes);
     let sig = Signature::from_bytes(&buf);
-    vk.verify(&canonical_manifest_bytes(m), &sig)
+    vk.verify_strict(&canonical_manifest_bytes(m), &sig)
         .map_err(|e| ManifestError::SignatureInvalid(e.to_string()))
 }
 

--- a/crates/nucleus-witness-olog/src/pin.rs
+++ b/crates/nucleus-witness-olog/src/pin.rs
@@ -36,7 +36,7 @@
 
 use base64::{engine::general_purpose::STANDARD, Engine as _};
 use ct_merkle::{ConsistencyProof, InclusionProof, RootHash};
-use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
+use ed25519_dalek::{Signature, Signer, SigningKey, VerifyingKey};
 use serde::{Deserialize, Serialize};
 use sha2::digest::Output;
 use sha2::Sha256;
@@ -136,7 +136,7 @@ fn verify_checkpoint_sig(c: &SignedCheckpoint, vk: &VerifyingKey) -> Result<(), 
     }
     let mut buf = [0u8; 64];
     buf.copy_from_slice(&sig_bytes);
-    vk.verify(&canonical_checkpoint_bytes(c), &Signature::from_bytes(&buf))
+    vk.verify_strict(&canonical_checkpoint_bytes(c), &Signature::from_bytes(&buf))
         .map_err(|e| TrustRejection::BadCheckpointSig(e.to_string()))
 }
 

--- a/crates/nucleus-witness/src/server.rs
+++ b/crates/nucleus-witness/src/server.rs
@@ -28,7 +28,7 @@ use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use ct_merkle::{digest::Output, ConsistencyProof, RootHash};
-use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+use ed25519_dalek::{Signature, VerifyingKey};
 use nucleus_lineage::{checkpoint_signed_bytes, ed25519_key_id, SIG_TYPE_ED25519};
 use sha2::Sha256;
 
@@ -246,7 +246,7 @@ fn check_trusted_signature(checkpoint: &Checkpoint, record: &OriginRecord) -> Re
                 }
             };
             let signature = Signature::from_bytes(&sig_arr);
-            if vk.verify(&signed_body, &signature).is_ok() {
+            if vk.verify_strict(&signed_body, &signature).is_ok() {
                 return Ok(()); // a trusted key validly signed.
             }
             saw_matching_key_bad_sig = true;

--- a/scripts/check-verify-strict.sh
+++ b/scripts/check-verify-strict.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Audit finding M-3 ratchet: forbid non-strict Ed25519 (`ed25519-dalek`)
+# re-verification on any production trust path.
+#
+# Non-strict `VerifyingKey::verify(...)` uses the *cofactored* verification
+# equation and accepts small-order / non-canonical public keys and `R`
+# points. A single crafted "identity-triple" signature then verifies under
+# multiple identities → key-substitution / weak signature-to-identity
+# binding. The strict inherent method `VerifyingKey::verify_strict(...)`
+# rejects those points. Every dalek trust-path re-verify MUST use
+# `verify_strict`.
+#
+# This gate FAILS (exit 1) if any *production* (non-`#[cfg(test)]`) call to
+# the dalek two-argument `.verify(msg, &sig)` reappears in a file that
+# imports `ed25519_dalek`, unless the exact call is listed (with a reason)
+# in scripts/verify-strict-allowlist.txt.
+#
+# Scope rationale (deliberately conservative to avoid false NEGATIVES):
+#   * Only files that mention `ed25519_dalek` are scanned, so `ring`
+#     (portcullis, nucleus-identity) and `p256` (nucleus-agent-card JWK)
+#     `.verify(` paths — which are NOT dalek and have no `verify_strict` —
+#     are never considered.
+#   * `#[cfg(test)]` modules/items are stripped before matching, so
+#     test-only `.verify(` calls do not trip the gate.
+#   * Single-argument wrapper calls (e.g. `Receipt::verify(&vk)`,
+#     `SignedTreeHead::verify(&witness)`) are NOT dalek leaf calls; the
+#     two-argument `(_, &sig)` shape distinguishes the leaf. Any wrapper
+#     that still trips the pattern is listed in the allowlist.
+#
+# Usage: scripts/check-verify-strict.sh
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel 2>/dev/null || echo .)"
+
+ALLOWLIST="scripts/verify-strict-allowlist.txt"
+
+# Prefer ripgrep (fast, honours .gitignore); fall back to POSIX grep so the
+# gate runs on any host or CI image without extra tooling.
+list_dalek_files() {
+    if command -v rg >/dev/null 2>&1; then
+        rg -l --glob '*.rs' 'ed25519_dalek' crates
+    else
+        grep -rl --include='*.rs' 'ed25519_dalek' crates
+    fi \
+        | grep -vE '/(tests|benches)/'   # integration tests/benches are test-only
+}
+
+# Load allowlist: non-empty, non-comment lines are literal code snippets
+# that are permitted to contain `.verify(` on a trust path (each with a
+# reason in a preceding comment).
+allow_snippets=()
+if [[ -f "$ALLOWLIST" ]]; then
+    while IFS= read -r line; do
+        # Trim leading/trailing whitespace.
+        trimmed="${line#"${line%%[![:space:]]*}"}"
+        trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
+        [[ -z "$trimmed" ]] && continue
+        [[ "$trimmed" == \#* ]] && continue
+        allow_snippets+=("$trimmed")
+    done < "$ALLOWLIST"
+fi
+
+# AWK program that emits `path:lineno:code` for every production line
+# (outside any #[cfg(test)] block) that contains a non-strict two-argument
+# dalek `.verify(` call. Brace-balanced #[cfg(test)] block stripping.
+read -r -d '' AWK_PROG <<'AWK' || true
+BEGIN { skip=0; brace=0; pending=0 }
+{
+    line=$0
+    # Count braces on this line without mutating the record we print.
+    tmp=line; no=gsub(/\{/,"{",tmp)
+    tmp=line; nc=gsub(/\}/,"}",tmp)
+
+    if (skip==1) {
+        brace += no - nc
+        if (brace <= 0) { skip=0; brace=0 }
+        next
+    }
+    if (line ~ /#\[cfg\(test\)\]/) { pending=1 }
+    if (pending==1 && no>0) {
+        skip=1
+        brace = no - nc
+        pending=0
+        if (brace <= 0) { skip=0; brace=0 }
+        next
+    }
+    # Skip comment lines (`//`, `///`, `//!`) — doc/example prose, not code.
+    stripped=line; sub(/^[[:space:]]+/,"",stripped)
+    if (stripped ~ /^\/\//) { next }
+    # Production line. Flag non-strict, two-argument dalek verify:
+    #   `.verify(` ... `,` ... `&` (a message and a &signature),
+    # but never `.verify_strict(`.
+    if (line ~ /\.verify[[:space:]]*\(/ && line !~ /verify_strict/ && line ~ /,[[:space:]]*&/) {
+        printf "%s:%d:%s\n", FILENAME, FNR, line
+    }
+}
+AWK
+
+# Files in scope: production Rust sources that reference the dalek crate.
+hits=()
+while IFS= read -r f; do
+    [[ -z "$f" ]] && continue
+    while IFS= read -r rec; do
+        [[ -z "$rec" ]] && continue
+        code="${rec#*:*:}"
+        trimmed="${code#"${code%%[![:space:]]*}"}"
+        trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
+        allowed=0
+        if [[ "${#allow_snippets[@]}" -gt 0 ]]; then
+            for snip in "${allow_snippets[@]}"; do
+                if [[ "$trimmed" == "$snip" ]]; then allowed=1; break; fi
+            done
+        fi
+        [[ "$allowed" -eq 1 ]] && continue
+        hits+=("$rec")
+    done < <(awk "$AWK_PROG" "$f")
+done < <(list_dalek_files || true)
+
+if [[ "${#hits[@]}" -gt 0 ]]; then
+    echo "M-3 verify-strict gate FAILED: non-strict dalek .verify(...) on a trust path:" >&2
+    printf '  %s\n' "${hits[@]}" >&2
+    echo >&2
+    echo "Fix: use VerifyingKey::verify_strict(msg, &sig) instead of .verify(...)." >&2
+    echo "If this is a legitimate non-dalek call, add the exact line to" >&2
+    echo "$ALLOWLIST with a justifying comment." >&2
+    exit 1
+fi
+
+echo "M-3 verify-strict gate PASSED: no non-strict dalek .verify(...) on any trust path."

--- a/scripts/verify-strict-allowlist.txt
+++ b/scripts/verify-strict-allowlist.txt
@@ -1,0 +1,17 @@
+# Allowlist for scripts/check-verify-strict.sh (audit finding M-3).
+#
+# Each non-comment line below is an EXACT (whitespace-trimmed) source line
+# that is permitted to contain a `.verify(msg, &sig)`-shaped call inside a
+# file that also imports `ed25519_dalek`, even though it is NOT a non-strict
+# dalek trust-path re-verify. Precede every entry with a comment giving the
+# file and the reason it is safe.
+#
+# Add an entry ONLY when the call provably does not reach
+# `ed25519_dalek::VerifyingKey::verify` (e.g. a `ring`/`p256` call that lives
+# beside dalek code, or a same-named wrapper on a different type). When in
+# doubt, convert the site to `verify_strict` instead of allowlisting it.
+#
+# There are currently no allowlisted entries: every dalek trust-path verify
+# uses `verify_strict`, and the wrapper `.verify(...)` methods
+# (`Receipt::verify(&vk)`, `SignedTreeHead::verify(&witness)`, ...) are
+# single-argument and do not match the gate's two-argument pattern.


### PR DESCRIPTION
## What
Completes M-2 as a **closed, CI-gated invariant**: every production Ed25519 (`ed25519-dalek`) trust-path re-verify uses `verify_strict`, and a CI gate fails the build if a non-strict trust-path `verify()` ever reappears. Non-strict verify cofactors the check and accepts small-order / non-canonical keys → key-substitution / weak binding.

## Converted (12 dalek leaf sites; `verify` → `verify_strict`)
STH cosig (`verifier-service/witness.rs`, `witness/server.rs`), **identity trust root** (`oidc-provider/token.rs` subject-token JWT), DSSE attestation (`nucleus-provenance`), passport binding (`node-binding`), **threshold declassify** (`provenance-memory/declassify.rs`), JWT-SVID auth (`control-plane-server/auth.rs`), oracle claim (`externality`), witness-gossip head, and 3 witness-olog sites. Wrappers (`Receipt::verify`, `SignedTreeHead::verify`) traced — already strict.

## The ratchet (the durable part)
`scripts/check-verify-strict.sh` (+ `verify-strict-allowlist.txt`), wired into `ci.yml` as job `verify-strict`: scans only `ed25519_dalek`-importing files, strips `#[cfg(test)]`, matches the two-arg dalek leaf `.verify(msg,&sig)`, fails on any un-allowlisted hit. **Proven to bite** (plant a non-strict verify → gate exits 1; remove → passes).

## Strong-binding tests (crown-jewel paths, through the real public fn)
`oidc-provider` token exchange, `provenance-memory` declassify, `control-plane` JWT-SVID auth: honest sig verifies; the identity-key triple (which non-strict `verify()` accepts) is refused; each test fails if its site is reverted.

## ⚠️ New sibling finding — SECURITY_TODO item 16 (OPEN, needs owner triage)
`portcullis` (`certificate.rs`, `token_sign.rs`, `receipt_sign.rs`, `manifest_registry.rs`) and `nucleus-identity` verify with **`ring`, not dalek** — `ring` has **no `verify_strict`**, and it was empirically confirmed that `ring`'s `ED25519.verify(identity_triple)` **accepts** the small-order key (and `verify_certificate` passed under the identity root key). So the **certificate-authority chain has the same weak-binding weakness, not fixable by this change.** Filed as item 16 (not fixed here — it's a load-bearing crypto change: explicit small-order/canonical rejection around each `ring` verify, or migrate those trust paths to dalek). No vulnerable-behavior test was shipped.

`SECURITY_TODO.md`: M-3 = item 15 (DONE), M-2 = item 14 (subsumed), ring finding = item 16 (open). No threat-model/TCB/outward-claim change for the dalek sweep itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)