### PR TITLE
feat(sandbox): fs writes require a DischargedBundle — every effect class type-enforced (terminal-push B6)

### DIFF
--- a/crates/nucleus-tool-proxy/src/main.rs
+++ b/crates/nucleus-tool-proxy/src/main.rs
@@ -2466,11 +2466,56 @@ async fn write_file(
     let path = req.path.clone();
     let contents = req.contents.clone();
 
-    match state
-        .runtime
-        .sandbox()
-        .write(&path, contents.as_bytes(), &decision_token)
-    {
+    // ─── Sealed discharge gate (B6, parity with the RunBash executor-proof gate
+    // and the B5 net-egress gate). PRECONDITION for the `_proof`-gated
+    // `Sandbox::write`: mint the sealed 8-witness `DischargedBundle` via
+    // `preflight_fs`. Fail closed — a Missing/Invalid session task token gives
+    // `verified_scope == None` ⇒ `InScopeWithTask` denies (no vacuous witness);
+    // an out-of-scope op denies. Without the bundle the `_proof`-gated write
+    // cannot be typed, so no un-preflighted agent fs write can reach cap-std.
+    // The cap-std root confinement inside `Sandbox::write` is retained
+    // (dual-stack): this bundle is additive, not a relocation.
+    let discharge_bundle = {
+        use nucleus_ifc_kernel::discharge::PreflightResult;
+        let verified_scope = state.session_task_token.verified_scope();
+        let fs_ceiling = state.runtime.policy().capabilities.write_files;
+        let flow = state.flow_tracker.lock().await;
+        let result = run_gate::preflight_fs(
+            Operation::WriteFiles,
+            verified_scope,
+            fs_ceiling,
+            &path,
+            &flow,
+        );
+        drop(flow);
+        match result {
+            PreflightResult::Allowed(bundle) => bundle,
+            PreflightResult::Denied { reason, .. }
+            | PreflightResult::RequiresApproval { reason } => {
+                if let Err(e) = sink.record(VerdictContext {
+                    operation,
+                    subject: path.clone(),
+                    outcome: VerdictOutcome::Deny {
+                        reason: format!("discharge denied: {reason}"),
+                    },
+                    actor,
+                    policy_rule: None,
+                    extensions: BTreeMap::new(),
+                }) {
+                    warn!(error = %e, "verdict recording failed -- audit gap");
+                }
+                return Err(ApiError::IfcDenied(format!("discharge denied: {reason}")));
+            }
+        }
+    };
+    let _discharge_note = run_gate::discharge_witness(&discharge_bundle);
+
+    match state.runtime.sandbox().write(
+        &path,
+        contents.as_bytes(),
+        &decision_token,
+        &discharge_bundle,
+    ) {
         Ok(()) => {}
         Err(NucleusError::ApprovalRequired { operation: op }) => {
             // Check if policy allows this operation (zero-prompt mode) or if approval was pre-granted
@@ -2487,6 +2532,7 @@ async fn write_file(
                     contents.as_bytes(),
                     &approved_dt,
                     &approval,
+                    &discharge_bundle,
                 )?;
             } else {
                 if let Err(e) = sink.record(VerdictContext {

--- a/crates/nucleus-tool-proxy/src/mcp.rs
+++ b/crates/nucleus-tool-proxy/src/mcp.rs
@@ -415,12 +415,49 @@ impl NucleusMcpServer {
             }
         };
 
+        // ─── Sealed discharge gate (B6, parity with the MCP RunBash/web handlers)
+        // PRECONDITION for the `_proof`-gated `Sandbox::write`: mint the sealed
+        // 8-witness `DischargedBundle` via `preflight_fs`. Fail closed — a
+        // Missing/Invalid session task token gives `verified_scope == None` ⇒
+        // `InScopeWithTask` denies; an out-of-scope op denies. No bundle ⇒ the
+        // handler returns its error and NEVER writes (cap-std is never reached).
+        let discharge_bundle = {
+            let verified_scope = self.state.session_task_token.verified_scope();
+            let fs_ceiling = self.state.runtime.policy().capabilities.write_files;
+            let flow = self.flow_tracker.lock().await;
+            let result = preflight_fs(
+                Operation::WriteFiles,
+                verified_scope,
+                fs_ceiling,
+                &params.path,
+                &flow,
+            );
+            drop(flow);
+            match result {
+                PreflightResult::Allowed(bundle) => bundle,
+                PreflightResult::Denied { reason, .. }
+                | PreflightResult::RequiresApproval { reason } => {
+                    warn!(path = %params.path, %reason, "discharge preflight DENIED write — no write");
+                    self.record_verdict(
+                        Operation::WriteFiles,
+                        &params.path,
+                        VerdictOutcome::Deny {
+                            reason: format!("discharge denied: {reason}"),
+                        },
+                    );
+                    return Ok(err_result(format!("discharge denied: {reason}")));
+                }
+            }
+        };
+        let _discharge_note = discharge_witness(&discharge_bundle);
+
         match self.guard.execute_and_record(proof, || {
             tokio::task::block_in_place(|| {
                 self.state.runtime.sandbox().write(
                     &params.path,
                     params.contents.as_bytes(),
                     &decision_token,
+                    &discharge_bundle,
                 )
             })
         }) {
@@ -1222,7 +1259,7 @@ fn build_action_term(operation: Operation, subject: &str) -> ActionTerm {
 // module, so the non-feature-gated HTTP `/v1/run` handler can share them with
 // this feature-gated MCP handler. Re-imported here so the local call sites and
 // the `#[cfg(test)]` module below resolve them unchanged.
-use crate::run_gate::{discharge_witness, preflight_runbash, preflight_web};
+use crate::run_gate::{discharge_witness, preflight_fs, preflight_runbash, preflight_web};
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Tests — enforcement boundary coverage (#1295)

--- a/crates/nucleus-tool-proxy/src/run_gate.rs
+++ b/crates/nucleus-tool-proxy/src/run_gate.rs
@@ -116,13 +116,60 @@ pub(crate) fn preflight_web(
     )
 }
 
-/// Shared term-builder + preflight for the sealed live paths (RunBash spawn and
-/// net egress). Feeds the discharge [`ActionTerm`](discharge::ActionTerm) the
-/// session's REAL IFC labels + content hashes (never fabricated defaults) and
-/// the honest no-escalation ceiling (`requested == ceiling`), then runs
-/// [`preflight_action`]. `operation`/`sink_class` select which effect class the
-/// obligations are minted for; everything else is identical across the two
-/// callers so the fail-closed guarantees cannot drift between them.
+/// The sealed discharge preflight for the live agent FILESYSTEM-WRITE path
+/// (`write_file`, B6).
+///
+/// The fs analogue of [`preflight_runbash`]/[`preflight_web`]: builds the
+/// discharge [`ActionTerm`](discharge::ActionTerm) for the given fs-write
+/// `operation` ([`Operation::WriteFiles`] or [`Operation::EditFiles`]) at the
+/// [`SinkClass::WorkspaceWrite`] sink and runs [`preflight_action`]. Returning
+/// [`PreflightResult::Allowed`] hands back the sealed [`DischargedBundle`] the
+/// handler must present to the `_proof`-gated
+/// [`Sandbox::write`](nucleus::Sandbox) — there is no other way to construct
+/// that bundle, so an un-preflighted agent fs write is a compile-time-checked
+/// impossibility, closing the last agent effect class (spawn ✓, net ✓, fs ✓).
+///
+/// Fail-closed / no-vacuous-witness — identical structure to the RunBash and net
+/// gates:
+/// - `verified_scope == None` (session token `Missing`/`Invalid`) ⇒
+///   `InScopeWithTask` DENIES (we pass `None` straight through);
+/// - fs op ∉ `scope.allowed_operations` ⇒ `InScopeWithTask` DENIES.
+///
+/// On the integrity axis `WorkspaceWrite` has a `sink_min_integrity` of
+/// `Adversarial` (the floor, like `BashExec`), so any session integrity passes
+/// and `InScopeWithTask` is the discriminating gate — this brick is
+/// class-coverage for the fs-write effect, not a new integrity constraint. The
+/// cap-std root confinement enforced inside `Sandbox::write` is retained and
+/// unchanged (dual-stack).
+pub(crate) fn preflight_fs(
+    operation: Operation,
+    verified_scope: Option<&TokenScope>,
+    fs_ceiling: CapabilityLevel,
+    subject: &str,
+    flow: &FlowTracker,
+) -> PreflightResult {
+    debug_assert!(
+        matches!(operation, Operation::WriteFiles | Operation::EditFiles),
+        "preflight_fs is only for the filesystem-write operations",
+    );
+    preflight_scoped(
+        operation,
+        SinkClass::WorkspaceWrite,
+        verified_scope,
+        fs_ceiling,
+        subject,
+        flow,
+    )
+}
+
+/// Shared term-builder + preflight for the sealed live paths (RunBash spawn, net
+/// egress, and filesystem write). Feeds the discharge
+/// [`ActionTerm`](discharge::ActionTerm) the session's REAL IFC labels + content
+/// hashes (never fabricated defaults) and the honest no-escalation ceiling
+/// (`requested == ceiling`), then runs [`preflight_action`].
+/// `operation`/`sink_class` select which effect class the obligations are minted
+/// for; everything else is identical across the three callers so the fail-closed
+/// guarantees cannot drift between them.
 fn preflight_scoped(
     operation: Operation,
     sink_class: SinkClass,
@@ -277,5 +324,96 @@ mod tests {
                 "bundle must carry the InScopeWithTask witness"
             );
         }
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Tests — the live FILESYSTEM-WRITE discharge gate (B6)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    // `preflight_fs` is the sole precondition standing between a write_file
+    // request and the `_proof`-gated `Sandbox::write`: the handler only reaches
+    // the write past its `Allowed` arm. Anything else means the handler returns
+    // its error early and NEVER writes. A clean session (`FlowTracker::new()`) is
+    // used so `WorkspaceWrite`'s Adversarial-floor integrity is met and
+    // `InScopeWithTask` is the discriminating gate. Exact ceiling is immaterial
+    // (`requested == ceiling`).
+    const FS_CEILING: CapabilityLevel = CapabilityLevel::LowRisk;
+
+    // (a) Missing/Invalid session token ⇒ verified_scope() is None ⇒ DENY
+    //     fail-closed (no-vacuous-witness) ⇒ no write.
+    #[test]
+    fn fs_denies_when_session_token_missing_or_invalid() {
+        let flow = FlowTracker::new();
+        let result = preflight_fs(
+            Operation::WriteFiles,
+            None,
+            FS_CEILING,
+            "/workspace/out.txt",
+            &flow,
+        );
+        assert!(
+            result.is_denied(),
+            "no verified scope must DENY WriteFiles (fail-closed), got {result:?}"
+        );
+        assert!(
+            result.denial_reason().unwrap().contains("InScopeWithTask"),
+            "denial must be the InScopeWithTask no-vacuous-witness guard: {result:?}"
+        );
+        assert!(!result.is_allowed(), "must not mint a bundle ⇒ no write");
+    }
+
+    // (b) A verified token whose scope does NOT include WriteFiles ⇒
+    //     InScopeWithTask DENIES ⇒ no write.
+    #[test]
+    fn fs_denies_when_out_of_token_scope() {
+        let flow = FlowTracker::new();
+        // Verified, but WriteFiles ∉ allowed_operations.
+        let scope = TokenScope::new(
+            vec![Operation::ReadFiles, Operation::RunBash],
+            vec!["/workspace/**".to_string()],
+        );
+        let result = preflight_fs(
+            Operation::WriteFiles,
+            Some(&scope),
+            FS_CEILING,
+            "/workspace/out.txt",
+            &flow,
+        );
+        assert!(
+            result.is_denied(),
+            "WriteFiles out of token scope must DENY, got {result:?}"
+        );
+        assert!(
+            result.denial_reason().unwrap().contains("InScopeWithTask"),
+            "denial must be InScopeWithTask: {result:?}"
+        );
+        assert!(!result.is_allowed(), "must not mint a bundle ⇒ no write");
+    }
+
+    // (c) A verified, in-scope token on a clean session ⇒ ALLOW and mint the
+    //     sealed `DischargedBundle` ⇒ the handler proceeds to the sealed write.
+    #[test]
+    fn fs_succeeds_with_valid_in_scope_token() {
+        let flow = FlowTracker::new();
+        let scope = TokenScope::new(
+            vec![Operation::WriteFiles],
+            vec!["/workspace/**".to_string()],
+        );
+        let result = preflight_fs(
+            Operation::WriteFiles,
+            Some(&scope),
+            FS_CEILING,
+            "/workspace/out.txt",
+            &flow,
+        );
+        assert!(
+            result.is_allowed(),
+            "valid in-scope token must ALLOW WriteFiles (reach write), got {result:?}"
+        );
+        let bundle = result.unwrap_bundle();
+        assert!(
+            discharge_witness(&bundle).contains("in_scope_with_task"),
+            "bundle must carry the InScopeWithTask witness"
+        );
     }
 }

--- a/crates/nucleus-tool-proxy/tests/red_team_harness.rs
+++ b/crates/nucleus-tool-proxy/tests/red_team_harness.rs
@@ -39,6 +39,8 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use nucleus::Sandbox;
+// Sanctioned test-only sealed bundle for the `_proof`-gated `Sandbox::write` (B6).
+use nucleus_ifc_kernel::discharge::test_helpers::allowed_bundle;
 use portcullis::kernel::Kernel;
 use portcullis::{
     CapabilityLevel, ExecuteError, GradedExposureGuard, Operation, PermissionLattice, StateRisk,
@@ -415,9 +417,17 @@ impl ToolDispatcher {
             kernel.issue_approved_token(Operation::WriteFiles, &format!("write {path}"))
         };
 
+        // B6: `Sandbox::write` is `_proof`-gated. This red-team harness models a
+        // handler that has already passed the discharge preflight, so it earns a
+        // sanctioned test-only bundle (WriteFiles/WorkspaceWrite term).
+        let discharge_bundle = allowed_bundle();
         match self.guard.execute_and_record(proof, || {
-            self.sandbox
-                .write(path, contents.as_bytes(), &decision_token)
+            self.sandbox.write(
+                path,
+                contents.as_bytes(),
+                &decision_token,
+                &discharge_bundle,
+            )
         }) {
             Ok(()) => ("ok".into(), false),
             Err(ExecuteError::OperationFailed(e)) => (format!("BLOCKED by sandbox: {e}"), true),

--- a/crates/nucleus-tool-proxy/tests/roguepilot_integration.rs
+++ b/crates/nucleus-tool-proxy/tests/roguepilot_integration.rs
@@ -14,6 +14,10 @@
 //! Closes: #102, #103
 
 use nucleus::Sandbox;
+// Sanctioned test-only sealed bundle for the `_proof`-gated `Sandbox::write`
+// (B6): the constructor is private to discharge, so tests earn a bundle via a
+// real `preflight_action` on a known-good WriteFiles/WorkspaceWrite term.
+use nucleus_ifc_kernel::discharge::test_helpers::allowed_bundle;
 use portcullis::kernel::{DecisionToken, Kernel};
 use portcullis::{
     CapabilityLevel, ExposureLabel, ExposureSet, GradedExposureGuard, Operation, PermissionLattice,
@@ -160,7 +164,12 @@ fn test_symlink_write_blocked() {
     // Write via symlink should fail (kernel may gate via obligations, so force token
     // to test sandbox-level cap-std symlink defense)
     let tok = kernel.issue_approved_token(Operation::WriteFiles, "test: symlink write");
-    let result = sandbox.write("write_escape.txt", b"OVERWRITTEN_BY_ATTACKER", &tok);
+    let result = sandbox.write(
+        "write_escape.txt",
+        b"OVERWRITTEN_BY_ATTACKER",
+        &tok,
+        &allowed_bundle(),
+    );
     assert!(
         result.is_err(),
         "symlink write should be blocked: {:?}",

--- a/crates/nucleus/src/sandbox.rs
+++ b/crates/nucleus/src/sandbox.rs
@@ -33,6 +33,7 @@ use std::sync::Arc;
 
 use crate::approval::{ApprovalRequest, ApprovalToken, Approver, CallbackApprover};
 use crate::error::{NucleusError, Result};
+use nucleus_ifc_kernel::discharge::DischargedBundle;
 use portcullis::kernel::DecisionToken;
 use portcullis::{
     CapabilityLattice, CapabilityLevel, Obligations, Operation, PathLattice, PermissionLattice,
@@ -328,11 +329,39 @@ impl Sandbox {
     }
 
     /// Write bytes to a file (creates if needed, truncates if exists).
+    ///
+    /// Requires a `&DischargedBundle` proof (mint via
+    /// [`preflight_action`](nucleus_ifc_kernel::discharge::preflight_action),
+    /// e.g. the tool-proxy's `run_gate::preflight_fs`). This makes the
+    /// FILESYSTEM-WRITE effect class a *compile*-checked precondition — parity
+    /// with the spawn executor-proof gate ([`Executor::run_args`](crate::Executor)
+    /// and the net [`NetEffect::fetch`]) — so an un-preflighted fs write cannot be
+    /// typed. The existing `DecisionToken` and cap-std root confinement are
+    /// retained (dual-stack, additive): the proof does not replace them. The
+    /// bundle is a sealed 8-witness proof that only `preflight_action` can mint;
+    /// there is no other constructor, so a caller that reaches this method has
+    /// necessarily passed the fail-closed discharge preflight.
+    ///
+    /// The following omits the proof and does **not** compile (mirrors the
+    /// sealed-bundle `compile_fail` doctest in `nucleus_ifc_kernel::discharge`
+    /// and the spawn gate in `command.rs`):
+    ///
+    /// ```compile_fail
+    /// use nucleus::Sandbox;
+    /// use nucleus::portcullis::kernel::DecisionToken;
+    ///
+    /// fn un_preflighted_write(sandbox: &Sandbox, dt: &DecisionToken) {
+    ///     // No trailing `&DischargedBundle` — the sealed proof is missing, so
+    ///     // this call cannot be typed. There is no way to write without one.
+    ///     let _ = sandbox.write("out.txt", b"data", dt);
+    /// }
+    /// ```
     pub fn write(
         &self,
         path: impl AsRef<Path>,
         contents: impl AsRef<[u8]>,
         decision: &DecisionToken,
+        _proof: &DischargedBundle,
     ) -> Result<()> {
         debug_assert_eq!(
             decision.operation(),
@@ -343,12 +372,18 @@ impl Sandbox {
     }
 
     /// Write bytes to a file with an approval token.
+    ///
+    /// The approval-elevated sibling of [`Self::write`]; it is behind the same
+    /// FILESYSTEM-WRITE effect gate and requires a `&DischargedBundle` proof in
+    /// addition to the `ApprovalToken` (parity with
+    /// [`Executor::run_args_with_approval`](crate::Executor)).
     pub fn write_approved(
         &self,
         path: impl AsRef<Path>,
         contents: impl AsRef<[u8]>,
         decision: &DecisionToken,
         approval: &ApprovalToken,
+        _proof: &DischargedBundle,
     ) -> Result<()> {
         debug_assert_eq!(
             decision.operation(),
@@ -746,6 +781,10 @@ impl Sandbox {
 #[cfg(test)]
 mod tests {
     use super::*;
+    // Sanctioned test-only sealed bundle (WriteFiles/WorkspaceWrite term) — the
+    // only supported way for a test to obtain a `DischargedBundle` for the
+    // `_proof`-gated write path (the constructor is private to discharge).
+    use nucleus_ifc_kernel::discharge::test_helpers::allowed_bundle;
     use portcullis::kernel::Kernel;
     use tempfile::tempdir;
 
@@ -785,7 +824,9 @@ mod tests {
 
         // Write a file
         let wt = token(&mut kernel, Operation::WriteFiles, "test.txt");
-        sandbox.write("test.txt", b"hello world", &wt).unwrap();
+        sandbox
+            .write("test.txt", b"hello world", &wt, &allowed_bundle())
+            .unwrap();
 
         // Read it back
         let rt = token(&mut kernel, Operation::ReadFiles, "test.txt");
@@ -807,13 +848,15 @@ mod tests {
         // running inside a git worktree. This test exercises the *sandbox*'s
         // path policy, not the kernel's.
         let wt = kernel.issue_approved_token(Operation::WriteFiles, "test: write normal file");
-        sandbox.write("normal_file.txt", b"# Hello", &wt).unwrap();
+        sandbox
+            .write("normal_file.txt", b"# Hello", &wt, &allowed_bundle())
+            .unwrap();
 
         // Should block .env files (sandbox policy blocks it; kernel also blocks via PathLattice)
         // Force a token to test the sandbox's own path policy enforcement
         let wt2 =
             kernel.issue_approved_token(Operation::WriteFiles, "test: .env blocked by sandbox");
-        let result = sandbox.write(".env", b"SECRET=foo", &wt2);
+        let result = sandbox.write(".env", b"SECRET=foo", &wt2, &allowed_bundle());
         assert!(result.is_err());
     }
 
@@ -898,7 +941,9 @@ mod tests {
         sandbox.create_dir("subdir", &wt1).unwrap();
 
         let wt2 = token(&mut kernel, Operation::WriteFiles, "subdir/file.txt");
-        sandbox.write("subdir/file.txt", b"nested", &wt2).unwrap();
+        sandbox
+            .write("subdir/file.txt", b"nested", &wt2, &allowed_bundle())
+            .unwrap();
 
         // Open as sub-sandbox
         let rt1 = token(&mut kernel, Operation::ReadFiles, "subdir");


### PR DESCRIPTION
B6 of the North Star terminal push. Makes the agent **filesystem-write** class require the sealed `DischargedBundle` — so **every** agent effect class (spawn ✓, net ✓, fs ✓) is now type-enforced. FS is already `cap_std` object-capability-confined (0 raw `std::fs` on the agent path), so this is **class-coverage, additive** — no relocation, no raw-count/allowlist change.

- `Sandbox::write` and `write_approved` gain a trailing `_proof: &DischargedBundle` (compile-time-only token), **alongside** the existing `DecisionToken` + cap-std `Dir`-root confinement (dual-stack). An un-preflighted fs write is now a **compile error**, like spawn/net.
- **Mint + gate in the handlers:** `run_gate::preflight_fs` (reuses B5's shared `preflight_scoped` at `Operation::WriteFiles` / `SinkClass::WorkspaceWrite`). Fail-closed: Missing/Invalid session token → `verified_scope: None` → `InScopeWithTask` DENY; out-of-scope op DENY. `write_file` (HTTP) + `write` (MCP) mint and pass `&bundle`; deny → `IfcDenied`/`err_result`, **no write**.
- Every in-repo `Sandbox::write` caller updated (handlers mint; tests use `allowed_bundle()`). Also gated `write_approved` (approval sibling) to match the spawn precedent (`run_args` + `run_args_with_approval`).

**Green (`--all-features` + 1.93 enforced):** build/clippy `--all-features` clean; `cargo +1.93 check --workspace --all-features --locked` clean; nucleus + tool-proxy tests (mcp + default) green; `fmt`/mediation(spawn+net)/verify-strict/ingest gates PASSED unchanged. New: `preflight_fs` deny/succeed/out-of-scope tests + the `Sandbox::write` **compile-fail doctest** (a write without a bundle doesn't compile). cap-std confinement retained (roguepilot symlink/traversal tests still pass).

**Note:** no `edit_file` handler exists in the tool-proxy (only `write_file` HTTP + `write` MCP, both `WriteFiles`); `preflight_fs` accepts `EditFiles` for future parity.

Next: B7 — the terminal certificate (the single machine-checkable stop condition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CNJdZb7LHWwXkrt9MCa8CG