### PR TITLE
Pod self-identity, and ManagePods scoped to descendants

### DIFF
--- a/crates/nucleus-guest-init/src/identity.rs
+++ b/crates/nucleus-guest-init/src/identity.rs
@@ -209,6 +209,41 @@ pub fn fetch_task_token(port: u32) -> Result<TaskTokenResponse, String> {
 /// and writes the certificate and key to the identity directory.
 ///
 /// Returns the SPIFFE ID on success.
+/// The pod's own UUID, read out of the SPIFFE ID the host just served it.
+///
+/// # Why this exists, and why it is not an environment variable from the host
+///
+/// The tool-proxy reads `NUCLEUS_POD_ID` to decide whether a pod-scoped lockdown
+/// command is aimed at it (`lockdown_client::apply_scope`). Nothing in the tree
+/// ever set that variable — so the `Some(my_id) => my_id == target_pod` branch was
+/// unreachable, and `apply_scope` fell to its `None => true` case: a lockdown
+/// aimed at ONE pod locked down EVERY pod on the node. Fail-safe, and silently
+/// non-functional as a targeting mechanism.
+///
+/// The identity is taken from the SVID rather than injected by the host as an
+/// env var because the SVID arrives over the per-pod vsock socket that the host
+/// creates per VM — the guest cannot forge which socket it is connected to,
+/// whereas any value merely placed in the environment is only as good as
+/// everything that can write to the environment. This is the same reasoning that
+/// makes the workload API's `pod_id` trustworthy host-side: the identifier comes
+/// from the transport, not from the payload.
+///
+/// Returns `None` rather than guessing when the ID is not the expected shape —
+/// a wrong pod id is worse than no pod id, because `apply_scope`'s `None` branch
+/// is the safe one.
+#[must_use]
+pub fn pod_id_from_spiffe(spiffe_id: &str) -> Option<String> {
+    // `spiffe://{trust_domain}/ns/pods/sa/{pod_id}` — see
+    // nucleus_node::workload_api_vsock, which mints exactly this form.
+    let rest = spiffe_id.strip_prefix("spiffe://")?;
+    let (_trust_domain, path) = rest.split_once('/')?;
+    let id = path.strip_prefix("ns/pods/sa/")?;
+    if id.is_empty() || id.contains('/') {
+        return None;
+    }
+    Some(id.to_string())
+}
+
 pub fn fetch_identity(port: u32) -> Result<String, String> {
     // Create identity directory
     fs::create_dir_all(IDENTITY_DIR)
@@ -335,4 +370,68 @@ pub fn parse_workload_api_port(cmdline: &str) -> Option<u32> {
 #[allow(dead_code)]
 pub fn should_fetch_identity(cmdline: &str) -> bool {
     parse_workload_api_port(cmdline).is_some()
+}
+
+#[cfg(test)]
+mod pod_id_tests {
+    use super::pod_id_from_spiffe;
+
+    /// The form `nucleus_node::workload_api_vsock` actually mints.
+    #[test]
+    fn the_pod_uuid_is_read_from_the_workload_api_form() {
+        assert_eq!(
+            pod_id_from_spiffe(
+                "spiffe://nucleus.local/ns/pods/sa/d6bf354e-6d41-42fe-8aa8-8c287a8db798"
+            )
+            .as_deref(),
+            Some("d6bf354e-6d41-42fe-8aa8-8c287a8db798")
+        );
+    }
+
+    /// The OTHER SPIFFE form a pod has — `ns/{namespace}/sa/{metadata.name}`,
+    /// which the node registers for the broker — is NOT a pod id and must not be
+    /// mistaken for one. Two pods can share a `metadata.name`; a pod UUID is
+    /// unique. Returning that string here would make lockdown scoping match the
+    /// wrong set of pods.
+    #[test]
+    fn the_namespace_form_is_not_mistaken_for_a_pod_id() {
+        assert_eq!(
+            pod_id_from_spiffe("spiffe://nucleus.local/ns/default/sa/my-agent"),
+            None
+        );
+    }
+
+    /// STRUCTURAL: the parser being correct proves nothing if nobody calls it.
+    /// The whole defect was a consumer (`apply_scope`) reading a variable no
+    /// producer ever set, and this test is what would have caught that. It reads
+    /// main.rs and fails if the identity branch stops setting NUCLEUS_POD_ID.
+    #[test]
+    fn guest_init_still_sets_the_pod_id_after_fetching_identity() {
+        let src = include_str!("main.rs");
+        assert!(
+            src.contains("pod_id_from_spiffe"),
+            "guest-init no longer derives the pod id from the SVID — pod-scoped \
+             lockdown silently reverts to locking every pod on the node"
+        );
+        assert!(
+            src.contains("NUCLEUS_POD_ID"),
+            "guest-init no longer sets NUCLEUS_POD_ID — the variable the \
+             tool-proxy reads would have no producer again"
+        );
+    }
+
+    /// Malformed input yields None rather than a guess: `apply_scope`'s None
+    /// branch is the conservative one, so refusing to parse fails safe.
+    #[test]
+    fn malformed_ids_yield_none_rather_than_a_guess() {
+        for bad in [
+            "",
+            "not-a-spiffe-id",
+            "spiffe://nucleus.local",
+            "spiffe://nucleus.local/ns/pods/sa/",
+            "spiffe://nucleus.local/ns/pods/sa/a/b",
+        ] {
+            assert_eq!(pod_id_from_spiffe(bad), None, "should not parse: {bad}");
+        }
+    }
 }

--- a/crates/nucleus-guest-init/src/main.rs
+++ b/crates/nucleus-guest-init/src/main.rs
@@ -111,6 +111,28 @@ fn run() -> Result<(), String> {
                 // always failed, so this gap was invisible: the pod died one
                 // step earlier for a different reason.
                 std::env::set_var("NUCLEUS_IDENTITY_CERT", identity::svid_cert_path());
+
+                // …and tell the proxy WHICH POD IT IS, from the same SVID.
+                //
+                // `lockdown_client::apply_scope` reads `NUCLEUS_POD_ID` to decide
+                // whether a `pod:<id>`-scoped lockdown is aimed at this pod.
+                // Nothing in the tree set it, so that branch was unreachable and
+                // apply_scope fell to `None => true`: a lockdown aimed at one pod
+                // locked down EVERY pod on the node. Fail-safe, and silently
+                // useless as targeting.
+                //
+                // Taken from the SVID rather than passed in as an env var by the
+                // host: the SVID arrives over the per-pod vsock socket the host
+                // creates per VM, so the identifier comes from the transport
+                // rather than from anything the guest could restate.
+                match identity::pod_id_from_spiffe(&spiffe_id) {
+                    Some(pod_id) => std::env::set_var("NUCLEUS_POD_ID", pod_id),
+                    None => eprintln!(
+                        "identity {spiffe_id} is not the workload-API pod form; \
+                         NUCLEUS_POD_ID unset, so pod-scoped lockdown will apply \
+                         conservatively to this pod"
+                    ),
+                }
             }
             Err(err) => {
                 eprintln!("failed to fetch identity: {err}");

--- a/crates/nucleus-node/src/main.rs
+++ b/crates/nucleus-node/src/main.rs
@@ -490,6 +490,16 @@ struct PodInfo {
     state: PodState,
     proxy_addr: Option<String>,
     labels: BTreeMap<String, String>,
+    /// The pod that created this one, if any.
+    ///
+    /// Exposed so a tool-proxy can tell WHICH pods are its own descendants.
+    /// Without it, `ManagePods` is a node-wide capability by accident: the proxy
+    /// has no way to distinguish the pods it spawned from every other tenant's,
+    /// so `list_sub_pods` returned all of them and `get_pod_logs` accepted any
+    /// UUID. The node has always tracked this (`PodHandle::parent_pod_id`) and
+    /// used it for cascade-cancel; it simply never told anyone.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    parent_pod_id: Option<Uuid>,
     /// The verified proof-carrying posture (`<posture>:verified`), present only
     /// when the pod carried a `dlc_posture` claim that passed admission against
     /// the host-measured rootfs and the trusted-posture registry. Absent means
@@ -1140,6 +1150,7 @@ impl PodHandle {
             created_at_unix: self.created_at,
             state,
             proxy_addr,
+            parent_pod_id: self.parent_pod_id,
             labels: self.spec.metadata.labels.clone(),
             posture: self.posture_stamp.clone(),
         }

--- a/crates/nucleus-tool-proxy/src/node_client.rs
+++ b/crates/nucleus-tool-proxy/src/node_client.rs
@@ -24,6 +24,11 @@ pub struct PodInfo {
     pub created_at_unix: u64,
     pub state: PodState,
     pub proxy_addr: Option<String>,
+    /// The pod that created this one, if any — what makes ownership checkable.
+    /// Absent on an older node that does not send it; `pod_mgmt` treats absent
+    /// as "not mine", which is the fail-closed direction.
+    #[serde(default)]
+    pub parent_pod_id: Option<Uuid>,
 }
 
 /// Pod state (mirrors nucleus-node PodState).

--- a/crates/nucleus-tool-proxy/src/pod_mgmt.rs
+++ b/crates/nucleus-tool-proxy/src/pod_mgmt.rs
@@ -210,6 +210,86 @@ pub(crate) async fn create_sub_pod(
     }))
 }
 
+/// Which pod THIS proxy serves, if it knows.
+///
+/// Set by guest-init from the SVID served over the per-pod vsock socket, so the
+/// value comes from the transport rather than from anything the guest could
+/// restate. `None` on deployments where identity was never fetched (local mode,
+/// or a boot where the fetch failed).
+fn self_pod_id() -> Option<String> {
+    std::env::var("NUCLEUS_POD_ID")
+        .ok()
+        .filter(|s| !s.is_empty())
+}
+
+/// Is `pod` a pod this proxy is entitled to manage?
+///
+/// # Why this exists
+///
+/// `check_manage_pods` asks whether the CALLER holds `ManagePods`. It does not
+/// ask WHICH pods that authorises, and nothing else did either — so a pod with
+/// the capability could list every pod on the node, read any pod's logs, and
+/// cancel any pod, including other tenants'. The node had tracked
+/// `parent_pod_id` all along and consulted it only for cascade-cancel.
+///
+/// The functions are named `list_sub_pods` / `cancel_sub_pod`; this makes the
+/// behaviour match the name.
+///
+/// **Where this is enforced, and the residual.** Proxy-side, which is where
+/// `check_manage_pods` already lives: the architecture treats the AGENT as
+/// untrusted and the tool-proxy as the guest's enforcement point. A *compromised
+/// proxy* could bypass it, because every proxy holds the node-wide auth secret —
+/// but that is a pre-existing property of the proxy↔node channel, not something
+/// this check weakens. Making the NODE enforce it needs per-caller identity at
+/// the node API, which does not exist today: every pod signs as the literal
+/// actor "tool-proxy" with the same shared secret.
+///
+/// **When identity is unknown** the check cannot be made, and this returns
+/// `true` — preserving today's behaviour rather than breaking pod management on
+/// deployments that never set `NUCLEUS_POD_ID`. That is a real, named gap, and
+/// it is logged so it is visible rather than silent.
+fn may_manage(pod: &node_client::PodInfo, me: Option<&str>) -> bool {
+    let Some(me) = me else {
+        tracing::warn!(
+            "this proxy does not know its own pod id (NUCLEUS_POD_ID unset), so \
+             sub-pod ownership cannot be enforced -- pod management is unrestricted \
+             on this deployment"
+        );
+        return true;
+    };
+    // A pod may manage its own descendants, and itself.
+    pod.parent_pod_id.map(|p| p.to_string()).as_deref() == Some(me) || pod.id.to_string() == me
+}
+
+/// Resolve `target` through the node and refuse unless this proxy may manage it.
+///
+/// Deliberately re-resolves rather than trusting anything in the request: the
+/// parentage that decides the answer must come from the node's registry, not
+/// from the caller.
+async fn ensure_may_manage(
+    node: &node_client::NodeClient,
+    target: uuid::Uuid,
+) -> Result<(), ApiError> {
+    let me = self_pod_id();
+    if me.is_none() {
+        // Unknown identity: the check cannot be made. `may_manage` logs the gap.
+        return Ok(());
+    }
+    let pods = node
+        .list_pods()
+        .await
+        .map_err(|e| ApiError::Spec(format!("node list_pods failed: {e}")))?;
+    let found = pods.iter().find(|p| p.id == target);
+    match found {
+        Some(pod) if may_manage(pod, me.as_deref()) => Ok(()),
+        // Same refusal for "not yours" and "does not exist": distinguishing them
+        // would let a caller enumerate which UUIDs are live on the node.
+        _ => Err(ApiError::Spec(
+            "pod not found or not managed by this pod".to_string(),
+        )),
+    }
+}
+
 pub(crate) async fn list_sub_pods(
     State(state): State<AppState>,
     _headers: HeaderMap,
@@ -226,7 +306,16 @@ pub(crate) async fn list_sub_pods(
         .await
         .map_err(|e| ApiError::Spec(format!("node list_pods failed: {e}")))?;
 
-    Ok(Json(pods))
+    // Only this pod's own descendants. The node returns every pod it runs;
+    // returning that list wholesale is what made ManagePods node-wide, and it is
+    // also how a caller LEARNED the UUIDs it could then pass to get_pod_logs.
+    let me = self_pod_id();
+    let mine: Vec<_> = pods
+        .into_iter()
+        .filter(|p| may_manage(p, me.as_deref()))
+        .collect();
+
+    Ok(Json(mine))
 }
 
 pub(crate) async fn get_pod_status(
@@ -269,6 +358,11 @@ pub(crate) async fn get_pod_logs(
         .parse()
         .map_err(|e| ApiError::Spec(format!("invalid pod_id: {e}")))?;
 
+    // Ownership: reading another tenant's pod log is a cross-pod disclosure, and
+    // nothing checked it. Resolve the target through the node's own list so the
+    // parentage comes from the node rather than from the request.
+    ensure_may_manage(node, pod_id).await?;
+
     let logs = node
         .pod_logs(pod_id)
         .await
@@ -300,6 +394,10 @@ pub(crate) async fn cancel_sub_pod(
         .pod_id
         .parse()
         .map_err(|e| ApiError::Spec(format!("invalid pod_id: {e}")))?;
+
+    // Ownership: cancelling another tenant's pod is a cross-pod WRITE — a denial
+    // of service against a workload this caller has nothing to do with.
+    ensure_may_manage(node, pod_id).await?;
 
     node.cancel_pod(pod_id)
         .await
@@ -762,5 +860,91 @@ spec:
         strip_requested_workload(&mut spec);
         assert_eq!(spec.spec.work_dir, work_dir);
         assert_eq!(spec.metadata.name.as_deref(), Some("sub"));
+    }
+}
+
+#[cfg(test)]
+mod ownership_tests {
+    //! `ManagePods` must mean "manage MY pods", not "manage every pod on the node".
+    //!
+    //! `check_manage_pods` asks whether the caller holds the capability; nothing
+    //! asked which pods it authorises. So a pod with it could list every tenant's
+    //! pods, read any pod's logs, and cancel any pod. The node tracked
+    //! `parent_pod_id` throughout and consulted it only for cascade-cancel.
+    use super::{may_manage, node_client};
+
+    fn pod(id: &str, parent: Option<&str>) -> node_client::PodInfo {
+        node_client::PodInfo {
+            id: id.parse().expect("uuid"),
+            name: None,
+            created_at_unix: 0,
+            state: node_client::PodState::Running,
+            proxy_addr: None,
+            parent_pod_id: parent.map(|p| p.parse().expect("uuid")),
+        }
+    }
+
+    const ME: &str = "11111111-1111-4111-8111-111111111111";
+    const OTHER: &str = "22222222-2222-4222-8222-222222222222";
+    const CHILD: &str = "33333333-3333-4333-8333-333333333333";
+
+    /// The defect, refused: another tenant's pod is not mine to manage.
+    #[test]
+    fn a_pod_i_did_not_create_is_not_mine() {
+        assert!(!may_manage(&pod(OTHER, None), Some(ME)));
+    }
+
+    /// …including one owned by a DIFFERENT parent, which is the multi-tenant case.
+    #[test]
+    fn another_pods_child_is_not_mine() {
+        assert!(!may_manage(&pod(CHILD, Some(OTHER)), Some(ME)));
+    }
+
+    /// Delegation still works: my own child is mine.
+    #[test]
+    fn my_own_child_is_mine() {
+        assert!(may_manage(&pod(CHILD, Some(ME)), Some(ME)));
+    }
+
+    /// A pod may address itself — cancelling yourself is legitimate.
+    #[test]
+    fn i_am_my_own() {
+        assert!(may_manage(&pod(ME, None), Some(ME)));
+    }
+
+    /// THE NAMED GAP, pinned so it stays a decision rather than an accident: with
+    /// no identity the check cannot be made and behaviour is unchanged. If this
+    /// ever becomes fail-closed, THIS is the test that should fail and be
+    /// deliberately updated.
+    #[test]
+    fn unknown_identity_is_unenforced_and_that_is_recorded() {
+        assert!(
+            may_manage(&pod(OTHER, Some(OTHER)), None),
+            "with no NUCLEUS_POD_ID the proxy cannot enforce ownership; this is the \
+             documented gap, not an oversight"
+        );
+    }
+
+    /// STRUCTURAL: the handlers must actually consult the check. The predicate
+    /// being right proves nothing if nobody calls it — the failure shape this
+    /// repo keeps finding.
+    #[test]
+    fn the_handlers_still_enforce_ownership() {
+        let src = include_str!("pod_mgmt.rs");
+        for (f, needle) in [
+            ("get_pod_logs", "ensure_may_manage"),
+            ("cancel_sub_pod", "ensure_may_manage"),
+            ("list_sub_pods", "may_manage"),
+        ] {
+            let body = src
+                .split(&format!("async fn {f}("))
+                .nth(1)
+                .unwrap_or_else(|| panic!("{f} must exist"));
+            let body = &body[..body.find("\npub(crate) ").unwrap_or(body.len())];
+            assert!(
+                body.contains(needle),
+                "{f} no longer calls {needle} -- ManagePods is node-wide again"
+            );
+        }
     }
 }


### PR DESCRIPTION
Two linked defects from a cross-pod audit. The second cannot be fixed without the first.

## 1. `NUCLEUS_POD_ID` had a consumer and no producer

`lockdown_client::apply_scope` reads it to decide whether a `pod:<id>`-scoped lockdown is aimed at this pod. **Nothing in the tree ever set it** — repo-wide, one occurrence: the read.

So the `Some(my_id) == target` branch was unreachable and `apply_scope` always fell to `None => true` (*"conservatively lock"*). **A lockdown aimed at ONE pod locked down EVERY pod on the node.** Fail-safe, which is why it survived, and silently useless as targeting: an operator scoping an incident to one tenant did not.

guest-init now derives it from the SVID it already fetches — **from the transport, not an env var**: the SVID arrives over the per-pod vsock socket the host creates per VM, so the identifier is not something the guest can restate. Only the workload-API form (`ns/pods/sa/{uuid}`) parses; the *other* SPIFFE ID a pod has (`ns/{namespace}/sa/{metadata.name}`) is rejected, because two pods can share a `metadata.name` and scoping would match the wrong set.

## 2. `ManagePods` was node-wide by accident

`check_manage_pods` asks whether the caller *holds* the capability, never *which pods* it authorises. A pod with it could list every tenant's pods, read any pod's logs, and cancel any pod — and `list_sub_pods` returning the whole node list is how a caller *learned* the UUIDs to pass.

The node had the answer all along: `parent_pod_id` has always been tracked and was consulted only for cascade-cancel. `PodInfo` now carries it, and the three handlers enforce descendant-only management. `get_pod_logs`/`cancel_sub_pod` re-resolve the target through the node's registry so parentage never comes from the request, and *"not yours"* and *"doesn't exist"* return the **same** refusal so UUIDs can't be enumerated.

## Where this is enforced, and the residual

**Proxy-side**, where `check_manage_pods` already lives: the architecture treats the agent as untrusted and the proxy as the guest's enforcement point, and the agent is who this stops. A **compromised proxy** can bypass it, because every proxy holds the node-wide auth secret. Making the *node* enforce it needs per-caller identity at the node API, which doesn't exist today — every pod signs as the literal actor `"tool-proxy"` with the same shared secret (`node_client.rs:89`). That's the next arc.

## The named gap

With `NUCLEUS_POD_ID` unset the check can't be made and behaviour is unchanged rather than fail-closed — otherwise this breaks pod management wherever identity was never fetched (local mode). Logged loudly, and **pinned by a test** whose failure would signal someone tightened it deliberately. Part 1 makes the real Firecracker path have identity.

## Tests (10)

Four ownership assertions, one pinning the named gap, four on the identity parser (including rejecting the namespace form), and **two structural** tests that read the source and fail if the wiring is dropped — the defect in part 1 was exactly a consumer with no producer.

Verified to fail for the right reason: neutering the ownership predicate reds exactly the two cross-tenant assertions. Full tool-proxy suite 299 passed; Linux `cargo check` on guest-init (a Linux-only target) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UA8kchV3eadjGv6BmJXfqm