### PR TITLE
aeneas.yml: correct the drift diagnosis — "never refreshed" was wrong, and dangerously so

### DIFF
--- a/.github/workflows/aeneas.yml
+++ b/.github/workflows/aeneas.yml
@@ -138,13 +138,24 @@ jobs:
       #     partial translation, and under the old condition those two outcomes
       #     were indistinguishable.
       #
-      #   * emitted files that DIFFER from the committed copies -> WARN, not fail,
-      #     and the reason is specific rather than a shrug. The committed
-      #     `generated/` tree is a KNOWN-STALE legacy artifact: `Types.lean` is 42
-      #     lines against ~838 from a fresh extraction, because the IFC source moved
-      #     to `crates/nucleus-ifc-kernel` (MVK M3) and this whole-crate lib was
-      #     never refreshed. Failing on that drift would be red for a pre-existing
-      #     reason this step cannot fix, so it is surfaced loudly and tracked.
+      #   * emitted files that DIFFER from the committed copies -> WARN, not fail.
+      #     The reason is specific, and it is NOT "nobody refreshed it" — that was
+      #     the first diagnosis and it was WRONG in a way that invites damage. The
+      #     committed `generated/Types.lean` (42 lines) and a fresh extraction
+      #     (~838) are not comparable artifacts:
+      #       - the committed file declares `inductive CapabilityLevel`; a fresh
+      #         extraction declares `inductive capability_level.CapabilityLevel`.
+      #         Aeneas emits MODULE-QUALIFIED names now that the IFC source moved to
+      #         `crates/nucleus-ifc-kernel` and was split into modules.
+      #       - the committed file is a deliberate CURATED SUBSET (two types); a
+      #         fresh extraction covers the whole crate, `core::*` trait shims and all.
+      #     So "just regenerate it" would RENAME the types out from under
+      #     `PortcullisCoreBridge` and `CompartmentProofs` — both import the bare
+      #     names, and PortcullisCoreBridge is in the proven-tier build list in
+      #     `portcullis-core-proven-lean.yml`. Retiring the lib is equally
+      #     unavailable, for the same reason: those proofs depend on it.
+      #     Hardening this limb to FAIL therefore needs a MIGRATION (requalify the
+      #     dependents, then re-curate or adopt the full extraction) — not a refresh.
       #     THE LOAD-BEARING FRESHNESS CHECK IS ELSEWHERE and is not advisory:
       #     `aeneas-ifc-scoped.yml` (and siblings) re-extract the slices the
       #     flagship theorems are proven over, hard-fail if Aeneas emits nothing,


### PR DESCRIPTION
## Why

The comment I landed in #2190 called the committed `generated/` lib known-stale and said it was never refreshed after the IFC source moved crates. Investigating the actual fix showed that reading is wrong — and wrong in the direction that gets someone hurt: it invites "just regenerate it", which would break proven-tier theorems.

## What's actually true

`generated/Types.lean` (42 lines) and a fresh extraction (~838) are **not comparable artifacts**:

- The committed file declares `inductive CapabilityLevel`; a fresh extraction declares `inductive capability_level.CapabilityLevel`. Aeneas emits **module-qualified** names now that the source lives in `crates/nucleus-ifc-kernel` and is split into modules. The types aren't missing — they're renamed.
- The committed file is a deliberate **curated subset** (two types); a fresh extraction covers the whole crate, `core::*` trait shims and all.

So regenerating in place would requalify `CapabilityLevel` out from under `PortcullisCoreBridge` and `CompartmentProofs`, which import the bare name — and `PortcullisCoreBridge` is in the proven-tier build list. **Retiring the lib is equally unavailable**: the same proofs depend on it.

## Result

The limb stays a WARN, now for the right reason, and the comment names the real work: a migration (requalify the dependents, then re-curate or adopt the full extraction), after which it can harden to FAIL.

Documentation only — no behaviour change.

## Provenance

Found because the step revived in #2190 ran for the first time and printed `MISMATCH: Types.lean`. A gate that had been inert immediately surfaced a migration hazard nobody was tracking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UA8kchV3eadjGv6BmJXfqm