### PR TITLE
fix(node): container driver fail-closed on unenforceable network policy — reject instead of silently ignoring (driver parity)

### DIFF
--- a/crates/nucleus-node/src/main.rs
+++ b/crates/nucleus-node/src/main.rs
@@ -1437,6 +1437,24 @@ async fn spawn_local_pod(
     Ok((DriverState::Local(Box::new(handle)), proxy_addr, log_path))
 }
 
+/// Fail-closed parity with `spawn_local_pod` (which rejects) and firecracker's
+/// `reject_unsupported_policy` (which enforces or rejects): the container driver
+/// sets only a coarse docker `network_mode` and CANNOT enforce a structured
+/// network egress policy (`spec.spec.network`). Silently ignoring one fails OPEN
+/// — the pod would run with unrestricted egress while believing its policy is in
+/// force — so reject it instead. Network policy requires the firecracker driver.
+fn container_driver_reject_unsupported_network_policy(spec: &PodSpec) -> Result<(), ApiError> {
+    if spec.spec.network.is_some() {
+        return Err(ApiError::Driver(
+            "network policy requires the firecracker driver — the container driver cannot enforce \
+             a structured egress policy (it would run with unrestricted egress); \
+             run with --driver firecracker"
+                .to_string(),
+        ));
+    }
+    Ok(())
+}
+
 async fn spawn_container_pod(
     state: &NodeState,
     pod_dir: &Path,
@@ -1444,6 +1462,11 @@ async fn spawn_container_pod(
     id: Uuid,
     raw_yaml: Option<&str>,
 ) -> Result<(DriverState, Option<String>, PathBuf), ApiError> {
+    // Fail-closed: reject a network egress policy the container driver cannot
+    // enforce (parity with spawn_local_pod / firecracker reject_unsupported_policy)
+    // — checked before acquiring the docker client so it rejects even without docker.
+    container_driver_reject_unsupported_network_policy(spec)?;
+
     let docker = state
         .docker
         .as_ref()

--- a/crates/nucleus-node/src/tests_main.rs
+++ b/crates/nucleus-node/src/tests_main.rs
@@ -64,3 +64,40 @@ fn label_selector_empty_value() {
     let labels = BTreeMap::from([("tag".into(), "".into())]);
     assert!(matches_label_selector(&labels, "tag="));
 }
+
+/// Fail-closed parity: the container driver cannot enforce a structured network
+/// egress policy, so it must REJECT one rather than silently ignore it (which
+/// would run the pod with unrestricted egress). RED on main — `spawn_container_pod`
+/// had no such rejection at all.
+#[test]
+fn container_driver_rejects_network_policy_fail_closed() {
+    use nucleus_spec::{PodSpecInner, PolicySpec};
+    use std::path::PathBuf;
+    let mk = |network| {
+        PodSpec::new(PodSpecInner {
+            work_dir: PathBuf::from("/workspace"),
+            timeout_seconds: 3600,
+            policy: PolicySpec::Profile {
+                name: "default".to_string(),
+            },
+            budget_model: None,
+            resources: None,
+            network,
+            image: None,
+            vsock: None,
+            seccomp: None,
+            cgroup: None,
+            audit_sink: None,
+            credentials: None,
+        })
+    };
+    let with_policy = mk(Some(
+        serde_json::from_str::<nucleus_spec::NetworkSpec>("{}").unwrap(),
+    ));
+    assert!(
+        container_driver_reject_unsupported_network_policy(&with_policy).is_err(),
+        "container driver must reject a network egress policy it cannot enforce (fail-closed parity)"
+    );
+    let without = mk(None);
+    assert!(container_driver_reject_unsupported_network_policy(&without).is_ok());
+}


### PR DESCRIPTION
## The fail-open (production driver, HIGH-sev)

The **container driver** (`spawn_container_pod`, `DriverKind::Container` — a **production** driver, **not** cfg-gated like the dev-only local driver) set only a coarse docker `network_mode` from a label/default and **never consulted `spec.spec.network`** (the structured egress policy): it neither enforced nor rejected it. So a pod requesting egress restriction ran with the policy **silently dropped — unrestricted egress** — on a container-driver node. A fail-open containment bypass: the requested control was neither applied nor surfaced.

## Fail-closed parity fix

The other two drivers already fail closed:
- **firecracker** (main.rs:1862): enforces via netns + default-deny, or `reject_unsupported_policy` → `Err`.
- **local (dev)** (main.rs:1301): `if spec.spec.network.is_some() { return Err("network policy requires firecracker driver") }`.

This brings the container driver to **parity — reject the policy it cannot enforce**, checked *before* docker-client acquisition (rejects even without docker). Seccomp is unaffected (container inherits docker's default seccomp profile, which nucleus doesn't disable).

## Verification (RED-first)

`container_driver_rejects_network_policy_fail_closed` — **verified RED** with the guard neutered (a network-policy pod is accepted, policy silently ignored), **GREEN** with the reject in place; a no-policy pod still spawns (no regression). 100 nucleus-node tests + clippy + rustfmt green.

## ⚠️ Behavior note

A container-driver node that was spawning pods with a network egress policy (silently **unenforced**) will now **reject** them with a clear error directing to `--driver firecracker`. Those pods were already running **without** the egress restriction they requested (the fail-open) — this surfaces the misconfiguration rather than silently violating the policy. Internal fail-closed, **parity with the existing local-driver gate**; no wire/trust-root/key/boot change. Auto-armed as a live fail-open closure; reversible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
