### PR TITLE
Observe /v1/run command output — close the transport asymmetry

### DIFF
--- a/crates/nucleus-tool-proxy/src/main.rs
+++ b/crates/nucleus-tool-proxy/src/main.rs
@@ -2483,6 +2483,55 @@ async fn http_observe_flow(state: &AppState, kind: NodeKind, bytes: &[u8]) {
     }
 }
 
+/// The flow node kind command output is observed as.
+///
+/// Extracted to a constant so the CHOICE is pinned by a test rather than
+/// inferred. A test asserting that `McpToolResult` is adversarial, plus a test
+/// that an `McpToolResult` observation trips the gate, BOTH pass even if this
+/// call site observes something weaker — verified by perturbation: swapping in
+/// `ToolResponse` (Untrusted, not Adversarial) failed nothing until this
+/// constant existed to assert against.
+pub(crate) const COMMAND_OUTPUT_NODE_KIND: NodeKind = NodeKind::McpToolResult;
+
+/// Taint COMMAND OUTPUT as adversarial — the HTTP twin of
+/// `mcp::Server::observe_tool_result`.
+///
+/// `/v1/run` returns arbitrary subprocess stdout/stderr to the agent, which is
+/// external bytes by any definition: `curl` through bash is an ingest the proxy
+/// cannot distinguish from `ls`. Every other HTTP handler that returns external
+/// bytes observes them (`read_file`, `web_fetch`, `glob_search`, `grep_search`,
+/// `web_search`); this one did not, so bash-fetched content entered the session
+/// with no flow node at all.
+///
+/// The asymmetry was the real defect. `NUCLEUS_PARANOID_TOOL_IO=1` has always
+/// covered the MCP transport (`mcp.rs:675`) and never covered HTTP, so an
+/// operator who enabled it got partial coverage with nothing to indicate half
+/// their surface was uncovered — worse than the flag not existing, because it
+/// reads as a decision that was made.
+///
+/// Same env var, same default (OFF), same node kind, and the same reason for the
+/// default that `observe_tool_result` documents: blanket-tainting the proxy's own
+/// command output makes a session "one privileged action then locked"
+/// (run-tests → cannot commit). That is an operator's policy call, not ours.
+///
+/// Observed regardless of exit status: a failing command's stderr is still bytes
+/// the agent read. Called only after the command actually RAN, so a denied
+/// operation still leaks no taint.
+async fn http_observe_command_output(state: &AppState, stdout: &[u8], stderr: &[u8]) {
+    let paranoid = std::env::var("NUCLEUS_PARANOID_TOOL_IO")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
+    if !paranoid {
+        return;
+    }
+    // Both streams in one node: they are one ingest event, and content-addressing
+    // them separately would imply two independent sources.
+    let mut bytes = Vec::with_capacity(stdout.len() + stderr.len());
+    bytes.extend_from_slice(stdout);
+    bytes.extend_from_slice(stderr);
+    http_observe_flow(state, COMMAND_OUTPUT_NODE_KIND, &bytes).await;
+}
+
 async fn read_file(
     State(state): State<AppState>,
     _headers: HeaderMap,
@@ -3027,6 +3076,8 @@ async fn run_command(
     }) {
         warn!(error = %e, "verdict recording failed -- audit gap");
     }
