### PR TITLE
Three more gates could not fail, including vendor neutrality

### DIFF
--- a/.github/workflows/aeneas-oidc-spiffe.yml
+++ b/.github/workflows/aeneas-oidc-spiffe.yml
@@ -176,13 +176,36 @@ jobs:
 
       - name: lake build (extracted core + theorems)
         working-directory: crates/nucleus-github-oidc/lean
+        # `shell: bash` is LOAD-BEARING. GitHub's default `run` shell is
+        # `bash -e {0}` — `-e` WITHOUT pipefail — so `lake build X | tee log`
+        # reports TEE's status and a failed build PASSED this step. Naming the
+        # shell gets `bash --noprofile --norc -eo pipefail {0}`.
+        #
+        #   bash -e           -c 'false | tee /dev/null; echo $?'  -> 0
+        #   bash -eo pipefail -c 'false | tee /dev/null; echo $?'  -> 1
+        shell: bash
         run: |
           lake build NucleusGithubOidc
           lake build OidcSpiffeProofs 2>&1 | tee /tmp/lake-oidc.log
 
       - name: Assert clean axiom set (no sorryAx / opaque axioms)
         working-directory: crates/nucleus-github-oidc/lean
+        shell: bash
         run: |
+          # NON-VACUITY FIRST. Every check below is "the log does not contain a
+          # bad string", and an EMPTY log satisfies all of them — which is what a
+          # failed build produces. Require positive evidence that `#print axioms`
+          # actually ran before believing its silence.
+          if [ ! -s /tmp/lake-oidc.log ]; then
+            echo "ERROR: /tmp/lake-oidc.log is missing or empty — the build did not run,"
+            echo "so the assertions below would pass by saying nothing."
+            exit 1
+          fi
+          if ! grep -q "depends on axioms" /tmp/lake-oidc.log; then
+            echo "ERROR: no '#print axioms' output in the build log. The theorems were"
+            echo "not elaborated, so this step asserts nothing about them."
+            exit 1
+          fi
           echo "=== #print axioms output (from build log) ==="
           grep -nE "axioms|sorryAx|propext|Quot\.sound|Classical\.choice|External" /tmp/lake-oidc.log || true
           if grep -qE "sorryAx|External" /tmp/lake-oidc.log; then

--- a/.github/workflows/coverage-matrix.yml
+++ b/.github/workflows/coverage-matrix.yml
@@ -145,7 +145,30 @@ jobs:
             -- --all-features 2>&1 | tee /tmp/mutants.txt
       - name: Check for survived mutants
         if: always()
+        shell: bash
         run: |
+          # NON-VACUITY FIRST, and this step needed it more than most.
+          #
+          # The gate below is `grep -q SURVIVED || pass`. A cargo-mutants run that
+          # CRASHED, timed out, or failed to build writes no SURVIVED line — so
+          # the else branch fired and reported "All mutants caught by tests."
+          # Absence satisfied by silence: the strongest-sounding result in this
+          # job was the one a total failure also produced.
+          #
+          # The `| tee` on the run step compounded it: without pipefail that step
+          # reported TEE's exit status, so a crashed run did not fail there either.
+          if [ ! -s /tmp/mutants.txt ]; then
+            echo "::error::/tmp/mutants.txt is missing or empty — cargo-mutants did not"
+            echo "::error::produce a report, so 'no survived mutants' means nothing."
+            exit 1
+          fi
+          if ! grep -qE "MISSED|CAUGHT|SURVIVED|Found [0-9]+ mutants|mutants tested" /tmp/mutants.txt; then
+            echo "::error::/tmp/mutants.txt contains no cargo-mutants result markers — the"
+            echo "::error::run did not complete, so this check is asserting nothing."
+            sed -n '1,20p' /tmp/mutants.txt
+            exit 1
+          fi
+
           echo "## Mutation Testing Report" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "**Modules tested:** capability, guard, lattice, certificate, delegation, trust" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/oidc-gates.yml
+++ b/.github/workflows/oidc-gates.yml
@@ -43,6 +43,13 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Run no-vendor-strings.sh
         id: gate
+        # `shell: bash` is LOAD-BEARING. The default `run` shell is `bash -e {0}`
+        # — no pipefail — so `bash ci/<gate>.sh ... | tee gate-output.txt` reports
+        # TEE's status. The gate script's `exit 1` was DISCARDED, this step
+        # passed, and the `if: failure()` PR-comment step below therefore never
+        # fired: the failure was silent twice over. `continue-on-error: false`
+        # did not help, because the step SUCCEEDED.
+        shell: bash
         run: |
           bash ci/no-vendor-strings.sh \
             crates/nucleus-oidc-provider \
