### PR TITLE
Stop fabricating W3C PROV derivation relations

### DIFF
--- a/crates/portcullis-core/src/prov_export.rs
+++ b/crates/portcullis-core/src/prov_export.rs
@@ -7,8 +7,11 @@
 //! - `NodeKind` source observations → PROV `Entity`
 //! - `NodeKind` action/model nodes → PROV `Activity`
 //! - User/agent nodes → PROV `Agent`
-//! - Parent edges → `wasDerivedFrom` / `used` relations
 //! - IFC labels → PROV attributes (derivation, authority, integrity)
+//!
+//! **Relations (`wasDerivedFrom`, `used`) are NOT emitted.** They would assert
+//! that data actually flowed between two nodes, and nothing in the session
+//! state this function receives records that. See `export_prov_json`.
 
 use crate::flow::NodeKind;
 use crate::{AuthorityLevel, DerivationClass, IntegLevel};
@@ -223,12 +226,33 @@ fn node_kind_str(kind: NodeKind) -> &'static str {
 /// Export flow observations as a W3C PROV-JSON document.
 ///
 /// Takes the raw flow observations `(node_kind_u8, label_str, subject)` from
-/// session state and produces a standards-compliant PROV-JSON document.
+/// session state and produces a standards-compliant PROV-JSON document of
+/// **nodes only** — `entity`, `activity`, `agent`, each a direct rendering of
+/// something actually observed, carrying its IFC label as attributes.
 ///
-/// Each observation becomes a PROV Entity, Activity, or Agent depending on
-/// its NodeKind. Parent relationships are inferred from sequential ordering
-/// (the full causal DAG requires the kernel's flow graph, which isn't
-/// available in session state — this produces a linear approximation).
+/// # No derivation relations are emitted, deliberately
+///
+/// This function used to emit `wasDerivedFrom` by linking each entity to the
+/// *previous* one, and `used` by pointing each activity at the *preceding*
+/// entity — both inferred from observation ORDER, commented as a "linear
+/// approximation". They are removed.
+///
+/// PROV's `wasDerivedFrom` and `used` are assertions that data actually flowed.
+/// Deriving them from sequence adjacency asserts flows that were never
+/// computed: two unrelated reads become a derivation chain purely because one
+/// happened after the other. In a document whose stated purpose is regulatory
+/// evidence, a fabricated relation is worse than a missing one — a missing
+/// relation is visibly absent, a fabricated one is indistinguishable from a
+/// real finding.
+///
+/// The relation types are retained because the schema is right; only the data
+/// is unavailable. Populating them needs genuine parent edges in the flow
+/// graph. Note this signature cannot carry them: `(u8, String, String)` has no
+/// field for a parent set, so restoring real relations is an input-type change
+/// here, not a change to the body.
+///
+/// Until then, a consumer sees the nodes and their labels, and sees plainly
+/// that no derivation was asserted.
 pub fn export_prov_json(observations: &[(u8, String, String)], session_id: &str) -> ProvDocument {
     let mut doc = ProvDocument {
         entity: BTreeMap::new(),
@@ -245,8 +269,6 @@ pub fn export_prov_json(observations: &[(u8, String, String)], session_id: &str)
         .insert("prov".into(), "http://www.w3.org/ns/prov#".into());
     doc.prefix
         .insert("nucleus".into(), "https://nucleus.dev/ns/prov#".into());
-
-    let mut prev_entity_id: Option<String> = None;
 
     for (i, (kind_u8, label, _subject)) in observations.iter().enumerate() {
         let kind = u8_to_node_kind(*kind_u8);
@@ -267,18 +289,6 @@ pub fn export_prov_json(observations: &[(u8, String, String)], session_id: &str)
                         node_kind: node_kind_str(kind).into(),
                     },
                 );
-
-                // wasDerivedFrom: link to previous entity (linear approx).
-                if let Some(ref prev) = prev_entity_id {
-                    doc.was_derived_from.insert(
-                        format!("nucleus:{session_id}/deriv/{i}"),
-                        ProvDerivation {
-                            generated_entity: node_id.clone(),
-                            used_entity: prev.clone(),
-                        },
-                    );
-                }
-                prev_entity_id = Some(node_id);
             }
             ProvCategory::Activity => {
                 doc.activity.insert(
@@ -288,17 +298,6 @@ pub fn export_prov_json(observations: &[(u8, String, String)], session_id: &str)
                         node_kind: node_kind_str(kind).into(),
                     },
                 );
