### PR TITLE
Close the disk-laundering channel with per-path taint propagation

### DIFF
--- a/crates/nucleus-tool-proxy/src/main.rs
+++ b/crates/nucleus-tool-proxy/src/main.rs
@@ -357,6 +357,19 @@ pub(crate) struct AppState {
     /// blocks outbound for all); true multi-tenancy would require keying the
     /// kernel AND tracker together — out of scope here.
     pub(crate) flow_tracker: Arc<tokio::sync::Mutex<FlowTracker>>,
+    /// Paths written while the session was integrity-tainted.
+    ///
+    /// Closes a disk-laundering channel: tainted bytes land in a file, the file
+    /// is read back, and the read produces a `FileRead` node whose intrinsic
+    /// integrity is `Trusted` — so the taint vanishes.
+    ///
+    /// This is EMPTY in the default configuration and cannot become non-empty:
+    /// with `NUCLEUS_GRADED_TAINT` off, `WriteFiles`/`EditFiles`/`RunBash` are
+    /// all DENIED in a tainted session, so tainted bytes never reach disk. The
+    /// channel opens only when grading converts those denials into approvals and
+    /// a human approves one. `RunBash` stays denied even when graded, so there
+    /// is no bash-written blind spot.
+    pub(crate) laundered_paths: Arc<tokio::sync::Mutex<std::collections::HashSet<String>>>,
     /// Provenance-verified, taint-labeled agent memory (next-bet #1). A write
     /// goes through `verified_admit`; a recall observes the record's own label
     /// into `flow_tracker` so the IFC gate governs whether it may inform an
@@ -1546,6 +1559,7 @@ async fn main() -> Result<(), ApiError> {
     enforce_hmac_key_quality(&args.auth_secret, vsock_binding.is_some());
 
     let state = AppState {
+        laundered_paths: Arc::new(tokio::sync::Mutex::new(std::collections::HashSet::new())),
         dlc_provisioned,
         runtime: Arc::new(runtime),
         approvals,
@@ -2493,6 +2507,26 @@ async fn http_observe_flow(state: &AppState, kind: NodeKind, bytes: &[u8]) {
 /// constant existed to assert against.
 pub(crate) const COMMAND_OUTPUT_NODE_KIND: NodeKind = NodeKind::McpToolResult;
 
+/// Which flow node kind a file read is observed as.
+///
+/// Extracted so the CHOICE is assertable. Perturbation showed why: with the
+/// branch inlined in `read_file` — a handler that needs a live sandbox to
+/// exercise — replacing the laundered arm with a plain `FileRead` (making the
+/// whole fix a no-op) passed every test, because the tests asserted the
+/// constant's properties and the tracker's behaviour but never what the handler
+/// actually selects.
+pub(crate) fn read_node_kind(is_laundered: bool) -> NodeKind {
+    if is_laundered {
+        // A path written while tainted re-enters adversarial, restoring the
+        // taint a disk round-trip would otherwise strip.
+        COMMAND_OUTPUT_NODE_KIND
+    } else {
+        // Ordinary reads stay trusted — labelling all reads adversarial would
+        // lock every session on its first read.
+        NodeKind::FileRead
+    }
+}
+
 /// Taint COMMAND OUTPUT as adversarial — the HTTP twin of
 /// `mcp::Server::observe_tool_result`.
 ///
@@ -2564,6 +2598,8 @@ async fn read_file(
     let decision_token = http_kernel_decide(&state, operation, &req.path).await?;
 
     let path = req.path.clone();
+    // Survives the sink record below, which consumes `path`.
+    let observed_path = path.clone();
 
     // Discharge the eight obligations for this read. Reads were previously
     // unmediated on this path: it went from `http_kernel_decide` straight to the
@@ -2661,7 +2697,14 @@ async fn read_file(
     }
     // IFC: a successful file read brings data into the session (#1633).
     // Brick 3: content-address the exact bytes read.
-    http_observe_flow(&state, NodeKind::FileRead, contents.as_bytes()).await;
+    // A path written during a tainted session re-enters as adversarial, not as a
+    // trusted file read — otherwise a round-trip through disk strips the taint.
+    let is_laundered = state.laundered_paths.lock().await.contains(&observed_path);
+    if is_laundered {
+        warn!(path = %observed_path, "reading a path written while tainted; observing as adversarial");
+    }
+    let read_kind = read_node_kind(is_laundered);
+    http_observe_flow(&state, read_kind, contents.as_bytes()).await;
     Ok(Json(ReadResponse { contents }))
 }
 
@@ -2699,6 +2742,8 @@ async fn write_file(
     let decision_token = http_kernel_decide(&state, operation, &req.path).await?;
 
     let path = req.path.clone();
+    // Survives the sink record below, which consumes `path`.
+    let written_path = path.clone();
     let contents = req.contents.clone();
 
     // ─── Sealed discharge gate (B6, parity with the RunBash executor-proof gate
@@ -2840,6 +2885,22 @@ async fn write_file(
     }) {
         warn!(error = %e, "verdict recording failed -- audit gap");
     }
+    // If this write succeeded while the session was tainted, the bytes on disk
+    // may carry that taint. Record the path so a later read of it is not treated
+    // as a trusted file read. Only reachable under grading — see the field docs.
+    {
+        let tainted = state.flow_tracker.lock().await.is_tainted();
+        if tainted {
+            let mut laundered = state.laundered_paths.lock().await;
+            laundered.insert(written_path.clone());
+            warn!(
+                path = %written_path,
+                "write taken while session tainted; later reads of this path \
+                 will be treated as adversarial"
+            );
+        }
+    }
+
     Ok(Json(WriteResponse { ok: true }))
 }
 

--- a/crates/nucleus-tool-proxy/src/tests_main.rs
+++ b/crates/nucleus-tool-proxy/src/tests_main.rs
@@ -929,11 +929,14 @@ mod command_output_taint {
         flow.observe(NodeKind::McpToolResult)
             .expect("observe command output");
 
+        // Asserts the action is NOT PERMITTED, not that it is specifically denied:
+        // the property under test is that command output taints, and that holds
+        // whether the graded policy refuses or defers. Pinning `IfcDenied` here
+        // would make this test a hostage of a policy it is not about.
         let (after, _) = decide_capturing(&mut kernel, &flow, Operation::WriteFiles, "out2.txt");
-        let err = after.expect_err("post-command-output write must be denied");
         assert!(
-            matches!(err, ApiError::IfcDenied(_)),
-            "expected IfcDenied, got {err:?}"
+            after.is_err(),
+            "post-command-output write must not be permitted; got {after:?}"
         );
     }
 
@@ -949,6 +952,148 @@ mod command_output_taint {
         assert!(
             after.is_ok(),
             "with no observation the session stays clean — this is the hole"
+        );
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Disk laundering: a round-trip through a file must not strip taint
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// `NodeKind::FileRead` carries `IntegLevel::Trusted`, so reading a file yields a
+// trusted node no matter what is in it. An audit reported this as a mislabelled
+// constant; it is not. Changing the label is either a no-op (`Untrusted` — every
+// live consumer tests `== Adversarial` by EQUALITY, `ifc_api.rs:519,558,812`) or
+// unusable (`Adversarial` — the first file read taints every session forever).
+//
+// The real defect is a missing mechanism, and its REACHABILITY is the whole
+// story: by default, tainted bytes cannot reach disk at all, so the channel is
+// shut. It opens only when grading turns a write-denial into an approval.
+mod disk_laundering {
+    use super::ifc_http_enforcement::{decide_capturing, permissive_kernel};
+    use super::*;
+
+    fn tainted() -> FlowTracker {
+        let mut f = FlowTracker::new();
+        f.observe(NodeKind::WebContent)
+            .expect("observe web content");
+        f
+    }
+
+    /// **The precondition.** Ungraded, every route by which tainted bytes could
+    /// reach disk is denied — so the laundering channel is UNREACHABLE in the
+    /// default configuration. If this ever fails, the fix below stops being
+    /// defence-in-depth and becomes load-bearing.
+    #[test]
+    fn ungraded_tainted_bytes_cannot_reach_disk() {
+        let flow = tainted();
+        for op in [
+            Operation::WriteFiles,
+            Operation::EditFiles,
+            Operation::RunBash,
+        ] {
+            let mut kernel = permissive_kernel();
+            let r = decide_capturing(&mut kernel, &flow, op, "f.txt").0;
+            assert!(
+                matches!(r, Err(ApiError::IfcDenied(_))),
+                "{op:?} is no longer DENIED in a tainted session (got {r:?}).\n\
+                 This test is a TRIPWIRE, not a regression: it holds only in the \
+                 ungraded configuration. If it fires because NUCLEUS_GRADED_TAINT \
+                 is on, or because the default was flipped, then tainted bytes can \
+                 now reach disk via an approved write — the laundering channel is \
+                 REACHABLE and the tracked-path mechanism has become load-bearing \
+                 rather than defence-in-depth. Re-scope this test deliberately."
+            );
+        }
+    }
+
+    /// A shell stays denied even under grading, so there is no bash-written
+    /// blind spot — the tracked-path set does not need to see bash writes.
+    #[test]
+    fn bash_stays_denied_even_when_graded() {
+        assert_eq!(
+            portcullis::exposure_core::graded_taint_response(Operation::RunBash),
+            portcullis::exposure_core::TaintResponse::Deny,
+            "if bash ever becomes approvable, files it writes bypass the tracked set"
+        );
+    }
+
+    /// The laundered read must be observed as a kind that actually re-taints.
+    /// Asserted against the constant the read path uses, not a kind named again
+    /// here — naming it twice is how this test passes while the handler observes
+    /// something weaker.
+    #[test]
+    fn a_laundered_read_is_observed_as_a_retainting_kind() {
+        let label = nucleus_ifc_kernel::flow::intrinsic_label(crate::COMMAND_OUTPUT_NODE_KIND, 0);
+        assert_eq!(
+            label.integrity,
+            nucleus_ifc_kernel::IntegLevel::Adversarial,
+            "a laundered read observed as {:?} would not restore the taint",
+            crate::COMMAND_OUTPUT_NODE_KIND
+        );
+    }
+
+    /// And the contrast that makes the above meaningful: an ORDINARY file read
+    /// stays trusted, so this does not blanket-taint every read.
+    #[test]
+    fn an_ordinary_file_read_is_still_trusted() {
+        let label = nucleus_ifc_kernel::flow::intrinsic_label(NodeKind::FileRead, 0);
+        assert_eq!(
+            label.integrity,
+            nucleus_ifc_kernel::IntegLevel::Trusted,
+            "ordinary reads must stay trusted or every session locks on first read"
+        );
+    }
+
+    /// **What the read path actually selects** — asserted against the function
+    /// the handler calls. Without this, replacing the laundered arm with a plain
+    /// `FileRead` (a total no-op) passes every other test here; verified by
+    /// perturbation before this test existed.
+    #[test]
+    fn the_read_path_selects_a_retainting_kind_for_a_laundered_path() {
+        let laundered = nucleus_ifc_kernel::flow::intrinsic_label(crate::read_node_kind(true), 0);
+        assert_eq!(
+            laundered.integrity,
+            nucleus_ifc_kernel::IntegLevel::Adversarial,
+            "laundered reads are observed as {:?}, which does not restore taint",
+            crate::read_node_kind(true)
+        );
+        let ordinary = nucleus_ifc_kernel::flow::intrinsic_label(crate::read_node_kind(false), 0);
+        assert_eq!(
+            ordinary.integrity,
+            nucleus_ifc_kernel::IntegLevel::Trusted,
+            "ordinary reads must stay trusted"
+        );
+    }
+
+    /// End to end on the flow tracker: re-observing a laundered read restores
+    /// the taint that the disk round-trip stripped.
+    #[test]
+    fn re_observing_a_laundered_read_restores_the_taint() {
+        // A plain file read leaves the session clean — the hole.
+        let mut clean = FlowTracker::new();
+        clean.observe(NodeKind::FileRead).expect("plain read");
+        assert!(
+            !clean.is_tainted(),
+            "a trusted read does not taint — the channel"
+        );
+
+        // The same read, recognised as laundered, does.
+        let mut fixed = FlowTracker::new();
+        fixed
+            .observe(crate::COMMAND_OUTPUT_NODE_KIND)
+            .expect("laundered read");
+        assert!(
+            fixed.is_tainted(),
+            "a laundered read must restore the taint"
+        );
+
+        // Not permitted — refused or deferred — for the same reason as above.
+        let mut kernel = permissive_kernel();
+        let r = decide_capturing(&mut kernel, &fixed, Operation::WriteFiles, "out.txt").0;
+        assert!(
+            r.is_err(),
+            "after a laundered read the session must not act outbound; got {r:?}"
         );
     }
 }


### PR DESCRIPTION
## What it does

A file written while the session is tainted, then read back, produced a `FileRead` node whose intrinsic integrity is `Trusted` — so a round-trip through disk **stripped the taint**. Writes taken while tainted now record their path; a later read of a recorded path is observed as adversarial instead of as a trusted file read.

## The audit's diagnosis was wrong, and this is not the fix it asked for

It reported `NodeKind::FileRead` carrying `IntegLevel::Trusted` as a mislabelled constant. Every live consumer tests `== IntegLevel::Adversarial` by **equality**, not ordering (`ifc_api.rs:519, 558, 812`):

| change | effect |
|---|---|
| `Trusted → Untrusted` | **no-op** — nothing on the live path tests for `Untrusted` |
| `Trusted → Adversarial` | **first file read taints every session forever** — reading your own source locks all outbound actions |

A test pins the second half: ordinary reads must stay `Trusted`.

## Reachability, measured, is the whole story

Ungraded, `WriteFiles` / `EditFiles` / `RunBash` are **all denied** in a tainted session — tainted bytes cannot reach disk and the channel is shut. It opens only when the graded response (#2133) turns those denials into approvals and a human approves one.

**That exposure is a consequence of my own previous change**, not a pre-existing hole. `RunBash` stays denied even when graded, so there's no bash-written blind spot and the tracked set needn't see bash writes — pinned by a test, because if bash ever becomes approvable this mechanism silently develops a gap.

So: defence-in-depth today, load-bearing the moment the graded default flips. `ungraded_tainted_bytes_cannot_reach_disk` is written as a **tripwire**, not a regression test — its failure message says tainted bytes can now reach disk and that this mechanism has become load-bearing.

## Third vacuous test of my own this session, caught the same way

Replacing the laundered arm with a plain `FileRead` — making the **entire fix a no-op** — passed every test, because they asserted the constant's properties and the tracker's behaviour but never what the read path *selects*.

Fixed by extracting `read_node_kind(is_laundered)` so the choice is assertable. Re-perturbed:

```
laundered reads are observed as FileRead, which does not restore taint
```

Two tests were also over-specified — they pinned `IfcDenied` while the property under test is taint *propagation*, which holds whether the graded policy refuses or defers. They now assert the action is not permitted, so they aren't hostages of a policy they aren't about.

## Verification

Default configuration: **7 suites, zero failures.** With grading on, the only failures are the three flips #2133 already documented, plus the tripwire. Aeneas fence untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UA8kchV3eadjGv6BmJXfqm