### PR TITLE
Gate the premise the declassify sink-scope deferral rests on

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,24 @@ jobs:
         shell: bash
         run: scripts/check-lean-libs-built.sh
 
+  # The sink-scope restriction on declassification tokens is signed, proven and
+  # documented — and NOT enforced (apply_token raises the node's label globally,
+  # so a token scoped to one sink clears its node for every sink). Hardening it
+  # is real surgery on the live IFC path, and it was deferred because the signed
+  # -token path is DORMANT: every caller is test code, so the over-grant is
+  # unreachable. This gate checks that premise, which is otherwise recorded only
+  # in prose — the day a production caller lands, the deferral stops being safe
+  # and CI must say so instead of the hole opening quietly.
+  declassify-token-dormant:
+    name: The unenforced declassify sink-scope stays unreachable
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+      - name: No production caller mints or applies a declassification token
+        shell: bash
+        run: scripts/check-declassify-token-dormant.sh
+
   # Every gate above is a claim that something is checked. This checks the claim.
   #
   # It needs full history and a clean tree because it PERTURBS real files and

--- a/crates/portcullis-core/src/declassify.rs
+++ b/crates/portcullis-core/src/declassify.rs
@@ -126,9 +126,33 @@ impl DeclassificationRule {
 ///
 /// - **Artifact-scoped**: Only applies to `target_node_id`, not the whole session
 /// - **Time-bounded**: Expires at `valid_until` (unix timestamp)
-/// - **Sink-restricted**: Declassified data may only reach `allowed_sinks`
+/// - **Sink-restricted (DECLARED, NOT ENFORCED — see below)**: the token names
+///   the sinks the declassified data may reach in `allowed_sinks`
 /// - **Signed**: Ed25519 signature over the token's canonical bytes
 /// - **Auditable**: Justification string included for receipt chain
+///
+/// # The sink restriction is not enforced on the live path
+///
+/// `allowed_sinks` is signed (it is count-prefixed into [`Self::canonical_bytes`]
+/// under the `nucleus-declass-v2` domain tag), proven in Lean
+/// (`DeclassifyProofs.lean`, `sink_outside_allowlist_denied`), and queryable via
+/// [`Self::allows_sink`] — but **nothing consults it when a token is applied**.
+/// `FlowGraph::apply_token` raises the target node's label GLOBALLY via
+/// `modify_label`, so a token scoped `allowed_sinks = [WebSearch]` in fact clears
+/// its node for `GitPush` as well. `allows_sink` has no non-test callers.
+///
+/// This is currently unreachable rather than exploitable: the signed-token path
+/// is dormant — every `DeclassificationToken::new` and every `apply_token` call
+/// site in the tree is test code — and `scripts/check-declassify-token-dormant.sh`
+/// fails CI if that stops being true, because the deferral is only safe while it
+/// is. Enforcing the scope means making `gather_labels` operation-aware (a
+/// declassified parent contributes its raised label only for operations in the
+/// token's scope, else its pre-declassify label), which needs a per-node
+/// declassify-scope and original-label field.
+///
+/// The bullet above says DECLARED rather than restricted for that reason: this
+/// doc comment previously read "Declassified data may only reach `allowed_sinks`",
+/// which is a claim the code does not keep.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DeclassificationToken {
     /// The flow graph node this token applies to.

--- a/scripts/check-declassify-token-dormant.sh
+++ b/scripts/check-declassify-token-dormant.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# Declassify-token DORMANCY gate — the premise of a deferral, mechanized.
+#
+# WHY THIS EXISTS
+#
+# `DeclassificationToken::allowed_sinks` restricts which sinks declassified data
+# may reach. It is signed (`canonical_bytes` count-prefixes it under the
+# `nucleus-declass-v2` domain tag), proven (`DeclassifyProofs.lean`
+# `sink_outside_allowlist_denied`), and documented — and it is **not enforced on
+# the live path**. `FlowGraph::apply_token` raises the target node's label
+# GLOBALLY via `modify_label`; `allows_sink()` has no non-test callers. A token
+# scoped `allowed_sinks=[WebSearch]` therefore clears its node for GitPush too.
+#
+# Hardening that properly means operation-aware `gather_labels` (a declassified
+# parent contributes its raised label only when the operation is in scope, else
+# its original pre-declassify label) plus a per-node scope/original-label field.
+# That is real surgery on the live IFC path.
+#
+# It was DEFERRED, on evidence: the signed-token path is **dormant**. Every
+# `DeclassificationToken::new` and every `apply_token` / `apply_declassification_token`
+# caller is under `#[cfg(test)]`. Nothing in production mints or applies one, so
+# the over-grant is unreachable and the risk budget was better spent elsewhere.
+#
+# THE PROBLEM WITH THAT: the deferral rests on a premise nobody checks. The day
+# someone wires a production caller — a perfectly reasonable thing to do, since
+# the API is public and looks finished — the dormant over-grant silently becomes
+# a live cross-scope exfiltration path, and the person doing the wiring has no
+# reason to know. A deferral whose premise is only recorded in a memory is not a
+# control. This gate makes the premise falsifiable: if the path stops being
+# dormant, CI says so and points at what must be built first.
+#
+# So this gate does NOT assert the sink restriction is enforced (it is not). It
+# asserts the ONLY reason it is currently safe not to be.
+#
+# Usage: scripts/check-declassify-token-dormant.sh
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel 2>/dev/null || echo .)"
+
+# The API's own definition sites (where the type and its appliers LIVE) are not
+# callers. Everything else that names these symbols must be test code.
+DEFINING_FILES=(
+  "crates/portcullis-core/src/declassify.rs"          # the type + allows_sink
+  "crates/portcullis/src/flow_graph.rs"               # apply_token / apply_token_verified
+  "crates/portcullis/src/kernel/declassify_authority.rs" # kernel apply + one-shot ledger
+)
+
+# Symbols whose appearance OUTSIDE the defining files means a caller exists.
+PATTERN='DeclassificationToken::new|apply_declassification_token|\.apply_token(_verified)?\('
+
+fail=0
+found_any=0
+
+# Strip `#[cfg(test)]` modules and `mod tests` blocks, then look for callers.
+# A python stripper rather than grep -v: a caller inside a test module is fine,
+# and only a structural strip can tell the difference reliably.
+report=$(python3 - "$PATTERN" "${DEFINING_FILES[@]}" <<'PY'
+import re, subprocess, sys, os
+
+pattern = re.compile(sys.argv[1])
+defining = set(sys.argv[2:])
+
+files = subprocess.run(
+    ["git", "ls-files", "crates/*.rs", "*.rs"],
+    capture_output=True, text=True, check=True,
+).stdout.split()
+
+def strip_test_code(src: str) -> str:
+    """Blank out #[cfg(test)] items and any `mod tests` body, brace-matched."""
+    out = []
+    i = 0
+    n = len(src)
+    while i < n:
+        m = re.compile(r'#\[cfg\(test\)\]|(?:pub\s+)?mod\s+tests\b').search(src, i)
+        if not m:
+            out.append(src[i:])
+            break
+        out.append(src[i:m.start()])
+        # Walk to the first '{' after the marker, then brace-match to its close.
+        j = src.find('{', m.start())
+        if j == -1:
+            # e.g. `#[cfg(test)] mod tests;` — a declaration, nothing to strip.
+            eol = src.find('\n', m.start())
+            i = n if eol == -1 else eol
+            continue
+        depth = 0
+        k = j
+        while k < n:
+            if src[k] == '{':
+                depth += 1
+            elif src[k] == '}':
+                depth -= 1
+                if depth == 0:
+                    break
+            k += 1
+        i = k + 1
+    return ''.join(out)
+
+hits = []
+for f in files:
+    if not f.endswith('.rs') or f in defining:
+        continue
+    # Test code by LOCATION: integration-test dirs, and the repo idiom of a
+    # `#[cfg(test)] #[path = "foo_tests.rs"] mod tests;` sidecar file (the file
+    # itself carries no cfg attribute — its INCLUSION is what is gated — so a
+    # within-file strip cannot see it).
+    if '/tests/' in f or f.startswith('tests/') or f.endswith('_tests.rs'):
+        continue
+    try:
+        src = open(f, errors='replace').read()
+    except OSError:
+        continue
+    if not pattern.search(src):
+        continue
+    stripped = strip_test_code(src)
+    # Strip string literals across the WHOLE file, not per line: these symbols
+    # are NAMED inside multi-line error messages ("… — use
+    # apply_declassification_token() (fail-closed)"), where the opening quote is
+    # on an earlier line, so a per-line strip cannot see that it is in a string.
+    # A mention is not a call.
+    stripped = re.sub(r'"(?:[^"\\]|\\.)*"', '""', stripped, flags=re.S)
+    for line in stripped.split('\n'):
+        s = line.strip()
+        if s.startswith('//') or s.startswith('*'):
+            continue
+        if pattern.search(line):
+            hits.append(f"{f}: {s[:100]}")
+
+for h in hits:
+    print(h)
+raise SystemExit(1 if hits else 0)
+PY
+) && dormant=0 || dormant=$?
+
+if [ "$dormant" -eq 0 ]; then
+  echo "ok  declassify-token path is DORMANT — no production caller mints or applies a token."
+  echo "    The unenforced allowed_sinks restriction is therefore unreachable, which is the"
+  echo "    premise the deferral rests on. Premise still true."
+else
+  echo "FAIL a PRODUCTION caller of the declassification-token path now exists:"
+  echo "$report" | sed 's/^/       /'
+  echo ""
+  echo "    This gate is not objecting to the caller. It is telling you that the caller"
+  echo "    activates a KNOWN, UNENFORCED over-grant: allowed_sinks is signed, proven and"
+  echo "    documented, but FlowGraph::apply_token raises the target node's label GLOBALLY"
+  echo "    (modify_label), so a token scoped to one sink clears its node for EVERY sink."
+  echo "    allows_sink() has no non-test callers."
+  echo ""
+  echo "    Before shipping a production path, enforce the scope: make gather_labels"
+  echo "    operation-aware (a declassified parent contributes its raised label only when"
+  echo "    the operation is in the token's allowed_sinks, else its pre-declassify label),"
+  echo "    which needs a per-node declassify-scope + original-label field. Then delete"
+  echo "    this gate in the same change — its whole job is to stop exactly this from"
+  echo "    landing silently."
+  fail=1
+fi
+
+exit $fail

