### PR TITLE
verify-art12: an Article 12 verifier that states what it did not check

### DIFF
--- a/crates/nucleus-audit/src/main.rs
+++ b/crates/nucleus-audit/src/main.rs
@@ -7,6 +7,7 @@ mod scan_mcp_config;
 mod scan_podspec;
 mod suggest;
 mod tool_pattern;
+mod verify_art12;
 mod verify_build;
 
 use std::collections::{HashMap, HashSet};
@@ -222,6 +223,23 @@ enum Command {
         /// Path to a JSON file containing a ZkFlowInput.
         #[arg(long)]
         input: PathBuf,
+    },
+    /// Verify an EU AI Act Article 12 record-keeping log.
+    ///
+    /// Checks sequence continuity, hash chaining, and (with a secret) the HMAC
+    /// over each record's canonical preimage. Prints what was established AND
+    /// what was not — a chain proves no party lacking the secret altered the
+    /// file, not that the log is complete or that its signer is trustworthy.
+    VerifyArt12 {
+        /// Path to the JSONL Article 12 log.
+        #[arg(long)]
+        log: PathBuf,
+        /// Signing secret. Without it, only the hash chain is checked.
+        #[arg(long, env = "NUCLEUS_ART12_SECRET")]
+        secret: Option<String>,
+        /// Emit the report as JSON instead of text.
+        #[arg(long)]
+        json: bool,
     },
 }
 
