### PR TITLE
Build the lineage: the first real provenance edges on the live path

### DIFF
--- a/crates/nucleus-ifc-kernel/src/ifc_api.rs
+++ b/crates/nucleus-ifc-kernel/src/ifc_api.rs
@@ -401,7 +401,7 @@ impl FlowTracker {
     /// and [`observe_with_content_hash`](Self::observe_with_content_hash): the
     /// intrinsic-label parent fold, ceiling ratchet, and node push, threading an
     /// optional content hash into node storage. Existing callers pass `None`.
-    fn observe_with_parents_and_hash(
+    pub fn observe_with_parents_and_hash(
         &mut self,
         kind: NodeKind,
         parents: &[u64],
@@ -806,6 +806,30 @@ impl FlowTracker {
     }
 
     /// Check if any node in the tracker has adversarial integrity.
+    /// The most recently observed node carrying `Adversarial` integrity.
+    ///
+    /// Used to attach a conservative provenance edge: when the proxy records
+    /// content the agent authored, it cannot know which prior nodes influenced
+    /// that content, so it attaches the latest adversarial one. That is an
+    /// OVER-approximation — the safe direction — and it is sufficient for the
+    /// label, because `propagate_label` JOINS parent labels: one adversarial
+    /// parent makes the child adversarial.
+    ///
+    /// Returning one node rather than all of them is deliberate. `MAX_PARENTS`
+    /// is 8, so attaching every adversarial node would fail with
+    /// `TooManyParents` on a long session. The resulting graph is therefore
+    /// INCOMPLETE — it records a real edge, not every real edge — while the
+    /// label it produces is correct. The session ceiling remains the backstop
+    /// for everything the graph does not capture.
+    pub fn latest_adversarial_node(&self) -> Option<u64> {
+        self.nodes
+            .iter()
+            .enumerate()
+            .rev()
+            .find(|(_, (_, l, _, _))| l.integrity == IntegLevel::Adversarial)
+            .map(|(i, _)| (i + 1) as u64)
+    }
+
     pub fn is_tainted(&self) -> bool {
         self.nodes
             .iter()

--- a/crates/nucleus-tool-proxy/src/ingest.rs
+++ b/crates/nucleus-tool-proxy/src/ingest.rs
@@ -1,0 +1,132 @@
+//! Ingest observation — where external bytes become flow-graph nodes.
+//!
+//! Extracted from `main.rs` to stay under the line ratchet, and because these
+//! belong together: every one of them answers "what node does this content
+//! become, and what does it derive from?".
+//!
+//! The provenance parent is derived INSIDE `http_observe_authored` rather than
+//! at the call site. That is deliberate — when the caller supplied it, a
+//! perturbation replacing it with `None` left every test green, because the unit
+//! tests drive the `FlowTracker` directly and the handlers need a live sandbox to
+//! exercise. Making the omission unrepresentable is the fix; a better test is
+//! not available at this layer.
+
+use nucleus::portcullis::NodeKind;
+use tracing::warn;
+
+use crate::{ingest_content_hash, AppState};
+
+/// Observe a data-ingest node in the session flow tracker after a *successful*
+/// read/fetch (#1633), mirroring the MCP server. `WebContent` is an adversarial
+/// taint source; `FileRead` contributes to the confidentiality ceiling. Must be
+/// called only on success paths so a denied/failed op never leaks taint.
+///
+/// InputsAuthorized brick 3: the caller passes the *actual ingested bytes*, whose
+/// recomputed SHA-256 is recorded on the node via `observe_with_content_hash`.
+/// Label/taint behaviour is identical to the old bare `observe` — only the hash
+/// is added.
+pub(crate) async fn http_observe_flow(
+    state: &AppState,
+    kind: NodeKind,
+    bytes: &[u8],
+) -> Option<u64> {
+    http_observe_flow_from(state, kind, bytes, &[]).await
+}
+
+/// Observe an ingest with explicit PARENTS, returning the new node's id.
+///
+/// The id used to be discarded, which is why the flow graph was edgeless in
+/// production: `observe_with_content_hash` passes `&[]` and nothing kept the
+/// handle needed to reference a node later. Both halves are fixed here.
+///
+/// Uses the hashing variant: `scripts/check-ingest-hashed.sh` fails the build on
+/// a non-hashing observe in the agent path, because a node with no content hash
+/// is a node whose bytes were never witnessed.
+/// Observe content the AGENT AUTHORED, deriving the provenance parent here
+/// rather than at the call site.
+///
+/// The derivation is inside this function on purpose. When the caller passed
+/// parents in, a perturbation that replaced them with `None` left every test
+/// green — the unit tests drive the `FlowTracker` directly, so they prove the
+/// mechanism works, not that the handler uses it, and the handler needs a live
+/// sandbox to exercise. Same shape as #2127: the fix is not a better test, it is
+/// making the omission unrepresentable. A caller can no longer forget the edge,
+/// because it does not supply it.
+pub(crate) async fn http_observe_authored(
+    state: &AppState,
+    kind: NodeKind,
+    bytes: &[u8],
+) -> Option<u64> {
+    // Conservative: the proxy cannot know which prior nodes influenced what the
+    // agent wrote, so it attaches the latest adversarial one and
+    // over-approximates. Over-approximation only ever ADDS taint.
+    let parent = state.flow_tracker.lock().await.latest_adversarial_node();
+    let parents: Vec<u64> = parent.into_iter().collect();
+    http_observe_flow_from(state, kind, bytes, &parents).await
+}
+
+pub(crate) async fn http_observe_flow_from(
+    state: &AppState,
+    kind: NodeKind,
+    bytes: &[u8],
+    parents: &[u64],
+) -> Option<u64> {
+    let hash = ingest_content_hash(bytes);
+    let mut flow = state.flow_tracker.lock().await;
+    match flow.observe_with_parents_and_hash(kind, parents, Some(hash)) {
+        Ok(id) => Some(id),
+        Err(e) => {
+            warn!(?kind, error = %e, "flow-tracker observe failed");
+            None
+        }
+    }
+}
+
+/// The flow node kind command output is observed as.
+///
+/// Extracted to a constant so the CHOICE is pinned by a test rather than
+/// inferred. A test asserting that `McpToolResult` is adversarial, plus a test
+/// that an `McpToolResult` observation trips the gate, BOTH pass even if this
+/// call site observes something weaker — verified by perturbation: swapping in
+/// `ToolResponse` (Untrusted, not Adversarial) failed nothing until this
+/// constant existed to assert against.
+pub(crate) const COMMAND_OUTPUT_NODE_KIND: NodeKind = NodeKind::McpToolResult;
+
+/// Taint COMMAND OUTPUT as adversarial — the HTTP twin of
+/// `mcp::Server::observe_tool_result`.
+///
+/// `/v1/run` returns arbitrary subprocess stdout/stderr to the agent, which is
+/// external bytes by any definition: `curl` through bash is an ingest the proxy
+/// cannot distinguish from `ls`. Every other HTTP handler that returns external
+/// bytes observes them (`read_file`, `web_fetch`, `glob_search`, `grep_search`,
+/// `web_search`); this one did not, so bash-fetched content entered the session
+/// with no flow node at all.
+///
+/// The asymmetry was the real defect. `NUCLEUS_PARANOID_TOOL_IO=1` has always
+/// covered the MCP transport (`mcp.rs:675`) and never covered HTTP, so an
+/// operator who enabled it got partial coverage with nothing to indicate half
+/// their surface was uncovered — worse than the flag not existing, because it
+/// reads as a decision that was made.
+///
+/// Same env var, same default (OFF), same node kind, and the same reason for the
+/// default that `observe_tool_result` documents: blanket-tainting the proxy's own
+/// command output makes a session "one privileged action then locked"
+/// (run-tests → cannot commit). That is an operator's policy call, not ours.
+///
+/// Observed regardless of exit status: a failing command's stderr is still bytes
+/// the agent read. Called only after the command actually RAN, so a denied
+/// operation still leaks no taint.
+pub(crate) async fn http_observe_command_output(state: &AppState, stdout: &[u8], stderr: &[u8]) {
+    let paranoid = std::env::var("NUCLEUS_PARANOID_TOOL_IO")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
+    if !paranoid {
+        return;
+    }
+    // Both streams in one node: they are one ingest event, and content-addressing
+    // them separately would imply two independent sources.
+    let mut bytes = Vec::with_capacity(stdout.len() + stderr.len());
+    bytes.extend_from_slice(stdout);
+    bytes.extend_from_slice(stderr);
+    http_observe_flow(state, COMMAND_OUTPUT_NODE_KIND, &bytes).await;
+}

--- a/crates/nucleus-tool-proxy/src/main.rs
+++ b/crates/nucleus-tool-proxy/src/main.rs
@@ -34,6 +34,7 @@ mod cert_bridge;
 mod dlc_admission;
 mod exit_report;
 mod identity_fusion;
+mod ingest;
 mod lockdown_client;
 #[cfg(feature = "mcp")]
 mod mcp;
@@ -357,19 +358,20 @@ pub(crate) struct AppState {
     /// blocks outbound for all); true multi-tenancy would require keying the
     /// kernel AND tracker together — out of scope here.
     pub(crate) flow_tracker: Arc<tokio::sync::Mutex<FlowTracker>>,
-    /// Paths written while the session was integrity-tainted.
+    /// Path → the flow node recording the content last written there.
     ///
-    /// Closes a disk-laundering channel: tainted bytes land in a file, the file
-    /// is read back, and the read produces a `FileRead` node whose intrinsic
-    /// integrity is `Trusted` — so the taint vanishes.
+    /// This is #2135's laundered-path SET, generalised from a boolean into an
+    /// EDGE. That version answered "was this path written while tainted?"; this
+    /// one answers "which node produced the content at this path?", and the
+    /// taint answer falls out of it — a read whose parent is a tainted write
+    /// node inherits `Adversarial` through `propagate_label`, so the special
+    /// case #2135 hand-coded becomes a consequence of the graph.
     ///
-    /// This is EMPTY in the default configuration and cannot become non-empty:
-    /// with `NUCLEUS_GRADED_TAINT` off, `WriteFiles`/`EditFiles`/`RunBash` are
-    /// all DENIED in a tainted session, so tainted bytes never reach disk. The
-    /// channel opens only when grading converts those denials into approvals and
-    /// a human approves one. `RunBash` stays denied even when graded, so there
-    /// is no bash-written blind spot.
-    pub(crate) laundered_paths: Arc<tokio::sync::Mutex<std::collections::HashSet<String>>>,
+    /// The proxy may only record edges it MEDIATED BOTH ENDS OF. It wrote these
+    /// bytes and it read them back, so this edge is established, not declared —
+    /// which matters because the agent is the compromised party under the threat
+    /// model and cannot be asked to report its own data flow.
+    pub(crate) path_provenance: Arc<tokio::sync::Mutex<std::collections::HashMap<String, u64>>>,
     /// Provenance-verified, taint-labeled agent memory (next-bet #1). A write
     /// goes through `verified_admit`; a recall observes the record's own label
     /// into `flow_tracker` so the IFC gate governs whether it may inform an
@@ -1559,7 +1561,7 @@ async fn main() -> Result<(), ApiError> {
     enforce_hmac_key_quality(&args.auth_secret, vsock_binding.is_some());
 
     let state = AppState {
-        laundered_paths: Arc::new(tokio::sync::Mutex::new(std::collections::HashSet::new())),
+        path_provenance: Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new())),
         dlc_provisioned,
         runtime: Arc::new(runtime),
         approvals,
@@ -2480,92 +2482,6 @@ pub(crate) fn ingest_content_hash(bytes: &[u8]) -> nucleus_ifc_kernel::ContentHa
     nucleus_ifc_kernel::ContentHash::from_bytes(digest)
 }
 
-/// Observe a data-ingest node in the session flow tracker after a *successful*
-/// read/fetch (#1633), mirroring the MCP server. `WebContent` is an adversarial
-/// taint source; `FileRead` contributes to the confidentiality ceiling. Must be
-/// called only on success paths so a denied/failed op never leaks taint.
-///
-/// InputsAuthorized brick 3: the caller passes the *actual ingested bytes*, whose
-/// recomputed SHA-256 is recorded on the node via `observe_with_content_hash`.
-/// Label/taint behaviour is identical to the old bare `observe` — only the hash
-/// is added.
-async fn http_observe_flow(state: &AppState, kind: NodeKind, bytes: &[u8]) {
-    let hash = ingest_content_hash(bytes);
-    let mut flow = state.flow_tracker.lock().await;
-    if let Err(e) = flow.observe_with_content_hash(kind, hash) {
-        warn!(?kind, error = %e, "flow-tracker observe failed");
-    }
-}
-
-/// The flow node kind command output is observed as.
-///
-/// Extracted to a constant so the CHOICE is pinned by a test rather than
-/// inferred. A test asserting that `McpToolResult` is adversarial, plus a test
-/// that an `McpToolResult` observation trips the gate, BOTH pass even if this
-/// call site observes something weaker — verified by perturbation: swapping in
-/// `ToolResponse` (Untrusted, not Adversarial) failed nothing until this
-/// constant existed to assert against.
-pub(crate) const COMMAND_OUTPUT_NODE_KIND: NodeKind = NodeKind::McpToolResult;
-
-/// Which flow node kind a file read is observed as.
-///
-/// Extracted so the CHOICE is assertable. Perturbation showed why: with the
-/// branch inlined in `read_file` — a handler that needs a live sandbox to
-/// exercise — replacing the laundered arm with a plain `FileRead` (making the
-/// whole fix a no-op) passed every test, because the tests asserted the
-/// constant's properties and the tracker's behaviour but never what the handler
-/// actually selects.
-pub(crate) fn read_node_kind(is_laundered: bool) -> NodeKind {
-    if is_laundered {
-        // A path written while tainted re-enters adversarial, restoring the
-        // taint a disk round-trip would otherwise strip.
-        COMMAND_OUTPUT_NODE_KIND
-    } else {
-        // Ordinary reads stay trusted — labelling all reads adversarial would
-        // lock every session on its first read.
-        NodeKind::FileRead
-    }
-}
-
-/// Taint COMMAND OUTPUT as adversarial — the HTTP twin of
-/// `mcp::Server::observe_tool_result`.
-///
-/// `/v1/run` returns arbitrary subprocess stdout/stderr to the agent, which is
-/// external bytes by any definition: `curl` through bash is an ingest the proxy
-/// cannot distinguish from `ls`. Every other HTTP handler that returns external
-/// bytes observes them (`read_file`, `web_fetch`, `glob_search`, `grep_search`,
-/// `web_search`); this one did not, so bash-fetched content entered the session
-/// with no flow node at all.
-///
-/// The asymmetry was the real defect. `NUCLEUS_PARANOID_TOOL_IO=1` has always
-/// covered the MCP transport (`mcp.rs:675`) and never covered HTTP, so an
-/// operator who enabled it got partial coverage with nothing to indicate half
-/// their surface was uncovered — worse than the flag not existing, because it
-/// reads as a decision that was made.
-///
-/// Same env var, same default (OFF), same node kind, and the same reason for the
-/// default that `observe_tool_result` documents: blanket-tainting the proxy's own
-/// command output makes a session "one privileged action then locked"
-/// (run-tests → cannot commit). That is an operator's policy call, not ours.
-///
-/// Observed regardless of exit status: a failing command's stderr is still bytes
-/// the agent read. Called only after the command actually RAN, so a denied
-/// operation still leaks no taint.
-async fn http_observe_command_output(state: &AppState, stdout: &[u8], stderr: &[u8]) {
-    let paranoid = std::env::var("NUCLEUS_PARANOID_TOOL_IO")
-        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-        .unwrap_or(false);
-    if !paranoid {
-        return;
-    }
-    // Both streams in one node: they are one ingest event, and content-addressing
-    // them separately would imply two independent sources.
-    let mut bytes = Vec::with_capacity(stdout.len() + stderr.len());
-    bytes.extend_from_slice(stdout);
-    bytes.extend_from_slice(stderr);
-    http_observe_flow(state, COMMAND_OUTPUT_NODE_KIND, &bytes).await;
-}
-
 async fn read_file(
     State(state): State<AppState>,
     _headers: HeaderMap,
@@ -2699,12 +2615,24 @@ async fn read_file(
     // Brick 3: content-address the exact bytes read.
     // A path written during a tainted session re-enters as adversarial, not as a
     // trusted file read — otherwise a round-trip through disk strips the taint.
-    let is_laundered = state.laundered_paths.lock().await.contains(&observed_path);
-    if is_laundered {
-        warn!(path = %observed_path, "reading a path written while tainted; observing as adversarial");
+    // If the proxy wrote this path, the read DERIVES from that write — a real
+    // edge, because the proxy mediated both ends. `propagate_label` joins the
+    // parent's label in, so a read of a tainted write is adversarial without any
+    // special case: #2135 selected a different NodeKind by boolean; the graph now
+    // produces the same outcome as a consequence.
+    let parents: Vec<u64> = state
+        .path_provenance
+        .lock()
+        .await
+        .get(&observed_path)
+        .copied()
+        .into_iter()
+        .collect();
+    if !parents.is_empty() {
+        warn!(path = %observed_path, parent = parents[0],
+              "read derives from a prior write; attaching provenance edge");
     }
-    let read_kind = read_node_kind(is_laundered);
-    http_observe_flow(&state, read_kind, contents.as_bytes()).await;
+    ingest::http_observe_flow_from(&state, NodeKind::FileRead, contents.as_bytes(), &parents).await;
     Ok(Json(ReadResponse { contents }))
 }
 
@@ -2888,16 +2816,26 @@ async fn write_file(
     // If this write succeeded while the session was tainted, the bytes on disk
     // may carry that taint. Record the path so a later read of it is not treated
     // as a trusted file read. Only reachable under grading — see the field docs.
+    // Record a node for the content now at this path, so a later read of it has
+    // something to derive FROM.
+    //
+    // Its parent is the latest adversarial node, when there is one. The proxy
+    // cannot know which prior nodes influenced what the agent chose to write —
+    // that happens inside the agent — so it attaches the conservative edge and
+    // over-approximates. Over-approximation is the safe direction: it can only
+    // add taint, never clear it.
+    // Record a node for the content now at this path, so a later read has
+    // something to derive FROM. The provenance parent is attached inside
+    // `http_observe_authored`, where it cannot be omitted.
     {
-        let tainted = state.flow_tracker.lock().await.is_tainted();
-        if tainted {
-            let mut laundered = state.laundered_paths.lock().await;
-            laundered.insert(written_path.clone());
-            warn!(
-                path = %written_path,
-                "write taken while session tainted; later reads of this path \
-                 will be treated as adversarial"
-            );
+        if let Some(node) =
+            ingest::http_observe_authored(&state, NodeKind::FileRead, req.contents.as_bytes()).await
+        {
+            state
+                .path_provenance
+                .lock()
+                .await
+                .insert(written_path.clone(), node);
         }
     }
 
@@ -3137,7 +3075,7 @@ async fn run_command(
     }) {
         warn!(error = %e, "verdict recording failed -- audit gap");
     }
-    http_observe_command_output(&state, &output.stdout, &output.stderr).await;
+    ingest::http_observe_command_output(&state, &output.stdout, &output.stderr).await;
 
     Ok(Json(RunResponse {
         status: output.status.code().unwrap_or(-1),
@@ -3372,7 +3310,7 @@ async fn web_fetch(
     // IFC: web content is an adversarial taint source — taint the session so
     // subsequent outbound actions are denied with IfcUnsafe (lethal trifecta, #1633).
     // Brick 3: content-address the exact fetched body bytes.
-    http_observe_flow(&state, NodeKind::WebContent, &bytes).await;
+    ingest::http_observe_flow(&state, NodeKind::WebContent, &bytes).await;
     Ok(Json(WebFetchResponse {
         status,
         headers: response_headers,
@@ -3529,7 +3467,7 @@ async fn glob_search(
     // IFC: a successful glob brings file data into the session (#1633).
     // Brick 3: content-address the exact match listing ingested.
     let listing = matches.join("\n");
-    http_observe_flow(&state, NodeKind::FileRead, listing.as_bytes()).await;
+    ingest::http_observe_flow(&state, NodeKind::FileRead, listing.as_bytes()).await;
     Ok(Json(GlobResponse {
         matches,
         truncated: if truncated { Some(true) } else { None },
@@ -3743,7 +3681,7 @@ async fn grep_search(
     // Brick 3: content-address the exact match set ingested (deterministic
     // serialization of the real matched bytes).
     let match_bytes = serde_json::to_vec(&matches).unwrap_or_default();
-    http_observe_flow(&state, NodeKind::FileRead, &match_bytes).await;
+    ingest::http_observe_flow(&state, NodeKind::FileRead, &match_bytes).await;
     Ok(Json(GrepResponse {
         matches,
         truncated: if truncated { Some(true) } else { None },
@@ -3952,7 +3890,7 @@ async fn web_search(
     }
     // IFC: web search results are an adversarial taint source (#1633).
     // Brick 3: content-address the exact search-backend response bytes.
-    http_observe_flow(&state, NodeKind::WebContent, &search_bytes).await;
+    ingest::http_observe_flow(&state, NodeKind::WebContent, &search_bytes).await;
     Ok(Json(WebSearchResponse { results }))
 }
 

--- a/crates/nucleus-tool-proxy/src/tests_main.rs
+++ b/crates/nucleus-tool-proxy/src/tests_main.rs
@@ -895,12 +895,13 @@ mod command_output_taint {
     /// perturbation confirmed exactly that before this test existed.
     #[test]
     fn command_output_is_observed_as_an_adversarial_kind() {
-        let label = nucleus_ifc_kernel::flow::intrinsic_label(crate::COMMAND_OUTPUT_NODE_KIND, 0);
+        let label =
+            nucleus_ifc_kernel::flow::intrinsic_label(crate::ingest::COMMAND_OUTPUT_NODE_KIND, 0);
         assert_eq!(
             label.integrity,
             nucleus_ifc_kernel::IntegLevel::Adversarial,
             "command output is observed as {:?}, which cannot trip the egress gate",
-            crate::COMMAND_OUTPUT_NODE_KIND
+            crate::ingest::COMMAND_OUTPUT_NODE_KIND
         );
     }
 
@@ -908,7 +909,7 @@ mod command_output_taint {
     #[test]
     fn http_and_mcp_observe_tool_output_identically() {
         assert_eq!(
-            crate::COMMAND_OUTPUT_NODE_KIND,
+            crate::ingest::COMMAND_OUTPUT_NODE_KIND,
             NodeKind::McpToolResult,
             "HTTP and MCP would enforce different policies under NUCLEUS_PARANOID_TOOL_IO"
         );
@@ -1018,18 +1019,19 @@ mod disk_laundering {
         );
     }
 
-    /// The laundered read must be observed as a kind that actually re-taints.
-    /// Asserted against the constant the read path uses, not a kind named again
-    /// here — naming it twice is how this test passes while the handler observes
-    /// something weaker.
+    /// Retained from the boolean era: `COMMAND_OUTPUT_NODE_KIND` still governs
+    /// /v1/run output (#2134), which has no path to attach an edge to. The READ
+    /// path no longer uses it — see `mod provenance_edges` for the mechanism
+    /// that replaced it.
     #[test]
-    fn a_laundered_read_is_observed_as_a_retainting_kind() {
-        let label = nucleus_ifc_kernel::flow::intrinsic_label(crate::COMMAND_OUTPUT_NODE_KIND, 0);
+    fn command_output_is_still_observed_as_a_retainting_kind() {
+        let label =
+            nucleus_ifc_kernel::flow::intrinsic_label(crate::ingest::COMMAND_OUTPUT_NODE_KIND, 0);
         assert_eq!(
             label.integrity,
             nucleus_ifc_kernel::IntegLevel::Adversarial,
             "a laundered read observed as {:?} would not restore the taint",
-            crate::COMMAND_OUTPUT_NODE_KIND
+            crate::ingest::COMMAND_OUTPUT_NODE_KIND
         );
     }
 
@@ -1045,29 +1047,10 @@ mod disk_laundering {
         );
     }
 
-    /// **What the read path actually selects** — asserted against the function
-    /// the handler calls. Without this, replacing the laundered arm with a plain
-    /// `FileRead` (a total no-op) passes every other test here; verified by
-    /// perturbation before this test existed.
-    #[test]
-    fn the_read_path_selects_a_retainting_kind_for_a_laundered_path() {
-        let laundered = nucleus_ifc_kernel::flow::intrinsic_label(crate::read_node_kind(true), 0);
-        assert_eq!(
-            laundered.integrity,
-            nucleus_ifc_kernel::IntegLevel::Adversarial,
-            "laundered reads are observed as {:?}, which does not restore taint",
-            crate::read_node_kind(true)
-        );
-        let ordinary = nucleus_ifc_kernel::flow::intrinsic_label(crate::read_node_kind(false), 0);
-        assert_eq!(
-            ordinary.integrity,
-            nucleus_ifc_kernel::IntegLevel::Trusted,
-            "ordinary reads must stay trusted"
-        );
-    }
-
-    /// End to end on the flow tracker: re-observing a laundered read restores
-    /// the taint that the disk round-trip stripped.
+    /// End to end on the flow tracker. NOTE this exercises the node-kind route
+    /// that /v1/run still uses; the FILE-read route now restores taint through a
+    /// provenance edge instead — `provenance_edges::a_read_inherits_the_taint_
+    /// of_the_write_it_derives_from` is the test for that.
     #[test]
     fn re_observing_a_laundered_read_restores_the_taint() {
         // A plain file read leaves the session clean — the hole.
@@ -1081,7 +1064,7 @@ mod disk_laundering {
         // The same read, recognised as laundered, does.
         let mut fixed = FlowTracker::new();
         fixed
-            .observe(crate::COMMAND_OUTPUT_NODE_KIND)
+            .observe(crate::ingest::COMMAND_OUTPUT_NODE_KIND)
             .expect("laundered read");
         assert!(
             fixed.is_tainted(),
@@ -1095,5 +1078,123 @@ mod disk_laundering {
             r.is_err(),
             "after a laundered read the session must not act outbound; got {r:?}"
         );
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Provenance edges — lineage the proxy MEDIATED, not lineage it was told
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// Production observed every flow node with no parents, so the causal DAG was
+// edgeless and every per-node check passed trivially. These are the first real
+// edges: the proxy wrote the bytes and read them back, so it established the
+// derivation itself. It never asks the agent, which is the compromised party
+// under this threat model and cannot be trusted to report its own data flow.
+mod provenance_edges {
+    use super::ifc_http_enforcement::{decide_capturing, permissive_kernel};
+    use super::*;
+
+    /// The parent's label joins into the child's, so a read of a tainted write
+    /// is adversarial WITHOUT a special case. #2135 achieved this by selecting a
+    /// different NodeKind from a boolean; it is now a consequence of the graph.
+    #[test]
+    fn a_read_inherits_the_taint_of_the_write_it_derives_from() {
+        let mut flow = FlowTracker::new();
+        let web = flow
+            .observe(NodeKind::WebContent)
+            .expect("taint the session");
+
+        // The write, parented on the adversarial node (what the live path does).
+        let write = flow
+            .observe_with_parents(NodeKind::FileRead, &[web])
+            .expect("write node");
+
+        // The read, parented on the write.
+        let read = flow
+            .observe_with_parents(NodeKind::FileRead, &[write])
+            .expect("read node");
+
+        let label = flow.label(read).expect("read has a label");
+        assert_eq!(
+            label.integrity,
+            nucleus_ifc_kernel::IntegLevel::Adversarial,
+            "taint must reach the read through the edge, not by special case"
+        );
+    }
+
+    /// The contrast that makes the above meaningful: with NO edge, the same read
+    /// is trusted. This is the edgeless production behaviour being fixed — and if
+    /// this test ever fails, `FileRead` has stopped being trusted and the one
+    /// above proves nothing.
+    #[test]
+    fn without_the_edge_the_same_read_is_trusted() {
+        let mut flow = FlowTracker::new();
+        flow.observe(NodeKind::WebContent)
+            .expect("taint the session");
+        let orphan = flow
+            .observe_with_parents(NodeKind::FileRead, &[])
+            .expect("parentless read");
+        assert_eq!(
+            flow.label(orphan).expect("label").integrity,
+            nucleus_ifc_kernel::IntegLevel::Trusted,
+            "a parentless FileRead is trusted — this is what the edge fixes"
+        );
+    }
+
+    /// A clean session's write/read chain stays clean, so the edge is not just
+    /// tainting everything it touches.
+    #[test]
+    fn a_clean_chain_stays_clean() {
+        let mut flow = FlowTracker::new();
+        let write = flow
+            .observe_with_parents(NodeKind::FileRead, &[])
+            .expect("write");
+        let read = flow
+            .observe_with_parents(NodeKind::FileRead, &[write])
+            .expect("read");
+        assert!(!flow.is_tainted(), "no adversarial node was ever observed");
+        assert_eq!(
+            flow.label(read).expect("label").integrity,
+            nucleus_ifc_kernel::IntegLevel::Trusted
+        );
+    }
+
+    /// End to end: after reading a laundered path the session cannot act.
+    #[test]
+    fn a_laundered_read_still_blocks_the_next_outbound_action() {
+        let mut flow = FlowTracker::new();
+        let web = flow.observe(NodeKind::WebContent).unwrap();
+        let write = flow
+            .observe_with_parents(NodeKind::FileRead, &[web])
+            .unwrap();
+        let _read = flow
+            .observe_with_parents(NodeKind::FileRead, &[write])
+            .unwrap();
+
+        let mut kernel = permissive_kernel();
+        let r = decide_capturing(&mut kernel, &flow, Operation::WriteFiles, "out.txt").0;
+        assert!(
+            r.is_err(),
+            "must not act outbound after a laundered read; got {r:?}"
+        );
+    }
+
+    /// `latest_adversarial_node` must actually find one, and must return `None`
+    /// on a clean session — otherwise the write path would attach a bogus parent
+    /// or none at all, and both failures are silent.
+    #[test]
+    fn latest_adversarial_node_is_selective() {
+        let mut clean = FlowTracker::new();
+        clean.observe(NodeKind::UserPrompt).unwrap();
+        assert_eq!(
+            clean.latest_adversarial_node(),
+            None,
+            "clean session has none"
+        );
+
+        let mut dirty = FlowTracker::new();
+        dirty.observe(NodeKind::UserPrompt).unwrap();
+        let web = dirty.observe(NodeKind::WebContent).unwrap();
+        assert_eq!(dirty.latest_adversarial_node(), Some(web));
     }
 }


### PR DESCRIPTION
Production observed every flow node with `&[]` parents, so the causal DAG was **edgeless** — which is why `check_flow` and `check_action_safety` have no production callers, and why documentation claiming per-node causal precision could not be true. These are the first edges.

## Where the edges come from matters more than that there are edges

The agent is the **compromised party** under this threat model, so it cannot be asked to report its own data flow — a per-node gate fed by client-declared lineage is defeated by declaring none.

So the proxy only records edges it **mediated both ends of**. It wrote these bytes and it read them back; the derivation is *established*, not declared.

```
write(P, B)  →  a node for the content now at P, parented on the latest adversarial node
read(P)      →  a node parented on P's write node
```

`propagate_label` **joins** parent labels, so a read of a tainted write inherits `Adversarial` with no special case.

## This subsumes #2135

`read_node_kind` — the boolean selector that picked a different `NodeKind` for laundered paths — is now **dead code and deleted**. The behaviour it hand-coded is a consequence of the graph, and the graph records *which* node rather than merely "was tainted."

## Two honest approximations, both in the safe direction

**The write's parent is the latest adversarial node, not all of them.** `MAX_PARENTS` is 8, so attaching every one fails on a long session. Since the label is a join, one adversarial parent gives the correct **label** while the **graph** stays incomplete — a real edge, not every real edge. The session ceiling remains the backstop.

**The proxy cannot know which prior nodes influenced what the agent chose to write.** It attaches the conservative edge and over-approximates, which can only *add* taint, never clear it.

## Fourth vacuous-test instance — and the first I predicted before running it

The unit tests drive the `FlowTracker` directly, so they prove the mechanism works, not that the handler uses it. Replacing the parent with `None` left all five green.

**No pure-function extraction fixes this one** — the perturbation removed a *call*, not logic. So the remedy is #2127's: the derivation moved **inside** `http_observe_authored`, where a caller cannot omit it. Deleting the edge now **fails the build** (helper goes dead, `written_path` unused) rather than passing tests.

Also: `http_observe_flow` now returns the node id it creates. Discarding it was half the reason the graph was edgeless — nothing kept the handle needed to reference a node later.

## Verification

30 suites green · clippy `-D warnings` clean · ratchet OK (ingest helpers extracted to `ingest.rs`; main.rs 5011 → 4905) · `check-ingest-hashed.sh` passes (uses the hashing observe variant).

`ifc_api.rs` gains two additive items and is **not** an Aeneas extraction root (`decide_pure` and `extracted/**` are), so the fence sees no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UA8kchV3eadjGv6BmJXfqm