### PR TITLE
arch(effects): decide against a monad tower and against F*; land the affine authority shape

### DIFF
--- a/crates/portcullis-effects/src/authority.rs
+++ b/crates/portcullis-effects/src/authority.rs
@@ -1,0 +1,184 @@
+//! `Authority` — a spent-on-use wrapper over [`DischargedBundle`].
+//!
+//! ## What this is for
+//!
+//! Today every effect takes `proof: &DischargedBundle`. In the vocabulary of
+//! effect systems that is `ReaderT Capability`: authority that is **ambient and
+//! readable at every bind**. [`require_scope`](crate::require_scope) rejects a
+//! bundle earned for a *different* action — real, and worth having — but nothing
+//! stops a *matching* bundle being replayed arbitrarily often. The one-shot
+//! property the Lean side proves has no counterpart in the Rust types.
+//!
+//! The fix is not a type-system fight. `DischargedBundle` is **already affine**:
+//! it is `!Clone`, `!Copy` and `#[must_use]`. The only reason it can be replayed
+//! is that it is passed by reference rather than moved. `Authority` is that
+//! move, made explicit and given a name.
+//!
+//! ## Affine, not linear — and affine is the one we want
+//!
+//! Rust gives *use at most once*, not *use exactly once*. At-most-once is
+//! precisely what one-shot declassification needs, so the weaker guarantee is
+//! the correct one. (A widely repeated claim that Rust 1.95 shipped linear types
+//! via `std::marker::MustMove` is false — checked against 1.96.1, which is
+//! newer; the trait does not exist.)
+//!
+//! ## Status: a shape, not the cutover
+//!
+//! This type is deliberately **not** wired into the effect traits. Doing that is
+//! a signature change through every layer from `PreflightOutcome::Allowed` down
+//! to each effect impl, and it is a change to the enforcement path of a security
+//! runtime. What lands here is the shape and its proofs, so the call sites can be
+//! read before anyone commits to that refactor. See
+//! `docs/architecture/effect-sequencing-and-authority.md`.
+
+use portcullis_core::discharge::DischargedBundle;
+use portcullis_core::{Operation, SinkClass};
+
+/// One authorised action, **spent when used**.
+///
+/// Holding an `Authority` is the right to perform exactly one operation. The
+/// scope check consumes it, so a second use is a compile error rather than a
+/// policy someone has to remember.
+///
+/// ## A single authority authorises a single action
+///
+/// A `compile_fail` doctest passes when the snippet fails to compile FOR ANY
+/// REASON — a typo would satisfy it just as well as the moved value. The error
+/// code below looks like it pins the reason. **It does not:** rustdoc on this
+/// toolchain does not enforce it (measured — swapping `E0382` for an unrelated
+/// `E0433` left the suite green). It is kept as documentation of intent only.
+///
+/// What actually establishes the reason is perturbation: delete the second
+/// `spend` and this snippet COMPILES, so the failure does depend on the replay
+/// and on nothing else. That was checked, not assumed.
+///
+/// ```compile_fail,E0382
+/// use portcullis_effects::authority::Authority;
+/// use portcullis_core::discharge::test_helpers::bundle_for;
+/// use portcullis_core::{Operation, SinkClass};
+///
+/// let authority = Authority::new(bundle_for(Operation::RunBash, SinkClass::BashExec));
+/// let _first = authority.spend(Operation::RunBash, SinkClass::BashExec);
+/// // Replay: `authority` was moved by the first `spend`.
+/// let _second = authority.spend(Operation::RunBash, SinkClass::BashExec);
+/// ```
+///
+/// ## …and it cannot be duplicated to get around that
+///
+/// ```compile_fail,E0599
+/// use portcullis_effects::authority::Authority;
+/// use portcullis_core::discharge::test_helpers::bundle_for;
+/// use portcullis_core::{Operation, SinkClass};
+///
+/// let authority = Authority::new(bundle_for(Operation::RunBash, SinkClass::BashExec));
+/// // `DischargedBundle` is deliberately not `Clone`, so neither is this.
+/// let copy = authority.clone();
+/// ```
+#[must_use = "an Authority that is never spent is an action that was authorised and not taken"]
+pub struct Authority {
+    bundle: DischargedBundle,
+}
+
+/// Why an authority could not be spent.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SpendError {
+    /// The authority was earned for a different (operation, sink) pair.
+    ScopeMismatch(String),
+}
+
+impl std::fmt::Display for SpendError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SpendError::ScopeMismatch(why) => write!(f, "{why}"),
+        }
+    }
+}
+
+impl std::error::Error for SpendError {}
+
+impl Authority {
+    /// Wrap a discharged bundle as a single-use authority.
+    ///
+    /// Takes the bundle **by value**: the caller gives up the ability to use it
+    /// again, which is the entire point.
+    pub fn new(bundle: DischargedBundle) -> Self {
+        Authority { bundle }
+    }
+
+    /// The operation and sink this authority was earned for, without spending it.
+    pub fn scope(&self) -> (Operation, SinkClass) {
+        (self.bundle.operation(), self.bundle.sink_class())
+    }
+
+    /// Spend this authority on exactly one `(operation, sink)` pair.
+    ///
+    /// Consumes `self`. On success the bundle is handed back so the caller can
+    /// pass it to today's `&DischargedBundle` effect surface — this is the
+    /// transitional seam, and it is worth being precise about what it does and
+    /// does not buy:
+    ///
+    /// * **Bought:** one `Authority` authorises one scope check. Holding it
+    ///   twice, or checking two different scopes with it, will not compile.
+    /// * **Not bought:** once the bundle is handed back, the old ambient
+    ///   surface applies to it again. Closing that is the signature change
+    ///   through the effect traits, which this type exists to inform rather
+    ///   than to pre-empt.
+    pub fn spend(self, op: Operation, sink: SinkClass) -> Result<DischargedBundle, SpendError> {
+        crate::require_scope(&self.bundle, op, sink).map_err(SpendError::ScopeMismatch)?;
+        Ok(self.bundle)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use portcullis_core::discharge::test_helpers::bundle_for;
+
+    #[test]
+    fn an_authority_spends_on_the_scope_it_was_earned_for() {
+        let a = Authority::new(bundle_for(Operation::RunBash, SinkClass::BashExec));
+        assert_eq!(a.scope(), (Operation::RunBash, SinkClass::BashExec));
+        assert!(a.spend(Operation::RunBash, SinkClass::BashExec).is_ok());
+    }
+
+    /// The confused deputy, at the authority layer: a right earned for writing
+    /// files does not become a right to run a shell just because both are
+    /// "allowed". Same property `require_scope` enforces, restated where the
+    /// caller actually holds the thing.
+    #[test]
+    fn an_authority_earned_for_one_action_will_not_spend_on_another() {
+        let a = Authority::new(bundle_for(Operation::WriteFiles, SinkClass::WorkspaceWrite));
+        let err = a
+            .spend(Operation::RunBash, SinkClass::BashExec)
+            .expect_err("a write authority must not buy a shell execution");
+        let SpendError::ScopeMismatch(why) = err;
+        assert!(
+            why.contains("WriteFiles") && why.contains("RunBash"),
+            "the refusal should name both the authority held and the action attempted: {why}"
+        );
+    }
+
+    /// The affine property is INHERITED, not invented here: it holds because
+    /// `DischargedBundle` is `!Clone`, and if that ever changed every guarantee
+    /// above would quietly become advisory.
+    ///
+    /// There is no runtime assertion for this. Rust cannot state a negative
+    /// bound, and the trick that looks like it can — a generic `is_clone::<T>()`
+    /// helper — asserts nothing about the type it names and is rejected by
+    /// clippy as an unused parameter. It was written, and deleted, rather than
+    /// left in place looking like evidence.
+    ///
+    /// The property is carried by the `compile_fail` doctest on `Authority`,
+    /// whose dependence on the replay was established by perturbation.
+    #[test]
+    fn spending_returns_the_bundle_for_the_transitional_surface() {
+        let a = Authority::new(bundle_for(Operation::RunBash, SinkClass::BashExec));
+        let bundle = a
+            .spend(Operation::RunBash, SinkClass::BashExec)
+            .expect("in-scope spend succeeds");
+        // The seam, stated: the bundle comes back, so today's `&`-taking effect
+        // surface still applies to it. One Authority buys one scope check, not
+        // one effect invocation.
+        assert_eq!(bundle.operation(), Operation::RunBash);
+    }
+}

--- a/crates/portcullis-effects/src/lib.rs
+++ b/crates/portcullis-effects/src/lib.rs
@@ -50,6 +50,8 @@
 pub mod async_traits;
 pub mod runtime;
 
+pub mod authority;
+
 use std::collections::BTreeMap;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -416,7 +418,7 @@ impl WebEffect for RealEffects {
 /// The COMPILE-TIME form would make the bundle generic in the operation
 /// (`DischargedBundle<RunBash>`) so a mismatch could not be written at all. That
 /// is a refactor through every signature and caller; this closes the hole now.
-fn require_scope(
+pub(crate) fn require_scope(
     proof: &DischargedBundle,
     op: portcullis_core::Operation,
     sink: portcullis_core::SinkClass,

--- a/docs/architecture/effect-sequencing-and-authority.md
+++ b/docs/architecture/effect-sequencing-and-authority.md
@@ -1,0 +1,128 @@
+# Effect sequencing and authority — why not a monad tower, and why not F\*
+
+Status: **decided**, 2026-07-26. Supersedes nothing; records a fork that was
+evaluated and closed so it is not re-opened from scratch.
+
+## The question
+
+Nested permissions and context — the discharge bundle, the IFC floating label,
+the delegation ceiling, the budget — look like a monad transformer stack. The
+appeal is concrete and worth taking seriously: **concise sequencing**. Threading
+four kinds of context by hand through every effect is the ergonomic cost we
+actually pay.
+
+Two candidate answers were examined: build the tower in Rust, or adopt F\* for
+its indexed effects.
+
+## What is already true
+
+`portcullis-wasi::ifc::BoundaryMonitor` **is** LIO with the monad removed: `pc`
+starts at `⊥`, `stamp` joins (monotone, only raises), `check` tests `flows_to` at
+the sink, and declassify is the sole lowering step. That is exactly the
+floating-label discipline of Stefan et al.'s `LIO` monad, implemented as a
+`&mut struct`. The shape fits; the question is only what an explicit encoding
+buys.
+
+And the enforcement path already **is** a monadic encoding — the least safe one.
+`proof: &DischargedBundle` at every effect boundary is `ReaderT Capability`:
+authority that is ambient and readable at every bind. `require_scope` rejects a
+bundle earned for a *different* action, which is real and was worth building. It
+does not stop a *matching* bundle from being replayed arbitrarily often. The
+one-shot property the Lean side proves has no counterpart in the Rust types.
+
+## Decision 1 — no monad transformer tower
+
+A tower is a good *description* of the sequencing and a poor *enforcement*
+mechanism, because it flattens the two properties the design rests on:
+
+* **Authority is graded, not ambient.** A monad has one fixed effect signature;
+  `ReaderT` makes the capability duplicable at every `>>=`. What the design needs
+  is a *graded* monad indexed by the permission lattice — "consumes authority
+  `a`, yields `b`" — so composition is the lattice operation. The algebra is
+  already present, unnamed: `delegation_is_functor` (`c' ≤ c → c'.scope ⊆
+  c.scope`) is a monotone map of preorders.
+* **One-shot tokens are affine, and monads duplicate.** Nothing in the monad laws
+  forbids `tok >>= \t -> f t >> g t`. Rust's move semantics already gives
+  at-most-once for free; a monadic re-encoding would trade that away.
+
+Transformer order is also a security property here rather than a style choice:
+`StateT s (Except e)` discards state on failure, `ExceptT e (State s)` keeps it.
+For a taint label and an audit trail, "what survives a denial" is exactly the
+kind of thing that should be stated and tested. It currently is not.
+
+## Decision 2 — no F\*
+
+F\* is the most mature system with genuine indexed effects, and Pulse/Steel are
+real (StarMalloc, HACL\*). It is still the wrong move here, for three reasons in
+ascending order of weight.
+
+1. **It moves off the recommended Aeneas backend.** Aeneas supports F\*, but its
+   most mature backends are Lean and HOL4; Lean is the recommended one and the
+   only one with partial functions, extrinsic termination proofs, and tactics for
+   monadic programs. `OlogCoreGen` is already the broken link in the Rust→Lean
+   chain — a less mature backend makes that worse.
+2. **It is a third kernel substrate.** olog's `check-language-sprawl.sh`
+   (Pa.Defense.A.1) states the rule: every active language is either the verified
+   kernel substrate (Rust/Lean) or a thin known-shape mount. This programme has
+   already made this call once — the Coq beachhead in capability-primitive was
+   retired as **debt, not an asset**: an option that is paid for and not
+   exercised.
+3. **Z3 enters the trusted base.** F\* is SMT-backed. For a programme whose thesis
+   is an enumerable trusted base — measured at 44 entries and, in the same week,
+   demonstrated irreducible by two independent mechanisms — adding an SMT solver
+   is a qualitative change from Lean's small kernel. It is also *priced*:
+   `report-trusted-base.py --gate` ratchets `proved edges / trusted entries`, and
+   F\* adds observations (build, verify, extract) with no new proved edges. **The
+   assurance ratio falls and the gate fires.** The metric registers this decision
+   as a regression before any human argues about it.
+
+The clearest way to see the mismatch: the ergonomic cost is at **Rust call
+sites**. F\* would not improve them. It relocates where the proof lives, which is
+an answer to an adjacent question.
+
+**What would re-open this:** if the Iris-in-Lean liveness work turns out to be
+permanently blocked rather than staged, Pulse/Steel is a genuine alternative for
+the concurrency track specifically. That is the one place F\* competes with
+something already invested in and resisted, so it is where to look — not a reason
+to switch wholesale.
+
+## Decision 3 — what to do instead
+
+**Rust: a consuming chain is linear do-notation.** `self` by value is a bind that
+consumes; `?` is the `ExceptT` layer with syntax support already; a phantom
+parameter carries the grade:
+
+```rust
+session.read(input)?.exec(cmd)?.egress(sink)?
+```
+
+Replay becomes a move-after-move compile error rather than a policy. No HKT, no
+new dependency, nothing added to the trusted base. This is the same move `dlc-d`
+already made — *compilation is the proof*.
+
+Note the precise property Rust gives: **affine** (use at most once), not linear
+(use exactly once). At-most-once is what one-shot declassification needs, so the
+weaker guarantee is the right one. A widely-circulated claim that Rust 1.95
+shipped linear types via a `std::marker::MustMove` trait is **false** — checked
+against 1.96.1, which is newer; the trait does not exist.
+
+**Lean: the graded structure already exists.** `delegation_calc`'s `Deriv` is an
+indexed family. If the syntax is wanted, a `do`-macro over an indexed bind is
+bounded work, not a language migration.
+
+## Cost, stated
+
+A linear spine is awkward for branching and parallel composition — one authority
+threading through one chain. If an action genuinely fans out, the chain is the
+wrong shape and the honest answer is to mint separate authorities. Grades also
+explode combinatorially if the lattice is fine-grained, so keep them coarse:
+`Operation` × `SinkClass`, which is what `require_scope` already checks.
+
+## References
+
+* Stefan et al., [Flexible Dynamic Information Flow Control in Haskell](https://www.scs.stanford.edu/~dm/home/papers/stefan:lio.pdf) — LIO
+* [Unifying graded and parameterised monads](https://arxiv.org/pdf/2001.10274)
+* [Granule](https://www.cs.kent.ac.uk/people/staff/dao7/publ/granule-icfp19.pdf) — graded modal types over a linear calculus
+* [Handlers in Action](https://homepages.inf.ed.ac.uk/slindley/papers/handlers.pdf) — why handlers beat transformer stacks ergonomically
+* [Programming and Proving with Indexed Effects](https://fstar-lang.org/papers/indexedeffects/indexedeffects.pdf) — F\*
+* [Aeneas](https://github.com/AeneasVerif/aeneas) — backend maturity


### PR DESCRIPTION
Records an architecture fork that was evaluated and closed, and lands the Rust half of the alternative as a **shape, not a cutover**.

### What was already true

`BoundaryMonitor` **is** LIO with the monad removed — `pc` at ⊥, `stamp` = monotone join, `check` = `flows_to` at the sink, declassify the sole lowering step.

And the enforcement path already *is* a monadic encoding, the least safe one: `proof: &DischargedBundle` at every effect boundary is `ReaderT Capability` — authority that is ambient and readable at every bind. `require_scope` rejects a bundle earned for a *different* action; nothing stops a *matching* one being replayed.

### Why not a monad tower

It flattens the two properties the design rests on. Authority is **graded** (needs indexing by the permission lattice, not a fixed effect signature), and one-shot tokens are **affine** — nothing in the monad laws forbids using a token twice, while Rust's move semantics already does, and a monadic re-encoding would trade that away. Transformer *order* is also a security property here (`StateT`-over-`Except` discards state on failure; `ExceptT`-over-`State` keeps it), and "what survives a denial" is currently unstated.

### Why not F\*

1. It moves off Aeneas's most mature backend — Lean is the recommended one, and `OlogCoreGen` is already the broken link in the Rust→Lean chain.
2. It's a third kernel substrate. olog's `check-language-sprawl.sh` names Rust/Lean as *the* substrate, and this programme already retired the Coq beachhead as debt.
3. **Z3 enters the trusted base.** F\* is SMT-backed. For a programme whose thesis is an enumerable trusted base — measured at 44 and shown irreducible this week — that's a qualitative change from Lean's small kernel, and it's *priced*: `report-trusted-base.py --gate` ratchets proved-edges/trusted-entries, so F\* adds observations with no new proved edges, the ratio falls, **and the gate fires**.

In one line: the ergonomic cost is at Rust call sites, and F\* wouldn't improve them — it relocates where the proof lives.

### What landed

`portcullis_effects::authority::Authority`, a spent-on-use wrapper. The finding that made it cheap: **`DischargedBundle` is already `!Clone`, `!Copy`, `#[must_use]`** — affine by construction. The only reason it can be replayed is that it's passed by reference instead of moved.

Deliberately **not** wired into the effect traits — that's a signature change through every layer from `PreflightOutcome::Allowed` down, on the enforcement path of a security runtime. This lands the shape and its proofs so the call sites can be read first.

### Two corrections, both from biting my own work

- A widely repeated claim that **Rust 1.95 shipped linear types via `std::marker::MustMove` is false** — checked against 1.96.1, which is newer. Rust gives *affine* (at most once), which is what one-shot declassification actually needs.
- I claimed `compile_fail,E0382` pins the failure *reason*. **It does not** — rustdoc here ignores the code (swapping it for an unrelated `E0433` left the suite green). The reason is established by perturbation instead: delete the second `spend` and the snippet compiles. The doc says so rather than implying a guarantee it lacks.

Also deleted a test that looked like evidence and wasn't — an `is_clone::<T>()` trick asserting `SpendError: Clone`, which says nothing about `DischargedBundle`, and which clippy correctly rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CSapSUYcfe9p3sYtBju9TL
