### PR TITLE
North Star: make the status table a machine-checked ledger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,24 @@ jobs:
         shell: bash
         run: scripts/check-declassify-token-dormant.sh
 
+  # The North Star doc's status table is the project's public claim of what is
+  # PROVED, TESTED, and NOT-YET. It drifted once: a row claimed "tested on the
+  # live path" for the declassification token while the dormancy gate above —
+  # in this same file — asserted that path has no production caller. This gate
+  # makes the table a ledger: every row covers a verbatim clause of the
+  # sentence, resolves an evidence handle, names its falsifier, and may not
+  # contradict any in-tree dormancy declaration. Row and NOT-YET counts are
+  # pinned, so deletions and demotions are visible events.
+  north-star-ledger:
+    name: The North Star status table cannot outrun its wiring
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+      - name: Every status row is earned, evidenced, and uncontradicted
+        shell: bash
+        run: scripts/check-north-star-ledger.sh
+
   # Every gate above is a claim that something is checked. This checks the claim.
   #
   # It needs full history and a clean tree because it PERTURBS real files and

--- a/docs/north-star.md
+++ b/docs/north-star.md
@@ -81,6 +81,10 @@ status is a visible event, not an edit.
 | C7 | "a theorem about the code that ships" | TESTED | `.github/workflows/aeneas-ifc-scoped.yml`, `crates/nucleus-ifc-kernel/src/extracted/identity.rs` | `.github/workflows/aeneas-ifc-scoped.yml` |
 | C8 | "re-checked on every change" | NOT-YET | `.github/workflows/aeneas-ifc-scoped.yml` | — |
 | C9 | "verify from the outside" | TESTED | `crates/nucleus-identity/src/attestation.rs`, `crates/nucleus-node/src/posture.rs#admit_posture` | `.github/workflows/quickstart-boot.yml` |
+*The clause fragments quote the sentence above, whose exclusions travel with
+them: the claim covers explicit flows only, excluding timing, cache, and other
+microarchitectural channels, and excluding availability and resource-contention
+channels.*
 
 What each status means, and what it deliberately does not:
 

--- a/docs/north-star.md
+++ b/docs/north-star.md
@@ -62,15 +62,69 @@ which is what this sentence now does.
 #### Status — what is proved, what is tested, what is not yet
 
 Keeping these apart is a house rule, because a north star written in the present
-tense is how a claim outruns its wiring.
+tense is how a claim outruns its wiring. This table is a **machine-checked
+ledger** (`scripts/check-north-star-ledger.sh`, run on every change): each row
+names a clause of the sentence verbatim, carries exactly one status from
+{PROVED, TESTED, NOT-YET}, an evidence handle CI can dereference, and the gate
+that reds if the status regresses. The row count and the NOT-YET count are
+pinned (`scripts/north-star-ledger-ratchet.txt`) — deleting a row or demoting a
+status is a visible event, not an edit.
 