+    http_observe_command_output(&state, &output.stdout, &output.stderr).await;
+
     Ok(Json(RunResponse {
         status: output.status.code().unwrap_or(-1),
         success: output.status.success(),

--- a/crates/nucleus-tool-proxy/src/tests_main.rs
+++ b/crates/nucleus-tool-proxy/src/tests_main.rs
@@ -352,7 +352,7 @@ fn test_lockdown_blocks_unknown_paths() {
 mod ifc_http_enforcement {
     use super::*;
 
-    fn permissive_kernel() -> Kernel {
+    pub(super) fn permissive_kernel() -> Kernel {
         Kernel::new(PermissionLattice::permissive())
     }
 
@@ -400,7 +400,7 @@ mod ifc_http_enforcement {
     /// Drive the live entry point and hand back both the mapped result and what
     /// the sink actually saw.
     #[allow(clippy::type_complexity)]
-    fn decide_capturing(
+    pub(super) fn decide_capturing(
         kernel: &mut Kernel,
         flow: &FlowTracker,
         operation: Operation,
@@ -871,4 +871,84 @@ fn an_unmapped_reason_keeps_its_text_instead_of_becoming_a_capability_claim() {
         !msg.contains("level is Never"),
         "not a capability claim: {msg}"
     );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Command output is a taint source (transport parity)
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// `/v1/run` returned arbitrary subprocess stdout to the agent and observed
+// nothing, while every other HTTP handler returning external bytes observes
+// them. `NUCLEUS_PARANOID_TOOL_IO=1` covered MCP and not HTTP, so enabling it
+// bought partial coverage with no signal that half the surface was uncovered.
+//
+// These tests are on the OBSERVATION SEMANTICS rather than on the handler,
+// which needs an AppState with a live sandbox. The handler wiring is one call
+// at the single return site of `run_command`.
+mod command_output_taint {
+    use super::ifc_http_enforcement::{decide_capturing, permissive_kernel};
+    use super::*;
+
+    /// **What the handler actually observes** — asserted against the constant the
+    /// call site uses, not against a kind named again in the test. Naming it
+    /// twice is how a test passes while the handler observes something weaker;
+    /// perturbation confirmed exactly that before this test existed.
+    #[test]
+    fn command_output_is_observed_as_an_adversarial_kind() {
+        let label = nucleus_ifc_kernel::flow::intrinsic_label(crate::COMMAND_OUTPUT_NODE_KIND, 0);
+        assert_eq!(
+            label.integrity,
+            nucleus_ifc_kernel::IntegLevel::Adversarial,
+            "command output is observed as {:?}, which cannot trip the egress gate",
+            crate::COMMAND_OUTPUT_NODE_KIND
+        );
+    }
+
+    /// The two transports must agree: one flag, one policy.
+    #[test]
+    fn http_and_mcp_observe_tool_output_identically() {
+        assert_eq!(
+            crate::COMMAND_OUTPUT_NODE_KIND,
+            NodeKind::McpToolResult,
+            "HTTP and MCP would enforce different policies under NUCLEUS_PARANOID_TOOL_IO"
+        );
+    }
+
+    /// The point of observing at all: a session that has read command output
+    /// must be unable to take a privileged outbound action afterwards.
+    #[test]
+    fn observed_command_output_blocks_a_later_outbound_action() {
+        let mut kernel = permissive_kernel();
+        let mut flow = FlowTracker::new();
+
+        // Before: a clean session may act.
+        let (before, _) = decide_capturing(&mut kernel, &flow, Operation::WriteFiles, "out.txt");
+        assert!(before.is_ok(), "clean session should allow the write");
+
+        // The command ran and its output entered the session.
+        flow.observe(NodeKind::McpToolResult)
+            .expect("observe command output");
+
+        let (after, _) = decide_capturing(&mut kernel, &flow, Operation::WriteFiles, "out2.txt");
+        let err = after.expect_err("post-command-output write must be denied");
+        assert!(
+            matches!(err, ApiError::IfcDenied(_)),
+            "expected IfcDenied, got {err:?}"
+        );
+    }
+
+    /// Without the observation the same sequence is permitted — which is what
+    /// the bug was, and what makes the test above load-bearing rather than a
+    /// restatement of the gate.
+    #[test]
+    fn unobserved_command_output_leaves_the_session_clean() {
+        let mut kernel = permissive_kernel();
+        let flow = FlowTracker::new();
+        // No observe call — the pre-fix behaviour of /v1/run.
+        let (after, _) = decide_capturing(&mut kernel, &flow, Operation::WriteFiles, "out.txt");
+        assert!(
+            after.is_ok(),
+            "with no observation the session stays clean — this is the hole"
+        );
+    }
 }


### PR DESCRIPTION
## The gap

`/v1/run` returned arbitrary subprocess stdout/stderr to the agent and **observed nothing**. Every other HTTP handler returning external bytes observes them — `read_file`, `web_fetch`, `glob_search`, `grep_search`, `web_search` — so this was the one ingest channel with no flow node at all. `curl` through bash entered the session untracked.

## The asymmetry was the defect

`NUCLEUS_PARANOID_TOOL_IO=1` has always covered **MCP** (`mcp.rs:675`) and never covered **HTTP**. An operator enabling it got partial coverage with nothing indicating half their surface was uncovered — worse than the flag not existing, because it reads as a decision that was made.

So this is the HTTP twin of an existing mechanism, not a new policy: same env var, same default (**OFF**), same node kind, and the same documented reason for the default that `observe_tool_result` already gives — blanket-tainting the proxy's own command output makes a session *"one privileged action then locked"* (run-tests → can't commit), which is an operator's call.

Observed regardless of exit status (a failing command's stderr is still bytes the agent read), and only after the command actually **ran**, so a denied operation still leaks no taint. Both streams go into one node — they're one ingest event.

## My first tests were vacuous, and perturbation caught it

They asserted that `McpToolResult` is adversarial, and that an `McpToolResult` observation trips the gate. Both true. Both passing. And **both still passing** when I swapped the call site to `ToolResponse` (Untrusted, not Adversarial).

Naming the kind a second time in the test is exactly how a test passes while the handler observes something weaker — the same "availability is not recording" shape as #2127. Fixed by extracting `COMMAND_OUTPUT_NODE_KIND` so the tests assert against the constant the call site *uses*. Re-perturbed:

```
command output is observed as ToolResponse, which cannot trip the egress gate
```

Removing the call site is caught separately — the helper goes dead-code, an error under CI's `-D warnings`.

## Verification

Flag in **both** positions: 7 suites green with it off (the default, unchanged), zero failures with it on. Aeneas fence untouched.

## Scope

This closes half of the audit finding. The other half — `NodeKind::FileRead` carrying `IntegLevel::Trusted` (`flow.rs:295-305`), so a disk round-trip launders taint — is **inside the Aeneas fence** and perturbs the label lattice every integrity proof folds over. Left deliberate rather than bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UA8kchV3eadjGv6BmJXfqm