### PR TITLE
identity registry: carry the key, don't re-derive it

### DIFF
--- a/crates/nucleus-node/src/identity.rs
+++ b/crates/nucleus-node/src/identity.rs
@@ -102,10 +102,21 @@ impl IdentityManager {
     }
 
     /// Unregisters a pod from the VM registry.
+    ///
+    /// Returns whether an entry was actually removed. `HashMap::remove` reports
+    /// this and the result used to be discarded, which is precisely how the
+    /// registry came to never drain: teardown removed by the pod's SPIFFE URI
+    /// while registration inserted under the pod's UUID, the two never matched,
+    /// and the no-op was invisible at every call site.
+    ///
+    /// `#[must_use]` so a caller cannot reintroduce that silence without saying
+    /// so in the code. A wrong key is a bug either way; the difference is whether
+    /// anyone finds out.
+    #[must_use = "a false return means NOTHING was removed -- usually a wrong key"]
     #[allow(dead_code)]
-    pub async fn unregister_pod(&self, connection_id: &str) {
+    pub async fn unregister_pod(&self, connection_id: &str) -> bool {
         let mut registry = self.vm_registry.write().await;
-        registry.remove(connection_id);
+        registry.remove(connection_id).is_some()
     }
 
     /// Starts the Workload API server on a Unix socket.
@@ -362,7 +373,10 @@ mod tests {
         drop(registry);
 
         // Unregister
-        manager.unregister_pod(&pod_id.to_string()).await;
+        assert!(
+            manager.unregister_pod(&pod_id.to_string()).await,
+            "the pod was registered under this key, so removal must report a hit"
+        );
         let registry = manager.vm_registry.read().await;
         assert!(!registry.contains_key(&pod_id.to_string()));
     }
@@ -482,5 +496,56 @@ mod tests {
             .unwrap();
 
         assert_eq!(cert.identity(), &identity);
+    }
+}
+
+#[cfg(test)]
+mod registry_key_tests {
+    use super::*;
+
+    fn manager() -> IdentityManager {
+        IdentityManager::new("example.org", std::time::Duration::from_secs(3600))
+            .expect("identity manager should construct")
+    }
+
+    /// The regression. A pod registered under its UUID is NOT removed by its
+    /// SPIFFE URI: the two key spaces are disjoint, so the mismatched teardown
+    /// silently removed nothing and the registry grew without bound.
+    ///
+    /// This matters beyond the leak. The Workload API's registry-lookup path
+    /// serves `registry.values().next()` -- an arbitrary entry -- and warns that
+    /// this is only safe while exactly one identity is registered. A registry
+    /// that never drains guarantees that precondition is false forever after the
+    /// second pod.
+    #[tokio::test]
+    async fn a_spiffe_uri_does_not_remove_a_uuid_keyed_entry() {
+        let m = manager();
+        let pod_id = uuid::Uuid::new_v4();
+        let identity = m.identity_for_pod(pod_id, "default", "agent");
+
+        m.register_pod(pod_id.to_string(), identity.clone()).await;
+
+        // The old teardown key.
+        assert!(
+            !m.unregister_pod(&identity.to_spiffe_uri()).await,
+            "a SPIFFE URI must not match a UUID-keyed entry -- if this ever \
+             passes, the two key spaces have merged and this test is no longer \
+             pinning anything"
+        );
+        assert_eq!(
+            m.vm_registry.read().await.len(),
+            1,
+            "the entry must still be there: that is the defect being pinned"
+        );
+
+        // The key registration actually used.
+        assert!(
+            m.unregister_pod(&pod_id.to_string()).await,
+            "removing by the registered key must actually remove"
+        );
+        assert!(
+            m.vm_registry.read().await.is_empty(),
+            "the registry must drain"
+        );
     }
 }

--- a/crates/nucleus-node/src/identity.rs
+++ b/crates/nucleus-node/src/identity.rs
@@ -119,6 +119,29 @@ impl IdentityManager {
         registry.remove(connection_id).is_some()
     }
 
