### PR TITLE
Wire the trace monitor to the live sink chain

### DIFF
--- a/crates/nucleus-node/src/main.rs
+++ b/crates/nucleus-node/src/main.rs
@@ -3568,39 +3568,8 @@ impl NodeService for GrpcService {
         let manifest_hash =
             nucleus_identity::approval_bundle::compute_manifest_hash(spec_yaml.as_bytes());
 
-        // Compute v1 content hash: SHA-256 of canonical v1 fields.
-        //
-        // Trust model (Trail of Bits finding #4): this hash covers CONTENT
-        // (what happened), not IDENTITY (who attested). The executor's Ed25519
-        // signature is sent separately in the X-Nucleus-Executor-Sig header and
-        // signs the serialized session-complete body (which includes this hash).
-        // Verification is two-phase:
-        //   1. Trust-service validates v1_content_hash was pre-registered.
-        //   2. Trust-service verifies Ed25519 signature against executor's
-        //      registered public key.
-        // See also: AuditEntry::content_hash() in portcullis/src/audit.rs.
-        let v1_content_hash = {
-            use sha2::{Digest, Sha256};
-            let mut hasher = Sha256::new();
-            hasher.update(id.as_bytes());
-            hasher.update(report.workspace_hash.as_bytes());
-            hasher.update(report.audit_tail_hash.as_bytes());
-            hasher.update(report.audit_entry_count.to_le_bytes());
-            hasher.update(report.timestamp_unix.to_le_bytes());
-            hasher.update(manifest_hash.as_bytes());
-            // Commit exposure labels into the hash — without this, the hash
-            // can be valid while the labels are tampered with, defeating the
-            // content-hash binding that the SandboxAttested upgrade path relies on.
-            for label in &report.observed_exposure_labels {
-                hasher.update(label.as_bytes());
-            }
-            hasher.update(report.observed_risk_tier.as_bytes());
-            hasher
-                .finalize()
-                .iter()
-                .map(|b| format!("{b:02x}"))
-                .collect::<String>()
-        };
+        let v1_content_hash =
+            trust_gate::compute_v1_content_hash(&id.to_string(), &manifest_hash, &report);
 
         // Extract trust metadata from pod labels (set during create_pod_internal)
         let trust_bracket = handle
@@ -3659,6 +3628,10 @@ impl NodeService for GrpcService {
                 report.observed_risk_tier.clone()
             },
             uninhabitable_reached: report.uninhabitable_reached,
+            // Runtime-verification findings from the tool proxy's TraceMonitor,
+            // written to .nucleus-exit-report.json at shutdown alongside exposure.
+            monitor_violations: report.monitor_violations.clone(),
+            monitor_violations_dropped: report.monitor_violations_dropped,
             // Cryptographic session identity — required for the SandboxAttested
             // upgrade path in the trust-service session-complete handler.
             sandbox_identity: if spiffe_id.is_empty() {

--- a/crates/nucleus-node/src/trust_gate.rs
+++ b/crates/nucleus-node/src/trust_gate.rs
@@ -706,6 +706,15 @@ pub struct ReceiptReport {
     pub observed_risk_tier: String,
     /// Whether the uninhabitable state was reached during execution.
     pub uninhabitable_reached: bool,
+    /// Decision-stream property violations observed by the tool proxy's
+    /// `TraceMonitor` (class labels), plus any dropped past the retention cap.
+    ///
+    /// Distinct from exposure: exposure says which capability legs the session
+    /// exercised, this says whether the mediation invariants held while it did.
+    pub monitor_violations: Vec<String>,
+    /// Violations observed but not retained. Non-zero means
+    /// `monitor_violations` is truncated.
+    pub monitor_violations_dropped: u64,
 
     // ── Cryptographic session identity ─────────────────────────────
     /// SPIFFE ID or pod identity from the sandbox. Sent as `sandbox_identity`
@@ -718,6 +727,57 @@ pub struct ReceiptReport {
     /// session-complete in secure mode; without it the handler returns 422
     /// when observed_exposure_labels are present.
     pub v1_content_hash: String,
+}
+
+/// Compute the v1 content hash over the canonical receipt fields.
+///
+/// # Trust model (Trail of Bits finding #4)
+///
+/// This hash covers CONTENT (what happened), not IDENTITY (who attested). The
+/// executor's Ed25519 signature travels separately in the
+/// `X-Nucleus-Executor-Sig` header and signs the serialized session-complete
+/// body, which includes this hash. Verification is two-phase: the trust service
+/// validates the hash was pre-registered, then verifies the signature against
+/// the executor's registered public key. See also `AuditEntry::content_hash()`
+/// in `portcullis/src/audit.rs`.
+///
+/// # What must be committed
+///
+/// **Every observation the trust service acts on.** A field the trust service
+/// reads but the hash does not cover can be stripped or rewritten in flight
+/// while the hash still validates — which defeats the binding the
+/// `SandboxAttested` upgrade path depends on. That is why the exposure labels,
+/// the risk tier, and the monitor's findings are all folded in here, and why a
+/// new observation field added to `ExitReport` must be added here too.
+///
+/// Extracted from `main.rs` so the preimage is testable: it was previously
+/// inline in a long handler and no test could reach it.
+pub(crate) fn compute_v1_content_hash(
+    pod_id: &str,
+    manifest_hash: &str,
+    report: &nucleus_spec::ExitReport,
+) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(pod_id.as_bytes());
+    hasher.update(report.workspace_hash.as_bytes());
+    hasher.update(report.audit_tail_hash.as_bytes());
+    hasher.update(report.audit_entry_count.to_le_bytes());
+    hasher.update(report.timestamp_unix.to_le_bytes());
+    hasher.update(manifest_hash.as_bytes());
+    for label in &report.observed_exposure_labels {
+        hasher.update(label.as_bytes());
+    }
+    hasher.update(report.observed_risk_tier.as_bytes());
+    for label in &report.monitor_violations {
+        hasher.update(label.as_bytes());
+    }
+    hasher.update(report.monitor_violations_dropped.to_le_bytes());
+    hasher
+        .finalize()
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect()
 }
 
 /// Compute a continuous session quality score in [0.0, 1.0] from execution signals.
@@ -778,10 +838,19 @@ pub(crate) fn build_session_complete_body(report: &ReceiptReport) -> serde_json:
         "sandbox_identity": report.sandbox_identity,
         "success": report.success,
         "score": compute_session_score(report),
-        "had_issues": !report.success || report.uninhabitable_reached,
+        // A recorded effect that nothing authorised is an issue by any reading
+        // of the word. Deliberately NOT folded into `compute_session_score`:
+        // the weight a violation should carry against reputation is a policy
+        // question, and inventing one here would be a number nobody chose.
+        "had_issues": !report.success
+            || report.uninhabitable_reached
+            || !report.monitor_violations.is_empty()
+            || report.monitor_violations_dropped > 0,
         "hook_event_name": "ExecutionReceipt",
         "observed_exposure_labels": report.observed_exposure_labels,
         "observed_risk_tier": report.observed_risk_tier,
+        "monitor_violations": report.monitor_violations,
+        "monitor_violations_dropped": report.monitor_violations_dropped,
         "v1_content_hash": report.v1_content_hash,
     })
 }
