### PR TITLE
Give ZkFlowInput a producer, and a second opinion on every decision

### DIFF
--- a/crates/nucleus-ifc-kernel/src/flow.rs
+++ b/crates/nucleus-ifc-kernel/src/flow.rs
@@ -1102,6 +1102,83 @@ pub struct ZkFlowInput {
     pub nodes: Vec<FlowNode>,
 }
 
+impl ZkFlowInput {
+    /// Build an input for the action a session is about to take, over the
+    /// session's causal DAG.
+    ///
+    /// # Why a constructor rather than a struct literal
+    ///
+    /// The struct is three public fields, and a caller can fill them with
+    /// anything. The combination that matters — a real DAG plus the action
+    /// actually being authorised — cannot be produced by
+    /// `FlowTracker::snapshot` alone (deliberately not an intra-doc link: this
+    /// file is kernel, and the boundary ratchet counts a link upward as a
+    /// dependency): every node a tracker holds is an observation, and
+    /// `check_flow` returns `Allow`
+    /// for any node with `operation: None`. A `ZkFlowInput` whose nodes all come
+    /// from a snapshot therefore verifies **nothing**; it confirms `Allow` for
+    /// every session including a maximally tainted one.
+    ///
+    /// This constructor appends the missing piece: an `OutboundAction` node
+    /// carrying the `operation` and `sink_class` the kernel decided on, whose
+    /// parents are the observations the action draws from. Its label is the
+    /// propagated join of those parents, so the verifier re-derives the same
+    /// label the kernel did rather than being handed one.
+    ///
+    /// `parents` beyond [`MAX_PARENTS`] are truncated — the same incompleteness
+    /// `latest_adversarial_node` documents. The resulting graph records real
+    /// edges, not necessarily every edge, and the session ceiling remains the
+    /// backstop.
+    ///
+    /// # Panics
+    ///
+    /// Never. An empty `snapshot` yields a single-node graph (the action with no
+    /// parents), which is a truthful description of a session that observed
+    /// nothing.
+    pub fn for_action(
+        snapshot: Vec<FlowNode>,
+        operation: Operation,
+        sink_class: Option<SinkClass>,
+        parents: &[NodeId],
+        expected_verdict: FlowVerdict,
+    ) -> Self {
+        let mut nodes = snapshot;
+        let action_node_id = (nodes.len() + 1) as NodeId;
+
+        let mut parent_ids = [0u64; MAX_PARENTS];
+        let n = parents.len().min(MAX_PARENTS);
+        parent_ids[..n].copy_from_slice(&parents[..n]);
+
+        // The action's label is the join of its parents with the intrinsic
+        // label of an outbound action — the same computation the kernel ran.
+        // Deriving it here rather than accepting one means a caller cannot
+        // hand the verifier a flattering label.
+        let parent_labels: Vec<IFCLabel> = parents
+            .iter()
+            .take(MAX_PARENTS)
+            .filter_map(|pid| nodes.iter().find(|n| n.id == *pid).map(|n| n.label))
+            .collect();
+        let label = propagate_label(&parent_labels, intrinsic_label(NodeKind::OutboundAction, 0));
+
+        nodes.push(FlowNode {
+            id: action_node_id,
+            kind: NodeKind::OutboundAction,
+            label,
+            parent_count: n as u8,
+            parents: parent_ids,
+            operation: Some(operation),
+            sink_class,
+            effect_kind: None,
+        });
+
+        Self {
+            action_node_id,
+            expected_verdict,
+            nodes,
+        }
+    }
+}
+
 // ═══════════════════════════════════════════════════════════════════════════
 // zkVM guest verification (#1134) — check IFC noninterference on a flow snapshot
 // ═══════════════════════════════════════════════════════════════════════════

--- a/crates/nucleus-ifc-kernel/src/ifc_api.rs
+++ b/crates/nucleus-ifc-kernel/src/ifc_api.rs
@@ -830,6 +830,58 @@ impl FlowTracker {
             .map(|(i, _)| (i + 1) as u64)
     }
 
