### PR TITLE
Art12 inc2a: gate classifier + synchronous decision-record writer (unwired)

### DIFF
--- a/crates/nucleus-tool-proxy/src/art12.rs
+++ b/crates/nucleus-tool-proxy/src/art12.rs
@@ -59,16 +59,9 @@ use std::path::Path;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Mutex;
 
-use serde::{Deserialize, Serialize};
-
-/// Schema version for [`Art12Record`]. v1 is FROZEN: fields may be added with
-/// `#[serde(default)]`, never removed or repurposed, and the canonical preimage
-/// below must not change without a version bump.
-pub const ART12_SCHEMA_VERSION: u32 = 1;
-
-/// Domain separation tag for the record preimage, so an Article 12 record can
-/// never be confused with another HMAC'd artifact signed by the same secret.
-const PREIMAGE_DOMAIN: &str = "nucleus-art12-record-v1";
+// The record TYPE and its canonical preimage live in `portcullis` so the writer
+// here and the verifier in `nucleus-audit` share one definition.
+use portcullis::art12_record::{Art12Record, ART12_SCHEMA_VERSION};
 
 /// What went wrong writing a record.
 #[derive(Debug)]
@@ -92,137 +85,6 @@ impl std::fmt::Display for Art12Error {
 }
 
 impl std::error::Error for Art12Error {}
