### PR TITLE
fix(tool-proxy): approval bundle verified against a PINNED trusted approver key, not the JWS header (close human-approval-gate bypass)

### DIFF
--- a/crates/nucleus-tool-proxy/src/main.rs
+++ b/crates/nucleus-tool-proxy/src/main.rs
@@ -608,36 +608,74 @@ fn load_approval_bundle(
         }
     };
 
-    verify_and_load_approval_bundle(&jws, spec_contents, approvals)
+    let trusted_keys = parse_approval_trusted_keys();
+    verify_and_load_approval_bundle(&jws, spec_contents, approvals, &trusted_keys)
 }
 
-/// Verify a JWS approval bundle and populate the ApprovalRegistry.
+/// Parse the pinned trusted approver keys from `NUCLEUS_APPROVAL_TRUSTED_KEYS`
+/// (a JSON array of JWKs). Unset / empty / parse-error ⇒ empty set ⇒ approval
+/// bundles are refused fail-closed. Mirrors the `NUCLEUS_DECLASSIFY_TRUSTED_KEYS`
+/// pinned-trust-anchor pattern.
+fn parse_approval_trusted_keys() -> Vec<nucleus_identity::did::JsonWebKey> {
+    match std::env::var("NUCLEUS_APPROVAL_TRUSTED_KEYS") {
+        Ok(val) if !val.trim().is_empty() => {
+            match serde_json::from_str::<Vec<nucleus_identity::did::JsonWebKey>>(&val) {
+                Ok(keys) => keys,
+                Err(e) => {
+                    warn!(
+                        error = %e,
+                        "NUCLEUS_APPROVAL_TRUSTED_KEYS is set but is not a valid JSON array of \
+                         JWKs — treating as empty (approval bundles will be refused fail-closed)"
+                    );
+                    Vec::new()
+                }
+            }
+        }
+        _ => Vec::new(),
+    }
+}
+
+/// Verify a JWS approval bundle against a PINNED set of trusted approver keys and
+/// populate the ApprovalRegistry.
+///
+/// SECURITY: the bundle is verified against `trusted_keys` (the pinned approver
+/// trust anchors), NOT against the key embedded in the JWS header. Trusting the
+/// header's own JWK would be vacuous — an attacker could sign a bundle with their
+/// own key, embed that key in the header, and self-verify, bypassing the
+/// human-in-the-loop approval gate. Fail-closed: if no trusted approver key is
+/// configured, the bundle is refused.
 fn verify_and_load_approval_bundle(
     jws: &str,
     spec_contents: &str,
     approvals: &ApprovalRegistry,
+    trusted_keys: &[nucleus_identity::did::JsonWebKey],
 ) -> Result<(), ApiError> {
     let manifest_hash = compute_manifest_hash(spec_contents.as_bytes());
 
-    // Extract the embedded JWK from the JWS header for self-trust verification.
-    // In production, the expected key would come from a pinned trust store.
-    let header = {
-        let header_b64 = jws.split('.').next().ok_or_else(|| {
-            ApiError::Spec("approval bundle is not a valid JWS (no header)".to_string())
-        })?;
-        let header_bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
-            .decode(header_b64)
-            .map_err(|e| ApiError::Spec(format!("approval bundle header decode error: {e}")))?;
-        let header: nucleus_identity::approval_bundle::ApprovalBundleHeader =
-            serde_json::from_slice(&header_bytes)
-                .map_err(|e| ApiError::Spec(format!("approval bundle header parse error: {e}")))?;
-        header
-    };
+    // Fail-closed: never self-trust the bundle's embedded key. Without a pinned
+    // trusted approver key there is no authority to check against, so refuse.
+    if trusted_keys.is_empty() {
+        return Err(ApiError::Spec(
+            "no trusted approver keys configured (set NUCLEUS_APPROVAL_TRUSTED_KEYS) — refusing \
+             to load an approval bundle fail-closed (the embedded JWS key is never self-trusted)"
+                .to_string(),
+        ));
+    }
 
     let verifier = ApprovalBundleVerifier::new();
-    let claims = verifier
-        .verify(jws, &header.jwk, &manifest_hash)
-        .map_err(|e| ApiError::Spec(format!("approval bundle verification failed: {e}")))?;
+    // Verify against each PINNED trusted approver key; accept the first that the
+    // bundle validly matches (correct key + valid signature + manifest binding).
+    // A bundle signed by any non-trusted key is rejected.
+    let claims = trusted_keys
+        .iter()
+        .find_map(|tk| verifier.verify(jws, tk, &manifest_hash).ok())
+        .ok_or_else(|| {
+            ApiError::Spec(
+                "approval bundle signer is not a trusted approver key (or the signature / \
+                 manifest binding is invalid)"
+                    .to_string(),
+            )
+        })?;
 
     // Populate the ApprovalRegistry with the approved operations
     let count = claims.max_uses.map(|n| n as usize).unwrap_or(usize::MAX);

--- a/crates/nucleus-tool-proxy/src/tests_main.rs
+++ b/crates/nucleus-tool-proxy/src/tests_main.rs
@@ -179,7 +179,7 @@ fn make_test_key() -> (Vec<u8>, nucleus_identity::did::JsonWebKey) {
 
 #[test]
 fn test_approval_bundle_populates_registry() {
-    let (pkcs8, _jwk) = make_test_key();
+    let (pkcs8, jwk) = make_test_key();
     let spec = "apiVersion: nucleus/v1\nkind: Pod\nspec:\n  work_dir: .";
     let manifest_hash = compute_manifest_hash(spec.as_bytes());
 
@@ -193,7 +193,7 @@ fn test_approval_bundle_populates_registry() {
             .unwrap();
 
     let registry = ApprovalRegistry::default();
-    let result = verify_and_load_approval_bundle(&jws, spec, &registry);
+    let result = verify_and_load_approval_bundle(&jws, spec, &registry, std::slice::from_ref(&jwk));
 
     assert!(result.is_ok(), "verify_and_load failed: {:?}", result);
     assert!(
@@ -209,7 +209,7 @@ fn test_approval_bundle_populates_registry() {
 
 #[test]
 fn test_approval_bundle_wrong_manifest() {
-    let (pkcs8, _jwk) = make_test_key();
+    let (pkcs8, jwk) = make_test_key();
     let manifest_hash = compute_manifest_hash(b"different-manifest");
 
     let jws =
@@ -221,13 +221,18 @@ fn test_approval_bundle_wrong_manifest() {
             .unwrap();
 
     let registry = ApprovalRegistry::default();
-    let result = verify_and_load_approval_bundle(&jws, "actual-manifest-content", &registry);
+    let result = verify_and_load_approval_bundle(
+        &jws,
+        "actual-manifest-content",
+        &registry,
+        std::slice::from_ref(&jwk),
+    );
     assert!(result.is_err(), "should fail with manifest hash mismatch");
 }
 
 #[test]
 fn test_approval_bundle_max_uses() {
-    let (pkcs8, _jwk) = make_test_key();
+    let (pkcs8, jwk) = make_test_key();
     let spec = "spec: limited-use";
     let manifest_hash = compute_manifest_hash(spec.as_bytes());
 
@@ -241,7 +246,7 @@ fn test_approval_bundle_max_uses() {
             .unwrap();
 
     let registry = ApprovalRegistry::default();
-    verify_and_load_approval_bundle(&jws, spec, &registry).unwrap();
+    verify_and_load_approval_bundle(&jws, spec, &registry, std::slice::from_ref(&jwk)).unwrap();
 
     // Should only allow 2 uses
     assert!(registry.consume("write_files"));
@@ -254,8 +259,16 @@ fn test_approval_bundle_max_uses() {
 
 #[test]
 fn test_approval_bundle_invalid_jws() {
+    let (_pkcs8, jwk) = make_test_key();
     let registry = ApprovalRegistry::default();
-    let result = verify_and_load_approval_bundle("not.a.valid.jws", "spec", &registry);
+    // A trusted key IS configured, so this exercises the invalid-JWS rejection
+    // (not the fail-closed-empty path).
+    let result = verify_and_load_approval_bundle(
+        "not.a.valid.jws",
+        "spec",
+        &registry,
+        std::slice::from_ref(&jwk),
+    );
     assert!(result.is_err());
 }
 
@@ -539,4 +552,65 @@ mod ingest_content_address {
             plain.session_taint_ceiling()
         );
     }
+}
+
+/// SECURITY (approval-gate bypass): the approval bundle must be verified against a
+/// PINNED trusted approver key, never the key embedded in the JWS header. Old code
+/// passed `&header.jwk` (attacker-controlled) as the expected key → any
+/// self-signed bundle verified → the human-approval gate was bypassable. RED on
+/// that code; GREEN now (pinned-key + fail-closed).
+#[test]
+fn approval_bundle_requires_pinned_trusted_key_not_header_self_trust() {
+    use nucleus_identity::approval_bundle::{compute_manifest_hash, ApprovalBundleBuilder};
+
+    let spec = "pod: spec yaml";
+    let manifest_hash = compute_manifest_hash(spec.as_bytes());
+
+    // Attacker signs a bundle approving a dangerous op with THEIR OWN key.
+    let (attacker_key, attacker_jwk) = make_test_key();
+    let jws = ApprovalBundleBuilder::new("spiffe://attacker/evil")
+        .approve_operation("run_bash")
+        .manifest_hash(&manifest_hash)
+        .ttl_seconds(3600)
+        .build(&attacker_key)
+        .unwrap();
+
+    // (1) Fail-closed: no trusted approver key configured ⇒ refuse.
+    let approvals = ApprovalRegistry::default();
+    let err = verify_and_load_approval_bundle(&jws, spec, &approvals, &[]).unwrap_err();
+    assert!(
+        format!("{err}").contains("no trusted approver keys"),
+        "empty trusted set must refuse fail-closed, got: {err}"
+    );
+
+    // (2) THE FIX: attacker's self-signed bundle REJECTED when the pinned trusted
+    // approver is a DIFFERENT (legit) key. Old self-trust code ACCEPTED it.
+    let (_legit_key, legit_jwk) = make_test_key();
+    let approvals = ApprovalRegistry::default();
+    assert!(
+        verify_and_load_approval_bundle(&jws, spec, &approvals, std::slice::from_ref(&legit_jwk))
+            .is_err(),
+        "a bundle signed by a non-trusted key must be rejected (no header self-trust)"
+    );
+    assert!(
+        !approvals.consume("run_bash"),
+        "the attacker's operation must NOT be registered"
+    );
+
+    // (3) No false-negative: a bundle whose signer IS the pinned trusted approver verifies.
+    let approvals = ApprovalRegistry::default();
+    assert!(
+        verify_and_load_approval_bundle(
+            &jws,
+            spec,
+            &approvals,
+            std::slice::from_ref(&attacker_jwk)
+        )
+        .is_ok(),
+        "a bundle from the configured trusted approver must verify"
+    );
+    assert!(
+        approvals.consume("run_bash"),
+        "the trusted-signed operation must be registered"
+    );
 }


### PR DESCRIPTION
## The bypass (HIGH-sev, human-approval gate)

`verify_and_load_approval_bundle` passed the JWS header's **own embedded JWK** (`&header.jwk`, attacker-controlled) as the `expected_key` to `ApprovalBundleVerifier::verify` — so the verifier's trust-anchor check (`header.jwk == expected_key`) was **vacuous** (`header.jwk == header.jwk`). An attacker signs an approval bundle with **their own** key, embeds it in the header, and it self-verifies → the bundle's `approved_operations` load into the `ApprovalRegistry` → **the human-in-the-loop approval gate is bypassed** (self-approve any approval-required op, e.g. uninhabitable-state exfil). The code even admitted it: *"In production, the expected key would come from a pinned trust store."*

## Fix (fail-closed)

Verify against a **pinned** set of trusted approver keys (`NUCLEUS_APPROVAL_TRUSTED_KEYS`, a JSON array of JWKs — mirrors the `NUCLEUS_DECLASSIFY_TRUSTED_KEYS` pinned-anchor pattern), **never** the header's own key. No trusted approver configured ⇒ **refuse** (fail-closed). A bundle signed by any non-trusted key is rejected.

## Verification (RED-first)

`approval_bundle_requires_pinned_trusted_key_not_header_self_trust`:
1. empty trusted set ⇒ refuse;
2. attacker-signed bundle with a *different* pinned trusted key ⇒ **rejected** + operation **not** registered;
3. bundle from the *configured* trusted approver ⇒ accepted.

**Verified RED** by temporarily restoring the self-trust behavior (the attacker bundle was accepted). The 4 existing approval-bundle tests updated to pass the signer's key as the pinned trusted key. 5 approval tests + clippy + rustfmt green.

## ⚠️ GATED — needs your decision (not auto-armed)

Two reasons this is unarmed for your call:
1. **New trust anchor on a security-critical gate:** it moves the approval path from self-trust → pinned-key trust.
2. **Trusted-key SOURCE is a design decision:** I implemented **env-configured JWKs** (`NUCLEUS_APPROVAL_TRUSTED_KEYS`) mirroring `declassify_trusted_keys` — but you may prefer an **SVID / DID trust-store** integration. The env approach is the minimal fail-closed fix; the source is pluggable.

**Behavior note:** a deployment using approval bundles must now set `NUCLEUS_APPROVAL_TRUSTED_KEYS` or bundles are refused — but the old path accepted **forgeries**, so this closes a bypass. Reversible; no wire-format/trust-root/key change to existing signed data. **Recommendation: arm** (the current self-trust is an exploitable approval-gate bypass), and confirm the env-JWK key source (or redirect to SVID/DID).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