+    /// Release everything this pod held in the identity subsystem.
+    ///
+    /// Takes the key registration actually USED rather than re-deriving one, and
+    /// keeps the "did anything get removed?" check beside the registry it
+    /// concerns. Both call sites of that check now live in this module, so a
+    /// future key change has one place to be wrong instead of two.
+    pub async fn release_pod(&self, registry_key: Option<&str>, identity: &Identity) {
+        if let Some(key) = registry_key {
+            if !self.unregister_pod(key).await {
+                // Reachable only if the key drifted again. Worth a warning
+                // rather than a silent no-op: a registry that does not drain is
+                // what makes the Workload API's "exactly one identity is
+                // registered" precondition permanently false.
+                tracing::warn!(
+                    registry_key = %key,
+                    "pod teardown removed no identity registry entry -- the \
+                     registration and removal keys have drifted apart"
+                );
+            }
+        }
+        self.forget_certificate(identity).await;
+    }
+
     /// Starts the Workload API server on a Unix socket.
     ///
     /// This should be called once at startup and the server runs in the background.

--- a/crates/nucleus-node/src/main.rs
+++ b/crates/nucleus-node/src/main.rs
@@ -441,6 +441,14 @@ struct FirecrackerPod {
     identity: Option<nucleus_identity::Identity>,
     /// Reference to identity manager for cleanup
     identity_manager: Option<identity::IdentityManager>,
+    /// The key this pod was REGISTERED under, carried rather than re-derived.
+    ///
+    /// Teardown used to call `unregister_pod(&identity.to_spiffe_uri())` while
+    /// registration used `register_pod(id.to_string(), ..)`. Those are different
+    /// strings, so `HashMap::remove` never matched and no pod was EVER removed
+    /// from the identity registry. Two derivations of one key is the bug; there
+    /// is now one value, produced once and carried to the removal.
+    identity_registry_key: Option<String>,
     /// Workload API vsock bridge for this pod
     workload_api_bridge: Mutex<Option<workload_api_vsock::WorkloadApiVsockBridge>>,
     /// The credential broker listening for this pod, when the rollout serves one.
@@ -1296,7 +1304,20 @@ impl FirecrackerPod {
         }
 
         if let (Some(ref identity), Some(ref manager)) = (&self.identity, &self.identity_manager) {
-            manager.unregister_pod(&identity.to_spiffe_uri()).await;
+            // By the key registration used, not a second derivation of it.
+            if let Some(ref key) = self.identity_registry_key {
+                if !manager.unregister_pod(key).await {
+                    // Reachable only if the key drifted again. Worth a warning
+                    // rather than a silent no-op: a registry that does not drain
+                    // is what makes the Workload API's "exactly one identity is
+                    // registered" precondition permanently false.
+                    tracing::warn!(
+                        registry_key = %key,
+                        "pod teardown removed no identity registry entry -- the \
+                         registration and removal keys have drifted apart"
+                    );
+                }
+            }
             manager.forget_certificate(identity).await;
         }
     }
