### PR TITLE
Declassify: enforce the sink scope — release is a per-operation view, not a label rewrite

### DIFF
--- a/crates/nucleus-ifc-kernel/src/extracted/declassify.rs
+++ b/crates/nucleus-ifc-kernel/src/extracted/declassify.rs
@@ -1,0 +1,270 @@
+//! Sink scope + one-shot burn — the slice the **declassification** theorems are
+//! proven over after Charon→Aeneas→Lean extraction.
+//!
+//! # What this is
+//!
+//! A `DeclassificationToken` (portcullis-core `declassify.rs`) is signed over a
+//! target node, a label rule, and a list of `allowed_sinks`. Two decisions give
+//! the token its meaning, and both are restated here `String`-free so their
+//! reachable dependency subgraph stays inside Aeneas's supported subset:
+//!
+//! * **Sink scope** — a declassified node contributes its *released*
+//!   confidentiality only to operations inside the token's signed sink mask;
+//!   every other operation keeps seeing the *strict* label. [`mask_admits`] is
+//!   the bit test, [`effective_conf`] the shadow pick, [`declass_release_ok`]
+//!   the composed release decision at a sink ceiling (composing [`cflows_to`]
+//!   exactly as `extracted::identity` composes it).
+//! * **One-shot burn** — a token authorizes at most one application, forever.
+//!   [`declass_step`] is the 2-state ABSORBING machine: applying burns, a
+//!   refusal preserves, and a burned token admits nothing ever again. This is
+//!   deliberately NOT the mediation machine (`extracted::mediation::med_step`),
+//!   whose `Discharge` re-arms the authority — re-arming is exactly what a
+//!   one-shot token must never do.
+//!
+//! # Why the mask is a `u16`
+//!
+//! `Operation` is `#[repr(u8)]` with 13 variants whose discriminants are pinned
+//! 0..=12 by compile-time asserts (ifc_ops.rs). `1 << discriminant` therefore
+//! fits a `u16` with three bits to spare, and bit arithmetic extracts cleanly
+//! (precedent: `extracted::egress`'s netmask). The mask is derived from the
+//! signed `allowed_sinks` list by `DeclassificationToken::sink_mask()`, and the
+//! parity of that derivation with [`mask_admits`] is checked exhaustively over
+//! the whole 2^13 × 13 domain in portcullis-core — for a finite domain an
+//! exhaustive check is a complete equivalence proof, not a sample.
+//!
+//! # Faithfulness
+//!
+//! [`MedOperation`]'s discriminants ARE the production `Operation`
+//! discriminants (bound in `extracted::mediation`). The graph-level binding —
+//! that `FlowGraph` verdicts actually route through these functions — is the
+//! pointwise binding test in `portcullis/tests/declassify_scope.rs`, the same
+//! layer FM-5 uses for its spawn binding.
+
+use super::ifc_confidentiality::{cflows_to, ConfLevel};
+use super::mediation::{opcode, MedOperation};
+
+/// Bit test: does the signed sink mask admit operation `op`?
+///
+/// An empty mask (0) admits nothing — a token with no allowed sinks is inert,
+/// matching `allowed_sinks: Empty = no sinks allowed` in the token's docs.
+pub fn mask_admits(mask: u16, op: MedOperation) -> bool {
+    let bit: u16 = 1 << opcode(op);
+    (mask & bit) != 0
+}
+
+/// The shadow pick: the confidentiality a declassified node contributes when
+/// operation `op` consumes it.
+///
+/// Inside the mask the node contributes its released level; outside it, the
+/// strict (pre-declassification) level. The node's stored label is never
+/// mutated — release is a per-operation VIEW, which is what makes a token
+/// scoped to one sink unable to clear its node for any other.
+pub fn effective_conf(
+    strict: ConfLevel,
+    released: ConfLevel,
+    mask: u16,
+    op: MedOperation,
+) -> ConfLevel {
+    if mask_admits(mask, op) {
+        released
+    } else {
+        strict
+    }
+}
+
+/// The composed release decision: may data with strict level `strict`,
+/// declassified to `released` for the sinks in `mask`, flow to a sink for
+/// operation `op` whose confidentiality ceiling is `sink_cap`?
+pub fn declass_release_ok(
+    strict: ConfLevel,
+    released: ConfLevel,
+    mask: u16,
+    op: MedOperation,
+    sink_cap: ConfLevel,
+) -> bool {
+    cflows_to(effective_conf(strict, released, mask, op), sink_cap)
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// The one-shot machine — the slice the burn theorems are proven over
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Whether the token's single authorization has been spent.
+///
+/// Flat struct rather than an enum for the same reason as
+/// `extracted::mediation::MedState`: no discriminated union on the proof's
+/// critical path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DeclassState {
+    /// Has the token been applied? Absorbing: once true, forever true.
+    pub burned: bool,
+}
+
+/// The fresh state: authorization unspent.
+pub fn declass_fresh() -> DeclassState {
+    DeclassState { burned: false }
+}
+
+/// The result of one application attempt: whether it applied, and the state
+/// after.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DeclassStepResult {
+    /// Did the token apply?
+    pub ok: bool,
+    /// The state afterwards. A refusal leaves the state unchanged — an
+    /// expired or precondition-unmet token did not exercise its authority
+    /// and stays usable once the obstacle clears (`runD` semantics: spend on
+    /// release, never on refusal).
+    pub next: DeclassState,
+}
+
+/// One application attempt.
+///
+/// * Applies iff the token is unburned AND its signature verified AND the
+///   rule's precondition matched — and applying burns it, forever. There is
+///   no re-arming action: unlike the mediation machine's `Discharge`, nothing
+///   in this machine can take `burned` back to false.
+/// * Any refusal (bad signature, unmet precondition, or already burned)
+///   leaves the state exactly as it was.
+pub fn declass_step(state: DeclassState, sig_ok: bool, precond_ok: bool) -> DeclassStepResult {
+    if !state.burned && sig_ok && precond_ok {
+        DeclassStepResult {
+            ok: true,
+            next: DeclassState { burned: true },
+        }
+    } else {
+        DeclassStepResult {
+            ok: false,
+            next: state,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ALL_OPS: [MedOperation; 13] = [
+        MedOperation::ReadFiles,
+        MedOperation::WriteFiles,
+        MedOperation::EditFiles,
+        MedOperation::RunBash,
+        MedOperation::GlobSearch,
+        MedOperation::GrepSearch,
+        MedOperation::WebSearch,
+        MedOperation::WebFetch,
+        MedOperation::GitCommit,
+        MedOperation::GitPush,
+        MedOperation::CreatePr,
+        MedOperation::ManagePods,
+        MedOperation::SpawnAgent,
+    ];
+
+    /// Every operation is admitted exactly by the masks with its bit set —
+    /// the full 2^13 × 13 domain, so this is an equivalence check of the bit
+    /// test against its specification, not a sample.
+    #[test]
+    fn mask_admits_is_exactly_the_bit_test() {
+        for mask in 0u16..(1 << 13) {
+            for op in ALL_OPS {
+                let expected = mask & (1u16 << opcode(op)) != 0;
+                assert_eq!(
+                    mask_admits(mask, op),
+                    expected,
+                    "mask_admits diverged for mask={mask:#06x}, op={op:?}"
+                );
+            }
+        }
+    }
+
+    /// The empty mask admits nothing; the full mask admits everything.
+    #[test]
+    fn empty_mask_is_inert_and_full_mask_is_total() {
+        for op in ALL_OPS {
+            assert!(!mask_admits(0, op), "empty mask admitted {op:?}");
+            assert!(
+                mask_admits((1 << 13) - 1, op),
+                "full mask refused {op:?}"
+            );
+        }
+    }
+
+    /// Outside the mask the strict level governs: a Secret node declassified
+    /// to Public for one sink stays Secret for every other.
+    #[test]
+    fn outside_the_mask_the_strict_level_governs() {
+        for granted in ALL_OPS {
+            let mask = 1u16 << opcode(granted);
+            for attempted in ALL_OPS {
+                let eff = effective_conf(ConfLevel::Secret, ConfLevel::Public, mask, attempted);
+                if opcode(attempted) == opcode(granted) {
+                    assert_eq!(eff, ConfLevel::Public);
+                } else {
+                    assert_eq!(
+                        eff,
+                        ConfLevel::Secret,
+                        "release leaked from {granted:?} to {attempted:?}"
+                    );
+                }
+            }
+        }
+    }
+
+    /// The composed decision: released-Secret data reaches a Public-ceiling
+    /// sink only through an in-mask operation.
+    #[test]
+    fn release_reaches_a_low_sink_only_in_mask() {
+        for granted in ALL_OPS {
+            let mask = 1u16 << opcode(granted);
+            for attempted in ALL_OPS {
+                let ok = declass_release_ok(
+                    ConfLevel::Secret,
+                    ConfLevel::Public,
+                    mask,
+                    attempted,
+                    ConfLevel::Public,
+                );
+                assert_eq!(
+                    ok,
+                    opcode(attempted) == opcode(granted),
+                    "declass_release_ok wrong for granted={granted:?}, attempted={attempted:?}"
+                );
+            }
+        }
+    }
+
+    /// One-shot: applying burns; a second apply is refused; the machine is
+    /// absorbing — no input sequence unburns it.
+    #[test]
+    fn apply_burns_and_nothing_unburns() {
+        let first = declass_step(declass_fresh(), true, true);
+        assert!(first.ok);
+        assert!(first.next.burned);
+
+        let second = declass_step(first.next, true, true);
+        assert!(!second.ok, "a burned token applied again");
+        assert!(second.next.burned);
+
+        // Exhaust the input alphabet from the burned state: still burned.
+        for sig_ok in [false, true] {
+            for precond_ok in [false, true] {
+                let r = declass_step(first.next, sig_ok, precond_ok);
+                assert!(!r.ok);
+                assert!(r.next.burned, "the machine un-burned itself");
+            }
+        }
+    }
+
+    /// A refusal preserves the token: bad signature or unmet precondition
+    /// leaves it fresh and a later valid apply still succeeds.
+    #[test]
+    fn refusal_preserves_the_token() {
+        for (sig_ok, precond_ok) in [(false, false), (false, true), (true, false)] {
+            let refused = declass_step(declass_fresh(), sig_ok, precond_ok);
+            assert!(!refused.ok);
+            assert!(!refused.next.burned, "a refusal burned the token");
+            let later = declass_step(refused.next, true, true);
+            assert!(later.ok, "the token was not usable after a refusal");
+        }
+    }
+}

--- a/crates/nucleus-ifc-kernel/src/extracted/declassify.rs
+++ b/crates/nucleus-ifc-kernel/src/extracted/declassify.rs
@@ -40,8 +40,8 @@
 //! pointwise binding test in `portcullis/tests/declassify_scope.rs`, the same
 //! layer FM-5 uses for its spawn binding.
 
-use super::ifc_confidentiality::{cflows_to, ConfLevel};
-use super::mediation::{opcode, MedOperation};
+use super::ifc_confidentiality::{ConfLevel, cflows_to};
+use super::mediation::{MedOperation, opcode};
 
 /// Bit test: does the signed sink mask admit operation `op`?
 ///
@@ -182,10 +182,7 @@ mod tests {
     fn empty_mask_is_inert_and_full_mask_is_total() {
         for op in ALL_OPS {
             assert!(!mask_admits(0, op), "empty mask admitted {op:?}");
-            assert!(
-                mask_admits((1 << 13) - 1, op),
-                "full mask refused {op:?}"
-            );
+            assert!(mask_admits((1 << 13) - 1, op), "full mask refused {op:?}");
         }
     }
 

--- a/crates/nucleus-ifc-kernel/src/extracted/mediation.rs
+++ b/crates/nucleus-ifc-kernel/src/extracted/mediation.rs
@@ -195,6 +195,30 @@ pub struct StepResult {
     pub next: MedState,
 }
 
+/// Production `Operation` → mirror, total by exhaustive match.
+///
+/// This is the production-side bridge (NOT an extraction root): callers that
+/// route a live decision through an extracted function use this to name the
+/// operation in the mirror's vocabulary. Totality by `match` means a new
+/// `Operation` variant fails compilation here rather than mapping silently.
+pub fn med_of(op: crate::Operation) -> MedOperation {
+    match op {
+        crate::Operation::ReadFiles => MedOperation::ReadFiles,
+        crate::Operation::WriteFiles => MedOperation::WriteFiles,
+        crate::Operation::EditFiles => MedOperation::EditFiles,
+        crate::Operation::RunBash => MedOperation::RunBash,
+        crate::Operation::GlobSearch => MedOperation::GlobSearch,
+        crate::Operation::GrepSearch => MedOperation::GrepSearch,
+        crate::Operation::WebSearch => MedOperation::WebSearch,
+        crate::Operation::WebFetch => MedOperation::WebFetch,
+        crate::Operation::GitCommit => MedOperation::GitCommit,
+        crate::Operation::GitPush => MedOperation::GitPush,
+        crate::Operation::CreatePr => MedOperation::CreatePr,
+        crate::Operation::ManagePods => MedOperation::ManagePods,
+        crate::Operation::SpawnAgent => MedOperation::SpawnAgent,
+    }
+}
+
 /// The idle state: nothing held.
 pub fn med_idle() -> MedState {
     MedState {

--- a/crates/nucleus-ifc-kernel/src/extracted/mod.rs
+++ b/crates/nucleus-ifc-kernel/src/extracted/mod.rs
@@ -19,6 +19,7 @@
 pub mod capability_quantale;
 pub mod channel;
 pub mod credential;
+pub mod declassify;
 pub mod egress;
 pub mod identity;
 pub mod ifc_confidentiality;

--- a/crates/portcullis-core/src/declassify.rs
+++ b/crates/portcullis-core/src/declassify.rs
@@ -126,33 +126,32 @@ impl DeclassificationRule {
 ///
 /// - **Artifact-scoped**: Only applies to `target_node_id`, not the whole session
 /// - **Time-bounded**: Expires at `valid_until` (unix timestamp)
-/// - **Sink-restricted (DECLARED, NOT ENFORCED — see below)**: the token names
-///   the sinks the declassified data may reach in `allowed_sinks`
+/// - **Sink-restricted**: the declassified node contributes its released label
+///   only to operations in `allowed_sinks`; every other operation keeps seeing
+///   the strict label (enforced in `FlowGraph` via a per-node declass scope —
+///   the node's stored label is never mutated)
 /// - **Signed**: Ed25519 signature over the token's canonical bytes
 /// - **Auditable**: Justification string included for receipt chain
 ///
-/// # The sink restriction is not enforced on the live path
+/// # How the sink restriction is enforced
 ///
-/// `allowed_sinks` is signed (it is count-prefixed into [`Self::canonical_bytes`]
-/// under the `nucleus-declass-v2` domain tag), proven in Lean
-/// (`DeclassifyProofs.lean`, `sink_outside_allowlist_denied`), and queryable via
-/// [`Self::allows_sink`] — but **nothing consults it when a token is applied**.
-/// `FlowGraph::apply_token` raises the target node's label GLOBALLY via
-/// `modify_label`, so a token scoped `allowed_sinks = [WebSearch]` in fact clears
-/// its node for `GitPush` as well. `allows_sink` has no non-test callers.
+/// `allowed_sinks` is signed (count-prefixed into [`Self::canonical_bytes`]
+/// under the `nucleus-declass-v2` domain tag) and compiled to a bit mask by
+/// [`Self::sink_mask`]. `FlowGraph::apply_token` records a
+/// `DeclassScope { released_label, sink_mask }` for the target node instead of
+/// modifying its label; flow verdicts are computed over the *effective* label —
+/// released inside the mask, strict outside — via the extracted decision
+/// functions in `nucleus-ifc-kernel::extracted::declassify`
+/// (`mask_admits` / `effective_conf` / `declass_release_ok`), whose parity with
+/// [`Self::allows_sink`] is checked exhaustively over the whole 2^13 × 13
+/// domain below. A token scoped `allowed_sinks = [WebSearch]` therefore clears
+/// its node for `WebSearch` and nothing else.
 ///
-/// This is currently unreachable rather than exploitable: the signed-token path
-/// is dormant — every `DeclassificationToken::new` and every `apply_token` call
-/// site in the tree is test code — and `scripts/check-declassify-token-dormant.sh`
-/// fails CI if that stops being true, because the deferral is only safe while it
-/// is. Enforcing the scope means making `gather_labels` operation-aware (a
-/// declassified parent contributes its raised label only for operations in the
-/// token's scope, else its pre-declassify label), which needs a per-node
-/// declassify-scope and original-label field.
-///
-/// The bullet above says DECLARED rather than restricted for that reason: this
-/// doc comment previously read "Declassified data may only reach `allowed_sinks`",
-/// which is a claim the code does not keep.
+/// The signed-token path is still dormant — every `DeclassificationToken::new`
+/// and every `apply_token` call site in the tree is test code, and
+/// `scripts/check-declassify-token-dormant.sh` fails CI if that stops being
+/// true. The gate remains until the production caller and its end-to-end tests
+/// land in the same change.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DeclassificationToken {
     /// The flow graph node this token applies to.
@@ -181,6 +180,10 @@ pub enum TokenApplyResult {
     },
     /// Token's target node was not found in the graph.
     NodeNotFound,
+    /// The target node already carries a declassification scope. A node is
+    /// declassified at most once; a second token — including a differently
+    /// scoped one — is refused, and (like every refusal) does not burn.
+    AlreadyDeclassified,
     /// Token has expired (now > valid_until).
     Expired { valid_until: u64, now: u64 },
     /// The underlying rule's precondition didn't match the node's label.
@@ -226,6 +229,21 @@ impl DeclassificationToken {
     /// Check if a sink operation is allowed by this token.
     pub fn allows_sink(&self, op: Operation) -> bool {
         self.allowed_sinks.contains(&op)
+    }
+
+    /// The signed sink list compiled to a bit mask (`1 << discriminant` per
+    /// operation) — the form the `FlowGraph`'s declass-scope machinery and
+    /// the extracted decision functions
+    /// (`nucleus-ifc-kernel::extracted::declassify::mask_admits`) consume.
+    ///
+    /// Equivalence with [`Self::allows_sink`] is checked exhaustively over
+    /// the whole 2^13 × 13 domain in this file's tests.
+    pub fn sink_mask(&self) -> u16 {
+        let mut mask = 0u16;
+        for op in &self.allowed_sinks {
+            mask |= 1u16 << (*op as u8);
+        }
+        mask
     }
 
     /// The canonical bytes for signing.
@@ -938,5 +956,76 @@ mod tests {
         rl.check_and_record(110).ok();
         assert_eq!(rl.current_count(120), 2);
         assert_eq!(rl.current_count(200), 0); // both events expired
+    }
+
+    // ── sink_mask ↔ allows_sink ↔ extracted mask_admits parity ─────────
+    //
+    // The FlowGraph consults the extracted bit test over `sink_mask()`; the
+    // token's own API is `allows_sink()` over the signed list. These are two
+    // implementations of one relation, so the check is EXHAUSTIVE over the
+    // whole domain — all 2^13 sink sets × all 13 operations, 106 496 cases.
+    // For a finite domain an exhaustive check is a complete equivalence
+    // proof, not a sample.
+
+    /// Production `Operation` by discriminant — the same order as
+    /// `Operation::ALL`, pinned by ifc_ops.rs's compile-time asserts.
+    #[test]
+    fn sink_mask_and_extracted_mask_admits_match_allows_sink_exhaustively() {
+        use nucleus_ifc_kernel::extracted::declassify::mask_admits;
+        use nucleus_ifc_kernel::extracted::mediation::MedOperation;
+
+        const ALL_MED: [MedOperation; 13] = [
+            MedOperation::ReadFiles,
+            MedOperation::WriteFiles,
+            MedOperation::EditFiles,
+            MedOperation::RunBash,
+            MedOperation::GlobSearch,
+            MedOperation::GrepSearch,
+            MedOperation::WebSearch,
+            MedOperation::WebFetch,
+            MedOperation::GitCommit,
+            MedOperation::GitPush,
+            MedOperation::CreatePr,
+            MedOperation::ManagePods,
+            MedOperation::SpawnAgent,
+        ];
+
+        for mask in 0u16..(1 << 13) {
+            // The sink set this mask denotes.
+            let allowed: Vec<Operation> = Operation::ALL
+                .iter()
+                .copied()
+                .filter(|op| mask & (1u16 << (*op as u8)) != 0)
+                .collect();
+            let token = DeclassificationToken::new(
+                1,
+                DeclassificationRule {
+                    action: DeclassifyAction::LowerConfidentiality {
+                        from: ConfLevel::Secret,
+                        to: ConfLevel::Internal,
+                    },
+                    justification: "parity sweep",
+                },
+                allowed,
+                u64::MAX,
+                "parity sweep".to_string(),
+            );
+
+            // The derivation itself round-trips.
+            assert_eq!(
+                token.sink_mask(),
+                mask,
+                "sink_mask() did not round-trip mask {mask:#06x}"
+            );
+
+            for (i, op) in Operation::ALL.iter().enumerate() {
+                let via_list = token.allows_sink(*op);
+                let via_bits = mask_admits(token.sink_mask(), ALL_MED[i]);
+                assert_eq!(
+                    via_list, via_bits,
+                    "allows_sink and mask_admits diverged: mask={mask:#06x}, op={op:?}"
+                );
+            }
+        }
     }
 }

--- a/crates/portcullis/src/flow_graph.rs
+++ b/crates/portcullis/src/flow_graph.rs
@@ -840,11 +840,7 @@ impl FlowGraph {
     /// empty — an absent scope and a mask-0 scope mean the same thing, and
     /// storing the former as the latter would make "how many nodes carry a
     /// release" unanswerable.
-    fn inherited_scope(
-        &self,
-        parents: &[NodeId],
-        intrinsic: IFCLabel,
-    ) -> Option<DeclassScope> {
+    fn inherited_scope(&self, parents: &[NodeId], intrinsic: IFCLabel) -> Option<DeclassScope> {
         let mut any_scoped = false;
         let mut mask = Self::FULL_SINK_MASK;
         let mut contributions: Vec<IFCLabel> = Vec::with_capacity(parents.len());

--- a/crates/portcullis/src/flow_graph.rs
+++ b/crates/portcullis/src/flow_graph.rs
@@ -327,6 +327,34 @@ pub struct FlowGraph {
     /// is `modify_label_with_token()` which requires a signed
     /// `DeclassificationToken`.
     frozen: BTreeSet<NodeId>,
+    /// Declassification scopes, keyed by node ID.
+    ///
+    /// A scope records that a signed token released this node's data — but
+    /// only for the operations in the token's signed sink mask. The node's
+    /// stored label is NEVER mutated by declassification: every consumer of
+    /// `FlowNode::label` keeps seeing the strict label, and release exists
+    /// only as the per-operation VIEW computed by
+    /// [`effective_label`](Self::effective_label). That is what makes a
+    /// token scoped to one sink unable to clear its node for any other —
+    /// and it is why scopes compose with freezing (#947) instead of
+    /// fighting it: freezing pins labels, and scopes never touch labels.
+    ///
+    /// Stored separately from `FlowNode` for the same reason as
+    /// `field_lineage`: the node struct is `Copy` and most nodes have no
+    /// scope.
+    declass_scopes: HashMap<NodeId, DeclassScope>,
+}
+
+/// A node's declassification scope: the released view and the signed sink
+/// mask it applies to. See [`FlowGraph::effective_label`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DeclassScope {
+    /// The label the node contributes to operations inside the mask.
+    pub released_label: IFCLabel,
+    /// Bit mask over `Operation` discriminants (`1 << op as u8`), derived
+    /// from the token's signed `allowed_sinks` by
+    /// `DeclassificationToken::sink_mask()`. Mask 0 admits nothing.
+    pub sink_mask: u16,
 }
 
 impl FlowGraph {
@@ -341,6 +369,7 @@ impl FlowGraph {
             quarantine_releases: Vec::new(),
             field_lineage: HashMap::new(),
             frozen: BTreeSet::new(),
+            declass_scopes: HashMap::new(),
         }
     }
 
@@ -434,6 +463,51 @@ impl FlowGraph {
         ))
     }
 
+    /// Like [`causal_label`](Self::causal_label), but for a NAMED operation:
+    /// the effective label the action would be judged by, honoring any
+    /// declass scope the parents pass down. Where no scope admits the
+    /// operation, this equals `causal_label` exactly.
+    pub fn causal_label_for(
+        &self,
+        parents: &[NodeId],
+        operation: Operation,
+        now: u64,
+    ) -> Result<IFCLabel, FlowGraphError> {
+        use portcullis_core::extracted::declassify::mask_admits;
+        use portcullis_core::extracted::mediation::med_of;
+        self.validate_parents(parents)?;
+        let intrinsic = intrinsic_label(NodeKind::OutboundAction, now);
+        if let Some(scope) = self.inherited_scope(parents, intrinsic) {
+            if mask_admits(scope.sink_mask, med_of(operation)) {
+                return Ok(scope.released_label);
+            }
+        }
+        Ok(propagate_label(&self.gather_labels(parents), intrinsic))
+    }
+
+    /// [`check_flow`] over a node's EFFECTIVE label: where the node carries
+    /// a declass scope admitting its own operation, the released view
+    /// governs; everywhere else (no scope, out-of-mask operation, or a
+    /// non-action node) the strict stored label does. This is the single
+    /// verdict path — insert-time decisions and receipt-time
+    /// recomputations both come here, so they cannot disagree.
+    fn check_flow_effective(
+        &self,
+        node: &FlowNode,
+        now: u64,
+    ) -> portcullis_core::flow::FlowVerdict {
+        use portcullis_core::extracted::declassify::mask_admits;
+        use portcullis_core::extracted::mediation::med_of;
+        if let (Some(op), Some(scope)) = (node.operation, self.declass_scopes.get(&node.id)) {
+            if mask_admits(scope.sink_mask, med_of(op)) {
+                let mut shadow = *node;
+                shadow.label = scope.released_label;
+                return check_flow(&shadow, now);
+            }
+        }
+        check_flow(node, now)
+    }
+
     /// Insert a data-source observation. NOT flow-checked.
     ///
     /// If any parent is quarantined (directly or via ancestry), the new
@@ -464,8 +538,16 @@ impl FlowGraph {
         // Check if any parent is quarantined (directly or transitively)
         let any_parent_quarantined = parents.iter().any(|&pid| self.is_quarantined(pid));
 
-        let label = propagate_label(&self.gather_labels(parents), intrinsic_label(kind, now));
+        let intrinsic = intrinsic_label(kind, now);
+        let label = propagate_label(&self.gather_labels(parents), intrinsic);
+        // Declass scopes flow to descendants: the released view survives
+        // into the child for exactly the operations every scoped ancestor
+        // granted. The child's STORED label above is the strict join.
+        let scope = self.inherited_scope(parents, intrinsic);
         let id = self.alloc_node(kind, label, parents, None);
+        if let Some(s) = scope {
+            self.declass_scopes.insert(id, s);
+        }
 
         // Propagate quarantine to the new observation node
         if any_parent_quarantined {
@@ -501,10 +583,8 @@ impl FlowGraph {
         // Check if any parent is quarantined (directly or transitively)
         let any_parent_quarantined = parents.iter().any(|&pid| self.is_quarantined(pid));
 
-        let label = propagate_label(
-            &self.gather_labels(parents),
-            intrinsic_label(NodeKind::OutboundAction, now),
-        );
+        let intrinsic = intrinsic_label(NodeKind::OutboundAction, now);
+        let label = propagate_label(&self.gather_labels(parents), intrinsic);
         let sink_class = Some(default_sink_class(operation));
         let node = self.build_node_with_effect(
             NodeKind::OutboundAction,
@@ -514,11 +594,33 @@ impl FlowGraph {
             sink_class,
             effect_kind,
         );
-        let verdict = check_flow(&node, now);
+        // The verdict is computed over the EFFECTIVE label: where a declass
+        // scope inherited from the parents admits this operation, the
+        // released view governs; everywhere else the strict join above
+        // does. The stored node keeps the strict label either way, so
+        // session taint, lineage, and `FlowDecision::label` never launder.
+        // This is the same computation `check_flow_effective` performs from
+        // stored state (the scope recorded below), so a later receipt
+        // recomputation cannot disagree with the decision made here.
+        let scope = self.inherited_scope(parents, intrinsic);
+        let verdict = {
+            use portcullis_core::extracted::declassify::mask_admits;
+            use portcullis_core::extracted::mediation::med_of;
+            let mut verdict_node = node;
+            if let Some(s) = &scope {
+                if mask_admits(s.sink_mask, med_of(operation)) {
+                    verdict_node.label = s.released_label;
+                }
+            }
+            check_flow(&verdict_node, now)
+        };
         self.maybe_compact();
         let id = self.next_id;
         self.nodes.push(Some(node));
         self.next_id += 1;
+        if let Some(s) = scope {
+            self.declass_scopes.insert(id, s);
+        }
 
         // Propagate quarantine to the new action node
         if any_parent_quarantined {
@@ -646,7 +748,7 @@ impl FlowGraph {
         let node = self.get(id)?;
         let ancestry = self.ancestors(id);
         let ancestor_refs: Vec<&FlowNode> = ancestry.ancestors.to_vec();
-        let verdict = check_flow(node, now);
+        let verdict = self.check_flow_effective(node, now);
         let mut receipt = build_receipt(node, &ancestor_refs, verdict, now);
 
         if !ancestry.tombstoned.is_empty() {
@@ -690,6 +792,80 @@ impl FlowGraph {
             .iter()
             .filter_map(|&pid| self.get(pid).map(|n| n.label))
             .collect()
+    }
+
+    // ── Declassification scopes (sink-scoped release views) ───────────
+
+    /// Full mask over the 13 `Operation` discriminants — the scope of a
+    /// parent that has no declass scope (its label applies to every
+    /// operation, so it constrains the child's mask not at all).
+    const FULL_SINK_MASK: u16 = (1 << 13) - 1;
+
+    /// A node's declassification scope, if a signed token released it.
+    pub fn declass_scope(&self, id: NodeId) -> Option<&DeclassScope> {
+        self.declass_scopes.get(&id)
+    }
+
+    /// The label node `id` contributes to operation `op` — the released
+    /// label inside the node's declass mask, the strict stored label
+    /// everywhere else. Routed through the extracted bit test
+    /// (`extracted::declassify::mask_admits`), the same function the Lean
+    /// sink-scope theorems are stated over.
+    pub fn effective_label(&self, id: NodeId, op: Operation) -> Option<IFCLabel> {
+        use portcullis_core::extracted::declassify::mask_admits;
+        use portcullis_core::extracted::mediation::med_of;
+        let node = self.get(id)?;
+        match self.declass_scopes.get(&id) {
+            Some(scope) if mask_admits(scope.sink_mask, med_of(op)) => Some(scope.released_label),
+            _ => Some(node.label),
+        }
+    }
+
+    /// The scope a new node inherits from its parents, if any ancestor was
+    /// declassified.
+    ///
+    /// * `released_label` — the propagated label where each SCOPED parent
+    ///   contributes its released label and every other parent its strict
+    ///   one, joined with the child's intrinsic.
+    /// * `sink_mask` — the AND of the parents' masks (full mask for
+    ///   unscoped parents): a release survives into the child only for
+    ///   operations EVERY scoped ancestor granted. Disjoint parent masks
+    ///   therefore intersect to 0 and the child stays strict — the
+    ///   deliberate sound over-approximation (per-parent precision at the
+    ///   verdict would be sharper; it is not taken, so that the verdict at
+    ///   insert time and any later receipt recomputation go through the one
+    ///   `effective_label` path and cannot disagree).
+    ///
+    /// Returns `None` when no parent is scoped or the intersection is
+    /// empty — an absent scope and a mask-0 scope mean the same thing, and
+    /// storing the former as the latter would make "how many nodes carry a
+    /// release" unanswerable.
+    fn inherited_scope(
+        &self,
+        parents: &[NodeId],
+        intrinsic: IFCLabel,
+    ) -> Option<DeclassScope> {
+        let mut any_scoped = false;
+        let mut mask = Self::FULL_SINK_MASK;
+        let mut contributions: Vec<IFCLabel> = Vec::with_capacity(parents.len());
+        for &pid in parents {
+            let Some(node) = self.get(pid) else { continue };
+            match self.declass_scopes.get(&pid) {
+                Some(scope) => {
+                    any_scoped = true;
+                    mask &= scope.sink_mask;
+                    contributions.push(scope.released_label);
+                }
+                None => contributions.push(node.label),
+            }
+        }
+        if !any_scoped || mask == 0 {
+            return None;
+        }
+        Some(DeclassScope {
+            released_label: propagate_label(&contributions, intrinsic),
+            sink_mask: mask,
+        })
     }
 
     fn build_node(
@@ -821,6 +997,14 @@ impl FlowGraph {
             let idx = *nid as usize;
             idx < self.nodes.len() && self.nodes[idx].is_some()
         });
+
+        // Remove declass scopes for tombstoned nodes: a scope is a VIEW of a
+        // node's label, and a compacted node's label survives only in the
+        // compaction log — strict, which is the conservative direction.
+        self.declass_scopes.retain(|nid, _| {
+            let idx = *nid as usize;
+            idx < self.nodes.len() && self.nodes[idx].is_some()
+        });
     }
 
     /// Read-only access to the compaction audit log.
@@ -848,10 +1032,22 @@ impl FlowGraph {
     /// Validates that:
     /// 1. The target node exists in the graph
     /// 2. The token has not expired
-    /// 3. The underlying rule's precondition matches the node's label
+    /// 3. The node does not already carry a declass scope
+    /// 4. The underlying rule's precondition matches the node's label
     ///
-    /// On success, modifies the node's label and returns the old/new labels.
-    /// The caller is responsible for recording this in the receipt chain.
+    /// On success, records a [`DeclassScope`] for the target node — the
+    /// node's stored label is NOT modified. `Applied::original_label` is the
+    /// strict label (which remains the stored one); `Applied::new_label` is
+    /// the released view that operations inside the token's signed sink mask
+    /// will see. The caller is responsible for recording this in the receipt
+    /// chain.
+    ///
+    /// Because no label is mutated, this path composes with freezing (#947)
+    /// instead of bypassing it — the historical variant of this method
+    /// called `modify_label` and DISCARDED its `Option`, so a frozen target
+    /// silently kept its label while `Applied` was returned. A scope on a
+    /// frozen node is the legitimate declassification #947 set out to
+    /// preserve.
     pub fn apply_token(
         &mut self,
         token: &portcullis_core::declassify::DeclassificationToken,
@@ -873,14 +1069,26 @@ impl FlowGraph {
             None => return TokenApplyResult::NodeNotFound,
         };
 
-        // Apply the underlying rule
+        // A node is declassified at most once. Refusing the second token
+        // (rather than joining or replacing scopes) keeps "which governor
+        // released this, for what" a single answerable fact per node.
+        if self.declass_scopes.contains_key(&token.target_node_id) {
+            return TokenApplyResult::AlreadyDeclassified;
+        }
+
+        // Apply the underlying rule to compute the released VIEW.
         let result = token.rule.apply(node.label);
         if !result.applied {
             return TokenApplyResult::PreconditionUnmet;
         }
 
-        // Modify the node's label
-        self.modify_label(token.target_node_id, result.label);
+        self.declass_scopes.insert(
+            token.target_node_id,
+            DeclassScope {
+                released_label: result.label,
+                sink_mask: token.sink_mask(),
+            },
+        );
         TokenApplyResult::Applied {
             original_label: result.original,
             new_label: result.label,
@@ -933,10 +1141,15 @@ impl FlowGraph {
     ///
     /// The check walks the full causal DAG (BFS), including the node
     /// itself, and collects any nodes with `Adversarial` integrity.
-    /// Denied nodes are skipped (they did not execute). Declassified
-    /// nodes that have been raised to `Untrusted` or above pass the
-    /// check — this is how web content can legitimately reach Execute
-    /// after explicit operator review.
+    /// Denied nodes are skipped (they did not execute).
+    ///
+    /// This walk reads STORED labels, which declassification no longer
+    /// mutates (release is the per-operation view in `declass_scopes`).
+    /// A declassified-but-Adversarial ancestor therefore still fails this
+    /// check — strictly narrower than the historical behavior, where one
+    /// token laundered the node's ancestry for every operation at once.
+    /// An operation-aware ancestry check that honors a scope for in-mask
+    /// operations is deliberately NOT-YET.
     ///
     /// Returns [`TrustAncestryResult::Trusted`] if the chain is clean,
     /// or [`TrustAncestryResult::Untrusted`] with the tainted node IDs.
@@ -1126,7 +1339,7 @@ impl FlowGraph {
         now: u64,
     ) -> Option<QuarantineVerdict> {
         let node = self.get(node_id)?;
-        let underlying = check_flow(node, now);
+        let underlying = self.check_flow_effective(node, now);
         let qa = self.quarantined_ancestors(node_id);
         if qa.is_empty() {
             Some(QuarantineVerdict::Clean(underlying))

--- a/crates/portcullis/src/flow_graph_tests.rs
+++ b/crates/portcullis/src/flow_graph_tests.rs
@@ -472,7 +472,9 @@ fn apply_token_twice_is_refused() {
     ));
     // And the refusal did not widen the original scope.
     assert_eq!(
-        g.effective_label(web, Operation::GitPush).unwrap().integrity,
+        g.effective_label(web, Operation::GitPush)
+            .unwrap()
+            .integrity,
         portcullis_core::IntegLevel::Adversarial
     );
 }
@@ -1326,7 +1328,9 @@ mod apply_token_verified_tests {
             portcullis_core::IntegLevel::Untrusted
         );
         assert_eq!(
-            g.effective_label(web, Operation::GitPush).unwrap().integrity,
+            g.effective_label(web, Operation::GitPush)
+                .unwrap()
+                .integrity,
             portcullis_core::IntegLevel::Adversarial,
             "release leaked outside the signed sink mask"
         );

--- a/crates/portcullis/src/flow_graph_tests.rs
+++ b/crates/portcullis/src/flow_graph_tests.rs
@@ -402,9 +402,124 @@ fn apply_token_raises_integrity() {
         other => panic!("Expected Applied, got {other:?}"),
     }
 
-    // Verify the node's label was actually modified in the graph
+    // The STORED label is not modified — release is a per-operation view,
+    // never a label rewrite.
     assert_eq!(
         g.get(web).unwrap().label.integrity,
+        portcullis_core::IntegLevel::Adversarial
+    );
+
+    // Inside the token's sink mask the effective label is the released one…
+    assert_eq!(
+        g.effective_label(web, Operation::WriteFiles)
+            .unwrap()
+            .integrity,
+        portcullis_core::IntegLevel::Untrusted
+    );
+    assert_eq!(
+        g.effective_label(web, Operation::GitCommit)
+            .unwrap()
+            .integrity,
+        portcullis_core::IntegLevel::Untrusted
+    );
+
+    // …and outside it the strict label governs: a token scoped to
+    // {WriteFiles, GitCommit} clears its node for those and nothing else.
+    for op in [Operation::GitPush, Operation::WebFetch, Operation::RunBash] {
+        assert_eq!(
+            g.effective_label(web, op).unwrap().integrity,
+            portcullis_core::IntegLevel::Adversarial,
+            "release leaked to out-of-mask operation {op:?}"
+        );
+    }
+}
+
+#[test]
+fn apply_token_twice_is_refused() {
+    use portcullis_core::declassify::*;
+
+    let mut g = FlowGraph::new();
+    let now = 1000;
+    let web = g
+        .insert_observation(NodeKind::WebContent, &[], now)
+        .unwrap();
+
+    let token = |sinks: Vec<Operation>| {
+        DeclassificationToken::new(
+            web,
+            DeclassificationRule {
+                action: DeclassifyAction::RaiseIntegrity {
+                    from: portcullis_core::IntegLevel::Adversarial,
+                    to: portcullis_core::IntegLevel::Untrusted,
+                },
+                justification: "test",
+            },
+            sinks,
+            now + 3600,
+            "double apply".to_string(),
+        )
+    };
+
+    assert!(matches!(
+        g.apply_token(&token(vec![Operation::WriteFiles]), now),
+        TokenApplyResult::Applied { .. }
+    ));
+    // A second token — even a differently scoped one — is refused: a node
+    // is declassified at most once.
+    assert!(matches!(
+        g.apply_token(&token(vec![Operation::GitPush]), now),
+        TokenApplyResult::AlreadyDeclassified
+    ));
+    // And the refusal did not widen the original scope.
+    assert_eq!(
+        g.effective_label(web, Operation::GitPush).unwrap().integrity,
+        portcullis_core::IntegLevel::Adversarial
+    );
+}
+
+#[test]
+fn apply_token_on_frozen_node_takes_effect() {
+    // The historical apply_token called modify_label and DISCARDED its
+    // Option, so a frozen target silently kept its label while `Applied`
+    // was returned — the caller was told a release happened that hadn't.
+    // Scopes never touch labels, so freezing no longer interferes with
+    // legitimate declassification (#947's stated intent).
+    use portcullis_core::declassify::*;
+
+    let mut g = FlowGraph::new();
+    let now = 1000;
+    let web = g
+        .insert_observation(NodeKind::WebContent, &[], now)
+        .unwrap();
+    g.freeze_all();
+
+    let token = DeclassificationToken::new(
+        web,
+        DeclassificationRule {
+            action: DeclassifyAction::RaiseIntegrity {
+                from: portcullis_core::IntegLevel::Adversarial,
+                to: portcullis_core::IntegLevel::Untrusted,
+            },
+            justification: "frozen target",
+        },
+        vec![Operation::WriteFiles],
+        now + 3600,
+        "frozen".to_string(),
+    );
+
+    assert!(matches!(
+        g.apply_token(&token, now),
+        TokenApplyResult::Applied { .. }
+    ));
+    // Frozen label untouched; released view live for the granted sink.
+    assert_eq!(
+        g.get(web).unwrap().label.integrity,
+        portcullis_core::IntegLevel::Adversarial
+    );
+    assert_eq!(
+        g.effective_label(web, Operation::WriteFiles)
+            .unwrap()
+            .integrity,
         portcullis_core::IntegLevel::Untrusted
     );
 }
@@ -990,22 +1105,23 @@ fn trusted_ancestry_web_ancestor_untrusted() {
 }
 
 #[test]
-fn trusted_ancestry_declassified_web_content_trusted() {
+fn trusted_ancestry_is_not_laundered_by_declassification() {
+    // Historical behavior: apply_token rewrote the stored label, so a
+    // declassified web node passed check_trusted_ancestry for EVERY
+    // subsequent operation — a token scoped to one sink laundered the
+    // node's whole ancestry. Scoped release keeps stored labels strict, so
+    // ancestry stays untrusted: strictly narrower, which is the safe
+    // direction. An operation-aware ancestry check that honors the scope
+    // for in-mask operations is deliberately NOT-YET.
     use portcullis_core::declassify::*;
 
     let mut g = FlowGraph::new();
     let now = 1000;
 
-    // Web content starts as Adversarial
     let web = g
         .insert_observation(NodeKind::WebContent, &[], now)
         .unwrap();
-    assert_eq!(
-        g.get(web).unwrap().label.integrity,
-        portcullis_core::IntegLevel::Adversarial
-    );
 
-    // Declassify: raise integrity from Adversarial to Untrusted
     let token = DeclassificationToken::new(
         web,
         DeclassificationRule {
@@ -1019,20 +1135,31 @@ fn trusted_ancestry_declassified_web_content_trusted() {
         now + 3600,
         "Curated search output".to_string(),
     );
-    let result = g.apply_token(&token, now);
-    assert!(matches!(result, TokenApplyResult::Applied { .. }));
+    assert!(matches!(
+        g.apply_token(&token, now),
+        TokenApplyResult::Applied { .. }
+    ));
 
-    // Insert a plan node depending on the declassified web content
     let plan = g
         .insert_observation(NodeKind::ModelPlan, &[web], now)
         .unwrap();
 
-    // The plan inherits Untrusted (from declassified web) — which is
-    // >= Untrusted, so the ancestry check should pass.
+    // Stored-label ancestry is strict: the web node's label is still
+    // Adversarial, so the plan's ancestry stays untrusted…
+    match g.check_trusted_ancestry(plan) {
+        Some(TrustAncestryResult::Untrusted { tainted_ancestors }) => {
+            assert!(tainted_ancestors.contains(&web));
+        }
+        other => panic!("Expected Untrusted (no ancestry laundering), got {other:?}"),
+    }
+
+    // …while the released view still flows to the granted sink: the plan
+    // inherits the scope, and a WriteFiles consumer sees Untrusted.
     assert_eq!(
-        g.check_trusted_ancestry(plan),
-        Some(TrustAncestryResult::Trusted),
-        "declassified web content (Untrusted) should pass trusted ancestry check"
+        g.effective_label(plan, Operation::WriteFiles)
+            .unwrap()
+            .integrity,
+        portcullis_core::IntegLevel::Untrusted
     );
 }
 
@@ -1186,10 +1313,22 @@ mod apply_token_verified_tests {
             other => panic!("Expected Applied, got {other:?}"),
         }
 
-        // Verify the graph node was actually modified
+        // The stored label is NOT modified — release is a scoped view. The
+        // released level is visible exactly through the token's sinks.
         assert_eq!(
             g.get(web).unwrap().label.integrity,
+            portcullis_core::IntegLevel::Adversarial
+        );
+        assert_eq!(
+            g.effective_label(web, Operation::WriteFiles)
+                .unwrap()
+                .integrity,
             portcullis_core::IntegLevel::Untrusted
+        );
+        assert_eq!(
+            g.effective_label(web, Operation::GitPush).unwrap().integrity,
+            portcullis_core::IntegLevel::Adversarial,
+            "release leaked outside the signed sink mask"
         );
     }
 

--- a/crates/portcullis/src/kernel/declassify_authority.rs
+++ b/crates/portcullis/src/kernel/declassify_authority.rs
@@ -11,11 +11,17 @@ impl Kernel {
     /// Set trusted Ed25519 public keys for declassification token verification.
     ///
     /// When set, [`apply_declassification_token`](Self::apply_declassification_token)
-    /// verifies token signatures against these keys before applying label
-    /// changes. Supports key rotation by accepting multiple keys.
+    /// verifies token signatures against these keys before recording the
+    /// declass scope. Supports key rotation by accepting multiple keys.
     ///
-    /// When no trusted keys are set (the default), unsigned declassification
-    /// rules are applied without verification for backward compatibility.
+    /// When no trusted keys are set (the default), token application is
+    /// REFUSED outright — fail-closed; see the body of
+    /// `apply_declassification_token`. (This doc previously claimed a
+    /// permissive backward-compatibility default the code does not have.)
+    ///
+    /// This key set is what the North Star means by "a governor": a
+    /// principal holding a key configured here. It is configuration, not
+    /// something any agent-reachable path may write.
     #[cfg(feature = "crypto")]
     pub fn set_trusted_keys(&mut self, keys: Vec<[u8; 32]>) {
         self.trusted_public_keys = keys;
@@ -29,7 +35,7 @@ impl Kernel {
     ///
     /// If trusted keys are configured, the token's signature is verified
     /// before applying. If no trusted keys are configured, the token is
-    /// applied without verification (backward compatibility) with a warning.
+    /// REFUSED — fail-closed; there is no unsigned fallback.
     ///
     /// Returns `Err(DenyReason::InvalidDeclassification)` if trusted keys
     /// are set and signature verification fails.

--- a/crates/portcullis/tests/declassify_scope.rs
+++ b/crates/portcullis/tests/declassify_scope.rs
@@ -87,18 +87,9 @@ fn graph_verdicts_match_the_extracted_decision_pointwise() {
     let mut oracle_divergence_seen = false;
 
     for op in Operation::ALL {
-        let v_token = g_token
-            .insert_action(op, &[src_t], NOW)
-            .unwrap()
-            .verdict;
-        let v_strict = g_strict
-            .insert_action(op, &[src_s], NOW)
-            .unwrap()
-            .verdict;
-        let v_released = g_released
-            .insert_action(op, &[src_r], NOW)
-            .unwrap()
-            .verdict;
+        let v_token = g_token.insert_action(op, &[src_t], NOW).unwrap().verdict;
+        let v_strict = g_strict.insert_action(op, &[src_s], NOW).unwrap().verdict;
+        let v_released = g_released.insert_action(op, &[src_r], NOW).unwrap().verdict;
 
         if v_strict != v_released {
             oracle_divergence_seen = true;
@@ -129,8 +120,12 @@ fn graph_verdicts_match_the_extracted_decision_pointwise() {
     let (mut g2_strict, s2) = graph_with_secret_source();
     let (mut g2_token, t2) = graph_with_secret_source();
     g2_token.apply_token(&lower_conf_token(t2, vec![Operation::WebFetch]), NOW);
-    let strict_fetch = g2_strict.insert_action(Operation::WebFetch, &[s2], NOW).unwrap();
-    let token_fetch = g2_token.insert_action(Operation::WebFetch, &[t2], NOW).unwrap();
+    let strict_fetch = g2_strict
+        .insert_action(Operation::WebFetch, &[s2], NOW)
+        .unwrap();
+    let token_fetch = g2_token
+        .insert_action(Operation::WebFetch, &[t2], NOW)
+        .unwrap();
     assert_ne!(
         strict_fetch.verdict, token_fetch.verdict,
         "non-vacuity: releasing Secret→Internal for WebFetch must change \
@@ -191,7 +186,9 @@ fn inherited_scope_intersects_toward_strict() {
         TokenApplyResult::Applied { .. }
     ));
 
-    let child = g.insert_observation(NodeKind::ModelPlan, &[a, b], NOW).unwrap();
+    let child = g
+        .insert_observation(NodeKind::ModelPlan, &[a, b], NOW)
+        .unwrap();
     for op in [Operation::WebFetch, Operation::WriteFiles] {
         assert_eq!(
             g.effective_label(child, op).unwrap().confidentiality,

--- a/crates/portcullis/tests/declassify_scope.rs
+++ b/crates/portcullis/tests/declassify_scope.rs
@@ -1,0 +1,259 @@
+//! Pointwise graph binding for sink-scoped declassification.
+//!
+//! The extracted decision layer (`nucleus-ifc-kernel::extracted::declassify`)
+//! is bound to `allows_sink` by an exhaustive 2^13 × 13 parity sweep in
+//! portcullis-core. This test binds the OTHER end: that `FlowGraph` verdicts
+//! actually route through that layer — the same binding layer FM-5 uses for
+//! its spawn path.
+//!
+//! Shape: one graph carries a signed-shape token scoped to a subset of sinks;
+//! two ORACLE graphs bracket it — the strict oracle (no token at all) and the
+//! released oracle (the parent's label force-lowered globally, the historical
+//! behavior). For every one of the 13 operations:
+//!
+//!   * in-mask   ⇒ the token graph's verdict equals the RELEASED oracle's;
+//!   * off-mask  ⇒ the token graph's verdict equals the STRICT oracle's.
+//!
+//! Plus the executable two-run statement: off-mask verdicts are IDENTICAL to
+//! a run in which the token never existed — a token scoped to one sink is
+//! unobservable at every other sink. Non-vacuity: the oracles must differ on
+//! at least one operation, or every assertion above is comparing equal
+//! things and the test proves nothing.
+
+use portcullis::flow_graph::FlowGraph;
+use portcullis_core::declassify::{
+    DeclassificationRule, DeclassificationToken, DeclassifyAction, TokenApplyResult,
+};
+use portcullis_core::flow::NodeKind;
+use portcullis_core::{ConfLevel, Operation};
+
+const NOW: u64 = 1000;
+
+/// A graph with one Secret-confidentiality source node (`EnvVar` intrinsic:
+/// Secret / Trusted / SYSTEM / NoAuthority / Deterministic).
+fn graph_with_secret_source() -> (FlowGraph, u64) {
+    let mut g = FlowGraph::new();
+    let src = g.insert_observation(NodeKind::EnvVar, &[], NOW).unwrap();
+    assert_eq!(
+        g.get(src).unwrap().label.confidentiality,
+        ConfLevel::Secret,
+        "test premise: the source must start Secret"
+    );
+    (g, src)
+}
+
+fn lower_conf_token(target: u64, sinks: Vec<Operation>) -> DeclassificationToken {
+    DeclassificationToken::new(
+        target,
+        DeclassificationRule {
+            action: DeclassifyAction::LowerConfidentiality {
+                from: ConfLevel::Secret,
+                to: ConfLevel::Internal,
+            },
+            justification: "sink-scope binding test",
+        },
+        sinks,
+        NOW + 3600,
+        "sink-scope binding test".to_string(),
+    )
+}
+
+#[test]
+fn graph_verdicts_match_the_extracted_decision_pointwise() {
+    // The granted sinks: one exfil-class operation (where the conf axis is
+    // decision-relevant) and one mutation operation.
+    let granted = vec![Operation::WebFetch, Operation::WriteFiles];
+
+    // Token graph: scoped release on the source.
+    let (mut g_token, src_t) = graph_with_secret_source();
+    let apply = g_token.apply_token(&lower_conf_token(src_t, granted.clone()), NOW);
+    assert!(
+        matches!(apply, TokenApplyResult::Applied { .. }),
+        "token failed to apply: {apply:?}"
+    );
+
+    // Strict oracle: no token ever existed.
+    let (mut g_strict, src_s) = graph_with_secret_source();
+
+    // Released oracle: the historical global lowering, forced.
+    let (mut g_released, src_r) = graph_with_secret_source();
+    let released_label = {
+        let mut l = g_released.get(src_r).unwrap().label;
+        l.confidentiality = ConfLevel::Internal;
+        l
+    };
+    g_released.modify_label_forced(src_r, released_label);
+
+    let mut oracle_divergence_seen = false;
+
+    for op in Operation::ALL {
+        let v_token = g_token
+            .insert_action(op, &[src_t], NOW)
+            .unwrap()
+            .verdict;
+        let v_strict = g_strict
+            .insert_action(op, &[src_s], NOW)
+            .unwrap()
+            .verdict;
+        let v_released = g_released
+            .insert_action(op, &[src_r], NOW)
+            .unwrap()
+            .verdict;
+
+        if v_strict != v_released {
+            oracle_divergence_seen = true;
+        }
+
+        if granted.contains(&op) {
+            assert_eq!(
+                v_token, v_released,
+                "in-mask operation {op:?} did not see the released view"
+            );
+        } else {
+            assert_eq!(
+                v_token, v_strict,
+                "off-mask operation {op:?} diverged from the token-free run — \
+                 the release leaked outside its signed sink mask"
+            );
+        }
+    }
+
+    assert!(
+        oracle_divergence_seen,
+        "the strict and released oracles never differed — every comparison \
+         above was vacuous and this test proved nothing"
+    );
+
+    // The differential is visible where it should be: WebFetch is granted
+    // and exfil-class, so the released view must change its verdict.
+    let (mut g2_strict, s2) = graph_with_secret_source();
+    let (mut g2_token, t2) = graph_with_secret_source();
+    g2_token.apply_token(&lower_conf_token(t2, vec![Operation::WebFetch]), NOW);
+    let strict_fetch = g2_strict.insert_action(Operation::WebFetch, &[s2], NOW).unwrap();
+    let token_fetch = g2_token.insert_action(Operation::WebFetch, &[t2], NOW).unwrap();
+    assert_ne!(
+        strict_fetch.verdict, token_fetch.verdict,
+        "non-vacuity: releasing Secret→Internal for WebFetch must change \
+         the WebFetch verdict (rule 1 no longer fires)"
+    );
+}
+
+#[test]
+fn stored_labels_and_decision_labels_stay_strict() {
+    // The release must be invisible in everything that persists: the stored
+    // node label, the FlowDecision label (what the kernel joins into the
+    // session flow cache), and the receipt's recomputed verdict must all be
+    // derived from the same stored state.
+    let (mut g, src) = graph_with_secret_source();
+    g.apply_token(&lower_conf_token(src, vec![Operation::WriteFiles]), NOW);
+
+    let decision = g.insert_action(Operation::WriteFiles, &[src], NOW).unwrap();
+
+    // The action node's stored label is the strict join — Secret.
+    assert_eq!(
+        g.get(decision.node_id).unwrap().label.confidentiality,
+        ConfLevel::Secret,
+        "the stored action label was laundered by the release"
+    );
+    // FlowDecision.label — the value the kernel accumulates into session
+    // taint — is the strict one too: a token never cleanses a session.
+    assert_eq!(
+        decision.label.confidentiality,
+        ConfLevel::Secret,
+        "FlowDecision.label was laundered by the release"
+    );
+
+    // Receipt recomputation agrees with the insert-time verdict: the scope
+    // is stored state, so the one verdict path serves both.
+    let receipt = g.build_receipt_for(decision.node_id, NOW).unwrap();
+    assert_eq!(
+        receipt.verdict(),
+        decision.verdict,
+        "receipt recomputation disagreed with the insert-time verdict"
+    );
+}
+
+#[test]
+fn inherited_scope_intersects_toward_strict() {
+    // Two declassified parents with DISJOINT masks: the child's mask is the
+    // intersection — empty — so the child is strict everywhere, even for
+    // operations each parent granted individually. The deliberate sound
+    // over-approximation.
+    let mut g = FlowGraph::new();
+    let a = g.insert_observation(NodeKind::EnvVar, &[], NOW).unwrap();
+    let b = g.insert_observation(NodeKind::EnvVar, &[], NOW).unwrap();
+    assert!(matches!(
+        g.apply_token(&lower_conf_token(a, vec![Operation::WebFetch]), NOW),
+        TokenApplyResult::Applied { .. }
+    ));
+    assert!(matches!(
+        g.apply_token(&lower_conf_token(b, vec![Operation::WriteFiles]), NOW),
+        TokenApplyResult::Applied { .. }
+    ));
+
+    let child = g.insert_observation(NodeKind::ModelPlan, &[a, b], NOW).unwrap();
+    for op in [Operation::WebFetch, Operation::WriteFiles] {
+        assert_eq!(
+            g.effective_label(child, op).unwrap().confidentiality,
+            ConfLevel::Secret,
+            "disjoint parent masks must intersect to strict for {op:?}"
+        );
+    }
+
+    // Overlapping masks DO survive: a child of two parents that both grant
+    // WriteFiles keeps the release for WriteFiles and only WriteFiles.
+    let mut g2 = FlowGraph::new();
+    let c = g2.insert_observation(NodeKind::EnvVar, &[], NOW).unwrap();
+    let d = g2.insert_observation(NodeKind::EnvVar, &[], NOW).unwrap();
+    g2.apply_token(
+        &lower_conf_token(c, vec![Operation::WriteFiles, Operation::WebFetch]),
+        NOW,
+    );
+    g2.apply_token(
+        &lower_conf_token(d, vec![Operation::WriteFiles, Operation::GitCommit]),
+        NOW,
+    );
+    let child2 = g2
+        .insert_observation(NodeKind::ModelPlan, &[c, d], NOW)
+        .unwrap();
+    assert_eq!(
+        g2.effective_label(child2, Operation::WriteFiles)
+            .unwrap()
+            .confidentiality,
+        ConfLevel::Internal,
+        "a jointly granted sink must keep the release in the child"
+    );
+    for op in [Operation::WebFetch, Operation::GitCommit] {
+        assert_eq!(
+            g2.effective_label(child2, op).unwrap().confidentiality,
+            ConfLevel::Secret,
+            "a sink granted by only one parent must be strict in the child"
+        );
+    }
+}
+
+#[test]
+fn causal_label_for_honors_the_scope() {
+    let (mut g, src) = graph_with_secret_source();
+    g.apply_token(&lower_conf_token(src, vec![Operation::WriteFiles]), NOW);
+
+    // The op-aware prospective label sees the release exactly in-mask…
+    assert_eq!(
+        g.causal_label_for(&[src], Operation::WriteFiles, NOW)
+            .unwrap()
+            .confidentiality,
+        ConfLevel::Internal
+    );
+    assert_eq!(
+        g.causal_label_for(&[src], Operation::GitPush, NOW)
+            .unwrap()
+            .confidentiality,
+        ConfLevel::Secret
+    );
+    // …and the op-blind causal_label stays strict (it answers "what taint
+    // does this ancestry carry", not "may this specific action run").
+    assert_eq!(
+        g.causal_label(&[src], NOW).unwrap().confidentiality,
+        ConfLevel::Secret
+    );
+}

--- a/crates/portcullis/tests/kernel_token.rs
+++ b/crates/portcullis/tests/kernel_token.rs
@@ -303,3 +303,43 @@ fn a_failed_application_does_not_burn_the_token() {
         Err(DenyReason::DeclassificationReplayed { .. })
     ));
 }
+
+#[test]
+fn second_token_on_a_declassified_node_is_refused_and_not_burned() {
+    let key = test_key();
+    let mut kernel = make_kernel_with_graph();
+    kernel.set_trusted_keys(vec![public_key_bytes(&key)]);
+
+    let node = kernel.observe(NodeKind::WebContent, &[]).unwrap();
+    let mut first = make_token(node);
+    token_sign::sign_token(&mut first, &key);
+    assert!(matches!(
+        kernel.apply_declassification_token(&first),
+        Ok(TokenApplyResult::Applied { .. })
+    ));
+
+    // A DISTINCT token for the same node (different justification ⇒
+    // different canonical bytes ⇒ different signature): refused, because a
+    // node is declassified at most once.
+    let mut second = make_token(node);
+    second.justification = "a second, distinct authorization".to_string();
+    token_sign::sign_token(&mut second, &key);
+    assert!(matches!(
+        kernel.apply_declassification_token(&second),
+        Ok(TokenApplyResult::AlreadyDeclassified)
+    ));
+
+    // The refusal did not burn the second token: retrying yields the same
+    // refusal, NOT DeclassificationReplayed. Only Applied spends.
+    assert!(matches!(
+        kernel.apply_declassification_token(&second),
+        Ok(TokenApplyResult::AlreadyDeclassified)
+    ));
+
+    // And the first token's ledger entry is intact: its replay is still the
+    // dedicated replay verdict.
+    assert!(matches!(
+        kernel.apply_declassification_token(&first),
+        Err(DenyReason::DeclassificationReplayed { .. })
+    ));
+}

--- a/examples/a2a-server/Cargo.lock
+++ b/examples/a2a-server/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fb24275cca126dc3301d272eef07bd4cefd87f9a7dd5d6f27200fe87e8a83d0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "chrono",
  "serde",
  "serde_json",
@@ -280,6 +280,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -547,6 +553,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
 dependencies = [
  "const-oid 0.10.2",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -1089,7 +1096,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1346,15 +1353,15 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "10.4.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
+checksum = "881733cbc631fc9e472e24447ce32a64bedf2da498d6d8570b08edc87de71f65"
 dependencies = [
  "aws-lc-rs",
- "base64",
+ "base64 0.22.1",
  "getrandom 0.2.17",
  "js-sys",
- "pem",
+ "pem 3.0.6",
  "serde",
  "serde_json",
  "signature 2.2.0",
@@ -1472,7 +1479,7 @@ dependencies = [
  "a2a-server-lf",
  "anyhow",
  "axum",
- "base64",
+ "base64 0.22.1",
  "chrono",
  "futures",
  "http",
@@ -1494,7 +1501,7 @@ dependencies = [
 name = "nucleus-agent-card"
 version = "1.0.0"
 dependencies = [
- "base64",
+ "base64 0.23.1",
  "nucleus-envelope",
  "nucleus-identity",
  "nucleus-lineage",
@@ -1509,7 +1516,7 @@ dependencies = [
 name = "nucleus-envelope"
 version = "1.0.0"
 dependencies = [
- "base64",
+ "base64 0.23.1",
  "chrono",
  "ed25519-dalek",
  "hex",
@@ -1525,10 +1532,10 @@ name = "nucleus-identity"
 version = "1.0.0"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.23.1",
  "chrono",
  "hex",
- "pem",
+ "pem 4.0.0",
  "portcullis-core",
  "prost",
  "rcgen",
@@ -1555,10 +1562,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "nucleus-ifc-kernel"
+version = "1.0.0"
+
+[[package]]
 name = "nucleus-lineage"
 version = "1.0.0"
 dependencies = [
- "base64",
+ "base64 0.23.1",
  "chrono",
  "ct-merkle",
  "ed25519-dalek",
@@ -1578,7 +1589,7 @@ name = "nucleus-verify-commerce"
 version = "1.0.0"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.23.1",
  "nucleus-agent-card",
  "nucleus-envelope",
  "nucleus-ifc",
@@ -1686,7 +1697,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8edd1efdd8ab23ba9cb9ace3d9987a72663d5d7c9f74fa00b51d6213645cf6c"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde",
 ]
 
@@ -1723,8 +1734,27 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde_core",
+]
+
+[[package]]
+name = "pem"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d354a98a3d1251555de99e8fdd8afda05573c31b82f59063a7b0a29b5527f120"
+dependencies = [
+ "base64 0.23.1",
+ "serde_core",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -1783,6 +1813,9 @@ dependencies = [
 [[package]]
 name = "portcullis-core"
 version = "1.0.0"
+dependencies = [
+ "nucleus-ifc-kernel",
+]
 
 [[package]]
 name = "potential_utf"
@@ -2111,7 +2144,7 @@ version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
 dependencies = [
- "pem",
+ "pem 3.0.6",
  "ring",
  "rustls-pki-types",
  "time",
@@ -2163,7 +2196,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "http",
@@ -2195,7 +2228,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -2869,7 +2902,7 @@ checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
  "axum",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "h2",
  "http",


### PR DESCRIPTION
## What

Closes the gap the dormancy gate exists for: `allowed_sinks` on `DeclassificationToken` is now **enforced at the graph level**. `FlowGraph::apply_token` no longer raises the target's label globally — it records a `DeclassScope { released_label, sink_mask }` in a side table (the `frozen`/`field_lineage` pattern), and flow verdicts are computed over the **effective** label: released inside the token's signed sink mask, strict outside. A token scoped to `[WebSearch]` clears its node for WebSearch and nothing else.

## Design invariants (each tested)

- **Stored labels never mutate.** Session taint, `FlowDecision.label`, lineage, and receipts all stay strict — a token never cleanses a session. (Incidental bug fix: the old path discarded `modify_label`'s `Option`, so a frozen target silently kept its label while `Applied` was returned.)
- **One verdict path.** Insert-time decisions and receipt recomputations both route through `check_flow_effective` over stored state, so they cannot disagree.
- **Descendants inherit by mask intersection.** Disjoint parent grants intersect to strict — the deliberate sound over-approximation, tested both ways.
- **At most one declassification per node.** New `TokenApplyResult::AlreadyDeclassified`; refusals never burn (kernel ledger spends on `Applied` only — tested at the kernel layer).
- **Ancestry is not laundered.** `check_trusted_ancestry` reads stored labels, so it is strictly narrower than the historical behavior; op-aware ancestry is a named NOT-YET.

## Extraction + parity (the A2 leg)

New `nucleus-ifc-kernel::extracted::declassify`: `mask_admits` / `effective_conf` / `declass_release_ok` (composing extracted `cflows_to`) + a **2-state absorbing one-shot machine** (`declass_step`) — deliberately *not* the mediation machine, whose `Discharge` re-arms; a one-shot token must never re-arm. Production routes through `mask_admits` via a total `med_of` bridge (new `Operation` variant = compile error).

Parity evidence:
- Exhaustive **2¹³ × 13 = 106,496-case** sweep: `sink_mask()` ↔ `allows_sink()` ↔ extracted `mask_admits` (complete domain = equivalence, not a sample).
- Pointwise **two-oracle graph binding** (`tests/declassify_scope.rs`): for all 13 operations, in-mask verdicts equal a force-released oracle graph, off-mask verdicts equal the token-free oracle graph — the executable two-run statement — with a non-vacuity witness that the oracles differ.

## What this deliberately does NOT do

- **The token path stays dormant.** `check-declassify-token-dormant.sh` still passes and still bites (its probe is unchanged). Un-dormanting — live caller, `NUCLEUS_DECLASS_TRUSTED_KEYS` governor provisioning, gate flip to `check-declassify-sink-scope-enforced.sh` — is the next increment, in one PR so the gate flip and the first caller land atomically.
- Lean theorems over the extracted functions (`sink_outside_allowlist_denied_extracted`, one-shot machine, released-set robustness) follow in the A3 PR, wired into `aeneas-ifc-scoped.yml`.
- Also fixed en route: `declassify_authority.rs` doc drift (code fails closed with no trusted keys; doc claimed a permissive fallback).

North Star arc increment **A1+A2(Rust)**, after #2206 (claim ledger). The C5 ledger row stays NOT-YET until the extracted theorem lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UA8kchV3eadjGv6BmJXfqm