### PR TITLE
Delivery conformance: the boot gate replays the observed workload environment through the extracted oracle

### DIFF
--- a/.github/workflows/quickstart-boot.yml
+++ b/.github/workflows/quickstart-boot.yml
@@ -312,6 +312,30 @@ jobs:
           }
           echo "in-guest workload probe: PASS present, FAIL absent"
 
+      - name: Delivery conformance (observed inventory vs the extracted oracle)
+        run: |
+          # The probe emits its observed environment inventory
+          # (NUCLEUS_WORKLOAD_ENV: <name>, names only) into the guest log. This
+          # step replays every observed name through the production classifier
+          # (env_key_material) and the extracted oracle (ident_may_deliver) — a
+          # categorical check behind the probe's hand-enumerated variable list:
+          # a NOVEL secret-classified name flunks here even though no list
+          # remembers it. Fails closed on an empty inventory: the binary exits
+          # non-zero when the needle never appears, so "the probe's evidence
+          # never reached the log" cannot read as conformant.
+          cargo build --release -p nucleus-delivery-conformance
+          state=/var/lib/nucleus/state
+          logs=$(sudo find "$state" -name firecracker.log)
+          [ -n "$logs" ] || { echo "::error::no firecracker.log found"; exit 1; }
+          # Copy root-owned logs somewhere the unprivileged binary can read them,
+          # rather than running the checker under sudo.
+          tmp=$(mktemp -d)
+          i=0
+          for f in $logs; do
+            sudo cp "$f" "$tmp/log$i"; sudo chown "$(id -u)" "$tmp/log$i"; i=$((i+1))
+          done
+          ./target/release/nucleus-delivery-conformance "$tmp"/log*
+
       - name: Show the guest log on failure
         if: failure()
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6754,6 +6754,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "nucleus-delivery-conformance"
+version = "1.0.0"
+dependencies = [
+ "nucleus-ifc-kernel",
+]
+
+[[package]]
 name = "nucleus-econ-kernels"
 version = "1.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ members = [
     "crates/ctf-mcp",                  # MCP server: lets any AI agent play The Vault CTF
     "crates/nucleus-flow-replay",   # Replay traces through the real kernel decision path
     "crates/nucleus-ifc-kernel",         # IFC admission core: dependency-free reference monitor (Aeneas target)
+    "crates/nucleus-delivery-conformance", # Boot-trace conformance: observed deliveries replayed through the extracted oracle
     "crates/portcullis-core",            # Aeneas verification target: dependency-free lattice types
     "crates/portcullis-effects",         # Sealed effect traits — I/O only through policy-enforced channels
     "crates/portcullis-wasi",            # WASI 0.3.0 world functor: capability lattice → component import world

--- a/crates/nucleus-delivery-conformance/Cargo.toml
+++ b/crates/nucleus-delivery-conformance/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "nucleus-delivery-conformance"
+version = "1.0.0"
+edition = "2024"
+license = "MIT"
+description = "Boot-trace conformance: replays a pod's observed delivery ledger through the extracted ident_may_deliver oracle, so every real boot is validated as a behaviour of the reference machine."
+repository = "https://github.com/coproduct-opensource/nucleus"
+
+[dependencies]
+nucleus-ifc-kernel = { path = "../nucleus-ifc-kernel" }
+
+[lints]
+workspace = true

