### PR TITLE
fix(control-plane): fail closed when SPIFFE auth is unconfigured in production — orchestration API no longer boots open (most-paranoid #6)

### DIFF
--- a/crates/nucleus-control-plane-server/src/auth.rs
+++ b/crates/nucleus-control-plane-server/src/auth.rs
@@ -311,6 +311,17 @@ pub enum SpiffeConfigError {
          trust_jwks/allowed_audience/allowed_subject_prefix, or NONE. Got {set_count}/3."
     )]
     Partial { set_count: usize },
+
+    /// Production build booted with SPIFFE auth UNCONFIGURED. The orchestration
+    /// API (submit/get/cancel/stream job) must not run open — fail-closed
+    /// (most-paranoid #6), mirroring the lineage-signer discipline in main.rs.
+    #[error(
+        "SPIFFE JWT-SVID auth is REQUIRED in production but is unconfigured — set \
+         --spiffe-trust-jwks-path / --spiffe-allowed-audience / --spiffe-allowed-subject-prefix \
+         (or build with `--features insecure-dev` to run WITHOUT auth, which is dangerous and \
+         must never be used in production)"
+    )]
+    AuthRequiredInProduction,
 }
 
 /// Resolve SPIFFE auth config from optional inputs. `None` from all
@@ -344,6 +355,31 @@ pub fn resolve_spiffe_auth(
             Ok(Some(SpiffeAuthConfig::new(jwks, aud, prefix)))
         }
         _ => Err(SpiffeConfigError::Partial { set_count }),
+    }
+}
+
+/// Fail-closed gate (most-paranoid #6): a PRODUCTION build REQUIRES SPIFFE
+/// JWT-SVID auth. Given the resolved config, returns it when present; when it is
+/// ABSENT (`None` — no SPIFFE flags set), a production build returns
+/// `Err(AuthRequiredInProduction)` so the server refuses to boot with the
+/// orchestration API open. Only a build with `--features insecure-dev` may boot
+/// without auth (`Ok(None)`). Mirrors the lineage-signer fail-closed discipline
+/// in `main.rs` (production `anyhow::bail!` when no signing key is configured).
+pub fn require_auth_or_insecure(
+    resolved: Option<SpiffeAuthConfig>,
+) -> Result<Option<SpiffeAuthConfig>, SpiffeConfigError> {
+    match resolved {
+        Some(c) => Ok(Some(c)),
+        None => {
+            #[cfg(not(feature = "insecure-dev"))]
+            {
+                Err(SpiffeConfigError::AuthRequiredInProduction)
+            }
+            #[cfg(feature = "insecure-dev")]
+            {
+                Ok(None)
+            }
+        }
     }
 }
 
