### PR TITLE
Correct three overstated claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@
 
 > **Assume the agent is compromised. Constrain what it can do anyway. Prove the constraints hold.**
 
-At its core is a small, dependency-free information-flow algebra. Two primitives — `join` and `flows_to` — enforce information-flow control under four algebraic laws. Once untrusted web content enters a session, it cannot silently reach a privileged sink like `git push`. That property is [machine-checked](FORMAL_METHODS.md), not hoped.
+At its core is a small, dependency-free information-flow algebra. Two primitives — `join` and `flows_to` — enforce information-flow control under four algebraic laws. Once untrusted web content enters a session **through a mediated ingest channel**, it cannot silently reach a privileged sink like `git push`. That property is [machine-checked](FORMAL_METHODS.md), not hoped.
+
+The qualifier is load-bearing, so it is stated here rather than in a footnote: the guarantee covers content the runtime *observes*. Fetches through `web_fetch`/`web_search`, file reads, and memory recalls are observed. Bytes an agent obtains by running a command — `curl` inside `run` — are observed only when `NUCLEUS_PARANOID_TOOL_IO=1`, because the runtime cannot tell `curl` from `ls` in a command's output and tainting all of it makes a session "one privileged action then locked". That is an operator's policy call, and until it is made, command output is an unmediated ingest channel.
 
 This is the **[lethal trifecta](https://simonwillison.net/2025/Jun/16/the-lethal-trifecta/)** — private data + untrusted content + an exfiltration sink — made safe by **non-interference**: attacker-tainted data cannot reach a consequential action, so a compromised agent cannot be turned into a *confused deputy*. We don't *detect* the prompt injection; we make its consequence impossible — and prove it. (Detection-based guardrails are probabilistic; this is a structural guarantee.)
 
@@ -432,6 +434,8 @@ Documented in [`SECURITY_TODO.md`](SECURITY_TODO.md) and [`docs/production-delta
 **Protects against:** prompt-injection side effects, invisible Unicode injection, misconfigured permissions, network policy drift, budget exhaustion, privilege escalation via delegation, audit-log tampering, memory poisoning, substitution/truncation of provenance bundles, and silent policy widening (constitutional kernel).
 
 **Does not protect against:** compromised host/kernel, malicious human approvals, side-channel attacks, VM kernel escapes — nor does a green provenance verification imply the agent *behaved well* or that any computation was *correct*.
+
+**Unmediated by default:** bytes an agent obtains by running a command (`curl` inside `run`) are not observed as an ingest unless `NUCLEUS_PARANOID_TOOL_IO=1`, so they do not taint the session and the information-flow guarantee above does not cover them. Setting that variable closes the channel on both the HTTP and MCP transports at the cost of a session becoming "one privileged action then locked".
 
 > **Versioning:** v1.0 means the **interface contract is stable** (see [`STABILITY.md`](STABILITY.md)), not "production-secure by default." The lattice is heavily verified; the runtime is tested but not yet battle-hardened.
 

--- a/crates/portcullis-core/lean/DeclassifyProofs.lean
+++ b/crates/portcullis-core/lean/DeclassifyProofs.lean
@@ -9,9 +9,10 @@ Proves that declassification rules cannot escalate privileges:
 - RaiseAuthority can only increase authority
 - No rule modifies dimensions it doesn't target
 - Applying a rule twice is idempotent
-- Robust declassification: the authenticated, artifact-scoped, sink-restricted
-  token path confines endorsement to the authorized target — an attacker cannot
-  influence what/where is endorsed (Askarov–Myers robustness)
+- Token guard scoping: the authenticated, artifact-scoped, sink-restricted token
+  path confines endorsement to the authorized target. This is NOT robust
+  declassification — see the note above `authorized_endorsement` for why the
+  citation was removed.
 
 Hand-written Lean models mirroring `portcullis-core/src/declassify.rs`.
 All proofs fully checked, no proof holes.
@@ -222,9 +223,20 @@ theorem non_expired_token_matches_rule (label from_ to_ : IntegLevel) (valid_unt
 -- under a security posture at both application (#2058) and registration (#2060).
 -- The signed path endorses ONLY a named target node, only with a verified
 -- signature, only before expiry, and only toward allowlisted sinks. These
--- theorems prove that path satisfies ROBUST DECLASSIFICATION: an attacker cannot
--- influence what/where is endorsed (Askarov–Myers robustness; Myers–Sabelfeld–
--- Zdancewic robust declassification).
+-- theorems prove the guard is ENFORCED. That is NOT robust declassification, and
+-- this comment used to claim it was.
+--
+-- Robust declassification (Myers–Sabelfeld–Zdancewic; Askarov–Myers) is a
+-- RELATIONAL property quantified over execution runs — canonically four, varying
+-- the secret within a pair and the attack across pairs — constraining the
+-- attacker's influence over both the CONTENT and the TIMING of a release. These
+-- theorems have no program, no step relation and no second run; timing is not
+-- modelled at all. They are guard-scoping lemmas.
+--
+-- Proving the real property needs a trace semantics for the reachable
+-- declassification path plus one-shot/timing constraints on the token. Until
+-- then the citation is removed rather than qualified: a reader who sees the name
+-- reasonably assumes the four-run obligation was discharged.
 
 /-- Endorsement via the authenticated, artifact-scoped token. `authorized` models
     successful Ed25519 signature verification against a trusted key (the runtime

--- a/docs/PROOFS.md
+++ b/docs/PROOFS.md
@@ -118,7 +118,11 @@ A claim that any of these is "proven" is a claim to watch for and correct.
 
 The deepest gap is between a *proven Lean model* and the *running Rust*. Two ways we close it, and where each applies:
 
-- **Extraction (strongest).** Aeneas (`rustc → Charon → LLBC → a functional model → Lean`) emits the model *from* the Rust, so the theorem is about the real code, not a hand-written mirror. **This is already done for IFC**: `integrity_sink_never_admitted` is proven over Charon-generated definitions (§1b). The natural next targets are the **pure-integer econ kernels** — `settlement.rs` (`seller_gross`/`refund`/`classify`) and `commons.rs` (`route_to_commons`) — which sit inside the Aeneas-supported subset (safe, sequential, non-nested loops, integer arithmetic).
+- **Extraction (strongest available, but read the boundary).** Aeneas (`rustc → Charon → LLBC → a functional model → Lean`) emits the Lean model *from* Rust, so no one hand-writes the Lean. **This is done for IFC**: `integrity_sink_never_admitted` is proven over Charon-generated definitions (§1b).
+
+  What this does NOT mean is that the theorem is about the production function. Aeneas cannot translate the whole crate, so the extraction roots live in `crates/nucleus-ifc-kernel/src/extracted/`, which its own module doc describes as *"pure, `String`-free **restatements**"* that are each a *"byte-faithful **mirror** of the corresponding clause in the production ... code in `lib.rs`, ... bound to that production code by exhaustive parity tests."*
+
+  So extraction removes the model↔Lean gap and **relocates** the model↔code gap into Rust, where it is closed by exhaustive testing rather than by proof. That is a real and unusual strength — the mirror is in the same language, same types, and diffable — but "the theorem is about the real code" overstates it by one link. Compare seL4, whose refinement chain reaches the compiled binary. The natural next targets are the **pure-integer econ kernels** — `settlement.rs` (`seller_gross`/`refund`/`classify`) and `commons.rs` (`route_to_commons`) — which sit inside the Aeneas-supported subset (safe, sequential, non-nested loops, integer arithmetic).
 - **Golden-vector parity (current floor for the rest).** Where extraction is *not* yet feasible — `run_vcg` (HashMap + sort + SHA-256 tie-break) and all crypto — the seal (§2) pins output bytes instead. This is TESTED, not PROVEN, and that is the honest label until extraction lands.
 
 **Aeneas supported / unsupported (so the boundary is not hand-waved):**


### PR DESCRIPTION
From the adversarial formalization audit. Each verified against current code rather than applied from the report — **one of the three had already changed**.

## 1. `README.md` — the information-flow headline

*"Once untrusted web content enters a session, it cannot silently reach a privileged sink like `git push`"* is **true** for content the runtime observes (`web_fetch`/`web_search`, file reads, memory recall) and **false by default** for bytes an agent obtains via `curl` inside `run` — command output is observed only under `NUCLEUS_PARANOID_TOOL_IO=1`.

The audit recommended moving the whole claim to "does not protect against". **That overcorrects now:** #2134 closed the transport asymmetry and #2135 closed the disk round-trip, so the claim is more defensible than when it was flagged.

Scoped instead — the qualifier *"through a mediated ingest channel"* is in the sentence itself rather than a footnote, with the reason stated inline: the runtime can't tell `curl` from `ls` in command output, and tainting all of it makes a session "one privileged action then locked", which is an operator's call. The threat model gains an explicit **"Unmediated by default"** entry.

## 2. `docs/PROOFS.md` — "not a hand-written mirror"

The Rust that Charon reads **is** a hand-written mirror, by its own module doc. `extracted/mod.rs` describes itself as *"pure, `String`-free **restatements**"*, each a *"byte-faithful **mirror** of the corresponding clause in the production … code"*, bound to production by exhaustive parity tests.

So extraction removes the model↔Lean gap and **relocates** the model↔code gap into Rust, where testing closes it rather than proof. Still a real and unusual strength — same language, same types, diffable — but overstated by one link. seL4's chain reaching the compiled binary is now named as the comparison.

## 3. `DeclassifyProofs.lean` (two sites) — robust declassification

Claimed: *"these theorems prove that path satisfies ROBUST DECLASSIFICATION … (Askarov–Myers; Myers–Sabelfeld–Zdancewic)"*.

What they prove: the token guard is **enforced** — only the named target, only under a verified signature, only before expiry, only toward allowlisted sinks.

Robust declassification is a **relational** property over execution runs (canonically four), constraining attacker influence over both the **content and the timing** of a release. These theorems have no program, no step relation, no second run, and timing isn't modelled at all.

Citation **removed rather than qualified** — a reader who sees the name reasonably assumes the four-run obligation was discharged. What proving it would actually require is stated in place.

## Considered and left alone

`SemanticIFC.lean:40` is a bibliography entry; `quarantine.rs:43` is design rationale arguing a specific limited point without claiming a theorem. Both corrected sites claimed proofs; these two don't.

## Verification

`DeclassifyProofs` builds clean (4 jobs) · `fmt --check` · `check-line-ratchet --strict`. **No code changed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UA8kchV3eadjGv6BmJXfqm