### PR TITLE
The test suite committed to the developer's repo

### DIFF
--- a/crates/portcullis-effects/src/lib.rs
+++ b/crates/portcullis-effects/src/lib.rs
@@ -414,12 +414,40 @@ pub struct SearchResult {
 /// obtain one is through [`production_effects`] / [`production_effects_concrete`],
 /// which always wrap it in `PolicyEnforced` and require a policy.
 pub struct RealEffects {
+    /// Working directory for git subprocesses.
+    ///
+    /// `None` means the process CWD, which is the historical behaviour. Naming
+    /// it matters because `git commit` is not scoped by its arguments: it acts
+    /// on whatever repository the process happens to be standing in. A caller
+    /// that means "commit the agent's workspace" and a caller that means
+    /// "commit wherever I am" are different callers, and until this field
+    /// existed there was no way to be the first one.
+    git_dir: Option<std::path::PathBuf>,
     _private: (),
 }
 
 impl RealEffects {
     pub(crate) fn new() -> Self {
-        Self { _private: () }
+        Self {
+            git_dir: None,
+            _private: (),
+        }
+    }
+
+    /// Scope git operations to `dir` instead of the process CWD.
+    pub fn with_git_dir(dir: impl Into<std::path::PathBuf>) -> Self {
+        Self {
+            git_dir: Some(dir.into()),
+            _private: (),
+        }
+    }
+
+    /// Apply the configured working directory, if any.
+    fn in_git_dir(&self, mut cmd: std::process::Command) -> std::process::Command {
+        if let Some(dir) = &self.git_dir {
+            cmd.current_dir(dir);
+        }
+        cmd
     }
 }
 
@@ -712,8 +740,10 @@ impl NetEffect for RealEffects {
 impl GitEffect for RealEffects {
     fn commit(&self, message: &str, _authority: Authority) -> Result<String, EffectError> {
         // Stage all tracked modifications and commit.
-        let add = std::process::Command::new("git")
-            .args(["add", "-u"])
+        let mut add_cmd = std::process::Command::new("git");
+        add_cmd.args(["add", "-u"]);
+        let add = self
+            .in_git_dir(add_cmd)
             .output()
             .map_err(|e| EffectError::Io(format!("git add: {e}")))?;
         if !add.status.success() {
@@ -722,8 +752,10 @@ impl GitEffect for RealEffects {
                 stderr: String::from_utf8_lossy(&add.stderr).into_owned(),
             });
         }
-        let commit = std::process::Command::new("git")
-            .args(["commit", "-m", message])
+        let mut commit_cmd = std::process::Command::new("git");
+        commit_cmd.args(["commit", "-m", message]);
+        let commit = self
+            .in_git_dir(commit_cmd)
             .output()
             .map_err(|e| EffectError::Io(format!("git commit: {e}")))?;
         if !commit.status.success() {
@@ -738,8 +770,10 @@ impl GitEffect for RealEffects {
     }
 
     fn push(&self, remote: &str, branch: &str, _authority: Authority) -> Result<(), EffectError> {
-        let output = std::process::Command::new("git")
-            .args(["push", remote, branch])
+        let mut push_cmd = std::process::Command::new("git");
+        push_cmd.args(["push", remote, branch]);
+        let output = self
+            .in_git_dir(push_cmd)
             .output()
             .map_err(|e| EffectError::Io(format!("git push: {e}")))?;
         if output.status.success() {
@@ -1146,6 +1180,19 @@ pub fn production_effects(
 pub fn production_effects_concrete(policy: CapabilityLattice) -> PolicyEnforced<RealEffects> {
     PolicyEnforced {
         inner: RealEffects::new(),
+        policy,
+        receipts: Arc::new(crate::receipt::ReceiptLog::new()),
+    }
+}
+
+/// As [`production_effects_concrete`], with git operations scoped to `git_dir`
+/// rather than the process working directory.
+pub fn production_effects_in(
+    policy: CapabilityLattice,
+    git_dir: impl Into<std::path::PathBuf>,
+) -> PolicyEnforced<RealEffects> {
+    PolicyEnforced {
+        inner: RealEffects::with_git_dir(git_dir),
         policy,
         receipts: Arc::new(crate::receipt::ReceiptLog::new()),
     }

--- a/crates/portcullis-effects/src/lib.rs
+++ b/crates/portcullis-effects/src/lib.rs
@@ -442,12 +442,15 @@ impl RealEffects {
         }
     }
 
-    /// Apply the configured working directory, if any.
-    fn in_git_dir(&self, mut cmd: std::process::Command) -> std::process::Command {
-        if let Some(dir) = &self.git_dir {
-            cmd.current_dir(dir);
-        }
-        cmd
+    /// The directory git subprocesses run in.
+    ///
+    /// Falls back to the process CWD (and to `.` if even that is unreadable),
+    /// which is the behaviour every caller had before `git_dir` existed.
+    fn git_cwd(&self) -> std::path::PathBuf {
+        self.git_dir
+            .clone()
+            .or_else(|| std::env::current_dir().ok())
+            .unwrap_or_else(|| std::path::PathBuf::from("."))
     }
 }
 
@@ -740,10 +743,9 @@ impl NetEffect for RealEffects {
 impl GitEffect for RealEffects {
     fn commit(&self, message: &str, _authority: Authority) -> Result<String, EffectError> {
         // Stage all tracked modifications and commit.
-        let mut add_cmd = std::process::Command::new("git");
-        add_cmd.args(["add", "-u"]);
-        let add = self
-            .in_git_dir(add_cmd)
+        let add = std::process::Command::new("git")
+            .args(["add", "-u"])
+            .current_dir(self.git_cwd())
             .output()
             .map_err(|e| EffectError::Io(format!("git add: {e}")))?;
         if !add.status.success() {
@@ -752,10 +754,9 @@ impl GitEffect for RealEffects {
                 stderr: String::from_utf8_lossy(&add.stderr).into_owned(),
             });
         }
-        let mut commit_cmd = std::process::Command::new("git");
-        commit_cmd.args(["commit", "-m", message]);
-        let commit = self
-            .in_git_dir(commit_cmd)
+        let commit = std::process::Command::new("git")
+            .args(["commit", "-m", message])
+            .current_dir(self.git_cwd())
             .output()
             .map_err(|e| EffectError::Io(format!("git commit: {e}")))?;
         if !commit.status.success() {
@@ -770,10 +771,9 @@ impl GitEffect for RealEffects {
     }
 
     fn push(&self, remote: &str, branch: &str, _authority: Authority) -> Result<(), EffectError> {
-        let mut push_cmd = std::process::Command::new("git");
-        push_cmd.args(["push", remote, branch]);
-        let output = self
-            .in_git_dir(push_cmd)
+        let output = std::process::Command::new("git")
+            .args(["push", remote, branch])
+            .current_dir(self.git_cwd())
             .output()
             .map_err(|e| EffectError::Io(format!("git push: {e}")))?;
         if output.status.success() {

--- a/crates/portcullis-effects/src/runtime.rs
+++ b/crates/portcullis-effects/src/runtime.rs
@@ -559,6 +559,7 @@ impl NucleusRuntime {
             task: String::new(),
             task_token: None,
             allowed_write_paths: Vec::new(),
+            git_dir: None,
         }
     }
 
@@ -1433,9 +1434,22 @@ pub struct NucleusRuntimeBuilder {
     task: String,
     task_token: Option<VerifiedTaskRef>,
     allowed_write_paths: Vec<PathBuf>,
+    /// Working directory for git effects; `None` = the process CWD.
+    git_dir: Option<PathBuf>,
 }
 
 impl NucleusRuntimeBuilder {
+    /// Scope git effects to `dir` instead of the process working directory.
+    ///
+    /// `git commit` acts on whichever repository the process is standing in,
+    /// not on anything named in its arguments. A runtime that means to commit a
+    /// specific workspace must say so; leaving this unset keeps the historical
+    /// process-CWD behaviour.
+    pub fn git_dir(mut self, dir: impl Into<PathBuf>) -> Self {
+        self.git_dir = Some(dir.into());
+        self
+    }
+
     /// Set the policy profile.
     ///
     /// This is the recommended way to configure capabilities. If you also
@@ -1536,7 +1550,10 @@ impl NucleusRuntimeBuilder {
             .custom_policy
             .unwrap_or_else(|| self.profile.to_lattice());
 
-        let effects = crate::production_effects_concrete(policy.clone());
+        let effects = match self.git_dir {
+            Some(dir) => crate::production_effects_in(policy.clone(), dir),
+            None => crate::production_effects_concrete(policy.clone()),
+        };
         NucleusRuntime {
             profile: self.profile,
             policy,
@@ -2321,10 +2338,46 @@ mod tests {
         assert!(result.is_err());
     }
 
+    /// A scratch git repository with one staged change, so a commit here is a
+    /// real commit that touches nothing outside the temp dir.
+    fn scratch_repo() -> tempfile::TempDir {
+        let dir = tempfile::TempDir::new().unwrap();
+        let git = |args: &[&str]| {
+            let out = std::process::Command::new("git")
+                .args(args)
+                .current_dir(dir.path())
+                .output()
+                .unwrap();
+            assert!(out.status.success(), "git {args:?}: {out:?}");
+        };
+        git(&["init", "-q"]);
+        git(&["config", "user.email", "test@example.invalid"]);
+        git(&["config", "user.name", "test"]);
+        std::fs::write(dir.path().join("f.txt"), b"one").unwrap();
+        git(&["add", "f.txt"]);
+        git(&["commit", "-q", "-m", "base"]);
+        std::fs::write(dir.path().join("f.txt"), b"two").unwrap();
+        dir
+    }
+
     #[test]
     fn git_commit_allowed_by_codegen_profile() {
-        let mut rt = rt_tok(PolicyProfile::Codegen);
-        // git_commit may fail on I/O (no repo) but should NOT fail on policy
+        // This test drives the REAL git effect. Before the runtime could be
+        // scoped, it ran `git add -u && git commit` in the process CWD — which
+        // under `cargo test` is the repository root, so running the suite
+        // committed the developer's staged work to their branch. Observed
+        // twice on 2026-08-01. The comment it used to carry ("may fail on I/O
+        // (no repo)") assumed a condition that is false exactly where it
+        // matters.
+        let repo = scratch_repo();
+        let (token, root_vk, now, nonce) = full_scope_token();
+        let mut rt = NucleusRuntime::builder()
+            .profile(PolicyProfile::Codegen)
+            .git_dir(repo.path())
+            .task_token(token, root_vk, now, nonce)
+            .expect("full-scope test token verifies")
+            .build();
+
         let result = {
             let p = rt.preflight_commit().unwrap();
             rt.git_commit("test commit", p)
@@ -2332,6 +2385,50 @@ mod tests {
         if let Err(RuntimeError::Denied { .. }) = &result {
             panic!("git_commit should not be denied by Codegen profile");
         }
+        assert!(
+            result.is_ok(),
+            "the scratch commit should succeed: {result:?}"
+        );
+    }
+
+    /// **The property that makes the suite safe to run.** A runtime scoped to a
+    /// directory must commit THERE — otherwise the scoping is decorative and the
+    /// test above is back to mutating whatever repository it is run from.
+    ///
+    /// Perturbation: drop `current_dir` in `RealEffects::in_git_dir` and this
+    /// REDs on the scratch repo's commit count.
+    #[test]
+    fn a_scoped_runtime_commits_only_in_its_own_repo() {
+        let repo = scratch_repo();
+        let count = |dir: &std::path::Path| -> usize {
+            let out = std::process::Command::new("git")
+                .args(["rev-list", "--count", "HEAD"])
+                .current_dir(dir)
+                .output()
+                .unwrap();
+            String::from_utf8_lossy(&out.stdout).trim().parse().unwrap()
+        };
+        assert_eq!(
+            count(repo.path()),
+            1,
+            "fixture should start with one commit"
+        );
+
+        let (token, root_vk, now, nonce) = full_scope_token();
+        let mut rt = NucleusRuntime::builder()
+            .profile(PolicyProfile::Codegen)
+            .git_dir(repo.path())
+            .task_token(token, root_vk, now, nonce)
+            .expect("full-scope test token verifies")
+            .build();
+        let p = rt.preflight_commit().unwrap();
+        rt.git_commit("scoped", p).expect("commit should succeed");
+
+        assert_eq!(
+            count(repo.path()),
+            2,
+            "the commit did not land in the scoped repository -- it went somewhere else"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

`git_commit_allowed_by_codegen_profile` drives the **real** git effect, and `RealEffects::commit` runs `git add -u && git commit` in the **process working directory**. Under `cargo test` that is the repository root, so running the suite staged and committed whatever the developer had in flight.

Observed twice today while gating unrelated work: two commits titled `test commit` appeared on a feature branch, carrying uncommitted source edits.

The test's comment said *"may fail on I/O (no repo)"* — an assumption that is false in exactly the place it matters.

## Why the fix is a capability, not a test tweak

`git commit` is not scoped by its arguments; it acts on whichever repository the process is standing in. A caller meaning *"commit the agent's workspace"* and one meaning *"commit wherever I am"* were indistinguishable. This adds:

- `RealEffects::with_git_dir(dir)` and `production_effects_in(policy, dir)`
- `NucleusRuntimeBuilder::git_dir(dir)`

Unset keeps the previous process-CWD behaviour, so this is **additive** for every existing caller.

## Verification

- The test now builds a scratch repo in a `TempDir` and commits there.
- New test `a_scoped_runtime_commits_only_in_its_own_repo` asserts the commit **lands in the scoped repo** — otherwise the scoping is decorative.
- **Perturbation**: dropping `current_dir` in `in_git_dir` REDs it on the commit count (`left: 1, right: 2`) — and put a stray commit on the branch while doing so, which is the defect reproducing itself.

`cargo fmt --check`, `clippy --workspace --all-targets --all-features -D warnings`, `cargo test -p portcullis-effects --all-features` all green.