### PR TITLE
fix(portcullis): verify_strict on the receipt/token cert chain — retire ring from the verify TCB (#16)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8258,6 +8258,7 @@ dependencies = [
  "cedar-policy",
  "cel-interpreter",
  "chrono",
+ "ed25519-dalek 3.0.0-pre.7",
  "hex",
  "hmac 0.13.0",
  "kani",

--- a/crates/portcullis/Cargo.toml
+++ b/crates/portcullis/Cargo.toml
@@ -21,7 +21,7 @@ default = ["serde", "crypto", "cedar"]
 serde = ["dep:serde", "dep:serde_json", "rust_decimal/serde", "chrono/serde", "uuid/serde"]
 
 # Ed25519 signing (ring) — disable for WASM targets where ring can't compile
-crypto = ["dep:ring"]
+crypto = ["dep:ring", "dep:ed25519-dalek"]
 
 # CEL-based policy constraints
 cel = ["dep:cel-interpreter"]
@@ -58,6 +58,10 @@ serde_json = { workspace = true, optional = true }
 
 # Ed25519 signatures for attested delegation certificates (optional for WASM)
 ring = { workspace = true, optional = true }
+# Ed25519 VERIFY on the cert chain uses verify_strict (rejects small-order keys /
+# non-canonical S) — unifies the trust path with the rest of the attest stack and
+# is WASM-capable (ring is not). Signing stays on ring. (#16)
+ed25519-dalek = { workspace = true, optional = true }
 
 # Base64 encoding for compact token transport
 base64 = { workspace = true }

--- a/crates/portcullis/src/receipt_sign.rs
+++ b/crates/portcullis/src/receipt_sign.rs
@@ -8,7 +8,7 @@
 //! distributed to verifiers.
 
 #[cfg(feature = "crypto")]
-use ring::signature::{self, Ed25519KeyPair, UnparsedPublicKey};
+use ring::signature::Ed25519KeyPair;
 
 use portcullis_core::receipt::{receipt_canonical_bytes, FlowReceipt, SignatureError};
 
@@ -66,10 +66,22 @@ pub fn verify_receipt(
     }
 
     let content = receipt_content_bytes(receipt);
-    let public_key = UnparsedPublicKey::new(&signature::ED25519, public_key_bytes);
 
-    public_key
-        .verify(&content, receipt.signature_bytes())
+    // verify_strict (ed25519-dalek), NOT ring's cofactored verify. Ring's verify
+    // ACCEPTS a small-order identity-key forgery (see
+    // small_order_key_rejected_by_verify_strict); verify_strict rejects small-order
+    // public keys and non-canonical R/A/S (RFC 8032, s < ℓ). This closes that on the
+    // receipt cert chain (#16), unifies the trust path on the strict semantics the
+    // rest of the attest stack already uses, removes `ring` from the verify TCB, and
+    // makes this verify WASM-capable. Signing stays on `ring`. Honest receipts remain
+    // valid — verify_strict accepts every canonical signature.
+    let vk_bytes: [u8; 32] = public_key_bytes
+        .try_into()
+        .map_err(|_| SignatureError::InvalidSignature)?;
+    let vk = ed25519_dalek::VerifyingKey::from_bytes(&vk_bytes)
+        .map_err(|_| SignatureError::InvalidSignature)?;
+    let sig = ed25519_dalek::Signature::from_bytes(receipt.signature_bytes());
+    vk.verify_strict(&content, &sig)
         .map_err(|_| SignatureError::InvalidSignature)
 }
 
@@ -102,6 +114,52 @@ mod tests {
             sink_class: None,
             effect_kind: None,
         }
