### PR TITLE
refactor(action_term): rename upstream PathAllowed → FsPathAllowed (WIDEN PR-A)

### DIFF
--- a/crates/nucleus-tool-proxy/src/mcp.rs
+++ b/crates/nucleus-tool-proxy/src/mcp.rs
@@ -1145,8 +1145,8 @@ mod tests {
         let obs = term.derive_obligations();
         assert!(
             obs.iter()
-                .any(|o| matches!(o, portcullis::action_term::ProofObligation::PathAllowed)),
-            "ReadFiles should derive PathAllowed"
+                .any(|o| matches!(o, portcullis::action_term::ProofObligation::FsPathAllowed)),
+            "ReadFiles should derive FsPathAllowed"
         );
     }
 
@@ -1156,8 +1156,8 @@ mod tests {
         let obs = term.derive_obligations();
         assert!(
             !obs.iter()
-                .any(|o| matches!(o, portcullis::action_term::ProofObligation::PathAllowed)),
-            "WebFetch should NOT derive PathAllowed"
+                .any(|o| matches!(o, portcullis::action_term::ProofObligation::FsPathAllowed)),
+            "WebFetch should NOT derive FsPathAllowed"
         );
     }
 

--- a/crates/portcullis/src/action_term.rs
+++ b/crates/portcullis/src/action_term.rs
@@ -212,7 +212,7 @@ pub enum ProofObligation {
     /// Requested authority stays within the session ceiling.
     WithinDelegationCeiling,
     /// Target path is allowed by the path lattice.
-    PathAllowed,
+    FsPathAllowed,
     /// Verified outputs must not depend on AI-derived or opaque inputs.
     VerifiedSinkCompatible,
 }
@@ -250,7 +250,7 @@ impl ActionTerm {
     ///   (`AIDerived`, `Mixed`, or `OpaqueExternal`).
     /// - `InputsAuthorized` — when the claimed capability exceeds `LowRisk`
     ///   (high-risk operations require explicit content-addressing of all inputs).
-    /// - `PathAllowed` — when the action writes to the filesystem (`EditFile`).
+    /// - `FsPathAllowed` — when the action writes to the filesystem (`EditFile`).
     /// - `VerifiedSinkCompatible` — when the proposed effect targets a verified sink.
     pub fn derive_obligations(&self) -> Vec<ProofObligation> {
         let mut obs: Vec<ProofObligation> = Vec::new();
@@ -289,7 +289,7 @@ impl ActionTerm {
                 | PrimitiveAction::WriteFile { .. }
                 | PrimitiveAction::GlobSearch { .. }
         ) {
-            obs.push(ProofObligation::PathAllowed);
+            obs.push(ProofObligation::FsPathAllowed);
         }
 
         // Verified sink compatibility: required when the effect targets a verified sink.
@@ -323,7 +323,7 @@ impl ActionTerm {
                 ProofObligation::InputsAuthorized,
                 ProofObligation::NoAdversarialAncestry,
                 ProofObligation::WithinDelegationCeiling,
-                ProofObligation::PathAllowed,
+                ProofObligation::FsPathAllowed,
             ],
         }
     }
@@ -642,7 +642,7 @@ pub fn preflight_action(term: &ActionTerm, ctx: &PreflightContext<'_>) -> Prefli
                     result.satisfied_obligations.push(obligation.clone());
                 }
             }
-            ProofObligation::PathAllowed => {
+            ProofObligation::FsPathAllowed => {
                 if let Some(path) = term.action_path() {
                     if !ctx.permissions.paths.can_access(std::path::Path::new(path)) {
                         push_failure(
@@ -912,12 +912,12 @@ mod tests {
         );
         assert!(edit
             .derive_obligations()
-            .contains(&ProofObligation::PathAllowed));
+            .contains(&ProofObligation::FsPathAllowed));
 
         let run = ActionTerm::run_command(None, "ls", vec![], EffectDisposition::Proposed);
         assert!(!run
             .derive_obligations()
-            .contains(&ProofObligation::PathAllowed));
+            .contains(&ProofObligation::FsPathAllowed));
     }
 
     #[test]
@@ -1073,7 +1073,7 @@ mod tests {
         );
         assert!(read
             .derive_obligations()
-            .contains(&ProofObligation::PathAllowed));
+            .contains(&ProofObligation::FsPathAllowed));
 
         let write = make_term(
             PrimitiveAction::WriteFile {
@@ -1083,7 +1083,7 @@ mod tests {
         );
         assert!(write
             .derive_obligations()
-            .contains(&ProofObligation::PathAllowed));
+            .contains(&ProofObligation::FsPathAllowed));
 
         let glob = make_term(
             PrimitiveAction::GlobSearch {
@@ -1093,7 +1093,7 @@ mod tests {
         );
         assert!(glob
             .derive_obligations()
-            .contains(&ProofObligation::PathAllowed));
+            .contains(&ProofObligation::FsPathAllowed));
     }
 
     #[test]
@@ -1106,7 +1106,7 @@ mod tests {
         );
         assert!(!fetch
             .derive_obligations()
-            .contains(&ProofObligation::PathAllowed));
+            .contains(&ProofObligation::FsPathAllowed));
     }
 
     #[test]


### PR DESCRIPTION
Pure rename, zero behavior change. Clears the name collision flagged in the Brick 1 reconciliation spec: the upstream `action_term::ProofObligation::PathAllowed` (filesystem path-lattice access) collides in name with the sealed `discharge::PathAllowed` (operation↔sink structural coherence). They never resolve to the same path (enum variant vs sealed struct, different crates) — this is a readability fix landed BEFORE the sealed-vocabulary WIDEN (PR-B) so that diff reads against unambiguous names.

Renamed all 13 upstream references (`portcullis/src/action_term.rs` ×11, `nucleus-tool-proxy/src/mcp.rs` ×2). The sealed `discharge::PathAllowed` struct is **untouched**. `cargo fmt --check`, `clippy --all-features -D warnings`, verify-strict + mediation gates all clean; portcullis test suite green (1040 + integration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CNJdZb7LHWwXkrt9MCa8CG