### PR TITLE
DLC-D verified admission on the kernel's live decision path (feature dlc)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3226,7 +3226,38 @@ dependencies = [
 [[package]]
 name = "dlc-core"
 version = "1.5.0"
-source = "git+https://github.com/coproduct-opensource/delegation_calc.git?rev=bc7bc35ff79226267c906a2e1f1317cae6e918bb#bc7bc35ff79226267c906a2e1f1317cae6e918bb"
+source = "git+https://github.com/coproduct-opensource/delegation_calc.git?rev=34358234cb46279c4ce8a8729736a4135174f65a#34358234cb46279c4ce8a8729736a4135174f65a"
+
+[[package]]
+name = "dlc-crypto"
+version = "1.5.0"
+source = "git+https://github.com/coproduct-opensource/delegation_calc.git?rev=34358234cb46279c4ce8a8729736a4135174f65a#34358234cb46279c4ce8a8729736a4135174f65a"
+dependencies = [
+ "dlc-core",
+ "ed25519-dalek 2.2.0",
+ "sha2 0.11.0",
+ "thiserror 2.0.19",
+]
+
+[[package]]
+name = "dlc-d"
+version = "1.5.0"
+source = "git+https://github.com/coproduct-opensource/delegation_calc.git?rev=34358234cb46279c4ce8a8729736a4135174f65a#34358234cb46279c4ce8a8729736a4135174f65a"
+dependencies = [
+ "dlc-core",
+ "dlc-crypto",
+ "dlc-d-macro",
+]
+
+[[package]]
+name = "dlc-d-macro"
+version = "1.5.0"
+source = "git+https://github.com/coproduct-opensource/delegation_calc.git?rev=34358234cb46279c4ce8a8729736a4135174f65a#34358234cb46279c4ce8a8729736a4135174f65a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "dlopen2"
@@ -8285,6 +8316,9 @@ dependencies = [
  "cedar-policy",
  "cel-interpreter",
  "chrono",
+ "dlc-core",
+ "dlc-crypto",
+ "dlc-d",
  "ed25519-dalek 3.0.0-pre.7",
  "hex",
  "hmac 0.13.0",

--- a/crates/nucleus-mcp/src/main.rs
+++ b/crates/nucleus-mcp/src/main.rs
@@ -567,6 +567,9 @@ fn format_deny_reason(reason: &DenyReason) -> String {
         DenyReason::CedarDenied { detail } => {
             format!("cedar policy denied: {detail}")
         }
+        DenyReason::DlcAdmissionDenied { detail } => {
+            format!("verified admission denied: {detail}")
+        }
     }
 }
 

--- a/crates/nucleus-policy-cert/Cargo.toml
+++ b/crates/nucleus-policy-cert/Cargo.toml
@@ -60,7 +60,7 @@ ed25519-dalek = { workspace = true, optional = true }
 # for the `dlc` bridge. no_std + zero-dep (only core/alloc), the Aeneas→Lean
 # translation target carrying T1–T4 — so depending on it keeps THIS crate a
 # leaf. Git-pinned like the other cross-repo upstreams.
-dlc-core = { git = "https://github.com/coproduct-opensource/delegation_calc.git", rev = "bc7bc35ff79226267c906a2e1f1317cae6e918bb", optional = true }
+dlc-core = { git = "https://github.com/coproduct-opensource/delegation_calc.git", rev = "34358234cb46279c4ce8a8729736a4135174f65a", optional = true }
 # Portcullis capability lattice + delegation certificates, for the `portcullis`
 # bridge. `default-features = false` drops `ring`/`cedar` (we only need the
 # always-compiled data types — VerifiedPermissions / PermissionLattice). Now an

--- a/crates/nucleus-tool-proxy/src/main.rs
+++ b/crates/nucleus-tool-proxy/src/main.rs
@@ -2414,7 +2414,8 @@ fn kernel_denial_to_api_error(operation: Operation, subject: &str, reason: DenyR
         | DenyReason::ActionTermRejected { .. }
         | DenyReason::SinkScopeDenied { .. }
         | DenyReason::IfcUnsafe { .. }
-        | DenyReason::CedarDenied { .. }) => {
+        | DenyReason::CedarDenied { .. }
+        | DenyReason::DlcAdmissionDenied { .. }) => {
             ApiError::KernelDenied(format!("{other:?} (operation {operation:?} on {subject})"))
         }
     }

