### PR TITLE
fix(nucleus): basename-normalize git-op classification — close path-qualified /usr/bin/git push capability bypass

### DIFF
--- a/crates/nucleus/src/command.rs
+++ b/crates/nucleus/src/command.rs
@@ -930,24 +930,50 @@ fn core_capabilities(caps: &CapabilityLattice) -> CoreCapabilityLattice {
     }
 }
 
+/// Program basename, so a path-qualified binary (`/usr/bin/git`) classifies by
+/// its real operation instead of slipping into the broad `run_bash` bucket and
+/// bypassing a per-operation capability (e.g. `git_push = Never`).
+fn program_basename(prog: &str) -> &str {
+    prog.rsplit('/').next().unwrap_or(prog)
+}
+
 /// Check if the command is a git push operation.
 fn is_git_push_command(args: &[String]) -> bool {
-    args.len() >= 2 && args[0] == "git" && args[1] == "push"
+    args.len() >= 2 && program_basename(&args[0]) == "git" && args[1] == "push"
 }
 
 /// Check if the command is a git commit operation.
 fn is_git_commit_command(args: &[String]) -> bool {
-    args.len() >= 2 && args[0] == "git" && args[1] == "commit"
+    args.len() >= 2 && program_basename(&args[0]) == "git" && args[1] == "commit"
 }
 
 /// Check if the command is a PR creation operation (gh pr create).
 fn is_pr_command(args: &[String]) -> bool {
-    args.len() >= 3 && args[0] == "gh" && args[1] == "pr" && args[2] == "create"
+    args.len() >= 3 && program_basename(&args[0]) == "gh" && args[1] == "pr" && args[2] == "create"
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Path-qualified git/gh must classify by operation, not slip into `run_bash`.
+    /// Before the basename fix the three path-qualified asserts RED (`/usr/bin/git
+    /// push` has args[0]="/usr/bin/git" != "git"), so a `git_push=Never` policy with
+    /// `run_bash` open is bypassed by path-qualifying the binary.
+    #[test]
+    fn path_qualified_git_ops_are_classified() {
+        assert!(is_git_push_command(&["/usr/bin/git".into(), "push".into()]));
+        assert!(is_git_commit_command(&["/usr/bin/git".into(), "commit".into()]));
+        assert!(is_pr_command(&[
+            "/usr/local/bin/gh".into(),
+            "pr".into(),
+            "create".into()
+        ]));
+        // Baseline unchanged.
+        assert!(is_git_push_command(&["git".into(), "push".into()]));
+        // No false positive: a different program whose basename isn't `git`.
+        assert!(!is_git_push_command(&["mygit".into(), "push".into()]));
+    }
     use crate::budget::AtomicBudget;
     use crate::sandbox::Sandbox;
     // Sanctioned cross-crate test-only bundle: runs a real `preflight_action` on a

--- a/crates/nucleus/src/command.rs
+++ b/crates/nucleus/src/command.rs
@@ -963,7 +963,10 @@ mod tests {
     #[test]
     fn path_qualified_git_ops_are_classified() {
         assert!(is_git_push_command(&["/usr/bin/git".into(), "push".into()]));
-        assert!(is_git_commit_command(&["/usr/bin/git".into(), "commit".into()]));
+        assert!(is_git_commit_command(&[
+            "/usr/bin/git".into(),
+            "commit".into()
+        ]));
         assert!(is_pr_command(&[
             "/usr/local/bin/gh".into(),
             "pr".into(),


### PR DESCRIPTION
**Verified-real per-operation capability bypass** (posture-improving → auto-armed). Independent file (`crates/nucleus/src/command.rs`).

## The bypass
`is_git_push_command`/`is_git_commit_command`/`is_pr_command` matched `args[0]` exactly, so **`/usr/bin/git push`** (args[0] != `"git"`) evaded classification and fell into the broad `run_bash` bucket. A policy with `git_push = Never` but `run_bash` open is bypassed by path-qualifying the binary — defeating the per-operation restriction.

(SECURITY_TODO #3's flagged first-argv-token exfil list is **already refactored away** — gating is now conservative operation-level and tested; no exfil fix warranted. This is the real adjacent residual.)

## Fix
`program_basename` normalizes `args[0]` in the three classifiers. Tightens classification only — no false positive (`mygit` ≠ `git`), reversible, no wire/API change. Interpreter-payload wrapping (`bash -c "git push"`) is intentionally not parsed (obfuscatable) — left to the conservative uninhabitable approval gate.

## RED→GREEN
`path_qualified_git_ops_are_classified`: RED pre-fix (all three path-qualified ops unclassified), GREEN after; baseline classified, `mygit push` not. Full `cargo test -p nucleus` green; clippy clean.

Note: may transiently fail "Check line ceiling" until #2065 (kernel.rs line-ratchet unblocker) merges; rebase then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_014uJPLKpYozSY3qogE6DW9q