### PR TITLE
feat(nucleus): relocate sync Executor spawn into sealed home — delete first allowlist entry (terminal-push B2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6478,6 +6478,7 @@ dependencies = [
  "nucleus-provenance",
  "parking_lot",
  "portcullis",
+ "portcullis-effects",
  "quanta",
  "rust_decimal",
  "sha2 0.11.0",

--- a/crates/nucleus/Cargo.toml
+++ b/crates/nucleus/Cargo.toml
@@ -20,6 +20,11 @@ async = ["tokio"]
 nucleus-provenance = { path = "../nucleus-provenance" }
 # Policy layer - the quotient lattice
 portcullis = { path = "../portcullis" }
+# Sealed effects home (brick B1's `ShellEffect::run_argv`). The Executor's
+# synchronous spawn is relocated behind this discharge-gated effect API (B2), so
+# the raw `Command::new` leaves `command.rs`. No cycle: portcullis-effects does
+# not depend on nucleus.
+portcullis-effects = { path = "../portcullis-effects" }
 # Sealed discharge proof: the `DischargedBundle` type is named in the Executor
 # spawn signature (`spawn_checked`/`run`/`run_args`/…) so no synchronous spawn can
 # compile without a minted preflight bundle. Additive — discharge is already

--- a/crates/nucleus/Cargo.toml
+++ b/crates/nucleus/Cargo.toml
@@ -56,7 +56,7 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 
 # Optional: async support
-tokio = { workspace = true, features = ["process", "fs", "io-util"], optional = true }
+tokio = { workspace = true, features = ["process", "fs", "io-util", "time"], optional = true }
 
 # Shell parsing for command validation
 shell-words = { workspace = true }

--- a/crates/nucleus/src/command.rs
+++ b/crates/nucleus/src/command.rs
@@ -9,7 +9,11 @@
 
 use std::collections::BTreeMap;
 use std::io;
-use std::process::{Command, ExitStatus, Output, Stdio};
+use std::process::{Command, ExitStatus, Output};
+// `Stdio` is only used by the async (tokio) spawn paths now that the sync
+// builder has been relocated into the sealed `ShellEffect::run_argv` home (B2).
+#[cfg(feature = "async")]
+use std::process::Stdio;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -19,11 +23,16 @@ use crate::error::{NucleusError, Result};
 use crate::sandbox::Sandbox;
 use crate::time::MonotonicGuard;
 use nucleus_ifc_kernel::discharge::DischargedBundle;
+// The sealed effects home (B1). `portcullis_core::CapabilityLattice` — the type
+// `production_effects` requires — is a re-export of `nucleus_ifc_kernel`'s
+// lattice (already a nucleus dependency), so no new dep is needed to name it.
+use nucleus_ifc_kernel::CapabilityLattice as CoreCapabilityLattice;
 use portcullis::kernel::DecisionToken;
 use portcullis::{
     CapabilityLattice, CapabilityLevel, CommandLattice, IsolationLattice, Obligations, Operation,
     PermissionLattice,
 };
+use portcullis_effects::{production_effects, ShellEffect};
 
 use crate::hardening::HostSandbox;
 
@@ -114,6 +123,13 @@ pub struct Executor<'a> {
     required_isolation: IsolationLattice,
     /// The declared containment posture. Default fails closed.
     containment: ContainmentMode,
+    /// The sealed effects home (B1) the synchronous spawn delegates to. Obtained
+    /// from [`production_effects`], so it is a `PolicyEnforced<RealEffects>`: the
+    /// only raw `Command::new` on the sync path now lives inside
+    /// `ShellEffect::run_argv`, reached only past the policy gate and a
+    /// `DischargedBundle`. Held as a trait object because the concrete effect
+    /// type is intentionally opaque outside `portcullis-effects`.
+    effects: Arc<dyn ShellEffect + Send + Sync>,
 }
 
 impl<'a> Executor<'a> {
@@ -130,6 +146,14 @@ impl<'a> Executor<'a> {
         // The required isolation is the policy's declared minimum; absent any
         // requirement it resolves to the weakest level (localhost = "no requirement").
         let required_isolation = normalized.effective_minimum_isolation();
+        // Build the sealed effects home from this Executor's own capabilities.
+        // `production_effects` wraps `RealEffects` in `PolicyEnforced`, so the
+        // spawn keeps the crate's policy gate; the Executor's own capability
+        // checks (`check_capability`) remain the primary authorization and run
+        // first, so behavior on the bash path is unchanged.
+        let effects: Arc<dyn ShellEffect + Send + Sync> = Arc::new(production_effects(
+            core_capabilities(&normalized.capabilities),
+        ));
         Self {
             capabilities: normalized.capabilities,
             obligations: normalized.obligations,
@@ -142,6 +166,7 @@ impl<'a> Executor<'a> {
             allowed_env: BTreeMap::new(),
             required_isolation,
             containment: ContainmentMode::Unconfigured,
+            effects,
         }
     }
 
@@ -305,11 +330,12 @@ impl<'a> Executor<'a> {
     /// The single, mediated choke point through which every *synchronous* spawn
     /// is built and executed.
     ///
-    /// All process hardening that is invariant across the synchronous call sites
-    /// lives here exactly once: environment isolation (`env_clear` +
-    /// `envs(allowed_env)`), stdout/stderr capture, and — under
-    /// [`ContainmentMode::HostHardened`] — `HostSandbox::harden_std`. Callers
-    /// supply only what legitimately differs between sites:
+    /// The raw `Command::new` no longer lives here: this now DELEGATES to the
+    /// sealed effects home [`ShellEffect::run_argv`] (brick B1), which reproduces
+    /// the previous inline builder byte-for-byte — environment isolation
+    /// (`env_clear` + `envs(allowed_env)`), stdout/stderr capture, stdin
+    /// pipe-vs-null, and the host-hardening hook. Callers supply only what
+    /// legitimately differs between sites:
     ///
     /// * `program` / `args` — the argv (never a shell string; no shell is ever
     ///   involved, preserving the "argv-not-shell" injection defense),
@@ -317,52 +343,45 @@ impl<'a> Executor<'a> {
     /// * `stdin_data` — `Some` to feed the child stdin over a pipe, `None` to
     ///   close it with `Stdio::null()`.
     ///
-    /// This is deliberately the *only* `Command::new` on the synchronous paths.
+    /// The invariant hardening is threaded through `run_argv`: the environment
+    /// allowlist as `&self.allowed_env`, and — under
+    /// [`ContainmentMode::HostHardened`] — `HostSandbox::harden_std` as the
+    /// injected `harden` hook (`None` reproduces the un-hardened spawn).
+    ///
     /// Keeping all three public methods routed through this one function lets the
-    /// executor-proof gate require a `_proof: &DischargedBundle` as the final
-    /// parameter here (and on every public method that reaches it): a synchronous
-    /// spawn cannot even be *named* without a discharged bundle in hand, so an
+    /// executor-proof gate require a `&DischargedBundle` as the final parameter
+    /// here (and on every public method that reaches it): a synchronous spawn
+    /// cannot even be *named* without a discharged bundle in hand, so an
     /// un-preflighted spawn is a compile error rather than a runtime check. The
-    /// proof is a sealed 7-witness bundle that only `preflight_action` can mint;
-    /// it is required by type but otherwise unused here (`_proof`) — its presence
-    /// in the signature is the enforcement.
+    /// bundle is a sealed 7-witness proof that only `preflight_action` can mint;
+    /// it is now threaded on into `run_argv` (the sealed home requires it too).
     fn spawn_checked(
         &self,
         program: &str,
         args: &[String],
         cwd: &std::path::Path,
         stdin_data: Option<&str>,
-        _proof: &DischargedBundle,
+        proof: &DischargedBundle,
     ) -> io::Result<Output> {
-        let mut cmd = Command::new(program);
-        cmd.args(args)
-            .current_dir(cwd)
-            .env_clear() // Security: prevent secret leakage from parent
-            .envs(&self.allowed_env) // Only explicitly allowed vars
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
+        // Under HostHardened, hand the sealed home `HostSandbox::harden_std` as
+        // the pre-spawn hook; otherwise `None` (un-hardened spawn). The concrete
+        // hardening lives in this crate, so it is injected as a callback.
+        let harden: Option<&(dyn Fn(&mut Command) + Send + Sync)> = (self.containment
+            == ContainmentMode::HostHardened)
+            .then_some(&HostSandbox::harden_std as &(dyn Fn(&mut Command) + Send + Sync));
 
-        // Stdin: pipe it when the caller has data to write, otherwise close it.
-        if stdin_data.is_some() {
-            cmd.stdin(Stdio::piped());
-        } else {
-            cmd.stdin(Stdio::null());
-        }
-
-        if self.containment == ContainmentMode::HostHardened {
-            HostSandbox::harden_std(&mut cmd);
-        }
-
-        if let Some(input) = stdin_data {
-            let mut child = cmd.spawn()?;
-            if let Some(ref mut stdin_pipe) = child.stdin {
-                use std::io::Write;
-                stdin_pipe.write_all(input.as_bytes())?;
-            }
-            child.wait_with_output()
-        } else {
-            cmd.output()
-        }
+        // Delegate to the sealed home. `stdin_data` (an `Option<&str>`) becomes
+        // `Option<&[u8]>` via `str::as_bytes` — the child receives the exact same
+        // bytes the previous inline `write_all(input.as_bytes())` wrote.
+        self.effects.run_argv(
+            program,
+            args,
+            cwd,
+            stdin_data.map(str::as_bytes),
+            &self.allowed_env,
+            harden,
+            proof,
+        )
     }
 
     /// Execute a command and return its output.
@@ -835,6 +854,32 @@ impl<'a> Executor<'a> {
             cost += duration.as_secs_f64() * self.budget_model.cost_per_second_usd;
         }
         self.budget.charge_usd(cost)
+    }
+}
+
+/// Convert the Executor's `portcullis::CapabilityLattice` into the
+/// `portcullis_core` lattice `production_effects` expects.
+///
+/// The two lattices carry the identical 13 named dimensions and share the same
+/// `CapabilityLevel` enum (both re-exported from `portcullis_core`), so this is
+/// a straight field-for-field copy; the `portcullis` lattice's extension
+/// dimensions have no `portcullis_core` counterpart and are not spawn-relevant,
+/// so they are dropped.
+fn core_capabilities(caps: &CapabilityLattice) -> CoreCapabilityLattice {
+    CoreCapabilityLattice {
+        read_files: caps.read_files,
+        write_files: caps.write_files,
+        edit_files: caps.edit_files,
+        run_bash: caps.run_bash,
+        glob_search: caps.glob_search,
+        grep_search: caps.grep_search,
+        web_search: caps.web_search,
+        web_fetch: caps.web_fetch,
+        git_commit: caps.git_commit,
+        git_push: caps.git_push,
+        create_pr: caps.create_pr,
+        manage_pods: caps.manage_pods,
+        spawn_agent: caps.spawn_agent,
     }
 }
 

--- a/crates/portcullis-effects/src/lib.rs
+++ b/crates/portcullis-effects/src/lib.rs
@@ -172,16 +172,30 @@ pub trait ShellEffect {
         harden: Option<&(dyn Fn(&mut Command) + Send + Sync)>,
         _proof: &DischargedBundle,
     ) -> io::Result<Output>;
+}
 
-    /// Async (tokio) variant of [`run_argv`](ShellEffect::run_argv).
-    ///
-    /// Mirrors the synchronous spawn but on `tokio::process`, with
-    /// `kill_on_drop(true)` and an optional `timeout`. When `timeout` is
-    /// `Some`, the wait is wrapped in `tokio::time::timeout` and a timeout maps
-    /// to an [`io::ErrorKind::TimedOut`] error; when `None`, the child is
-    /// awaited to completion. Gated behind the `async` feature so the default
-    /// crate stays free of the tokio dependency.
-    #[cfg(feature = "async")]
+/// Async (tokio) structured argv spawn.
+///
+/// This lives in its own trait, **separate from [`ShellEffect`]**, so that
+/// `ShellEffect` stays free of any `async fn` and therefore remains
+/// dyn-compatible (`Arc<dyn ShellEffect>` must build a vtable — an `async fn`
+/// in the trait would break that with `E0038`). Callers that need the async
+/// spawn depend on this trait explicitly; the sync `Arc<dyn ShellEffect>`
+/// consumers are unaffected.
+///
+/// The method mirrors [`ShellEffect::run_argv`] but on `tokio::process`, with
+/// `kill_on_drop(true)` and an optional `timeout`. When `timeout` is `Some`,
+/// the wait is wrapped in `tokio::time::timeout` and a timeout maps to an
+/// [`io::ErrorKind::TimedOut`] error; when `None`, the child is awaited to
+/// completion. Gated behind the `async` feature so the default crate stays free
+/// of the tokio dependency.
+///
+/// (Distinct from [`async_traits::AsyncShellEffect`](crate::async_traits::AsyncShellEffect),
+/// which is the sync→async *mirror* of `ShellEffect::run`; this trait is the
+/// async home of the structured `run_argv` spawn.)
+#[cfg(feature = "async")]
+pub trait AsyncShellSpawnEffect {
+    /// Async (tokio) variant of [`ShellEffect::run_argv`].
     #[allow(clippy::too_many_arguments, async_fn_in_trait)]
     async fn run_argv_async(
         &self,
@@ -389,8 +403,10 @@ impl ShellEffect for RealEffects {
             cmd.output()
         }
     }
+}
 
-    #[cfg(feature = "async")]
+#[cfg(feature = "async")]
+impl AsyncShellSpawnEffect for RealEffects {
     async fn run_argv_async(
         &self,
         program: &str,
@@ -582,8 +598,10 @@ impl<E: ShellEffect> ShellEffect for PolicyEnforced<E> {
         self.inner
             .run_argv(program, args, cwd, stdin, allowed_env, harden, proof)
     }
+}
 
-    #[cfg(feature = "async")]
+#[cfg(feature = "async")]
+impl<E: AsyncShellSpawnEffect> AsyncShellSpawnEffect for PolicyEnforced<E> {
     async fn run_argv_async(
         &self,
         program: &str,
@@ -805,8 +823,10 @@ impl ShellEffect for RecordingEffects {
         );
         Ok(empty_success_output())
     }
+}
 
-    #[cfg(feature = "async")]
+#[cfg(feature = "async")]
+impl AsyncShellSpawnEffect for RecordingEffects {
     async fn run_argv_async(
         &self,
         program: &str,
@@ -912,8 +932,10 @@ impl ShellEffect for DenyAllEffects {
             format!("shell denied: {program}"),
         ))
     }
+}
 
-    #[cfg(feature = "async")]
+#[cfg(feature = "async")]
+impl AsyncShellSpawnEffect for DenyAllEffects {
     async fn run_argv_async(
         &self,
         program: &str,

--- a/scripts/mediation-allowlist.txt
+++ b/scripts/mediation-allowlist.txt
@@ -7,16 +7,13 @@
 #
 # Format: exact TRIMMED source line (leading/trailing whitespace removed).
 #
-# nucleus::Executor SEALED synchronous spawn home (command.rs :337, in
-# `Executor::spawn_checked`). This is the single sync `Command::new` choke point
-# and it is now gated by a required `_proof: &DischargedBundle` final parameter:
-# every path that reaches it (`run` / `run_args` / `run_with_approval` and the
-# internal hops) must thread a sealed bundle that ONLY `preflight_action` can
-# mint, so this line is reachable only PAST a minted discharge bundle — an
-# un-preflighted spawn is a compile error, not a runtime check. RETAINED (not
-# deleted): the raw spawn still lives here in gate scope; deleting the entry needs
-# the later ShellEffect-relocation brick that moves the spawn behind the effect API.
-let mut cmd = Command::new(program);
+# nucleus::Executor SEALED synchronous spawn — RELOCATED (brick B2). The sync
+# `Command::new` that used to live in `Executor::spawn_checked` has moved behind
+# the discharge-gated effect API: `spawn_checked` now delegates to the sealed
+# home `ShellEffect::run_argv` (portcullis-effects), reached only PAST a minted
+# `DischargedBundle` and the `PolicyEnforced` gate. No raw sync spawn remains in
+# `crates/nucleus/src`, so this allowlist entry is DELETED — one fewer raw
+# primitive, one fewer allowlist entry (the metric win).
 #
 # nucleus::Executor async spawn (command.rs :677, :750)
 #   -> migrate behind ShellEffect / production_effects(policy)


### PR DESCRIPTION
B2 of the North Star terminal push. The Executor's SYNC raw `Command::new` **relocates into the sealed effects home** (B1's `run_argv`, #2045), so the raw primitive leaves the mediation scope and its **allowlist entry is DELETED** — the first actual decrement of the raw-primitive counter. Behavior identical (`run_argv` reproduces `spawn_checked` byte-for-byte).

- `Executor` now holds `effects: Arc<dyn ShellEffect>` built in `Executor::new` via `production_effects(core_capabilities(...))` → `PolicyEnforced<RealEffects>`, so the **sealed policy gate is preserved** (constructed from the same policy; `NucleusRuntime` lives in portcullis-effects and can't be held without a cycle). Added the `nucleus → portcullis-effects` dep.
- `spawn_checked` delegates: `self.effects.run_argv(program, args, cwd, stdin.map(str::as_bytes), &self.allowed_env, harden, proof)` where `harden = (containment==HostHardened).then_some(&HostSandbox::harden_std)`. Raw `Command::new` + inline builder removed from `command.rs`.
- **Deleted** the `let mut cmd = Command::new(program);` allowlist entry; async (`tokio::process::Command::new`, B3) and mcp-guard (B4) entries retained.

**Green:** raw sync `Command::new` gone from `crates/nucleus/src`; `check-mediation.sh` PASSED with the entry deleted; verify-strict + ingest gates PASSED; `cargo test -p nucleus -p portcullis-effects` green (48 + 81 + doctests incl. the no-proof-no-spawn compile-fail), all argv/stdin/cwd/env-isolation/harden/approval/budget behavior tests unchanged; `fmt`/`clippy -p nucleus -p portcullis-effects -D warnings` clean; consumers build.

**Disclosed:** `PolicyEnforced` adds a `run_bash != Never` check that only diverges under an incoherent 'forbid all shell yet enable a git capability' policy (git *is* a shell command) — no profile constructs it; observably identical. (Pre-existing `-p nucleus --features async` tokio::time issue on the untouched `run_with_timeout` is B3 surface, confirmed on clean main.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CNJdZb7LHWwXkrt9MCa8CG