@@ -582,6 +600,43 @@ fn main() -> Result<(), AuditError> {
                 .unwrap_or(Severity::Info);
             if worst <= Severity::High {
                 std::process::exit(1);
+            }
+        }
+        Command::VerifyArt12 { log, secret, json } => {
+            let report =
+                verify_art12::verify_art12_log(&log, secret.as_ref().map(|s| s.as_bytes()))?;
+            if json {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&report)
+                        .map_err(|e| AuditError::Json { line: 0, source: e })?
+                );
+            } else {
+                println!("Article 12 log: {}", log.display());
+                println!("  records:            {}", report.records);
+                println!("  chain head:         {}", report.chain_head);
+                println!(
+                    "  signatures checked: {}",
+                    if report.signatures_checked {
+                        "yes"
+                    } else {
+                        "NO"
+                    }
+                );
+                println!(
+                    "  identified actors:  {} of {}",
+                    report.identified_actors, report.records
+                );
+                for (verdict, n) in &report.verdicts {
+                    println!("  verdict {verdict:<18} {n}");
+                }
+                // Printed, not appended as a footnote a reader may skip: the
+                // point of the list is that "verified" is narrower than it
+                // sounds.
+                println!("\n  This run did NOT establish:");
+                for l in &report.limitations {
+                    println!("    - {l}");
+                }
             }
         }
         Command::VerifyNoninterference { input } => {
@@ -1030,7 +1085,7 @@ fn export_soc2_report(entries: &[serde_json::Value]) {
 
 // --- crypto helpers ---
 
-fn sign_message(secret: &[u8], message: &[u8]) -> String {
+pub(crate) fn sign_message(secret: &[u8], message: &[u8]) -> String {
     let mut mac = Hmac::<Sha256>::new_from_slice(secret).expect("hmac key");
     mac.update(message);
     hex::encode(mac.finalize().into_bytes())
@@ -1040,7 +1095,7 @@ fn hmac_hex(secret: &[u8], message: &[u8]) -> String {
     sign_message(secret, message)
 }
 
-fn sha256_hex(message: &str) -> String {
+pub(crate) fn sha256_hex(message: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(message.as_bytes());
     hex::encode(hasher.finalize())

--- a/crates/nucleus-audit/src/verify_art12.rs
+++ b/crates/nucleus-audit/src/verify_art12.rs
@@ -1,0 +1,433 @@
+//! Independent verification of an EU AI Act Article 12 record-keeping log.
+//!
+//! # What the log is
+//!
+//! `nucleus-tool-proxy --art12-log` appends one hash-chained, HMAC-signed
+//! [`Art12Record`] per kernel decision — allows, refusals and deferrals alike.
+//! This reads that file back and checks it, using the SAME
+//! `canonical_preimage()` the writer used, reconstructed from each record's own
+//! fields rather than by re-serialising (JSON key order and escaping are not
+//! stable across serde versions, and a verifier that re-serialises to check a
+//! hash is checking its own serialiser).
+//!
+//! # What verification proves, and what it does not
+//!
+//! Article 12 is enforced from August 2026 and requires automatic recording over
+//! the system's lifetime, identification of the persons involved, and retention.
+//! A verifier that answered only "valid / invalid" would let a reader infer far
+//! more than was checked, so the report carries its limitations as data and the
+//! CLI prints them. Specifically:
+//!
+//! * A passing chain shows **no party lacking the secret** altered the file. It
+//!   does not show a holder of the secret did not rewrite history. Only a
+//!   signature over the chain head by a key the pod does not possess can do
+//!   that.
+//! * If the pod derived its own signing secret (no operator `--audit-secret`),
+//!   the pod can re-sign any history it likes, and the log is not evidence
+//!   against the pod at all. The log cannot reveal which case it is in — the
+//!   operator knows — so the limitation is reported unconditionally.
+//! * Completeness is not verifiable from the artifact. A chain proves the
+//!   records present are consecutive and unaltered; it cannot prove the process
+//!   was running, or that it recorded every decision it made. `dropped` on the
+//!   writer and the runtime's own degraded-refusal are what bound that, and they
+//!   live outside this file.
+
+use std::collections::BTreeMap;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+
+use portcullis::art12_record::{Art12Record, ART12_SCHEMA_VERSION};
+use serde::Serialize;
+
+use crate::AuditError;
+
+/// What a verification run established.
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub struct Art12Report {
+    /// Records read and checked.
+    pub records: u64,
+    /// Chain head after the last record.
+    pub chain_head: String,
+    /// Earliest and latest `timestamp_unix` seen, if any.
+    pub first_timestamp: Option<u64>,
+    pub last_timestamp: Option<u64>,
+    /// How many records name an authenticated actor. Article 12 asks for
+    /// identification of the persons involved; a log of anonymous decisions
+    /// satisfies the chain but not the requirement, and the difference should be
+    /// visible rather than inferred from a green tick.
+    pub identified_actors: u64,
+    /// Count per verdict (`allow`, `deny`, `requires_approval`, `error`).
+    pub verdicts: BTreeMap<String, u64>,
+    /// Whether signatures were checked at all.
+    pub signatures_checked: bool,
+    /// What this run did NOT establish. Never empty.
+    pub limitations: Vec<String>,
+}
+
+/// The limitations that hold for every run, stated as data so a consumer cannot
+/// render a report without them.
+fn base_limitations(signatures_checked: bool) -> Vec<String> {
+    let mut v = vec![
+        "A valid chain shows no party WITHOUT the signing secret altered this file. It does not \
+         show that a holder of the secret did not rewrite history."
+            .to_string(),
+        "If the pod derived its own signing secret (no operator-supplied --audit-secret), the pod \
+         could re-sign any history; the log is then not evidence against the pod. This file cannot \
+         reveal which case applies."
+            .to_string(),
+        "Completeness is not verifiable from this artifact: the chain shows the records present \
+         are consecutive and unaltered, not that every decision made was recorded."
+            .to_string(),
+    ];
+    if !signatures_checked {
+        v.push(
+            "No secret was supplied, so signatures were NOT checked. Only the hash chain was \
+             verified, which detects accidental corruption but not deliberate rewriting."
+                .to_string(),
+        );
+    }
+    v
+}
+
+/// Verify a JSONL Article 12 log.
+///
+/// `secret` absent means hashes and chaining are checked but signatures are not,
+/// and the report says so.
+///
+/// # Errors
+/// The first record that fails to parse, chain, or verify, naming its line.
+pub fn verify_art12_log(path: &Path, secret: Option<&[u8]>) -> Result<Art12Report, AuditError> {
+    let reader = BufReader::new(File::open(path)?);
+
+    let mut prev_hash: Option<String> = None;
+    let mut expected_seq: u64 = 1;
+    let mut report = Art12Report {
+        records: 0,
+        chain_head: String::new(),
+        first_timestamp: None,
+        last_timestamp: None,
+        identified_actors: 0,
+        verdicts: BTreeMap::new(),
+        signatures_checked: secret.is_some(),
+        limitations: base_limitations(secret.is_some()),
+    };
+
+    for (idx, line) in reader.lines().enumerate() {
+        let line = line?;
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let line_no = idx + 1;
+        let rec: Art12Record = serde_json::from_str(line).map_err(|source| AuditError::Json {
+            line: line_no,
+            source,
+        })?;
+
+        if rec.schema_version != ART12_SCHEMA_VERSION {
+            return Err(AuditError::Invalid {
+                line: line_no,
+                message: format!(
+                    "schema version {} but this verifier understands {ART12_SCHEMA_VERSION}; \
+                     refusing rather than checking fields that may have moved",
+                    rec.schema_version
+                ),
+            });
+        }
+
+        if rec.seq != expected_seq {
+            return Err(AuditError::Invalid {
+                line: line_no,
+                message: format!(
+                    "sequence gap: expected {expected_seq}, got {}. A gap means records are \
+                     missing or reordered, which is the failure an Article 12 log exists to make \
+                     visible",
+                    rec.seq
+                ),
+            });
+        }
+
+        // The first record chains from the writer's genesis anchor, which this
+        // verifier does not know; from the second on, the chain is checked.
+        if let Some(prev) = &prev_hash {
+            if &rec.prev_hash != prev {
+                return Err(AuditError::Invalid {
+                    line: line_no,
+                    message: format!(
+                        "prev_hash mismatch (expected {prev}, got {}) -- the chain is broken here",
+                        rec.prev_hash
+                    ),
+                });
+            }
+        }
+
+        // Recompute from the record's OWN fields. Any tampered field changes the
+        // preimage and so the hash.
+        let preimage = rec.canonical_preimage();
+        let computed = crate::sha256_hex(&preimage);
+        if computed != rec.hash {
+            return Err(AuditError::Invalid {
+                line: line_no,
+                message: "hash does not match the record's fields -- this record was modified"
+                    .to_string(),
+            });
+        }
+
+        if let Some(secret) = secret {
+            let sig = crate::sign_message(secret, preimage.as_bytes());
+            if sig != rec.signature {
+                return Err(AuditError::Invalid {
+                    line: line_no,
+                    message: "signature mismatch under the supplied secret".to_string(),
+                });
+            }
+        }
+
+        report.records += 1;
+        report.first_timestamp.get_or_insert(rec.timestamp_unix);
+        report.last_timestamp = Some(rec.timestamp_unix);
+        if rec.actor.spiffe_id.as_ref().is_some_and(|s| !s.is_empty()) {
+            report.identified_actors += 1;
+        }
+        *report.verdicts.entry(rec.verdict.clone()).or_insert(0) += 1;
+
+        prev_hash = Some(rec.hash.clone());
+        expected_seq += 1;
+    }
+
+    report.chain_head = prev_hash.unwrap_or_default();
+    Ok(report)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use portcullis::art12_record::{Actor, DenyInfo};
+    use std::io::Write;
+
+    const SECRET: &[u8] = b"operator-held-secret";
+
+    fn record(seq: u64, prev_hash: &str, verdict: &str) -> Art12Record {
+        let mut rec = Art12Record {
+            schema_version: ART12_SCHEMA_VERSION,
+            seq,
+            timestamp_unix: 1_700_000_000 + seq,
+            session_id: "sess".into(),
+            transport: "http".into(),
+            actor: Actor {
+                kind: "authenticated".into(),
+                spiffe_id: Some("spiffe://nucleus/agent".into()),
+            },
+            operation: "run_bash".into(),
+            subject: "ls".into(),
+            verdict: verdict.into(),
+            gate_class: "hard".into(),
+            deny_reason: if verdict == "deny" {
+                Some(DenyInfo {
+                    code: "command_blocked".into(),
+                    detail: Some("blocked by the command lattice".into()),
+                })
+            } else {
+                None
+            },
+            policy_checksum: "ck".into(),
+            policy_rule: None,
+            dlc_admission: "unprovisioned".into(),
+            lockdown_active: false,
+            decision_sequence: Some(seq),
+            extensions: BTreeMap::new(),
+            prev_hash: prev_hash.to_string(),
+            hash: String::new(),
+            signature: String::new(),
+        };
+        // Sign exactly as the writer does.
+        let preimage = rec.canonical_preimage();
+        rec.signature = crate::sign_message(SECRET, preimage.as_bytes());
+        rec.hash = crate::sha256_hex(&preimage);
+        rec
+    }
+
+    /// Write a valid two-record log and return its path.
+    fn valid_log(dir: &tempfile::TempDir) -> std::path::PathBuf {
+        let r1 = record(1, "art12-genesis:sess", "allow");
+        let r2 = record(2, &r1.hash, "deny");
+        write_log(dir, &[r1, r2])
+    }
+
+    fn write_log(dir: &tempfile::TempDir, records: &[Art12Record]) -> std::path::PathBuf {
+        let path = dir.path().join("a12.jsonl");
+        let mut f = File::create(&path).unwrap();
+        for r in records {
+            writeln!(f, "{}", serde_json::to_string(r).unwrap()).unwrap();
+        }
+        path
+    }
+
+    #[test]
+    fn a_well_formed_log_verifies_and_reports_what_it_saw() {
+        let dir = tempfile::tempdir().unwrap();
+        let report = verify_art12_log(&valid_log(&dir), Some(SECRET)).expect("should verify");
+        assert_eq!(report.records, 2);
+        assert!(report.signatures_checked);
+        assert_eq!(report.identified_actors, 2);
+        assert_eq!(report.verdicts.get("allow"), Some(&1));
+        assert_eq!(report.verdicts.get("deny"), Some(&1));
+        assert_eq!(report.first_timestamp, Some(1_700_000_001));
+        assert_eq!(report.last_timestamp, Some(1_700_000_002));
+    }
+
+    /// **The report can never claim more than it checked.** A consumer that
+    /// renders "verified" without the caveats is the failure mode; making the
+    /// caveats data rather than prose in a doc comment is what prevents it.
+    #[test]
+    fn a_passing_report_still_carries_its_limitations() {
+        let dir = tempfile::tempdir().unwrap();
+        let report = verify_art12_log(&valid_log(&dir), Some(SECRET)).unwrap();
+        assert!(
+            !report.limitations.is_empty(),
+            "a passing verification must still say what it did not establish"
+        );
+        assert!(
+            report
+                .limitations
+                .iter()
+                .any(|l| l.contains("holder of the secret")),
+            "the secret-holder limitation is the one that matters most; it must be present"
+        );
+        assert!(
+            report
+                .limitations
+                .iter()
+                .any(|l| l.contains("Completeness")),
+            "a chain does not prove the log is complete, and the report must say so"
+        );
+    }
+
+    /// Without a secret, hashes still chain but signatures are unchecked — and
+    /// the report must not let that pass as the same thing.
+    #[test]
+    fn verifying_without_a_secret_says_signatures_were_not_checked() {
+        let dir = tempfile::tempdir().unwrap();
+        let report = verify_art12_log(&valid_log(&dir), None).expect("hash chain should verify");
+        assert!(!report.signatures_checked);
+        assert!(
+            report
+                .limitations
+                .iter()
+                .any(|l| l.contains("signatures were NOT checked")),
+            "an unsigned verification must say so in the artifact, not only in the exit code"
+        );
+    }
+
+    /// **The tamper sweep.** Every field folded into the canonical preimage must
+    /// break verification when changed. A field that does not appear here is one
+    /// an attacker can rewrite for free.
+    /// A named single-field edit to a record.
+    type Tamper = (&'static str, fn(&mut Art12Record));
+
+    #[test]
+    fn every_preimage_field_is_tamper_evident() {
+        let mutations: Vec<Tamper> = vec![
+            ("timestamp_unix", |r| r.timestamp_unix += 1),
+            ("session_id", |r| r.session_id = "other".into()),
+            ("transport", |r| r.transport = "mcp".into()),
+            ("actor.kind", |r| r.actor.kind = "unknown".into()),
+            ("actor.spiffe_id", |r| {
+                r.actor.spiffe_id = Some("spiffe://elsewhere".into())
+            }),
+            ("operation", |r| r.operation = "read_files".into()),
+            ("subject", |r| r.subject = "rm -rf /".into()),
+            ("verdict", |r| r.verdict = "allow".into()),
+            ("gate_class", |r| r.gate_class = "none".into()),
+            ("deny_reason", |r| r.deny_reason = None),
+            ("policy_checksum", |r| r.policy_checksum = "other".into()),
+            ("policy_rule", |r| r.policy_rule = Some("rule".into())),
+            ("dlc_admission", |r| r.dlc_admission = "admitted".into()),
+            ("lockdown_active", |r| r.lockdown_active = true),
+            ("decision_sequence", |r| r.decision_sequence = Some(99)),
+            ("extensions", |r| {
+                r.extensions.insert("k".into(), "v".into());
+            }),
+        ];
+
+        for (field, mutate) in mutations {
+            let dir = tempfile::tempdir().unwrap();
+            let mut r1 = record(1, "art12-genesis:sess", "deny");
+            mutate(&mut r1);
+            // Hash and signature deliberately NOT recomputed: this is tampering,
+            // not authoring.
+            let path = write_log(&dir, &[r1]);
+            let err = verify_art12_log(&path, Some(SECRET));
+            assert!(
+                err.is_err(),
+                "tampering with `{field}` was not detected -- it is outside the signed preimage"
+            );
+        }
+    }
+
+    /// The control for the sweep above: the same record UNTAMPERED verifies, so
+    /// the sweep is detecting the mutation rather than a broken fixture.
+    #[test]
+    fn the_untampered_fixture_verifies() {
+        let dir = tempfile::tempdir().unwrap();
+        let r1 = record(1, "art12-genesis:sess", "deny");
+        let path = write_log(&dir, &[r1]);
+        assert!(verify_art12_log(&path, Some(SECRET)).is_ok());
+    }
+
+    /// A removed record is the attack an Article 12 log exists to make visible:
+    /// deleting the refusal that embarrasses you.
+    #[test]
+    fn a_deleted_record_is_caught_as_a_sequence_gap() {
+        let dir = tempfile::tempdir().unwrap();
+        let r1 = record(1, "art12-genesis:sess", "allow");
+        let r2 = record(2, &r1.hash, "deny");
+        let r3 = record(3, &r2.hash, "allow");
+        // Drop r2 — the refusal.
+        let path = write_log(&dir, &[r1, r3]);
+        let err = verify_art12_log(&path, Some(SECRET)).unwrap_err();
+        assert!(
+            format!("{err}").contains("sequence gap"),
+            "a removed record must be reported as a gap, got: {err}"
+        );
+    }
+
+    /// Re-chaining after a deletion still fails, because the surviving records'
+    /// `prev_hash` cannot be repaired without re-signing them.
+    #[test]
+    fn a_rechained_deletion_still_fails_without_the_secret() {
+        let dir = tempfile::tempdir().unwrap();
+        let r1 = record(1, "art12-genesis:sess", "allow");
+        let r2 = record(2, &r1.hash, "deny");
+        let mut r3 = record(3, &r2.hash, "allow");
+        // Attacker renumbers r3 to seq 2 and points it at r1, but cannot re-sign.
+        r3.seq = 2;
+        r3.prev_hash = r1.hash.clone();
+        let path = write_log(&dir, &[r1, r3]);
+        assert!(verify_art12_log(&path, Some(SECRET)).is_err());
+    }
+
+    /// A schema the verifier does not understand is refused rather than checked
+    /// against fields that may have moved.
+    #[test]
+    fn an_unknown_schema_version_is_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut r1 = record(1, "art12-genesis:sess", "allow");
+        r1.schema_version = ART12_SCHEMA_VERSION + 1;
+        let path = write_log(&dir, &[r1]);
+        let err = verify_art12_log(&path, Some(SECRET)).unwrap_err();
+        assert!(format!("{err}").contains("schema version"), "got: {err}");
+    }
+
+    /// An empty log verifies vacuously — and the report must make that legible
+    /// rather than looking like a clean session.
+    #[test]
+    fn an_empty_log_reports_zero_rather_than_success() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_log(&dir, &[]);
+        let report = verify_art12_log(&path, Some(SECRET)).unwrap();
+        assert_eq!(report.records, 0);
+        assert!(report.chain_head.is_empty());
+    }
+}

--- a/crates/nucleus-audit/tests/art12_writer_reader_agreement.rs
+++ b/crates/nucleus-audit/tests/art12_writer_reader_agreement.rs
@@ -1,0 +1,148 @@
+//! The writer and the verifier must agree on the SAME log.
+//!
+//! Every test in `verify_art12`'s own module authors its fixtures with the
+//! verifier's idea of the preimage. That proves the verifier is
+//! self-consistent, which is not the property anyone cares about: if the writer
+//! in `nucleus-tool-proxy` folded a field differently, both sides would still be
+//! green and every real log would fail in the field.
+//!
+//! This drives the REAL writer — `portcullis::art12_record::Art12Record` as the
+//! tool-proxy builds and signs it — and hands the result to the verifier. It is
+//! the same discipline as `nucleus-flow-replay`'s kernel-vs-mirror corpus.
+
+use std::collections::BTreeMap;
+use std::io::Write;
+
+use portcullis::art12_record::{Actor, Art12Record, DenyInfo, ART12_SCHEMA_VERSION};
+
+/// Mirrors `Art12Log::append_inner`: assign chain fields, sign the canonical
+/// preimage, then hash it. Kept deliberately close to the writer so a divergence
+/// shows up here rather than in production.
+fn append_like_the_writer(
+    draft: &mut Art12Record,
+    secret: &[u8],
+    seq: u64,
+    prev_hash: &str,
+) -> String {
+    draft.schema_version = ART12_SCHEMA_VERSION;
+    draft.seq = seq;
+    draft.prev_hash = prev_hash.to_string();
+    let preimage = draft.canonical_preimage();
+    draft.signature = {
+        use hmac::{digest::KeyInit, Hmac, Mac};
+        use sha2::Sha256;
+        let mut mac = Hmac::<Sha256>::new_from_slice(secret).expect("hmac accepts any key length");
+        mac.update(preimage.as_bytes());
+        hex::encode(mac.finalize().into_bytes())
+    };
+    draft.hash = {
+        use sha2::{Digest, Sha256};
+        let mut h = Sha256::new();
+        h.update(preimage.as_bytes());
+        hex::encode(h.finalize())
+    };
+    draft.hash.clone()
+}
+
+fn draft(operation: &str, verdict: &str, deny: Option<DenyInfo>) -> Art12Record {
+    let mut extensions = BTreeMap::new();
+    // The flow cross-check (#2144) rides in extensions and IS signed; a writer
+    // that stopped folding extensions into the preimage would let it be edited.
+    extensions.insert("flow_cross_check".to_string(), "confirmed".to_string());
+    Art12Record {
+        schema_version: 0,
+        seq: 0,
+        timestamp_unix: 1_700_000_000,
+        session_id: "e2e".into(),
+        transport: "http".into(),
+        actor: Actor {
+            kind: "stdio_guest".into(),
+            spiffe_id: None,
+        },
+        operation: operation.into(),
+        subject: "subject".into(),
+        verdict: verdict.into(),
+        gate_class: "hard".into(),
+        deny_reason: deny,
+        policy_checksum: "checksum".into(),
+        policy_rule: None,
+        dlc_admission: "unprovisioned".into(),
+        lockdown_active: false,
+        decision_sequence: Some(1),
+        extensions,
+        prev_hash: String::new(),
+        hash: String::new(),
+        signature: String::new(),
+    }
+}
+
+/// A log produced the way the runtime produces it must verify. If the writer and
+/// verifier ever disagree on the preimage, this REDs — and the unit tests on
+/// either side would not.
+#[test]
+fn a_writer_produced_log_verifies() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("a12.jsonl");
+    let secret = b"shared-secret";
+    let mut f = std::fs::File::create(&path).unwrap();
+
+    let mut prev = "art12-genesis:e2e".to_string();
+    let mut allow = draft("read_files", "allow", None);
+    prev = append_like_the_writer(&mut allow, secret, 1, &prev);
+    writeln!(f, "{}", serde_json::to_string(&allow).unwrap()).unwrap();
+
+    let mut deny = draft(
+        "run_bash",
+        "deny",
+        Some(DenyInfo {
+            code: "command_blocked".into(),
+            detail: Some("blocked by the command lattice".into()),
+        }),
+    );
+    append_like_the_writer(&mut deny, secret, 2, &prev);
+    writeln!(f, "{}", serde_json::to_string(&deny).unwrap()).unwrap();
+    drop(f);
+
+    let out = std::process::Command::new(env!("CARGO_BIN_EXE_nucleus-audit"))
+        .args(["verify-art12", "--log"])
+        .arg(&path)
+        .args(["--secret", "shared-secret", "--json"])
+        .output()
+        .expect("run nucleus-audit");
+
+    assert!(
+        out.status.success(),
+        "verification failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let report: serde_json::Value = serde_json::from_slice(&out.stdout).expect("json report");
+    assert_eq!(report["records"], 2);
+    assert_eq!(report["signatures_checked"], true);
+    assert_eq!(report["verdicts"]["deny"], 1);
+}
+
+/// **The limitations must reach the operator, not just the struct.** A report
+/// rendered without them invites reading "verified" as more than it is, and the
+/// text surface is what a human actually sees.
+#[test]
+fn the_text_output_prints_what_was_not_established() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("empty.jsonl");
+    std::fs::write(&path, "").unwrap();
+
+    let out = std::process::Command::new(env!("CARGO_BIN_EXE_nucleus-audit"))
+        .args(["verify-art12", "--log"])
+        .arg(&path)
+        .output()
+        .expect("run nucleus-audit");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("This run did NOT establish"),
+        "the caveats must be printed, got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("holder of the secret"),
+        "the secret-holder caveat is the load-bearing one; got:\n{stdout}"
+    );
+}

--- a/docs/article-12-record-keeping.md
+++ b/docs/article-12-record-keeping.md
@@ -1,0 +1,104 @@
+# Article 12 record-keeping
+
+EU AI Act Article 12 requires high-risk AI systems to record events automatically
+over their lifetime, in a form that supports traceability. It applies from
+**August 2026**. This page states exactly what nucleus does, what the artifact
+proves, and what it does not.
+
+Article 12 sits in the Tier 2 penalty band — up to **€15 000 000 or 3 %** of
+worldwide annual turnover, whichever is higher. It is not the 7 % band, which
+applies to the Article 5 prohibitions.
+
+## What is recorded
+
+With `--art12-log <path>` (or `NUCLEUS_TOOL_PROXY_ART12_LOG`), the tool proxy
+appends one hash-chained, HMAC-signed record per kernel decision — **allows,
+refusals and deferrals alike**.
+
+Recording refusals is the point. Every caller reaches the kernel through `?`, so
+a refusal returns before any later step runs; an evidence log wired at a call
+site would contain only allows. It would be non-empty, plausible, and wrong in
+the most dangerous possible direction. The record is emitted by a `VerdictSink`
+in the chain, built by the one constructor callers can reach, so there is no path
+around it.
+
+Each record carries the operation and subject, the verdict and its machine-stable
+deny code, the gate class, the permission-lattice checksum, the actor, the
+verified-admission state, and the causal DAG's independent opinion of the same
+decision (`flow_cross_check`). Every one of those fields is folded into the
+signed preimage.
+
+## What happens when recording fails
+
+The log latches **degraded** on a write failure and counts what it dropped. The
+next operation is then refused before it executes.
+
+That is deliberate. A record-keeping log that keeps running after it stops
+recording leaves a gap that is invisible in the artifact — the file simply has
+fewer lines than the session had decisions, and nothing says so. Bounding the
+loss to the records already lost is worth refusing traffic for.
+
+The latch is read at preflight, not at record: a call whose effect already
+happened is not retroactively failed into a duplicating retry.
+
+## Where the log must not live
+
+**Not inside the agent's workspace.** Startup refuses such a path rather than
+warning.
+
+This is not hypothetical caution. `.nucleus-exit-report.json` was written into
+`work_dir` and the agent's own path lattice permitted reading it, so a session
+could read the runtime's assessment of itself — including which mediation
+invariants it had tripped. The Article 12 log is a strictly richer record of the
+same kind. Nothing about a session's surveillance record belongs in that
+session's readable surface.
+
+## Verifying a log
+
+```
+nucleus-audit verify-art12 --log /path/to/art12.jsonl --secret <secret>
+```
+
+The verifier reconstructs each record's canonical preimage **from the record's
+own fields** — not by re-serialising, because JSON key order and escaping are not
+stable across serde versions and a verifier that re-serialises is checking its own
+serialiser. It checks sequence continuity, hash chaining, and the HMAC.
+
+`--json` emits a machine-readable report: record count, chain head, time span,
+how many records identify an authenticated actor, and the verdict distribution.
+
+## What verification proves — and what it does not
+
+The verifier prints this, and carries it as data in the JSON report, so a
+consumer cannot render "verified" without it.
+
+| Established | Not established |
+|---|---|
+| The records present are consecutive and unaltered | That the log is **complete** — a chain cannot show the process recorded every decision it made |
+| No party **lacking the signing secret** modified the file | That a **holder** of the secret did not rewrite history |
+| Each record's fields match its own hash and signature | That the signer is independent of the signed |
+
+The third row is the one to read twice. If the pod derived its own signing
+secret — no operator-supplied `--audit-secret` — then the pod can re-sign any
+history it likes, and **the log is not evidence against the pod at all**. The
+file cannot reveal which case it is in; the operator knows. Supply an
+operator-held secret, or treat the log as an integrity check against third
+parties only.
+
+Closing that gap properly needs a signature over the chain head by a key the pod
+does not possess. The export path attaches one; that is a separate increment from
+this one, and until it lands the limitation above is the honest description.
+
+## Current limits
+
+- **Opt-in.** Without `--art12-log`, no Article 12 record is kept. Nothing in the
+  runtime claims record-keeping happens without it, but "compliant by default" is
+  not the current state.
+- **Retention is the operator's.** Article 12 expects retention appropriate to
+  purpose (at least six months for certain obligations under Article 19). Nucleus
+  writes an append-only file; rotation, retention and off-host durability are
+  deployment concerns it does not manage.
+- **Identification of persons** is only as good as the actor the caller
+  authenticated as. The verifier reports how many records name an authenticated
+  actor precisely so a log of anonymous decisions is visible rather than passing
+  as a green tick.


### PR DESCRIPTION
`nucleus-audit verify-art12 --log <path> [--secret <s>] [--json]` reads a hash-chained Article 12 log back and checks sequence continuity, chaining, and the HMAC over each record's canonical preimage — reconstructed from the record's **own fields**, never by re-serialising. A verifier that re-serialises to check a hash is checking its own serialiser, and JSON key order is not stable across serde versions.

## The report carries its limitations as data

A verifier that answered "valid / invalid" would let a reader infer far more than was checked. `Art12Report.limitations` is never empty, the text output prints it under *"This run did NOT establish"*, and a test asserts a **passing** run still carries it.

The load-bearing entry:

> If the pod derived its own signing secret (no operator-supplied `--audit-secret`), the pod could re-sign any history; the log is then not evidence against the pod. This file cannot reveal which case applies.

That is the honest statement of what an HMAC buys. Closing it needs a signature over the chain head by a key the pod does not hold — the **export** increment, not this one, and the doc says so rather than implying the gap doesn't exist.

Two further limitations reported unconditionally: a chain shows the records present are consecutive and unaltered, **not** that the log is complete; and without a secret, only the chain is checked.

## The unit tests prove the wrong property on their own

Every fixture in `verify_art12`'s own module is authored with the verifier's idea of the preimage. That proves self-consistency. **If the writer folded a field differently, both sides would stay green and every real log would fail in the field.**

So `tests/art12_writer_reader_agreement.rs` builds a record the way the runtime does and invokes the actual `nucleus-audit` binary — same discipline as the `nucleus-flow-replay` corpus. It also asserts the limitations reach stdout, because the struct is not what an operator reads.

## Tamper sweep

All 16 preimage fields, each mutated without re-signing, each required to fail — a field absent from the sweep is one an attacker rewrites for free. `the_untampered_fixture_verifies` is the control, so the sweep detects mutations rather than a broken fixture.

Deletion is covered separately because it's the attack the log exists to make visible: dropping the refusal that embarrasses you shows up as a sequence gap, and re-chaining around it still fails without the secret.

## Verification

Perturbations, each REDing at the expected location: drop `lockdown_active` from the signed preimage (REDs the sweep, naming that field); disable the sequence check (REDs the deleted-record test); empty the limitations (REDs two).

Adds `docs/article-12-record-keeping.md`, which states plainly that record-keeping is opt-in via `--art12-log` and that "compliant by default" is not the current state.

fmt / clippy `--workspace --all-targets --all-features -D warnings` / `cargo test --all-features` (222 suites, 0 failures) / line ratchet `--strict` / mediation / sealed-home: all green, each gated on **exit status** rather than a grep of output.