### PR TITLE
Credentialed egress goes through the broker, and only through it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6707,8 +6707,11 @@ dependencies = [
 name = "nucleus-cred-protocol"
 version = "1.0.0"
 dependencies = [
+ "hex",
+ "hmac 0.13.0",
  "serde",
  "serde_json",
+ "sha2 0.11.0",
 ]
 
 [[package]]

--- a/crates/nucleus-cred-protocol/Cargo.toml
+++ b/crates/nucleus-cred-protocol/Cargo.toml
@@ -20,6 +20,16 @@ description = "Wire types shared by the credential broker's host and guest halve
 [dependencies]
 serde = { workspace = true }
 
+# The frame codec lives here so the guest that SIGNS and the host that VERIFIES
+# run one implementation rather than two that agree today. These add no new
+# supply-chain surface: nucleus-tool-proxy already links all three at the same
+# workspace versions, so the guest's dependency graph is unchanged. That check
+# was made rather than assumed — adding a dependency to a credential path
+# casually is what the LiteLLM compromise punishes.
+hmac = { workspace = true }
+sha2 = { workspace = true }
+hex = { workspace = true }
+
 [dev-dependencies]
 serde_json = { workspace = true }
 

--- a/crates/nucleus-cred-protocol/src/lib.rs
+++ b/crates/nucleus-cred-protocol/src/lib.rs
@@ -18,6 +18,94 @@
 
 use serde::{Deserialize, Serialize};
 
+/// Wire framing for authenticated broker frames.
+///
+/// # Why the codec lives here and not on either side
+///
+/// The guest SIGNS and the host VERIFIES. Written separately those are two
+/// implementations of one format, each testable in isolation, each passing, and
+/// wrong together the moment one changes — the same shape as the defect one
+/// increment ago, where the capability was minted in one file and the verifier
+/// was handed `None` in another. Both sides call the functions below.
+///
+/// Nothing here holds anything. `sign` takes a key by reference and returns a
+/// digest; the crate's guarantee — that no *type* here can carry credential
+/// material — is untouched, and `no_type_here_can_carry_a_credential` still
+/// scans for it.
+///
+/// # The wire form
+///
+/// `<hex-hmac-sha256> <payload-json>` — one space, signature first, newline
+/// terminated by the transport. Not a JSON wrapper: the payload would need
+/// escaping inside a JSON string, and a verifier that re-serialises in order to
+/// check a signature is checking its own serialiser rather than what arrived.
+pub mod frame {
+    /// Sign `payload` under `key`, producing the wire form.
+    ///
+    /// No trailing newline — framing belongs to the transport, which is the only
+    /// layer that knows whether it is writing to a socket or a buffer.
+    #[must_use]
+    pub fn sign(key: &[u8], payload: &str) -> String {
+        use hmac::{digest::KeyInit, Hmac, Mac};
+        use sha2::Sha256;
+        let mut mac = <Hmac<Sha256> as KeyInit>::new_from_slice(key)
+            // HMAC accepts a key of any length, so this cannot fail for any
+            // `&[u8]`. Expressed as a fallback rather than an unwrap because a
+            // panic here would take down the proxy over a frame.
+            .expect("HMAC-SHA256 accepts keys of any length");
+        mac.update(payload.as_bytes());
+        format!("{} {payload}", hex::encode(mac.finalize().into_bytes()))
+    }
+
+    /// Split a signed frame into its signature and the payload it covers.
+    ///
+    /// `None` for anything that is not exactly that shape. A caller must treat
+    /// `None` as a refusal — an unsigned frame is not a frame with an empty
+    /// signature.
+    #[must_use]
+    pub fn split(frame: &str) -> Option<(&str, &str)> {
+        let (sig, payload) = frame.split_once(' ')?;
+        if sig.is_empty() || payload.is_empty() {
+            return None;
+        }
+        Some((sig, payload))
+    }
+
+    /// Whether `frame` was signed under `key`.
+    ///
+    /// # A missing key verifies nothing
+    ///
+    /// `None` means no capability was provisioned, so nothing can be
+    /// authenticated and therefore nothing is accepted. Treating "no key" as "no
+    /// signature required" is the fail-OPEN reading, and it turns a provisioning
+    /// failure into an open door at the moment nobody is watching.
+    ///
+    /// # Constant-time
+    ///
+    /// `verify_slice`, not `==` on the hex: a byte-by-byte compare leaks how
+    /// much of a guessed signature was right, and a guest can retry freely.
+    #[must_use]
+    pub fn is_authentic(frame: &str, key: Option<&[u8]>) -> bool {
+        use hmac::{digest::KeyInit, Hmac, Mac};
+        use sha2::Sha256;
+
+        let Some(key) = key else {
+            return false;
+        };
+        let Some((sig_hex, payload)) = split(frame) else {
+            return false;
+        };
+        let Ok(sig) = hex::decode(sig_hex) else {
+            return false;
+        };
+        let Ok(mut mac) = <Hmac<Sha256> as KeyInit>::new_from_slice(key) else {
+            return false;
+        };
+        mac.update(payload.as_bytes());
+        mac.verify_slice(&sig).is_ok()
+    }
+}
+
 /// A CB4A **Task Request Envelope**: what a guest submits to ask for an action.
 ///
 /// Every field crosses from the guest, so every field is untrusted input.
@@ -142,6 +230,96 @@ pub struct PerformReply {
     /// Upstream response body, when the call was made.
     #[serde(default)]
     pub body: Vec<u8>,
+}
+
+#[cfg(test)]
+mod frame_codec {
+    use super::frame;
+
+    const KEY: &[u8] = b"a-pod-broker-capability";
+
+    /// **The property the shared codec exists for.** What `sign` produces,
+    /// `is_authentic` accepts. Two implementations could pass their own tests
+    /// and disagree with each other; this cannot.
+    #[test]
+    fn what_is_signed_verifies() {
+        let f = frame::sign(KEY, r#"{"operation":"WebFetch"}"#);
+        assert!(frame::is_authentic(&f, Some(KEY)));
+    }
+
+    /// **The non-vacuity control.** Everything below asserts a refusal, and an
+    /// `is_authentic` that returned `false` always would satisfy all of it while
+    /// making the broker unusable. Paired with the test above deliberately.
+    #[test]
+    fn a_wrong_key_is_refused_and_the_right_one_is_not() {
+        let f = frame::sign(KEY, "payload");
+        assert!(!frame::is_authentic(&f, Some(b"not-the-capability")));
+        assert!(
+            frame::is_authentic(&f, Some(KEY)),
+            "the refusal above must be about the KEY, not about refusing everything"
+        );
+    }
+
+    /// An unsigned frame is not a frame with an empty signature.
+    #[test]
+    fn an_unsigned_frame_is_refused() {
+        assert!(!frame::is_authentic(
+            r#"{"operation":"WebFetch"}"#,
+            Some(KEY)
+        ));
+        assert!(!frame::is_authentic(" payload", Some(KEY)));
+        assert!(!frame::is_authentic("deadbeef ", Some(KEY)));
+        assert!(!frame::is_authentic("", Some(KEY)));
+    }
+
+    /// No key means nothing is accepted — the fail-CLOSED reading. The
+    /// alternative turns a provisioning failure into an open door.
+    #[test]
+    fn no_key_accepts_nothing() {
+        let f = frame::sign(KEY, "payload");
+        assert!(!frame::is_authentic(&f, None));
+    }
+
+    /// A payload altered after signing must not verify. Signing covers the
+    /// payload, not merely accompanies it.
+    #[test]
+    fn a_tampered_payload_is_refused() {
+        let f = frame::sign(KEY, r#"{"target":"allowed"}"#);
+        let (sig, _) = frame::split(&f).expect("well formed");
+        let tampered = format!("{sig} {}", r#"{"target":"attacker"}"#);
+        assert!(!frame::is_authentic(&tampered, Some(KEY)));
+    }
+
+    /// The payload survives the round trip byte for byte, including the spaces
+    /// that the frame format also uses as its delimiter — `split_once` takes the
+    /// FIRST space, so a payload containing spaces must still verify.
+    #[test]
+    fn a_payload_containing_spaces_round_trips() {
+        let payload = r#"{"justification":"because the agent asked nicely"}"#;
+        let f = frame::sign(KEY, payload);
+        assert_eq!(frame::split(&f).map(|(_, p)| p), Some(payload));
+        assert!(frame::is_authentic(&f, Some(KEY)));
+    }
+
+    /// Signing is deterministic, so a retry of the same request is byte-identical
+    /// and the host's idempotency ledger sees one logical operation rather than
+    /// two frames it cannot relate.
+    #[test]
+    fn signing_is_deterministic() {
+        assert_eq!(frame::sign(KEY, "payload"), frame::sign(KEY, "payload"));
+    }
+
+    /// The signature comes FIRST. If the order ever flipped, every existing
+    /// frame would still be well formed and none would verify — a change that
+    /// looks cosmetic and is not.
+    #[test]
+    fn the_signature_is_the_first_field() {
+        let f = frame::sign(KEY, "payload");
+        let (sig, payload) = frame::split(&f).expect("well formed");
+        assert_eq!(payload, "payload");
+        assert_eq!(sig.len(), 64, "hex-encoded SHA-256 is 64 characters: {sig}");
+        assert!(hex::decode(sig).is_ok());
+    }
 }
 
 #[cfg(test)]

--- a/crates/nucleus-node/src/broker_launch.rs
+++ b/crates/nucleus-node/src/broker_launch.rs
@@ -263,6 +263,7 @@ pub fn start_broker_for_pod(
     registered: Option<&nucleus_identity::Identity>,
     id: uuid::Uuid,
     capability: &BrokerCapability,
+    jail_owner: Option<(u32, u32)>,
 ) -> Result<Option<crate::broker_transport::BrokerListener>, crate::ApiError> {
     let transport = if spec.spec.vsock.is_some() {
         crate::broker_rollout::BrokerTransport::Vsock
@@ -321,13 +322,16 @@ pub fn start_broker_for_pod(
     match crate::broker_transport::BrokerListener::start(
         vsock_path,
         state.broker_vsock_port,
-        identity,
-        policy,
-        store,
-        upstreams,
-        // The SAME value the workload API serves the guest. Passing `None` here
-        // is what made the capability inert; see `BrokerCapability`.
-        capability.to_verify(),
+        crate::broker_transport::PodBrokerConfig {
+            identity,
+            policy,
+            store,
+            upstreams,
+            // The SAME value the workload API serves the guest. Passing `None`
+            // here is what made the capability inert; see `BrokerCapability`.
+            broker_secret: capability.to_verify(),
+        },
+        jail_owner,
     ) {
         Ok(listener) => {
             tracing::info!(

--- a/crates/nucleus-node/src/broker_transport.rs
+++ b/crates/nucleus-node/src/broker_transport.rs
@@ -256,55 +256,31 @@ pub async fn read_frame_async(
 
 /// Split a signed frame into its signature and the payload it covers.
 ///
-/// Wire form is `<hex-hmac> <payload-json>` — one space, signature first. Chosen
-/// over a JSON wrapper because the payload would then need escaping inside a
-/// JSON string, and a verifier that re-serialises to check a signature is
-/// checking its own serialiser (the same reasoning `Art12Record::canonical_preimage`
-/// gives).
-///
-/// Returns `None` for anything that is not exactly that shape. The caller must
-/// treat `None` as a refusal — an unsigned frame is not a frame with an empty
-/// signature.
+/// Delegates to [`nucleus_cred_protocol::frame::split`]. The guest builds these
+/// frames and the host reads them, so the format is defined once, in the crate
+/// both sides link, rather than twice in crates that agree until one changes.
 pub fn split_signed_frame(frame: &str) -> Option<(&str, &str)> {
-    let (sig, payload) = frame.split_once(' ')?;
-    if sig.is_empty() || payload.is_empty() {
-        return None;
-    }
-    Some((sig, payload))
+    nucleus_cred_protocol::frame::split(frame)
 }
 
 /// Whether a frame was signed by the holder of this pod's broker capability.
 ///
-/// # A missing secret refuses everything
+/// # One implementation, not two that agree
 ///
-/// `None` means no capability was provisioned for this pod, so the host cannot
-/// authenticate anything and therefore accepts nothing. Treating "no secret" as
-/// "no signature required" is the fail-OPEN reading, and it is the reading an
-/// attacker would prefer: it turns a provisioning failure into an open door.
+/// This was a local HMAC verification, and the guest client was going to grow a
+/// local HMAC signing to match it. Two implementations of one format, in
+/// different crates, each testable in isolation and each passing — which is the
+/// exact shape of the defect that made the capability inert one increment ago.
+/// Both sides now call [`nucleus_cred_protocol::frame`], where `sign` and
+/// `is_authentic` are pinned to each other by a round-trip test.
 ///
-/// # Constant-time
-///
-/// `verify_slice` rather than `==` on the hex: a byte-by-byte comparison leaks
-/// how much of a guessed signature was right, and a guest can retry freely.
+/// The properties are unchanged and are documented at the definition: `None`
+/// accepts NOTHING (the fail-open reading turns a provisioning failure into an
+/// open door), and verification is constant-time (a byte-by-byte compare leaks
+/// how much of a guessed signature was right, and a guest can retry freely).
 #[must_use]
 pub fn frame_is_authentic(frame: &str, secret: Option<&[u8]>) -> bool {
-    use hmac::{digest::KeyInit, Hmac, Mac};
-    use sha2::Sha256;
-
-    let Some(secret) = secret else {
-        return false;
-    };
-    let Some((sig_hex, payload)) = split_signed_frame(frame) else {
-        return false;
-    };
-    let Ok(sig) = hex::decode(sig_hex) else {
-        return false;
-    };
-    let Ok(mut mac) = Hmac::<Sha256>::new_from_slice(secret) else {
-        return false;
-    };
-    mac.update(payload.as_bytes());
-    mac.verify_slice(&sig).is_ok()
+    nucleus_cred_protocol::frame::is_authentic(frame, secret)
 }
 
 /// Serve exactly one request on an already-accepted connection.
@@ -356,6 +332,26 @@ pub type UpstreamCaller = Arc<
         > + Send
         + Sync,
 >;
+
+/// What an operator configured for one pod, before the listener exists.
+///
+/// Distinct from [`PodBroker`], which is what the SERVING task holds: this has no
+/// caller, because `start` decides that (and refuses to perform at all when no
+/// crypto provider is installed). Grouping is not only clippy's argument count —
+/// every field is per-pod, and a listener assembled from a mixture of two pods'
+/// values is the failure this arc has already produced once.
+pub struct PodBrokerConfig {
+    /// Bound at the listener, never read from a frame.
+    pub identity: PodIdentity,
+    /// This pod's policy.
+    pub policy: Arc<PermissionLattice>,
+    /// This pod's credentials, from the node's environment.
+    pub store: Arc<CredentialStore>,
+    /// The upstreams the operator configured.
+    pub upstreams: Arc<Vec<CredentialedEgressSpec>>,
+    /// The capability the guest is served and this listener verifies.
+    pub broker_secret: Arc<Vec<u8>>,
+}
 
 /// One pod's broker, owned, as the listener task needs it.
 ///
@@ -1276,14 +1272,24 @@ impl BrokerListener {
     pub fn start(
         uds_path: &std::path::Path,
         port: u32,
-        identity: PodIdentity,
-        policy: Arc<PermissionLattice>,
-        store: Arc<CredentialStore>,
-        upstreams: Arc<Vec<CredentialedEgressSpec>>,
-        broker_secret: Arc<Vec<u8>>,
+        pod: PodBrokerConfig,
+        jail_owner: Option<(u32, u32)>,
     ) -> io::Result<Self> {
+        let PodBrokerConfig {
+            identity,
+            policy,
+            store,
+            upstreams,
+            broker_secret,
+        } = pod;
         let socket_path = broker_socket_path(uds_path, port);
         let listener = prepare_socket(&socket_path)?;
+        // Without this the node binds, logs "started credential broker at …",
+        // passes every launch check, and no jailed guest can ever connect: the
+        // socket lands root-owned and `connect()` needs write permission on it.
+        // The workload API socket in this same directory has always done this;
+        // this one did not. See `guest_socket` for the post-mortem.
+        crate::guest_socket::give_socket_to_jail(&socket_path, jail_owner)?;
         let (tx, rx) = tokio::sync::oneshot::channel();
         // One client for the pod's lifetime, so connections to the upstream are
         // pooled rather than rebuilt per request. Its TLS trust is the HOST's,
@@ -1462,11 +1468,14 @@ mod listener_lifecycle_tests {
         let first = BrokerListener::start(
             &uds,
             9999,
-            PodIdentity::observed_by_host("spiffe://nucleus/pod/dead"),
-            policy(),
-            store("api.example.test", "v"),
-            Arc::new(Vec::new()),
-            Arc::new(TEST_SECRET.to_vec()),
+            PodBrokerConfig {
+                identity: PodIdentity::observed_by_host("spiffe://nucleus/pod/dead"),
+                policy: policy(),
+                store: store("api.example.test", "v"),
+                upstreams: Arc::new(Vec::new()),
+                broker_secret: Arc::new(TEST_SECRET.to_vec()),
+            },
+            None,
         )
         .expect("first listener binds");
         let path = first.socket_path().to_path_buf();
@@ -1486,11 +1495,14 @@ mod listener_lifecycle_tests {
         let second = BrokerListener::start(
             &uds,
             9999,
-            PodIdentity::observed_by_host("spiffe://nucleus/pod/alive"),
-            policy(),
-            store("api.example.test", "v"),
-            Arc::new(Vec::new()),
-            Arc::new(TEST_SECRET.to_vec()),
+            PodBrokerConfig {
+                identity: PodIdentity::observed_by_host("spiffe://nucleus/pod/alive"),
+                policy: policy(),
+                store: store("api.example.test", "v"),
+                upstreams: Arc::new(Vec::new()),
+                broker_secret: Arc::new(TEST_SECRET.to_vec()),
+            },
+            None,
         )
         .expect("a second listener must be able to bind the freed path");
         assert_eq!(second.socket_path(), path);
@@ -1518,11 +1530,14 @@ mod listener_lifecycle_tests {
         let listener = BrokerListener::start(
             &uds,
             9998,
-            PodIdentity::observed_by_host("spiffe://nucleus/pod/abc"),
-            policy(),
-            store("api.example.test", "v"),
-            Arc::new(Vec::new()),
-            Arc::new(TEST_SECRET.to_vec()),
+            PodBrokerConfig {
+                identity: PodIdentity::observed_by_host("spiffe://nucleus/pod/abc"),
+                policy: policy(),
+                store: store("api.example.test", "v"),
+                upstreams: Arc::new(Vec::new()),
+                broker_secret: Arc::new(TEST_SECRET.to_vec()),
+            },
+            None,
         )
         .expect("binds");
 

--- a/crates/nucleus-node/src/guest_socket.rs
+++ b/crates/nucleus-node/src/guest_socket.rs
@@ -1,0 +1,171 @@
+//! Handing a host-created socket to the jailed guest.
+//!
+//! # The failure this exists to make unrepeatable
+//!
+//! Firecracker's guest-initiated vsock connections arrive at `{uds_path}_{port}`
+//! — a socket the NODE creates, running as root, while Firecracker runs as the
+//! jailer uid. `prepare_jail` chowns everything it places and its comment notes
+//! that the vsock socket is "deliberately absent" because Firecracker creates
+//! it. That is true of `vsock.sock`, and **not** of the `_{port}` sockets.
+//!
+//! Connecting to a Unix socket requires WRITE permission on it, so a root-owned
+//! socket gives Firecracker's `connect()` EACCES and the guest sees "connection
+//! reset by peer" from a socket that is demonstrably listening. Measured on a
+//! booted pod, 2026-07-29:
+//!
+//! ```text
+//! srwxr-xr-x 1  123 users  vsock.sock          <- Firecracker made this
+//! srwxr-xr-x 1 root root   vsock.sock_15012    <- the node made this
+//! ```
+//!
+//! Downstream the guest fetched no SVID and no task token, all three
+//! sandbox-proof tiers failed, and the tool-proxy exited as PID 1 — a kernel
+//! panic whose visible cause was four layers from the file mode.
+//!
+//! # Why this is a shared function and not a second copy of that fix
+//!
+//! The workload API socket was fixed. The credential broker socket, created the
+//! same way, in the same directory, by the same root process, **was not** — it
+//! bound successfully, logged "started credential broker at …", passed every
+//! launch check, and no guest could ever have connected. It fails CLOSED and is
+//! indistinguishable from a policy refusal from inside the guest, which is
+//! exactly how it would have survived indefinitely.
+//!
+//! One socket got the lesson and its sibling did not, because the lesson lived
+//! in a comment next to one call site. It lives in a function now, and
+//! `every_guest_socket_is_handed_over` fails if a third listener appears without
+//! calling it.
+//!
+//! # chown, not chmod
+//!
+//! Only the jailed Firecracker should be able to connect. Widening the mode
+//! would open these sockets — which serve SVIDs, task tokens and the broker
+//! capability — to every user on the host.
+
+// The launch path that calls this is `cfg(target_os = "linux")`, so a macOS
+// build compiles no caller. On Linux the dead-code detector stays live.
+#![cfg_attr(all(not(test), not(target_os = "linux")), allow(dead_code))]
+
+use std::io;
+use std::path::Path;
+
+/// Give a node-created guest socket to the jailed uid.
+///
+/// `None` means the pod is not jailed: unjailed Firecracker runs as the same
+/// user as the node and can already connect, so handing the socket away would
+/// give up our own socket for nothing.
+pub fn give_socket_to_jail(path: &Path, owner: Option<(u32, u32)>) -> io::Result<()> {
+    #[cfg(target_os = "linux")]
+    if let Some((uid, gid)) = owner {
+        std::os::unix::fs::chown(path, Some(uid), Some(gid)).map_err(|e| {
+            io::Error::other(format!(
+                "cannot give {} to the jailed uid {uid}:{gid}: {e}",
+                path.display()
+            ))
+        })?;
+    }
+    // Referenced on every platform so a macOS build type-checks the call sites
+    // and cannot drift from the Linux one.
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = (path, owner);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The handover runs and succeeds on the real socket path.
+    ///
+    /// # What this can and cannot show, stated rather than implied
+    ///
+    /// An unprivileged process may chown a file it owns only to ITSELF, so this
+    /// exercises the call path and its error handling and cannot demonstrate a
+    /// change of owner. That half needs root, and it is checked where it is
+    /// actually consequential: the end-to-end test stats
+    /// `<jail_root>/vsock.sock_<broker_port>` on a booted pod.
+    ///
+    /// The uid comes from the socket's own metadata rather than `libc::getuid`,
+    /// so this needs no new dependency in a credential-adjacent crate.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn the_handover_succeeds_on_a_real_socket() {
+        use std::os::unix::fs::MetadataExt;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("vsock.sock_1027");
+        let _listener = std::os::unix::net::UnixListener::bind(&path).expect("bind");
+
+        let before = std::fs::metadata(&path).expect("stat");
+        let (uid, gid) = (before.uid(), before.gid());
+        give_socket_to_jail(&path, Some((uid, gid))).expect("chown to self must succeed");
+
+        let after = std::fs::metadata(&path).expect("stat");
+        assert_eq!(after.uid(), uid);
+        assert_eq!(after.gid(), gid);
+    }
+
+    /// A path that does not exist is an ERROR, not a silent success.
+    ///
+    /// This is the half that matters for the defect: a handover that quietly did
+    /// nothing would leave the socket root-owned and report success, which is
+    /// indistinguishable from the bug it fixes.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn a_missing_socket_is_an_error_not_a_silent_success() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let err = give_socket_to_jail(&dir.path().join("nothing-here"), Some((0, 0)))
+            .expect_err("chowning a path that does not exist must fail");
+        assert!(
+            err.to_string().contains("nothing-here"),
+            "the error must name the path so an operator can act on it: {err}"
+        );
+    }
+
+    /// An unjailed pod is left alone. Handing the socket to another uid there
+    /// would give away a socket the node itself needs to keep.
+    #[test]
+    fn an_unjailed_pod_leaves_the_socket_alone() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("vsock.sock_1027");
+        let _listener = std::os::unix::net::UnixListener::bind(&path).expect("bind");
+        give_socket_to_jail(&path, None).expect("no owner is not an error");
+        assert!(path.exists());
+    }
+
+    /// **The anti-divergence check.** The broker socket went unfixed for the
+    /// whole life of the workload API's fix because the reasoning lived in a
+    /// comment beside one call site rather than in a function.
+    ///
+    /// Every module that binds a guest-initiated `{uds}_{port}` socket must hand
+    /// it over. A third listener that forgets fails here, at the moment it is
+    /// written, rather than on a booted pod four layers away from the file mode.
+    #[test]
+    fn every_guest_socket_is_handed_over() {
+        // Modules that create a guest-initiated socket the jailed Firecracker
+        // must be able to connect to.
+        let binders = [
+            ("broker_transport.rs", include_str!("broker_transport.rs")),
+            (
+                "workload_api_vsock.rs",
+                include_str!("workload_api_vsock.rs"),
+            ),
+        ];
+        for (name, src) in binders {
+            // Non-vacuity: the file really does bind a socket, so a rename that
+            // silently emptied this check fails rather than passing.
+            assert!(
+                src.contains("UnixListener::bind"),
+                "{name} no longer binds a socket — this check is watching the wrong file"
+            );
+            assert!(
+                src.contains("give_socket_to_jail"),
+                "{name} binds a guest-initiated socket and never hands it to the jailed \
+                 uid. Firecracker's connect() will get EACCES and the guest will see a \
+                 socket that is listening and unreachable — see this module's docs for \
+                 the post-mortem."
+            );
+        }
+    }
+}

--- a/crates/nucleus-node/src/main.rs
+++ b/crates/nucleus-node/src/main.rs
@@ -45,6 +45,7 @@ mod broker_transport;
 mod cgroup;
 mod cred_split;
 mod envelope_frame;
+mod guest_socket;
 mod net;
 mod session_mint;
 mod signed_proxy;
@@ -2802,6 +2803,12 @@ async fn spawn_firecracker_pod(
             pod_identity.as_ref(),
             id,
             &broker_capability,
+            // The SAME expression the workload API bridge uses. That socket was
+            // chowned and this one was not, which is why no guest could have
+            // reached the broker under the jailer.
+            jail_layout
+                .as_ref()
+                .map(|_| (state.jailer_uid, state.jailer_gid)),
         )?;
 
         let handle = FirecrackerPod {

--- a/crates/nucleus-node/src/workload_api_vsock.rs
+++ b/crates/nucleus-node/src/workload_api_vsock.rs
@@ -173,15 +173,7 @@ impl WorkloadApiVsockBridge {
         // chown, not chmod: only the jailed Firecracker should be able to
         // connect. Widening the mode would open the workload API — which serves
         // SVIDs and task tokens — to every user on the host.
-        #[cfg(target_os = "linux")]
-        if let Some((uid, gid)) = jail_owner {
-            std::os::unix::fs::chown(&socket_path, Some(uid), Some(gid)).map_err(|e| {
-                std::io::Error::other(format!(
-                    "cannot give {} to the jailed uid {uid}:{gid}: {e}",
-                    socket_path.display()
-                ))
-            })?;
-        }
+        crate::guest_socket::give_socket_to_jail(&socket_path, jail_owner)?;
         #[cfg(not(target_os = "linux"))]
         let _ = jail_owner;
         let (shutdown_tx, mut shutdown_rx) = oneshot::channel();

--- a/crates/nucleus-tool-proxy/src/broker_client.rs
+++ b/crates/nucleus-tool-proxy/src/broker_client.rs
@@ -101,6 +101,19 @@ pub fn parse_reply(line: &str) -> BrokerOutcome {
     }
 }
 
+/// This pod's broker capability: the key to sign with and where to send it.
+///
+/// One type because they are one capability. Delivered together in a single
+/// one-shot reply, and read together, so a proxy cannot end up able to sign and
+/// unable to connect.
+#[derive(Debug, Clone)]
+pub struct Capability {
+    /// The HMAC key. Never logged.
+    pub secret: String,
+    /// The vsock port the host broker listens on.
+    pub port: u32,
+}
+
 /// Host CID for vsock. Always 2 in Firecracker.
 ///
 /// Linux-only because only the Linux arm of `ask` dials anything.

--- a/crates/nucleus-tool-proxy/src/broker_client.rs
+++ b/crates/nucleus-tool-proxy/src/broker_client.rs
@@ -43,11 +43,10 @@
 //! suggestion), and the host claims it *before* the call rather than recording
 //! it after, so two frames carrying one key cannot both reach the upstream.
 //!
-//! What is written here still describes what THIS module sends: it builds
-//! queries only. The perform request is composed where the discharge is —
-//! whichever code path calls the broker for an action must do so past a minted
-//! `DischargedBundle`, because the host applies a coarse capability check and
-//! cannot see the flow state that makes a call safe or not.
+//! `perform_line` builds them here, and the obligation is no longer prose: it
+//! takes an `Authority`, which is constructible only from a `DischargedBundle`,
+//! which only `preflight_action` can mint. Spending it also RECORDS the attempt,
+//! so a perform that reached the wire with no audit record is not expressible.
 
 // Not yet called: the tool-proxy still reads credential values from its spec,
 // and switching it over is gated on `BrokerRollout::Enforcing` on the host.
@@ -102,20 +101,175 @@ pub fn parse_reply(line: &str) -> BrokerOutcome {
     }
 }
 
-/// Build the request line for an envelope.
+/// Host CID for vsock. Always 2 in Firecracker.
 ///
-/// Newline-terminated because the host frames on newlines — vsock has no
-/// message boundaries, so the delimiter is the protocol.
-pub fn request_line(envelope: &nucleus_cred_protocol::TaskRequestEnvelope) -> String {
-    let mut s = serde_json::to_string(envelope).unwrap_or_default();
-    s.push('\n');
-    s
+/// Linux-only because only the Linux arm of `ask` dials anything.
+#[cfg(target_os = "linux")]
+const VMADDR_CID_HOST: u32 = 2;
+
+/// Build the request line for a QUERY envelope.
+///
+/// Signed, and newline-terminated because the host frames on newlines — vsock
+/// has no message boundaries, so the delimiter is the protocol.
+///
+/// # This did not sign, and the host had already started refusing
+///
+/// The unsigned form predates the host-side capability check. Left as it was, a
+/// wired-up client would have produced frames the host refuses, and the failure
+/// would have looked like a policy denial rather than a format mismatch —
+/// because the two are deliberately indistinguishable on the wire.
+///
+/// Signing goes through `nucleus_cred_protocol::frame`, the same function the
+/// host verifies with. Not a local HMAC that matches it today.
+pub fn request_line(key: &[u8], envelope: &nucleus_cred_protocol::TaskRequestEnvelope) -> String {
+    let payload = serde_json::to_string(envelope).unwrap_or_default();
+    format!("{}\n", nucleus_cred_protocol::frame::sign(key, &payload))
 }
+
+/// Build the request line for a PERFORM — a request that the host ACT.
+///
+/// # The `Authority` is the whole point of this signature
+///
+/// `broker_perform`'s module docs on the host state an obligation the host
+/// cannot check: *a `PerformRequest` is composed only past a minted
+/// `DischargedBundle`*. The host applies a coarse capability check and
+/// structurally cannot see the flow state — `FlowTracker`, the session taint
+/// ceiling, the lethal-trifecta guard — that makes an egress safe or not. Those
+/// live here, in the guest.
+///
+/// So the obligation is discharged here or nowhere, and this signature is what
+/// stops it being prose. An [`Authority`] is constructible only from a
+/// `DischargedBundle`, whose constructor is private to
+/// `nucleus_ifc_kernel::discharge` — `preflight_action` is the only way to mint
+/// one, and a struct literal naming all eight obligation fields still does not
+/// compile outside that module.
+///
+/// # Why `Authority` and not `&DischargedBundle`
+///
+/// A `&DischargedBundle` parameter would be a witness the function ignores, and
+/// an ignored parameter proves only that a caller had one to pass. Spending the
+/// authority does two further things:
+///
+/// * it **records** the attempt — `spend` refuses an unwitnessed authority
+///   outright (`SpendError::Unwitnessed`), so a perform that reached the wire
+///   with no audit record is not expressible;
+/// * it **binds the scope** — the bundle is spent at `(WebFetch, HTTPEgress)`,
+///   the same pair a direct fetch spends, because a brokered call is HTTP egress
+///   by exactly the definition that governs `web_fetch`. A bundle earned for a
+///   file write cannot pay for this.
+pub fn perform_line(
+    authority: portcullis_effects::authority::Authority,
+    key: &[u8],
+    request: &nucleus_cred_protocol::PerformRequest,
+) -> Result<String, portcullis_effects::authority::SpendError> {
+    use nucleus_ifc_kernel::{Operation, SinkClass};
+    // Spent BEFORE the frame is built. A frame that exists is a frame that could
+    // be written to the socket by a later edit, so the refusal has to happen
+    // before there is anything to write.
+    let _bundle = authority.spend(Operation::WebFetch, SinkClass::HTTPEgress)?;
+    let payload = serde_json::to_string(request).unwrap_or_default();
+    Ok(format!(
+        "{}\n",
+        nucleus_cred_protocol::frame::sign(key, &payload)
+    ))
+}
+
+/// Send one frame to the host broker over vsock and read the reply.
+///
+/// # One frame per connection
+///
+/// The host serves exactly one request per connection and closes. Matching that
+/// here means no per-connection state and no lifetime policy on either side; the
+/// guest is not a latency-sensitive client.
+///
+/// # Every failure is the same failure
+///
+/// A connect error, a write error, a timeout and a refusal all produce
+/// [`BrokerOutcome::NotGranted`] at the call site. That is deliberate — see the
+/// type's docs — and it is why this returns the raw line rather than a rich
+/// error: there is nothing a caller should do differently, and a caller that
+/// could tell "denied" from "broker down" would learn host state from a failure
+/// it caused.
+/// # Why this is `cfg`-split rather than `cfg`-gated
+///
+/// `tokio-vsock` is a Linux-only dependency, and the guest is always Linux. A
+/// bare `#[cfg(target_os = "linux")]` on this function would force every CALLER
+/// to be cfg-gated too — and the callers are the interesting code (the egress
+/// path's kernel decision, the discharge, the taint observation). Splitting the
+/// implementation instead keeps a macOS build type-checking all of that, which is
+/// where most of this is actually reviewed.
+#[cfg(target_os = "linux")]
+pub async fn ask(port: u32, line: &str) -> std::io::Result<String> {
+    // `AsyncReadExt` is needed for `.take()` on the reader. Its absence is a
+    // LINUX-ONLY compile error: macOS builds the other arm of this cfg split and
+    // never type-checks this body.
+    use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
+
+    let fut = async {
+        let mut stream =
+            tokio_vsock::VsockStream::connect(tokio_vsock::VsockAddr::new(VMADDR_CID_HOST, port))
+                .await?;
+        stream.write_all(line.as_bytes()).await?;
+        stream.flush().await?;
+
+        let (reader, _writer) = tokio::io::split(stream);
+        let mut reply = String::new();
+        // Bounded: the host's reply carries an upstream body, but a guest that
+        // read without limit would let a compromised HOST exhaust the guest.
+        // The trust here runs both ways less than it looks.
+        let mut limited = BufReader::new(reader).take(MAX_REPLY_BYTES);
+        limited.read_line(&mut reply).await?;
+        Ok::<_, std::io::Error>(reply)
+    };
+
+    match tokio::time::timeout(REQUEST_TIMEOUT, fut).await {
+        Ok(r) => r,
+        Err(_) => Err(std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            "the broker did not answer within the request timeout",
+        )),
+    }
+}
+
+/// The non-Linux arm: there is no vsock, so there is no broker.
+///
+/// An error and never a bypass. A build that cannot reach the broker must refuse
+/// the action, not fall back to some other way of getting the credential — the
+/// module header says why at length, and this is the one line where getting it
+/// wrong would be invisible on the platform CI does not gate.
+#[cfg(not(target_os = "linux"))]
+pub async fn ask(_port: u32, _line: &str) -> std::io::Result<String> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "vsock is Linux-only; there is no credential broker on this platform",
+    ))
+}
+
+/// Largest reply the guest will read from the host.
+///
+/// Matches the host's own `MAX_UPSTREAM_BODY_BYTES` with room for the JSON
+/// envelope around it: the body is serialised as a byte array, which is about
+/// four times its length.
+pub const MAX_REPLY_BYTES: u64 = 2 * 1024 * 1024;
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use nucleus_cred_protocol::TaskRequestEnvelope;
+
+    /// The capability these tests speak with. A real pod's is minted per pod.
+    const TEST_KEY: &[u8] = b"a-test-broker-capability";
+
+    fn perform_request() -> nucleus_cred_protocol::PerformRequest {
+        nucleus_cred_protocol::PerformRequest {
+            operation: "WebFetch".to_string(),
+            target: "model-api".to_string(),
+            justification: "routine".to_string(),
+            idempotency_key: "key-1".to_string(),
+            path: "/messages".to_string(),
+            body: b"{}".to_vec(),
+        }
+    }
 
     fn envelope() -> TaskRequestEnvelope {
         TaskRequestEnvelope {
@@ -168,7 +322,7 @@ mod tests {
     /// The request is newline-terminated, because that is how the host frames.
     #[test]
     fn the_request_is_newline_terminated() {
-        let line = request_line(&envelope());
+        let line = request_line(TEST_KEY, &envelope());
         assert!(
             line.ends_with('\n'),
             "the host frames on newlines: {line:?}"
@@ -176,13 +330,143 @@ mod tests {
         assert_eq!(line.matches('\n').count(), 1, "exactly one terminator");
     }
 
-    /// The request round-trips into what the host parses.
+    /// **The transport refuses rather than bypassing, on a platform with no
+    /// vsock.** The module header commits to "failure is a refusal, never a
+    /// fallback", and this is the one place that could be got wrong invisibly:
+    /// a non-Linux arm returning `Ok` with a synthesised grant would be a
+    /// bypass on the platform CI does not gate.
+    #[cfg(not(target_os = "linux"))]
+    #[tokio::test]
+    async fn there_is_no_broker_without_vsock() {
+        let err = ask(1027, "frame\n").await.expect_err("must not succeed");
+        assert_eq!(err.kind(), std::io::ErrorKind::Unsupported);
+    }
+
+    /// On Linux the transport must fail rather than hang when nothing is
+    /// listening. A guest blocked forever on a dead broker is a pod that never
+    /// reports anything, which is worse than a refusal.
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn a_dead_broker_is_an_error_not_a_hang() {
+        // A port nothing binds. The connect fails fast; if it ever did not, the
+        // REQUEST_TIMEOUT is the backstop and this still completes.
+        let started = std::time::Instant::now();
+        let err = ask(65_000, "frame\n")
+            .await
+            .expect_err("nothing is listening");
+        assert!(
+            started.elapsed() <= REQUEST_TIMEOUT + Duration::from_secs(2),
+            "the transport must bound its own wait: {err}"
+        );
+    }
+
+    /// The reply bound is large enough to carry what the host may return, and
+    /// bounded at all — an unbounded read would let a compromised host exhaust
+    /// the guest, and the trust here runs both ways less than it looks.
     #[test]
-    fn the_request_parses_as_the_envelope_the_host_expects() {
-        let line = request_line(&envelope());
+    fn the_reply_bound_admits_a_full_upstream_body() {
+        const _: () = assert!(MAX_REPLY_BYTES >= 1024 * 1024);
+    }
+
+    /// **The cross-boundary round trip.** What the guest signs, the host both
+    /// authenticates and parses.
+    ///
+    /// This used to parse the whole line as JSON, which worked only because the
+    /// line was unsigned — and unsigned is precisely what the host refuses. It
+    /// now does what the host does: authenticate, split, then parse the payload.
+    /// A format drift on either side fails here rather than at a booted pod.
+    #[test]
+    fn the_request_is_authentic_and_parses_as_the_envelope_the_host_expects() {
+        let line = request_line(TEST_KEY, &envelope());
+        let frame = line.trim_end();
+
+        assert!(
+            nucleus_cred_protocol::frame::is_authentic(frame, Some(TEST_KEY)),
+            "the host verifies with this function; if it refuses here it refuses in production"
+        );
+        let (_sig, payload) = nucleus_cred_protocol::frame::split(frame).expect("well formed");
         let back: TaskRequestEnvelope =
-            serde_json::from_str(line.trim_end()).expect("the host must be able to parse this");
+            serde_json::from_str(payload).expect("the host must be able to parse this");
         assert_eq!(back, envelope());
+    }
+
+    /// The non-vacuity control for the test above: a frame signed under a
+    /// DIFFERENT capability must NOT authenticate, or `is_authentic` returning
+    /// true unconditionally would satisfy it.
+    #[test]
+    fn a_request_signed_with_another_capability_is_not_authentic() {
+        let line = request_line(b"someone-elses-capability", &envelope());
+        assert!(!nucleus_cred_protocol::frame::is_authentic(
+            line.trim_end(),
+            Some(TEST_KEY)
+        ));
+    }
+
+    /// **A perform request cannot be built without a discharge, and building one
+    /// leaves a record.**
+    ///
+    /// `spend` refuses an unwitnessed authority, so this also pins that a perform
+    /// frame reaching the wire with no audit entry is not expressible.
+    #[test]
+    fn a_witnessed_authority_produces_a_signed_perform_frame() {
+        use portcullis_effects::authority::Authority;
+        use std::sync::Arc;
+
+        let log = Arc::new(portcullis_effects::receipt::ReceiptLog::new());
+        let authority = Authority::new(nucleus_ifc_kernel::discharge::test_helpers::bundle_for(
+            nucleus_ifc_kernel::Operation::WebFetch,
+            nucleus_ifc_kernel::SinkClass::HTTPEgress,
+        ))
+        .witnessed_by(Arc::clone(&log));
+
+        let line = perform_line(authority, TEST_KEY, &perform_request())
+            .expect("a witnessed, correctly scoped authority must be spendable");
+        assert!(nucleus_cred_protocol::frame::is_authentic(
+            line.trim_end(),
+            Some(TEST_KEY)
+        ));
+        assert_eq!(
+            log.len(),
+            1,
+            "spending the authority must leave exactly one receipt"
+        );
+    }
+
+    /// **An unwitnessed authority produces no frame at all.** The refusal has to
+    /// happen before the frame exists — a frame that exists is a frame a later
+    /// edit could write to the socket.
+    #[test]
+    fn an_unwitnessed_authority_cannot_produce_a_perform_frame() {
+        use portcullis_effects::authority::{Authority, SpendError};
+
+        let authority = Authority::new(nucleus_ifc_kernel::discharge::test_helpers::bundle_for(
+            nucleus_ifc_kernel::Operation::WebFetch,
+            nucleus_ifc_kernel::SinkClass::HTTPEgress,
+        ));
+        assert_eq!(
+            perform_line(authority, TEST_KEY, &perform_request()).unwrap_err(),
+            SpendError::Unwitnessed
+        );
+    }
+
+    /// **A bundle earned for something else cannot pay for egress.** A file-write
+    /// discharge is a real discharge; it is not THIS discharge.
+    #[test]
+    fn a_bundle_earned_for_a_file_write_cannot_pay_for_a_perform() {
+        use portcullis_effects::authority::{Authority, SpendError};
+        use std::sync::Arc;
+
+        let log = Arc::new(portcullis_effects::receipt::ReceiptLog::new());
+        let authority = Authority::new(nucleus_ifc_kernel::discharge::test_helpers::bundle_for(
+            nucleus_ifc_kernel::Operation::WriteFiles,
+            nucleus_ifc_kernel::SinkClass::WorkspaceWrite,
+        ))
+        .witnessed_by(log);
+
+        assert!(matches!(
+            perform_line(authority, TEST_KEY, &perform_request()).unwrap_err(),
+            SpendError::ScopeMismatch(_)
+        ));
     }
 
     /// The guest gives up before the host does, so the failure is reported once

--- a/crates/nucleus-tool-proxy/src/egress.rs
+++ b/crates/nucleus-tool-proxy/src/egress.rs
@@ -32,22 +32,53 @@
 
 use nucleus_spec::CredentialedEgressSpec;
 
-/// Resolve the credential for an upstream from the RUNTIME's environment.
+use std::sync::Arc;
+
+/// This pod's broker capability, from the environment `guest-init` prepared.
 ///
-/// `None` when unset. The caller must then refuse rather than forward
-/// unauthenticated: an upstream that rejects the call would be the lucky case,
-/// and one that accepts it anonymously is worse.
-#[must_use]
-pub(crate) fn credential_for(spec: &CredentialedEgressSpec) -> Option<String> {
-    std::env::var(&spec.credential_env)
-        .ok()
-        .filter(|v| !v.is_empty())
+/// # There is no `credential_for` any more, and that is the change
+///
+/// This module used to read the credential itself, with
+/// `std::env::var(&spec.credential_env)` — in the GUEST. That function and its
+/// header-building sibling are deleted rather than kept as a fallback: a broker
+/// that applies only when a credential happens to be absent is advisory, and an
+/// attacker who can arrange for one to be present restores the exposure the
+/// broker exists to remove. It was also dead weight on Firecracker, where the
+/// value never reached the guest at all.
+///
+/// Both halves or neither: a secret with no port can sign and not connect. They
+/// arrive together in one reply for exactly that reason, and are read together
+/// here.
+fn broker_capability() -> Option<crate::broker_client::Capability> {
+    let secret = std::env::var("NUCLEUS_TOOL_PROXY_BROKER_SECRET").ok()?;
+    let port: u32 = std::env::var("NUCLEUS_TOOL_PROXY_BROKER_PORT")
+        .ok()?
+        .parse()
+        .ok()?;
+    (!secret.is_empty() && port != 0).then_some(crate::broker_client::Capability { secret, port })
 }
 
-/// The header value sent upstream.
-#[must_use]
-pub(crate) fn header_value(spec: &CredentialedEgressSpec, credential: &str) -> String {
-    format!("{}{}", spec.value_prefix, credential)
+/// The idempotency key for one logical upstream call.
+///
+/// Derived from what the request IS — upstream name, path, body — rather than
+/// randomly, so a retry of the same call carries the same key and the host's
+/// ledger recognises it as one operation. A fresh random key per attempt would
+/// leave the host unable to tell a retry from a new request, which is the exact
+/// thing the key exists to prevent; the machinery would still run and still be
+/// decorative.
+///
+/// Hashed rather than concatenated: the body can be large and the key is bounded
+/// by `MAX_FIELD_BYTES` on the host, and a delimiter-joined key would let a
+/// crafted path collide with a different (name, path) pair.
+fn idempotency_key(name: &str, path: &str, body: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    let mut h = Sha256::new();
+    // Length-prefixed, so ("ab", "c") and ("a", "bc") cannot produce one digest.
+    for part in [name.as_bytes(), path.as_bytes(), body] {
+        h.update((part.len() as u64).to_be_bytes());
+        h.update(part);
+    }
+    hex::encode(h.finalize())
 }
 
 /// Build the upstream URL for a request path.
@@ -144,6 +175,53 @@ pub(crate) fn reject_bypassable_upstreams(
     ))
 }
 
+/// Refuse to start a pod that configures credentialed egress it cannot perform.
+///
+/// # Why at startup and not per request
+///
+/// Since the in-guest credential path was deleted, a credentialed upstream is
+/// callable ONLY through the host broker. A pod configured with upstreams but no
+/// broker capability will refuse every request at the moment the workload makes
+/// one — which surfaces as an application error, minutes into a run, four layers
+/// from the pod spec that caused it.
+///
+/// Refusing at startup names the cause once, before anything has been attempted.
+/// It is the same reasoning `reject_bypassable_upstreams` gives, and it sits
+/// beside it for that reason.
+///
+/// # The driver this affects
+///
+/// The container driver has no broker: `broker_identity` refuses a pod with no
+/// host-established identity, and that driver registers none. Giving it one is a
+/// design question rather than wiring — a Firecracker identity comes with an
+/// attested SVID and a default-deny netns, and a container has neither, so the
+/// identity would assert what the driver cannot back. So this refusal is what a
+/// container pod with `credentialed_egress` now gets, and saying so loudly beats
+/// a silent per-request failure.
+///
+/// # Errors
+/// Names the upstreams, so an operator sees what to remove or which driver to use.
+pub(crate) fn reject_egress_without_a_broker(
+    specs: &[CredentialedEgressSpec],
+    has_broker: bool,
+) -> Result<(), String> {
+    if specs.is_empty() || has_broker {
+        return Ok(());
+    }
+    Err(format!(
+        "this pod configures credentialed egress ({}) but has no credential-broker \
+         capability, so the upstream cannot be called on its behalf. The in-guest \
+         credential path was removed deliberately — a broker that applies only when a \
+         credential happens to be absent is advisory. Either run this pod on a driver \
+         that provides a broker, or remove the credentialed_egress entries.",
+        specs
+            .iter()
+            .map(|s| s.name.as_str())
+            .collect::<Vec<_>>()
+            .join(", ")
+    ))
+}
+
 /// `POST /v1/egress/{name}/{*path}` — call an upstream on the workload's behalf.
 ///
 /// # Order of operations, and why it is this order
@@ -154,12 +232,13 @@ pub(crate) fn reject_bypassable_upstreams(
 /// 3. Kernel decision, exactly as `web_fetch` does. This is what makes a tainted
 ///    session's upstream call subject to the same egress gate as its tool calls,
 ///    and it is the half that a plain credential-injecting proxy does not have.
-/// 4. Inject the credential and forward.
+/// 4. Mint the discharge, then ask the HOST to perform the call. The credential
+///    is never read here — see `broker_capability`.
 /// 5. Observe the response as untrusted, AI-derived content, so anything the
 ///    workload does with it carries the taint.
 ///
-/// The credential is read here, in the runtime, and never appears in the
-/// workload's environment or in any response.
+/// The credential is in the NODE's environment and never enters this process.
+/// What crosses is a request to act; what comes back is the upstream's answer.
 pub(crate) async fn credentialed_egress(
     axum::extract::State(state): axum::extract::State<crate::AppState>,
     axum::extract::Path((name, path)): axum::extract::Path<(String, String)>,
@@ -192,24 +271,17 @@ pub(crate) async fn credentialed_egress(
     // it differently would be the hole this whole module exists to close.
     let _decision = crate::http_kernel_decide(&state, Operation::WebFetch, &url).await?;
 
-    let Some(credential) = credential_for(&spec) else {
-        // Refused rather than forwarded unauthenticated: at best the upstream
-        // rejects it, at worst it accepts anonymously.
-        return Err(ApiError::Spec(format!(
-            "no credential in {} for upstream {name:?}",
-            spec.credential_env
-        )));
-    };
-
-    // Through the SEALED effect, exactly as `web_fetch` does — not a raw client.
+    // ── The credential is NOT read here, and cannot be ─────────────────────
     //
-    // The mediation gate caught the first version of this doing its own
-    // `.send()`. It was right to: the sealed `NetEffect::fetch` is reachable
-    // only past a minted `DischargedBundle`, so "no un-preflighted agent egress
-    // reaches the wire" is a property of what can be TYPED rather than of what
-    // was remembered. Credentialed egress is still agent egress; allowlisting it
-    // would have carved the one hole the gate exists to prevent.
-    use portcullis_effects::{NetCapability, NetEffect};
+    // This used to be `credential_for(&spec)` — a `std::env::var` in the GUEST.
+    // That path is gone, not kept as a fallback, and the deletion is the point:
+    // a broker that applies only when a credential happens to be absent is
+    // advisory, and an attacker who can arrange for it to be present restores
+    // the exposure. On Firecracker the value never reached the guest anyway, so
+    // the in-guest path could only ever fail closed there.
+    //
+    // What crosses to the host is a request to ACT. What comes back is the
+    // upstream's response. The credential stays in the node's environment.
 
     let discharge_bundle = {
         use nucleus_ifc_kernel::discharge::PreflightResult;
@@ -228,33 +300,64 @@ pub(crate) async fn credentialed_egress(
         }
     };
 
-    let headers = vec![
-        (spec.header.clone(), header_value(&spec, &credential)),
-        ("content-type".to_string(), "application/json".to_string()),
-    ];
-    let effects = portcullis_effects::production_effects_concrete(crate::core_capabilities(
-        &state.runtime.policy().capabilities,
-    ));
-    let resp = effects
-        .fetch(
-            &state.web_client,
-            NetCapability::WebFetch,
-            reqwest::Method::POST,
-            reqwest::Url::parse(&url)
-                .map_err(|e| ApiError::Spec(format!("upstream url is not parseable: {e}")))?,
-            &headers,
-            Some(body.to_vec()),
-            None,
-            portcullis_effects::authority::Authority::new(discharge_bundle),
-        )
-        .await
-        .map_err(|e| ApiError::Spec(format!("upstream request failed: {e}")))?;
+    // The discharge is minted HERE and spent by `perform_line`. That is the
+    // whole reason the guest half exists: the host applies a coarse capability
+    // check and structurally cannot see `FlowTracker`, the session taint ceiling
+    // or the lethal-trifecta guard. Those live in this process, and a
+    // `PerformRequest` that was not composed past them would be egress the
+    // kernel never saw.
+    let authority = portcullis_effects::authority::Authority::new(discharge_bundle)
+        .witnessed_by(Arc::clone(&state.receipts));
 
-    let status = resp.status();
-    let bytes = resp
-        .bytes()
+    let Some(capability) = broker_capability() else {
+        // No capability means no broker. Refused, never forwarded another way —
+        // see `broker_client`'s header: a broker that can be bypassed by
+        // breaking it is not a boundary.
+        return Err(ApiError::Spec(
+            "this pod has no credential-broker capability, so the upstream cannot be \
+             called on its behalf"
+                .to_string(),
+        ));
+    };
+
+    let request = nucleus_cred_protocol::PerformRequest {
+        operation: "WebFetch".to_string(),
+        target: name.clone(),
+        justification: "credentialed egress".to_string(),
+        // Derived from what the request IS, so a retry of the same call carries
+        // the same key and the host's ledger sees one logical operation. A
+        // random key per attempt would make the idempotency machinery decorative.
+        idempotency_key: idempotency_key(&name, &path, &body),
+        path: path.clone(),
+        body: body.to_vec(),
+    };
+
+    let line =
+        crate::broker_client::perform_line(authority, capability.secret.as_bytes(), &request)
+            .map_err(|e| ApiError::IfcDenied(format!("authority not spendable: {e}")))?;
+
+    let reply_line = crate::broker_client::ask(capability.port, &line)
         .await
-        .map_err(|e| ApiError::Spec(format!("upstream response failed: {e}")))?;
+        .map_err(|e| ApiError::Spec(format!("the credential broker did not answer: {e}")))?;
+
+    let reply: nucleus_cred_protocol::PerformReply = serde_json::from_str(reply_line.trim_end())
+        .map_err(|_| {
+            ApiError::Spec("the credential broker sent an unreadable reply".to_string())
+        })?;
+
+    if !reply.granted {
+        // The host's reason is deliberately coarse — it must not let a guest
+        // enumerate which credentials exist — so it is passed through unchanged
+        // rather than elaborated here.
+        return Err(ApiError::IfcDenied(format!(
+            "the credential broker refused: {}",
+            reply.reason
+        )));
+    }
+
+    let status = axum::http::StatusCode::from_u16(reply.status)
+        .unwrap_or(axum::http::StatusCode::BAD_GATEWAY);
+    let bytes = axum::body::Bytes::from(reply.body);
 
     // External AND model-authored. Observing it is what makes the taint real for
     // everything the workload does next.
@@ -341,22 +444,6 @@ mod tests {
         );
     }
 
-    /// An unset credential yields `None`, so the caller refuses. Forwarding
-    /// unauthenticated would at best fail upstream and at worst succeed
-    /// anonymously against something that does not require auth.
-    #[test]
-    fn an_unset_credential_is_absent_rather_than_empty() {
-        let sp = spec_named("NUCLEUS_TEST_EGRESS_CRED_UNSET");
-        std::env::remove_var(&sp.credential_env);
-        assert!(credential_for(&sp).is_none());
-        std::env::set_var(&sp.credential_env, "");
-        assert!(
-            credential_for(&sp).is_none(),
-            "an empty value is not a credential"
-        );
-        std::env::remove_var(&sp.credential_env);
-    }
-
     /// **A credentialed upstream that is also directly reachable is a control
     /// that appears to work and does not.** The workload would just call the API
     /// itself: same data out, no kernel decision, no IFC gate, no record.
@@ -393,8 +480,90 @@ mod tests {
         assert!(reject_bypassable_upstreams(&[spec()], &[]).is_ok());
     }
 
+    /// **A pod that cannot perform credentialed egress refuses to start.**
     #[test]
-    fn the_prefix_is_applied_to_the_header_value() {
-        assert_eq!(header_value(&spec(), "tok"), "Bearer tok");
+    fn credentialed_egress_without_a_broker_refuses_to_start() {
+        let err = reject_egress_without_a_broker(&[spec()], false)
+            .expect_err("no capability means the upstream can never be called");
+        assert!(err.contains("model-api"), "name the offender: {err}");
+        assert!(
+            err.contains("advisory"),
+            "and say why there is no fallback: {err}"
+        );
+    }
+
+    /// **The two controls, each doing its own job.** With a broker it starts; with
+    /// no upstreams configured it starts regardless. Without both of these the
+    /// refusal above is satisfied by a function that refuses everything.
+    #[test]
+    fn a_pod_that_can_perform_egress_is_not_refused() {
+        assert!(reject_egress_without_a_broker(&[spec()], true).is_ok());
+        assert!(
+            reject_egress_without_a_broker(&[], false).is_ok(),
+            "a pod configuring no credentialed egress needs no broker"
+        );
+    }
+
+    /// **The in-guest credential path is GONE, not merely unused.**
+    ///
+    /// Scans the source, because the property is about what this module CAN do.
+    /// A dead-but-present `credential_for` is one call site away from being a
+    /// fallback again, and a fallback is what makes a broker advisory: an
+    /// attacker who can arrange for the environment variable to be set restores
+    /// exactly the exposure the broker removes.
+    #[test]
+    fn this_module_cannot_read_a_credential_from_the_guest_environment() {
+        let src = include_str!("egress.rs");
+        // PRODUCTION half only. The test module below names `credential_env` in
+        // its fixtures and in this very assertion, and a scanner that counted
+        // those would fire on the explanation of the property it checks — the
+        // same scoping `nucleus_cred_protocol`'s `declarations()` helper needs.
+        let production = src
+            .split("#[cfg(test)]")
+            .next()
+            .expect("source before tests");
+        let code: String = production
+            .lines()
+            .filter(|l| {
+                let t = l.trim_start();
+                !t.starts_with("///") && !t.starts_with("//!") && !t.starts_with("//")
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            !code.contains("credential_env"),
+            "egress.rs reads `credential_env` again. That field names a variable in the \
+             NODE's environment now; a read of it HERE is a read inside the guest, which \
+             is the exposure this module was rewritten to remove."
+        );
+        assert!(
+            !code.contains("fn credential_for") && !code.contains("fn header_value"),
+            "the in-guest credential path is back"
+        );
+    }
+
+    /// The idempotency key is a function of the REQUEST, so a retry repeats it.
+    /// A random key per attempt would leave the host unable to recognise a retry
+    /// and the whole ledger would be decoration.
+    #[test]
+    fn the_same_call_produces_the_same_idempotency_key() {
+        let a = idempotency_key("model-api", "/messages", b"{}");
+        let b = idempotency_key("model-api", "/messages", b"{}");
+        assert_eq!(a, b);
+    }
+
+    /// Different calls must not collide, including under the delimiter attack a
+    /// concatenated key would admit.
+    #[test]
+    fn different_calls_produce_different_keys() {
+        let base = idempotency_key("model-api", "/messages", b"{}");
+        assert_ne!(base, idempotency_key("other-api", "/messages", b"{}"));
+        assert_ne!(base, idempotency_key("model-api", "/other", b"{}"));
+        assert_ne!(base, idempotency_key("model-api", "/messages", b"{ }"));
+        // Length-prefixing is what stops this pair colliding.
+        assert_ne!(
+            idempotency_key("ab", "c", b""),
+            idempotency_key("a", "bc", b"")
+        );
     }
 }

--- a/crates/nucleus-tool-proxy/src/main.rs
+++ b/crates/nucleus-tool-proxy/src/main.rs
@@ -314,6 +314,21 @@ pub(crate) struct AppState {
     pub(crate) runtime: Arc<PodRuntime>,
     approvals: Arc<ApprovalRegistry>,
     audit: Arc<AuditLog>,
+    /// Where a spent [`Authority`] records that it was exercised.
+    ///
+    /// Distinct from `audit` above: that is the pod's hash-chained audit surface,
+    /// this is the effect-discharge receipt log that
+    /// `portcullis_effects::authority::Authority::spend` writes to. `spend`
+    /// REFUSES an unwitnessed authority (`SpendError::Unwitnessed`), so without
+    /// this field the brokered-egress path would fail on every request — safe,
+    /// and inert, which is the failure shape this arc has already produced twice.
+    ///
+    /// **Limit, and it is the one already recorded for FM-3 rather than a new
+    /// one:** `ReceiptLog` is an in-memory `Vec`, so an append cannot fail and
+    /// "the effect is refused if the record cannot be written" is still not
+    /// expressible. It becomes real when the log gains durable backing. See
+    /// `docs/production-delta.md`, "Receipt log resilience (FM-3)".
+    receipts: Arc<portcullis_effects::receipt::ReceiptLog>,
     auth: AuthConfig,
     approval_auth: AuthConfig,
     /// True when this server was started on a vsock listener that accepts only
@@ -1558,6 +1573,16 @@ async fn main() -> Result<(), ApiError> {
     egress::reject_bypassable_upstreams(&spec.spec.credentialed_egress, &dns_allow)
         .map_err(ApiError::Spec)?;
 
+    // Credentialed egress goes through the host broker and nowhere else, so a
+    // pod configured for it without a capability can never succeed. Refuse here
+    // rather than at the first request, where it would look like a transient
+    // upstream error minutes into a run.
+    egress::reject_egress_without_a_broker(
+        &spec.spec.credentialed_egress,
+        std::env::var("NUCLEUS_TOOL_PROXY_BROKER_SECRET").is_ok_and(|v| !v.is_empty()),
+    )
+    .map_err(ApiError::Spec)?;
+
     let dlc_admission = dlc_admission::provision_from_env();
     let dlc_provisioned = dlc_admission.is_some();
 
@@ -1634,7 +1659,9 @@ async fn main() -> Result<(), ApiError> {
     // === Auth-secret sanity, transport-aware (fail-closed where it matters) ===
     enforce_hmac_key_quality(&args.auth_secret, vsock_binding.is_some());
 
+    let receipts = Arc::new(portcullis_effects::receipt::ReceiptLog::new());
     let state = AppState {
+        receipts: Arc::clone(&receipts),
         path_provenance: Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new())),
         dlc_provisioned,
         runtime: Arc::new(runtime),

--- a/crates/nucleus-tool-proxy/src/workload.rs
+++ b/crates/nucleus-tool-proxy/src/workload.rs
@@ -36,6 +36,20 @@ use nucleus_spec::WorkloadSpec;
 /// `NUCLEUS_TOOL_PROXY_URL` itself would otherwise point its workload at some
 /// other endpoint — mediating nothing while looking mediated — and a pod spec is
 /// not necessarily written by the same party that owns the policy.
+/// The only variables a workload inherits from the runtime, by name.
+///
+/// Deliberately tiny, and deliberately a list rather than a filter: a
+/// deny-list of secret-looking names fails the moment somebody adds a secret
+/// whose name does not look like one, which is exactly how the broker
+/// capability got through in the first place.
+///
+/// Everything else a workload needs goes in `spec.env`, where an operator wrote
+/// it down. `PATH` is here because a command resolved without one fails in a way
+/// that looks like a missing binary rather than a missing variable; `HOME`,
+/// `LANG` and `TZ` because tools misbehave in confusing ways without them and
+/// none of the three can carry authority.
+pub(crate) const INHERITED_BY_NAME: [&str; 4] = ["PATH", "HOME", "LANG", "TZ"];
+
 #[must_use]
 pub(crate) fn workload_env(
     spec: &WorkloadSpec,
@@ -76,9 +90,39 @@ pub(crate) fn spawn_workload(
     cmd.args(&spec.args)
         .current_dir(work_dir)
         .kill_on_drop(true);
-    // A uid boundary is what makes "the workload does not have the credential"
-    // true. Same-uid processes can read each other's `/proc/<pid>/environ`, so
-    // without this the workload reads the runtime's environment and helps itself.
+
+    // ── The workload's environment is DECLARED, never inherited ──────────────
+    //
+    // `Command` passes the parent's environment to the child unless told
+    // otherwise, and this did not tell it otherwise. The proxy's own environment
+    // carries `NUCLEUS_TOOL_PROXY_BROKER_SECRET` — `nucleus-guest-init` sets it
+    // before exec'ing the proxy — so **the workload inherited the broker
+    // capability**. The one thing steps 1 and 2 of this arc exist to prevent:
+    // the capability distinguishes the mediating proxy from every other process
+    // in the guest, and it was being handed to the workload for free.
+    //
+    // The uid boundary below does NOT close this, and the comment that used to
+    // sit there claimed it did. A uid stops the workload READING
+    // `/proc/<proxy_pid>/environ`; it does nothing about a value already in the
+    // workload's own environment. Inheritance arrives before any permission
+    // check applies.
+    //
+    // `env_clear` first, then an explicit allowlist. The fail-closed direction:
+    // a new variable now has to be added on purpose, rather than reaching the
+    // workload because it happened to be in the proxy's environment. Anything a
+    // workload genuinely needs belongs in `spec.env`, where an operator wrote it
+    // and a reader can see it.
+    cmd.env_clear();
+    for key in INHERITED_BY_NAME {
+        if let Ok(value) = std::env::var(key) {
+            cmd.env(key, value);
+        }
+    }
+
+    // A uid boundary, for the DIFFERENT thing it actually buys: same-uid
+    // processes can read each other's `/proc/<pid>/environ`, so without this the
+    // workload could read the runtime's environment directly — which still holds
+    // the broker capability, whatever the workload's own environment says.
     if let Some(uid) = spec.uid {
         cmd.uid(uid);
     }
@@ -238,16 +282,84 @@ mod tests {
         );
     }
 
-    /// **The broker capability must never reach the workload.** It is what lets
-    /// the host tell the mediating proxy from every other process in the guest;
-    /// a workload holding it could ask the broker to act directly, skipping the
-    /// kernel decision, taint ceiling and flow cross-check.
+    /// **The capability does not reach a real child.** This is the property; the
+    /// map-level test above is a necessary half of it.
     ///
-    /// Asserted rather than left to a grep: absence is easy to establish by
-    /// accident and easy to lose by accident, and the losing edit would look
-    /// like a helpful convenience.
+    /// Spawns an actual process and reads the environment it actually got,
+    /// because the defect this covers lives entirely in the gap between the map
+    /// and the child: `Command` inherits the parent's environment, the proxy's
+    /// environment holds the capability, and no amount of checking the overlay
+    /// map can see that.
+    #[tokio::test]
+    async fn the_spawned_child_does_not_inherit_the_capability() {
+        // Put the capability in THIS process's environment, exactly as
+        // `guest-init` puts it in the proxy's before exec.
+        std::env::set_var("NUCLEUS_TOOL_PROXY_BROKER_SECRET", "leaked-capability");
+        std::env::set_var("NUCLEUS_TOOL_PROXY_BROKER_PORT", "1027");
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let dump = dir.path().join("child-env");
+        // Written to a FILE, not read from stdout: `spawn_workload` does not pipe
+        // stdout, so `wait_with_output` returns an empty buffer and every
+        // "does not contain the secret" assertion below would pass vacuously.
+        // The non-vacuity control at the end of this test is what caught that.
+        let spec = WorkloadSpec {
+            command: "/bin/sh".into(),
+            args: vec!["-c".into(), format!("env > {}", dump.display())],
+            uid: None,
+            env: std::collections::BTreeMap::new(),
+        };
+        let mut child = spawn_workload(&spec, "http://127.0.0.1:8080", "s3cret", dir.path(), &[])
+            .expect("sh must be spawnable");
+        let status = child.wait().await.expect("child ran");
+        assert!(status.success(), "the child must actually run: {status:?}");
+        let observed = std::fs::read_to_string(&dump).expect("the child wrote its environment");
+
+        std::env::remove_var("NUCLEUS_TOOL_PROXY_BROKER_SECRET");
+        std::env::remove_var("NUCLEUS_TOOL_PROXY_BROKER_PORT");
+
+        assert!(
+            !observed.contains("leaked-capability"),
+            "the workload inherited the broker capability from the proxy's environment. \
+             It can now sign broker frames directly, which is exactly what the capability \
+             exists to prevent. Child environment was:\n{observed}"
+        );
+        assert!(
+            !observed.contains("NUCLEUS_TOOL_PROXY_BROKER_PORT"),
+            "the workload was told where the broker listens:\n{observed}"
+        );
+
+        // **The non-vacuity control.** A child with an EMPTY environment would
+        // satisfy every assertion above while being completely broken, and
+        // `env_clear` makes that failure one line away.
+        assert!(
+            observed.contains("NUCLEUS_TOOL_PROXY_URL"),
+            "the workload must still be told where its proxy is, or the assertions \
+             above are satisfied by a child that got nothing:\n{observed}"
+        );
+        assert!(
+            observed.contains("PATH="),
+            "PATH must survive the clear, or a workload cannot resolve its own \
+             command:\n{observed}"
+        );
+    }
+
+    /// **`workload_env` does not SOURCE the capability from the runtime.**
+    ///
+    /// # This test was necessary and not sufficient, and the gap was a real hole
+    ///
+    /// It asserts a property of the overlay map. `spawn_workload` applies that
+    /// map with `cmd.env(k, v)` — additive — on top of an environment the child
+    /// INHERITS from the proxy, and the proxy's environment holds
+    /// `NUCLEUS_TOOL_PROXY_BROKER_SECRET` because `nucleus-guest-init` sets it
+    /// before exec. So the workload received the capability, this test passed,
+    /// and the two facts had nothing to do with each other.
+    ///
+    /// Renamed to what it actually checks. The property people want is in
+    /// `the_spawned_child_does_not_inherit_the_capability`, which asserts over a
+    /// real child's environment.
     #[test]
-    fn the_broker_capability_never_reaches_the_workload() {
+    fn workload_env_does_not_source_the_capability_from_the_runtime() {
         let hostile = spec_with(&[("NUCLEUS_TOOL_PROXY_BROKER_SECRET", "stolen")]);
         let env = workload_env(&hostile, "http://127.0.0.1:8080", "s3cret", &[]);
         // A spec that names it gets it back — that value is the SPEC's, not the

--- a/scripts/check-mediation.sh
+++ b/scripts/check-mediation.sh
@@ -35,6 +35,7 @@ cd "$(git rev-parse --show-toplevel 2>/dev/null || echo .)"
 
 SPAWN_ALLOWLIST="scripts/mediation-allowlist.txt"
 NET_ALLOWLIST="scripts/mediation-net-allowlist.txt"
+VSOCK_ALLOWLIST="scripts/mediation-vsock-allowlist.txt"
 
 # In-scope = the agent effect path. Effects here MUST go through
 # `preflight_action` -> `DischargedBundle`, never a raw primitive.
@@ -157,13 +158,31 @@ run_pattern 'Command::new' 'spawn' "$SPAWN_ALLOWLIST"
 # not matched, so the net pattern isolates HTTP egress without false positives.
 run_pattern '.send()' 'net' "$NET_ALLOWLIST"
 
+# VSOCK — the third pattern, and the reason it exists.
+#
+# Credentialed egress no longer reaches the wire from inside the guest. It asks
+# the HOST to perform the call, over vsock. A `write_all` on a vsock stream is
+# invisible to the `.send()` pattern above, so that egress dropped out of this
+# gate's view entirely the moment it started working.
+#
+# The typestate does most of the work: `broker_client::perform_line` takes an
+# `Authority`, so a typed perform without a discharge does not compile. This
+# pattern is NOT redundant with it, and the distinction is the point — the
+# signature stops a typed call with no bundle; this stops a HAND-ROLLED frame
+# that never touches the typed API. Neither covers the other's hole, and each is
+# perturbed alone.
+#
+# Allowlist: the sanctioned client file only.
+run_pattern 'VsockStream::connect' 'vsock' "$VSOCK_ALLOWLIST"
+
 if [[ "$FAILED" -ne 0 ]]; then
     echo >&2
     echo "Fix: obtain the effect through portcullis_core::discharge (preflight_action -> DischargedBundle)" >&2
     echo "via portcullis-effects (spawn -> ShellEffect::run_argv[_async]; net -> NetEffect::fetch), not a" >&2
-    echo "raw Command::new / reqwest .send(. If this is legitimate un-migrated baseline debt (spawn) or an" >&2
+    echo "raw Command::new / reqwest .send( / VsockStream::connect. If this is legitimate un-migrated" >&2
+    echo "baseline debt (spawn) or an" >&2
     echo "infra sink (net), add it to the matching allowlist (spawn debt only shrinks; net infra is by-file/by-line)." >&2
     exit 1
 fi
 
-echo "mediation gate PASSED: no un-allowlisted raw effect primitive on the agent path (spawn + net)."
+echo "mediation gate PASSED: no un-allowlisted raw effect primitive on the agent path (spawn + net + vsock)."

--- a/scripts/check-test-helpers-not-in-production.sh
+++ b/scripts/check-test-helpers-not-in-production.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# The discharge seal holds only while `test-helpers` stays out of production.
+#
+# WHY THIS EXISTS
+#
+# `nucleus_ifc_kernel::discharge::test_helpers::bundle_for` mints a
+# `DischargedBundle` with NO preflight. That is correct and necessary — tests
+# must be able to exercise effect sites — and it is gated behind a `test-helpers`
+# feature that three crates enable, all of them from `[dev-dependencies]`.
+#
+# `broker_client::perform_line` takes an `Authority`, which is constructible only
+# from a `DischargedBundle`, whose constructor is private to the discharge
+# module. That signature is what turns "a PerformRequest is composed only past a
+# minted DischargedBundle" from a sentence in a doc comment into a compile-time
+# obligation.
+#
+# It stops being an obligation the moment `test-helpers` is enabled through a
+# NORMAL dependency edge anywhere in the graph, because Cargo unifies features
+# per build: `bundle_for` becomes callable from production code and anyone can
+# mint the proof. Nothing would fail. Every test would stay green — tests already
+# have the feature on, so they cannot notice.
+#
+# One line moving from `[dev-dependencies]` to `[dependencies]` is the whole
+# distance between a real gate and a decorative one.
+#
+# WHY THE RESOLVED GRAPH AND NOT A MANIFEST GREP
+#
+# Grepping Cargo.toml for `features = ["test-helpers"]` under `[dependencies]`
+# would miss transitive enabling — some other crate turning on
+# `portcullis-core/test-helpers` as a normal dep pulls
+# `nucleus-ifc-kernel/test-helpers` with it (portcullis-core/Cargo.toml declares
+# exactly that mapping). `cargo tree --edges features,no-dev` reports what a
+# production build actually resolves, which is the question being asked.
+#
+# A NOTE ON `cargo tree`
+#
+# `-e features` alone does NOT exclude dev edges; the default edge set still
+# includes them, so it reports `test-helpers` as present and looks alarming.
+# `no-dev` is the flag that answers "what does a production build see". This
+# script exists partly because that distinction cost a wrong conclusion once.
+#
+# Usage: scripts/check-test-helpers-not-in-production.sh
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel 2>/dev/null || echo .)"
+
+# Crates that ship and are on the agent effect path. A `DischargedBundle` minted
+# without preflight in any of these defeats the discharge boundary.
+CRATES=(nucleus-tool-proxy nucleus-node nucleus-mcp)
+
+violations=0
+for crate in "${CRATES[@]}"; do
+    if ! cargo metadata --no-deps --format-version 1 2>/dev/null \
+        | grep -q "\"name\":\"${crate}\""; then
+        echo "ERROR: $crate is not a workspace member — this gate is watching a crate that moved"
+        exit 1
+    fi
+
+    found=$(cargo tree --edges features,no-dev -p "$crate" 2>/dev/null \
+        | grep -c 'test-helpers' || true)
+
+    echo "test-helpers in $crate (production build): $found"
+    if [[ "$found" -ne 0 ]]; then
+        echo ""
+        echo "VIOLATION: $crate resolves \`test-helpers\` in a NON-dev build."
+        echo ""
+        echo "  discharge::test_helpers::bundle_for mints a DischargedBundle with no"
+        echo "  preflight. With this feature on in production, any code in $crate can"
+        echo "  mint the proof that broker_client::perform_line demands, and the"
+        echo "  compile-time obligation becomes decorative."
+        echo ""
+        echo "  Every test will still pass — tests already enable the feature, so they"
+        echo "  cannot see this. Find it with:"
+        echo "      cargo tree --edges features,no-dev -p $crate | grep -B5 test-helpers"
+        echo "  and move the enabling entry back to [dev-dependencies]."
+        violations=$((violations + 1))
+    fi
+done
+
+# NON-VACUITY. If `test-helpers` stopped existing, or the feature were renamed,
+# every check above would report 0 and this gate would pass while enforcing
+# nothing. So assert the feature is real AND that a dev build genuinely resolves
+# it — the same query that must return 0 above must return non-zero here.
+dev_found=$(cargo tree --edges features -p nucleus-tool-proxy 2>/dev/null \
+    | grep -c 'test-helpers' || true)
+if [[ "$dev_found" -eq 0 ]]; then
+    echo ""
+    echo "ERROR: \`test-helpers\` does not appear in nucleus-tool-proxy's DEV feature"
+    echo "graph either. The feature has been renamed or removed, so the checks above"
+    echo "are passing without enforcing anything. Update this gate to the new name."
+    exit 1
+fi
+echo "non-vacuity: dev build resolves test-helpers ($dev_found edges), production does not"
+
+if [[ "$violations" -gt 0 ]]; then
+    exit 1
+fi
+
+echo "OK: the discharge seal is not reachable from any shipping build"

--- a/scripts/mediation-vsock-allowlist.txt
+++ b/scripts/mediation-vsock-allowlist.txt
@@ -1,0 +1,22 @@
+# Mediation gate — VSOCK allowlist.
+#
+# Credentialed egress asks the HOST to perform a call, over vsock. A vsock
+# `write_all` is invisible to the `.send()` net pattern, so without this pattern
+# that egress left the gate's view at exactly the moment it began working.
+#
+# WHY THIS IS NOT REDUNDANT WITH THE TYPESTATE
+#
+# `broker_client::perform_line` takes an `Authority`, which is constructible only
+# from a `DischargedBundle` whose constructor is private to the discharge module.
+# So a TYPED perform with no discharge does not compile.
+#
+# That signature cannot see a hand-rolled frame: code that opens its own
+# VsockStream, formats the JSON itself and writes it never touches `perform_line`
+# and never needs an `Authority`. The typestate covers the typed path; this
+# covers the raw-primitive escape. Neither subsumes the other, and each is
+# perturbed on its own — a green from both together would otherwise say nothing
+# about which one is load-bearing.
+#
+# ONE ENTRY, and it should stay that way. A second sanctioned vsock client on the
+# agent path is a second thing that must remember to spend an authority.
+file:crates/nucleus-tool-proxy/src/broker_client.rs


### PR DESCRIPTION
**Increment 3 of four.** Stacked on #2160 → #2158 → #2157 → #2156. The guest no longer reads a credential; it asks the host to act and receives the result.

## The in-guest path is deleted, not kept as a fallback

`credential_for` was a `std::env::var` **inside the guest**. It is gone, along with `header_value` and their tests. A broker that applies only when a credential happens to be absent is *advisory*: an attacker who can arrange for the variable to be set restores exactly the exposure the broker removes. On Firecracker the value never reached the guest anyway, so that path could only ever fail closed there.

`this_module_cannot_read_a_credential_from_the_guest_environment` scans the production half of the file — a dead-but-present `credential_for` is one call site away from being a fallback again.

What survives unchanged is the part that matters: the kernel decision, the `preflight_web` discharge, and the `ModelPlan` taint observation on the response. A brokered call gets the same treatment a `web_fetch` gets, which is the half a plain credential-injecting gateway does not have.

## The discharge is spent, so it is also recorded

`perform_line` takes an `Authority`, not a `&DischargedBundle`. That required a receipt log the proxy did not have — `spend` refuses an unwitnessed authority, so **without one the brokered path would have failed on every request**: safe, and inert, which is the shape this arc has produced twice already.

`AppState` gains `receipts`. The in-memory limit is the one already recorded for FM-3 in `docs/production-delta.md`, not a new one — a `Result` that can never be `Err` would look like a guarantee and provide none.

## The idempotency key is derived, not random

From `(name, path, body)`, length-prefixed and hashed. A fresh random key per attempt would leave the host unable to tell a retry from a new request, and the entire ledger — reservation, TTL, capacity refusal — would run and be decoration. Length-prefixed so `("ab","c")` and `("a","bc")` cannot collide.

## A pod that cannot perform egress refuses to START

Beside `reject_bypassable_upstreams`, for the same reason it is there. With the in-guest path gone, a pod with credentialed upstreams and no broker capability fails every request the moment its workload makes one — an application error, minutes in, four layers from the pod spec that caused it.

The container driver is what this affects: `broker_identity` refuses a pod with no host-established identity and that driver registers none. Giving it one is a design question, not wiring — a Firecracker identity comes with an attested SVID and a default-deny netns and a container has neither, so the identity would assert what the driver cannot back. **A loud refusal beats a silent per-request failure.**

## The mediation gate could no longer see this egress

`check-mediation.sh` greps for `.send()`. A vsock `write_all` is invisible to it, so credentialed egress **left the gate's view at exactly the moment it started working**. Third pattern added: `VsockStream::connect`, with the sanctioned client file allowlisted.

**Not redundant with the typestate, and that is the point.** `perform_line`'s signature stops a *typed* call with no discharge; the gate stops a *hand-rolled frame* that never touches the typed API. Neither covers the other's hole, so each was perturbed alone rather than trusting a green from both together.

## Verification

Perturbations, each RED at a named location: a hand-rolled `VsockStream::connect` in `egress.rs` (gate exit 1, restored 0); the startup refusal exercised with a broker present and with no upstreams configured, as the two controls that stop it refusing everything.

The source scanner caught its own scope bug first — it read the test module, where fixtures legitimately name `credential_env`, so it now reads the production half only.

fmt, six gates, macOS + Linux (OrbStack) clippy `--workspace --all-targets --all-features -D warnings`, `cargo test --all-features` (222 suites, 0 failures; 306 tool-proxy and 287 node tests on Linux).