### PR TITLE
ci(gate): no-unwitnessed-ingest ratchet — content-address every agent input (InputsAuthorized brick 4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,15 @@ jobs:
       - name: Forbid raw agent-path effect primitives outside the discharge-gated API
         run: scripts/check-mediation.sh
 
+  ingest-hash-gate:
+    name: No-unwitnessed-ingest gate (InputsAuthorized)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+      - name: Forbid non-hashing agent-path ingest observes (content-address every input)
+        run: scripts/check-ingest-hashed.sh
+
   clippy:
     name: Clippy
     runs-on: ubuntu-latest

--- a/scripts/check-ingest-hashed.sh
+++ b/scripts/check-ingest-hashed.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# InputsAuthorized "no-unwitnessed-ingest" gate — RATCHET (brick 4).
+#
+# Brick 3 (#2042) content-addressed every agent-INPUT ingest: each site now
+# records the SHA-256 of the ACTUAL ingested bytes on its FlowTracker node via
+# the hashing variants `observe_with_content_hash` /
+# `observe_with_label_and_content_hash`, or through the ingest chokepoint helpers
+# `observe_flow` / `http_observe_flow` (which hash internally). This gate LOCKS
+# that: it FAILS the build if a NON-hashing FlowTracker observe that could create
+# an un-witnessed INGEST node reappears on the agent path — the structural defeat
+# of the McpToolResult laundering channel (an ingest node with no content hash is
+# a node whose bytes were never witnessed, so a poisoned tool result could be
+# laundered back in un-attested).
+#
+# The gate flags the NON-hashing observe variants — bare `.observe(`,
+# `.observe_with_label(`, `.observe_with_parents(` — in the agent-path scope,
+# UNLESS the exact trimmed snippet is listed in scripts/ingest-hashed-allowlist.txt.
+# The hashing variants (`observe_with_content_hash`,
+# `observe_with_label_and_content_hash`) and the `_with_parents_and_hash` inner
+# helper are NOT matched (the `_content_hash` / `_and_hash` suffix defeats the
+# pattern), so a correctly-hashed ingest never trips.
+#
+# Allowlist = the legitimate NON-INGEST observe sites (F13 classification):
+# OutboundAction egress markers, the portcullis-effects NucleusRuntime observes
+# on the type-level discharge path (where the `Labeled<_,Integrity,Conf>` return
+# type + `DischargedBundle` proof — not the content hash — is the enforcement),
+# ceiling-propagation sentinels, and the kernel operation-causal marker. Each
+# entry carries a comment naming its NodeKind and why it is not an input ingest.
+# The list only shrinks; any NEW un-allowlisted bare ingest observe fails.
+#
+# Scope = the agent ingest path: the MCP tool proxy (the McpToolResult laundering
+# channel this brick locks), the standalone MCP server/guard, and the
+# portcullis-effects runtime where file/web bytes enter the causal DAG.
+# `#[cfg(test)]` blocks and comment lines are stripped.
+#
+# Usage: scripts/check-ingest-hashed.sh
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel 2>/dev/null || echo .)"
+
+ALLOWLIST="scripts/ingest-hashed-allowlist.txt"
+
+# In-scope = the agent ingest path. Every agent-INPUT ingest here MUST record the
+# content hash of the bytes it observed (Brick 3), via a hashing observe variant
+# or an ingest chokepoint helper. portcullis-effects is IN scope for THIS gate
+# (unlike the mediation gate) because the NucleusRuntime is where file/web bytes
+# enter the FlowTracker; its non-ingest observes are allowlisted below.
+SCOPE_DIRS=(crates/nucleus/src crates/nucleus-tool-proxy/src \
+            crates/nucleus-mcp/src crates/nucleus-mcp-guard/src \
+            crates/portcullis-effects/src)
+
+# The NON-hashing observe variants (bare / label / parents). The hashing variants
+# `observe_with_content_hash` and `observe_with_label_and_content_hash`, and the
+# `observe_with_parents_and_hash` inner helper, are NOT matched: their suffix
+# means the required `(` does not immediately follow the captured method name.
+PATTERN='\.observe(_with_label|_with_parents)?[[:space:]]*\('
+
+# Load allowlist: non-empty, non-comment lines are literal TRIMMED code snippets
+# permitted to hold a non-hashing observe (each a justified NON-INGEST site).
+allow_snippets=()
+if [[ -f "$ALLOWLIST" ]]; then
+    while IFS= read -r line; do
+        trimmed="${line#"${line%%[![:space:]]*}"}"
+        trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
+        [[ -z "$trimmed" ]] && continue
+        [[ "$trimmed" == \#* ]] && continue
+        allow_snippets+=("$trimmed")
+    done < "$ALLOWLIST"
+fi
+
+# AWK: emit `path:lineno:code` for each production line (outside any #[cfg(test)]
+# block) that matches the non-hashing observe pattern. Brace-balanced cfg(test)
+# stripping; skip comment lines.
+read -r -d '' AWK_PROG <<'AWK' || true
+BEGIN { skip=0; brace=0; pending=0 }
+{
+    line=$0
+    tmp=line; no=gsub(/\{/,"{",tmp)
+    tmp=line; nc=gsub(/\}/,"}",tmp)
+    if (skip==1) { brace += no - nc; if (brace <= 0) { skip=0; brace=0 } next }
+    if (line ~ /#\[cfg\(test\)\]/) { pending=1; next }
+    if (pending==1) {
+        if (no>0) {                       # block body starts on this line
+            skip=1; brace = no - nc; pending=0
+            if (brace <= 0) { skip=0; brace=0 }
+            next
+        }
+        # cfg(test) on a non-block item (`mod tests;`, `use ...;`): no block to
+        # skip — clear pending so it does not swallow the next braced item
+        # (latent false-NEGATIVE; fix shared with scripts/check-mediation.sh).
+        if (line ~ /;/) { pending=0 }
+    }
+    stripped=line; sub(/^[[:space:]]+/,"",stripped)
+    if (stripped ~ /^\/\//) { next }
+    # Non-hashing observe variant (bare / label / parents), never a hashing one.
+    if (line ~ /\.observe(_with_label|_with_parents)?[[:space:]]*\(/) {
+        printf "%s:%d:%s\n", FILENAME, FNR, line
+    }
+}
+AWK
+
+# Drop test-only sources. As well as the `/(tests|benches)/` integration dirs
+# (mediation-gate convention), exclude src-level whole-file test modules pulled
+# in via `#[cfg(test)] mod ...;` — e.g. `tests_main.rs`, `*_tests.rs` — whose
+# `#[cfg(test)]` lives on the OUTER `mod` line, so the in-file AWK stripper never
+# sees it. Codebase naming convention: `tests_<x>.rs`, `<x>_tests.rs`.
+list_files() {
+    if command -v rg >/dev/null 2>&1; then
+        rg -l --glob '*.rs' -e "$PATTERN" "${SCOPE_DIRS[@]}"
+    else
+        grep -rlE --include='*.rs' "$PATTERN" "${SCOPE_DIRS[@]}"
+    fi | grep -vE '/(tests|benches)/|/tests?_[^/]*\.rs$|_tests?\.rs$' || true
+}
+
+hits=()
+while IFS= read -r f; do
+    [[ -z "$f" ]] && continue
+    while IFS= read -r rec; do
+        [[ -z "$rec" ]] && continue
+        code="${rec#*:*:}"
+        trimmed="${code#"${code%%[![:space:]]*}"}"
+        trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
+        allowed=0
+        if [[ "${#allow_snippets[@]}" -gt 0 ]]; then
+            for snip in "${allow_snippets[@]}"; do
+                [[ "$trimmed" == "$snip" ]] && { allowed=1; break; }
+            done
+        fi
+        [[ "$allowed" -eq 1 ]] && continue
+        hits+=("$rec")
+    done < <(awk "$AWK_PROG" "$f")
+done < <(list_files)
+
+if [[ "${#hits[@]}" -gt 0 ]]; then
+    echo "ingest-hash gate FAILED: non-hashing FlowTracker observe (possible un-witnessed ingest) on the agent path:" >&2
+    printf '  %s\n' "${hits[@]}" >&2
+    echo >&2
+    echo "Fix: content-address the ingested bytes. Record the SHA-256 of the ACTUAL bytes on the node via" >&2
+    echo "observe_with_content_hash / observe_with_label_and_content_hash, or route through the ingest" >&2
+    echo "chokepoint helpers (observe_flow / http_observe_flow, which hash internally)." >&2
+    echo "If this observe is a legitimate NON-INGEST site (it observes no incoming bytes), add the exact" >&2
+    echo "trimmed line to $ALLOWLIST with a comment naming its NodeKind and why it is not an input ingest." >&2
+    exit 1
+fi
+
+echo "ingest-hash gate PASSED: no un-allowlisted non-hashing ingest observe on the agent path."

--- a/scripts/ingest-hashed-allowlist.txt
+++ b/scripts/ingest-hashed-allowlist.txt
@@ -1,0 +1,41 @@
+# InputsAuthorized ingest-hash gate — NON-INGEST observe allowlist (brick 4).
+#
+# Each entry is a NON-hashing FlowTracker/Kernel observe that the gate would
+# otherwise flag, but that is NOT an agent-INPUT ingest — it observes no incoming
+# external bytes, so there is nothing to content-address. (Contrast the ingest
+# sites, which Brick 3 (#2042) moved onto observe_with_content_hash /
+# observe_with_label_and_content_hash / the hashing chokepoints.) F13
+# classification. This list only shrinks; a NEW un-allowlisted bare observe on
+# the agent path fails the build.
+#
+# Format: exact TRIMMED source line (leading/trailing whitespace removed).
+#
+# ── nucleus-mcp: kernel operation-causal marker (main.rs :1021) ──
+# NodeKind = operation_to_node_kind(op) for an operation the Kernel ALREADY
+# admitted via decide_with_parents (Verdict::Allow). This is the Kernel 2-arg
+# observe(kind, &parents) that records the allowed OPERATION in the causal DAG
+# for audit — not an ingest of tool-result/file/web bytes. The standalone
+# MCP-server decision path, not the tool-proxy McpToolResult laundering channel.
+if let Ok(node_id) = kernel.observe(obs_kind, &obs_parents) {
+#
+# ── portcullis-effects NucleusRuntime: type-level discharge path (runtime.rs) ──
+# On this path the enforcement is the compile-time Labeled<T, Integrity, Conf>
+# return type + the DischargedBundle proof, NOT the FlowTracker content hash. The
+# observe records the discharged effect in the causal DAG; the bytes are already
+# provenance-bound by their Labeled<> type at the boundary.
+#
+#   :667 unmediated_effects — OutboundAction: records the unmediated-access GRANT
+#   (an egress/authority marker), not incoming bytes.
+.observe(NodeKind::OutboundAction)
+#   :705 read_file — FileRead: returns Labeled<Vec<u8>, Trusted, Internal>; the
+#   Labeled type carries provenance, the observe marks the discharged read op.
+.observe(NodeKind::FileRead)
+#   :759 fetch_url — WebContent: returns Labeled<Vec<u8>, Adversarial, Public>;
+#   the Labeled type carries the adversarial taint, the observe marks the op.
+.observe(NodeKind::WebContent)
+#
+# ── portcullis-effects: child-ceiling propagation sentinel (runtime.rs :1091) ──
+# WebContent used purely as a SENTINEL to raise a freshly-built child runtime's
+# taint/conf ceilings to the parent's (the FlowTracker API only raises ceilings
+# via observation). No bytes are ingested — it is a ceiling-init, not an input.
+.observe(portcullis_core::flow::NodeKind::WebContent);


### PR DESCRIPTION
Brick 4 of the InputsAuthorized (8/8) project. A CI ratchet gate that **fails the build if an agent-path FlowTracker ingest observe lacks a content hash** — turning "every agent input is content-addressed" (Brick 3) into a build-time invariant, so the `McpToolResult`-style laundering channel can't silently reappear.

**Mirrors the proven mediation gate** (`check-mediation.sh`): snippet-based allowlist, agent-path `SCOPE_DIRS`, and the `#[cfg(test)]`-stripping AWK **including the cfg(test)-on-a-semicolon-item fix** (counter-tested here as load-bearing — with the fix removed, a plant after `#[cfg(test)] mod …;` becomes a false-negative).

**Forbid pattern:** the three NON-hashing observe variants (`.observe(`, `.observe_with_label(`, `.observe_with_parents(`). The hashing variants Brick 3 installed (`observe_with_content_hash` / `observe_with_label_and_content_hash` / `observe_with_parents_and_hash`) don't match (the `_…hash` suffix intervenes before `(`), so the tree is green at floor and a newly-added bare ingest observe bites.

**Scope:** the mediation agent-path dirs **plus `portcullis-effects/src`** (where the NucleusRuntime observes live). **Allowlist = 5 legitimate non-ingest observes**, each justified: `OutboundAction` egress marker; the runtime discharge-path `FileRead`/`WebContent` observes (enforcement is the `Labeled<…>` type + `DischargedBundle` proof, not the hash); the ceiling-sentinel `WebContent`; the standalone MCP causal-DAG `observe(kind,&parents)`.

**Tested:** green at floor; bites on a planted bare `flow.observe(NodeKind::WebContent)` (both plain and after a trailing `#[cfg(test)] mod …;`); green after cleanup. `bash -n` clean. New `ingest-hash-gate` CI job mirrors `mediation-gate`. No Rust source modified.

**Honest limitation (same as the mediation gate):** snippet-based allowlisting means a new ingest written to *exactly* match an allowlisted non-ingest snippet could slip — the deliberate drift-robust-over-collision-proof tradeoff (file:line would be collision-proof but line-drift-fragile). A normally-written new ingest still bites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CNJdZb7LHWwXkrt9MCa8CG
