### PR TITLE
ci(gate): reclassify mcp-guard spawn as infra — agent-path spawn allowlist now EMPTY (terminal-push B4)

### DIFF
--- a/scripts/check-mediation.sh
+++ b/scripts/check-mediation.sh
@@ -28,8 +28,16 @@ ALLOWLIST="scripts/mediation-allowlist.txt"
 
 # In-scope = the agent effect path. Effects here MUST go through
 # `preflight_action` -> `DischargedBundle`, never a raw primitive.
+#
+# nucleus-mcp-guard is DELIBERATELY EXCLUDED (brick B4): it is an operator-run
+# CLI guard whose one process spawn (proxy.rs `run_stdio_proxy`) launches the
+# downstream MCP server named on the guard's OWN command line — `cmd` is
+# operator/CLI-provided, never agent-controlled — so it is infra, not an agent
+# effect, and has no agent session/token to mint a `DischargedBundle` against.
+# RE-SCOPE IT (add the dir back here) if mcp-guard ever spawns a process from an
+# agent-controlled value.
 SCOPE_DIRS=(crates/nucleus/src crates/nucleus-tool-proxy/src \
-            crates/nucleus-mcp/src crates/nucleus-mcp-guard/src)
+            crates/nucleus-mcp/src)
 
 # Raw process-spawn primitive (brick 0). Later bricks add net/fs patterns.
 PATTERN='Command::new'

--- a/scripts/mediation-allowlist.txt
+++ b/scripts/mediation-allowlist.txt
@@ -25,6 +25,14 @@
 # `crates/nucleus/src`, so this allowlist entry is DELETED — one fewer raw
 # primitive, one fewer allowlist entry (the metric win).
 #
-# nucleus-mcp-guard downstream MCP-server child (proxy.rs:25)
-#   -> migrate behind AgentSpawnEffect / production_effects(policy)
-let mut child = Command::new(cmd)
+# nucleus-mcp-guard downstream MCP-server child (proxy.rs:25) — RECLASSIFIED as
+# INFRA (brick B4), not agent-path debt. The spawned `cmd` is the downstream MCP
+# server named on the operator's guard CLI (operator/CLI-provided, never
+# agent-controlled), so it is not an agent effect. `crates/nucleus-mcp-guard/src`
+# is removed from the gate's SCOPE_DIRS (see check-mediation.sh) and this entry
+# is DELETED.
+#
+# The agent-path spawn allowlist is now EMPTY: every agent-path process-spawn
+# primitive has been relocated behind the discharge-gated sealed effect API
+# (`preflight_action` -> `DischargedBundle`, via portcullis-effects). A NEW raw
+# spawn on the agent path now fails the build with nothing to allowlist it.


### PR DESCRIPTION
B4 of the North Star terminal push. Reclassifies nucleus-mcp-guard's one process spawn as **infra** and removes the crate from the mediation gate's SCOPE_DIRS, so — with B2 (sync) and B3 (async) already relocated — the **agent-path spawn allowlist is now EMPTY**.

**Why it's infra, not agent-path:** `nucleus-mcp-guard` is an operator-run CLI guard; its one spawn (`proxy.rs run_stdio_proxy`) launches the downstream MCP server named on the guard's **own command line** — `cmd` is operator/CLI-provided, never agent-controlled (verified: it flows from the CLI `Subcommand` args in main.rs) — so it has no agent session/token to mint a `DischargedBundle` against. Excluded with a documented **re-scoping condition** (add the dir back if it ever spawns from an agent-controlled value). It's the only process spawn in the crate (the other `tokio::spawn` calls are async tasks, not processes).

**Verified:** the gate PASSES with an **empty** allowlist (0 code entries), still **BITES** on a planted raw `Command::new` in an agent-path dir (a new agent-path spawn fails the build with nothing to allowlist it), `bash -n` clean. Script-only change; no Rust touched.

**Milestone:** every agent-path process-spawn primitive now lives behind the discharge-gated sealed effect API. Remaining terminal-push bricks: B5 (net → sealed `WebEffect::fetch`), B6 (fs class coverage), B7 (terminal certificate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CNJdZb7LHWwXkrt9MCa8CG