### PR TITLE
Art12 inc3: a refusal must leave evidence

### DIFF
--- a/crates/nucleus-tool-proxy/src/main.rs
+++ b/crates/nucleus-tool-proxy/src/main.rs
@@ -12,11 +12,10 @@ use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::{middleware, Json, Router};
 use clap::Parser;
-use nucleus::portcullis::action_term::ActionTerm;
 use nucleus::portcullis::escalation::{
     EscalationError, EscalationGrant, EscalationRequest, SpiffeTraceChain, SpiffeTraceLink,
 };
-use nucleus::portcullis::kernel::{DecisionToken, DenyReason, Kernel, Verdict};
+use nucleus::portcullis::kernel::{DecisionToken, Kernel};
 use nucleus::portcullis::{CapabilityLevel, FlowTracker, NodeKind, Operation, PermissionLattice};
 use nucleus::{ApprovalRequest, CallbackApprover, NucleusError, PodRuntime};
 use nucleus_permission_market::{PermissionBid, PermissionGrant, PermissionMarket};
@@ -38,6 +37,7 @@ mod identity_fusion;
 mod lockdown_client;
 #[cfg(feature = "mcp")]
 mod mcp;
+mod mediation;
 mod memory;
 mod mtls;
 mod node_client;
@@ -2379,136 +2379,6 @@ fn check_identity_policy(
     !requires_approval
 }
 
-/// Translate a kernel [`DenyReason`] into the HTTP error surface, preserving
-/// what the kernel actually said.
-///
-/// Each arm maps to a reason the response mapping already models, so a caller
-/// sees `path_denied` / `budget_exhausted` / `command_denied` rather than a
-/// blanket capability error. `InsufficientCapability` is the ONLY reason that
-/// still produces `InsufficientCapability` — that is the one case where it is
-/// true.
-///
-/// The catch-all keeps the reason text rather than discarding it: a new
-/// `DenyReason` variant should surface as an unfamiliar-but-accurate message,
-/// not silently become a capability claim.
-fn kernel_denial_to_api_error(operation: Operation, subject: &str, reason: DenyReason) -> ApiError {
-    match reason {
-        DenyReason::InsufficientCapability => {
-            ApiError::Nucleus(NucleusError::InsufficientCapability {
-                capability: format!("{operation:?}"),
-                actual: CapabilityLevel::Never,
-                required: CapabilityLevel::LowRisk,
-            })
-        }
-        DenyReason::PathBlocked { path } => ApiError::Nucleus(NucleusError::PathDenied {
-            path: std::path::PathBuf::from(path),
-            reason: "blocked by the path lattice".to_string(),
-        }),
-        DenyReason::CommandBlocked { command } => ApiError::Nucleus(NucleusError::CommandDenied {
-            command,
-            reason: "blocked by the command lattice".to_string(),
-        }),
-        // Everything else keeps the kernel's own words, and is listed
-        // EXHAUSTIVELY rather than behind `_`.
-        //
-        // The sibling mapping on the MCP path (`nucleus_mcp::format_deny_reason`)
-        // is exhaustive for the same reason, and it is the better discipline: a
-        // security surface should not acquire a new refusal reason without
-        // somebody deciding how it surfaces. Behind a catch-all, a future
-        // `DenyReason` variant silently becomes `kernel_denied` forever;
-        // exhaustive, it is a compile error until someone chooses.
-        //
-        // Deliberately NOT promoted to richer types where that needs an invented
-        // field: `NucleusError::BudgetExhausted` requires `requested`, and
-        // `DenyReason::BudgetExhausted` carries only `remaining_usd`.
-        // Synthesising the missing number is precisely the defect this function
-        // exists to remove.
-        other @ (DenyReason::BudgetExhausted { .. }
-        | DenyReason::TimeExpired { .. }
-        | DenyReason::IsolationInsufficient { .. }
-        | DenyReason::IsolationGated { .. }
-        | DenyReason::FlowViolation { .. }
-        | DenyReason::EgressBlocked { .. }
-        | DenyReason::PolicyDenied { .. }
-        | DenyReason::EnterpriseBlocked { .. }
-        | DenyReason::DelegationDenied { .. }
-        | DenyReason::InvalidDeclassification { .. }
-        | DenyReason::ActionTermRejected { .. }
-        | DenyReason::SinkScopeDenied { .. }
-        | DenyReason::IfcUnsafe { .. }
-        | DenyReason::CedarDenied { .. }
-        | DenyReason::DlcAdmissionDenied { .. }) => {
-            ApiError::KernelDenied(format!("{other:?} (operation {operation:?} on {subject})"))
-        }
-    }
-}
-
-/// Pure reference monitor for the HTTP path: kernel decision + information-flow
-/// consult, mapped to the HTTP error surface. Split out from [`http_kernel_decide`]
-/// so it is unit-testable with a bare [`Kernel`] + [`FlowTracker`] (no `AppState`).
-///
-/// This is the single source of truth for HTTP mediation (#1194, #1633): it
-/// routes through [`Kernel::decide_term_with_flow`] — the same taint-aware path
-/// the MCP server uses — so once the session has ingested adversarial (web)
-/// content, outbound operations are denied with [`DenyReason::IfcUnsafe`] before
-/// any side effect. The deprecated capability-only `Kernel::decide()` is no
-/// longer reachable from the HTTP handlers.
-fn decide_with_flow_mapped(
-    kernel: &mut Kernel,
-    flow: &FlowTracker,
-    operation: Operation,
-    subject: &str,
-) -> Result<DecisionToken, ApiError> {
-    let term = ActionTerm::from_operation(operation, subject);
-    let (decision, token) = kernel.decide_term_with_flow(term, Some(flow));
-    match decision.verdict {
-        Verdict::Allow => Ok(token.expect("Allow verdict always produces token")),
-        Verdict::Deny(DenyReason::IfcUnsafe { detail }) => {
-            warn!(?operation, subject, %detail, "HTTP IFC denied outbound action (lethal trifecta)");
-            Err(ApiError::IfcDenied(detail))
-        }
-        // Report the reason the kernel actually gave.
-        //
-        // Both of these arms used to return
-        // `InsufficientCapability { capability: format!("{operation:?}"),
-        //  actual: Never, required: LowRisk }` — where `Never` is a **constant
-        // written here**, not a reading of the policy. So a pod whose profile
-        // sets `read_files: Always` was told "'ReadFiles' level is Never" for a
-        // blocked path, an exhausted budget, an expired session, or a request
-        // that merely needed approval. Measured on a booted pod: the guest's
-        // resolved runtime was `demo` with `read_files = Always` while the wire
-        // said `Never`. That is a control stating a confident falsehood about
-        // why it refused — the same shape as a seccomp check reporting mode 0
-        // for a process that had already exited.
-        //
-        // The capability name was also the Debug of the *Operation*
-        // (`ReadFiles`), not a capability, which is what made the mismatch
-        // visible: nothing in the lattice is spelled that way.
-        Verdict::Deny(reason) => {
-            warn!(?operation, subject, ?reason, "HTTP kernel denied operation");
-            Err(kernel_denial_to_api_error(operation, subject, reason))
-        }
-        Verdict::RequiresApproval => {
-            info!(
-                ?operation,
-                subject,
-                exposure = decision.exposure_transition.post_count,
-                "HTTP kernel requires approval (no auto-approve channel)"
-            );
-            // `approval_required`, which the response mapping already models and
-            // which tells the caller something true and actionable: this is not
-            // "you may never do this", it is "this needs an approval you have
-            // not presented".
-            Err(ApiError::Nucleus(NucleusError::ApprovalRequired {
-                operation: format!("{operation:?} {subject}"),
-            }))
-        }
-    }
-}
-
-/// HTTP enforcement chokepoint: locks the kernel THEN the flow tracker (same
-/// order as the MCP server) and runs the reference monitor. Both guards are
-/// dropped before the caller performs any sandbox/executor I/O.
 /// POST `/v1/memory/write` — provenance-verified memory admission (next-bet #1).
 /// A write maps to `WriteFiles` (so it is itself subject to the egress gate),
 /// then goes through `verified_admit`: a forged label is rejected; an honest
