### PR TITLE
Bind the credential broker's socket at pod spawn

### DIFF
--- a/crates/nucleus-node/src/broker_transport.rs
+++ b/crates/nucleus-node/src/broker_transport.rs
@@ -24,11 +24,22 @@
 //! at the limit rather than after it. The two bounds are not redundant: one
 //! protects the parser, the other protects the reader that feeds it.
 
-// Not yet reachable: no accept loop binds this socket during pod spawn, so the
-// guest cannot submit an envelope and credentials still arrive the old way.
-// CI denies warnings, and a bare dead_code warning would read as an oversight
-// rather than a stated gap. Every item is exercised by the tests below.
-#![cfg_attr(not(test), allow(dead_code))]
+// The SERVING path is live: `spawn_firecracker_pod` binds this socket and spawns
+// `serve_broker`. What is still unreached is the CLIENT half — the guest has no
+// way to submit an envelope yet — so the three items that await it carry their
+// own `allow(dead_code)` naming what will use them, rather than a file-level
+// allow that would also exempt the serving path.
+//
+// That distinction is the point. If the spawn path ever stops binding the
+// socket, `serve_broker` goes dead and `-D warnings` says so ON LINUX. A blanket
+// allow would have hidden exactly that.
+//
+// The file-level allow below is therefore conditioned on NOT being Linux:
+// everything after the `#[cfg(target_os = "linux")]` guard in
+// `spawn_firecracker_pod` is not compiled on other hosts, so on macOS the whole
+// serving path is legitimately unreachable and warning about it would be noise.
+// On Linux the allow does not apply and the detector is live.
+#![cfg_attr(all(not(test), not(target_os = "linux")), allow(dead_code))]
 
 use std::io::BufRead;
 use std::path::{Path, PathBuf};