@@ -83,6 +90,13 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Run alg-pin-check.sh
         id: gate
+        # `shell: bash` is LOAD-BEARING. The default `run` shell is `bash -e {0}`
+        # — no pipefail — so `bash ci/<gate>.sh ... | tee gate-output.txt` reports
+        # TEE's status. The gate script's `exit 1` was DISCARDED, this step
+        # passed, and the `if: failure()` PR-comment step below therefore never
+        # fired: the failure was silent twice over. `continue-on-error: false`
+        # did not help, because the step SUCCEEDED.
+        shell: bash
         run: |
           bash ci/alg-pin-check.sh \
             crates/nucleus-oidc-provider \

--- a/crates/nucleus-oidc-core/src/spiffe_federation.rs
+++ b/crates/nucleus-oidc-core/src/spiffe_federation.rs
@@ -82,14 +82,14 @@ use crate::jwks::Jwks;
 /// silently downgraded). This is a transitive-dependency capability gap,
 /// not a security decision; revisit if the backend gains P-521.
 pub const ALLOWED_ALGS: &[Algorithm] = &[
-    Algorithm::RS256,
-    Algorithm::RS384,
-    Algorithm::RS512,
-    Algorithm::ES256,
-    Algorithm::ES384,
-    Algorithm::PS256,
-    Algorithm::PS384,
-    Algorithm::PS512,
+    Algorithm::RS256, // alg-pin-allow: JWT-SVID verification allowlist, not OP signing — EdDSA is out of spec for JWT-SVID (see the doc comment above); the T04 EdDSA-exclusive rule governs what the OP SIGNS, not what a federated SPIFFE issuer may have signed.
+    Algorithm::RS384, // alg-pin-allow: JWT-SVID verification allowlist, not OP signing — EdDSA is out of spec for JWT-SVID (see the doc comment above); the T04 EdDSA-exclusive rule governs what the OP SIGNS, not what a federated SPIFFE issuer may have signed.
+    Algorithm::RS512, // alg-pin-allow: JWT-SVID verification allowlist, not OP signing — EdDSA is out of spec for JWT-SVID (see the doc comment above); the T04 EdDSA-exclusive rule governs what the OP SIGNS, not what a federated SPIFFE issuer may have signed.
+    Algorithm::ES256, // alg-pin-allow: JWT-SVID verification allowlist, not OP signing — EdDSA is out of spec for JWT-SVID (see the doc comment above); the T04 EdDSA-exclusive rule governs what the OP SIGNS, not what a federated SPIFFE issuer may have signed.
+    Algorithm::ES384, // alg-pin-allow: JWT-SVID verification allowlist, not OP signing — EdDSA is out of spec for JWT-SVID (see the doc comment above); the T04 EdDSA-exclusive rule governs what the OP SIGNS, not what a federated SPIFFE issuer may have signed.
+    Algorithm::PS256, // alg-pin-allow: JWT-SVID verification allowlist, not OP signing — EdDSA is out of spec for JWT-SVID (see the doc comment above); the T04 EdDSA-exclusive rule governs what the OP SIGNS, not what a federated SPIFFE issuer may have signed.
+    Algorithm::PS384, // alg-pin-allow: JWT-SVID verification allowlist, not OP signing — EdDSA is out of spec for JWT-SVID (see the doc comment above); the T04 EdDSA-exclusive rule governs what the OP SIGNS, not what a federated SPIFFE issuer may have signed.
+    Algorithm::PS512, // alg-pin-allow: JWT-SVID verification allowlist, not OP signing — EdDSA is out of spec for JWT-SVID (see the doc comment above); the T04 EdDSA-exclusive rule governs what the OP SIGNS, not what a federated SPIFFE issuer may have signed.
 ];
 
 /// Default refresh poll period when a bundle carries no