--- a/crates/portcullis/Cargo.toml
+++ b/crates/portcullis/Cargo.toml
@@ -38,6 +38,15 @@ remote-audit = ["dep:aws-sdk-s3", "dep:aws-config", "dep:tokio", "serde"]
 # Cedar policy language integration (CNCF Sandbox project)
 cedar = ["dep:cedar-policy", "serde"]
 
+# DLC-D verified admission (#says-admission): a cryptographic, proof-carrying
+# admission conjunct — the kernel consults an issuer-signed says-credential per
+# operation, checked by a PEP whose positive verdict is backed by the
+# machine-checked `admit_joint` theorem (no false admits on the admission
+# fragment). Inert unless `Kernel::set_dlc_admission` provisions credentials,
+# mirroring the `cedar` pattern. Rev-pinned git dep, same pattern as
+# nucleus-policy-cert's `dlc` feature.
+dlc = ["dep:dlc-d", "dep:dlc-core", "crypto"]
+
 # SECURITY: Enable this feature ONLY for testing. It exposes methods that
 # bypass security constraints (e.g., disabling uninhabitable state enforcement).
 # DO NOT enable in production builds.
@@ -45,6 +54,10 @@ testing = []
 
 [dependencies]
 portcullis-core = { path = "../portcullis-core", features = ["serde", "envelope"] }
+# DLC-D admission (feature `dlc`) — rev-pinned to delegation_calc main. The pin
+# is the U3 state: gated mint + one-atom binding (see says_admission module docs).
+dlc-d = { git = "https://github.com/coproduct-opensource/delegation_calc.git", rev = "34358234cb46279c4ce8a8729736a4135174f65a", optional = true }
+dlc-core = { git = "https://github.com/coproduct-opensource/delegation_calc.git", rev = "34358234cb46279c4ce8a8729736a4135174f65a", optional = true }
 chrono = { workspace = true }
 hex = { workspace = true }
 hmac = { workspace = true }
@@ -98,6 +111,8 @@ proptest = { workspace = true }
 serde_json = { workspace = true }
 tempfile = { workspace = true }
 kani = "0.0.1"
+# Credential minting for the `dlc` admission tests (signing side of dlc-d's PEP).
+dlc-crypto = { git = "https://github.com/coproduct-opensource/delegation_calc.git", rev = "34358234cb46279c4ce8a8729736a4135174f65a" }
 
 [[test]]
 name = "example_policies"
@@ -114,3 +129,7 @@ required-features = ["spec"]
 [[test]]
 name = "kernel_token"
 required-features = ["crypto"]
+
+[[test]]
+name = "kernel_dlc_admission"
+required-features = ["dlc"]

--- a/crates/portcullis/src/kernel.rs
+++ b/crates/portcullis/src/kernel.rs
@@ -81,6 +81,8 @@ use crate::receipt_chain::{ReceiptChain, VerdictReceipt};
 use crate::token::SessionProvenance;
 use crate::{ActionTerm, PreflightContext, PreflightResult, PreflightVerdict};
 
+#[cfg(feature = "dlc")]
+mod dlc;
 /// IFC flow gate (poison + tainted-outbound denial) — extends `impl Kernel`.
 mod ifc;
 
@@ -231,6 +233,13 @@ pub enum DenyReason {
         host: String,
         /// Human-readable reason from the egress policy.
         policy_reason: String,
+    },
+    /// Operation denied by DLC-D verified admission: no issuer-signed
+    /// credential verifies for exactly this operation's cap atom (fail-closed;
+    /// see the `says_admission` module for the trust boundary).
+    DlcAdmissionDenied {
+        /// Human-readable detail from the admission PEP.
+        detail: String,
     },
     /// Operation denied by an admissibility policy rule.
     ///
