### PR TITLE
Machine v2's oracle mirrors had no faithfulness theorem — prove all five

### DIFF
--- a/.github/workflows/portcullis-core-proven-lean.yml
+++ b/.github/workflows/portcullis-core-proven-lean.yml
@@ -108,7 +108,8 @@ jobs:
             PodMachineSpike \
             IdentityOracleMirror \
             ConfidentialityOracleMirror \
-            IntegrityOracleMirror
+            IntegrityOracleMirror \
+            ChannelOracleMirror
           # CapabilityResiduatedQuantaleProofs: the residuation adjunction
           # (a⊗b≤c ⟺ b≤a⊸c) for capability, proven over the Aeneas-extracted
           # capability_quantale slice — the enriching value V of the

--- a/.github/workflows/portcullis-core-proven-lean.yml
+++ b/.github/workflows/portcullis-core-proven-lean.yml
@@ -107,7 +107,8 @@ jobs:
             UniversalDetection \
             PodMachineSpike \
             IdentityOracleMirror \
-            ConfidentialityOracleMirror
+            ConfidentialityOracleMirror \
+            IntegrityOracleMirror
           # CapabilityResiduatedQuantaleProofs: the residuation adjunction
           # (a⊗b≤c ⟺ b≤a⊸c) for capability, proven over the Aeneas-extracted
           # capability_quantale slice — the enriching value V of the

--- a/.github/workflows/portcullis-core-proven-lean.yml
+++ b/.github/workflows/portcullis-core-proven-lean.yml
@@ -106,7 +106,8 @@ jobs:
             AssuranceCoverage \
             UniversalDetection \
             PodMachineSpike \
-            IdentityOracleMirror
+            IdentityOracleMirror \
+            ConfidentialityOracleMirror
           # CapabilityResiduatedQuantaleProofs: the residuation adjunction
           # (a⊗b≤c ⟺ b≤a⊸c) for capability, proven over the Aeneas-extracted
           # capability_quantale slice — the enriching value V of the

