### PR TITLE
docs(fm-4): re-derive the remaining four cmdline keys instead of inheriting notes

### DIFF
--- a/crates/nucleus-node/src/firecracker_config.rs
+++ b/crates/nucleus-node/src/firecracker_config.rs
@@ -1021,7 +1021,7 @@ mod tests {
     use proptest::prelude::*;
     use std::collections::HashSet;
     use std::ffi::OsString;
-    use std::path::{Path, PathBuf};
+    use std::path::PathBuf;
 
     /// Minimal valid PodSpec with all optional sections defaulted to absent.
     /// Built by deserialization so it exercises the real spec defaults rather
@@ -1051,8 +1051,8 @@ mod tests {
     fn boot_args_with_identity(will_have_identity: bool) -> String {
         let config = FirecrackerConfig::from_spec(
             &base_spec(),
-            Path::new("/unused/firecracker.log"),
-            Path::new("/unused/vsock.sock"),
+            std::path::Path::new("/unused/firecracker.log"),
+            std::path::Path::new("/unused/vsock.sock"),
             &image(true, false),
             None,
             "auth-secret",

--- a/crates/nucleus-node/src/snapshot.rs
+++ b/crates/nucleus-node/src/snapshot.rs
@@ -73,7 +73,34 @@
 /// `nucleus.workload_api_port` is NOT here: it is a port number, identical for
 /// every pod on a node, and carries no authority by itself — the identity it
 /// leads to is gated separately by `net::decide_identity_grant`.
-/// # The next removal, and what has to be true first
+/// # The remaining four, each re-derived rather than inherited
+///
+/// `nucleus.sandbox_token` was removed for identity-bearing pods once the
+/// blocking question turned out to be the wrong one — it was filed as needing a
+/// booted pod to confirm attestation, when attestation only distinguishes Tier 1
+/// from Tier 2 and both satisfy the proof. That is a reason to re-derive the
+/// others rather than inherit their notes:
+///
+/// * **`nucleus.approval_secret`** — NOT redundant. `select_auth_tier` puts the
+///   approval path on `ApprovalHmacDrand` *above* `HostVsock`, deliberately: a
+///   host-verified transport does not remove the drand anchor from an approval.
+///   A conditional emission would need "this pod can never require approval"
+///   derived from the resolved policy, and `requires_approval` lives on an
+///   autonomy ceiling rather than on `PermissionLattice`. Getting that wrong
+///   fails approvals at the moment a human is meant to be in the loop, which is
+///   a worse failure than the exposure it would close.
+/// * **`nucleus.task_token_hex` / `_issuer` / `_nonce`** — these are documented
+///   at the emission site as *"a scoped capability + PUBLIC issuer key — NOT a
+///   secret"*, with anti-replay resting on a host-pinned nonce. They are in
+///   [`PER_POD_SECRET_KEYS`] for a different reason: they are **per-pod**, and a
+///   clone that inherited them would duplicate a value minted for one pod. So
+///   the fix is not to stop emitting them but to deliver them **after restore**,
+///   over a channel that is not the command line. The workload API vsock bridge
+///   is already that shape — it serves per-pod SVIDs over a per-pod socket — and
+///   carrying the task token on it is the next real piece of work here. It is
+///   architecture, not a conditional.
+///
+/// # An earlier note, and what has to be true first
 ///
 /// `nucleus.sandbox_token` is the strongest candidate for deletion rather than
 /// relocation — the same shape as `nucleus.auth_secret`, which Phase 1 deleted


### PR DESCRIPTION
`sandbox_token` came off the command line in #2107 only because its recorded
blocker turned out to be **the wrong question** — filed as needing a booted pod
to confirm attestation, when attestation only distinguishes Tier 1 from Tier 2
and *both* satisfy the proof. That is a reason to re-derive the other four rather
than trust their notes.

## `approval_secret` is not redundant

The easy mistake here is arguing by analogy with `auth_secret`, which *was*
deleted once the vsock peer check made it redundant. It doesn't transfer:
`select_auth_tier` puts the approval path on `ApprovalHmacDrand` **above**
`HostVsock`, deliberately — a host-verified transport does not remove the drand
anchor from an approval.

A conditional emission would need *"this pod can never require approval"* derived
from the resolved policy, and `requires_approval` lives on an autonomy ceiling
rather than on `PermissionLattice`. Getting that wrong fails approvals **at the
moment a human is meant to be in the loop** — a worse failure than the exposure
it would close.

## The three `task_token_*` keys are not secrets at all

The emission site says so outright: *"a scoped capability + PUBLIC issuer key —
NOT a secret"*, with anti-replay resting on a host-pinned nonce.

They are in `PER_POD_SECRET_KEYS` for a **different reason**: they are *per-pod*,
and a clone restored from a snapshot would duplicate a value minted for one pod.

So the fix is not to stop emitting them but to **deliver them after restore**,
over a channel that is not the command line. The workload API vsock bridge is
already exactly that shape — per-pod SVIDs over a per-pod socket — and carrying
the task token on it is the next real piece of work. It is architecture, not a
conditional, and saying so is the point of this change.

## Also: a warning I introduced

Gating `boot_args_with_identity` behind `cfg(linux)` in #2107 left its `Path`
import unused on macOS. CI is Linux, so it stayed green — which is exactly why it
was worth catching locally rather than trusting the pipeline.

## Verification

macOS clippy clean; OrbStack `clippy -D warnings` clean and 211 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JrdSLoPjBVXhQq3Xmh1TVa