--- a/crates/nucleus-delivery-conformance/src/main.rs
+++ b/crates/nucleus-delivery-conformance/src/main.rs
@@ -1,0 +1,194 @@
+//! `nucleus-delivery-conformance` — the boot gate's trace-conformance step: the
+//! in-guest probe's OBSERVED environment inventory, replayed through the
+//! production classifier and the extracted delivery oracle.
+//!
+//! The FM-5 chain so far: the delivery relation is PROVED (Lean, over the
+//! Aeneas-extracted `ident_may_deliver`), the launch construction is
+//! host-unit-TESTED against it pointwise, and the in-guest probe OBSERVES the
+//! real child's posture per boot (asserting a fixed list of identity variables
+//! is absent). This binary closes the remaining gap between the probe and the
+//! oracle: the probe's list is a hand-enumerated sample, while the oracle is
+//! categorical. Here, every name the probe actually SAW in the workload's
+//! environment (`NUCLEUS_WORKLOAD_ENV: <name>` inventory lines in the guest
+//! log) is classified with the SAME `env_key_material` the launch builder uses
+//! and checked against the SAME `ident_may_deliver(kind, Workload)` the Lean
+//! theorems are about — so a leaked variable is refused by classification, not
+//! by membership in a list someone remembered to extend.
+//!
+//! Fail-closed on silence: an empty inventory (or one missing the proxy-URL
+//! anchor the probe itself requires) FAILS. A checker that passes when the
+//! thing it checks never ran is the false-green shape this repo has removed
+//! several times; absence of evidence here is a red verdict, not a green one.
+//!
+//! Exit codes: 0 conformant; 1 violation or missing/empty inventory; 2 usage.
+
+use nucleus_ifc_kernel::env_classifier::env_key_material;
+use nucleus_ifc_kernel::extracted::identity::{Principal, ident_may_deliver};
+
+/// The inventory needle the workload probe emits, one line per observed
+/// environment name (names only — values never leave the guest).
+const INVENTORY_NEEDLE: &str = "NUCLEUS_WORKLOAD_ENV: ";
+
+/// The non-vacuity anchor: the probe requires this to be present in the
+/// workload environment, so a real inventory always contains it.
+const ANCHOR: &str = "NUCLEUS_TOOL_PROXY_URL";
+
+/// Extract the observed inventory (deduplicated, order-preserving) from log text.
+fn parse_inventory(log: &str) -> Vec<String> {
+    let mut seen = std::collections::BTreeSet::new();
+    let mut names = Vec::new();
+    for line in log.lines() {
+        if let Some(idx) = line.find(INVENTORY_NEEDLE) {
+            let name = line[idx + INVENTORY_NEEDLE.len()..].trim();
+            // Guest consoles interleave; keep only plausible env names so a
+            // corrupted line cannot smuggle an unparseable entry past review.
+            if !name.is_empty()
+                && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+                && seen.insert(name.to_string())
+            {
+                names.push(name.to_string());
+            }
+        }
+    }
+    names
+}
+
+/// One verdict line per name; returns the violations.
+fn check_inventory(names: &[String]) -> Vec<String> {
+    let mut violations = Vec::new();
+    for name in names {
+        let kind = env_key_material(name);
+        let licensed = ident_may_deliver(kind, Principal::Workload);
+        println!(
+            "conformance: {name} -> {kind:?} -> {}",
+            if licensed { "licensed" } else { "REFUSED" }
+        );
+        if !licensed {
+            violations.push(format!(
+                "{name} classifies as {kind:?}, which ident_may_deliver refuses for the workload"
+            ));
+        }
+    }
+    violations
+}
+
+fn main() {
+    let paths: Vec<String> = std::env::args().skip(1).collect();
+    if paths.is_empty() {
+        eprintln!("usage: nucleus-delivery-conformance <guest-log>...");
+        std::process::exit(2);
+    }
+
+    let mut inventory: Vec<String> = Vec::new();
+    for path in &paths {
+        match std::fs::read_to_string(path) {
+            Ok(text) => inventory.extend(parse_inventory(&text)),
+            Err(err) => {
+                // A named log that cannot be read is a broken harness, not a pass.
+                eprintln!("conformance: cannot read {path}: {err}");
+                std::process::exit(1);
+            }
+        }
+    }
+
+    if inventory.is_empty() {
+        eprintln!(
+            "conformance: no {INVENTORY_NEEDLE:?} lines found in {} log(s) — the probe's \
+             inventory never reached the collected logs, so there is nothing to certify. \
+             Failing closed.",
+            paths.len()
+        );
+        std::process::exit(1);
+    }
+    if !inventory.iter().any(|n| n == ANCHOR) {
+        eprintln!(
+            "conformance: inventory ({} names) is missing the {ANCHOR} anchor the probe \
+             requires — the inventory is not from a mediated workload run. Failing closed.",
+            inventory.len()
+        );
+        std::process::exit(1);
+    }
+
+    let violations = check_inventory(&inventory);
+    if violations.is_empty() {
+        println!(
+            "conformance: OK — {} observed name(s), every one licensed by \
+             ident_may_deliver(_, Workload)",
+            inventory.len()
+        );
+    } else {
+        for v in &violations {
+            eprintln!("conformance: VIOLATION — {v}");
+        }
+        std::process::exit(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The observed-shape fixture: what a real green boot's inventory looks like
+    /// (names from the probe's own contract plus ordinary runtime vars). The
+    /// middle rung does real work here: the AUTH secret is Internal and
+    /// LICENSED, while everything Secret is refused — so a green verdict is not
+    /// "nothing NUCLEUS_-prefixed crossed".
+    const GREEN_LOG: &str = "\
+[    7.1] NUCLEUS_WORKLOAD_ENV: PATH\n\
+[    7.1] NUCLEUS_WORKLOAD_ENV: HOME\n\
+[    7.1] NUCLEUS_WORKLOAD_ENV: NUCLEUS_TOOL_PROXY_URL\n\
+[    7.1] NUCLEUS_WORKLOAD_ENV: NUCLEUS_TOOL_PROXY_AUTH_SECRET\n\
+[    7.1] NUCLEUS_WORKLOAD_ENV: NUCLEUS_EGRESS_GITHUB_URL\n";
+
+    #[test]
+    fn green_inventory_is_licensed() {
+        let inv = parse_inventory(GREEN_LOG);
+        assert_eq!(inv.len(), 5);
+        assert!(inv.iter().any(|n| n == ANCHOR));
+        assert!(check_inventory(&inv).is_empty());
+    }
+
+    #[test]
+    fn the_internal_rung_is_licensed_not_merely_absent() {
+        // ProxyAuthSecret is Internal — deliverable to the workload BY THE
+        // ORACLE, not by fallthrough. If this ever flips, the green fixture
+        // above goes red for the right reason.
+        let v = check_inventory(&["NUCLEUS_TOOL_PROXY_AUTH_SECRET".into()]);
+        assert!(v.is_empty());
+    }
+
+    #[test]
+    fn a_leaked_identity_cert_is_refused_by_the_oracle() {
+        let log = format!("{GREEN_LOG}[    7.2] NUCLEUS_WORKLOAD_ENV: NUCLEUS_IDENTITY_CERT\n");
+        let inv = parse_inventory(&log);
+        let violations = check_inventory(&inv);
+        assert_eq!(violations.len(), 1);
+        assert!(violations[0].contains("NUCLEUS_IDENTITY_CERT"));
+        assert!(violations[0].contains("SvidCert"));
+    }
+
+    #[test]
+    fn a_leaked_task_token_is_refused_by_the_oracle() {
+        let violations = check_inventory(&["NUCLEUS_TASK_TOKEN".into()]);
+        assert_eq!(violations.len(), 1);
+    }
+
+    #[test]
+    fn a_novel_dlc_variable_is_refused_by_the_prefix_rule_not_a_list() {
+        // The probe's hand-enumerated list could not know this name; the
+        // classifier's prefix rule + the oracle refuse it anyway. This is the
+        // categorical-beats-remembered-attack case the harness exists for.
+        let violations = check_inventory(&["NUCLEUS_DLC_SOMETHING_NEW".into()]);
+        assert_eq!(violations.len(), 1);
+    }
+
+    #[test]
+    fn inventory_parse_ignores_corrupt_and_duplicate_lines() {
+        let log = "\
+noise NUCLEUS_WORKLOAD_ENV: GOOD_NAME\n\
+NUCLEUS_WORKLOAD_ENV: bad name with spaces\n\
+NUCLEUS_WORKLOAD_ENV: GOOD_NAME\n";
+        let inv = parse_inventory(log);
+        assert_eq!(inv, vec!["GOOD_NAME".to_string()]);
+    }
+}

--- a/crates/nucleus-ifc-kernel/src/env_classifier.rs
+++ b/crates/nucleus-ifc-kernel/src/env_classifier.rs
@@ -1,0 +1,46 @@
+//! The environment-name → material-kind classifier — the trusted map FM-5's
+//! completeness argument rests on, colocated with the extracted oracle it feeds.
+//!
+//! Moved here from `nucleus-tool-proxy/src/workload.rs` (which re-exports it, so
+//! the launch builder's behaviour is unchanged) for two reasons:
+//!
+//! 1. **One roof.** `ident_may_deliver` (extracted, proven) decides delivery for
+//!    a `MaterialKind`; this classifier decides which `MaterialKind` an env name
+//!    IS. Splitting them across crates left the classifier in the spawn crate
+//!    while its meaning lived here. The pair is the whole judgment.
+//! 2. **The conformance harness.** The boot gate's delivery-conformance step
+//!    (`nucleus-delivery-conformance`) replays the in-guest probe's observed
+//!    environment inventory through classifier + oracle. It must use THIS
+//!    function — a restated table would be a second copy that drifts.
+//!
+//! This module is NOT part of the Aeneas-translated slice set (string matching
+//! is opaque to Aeneas — the `_ => OrdinaryData` fallthrough is the known,
+//! fundamental residual; see the FM-5 row in `docs/production-delta.md`). It
+//! lives beside `extracted/`, not inside it.
+
+use crate::extracted::identity::MaterialKind;
+
+/// Classify an environment variable name as the identity material it carries.
+///
+/// The `_ => OrdinaryData` fallthrough is the one place a NEW secret hides: a
+/// `NUCLEUS_*` variable added to the overlay without a case here would be
+/// classified public and admitted. The corpus test in
+/// `nucleus-tool-proxy/src/workload.rs` enumerates the `NUCLEUS_*` namespace
+/// against an independently-written oracle to catch exactly that.
+pub fn env_key_material(key: &str) -> MaterialKind {
+    match key {
+        "NUCLEUS_IDENTITY_CERT" => MaterialKind::SvidCert,
+        "NUCLEUS_TASK_TOKEN" | "NUCLEUS_TASK_TOKEN_NONCE" | "NUCLEUS_TASK_TOKEN_ISSUER" => {
+            MaterialKind::TaskToken
+        }
+        "NUCLEUS_TOOL_PROXY_BROKER_SECRET" | "NUCLEUS_TOOL_PROXY_BROKER_PORT" => {
+            MaterialKind::BrokerSecret
+        }
+        "NUCLEUS_TOOL_PROXY_APPROVAL_SECRET" => MaterialKind::ApprovalSecret,
+        "NUCLEUS_SANDBOX_TOKEN" => MaterialKind::SandboxToken,
+        "NUCLEUS_TOOL_PROXY_AUTH_SECRET" => MaterialKind::ProxyAuthSecret,
+        k if k.starts_with("NUCLEUS_DLC_") => MaterialKind::DlcCredentials,
+        k if k.starts_with("NUCLEUS_EGRESS_") => MaterialKind::EgressEnv,
+        _ => MaterialKind::OrdinaryData,
+    }
+}

--- a/crates/nucleus-ifc-kernel/src/lib.rs
+++ b/crates/nucleus-ifc-kernel/src/lib.rs
@@ -57,6 +57,7 @@ pub use hash_types::ContentHash;
 
 pub mod discharge;
 pub mod effect;
+pub mod env_classifier;
 pub mod extracted;
 pub mod flow;
 pub mod ifc_api;

--- a/crates/nucleus-ifc-kernel/tests/kernel_boundary_ratchet.rs
+++ b/crates/nucleus-ifc-kernel/tests/kernel_boundary_ratchet.rs
@@ -45,6 +45,7 @@ const KERNEL_FILES: &[&str] = &[
     "src/effect.rs",
     "src/storage_lane.rs",
     "src/discharge.rs",
+    "src/env_classifier.rs",
     "src/extracted/mod.rs",
     "src/extracted/ifc_integrity.rs",
     "src/extracted/ifc_confidentiality.rs",
@@ -65,6 +66,7 @@ const KERNEL_MODULES: &[&str] = &[
     "effect",
     "storage_lane",
     "discharge",
+    "env_classifier",
     "extracted",
 ];
 

--- a/crates/nucleus-tool-proxy/src/workload.rs
+++ b/crates/nucleus-tool-proxy/src/workload.rs
@@ -44,23 +44,7 @@ use nucleus_spec::WorkloadSpec;
 /// classified public and admitted. The corpus test exists to catch exactly
 /// that, which is why it enumerates the `NUCLEUS_*` namespace rather than a
 /// sample.
-pub(crate) fn env_key_material(key: &str) -> MaterialKind {
-    match key {
-        "NUCLEUS_IDENTITY_CERT" => MaterialKind::SvidCert,
-        "NUCLEUS_TASK_TOKEN" | "NUCLEUS_TASK_TOKEN_NONCE" | "NUCLEUS_TASK_TOKEN_ISSUER" => {
-            MaterialKind::TaskToken
-        }
-        "NUCLEUS_TOOL_PROXY_BROKER_SECRET" | "NUCLEUS_TOOL_PROXY_BROKER_PORT" => {
-            MaterialKind::BrokerSecret
-        }
-        "NUCLEUS_TOOL_PROXY_APPROVAL_SECRET" => MaterialKind::ApprovalSecret,
-        "NUCLEUS_SANDBOX_TOKEN" => MaterialKind::SandboxToken,
-        "NUCLEUS_TOOL_PROXY_AUTH_SECRET" => MaterialKind::ProxyAuthSecret,
-        k if k.starts_with("NUCLEUS_DLC_") => MaterialKind::DlcCredentials,
-        k if k.starts_with("NUCLEUS_EGRESS_") => MaterialKind::EgressEnv,
-        _ => MaterialKind::OrdinaryData,
-    }
-}
+pub(crate) use nucleus_ifc_kernel::env_classifier::env_key_material;
 
 /// Where an admitted env entry came from — kept in the launch receipt so an
 /// auditor can see not just what crossed but why it was allowed to.

--- a/crates/nucleus-workload-probe/src/main.rs
+++ b/crates/nucleus-workload-probe/src/main.rs
@@ -86,6 +86,16 @@ fn check_environment(fails: &mut Vec<String>) {
         keys.insert(key);
     }
 
+    // Inventory for the boot gate's conformance step: every observed NAME (never
+    // a value) on stderr, which the proxy drains into the guest log where
+    // `nucleus-delivery-conformance` replays it through the production
+    // classifier and the extracted `ident_may_deliver` oracle — the categorical
+    // check behind the fixed list below. Emitted before the checks so even a
+    // FAIL run ships its evidence.
+    for key in &keys {
+        eprintln!("NUCLEUS_WORKLOAD_ENV: {key}");
+    }
+
     for var in IDENTITY_VARS {
         if keys.contains(*var) {
             fails.push(format!(


### PR DESCRIPTION
## What

The in-guest probe now emits its observed environment inventory (`NUCLEUS_WORKLOAD_ENV: <name>`, names only), and a new boot-gate step — `nucleus-delivery-conformance` — replays every observed name through the **production classifier** (`env_key_material`, moved to `nucleus-ifc-kernel` beside the oracle it feeds; tool-proxy re-exports it unchanged) and the **extracted oracle** (`ident_may_deliver(_, Workload)`).

## Why

The probe's identity-variable list is a hand-enumerated sample; a novel secret name nobody listed would pass it. The oracle is categorical: a leaked variable is refused by *classification*, not by membership in a list someone remembered to extend. This is the trace-conformance leg of the reference-execution-semantics program: every real boot's observed workload surface is validated as a behaviour the proven delivery relation licenses.

## Fail-closed

Empty inventory or missing `NUCLEUS_TOOL_PROXY_URL` anchor ⇒ red. Absence of evidence is not conformance.

## Verified

- `cargo test -p nucleus-delivery-conformance`: 6/6 (green fixture; Internal rung licensed *by the oracle*; leaked cert/token refused; novel `NUCLEUS_DLC_*` refused by prefix rule; corrupt-line handling)
- Linux (OrbStack): tool-proxy + probe + conformance compile; 13/13 `workload::tests` incl. the classifier-vs-independent-oracle corpus test through the re-export
- rustfmt clean
- This PR's own `boot-a-real-pod` run exercises inventory → drain → conformance end to end (the rootfs is built from the tree)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UA8kchV3eadjGv6BmJXfqm