### PR TITLE
fix(ci): close cfg(test) false-negative in verify-strict gate (Focus C)

### DIFF
--- a/scripts/check-verify-strict.sh
+++ b/scripts/check-verify-strict.sh
@@ -76,13 +76,19 @@ BEGIN { skip=0; brace=0; pending=0 }
         if (brace <= 0) { skip=0; brace=0 }
         next
     }
-    if (line ~ /#\[cfg\(test\)\]/) { pending=1 }
-    if (pending==1 && no>0) {
-        skip=1
-        brace = no - nc
-        pending=0
-        if (brace <= 0) { skip=0; brace=0 }
-        next
+    if (line ~ /#\[cfg\(test\)\]/) { pending=1; next }
+    if (pending==1) {
+        if (no>0) {                       # block body starts on this line
+            skip=1
+            brace = no - nc
+            pending=0
+            if (brace <= 0) { skip=0; brace=0 }
+            next
+        }
+        # cfg(test) on a non-block item (`mod tests;`, `use ...;`): no block to
+        # skip — clear pending so it does not swallow the next braced item
+        # (latent false-NEGATIVE; fix shared with scripts/check-mediation.sh).
+        if (line ~ /;/) { pending=0 }
     }
     # Skip comment lines (`//`, `///`, `//!`) — doc/example prose, not code.
     stripped=line; sub(/^[[:space:]]+/,"",stripped)


### PR DESCRIPTION
The merged M-3 `verify-strict` trust-path gate shares a latent false-**negative** with the mediation gate's original AWK: the `#[cfg(test)]` stripper armed `pending` on the attribute but only disarmed on a brace-opening line. When the attribute is on a **semicolon-item** (`#[cfg(test)] mod tests;`), `pending` stayed armed and the next braced item (a production `fn`) was swallowed as if it were the test block — so a non-strict dalek `.verify(msg, &sig)` inside that block would **not** trip the gate.

**Fix** (mirrors the one already in `scripts/check-mediation.sh`, where it was first caught): `next` after arming `pending`, and clear `pending` when the pending line is a semicolon-item with no brace, so it can't swallow the following braced item. Keeps the two gates' AWK logic identical.

**Verified:**
- Synthetic dalek file with `#[cfg(test)] mod tests;` then a production `vk.verify(msg, &sig)`: old program flags nothing, fixed program flags the call.
- Gate still PASSES on the current tree — no regression, no allowlist change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CNJdZb7LHWwXkrt9MCa8CG