### PR TITLE
mediation lint was blind to every `async fn` — 14 hidden unmediated paths

### DIFF
--- a/tools/nucleus-mediation-lint/src/lib.rs
+++ b/tools/nucleus-mediation-lint/src/lib.rs
@@ -137,6 +137,31 @@ const DENY_SET: &[&str] = &[
 /// The type whose by-value presence in a signature marks a mediation boundary.
 const AUTHORITY_PATH_SUFFIX: &str = "authority::Authority";
 
+/// Strip generic argument lists from a `def_path_str` rendering.
+///
+/// `def_path_str` renders generics — a call on a parameterised type comes back
+/// as `nucleus::Executor::<'a>::run_args` — so a deny-set prefix that does not
+/// anticipate the parameterisation silently never matches. A miss is
+/// indistinguishable from "no I/O here", which is the failure mode this pass
+/// exists to prevent, so the path is normalised once rather than every entry
+/// guessing.
+fn strip_generics(path: &str) -> String {
+    let mut out = String::with_capacity(path.len());
+    let mut depth = 0usize;
+    for c in path.chars() {
+        match c {
+            '<' => depth += 1,
+            '>' => depth = depth.saturating_sub(1),
+            _ if depth == 0 => out.push(c),
+            _ => {}
+        }
+    }
+    while out.contains("::::") {
+        out = out.replace("::::", "::");
+    }
+    out
+}
+
 /// What we learned about one function, before the call-graph closure runs.
 struct FnFacts {
     span: Span,
@@ -197,7 +222,7 @@ struct CallScan<'a, 'tcx> {
 
 impl<'a, 'tcx> CallScan<'a, 'tcx> {
     fn record(&mut self, did: DefId, span: Span) {
-        let path = self.cx.tcx.def_path_str(did);
+        let path = strip_generics(&self.cx.tcx.def_path_str(did));
         if self.direct_io.is_none()
             && let Some(hit) = DENY_SET.iter().find(|p| path.starts_with(**p))
         {
@@ -234,8 +259,14 @@ impl<'a, 'tcx> Visitor<'tcx> for CallScan<'a, 'tcx> {
         match ex.kind {
             ExprKind::Call(callee, _) => {
                 if let ExprKind::Path(ref qpath) = callee.kind {
+                    use rustc_hir::def::{DefKind, Res};
                     match self.cx.qpath_res(qpath, callee.hir_id) {
-                        rustc_hir::def::Res::Def(_, did) => self.record(did, ex.span),
+                        // A tuple-struct or enum-variant constructor is not a
+                        // call that can reach I/O. Reporting `Self(bytes)` as
+                        // "the call graph cannot see past this" is noise that
+                        // buries real findings.
+                        Res::Def(DefKind::Ctor(..), _) | Res::SelfCtor(_) => {}
+                        Res::Def(_, did) => self.record(did, ex.span),
                         _ => self
                             .unresolved
                             .push((ex.span, "call through an unresolved path".to_string())),
@@ -258,6 +289,22 @@ impl<'a, 'tcx> Visitor<'tcx> for CallScan<'a, 'tcx> {
             ExprKind::InlineAsm(_) => self
                 .unresolved
                 .push((ex.span, "inline `asm!` — opaque to the call graph".to_string())),
+            // Descend into closure bodies.
+            //
+            // An `async fn`'s body in HIR IS a closure, and `check_fn` returns
+            // early for `FnKind::Closure`, so without this every async function
+            // was recorded with ZERO callees and its body was never analysed.
+            // That is not a corner case here: 153 of ~571 functions in
+            // `nucleus-node` and 21 of ~376 in `portcullis-effects` are `async
+            // fn`, and this pass is a CI gate over both. Its green board did not
+            // cover them.
+            //
+            // `walk_expr` visits the closure EXPRESSION; the body is a separate
+            // `Body` reached through the HIR map.
+            ExprKind::Closure(closure) => {
+                let body = self.cx.tcx.hir_body(closure.body);
+                self.visit_body(body);
+            }
             _ => {}
         }
         walk_expr(self, ex);


### PR DESCRIPTION
## The bug

`check_fn` returns early for `FnKind::Closure`, and **an `async fn`'s body *is* a closure**. `walk_expr` visits a closure *expression* but not its body, which is a separate `Body` reached through the HIR map.

So every async function was recorded with **zero callees** and its body never analysed — in a pass that is a **CI gate** over crates where `async fn` is the majority idiom:

- `nucleus-node`: **153 of ~571** functions
- `portcullis-effects`: **21 of ~376**

## Measured — same corpus, only the pass changed

| crate | unmediated before | after | unresolved before | after |
|---|---:|---:|---:|---:|
| `portcullis-effects` | 13 | 13 | 39 | **17** |
| `nucleus-node` | 27 | **41** | 93 | **59** |

**Fourteen unmediated paths in `nucleus-node` were being hidden.** The gate's green board never covered them — it could not see the code.

This is the same shape as the other findings this week (a check that passes because it isn't looking), except this one was already being relied upon.

## Two further fixes, both found while debugging the first

**`def_path_str` renders generics.** A call on a parameterised type comes back as `nucleus::Executor::<'a>::run_args`, so a deny-set entry that doesn't anticipate the parameterisation silently never matches — and a miss is indistinguishable from "no I/O here", which is exactly the failure mode this pass exists to prevent. Paths are now normalised once rather than every entry guessing.

**Constructors are not unresolvable calls.** `Self(bytes)` was reported as *"the call graph cannot see past this"* — over half the unresolved output on both crates, burying actionable reports under noise that can never be actioned.

## What this PR does not do

**The 14 new findings are not triaged.** This change makes the pass *see*; whether each path is a real unmediated effect or a deny-set false positive is separate work, and bundling a triage with the fix makes both harder to review. The gate is currently non-blocking, so surfacing them doesn't break CI.

## Provenance

Found while building the source-side dual (`observed`, #2137), which had the identical bug — and where it was caught **only because that pass had an acceptance test that failed**. This one had no such test, which is why it went unnoticed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UA8kchV3eadjGv6BmJXfqm