### PR TITLE
feat(node): mint role-separated session task tokens for pods (live-path migration)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6787,6 +6787,7 @@ dependencies = [
 name = "nucleus-guest-init"
 version = "1.0.0"
 dependencies = [
+ "hex",
  "nix",
  "serde",
  "serde_json",
@@ -6958,6 +6959,7 @@ dependencies = [
  "nucleus-client",
  "nucleus-identity",
  "nucleus-proto",
+ "nucleus-provenance-memory",
  "nucleus-spec",
  "oid-registry",
  "portcullis",

--- a/crates/nucleus-guest-init/Cargo.toml
+++ b/crates/nucleus-guest-init/Cargo.toml
@@ -17,3 +17,4 @@ nix = { version = "0.31", default-features = false, features = ["mount", "fs"] }
 vsock = "0.5"
 serde = { workspace = true }
 serde_json = { workspace = true }
+hex = { workspace = true }

--- a/crates/nucleus-guest-init/src/main.rs
+++ b/crates/nucleus-guest-init/src/main.rs
@@ -123,6 +123,36 @@ fn run() -> Result<(), String> {
         std::env::set_var("NUCLEUS_SANDBOX_TOKEN", sandbox_token);
     }
 
+    // Live-path session capability token (optional). The node injects it on the
+    // kernel cmdline as `nucleus.task_token_hex` (hex of the token JSON — the
+    // cmdline is whitespace-delimited and quote-sensitive, so raw JSON is unsafe)
+    // plus hex nonce/issuer. We decode the token back to the exact JSON string
+    // the tool-proxy verify half expects and forward all three as env vars. If
+    // the token is absent or the hex is malformed we simply do not set them —
+    // the tool-proxy then records Missing/Invalid and fails closed.
+    if let Some(token_hex) = parse_cmdline_secret(&cmdline, "nucleus.task_token_hex") {
+        match hex::decode(&token_hex)
+            .ok()
+            .and_then(|b| String::from_utf8(b).ok())
+        {
+            Some(token_json) => {
+                std::env::set_var("NUCLEUS_TASK_TOKEN", token_json);
+                if let Some(nonce) = parse_cmdline_secret(&cmdline, "nucleus.task_token_nonce") {
+                    std::env::set_var("NUCLEUS_TASK_TOKEN_NONCE", nonce);
+                }
+                if let Some(issuer) = parse_cmdline_secret(&cmdline, "nucleus.task_token_issuer") {
+                    std::env::set_var("NUCLEUS_TASK_TOKEN_ISSUER", issuer);
+                }
+            }
+            None => {
+                eprintln!(
+                    "nucleus-guest-init: nucleus.task_token_hex is not valid hex/UTF-8; \
+                     skipping session token (tool-proxy will fail closed)"
+                );
+            }
+        }
+    }
+
     // S3 audit sink config (optional, passed via kernel args from nucleus-node)
     for (arg, env_var) in [
         (
@@ -388,5 +418,39 @@ mod tests {
     fn parse_sandbox_token_empty_value() {
         let cmdline = "nucleus.sandbox_token=";
         assert_eq!(parse_cmdline_secret(cmdline, "nucleus.sandbox_token"), None);
+    }
+
+    /// The live-path token rides the cmdline hex-encoded; decoding it back must
+    /// reproduce the EXACT JSON string the tool-proxy verify half parses. JSON
+    /// contains `{`, `"`, `:`, `,` — all cmdline-hostile — which is why it is
+    /// hex-wrapped; this asserts the wrapper round-trips losslessly and that the
+    /// hex token is a single whitespace-delimited cmdline argument.
+    #[test]
+    fn task_token_hex_roundtrips_to_exact_json() {
+        let token_json = r#"{"task_id":"pod-1","blocks":[{"claim":{"nonce":[1,2,3]}}]}"#;
+        let token_hex = hex::encode(token_json.as_bytes());
+        let nonce_hex = hex::encode([7u8; 16]);
+        let issuer_hex = hex::encode([9u8; 32]);
+        let cmdline = format!(
+            "console=ttyS0 nucleus.auth_secret=a nucleus.task_token_hex={token_hex} \
+             nucleus.task_token_nonce={nonce_hex} nucleus.task_token_issuer={issuer_hex}"
+        );
+
+        let parsed_hex = parse_cmdline_secret(&cmdline, "nucleus.task_token_hex")
+            .expect("hex token must parse as a single cmdline arg");
+        let decoded = String::from_utf8(hex::decode(&parsed_hex).unwrap()).unwrap();
+        assert_eq!(
+            decoded, token_json,
+            "hex must decode back to the exact JSON"
+        );
+
+        assert_eq!(
+            parse_cmdline_secret(&cmdline, "nucleus.task_token_nonce"),
+            Some(nonce_hex)
+        );
+        assert_eq!(
+            parse_cmdline_secret(&cmdline, "nucleus.task_token_issuer"),
+            Some(issuer_hex)
+        );
     }
 }

--- a/crates/nucleus-node/Cargo.toml
+++ b/crates/nucleus-node/Cargo.toml
@@ -68,6 +68,7 @@ nucleus-identity = { path = "../nucleus-identity" }
 nucleus-proto = { path = "../nucleus-proto" }
 nucleus-spec = { path = "../nucleus-spec" }
 nucleus-client = { path = "../nucleus-client", features = ["async-drand"] }
+nucleus-provenance-memory = { path = "../nucleus-provenance-memory" }
 portcullis = { path = "../portcullis", features = ["serde"] }
 
 uuid = { workspace = true, features = ["serde"] }

--- a/crates/nucleus-node/src/firecracker_config.rs
+++ b/crates/nucleus-node/src/firecracker_config.rs
@@ -111,6 +111,7 @@ impl FirecrackerConfig {
         auth_secret: &str,
         approval_secret: &str,
         workload_api_port: Option<u32>,
+        task_token: Option<&crate::session_mint::MintedTaskToken>,
     ) -> Self {
         let vcpu_count = spec
             .spec
@@ -221,6 +222,34 @@ impl FirecrackerConfig {
             boot_args = match boot_args.take() {
                 Some(args) => Some(format!("{args} nucleus.sandbox_token={sandbox_token}")),
                 None => Some(format!("nucleus.sandbox_token={sandbox_token}")),
+            };
+        }
+
+        // Inject the live-path session capability token via the kernel cmdline,
+        // for nucleus-guest-init to forward to the in-VM tool-proxy as
+        // NUCLEUS_TASK_TOKEN{,_NONCE,_ISSUER}.
+        //
+        // The token JSON is **hex-encoded** here (`nucleus.task_token_hex`)
+        // because the kernel cmdline is whitespace-delimited and quote-sensitive;
+        // raw JSON (braces/quotes) is unsafe to embed. guest-init hex-decodes it
+        // back to the exact JSON the tool-proxy verify half expects. Nonce and
+        // issuer are already hex. This is a scoped capability + PUBLIC issuer key
+        // — NOT a secret — so riding the world-readable cmdline (M-4 caveat,
+        // same channel as nucleus.auth_secret) is acceptable; the anti-replay /
+        // anti-truncation defense rests on the host-pinned nonce, not secrecy.
+        if let Some(tok) = task_token {
+            let token_hex = hex::encode(tok.token_json.as_bytes());
+            boot_args = match boot_args.take() {
+                Some(args) => Some(format!(
+                    "{args} nucleus.task_token_hex={token_hex} \
+                     nucleus.task_token_nonce={} nucleus.task_token_issuer={}",
+                    tok.nonce_hex, tok.issuer_hex
+                )),
+                None => Some(format!(
+                    "nucleus.task_token_hex={token_hex} \
+                     nucleus.task_token_nonce={} nucleus.task_token_issuer={}",
+                    tok.nonce_hex, tok.issuer_hex
+                )),
             };
         }
 

--- a/crates/nucleus-node/src/main.rs
+++ b/crates/nucleus-node/src/main.rs
@@ -38,6 +38,7 @@ mod workload_api_vsock;
 use auth::{AuthConfig, AuthError};
 mod cgroup;
 mod net;
+mod session_mint;
 mod signed_proxy;
 mod trust_gate;
 mod vsock_bridge;
@@ -1220,6 +1221,64 @@ impl ContainerPod {
     }
 }
 
+/// Resolve the pod's policy and mint a fresh live-path session capability
+/// token scoped to its granted operations.
+///
+/// Returns `None` (with a warning) if the policy cannot be resolved, the clock
+/// is unavailable, or the token cannot be serialized. That is fail-closed: the
+/// pod still spawns, but with NO token, so the tool-proxy's startup verify half
+/// records `Missing`/`Invalid` and later token-gated operations are denied.
+///
+/// The signing key is the node's dedicated task-issuer key (role-separated from
+/// the executor key); only its public half is injected downstream.
+#[cfg_attr(
+    not(any(feature = "local-driver", target_os = "linux")),
+    allow(dead_code)
+)]
+fn mint_task_token_for_spec(
+    state: &NodeState,
+    spec: &PodSpec,
+    id: Uuid,
+) -> Option<session_mint::MintedTaskToken> {
+    let policy = match spec.spec.resolve_policy() {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!(
+                pod = %id,
+                error = %e,
+                "live-path mint: policy resolution failed; no session token injected (fail-closed at verify)"
+            );
+            return None;
+        }
+    };
+    let now_unix = match std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH) {
+        Ok(d) => d.as_secs(),
+        Err(_) => {
+            tracing::warn!(pod = %id, "live-path mint: clock before epoch; no session token injected");
+            return None;
+        }
+    };
+    // TTL = the pod/session lifetime (the spec's own timeout bound, in seconds).
+    let ttl_secs = spec.spec.timeout_seconds;
+    match session_mint::mint_session_task_token(
+        &id.to_string(),
+        &policy,
+        ttl_secs,
+        now_unix,
+        state.trust_gate.task_issuer_signing_key.as_ref(),
+    ) {
+        Ok(minted) => Some(minted),
+        Err(e) => {
+            tracing::warn!(
+                pod = %id,
+                error = %e,
+                "live-path mint: token serialization failed; no session token injected"
+            );
+            None
+        }
+    }
+}
+
 #[cfg(feature = "local-driver")]
 async fn spawn_local_pod(
     state: &NodeState,
@@ -1309,6 +1368,17 @@ async fn spawn_local_pod(
         &spec_yaml_hash,
     );
     command.env("NUCLEUS_SANDBOX_TOKEN", &sandbox_token);
+
+    // Live-path: mint + inject the session capability token scoped to exactly
+    // the pod policy's granted operations. The tool-proxy verifies it once at
+    // startup (fail-closed). Injected on the same host-controlled env channel as
+    // the secrets above; the token itself is a scoped capability + PUBLIC issuer
+    // key (not a secret). Names match the tool-proxy verify half exactly.
+    if let Some(minted) = mint_task_token_for_spec(state, spec, id) {
+        command.env("NUCLEUS_TASK_TOKEN", &minted.token_json);
+        command.env("NUCLEUS_TASK_TOKEN_NONCE", &minted.nonce_hex);
+        command.env("NUCLEUS_TASK_TOKEN_ISSUER", &minted.issuer_hex);
+    }
 
     // Detect orchestrator pod: inject pod management env vars
     let enable_pod_mgmt = spec
@@ -1469,6 +1539,14 @@ async fn spawn_container_pod(
                     env.push(format!("{key}={val}"));
                 }
             }
+        }
+
+        // Live-path session capability token (see spawn_local_pod). Injected in
+        // proxy mode — the only container mode that runs the tool-proxy sidecar.
+        if let Some(minted) = mint_task_token_for_spec(state, spec, id) {
+            env.push(format!("NUCLEUS_TASK_TOKEN={}", minted.token_json));
+            env.push(format!("NUCLEUS_TASK_TOKEN_NONCE={}", minted.nonce_hex));
+            env.push(format!("NUCLEUS_TASK_TOKEN_ISSUER={}", minted.issuer_hex));
         }
     }
 
