### PR TITLE
Twenty theorems that compile fine were type-checked by nothing

### DIFF
--- a/.github/workflows/portcullis-core-proven-lean.yml
+++ b/.github/workflows/portcullis-core-proven-lean.yml
@@ -98,7 +98,9 @@ jobs:
             RepairAlgebraProofs \
             MatrixBridge \
             PortcullisCoreCapQuantale \
-            CapabilityResiduatedQuantaleProofs
+            CapabilityResiduatedQuantaleProofs \
+            AssuranceCoverage \
+            UniversalDetection
           # CapabilityResiduatedQuantaleProofs: the residuation adjunction
           # (a⊗b≤c ⟺ b≤a⊸c) for capability, proven over the Aeneas-extracted
           # capability_quantale slice — the enriching value V of the
@@ -187,9 +189,13 @@ jobs:
           import ExposureProofs
           import IntegrityNoninterferenceExtracted
           import CapabilityResiduatedQuantaleProofs
+          import AssuranceCoverage
+          import UniversalDetection
           #print axioms FlowProofs.authority_confinement_left
           #print axioms IntegrityNoninterferenceExtracted.web_tainted_never_git_pushes
           #print axioms CapabilityResiduatedQuantaleProofs.residuation_adjunction
+          #print axioms Nucleus.Assurance.suite_not_full
+          #print axioms PortcullisCore.UniversalDetection.universal_detection_impossibility
           EOF
           AXIOMS="$(lake env lean PrintAxioms.lean 2>&1 || true)"
           echo "$AXIOMS"

--- a/scripts/check-lean-libs-built.sh
+++ b/scripts/check-lean-libs-built.sh
@@ -151,9 +151,12 @@ echo "lean_lib coverage: $total declared, $covered covered (named target, defaul
 # false green in the gate written to find false greens. Portable constructs are
 # not pedantry here; the gate must run wherever it is probed.
 ALLOWED_UNBUILT=(
+    # CONFIRMED by direct build, not inherited from the workflow comment that
+    # asserts it: a clean rebuild fails with `unknown namespace
+    # PortcullisCoreBridge` plus ~12 unsynthesized instances. It was also the
+    # CONTROL that validated the triage of the two libraries below — without a
+    # library known to fail, "it compiles" is not a measurement.
     "CategoryProofs|does not compile — Mathlib order-refactor drift / unbound auto-implicits; Tier 3 (STALE) in CONJECTURES.md, excluded by name in portcullis-core-proven-lean.yml"
-    "AssuranceCoverage|unbuilt and unnoticed until 2026-08-04 — NOT a deliberate exclusion, needs triage"
-    "UniversalDetection|unbuilt and unnoticed until 2026-08-04 — NOT a deliberate exclusion, needs triage"
     "AugmentedBorromeanTheorems|research spike, never wired"
     "BraidObstruction|research spike, never wired"
     "BraidEmpirical|research spike, never wired"


### PR DESCRIPTION
Follow-up to #2169, which found eleven `lean_lib`s built by nothing and allowlisted them *by
name with a reason* so the set could be reviewed rather than counted. Two entries said "needs
triage" because I had not looked yet. Looking says **both compile**, so they are wired here
and their entries are gone.

| library | theorems | `sorry` |
|---|---|---|
| `AssuranceCoverage` | 6 | 0 |
| `UniversalDetection` | 14 | 0 |

## How this was established, since "lake build said OK" is not evidence

Lake traces by **content hash**, so building over an existing `.olean` reports success without
elaborating anything. Both `.olean`s were deleted first and rebuilt from source —
`AssuranceCoverage` in 3 jobs, `UniversalDetection` in 614 — with regeneration confirmed by
mtime.

`CategoryProofs` was the **control, and it failed**, which is the only reason the two passes
mean anything:

```
error: CategoryProofs.lean:27:5: unknown namespace `PortcullisCoreBridge`
error: CategoryProofs.lean:39:48: failed to synthesize instance of type class
... (~12 more)
```

Its allowlist entry is now confirmed by direct build rather than inherited from the workflow
comment asserting it.

## Not just "it elaborates"

Both are added to the axiom audit, so this is a claim about their content:

```
Nucleus.Assurance.suite_not_full                     -> [propext]
PortcullisCore.UniversalDetection.universal_detection_impossibility
                                                     -> does not depend on any axioms
```

Verified locally before pushing — a misspelled constant makes `#print axioms` answer `Unknown
constant`, and the `sorryAx` grep then passes over a question that was never asked.

## The ratchet did the bookkeeping

Adding the build targets *without* removing the allowlist entries fails
`check-lean-libs-built.sh`'s stale-allowance half. Watched, not assumed — it named exactly
those two libraries and exited 1, then went green once the entries were deleted. An allowlist
checked in one direction only becomes the second place things hide.

Coverage **66/77 → 68/77**; allowlist **11 → 9**. `check-gates-can-fail.sh` still green: 12
gates found, 9 probed, 0 unaccounted.

## What these theorems say

Worth noting, because they are unusual things to leave unchecked. `suite_not_full` proves the
assurance suite is **not** complete, with `zk_export_uncovered`,
`declassification_uncovered` and `agreement_does_not_imply_coverage` beside it. They are this
repo's own negative results about its coverage — and nothing was elaborating them.
