### PR TITLE
fix(portcullis): fail-closed unsigned declassification under trusted keys — close the endorsement escape hatch (#C-2)

### DIFF
--- a/crates/portcullis/src/kernel.rs
+++ b/crates/portcullis/src/kernel.rs
@@ -824,17 +824,29 @@ impl Kernel {
         // apply_declassification_token() instead, which verifies Ed25519
         // signatures before applying label changes.
         if !self.declassification_rules.is_empty() {
+            // FAIL-CLOSED (#C-2): under the SECURE posture (trusted keys configured),
+            // unsigned rules must NOT silently endorse attacker-tainted data
+            // (RaiseIntegrity Adversarial→Untrusted/Trusted) on the live observe()
+            // path — that voids the non-interference guarantee (an unauthenticated
+            // endorsement the Lean proofs never cover). Refuse to apply them; the
+            // signed, artifact-scoped apply_declassification_token() is the only path
+            // that may declassify under a security posture. Leaving the node at its
+            // true integrity keeps an un-endorsed adversarial node unable to reach a
+            // privileged sink, preserving the NI precondition. The permissive default
+            // (no trusted keys / no `crypto` feature) is byte-for-byte unchanged.
             #[cfg(feature = "crypto")]
-            if !self.trusted_public_keys.is_empty() {
-                tracing::warn!(
+            let secure_posture = !self.trusted_public_keys.is_empty();
+            #[cfg(not(feature = "crypto"))]
+            let secure_posture = false;
+
+            if secure_posture {
+                tracing::error!(
                     node_id = node_id,
                     rule_count = self.declassification_rules.len(),
-                    "applying unsigned declassification rules during observe() while trusted \
-                     keys are configured — use apply_declassification_token() for verified \
-                     declassification"
+                    "REFUSED unsigned declassification rules during observe() while trusted \
+                     keys are configured — use apply_declassification_token() (fail-closed, #C-2)"
                 );
-            }
-            if let Some(node) = graph.get(node_id) {
+            } else if let Some(node) = graph.get(node_id) {
                 let mut label = node.label;
                 for rule in &self.declassification_rules {
                     let result = rule.apply(label);

--- a/crates/portcullis/src/kernel_tests.rs
+++ b/crates/portcullis/src/kernel_tests.rs
@@ -1728,6 +1728,46 @@ fn dag_declassification_authority_upgrade() {
     );
 }
 
+/// #C-2: Under the SECURE posture (trusted keys configured), an UNSIGNED
+/// declassification rule must NOT endorse attacker-tainted data on the live
+/// `observe()` path. Before the fail-closed fix this REDs (integrity becomes
+/// Trusted — the endorsement escape hatch fired with only a `warn!`); after it,
+/// the node keeps its true Adversarial integrity (rule refused), preserving the
+/// non-interference guarantee. The signed `apply_declassification_token()` path
+/// remains the only way to declassify under a security posture.
+#[cfg(feature = "crypto")]
+#[test]
+fn unsigned_declassify_refused_under_trusted_keys() {
+    use portcullis_core::declassify::{DeclassificationRule, DeclassifyAction};
+    use portcullis_core::IntegLevel;
+
+    let mut kernel = Kernel::new(PermissionLattice::safe_pr_fixer());
+
+    // Worst-case unsigned endorsement: Adversarial → Trusted.
+    kernel.add_declassification_rule(DeclassificationRule {
+        action: DeclassifyAction::RaiseIntegrity {
+            from: IntegLevel::Adversarial,
+            to: IntegLevel::Trusted,
+        },
+        justification: "adversarial endorsement — must be refused under trusted keys",
+    });
+
+    // Secure posture: operator opted into VERIFIED declassification.
+    kernel.set_trusted_keys(vec![[0u8; 32]]);
+
+    // Observe attacker-tainted web content (Adversarial integrity).
+    let web = kernel
+        .observe(portcullis_core::flow::NodeKind::WebContent, &[])
+        .unwrap();
+
+    let integ = kernel.flow_graph().get(web).unwrap().label.integrity;
+    assert_eq!(
+        integ,
+        IntegLevel::Adversarial,
+        "unsigned declassify must NOT endorse adversarial data under trusted keys (#C-2)"
+    );
+}
+
 // ── Egress policy integration tests → tests/kernel_egress.rs (#825) ──
 
 // ── #654: Causal decide — flow graph supersedes flat label in decide() ──


### PR DESCRIPTION
## Verified-real fail-open on the live security path

`Kernel::observe()` (`crates/portcullis/src/kernel.rs`) applied **unsigned** declassification rules under the **secure posture** (trusted keys configured) with only a `tracing::warn!`. So an unsigned `RaiseIntegrity { Adversarial → Trusted }` rule **endorsed attacker-tainted WebContent on the live path** — voiding the non-interference guarantee ("attacker-tainted data cannot reach a consequential action"). The Lean `DeclassifyProofs` prove `raiseInteg` *monotonicity*, not NI-preservation or the auth gate, so the claim outran the wiring. This is the documented robust-declassification / endorsement soundness violation (Myers–Sabelfeld–Zdancewic): an endorsement must not be influenceable outside the authenticated path.

## Fix — fail-closed

When `trusted_public_keys` is non-empty, `observe()` **refuses** to apply unsigned rules (logs `error!`, leaves the node at its true integrity). An un-endorsed adversarial node then structurally cannot reach a privileged sink → the NI precondition is preserved. The signed, artifact-scoped `apply_declassification_token()` remains the only path that may declassify under a security posture.

## Safety / scope
- **Only tightens the security-enabled config.** The permissive default (no trusted keys / no `crypto` feature) is **byte-for-byte unchanged**.
- **Reversible** (revert the `secure_posture` guard). No wire-format / trust-root / key change; no outward-facing behavior.

## RED-first evidence (`a-failing-test-must-fail-for-the-right-reason`)
`unsigned_declassify_refused_under_trusted_keys`:
- **RED on pre-fix `main`:** `left: Trusted, right: Adversarial` — the endorsement fired (hole reproduced, right reason/location).
- **GREEN after fix:** integrity stays `Adversarial` (rule refused).
- Full `cargo test -p portcullis --features crypto` green (921+ tests); permissive-default declassify tests unaffected.

## Follow-ups (not in this PR)
- (B2) fail-close `add_declassification_rule` itself (reject, not warn, under trusted keys); consider deprecating unsigned rules entirely.
- (A) add a Lean theorem that declassification *under the authenticated token path* preserves robust-NI, so the proof finally covers the (now-closed) escape hatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_014uJPLKpYozSY3qogE6DW9q