### PR TITLE
Wire the Article 12 log to the live decision path

### DIFF
--- a/crates/nucleus-tool-proxy/src/art12.rs
+++ b/crates/nucleus-tool-proxy/src/art12.rs
@@ -43,15 +43,18 @@
 //! one. Both properties are asserted by tests, including the one that
 //! deliberately demonstrates the HMAC limit.
 //!
-//! # Why `allow(dead_code)` here
+//! # Wired
 //!
-//! This module is landed UNWIRED on purpose: the staging puts every unit and
-//! perturbation test green before anything on the live decision path changes.
-//! Until the sink is wired to it (the increment that adds `--art12-log`),
-//! nothing outside the tests constructs an `Art12Log`, and CI builds with
-//! `-D warnings`. **Remove this allow in the wiring increment** — once the sink
-//! calls `append`, genuinely dead code here should fail the build again.
-#![allow(dead_code)]
+//! This module was landed UNWIRED on purpose, behind `#![allow(dead_code)]`, so
+//! that every unit and perturbation test was green before anything on the live
+//! decision path changed. That allow said to remove it in the wiring increment,
+//! and this is that increment: `--art12-log` opens the log at startup and
+//! `Art12Sink` appends a record for every verdict.
+//!
+//! The allow is gone, which is not cosmetic — with `-D warnings`, genuinely dead
+//! code here now fails the build again. That is the check that the wiring is
+//! real: if the sink stopped calling `append`, this module would go dead and CI
+//! would say so.
 
 use std::fs::{File, OpenOptions};
 use std::io::Write;
@@ -140,6 +143,22 @@ impl Art12Log {
             dropped: AtomicU64::new(0),
             console_mirror,
         })
+    }
+
+    /// Latch the degraded flag without a real write failure.
+    ///
+    /// `#[cfg(test)]`, so it does not exist in a production build — the concern
+    /// with test affordances is that they are REACHABLE from production, and
+    /// this one is compiled out. It exists because a genuine write failure is
+    /// not reliably reproducible: on unix an already-open descriptor keeps
+    /// accepting writes after the file is unlinked and after its directory is
+    /// removed. The alternative was a test with a conditional early return,
+    /// which passes without asserting anything on exactly the platforms where
+    /// the write succeeds.
+    #[cfg(test)]
+    pub(crate) fn force_degraded(&self) {
+        self.degraded.store(true, Ordering::Release);
+        self.dropped.fetch_add(1, Ordering::AcqRel);
     }
 
     /// Whether a write has failed since startup.

--- a/crates/nucleus-tool-proxy/src/art12_sink.rs
+++ b/crates/nucleus-tool-proxy/src/art12_sink.rs
@@ -115,6 +115,62 @@ pub(crate) fn reject_workspace_path(path: &Path, work_dir: &Path) -> Result<(), 
     Ok(())
 }
 
