### PR TITLE
North Star: demote C1 — the workload can read secrets from /proc/cmdline

### DIFF
--- a/docs/north-star.md
+++ b/docs/north-star.md
@@ -72,7 +72,7 @@ status is a visible event, not an edit.
 
 | # | Clause (verbatim from the sentence) | Status | Evidence | Falsified by |
 | --- | --- | --- | --- | --- |
-| C1 | "learn the secrets Nucleus holds on its behalf" | PROVED | `crates/portcullis-core/lean/IdentityMaterialNoninterferenceExtracted.lean#identity_material_never_reaches_the_workload`, `crates/portcullis-core/lean/ChannelAdmissionExtracted.lean#no_channel_delivers_secret_to_the_workload` | `.github/workflows/aeneas-ifc-scoped.yml` |
+| C1 | "learn the secrets Nucleus holds on its behalf" | NOT-YET | `crates/portcullis-core/lean/IdentityMaterialNoninterferenceExtracted.lean#identity_material_never_reaches_the_workload`, `crates/portcullis-core/lean/ChannelAdmissionExtracted.lean#no_channel_delivers_secret_to_the_workload`, `crates/nucleus-node/src/firecracker_config.rs` | — |
 | C2 | "nor those of any other pod" | NOT-YET | `docs/cross-pod-view.md` | — |
 | C3 | "nor influence which of them get released" | PROVED | `crates/portcullis-core/lean/PodMachineSpike.lean#noninterference` | `.github/workflows/portcullis-core-proven-lean.yml` |
 | C4 | "a governor deliberately released with a single-use token" | PROVED | `crates/portcullis-core/lean/DeclassifySinkScopeExtracted.lean#no_second_apply`, `crates/portcullis/src/kernel/declassify_authority.rs#apply_declassification_token`, `crates/nucleus-tool-proxy/src/declassify.rs#apply_declassification` | `scripts/check-declassify-sink-scope-enforced.sh` |
@@ -88,11 +88,26 @@ channels.*
 
 What each status means, and what it deliberately does not:
 
-- **C1 (PROVED)** — over the six modelled child-inheritance channels (Env,
-  Argv, Cwd, Stdio, ExtraFd, Uid), the 11-kind × 3-principal delivery table,
-  Aeneas-extracted from the shipping enforcement predicates, `sorry`-free,
-  axiom-audited. Residuals, named: the `_ => OrdinaryData` classifier
-  fallthrough is trusted, not proved; **mounts are not a modelled channel**.
+- **C1 (NOT-YET — demoted 2026-08-08, was PROVED).** FM-5 genuinely proves,
+  over the six modelled child-inheritance channels (Env, Argv, Cwd, Stdio,
+  ExtraFd, Uid), the 11-kind × 3-principal delivery table, Aeneas-extracted,
+  `sorry`-free, axiom-audited — but the *clause* is broader than that theorem,
+  and it is **falsified today by a channel FM-5 does not model**: the guest
+  kernel command line (`/proc/cmdline`) is world-readable inside the VM, and
+  `firecracker_config.rs` emits `nucleus.approval_secret` there on **every** pod
+  (~line 631; the code comment at ~615 states outright that the agent can read
+  it), plus the AWS credentials (`aws_access_key_id` / `_secret_access_key` /
+  `_session_token`) whenever an audit sink is configured. A workload that reads
+  `/proc/cmdline` learns a real secret Nucleus holds on its behalf, so "cannot
+  learn the secrets" is not established. Also unmodeled: mounts,
+  `/proc/<pid>/environ`, `/etc/nucleus/*`; and the `_ => OrdinaryData`
+  classifier fallthrough is trusted, not proved. **Re-earning C1** requires:
+  get `approval_secret` off the cmdline (needs a host-side or drand-only
+  approval tier — the HMAC key is used *in the guest* today), move the AWS
+  creds to a non-cmdline channel, and add the cmdline as a modelled channel to
+  `ChannelAdmissionExtracted` so any Secret-on-cmdline becomes a red theorem.
+  The task-token cmdline copies are not secrets (public issuer + host-pinned
+  nonce) and are not the blocker here.
 - **C2 (NOT-YET)** — no artifact in the corpus mentions a second pod; the host
   is outside every model. `docs/cross-pod-view.md` is the design.
 - **C3 (PROVED)** — the two-run noninterference theorem over the reference pod

