### PR TITLE
feat(discharge): widen sealed DischargedBundle 7→8 — InputsAuthorized (8/8, HELD for review)

### DIFF
--- a/crates/nucleus-ifc-kernel/src/discharge.rs
+++ b/crates/nucleus-ifc-kernel/src/discharge.rs
@@ -20,7 +20,7 @@
 //! `DischargedBundle` is **sealed** — its constructor is private to this
 //! module. The only code path that produces one is a successful
 //! `preflight_action` call. Receiving a `DischargedBundle` is a compile-time
-//! proof that all seven obligations passed.
+//! proof that all eight obligations passed.
 //!
 //! ## Obligations checked
 //!
@@ -33,6 +33,7 @@
 //! | `Discharged<BudgetNotExceeded>` | Estimated cost is within budget |
 //! | `Discharged<WithinDelegationCeiling>` | Requested capability ≤ policy ceiling for the op |
 //! | `Discharged<InScopeWithTask>` | Operation is within the verified task token's scope |
+//! | `Discharged<InputsAuthorized>` | Every action input is content-addressed (present) |
 //!
 //! ## Seam notes (cross-layer obligation correspondence)
 //!
@@ -51,6 +52,16 @@
 //!   source-label check (`no source label carries `IntegLevel::Adversarial``).
 //!   Upstream keys off input `DerivationClass`; the discharge layer keys off
 //!   the propagated IFC integrity label, which is the source of truth.
+//! - **`InputsAuthorized`** (upstream) fails if any input's `source_hash` is
+//!   empty (`term.inputs.any(|i| i.source_hash.trim().is_empty())`). The
+//!   discharge layer attests the same property structurally: a kernel
+//!   [`ContentHash`] is a 32-byte recomputed digest **by construction** (bricks
+//!   3+4 recompute ingest hashes from bytes), so there is no "empty hash" state
+//!   to check per-element — the discharge obligation attests *presence*. A
+//!   `content_addressed_inputs` of `None` is the un-plumbed state and is
+//!   **denied** fail-closed; `Some(inputs)` mints the witness (an empty vec = an
+//!   action with no inputs = vacuously authorized, matching upstream's
+//!   `!any(empty_hash)` returning satisfied for zero inputs).
 //!
 //! ## Sealing
 //!
@@ -61,7 +72,9 @@
 use std::marker::PhantomData;
 
 use crate::storage_lane::StorageLane;
-use crate::{CapabilityLevel, DerivationClass, IFCLabel, IntegLevel, Operation, SinkClass};
+use crate::{
+    CapabilityLevel, ContentHash, DerivationClass, IFCLabel, IntegLevel, Operation, SinkClass,
+};
 
 // ═══════════════════════════════════════════════════════════════════════════
 // RepairHint — structured self-repair targets (#1189)
@@ -142,6 +155,14 @@ pub enum RepairHint {
         /// The subject that submitted the action.
         subject: String,
     },
+    /// The action's inputs are not content-addressed (the `content_addressed_inputs`
+    /// channel is un-plumbed, `None`). Plumb the FlowTracker content hashes onto
+    /// the term (`Some(..)`) before retrying — the discharge layer will not mint
+    /// `Discharged<InputsAuthorized>` from an absent inputs channel.
+    ProvideContentAddressedInputs {
+        /// The subject that submitted the action.
+        subject: String,
+    },
 }
 
 impl std::fmt::Display for RepairHint {
@@ -189,6 +210,11 @@ impl std::fmt::Display for RepairHint {
                 f,
                 "operation {operation:?} by '{subject}' is outside the verified task scope — \
                  narrow the operation or obtain a task token that authorizes it"
+            ),
+            Self::ProvideContentAddressedInputs { subject } => write!(
+                f,
+                "action by '{subject}' has un-plumbed inputs — populate \
+                 content_addressed_inputs from the FlowTracker before retrying"
             ),
         }
     }
@@ -274,6 +300,7 @@ impl RepairHint {
     ///     capability_ceiling: None,
     ///     requested_capability: None,
     ///     verified_scope: None,
+    ///     content_addressed_inputs: Some(vec![]),
     /// };
     ///
     /// let result = preflight_action(&term);
@@ -385,6 +412,14 @@ impl RepairHint {
                     operation
                 ),
             }),