--- a/crates/portcullis-core/lean/ChannelOracleMirror.lean
+++ b/crates/portcullis-core/lean/ChannelOracleMirror.lean
@@ -1,0 +1,107 @@
+/-
+  The CHANNEL-ADMISSION oracle, mirrored in plain Lean — Machine v3, gate 2.
+
+  # What this adds to the machine
+
+  v3-1 widened the machine's LABEL (a second, dual axis). This widens the
+  DECISION: delivery stops being a one-argument table lookup on the material and
+  becomes a three-argument judgement over `(channel, material, principal)`. The
+  shipped oracle:
+
+      Env              -> ident_may_deliver m p        (the one channel carrying values)
+      Argv, Cwd        -> is_public m ∧ ident_may_deliver m p   (strictly narrower)
+      Stdio, ExtraFd, Uid -> false                     (material-CLOSED, always)
+
+  Three of the six channels carry nothing at all, by construction rather than by
+  policy — `ExtraFd` because `close_range` shuts every inherited descriptor before
+  exec, `Uid` because a uid is not a value. That is a different shape from the
+  tables mirrored so far: a whole dimension proved empty, not merely restricted.
+
+  As with the confidentiality and integrity mirrors, these are plain Lean (no
+  Aeneas monad, no Mathlib) so they port to the iris substrate, each carries a
+  faithfulness theorem against the shipped extraction, and the copies living in
+  `capability-primitive/iris` are checked separately by that repo's Gate 4c.
+-/
+
+import PortcullisCoreChannel.Types
+import PortcullisCoreChannel.Funs
+
+open Aeneas Aeneas.Std Result
+
+namespace ChannelOracleMirror
+
+open nucleus_ifc_kernel
+
+abbrev Chan := extracted.channel.ChannelKind
+abbrev Material := extracted.identity.MaterialKind
+abbrev Principal := extracted.identity.Principal
+
+/-- Plain-Lean mirror of `is_public` — the material's label is the bottom. -/
+def mirrorIsPublic (m : Material) : Bool :=
+  match m with
+  | .TrustBundle | .EgressEnv | .OrdinaryData => true
+  | _ => false
+
+/-- **Faithfulness of the public predicate.** -/
+theorem is_public_faithful (m : Material) :
+    ok (mirrorIsPublic m) = extracted.channel.is_public m := by
+  cases m <;> rfl
+
+/-- Plain-Lean mirror of the v1/v2 delivery decision, restated here so this file
+    stands alone (it agrees with `ConfidentialityOracleMirror.mirrorMayDeliver`
+    by construction — both are the extracted `ident_may_deliver`). -/
+def mirrorMayDeliver (m : Material) (p : Principal) : Bool :=
+  match p with
+  | .Host | .GuestRuntime => true
+  | .Workload =>
+    match m with
+    | .TrustBundle | .ProxyAuthSecret | .EgressEnv | .OrdinaryData => true
+    | _ => false
+
+/-- Plain-Lean mirror of `channel_admits`. -/
+def mirrorChannelAdmits (c : Chan) (m : Material) (p : Principal) : Bool :=
+  match c with
+  | .Env => mirrorMayDeliver m p
+  | .Argv | .Cwd => mirrorIsPublic m && mirrorMayDeliver m p
+  | .Stdio | .ExtraFd | .Uid => false
+
+/-- **Faithfulness of channel admission**, over the full 6 × 11 × 3 product —
+    198 cases, all checked by the kernel. -/
+theorem channel_admits_faithful (c : Chan) (m : Material) (p : Principal) :
+    ok (mirrorChannelAdmits c m p) = extracted.channel.channel_admits c m p := by
+  cases c <;> cases m <;> cases p <;> rfl
+
+/-! ## The two structural facts the v3 machine needs -/
+
+/-- **No channel delivers Secret material to the workload.** The machine-level
+    analogue of `ChannelAdmissionExtracted.no_channel_delivers_secret_to_the_workload`,
+    stated over the portable mirror so the pod machine can carry it across the
+    toolchain boundary. Quantified over the channel enum, so a NEW channel forces
+    a match arm and cannot silently carry a secret. -/
+theorem no_channel_delivers_secret (c : Chan) (m : Material)
+    (hsec : mirrorIsPublic m = false) (hnodeliver : mirrorMayDeliver m .Workload = false) :
+    mirrorChannelAdmits c m .Workload = false := by
+  cases c <;> simp [mirrorChannelAdmits, hsec, hnodeliver]
+
+/-- **Three channels are material-CLOSED** — they admit nothing, for any material
+    and any principal. Not "restricted": empty. `ExtraFd` is closed because
+    `close_range` shuts every inherited descriptor before exec; `Uid` because a
+    uid is not a value; `Stdio` because the dispositions are null/pipe. -/
+theorem fd_stdio_uid_carry_nothing (m : Material) (p : Principal) :
+    mirrorChannelAdmits .Stdio m p = false
+  ∧ mirrorChannelAdmits .ExtraFd m p = false
+  ∧ mirrorChannelAdmits .Uid m p = false := by
+  refine ⟨rfl, rfl, rfl⟩
+
+/-- **Argv/Cwd are STRICTLY narrower than Env** — anti-vacuity for the channel
+    dimension. If every channel admitted the same set, indexing the decision by
+    channel would be decoration. `ProxyAuthSecret` is the witness: the workload's
+    own credential crosses in the environment (it must — the workload
+    authenticates with it) and is refused on the command line, where it would be
+    world-readable in the process table. -/
+theorem argv_is_strictly_narrower_than_env :
+    mirrorChannelAdmits .Env .ProxyAuthSecret .Workload = true
+  ∧ mirrorChannelAdmits .Argv .ProxyAuthSecret .Workload = false := by
+  constructor <;> rfl
+
+end ChannelOracleMirror