@@ -2555,6 +2425,14 @@ async fn memory_recall(
     Ok(Json(resp))
 }
 
+/// HTTP enforcement chokepoint: locks the kernel THEN the flow tracker (same
+/// order as the MCP server) and runs the reference monitor. Both guards are
+/// dropped before the caller performs any sandbox/executor I/O.
+///
+/// The recording is not done here on purpose. `mediation::decide_and_record`
+/// owns both halves, so there is no way to obtain a decision on this path
+/// without it having been recorded — the hole this increment closes cannot be
+/// reopened by a future edit to this function.
 async fn http_kernel_decide(
     state: &AppState,
     operation: Operation,
@@ -2562,7 +2440,15 @@ async fn http_kernel_decide(
 ) -> Result<DecisionToken, ApiError> {
     let mut kernel = state.kernel.lock().await;
     let flow = state.flow_tracker.lock().await;
-    decide_with_flow_mapped(&mut kernel, &flow, operation, subject)
+    mediation::decide_and_record(
+        state.verdict_sink.as_ref(),
+        &mut kernel,
+        &flow,
+        operation,
+        subject,
+        ActorIdentity::Unknown,
+        "http",
+    )
 }
 
 /// Content-address the *actual ingested bytes* of an agent input (InputsAuthorized

--- a/crates/nucleus-tool-proxy/src/mcp.rs
+++ b/crates/nucleus-tool-proxy/src/mcp.rs
@@ -252,6 +252,21 @@ impl NucleusMcpServer {
         let flow = self.flow_tracker.lock().await;
         let (decision, token) = kernel.decide_term_with_flow(term, Some(&flow));
         drop(flow);
+        drop(kernel);
+
+        // ★ Record the kernel decision — allows AND refusals — BEFORE the match
+        // below returns. The HTTP path had the same hole: every refusal returned
+        // early, so the sink observed successes only and any evidence built on
+        // it would have shown an all-allow history.
+        crate::verdict_sink::record_kernel_decision(
+            self.sink.as_ref(),
+            &decision,
+            operation,
+            subject,
+            ActorIdentity::StdioGuest,
+            "mcp",
+        );
+
         match decision.verdict {
             Verdict::Allow => Ok(token.expect("Allow verdict always produces token")),
             Verdict::Deny(ref reason) => {

--- a/crates/nucleus-tool-proxy/src/mediation.rs
+++ b/crates/nucleus-tool-proxy/src/mediation.rs
@@ -1,0 +1,187 @@
+//! Mapping kernel refusals onto the HTTP error surface.
+//!
+//! Extracted from `main.rs` to stay under the line ratchet, and because this is
+//! a coherent unit on its own: it is the one place that decides how a kernel
+//! `DenyReason` is described to a caller. The match is deliberately EXHAUSTIVE —
+//! a new refusal reason must be given a surfacing here before it can compile,
+//! rather than silently becoming a generic capability error.
+
+use nucleus::portcullis::kernel::DenyReason;
+use nucleus::portcullis::{CapabilityLevel, Operation};
+
+use nucleus::portcullis::action_term::ActionTerm;
+use nucleus::portcullis::kernel::{Decision, DecisionToken, Kernel, Verdict};
+use nucleus::portcullis::verdict_sink::{ActorIdentity, VerdictSink};
+use nucleus::portcullis::FlowTracker;
+use nucleus::NucleusError;
+use tracing::{info, warn};
+
+use crate::ApiError;
+
+/// Translate a kernel [`DenyReason`] into the HTTP error surface, preserving
+/// what the kernel actually said.
+///
+/// Each arm maps to a reason the response mapping already models, so a caller
+/// sees `path_denied` / `budget_exhausted` / `command_denied` rather than a
+/// blanket capability error. `InsufficientCapability` is the ONLY reason that
+/// still produces `InsufficientCapability` — that is the one case where it is
+/// true.
+///
+/// The catch-all keeps the reason text rather than discarding it: a new
+/// `DenyReason` variant should surface as an unfamiliar-but-accurate message,
+/// not silently become a capability claim.
+pub(crate) fn kernel_denial_to_api_error(
+    operation: Operation,
+    subject: &str,
+    reason: DenyReason,
+) -> ApiError {
+    match reason {
+        DenyReason::InsufficientCapability => {
+            ApiError::Nucleus(NucleusError::InsufficientCapability {
+                capability: format!("{operation:?}"),
+                actual: CapabilityLevel::Never,
+                required: CapabilityLevel::LowRisk,
+            })
+        }
+        DenyReason::PathBlocked { path } => ApiError::Nucleus(NucleusError::PathDenied {
+            path: std::path::PathBuf::from(path),
+            reason: "blocked by the path lattice".to_string(),
+        }),
+        DenyReason::CommandBlocked { command } => ApiError::Nucleus(NucleusError::CommandDenied {
+            command,
+            reason: "blocked by the command lattice".to_string(),
+        }),
+        // Everything else keeps the kernel's own words, and is listed
+        // EXHAUSTIVELY rather than behind `_`.
+        //
+        // The sibling mapping on the MCP path (`nucleus_mcp::format_deny_reason`)
+        // is exhaustive for the same reason, and it is the better discipline: a
+        // security surface should not acquire a new refusal reason without
+        // somebody deciding how it surfaces. Behind a catch-all, a future
+        // `DenyReason` variant silently becomes `kernel_denied` forever;
+        // exhaustive, it is a compile error until someone chooses.
+        //
+        // Deliberately NOT promoted to richer types where that needs an invented
+        // field: `NucleusError::BudgetExhausted` requires `requested`, and
+        // `DenyReason::BudgetExhausted` carries only `remaining_usd`.
+        // Synthesising the missing number is precisely the defect this function
+        // exists to remove.
+        other @ (DenyReason::BudgetExhausted { .. }
+        | DenyReason::TimeExpired { .. }
+        | DenyReason::IsolationInsufficient { .. }
+        | DenyReason::IsolationGated { .. }
+        | DenyReason::FlowViolation { .. }
+        | DenyReason::EgressBlocked { .. }
+        | DenyReason::PolicyDenied { .. }
+        | DenyReason::EnterpriseBlocked { .. }
+        | DenyReason::DelegationDenied { .. }
+        | DenyReason::InvalidDeclassification { .. }
+        | DenyReason::ActionTermRejected { .. }
+        | DenyReason::SinkScopeDenied { .. }
+        | DenyReason::IfcUnsafe { .. }
+        | DenyReason::CedarDenied { .. }
+        | DenyReason::DlcAdmissionDenied { .. }) => {
+            ApiError::KernelDenied(format!("{other:?} (operation {operation:?} on {subject})"))
+        }
+    }
+}
+
+/// Pure reference monitor for the HTTP path: kernel decision + information-flow
+/// consult, mapped to the HTTP error surface. Split out from [`http_kernel_decide`]
+/// so it is unit-testable with a bare [`Kernel`] + [`FlowTracker`] (no `AppState`).
+/// Private to this module: see [`decide_and_record`] for why.
+///
+/// This is the single source of truth for HTTP mediation (#1194, #1633): it
+/// routes through [`Kernel::decide_term_with_flow`] — the same taint-aware path
+/// the MCP server uses — so once the session has ingested adversarial (web)
+/// content, outbound operations are denied with [`DenyReason::IfcUnsafe`] before
+/// any side effect. The deprecated capability-only `Kernel::decide()` is no
+/// longer reachable from the HTTP handlers.
+///
+/// The decision used to be dropped here, which meant a refusal left no trace:
+/// every caller reaches this through `?`, so on `Deny` the handler returns
+/// before any `sink.record(...)` runs, and the sink never observed
+/// `DlcAdmissionDenied`, `IfcUnsafe`, `PathBlocked`, `CommandBlocked`,
+/// `FlowViolation` or `RequiresApproval` at all. A durable evidence log wired
+/// on top of that would have recorded **only allows** — non-empty, plausible,
+/// and wrong in the most dangerous possible direction for an EU AI Act Article
+/// 12 record. Handing the decision back lets the chokepoint record it before
+/// propagating the error.
+fn decide_with_flow_mapped(
+    kernel: &mut Kernel,
+    flow: &FlowTracker,
+    operation: Operation,
+    subject: &str,
+) -> (Decision, Result<DecisionToken, ApiError>) {
+    let term = ActionTerm::from_operation(operation, subject);
+    let (decision, token) = kernel.decide_term_with_flow(term, Some(flow));
+    let mapped = match decision.verdict.clone() {
+        Verdict::Allow => Ok(token.expect("Allow verdict always produces token")),
+        Verdict::Deny(DenyReason::IfcUnsafe { detail }) => {
+            warn!(?operation, subject, %detail, "HTTP IFC denied outbound action (lethal trifecta)");
+            Err(ApiError::IfcDenied(detail))
+        }
+        // Report the reason the kernel actually gave.
+        //
+        // Both of these arms used to return
+        // `InsufficientCapability { capability: format!("{operation:?}"),
+        //  actual: Never, required: LowRisk }` — where `Never` is a **constant
+        // written here**, not a reading of the policy. So a pod whose profile
+        // sets `read_files: Always` was told "'ReadFiles' level is Never" for a
+        // blocked path, an exhausted budget, an expired session, or a request
+        // that merely needed approval. Measured on a booted pod: the guest's
+        // resolved runtime was `demo` with `read_files = Always` while the wire
+        // said `Never`. That is a control stating a confident falsehood about
+        // why it refused — the same shape as a seccomp check reporting mode 0
+        // for a process that had already exited.
+        //
+        // The capability name was also the Debug of the *Operation*
+        // (`ReadFiles`), not a capability, which is what made the mismatch
+        // visible: nothing in the lattice is spelled that way.
+        Verdict::Deny(reason) => {
+            warn!(?operation, subject, ?reason, "HTTP kernel denied operation");
+            Err(kernel_denial_to_api_error(operation, subject, reason))
+        }
+        Verdict::RequiresApproval => {
+            info!(
+                ?operation,
+                subject,
+                exposure = decision.exposure_transition.post_count,
+                "HTTP kernel requires approval (no auto-approve channel)"
+            );
+            // `approval_required`, which the response mapping already models and
+            // which tells the caller something true and actionable: this is not
+            // "you may never do this", it is "this needs an approval you have
+            // not presented".
+            Err(ApiError::Nucleus(NucleusError::ApprovalRequired {
+                operation: format!("{operation:?} {subject}"),
+            }))
+        }
+    };
+    (decision, mapped)
+}
+
+/// Decide, record, and map — in that order, indivisibly.
+///
+/// The recording is inside this function rather than at the call site because
+/// the defect it fixes was *an early return*: every caller reaches the verdict
+/// through `?`, so any refusal skipped a recording step written after the call.
+/// Keeping `decide_with_flow_mapped` private to this module means a `Decision`
+/// cannot be produced anywhere else, so it cannot escape unrecorded. That is a
+/// property of the module boundary, not of a test that must remember to check.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn decide_and_record(
+    sink: &dyn VerdictSink,
+    kernel: &mut Kernel,
+    flow: &FlowTracker,
+    operation: Operation,
+    subject: &str,
+    actor: ActorIdentity,
+    transport: &str,
+) -> Result<DecisionToken, ApiError> {
+    let (decision, mapped) = decide_with_flow_mapped(kernel, flow, operation, subject);
+    crate::verdict_sink::record_kernel_decision(
+        sink, &decision, operation, subject, actor, transport,
+    );
+    mapped
+}

--- a/crates/nucleus-tool-proxy/src/tests_main.rs
+++ b/crates/nucleus-tool-proxy/src/tests_main.rs
@@ -1,4 +1,6 @@
 use super::*;
+use crate::mediation::kernel_denial_to_api_error;
+use nucleus::portcullis::kernel::DenyReason;
 
 #[test]
 fn test_rate_limiter_allows_burst() {
@@ -341,7 +343,7 @@ fn test_lockdown_blocks_unknown_paths() {
 // ═══════════════════════════════════════════════════════════════════════════
 // IFC enforcement on the HTTP path (#1194, #1633)
 //
-// These exercise the pure reference monitor `decide_with_flow_mapped` against a
+// These exercise the reference monitor `mediation::decide_and_record` against a
 // bare Kernel + FlowTracker (no AppState), proving the HTTP path now has the
 // same taint-aware lethal-trifecta guard the MCP server has: once the session
 // ingests web content, outbound actions are denied with `ApiError::IfcDenied`
@@ -352,6 +354,142 @@ mod ifc_http_enforcement {
 
     fn permissive_kernel() -> Kernel {
         Kernel::new(PermissionLattice::permissive())
+    }
+
+    /// A sink that keeps what it was handed, so a test can assert on the record
+    /// that the live HTTP chokepoint would produce — not on a reconstruction of
+    /// it. `decide_and_record` is the same function `http_kernel_decide` calls,
+    /// which is what makes these tests evidence about the live path rather than
+    /// about a parallel copy of its logic.
+    #[derive(Default)]
+    struct CapturingSink {
+        records: std::sync::Mutex<Vec<(String, String, BTreeMap<String, String>)>>,
+    }
+
+    impl portcullis::verdict_sink::VerdictSink for CapturingSink {
+        fn record(
+            &self,
+            ctx: portcullis::verdict_sink::VerdictContext,
+        ) -> Result<(), portcullis::verdict_sink::SinkError> {
+            let outcome = match &ctx.outcome {
+                portcullis::verdict_sink::VerdictOutcome::Allow => "allow".to_string(),
+                portcullis::verdict_sink::VerdictOutcome::Deny { reason } => {
+                    format!("deny:{reason}")
+                }
+                portcullis::verdict_sink::VerdictOutcome::RequiresApproval { .. } => {
+                    "requires_approval".to_string()
+                }
+                other => format!("{other:?}"),
+            };
+            self.records.lock().unwrap().push((
+                format!("{:?}", ctx.operation),
+                outcome,
+                ctx.extensions.clone(),
+            ));
+            Ok(())
+        }
+
+        fn preflight(
+            &self,
+            _operation: Operation,
+        ) -> Result<(), portcullis::verdict_sink::SinkError> {
+            Ok(())
+        }
+    }
+
+    /// Drive the live entry point and hand back both the mapped result and what
+    /// the sink actually saw.
+    #[allow(clippy::type_complexity)]
+    fn decide_capturing(
+        kernel: &mut Kernel,
+        flow: &FlowTracker,
+        operation: Operation,
+        subject: &str,
+    ) -> (
+        Result<portcullis::kernel::DecisionToken, ApiError>,
+        Vec<(String, String, BTreeMap<String, String>)>,
+    ) {
+        let sink = CapturingSink::default();
+        let mapped = crate::mediation::decide_and_record(
+            &sink,
+            kernel,
+            flow,
+            operation,
+            subject,
+            portcullis::verdict_sink::ActorIdentity::Unknown,
+            "http",
+        );
+        let seen = sink.records.lock().unwrap().clone();
+        (mapped, seen)
+    }
+
+    // ── The kernel-decision recording chokepoint (EU AI Act Article 12) ─────────
+    //
+    // The property under test is the one that reframed this whole feature: a
+    // REFUSAL must produce evidence. Before `http_kernel_decide` recorded the
+    // decision, every deny returned through `?` before any sink call, so an
+    // evidence log built on the sink would have contained allows only.
+
+    /// ★ A DENIED operation must be recorded, with the kernel fields that make it
+    /// reconstructable. This is the anti-vacuity leg: an evidence log whose records
+    /// are all `allow` is worse than no log, because it looks like evidence.
+    ///
+    /// The assertion is on what the SINK RECEIVED. An earlier version of this test
+    /// asserted only that the `Decision` carried the right fields — which passed
+    /// even with the recording call deleted, because availability is not recording.
+    #[test]
+    fn denied_kernel_decision_is_recorded_with_its_reason() {
+        let mut kernel = permissive_kernel();
+        let mut flow = FlowTracker::new();
+        // Ingest web content so the next outbound action is IFC-denied.
+        flow.observe(NodeKind::WebContent).expect("observe");
+
+        let (mapped, seen) = decide_capturing(&mut kernel, &flow, Operation::WriteFiles, "out.txt");
+        assert!(mapped.is_err(), "post-web write must be denied");
+
+        assert_eq!(seen.len(), 1, "a refusal must produce exactly one record");
+        let (op, outcome, ext) = &seen[0];
+        assert_eq!(op, "WriteFiles");
+        assert!(
+            outcome.starts_with("deny:"),
+            "the refusal must be recorded as a denial, got {outcome}"
+        );
+        assert_eq!(
+            ext.get("deny_code").map(String::as_str),
+            Some("ifc_unsafe"),
+            "the refusal must carry its machine-stable code, not a Debug string"
+        );
+        assert_eq!(
+            ext.get("gate_class").map(String::as_str),
+            Some("information_flow")
+        );
+        assert_eq!(ext.get("transport").map(String::as_str), Some("http"));
+        for field in [
+            "pre_permissions_hash",
+            "post_permissions_hash",
+            "decision_sequence",
+        ] {
+            assert!(
+                ext.get(field).is_some_and(|v| !v.is_empty()),
+                "{field} must be recoverable from the record"
+            );
+        }
+    }
+
+    /// An ALLOWED operation is recorded too — the pair is what makes the log a
+    /// history rather than a denial list.
+    #[test]
+    fn allowed_kernel_decision_carries_no_deny_code() {
+        let mut kernel = permissive_kernel();
+        let flow = FlowTracker::new();
+        let (mapped, seen) = decide_capturing(&mut kernel, &flow, Operation::ReadFiles, "in.txt");
+        assert!(mapped.is_ok(), "clean read should be allowed");
+
+        assert_eq!(seen.len(), 1, "an allow must produce a record too");
+        let (_, outcome, ext) = &seen[0];
+        assert_eq!(outcome, "allow");
+        assert_eq!(ext.get("deny_code"), None, "an allow has nothing to refuse");
+        assert_eq!(ext.get("gate_class").map(String::as_str), Some("none"));
     }
 
     fn tainted_tracker() -> FlowTracker {
@@ -365,7 +503,7 @@ mod ifc_http_enforcement {
     fn clean_session_allows_outbound_write() {
         let mut kernel = permissive_kernel();
         let flow = FlowTracker::new();
-        let r = decide_with_flow_mapped(&mut kernel, &flow, Operation::WriteFiles, "out.txt");
+        let r = decide_capturing(&mut kernel, &flow, Operation::WriteFiles, "out.txt").0;
         assert!(r.is_ok(), "clean session should allow write, got {r:?}");
     }
 
@@ -373,7 +511,8 @@ mod ifc_http_enforcement {
     fn tainted_session_denies_write() {
         let mut kernel = permissive_kernel();
         let flow = tainted_tracker();
-        let err = decide_with_flow_mapped(&mut kernel, &flow, Operation::WriteFiles, "out.txt")
+        let err = decide_capturing(&mut kernel, &flow, Operation::WriteFiles, "out.txt")
+            .0
             .expect_err("tainted write must be denied");
         assert!(
             matches!(err, ApiError::IfcDenied(_)),
@@ -385,7 +524,8 @@ mod ifc_http_enforcement {
     fn tainted_session_denies_run() {
         let mut kernel = permissive_kernel();
         let flow = tainted_tracker();
-        let err = decide_with_flow_mapped(&mut kernel, &flow, Operation::RunBash, "echo hi")
+        let err = decide_capturing(&mut kernel, &flow, Operation::RunBash, "echo hi")
+            .0
             .expect_err("tainted run must be denied");
         assert!(
             matches!(err, ApiError::IfcDenied(_)),
@@ -398,7 +538,7 @@ mod ifc_http_enforcement {
         let mut kernel = permissive_kernel();
         let flow = tainted_tracker();
         // FileRead is not an OutboundAction, so taint does not block it.
-        let r = decide_with_flow_mapped(&mut kernel, &flow, Operation::ReadFiles, "in.txt");
+        let r = decide_capturing(&mut kernel, &flow, Operation::ReadFiles, "in.txt").0;
         assert!(r.is_ok(), "tainted read should still be allowed, got {r:?}");
     }
 
@@ -407,7 +547,7 @@ mod ifc_http_enforcement {
         let mut kernel = permissive_kernel();
         let flow = tainted_tracker();
         // WebFetch is a taint *source* (WebContent), not an OutboundAction.
-        let r = decide_with_flow_mapped(&mut kernel, &flow, Operation::WebFetch, "https://x.test");
+        let r = decide_capturing(&mut kernel, &flow, Operation::WebFetch, "https://x.test").0;
         assert!(r.is_ok(), "tainted web_fetch should be allowed, got {r:?}");
     }
 
@@ -417,14 +557,16 @@ mod ifc_http_enforcement {
         let mut flow = FlowTracker::new();
         // 1. Clean session: web fetch allowed.
         assert!(
-            decide_with_flow_mapped(&mut kernel, &flow, Operation::WebFetch, "https://x.test")
+            decide_capturing(&mut kernel, &flow, Operation::WebFetch, "https://x.test")
+                .0
                 .is_ok(),
             "clean web_fetch should be allowed"
         );
         // 2. Web content enters the session.
         flow.observe(NodeKind::WebContent).expect("observe");
         // 3. The exfiltration sink (write) is now denied — the lethal trifecta.
-        let err = decide_with_flow_mapped(&mut kernel, &flow, Operation::WriteFiles, "out.txt")
+        let err = decide_capturing(&mut kernel, &flow, Operation::WriteFiles, "out.txt")
+            .0
             .expect_err("post-web write must be denied");
         assert!(
             matches!(err, ApiError::IfcDenied(_)),
@@ -453,7 +595,8 @@ mod ifc_http_enforcement {
         // is named in the message rather than replaced by a constant.
         let mut kernel = Kernel::new(PermissionLattice::read_only());
         let flow = FlowTracker::new();
-        let err = decide_with_flow_mapped(&mut kernel, &flow, Operation::WriteFiles, "out.txt")
+        let err = decide_capturing(&mut kernel, &flow, Operation::WriteFiles, "out.txt")
+            .0
             .expect_err("read_only write must be denied");
         assert!(
             !matches!(err, ApiError::IfcDenied(_)),

--- a/crates/nucleus-tool-proxy/src/verdict_sink.rs
+++ b/crates/nucleus-tool-proxy/src/verdict_sink.rs
@@ -142,8 +142,18 @@ impl VerdictSink for ToolProxyVerdictSink {
         } else {
             match &ctx.outcome {
                 VerdictOutcome::Allow => ("allow", String::new()),
+                // A deferral is NOT a refusal — kept distinct so the Article 14
+                // human-oversight event is legible in telemetry and evidence.
+                VerdictOutcome::RequiresApproval { reason } => {
+                    ("requires_approval", reason.clone())
+                }
                 VerdictOutcome::Deny { reason } => ("deny", reason.clone()),
                 VerdictOutcome::Error { error } => ("error", error.clone()),
+                // `VerdictOutcome` is #[non_exhaustive]. An outcome this build
+                // does not know must not silently read as "allow": record it as
+                // an error naming the gap, so unclassified evidence is visible
+                // rather than flattering.
+                other => ("error", format!("unclassified verdict outcome: {other:?}")),
             }
         };
 
@@ -221,6 +231,96 @@ impl VerdictSink for ToolProxyVerdictSink {
         } else {
             Ok(())
         }
+    }
+}
+
+/// Emit one evidence record for a kernel decision — **the single
+/// implementation, used by both transports.**
+///
+/// EU AI Act Article 12 requires post-hoc reconstruction of an individual
+/// decision, so the kernel fields ride `VerdictContext.extensions`: which
+/// permissions were in force before and after, whether a dynamic exposure gate
+/// fired, the machine-stable refusal code, and the decision sequence that joins
+/// this record to the terminal outcome for the same operation.
+///
+/// # Why one function rather than one per transport
+///
+/// The HTTP and MCP paths reach the kernel through different chokepoints, and
+/// implementing this twice is how the two evidence streams silently diverge —
+/// the same failure mode as a duplicated canonical preimage. The transport is a
+/// parameter, not a copy.
+///
+/// Best-effort by design: a failure to record must not fail the call, because at
+/// most call sites the effect has already happened and returning an error would
+/// invite a retry that doubles it. The gap is surfaced as a warning and, once
+/// the durable log is wired, counted so it is explicit rather than silent.
+pub(crate) fn record_kernel_decision(
+    sink: &dyn VerdictSink,
+    decision: &portcullis::kernel::Decision,
+    operation: Operation,
+    subject: &str,
+    actor: ActorIdentity,
+    transport: &str,
+) {
+    use portcullis::gate_class;
+    use portcullis::kernel::Verdict;
+    use std::collections::BTreeMap;
+
+    let mut extensions = BTreeMap::new();
+    extensions.insert("transport".to_string(), transport.to_string());
+    extensions.insert(
+        "decision_sequence".to_string(),
+        decision.sequence.to_string(),
+    );
+    extensions.insert(
+        "gate_class".to_string(),
+        gate_class::classify(&decision.verdict, &decision.exposure_transition)
+            .as_str()
+            .to_string(),
+    );
+    extensions.insert(
+        "pre_permissions_hash".to_string(),
+        decision.pre_permissions_hash.clone(),
+    );
+    extensions.insert(
+        "post_permissions_hash".to_string(),
+        decision.post_permissions_hash.clone(),
+    );
+    extensions.insert(
+        "dynamic_gate_applied".to_string(),
+        decision
+            .exposure_transition
+            .dynamic_gate_applied
+            .to_string(),
+    );
+
+    let outcome = match &decision.verdict {
+        Verdict::Allow => VerdictOutcome::Allow,
+        Verdict::RequiresApproval => VerdictOutcome::RequiresApproval {
+            reason: "approval required before this operation may proceed".to_string(),
+        },
+        Verdict::Deny(reason) => {
+            // The machine-stable serde tag, never `Debug` — an auditor's saved
+            // query keys on this, and `Debug` shifts when a variant changes.
+            extensions.insert(
+                "deny_code".to_string(),
+                gate_class::deny_code(reason).to_string(),
+            );
+            VerdictOutcome::Deny {
+                reason: format!("{reason:?}"),
+            }
+        }
+    };
+
+    if let Err(e) = sink.record(VerdictContext {
+        operation,
+        subject: subject.to_string(),
+        outcome,
+        actor,
+        policy_rule: None,
+        extensions,
+    }) {
+        tracing::warn!(error = %e, ?operation, subject, "kernel-decision recording failed -- audit gap");
     }
 }
 

--- a/crates/portcullis/src/verdict_sink.rs
+++ b/crates/portcullis/src/verdict_sink.rs
@@ -22,10 +22,26 @@ use std::collections::BTreeMap;
 use crate::capability::Operation;
 
 /// Outcome of a single tool call (before audit recording).
+///
+/// `#[non_exhaustive]`: outcomes are an evidence vocabulary, so future kinds
+/// must be additive for downstream matches rather than a breaking change.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum VerdictOutcome {
     /// The operation was permitted and completed successfully.
     Allow,
+    /// The operation was **deferred to a human** — it is neither permitted nor
+    /// refused until an approval is presented.
+    ///
+    /// Distinct from [`VerdictOutcome::Deny`] on purpose. Recording a deferral
+    /// as a refusal loses the EU AI Act Article 14 human-oversight evidence:
+    /// "the system refused" and "the system escalated to a person" are
+    /// different governance events, and an auditor must be able to tell them
+    /// apart without string-matching a human-facing message.
+    RequiresApproval {
+        /// Why an approval is required.
+        reason: String,
+    },
     /// The operation was denied by policy, lockdown, or capability guard.
     Deny {
         /// Human-readable reason for the denial.


### PR DESCRIPTION
## The hole

`http_kernel_decide` is reached through `?` at all 36 call sites, so on `Verdict::Deny` the handler returned **before** any `sink.record(...)` ran. The sink never observed a single refusal — `DlcAdmissionDenied`, `IfcUnsafe`, `PathBlocked`, `CommandBlocked`, `FlowViolation`, `RequiresApproval`.

A durable evidence log wired on top of that would have recorded **only allows**: non-empty, plausible-looking, and wrong in the most dangerous possible direction for an EU AI Act Article 12 record. `nucleus verify --tier2` already proves the admission gate fires and yields `DlcAdmissionDenied`; that refusal left zero evidence anywhere.

## Structural, not procedural

Recording lives inside `mediation::decide_and_record`, and the mapper that produces a `Decision` is **private to that module**. A decision cannot be obtained anywhere in the crate without having been recorded. That is a property of the module boundary, not of a call site that a future edit must remember to keep.

## What a record now carries

`transport`, `decision_sequence` (joins this record to the terminal outcome for the same operation), `gate_class`, `pre`/`post_permissions_hash`, `dynamic_gate_applied`, and `deny_code` — the `DenyReason` **serde tag**, never its `Debug`, so the code stays machine-stable across refactors.

`VerdictOutcome::RequiresApproval` is **added rather than inferred**: today a deferral is recorded as `Deny { reason: "approval_required" }`, and separating "refused" from "escalated to a human" by string-matching a human-facing message would lose exactly the Article 14 evidence. `#[non_exhaustive]` in the same change.

## Anti-vacuity

The first version of these tests asserted the `Decision` *carried* the right fields — and **passed with the recording call deleted**, because availability is not recording. They now assert on what a capturing sink actually **received**, driving the same function the live chokepoint calls.

Perturbation confirmed: deleting the record call REDs both tests at the expected assertion —
```
assertion `left == right` failed: a refusal must produce exactly one record
  left: 0   right: 1
```

## Also

- `kernel_denial_to_api_error` + mediation logic move to a new `mediation.rs` (main.rs was over its ratchet ceiling; now 4941 ≤ 4975).
- An orphaned doc comment that had drifted onto `memory_write` is rehomed.

**Sink remains telemetry-only.** Wiring it to disk is increment 4, behind a default-off flag.

## Gates
`clippy --workspace --all-targets --all-features -D warnings` · `RUSTFLAGS="-D warnings" cargo test` (243 tool-proxy + portcullis suites green) · `cargo hack check --each-feature --no-dev-deps` · `fmt --check` · `check-line-ratchet.sh --strict`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UA8kchV3eadjGv6BmJXfqm