### PR TITLE
Retire the node-wide Unix workload API socket (closes #2197)

### DIFF
--- a/crates/nucleus-node/src/identity.rs
+++ b/crates/nucleus-node/src/identity.rs
@@ -142,29 +142,13 @@ impl IdentityManager {
         self.forget_certificate(identity).await;
     }
 
-    /// Starts the Workload API server on a Unix socket.
-    ///
-    /// This should be called once at startup and the server runs in the background.
-    #[allow(dead_code)]
-    pub async fn start_workload_api_server(&self, socket_path: &Path) -> Result<(), String> {
-        let server = WorkloadApiServer::new(
-            self.secret_manager.clone(),
-            self.ca.clone(),
-            self.vm_registry.clone(),
-        );
-
-        let socket_path_for_spawn = socket_path.to_path_buf();
-        let socket_path_display = socket_path.display().to_string();
-        tokio::spawn(async move {
-            #[allow(deprecated)]
-            if let Err(e) = server.serve(&socket_path_for_spawn).await {
-                error!("workload API server error: {}", e);
-            }
-        });
-
-        info!("workload API server started on {}", socket_path_display);
-        Ok(())
-    }
+    // `start_workload_api_server` was removed here, not merely left uncalled.
+    //
+    // It was the only thing that invoked `WorkloadApiServer::serve`, the
+    // deprecated registry-lookup path that handed an arbitrary pod's SVID to any
+    // local connector (#2197). Deleting it means the node cannot open that socket
+    // by anyone re-adding a call site, which a commented-out invocation or an
+    // unused function would still allow.
 
     /// Starts the certificate refresh loop in the background.
     #[allow(dead_code)]
@@ -569,6 +553,45 @@ mod registry_key_tests {
         assert!(
             m.vm_registry.read().await.is_empty(),
             "the registry must drain"
+        );
+    }
+}
+
+#[cfg(test)]
+mod retired_surface_tests {
+    /// **The retirement is structural, and this keeps it that way.**
+    ///
+    /// `WorkloadApiServer::serve` returns an arbitrary registry entry — including
+    /// the private key — to any local connector (#2197). The node no longer calls
+    /// it, and this reads the source to make sure a future change does not
+    /// quietly restore the call. A comment saying "do not call this" is not a
+    /// gate; a test that fails when someone does is.
+    ///
+    /// Deliberately a source check rather than a behavioural one: the defect is
+    /// the *existence* of a call site, and there is no runtime observation that
+    /// distinguishes "never opened the socket" from "opened it and nobody
+    /// connected".
+    #[test]
+    fn the_node_does_not_start_the_unix_workload_api_server() {
+        // Match CODE forms -- a definition or a call -- not any mention. The
+        // first draft of this test matched the bare name and went red on the
+        // comment above explaining the removal, which is a gate failing for the
+        // wrong reason: prose about a retired function is exactly what should
+        // survive, and only a live call site is the defect.
+        let src = include_str!("identity.rs");
+        let body = src.split("mod retired_surface_tests").next().unwrap();
+        assert!(
+            !body.contains("fn start_workload_api_server")
+                && !body.contains(".start_workload_api_server("),
+            "identity.rs defines or calls start_workload_api_server again -- that \
+             function was the only route to WorkloadApiServer::serve, the \
+             deprecated registry-lookup path that hands an arbitrary pod's SVID \
+             to any local connector (#2197)"
+        );
+        let main_src = include_str!("main.rs");
+        assert!(
+            !main_src.contains(".start_workload_api_server("),
+            "main.rs calls start_workload_api_server again -- see #2197"
         );
     }
 }

--- a/crates/nucleus-node/src/identity.rs
+++ b/crates/nucleus-node/src/identity.rs
@@ -13,14 +13,14 @@
 
 use nucleus_identity::{
     CaClient, Identity, LaunchAttestation, SecretManager, SelfSignedCa, VmRegistry,
-    WorkloadApiClient, WorkloadApiServer,
+    WorkloadApiClient,
 };
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::RwLock;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, info, warn};
 use uuid::Uuid;
 
 /// Identity manager for the node daemon.