-
-/// The identity of whoever caused a decision.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
-pub struct Actor {
-    /// `authenticated` | `stdio_guest` | `unknown`.
-    pub kind: String,
-    /// SPIFFE ID when authenticated.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub spiffe_id: Option<String>,
-}
-
-/// A refusal, in machine-queryable form.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
-pub struct DenyInfo {
-    /// The `DenyReason` serde tag (e.g. `dlc_admission_denied`) — stable across
-    /// releases, unlike a `Debug` rendering.
-    pub code: String,
-    /// Human-readable detail, for a reader rather than a query.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub detail: Option<String>,
-}
-
-/// One reconstructable decision.
-///
-/// Field set is deliberately sufficient to answer, without any other artifact:
-/// *who* asked, *what* they asked for, *what was decided*, *which kind of
-/// control decided it*, and *against which policy* — plus the chain fields that
-/// make the answer tamper-evident.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
-pub struct Art12Record {
-    /// Schema version; see [`ART12_SCHEMA_VERSION`].
-    pub schema_version: u32,
-    /// Monotonic sequence within this log, starting at 1.
-    pub seq: u64,
-    /// Seconds since the Unix epoch.
-    pub timestamp_unix: u64,
-    /// Session this decision belongs to.
-    pub session_id: String,
-    /// Which transport carried the request (`http` | `mcp`).
-    pub transport: String,
-    /// Who asked.
-    pub actor: Actor,
-    /// The operation's canonical name.
-    pub operation: String,
-    /// What it was requested against (path, command, URL, …).
-    pub subject: String,
-    /// `allow` | `requires_approval` | `deny` | `error`.
-    pub verdict: String,
-    /// Which KIND of control decided — the Article 12 hard/soft gate field.
-    pub gate_class: String,
-    /// Present iff `verdict == "deny"`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub deny_reason: Option<DenyInfo>,
-    /// Checksum of the permission lattice in force.
-    pub policy_checksum: String,
-    /// The named policy rule that decided, when one did.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub policy_rule: Option<String>,
-    /// `admitted` | `not_admitted` | `unprovisioned` — whether verified
-    /// admission was armed, and whether it passed. Distinguishes "the gate
-    /// refused" from "the gate was never armed".
-    pub dlc_admission: String,
-    /// Whether emergency lockdown was active at decision time (Article 14).
-    pub lockdown_active: bool,
-    /// Kernel decision sequence, when this record reflects a kernel decision —
-    /// joins the pre-effect and post-effect records for one operation.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub decision_sequence: Option<u64>,
-    /// Domain-specific metadata (e.g. a discharged-bundle witness).
-    #[serde(default, skip_serializing_if = "std::collections::BTreeMap::is_empty")]
-    pub extensions: std::collections::BTreeMap<String, String>,
-    /// Hash of the previous record; for the first record, the boot report's hash.
-    pub prev_hash: String,
-    /// SHA-256 over the canonical preimage.
-    pub hash: String,
-    /// HMAC-SHA256 over the canonical preimage, under the audit secret.
-    pub signature: String,
-}
-
-impl Art12Record {
-    /// The canonical preimage: a `|`-joined, field-ordered rendering that both
-    /// the writer and any verifier reconstruct **from the record's own fields**.
-    ///
-    /// Deliberately not `serde_json::to_string` — JSON key order and escaping
-    /// are not guaranteed stable across serde versions, and a verifier that
-    /// re-serializes to check a hash is checking its own serializer.
-    #[must_use]
-    pub fn canonical_preimage(&self) -> String {
-        let deny = self
-            .deny_reason
-            .as_ref()
-            .map(|d| format!("{}:{}", d.code, d.detail.as_deref().unwrap_or("")))
-            .unwrap_or_default();
-        let ext = self
-            .extensions
-            .iter()
-            .map(|(k, v)| format!("{k}={v}"))
-            .collect::<Vec<_>>()
-            .join(",");
-        format!(
-            "{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}",
-            PREIMAGE_DOMAIN,
-            self.schema_version,
-            self.seq,
-            self.timestamp_unix,
-            self.session_id,
-            self.transport,
-            self.actor.kind,
-            self.actor.spiffe_id.as_deref().unwrap_or(""),
-            self.operation,
-            self.subject,
-            self.verdict,
-            self.gate_class,
-            deny,
-            self.policy_checksum,
-            self.policy_rule.as_deref().unwrap_or(""),
-            self.dlc_admission,
-            self.lockdown_active,
-            self.prev_hash,
-        ) + &format!(
-            "|{}|{}",
-            self.decision_sequence
-                .map(|s| s.to_string())
-                .unwrap_or_default(),
-            ext
-        )
-    }
-}
 
 /// The synchronous, chained writer.
 pub struct Art12Log {
@@ -370,6 +232,7 @@ pub fn sha256_hex(message: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use portcullis::art12_record::{Actor, DenyInfo};
     use std::collections::BTreeMap;
 
     fn draft(operation: &str, verdict: &str, gate_class: &str) -> Art12Record {
@@ -524,11 +387,27 @@ mod tests {
         assert_eq!(head, read_records(&path)[1].hash);
     }
 
-    /// Domain separation: an Article 12 preimage cannot collide with another
-    /// artifact HMAC'd under the same secret.
+    /// A refusal record carries its machine-queryable code — the field an
+    /// auditor queries on, and the one increment 3 makes reachable at all.
     #[test]
-    fn preimage_is_domain_separated() {
-        let rec = draft("read_files", "allow", "none");
-        assert!(rec.canonical_preimage().starts_with(PREIMAGE_DOMAIN));
+    fn deny_records_carry_their_reason_code() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("art12.jsonl");
+        let log = Art12Log::open(&path, b"s".to_vec(), "g".to_string(), false).unwrap();
+
+        let mut d = draft("run_bash", "deny", "admission");
+        d.deny_reason = Some(DenyInfo {
+            code: "dlc_admission_denied".to_string(),
+            detail: Some("no issuer-signed credential".to_string()),
+        });
+        log.append(d).unwrap();
+
+        let rec = read_records(&path).remove(0);
+        let reason = rec
+            .deny_reason
+            .as_ref()
+            .expect("deny record carries a reason");
+        assert_eq!(reason.code, "dlc_admission_denied");
+        assert_eq!(sha256_hex(&rec.canonical_preimage()), rec.hash);
     }
 }

--- a/crates/nucleus-tool-proxy/src/art12.rs
+++ b/crates/nucleus-tool-proxy/src/art12.rs
@@ -42,6 +42,16 @@
 //! key the pod does not possess can do that, which is why the export attaches
 //! one. Both properties are asserted by tests, including the one that
 //! deliberately demonstrates the HMAC limit.
+//!
+//! # Why `allow(dead_code)` here
+//!
+//! This module is landed UNWIRED on purpose: the staging puts every unit and
+//! perturbation test green before anything on the live decision path changes.
+//! Until the sink is wired to it (the increment that adds `--art12-log`),
+//! nothing outside the tests constructs an `Art12Log`, and CI builds with
+//! `-D warnings`. **Remove this allow in the wiring increment** — once the sink
+//! calls `append`, genuinely dead code here should fail the build again.
+#![allow(dead_code)]
 
 use std::fs::{File, OpenOptions};
 use std::io::Write;

--- a/crates/nucleus-tool-proxy/src/art12.rs
+++ b/crates/nucleus-tool-proxy/src/art12.rs
@@ -1,0 +1,524 @@
+//! EU AI Act Article 12 decision records — a synchronous, hash-chained,
+//! per-decision evidence log.
+//!
+//! Article 12 obliges automatic event logging over a system's lifetime, with
+//! traceability that regulators read as **tamper-evident**, sufficient to
+//! **reconstruct an individual AI-assisted decision** after the fact. This
+//! module is the writer for that record.
+//!
+//! # Why a second log, and not the existing one
+//!
+//! The tool-proxy already has an HMAC-chained [`AuditLog`](crate::AuditLog), and
+//! reusing it was the obvious first idea. It is the wrong home here:
+//!
+//! - Its `log()` is **async**, because it optionally fetches a drand round per
+//!   entry. [`VerdictSink::record`] is **sync**, and a per-tool-call network
+//!   round-trip on the decision path is unacceptable regardless.
+//! - Node-side lifecycle events historically shared its file, which is why
+//!   every local/container audit log failed verification until that was split
+//!   out. A record an auditor must be able to verify should not share a file
+//!   with unsigned lines by construction.
+//!
+//! So Article 12 records go to their own file, with their own chain — and that
+//! chain's **genesis is bound to the existing one**: the first record's
+//! `prev_hash` is the boot report's hash. There is still exactly one chain to
+//! follow, and the boot report (which carries the sandbox-proof tier) is its
+//! commitment.
+//!
+//! # Durability posture, stated plainly
+//!
+//! Each append is `write_all` + `flush` into the page cache, under a mutex,
+//! holding one file handle for the process lifetime. There is **no `fsync`**:
+//! it would add a journal commit per tool call, and the failure it guards
+//! (host power loss) is both bounded and *detectable* — a lost tail shows up as
+//! a `seq` gap and a `head_hash` that does not match. This is recorded in the
+//! exported bundle's `limitations`, not papered over.
+//!
+//! # What tamper-evidence here does and does not mean
+//!
+//! The chain is HMAC'd with the audit secret. That detects modification by any
+//! party who does not hold the secret. It does **not** protect against a holder
+//! of the secret rewriting history — only a signature over the chain head by a
+//! key the pod does not possess can do that, which is why the export attaches
+//! one. Both properties are asserted by tests, including the one that
+//! deliberately demonstrates the HMAC limit.
+
+use std::fs::{File, OpenOptions};
+use std::io::Write;
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Mutex;
+
+use serde::{Deserialize, Serialize};
+
+/// Schema version for [`Art12Record`]. v1 is FROZEN: fields may be added with
+/// `#[serde(default)]`, never removed or repurposed, and the canonical preimage
+/// below must not change without a version bump.
+pub const ART12_SCHEMA_VERSION: u32 = 1;
+
+/// Domain separation tag for the record preimage, so an Article 12 record can
+/// never be confused with another HMAC'd artifact signed by the same secret.
+const PREIMAGE_DOMAIN: &str = "nucleus-art12-record-v1";
+
+/// What went wrong writing a record.
+#[derive(Debug)]
+pub enum Art12Error {
+    /// The record could not be serialized.
+    Serialize(serde_json::Error),
+    /// The record could not be written or flushed.
+    Io(std::io::Error),
+    /// The log's mutex was poisoned by a panic in another thread.
+    Poisoned,
+}
+
+impl std::fmt::Display for Art12Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Art12Error::Serialize(e) => write!(f, "serialize art12 record: {e}"),
+            Art12Error::Io(e) => write!(f, "write art12 record: {e}"),
+            Art12Error::Poisoned => write!(f, "art12 log mutex poisoned"),
+        }
+    }
+}
+
+impl std::error::Error for Art12Error {}
+
+/// The identity of whoever caused a decision.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct Actor {
+    /// `authenticated` | `stdio_guest` | `unknown`.
+    pub kind: String,
+    /// SPIFFE ID when authenticated.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub spiffe_id: Option<String>,
+}
+
+/// A refusal, in machine-queryable form.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct DenyInfo {
+    /// The `DenyReason` serde tag (e.g. `dlc_admission_denied`) — stable across
+    /// releases, unlike a `Debug` rendering.
+    pub code: String,
+    /// Human-readable detail, for a reader rather than a query.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+}
+
+/// One reconstructable decision.
+///
+/// Field set is deliberately sufficient to answer, without any other artifact:
+/// *who* asked, *what* they asked for, *what was decided*, *which kind of
+/// control decided it*, and *against which policy* — plus the chain fields that
+/// make the answer tamper-evident.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct Art12Record {
+    /// Schema version; see [`ART12_SCHEMA_VERSION`].
+    pub schema_version: u32,
+    /// Monotonic sequence within this log, starting at 1.
+    pub seq: u64,
+    /// Seconds since the Unix epoch.
+    pub timestamp_unix: u64,
+    /// Session this decision belongs to.
+    pub session_id: String,
+    /// Which transport carried the request (`http` | `mcp`).
+    pub transport: String,
+    /// Who asked.
+    pub actor: Actor,
+    /// The operation's canonical name.
+    pub operation: String,
+    /// What it was requested against (path, command, URL, …).
+    pub subject: String,
+    /// `allow` | `requires_approval` | `deny` | `error`.
+    pub verdict: String,
+    /// Which KIND of control decided — the Article 12 hard/soft gate field.
+    pub gate_class: String,
+    /// Present iff `verdict == "deny"`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deny_reason: Option<DenyInfo>,
+    /// Checksum of the permission lattice in force.
+    pub policy_checksum: String,
+    /// The named policy rule that decided, when one did.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub policy_rule: Option<String>,
+    /// `admitted` | `not_admitted` | `unprovisioned` — whether verified
+    /// admission was armed, and whether it passed. Distinguishes "the gate
+    /// refused" from "the gate was never armed".
+    pub dlc_admission: String,
+    /// Whether emergency lockdown was active at decision time (Article 14).
+    pub lockdown_active: bool,
+    /// Kernel decision sequence, when this record reflects a kernel decision —
+    /// joins the pre-effect and post-effect records for one operation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub decision_sequence: Option<u64>,
+    /// Domain-specific metadata (e.g. a discharged-bundle witness).
+    #[serde(default, skip_serializing_if = "std::collections::BTreeMap::is_empty")]
+    pub extensions: std::collections::BTreeMap<String, String>,
+    /// Hash of the previous record; for the first record, the boot report's hash.
+    pub prev_hash: String,
+    /// SHA-256 over the canonical preimage.
+    pub hash: String,
+    /// HMAC-SHA256 over the canonical preimage, under the audit secret.
+    pub signature: String,
+}
+
+impl Art12Record {
+    /// The canonical preimage: a `|`-joined, field-ordered rendering that both
+    /// the writer and any verifier reconstruct **from the record's own fields**.
+    ///
+    /// Deliberately not `serde_json::to_string` — JSON key order and escaping
+    /// are not guaranteed stable across serde versions, and a verifier that
+    /// re-serializes to check a hash is checking its own serializer.
+    #[must_use]
+    pub fn canonical_preimage(&self) -> String {
+        let deny = self
+            .deny_reason
+            .as_ref()
+            .map(|d| format!("{}:{}", d.code, d.detail.as_deref().unwrap_or("")))
+            .unwrap_or_default();
+        let ext = self
+            .extensions
+            .iter()
+            .map(|(k, v)| format!("{k}={v}"))
+            .collect::<Vec<_>>()
+            .join(",");
+        format!(
+            "{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}",
+            PREIMAGE_DOMAIN,
+            self.schema_version,
+            self.seq,
+            self.timestamp_unix,
+            self.session_id,
+            self.transport,
+            self.actor.kind,
+            self.actor.spiffe_id.as_deref().unwrap_or(""),
+            self.operation,
+            self.subject,
+            self.verdict,
+            self.gate_class,
+            deny,
+            self.policy_checksum,
+            self.policy_rule.as_deref().unwrap_or(""),
+            self.dlc_admission,
+            self.lockdown_active,
+            self.prev_hash,
+        ) + &format!(
+            "|{}|{}",
+            self.decision_sequence
+                .map(|s| s.to_string())
+                .unwrap_or_default(),
+            ext
+        )
+    }
+}
+
+/// The synchronous, chained writer.
+pub struct Art12Log {
+    inner: Mutex<Inner>,
+    secret: Vec<u8>,
+    /// Latched once a write fails. Consulted by `preflight` so the NEXT
+    /// operation is denied before it executes — bounding evidence loss without
+    /// failing calls whose effect already happened.
+    degraded: AtomicBool,
+    /// Records that could not be written. Published in the export so a gap is
+    /// explicit rather than silent.
+    dropped: AtomicU64,
+    /// Mirror each append to stdout, for guests whose file the host cannot read.
+    console_mirror: bool,
+}
+
+struct Inner {
+    file: File,
+    last_hash: String,
+    seq: u64,
+}
+
+impl Art12Log {
+    /// Open (or create) the log, chaining from `genesis_prev_hash` — the boot
+    /// report's hash, so this chain is anchored to the existing audit chain.
+    ///
+    /// # Errors
+    /// If the file cannot be opened for appending.
+    pub fn open(
+        path: &Path,
+        secret: Vec<u8>,
+        genesis_prev_hash: String,
+        console_mirror: bool,
+    ) -> Result<Self, Art12Error> {
+        if let Some(parent) = path.parent() {
+            if !parent.as_os_str().is_empty() {
+                std::fs::create_dir_all(parent).map_err(Art12Error::Io)?;
+            }
+        }
+        let file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+            .map_err(Art12Error::Io)?;
+        Ok(Self {
+            inner: Mutex::new(Inner {
+                file,
+                last_hash: genesis_prev_hash,
+                seq: 0,
+            }),
+            secret,
+            degraded: AtomicBool::new(false),
+            dropped: AtomicU64::new(0),
+            console_mirror,
+        })
+    }
+
+    /// Whether a write has failed since startup.
+    #[must_use]
+    pub fn is_degraded(&self) -> bool {
+        self.degraded.load(Ordering::Acquire)
+    }
+
+    /// How many records could not be written.
+    #[must_use]
+    pub fn dropped(&self) -> u64 {
+        self.dropped.load(Ordering::Acquire)
+    }
+
+    /// The current chain head, and how many records this process wrote.
+    ///
+    /// # Errors
+    /// If the mutex is poisoned.
+    pub fn head(&self) -> Result<(String, u64), Art12Error> {
+        let inner = self.inner.lock().map_err(|_| Art12Error::Poisoned)?;
+        Ok((inner.last_hash.clone(), inner.seq))
+    }
+
+    /// Append a decision. `draft` supplies everything except the chain fields,
+    /// which are assigned here.
+    ///
+    /// # Errors
+    /// [`Art12Error`] on serialize/IO failure; the log latches `degraded` and
+    /// increments `dropped` before returning, so the caller may continue while
+    /// the next `preflight` fails closed.
+    pub fn append(&self, mut draft: Art12Record) -> Result<(), Art12Error> {
+        let result = self.append_inner(&mut draft);
+        if result.is_err() {
+            self.degraded.store(true, Ordering::Release);
+            self.dropped.fetch_add(1, Ordering::AcqRel);
+        }
+        result
+    }
+
+    fn append_inner(&self, draft: &mut Art12Record) -> Result<(), Art12Error> {
+        let mut inner = self.inner.lock().map_err(|_| Art12Error::Poisoned)?;
+
+        draft.schema_version = ART12_SCHEMA_VERSION;
+        draft.seq = inner.seq + 1;
+        draft.prev_hash = inner.last_hash.clone();
+
+        let preimage = draft.canonical_preimage();
+        draft.signature = crate::auth::sign_message(&self.secret, preimage.as_bytes());
+        draft.hash = sha256_hex(&preimage);
+
+        let line = serde_json::to_string(&draft).map_err(Art12Error::Serialize)?;
+        inner
+            .file
+            .write_all(line.as_bytes())
+            .and_then(|()| inner.file.write_all(b"\n"))
+            .and_then(|()| inner.file.flush())
+            .map_err(Art12Error::Io)?;
+
+        // Console mirror: a compact checkpoint the HOST can read even when the
+        // record file lives on a guest filesystem it cannot mount. Direct
+        // `println!`, never `tracing` — tracing is `RUST_LOG`-gated and is
+        // precisely why per-call evidence was invisible before this.
+        if self.console_mirror {
+            let mut out = std::io::stdout().lock();
+            let _ = writeln!(
+                out,
+                "NUCLEUS-ART12 {}|{}|{}|{}|{}",
+                draft.seq, draft.hash, draft.verdict, draft.gate_class, draft.operation
+            );
+            let _ = out.flush();
+        }
+
+        inner.last_hash = draft.hash.clone();
+        inner.seq = draft.seq;
+        Ok(())
+    }
+}
+
+/// SHA-256 of a string, hex-encoded.
+///
+/// Lives here rather than in `main.rs` because this is where the hashing it
+/// serves lives; the boot-report chain in `AuditLog` uses the same helper.
+pub fn sha256_hex(message: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(message.as_bytes());
+    hex::encode(hasher.finalize())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    fn draft(operation: &str, verdict: &str, gate_class: &str) -> Art12Record {
+        Art12Record {
+            schema_version: 0, // overwritten by append
+            seq: 0,            // overwritten
+            timestamp_unix: 1_700_000_000,
+            session_id: "sess-1".to_string(),
+            transport: "http".to_string(),
+            actor: Actor {
+                kind: "stdio_guest".to_string(),
+                spiffe_id: None,
+            },
+            operation: operation.to_string(),
+            subject: "/work/x".to_string(),
+            verdict: verdict.to_string(),
+            gate_class: gate_class.to_string(),
+            deny_reason: None,
+            policy_checksum: "abc123".to_string(),
+            policy_rule: None,
+            dlc_admission: "unprovisioned".to_string(),
+            lockdown_active: false,
+            decision_sequence: None,
+            extensions: BTreeMap::new(),
+            prev_hash: String::new(), // overwritten
+            hash: String::new(),      // overwritten
+            signature: String::new(), // overwritten
+        }
+    }
+
+    fn read_records(path: &Path) -> Vec<Art12Record> {
+        std::fs::read_to_string(path)
+            .expect("read log")
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .map(|l| serde_json::from_str(l).expect("record parses"))
+            .collect()
+    }
+
+    #[test]
+    fn append_writes_exactly_one_parseable_line() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("art12.jsonl");
+        let log = Art12Log::open(&path, b"s".to_vec(), "genesis".to_string(), false).unwrap();
+        log.append(draft("read_files", "allow", "none")).unwrap();
+
+        let recs = read_records(&path);
+        assert_eq!(recs.len(), 1);
+        assert_eq!(recs[0].seq, 1);
+        assert_eq!(recs[0].schema_version, ART12_SCHEMA_VERSION);
+        assert_eq!(recs[0].prev_hash, "genesis");
+        assert!(!recs[0].hash.is_empty() && !recs[0].signature.is_empty());
+    }
+
+    #[test]
+    fn two_appends_chain() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("art12.jsonl");
+        let log = Art12Log::open(&path, b"s".to_vec(), "genesis".to_string(), false).unwrap();
+        log.append(draft("read_files", "allow", "none")).unwrap();
+        log.append(draft("run_bash", "deny", "admission")).unwrap();
+
+        let recs = read_records(&path);
+        assert_eq!(recs.len(), 2);
+        assert_eq!(recs[1].prev_hash, recs[0].hash, "record 2 must chain to 1");
+        assert_eq!(recs[1].seq, 2);
+    }
+
+    /// The chain's first link is the EXISTING audit chain's head, so there is
+    /// one chain to verify rather than two unrelated ones.
+    #[test]
+    fn genesis_prev_hash_is_the_supplied_boot_hash() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("art12.jsonl");
+        let log =
+            Art12Log::open(&path, b"s".to_vec(), "boot-report-hash".to_string(), false).unwrap();
+        log.append(draft("read_files", "allow", "none")).unwrap();
+        assert_eq!(read_records(&path)[0].prev_hash, "boot-report-hash");
+    }
+
+    /// The hash must be recomputable from the record's own fields — this is
+    /// exactly what a third-party verifier will do.
+    #[test]
+    fn hash_recomputes_from_the_record_alone() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("art12.jsonl");
+        let log = Art12Log::open(&path, b"secret".to_vec(), "g".to_string(), false).unwrap();
+        log.append(draft("read_files", "allow", "none")).unwrap();
+
+        let rec = &read_records(&path)[0];
+        assert_eq!(sha256_hex(&rec.canonical_preimage()), rec.hash);
+        assert_eq!(
+            crate::auth::sign_message(b"secret", rec.canonical_preimage().as_bytes()),
+            rec.signature
+        );
+    }
+
+    /// ★ Tampering must be detectable: change one field and the stored hash no
+    /// longer matches the recomputed preimage.
+    #[test]
+    fn tampering_breaks_the_recomputed_hash() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("art12.jsonl");
+        let log = Art12Log::open(&path, b"secret".to_vec(), "g".to_string(), false).unwrap();
+        log.append(draft("run_bash", "deny", "admission")).unwrap();
+
+        let mut rec = read_records(&path).remove(0);
+        assert_eq!(sha256_hex(&rec.canonical_preimage()), rec.hash);
+        rec.verdict = "allow".to_string(); // the edit an attacker wants
+        assert_ne!(
+            sha256_hex(&rec.canonical_preimage()),
+            rec.hash,
+            "flipping deny→allow must invalidate the hash"
+        );
+    }
+
+    /// A write failure latches `degraded` and counts the loss, so the gap is
+    /// explicit and the next `preflight` can fail closed.
+    #[test]
+    fn write_failure_latches_degraded_and_counts() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("art12.jsonl");
+        let log = Art12Log::open(&path, b"s".to_vec(), "g".to_string(), false).unwrap();
+        assert!(!log.is_degraded() && log.dropped() == 0);
+
+        // Poison the mutex to force the failure path deterministically, without
+        // depending on filesystem permissions (which differ under CI and root).
+        let poisoner = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = log.inner.lock().unwrap();
+            panic!("poison");
+        }));
+        assert!(poisoner.is_err());
+
+        let err = log.append(draft("read_files", "allow", "none"));
+        assert!(err.is_err(), "append must fail on a poisoned log");
+        assert!(log.is_degraded(), "degraded must latch");
+        assert_eq!(log.dropped(), 1, "the loss must be counted");
+    }
+
+    #[test]
+    fn head_tracks_the_last_record() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("art12.jsonl");
+        let log = Art12Log::open(&path, b"s".to_vec(), "g".to_string(), false).unwrap();
+        assert_eq!(log.head().unwrap(), ("g".to_string(), 0));
+
+        log.append(draft("read_files", "allow", "none")).unwrap();
+        log.append(draft("run_bash", "deny", "admission")).unwrap();
+
+        let (head, count) = log.head().unwrap();
+        assert_eq!(count, 2);
+        assert_eq!(head, read_records(&path)[1].hash);
+    }
+
+    /// Domain separation: an Article 12 preimage cannot collide with another
+    /// artifact HMAC'd under the same secret.
+    #[test]
+    fn preimage_is_domain_separated() {
+        let rec = draft("read_files", "allow", "none");
+        assert!(rec.canonical_preimage().starts_with(PREIMAGE_DOMAIN));
+    }
+}

