### PR TITLE
Two flagship proofs were never built, and a build failure reported success

### DIFF
--- a/.github/workflows/aeneas-ifc-scoped.yml
+++ b/.github/workflows/aeneas-ifc-scoped.yml
@@ -376,7 +376,29 @@ jobs:
           # (a real hole shows up as `sorryAx`); this is belt-and-suspenders and
           # must NOT false-positive on the file's own honest prose discussing
           # `sorryAx` / "sorry-free" (a plain substring grep does, and did).
-          if grep -rnE '(:=|=>|\bby\b|<;>|·|;|^)[[:space:]]*(sorry|admit)\b|\bnative_decide\b' \
+          # `native_decide` now shares the TACTIC-CONTEXT guard with sorry/admit.
+          # It did not, and the comment above already knew why that matters: this
+          # step fired on the two files' own prose EXPLAINING that native_decide
+          # is NOT used —
+          #
+          #   EgressConfinementExtracted.lean:268  `native_decide` ... is not used
+          #   CredentialNoninterferenceExtracted.lean:146  `native_decide` was
+          #     written first ... and then removed
+          #
+          # A gate that fires on the explanation of the property it checks is the
+          # same defect as one that never fires: neither is about the code.
+          #
+          # `^` was INSIDE the alternation group, where it does not anchor — so a
+          # bare tactic on its own line was missed entirely:
+          #
+          #     theorem t : True := by
+          #       sorry            <- NOT caught by the previous pattern
+          #
+          # That hole predates this change and applied to sorry/admit too. It is
+          # mitigated — a real hole shows up as `sorryAx` in the axiom audit above,
+          # which is the authoritative check — but a backstop that misses the most
+          # ordinary formatting of the thing it looks for is not backstopping.
+          if grep -rnE '((:=|=>|\bby\b|<;>|·|;)[[:space:]]*|^[[:space:]]*)(sorry|admit|native_decide)\b' \
                IntegrityNoninterferenceExtracted.lean \
                MediationScopeExtracted.lean \
                EgressConfinementExtracted.lean \

--- a/.github/workflows/aeneas-ifc-scoped.yml
+++ b/.github/workflows/aeneas-ifc-scoped.yml
@@ -321,7 +321,36 @@ jobs:
           # `|| true` because a grep matching nothing exits 1, and under pipefail
           # that would fail the assignment and RED a clean log — verified against
           # a clean log rather than assumed.