--- a/scripts/north-star-ledger-ratchet.txt
+++ b/scripts/north-star-ledger-ratchet.txt
@@ -6,6 +6,14 @@
 #     deleted to dodge a red, which is the exact move a shrinkable count pays.
 #   NOT_YET may only SHRINK — and the pin must be lowered in the same change
 #     that earns the promotion, so every promotion is on the record with its
-#     evidence handle beside it.
+#     evidence handle beside it. The one legitimate RAISE is a demotion: a row
+#     found to be overclaimed. That is a visible event, recorded here.
+#
+# 2026-08-08: raised 3 -> 4. C1 ("cannot learn the secrets Nucleus holds on
+#   its behalf") demoted PROVED -> NOT-YET. FM-5 proves it over the six
+#   child-inheritance channels, but the workload can read `nucleus.approval_secret`
+#   (always) and the AWS audit creds (with an audit sink) from the world-readable
+#   guest /proc/cmdline — a channel FM-5 does not model. The clause is falsified
+#   today; re-earning it is tracked in the C1 note in docs/north-star.md.
 CLAUSES=9
-NOT_YET=3
+NOT_YET=4


### PR DESCRIPTION
## What

Demotes ledger clause **C1** ("cannot learn the secrets Nucleus holds on its behalf") from **PROVED → NOT-YET**, and raises the ledger's NOT-YET pin 3 → 4. This is a demotion for honesty, recorded as a visible event (the one legitimate pin *raise*), not a regression.

## Why

FM-5 genuinely proves no Secret reaches the workload over the six child-inheritance channels (Env/Argv/Cwd/Stdio/ExtraFd/Uid). But the clause is broader than that theorem, and it is **falsified today** by a seventh channel FM-5 does not model — the guest kernel command line, which is world-readable inside the VM:

- `firecracker_config.rs` emits `nucleus.approval_secret` on **every** pod's cmdline (~line 631); its own comment (~615) says the agent can read it.
- The AWS audit credentials ride the cmdline whenever an audit sink is set — and because they're emitted through a loop rather than a literal `nucleus.KEY=`, the snapshot "distance is five keys" ratchet's source-scan doesn't even count them.

Reading `/proc/cmdline` — the cheapest attack — beats C1 for those values. The ledger exists precisely to stop a clause from outrunning its wiring, so it must not carry C1 as PROVED.

## What this does *not* do

It doesn't close the exposure — that's boot-path work the repo deliberately gates on a real KVM boot (task-token vsock-fatal, sandbox_token deletion) and an approval-tier redesign (`approval_secret` is verified *in the guest* today, so the key can't just move). The C1 note records exactly what re-earning it takes: `approval_secret` off the cmdline, AWS creds to a non-cmdline channel, and the cmdline modelled as a channel in `ChannelAdmissionExtracted` so any Secret-on-cmdline reds a theorem.

## Decisions this surfaces for you

1. **The North Star sentence** still asserts "cannot learn the secrets" absolutely, with no cmdline exclusion. Either the secrets come off the cmdline, or the sentence needs the same kind of in-sentence exclusion it already carries for timing/availability — your call (sentence edits are yours).
2. **AWS creds channel** — move to the workload-API vsock (firecracker-only) or a mode-restricted mounted secret?
3. **`approval_secret`** — host-side approval verification, or a drand-only tier?

Ledger gate passes at 9 clauses / 4 NOT-YET.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UA8kchV3eadjGv6BmJXfqm