--- a/crates/portcullis-core/lean/ConfidentialityOracleMirror.lean
+++ b/crates/portcullis-core/lean/ConfidentialityOracleMirror.lean
@@ -1,0 +1,132 @@
+/-
+  The CONFIDENTIALITY oracles, mirrored in plain Lean — the v2 half of the
+  toolchain bridge for the reference pod-execution semantics.
+
+  # Why this file exists
+
+  `IdentityOracleMirror` did this for ONE oracle: the machine's v1 guard
+  (`identity_reaches_workload`). Machine v2 grew a floating label, and its
+  mirrors — the confidentiality lattice, its rank, its join, its flows-to, the
+  material label table, and the principal ceiling — were transcribed into the
+  iris tree with NOTHING proving they match the shipped extraction. A single
+  wrong entry in `matLabel` would have made the v2 noninterference theorem a true
+  statement about the wrong system, and no gate would have noticed.
+
+  This file closes that. Each mirror below is plain Lean (no Aeneas monad, no
+  Mathlib) so it is portable to the iris v4.32 substrate, and each carries a
+  faithfulness theorem against the Aeneas-extracted function that actually ships.
+  `cases … <;> rfl` forces agreement: a wrong entry fails to COMPILE.
+
+  What this does and does not buy. It anchors the mirror DEFINITIONS to the
+  extraction. It does not, by itself, guarantee that the copies living in
+  `capability-primitive/iris` are these definitions — that is a separate control
+  (`iris/gate_mirror_parity.py` over there), because a proof here cannot see a
+  file in another repository.
+-/
+
+import PortcullisCoreIdentity.Types
+import PortcullisCoreIdentity.Funs
+
+open Aeneas Aeneas.Std Result
+
+namespace ConfidentialityOracleMirror
+
+open nucleus_ifc_kernel
+
+abbrev Material := extracted.identity.MaterialKind
+abbrev Principal := extracted.identity.Principal
+abbrev Conf := extracted.ifc_confidentiality.ConfLevel
+
+/-! ## The lattice -/
+
+/-- Plain-Lean mirror of the extracted `ConfLevel` rank. The discriminants ARE
+    the confidentiality order (`Public 0 < Internal 1 < Secret 2`). -/
+def mirrorCrank : Conf → Nat
+  | .Public => 0
+  | .Internal => 1
+  | .Secret => 2
+
+/- No separate faithfulness theorem for the rank, deliberately. The extracted
+   `crank` returns an Aeneas `Std.U8` while a portable mirror must return `Nat`,
+   so stating their equality means threading a scalar conversion that adds TCB
+   without adding assurance. The rank is an internal helper, and its behaviour is
+   fully pinned by the two composites below: `cjoin_faithful` and `cflows_faithful`
+   are proved by exhaustive case analysis over ALL argument pairs, so a mirror
+   rank that disagreed with the extracted one anywhere it matters would make one
+   of them fail to compile. -/
+
+/-- Plain-Lean mirror of the extracted confidentiality JOIN (max by rank:
+    combining data raises confidentiality). -/
+def mirrorCjoin (a b : Conf) : Conf :=
+  if mirrorCrank a ≥ mirrorCrank b then a else b
+
+/-- **Faithfulness of the join.** -/
+theorem cjoin_faithful (a b : Conf) :
+    ok (mirrorCjoin a b) = extracted.ifc_confidentiality.cjoin a b := by
+  cases a <;> cases b <;> rfl
+
+/-- Plain-Lean mirror of the extracted flows-to (BLP no-read-up). -/
+def mirrorCflows (a ceiling : Conf) : Bool := mirrorCrank a ≤ mirrorCrank ceiling
+
+/-- **Faithfulness of flows-to.** -/
+theorem cflows_faithful (a ceiling : Conf) :
+    ok (mirrorCflows a ceiling) = extracted.ifc_confidentiality.cflows_to a ceiling := by
+  cases a <;> cases ceiling <;> rfl
+
+/-! ## The tables -/
+
+/-- Plain-Lean mirror of the extracted `mat_label`: identity material is Secret,
+    the workload's own proxy HMAC is Internal, verification material and ordinary
+    data are Public. THIS is the table a typo would have silently corrupted. -/
+def mirrorMatLabel : Material → Conf
+  | .SvidCert => .Secret
+  | .SvidPrivateKey => .Secret
+  | .TrustBundle => .Public
+  | .TaskToken => .Secret
+  | .BrokerSecret => .Secret
+  | .ApprovalSecret => .Secret
+  | .SandboxToken => .Secret
+  | .DlcCredentials => .Secret
+  | .ProxyAuthSecret => .Internal
+  | .EgressEnv => .Public
+  | .OrdinaryData => .Public
+
+/-- **Faithfulness of the material-label table.** Every one of the eleven
+    materials is checked against the shipped extraction. -/
+theorem mat_label_faithful (m : Material) :
+    ok (mirrorMatLabel m) = extracted.identity.mat_label m := by
+  cases m <;> rfl
+
+/-- Plain-Lean mirror of the extracted `principal_ceiling`. Host and GuestRuntime
+    hold the pod's identity by design; the workload's ceiling is Internal. -/
+def mirrorCeiling : Principal → Conf
+  | .Host => .Secret
+  | .GuestRuntime => .Secret
+  | .Workload => .Internal
+
+/-- **Faithfulness of the principal ceiling.** -/
+theorem ceiling_faithful (p : Principal) :
+    ok (mirrorCeiling p) = extracted.identity.principal_ceiling p := by
+  cases p <;> rfl
+
+/-! ## The delivery decision, as a composite -/
+
+/-- Plain-Lean mirror of `ident_may_deliver` — delivery IS the flow decision
+    against the principal's ceiling. -/
+def mirrorMayDeliver (m : Material) (p : Principal) : Bool :=
+  mirrorCflows (mirrorMatLabel m) (mirrorCeiling p)
+
+/-- **Faithfulness of the delivery decision**, over the full 11 × 3 product. -/
+theorem may_deliver_faithful (m : Material) (p : Principal) :
+    ok (mirrorMayDeliver m p) = extracted.identity.ident_may_deliver m p := by
+  cases m <;> cases p <;> rfl
+
+/-- **The v1 guard is the v2 oracle at the workload's ceiling.** The pod machine's
+    `reachesWorkload` and the floating-label machine's flow check are the SAME
+    decision — stated here against the extraction rather than asserted in a
+    docstring, which is where it lived before. -/
+theorem reaches_is_a_flow_faithful (m : Material) :
+    ok (mirrorMayDeliver m .Workload) = extracted.identity.identity_reaches_workload m := by
+  cases m <;> rfl
+
+end ConfidentialityOracleMirror

