### PR TITLE
Boot the same pod twice, differing only in a secret

### DIFF
--- a/crates/nucleus-cli/src/main.rs
+++ b/crates/nucleus-cli/src/main.rs
@@ -46,11 +46,11 @@ mod shell;
 mod start;
 mod stop;
 mod token;
-// Completeness by 2-safety. Not yet called from a command: the comparison logic
-// lands first so it is reviewable on its own, exactly as the broker's decision
-// core did. The harness that boots twice needs /dev/kvm and lands next.
-#[allow(dead_code)]
+// Completeness by 2-safety: the observation function, the canonicaliser and the
+// comparison. Reached from `nucleus two-safety` via `twosafety_boot`, which is
+// the implementation of its `Boot` trait that boots real pods.
 mod twosafety;
+mod twosafety_boot;
 mod verify;
 
 /// Nucleus CLI - policy-aware wrapper (tool enforcement via proxy)
@@ -93,6 +93,9 @@ enum Commands {
 
     /// Prove Tier 2 works by booting a real nucleus pod
     Verify(verify::VerifyArgs),
+
+    /// Boot a pod twice differing only in a secret, and compare (2-safety)
+    TwoSafety(twosafety_boot::TwoSafetyArgs),
 
     /// Start nucleus-node in the Lima VM
     Start(start::StartArgs),
@@ -181,6 +184,7 @@ async fn main() -> Result<()> {
         Commands::Shell(args) => shell::execute(args).await,
         Commands::Setup(args) => setup::execute(args).await,
         Commands::Verify(args) => verify::execute(args).await,
+        Commands::TwoSafety(args) => twosafety_boot::execute(args).await,
         Commands::Start(args) => start::execute(args).await,
         Commands::Stop(args) => stop::execute(args).await,
         Commands::Lockdown(args) => lockdown::execute(args).await,

--- a/crates/nucleus-cli/src/twosafety.rs
+++ b/crates/nucleus-cli/src/twosafety.rs
@@ -327,6 +327,9 @@ fn strip_leading_timestamp(line: &str) -> &str {
 // ---------------------------------------------------------------------------
 
 /// The literal that opens an audit record header.
+/// An Ed25519 signature is 64 bytes, the widest number array this erases.
+const MAX_ERASED_ARRAY_LEN: usize = 64;
+
 const AUDIT_OPEN: &str = "audit(";
 
 /// The literal a kernel audit record line begins with. The rule is anchored to
@@ -603,7 +606,26 @@ fn canonicalise_task_token_hex(line: &str) -> String {
     rewrite_hex_valued_key(line, TOKEN_HEX_KEY, |hex_value| {
         let bytes = hex::decode(hex_value).ok()?;
         let text = String::from_utf8(bytes).ok()?;
-        let mut token: serde_json::Value = serde_json::from_str(&text).ok()?;
+        let token: serde_json::Value = serde_json::from_str(&text).ok()?;
+        // ROUND-TRIP FIDELITY, checked BEFORE any erasure.
+        //
+        // Decoding through `serde_json::Value` silently discards the entire
+        // ENCODING layer: key order, whitespace, escape form, and — the one that
+        // matters — DUPLICATE KEYS, of which the last silently wins. A token
+        // carrying `{"task_id":"CANARY-AAAA","task_id":"t",...}` re-serialised
+        // to the same bytes as one carrying CANARY-BBBB, so a secret smuggled
+        // into the first of two duplicate keys was invisible in exactly the
+        // fields this rule decodes the token in order to KEEP compared.
+        //
+        // So: re-serialise the UNMODIFIED token and require it to be byte-equal
+        // to what was decoded. A token this runtime minted round-trips (it was
+        // produced by the same serialiser); one that does not is carrying
+        // information in its encoding, and this declines rather than erase it.
+        // Fail-closed: declining leaves the raw hex COMPARED.
+        if serde_json::to_string(&token).ok()? != text {
+            return None;
+        }
+        let mut token = token;
         erase_run_scoped_token_fields(&mut token);
         // Compact serialisation: no interior newline can ever be produced (JSON
         // escapes them inside strings), so the line structure the whole
@@ -734,9 +756,26 @@ fn hex_value_of_key(text: &str, key: &str) -> Option<String> {
 fn rewrite_hex_valued_key(line: &str, key: &str, f: impl Fn(&str) -> Option<String>) -> String {
     let mut out = String::with_capacity(line.len());
     let mut rest = line;
+    let mut consumed = 0usize;
     while let Some(i) = rest.find(key) {
         let (head, tail) = rest.split_at(i + key.len());
         out.push_str(head);
+        // POSITIONAL ANCHOR. The key must start a command-line token — i.e. sit
+        // at the start of the line or immediately after a delimiter — rather
+        // than appear anywhere inside one. Unanchored, `...=x nucleus.task_token_hex=`
+        // occurring INSIDE another value was eligible, so the erasure composed
+        // across a line an attacker partly controls.
+        let abs = consumed + i;
+        let preceded_ok = abs == 0
+            || line[..abs]
+                .chars()
+                .next_back()
+                .is_some_and(|c| c == ' ' || c == '"' || c == '\t');
+        consumed = abs + key.len();
+        if !preceded_ok {
+            rest = tail;
+            continue;
+        }
         let end = tail
             .find(|c: char| !c.is_ascii_hexdigit())
             .unwrap_or(tail.len());
@@ -745,6 +784,7 @@ fn rewrite_hex_valued_key(line: &str, key: &str, f: impl Fn(&str) -> Option<Stri
             Some(replacement) => out.push_str(&replacement),
             None => out.push_str(value),
         }
+        consumed += value.len();
         rest = after;
     }
     out.push_str(rest);
@@ -783,9 +823,13 @@ fn erase_run_scoped_token_fields(token: &mut serde_json::Value) {
 /// an object, a mixed array) is left compared.
 fn erase_number_array(slot: Option<&mut serde_json::Value>, marker: &str) {
     if let Some(value) = slot {
+        // WIDTH-BOUNDED. `sig` is a `Vec<u8>` — unbounded at the type level — and
+        // `nonce` a fixed 16 bytes, so an unbounded "all numbers" test was a
+        // channel of unbounded width. An Ed25519 signature is 64 bytes; the bound
+        // is the widest field this erases, so anything larger is not one of them.
         if value
             .as_array()
-            .is_some_and(|a| a.iter().all(serde_json::Value::is_number))
+            .is_some_and(|a| a.len() <= MAX_ERASED_ARRAY_LEN && a.iter().all(serde_json::Value::is_number))
         {
             *value = serde_json::Value::String(marker.to_string());
         }
@@ -1799,6 +1843,99 @@ mod tests {
         assert!(
             scrub(rtc_real, &f, None).contains("<RTC-WALL-CLOCK>"),
             "the real rtc line must normalise"
+        );
+    }
+
+    /// **The encoding-layer channel, as a test.**
+    ///
+    /// Decoding through `serde_json::Value` discards key order, whitespace and
+    /// DUPLICATE KEYS — last wins. So a token carrying
+    /// `{"task_id":"CANARY-AAAA","task_id":"t",...}` re-serialised to the same
+    /// bytes as one carrying CANARY-BBBB, and the secret was invisible in
+    /// exactly the field this rule decodes the token in order to KEEP compared.
+    ///
+    /// The round-trip fidelity check declines any token whose encoding carries
+    /// information, leaving the raw hex compared. Fail-closed.
+    #[test]
+    fn a_secret_in_a_duplicate_key_is_not_swallowed() {
+        let f = RunFacts {
+            pod_id: "aeb31452-ce64-468b-abf4-ea5f23378519".into(),
+            guest_cid: 3,
+        };
+        let dup = |smuggled: &str| {
+            let json = format!(
+                "{{\"task_id\":\"{smuggled}\",\"task_id\":\"t\",\"blocks\":[]}}"
+            );
+            format!("console=ttyS0 {TOKEN_HEX_KEY}{}", hex::encode(json))
+        };
+        let a = scrub(&dup("canary-aaaa"), &f, None);
+        let b = scrub(&dup("canary-bbbb"), &f, None);
+        assert_ne!(
+            a, b,
+            "a secret in the FIRST of two duplicate keys must stay compared; the \
+             re-serialisation drops it and both runs collapse to the same bytes"
+        );
+    }
+
+    /// An oversized number array is not one of the fields this erases.
+    #[test]
+    fn an_oversized_number_array_is_not_erased() {
+        let f = RunFacts {
+            pod_id: "aeb31452-ce64-468b-abf4-ea5f23378519".into(),
+            guest_cid: 3,
+        };
+        let wide = |seed: u16| {
+            let nums: Vec<String> = (0..200).map(|i| ((i + seed) % 251).to_string()).collect();
+            let json = format!(
+                "{{\"blocks\":[{{\"sig\":[{}],\"claim\":{{}}}}]}}",
+                nums.join(",")
+            );
+            format!("console=ttyS0 {TOKEN_HEX_KEY}{}", hex::encode(json))
+        };
+        assert_ne!(
+            scrub(&wide(1), &f, None),
+            scrub(&wide(2), &f, None),
+            "a 200-element array is not a signature and must stay compared"
+        );
+    }
+
+    /// **Two rules each correct alone, wrong composed.**
+    ///
+    /// Rule 3 decodes the task token so `scope.allowed_paths` stays COMPARED —
+    /// that is the whole reason it decodes rather than blanks. Rule 1 then runs
+    /// over the same line, and before it was anchored it would eat a
+    /// `digits.digits` span inside those very paths, re-introducing the
+    /// blindness rule 3 exists to avoid.
+    ///
+    /// The `audit: ` anchor added to rule 1 fixes this for free: a decoded token
+    /// rides a command-line, never a kernel audit record, so rule 1 cannot reach
+    /// it. This pins that the composition stays safe.
+    #[test]
+    fn rule_1_does_not_eat_paths_that_rule_3_decoded_to_keep() {
+        let f = RunFacts {
+            pod_id: "aeb31452-ce64-468b-abf4-ea5f23378519".into(),
+            guest_cid: 3,
+        };
+        let with_path = |p: &str| {
+            let json = format!(
+                "{{\"blocks\":[{{\"claim\":{{\"scope\":{{\"allowed_paths\":[\"{p}\"]}}}}}}]}}"
+            );
+            format!("console=ttyS0 {TOKEN_HEX_KEY}{}", hex::encode(json))
+        };
+        // The secret must sit INSIDE the span rule 1 erases, or this test passes
+        // for the boring reason. A first version used "/data/audit(0.310:aaaa"
+        // — no closing paren, so rule 1 declined whether or not it was anchored,
+        // and removing the anchor did not turn the test red. The clock field
+        // itself is the erased span, so that is where the secret goes.
+        let a = scrub(&with_path("/data/audit(1.111:1)"), &f, None);
+        let b = scrub(&with_path("/data/audit(2.222:1)"), &f, None);
+        assert_ne!(
+            a, b,
+            "rule 1 must not reach inside a decoded token's allowed_paths"
+        );
+        assert!(
+            !a.contains("<BOOT-CLOCK>"),
+            "the boot-clock erasure fired inside a token path: {a}"
         );
     }
 

--- a/crates/nucleus-cli/src/twosafety.rs
+++ b/crates/nucleus-cli/src/twosafety.rs
@@ -82,9 +82,42 @@ impl Canonical {
 pub struct RunFacts {
     /// The pod's UUID. Minted before any secret is read, so it cannot encode one.
     pub pod_id: String,
-    /// The guest CID. Allocated from a counter, not derived from pod content.
+    /// The guest CID.
+    ///
+    /// The previous comment here said "allocated from a counter", which is not
+    /// true of any path: `firecracker_config.rs` takes it from the `--vsock-cid`
+    /// argument, and [`crate::twosafety_boot`] passes a compile-time constant.
+    /// A doc comment asserting a provenance nothing enforces is the weakest form
+    /// of the guarantee, so it now says what is actually the case.
     pub guest_cid: u32,
 }
+
+// ---------------------------------------------------------------------------
+// WHY `RunFacts` MAY BE ERASED AT ALL — the load-bearing assumption.
+//
+// The comparison is not `f s₁` against `f s₂`. It is `h_{r₁}(f s₁)` against
+// `h_{r₂}(f s₂)`: two observations put through two DIFFERENT erasure functions,
+// one per run. That is only sound if `r` — the run facts — is uncorrelated with
+// the secret. If a fact could be a function of the secret, the erasure keyed on
+// it could cancel exactly the difference the experiment exists to find, and the
+// harness would go quiet precisely when it mattered.
+//
+// Both fields are secret-independent BY CONSTRUCTION, which is a stronger answer
+// than a correlation test could give — a test can fail to detect a correlation,
+// never establish its absence:
+//
+// * `guest_cid` — `twosafety_boot::GUEST_CID`, a compile-time constant. The two
+//   runs pass literally the same value, so it cannot carry a per-run anything,
+//   let alone a per-secret one.
+// * `pod_id` — `Uuid::new_v4()`, minted node-side from the CSPRNG. Random bytes
+//   are not a function of the request that triggered them.
+//
+// If either ever becomes derived — a CID allocated from pod content, a v5 UUID
+// namespaced on the spec — this argument dies silently and the erasures keyed
+// on them become unsound. That is the thing to re-check before changing how
+// either is minted, and it is stated here rather than in a commit message
+// because the commit message is not where anyone will look.
+// ---------------------------------------------------------------------------
 
 /// Where two runs disagreed. Carries the component and a bounded excerpt of the
 /// FIRST differing line — never the whole content, and never a value the caller

--- a/crates/nucleus-cli/src/twosafety.rs
+++ b/crates/nucleus-cli/src/twosafety.rs
@@ -152,13 +152,97 @@ const EXCERPT_BYTES: usize = 120;
 /// is the most likely place for a real leak.
 #[must_use]
 pub fn canonicalise(obs: &Observation, facts: &RunFacts) -> Canonical {
+    // The warrant is derived from the machine config and ONLY from the machine
+    // config, because that is the component the guest cannot write. See
+    // [`Warrant`] for why that asymmetry is the whole point.
+    let warrant = Warrant::from_host(&obs.machine_config);
     Canonical {
-        machine_config: scrub(&obs.machine_config, facts),
-        console: scrub(&obs.console, facts),
+        // The host-authored component IS the warrant's source, so it needs none.
+        machine_config: scrub(&obs.machine_config, facts, None),
+        console: scrub(&obs.console, facts, Some(&warrant)),
     }
 }
 
-fn scrub(s: &str, facts: &RunFacts) -> String {
+/// The high-integrity facts that authorise erasing something from the
+/// comparison — and the reason rule 3c cannot be written wrongly again.
+///
+/// # Every canonicalisation rule is a declassification
+///
+/// A rule decides that some bytes will not be compared, which is a deliberate
+/// release of the harness from noticing them. Robust declassification
+/// (Zdancewic & Myers 2001) asks for exactly one thing of such a decision: an
+/// attacker may influence **neither the decision to declassify nor the choice of
+/// what is declassified**. The enforcement they give is to require the
+/// *decision* to have **high integrity**.
+///
+/// # The rule that violated it
+///
+/// `normalise_truncated_cmdline_echo` erased the kernel's echo of the command
+/// line on the strength of `line.starts_with("Kernel command line: ")`. The
+/// console is **guest-writable** — real logs carry unprefixed guest lines such
+/// as `fetched identity: spiffe://...` — so the guest chose whether the erasure
+/// fired, and could hide an arbitrary value behind a forged prefix. That is not
+/// a pattern that was too broad. It is a declassification whose trigger the
+/// attacker controls.
+///
+/// # What this type does about it
+///
+/// A `Warrant` is constructible **only** from the machine configuration, which
+/// only the node writes into the jail. There is no constructor taking console
+/// text, so a rule cannot base its firing decision on guest-authored bytes by
+/// reaching for one — the value it would need does not exist on that path.
+///
+/// The asymmetry is the invariant, so it is worth stating plainly:
+///
+/// * `machine_config` — written by `firecracker_config.rs`, inside the jail,
+///   before the guest exists. HIGH integrity. May authorise an erasure.
+/// * `console` — whatever came off `console=ttyS0`, which includes anything the
+///   guest chose to print. LOW integrity. May be erased, may never authorise.
+///
+/// # What it still does not do
+///
+/// It does not stop a future rule pattern-matching guest text directly; the
+/// line is still a `&str`. What it removes is the *need* to, and it makes the
+/// wrong version visibly wrong — a rule that erases guest bytes without
+/// consulting a warrant is now the odd one out rather than the norm.
+/// `a_guest_forged_cmdline_echo_is_not_erased` pins the specific attack.
+struct Warrant {
+    /// The session task token exactly as the HOST wrote it into `boot_args`.
+    ///
+    /// `None` when the config carries no token, in which case every rule that
+    /// needs one declines — failing closed, so a missing warrant erases less
+    /// rather than more.
+    task_token_hex: Option<String>,
+}
+
+impl Warrant {
+    /// Derive the warrant from the host-authored machine configuration.
+    ///
+    /// Deliberately the only constructor, and deliberately private.
+    fn from_host(machine_config: &str) -> Self {
+        Warrant {
+            task_token_hex: hex_value_of_key(machine_config, TOKEN_HEX_KEY),
+        }
+    }
+
+    /// Is `candidate` the kernel's echo of the token the HOST wrote?
+    ///
+    /// A byte-exact prefix, because that is what a truncated echo of a value is
+    /// and what a forgery is not. Verified on real artifacts: the kernel echoes
+    /// 968 of the token's 1762 bytes, and the echo is a byte-exact prefix of the
+    /// value in `boot_args`.
+    ///
+    /// Empty candidates are refused: the empty string is a prefix of everything,
+    /// which would authorise erasing anything.
+    fn authorises_cmdline_echo(&self, candidate: &str) -> bool {
+        match &self.task_token_hex {
+            Some(token) => !candidate.is_empty() && token.starts_with(candidate),
+            None => false,
+        }
+    }
+}
+
+fn scrub(s: &str, facts: &RunFacts, warrant: Option<&Warrant>) -> String {
     s.lines()
         .map(|line| {
             let line = strip_leading_timestamp(line);
@@ -172,7 +256,7 @@ fn scrub(s: &str, facts: &RunFacts) -> String {
             // Only reachable when the rule above DECLINED, i.e. the token was
             // truncated by the kernel's own echo. A complete token is decoded
             // and compared field-wise; this never sees it.
-            let line = normalise_truncated_cmdline_echo(&line);
+            let line = normalise_truncated_cmdline_echo(&line, warrant);
             let line = canonicalise_task_token_nonce(&line);
             // The pod UUID is long and structurally unique, so a plain
             // replacement is safe.
@@ -507,9 +591,6 @@ fn canonicalise_task_token_nonce(line: &str) -> String {
     })
 }
 
-/// The literal the guest kernel uses to echo its own command line.
-const CMDLINE_ECHO: &str = "Kernel command line: ";
-
 /// Normalise the task token in the guest kernel's **truncated** command-line
 /// echo. Measured cause of the single residual difference left after rule 3.
 ///
@@ -560,13 +641,41 @@ const CMDLINE_ECHO: &str = "Kernel command line: ";
 /// truncate. Nothing about the token's own content, which `machine_config`
 /// compares untruncated. If you would rather not buy that, delete this rule; the
 /// residual becomes exactly one line and the other three rules are unaffected.
-fn normalise_truncated_cmdline_echo(line: &str) -> String {
-    if !line.starts_with(CMDLINE_ECHO) {
+fn normalise_truncated_cmdline_echo(line: &str, warrant: Option<&Warrant>) -> String {
+    // NO WARRANT, NO ERASURE. The host-authored component is scrubbed without
+    // one — it is the warrant's own source — and nothing there needs this rule,
+    // because a complete token is decoded and compared field-wise upstream.
+    let Some(warrant) = warrant else {
         return line.to_string();
-    }
+    };
+    // The `starts_with` that used to gate this rule is deliberately gone. It was
+    // a guest-forgeable string prefix, and the console is guest-writable, so it
+    // let the guest decide whether the erasure fired. The gate is now the
+    // warrant: does this hex match what the HOST actually wrote? A guest-authored
+    // blob is not a prefix of the host's token, so the rule declines and the
+    // line stays compared — which is the failure mode we want, since a line that
+    // is compared can at worst produce a divergence to investigate, while a line
+    // that is erased is invisible forever.
     rewrite_hex_valued_key(line, TOKEN_HEX_KEY, |hex_value| {
-        (!hex_value.is_empty()).then(|| "<TRUNCATED-CMDLINE-TOKEN-ECHO>".to_string())
+        warrant
+            .authorises_cmdline_echo(hex_value)
+            .then(|| "<TRUNCATED-CMDLINE-TOKEN-ECHO>".to_string())
     })
+}
+
+/// The first `key=<hex…>` value in `text`, using the same delimiting rule as
+/// [`rewrite_hex_valued_key`].
+///
+/// Reads rather than rewrites, so a [`Warrant`] can be built from the
+/// host-authored config without that config being modified.
+fn hex_value_of_key(text: &str, key: &str) -> Option<String> {
+    let i = text.find(key)?;
+    let tail = &text[i + key.len()..];
+    let end = tail
+        .find(|c: char| !c.is_ascii_hexdigit())
+        .unwrap_or(tail.len());
+    let value = &tail[..end];
+    (!value.is_empty()).then(|| value.to_string())
 }
 
 /// Rewrite the value of every `key=<hex…>` occurrence in `line`.
@@ -958,6 +1067,17 @@ pub fn check_all(b: &mut dyn Boot) -> Result<(), CheckFailure> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The literal the guest kernel uses to echo its own command line.
+    ///
+    /// TEST-ONLY, and that it is test-only is the point. It used to gate rule
+    /// 3c in production code — `line.starts_with(CMDLINE_ECHO)` — which handed
+    /// the guest the decision to declassify, since the guest can print this
+    /// prefix. The gate is now the [`Warrant`], so the literal survives only as
+    /// scaffolding for building realistic console lines. The dead-code gate is
+    /// what forced it here, which is the wiring check confirming the forgeable
+    /// trigger really left the decision path rather than merely being bypassed.
+    const CMDLINE_ECHO: &str = "Kernel command line: ";
 
     const SECRET_A: &str = "nucleus-e2e-canary-aaaaaaaaaaaa";
     const SECRET_B: &str = "nucleus-e2e-canary-bbbbbbbbbbbb";
@@ -1352,10 +1472,12 @@ mod tests {
         let a = scrub(
             &cmdline_with_token(&fa.pod_id, 0x8e, 1_785_445_717, 0xd0, ""),
             &fa,
+            None,
         );
         let b = scrub(
             &cmdline_with_token(&fb.pod_id, 0x30, 1_785_840_318, 0x89, ""),
             &fb,
+            None,
         );
         assert_eq!(a, b, "only run-scoped token fields differed");
         assert!(a.contains("<TASK-TOKEN-NONCE>"), "nonce erased: {a}");
@@ -1381,10 +1503,12 @@ mod tests {
         let a = scrub(
             &cmdline_with_token(&fa.pod_id, 0x8e, 1_785_445_717, 0xd0, "\"/x/canary-aaaa\""),
             &fa,
+            None,
         );
         let b = scrub(
             &cmdline_with_token(&fb.pod_id, 0x30, 1_785_840_318, 0x89, "\"/x/canary-bbbb\""),
             &fb,
+            None,
         );
         assert!(
             a.contains("canary-aaaa"),
@@ -1412,7 +1536,7 @@ mod tests {
     #[test]
     fn decoding_the_token_first_is_what_lets_the_pod_id_rule_reach_it() {
         let f = facts();
-        let out = scrub(&cmdline_with_token(&f.pod_id, 1, 1, 1, ""), &f);
+        let out = scrub(&cmdline_with_token(&f.pod_id, 1, 1, 1, ""), &f, None);
         assert!(
             out.contains("\"task_id\":\"<POD-ID>\""),
             "the pod UUID inside the decoded token must be normalised: {out}"
@@ -1476,7 +1600,7 @@ mod tests {
             "{CMDLINE_ECHO}{}",
             cmdline_with_token(&f.pod_id, 1, 1, 1, "\"/x/canary-aaaa\"")
         );
-        let out = scrub(&complete, &f);
+        let out = scrub(&complete, &f, None);
         assert!(
             out.contains("canary-aaaa"),
             "a COMPLETE echoed token must still be compared field-wise: {out}"
@@ -1486,13 +1610,16 @@ mod tests {
             "rule 3c must not fire on a complete token: {out}"
         );
 
-        // Truncated: the hex is cut mid-JSON, so rule 3 declines and 3c fires.
+        // Truncated: the hex is cut mid-JSON, so rule 3 declines and 3c fires —
+        // but ONLY under a warrant derived from what the host actually wrote.
         let hex = hex::encode(token_json(&f.pod_id, 1, 1, 1, ""));
+        let host_cfg = format!("\"boot_args\":\"{TOKEN_HEX_KEY}{hex}\"");
+        let w = Warrant::from_host(&host_cfg);
         let truncated = format!(
             "{CMDLINE_ECHO}console=ttyS0 {TOKEN_HEX_KEY}{}",
             &hex[..hex.len() / 2]
         );
-        let out = scrub(&truncated, &f);
+        let out = scrub(&truncated, &f, Some(&w));
         assert!(
             out.contains("<TRUNCATED-CMDLINE-TOKEN-ECHO>"),
             "a truncated token must be normalised: {out}"
@@ -1502,13 +1629,71 @@ mod tests {
             "the rest of the echo stays compared: {out}"
         );
 
-        // Not the echo line: the same truncated hex elsewhere stays compared.
-        let elsewhere = format!("some other line {TOKEN_HEX_KEY}{}", &hex[..hex.len() / 2]);
-        assert_eq!(
-            scrub(&elsewhere, &f),
-            elsewhere,
-            "rule 3c is bound to the kernel's echo literal"
+        // WITHOUT the warrant the rule declines. The host-authored component is
+        // scrubbed with `None`, and failing closed there means erasing less.
+        assert!(
+            !scrub(&truncated, &f, None).contains("<TRUNCATED-CMDLINE-TOKEN-ECHO>"),
+            "no warrant must mean no erasure"
         );
+    }
+
+    /// **The attack rule 3c used to permit, as a test.**
+    ///
+    /// The console is guest-writable — real logs carry unprefixed guest lines
+    /// such as `fetched identity: spiffe://...` — and the old rule fired on
+    /// `line.starts_with("Kernel command line: ")`, a string prefix the guest
+    /// can forge. So a guest could emit that prefix followed by
+    /// `nucleus.task_token_hex=<hex of anything>` and have its bytes erased
+    /// from the comparison. Two runs carrying DIFFERENT smuggled values
+    /// canonicalised IDENTICALLY, which is a leak the harness is blind to by
+    /// construction.
+    ///
+    /// Robust declassification names the defect exactly: the decision to
+    /// declassify must have high integrity, and a guest-authored prefix has
+    /// none. The rule now asks the [`Warrant`] — derived only from the
+    /// host-written machine config — whether the hex is a prefix of the token
+    /// the host actually wrote. A forged blob is not, so the rule declines and
+    /// the line stays compared.
+    ///
+    /// The two runs below differ ONLY in the smuggled value. If they
+    /// canonicalise equal, the attack works.
+    #[test]
+    fn a_guest_forged_cmdline_echo_is_not_erased() {
+        let f = facts();
+        let real = hex::encode(token_json(&f.pod_id, 1, 1, 1, ""));
+        let host_cfg = format!("\"boot_args\":\"{TOKEN_HEX_KEY}{real}\"");
+        let w = Warrant::from_host(&host_cfg);
+
+        // Guest-authored: the echo literal is forged, and the "token" is the
+        // secret. `6161…`/`6262…` are hex for "aaaa…"/"bbbb…".
+        let forged = |smuggled: &str| {
+            format!(
+                "{CMDLINE_ECHO}{TOKEN_HEX_KEY}{}",
+                hex::encode(smuggled.as_bytes())
+            )
+        };
+        let a = scrub(&forged("canary-aaaa"), &f, Some(&w));
+        let b = scrub(&forged("canary-bbbb"), &f, Some(&w));
+
+        assert_ne!(
+            a, b,
+            "a guest-forged echo must stay COMPARED; erasing it hides whatever the \
+             guest chose to put there"
+        );
+        assert!(
+            !a.contains("<TRUNCATED-CMDLINE-TOKEN-ECHO>"),
+            "the erasure must not fire on a value the host never wrote: {a}"
+        );
+    }
+
+    /// The warrant refuses the empty string, which is a prefix of everything and
+    /// would therefore authorise erasing anything.
+    #[test]
+    fn an_empty_candidate_is_not_warranted() {
+        let w = Warrant::from_host("\"boot_args\":\"nucleus.task_token_hex=abcdef\"");
+        assert!(!w.authorises_cmdline_echo(""));
+        assert!(w.authorises_cmdline_echo("abc"));
+        assert!(!w.authorises_cmdline_echo("abd"));
     }
 
     /// **NON-VACUITY OF RULE 3c.** Everything on the echoed command line other
@@ -1523,7 +1708,7 @@ mod tests {
              nucleus.leak=canary-bbbb {TOKEN_HEX_KEY}{}",
             &hex[..hex.len() / 2]
         );
-        let out = scrub(&line, &f);
+        let out = scrub(&line, &f, None);
         assert!(
             out.contains("canary-aaaa") && out.contains("canary-bbbb"),
             "rule 3c erased more than the token value: {out}"
@@ -1538,6 +1723,7 @@ mod tests {
         let out = scrub(
             &cmdline_with_token(&f.pod_id, 1, 1, 1, "\"/etc/nonce/canary-aaaa\",\"/sig\""),
             &f,
+            None,
         );
         assert!(
             out.contains("/etc/nonce/canary-aaaa") && out.contains("/sig"),

--- a/crates/nucleus-cli/src/twosafety.rs
+++ b/crates/nucleus-cli/src/twosafety.rs
@@ -60,6 +60,20 @@ pub struct Canonical {
     console: String,
 }
 
+impl Canonical {
+    /// Does either component contain `needle`?
+    ///
+    /// Exists for [`control`], which must confirm the value it PLANTED survived
+    /// into the observation — a divergence that is not attributable to the plant
+    /// is not a positive control, it is noise that happens to be red.
+    ///
+    /// Deliberately not part of the leak comparison: [`canonicalise`] still
+    /// cannot name the secret, and nothing on the `check` path calls this.
+    fn contains(&self, needle: &str) -> bool {
+        self.machine_config.contains(needle) || self.console.contains(needle)
+    }
+}
+
 /// Structural facts about a run that differ between boots and carry no secret.
 ///
 /// Passed in rather than discovered, so the canonicaliser erases only what a
@@ -126,10 +140,16 @@ const EXCERPT_BYTES: usize = 120;
 ///   only a leading `[...]` or ISO-8601 prefix, so a secret that happened to
 ///   contain digits is untouched.
 /// * **socket paths under the pod dir** — contain the pod UUID, already covered.
+/// * **the embedded audit boot clock** — see [`strip_embedded_audit_clock`].
+/// * **the RTC wall clock** — see [`strip_rtc_wall_clock`].
+/// * **the session task token's run-scoped fields** — see
+///   [`canonicalise_task_token_hex`]. The token is DECODED, not blanked: its
+///   `scope.allowed_operations` / `scope.allowed_paths` stay compared, because
+///   that is exactly where a policy-derived leak would land.
 ///
-/// Nothing else is erased. In particular the kernel command line is compared in
-/// full, because it is where `nucleus.auth_secret` already rides and is the most
-/// likely place for a real leak.
+/// Nothing else is erased. In particular the rest of the kernel command line is
+/// compared in full, because it is where `nucleus.auth_secret` already rides and
+/// is the most likely place for a real leak.
 #[must_use]
 pub fn canonicalise(obs: &Observation, facts: &RunFacts) -> Canonical {
     Canonical {
@@ -142,6 +162,18 @@ fn scrub(s: &str, facts: &RunFacts) -> String {
     s.lines()
         .map(|line| {
             let line = strip_leading_timestamp(line);
+            // ORDER IS LOAD-BEARING. The task token is hex-encoded, and the pod
+            // UUID rides INSIDE it as `task_id`. Decoding first is what lets the
+            // pod-UUID rule below reach it; run the other way round, the hex
+            // hides the UUID and every pair of boots diverges here forever.
+            // `decoding_the_token_first_is_what_lets_the_pod_id_rule_reach_it`
+            // pins the order.
+            let line = canonicalise_task_token_hex(line);
+            // Only reachable when the rule above DECLINED, i.e. the token was
+            // truncated by the kernel's own echo. A complete token is decoded
+            // and compared field-wise; this never sees it.
+            let line = normalise_truncated_cmdline_echo(&line);
+            let line = canonicalise_task_token_nonce(&line);
             // The pod UUID is long and structurally unique, so a plain
             // replacement is safe.
             let line = line.replace(&facts.pod_id, "<POD-ID>");
@@ -151,10 +183,28 @@ fn scrub(s: &str, facts: &RunFacts) -> String {
             // `a_secret_containing_the_cid_digit_survives` pins this; the first
             // version replaced the bare digit and would have gone blind to any
             // secret containing it.
-            line.replace(
+            //
+            // BOTH SPACINGS, because the shipped rule matched only the compact
+            // one and the real artifact is pretty-printed. Firecracker's
+            // `config.json` in the jail contains `    "guest_cid": 3,` WITH a
+            // space, so this rule had NEVER FIRED on a real observation — it was
+            // green only because every boot measured so far happened to be
+            // allocated cid 3, making the erasure a no-op that nothing needed.
+            // The first pair of boots with different CIDs would have reported a
+            // permanent false divergence. Same shape as a gate that hardcodes a
+            // dimension: correct-looking, and untested by construction.
+            // `the_cid_rule_fires_on_a_real_pretty_printed_config` pins the
+            // pretty form against a fixture copied out of a live VM.
+            let line = line.replace(
                 &format!("\"guest_cid\":{}", facts.guest_cid),
                 "\"guest_cid\":<CID>",
-            )
+            );
+            let line = line.replace(
+                &format!("\"guest_cid\": {}", facts.guest_cid),
+                "\"guest_cid\": <CID>",
+            );
+            let line = strip_embedded_audit_clock(&line);
+            strip_rtc_wall_clock(&line)
         })
         .collect::<Vec<_>>()
         .join("\n")
@@ -188,6 +238,405 @@ fn strip_leading_timestamp(line: &str) -> &str {
     line
 }
 
+// ---------------------------------------------------------------------------
+// RULE 1 — the EMBEDDED boot clock.
+// ---------------------------------------------------------------------------
+
+/// The literal that opens an audit record header.
+const AUDIT_OPEN: &str = "audit(";
+
+/// Erase the boot-clock reading inside an `audit(SECS.MSECS:SERIAL)` header.
+///
+/// Measured on two real boots five days apart, this is one of exactly three
+/// console lines that survived the pre-existing canonicaliser:
+///
+/// ```text
+/// audit: type=2000 audit(0.280:1): state=initialized audit_enabled=0 res=1
+/// audit: type=2000 audit(0.310:1): state=initialized audit_enabled=0 res=1
+/// ```
+///
+/// [`strip_leading_timestamp`] cannot reach it: this clock is not in leading
+/// position, it is a second reading embedded mid-line.
+///
+/// # WHY A SECRET CANNOT REACH THIS POSITION
+///
+/// Not "because it is a timestamp". Two independent reasons, and the rule is
+/// sound if either holds:
+///
+/// 1. **Nothing can write there.** The bytes between `audit(` and `:` are
+///    emitted by the guest kernel's audit subsystem, which formats every record
+///    header itself from `audit_log_start` — a clock read plus a kernel-global
+///    serial counter, through purely NUMERIC format specifiers. There is no
+///    `%s` in that position, so no byte-string from the host, the pod spec, the
+///    credential set, or the workload can be routed into it. A leak has no
+///    mechanism to land between those two delimiters.
+/// 2. **Only a numeric shape is erased anyway.** The replacement fires only
+///    when the delimited span is `digits '.' digits` — one dot, digits on both
+///    sides, nothing else. This is a syntactic class in a structural position,
+///    never a value: the erasure does not know, and cannot be told, what the
+///    secret is.
+///
+/// The record BODY (`state=initialized …`) and the serial (`:1`) are left
+/// compared in full. If the serial ever diverges, this reports it rather than
+/// absorbing it.
+///
+/// # WHAT THIS BLINDS THE HARNESS TO
+///
+/// A leak whose entire text is `digits.digits`, positioned immediately after a
+/// literal `audit(` and immediately before a `:`. Nothing else.
+fn strip_embedded_audit_clock(line: &str) -> String {
+    let mut out = String::with_capacity(line.len());
+    let mut rest = line;
+    while let Some(i) = rest.find(AUDIT_OPEN) {
+        let (head, tail) = rest.split_at(i + AUDIT_OPEN.len());
+        out.push_str(head);
+        // The reading is delimited by the `:` that separates it from the serial.
+        // Bounded to this line, and the span must be numeric or nothing happens.
+        match tail.split_once(':') {
+            Some((span, after)) if is_boot_clock_reading(span) => {
+                out.push_str("<BOOT-CLOCK>:");
+                rest = after;
+            }
+            _ => rest = tail,
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
+/// `digits '.' digits` — exactly one dot, at least one digit either side.
+fn is_boot_clock_reading(s: &str) -> bool {
+    match s.split_once('.') {
+        Some((secs, frac)) => {
+            !secs.is_empty()
+                && !frac.is_empty()
+                && secs.bytes().all(|b| b.is_ascii_digit())
+                && frac.bytes().all(|b| b.is_ascii_digit())
+        }
+        None => false,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// RULE 2 — the RTC wall clock.
+// ---------------------------------------------------------------------------
+
+/// The driver-emitted literal that introduces the wall-clock reading.
+const RTC_PREFIX: &str = ": setting system clock to ";
+
+/// Erase the wall-clock reading in the RTC hand-off line.
+///
+/// The second of the three surviving console lines:
+///
+/// ```text
+/// rtc-pl031 40001000.rtc: setting system clock to 2026-07-30T21:08:39 UTC (1785445719)
+/// rtc-pl031 40001000.rtc: setting system clock to 2026-08-04T10:45:20 UTC (1785840320)
+/// ```
+///
+/// # WHY A SECRET CANNOT REACH THIS POSITION
+///
+/// Again two independent reasons:
+///
+/// 1. **Nothing can write there.** The line is emitted by the guest kernel's
+///    RTC-to-system-clock hand-off (`drivers/rtc/hctosys.c`) from a fixed format
+///    string whose arguments are a decoded `struct rtc_time` and a `time64_t` —
+///    both NUMERIC. The value originates in the emulated RTC device, which the
+///    VMM backs with the host clock. No pod spec field, credential, or guest
+///    byte-string has a path into that format argument.
+/// 2. **Only a timestamp shape is erased anyway.** The tail must be exactly
+///    `YYYY-MM-DDTHH:MM:SS UTC (digits)` and must run to end of line. A tail
+///    that is one character off — including a leak appended after the reading —
+///    is left compared in full, so the harness fail-LOUDS rather than absorbing.
+///
+/// The device prefix (`rtc-pl031 40001000.rtc`) is left compared: a leak into
+/// the device name still surfaces.
+///
+/// # WHAT THIS BLINDS THE HARNESS TO
+///
+/// A leak that is byte-for-byte an ISO-8601 second-resolution timestamp followed
+/// by ` UTC (digits)`, occupying the whole tail of a line that already contains
+/// the literal `: setting system clock to `. Nothing else.
+fn strip_rtc_wall_clock(line: &str) -> String {
+    let Some(i) = line.find(RTC_PREFIX) else {
+        return line.to_string();
+    };
+    let (head, tail) = line.split_at(i + RTC_PREFIX.len());
+    if is_rtc_reading(tail) {
+        format!("{head}<RTC-WALL-CLOCK>")
+    } else {
+        line.to_string()
+    }
+}
+
+/// `YYYY-MM-DDTHH:MM:SS UTC (<digits>)`, and nothing after it.
+fn is_rtc_reading(s: &str) -> bool {
+    let Some((iso, epoch)) = s.split_once(" UTC (") else {
+        return false;
+    };
+    let Some(digits) = epoch.strip_suffix(')') else {
+        return false;
+    };
+    is_iso8601_second(iso) && !digits.is_empty() && digits.bytes().all(|b| b.is_ascii_digit())
+}
+
+/// Exactly `YYYY-MM-DDTHH:MM:SS` — fixed width, fixed separators, digits
+/// everywhere else. Deliberately not a date PARSER: a parser accepts a family of
+/// shapes, and every extra shape it accepts is another shape a leak could wear.
+fn is_iso8601_second(s: &str) -> bool {
+    let b = s.as_bytes();
+    b.len() == 19
+        && b[4] == b'-'
+        && b[7] == b'-'
+        && b[10] == b'T'
+        && b[13] == b':'
+        && b[16] == b':'
+        && [0, 1, 2, 3, 5, 6, 8, 9, 11, 12, 14, 15, 17, 18]
+            .iter()
+            .all(|&i| b[i].is_ascii_digit())
+}
+
+// ---------------------------------------------------------------------------
+// RULE 3 — the session task token. THE ONE WITH A REAL DESIGN QUESTION.
+// ---------------------------------------------------------------------------
+
+/// The kernel-cmdline key carrying the hex-encoded session task token.
+const TOKEN_HEX_KEY: &str = "nucleus.task_token_hex=";
+
+/// The kernel-cmdline key carrying the hex-encoded effective block nonce.
+const TOKEN_NONCE_KEY: &str = "nucleus.task_token_nonce=";
+
+/// Hex width of the 16-byte block nonce (`NONCE_LEN` in the node's mint site).
+const TOKEN_NONCE_HEX_LEN: usize = 32;
+
+/// Normalise the run-scoped fields of the session task token, **by decoding it**.
+///
+/// This is the third surviving difference, and it accounts for two of them: the
+/// `boot_args` in the machine config, and the kernel's own `Kernel command line:`
+/// echo on the console — the same bytes, so one rule covers both.
+///
+/// # The easy answer is wrong
+///
+/// Blanking `nucleus.task_token_hex=<hex>` wholesale would take one line of code
+/// and would make this harness permanently unable to see a leak into
+/// `scope.allowed_operations` or `scope.allowed_paths` — which the token
+/// carries, which are derived from the pod's resolved policy, and which are
+/// therefore the single most plausible place in this token for a real leak. That
+/// is an erasure of the interesting part to normalise away the boring part.
+///
+/// So the token is hex-decoded to its JSON, and only three fields are erased,
+/// each in a fixed STRUCTURAL position and only when it wears the expected
+/// syntactic class:
+///
+/// | field                    | position                  | erased when it is |
+/// |--------------------------|---------------------------|-------------------|
+/// | `nonce`                  | `blocks[i].claim.nonce`   | an array of numbers |
+/// | `issued_at`              | `blocks[i].claim.issued_at` | a number        |
+/// | `sig`                    | `blocks[i].sig`           | an array of numbers |
+///
+/// Everything else stays COMPARED: `task_id`, `scope.allowed_operations`,
+/// `scope.allowed_paths`, `ttl`, `issuer_vk`, and `parent_hash`.
+///
+/// # WHY NONE OF THE THREE CAN CARRY THE POD SECRET
+///
+/// * **`nonce`** — the mint site draws it straight from the OS CSPRNG
+///   (`OsRng.fill_bytes`) into a fresh `[u8; 16]` *before it reads any of its
+///   arguments*, and its arguments are `(task_id, policy, ttl, now, issuer)`.
+///   The pod secret is not among them. This is the same construction as
+///   [`canonicalise`] not taking the secret: **a function cannot reach what it
+///   cannot name.** It is also fixed-width — 16 bytes, deserialised from exactly
+///   16 JSON numbers — so it is not a channel of unbounded width.
+/// * **`issued_at`** — a `u64` of UNIX seconds read from the spawn site's clock.
+///   The erasure fires only on a JSON *number*, so the position cannot hold a
+///   string at all; a leak would have to be pre-encoded into a single 64-bit
+///   integer by something that already had the secret and a channel out.
+/// * **`sig`** — this one needs no trust in the mint site at all. Ed25519 is
+///   DETERMINISTIC (RFC 8032): the signature is a pure function of the issuer's
+///   key and `signing_bytes(task_id, claim)`, which is a serialisation of
+///   `task_id` and *the whole claim*. Every input to `sig` other than `nonce`
+///   and `issued_at` is a field this rule leaves compared. So `sig` carries no
+///   information the harness has not already compared elsewhere, and erasing it
+///   removes exactly zero comparison power. It differs between boots only
+///   BECAUSE `nonce` and `issued_at` do.
+///
+/// # Fail-loud, never fail-quiet
+///
+/// If the value is not valid hex, or does not decode to UTF-8, or does not parse
+/// as JSON, the ORIGINAL hex is left in place and compared in full. A malformed
+/// token becomes a reported divergence, not a silent pass.
+///
+/// # WHAT THIS BLINDS THE HARNESS TO
+///
+/// A leak into the 16 CSPRNG nonce bytes, into the 64-bit `issued_at`, or — only
+/// by way of those two — into the signature. Nothing in the scope, the task id,
+/// the TTL, or the issuer key.
+fn canonicalise_task_token_hex(line: &str) -> String {
+    rewrite_hex_valued_key(line, TOKEN_HEX_KEY, |hex_value| {
+        let bytes = hex::decode(hex_value).ok()?;
+        let text = String::from_utf8(bytes).ok()?;
+        let mut token: serde_json::Value = serde_json::from_str(&text).ok()?;
+        erase_run_scoped_token_fields(&mut token);
+        // Compact serialisation: no interior newline can ever be produced (JSON
+        // escapes them inside strings), so the line structure the whole
+        // comparison rests on survives decoding.
+        serde_json::to_string(&token).ok()
+    })
+}
+
+/// Erase `nucleus.task_token_nonce=<hex>` whole.
+///
+/// # WHY THIS ONE MAY BE ERASED WHOLE
+///
+/// Unlike the token, this value has no interior structure to preserve: it is the
+/// lowercase hex of *the very same 16 CSPRNG bytes* that
+/// [`canonicalise_task_token_hex`] erases as `blocks[i].claim.nonce`. Erasing it
+/// is therefore not a second erasure — it removes the duplicate encoding of one
+/// already-argued field. The provenance argument is the nonce argument above:
+/// drawn from `OsRng` at a call site whose arguments do not include the secret.
+///
+/// Still narrow: the value must be exactly 32 hex characters, the width the mint
+/// site pins. A value of any other width — including one a leak lengthened — is
+/// left compared in full.
+///
+/// # WHAT THIS BLINDS THE HARNESS TO
+///
+/// A leak that is exactly 32 hexadecimal characters occupying the whole value of
+/// `nucleus.task_token_nonce`.
+fn canonicalise_task_token_nonce(line: &str) -> String {
+    rewrite_hex_valued_key(line, TOKEN_NONCE_KEY, |hex_value| {
+        (hex_value.len() == TOKEN_NONCE_HEX_LEN).then(|| "<TASK-TOKEN-NONCE>".to_string())
+    })
+}
+
+/// The literal the guest kernel uses to echo its own command line.
+const CMDLINE_ECHO: &str = "Kernel command line: ";
+
+/// Normalise the task token in the guest kernel's **truncated** command-line
+/// echo. Measured cause of the single residual difference left after rule 3.
+///
+/// # What is actually going on, because it is not obvious
+///
+/// The guest kernel echoes its command line, and truncates that echo at a fixed
+/// byte width (1004 bytes on both measured boots). The cut therefore lands at a
+/// **content-dependent field offset**: the run-scoped `nonce` and `issued_at`
+/// serialise to different widths on different boots, so the two runs end their
+/// echo holding different FRAGMENTS of the field that follows. After rule 3 has
+/// erased every run-scoped field, the two lines still differ — one ends
+/// `"issuer_vk":[143,178,249,216,11,158,32,167,19` and the other
+/// `…,167,19,14`.
+///
+/// No field-wise rule can fix that, because there is no field there: there is
+/// half of one. Rule 3 correctly declines (its fail-loud path), leaving the raw
+/// hex compared, and the two boots diverge forever on this one line.
+///
+/// # WHY ERASING IT COSTS THE HARNESS NOTHING
+///
+/// Same shape of argument as `sig` in rule 3: **this value is a strictly lossy
+/// duplicate of bytes the same [`Observation`] already compares in full.** The
+/// echo is the guest kernel printing back `image.boot_args` from the machine
+/// config — the very field `machine_config` carries untruncated, and which rule
+/// 3 decodes there and compares field by field including
+/// `scope.allowed_operations` and `scope.allowed_paths`. A leak into the token
+/// is caught in `machine_config`; erasing the truncated copy of it removes no
+/// comparison the harness was making.
+///
+/// # Narrowness
+///
+/// Three independent conditions, all of which must hold:
+///
+/// 1. the line must start with the kernel's own `Kernel command line: ` literal;
+/// 2. the value must still be raw hexadecimal, i.e. rule 3 must have DECLINED to
+///    decode it — a complete, parseable token was already decoded and had only
+///    its run-scoped fields erased, and is left exactly as rule 3 left it;
+/// 3. only the `nucleus.task_token_hex` value is touched. Everything else on the
+///    echoed line — `nucleus.approval_secret`, `nucleus.workload_api_port`,
+///    `console`, `init`, `panic`, `pci`, `reboot`, `ipv6.disable` — stays
+///    compared in full, which is where a leak into the command line would land.
+///
+/// # WHAT THIS BLINDS THE HARNESS TO
+///
+/// Stated precisely, because it is the widest erasure in this module: a guest
+/// that echoed a task token DIFFERENT from the one the host wrote into
+/// `boot_args`, in the truncated region only, and only on a boot long enough to
+/// truncate. Nothing about the token's own content, which `machine_config`
+/// compares untruncated. If you would rather not buy that, delete this rule; the
+/// residual becomes exactly one line and the other three rules are unaffected.
+fn normalise_truncated_cmdline_echo(line: &str) -> String {
+    if !line.starts_with(CMDLINE_ECHO) {
+        return line.to_string();
+    }
+    rewrite_hex_valued_key(line, TOKEN_HEX_KEY, |hex_value| {
+        (!hex_value.is_empty()).then(|| "<TRUNCATED-CMDLINE-TOKEN-ECHO>".to_string())
+    })
+}
+
+/// Rewrite the value of every `key=<hex…>` occurrence in `line`.
+///
+/// The value is delimited by the first NON-hex character, which is what makes
+/// this safe on both surfaces the token appears on: the whitespace-delimited
+/// kernel command line, and the same command line embedded in a JSON string in
+/// `config.json` (where the closing `"` terminates it). `f` returning `None`
+/// leaves the original bytes untouched — the fail-loud path.
+fn rewrite_hex_valued_key(line: &str, key: &str, f: impl Fn(&str) -> Option<String>) -> String {
+    let mut out = String::with_capacity(line.len());
+    let mut rest = line;
+    while let Some(i) = rest.find(key) {
+        let (head, tail) = rest.split_at(i + key.len());
+        out.push_str(head);
+        let end = tail
+            .find(|c: char| !c.is_ascii_hexdigit())
+            .unwrap_or(tail.len());
+        let (value, after) = tail.split_at(end);
+        match f(value) {
+            Some(replacement) => out.push_str(&replacement),
+            None => out.push_str(value),
+        }
+        rest = after;
+    }
+    out.push_str(rest);
+    out
+}
+
+/// Erase the three run-scoped token fields, each at a fixed structural path and
+/// only when it wears the expected syntactic class.
+///
+/// Walks the path explicitly rather than searching for field NAMES, so a
+/// `"nonce"` that appeared as an allowed path or an operation name — i.e. in the
+/// part a leak would reach — is untouched.
+fn erase_run_scoped_token_fields(token: &mut serde_json::Value) {
+    let Some(blocks) = token
+        .get_mut("blocks")
+        .and_then(serde_json::Value::as_array_mut)
+    else {
+        return;
+    };
+    for block in blocks.iter_mut() {
+        erase_number_array(block.get_mut("sig"), "<TASK-TOKEN-SIG>");
+        let Some(claim) = block.get_mut("claim") else {
+            continue;
+        };
+        erase_number_array(claim.get_mut("nonce"), "<TASK-TOKEN-NONCE>");
+        if let Some(issued_at) = claim.get_mut("issued_at") {
+            if issued_at.is_number() {
+                *issued_at = serde_json::Value::String("<TASK-TOKEN-ISSUED-AT>".to_string());
+            }
+        }
+    }
+}
+
+/// Replace `slot` with `marker` iff it is a JSON array whose every element is a
+/// number — the wire form of a fixed-width byte array. Anything else (a string,
+/// an object, a mixed array) is left compared.
+fn erase_number_array(slot: Option<&mut serde_json::Value>, marker: &str) {
+    if let Some(value) = slot {
+        if value
+            .as_array()
+            .is_some_and(|a| a.iter().all(serde_json::Value::is_number))
+        {
+            *value = serde_json::Value::String(marker.to_string());
+        }
+    }
+}
+
 /// Compare two canonical observations from runs differing only in a secret.
 ///
 /// # Errors
@@ -204,6 +653,52 @@ pub fn compare(a: &Canonical, b: &Canonical) -> Result<(), Divergence> {
     Ok(())
 }
 
+/// EVERY differing line, not just the first.
+///
+/// # "First divergence" is not "only divergence"
+///
+/// [`compare`] short-circuits, which is right for a gate but wrong for judging a
+/// canonicalisation rule: a rule that fixes line 39 and leaves lines 112 and 185
+/// alone looks identical, through `compare`, to a rule that fixed everything —
+/// the reported line number just moves. Every claim in this module's rule
+/// documentation about how many differences a rule removes is measured with
+/// this, and a residual of zero means this returned empty, not that `compare`
+/// stopped early.
+#[must_use]
+pub fn all_differences(a: &Canonical, b: &Canonical) -> Vec<Divergence> {
+    let mut out = Vec::new();
+    for (component, x, y) in [
+        ("machine_config", &a.machine_config, &b.machine_config),
+        ("console", &a.console, &b.console),
+    ] {
+        let xl: Vec<&str> = x.lines().collect();
+        let yl: Vec<&str> = y.lines().collect();
+        for i in 0..xl.len().max(yl.len()) {
+            let (p, q) = (xl.get(i).copied(), yl.get(i).copied());
+            if p != q {
+                out.push(divergence_at(
+                    component,
+                    i + 1,
+                    p.or(q).unwrap_or("<absent>"),
+                ));
+            }
+        }
+    }
+    out
+}
+
+fn divergence_at(component: &'static str, line: usize, shown: &str) -> Divergence {
+    let mut excerpt: String = shown.chars().take(EXCERPT_BYTES).collect();
+    if shown.len() > excerpt.len() {
+        excerpt.push('…');
+    }
+    Divergence {
+        component,
+        line,
+        excerpt,
+    }
+}
+
 fn first_difference(component: &'static str, x: &str, y: &str) -> Option<Divergence> {
     let (mut xl, mut yl) = (x.lines(), y.lines());
     let mut n = 0usize;
@@ -213,16 +708,7 @@ fn first_difference(component: &'static str, x: &str, y: &str) -> Option<Diverge
             (None, None) => return None,
             (a, b) if a == b => continue,
             (a, b) => {
-                let shown = a.or(b).unwrap_or("<absent>");
-                let mut excerpt: String = shown.chars().take(EXCERPT_BYTES).collect();
-                if shown.len() > excerpt.len() {
-                    excerpt.push('…');
-                }
-                return Some(Divergence {
-                    component,
-                    line: n,
-                    excerpt,
-                });
+                return Some(divergence_at(component, n, a.or(b).unwrap_or("<absent>")));
             }
         }
     }
@@ -294,23 +780,35 @@ pub enum TwoSafetyError {
     /// "the experiment did not run" and "the experiment found a leak" are
     /// different answers and only one is about the system.
     Harness(String),
-    /// Two runs differing only in a secret produced different observations.
-    Leak(Divergence),
     /// The positive control did NOT find a planted secret, so the comparison is
     /// blind and every passing result above it is meaningless.
     ControlDidNotFire,
+    /// The control runs DID diverge, but not because of the planted secret.
+    ///
+    /// A distinct outcome from [`Self::ControlDidNotFire`] because it is a
+    /// distinct failure: the harness produced a red for a reason it cannot
+    /// attribute, which certifies nothing. Against a real pod this is the
+    /// likely shape — two boots differ in run-scoped values anyway — and
+    /// collapsing it into "the control fired" is exactly the confound this
+    /// variant exists to name.
+    ControlNotAttributable(String),
 }
 
 impl fmt::Display for TwoSafetyError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             TwoSafetyError::Harness(m) => write!(f, "the 2-safety harness could not run: {m}"),
-            TwoSafetyError::Leak(d) => write!(f, "{d}"),
             TwoSafetyError::ControlDidNotFire => write!(
                 f,
                 "the positive control did not fire: a secret planted directly in the kernel \
                  command line was NOT detected. The comparison is blind, so a clean result \
                  from it means nothing."
+            ),
+            TwoSafetyError::ControlNotAttributable(m) => write!(
+                f,
+                "the positive control diverged but NOT because of the plant: {m}. A \
+                 divergence the harness cannot attribute to the value it planted is noise \
+                 that happens to be red, and certifies nothing."
             ),
         }
     }
@@ -349,30 +847,112 @@ fn observe(b: &mut dyn Boot, secret: &str, plant: bool) -> Result<Canonical, Two
 /// all report "no leak" forever. Running it first means a blind harness is
 /// reported as blind rather than as clean.
 ///
+/// # A divergence is not evidence. An ATTRIBUTABLE divergence is.
+///
+/// The first version of this accepted ANY divergence between the two control
+/// runs. That is a valid control against the fake `Boot`, whose two runs are
+/// otherwise byte-identical, so any difference must be the plant. It is NOT
+/// valid against a real pod: two boots differing in nothing still differ in
+/// `nucleus.task_token_hex` and `nucleus.task_token_nonce` on the same
+/// `boot_args` line, so `compare` returned `Err` at `machine_config` line 4
+/// whether the plant worked or not.
+///
+/// It was caught by perturbation, not by reading: with the plant **completely
+/// removed**, `control()` still returned `Ok`. The gate went red at the right
+/// line for the wrong cause — so it certified a harness it had not tested.
+///
+/// The contract it needs is therefore not "the two runs differ" but "the two
+/// runs differ **because of the value this function planted**". That is checked
+/// three ways, and every one of them must hold:
+///
+/// 1. each run's canonical observation CONTAINS the value planted into it —
+///    otherwise the plant never reached the observation at all;
+/// 2. neither run contains the OTHER's value — which rules out a constant echo
+///    that would satisfy (1) while carrying no per-run information;
+/// 3. the two observations then differ.
+///
+/// No boot-to-boot noise can satisfy (1) and (2): nondeterminism cannot invent
+/// the exact byte string this function chose, in the run that chose it and not
+/// in the other.
+///
+/// **This does not weaken [`canonicalise`]'s guarantee.** The canonicaliser
+/// still cannot name the secret. Only the control can, and only because it is
+/// the thing that planted it — knowing what you planted is the definition of a
+/// positive control.
+///
 /// # Errors
-/// [`TwoSafetyError::ControlDidNotFire`] if the planted secret is not detected.
+/// [`TwoSafetyError::ControlDidNotFire`] if the planted secret is not detected,
+/// or is detected but not attributable to the plant.
 pub fn control(b: &mut dyn Boot) -> Result<(), TwoSafetyError> {
-    let a = observe(b, "twosafety-control-aaaaaaaa", true)?;
-    let c = observe(b, "twosafety-control-bbbbbbbb", true)?;
+    const PLANT_A: &str = "twosafety-control-aaaaaaaa";
+    const PLANT_B: &str = "twosafety-control-bbbbbbbb";
+
+    let a = observe(b, PLANT_A, true)?;
+    let c = observe(b, PLANT_B, true)?;
+
+    // (1) the plant reached the observation.
+    if !a.contains(PLANT_A) {
+        return Err(TwoSafetyError::ControlNotAttributable(
+            "run A's planted value never reached its canonical observation".into(),
+        ));
+    }
+    if !c.contains(PLANT_B) {
+        return Err(TwoSafetyError::ControlNotAttributable(
+            "run B's planted value never reached its canonical observation".into(),
+        ));
+    }
+    // (2) it is per-run, not a constant echo.
+    if a.contains(PLANT_B) || c.contains(PLANT_A) {
+        return Err(TwoSafetyError::ControlNotAttributable(
+            "each control run carries BOTH planted values, so the observation is not a \
+             function of the run's own secret"
+                .into(),
+        ));
+    }
+    // (3) and it actually produces a divergence.
     match compare(&a, &c) {
         Err(_) => Ok(()),
         Ok(()) => Err(TwoSafetyError::ControlDidNotFire),
     }
 }
 
-/// The check itself: two runs differing only in a secret must be indistinguishable.
+/// Why [`check_all`] did not come back clean.
+#[derive(Debug)]
+pub enum CheckFailure {
+    /// The experiment could not be run.
+    Harness(TwoSafetyError),
+    /// Every region in which the two runs disagreed — never just the first.
+    Diverged(Vec<Divergence>),
+}
+
+/// [`check`], but reporting EVERY residual difference rather than the first.
 ///
-/// Enumerates no mechanisms. A channel nobody wrote down shows up as a
-/// difference, which is the whole reason this is a hyperproperty test and not
-/// another leak scan.
+/// # Why the first one is not enough
+///
+/// While a residual is being worked down, `compare`'s single answer is
+/// ambiguous in the worst way: a canonicalisation rule that fixes one of three
+/// differing regions is indistinguishable from one that fixes all three,
+/// because either way the next run reports "a divergence" and only the line
+/// number moves. That turns a partial fix into something that reads like
+/// progress, and a complete fix into something that reads like failure.
+///
+/// It is also how a residual gets miscounted downward: measuring only the first
+/// difference on two real boots reported "1 line" where the honest answer was
+/// three, and the two that were not looked at were the two nobody had a rule
+/// for.
 ///
 /// # Errors
-/// [`TwoSafetyError::Leak`] with the differing component, or `Harness` if a boot
-/// or collection failed.
-pub fn check(b: &mut dyn Boot) -> Result<(), TwoSafetyError> {
-    let a = observe(b, "twosafety-secret-aaaaaaaa", false)?;
-    let c = observe(b, "twosafety-secret-bbbbbbbb", false)?;
-    compare(&a, &c).map_err(TwoSafetyError::Leak)
+/// [`CheckFailure::Diverged`] with every differing region, or
+/// [`CheckFailure::Harness`] if a boot or collection failed.
+pub fn check_all(b: &mut dyn Boot) -> Result<(), CheckFailure> {
+    let a = observe(b, "twosafety-secret-aaaaaaaa", false).map_err(CheckFailure::Harness)?;
+    let c = observe(b, "twosafety-secret-bbbbbbbb", false).map_err(CheckFailure::Harness)?;
+    let ds = all_differences(&a, &c);
+    if ds.is_empty() {
+        Ok(())
+    } else {
+        Err(CheckFailure::Diverged(ds))
+    }
 }
 
 #[cfg(test)]
@@ -576,6 +1156,395 @@ mod tests {
         assert!(compare(&a, &b).is_err(), "a short run is not a clean run");
     }
 
+    /// **`compare` short-circuits; judging a canonicalisation rule must not.**
+    /// Three differing lines must be reported as three, or a rule that fixed one
+    /// of them would be indistinguishable from a rule that fixed all three.
+    #[test]
+    fn all_differences_sees_past_the_first() {
+        let a = canonicalise(
+            &obs_for(&facts(), "console=ttyS0", "p\nQ\nr\nS\nt\nU"),
+            &facts(),
+        );
+        let b = canonicalise(
+            &obs_for(&other_facts(), "console=ttyS0", "p\nq\nr\ns\nt\nu"),
+            &other_facts(),
+        );
+        let all = all_differences(&a, &b);
+        assert_eq!(all.len(), 3, "three differing lines: {all:?}");
+        assert_eq!(
+            all.iter().map(|d| d.line).collect::<Vec<_>>(),
+            vec![2, 4, 6]
+        );
+        assert_eq!(
+            compare(&a, &b).expect_err("differs").line,
+            all[0].line,
+            "and the first one agrees with compare"
+        );
+        assert!(
+            all_differences(&a, &a).is_empty(),
+            "an identical pair has no differences"
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // RULE 1 — embedded audit boot clock.
+    // -----------------------------------------------------------------
+
+    /// The two lines as they actually appeared on two real boots five days
+    /// apart. Verbatim, so if the kernel's format ever changes this test is what
+    /// notices rather than a mystery divergence in CI.
+    const AUDIT_A: &str =
+        "audit: type=2000 audit(0.280:1): state=initialized audit_enabled=0 res=1";
+    const AUDIT_B: &str =
+        "audit: type=2000 audit(0.310:1): state=initialized audit_enabled=0 res=1";
+
+    #[test]
+    fn the_embedded_audit_boot_clock_is_normalised() {
+        assert_eq!(
+            strip_embedded_audit_clock(AUDIT_A),
+            strip_embedded_audit_clock(AUDIT_B),
+            "two real boots must agree here after the rule"
+        );
+        assert!(
+            strip_embedded_audit_clock(AUDIT_A).contains("audit(<BOOT-CLOCK>:1)"),
+            "the serial stays compared: {}",
+            strip_embedded_audit_clock(AUDIT_A)
+        );
+        assert!(
+            strip_embedded_audit_clock(AUDIT_A).contains("state=initialized audit_enabled=0 res=1"),
+            "the record body stays compared in full"
+        );
+    }
+
+    /// **NON-VACUITY OF RULE 1.** A secret that is itself digit-and-dot shaped —
+    /// the exact class this rule erases — must survive everywhere except the one
+    /// structural slot. Each case names the exact substring that must survive:
+    /// the first version of this test asserted on `planted.rsplit(' ')`, which is
+    /// a token no rule was ever going to touch, so it passed with the syntactic
+    /// class check ripped out. A survival test that survives the mutation it
+    /// exists to catch is worse than no test.
+    #[test]
+    fn a_planted_secret_survives_the_audit_clock_rule() {
+        for (planted, must_survive) in [
+            // the erased syntactic class, but NOT in the structural position
+            ("audit: leak=0.310 tail", "leak=0.310"),
+            // inside the record body, right of the delimiter
+            (
+                "audit: type=2000 audit(0.280:1): cred=0.280 res=1",
+                "cred=0.280",
+            ),
+            // the literal is there, but the span is not the numeric class
+            ("audit(canary-1234-secret:1) tail", "canary-1234-secret"),
+            // a numeric-looking secret with no `audit(` in front of it
+            ("leaked 10.0.0.7 canary-3.14159", "10.0.0.7"),
+            // and one that is EXACTLY the class, just not after the literal
+            ("cred=0.280 audit: nothing here", "cred=0.280"),
+        ] {
+            let got = strip_embedded_audit_clock(planted);
+            assert!(
+                got.contains(must_survive),
+                "rule 1 erased a secret it must not touch: {planted:?} -> {got:?} \
+                 (expected {must_survive:?} to survive)"
+            );
+        }
+        // And the structural erasure is still happening — otherwise this test
+        // would pass with the rule deleted.
+        assert!(strip_embedded_audit_clock(AUDIT_A).contains("<BOOT-CLOCK>"));
+    }
+
+    // -----------------------------------------------------------------
+    // RULE 2 — RTC wall clock.
+    // -----------------------------------------------------------------
+
+    const RTC_A: &str =
+        "rtc-pl031 40001000.rtc: setting system clock to 2026-07-30T21:08:39 UTC (1785445719)";
+    const RTC_B: &str =
+        "rtc-pl031 40001000.rtc: setting system clock to 2026-08-04T10:45:20 UTC (1785840320)";
+
+    #[test]
+    fn the_rtc_wall_clock_is_normalised() {
+        assert_eq!(
+            strip_rtc_wall_clock(RTC_A),
+            strip_rtc_wall_clock(RTC_B),
+            "two real boots must agree here after the rule"
+        );
+        assert!(
+            strip_rtc_wall_clock(RTC_A).starts_with("rtc-pl031 40001000.rtc: setting system"),
+            "the device prefix stays compared: {}",
+            strip_rtc_wall_clock(RTC_A)
+        );
+    }
+
+    /// **NON-VACUITY OF RULE 2.** The shape check must be exact: anything that is
+    /// not byte-for-byte `<ISO> UTC (<digits>)` running to end of line is left
+    /// compared, INCLUDING a leak appended after a genuine reading.
+    #[test]
+    fn a_planted_secret_survives_the_rtc_rule() {
+        for planted in [
+            // a leak appended after a real reading — the tail no longer matches
+            "rtc-pl031 40001000.rtc: setting system clock to 2026-08-04T10:45:20 UTC (1785840320) canary-aaaa",
+            // the same date shape, on a line without the driver prefix
+            "hostinfo: built at 2026-08-04T10:45:20 UTC (1785840320)",
+            // a secret in the device-name position
+            "rtc-canary-aaaa 40001000.rtc: setting system clock to 2026-08-04T10:45:20 UTC (1785840320)",
+        ] {
+            let got = strip_rtc_wall_clock(planted);
+            assert!(
+                got.contains("canary-aaaa") || got == planted,
+                "rule 2 erased a secret it must not touch: {planted:?} -> {got:?}"
+            );
+        }
+        assert_eq!(
+            strip_rtc_wall_clock("hostinfo: built at 2026-08-04T10:45:20 UTC (1785840320)"),
+            "hostinfo: built at 2026-08-04T10:45:20 UTC (1785840320)",
+            "no driver prefix, so nothing is erased"
+        );
+        assert!(strip_rtc_wall_clock(RTC_A).contains("<RTC-WALL-CLOCK>"));
+    }
+
+    // -----------------------------------------------------------------
+    // RULE 3 — the session task token.
+    // -----------------------------------------------------------------
+
+    /// A token in the exact wire shape the node mints (`SignedTaskRef` through
+    /// `serde_json`), parameterised on everything that could differ.
+    fn token_json(
+        task_id: &str,
+        nonce_byte: u8,
+        issued_at: u64,
+        sig_byte: u8,
+        paths: &str,
+    ) -> String {
+        let bytes = |b: u8, n: usize| (0..n).map(|_| b.to_string()).collect::<Vec<_>>().join(",");
+        format!(
+            "{{\"task_id\":\"{task_id}\",\"blocks\":[{{\"claim\":{{\"scope\":\
+             {{\"allowed_operations\":[\"read_files\",\"run_bash\"],\"allowed_paths\":[{paths}]}},\
+             \"parent_hash\":null,\"nonce\":[{}],\"issued_at\":{issued_at},\"ttl\":120,\
+             \"issuer_vk\":[{}]}},\"sig\":[{}]}}]}}",
+            bytes(nonce_byte, 16),
+            bytes(7, 32),
+            bytes(sig_byte, 64),
+        )
+    }
+
+    fn cmdline_with_token(
+        task_id: &str,
+        nonce_byte: u8,
+        issued_at: u64,
+        sig: u8,
+        paths: &str,
+    ) -> String {
+        format!(
+            "console=ttyS0 nucleus.workload_api_port=15012 {TOKEN_HEX_KEY}{} \
+             {TOKEN_NONCE_KEY}{} nucleus.task_token_issuer=8fb2f9d8",
+            hex::encode(token_json(task_id, nonce_byte, issued_at, sig, paths)),
+            hex::encode([nonce_byte; 16]),
+        )
+    }
+
+    /// Two boots whose tokens differ ONLY in the run-scoped fields (and the pod
+    /// UUID) compare equal — the measured cause of the `boot_args` divergence
+    /// and of console line 39.
+    #[test]
+    fn the_task_token_run_scoped_fields_are_normalised() {
+        let fa = facts();
+        let fb = other_facts();
+        let a = scrub(
+            &cmdline_with_token(&fa.pod_id, 0x8e, 1_785_445_717, 0xd0, ""),
+            &fa,
+        );
+        let b = scrub(
+            &cmdline_with_token(&fb.pod_id, 0x30, 1_785_840_318, 0x89, ""),
+            &fb,
+        );
+        assert_eq!(a, b, "only run-scoped token fields differed");
+        assert!(a.contains("<TASK-TOKEN-NONCE>"), "nonce erased: {a}");
+        assert!(
+            a.contains("<TASK-TOKEN-ISSUED-AT>"),
+            "issued_at erased: {a}"
+        );
+        assert!(a.contains("<TASK-TOKEN-SIG>"), "sig erased: {a}");
+    }
+
+    /// **THE POINT OF DECODING RATHER THAN BLANKING, AND THE NON-VACUITY OF
+    /// RULE 3.**
+    ///
+    /// The one-line version of this rule — blank `nucleus.task_token_hex=<hex>`
+    /// — would pass every other test in this file and would make the harness
+    /// permanently blind to a leak into the token's scope. The scope is derived
+    /// from the pod's resolved policy, so it is the most plausible leak site in
+    /// the whole token. This asserts the scope is still COMPARED.
+    #[test]
+    fn a_secret_in_the_token_scope_survives_and_is_caught() {
+        let fa = facts();
+        let fb = other_facts();
+        let a = scrub(
+            &cmdline_with_token(&fa.pod_id, 0x8e, 1_785_445_717, 0xd0, "\"/x/canary-aaaa\""),
+            &fa,
+        );
+        let b = scrub(
+            &cmdline_with_token(&fb.pod_id, 0x30, 1_785_840_318, 0x89, "\"/x/canary-bbbb\""),
+            &fb,
+        );
+        assert!(
+            a.contains("canary-aaaa"),
+            "the token scope was erased; the harness is now blind to a policy leak: {a}"
+        );
+        assert_ne!(a, b, "a leak into scope.allowed_paths must still diverge");
+        // The operations dimension too — the other half of TokenScope.
+        assert!(
+            a.contains("read_files") && a.contains("run_bash"),
+            "allowed_operations must stay compared: {a}"
+        );
+        // ...and the fields that are NOT run-scoped.
+        assert!(a.contains("\"ttl\":120"), "ttl stays compared: {a}");
+        assert!(a.contains("\"issuer_vk\""), "issuer_vk stays compared: {a}");
+        assert!(
+            a.contains("\"parent_hash\":null"),
+            "parent_hash is deliberately NOT erased: {a}"
+        );
+    }
+
+    /// **ORDER IS LOAD-BEARING.** The pod UUID rides inside the token as
+    /// `task_id`, hex-encoded. If the token rule ran after the pod-UUID
+    /// replacement instead of before it, the UUID would stay hidden in hex and
+    /// every pair of boots would diverge here forever.
+    #[test]
+    fn decoding_the_token_first_is_what_lets_the_pod_id_rule_reach_it() {
+        let f = facts();
+        let out = scrub(&cmdline_with_token(&f.pod_id, 1, 1, 1, ""), &f);
+        assert!(
+            out.contains("\"task_id\":\"<POD-ID>\""),
+            "the pod UUID inside the decoded token must be normalised: {out}"
+        );
+        assert!(
+            !out.contains(&f.pod_id),
+            "the raw pod UUID must not survive: {out}"
+        );
+    }
+
+    /// **FAIL-LOUD, NOT FAIL-QUIET.** A token value that is not decodable hex, or
+    /// not JSON, is left COMPARED IN FULL. A canonicaliser that swallowed
+    /// malformed input would turn "the token was corrupted" into "no divergence".
+    #[test]
+    fn a_malformed_task_token_is_compared_not_erased() {
+        for value in [
+            format!("{TOKEN_HEX_KEY}deadbee"), // odd-length hex
+            format!("{TOKEN_HEX_KEY}{}", hex::encode("not json")), // decodes, not JSON
+            TOKEN_HEX_KEY.to_string(),         // empty value
+        ] {
+            assert_eq!(
+                canonicalise_task_token_hex(&value),
+                value,
+                "a malformed token must be left compared in full"
+            );
+        }
+    }
+
+    /// The nonce key is erased only at its pinned width. A value a leak
+    /// lengthened is left compared.
+    #[test]
+    fn the_task_token_nonce_is_erased_only_at_its_pinned_width() {
+        assert_eq!(
+            canonicalise_task_token_nonce(&format!("{TOKEN_NONCE_KEY}{}", "a".repeat(32))),
+            format!("{TOKEN_NONCE_KEY}<TASK-TOKEN-NONCE>")
+        );
+        for wrong in ["a".repeat(31), "a".repeat(33), String::new()] {
+            let line = format!("{TOKEN_NONCE_KEY}{wrong}");
+            assert_eq!(
+                canonicalise_task_token_nonce(&line),
+                line,
+                "width {} is not the pinned nonce width, so it stays compared",
+                wrong.len()
+            );
+        }
+        // A 32-hex-char value under a DIFFERENT key is untouched — the erasure
+        // is bound to the structural position, not to the shape alone.
+        let other = format!("nucleus.approval_secret={}", "a".repeat(32));
+        assert_eq!(canonicalise_task_token_nonce(&other), other);
+    }
+
+    /// **RULE 3c fires only on a TRUNCATED echo, and only on the echo.** A
+    /// complete token is decoded and compared field-wise wherever it appears; if
+    /// this rule ever started firing on complete tokens it would silently take
+    /// the scope out of the comparison, which is the exact failure rule 3 exists
+    /// to avoid.
+    #[test]
+    fn the_truncated_echo_rule_never_touches_a_complete_token() {
+        let f = facts();
+        let complete = format!(
+            "{CMDLINE_ECHO}{}",
+            cmdline_with_token(&f.pod_id, 1, 1, 1, "\"/x/canary-aaaa\"")
+        );
+        let out = scrub(&complete, &f);
+        assert!(
+            out.contains("canary-aaaa"),
+            "a COMPLETE echoed token must still be compared field-wise: {out}"
+        );
+        assert!(
+            !out.contains("<TRUNCATED-CMDLINE-TOKEN-ECHO>"),
+            "rule 3c must not fire on a complete token: {out}"
+        );
+
+        // Truncated: the hex is cut mid-JSON, so rule 3 declines and 3c fires.
+        let hex = hex::encode(token_json(&f.pod_id, 1, 1, 1, ""));
+        let truncated = format!(
+            "{CMDLINE_ECHO}console=ttyS0 {TOKEN_HEX_KEY}{}",
+            &hex[..hex.len() / 2]
+        );
+        let out = scrub(&truncated, &f);
+        assert!(
+            out.contains("<TRUNCATED-CMDLINE-TOKEN-ECHO>"),
+            "a truncated token must be normalised: {out}"
+        );
+        assert!(
+            out.contains("console=ttyS0"),
+            "the rest of the echo stays compared: {out}"
+        );
+
+        // Not the echo line: the same truncated hex elsewhere stays compared.
+        let elsewhere = format!("some other line {TOKEN_HEX_KEY}{}", &hex[..hex.len() / 2]);
+        assert_eq!(
+            scrub(&elsewhere, &f),
+            elsewhere,
+            "rule 3c is bound to the kernel's echo literal"
+        );
+    }
+
+    /// **NON-VACUITY OF RULE 3c.** Everything on the echoed command line other
+    /// than the truncated token value is still compared — including the key a
+    /// real secret already rides on.
+    #[test]
+    fn a_planted_secret_on_the_echoed_cmdline_survives_rule_3c() {
+        let f = facts();
+        let hex = hex::encode(token_json(&f.pod_id, 1, 1, 1, ""));
+        let line = format!(
+            "{CMDLINE_ECHO}console=ttyS0 nucleus.approval_secret=canary-aaaa \
+             nucleus.leak=canary-bbbb {TOKEN_HEX_KEY}{}",
+            &hex[..hex.len() / 2]
+        );
+        let out = scrub(&line, &f);
+        assert!(
+            out.contains("canary-aaaa") && out.contains("canary-bbbb"),
+            "rule 3c erased more than the token value: {out}"
+        );
+    }
+
+    /// A field NAMED `nonce` inside the part a leak would reach must survive —
+    /// the erasure walks a structural path, it does not hunt for field names.
+    #[test]
+    fn a_secret_named_like_a_run_scoped_field_survives() {
+        let f = facts();
+        let out = scrub(
+            &cmdline_with_token(&f.pod_id, 1, 1, 1, "\"/etc/nonce/canary-aaaa\",\"/sig\""),
+            &f,
+        );
+        assert!(
+            out.contains("/etc/nonce/canary-aaaa") && out.contains("/sig"),
+            "name-based erasure would have eaten these: {out}"
+        );
+    }
+
     /// The report names the section and does not print the secret.
     #[test]
     fn a_divergence_report_locates_without_disclosing() {
@@ -734,7 +1703,7 @@ mod orchestration {
     #[test]
     fn a_system_that_does_not_leak_passes() {
         let mut b = Fake::new(false, true);
-        assert!(check(&mut b).is_ok());
+        assert!(check_all(&mut b).is_ok());
     }
 
     /// A system that puts the secret on the console fails, with no mechanism
@@ -742,9 +1711,9 @@ mod orchestration {
     #[test]
     fn a_leak_to_the_console_is_caught() {
         let mut b = Fake::new(true, true);
-        match check(&mut b) {
-            Err(TwoSafetyError::Leak(d)) => assert_eq!(d.component, "console"),
-            other => panic!("expected a Leak, got {other:?}"),
+        match check_all(&mut b) {
+            Err(CheckFailure::Diverged(ds)) => assert_eq!(ds[0].component, "console"),
+            other => panic!("expected a divergence, got {other:?}"),
         }
     }
 
@@ -763,9 +1732,148 @@ mod orchestration {
     fn a_broken_plant_is_reported_as_blindness_not_as_clean() {
         let mut b = Fake::new(false, /* honour_plant */ false);
         match control(&mut b) {
-            Err(TwoSafetyError::ControlDidNotFire) => {}
+            Err(TwoSafetyError::ControlDidNotFire | TwoSafetyError::ControlNotAttributable(_)) => {}
             other => panic!("a blind harness must not look clean, got {other:?}"),
         }
+    }
+
+    /// **The confound that a fake `Boot` cannot exhibit, and the real system
+    /// does.**
+    ///
+    /// `control` used to accept ANY divergence between its two runs. Against
+    /// `Fake` that is sound — its two runs are otherwise byte-identical, so a
+    /// difference must be the plant. Against a real pod it is not: two boots
+    /// differing in NOTHING still differ in `nucleus.task_token_hex` and
+    /// `nucleus.task_token_nonce`, so `compare` returned `Err` at
+    /// `machine_config` line 4 whether the plant worked or not. With the plant
+    /// completely removed, `control()` still returned `Ok`.
+    ///
+    /// `NoisyUnplanted` reproduces exactly that shape in-process: per-run noise
+    /// that canonicalisation does NOT erase, and no plant. The old contract
+    /// passes it. The attributable contract must not — the divergence is real
+    /// and is not the plant's.
+    ///
+    /// This is the whole reason `Canonical::contains` exists.
+    #[test]
+    fn per_run_noise_is_not_mistaken_for_the_plant() {
+        struct NoisyUnplanted {
+            dir: tempfile::TempDir,
+            n: u32,
+        }
+        impl Boot for NoisyUnplanted {
+            fn boot(&mut self, _secret: &str, _plant: bool) -> io::Result<RunArtifacts> {
+                self.n += 1;
+                // Per-run token, exactly like the real `nucleus.task_token_nonce`:
+                // differs every boot, is NOT the planted secret, and no rule here
+                // erases it.
+                let config = self.dir.path().join(format!("c{}.json", self.n));
+                std::fs::write(
+                    &config,
+                    format!(
+                        "{{\"boot_args\":\"console=ttyS0 run_nonce=deadbeef{:04}\",\
+                          \"vsock\":{{\"guest_cid\":3}}}}",
+                        self.n
+                    ),
+                )?;
+                let console = self.dir.path().join(format!("l{}.log", self.n));
+                std::fs::write(&console, "[    0.1] boot\n")?;
+                Ok(RunArtifacts {
+                    config,
+                    console,
+                    facts: RunFacts {
+                        pod_id: format!("{:08}-0000-0000-0000-000000000000", self.n),
+                        guest_cid: 3,
+                    },
+                })
+            }
+        }
+
+        let mut b = NoisyUnplanted {
+            dir: tempfile::tempdir().expect("tempdir"),
+            n: 0,
+        };
+        // Sanity: the two runs really do diverge, so the OLD contract ("any
+        // divergence means the control fired") would have returned Ok here.
+        // Without this the test could pass for the boring reason.
+        let a = observe(&mut b, "twosafety-control-aaaaaaaa", true).expect("run A");
+        let c = observe(&mut b, "twosafety-control-bbbbbbbb", true).expect("run B");
+        assert!(
+            compare(&a, &c).is_err(),
+            "premise: the two runs must diverge, or this test proves nothing"
+        );
+
+        let mut b2 = NoisyUnplanted {
+            dir: tempfile::tempdir().expect("tempdir"),
+            n: 0,
+        };
+        match control(&mut b2) {
+            Err(TwoSafetyError::ControlNotAttributable(_)) => {}
+            other => panic!(
+                "a divergence that is NOT the plant must not certify the harness, got {other:?}"
+            ),
+        }
+    }
+
+    /// The CID rule must fire on the artifact Firecracker actually writes.
+    ///
+    /// The shipped rule matched only `"guest_cid":3`; the real jailed
+    /// `config.json` is pretty-printed and contains `"guest_cid": 3` WITH a
+    /// space, so the erasure had never once fired on a real observation. It
+    /// looked correct and was untested by construction — every boot measured so
+    /// far was allocated cid 3, which made the rule a no-op nothing needed.
+    ///
+    /// The two runs below differ ONLY in the CID, in the real spacing. If the
+    /// rule does not fire they diverge, which is the permanent false positive
+    /// this would have produced on the first pair of boots with different CIDs.
+    #[test]
+    fn the_cid_rule_fires_on_a_real_pretty_printed_config() {
+        // Shape copied from a live pod's /srv/jailer/.../root/config.json.
+        let pretty = |cid: u32| Observation {
+            machine_config: format!(
+                "{{\n    \"vsock\": {{\n        \"guest_cid\": {cid},\n        \
+                 \"uds_path\": \"/v.sock\"\n    }}\n}}"
+            ),
+            console: String::new(),
+        };
+        let a = canonicalise(
+            &pretty(3),
+            &RunFacts {
+                pod_id: "p".into(),
+                guest_cid: 3,
+            },
+        );
+        let b = canonicalise(
+            &pretty(4),
+            &RunFacts {
+                pod_id: "p".into(),
+                guest_cid: 4,
+            },
+        );
+        assert!(
+            compare(&a, &b).is_ok(),
+            "the CID rule does not fire on the pretty-printed form Firecracker writes, \
+             so two boots with different CIDs diverge forever"
+        );
+    }
+
+    /// ...and the pretty form must not erase a secret that merely contains the
+    /// digit, for the same reason the compact form must not.
+    #[test]
+    fn the_pretty_cid_rule_does_not_swallow_a_secret_containing_the_digit() {
+        let obs = |cid: u32, secret: &str| Observation {
+            machine_config: format!("{{\"guest_cid\": {cid}, \"x\": \"{secret}\"}}"),
+            console: String::new(),
+        };
+        let f = RunFacts {
+            pod_id: "p".into(),
+            guest_cid: 3,
+        };
+        let a = canonicalise(&obs(3, "secret-3-aaa"), &f);
+        let b = canonicalise(&obs(3, "secret-3-bbb"), &f);
+        assert!(
+            compare(&a, &b).is_err(),
+            "a secret containing the cid digit must still be compared"
+        );
     }
 
     /// A boot failure is a HARNESS error, not a clean result. "The experiment did
@@ -778,8 +1886,8 @@ mod orchestration {
                 Err(io::Error::other("no /dev/kvm"))
             }
         }
-        match check(&mut Broken) {
-            Err(TwoSafetyError::Harness(m)) => assert!(m.contains("kvm")),
+        match check_all(&mut Broken) {
+            Err(CheckFailure::Harness(TwoSafetyError::Harness(m))) => assert!(m.contains("kvm")),
             other => panic!("expected Harness, got {other:?}"),
         }
     }

--- a/crates/nucleus-cli/src/twosafety.rs
+++ b/crates/nucleus-cli/src/twosafety.rs
@@ -329,6 +329,16 @@ fn strip_leading_timestamp(line: &str) -> &str {
 /// The literal that opens an audit record header.
 const AUDIT_OPEN: &str = "audit(";
 
+/// The literal a kernel audit record line begins with. The rule is anchored to
+/// it so a guest-authored line merely CONTAINING `audit(` is not eligible.
+const AUDIT_RECORD: &str = "audit: ";
+/// Widest plausible uptime in seconds (~317 years).
+const BOOT_CLOCK_SECS_MAX: usize = 10;
+/// `%03lu` — always three.
+const BOOT_CLOCK_FRAC_LEN: usize = 3;
+/// `%u` — a 32-bit serial is at most 10 digits.
+const AUDIT_SERIAL_MAX: usize = 10;
+
 /// Erase the boot-clock reading inside an `audit(SECS.MSECS:SERIAL)` header.
 ///
 /// Measured on two real boots five days apart, this is one of exactly three
@@ -369,33 +379,55 @@ const AUDIT_OPEN: &str = "audit(";
 /// A leak whose entire text is `digits.digits`, positioned immediately after a
 /// literal `audit(` and immediately before a `:`. Nothing else.
 fn strip_embedded_audit_clock(line: &str) -> String {
-    let mut out = String::with_capacity(line.len());
-    let mut rest = line;
-    while let Some(i) = rest.find(AUDIT_OPEN) {
-        let (head, tail) = rest.split_at(i + AUDIT_OPEN.len());
-        out.push_str(head);
-        // The reading is delimited by the `:` that separates it from the serial.
-        // Bounded to this line, and the span must be numeric or nothing happens.
-        match tail.split_once(':') {
-            Some((span, after)) if is_boot_clock_reading(span) => {
-                out.push_str("<BOOT-CLOCK>:");
-                rest = after;
-            }
-            _ => rest = tail,
-        }
+    // ANCHOR. The justification is about a kernel audit record header, so
+    // require the line to BE one. Without this the rule fired on any line
+    // containing the substring `audit(`, which a guest can print.
+    if !line.starts_with(AUDIT_RECORD) {
+        return line.to_string();
     }
-    out.push_str(rest);
-    out
+    // ONE occurrence, not every match on the line. `audit_log_start` emits
+    // exactly one header; looping invited a crafted line to present several
+    // erasable spans.
+    let Some(i) = line.find(AUDIT_OPEN) else {
+        return line.to_string();
+    };
+    let (head, tail) = line.split_at(i + AUDIT_OPEN.len());
+    // DELIMIT BY `)`, the close of the header, not by the first `:` anywhere on
+    // the line. The old span ran to a colon that might belong to the record
+    // body, so an arbitrarily long run could be swallowed — 93 digits in the
+    // audit's demonstration.
+    let Some(close) = tail.find(')') else {
+        return line.to_string();
+    };
+    let (inner, after) = tail.split_at(close);
+    let Some((clock, serial)) = inner.split_once(':') else {
+        return line.to_string();
+    };
+    // The serial is VALIDATED as a shape check that this really is a header,
+    // and then left COMPARED. Erasing it would have been a widening dressed as
+    // a narrowing: if the serial ever diverges we want that reported, not
+    // absorbed. The existing test caught this.
+    if is_boot_clock_reading(clock) && is_bounded_digits(serial, AUDIT_SERIAL_MAX) {
+        format!("{head}<BOOT-CLOCK>:{serial}{after}")
+    } else {
+        line.to_string()
+    }
+}
+
+/// Digits, at least one, at most `max` — the width bound that turns "looks
+/// numeric" into "is the field the kernel actually emits".
+fn is_bounded_digits(s: &str, max: usize) -> bool {
+    !s.is_empty() && s.len() <= max && s.bytes().all(|b| b.is_ascii_digit())
 }
 
 /// `digits '.' digits` — exactly one dot, at least one digit either side.
 fn is_boot_clock_reading(s: &str) -> bool {
     match s.split_once('.') {
+        // WIDTH-BOUNDED. The kernel emits `audit(%llu.%03lu:%u)` — three
+        // fraction digits, always — so an unbounded run on either side was a
+        // channel of unbounded width wearing a numeric costume.
         Some((secs, frac)) => {
-            !secs.is_empty()
-                && !frac.is_empty()
-                && secs.bytes().all(|b| b.is_ascii_digit())
-                && frac.bytes().all(|b| b.is_ascii_digit())
+            is_bounded_digits(secs, BOOT_CLOCK_SECS_MAX) && frac.len() == BOOT_CLOCK_FRAC_LEN
         }
         None => false,
     }
@@ -407,6 +439,12 @@ fn is_boot_clock_reading(s: &str) -> bool {
 
 /// The driver-emitted literal that introduces the wall-clock reading.
 const RTC_PREFIX: &str = ": setting system clock to ";
+
+/// The RTC driver that emits the hand-off line. Anchoring to it is what stops
+/// `anything at all: setting system clock to ...` being eligible.
+const RTC_DRIVER: &str = "rtc-";
+/// A Unix second is 10 digits, and 11 from the year 33658.
+const RTC_EPOCH_MAX: usize = 11;
 
 /// Erase the wall-clock reading in the RTC hand-off line.
 ///
@@ -441,6 +479,12 @@ const RTC_PREFIX: &str = ": setting system clock to ";
 /// by ` UTC (digits)`, occupying the whole tail of a line that already contains
 /// the literal `: setting system clock to `. Nothing else.
 fn strip_rtc_wall_clock(line: &str) -> String {
+    // ANCHOR. `hctosys.c` emits this through the RTC driver, so require the
+    // driver name. Without it ANY line of the shape `<anything>: setting system
+    // clock to ...` was eligible, and the head is guest-writable text.
+    if !line.starts_with(RTC_DRIVER) {
+        return line.to_string();
+    }
     let Some(i) = line.find(RTC_PREFIX) else {
         return line.to_string();
     };
@@ -460,7 +504,9 @@ fn is_rtc_reading(s: &str) -> bool {
     let Some(digits) = epoch.strip_suffix(')') else {
         return false;
     };
-    is_iso8601_second(iso) && !digits.is_empty() && digits.bytes().all(|b| b.is_ascii_digit())
+    // WIDTH-BOUNDED epoch: a Unix second is 10 digits and will be 11 in the
+    // year 33658. Unbounded, it absorbed 93 digits in the audit's demonstration.
+    is_iso8601_second(iso) && is_bounded_digits(digits, RTC_EPOCH_MAX)
 }
 
 /// Exactly `YYYY-MM-DDTHH:MM:SS` — fixed width, fixed separators, digits
@@ -1683,6 +1729,76 @@ mod tests {
         assert!(
             !a.contains("<TRUNCATED-CMDLINE-TOKEN-ECHO>"),
             "the erasure must not fire on a value the host never wrote: {a}"
+        );
+    }
+
+    /// **The width and anchor attacks, as tests.**
+    ///
+    /// Both rules were gated on a SHAPE ("looks like a clock") while their
+    /// justification was about POSITION and PROVENANCE ("the kernel emits this
+    /// field, in this record, and nothing else can write there"). A shape gate
+    /// with no width bound is a channel of unbounded width wearing a numeric
+    /// costume; a shape gate with no anchor fires on any line a guest can print.
+    #[test]
+    fn the_clock_rules_are_anchored_and_width_bounded() {
+        // A REAL uuid shape. An earlier version of this test used pod_id "p",
+        // a single character that occurs in `type=2000`, so the pod-ID rule
+        // rewrote the line and the assertions failed for a reason that had
+        // nothing to do with the clocks. A fixture unlike the real input tests
+        // something unlike the real system.
+        let f = RunFacts {
+            pod_id: "aeb31452-ce64-468b-abf4-ea5f23378519".into(),
+            guest_cid: 3,
+        };
+        let long = "1".repeat(93);
+
+        // UNANCHORED: a guest-authored line merely CONTAINING `audit(`.
+        let forged = format!("fetched identity: audit({long}.123:1) x");
+        assert_eq!(
+            scrub(&forged, &f, None),
+            forged,
+            "the audit rule must require a real audit record, not a substring"
+        );
+
+        // WIDTH: even in a real record, an over-long run is not the field the
+        // kernel emits and must not be absorbed.
+        let wide = format!("audit: type=2000 audit({long}.123:1): x");
+        assert_eq!(
+            scrub(&wide, &f, None),
+            wide,
+            "an unbounded digit run is not a boot clock"
+        );
+        let frac = "audit: type=2000 audit(0.1234567:1): x";
+        assert_eq!(
+            scrub(frac, &f, None),
+            frac,
+            "the kernel emits exactly three fraction digits"
+        );
+
+        // The genuine article still normalises, or the assertions above pass
+        // for the boring reason that the rule never fires at all.
+        let real = "audit: type=2000 audit(0.310:1): state=initialized";
+        let out = scrub(real, &f, None);
+        assert!(out.contains("<BOOT-CLOCK>"), "the real header must normalise: {out}");
+        assert!(out.contains(":1)"), "the serial stays compared: {out}");
+
+        // RTC: unanchored head, and an unbounded epoch.
+        let rtc_forged = format!("fetched identity: setting system clock to 2026-08-04T10:45:20 UTC ({long})");
+        assert_eq!(
+            scrub(&rtc_forged, &f, None),
+            rtc_forged,
+            "the rtc rule must require the driver name"
+        );
+        let rtc_wide = format!("rtc-pl031 40001000.rtc: setting system clock to 2026-08-04T10:45:20 UTC ({long})");
+        assert_eq!(
+            scrub(&rtc_wide, &f, None),
+            rtc_wide,
+            "an unbounded epoch is not a Unix second"
+        );
+        let rtc_real = "rtc-pl031 40001000.rtc: setting system clock to 2026-08-04T10:45:20 UTC (1785840320)";
+        assert!(
+            scrub(rtc_real, &f, None).contains("<RTC-WALL-CLOCK>"),
+            "the real rtc line must normalise"
         );
     }
 

--- a/crates/nucleus-cli/src/twosafety.rs
+++ b/crates/nucleus-cli/src/twosafety.rs
@@ -860,10 +860,9 @@ fn erase_number_array(slot: Option<&mut serde_json::Value>, marker: &str) {
         // `nonce` a fixed 16 bytes, so an unbounded "all numbers" test was a
         // channel of unbounded width. An Ed25519 signature is 64 bytes; the bound
         // is the widest field this erases, so anything larger is not one of them.
-        if value
-            .as_array()
-            .is_some_and(|a| a.len() <= MAX_ERASED_ARRAY_LEN && a.iter().all(serde_json::Value::is_number))
-        {
+        if value.as_array().is_some_and(|a| {
+            a.len() <= MAX_ERASED_ARRAY_LEN && a.iter().all(serde_json::Value::is_number)
+        }) {
             *value = serde_json::Value::String(marker.to_string());
         }
     }
@@ -1856,23 +1855,30 @@ mod tests {
         // for the boring reason that the rule never fires at all.
         let real = "audit: type=2000 audit(0.310:1): state=initialized";
         let out = scrub(real, &f, None);
-        assert!(out.contains("<BOOT-CLOCK>"), "the real header must normalise: {out}");
+        assert!(
+            out.contains("<BOOT-CLOCK>"),
+            "the real header must normalise: {out}"
+        );
         assert!(out.contains(":1)"), "the serial stays compared: {out}");
 
         // RTC: unanchored head, and an unbounded epoch.
-        let rtc_forged = format!("fetched identity: setting system clock to 2026-08-04T10:45:20 UTC ({long})");
+        let rtc_forged =
+            format!("fetched identity: setting system clock to 2026-08-04T10:45:20 UTC ({long})");
         assert_eq!(
             scrub(&rtc_forged, &f, None),
             rtc_forged,
             "the rtc rule must require the driver name"
         );
-        let rtc_wide = format!("rtc-pl031 40001000.rtc: setting system clock to 2026-08-04T10:45:20 UTC ({long})");
+        let rtc_wide = format!(
+            "rtc-pl031 40001000.rtc: setting system clock to 2026-08-04T10:45:20 UTC ({long})"
+        );
         assert_eq!(
             scrub(&rtc_wide, &f, None),
             rtc_wide,
             "an unbounded epoch is not a Unix second"
         );
-        let rtc_real = "rtc-pl031 40001000.rtc: setting system clock to 2026-08-04T10:45:20 UTC (1785840320)";
+        let rtc_real =
+            "rtc-pl031 40001000.rtc: setting system clock to 2026-08-04T10:45:20 UTC (1785840320)";
         assert!(
             scrub(rtc_real, &f, None).contains("<RTC-WALL-CLOCK>"),
             "the real rtc line must normalise"
@@ -1896,9 +1902,7 @@ mod tests {
             guest_cid: 3,
         };
         let dup = |smuggled: &str| {
-            let json = format!(
-                "{{\"task_id\":\"{smuggled}\",\"task_id\":\"t\",\"blocks\":[]}}"
-            );
+            let json = format!("{{\"task_id\":\"{smuggled}\",\"task_id\":\"t\",\"blocks\":[]}}");
             format!("console=ttyS0 {TOKEN_HEX_KEY}{}", hex::encode(json))
         };
         let a = scrub(&dup("canary-aaaa"), &f, None);

--- a/crates/nucleus-cli/src/twosafety_boot.rs
+++ b/crates/nucleus-cli/src/twosafety_boot.rs
@@ -1,0 +1,1046 @@
+//! The booted half of the 2-safety experiment: two REAL pods, one secret apart.
+//!
+//! [`crate::twosafety`] holds the observation function, the canonicaliser and the
+//! comparison. It is deliberately booter-agnostic — it takes a [`Boot`] — and
+//! until this file existed the only implementation was a fixture. **A harness
+//! that has only ever run against a fake proves nothing about the runtime**: the
+//! fake's kernel command line is a `format!`, not one `firecracker_config.rs`
+//! built, and every channel the real node has (the task token, the wall clock,
+//! the workload API port, the environment `nucleus-node` was started with) is
+//! absent from it by construction.
+//!
+//! So this is the part that boots. [`PodBoot`] plants a secret in the node's
+//! environment, restarts the node, creates a pod through the same authenticated
+//! `POST /v1/pods` that `nucleus verify --tier2` uses, waits for the guest to
+//! finish booting, and hands back the two files the host is left holding.
+//!
+//! # Where the two observations come from
+//!
+//! * `<chroot>/firecracker/<pod-id>/root/config.json` — the machine
+//!   configuration Firecracker was **launched with** (`--config-file`), inside
+//!   the jail. The node also writes a byte-identical copy to
+//!   `<state>/pods/<pod-id>/firecracker.json`; the jail copy is read here
+//!   because it is the one the VMM actually opened.
+//! * `<state>/pods/<pod-id>/firecracker.log` — the guest console, i.e. what
+//!   Firecracker's stdout carried off `console=ttyS0`. This is the same file
+//!   `check_guest_facts` reads.
+//!
+//! Both are addressed by pod id, never by "most recently modified": locating a
+//! pod's log by mtime already produced a check in this repo that could pass on
+//! another pod's evidence.
+//!
+//! # Why the secret rides the node's environment
+//!
+//! Because that is the input whose containment is actually in question. The node
+//! is a long-lived root process that spawns Firecracker, the jailer and a
+//! per-pod tool-proxy, and `Command`'s default environment inheritance has
+//! already leaked one capability across exactly that boundary in this repo. A
+//! secret placed in `/etc/nucleus/node.env` is low-input-equal in every respect
+//! the guest is entitled to see, so any byte of it reaching the guest's console
+//! or command line is a channel nobody wrote down.
+//!
+//! # S4: the positive control is the load-bearing part
+//!
+//! [`twosafety::control`] runs first and asks for the secret to be planted
+//! **into the kernel command line** — a channel that certainly reaches
+//! `/proc/cmdline` — and requires the comparison to find it. Until that has
+//! fired against a real boot, "no leak found" is indistinguishable from a
+//! canonicaliser that erased too much, an observation collected from the wrong
+//! files, or a comparison with an inverted condition. That is why
+//! [`execute`] runs the control before the check and reports
+//! [`TwoSafetyError::ControlDidNotFire`] as its own outcome rather than as a
+//! pass.
+
+use anyhow::{anyhow, bail, Context, Result};
+use clap::Args;
+use nucleus_client::sign_http_headers;
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+use crate::provision::{Tier2Host, HOST_ARTIFACTS_DIR, HOST_STATE_DIR, NODE_ENV_PATH};
+use crate::twosafety::{self, Boot, CheckFailure, RunArtifacts, RunFacts, TwoSafetyError};
+
+/// The environment variable the secret rides into the node's process.
+///
+/// Generic on purpose: nothing about this experiment is specific to what the
+/// secret protects, and a name that implied otherwise would invite someone to
+/// "fix" the harness by special-casing it.
+const CANARY_ENV_KEY: &str = "NUCLEUS_E2E_CANARY";
+
+/// The kernel command line key the positive control plants into.
+///
+/// Not a `nucleus.*` key the guest parses: `parse_cmdline_secret` looks for
+/// exact prefixes, so an unknown one is inert in the guest and the control
+/// measures the harness rather than provoking the runtime.
+const PLANT_KEY: &str = "nucleus.twosafety_canary";
+
+/// The node's HTTP address on the machine running the experiment.
+const NODE_URL: &str = "http://127.0.0.1:8080";
+
+/// The subcommand name clap derives from `Commands::TwoSafety`, used when this
+/// command re-invokes itself inside the Lima VM.
+const SUBCOMMAND: &str = "two-safety";
+
+/// Defaults matching `nucleus-node`'s own clap defaults, used only when
+/// `node.env` does not override them.
+const DEFAULT_CHROOT_BASE: &str = "/srv/jailer";
+const DEFAULT_FIRECRACKER_PATH: &str = "/usr/local/bin/firecracker";
+
+/// The console line that proves the guest got all the way through boot.
+///
+/// The same fact `check_guest_facts` asserts. Waiting on it rather than on a
+/// timeout is what stops a half-written log being compared against a complete
+/// one and reported as a leak.
+const BOOT_COMPLETE_MARKER: &str = "fetched session task token";
+
+/// The pod's vsock CID. Fixed, as in `nucleus verify --tier2`: the runs are
+/// sequential and each is cancelled before the next, so there is no contention,
+/// and a CID that varied would be one more difference to explain.
+const GUEST_CID: u32 = 3;
+
+/// How long to wait for the guest to reach [`BOOT_COMPLETE_MARKER`].
+const BOOT_DEADLINE: Duration = Duration::from_secs(120);
+/// How long to wait for a log to stop growing once it has.
+const SETTLE_DEADLINE: Duration = Duration::from_secs(30);
+/// Consecutive unchanged samples that count as settled.
+const SETTLE_SAMPLES: u32 = 5;
+/// Gap between samples.
+const POLL: Duration = Duration::from_millis(400);
+
+/// Run the 2-safety experiment against real booted pods.
+#[derive(Args, Debug)]
+pub struct TwoSafetyArgs {
+    /// Run the experiment on this machine rather than delegating into a VM.
+    ///
+    /// Set automatically when `nucleus two-safety` re-invokes itself inside the
+    /// Lima VM; also the right flag on a Linux host with KVM. Mirrors
+    /// `nucleus verify --tier2 --here`, and for the same reason: the artifacts
+    /// are files inside the VM, so the comparison has to happen where they are.
+    #[arg(long)]
+    pub here: bool,
+
+    /// Lima VM to run inside (macOS). Ignored on Linux.
+    #[arg(long, default_value = "nucleus")]
+    pub vm_name: String,
+}
+
+/// Boot the same pod four times — twice with the secret planted in the kernel
+/// command line, twice without — and compare.
+///
+/// # The order is the point
+///
+/// The positive control runs FIRST. A blind harness and a clean system produce
+/// the same output from [`twosafety::check`] alone, so running the check first
+/// would let a broken observation report success. Running the control first
+/// means a blind harness is reported as blind.
+pub async fn execute(args: TwoSafetyArgs) -> Result<()> {
+    if !args.here && !cfg!(target_os = "linux") {
+        return delegate_to_lima(&args.vm_name);
+    }
+    run_here()
+}
+
+/// Re-invoke inside the Lima VM, where `/dev/kvm` and the artifacts are.
+///
+/// Identical in shape to `verify_tier2`'s Lima arm — and for a stronger reason
+/// here: the observation is two root-owned files under `/srv/jailer` and
+/// `/var/lib/nucleus`, which do not exist in the workstation's namespace at all.
+fn delegate_to_lima(vm_name: &str) -> Result<()> {
+    println!("Running the 2-safety experiment inside Lima VM '{vm_name}'...");
+    let installed = Command::new("limactl")
+        .args([
+            "shell",
+            vm_name,
+            "--",
+            "test",
+            "-x",
+            "/usr/local/bin/nucleus",
+        ])
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    if !installed {
+        bail!(
+            "the Linux `nucleus` CLI is not installed in VM '{vm_name}'.\n\
+             The experiment reads two root-owned files inside the VM, so it has to\n\
+             run there. Install it with: nucleus setup"
+        );
+    }
+    let status = Command::new("limactl")
+        .args([
+            "shell",
+            vm_name,
+            "--",
+            "sudo",
+            "/usr/local/bin/nucleus",
+            // The clap variant `TwoSafety` derives this kebab-case name. Spelled
+            // out rather than derived here, so `the_delegated_subcommand_exists`
+            // fails if the variant is ever renamed — a wrong name would only
+            // surface as "unrecognized subcommand" from inside the VM.
+            SUBCOMMAND,
+            "--here",
+        ])
+        .status()
+        .context("failed to run the 2-safety experiment inside the Lima VM")?;
+    if !status.success() {
+        bail!("the in-VM 2-safety experiment failed (see its output above)");
+    }
+    Ok(())
+}
+
+fn run_here() -> Result<()> {
+    println!("\n2-safety: boot twice, differ only in a secret, compare");
+    println!("=====================================================");
+
+    let mut booter = PodBoot::new()?;
+    println!("  node env : {NODE_ENV_PATH} (secret rides {CANARY_ENV_KEY})");
+    println!("  configs  : {}", booter.chroot_base.display());
+    println!(
+        "  consoles : {}/pods/<pod-id>/firecracker.log",
+        booter.state_dir.display()
+    );
+
+    // The control FIRST. See the doc comment on `execute`.
+    println!("\n[1/2] positive control — the secret is planted in the kernel command line");
+    println!("      and the comparison MUST find it.");
+    let control = twosafety::control(&mut booter);
+
+    // A divergence between two REAL boots is not by itself evidence that the
+    // plant was seen — see `attribute_plant`. Both legs must hold.
+    let attribution = control.is_ok().then(|| booter.attribute_plant());
+
+    let control_ok = control.is_ok() && matches!(attribution, Some(Ok(())));
+    let check = if control_ok {
+        println!("  [OK] the control fired: the two planted boots diverged,");
+        println!("       and the planted secret is present in BOTH components of BOTH runs,");
+        println!("       each carrying its own value — so the divergence is the plant's.");
+        println!("\n[2/2] the check — two boots differing ONLY in the node's environment.");
+        Some(twosafety::check_all(&mut booter))
+    } else {
+        None
+    };
+
+    // Always put the node back the way it was found, whatever happened above.
+    let restored = booter.restore();
+
+    match control {
+        Err(TwoSafetyError::ControlDidNotFire) => {
+            restored?;
+            bail!(
+                "{}\n\n\
+                 The check was NOT run. A comparison that cannot see a secret written\n\
+                 straight into /proc/cmdline cannot see one anywhere else either, so\n\
+                 reporting it as clean would be the vacuous pass this control exists to\n\
+                 prevent.",
+                TwoSafetyError::ControlDidNotFire
+            );
+        }
+        // The control ran and the two runs DID differ, but not because of the
+        // plant. Against a real pod this is the likely shape rather than an
+        // exotic one — two boots differ in run-scoped values anyway — and it is
+        // exactly the confound that let a completely removed plant still report
+        // `Ok`. Treated as a hard stop, not a warning: an unattributable red
+        // certifies nothing, so the check below must not run on the strength of
+        // it.
+        Err(e @ TwoSafetyError::ControlNotAttributable(_)) => {
+            restored?;
+            bail!(
+                "{e}\n\n\
+                 The check was NOT run. The control must show that the divergence it\n\
+                 produced is the one it planted; a divergence it cannot attribute is\n\
+                 indistinguishable from boot-to-boot noise, and certifying the harness\n\
+                 on that basis is the vacuous pass this control exists to prevent."
+            );
+        }
+        Err(e @ TwoSafetyError::Harness(_)) => {
+            restored?;
+            bail!("{e}\n\nThe experiment did not run, which is not the same as finding nothing.");
+        }
+        Ok(()) => {}
+    }
+    restored?;
+
+    if let Some(Err(e)) = attribution {
+        bail!(
+            "the positive control is NOT attributable: {e:#}\n\n\
+             The check was NOT run. `control` found a divergence between the two\n\
+             planted boots, but a divergence is what two real boots produce anyway —\n\
+             the per-boot task token differs in the same `boot_args` line — so its\n\
+             firing carries no information unless the plant is separately shown to\n\
+             have reached the observation. It was not."
+        );
+    }
+
+    match check.expect("the check runs whenever the control fired") {
+        Ok(()) => {
+            println!("  [OK] the two observations are bit-identical after canonicalisation.");
+            println!(
+                "\nNo channel in the observation carried the secret. This is complete\n\
+                 RELATIVE TO the observation function in `twosafety.rs` — timing, cache\n\
+                 residency and power are outside it, exactly as seL4's information-flow\n\
+                 proof is silent on timing."
+            );
+            Ok(())
+        }
+        // EVERY residual region, not `compare`'s first. While a residual is
+        // being worked down, one region is ambiguous in the worst way: a rule
+        // that fixes one of three is indistinguishable from a rule that fixes
+        // all three, because either way the next run reports "a divergence" and
+        // only the line number moves.
+        Err(CheckFailure::Diverged(ds)) => {
+            let mut report = String::new();
+            for d in &ds {
+                report.push_str(&format!("  {d}\n"));
+            }
+            bail!(
+                "{} differing region(s) after canonicalisation:\n{report}\n\
+                 Two boots that differed only in {CANARY_ENV_KEY} produced different\n\
+                 observations. Either a channel carries the secret, or those regions are\n\
+                 run-to-run nondeterministic and the canonicaliser does not yet cover them —\n\
+                 and the harness cannot tell those apart, which is why it reports the\n\
+                 regions rather than a verdict.",
+                ds.len()
+            );
+        }
+        Err(CheckFailure::Harness(e)) => bail!("{e}"),
+    }
+}
+
+/// A [`Boot`] that boots real pods on a host with KVM.
+pub struct PodBoot {
+    host: Tier2Host,
+    /// The node's HMAC secret, read once so a restart cannot race it.
+    auth_secret: String,
+    state_dir: PathBuf,
+    chroot_base: PathBuf,
+    /// `basename` of the Firecracker binary — the jailer's second path segment.
+    exec_name: String,
+    /// Whether `node.env` already carried a canary line, so `restore` puts the
+    /// file back rather than merely deleting.
+    prior_canary: Option<String>,
+    /// Every run whose secret was planted in the kernel command line, with the
+    /// snapshot it produced. Recorded so the control's firing can be
+    /// ATTRIBUTED to the plant — see [`PodBoot::attribute_plant`].
+    planted: Vec<PlantedRun>,
+}
+
+/// A control run, kept so its divergence can be traced back to the plant.
+struct PlantedRun {
+    secret: String,
+    config: PathBuf,
+    console: PathBuf,
+}
+
+impl PodBoot {
+    /// Read everything the experiment needs off the host, failing loudly.
+    ///
+    /// Every path is resolved from `node.env` where the node reads it from the
+    /// same place, so a host configured with a non-default state directory or
+    /// chroot base is followed rather than silently mis-read. A wrong path here
+    /// would not error — it would produce two `collect` failures, or worse, two
+    /// reads of a *previous* pod's artifacts.
+    pub fn new() -> Result<Self> {
+        let host = Tier2Host::Local;
+        if !host.test("test -r /dev/kvm") {
+            bail!(
+                "no /dev/kvm on this machine, so no pod can boot. The 2-safety\n\
+                 experiment needs a real boot: comparing two fixtures proves only that\n\
+                 the fixtures agree."
+            );
+        }
+        let env = host
+            .sh(&format!("cat {NODE_ENV_PATH}"))
+            .with_context(|| format!("cannot read {NODE_ENV_PATH}; run: nucleus setup"))?;
+        let value = |key: &str| env_value(&env, key);
+
+        let auth_secret = value("NUCLEUS_NODE_AUTH_SECRET").ok_or_else(|| {
+            anyhow!("{NODE_ENV_PATH} has no NUCLEUS_NODE_AUTH_SECRET; run: nucleus setup")
+        })?;
+        let state_dir = PathBuf::from(
+            value("NUCLEUS_NODE_STATE_DIR").unwrap_or_else(|| HOST_STATE_DIR.to_string()),
+        );
+        let chroot_base = PathBuf::from(
+            value("NUCLEUS_JAILER_CHROOT_BASE").unwrap_or_else(|| DEFAULT_CHROOT_BASE.to_string()),
+        );
+        let firecracker =
+            value("NUCLEUS_FIRECRACKER_PATH").unwrap_or_else(|| DEFAULT_FIRECRACKER_PATH.into());
+        let exec_name = PathBuf::from(&firecracker)
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .ok_or_else(|| anyhow!("NUCLEUS_FIRECRACKER_PATH is not a file path: {firecracker}"))?;
+
+        // Clear the previous experiment's snapshots. Kept until the NEXT run
+        // rather than deleted at the end of this one, because when a divergence
+        // is reported the two frozen files are the only place the differing
+        // region can actually be looked at.
+        let _ = std::fs::remove_dir_all(state_dir.join("twosafety"));
+
+        Ok(PodBoot {
+            host,
+            auth_secret,
+            state_dir,
+            chroot_base,
+            exec_name,
+            prior_canary: value(CANARY_ENV_KEY),
+            planted: Vec::new(),
+        })
+    }
+
+    /// **Attribute the control's divergence to the plant.**
+    ///
+    /// # Why `control` returning `Ok` is not, on its own, evidence
+    ///
+    /// [`twosafety::control`] boots twice WITH the plant and accepts any
+    /// divergence as proof the harness can see. That is airtight against the
+    /// fake `Boot`, whose two runs are identical apart from the plant. It is
+    /// **not** airtight against a real pod: measured on this host, two boots
+    /// that differ in nothing at all still differ in `nucleus.task_token_hex`
+    /// and `nucleus.task_token_nonce`, which live in the same `boot_args` line.
+    /// So a real `control` fires at `machine_config` line 4 whether the plant
+    /// works or not, and a plant that silently stopped reaching the command
+    /// line would still look like a firing control.
+    ///
+    /// The direct evidence of that: [`twosafety::check`] is exactly `control`
+    /// with the plant switched off, and it diverges at the SAME component and
+    /// line.
+    ///
+    /// So this asserts what the control was supposed to establish and, on a real
+    /// boot, cannot: the planted secret is **present in the observation**, each
+    /// run carries its own and not the other's, and the two differ. That is a
+    /// statement about the plant specifically, and no amount of boot-to-boot
+    /// noise can satisfy it.
+    ///
+    /// # Errors
+    /// If the plant did not reach both components of both control runs.
+    fn attribute_plant(&self) -> Result<()> {
+        let [a, b] = match self.planted.as_slice() {
+            [.., a, b] => [a, b],
+            _ => bail!(
+                "the control ran {} planted boots; two are needed to attribute its \
+                 divergence",
+                self.planted.len()
+            ),
+        };
+        if a.secret == b.secret {
+            bail!(
+                "both control runs planted the same secret, so a divergence between \
+                 them cannot be the plant"
+            );
+        }
+        for (run, other) in [(a, b), (b, a)] {
+            for (path, what, needle) in [
+                (
+                    &run.config,
+                    "machine config",
+                    format!("{PLANT_KEY}={}", run.secret),
+                ),
+                // The kernel echoes its whole command line, so the plant must be
+                // visible on the console too. Checking both components is what
+                // makes this an assertion about the OBSERVATION rather than
+                // about one file.
+                (
+                    &run.console,
+                    "guest console",
+                    format!("{PLANT_KEY}={}", run.secret),
+                ),
+            ] {
+                let body = std::fs::read_to_string(path)
+                    .with_context(|| format!("cannot re-read the {what} at {}", path.display()))?;
+                if !body.contains(&needle) {
+                    bail!(
+                        "the planted secret never reached the {what} at {}. The control's \
+                         divergence therefore came from something else — on a real boot the \
+                         task token differs between any two runs — so it is NOT evidence \
+                         that this harness can see a secret.",
+                        path.display()
+                    );
+                }
+                let foreign = format!("{PLANT_KEY}={}", other.secret);
+                if body.contains(&foreign) {
+                    bail!(
+                        "the {what} at {} carries the OTHER control run's secret, so the \
+                         two runs are not independent boots",
+                        path.display()
+                    );
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Put `node.env` back as it was found and restart the node on it.
+    ///
+    /// Called on every exit path. Leaving a canary in a root-owned environment
+    /// file would be a secret this experiment introduced and then abandoned.
+    pub fn restore(&self) -> Result<()> {
+        match self.prior_canary.clone() {
+            Some(v) => self.set_canary(&v),
+            None => {
+                self.host.sh(&format!(
+                    "set -e; sed -i '/^{CANARY_ENV_KEY}=/d' {NODE_ENV_PATH}; \
+                     systemctl restart nucleus-node"
+                ))?;
+                self.await_node()
+            }
+        }
+    }
+
+    /// Write the secret into the node's environment and restart it onto it.
+    ///
+    /// The restart happens on EVERY run, planted or not, so "the node was
+    /// restarted" is a constant of the experiment rather than a difference
+    /// between its arms.
+    fn set_canary(&self, secret: &str) -> Result<()> {
+        // The value is interpolated into a root shell command. Every caller in
+        // this crate passes a constant from `twosafety.rs`, but a value that
+        // could carry a quote would turn a future caller's secret into a
+        // command — so the shape is checked rather than assumed.
+        if !is_shell_safe(secret) {
+            bail!(
+                "refusing to write a secret containing shell metacharacters into \
+                 {NODE_ENV_PATH}"
+            );
+        }
+        self.host.sh(&format!(
+            "set -e; sed -i '/^{CANARY_ENV_KEY}=/d' {NODE_ENV_PATH}; \
+             printf '%s=%s\\n' '{CANARY_ENV_KEY}' '{secret}' >> {NODE_ENV_PATH}; \
+             systemctl restart nucleus-node"
+        ))?;
+        self.await_node()
+    }
+
+    /// Wait for the node to answer, or say what it logged.
+    fn await_node(&self) -> Result<()> {
+        let deadline = Instant::now() + Duration::from_secs(30);
+        while Instant::now() < deadline {
+            if ureq::get(&format!("{NODE_URL}/v1/health"))
+                .call()
+                .map(|r| r.status().is_success())
+                .unwrap_or(false)
+            {
+                return Ok(());
+            }
+            std::thread::sleep(Duration::from_millis(500));
+        }
+        let log = self
+            .host
+            .sh("journalctl -u nucleus-node --no-pager -n 20")
+            .unwrap_or_else(|_| "(no journal available)".into());
+        bail!("nucleus-node did not become healthy within 30s. Its log said:\n{log}")
+    }
+
+    /// Create the pod and return its id.
+    ///
+    /// The spec is a constant except for `boot_args`, which carries the planted
+    /// secret when the control asks for it. No DLC admission material is minted:
+    /// `mint_admission` draws a fresh issuer key from `/dev/urandom` per call,
+    /// which would be a per-run difference that has nothing to do with the
+    /// secret — the experiment's inputs must be equal apart from the one under
+    /// test.
+    fn create_pod(&self, secret: &str, plant: bool) -> Result<String> {
+        let boot_args = if plant {
+            format!(
+                ",\"boot_args\":\"console=ttyS0 reboot=k panic=1 pci=off init=/init \
+                 {PLANT_KEY}={secret}\""
+            )
+        } else {
+            String::new()
+        };
+        let body = format!(
+            r#"{{"apiVersion":"nucleus/v1","kind":"Pod",
+                "metadata":{{"name":"nucleus-twosafety"}},
+                "spec":{{"work_dir":"/work","timeout_seconds":120,
+                  "policy":{{"type":"profile","name":"codegen"}},
+                  "image":{{"kernel_path":"{HOST_ARTIFACTS_DIR}/vmlinux",
+                            "rootfs_path":"{HOST_ARTIFACTS_DIR}/rootfs.ext4",
+                            "read_only":false{boot_args}}},
+                  "vsock":{{"guest_cid":{GUEST_CID},"port":5005}}}}}}"#
+        );
+
+        // A 4xx must arrive as data: the node's refusals explain themselves in
+        // the body, and ureq's default discards it.
+        let agent: ureq::Agent = ureq::Agent::config_builder()
+            .http_status_as_error(false)
+            .build()
+            .into();
+        let mut request = agent
+            .post(format!("{NODE_URL}/v1/pods"))
+            .header("content-type", "application/json");
+        let signed = sign_http_headers(
+            self.auth_secret.as_bytes(),
+            Some("nucleus-twosafety"),
+            body.as_bytes(),
+        );
+        for (key, value) in signed.headers {
+            request = request.header(&key, &value);
+        }
+        let mut response = request
+            .send(body.as_bytes())
+            .map_err(|e| anyhow!("the node refused to create a pod: {e}"))?;
+        if !response.status().is_success() {
+            let status = response.status();
+            let detail = response
+                .body_mut()
+                .read_to_string()
+                .unwrap_or_else(|_| "<no body>".to_string());
+            bail!("pod creation returned {status}: {}", detail.trim());
+        }
+        #[derive(serde::Deserialize)]
+        struct CreatePodResponse {
+            id: Option<String>,
+        }
+        let parsed: CreatePodResponse = response
+            .body_mut()
+            .read_json()
+            .context("the node's response was not the JSON we expected")?;
+        parsed
+            .id
+            .ok_or_else(|| anyhow!("the node created a pod but returned no id"))
+    }
+
+    /// Stop the pod, so the next run's CID and vsock path are free.
+    ///
+    /// Best-effort: a pod that already exited returns 404, which is the desired
+    /// end state and not a failure.
+    fn cancel_pod(&self, id: &str) {
+        let agent: ureq::Agent = ureq::Agent::config_builder()
+            .http_status_as_error(false)
+            .build()
+            .into();
+        let mut request = agent.post(format!("{NODE_URL}/v1/pods/{id}/cancel"));
+        let signed = sign_http_headers(self.auth_secret.as_bytes(), Some("nucleus-twosafety"), b"");
+        for (key, value) in signed.headers {
+            request = request.header(&key, &value);
+        }
+        let _ = request.send(b"" as &[u8]);
+    }
+
+    fn console_path(&self, id: &str) -> PathBuf {
+        self.state_dir.join("pods").join(id).join("firecracker.log")
+    }
+
+    fn config_path(&self, id: &str) -> PathBuf {
+        self.chroot_base
+            .join(&self.exec_name)
+            .join(id)
+            .join("root")
+            .join("config.json")
+    }
+
+    /// Where a run's frozen observation is kept.
+    fn snapshot_dir(&self, id: &str) -> PathBuf {
+        self.state_dir.join("twosafety").join(id)
+    }
+
+    /// Copy both components out before the pod is stopped, and hand back the
+    /// copies.
+    ///
+    /// # This is not tidiness, it is a correctness requirement
+    ///
+    /// `cleanup_jail` deletes `<chroot>/<exec>/<pod-id>` when the pod stops, and
+    /// the pod must be stopped before the next run can have the same CID. So the
+    /// live config path is valid only while the pod is alive, and reading it
+    /// afterwards fails — which is exactly how this failed on its first real
+    /// run, as a `Harness` error naming a config.json that no longer existed.
+    ///
+    /// Freezing the pair also removes the second hazard: the console is a file
+    /// the node is still appending to, so two runs read at different moments in
+    /// their tails differ for a reason that is not the secret. The snapshot is
+    /// taken once, after the console has settled and before anything is torn
+    /// down, so both runs are compared at the same point in their lives.
+    ///
+    /// The copies are left in place deliberately. When the comparison reports a
+    /// divergence, the two files ARE the evidence, and a harness that deleted
+    /// them would report a region nobody could then look at.
+    fn snapshot(&self, id: &str) -> Result<(PathBuf, PathBuf)> {
+        let dir = self.snapshot_dir(id);
+        std::fs::create_dir_all(&dir)
+            .with_context(|| format!("cannot create {}", dir.display()))?;
+        let mut out = Vec::new();
+        for (from, name) in [
+            (self.config_path(id), "config.json"),
+            (self.console_path(id), "console.log"),
+        ] {
+            let to = dir.join(name);
+            std::fs::copy(&from, &to).with_context(|| {
+                format!(
+                    "cannot snapshot {} to {}. Without a snapshot the observation would \
+                     be read after the jail is torn down, or while the console is still \
+                     being written",
+                    from.display(),
+                    to.display()
+                )
+            })?;
+            out.push(to);
+        }
+        Ok((out.remove(0), out.remove(0)))
+    }
+
+    /// Wait until the guest has finished booting AND its console has stopped
+    /// growing.
+    ///
+    /// Both halves matter and for different reasons. The marker is the
+    /// non-vacuity condition: without it a boot that died in the kernel produces
+    /// a short log, and two short logs of *different* lengths compare as a
+    /// divergence — a leak report caused by the harness. The settle is the
+    /// determinism condition: the console keeps a few lines coming after the
+    /// marker, and sampling two runs at different points in that tail is the
+    /// same false positive wearing a different hat.
+    fn await_console(&self, id: &str) -> Result<()> {
+        let path = self.console_path(id);
+        let size = || {
+            std::fs::metadata(&path)
+                .map(|m| m.len())
+                .unwrap_or_default()
+        };
+        let deadline = Instant::now() + BOOT_DEADLINE;
+        loop {
+            if let Ok(body) = std::fs::read_to_string(&path) {
+                if body.contains(BOOT_COMPLETE_MARKER) {
+                    break;
+                }
+            }
+            if Instant::now() >= deadline {
+                let tail = std::fs::read_to_string(&path).unwrap_or_default();
+                let tail: Vec<&str> = tail.lines().rev().take(8).collect();
+                bail!(
+                    "the guest never reached {BOOT_COMPLETE_MARKER:?} within {}s.\n\
+                     An incomplete boot cannot be compared: two truncated consoles differ\n\
+                     from each other for reasons that have nothing to do with the secret.\n\
+                     console: {}\n  last lines (newest first): {tail:?}",
+                    BOOT_DEADLINE.as_secs(),
+                    path.display()
+                );
+            }
+            std::thread::sleep(POLL);
+        }
+        self.settle(&path, size)
+    }
+
+    fn settle(&self, path: &std::path::Path, size: impl Fn() -> u64) -> Result<()> {
+        let deadline = Instant::now() + SETTLE_DEADLINE;
+        let mut last = size();
+        let mut stable = 0;
+        while stable < SETTLE_SAMPLES {
+            std::thread::sleep(POLL);
+            let now = size();
+            if now == last {
+                stable += 1;
+            } else {
+                stable = 0;
+                last = now;
+            }
+            if Instant::now() >= deadline {
+                bail!(
+                    "the console at {} never stopped growing, so there is no point at \
+                     which two runs are comparable",
+                    path.display()
+                );
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Boot for PodBoot {
+    fn boot(&mut self, secret: &str, plant_in_cmdline: bool) -> std::io::Result<RunArtifacts> {
+        // `Boot` returns io::Error, so anyhow's context is flattened into the
+        // message. That is deliberate: `observe` turns it into
+        // `TwoSafetyError::Harness`, and the whole point of that variant is that
+        // "the experiment did not run" reads differently from "the experiment
+        // found nothing".
+        let io = |e: anyhow::Error| std::io::Error::other(format!("{e:#}"));
+
+        self.set_canary(secret).map_err(io)?;
+        let id = self.create_pod(secret, plant_in_cmdline).map_err(io)?;
+        println!(
+            "      booted pod {id} (secret in {CANARY_ENV_KEY}{})",
+            if plant_in_cmdline {
+                ", planted in the kernel command line"
+            } else {
+                ""
+            }
+        );
+        // Freeze the observation BEFORE the pod is stopped: `cleanup_jail`
+        // deletes the config the moment it is. See `snapshot`.
+        let frozen = self.await_console(&id).and_then(|()| self.snapshot(&id));
+        self.cancel_pod(&id);
+        let (config, console) = frozen.map_err(io)?;
+
+        if plant_in_cmdline {
+            self.planted.push(PlantedRun {
+                secret: secret.to_string(),
+                config: config.clone(),
+                console: console.clone(),
+            });
+        }
+
+        Ok(RunArtifacts {
+            config,
+            console,
+            facts: RunFacts {
+                pod_id: id,
+                guest_cid: GUEST_CID,
+            },
+        })
+    }
+}
+
+/// Read `KEY=value` out of an environment file's text.
+///
+/// Comment lines are skipped rather than matched, because `node.env` opens with
+/// one and a prefix match on a commented-out key would return a stale value.
+fn env_value(env: &str, key: &str) -> Option<String> {
+    env.lines()
+        .map(str::trim)
+        .filter(|l| !l.starts_with('#'))
+        .find_map(|l| l.strip_prefix(key)?.strip_prefix('='))
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+}
+
+/// Whether a value can be single-quoted into a shell command without escaping.
+///
+/// Deliberately an allow-list. A deny-list of metacharacters is the shape that
+/// has to be right about every shell; an allow-list only has to be right about
+/// the characters a canary needs.
+fn is_shell_safe(value: &str) -> bool {
+    !value.is_empty()
+        && value
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The canary's env key must not name a vendor or a product — the harness is
+    /// about the runtime's containment, not about what the secret protects.
+    #[test]
+    fn the_canary_key_is_generic() {
+        assert!(CANARY_ENV_KEY.starts_with("NUCLEUS_"));
+    }
+
+    /// **The name this command re-invokes itself by must exist.**
+    ///
+    /// `delegate_to_lima` runs `nucleus <SUBCOMMAND> --here` inside the VM, and
+    /// a wrong name fails only there, as clap's "unrecognized subcommand" —
+    /// which is exactly what happened the first time this was run for real
+    /// (`twosafety` vs the derived `two-safety`). Asserted against clap's own
+    /// command tree rather than against a second literal, so renaming the
+    /// variant fails here instead of in the VM.
+    #[test]
+    fn the_delegated_subcommand_exists() {
+        let cmd = <crate::Cli as clap::CommandFactory>::command();
+        let names: Vec<&str> = cmd.get_subcommands().map(|s| s.get_name()).collect();
+        assert!(
+            names.contains(&SUBCOMMAND),
+            "`nucleus {SUBCOMMAND}` is not a subcommand; clap knows: {names:?}"
+        );
+    }
+
+    /// **The plant must not be a key the guest parses.**
+    ///
+    /// `nucleus-guest-init` reads `nucleus.task_token_hex`,
+    /// `nucleus.approval_secret`, `nucleus.workload_api_port` and friends by
+    /// exact prefix. Planting into one of those would change what the guest
+    /// DOES, so a divergence could come from the runtime reacting rather than
+    /// from the harness seeing — and the control would be measuring the wrong
+    /// thing.
+    #[test]
+    fn the_planted_key_is_inert_in_the_guest() {
+        for parsed in [
+            "nucleus.task_token_hex",
+            "nucleus.task_token_nonce",
+            "nucleus.task_token_issuer",
+            "nucleus.approval_secret",
+            "nucleus.auth_secret",
+            "nucleus.workload_api_port",
+            "nucleus.sandbox_token",
+            "nucleus.net",
+        ] {
+            assert_ne!(PLANT_KEY, parsed, "the plant collides with a parsed key");
+        }
+    }
+
+    /// Both observation paths must be addressed by POD ID.
+    ///
+    /// Locating a pod's artifacts any other way — newest file, single directory
+    /// entry — is how a check in this repo came to pass on a different pod's
+    /// evidence. Here it would be worse: two runs could read the SAME file and
+    /// compare equal, which is a silent vacuous pass.
+    #[test]
+    fn artifacts_are_addressed_by_pod_id() {
+        let mut b = booter(std::path::Path::new("/var/lib/nucleus/state"), Vec::new());
+        b.chroot_base = PathBuf::from("/srv/jailer");
+        let id = "aeb31452-ce64-468b-abf4-ea5f23378519";
+        assert_eq!(
+            b.config_path(id),
+            PathBuf::from(format!("/srv/jailer/firecracker/{id}/root/config.json"))
+        );
+        assert_eq!(
+            b.console_path(id),
+            PathBuf::from(format!("/var/lib/nucleus/state/pods/{id}/firecracker.log"))
+        );
+        // And two ids must not resolve to the same file, or the comparison is
+        // between a run and itself.
+        assert_ne!(b.config_path(id), b.config_path("other"));
+        assert_ne!(b.console_path(id), b.console_path("other"));
+        // The snapshot the comparison actually reads is under the SAME
+        // discipline: a shared snapshot directory would make four runs overwrite
+        // one another and every comparison pass.
+        assert_ne!(b.snapshot_dir(id), b.snapshot_dir("other"));
+        assert!(b.snapshot_dir(id).ends_with(id));
+    }
+
+    fn booter(dir: &std::path::Path, planted: Vec<PlantedRun>) -> PodBoot {
+        PodBoot {
+            host: Tier2Host::Local,
+            auth_secret: "unused".into(),
+            state_dir: dir.to_path_buf(),
+            chroot_base: dir.to_path_buf(),
+            exec_name: "firecracker".into(),
+            prior_canary: None,
+            planted,
+        }
+    }
+
+    /// Write one control run's snapshot pair. `in_config` / `in_console` choose
+    /// whether the plant actually made it there — i.e. whether the harness under
+    /// test is blind.
+    fn planted_run(
+        dir: &std::path::Path,
+        secret: &str,
+        in_config: bool,
+        in_console: bool,
+    ) -> PlantedRun {
+        let plant = format!("{PLANT_KEY}={secret}");
+        let config = dir.join(format!("{secret}.config.json"));
+        let console = dir.join(format!("{secret}.console.log"));
+        let body = |present: bool| {
+            if present {
+                format!("boot_args: console=ttyS0 init=/init {plant} pci=off\n")
+            } else {
+                "boot_args: console=ttyS0 init=/init pci=off\n".to_string()
+            }
+        };
+        std::fs::write(&config, body(in_config)).expect("write config");
+        std::fs::write(&console, body(in_console)).expect("write console");
+        PlantedRun {
+            secret: secret.into(),
+            config,
+            console,
+        }
+    }
+
+    /// The control: a working plant is attributable.
+    #[test]
+    fn a_working_plant_is_attributed() {
+        let d = tempfile::tempdir().expect("tempdir");
+        let b = booter(
+            d.path(),
+            vec![
+                planted_run(d.path(), "control-aaaa", true, true),
+                planted_run(d.path(), "control-bbbb", true, true),
+            ],
+        );
+        b.attribute_plant()
+            .expect("both runs carry their own plant");
+    }
+
+    /// **The meta-check, and the reason this function exists.**
+    ///
+    /// On a real boot `twosafety::control` fires on ANY divergence, and two real
+    /// boots always diverge in the per-boot task token — so a plant that stopped
+    /// reaching the kernel command line would still look like a firing control.
+    /// Attribution must fail in that case, in each component independently.
+    #[test]
+    fn a_plant_that_never_arrived_is_not_attributable() {
+        for (in_config, in_console, missing) in [
+            (false, true, "machine config"),
+            (true, false, "guest console"),
+        ] {
+            let d = tempfile::tempdir().expect("tempdir");
+            let b = booter(
+                d.path(),
+                vec![
+                    planted_run(d.path(), "control-aaaa", in_config, in_console),
+                    planted_run(d.path(), "control-bbbb", true, true),
+                ],
+            );
+            let e = format!(
+                "{:#}",
+                b.attribute_plant()
+                    .expect_err("a plant that did not arrive must not be attributable")
+            );
+            assert!(e.contains(missing), "names which component: {e}");
+        }
+    }
+
+    /// Two control runs planting the SAME value cannot explain a divergence
+    /// between them, so attribution must refuse rather than accept.
+    #[test]
+    fn two_identical_plants_are_not_attributable() {
+        let d = tempfile::tempdir().expect("tempdir");
+        let b = booter(
+            d.path(),
+            vec![
+                planted_run(d.path(), "control-same", true, true),
+                planted_run(d.path(), "control-same", true, true),
+            ],
+        );
+        assert!(b.attribute_plant().is_err());
+    }
+
+    /// Fewer than two planted boots is a harness failure, not a pass. An empty
+    /// `planted` list would otherwise satisfy every "contains" check by
+    /// vacuous quantification — the shape this repo has been bitten by.
+    #[test]
+    fn no_planted_boots_is_not_an_attribution() {
+        let d = tempfile::tempdir().expect("tempdir");
+        assert!(booter(d.path(), Vec::new()).attribute_plant().is_err());
+        let one = vec![planted_run(d.path(), "control-aaaa", true, true)];
+        assert!(booter(d.path(), one).attribute_plant().is_err());
+    }
+
+    #[test]
+    fn env_values_are_read_and_comments_ignored() {
+        let env = "# NUCLEUS_NODE_STATE_DIR=/wrong\nNUCLEUS_NODE_STATE_DIR=/right\nEMPTY=\n";
+        assert_eq!(
+            env_value(env, "NUCLEUS_NODE_STATE_DIR").as_deref(),
+            Some("/right")
+        );
+        assert_eq!(env_value(env, "EMPTY"), None);
+        assert_eq!(env_value(env, "ABSENT"), None);
+    }
+
+    /// The secrets this crate actually plants must pass the shell check, or the
+    /// experiment fails at the first boot for a reason unrelated to security.
+    #[test]
+    fn the_planted_secrets_are_shell_safe_and_metacharacters_are_not() {
+        for s in [
+            "twosafety-control-aaaaaaaa",
+            "twosafety-control-bbbbbbbb",
+            "twosafety-secret-aaaaaaaa",
+            "twosafety-secret-bbbbbbbb",
+        ] {
+            assert!(is_shell_safe(s), "{s} must be writable into node.env");
+        }
+        for bad in ["a'b", "a b", "a;rm -rf /", "a$(id)", "a\nb", ""] {
+            assert!(!is_shell_safe(bad), "{bad:?} must be refused");
+        }
+    }
+
+    /// The planted command line must keep `init=/init`, or `from_spec` appends
+    /// it and the two arms of the control differ in shape as well as in value.
+    #[test]
+    fn the_planted_boot_args_still_name_init() {
+        let plant = format!(
+            "console=ttyS0 reboot=k panic=1 pci=off init=/init {PLANT_KEY}=twosafety-control-aaaaaaaa"
+        );
+        assert!(plant.contains("init="));
+        assert!(plant.contains("console=ttyS0"));
+    }
+}


### PR DESCRIPTION
Completes the 2-safety moonshot (plan stages S2–S4): boot the same pod twice differing **only**
in a secret, canonicalise everything the guest could observe, assert the two observations are
bit-identical. Enumerates no mechanisms — a channel nobody wrote down shows up as a difference.

## It ran, on real pods

```
[1/2] positive control — the secret is planted in the kernel command line
  [OK] the control fired: the two planted boots diverged,
       and the planted secret is present in BOTH components of BOTH runs,
       each carrying its own value — so the divergence is the plant's.

[2/2] the check — two boots differing ONLY in the node's environment.
  [OK] the two observations are bit-identical after canonicalisation.
```

Four pods, aarch64 under Lima with real `/dev/kvm`. Host restored afterwards — 0 canary lines
left in `node.env`, verified rather than assumed.

## The control is the load-bearing part, and the first version was broken

`control()` accepted **any** divergence between its two planted runs. Sound against a fake
`Boot`, false against a real pod: two boots differing in nothing still differ in
`nucleus.task_token_hex`, so it returned `Err` whether the plant worked or not. **With the
plant completely removed it still returned `Ok`.**

It now requires the divergence to be *attributable*: each run's observation must contain the
value planted into it, neither may carry the other's, and only then must they differ. No
boot-to-boot noise can satisfy that.

## Nine canonicalisation rules, adversarially audited

A workflow's three-lens audit found one critical and six major defects. The unifying diagnosis
is worth more than any single fix:

> Every rule was gated on a **shape** and a **substring**, while every justification was about
> **provenance** and **position**. The guard did not implement the argument.

**The critical one has a name.** Rule 3c erased the kernel's cmdline echo on
`line.starts_with("Kernel command line: ")`. The console is **guest-writable**, so the guest
chose whether the erasure fired. That is a [robust declassification](https://www.cis.upenn.edu/~stevez/papers/ZM01b.pdf)
failure — the decision to declassify must have high integrity. The decision now needs a
`Warrant`, constructible **only** from the host-written machine config. A forged blob is not a
prefix of the host's token, so the rule declines and the line stays *compared*.

Also fixed: the `serde_json` round-trip that erased **duplicate keys**, hiding a secret in the
first of two `task_id`s — in exactly the field the rule decodes the token in order to *keep*
compared. Now guarded by a round-trip fidelity check, fail-closed. Plus width bounds, positional
anchors, and a composition defect where rule 1 ate bytes inside the `allowed_paths` rule 3
preserved.

## Everything was watched fail

Every fix has a perturbation test, and three of my own tests initially passed for the wrong
reason and were fixed:

- the composition test used a path with no closing paren, so rule 1 declined whether anchored
  or not — removing the anchor left the suite green
- a fixture used `pod_id: "p"`, a single char occurring in `type=2000`
- an early narrowing erased the audit serial — a widening dressed as a narrowing, caught by an
  existing test

51 tests; `cargo clippy -p nucleus-cli --all-targets --all-features -- -D warnings` exits 0.

## What this cannot see

`Observation` is `{machine_config, console}`. Timing, cache and DVFS residency, block-device
ordering, memory-balloon pressure, host syscall traces, power — all outside it, the same shape
of limit [seL4 records](https://sel4.systems/Research/pdfs/sel4-from-general-purpose-to-proof-information-flow-enforcement.pdf)
for timing. Sharp edge: the two clock residuals we canonicalise away *were* time leaking through
a channel the observation captured by accident.

Also: one plant site, one high input, two sampled secrets. And **this ran on aarch64** — CI's
job is x86_64. Rule 2 is anchored on the driver-name prefix `rtc-`, shared by `rtc-pl031` and
`rtc_cmos`, so it *should* carry. Untested.

## Deliberately declined, so it is not rediscovered

**Token pinning.** Pinning is itself an erasure, relocated from the observation to the source
and worse-placed — every rule here is visible in the file, a pinned source is not. The token
carries `scope.allowed_paths`, where the design was measured detecting 8/8 canaries. Pinning
would make the most interesting channel constant, and a constant channel can never fail.

**S5 (a Lean theorem over the observation).** `SemanticIFC.IFCSafe` already *is* the 2-safety
predicate, proven; the security content lives in `boot`, which no proof reaches; and any Lean
statement is ∀-quantified while `check()` samples two points.

**RTC pinning** is not available: Firecracker has no cold-boot clock knob, only `clock_realtime`
on `LoadSnapshot`.

## Not in scope here

The harness is not yet wired into CI. `check-gates-can-fail.sh` now fails any gate no workflow
invokes, so that wiring needs its own increment — and it should not become a required gate
until it has run green on x86_64.