-          bad=$(grep -hoE "depends on axioms: \[[^]]*\]" $LOGS \
+          # FLATTEN NEWLINES FIRST. Lean WRAPS long axiom lists:
+          #
+          #   'thm' depends on axioms: [propext,
+          #    Classical.choice,
+          #    Quot.sound]
+          #
+          # A line-based `grep -o` never matches those — no closing `]` on the
+          # line — so it silently audits only the unwrapped ones. Measured on the
+          # real output: 3 of 7 credential theorems matched before this fix, and
+          # the step still reported success, because "found no bad axiom" is true
+          # of the four it never looked at.
+          #
+          # Every fixture I invented for this check was single-line. The real
+          # build is what found it.
+          flat=$(cat $LOGS | tr '\n' ' ')
+
+          # SELF-CONSISTENCY, which is what would have caught the above at once:
+          # the number of axiom lists EXTRACTED must equal the number PRINTED. A
+          # parser that silently drops entries fails here instead of passing.
+          printed=$(grep -hc "depends on axioms" $LOGS | paste -sd+ - | bc)
+          extracted=$(printf '%s' "$flat" | grep -oE "depends on axioms: \[[^]]*\]" | wc -l | tr -d ' ')
+          if [ "$printed" != "$extracted" ]; then
+            echo "ERROR: $printed theorems printed an axiom profile but only $extracted were"
+            echo "parsed. The extraction is dropping entries, so the audit below is"
+            echo "asserting nothing about the difference."
+            exit 1
+          fi
+          echo "Axiom profiles parsed: $extracted of $printed printed."
+
+          bad=$(printf '%s' "$flat" | grep -oE "depends on axioms: \[[^]]*\]" \
                 | sed -E 's/.*\[([^]]*)\]/\1/' | tr ',' '\n' | sed 's/^ *//;s/ *$//' \
                 | grep -vE "^($ALLOWED)$" | grep -v '^$' | sort -u || true)
           if [ -n "$bad" ]; then

--- a/.github/workflows/aeneas-ifc-scoped.yml
+++ b/.github/workflows/aeneas-ifc-scoped.yml
@@ -229,25 +229,77 @@ jobs:
 
       - name: lake build (extracted core + theorem)
         working-directory: crates/portcullis-core/lean
+        # `shell: bash` is LOAD-BEARING, not style. GitHub's default `run` shell
+        # is `bash -e {0}` — `-e` WITHOUT pipefail — so `lake build X | tee log`
+        # reports TEE's exit status and a failed build passed this step. Naming
+        # the shell explicitly gets `bash --noprofile --norc -eo pipefail {0}`.
+        #
+        # Demonstrated rather than assumed:
+        #   bash -e         -c 'false | tee /dev/null; echo $?'  -> 0
+        #   bash -eo pipefail -c 'false | tee /dev/null; echo $?' -> 1
+        #
+        # Every target below is piped to `tee` so the axiom audit can read the
+        # log, so every one of them was affected.
+        shell: bash
         run: |
           lake build PortcullisCoreIFC
           lake build IntegrityNoninterferenceExtracted 2>&1 | tee /tmp/lake-ifc.log
           lake build ConfidentialityNoninterferenceExtracted 2>&1 | tee /tmp/lake-conf-ifc.log
           lake build MediationScopeExtracted 2>&1 | tee /tmp/lake-mediation.log
+          # These two were listed in this workflow's `paths:` triggers and built
+          # by NOTHING — editing either fired a job that did not compile it. They
+          # back docs/production-delta.md rows 9 (egress confinement) and 36
+          # (FM-1 credential noninterference), whose quoted axiom profiles were
+          # therefore transcribed rather than produced by a run.
+          lake build PortcullisCoreEgress
+          lake build EgressConfinementExtracted 2>&1 | tee /tmp/lake-egress.log
+          lake build PortcullisCoreCredential
+          lake build CredentialNoninterferenceExtracted 2>&1 | tee /tmp/lake-credential.log
 
       # The #print axioms commands are in the .lean file; their output lands in
       # the build log above. Surface it explicitly and fail on a dirty axiom set.
       - name: Assert clean axiom set (no sorryAx / opaque axioms)
         working-directory: crates/portcullis-core/lean
+        shell: bash
         run: |
-          echo "=== #print axioms output (from build log) ==="
-          grep -nE "axioms|sorryAx|propext|Quot\.sound|Classical\.choice|External" /tmp/lake-ifc.log || true
-          grep -nE "axioms|sorryAx|propext|Quot\.sound|Classical\.choice|External" /tmp/lake-mediation.log || true
-          if grep -qE "sorryAx|External" /tmp/lake-ifc.log /tmp/lake-mediation.log; then
+          LOGS="/tmp/lake-ifc.log /tmp/lake-mediation.log /tmp/lake-egress.log /tmp/lake-credential.log"
+
+          # NON-VACUITY FIRST. Every check below is "the log does not contain a
+          # bad string", and an EMPTY log satisfies all of them — which is
+          # exactly what a failed or skipped build produces. So require positive
+          # evidence that `#print axioms` actually ran before believing its
+          # silence about sorryAx.
+          for log in $LOGS; do
+            if [ ! -s "$log" ]; then
+              echo "ERROR: $log is missing or empty. The build did not run, so the"
+              echo "axiom assertions below would pass by saying nothing."
+              exit 1
+            fi
+            if ! grep -qE "^'[^']+' depends on axioms|depends on axioms" "$log"; then
+              echo "ERROR: $log contains no '#print axioms' output. The theorems it"
+              echo "should audit were not elaborated, so this step is asserting"
+              echo "nothing about them."
+              exit 1
+            fi
+          done
+
+          echo "=== #print axioms output (from build logs) ==="
+          for log in $LOGS; do
+            echo "--- $log ---"
+            grep -nE "axioms|sorryAx|propext|Quot\.sound|Classical\.choice|External" "$log" || true
+          done
+
+          if grep -qE "sorryAx|External" $LOGS; then
             echo "ERROR: dirty axiom set — sorryAx or an opaque *External axiom is on the proof's critical path."
             exit 1
           fi
           echo "No sorryAx / opaque-External axiom detected in the axiom audit."
+          # FOLLOW-UP, stated rather than silently skipped: this asserts the
+          # absence of sorryAx/External, not that the printed axiom SET equals
+          # the one docs/production-delta.md quotes. Pinning the exact set needs
+          # the real output from a run — and the documented profiles have never
+          # been produced by one, so encoding them now would pin a transcription.
+          # The profiles printed above are that ground truth; pin them next.
 
       - name: Reject sorry (proof holes)
         working-directory: crates/portcullis-core/lean
@@ -261,8 +313,12 @@ jobs:
           if grep -rnE '(:=|=>|\bby\b|<;>|·|;|^)[[:space:]]*(sorry|admit)\b|\bnative_decide\b' \
                IntegrityNoninterferenceExtracted.lean \
                MediationScopeExtracted.lean \
+               EgressConfinementExtracted.lean \
+               CredentialNoninterferenceExtracted.lean \
                generated-ifc/PortcullisCoreIFC/ \
-               generated-mediation/PortcullisCoreMediation/ --include='*.lean'; then
+               generated-mediation/PortcullisCoreMediation/ \
+               generated-egress/PortcullisCoreEgress/ \
+               generated-credential/PortcullisCoreCredential/ --include='*.lean'; then
             echo "ERROR: proof contains a sorry/admit/native_decide tactic."
             exit 1
           fi

--- a/.github/workflows/aeneas-ifc-scoped.yml
+++ b/.github/workflows/aeneas-ifc-scoped.yml
@@ -294,12 +294,49 @@ jobs:
             exit 1
           fi
           echo "No sorryAx / opaque-External axiom detected in the axiom audit."
-          # FOLLOW-UP, stated rather than silently skipped: this asserts the
-          # absence of sorryAx/External, not that the printed axiom SET equals
-          # the one docs/production-delta.md quotes. Pinning the exact set needs
-          # the real output from a run — and the documented profiles have never
-          # been produced by one, so encoding them now would pin a transcription.
-          # The profiles printed above are that ground truth; pin them next.
+
+          # EVERY axiom named must be on the clean-Lean allowlist.
+          #
+          # An ALLOWLIST (subset), not the expected SET (equality). The two are
+          # not the same decision and only one of them is safe to make today:
+          #
+          # * Equality would pin what docs/production-delta.md QUOTES — and those
+          #   profiles have never been produced by a run, so pinning them encodes
+          #   a transcription. If reality differs CI reds for the wrong reason,
+          #   and the natural response is to edit the gate to match, which trains
+          #   people to silence gates rather than read them.
+          # * Subset needs no ground truth: it passes whichever subset is really
+          #   printed. It cannot red for the wrong reason, and it still catches
+          #   everything the grep above misses.
+          #
+          # What the grep above does NOT catch and this does: `Lean.ofReduceBool`
+          # (introduced by `native_decide`), which matches neither `sorryAx` nor
+          # `External`. The textual scan below covers these four proof files and
+          # their generated dirs; a `native_decide` in a dependency OUTSIDE those
+          # paths would land in the profile and pass unremarked without this.
+          #
+          # These three are the standard clean-Lean axiom set, so the allowlist
+          # is not a guess about these particular files.
+          ALLOWED="propext|Classical.choice|Quot.sound"
+          # `|| true` because a grep matching nothing exits 1, and under pipefail
+          # that would fail the assignment and RED a clean log — verified against
+          # a clean log rather than assumed.
+          bad=$(grep -hoE "depends on axioms: \[[^]]*\]" $LOGS \
+                | sed -E 's/.*\[([^]]*)\]/\1/' | tr ',' '\n' | sed 's/^ *//;s/ *$//' \
+                | grep -vE "^($ALLOWED)$" | grep -v '^$' | sort -u || true)
+          if [ -n "$bad" ]; then
+            echo "ERROR: axiom(s) outside the clean set on a proof's critical path:"
+            echo "$bad" | sed 's/^/  /'
+            echo "Allowed: propext, Classical.choice, Quot.sound."
+            echo "If one of these is genuinely intended, widening the allowlist is a"
+            echo "decision to record in docs/production-delta.md, not a CI edit."
+            exit 1
+          fi
+          echo "Every axiom named is on the clean-Lean allowlist."
+
+          # STILL NOT DONE, and deliberately: asserting the set EQUALS what the
+          # docs quote. That needs ground truth from a run. The profiles printed
+          # above are it — pin them in a follow-up, with a real log as input.
 
       - name: Reject sorry (proof holes)
         working-directory: crates/portcullis-core/lean


### PR DESCRIPTION
The strongest-sounding evidence in this repo — machine-checked theorems with quoted axiom profiles — was the evidence least connected to anything that ran.

## Neither proof was compiled by any job

`CredentialNoninterferenceExtracted.lean` and `EgressConfinementExtracted.lean` appear in `aeneas-ifc-scoped.yml` **only in its `paths:` triggers** (lines 41–42, 55–56). The build step at 233–236 compiled four *other* libraries. Across every workflow there were **zero** `lake build` sites naming these two, or their generated dependencies `PortcullisCoreEgress` / `PortcullisCoreCredential` — which had no workflow mention at all.

So editing either proof fired a job that did not compile it.

They back `docs/production-delta.md` row 9 (egress confinement, 8 theorems) and row 36 — **FM-1 credential noninterference, the flagship formal claim**: *"Seven theorems … all `[propext, Classical.choice, Quot.sound]`, zero `sorry`, 0 opaque functions."* Those profiles were transcribed from some local run.

Everything else was already in place — both `lean_lib` targets declared, both generated directories committed, `#print axioms` written in both files. Only the build was missing.

## And the three that *were* built could not fail

Found while fixing the above. Every theorem target is piped to `tee` so the axiom audit can read the log, and GitHub's default `run` shell is `bash -e {0}` — `-e` **without** pipefail. The pipeline reports *tee's* exit status.

Demonstrated rather than argued:

```
bash -e           -c 'false | tee /dev/null; echo $?'   -> 0
bash -eo pipefail -c 'false | tee /dev/null; echo $?'   -> 1
```

None of the three Lean workflows sets `shell: bash`. So a type error in `IntegrityNoninterferenceExtracted`, `ConfidentialityNoninterferenceExtracted` or `MediationScopeExtracted` passed the build step — and then passed the axiom step too, because that step only asks whether a log *contains* `sorryAx`, and a log that was never written contains nothing.

## The axiom assertion was satisfied by silence

"The log does not contain `sorryAx`" is true of an empty file. Same shape as `check_art12_witnessed`, which asserts non-vacuity **first** for exactly this reason.

The step now requires positive evidence — each log must exist, be non-empty, and contain `#print axioms` output — before believing its silence. Verified against four log states rather than reasoned about:

| log | meaning | exit |
|---|---|---|
| `good.log` | real axiom output | 0 |
| `empty.log` | build never ran | 1 |
| `buildfail.log` | compile error | 1 |
| `dirty.log` | `sorryAx` present | 1 |

The middle two are the ones that used to pass.

## Deliberately not done

Pinning the exact axiom **set** against what the docs quote. That needs the real output from a run, and the documented profiles have never been produced by one — encoding them now would pin a transcription rather than a fact. The step prints the profiles prominently; pinning them is the next change, once there is ground truth to pin.

## Provenance

The missing builds were found by an adversarial subagent sweep and verified independently here (every `lake build` site enumerated; the two files' only mentions confirmed to be `paths:` triggers). The pipefail masking was found while implementing the fix.

The sweep's own verifier corrected two overreaches in the finding it confirmed, which is why it was worth trusting: a **literal** `sorry` token *is* caught by `portcullis-core-proven-lean.yml`'s whole-tree textual scan, so the gap was always the kernel check specifically.