--- a/crates/portcullis-core/lean/IntegrityOracleMirror.lean
+++ b/crates/portcullis-core/lean/IntegrityOracleMirror.lean
@@ -1,0 +1,103 @@
+/-
+  The INTEGRITY oracles, mirrored in plain Lean — the second axis of the
+  reference pod machine (Machine v3, gate 1).
+
+  # Why a second axis
+
+  Machine v1 and v2 are confidentiality-only: a floating `ConfLevel` that JOINS
+  (combining data raises secrecy) and a flows-to that is `≤` (no read up). The
+  shipped kernel has a second, ORTHOGONAL axis, and it runs the other way:
+
+      confidentiality   Public 0 < Internal 1 < Secret 2     join = max   flows: a ≤ ceiling
+      integrity     Adversarial 0 < Untrusted 1 < Trusted 2  meet = MIN   flows: a ≥ ceiling
+
+  Combining data LOWERS integrity (`imeet`) exactly as it RAISES confidentiality
+  (`cjoin`), and the two flows-to relations point in opposite directions. That
+  asymmetry is where a two-axis unwinding proof is most likely to break, and it
+  is the reason the v3 gate is worth running rather than assuming.
+
+  These mirrors are plain Lean (no Aeneas monad, no Mathlib) so they port to the
+  iris v4.32 substrate, and each carries a faithfulness theorem against the
+  extracted function that ships. As with the confidentiality mirrors, the copies
+  living in `capability-primitive/iris` are checked separately by that repo's
+  Gate 4c — a proof here cannot see a file in another repository.
+-/
+
+import PortcullisCoreIdentity.Types
+import PortcullisCoreIdentity.Funs
+
+open Aeneas Aeneas.Std Result
+
+namespace IntegrityOracleMirror
+
+open nucleus_ifc_kernel
+
+abbrev Integ := extracted.ifc_integrity.IntegLevel
+
+/-- Plain-Lean mirror of the extracted integrity rank. Adversarial is the BOTTOM
+    (least trusted); the discriminants are the trust order. -/
+def mirrorIrank : Integ → Nat
+  | .Adversarial => 0
+  | .Untrusted => 1
+  | .Trusted => 2
+
+/- As on the confidentiality side, no standalone faithfulness theorem for the
+   rank: the extracted `irank` returns an Aeneas `Std.U8` and a portable mirror
+   must return `Nat`, so equating them threads a scalar conversion that adds TCB
+   without adding assurance. The rank is pinned by the two composites below,
+   which are exhaustive over all argument pairs. -/
+
+/-- Plain-Lean mirror of the extracted integrity MEET. Combining data takes the
+    LEAST trusted input — the dual of the confidentiality join. -/
+def mirrorImeet (a b : Integ) : Integ :=
+  if mirrorIrank a ≤ mirrorIrank b then a else b
+
+/-- **Faithfulness of the integrity meet.** -/
+theorem imeet_faithful (a b : Integ) :
+    ok (mirrorImeet a b) = extracted.ifc_integrity.imeet a b := by
+  cases a <;> cases b <;> rfl
+
+/-- Plain-Lean mirror of the extracted integrity flows-to: data of integrity `a`
+    may reach a sink requiring `ceiling` iff it is AT LEAST as trusted. Note the
+    direction — `≥`, where confidentiality's is `≤`. -/
+def mirrorIflows (a ceiling : Integ) : Bool := mirrorIrank a ≥ mirrorIrank ceiling
+
+/-- **Faithfulness of integrity flows-to.** -/
+theorem iflows_faithful (a ceiling : Integ) :
+    ok (mirrorIflows a ceiling) = extracted.ifc_integrity.iflows_to a ceiling := by
+  cases a <;> cases ceiling <;> rfl
+
+/-- Plain-Lean mirror of the extracted per-operation integrity fold step, which
+    the extraction defines to be exactly `imeet`. -/
+def mirrorIrunStep (eff src : Integ) : Integ := mirrorImeet eff src
+
+/-- **Faithfulness of the fold step.** -/
+theorem irun_step_faithful (eff src : Integ) :
+    ok (mirrorIrunStep eff src) = extracted.ifc_integrity.irun_step eff src := by
+  cases eff <;> cases src <;> rfl
+
+/-! ## The structural fact the v3 machine needs
+
+The confidentiality unwinding rides on `cflows (cjoin a b) c = cflows a c && cflows b c`
+— the join decomposes below a ceiling. The integrity axis needs the DUAL, and it is
+not obvious that reversing both the order and the operation preserves it. It does,
+and here is why, proved rather than assumed: `min a b ≥ c` iff `a ≥ c` and `b ≥ c`. -/
+
+/-- **The meet decomposes above a floor** — the integrity analogue of
+    `cflows_cjoin_iff`, and the lemma a two-axis unwinding proof needs. -/
+theorem iflows_imeet_iff (a b c : Integ) :
+    mirrorIflows (mirrorImeet a b) c = (mirrorIflows a c && mirrorIflows b c) := by
+  cases a <;> cases b <;> cases c <;> rfl
+
+/-- **The two axes really do disagree.** Not decoration: this is the anti-vacuity
+    witness for the claim that integrity is a genuinely new dimension rather than
+    confidentiality renamed. If both axes agreed everywhere, the v3 machine would
+    be v2 with extra syntax. `Untrusted` data may reach an `Adversarial` sink
+    (downgrading trust is fine) but NOT a `Trusted` one — the opposite pattern to
+    confidentiality, where `Internal` may reach `Secret` but not `Public`. -/
+theorem axes_point_opposite_ways :
+    mirrorIflows .Untrusted .Adversarial = true
+  ∧ mirrorIflows .Untrusted .Trusted = false := by
+  constructor <;> rfl
+
+end IntegrityOracleMirror