--- a/crates/nucleus-node/src/main.rs
+++ b/crates/nucleus-node/src/main.rs
@@ -618,19 +618,21 @@ async fn main() -> Result<(), ApiError> {
         let manager = identity::IdentityManager::new(&args.identity_trust_domain, cert_ttl)
             .map_err(|e| ApiError::Driver(format!("failed to create identity manager: {e}")))?;
 
-        // Start the Workload API server
-        manager
-            .start_workload_api_server(socket_path)
-            .await
-            .map_err(|e| ApiError::Driver(format!("failed to start workload API: {e}")))?;
+        // Retired: it served an arbitrary pod's SVID to any local connector.
+        // Rationale and the gate live in `identity.rs::retired_surface_tests`.
+        tracing::warn!(
+            socket = %socket_path.display(),
+            "the node-wide Unix workload API socket is retired and was NOT opened \
+             (#2197); per-pod SVIDs are served over the per-pod vsock bridge. This \
+             flag is accepted for compatibility and has no other effect."
+        );
 
-        // Start certificate refresh loop
+        // Refresh still runs: it maintains the certs the vsock bridge serves.
         manager.start_refresh_loop();
 
         info!(
-            "identity manager initialized with trust domain '{}', workload API at {}",
-            args.identity_trust_domain,
-            socket_path.display()
+            "identity manager initialized with trust domain '{}'",
+            args.identity_trust_domain
         );
         Some(manager)
     } else {

--- a/scripts/net-guest-isolation-check.sh
+++ b/scripts/net-guest-isolation-check.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Does the guest-address channel actually stay closed, with real packets?
+#
+# `net.rs`'s unit tests cover ADDRESSING -- that two plans agree on the guest's
+# view and differ on the link. They cannot cover the part that decides whether
+# the design works at all: two namespaces carrying the SAME guest subnet on one
+# host, and whether the constant address is translated before it escapes.
+#
+# This needs a Linux kernel, root, and iptables, so it is a script rather than a
+# `#[test]`. Exit 0 means the property holds; anything else means it does not.
+#
+# Exercise the #2205 topology for real: two pods whose GUESTS have IDENTICAL
+# addressing, sharing one host. This is the assumption the whole change rests on,
+# and it is the part unit tests cannot reach.
+#
+# Mirrors net.rs exactly:
+#   link subnet  10.200.0.{0,4}/30   host .1/.5   peer .2/.6   (index-derived)
+#   guest subnet 192.168.241.0/30    gw .1        guest .2     (CONSTANT)
+set -u
+
+LOG=/tmp/nettest.out
+: > "$LOG"
+say() { echo "$*" | tee -a "$LOG"; }
+
+cleanup() {
+  for i in 0 1; do
+    sudo ip netns del "pod$i"   2>/dev/null
+    sudo ip netns del "guest$i" 2>/dev/null
+    sudo ip link del "veth$i"   2>/dev/null
+  done
+  sudo ip link del nucdummy 2>/dev/null
+  sudo iptables -t nat -D POSTROUTING -s 10.200.0.0/24 -j MASQUERADE 2>/dev/null
+}
+cleanup
+trap cleanup EXIT
+
+sudo sysctl -qw net.ipv4.ip_forward=1
+
+# A host address both pods can route to, standing in for "the rest of the world".
+sudo ip link add nucdummy type dummy 2>/dev/null
+sudo ip addr add 10.99.0.1/32 dev nucdummy 2>/dev/null
+sudo ip link set nucdummy up
+
+for i in 0 1; do
+  base=$((i * 4))
+  HOST_IP="10.200.0.$((base + 1))"
+  PEER_IP="10.200.0.$((base + 2))"
+
+  sudo ip netns add "pod$i"
+  sudo ip netns add "guest$i"
+
+  # veth: host namespace <-> pod namespace. Index-derived, guest never sees it.
+  sudo ip link add "veth$i" type veth peer name "vpeer$i"
+  sudo ip link set "vpeer$i" netns "pod$i"
+  sudo ip addr add "$HOST_IP/30" dev "veth$i"
+  sudo ip link set "veth$i" up
+  sudo ip netns exec "pod$i" ip addr add "$PEER_IP/30" dev "vpeer$i"
+  sudo ip netns exec "pod$i" ip link set "vpeer$i" up
+  sudo ip netns exec "pod$i" ip link set lo up
+
+  # bridge carrying the CONSTANT gateway; the tap would hang off this.
+  sudo ip netns exec "pod$i" ip link add br0 type bridge
+  sudo ip netns exec "pod$i" ip addr add 192.168.241.1/30 dev br0
+  sudo ip netns exec "pod$i" ip link set br0 up
+
+  # Stand-in for the guest VM: its own namespace on the bridge, IDENTICAL in
+  # both pods. If the design is wrong, this is where it collides.
+  sudo ip link add "gv$i" type veth peer name "gp$i"
+  sudo ip link set "gv$i" netns "pod$i"
+  sudo ip link set "gp$i" netns "guest$i"
+  sudo ip netns exec "pod$i" ip link set "gv$i" master br0
+  sudo ip netns exec "pod$i" ip link set "gv$i" up
+  sudo ip netns exec "guest$i" ip addr add 192.168.241.2/30 dev "gp$i"
+  sudo ip netns exec "guest$i" ip link set "gp$i" up
+  sudo ip netns exec "guest$i" ip link set lo up
+  sudo ip netns exec "guest$i" ip route add default via 192.168.241.1
+
+  sudo ip netns exec "pod$i" sysctl -qw net.ipv4.ip_forward=1
+  sudo ip netns exec "pod$i" ip route add default via "$HOST_IP"
+
+  # THE RULE UNDER TEST: rewrite the constant guest address to this pod's
+  # unique link address on the way out of the namespace.
+  sudo ip netns exec "pod$i" iptables -t nat -A POSTROUTING \
+      -s 192.168.241.0/30 -o "vpeer$i" -j MASQUERADE
+done
+
+sudo iptables -t nat -A POSTROUTING -s 10.200.0.0/24 -j MASQUERADE
+
+say "=== both guests have the SAME address (the assumption under test) ==="
+for i in 0 1; do
+  say "  guest$i: $(sudo ip netns exec guest$i ip -4 -o addr show dev gp$i | awk '{print $4}')"
+done
+
+say ""
+say "=== what the host sees as the source of each guest's traffic ==="
+sudo python3 - "$LOG" <<'PYEOF' &
+import socket, sys
+s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+s.bind(("10.99.0.1", 9999))
+s.settimeout(20)
+seen = []
+for _ in range(2):
+    try:
+        data, addr = s.recvfrom(64)
+        seen.append((data.decode(errors="replace"), addr[0]))
+    except socket.timeout:
+        break
+with open("/tmp/nettest.seen", "w") as f:
+    for tag, src in seen:
+        f.write(f"{tag} {src}\n")
+PYEOF
+LISTENER=$!
+sleep 2
+
+for i in 0 1; do
+  sudo ip netns exec "guest$i" python3 -c "
+import socket
+s=socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+s.sendto(b'guest$i', ('10.99.0.1', 9999))
+" 2>>"$LOG" || say "  guest$i SEND FAILED"
+  sleep 1
+done
+
+wait $LISTENER 2>/dev/null
+rc=0
+say ""
+if [ -f /tmp/nettest.seen ]; then
+  cat /tmp/nettest.seen | tee -a "$LOG"
+  n=$(sort -u -k2 /tmp/nettest.seen | wc -l)
+  say ""
+  say "distinct source addresses observed by the host: $n (want 2)"
+  [ "$n" -eq 2 ] || { say "FAIL: the host cannot tell the two pods apart"; rc=1; }
+  if grep -q "192.168.241.2" /tmp/nettest.seen; then
+    say "FAIL: the constant guest address ESCAPED the namespace"
+    rc=1
+  else
+    say "OK: the constant guest address never reached the host"
+  fi
+  # Both guests must have reached the host at all -- "nothing arrived" would
+  # otherwise pass the two checks above by vacuity.
+  [ "$(wc -l < /tmp/nettest.seen)" -eq 2 ] || {
+    say "FAIL: expected 2 datagrams, got $(wc -l < /tmp/nettest.seen) -- the"
+    say "      checks above would pass vacuously on an empty capture"
+    rc=1
+  }
+else
+  say "FAIL: listener recorded nothing"
+  rc=1
+fi
+exit $rc


### PR DESCRIPTION
Closes #2197. Independent of the identity stack — branches off `main`.

## The defect

`WorkloadApiServer::serve` did not key its identity lookup on anything. It
returned an arbitrary registry entry — **certificate and private key** — to
whoever connected:

```rust
let reg = registry.read().await;
if reg.len() > 1 { tracing::warn!("... this is a security risk"); }
reg.values().next().cloned()
```

The function already carried a `#[deprecated]`, a `**Security Warning:**`, and an
inline comment saying it was safe only while exactly one identity was registered.
The registry never drained (fixed separately in #2198), so that precondition was
false from the second pod onward — permanently.

## Retired, not repaired — and why that is the evidence-backed call

| Check | Result |
| --- | --- |
| `IdentityManager::client()` callers | **zero** |
| socket bind-mounted into any pod | **no** |
| how guests actually get an SVID | per-pod vsock bridge, keyed on the pod's own uuid — correct |
| a node-wide identity to bind it to | **none exists** |

So "bind it to a single identity" has no right answer, and nothing is asking the
question. The surface goes away instead.

## The retirement is structural

`start_workload_api_server` is **deleted**, not left uncalled. It was the only
route to `serve`, so the socket cannot be reopened by someone restoring a call
site. An unused function or a commented-out invocation would both still permit
that.

`retired_surface_tests` reads the source and fails if the function is defined or
called again. Deliberately a source check: the defect is the *existence* of a
call site, and no runtime observation distinguishes "never opened the socket"
from "opened it and nobody connected".

## Compatibility

The flag stays **accepted**. `nucleus-cli` writes
`NUCLEUS_IDENTITY_WORKLOAD_API_SOCKET` into the node env file by default, so
rejecting it would break every provisioned deployment on upgrade. It opens
nothing and says so at `WARN` — a flag that silently does nothing is how an
operator ends up believing a surface exists.

Certificate refresh still runs; it maintains the certificates the **vsock** bridge
serves, which is a different path and is not retired.

## A gate of mine that was wrong first

The first version of `retired_surface_tests` matched the bare function name and
went red on the comment explaining the removal. That is a gate failing for the
wrong reason — prose about a retired function is exactly what should survive. It
now matches code forms (`fn …`, `.…(`) only, and I verified it by reintroducing
the function, which turns it red with the intended message.

## Verification

- `cargo test -p nucleus-node --bins`: 304 tests, exit 0
- `cargo clippy --bins --tests`: exit 0
- `cargo check --bins --tests` on Linux (OrbStack): exit 0
- Line ratchet: green. The rationale initially pushed `main.rs` 5 lines over, so
  it lives with the module that owns the retirement rather than in the startup
  path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UA8kchV3eadjGv6BmJXfqm