### PR TITLE
Two theorems verified a model nothing re-derived from the Rust

### DIFF
--- a/.github/workflows/aeneas-ifc-scoped.yml
+++ b/.github/workflows/aeneas-ifc-scoped.yml
@@ -205,6 +205,53 @@ jobs:
           sed 's/NucleusIfcKernel\.Types/PortcullisCoreMediation.Types/' "$SRC/Funs.lean" > "$DST/Funs.lean"
           echo "generated-mediation/ canonicalized from the fresh extraction."
 
+      # generated-egress and generated-credential were NOT canonicalized here
+      # until now, and the omission was invisible: both appear in this workflow's
+      # `paths:` triggers, so editing them starts the run, and the build steps
+      # below compile EgressConfinementExtracted and
+      # CredentialNoninterferenceExtracted — against the COMMITTED copies. The
+      # theorems verified a model nothing re-derived from the Rust, so changing
+      # `egress::rule_admits` or `credential::cred_may_deliver` left them green
+      # while describing code that no longer existed. A `paths:` trigger reads as
+      # coverage and is not coverage.
+      #
+      # No new extraction is needed: EXTRACT_ROOTS already names every
+      # egress::* and credential::* root, so ci-generated-ifc/ — one Aeneas run
+      # over the whole scoped slice — contains these definitions too. Same single
+      # disclosed hand-edit as the two steps above: only the inter-module import
+      # is retargeted so the lib names do not collide.
+      - name: Canonicalize generated-egress from the fresh extraction
+        run: |
+          DST=crates/portcullis-core/lean/generated-egress/PortcullisCoreEgress
+          SRC=crates/portcullis-core/lean/ci-generated-ifc
+          for f in Types.lean Funs.lean; do
+            if [ ! -f "$SRC/$f" ]; then
+              echo "ERROR: Aeneas did not emit $f (scoped extraction failed)"; exit 1
+            fi
+            if ! diff -q "$DST/$f" "$SRC/$f" > /dev/null 2>&1; then
+              echo "::warning::generated-egress $f drifted from the committed copy — building against the fresh canonical extraction"
+            fi
+          done
+          cp "$SRC/Types.lean" "$DST/Types.lean"
+          sed 's/NucleusIfcKernel\.Types/PortcullisCoreEgress.Types/' "$SRC/Funs.lean" > "$DST/Funs.lean"
+          echo "generated-egress/ canonicalized from the fresh extraction; theorem builds against it."
+
+      - name: Canonicalize generated-credential from the fresh extraction
+        run: |
+          DST=crates/portcullis-core/lean/generated-credential/PortcullisCoreCredential
+          SRC=crates/portcullis-core/lean/ci-generated-ifc
+          for f in Types.lean Funs.lean; do
+            if [ ! -f "$SRC/$f" ]; then
+              echo "ERROR: Aeneas did not emit $f (scoped extraction failed)"; exit 1
+            fi
+            if ! diff -q "$DST/$f" "$SRC/$f" > /dev/null 2>&1; then
+              echo "::warning::generated-credential $f drifted from the committed copy — building against the fresh canonical extraction"
+            fi
+          done
+          cp "$SRC/Types.lean" "$DST/Types.lean"
+          sed 's/NucleusIfcKernel\.Types/PortcullisCoreCredential.Types/' "$SRC/Funs.lean" > "$DST/Funs.lean"
+          echo "generated-credential/ canonicalized from the fresh extraction; theorem builds against it."
+
       - name: Dump FULL canonical generated defs (to develop the proof against)
         run: |
           echo "CANONICAL-TYPES-START"


### PR DESCRIPTION
## What this fixes

`aeneas-ifc-scoped.yml` re-extracts the enforcement subgraph with charon+aeneas and
canonicalizes the result into the committed Lean models, so proofs build against the current
toolchain's output rather than a checked-in snapshot.

It did that for `generated-ifc` and `generated-mediation`. It did **not** do it for
`generated-egress` or `generated-credential` — and then built `EgressConfinementExtracted`
and `CredentialNoninterferenceExtracted` anyway, against the committed copies.

Both theorems verified a model that nothing re-derived from the Rust. Editing
`egress::rule_admits` or `credential::cred_may_deliver` left them green while describing code
that no longer existed.

## Why it stayed invisible

Both directories **are** named in this workflow's `paths:` triggers, so touching them starts
the run and the board lights up green. A `paths:` trigger reads as coverage and is not
coverage — the same shape as the two Lean libraries in #2162 that appeared in a trigger list
and were compiled by no job at all.

## The change

No new extraction. `EXTRACT_ROOTS` already names every `egress::*` and `credential::*` root,
so `ci-generated-ifc/` — one Aeneas run over the whole scoped slice — already contains these
definitions. Only the inter-module import needs retargeting, exactly as for the two existing
steps. Both new steps carry the drift `::warning::` that `generated-ifc` has and
`generated-mediation` lacks.

## This may go RED, and red would be the point

If the committed egress or credential model has drifted from what the current pinned
toolchain extracts, those theorems will now **fail to build**. That is a finding, not a
regression — it would mean they had been passing against a stale model, which is exactly what
this PR exists to stop.

It cannot be checked locally: charon and aeneas are pinned Linux releases. **CI is the first
execution.** If it reds, the fix is to repair the proofs against the fresh extraction, not to
revert this.

## Still open — deliberately not fixed here

`generated-cap-quantale` is the **sixth** extracted model and has no canonicalize step in any
workflow, while `portcullis-core-proven-lean.yml` *does* build `PortcullisCoreCapQuantale` and
`CapabilityResiduatedQuantaleProofs` over it. Its Rust
(`crates/nucleus-ifc-kernel/src/extracted/capability_quantale.rs`) is real and sits in the
same module as the others, but it is absent from `EXTRACT_ROOTS` — so fixing it means growing
the shared slice every other proof here builds against. Riskier than this change, and it gets
its own increment.

That gap is also the honest residue of a claim I got wrong earlier today: I reported
`CapabilityResiduatedQuantaleProofs` as never type-checked. It **is** built. What is true is
narrower and still worth fixing — it is built against a model nothing re-derives.