@@ -487,6 +496,9 @@ pub struct Kernel {
     /// default-on does not change behavior for sessions without a policy.
     #[cfg(feature = "cedar")]
     cedar_evaluator: Option<crate::cedar_bridge::CedarEvaluator>,
+    /// DLC-D verified admission (inert until [`Kernel::set_dlc_admission`]).
+    #[cfg(feature = "dlc")]
+    dlc_admission: Option<crate::says_admission::DlcAdmission>,
     /// Optional enterprise allowlist — when present, `decide()` checks the
     /// operation's sink class against the enterprise policy after admissibility
     /// policy checks and before path/command checks.
@@ -587,6 +599,8 @@ impl Kernel {
             policy_rules: None,
             #[cfg(feature = "cedar")]
             cedar_evaluator: None,
+            #[cfg(feature = "dlc")]
+            dlc_admission: None,
             enterprise: None,
             delegation: None,
             delegation_depth: 0,
@@ -638,6 +652,8 @@ impl Kernel {
             policy_rules: None,
             #[cfg(feature = "cedar")]
             cedar_evaluator: None,
+            #[cfg(feature = "dlc")]
+            dlc_admission: None,
             enterprise: None,
             delegation: None,
             delegation_depth: 0,
@@ -1027,6 +1043,8 @@ impl Kernel {
             policy_rules: None,
             #[cfg(feature = "cedar")]
             cedar_evaluator: None,
+            #[cfg(feature = "dlc")]
+            dlc_admission: None,
             enterprise: None,
             delegation: None,
             delegation_depth: 0,
@@ -1084,6 +1102,8 @@ impl Kernel {
             policy_rules: None,
             #[cfg(feature = "cedar")]
             cedar_evaluator: None,
+            #[cfg(feature = "dlc")]
+            dlc_admission: None,
             enterprise: None,
             delegation: None,
             delegation_depth: 0,
@@ -1675,6 +1695,13 @@ impl Kernel {
             return denied;
         }
 
+        // DLC-D verified admission (`kernel::dlc`): deny-narrowing, inert
+        // until `set_dlc_admission` provisions credentials.
+        #[cfg(feature = "dlc")]
+        if let Some(denied) = self.dlc_admission_gate(&term) {
+            return denied;
+        }
+
         // Only the Cedar consult below uses `operation`; bind it under the same
         // cfg so non-cedar feature combos don't trip `-D unused-variables`.
         #[cfg(feature = "cedar")]
@@ -1742,43 +1769,6 @@ impl Kernel {
     pub fn set_cedar_policy(&mut self, policy_src: &str) -> Result<(), String> {
         self.cedar_evaluator = Some(crate::cedar_bridge::CedarEvaluator::new(policy_src)?);
         Ok(())
-    }
-
-    /// Map an Operation to the most appropriate FlowNode kind.
-    fn node_kind_for(op: Operation) -> portcullis_core::flow::NodeKind {
-        use portcullis_core::flow::NodeKind;
-        match op {
-            Operation::ReadFiles | Operation::GlobSearch | Operation::GrepSearch => {
-                NodeKind::FileRead
-            }
-            Operation::WebFetch | Operation::WebSearch => NodeKind::WebContent,
-            Operation::WriteFiles | Operation::EditFiles => NodeKind::OutboundAction,
-            Operation::RunBash
-            | Operation::GitCommit
-            | Operation::GitPush
-            | Operation::CreatePr
-            | Operation::ManagePods
-            | Operation::SpawnAgent => NodeKind::OutboundAction,
-        }
-    }
-
-    /// Extract source and artifact labels for policy rule evaluation.
-    ///
-    /// Reads the cached flow label (derived from graph state). When flow
-    /// control is enabled, uses the cache as both source and artifact label.
-    /// Otherwise returns empty sources and a bottom label (which causes
-    /// source predicates to be vacuously true and artifact predicates to
-    /// match permissively).
-    fn policy_flow_labels(&self) -> (Vec<portcullis_core::IFCLabel>, portcullis_core::IFCLabel) {
-        if let Some(ref label) = self.flow_label {
-            // Cached label (derived from graph): use as both source and artifact.
-            (vec![*label], *label)
-        } else {
-            // No flow control — use bottom label (most permissive).
-            let now = chrono::Utc::now().timestamp() as u64;
-            let bottom = portcullis_core::IFCLabel::user_prompt(now);
-            (vec![], bottom)
-        }
     }
 
     /// Incrementally update the cached flow label from a newly inserted

--- a/crates/portcullis/src/kernel/dlc.rs
+++ b/crates/portcullis/src/kernel/dlc.rs
@@ -1,0 +1,71 @@
+//! DLC-D verified-admission gate for the kernel (feature `dlc`).
+//!
+//! Extracted from `kernel.rs` to keep that file under the line ratchet, in the
+//! same shape as [`super::Kernel::decide_term_with_flow`]'s other consults: the
+//! IFC gate (`kernel::ifc`) and the Cedar consult. Default-inert — a kernel
+//! with no [`DlcAdmission`](crate::says_admission::DlcAdmission) provisioned
+//! behaves exactly as before; once provisioned via
+//! [`Kernel::set_dlc_admission`], every operation additionally requires a
+//! valid issuer-signed says-credential for exactly that operation, decided by
+//! DLC-D's proof-carrying PEP (fail-closed; see the `says_admission` module
+//! docs for the trust boundary and the credential namespace).
+
+use super::{Decision, DecisionToken, DenyReason, Kernel, Verdict};
+use crate::exposure_core;
+use crate::says_admission::DlcAdmission;
+use crate::ActionTerm;
+
+impl Kernel {
+    /// Provision DLC-D admission: after this call, every decision through
+    /// [`Kernel::decide_term_with_flow`](Kernel::decide_term_with_flow)
+    /// additionally requires an issuer-signed credential for the operation
+    /// (deny-narrowing — this can only refuse what the lattice/IFC/Cedar
+    /// layers would otherwise allow, never widen).
+    pub fn set_dlc_admission(&mut self, admission: DlcAdmission) {
+        self.dlc_admission = Some(admission);
+    }
+
+    /// Consult the provisioned admission state. `None` when unprovisioned or
+    /// admitted; `Some(deny_decision)` when the credential check refuses.
+    pub(super) fn dlc_admission_gate(
+        &mut self,
+        term: &ActionTerm,
+    ) -> Option<(Decision, Option<DecisionToken>)> {
+        let admission = self.dlc_admission.as_ref()?;
+        let operation = term.operation();
+        let op_name = operation.to_string();
+        let verdict = admission.decide_operation(&op_name);
+        if verdict.is_admit() {
+            return None;
+        }
+        let detail = match verdict {
+            dlc_d::admission::Decision::Deny(reason) => reason.to_string(),
+            dlc_d::admission::Decision::Admit => unreachable!("is_admit checked above"),
+        };
+        tracing::warn!(
+            ?operation,
+            subject = term.subject(),
+            %detail,
+            "DLC-D admission denied operation"
+        );
+        let pre_hash = self.effective.checksum();
+        let pre_exposure_count = self.exposure.count();
+        let contributed_label = exposure_core::classify_operation(operation);
+        let subject = term.subject().to_string();
+        let (mut decision, token) = self.record_with_exposure(
+            operation,
+            &subject,
+            Verdict::Deny(DenyReason::DlcAdmissionDenied { detail }),
+            &pre_hash,
+            pre_exposure_count,
+            contributed_label,
+            false,
+            false,
+        );
+        decision.action_term = Some(term.clone());
+        if let Some(last) = self.trace.last_mut() {
+            last.action_term = Some(term.clone());
+        }
+        Some((decision, token))
+    }
+}

--- a/crates/portcullis/src/kernel/ifc.rs
+++ b/crates/portcullis/src/kernel/ifc.rs
@@ -16,8 +16,50 @@ use portcullis_core::ifc_api::FlowTracker;
 use super::{Decision, DecisionToken, DenyReason, Kernel, Verdict};
 use crate::exposure_core;
 use crate::ActionTerm;
+use crate::Operation;
 
 impl Kernel {
+    /// Extract source and artifact labels for policy rule evaluation.
+    ///
+    /// Reads the cached flow label (derived from graph state). When flow
+    /// control is enabled, uses the cache as both source and artifact label.
+    /// Otherwise returns empty sources and a bottom label (which causes
+    /// source predicates to be vacuously true and artifact predicates to
+    /// match permissively).
+    pub(super) fn policy_flow_labels(
+        &self,
+    ) -> (Vec<portcullis_core::IFCLabel>, portcullis_core::IFCLabel) {
+        if let Some(ref label) = self.flow_label {
+            // Cached label (derived from graph): use as both source and artifact.
+            (vec![*label], *label)
+        } else {
+            // No flow control — use bottom label (most permissive).
+            let now = chrono::Utc::now().timestamp() as u64;
+            let bottom = portcullis_core::IFCLabel::user_prompt(now);
+            (vec![], bottom)
+        }
+    }
+
+    /// Map an Operation to the most appropriate FlowNode kind.
+    /// (Moved here from `kernel.rs` for the line ratchet; used by the IFC gate
+    /// below and by `decide`'s intrinsic-label path.)
+    pub(super) fn node_kind_for(op: Operation) -> portcullis_core::flow::NodeKind {
+        use portcullis_core::flow::NodeKind;
+        match op {
+            Operation::ReadFiles | Operation::GlobSearch | Operation::GrepSearch => {
+                NodeKind::FileRead
+            }
+            Operation::WebFetch | Operation::WebSearch => NodeKind::WebContent,
+            Operation::WriteFiles | Operation::EditFiles => NodeKind::OutboundAction,
+            Operation::RunBash
+            | Operation::GitCommit
+            | Operation::GitPush
+            | Operation::CreatePr
+            | Operation::ManagePods
+            | Operation::SpawnAgent => NodeKind::OutboundAction,
+        }
+    }
+
     /// Consult the session flow tracker. Returns `Some(deny_decision)` if the
     /// IFC gate denies the action, or `None` to fall through to the normal
     /// decision path. `flow == None` ⇒ always `None` (backward compatible).

--- a/crates/portcullis/src/lib.rs
+++ b/crates/portcullis/src/lib.rs
@@ -153,6 +153,10 @@ pub mod profile;
 pub mod receipt_chain;
 #[cfg(feature = "crypto")]
 pub mod receipt_sign;
+/// DLC-D verified admission — cryptographic, proof-carrying admission conjunct
+/// (feature `dlc`); consulted by the kernel, composable as a `PolicyCheck`.
+#[cfg(feature = "dlc")]
+pub mod says_admission;
 #[cfg(feature = "crypto")]
 pub use receipt_sign::{receipt_hash, sign_receipt, verify_receipt};
 #[cfg(feature = "remote-audit")]

--- a/crates/portcullis/src/says_admission.rs
+++ b/crates/portcullis/src/says_admission.rs
@@ -1,0 +1,112 @@
+//! DLC-D verified admission — a cryptographic, proof-carrying admission conjunct.
+//!
+//! `portcullis-core`'s structural admission (`manifest::check_admission`) validates what a tool
+//! *declares*; its own docstring notes a tool that lies in its manifest will pass. This module
+//! supplies the conjunct structural rules cannot: an invocation is admitted **iff the issuer
+//! really signed a capability for this operation** — a real Ed25519 verify over the operation's
+//! domain-separated cap atom, fail-closed — and a positive verdict is backed by DLC-D's
+//! machine-checked `admit_joint` theorem (*no false admits* on the admission fragment;
+//! `delegation_calc/lean/DLC/AdmitFrag.lean`, axiom footprint `[propext, Classical.choice,
+//! Quot.sound]`). Cost is one Ed25519 verify (~19.5 µs measured), far below tool-call timescales.
+//!
+//! ## Where this sits (the live path)
+//!
+//! The kernel consults a provisioned [`DlcAdmission`] inside
+//! [`Kernel::decide_term_with_flow`](crate::kernel::Kernel::decide_term_with_flow) — the same
+//! deny-narrowing, default-inert idiom as the Cedar consult: no provisioning ⇒ no behavior
+//! change; provisioned ⇒ every decision additionally requires a valid credential for the
+//! operation. See [`Kernel::set_dlc_admission`](crate::kernel::Kernel::set_dlc_admission).
+//! A [`PolicyCheck`] impl is also provided for composition-layer use (`AllOf` etc.).
+//!
+//! ## The credential namespace (a deliberate decision)
+//!
+//! Credentials bind to **portcullis operation names** (`Operation`'s canonical snake_case
+//! `Display` strings: `"web_fetch"`, `"run_bash"`, …) — the kernel's actual enforcement
+//! vocabulary — not to transport-level tool names (`"mcp__github__search"`), which the kernel
+//! never sees. Credential granularity therefore equals enforcement granularity. Finer,
+//! tool-name-level binding is a possible extension via the request context, not silently
+//! implied by this module.
+//!
+//! ## Trust boundary
+//!
+//! DLC-D proves the *credential↔operation* binding (a credential for operation A provably
+//! cannot admit operation B — the signature covers A's cap atom). The **host** supplies: the
+//! [`KeyRing`] (which issuer keys are trusted is a host provenance decision), the issuer
+//! [`Principal`], and the per-operation credentials presented for this session. Admission
+//! authorizes the *invocation*; it does not prove the tool behaves as declared.
+
+use std::collections::BTreeMap;
+
+use dlc_core::judgment::KeyRing;
+use dlc_core::principal::Principal;
+use dlc_core::syntax::Signature;
+use dlc_d::admission::{decide, Decision};
+
+use portcullis_core::combinators::{CheckResult, PolicyCheck, PolicyRequest};
+
+/// The provisioned admission state for a session: the trusted issuer keys, the issuer identity,
+/// and the credentials presented for this session (operation name → issuer-signed capability).
+///
+/// Fail-closed by construction: once provisioned on a kernel, an operation with **no** presented
+/// credential — or one whose credential does not verify for exactly that operation's cap atom —
+/// is denied.
+#[derive(Debug, Clone)]
+pub struct DlcAdmission {
+    keyring: KeyRing,
+    issuer: Principal,
+    credentials: BTreeMap<String, Signature>,
+}
+
+impl DlcAdmission {
+    /// Admission state with the given trust anchors and issuer, and no credentials yet
+    /// (which denies every operation until credentials are presented — fail-closed).
+    #[must_use]
+    pub fn new(keyring: KeyRing, issuer: Principal) -> Self {
+        Self {
+            keyring,
+            issuer,
+            credentials: BTreeMap::new(),
+        }
+    }
+
+    /// Present an issuer-signed credential for one operation (canonical snake_case name,
+    /// e.g. `"web_fetch"`). The signature must cover exactly that operation's cap atom.
+    #[must_use]
+    pub fn with_credential(mut self, operation: &str, sig: Signature) -> Self {
+        self.credentials.insert(operation.to_string(), sig);
+        self
+    }
+
+    /// Decide one operation: [`Decision::Admit`] iff a credential was presented for exactly
+    /// this operation name **and** it verifies against the issuer's key in the keyring.
+    /// Fail-closed: no credential, unknown issuer, bad signature, or a credential minted for
+    /// a different operation all land in [`Decision::Deny`].
+    #[must_use]
+    pub fn decide_operation(&self, operation: &str) -> Decision {
+        match self.credentials.get(operation) {
+            Some(sig) => decide(&self.keyring, &self.issuer, operation, sig),
+            None => Decision::Deny("no issuer-signed credential presented for this operation"),
+        }
+    }
+}
+
+impl PolicyCheck for DlcAdmission {
+    /// Composition-layer form of the same check. The operation name is taken from the request's
+    /// `operation` field (the kernel's canonical vocabulary); a `"tool"` context entry, when
+    /// present, overrides it for hosts that bind credentials at tool-name granularity.
+    fn check(&self, req: &PolicyRequest) -> CheckResult {
+        let name = req
+            .context
+            .get("tool")
+            .map(String::as_str)
+            .unwrap_or(&req.operation);
+        match self.decide_operation(name) {
+            Decision::Admit => CheckResult::Allow,
+            Decision::Deny(reason) => CheckResult::Deny(reason.to_string()),
+        }
+    }
+
+    fn name(&self) -> &str {
+        "dlc-d/says-admission"
+    }
+}

--- a/crates/portcullis/tests/kernel_dlc_admission.rs
+++ b/crates/portcullis/tests/kernel_dlc_admission.rs
@@ -1,0 +1,146 @@
+//! Kernel-level DLC-D verified-admission tests (feature `dlc`) — the bites on the LIVE path.
+//!
+//! These prove the `says_admission` consult in `Kernel::decide_term_with_flow` actually gates:
+//! an unprovisioned kernel is unchanged (inert-by-default), a valid issuer-signed credential
+//! admits, and every failure mode — missing credential, credential minted for a different
+//! operation, unknown issuer — denies with `DenyReason::DlcAdmissionDenied` (the right reason
+//! at the right layer: the DLC gate runs before the lattice, so the deny reason itself proves
+//! WHICH check fired).
+#![cfg(feature = "dlc")]
+
+use dlc_core::judgment::KeyRing;
+use dlc_core::principal::{KeyRecord, Principal, PrincipalId};
+use dlc_core::syntax::Signature;
+use dlc_d::admission::cap_atom;
+use portcullis::kernel::{DenyReason, Kernel, Verdict};
+use portcullis::says_admission::DlcAdmission;
+use portcullis::{ActionTerm, Operation, PermissionLattice};
+
+const SEED: [u8; 32] = [7u8; 32];
+
+fn issuer_and_keyring() -> (KeyRing, Principal) {
+    let pk = dlc_crypto::ed25519::public_key(&SEED);
+    let issuer = Principal::Atom(PrincipalId(pk));
+    let keyring = KeyRing {
+        entries: vec![KeyRecord {
+            principal: PrincipalId(pk),
+            alg: 0,
+            public_key: pk.to_vec(),
+        }],
+    };
+    (keyring, issuer)
+}
+
+/// Mint an issuer-signed credential for one operation name. Mirrors dlc-d's v1 cap-invoke
+/// message layout (domain tag + LE cap atom); the layout is an implementation detail of the
+/// REV-PINNED dlc-d dependency, so a layout change surfaces here as a red test at pin-bump.
+fn credential(operation: &str) -> Signature {
+    let mut msg = b"dlc-d/cap-invoke:".to_vec();
+    msg.extend_from_slice(&cap_atom(operation).to_le_bytes());
+    Signature {
+        alg: 0,
+        bytes: dlc_crypto::ed25519::sign(&SEED, &msg).to_vec(),
+    }
+}
+
+fn read_term() -> ActionTerm {
+    ActionTerm::from_operation(Operation::ReadFiles, "README.md")
+}
+
+fn deny_reason(kernel: &mut Kernel, term: ActionTerm) -> Option<DenyReason> {
+    let (decision, _token) = kernel.decide_term_with_flow(term, None);
+    match decision.verdict {
+        Verdict::Deny(reason) => Some(reason),
+        _ => None,
+    }
+}
+
+#[test]
+fn unprovisioned_kernel_is_unchanged() {
+    // Inert-by-default: no set_dlc_admission ⇒ the gate never fires.
+    let mut kernel = Kernel::new(PermissionLattice::safe_pr_fixer());
+    let (decision, _) = kernel.decide_term_with_flow(read_term(), None);
+    assert!(
+        decision.verdict.is_allowed(),
+        "baseline lattice must allow the read, got {:?}",
+        decision.verdict
+    );
+}
+
+#[test]
+fn valid_credential_admits() {
+    let (keyring, issuer) = issuer_and_keyring();
+    let mut kernel = Kernel::new(PermissionLattice::safe_pr_fixer());
+    kernel.set_dlc_admission(
+        DlcAdmission::new(keyring, issuer).with_credential("read_files", credential("read_files")),
+    );
+    let (decision, _) = kernel.decide_term_with_flow(read_term(), None);
+    assert!(
+        decision.verdict.is_allowed(),
+        "a genuine issuer-signed credential for read_files must admit, got {:?}",
+        decision.verdict
+    );
+}
+
+#[test]
+fn missing_credential_denies_fail_closed() {
+    // Provisioned, but no credential presented for this operation ⇒ deny — and the reason
+    // proves the DLC gate (not the lattice) is what fired.
+    let (keyring, issuer) = issuer_and_keyring();
+    let mut kernel = Kernel::new(PermissionLattice::safe_pr_fixer());
+    kernel.set_dlc_admission(DlcAdmission::new(keyring, issuer));
+    match deny_reason(&mut kernel, read_term()) {
+        Some(DenyReason::DlcAdmissionDenied { .. }) => {}
+        other => panic!("expected DlcAdmissionDenied, got {other:?}"),
+    }
+}
+
+#[test]
+fn wrong_operation_credential_denies() {
+    // The cryptographic bite: a credential MINTED for web_fetch, presented under read_files.
+    // The map lookup succeeds — the Ed25519 signature is what refuses (it covers web_fetch's
+    // cap atom, not read_files'), so this cannot be faked by registry bookkeeping.
+    let (keyring, issuer) = issuer_and_keyring();
+    let mut kernel = Kernel::new(PermissionLattice::safe_pr_fixer());
+    kernel.set_dlc_admission(
+        DlcAdmission::new(keyring, issuer).with_credential("read_files", credential("web_fetch")),
+    );
+    match deny_reason(&mut kernel, read_term()) {
+        Some(DenyReason::DlcAdmissionDenied { .. }) => {}
+        other => panic!("expected DlcAdmissionDenied, got {other:?}"),
+    }
+}
+
+#[test]
+fn unknown_issuer_denies() {
+    let (_keyring, issuer) = issuer_and_keyring();
+    let empty = KeyRing { entries: vec![] };
+    let mut kernel = Kernel::new(PermissionLattice::safe_pr_fixer());
+    kernel.set_dlc_admission(
+        DlcAdmission::new(empty, issuer).with_credential("read_files", credential("read_files")),
+    );
+    match deny_reason(&mut kernel, read_term()) {
+        Some(DenyReason::DlcAdmissionDenied { .. }) => {}
+        other => panic!("expected DlcAdmissionDenied, got {other:?}"),
+    }
+}
+
+#[test]
+fn deny_narrowing_only() {
+    // The gate can only NARROW: an operation the lattice would deny anyway stays denied
+    // (with the earlier gate's reason), and providing a valid credential for it does not
+    // widen the lattice's verdict.
+    let (keyring, issuer) = issuer_and_keyring();
+    let mut kernel = Kernel::new(PermissionLattice::safe_pr_fixer());
+    kernel.set_dlc_admission(
+        DlcAdmission::new(keyring, issuer)
+            .with_credential("manage_pods", credential("manage_pods")),
+    );
+    let term = ActionTerm::from_operation(Operation::ManagePods, "pod-1");
+    let (decision, _) = kernel.decide_term_with_flow(term, None);
+    assert!(
+        !decision.verdict.is_allowed(),
+        "a valid credential must not widen what the lattice denies, got {:?}",
+        decision.verdict
+    );
+}


### PR DESCRIPTION
Adds a cryptographic, **proof-carrying** admission conjunct to `Kernel::decide_term_with_flow`: with `DlcAdmission` provisioned, every operation additionally requires an issuer-signed Ed25519 credential for exactly that operation's cap atom, decided by DLC-D's PEP — whose positive verdict is backed by the machine-checked `admit_joint` theorem (no false admits on the admission fragment; ~19.5µs/check). Default-inert (the Cedar pattern), fail-closed, deny-narrowing only.

Two deliberate deviations from the original integration design (`delegation_calc/spec/nucleus-admission-integration.md`), found while wiring:
1. The consult lands on the **live path** (alongside the IFC gate and Cedar consult) rather than the proposed `PolicyCheck`/`AllOf` composition — that seam has no production constructors today. A `PolicyCheck` impl ships anyway for composition use.
2. Credentials bind to **operation names** (the kernel's enforcement vocabulary), not transport tool names the kernel never sees.

Six bites in `tests/kernel_dlc_admission.rs`: inert-by-default, valid-admits, missing-credential fail-closed, wrong-operation credential refused **by the signature**, unknown issuer, deny-narrowing. Denied admissions are attested today via the existing trace/receipt chain (`DenyReason::DlcAdmissionDenied`); positive-verdict attestation + tool-proxy provisioning is the follow-up PR.

Line-ratchet paid for by extraction (`node_kind_for`, `policy_flow_labels` → `kernel/ifc.rs`; kernel.rs 2477→2467). Dep: rev-pinned git dep on delegation_calc @ 3435823 behind feature `dlc`, following nucleus-policy-cert's existing pattern (its pin aligned to the same rev).

Prior-art context: runtime pre-action authorization for agents is now the industry direction (Delinea 2026-07-29; Microsoft PEP/PDP-at-the-tool-boundary; arXiv 2605.05440, 2606.29142) — none carry a proof on the checker itself, which is this conjunct's contribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UA8kchV3eadjGv6BmJXfqm