-
-                // used: activity used the previous entity.
-                if let Some(ref prev) = prev_entity_id {
-                    doc.used.insert(
-                        format!("nucleus:{session_id}/used/{i}"),
-                        ProvUsage {
-                            activity: node_id,
-                            entity: prev.clone(),
-                        },
-                    );
-                }
             }
             ProvCategory::Agent => {
                 doc.agent.insert(
@@ -355,18 +354,28 @@ mod tests {
     }
 
     #[test]
-    fn sequential_entities_linked_by_derivation() {
+    fn adjacent_entities_are_not_asserted_to_derive_from_each_other() {
+        // A local file read followed by an unrelated web fetch. Nothing flowed
+        // between them; they are merely adjacent in time. The exporter used to
+        // emit a `wasDerivedFrom` here, which claims the web content was
+        // derived from the file.
         let obs = vec![
             (5u8, "Read".into(), "a.rs".into()),
             (2u8, "WebFetch".into(), "url".into()),
         ];
         let doc = export_prov_json(&obs, "s1");
-        assert_eq!(doc.entity.len(), 2);
-        assert_eq!(doc.was_derived_from.len(), 1);
+        assert_eq!(doc.entity.len(), 2, "both observations are still exported");
+        assert!(
+            doc.was_derived_from.is_empty(),
+            "sequence adjacency is not derivation: {:?}",
+            doc.was_derived_from
+        );
     }
 
     #[test]
-    fn activity_uses_preceding_entity() {
+    fn an_activity_is_not_asserted_to_have_used_the_preceding_entity() {
+        // Reading `a.rs` then writing `b.rs` does not mean the write consumed
+        // the read. PROV `used` is a claim about data flow, not about order.
         let obs = vec![
             (5u8, "Read".into(), "a.rs".into()),
             (9u8, "Write".into(), "b.rs".into()),
@@ -374,7 +383,24 @@ mod tests {
         let doc = export_prov_json(&obs, "s1");
         assert_eq!(doc.entity.len(), 1);
         assert_eq!(doc.activity.len(), 1);
-        assert_eq!(doc.used.len(), 1);
+        assert!(doc.used.is_empty(), "ordering is not usage: {:?}", doc.used);
+    }
+
+    /// The serialized document must not carry relation keys at all — a consumer
+    /// reading the JSON should see plainly that no derivation was asserted,
+    /// rather than an empty object that looks like a graph with no findings.
+    #[test]
+    fn serialized_document_omits_relation_keys_entirely() {
+        let obs = vec![
+            (5u8, "Read".into(), "a.rs".into()),
+            (2u8, "WebFetch".into(), "url".into()),
+            (9u8, "Write".into(), "b.rs".into()),
+        ];
+        let json = serde_json::to_string(&export_prov_json(&obs, "s1")).unwrap();
+        assert!(json.contains("entity"), "nodes are still exported: {json}");
+        for key in ["wasDerivedFrom", "used", "wasGeneratedBy"] {
+            assert!(!json.contains(key), "{key} must be absent, got: {json}");
+        }
     }
 
     #[test]

--- a/docs/quickstart-provenance.md
+++ b/docs/quickstart-provenance.md
@@ -96,7 +96,9 @@ The `price` and `volume` values have a **cryptographic proof chain**:
 Source URL → SHA-256 content hash → WASM parser (content-addressed) → output hash
 ```
 
-The flow graph proves there is **no model node** in the causal ancestry of these values. The model orchestrated the fetch and parser, but never touched the data. An auditor can independently re-execute the parser on the raw content and verify the output hash matches.
+The model orchestrated the fetch and parser, but never touched the data — and the evidence for that is **re-execution, not graph traversal**. Every step is content-addressed: the fetched bytes, the parser module, and the output. An auditor re-runs the parser on the raw content and checks that the output hash matches. If a model had altered the value, the hash would not reproduce.
+
+> **What this does not claim.** Nucleus's flow graph does not currently carry derivation edges — nodes are recorded without parents — so nothing here is established by walking a causal ancestry. Phrasing it that way would be worse than useless: with no edges, "no model node in the ancestry" is trivially true of *every* value, including ones a model did produce. The guarantee above rests on content-addressed re-execution, which is independently checkable by someone who does not trust us.
 
 The `analysis` field is honestly labeled as `AIDerived` — the model generated it, and the provenance output says so. No false claims.
 
@@ -144,5 +146,14 @@ The `analysis` field is honestly labeled as `AIDerived` — the model generated 
 |----------|----------------------|
 | **EU AI Act Article 50** | `contains_ai_derived` flag, machine-readable provenance |
 | **FINRA/SEC** | Immutable receipt chain, Ed25519 signed |
-| **W3C PROV-DM** | PROV-JSON export from flow graph |
+| **W3C PROV-DM** | PROV-JSON export of flow *nodes* (entities/activities/agents + IFC labels). Derivation relations (`wasDerivedFrom`, `used`) are **not** emitted — see note below. CLI export not yet shipped. |
 | **NIST AI RMF** | Execution context telemetry in receipts |
+
+> **Note on derivation relations.** The PROV exporter previously emitted
+> `wasDerivedFrom` and `used` inferred from *observation order* — entity *i* was
+> declared derived from entity *i−1* — which asserts data flows that were never
+> computed. Those relations have been removed rather than left in place with a
+> caveat: in a document offered as regulatory evidence, a fabricated relation is
+> worse than a missing one, because a missing relation is visibly absent while a
+> fabricated one is indistinguishable from a real finding. Emitting real
+> relations requires derivation edges in the flow graph, which is open work.


### PR DESCRIPTION
## The defect

`export_prov_json` emitted two PROV relations inferred from observation **order**:

```rust
// wasDerivedFrom: link to previous entity (linear approx).
// used: activity used the previous entity.
```

Both are assertions that data actually flowed. Deriving them from sequence adjacency asserts flows that were never computed — a local file read followed by an unrelated web fetch became a derivation chain purely because one happened after the other.

The module header says it exists "for regulatory compliance." **In a document offered as evidence, a fabricated relation is worse than a missing one**: a missing relation is visibly absent; a fabricated one is indistinguishable from a real finding.

Nothing shipped wrong — the only caller is a test.

## The fix

Both relations removed. Nodes (`entity`/`activity`/`agent` with IFC labels) are untouched — those are direct renderings of things actually observed.

The relation **types** stay: the schema is right, only the data is unavailable. Worth noting for whoever picks this up — the signature `&[(u8, String, String)]` has **no field for a parent set**, so restoring real relations is an input-type change, not a change to the body.

## Tests

The two tests that asserted the fabrication (`sequential_entities_linked_by_derivation`, `activity_uses_preceding_entity`) are replaced by tests asserting its absence, named for the property rather than the mechanism. Plus a new one checking the **serialized** document omits the relation keys entirely — an empty relation object still reads to a consumer as "a graph with no findings."

**Perturbation-verified:** reinstating the sequence-order link REDs exactly those two, at the derivation assertions.

## Docs corrected in the same change

**The causal-ancestry claim.** The quickstart said *"the flow graph proves there is no model node in the causal ancestry of these values."* Nucleus's flow graph carries no derivation edges — nodes are recorded with no parents — so that predicate is **trivially true of every value**, including ones a model did produce.

The underlying guarantee is real, but it comes from somewhere else: content-addressed re-execution, which an auditor can verify without trusting us. The text now attributes it correctly and states explicitly what is *not* being claimed.

**The compliance table.** Listed `W3C PROV-DM | PROV-JSON export from flow graph` with no qualifier, directly below a CLI command marked "coming soon." Now states that nodes are exported, relations are not, and the CLI has not shipped.

## Gates

`clippy --workspace --all-targets --all-features -D warnings` · `RUSTFLAGS="-D warnings" cargo test` (933 portcullis-core tests) · `cargo hack check --each-feature --no-dev-deps` · `fmt --check` · `check-line-ratchet --strict` — all green.

Touches `portcullis-core/src/`, which is outside the Aeneas fence (`portcullis-core/lean/**`, `nucleus-ifc-kernel/src/**`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UA8kchV3eadjGv6BmJXfqm