### PR TITLE
feat(ifc-kernel): optional content hash on FlowTracker nodes (InputsAuthorized brick 1)

### DIFF
--- a/crates/nucleus-ifc-kernel/src/hash_types.rs
+++ b/crates/nucleus-ifc-kernel/src/hash_types.rs
@@ -1,0 +1,72 @@
+//! Content-address newtype for the IFC kernel (InputsAuthorized, brick 1).
+//!
+//! [`ContentHash`] is a transparent 32-byte SHA-256 wrapper used to tag a
+//! [`crate::ifc_api::FlowTracker`] node with the digest of the bytes it
+//! observed. The newtype (vs a bare `[u8; 32]`) prevents mixing a content
+//! digest up with an unrelated 32-byte value.
+//!
+//! ## Why the kernel defines its own `ContentHash`
+//!
+//! `portcullis-core` also has a `ContentHash` (with a `sha2`-backed
+//! `compute()`), but this kernel crate is the **dependency-free bottom** of the
+//! graph (`portcullis-core` depends on *it*, not the reverse), so it cannot name
+//! that type without a dependency cycle. It also must not pull in `sha2` — its
+//! reason to exist is Aeneas's dependency-free requirement. So the kernel owns a
+//! pure, hashing-free `ContentHash` here: callers that already hold a digest
+//! wrap it with [`ContentHash::from_bytes`]. (A later brick may unify the two by
+//! re-exporting this type from `portcullis-core`, the established layering
+//! pattern for kernel types — out of scope for this additive change.)
+
+/// SHA-256 content address of the bytes a flow node observed.
+///
+/// Transparent `[u8; 32]` newtype — zero runtime cost. The kernel never hashes
+/// (it stays `sha2`-free); construct one from an already-computed digest with
+/// [`Self::from_bytes`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ContentHash([u8; 32]);
+
+impl ContentHash {
+    /// Wrap an already-computed 32-byte digest.
+    pub const fn from_bytes(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+
+    /// Borrow the raw 32-byte digest.
+    pub const fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+impl From<[u8; 32]> for ContentHash {
+    fn from(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+}
+
+impl From<ContentHash> for [u8; 32] {
+    fn from(h: ContentHash) -> Self {
+        h.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_bytes_round_trips() {
+        let bytes = [7u8; 32];
+        let h = ContentHash::from_bytes(bytes);
+        assert_eq!(h.as_bytes(), &bytes);
+        let back: [u8; 32] = h.into();
+        assert_eq!(back, bytes);
+    }
+
+    #[test]
+    fn distinct_digests_are_unequal() {
+        assert_ne!(
+            ContentHash::from_bytes([1u8; 32]),
+            ContentHash::from_bytes([2u8; 32])
+        );
+    }
+}

--- a/crates/nucleus-ifc-kernel/src/ifc_api.rs
+++ b/crates/nucleus-ifc-kernel/src/ifc_api.rs
@@ -16,7 +16,7 @@
 //! ```
 
 use crate::flow::{NodeKind, intrinsic_label};
-use crate::{AuthorityLevel, ConfLevel, DerivationClass, IFCLabel, IntegLevel};
+use crate::{AuthorityLevel, ConfLevel, ContentHash, DerivationClass, IFCLabel, IntegLevel};
 
 /// Unix seconds, wasm-safe. `wasm32-unknown-unknown` has no clock, so it returns
 /// 0 there; this only feeds the label's freshness metadata (not the
@@ -108,8 +108,15 @@ impl SessionCleanseToken {
 /// [`check_action_safety_with_ceiling`] if the session has previously observed
 /// `OpaqueExternal` content through *any* path.
 pub struct FlowTracker {
-    /// Node storage: (kind, label, parents).
-    nodes: Vec<(NodeKind, IFCLabel, Vec<u64>)>,
+    /// Node storage: (kind, label, parents, content_hash).
+    ///
+    /// The 4th element is the optional [`ContentHash`] of the bytes this node
+    /// observed (InputsAuthorized brick 1). It is `None` for every node created
+    /// via [`observe`](Self::observe)/[`observe_with_parents`](Self::observe_with_parents)/[`observe_with_label`](Self::observe_with_label);
+    /// only [`observe_with_content_hash`](Self::observe_with_content_hash) sets
+    /// it. Purely additive — nothing in the kernel reads it yet, so it does not
+    /// affect any label, ceiling, or safety decision.
+    nodes: Vec<(NodeKind, IFCLabel, Vec<u64>, Option<ContentHash>)>,
     next_id: u64,
     /// Monotonically non-decreasing session-level taint ceiling.
     ///
@@ -302,7 +309,7 @@ impl FlowTracker {
         let label = parents
             .iter()
             .fold(label, |acc, &pid| match self.node_entry(pid) {
-                Some((_, parent_label, _)) => acc.join(*parent_label),
+                Some((_, parent_label, _, _)) => acc.join(*parent_label),
                 None => acc,
             });
 
@@ -316,7 +323,8 @@ impl FlowTracker {
         if label.confidentiality > self.session_conf_ceiling {
             self.session_conf_ceiling = label.confidentiality;
         }
-        self.nodes.push((kind, label, parents.to_vec()));
+        // Brick 1: caller-labelled observations carry no content hash.
+        self.nodes.push((kind, label, parents.to_vec(), None));
         Ok(id)
     }
 
@@ -328,6 +336,38 @@ impl FlowTracker {
         &mut self,
         kind: NodeKind,
         parents: &[u64],
+    ) -> Result<u64, FlowError> {
+        // Existing behavior unchanged: no content hash attached.
+        self.observe_with_parents_and_hash(kind, parents, None)
+    }
+
+    /// Observe a new data source, tagging it with the [`ContentHash`] of the
+    /// bytes it carried (InputsAuthorized brick 1).
+    ///
+    /// Identical to [`observe`](Self::observe) — a parent-less ingest whose
+    /// label is `intrinsic_label(kind)` — except the node also records
+    /// `Some(hash)`, retrievable via [`content_hash`](Self::content_hash).
+    ///
+    /// Purely additive: the hash is stored, not consulted. Session ceilings and
+    /// the label are computed exactly as for [`observe`](Self::observe), so the
+    /// flow/safety verdict is unchanged by supplying a hash.
+    pub fn observe_with_content_hash(
+        &mut self,
+        kind: NodeKind,
+        hash: ContentHash,
+    ) -> Result<u64, FlowError> {
+        self.observe_with_parents_and_hash(kind, &[], Some(hash))
+    }
+
+    /// Shared implementation of [`observe_with_parents`](Self::observe_with_parents)
+    /// and [`observe_with_content_hash`](Self::observe_with_content_hash): the
+    /// intrinsic-label parent fold, ceiling ratchet, and node push, threading an
+    /// optional content hash into node storage. Existing callers pass `None`.
+    fn observe_with_parents_and_hash(
+        &mut self,
+        kind: NodeKind,
+        parents: &[u64],
+        content_hash: Option<ContentHash>,
     ) -> Result<u64, FlowError> {
         if parents.len() > 8 {
             return Err(FlowError::TooManyParents(parents.len()));
@@ -341,7 +381,7 @@ impl FlowTracker {
         // DeterministicBind invariant (#1230): parents must be non-AI nodes.
         if kind == NodeKind::DeterministicBind {
             for &pid in parents {
-                if let Some((parent_kind, _, _)) = self.node_entry(pid)
+                if let Some((parent_kind, _, _, _)) = self.node_entry(pid)
                     && parent_kind.is_ai_derived()
                 {
                     return Err(FlowError::NonDeterministicParent {
@@ -366,7 +406,7 @@ impl FlowTracker {
             .iter()
             .fold(intrinsic_label(kind, now), |acc, &pid| {
                 match self.node_entry(pid) {
-                    Some((_, parent_label, _)) => acc.join(*parent_label),
+                    Some((_, parent_label, _, _)) => acc.join(*parent_label),
                     None => acc,
                 }
             });
@@ -382,7 +422,8 @@ impl FlowTracker {
         if label.confidentiality > self.session_conf_ceiling {
             self.session_conf_ceiling = label.confidentiality;
         }
-        self.nodes.push((kind, label, parents.to_vec()));
+        self.nodes
+            .push((kind, label, parents.to_vec(), content_hash));
         Ok(id)
     }
 
@@ -390,14 +431,28 @@ impl FlowTracker {
     ///
     /// Returns `None` for unknown or sentinel (0) IDs without panicking (#1203).
     pub fn label(&self, node_id: u64) -> Option<&IFCLabel> {
-        self.node_entry(node_id).map(|(_, l, _)| l)
+        self.node_entry(node_id).map(|(_, l, _, _)| l)
+    }
+
+    /// Get the [`ContentHash`] recorded for a node, if one was supplied via
+    /// [`observe_with_content_hash`](Self::observe_with_content_hash)
+    /// (InputsAuthorized brick 1).
+    ///
+    /// Returns `None` for a node observed without a hash, and `None` for an
+    /// unknown or sentinel (0) ID — the same not-found convention as
+    /// [`label`](Self::label). Read-only; does not affect any flow decision.
+    pub fn content_hash(&self, node_id: u64) -> Option<ContentHash> {
+        self.node_entry(node_id).and_then(|(_, _, _, h)| *h)
     }
 
     /// Internal helper: look up a node entry by ID, guarding the sentinel.
     ///
     /// Node IDs are 1-based; ID 0 is reserved as a sentinel and must not be
     /// used in arithmetic without first checking for zero (#1203).
-    fn node_entry(&self, node_id: u64) -> Option<&(NodeKind, IFCLabel, Vec<u64>)> {
+    fn node_entry(
+        &self,
+        node_id: u64,
+    ) -> Option<&(NodeKind, IFCLabel, Vec<u64>, Option<ContentHash>)> {
         // Use try_from to avoid silent truncation on 32-bit targets (#1212).
         let idx = usize::try_from(node_id.checked_sub(1)?).ok()?;
         self.nodes.get(idx)
@@ -419,7 +474,7 @@ impl FlowTracker {
     /// assert!(tracker.check_action_safety(plan, true).is_denied());
     /// ```
     pub fn check_action_safety(&self, node_id: u64, requires_authority: bool) -> SafetyCheck {
-        let Some((_, label, _)) = self.node_entry(node_id) else {
+        let Some((_, label, _, _)) = self.node_entry(node_id) else {
             // Unknown or sentinel node — fail-closed (#1198, #1203).
             return SafetyCheck::UnknownNode { node_id };
         };
@@ -461,7 +516,7 @@ impl FlowTracker {
                     // Fail closed: unknown or sentinel IDs are unsafe (#1180, #1203).
                     return SafetyCheck::UnknownNode { node_id: pid };
                 }
-                Some((_, label, _)) => {
+                Some((_, label, _, _)) => {
                     if label.integrity == IntegLevel::Adversarial {
                         return SafetyCheck::AdversarialAncestry { tainted_node: pid };
                     }
@@ -604,7 +659,7 @@ impl FlowTracker {
         node_id: u64,
         sink_max_conf: ConfLevel,
     ) -> SafetyCheck {
-        let Some((_, label, _)) = self.node_entry(node_id) else {
+        let Some((_, label, _, _)) = self.node_entry(node_id) else {
             return SafetyCheck::UnknownNode { node_id };
         };
         if label.confidentiality > sink_max_conf {
@@ -716,14 +771,14 @@ impl FlowTracker {
     pub fn is_tainted(&self) -> bool {
         self.nodes
             .iter()
-            .any(|(_, l, _)| l.integrity == IntegLevel::Adversarial)
+            .any(|(_, l, _, _)| l.integrity == IntegLevel::Adversarial)
     }
 
     /// Check if any node has AI-derived derivation.
     pub fn has_ai_derived(&self) -> bool {
         self.nodes
             .iter()
-            .any(|(_, l, _)| l.derivation == DerivationClass::AIDerived)
+            .any(|(_, l, _, _)| l.derivation == DerivationClass::AIDerived)
     }
 }
 
@@ -747,6 +802,44 @@ mod tests {
         let id = t.observe(NodeKind::FileRead).unwrap();
         assert_eq!(id, 1);
         assert_eq!(t.node_count(), 1);
+    }
+
+    // ── Optional content hash (InputsAuthorized brick 1) ─────────────────
+
+    #[test]
+    fn observe_with_content_hash_round_trips_digest() {
+        let mut t = FlowTracker::new();
+        let digest = ContentHash::from_bytes([0xAB; 32]);
+        let id = t
+            .observe_with_content_hash(NodeKind::FileRead, digest)
+            .unwrap();
+
+        // The digest round-trips via the reader.
+        assert_eq!(t.content_hash(id), Some(digest));
+
+        // Purely additive: the hash does not perturb the node's label/flow — a
+        // hashed FileRead is identical to a plain one apart from the stored hash.
+        let plain = t.observe(NodeKind::FileRead).unwrap();
+        assert_eq!(t.label(id), t.label(plain));
+    }
+
+    #[test]
+    fn plain_observe_has_no_content_hash() {
+        let mut t = FlowTracker::new();
+        let id = t.observe(NodeKind::FileRead).unwrap();
+        assert_eq!(t.content_hash(id), None);
+
+        // The other existing constructors also default the hash to None.
+        let with_parents = t.observe_with_parents(NodeKind::ModelPlan, &[id]).unwrap();
+        assert_eq!(t.content_hash(with_parents), None);
+        let with_label = t
+            .observe_with_label(NodeKind::MemoryRead, *t.label(id).unwrap(), &[])
+            .unwrap();
+        assert_eq!(t.content_hash(with_label), None);
+
+        // Unknown / sentinel IDs report None (same not-found convention as label).
+        assert_eq!(t.content_hash(0), None);
+        assert_eq!(t.content_hash(9999), None);
     }
 
     #[test]

--- a/crates/nucleus-ifc-kernel/src/lib.rs
+++ b/crates/nucleus-ifc-kernel/src/lib.rs
@@ -51,6 +51,10 @@ pub use capability_lattice::*;
 mod exposure;
 pub use exposure::*;
 
+// Content-address newtype for tagging flow nodes (InputsAuthorized brick 1).
+mod hash_types;
+pub use hash_types::ContentHash;
+
 pub mod discharge;
 pub mod effect;
 pub mod extracted;

--- a/crates/nucleus-ifc-kernel/tests/kernel_boundary_ratchet.rs
+++ b/crates/nucleus-ifc-kernel/tests/kernel_boundary_ratchet.rs
@@ -37,6 +37,7 @@ const KERNEL_FILES: &[&str] = &[
     "src/capability_level.rs",
     "src/capability_lattice.rs",
     "src/exposure.rs",
+    "src/hash_types.rs",
     "src/ifc_lattice.rs",
     "src/ifc_ops.rs",
     "src/flow.rs",
@@ -56,6 +57,7 @@ const KERNEL_MODULES: &[&str] = &[
     "capability_level",
     "capability_lattice",
     "exposure",
+    "hash_types",
     "ifc_lattice",
     "ifc_ops",
     "flow",
@@ -81,6 +83,8 @@ const KERNEL_ROOT_PRIMITIVES: &[&str] = &[
     "Freshness",
     "DerivationClass",
     "IFCLabel",
+    // hash_types.rs (InputsAuthorized brick 1)
+    "ContentHash",
     // ifc_ops.rs (M1b)
     "Operation",
     "SinkClass",


### PR DESCRIPTION
Brick 1 of the InputsAuthorized (8/8) project. **Purely additive** — gives a FlowTracker node an optional content hash + the API to set it, so later bricks can content-address agent inputs. Nothing reads the new field yet; no behavior change.

- **`ContentHash` newtype** (new `nucleus-ifc-kernel/src/hash_types.rs`): a transparent, `sha2`-free `[u8;32]` wrapper (`from_bytes`/`as_bytes`, zero logic). Defined **in the kernel**, not reused from `portcullis-core` — because `portcullis-core` *depends on* the kernel (the kernel is the dependency-free bottom of the graph), so naming its `ContentHash` would be a build cycle, and the kernel must stay `sha2`-free (Aeneas). Callers wrap an already-computed digest; the kernel never hashes. Registered in the kernel-boundary ratchet (`KERNEL_MODULES`/`KERNEL_FILES`/`KERNEL_ROOT_PRIMITIVES`) — a deliberate, minimal (zero-logic) expansion of the verified surface.
- **Node shape:** `(NodeKind, IFCLabel, Vec<u64>)` → `(NodeKind, IFCLabel, Vec<u64>, Option<ContentHash>)` (kept a tuple; the ripple was 13 trivial behavior-preserving `, _`/`, None` reader edits — a struct is a fine future refactor if more fields accrue).
- **API:** `observe_with_content_hash(kind, hash)` alongside the existing `observe*` (which default the hash to `None`); reader `content_hash(node_id) -> Option<ContentHash>`.

**Green:** `cargo test -p nucleus-ifc-kernel` 179 pass + boundary ratchet + doctests; `fmt`/`clippy --all-features -D warnings`/verify-strict/mediation clean; downstream `portcullis`/`portcullis-effects` build. New tests: `observe_with_content_hash_round_trips_digest`, `plain_observe_has_no_content_hash`.

**Disclosed:** a `ContentHash` now exists in three places (this kernel one, `portcullis-core`'s test-only one, `nucleus-provenance-memory`'s) — unifying them (re-export the kernel type from portcullis-core, the established layering pattern) is a separate non-additive brick, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CNJdZb7LHWwXkrt9MCa8CG