+    /// Snapshot the session's causal DAG as [`FlowNode`]s.
+    ///
+    /// # Why this exists
+    ///
+    /// [`ZkFlowInput`](crate::flow::ZkFlowInput) has a zkVM guest and a working
+    /// verifier and, until this accessor, **no producer**: nothing could turn a
+    /// live session into one, so `verify_noninterference` only ever ran on
+    /// hand-written fixtures. The graph it needs was here all along, behind a
+    /// private field.
+    ///
+    /// # Every node here is an observation, and that is not a lossy conversion
+    ///
+    /// `FlowNode` carries `operation`, `sink_class` and `effect_kind`; this
+    /// tracker stores none of them, and the returned nodes have them as `None`.
+    /// That is **correct rather than approximate**: every node in a
+    /// `FlowTracker` was created by an `observe*` call, and an observation
+    /// performs no side effect. `check_flow` treats `operation: None` as
+    /// "nothing to check here" for exactly that reason.
+    ///
+    /// The consequence matters, so it is stated rather than left to be
+    /// discovered: a `ZkFlowInput` built from **only** this snapshot verifies
+    /// nothing. Every node in it is unconditionally `Allow`, so
+    /// `verify_noninterference` would confirm `Allow` for any session, however
+    /// tainted. The action being authorised is not in this graph — it is in the
+    /// kernel's `Decision` — and it must be supplied separately. See
+    /// [`ZkFlowInput::for_action`](crate::flow::ZkFlowInput::for_action), which
+    /// is the only constructor that can produce a non-vacuous input.
+    ///
+    /// Node IDs are 1-based and match the ids returned by `observe*`.
+    pub fn snapshot(&self) -> Vec<crate::flow::FlowNode> {
+        self.nodes
+            .iter()
+            .enumerate()
+            .map(|(i, (kind, label, parents, _hash))| {
+                let mut parent_ids = [0u64; crate::flow::MAX_PARENTS];
+                let n = parents.len().min(crate::flow::MAX_PARENTS);
+                parent_ids[..n].copy_from_slice(&parents[..n]);
+                crate::flow::FlowNode {
+                    id: (i + 1) as u64,
+                    kind: *kind,
+                    label: *label,
+                    parent_count: n as u8,
+                    parents: parent_ids,
+                    // See the doc comment: observations carry no operation.
+                    operation: None,
+                    sink_class: None,
+                    effect_kind: None,
+                }
+            })
+            .collect()
+    }
+
     pub fn is_tainted(&self) -> bool {
         self.nodes
             .iter()

--- a/crates/nucleus-ifc-kernel/tests/zk_flow_producer.rs
+++ b/crates/nucleus-ifc-kernel/tests/zk_flow_producer.rs
@@ -1,0 +1,213 @@
+//! The `ZkFlowInput` producer, exercised through the public API.
+//!
+//! These live outside `src/` on purpose. `flow.rs` is kernel and the boundary
+//! ratchet (`kernel_boundary_ratchet.rs`) forbids it from reaching up to
+//! `FlowTracker` — including from its own `#[cfg(test)]` module. An integration
+//! test is also the honest place for them: it composes the two halves exactly as
+//! a real producer must, across the same public surface.
+//!
+//! The point of the suite is **non-vacuity**. `ZkFlowInput` had a verifier and a
+//! zkVM guest and no producer, and the obvious producer — hand the verifier the
+//! session's graph — confirms `Allow` for every session that has ever run. The
+//! first test pins that failure mode so the rest are known to be testing
+//! something.
+
+use nucleus_ifc_kernel::IntegLevel;
+use nucleus_ifc_kernel::flow::{
+    FlowVerdict, NodeId, NodeKind, VerificationResult, ZkFlowInput, check_flow,
+    verify_noninterference,
+};
+use nucleus_ifc_kernel::ifc_api::FlowTracker;
+use nucleus_ifc_kernel::{Operation, SinkClass};
+
+// ═══════════════════════════════════════════════════════════════════════
+// ZkFlowInput::for_action — the producer, and its non-vacuity
+// ═══════════════════════════════════════════════════════════════════════
+
+/// **The vacuity this constructor exists to avoid.** A `ZkFlowInput` built
+/// from a snapshot ALONE confirms `Allow` for any session, however tainted,
+/// because every node a `FlowTracker` holds is an observation and
+/// `check_flow` returns `Allow` for `operation: None`.
+///
+/// This test asserts the failure mode is real. If it ever REDs, the claim in
+/// `FlowTracker::snapshot`'s doc comment is wrong and `for_action` may no
+/// longer be load-bearing.
+#[test]
+fn a_snapshot_alone_would_confirm_allow_for_a_maximally_tainted_session() {
+    let mut tracker = FlowTracker::new();
+    let adversarial = tracker
+        .observe(NodeKind::WebContent)
+        .expect("observe web content");
+    assert_eq!(
+        tracker.snapshot()[(adversarial - 1) as usize]
+            .label
+            .integrity,
+        IntegLevel::Adversarial,
+        "fixture must actually be tainted"
+    );
+
+    let snapshot = tracker.snapshot();
+    let last = snapshot.last().unwrap().id;
+    let vacuous = ZkFlowInput {
+        action_node_id: last,
+        expected_verdict: FlowVerdict::Allow,
+        nodes: snapshot,
+    };
+    assert_eq!(
+        verify_noninterference(&vacuous),
+        VerificationResult::Confirmed,
+        "a snapshot-only input is expected to confirm Allow vacuously; \
+         if this changed, revisit FlowTracker::snapshot's documented caveat"
+    );
+}
+
+/// **The refutable witness.** The same tainted session, with the action the
+/// kernel would actually be authorising attached, must NOT confirm `Allow`.
+/// This is the assertion that distinguishes a real producer from the vacuous
+/// one above.
+#[test]
+fn for_action_refuses_to_confirm_allow_on_a_tainted_exfil_action() {
+    let mut tracker = FlowTracker::new();
+    let tainted = tracker.observe(NodeKind::WebContent).expect("observe");
+
+    let input = ZkFlowInput::for_action(
+        tracker.snapshot(),
+        Operation::WebFetch,
+        Some(SinkClass::HTTPEgress),
+        &[tainted],
+        FlowVerdict::Allow,
+    );
+
+    assert!(
+        matches!(
+            verify_noninterference(&input),
+            VerificationResult::Mismatch { .. }
+        ),
+        "adversarial content flowing to an exfil sink must not verify as Allow; got {:?}",
+        verify_noninterference(&input)
+    );
+}
+
+/// **The satisfiable witness.** The producer must also be able to confirm a
+/// verdict — a constructor that only ever mismatches proves nothing either.
+#[test]
+fn for_action_confirms_the_deny_the_kernel_would_reach() {
+    let mut tracker = FlowTracker::new();
+    let tainted = tracker.observe(NodeKind::WebContent).expect("observe");
+
+    let action_node = ZkFlowInput::for_action(
+        tracker.snapshot(),
+        Operation::WebFetch,
+        Some(SinkClass::HTTPEgress),
+        &[tainted],
+        FlowVerdict::Allow,
+    );
+    // Ask the kernel what the verdict actually is, then assert the producer
+    // confirms THAT — rather than hard-coding a reason this test would keep
+    // asserting after the policy changed underneath it.
+    let action = action_node
+        .nodes
+        .iter()
+        .find(|n| n.id == action_node.action_node_id)
+        .unwrap();
+    let real_verdict = check_flow(action, 0);
+    assert!(
+        matches!(real_verdict, FlowVerdict::Deny(_)),
+        "fixture should be denied, got {real_verdict:?}"
+    );
+
+    let honest = ZkFlowInput::for_action(
+        tracker.snapshot(),
+        Operation::WebFetch,
+        Some(SinkClass::HTTPEgress),
+        &[tainted],
+        real_verdict,
+    );
+    assert_eq!(
+        verify_noninterference(&honest),
+        VerificationResult::Confirmed
+    );
+}
+
+/// A clean session taking an ordinary action confirms `Allow` — so the
+/// producer is not simply denying everything.
+#[test]
+fn for_action_confirms_allow_on_a_clean_session() {
+    let mut tracker = FlowTracker::new();
+    let clean = tracker.observe(NodeKind::UserPrompt).expect("observe");
+
+    let input = ZkFlowInput::for_action(
+        tracker.snapshot(),
+        Operation::ReadFiles,
+        Some(SinkClass::WorkspaceWrite),
+        &[clean],
+        FlowVerdict::Allow,
+    );
+    assert_eq!(
+        verify_noninterference(&input),
+        VerificationResult::Confirmed
+    );
+}
+
+/// The action's label must be DERIVED from its parents, not accepted from a
+/// caller. Attaching a tainted parent must change the action's label, or the
+/// verifier is re-checking a label the prover chose.
+#[test]
+fn the_action_label_is_derived_from_its_parents() {
+    let mut tracker = FlowTracker::new();
+    let clean = tracker.observe(NodeKind::UserPrompt).expect("observe");
+    let tainted = tracker.observe(NodeKind::WebContent).expect("observe");
+
+    let label_of = |parents: &[NodeId]| {
+        let i = ZkFlowInput::for_action(
+            tracker.snapshot(),
+            Operation::WebFetch,
+            Some(SinkClass::HTTPEgress),
+            parents,
+            FlowVerdict::Allow,
+        );
+        i.nodes
+            .iter()
+            .find(|n| n.id == i.action_node_id)
+            .unwrap()
+            .label
+    };
+
+    assert_ne!(
+        label_of(&[clean]).integrity,
+        label_of(&[tainted]).integrity,
+        "the action's label did not move with its parents -- it is not being propagated"
+    );
+}
+
+/// Parent references must point at nodes that exist, or
+/// `verify_noninterference` reports `BrokenParentRef` and the whole input is
+/// unusable. This pins the 1-based id convention shared with `observe*`.
+#[test]
+fn snapshot_ids_line_up_with_observe_ids() {
+    let mut tracker = FlowTracker::new();
+    let a = tracker.observe(NodeKind::UserPrompt).expect("observe");
+    let b = tracker
+        .observe_with_parents(NodeKind::DeterministicBind, &[a])
+        .expect("observe with parent");
+
+    let input = ZkFlowInput::for_action(
+        tracker.snapshot(),
+        Operation::ReadFiles,
+        None,
+        &[b],
+        FlowVerdict::Allow,
+    );
+    assert_ne!(
+        verify_noninterference(&input),
+        VerificationResult::BrokenParentRef {
+            node_id: b,
+            parent_id: a
+        },
+        "snapshot ids must match the ids observe() handed out"
+    );
+    assert_eq!(
+        verify_noninterference(&input),
+        VerificationResult::Confirmed
+    );
+}

--- a/crates/nucleus-tool-proxy/src/mcp.rs
+++ b/crates/nucleus-tool-proxy/src/mcp.rs
@@ -251,6 +251,10 @@ impl NucleusMcpServer {
         // are denied with `IfcUnsafe` before the normal decision path.
         let flow = self.flow_tracker.lock().await;
         let (decision, token) = kernel.decide_term_with_flow(term, Some(&flow));
+        // Same second opinion the HTTP path takes (`mediation::cross_check_flow`),
+        // computed before the tracker lock is released. Both transports route
+        // through the same kernel, so both owe the same evidence.
+        let flow_check = crate::mediation::cross_check_flow(&flow, &decision, operation);
         drop(flow);
         drop(kernel);
 
@@ -265,6 +269,7 @@ impl NucleusMcpServer {
             subject,
             ActorIdentity::StdioGuest,
             "mcp",
+            flow_check,
         );
 
         match decision.verdict {

--- a/crates/nucleus-tool-proxy/src/mediation.rs
+++ b/crates/nucleus-tool-proxy/src/mediation.rs
@@ -180,8 +180,273 @@ pub(crate) fn decide_and_record(
     transport: &str,
 ) -> Result<DecisionToken, ApiError> {
     let (decision, mapped) = decide_with_flow_mapped(kernel, flow, operation, subject);
+
+    // Second opinion from the causal DAG. Inside this function, beside the
+    // recording, for the same reason the recording is here: a step written at
+    // the call site is a step a refusal's `?` can skip.
+    let flow_check = cross_check_flow(flow, &decision, operation);
+    if let Some(result) = &flow_check {
+        if *result
+            != FlowCrossCheck::Checked(nucleus::portcullis::flow::VerificationResult::Confirmed)
+        {
+            warn!(
+                ?operation,
+                subject,
+                ?result,
+                verdict = ?decision.verdict,
+                "flow cross-check did not confirm the kernel verdict"
+            );
+        }
+    }
+
     crate::verdict_sink::record_kernel_decision(
-        sink, &decision, operation, subject, actor, transport,
+        sink, &decision, operation, subject, actor, transport, flow_check,
     );
     mapped
+}
+
+#[cfg(test)]
+mod cross_check_tests {
+    use super::*;
+    use nucleus::portcullis::flow::VerificationResult;
+    use nucleus::portcullis::kernel::ExposureTransition;
+    use nucleus::portcullis::NodeKind;
+
+    fn decision_with(verdict: Verdict) -> Decision {
+        Decision {
+            id: uuid::Uuid::nil(),
+            sequence: 1,
+            operation: Operation::WebFetch,
+            subject: "https://example.invalid".to_string(),
+            verdict,
+            timestamp: chrono::Utc::now(),
+            pre_permissions_hash: String::new(),
+            post_permissions_hash: String::new(),
+            exposure_transition: ExposureTransition {
+                pre_count: 0,
+                post_count: 0,
+                contributed_label: None,
+                state_uninhabitable: false,
+                dynamic_gate_applied: false,
+            },
+            flow_node_id: None,
+            action_term: None,
+            preflight_result: None,
+        }
+    }
+
+    /// **The bound that keeps this off the hot path.** A clean session has no
+    /// adversarial node, so the answer is `Allow` by construction and the
+    /// O(nodes) snapshot would buy nothing. Skipping is not an optimisation
+    /// that loses information; there is no information there.
+    #[test]
+    fn a_clean_session_is_not_cross_checked() {
+        let mut flow = FlowTracker::new();
+        flow.observe(NodeKind::UserPrompt).expect("observe");
+        assert!(
+            cross_check_flow(&flow, &decision_with(Verdict::Allow), Operation::WebFetch).is_none(),
+            "an untainted session should not pay for a check whose answer is fixed"
+        );
+    }
+
+    /// **The finding this exists to produce.** An allow on a tainted session,
+    /// heading for an exfil sink, is exactly what the causal graph should
+    /// refuse to confirm.
+    #[test]
+    fn an_allow_on_a_tainted_exfil_path_is_not_confirmed() {
+        let mut flow = FlowTracker::new();
+        flow.observe(NodeKind::WebContent).expect("observe");
+
+        let result = cross_check_flow(&flow, &decision_with(Verdict::Allow), Operation::WebFetch)
+            .expect("a tainted session must be checked");
+        assert!(
+            matches!(
+                result,
+                FlowCrossCheck::Checked(VerificationResult::Mismatch { .. })
+            ),
+            "the graph should refuse to confirm this Allow; got {result:?}"
+        );
+    }
+
+    /// The complement: an IFC refusal on the same session IS confirmed, so the
+    /// check is not simply reporting Mismatch for everything tainted.
+    #[test]
+    fn an_ifc_refusal_on_the_same_session_is_confirmed() {
+        let mut flow = FlowTracker::new();
+        flow.observe(NodeKind::WebContent).expect("observe");
+
+        let denied = decision_with(Verdict::Deny(DenyReason::IfcUnsafe {
+            detail: "lethal trifecta".to_string(),
+        }));
+        assert_eq!(
+            cross_check_flow(&flow, &denied, Operation::WebFetch),
+            Some(FlowCrossCheck::Checked(VerificationResult::Confirmed)),
+            "the graph agrees this should be denied; the check must say so"
+        );
+    }
+
+    /// A capability refusal is not a flow refusal. Conflating them would make
+    /// every budget or path denial look like an IFC finding, which is how a
+    /// real signal gets ignored.
+    #[test]
+    fn a_capability_refusal_is_judged_on_the_flow_axis_only() {
+        let mut flow = FlowTracker::new();
+        flow.observe(NodeKind::UserPrompt).expect("observe");
+        flow.observe(NodeKind::WebContent).expect("observe");
+
+        // Same session, same operation: a non-IFC denial must be treated as
+        // "flow was fine, something else stopped it" — i.e. compared against
+        // Allow, exactly as the Allow case above.
+        let cap_denied = decision_with(Verdict::Deny(DenyReason::InsufficientCapability));
+        let allowed = decision_with(Verdict::Allow);
+        assert_eq!(
+            cross_check_flow(&flow, &cap_denied, Operation::WebFetch),
+            cross_check_flow(&flow, &allowed, Operation::WebFetch),
+            "a capability refusal must not be scored differently on the flow axis"
+        );
+    }
+
+    /// **No silent caps.** Above the ceiling the check does not run — and must
+    /// say so distinctly, because "we did not look" read as "we looked and it
+    /// was fine" is the worst possible reading of an evidence field.
+    #[test]
+    fn an_oversized_graph_is_skipped_visibly_not_silently() {
+        let mut flow = FlowTracker::new();
+        flow.observe(NodeKind::WebContent).expect("observe");
+        while flow.node_count() <= MAX_CROSS_CHECK_NODES {
+            flow.observe(NodeKind::UserPrompt).expect("observe");
+        }
+
+        let result = cross_check_flow(&flow, &decision_with(Verdict::Allow), Operation::WebFetch)
+            .expect("an oversized graph must still report something");
+        assert_eq!(
+            result,
+            FlowCrossCheck::SkippedGraphTooLarge,
+            "the skip must be distinguishable from a confirmation"
+        );
+        assert_ne!(
+            result,
+            FlowCrossCheck::Checked(VerificationResult::Confirmed),
+            "a skipped check must never read as confirmed"
+        );
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Independent re-derivation of the flow verdict (the ZkFlowInput producer)
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Cross-check the kernel's IFC verdict against the session's causal DAG.
+///
+/// # What this is
+///
+/// `verify_noninterference` walks the DAG, propagates labels from parents to
+/// children, and evaluates `check_flow` on the action node. Until now it had a
+/// zkVM guest, a CLI subcommand, and **no producer** — it only ever ran on
+/// hand-written fixtures. This is the producer, and it makes the function a live
+/// second opinion: the kernel decides, and an independent evaluator over the
+/// graph says whether the graph implies the same thing.
+///
+/// A `Mismatch` is a real finding either way round. The kernel allowed something
+/// the causal graph says it should not have, or refused something the graph does
+/// not justify.
+///
+/// # Only the IFC axis
+///
+/// The kernel's `Verdict` covers capabilities, budget, approval and flow. Only
+/// the last is comparable to a `FlowVerdict`, so a capability refusal maps to
+/// `FlowVerdict::Allow` here — the flow was fine, something else stopped it.
+/// Conflating the two would make every budget denial look like an IFC finding.
+///
+/// # Measured cost, and why there is a ceiling
+///
+/// The check is O(nodes): it snapshots the DAG and re-walks it. Measured on this
+/// machine (release, 100 iterations per point):
+///
+/// | nodes  | per decision |
+/// |--------|--------------|
+/// | 10     | 460 ns       |
+/// | 100    | 3.1 µs       |
+/// | 1 000  | 33 µs        |
+/// | 10 000 | 458 µs       |
+///
+/// Half a millisecond per decision on a long-lived session is not a cost to take
+/// silently, so above [`MAX_CROSS_CHECK_NODES`] the check is SKIPPED and says so
+/// — `skipped:graph_too_large`, which is neither a confirmation nor a finding.
+/// Truncating the graph instead was rejected: a smaller graph can confirm a
+/// verdict the full graph would refuse, which is a false assurance rather than a
+/// slower one.
+///
+/// # Why only on tainted sessions
+///
+/// On a session with no adversarial node the action has no parents, its label is
+/// the intrinsic label of an outbound action, and the answer is `Allow` by
+/// construction — confirming it costs an O(nodes) snapshot to learn nothing.
+/// The check runs where its answer can differ.
+/// Graph size above which the cross-check is skipped rather than paid for.
+/// ~135 µs per decision at this size, by the measurement in
+/// [`cross_check_flow`].
+pub(crate) const MAX_CROSS_CHECK_NODES: usize = 4096;
+
+/// Outcome of the cross-check, including the reasons it did not run.
+///
+/// A three-way answer rather than `Option<VerificationResult>` so that "we did
+/// not look" can never be read as "we looked and it was fine".
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum FlowCrossCheck {
+    /// The DAG was consulted; this is what it said.
+    Checked(nucleus::portcullis::flow::VerificationResult),
+    /// The graph exceeded [`MAX_CROSS_CHECK_NODES`].
+    SkippedGraphTooLarge,
+}
+
+pub(crate) fn cross_check_flow(
+    flow: &FlowTracker,
+    decision: &Decision,
+    operation: Operation,
+) -> Option<FlowCrossCheck> {
+    use nucleus::portcullis::flow::{FlowVerdict, ZkFlowInput};
+
+    if !flow.is_tainted() {
+        return None;
+    }
+    if flow.node_count() > MAX_CROSS_CHECK_NODES {
+        return Some(FlowCrossCheck::SkippedGraphTooLarge);
+    }
+
+    // The kernel's verdict, projected onto the flow axis.
+    let expected = match &decision.verdict {
+        Verdict::Deny(DenyReason::IfcUnsafe { .. }) => {
+            // The DAG must agree that SOMETHING is denied; which reason the two
+            // paths name is not required to match, since the kernel's detail
+            // string and `FlowDenyReason` are different vocabularies.
+            None
+        }
+        _ => Some(FlowVerdict::Allow),
+    };
+
+    let parents: Vec<u64> = flow.latest_adversarial_node().into_iter().collect();
+    let input = ZkFlowInput::for_action(
+        flow.snapshot(),
+        operation,
+        Some(nucleus::portcullis::default_sink_class(operation)),
+        &parents,
+        expected.unwrap_or(FlowVerdict::Allow),
+    );
+
+    let result = nucleus::portcullis::flow::verify_noninterference(&input);
+
+    match (&expected, &result) {
+        // Kernel said IFC-deny and the graph agrees it is not an Allow.
+        (
+            None,
+            nucleus::portcullis::flow::VerificationResult::Mismatch {
+                computed: FlowVerdict::Deny(_),
+                ..
+            },
+        ) => Some(FlowCrossCheck::Checked(
+            nucleus::portcullis::flow::VerificationResult::Confirmed,
+        )),
+        _ => Some(FlowCrossCheck::Checked(result)),
+    }
 }

--- a/crates/nucleus-tool-proxy/src/verdict_sink.rs
+++ b/crates/nucleus-tool-proxy/src/verdict_sink.rs
@@ -301,6 +301,14 @@ impl VerdictSink for ToolProxyVerdictSink {
 /// most call sites the effect has already happened and returning an error would
 /// invite a retry that doubles it. The gap is surfaced as a warning and, once
 /// the durable log is wired, counted so it is explicit rather than silent.
+///
+/// `flow_check` is the causal DAG's independent opinion of the same decision
+/// (`mediation::cross_check_flow`), `None` when the session is untainted and the
+/// answer is fixed. It is a REQUIRED parameter rather than something a caller
+/// may attach: the check exists to be visible in evidence, and a check whose
+/// result only reaches a log line is one a later edit can delete with every test
+/// still green. Passing it here means the call cannot be removed without the
+/// build failing.
 pub(crate) fn record_kernel_decision(
     sink: &dyn VerdictSink,
     decision: &portcullis::kernel::Decision,
@@ -308,6 +316,7 @@ pub(crate) fn record_kernel_decision(
     subject: &str,
     actor: ActorIdentity,
     transport: &str,
+    flow_check: Option<crate::mediation::FlowCrossCheck>,
 ) {
     use portcullis::gate_class;
     use portcullis::kernel::Verdict;
@@ -333,6 +342,32 @@ pub(crate) fn record_kernel_decision(
         "post_permissions_hash".to_string(),
         decision.post_permissions_hash.clone(),
     );
+    // The DAG's second opinion. `confirmed` / `unconfirmed:<kind>` rather than
+    // the full result: which node broke the flow is session state, and this
+    // record crosses a process boundary.
+    if let Some(check) = &flow_check {
+        extensions.insert(
+            "flow_cross_check".to_string(),
+            match check {
+                crate::mediation::FlowCrossCheck::SkippedGraphTooLarge => {
+                    // Neither a confirmation nor a finding: the check did not run.
+                    "skipped:graph_too_large".to_string()
+                }
+                crate::mediation::FlowCrossCheck::Checked(v) => match v {
+                    portcullis::flow::VerificationResult::Confirmed => "confirmed".to_string(),
+                    portcullis::flow::VerificationResult::Mismatch { .. } => {
+                        "unconfirmed:mismatch".to_string()
+                    }
+                    portcullis::flow::VerificationResult::ActionNodeNotFound => {
+                        "unconfirmed:action_node_not_found".to_string()
+                    }
+                    portcullis::flow::VerificationResult::BrokenParentRef { .. } => {
+                        "unconfirmed:broken_parent_ref".to_string()
+                    }
+                },
+            },
+        );
+    }
     extensions.insert(
         "dynamic_gate_applied".to_string(),
         decision
@@ -454,6 +489,126 @@ mod tests {
             locked.preflight(Operation::ReadFiles).unwrap_err(),
             SinkError::Locked
         ));
+    }
+
+    /// A sink that keeps what it was handed, so a test can assert on what the
+    /// recording RECEIVED rather than on what was available to it.
+    #[derive(Default)]
+    struct CapturingSink(std::sync::Mutex<Vec<VerdictContext>>);
+    impl VerdictSink for CapturingSink {
+        fn record(&self, ctx: VerdictContext) -> Result<(), SinkError> {
+            self.0.lock().unwrap().push(ctx);
+            Ok(())
+        }
+        fn preflight(&self, _op: Operation) -> Result<(), SinkError> {
+            Ok(())
+        }
+    }
+
+    fn sample_decision() -> portcullis::kernel::Decision {
+        portcullis::kernel::Decision {
+            id: uuid::Uuid::nil(),
+            sequence: 7,
+            operation: Operation::WebFetch,
+            subject: "s".to_string(),
+            verdict: portcullis::kernel::Verdict::Allow,
+            timestamp: chrono::Utc::now(),
+            pre_permissions_hash: "pre".to_string(),
+            post_permissions_hash: "post".to_string(),
+            exposure_transition: portcullis::kernel::ExposureTransition {
+                pre_count: 0,
+                post_count: 0,
+                contributed_label: None,
+                state_uninhabitable: false,
+                dynamic_gate_applied: false,
+            },
+            flow_node_id: None,
+            action_term: None,
+            preflight_result: None,
+        }
+    }
+
+    /// **The cross-check must reach evidence, not just a log line.** This is why
+    /// `flow_check` is a parameter: a check whose only output is `tracing::warn`
+    /// can be deleted with every test still green, which is the defect the whole
+    /// exercise is about.
+    #[test]
+    fn the_flow_cross_check_reaches_the_record() {
+        let sink = CapturingSink::default();
+        record_kernel_decision(
+            &sink,
+            &sample_decision(),
+            Operation::WebFetch,
+            "s",
+            ActorIdentity::Unknown,
+            "http",
+            Some(crate::mediation::FlowCrossCheck::Checked(
+                portcullis::flow::VerificationResult::Mismatch {
+                    computed: portcullis::flow::FlowVerdict::Deny(
+                        portcullis::flow::FlowDenyReason::IntegrityViolation,
+                    ),
+                    expected: portcullis::flow::FlowVerdict::Allow,
+                },
+            )),
+        );
+        let recorded = sink.0.lock().unwrap();
+        assert_eq!(recorded.len(), 1);
+        assert_eq!(
+            recorded[0]
+                .extensions
+                .get("flow_cross_check")
+                .map(String::as_str),
+            Some("unconfirmed:mismatch"),
+            "the DAG's disagreement with the kernel must be in the record"
+        );
+    }
+
+    /// An untainted session is not checked, and the record says nothing rather
+    /// than claiming confirmation it never obtained.
+    #[test]
+    fn an_unchecked_decision_claims_nothing() {
+        let sink = CapturingSink::default();
+        record_kernel_decision(
+            &sink,
+            &sample_decision(),
+            Operation::WebFetch,
+            "s",
+            ActorIdentity::Unknown,
+            "http",
+            None,
+        );
+        let recorded = sink.0.lock().unwrap();
+        assert!(
+            !recorded[0].extensions.contains_key("flow_cross_check"),
+            "absent must read as 'not checked', never as 'confirmed'"
+        );
+    }
+
+    /// The record carries the verification CLASS, not which node broke the flow.
+    /// Everything in `extensions` crosses a process boundary.
+    #[test]
+    fn the_record_does_not_export_which_node_broke_the_flow() {
+        let sink = CapturingSink::default();
+        record_kernel_decision(
+            &sink,
+            &sample_decision(),
+            Operation::WebFetch,
+            "s",
+            ActorIdentity::Unknown,
+            "http",
+            Some(crate::mediation::FlowCrossCheck::Checked(
+                portcullis::flow::VerificationResult::BrokenParentRef {
+                    node_id: 41,
+                    parent_id: 42,
+                },
+            )),
+        );
+        let recorded = sink.0.lock().unwrap();
+        let v = recorded[0].extensions.get("flow_cross_check").unwrap();
+        assert!(
+            !v.contains("41") && !v.contains("42"),
+            "node ids leaked: {v}"
+        );
     }
 
     #[test]

--- a/crates/portcullis/src/lib.rs
+++ b/crates/portcullis/src/lib.rs
@@ -311,6 +311,11 @@ pub use portcullis_core::witness::{ChainVerifyError as WitnessChainVerifyError, 
 // Re-export the information-flow tracker so downstream runtimes (e.g. the MCP
 // server in nucleus-tool-proxy) can drive `Kernel::decide_term_with_flow`
 // without depending on portcullis-core directly (#1633).
+/// The kernel's flow module, re-exported so a downstream runtime can build a
+/// `ZkFlowInput` from a live `FlowTracker` without taking a direct
+/// portcullis-core dependency — the same reason `FlowTracker` is re-exported
+/// above.
+pub use portcullis_core::flow;
 pub use portcullis_core::flow::NodeKind;
 pub use portcullis_core::ifc_api::{FlowTracker, SafetyCheck};
 


### PR DESCRIPTION
`ZkFlowInput` has a zkVM guest, a working verifier and a CLI subcommand, and had **no producer** — nothing could turn a live session into one, so `verify_noninterference` only ever ran on hand-written fixtures. This is the producer, and it turns that function into a live cross-check.

Vocabulary: this is **decision provenance** in the sense of [Singh, Cobbe & Norval](https://arxiv.org/pdf/1804.05741) — using data-flow provenance to make automated decisions accountable — rather than a bespoke mechanism.

## Why it did not exist

The information is split across two objects. `FlowTracker` holds the causal DAG; the action being authorised is in the kernel's `Decision`. Neither alone can build the input, and nothing joined them.

**The naive join is worse than nothing.** Every node a `FlowTracker` holds was made by an `observe*` call, so it carries no operation — and `check_flow` returns `Allow` for any node with `operation: None`. Hand the verifier the session's graph and it confirms `Allow` for *every session, however tainted*.

That failure mode is pinned by `a_snapshot_alone_would_confirm_allow_for_a_maximally_tainted_session`, so the other tests are known to be testing something.

`ZkFlowInput::for_action` appends what is missing: an `OutboundAction` node with the operation and sink class the kernel decided on, whose label is **derived** from its parents via `propagate_label` rather than accepted from the caller. A prover cannot hand the verifier a flattering label.

## The live path

`mediation::cross_check_flow` runs on every kernel decision, on both transports. The result is a **required parameter** of `record_kernel_decision`, not a log line — a check whose only output is `tracing::warn` can be deleted with every test still green.

Honest limit: being a parameter prevents *silent* deletion, but a caller could still pass `None` deliberately. That is weaker than the module boundary #2143 used.

Only the IFC axis is compared. A capability or budget refusal maps to `FlowVerdict::Allow` — the flow was fine, something else stopped it. Conflating them would make every budget denial look like an IFC finding, which is how a real signal gets ignored.

## Measured, then bounded visibly

O(nodes), release, 100 iterations per point:

| nodes | per decision |
|-------|--------------|
| 10 | 460 ns |
| 100 | 3.1 µs |
| 1 000 | 33 µs |
| 10 000 | 458 µs |

Above `MAX_CROSS_CHECK_NODES` (4096) the check is **skipped** and records `skipped:graph_too_large` — a third value, distinct from both a confirmation and a finding. Truncating the graph was rejected: a smaller graph can confirm a verdict the full graph would refuse, which is false assurance rather than slower assurance. Untainted sessions aren't checked at all; there the answer is `Allow` by construction.

Only the verification **class** crosses the process boundary — which node broke the flow is session state.

## Verification

Perturbations, each REDing at the expected location for the expected cause: remove the tainted-session bound; stop deriving the action label from parents (REDs two); drop the record extension (REDs two).

The kernel boundary ratchet rejected `flow.rs` reaching up to `FlowTracker` — from its own `#[cfg(test)]` module, and again through an intra-doc link. Both correct: `flow.rs` is kernel. Tests moved to `tests/zk_flow_producer.rs`, which composes the two halves across the same public surface a real producer must.

fmt / clippy `--workspace --all-targets --all-features -D warnings` / `cargo test --all-features` (221 suites, 0 failures) / line ratchet `--strict` / mediation gate / sealed-home gate: all green.