--- a/crates/nucleus-oidc-core/tests/spiffe_federation_e2e.rs
+++ b/crates/nucleus-oidc-core/tests/spiffe_federation_e2e.rs
@@ -93,7 +93,7 @@ fn federated_store(seq: u64) -> FederationStore {
 /// Mint an ES256 SVID with the given key, sub, aud, exp, and kid.
 fn mint_es256(priv_pkcs8: &str, sub: &str, aud: &str, exp: u64, kid: Option<&str>) -> String {
     let key = EncodingKey::from_ec_pem(priv_pkcs8.as_bytes()).expect("EC pem parses");
-    let mut header = Header::new(Algorithm::ES256);
+    let mut header = Header::new(Algorithm::ES256); // alg-pin-allow: signs a test JWT-SVID as a federated SPIFFE issuer would; EC is what SPIRE emits, and the point of these tests is that verification handles it correctly.
     header.kid = kid.map(|k| k.to_string());
     let claims = json!({ "sub": sub, "aud": aud, "exp": exp });
     encode(&header, &claims, &key).expect("ES256 sign")
@@ -190,7 +190,7 @@ fn negative_b_expired_svid_rejected() {
 fn negative_b_absent_exp_rejected() {
     let store = federated_store(1);
     let key = EncodingKey::from_ec_pem(SVID_PRIV_PKCS8.as_bytes()).unwrap();
-    let mut header = Header::new(Algorithm::ES256);
+    let mut header = Header::new(Algorithm::ES256); // alg-pin-allow: signs a test JWT-SVID as a federated SPIFFE issuer would; EC is what SPIRE emits, and the point of these tests is that verification handles it correctly.
     header.kid = Some(SVID_KID.to_string());
     // No `exp` claim at all.
     let claims = json!({ "sub": SUB, "aud": AUD });
@@ -208,7 +208,7 @@ fn negative_b_absent_aud_rejected() {
     // aud MUST be present and contain the expected audience.
     let store = federated_store(1);
     let key = EncodingKey::from_ec_pem(SVID_PRIV_PKCS8.as_bytes()).unwrap();
-    let mut header = Header::new(Algorithm::ES256);
+    let mut header = Header::new(Algorithm::ES256); // alg-pin-allow: signs a test JWT-SVID as a federated SPIFFE issuer would; EC is what SPIRE emits, and the point of these tests is that verification handles it correctly.
     header.kid = Some(SVID_KID.to_string());
     let claims = json!({ "sub": SUB, "exp": now() + 300 });
     let token = encode(&header, &claims, &key).unwrap();


### PR DESCRIPTION
#2162 fixed one instance of `cmd | tee` under GitHub's default `run` shell — `bash -e {0}`, no pipefail, so the pipeline reports **tee's** exit status. Sweeping every workflow for the same shape found three more.

## The vendor-neutrality gate reported success on a real violation

`oidc-gates.yml:50` and `:90` run `bash ci/no-vendor-strings.sh … | tee` and `bash ci/alg-pin-check.sh … | tee`. Both scripts `exit 1`. Both steps reported 0.

Demonstrated on an actual violation rather than argued:

```
$ printf 'let x = "anthropic";' > fakecrate/src/lib.rs
$ bash ci/no-vendor-strings.sh fakecrate       -> exit 1
$ bash -e           -c '... | tee ...'         -> exit 0   step PASSES
$ bash -eo pipefail -c '... | tee ...'         -> exit 1   step FAILS
```

Vendor neutrality is a **hard rule** in `CLAUDE.md` — no Anthropic/OpenAI names, no vendor SDKs, no vendor credential formats. It was gated by a script whose exit status was discarded.

**It was silent twice over:** the `if: failure()` "Surface failure as PR comment" step below never fired either, because the step *succeeded*. `continue-on-error: false` didn't help for the same reason.

My first attempt to demonstrate this used a nonexistent path and got exit 0 from *both* shells — which proves nothing, because the gate had found no violation to report. Checking the numbers rather than the narrative is what caught it.

## Another Lean proof build that cannot fail

`aeneas-oidc-spiffe.yml:181` — `lake build OidcSpiffeProofs | tee`, then an axiom step that greps the log for `sorryAx`. A failed build writes no log, the grep finds nothing, both steps pass. Identical to #2162, different workflow.

Its axiom step gains the same non-vacuity requirement: the log must exist, be non-empty, and contain `depends on axioms` before its silence about `sorryAx` means anything.

## cargo-mutants reported "All mutants caught" when it crashed

`coverage-matrix.yml` runs cargo-mutants over portcullis's security-critical modules, and the following step gates on `grep -q SURVIVED || pass`.

A run that crashed, timed out, or failed to build writes no `SURVIVED` line — so the else branch fired and reported **"All mutants caught by tests."** The strongest-sounding result in that job was the one a total failure also produced. The `| tee` compounded it: without pipefail the run step didn't fail either.

Its `set -euo pipefail` at line 38 is in a **different step** and never applied to the tee'd ones.

## Verified by running the real step bodies

Extracted verbatim from the workflows and run against their failure states:

| step | states |
|---|---|
| axiom (oidc-spiffe) | real output **0** · build failed **1** · empty **1** · `sorryAx` **1** |
| mutants check | clean **0** · survived **1** · crashed **1** · build error **1** |

The clean-run case is the one that matters: my first extraction swallowed the rest of the file and returned **127 on a pass**. Testing only the failure cases would have shipped a check that fails on everything — which then gets loosened until it stops complaining.