@@ -391,6 +427,35 @@ mod tests {
     use ed25519_dalek::{Signer as _, SigningKey, SECRET_KEY_LENGTH};
     use nucleus_oidc_core::Jwk;
     use serde_json::json;
+
+    /// Fail-closed: a PRODUCTION build (no `insecure-dev`) must REFUSE to boot
+    /// when SPIFFE auth is unconfigured. On main the `None` branch only warned
+    /// and booted the orchestration API open — this is the RED→GREEN.
+    #[cfg(not(feature = "insecure-dev"))]
+    #[test]
+    fn production_fails_closed_without_spiffe_auth() {
+        assert!(
+            matches!(
+                require_auth_or_insecure(None),
+                Err(SpiffeConfigError::AuthRequiredInProduction)
+            ),
+            "production must fail closed when SPIFFE auth is unconfigured"
+        );
+    }
+
+    /// The escape hatch: an `insecure-dev` build may boot without auth.
+    #[cfg(feature = "insecure-dev")]
+    #[test]
+    fn insecure_dev_permits_no_auth() {
+        assert!(matches!(require_auth_or_insecure(None), Ok(None)));
+    }
+
+    /// No regression: a configured auth always passes through, in any build.
+    #[test]
+    fn configured_auth_always_passes() {
+        let f = Fixture::new();
+        assert!(require_auth_or_insecure(Some(config(f.jwks()))).is_ok());
+    }
 
     /// Helpers for building a signed JWT-SVID against a known signing key.
     struct Fixture {

--- a/crates/nucleus-control-plane-server/src/lib.rs
+++ b/crates/nucleus-control-plane-server/src/lib.rs
@@ -45,8 +45,8 @@ pub mod webhook;
 
 pub use app::build_app;
 pub use auth::{
-    resolve_spiffe_auth, verify_jwt_svid, AuthenticatedPrincipal, RequireSpiffeAuth,
-    SpiffeAuthConfig, SpiffeConfigError,
+    require_auth_or_insecure, resolve_spiffe_auth, verify_jwt_svid, AuthenticatedPrincipal,
+    RequireSpiffeAuth, SpiffeAuthConfig, SpiffeConfigError,
 };
 pub use error::ApiError;
 pub use registry::{InMemoryRegistry, JobRegistry, JobRegistryError, RunnerRegistry};

--- a/crates/nucleus-control-plane-server/src/main.rs
+++ b/crates/nucleus-control-plane-server/src/main.rs
@@ -12,7 +12,8 @@ use clap::Parser;
 #[cfg(feature = "insecure-dev")]
 use nucleus_control_plane::MockJobRunner;
 use nucleus_control_plane_server::{
-    build_app, registry::RunnerRegistry, resolve_spiffe_auth, state::build_state,
+    build_app, registry::RunnerRegistry, require_auth_or_insecure, resolve_spiffe_auth,
+    state::build_state,
 };
 use nucleus_lineage::{
     Ed25519Witness, EdgeSigner, JsonlSink, MerkleConfig, MerkleSink, SigningProvider, TreeWitness,
@@ -215,10 +216,12 @@ async fn main() -> Result<()> {
     state.merkle_prover = Some(merkle_sink.clone());
     state.witness_pubkey = Some(witness_pubkey);
 
-    // SPIFFE auth wiring. fail-loud on partial config; warn loud when
-    // auth is disabled so operators don't ship demo-mode to prod by
-    // omission.
-    match cli_spiffe_auth(&cli)? {
+    // SPIFFE auth wiring. fail-loud on partial config; fail-CLOSED when auth is
+    // unconfigured in a production build (require_auth_or_insecure) so the
+    // orchestration API never boots open — mirroring the lineage-signer
+    // discipline above (most-paranoid #6). Only `--features insecure-dev` may
+    // boot without auth.
+    match require_auth_or_insecure(cli_spiffe_auth(&cli)?)? {
         Some(cfg) => {
             tracing::info!(
                 audience = %cfg.allowed_audience,
@@ -229,10 +232,11 @@ async fn main() -> Result<()> {
             state.spiffe_auth = Some(Arc::new(cfg));
         }
         None => {
+            // Reachable ONLY under `--features insecure-dev` — a production build
+            // returns Err(AuthRequiredInProduction) above and never reaches here.
             tracing::warn!(
-                "SPIFFE JWT-SVID auth DISABLED — every endpoint is open. \
-                 Set --spiffe-trust-jwks-path / --spiffe-allowed-audience / \
-                 --spiffe-allowed-subject-prefix in production."
+                "SPIFFE JWT-SVID auth DISABLED (insecure-dev build) — every endpoint is OPEN. \
+                 This build must never run in production."
             );
         }
     }


### PR DESCRIPTION
## The fail-open (LIVE path, named callers)

The control-plane **orchestration API** — `submit_job` (routes.rs:55, POST), `get_job`, `cancel_job`, `stream_job_events`, all gated by the `RequireSpiffeAuth` extractor — **booted OPEN when SPIFFE auth was unconfigured, in ALL builds**. `main.rs` resolved auth and the `None` branch only **warned** and continued (its own doc: *"every endpoint is open"*). The extractor returns `Ok(unauthenticated())` when `spiffe_auth` is `None`, so omitting `--spiffe-trust-jwks-path` / `--spiffe-allowed-audience` / `--spiffe-allowed-subject-prefix` **silently disabled auth on the whole orchestration API** — a config-omission fail-open, same class as the empty-HMAC-secret gap (#2070).

## Violated the codebase's own discipline

Three lines up in the same `main.rs`, the **lineage signer** already hard-errors in production without a key (`#[cfg(not(feature = "insecure-dev"))] bail!(… "most-paranoid #6")`). SPIFFE auth was the inconsistency. This fix mirrors that precedent:

- `require_auth_or_insecure(resolved)` → `Err(AuthRequiredInProduction)` when auth is unconfigured in a **production** build; only `--features insecure-dev` may boot without auth (`Ok(None)`).

## Verification (RED-first)

`production_fails_closed_without_spiffe_auth` — **verified RED with the guard neutered** (boots open like main), GREEN with it in place. Plus `insecure_dev_permits_no_auth` (opt-out) and `configured_auth_always_passes` (no regression). Tests pass in **both** feature configs; clippy + rustfmt clean.

## ⚠️ Arm decision needed (not auto-armed)

This changes a **production boot default**: a deployment currently running the orchestration API **without** SPIFFE auth will **refuse to boot** until it configures auth or builds `--features insecure-dev` (which is all-or-nothing — it also downgrades the signer/driver). Correct direction (matches the lineage-signer precedent + the project's emphatic fail-closed posture), **reversible**, **no wire-format/trust-root/key change**. Because the blast radius is a live boot-behavior change, I opened it **unarmed** for an explicit arm decision rather than auto-merging. Recommendation: **arm** — an open orchestration API in production is insecure by the project's own standard, and `insecure-dev` is the intended escape hatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
