### PR TITLE
feat(nucleus): un-preflighted Executor spawn is a compile error (type-enforced mediation)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6474,6 +6474,7 @@ dependencies = [
  "hex",
  "hmac 0.13.0",
  "libc",
+ "nucleus-ifc-kernel",
  "nucleus-provenance",
  "parking_lot",
  "portcullis",

--- a/crates/nucleus-tool-proxy/src/main.rs
+++ b/crates/nucleus-tool-proxy/src/main.rs
@@ -41,6 +41,7 @@ mod mtls;
 mod node_client;
 mod pod_mgmt;
 mod policy;
+mod run_gate;
 mod sandbox_proof;
 mod session_token;
 mod telemetry;
@@ -2559,7 +2560,68 @@ async fn run_command(
     let stdin = req.stdin.as_deref();
     let directory = req.directory.as_deref();
 
-    let output = match executor.run_args(&req.args, stdin, directory, &decision_token) {
+    // ─── Executor-proof gate (PR-2, parity with the MCP RunBash handler) ──────
+    // Mint the sealed 7-witness `DischargedBundle` — the type-level precondition
+    // that lets `run_args`/`run_args_with_approval` even be typed. Reuses the exact
+    // `preflight_runbash` the MCP path uses (no re-mint, no forged bundle). Fail
+    // closed on Denied/RequiresApproval: a Missing/Invalid session task token gives
+    // `verified_scope == None` ⇒ `InScopeWithTask` denies — never a permissive
+    // default. Without a bundle here this HTTP spawn would not compile.
+    let discharge_bundle = {
+        use nucleus_ifc_kernel::discharge::PreflightResult;
+        let verified_scope = state.session_task_token.verified_scope();
+        let run_bash_ceiling = state.runtime.policy().capabilities.run_bash;
+        let flow = state.flow_tracker.lock().await;
+        let result =
+            run_gate::preflight_runbash(verified_scope, run_bash_ceiling, &display_command, &flow);
+        drop(flow);
+        match result {
+            PreflightResult::Allowed(bundle) => bundle,
+            PreflightResult::Denied { reason, .. } => {
+                if let Err(e) = sink.record(VerdictContext {
+                    operation,
+                    subject: display_command.clone(),
+                    outcome: VerdictOutcome::Deny {
+                        reason: format!("discharge denied: {reason}"),
+                    },
+                    actor,
+                    policy_rule: None,
+                    extensions: BTreeMap::new(),
+                }) {
+                    warn!(error = %e, "verdict recording failed -- audit gap");
+                }
+                return Err(ApiError::IfcDenied(format!("discharge denied: {reason}")));
+            }
+            PreflightResult::RequiresApproval { reason } => {
+                if let Err(e) = sink.record(VerdictContext {
+                    operation,
+                    subject: display_command.clone(),
+                    outcome: VerdictOutcome::Deny {
+                        reason: format!("discharge requires approval: {reason}"),
+                    },
+                    actor,
+                    policy_rule: None,
+                    extensions: BTreeMap::new(),
+                }) {
+                    warn!(error = %e, "verdict recording failed -- audit gap");
+                }
+                return Err(ApiError::IfcDenied(format!(
+                    "discharge requires approval: {reason}"
+                )));
+            }
+        }
+    };
+    // Durable audit witness of the sealed 7-witness proof (parity with the MCP
+    // handler's `discharge_bundle` verdict extension).
+    let discharge_note = run_gate::discharge_witness(&discharge_bundle);
+
+    let output = match executor.run_args(
+        &req.args,
+        stdin,
+        directory,
+        &decision_token,
+        &discharge_bundle,
+    ) {
         Ok(output) => output,
         Err(NucleusError::ApprovalRequired { operation: op }) => {
             // Check if policy allows this operation (zero-prompt mode) or if approval was pre-granted
@@ -2583,6 +2645,8 @@ async fn run_command(
                     directory,
                     &approved_dt,
                     &approval,
+                    // Same sealed bundle minted above authorizes the approved retry.
+                    &discharge_bundle,
                 )?
             } else {
                 if let Err(e) = sink.record(VerdictContext {
@@ -2611,7 +2675,10 @@ async fn run_command(
                 },
                 actor,
                 policy_rule: None,
-                extensions: BTreeMap::new(),
+                extensions: BTreeMap::from([(
+                    "discharge_bundle".to_string(),
+                    discharge_note.clone(),
+                )]),
             }) {
                 warn!(error = %e, "verdict recording failed -- audit gap");
             }
@@ -2625,7 +2692,7 @@ async fn run_command(
         outcome: VerdictOutcome::Allow,
         actor,
         policy_rule: None,
-        extensions: BTreeMap::new(),
+        extensions: BTreeMap::from([("discharge_bundle".to_string(), discharge_note)]),
     }) {
         warn!(error = %e, "verdict recording failed -- audit gap");
     }

--- a/crates/nucleus-tool-proxy/src/mcp.rs
+++ b/crates/nucleus-tool-proxy/src/mcp.rs
@@ -19,14 +19,10 @@ use portcullis::{
     CapabilityLevel, FlowTracker, GradedExposureGuard, NodeKind, Operation, ToolCallGuard,
 };
 // Sealed discharge preflight (#2038): the live RunBash path must mint a
-// `DischargedBundle` before it may spawn. `discharge::ActionTerm` is a distinct
-// type from `portcullis::action_term::ActionTerm` above — always name it through
-// the `discharge::` path to avoid the collision.
-use nucleus_ifc_kernel::discharge::{
-    self, preflight_action, DischargedBundle, PreflightResult, VerifiedScope,
-};
-use nucleus_ifc_kernel::{IFCLabel, SinkClass};
-use nucleus_provenance_memory::TokenScope;
+// `DischargedBundle` before it may spawn. The bundle-minting itself
+// (`preflight_runbash`) now lives in `crate::run_gate` (shared with the HTTP
+// handler); here we only need the result/bundle types it returns.
+use nucleus_ifc_kernel::discharge::PreflightResult;
 use rmcp::{
     handler::server::router::tool::ToolRouter, handler::server::wrapper::Parameters, model::*,
     tool, tool_handler, tool_router, ErrorData as McpError, ServerHandler, ServiceExt,
@@ -491,7 +487,7 @@ impl NucleusMcpServer {
         // them). The `DischargedBundle` can only be built by `preflight_action`,
         // so reaching `run_args` past the `Allowed` arm is a compile-time-checked
         // authorization proof.
-        let discharge_note = {
+        let (discharge_note, discharge_bundle) = {
             let verified_scope = self.state.session_task_token.verified_scope();
             let run_bash_ceiling = self.state.runtime.policy().capabilities.run_bash;
             let flow = self.flow_tracker.lock().await;
@@ -499,9 +495,13 @@ impl NucleusMcpServer {
             drop(flow);
             match result {
                 PreflightResult::Allowed(bundle) => {
-                    // Consume the bundle (satisfies its `#[must_use]`) into the
-                    // audit record so the sealed proof is durable, not dead.
-                    discharge_witness(&bundle)
+                    // Keep the sealed bundle ALIVE: it is now the type-level proof
+                    // required by `run_args` (executor-proof gate), and its
+                    // `#[must_use]` is satisfied by both the audit witness and the
+                    // spawn call below. Record the durable witness, then hand the
+                    // bundle down to the spawn.
+                    let note = discharge_witness(&bundle);
+                    (note, bundle)
                 }
                 PreflightResult::Denied { reason, .. } => {
                     warn!(
@@ -543,6 +543,11 @@ impl NucleusMcpServer {
                     params.stdin.as_deref(),
                     params.directory.as_deref(),
                     &decision_token,
+                    // Executor-proof gate (#2038 → PR-2): the sealed bundle minted
+                    // by `preflight_runbash` above is the type-level authorization.
+                    // Reaching this spawn requires it, so no un-preflighted spawn
+                    // can compile.
+                    &discharge_bundle,
                 )
             })
         }) {
@@ -1141,96 +1146,12 @@ fn build_action_term(operation: Operation, subject: &str) -> ActionTerm {
     ActionTerm::from_operation(operation, subject)
 }
 
-/// The sealed discharge preflight for the live RunBash path (#2038).
-///
-/// Builds the discharge [`ActionTerm`](discharge::ActionTerm) for
-/// `RunBash`/`BashExec` and runs [`preflight_action`]. Returning
-/// [`PreflightResult::Allowed`] hands back a [`DischargedBundle`] — the sealed
-/// 7-witness proof that the operation is authorized. There is no other way to
-/// construct that bundle, so a caller that reaches `run_args` only past an
-/// `Allowed` arm is a compile-time-checked precondition.
-///
-/// Fail-closed / no-vacuous-witness:
-/// - `verified_scope == None` (session token `Missing`/`Invalid`) ⇒
-///   `InScopeWithTask` DENIES. We pass `None` straight through — never a
-///   permissive default.
-/// - `RunBash ∉ scope.allowed_operations` ⇒ `InScopeWithTask` DENIES.
-///
-/// HONESTY (what actually bites, #2038): for the `BashExec` sink the five
-/// original discharge obligations are structurally satisfied by the honest
-/// inputs below and do not add enforcement here:
-/// - IntegrityGate: `sink_min_integrity(BashExec)` is `Adversarial` (the floor),
-///   so any integrity passes;
-/// - PathAllowed: the fixed `RunBash`/`BashExec` pair is always structurally OK;
-/// - DerivationClear: `BashExec` is not a verified-lane sink, so it is skipped;
-/// - NoAdversarialAncestry: passes whenever the session carries no
-///   adversarial-integrity source label (with an empty [`FlowTracker`], vacuous);
-/// - BudgetNotExceeded: cost is 0 (no cost estimator wired, #1362);
-/// - WithinDelegationCeiling: `requested == ceiling == level_for(RunBash)`, the
-///   runtime's honest no-escalation claim, so `requested ≤ ceiling` holds by
-///   construction (sound-but-dormant, mirrors `build_term_scoped`).
-///
-/// So the real added enforcement of this brick is **`InScopeWithTask`** (gated by
-/// the verified session task token) plus the fail-closed ceiling. The IFC labels
-/// ARE fed honestly from the session's real [`FlowTracker`] (not `default()`), so
-/// `NoAdversarialAncestry`/`IntegrityGate` bite for real once web/adversarial
-/// content is in the session — they are simply vacuous on a clean session.
-fn preflight_runbash(
-    verified_scope: Option<&TokenScope>,
-    run_bash_ceiling: CapabilityLevel,
-    subject: &str,
-    flow: &FlowTracker,
-) -> PreflightResult {
-    // Real source labels from the session flow tracker (#1633 taint state) —
-    // NOT fabricated defaults. Mirrors `build_term_scoped` in portcullis-effects.
-    let mut source_labels = Vec::new();
-    for node_id in 1..=flow.node_count() as u64 {
-        if let Some(label) = flow.label(node_id) {
-            source_labels.push(*label);
-        }
-    }
-    // Artifact label: join of all source labels (most restrictive composite); an
-    // empty (clean) session yields the default label.
-    let artifact_label = if source_labels.is_empty() {
-        IFCLabel::default()
-    } else {
-        source_labels
-            .iter()
-            .skip(1)
-            .fold(source_labels[0], |acc, l| acc.join(*l))
-    };
-
-    // Convert the verified `TokenScope` into the kernel's local `VerifiedScope`
-    // carrier field-for-field (the kernel is dependency-free and cannot name
-    // `TokenScope`). `None` ⇒ `InScopeWithTask` denied fail-closed.
-    let term_scope = verified_scope.map(|s| VerifiedScope {
-        allowed_operations: s.allowed_operations.clone(),
-        allowed_paths: s.allowed_paths.clone(),
-    });
-
-    let term = discharge::ActionTerm {
-        operation: Operation::RunBash,
-        sink_class: SinkClass::BashExec,
-        source_labels,
-        artifact_label,
-        subject: subject.to_string(),
-        estimated_cost_micro_usd: 0,
-        // Honest no-escalation: request exactly what the policy grants for the op.
-        capability_ceiling: Some(run_bash_ceiling),
-        requested_capability: Some(run_bash_ceiling),
-        verified_scope: term_scope,
-    };
-
-    preflight_action(&term)
-}
-
-/// Consume a [`DischargedBundle`] into an audit-record string.
-///
-/// Satisfies the bundle's `#[must_use]` by reading it, and threads the sealed
-/// 7-witness proof into the verdict record so it is not dead.
-fn discharge_witness(bundle: &DischargedBundle) -> String {
-    format!("{bundle:?}")
-}
+// The sealed discharge preflight (`preflight_runbash`) and its audit-witness
+// helper (`discharge_witness`) now live in the always-compiled `crate::run_gate`
+// module, so the non-feature-gated HTTP `/v1/run` handler can share them with
+// this feature-gated MCP handler. Re-imported here so the local call sites and
+// the `#[cfg(test)]` module below resolve them unchanged.
+use crate::run_gate::{discharge_witness, preflight_runbash};
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Tests — enforcement boundary coverage (#1295)
@@ -1239,6 +1160,9 @@ fn discharge_witness(bundle: &DischargedBundle) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    // The `preflight_runbash` scope tests build `TokenScope`s directly; its home
+    // crate import is test-only now that the mint helper moved to `run_gate`.
+    use nucleus_provenance_memory::TokenScope;
 
     // ── build_action_term coverage ──────────────────────────────────────
 

--- a/crates/nucleus-tool-proxy/src/run_gate.rs
+++ b/crates/nucleus-tool-proxy/src/run_gate.rs
@@ -1,0 +1,108 @@
+//! Sealed discharge preflight for the RunBash spawn path (#2038 / PR-2).
+//!
+//! Both the MCP `run` handler ([`crate::mcp`], feature-gated) and the HTTP
+//! `/v1/run` handler ([`crate::run_command`], always compiled) must mint a
+//! sealed [`DischargedBundle`] before they may reach `Executor::run_args` — the
+//! executor-proof gate makes an un-preflighted spawn a *compile* error. Because
+//! the MCP module is behind `#[cfg(feature = "mcp")]` but the HTTP path is not,
+//! the shared preflight lives here, in an always-compiled module, so neither
+//! caller depends on the other's feature.
+
+use portcullis::{CapabilityLevel, FlowTracker, Operation};
+
+use nucleus_ifc_kernel::discharge::{
+    self, preflight_action, DischargedBundle, PreflightResult, VerifiedScope,
+};
+use nucleus_ifc_kernel::{IFCLabel, SinkClass};
+use nucleus_provenance_memory::TokenScope;
+
+/// The sealed discharge preflight for the live RunBash path (#2038).
+///
+/// Builds the discharge [`ActionTerm`](discharge::ActionTerm) for
+/// `RunBash`/`BashExec` and runs [`preflight_action`]. Returning
+/// [`PreflightResult::Allowed`] hands back a [`DischargedBundle`] — the sealed
+/// 7-witness proof that the operation is authorized. There is no other way to
+/// construct that bundle, so a caller that reaches `run_args` only past an
+/// `Allowed` arm is a compile-time-checked precondition.
+///
+/// Fail-closed / no-vacuous-witness:
+/// - `verified_scope == None` (session token `Missing`/`Invalid`) ⇒
+///   `InScopeWithTask` DENIES. We pass `None` straight through — never a
+///   permissive default.
+/// - `RunBash ∉ scope.allowed_operations` ⇒ `InScopeWithTask` DENIES.
+///
+/// HONESTY (what actually bites, #2038): for the `BashExec` sink the five
+/// original discharge obligations are structurally satisfied by the honest
+/// inputs below and do not add enforcement here:
+/// - IntegrityGate: `sink_min_integrity(BashExec)` is `Adversarial` (the floor),
+///   so any integrity passes;
+/// - PathAllowed: the fixed `RunBash`/`BashExec` pair is always structurally OK;
+/// - DerivationClear: `BashExec` is not a verified-lane sink, so it is skipped;
+/// - NoAdversarialAncestry: passes whenever the session carries no
+///   adversarial-integrity source label (with an empty [`FlowTracker`], vacuous);
+/// - BudgetNotExceeded: cost is 0 (no cost estimator wired, #1362);
+/// - WithinDelegationCeiling: `requested == ceiling == level_for(RunBash)`, the
+///   runtime's honest no-escalation claim, so `requested ≤ ceiling` holds by
+///   construction (sound-but-dormant, mirrors `build_term_scoped`).
+///
+/// So the real added enforcement of this brick is **`InScopeWithTask`** (gated by
+/// the verified session task token) plus the fail-closed ceiling. The IFC labels
+/// ARE fed honestly from the session's real [`FlowTracker`] (not `default()`), so
+/// `NoAdversarialAncestry`/`IntegrityGate` bite for real once web/adversarial
+/// content is in the session — they are simply vacuous on a clean session.
+pub(crate) fn preflight_runbash(
+    verified_scope: Option<&TokenScope>,
+    run_bash_ceiling: CapabilityLevel,
+    subject: &str,
+    flow: &FlowTracker,
+) -> PreflightResult {
+    // Real source labels from the session flow tracker (#1633 taint state) —
+    // NOT fabricated defaults. Mirrors `build_term_scoped` in portcullis-effects.
+    let mut source_labels = Vec::new();
+    for node_id in 1..=flow.node_count() as u64 {
+        if let Some(label) = flow.label(node_id) {
+            source_labels.push(*label);
+        }
+    }
+    // Artifact label: join of all source labels (most restrictive composite); an
+    // empty (clean) session yields the default label.
+    let artifact_label = if source_labels.is_empty() {
+        IFCLabel::default()
+    } else {
+        source_labels
+            .iter()
+            .skip(1)
+            .fold(source_labels[0], |acc, l| acc.join(*l))
+    };
+
+    // Convert the verified `TokenScope` into the kernel's local `VerifiedScope`
+    // carrier field-for-field (the kernel is dependency-free and cannot name
+    // `TokenScope`). `None` ⇒ `InScopeWithTask` denied fail-closed.
+    let term_scope = verified_scope.map(|s| VerifiedScope {
+        allowed_operations: s.allowed_operations.clone(),
+        allowed_paths: s.allowed_paths.clone(),
+    });
+
+    let term = discharge::ActionTerm {
+        operation: Operation::RunBash,
+        sink_class: SinkClass::BashExec,
+        source_labels,
+        artifact_label,
+        subject: subject.to_string(),
+        estimated_cost_micro_usd: 0,
+        // Honest no-escalation: request exactly what the policy grants for the op.
+        capability_ceiling: Some(run_bash_ceiling),
+        requested_capability: Some(run_bash_ceiling),
+        verified_scope: term_scope,
+    };
+
+    preflight_action(&term)
+}
+
+/// Consume a [`DischargedBundle`] into an audit-record string.
+///
+/// Satisfies the bundle's `#[must_use]` by reading it, and threads the sealed
+/// 7-witness proof into the verdict record so it is not dead.
+pub(crate) fn discharge_witness(bundle: &DischargedBundle) -> String {
+    format!("{bundle:?}")
+}

--- a/crates/nucleus/Cargo.toml
+++ b/crates/nucleus/Cargo.toml
@@ -20,6 +20,13 @@ async = ["tokio"]
 nucleus-provenance = { path = "../nucleus-provenance" }
 # Policy layer - the quotient lattice
 portcullis = { path = "../portcullis" }
+# Sealed discharge proof: the `DischargedBundle` type is named in the Executor
+# spawn signature (`spawn_checked`/`run`/`run_args`/…) so no synchronous spawn can
+# compile without a minted preflight bundle. Additive — discharge is already
+# trusted (defined in this crate, re-exported through portcullis-core → portcullis,
+# hence already a transitive dependency; it is dependency-free so no cycle). This
+# adds no new TCB, only names the existing proof type.
+nucleus-ifc-kernel = { path = "../nucleus-ifc-kernel", version = "1.0.0" }
 
 # Atomic budget tracking
 parking_lot = "0.12"

--- a/crates/nucleus/src/command.rs
+++ b/crates/nucleus/src/command.rs
@@ -18,6 +18,7 @@ use crate::budget::AtomicBudget;
 use crate::error::{NucleusError, Result};
 use crate::sandbox::Sandbox;
 use crate::time::MonotonicGuard;
+use nucleus_ifc_kernel::discharge::DischargedBundle;
 use portcullis::kernel::DecisionToken;
 use portcullis::{
     CapabilityLattice, CapabilityLevel, CommandLattice, IsolationLattice, Obligations, Operation,
@@ -317,16 +318,21 @@ impl<'a> Executor<'a> {
     ///   close it with `Stdio::null()`.
     ///
     /// This is deliberately the *only* `Command::new` on the synchronous paths.
-    /// Keeping all three public methods routed through this one function means
-    /// PR-2 can add a `_proof: &DischargedBundle` as the final parameter here to
-    /// type-enforce that no synchronous spawn occurs without a discharged bundle,
-    /// with minimal churn at the call sites.
+    /// Keeping all three public methods routed through this one function lets the
+    /// executor-proof gate require a `_proof: &DischargedBundle` as the final
+    /// parameter here (and on every public method that reaches it): a synchronous
+    /// spawn cannot even be *named* without a discharged bundle in hand, so an
+    /// un-preflighted spawn is a compile error rather than a runtime check. The
+    /// proof is a sealed 7-witness bundle that only `preflight_action` can mint;
+    /// it is required by type but otherwise unused here (`_proof`) — its presence
+    /// in the signature is the enforcement.
     fn spawn_checked(
         &self,
         program: &str,
         args: &[String],
         cwd: &std::path::Path,
         stdin_data: Option<&str>,
+        _proof: &DischargedBundle,
     ) -> io::Result<Output> {
         let mut cmd = Command::new(program);
         cmd.args(args)
@@ -362,8 +368,15 @@ impl<'a> Executor<'a> {
     /// Execute a command and return its output.
     ///
     /// The command string is parsed, validated against policy, and then executed
-    /// in the sandbox directory. Requires a `DecisionToken` from `Kernel::decide()`.
-    pub fn run(&self, command: &str, decision: &DecisionToken) -> Result<Output> {
+    /// in the sandbox directory. Requires a `DecisionToken` from `Kernel::decide()`
+    /// and a `&DischargedBundle` proof (mint via `preflight_action`) — the
+    /// executor-proof gate: no spawn without a discharged bundle.
+    pub fn run(
+        &self,
+        command: &str,
+        decision: &DecisionToken,
+        proof: &DischargedBundle,
+    ) -> Result<Output> {
         debug_assert_eq!(
             decision.operation(),
             Operation::RunBash,
@@ -407,14 +420,20 @@ impl<'a> Executor<'a> {
         // Build and execute the command
         let (program, program_args) = args.split_first().unwrap();
 
-        let output = self.spawn_checked(program, program_args, self.sandbox.root_path(), None)?;
+        let output =
+            self.spawn_checked(program, program_args, self.sandbox.root_path(), None, proof)?;
 
         Ok(output)
     }
 
     /// Execute a command and return just the exit status.
-    pub fn status(&self, command: &str, decision: &DecisionToken) -> Result<ExitStatus> {
-        let output = self.run(command, decision)?;
+    pub fn status(
+        &self,
+        command: &str,
+        decision: &DecisionToken,
+        proof: &DischargedBundle,
+    ) -> Result<ExitStatus> {
+        let output = self.run(command, decision, proof)?;
         Ok(output.status)
     }
 
@@ -422,19 +441,37 @@ impl<'a> Executor<'a> {
     ///
     /// This is the preferred method for MCP tool calls as it prevents shell injection
     /// by bypassing shell interpretation entirely.
+    ///
+    /// Requires a `&DischargedBundle` proof (mint via `preflight_action`). This is
+    /// the executor-proof gate: an un-preflighted spawn is a *compile* error, not a
+    /// runtime check. The following omits the proof and does **not** compile
+    /// (mirrors the sealed-bundle `compile_fail` doctest in
+    /// `nucleus_ifc_kernel::discharge`):
+    ///
+    /// ```compile_fail
+    /// use nucleus::Executor;
+    /// use nucleus::portcullis::kernel::DecisionToken;
+    ///
+    /// fn un_preflighted_spawn(executor: &Executor, args: &[String], dt: &DecisionToken) {
+    ///     // No trailing `&DischargedBundle` — the sealed proof is missing, so
+    ///     // this call cannot be typed. There is no way to spawn without one.
+    ///     let _ = executor.run_args(args, None, None, dt);
+    /// }
+    /// ```
     pub fn run_args(
         &self,
         args: &[String],
         stdin: Option<&str>,
         directory: Option<&str>,
         decision: &DecisionToken,
+        proof: &DischargedBundle,
     ) -> Result<Output> {
         debug_assert_eq!(
             decision.operation(),
             Operation::RunBash,
             "DecisionToken operation mismatch"
         );
-        self.run_args_internal(args, stdin, directory, None)
+        self.run_args_internal(args, stdin, directory, None, proof)
     }
 
     /// Execute a pre-parsed command array with an approval token.
@@ -445,13 +482,14 @@ impl<'a> Executor<'a> {
         directory: Option<&str>,
         decision: &DecisionToken,
         approval: &ApprovalToken,
+        proof: &DischargedBundle,
     ) -> Result<Output> {
         debug_assert_eq!(
             decision.operation(),
             Operation::RunBash,
             "DecisionToken operation mismatch"
         );
-        self.run_args_internal(args, stdin, directory, Some(approval))
+        self.run_args_internal(args, stdin, directory, Some(approval), proof)
     }
 
     /// Internal implementation for array-based command execution.
@@ -461,6 +499,7 @@ impl<'a> Executor<'a> {
         stdin_data: Option<&str>,
         directory: Option<&str>,
         approval: Option<&ApprovalToken>,
+        proof: &DischargedBundle,
     ) -> Result<Output> {
         // Fail-closed isolation gate (most-paranoid #2).
         self.enforce_isolation()?;
@@ -525,7 +564,7 @@ impl<'a> Executor<'a> {
             self.sandbox.root_path().to_path_buf()
         };
 
-        self.spawn_checked(program, program_args, &work_dir, stdin_data)
+        self.spawn_checked(program, program_args, &work_dir, stdin_data, proof)
             .map_err(Into::into)
     }
 
@@ -535,6 +574,7 @@ impl<'a> Executor<'a> {
         command: &str,
         decision: &DecisionToken,
         approval: &ApprovalToken,
+        proof: &DischargedBundle,
     ) -> Result<Output> {
         debug_assert_eq!(
             decision.operation(),
@@ -578,7 +618,8 @@ impl<'a> Executor<'a> {
         // Build and execute the command
         let (program, program_args) = args.split_first().unwrap();
 
-        let output = self.spawn_checked(program, program_args, self.sandbox.root_path(), None)?;
+        let output =
+            self.spawn_checked(program, program_args, self.sandbox.root_path(), None, proof)?;
 
         Ok(output)
     }
@@ -817,6 +858,10 @@ mod tests {
     use super::*;
     use crate::budget::AtomicBudget;
     use crate::sandbox::Sandbox;
+    // Sanctioned cross-crate test-only bundle: runs a real `preflight_action` on a
+    // known-good term. This is the only supported way for out-of-module tests to
+    // obtain a sealed `DischargedBundle` (the constructor is private to discharge).
+    use nucleus_ifc_kernel::discharge::test_helpers::allowed_bundle;
     use portcullis::kernel::Kernel;
     use portcullis::BudgetLattice;
     use rust_decimal::Decimal;
@@ -873,7 +918,7 @@ mod tests {
             .allow_unsandboxed_local();
 
         let dt = run_token(&mut kernel, "echo hello");
-        let output = executor.run("echo hello", &dt).unwrap();
+        let output = executor.run("echo hello", &dt, &allowed_bundle()).unwrap();
         assert!(output.status.success());
         assert!(String::from_utf8_lossy(&output.stdout).contains("hello"));
     }
@@ -893,7 +938,7 @@ mod tests {
             .allow_unsandboxed_local();
 
         let dt = run_token(&mut kernel, "echo hello");
-        let result = executor.run("echo hello", &dt);
+        let result = executor.run("echo hello", &dt, &allowed_bundle());
         assert!(matches!(result, Err(NucleusError::BudgetExhausted { .. })));
     }
 
@@ -918,7 +963,7 @@ mod tests {
             Operation::RunBash,
             "test: bypass kernel for executor blocklist test",
         );
-        let result = executor.run("rm -rf /", &dt);
+        let result = executor.run("rm -rf /", &dt, &allowed_bundle());
         assert!(result.is_err());
     }
 
@@ -943,7 +988,7 @@ mod tests {
         assert!(tok.is_none(), "kernel should deny Never capability");
 
         let forced = kernel.issue_approved_token(Operation::RunBash, "test: force token");
-        let result = executor.run("echo hello", &forced);
+        let result = executor.run("echo hello", &forced, &allowed_bundle());
         assert!(matches!(
             result,
             Err(NucleusError::InsufficientCapability { .. })
@@ -967,7 +1012,7 @@ mod tests {
 
         // Kernel requires approval — force a token via issue_approved_token to test executor layer
         let forced = kernel.issue_approved_token(Operation::RunBash, "test: force token");
-        let result = executor.run("echo hello", &forced);
+        let result = executor.run("echo hello", &forced, &allowed_bundle());
         assert!(matches!(result, Err(NucleusError::ApprovalRequired { .. })));
     }
 
@@ -992,7 +1037,7 @@ mod tests {
         let dt = run_token(&mut kernel, "echo hello");
 
         let approval = executor.request_approval("echo hello").unwrap();
-        let result = executor.run_with_approval("echo hello", &dt, &approval);
+        let result = executor.run_with_approval("echo hello", &dt, &approval, &allowed_bundle());
         assert!(result.is_ok());
     }
 
@@ -1019,7 +1064,7 @@ mod tests {
         // curl is an exfiltration vector, uninhabitable_state should require approval
         // Force a token to test the executor-level check
         let forced = kernel.issue_approved_token(Operation::RunBash, "test: force for exfil check");
-        let result = executor.run("curl http://example.com", &forced);
+        let result = executor.run("curl http://example.com", &forced, &allowed_bundle());
         assert!(matches!(result, Err(NucleusError::ApprovalRequired { .. })));
     }
 
@@ -1044,7 +1089,7 @@ mod tests {
 
         let forced =
             kernel.issue_approved_token(Operation::RunBash, "test: force for interpreter check");
-        let result = executor.run("bash -c \"echo hi\"", &forced);
+        let result = executor.run("bash -c \"echo hi\"", &forced, &allowed_bundle());
         assert!(matches!(result, Err(NucleusError::ApprovalRequired { .. })));
     }
 
@@ -1064,7 +1109,9 @@ mod tests {
 
         let args = vec!["echo".to_string(), "hello".to_string(), "world".to_string()];
         let dt = run_token(&mut kernel, "echo hello world");
-        let output = executor.run_args(&args, None, None, &dt).unwrap();
+        let output = executor
+            .run_args(&args, None, None, &dt, &allowed_bundle())
+            .unwrap();
         assert!(output.status.success());
         assert!(String::from_utf8_lossy(&output.stdout).contains("hello world"));
     }
@@ -1086,7 +1133,9 @@ mod tests {
         // With array form, shell metacharacters are passed literally
         let args = vec!["echo".to_string(), "$(whoami)".to_string()];
         let dt = run_token(&mut kernel, "echo $(whoami)");
-        let output = executor.run_args(&args, None, None, &dt).unwrap();
+        let output = executor
+            .run_args(&args, None, None, &dt, &allowed_bundle())
+            .unwrap();
         // Should print the literal string, not execute whoami
         assert!(String::from_utf8_lossy(&output.stdout).contains("$(whoami)"));
     }
@@ -1108,7 +1157,13 @@ mod tests {
         let args = vec!["cat".to_string()];
         let dt = run_token(&mut kernel, "cat");
         let output = executor
-            .run_args(&args, Some("hello from stdin"), None, &dt)
+            .run_args(
+                &args,
+                Some("hello from stdin"),
+                None,
+                &dt,
+                &allowed_bundle(),
+            )
             .unwrap();
         assert!(output.status.success());
         assert!(String::from_utf8_lossy(&output.stdout).contains("hello from stdin"));
@@ -1131,7 +1186,7 @@ mod tests {
         let args: Vec<String> = vec![];
         // Kernel also blocks empty commands, so force a token to test executor layer
         let dt = kernel.issue_approved_token(Operation::RunBash, "test: empty command");
-        let result = executor.run_args(&args, None, None, &dt);
+        let result = executor.run_args(&args, None, None, &dt, &allowed_bundle());
         assert!(matches!(result, Err(NucleusError::CommandDenied { .. })));
     }
 
@@ -1152,7 +1207,7 @@ mod tests {
         let args = vec!["pwd".to_string()];
         let dt = run_token(&mut kernel, "pwd");
         // Attempt to escape sandbox using absolute path
-        let result = executor.run_args(&args, None, Some("/etc"), &dt);
+        let result = executor.run_args(&args, None, Some("/etc"), &dt, &allowed_bundle());
         assert!(matches!(result, Err(NucleusError::SandboxEscape { .. })));
     }
 
@@ -1175,7 +1230,9 @@ mod tests {
 
         // Try to access the parent env var - should NOT be visible
         let dt = run_token(&mut kernel, "printenv TEST_PARENT_SECRET");
-        let output = executor.run("printenv TEST_PARENT_SECRET", &dt).unwrap();
+        let output = executor
+            .run("printenv TEST_PARENT_SECRET", &dt, &allowed_bundle())
+            .unwrap();
 
         // Command should succeed but output should be empty (var not found)
         // printenv returns exit code 1 when var is not found
@@ -1204,7 +1261,9 @@ mod tests {
 
         // The allowed var should be visible
         let dt = run_token(&mut kernel, "printenv ALLOWED_TOKEN");
-        let output = executor.run("printenv ALLOWED_TOKEN", &dt).unwrap();
+        let output = executor
+            .run("printenv ALLOWED_TOKEN", &dt, &allowed_bundle())
+            .unwrap();
         assert!(output.status.success());
         assert!(String::from_utf8_lossy(&output.stdout).contains("test-value-123"));
     }
@@ -1231,12 +1290,16 @@ mod tests {
 
         // Both vars should be visible
         let dt_a = run_token(&mut kernel, "printenv VAR_A");
-        let output_a = executor.run("printenv VAR_A", &dt_a).unwrap();
+        let output_a = executor
+            .run("printenv VAR_A", &dt_a, &allowed_bundle())
+            .unwrap();
         assert!(output_a.status.success());
         assert!(String::from_utf8_lossy(&output_a.stdout).contains("value_a"));
 
         let dt_b = run_token(&mut kernel, "printenv VAR_B");
-        let output_b = executor.run("printenv VAR_B", &dt_b).unwrap();
+        let output_b = executor
+            .run("printenv VAR_B", &dt_b, &allowed_bundle())
+            .unwrap();
         assert!(output_b.status.success());
         assert!(String::from_utf8_lossy(&output_b.stdout).contains("value_b"));
     }
@@ -1262,7 +1325,9 @@ mod tests {
         // Parent env should not be visible
         let args = vec!["printenv".to_string(), "TEST_RUN_ARGS_SECRET".to_string()];
         let dt1 = run_token(&mut kernel, "printenv TEST_RUN_ARGS_SECRET");
-        let output = executor.run_args(&args, None, None, &dt1).unwrap();
+        let output = executor
+            .run_args(&args, None, None, &dt1, &allowed_bundle())
+            .unwrap();
         assert!(
             !output.status.success(),
             "parent env should not be accessible"
@@ -1271,7 +1336,9 @@ mod tests {
         // But allowed env should be visible
         let args = vec!["printenv".to_string(), "ALLOWED_VAR".to_string()];
         let dt2 = run_token(&mut kernel, "printenv ALLOWED_VAR");
-        let output = executor.run_args(&args, None, None, &dt2).unwrap();
+        let output = executor
+            .run_args(&args, None, None, &dt2, &allowed_bundle())
+            .unwrap();
         assert!(output.status.success());
         assert!(String::from_utf8_lossy(&output.stdout).contains("allowed-value"));
 
@@ -1299,7 +1366,7 @@ mod tests {
             let executor = Executor::new(&policy, &sandbox, &budget).with_time_guard(&guard);
 
             let dt = run_token(&mut kernel, "echo hi");
-            let err = executor.run("echo hi", &dt).unwrap_err();
+            let err = executor.run("echo hi", &dt, &allowed_bundle()).unwrap_err();
             assert!(
                 matches!(err, NucleusError::IsolationNotConfigured),
                 "expected IsolationNotConfigured, got {err:?}"
@@ -1319,7 +1386,9 @@ mod tests {
 
             let args = vec!["echo".to_string(), "hi".to_string()];
             let dt = run_token(&mut kernel, "echo hi");
-            let err = executor.run_args(&args, None, None, &dt).unwrap_err();
+            let err = executor
+                .run_args(&args, None, None, &dt, &allowed_bundle())
+                .unwrap_err();
             assert!(
                 matches!(err, NucleusError::IsolationNotConfigured),
                 "got {err:?}"
@@ -1341,7 +1410,7 @@ mod tests {
                 .allow_unsandboxed_local();
 
             let dt = run_token(&mut kernel, "echo hi");
-            let output = executor.run("echo hi", &dt).unwrap();
+            let output = executor.run("echo hi", &dt, &allowed_bundle()).unwrap();
             assert!(output.status.success());
         }
 
@@ -1364,7 +1433,7 @@ mod tests {
                 .allow_unsandboxed_local();
 
             let dt = run_token(&mut kernel, "echo hi");
-            let err = executor.run("echo hi", &dt).unwrap_err();
+            let err = executor.run("echo hi", &dt, &allowed_bundle()).unwrap_err();
             assert!(
                 matches!(err, NucleusError::IsolationInsufficient { .. }),
                 "expected IsolationInsufficient, got {err:?}"
@@ -1386,7 +1455,7 @@ mod tests {
                 .in_microvm();
 
             let dt = run_token(&mut kernel, "echo hi");
-            let output = executor.run("echo hi", &dt).unwrap();
+            let output = executor.run("echo hi", &dt, &allowed_bundle()).unwrap();
             assert!(output.status.success());
         }
 
@@ -1407,7 +1476,7 @@ mod tests {
                 .with_host_hardening();
 
             let dt = run_token(&mut kernel, "echo hi");
-            let err = executor.run("echo hi", &dt).unwrap_err();
+            let err = executor.run("echo hi", &dt, &allowed_bundle()).unwrap_err();
             assert!(
                 matches!(err, NucleusError::HardeningUnavailable { .. }),
                 "expected HardeningUnavailable off-Linux, got {err:?}"
@@ -1431,7 +1500,9 @@ mod tests {
                 .with_host_hardening();
 
             let dt = run_token(&mut kernel, "cat /proc/self/status");
-            let output = executor.run("cat /proc/self/status", &dt).unwrap();
+            let output = executor
+                .run("cat /proc/self/status", &dt, &allowed_bundle())
+                .unwrap();
             let status = String::from_utf8_lossy(&output.stdout);
             assert!(
                 status

--- a/scripts/mediation-allowlist.txt
+++ b/scripts/mediation-allowlist.txt
@@ -7,11 +7,18 @@
 #
 # Format: exact TRIMMED source line (leading/trailing whitespace removed).
 #
-# nucleus::Executor synchronous spawn (command.rs :351, :451, :561)
-#   -> migrate behind ShellEffect / production_effects(policy)
+# nucleus::Executor SEALED synchronous spawn home (command.rs :337, in
+# `Executor::spawn_checked`). This is the single sync `Command::new` choke point
+# and it is now gated by a required `_proof: &DischargedBundle` final parameter:
+# every path that reaches it (`run` / `run_args` / `run_with_approval` and the
+# internal hops) must thread a sealed bundle that ONLY `preflight_action` can
+# mint, so this line is reachable only PAST a minted discharge bundle — an
+# un-preflighted spawn is a compile error, not a runtime check. RETAINED (not
+# deleted): the raw spawn still lives here in gate scope; deleting the entry needs
+# the later ShellEffect-relocation brick that moves the spawn behind the effect API.
 let mut cmd = Command::new(program);
 #
-# nucleus::Executor async spawn (command.rs :627, :700)
+# nucleus::Executor async spawn (command.rs :677, :750)
 #   -> migrate behind ShellEffect / production_effects(policy)
 let mut cmd = tokio::process::Command::new(program);
 #


### PR DESCRIPTION
**The North Star's distinctive property, made real: an un-preflighted Executor spawn is now a COMPILE ERROR.** PR-2 of 2 (PR-1 #2039 landed the `spawn_checked` choke point). Threads `_proof: &DischargedBundle` through `spawn_checked` and the public spawn methods (`run`, `run_args`, `run_with_approval`, `run_args_internal`), so reaching the raw spawn is impossible without a sealed bundle minted by `preflight_action`. Converts the #2038 handler-precondition into a type-level guarantee.

**Dep:** `nucleus → nucleus-ifc-kernel` (the crate defining `DischargedBundle`; already transitive via `portcullis → portcullis-core`, dependency-free, no cycle, no new TCB).

**The compile-fail guard** (`command.rs` doctest): a call to `run_args` without a trailing `&DischargedBundle` fails to compile (E0061). This *is* the "unmediated spawn is unconstructable" property, pinned as a test.

**Type-enforcement earned its keep immediately — it surfaced a SECOND un-mediated live spawn.** The HTTP `POST /v1/run` handler (`main.rs::run_command`) was calling `run_args` with no bundle — a live spawn path #2038's handler-level gate never touched. It wouldn't compile, so it is now mediated by the *same* `preflight_runbash` (relocated to a new always-compiled `run_gate.rs` shared by the mcp and http paths — no re-mint, one preflight per request). Fail-closed: a Missing/Invalid session token → `verified_scope: None` → `InScopeWithTask` denies → `ApiError::IfcDenied` (403), never a permissive default. This is a behavior change to `/v1/run` (now requires a verified session token, same as the MCP path) — the correct security outcome; the path had no dedicated tests.

**mcp bundle-flow:** the #2038 `Allowed(bundle)` arm now returns the bundle (not just the audit witness); it's passed as `&bundle` to `run_args` inside the `execute_and_record` closure (that signature unchanged). Deny/RequiresApproval still return before any spawn.

**Test callers:** all 26 in-crate `command.rs` callers construct a real bundle via `nucleus_ifc_kernel::discharge::test_helpers::allowed_bundle()` (pub `#[doc(hidden)]`, runs a real `preflight_action`) — no forged bundle, assertions unchanged.

**Allowlist:** the raw `Command::new` stays in `spawn_checked` (in gate scope) → its allowlist entry is **retained and reworded** as the sealed `_proof`-gated Executor spawn home (reachable only past a minted bundle). Not deleted — deletion awaits the later ShellEffect-relocation brick.

**Green:** `cargo test -p nucleus` 48 + compile-fail doctest; `-p nucleus-tool-proxy` 193 (mcp + default), incl. the #2038 gate tests and command.rs argv/stdin/cwd/env-isolation/timeout tests. `fmt`/`clippy -p nucleus -p nucleus-tool-proxy -D warnings`/verify-strict/mediation all clean.

**Disclosed:** the async `run_with_timeout*` (its own `tokio::process::Command`, zero callers) remains a separate future brick; dual-stack (sealed bundle alongside kernel/guard) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CNJdZb7LHWwXkrt9MCa8CG
