### PR TITLE
hotfix: close_range is glibc-only — restore musl build (FM-5 inc3)

### DIFF
--- a/crates/nucleus-tool-proxy/src/workload.rs
+++ b/crates/nucleus-tool-proxy/src/workload.rs
@@ -428,11 +428,20 @@ mod harden {
         unsafe {
             // Close every fd from 3 up. std has already dup2'd this child's
             // stdio onto 0/1/2, so the only fds left above 2 are ones inherited
-            // from the parent — the leak this closes. `close_range` is a single
-            // syscall (async-signal-safe); ENOSYS on a pre-5.9 kernel is
-            // tolerated (the guest kernel is modern, and CLOEXEC is the fallback
+            // from the parent — the leak this closes. Invoked as the raw
+            // `close_range` syscall, not `libc::close_range`, because the latter
+            // is a glibc-only wrapper in the `libc` crate and the guest rootfs is
+            // musl (`libc::close_range` fails to resolve on the musl target). A
+            // single syscall is async-signal-safe; ENOSYS on a pre-5.9 kernel is
+            // tolerated (the guest kernel is modern, CLOEXEC is the fallback
             // there), any other error fails the spawn.
-            if libc::close_range(3, libc::c_uint::MAX, 0) != 0 {
+            if libc::syscall(
+                libc::SYS_close_range,
+                3 as libc::c_long,
+                libc::c_uint::MAX as libc::c_long,
+                0 as libc::c_long,
+            ) != 0
+            {
                 let err = io::Error::last_os_error();
                 if err.raw_os_error() != Some(libc::ENOSYS) {
                     return Err(err);


### PR DESCRIPTION
## Fire

FM-5 increment 3 (#2179) merged with `libc::close_range` in the workload-spawn hardening hook. That wrapper is **glibc-only in the `libc` crate**, but the guest rootfs is **musl** (static). So the symbol doesn't resolve on the musl target, and the moment #2179 merged, **main broke**: `musl type-check (nucleus-node, nucleus-tool-proxy)` and `a real nucleus pod boots and is enforced (x86_64)` both fail (they're not required checks, so auto-merge landed #2179 on the required set passing — my miss).

## Fix

Switch to the raw `syscall(SYS_close_range, ..)`, which is environment-agnostic. `SYS_close_range` is defined for every musl arch in the pinned `libc-0.2.189` (verified in-source); `libc::syscall` / `c_long` / `c_uint` / `ENOSYS` / `raw_os_error` are all universal. Behavior is byte-identical: close fds 3.., tolerate `ENOSYS` on pre-5.9 kernels, fail-closed on any other error.

## Verification

macOS build + fmt clean. The authoritative checks are this PR's own `musl type-check` and pod-boot jobs — the two that main is currently red on — so CI *is* the verification here (a local musl reproduction needs the musl cross-toolchain and is far slower than CI under load). Root cause is a one-symbol swap with every replacement symbol verified present on musl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UA8kchV3eadjGv6BmJXfqm