### PR TITLE
Decompose the 8-second pod boot into measured, reconciled stages

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -105,4 +105,15 @@ ignore = [
     # does not do. REVISIT as its own PR — a major engine bump does not belong
     # inside unrelated work.
     "RUSTSEC-2026-0222",
+
+    # rkyv 0.7.46 out-of-bounds reads validating Rc/Arc archives
+    # (RUSTSEC-2026-0235). Advisory-DB refresh red — hit unrelated PRs the
+    # same day with no tree change. rkyv is orphan lockfile residue: it backs
+    # rust_decimal's optional `rkyv` feature, which nothing enables —
+    # `cargo tree -i rkyv --all-features --target all` finds no path, so the
+    # crate is never compiled, same class as the RUSTSEC-2026-0104 orphan
+    # entry. The fix line (rkyv >=0.8.17) is unreachable until rust_decimal
+    # migrates off the 0.7 API. Drops if rust_decimal bumps or the lock stops
+    # recording the unused optional dep. REVISIT with rust_decimal updates.
+    "RUSTSEC-2026-0235",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7035,6 +7035,7 @@ dependencies = [
  "nucleus-cred-protocol",
  "nucleus-identity",
  "nucleus-ifc-kernel",
+ "nucleus-otel-bootstrap",
  "nucleus-proto",
  "nucleus-provenance-memory",
  "nucleus-spec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,9 +146,8 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
 # OpenTelemetry (opt-in via feature flags)
-# Pinned to 0.31 because tracing-opentelemetry 0.32.1 (latest) still depends on
-# opentelemetry ^0.31; bumping to 0.32 here introduces a Tracer-trait mismatch.
-# Revisit when tracing-opentelemetry releases a 0.32-compatible version.
+# opentelemetry 0.32 pairs with tracing-opentelemetry 0.33 (the 0.33 line is
+# the one built against opentelemetry ^0.32); bump the pair together.
 opentelemetry = "0.32"
 opentelemetry_sdk = { version = "0.32", features = ["rt-tokio"] }
 opentelemetry-otlp = { version = "0.32", features = ["grpc-tonic", "http-proto", "trace"] }

--- a/crates/nucleus-node/Cargo.toml
+++ b/crates/nucleus-node/Cargo.toml
@@ -19,6 +19,11 @@ path = "src/main.rs"
 default = []
 # Enable local driver (no VM isolation). DO NOT enable in production.
 local-driver = []
+# OTLP span export for boot-stage tracing (tool-proxy precedent: off by
+# default, and even when built in it is inert unless
+# OTEL_EXPORTER_OTLP_ENDPOINT is set). All OTel deps come through the
+# bootstrap crate — no version lines here.
+otel = ["dep:nucleus-otel-bootstrap"]
 
 [dependencies]
 axum = { workspace = true }
@@ -65,6 +70,7 @@ bollard = "0.21"
 
 nucleus = { path = "../nucleus" }
 nucleus-identity = { path = "../nucleus-identity" }
+nucleus-otel-bootstrap = { path = "../nucleus-otel-bootstrap", optional = true }
 nucleus-proto = { path = "../nucleus-proto" }
 nucleus-spec = { path = "../nucleus-spec" }
 # The extracted egress matcher the Lean confinement theorem is stated over, so

--- a/crates/nucleus-node/src/boot_trace.rs
+++ b/crates/nucleus-node/src/boot_trace.rs
@@ -1,0 +1,459 @@
+//! Per-stage timing for pod creation.
+//!
+//! `nucleus verify --tier2` reports one number ("pod created in N ms") that is
+//! wall clock around a single blocking POST. This module decomposes it: every
+//! boot-path segment owner carries an `#[instrument]` span with a
+//! `boot.stage` field, and [`BootTraceLayer`] records each span's
+//! open→close duration, grouped under the root `pod.create` span
+//! (`create_pod_internal`).
+//!
+//! When the root closes, the layer emits a single `boot_trace` event with the
+//! per-stage breakdown AND the reconciliation figure:
+//! `unaccounted = wall - sum(top-level stages)`. A large `unaccounted` is a
+//! finding (unmeasured work), not an error to hide — a profiler that always
+//! sums to 100% has stopped being able to say it missed something. Stages
+//! nested inside another stage are shown prefixed `+` and excluded from the
+//! sum so nothing is counted twice.
+//!
+//! Spans and the breakdown event are emitted at INFO: the node must run with
+//! `RUST_LOG=info` (or a `boot_trace=info` directive) for any of this to
+//! appear.
+
+use std::path::Path;
+use std::time::Instant;
+
+use tracing::field::{Field, Visit};
+use tracing::span::{Attributes, Id, Record};
+use tracing::Subscriber;
+use tracing_subscriber::layer::{Context, Layer, SubscriberExt};
+use tracing_subscriber::registry::LookupSpan;
+use tracing_subscriber::util::SubscriberInitExt;
+
+/// Field name every boot-stage span carries. `#[instrument]` call sites must
+/// spell this literally (`fields(boot.stage = "..."`)); the layer
+/// matches on it.
+const STAGE_FIELD: &str = "boot.stage";
+
+/// Stage name of the root span (`create_pod_internal`). Its wall clock is what
+/// the per-stage sum reconciles against.
+const ROOT_STAGE: &str = "pod.create";
+
+/// Installs the node's global subscriber: JSON fmt to stdout (the format the
+/// node has always logged; anything parsing its logs depends on it), env
+/// filter, [`BootTraceLayer`], and — with the `otel` feature and
+/// `OTEL_EXPORTER_OTLP_ENDPOINT` set — the OTLP export layer. With the
+/// endpoint unset the node makes no outbound telemetry connection at all.
+pub(crate) fn init_tracing() -> Result<TracingGuard, String> {
+    let filter = tracing_subscriber::EnvFilter::from_default_env();
+    let fmt = tracing_subscriber::fmt::layer().json();
+    let stack = tracing_subscriber::registry()
+        .with(filter)
+        .with(fmt)
+        .with(BootTraceLayer);
+    #[cfg(feature = "otel")]
+    {
+        let otel = nucleus_otel_bootstrap::otel_layer("nucleus-node")
+            .map_err(|e| format!("OTLP exporter init failed: {e}"))?;
+        match otel {
+            Some((layer, guard)) => {
+                stack
+                    .with(layer)
+                    .try_init()
+                    .map_err(|e| format!("tracing init failed: {e}"))?;
+                tracing::info!("OTLP exporter enabled");
+                Ok(TracingGuard { _otel: Some(guard) })
+            }
+            None => {
+                stack
+                    .try_init()
+                    .map_err(|e| format!("tracing init failed: {e}"))?;
+                Ok(TracingGuard { _otel: None })
+            }
+        }
+    }
+    #[cfg(not(feature = "otel"))]
+    {
+        stack
+            .try_init()
+            .map_err(|e| format!("tracing init failed: {e}"))?;
+        Ok(TracingGuard {})
+    }
+}
+
+/// Held by `main` for the process lifetime; dropping it flushes pending OTLP
+/// spans when export is active.
+pub(crate) struct TracingGuard {
+    #[cfg(feature = "otel")]
+    _otel: Option<nucleus_otel_bootstrap::OtelGuard>,
+}
+
+/// Times a synchronous, non-yielding closure as a boot stage. For call sites
+/// where the stage is an expression rather than a function (`command.spawn()`)
+/// and an `#[instrument]` attribute has nothing to attach to. Must not be
+/// given anything that awaits — the span guard is held across the call.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+pub(crate) fn time_sync<T>(stage: &'static str, f: impl FnOnce() -> T) -> T {
+    let span = tracing::info_span!("boot_stage", boot.stage = stage);
+    let _guard = span.enter();
+    f()
+}
+
+/// One closed stage span, recorded under its `pod.create` root.
+#[derive(Debug, Clone)]
+struct StageRecord {
+    stage: String,
+    /// Milliseconds from root-span open to this span's open.
+    offset_ms: u128,
+    dur_ms: u128,
+    /// True when another stage span (besides the root) encloses this one;
+    /// nested stages are excluded from the reconciliation sum.
+    nested: bool,
+}
+
+/// Span-extension marker for any boot-stage span.
+struct StageStart {
+    stage: String,
+    started: Instant,
+    offset_ms: Option<u128>,
+}
+
+/// Span-extension accumulator, present only on the root span.
+#[derive(Default)]
+struct RootAgg {
+    pod_id: Option<String>,
+    records: Vec<StageRecord>,
+}
+
+/// Records boot-stage span durations and emits the breakdown when the root
+/// `pod.create` span closes. Spans without the `boot.stage` field are
+/// ignored entirely.
+pub(crate) struct BootTraceLayer;
+
+impl<S> Layer<S> for BootTraceLayer
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
+        let mut visitor = StageVisitor::default();
+        attrs.record(&mut visitor);
+        let Some(stage) = visitor.stage else { return };
+        let Some(span) = ctx.span(id) else { return };
+
+        let mut offset_ms = None;
+        if stage != ROOT_STAGE {
+            for ancestor in span.scope().skip(1) {
+                let ext = ancestor.extensions();
+                if ext.get::<RootAgg>().is_some() {
+                    if let Some(root_start) = ext.get::<StageStart>() {
+                        offset_ms = Some(root_start.started.elapsed().as_millis());
+                    }
+                    break;
+                }
+            }
+        }
+
+        let mut ext = span.extensions_mut();
+        if stage == ROOT_STAGE {
+            ext.insert(RootAgg::default());
+        }
+        ext.insert(StageStart {
+            stage,
+            started: Instant::now(),
+            offset_ms,
+        });
+    }
+
+    fn on_record(&self, id: &Id, values: &Record<'_>, ctx: Context<'_, S>) {
+        // The root span declares `pod_id` as an empty field and records it
+        // after the Uuid exists; pick it up for the breakdown event.
+        let mut visitor = PodIdVisitor::default();
+        values.record(&mut visitor);
+        let Some(pod_id) = visitor.pod_id else { return };
+        let Some(span) = ctx.span(id) else { return };
+        let mut ext = span.extensions_mut();
+        if let Some(agg) = ext.get_mut::<RootAgg>() {
+            agg.pod_id = Some(pod_id);
+        }
+    }
+
+    fn on_close(&self, id: Id, ctx: Context<'_, S>) {
+        let Some(span) = ctx.span(&id) else { return };
+        let (stage, dur_ms, offset_ms) = {
+            let ext = span.extensions();
+            match ext.get::<StageStart>() {
+                Some(s) => (s.stage.clone(), s.started.elapsed().as_millis(), s.offset_ms),
+                None => return,
+            }
+        };
+
+        let is_root = span.extensions().get::<RootAgg>().is_some();
+        if is_root {
+            // Take the accumulator out (extension locks dropped) before
+            // emitting, so the event dispatch never re-enters a held lock.
+            let agg = span.extensions_mut().remove::<RootAgg>().unwrap_or_default();
+            let (measured_ms, unaccounted_ms, stages) = summarize(&agg.records, dur_ms);
+            tracing::info!(
+                target: "boot_trace",
+                pod_id = %agg.pod_id.unwrap_or_default(),
+                wall_ms = dur_ms as u64,
+                measured_ms = measured_ms as u64,
+                unaccounted_ms,
+                stages = %stages,
+                "pod boot breakdown (unaccounted = wall - sum of top-level stages; \
+                 a large value means unmeasured work, which is a finding)"
+            );
+            return;
+        }
+
+        let mut nested = false;
+        for ancestor in span.scope().skip(1) {
+            let is_ancestor_root = ancestor.extensions().get::<RootAgg>().is_some();
+            if is_ancestor_root {
+                let mut ext = ancestor.extensions_mut();
+                if let Some(agg) = ext.get_mut::<RootAgg>() {
+                    agg.records.push(StageRecord {
+                        stage,
+                        offset_ms: offset_ms.unwrap_or(0),
+                        dur_ms,
+                        nested,
+                    });
+                }
+                return;
+            }
+            if ancestor.extensions().get::<StageStart>().is_some() {
+                nested = true;
+            }
+        }
+        // No root ancestor: the span ran outside a pod.create (e.g. a health
+        // probe of an existing pod). Nothing to attribute it to; drop it.
+    }
+}
+
+/// Pure summary: (sum of top-level stage durations, wall − sum, rendered
+/// stage list ordered by start offset, nested stages prefixed `+`).
+fn summarize(records: &[StageRecord], wall_ms: u128) -> (u128, i64, String) {
+    let mut ordered: Vec<&StageRecord> = records.iter().collect();
+    ordered.sort_by_key(|r| r.offset_ms);
+    let measured: u128 = ordered
+        .iter()
+        .filter(|r| !r.nested)
+        .map(|r| r.dur_ms)
+        .sum();
+    let unaccounted = wall_ms as i64 - measured as i64;
+    let stages = ordered
+        .iter()
+        .map(|r| {
+            format!(
+                "{}{}={}ms@+{}ms",
+                if r.nested { "+" } else { "" },
+                r.stage,
+                r.dur_ms,
+                r.offset_ms
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(" ");
+    (measured, unaccounted, stages)
+}
+
+#[derive(Default)]
+struct StageVisitor {
+    stage: Option<String>,
+}
+
+impl Visit for StageVisitor {
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if field.name() == STAGE_FIELD {
+            self.stage = Some(value.to_string());
+        }
+    }
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        if field.name() == STAGE_FIELD {
+            self.stage = Some(format!("{value:?}").trim_matches('"').to_string());
+        }
+    }
+}
+
+#[derive(Default)]
+struct PodIdVisitor {
+    pod_id: Option<String>,
+}
+
+impl Visit for PodIdVisitor {
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if field.name() == "pod_id" {
+            self.pod_id = Some(value.to_string());
+        }
+    }
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "pod_id" {
+            self.pod_id = Some(format!("{value:?}").trim_matches('"').to_string());
+        }
+    }
+}
+
+/// Console-log markers whose position in the captured `firecracker.log` dates
+/// the guest's boot milestones. Kernel lines carry `[ N.NNNNNN]` timestamps;
+/// guest-init's own stderr lines do not, so those are reported as `>=t` lower
+/// bounds from the last kernel timestamp seen before them.
+const GUEST_MARKERS: &[&str] = &[
+    "Run /init as init process",
+    "fetched identity",
+    "failed to fetch identity",
+    "fetched broker capability over vsock",
+    "no broker capability over vsock",
+    "fetched session task token over vsock",
+    "failed to fetch session task token over vsock",
+    "fetched DLC admission provisioning",
+    "failed to fetch DLC admission provisioning",
+];
+
+/// Emits the guest-side boot timeline parsed from the pod's console log.
+/// Best-effort by design: a missing or unparseable log must never affect the
+/// launch — the pod is already up when this runs.
+pub(crate) async fn log_guest_console_timeline(log_path: &Path) {
+    let console = match tokio::fs::read_to_string(log_path).await {
+        Ok(c) => c,
+        Err(err) => {
+            tracing::debug!(target: "boot_trace", %err, "no guest console log to parse");
+            return;
+        }
+    };
+    let timeline = guest_timeline(&console);
+    if timeline.is_empty() {
+        return;
+    }
+    tracing::info!(
+        target: "boot_trace",
+        timeline = %timeline,
+        "guest console timeline (kernel-clock seconds; >=t marks an untimestamped \
+         guest-init line dated by the last kernel timestamp before it)"
+    );
+}
+
+/// Pure parse of a captured console log into an ordered timeline string.
+fn guest_timeline(console: &str) -> String {
+    let mut out = Vec::new();
+    let mut first_ts: Option<f64> = None;
+    let mut last_ts: Option<f64> = None;
+    for line in console.lines() {
+        let ts = parse_kernel_ts(line);
+        if let Some(t) = ts {
+            if first_ts.is_none() {
+                first_ts = Some(t);
+                out.push(format!("kernel_first@{t:.3}"));
+            }
+            last_ts = Some(t);
+        }
+        for marker in GUEST_MARKERS {
+            if line.contains(marker) {
+                match ts {
+                    Some(t) => out.push(format!("'{marker}'@{t:.3}")),
+                    None => out.push(format!(
+                        "'{marker}'@>={:.3}",
+                        last_ts.unwrap_or(0.0)
+                    )),
+                }
+            }
+        }
+    }
+    if let Some(t) = last_ts {
+        out.push(format!("kernel_last@{t:.3}"));
+    }
+    out.join(" | ")
+}
+
+/// Parses the leading `[ N.NNNNNN]` kernel timestamp, if the line has one.
+fn parse_kernel_ts(line: &str) -> Option<f64> {
+    let rest = line.strip_prefix('[')?;
+    let end = rest.find(']')?;
+    rest[..end].trim().parse::<f64>().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rec(stage: &str, offset_ms: u128, dur_ms: u128, nested: bool) -> StageRecord {
+        StageRecord {
+            stage: stage.to_string(),
+            offset_ms,
+            dur_ms,
+            nested,
+        }
+    }
+
+    #[test]
+    fn summarize_sums_top_level_and_reports_gap() {
+        let records = vec![
+            rec("prepare_jail", 10, 200, false),
+            rec("attestation.hash", 300, 3000, false),
+            rec("proxy.health_wait", 3400, 4000, false),
+        ];
+        let (measured, unaccounted, stages) = summarize(&records, 8000);
+        assert_eq!(measured, 7200);
+        assert_eq!(unaccounted, 800);
+        assert!(stages.starts_with("prepare_jail=200ms@+10ms"));
+    }
+
+    #[test]
+    fn summarize_excludes_nested_stages_from_the_sum() {
+        let records = vec![
+            rec("net.setup", 0, 500, false),
+            rec("net.dns_proxy", 100, 300, true),
+        ];
+        let (measured, unaccounted, stages) = summarize(&records, 600);
+        assert_eq!(measured, 500, "nested stage must not double-count");
+        assert_eq!(unaccounted, 100);
+        assert!(stages.contains("+net.dns_proxy=300ms"));
+    }
+
+    #[test]
+    fn summarize_reports_negative_unaccounted_rather_than_hiding_it() {
+        // Overlapping stages summing past wall clock must show up as a
+        // negative gap, not saturate to zero — either way the instrument has
+        // to say something is off.
+        let records = vec![rec("a", 0, 500, false), rec("b", 0, 500, false)];
+        let (_, unaccounted, _) = summarize(&records, 700);
+        assert_eq!(unaccounted, -300);
+    }
+
+    #[test]
+    fn summarize_orders_stages_by_start_offset() {
+        let records = vec![rec("late", 500, 10, false), rec("early", 5, 10, false)];
+        let (_, _, stages) = summarize(&records, 600);
+        let early = stages.find("early").unwrap();
+        let late = stages.find("late").unwrap();
+        assert!(early < late);
+    }
+
+    #[test]
+    fn kernel_timestamp_parses_and_rejects() {
+        assert_eq!(parse_kernel_ts("[    0.123456] Linux version"), Some(0.123456));
+        assert_eq!(parse_kernel_ts("[   12.5] foo"), Some(12.5));
+        assert_eq!(parse_kernel_ts("[WARN] not a timestamp"), None);
+        assert_eq!(parse_kernel_ts("no brackets"), None);
+    }
+
+    #[test]
+    fn guest_timeline_brackets_untimestamped_markers() {
+        let console = "\
+[    0.000000] Linux version 6.1\n\
+[    0.800000] Run /init as init process\n\
+fetched identity: spiffe://example/pod\n\
+[    1.200000] random: crng init done\n\
+fetched session task token over vsock\n";
+        let tl = guest_timeline(console);
+        assert!(tl.contains("kernel_first@0.000"));
+        assert!(tl.contains("'Run /init as init process'@0.800"));
+        // Marker after the 0.8 kernel line but before the 1.2 one.
+        assert!(tl.contains("'fetched identity'@>=0.800"));
+        assert!(tl.contains("'fetched session task token over vsock'@>=1.200"));
+        assert!(tl.contains("kernel_last@1.200"));
+    }
+
+    #[test]
+    fn guest_timeline_is_empty_for_a_log_with_nothing_recognizable() {
+        assert!(guest_timeline("plain firecracker chatter\n").is_empty());
+    }
+}

