### PR TITLE
feat(uniform-primitive): type GAP 2 (ocap→ISA) in RSC robust-preservation shape; ISA NI → trace hyperproperty (brick 4)

### DIFF
--- a/.github/workflows/uniform-primitive-lean.yml
+++ b/.github/workflows/uniform-primitive-lean.yml
@@ -55,11 +55,14 @@ jobs:
       - name: Axiom ratchet (layer-bridge count = distance-to-done; may only drop)
         working-directory: crates/nucleus-uniform-primitive/lean
         run: |
-          count=$(grep -rhcE '^[[:space:]]*axiom ' --include='*.lean' --exclude-dir=.lake . 2>/dev/null \
+          # Anchor at column 0: a Lean top-level `axiom` declaration is never
+          # indented, whereas an "axiom" mentioned inside a wrapped doc-comment line
+          # always is — so `^axiom ` counts real axioms and ignores comment prose.
+          count=$(grep -rhcE '^axiom ' --include='*.lean' --exclude-dir=.lake . 2>/dev/null \
                     | awk '{s+=$1} END{print s+0}')
           baseline=$(cat .uniform-primitive-axiom-baseline)
           echo "uniform-primitive layer-bridge axioms: $count (baseline $baseline)"
-          grep -rnE '^[[:space:]]*axiom ' --include='*.lean' --exclude-dir=.lake . || true
+          grep -rnE '^axiom ' --include='*.lean' --exclude-dir=.lake . || true
           if [ "$count" -gt "$baseline" ]; then
             echo "::error::layer-bridge axiom count increased ($count > baseline $baseline) — a new gap was introduced"
             exit 1

--- a/crates/nucleus-uniform-primitive/lean/UniformPrimitive.lean
+++ b/crates/nucleus-uniform-primitive/lean/UniformPrimitive.lean
@@ -162,13 +162,59 @@ abbrev IsaProg    : Type := Unit
 abbrev KernelProg : Type := Unit
 abbrev HwProg     : Type := Unit
 
-opaque IsaNI    : IsaProg    → Prop
 opaque KernelNI : KernelProg → Prop
 opaque HwNI     : HwProg     → Prop
 
 opaque γ_secomp : OcapProg   → IsaProg
 opaque γ_kernel : IsaProg    → KernelProg
 opaque γ_cheri  : KernelProg → HwProg
+
+/-! ## GAP 2 — ocap ⇝ ISA, faithfully typed on SECOMP/StkTokens robust preservation.
+
+    The bare `Preserves L_ocap L_isa γ_secomp` hid WHAT is preserved and against
+    WHOM. RSC/SECOMP (Patrignani-Garg, TOPLAS'21; Abate-Thibault-Blanco et al.,
+    CCS'24) prove ROBUST preservation: a compiler attains RSC when every source
+    program that robustly satisfies a (hyper)safety property — against ALL
+    adversarial contexts — compiles to one that robustly satisfies it too, by
+    inserting defensive checks so no target-level adversary can mount an attack no
+    source adversary could (proof technique: trace back-translation). We type the
+    boundary axiom in exactly that shape — quantified over ISA adversarial contexts
+    and observable traces, with `Leak` the trace-level NI violation — so the ISA
+    layer's NI becomes a genuine trace hyperproperty (`IsaRobustNI`) instead of an
+    opaque predicate. Still ONE boundary axiom (the ISA operational model and the
+    compiler are not yet in-tree), but its SHAPE now states the real theorem. -/
+
+/-- Observable execution traces (genuine, Nonempty; the `Nat` payload is a
+    placeholder for the real trace algebra). -/
+inductive Trace where
+  | tr : Nat → Trace
+
+/-- ISA-level adversarial linking contexts. -/
+inductive IsaCtx where
+  | ctx : Nat → IsaCtx
+
+/-- Behaviour relation: `tgtBehav Q C t` — the compiled ISA program `Q` linked with
+    adversarial context `C` can exhibit observable trace `t`. -/
+opaque tgtBehav : IsaProg → IsaCtx → Trace → Prop
+
+/-- A trace exhibiting a noninterference violation (the hypersafety refutation). -/
+opaque Leak : Trace → Prop
+
+/-- **ISA-layer robust noninterference** — a genuine subset-closed trace
+    hyperproperty: against EVERY adversarial context, the program exhibits no
+    leaking trace. The target of SECOMP's robust-preservation theorem. -/
+def IsaRobustNI (Q : IsaProg) : Prop :=
+  ∀ (C : IsaCtx) (t : Trace), tgtBehav Q C t → ¬ Leak t
+
+/-- **SECOMP/StkTokens robust NI-preservation — the faithfully-typed boundary
+    axiom** (replaces the bare `Preserves`). A source ocap effect carrying a
+    COMPLETE mediation token (`OcapNI`) compiles to an ISA program that, against
+    every adversarial context, exhibits no leaking trace (`IsaRobustNI`) — the RSC
+    robust-hypersafety-preservation shape, the statement SECOMP proves by
+    back-translation. Undischarged (ISA model/compiler not yet in-tree); its TYPE
+    now encodes the real theorem rather than a bare implication. -/
+axiom secomp_robust_preservation :
+    ∀ (P : OcapProg), OcapNI P → IsaRobustNI (γ_secomp P)
 
 /-- Policy-layer admission: requested authority within the delegation ceiling. -/
 def PolicyPre (p : PolicyProg) : Prop := p.authority ≤ capCeiling
@@ -179,7 +225,7 @@ def OcapPre (e : OcapProg) : Prop := e.authority ≤ capCeiling
 
 def L_policy : Layer := ⟨PolicyProg, PolicyNI, PolicyPre⟩
 def L_ocap   : Layer := ⟨OcapProg,   OcapNI,   OcapPre⟩
-def L_isa    : Layer := ⟨IsaProg,    IsaNI,    fun _ => True⟩
+def L_isa    : Layer := ⟨IsaProg,    IsaRobustNI, fun _ => True⟩
 def L_kernel : Layer := ⟨KernelProg, KernelNI, fun _ => True⟩
 def L_hw     : Layer := ⟨HwProg,     HwNI,     fun _ => True⟩
 
@@ -201,9 +247,12 @@ theorem interface_policy_ocap :
   intro p hPre _
   exact Nat.le_trans (γ_ocap_no_escalation p) hPre
 
-/-- GAP 2 — ocap ⇝ machine/ISA via a noninterference-preserving compiler
-    (SECOMP / StkTokens linear capabilities). Artifacts exist upstream; UNWIRED here. -/
-axiom bridge_ocap_isa : Preserves L_ocap L_isa γ_secomp
+/-- **GAP 2 bridge — now DERIVED** (was a bare axiom) from the faithfully-typed
+    robust-preservation statement `secomp_robust_preservation`. A complete-token
+    source effect compiles to an ISA program that robustly satisfies NI. -/
+theorem bridge_ocap_isa : Preserves L_ocap L_isa γ_secomp := by
+  intro P _ hNI
+  exact secomp_robust_preservation P hNI
 
 /-- GAP 3 — ISA ⇝ verified kernel/hypervisor (seL4-class). UNWIRED. -/
 axiom bridge_isa_kernel : Preserves L_isa L_kernel γ_kernel
@@ -234,6 +283,8 @@ theorem end_to_end :
 #print axioms preserves_seq
 #print axioms bridge_policy_ocap
 #print axioms interface_policy_ocap
+#print axioms secomp_robust_preservation
+#print axioms bridge_ocap_isa
 #print axioms end_to_end
 
 end Nucleus.UniformPrimitive


### PR DESCRIPTION
**Initiative brick 4** — make the ocap→ISA boundary axiom *honest-by-shape*.

Off clean `main` (bricks 1–3 merged). Replaces the bare `axiom bridge_ocap_isa : Preserves L_ocap L_isa γ_secomp` with a faithfully-typed `secomp_robust_preservation` in the **RSC / SECOMP robust-hypersafety-preservation** shape (Patrignani–Garg TOPLAS'21; SECOMP CCS'24):

- ISA-layer NI upgraded opaque → a genuine **trace hyperproperty** `IsaRobustNI` (`∀ adversarial context, no leaking trace`), parameterized by `tgtBehav`/`IsaCtx`/`Trace`/`Leak`.
- `secomp_robust_preservation : ∀ P, OcapNI P → IsaRobustNI (γ_secomp P)` — the statement SECOMP proves by back-translation (back-translation is the proof *method*, so one robust-preservation axiom suffices).
- `bridge_ocap_isa` now a **derived theorem**.

Axiom count unchanged at 3 (bare axiom → faithfully-typed axiom). Also **hardens the axiom-ratchet workflow** grep to a column-0 anchor (`^axiom `) so "axiom" in wrapped doc-comment prose can't false-trip the count — a bug this brick's own doc exposed.

Verified: `lake build` green; `bridge_ocap_isa` derived; `end_to_end` on exactly `{secomp_robust_preservation, bridge_isa_kernel, bridge_kernel_hw}`; sorry=0; axioms=3=baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_014uJPLKpYozSY3qogE6DW9q