### PR TITLE
feat(discharge): widen sealed DischargedBundle 5 → 7 obligations (WIDEN PR-B)

### DIFF
--- a/crates/nucleus-ifc-kernel/src/discharge.rs
+++ b/crates/nucleus-ifc-kernel/src/discharge.rs
@@ -20,7 +20,7 @@
 //! `DischargedBundle` is **sealed** — its constructor is private to this
 //! module. The only code path that produces one is a successful
 //! `preflight_action` call. Receiving a `DischargedBundle` is a compile-time
-//! proof that all five obligations passed.
+//! proof that all seven obligations passed.
 //!
 //! ## Obligations checked
 //!
@@ -31,6 +31,26 @@
 //! | `Discharged<DerivationClear>` | Derivation class is compatible with this sink |
 //! | `Discharged<NoAdversarialAncestry>` | No source label has `Adversarial` integrity |
 //! | `Discharged<BudgetNotExceeded>` | Estimated cost is within budget |
+//! | `Discharged<WithinDelegationCeiling>` | Requested capability ≤ policy ceiling for the op |
+//! | `Discharged<InScopeWithTask>` | Operation is within the verified task token's scope |
+//!
+//! ## Seam notes (cross-layer obligation correspondence)
+//!
+//! These document how the discharge vocabulary lines up with the upstream
+//! `portcullis::action_term` obligation set — no code, just the mapping a
+//! reviewer needs:
+//!
+//! - **`VerifiedSinkCompatible`** (upstream) is witnessed here by
+//!   `Discharged<DerivationClear>`: the discharge `DerivationClear` check
+//!   (`sink_requires_verified_derivation` ∧ `StorageLane::Verified.accepts`)
+//!   is the canonical form of "a verified sink only accepts Deterministic /
+//!   HumanPromoted derivation". There is deliberately **no** separate
+//!   `VerifiedSinkCompatible` field — it would be redundant with
+//!   `DerivationClear`.
+//! - **`NoAdversarialAncestry`** canonical semantics = the discharge
+//!   source-label check (`no source label carries `IntegLevel::Adversarial``).
+//!   Upstream keys off input `DerivationClass`; the discharge layer keys off
+//!   the propagated IFC integrity label, which is the source of truth.
 //!
 //! ## Sealing
 //!
@@ -113,6 +133,15 @@ pub enum RepairHint {
         /// The policy ceiling for this dimension.
         ceiling: CapabilityLevel,
     },
+    /// The operation is outside the verified task token's scope (or no
+    /// verified scope was supplied). Either narrow the operation to one the
+    /// task authorizes, or obtain a task token whose scope covers it.
+    OutOfTaskScope {
+        /// The operation that fell outside scope.
+        operation: Operation,
+        /// The subject that submitted the action.
+        subject: String,
+    },
 }
 
 impl std::fmt::Display for RepairHint {
@@ -155,6 +184,11 @@ impl std::fmt::Display for RepairHint {
             Self::ReduceCapabilityRequest { requested, ceiling } => write!(
                 f,
                 "reduce capability request from {requested:?} to at most {ceiling:?}"
+            ),
+            Self::OutOfTaskScope { operation, subject } => write!(
+                f,
+                "operation {operation:?} by '{subject}' is outside the verified task scope — \
+                 narrow the operation or obtain a task token that authorizes it"
             ),
         }
     }
@@ -237,6 +271,9 @@ impl RepairHint {
     ///     artifact_label: IFCLabel::default(),
     ///     subject: "agent".to_string(),
     ///     estimated_cost_micro_usd: 500, // non-zero cost, no budget gate
+    ///     capability_ceiling: None,
+    ///     requested_capability: None,
+    ///     verified_scope: None,
     /// };
     ///
     /// let result = preflight_action(&term);
@@ -335,6 +372,19 @@ impl RepairHint {
                     ),
                 })
             }
+
+            // OutOfTaskScope: structural — the operation is not authorized by
+            // the verified task token. There is no automatic rewrite (we cannot
+            // widen a token from here — that would be exactly the forgery the
+            // token system prevents). The caller must obtain a broader token.
+            Self::OutOfTaskScope { operation, .. } => Some(Repair::NeedsApproval {
+                term: repaired,
+                gate: format!(
+                    "task token change required: obtain a verified task token whose \
+                     scope authorizes operation {:?}",
+                    operation
+                ),
+            }),
         }
     }
 }
@@ -409,6 +459,60 @@ pub struct BudgetNotExceeded;
 impl obligation_sealed::ObligationSealed for BudgetNotExceeded {}
 impl ProofObligation for BudgetNotExceeded {}
 
+/// Obligation: the requested capability level is within the policy ceiling for
+/// this operation.
+///
+/// Lifts the upstream `WithinDelegationCeiling` check
+/// (`portcullis::action_term`): a requested authority must not exceed the level
+/// the capability lattice grants for the operation. Fail-closed — if
+/// either the ceiling or the requested level is absent, the obligation is
+/// **denied**, never minted (see [`preflight_action`]).
+pub struct WithinDelegationCeiling;
+impl obligation_sealed::ObligationSealed for WithinDelegationCeiling {}
+impl ProofObligation for WithinDelegationCeiling {}
+
+/// Obligation: the operation is within the verified task token's scope.
+///
+/// Lifts the upstream `InScopeWithTask` check (`portcullis::action_term`): the
+/// operation must be a member of the verified token's `allowed_operations`.
+/// Fail-closed — if no [`VerifiedScope`] is present (no verified token), the
+/// obligation is **denied**, never minted (the NO-VACUOUS-WITNESS guard). See
+/// [`preflight_action`].
+pub struct InScopeWithTask;
+impl obligation_sealed::ObligationSealed for InScopeWithTask {}
+impl ProofObligation for InScopeWithTask {}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// VerifiedScope — dependency-free carrier for the verified task-token scope
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// The verified effective scope of a task capability token, mirrored locally.
+///
+/// This is a **fallback carrier** for the shape of
+/// `nucleus_provenance_memory::taskref_token::TokenScope`
+/// (`allowed_operations` + `allowed_paths`). The canonical `TokenScope` lives in
+/// `nucleus-provenance-memory`, which depends on `portcullis-core`, which
+/// re-exports **this** crate — so `nucleus-ifc-kernel` cannot depend on
+/// `nucleus-provenance-memory` without forming the cycle
+/// `nucleus-ifc-kernel → nucleus-provenance-memory → portcullis-core →
+/// nucleus-ifc-kernel`. The dependency-free Aeneas kernel must stay acyclic, so
+/// the scope is carried in this local struct and `portcullis-effects` converts
+/// `TokenScope → VerifiedScope` at the term-building seam (`build_term_scoped`).
+///
+/// Only the `allowed_operations` dimension is enforced by
+/// [`InScopeWithTask`] today: the discharge [`ActionTerm`] carries no path, so
+/// `allowed_paths` is retained for completeness/audit but not checked here (this
+/// mirrors upstream's behavior when `action_path()` is `None`). A follow-up that
+/// adds a path to the discharge term can lift the path dimension too.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifiedScope {
+    /// Operations the verified token authorizes (allowlist; empty = none).
+    pub allowed_operations: Vec<Operation>,
+    /// Path patterns the token authorizes. Retained for audit; not enforced by
+    /// `InScopeWithTask` because the discharge `ActionTerm` carries no path.
+    pub allowed_paths: Vec<String>,
+}
+
 // ═══════════════════════════════════════════════════════════════════════════
 // Discharged<O> — zero-sized proof token
 // ═══════════════════════════════════════════════════════════════════════════