+
+            // InputsAuthorized: the inputs channel is un-plumbed (`None`). This is
+            // a wiring defect, not a policy decision — we cannot fabricate the
+            // FlowTracker content hashes here (that would be exactly the vacuous
+            // witness the fail-closed check exists to prevent). No automatic
+            // rewrite; the caller must populate `content_addressed_inputs` from the
+            // term-building seam. Structural, like `CorrectOperationSinkPair`.
+            Self::ProvideContentAddressedInputs { .. } => None,
         }
     }
 }
@@ -482,6 +517,24 @@ pub struct InScopeWithTask;
 impl obligation_sealed::ObligationSealed for InScopeWithTask {}
 impl ProofObligation for InScopeWithTask {}
 
+/// Obligation: every input feeding this action is content-addressed.
+///
+/// Lifts the upstream `InputsAuthorized` check (`portcullis::action_term`),
+/// which fails when any input carries an empty `source_hash`. The discharge
+/// layer attests the same property *structurally*: the content-addressed inputs
+/// flow onto the [`ActionTerm`] as kernel [`ContentHash`]es, and a `ContentHash`
+/// is a 32-byte recomputed digest **by construction** (bricks 3+4 recompute
+/// ingest hashes from bytes) — so there is no empty-hash state to reject
+/// per-element; the obligation attests *presence*. Fail-closed — if the
+/// [`ActionTerm`]'s `content_addressed_inputs` is `None` (the un-plumbed state),
+/// the obligation is **denied**, never minted (the NO-VACUOUS-WITNESS guard). A
+/// `Some(vec![])` (an action with no inputs) mints vacuously, matching upstream's
+/// `!inputs.any(empty_hash)` returning satisfied for zero inputs. See
+/// [`preflight_action`].
+pub struct InputsAuthorized;
+impl obligation_sealed::ObligationSealed for InputsAuthorized {}
+impl ProofObligation for InputsAuthorized {}
+
 // ═══════════════════════════════════════════════════════════════════════════
 // VerifiedScope — dependency-free carrier for the verified task-token scope
 // ═══════════════════════════════════════════════════════════════════════════
