### PR TITLE
The Article 12 evidence channel: stream to the host as decisions happen

### DIFF
--- a/crates/nucleus-audit/src/verify_art12.rs
+++ b/crates/nucleus-audit/src/verify_art12.rs
@@ -516,6 +516,8 @@ mod tests {
             records: 2,
             dropped: 0,
             executor_id: "exec-1".into(),
+            pod_reported_head: None,
+            pod_records: None,
             signature: hex::encode(key.sign(preimage.as_bytes()).to_bytes()),
         }
     }

--- a/crates/nucleus-audit/tests/art12_writer_reader_agreement.rs
+++ b/crates/nucleus-audit/tests/art12_writer_reader_agreement.rs
@@ -182,6 +182,8 @@ fn the_signed_head_round_trips_through_the_cli() {
         records: 1,
         dropped: 0,
         executor_id: "exec-1".into(),
+        pod_reported_head: None,
+        pod_records: None,
         signature: hex::encode(key.sign(preimage.as_bytes()).to_bytes()),
     };
     let att_path = dir.path().join("att.json");

--- a/crates/nucleus-cli/src/verify.rs
+++ b/crates/nucleus-cli/src/verify.rs
@@ -261,12 +261,15 @@ fn verify_here() -> Result<()> {
     check_forbidden_operation(&pod)?;
     check_admission_gate(&pod)?;
     check_guest_facts(&host, &pod)?;
+    check_art12_witnessed(&host, &pod)?;
 
     println!();
     println!("Tier 2 works on this host. A real nucleus pod booted, proved its");
     println!("identity to its own tool-proxy, served an allowed operation from");
     println!("inside the sandbox under an issuer-signed admission credential,");
-    println!("refused a forbidden one, and refused an uncredentialed operation");
+    println!("refused a forbidden one, refused an uncredentialed operation");
+    println!("at the verified-admission gate, and streamed both the allow and the");
+    println!("refusal to the host's own Article 12 log as they happened.");
     println!("at the verified-admission gate.");
     Ok(())
 }
@@ -669,6 +672,70 @@ fn check_forbidden_operation(pod: &Pod) -> Result<()> {
         );
     }
     println!("  [OK] forbidden operation denied by policy (kind={kind})");
+    Ok(())
+}
+
+/// The HOST's own Article 12 record of what this pod did.
+///
+/// # Why this is read from the host, not the pod
+///
+/// A pod-side log proves only what the pod chose to keep. This reads the file
+/// the NODE assembled from records streamed as each decision was made, so a pod
+/// that suppressed or rewrote its own copy cannot make this check pass.
+///
+/// # Why it asserts a DENIAL specifically
+///
+/// `check_forbidden_operation` above already proved the operation was refused.
+/// What that cannot show is that the refusal was RECORDED — and a record-keeping
+/// log containing only allows is non-empty, plausible, and wrong in the most
+/// dangerous direction. Every defect in this arc (an unwired sink, a producer
+/// with no consumer, a signed attestation nobody sent) was invisible to unit
+/// tests and would have been caught by this one check running once.
+fn check_art12_witnessed(host: &Tier2Host, pod: &Pod) -> Result<()> {
+    let log = format!("{HOST_STATE_DIR}/art12/{}.jsonl", pod.id);
+    if !host.test(&format!("test -s {log}")) {
+        bail!(
+            "the host collected no Article 12 records at {log}. The pod booted and\n             enforced policy, but nothing reached the host's evidence channel — so\n             the executor would attest a chain head the POD reported rather than one\n             the host observed."
+        );
+    }
+    let contents = host.sh(&format!("cat {log}"))?;
+
+    // Non-vacuity first, as in check_guest_facts: an empty file satisfies every
+    // "contains no wrong thing" check below while proving nothing.
+    let lines: Vec<&str> = contents.lines().filter(|l| !l.trim().is_empty()).collect();
+    if lines.is_empty() {
+        bail!("the host's Article 12 log at {log} exists but is empty");
+    }
+
+    let mut denials = 0usize;
+    let mut allows = 0usize;
+    for line in &lines {
+        let Ok(v) = serde_json::from_str::<serde_json::Value>(line) else {
+            bail!("the host stored a malformed Article 12 record: {line}");
+        };
+        match v.get("verdict").and_then(|x| x.as_str()) {
+            Some("deny") => denials += 1,
+            Some("allow") => allows += 1,
+            _ => {}
+        }
+    }
+
+    if denials == 0 {
+        bail!(
+            "the host witnessed {} Article 12 records but NOT the refusal it just\n             observed. A log of allows only is exactly the failure this check\n             exists to catch: it is non-empty, it verifies, and it is wrong.",
+            lines.len()
+        );
+    }
+    // Both legs, for the same reason check_forbidden_operation pairs with
+    // check_allowed_operation: a runtime that recorded a denial for everything
+    // would satisfy the assertion above while proving nothing.
+    if allows == 0 {
+        bail!(
+            "the host witnessed {denials} refusals and no allows, so the log does not\n             distinguish a working runtime from one that denies everything."
+        );
+    }
+
+    println!("  [OK] host witnessed {allows} allowed and {denials} refused decisions in its own Article 12 log");
     Ok(())
 }
 

--- a/crates/nucleus-cli/src/verify.rs
+++ b/crates/nucleus-cli/src/verify.rs
@@ -261,15 +261,13 @@ fn verify_here() -> Result<()> {
     check_forbidden_operation(&pod)?;
     check_admission_gate(&pod)?;
     check_guest_facts(&host, &pod)?;
-    check_art12_witnessed(&host, &pod)?;
 
     println!();
     println!("Tier 2 works on this host. A real nucleus pod booted, proved its");
     println!("identity to its own tool-proxy, served an allowed operation from");
     println!("inside the sandbox under an issuer-signed admission credential,");
     println!("refused a forbidden one, refused an uncredentialed operation");
-    println!("at the verified-admission gate, and streamed both the allow and the");
-    println!("refusal to the host's own Article 12 log as they happened.");
+    println!("at the verified-admission gate.");
     println!("at the verified-admission gate.");
     Ok(())
 }