--- a/crates/nucleus-node/src/boot_trace.rs
+++ b/crates/nucleus-node/src/boot_trace.rs
@@ -181,7 +181,11 @@ where
         let (stage, dur_ms, offset_ms) = {
             let ext = span.extensions();
             match ext.get::<StageStart>() {
-                Some(s) => (s.stage.clone(), s.started.elapsed().as_millis(), s.offset_ms),
+                Some(s) => (
+                    s.stage.clone(),
+                    s.started.elapsed().as_millis(),
+                    s.offset_ms,
+                ),
                 None => return,
             }
         };
@@ -190,7 +194,10 @@ where
         if is_root {
             // Take the accumulator out (extension locks dropped) before
             // emitting, so the event dispatch never re-enters a held lock.
-            let agg = span.extensions_mut().remove::<RootAgg>().unwrap_or_default();
+            let agg = span
+                .extensions_mut()
+                .remove::<RootAgg>()
+                .unwrap_or_default();
             let (measured_ms, unaccounted_ms, stages) = summarize(&agg.records, dur_ms);
             tracing::info!(
                 target: "boot_trace",
@@ -234,11 +241,7 @@ where
 fn summarize(records: &[StageRecord], wall_ms: u128) -> (u128, i64, String) {
     let mut ordered: Vec<&StageRecord> = records.iter().collect();
     ordered.sort_by_key(|r| r.offset_ms);
-    let measured: u128 = ordered
-        .iter()
-        .filter(|r| !r.nested)
-        .map(|r| r.dur_ms)
-        .sum();
+    let measured: u128 = ordered.iter().filter(|r| !r.nested).map(|r| r.dur_ms).sum();
     let unaccounted = wall_ms as i64 - measured as i64;
     let stages = ordered
         .iter()
@@ -349,10 +352,7 @@ fn guest_timeline(console: &str) -> String {
             if line.contains(marker) {
                 match ts {
                     Some(t) => out.push(format!("'{marker}'@{t:.3}")),
-                    None => out.push(format!(
-                        "'{marker}'@>={:.3}",
-                        last_ts.unwrap_or(0.0)
-                    )),
+                    None => out.push(format!("'{marker}'@>={:.3}", last_ts.unwrap_or(0.0))),
                 }
             }
         }
@@ -429,7 +429,10 @@ mod tests {
 
     #[test]
     fn kernel_timestamp_parses_and_rejects() {
-        assert_eq!(parse_kernel_ts("[    0.123456] Linux version"), Some(0.123456));
+        assert_eq!(
+            parse_kernel_ts("[    0.123456] Linux version"),
+            Some(0.123456)
+        );
         assert_eq!(parse_kernel_ts("[   12.5] foo"), Some(12.5));
         assert_eq!(parse_kernel_ts("[WARN] not a timestamp"), None);
         assert_eq!(parse_kernel_ts("no brackets"), None);

--- a/crates/nucleus-node/src/firecracker_config.rs
+++ b/crates/nucleus-node/src/firecracker_config.rs
@@ -288,6 +288,7 @@ fn place_resource(resource: &JailResource, dest: &Path) -> Result<(), String> {
 /// The vsock socket is deliberately absent: Firecracker CREATES it at `uds_path`
 /// inside the jail, and the host reaches it through `layout.host_path(VSOCK)`.
 #[cfg(target_os = "linux")]
+#[tracing::instrument(skip_all, fields(boot.stage = "prepare_jail"))]
 pub(crate) fn prepare_jail(
     layout: &JailLayout,
     image: &nucleus_spec::ImageSpec,
@@ -987,6 +988,7 @@ pub(crate) fn verify_seccomp_active(_pid: u32) -> Result<(), String> {
 /// deciding it is fine — see the rule in `check-failclosed-verifiers.sh`. A
 /// verifier may never SUCCEED when it cannot check; it may take a moment to look.
 #[cfg(target_os = "linux")]
+#[tracing::instrument(skip_all, fields(boot.stage = "seccomp.wait"))]
 pub(crate) async fn verify_seccomp_active_within(
     pid: u32,
     timeout: std::time::Duration,

--- a/crates/nucleus-node/src/identity.rs
+++ b/crates/nucleus-node/src/identity.rs
@@ -197,6 +197,7 @@ impl IdentityManager {
     ///
     /// The computed attestation, or an error if hashing fails.
     #[allow(dead_code)]
+    #[tracing::instrument(skip_all, fields(boot.stage = "attestation.hash"))]
     pub async fn compute_attestation(
         &self,
         pod_id: &str,
@@ -249,6 +250,7 @@ impl IdentityManager {
     /// If attestation exists for the pod, it will be embedded in the certificate
     /// as an X.509 extension.
     #[allow(dead_code)]
+    #[tracing::instrument(skip_all, fields(boot.stage = "cert.issue"))]
     pub async fn fetch_attested_certificate(
         &self,
         identity: &Identity,

--- a/crates/nucleus-node/src/main.rs
+++ b/crates/nucleus-node/src/main.rs
@@ -37,6 +37,7 @@ mod oidc;
 mod workload_api_protocol;
 mod workload_api_vsock;
 use auth::{AuthConfig, AuthError};
+mod boot_trace;
 mod broker;
 mod broker_launch;
 mod broker_perform;
@@ -536,10 +537,7 @@ async fn main() -> Result<(), ApiError> {
         .install_default()
         .map_err(|_| ApiError::Driver("failed to install rustls crypto provider".to_string()))?;
 
-    tracing_subscriber::fmt()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-        .json()
-        .init();
+    let _tracing_guard = boot_trace::init_tracing().map_err(ApiError::Driver)?;
 
     let args = Args::parse();
     tokio::fs::create_dir_all(&args.state_dir).await?;
@@ -997,6 +995,7 @@ async fn auth_middleware(
     Ok(next.run(req).await)
 }
 
+#[tracing::instrument(skip_all, fields(boot.stage = "pod.create", pod_id = tracing::field::Empty))]
 async fn create_pod_internal(
     state: &NodeState,
     mut spec: PodSpec,
@@ -1004,6 +1003,7 @@ async fn create_pod_internal(
     raw_yaml: Option<String>,
 ) -> Result<(Uuid, Option<String>), ApiError> {
     let id = Uuid::new_v4();
+    tracing::Span::current().record("pod_id", tracing::field::display(id));
     let created_at = now_unix();
 
     // ── Trust Gate: verify agent reputation, scope permissions ──────
@@ -1024,6 +1024,7 @@ async fn create_pod_internal(
             spawn_container_pod(state, &pod_dir, &spec, id, raw_yaml.as_deref()).await?
         }
     };
+    boot_trace::log_guest_console_timeline(&log_path).await;
 
     // Write lifecycle audit event so even direct-task pods have an audit trail.
     write_lifecycle_audit(
@@ -1980,6 +1981,7 @@ async fn wait_for_container_announce(
 /// is never compiled or tested on a macOS dev host. `vmm_preflight_refuses_*`
 /// exercise it here.
 #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+#[tracing::instrument(skip_all, fields(boot.stage = "vmm.preflight"))]
 async fn vmm_preflight(firecracker_path: &Path) -> nucleus_spec::vmm_version::VmmVerdict {
     use nucleus_spec::vmm_version::{judge, VmmVerdict};
 
@@ -2348,7 +2350,9 @@ async fn spawn_firecracker_pod(
             cmd
         };
         firecracker_config::apply_seccomp_flags(&mut command, spec, jail_layout.is_some())?;
-        let mut child = match command.stdout(log_stdout).stderr(log_stderr).spawn() {
+        let mut child = match boot_trace::time_sync("firecracker.spawn", || {
+            command.stdout(log_stdout).stderr(log_stderr).spawn()
+        }) {
             Ok(child) => child,
             Err(err) => {
                 cleanup_net_resources(
@@ -3061,6 +3065,7 @@ fn start_pod_reaper(state: NodeState) {
 }
 
 #[cfg(target_os = "linux")]
+#[tracing::instrument(skip_all, fields(boot.stage = "vsock.wait"))]
 async fn wait_for_vsock_socket(path: &Path) -> Result<(), ApiError> {
     let start = std::time::Instant::now();
     while start.elapsed() < Duration::from_secs(3) {
@@ -3110,6 +3115,7 @@ async fn wait_for_vsock_socket(path: &Path) -> Result<(), ApiError> {
 const PROXY_HEALTH_TIMEOUT_SECS_DEFAULT: u64 = 30;
 
 #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+#[tracing::instrument(skip_all, fields(boot.stage = "proxy.health_wait"))]
 async fn wait_for_proxy_health(addr: SocketAddr) -> Result<(), ApiError> {
     wait_for_proxy_health_within(
         addr,

--- a/crates/nucleus-node/src/net.rs
+++ b/crates/nucleus-node/src/net.rs
@@ -260,6 +260,7 @@ pub fn validate_policy(policy: &NetworkSpec) -> Result<(), ApiError> {
 }
 
 #[cfg(target_os = "linux")]
+#[tracing::instrument(skip_all, fields(boot.stage = "net.dns_proxy"))]
 pub async fn start_dns_proxy(
     plan: &mut NetPlan,
     policy: &NetworkSpec,
@@ -315,6 +316,7 @@ pub async fn start_dns_proxy(
 }
 
 #[cfg(target_os = "linux")]
+#[tracing::instrument(skip_all, fields(boot.stage = "net.create_netns"))]
 pub async fn create_netns(name: &str) -> Result<(), ApiError> {
     ensure_command("ip")?;
     let status = Command::new("ip")
@@ -340,6 +342,7 @@ pub async fn create_netns(_name: &str) -> Result<(), ApiError> {
 /// This must be called BEFORE spawning any process in the netns to prevent
 /// race conditions where a process could exfiltrate data before policy applies.
 #[cfg(target_os = "linux")]
+#[tracing::instrument(skip_all, fields(boot.stage = "net.default_deny"))]
 pub async fn apply_default_deny(netns: &str) -> Result<(), ApiError> {
     ensure_command("iptables")?;
 
@@ -436,6 +439,7 @@ pub async fn cleanup_netns(_name: &str) -> Result<(), ApiError> {
 }
 
 #[cfg(target_os = "linux")]
+#[tracing::instrument(skip_all, fields(boot.stage = "net.setup"))]
 pub async fn setup_network(plan: &NetPlan) -> Result<(), ApiError> {
     ensure_command("ip")?;
     ensure_command("iptables")?;

--- a/crates/nucleus-node/src/trust_gate.rs
+++ b/crates/nucleus-node/src/trust_gate.rs
@@ -308,6 +308,7 @@ struct Brackets {
 ///
 /// If the trust API is unreachable or returns an error, falls back to
 /// the default bracket (never blocks execution due to trust API failure).
+#[tracing::instrument(skip_all, fields(boot.stage = "trust_gate.verify"))]
 pub async fn verify_agent_trust(
     config: &TrustGateConfig,
     spec: &PodSpec,

--- a/crates/nucleus-otel-bootstrap/src/lib.rs
+++ b/crates/nucleus-otel-bootstrap/src/lib.rs
@@ -8,10 +8,13 @@
 //! # Activation
 //!
 //! Sets up OTLP export when `OTEL_EXPORTER_OTLP_ENDPOINT` is set
-//! (the canonical env per [OTel spec][envs]). Optional knobs:
+//! (the canonical env per [OTel spec][envs]). One optional knob:
 //! - `OTEL_SERVICE_NAME` — overrides the `service_name` argument
-//! - `OTEL_PROPAGATORS` — defaults to `tracecontext,baggage` (W3C)
-//! - `OTEL_EXPORTER_OTLP_PROTOCOL` — `grpc` (default) or `http/protobuf`
+//!
+//! The propagator is always W3C `tracecontext` and the exporter always
+//! speaks OTLP over gRPC; `OTEL_PROPAGATORS` and
+//! `OTEL_EXPORTER_OTLP_PROTOCOL` are **not** read. (This doc previously
+//! claimed they were honoured while nothing implemented either.)
 //!
 //! [envs]: https://opentelemetry.io/docs/languages/sdk-configuration/general/
 //!
@@ -95,15 +98,58 @@ pub fn init(service_name: &str) -> Result<OtelGuard> {
     }
     let endpoint = endpoint.unwrap();
 
-    // W3C Trace Context propagation (canonical default; injectable
-    // override via OTEL_PROPAGATORS — we trust the SDK default since
-    // tracecontext is the only universally-supported propagator).
+    let (layer, guard) = build_otel_layer(service_name, &endpoint)?;
+
+    tracing_subscriber::registry()
+        .with(env_filter)
+        .with(fmt_layer)
+        .with(layer)
+        .try_init()
+        .context("install tracing subscriber (with OTLP layer)")?;
+
+    tracing::info!(endpoint = %endpoint, "OTLP exporter enabled");
+
+    Ok(guard)
+}
+
+/// The OTLP layer alone, for binaries that compose their own subscriber
+/// (the node keeps its JSON fmt layer and adds boot-stage tracing; swapping
+/// its subscriber for [`init`]'s would silently turn its logs from JSON to
+/// text and break whatever parses them).
+///
+/// Returns `Ok(None)` when `OTEL_EXPORTER_OTLP_ENDPOINT` is unset — no
+/// exporter is built and no outbound connection will ever be made. The
+/// caller must hold the [`OtelGuard`] for the process lifetime and add the
+/// layer to the subscriber it installs.
+pub fn otel_layer<S>(
+    service_name: &str,
+) -> Result<Option<(impl tracing_subscriber::Layer<S>, OtelGuard)>>
+where
+    S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
+{
+    let Ok(endpoint) = std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT") else {
+        return Ok(None);
+    };
+    build_otel_layer(service_name, &endpoint).map(Some)
+}
+
+/// Shared exporter wiring: propagator, OTLP gRPC exporter, resource,
+/// provider. Sets the global propagator and tracer provider as side effects.
+fn build_otel_layer<S>(
+    service_name: &str,
+    endpoint: &str,
+) -> Result<(impl tracing_subscriber::Layer<S>, OtelGuard)>
+where
+    S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
+{
+    // W3C Trace Context propagation: the only universally-supported
+    // propagator, and the only one this crate implements.
     global::set_text_map_propagator(TraceContextPropagator::new());
 
     // OTLP gRPC exporter.
     let exporter = opentelemetry_otlp::SpanExporter::builder()
         .with_tonic()
-        .with_endpoint(&endpoint)
+        .with_endpoint(endpoint)
         .build()
         .context("build OTLP gRPC span exporter")?;
 
@@ -121,27 +167,17 @@ pub fn init(service_name: &str) -> Result<OtelGuard> {
         .with_batch_exporter(exporter)
         .build();
 
-    let tracer = provider.tracer(resolved_name.clone());
-    let otel_layer = tracing_opentelemetry::layer().with_tracer(tracer);
+    let tracer = provider.tracer(resolved_name);
+    let layer = tracing_opentelemetry::layer().with_tracer(tracer);
 
     global::set_tracer_provider(provider.clone());
 
-    tracing_subscriber::registry()
-        .with(env_filter)
-        .with(fmt_layer)
-        .with(otel_layer)
-        .try_init()
-        .context("install tracing subscriber (with OTLP layer)")?;
-
-    tracing::info!(
-        service = %resolved_name,
-        endpoint = %endpoint,
-        "OTLP exporter enabled"
-    );
-
-    Ok(OtelGuard {
-        provider: Some(provider),
-    })
+    Ok((
+        layer,
+        OtelGuard {
+            provider: Some(provider),
+        },
+    ))
 }
 
 #[cfg(test)]

--- a/deny.toml
+++ b/deny.toml
@@ -89,6 +89,15 @@ ignore = [
   # RUSTSEC-2026-0114 entry above. REVISIT as its own PR — a major engine bump
   # does not belong inside unrelated work.
   "RUSTSEC-2026-0222",
+
+  # rkyv 0.7.46 OOB reads validating Rc/Arc archives (RUSTSEC-2026-0235).
+  # Advisory-DB refresh red on unrelated PRs the same day. Orphan lockfile
+  # residue: backs rust_decimal's optional `rkyv` feature, which nothing
+  # enables — `cargo tree -i rkyv --all-features --target all` finds no path,
+  # so it never compiles (same class as RUSTSEC-2026-0104). Fix line
+  # (rkyv >=0.8.17) unreachable until rust_decimal migrates off 0.7.
+  # REVISIT with rust_decimal updates.
+  "RUSTSEC-2026-0235",
 ]
 # These are informational; scope to workspace dependencies.
 unmaintained = "workspace"


### PR DESCRIPTION
## What

`nucleus verify --tier2` prints `pod created in N ms` — wall clock around one blocking POST that silently includes the entire guest boot. No stage on the path measured itself. This adds:

- **`nucleus-node/src/boot_trace.rs`**: `boot.stage` spans on every boot-path segment owner, and a `BootTraceLayer` that renders a per-pod breakdown when the root `pod.create` span closes — reconciled against the handler's own wall clock. `unaccounted = wall − sum(top-level stages)` is printed, not hidden: a profiler that always sums to 100% can no longer say it missed something. Nested stages are marked `+` and excluded from the sum so nothing double-counts.
- **Guest timing with zero guest changes**: the captured `firecracker.log` is parsed for kernel `[N.NNNNNN]` timestamps and guest-init's marker lines; untimestamped markers are reported as `>=t` lower bounds from the last kernel timestamp before them.
- **OTLP export behind an `otel` feature** (tool-proxy precedent — off by default, inert without `OTEL_EXPORTER_OTLP_ENDPOINT`). All OTel deps come through `nucleus-otel-bootstrap`'s new composable `otel_layer()`, so the node keeps its JSON log format — adopting the bootstrap's `init()` would have silently switched the logs to text.
- The bootstrap's doc no longer claims `OTEL_PROPAGATORS` / `OTEL_EXPORTER_OTLP_PROTOCOL` are honoured (nothing implements either), and the stale "Pinned to 0.31" workspace comment is corrected.

## The answer (Lima VM, real Firecracker pods, 4 boots + 1 perturbed)

```
wall 7.7–7.8 s, unaccounted < 50 ms in every run:
  0.38 s  host prep (attestation.hash 290 ms cold / ~130 ms warm; net 25 ms; seccomp 21 ms)
  1.45 s  guest kernel to "Run /init as init process"
  ~0.1 s  guest-init (identity + task token over vsock)
  ~6.1 s  guest tool-proxy startup — health probes get "handshake EOF" every 100 ms
          until the proxy starts accepting, then 200 OK immediately
```

**The rootfs-hash hypothesis is refuted twice over**: `attestation.hash` costs 290 ms, and the vsock bridge it allegedly blocked was listening a full second before the guest's first connect arrived. The 8 seconds live inside the guest's tool-proxy startup window, which is currently unattributable because the guest proxy runs with an error-only log filter and prints nothing. Attributing (and then shrinking) that interior is the next increment; this one is measurement only.

## Verification

- Perturbation, not trust: a planted 750 ms sleep in `prepare_jail` moved that stage 0→760 ms, shifted every downstream offset by exactly the plant, and changed nothing else. Plant reverted.
- 4 unperturbed boots: stable stage profile, unaccounted 39–49 ms.
- Jaeger (all-in-one in the VM): the same spans arrive as a parent-child waterfall under service `nucleus-node`.
- Endpoint unset with the `otel`-featured binary: node starts, logs stay JSON, `ss` shows zero connections to the collector port.
- `cargo clippy --all-targets --all-features -- -D warnings` clean for both changed crates on macOS and Linux; `cargo test`: 295/295 (Linux) and 285/285 (macOS) for nucleus-node, 2/2 bootstrap; doctests, line-ratchet (3988 ≤ 4042), dep-ceiling all green.
- The snapshot cmdline-classification gate caught the span field's original `nucleus.boot_stage` name (its scraper owns the `nucleus.*` namespace in `firecracker_config.rs`); renamed to `boot.stage` rather than teaching the classifier a non-key.

## Pre-existing failure, not from this branch

`verify --tier2 --here` ends with `dlc_admission=None, expected "provisioned"` — reproduced byte-for-byte with a stock `origin/main` (b5a3bbca) node binary on the same VM. The labels→node→guest chain break predates this work ("fetched DLC admission provisioning" never appears on the guest console). Filed here for visibility; needs its own investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UA8kchV3eadjGv6BmJXfqm