@@ -75,6 +86,7 @@ pub enum ReadError {
 /// Returns the frame WITHOUT its trailing newline. Reads byte-at-a-time rather
 /// than with `read_line`, because `read_line` will happily grow its buffer to
 /// whatever the peer sends — which is exactly the behaviour being prevented.
+#[allow(dead_code)] // Awaiting the guest client — the guest-side submit path will read framed replies.
 pub fn read_frame_bounded(mut reader: impl BufRead, max: usize) -> Result<String, ReadError> {
     let mut buf: Vec<u8> = Vec::new();
     loop {
@@ -96,6 +108,7 @@ pub fn read_frame_bounded(mut reader: impl BufRead, max: usize) -> Result<String
 }
 
 /// Read a frame using the module's default ceiling.
+#[allow(dead_code)] // Awaiting the guest client — as `read_frame_bounded`.
 pub fn read_frame(reader: impl BufRead) -> Result<String, ReadError> {
     read_frame_bounded(reader, MAX_FRAME_BYTES)
 }
@@ -674,6 +687,7 @@ impl BrokerListener {
     }
 }
 
+#[allow(dead_code)] // Awaiting the guest client — this IS the client half: the guest-side submit path.
 pub async fn request_over_socket(path: &std::path::Path, frame: &str) -> io::Result<String> {
     let stream = UnixStream::connect(path).await?;
     let (r, mut w) = tokio::io::split(stream);

--- a/crates/nucleus-node/src/main.rs
+++ b/crates/nucleus-node/src/main.rs
@@ -2780,6 +2780,60 @@ async fn spawn_firecracker_pod(
                 }
             };
 
+            // The credential broker's listener. Every piece of this existed —
+            // framing, bounds, the accept loop, listener-bound identity — with
+            // nothing binding the socket at spawn, so the guest had no way to
+            // submit an envelope and `cred_split` had no call site. This is that
+            // binding.
+            //
+            // Identity comes from `broker_identity`, which returns `None` rather
+            // than a bool so a caller cannot get a socket decision without the
+            // identity that socket speaks for. The rollout is decided from the
+            // transport, so a driver with no per-pod vsock gets `Disabled`
+            // instead of a listener nobody can reach.
+            let broker_rollout = broker_rollout::decide_rollout(
+                state.broker_enforcing,
+                state.broker_listen,
+                broker_rollout::BrokerTransport::Vsock,
+            );
+            if let Some(broker_id) = broker_launch::broker_identity(broker_rollout, Some(&identity))
+            {
+                let path = broker_transport::broker_socket_path(
+                    &vsock_path,
+                    broker_transport::BROKER_VSOCK_PORT,
+                );
+                match broker_transport::prepare_socket(&path) {
+                    Ok(listener) => {
+                        let policy = Arc::new(spec.spec.resolve_policy().unwrap_or_default());
+                        let store = Arc::new(nucleus_cred_broker::CredentialStore::default());
+                        tokio::spawn(async move {
+                            broker_transport::serve_broker(
+                                listener,
+                                broker_id,
+                                policy,
+                                store,
+                                std::future::pending::<()>(),
+                            )
+                            .await;
+                        });
+                        info!("broker listening at {} for pod {}", path.display(), id);
+                    }
+                    Err(e) => match broker_launch::on_start_failure(broker_rollout) {
+                        // Credentials were withheld and the guest has no way to
+                        // ask: it cannot do its job, so failing the launch is
+                        // kinder than a pod that starts and cannot work.
+                        broker_launch::StartFailure::AbortLaunch => {
+                            return Err(ApiError::Driver(format!(
+                                "broker socket required but could not be created: {e}"
+                            )));
+                        }
+                        broker_launch::StartFailure::ContinueDegraded => {
+                            tracing::warn!("broker socket unavailable for pod {id}: {e}");
+                        }
+                    },
+                }
+            }
+
             info!(
                 "registered identity {} for pod {}",
                 identity.to_spiffe_uri(),


### PR DESCRIPTION
Every piece of the broker existed — framing with bounds, the accept loop, listener-bound identity, a `BrokerResponse` that **cannot** carry a credential because `Credential` has no `Serialize` impl — and nothing bound the socket. The source said so plainly:

> no accept loop binds this socket during pod spawn, so the guest cannot submit an envelope

This is that binding. `spawn_firecracker_pod` now runs the launch decisions the pure functions were written for: `decide_rollout` from the transport, `broker_identity` (returns `Option<PodIdentity>` so a caller cannot get a socket decision without the identity it speaks for), `prepare_socket`, then `serve_broker`. `on_start_failure` decides the failure mode — abort when credentials were withheld, because a guest denied its credentials with no way to ask cannot do its job.

## This is the host half only

The guest still cannot submit an envelope. Linux `-D warnings` now says exactly that: `serve_broker` and `serve_connection` are no longer dead, and the three items still unused are all the client half, including `request_over_socket`.

The compiler is stating *"the host serves, the guest cannot yet ask"* — which is the honest description of this change, and the guest client is the next piece.

## Two compile errors macOS could not see

Everything past `spawn_firecracker_pod`'s `#[cfg(target_os = "linux")]` guard isn't compiled on macOS, so a local check says nothing about it. Type-checked in an OrbStack Linux VM, which found `BrokerTransport::PerPodVsock` (the variant is `Vsock`) and `ApiError::Spec` (nucleus-node's is `Driver`; `Spec` is the tool-proxy's). **Both had already been reported as compiling clean.**

## The dead-code allow needs two layers

- **File-level, scoped to non-Linux**: on macOS the serving path is behind the cfg guard and legitimately unreachable, so warning is noise. On Linux it does not apply and the detector is live — if the spawn path stops binding the socket, `serve_broker` goes dead and CI says so.
- **Per-item on the three client-half functions**: dead on both platforms until the guest client exists, each naming what will use it.

Blanket file-level would hide the first; removing it entirely breaks macOS.

## Verification

Linux clippy `-D warnings` clean, macOS clippy clean, 44 broker tests, fmt, line ratchet `--strict`, mediation, sealed-home, verify-strict, dep ceiling.