@@ -1852,6 +1930,9 @@ async fn spawn_firecracker_pod(
             .identity_manager
             .as_ref()
             .map(|_| state.identity_vsock_port);
+        // Live-path: mint the session capability token; from_spec injects it on
+        // the kernel cmdline for guest-init to forward into the in-VM tool-proxy.
+        let task_token = mint_task_token_for_spec(state, spec, id);
         let config = firecracker_config::FirecrackerConfig::from_spec(
             spec,
             &log_path,
@@ -1861,6 +1942,7 @@ async fn spawn_firecracker_pod(
             &state.proxy_auth_secret,
             &state.proxy_approval_secret,
             workload_api_port,
+            task_token.as_ref(),
         );
         let config_json = match serde_json::to_vec_pretty(&config) {
             Ok(data) => data,

--- a/crates/nucleus-node/src/session_mint.rs
+++ b/crates/nucleus-node/src/session_mint.rs
@@ -1,0 +1,221 @@
+//! Live-path session capability-token **minting** (the node MINTING half).
+//!
+//! This is the counterpart to the tool-proxy's startup verification
+//! (`nucleus-tool-proxy::session_token`, live-path PR-2). At pod spawn the node
+//! mints a fresh [`SignedTaskRef`] scoped to exactly the operations the pod's
+//! resolved policy permits, then injects the serialized token, its effective
+//! nonce, and the task-issuer PUBLIC key into the pod on the **same
+//! host-controlled boot channel** the node already uses for credentials
+//! (process env / kernel cmdline the agent cannot set). The tool-proxy reads
+//! them from `NUCLEUS_TASK_TOKEN` / `NUCLEUS_TASK_TOKEN_NONCE` /
+//! `NUCLEUS_TASK_TOKEN_ISSUER` and verifies once at startup, fail-closed.
+//!
+//! ## Trust choke point
+//!
+//! The scope's operation set is [`PermissionLattice::granted_operations`] — the
+//! ops whose capability level is strictly above `Never`. By construction the
+//! minted [`TokenScope`] is a subset of the policy: an op is in scope **iff**
+//! the policy does not fully deny it. A fully-locked-down policy therefore
+//! mints an EMPTY-scope token (which later DENIES `RunBash`), never a wildcard.
+//!
+//! ## What is (and isn't) a secret
+//!
+//! The token is a **scoped capability plus a public issuer key** — not a
+//! secret. Only the issuer's PUBLIC half is ever injected; the private
+//! task-issuer key stays on the node ([`TrustGateConfig::task_issuer_signing_key`](crate::trust_gate::TrustGateConfig)).
+//! On the Firecracker path the material rides the kernel cmdline alongside the
+//! existing `nucleus.auth_secret` (see the M-4 cmdline-readability caveat): the
+//! token's confidentiality is not load-bearing, and the anti-truncation /
+//! anti-replay defense rests on the host-pinned effective nonce, not on secrecy.
+//!
+//! ## Paths (deferred)
+//!
+//! Path scoping is the NEXT gating brick (path mediation). `allowed_paths` is
+//! intentionally left EMPTY here rather than lifted from `PathLattice`, whose
+//! "empty allowed = all readable" semantics are the inverse of `TokenScope`'s
+//! "empty = nothing" allowlist semantics — conflating them would silently
+//! mis-scope the token. Operations are the choke point this brick owns.
+
+use ed25519_dalek::SigningKey;
+use nucleus_provenance_memory::{SignedTaskRef, TokenScope};
+use portcullis::PermissionLattice;
+use rand_core::RngCore as _;
+
+/// Width of a [`SignedTaskRef`] block nonce, in bytes.
+const NONCE_LEN: usize = 16;
+
+/// The three host-injected boot-channel strings the tool-proxy verify half
+/// consumes. Field serialization matches
+/// `nucleus-tool-proxy::session_token` exactly: JSON token, lowercase-hex
+/// nonce, lowercase-hex issuer public key.
+pub(crate) struct MintedTaskToken {
+    /// `serde_json` serialization of the [`SignedTaskRef`] → `NUCLEUS_TASK_TOKEN`.
+    pub token_json: String,
+    /// Hex of the 16-byte effective nonce → `NUCLEUS_TASK_TOKEN_NONCE`.
+    pub nonce_hex: String,
+    /// Hex of the 32-byte task-issuer PUBLIC key → `NUCLEUS_TASK_TOKEN_ISSUER`.
+    pub issuer_hex: String,
+}
+
+/// Mint a fresh per-pod session capability token from the pod's resolved
+/// policy.
+///
+/// - `task_id`   — stable id bound into the token signature (the pod UUID).
+/// - `policy`    — the pod's resolved [`PermissionLattice`]; its
+///   `granted_operations()` become the token's operation scope.
+/// - `ttl_secs`  — token lifetime in **seconds** (the pod/session lifetime,
+///   e.g. `spec.spec.timeout_seconds`); verify uses `issued_at + ttl < now`.
+/// - `now_unix`  — issue time as **UNIX seconds** (wall clock at the spawn
+///   site; passed in so this stays pure/deterministic for tests). Matches the
+///   verify half's `elapsed.as_secs()`.
+/// - `issuer`    — the node's dedicated task-issuer signing key; only its
+///   public half is emitted.
+///
+/// A fresh CSPRNG nonce is drawn per call (per pod), so no two pods share an
+/// effective nonce — the host-pinned anti-replay / anti-truncation input.
+pub(crate) fn mint_session_task_token(
+    task_id: &str,
+    policy: &PermissionLattice,
+    ttl_secs: u64,
+    now_unix: u64,
+    issuer: &SigningKey,
+) -> Result<MintedTaskToken, serde_json::Error> {
+    // Fresh per-pod nonce from the OS CSPRNG, at the exact width SignedTaskRef
+    // pins as the effective nonce.
+    let mut nonce = [0u8; NONCE_LEN];
+    rand_core::OsRng.fill_bytes(&mut nonce);
+
+    // THE choke point: scope operations = ops the policy does not deny. Subset
+    // of the policy by construction (granted_operations excludes every Never
+    // op). Paths deferred to the next brick — see module docs.
+    let scope = TokenScope::new(policy.granted_operations(), Vec::new());
+
+    let token = SignedTaskRef::issue(task_id, scope, nonce, now_unix, ttl_secs, issuer);
+    let token_json = serde_json::to_string(&token)?;
+
+    Ok(MintedTaskToken {
+        token_json,
+        nonce_hex: hex::encode(nonce),
+        issuer_hex: hex::encode(issuer.verifying_key().to_bytes()),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use portcullis::{CapabilityLattice, CapabilityLevel, Operation};
+
+    // Decode-only test key (no CSPRNG) — production keys come from the node's
+    // persisted task-issuer key file.
+    fn issuer_key(seed: u8) -> SigningKey {
+        SigningKey::from_bytes(&[seed; 32])
+    }
+
+    const NOW: u64 = 1_700_000_000;
+    const TTL: u64 = 3_600;
+
+    /// (c) End-to-end mint→verify: the three injected strings round-trip and the
+    /// token `SignedTaskRef::verify` ACCEPTS under the injected issuer pubkey +
+    /// injected nonce, at a `now` within the TTL window. The verified effective
+    /// scope equals the policy's `granted_operations()` (subset-by-construction).
+    #[test]
+    fn minted_token_verifies_under_injected_issuer_and_nonce() {
+        let issuer = issuer_key(3);
+        let policy = PermissionLattice::local_dev(); // read/write/edit/bash/glob/grep/commit
+
+        let minted = mint_session_task_token("pod-abc", &policy, TTL, NOW, &issuer).expect("mint");
+
+        // Reconstruct the verifier inputs from the injected strings exactly as
+        // the tool-proxy would.
+        let token: SignedTaskRef = serde_json::from_str(&minted.token_json).unwrap();
+        let nonce_bytes = hex::decode(&minted.nonce_hex).unwrap();
+        let nonce: [u8; 16] = nonce_bytes.try_into().unwrap();
+        let issuer_bytes = hex::decode(&minted.issuer_hex).unwrap();
+        let issuer_pub: [u8; 32] = issuer_bytes.try_into().unwrap();
+
+        // Injected issuer hex must be the PUBLIC key (never the private key).
+        assert_eq!(issuer_pub, issuer.verifying_key().to_bytes());
+
+        let scope = token
+            .verify(&issuer_pub, NOW + 10, &nonce)
+            .expect("minted token must verify under injected issuer + nonce");
+
+        // The verified scope's operations are exactly granted_operations().
+        assert_eq!(scope.allowed_operations, policy.granted_operations());
+        assert!(
+            scope.allowed_paths.is_empty(),
+            "paths deferred to next brick"
+        );
+
+        // No minted op is Never in the source policy.
+        for op in &scope.allowed_operations {
+            assert_ne!(policy.capabilities.level_for(*op), CapabilityLevel::Never);
+        }
+    }
+
+    /// (b) A fully-locked-down policy mints an EMPTY-scope token — which the
+    /// verifier accepts as a valid, zero-authority token. RunBash is absent, so
+    /// the later gate DENIES bash (not a wildcard).
+    #[test]
+    fn all_never_policy_mints_empty_scope_token() {
+        let issuer = issuer_key(4);
+        let mut policy = PermissionLattice::read_only();
+        policy.capabilities = CapabilityLattice {
+            read_files: CapabilityLevel::Never,
+            write_files: CapabilityLevel::Never,
+            edit_files: CapabilityLevel::Never,
+            run_bash: CapabilityLevel::Never,
+            glob_search: CapabilityLevel::Never,
+            grep_search: CapabilityLevel::Never,
+            web_search: CapabilityLevel::Never,
+            web_fetch: CapabilityLevel::Never,
+            git_commit: CapabilityLevel::Never,
+            git_push: CapabilityLevel::Never,
+            create_pr: CapabilityLevel::Never,
+            manage_pods: CapabilityLevel::Never,
+            spawn_agent: CapabilityLevel::Never,
+            #[cfg(not(kani))]
+            extensions: std::collections::BTreeMap::new(),
+        };
+
+        let minted = mint_session_task_token("pod-locked", &policy, TTL, NOW, &issuer).unwrap();
+        let token: SignedTaskRef = serde_json::from_str(&minted.token_json).unwrap();
+        let nonce: [u8; 16] = hex::decode(&minted.nonce_hex).unwrap().try_into().unwrap();
+        let issuer_pub: [u8; 32] = hex::decode(&minted.issuer_hex).unwrap().try_into().unwrap();
+
+        let scope = token
+            .verify(&issuer_pub, NOW, &nonce)
+            .expect("empty token verifies");
+        assert!(
+            scope.allowed_operations.is_empty(),
+            "locked-down policy must mint an EMPTY operation scope, got {:?}",
+            scope.allowed_operations
+        );
+        assert!(!scope.allowed_operations.contains(&Operation::RunBash));
+    }
+
+    /// The minted scope is a subset of the policy for a mid-privilege profile:
+    /// every op with `level_for == Never` is absent from the token scope.
+    #[test]
+    fn minted_scope_is_subset_of_policy() {
+        let issuer = issuer_key(5);
+        let policy = PermissionLattice::pr_review(); // read/glob/grep/web only
+
+        let minted = mint_session_task_token("pod-pr", &policy, TTL, NOW, &issuer).unwrap();
+        let token: SignedTaskRef = serde_json::from_str(&minted.token_json).unwrap();
+
+        let scope = token.effective_scope().unwrap();
+        for op in Operation::ALL {
+            if policy.capabilities.level_for(op) == CapabilityLevel::Never {
+                assert!(
+                    !scope.allowed_operations.contains(&op),
+                    "denied op {op:?} must not appear in the minted scope"
+                );
+            }
+        }
+        // Sanity: a denied op (run_bash is Never in pr_review) is absent; an
+        // allowed op (read_files) is present.
+        assert!(!scope.allowed_operations.contains(&Operation::RunBash));
+        assert!(scope.allowed_operations.contains(&Operation::ReadFiles));
+    }
+}

--- a/crates/nucleus-node/src/trust_gate.rs
+++ b/crates/nucleus-node/src/trust_gate.rs
@@ -55,6 +55,15 @@ pub struct TrustGateConfig {
     pub executor_signing_key: Arc<SigningKey>,
     /// Executor identity sent as X-Nucleus-Executor-Id on receipt POSTs.
     pub executor_id: String,
+    /// Dedicated Ed25519 key that signs live-path **session capability tokens**
+    /// ([`SignedTaskRef`](nucleus_provenance_memory::SignedTaskRef)) minted at
+    /// pod spawn. Deliberately DISTINCT from `executor_signing_key` (role
+    /// separation): the executor key signs executor decisions and is the
+    /// executor's receipt identity, so reusing it as the token root issuer
+    /// would conflate two trust roles. Only the PUBLIC half is ever injected
+    /// into a pod (as `NUCLEUS_TASK_TOKEN_ISSUER`); the private key never leaves
+    /// the node.
+    pub task_issuer_signing_key: Arc<SigningKey>,
 }
 
 impl Default for TrustGateConfig {
@@ -66,6 +75,7 @@ impl Default for TrustGateConfig {
             receipt_secret: None,
             executor_signing_key: Arc::new(generate_signing_key()),
             executor_id: format!("nucleus-executor/{}", uuid_hex()),
+            task_issuer_signing_key: Arc::new(generate_signing_key()),
         }
     }
 }
@@ -87,6 +97,11 @@ fn uuid_hex() -> String {
 
 /// Filename (under `state_dir`) holding the persisted executor signing key.
 const EXECUTOR_KEY_FILE: &str = "executor_signing_key.der";
+
+/// Filename (under `state_dir`) holding the persisted **task-issuer** signing
+/// key — the root that signs live-path session capability tokens. DISTINCT from
+/// [`EXECUTOR_KEY_FILE`] so the two trust roles never share a key.
+const TASK_ISSUER_KEY_FILE: &str = "task_issuer_signing_key.der";
 
 /// Generate a fresh Ed25519 signing key from the OS CSPRNG.
 ///
@@ -117,25 +132,45 @@ fn generate_signing_key() -> SigningKey {
 /// replaced rather than crashing the node (fail-open on *availability*, not on
 /// identity — a corrupt key was never a valid enrollment anyway).
 pub fn load_or_create_signing_key(state_dir: &Path) -> SigningKey {
-    let path = state_dir.join(EXECUTOR_KEY_FILE);
+    load_or_create_key_file(state_dir, EXECUTOR_KEY_FILE, "executor signing key")
+}
+
+/// Load the dedicated **task-issuer** Ed25519 signing key from `state_dir`,
+/// creating and persisting a fresh one on first run.
+///
+/// Uses the identical persistence discipline as
+/// [`load_or_create_signing_key`] (PKCS#8 DER, `0o400`, fail-open on
+/// availability) but a DISTINCT file ([`TASK_ISSUER_KEY_FILE`]). This is the
+/// root that signs live-path session capability tokens; keeping it separate
+/// from the executor key enforces role separation — a compromise or rotation
+/// of one identity does not implicate the other, and the executor key (which
+/// is also the executor's receipt identity) never doubles as a token root.
+pub fn load_or_create_task_issuer_signing_key(state_dir: &Path) -> SigningKey {
+    load_or_create_key_file(state_dir, TASK_ISSUER_KEY_FILE, "task issuer signing key")
+}
+
+/// Shared implementation for the persisted per-node Ed25519 keys. `filename` is
+/// the basename under `state_dir`; `label` is used only in log lines.
+fn load_or_create_key_file(state_dir: &Path, filename: &str, label: &str) -> SigningKey {
+    let path = state_dir.join(filename);
 
     if path.exists() {
         match std::fs::read(&path) {
             Ok(bytes) => match SigningKey::from_pkcs8_der(&bytes) {
                 Ok(key) => {
-                    debug!(path = %path.display(), "loaded persisted executor signing key");
+                    debug!(path = %path.display(), "loaded persisted {label}");
                     return key;
                 }
                 Err(e) => warn!(
                     path = %path.display(),
                     error = %e,
-                    "executor signing key file is unreadable; regenerating"
+                    "{label} file is unreadable; regenerating"
                 ),
             },
             Err(e) => warn!(
                 path = %path.display(),
                 error = %e,
-                "failed to read executor signing key file; regenerating"
+                "failed to read {label} file; regenerating"
             ),
         }
     }
@@ -147,13 +182,13 @@ pub fn load_or_create_signing_key(state_dir: &Path) -> SigningKey {
                 warn!(
                     path = %path.display(),
                     error = %e,
-                    "failed to persist executor signing key; identity will not survive restart"
+                    "failed to persist {label}; identity will not survive restart"
                 );
             } else {
-                info!(path = %path.display(), "generated and persisted new executor signing key");
+                info!(path = %path.display(), "generated and persisted new {label}");
             }
         }
-        Err(e) => warn!(error = %e, "failed to PKCS#8-encode executor signing key; not persisting"),
+        Err(e) => warn!(error = %e, "failed to PKCS#8-encode {label}; not persisting"),
     }
     key
 }
@@ -190,6 +225,8 @@ impl TrustGateConfig {
             .map(Arc::new);
 
         let executor_signing_key = load_or_create_signing_key(state_dir);
+        // Role-separated key that signs live-path session capability tokens.
+        let task_issuer_signing_key = load_or_create_task_issuer_signing_key(state_dir);
 
         // Prefer an explicit id; otherwise derive a stable one from the
         // persistent key (not a fresh uuid per process — #1636).
@@ -206,6 +243,7 @@ impl TrustGateConfig {
             receipt_secret,
             executor_signing_key: Arc::new(executor_signing_key),
             executor_id,
+            task_issuer_signing_key: Arc::new(task_issuer_signing_key),
         }
     }
 
@@ -1165,6 +1203,47 @@ mod tests {
             "executor signing key must be stable across restarts"
         );
         assert!(dir.path().join(EXECUTOR_KEY_FILE).exists());
+    }
+
+    /// Role separation: the task-issuer key must be a DIFFERENT key from the
+    /// executor key in the same state_dir (distinct files), yet each must be
+    /// stable across restarts. Reusing the executor key as the token root would
+    /// conflate the executor identity with the capability-token issuer.
+    #[test]
+    fn test_task_issuer_key_is_distinct_from_executor_and_persists() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let exec = load_or_create_signing_key(dir.path());
+        let issuer = load_or_create_task_issuer_signing_key(dir.path());
+        assert_ne!(
+            exec.verifying_key().as_bytes(),
+            issuer.verifying_key().as_bytes(),
+            "task-issuer key must not equal the executor key (role separation)"
+        );
+
+        // Distinct files on disk.
+        assert!(dir.path().join(EXECUTOR_KEY_FILE).exists());
+        assert!(dir.path().join(TASK_ISSUER_KEY_FILE).exists());
+
+        // Stable across a "restart" (second load from the same dir).
+        let issuer2 = load_or_create_task_issuer_signing_key(dir.path());
+        assert_eq!(
+            issuer.verifying_key().as_bytes(),
+            issuer2.verifying_key().as_bytes(),
+            "task-issuer key must be stable across restarts"
+        );
+    }
+
+    /// `from_env` provisions BOTH keys and they are role-separated.
+    #[test]
+    fn test_from_env_provisions_role_separated_task_issuer_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = TrustGateConfig::from_env(dir.path());
+        assert_ne!(
+            config.executor_signing_key.verifying_key().as_bytes(),
+            config.task_issuer_signing_key.verifying_key().as_bytes(),
+            "from_env must provision a task-issuer key distinct from the executor key"
+        );
     }
 
     #[test]

--- a/crates/portcullis/src/lattice.rs
+++ b/crates/portcullis/src/lattice.rs
@@ -482,6 +482,28 @@ impl PermissionLattice {
         self.obligations.requires(op)
     }
 
+    /// The operations this policy actually permits — every core [`Operation`]
+    /// whose capability level is **strictly above** [`CapabilityLevel::Never`].
+    ///
+    /// This is **the trust choke point** for minting a session capability
+    /// token: a [`TokenScope`](crate) built from `granted_operations()` is a
+    /// subset of the policy *by construction*, because an operation is present
+    /// here **iff** `level_for(op) > Never`. Equivalently, every op excluded
+    /// here is exactly one with `level_for(op) == Never` (fully denied), so the
+    /// minted scope can never grant an operation the policy denies.
+    ///
+    /// Enumeration is over [`Operation::ALL`] (the 13 statically-known core
+    /// operations), so the ordering is **deterministic** — it follows the
+    /// enum's declaration order. `ExtensionOperation`s are intentionally
+    /// excluded: they are string-keyed, out of the formally-verified core, and
+    /// not part of the token vocabulary.
+    pub fn granted_operations(&self) -> Vec<Operation> {
+        Operation::ALL
+            .into_iter()
+            .filter(|&op| self.capabilities.level_for(op) > CapabilityLevel::Never)
+            .collect()
+    }
+
     /// Delegate permissions to a subagent.
     ///
     /// The resulting permissions are `self ∧ requested`, ensuring:
@@ -1462,6 +1484,122 @@ mod tests {
         assert!(
             serde_json::from_str::<PermissionLattice>(&serde_json::to_string(&good).unwrap())
                 .is_ok()
+        );
+    }
+
+    /// LOAD-BEARING (live-path mint brick, acceptance (a)): for EVERY policy
+    /// profile, `granted_operations()` is exactly the set of operations whose
+    /// capability level is strictly above `Never`. Concretely:
+    ///
+    /// 1. no granted op is `Never` (a minted scope never grants a denied op);
+    /// 2. every op with `level_for(op) == Never` is excluded;
+    /// 3. the granted set == the `> Never` set (nothing dropped either way);
+    /// 4. ordering is deterministic (follows `Operation::ALL`).
+    ///
+    /// This is the by-construction guarantee that a token scope minted from
+    /// `granted_operations()` is a subset of the policy.
+    #[test]
+    fn granted_operations_excludes_every_never_op_for_all_profiles() {
+        let profiles: Vec<(&str, PermissionLattice)> = vec![
+            ("default", PermissionLattice::default()),
+            ("permissive", PermissionLattice::permissive()),
+            ("restrictive", PermissionLattice::restrictive()),
+            ("read_only", PermissionLattice::read_only()),
+            (
+                "filesystem_readonly",
+                PermissionLattice::filesystem_readonly(),
+            ),
+            ("network_only", PermissionLattice::network_only()),
+            ("web_research", PermissionLattice::web_research()),
+            ("code_review", PermissionLattice::code_review()),
+            ("edit_only", PermissionLattice::edit_only()),
+            ("local_dev", PermissionLattice::local_dev()),
+            ("fix_issue", PermissionLattice::fix_issue()),
+            ("safe_pr_fixer", PermissionLattice::safe_pr_fixer()),
+            ("release", PermissionLattice::release()),
+            ("database_client", PermissionLattice::database_client()),
+            ("demo", PermissionLattice::demo()),
+            ("pr_review", PermissionLattice::pr_review()),
+            ("codegen", PermissionLattice::codegen()),
+            ("pr_approve", PermissionLattice::pr_approve()),
+            ("orchestrator", PermissionLattice::orchestrator()),
+        ];
+
+        for (name, policy) in &profiles {
+            let granted = policy.granted_operations();
+
+            // (1)+(2)+(3): granted == { op | level_for(op) > Never }.
+            let expected: Vec<Operation> = Operation::ALL
+                .into_iter()
+                .filter(|&op| policy.capabilities.level_for(op) > CapabilityLevel::Never)
+                .collect();
+            assert_eq!(
+                granted, expected,
+                "profile {name}: granted_operations must equal the >Never set"
+            );
+
+            // (1) restated as a direct denial check: no granted op is Never.
+            for op in &granted {
+                assert_ne!(
+                    policy.capabilities.level_for(*op),
+                    CapabilityLevel::Never,
+                    "profile {name}: granted op {op:?} must not be Never"
+                );
+            }
+            // (2) restated: every Never op is absent from the granted set.
+            for op in Operation::ALL {
+                if policy.capabilities.level_for(op) == CapabilityLevel::Never {
+                    assert!(
+                        !granted.contains(&op),
+                        "profile {name}: denied (Never) op {op:?} leaked into granted set"
+                    );
+                }
+            }
+
+            // (4) deterministic ordering: granted is a subsequence of ALL.
+            let mut all_iter = Operation::ALL.into_iter();
+            for op in &granted {
+                assert!(
+                    all_iter.by_ref().any(|a| a == *op),
+                    "profile {name}: granted ops must follow Operation::ALL order"
+                );
+            }
+        }
+    }
+
+    /// A fully-locked-down policy (every capability `Never`) grants NO
+    /// operations — an empty scope, not a wildcard. In particular `RunBash` is
+    /// absent, so a token minted from it later DENIES bash (acceptance (b)).
+    #[test]
+    fn granted_operations_empty_for_all_never_policy() {
+        // read_only already has run_bash = Never; build a stricter one where
+        // every capability is Never to prove the empty-scope case exactly.
+        let mut locked = PermissionLattice::read_only();
+        locked.capabilities = CapabilityLattice {
+            read_files: CapabilityLevel::Never,
+            write_files: CapabilityLevel::Never,
+            edit_files: CapabilityLevel::Never,
+            run_bash: CapabilityLevel::Never,
+            glob_search: CapabilityLevel::Never,
+            grep_search: CapabilityLevel::Never,
+            web_search: CapabilityLevel::Never,
+            web_fetch: CapabilityLevel::Never,
+            git_commit: CapabilityLevel::Never,
+            git_push: CapabilityLevel::Never,
+            create_pr: CapabilityLevel::Never,
+            manage_pods: CapabilityLevel::Never,
+            spawn_agent: CapabilityLevel::Never,
+            #[cfg(not(kani))]
+            extensions: std::collections::BTreeMap::new(),
+        };
+        let granted = locked.granted_operations();
+        assert!(
+            granted.is_empty(),
+            "an all-Never policy must grant an EMPTY operation set, got {granted:?}"
+        );
+        assert!(
+            !granted.contains(&Operation::RunBash),
+            "RunBash must never appear in an all-Never policy's granted ops"
         );
     }
 


### PR DESCRIPTION
Node-side **minting** brick of the live-path token migration (Focus A). The tool-proxy verify half (#2036) is merged; this makes real pods boot with a `Verified` session task token. **Does not yet gate any effect** — that is the next (RunBash) brick. Executor / mediation gate / allowlist untouched.

**The trust choke point — `PermissionLattice::granted_operations()`** (`portcullis/src/lattice.rs`): returns every `Operation::ALL` variant with `level_for(op) > CapabilityLevel::Never` (Never = 0 is the documented ⊥). The minted `TokenScope.allowed_operations` is exactly this, so **scope ⊆ policy by construction** — a pod's token can never grant an op its policy denies. `ExtensionOperation`s (string-keyed, out of the verified core) are excluded from the token vocabulary.

**Role-separated key (F7):** a dedicated `task_issuer_signing_key` provisioned via the existing `load_or_create_signing_key` pattern but a distinct file (`task_issuer_signing_key.der`), held in `TrustGate` next to `executor_signing_key`. Not reused — the executor key already signs executor decisions and is the published executor identity, so overloading it would couple two authorities. Only the **public** half is ever emitted.

**Mint + inject** (`nucleus-node` `spawn_local_pod`, `spawn_container_pod`, firecracker path): fresh 16-byte OsRng nonce per pod, `scope = granted_operations()`, `issued_at = now (unix secs)`, `ttl = timeout_seconds`; `SignedTaskRef::issue(...)`; injected as `NUCLEUS_TASK_TOKEN` / `NUCLEUS_TASK_TOKEN_NONCE` / `NUCLEUS_TASK_TOKEN_ISSUER` (issuer = task-issuer **public** key) alongside existing env secrets. Serialization matches the merged verify half exactly.

**Tests (all green; fmt/clippy --all-features/verify-strict/mediation clean):**
- `granted_operations_excludes_every_never_op_for_all_profiles` (all profiles) + `granted_operations_empty_for_all_never_policy`.
- `minted_scope_is_subset_of_policy` and `all_never_policy_mints_empty_scope_token` (empty policy → empty scope → later denies RunBash, not a wildcard).
- `minted_token_verifies_under_injected_issuer_and_nonce`.
- `task_issuer_key_is_distinct_from_executor_and_persists`, `from_env_provisions_role_separated_task_issuer_key`.
- firecracker bridge: `task_token_hex_roundtrips_to_exact_json`.

**Disclosed flags:**
1. **Env-var names corrected** — the scoping said `NUCLEUS_TASK_NONCE`/`_ISSUER`; the merged consumer actually reads `NUCLEUS_TASK_TOKEN_NONCE`/`_ISSUER`. Matched the real consumer.
2. **Firecracker cmdline (M-4):** raw JSON is unsafe on a whitespace/quote-sensitive kernel cmdline, so the token is hex-wrapped and decoded in `nucleus-guest-init` (adds a `hex` dep there — outside the originally-scoped files but necessary to make the microVM path functional). It rides the world-readable cmdline alongside `nucleus.auth_secret`; acceptable because the token is a **scoped capability + public key, not a secret**, and anti-replay/anti-truncation rests on the host-pinned nonce. Unreadable-channel hardening stays a deferred defense-in-depth option.
3. **Paths deferred** — `allowed_paths = vec![]`: `PathLattice`'s "empty = all" is the inverse of `TokenScope`'s "empty = nothing", so lifting paths naively would mis-scope. Path mediation is a later brick (and the discharge `InScopeWithTask` check is operation-only today anyway).
4. Added `nucleus-provenance-memory` dep to `nucleus-node`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CNJdZb7LHWwXkrt9MCa8CG
