### PR TITLE
Article 12 records: bind the signature to the destination, not just the payload

### DIFF
--- a/crates/nucleus-client/src/lib.rs
+++ b/crates/nucleus-client/src/lib.rs
@@ -73,6 +73,38 @@ pub struct DrandSignedHeaders {
 /// Sign an HTTP request body.
 ///
 /// The server expects: `signature = HMAC_SHA256(secret, "{ts}.{actor}.{body}")`.
+/// The bytes an Article 12 record's signature must cover: the DESTINATION as
+/// well as the payload.
+///
+/// # The defect this closes
+///
+/// `art12_append` verified the signature over the request BODY alone, while the
+/// `session_id` that decides which chain the record lands in came from the URL
+/// path and was only sanitised against traversal. So a validly-signed record
+/// could be replayed into ANY session's chain by changing the path — and every
+/// pod configured with the node-wide receipt secret can sign. On the evidence
+/// path (EU AI Act Article 12 record-keeping), that is one tenant able to write
+/// into another tenant's audit chain.
+///
+/// A signature that authenticates a payload but not its destination is not
+/// authenticating the thing that matters.
+///
+/// # Framing
+///
+/// Length-prefixed, not concatenated. `session_id || body` is ambiguous: a
+/// session id ending in digits and a body starting with them can be re-split,
+/// so two different (session, body) pairs could share one signature. The
+/// domain tag makes these bytes unusable as any other signature in the system.
+#[must_use]
+pub fn art12_signed_bytes(session_id: &str, body: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(session_id.len() + body.len() + 32);
+    out.extend_from_slice(b"nucleus-art12-v2\0");
+    out.extend_from_slice(&(session_id.len() as u64).to_be_bytes());
+    out.extend_from_slice(session_id.as_bytes());
+    out.extend_from_slice(body);
+    out
+}
+
 pub fn sign_http_headers(secret: &[u8], actor: Option<&str>, body: &[u8]) -> SignedHeaders {
     let timestamp = now_unix();
     let actor_value = actor.unwrap_or("");
@@ -650,5 +682,40 @@ mod tests {
         assert!(!constant_time_eq(b"hello", b"hell"));
         assert!(!constant_time_eq(b"", b"a"));
         assert!(constant_time_eq(b"", b""));
+    }
+}
+
+#[cfg(test)]
+mod art12_binding_tests {
+    use super::art12_signed_bytes;
+
+    /// The whole point: the same body aimed at a different session must produce
+    /// different signed bytes, or the signature does not bind the destination.
+    #[test]
+    fn the_destination_changes_the_signed_bytes() {
+        let body = br#"{"event":"x"}"#;
+        assert_ne!(
+            art12_signed_bytes("session-a", body),
+            art12_signed_bytes("session-b", body)
+        );
+    }
+
+    /// Length-prefixing, demonstrated rather than asserted in a comment: without
+    /// it, ("ab", "cd") and ("abc", "d") would frame identically.
+    #[test]
+    fn framing_is_unambiguous_across_the_boundary() {
+        assert_ne!(
+            art12_signed_bytes("ab", b"cd"),
+            art12_signed_bytes("abc", b"d")
+        );
+    }
+
+    /// Same inputs, same bytes — the signature has to be reproducible.
+    #[test]
+    fn framing_is_deterministic() {
+        assert_eq!(
+            art12_signed_bytes("s", b"body"),
+            art12_signed_bytes("s", b"body")
+        );
     }
 }

--- a/crates/nucleus-node/src/art12_collector.rs
+++ b/crates/nucleus-node/src/art12_collector.rs
@@ -244,7 +244,13 @@ pub async fn accept(
     let Some(signature) = signature else {
         return (StatusCode::UNAUTHORIZED, "missing signature");
     };
-    if crate::auth::verify_signature_pub(secret, body.as_bytes(), signature).is_err() {
+    // Verify over the DESTINATION as well as the payload. Verifying the body
+    // alone authenticated "someone holding the receipt secret said this", never
+    // "…and meant it for THIS session" — so a validly-signed record could be
+    // replayed into any other session's chain by changing the URL path, and
+    // every pod configured with the node-wide receipt secret can sign.
+    let signed = nucleus_client::art12_signed_bytes(&session_id, body.as_bytes());
+    if crate::auth::verify_signature_pub(secret, &signed, signature).is_err() {
         tracing::warn!(%session_id, "rejected an unauthenticated Article 12 record");
         return (StatusCode::UNAUTHORIZED, "bad signature");
     }
@@ -261,6 +267,46 @@ pub async fn accept(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// **The cross-session replay, refused.** A record legitimately signed for
+    /// session A must not be accepted into session B's chain. Before the
+    /// signature covered the destination, this succeeded: the body verified, and
+    /// the session id came from a URL path that nothing authenticated.
+    ///
+    /// This is an integrity property of the EVIDENCE path (Article 12
+    /// record-keeping), and every pod configured with the node-wide receipt
+    /// secret can produce a valid signature — so "who can sign" is not a
+    /// meaningful restriction on "whose chain it lands in".
+    #[test]
+    fn a_record_signed_for_one_session_is_refused_by_another() {
+        let secret = b"node-wide-receipt-secret";
+        let body = r#"{"event":"decision"}"#;
+
+        let sig_for_a = {
+            use hmac::{digest::KeyInit, Hmac, Mac};
+            let mut mac = Hmac::<sha2::Sha256>::new_from_slice(secret).expect("key");
+            mac.update(&nucleus_client::art12_signed_bytes(
+                "session-a",
+                body.as_bytes(),
+            ));
+            hex::encode(mac.finalize().into_bytes())
+        };
+
+        // Its own session accepts it…
+        let signed_a = nucleus_client::art12_signed_bytes("session-a", body.as_bytes());
+        assert!(
+            crate::auth::verify_signature_pub(secret, &signed_a, &sig_for_a).is_ok(),
+            "a record must still verify for the session it was signed for"
+        );
+
+        // …and another session does not.
+        let signed_b = nucleus_client::art12_signed_bytes("session-b", body.as_bytes());
+        assert!(
+            crate::auth::verify_signature_pub(secret, &signed_b, &sig_for_a).is_err(),
+            "a record signed for session-a was accepted into session-b's chain -- \
+             the signature does not bind the destination"
+        );
+    }
 
     #[test]
     fn a_traversing_session_id_is_refused() {
@@ -314,8 +360,15 @@ mod tests {
 
     use axum::http::StatusCode;
 
-    fn sign(secret: &[u8], body: &str) -> String {
-        crate::auth::sign_message(secret, body.as_bytes())
+    /// Sign the way a real shipper does — over the DESTINATION and the payload.
+    /// Taking `session` is the point: a helper that signed the body alone would
+    /// let every test below pass while the destination went unauthenticated,
+    /// which is precisely the defect that shipped.
+    fn sign(secret: &[u8], session: &str, body: &str) -> String {
+        crate::auth::sign_message(
+            secret,
+            &nucleus_client::art12_signed_bytes(session, body.as_bytes()),
+        )
     }
 
     /// **Evidence anyone can append to is not evidence.** An unsigned record
@@ -341,7 +394,7 @@ mod tests {
             dir.path(),
             Some(b"k"),
             "s1",
-            Some(&sign(b"other", "{}")),
+            Some(&sign(b"other", "s1", "{}")),
             "{}",
         )
         .await;
@@ -355,7 +408,14 @@ mod tests {
     async fn a_correctly_signed_record_is_stored() {
         let dir = tempfile::tempdir().unwrap();
         let body = "{\"seq\":1}";
-        let (code, _) = accept(dir.path(), Some(b"k"), "s1", Some(&sign(b"k", body)), body).await;
+        let (code, _) = accept(
+            dir.path(),
+            Some(b"k"),
+            "s1",
+            Some(&sign(b"k", "s1", body)),
+            body,
+        )
+        .await;
         assert_eq!(code, StatusCode::NO_CONTENT);
         let stored = std::fs::read_to_string(session_log_path(dir.path(), "s1")).unwrap();
         assert!(stored.contains("\"seq\":1"));
@@ -369,7 +429,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let body = "{}";
         // Even a signature valid under the EMPTY key must not get in.
-        let (code, _) = accept(dir.path(), None, "s1", Some(&sign(b"", body)), body).await;
+        let (code, _) = accept(dir.path(), None, "s1", Some(&sign(b"", "s1", body)), body).await;
         assert_eq!(code, StatusCode::SERVICE_UNAVAILABLE);
         assert!(!session_log_path(dir.path(), "s1").exists());
     }
@@ -383,7 +443,7 @@ mod tests {
             dir.path(),
             Some(b"k"),
             "../escaped",
-            Some(&sign(b"k", body)),
+            Some(&sign(b"k", "s1", body)),
             body,
         )
         .await;

--- a/crates/nucleus-tool-proxy/src/art12_shipper.rs
+++ b/crates/nucleus-tool-proxy/src/art12_shipper.rs
@@ -56,7 +56,12 @@ impl Art12Shipper {
     /// `url` is operator-configured and points at the host. It is not agent
     /// egress: nothing the agent does can influence it, and the mediation gate
     /// exempts this path for the same reason it exempts the audit webhook.
-    pub(crate) fn start(url: String, secret: Vec<u8>, client: reqwest::Client) -> Self {
+    pub(crate) fn start(
+        url: String,
+        secret: Vec<u8>,
+        session: String,
+        client: reqwest::Client,
+    ) -> Self {
         let (tx, mut rx) = tokio::sync::mpsc::channel::<String>(QUEUE_DEPTH);
         let degraded = Arc::new(AtomicBool::new(false));
         let unshipped = Arc::new(AtomicU64::new(0));
@@ -68,7 +73,13 @@ impl Art12Shipper {
                 let sig = {
                     let mut mac =
                         Hmac::<Sha256>::new_from_slice(&secret).expect("hmac accepts any key");
-                    mac.update(line.as_bytes());
+                    // Sign the DESTINATION as well as the payload. Signing the body
+                    // alone let a validly-signed record be replayed into any other
+                    // session's chain by changing the URL path.
+                    mac.update(&nucleus_client::art12_signed_bytes(
+                        &session,
+                        line.as_bytes(),
+                    ));
                     hex::encode(mac.finalize().into_bytes())
                 };
                 let sent = client
@@ -140,6 +151,7 @@ impl Art12Shipper {
         Some(Arc::new(Self::start(
             url.clone(),
             secret,
+            session_id.to_string(),
             reqwest::Client::new(),
         )))
     }

--- a/crates/nucleus-tool-proxy/src/art12_shipper.rs
+++ b/crates/nucleus-tool-proxy/src/art12_shipper.rs
@@ -186,6 +186,7 @@ mod tests {
         let s = Art12Shipper::start(
             "http://127.0.0.1:1/v1/art12".to_string(),
             b"k".to_vec(),
+            "test-session".to_string(),
             client(),
         );
         assert!(
@@ -215,6 +216,7 @@ mod tests {
         let s = Art12Shipper::start(
             "http://127.0.0.1:1/v1/art12".to_string(),
             b"k".to_vec(),
+            "test-session".to_string(),
             client(),
         );
         // Submit well past the queue depth without awaiting the drain.


### PR DESCRIPTION
## The defect

`art12_append` verified the signature over the request **body alone**, while the `session_id` deciding *which chain the record lands in* came from the URL path and was only sanitised against traversal (`art12_collector.rs:248`).

So the signature authenticated *"someone holding the receipt secret said this"* and never *"…and meant it for THIS session"*. A validly-signed record could be replayed into any other session's chain by changing the path.

This is not gated by anything else: the endpoint is on the **public router** (`main.rs:737-744`) with no auth middleware — the signature *is* the authentication — and the secret is **node-wide** (node reads `TRUST_RECEIPT_SECRET`; pods receive it via `--audit-secret`). So *who can sign* is not a meaningful restriction on *whose chain it lands in*: this is one tenant able to write into another tenant's audit chain.

That chain isn't incidental — `observed_chain` reads it back into a pod's **exit attestation**, and Article 12 is the EU AI Act record-keeping obligation. It's the evidence path.

> A signature that authenticates a payload but not its destination is not authenticating the thing that matters.

## The fix

`nucleus_client::art12_signed_bytes` frames what must be signed, in the crate **both sides already depend on** rather than duplicated per side — sender and verifier can now disagree only by failing to compile against the same function.

**Length-prefixed, not concatenated.** `session_id || body` is ambiguous: a session id ending in digits and a body starting with them can be re-split, so two different (session, body) pairs could share a signature — a subtler version of the same defect. A domain tag makes the bytes unusable as any other signature in the system.

## Tests

Three on the framing (destination changes the bytes; ambiguity demonstrated with `("ab","cd")` vs `("abc","d")` rather than asserted in a comment; determinism), and one on the handler: a record signed for `session-a` verifies for `session-a` and is **refused** for `session-b`.

The existing `sign` test helper now takes the session **deliberately** — a helper that signed the body alone would let every test in that module pass while the destination went unauthenticated, which is exactly the defect that shipped.

**Verified to fail for the right reason:** removing the destination from the framed bytes reds the replay test and the framing test, at both layers.

## Wire change, stated plainly

A node with this verification rejects records from a shipper without it. Both sides live in this tree and the tool-proxy is baked into the rootfs from it, so they move together; a partially-updated deployment loses Article 12 shipping until the guest image is rebuilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UA8kchV3eadjGv6BmJXfqm