@@ -2630,6 +2651,9 @@ async fn spawn_firecracker_pod(
         // The refusal is at the source rather than the advertisement.
         let identity_source =
             net::identity_registration(state.identity_manager.as_ref(), &identity_grant);
+        // Set at registration, read at teardown. Declared out here so exactly one
+        // value spans both -- see `FirecrackerPod::identity_registry_key`.
+        let mut identity_registry_key: Option<String> = None;
         // ONE capability, TWO consumers: the workload API serves it to the guest
         // (once, before any workload exists) and the broker listener verifies
         // signatures against it. Minted here because those two are started in
@@ -2647,7 +2671,9 @@ async fn spawn_firecracker_pod(
             let identity = manager.identity_for_pod(id, namespace, service_account);
 
             // Register the pod identity
-            manager.register_pod(id.to_string(), identity.clone()).await;
+            let registry_key = id.to_string();
+            identity_registry_key = Some(registry_key.clone());
+            manager.register_pod(registry_key, identity.clone()).await;
 
             // Compute launch attestation for this pod
             // This captures integrity measurements of kernel, rootfs, and config
@@ -2865,6 +2891,7 @@ async fn spawn_firecracker_pod(
             drift_stop,
             network_allocator: state.network_allocator.clone(),
             identity: pod_identity,
+            identity_registry_key: identity_registry_key.clone(),
             identity_manager,
             workload_api_bridge: Mutex::new(workload_api_bridge),
             broker: Mutex::new(broker),

--- a/crates/nucleus-node/src/main.rs
+++ b/crates/nucleus-node/src/main.rs
@@ -1304,21 +1304,9 @@ impl FirecrackerPod {
         }
 
         if let (Some(ref identity), Some(ref manager)) = (&self.identity, &self.identity_manager) {
-            // By the key registration used, not a second derivation of it.
-            if let Some(ref key) = self.identity_registry_key {
-                if !manager.unregister_pod(key).await {
-                    // Reachable only if the key drifted again. Worth a warning
-                    // rather than a silent no-op: a registry that does not drain
-                    // is what makes the Workload API's "exactly one identity is
-                    // registered" precondition permanently false.
-                    tracing::warn!(
-                        registry_key = %key,
-                        "pod teardown removed no identity registry entry -- the \
-                         registration and removal keys have drifted apart"
-                    );
-                }
-            }
-            manager.forget_certificate(identity).await;
+            manager
+                .release_pod(self.identity_registry_key.as_deref(), identity)
+                .await;
         }
     }
 }


### PR DESCRIPTION
## The defect

The pod identity registry **never drained**. Registration inserted under the pod
UUID:

```rust
manager.register_pod(id.to_string(), identity.clone()).await;   // main.rs
```

and teardown removed by the pod's SPIFFE URI:

```rust
manager.unregister_pod(&identity.to_spiffe_uri()).await;        // main.rs
```

Those are different strings, so `HashMap::remove` never matched and **no pod was
ever removed** for the lifetime of a node.

## Why it is more than a leak

The Workload API's registry-lookup path serves `registry.values().next()` — an
arbitrary `HashMap` entry — and its own comment states this is safe only while
exactly one identity is registered. A registry that never drains makes that
precondition false from the second pod onward, permanently. So a "memory leak"
silently converted a documented, conditionally-safe path into an
unconditionally-unsafe one.

That lookup is the wider defect and is filed as #2197 rather than fixed here:
changing a live serving path is a different decision from fixing a key, and
#2197 needs a call on whether the unix-socket surface should exist at all.
**This PR does not close #2197** — it restores the precondition only while
exactly one pod runs at a time.

## The fix

Two derivations of one key is the bug, so the fix is **one value**.
`FirecrackerPod` carries `identity_registry_key`, set at registration and read at
teardown. There is no second derivation left to drift.

## The silence was the real problem

`HashMap::remove` reports whether it removed anything, and the result was
discarded — so a wrong key and a successful removal were indistinguishable at
every call site. `unregister_pod` now returns `bool` and is `#[must_use]`:
reintroducing that silence requires writing it explicitly. Teardown warns when it
removes nothing, which is reachable only if the keys drift again.

A wrong key is a bug either way. The difference is whether anyone finds out.

## Test

`a_spiffe_uri_does_not_remove_a_uuid_keyed_entry` pins the actual regression. Its
load-bearing leg is the **negative** one: register by UUID, attempt removal by
SPIFFE URI, assert the entry *survives* and the registry still holds one element
— then remove by the registered key and assert it drains. Asserting only the
positive leg would pass on the buggy code too.

## Verification

Both call sites are inside `cfg(target_os = "linux")`, which macOS never
type-checks, so a local green on this file means little by itself — the CI Linux
jobs are the authoritative gate, and the change was also type-checked on Linux
under OrbStack.

- `cargo test -p nucleus-node --bins`: exit 0, 311 tests
- `cargo check -p nucleus-node --bins --tests` on Linux (OrbStack)

## Found by

The cross-pod noninterference audit (Phase X-0), which sequences live-surface
review ahead of modelling precisely because a lookup keyed on the wrong thing is
a likelier defect than a flaw in the label lattice. It was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UA8kchV3eadjGv6BmJXfqm