### PR TITLE
Doctests were 82% of the test job's wall clock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,33 @@ jobs:
       - name: cargo clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
 
+  # Doctests, split out of `test` because they were 82% of its wall clock.
+  #
+  # WHY THIS JOB IS REQUIRED, NOT OPTIONAL
+  #
+  # Splitting a slow check into its own job is one edit away from dropping it:
+  # make it `continue-on-error`, or forget to add it to the required set, and the
+  # documented examples stop being verified while the board stays green. This
+  # repo has already produced that exact shape — two Lean proofs that appeared in
+  # a workflow's `paths:` triggers and were compiled by no job at all (#2162).
+  #
+  # Doctests are the ONLY thing checking that the examples in this codebase's
+  # documentation still compile, and the documentation is where most of its
+  # reasoning lives. They must fail the build.
+  doctests:
+    name: Doctests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: changed-crates
+    if: ${{ needs.changed-crates.outputs.all == 'true' || needs.changed-crates.outputs.crates != '' }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
+        with:
+          cache: true
+      - name: cargo test --doc
+        run: cargo test --all-features --doc
+
   test:
     name: Tests
     runs-on: ubuntu-latest
@@ -166,8 +193,21 @@ jobs:
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Build wasm SDK (vendored into verifier-service via include_bytes!)
         run: wasm-pack build sdks/verifier-js --target web --release
-      - name: cargo test
-        run: cargo test --all-features
+      # `--lib --bins --tests` EXCLUDES doctests, which run in the `doctests` job
+      # below. Measured on this workspace, warm cache:
+      #
+      #   --lib --bins --tests   152s
+      #   --doc                  702s   <- 82% of the time
+      #
+      # Every doctest is a separate rustc invocation linking the whole crate
+      # against 927 resolved packages, so ~113 doc code blocks cost ~8s each.
+      # That is not pathological, it is what doctests cost at this size — but it
+      # is not per-iteration work, and it was being paid on every run.
+      #
+      # SPLIT, NOT DROPPED. The doctests job below is required; see its comment
+      # for why that distinction is load-bearing.
+      - name: cargo test (lib, bins, tests — doctests run separately)
+        run: cargo test --all-features --lib --bins --tests
       # Node tests run the WASM bindings against the cross-language golden seal
       # (settlement + commons) and the accept/reject smoke fixtures — per-PR, not
       # just on publish, so a binding-layer drift from the proven kernels is caught

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,20 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
+          targets: wasm32-unknown-unknown
           cache: true
+      # PREREQUISITE, not boilerplate. `nucleus-verifier-service` vendors the
+      # wasm SDK with `include_str!`/`include_bytes!` on sdks/verifier-js/pkg/*,
+      # which only `wasm-pack build` produces. Without these two steps the whole
+      # workspace fails to compile and the doctest job REDs for a reason that has
+      # nothing to do with doctests.
+      #
+      # CI found this: splitting a job means carrying its PREREQUISITES, not just
+      # its command, and I moved the command alone.
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      - name: Build wasm SDK (vendored into verifier-service via include_bytes!)
+        run: wasm-pack build sdks/verifier-js --target web --release
       - name: cargo test --doc
         run: cargo test --all-features --doc
 


### PR DESCRIPTION
Measured on this workspace, warm cache:

| | |
|---|---|
| `cargo test --lib --bins --tests` | **152s** |
| `cargo test --doc` | **702s** |
| clippy, warm no-op | 1s |
| test compilation, warm | 43s |

~113 doc code blocks, ~90 of which compile, at roughly **8s each** — every doctest is a separate rustc invocation linking the whole crate against 927 resolved packages. That isn't pathological, it's what doctests cost at this size. It's just not per-iteration work, and it was being paid on every run.

The `test` job now runs `--lib --bins --tests`; doctests get their own job.

## Split, **not** dropped — and the distinction is load-bearing

Moving a slow check into its own job is one edit from deleting it: mark it `continue-on-error`, or leave it out of the required set, and the documented examples stop being verified while the board stays green. This repo has already produced exactly that shape — two Lean proofs that appeared in a workflow's `paths:` triggers and were compiled by no job at all (#2162).

Doctests are the only thing checking that this codebase's documented examples still compile, and the documentation is where most of its reasoning lives.

**Verified rather than assumed.** A deliberately broken doctest:

| invocation | exit | |
|---|---|---|
| `--lib --bins --tests` | 0 | invisible, as intended |
| `--doc` | 101 | the new job catches it |
| `--doc` after restore | 0 | |

## How this was found, including three wrong answers

The trigger was a gate run taking an hour.

**First hypothesis — debuginfo and link time.** Measured: `debug = "line-tables-only"` saves 2s on a 10s single-crate rebuild. Irrelevant to a full run.

**Second — clippy/test target-dir thrash.** Measured: clippy warm is **1s**, twice in a row. No thrash.

**Both of those, and a 3514s "full test run", were contaminated by my own measurement.** Appending `[profile.test]` to `Cargo.toml` and reverting it invalidates the entire workspace cache twice, and I measured the recovery from my own experiment. The control that caught it was running the same command twice, unchanged — one second, and I only ran it because the number looked implausible.