### PR TITLE
ci+docs: sealed-home integrity gate + North Star terminal certificate (terminal-push B7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,15 @@ jobs:
       - name: Forbid non-hashing agent-path ingest observes (content-address every input)
         run: scripts/check-ingest-hashed.sh
 
+  sealed-home-gate:
+    name: Sealed-home integrity gate (North Star)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+      - name: Forbid raw effect primitives outside the sealed RealEffects home
+        run: scripts/check-sealed-home.sh
+
   clippy:
     name: Clippy
     runs-on: ubuntu-latest

--- a/reviews/north-star-certificate.md
+++ b/reviews/north-star-certificate.md
@@ -1,0 +1,189 @@
+# North Star terminal certificate
+
+The honest, machine-checkable stop condition for the North Star terminal push.
+This document names the invariant, the exact set of CI assertions that together
+mean DONE, the PR trail that is the audit record, and the caveats that keep the
+claim honest. It is a point-in-time certificate, not a build input.
+
+---
+
+## The invariant
+
+> **An unmediated external effect is unconstructable.**
+
+A consequential agent effect — process spawn (sync and async), network egress,
+filesystem write — cannot be performed without first passing the fail-closed
+discharge preflight (`portcullis_core` / `nucleus_ifc_kernel::discharge` →
+`preflight_action` → a sealed `DischargedBundle`). This is now **type-enforced on
+the live agent path**: every sealed effect fn takes a trailing
+`_proof: &DischargedBundle`, the bundle has no constructor other than a
+successful preflight, and every raw effect primitive has been relocated behind
+that gate into a single sealed home. An un-preflighted effect is a **compile
+error**, not a runtime check.
+
+The claim this certificate makes is precise: **the structural invariant is closed
+and ratcheted.** It is NOT "the system is secure" (see caveats).
+
+---
+
+## The machine-checkable certificate
+
+DONE ≡ all six assertions below hold simultaneously. Each maps to the concrete
+gate or test that enforces it. All are wired into `.github/workflows/ci.yml`.
+
+### (i) Mediation gate green — spawn allowlist EMPTY, net infra-only
+- **Enforces:** no raw agent-path effect primitive bypasses the discharge-gated
+  effect API.
+- **Gate:** `scripts/check-mediation.sh` (CI job `mediation-gate`), scoped to the
+  agent effect path (`crates/nucleus/src`, `crates/nucleus-tool-proxy/src`,
+  `crates/nucleus-mcp/src`).
+- **State:** `scripts/mediation-allowlist.txt` (spawn) is **EMPTY** — every
+  agent-path process spawn has been relocated; a new one fails with nothing to
+  allowlist it. `scripts/mediation-net-allowlist.txt` exempts only INFRA egress,
+  by-file (`node_client.rs` control plane) and by-line (audit S3 / webhook
+  operator sinks) — no agent session/token.
+
+### (ii) No raw agent-path spawn/net primitive (the repo grep)
+- **Enforces:** the same as (i), stated as a raw-primitive grep: `Command::new`
+  (subsumes sync `std::process` and async `tokio::process`) and reqwest
+  `.send()` do not appear on the agent path outside the sealed API.
+- **Gate:** `scripts/check-mediation.sh` — it IS the repo grep (literal-match,
+  `#[cfg(test)]`-stripped).
+
+### (iii) Every effect class unconstructable without a `DischargedBundle`
+- **Enforces:** the type-level gate for each effect class. Verified by
+  `cargo test --doc` (the `compile_fail` doctests) and `cargo build` (the fn
+  signatures that require the proof).
+- **`compile_fail` doctests (named):**
+  - **Sealed-bundle seal** — `nucleus_ifc_kernel::discharge`, on
+    `DischargedBundle` (`crates/nucleus-ifc-kernel/src/discharge.rs`): no external
+    struct literal compiles (the `_seal` field is private and `Discharged::mint()`
+    is private), so the bundle is unconstructable except via `preflight_action`.
+  - **Sync spawn** — `nucleus::Executor::run_args`
+    (`crates/nucleus/src/command.rs`): the doctest omits the trailing
+    `&DischargedBundle` and does **not** compile.
+  - **Filesystem write** — `nucleus::Sandbox::write`
+    (`crates/nucleus/src/sandbox.rs`): the doctest omits the proof and does
+    **not** compile.
+- **Async spawn + net (type-level, by signature — no dedicated doctest):**
+  - **Async spawn** — `Executor::run_with_timeout` / `run_with_timeout_approved`
+    and the sealed home `AsyncShellSpawnEffect::run_argv_async` all require
+    `proof: &DischargedBundle`; the trait's `async fn` is not dyn-compatible, so
+    the concrete `PolicyEnforced<RealEffects>` handle is the only reachable path
+    and it still demands the bundle.
+  - **Net** — `NetEffect::fetch` requires `_proof: &DischargedBundle`; the
+    tool-proxy web_fetch/web_search handlers must mint the bundle
+    (`preflight_web`) before they may call it.
+  These two are the SAME compile-time guarantee as the doctests (the bundle in
+  the signature is unconstructable per the seal doctest above), enforced by the
+  signature rather than by a dedicated `compile_fail` block.
+
+### (iv) Ingest gate green (content-addressing)
+- **Enforces:** every agent-path input observe is content-addressed (hashed) at
+  ingest — the `InputsAuthorized` obligation has real evidence to discharge
+  against.
+- **Gate:** `scripts/check-ingest-hashed.sh` (CI job `ingest-hash-gate`).
+
+### (v) `DischargedBundle` proves 8/8 obligations
+- **Enforces:** the sealed bundle carries a typed witness for **all eight** policy
+  obligations; `preflight_action` mints it only when every one discharges.
+- **The eight** (`crates/nucleus-ifc-kernel/src/discharge.rs`): `IntegrityGate`,
+  `PathAllowed`, `DerivationClear`, `NoAdversarialAncestry`, `BudgetNotExceeded`,
+  `WithinDelegationCeiling`, `InScopeWithTask`, `InputsAuthorized`.
+
+### (vi) Sealed-home integrity gate green (this brick, B7)
+- **Enforces:** the relocation did not open a NEW hole — inside the sealed home
+  crate `crates/portcullis-effects/src`, a raw effect primitive
+  (`Command::new` / reqwest `.send()`) appears ONLY on the known sealed-home
+  lines. A new helper fn, method, or second sink is an un-gated leak and fails
+  the build.
+- **Gate:** `scripts/check-sealed-home.sh` + `scripts/sealed-home-allowlist.txt`
+  (CI job `sealed-home-gate`). The allowlist is the exact trimmed source lines of
+  the raw primitives inside `impl … for RealEffects` (the crate's sole
+  I/O-capable, externally-unconstructable type): the three `_proof`-gated
+  sealed-fn sites (`run_argv`, `run_argv_async`, `fetch`) plus the pre-existing
+  policy-gated `ShellEffect::run` and `GitEffect::{commit, push}` legacy methods.
+
+Gates (i), (iv), (vi) are the complementary pair-plus: (i) proves the agent
+crates are clean; (vi) proves the sealed home they relocated INTO is clean; (iv)
+proves inputs are witnessed. Together with the type-level gates (iii)/(v) they
+close the loop.
+
+---
+
+## The PR trail (audit record)
+
+The North Star push, in order. #2029 opened the backstop; this brick (B7) closes
+and certifies it.
+
+| PR | Brick | What it landed |
+|----|-------|----------------|
+| #2029 | brick 0 | Mediation backstop gate — forbid raw agent-path spawns |
+| #2030 | Focus-A brick 1 | Obligation-vocabulary reconciliation spec |
+| #2033 | — | Thread verified `TaskRef` capability tokens into `NucleusRuntime` |
+| #2035 | WIDEN PR-B | Widen sealed `DischargedBundle` 5 → 7 obligations |
+| #2038 | — | Gate live `RunBash` on the sealed 7-witness `DischargedBundle` |
+| #2039 | — | Route all three sync Executor spawns through `spawn_checked` |
+| #2040 | PR-2 | Gate the sync Executor spawn on a `&DischargedBundle` proof |
+| #2041–#2044 | InputsAuthorized 1–5 | Content-address agent inputs; ingest ratchet gate; widen bundle 7 → 8 with `InputsAuthorized` |
+| #2045 | B1 | Widen `ShellEffect` with the sealed `run_argv` spawn (sealed home) |
+| #2046 | B2 | Relocate sync Executor spawn into the sealed home — delete allowlist entry 1 |
+| #2047 | B3 | Relocate async Executor spawn into the sealed home — delete allowlist entry 2 |
+| #2048 | B4 | Reclassify mcp-guard spawn as infra — spawn allowlist now EMPTY |
+| #2049 | B5 | Relocate agent NET egress behind the sealed `_proof` effect + net mediation gate |
+| #2050 | B6 | Gate agent FILESYSTEM-WRITE behind the sealed `_proof` `DischargedBundle` |
+| this | **B7** | **Sealed-home integrity gate + this terminal certificate** |
+
+---
+
+## Honest caveats (do NOT overclaim)
+
+- **Dual-stack, not replacement.** The sealed `DischargedBundle` runs
+  ALONGSIDE the legacy kernel/guard (the existing `DecisionToken` and cap-std
+  root confinement are retained, additive). The proof does not yet replace them;
+  consolidating to a single stack is deferred to Focus-C.
+- **`WithinDelegationCeiling` is dormant.** It is a real obligation in the 8/8
+  bundle, but on the current wiring requested == ceiling, so its check does not
+  yet constrain anything. It is a placeholder discharged trivially today.
+- **Base discharge checks are vacuous on a clean session.** The obligation checks
+  are wired to real taint/flow evidence and BITE on an adversarial session, but
+  on a clean session with no adversarial ancestry / no budget pressure they
+  discharge trivially. The guarantee is "fail-closed structure," not "proven
+  non-vacuous on every input."
+- **Net infra is exempted by-file/by-line.** The mediation net gate permits infra
+  egress (control-plane `node_client.rs`; audit S3 / webhook operator sinks) —
+  operator/host authority, no agent session/token. These are permanent
+  exemptions, not shrinking debt.
+- **Filesystem is 0-raw via cap-std, bundle-gated — not relocated.** The fs write
+  path is confined by cap-std (0 raw `std::fs` on the agent write path) and gated
+  on the `DischargedBundle` at `Sandbox::write`; it was not relocated into
+  `RealEffects` the way spawn/net were.
+- **mcp-guard reclassified as infra.** `nucleus-mcp-guard`'s one spawn launches
+  the downstream MCP server named on the operator's guard CLI (operator-provided,
+  never agent-controlled), so it is infra, not an agent effect. It is out of the
+  mediation gate's scope. Re-scope it if it ever spawns from an agent-controlled
+  value.
+- **Kani-pinned MSRV floor 1.93.** The workspace `rust-version` is pinned to 1.93
+  because `cargo kani`'s bundled nightly (kani-verifier 0.67.0) is rustc 1.93 and
+  has no `--ignore-rust-version`. The BMC job would refuse to compile above it.
+  Raise only when Kani's bundled nightly catches up.
+
+**The claim, stated plainly:** the structural invariant ("an unmediated external
+effect is unconstructable") is **closed and ratcheted** on the live agent path.
+This is a statement about structure and enforcement — NOT a claim that the system
+is secure.
+
+---
+
+## What remains — Focus-C (human-elective, not North-Star-terminating)
+
+None of the following blocks the terminal certificate above; they are elective
+follow-ups.
+
+- **Dual-stack consolidation** — collapse the sealed bundle and the legacy
+  kernel/guard into a single stack.
+- **The recurring `git_commit_allowed_by_codegen_profile` test-footgun** — a
+  recurring flaky/footgun test to stabilize.
+- **Open audit findings C-3 / C-4 / #16.**
+- **SPIFFE binding.**
+- **Unreadable-nonce hardening.**

--- a/scripts/check-sealed-home.sh
+++ b/scripts/check-sealed-home.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# North Star sealed-home INTEGRITY gate (terminal-push B7).
+#
+# The migration relocated every raw agent-path effect primitive OUT of the agent
+# crates and INTO the single sealed home `RealEffects` in portcullis-effects,
+# where it is legitimate because the sealed fn is reached only PAST a minted
+# `DischargedBundle` (`_proof: &DischargedBundle`) and the `PolicyEnforced` gate.
+# The mediation gate (check-mediation.sh) proves the agent crates are CLEAN; it
+# DELIBERATELY EXCLUDES portcullis-effects (the sealed home is where raw
+# primitives are allowed to live). This gate is the COMPLEMENT: it guards the
+# sealed home itself, so the relocation did not silently open a NEW hole.
+#
+# Invariant: inside `crates/portcullis-effects/src`, a raw effect primitive may
+# appear ONLY on the exact known sealed-home lines (the allowlist). A NEW raw
+# primitive anywhere else in portcullis-effects — a free helper fn, a new method,
+# a second reqwest sink — is an UN-GATED leak (it bypasses the `_proof` gate that
+# only the sealed `RealEffects::{run_argv, run_argv_async, fetch}` fns carry) and
+# FAILS the build. The allowlist only shrinks or holds; it never grows without a
+# reviewer consciously blessing a new sealed-home line.
+#
+# TWO patterns are enforced (mirrors check-mediation.sh exactly):
+#   * SPAWN — the literal `Command::new`. This subsumes BOTH the sync
+#     `std::process::Command::new` and the async `tokio::process::Command::new`
+#     (both contain the substring `Command::new`); the bare
+#     `Fn(&mut tokio::process::Command)` harden-hook type signatures do NOT
+#     contain `Command::new`, so they never match.
+#   * NET   — the reqwest `RequestBuilder::send()` egress (`.send()` with EMPTY
+#     parens). Channel/other sends carry a message argument (`.send(msg)`) and are
+#     not matched.
+#
+# Scope = the sealed home ONLY: `crates/portcullis-effects/src`. `#[cfg(test)]`
+# blocks and comment lines are stripped (brace-balanced cfg(test) AWK, literal
+# index match — identical to check-mediation.sh).
+#
+# Allowlist = scripts/sealed-home-allowlist.txt: the exact TRIMMED source lines
+# of the known sealed-home raw primitives inside `impl … for RealEffects`
+# (the crate's sole I/O-capable, externally-unconstructable type). See that file
+# for the per-line site map.
+#
+# Usage: scripts/check-sealed-home.sh
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel 2>/dev/null || echo .)"
+
+ALLOWLIST="scripts/sealed-home-allowlist.txt"
+
+# In-scope = the sealed home. A raw effect primitive here is legitimate ONLY on
+# an allowlisted RealEffects sealed-home line; anywhere else it is an un-gated
+# leak that bypasses the `_proof` gate.
+SCOPE_DIRS=(crates/portcullis-effects/src)
+
+# AWK: emit `path:lineno:code` for each production line (outside any #[cfg(test)]
+# block) that contains the literal PAT. Brace-balanced cfg(test) stripping; skip
+# comment lines. Literal (index-based) match so PAT needs no regex escaping.
+read -r -d '' AWK_PROG <<'AWK' || true
+BEGIN { skip=0; brace=0; pending=0 }
+{
+    line=$0
+    tmp=line; no=gsub(/\{/,"{",tmp)
+    tmp=line; nc=gsub(/\}/,"}",tmp)
+    if (skip==1) { brace += no - nc; if (brace <= 0) { skip=0; brace=0 } next }
+    if (line ~ /#\[cfg\(test\)\]/) { pending=1; next }
+    if (pending==1) {
+        if (no>0) {                       # block body starts on this line
+            skip=1; brace = no - nc; pending=0
+            if (brace <= 0) { skip=0; brace=0 }
+            next
+        }
+        # cfg(test) on a non-block item (`mod tests;`, `use ...;`): no block to
+        # skip — clear pending so it does not swallow the next braced item.
+        if (line ~ /;/) { pending=0 }
+    }
+    stripped=line; sub(/^[[:space:]]+/,"",stripped)
+    if (stripped ~ /^\/\//) { next }
+    if (index(line, PAT) > 0) { printf "%s:%d:%s\n", FILENAME, FNR, line }
+}
+AWK
+
+# Loaded per-pattern by load_allowlist:
+allow_snippets=()   # exact TRIMMED-line snippets permitted to carry the primitive
+allow_files=()      # whole-file exemptions (repo-relative paths)
+
+load_allowlist() {
+    local f="$1" line trimmed
+    allow_snippets=()
+    allow_files=()
+    [[ -f "$f" ]] || return 0
+    while IFS= read -r line; do
+        trimmed="${line#"${line%%[![:space:]]*}"}"
+        trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
+        [[ -z "$trimmed" ]] && continue
+        [[ "$trimmed" == \#* ]] && continue
+        if [[ "$trimmed" == file:* ]]; then
+            allow_files+=("${trimmed#file:}")
+        else
+            allow_snippets+=("$trimmed")
+        fi
+    done < "$f"
+}
+
+# List in-scope .rs files containing the literal PAT, excluding tests/benches
+# directories (never the sealed runtime path).
+list_files() {
+    local pat="$1"
+    if command -v rg >/dev/null 2>&1; then
+        rg -l -F --glob '*.rs' "$pat" "${SCOPE_DIRS[@]}"
+    else
+        grep -rlF --include='*.rs' "$pat" "${SCOPE_DIRS[@]}"
+    fi | grep -vE '/(tests|benches)/' || true
+}
+
+# Run one pattern; sets the global FAILED on any un-allowlisted hit.
+run_pattern() {
+    local pat="$1" label="$2" allowfile="$3"
+    load_allowlist "$allowfile"
+
+    local hits=() f rec code trimmed snip af allowed
+    while IFS= read -r f; do
+        [[ -z "$f" ]] && continue
+        # Whole-file exemption (unused by default — the sealed home is scanned
+        # in full; kept for structural parity with check-mediation.sh).
+        allowed=0
+        for af in "${allow_files[@]:-}"; do
+            [[ -z "$af" ]] && continue
+            if [[ "$f" == "$af" || "$f" == */"$af" ]]; then allowed=1; break; fi
+        done
+        [[ "$allowed" -eq 1 ]] && continue
+
+        while IFS= read -r rec; do
+            [[ -z "$rec" ]] && continue
+            code="${rec#*:*:}"
+            trimmed="${code#"${code%%[![:space:]]*}"}"
+            trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
+            allowed=0
+            for snip in "${allow_snippets[@]:-}"; do
+                [[ -z "$snip" ]] && continue
+                [[ "$trimmed" == "$snip" ]] && { allowed=1; break; }
+            done
+            [[ "$allowed" -eq 1 ]] && continue
+            hits+=("$rec")
+        done < <(awk -v PAT="$pat" "$AWK_PROG" "$f")
+    done < <(list_files "$pat")
+
+    if [[ "${#hits[@]}" -gt 0 ]]; then
+        echo "sealed-home gate FAILED ($label): raw effect primitive in portcullis-effects OUTSIDE the sealed RealEffects home:" >&2
+        printf '  %s\n' "${hits[@]}" >&2
+        echo >&2
+        FAILED=1
+        return 0
+    fi
+    echo "sealed-home gate PASSED ($label): every raw primitive is on a known sealed-home line."
+}
+
+FAILED=0
+run_pattern 'Command::new' 'spawn' "$ALLOWLIST"
+# `.send()` with EMPTY parens is the reqwest `RequestBuilder::send()` egress
+# signature; channel/other sends carry a message argument (`.send(msg)`) and are
+# not matched, so the net pattern isolates HTTP egress without false positives.
+run_pattern '.send()' 'net' "$ALLOWLIST"
+
+if [[ "$FAILED" -ne 0 ]]; then
+    echo >&2
+    echo "Fix: a raw effect primitive may live in portcullis-effects ONLY inside the sealed" >&2
+    echo "RealEffects home (run_argv / run_argv_async / fetch — reached past a minted" >&2
+    echo "&DischargedBundle and the PolicyEnforced gate). A NEW raw Command::new / reqwest" >&2
+    echo ".send() elsewhere in the crate is an un-gated leak. Either route it through an" >&2
+    echo "existing sealed fn, or (if it is a genuine new sealed-home line) add the exact" >&2
+    echo "TRIMMED line to scripts/sealed-home-allowlist.txt with a site-map comment." >&2
+    exit 1
+fi
+
+echo "sealed-home gate PASSED: no raw effect primitive outside the sealed RealEffects home (spawn + net)."

--- a/scripts/sealed-home-allowlist.txt
+++ b/scripts/sealed-home-allowlist.txt
@@ -1,0 +1,53 @@
+# North Star sealed-home INTEGRITY allowlist (terminal-push B7).
+#
+# The exact TRIMMED source lines where a raw effect primitive (`Command::new`,
+# reqwest `.send()`) legitimately lives inside the sealed home — every one is a
+# method of `RealEffects` in crates/portcullis-effects/src/lib.rs, the crate's
+# SOLE I/O-capable type (unconstructable outside the crate; only ever handed out
+# wrapped in `PolicyEnforced`, which checks the capability policy on every call).
+# check-sealed-home.sh FAILS on any `Command::new` / `.send()` in
+# portcullis-effects that is NOT one of these lines — i.e. a new helper, a new
+# fn, or a second sink that would bypass the sealed `_proof` gate.
+#
+# Format: exact TRIMMED source line (leading/trailing whitespace removed).
+# `file:<path>` whole-file exemptions are supported by the gate but intentionally
+# UNUSED here — the sealed home is scanned in full.
+#
+# ── THE _proof-GATED SEALED-FN SITES (the relocated agent effect path) ─────────
+# These three fns take a trailing `_proof: &DischargedBundle`: they are reached
+# ONLY past a minted 8-witness bundle (`preflight_action`) and the PolicyEnforced
+# gate. They ARE the sealed home the migration built (bricks B1/B2/B3/B5).
+#
+# ShellEffect::run_argv for RealEffects — the relocated SYNC agent spawn (B1/B2).
+# (was Executor::spawn_checked's raw std::process::Command::new).
+let mut cmd = Command::new(program);
+#
+# AsyncShellSpawnEffect::run_argv_async for RealEffects — the relocated ASYNC
+# agent spawn (B1/B3) (was Executor::run_with_timeout*'s raw tokio spawn).
+let mut cmd = tokio::process::Command::new(program);
+#
+# NetEffect::fetch for RealEffects — the relocated agent NET egress (B5): the one
+# raw reqwest `RequestBuilder::send()` on the effect path (was the tool-proxy
+# web_fetch/web_search handlers' raw send). This is the ONLY `.send()` permitted
+# anywhere in the sealed home.
+.send()
+#
+# ── LEGACY POLICY-GATED RealEffects METHODS (pre-existing sealed-home lines) ───
+# Also methods of RealEffects, so also inside the sealed home and behind the
+# PolicyEnforced capability gate — but NOT part of the relocated `_proof`-gated
+# agent path. They are the crate's convenience `ShellEffect::run` (raw-string
+# bash) and `GitEffect` impls, present on main before B7. Allowlisted as the
+# floor so the gate is green at the sealed home as it stands; the gate still
+# BITES any NEW raw primitive added outside these exact lines.
+#
+# ShellEffect::run for RealEffects — raw-string bash convenience spawn.
+let output = std::process::Command::new(&words[0])
+#
+# GitEffect::commit for RealEffects — `git add -u`.
+let add = std::process::Command::new("git")
+#
+# GitEffect::commit for RealEffects — `git commit -m`.
+let commit = std::process::Command::new("git")
+#
+# GitEffect::push for RealEffects — `git push <remote> <branch>`.
+let output = std::process::Command::new("git")


### PR DESCRIPTION
B7 — the **final** brick of the North Star terminal push. Locks the migration and writes down the machine-checkable stop condition.

**Deliverable 1 — sealed-home integrity gate** (`scripts/check-sealed-home.sh` + allowlist, CI job `sealed-home-gate`): mirrors the mediation gate, scoped to `crates/portcullis-effects/src` (the sealed home the mediation gate excludes). Forbids any raw effect primitive (`Command::new`, reqwest `.send()`) OUTSIDE the allowlisted `RealEffects` sealed-fn sites — so relocation can't leak an un-gated primitive into a helper. Allowlist = the RealEffects sites: the 3 `_proof`-gated sealed fns (`run_argv`/`run_argv_async`/`fetch`, B1–B5) **and** 4 pre-existing legacy policy-gated ones (`ShellEffect::run`, `GitEffect::commit/push`) that already lived in `RealEffects` on main — documented as such. Tested: PASSES at floor, BITES on a planted raw `Command::new`/`.send()` outside RealEffects, green after removal; `bash -n` clean.

**Deliverable 2 — terminal certificate** (`reviews/north-star-certificate.md`): the honest, checkable stop condition, each clause mapped to its enforcing gate/test — (i) mediation green + spawn allowlist EMPTY + net infra-only; (ii) no raw agent-path spawn/net primitive; (iii) every effect class unconstructable without a `DischargedBundle` (compile-fail doctests for bundle-seal/sync-spawn/fs; async-spawn + net enforced by `_proof` signature, stated honestly); (iv) ingest gate green; (v) bundle proves 8/8; (vi) sealed-home gate green. Plus the **caveats it must not overclaim** — dual-stack (sealed bundle runs alongside the legacy kernel/guard; consolidation is Focus-C), `WithinDelegationCeiling` dormant, base checks vacuous on a clean session, net-infra by-file/line, fs 0-raw via cap-std, mcp-guard reclassified infra, the Kani-pinned 1.93 MSRV floor. The claim is **"the structural invariant is closed + ratcheted," NOT "the system is secure."** Focus-C remainder + the #2029→B7 PR trail tabulated.

**With this merged, all six certificate clauses are green in CI simultaneously** — the raw agent-path effect counter is provably zero, every effect class is a compile error to bypass, and the North Star's fixed point is reached. Gate-and-doc only; no Rust or discharge-vocabulary change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CNJdZb7LHWwXkrt9MCa8CG