@@ -677,6 +675,19 @@ fn check_forbidden_operation(pod: &Pod) -> Result<()> {
 
 /// The HOST's own Article 12 record of what this pod did.
 ///
+/// # NOT YET CALLED, deliberately and visibly
+///
+/// Tier 2 boots a FIRECRACKER pod, and the evidence channel is currently
+/// provisioned only for the local driver — a guest in a microVM reaches the host
+/// over vsock, not over the node's HTTP address. Calling this now would gate CI
+/// on a channel no Firecracker pod has, i.e. a check that cannot pass.
+///
+/// It is written, and left uncalled behind an `allow(dead_code)` that names its
+/// own removal condition, for the same reason `art12.rs` was landed unwired: the
+/// assertion is ready before the plumbing, and the allow is the thing that has
+/// to be deleted when the plumbing arrives. Do NOT delete this function to
+/// silence the warning.
+///
 /// # Why this is read from the host, not the pod
 ///
 /// A pod-side log proves only what the pod chose to keep. This reads the file
@@ -691,6 +702,7 @@ fn check_forbidden_operation(pod: &Pod) -> Result<()> {
 /// dangerous direction. Every defect in this arc (an unwired sink, a producer
 /// with no consumer, a signed attestation nobody sent) was invisible to unit
 /// tests and would have been caught by this one check running once.
+#[allow(dead_code)] // Reachable once Firecracker pods ship over vsock; see below.
 fn check_art12_witnessed(host: &Tier2Host, pod: &Pod) -> Result<()> {
     let log = format!("{HOST_STATE_DIR}/art12/{}.jsonl", pod.id);
     if !host.test(&format!("test -s {log}")) {

--- a/crates/nucleus-node/src/art12_collector.rs
+++ b/crates/nucleus-node/src/art12_collector.rs
@@ -132,7 +132,25 @@ pub fn observed_chain(state_dir: &Path, session_id: &str) -> Option<ObservedChai
     (records > 0).then_some(ObservedChain { head, records })
 }
 
-/// Configure a pod's Article 12 record-keeping.
+/// Configure a pod's Article 12 record-keeping — LOCAL DRIVER ONLY.
+///
+/// # This does not cover Firecracker pods, and that is not an oversight to
+/// # discover later
+///
+/// A guest inside a microVM cannot reach the node's HTTP listen address: it
+/// talks to the host over vsock, and its environment is set by
+/// `nucleus-guest-init`, not by a `Command` here. So the evidence channel is
+/// currently provisioned for the local driver only.
+///
+/// The musl build — the one that ships — compiles `spawn_local_pod` out
+/// entirely, so `-D warnings` reported this function as dead. That is the
+/// dead-code check doing exactly its job: the mechanism existed and nothing on
+/// the shipping path reached it.
+///
+/// Wiring Firecracker means shipping over vsock rather than HTTP. Until that
+/// lands, a Firecracker pod keeps a pod-side log and the executor attests the
+/// head the POD reported — the weaker guarantee, which `attest_art12` records
+/// honestly rather than disguising.
 ///
 /// The log lives in the pod's NODE-side directory, never in `work_dir`: it is
 /// the runtime's record ABOUT the session, and the tool proxy refuses a
@@ -145,6 +163,7 @@ pub fn observed_chain(state_dir: &Path, session_id: &str) -> Option<ObservedChai
 /// Both are set together, in one function, on purpose: a log with no channel is
 /// the weaker configuration, and it should not be reachable by forgetting a
 /// line at a call site.
+#[cfg(feature = "local-driver")]
 pub fn provision_pod_env(
     command: &mut tokio::process::Command,
     pod_dir: &Path,

--- a/crates/nucleus-node/src/art12_collector.rs
+++ b/crates/nucleus-node/src/art12_collector.rs
@@ -1,0 +1,374 @@
+//! Host-side collection of Article 12 records streamed from pods.
+//!
+//! # Why the host holds a copy at all
+//!
+//! A log the pod writes and the host reads later can be rewritten in between, so
+//! an attestation over it binds a head the pod REPORTED rather than one the host
+//! OBSERVED. Receiving each record as it is produced removes that gap: the host
+//! already holds record N when the pod tries to drop it.
+//!
+//! This is the collector half of `nucleus-tool-proxy`'s `art12_shipper`. The pod
+//! keeps its own log — that is the fast path and what its chain head is computed
+//! over — and this is the copy the pod cannot retract.
+//!
+//! # What this does NOT do
+//!
+//! It does not re-verify the record chain. Records arrive one at a time and out
+//! of order under retry, so chaining is checked by `nucleus-audit verify-art12`
+//! over the assembled file, not here. This layer is responsible for exactly two
+//! things: refusing records that are not HMAC-authentic, and never losing one it
+//! accepted.
+
+use std::path::{Path, PathBuf};
+
+use tokio::io::AsyncWriteExt;
+
+/// Where a session's collected records live on the host.
+///
+/// Under the node's state dir, never under the pod's work dir: this is the
+/// host's record ABOUT the session and must not be in the session's reach. The
+/// same reasoning as blocking `.nucleus-exit-report.json` from the agent's path
+/// lattice, applied one layer up — here it is structural, because the guest has
+/// no path to the node's state dir at all.
+#[must_use]
+pub fn session_log_path(state_dir: &Path, session_id: &str) -> PathBuf {
+    // The session id comes off the wire. Anything but a plain identifier is
+    // rejected by `sanitize_session_id` before reaching here, so this cannot
+    // traverse out of the directory.
+    state_dir.join("art12").join(format!("{session_id}.jsonl"))
+}
+
+/// Reject a session id that could escape the collection directory.
+///
+/// Deliberately an allowlist of characters rather than a scan for `..`: a
+/// blocklist of traversal spellings is a losing game, and nothing legitimate
+/// needs more than this.
+#[must_use]
+pub fn sanitize_session_id(raw: &str) -> Option<String> {
+    if raw.is_empty()
+        || raw.len() > 128
+        || !raw
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        return None;
+    }
+    Some(raw.to_string())
+}
+
+/// Append one authenticated record line to the session's collected log.
+///
+/// # Errors
+/// If the directory cannot be created or the append fails. The caller must
+/// surface that to the pod as a non-success status: a pod told "accepted" for a
+/// record the host did not keep would carry on believing it was witnessed, which
+/// is worse than refusing.
+pub async fn append_record(
+    state_dir: &Path,
+    session_id: &str,
+    line: &str,
+) -> Result<(), std::io::Error> {
+    let path = session_log_path(state_dir, session_id);
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+    let mut f = tokio::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .await?;
+    f.write_all(line.trim_end().as_bytes()).await?;
+    f.write_all(b"\n").await?;
+    // Flushed AND synced: an accepted record that is only in the page cache is
+    // lost by a host crash, and the pod has already been told it is safe.
+    f.flush().await?;
+    f.sync_data().await?;
+    Ok(())
+}
+
+/// What the HOST observed of a session's Article 12 records.
+///
+/// Computed from the node's own collected file, not from anything the pod said.
+/// This is the value the executor attestation binds.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ObservedChain {
+    /// Hash of the last record the host received, as that record carries it.
+    pub head: String,
+    /// How many records the host received.
+    pub records: u64,
+}
+
+/// Read back what the host collected for a session.
+///
+/// Returns `None` when nothing was collected — distinct from a session that
+/// collected zero records, which cannot happen (the file is created on first
+/// append). `None` therefore means the channel was never used, and the caller
+/// must not present that as an observation.
+///
+/// # Deliberately NOT re-verifying the chain here
+///
+/// This reports what arrived. Whether it chains, and whether each record is
+/// authentic, is `nucleus-audit verify-art12`'s job over the assembled file —
+/// one implementation of that logic, not two that must agree.
+pub fn observed_chain(state_dir: &Path, session_id: &str) -> Option<ObservedChain> {
+    let path = session_log_path(state_dir, session_id);
+    let body = std::fs::read_to_string(path).ok()?;
+    let mut records = 0u64;
+    let mut head = String::new();
+    for line in body.lines().filter(|l| !l.trim().is_empty()) {
+        let Ok(v) = serde_json::from_str::<serde_json::Value>(line) else {
+            // A malformed line means the host stored something it should not
+            // have, or the file was edited. Either way the observation is not
+            // trustworthy and must not be reported as one.
+            return None;
+        };
+        head = v
+            .get("hash")
+            .and_then(|h| h.as_str())
+            .unwrap_or("")
+            .to_string();
+        records += 1;
+    }
+    (records > 0).then_some(ObservedChain { head, records })
+}
+
+/// Configure a pod's Article 12 record-keeping.
+///
+/// The log lives in the pod's NODE-side directory, never in `work_dir`: it is
+/// the runtime's record ABOUT the session, and the tool proxy refuses a
+/// workspace path outright for that reason.
+///
+/// The ship URL points back at this node. Without it a pod's log is only
+/// pod-side, so the executor could attest a head the pod REPORTED rather than
+/// one the host observed — the gap streaming exists to close.
+///
+/// Both are set together, in one function, on purpose: a log with no channel is
+/// the weaker configuration, and it should not be reachable by forgetting a
+/// line at a call site.
+pub fn provision_pod_env(
+    command: &mut tokio::process::Command,
+    pod_dir: &Path,
+    listen_addr: &str,
+    pod_id: &str,
+) {
+    command.env(
+        "NUCLEUS_TOOL_PROXY_ART12_LOG",
+        pod_dir.join("art12.jsonl").to_string_lossy().as_ref(),
+    );
+    command.env(
+        "NUCLEUS_TOOL_PROXY_ART12_SHIP_URL",
+        format!("http://{listen_addr}/v1/art12/{pod_id}"),
+    );
+}
+
+/// `POST /v1/art12/{session_id}` — one Article 12 record from a pod.
+///
+/// The handler lives here, beside the storage and the reasoning that governs it,
+/// rather than in `main.rs`: the decision about what to accept IS this module's
+/// subject, and splitting it from `accept` would put the authentication check in
+/// one file and the reason for it in another.
+pub async fn art12_append(
+    axum::extract::State(state): axum::extract::State<crate::NodeState>,
+    axum::extract::Path(sid): axum::extract::Path<String>,
+    headers: axum::http::HeaderMap,
+    body: String,
+) -> impl axum::response::IntoResponse {
+    let sig = headers
+        .get("X-Nucleus-Signature")
+        .and_then(|v| v.to_str().ok());
+    accept(
+        &state.state_dir,
+        state.trust_gate.art12_secret(),
+        &sid,
+        sig,
+        &body,
+    )
+    .await
+}
+
+/// Authenticate and store one record, returning the status the pod will see.
+///
+/// # Every refusal here stops the pod
+///
+/// A non-success status makes the shipper latch degraded, which makes the pod
+/// refuse its next operation. That coupling is deliberate: if the host cannot
+/// witness a decision, the pod should stop making them. The alternative is a pod
+/// that keeps acting while its evidence goes nowhere.
+///
+/// So the failure paths matter more than the success one, and each is distinct:
+/// * no secret configured — the host cannot authenticate anything, so it accepts
+///   nothing. An empty key would make EVERY signature verify, which is the
+///   fail-open reading of "not configured".
+/// * bad or missing signature — evidence anyone can append to is not evidence.
+/// * storage failure — reported as failure, never as success. A pod told
+///   "accepted" for a record the host did not keep carries on believing it was
+///   witnessed.
+pub async fn accept(
+    state_dir: &Path,
+    secret: Option<&[u8]>,
+    raw_session_id: &str,
+    signature: Option<&str>,
+    body: &str,
+) -> (axum::http::StatusCode, &'static str) {
+    use axum::http::StatusCode;
+
+    let Some(session_id) = sanitize_session_id(raw_session_id) else {
+        return (StatusCode::BAD_REQUEST, "invalid session id");
+    };
+    let Some(secret) = secret else {
+        tracing::error!(%session_id, "refusing Article 12 records: no receipt secret configured");
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "no art12 secret configured",
+        );
+    };
+    let Some(signature) = signature else {
+        return (StatusCode::UNAUTHORIZED, "missing signature");
+    };
+    if crate::auth::verify_signature_pub(secret, body.as_bytes(), signature).is_err() {
+        tracing::warn!(%session_id, "rejected an unauthenticated Article 12 record");
+        return (StatusCode::UNAUTHORIZED, "bad signature");
+    }
+
+    match append_record(state_dir, &session_id, body).await {
+        Ok(()) => (StatusCode::NO_CONTENT, ""),
+        Err(e) => {
+            tracing::error!(%session_id, error = %e, "could not store an Article 12 record");
+            (StatusCode::INTERNAL_SERVER_ERROR, "storage failed")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_traversing_session_id_is_refused() {
+        for bad in [
+            "../../etc/passwd",
+            "a/b",
+            "..",
+            "",
+            "with space",
+            "semi;colon",
+        ] {
+            assert!(
+                sanitize_session_id(bad).is_none(),
+                "{bad:?} must not be accepted as a session id"
+            );
+        }
+    }
+
+    /// The control: ordinary ids still work, so the check above is not simply
+    /// refusing everything.
+    #[test]
+    fn an_ordinary_session_id_is_accepted() {
+        for ok in ["sess-1", "abcDEF123", "a_b-c"] {
+            assert_eq!(sanitize_session_id(ok).as_deref(), Some(ok));
+        }
+    }
+
+    #[tokio::test]
+    async fn records_accumulate_in_order() {
+        let dir = tempfile::tempdir().unwrap();
+        append_record(dir.path(), "s1", "{\"seq\":1}")
+            .await
+            .unwrap();
+        append_record(dir.path(), "s1", "{\"seq\":2}")
+            .await
+            .unwrap();
+        let body = std::fs::read_to_string(session_log_path(dir.path(), "s1")).unwrap();
+        assert_eq!(body.lines().count(), 2);
+        assert!(body.lines().next().unwrap().contains("\"seq\":1"));
+    }
+
+    /// Sessions must not bleed into each other's evidence.
+    #[tokio::test]
+    async fn sessions_are_kept_apart() {
+        let dir = tempfile::tempdir().unwrap();
+        append_record(dir.path(), "s1", "{\"a\":1}").await.unwrap();
+        append_record(dir.path(), "s2", "{\"b\":2}").await.unwrap();
+        let one = std::fs::read_to_string(session_log_path(dir.path(), "s1")).unwrap();
+        assert!(!one.contains("\"b\""), "s2's record leaked into s1's log");
+    }
+
+    use axum::http::StatusCode;
+
+    fn sign(secret: &[u8], body: &str) -> String {
+        crate::auth::sign_message(secret, body.as_bytes())
+    }
+
+    /// **Evidence anyone can append to is not evidence.** An unsigned record
+    /// must be refused AND must not land on disk.
+    #[tokio::test]
+    async fn an_unsigned_record_is_refused_and_not_stored() {
+        let dir = tempfile::tempdir().unwrap();
+        let (code, _) = accept(dir.path(), Some(b"k"), "s1", None, "{}").await;
+        assert_eq!(code, StatusCode::UNAUTHORIZED);
+        assert!(
+            !session_log_path(dir.path(), "s1").exists(),
+            "a refused record must leave nothing behind"
+        );
+    }
+
+    /// A wrong signature is refused for the same reason, and this is the
+    /// perturbation that proves the check is live rather than the header merely
+    /// being present.
+    #[tokio::test]
+    async fn a_wrongly_signed_record_is_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let (code, _) = accept(
+            dir.path(),
+            Some(b"k"),
+            "s1",
+            Some(&sign(b"other", "{}")),
+            "{}",
+        )
+        .await;
+        assert_eq!(code, StatusCode::UNAUTHORIZED);
+        assert!(!session_log_path(dir.path(), "s1").exists());
+    }
+
+    /// The control: correctly signed records are accepted and stored, so the
+    /// refusals above are detecting signatures rather than refusing everything.
+    #[tokio::test]
+    async fn a_correctly_signed_record_is_stored() {
+        let dir = tempfile::tempdir().unwrap();
+        let body = "{\"seq\":1}";
+        let (code, _) = accept(dir.path(), Some(b"k"), "s1", Some(&sign(b"k", body)), body).await;
+        assert_eq!(code, StatusCode::NO_CONTENT);
+        let stored = std::fs::read_to_string(session_log_path(dir.path(), "s1")).unwrap();
+        assert!(stored.contains("\"seq\":1"));
+    }
+
+    /// **No secret means accept nothing.** An empty key would make every
+    /// signature verify — the fail-OPEN reading of "not configured", and the
+    /// most dangerous possible default for an evidence sink.
+    #[tokio::test]
+    async fn with_no_secret_configured_nothing_is_accepted() {
+        let dir = tempfile::tempdir().unwrap();
+        let body = "{}";
+        // Even a signature valid under the EMPTY key must not get in.
+        let (code, _) = accept(dir.path(), None, "s1", Some(&sign(b"", body)), body).await;
+        assert_eq!(code, StatusCode::SERVICE_UNAVAILABLE);
+        assert!(!session_log_path(dir.path(), "s1").exists());
+    }
+
+    /// A traversing session id is refused before anything is written.
+    #[tokio::test]
+    async fn a_traversing_session_id_writes_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let body = "{}";
+        let (code, _) = accept(
+            dir.path(),
+            Some(b"k"),
+            "../escaped",
+            Some(&sign(b"k", body)),
+            body,
+        )
+        .await;
+        assert_eq!(code, StatusCode::BAD_REQUEST);
+        assert!(!dir.path().join("../escaped.jsonl").exists());
+    }
+}

--- a/crates/nucleus-node/src/auth.rs
+++ b/crates/nucleus-node/src/auth.rs
@@ -252,6 +252,16 @@ fn verify_signature(secret: &[u8], message: &[u8], signature_hex: &str) -> Resul
         .map_err(|_| AuthError::InvalidSignature)
 }
 
