### PR TITLE
The broker capability was inert, and the store was empty

### DIFF
--- a/crates/nucleus-guest-init/src/identity.rs
+++ b/crates/nucleus-guest-init/src/identity.rs
@@ -126,7 +126,14 @@ pub fn fetch_dlc_admission(port: u32) -> Result<Option<DlcAdmissionResponse>, St
 /// mediating proxy. Unlike the task token (a scoped capability plus a public
 /// issuer key) there is no sense in which handing it out is harmless, so errors
 /// here name the failure and never the payload.
-pub fn fetch_broker_secret(port: u32) -> Result<String, String> {
+pub struct BrokerCapability {
+    /// The HMAC key the proxy signs broker frames with.
+    pub secret: String,
+    /// The vsock port the broker listens on.
+    pub port: u32,
+}
+
+pub fn fetch_broker_secret(port: u32) -> Result<BrokerCapability, String> {
     let mut stream = VsockStream::connect_with_cid_port(VMADDR_CID_HOST, port)
         .map_err(|e| format!("failed to connect to workload API: {e}"))?;
     stream
@@ -149,11 +156,24 @@ pub fn fetch_broker_secret(port: u32) -> Result<String, String> {
     if let Some(err) = parsed.get("error").and_then(|e| e.as_str()) {
         return Err(err.to_string());
     }
-    parsed
+    let secret = parsed
         .get("secret")
         .and_then(|v| v.as_str())
         .map(str::to_string)
-        .ok_or_else(|| "broker-secret response had no `secret`".to_string())
+        .ok_or_else(|| "broker-secret response had no `secret`".to_string())?;
+    // Both or neither. A secret with no port leaves the proxy able to sign and
+    // unable to connect — a capability that looks held and is not, which is the
+    // failure shape this whole arc keeps producing.
+    let broker_port = parsed
+        .get("port")
+        .and_then(serde_json::Value::as_u64)
+        .and_then(|p| u32::try_from(p).ok())
+        .filter(|p| *p != 0)
+        .ok_or_else(|| "broker-secret response had no usable `port`".to_string())?;
+    Ok(BrokerCapability {
+        secret,
+        port: broker_port,
+    })
 }
 
 pub fn fetch_task_token(port: u32) -> Result<TaskTokenResponse, String> {

--- a/crates/nucleus-guest-init/src/main.rs
+++ b/crates/nucleus-guest-init/src/main.rs
@@ -139,10 +139,18 @@ fn run() -> Result<(), String> {
     // it fatal would break every pod that never had one.
     if let Some(port) = workload_api_port {
         match identity::fetch_broker_secret(port) {
-            Ok(secret) => {
-                std::env::set_var("NUCLEUS_TOOL_PROXY_BROKER_SECRET", secret);
-                // Presence only — never the value, and never its length.
-                eprintln!("fetched broker capability over vsock");
+            Ok(cap) => {
+                std::env::set_var("NUCLEUS_TOOL_PROXY_BROKER_SECRET", &cap.secret);
+                // The port is NOT a secret — it is where to connect — so unlike
+                // the key it is safe to log, and worth logging: a proxy that
+                // cannot reach the broker looks identical to one that was never
+                // given a capability.
+                std::env::set_var("NUCLEUS_TOOL_PROXY_BROKER_PORT", cap.port.to_string());
+                // Presence only for the secret — never the value, never its length.
+                eprintln!(
+                    "fetched broker capability over vsock (broker port {})",
+                    cap.port
+                );
             }
             Err(err) => eprintln!("no broker capability over vsock: {err}"),
         }

--- a/crates/nucleus-node/src/broker_launch.rs
+++ b/crates/nucleus-node/src/broker_launch.rs
@@ -42,10 +42,16 @@
 //! rather than a launch refusal. Under `ListenOnly` nothing depends on the
 //! socket yet, so a failure there is a warning.
 
-// Not yet reachable from the spawn path itself in this change: the functions are
-// consulted by `firecracker_spawn`, but the modules they gate (`cred_split`)
-// only run under `Enforcing`, which is off by default.
-#![cfg_attr(not(test), allow(dead_code))]
+// The blanket allow this replaced said "not yet reachable from the spawn path
+// itself". That is false: with the allow removed, Linux clippy at `-D warnings`
+// names ZERO dead items in this file. Every function here is on the live path —
+// `start_broker_for_pod` is called from `spawn_firecracker_pod`, and it reaches
+// all of them.
+//
+// NON-LINUX ONLY, because `start_broker_for_pod` is `cfg(target_os = "linux")`
+// and it is the only caller, so a macOS build compiles none of this. On Linux
+// the detector stays live and will report the next thing that stops being wired.
+#![cfg_attr(all(not(test), not(target_os = "linux")), allow(dead_code))]
 
 use crate::broker_rollout::BrokerRollout;
 use nucleus_cred_broker::PodIdentity;
@@ -135,6 +141,113 @@ pub fn on_start_failure(rollout: BrokerRollout) -> StartFailure {
     }
 }
 
+/// One pod's broker capability, minted once and consumed by exactly two places.
+///
+/// # The defect this type exists to make impossible
+///
+/// The capability was minted at the workload API bridge
+/// (`main.rs`, `PodMaterial { broker_secret: Some(Uuid::new_v4()…) }`) while
+/// `BrokerListener::start` passed `broker_secret: None` to the thing that
+/// VERIFIES it. So the guest fetched a secret the broker had never heard of, and
+/// every signed frame was refused.
+///
+/// Nothing caught it, and nothing could have: both halves were individually
+/// correct and individually tested. The serving side served, the verifying side
+/// verified, and the failure lived in the gap between two files. It fails
+/// CLOSED — a broker that refuses everything is safe — which is exactly why it
+/// could sit there indefinitely looking like a working capability.
+///
+/// A single value with two projections is the smallest fix that makes the two
+/// consumers provably the same secret rather than coincidentally the same
+/// secret. `mint_appears_exactly_once_on_the_spawn_path` covers the one hole
+/// this shape leaves: calling [`Self::mint`] twice.
+#[derive(Debug, Clone)]
+pub struct BrokerCapability {
+    secret: String,
+}
+
+impl BrokerCapability {
+    /// Mint a fresh capability for one pod.
+    ///
+    /// Per-pod and never reused: two pods sharing one would let either sign for
+    /// the other, and the listener's identity binding — one socket per VM — would
+    /// stop meaning anything.
+    #[must_use]
+    pub fn mint() -> Self {
+        Self {
+            secret: uuid::Uuid::new_v4().simple().to_string(),
+        }
+    }
+
+    /// The copy the workload API serves to the guest, exactly once.
+    #[must_use]
+    pub fn to_serve(&self) -> String {
+        self.secret.clone()
+    }
+
+    /// The copy the broker listener verifies signatures against.
+    #[must_use]
+    pub fn to_verify(&self) -> std::sync::Arc<Vec<u8>> {
+        std::sync::Arc::new(self.secret.as_bytes().to_vec())
+    }
+}
+
+/// Build this pod's credential store from **the node's own environment**.
+///
+/// # The signature is the security property
+///
+/// This takes a slice of upstream specs and NOT a `PodSpec`, deliberately, and
+/// that is the whole design rather than a style choice.
+///
+/// On Firecracker, `scripts/firecracker/build-rootfs.sh` copies the pod spec
+/// into the rootfs **at image build time**. A credential sourced from
+/// `spec.spec.credentials.env` would therefore be written into the guest image —
+/// the precise opposite of the property this broker exists to provide, and
+/// invisible at runtime because the file was baked days earlier.
+///
+/// A function that cannot name `PodSpec` cannot read `credentials.env` from it.
+/// That beats a test asserting it does not: the test would pass for as long as
+/// nobody added the field, and the compiler enforces this for as long as the
+/// signature stands. `the_store_is_built_without_naming_the_pod_spec` pins the
+/// signature so the guarantee cannot be widened without the widening being seen.
+///
+/// # What comes from where
+///
+/// The operator writes the upstream's `name` and `credential_env` in the pod
+/// spec — those are configuration, not secrets. The VALUE comes from the node's
+/// environment, where an operator put it and where no guest can reach.
+///
+/// An upstream whose variable is unset (or empty) registers nothing, so the
+/// broker refuses it by absence — the same refusal a policy denial gives, which
+/// is what stops a guest probing which credentials the host holds.
+pub fn store_from_node_environment(
+    upstreams: &[nucleus_spec::CredentialedEgressSpec],
+) -> nucleus_cred_broker::CredentialStore {
+    let mut store = nucleus_cred_broker::CredentialStore::new();
+    for spec in upstreams {
+        // Keyed by NAME, because that is what `PerformRequest.target` carries and
+        // what `cdp_fetch` looks up. Keying by host would let two upstreams on
+        // one host share a credential without anyone saying so.
+        match std::env::var(&spec.credential_env) {
+            Ok(value) if !value.is_empty() => {
+                store.insert(&spec.name, nucleus_cred_broker::Credential::new(value));
+            }
+            _ => {
+                // Logged by variable NAME, never by value, and at info because an
+                // operator who configured an upstream and forgot its credential
+                // otherwise sees only a coarse refusal from inside the guest.
+                tracing::info!(
+                    upstream = %spec.name,
+                    variable = %spec.credential_env,
+                    "no credential in the node's environment for this upstream; the broker \
+                     will refuse requests for it"
+                );
+            }
+        }
+    }
+    store
+}
+
 /// Start the credential broker for a pod, if the rollout and the pod's identity
 /// both permit it.
 ///
@@ -149,6 +262,7 @@ pub fn start_broker_for_pod(
     vsock_path: &std::path::Path,
     registered: Option<&nucleus_identity::Identity>,
     id: uuid::Uuid,
+    capability: &BrokerCapability,
 ) -> Result<Option<crate::broker_transport::BrokerListener>, crate::ApiError> {
     let transport = if spec.spec.vsock.is_some() {
         crate::broker_rollout::BrokerTransport::Vsock
@@ -187,12 +301,6 @@ pub fn start_broker_for_pod(
         }
     };
 
-    // Empty until `cred_split` has a call site on this driver. A broker with an
-    // empty store answers every request with a refusal, which is the correct
-    // behaviour for a pod whose credentials are not brokered yet — and is why
-    // enforcing is refused above rather than merely discouraged.
-    let store = std::sync::Arc::new(nucleus_cred_broker::CredentialStore::new());
-
     // The upstreams the HOST may be asked to call, straight from the pod spec.
     //
     // This is the only source: a `PerformRequest` names an upstream, it does not
@@ -202,6 +310,14 @@ pub fn start_broker_for_pod(
     // which is the right answer for a pod whose operator configured none.
     let upstreams = std::sync::Arc::new(spec.spec.credentialed_egress.clone());
 
+    // The comment here used to read "Empty until `cred_split` has a call site on
+    // this driver", and a `CredentialStore::new()` sat under it refusing
+    // everything. It is populated now — from the NODE's environment, never from
+    // the pod spec, for the reason `store_from_node_environment` gives at
+    // length: on Firecracker the pod spec is baked into the guest rootfs, so a
+    // credential taken from it would ship inside the image.
+    let store = std::sync::Arc::new(store_from_node_environment(&upstreams));
+
     match crate::broker_transport::BrokerListener::start(
         vsock_path,
         state.broker_vsock_port,
@@ -209,6 +325,9 @@ pub fn start_broker_for_pod(
         policy,
         store,
         upstreams,
+        // The SAME value the workload API serves the guest. Passing `None` here
+        // is what made the capability inert; see `BrokerCapability`.
+        capability.to_verify(),
     ) {
         Ok(listener) => {
             tracing::info!(
@@ -229,6 +348,194 @@ pub fn start_broker_for_pod(
                 Ok(None)
             }
         },
+    }
+}
+
+#[cfg(test)]
+mod broker_capability {
+    use super::*;
+
+    /// **The property, stated directly.** The value served to the guest and the
+    /// value the broker verifies against must be the same bytes. They were not:
+    /// the bridge minted its own and the listener got `None`.
+    #[test]
+    fn what_is_served_is_what_is_verified() {
+        let cap = BrokerCapability::mint();
+        assert_eq!(
+            cap.to_serve().as_bytes(),
+            cap.to_verify().as_slice(),
+            "the guest would hold a capability the verifier cannot recognise"
+        );
+    }
+
+    /// Per-pod, never shared. Two pods on one capability could sign for each
+    /// other, and the listener's one-socket-per-VM identity binding would stop
+    /// meaning anything.
+    #[test]
+    fn two_pods_do_not_share_a_capability() {
+        assert_ne!(
+            BrokerCapability::mint().to_serve(),
+            BrokerCapability::mint().to_serve()
+        );
+    }
+
+    /// **The hole this type's shape leaves, closed by counting.**
+    ///
+    /// `BrokerCapability` guarantees that the two PROJECTIONS agree. It cannot
+    /// stop someone calling `mint()` twice on the spawn path and handing one to
+    /// each consumer — which reproduces the original defect exactly, with a type
+    /// that looks like it prevents it.
+    ///
+    /// So the call site is counted. One mint per spawn path. A second one is a
+    /// compile-green, test-green, silently-refusing broker, and this is the only
+    /// thing standing between that and a reviewer noticing.
+    #[test]
+    fn mint_appears_exactly_once_on_the_spawn_path() {
+        let src = include_str!("main.rs");
+        let mints = src.matches("BrokerCapability::mint()").count();
+        assert_eq!(
+            mints, 1,
+            "found {mints} calls to BrokerCapability::mint() in main.rs. Two mints means the \
+             workload API and the broker listener can each get their own, which is the exact \
+             defect this type was introduced to remove."
+        );
+    }
+}
+
+#[cfg(test)]
+mod store_population {
+    use super::*;
+    use nucleus_cred_broker::{PodIdentity, TaskRequestEnvelope};
+    use nucleus_spec::CredentialedEgressSpec;
+    use portcullis::PermissionLattice;
+
+    const NOW: u64 = 1_700_000_000;
+
+    /// Each env-touching test uses its OWN variable name. Tests share a process
+    /// and run in parallel, so two of them on one name is a race that surfaces
+    /// as an unrelated flake — which teaches people to re-run rather than look.
+    fn upstream(name: &str, credential_env: &str) -> CredentialedEgressSpec {
+        CredentialedEgressSpec {
+            name: name.into(),
+            upstream: "https://upstream.invalid/v1".into(),
+            credential_env: credential_env.into(),
+            header: "authorization".into(),
+            value_prefix: "Bearer ".into(),
+        }
+    }
+
+    /// Look a credential up exactly as the broker does.
+    ///
+    /// Through `authorize_and_fetch` rather than a test-only accessor on
+    /// `CredentialStore`, deliberately: the risk this whole module carries is a
+    /// KEYING mismatch — the store writing under one key while `cdp_fetch` reads
+    /// another — and an accessor that read the map directly would agree with the
+    /// store by construction and never notice. This fails if they disagree.
+    fn brokered(store: &nucleus_cred_broker::CredentialStore, target: &str) -> Option<String> {
+        let envelope = TaskRequestEnvelope {
+            operation: "WebFetch".into(),
+            target: target.into(),
+            justification: "test".into(),
+        };
+        crate::broker::authorize_and_fetch(
+            &envelope,
+            &PodIdentity::observed_by_host("spiffe://nucleus/pod/abc"),
+            &PermissionLattice::permissive(),
+            store,
+            NOW,
+        )
+        .ok()
+        .map(|c| c.expose().to_string())
+    }
+
+    /// **The non-vacuity control, first.** Everything else here asserts that
+    /// something is ABSENT from the store, and a function returning an empty
+    /// store would satisfy all of it while being useless.
+    ///
+    /// This also pins the keying: the target is the upstream NAME, which is what
+    /// `PerformRequest.target` carries.
+    #[test]
+    fn a_configured_upstream_with_a_set_variable_is_reachable_by_name() {
+        let var = "NUCLEUS_TEST_STORE_POP_HAPPY";
+        std::env::set_var(var, "node-side-token");
+        let store = store_from_node_environment(&[upstream("model-api", var)]);
+        std::env::remove_var(var);
+
+        assert_eq!(
+            brokered(&store, "model-api").as_deref(),
+            Some("node-side-token"),
+            "the store must key by the upstream NAME — the key PerformRequest.target \
+             carries and cdp_fetch looks up"
+        );
+    }
+
+    /// An unset variable registers nothing, so the broker refuses by absence.
+    /// Registering an empty credential instead would send a bare `Bearer `
+    /// upstream — authenticating as nobody, which some upstreams accept.
+    #[test]
+    fn an_unset_variable_registers_nothing() {
+        let store =
+            store_from_node_environment(&[upstream("model-api", "NUCLEUS_TEST_STORE_POP_UNSET")]);
+        assert_eq!(brokered(&store, "model-api"), None);
+    }
+
+    /// Same for a variable that is set but empty — the more common operator
+    /// mistake, and the one that looks configured.
+    #[test]
+    fn an_empty_variable_registers_nothing() {
+        let var = "NUCLEUS_TEST_STORE_POP_EMPTY";
+        std::env::set_var(var, "");
+        let store = store_from_node_environment(&[upstream("model-api", var)]);
+        std::env::remove_var(var);
+        assert_eq!(
+            brokered(&store, "model-api"),
+            None,
+            "an empty credential would authenticate as nobody"
+        );
+    }
+
+    /// One upstream missing its credential must not take out the others. An
+    /// operator adding a second upstream should not silently lose the first.
+    #[test]
+    fn one_missing_credential_does_not_discard_the_rest() {
+        let var = "NUCLEUS_TEST_STORE_POP_PARTIAL";
+        std::env::set_var(var, "present");
+        let store = store_from_node_environment(&[
+            upstream("has-one", var),
+            upstream("has-none", "NUCLEUS_TEST_STORE_POP_PARTIAL_MISSING"),
+        ]);
+        std::env::remove_var(var);
+
+        assert_eq!(brokered(&store, "has-one").as_deref(), Some("present"));
+        assert_eq!(brokered(&store, "has-none"), None);
+    }
+
+    /// **The structural guarantee, checked against the signature.**
+    ///
+    /// `store_from_node_environment` takes upstream specs and NOT a `PodSpec`,
+    /// so it CANNOT read `spec.spec.credentials.env`. That matters because on
+    /// Firecracker the pod spec is baked into the guest rootfs at image build
+    /// time — a credential sourced from it would ship inside the image, which is
+    /// the exact property the broker exists to provide, inverted.
+    ///
+    /// Scanning the signature rather than the behaviour is deliberate: a
+    /// behavioural test ("it did not read the spec") passes for as long as
+    /// nobody adds the parameter, and says nothing the moment somebody does.
+    /// This one fails at the widening, which is when it matters.
+    #[test]
+    fn the_store_is_built_without_naming_the_pod_spec() {
+        let src = include_str!("broker_launch.rs");
+        let sig = src
+            .split("pub fn store_from_node_environment(")
+            .nth(1)
+            .and_then(|s| s.split(") -> ").next())
+            .expect("store_from_node_environment signature");
+        assert!(
+            !sig.contains("PodSpec") && !sig.contains("credentials"),
+            "the store builder can now reach the pod spec, and on Firecracker the pod \
+             spec is baked into the guest rootfs — a credential read from it would ship \
+             inside the image. Signature was: {sig}"
+        );
     }
 }
 

--- a/crates/nucleus-node/src/broker_transport.rs
+++ b/crates/nucleus-node/src/broker_transport.rs
@@ -1280,6 +1280,7 @@ impl BrokerListener {
         policy: Arc<PermissionLattice>,
         store: Arc<CredentialStore>,
         upstreams: Arc<Vec<CredentialedEgressSpec>>,
+        broker_secret: Arc<Vec<u8>>,
     ) -> io::Result<Self> {
         let socket_path = broker_socket_path(uds_path, port);
         let listener = prepare_socket(&socket_path)?;
@@ -1315,7 +1316,12 @@ impl BrokerListener {
                     identity,
                     policy,
                     store,
-                    broker_secret: None,
+                    // NOT `None`. This used to be `None` while the workload
+                    // API served the guest a freshly minted secret, so the
+                    // guest held a capability the verifier had never seen and
+                    // every signed frame was refused. Both halves now come from
+                    // one `BrokerCapability`.
+                    broker_secret: Some(broker_secret),
                     upstreams,
                     caller,
                 },
@@ -1402,6 +1408,12 @@ mod listener_lifecycle_tests {
     use super::*;
     use nucleus_cred_broker::Credential;
 
+    /// These tests are about socket lifecycle, not authentication, so the value
+    /// is arbitrary — but it must not be absent. `start` takes the capability
+    /// now precisely because passing `None` there is what made the guest's
+    /// fetched secret useless.
+    const TEST_SECRET: &[u8] = b"lifecycle-test-capability";
+
     fn policy() -> Arc<PermissionLattice> {
         Arc::new(PermissionLattice::default())
     }
@@ -1454,6 +1466,7 @@ mod listener_lifecycle_tests {
             policy(),
             store("api.example.test", "v"),
             Arc::new(Vec::new()),
+            Arc::new(TEST_SECRET.to_vec()),
         )
         .expect("first listener binds");
         let path = first.socket_path().to_path_buf();
@@ -1477,14 +1490,27 @@ mod listener_lifecycle_tests {
             policy(),
             store("api.example.test", "v"),
             Arc::new(Vec::new()),
+            Arc::new(TEST_SECRET.to_vec()),
         )
         .expect("a second listener must be able to bind the freed path");
         assert_eq!(second.socket_path(), path);
         assert_eq!(second.shutdown().await, ShutdownOutcome::Stopped);
     }
 
-    /// The listener actually answers on the path it reports — a socket that
-    /// exists but serves nothing would pass the test above while being useless.
+    /// The listener answers on the path it reports **and honours the capability
+    /// it was handed**.
+    ///
+    /// # What this test used to assert, and why that was nothing
+    ///
+    /// It sent an UNSIGNED frame and asserted `reply.contains("granted")` —
+    /// which `"granted":false` satisfies. So it passed whether the listener used
+    /// its capability or refused every frame on earth. A perturbation restoring
+    /// `broker_secret: None` in `start` — the original defect, where the guest
+    /// held a secret the verifier had never seen — left all 275 tests green.
+    ///
+    /// It now signs under the capability `start` was given and requires
+    /// `"granted":true`. That is only reachable if the value survives the trip
+    /// from `start` into `PodBroker` into `frame_is_authentic`.
     #[tokio::test]
     async fn the_listener_answers_on_the_path_it_reports() {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -1496,22 +1522,32 @@ mod listener_lifecycle_tests {
             policy(),
             store("api.example.test", "v"),
             Arc::new(Vec::new()),
+            Arc::new(TEST_SECRET.to_vec()),
         )
         .expect("binds");
 
-        let frame = serde_json::json!({
+        let payload = serde_json::json!({
             "operation": "WebFetch",
             "target": "api.example.test",
             "justification": "routine"
         })
-        .to_string()
-            + "\n";
+        .to_string();
+        // Signed under the SAME capability `start` was handed above.
+        let frame = {
+            use hmac::{digest::KeyInit, Hmac, Mac};
+            use sha2::Sha256;
+            let mut mac = Hmac::<Sha256>::new_from_slice(TEST_SECRET).expect("hmac key");
+            mac.update(payload.as_bytes());
+            format!("{} {payload}\n", hex::encode(mac.finalize().into_bytes()))
+        };
         let reply = request_over_socket(listener.socket_path(), &frame)
             .await
             .expect("the listener must answer");
         assert!(
-            reply.contains("granted"),
-            "expected a broker reply, got {reply:?}"
+            reply.contains("\"granted\":true"),
+            "a frame signed under the capability `start` was given must be SERVED. Got \
+             {reply:?} — if this is a refusal, the listener is not using the capability it \
+             was handed, and the guest holds a secret the verifier has never seen."
         );
         assert_eq!(listener.shutdown().await, ShutdownOutcome::Stopped);
     }

--- a/crates/nucleus-node/src/main.rs
+++ b/crates/nucleus-node/src/main.rs
@@ -2588,6 +2588,14 @@ async fn spawn_firecracker_pod(
         // The refusal is at the source rather than the advertisement.
         let identity_source =
             net::identity_registration(state.identity_manager.as_ref(), &identity_grant);
+        // ONE capability, TWO consumers: the workload API serves it to the guest
+        // (once, before any workload exists) and the broker listener verifies
+        // signatures against it. Minted here because those two are started in
+        // different blocks below, and this used to be exactly the gap they fell
+        // into — the bridge minted its own while the listener got `None`, so the
+        // guest held a capability the verifier had never seen.
+        let broker_capability = broker_launch::BrokerCapability::mint();
+
         let (pod_identity, identity_manager, workload_api_bridge) = if let Some(manager) =
             identity_source
         {
@@ -2672,7 +2680,10 @@ async fn spawn_firecracker_pod(
                     // The broker capability, minted per pod and served ONCE. See
                     // `handle_fetch_broker_secret`: this is what lets the host
                     // tell the mediating proxy from every other guest process.
-                    broker_secret: Some(uuid::Uuid::new_v4().simple().to_string()),
+                    broker_secret: Some(broker_capability.to_serve()),
+                    // Served WITH the capability, not separately — the proxy
+                    // needs both to reach the broker and neither is useful alone.
+                    broker_port: state.broker_vsock_port,
                     broker_secret_served: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(
                         false,
                     )),
@@ -2790,6 +2801,7 @@ async fn spawn_firecracker_pod(
             &vsock_path,
             pod_identity.as_ref(),
             id,
+            &broker_capability,
         )?;
 
         let handle = FirecrackerPod {

--- a/crates/nucleus-node/src/workload_api_vsock.rs
+++ b/crates/nucleus-node/src/workload_api_vsock.rs
@@ -87,6 +87,14 @@ pub struct PodMaterial {
     pub dlc_admission: Option<DlcAdmissionMaterial>,
     /// The credential-broker capability, served exactly once.
     pub broker_secret: Option<String>,
+    /// The vsock port the broker listens on, served WITH the capability.
+    ///
+    /// Together and not separately, deliberately: knowing where to connect and
+    /// being able to sign are one capability, and delivering them through two
+    /// mechanisms would let a proxy end up holding one without the other — able
+    /// to sign but not to find the socket, or the reverse. Both arrive in the
+    /// same one-shot reply or neither does.
+    pub broker_port: u32,
     /// Whether the capability has been served. SHARED across every connection
     /// this listener accepts — a per-connection flag would make "once" mean
     /// "once per connection", which is not a restriction.
@@ -126,6 +134,7 @@ impl WorkloadApiVsockBridge {
             dlc_admission,
             broker_secret,
             broker_secret_served,
+            broker_port,
         } = material;
         // Firecracker naming convention: {uds_path}_{port}
         let socket_path = PathBuf::from(format!("{}_{}", vsock_uds_path.as_ref().display(), port));
@@ -207,7 +216,11 @@ impl WorkloadApiVsockBridge {
                                 tokio::spawn(async move {
                                     if let Err(err) = handle_connection(
                                         stream, manager, pod_id, task_token, dlc_admission,
-                                        broker_secret, broker_secret_served,
+                                        BrokerHandout {
+                                            secret: broker_secret,
+                                            port: broker_port,
+                                            served: broker_secret_served,
+                                        },
                                     )
                                     .await
                                     {
@@ -284,8 +297,22 @@ impl WorkloadApiVsockBridge {
 ///
 /// `Acquire`/`AcqRel` via `swap` rather than a load-then-store: two concurrent
 /// connections must not both observe "not yet served".
+/// The broker capability as one connection sees it.
+///
+/// Three fields that are one thing: the secret, where to use it, and whether it
+/// has already been handed out. Grouping them is not only clippy's argument
+/// count — it is that delivering any of them without the others produces a proxy
+/// that can sign but not connect, or connect but not sign, and the one-shot flag
+/// must be the SAME flag across every connection or "once" means "once each".
+struct BrokerHandout {
+    secret: Option<String>,
+    port: u32,
+    served: std::sync::Arc<std::sync::atomic::AtomicBool>,
+}
+
 fn handle_fetch_broker_secret(
     secret: Option<&str>,
+    port: u32,
     already_served: &std::sync::atomic::AtomicBool,
 ) -> String {
     use std::sync::atomic::Ordering;
@@ -299,7 +326,7 @@ fn handle_fetch_broker_secret(
         );
         return r#"{"error":"broker secret already served"}"#.to_string();
     }
-    serde_json::json!({ "secret": secret }).to_string()
+    serde_json::json!({ "secret": secret, "port": port }).to_string()
 }
 
 fn handle_fetch_dlc_admission(material: Option<&DlcAdmissionMaterial>) -> String {
@@ -332,8 +359,7 @@ async fn handle_connection(
     pod_id: uuid::Uuid,
     task_token: Option<crate::session_mint::MintedTaskToken>,
     dlc_admission: Option<DlcAdmissionMaterial>,
-    broker_secret: Option<String>,
-    broker_secret_served: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    broker: BrokerHandout,
 ) -> std::io::Result<()> {
     let (reader, mut writer) = stream.into_split();
     let mut reader = BufReader::new(reader);
@@ -370,7 +396,7 @@ async fn handle_connection(
                 // Value never logged, at any level: this is the one workload-API
                 // payload whose possession IS the capability.
                 debug!("workload API FETCH_BROKER_SECRET for pod {}", pod_id);
-                handle_fetch_broker_secret(broker_secret.as_deref(), &broker_secret_served)
+                handle_fetch_broker_secret(broker.secret.as_deref(), broker.port, &broker.served)
             }
             Err(err) => {
                 debug!("workload API rejected command for pod {}: {err}", pod_id);
@@ -819,11 +845,11 @@ mod tests {
     #[test]
     fn the_broker_secret_is_served_exactly_once() {
         let served = AtomicBool::new(false);
-        let first = handle_fetch_broker_secret(Some("cap"), &served);
+        let first = handle_fetch_broker_secret(Some("cap"), 1027, &served);
         let v: serde_json::Value = serde_json::from_str(&first).unwrap();
         assert_eq!(v["secret"], "cap", "the first request must be served");
 
-        let second = handle_fetch_broker_secret(Some("cap"), &served);
+        let second = handle_fetch_broker_secret(Some("cap"), 1027, &served);
         assert!(
             second.contains("already served"),
             "a second request must be refused: {second}"
@@ -834,6 +860,32 @@ mod tests {
         );
     }
 
+    /// **The port travels with the secret.** A proxy given one and not the other
+    /// can sign but not connect, or connect but not sign — a capability that
+    /// looks held and is not, which is the shape of the defect
+    /// `BrokerCapability` was introduced to remove one file over.
+    #[test]
+    fn the_reply_carries_the_port_as_well_as_the_secret() {
+        let served = AtomicBool::new(false);
+        let reply = handle_fetch_broker_secret(Some("cap"), 4242, &served);
+        let v: serde_json::Value = serde_json::from_str(&reply).unwrap();
+        assert_eq!(v["secret"], "cap");
+        assert_eq!(
+            v["port"], 4242,
+            "the guest cannot reach the broker without being told where it is: {reply}"
+        );
+    }
+
+    /// The port is the CONFIGURED one, not a constant re-derived guest-side. An
+    /// operator who moves the broker port must not have to move it twice.
+    #[test]
+    fn the_served_port_is_whatever_the_node_was_configured_with() {
+        let served = AtomicBool::new(false);
+        let reply = handle_fetch_broker_secret(Some("cap"), 9999, &served);
+        let v: serde_json::Value = serde_json::from_str(&reply).unwrap();
+        assert_eq!(v["port"], 9999);
+    }
+
     /// A pod with no broker secret gets an explicit error, and — the part that
     /// matters — the refusal must not consume the one-shot. Otherwise a
     /// misconfigured pod could be made to burn its own capability before the
@@ -841,7 +893,7 @@ mod tests {
     #[test]
     fn an_absent_secret_does_not_consume_the_one_shot() {
         let served = AtomicBool::new(false);
-        let r = handle_fetch_broker_secret(None, &served);
+        let r = handle_fetch_broker_secret(None, 1027, &served);
         assert!(r.contains("error"), "got: {r}");
         assert!(
             !served.load(std::sync::atomic::Ordering::Acquire),

--- a/crates/nucleus-spec/src/lib.rs
+++ b/crates/nucleus-spec/src/lib.rs
@@ -729,8 +729,27 @@ pub struct CredentialedEgressSpec {
     pub name: String,
     /// Absolute upstream base URL. Fixed here; a request cannot change it.
     pub upstream: String,
-    /// Environment variable, in the RUNTIME's environment, holding the
-    /// credential. Never placed in the workload's environment.
+    /// Environment variable **in the NODE's environment** holding the credential.
+    ///
+    /// # It is the node's, not the guest's, and not the pod spec's
+    ///
+    /// This said "the RUNTIME's environment" when the runtime that held the
+    /// credential was the in-guest proxy. The host holds it now, and the
+    /// distinction is load-bearing rather than a rename:
+    ///
+    /// * **Not the pod spec.** On Firecracker `build-rootfs.sh` copies the pod
+    ///   spec into the image at BUILD time, so a credential taken from
+    ///   `credentials.env` would be written into the guest rootfs — the exact
+    ///   opposite of what this type exists to arrange.
+    /// * **Not the guest.** That is the whole point: the guest receives the
+    ///   RESULT of a call made with this, never this.
+    ///
+    /// `nucleus_node::broker_launch::store_from_node_environment` cannot reach a
+    /// `PodSpec` at all, so the first of those is a property of a signature
+    /// rather than a rule someone has to remember.
+    ///
+    /// An unset or empty variable registers nothing and the broker refuses that
+    /// upstream by absence.
     pub credential_env: String,
     /// Header the credential is injected as (e.g. `authorization`).
     pub header: String,


### PR DESCRIPTION
**Increment 1 of four.** Stacked on #2157 → #2156. The arc's mechanisms exist; this is the first change that makes them *run*.

## The capability was never joined to its verifier

`main.rs` minted a fresh UUID and gave it to the workload API to serve the guest. `BrokerListener::start` passed `broker_secret: None` to the thing that **verifies** signatures. So the guest held a capability the verifier had never seen, and every signed frame was refused.

Both halves were individually correct and individually tested. The serving side served, the verifying side verified, and the failure lived in the gap between two files. It fails **closed** — a broker that refuses everything is safe — which is exactly why it could sit there indefinitely looking like a working feature.

`BrokerCapability` is one value with two projections, so the served copy and the verified copy are *provably* the same rather than coincidentally the same.

## My first fix did not work, and a perturbation is the only reason I know

I added `BrokerCapability` plus a test that its two projections agree. Then I perturbed `start` back to `broker_secret: None` — the original defect — and **all 275 tests passed**. The test proved the type was self-consistent. It said nothing about whether the wiring used it.

What was missing: `the_listener_answers_on_the_path_it_reports` sent an **unsigned** frame and asserted `reply.contains("granted")` — which `"granted":false` satisfies. It passed whether the listener honoured its capability or refused every frame on earth.

It now signs under the capability `start` was handed and requires `"granted":true`, reachable only if the value survives the trip into `frame_is_authentic`. That perturbation now REDs.

`BrokerCapability` still cannot stop someone calling `mint()` twice, so the call site is counted: `mint_appears_exactly_once_on_the_spawn_path`.

## The store, and the one decision that decides where a credential lives

`CredentialStore::new()` refused everything. It is populated now — from the **node's** environment — and the signature is the reason:

```rust
pub fn store_from_node_environment(
    upstreams: &[CredentialedEgressSpec],   // NOT a PodSpec
) -> CredentialStore
```

On Firecracker `build-rootfs.sh` copies the pod spec into the rootfs at **image build time**. A credential read from `spec.spec.credentials.env` would be written into the guest image — the exact opposite of the property this broker provides, and invisible at runtime because the file was baked days earlier.

A function that cannot name `PodSpec` cannot read `credentials.env` from it. That beats a test asserting it does not, which passes for as long as nobody adds the parameter. `the_store_is_built_without_naming_the_pod_spec` fails at the *widening* instead of at the misuse.

Lookups in tests go through `authorize_and_fetch` rather than a store accessor: the risk here is a **keying mismatch** — the store writing under one key while `cdp_fetch` reads another — and an accessor reading the map directly would agree with the store by construction and never notice.

## The port travels with the secret

The tool-proxy had no idea which vsock port the broker listens on. Both now arrive in the same one-shot reply: knowing where to connect and being able to sign are one capability, and two delivery mechanisms would let a proxy hold one without the other — able to sign but not connect. `BrokerHandout` groups them so the argument count says so too.

## `broker_launch`'s header was false

Measured, as in #2157: with the blanket allow removed, Linux clippy names **zero** dead items in that file. Everything is live. The header now states what was measured, and the allow is non-Linux only.

## Verification

Five perturbations, each RED at a named location: listener back to `None`; the two consumers each minting their own; store keyed by upstream host not name; an empty credential registered anyway; the store builder widened to take a `PodSpec`.

fmt, five gates, macOS + Linux (OrbStack) clippy `--workspace --all-targets --all-features -D warnings`, `cargo test --all-features` (222 suites, 0 failures).

Re-run clean after a shared-tree race — the first suite ran while I was editing `broker_launch.rs`, so its result described a tree that no longer existed.