-| Part of the claim | Status |
-| --- | --- |
-| Single-pod: workload cannot learn its own mediated secrets | **Proved** — the confidentiality/integrity/channel oracles and their faithfulness mirrors against the Rust extraction |
-| Adversary-controlled inputs do not change the released set | **Proved** — the two-run noninterference result over the reference pod machine |
-| Declassification is single-use and not adversary-steerable | **Proved** in the model; **tested** on the live path (spent-token set keyed on the Ed25519 signature) |
-| Remote verification that the pod is the modelled artifact | **Tested** — attestation and the delivery-conformance boot gate |
-| **Cross-pod**: one pod cannot learn another's secrets | **Not yet.** No artifact in the corpus mentions a second pod; the host is outside every model |
+| # | Clause (verbatim from the sentence) | Status | Evidence | Falsified by |
+| --- | --- | --- | --- | --- |
+| C1 | "learn the secrets Nucleus holds on its behalf" | PROVED | `crates/portcullis-core/lean/IdentityMaterialNoninterferenceExtracted.lean#identity_material_never_reaches_the_workload`, `crates/portcullis-core/lean/ChannelAdmissionExtracted.lean#no_channel_delivers_secret_to_the_workload` | `.github/workflows/aeneas-ifc-scoped.yml` |
+| C2 | "nor those of any other pod" | NOT-YET | `docs/cross-pod-view.md` | — |
+| C3 | "nor influence which of them get released" | PROVED | `crates/portcullis-core/lean/PodMachineSpike.lean#noninterference` | `.github/workflows/portcullis-core-proven-lean.yml` |
+| C4 | "a governor deliberately released with a single-use token" | NOT-YET | `crates/portcullis/src/kernel/declassify_authority.rs#apply_declassification_token`, `scripts/check-declassify-token-dormant.sh` | — |
+| C5 | "cannot steer which value that is" | NOT-YET | `crates/portcullis-core/lean/DeclassifyProofs.lean#sink_outside_allowlist_denied`, `crates/portcullis-core/src/declassify.rs#allows_sink` | — |
+| C6 | "every mediated channel" | NOT-YET | `crates/portcullis-core/lean/ChannelAdmissionExtracted.lean#no_channel_delivers_secret_to_the_workload`, `docs/architecture/mediated-set.md` | — |
+| C7 | "a theorem about the code that ships" | TESTED | `.github/workflows/aeneas-ifc-scoped.yml`, `crates/nucleus-ifc-kernel/src/extracted/identity.rs` | `.github/workflows/aeneas-ifc-scoped.yml` |
+| C8 | "re-checked on every change" | NOT-YET | `.github/workflows/aeneas-ifc-scoped.yml` | — |
+| C9 | "verify from the outside" | TESTED | `crates/nucleus-identity/src/attestation.rs`, `crates/nucleus-node/src/posture.rs#admit_posture` | `.github/workflows/quickstart-boot.yml` |
+
+What each status means, and what it deliberately does not:
+
+- **C1 (PROVED)** — over the six modelled child-inheritance channels (Env,
+  Argv, Cwd, Stdio, ExtraFd, Uid), the 11-kind × 3-principal delivery table,
+  Aeneas-extracted from the shipping enforcement predicates, `sorry`-free,
+  axiom-audited. Residuals, named: the `_ => OrdinaryData` classifier
+  fallthrough is trusted, not proved; **mounts are not a modelled channel**.
+- **C2 (NOT-YET)** — no artifact in the corpus mentions a second pod; the host
+  is outside every model. `docs/cross-pod-view.md` is the design.
+- **C3 (PROVED)** — the two-run noninterference theorem over the reference pod
+  machine, whose step relation calls the extracted delivery oracle. Scope is
+  honest: a coarse monitor LTS with an opaque workload, labelled Phase 0.
+- **C4 (NOT-YET)** — the one-shot ledger (spent-token set keyed on the Ed25519
+  signature, burn-on-success-only, fail-closed without trusted keys) is
+  implemented and unit-tested, but the whole token path is **dormant and
+  CI-gated to stay dormant** (`scripts/check-declassify-token-dormant.sh`),
+  because the sink-scope restriction is not enforced on the live path. No
+  production caller mints or applies a token; "governor" names the trusted-key
+  registry, not a modelled principal.
+- **C5 (NOT-YET)** — `sink_outside_allowlist_denied` is proved in a
+  hand-written model of a restriction the shipping code does not implement:
+  `allows_sink()` has no non-test callers, and `FlowGraph::apply_token` raises
+  the target node's label globally.
+- **C6 (NOT-YET)** — the six child-inheritance channels are proved total (the
+  quantification is over the channel enum, so a new channel forces a match
+  arm); the effect/API set is enumerated with named exclusions in
+  `docs/architecture/mediated-set.md` with its lint reporting-only; the
+  transport channels (vsock, pod-dir socket, in-guest HTTP, netns, DNS, node
+  gRPC) have no unified inventory. "Every" is not yet earned.
+- **C7 (TESTED)** — the theorems are about a scalar-only extracted restatement
+  of the enforcement predicates, re-extracted from the current Rust on every
+  proof-workflow run and bound to production by exhaustive parity tests and
+  the boot-gate conformance replay. The surrounding kernel, classifier, and
+  spawn path are covered by tests and lints, not by the theorem.
+- **C8 (NOT-YET)** — the proof workflow is path-filtered; a change to the
+  trusted classifier or the spawn path does not re-run it, and nothing checks
+  that the call sites of the extracted predicates still exist.
+- **C9 (TESTED)** — DICE-format measurements (kernel, rootfs, PodSpec+policy)
+  embedded in the pod's SVID; `admit_posture` verifies a claimed
+  `posture@digest` against a self-measured digest, fail-closed,
+  perturbation-tested. The registry binding a posture NAME to the FM-5 proof
+  is operator-asserted — no signed provenance binds artifact digest to
+  theorem set yet.
 
 The cross-pod leg is the open one, and it is deliberately sequenced audit-first:
 a lookup keyed on something a guest can forge is a far likelier defect than a