@@ -447,18 +551,33 @@ impl<O: ProofObligation> std::fmt::Debug for Discharged<O> {
 
 /// The result of a successful [`preflight_action`] call.
 ///
-/// Holds typed discharge witnesses for all five policy obligations. Effect
+/// Holds typed discharge witnesses for all seven policy obligations. Effect
 /// functions require a `&DischargedBundle` to proceed; there is **no other
 /// way to construct one** — the `_seal` field is private to this module.
 ///
 /// # Sealing guarantee
 ///
+/// The `_seal` field is unnameable outside this module, so **no**
+/// `DischargedBundle` struct literal compiles externally — even one that names
+/// every one of the seven public obligation fields (the missing `_seal` alone
+/// is fatal, and `Discharged::mint()` is private too):
+///
 /// ```compile_fail
-/// // This code does NOT compile — Seal is not accessible outside this module.
-/// use nucleus_ifc_kernel::discharge::{DischargedBundle, IntegrityGate, Discharged};
+/// // This code does NOT compile — neither Seal nor mint() is accessible.
+/// use nucleus_ifc_kernel::discharge::{
+///     DischargedBundle, Discharged, IntegrityGate, PathAllowed, DerivationClear,
+///     NoAdversarialAncestry, BudgetNotExceeded, WithinDelegationCeiling, InScopeWithTask,
+/// };
 /// let bundle = DischargedBundle {
-///     integrity_gate: Discharged::mint(),  // mint() is private
-///     // ...
+///     integrity_gate: Discharged::<IntegrityGate>::mint(),  // mint() is private
+///     path_allowed: Discharged::<PathAllowed>::mint(),
+///     derivation_clear: Discharged::<DerivationClear>::mint(),
+///     no_adversarial_ancestry: Discharged::<NoAdversarialAncestry>::mint(),
+///     budget_not_exceeded: Discharged::<BudgetNotExceeded>::mint(),
+///     within_delegation_ceiling: Discharged::<WithinDelegationCeiling>::mint(),
+///     in_scope_with_task: Discharged::<InScopeWithTask>::mint(),
+///     // no `_seal`: the field is private — and even with all seven fields
+///     // above this literal cannot be completed outside the module.
 /// };
 /// ```
 ///
@@ -476,6 +595,10 @@ pub struct DischargedBundle {
     pub no_adversarial_ancestry: Discharged<NoAdversarialAncestry>,
     /// Estimated cost fits within the budget gate.
     pub budget_not_exceeded: Discharged<BudgetNotExceeded>,
+    /// Requested capability ≤ policy ceiling for the operation.
+    pub within_delegation_ceiling: Discharged<WithinDelegationCeiling>,
+    /// Operation is within the verified task token's scope.
+    pub in_scope_with_task: Discharged<InScopeWithTask>,
     _seal: Seal,
 }
 
@@ -488,6 +611,8 @@ impl DischargedBundle {
             derivation_clear: Discharged::mint(),
             no_adversarial_ancestry: Discharged::mint(),
             budget_not_exceeded: Discharged::mint(),
+            within_delegation_ceiling: Discharged::mint(),
+            in_scope_with_task: Discharged::mint(),
             _seal: Seal,
         }
     }
@@ -501,6 +626,8 @@ impl std::fmt::Debug for DischargedBundle {
             .field("derivation_clear", &self.derivation_clear)
             .field("no_adversarial_ancestry", &self.no_adversarial_ancestry)
             .field("budget_not_exceeded", &self.budget_not_exceeded)
+            .field("within_delegation_ceiling", &self.within_delegation_ceiling)
+            .field("in_scope_with_task", &self.in_scope_with_task)
             .finish()
     }
 }
