### PR TITLE
fix(portcullis): fail-closed unsigned declassification at REGISTRATION under trusted keys — defense in depth (#C-2 B2)

### DIFF
--- a/crates/portcullis/src/kernel.rs
+++ b/crates/portcullis/src/kernel.rs
@@ -702,13 +702,22 @@ impl Kernel {
         &mut self,
         rule: portcullis_core::declassify::DeclassificationRule,
     ) {
+        // FAIL-CLOSED / defense-in-depth (#C-2 B2): under the secure posture
+        // (trusted keys configured) REFUSE to register an unsigned rule — do not
+        // warn-and-add. Together with the observe() refusal (#C-2), the endorsement
+        // escape hatch is rejected at BOTH registration and application, so a
+        // compromised caller cannot pre-seed a laundering rule. Unsigned rules
+        // endorse by label-class; the artifact-scoped, sink-restricted, signed
+        // apply_declassification_token() is the only admissible path under security.
+        // Permissive default (no trusted keys / no `crypto`) is unchanged.
         #[cfg(feature = "crypto")]
         if !self.trusted_public_keys.is_empty() {
-            tracing::warn!(
+            tracing::error!(
                 justification = %rule.justification,
-                "unsigned declassification rule added while trusted keys are configured — \
-                 use apply_declassification_token() for verified declassification"
+                "REFUSED unsigned declassification rule while trusted keys are configured — \
+                 use apply_declassification_token() (fail-closed, #C-2 B2)"
             );
+            return;
         }
         self.declassification_rules.push(rule);
     }

--- a/crates/portcullis/src/kernel_tests.rs
+++ b/crates/portcullis/src/kernel_tests.rs
@@ -1768,6 +1768,45 @@ fn unsigned_declassify_refused_under_trusted_keys() {
     );
 }
 
+/// #C-2 B2 (defense in depth): an unsigned rule must be REFUSED at REGISTRATION
+/// under the secure posture, not merely warned-and-added. This test registers the
+/// rule under trusted keys, then relaxes the posture so `observe()` would apply any
+/// stored rule — isolating whether the rule was ever registered. Before the fix it
+/// REDs (rule stored → fires under permissive observe → integrity Trusted); after,
+/// the rule was never stored, so integrity stays Adversarial.
+#[cfg(feature = "crypto")]
+#[test]
+fn unsigned_rule_refused_at_registration_under_trusted_keys() {
+    use portcullis_core::declassify::{DeclassificationRule, DeclassifyAction};
+    use portcullis_core::IntegLevel;
+
+    let mut kernel = Kernel::new(PermissionLattice::safe_pr_fixer());
+
+    // Secure posture at REGISTRATION time.
+    kernel.set_trusted_keys(vec![[0u8; 32]]);
+    kernel.add_declassification_rule(DeclassificationRule {
+        action: DeclassifyAction::RaiseIntegrity {
+            from: IntegLevel::Adversarial,
+            to: IntegLevel::Trusted,
+        },
+        justification: "adversarial: must be refused at registration under trusted keys",
+    });
+
+    // Relax the posture so observe() WILL apply any *registered* rule — this
+    // isolates registration-time behavior (the B2 change) from application.
+    kernel.set_trusted_keys(vec![]);
+    let node_id = kernel
+        .observe(portcullis_core::flow::NodeKind::WebContent, &[])
+        .unwrap();
+    let integ = kernel.flow_graph().get(node_id).unwrap().label.integrity;
+    assert_eq!(
+        integ,
+        IntegLevel::Adversarial,
+        "unsigned rule must be REFUSED at registration under trusted keys — never stored, so it \
+         cannot fire even after the posture is later relaxed (#C-2 B2)"
+    );
+}
+
 // ── Egress policy integration tests → tests/kernel_egress.rs (#825) ──
 
 // ── #654: Causal decide — flow graph supersedes flat label in decide() ──


### PR DESCRIPTION
**Registration-time twin of #2058.** Stacked on #2058 (observe() fail-close); diff reduces to just these two hunks once #2058 merges.

## The gap (verified real)
`add_declassification_rule` (`crates/portcullis/src/kernel.rs:701`) only `warn!`ed and **pushed the rule regardless** when trusted keys were configured. So a compromised/careless caller could **pre-seed a laundering rule** (`RaiseIntegrity { Adversarial → Trusted }`) under the secure posture — the registration-time twin of the observe() fail-open.

## Fix — defense in depth
Under the secure posture, **refuse** to register an unsigned rule (`error!` + return, no push). With #2058's observe() refusal, the endorsement escape hatch is now rejected at **both registration and application** — one bypass isn't fatal. Kept `-> ()` (no semver break); `-> Result` rejected as more consequential for no security gain.

## Safety / scope
- `add_declassification_rule` has **no in-tree production callers** (only 3 tests, which use no trusted keys — unaffected).
- Only tightens the security-enabled config; **permissive default byte-for-byte unchanged**; reversible; no signature/wire/trust-root/key change.

## RED→GREEN evidence
`unsigned_rule_refused_at_registration_under_trusted_keys` — isolates *registration* by relaxing the posture before `observe()`:
- **RED pre-fix:** `left: Trusted` (rule was stored, then fired).
- **GREEN after:** integrity stays `Adversarial` (never stored).
- Full `cargo test -p portcullis --features crypto` green.

## Parked owner-decision (raised, not acted)
Fully deprecating/removing unsigned label-class rules even in the permissive default — a default-behavior + public-API change with external blast radius. **Needs your sign-off.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_014uJPLKpYozSY3qogE6DW9q