--- a/crates/portcullis-core/lean/lakefile.lean
+++ b/crates/portcullis-core/lean/lakefile.lean
@@ -145,6 +145,13 @@ lean_lib «PodMachineSpike» where
 lean_lib «IdentityOracleMirror» where
   roots := #[`IdentityOracleMirror]
 
+-- The v2 half of the toolchain bridge: the confidentiality lattice, the material
+-- label table, and the principal ceiling, mirrored in plain Lean and PROVED equal
+-- to the shipped extraction. Machine v2's mirrors previously had no faithfulness
+-- theorem at all.
+lean_lib «ConfidentialityOracleMirror» where
+  roots := #[`ConfidentialityOracleMirror]
+
 -- Unwinding theorem instantiated over the real IFCLabel2 lattice (D1/M1b; Mathlib)
 lean_lib «UnwindingIFC» where
   roots := #[`UnwindingIFC]

--- a/crates/portcullis-core/lean/lakefile.lean
+++ b/crates/portcullis-core/lean/lakefile.lean
@@ -158,6 +158,12 @@ lean_lib «ConfidentialityOracleMirror» where
 lean_lib «IntegrityOracleMirror» where
   roots := #[`IntegrityOracleMirror]
 
+-- The CHANNEL dimension (Machine v3 gate 2): delivery becomes a three-argument
+-- judgement over (channel, material, principal), and three of the six channels
+-- are material-closed by construction rather than by policy.
+lean_lib «ChannelOracleMirror» where
+  roots := #[`ChannelOracleMirror]
+
 -- Unwinding theorem instantiated over the real IFCLabel2 lattice (D1/M1b; Mathlib)
 lean_lib «UnwindingIFC» where
   roots := #[`UnwindingIFC]