--- a/scripts/check-gates-can-fail.sh
+++ b/scripts/check-gates-can-fail.sh
@@ -227,6 +227,28 @@ perturb_trusted_base() {
     append_line "$1" 'gate_of_gates_fake_component pinned_by:definitely_not_a_real_test_anywhere'
 }
 
+# The EXACT defect the North Star ledger gate was built for: the status row
+# that claimed "tested on the live path" for the declassification token while
+# the dormancy gate asserted that path has no production caller. Not a
+# synthetic perturbation — this row is quoted verbatim from the table as it
+# stood when the gate was written, so a gate that greens on it has stopped
+# detecting its own founding defect.
+perturb_ledger_restore_false_row() {
+    local f="$1"
+    local legacy='| Declassification is single-use and not adversary-steerable | **Proved** in the model; **tested** on the live path (spent-token set keyed on the Ed25519 signature) |'
+    if ! awk -v legacy="$legacy" '
+        $0 ~ /^\| C4 \|/ { print legacy; hit = 1; next }
+        { print }
+        END { exit hit ? 0 : 1 }
+    ' "$f" > "$f.gate-tmp"; then
+        rm -f "$f.gate-tmp"
+        echo "  ERROR: no '| C4 |' row found in $f;"
+        echo "         the ledger's C4 row moved and this perturbation must be updated."
+        return 1
+    fi
+    mv "$f.gate-tmp" "$f"
+}
+
 echo "Probing whether each gate fails on its own subject..."
 echo
 
@@ -276,6 +298,9 @@ probe check-lean-libs-built.sh "" crates/portcullis-core/lean/lakefile.lean \
 probe check-declassify-token-dormant.sh "" crates/portcullis/src/kernel.rs \
       "a production caller of the dormant declassify-token path" \
       perturb_declassify_production_caller
+probe check-north-star-ledger.sh "" docs/north-star.md \
+      "the original overclaiming declassification status row restored" \
+      perturb_ledger_restore_false_row
 
 # ── Uncovered, listed rather than omitted ─────────────────────────────────
 #