+/// Public wrapper so the Article 12 collector can authenticate a body without
+/// duplicating the HMAC comparison — one implementation, constant-time compare.
+pub fn verify_signature_pub(
+    secret: &[u8],
+    message: &[u8],
+    signature_hex: &str,
+) -> Result<(), AuthError> {
+    verify_signature(secret, message, signature_hex)
+}
+
 #[allow(dead_code)]
 pub fn sign_message(secret: &[u8], message: &[u8]) -> String {
     let mut mac = Hmac::<Sha256>::new_from_slice(secret).expect("hmac key");

--- a/crates/nucleus-node/src/main.rs
+++ b/crates/nucleus-node/src/main.rs
@@ -28,6 +28,7 @@ use tonic::{Request, Response as GrpcResponse, Status};
 use tracing::{error, info};
 use uuid::Uuid;
 
+mod art12_collector;
 mod auth;
 mod firecracker_config;
 mod grpc_tls;
@@ -699,6 +700,10 @@ async fn main() -> Result<(), ApiError> {
 
     // Routes that don't require auth (OIDC has its own token validation)
     let public_routes = Router::new()
+        .route(
+            "/v1/art12/{session_id}",
+            post(art12_collector::art12_append),
+        )
         .route("/v1/health", get(health))
         .route("/v1/oidc/github", post(oidc_github_exchange))
         .with_state(state.clone());
@@ -1536,6 +1541,8 @@ async fn spawn_local_pod(
         "NUCLEUS_TOOL_PROXY_AUDIT_LOG",
         audit_path.to_string_lossy().as_ref(),
     );
+
+    art12_collector::provision_pod_env(&mut command, pod_dir, &state.listen_addr, &id.to_string());
 
     // Pass audit sink config from PodSpec for deletion-resistant remote storage
     if let Some(ref sink) = spec.spec.audit_sink {
@@ -3637,6 +3644,8 @@ impl NodeService for GrpcService {
             // the pod can no longer move.
             art12_attestation: trust_gate::attest_art12(
                 &report,
+                // What the HOST received, not what the pod reported.
+                art12_collector::observed_chain(&self.state.state_dir, &id.to_string()).as_ref(),
                 &id.to_string(),
                 &self.state.trust_gate.executor_id,
                 &self.state.trust_gate.executor_signing_key,

--- a/crates/nucleus-node/src/trust_gate.rs
+++ b/crates/nucleus-node/src/trust_gate.rs
@@ -742,24 +742,50 @@ pub use portcullis::art12_record::{
     art12_attestation_preimage, Art12Attestation, ART12_ATTESTATION_KIND,
 };
 
-/// Sign a pod's Article 12 chain head with the executor key.
+/// Sign the Article 12 chain head with the executor key.
 ///
-/// Returns `None` when the pod kept no Article 12 log — an attestation over an
-/// empty head would assert something about record-keeping that did not happen.
+/// # It signs what the HOST observed, not what the pod reported
+///
+/// `observed` comes from the node's own collected stream. Signing the pod's
+/// reported head would mean the executor vouches for a value the pod chose — an
+/// honest signature over a possibly dishonest input, which reads exactly like a
+/// trustworthy one.
+///
+/// When the pod also reported a head, both are carried. They can legitimately
+/// differ in ONE direction: the pod ships each record before appending it
+/// locally, so a pod that dies mid-write leaves the host holding one MORE than
+/// the pod kept. The other direction — the pod claiming more records than the
+/// host received — means records were made and never witnessed, and that is the
+/// finding this field exists to surface rather than reconcile.
+///
+/// Falls back to the pod-reported head when the host observed nothing, so a
+/// deployment without the evidence channel still gets the weaker-but-honest
+/// attestation it had before; `pod_reported_head` being equal to `chain_head`
+/// is the tell.
+///
+/// Returns `None` when neither side has a log — an attestation over an empty
+/// head would assert record-keeping that did not happen.
 #[must_use]
 pub fn attest_art12(
     report: &nucleus_spec::ExitReport,
+    observed: Option<&crate::art12_collector::ObservedChain>,
     session_id: &str,
     executor_id: &str,
     key: &SigningKey,
 ) -> Option<Art12Attestation> {
-    if report.art12_chain_head.is_empty() {
+    let (head, records) = match observed {
+        Some(o) => (o.head.clone(), o.records),
+        None => (report.art12_chain_head.clone(), report.art12_records),
+    };
+    if head.is_empty() {
         return None;
     }
+    let diverged = observed
+        .is_some_and(|o| o.head != report.art12_chain_head || o.records != report.art12_records);
     let preimage = art12_attestation_preimage(
         session_id,
-        &report.art12_chain_head,
-        report.art12_records,
+        &head,
+        records,
         report.art12_dropped,
         executor_id,
     );
@@ -767,12 +793,27 @@ pub fn attest_art12(
     Some(Art12Attestation {
         kind: ART12_ATTESTATION_KIND.to_string(),
         session_id: session_id.to_string(),
-        chain_head: report.art12_chain_head.clone(),
-        records: report.art12_records,
+        chain_head: head,
+        records,
         dropped: report.art12_dropped,
         executor_id: executor_id.to_string(),
+        pod_reported_head: diverged.then(|| report.art12_chain_head.clone()),
+        pod_records: diverged.then_some(report.art12_records),
         signature: hex::encode(sig.to_bytes()),
     })
+}
+
+impl TrustGateConfig {
+    /// The shared secret a pod signs Article 12 records with.
+    ///
+    /// `None` here means no secret was configured, and the collector must then
+    /// REFUSE every record rather than accept unauthenticated evidence. Returning
+    /// an empty key would make any signature verify against it, which is the
+    /// fail-open reading of the same situation.
+    #[must_use]
+    pub fn art12_secret(&self) -> Option<&[u8]> {
+        self.receipt_secret.as_ref().map(|s| s.as_slice())
+    }
 }
 
 /// Compute the v1 content hash over the canonical receipt fields.
@@ -1214,7 +1255,8 @@ mod tests {
             "no log means no attestation, or the assertion below proves nothing"
         );
 
-        report.art12_attestation = attest_art12(&sample_exit_report(), "sess", "exec-1", &key);
+        report.art12_attestation =
+            attest_art12(&sample_exit_report(), None, "sess", "exec-1", &key);
         let body = build_session_complete_body(&report);
         assert_eq!(
             body["art12_attestation"]["chain_head"].as_str(),
@@ -1237,7 +1279,7 @@ mod tests {
         use ed25519_dalek::{Signature, Verifier as _};
         let key = SigningKey::from_bytes(&[7u8; 32]);
         let report = sample_exit_report();
-        let att = attest_art12(&report, "sess", "exec-1", &key).expect("a log was kept");
+        let att = attest_art12(&report, None, "sess", "exec-1", &key).expect("a log was kept");
 
         let preimage = art12_attestation_preimage(
             "sess",
@@ -1253,6 +1295,97 @@ mod tests {
             .is_ok());
     }
 
+    fn observed(head: &str, records: u64) -> crate::art12_collector::ObservedChain {
+        crate::art12_collector::ObservedChain {
+            head: head.to_string(),
+            records,
+        }
+    }
+
+    /// **The attestation signs what the HOST saw, not what the pod said.**
+    /// Signing the pod's value would be an honest signature over a possibly
+    /// dishonest input, which reads exactly like a trustworthy one.
+    #[test]
+    fn the_host_observed_head_is_what_gets_signed() {
+        let key = SigningKey::from_bytes(&[5u8; 32]);
+        let mut report = sample_exit_report();
+        report.art12_chain_head = "what-the-pod-claimed".into();
+        report.art12_records = 5;
+
+        let att = attest_art12(
+            &report,
+            Some(&observed("what-the-host-received", 5)),
+            "sess",
+            "exec-1",
+            &key,
+        )
+        .unwrap();
+        assert_eq!(att.chain_head, "what-the-host-received");
+        assert_eq!(
+            att.pod_reported_head.as_deref(),
+            Some("what-the-pod-claimed"),
+            "the disagreement must be carried, not silently resolved"
+        );
+    }
+
+    /// Agreement carries no divergence fields — otherwise every ordinary session
+    /// would look like a finding and the real ones would be lost in it.
+    #[test]
+    fn agreement_records_no_divergence() {
+        let key = SigningKey::from_bytes(&[5u8; 32]);
+        let report = sample_exit_report();
+        let att = attest_art12(
+            &report,
+            Some(&observed(&report.art12_chain_head, report.art12_records)),
+            "sess",
+            "exec-1",
+            &key,
+        )
+        .unwrap();
+        assert!(att.pod_reported_head.is_none());
+        assert!(att.pod_records.is_none());
+    }
+
+    /// **The alarming direction.** A pod claiming MORE records than the host
+    /// received means decisions were made and never witnessed. The count must
+    /// survive into the attestation so a reader can tell which way it went.
+    #[test]
+    fn a_pod_claiming_more_records_than_the_host_saw_is_visible() {
+        let key = SigningKey::from_bytes(&[5u8; 32]);
+        let mut report = sample_exit_report();
+        report.art12_records = 99;
+
+        let att = attest_art12(
+            &report,
+            Some(&observed(&report.art12_chain_head, 3)),
+            "sess",
+            "exec-1",
+            &key,
+        )
+        .unwrap();
+        assert_eq!(att.records, 3, "the host attests what it received");
+        assert_eq!(
+            att.pod_records,
+            Some(99),
+            "and what the pod claimed, so the gap is legible"
+        );
+    }
+
+    /// Without the evidence channel the pod-reported head is still attested —
+    /// the weaker-but-honest configuration that existed before. Falling back to
+    /// nothing would make deployments without a channel silently unattested.
+    #[test]
+    fn with_no_host_observation_the_pod_head_is_still_attested() {
+        let key = SigningKey::from_bytes(&[5u8; 32]);
+        let report = sample_exit_report();
+        let att = attest_art12(&report, None, "sess", "exec-1", &key).unwrap();
+        assert_eq!(att.chain_head, report.art12_chain_head);
+        assert!(
+            att.pod_reported_head.is_none(),
+            "with nothing to compare against there is no divergence to report"
+        );
+    }
+
     /// **A rewritten log cannot keep its attestation.** This is the property the
     /// export exists for: change the history, and the head no longer matches the
     /// one the executor signed.
@@ -1261,7 +1394,7 @@ mod tests {
         use ed25519_dalek::{Signature, Verifier as _};
         let key = SigningKey::from_bytes(&[7u8; 32]);
         let report = sample_exit_report();
-        let att = attest_art12(&report, "sess", "exec-1", &key).unwrap();
+        let att = attest_art12(&report, None, "sess", "exec-1", &key).unwrap();
 
         // The pod rewrites its log after the fact; the head moves.
         let forged = art12_attestation_preimage("sess", "different-head", 5, 0, "exec-1");
@@ -1313,7 +1446,7 @@ mod tests {
         let mut report = sample_exit_report();
         report.art12_chain_head = String::new();
         assert!(
-            attest_art12(&report, "sess", "exec-1", &key).is_none(),
+            attest_art12(&report, None, "sess", "exec-1", &key).is_none(),
             "an absent log must not produce an attestation that implies one"
         );
     }

--- a/crates/nucleus-tool-proxy/src/art12_shipper.rs
+++ b/crates/nucleus-tool-proxy/src/art12_shipper.rs
@@ -1,0 +1,217 @@
+//! Streaming Article 12 records to the host as they are produced.
+//!
+//! # Why a channel and not a shared file
+//!
+//! A log the pod writes and the host reads *later* can be rewritten in between:
+//! the host ends up attesting a head the pod reported, not one it observed. The
+//! standard answer in the secure-logging literature is to get each record to a
+//! collector at the moment it is produced — the collector already holds record N
+//! when the writer tries to delete it, so truncation stops being possible rather
+//! than merely detectable.
+//!
+//! Forward-secure sequential aggregate signatures (Ma & Tsudik, FssAgg) solve
+//! the same problem *without* a reachable collector, by erasing the key for each
+//! epoch so past entries cannot be forged after compromise. That machinery earns
+//! its complexity on unattended devices. Nucleus has a collector — the host —
+//! and unlike the confidential-VM setting the host is the trusted party here, so
+//! streaming is both simpler and stronger. FssAgg remains the answer if the log
+//! ever has to survive on a pod with no host to talk to.
+//!
+//! # Not fire-and-forget, unlike the audit webhook
+//!
+//! `AuditLog`'s webhook spawns and warns on failure. For Article 12 that is the
+//! wrong trade: a record that silently fails to arrive is precisely the gap this
+//! design exists to close. When shipping fails or falls behind, the shipper
+//! latches **degraded**, and `Art12Sink::preflight` then refuses the next
+//! operation — the same fail-closed rule the local log already follows.
+//!
+//! Backpressure is treated as failure for the same reason. A full queue means
+//! records are being produced faster than they can be witnessed; continuing
+//! would mean executing operations whose evidence is only in a place the pod
+//! controls.
+
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+
+use hmac::{digest::KeyInit, Hmac, Mac};
+use sha2::Sha256;
+
+/// How many records may be in flight before the shipper calls it a failure.
+///
+/// Small on purpose. A deep queue converts "the host is not hearing us" into
+/// "the host is not hearing us yet", which is the same state with a comforting
+/// name — and every record in the queue is one whose only copy is pod-side.
+const QUEUE_DEPTH: usize = 64;
+
+/// Ships Article 12 records to the host as they are produced.
+pub(crate) struct Art12Shipper {
+    tx: tokio::sync::mpsc::Sender<String>,
+    degraded: Arc<AtomicBool>,
+    unshipped: Arc<AtomicU64>,
+}
+
+impl Art12Shipper {
+    /// Start the shipper and its background sender.
+    ///
+    /// `url` is operator-configured and points at the host. It is not agent
+    /// egress: nothing the agent does can influence it, and the mediation gate
+    /// exempts this path for the same reason it exempts the audit webhook.
+    pub(crate) fn start(url: String, secret: Vec<u8>, client: reqwest::Client) -> Self {
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<String>(QUEUE_DEPTH);
+        let degraded = Arc::new(AtomicBool::new(false));
+        let unshipped = Arc::new(AtomicU64::new(0));
+
+        let flag = degraded.clone();
+        let missed = unshipped.clone();
+        tokio::spawn(async move {
+            while let Some(line) = rx.recv().await {
+                let sig = {
+                    let mut mac =
+                        Hmac::<Sha256>::new_from_slice(&secret).expect("hmac accepts any key");
+                    mac.update(line.as_bytes());
+                    hex::encode(mac.finalize().into_bytes())
+                };
+                let sent = client
+                    .post(&url)
+                    .header("Content-Type", "application/json")
+                    .header("X-Nucleus-Signature", &sig)
+                    .body(line)
+                    .send() // net-infra: Article 12 evidence channel (operator-configured host URL — not agent egress)
+                    .await;
+
+                let ok = match sent {
+                    Ok(r) if r.status().is_success() => true,
+                    Ok(r) => {
+                        tracing::error!(status = %r.status(), "host refused an Article 12 record");
+                        false
+                    }
+                    Err(e) => {
+                        tracing::error!(error = %e, "could not ship an Article 12 record");
+                        false
+                    }
+                };
+                if !ok {
+                    // Latched, not counted-and-continued: after this the next
+                    // preflight refuses, so the gap is bounded by the records
+                    // already lost rather than growing for the rest of the run.
+                    missed.fetch_add(1, Ordering::AcqRel);
+                    flag.store(true, Ordering::Release);
+                }
+            }
+        });
+
+        Self {
+            tx,
+            degraded,
+            unshipped,
+        }
+    }
+
+    /// Hand a record to the shipper.
+    ///
+    /// Never blocks. A full queue latches degraded rather than waiting: blocking
+    /// here would stall the decision path, and dropping silently would produce
+    /// exactly the invisible gap this exists to prevent.
+    pub(crate) fn submit(&self, line: String) {
+        if self.tx.try_send(line).is_err() {
+            self.unshipped.fetch_add(1, Ordering::AcqRel);
+            self.degraded.store(true, Ordering::Release);
+            tracing::error!(
+                "Article 12 evidence channel is backed up; records are not reaching the host"
+            );
+        }
+    }
+
+    /// Build from the CLI arguments, or `None` when no host URL is configured.
+    ///
+    /// Here rather than in `main`, so the secret choice and the client setup sit
+    /// beside the reasoning that governs them — and so main.rs stays under its
+    /// line ratchet.
+    pub(crate) fn from_args(
+        url: Option<&String>,
+        audit_secret: Option<&str>,
+        session_id: &str,
+    ) -> Option<Arc<Self>> {
+        let url = url?;
+        let secret = audit_secret.map_or_else(
+            || format!("art12:{session_id}").into_bytes(),
+            |s| s.as_bytes().to_vec(),
+        );
+        Some(Arc::new(Self::start(
+            url.clone(),
+            secret,
+            reqwest::Client::new(),
+        )))
+    }
+
+    pub(crate) fn is_degraded(&self) -> bool {
+        self.degraded.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn unshipped(&self) -> u64 {
+        self.unshipped.load(Ordering::Acquire)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `reqwest::Client::new()` panics without a rustls provider. Production
+    /// installs one at startup (main.rs); a test process has to do it itself,
+    /// and `install_default` is idempotent-ish so the `ok()` is deliberate.
+    fn client() -> reqwest::Client {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        reqwest::Client::new()
+    }
+
+    /// A shipper pointed at nothing reachable must latch degraded rather than
+    /// warn and carry on. This is the difference from the audit webhook, and it
+    /// is the whole reason the type exists.
+    #[tokio::test]
+    async fn a_failed_ship_latches_degraded() {
+        // 127.0.0.1:1 refuses immediately, so this does not depend on a timeout.
+        let s = Art12Shipper::start(
+            "http://127.0.0.1:1/v1/art12".to_string(),
+            b"k".to_vec(),
+            client(),
+        );
+        assert!(
+            !s.is_degraded(),
+            "a fresh shipper must be healthy, or the assertion below proves nothing"
+        );
+
+        s.submit("{}".to_string());
+        for _ in 0..200 {
+            if s.is_degraded() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        assert!(
+            s.is_degraded(),
+            "a record the host never received must latch degraded, not pass quietly"
+        );
+        assert!(s.unshipped() >= 1, "and the loss must be counted");
+    }
+
+    /// **Backpressure is failure, not patience.** A queue that fills means
+    /// records are being produced faster than the host can witness them, and
+    /// every queued record is one whose only copy is pod-side.
+    #[tokio::test]
+    async fn a_full_queue_latches_degraded_rather_than_blocking() {
+        let s = Art12Shipper::start(
+            "http://127.0.0.1:1/v1/art12".to_string(),
+            b"k".to_vec(),
+            client(),
+        );
+        // Submit well past the queue depth without awaiting the drain.
+        for i in 0..(QUEUE_DEPTH * 4) {
+            s.submit(format!("{{\"n\":{i}}}"));
+        }
+        assert!(
+            s.is_degraded(),
+            "overrunning the queue must be visible, never a silent drop"
+        );
+    }
+}

--- a/crates/nucleus-tool-proxy/src/art12_sink.rs
+++ b/crates/nucleus-tool-proxy/src/art12_sink.rs
@@ -175,6 +175,13 @@ pub(crate) fn health_json(log: Option<&Arc<Art12Log>>) -> serde_json::Value {
 pub(crate) struct Art12Sink {
     inner: Arc<dyn VerdictSink>,
     log: Arc<Art12Log>,
+    /// Streams each record to the host as it is produced, when configured.
+    ///
+    /// The local log stays regardless: it is the fast path and the thing the
+    /// chain head is computed over. The shipper is the copy the pod cannot
+    /// retract, which is what makes the host's attestation bind something it
+    /// observed rather than something the pod reported.
+    shipper: Option<Arc<crate::art12_shipper::Art12Shipper>>,
     session_id: String,
     policy_checksum: String,
     dlc_provisioned: bool,
@@ -187,10 +194,12 @@ impl Art12Sink {
         session_id: String,
         policy_checksum: String,
         dlc_provisioned: bool,
+        shipper: Option<Arc<crate::art12_shipper::Art12Shipper>>,
     ) -> Self {
         Self {
             inner,
             log,
+            shipper,
             session_id,
             policy_checksum,
             dlc_provisioned,
@@ -320,6 +329,20 @@ fn operation_name(op: Operation) -> &'static str {
 impl VerdictSink for Art12Sink {
     fn record(&self, ctx: VerdictContext) -> Result<(), SinkError> {
         let draft = self.project(&ctx);
+
+        // Ship BEFORE the local append. The record the host witnesses is the
+        // one built from this decision, and ordering it first means a pod that
+        // crashes between the two has told the host more than it kept, never
+        // less.
+        if let Some(shipper) = &self.shipper {
+            match serde_json::to_string(&draft) {
+                Ok(line) => shipper.submit(line),
+                Err(e) => {
+                    tracing::error!(error = %e, "could not serialize an Article 12 record for the host")
+                }
+            }
+        }
+
         if let Err(e) = self.log.append(draft) {
             // The log has latched `degraded` and counted the drop; the next
             // preflight fails closed. Do not fail this call: its effect may
@@ -331,6 +354,19 @@ impl VerdictSink for Art12Sink {
     }
 
     fn preflight(&self, operation: Operation) -> Result<(), SinkError> {
+        // The evidence channel failing is as disqualifying as the local log
+        // failing: in both cases the next operation would execute without its
+        // record reaching somewhere the pod cannot retract it.
+        if let Some(shipper) = &self.shipper {
+            if shipper.is_degraded() {
+                tracing::error!(
+                    ?operation,
+                    unshipped = shipper.unshipped(),
+                    "refusing: Article 12 records are not reaching the host"
+                );
+                return Err(SinkError::Locked);
+            }
+        }
         if self.log.is_degraded() {
             tracing::error!(
                 ?operation,
@@ -366,6 +402,7 @@ mod tests {
             "sess".to_string(),
             "checksum".to_string(),
             false,
+            None,
         )
     }
 

--- a/crates/nucleus-tool-proxy/src/main.rs
+++ b/crates/nucleus-tool-proxy/src/main.rs
@@ -27,6 +27,7 @@ use tokio::net::TcpListener;
 use tracing::{error, info, warn};
 
 mod art12;
+mod art12_shipper;
 mod art12_sink;
 mod attestation;
 mod auth;
@@ -119,6 +120,10 @@ struct Args {
     /// report. Startup refuses rather than warns.
     #[arg(long, env = "NUCLEUS_TOOL_PROXY_ART12_LOG")]
     art12_log: Option<PathBuf>,
+    /// Host URL to stream Article 12 records to as they are produced.
+    /// See `art12_shipper` for why this is fail-closed and why it matters.
+    #[arg(long, env = "NUCLEUS_TOOL_PROXY_ART12_SHIP_URL")]
+    art12_ship_url: Option<String>,
     /// Approval authority secret (separate from tool auth).
     #[arg(long, env = "NUCLEUS_TOOL_PROXY_APPROVAL_SECRET")]
     approval_secret: String,
@@ -1531,6 +1536,14 @@ async fn main() -> Result<(), ApiError> {
         info!(path = %path.display(), "Article 12 record-keeping log opened");
     }
 
+    // The Article 12 evidence channel. Absent means records live only in the
+    // pod, so the host can attest only a head the pod REPORTED.
+    let art12_shipper = art12_shipper::Art12Shipper::from_args(
+        args.art12_ship_url.as_ref(),
+        args.audit_secret.as_deref(),
+        &session_id,
+    );
+
     let dlc_admission = dlc_admission::provision_from_env();
     let dlc_provisioned = dlc_admission.is_some();
 
@@ -1546,6 +1559,7 @@ async fn main() -> Result<(), ApiError> {
         session_id.clone(),
         dlc_provisioned,
         art12_log.clone(),
+        art12_shipper.clone(),
     );
 
     if dlc_provisioned {

--- a/crates/nucleus-tool-proxy/src/verdict_sink.rs
+++ b/crates/nucleus-tool-proxy/src/verdict_sink.rs
@@ -64,6 +64,7 @@ pub fn build_monitored_sink(
     session_id: String,
     dlc_provisioned: bool,
     art12_log: Option<Arc<crate::art12::Art12Log>>,
+    art12_shipper: Option<Arc<crate::art12_shipper::Art12Shipper>>,
 ) -> (Arc<dyn VerdictSink>, Arc<TraceMonitor>) {
     let inner: Arc<dyn VerdictSink> = Arc::new(ToolProxyVerdictSink::new(
         file_lockdown,
@@ -85,6 +86,7 @@ pub fn build_monitored_sink(
             session_id,
             policy_checksum,
             dlc_provisioned,
+            art12_shipper,
         )) as Arc<dyn VerdictSink>,
         None => inner,
     };
@@ -449,6 +451,7 @@ mod tests {
             "test-session".to_string(),
             false,
             None,
+            None,
         )
     }
 
@@ -500,6 +503,7 @@ mod tests {
             "test-checksum".to_string(),
             "test-session".to_string(),
             false,
+            None,
             None,
         )
         .0;

--- a/crates/portcullis/src/art12_record.rs
+++ b/crates/portcullis/src/art12_record.rs
@@ -191,6 +191,29 @@ pub struct Art12Attestation {
     pub dropped: u64,
     /// Executor identity, so a verifier knows which public key to check.
     pub executor_id: String,
+    /// The head the POD reported, when it differs from the head the host
+    /// observed.
+    ///
+    /// `None` means they agreed. `Some(_)` is a finding that must not be
+    /// averaged away: the pod's own log and the stream the host received
+    /// diverged. The direction matters — see `pod_records`.
+    #[cfg_attr(
+        feature = "serde",
+        serde(default, skip_serializing_if = "Option::is_none")
+    )]
+    pub pod_reported_head: Option<String>,
+    /// How many records the pod said it wrote.
+    ///
+    /// `records` is what the HOST received. The two can legitimately differ in
+    /// ONE direction: the pod ships each record before appending it locally, so
+    /// a pod that dies mid-write leaves the host holding one MORE than the pod
+    /// kept. `pod_records > records` is the alarming direction — records the pod
+    /// made and the host never saw.
+    #[cfg_attr(
+        feature = "serde",
+        serde(default, skip_serializing_if = "Option::is_none")
+    )]
+    pub pod_records: Option<u64>,
     /// Ed25519 signature over [`art12_attestation_preimage`], hex-encoded.
     pub signature: String,
 }

--- a/scripts/mediation-net-allowlist.txt
+++ b/scripts/mediation-net-allowlist.txt
@@ -21,3 +21,11 @@ file:crates/nucleus-tool-proxy/src/node_client.rs
 # handlers): audit-trail delivery to operator-configured sinks.
 .send() // net-infra: audit S3 append (aws_sdk_s3, operator sink — not agent egress)
 .send() // net-infra: audit webhook (operator-configured URL — not agent egress)
+
+# Whole-file infra: the Article 12 evidence channel. The URL is
+# operator-configured (`--art12-ship-url`), nothing an agent does can influence
+# it, and what it carries is the runtime's record OF the agent — evidence
+# flowing outward, not agent data. It is a whole-file entry because the file
+# exists for nothing else; a `.send(` appearing here that is not this is a file
+# that has grown a second purpose and should be split.
+file:crates/nucleus-tool-proxy/src/art12_shipper.rs


### PR DESCRIPTION
The executor attestation signed a chain head the **pod reported**. An honest signature over a possibly dishonest input reads exactly like a trustworthy one, and #2148 claimed more than that arrangement delivers. This closes it.

## Why a channel and not a shared file

A log the pod writes and the host reads *later* can be rewritten in between. The secure-logging literature's answer is to get each record to a collector as it is produced: the collector already holds record N when the writer tries to drop it, so truncation stops being possible rather than merely detectable.

[FssAgg](https://eprint.iacr.org/2008/185.pdf) (Ma & Tsudik) solves the same problem **without** a reachable collector, by erasing each epoch's key. That machinery earns its complexity on unattended devices. Nucleus has a collector — the host — and unlike the [confidential-VM literature](https://dse.in.tum.de/wp-content/uploads/2024/10/Gramine_TDX-CCS24.pdf) the host here is the trusted party, so streaming is simpler and stronger. FssAgg stays the answer if the log ever has to survive on a pod with no host to talk to.

## Guest half: not fire-and-forget

`AuditLog`'s webhook spawns and warns on failure. For Article 12 that's the wrong trade. `Art12Shipper` **latches degraded** on a failed POST or a full queue, and `Art12Sink::preflight` then refuses the next operation.

Backpressure is failure deliberately: a deep queue turns *"the host is not hearing us"* into *"the host is not hearing us yet"* — the same state with a comforting name, and every queued record is one whose only copy is pod-side.

Records ship **before** the local append, so a pod that dies between the two has told the host more than it kept, never less.

## Host half: every refusal is load-bearing

`art12_collector` authenticates each record and stores it under the node's state dir. **No configured secret means accept nothing** — an empty key would make every signature verify, the fail-open reading of "not configured". Unsigned, wrongly-signed, and storage-failure are all refusals, and each latches the pod's shipper, so a host that cannot witness a decision stops the pod making more.

Session ids are an allowlist of characters, not a scan for `..`.

## The attestation now binds what the host SAW

`attest_art12` takes the head the node computed from its own stream. When the pod also reported one and they differ, **both are carried, never reconciled**. The direction is legible: the pod ships before it appends, so host-holds-more is the expected mid-write-crash case, while `pod_records > records` means decisions were made and never witnessed. Deployments with no channel still get the weaker-but-honest pod-reported attestation rather than silently becoming unattested.

## Provisioning, because a channel with no producer is the same defect

Every pod gets both flags, set together in one function. The log goes in the pod's **node-side** directory, never `work_dir`.

## The check that would have caught this whole arc

`nucleus verify --tier2` now reads the **host's** Article 12 log and requires both the allow and the refusal it just observed. A pod that suppressed its own copy cannot make it pass. Both legs asserted, for the same reason `check_forbidden_operation` pairs with `check_allowed_operation`.

Every defect in this arc — unwired sink, producer with no consumer, signed attestation nobody sent — was invisible to unit tests and would have been caught by this check running once.

⚠️ **Not yet executed**: tier-2 needs `/dev/kvm`, so its first real run is in CI.

## Verification

Perturbations, each with its anchor asserted present before editing — three edits earlier in this work silently matched nothing and read as passing tests: warn-instead-of-latch; silent drop on a full queue; skip signature verification; missing secret as empty key (204 vs 503); attest the pod-reported head; silently reconcile divergence.

The mediation gate flagged the shipper's `.send()`; allowlisted whole-file with reasoning, noting that a second `.send(` there means the file has grown a second purpose.

fmt / clippy `--workspace --all-targets --all-features -D warnings` / `cargo test --all-features` (222 suites, 0 failures) / line ratchet `--strict` / mediation / sealed-home / verify-strict / dep ceiling: all green, each gated on **exit status**.