+    }
+
+    /// Ed25519 small-order (identity) public-key encoding: y = 1, x = 0.
+    fn identity_vk_bytes() -> [u8; 32] {
+        let mut id = [0u8; 32];
+        id[0] = 1;
+        id
+    }
+
+    /// The "identity triple" signature: R = identity encoding, s = 0. Under the
+    /// identity key A = R, the cofactored equation `[s]B == R + [k]A` reduces to
+    /// `identity == identity` for EVERY message — a small-order key-substitution
+    /// forgery that cofactored `verify` accepts but `verify_strict` rejects.
+    fn identity_sig_bytes() -> [u8; 64] {
+        let mut sig = [0u8; 64];
+        sig[..32].copy_from_slice(&identity_vk_bytes());
+        sig
+    }
+
+    /// #16: the receipt cert-chain verify must reject a small-order-key forgery
+    /// that ring's cofactored `verify` may accept. Honest receipts still verify.
+    #[test]
+    fn small_order_key_rejected_by_verify_strict() {
+        let key = test_key();
+        let action = make_node(
+            1,
+            NodeKind::OutboundAction,
+            IFCLabel::user_prompt(1000),
+            Some(Operation::WriteFiles),
+        );
+
+        // (i) No regression: an honest signed receipt still verifies.
+        let mut honest = build_receipt(&action, &[], FlowVerdict::Allow, 2000);
+        sign_receipt(&mut honest, &key);
+        verify_receipt(&honest, key.public_key().as_ref())
+            .expect("honest receipt must still verify");
+
+        // (ii) Strong binding: a well-formed receipt with the identity-triple
+        // signature, verified against the small-order identity key, must be
+        // REJECTED. verify_strict rejects it; cofactored verify would accept it.
+        let mut forged = build_receipt(&action, &[], FlowVerdict::Allow, 2000);
+        forged.set_signature(identity_sig_bytes());
+        assert!(
+            verify_receipt(&forged, &identity_vk_bytes()).is_err(),
+            "small-order identity-key forgery must be REJECTED by the receipt verify (#16)"
+        );
     }
 
     #[test]

--- a/crates/portcullis/src/token_sign.rs
+++ b/crates/portcullis/src/token_sign.rs
@@ -11,7 +11,7 @@
 //! The signing/verification follows the same pattern as `receipt_sign.rs`.
 
 #[cfg(feature = "crypto")]
-use ring::signature::{self, Ed25519KeyPair, UnparsedPublicKey};
+use ring::signature::Ed25519KeyPair;
 
 use portcullis_core::declassify::DeclassificationToken;
 use portcullis_core::receipt::SignatureError;
@@ -44,10 +44,16 @@ pub fn verify_token(
     }
 
     let content = token.canonical_bytes();
-    let public_key = UnparsedPublicKey::new(&signature::ED25519, public_key_bytes);
 
-    public_key
-        .verify(&content, &token.signature)
+    // verify_strict — see receipt_sign.rs rationale (#16): rejects small-order keys /
+    // non-canonical S that ring's cofactored verify accepts. Signing stays on `ring`.
+    let vk_bytes: [u8; 32] = public_key_bytes
+        .try_into()
+        .map_err(|_| SignatureError::InvalidSignature)?;
+    let vk = ed25519_dalek::VerifyingKey::from_bytes(&vk_bytes)
+        .map_err(|_| SignatureError::InvalidSignature)?;
+    let sig = ed25519_dalek::Signature::from_bytes(&token.signature);
+    vk.verify_strict(&content, &sig)
         .map_err(|_| SignatureError::InvalidSignature)
 }
 


### PR DESCRIPTION
**Verified-real crypto weakness** on the receipt/token cert chain. Held un-armed — crypto on the security path.

## The gap (verified, with a TRUE RED)
`portcullis::verify_receipt` / `verify_token` verified Ed25519 via `ring`'s **cofactored `verify`**, which **accepts a small-order identity-key forgery** (R = identity, s = 0, A = identity — `[s]B == R + [k]A` reduces to `identity == identity` for every message). That's a key-substitution / weak-binding forgery on the cert chain. The rest of the attest stack already uses `verify_strict`; **portcullis was the divergent residual** (second verifier in the TCB, WASM-incapable).

## Fix
Migrate the two VERIFY functions to `ed25519_dalek::VerifyingKey::verify_strict` (rejects small-order keys + non-canonical R/A/S, RFC 8032 `s < ℓ`). **Signing stays on `ring`** (not the trust decision). Removes ring from the verify TCB, unifies the trust path, makes verify WASM-capable.

## Safety
- **No wire/signature-format change** — honest signatures still verify (verify_strict accepts every canonical sig); only malformed/small-order/malleable sigs ring accepted are now rejected.
- Pure hardening; reversible; no trust-root/key change; non-crypto build unaffected (dalek optional under `crypto`).

## RED→GREEN evidence
`small_order_key_rejected_by_verify_strict`:
- **RED on pre-fix `main`:** ring **accepts** the identity-triple forgery (`verify_receipt` returns Ok) — the assertion `is_err()` fails.
- **GREEN after:** verify_strict rejects it; honest receipts still verify.
- Full `cargo test -p portcullis --features crypto` green (19 binaries, 0 failed); non-crypto build compiles; clippy clean.

Closes the #16 residual from the open-guarantees enumeration (Pillar 3 crypto-on-attest). The outer attest stack was already strict; this brings the core crate in line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_014uJPLKpYozSY3qogE6DW9q