### PR TITLE
Tool-proxy: provision DLC-D verified admission from env + attest per-call admission state

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -82,4 +82,13 @@ ignore = [
     # ^0.39); local macOS plist parsing, not attacker-controlled XML.
     # REVISIT when plist releases >1.9.0.
     "RUSTSEC-2026-0195",
+
+    # event-listener 5.4.1 unsound: `!Send` tags can cross thread boundaries
+    # via `StackSlot` (RUSTSEC-2026-0221, filed 2026-07-13; hit CI when the
+    # advisory DB refreshed — the tree didn't change). No fixed release yet
+    # (5.4.1 is latest). Transitive via sqlx-core in nucleus-verifier-service
+    # only — not in the enforcement path — and sqlx does not use the unsound
+    # StackSlot API with !Send tags. REVISIT when event-listener releases a
+    # fix or sqlx bumps past it.
+    "RUSTSEC-2026-0221",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7318,6 +7318,8 @@ dependencies = [
  "chrono",
  "clap",
  "dirs",
+ "dlc-crypto",
+ "dlc-d",
  "ed25519-dalek 3.0.0-pre.7",
  "glob",
  "hex",

--- a/crates/nucleus-tool-proxy/Cargo.toml
+++ b/crates/nucleus-tool-proxy/Cargo.toml
@@ -60,7 +60,7 @@ nucleus-spec = { path = "../nucleus-spec" }
 nucleus-identity = { path = "../nucleus-identity" }
 nucleus-client = { path = "../nucleus-client", features = ["async-drand"] }
 nucleus-proto = { path = "../nucleus-proto" }
-portcullis = { path = "../portcullis", features = ["serde", "spec", "crypto"] }
+portcullis = { path = "../portcullis", features = ["serde", "spec", "crypto", "dlc"] }
 # The dependency-free IFC reference monitor. Used directly for the sealed
 # `DischargedBundle` preflight that gates the live RunBash path (#2038). Discharge
 # is already trusted (re-exported through `portcullis-core`); this is an additive
@@ -110,6 +110,10 @@ aws-config = { workspace = true, optional = true }
 tokio-vsock = "0.7"
 
 [dev-dependencies]
+# Credential minting for the DLC admission provisioning tests (same rev as
+# portcullis's dlc-d pin).
+dlc-crypto = { git = "https://github.com/coproduct-opensource/delegation_calc.git", rev = "34358234cb46279c4ce8a8729736a4135174f65a" }
+dlc-d = { git = "https://github.com/coproduct-opensource/delegation_calc.git", rev = "34358234cb46279c4ce8a8729736a4135174f65a" }
 tempfile = { workspace = true }
 ed25519-dalek = { workspace = true }
 # In-process router driving for the H-3 panic-net regression test

--- a/crates/nucleus-tool-proxy/src/dlc_admission.rs
+++ b/crates/nucleus-tool-proxy/src/dlc_admission.rs
@@ -1,0 +1,207 @@
+//! Host-side provisioning for DLC-D verified admission (portcullis feature `dlc`).
+//!
+//! Reads the pod's admission credentials from environment variables — the same
+//! host-injection pattern as `NUCLEUS_DECLASSIFY_TRUSTED_KEYS` — and builds the
+//! [`DlcAdmission`] both transports' kernels are provisioned with:
+//!
+//! - `NUCLEUS_DLC_TRUSTED_KEYS` — comma-separated 64-hex Ed25519 issuer public
+//!   keys (the trust anchors). **Unset or empty ⇒ admission is inert** (the
+//!   kernel gate never fires; behavior identical to before this feature).
+//! - `NUCLEUS_DLC_ISSUER` — 64-hex public key of the issuer whose credentials
+//!   this pod presents (its bytes are also its principal id, matching dlc-d's
+//!   `Principal::Atom(PrincipalId(pk))` convention).
+//! - `NUCLEUS_DLC_CREDENTIALS` — comma-separated `operation=hex_signature`
+//!   pairs (canonical snake_case operation names, e.g.
+//!   `read_files=ab12…,web_fetch=…`); each signature is the issuer's Ed25519
+//!   credential over that operation's cap atom.
+//!
+//! **Fail-closed on partial configuration:** once `NUCLEUS_DLC_TRUSTED_KEYS` is
+//! set, provisioning ALWAYS happens — a malformed issuer yields an
+//! unsatisfiable admission state (empty keyring), and malformed or missing
+//! credentials simply deny their operations. Misconfiguration can only narrow.
+
+use portcullis::says_admission::{
+    DlcAdmission, DlcKeyRecord, DlcKeyRing, DlcPrincipal, DlcPrincipalId, DlcSignature,
+};
+
+/// Decode a 64-char hex string into 32 bytes.
+fn hex32(s: &str) -> Option<[u8; 32]> {
+    let bytes = hex::decode(s.trim()).ok()?;
+    bytes.try_into().ok()
+}
+
+/// Build the pod's [`DlcAdmission`] from the environment. `None` ⇔ the feature
+/// is unprovisioned (inert). See the module docs for the variables and the
+/// fail-closed semantics.
+pub(crate) fn provision_from_env() -> Option<DlcAdmission> {
+    let raw_keys = std::env::var("NUCLEUS_DLC_TRUSTED_KEYS").ok()?;
+    if raw_keys.trim().is_empty() {
+        return None;
+    }
+
+    let entries: Vec<DlcKeyRecord> = raw_keys
+        .split(',')
+        .filter_map(|k| {
+            let pk = hex32(k).or_else(|| {
+                tracing::warn!("NUCLEUS_DLC_TRUSTED_KEYS: skipping malformed key entry");
+                None
+            })?;
+            Some(DlcKeyRecord {
+                principal: DlcPrincipalId(pk),
+                alg: 0,
+                public_key: pk.to_vec(),
+            })
+        })
+        .collect();
+
+    let issuer = match std::env::var("NUCLEUS_DLC_ISSUER")
+        .ok()
+        .and_then(|s| hex32(&s))
+    {
+        Some(pk) => DlcPrincipal::Atom(DlcPrincipalId(pk)),
+        None => {
+            // Trusted keys were set but the issuer is absent/malformed: provision an
+            // unsatisfiable state (zero principal + EMPTY keyring) so every operation
+            // is denied — misconfiguration narrows, never widens.
+            tracing::error!(
+                "NUCLEUS_DLC_TRUSTED_KEYS is set but NUCLEUS_DLC_ISSUER is missing or \
+                 malformed — provisioning DENY-ALL admission (fail-closed)"
+            );
+            return Some(DlcAdmission::new(
+                DlcKeyRing { entries: vec![] },
+                DlcPrincipal::Atom(DlcPrincipalId([0u8; 32])),
+            ));
+        }
+    };
+
+    let mut admission = DlcAdmission::new(DlcKeyRing { entries }, issuer);
+    if let Ok(raw_creds) = std::env::var("NUCLEUS_DLC_CREDENTIALS") {
+        for pair in raw_creds.split(',').filter(|p| !p.trim().is_empty()) {
+            match pair.split_once('=') {
+                Some((op, sig_hex)) => match hex::decode(sig_hex.trim()) {
+                    Ok(bytes) => {
+                        admission =
+                            admission.with_credential(op.trim(), DlcSignature { alg: 0, bytes });
+                    }
+                    Err(_) => tracing::warn!(
+                        operation = op.trim(),
+                        "NUCLEUS_DLC_CREDENTIALS: malformed signature hex — operation \
+                         will be denied"
+                    ),
+                },
+                None => {
+                    tracing::warn!("NUCLEUS_DLC_CREDENTIALS: entry without '=' — skipped (denied)")
+                }
+            }
+        }
+    }
+    Some(admission)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Env-var tests mutate process state; serialize them.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn with_env(vars: &[(&str, Option<&str>)], f: impl FnOnce()) {
+        let _guard = ENV_LOCK.lock().unwrap();
+        for (k, v) in vars {
+            match v {
+                Some(val) => std::env::set_var(k, val),
+                None => std::env::remove_var(k),
+            }
+        }
+        f();
+        for (k, _) in vars {
+            std::env::remove_var(k);
+        }
+    }
+
+    /// Mint a real issuer keypair + credential for one operation, mirroring
+    /// dlc-d's v1 cap-invoke layout (guarded by the rev-pinned dependency).
+    fn mint(seed: &[u8; 32], operation: &str) -> (String, String) {
+        let pk = dlc_crypto::ed25519::public_key(seed);
+        let atom = dlc_d::admission::cap_atom(operation);
+        let mut msg = b"dlc-d/cap-invoke:".to_vec();
+        msg.extend_from_slice(&atom.to_le_bytes());
+        let sig = dlc_crypto::ed25519::sign(seed, &msg);
+        (hex::encode(pk), hex::encode(sig))
+    }
+
+    #[test]
+    fn unset_is_inert() {
+        with_env(
+            &[
+                ("NUCLEUS_DLC_TRUSTED_KEYS", None),
+                ("NUCLEUS_DLC_ISSUER", None),
+                ("NUCLEUS_DLC_CREDENTIALS", None),
+            ],
+            || assert!(provision_from_env().is_none()),
+        );
+    }
+
+    #[test]
+    fn happy_path_admits_credentialed_operation_only() {
+        let seed = [9u8; 32];
+        let (pk_hex, sig_hex) = mint(&seed, "read_files");
+        with_env(
+            &[
+                ("NUCLEUS_DLC_TRUSTED_KEYS", Some(pk_hex.as_str())),
+                ("NUCLEUS_DLC_ISSUER", Some(pk_hex.as_str())),
+                (
+                    "NUCLEUS_DLC_CREDENTIALS",
+                    Some(&format!("read_files={sig_hex}")),
+                ),
+            ],
+            || {
+                let adm = provision_from_env().expect("provisioned");
+                assert!(adm.decide_operation("read_files").is_admit());
+                assert!(!adm.decide_operation("web_fetch").is_admit());
+            },
+        );
+    }
+
+    #[test]
+    fn missing_issuer_is_deny_all() {
+        let seed = [9u8; 32];
+        let (pk_hex, sig_hex) = mint(&seed, "read_files");
+        with_env(
+            &[
+                ("NUCLEUS_DLC_TRUSTED_KEYS", Some(pk_hex.as_str())),
+                ("NUCLEUS_DLC_ISSUER", None),
+                (
+                    "NUCLEUS_DLC_CREDENTIALS",
+                    Some(&format!("read_files={sig_hex}")),
+                ),
+            ],
+            || {
+                let adm = provision_from_env().expect("still provisioned — fail-closed");
+                assert!(!adm.decide_operation("read_files").is_admit());
+            },
+        );
+    }
+
+    #[test]
+    fn wrong_operation_credential_is_denied_by_signature() {
+        // A credential minted for web_fetch, registered under read_files: the
+        // registry lookup succeeds; the Ed25519 verify is what refuses.
+        let seed = [9u8; 32];
+        let (pk_hex, wrong_sig) = mint(&seed, "web_fetch");
+        with_env(
+            &[
+                ("NUCLEUS_DLC_TRUSTED_KEYS", Some(pk_hex.as_str())),
+                ("NUCLEUS_DLC_ISSUER", Some(pk_hex.as_str())),
+                (
+                    "NUCLEUS_DLC_CREDENTIALS",
+                    Some(&format!("read_files={wrong_sig}")),
+                ),
+            ],
+            || {
+                let adm = provision_from_env().expect("provisioned");
+                assert!(!adm.decide_operation("read_files").is_admit());
+            },
+        );
+    }
+}

--- a/crates/nucleus-tool-proxy/src/main.rs
+++ b/crates/nucleus-tool-proxy/src/main.rs
@@ -32,6 +32,7 @@ mod attestation;
 mod auth;
 mod broker_client;
 mod cert_bridge;
+mod dlc_admission;
 mod exit_report;
 mod identity_fusion;
 mod lockdown_client;
@@ -1464,6 +1465,12 @@ async fn main() -> Result<(), ApiError> {
     let exposure_guard: Arc<std::sync::RwLock<Option<Arc<portcullis::GradedExposureGuard>>>> =
         Arc::new(std::sync::RwLock::new(None));
 
+    // DLC-D verified admission: provisioned from NUCLEUS_DLC_* env (inert when
+    // unset). The SAME provisioning is applied to both transports' kernels, and
+    // the sink stamps every allowed verdict's span with the admission state.
+    let dlc_admission = dlc_admission::provision_from_env();
+    let dlc_provisioned = dlc_admission.is_some();
+
     let verdict_sink: Arc<dyn portcullis::verdict_sink::VerdictSink> =
         Arc::new(verdict_sink::ToolProxyVerdictSink::new(
             file_lockdown.clone(),
@@ -1472,11 +1479,16 @@ async fn main() -> Result<(), ApiError> {
             exposure_guard.clone(),
             policy_checksum.clone(),
             session_id.clone(),
+            dlc_provisioned,
         ));
 
-    let kernel = Arc::new(tokio::sync::Mutex::new(Kernel::new(
-        runtime.policy().clone(),
-    )));
+    let kernel = Arc::new(tokio::sync::Mutex::new({
+        let mut k = Kernel::new(runtime.policy().clone());
+        if let Some(admission) = dlc_admission {
+            k.set_dlc_admission(admission);
+        }
+        k
+    }));
 
     let flow_tracker = Arc::new(tokio::sync::Mutex::new(FlowTracker::new()));
 

--- a/crates/nucleus-tool-proxy/src/mcp.rs
+++ b/crates/nucleus-tool-proxy/src/mcp.rs
@@ -161,7 +161,15 @@ impl NucleusMcpServer {
         let tool_schemas = format!("{:?}", tool_router.list_all());
         let policy = state.runtime.policy().clone();
 
-        let kernel = Arc::new(tokio::sync::Mutex::new(Kernel::new(policy.clone())));
+        let kernel = Arc::new(tokio::sync::Mutex::new({
+            let mut k = Kernel::new(policy.clone());
+            // Same NUCLEUS_DLC_* provisioning as the HTTP path's kernel —
+            // verified admission gates both transports or neither.
+            if let Some(admission) = crate::dlc_admission::provision_from_env() {
+                k.set_dlc_admission(admission);
+            }
+            k
+        }));
 
         let guard = Arc::new(GradedExposureGuard::new(policy, &tool_schemas));
 

--- a/crates/nucleus-tool-proxy/src/verdict_sink.rs
+++ b/crates/nucleus-tool-proxy/src/verdict_sink.rs
@@ -27,6 +27,12 @@ pub struct ToolProxyVerdictSink {
     exposure_guard: Arc<std::sync::RwLock<Option<Arc<GradedExposureGuard>>>>,
     policy_checksum: String,
     session_id: String,
+    /// Whether DLC-D verified admission is provisioned on this pod's kernels.
+    /// When true, every `Allow` this sink records has — by kernel construction
+    /// (the dlc gate is consulted before any Allow can emerge from
+    /// `decide_term_with_flow`, and complete mediation routes every tool call
+    /// through the kernel) — passed the issuer-credential check.
+    dlc_provisioned: bool,
 }
 
 impl ToolProxyVerdictSink {
@@ -38,6 +44,7 @@ impl ToolProxyVerdictSink {
         exposure_guard: Arc<std::sync::RwLock<Option<Arc<GradedExposureGuard>>>>,
         policy_checksum: String,
         session_id: String,
+        dlc_provisioned: bool,
     ) -> Self {
         Self {
             file_lockdown,
@@ -46,6 +53,7 @@ impl ToolProxyVerdictSink {
             exposure_guard,
             policy_checksum,
             session_id,
+            dlc_provisioned,
         }
     }
 
@@ -144,6 +152,19 @@ impl VerdictSink for ToolProxyVerdictSink {
         let actor = Self::actor_str(&ctx.actor);
         let operation = Self::operation_name(ctx.operation);
         let is_ok = verdict_str == "allow";
+        // Attestation of the verified-admission state, per tool call: "admitted"
+        // is only ever emitted when admission is provisioned AND the kernel
+        // allowed (see the `dlc_provisioned` field docs for why that implies
+        // the credential check passed); otherwise the span says so honestly.
+        let dlc_admission = if self.dlc_provisioned {
+            if is_ok {
+                "admitted"
+            } else {
+                "not-admitted"
+            }
+        } else {
+            "unprovisioned"
+        };
 
         // 2. Emit a proper span (not an event) so it has duration and
         //    propagates trace context.  When the `otel` layer is active,
@@ -178,6 +199,7 @@ impl VerdictSink for ToolProxyVerdictSink {
             exposure.exfil_vector = exposure.exfil_vector,
             exposure.uninhabitable = exposure.is_uninhabitable,
             // Context
+            nucleus.dlc_admission = dlc_admission,
             nucleus.lockdown_active = lockdown_active,
             nucleus.lattice_checksum = %self.policy_checksum,
             nucleus.session_id = %self.session_id,
@@ -215,6 +237,7 @@ mod tests {
             Arc::new(std::sync::RwLock::new(None)),
             "test-checksum".to_string(),
             "test-session".to_string(),
+            false,
         )
     }
 

--- a/crates/portcullis/src/says_admission.rs
+++ b/crates/portcullis/src/says_admission.rs
@@ -42,6 +42,18 @@ use dlc_core::principal::Principal;
 use dlc_core::syntax::Signature;
 use dlc_d::admission::{decide, Decision};
 
+/// Re-exported credential types, so a host crate (e.g. the tool proxy) can
+/// provision a [`DlcAdmission`] without depending on `dlc-core` directly.
+pub use dlc_core::judgment::KeyRing as DlcKeyRing;
+/// Re-export: a keyring row (issuer principal id + public key).
+pub use dlc_core::principal::KeyRecord as DlcKeyRecord;
+/// Re-export: the issuer principal.
+pub use dlc_core::principal::Principal as DlcPrincipal;
+/// Re-export: the issuer's stable principal id (32 bytes).
+pub use dlc_core::principal::PrincipalId as DlcPrincipalId;
+/// Re-export: an issuer-signed capability credential.
+pub use dlc_core::syntax::Signature as DlcSignature;
+
 use portcullis_core::combinators::{CheckResult, PolicyCheck, PolicyRequest};
 
 /// The provisioned admission state for a session: the trusted issuer keys, the issuer identity,


### PR DESCRIPTION
Phase 2 of the verified-admission arc (#2121 landed the kernel gate). Provisions `DlcAdmission` on BOTH transports' kernels from `NUCLEUS_DLC_*` env (inert when unset; set-but-partial = deny-all, fail-closed), and stamps every tool-call OTLP span with `nucleus.dlc_admission = admitted|not-admitted|unprovisioned` — the sink's span is the surface operators read (`VerdictContext.extensions` is carried but never emitted, so stamping it would have been attestation theater). Four bites with real Ed25519 minting, including wrong-operation-credential-refused-by-signature.

Touching tool-proxy triggers the pod-boot workflow, so a real pod boots against this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UA8kchV3eadjGv6BmJXfqm