### PR TITLE
Close the attestation loop: verify the signed head, share one preimage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6553,6 +6553,7 @@ dependencies = [
  "c2pa",
  "chrono",
  "clap",
+ "ed25519-dalek 3.0.0-pre.7",
  "hex",
  "hmac 0.13.0",
  "nucleus-spec",

--- a/crates/nucleus-audit/Cargo.toml
+++ b/crates/nucleus-audit/Cargo.toml
@@ -8,6 +8,7 @@ authors.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }
+ed25519-dalek = { workspace = true }
 hex = { workspace = true }
 hmac = { workspace = true }
 portcullis = { path = "../portcullis", features = ["serde"] }

--- a/crates/nucleus-audit/src/main.rs
+++ b/crates/nucleus-audit/src/main.rs
@@ -240,6 +240,16 @@ enum Command {
         /// Emit the report as JSON instead of text.
         #[arg(long)]
         json: bool,
+        /// Executor attestation JSON, as sent with the session-complete receipt.
+        ///
+        /// Supplying it (with --executor-pubkey) is what turns "no third party
+        /// altered this file" into evidence about the pod: the executor key
+        /// lives on the node and the pod never holds it.
+        #[arg(long, requires = "executor_pubkey")]
+        attestation: Option<PathBuf>,
+        /// The executor's Ed25519 public key, hex-encoded (32 bytes).
+        #[arg(long, requires = "attestation")]
+        executor_pubkey: Option<String>,
     },
 }
 
@@ -602,9 +612,44 @@ fn main() -> Result<(), AuditError> {
                 std::process::exit(1);
             }
         }