@@ -551,7 +604,7 @@ impl<O: ProofObligation> std::fmt::Debug for Discharged<O> {
 
 /// The result of a successful [`preflight_action`] call.
 ///
-/// Holds typed discharge witnesses for all seven policy obligations. Effect
+/// Holds typed discharge witnesses for all eight policy obligations. Effect
 /// functions require a `&DischargedBundle` to proceed; there is **no other
 /// way to construct one** — the `_seal` field is private to this module.
 ///
@@ -559,7 +612,7 @@ impl<O: ProofObligation> std::fmt::Debug for Discharged<O> {
 ///
 /// The `_seal` field is unnameable outside this module, so **no**
 /// `DischargedBundle` struct literal compiles externally — even one that names
-/// every one of the seven public obligation fields (the missing `_seal` alone
+/// every one of the eight public obligation fields (the missing `_seal` alone
 /// is fatal, and `Discharged::mint()` is private too):
 ///
 /// ```compile_fail
@@ -567,6 +620,7 @@ impl<O: ProofObligation> std::fmt::Debug for Discharged<O> {
 /// use nucleus_ifc_kernel::discharge::{
 ///     DischargedBundle, Discharged, IntegrityGate, PathAllowed, DerivationClear,
 ///     NoAdversarialAncestry, BudgetNotExceeded, WithinDelegationCeiling, InScopeWithTask,
+///     InputsAuthorized,
 /// };
 /// let bundle = DischargedBundle {
 ///     integrity_gate: Discharged::<IntegrityGate>::mint(),  // mint() is private
@@ -576,7 +630,8 @@ impl<O: ProofObligation> std::fmt::Debug for Discharged<O> {
 ///     budget_not_exceeded: Discharged::<BudgetNotExceeded>::mint(),
 ///     within_delegation_ceiling: Discharged::<WithinDelegationCeiling>::mint(),
 ///     in_scope_with_task: Discharged::<InScopeWithTask>::mint(),
-///     // no `_seal`: the field is private — and even with all seven fields
+///     inputs_authorized: Discharged::<InputsAuthorized>::mint(),
+///     // no `_seal`: the field is private — and even with all eight fields
 ///     // above this literal cannot be completed outside the module.
 /// };
 /// ```
@@ -599,6 +654,8 @@ pub struct DischargedBundle {
     pub within_delegation_ceiling: Discharged<WithinDelegationCeiling>,
     /// Operation is within the verified task token's scope.
     pub in_scope_with_task: Discharged<InScopeWithTask>,
+    /// Every action input is content-addressed (present on the term).
+    pub inputs_authorized: Discharged<InputsAuthorized>,
     _seal: Seal,
 }
 
@@ -613,6 +670,7 @@ impl DischargedBundle {
             budget_not_exceeded: Discharged::mint(),
             within_delegation_ceiling: Discharged::mint(),
             in_scope_with_task: Discharged::mint(),
+            inputs_authorized: Discharged::mint(),
             _seal: Seal,
         }
     }
@@ -628,6 +686,7 @@ impl std::fmt::Debug for DischargedBundle {
             .field("budget_not_exceeded", &self.budget_not_exceeded)
             .field("within_delegation_ceiling", &self.within_delegation_ceiling)
             .field("in_scope_with_task", &self.in_scope_with_task)
+            .field("inputs_authorized", &self.inputs_authorized)
             .finish()
     }
 }
@@ -658,6 +717,7 @@ impl std::fmt::Debug for DischargedBundle {
 ///     capability_ceiling: None,
 ///     requested_capability: None,
 ///     verified_scope: None,
+///     content_addressed_inputs: Some(vec![]),
 /// };
 /// ```
 #[derive(Debug, Clone)]
@@ -697,6 +757,18 @@ pub struct ActionTerm {
     /// NO-VACUOUS-WITNESS guard: an action with no verified scope can never mint
     /// `Discharged<InScopeWithTask>`.
     pub verified_scope: Option<VerifiedScope>,
+    /// The content-addressed inputs feeding this action, one [`ContentHash`] per
+    /// source node that carries a recorded digest (InputsAuthorized bricks 1+3).
+    ///
+    /// `None` is the **un-plumbed** state and denies [`InputsAuthorized`]
+    /// fail-closed (the NO-VACUOUS-WITNESS guard: no witness is minted from an
+    /// absent inputs channel). `Some(inputs)` mints the witness — every
+    /// `ContentHash` is a 32-byte recomputed digest by construction, so the
+    /// discharge layer attests *presence*, not per-element validity. A
+    /// `Some(vec![])` (an action with no inputs) mints vacuously. Callers building
+    /// real terms collect these from the FlowTracker (see `build_term_scoped` in
+    /// `portcullis-effects`).
+    pub content_addressed_inputs: Option<Vec<ContentHash>>,
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -794,6 +866,8 @@ impl PreflightResult {
 ///    fail-closed if either level is absent
 /// 7. **InScopeWithTask** — operation is within the verified task token's scope;
 ///    fail-closed if no verified scope is present (NO-VACUOUS-WITNESS guard)
+/// 8. **InputsAuthorized** — every action input is content-addressed (present);
+///    fail-closed if the inputs channel is un-plumbed (`None`) — NO-VACUOUS-WITNESS
 ///
 /// Checks short-circuit on the first denial for latency. All non-denial
 /// states are fully evaluated before the bundle is minted.
@@ -819,6 +893,8 @@ impl PreflightResult {
 ///         allowed_operations: vec![Operation::WriteFiles],
 ///         allowed_paths: vec![],
 ///     }),
+///     // Inputs channel plumbed (no inputs → vacuously authorized).
+///     content_addressed_inputs: Some(vec![]),
 /// };
 ///
 /// match preflight_action(&term) {
@@ -866,6 +942,9 @@ pub mod test_helpers {
                 allowed_operations: vec![Operation::WriteFiles],
                 allowed_paths: vec![],
             }),
+            // Happy-path input for the widen 7 → 8 obligation (InputsAuthorized):
+            // the inputs channel is plumbed (no inputs → vacuously authorized).
+            content_addressed_inputs: Some(vec![]),
         };
         match preflight_action(&term) {
             PreflightResult::Allowed(bundle) => bundle,
@@ -1012,6 +1091,29 @@ pub fn preflight_action(term: &ActionTerm) -> PreflightResult {
                 },
             };
         }
+    }
+
+    // 8. InputsAuthorized: every input feeding this action must be
+    //    content-addressed. FAIL-CLOSED — if `content_addressed_inputs` is `None`
+    //    (the un-plumbed state), DENY and never mint (the NO-VACUOUS-WITNESS
+    //    guard). `Some(inputs)` mints: each `ContentHash` is a 32-byte recomputed
+    //    digest by construction (bricks 3+4 recompute ingest hashes from bytes),
+    //    so the discharge layer attests PRESENCE — there is no empty-hash state to
+    //    reject per-element. An empty vec = an action with no inputs = vacuously
+    //    authorized = mint, matching `portcullis::action_term`'s
+    //    `!inputs.any(|i| i.source_hash.is_empty())` returning satisfied for zero
+    //    inputs.
+    if term.content_addressed_inputs.is_none() {
+        return PreflightResult::Denied {
+            reason: format!(
+                "InputsAuthorized: content-addressed inputs channel is un-plumbed (None) \
+                 for operation {:?} by subject '{}' — denied fail-closed (no vacuous witness)",
+                term.operation, term.subject
+            ),
+            hint: RepairHint::ProvideContentAddressedInputs {
+                subject: term.subject.clone(),
+            },
+        };
     }
 
     PreflightResult::Allowed(DischargedBundle::new())
@@ -1197,6 +1299,11 @@ mod tests {
                 ],
                 allowed_paths: vec![],
             }),