--- a/scripts/check-gates-can-fail.sh
+++ b/scripts/check-gates-can-fail.sh
@@ -230,6 +230,31 @@ perturb_trusted_base() {
 echo "Probing whether each gate fails on its own subject..."
 echo
 
+# A PRODUCTION caller of the dormant declassification-token path — the exact
+# event the dormancy gate exists to catch. Deliberately a plain `pub fn` on the
+# kernel (no #[cfg(test)]), because a caller inside test code is FINE and must
+# not trip the gate; only a real one may.
+perturb_declassify_production_caller() {
+    local f="$1"
+    python3 - "$f" <<'EOF'
+import sys
+p = sys.argv[1]
+s = open(p).read()
+anchor = "    /// Set the Ed25519 signing key for receipt signing."
+probe = """    #[cfg(feature = "crypto")]
+    pub fn gate_probe_production_caller(
+        &mut self,
+        token: &portcullis_core::declassify::DeclassificationToken,
+    ) -> Result<portcullis_core::declassify::TokenApplyResult, DenyReason> {
+        self.apply_declassification_token(token)
+    }
+
+"""
+assert anchor in s, "anchor for the declassify production-caller probe moved"
+open(p, "w").write(s.replace(anchor, probe + anchor, 1))
+EOF
+}
+
 probe check-line-ratchet.sh   "--strict" crates/portcullis/src/kernel.rs \
       "400 lines past the ceiling"            perturb_line_ratchet
 probe check-mediation.sh      "" crates/nucleus-tool-proxy/src/egress.rs \
@@ -248,6 +273,9 @@ probe check-test-helpers-not-in-production.sh "" crates/nucleus-tool-proxy/Cargo
       "test-helpers enabled on a non-dev edge"  perturb_test_helpers_in_prod
 probe check-lean-libs-built.sh "" crates/portcullis-core/lean/lakefile.lean \
       "a lean_lib nothing builds"               perturb_lean_lib_unbuilt
+probe check-declassify-token-dormant.sh "" crates/portcullis/src/kernel.rs \
+      "a production caller of the dormant declassify-token path" \
+      perturb_declassify_production_caller
 
 # ── Uncovered, listed rather than omitted ─────────────────────────────────
 #


### PR DESCRIPTION
## The situation

`DeclassificationToken::allowed_sinks` restricts which sinks declassified data may reach. It is **signed** (count-prefixed into `canonical_bytes` under the `nucleus-declass-v2` tag), **proven** in Lean (`sink_outside_allowlist_denied`), **documented**, and has an `allows_sink()` method — and **nothing consults it**. `FlowGraph::apply_token` raises the target node's label *globally* via `modify_label`, so a token scoped `[WebSearch]` clears its node for `GitPush` too.

Enforcing it properly means operation-aware `gather_labels` plus a per-node declassify-scope and original-label field — real surgery on the live IFC path. That was deferred, **correctly**, on evidence: the signed-token path is *dormant*, every caller being test code, so the over-grant is unreachable.

## What this PR changes

The deferral's premise was recorded only in prose. Whoever next wires a production caller — reasonable, the API is public and looks finished — silently converts a dormant over-grant into a live cross-scope exfiltration path, with no reason to know.

This makes the premise **falsifiable**: CI fails the moment a non-test caller mints or applies a token, and the failure message explains what must be built first and says to delete the gate in that same change.

It does **not** claim the sink restriction is enforced. It asserts the only reason it is currently safe not to be.

Plus the doc-honesty fix pending since the MEET audit: the "Sink-restricted: Declassified data may only reach `allowed_sinks`" bullet stated a property the code does not keep. It now reads DECLARED, NOT ENFORCED, with the mechanism and the enforcement design written out.

## Verification

- Perturbation-verified **through the meta-gate**: a plain non-test method on the kernel calling `apply_declassification_token` REDs the gate naming the exact line; restored, GREEN.
- Registered in `check-gates-can-fail.sh` (13 gates found, 10 probed, 2 listed uncovered, 0 unaccounted) and wired into `ci.yml`, so the gate is itself probed and its CI invocation is checked.
- Two false positives found and fixed while building it: a `cfg(test)` `#[path]` sidecar module (its *inclusion* is gated, so a within-file strip can't see it), and these symbols named inside multi-line error strings (a per-line literal strip can't see a quote opened on an earlier line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UA8kchV3eadjGv6BmJXfqm