-        Command::VerifyArt12 { log, secret, json } => {
-            let report =
+        Command::VerifyArt12 {
+            log,
+            secret,
+            json,
+            attestation,
+            executor_pubkey,
+        } => {
+            let mut report =
                 verify_art12::verify_art12_log(&log, secret.as_ref().map(|s| s.as_bytes()))?;
+
+            if let (Some(att_path), Some(pubkey_hex)) = (attestation, executor_pubkey) {
+                let att: portcullis::art12_record::Art12Attestation =
+                    serde_json::from_str(&std::fs::read_to_string(&att_path)?)
+                        .map_err(|e| AuditError::Json { line: 0, source: e })?;
+                let key_bytes: [u8; 32] = hex::decode(&pubkey_hex)
+                    .ok()
+                    .and_then(|v| v.try_into().ok())
+                    .ok_or_else(|| AuditError::Invalid {
+                        line: 0,
+                        message: "--executor-pubkey must be 32 hex-encoded bytes".to_string(),
+                    })?;
+                let key = ed25519_dalek::VerifyingKey::from_bytes(&key_bytes).map_err(|_| {
+                    AuditError::Invalid {
+                        line: 0,
+                        message: "--executor-pubkey is not a valid Ed25519 public key".to_string(),
+                    }
+                })?;
+                verify_art12::check_attestation(&att, &report.chain_head, &key)?;
+                report.attestation_checked = true;
+                report
+                    .limitations
+                    .retain(|l| !l.contains("holder of the secret"));
+                report.limitations.push(
+                    "The executor attestation binds this log's HEAD, not its content: a pod that \
+                     recorded nothing would export a validly signed empty log."
+                        .to_string(),
+                );
+            }
             if json {
                 println!(
                     "{}",
@@ -626,6 +671,14 @@ fn main() -> Result<(), AuditError> {
                 println!(
                     "  identified actors:  {} of {}",
                     report.identified_actors, report.records
+                );
+                println!(
+                    "  executor attested:  {}",
+                    if report.attestation_checked {
+                        "yes"
+                    } else {
+                        "NO"
+                    }
                 );
                 for (verdict, n) in &report.verdicts {
                     println!("  verdict {verdict:<18} {n}");

--- a/crates/nucleus-audit/src/verify_art12.rs
+++ b/crates/nucleus-audit/src/verify_art12.rs
@@ -37,7 +37,8 @@ use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
 
-use portcullis::art12_record::{Art12Record, ART12_SCHEMA_VERSION};
+use ed25519_dalek::{Signature, Verifier as _, VerifyingKey};
+use portcullis::art12_record::{Art12Attestation, Art12Record, ART12_SCHEMA_VERSION};
 use serde::Serialize;
 
 use crate::AuditError;
@@ -61,8 +62,71 @@ pub struct Art12Report {
     pub verdicts: BTreeMap<String, u64>,
     /// Whether signatures were checked at all.
     pub signatures_checked: bool,
+    /// Whether an executor attestation was checked against the computed head.
+    pub attestation_checked: bool,
     /// What this run did NOT establish. Never empty.
     pub limitations: Vec<String>,
+}
+
+/// Check an executor attestation against the head this verifier computed.
+///
+/// # What this closes
+///
+/// Without it, a passing chain means "no party lacking the HMAC secret altered
+/// this file" — which says nothing about a pod that holds its own secret. The
+/// executor key lives on the node and the pod never sees it, so a pod that
+/// rewrites its log produces a different head and cannot forge a signature over
+/// the new one.
+///
+/// The signature is checked over the attestation's OWN preimage, then the head
+/// it names is compared to the head computed from the log. Both halves are
+/// required: a valid signature over a head that is not this log's proves only
+/// that some other log was attested.
+///
+/// # Errors
+/// If the signature does not verify, or the attested head is not the computed one.
+pub fn check_attestation(
+    att: &Art12Attestation,
+    computed_head: &str,
+    executor_pubkey: &VerifyingKey,
+) -> Result<(), AuditError> {
+    if att.kind != portcullis::art12_record::ART12_ATTESTATION_KIND {
+        return Err(AuditError::Invalid {
+            line: 0,
+            message: format!(
+                "unknown attestation kind {:?}; refusing rather than checking fields that may \
+                 have moved",
+                att.kind
+            ),
+        });
+    }
+
+    let bytes: [u8; 64] = hex::decode(&att.signature)
+        .ok()
+        .and_then(|v| v.try_into().ok())
+        .ok_or_else(|| AuditError::Invalid {
+            line: 0,
+            message: "attestation signature is not 64 hex-encoded bytes".to_string(),
+        })?;
+    executor_pubkey
+        .verify(att.preimage().as_bytes(), &Signature::from_bytes(&bytes))
+        .map_err(|_| AuditError::Invalid {
+            line: 0,
+            message: "attestation signature does not verify under the executor public key"
+                .to_string(),
+        })?;
+
+    if att.chain_head != computed_head {
+        return Err(AuditError::Invalid {
+            line: 0,
+            message: format!(
+                "the executor attested chain head {} but this log computes {computed_head} -- \
+                 the log was rewritten after it was attested",
+                att.chain_head
+            ),
+        });
+    }
+    Ok(())
 }
 
 /// The limitations that hold for every run, stated as data so a consumer cannot
@@ -70,11 +134,12 @@ pub struct Art12Report {
 fn base_limitations(signatures_checked: bool) -> Vec<String> {
     let mut v = vec![
         "A valid chain shows no party WITHOUT the signing secret altered this file. It does not \
-         show that a holder of the secret did not rewrite history."
+         show that a holder of the secret did not rewrite history. Supply --attestation and \
+         --executor-pubkey to close that: the executor key is one the pod never holds."
             .to_string(),
         "If the pod derived its own signing secret (no operator-supplied --audit-secret), the pod \
-         could re-sign any history; the log is then not evidence against the pod. This file cannot \
-         reveal which case applies."
+         could re-sign any history; the log is then not evidence against the pod UNLESS an \
+         executor attestation was checked. This file alone cannot reveal which case applies."
             .to_string(),
         "Completeness is not verifiable from this artifact: the chain shows the records present \
          are consecutive and unaltered, not that every decision made was recorded."
@@ -110,6 +175,7 @@ pub fn verify_art12_log(path: &Path, secret: Option<&[u8]>) -> Result<Art12Repor
         identified_actors: 0,
         verdicts: BTreeMap::new(),
         signatures_checked: secret.is_some(),
+        attestation_checked: false,
         limitations: base_limitations(secret.is_some()),
     };
 
@@ -429,5 +495,98 @@ mod tests {
         let report = verify_art12_log(&path, Some(SECRET)).unwrap();
         assert_eq!(report.records, 0);
         assert!(report.chain_head.is_empty());
+    }
+
+    // ── executor attestation ────────────────────────────────────────────────
+
+    use ed25519_dalek::{Signer as _, SigningKey};
+    use portcullis::art12_record::{art12_attestation_preimage, ART12_ATTESTATION_KIND};
+
+    fn attest(chain_head: &str, key: &SigningKey) -> Art12Attestation {
+        let preimage = art12_attestation_preimage("sess", chain_head, 2, 0, "exec-1");
+        Art12Attestation {
+            kind: ART12_ATTESTATION_KIND.to_string(),
+            session_id: "sess".into(),
+            chain_head: chain_head.to_string(),
+            records: 2,
+            dropped: 0,
+            executor_id: "exec-1".into(),
+            signature: hex::encode(key.sign(preimage.as_bytes()).to_bytes()),
+        }
+    }
+
+    /// The happy path: the executor attested the head this log actually computes.
+    #[test]
+    fn an_attestation_over_the_computed_head_checks_out() {
+        let dir = tempfile::tempdir().unwrap();
+        let report = verify_art12_log(&valid_log(&dir), Some(SECRET)).unwrap();
+        let key = SigningKey::from_bytes(&[3u8; 32]);
+        assert!(check_attestation(
+            &attest(&report.chain_head, &key),
+            &report.chain_head,
+            &key.verifying_key()
+        )
+        .is_ok());
+    }
+
+    /// **The property the export exists for.** A pod that rewrites its log after
+    /// being attested produces a different head, and cannot re-sign.
+    #[test]
+    fn a_log_rewritten_after_attestation_is_caught() {
+        let dir = tempfile::tempdir().unwrap();
+        let key = SigningKey::from_bytes(&[3u8; 32]);
+        // Attested when the log ended at some earlier head.
+        let att = attest("the-head-that-was-attested", &key);
+
+        let report = verify_art12_log(&valid_log(&dir), Some(SECRET)).unwrap();
+        let err = check_attestation(&att, &report.chain_head, &key.verifying_key()).unwrap_err();
+        assert!(
+            format!("{err}").contains("rewritten after it was attested"),
+            "got: {err}"
+        );
+    }
+
+    /// A signature from the wrong key must not pass — otherwise the attestation
+    /// proves only that SOMEONE signed, which is what the pod can already do.
+    #[test]
+    fn an_attestation_from_another_key_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let report = verify_art12_log(&valid_log(&dir), Some(SECRET)).unwrap();
+        let real = SigningKey::from_bytes(&[3u8; 32]);
+        let impostor = SigningKey::from_bytes(&[4u8; 32]);
+        let err = check_attestation(
+            &attest(&report.chain_head, &impostor),
+            &report.chain_head,
+            &real.verifying_key(),
+        )
+        .unwrap_err();
+        assert!(format!("{err}").contains("does not verify"), "got: {err}");
+    }
+
+    /// Both halves are required. A signature valid over ANOTHER log's head must
+    /// not pass for this one — that is the substitution attack.
+    #[test]
+    fn a_valid_signature_over_a_different_log_does_not_pass() {
+        let key = SigningKey::from_bytes(&[3u8; 32]);
+        let att = attest("head-of-some-other-session", &key);
+        // The signature itself is perfectly valid...
+        assert!(
+            check_attestation(&att, "head-of-some-other-session", &key.verifying_key()).is_ok()
+        );
+        // ...but not for this log.
+        assert!(check_attestation(&att, "this-logs-head", &key.verifying_key()).is_err());
+    }
+
+    /// An unknown attestation kind is refused rather than field-guessed.
+    #[test]
+    fn an_unknown_attestation_kind_is_refused() {
+        let key = SigningKey::from_bytes(&[3u8; 32]);
+        let mut att = attest("h", &key);
+        att.kind = "something-else-v9".into();
+        let err = check_attestation(&att, "h", &key.verifying_key()).unwrap_err();
+        assert!(
+            format!("{err}").contains("unknown attestation kind"),
+            "got: {err}"
+        );
     }
 }

--- a/crates/nucleus-audit/src/verify_art12.rs
+++ b/crates/nucleus-audit/src/verify_art12.rs
@@ -37,7 +37,7 @@ use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
 
-use ed25519_dalek::{Signature, Verifier as _, VerifyingKey};
+use ed25519_dalek::{Signature, VerifyingKey};
 use portcullis::art12_record::{Art12Attestation, Art12Record, ART12_SCHEMA_VERSION};
 use serde::Serialize;
 
@@ -108,8 +108,13 @@ pub fn check_attestation(
             line: 0,
             message: "attestation signature is not 64 hex-encoded bytes".to_string(),
         })?;
+    // STRICT, not `verify`. Audit finding M-3: the cofactored equation accepts
+    // small-order and non-canonical points, so one crafted signature can verify
+    // under several identities. This attestation exists to bind a log to ONE
+    // executor, so a weak signature-to-identity binding would defeat its whole
+    // purpose. `check-verify-strict.sh` caught this before it landed.
     executor_pubkey
-        .verify(att.preimage().as_bytes(), &Signature::from_bytes(&bytes))
+        .verify_strict(att.preimage().as_bytes(), &Signature::from_bytes(&bytes))
         .map_err(|_| AuditError::Invalid {
             line: 0,
             message: "attestation signature does not verify under the executor public key"

--- a/crates/nucleus-audit/tests/art12_writer_reader_agreement.rs
+++ b/crates/nucleus-audit/tests/art12_writer_reader_agreement.rs
@@ -146,3 +146,97 @@ fn the_text_output_prints_what_was_not_established() {
         "the secret-holder caveat is the load-bearing one; got:\n{stdout}"
     );
 }
+
+/// **The whole export loop, through the CLI.** Writer produces a log; the host
+/// signs its head with a key the pod never holds; the verifier recomputes the
+/// head from the file and checks the signature against it.
+///
+/// The signer (`nucleus-node::attest_art12`) and this verifier now share ONE
+/// preimage function in `portcullis::art12_record`, so they cannot disagree
+/// about what is signed — but the CLI plumbing between them can still be wrong,
+/// and that is what this exercises.
+#[test]
+fn the_signed_head_round_trips_through_the_cli() {
+    use ed25519_dalek::{Signer as _, SigningKey};
+    use portcullis::art12_record::{
+        art12_attestation_preimage, Art12Attestation, ART12_ATTESTATION_KIND,
+    };
+
+    let dir = tempfile::tempdir().unwrap();
+    let log_path = dir.path().join("a12.jsonl");
+    let secret = b"shared-secret";
+    let mut f = std::fs::File::create(&log_path).unwrap();
+
+    let mut rec = draft("read_files", "allow", None);
+    let head = append_like_the_writer(&mut rec, secret, 1, "art12-genesis:e2e");
+    writeln!(f, "{}", serde_json::to_string(&rec).unwrap()).unwrap();
+    drop(f);
+
+    // The host signs the head it was told, with the executor key.
+    let key = SigningKey::from_bytes(&[11u8; 32]);
+    let preimage = art12_attestation_preimage("e2e", &head, 1, 0, "exec-1");
+    let att = Art12Attestation {
+        kind: ART12_ATTESTATION_KIND.to_string(),
+        session_id: "e2e".into(),
+        chain_head: head.clone(),
+        records: 1,
+        dropped: 0,
+        executor_id: "exec-1".into(),
+        signature: hex::encode(key.sign(preimage.as_bytes()).to_bytes()),
+    };
+    let att_path = dir.path().join("att.json");
+    std::fs::write(&att_path, serde_json::to_string(&att).unwrap()).unwrap();
+    let pubkey = hex::encode(key.verifying_key().to_bytes());
+
+    let run = |att: &std::path::Path| {
+        std::process::Command::new(env!("CARGO_BIN_EXE_nucleus-audit"))
+            .args(["verify-art12", "--log"])
+            .arg(&log_path)
+            .args(["--secret", "shared-secret", "--json", "--attestation"])
+            .arg(att)
+            .args(["--executor-pubkey", &pubkey])
+            .output()
+            .expect("run nucleus-audit")
+    };
+
+    let out = run(&att_path);
+    assert!(
+        out.status.success(),
+        "attested verification failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let report: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(report["attestation_checked"], true);
+    // With the head bound by a key the pod never held, the secret-holder caveat
+    // no longer applies and must be gone — a report that keeps it would be
+    // understating what was established.
+    let limits = report["limitations"].as_array().unwrap();
+    assert!(
+        !limits
+            .iter()
+            .any(|l| l.as_str().unwrap().contains("holder of the secret")),
+        "the secret-holder limitation should be lifted once the head is attested"
+    );
+    assert!(
+        limits
+            .iter()
+            .any(|l| l.as_str().unwrap().contains("HEAD, not its content")),
+        "and replaced by the one that still applies"
+    );
+
+    // A rewritten log fails: the recomputed head no longer matches.
+    let mut f = std::fs::OpenOptions::new()
+        .append(true)
+        .open(&log_path)
+        .unwrap();
+    let mut extra = draft("run_bash", "allow", None);
+    append_like_the_writer(&mut extra, secret, 2, &head);
+    writeln!(f, "{}", serde_json::to_string(&extra).unwrap()).unwrap();
+    drop(f);
+
+    let out = run(&att_path);
+    assert!(
+        !out.status.success(),
+        "a log extended after attestation must not verify"
+    );
+}

--- a/crates/nucleus-node/src/trust_gate.rs
+++ b/crates/nucleus-node/src/trust_gate.rs
@@ -733,60 +733,14 @@ pub struct ReceiptReport {
     pub v1_content_hash: String,
 }
 
-/// A host-signed attestation binding an Article 12 log to the executor that ran it.
-///
-/// # Why this exists
-///
-/// `verify-art12` can show that no party lacking the signing secret altered the
-/// log. It cannot show that a HOLDER of the secret did not rewrite history — and
-/// when the pod derives its own secret, the pod is such a holder, so the log is
-/// not evidence against the pod at all.
-///
-/// The executor key closes that. It lives on the node, is role-separated from
-/// the task-issuer key, and the pod never sees it. A pod that rewrites its log
-/// produces a different chain head and cannot forge this signature over the new
-/// one.
-///
-/// # What it does NOT establish
-///
-/// It binds the HEAD, not the content: a pod that recorded nothing exports a
-/// validly-signed empty log. Completeness remains unverifiable from the
-/// artifact, which is why `verify-art12` reports it as a limitation regardless.
-///
-/// The binding is also only as strong as the moment it is made. Signing happens
-/// at pod exit, after the host has stopped the pod — a signature taken while the
-/// pod could still write would bind a head the pod could move.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
-pub struct Art12Attestation {
-    /// Schema tag, so a verifier refuses rather than guessing at field drift.
-    pub kind: String,
-    pub session_id: String,
-    /// The log's chain head as the pod reported it at shutdown.
-    pub chain_head: String,
-    pub records: u64,
-    /// Records the pod could not write. Non-zero means the log went degraded.
-    pub dropped: u64,
-    /// Executor identity, so a verifier knows which public key to check.
-    pub executor_id: String,
-    /// Ed25519 signature over the canonical preimage, hex-encoded.
-    pub signature: String,
-}
-
-/// The signed preimage. Field-ordered and delimited, never `serde_json` — a
-/// verifier that re-serialises to check a signature is checking its own
-/// serialiser.
-#[must_use]
-pub fn art12_attestation_preimage(
-    session_id: &str,
-    chain_head: &str,
-    records: u64,
-    dropped: u64,
-    executor_id: &str,
-) -> String {
-    format!(
-        "nucleus-art12-attestation-v1|{session_id}|{chain_head}|{records}|{dropped}|{executor_id}"
-    )
-}
+// `Art12Attestation` and `art12_attestation_preimage` live in
+// `portcullis::art12_record`, beside `Art12Record`, so this signer and the
+// verifier in `nucleus-audit` share ONE definition of the preimage. Two
+// renderings that agree today break the first time either side gains a field —
+// and they break by rejecting authentic evidence, which is the worst direction.
+pub use portcullis::art12_record::{
+    art12_attestation_preimage, Art12Attestation, ART12_ATTESTATION_KIND,
+};
 
 /// Sign a pod's Article 12 chain head with the executor key.
 ///
@@ -811,7 +765,7 @@ pub fn attest_art12(
     );
     let sig = key.sign(preimage.as_bytes());
     Some(Art12Attestation {
-        kind: "nucleus-art12-attestation-v1".to_string(),
+        kind: ART12_ATTESTATION_KIND.to_string(),
         session_id: session_id.to_string(),
         chain_head: report.art12_chain_head.clone(),
         records: report.art12_records,

--- a/crates/portcullis/src/art12_record.rs
+++ b/crates/portcullis/src/art12_record.rs
@@ -152,6 +152,83 @@ impl Art12Record {
     }
 }
 
+/// A host-signed attestation binding an Article 12 log to the executor that ran it.
+///
+/// # Why it lives here, beside `Art12Record`
+///
+/// For the same reason the record does: the SIGNER (`nucleus-node`) and the
+/// VERIFIER (`nucleus-audit`) must share one definition of the preimage. Two
+/// independent renderings that happen to agree today are the shape that breaks
+/// the first time either side gains a field, and it breaks by rejecting
+/// authentic evidence.
+///
+/// # What it establishes
+///
+/// `verify-art12` can show no party LACKING the log's HMAC secret altered it. It
+/// cannot show that a HOLDER of the secret did not rewrite history — and a pod
+/// that derives its own secret is such a holder. This is signed with the node's
+/// executor key, which the pod never sees, so a pod that rewrites its log
+/// produces a different chain head and cannot forge a signature over the new one.
+///
+/// # What it does NOT establish
+///
+/// It binds the HEAD, not the content: a pod that recorded nothing exports a
+/// validly signed empty log, so completeness stays unverifiable from the
+/// artifact. And it binds a MOMENT — signing happens at pod exit, after the host
+/// has stopped the pod, so the head is one the pod can no longer move.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Art12Attestation {
+    /// Schema tag, so a verifier refuses rather than guessing at field drift.
+    pub kind: String,
+    /// The session whose log this attests to.
+    pub session_id: String,
+    /// The log's chain head as the pod reported it at shutdown.
+    pub chain_head: String,
+    /// Records the log wrote.
+    pub records: u64,
+    /// Records the log could not write. Non-zero means it went degraded.
+    pub dropped: u64,
+    /// Executor identity, so a verifier knows which public key to check.
+    pub executor_id: String,
+    /// Ed25519 signature over [`art12_attestation_preimage`], hex-encoded.
+    pub signature: String,
+}
+
+/// The tag every attestation carries, and the domain separator in its preimage.
+pub const ART12_ATTESTATION_KIND: &str = "nucleus-art12-attestation-v1";
+
+/// The signed preimage, field-ordered and delimited.
+///
+/// Deliberately not `serde_json::to_string`, for the reason
+/// [`Art12Record::canonical_preimage`] gives: JSON key order and escaping are not
+/// guaranteed stable across serde versions, and a verifier that re-serialises to
+/// check a signature is checking its own serialiser.
+#[must_use]
+pub fn art12_attestation_preimage(
+    session_id: &str,
+    chain_head: &str,
+    records: u64,
+    dropped: u64,
+    executor_id: &str,
+) -> String {
+    format!("{ART12_ATTESTATION_KIND}|{session_id}|{chain_head}|{records}|{dropped}|{executor_id}")
+}
+
+impl Art12Attestation {
+    /// This attestation's own preimage, reconstructed from its own fields.
+    #[must_use]
+    pub fn preimage(&self) -> String {
+        art12_attestation_preimage(
+            &self.session_id,
+            &self.chain_head,
+            self.records,
+            self.dropped,
+            &self.executor_id,
+        )
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/docs/article-12-record-keeping.md
+++ b/docs/article-12-record-keeping.md
@@ -80,14 +80,44 @@ consumer cannot render "verified" without it.
 
 The third row is the one to read twice. If the pod derived its own signing
 secret — no operator-supplied `--audit-secret` — then the pod can re-sign any
-history it likes, and **the log is not evidence against the pod at all**. The
-file cannot reveal which case it is in; the operator knows. Supply an
-operator-held secret, or treat the log as an integrity check against third
-parties only.
+history it likes, and **the log alone is not evidence against the pod**.
 
-Closing that gap properly needs a signature over the chain head by a key the pod
-does not possess. The export path attaches one; that is a separate increment from
-this one, and until it lands the limitation above is the honest description.
+## The executor attestation closes that
+
+At pod exit the tool proxy reports its final chain head in the exit report, and
+`nucleus-node` signs `(session_id, chain_head, records, dropped, executor_id)`
+with its **executor key** — Ed25519, resident on the node, role-separated from
+the task-issuer key, and never seen by the pod. The attestation travels with the
+receipt in the `session-complete` body, and the chain head is committed into
+`v1_content_hash` so it cannot be stripped in flight.
+
+```
+nucleus-audit verify-art12 --log art12.jsonl --secret <s> \
+    --attestation att.json --executor-pubkey <hex>
+```
+
+The verifier checks the signature over the attestation's own preimage **and**
+that the head it names is the head recomputed from the log. Both halves are
+required: a valid signature over a different head proves only that some other log
+was attested. When both pass, the secret-holder limitation is lifted from the
+report — that is the one case where it does not apply.
+
+The signer and the verifier share one preimage function in
+`portcullis::art12_record`, for the reason `Art12Record` lives there too: two
+renderings that agree today break the first time either side gains a field, and
+they break by *rejecting authentic evidence*.
+
+Two limits remain, both structural:
+
+- **It binds the head, not the content.** A pod that recorded nothing exports a
+  validly signed empty log. Completeness stays unverifiable from the artifact.
+- **It binds a moment.** Signing happens at pod exit, after the host has stopped
+  the pod, so the head is one the pod can no longer move. A signature taken while
+  the pod still ran would bind a head the pod could advance past.
+
+An absent attestation means no Article 12 log was kept: `attest_art12` returns
+`None` rather than signing an empty head, because a signature over nothing would
+assert record-keeping that did not happen.
 
 ## Current limits
 


### PR DESCRIPTION
#2148 signs a pod's Article 12 chain head with the executor key. **Nothing checked it** — the mechanism existed, the claim was made, and the loop was open. That is the defect this whole arc has been about, sitting in my own PR; the difference is only that #2148 said so rather than implying otherwise.

## One definition of the preimage

`Art12Attestation` and `art12_attestation_preimage` move to `portcullis::art12_record`, beside `Art12Record`, whose own comment already states the rule: *the writer and the verifier must share one definition.*

Left in `nucleus-node`, a verifier in `nucleus-audit` would have had to restate the preimage — two renderings that agree today and break the first time either side gains a field, **by rejecting authentic evidence**. That failure mode has already happened once in this repo (the drand-anchored audit log).

## Both halves of the check are required

`verify-art12 --attestation <f> --executor-pubkey <hex>` verifies the signature over the attestation's own preimage **and** that the head it names is the head recomputed from the log.

Either alone is worthless. A valid signature over a different head proves only that *some other log* was attested — pinned by `a_valid_signature_over_a_different_log_does_not_pass`, which asserts the same attestation passes for its own head and fails for this one.

## The report's limitations move with what was established

When the attestation checks out, the secret-holder caveat is **removed** — it is the one case where it does not apply — and replaced by the one that still does (*"binds the HEAD, not its content"*). A report that kept the lifted caveat would understate what was proven, which is the mirror of the overclaiming the rest of this design guards against.

## Verification

End-to-end through the real CLI: a log written the way the runtime writes it, its head signed with a key the pod never holds, the verifier recomputing and checking. The test then appends one more record and asserts verification now **fails** — the rewritten-after-attestation case, which is the property the export exists for.

Perturbations: skip the head comparison (REDs two); skip the signature verification (REDs one).

Adds the export section to `docs/article-12-record-keeping.md` — the follow-up owed by #2148, whose branch predated the file.

fmt / clippy `--workspace --all-targets --all-features -D warnings` / `cargo test --all-features` (222 suites, 0 failures) / line ratchet `--strict` / mediation / sealed-home / dep ceiling: all green, each gated on **exit status**.