--- a/crates/nucleus-tool-proxy/src/main.rs
+++ b/crates/nucleus-tool-proxy/src/main.rs
@@ -28,6 +28,7 @@ use tokio::io::AsyncWriteExt;
 use tokio::net::TcpListener;
 use tracing::{error, info, warn};
 
+mod art12;
 mod attestation;
 mod auth;
 mod broker_client;
@@ -4720,7 +4721,7 @@ impl AuditLog {
                 drand_part
             );
             let signature = auth::sign_message(&self.secret, message.as_bytes());
-            let hash = sha256_hex(&format!("{}|{}", message, signature));
+            let hash = art12::sha256_hex(&format!("{}|{}", message, signature));
             *last_hash = hash.clone();
             (prev_hash, hash, signature)
         };
@@ -4793,12 +4794,6 @@ fn now_unix() -> u64 {
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs()
-}
-
-fn sha256_hex(message: &str) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(message.as_bytes());
-    hex::encode(hasher.finalize())
 }
 
 fn load_last_hash(path: &Path) -> Option<String> {

--- a/crates/nucleus-tool-proxy/src/main.rs
+++ b/crates/nucleus-tool-proxy/src/main.rs
@@ -23,7 +23,6 @@ use nucleus_permission_market::{PermissionBid, PermissionGrant, PermissionMarket
 use nucleus_spec::PodSpec;
 use portcullis::verdict_sink::{ActorIdentity, VerdictContext, VerdictOutcome};
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
 use tokio::io::AsyncWriteExt;
 use tokio::net::TcpListener;
 use tracing::{error, info, warn};

--- a/crates/portcullis/src/art12_record.rs
+++ b/crates/portcullis/src/art12_record.rs
@@ -1,0 +1,290 @@
+//! The EU AI Act Article 12 decision-record TYPE and its canonical preimage.
+//!
+//! Lives in `portcullis` — not in the tool-proxy that writes records, nor in the
+//! audit tool that verifies them — so that the writer and the verifier share
+//! **one** definition. A duplicated canonical preimage is the failure mode this
+//! placement exists to prevent: two copies that drift produce a verifier which
+//! rejects authentic evidence (exactly the drand-suffix bug fixed alongside
+//! this work) or, worse, accepts forged evidence.
+//!
+//! The writer (`nucleus_tool_proxy::art12::Art12Log`) owns file I/O and chain
+//! state; everything about what a record *is* lives here.
+
+use serde::{Deserialize, Serialize};
+
+/// Schema version for [`Art12Record`]. v1 is FROZEN: fields may be added with
+/// `#[serde(default)]`, never removed or repurposed, and the canonical preimage
+/// below must not change without a version bump.
+pub const ART12_SCHEMA_VERSION: u32 = 1;
+
+/// Domain separation tag for the record preimage, so an Article 12 record can
+/// never be confused with another HMAC'd artifact signed by the same secret.
+pub const PREIMAGE_DOMAIN: &str = "nucleus-art12-record-v1";
+
+/// The identity of whoever caused a decision.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct Actor {
+    /// `authenticated` | `stdio_guest` | `unknown`.
+    pub kind: String,
+    /// SPIFFE ID when authenticated.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub spiffe_id: Option<String>,
+}
+
+/// A refusal, in machine-queryable form.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct DenyInfo {
+    /// The `DenyReason` serde tag (e.g. `dlc_admission_denied`) — stable across
+    /// releases, unlike a `Debug` rendering.
+    pub code: String,
+    /// Human-readable detail, for a reader rather than a query.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+}
+
+/// One reconstructable decision.
+///
+/// Field set is deliberately sufficient to answer, without any other artifact:
+/// *who* asked, *what* they asked for, *what was decided*, *which kind of
+/// control decided it*, and *against which policy* — plus the chain fields that
+/// make the answer tamper-evident.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct Art12Record {
+    /// Schema version; see [`ART12_SCHEMA_VERSION`].
+    pub schema_version: u32,
+    /// Monotonic sequence within this log, starting at 1.
+    pub seq: u64,
+    /// Seconds since the Unix epoch.
+    pub timestamp_unix: u64,
+    /// Session this decision belongs to.
+    pub session_id: String,
+    /// Which transport carried the request (`http` | `mcp`).
+    pub transport: String,
+    /// Who asked.
+    pub actor: Actor,
+    /// The operation's canonical name.
+    pub operation: String,
+    /// What it was requested against (path, command, URL, …).
+    pub subject: String,
+    /// `allow` | `requires_approval` | `deny` | `error`.
+    pub verdict: String,
+    /// Which KIND of control decided — the Article 12 hard/soft gate field.
+    pub gate_class: String,
+    /// Present iff `verdict == "deny"`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deny_reason: Option<DenyInfo>,
+    /// Checksum of the permission lattice in force.
+    pub policy_checksum: String,
+    /// The named policy rule that decided, when one did.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub policy_rule: Option<String>,
+    /// `admitted` | `not_admitted` | `unprovisioned` — whether verified
+    /// admission was armed, and whether it passed. Distinguishes "the gate
+    /// refused" from "the gate was never armed".
+    pub dlc_admission: String,
+    /// Whether emergency lockdown was active at decision time (Article 14).
+    pub lockdown_active: bool,
+    /// Kernel decision sequence, when this record reflects a kernel decision —
+    /// joins the pre-effect and post-effect records for one operation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub decision_sequence: Option<u64>,
+    /// Domain-specific metadata (e.g. a discharged-bundle witness).
+    #[serde(default, skip_serializing_if = "std::collections::BTreeMap::is_empty")]
+    pub extensions: std::collections::BTreeMap<String, String>,
+    /// Hash of the previous record; for the first record, the boot report's hash.
+    pub prev_hash: String,
+    /// SHA-256 over the canonical preimage.
+    pub hash: String,
+    /// HMAC-SHA256 over the canonical preimage, under the audit secret.
+    pub signature: String,
+}
+
+impl Art12Record {
+    /// The canonical preimage: a `|`-joined, field-ordered rendering that both
+    /// the writer and any verifier reconstruct **from the record's own fields**.
+    ///
+    /// Deliberately not `serde_json::to_string` — JSON key order and escaping
+    /// are not guaranteed stable across serde versions, and a verifier that
+    /// re-serializes to check a hash is checking its own serializer.
+    #[must_use]
+    pub fn canonical_preimage(&self) -> String {
+        let deny = self
+            .deny_reason
+            .as_ref()
+            .map(|d| format!("{}:{}", d.code, d.detail.as_deref().unwrap_or("")))
+            .unwrap_or_default();
+        let ext = self
+            .extensions
+            .iter()
+            .map(|(k, v)| format!("{k}={v}"))
+            .collect::<Vec<_>>()
+            .join(",");
+        format!(
+            "{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}|{}",
+            PREIMAGE_DOMAIN,
+            self.schema_version,
+            self.seq,
+            self.timestamp_unix,
+            self.session_id,
+            self.transport,
+            self.actor.kind,
+            self.actor.spiffe_id.as_deref().unwrap_or(""),
+            self.operation,
+            self.subject,
+            self.verdict,
+            self.gate_class,
+            deny,
+            self.policy_checksum,
+            self.policy_rule.as_deref().unwrap_or(""),
+            self.dlc_admission,
+            self.lockdown_active,
+            self.prev_hash,
+        ) + &format!(
+            "|{}|{}",
+            self.decision_sequence
+                .map(|s| s.to_string())
+                .unwrap_or_default(),
+            ext
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    fn rec() -> Art12Record {
+        Art12Record {
+            schema_version: ART12_SCHEMA_VERSION,
+            seq: 1,
+            timestamp_unix: 1_700_000_000,
+            session_id: "s".into(),
+            transport: "http".into(),
+            actor: Actor {
+                kind: "stdio_guest".into(),
+                spiffe_id: None,
+            },
+            operation: "read_files".into(),
+            subject: "/work/x".into(),
+            verdict: "deny".into(),
+            gate_class: "admission".into(),
+            deny_reason: Some(DenyInfo {
+                code: "dlc_admission_denied".into(),
+                detail: Some("no credential".into()),
+            }),
+            policy_checksum: "abc".into(),
+            policy_rule: None,
+            dlc_admission: "not_admitted".into(),
+            lockdown_active: false,
+            decision_sequence: Some(7),
+            extensions: BTreeMap::new(),
+            prev_hash: "p".into(),
+            hash: String::new(),
+            signature: String::new(),
+        }
+    }
+
+    /// Domain separation: an Article 12 preimage cannot collide with another
+    /// artifact HMAC'd under the same audit secret.
+    #[test]
+    fn preimage_is_domain_separated() {
+        assert!(rec().canonical_preimage().starts_with(PREIMAGE_DOMAIN));
+    }
+
+    /// ★ Every field an auditor would rely on must CHANGE the preimage. A field
+    /// that does not is a field an attacker can edit without breaking the hash —
+    /// which is the whole tamper-evidence claim.
+    #[test]
+    fn every_load_bearing_field_changes_the_preimage() {
+        let base = rec().canonical_preimage();
+        /// One named mutation of a record field, for the coverage sweep below.
+        type Mutation = (&'static str, Box<dyn Fn(&mut Art12Record)>);
+
+        let mutate: Vec<Mutation> = vec![
+            ("seq", Box::new(|r: &mut Art12Record| r.seq = 2)),
+            (
+                "timestamp",
+                Box::new(|r: &mut Art12Record| r.timestamp_unix += 1),
+            ),
+            (
+                "session_id",
+                Box::new(|r: &mut Art12Record| r.session_id = "other".into()),
+            ),
+            (
+                "transport",
+                Box::new(|r: &mut Art12Record| r.transport = "mcp".into()),
+            ),
+            (
+                "actor.kind",
+                Box::new(|r: &mut Art12Record| r.actor.kind = "authenticated".into()),
+            ),
+            (
+                "actor.spiffe",
+                Box::new(|r: &mut Art12Record| r.actor.spiffe_id = Some("spiffe://x".into())),
+            ),
+            (
+                "operation",
+                Box::new(|r: &mut Art12Record| r.operation = "run_bash".into()),
+            ),
+            (
+                "subject",
+                Box::new(|r: &mut Art12Record| r.subject = "/etc/shadow".into()),
+            ),
+            (
+                "verdict",
+                Box::new(|r: &mut Art12Record| r.verdict = "allow".into()),
+            ),
+            (
+                "gate_class",
+                Box::new(|r: &mut Art12Record| r.gate_class = "none".into()),
+            ),
+            (
+                "deny_reason",
+                Box::new(|r: &mut Art12Record| r.deny_reason = None),
+            ),
+            (
+                "policy_checksum",
+                Box::new(|r: &mut Art12Record| r.policy_checksum = "zzz".into()),
+            ),
+            (
+                "policy_rule",
+                Box::new(|r: &mut Art12Record| r.policy_rule = Some("rule".into())),
+            ),
+            (
+                "dlc_admission",
+                Box::new(|r: &mut Art12Record| r.dlc_admission = "admitted".into()),
+            ),
+            (
+                "lockdown",
+                Box::new(|r: &mut Art12Record| r.lockdown_active = true),
+            ),
+            (
+                "decision_seq",
+                Box::new(|r: &mut Art12Record| r.decision_sequence = Some(8)),
+            ),
+            (
+                "prev_hash",
+                Box::new(|r: &mut Art12Record| r.prev_hash = "q".into()),
+            ),
+            (
+                "extensions",
+                Box::new(|r: &mut Art12Record| {
+                    r.extensions.insert("k".into(), "v".into());
+                }),
+            ),
+        ];
+        for (name, f) in mutate {
+            let mut r = rec();
+            f(&mut r);
+            assert_ne!(
+                r.canonical_preimage(),
+                base,
+                "changing `{name}` left the preimage identical — it is not covered by the hash"
+            );
+        }
+    }
+}

--- a/crates/portcullis/src/gate_class.rs
+++ b/crates/portcullis/src/gate_class.rs
@@ -1,0 +1,355 @@
+//! Gate classification — which *kind* of control decided an operation.
+//!
+//! EU AI Act Article 12 asks for a queryable record of AI-driven decisions that
+//! distinguishes governance interventions by kind: a **hard gate** (the system
+//! refused) reads differently to a **soft gate** (the system deferred to a
+//! human), and both read differently to "nothing intervened". [`GateClass`]
+//! makes that distinction a first-class, machine-queryable field rather than
+//! something an auditor infers by string-matching a refusal message.
+//!
+//! # Why this lives here
+//!
+//! It is deliberately in `portcullis`, **not** `portcullis-core` and not
+//! `kernel.rs`:
+//!
+//! - `portcullis-core` and `nucleus-ifc-kernel` are inside the Aeneas/Lean
+//!   verification fence; adding a derived classifier there would drag a
+//!   non-verified convenience type into the extracted core.
+//! - `kernel.rs` is under a line ratchet with single-digit headroom, and this
+//!   needs none of its internals — [`Verdict`], [`DenyReason`] and
+//!   [`ExposureTransition`] are already public.
+//!
+//! Co-locating it in the same crate as `DenyReason` is intentional: the match
+//! below is exhaustive, so adding a refusal reason is a compile error in the
+//! crate the author already has open.
+
+use crate::kernel::{DenyReason, ExposureTransition, Verdict};
+
+/// The kind of control that decided an operation.
+///
+/// Ordering is not meaningful; this is a label, not a lattice.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
+pub enum GateClass {
+    /// Allowed with no governance intervention.
+    None,
+    /// **Soft gate** — deferred to a human because a *static* obligation
+    /// (declared in the policy) requires approval for this operation.
+    StaticObligation,
+    /// **Soft gate** — deferred to a human because *runtime exposure* completed
+    /// a risky combination, independent of what the policy statically declared.
+    /// This is the distinction `ExposureTransition::dynamic_gate_applied`
+    /// carries, and it is the one an auditor most needs: the system escalated
+    /// because of what it had already seen, not because of how it was configured.
+    DynamicExposure,
+    /// **Hard gate** — refused by the capability lattice, path/command
+    /// restrictions, budget, time window, or isolation requirements.
+    Capability,
+    /// **Hard gate** — refused by information-flow control: taint, egress,
+    /// sink scope, declassification, or a flow rule.
+    InformationFlow,
+    /// **Hard gate** — refused by verified admission: no valid issuer-signed
+    /// credential for this operation.
+    Admission,
+    /// **Hard gate** — refused by an external policy engine (Cedar) or an
+    /// enterprise/delegation policy layered above the lattice.
+    Policy,
+    /// **Hard gate** — refused because the action term itself was rejected
+    /// before evaluation (malformed or out-of-scope request).
+    Validation,
+}
+
+impl GateClass {
+    /// Whether this class represents a refusal (as opposed to an allow or a
+    /// deferral to a human).
+    #[must_use]
+    pub fn is_hard_gate(self) -> bool {
+        matches!(
+            self,
+            GateClass::Capability
+                | GateClass::InformationFlow
+                | GateClass::Admission
+                | GateClass::Policy
+                | GateClass::Validation
+        )
+    }
+
+    /// Whether this class represents deferral to a human — the Article 14
+    /// human-oversight evidence.
+    #[must_use]
+    pub fn is_soft_gate(self) -> bool {
+        matches!(
+            self,
+            GateClass::StaticObligation | GateClass::DynamicExposure
+        )
+    }
+
+    /// The stable wire string. Matches the serde rename, and is what an
+    /// evidence record carries.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            GateClass::None => "none",
+            GateClass::StaticObligation => "static_obligation",
+            GateClass::DynamicExposure => "dynamic_exposure",
+            GateClass::Capability => "capability",
+            GateClass::InformationFlow => "information_flow",
+            GateClass::Admission => "admission",
+            GateClass::Policy => "policy",
+            GateClass::Validation => "validation",
+        }
+    }
+}
+
+/// Classify a decision.
+///
+/// `exposure` disambiguates the two soft-gate kinds: an approval requirement
+/// raised by runtime exposure is [`GateClass::DynamicExposure`], one raised by
+/// a static policy obligation is [`GateClass::StaticObligation`]. The kernel
+/// records exactly this in `ExposureTransition::dynamic_gate_applied`.
+///
+/// The `DenyReason` match is **exhaustive by design** — a new refusal reason
+/// must be classified here before it can be recorded, so evidence can never
+/// carry an unclassified refusal.
+#[must_use]
+pub fn classify(verdict: &Verdict, exposure: &ExposureTransition) -> GateClass {
+    match verdict {
+        Verdict::Allow => GateClass::None,
+        Verdict::RequiresApproval => {
+            if exposure.dynamic_gate_applied {
+                GateClass::DynamicExposure
+            } else {
+                GateClass::StaticObligation
+            }
+        }
+        Verdict::Deny(reason) => match reason {
+            DenyReason::InsufficientCapability
+            | DenyReason::BudgetExhausted { .. }
+            | DenyReason::TimeExpired { .. }
+            | DenyReason::PathBlocked { .. }
+            | DenyReason::CommandBlocked { .. }
+            | DenyReason::IsolationInsufficient { .. }
+            | DenyReason::IsolationGated { .. } => GateClass::Capability,
+
+            DenyReason::EgressBlocked { .. }
+            | DenyReason::FlowViolation { .. }
+            | DenyReason::InvalidDeclassification { .. }
+            | DenyReason::SinkScopeDenied { .. }
+            | DenyReason::IfcUnsafe { .. } => GateClass::InformationFlow,
+
+            DenyReason::DlcAdmissionDenied { .. } => GateClass::Admission,
+
+            DenyReason::PolicyDenied { .. }
+            | DenyReason::EnterpriseBlocked { .. }
+            | DenyReason::DelegationDenied { .. }
+            | DenyReason::CedarDenied { .. } => GateClass::Policy,
+
+            DenyReason::ActionTermRejected { .. } => GateClass::Validation,
+        },
+    }
+}
+
+/// The machine-stable code for a refusal — the `DenyReason` serde tag.
+///
+/// **Never `Debug`.** `format!("{reason:?}")` embeds field values and changes
+/// whenever a variant gains a field, so an auditor's query would silently stop
+/// matching. These strings mirror `#[serde(rename_all = "snake_case")]` on
+/// `DenyReason` and are covered by the round-trip test below.
+#[must_use]
+pub fn deny_code(reason: &DenyReason) -> &'static str {
+    match reason {
+        DenyReason::InsufficientCapability => "insufficient_capability",
+        DenyReason::BudgetExhausted { .. } => "budget_exhausted",
+        DenyReason::TimeExpired { .. } => "time_expired",
+        DenyReason::PathBlocked { .. } => "path_blocked",
+        DenyReason::CommandBlocked { .. } => "command_blocked",
+        DenyReason::IsolationInsufficient { .. } => "isolation_insufficient",
+        DenyReason::IsolationGated { .. } => "isolation_gated",
+        DenyReason::EgressBlocked { .. } => "egress_blocked",
+        DenyReason::DlcAdmissionDenied { .. } => "dlc_admission_denied",
+        DenyReason::PolicyDenied { .. } => "policy_denied",
+        DenyReason::EnterpriseBlocked { .. } => "enterprise_blocked",
+        DenyReason::DelegationDenied { .. } => "delegation_denied",
+        DenyReason::FlowViolation { .. } => "flow_violation",
+        DenyReason::InvalidDeclassification { .. } => "invalid_declassification",
+        DenyReason::SinkScopeDenied { .. } => "sink_scope_denied",
+        DenyReason::ActionTermRejected { .. } => "action_term_rejected",
+        DenyReason::IfcUnsafe { .. } => "ifc_unsafe",
+        DenyReason::CedarDenied { .. } => "cedar_denied",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+
+    fn exposure(dynamic: bool) -> ExposureTransition {
+        ExposureTransition {
+            pre_count: 0,
+            post_count: 0,
+            contributed_label: None,
+            state_uninhabitable: false,
+            dynamic_gate_applied: dynamic,
+        }
+    }
+
+    /// Every `DenyReason` variant, constructed. Adding a variant breaks this
+    /// list at compile time — which is the point: an unclassified refusal must
+    /// never reach an evidence record.
+    fn all_deny_reasons() -> Vec<DenyReason> {
+        vec![
+            DenyReason::InsufficientCapability,
+            DenyReason::BudgetExhausted {
+                remaining_usd: "0".to_string(),
+            },
+            DenyReason::TimeExpired {
+                expired_at: Utc::now(),
+            },
+            DenyReason::PathBlocked {
+                path: "/x".to_string(),
+            },
+            DenyReason::CommandBlocked {
+                command: "rm".to_string(),
+            },
+            DenyReason::IsolationInsufficient {
+                required: "vm".to_string(),
+                actual: "none".to_string(),
+            },
+            DenyReason::IsolationGated {
+                dimension: "network".to_string(),
+            },
+            DenyReason::EgressBlocked {
+                host: "h".to_string(),
+                policy_reason: "r".to_string(),
+            },
+            DenyReason::DlcAdmissionDenied {
+                detail: "d".to_string(),
+            },
+            DenyReason::PolicyDenied {
+                rule_name: "r".to_string(),
+                sink_class: "s".to_string(),
+            },
+            DenyReason::EnterpriseBlocked {
+                detail: "d".to_string(),
+            },
+            DenyReason::DelegationDenied {
+                detail: "d".to_string(),
+            },
+            DenyReason::FlowViolation {
+                rule: "r".to_string(),
+                receipt: None,
+            },
+            DenyReason::InvalidDeclassification {
+                detail: "d".to_string(),
+            },
+            DenyReason::SinkScopeDenied {
+                dimension: "d".to_string(),
+                detail: "x".to_string(),
+            },
+            DenyReason::ActionTermRejected {
+                detail: "d".to_string(),
+            },
+            DenyReason::IfcUnsafe {
+                detail: "d".to_string(),
+            },
+            DenyReason::CedarDenied {
+                detail: "d".to_string(),
+            },
+        ]
+    }
+
+    #[test]
+    fn every_deny_reason_classifies_as_a_hard_gate() {
+        for reason in all_deny_reasons() {
+            let class = classify(&Verdict::Deny(reason.clone()), &exposure(false));
+            assert!(
+                class.is_hard_gate(),
+                "{} classified as {:?}, which is not a hard gate",
+                deny_code(&reason),
+                class
+            );
+            assert!(!class.is_soft_gate());
+        }
+    }
+
+    /// ★ The codes must be the SERDE tags, not `Debug`. If `DenyReason`'s serde
+    /// rename ever changes, or a variant gains a field that `Debug` would
+    /// stringify, this catches it — an auditor's saved query keys on these.
+    #[cfg(feature = "serde")]
+    #[test]
+    fn deny_code_matches_the_serde_tag() {
+        for reason in all_deny_reasons() {
+            let json = serde_json::to_value(&reason).expect("DenyReason serializes");
+            let tag = json
+                .get("reason")
+                .and_then(|v| v.as_str())
+                .expect("tagged representation carries `reason`");
+            assert_eq!(
+                deny_code(&reason),
+                tag,
+                "deny_code disagrees with the serde tag"
+            );
+        }
+    }
+
+    #[test]
+    fn allow_is_not_a_gate() {
+        let c = classify(&Verdict::Allow, &exposure(false));
+        assert_eq!(c, GateClass::None);
+        assert!(!c.is_hard_gate() && !c.is_soft_gate());
+    }
+
+    /// The soft-gate split is the Article 14 evidence: escalated because of what
+    /// the session had SEEN, versus because of how it was CONFIGURED.
+    #[test]
+    fn approval_splits_on_dynamic_gate_applied() {
+        assert_eq!(
+            classify(&Verdict::RequiresApproval, &exposure(true)),
+            GateClass::DynamicExposure
+        );
+        assert_eq!(
+            classify(&Verdict::RequiresApproval, &exposure(false)),
+            GateClass::StaticObligation
+        );
+        for c in [GateClass::DynamicExposure, GateClass::StaticObligation] {
+            assert!(c.is_soft_gate() && !c.is_hard_gate());
+        }
+    }
+
+    #[test]
+    fn admission_denial_is_its_own_class() {
+        let c = classify(
+            &Verdict::Deny(DenyReason::DlcAdmissionDenied {
+                detail: "no credential".to_string(),
+            }),
+            &exposure(false),
+        );
+        assert_eq!(c, GateClass::Admission);
+        assert_eq!(c.as_str(), "admission");
+    }
+
+    #[test]
+    fn as_str_is_distinct_per_class() {
+        let all = [
+            GateClass::None,
+            GateClass::StaticObligation,
+            GateClass::DynamicExposure,
+            GateClass::Capability,
+            GateClass::InformationFlow,
+            GateClass::Admission,
+            GateClass::Policy,
+            GateClass::Validation,
+        ];
+        let mut seen = std::collections::BTreeSet::new();
+        for c in all {
+            assert!(
+                seen.insert(c.as_str()),
+                "duplicate wire string {}",
+                c.as_str()
+            );
+        }
+        assert_eq!(seen.len(), all.len());
+    }
+}

--- a/crates/portcullis/src/lib.rs
+++ b/crates/portcullis/src/lib.rs
@@ -108,6 +108,12 @@ pub mod uninhabitable_state;
 /// The EU AI Act Article 12 decision-record type and its canonical preimage —
 /// shared by the tool-proxy that writes records and the audit tool that
 /// verifies them, so there is exactly one definition.
+///
+/// Gated on `serde`: a decision record exists to be serialized into a
+/// tamper-evident log and read back by a third-party verifier, so the type is
+/// meaningless without it. Both consumers (`nucleus-tool-proxy`,
+/// `nucleus-audit`) enable the feature.
+#[cfg(feature = "serde")]
 pub mod art12_record;
 /// Kernel decision engine — complete mediation with monotone session state.
 pub mod delegation;

--- a/crates/portcullis/src/lib.rs
+++ b/crates/portcullis/src/lib.rs
@@ -102,6 +102,13 @@ mod command;
 pub mod constraint;
 pub mod uninhabitable_state;
 
+/// Attenuation tokens — compact delegation credentials for wire transport.
+///
+/// Requires the `serde` feature for serialization.
+/// The EU AI Act Article 12 decision-record type and its canonical preimage —
+/// shared by the tool-proxy that writes records and the audit tool that
+/// verifies them, so there is exactly one definition.
+pub mod art12_record;
 /// Kernel decision engine — complete mediation with monotone session state.
 pub mod delegation;
 pub mod dropout;
@@ -118,9 +125,6 @@ pub mod exposure_core;
 pub mod flow_graph;
 pub mod frame;
 pub mod galois;
-/// Attenuation tokens — compact delegation credentials for wire transport.
-///
-/// Requires the `serde` feature for serialization.
 /// Gate classification — which KIND of control decided an operation
 /// (hard gate / soft gate / none), for EU AI Act Article 12 decision records.
 pub mod gate_class;

--- a/crates/portcullis/src/lib.rs
+++ b/crates/portcullis/src/lib.rs
@@ -118,6 +118,12 @@ pub mod exposure_core;
 pub mod flow_graph;
 pub mod frame;
 pub mod galois;
+/// Attenuation tokens — compact delegation credentials for wire transport.
+///
+/// Requires the `serde` feature for serialization.
+/// Gate classification — which KIND of control decided an operation
+/// (hard gate / soft gate / none), for EU AI Act Article 12 decision records.
+pub mod gate_class;
 pub mod graded;
 pub mod guard;
 pub mod heyting;
@@ -146,9 +152,6 @@ pub mod observe;
 pub mod policy;
 #[cfg(feature = "spec")]
 pub mod profile;
-/// Attenuation tokens — compact delegation credentials for wire transport.
-///
-/// Requires the `serde` feature for serialization.
 /// Append-only receipt chain with hash-chain integrity enforcement.
 pub mod receipt_chain;
 #[cfg(feature = "crypto")]


### PR DESCRIPTION
Types only — nothing on the live path calls either yet, so every anti-vacuity test is green **before** a byte moves in production.

**`portcullis/src/gate_class.rs`** — the hard-gate/soft-gate distinction Article 12 asks for, derived from `(Verdict, ExposureTransition)`. The soft-gate split is the Article 14 evidence: escalated because of what the session had *seen* (`dynamic_exposure`) vs how it was *configured* (`static_obligation`). Deny codes are the **serde tags, never `Debug`** — a `Debug` rendering embeds field values and shifts when a variant gains a field, silently breaking an auditor's saved query; a round-trip test compares every code against actual serialization, and perturbing one REDs naming both sides. Lives in `portcullis` (not `portcullis-core`, not `kernel.rs`) to keep the Aeneas fence and the line ratchet untouched.

**`nucleus-tool-proxy/src/art12.rs`** — `Art12Log`, the sync hash-chained writer. Reusing the existing `AuditLog` was rejected: its `log()` is async (per-entry drand fetch = a network round-trip on the decision path) and its file historically carried unsigned lines. Records get their own file, with the chain's **genesis bound to the existing one** (first `prev_hash` = boot report hash), so there is still one chain to follow. No `fsync`, stated in the module docs with the reason (the failure it guards is bounded *and* detectable as a seq gap + head mismatch). Write failure latches `degraded` and counts `dropped` so a gap is explicit. 8 tests incl. tamper-detection and hash-recomputes-from-the-record-alone.

The line ratchet fixed in inc1 immediately bit this (`mod art12;` put main.rs 1 over). Paid by relocating `sha256_hex` beside the hashing it serves — not by raising the ceiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UA8kchV3eadjGv6BmJXfqm