+/// Open the Article 12 log for a session, refusing a workspace-local path.
+///
+/// Lives here rather than in `main.rs` so the startup sequence is one call: the
+/// path check, the secret choice and the genesis anchor are a single decision
+/// about evidence, and splitting them across a long `main` is how one of them
+/// gets edited without the others.
+///
+/// The secret defaults to a session-derived value when no audit secret is
+/// configured. That is weaker than an operator-held secret — a pod that derives
+/// its own signing key can re-sign a rewritten chain — and is reported as a
+/// limitation by the verifier rather than passed off as tamper-evidence.
+pub(crate) fn open_log(
+    path: &Path,
+    audit_secret: Option<&str>,
+    work_dir: &Path,
+    session_id: &str,
+) -> Result<Arc<Art12Log>, String> {
+    reject_workspace_path(path, work_dir).map_err(|e| e.to_string())?;
+    let secret = audit_secret.map_or_else(
+        || format!("art12:{session_id}").into_bytes(),
+        |s| s.as_bytes().to_vec(),
+    );
+    // A dedicated genesis string rather than a borrowed hash: the audit log is
+    // constructed later in startup, and reaching for a value that does not exist
+    // yet is how an anchor silently becomes the empty string.
+    let genesis = format!("art12-genesis:{session_id}");
+    let log = Art12Log::open(path, secret, genesis, false)
+        .map_err(|e| format!("failed to open Article 12 log: {e:?}"))?;
+    Ok(Arc::new(log))
+}
+
+/// The Article 12 log's state, for `/v1/health`.
+///
+/// `configured: false` says plainly that no log is being kept, rather than
+/// leaving a host to infer it from an absent field — the same reason
+/// `dlc_admission` reports "unprovisioned" instead of going quiet.
+///
+/// The chain head is published so a host can tie the log it holds to the process
+/// that wrote it. It is a hash of records the runtime made ABOUT this session,
+/// not session content.
+pub(crate) fn health_json(log: Option<&Arc<Art12Log>>) -> serde_json::Value {
+    match log {
+        None => serde_json::json!({ "configured": false }),
+        Some(log) => {
+            let (head, records) = log.head().unwrap_or_else(|_| (String::new(), 0));
+            serde_json::json!({
+                "configured": true,
+                "degraded": log.is_degraded(),
+                "records": records,
+                "dropped": log.dropped(),
+                "chain_head": head,
+            })
+        }
+    }
+}
+
 /// Appends an Article 12 record for every verdict, then delegates.
 pub(crate) struct Art12Sink {
     inner: Arc<dyn VerdictSink>,

--- a/crates/nucleus-tool-proxy/src/art12_sink.rs
+++ b/crates/nucleus-tool-proxy/src/art12_sink.rs
@@ -1,0 +1,471 @@
+//! The Article 12 record-keeping log, on the live decision path.
+//!
+//! `art12.rs` was landed deliberately unwired — its own module docs say so, and
+//! name the removal condition for its `allow(dead_code)`. This is that
+//! increment: a [`VerdictSink`] that projects each verdict into an
+//! [`Art12Record`] and appends it to the chained log.
+//!
+//! # Why a sink wrapper
+//!
+//! The record must exist for **every** decision the runtime makes, including
+//! refusals. Putting the projection at a call site would reintroduce the defect
+//! #2127 fixed: a refusal returns through `?` before any later step runs. A sink
+//! in the chain sees exactly what the chain sees, and there is no path around
+//! it — the sink is built by `build_monitored_sink`, which is the only
+//! constructor callers can reach.
+//!
+//! # It fails CLOSED, and that is the point of wiring it
+//!
+//! `Art12Log` latches `degraded` when a write fails and counts what it dropped.
+//! Consulting that in [`preflight`](Art12Sink::preflight) means the NEXT
+//! operation is denied before it executes: evidence loss is bounded to the
+//! records already lost, rather than continuing silently. An Article 12 log that
+//! keeps going after it stops recording is worse than no log, because the gap is
+//! invisible in the artifact.
+//!
+//! Calls whose effect has already happened are not failed retroactively — the
+//! latch is read at preflight, not at record.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use portcullis::art12_record::{Actor, Art12Record, DenyInfo};
+use portcullis::verdict_sink::{
+    ActorIdentity, SinkError, VerdictContext, VerdictOutcome, VerdictSink,
+};
+use portcullis::Operation;
+
+use crate::art12::Art12Log;
+
+/// Why a log path was refused.
+#[derive(Debug)]
+pub(crate) enum Art12PathError {
+    /// The path is inside the agent's workspace.
+    InsideWorkspace { path: PathBuf, work_dir: PathBuf },
+}
+
+impl std::fmt::Display for Art12PathError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InsideWorkspace { path, work_dir } => write!(
+                f,
+                "the Article 12 log path {} is inside the agent workspace {} -- the log is the \
+                 runtime's record ABOUT this session and must not be in the session's own read \
+                 surface (see #2145); choose a host-private path",
+                path.display(),
+                work_dir.display()
+            ),
+        }
+    }
+}
+
+/// Refuse a log path that lands inside the agent's workspace.
+///
+/// Learned from #2145: `.nucleus-exit-report.json` was written into `work_dir`
+/// and the agent's path lattice permitted reading it. The Article 12 log is a
+/// strictly richer record of the same kind — every decision, with gate class and
+/// deny code — so it must not repeat that. This is checked at startup and
+/// refuses to boot rather than warning, because a misconfigured evidence path is
+/// not something to discover from an artifact later.
+///
+/// # Normalising a path that does not exist yet
+///
+/// The log file has not been created when this runs, so `canonicalize` on it
+/// fails — and falling back to the raw path compares an unresolved path against
+/// a resolved one. On macOS that alone defeats the check, because the workspace
+/// canonicalises `/var/...` to `/private/var/...` and the prefix test then never
+/// matches. The first version of this function had exactly that bug and its test
+/// caught it; a guard that silently never fires is worse than no guard.
+///
+/// So: canonicalise the deepest ancestor that DOES exist, then re-attach the
+/// remaining components. Both sides end up resolved through the same symlinks.
+///
+/// This is a guard against misconfiguration, not a defence against a hostile
+/// operator — the operator supplies both paths.
+pub(crate) fn reject_workspace_path(path: &Path, work_dir: &Path) -> Result<(), Art12PathError> {
+    /// Canonicalise as much of `p` as exists, keeping the rest verbatim.
+    fn resolve(p: &Path) -> PathBuf {
+        if let Ok(c) = p.canonicalize() {
+            return c;
+        }
+        let mut suffix: Vec<std::ffi::OsString> = Vec::new();
+        let mut cur = p;
+        while let Some(parent) = cur.parent() {
+            if let Some(name) = cur.file_name() {
+                suffix.push(name.to_os_string());
+            }
+            if let Ok(c) = parent.canonicalize() {
+                let mut out = c;
+                for part in suffix.iter().rev() {
+                    out.push(part);
+                }
+                return out;
+            }
+            cur = parent;
+        }
+        p.to_path_buf()
+    }
+    let (p, w) = (resolve(path), resolve(work_dir));
+    if p.starts_with(&w) {
+        return Err(Art12PathError::InsideWorkspace {
+            path: p,
+            work_dir: w,
+        });
+    }
+    Ok(())
+}
+
+/// Appends an Article 12 record for every verdict, then delegates.
+pub(crate) struct Art12Sink {
+    inner: Arc<dyn VerdictSink>,
+    log: Arc<Art12Log>,
+    session_id: String,
+    policy_checksum: String,
+    dlc_provisioned: bool,
+}
+
+impl Art12Sink {
+    pub(crate) fn new(
+        inner: Arc<dyn VerdictSink>,
+        log: Arc<Art12Log>,
+        session_id: String,
+        policy_checksum: String,
+        dlc_provisioned: bool,
+    ) -> Self {
+        Self {
+            inner,
+            log,
+            session_id,
+            policy_checksum,
+            dlc_provisioned,
+        }
+    }
+
+    /// Project a verdict into an Article 12 record draft.
+    ///
+    /// A total function of the context plus this sink's session fields — no
+    /// ambient state, no I/O. Chain fields (`seq`, `prev_hash`, `hash`,
+    /// `signature`) are assigned by `Art12Log::append` and left empty here.
+    ///
+    /// Extracted and public-in-crate so the test asserts on the SAME function
+    /// the sink calls, rather than restating what it expects the sink to do.
+    pub(crate) fn project(&self, ctx: &VerdictContext) -> Art12Record {
+        let ext = |k: &str| ctx.extensions.get(k).cloned();
+
+        let (verdict, deny_reason) = match &ctx.outcome {
+            VerdictOutcome::Allow => ("allow", None),
+            VerdictOutcome::RequiresApproval { .. } => ("requires_approval", None),
+            VerdictOutcome::Deny { reason } => (
+                "deny",
+                Some(DenyInfo {
+                    // The machine-stable code the kernel recorded, when this is
+                    // a kernel decision; handler-side refusals carry none, and
+                    // saying so beats inventing one.
+                    code: ext("deny_code").unwrap_or_else(|| "unclassified".to_string()),
+                    detail: Some(reason.clone()),
+                }),
+            ),
+            // `VerdictOutcome` is #[non_exhaustive]: an outcome this build does
+            // not know must not read as "allow" in a regulatory record.
+            other => (
+                "error",
+                Some(DenyInfo {
+                    code: "unclassified_outcome".to_string(),
+                    detail: Some(format!("{other:?}")),
+                }),
+            ),
+        };
+
+        // Everything the recorder attached that is not already a named field
+        // travels as extensions — including `flow_cross_check` (#2144), so the
+        // DAG's second opinion is in the regulatory record and not only in a log.
+        let extensions = ctx
+            .extensions
+            .iter()
+            .filter(|(k, _)| {
+                !matches!(
+                    k.as_str(),
+                    "transport" | "decision_sequence" | "gate_class" | "deny_code"
+                )
+            })
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+
+        Art12Record {
+            // Assigned by `Art12Log::append`.
+            schema_version: 0,
+            seq: 0,
+            prev_hash: String::new(),
+            hash: String::new(),
+            signature: String::new(),
+
+            timestamp_unix: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs(),
+            session_id: self.session_id.clone(),
+            transport: ext("transport").unwrap_or_else(|| "unknown".to_string()),
+            actor: match &ctx.actor {
+                ActorIdentity::Authenticated { spiffe_id } => Actor {
+                    kind: "authenticated".to_string(),
+                    spiffe_id: Some(spiffe_id.clone()),
+                },
+                ActorIdentity::StdioGuest => Actor {
+                    kind: "stdio_guest".to_string(),
+                    spiffe_id: None,
+                },
+                ActorIdentity::Unknown => Actor {
+                    kind: "unknown".to_string(),
+                    spiffe_id: None,
+                },
+            },
+            operation: operation_name(ctx.operation).to_string(),
+            subject: ctx.subject.clone(),
+            verdict: verdict.to_string(),
+            gate_class: ext("gate_class").unwrap_or_else(|| "none".to_string()),
+            deny_reason,
+            policy_checksum: self.policy_checksum.clone(),
+            policy_rule: ctx.policy_rule.clone(),
+            dlc_admission: if self.dlc_provisioned {
+                if verdict == "allow" {
+                    "admitted".to_string()
+                } else {
+                    "not_admitted".to_string()
+                }
+            } else {
+                "unprovisioned".to_string()
+            },
+            lockdown_active: ext("lockdown_active").is_some_and(|v| v == "true"),
+            decision_sequence: ext("decision_sequence").and_then(|s| s.parse().ok()),
+            extensions,
+        }
+    }
+}
+
+/// Canonical operation names, matching the audit log's vocabulary.
+fn operation_name(op: Operation) -> &'static str {
+    match op {
+        Operation::ReadFiles => "read_files",
+        Operation::WriteFiles => "write_files",
+        Operation::EditFiles => "edit_files",
+        Operation::RunBash => "run_bash",
+        Operation::GlobSearch => "glob_search",
+        Operation::GrepSearch => "grep_search",
+        Operation::WebSearch => "web_search",
+        Operation::WebFetch => "web_fetch",
+        Operation::GitCommit => "git_commit",
+        Operation::GitPush => "git_push",
+        Operation::CreatePr => "create_pr",
+        Operation::ManagePods => "manage_pods",
+        Operation::SpawnAgent => "spawn_agent",
+    }
+}
+
+impl VerdictSink for Art12Sink {
+    fn record(&self, ctx: VerdictContext) -> Result<(), SinkError> {
+        let draft = self.project(&ctx);
+        if let Err(e) = self.log.append(draft) {
+            // The log has latched `degraded` and counted the drop; the next
+            // preflight fails closed. Do not fail this call: its effect may
+            // already have happened, and returning an error here would invite a
+            // retry that duplicates it.
+            tracing::error!(error = ?e, "article 12 record could not be written -- evidence gap");
+        }
+        self.inner.record(ctx)
+    }
+
+    fn preflight(&self, operation: Operation) -> Result<(), SinkError> {
+        if self.log.is_degraded() {
+            tracing::error!(
+                ?operation,
+                dropped = self.log.dropped(),
+                "refusing: the Article 12 log is degraded and this operation would not be recorded"
+            );
+            return Err(SinkError::Locked);
+        }
+        self.inner.preflight(operation)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+    use tempfile::TempDir;
+
+    struct NullSink;
+    impl VerdictSink for NullSink {
+        fn record(&self, _c: VerdictContext) -> Result<(), SinkError> {
+            Ok(())
+        }
+        fn preflight(&self, _o: Operation) -> Result<(), SinkError> {
+            Ok(())
+        }
+    }
+
+    fn sink_with(log: Arc<Art12Log>) -> Art12Sink {
+        Art12Sink::new(
+            Arc::new(NullSink),
+            log,
+            "sess".to_string(),
+            "checksum".to_string(),
+            false,
+        )
+    }
+
+    fn open_log(dir: &TempDir) -> Arc<Art12Log> {
+        Arc::new(
+            Art12Log::open(
+                &dir.path().join("a12.jsonl"),
+                b"k".to_vec(),
+                "g".into(),
+                false,
+            )
+            .unwrap(),
+        )
+    }
+
+    fn ctx(outcome: VerdictOutcome, ext: &[(&str, &str)]) -> VerdictContext {
+        let mut extensions = BTreeMap::new();
+        for (k, v) in ext {
+            extensions.insert((*k).to_string(), (*v).to_string());
+        }
+        VerdictContext {
+            operation: Operation::RunBash,
+            subject: "rm -rf /".to_string(),
+            outcome,
+            actor: ActorIdentity::StdioGuest,
+            policy_rule: None,
+            extensions,
+        }
+    }
+
+    /// **The reason this module exists.** A refusal must be recorded. An
+    /// Article 12 log containing only allows is non-empty, plausible, and wrong
+    /// in the most dangerous direction.
+    #[test]
+    fn a_refusal_is_recorded_with_its_machine_stable_code() {
+        let dir = TempDir::new().unwrap();
+        let log = open_log(&dir);
+        let sink = sink_with(log.clone());
+
+        sink.record(ctx(
+            VerdictOutcome::Deny {
+                reason: "blocked by the command lattice".to_string(),
+            },
+            &[("deny_code", "command_blocked"), ("gate_class", "hard")],
+        ))
+        .unwrap();
+
+        let lines = std::fs::read_to_string(dir.path().join("a12.jsonl")).unwrap();
+        assert_eq!(lines.lines().count(), 1, "the refusal must be on disk");
+        let rec: serde_json::Value = serde_json::from_str(lines.lines().next().unwrap()).unwrap();
+        assert_eq!(rec["verdict"], "deny");
+        assert_eq!(rec["deny_reason"]["code"], "command_blocked");
+        assert_eq!(rec["gate_class"], "hard");
+    }
+
+    /// The DAG's second opinion (#2144) belongs in the regulatory record, not
+    /// only in a log line — it is the runtime's own evidence that the decision
+    /// followed from the causal graph.
+    #[test]
+    fn the_flow_cross_check_survives_into_the_record() {
+        let dir = TempDir::new().unwrap();
+        let sink = sink_with(open_log(&dir));
+        sink.record(ctx(
+            VerdictOutcome::Allow,
+            &[("flow_cross_check", "unconfirmed:mismatch")],
+        ))
+        .unwrap();
+
+        let line = std::fs::read_to_string(dir.path().join("a12.jsonl")).unwrap();
+        let rec: serde_json::Value = serde_json::from_str(line.trim()).unwrap();
+        assert_eq!(
+            rec["extensions"]["flow_cross_check"],
+            "unconfirmed:mismatch"
+        );
+    }
+
+    /// An unknown outcome must not read as `allow` in a regulatory record.
+    /// `VerdictOutcome` is `#[non_exhaustive]`, so this is reachable by a
+    /// version skew rather than only in principle.
+    #[test]
+    fn a_deny_without_a_code_says_unclassified_rather_than_inventing_one() {
+        let dir = TempDir::new().unwrap();
+        let sink = sink_with(open_log(&dir));
+        // A handler-side refusal: no kernel decision, so no `deny_code`.
+        sink.record(ctx(
+            VerdictOutcome::Deny {
+                reason: "validation: bad path".to_string(),
+            },
+            &[],
+        ))
+        .unwrap();
+
+        let line = std::fs::read_to_string(dir.path().join("a12.jsonl")).unwrap();
+        let rec: serde_json::Value = serde_json::from_str(line.trim()).unwrap();
+        assert_eq!(rec["deny_reason"]["code"], "unclassified");
+        assert_ne!(rec["verdict"], "allow");
+    }
+
+    /// **Fail closed.** Once the log is degraded the NEXT operation is refused —
+    /// a record-keeping log that keeps going after it stops recording leaves an
+    /// invisible gap in the artifact, which is worse than no log at all.
+    #[test]
+    fn a_degraded_log_refuses_the_next_operation() {
+        let dir = TempDir::new().unwrap();
+        let log = open_log(&dir);
+        let sink = sink_with(log.clone());
+        assert!(
+            sink.preflight(Operation::RunBash).is_ok(),
+            "a healthy log must permit, or the assertion below proves nothing"
+        );
+
+        log.force_degraded();
+
+        assert!(
+            sink.preflight(Operation::RunBash).is_err(),
+            "a degraded Article 12 log must refuse the next operation"
+        );
+    }
+
+    /// A record whose effect may already have happened is still delegated: the
+    /// latch is read at preflight, not at record, so a write failure does not
+    /// retroactively fail a call and invite a duplicating retry.
+    #[test]
+    fn a_degraded_log_does_not_fail_the_call_in_flight() {
+        let dir = TempDir::new().unwrap();
+        let log = open_log(&dir);
+        let sink = sink_with(log.clone());
+        log.force_degraded();
+        assert!(
+            sink.record(ctx(VerdictOutcome::Allow, &[])).is_ok(),
+            "recording must not fail a call whose effect already happened"
+        );
+    }
+
+    /// **The lesson from #2145, enforced at startup.** The Article 12 log is a
+    /// strictly richer record than the exit report — every decision, with gate
+    /// class and deny code — so it must never land where the agent can read it.
+    #[test]
+    fn a_log_path_inside_the_workspace_is_refused() {
+        let work = TempDir::new().unwrap();
+        assert!(
+            reject_workspace_path(&work.path().join("evidence.jsonl"), work.path()).is_err(),
+            "a log path inside the agent workspace must be refused"
+        );
+        assert!(
+            reject_workspace_path(&work.path().join("nested/deep/a.jsonl"), work.path()).is_err(),
+            "nesting must not evade the check"
+        );
+    }
+
+    /// The control: a host-private path is accepted, so the check above is not
+    /// simply refusing everything.
+    #[test]
+    fn a_host_private_log_path_is_accepted() {
+        let work = TempDir::new().unwrap();
+        let elsewhere = TempDir::new().unwrap();
+        assert!(reject_workspace_path(&elsewhere.path().join("a.jsonl"), work.path()).is_ok());
+    }
+}

--- a/crates/nucleus-tool-proxy/src/main.rs
+++ b/crates/nucleus-tool-proxy/src/main.rs
@@ -1516,27 +1516,20 @@ async fn main() -> Result<(), ApiError> {
     // the chain takes it by value and there must be no window in which decisions
     // are made against a chain that is missing it.
     let art12_log = match args.art12_log.as_ref() {
-        Some(path) => {
-            art12_sink::reject_workspace_path(path, &spec.spec.work_dir)
-                .map_err(|e| ApiError::Spec(e.to_string()))?;
-            let secret = args
-                .audit_secret
-                .as_ref()
-                .map_or_else(|| session_id.as_bytes().to_vec(), |s| s.as_bytes().to_vec());
-            // Anchored to the boot report's hash where one exists, so this chain
-            // continues the existing audit chain rather than starting fresh.
-            // The chain's anchor. A dedicated genesis string rather than a
-            // borrowed hash: the audit log is constructed later in this
-            // function, and reaching for a value that does not exist yet is how
-            // an anchor silently becomes the empty string.
-            let genesis = format!("art12-genesis:{session_id}");
-            let log = crate::art12::Art12Log::open(path, secret, genesis, false)
-                .map_err(|e| ApiError::Spec(format!("failed to open Article 12 log: {e:?}")))?;
-            info!(path = %path.display(), "Article 12 record-keeping log opened");
-            Some(Arc::new(log))
-        }
+        Some(path) => Some(
+            art12_sink::open_log(
+                path,
+                args.audit_secret.as_deref(),
+                &spec.spec.work_dir,
+                &session_id,
+            )
+            .map_err(ApiError::Spec)?,
+        ),
         None => None,
     };
+    if let Some(path) = args.art12_log.as_ref() {
+        info!(path = %path.display(), "Article 12 record-keeping log opened");
+    }
 
     let dlc_admission = dlc_admission::provision_from_env();
     let dlc_provisioned = dlc_admission.is_some();
@@ -2401,27 +2394,7 @@ async fn health(State(state): State<AppState>) -> Json<serde_json::Value> {
             "violations": state.trace_monitor.violations().len(),
             "violations_dropped": state.trace_monitor.violations_dropped(),
         },
-        // Article 12 record-keeping. `configured: false` says plainly that no
-        // log is being kept, rather than leaving a host to infer it from an
-        // absent field — the same reason `dlc_admission` reports
-        // "unprovisioned" instead of going quiet.
-        //
-        // The chain head is published so a host can tie the log it holds to the
-        // process that wrote it. It is a hash of records the runtime made about
-        // this session, not session content.
-        "art12": match &state.art12_log {
-            None => serde_json::json!({ "configured": false }),
-            Some(log) => {
-                let (head, records) = log.head().unwrap_or_else(|_| (String::new(), 0));
-                serde_json::json!({
-                    "configured": true,
-                    "degraded": log.is_degraded(),
-                    "records": records,
-                    "dropped": log.dropped(),
-                    "chain_head": head,
-                })
-            }
-        }
+        "art12": art12_sink::health_json(state.art12_log.as_ref())
     }))
 }
 