@@ -528,6 +655,9 @@ impl std::fmt::Debug for DischargedBundle {
 ///     artifact_label: IFCLabel::default(),
 ///     subject: "spiffe://nucleus/agent/ci-bot".to_string(),
 ///     estimated_cost_micro_usd: 0,
+///     capability_ceiling: None,
+///     requested_capability: None,
+///     verified_scope: None,
 /// };
 /// ```
 #[derive(Debug, Clone)]
@@ -553,6 +683,20 @@ pub struct ActionTerm {
     /// structurally sound but operationally dormant until a cost estimator
     /// is integrated (e.g., LLM token pricing, API call metering).
     pub estimated_cost_micro_usd: u64,
+    /// The policy ceiling: the capability level the capability lattice
+    /// grants for `operation`. `None` when unknown — which **denies**
+    /// [`WithinDelegationCeiling`] fail-closed (never mints a vacuous witness).
+    pub capability_ceiling: Option<CapabilityLevel>,
+    /// The capability level this action requests for `operation`. `None` denies
+    /// [`WithinDelegationCeiling`] fail-closed. Callers building real terms set
+    /// this to the operation's inherent floor (see `build_term` in
+    /// `portcullis-effects`); the ceiling check is `requested ≤ ceiling`.
+    pub requested_capability: Option<CapabilityLevel>,
+    /// The verified effective scope of the session's task capability token, if
+    /// any. `None` denies [`InScopeWithTask`] fail-closed — the
+    /// NO-VACUOUS-WITNESS guard: an action with no verified scope can never mint
+    /// `Discharged<InScopeWithTask>`.
+    pub verified_scope: Option<VerifiedScope>,
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -646,6 +790,10 @@ impl PreflightResult {
 /// 3. **DerivationClear** — derivation class is compatible with this sink
 /// 4. **NoAdversarialAncestry** — no source label carries `Adversarial` integrity
 /// 5. **BudgetNotExceeded** — zero-cost always passes; non-zero requires budget gate
+/// 6. **WithinDelegationCeiling** — requested capability ≤ policy ceiling for the op;
+///    fail-closed if either level is absent
+/// 7. **InScopeWithTask** — operation is within the verified task token's scope;
+///    fail-closed if no verified scope is present (NO-VACUOUS-WITNESS guard)
 ///
 /// Checks short-circuit on the first denial for latency. All non-denial
 /// states are fully evaluated before the bundle is minted.
@@ -653,8 +801,8 @@ impl PreflightResult {
 /// # Example
 ///
 /// ```rust
-/// use nucleus_ifc_kernel::discharge::{ActionTerm, preflight_action, PreflightResult};
-/// use nucleus_ifc_kernel::{Operation, SinkClass, IFCLabel};
+/// use nucleus_ifc_kernel::discharge::{ActionTerm, VerifiedScope, preflight_action, PreflightResult};
+/// use nucleus_ifc_kernel::{CapabilityLevel, Operation, SinkClass, IFCLabel};
 ///
 /// let term = ActionTerm {
 ///     operation: Operation::WriteFiles,
@@ -663,6 +811,14 @@ impl PreflightResult {
 ///     artifact_label: IFCLabel::default(),
 ///     subject: "spiffe://nucleus/agent/test".to_string(),
 ///     estimated_cost_micro_usd: 0,
+///     // Fail-closed inputs for the two new obligations: without these the
+///     // action is denied (WithinDelegationCeiling / InScopeWithTask).
+///     capability_ceiling: Some(CapabilityLevel::LowRisk),
+///     requested_capability: Some(CapabilityLevel::LowRisk),
+///     verified_scope: Some(VerifiedScope {
+///         allowed_operations: vec![Operation::WriteFiles],
+///         allowed_paths: vec![],
+///     }),
 /// };
 ///
 /// match preflight_action(&term) {
@@ -702,6 +858,14 @@ pub mod test_helpers {
             },
             subject: "test-helper".to_string(),
             estimated_cost_micro_usd: 0,
+            // Happy-path inputs for the two new obligations (widen 5 → 7):
+            // the op is granted at LowRisk and is in the verified token scope.
+            capability_ceiling: Some(crate::CapabilityLevel::LowRisk),
+            requested_capability: Some(crate::CapabilityLevel::LowRisk),
+            verified_scope: Some(VerifiedScope {
+                allowed_operations: vec![Operation::WriteFiles],
+                allowed_paths: vec![],
+            }),
         };
         match preflight_action(&term) {
             PreflightResult::Allowed(bundle) => bundle,
@@ -786,6 +950,68 @@ pub fn preflight_action(term: &ActionTerm) -> PreflightResult {
                 cost_micro_usd: term.estimated_cost_micro_usd,
             },
         };
+    }
+
+    // 6. WithinDelegationCeiling: the requested capability must not exceed the
+    //    policy ceiling for this operation. FAIL-CLOSED — if either the ceiling
+    //    or the requested level is absent, DENY (never mint a vacuous witness).
+    //    Mirrors `portcullis::action_term`'s `requested_level > available` gate
+    //    (level_for(op) is the ceiling); with the runtime's inherent per-op
+    //    floor for `requested`, this denies exactly the operations the policy
+    //    forbids (ceiling == Never).
+    match (term.capability_ceiling, term.requested_capability) {
+        (Some(ceiling), Some(requested)) => {
+            if requested > ceiling {
+                return PreflightResult::Denied {
+                    reason: format!(
+                        "WithinDelegationCeiling: requested capability {requested:?} exceeds \
+                         policy ceiling {ceiling:?} for operation {:?}",
+                        term.operation
+                    ),
+                    hint: RepairHint::ReduceCapabilityRequest { requested, ceiling },
+                };
+            }
+        }
+        _ => {
+            return PreflightResult::Denied {
+                reason: format!(
+                    "WithinDelegationCeiling: missing capability ceiling/request for \
+                     operation {:?} — denied fail-closed (no vacuous witness)",
+                    term.operation
+                ),
+                hint: RepairHint::ReduceCapabilityRequest {
+                    // No known request/ceiling: surface the strictest hint (Never
+                    // ceiling) so any non-Never request is flagged.
+                    requested: term.requested_capability.unwrap_or(CapabilityLevel::Always),
+                    ceiling: term.capability_ceiling.unwrap_or(CapabilityLevel::Never),
+                },
+            };
+        }
+    }
+
+    // 7. InScopeWithTask: the operation must be within the verified task token's
+    //    scope. FAIL-CLOSED — if no VerifiedScope is present (no verified token),
+    //    DENY and never mint (the NO-VACUOUS-WITNESS guard). Mirrors
+    //    `portcullis::action_term`'s `InScopeWithTask`: op ∈ allowed_operations.
+    //    (The discharge ActionTerm carries no path, so the allowed_paths
+    //    dimension is not enforced here — see `VerifiedScope`.)
+    match &term.verified_scope {
+        Some(scope) if scope.allowed_operations.contains(&term.operation) => {
+            // in scope — fall through to mint.
+        }
+        _ => {
+            return PreflightResult::Denied {
+                reason: format!(
+                    "InScopeWithTask: operation {:?} is not within the verified task scope \
+                     (or no verified scope present) for subject '{}'",
+                    term.operation, term.subject
+                ),
+                hint: RepairHint::OutOfTaskScope {
+                    operation: term.operation,
+                    subject: term.subject.clone(),
+                },
+            };
+        }
     }
 
     PreflightResult::Allowed(DischargedBundle::new())
@@ -955,6 +1181,22 @@ mod tests {
             artifact_label: trusted_label(),
             subject: "spiffe://nucleus/agent/test".to_string(),
             estimated_cost_micro_usd: 0,
+            // Happy-path inputs for the two widen-added obligations. The base
+            // scope authorizes every operation the happy-path tests exercise;
+            // denial tests override `operation`/labels to trip an *earlier*
+            // check (integrity/path/derivation/ancestry/budget), which
+            // short-circuits before the ceiling/scope checks.
+            capability_ceiling: Some(CapabilityLevel::LowRisk),
+            requested_capability: Some(CapabilityLevel::LowRisk),
+            verified_scope: Some(VerifiedScope {
+                allowed_operations: vec![
+                    Operation::WriteFiles,
+                    Operation::GitCommit,
+                    Operation::GitPush,
+                    Operation::CreatePr,
+                ],
+                allowed_paths: vec![],
+            }),
         }
     }
 
@@ -1544,5 +1786,172 @@ mod tests {
         // After approval, the repaired term passes preflight
         let retry = preflight_action(repair.term());
         assert!(retry.is_allowed());
+    }
+
+    // ── Widen 5 → 7: WithinDelegationCeiling + InScopeWithTask ──────────────
+    //
+    // These are the soundness guards for PR-B. The central property is the
+    // NO-VACUOUS-WITNESS rule: a term that is MISSING an input required by one
+    // of the two new obligations must be DENIED — a witness is never minted
+    // from absent evidence.
+
+    #[test]
+    fn happy_path_mints_full_seven_field_bundle() {
+        // All inputs present + in-scope + within ceiling → Allowed with a bundle
+        // whose Debug shows all seven obligation witnesses.
+        let bundle = preflight_action(&workspace_write_term()).unwrap_bundle();
+        let dbg = format!("{bundle:?}");
+        for needle in [
+            "IntegrityGate",
+            "PathAllowed",
+            "DerivationClear",
+            "NoAdversarialAncestry",
+            "BudgetNotExceeded",
+            "WithinDelegationCeiling",
+            "InScopeWithTask",
+        ] {
+            assert!(dbg.contains(needle), "bundle debug missing {needle}: {dbg}");
+        }
+    }
+
+    // ── NO-VACUOUS-WITNESS: InScopeWithTask ────────────────────────────────
+
+    #[test]
+    fn missing_verified_scope_denies_in_scope_with_task() {
+        // verified_scope: None → must DENY (never mint InScopeWithTask).
+        let term = ActionTerm {
+            verified_scope: None,
+            ..workspace_write_term()
+        };
+        let result = preflight_action(&term);
+        assert!(
+            result.is_denied(),
+            "absent verified scope must deny fail-closed"
+        );
+        assert!(
+            result.denial_reason().unwrap().contains("InScopeWithTask"),
+            "denial should name InScopeWithTask, got: {:?}",
+            result.denial_reason()
+        );
+        assert!(matches!(
+            result.repair_hint().unwrap(),
+            RepairHint::OutOfTaskScope { .. }
+        ));
+    }
+
+    #[test]
+    fn operation_outside_scope_denies_in_scope_with_task() {
+        // scope present but does NOT authorize the operation → DENY.
+        let term = ActionTerm {
+            verified_scope: Some(VerifiedScope {
+                allowed_operations: vec![Operation::ReadFiles], // not WriteFiles
+                allowed_paths: vec![],
+            }),
+            ..workspace_write_term()
+        };
+        let result = preflight_action(&term);
+        assert!(result.is_denied());
+        assert!(result.denial_reason().unwrap().contains("InScopeWithTask"));
+    }
+
+    #[test]
+    fn empty_scope_denies_in_scope_with_task_fail_closed() {
+        // Empty allowed_operations = nothing authorized (TokenScope allowlist
+        // semantics) → DENY. This is STRICTER than upstream's empty=allow-all
+        // TaskRef guard, on purpose: a VerifiedScope is a capability-token scope.
+        let term = ActionTerm {
+            verified_scope: Some(VerifiedScope {
+                allowed_operations: vec![],
+                allowed_paths: vec![],
+            }),
+            ..workspace_write_term()
+        };
+        assert!(preflight_action(&term).is_denied());
+    }
+
+    // ── NO-VACUOUS-WITNESS: WithinDelegationCeiling ────────────────────────
+
+    #[test]
+    fn missing_capability_ceiling_denies_within_delegation_ceiling() {
+        let term = ActionTerm {
+            capability_ceiling: None,
+            ..workspace_write_term()
+        };
+        let result = preflight_action(&term);
+        assert!(
+            result.is_denied(),
+            "absent capability ceiling must deny fail-closed"
+        );
+        assert!(
+            result
+                .denial_reason()
+                .unwrap()
+                .contains("WithinDelegationCeiling")
+        );
+    }
+
+    #[test]
+    fn missing_requested_capability_denies_within_delegation_ceiling() {
+        let term = ActionTerm {
+            requested_capability: None,
+            ..workspace_write_term()
+        };
+        let result = preflight_action(&term);
+        assert!(result.is_denied());
+        assert!(
+            result
+                .denial_reason()
+                .unwrap()
+                .contains("WithinDelegationCeiling")
+        );
+    }
+
+    #[test]
+    fn requested_above_ceiling_denies_within_delegation_ceiling() {
+        // requested Always > ceiling LowRisk → DENY with ReduceCapabilityRequest.
+        let term = ActionTerm {
+            capability_ceiling: Some(CapabilityLevel::LowRisk),
+            requested_capability: Some(CapabilityLevel::Always),
+            ..workspace_write_term()
+        };
+        let result = preflight_action(&term);
+        assert!(result.is_denied());
+        assert!(matches!(
+            result.repair_hint().unwrap(),
+            RepairHint::ReduceCapabilityRequest {
+                requested: CapabilityLevel::Always,
+                ceiling: CapabilityLevel::LowRisk,
+            }
+        ));
+    }
+
+    #[test]
+    fn never_ceiling_denies_forbidden_operation() {
+        // The meaningful lift: an operation the policy forbids (ceiling == Never)
+        // is denied because requested LowRisk > Never. Not vacuous.
+        let term = ActionTerm {
+            capability_ceiling: Some(CapabilityLevel::Never),
+            requested_capability: Some(CapabilityLevel::LowRisk),
+            ..workspace_write_term()
+        };
+        assert!(preflight_action(&term).is_denied());
+    }
+
+    #[test]
+    fn ceiling_check_precedes_scope_check() {
+        // Both new inputs bad: ceiling fires (check 6) before scope (check 7).
+        let term = ActionTerm {
+            capability_ceiling: None,
+            verified_scope: None,
+            ..workspace_write_term()
+        };
+        let result = preflight_action(&term);
+        assert!(
+            result
+                .denial_reason()
+                .unwrap()
+                .contains("WithinDelegationCeiling"),
+            "ceiling (check 6) should fire before scope (check 7)"
+        );
     }
 }

--- a/crates/portcullis-effects/src/runtime.rs
+++ b/crates/portcullis-effects/src/runtime.rs
@@ -29,7 +29,9 @@ use std::path::{Path, PathBuf};
 
 use ed25519_dalek::SigningKey;
 use nucleus_provenance_memory::{SignedTaskRef, TokenError, TokenScope};
-use portcullis_core::discharge::{preflight_action, ActionTerm, DischargedBundle, PreflightResult};
+use portcullis_core::discharge::{
+    preflight_action, ActionTerm, DischargedBundle, PreflightResult, VerifiedScope,
+};
 use portcullis_core::flow::NodeKind;
 use portcullis_core::ifc_api::FlowTracker;
 use portcullis_core::labeled::{self, Labeled};
@@ -620,9 +622,22 @@ impl NucleusRuntime {
     /// ```rust
     /// use portcullis_effects::runtime::{NucleusRuntime, PolicyProfile};
     /// use portcullis_effects::FileEffect;
+    /// use nucleus_provenance_memory::{SignedTaskRef, TokenScope};
+    /// use ed25519_dalek::SigningKey;
+    /// use portcullis_core::Operation;
+    ///
+    /// // PR-B: discharge now requires a verified task token whose scope
+    /// // authorizes the operation (`InScopeWithTask`, fail-closed).
+    /// let root = SigningKey::from_bytes(&[9u8; 32]);
+    /// let root_vk = root.verifying_key().to_bytes();
+    /// let nonce = [0u8; 16];
+    /// let scope = TokenScope::new(vec![Operation::WebFetch], vec!["/**".to_string()]);
+    /// let signed = SignedTaskRef::issue("task", scope, nonce, 1_000, 1_000_000, &root);
     ///
     /// let (builder, token) = NucleusRuntime::builder()
     ///     .profile(PolicyProfile::Codegen)
+    ///     .task_token(signed, root_vk, 1_001, nonce)
+    ///     .expect("token verifies")
     ///     .allow_unmediated_access();
     /// let mut rt = builder.build();
     ///
@@ -856,6 +871,22 @@ impl NucleusRuntime {
                 .fold(source_labels[0], |acc, l| acc.join(*l))
         };
 
+        // PR2: read the verified effective scope (allowed_operations /
+        // allowed_paths). `None` preserves the legacy no-token behavior.
+        let verified_scope = self.task_token.as_ref().map(|t| t.scope().clone());
+
+        // PR-B: convert the verified `TokenScope` into the kernel's local
+        // `VerifiedScope` carrier so `preflight_action` can mint
+        // `Discharged<InScopeWithTask>`. The kernel is the dependency-free
+        // Aeneas target and cannot depend on `nucleus-provenance-memory` (that
+        // would cycle back through `portcullis-core`), so the scope is copied
+        // field-for-field here at the seam. `None` → `InScopeWithTask` is
+        // denied fail-closed by `preflight_action` (NO-VACUOUS-WITNESS).
+        let term_scope = verified_scope.as_ref().map(|s| VerifiedScope {
+            allowed_operations: s.allowed_operations.clone(),
+            allowed_paths: s.allowed_paths.clone(),
+        });
+
         let term = ActionTerm {
             operation,
             sink_class,
@@ -863,14 +894,50 @@ impl NucleusRuntime {
             artifact_label,
             subject: self.task.clone(),
             estimated_cost_micro_usd: 0,
+            // PR-B: WithinDelegationCeiling inputs. Both the ceiling and the
+            // request are `level_for(op)`: the runtime is an honest caller that
+            // requests exactly the authority the policy grants for the op and
+            // never over-claims, so `requested ≤ ceiling` holds by construction
+            // (a truthful, non-vacuous witness minted from the *present* policy
+            // level — not from absent evidence). The obligation still bites on
+            // any term that over-claims (`requested > ceiling` → DENY, exercised
+            // by the kernel guard tests) and is fail-closed on `None`; like
+            // `BudgetNotExceeded` it is sound-but-dormant on runtime-built terms.
+            // Actual per-op capability enforcement remains the PolicyEnforced
+            // effect layer's job (unchanged). Mirrors upstream's
+            // `requested_level > available → deny` with the runtime's honest
+            // no-escalation claim.
+            capability_ceiling: Some(self.level_for(operation)),
+            requested_capability: Some(self.level_for(operation)),
+            verified_scope: term_scope,
         };
 
-        // PR2: read the verified effective scope (allowed_operations /
-        // allowed_paths) and hand it back alongside the term so a later PR can
-        // consult it. `None` preserves today's behavior exactly.
-        let verified_scope = self.task_token.as_ref().map(|t| t.scope().clone());
-
         (term, verified_scope)
+    }
+
+    /// The capability level the session policy grants for `op`.
+    ///
+    /// Mirrors `portcullis::CapabilityLattice::level_for` over
+    /// `portcullis_core::CapabilityLattice` (the kernel lattice, which exposes
+    /// the per-dimension fields but not `level_for`). Used to source the
+    /// `WithinDelegationCeiling` ceiling in [`build_term_scoped`].
+    fn level_for(&self, op: Operation) -> CapabilityLevel {
+        let p = &self.policy;
+        match op {
+            Operation::ReadFiles => p.read_files,
+            Operation::WriteFiles => p.write_files,
+            Operation::EditFiles => p.edit_files,
+            Operation::RunBash => p.run_bash,
+            Operation::GlobSearch => p.glob_search,
+            Operation::GrepSearch => p.grep_search,
+            Operation::WebSearch => p.web_search,
+            Operation::WebFetch => p.web_fetch,
+            Operation::GitCommit => p.git_commit,
+            Operation::GitPush => p.git_push,
+            Operation::CreatePr => p.create_pr,
+            Operation::ManagePods => p.manage_pods,
+            Operation::SpawnAgent => p.spawn_agent,
+        }
     }
 
     /// Run `preflight_action` and return the `DischargedBundle` on success.
@@ -1367,6 +1434,59 @@ impl NucleusRuntimeBuilder {
 mod tests {
     use super::*;
 
+    // ── PR-B token helpers ──────────────────────────────────────────────
+    //
+    // Widening the bundle to 7 obligations makes `InScopeWithTask` mandatory:
+    // `preflight_action` denies fail-closed unless the session carries a
+    // verified task token whose scope authorizes the operation. These helpers
+    // mint a broad-scope verified token so the capability/flow/effect tests
+    // below exercise the SAME behavior they did before PR-B (coverage preserved:
+    // the token supplies the now-required in-scope evidence, nothing is
+    // asserted-away). Token semantics themselves are covered by the dedicated
+    // `task_token` submodule.
+
+    /// A verified full-scope task token: (signed, root_vk, now, nonce).
+    /// Scope authorizes every core operation; paths are unconstrained (the
+    /// discharge term carries no path, so `allowed_paths` is not enforced).
+    fn full_scope_token() -> (SignedTaskRef, [u8; 32], u64, [u8; 16]) {
+        let root = SigningKey::from_bytes(&[9u8; 32]);
+        let root_vk = root.verifying_key().to_bytes();
+        let nonce = [0u8; 16];
+        let issued_at = 1_000;
+        let ttl = 1_000_000;
+        let now = 1_001;
+        let scope = TokenScope::new(
+            vec![
+                Operation::ReadFiles,
+                Operation::WriteFiles,
+                Operation::EditFiles,
+                Operation::RunBash,
+                Operation::GlobSearch,
+                Operation::GrepSearch,
+                Operation::WebSearch,
+                Operation::WebFetch,
+                Operation::GitCommit,
+                Operation::GitPush,
+                Operation::CreatePr,
+                Operation::ManagePods,
+                Operation::SpawnAgent,
+            ],
+            vec!["/**".to_string()],
+        );
+        let token = SignedTaskRef::issue("test-task", scope, nonce, issued_at, ttl, &root);
+        (token, root_vk, now, nonce)
+    }
+
+    /// A runtime for `profile` carrying a verified full-scope task token.
+    fn rt_tok(profile: PolicyProfile) -> NucleusRuntime {
+        let (token, root_vk, now, nonce) = full_scope_token();
+        NucleusRuntime::builder()
+            .profile(profile)
+            .task_token(token, root_vk, now, nonce)
+            .expect("full-scope test token verifies")
+            .build()
+    }
+
     #[test]
     fn builder_defaults_to_strict() {
         let rt = NucleusRuntime::builder().build();
@@ -1518,8 +1638,11 @@ mod tests {
     fn effects_respect_policy() {
         use crate::FileEffect;
 
+        let (task_token, root_vk, now, nonce) = full_scope_token();
         let (builder, token) = NucleusRuntime::builder()
             .profile(PolicyProfile::ReadOnly)
+            .task_token(task_token, root_vk, now, nonce)
+            .expect("full-scope test token verifies")
             .allow_unmediated_access();
         let mut rt = builder.build();
         let proof = rt.preflight_unmediated().unwrap();
@@ -1536,8 +1659,11 @@ mod tests {
     /// the bundle was handed out with no IFC trace — `node_count` stayed 0.
     #[test]
     fn unmediated_effects_advances_flow_tracker() {
+        let (task_token, root_vk, now, nonce) = full_scope_token();
         let (builder, token) = NucleusRuntime::builder()
             .profile(PolicyProfile::Codegen)
+            .task_token(task_token, root_vk, now, nonce)
+            .expect("full-scope test token verifies")
             .allow_unmediated_access();
         let mut rt = builder.build();
         assert_eq!(rt.flow_tracker().node_count(), 0);
@@ -1596,8 +1722,11 @@ mod tests {
                 PolicyProfile::Permissive,
             ][profile_idx];
 
+            let (task_token, root_vk, now, nonce) = full_scope_token();
             let (builder, token) = NucleusRuntime::builder()
                 .profile(profile)
+                .task_token(task_token, root_vk, now, nonce)
+                .expect("full-scope test token verifies")
                 .allow_unmediated_access();
             let mut rt = builder.build();
 
@@ -1666,9 +1795,7 @@ mod tests {
 
     #[test]
     fn write_file_denied_by_read_only_profile() {
-        let mut rt = NucleusRuntime::builder()
-            .profile(PolicyProfile::ReadOnly)
-            .build();
+        let mut rt = rt_tok(PolicyProfile::ReadOnly);
         let result = {
             let p = rt
                 .preflight_write(std::path::Path::new("/tmp/test.txt"))
@@ -1697,9 +1824,7 @@ mod tests {
     #[test]
     fn write_file_empty_allowlist_permits_any_path() {
         // Empty allowlist = no path restriction (only policy governs)
-        let mut rt = NucleusRuntime::builder()
-            .profile(PolicyProfile::Codegen)
-            .build();
+        let mut rt = rt_tok(PolicyProfile::Codegen);
         // This will fail on discharge (IFCLabel default is Untrusted integrity)
         // or on the actual I/O, but NOT on path checking
         let result = {
@@ -1716,9 +1841,7 @@ mod tests {
 
     #[test]
     fn read_file_updates_flow_tracker() {
-        let mut rt = NucleusRuntime::builder()
-            .profile(PolicyProfile::Codegen)
-            .build();
+        let mut rt = rt_tok(PolicyProfile::Codegen);
         assert_eq!(rt.flow_tracker().node_count(), 0);
 
         // Read a file that exists
@@ -1746,9 +1869,7 @@ mod tests {
 
     #[test]
     fn fetch_url_updates_flow_tracker_with_adversarial() {
-        let mut rt = NucleusRuntime::builder()
-            .profile(PolicyProfile::Research)
-            .build();
+        let mut rt = rt_tok(PolicyProfile::Research);
 
         // fetch will fail (stub) but we can test that it gets past discharge
         let result = {
@@ -1773,9 +1894,7 @@ mod tests {
 
     #[test]
     fn run_shell_denied_by_research_profile() {
-        let mut rt = NucleusRuntime::builder()
-            .profile(PolicyProfile::Research)
-            .build();
+        let mut rt = rt_tok(PolicyProfile::Research);
         let result = {
             let p = rt.preflight_shell().unwrap();
             rt.run_shell("echo hello", p)
@@ -1786,9 +1905,7 @@ mod tests {
 
     #[test]
     fn git_push_denied_by_codegen_profile() {
-        let mut rt = NucleusRuntime::builder()
-            .profile(PolicyProfile::Codegen)
-            .build();
+        let mut rt = rt_tok(PolicyProfile::Codegen);
         let result = {
             let p = rt.preflight_push().unwrap();
             rt.git_push("origin", "main", p)
@@ -1799,9 +1916,7 @@ mod tests {
 
     #[test]
     fn denied_error_mentions_capability() {
-        let mut rt = NucleusRuntime::builder()
-            .profile(PolicyProfile::ReadOnly)
-            .build();
+        let mut rt = rt_tok(PolicyProfile::ReadOnly);
         let result = {
             let p = rt.preflight_shell().unwrap();
             rt.run_shell("echo hello", p)
@@ -1923,9 +2038,7 @@ mod tests {
     #[test]
     fn git_push_denied_by_codegen_profile_via_discharge() {
         // Codegen has git_commit but NOT git_push
-        let mut rt = NucleusRuntime::builder()
-            .profile(PolicyProfile::Codegen)
-            .build();
+        let mut rt = rt_tok(PolicyProfile::Codegen);
         let result = {
             let p = rt.preflight_push().unwrap();
             rt.git_push("origin", "main", p)
@@ -1935,9 +2048,7 @@ mod tests {
 
     #[test]
     fn git_commit_allowed_by_codegen_profile() {
-        let mut rt = NucleusRuntime::builder()
-            .profile(PolicyProfile::Codegen)
-            .build();
+        let mut rt = rt_tok(PolicyProfile::Codegen);
         // git_commit may fail on I/O (no repo) but should NOT fail on policy
         let result = {
             let p = rt.preflight_commit().unwrap();
@@ -1950,9 +2061,7 @@ mod tests {
 
     #[test]
     fn run_shell_allowed_by_codegen_profile() {
-        let mut rt = NucleusRuntime::builder()
-            .profile(PolicyProfile::Codegen)
-            .build();
+        let mut rt = rt_tok(PolicyProfile::Codegen);
         // run_shell may fail on I/O but should NOT fail on policy
         let result = {
             let p = rt.preflight_shell().unwrap();
@@ -1965,9 +2074,7 @@ mod tests {
 
     #[test]
     fn read_file_returns_labeled_with_correct_tags() {
-        let mut rt = NucleusRuntime::builder()
-            .profile(PolicyProfile::Codegen)
-            .build();
+        let mut rt = rt_tok(PolicyProfile::Codegen);
         let result = {
             let p = rt.preflight_read().unwrap();
             rt.read_file(std::path::Path::new("Cargo.toml"), p)
@@ -1986,9 +2093,7 @@ mod tests {
 
     #[test]
     fn session_tracks_taint_after_operations() {
-        let mut rt = NucleusRuntime::builder()
-            .profile(PolicyProfile::Codegen)
-            .build();
+        let mut rt = rt_tok(PolicyProfile::Codegen);
         assert!(!rt.is_tainted());
         assert_eq!(rt.flow_tracker().node_count(), 0);
 

--- a/crates/portcullis/tests/cross_layer_discharge_consistency.rs
+++ b/crates/portcullis/tests/cross_layer_discharge_consistency.rs
@@ -1,0 +1,162 @@
+//! Cross-layer consistency guard (PR-B regression guard (a)).
+//!
+//! The discharge layer (`portcullis_core::discharge`, the sealed 7-obligation
+//! vocabulary in `nucleus-ifc-kernel`) LIFTS two obligations from the upstream
+//! `portcullis::action_term` checker: `WithinDelegationCeiling` and
+//! `InScopeWithTask`. This test pins the two layers together: for a corpus of
+//! matched terms, the upstream verdict (all obligations satisfied) must agree
+//! with the discharge verdict (`preflight_action == Allowed`) **on the shared /
+//! lifted obligations**.
+//!
+//! ## Why this lives in the `portcullis` crate
+//!
+//! `portcullis` is the only crate that sees BOTH checkers: it depends on
+//! `portcullis-core` (which re-exports `nucleus_ifc_kernel::discharge`) and it
+//! IS the home of the upstream `action_term` checker. Neither
+//! `nucleus-ifc-kernel` nor `portcullis-effects` (the PR acceptance's two
+//! crates) can see the upstream checker — the kernel is dependency-free and
+//! `portcullis-effects` does not depend on `portcullis`. So this guard runs
+//! under `cargo test -p portcullis --test cross_layer_discharge_consistency`,
+//! outside the two-crate acceptance set (reported).
+//!
+//! ## Scenario shape (isolating the two lifted obligations)
+//!
+//! We use `Operation::GitCommit` with a `Proposed` effect and no inputs so the
+//! upstream `derive_obligations` yields exactly `[WithinDelegationCeiling,
+//! InScopeWithTask]` (no `FsPathAllowed` — GitCommit has no action path; no
+//! `VerifiedSinkCompatible` — Proposed; no `NoAdversarialAncestry` /
+//! `InputsAuthorized` — no inputs, LowRisk request). The matched discharge term
+//! is built to pass every OTHER discharge obligation (trusted+deterministic
+//! artifact into the GitCommit sink, no source labels, zero cost) so that only
+//! the two lifted obligations decide the verdict.
+
+use portcullis::action_term::{
+    preflight_action as upstream_preflight, ActionTerm as UpstreamTerm, PreflightContext,
+    PreflightVerdict, TaskRef,
+};
+use portcullis::PermissionLattice;
+use portcullis_core::discharge::{
+    preflight_action as discharge_preflight, ActionTerm as DischargeTerm, VerifiedScope,
+};
+use portcullis_core::{
+    AuthorityLevel, CapabilityLevel, ConfLevel, DerivationClass, Freshness, IFCLabel, IntegLevel,
+    Operation, ProvenanceSet, SinkClass,
+};
+
+/// A trusted, deterministic artifact label — passes the discharge
+/// IntegrityGate / DerivationClear checks at the GitCommit (verified) sink.
+fn trusted_deterministic() -> IFCLabel {
+    IFCLabel {
+        confidentiality: ConfLevel::Internal,
+        integrity: IntegLevel::Trusted,
+        authority: AuthorityLevel::Directive,
+        provenance: ProvenanceSet::SYSTEM,
+        freshness: Freshness {
+            observed_at: 1_000,
+            ttl_secs: 0,
+        },
+        derivation: DerivationClass::Deterministic,
+    }
+}
+
+/// Run the UPSTREAM checker for a GitCommit term with the given task scope and
+/// policy ceiling. Returns `true` iff the aggregate verdict is `Pass` (i.e.
+/// both lifted obligations are satisfied — they are the only ones derived).
+fn upstream_all_satisfied(allowed_ops: &[Operation], git_commit_ceiling: CapabilityLevel) -> bool {
+    let mut perms = PermissionLattice::permissive();
+    // Set the ceiling for the operation under test (mutation sticks — it runs
+    // after `normalize()`; the two lifted checks only read `capabilities` and
+    // `paths`, so obligation normalization is irrelevant here).
+    perms.capabilities.git_commit = git_commit_ceiling;
+    let ctx = PreflightContext::new(&perms);
+
+    let mut term = UpstreamTerm::from_operation(Operation::GitCommit, "commit message");
+    term.task = Some(TaskRef::new(
+        "task-1",
+        "cross-layer scenario",
+        allowed_ops.to_vec(),
+        vec![],
+    ));
+    // Honest LowRisk request (matches from_operation's default and the matched
+    // discharge term's `requested_capability` below).
+    let result = upstream_preflight(&term, &ctx);
+    result.verdict == PreflightVerdict::Pass
+}
+
+/// Run the DISCHARGE checker for the matched GitCommit term. Every non-lifted
+/// obligation is arranged to pass, so `Allowed` iff both lifted obligations
+/// (WithinDelegationCeiling, InScopeWithTask) hold.
+fn discharge_allowed(allowed_ops: &[Operation], git_commit_ceiling: CapabilityLevel) -> bool {
+    let term = DischargeTerm {
+        operation: Operation::GitCommit,
+        sink_class: SinkClass::GitCommit,
+        source_labels: vec![],
+        artifact_label: trusted_deterministic(),
+        subject: "commit message".to_string(),
+        estimated_cost_micro_usd: 0,
+        capability_ceiling: Some(git_commit_ceiling),
+        // Mirror the upstream term's honest LowRisk authority claim.
+        requested_capability: Some(CapabilityLevel::LowRisk),
+        verified_scope: Some(VerifiedScope {
+            allowed_operations: allowed_ops.to_vec(),
+            allowed_paths: vec![],
+        }),
+    };
+    discharge_preflight(&term).is_allowed()
+}
+
+#[test]
+fn upstream_and_discharge_agree_on_lifted_obligations() {
+    // Corpus of matched scenarios over NON-EMPTY task scopes (the empty-scope
+    // case is deliberately divergent — see the dedicated test below). Each entry
+    // is (allowed_operations, git_commit_ceiling, expected_both_pass).
+    let corpus: &[(&[Operation], CapabilityLevel, bool)] = &[
+        // In-scope + within ceiling → both pass.
+        (&[Operation::GitCommit], CapabilityLevel::Always, true),
+        (&[Operation::GitCommit], CapabilityLevel::LowRisk, true),
+        (
+            &[Operation::GitCommit, Operation::ReadFiles],
+            CapabilityLevel::LowRisk,
+            true,
+        ),
+        // Ceiling forbids the op (Never < LowRisk request) → both fail.
+        (&[Operation::GitCommit], CapabilityLevel::Never, false),
+        // Op not in task scope → both fail.
+        (&[Operation::ReadFiles], CapabilityLevel::Always, false),
+        // Both dimensions bad → both fail.
+        (&[Operation::ReadFiles], CapabilityLevel::Never, false),
+    ];
+
+    for (allowed_ops, ceiling, expected_both_pass) in corpus {
+        let up = upstream_all_satisfied(allowed_ops, *ceiling);
+        let dis = discharge_allowed(allowed_ops, *ceiling);
+        assert_eq!(
+            up, dis,
+            "cross-layer divergence for ops={allowed_ops:?} ceiling={ceiling:?}: \
+             upstream_all_satisfied={up} discharge_allowed={dis}"
+        );
+        assert_eq!(
+            dis, *expected_both_pass,
+            "unexpected verdict for ops={allowed_ops:?} ceiling={ceiling:?}"
+        );
+    }
+}
+
+/// Documented, intentional divergence: an EMPTY task scope.
+///
+/// Upstream `InScopeWithTask` treats an empty `allowed_operations` as
+/// "no restriction" (allow-all) — the `!is_empty() &&` guard. The discharge
+/// layer treats an empty `VerifiedScope.allowed_operations` as an allowlist that
+/// authorizes NOTHING (fail-closed), because a `VerifiedScope` is a
+/// capability-token scope, not a coarse task hint. This test pins that the
+/// stricter discharge behavior is deliberate.
+#[test]
+fn empty_scope_is_intentionally_stricter_in_discharge() {
+    let up = upstream_all_satisfied(&[], CapabilityLevel::Always);
+    let dis = discharge_allowed(&[], CapabilityLevel::Always);
+    assert!(up, "upstream treats empty allowed_operations as allow-all");
+    assert!(
+        !dis,
+        "discharge treats an empty verified scope as fail-closed (deny)"
+    );
+}


### PR DESCRIPTION
The WIDEN Brandon approved. Adds two sealed obligations to the proof-carrying admission vocabulary so a `DischargedBundle` proves **7** obligations: the existing 5 + `WithinDelegationCeiling` + `InScopeWithTask`. `InputsAuthorized` remains the disclosed, **parked** 8th (its own P2 project). Follows `reviews/obligation-reconciliation.md`; PR-A (#2034) already renamed the upstream `PathAllowed → FsPathAllowed` so this diff reads against unambiguous names.

**Design (sound, fail-closed):**
- 2 new sealed obligation structs; `DischargedBundle` 5→7 (`new()`, `Debug`, `#[must_use]`, and the sealing `compile_fail` doctest all extended to 7).
- Discharge `ActionTerm` widened: `capability_ceiling`/`requested_capability: Option<CapabilityLevel>` + `verified_scope: Option<VerifiedScope>`. `VerifiedScope` is a **dependency-free local carrier** — importing `TokenScope` would cycle `nucleus-ifc-kernel → nucleus-provenance-memory → portcullis-core → nucleus-ifc-kernel`; it's converted from `TokenScope` in portcullis-effects at the seam.
- `preflight_action` mints both with the **no-vacuous-witness guard**: absent ceiling/request **or** absent `verified_scope` → **DENY**, never a silent mint.

**Regression guards:** cross-layer consistency (portcullis test, the only crate that sees both checkers), 7-field sealing compile-fail doctest, and 9 no-vacuous-witness unit tests. Tooling: `cargo fmt --check`, `cargo clippy --all-features -D warnings`, the verify-strict gate, and the mediation gate are all clean; `nucleus-ifc-kernel` (175) + `portcullis-effects` (79) + doctests + cross-layer (2) all green.

**Reviewer — honest caveats (so the "7 witnesses" claim stays exact):**
1. **`WithinDelegationCeiling` is wired sound but DORMANT on the `build_term` path.** `build_term` sets `requested == ceiling` (both `= self.policy.level_for(op)`), so `requested ≤ ceiling` holds by construction and the check never fires there. It correctly gates adversarial hand-built terms (tested) and becomes load-bearing only when delegation supplies a requested level independent of the policy ceiling. **Effectively 6 of 7 witnesses actively discriminate on the live path today** — this is the flip side of the "P1 ceiling is near-free" finding (the runtime's policy *is* the ceiling).
2. **`InScopeWithTask` enforces the operation dimension only** — the discharge `ActionTerm` carries no path, so `allowed_paths` is not gated here (paths are separately enforced by `FsPathAllowed`/`check_path_allowed` at the effect site).
3. **Mandatory-token contract change** — `verified_scope: None → DENY` makes a verified task token required for any `NucleusRuntime` discharge. **No live consumer impact:** tool-proxy/nucleus use `PodRuntime` (not this path); `portcullis-python` holds a `NucleusRuntime` but exposes **no effect methods**; only `portcullis-effects`' own tests exercised the untokened path and were migrated to supply a full-scope token (coverage preserved). tool-proxy provisions tokens when it migrates onto this facade (a later brick).

**Doc-truth:** `FORMAL_METHODS.md`/NORTH_STAR should state "7 sealed obligations; InputsAuthorized parked; WithinDelegationCeiling dormant-until-delegation" — a follow-up doc PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CNJdZb7LHWwXkrt9MCa8CG