@@ -1057,6 +1126,81 @@ pub async fn register_executor_pubkey(config: &TrustGateConfig, http_client: &re
 mod tests {
     use super::*;
 
+    fn sample_exit_report() -> nucleus_spec::ExitReport {
+        nucleus_spec::ExitReport {
+            workspace_hash: "ws".to_string(),
+            audit_tail_hash: "tail".to_string(),
+            audit_entry_count: 3,
+            timestamp_unix: 1_700_000_000,
+            input_tokens: 0,
+            output_tokens: 0,
+            cache_read_tokens: 0,
+            cost_usd: 0.0,
+            observed_exposure_labels: vec!["PrivateData".to_string()],
+            observed_risk_tier: "medium".to_string(),
+            uninhabitable_reached: false,
+            monitor_violations: vec!["OutcomeWithoutDecision".to_string()],
+            monitor_violations_dropped: 2,
+        }
+    }
+
+    /// **Every observation the trust service acts on must be committed.** A
+    /// field it reads but the hash does not cover can be stripped in flight
+    /// while the hash still validates, which is precisely the tamper the
+    /// content-hash binding exists to prevent.
+    ///
+    /// Perturbing any field below must change the hash; a field that does not
+    /// appear here is one an attacker can rewrite for free.
+    #[test]
+    fn every_committed_field_changes_the_v1_content_hash() {
+        let base = sample_exit_report();
+        let baseline = compute_v1_content_hash("pod-1", "manifest", &base);
+
+        let mut mutations: Vec<(&str, nucleus_spec::ExitReport)> = Vec::new();
+        let mut m = base.clone();
+        m.workspace_hash = "other".into();
+        mutations.push(("workspace_hash", m));
+        let mut m = base.clone();
+        m.audit_tail_hash = "other".into();
+        mutations.push(("audit_tail_hash", m));
+        let mut m = base.clone();
+        m.audit_entry_count = 4;
+        mutations.push(("audit_entry_count", m));
+        let mut m = base.clone();
+        m.timestamp_unix += 1;
+        mutations.push(("timestamp_unix", m));
+        let mut m = base.clone();
+        m.observed_exposure_labels = vec!["ExfilVector".into()];
+        mutations.push(("observed_exposure_labels", m));
+        let mut m = base.clone();
+        m.observed_risk_tier = "safe".into();
+        mutations.push(("observed_risk_tier", m));
+        // The two added by the trace-monitor wiring. Stripping the violations is
+        // the interesting attack: a session that broke its mediation invariants
+        // filing a clean receipt.
+        let mut m = base.clone();
+        m.monitor_violations = Vec::new();
+        mutations.push(("monitor_violations", m));
+        let mut m = base.clone();
+        m.monitor_violations_dropped = 0;
+        mutations.push(("monitor_violations_dropped", m));
+
+        for (field, mutated) in mutations {
+            assert_ne!(
+                compute_v1_content_hash("pod-1", "manifest", &mutated),
+                baseline,
+                "{field} is not committed into v1_content_hash — it can be tampered with freely"
+            );
+        }
+
+        // The two arguments are committed too.
+        assert_ne!(
+            compute_v1_content_hash("pod-2", "manifest", &base),
+            baseline
+        );
+        assert_ne!(compute_v1_content_hash("pod-1", "other", &base), baseline);
+    }
+
     /// Helper to build a minimal ReceiptReport for body-structure tests.
     fn sample_receipt_report() -> ReceiptReport {
         ReceiptReport {
@@ -1073,6 +1217,8 @@ mod tests {
             observed_exposure_labels: vec!["NetworkEgress".to_string(), "WriteFiles".to_string()],
             observed_risk_tier: "medium".to_string(),
             uninhabitable_reached: false,
+            monitor_violations: Vec::new(),
+            monitor_violations_dropped: 0,
             sandbox_identity: "spiffe://nucleus/test-agent".to_string(),
             v1_content_hash: "cafebabe11223344556677889900aabbccddeeff".to_string(),
         }
@@ -1161,6 +1307,53 @@ mod tests {
             (score - 0.56).abs() < 0.001,
             "expected score ≈ 0.56 with uninhabitable penalty, got {score}"
         );
+    }
+
+    /// A monitor violation is a recorded effect that nothing authorised. A
+    /// session that produced one did not go cleanly, whatever its exit code —
+    /// and without this the exit report's new fields would be written by the
+    /// proxy and read by nothing, which is the defect they exist to detect.
+    #[test]
+    fn test_session_complete_body_had_issues_when_monitor_flagged() {
+        let mut report = sample_receipt_report();
+        report.success = true;
+        report.uninhabitable_reached = false;
+        assert_eq!(
+            build_session_complete_body(&report)["had_issues"].as_bool(),
+            Some(false),
+            "the control must be clean, or the assertion below proves nothing"
+        );
+
+        report.monitor_violations = vec!["OutcomeWithoutDecision".to_string()];
+        let body = build_session_complete_body(&report);
+        assert_eq!(
+            body["had_issues"].as_bool(),
+            Some(true),
+            "had_issues must be true when the monitor observed a violation"
+        );
+        assert_eq!(
+            body["monitor_violations"][0].as_str(),
+            Some("OutcomeWithoutDecision"),
+            "the violation classes must reach the trust service, not just the flag"
+        );
+    }
+
+    /// Truncation must not read as cleanliness: a session whose violations all
+    /// overflowed the retention cap still had issues.
+    #[test]
+    fn test_dropped_violations_alone_set_had_issues() {
+        let mut report = sample_receipt_report();
+        report.success = true;
+        report.monitor_violations = Vec::new();
+        report.monitor_violations_dropped = 7;
+
+        let body = build_session_complete_body(&report);
+        assert_eq!(
+            body["had_issues"].as_bool(),
+            Some(true),
+            "an empty-but-truncated violation list must not read as clean"
+        );
+        assert_eq!(body["monitor_violations_dropped"].as_u64(), Some(7));
     }
 
     /// Verify failure path: score drops significantly and had_issues is set.

--- a/crates/nucleus-spec/src/lib.rs
+++ b/crates/nucleus-spec/src/lib.rs
@@ -645,6 +645,29 @@ pub struct ExitReport {
     /// Whether the uninhabitable state was reached during execution.
     #[serde(default)]
     pub uninhabitable_reached: bool,
+
+    // ── Runtime verification (written by the tool proxy's TraceMonitor) ──
+    /// Decision-stream properties observed to be violated during execution,
+    /// as class labels (`OutcomeWithoutDecision`, `PermissionDiscontinuity`,
+    /// `ExposureRegressed`).
+    ///
+    /// These are *observations of what ran*, complementing
+    /// `observed_exposure_labels`: exposure says which capability legs the
+    /// session exercised, this says whether the mediation invariants held while
+    /// it did. An empty list on a session with a non-zero
+    /// `audit_entry_count` is the expected, healthy case.
+    ///
+    /// Detail fields are deliberately not carried across this boundary — the
+    /// class is enough to say which property broke without exporting the
+    /// session state that broke it.
+    #[serde(default)]
+    pub monitor_violations: Vec<String>,
+
+    /// Violations observed but not retained, because the in-memory cap was
+    /// reached. Non-zero means `monitor_violations` is truncated and its length
+    /// must not be read as the total.
+    #[serde(default)]
+    pub monitor_violations_dropped: u64,
 }
 
 /// Errors resolving policies.

--- a/crates/nucleus-tool-proxy/src/exit_report.rs
+++ b/crates/nucleus-tool-proxy/src/exit_report.rs
@@ -6,6 +6,7 @@
 //! The host (nucleus-node) reads this to build an `ExecutionReceipt`.
 
 use nucleus_spec::{sha256_bytes_hex, ExitReport};
+use portcullis::trace_monitor::TraceMonitor;
 use sha2::{Digest, Sha256};
 use std::path::Path;
 
@@ -82,11 +83,18 @@ pub struct TokenUsage {
 }
 
 /// Build an exit report from the current state.
+///
+/// `monitor` is a required argument, not an optional enrichment applied by the
+/// caller afterwards. A report is the session's account of itself, and a session
+/// that recorded effects nothing authorised must not be able to produce a clean
+/// account by way of a caller forgetting a line. There is no signature here that
+/// omits the monitor.
 pub fn build_exit_report(
     workspace_hash: String,
     audit_tail_hash: String,
     audit_entry_count: u64,
     token_usage: Option<TokenUsage>,
+    monitor: &TraceMonitor,
 ) -> ExitReport {
     let timestamp_unix = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -108,6 +116,13 @@ pub fn build_exit_report(
         observed_exposure_labels: Vec::new(),
         observed_risk_tier: String::new(),
         uninhabitable_reached: false,
+        // Class labels only — the detail stays in-process (Violation::label).
+        monitor_violations: monitor
+            .violations()
+            .iter()
+            .map(|v| v.label().to_string())
+            .collect(),
+        monitor_violations_dropped: monitor.violations_dropped(),
     }
 }
 
@@ -171,6 +186,93 @@ mod tests {
         assert_eq!(hash.len(), 64);
     }
 
+    /// A monitor that has observed nothing.
+    fn clean_monitor() -> TraceMonitor {
+        struct NullSink;
+        impl portcullis::verdict_sink::VerdictSink for NullSink {
+            fn record(
+                &self,
+                _c: portcullis::verdict_sink::VerdictContext,
+            ) -> Result<(), portcullis::verdict_sink::SinkError> {
+                Ok(())
+            }
+            fn preflight(
+                &self,
+                _o: portcullis::Operation,
+            ) -> Result<(), portcullis::verdict_sink::SinkError> {
+                Ok(())
+            }
+        }
+        TraceMonitor::new(std::sync::Arc::new(NullSink))
+    }
+
+    /// A monitor that has seen `n` unmediated effects: a terminal Allow with no
+    /// preceding kernel decision.
+    fn monitor_with_violations(n: usize) -> TraceMonitor {
+        use portcullis::verdict_sink::{
+            ActorIdentity, VerdictContext, VerdictOutcome, VerdictSink,
+        };
+        let m = clean_monitor();
+        for _ in 0..n {
+            m.record(VerdictContext {
+                operation: portcullis::Operation::RunBash,
+                subject: "unmediated".to_string(),
+                outcome: VerdictOutcome::Allow,
+                actor: ActorIdentity::Unknown,
+                policy_rule: None,
+                extensions: std::collections::BTreeMap::new(),
+            })
+            .unwrap();
+        }
+        assert_eq!(
+            m.violations().len(),
+            n,
+            "fixture did not produce violations"
+        );
+        m
+    }
+
+    /// **The acceptance test for the exit-report half.** The report is the
+    /// session's account of itself; a session whose mediation invariants broke
+    /// must not be able to file a clean one.
+    ///
+    /// Perturbation: drop the `monitor_violations` population in
+    /// `build_exit_report` and this REDs — and because `build_exit_report` is
+    /// the function the live shutdown path calls, the test and the live path
+    /// cannot disagree.
+    #[test]
+    fn the_report_carries_what_the_monitor_observed() {
+        let clean = build_exit_report("w".into(), "t".into(), 1, None, &clean_monitor());
+        assert!(
+            clean.monitor_violations.is_empty(),
+            "a clean session must file a clean report, or the assertion below proves nothing"
+        );
+
+        let dirty = build_exit_report("w".into(), "t".into(), 1, None, &monitor_with_violations(2));
+        assert_eq!(
+            dirty.monitor_violations,
+            vec!["OutcomeWithoutDecision", "OutcomeWithoutDecision"],
+            "the report must carry the violations the monitor observed"
+        );
+    }
+
+    /// The report carries the violation CLASS and not the session state behind
+    /// it. Everything in this vector leaves the process.
+    #[test]
+    fn the_report_does_not_export_violation_detail() {
+        let report =
+            build_exit_report("w".into(), "t".into(), 1, None, &monitor_with_violations(1));
+        // Without this the loop below is vacuous on an empty vector — which is
+        // exactly what an unwired report produces.
+        assert_eq!(report.monitor_violations.len(), 1);
+        for label in &report.monitor_violations {
+            assert!(
+                !label.contains("unmediated"),
+                "the subject of the violating record escaped into the report: {label}"
+            );
+        }
+    }
+
     #[test]
     fn test_build_exit_report() {
         let report = build_exit_report(
@@ -178,6 +280,7 @@ mod tests {
             "audit_hash".to_string(),
             10,
             None,
+            &clean_monitor(),
         );
         assert_eq!(report.workspace_hash, "workspace_hash");
         assert_eq!(report.audit_tail_hash, "audit_hash");
@@ -195,7 +298,13 @@ mod tests {
             cache_read_tokens: 200,
             cost_usd: 0.42,
         };
-        let report = build_exit_report("hash".to_string(), "tail".to_string(), 5, Some(usage));
+        let report = build_exit_report(
+            "hash".to_string(),
+            "tail".to_string(),
+            5,
+            Some(usage),
+            &clean_monitor(),
+        );
         assert_eq!(report.input_tokens, 1500);
         assert_eq!(report.output_tokens, 500);
         assert_eq!(report.cache_read_tokens, 200);

--- a/crates/nucleus-tool-proxy/src/main.rs
+++ b/crates/nucleus-tool-proxy/src/main.rs
@@ -341,7 +341,14 @@ pub(crate) struct AppState {
     #[allow(dead_code)]
     session_id: String,
     /// Shared verdict sink for lockdown + telemetry convergence (HTTP + MCP).
+    ///
+    /// This IS the monitor below — `build_monitored_sink` returns one object
+    /// under two handles — so the field cannot hold an unmonitored sink.
     pub(crate) verdict_sink: Arc<dyn portcullis::verdict_sink::VerdictSink>,
+    /// Read handle on the runtime monitor wrapping `verdict_sink`, so the
+    /// process can report what the decision stream actually did — live at
+    /// `/v1/health`, and at shutdown in the exit report.
+    pub(crate) trace_monitor: Arc<portcullis::trace_monitor::TraceMonitor>,
     /// Kernel decision engine for complete mediation (HTTP path).
     pub(crate) kernel: Arc<tokio::sync::Mutex<Kernel>>,
     /// Whether DLC-D verified admission was provisioned on this pod's kernels
@@ -1491,16 +1498,18 @@ async fn main() -> Result<(), ApiError> {
     let dlc_admission = dlc_admission::provision_from_env();
     let dlc_provisioned = dlc_admission.is_some();
 
-    let verdict_sink: Arc<dyn portcullis::verdict_sink::VerdictSink> =
-        Arc::new(verdict_sink::ToolProxyVerdictSink::new(
-            file_lockdown.clone(),
-            stream_lockdown.clone(),
-            runtime.policy().capabilities.clone(),
-            exposure_guard.clone(),
-            policy_checksum.clone(),
-            session_id.clone(),
-            dlc_provisioned,
-        ));
+    // Runtime verification over the decision stream (#2141). The sink comes back
+    // already monitored — `build_monitored_sink` is the only constructor
+    // reachable from here — so there is no unmonitored chain to fall back to.
+    let (verdict_sink, trace_monitor) = verdict_sink::build_monitored_sink(
+        file_lockdown.clone(),
+        stream_lockdown.clone(),
+        runtime.policy().capabilities.clone(),
+        exposure_guard.clone(),
+        policy_checksum.clone(),
+        session_id.clone(),
+        dlc_provisioned,
+    );
 
     if dlc_provisioned {
         tracing::info!("DLC-D verified admission provisioned from NUCLEUS_DLC_* env");
@@ -1593,6 +1602,7 @@ async fn main() -> Result<(), ApiError> {
         policy_checksum,
         session_id,
         verdict_sink,
+        trace_monitor,
         kernel,
         flow_tracker,
         provenance_memory,
@@ -1713,6 +1723,7 @@ async fn main() -> Result<(), ApiError> {
     let exit_audit = state.audit.clone();
     let exit_work_dir = spec.spec.work_dir.clone();
     let exit_exposure = state.exposure_guard.clone();
+    let exit_monitor = state.trace_monitor.clone();
 
     let app = app
         .with_state(state.clone())
@@ -1728,7 +1739,7 @@ async fn main() -> Result<(), ApiError> {
 
     if let Some(vsock) = vsock_binding {
         pod_mgmt::serve_vsock(app, vsock, args.announce_path).await?;
-        write_exit_report(&exit_audit, &exit_work_dir, &exit_exposure).await;
+        write_exit_report(&exit_audit, &exit_work_dir, &exit_exposure, &exit_monitor).await;
         return Ok(());
     }
 
@@ -1770,7 +1781,7 @@ async fn main() -> Result<(), ApiError> {
             .await?;
     }
 
-    write_exit_report(&exit_audit, &exit_work_dir, &exit_exposure).await;
+    write_exit_report(&exit_audit, &exit_work_dir, &exit_exposure, &exit_monitor).await;
 
     Ok(())
 }
@@ -1807,6 +1818,7 @@ async fn write_exit_report(
     audit: &AuditLog,
     work_dir_path: &Path,
     exposure_guard: &std::sync::RwLock<Option<Arc<portcullis::GradedExposureGuard>>>,
+    monitor: &portcullis::trace_monitor::TraceMonitor,
 ) {
     let workspace_hash = match exit_report::hash_workspace(work_dir_path).await {
         Ok(h) => h,
@@ -1817,7 +1829,15 @@ async fn write_exit_report(
     };
 
     let (tail_hash, count) = audit.tail_hash_and_count();
-    let mut report = exit_report::build_exit_report(workspace_hash, tail_hash, count, None);
+    let mut report =
+        exit_report::build_exit_report(workspace_hash, tail_hash, count, None, monitor);
+    if !report.monitor_violations.is_empty() || report.monitor_violations_dropped > 0 {
+        warn!(
+            violations = ?report.monitor_violations,
+            dropped = report.monitor_violations_dropped,
+            "exit report: decision-stream properties were violated during this session"
+        );
+    }
 
     // Extract verified exposure from the session guard
     if let Ok(guard_opt) = exposure_guard.read() {
@@ -2326,7 +2346,16 @@ async fn health(State(state): State<AppState>) -> Json<serde_json::Value> {
             "tier": state.sandbox_proof.tier(),
             "label": state.sandbox_proof.tier_label(),
         },
-        "dlc_admission": if state.dlc_provisioned { "provisioned" } else { "unprovisioned" }
+        "dlc_admission": if state.dlc_provisioned { "provisioned" } else { "unprovisioned" },
+        // Counts only, never labels or detail. Same reasoning as the DLC field
+        // above — a host needs to distinguish "the monitor saw nothing" from
+        // "the monitor was never armed" — but this endpoint is reachable from
+        // inside the sandbox, so it must not become a channel for reading back
+        // which invariant a probe just tripped.
+        "trace_monitor": {
+            "violations": state.trace_monitor.violations().len(),
+            "violations_dropped": state.trace_monitor.violations_dropped(),
+        }
     }))
 }
 

--- a/crates/nucleus-tool-proxy/src/verdict_sink.rs
+++ b/crates/nucleus-tool-proxy/src/verdict_sink.rs
@@ -9,6 +9,7 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
+use portcullis::trace_monitor::TraceMonitor;
 use portcullis::verdict_sink::{
     ActorIdentity, SinkError, VerdictContext, VerdictOutcome, VerdictSink,
 };
@@ -35,9 +36,55 @@ pub struct ToolProxyVerdictSink {
     dlc_provisioned: bool,
 }
 
+/// Build the process's verdict sink, already wrapped in its monitor.
+///
+/// # Why this is the only constructor
+///
+/// `ToolProxyVerdictSink::new` is private to this module, so no caller can
+/// obtain an *unmonitored* sink. That is deliberate, and is the same move
+/// `mediation::decide_and_record` makes for the decision: the property "the
+/// live sink chain is monitored" holds because of a module boundary, not
+/// because a call site in `main.rs` remembers to wrap.
+///
+/// The alternative — construct the sink, then wrap it at the call site — is
+/// precisely the shape that has failed repeatedly here: an artifact attached to
+/// the live path by an edit that a later edit can silently undo, with every test
+/// still green. There is nothing to undo if there is nothing else to return.
+///
+/// Returns `(sink, monitor)`. Both handles refer to the same object; the second
+/// exists so the process can read violations back out at `/v1/health` and at
+/// exit.
+#[allow(clippy::too_many_arguments)]
+pub fn build_monitored_sink(
+    file_lockdown: Arc<AtomicBool>,
+    stream_lockdown: Arc<AtomicBool>,
+    capabilities: CapabilityLattice,
+    exposure_guard: Arc<std::sync::RwLock<Option<Arc<GradedExposureGuard>>>>,
+    policy_checksum: String,
+    session_id: String,
+    dlc_provisioned: bool,
+) -> (Arc<dyn VerdictSink>, Arc<TraceMonitor>) {
+    let inner = Arc::new(ToolProxyVerdictSink::new(
+        file_lockdown,
+        stream_lockdown,
+        capabilities,
+        exposure_guard,
+        policy_checksum,
+        session_id,
+        dlc_provisioned,
+    ));
+    let monitor = Arc::new(TraceMonitor::new(inner));
+    (monitor.clone(), monitor)
+}
+
 impl ToolProxyVerdictSink {
     /// Build from the same fields already present on `AppState`.
-    pub fn new(
+    ///
+    /// Private: see [`build_monitored_sink`]. The unit tests below construct
+    /// bare sinks because their subject is the sink's own behaviour; the live
+    /// path cannot.
+    #[allow(clippy::too_many_arguments)]
+    fn new(
         file_lockdown: Arc<AtomicBool>,
         stream_lockdown: Arc<AtomicBool>,
         capabilities: CapabilityLattice,
@@ -339,6 +386,74 @@ mod tests {
             "test-session".to_string(),
             false,
         )
+    }
+
+    fn built() -> (Arc<dyn VerdictSink>, Arc<TraceMonitor>) {
+        build_monitored_sink(
+            Arc::new(AtomicBool::new(false)),
+            Arc::new(AtomicBool::new(false)),
+            CapabilityLattice::default(),
+            Arc::new(std::sync::RwLock::new(None)),
+            "test-checksum".to_string(),
+            "test-session".to_string(),
+            false,
+        )
+    }
+
+    /// **The acceptance test for the wiring.** Not "a TraceMonitor works" —
+    /// #2141 proved that — but "the sink this process actually uses is the
+    /// monitored one". It asserts on what the monitor OBSERVED, so it cannot
+    /// pass if the chain is unwired.
+    ///
+    /// Perturbation (run 2026-08-01): return the bare `ToolProxyVerdictSink`
+    /// from `build_monitored_sink` and this REDs on the count, naming the
+    /// defect.
+    #[test]
+    fn records_flowing_through_the_built_sink_reach_the_monitor() {
+        let (sink, monitor) = built();
+        assert!(
+            monitor.violations().is_empty(),
+            "a fresh monitor must be clean, or the assertion below proves nothing"
+        );
+
+        // A terminal Allow with no preceding kernel decision: an effect that
+        // nothing on the record authorised.
+        sink.record(VerdictContext {
+            operation: Operation::RunBash,
+            subject: "unmediated".to_string(),
+            outcome: VerdictOutcome::Allow,
+            actor: ActorIdentity::Unknown,
+            policy_rule: None,
+            extensions: BTreeMap::new(),
+        })
+        .unwrap();
+
+        assert_eq!(
+            monitor.violations().len(),
+            1,
+            "the sink handed to the process must be monitored; the monitor saw nothing"
+        );
+    }
+
+    /// Monitoring must not change what the sink does. A locked sink still
+    /// refuses through the wrapper, so wiring the monitor cannot have opened a
+    /// path that lockdown used to close.
+    #[test]
+    fn the_built_sink_still_enforces_lockdown() {
+        let locked = build_monitored_sink(
+            Arc::new(AtomicBool::new(true)),
+            Arc::new(AtomicBool::new(false)),
+            CapabilityLattice::default(),
+            Arc::new(std::sync::RwLock::new(None)),
+            "test-checksum".to_string(),
+            "test-session".to_string(),
+            false,
+        )
+        .0;
+        assert!(matches!(
+            locked.preflight(Operation::ReadFiles).unwrap_err(),
+            SinkError::Locked
+        ));
     }
 
     #[test]

--- a/crates/portcullis/src/trace_monitor.rs
+++ b/crates/portcullis/src/trace_monitor.rs
@@ -66,6 +66,34 @@ pub enum Violation {
     },
 }
 
+impl Violation {
+    /// The violation's class, as a stable string.
+    ///
+    /// This is what crosses a process boundary (the exit report, `/v1/health`).
+    /// The detail fields stay in-process: a permission hash or an exposure count
+    /// is a fact about the session's internals, and a refusal explanation that
+    /// travels outward is a probing oracle. The class is enough to say *what*
+    /// property broke without saying which state broke it.
+    pub fn label(&self) -> &'static str {
+        match self {
+            Violation::OutcomeWithoutDecision { .. } => "OutcomeWithoutDecision",
+            Violation::PermissionDiscontinuity { .. } => "PermissionDiscontinuity",
+            Violation::ExposureRegressed { .. } => "ExposureRegressed",
+        }
+    }
+}
+
+/// Violations retained in memory. A monitor on a long-running session must not
+/// grow without bound, and the count matters more than the tail: past this many,
+/// the process is not "slightly wrong", and the dropped counter carries the rest.
+const MAX_RETAINED_VIOLATIONS: usize = 256;
+
+#[derive(Default)]
+struct Violations {
+    retained: Vec<Violation>,
+    dropped: u64,
+}
+
 #[derive(Default)]
 struct State {
     /// Operations for which a kernel decision has been seen and no terminal
@@ -83,7 +111,7 @@ struct State {
 pub struct TraceMonitor {
     inner: Arc<dyn VerdictSink>,
     state: Mutex<State>,
-    violations: Mutex<Vec<Violation>>,
+    violations: Mutex<Violations>,
 }
 
 impl TraceMonitor {
@@ -92,18 +120,34 @@ impl TraceMonitor {
         Self {
             inner,
             state: Mutex::new(State::default()),
-            violations: Mutex::new(Vec::new()),
+            violations: Mutex::new(Violations::default()),
         }
     }
 
-    /// Everything the monitor has observed to be wrong.
+    /// Everything the monitor has observed to be wrong, up to
+    /// `MAX_RETAINED_VIOLATIONS`. Read `violations_dropped` alongside it: a
+    /// truncated list that looks like a bounded problem is worse than no list.
     pub fn violations(&self) -> Vec<Violation> {
-        self.violations.lock().expect("monitor lock").clone()
+        self.violations
+            .lock()
+            .expect("monitor lock")
+            .retained
+            .clone()
+    }
+
+    /// Violations observed but not retained, because the cap was reached.
+    pub fn violations_dropped(&self) -> u64 {
+        self.violations.lock().expect("monitor lock").dropped
     }
 
     fn flag(&self, v: Violation) {
         tracing::warn!(violation = ?v, "decision-stream property violated");
-        self.violations.lock().expect("monitor lock").push(v);
+        let mut vs = self.violations.lock().expect("monitor lock");
+        if vs.retained.len() < MAX_RETAINED_VIOLATIONS {
+            vs.retained.push(v);
+        } else {
+            vs.dropped += 1;
+        }
     }
 
     /// A record carrying `decision_sequence` is a KERNEL DECISION (#2127);
@@ -367,5 +411,55 @@ mod tests {
         let m = TraceMonitor::new(Arc::new(LockedSink));
         assert!(m.record(outcome(Operation::ReadFiles)).is_err());
         assert!(m.preflight(Operation::ReadFiles).is_err());
+    }
+
+    /// A monitor on a long-lived session must not grow without bound — and the
+    /// truncation must be VISIBLE, or a capped list reads as "only 256 things
+    /// went wrong" when the real number is unbounded.
+    #[test]
+    fn violations_are_capped_and_the_overflow_is_counted() {
+        let m = monitor();
+        let overflow = 5;
+        for _ in 0..(MAX_RETAINED_VIOLATIONS + overflow) {
+            m.record(outcome(Operation::RunBash)).unwrap();
+        }
+        assert_eq!(m.violations().len(), MAX_RETAINED_VIOLATIONS);
+        assert_eq!(m.violations_dropped(), overflow as u64);
+    }
+
+    /// The label is what crosses a process boundary, so each variant needs a
+    /// distinct one — a shared label would make two different defects
+    /// indistinguishable in the exit report.
+    #[test]
+    fn every_violation_class_has_a_distinct_label() {
+        let all = [
+            Violation::OutcomeWithoutDecision {
+                operation: Operation::RunBash,
+            },
+            Violation::PermissionDiscontinuity {
+                expected: "a".into(),
+                found: "b".into(),
+            },
+            Violation::ExposureRegressed { from: 3, to: 1 },
+        ];
+        let labels: BTreeSet<&str> = all.iter().map(|v| v.label()).collect();
+        assert_eq!(labels.len(), all.len(), "labels collide: {labels:?}");
+    }
+
+    /// The label must NOT carry the detail fields: a permission hash or an
+    /// exposure count travelling outward is session state leaking through an
+    /// error channel. Perturbing the detail must leave the label identical.
+    #[test]
+    fn the_label_does_not_carry_session_state() {
+        let a = Violation::PermissionDiscontinuity {
+            expected: "hash-of-real-permissions".into(),
+            found: "other".into(),
+        };
+        let b = Violation::PermissionDiscontinuity {
+            expected: "totally-different".into(),
+            found: "and-again".into(),
+        };
+        assert_eq!(a.label(), b.label());
+        assert!(!a.label().contains("hash-of-real-permissions"));
     }
 }


### PR DESCRIPTION
#2141 built a runtime monitor over the decision stream and left it with **no producer** — the exact defect class it was written to detect, one level up. This wires it, structurally rather than by a call site anyone can undo.

## The sink cannot be obtained unmonitored

`ToolProxyVerdictSink::new` is now private to its module; `build_monitored_sink` is the only constructor reachable from `main.rs`, and it returns the wrapped chain. There is no unmonitored sink to fall back to. Same move as `mediation::decide_and_record` (#2127): a module boundary, not a remembered line.

`records_flowing_through_the_built_sink_reach_the_monitor` asserts on what the monitor **observed**. Perturbation: return the bare sink → REDs with *"the sink handed to the process must be monitored; the monitor saw nothing"*.

## The report cannot omit what the monitor saw

`build_exit_report` takes `&TraceMonitor` as a **required argument**. A session that recorded effects nothing authorised cannot file a clean account of itself by way of a caller forgetting a line. Since `build_exit_report` is the function the live shutdown path calls, test and live path cannot disagree.

## The new fields are read, not just written

Writing `monitor_violations` into `ExitReport` and stopping there would recreate `reset_session_ceiling` — a field nothing consumes. nucleus-node forwards them in the session-complete body and folds them into `had_issues`.

Deliberately **not** into `compute_session_score`: the weight a violation should carry against reputation is a policy question, and inventing one here would be a number nobody chose.

They are also committed into `v1_content_hash`, for the same reason the exposure labels already are — a field the trust service acts on but the hash does not cover can be stripped in flight while the hash still validates. Stripping the violations is the interesting attack: a session that broke its mediation invariants filing a clean receipt.

That hash computation moved to `trust_gate::compute_v1_content_hash` (previously inline in a long handler, under a line ratchet, unreachable by any test) and now has a field sweep asserting every committed field changes it.

## Boundaries

- Only violation **class** labels cross a process boundary (`Violation::label`). Detail — permission hashes, exposure counts — stays in-process. A refusal explanation that travels outward is a probing oracle.
- `/v1/health` exposes **counts only**, and is reachable from inside the sandbox.
- Retention capped at 256 with a dropped counter; dropped-alone still sets `had_issues` — an empty-but-truncated list must not read as clean.
- **Still not fail-closed.** Violations are recorded and exposed, not denied.

## Verification

Three perturbations run, each REDing at the expected location for the expected cause: unwrap the monitor, drop the report population, drop the `had_issues` clause. `the_built_sink_still_enforces_lockdown` confirms monitoring did not open a path lockdown used to close.

`fmt` / `clippy --workspace --all-targets --all-features -D warnings` / `cargo test --all-features` / line ratchet `--strict` / mediation gate / `cargo hack --each-feature`: all green.