--- a/crates/portcullis-core/lean/lakefile.lean
+++ b/crates/portcullis-core/lean/lakefile.lean
@@ -152,6 +152,12 @@ lean_lib «IdentityOracleMirror» where
 lean_lib «ConfidentialityOracleMirror» where
   roots := #[`ConfidentialityOracleMirror]
 
+-- The INTEGRITY axis — the second, orthogonal dimension of the reference machine
+-- (Machine v3 gate 1). Integrity MEETS where confidentiality JOINS, and its
+-- flows-to points the other way; those mirrors need their own anchor.
+lean_lib «IntegrityOracleMirror» where
+  roots := #[`IntegrityOracleMirror]
+
 -- Unwinding theorem instantiated over the real IFCLabel2 lattice (D1/M1b; Mathlib)
 lean_lib «UnwindingIFC» where
   roots := #[`UnwindingIFC]


### PR DESCRIPTION
## The gap

`IdentityOracleMirror` anchored **one** oracle (the v1 guard). Machine v2 grew a floating label, and its mirrors — the confidentiality lattice, its join, its flows-to, the material-label table, the principal ceiling — were transcribed into the iris tree with **nothing** proving they match the shipped extraction.

That's the sharpest form of the objection: one wrong entry in `matLabel` makes the v2 noninterference theorem a *true statement about the wrong system*, with every gate green. A proof that's real and a claim that's worthless is worse than having neither.

## The fix

Five faithfulness theorems against the Aeneas-extracted functions that ship — `cjoin_faithful`, `cflows_faithful`, `mat_label_faithful` (all 11 materials), `ceiling_faithful`, `may_deliver_faithful` (the full 11×3 product) — each by exhaustive case analysis, so a wrong entry **fails to compile**. Perturbation-verified: flipping `ProxyAuthSecret` Internal→Public breaks `mat_label_faithful`'s `rfl`.

`reaches_is_a_flow_faithful` additionally proves against the extraction what the iris tree only asserted in a docstring: the v1 delivery guard **is** the v2 flow decision at the workload's ceiling.

## Deliberate omission

No faithfulness theorem for the rank, with the reason in the file: extracted `crank` returns an Aeneas `Std.U8` while a portable mirror must return `Nat`, so stating equality threads a scalar conversion that adds TCB without adding assurance. The rank is internal and fully pinned by the two composites, which are exhaustive over all argument pairs.

## Scope

This anchors the mirror **definitions**. That the *copies* in `capability-primitive/iris` are these definitions cannot be proved here — a Lean proof can't see another repository — and is gated there by a companion parity check.

Added to the proven-tier build list so it can't rot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UA8kchV3eadjGv6BmJXfqm