--- a/scripts/check-north-star-ledger.sh
+++ b/scripts/check-north-star-ledger.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# North Star claim ledger — the status table cannot outrun its wiring.
+#
+# WHY THIS EXISTS
+#
+# docs/north-star.md carries the flagship confidentiality sentence and, below
+# it, a table saying which parts are PROVED, which are TESTED, and which are
+# NOT-YET. That table is the project's single most load-bearing honesty
+# artifact — and until this gate, nothing checked it. It drifted in the exact
+# way the doc's own preamble warns about: a row claimed "tested on the live
+# path" for the declassification token while scripts/check-declassify-token-
+# dormant.sh — running in the same CI — asserted that path has no production
+# caller at all, and the row's "not adversary-steerable" leg was proved only in
+# a hand model of a sink restriction the shipping code does not implement.
+#
+# So: make the table a ledger. Every row names the clause of the sentence it
+# covers (verbatim, so a row cannot cover a clause the sentence does not make),
+# carries a status from a closed vocabulary, an evidence handle that must
+# resolve, and the gate that would catch the status regressing. The checker
+# fails on: a dangling handle, an uncovered clause, a deleted row (the clause
+# count is pinned — carrying the population, a count that can silently shrink
+# rewards deletion), and — the finding that motivated all of this — a row
+# claiming live-path status for a subject that another in-tree gate declares
+# dormant. Two independent declarations, compared; not a tautology.
+#
+# Usage: scripts/check-north-star-ledger.sh
+set -uo pipefail
+cd "$(git rev-parse --show-toplevel 2>/dev/null || echo .)"
+
+DOC="docs/north-star.md"
+RATCHET="scripts/north-star-ledger-ratchet.txt"
+STATUS_HEADING='#### Status'
+
+failures=0
+fail() {
+    echo "  FAIL  $1"
+    failures=$((failures + 1))
+}
+
+[[ -f "$DOC" ]] || { echo "ERROR: $DOC not found"; exit 1; }
+[[ -f "$RATCHET" ]] || { echo "ERROR: $RATCHET not found — the ledger has no pinned population"; exit 1; }
+
+# ── The sentence ────────────────────────────────────────────────────────────
+# The flagship claim, extracted verbatim so clause fragments below are checked
+# against what the sentence actually says, not against what a row wishes it said.
+sentence="$(awk '/^\*\*Whatever an agent workload does/{grab=1} grab{printf "%s ", $0} grab&&/about\.\*\*$/{exit}' "$DOC" | tr -s '[:space:]' ' ')"
+
+# Non-vacuity: if the anchor moved, everything below would "pass" against an
+# empty string. Refuse instead.
+if [[ -z "$sentence" || "$sentence" != *"single-use token"* ]]; then
+    echo "ERROR: could not extract the North Star sentence from $DOC"
+    echo "       (anchor '**Whatever an agent workload does' … 'about.**' moved?)"
+    exit 1
+fi
+
+# ── The table ───────────────────────────────────────────────────────────────
+# Everything between the Status heading and the next heading.
+section="$(awk -v h="$STATUS_HEADING" 'index($0,h)==1{grab=1; next} grab && /^#{2,4} /{exit} grab{print}' "$DOC")"
+
+# All table rows (any line starting with '|'), minus the header and separator.
+all_rows="$(printf '%s\n' "$section" | grep -E '^\|' | grep -vE '^\|[ -]*-' | grep -viE '^\| *#? *\| *clause|^\| *part of the claim')"
+if [[ -z "$all_rows" ]]; then
+    echo "ERROR: no table rows found under '$STATUS_HEADING' in $DOC"
+    exit 1
+fi
+
+# ── Ratchet: the pinned population ──────────────────────────────────────────
+# Both directions, like the cmdline five-keys ratchet: a clause vanishing from
+# the ledger and a NOT-YET quietly appearing are both events a human must
+# acknowledge by editing this file in the same change.
+clauses_pinned="$(grep -E '^CLAUSES=' "$RATCHET" | cut -d= -f2)"
+not_yet_pinned="$(grep -E '^NOT_YET=' "$RATCHET" | cut -d= -f2)"
+if [[ -z "$clauses_pinned" || -z "$not_yet_pinned" ]]; then
+    echo "ERROR: $RATCHET must pin CLAUSES=<n> and NOT_YET=<n>"
+    exit 1
+fi
+
+# ── Per-row checks ──────────────────────────────────────────────────────────
+declare -a seen_ids=()
+valid_rows=0
+not_yet_count=0
+
+while IFS= read -r row; do
+    # Strict ledger rows: | C<n> | "<clause fragment>" | STATUS | evidence | falsified-by |
+    if [[ ! "$row" =~ ^\|[[:space:]]*C[0-9]+[[:space:]]*\| ]]; then
+        fail "row not in ledger format (no clause ID): ${row:0:100}"
+        continue
+    fi
+
+    id="$(echo "$row"  | awk -F'|' '{gsub(/^ +| +$/,"",$2); print $2}')"
+    clause="$(echo "$row" | awk -F'|' '{gsub(/^ +| +$/,"",$3); print $3}')"
+    status="$(echo "$row" | awk -F'|' '{gsub(/^ +| +$/,"",$4); print $4}')"
+    evidence="$(echo "$row" | awk -F'|' '{gsub(/^ +| +$/,"",$5); print $5}')"
+    falsifier="$(echo "$row" | awk -F'|' '{gsub(/^ +| +$/,"",$6); print $6}')"
+
+    # Unique IDs — a duplicated row is double-counted coverage.
+    for s in "${seen_ids[@]:-}"; do
+        [[ "$s" == "$id" ]] && fail "$id: duplicate clause ID"
+    done
+    seen_ids+=("$id")
+
+    # The clause fragment must be verbatim in the sentence. Strip the quotes
+    # and any markdown emphasis, collapse whitespace, then substring-match.
+    frag="$(echo "$clause" | sed -e 's/^"//' -e 's/"$//' -e 's/\*\*//g' | tr -s '[:space:]' ' ' | sed -e 's/^ *//' -e 's/ *$//')"
+    if [[ -z "$frag" ]]; then
+        fail "$id: empty clause fragment"
+    elif [[ "$sentence" != *"$frag"* ]]; then
+        fail "$id: clause fragment is not verbatim in the sentence: \"$frag\""
+        continue
+    fi
+
+    # Closed status vocabulary. "Proved in the model; tested on the live path"
+    # is two claims in one cell, which is how the last drift hid.
+    case "$status" in
+        PROVED|TESTED) : ;;
+        NOT-YET) not_yet_count=$((not_yet_count + 1)) ;;
+        *) fail "$id: status '$status' not in {PROVED, TESTED, NOT-YET}"; continue ;;
+    esac
+
+    # Evidence handles must resolve: `path` (file exists) or `path#symbol`
+    # (file exists AND names the symbol). An evidence cell nothing can
+    # dereference is prose wearing a column.
+    if [[ -z "$evidence" ]]; then
+        fail "$id: empty evidence cell"
+    fi
+    while IFS= read -r h; do
+        [[ -z "$h" ]] && continue
+        path="${h%%#*}"
+        sym=""
+        [[ "$h" == *"#"* ]] && sym="${h#*#}"
+        if [[ ! -f "$path" ]]; then
+            fail "$id: evidence handle dangles — no such file: $path"
+        elif [[ -n "$sym" ]] && ! grep -qF "$sym" "$path"; then
+            fail "$id: evidence handle dangles — '$sym' not found in $path"
+        fi
+    done < <(echo "$evidence" | grep -oE '`[^`]+`' | tr -d '`')
+
+    # The falsifier must exist, and a gate script must actually be wired into
+    # a workflow — an uncalled falsifier falsifies nothing. NOT-YET rows may
+    # carry '—': there is no earned status to regress.
+    f="$(echo "$falsifier" | grep -oE '`[^`]+`' | head -1 | tr -d '\`')"
+    if [[ -z "$f" || "$f" == "—" ]]; then
+        if [[ "$status" != "NOT-YET" ]]; then
+            fail "$id: status $status but no falsifying gate named"
+        fi
+    else
+        if [[ ! -f "$f" ]]; then
+            fail "$id: falsifier does not exist: $f"
+        elif [[ "$f" == scripts/*.sh ]] && ! grep -rql "$f" .github/workflows/ 2>/dev/null; then
+            fail "$id: falsifier $f is not invoked by any workflow"
+        fi
+    fi
+
+    valid_rows=$((valid_rows + 1))
+done <<< "$all_rows"
+
+# ── Coverage: every clause of the sentence has a row ────────────────────────
+if [[ "$valid_rows" -lt "$clauses_pinned" ]]; then
+    fail "clause coverage: $valid_rows valid ledger row(s), but the sentence has $clauses_pinned pinned clauses — the missing rows are the claim's uncovered clauses"
+elif [[ "$valid_rows" -gt "$clauses_pinned" ]]; then
+    fail "clause coverage: $valid_rows valid rows exceed the $clauses_pinned pinned clauses — raise CLAUSES in $RATCHET in the same change (it may only grow)"
+fi
+
+# ── NOT-YET ratchet ─────────────────────────────────────────────────────────
+if [[ "$not_yet_count" -gt "$not_yet_pinned" ]]; then
+    fail "NOT-YET count rose: $not_yet_count row(s), ratchet pins $not_yet_pinned — a status was demoted; if that is real, raise the pin in $RATCHET and say why in the change"
+elif [[ "$not_yet_count" -lt "$not_yet_pinned" ]]; then
+    fail "NOT-YET count fell to $not_yet_count but $RATCHET still pins $not_yet_pinned — lower the pin in the same change so the promotion is on the record"
+fi
+
+# ── Cross-declaration: live-path claims vs dormancy gates ───────────────────
+# A scripts/check-*dormant*.sh gate is an in-tree declaration that some path
+# has no production caller. No ledger row may simultaneously claim that
+# subject is exercised on the live path. This compares two independent
+# declarations that run in the same CI; when they disagree, one of them is
+# lying, and the gate refuses to let the table be the one that wins.
+for dg in scripts/check-*dormant*.sh; do
+    [[ -f "$dg" ]] || continue
+    # Subject word derived from the gate's own filename: check-<subject>-…-dormant.sh
+    # Stemmed (trailing 'y' dropped) so "declassify" also matches
+    # "declassification" — the noun is how the table talks about it.
+    subject="$(basename "$dg" | sed -e 's/^check-//' -e 's/-dormant.*$//' | cut -d- -f1)"
+    subject="${subject%y}"
+    [[ -z "$subject" ]] && continue
+
+    # (a) Prose form: any row about this subject claiming "tested … live path".
+    while IFS= read -r row; do
+        if echo "$row" | grep -qi "$subject" \
+           && echo "$row" | grep -qi 'tested' \
+           && echo "$row" | grep -qiE 'live[ -]path'; then
+            fail "cross-declaration: this row claims live-path testing for '$subject' while $dg asserts that path is DORMANT (no production caller):"
+            echo "        ${row:0:160}"
+        fi
+    done <<< "$all_rows"
+
+    # (b) Structured form: a PROVED/TESTED row whose evidence cites one of the
+    # dormancy gate's own DEFINING_FILES — status earned on a path the gate
+    # says nothing reaches.
+    defining="$(sed -n '/^DEFINING_FILES=(/,/^)/p' "$dg" | grep -oE '"[^"]+"' | tr -d '"')"
+    while IFS= read -r row; do
+        [[ "$row" =~ ^\|[[:space:]]*C[0-9]+[[:space:]]*\| ]] || continue
+        st="$(echo "$row" | awk -F'|' '{gsub(/^ +| +$/,"",$4); print $4}')"
+        [[ "$st" == "PROVED" || "$st" == "TESTED" ]] || continue
+        ev="$(echo "$row" | awk -F'|' '{gsub(/^ +| +$/,"",$5); print $5}')"
+        while IFS= read -r df; do
+            [[ -z "$df" ]] && continue
+            if echo "$ev" | grep -qF "$df"; then
+                fail "cross-declaration: a $st row cites $df as evidence, but $dg declares that file's path dormant"
+            fi
+        done <<< "$defining"
+    done <<< "$all_rows"
+done
+
+echo
+if [[ "$failures" -gt 0 ]]; then
+    echo "FAILED: $failures problem(s) in the North Star ledger."
+    echo "The status table is the claim's public face; a row it cannot back is"
+    echo "the exact overclaim the doc's own preamble warns about."
+    exit 1
+fi
+echo "OK: every ledger row covers a verbatim clause, resolves its evidence,"
+echo "names its falsifier, and contradicts no in-tree dormancy declaration."
+echo "($valid_rows clauses, $not_yet_count NOT-YET — both pinned by $RATCHET)"

--- a/scripts/north-star-ledger-ratchet.txt
+++ b/scripts/north-star-ledger-ratchet.txt
@@ -1,0 +1,11 @@
+# North Star ledger population pin — read by scripts/check-north-star-ledger.sh.
+#
+# Both directions, deliberately (the cmdline five-keys ratchet pattern):
+#   CLAUSES may only GROW — a clause leaving the ledger means either the
+#     sentence was weakened (Brandon's call, made in the open) or a row was
+#     deleted to dodge a red, which is the exact move a shrinkable count pays.
+#   NOT_YET may only SHRINK — and the pin must be lowered in the same change
+#     that earns the promotion, so every promotion is on the record with its
+#     evidence handle beside it.
+CLAUSES=9
+NOT_YET=5


### PR DESCRIPTION
## What

`docs/north-star.md`'s status table — the public claim of what is PROVED / TESTED / NOT-YET about the confidentiality sentence — becomes a machine-checked ledger, gated by new `scripts/check-north-star-ledger.sh` on every PR.

Each row now: names its clause **verbatim** (checked against the sentence, so a row cannot cover a clause the sentence doesn't make) · carries exactly one status from {PROVED, TESTED, NOT-YET} · cites an evidence handle CI dereferences (`path` or `path#symbol`) · names the gate that reds if the status regresses. Clause count and NOT-YET count are pinned both directions in `scripts/north-star-ledger-ratchet.txt`, so a deleted row or a quiet demotion is a visible event.

## Why now

The table had drifted in exactly the way the doc's own preamble warns about, and nothing checked it:

1. **Coverage**: 5 rows for a sentence with 9 checkable clauses — the four omitted (influence-on-release, steering, every-channel, re-checked-on-every-change) are the four hardest, and one of them is currently a NO.
2. **Contradiction**: row 3 claimed the declassification token is *"tested on the live path"* while `scripts/check-declassify-token-dormant.sh` — running in the same CI — asserts that path has **no production caller**, and the "not adversary-steerable" leg is proved only in a hand model of a sink restriction the shipping code does not implement (`allows_sink` has zero non-test callers).

The checker fails on both findings on the pre-fix tree (outputs recorded below), and the corrected table now says what is actually true: **9 clauses, 5 NOT-YET** (cross-pod, single-use token path, non-steerability, every-channel, re-checked-on-every-change), each with the honest note of what exists and what is missing.

## Gate discipline

- **Cross-declaration check** compares two independent in-tree declarations (a ledger row vs any `check-*-dormant.sh` gate's subject and `DEFINING_FILES`) — not a tautology.
- **gates-can-fail probe**: the perturbation is the *original defect* — the pre-fix row 3 restored verbatim — asserting red at that row citing the dormancy gate, then green on restore. All 11 probes pass; `UNCOVERED_CEILING` stays 2; 0 unaccounted.

<details><summary>Recorded red on the pre-fix tree (exit 1)</summary>

```
FAIL  clause coverage: 0 valid ledger row(s), but the sentence has 9 pinned clauses ...
FAIL  cross-declaration: this row claims live-path testing for 'declassif' while
      scripts/check-declassify-token-dormant.sh asserts that path is DORMANT (no production caller):
      | Declassification is single-use and not adversary-steerable | **Proved** in the model; **tested** on the live path ...
(+ 5 legacy rows named, NOT-YET pin mismatch — 8 problems total)
```
</details>

## After merge

The job `north-star-ledger` (name: *"The North Star status table cannot outrun its wiring"*) should be added to the required status checks on `main`, alongside the dormancy gate it cross-checks. Flagging rather than assuming — it's a branch-protection edit.

This is increment **A0** of the North Star arc (plan: robust one-shot declassification → CI trigger totality → cross-pod → attestation binding); every later status promotion in that arc must now fall out of this gate rather than be hand-asserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UA8kchV3eadjGv6BmJXfqm