### PR TITLE
The broker capability is affine, and the compiler says so

### DIFF
--- a/crates/nucleus-node/src/broker_launch.rs
+++ b/crates/nucleus-node/src/broker_launch.rs
@@ -161,34 +161,88 @@ pub fn on_start_failure(rollout: BrokerRollout) -> StartFailure {
 /// consumers provably the same secret rather than coincidentally the same
 /// secret. `mint_appears_exactly_once_on_the_spawn_path` covers the one hole
 /// this shape leaves: calling [`Self::mint`] twice.
-#[derive(Debug, Clone)]
-pub struct BrokerCapability {
+///
+/// # Affine, not linear — and the difference is worth stating
+///
+/// This derived `Clone` and handed out copies through `&self`, so it was freely
+/// duplicable: "one value with two projections" described the intent, not the
+/// type. It is now a PAIR of move-only tokens, neither `Clone` nor `Copy`, each
+/// consumed by value. Duplication is a compile error.
+///
+/// What Rust gives is AFFINE — used at most once. Linear — used *exactly* once,
+/// with the two tokens provably from the same mint — needs either an
+/// invariant-lifetime brand (which requires a closure-shaped scope the async pod
+/// spawn path does not naturally take) or a runtime check, which is not a proof.
+/// So the residual hole is calling [`Self::mint`] twice and handing one consumer
+/// a token from each; `mint_appears_exactly_once_on_the_spawn_path` covers it by
+/// counting, and that test survives precisely because the type cannot.
+///
+/// True linearity lives in the model, not here. That asymmetry is the reason a
+/// proved model↔code correspondence matters rather than being a nicety: it is
+/// what would let the Lean side's linearity say anything about this side's
+/// affineness.
+pub struct BrokerCapability;
+
+/// The token the workload API serves to the guest. Move-only, consumed once.
+#[must_use = "a ServeToken that is never served is a capability the guest never gets"]
+pub struct ServeToken {
     secret: String,
 }
 
+/// The token the broker listener verifies against. Move-only, consumed once.
+#[must_use = "a VerifyToken that is never installed leaves the verifier with nothing, \
+              which is exactly the defect BrokerCapability exists to prevent"]
+pub struct VerifyToken {
+    secret: String,
+}
+
+impl std::fmt::Debug for ServeToken {
+    /// Never the value, and never its length.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("ServeToken(<redacted>)")
+    }
+}
+
+impl std::fmt::Debug for VerifyToken {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("VerifyToken(<redacted>)")
+    }
+}
+
+impl ServeToken {
+    /// Consume the token, yielding the value served to the guest exactly once.
+    #[must_use]
+    pub fn into_served(self) -> String {
+        self.secret
+    }
+}
+
+impl VerifyToken {
+    /// Consume the token, yielding the key the listener authenticates with.
+    #[must_use]
+    pub fn into_verifier(self) -> std::sync::Arc<Vec<u8>> {
+        std::sync::Arc::new(self.secret.into_bytes())
+    }
+}
+
 impl BrokerCapability {
-    /// Mint a fresh capability for one pod.
+    /// Mint a fresh capability for one pod, as a linked pair.
+    ///
+    /// Returns BOTH tokens because there is no use for one without the other:
+    /// a served capability no verifier holds is what made this inert, and a
+    /// verifier with a capability nobody was served refuses every frame.
     ///
     /// Per-pod and never reused: two pods sharing one would let either sign for
-    /// the other, and the listener's identity binding — one socket per VM — would
-    /// stop meaning anything.
-    #[must_use]
-    pub fn mint() -> Self {
-        Self {
-            secret: uuid::Uuid::new_v4().simple().to_string(),
-        }
-    }
-
-    /// The copy the workload API serves to the guest, exactly once.
-    #[must_use]
-    pub fn to_serve(&self) -> String {
-        self.secret.clone()
-    }
-
-    /// The copy the broker listener verifies signatures against.
-    #[must_use]
-    pub fn to_verify(&self) -> std::sync::Arc<Vec<u8>> {
-        std::sync::Arc::new(self.secret.as_bytes().to_vec())
+    /// the other, and the listener's identity binding — one socket per VM —
+    /// would stop meaning anything.
+    pub fn mint() -> (ServeToken, VerifyToken) {
+        let secret = uuid::Uuid::new_v4().simple().to_string();
+        (
+            ServeToken {
+                secret: secret.clone(),
+            },
+            VerifyToken { secret },
+        )
     }
 }
 
@@ -262,7 +316,7 @@ pub fn start_broker_for_pod(
     vsock_path: &std::path::Path,
     registered: Option<&nucleus_identity::Identity>,
     id: uuid::Uuid,
-    capability: &BrokerCapability,
+    capability: VerifyToken,
     jail_owner: Option<(u32, u32)>,
 ) -> Result<Option<crate::broker_transport::BrokerListener>, crate::ApiError> {
     let transport = if spec.spec.vsock.is_some() {
@@ -329,7 +383,7 @@ pub fn start_broker_for_pod(
             upstreams,
             // The SAME value the workload API serves the guest. Passing `None`
             // here is what made the capability inert; see `BrokerCapability`.
-            broker_secret: capability.to_verify(),
+            broker_secret: capability.into_verifier(),
         },
         jail_owner,
     ) {
@@ -364,10 +418,12 @@ mod broker_capability {
     /// the bridge minted its own and the listener got `None`.
     #[test]
     fn what_is_served_is_what_is_verified() {
-        let cap = BrokerCapability::mint();
+        let (serve, verify) = BrokerCapability::mint();
+        let served = serve.into_served();
+        let verifier = verify.into_verifier();
         assert_eq!(
-            cap.to_serve().as_bytes(),
-            cap.to_verify().as_slice(),
+            served.as_bytes(),
+            verifier.as_slice(),
             "the guest would hold a capability the verifier cannot recognise"
         );
     }
@@ -378,9 +434,59 @@ mod broker_capability {
     #[test]
     fn two_pods_do_not_share_a_capability() {
         assert_ne!(
-            BrokerCapability::mint().to_serve(),
-            BrokerCapability::mint().to_serve()
+            BrokerCapability::mint().0.into_served(),
+            BrokerCapability::mint().0.into_served()
         );
+    }
+
+    /// **The tokens cannot be duplicated, and the COMPILER says so.**
+    ///
+    /// This type derived `Clone` and served copies through `&self`, so "one value
+    /// with two projections" described the intent and not the property: any
+    /// holder could make as many capabilities as it liked.
+    ///
+    /// # This was a source scan, and it did not need to be
+    ///
+    /// The first version grepped the declarations for `Clone`/`Copy`, on the
+    /// belief that "does not implement a trait" is not assertable in Rust. That
+    /// is false. The `static_assertions` crate's `assert_not_impl_any!` does it
+    /// on stable via deliberate inference ambiguity, and the trick is ten lines,
+    /// so it is inlined here rather than adding a dependency to a crate that
+    /// links credential material.
+    ///
+    /// How it works: two blanket impls that overlap ONLY when `T: Clone`. If the
+    /// token is `Clone`, both apply, the type parameter cannot be inferred, and
+    /// the build fails. If it is not, exactly one applies and this resolves.
+    ///
+    /// The failure therefore moves from a test to the compiler — a grep enforcing
+    /// a type-level property was a confession, and this retires it.
+    ///
+    /// # What this does NOT establish
+    ///
+    /// Affine, not linear. Rust enforces at-most-once; it does not enforce that
+    /// the two tokens came from the SAME mint. That needs an invariant-lifetime
+    /// brand — reachable with `generativity`'s Drop-guard macro, which needs no
+    /// closure — so `mint_appears_exactly_once_on_the_spawn_path` below is
+    /// deletable debt rather than a permanent limit.
+    #[test]
+    fn the_tokens_are_move_only() {
+        trait AmbiguousIfClone<A> {
+            fn some_item() {}
+        }
+        impl<T: ?Sized> AmbiguousIfClone<()> for T {}
+        impl<T: Clone> AmbiguousIfClone<u8> for T {}
+
+        // Each line fails to COMPILE if that token becomes duplicable.
+        let _ = <ServeToken as AmbiguousIfClone<_>>::some_item;
+        let _ = <VerifyToken as AmbiguousIfClone<_>>::some_item;
+
+        // NON-VACUITY, and it was run rather than assumed. A test cannot contain
+        // its own compile error, so the control is a perturbation: uncommenting
+        // the line below — `String` IS `Clone` — must fail to build. Measured:
+        // `error[E0283]: type annotations needed`, the same error that
+        // re-deriving `Clone` on a token produces. So the two assertions above
+        // are not passing by failing to work.
+        //   let _ = <String as AmbiguousIfClone<_>>::some_item;
     }
 
     /// **The hole this type's shape leaves, closed by counting.**

--- a/crates/nucleus-node/src/main.rs
+++ b/crates/nucleus-node/src/main.rs
@@ -2595,7 +2595,7 @@ async fn spawn_firecracker_pod(
         // different blocks below, and this used to be exactly the gap they fell
         // into — the bridge minted its own while the listener got `None`, so the
         // guest held a capability the verifier had never seen.
-        let broker_capability = broker_launch::BrokerCapability::mint();
+        let (broker_serve, broker_verify) = broker_launch::BrokerCapability::mint();
 
         let (pod_identity, identity_manager, workload_api_bridge) = if let Some(manager) =
             identity_source
@@ -2681,7 +2681,7 @@ async fn spawn_firecracker_pod(
                     // The broker capability, minted per pod and served ONCE. See
                     // `handle_fetch_broker_secret`: this is what lets the host
                     // tell the mediating proxy from every other guest process.
-                    broker_secret: Some(broker_capability.to_serve()),
+                    broker_secret: Some(broker_serve.into_served()),
                     // Served WITH the capability, not separately — the proxy
                     // needs both to reach the broker and neither is useful alone.
                     broker_port: state.broker_vsock_port,
@@ -2802,7 +2802,7 @@ async fn spawn_firecracker_pod(
             &vsock_path,
             pod_identity.as_ref(),
             id,
-            &broker_capability,
+            broker_verify,
             // The SAME expression the workload API bridge uses. That socket was
             // chowned and this one was not, which is why no guest could have
             // reached the broker under the jailer.


### PR DESCRIPTION
Stacked on #2161. A first rung on making the capability a *proof-carrying construction* rather than a convention — it replaces two runtime checks with compile errors, and more usefully establishes exactly where that rung ends.

## "One value with two projections" was intent, not property

`BrokerCapability` derived `Clone` and served copies through `&self`. Any holder could mint as many capabilities as it liked. The phrase described what I meant; the type permitted the opposite.

It is now a pair of move-only tokens: `mint() -> (ServeToken, VerifyToken)`, neither `Clone` nor `Copy`, each consumed by value. Consuming one twice is `error[E0382]: use of moved value` — **no test involved**.

## The `Clone` check was a grep, and it did not need to be

`the_tokens_are_move_only` scanned the source for a derive list, on the belief that "does not implement a trait" is not assertable in Rust. **That is false.** [`static_assertions::assert_not_impl_any!`](https://docs.rs/static_assertions/) does it on stable via deliberate inference ambiguity, and the trick is ten lines — so it is inlined rather than adding a dependency to a crate that links credential material.

Two blanket impls that overlap only when `T: Clone`. If a token becomes duplicable, the type parameter cannot be inferred and the build fails.

**Non-vacuity was run, not assumed.** A test cannot contain its own compile error, so the control is a perturbation: the same construction against `String` — which *is* `Clone` — must fail to build. It does, with the same `error[E0283]` that re-deriving `Clone` on a token produces.

## Where the rung ends, stated rather than implied

**Affine, not linear.** Rust enforces at-most-once; it does not enforce that the two tokens came from the *same* mint. So `mint_appears_exactly_once_on_the_spawn_path` — a test that counts call sites — survives, because the type cannot express what it checks.

I had recorded that as a permanent limit requiring a closure-shaped scope the async spawn path won't take. **That's wrong:** [`generativity`](https://docs.rs/generativity/)'s `make_guard!` mints an invariant-lifetime brand with a macro and a `Drop` scope guard, no closure. So the counting test is *deletable debt*, not a boundary. It stays for now because the dependency lands in credential-adjacent code, and the `Drop`-guard's survival across an `await` point should be measured before adding it.

## Also fixed, both caught by the compiler and not by me

`double_must_use` on `mint` (the tokens carry their own messages), and `?Sized + Clone` where `Clone: Sized` makes the bound meaningless.

## Verification

| perturbation | result |
|---|---|
| consume a token twice | `error[E0382]` at compile time |
| re-derive `Clone` on a token | `error[E0283]` |
| the `String` non-vacuity control | `error[E0283]` |

fmt, six gates, macOS + Linux (OrbStack) clippy `--workspace --all-targets --all-features -D warnings`, `cargo test --all-features` (222 suites, 0 failures; 288 node tests on Linux).

Re-run on a **frozen tree** — two earlier gate runs reported `MACOS_CLIPPY=101` because I edited files while they were in flight, so their answers described a tree that no longer existed.