### PR TITLE
fix(auth): fail-closed on empty HMAC auth secret — reject world-known-key sandbox tokens & request auth

### DIFF
--- a/crates/nucleus-client/src/lib.rs
+++ b/crates/nucleus-client/src/lib.rs
@@ -224,6 +224,10 @@ pub fn verify_drand_signature(
     body: &[u8],
     signature: &str,
 ) -> bool {
+    // Fail-closed: never authenticate against a world-known (empty) key.
+    if !auth_secret_is_usable(secret) {
+        return false;
+    }
     let actor_value = actor.unwrap_or("");
     let message = build_drand_message(drand_round, timestamp, actor_value, body);
     let expected = sign_message(secret, &message);
@@ -240,6 +244,10 @@ pub fn verify_signature(
     body: &[u8],
     signature: &str,
 ) -> bool {
+    // Fail-closed: never authenticate against a world-known (empty) key.
+    if !auth_secret_is_usable(secret) {
+        return false;
+    }
     let actor_value = actor.unwrap_or("");
     let message = build_message(timestamp, actor_value, body);
     let expected = sign_message(secret, &message);
@@ -283,6 +291,24 @@ fn now_unix() -> i64 {
         .as_secs() as i64
 }
 
+/// Minimum recommended HMAC auth-secret length, in bytes. Shorter-but-nonempty
+/// secrets are weak (warned about at startup) but not world-known; an EMPTY
+/// secret is world-known and is rejected outright (see [`auth_secret_is_usable`]).
+pub const MIN_AUTH_SECRET_LEN: usize = 16;
+
+/// Fail-closed usability check for an HMAC auth secret.
+///
+/// `Hmac::<Sha256>::new_from_slice` accepts a key of ANY length, including the
+/// empty key — so an empty `auth_secret` is a *world-known* key: an attacker can
+/// compute `HMAC(∅, msg)` themselves and forge any signature or sandbox token.
+/// Every verifier consults this first and refuses to authenticate against an
+/// empty key, so a mis-provisioned (empty) secret fails closed instead of
+/// silently accepting forgeries.
+#[must_use]
+pub fn auth_secret_is_usable(secret: &[u8]) -> bool {
+    !secret.is_empty()
+}
+
 /// Maximum age of a sandbox token before it's considered expired.
 const MAX_TOKEN_AGE_SECS: u64 = 300;
 
@@ -313,6 +339,13 @@ pub fn generate_sandbox_token(secret: &[u8], pod_id: &str, spec_hash: &str) -> S
 /// Returns the verified payload (pod_id, spec_hash) on success,
 /// or an error string on failure.
 pub fn verify_sandbox_token(secret: &[u8], token: &str) -> Result<SandboxTokenPayload, String> {
+    // Fail-closed: an empty secret is a world-known key, so an attacker could
+    // forge a token by signing with the empty key. Refuse verification outright.
+    if !auth_secret_is_usable(secret) {
+        return Err("empty auth secret: refusing HMAC verification against a \
+                    world-known key (fail-closed)"
+            .to_string());
+    }
     if token.is_empty() {
         return Err("empty token".to_string());
     }
@@ -387,6 +420,58 @@ fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn empty_secret_never_verifies_sandbox_token() {
+        // World-known empty key: an attacker forges a token by signing with b"".
+        let forged = generate_sandbox_token(b"", "pod1", "hashX");
+        // RED on main: empty secret verifies the empty-key-forged token.
+        assert!(
+            verify_sandbox_token(b"", &forged).is_err(),
+            "empty auth secret must never verify a token (world-known key, fail-closed)"
+        );
+        // No regression: a real secret still round-trips.
+        let real: &[u8] = b"a-real-16byte-secret!!";
+        let good = generate_sandbox_token(real, "pod1", "hashX");
+        assert!(verify_sandbox_token(real, &good).is_ok());
+    }
+
+    #[test]
+    fn empty_secret_never_verifies_request_signature() {
+        let ts = now_unix();
+        let body = b"payload";
+        // World-known empty-key signature over the exact message the verifier builds.
+        let forged = sign_message(b"", &build_message(ts, "", body));
+        assert!(
+            !verify_signature(b"", ts, None, body, &forged),
+            "empty auth secret must never verify a request signature (fail-closed)"
+        );
+        // No regression: a real secret verifies.
+        let real: &[u8] = b"a-real-16byte-secret!!";
+        let sig = sign_message(real, &build_message(ts, "", body));
+        assert!(verify_signature(real, ts, None, body, &sig));
+    }
+
+    #[test]
+    fn empty_secret_never_verifies_drand_signature() {
+        let ts = now_unix();
+        let body = b"payload";
+        let forged = sign_message(b"", &build_drand_message(7, ts, "", body));
+        assert!(
+            !verify_drand_signature(b"", 7, ts, None, body, &forged),
+            "empty auth secret must never verify a drand signature (fail-closed)"
+        );
+        let real: &[u8] = b"a-real-16byte-secret!!";
+        let sig = sign_message(real, &build_drand_message(7, ts, "", body));
+        assert!(verify_drand_signature(real, 7, ts, None, body, &sig));
+    }
+
+    #[test]
+    fn auth_secret_usable_rejects_only_empty() {
+        assert!(!auth_secret_is_usable(b""));
+        assert!(auth_secret_is_usable(b"x"));
+        assert!(auth_secret_is_usable(&[0u8; MIN_AUTH_SECRET_LEN]));
+    }
 
     #[test]
     fn test_sign_http_headers() {

--- a/crates/nucleus-tool-proxy/src/main.rs
+++ b/crates/nucleus-tool-proxy/src/main.rs
@@ -26,7 +26,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tokio::io::AsyncWriteExt;
 use tokio::net::TcpListener;
-use tracing::{info, warn};
+use tracing::{error, info, warn};
 
 mod attestation;
 mod auth;
@@ -1111,6 +1111,42 @@ async fn main() -> Result<(), ApiError> {
     }
 
     let args = Args::parse();
+
+    // === Auth-secret sanity (fail-closed on a world-known key) ===
+    // `auth_secret` is a required arg, but an EMPTY string satisfies "present"
+    // while being a world-known HMAC key — an empty key makes sandbox tokens and
+    // signed requests trivially forgeable (an attacker computes HMAC(∅, msg)).
+    // Refuse to start rather than authenticate against it. Legit deployments
+    // always provide a real secret, so this never affects them.
+    // `.trim().is_empty()` (matching nucleus-node) also rejects a whitespace-only
+    // secret, which is effectively unset.
+    if args.auth_secret.trim().is_empty() {
+        error!(
+            "NUCLEUS_TOOL_PROXY_AUTH_SECRET is empty — refusing to start: an empty HMAC key is \
+             world-known and makes sandbox tokens and request auth forgeable (fail-closed)"
+        );
+        std::process::exit(1);
+    }
+    if args.auth_secret.len() < nucleus_client::MIN_AUTH_SECRET_LEN {
+        warn!(
+            secret_len = args.auth_secret.len(),
+            min = nucleus_client::MIN_AUTH_SECRET_LEN,
+            "NUCLEUS_TOOL_PROXY_AUTH_SECRET is shorter than the recommended minimum — weak HMAC key"
+        );
+    }
+    // The node-auth secret defaults to `auth_secret` when unset, but an explicitly
+    // provided EMPTY `--node-auth-secret` would be a world-known key for node
+    // requests — refuse it too (fail-closed).
+    if let Some(ref node_secret) = args.node_auth_secret {
+        if node_secret.trim().is_empty() {
+            error!(
+                "NUCLEUS_TOOL_PROXY_NODE_AUTH_SECRET is empty — refusing to start: an empty HMAC \
+                 key makes node request auth forgeable (fail-closed). Unset it to inherit \
+                 the main auth secret instead."
+            );
+            std::process::exit(1);
+        }
+    }
 
     // === Sandbox Proof Gate ===
     // Refuse to start unless we can cryptographically prove we're in a managed sandbox.


### PR DESCRIPTION
## The fail-open (LIVE path, named caller)

`auth_secret` is a **required** clap arg, but an **empty string satisfies "present"** while being a *world-known* HMAC key: `Hmac::<Sha256>::new_from_slice` accepts a zero-length key, so an attacker computes `HMAC(∅, msg)` themselves and forges a valid sandbox token or signed request. On the live tool-proxy path `verify_sandbox_token` (called at `sandbox_proof.rs:326`) and the request verifiers **never rejected an empty secret** → a WebSearch-scoped process (or any peer) can mint a token/signature the proxy accepts.

Reachability confirmed: `NUCLEUS_TOOL_PROXY_AUTH_SECRET` empty → `args.auth_secret.as_bytes().to_vec()` = `[]` (main.rs:1124) → verifiers accept empty-key forgeries.

## Fail-closed on both boundaries (legit secrets unaffected)

- **nucleus-client** (the security boundary): `auth_secret_is_usable` + `MIN_AUTH_SECRET_LEN`; **every verifier** — `verify_signature`, `verify_drand_signature`, `verify_sandbox_token` — refuses an empty key up front, correct regardless of how the empty key arrives.
- **nucleus-tool-proxy** (fail-fast): refuse to START on empty/whitespace-only `NUCLEUS_TOOL_PROXY_AUTH_SECRET` or explicitly-empty `NUCLEUS_TOOL_PROXY_NODE_AUTH_SECRET`; warn on shorter-than-`MIN` (weak, not world-known). Matches **nucleus-node's existing** `.trim().is_empty()` guard — node was already fail-closed; **tool-proxy was the gap**.

## Verification (RED-first)

3 forgery tests (sandbox token, request sig, drand sig) — **verified RED with the guard neutered** (empty-key forgery accepted on all three verifiers), GREEN with it in place; real secrets still round-trip (no regression). 26 nucleus-client tests + tool-proxy build + clippy green.

Empty ⇒ reject (world-known); short-but-nonempty ⇒ warn (right-sized — rejecting could break legit short-secret deployments). **No wire/trust/key change.**

_Note: 122 LOC (under the 150 batch target) — opened rather than held because it closes a live token-forgery vector and nucleus-node (the cohesive batch-mate) is already guarded, leaving no non-padding path to 150._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
