### PR TITLE
Lockdown: filter server-side, and give gRPC the caller identity it was missing

### DIFF
--- a/crates/nucleus-node/src/lockdown.rs
+++ b/crates/nucleus-node/src/lockdown.rs
@@ -1,0 +1,126 @@
+//! Who a lockdown command is allowed to reach.
+//!
+//! Its own module because `main.rs` carries a line ratchet and anything added
+//! must be paid for by something taken out -- and because the fail-open rule
+//! below is the one place in this subsystem that deliberately inverts the
+//! project's fail-closed default, which is easier to find here than buried
+//! among request handlers.
+
+use uuid::Uuid;
+
+/// Forward broadcast lockdown commands to one watcher's stream, filtered.
+///
+/// Lives beside `reaches` rather than in the gRPC handler so the decision and
+/// the rule it applies are read together. Every proxy used to receive every
+/// command and filter locally, which put pod A's uuid and the operator's
+/// free-text reason into every other pod's VM -- the same mistake as returning
+/// a full pod list and refusing individually, since the information has already
+/// crossed by the time the check runs.
+pub(crate) fn spawn_filtered_forwarder(
+    mut rx: tokio::sync::broadcast::Receiver<crate::proto::LockdownCommand>,
+    tx: tokio::sync::mpsc::Sender<Result<crate::proto::LockdownCommand, tonic::Status>>,
+    watcher: Option<Uuid>,
+) {
+    tokio::spawn(async move {
+        while let Ok(cmd) = rx.recv().await {
+            if !reaches(&cmd.scope, watcher) {
+                continue;
+            }
+            if tx.send(Ok(cmd)).await.is_err() {
+                break; // client disconnected
+            }
+        }
+    });
+}
+
+/// Should a lockdown command scoped `scope` reach a watcher that is `watcher`?
+///
+/// # The direction of the doubt is deliberately opposite to the rest of this arc
+///
+/// Everything else here fails CLOSED: when the node cannot establish something,
+/// it withholds. This fails OPEN, and on purpose. Lockdown is a *safety* control
+/// — an operator halting a workload — so the cost of over-delivering is that a
+/// pod learns another pod was locked down, while the cost of under-delivering is
+/// that a pod the operator meant to stop keeps running. Those are not
+/// comparable, and confidentiality does not get to win that trade.
+///
+/// So anything unresolvable is delivered: an unidentified watcher, an
+/// unparseable id, a label selector, an unrecognised scope form. What this
+/// removes is the case that is both resolvable and was leaking —
+/// `pod:<uuid>` reaching pods that are not that uuid.
+///
+/// Label selectors are still broadcast. The node holds the PodSpecs and could
+/// evaluate them properly — which would also fix the proxy applying label
+/// lockdowns it cannot evaluate and so over-applies — but that is a behaviour
+/// change to the lockdown semantics rather than to who hears about them, and it
+/// belongs in its own change.
+pub(crate) fn reaches(scope: &str, watcher: Option<Uuid>) -> bool {
+    let Some(watcher) = watcher else {
+        return true;
+    };
+    if scope.is_empty() || scope == "all" {
+        return true;
+    }
+    match scope.strip_prefix("pod:") {
+        Some(id) => match Uuid::parse_str(id) {
+            Ok(target) => target == watcher,
+            // Malformed scope: deliver. See above — a lockdown nobody can parse
+            // must not become a lockdown nobody receives.
+            Err(_) => true,
+        },
+        None => true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::reaches as lockdown_reaches;
+    use uuid::Uuid;
+
+    fn a() -> Uuid {
+        Uuid::parse_str("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa").unwrap()
+    }
+    fn b() -> Uuid {
+        Uuid::parse_str("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb").unwrap()
+    }
+
+    /// **The disclosure this closes.** A lockdown aimed at pod A no longer
+    /// reaches pod B, so B's VM never receives A's uuid or the operator's
+    /// free-text reason.
+    #[test]
+    fn a_pod_scoped_lockdown_does_not_reach_other_pods() {
+        assert!(!lockdown_reaches(&format!("pod:{}", a()), Some(b())));
+    }
+
+    /// And it does still reach its target, or the control would be broken
+    /// rather than narrowed.
+    #[test]
+    fn a_pod_scoped_lockdown_reaches_its_target() {
+        assert!(lockdown_reaches(&format!("pod:{}", a()), Some(a())));
+    }
+
+    /// A node-wide lockdown reaches everyone. Nothing about scoping may weaken
+    /// the operator's blunt instrument.
+    #[test]
+    fn an_all_scoped_lockdown_reaches_everyone() {
+        assert!(lockdown_reaches("all", Some(b())));
+        assert!(lockdown_reaches("", Some(b())));
+    }
+
+    /// **The fail-OPEN legs**, stated as tests because they are the deliberate
+    /// exception to this arc's fail-closed rule. Under-delivering a lockdown
+    /// leaves a pod running that an operator meant to stop; over-delivering only
+    /// discloses that some pod was locked down. Those costs are not comparable.
+    #[test]
+    fn anything_unresolvable_is_still_delivered() {
+        // No proved identity: cannot decide, so deliver.
+        assert!(lockdown_reaches(&format!("pod:{}", a()), None));
+        // Label selectors: the node could evaluate these but does not yet.
+        assert!(lockdown_reaches("label:tier=prod", Some(b())));
+        // Malformed target: a lockdown nobody can parse must not become a
+        // lockdown nobody receives.
+        assert!(lockdown_reaches("pod:not-a-uuid", Some(b())));
+        // Unrecognised scope form.
+        assert!(lockdown_reaches("something-new", Some(b())));
+    }
+}

--- a/crates/nucleus-node/src/main.rs
+++ b/crates/nucleus-node/src/main.rs
@@ -33,6 +33,7 @@ mod auth;
 mod firecracker_config;
 mod grpc_tls;
 mod identity;
+mod lockdown;
 mod oidc;
 mod pod_api;
 mod pod_caller_identity;
@@ -3811,19 +3812,19 @@ impl NodeService for GrpcService {
             auth::Operation::CancelPod,
         )?;
 
+        // WHICH pod is watching; an unidentified watcher is unchanged.
+        let watcher = pod_caller_identity::identify_from_metadata(
+            self.state.caller_secret.as_ref(),
+            request.metadata(),
+        )
+        .ok();
+
         let mut ack_stream = request.into_inner();
         let mut rx = self.state.lockdown_tx.subscribe();
 
         let (tx, grpc_rx) = tokio::sync::mpsc::channel(16);
 
-        // Forwarder: broadcast → gRPC response stream
-        tokio::spawn(async move {
-            while let Ok(cmd) = rx.recv().await {
-                if tx.send(Ok(cmd)).await.is_err() {
-                    break; // client disconnected
-                }
-            }
-        });
+        lockdown::spawn_filtered_forwarder(rx, tx, watcher);
 
         // ACK consumer: log acknowledgements from the tool-proxy
         tokio::spawn(async move {

--- a/crates/nucleus-node/src/main.rs
+++ b/crates/nucleus-node/src/main.rs
@@ -3820,7 +3820,9 @@ impl NodeService for GrpcService {
         .ok();
 
         let mut ack_stream = request.into_inner();
-        let mut rx = self.state.lockdown_tx.subscribe();
+        // `rx` is moved into the forwarder (which owns the `recv` loop and takes
+        // `mut` internally), so it needs no `mut` here.
+        let rx = self.state.lockdown_tx.subscribe();
 
         let (tx, grpc_rx) = tokio::sync::mpsc::channel(16);
 

--- a/crates/nucleus-node/src/pod_caller_identity.rs
+++ b/crates/nucleus-node/src/pod_caller_identity.rs
@@ -122,6 +122,38 @@ pub(crate) fn identify_caller(
 /// nothing), so this cannot change a verdict. What it DOES change is that a
 /// caller CLAIMING to be a pod and failing to prove it becomes visible instead
 /// of indistinguishable from every other request.
+/// Identify the calling pod from gRPC request metadata.
+///
+/// The same two headers as the HTTP surface, read off `MetadataMap` instead of
+/// `HeaderMap`. Sharing `identify_caller` rather than re-deriving means the two
+/// transports cannot disagree about who a caller is.
+pub(crate) fn identify_from_metadata(
+    node_secret: &[u8],
+    md: &tonic::metadata::MetadataMap,
+) -> Result<Uuid, CallerError> {
+    let get = |name: &str| md.get(name).and_then(|v| v.to_str().ok());
+    let caller = identify_caller(
+        node_secret,
+        get(nucleus_client::HEADER_POD_ID),
+        get(nucleus_client::HEADER_POD_TOKEN),
+    );
+    report_identification(&caller);
+    caller
+}
+
+/// Log what the identification concluded. Shared so the two transports report
+/// the same way; an "unidentified over gRPC but identified over HTTP" split
+/// would be invisible if each logged its own way.
+fn report_identification(caller: &Result<Uuid, CallerError>) {
+    match caller {
+        Ok(pod_id) => tracing::debug!(%pod_id, "identified the calling pod"),
+        Err(CallerError::Absent) => {}
+        Err(CallerError::Invalid) => {
+            tracing::warn!("a request claimed a pod identity it could not prove");
+        }
+    }
+}
+
 pub(crate) fn identify_from_headers(
     node_secret: &[u8],
     headers: &axum::http::HeaderMap,
@@ -132,16 +164,9 @@ pub(crate) fn identify_from_headers(
         header(nucleus_client::HEADER_POD_ID),
         header(nucleus_client::HEADER_POD_TOKEN),
     );
-    match &caller {
-        Ok(pod_id) => tracing::debug!(%pod_id, "identified the calling pod"),
-        Err(CallerError::Absent) => {}
-        Err(CallerError::Invalid) => {
-            // Something claimed to be a pod and could not prove it. Not refused —
-            // refusing would change behaviour for a caller that is currently
-            // accepted — but it is the one case worth seeing.
-            tracing::warn!("a request claimed a pod identity it could not prove");
-        }
-    }
+    // Not refused — refusing would change behaviour for a caller that is
+    // currently accepted — but a failed claim is the one case worth seeing.
+    report_identification(&caller);
     caller
 }
 


### PR DESCRIPTION
> Stacked on #2196. Closes #2200.

## The disclosure

`NodeState.lockdown_tx` is a `broadcast::Sender`. The node sent **one command to
every subscribed proxy** and each proxy decided locally whether it applied. So
locking down pod A delivered pod A's uuid, the operator's free-text `reason`, and
the `operator_id` into **every other pod's VM**.

Client-side filtering of a broadcast is the same mistake as returning the full
pod list and refusing individually: the information has already crossed by the
time the check runs.

The node could not do better before it could tell its proxies apart. It can now.

## gRPC learns the caller

`identify_from_metadata` reads the same two headers off tonic's `MetadataMap`
that the HTTP middleware reads off `HeaderMap`. Both route through the same
`identify_caller` and the same reporter, so the two transports cannot disagree
about who a caller is — and an "identified over HTTP, unidentified over gRPC"
split cannot hide in differently-worded log lines.

That closes the gRPC identity gap #2196 documented as its known residual.

## The doubt runs the other way here, on purpose

Everything else in this arc fails **closed**. `lockdown::reaches` fails **open**.

Lockdown is a *safety* control. Over-delivering costs a pod learning that some
pod was locked down. Under-delivering leaves a pod running that an operator meant
to stop. Those are not comparable, and confidentiality does not get to win that
trade.

So all of these are still delivered:

| Case | Why |
| --- | --- |
| unidentified watcher | cannot decide, so do not withhold |
| `label:<selector>` | the node does not evaluate selectors yet |
| `pod:not-a-uuid` | a lockdown nobody can parse must not become one nobody receives |
| unrecognised scope form | same |

What is removed is the single case that was both **resolvable and leaking**:
`pod:<uuid>` reaching pods that are not that uuid.

The fail-open legs are **tests, not comments**, because a deliberate exception to
a project-wide rule should be visible to whoever later tries to "tidy" it into
consistency.

## Deliberately not in scope

Label selectors stay broadcast. The node holds the PodSpecs and could evaluate
them properly — which would *also* fix the proxy over-applying label lockdowns it
has no label information to evaluate — but that changes lockdown **semantics**
rather than who hears about them. Separate change, separate blast radius.

## Verification

- Perturbing `lockdown::reaches` to accept everything fails **exactly one** test —
  the disclosure one — and no others.
- `cargo test -p nucleus-node --bins`: 314 tests, exit 0
- `cargo clippy --bins --tests`: exit 0
- `cargo check --bins --tests` on Linux (OrbStack): exit 0
- Line ratchet: the added code would have broken it by 89 lines, so
  `lockdown.rs` is its own module — which is also a better home for the one
  fail-open rule in this subsystem than the middle of a request handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UA8kchV3eadjGv6BmJXfqm