+            // Happy-path input for the widen 7 → 8 obligation (InputsAuthorized).
+            // The channel is plumbed; denial tests that must trip InputsAuthorized
+            // override this to `None`. Denial tests for *earlier* checks
+            // short-circuit before check 8, so they inherit the happy-path value.
+            content_addressed_inputs: Some(vec![]),
         }
     }
 
@@ -1796,9 +1903,9 @@ mod tests {
     // from absent evidence.
 
     #[test]
-    fn happy_path_mints_full_seven_field_bundle() {
-        // All inputs present + in-scope + within ceiling → Allowed with a bundle
-        // whose Debug shows all seven obligation witnesses.
+    fn happy_path_mints_full_eight_field_bundle() {
+        // All inputs present + in-scope + within ceiling + inputs plumbed →
+        // Allowed with a bundle whose Debug shows all eight obligation witnesses.
         let bundle = preflight_action(&workspace_write_term()).unwrap_bundle();
         let dbg = format!("{bundle:?}");
         for needle in [
@@ -1809,9 +1916,93 @@ mod tests {
             "BudgetNotExceeded",
             "WithinDelegationCeiling",
             "InScopeWithTask",
+            "InputsAuthorized",
         ] {
             assert!(dbg.contains(needle), "bundle debug missing {needle}: {dbg}");
         }
+    }
+
+    // ── NO-VACUOUS-WITNESS: InputsAuthorized (widen 7 → 8) ─────────────────
+
+    #[test]
+    fn missing_content_addressed_inputs_denies_inputs_authorized() {
+        // content_addressed_inputs: None (un-plumbed) → must DENY (never mint
+        // InputsAuthorized from an absent inputs channel).
+        let term = ActionTerm {
+            content_addressed_inputs: None,
+            ..workspace_write_term()
+        };
+        let result = preflight_action(&term);
+        assert!(
+            result.is_denied(),
+            "absent content-addressed inputs channel must deny fail-closed"
+        );
+        assert!(
+            result.denial_reason().unwrap().contains("InputsAuthorized"),
+            "denial should name InputsAuthorized, got: {:?}",
+            result.denial_reason()
+        );
+        assert!(matches!(
+            result.repair_hint().unwrap(),
+            RepairHint::ProvideContentAddressedInputs { .. }
+        ));
+    }
+
+    #[test]
+    fn empty_inputs_vec_mints_inputs_authorized_vacuously() {
+        // Some(vec![]) = an action with no inputs = vacuously authorized → Allowed.
+        // Mirrors upstream `!inputs.any(empty_hash)` returning satisfied for zero
+        // inputs. This is the deliberate empty-vec-vs-None asymmetry.
+        let term = ActionTerm {
+            content_addressed_inputs: Some(vec![]),
+            ..workspace_write_term()
+        };
+        assert!(preflight_action(&term).is_allowed());
+    }
+
+    #[test]
+    fn present_content_hashes_mint_inputs_authorized() {
+        // Some(non-empty) with real 32-byte digests → Allowed (presence attested).
+        let term = ActionTerm {
+            content_addressed_inputs: Some(vec![
+                ContentHash::from_bytes([0x11; 32]),
+                ContentHash::from_bytes([0x22; 32]),
+            ]),
+            ..workspace_write_term()
+        };
+        assert!(preflight_action(&term).is_allowed());
+    }
+
+    #[test]
+    fn scope_check_precedes_inputs_check() {
+        // Both scope and inputs un-plumbed: scope (check 7) fires before inputs
+        // (check 8), confirming ordering and short-circuit.
+        let term = ActionTerm {
+            verified_scope: None,
+            content_addressed_inputs: None,
+            ..workspace_write_term()
+        };
+        let result = preflight_action(&term);
+        assert!(
+            result.denial_reason().unwrap().contains("InScopeWithTask"),
+            "scope (check 7) should fire before inputs (check 8)"
+        );
+    }
+
+    #[test]
+    fn provide_inputs_hint_has_no_automatic_repair() {
+        // The un-plumbed inputs state is a wiring defect, not a policy decision —
+        // try_repair returns None (we cannot fabricate content hashes).
+        let term = ActionTerm {
+            content_addressed_inputs: None,
+            ..workspace_write_term()
+        };
+        let hint = preflight_action(&term).repair_hint().unwrap().clone();
+        assert!(matches!(
+            hint,
+            RepairHint::ProvideContentAddressedInputs { .. }
+        ));
+        assert!(hint.try_repair(&term).is_none());
     }
 
     // ── NO-VACUOUS-WITNESS: InScopeWithTask ────────────────────────────────

--- a/crates/nucleus-tool-proxy/src/main.rs
+++ b/crates/nucleus-tool-proxy/src/main.rs
@@ -2583,7 +2583,7 @@ async fn run_command(
     let directory = req.directory.as_deref();
 
     // ─── Executor-proof gate (PR-2, parity with the MCP RunBash handler) ──────
-    // Mint the sealed 7-witness `DischargedBundle` — the type-level precondition
+    // Mint the sealed 8-witness `DischargedBundle` — the type-level precondition
     // that lets `run_args`/`run_args_with_approval` even be typed. Reuses the exact
     // `preflight_runbash` the MCP path uses (no re-mint, no forged bundle). Fail
     // closed on Denied/RequiresApproval: a Missing/Invalid session task token gives
@@ -2633,7 +2633,7 @@ async fn run_command(
             }
         }
     };
-    // Durable audit witness of the sealed 7-witness proof (parity with the MCP
+    // Durable audit witness of the sealed 8-witness proof (parity with the MCP
     // handler's `discharge_bundle` verdict extension).
     let discharge_note = run_gate::discharge_witness(&discharge_bundle);
 

--- a/crates/nucleus-tool-proxy/src/mcp.rs
+++ b/crates/nucleus-tool-proxy/src/mcp.rs
@@ -493,7 +493,7 @@ impl NucleusMcpServer {
         };
 
         // ─── Sealed discharge gate (#2038, F8/F9/F6 dual-stack) ──────────────
-        // PRECONDITION for `run_args`: mint the sealed 7-witness `DischargedBundle`.
+        // PRECONDITION for `run_args`: mint the sealed 8-witness `DischargedBundle`.
         // Fail-closed on a Missing/Invalid session task token (verified_scope
         // None ⇒ InScopeWithTask denies) — never substitutes a permissive scope.
         // This runs ALONGSIDE the sink/kernel/guard checks above (not instead of
@@ -1376,7 +1376,7 @@ mod tests {
             result.is_allowed(),
             "valid in-scope token must ALLOW RunBash (reach run_args), got {result:?}"
         );
-        // The Allowed bundle is the sealed 7-witness proof the handler consumes.
+        // The Allowed bundle is the sealed 8-witness proof the handler consumes.
         let bundle = result.unwrap_bundle();
         assert!(
             discharge_witness(&bundle).contains("in_scope_with_task"),

--- a/crates/nucleus-tool-proxy/src/run_gate.rs
+++ b/crates/nucleus-tool-proxy/src/run_gate.rs
@@ -21,7 +21,7 @@ use nucleus_provenance_memory::TokenScope;
 /// Builds the discharge [`ActionTerm`](discharge::ActionTerm) for
 /// `RunBash`/`BashExec` and runs [`preflight_action`]. Returning
 /// [`PreflightResult::Allowed`] hands back a [`DischargedBundle`] — the sealed
-/// 7-witness proof that the operation is authorized. There is no other way to
+/// 8-witness proof that the operation is authorized. There is no other way to
 /// construct that bundle, so a caller that reaches `run_args` only past an
 /// `Allowed` arm is a compile-time-checked precondition.
 ///
@@ -44,6 +44,11 @@ use nucleus_provenance_memory::TokenScope;
 /// - WithinDelegationCeiling: `requested == ceiling == level_for(RunBash)`, the
 ///   runtime's honest no-escalation claim, so `requested ≤ ceiling` holds by
 ///   construction (sound-but-dormant, mirrors `build_term_scoped`).
+/// - InputsAuthorized: the content-addressed inputs channel is plumbed from the
+///   session [`FlowTracker`] (`Some(..)`, never a `None` default), so the
+///   obligation is minted — vacuously on a clean session with no
+///   content-addressed inputs (empty vec), and for real once bricks 1+3 record
+///   digests on the session's source nodes.
 ///
 /// So the real added enforcement of this brick is **`InScopeWithTask`** (gated by
 /// the verified session task token) plus the fail-closed ceiling. The IFC labels
@@ -58,10 +63,19 @@ pub(crate) fn preflight_runbash(
 ) -> PreflightResult {
     // Real source labels from the session flow tracker (#1633 taint state) —
     // NOT fabricated defaults. Mirrors `build_term_scoped` in portcullis-effects.
+    // In the same pass, collect the per-node content hash (InputsAuthorized
+    // bricks 1+3): one `ContentHash` per node that carries a recorded digest. The
+    // channel is `Some(..)` (plumbed) here, so `InputsAuthorized` is minted — an
+    // empty vec (clean session with no content-addressed inputs) is vacuously
+    // authorized. `None` (fail-closed deny) is reserved for un-plumbed callers.
     let mut source_labels = Vec::new();
+    let mut content_addressed_inputs = Vec::new();
     for node_id in 1..=flow.node_count() as u64 {
         if let Some(label) = flow.label(node_id) {
             source_labels.push(*label);
+        }
+        if let Some(hash) = flow.content_hash(node_id) {
+            content_addressed_inputs.push(hash);
         }
     }
     // Artifact label: join of all source labels (most restrictive composite); an
@@ -94,6 +108,9 @@ pub(crate) fn preflight_runbash(
         capability_ceiling: Some(run_bash_ceiling),
         requested_capability: Some(run_bash_ceiling),
         verified_scope: term_scope,
+        // Plumbed inputs channel → InputsAuthorized minted (empty on a clean
+        // session = vacuously authorized). Never a `None` default.
+        content_addressed_inputs: Some(content_addressed_inputs),
     };
 
     preflight_action(&term)
@@ -102,7 +119,7 @@ pub(crate) fn preflight_runbash(
 /// Consume a [`DischargedBundle`] into an audit-record string.
 ///
 /// Satisfies the bundle's `#[must_use]` by reading it, and threads the sealed
-/// 7-witness proof into the verdict record so it is not dead.
+/// 8-witness proof into the verdict record so it is not dead.
 pub(crate) fn discharge_witness(bundle: &DischargedBundle) -> String {
     format!("{bundle:?}")
 }

--- a/crates/portcullis-effects/src/runtime.rs
+++ b/crates/portcullis-effects/src/runtime.rs
@@ -608,7 +608,7 @@ impl NucleusRuntime {
     ///
     /// 1. an [`UnmediatedAccess`] token (builder opt-in, auditable),
     /// 2. a [`DischargedBundle`] from [`preflight_unmediated`] — proof that all
-    ///    five policy obligations passed for the strictest egress sink, and
+    ///    eight policy obligations passed for the strictest egress sink, and
     /// 3. a FlowTracker observation: the grant is recorded as an
     ///    [`NodeKind::OutboundAction`] node, so the IFC graph reflects that an
     ///    unmediated bundle was issued (`flow_tracker().node_count()` advances).
@@ -853,11 +853,21 @@ impl NucleusRuntime {
         operation: Operation,
         sink_class: SinkClass,
     ) -> (ActionTerm, Option<TokenScope>) {
-        // Collect source labels from all tracked nodes
+        // Collect source labels from all tracked nodes. In the same pass, collect
+        // the per-node content hash (InputsAuthorized bricks 1+3): one
+        // `ContentHash` per source node that carries a recorded digest. The
+        // channel is always `Some(..)` here — a real runtime-built term is always
+        // plumbed — so `InputsAuthorized` is minted (nodes without a recorded
+        // hash are simply omitted; an empty vec = no inputs = vacuously
+        // authorized). `None` (deny) is reserved for un-plumbed callers only.
         let mut source_labels = Vec::new();
+        let mut content_addressed_inputs = Vec::new();
         for node_id in 1..=self.flow_tracker.node_count() as u64 {
             if let Some(label) = self.flow_tracker.label(node_id) {
                 source_labels.push(*label);
+            }
+            if let Some(hash) = self.flow_tracker.content_hash(node_id) {
+                content_addressed_inputs.push(hash);
             }
         }
 
@@ -910,6 +920,11 @@ impl NucleusRuntime {
             capability_ceiling: Some(self.level_for(operation)),
             requested_capability: Some(self.level_for(operation)),
             verified_scope: term_scope,
+            // PR-5: InputsAuthorized inputs. Always `Some(..)` on a runtime-built
+            // term (the channel is plumbed from the FlowTracker), so the
+            // obligation is minted; `None` (fail-closed deny) is reserved for
+            // un-plumbed callers. Sound-but-dormant like `WithinDelegationCeiling`.
+            content_addressed_inputs: Some(content_addressed_inputs),
         };
 
         (term, verified_scope)
@@ -942,7 +957,7 @@ impl NucleusRuntime {
 
     /// Run `preflight_action` and return the `DischargedBundle` on success.
     ///
-    /// The bundle is proof that all 5 obligations passed. Callers should
+    /// The bundle is proof that all 8 obligations passed. Callers should
     /// thread it to effect functions rather than discarding (#1360).
     fn discharge(&self, term: &ActionTerm) -> Result<DischargedBundle, RuntimeError> {
         match preflight_action(term) {
@@ -1436,7 +1451,7 @@ mod tests {
 
     // ── PR-B token helpers ──────────────────────────────────────────────
     //
-    // Widening the bundle to 7 obligations makes `InScopeWithTask` mandatory:
+    // Widening the bundle to 8 obligations makes `InScopeWithTask` mandatory:
     // `preflight_action` denies fail-closed unless the session carries a
     // verified task token whose scope authorizes the operation. These helpers
     // mint a broad-scope verified token so the capability/flow/effect tests

--- a/crates/portcullis/tests/cross_layer_discharge_consistency.rs
+++ b/crates/portcullis/tests/cross_layer_discharge_consistency.rs
@@ -1,6 +1,6 @@
 //! Cross-layer consistency guard (PR-B regression guard (a)).
 //!
-//! The discharge layer (`portcullis_core::discharge`, the sealed 7-obligation
+//! The discharge layer (`portcullis_core::discharge`, the sealed 8-obligation
 //! vocabulary in `nucleus-ifc-kernel`) LIFTS two obligations from the upstream
 //! `portcullis::action_term` checker: `WithinDelegationCeiling` and
 //! `InScopeWithTask`. This test pins the two layers together: for a corpus of
@@ -101,6 +101,10 @@ fn discharge_allowed(allowed_ops: &[Operation], git_commit_ceiling: CapabilityLe
             allowed_operations: allowed_ops.to_vec(),
             allowed_paths: vec![],
         }),
+        // No inputs (matches the upstream scenario) → InputsAuthorized minted
+        // vacuously. Plumbed `Some(vec![])`, never `None`, so this obligation
+        // never decides the verdict — only the two lifted obligations do.
+        content_addressed_inputs: Some(vec![]),
     };
     discharge_preflight(&term).is_allowed()
 }


### PR DESCRIPTION
**The final brick of the InputsAuthorized (8/8) project — a SEALED-VOCABULARY change.** Widens the sealed `DischargedBundle` from 7 to 8 obligations by adding `InputsAuthorized`, minted from the content-addressed inputs now flowing on the FlowTracker (bricks 1+3) and locked by the ingest CI gate (brick 4). Mirrors the merged 5→7 widen exactly.

**Held for explicit owner review** before auto-merge (sealed security core).

- **Sealed obligation:** `struct InputsAuthorized;` + `ObligationSealed`/`ProofObligation` (mirrors `InScopeWithTask`). `DischargedBundle` 7→8 (`inputs_authorized` field; `new()`/`Debug`/`#[must_use]`).
- **Discharge `ActionTerm`:** new `content_addressed_inputs: Option<Vec<ContentHash>>` (kernel `ContentHash`).
- **`preflight_action` check 8 — fail-closed, no-vacuous:** `None` → **DENY** (un-plumbed); `Some` → mint. Each `ContentHash` is a 32-byte digest recomputed-from-bytes by construction (bricks 3+4), so the discharge attests **presence**; `Some(vec![])` (no inputs) mints vacuously, matching upstream's `!inputs.any(empty_hash)`. New `RepairHint::ProvideContentAddressedInputs` (structural, no auto-repair — fabricating a hash would be the exact vacuous witness the check prevents).
- **`build_term_scoped` + `run_gate::preflight_runbash`** populate the field from `flow_tracker.content_hash(id)` per node.

**Honest soundness layering (the caveats):**
1. `InputsAuthorized`'s soundness **rests on bricks 3+4** — the discharge attests the hashes are *present*; the recompute-from-bytes (brick 3) and the no-unwitnessed-ingest gate (brick 4) are what guarantee they're *real* and *complete*.
2. Semantic scope: it attests "every FlowTracker-**observed** input is content-addressed," not "all inputs are observed" (FlowTracker completeness is a separate, pre-existing IFC property) — the same scope as the upstream check.

**Green:** `nucleus-ifc-kernel` 185 + `portcullis-effects` 79 + doctests (incl. the **8-field** compile-fail sealing doctest) + `portcullis` cross-layer consistency; `fmt`/`clippy --all-features -D warnings`/verify-strict/mediation clean. New tests: `happy_path_mints_full_eight_field_bundle`, `missing_content_addressed_inputs_denies_inputs_authorized` (deny-on-absent), `empty_inputs_vec_mints_inputs_authorized_vacuously`, `present_content_hashes_mint_inputs_authorized`, `scope_check_precedes_inputs_check`. Consumers needing source changes: exactly the discharge-`ActionTerm` constructors (`portcullis-effects/runtime.rs`, `nucleus-tool-proxy/run_gate.rs`, the cross-layer test) — all in-repo, updated. Also synced stale obligation-count comments the 5→7 widen left behind.

With this, the sealed bundle proves **8/8** admission obligations; the parked gap is closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CNJdZb7LHWwXkrt9MCa8CG