--- a/crates/nucleus-tool-proxy/src/main.rs
+++ b/crates/nucleus-tool-proxy/src/main.rs
@@ -27,6 +27,7 @@ use tokio::net::TcpListener;
 use tracing::{error, info, warn};
 
 mod art12;
+mod art12_sink;
 mod attestation;
 mod auth;
 mod broker_client;
@@ -106,6 +107,18 @@ struct Args {
     /// Optional audit log signing secret (defaults to auth secret if omitted).
     #[arg(long, env = "NUCLEUS_TOOL_PROXY_AUDIT_SECRET")]
     audit_secret: Option<String>,
+    /// Path for the EU AI Act Article 12 record-keeping log (JSONL, hash-chained).
+    ///
+    /// Absent means no Article 12 log is kept — the runtime does not pretend to
+    /// record-keeping it was not configured for. Present means EVERY kernel
+    /// decision is appended before the operation proceeds, and a write failure
+    /// latches the log degraded so the next operation is refused.
+    ///
+    /// MUST NOT be inside the agent's workspace: the log is the runtime's record
+    /// about the session, and #2145 is the same mistake made with the exit
+    /// report. Startup refuses rather than warns.
+    #[arg(long, env = "NUCLEUS_TOOL_PROXY_ART12_LOG")]
+    art12_log: Option<PathBuf>,
     /// Approval authority secret (separate from tool auth).
     #[arg(long, env = "NUCLEUS_TOOL_PROXY_APPROVAL_SECRET")]
     approval_secret: String,
@@ -345,6 +358,10 @@ pub(crate) struct AppState {
     /// This IS the monitor below — `build_monitored_sink` returns one object
     /// under two handles — so the field cannot hold an unmonitored sink.
     pub(crate) verdict_sink: Arc<dyn portcullis::verdict_sink::VerdictSink>,
+    /// The Article 12 record-keeping log, when configured. Held so the host can
+    /// see the chain head and whether recording is still happening — a log the
+    /// operator cannot observe is one that can stop without anyone noticing.
+    pub(crate) art12_log: Option<Arc<crate::art12::Art12Log>>,
     /// Read handle on the runtime monitor wrapping `verdict_sink`, so the
     /// process can report what the decision stream actually did — live at
     /// `/v1/health`, and at shutdown in the exit report.
@@ -1495,6 +1512,32 @@ async fn main() -> Result<(), ApiError> {
     // DLC-D verified admission: provisioned from NUCLEUS_DLC_* env (inert when
     // unset). The SAME provisioning is applied to both transports' kernels, and
     // the sink stamps every allowed verdict's span with the admission state.
+    // Article 12 record-keeping (opt-in). Opened BEFORE the sink chain, because
+    // the chain takes it by value and there must be no window in which decisions
+    // are made against a chain that is missing it.
+    let art12_log = match args.art12_log.as_ref() {
+        Some(path) => {
+            art12_sink::reject_workspace_path(path, &spec.spec.work_dir)
+                .map_err(|e| ApiError::Spec(e.to_string()))?;
+            let secret = args
+                .audit_secret
+                .as_ref()
+                .map_or_else(|| session_id.as_bytes().to_vec(), |s| s.as_bytes().to_vec());
+            // Anchored to the boot report's hash where one exists, so this chain
+            // continues the existing audit chain rather than starting fresh.
+            // The chain's anchor. A dedicated genesis string rather than a
+            // borrowed hash: the audit log is constructed later in this
+            // function, and reaching for a value that does not exist yet is how
+            // an anchor silently becomes the empty string.
+            let genesis = format!("art12-genesis:{session_id}");
+            let log = crate::art12::Art12Log::open(path, secret, genesis, false)
+                .map_err(|e| ApiError::Spec(format!("failed to open Article 12 log: {e:?}")))?;
+            info!(path = %path.display(), "Article 12 record-keeping log opened");
+            Some(Arc::new(log))
+        }
+        None => None,
+    };
+
     let dlc_admission = dlc_admission::provision_from_env();
     let dlc_provisioned = dlc_admission.is_some();
 
@@ -1509,6 +1552,7 @@ async fn main() -> Result<(), ApiError> {
         policy_checksum.clone(),
         session_id.clone(),
         dlc_provisioned,
+        art12_log.clone(),
     );
 
     if dlc_provisioned {
@@ -1602,6 +1646,7 @@ async fn main() -> Result<(), ApiError> {
         policy_checksum,
         session_id,
         verdict_sink,
+        art12_log,
         trace_monitor,
         kernel,
         flow_tracker,
@@ -2355,6 +2400,27 @@ async fn health(State(state): State<AppState>) -> Json<serde_json::Value> {
         "trace_monitor": {
             "violations": state.trace_monitor.violations().len(),
             "violations_dropped": state.trace_monitor.violations_dropped(),
+        },
+        // Article 12 record-keeping. `configured: false` says plainly that no
+        // log is being kept, rather than leaving a host to infer it from an
+        // absent field — the same reason `dlc_admission` reports
+        // "unprovisioned" instead of going quiet.
+        //
+        // The chain head is published so a host can tie the log it holds to the
+        // process that wrote it. It is a hash of records the runtime made about
+        // this session, not session content.
+        "art12": match &state.art12_log {
+            None => serde_json::json!({ "configured": false }),
+            Some(log) => {
+                let (head, records) = log.head().unwrap_or_else(|_| (String::new(), 0));
+                serde_json::json!({
+                    "configured": true,
+                    "degraded": log.is_degraded(),
+                    "records": records,
+                    "dropped": log.dropped(),
+                    "chain_head": head,
+                })
+            }
         }
     }))
 }

--- a/crates/nucleus-tool-proxy/src/verdict_sink.rs
+++ b/crates/nucleus-tool-proxy/src/verdict_sink.rs
@@ -63,16 +63,32 @@ pub fn build_monitored_sink(
     policy_checksum: String,
     session_id: String,
     dlc_provisioned: bool,
+    art12_log: Option<Arc<crate::art12::Art12Log>>,
 ) -> (Arc<dyn VerdictSink>, Arc<TraceMonitor>) {
-    let inner = Arc::new(ToolProxyVerdictSink::new(
+    let inner: Arc<dyn VerdictSink> = Arc::new(ToolProxyVerdictSink::new(
         file_lockdown,
         stream_lockdown,
         capabilities,
         exposure_guard,
-        policy_checksum,
-        session_id,
+        policy_checksum.clone(),
+        session_id.clone(),
         dlc_provisioned,
     ));
+
+    // Article 12 record-keeping, when configured. INSIDE the monitor, so the
+    // monitor still observes every record; and inside this constructor, so
+    // there is no way to assemble a chain that skips it.
+    let inner = match art12_log {
+        Some(log) => Arc::new(crate::art12_sink::Art12Sink::new(
+            inner,
+            log,
+            session_id,
+            policy_checksum,
+            dlc_provisioned,
+        )) as Arc<dyn VerdictSink>,
+        None => inner,
+    };
+
     let monitor = Arc::new(TraceMonitor::new(inner));
     (monitor.clone(), monitor)
 }
@@ -432,6 +448,7 @@ mod tests {
             "test-checksum".to_string(),
             "test-session".to_string(),
             false,
+            None,
         )
     }
 
@@ -483,6 +500,7 @@ mod tests {
             "test-checksum".to_string(),
             "test-session".to_string(),
             false,
+            None,
         )
         .0;
         assert!(matches!(


### PR DESCRIPTION
`art12.rs` was landed deliberately unwired behind `#![allow(dead_code)]`, and its own module docs named the removal condition:

> *"Remove this allow in the wiring increment — once the sink calls `append`, genuinely dead code here should fail the build again."*

This is that increment. Worth saying plainly: this was **declared debt, not a hidden defect**. The module told the truth about its own limits — the opposite of the pattern the last several PRs have been chasing.

## The wiring

`--art12-log <path>` opens the chained log at startup. `Art12Sink` is a `VerdictSink` that projects each verdict into an `Art12Record`, appends it, then delegates. It is built inside `build_monitored_sink` — the only constructor callers can reach — so no chain can be assembled that skips it, and inside the `TraceMonitor` so the monitor still observes every record.

A sink wrapper rather than a call site, for the reason #2127 established: a refusal returns through `?` before any later step runs. **An Article 12 log holding only allows is non-empty, plausible, and wrong in the most dangerous direction.**

Absent flag means no log; the runtime does not pretend to record-keeping it was not configured for.

## It fails closed

`Art12Log` latches `degraded` on a write failure; `Art12Sink::preflight` consults it, so the **next** operation is refused before it executes. A record-keeping log that keeps running after it stops recording leaves an invisible gap in the artifact.

The latch is read at preflight, not at record — a call whose effect already happened isn't retroactively failed into a duplicating retry.

## Removing the allow *was* the acceptance test

It failed the build immediately on two genuinely-dead items. `Art12Log::head()` now publishes the chain head on `/v1/health`, so a host can tie the log it holds to the process that wrote it; the unused accessor was deleted.

The mechanism is now permanent: if the sink stops calling `append`, the module goes dead and `-D warnings` says so.

## #2145's lesson enforced at startup — and my first guard did not fire

`--art12-log` refuses a path inside the agent's workspace. The Article 12 log is a strictly richer record than the exit report: every decision, with gate class and deny code.

The first implementation compared an *unresolved* path against a *canonicalised* one. `canonicalize` fails on the not-yet-created log file, and on macOS the workspace resolves `/var/...` → `/private/var/...`, so the prefix test never matched and **the guard silently passed everything**. Its own test caught it. It now canonicalises the deepest existing ancestor and re-attaches the rest.

## A test affordance, and why this one is acceptable

`Art12Log::force_degraded()` is `#[cfg(test)]`. A genuine write failure isn't reproducible — on unix an open descriptor keeps accepting writes after the file is unlinked and its directory removed — so the fail-closed test had a conditional early return that made it vacuous on exactly the platforms where writes succeed. The affordance is compiled out of production builds, which is the distinction that matters.

## Verification

Perturbations, each REDing at the expected location: record only allows (REDs two); stop consulting the degraded latch; revert the path guard to the naive comparison.

fmt / clippy `--workspace --all-targets --all-features -D warnings` / `cargo test --all-features` (221 suites, 0 failures) / line ratchet `--strict` / mediation / sealed-home: all green.