### PR TITLE
A proxy-only broker capability, served exactly once

### DIFF
--- a/crates/nucleus-guest-init/src/identity.rs
+++ b/crates/nucleus-guest-init/src/identity.rs
@@ -109,6 +109,53 @@ pub fn fetch_dlc_admission(port: u32) -> Result<Option<DlcAdmissionResponse>, St
     }
 }
 
+/// Fetch this pod's credential-broker capability, once.
+///
+/// # Why this must happen before `exec_proxy`
+///
+/// The host serves this secret EXACTLY ONCE per pod. That one-shot is the whole
+/// security property: any guest process can open `AF_VSOCK` — permissions on
+/// `/dev/vsock` do not gate the socket family, which was verified by experiment
+/// — so a workload can reach the workload API too. What it cannot do is arrive
+/// first. Fetching here, before the proxy execs and long before it spawns any
+/// workload, is what makes "first" true.
+///
+/// # And why the value must not be logged
+///
+/// Possession of this IS the capability to speak to the credential broker as the
+/// mediating proxy. Unlike the task token (a scoped capability plus a public
+/// issuer key) there is no sense in which handing it out is harmless, so errors
+/// here name the failure and never the payload.
+pub fn fetch_broker_secret(port: u32) -> Result<String, String> {
+    let mut stream = VsockStream::connect_with_cid_port(VMADDR_CID_HOST, port)
+        .map_err(|e| format!("failed to connect to workload API: {e}"))?;
+    stream
+        .write_all(b"FETCH_BROKER_SECRET\n")
+        .map_err(|e| format!("failed to send FETCH_BROKER_SECRET: {e}"))?;
+    stream
+        .flush()
+        .map_err(|e| format!("failed to flush: {e}"))?;
+
+    let mut reader = BufReader::new(&mut stream);
+    let mut response = String::new();
+    reader
+        .read_line(&mut response)
+        .map_err(|e| format!("failed to read broker-secret response: {e}"))?;
+
+    let parsed: serde_json::Value = serde_json::from_str(&response)
+        // Not `{e}` and not the body: a parse error that echoed the response
+        // would put the capability in the guest console log.
+        .map_err(|_| "broker-secret response was not valid JSON".to_string())?;
+    if let Some(err) = parsed.get("error").and_then(|e| e.as_str()) {
+        return Err(err.to_string());
+    }
+    parsed
+        .get("secret")
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .ok_or_else(|| "broker-secret response had no `secret`".to_string())
+}
+
 pub fn fetch_task_token(port: u32) -> Result<TaskTokenResponse, String> {
     let mut stream = VsockStream::connect_with_cid_port(VMADDR_CID_HOST, port)
         .map_err(|e| format!("failed to connect to workload API: {e}"))?;

--- a/crates/nucleus-guest-init/src/main.rs
+++ b/crates/nucleus-guest-init/src/main.rs
@@ -130,6 +130,24 @@ fn run() -> Result<(), String> {
     //
     // Synchronous, and before `exec_proxy`, so the values are in the environment
     // before anything reads them.
+    // The broker capability, fetched BEFORE `exec_proxy` and therefore before any
+    // workload exists. The host serves it once; arriving first is the entire
+    // property, since any guest process can open AF_VSOCK.
+    //
+    // Not fatal when absent: a pod may have no broker at all, and the tool-proxy
+    // fails closed on its own (an unsigned envelope is refused host-side). Making
+    // it fatal would break every pod that never had one.
+    if let Some(port) = workload_api_port {
+        match identity::fetch_broker_secret(port) {
+            Ok(secret) => {
+                std::env::set_var("NUCLEUS_TOOL_PROXY_BROKER_SECRET", secret);
+                // Presence only — never the value, and never its length.
+                eprintln!("fetched broker capability over vsock");
+            }
+            Err(err) => eprintln!("no broker capability over vsock: {err}"),
+        }
+    }
+
     let mut token_from_vsock = false;
     if let Some(port) = workload_api_port {
         match identity::fetch_task_token(port) {

--- a/crates/nucleus-node/src/main.rs
+++ b/crates/nucleus-node/src/main.rs
@@ -2734,28 +2734,35 @@ async fn spawn_firecracker_pod(
                 state.identity_vsock_port,
                 id,
                 manager.clone(),
-                // The same token that rides the kernel command line today.
-                // Serving it here is what lets the cmdline copy go: a value
-                // fetched after boot is not baked into a snapshot base.
-                task_token.clone(),
-                // Pod-scoped DLC-D admission provisioning (PodSpec labels).
-                // Served over the workload API rather than the cmdline:
-                // per-pod material survives snapshot restore correctly, and
-                // a credential set exceeds the cmdline capacity (observed
-                // live). Partial labels still provision — the proxy's
-                // parser fails CLOSED, so misconfiguration narrows.
-                {
-                    let l = &spec.metadata.labels;
-                    l.get("dlc_trusted_keys")
-                        .map(|keys| workload_api_vsock::DlcAdmissionMaterial {
-                            trusted_keys: keys.clone(),
-                            issuer: l.get("dlc_issuer").cloned().unwrap_or_default(),
-                            credentials: l.get("dlc_credentials").cloned().unwrap_or_default(),
+                workload_api_vsock::PodMaterial {
+                    // The same token that rides the kernel command line today.
+                    // Serving it here is what lets the cmdline copy go: a value
+                    // fetched after boot is not baked into a snapshot base.
+                    task_token: task_token.clone(),
+                    // Pod-scoped DLC-D admission provisioning (PodSpec labels).
+                    // Partial labels still provision — the proxy's parser fails
+                    // CLOSED, so misconfiguration narrows rather than widens.
+                    dlc_admission: {
+                        let l = &spec.metadata.labels;
+                        l.get("dlc_trusted_keys").map(|keys| {
+                            workload_api_vsock::DlcAdmissionMaterial {
+                                trusted_keys: keys.clone(),
+                                issuer: l.get("dlc_issuer").cloned().unwrap_or_default(),
+                                credentials: l.get("dlc_credentials").cloned().unwrap_or_default(),
+                            }
                         })
+                    },
+                    // The broker capability, minted per pod and served ONCE. See
+                    // `handle_fetch_broker_secret`: this is what lets the host
+                    // tell the mediating proxy from every other guest process.
+                    broker_secret: Some(uuid::Uuid::new_v4().simple().to_string()),
+                    broker_secret_served: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(
+                        false,
+                    )),
                 },
-                // Only when jailed: unjailed Firecracker runs as this same
-                // user and can already connect. Passing an owner there would
-                // hand our own socket away for no reason.
+                // Only when jailed: unjailed Firecracker runs as this same user
+                // and can already connect. Passing an owner there would hand our
+                // own socket away for no reason.
                 jail_layout
                     .as_ref()
                     .map(|_| (state.jailer_uid, state.jailer_gid)),

--- a/crates/nucleus-node/src/workload_api_protocol.rs
+++ b/crates/nucleus-node/src/workload_api_protocol.rs
@@ -79,6 +79,39 @@ pub enum WorkloadApiCommand {
     /// public keyset plus the pod's OWN capability grants; possession is
     /// exactly the authority intended.
     FetchDlcAdmission,
+    /// `FETCH_BROKER_SECRET` — request this pod's credential-broker capability.
+    ///
+    /// # Served exactly ONCE per pod, and that is the security property
+    ///
+    /// Its neighbours may be fetched repeatedly: a task token and an admission
+    /// keyset are per-pod material whose possession is the authority intended,
+    /// so serving them twice changes nothing. This one is different. It exists
+    /// to distinguish the mediating tool-proxy from every OTHER process in the
+    /// guest, and a secret served twice cannot do that.
+    ///
+    /// # What it defends against, concretely
+    ///
+    /// Any guest process can open `AF_VSOCK` — verified by experiment, and NOT
+    /// preventable by permissions on `/dev/vsock`, which does not gate the
+    /// socket family. So a workload can reach the broker directly. The broker
+    /// enforces the pod's capability lattice but has no taint state (the
+    /// `FlowTracker` lives in the tool-proxy), so a direct connection would
+    /// bypass the kernel decision, the session taint ceiling, the
+    /// lethal-trifecta guard and the flow cross-check.
+    ///
+    /// One-shot delivery closes that: `nucleus-guest-init` fetches this before
+    /// `exec_proxy`, so before any workload exists, and a workload that asks
+    /// later is refused. Combined with the uid boundary the tool-proxy already
+    /// requires when a credential is being withheld — same-uid processes can
+    /// read each other's `/proc/<pid>/environ` — the secret is reachable only by
+    /// the proxy.
+    ///
+    /// # Why not the kernel command line
+    ///
+    /// `/proc/cmdline` is world-readable in the guest, which is where
+    /// `nucleus.auth_secret` and `nucleus.approval_secret` arrive today. Neither
+    /// is a proxy-only capability for exactly that reason.
+    FetchBrokerSecret,
 }
 
 impl WorkloadApiCommand {
@@ -96,6 +129,7 @@ impl WorkloadApiCommand {
             WorkloadApiCommand::Ping => "PING",
             WorkloadApiCommand::FetchTaskToken => "FETCH_TASK_TOKEN",
             WorkloadApiCommand::FetchDlcAdmission => "FETCH_DLC_ADMISSION",
+            WorkloadApiCommand::FetchBrokerSecret => "FETCH_BROKER_SECRET",
         }
     }
 }
@@ -160,6 +194,7 @@ pub fn parse_command(frame: &[u8]) -> Result<WorkloadApiCommand, CommandParseErr
         "PING" => Ok(WorkloadApiCommand::Ping),
         "FETCH_TASK_TOKEN" => Ok(WorkloadApiCommand::FetchTaskToken),
         "FETCH_DLC_ADMISSION" => Ok(WorkloadApiCommand::FetchDlcAdmission),
+        "FETCH_BROKER_SECRET" => Ok(WorkloadApiCommand::FetchBrokerSecret),
         other => Err(CommandParseError::Unknown(other.to_string())),
     }
 }
@@ -329,12 +364,14 @@ mod tests {
                 WorkloadApiCommand::Ping => "PING",
                 WorkloadApiCommand::FetchTaskToken => "FETCH_TASK_TOKEN",
                 WorkloadApiCommand::FetchDlcAdmission => "FETCH_DLC_ADMISSION",
+                WorkloadApiCommand::FetchBrokerSecret => "FETCH_BROKER_SECRET",
             }
         }
         for cmd in [
             WorkloadApiCommand::FetchSvid,
             WorkloadApiCommand::FetchBundle,
             WorkloadApiCommand::FetchDlcAdmission,
+            WorkloadApiCommand::FetchBrokerSecret,
             WorkloadApiCommand::Ping,
         ] {
             assert_eq!(assert_known(cmd), cmd.as_wire());

--- a/crates/nucleus-node/src/workload_api_vsock.rs
+++ b/crates/nucleus-node/src/workload_api_vsock.rs
@@ -72,6 +72,26 @@ impl std::fmt::Debug for WorkloadApiVsockBridge {
             .finish()
     }
 }
+/// The per-pod material a workload-API bridge serves.
+///
+/// Bundled rather than passed as six positional arguments: clippy's
+/// `too_many_arguments` fired when the broker capability was added, and it was
+/// right to. These four are one thing — everything the host holds ON BEHALF of
+/// one pod — and a struct makes a new item a named field at every construction
+/// site rather than another `None` in a row of them.
+#[derive(Default)]
+pub struct PodMaterial {
+    /// The pod's live-path session capability token.
+    pub task_token: Option<crate::session_mint::MintedTaskToken>,
+    /// DLC-D verified-admission provisioning.
+    pub dlc_admission: Option<DlcAdmissionMaterial>,
+    /// The credential-broker capability, served exactly once.
+    pub broker_secret: Option<String>,
+    /// Whether the capability has been served. SHARED across every connection
+    /// this listener accepts — a per-connection flag would make "once" mean
+    /// "once per connection", which is not a restriction.
+    pub broker_secret_served: std::sync::Arc<std::sync::atomic::AtomicBool>,
+}
 
 impl WorkloadApiVsockBridge {
     /// Starts the Workload API vsock bridge for a specific pod.
@@ -98,10 +118,15 @@ impl WorkloadApiVsockBridge {
         port: u32,
         pod_id: uuid::Uuid,
         identity_manager: IdentityManager,
-        task_token: Option<crate::session_mint::MintedTaskToken>,
-        dlc_admission: Option<DlcAdmissionMaterial>,
+        material: PodMaterial,
         jail_owner: Option<(u32, u32)>,
     ) -> std::io::Result<Self> {
+        let PodMaterial {
+            task_token,
+            dlc_admission,
+            broker_secret,
+            broker_secret_served,
+        } = material;
         // Firecracker naming convention: {uds_path}_{port}
         let socket_path = PathBuf::from(format!("{}_{}", vsock_uds_path.as_ref().display(), port));
 
@@ -173,9 +198,16 @@ impl WorkloadApiVsockBridge {
                                 let manager = identity_manager.clone();
                                 let task_token = task_token.clone();
                                 let dlc_admission = dlc_admission.clone();
+                                let broker_secret = broker_secret.clone();
+                                // Arc, so the one-shot flag is SHARED across every
+                                // connection this listener accepts. A per-connection
+                                // flag would make "once" mean "once per connection",
+                                // which is not a restriction at all.
+                                let broker_secret_served = std::sync::Arc::clone(&broker_secret_served);
                                 tokio::spawn(async move {
                                     if let Err(err) = handle_connection(
                                         stream, manager, pod_id, task_token, dlc_admission,
+                                        broker_secret, broker_secret_served,
                                     )
                                     .await
                                     {
@@ -234,6 +266,42 @@ impl WorkloadApiVsockBridge {
 /// verify half treats a missing token and an invalid one differently.
 /// Serve the pod's DLC admission provisioning, or a JSON error when the pod
 /// was not provisioned (the ordinary case — the guest treats it as "inert").
+/// Serve the broker capability EXACTLY ONCE.
+///
+/// # The one-shot is the whole mechanism
+///
+/// This secret's job is to distinguish the mediating tool-proxy from every other
+/// process in the guest. Any guest process can open `AF_VSOCK` — that is not
+/// preventable by permissions on `/dev/vsock`, which does not gate the socket
+/// family — so a workload can reach this API too. What it cannot do is arrive
+/// FIRST: `nucleus-guest-init` fetches before `exec_proxy`, i.e. before any
+/// workload exists.
+///
+/// So a second request is not a retry to be tolerated, it is either a bug or an
+/// attempt, and either way the answer is no. Serving it twice would hand the
+/// capability to whoever asked second and silently reduce the broker to
+/// unauthenticated.
+///
+/// `Acquire`/`AcqRel` via `swap` rather than a load-then-store: two concurrent
+/// connections must not both observe "not yet served".
+fn handle_fetch_broker_secret(
+    secret: Option<&str>,
+    already_served: &std::sync::atomic::AtomicBool,
+) -> String {
+    use std::sync::atomic::Ordering;
+    let Some(secret) = secret else {
+        return r#"{"error":"no broker secret provisioned for this pod"}"#.to_string();
+    };
+    if already_served.swap(true, Ordering::AcqRel) {
+        tracing::warn!(
+            "refused a repeat FETCH_BROKER_SECRET — the capability is served once, before the \
+             workload exists; a second request is a bug or an attempt to obtain it"
+        );
+        return r#"{"error":"broker secret already served"}"#.to_string();
+    }
+    serde_json::json!({ "secret": secret }).to_string()
+}
+
 fn handle_fetch_dlc_admission(material: Option<&DlcAdmissionMaterial>) -> String {
     match material {
         Some(m) => serde_json::json!({
@@ -264,6 +332,8 @@ async fn handle_connection(
     pod_id: uuid::Uuid,
     task_token: Option<crate::session_mint::MintedTaskToken>,
     dlc_admission: Option<DlcAdmissionMaterial>,
+    broker_secret: Option<String>,
+    broker_secret_served: std::sync::Arc<std::sync::atomic::AtomicBool>,
 ) -> std::io::Result<()> {
     let (reader, mut writer) = stream.into_split();
     let mut reader = BufReader::new(reader);
@@ -295,6 +365,12 @@ async fn handle_connection(
             Ok(WorkloadApiCommand::FetchDlcAdmission) => {
                 debug!("workload API FETCH_DLC_ADMISSION for pod {}", pod_id);
                 handle_fetch_dlc_admission(dlc_admission.as_ref())
+            }
+            Ok(WorkloadApiCommand::FetchBrokerSecret) => {
+                // Value never logged, at any level: this is the one workload-API
+                // payload whose possession IS the capability.
+                debug!("workload API FETCH_BROKER_SECRET for pod {}", pod_id);
+                handle_fetch_broker_secret(broker_secret.as_deref(), &broker_secret_served)
             }
             Err(err) => {
                 debug!("workload API rejected command for pod {}: {err}", pod_id);
@@ -495,8 +571,7 @@ mod tests {
             15012,
             pod_id,
             manager,
-            None,
-            None,
+            PodMaterial::default(),
             None,
         )
         .await
@@ -542,8 +617,7 @@ mod tests {
             15012,
             pod_id,
             manager,
-            None,
-            None,
+            PodMaterial::default(),
             None,
         )
         .await
@@ -578,10 +652,16 @@ mod tests {
         let pod_id = uuid::Uuid::new_v4();
 
         let manager = IdentityManager::new("test.local", Duration::from_secs(3600)).unwrap();
-        let bridge =
-            WorkloadApiVsockBridge::start(&vsock_uds_path, 8080, pod_id, manager, None, None, None)
-                .await
-                .unwrap();
+        let bridge = WorkloadApiVsockBridge::start(
+            &vsock_uds_path,
+            8080,
+            pod_id,
+            manager,
+            PodMaterial::default(),
+            None,
+        )
+        .await
+        .unwrap();
 
         // Verify Firecracker naming convention: {uds_path}_{port}
         let expected_path = temp_dir.path().join("pod-123").join("vsock.sock_8080");
@@ -602,8 +682,7 @@ mod tests {
             15012,
             pod_id,
             manager,
-            None,
-            None,
+            PodMaterial::default(),
             None,
         )
         .await
@@ -671,8 +750,7 @@ mod tests {
             15012,
             pod1_id,
             manager.clone(),
-            None,
-            None,
+            PodMaterial::default(),
             None,
         )
         .await
@@ -682,8 +760,7 @@ mod tests {
             15012,
             pod2_id,
             manager.clone(),
-            None,
-            None,
+            PodMaterial::default(),
             None,
         )
         .await
@@ -730,5 +807,56 @@ mod tests {
         let mut response = String::new();
         reader.read_line(&mut response).await.unwrap();
         response
+    }
+
+    use std::sync::atomic::AtomicBool;
+
+    /// **The one-shot IS the mechanism.** This secret distinguishes the
+    /// mediating tool-proxy from every other process in the guest. Any guest
+    /// process can open AF_VSOCK, so what the proxy has that a workload does not
+    /// is only that it asked FIRST — before `exec_proxy`, before a workload
+    /// exists. Serving twice hands the capability to whoever asks second.
+    #[test]
+    fn the_broker_secret_is_served_exactly_once() {
+        let served = AtomicBool::new(false);
+        let first = handle_fetch_broker_secret(Some("cap"), &served);
+        let v: serde_json::Value = serde_json::from_str(&first).unwrap();
+        assert_eq!(v["secret"], "cap", "the first request must be served");
+
+        let second = handle_fetch_broker_secret(Some("cap"), &served);
+        assert!(
+            second.contains("already served"),
+            "a second request must be refused: {second}"
+        );
+        assert!(
+            !second.contains("cap"),
+            "and must not leak the secret in the refusal: {second}"
+        );
+    }
+
+    /// A pod with no broker secret gets an explicit error, and — the part that
+    /// matters — the refusal must not consume the one-shot. Otherwise a
+    /// misconfigured pod could be made to burn its own capability before the
+    /// proxy ever asks.
+    #[test]
+    fn an_absent_secret_does_not_consume_the_one_shot() {
+        let served = AtomicBool::new(false);
+        let r = handle_fetch_broker_secret(None, &served);
+        assert!(r.contains("error"), "got: {r}");
+        assert!(
+            !served.load(std::sync::atomic::Ordering::Acquire),
+            "a refusal for an absent secret must not mark the capability as served"
+        );
+    }
+
+    /// `FETCH_BROKER_SECRET` must be a command the parser knows, or the guest
+    /// client would fail closed — correctly, but silently and far from the cause.
+    #[test]
+    fn the_broker_secret_command_round_trips_through_the_parser() {
+        use crate::workload_api_protocol::{parse_command, WorkloadApiCommand};
+        assert_eq!(
+            parse_command(b"FETCH_BROKER_SECRET\n").unwrap(),
+            WorkloadApiCommand::FetchBrokerSecret
+        );
     }
 }

--- a/crates/nucleus-tool-proxy/src/workload.rs
+++ b/crates/nucleus-tool-proxy/src/workload.rs
@@ -238,6 +238,36 @@ mod tests {
         );
     }
 
+    /// **The broker capability must never reach the workload.** It is what lets
+    /// the host tell the mediating proxy from every other process in the guest;
+    /// a workload holding it could ask the broker to act directly, skipping the
+    /// kernel decision, taint ceiling and flow cross-check.
+    ///
+    /// Asserted rather than left to a grep: absence is easy to establish by
+    /// accident and easy to lose by accident, and the losing edit would look
+    /// like a helpful convenience.
+    #[test]
+    fn the_broker_capability_never_reaches_the_workload() {
+        let hostile = spec_with(&[("NUCLEUS_TOOL_PROXY_BROKER_SECRET", "stolen")]);
+        let env = workload_env(&hostile, "http://127.0.0.1:8080", "s3cret", &[]);
+        // A spec that names it gets it back — that value is the SPEC's, not the
+        // runtime's, and the runtime never puts its own there. The property is
+        // that nothing in `workload_env` SOURCES it from the runtime.
+        assert_eq!(
+            env.get("NUCLEUS_TOOL_PROXY_BROKER_SECRET")
+                .map(String::as_str),
+            Some("stolen"),
+            "spec env passes through; the point is the runtime adds nothing here"
+        );
+
+        // With a clean spec, the key must be absent entirely.
+        let env = workload_env(&spec_with(&[]), "http://127.0.0.1:8080", "s3cret", &[]);
+        assert!(
+            !env.contains_key("NUCLEUS_TOOL_PROXY_BROKER_SECRET"),
+            "the runtime must never place its broker capability in the workload's environment"
+        );
+    }
+
     /// The control: ordinary spec env still reaches the workload, so the
     /// precedence above is not simply discarding what the spec asked for.
     #[test]


### PR DESCRIPTION
Step 1 of routing credentialed egress through the host on Firecracker. It closes the bypass that would otherwise make that change a **weakening**.

## The bypass

Any guest process can open AF_VSOCK and reach the host credential broker directly. The broker enforces the pod's capability lattice but has **no taint state** — the `FlowTracker` lives in the tool-proxy — so a direct connection skips the kernel decision, the session taint ceiling, the lethal-trifecta guard and the flow cross-check.

## Why a capability and not a namespace control

An earlier attempt restricted `/dev/vsock` to root. It was written, documented, and **completely ineffective**: `socket(AF_VSOCK)` is a socket-family call and is not gated by device-node permissions.

Disproved by experiment in a Linux VM — with `/dev/vsock` at `0600 root`, a non-root user created the socket anyway. Discarded rather than shipped, because a control that reads convincingly and does nothing is worse than none.

## What makes this one work

The host mints a per-pod secret and serves it **exactly once**. `nucleus-guest-init` fetches it before `exec_proxy` — before any workload exists. The workload can still open vsock and ask; it just cannot arrive *first*, and a second request is refused.

Four things carry it, each perturbation-tested:

- **`swap`, not load-then-store** — two concurrent connections must not both observe "not yet served".
- **A refusal for an absent secret does not consume the one-shot.** Otherwise a misconfigured pod could be made to burn its own capability before the proxy asks — a denial-of-capability attack on a pod that did nothing wrong.
- **The runtime never places the secret in the workload's environment**, asserted by test rather than by absence in a grep. The perturbation is a plausible "helpful" forward, and it REDs.
- **The uid boundary** #2152 already enforces fail-closed stops the workload reading it from `/proc/<pid>/environ`.

Not the kernel command line, where `nucleus.auth_secret` and `nucleus.approval_secret` arrive: `/proc/cmdline` is world-readable in the guest, so neither of those is a proxy-only capability.

## PodMaterial

Adding two parameters pushed `WorkloadApiVsockBridge::start` to 9 arguments and clippy's `too_many_arguments` fired. It was right: these are one thing — everything the host holds on behalf of one pod — so they became a struct rather than an `allow`. Six test call sites went from five `None`s each to `PodMaterial::default()`, so the next addition is a named field instead of another `None` in a row of them.

## Verification

Verified on **both platforms with identical flags** — a Linux run that omitted `--all-features` failed two feature-gated tests and read exactly like a real Linux-only defect.

macOS + Linux clippy `--workspace --all-targets --all-features -D warnings`, `cargo test --all-features` (222 suites, 0 failures), fmt, line ratchet `--strict`, mediation, sealed-home, verify-strict, dep ceiling.