### PR TITLE
audit: move the S3 audit credentials off the kernel command line onto the workload API

### DIFF
--- a/crates/nucleus-guest-init/src/identity.rs
+++ b/crates/nucleus-guest-init/src/identity.rs
@@ -176,6 +176,74 @@ pub fn fetch_broker_secret(port: u32) -> Result<BrokerCapability, String> {
     })
 }
 
+/// The S3 audit-sink credentials, fetched over the workload API instead of
+/// read off the world-readable kernel command line.
+pub struct AuditCredentials {
+    pub access_key_id: String,
+    pub secret_access_key: String,
+    /// Present only for temporary (STS) credentials.
+    pub session_token: Option<String>,
+}
+
+/// Fetch the S3 audit-sink credentials, once.
+///
+/// Same discipline as [`fetch_broker_secret`], for the same reason: the host
+/// serves these EXACTLY ONCE, and fetching before `exec_proxy` — before any
+/// workload exists — is what makes "first" mean "the proxy". These credentials
+/// write the audit trail, so errors here name the failure and never echo the
+/// response body (which would put cloud credentials in the guest console log).
+///
+/// `Ok(None)` when the pod has no audit sink — the ordinary case, not a
+/// failure.
+pub fn fetch_audit_credentials(port: u32) -> Result<Option<AuditCredentials>, String> {
+    let mut stream = VsockStream::connect_with_cid_port(VMADDR_CID_HOST, port)
+        .map_err(|e| format!("failed to connect to workload API: {e}"))?;
+    stream
+        .write_all(b"FETCH_AUDIT_CREDENTIALS\n")
+        .map_err(|e| format!("failed to send FETCH_AUDIT_CREDENTIALS: {e}"))?;
+    stream
+        .flush()
+        .map_err(|e| format!("failed to flush: {e}"))?;
+
+    let mut reader = BufReader::new(&mut stream);
+    let mut response = String::new();
+    reader
+        .read_line(&mut response)
+        .map_err(|e| format!("failed to read audit-credentials response: {e}"))?;
+
+    let parsed: serde_json::Value = serde_json::from_str(&response)
+        // Not `{e}` and not the body: a parse error that echoed the response
+        // would put the credentials in the guest console log.
+        .map_err(|_| "audit-credentials response was not valid JSON".to_string())?;
+    if let Some(err) = parsed.get("error").and_then(|e| e.as_str()) {
+        // "not provisioned" is the unremarkable no-audit-sink case; every other
+        // error (including "already served") is worth surfacing.
+        if err.contains("no audit credentials provisioned") {
+            return Ok(None);
+        }
+        return Err(err.to_string());
+    }
+    let access_key_id = parsed
+        .get("access_key_id")
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .ok_or_else(|| "audit-credentials response had no `access_key_id`".to_string())?;
+    let secret_access_key = parsed
+        .get("secret_access_key")
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .ok_or_else(|| "audit-credentials response had no `secret_access_key`".to_string())?;
+    let session_token = parsed
+        .get("session_token")
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
+    Ok(Some(AuditCredentials {
+        access_key_id,
+        secret_access_key,
+        session_token,
+    }))
+}
+
 /// Fetch this pod's caller-identity token for the node's management API.
 ///
 /// Over the per-pod workload-API socket, like every other per-pod artifact: the

--- a/crates/nucleus-guest-init/src/main.rs
+++ b/crates/nucleus-guest-init/src/main.rs
@@ -154,6 +154,29 @@ fn run() -> Result<(), String> {
             }
             Err(err) => eprintln!("no broker capability over vsock: {err}"),
         }
+
+        // The S3 audit-sink credentials, fetched with the same before-
+        // `exec_proxy` ordering as the broker capability (the host serves them
+        // once; arriving before any workload exists is the property). They
+        // used to arrive as `nucleus.aws_*` kernel args, world-readable by the
+        // workload whose audit trail they write.
+        //
+        // Not fatal when absent: most pods have no audit sink, and the
+        // tool-proxy's S3 sink init is non-fatal on missing credentials — the
+        // failure mode is audit degradation, which the proxy logs.
+        match identity::fetch_audit_credentials(port) {
+            Ok(Some(creds)) => {
+                std::env::set_var("AWS_ACCESS_KEY_ID", &creds.access_key_id);
+                std::env::set_var("AWS_SECRET_ACCESS_KEY", &creds.secret_access_key);
+                if let Some(token) = &creds.session_token {
+                    std::env::set_var("AWS_SESSION_TOKEN", token);
+                }
+                // Presence only — never the values, never their length.
+                eprintln!("fetched audit-sink credentials over vsock");
+            }
+            Ok(None) => {}
+            Err(err) => eprintln!("no audit-sink credentials over vsock: {err}"),
+        }
     }
 
     let mut token_from_vsock = false;
@@ -299,16 +322,11 @@ fn run() -> Result<(), String> {
         }
     }
 
-    // AWS credentials for S3 audit sink (optional)
-    for (arg, env_var) in [
-        ("nucleus.aws_access_key_id", "AWS_ACCESS_KEY_ID"),
-        ("nucleus.aws_secret_access_key", "AWS_SECRET_ACCESS_KEY"),
-        ("nucleus.aws_session_token", "AWS_SESSION_TOKEN"),
-        ("nucleus.aws_default_region", "AWS_DEFAULT_REGION"),
-    ] {
-        if let Some(val) = parse_cmdline_secret(&cmdline, arg) {
-            std::env::set_var(env_var, val);
-        }
+    // The AWS *credentials* no longer ride the kernel command line — they are
+    // fetched over the workload API above, before any workload exists. Only
+    // the region remains here: per-fleet configuration, not a secret.
+    if let Some(val) = parse_cmdline_secret(&cmdline, "nucleus.aws_default_region") {
+        std::env::set_var("AWS_DEFAULT_REGION", val);
     }
 
     let audit_path = resolve_audit_path();

--- a/crates/nucleus-node/src/firecracker_config.rs
+++ b/crates/nucleus-node/src/firecracker_config.rs
@@ -662,17 +662,21 @@ impl FirecrackerConfig {
                     args.push_str(&format!(" nucleus.audit_s3_endpoint={endpoint}"));
                 }
             }
-            // Forward ambient AWS credentials for S3 audit sink
-            for (env_key, arg_key) in [
-                ("AWS_ACCESS_KEY_ID", "nucleus.aws_access_key_id"),
-                ("AWS_SECRET_ACCESS_KEY", "nucleus.aws_secret_access_key"),
-                ("AWS_SESSION_TOKEN", "nucleus.aws_session_token"),
-                ("AWS_DEFAULT_REGION", "nucleus.aws_default_region"),
-            ] {
-                if let Ok(val) = std::env::var(env_key) {
-                    if let Some(ref mut args) = boot_args {
-                        args.push_str(&format!(" {arg_key}={val}"));
-                    }
+            // The AWS credentials are NO LONGER EMITTED here.
+            //
+            // They were forwarded as `nucleus.aws_access_key_id` /
+            // `_secret_access_key` / `_session_token`, which put long-lived
+            // cloud credentials on the world-readable `/proc/cmdline` — the C1
+            // exposure, and the sharpest instance of it: these keys write the
+            // audit trail, so the workload they were readable by could erase
+            // its own record. They now ride the workload API
+            // (`FETCH_AUDIT_CREDENTIALS`, served once, before any workload
+            // exists) — see `handle_fetch_audit_credentials`. Only the REGION
+            // stays: it is per-fleet configuration, not a secret, and the
+            // snapshot guard classifies it as shared.
+            if let Ok(region) = std::env::var("AWS_DEFAULT_REGION") {
+                if let Some(ref mut args) = boot_args {
+                    args.push_str(&format!(" nucleus.aws_default_region={region}"));
                 }
             }
         }

--- a/crates/nucleus-node/src/main.rs
+++ b/crates/nucleus-node/src/main.rs
@@ -2743,6 +2743,25 @@ async fn spawn_firecracker_pod(
                     broker_secret_served: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(
                         false,
                     )),
+                    // The S3 audit-sink credentials, served once over this
+                    // socket instead of riding the world-readable kernel
+                    // command line (the C1 exposure). Same source the cmdline
+                    // emission read: the node's ambient AWS environment.
+                    // Provisioned only when the pod has an audit sink, and only
+                    // as a pair — an access key id without its secret (or the
+                    // reverse) is not a credential, so `None` beats half of one.
+                    audit_creds: spec.spec.audit_sink.as_ref().and_then(|_| {
+                        let id = std::env::var("AWS_ACCESS_KEY_ID").ok()?;
+                        let key = std::env::var("AWS_SECRET_ACCESS_KEY").ok()?;
+                        Some(workload_api_vsock::AuditCredentials {
+                            access_key_id: id,
+                            secret_access_key: key,
+                            session_token: std::env::var("AWS_SESSION_TOKEN").ok(),
+                        })
+                    }),
+                    audit_creds_served: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(
+                        false,
+                    )),
                 },
                 // Only when jailed: unjailed Firecracker runs as this same user
                 // and can already connect. Passing an owner there would hand our

--- a/crates/nucleus-node/src/main.rs
+++ b/crates/nucleus-node/src/main.rs
@@ -2641,165 +2641,143 @@ async fn spawn_firecracker_pod(
         // guest held a capability the verifier had never seen.
         let (broker_serve, broker_verify) = broker_launch::BrokerCapability::mint();
 
-        let (pod_identity, identity_manager, workload_api_bridge) = if let Some(manager) =
-            identity_source
-        {
-            // Use pod metadata for namespace/service_account context
-            let namespace = spec.metadata.namespace.as_deref().unwrap_or("default");
-            let service_account = spec.metadata.name.as_deref().unwrap_or("");
-            let identity = manager.identity_for_pod(id, namespace, service_account);
+        let (pod_identity, identity_manager, workload_api_bridge) =
+            if let Some(manager) = identity_source {
+                // Use pod metadata for namespace/service_account context
+                let namespace = spec.metadata.namespace.as_deref().unwrap_or("default");
+                let service_account = spec.metadata.name.as_deref().unwrap_or("");
+                let identity = manager.identity_for_pod(id, namespace, service_account);
 
-            // Register the pod identity
-            let registry_key = id.to_string();
-            identity_registry_key = Some(registry_key.clone());
-            manager.register_pod(registry_key, identity.clone()).await;
+                // Register the pod identity
+                let registry_key = id.to_string();
+                identity_registry_key = Some(registry_key.clone());
+                manager.register_pod(registry_key, identity.clone()).await;
 
-            // Compute launch attestation for this pod
-            // This captures integrity measurements of kernel, rootfs, and config
-            let pod_id_str = id.to_string();
-            let config_bytes = serde_json::to_vec(spec).unwrap_or_default();
-            match manager
-                .compute_attestation(
-                    &pod_id_str,
-                    &image.kernel_path,
-                    &image.rootfs_path,
-                    &config_bytes,
-                )
-                .await
-            {
-                Ok(attestation) => {
-                    info!(
-                        "computed launch attestation for pod {}: {}",
-                        id,
-                        attestation.to_hex_summary()
-                    );
-                    // Fetch attested certificate (includes attestation in X.509 extension)
-                    if let Err(e) = manager
-                        .fetch_attested_certificate(&identity, &pod_id_str)
-                        .await
-                    {
-                        tracing::warn!(
-                            "failed to fetch attested certificate for pod {}: {}",
+                // Compute launch attestation for this pod
+                // This captures integrity measurements of kernel, rootfs, and config
+                let pod_id_str = id.to_string();
+                let config_bytes = serde_json::to_vec(spec).unwrap_or_default();
+                match manager
+                    .compute_attestation(
+                        &pod_id_str,
+                        &image.kernel_path,
+                        &image.rootfs_path,
+                        &config_bytes,
+                    )
+                    .await
+                {
+                    Ok(attestation) => {
+                        info!(
+                            "computed launch attestation for pod {}: {}",
                             id,
-                            e
+                            attestation.to_hex_summary()
                         );
+                        // Fetch attested certificate (includes attestation in X.509 extension)
+                        if let Err(e) = manager
+                            .fetch_attested_certificate(&identity, &pod_id_str)
+                            .await
+                        {
+                            tracing::warn!(
+                                "failed to fetch attested certificate for pod {}: {}",
+                                id,
+                                e
+                            );
+                        }
                     }
-                }
-                Err(e) => {
-                    tracing::warn!(
+                    Err(e) => {
+                        tracing::warn!(
                         "failed to compute attestation for pod {}, using standard certificate: {}",
                         id,
                         e
                     );
-                    // Fall back to standard certificate without attestation
-                    if let Err(e) = manager.prefetch_certificate(&identity).await {
-                        tracing::warn!("failed to prefetch certificate for pod {}: {}", id, e);
+                        // Fall back to standard certificate without attestation
+                        if let Err(e) = manager.prefetch_certificate(&identity).await {
+                            tracing::warn!("failed to prefetch certificate for pod {}: {}", id, e);
+                        }
                     }
                 }
-            }
 
-            // Start workload API vsock bridge for this pod
-            // Uses Firecracker's naming convention: {vsock_uds_path}_{port}
-            // Guest connects to CID 2 (host) on the workload API port via AF_VSOCK
-            let bridge = match workload_api_vsock::WorkloadApiVsockBridge::start(
-                &vsock_path,
-                state.identity_vsock_port,
-                id,
-                manager.clone(),
-                workload_api_vsock::PodMaterial {
-                    // The same token that rides the kernel command line today.
-                    // Serving it here is what lets the cmdline copy go: a value
-                    // fetched after boot is not baked into a snapshot base.
-                    task_token: task_token.clone(),
-                    // This pod's caller identity for the management API, derived
-                    // from a NODE-ONLY secret. Deliberately not `auth_secret`:
-                    // every proxy already holds that one, so deriving from it
-                    // would let any pod compute any other pod's token and the
-                    // mechanism would prove nothing.
-                    caller_token: Some(pod_caller_identity::derive_token(
-                        state.caller_secret.as_ref(),
-                        id,
-                    )),
-                    // Pod-scoped DLC-D admission provisioning (PodSpec labels).
-                    // Partial labels still provision — the proxy's parser fails
-                    // CLOSED, so misconfiguration narrows rather than widens.
-                    dlc_admission: {
-                        let l = &spec.metadata.labels;
-                        l.get("dlc_trusted_keys").map(|keys| {
-                            workload_api_vsock::DlcAdmissionMaterial {
-                                trusted_keys: keys.clone(),
-                                issuer: l.get("dlc_issuer").cloned().unwrap_or_default(),
-                                credentials: l.get("dlc_credentials").cloned().unwrap_or_default(),
-                            }
-                        })
+                // Start workload API vsock bridge for this pod
+                // Uses Firecracker's naming convention: {vsock_uds_path}_{port}
+                // Guest connects to CID 2 (host) on the workload API port via AF_VSOCK
+                let bridge = match workload_api_vsock::WorkloadApiVsockBridge::start(
+                    &vsock_path,
+                    state.identity_vsock_port,
+                    id,
+                    manager.clone(),
+                    workload_api_vsock::PodMaterial {
+                        // The same token that rides the kernel command line today.
+                        // Serving it here is what lets the cmdline copy go: a value
+                        // fetched after boot is not baked into a snapshot base.
+                        task_token: task_token.clone(),
+                        // This pod's caller identity for the management API, derived
+                        // from a NODE-ONLY secret. Deliberately not `auth_secret`:
+                        // every proxy already holds that one, so deriving from it
+                        // would let any pod compute any other pod's token and the
+                        // mechanism would prove nothing.
+                        caller_token: Some(pod_caller_identity::derive_token(
+                            state.caller_secret.as_ref(),
+                            id,
+                        )),
+                        // Pod-scoped DLC-D admission provisioning (PodSpec labels).
+                        dlc_admission: workload_api_vsock::DlcAdmissionMaterial::from_labels(
+                            &spec.metadata.labels,
+                        ),
+                        // The broker capability, minted per pod and served ONCE. See
+                        // `handle_fetch_broker_secret`: this is what lets the host
+                        // tell the mediating proxy from every other guest process.
+                        broker_secret: Some(broker_serve.into_served()),
+                        // Served WITH the capability, not separately — the proxy
+                        // needs both to reach the broker and neither is useful alone.
+                        broker_port: state.broker_vsock_port,
+                        broker_secret_served: std::sync::Arc::new(
+                            std::sync::atomic::AtomicBool::new(false),
+                        ),
+                        // The S3 audit-sink credentials, served once over this
+                        // socket instead of riding the world-readable kernel
+                        // command line (the C1 exposure).
+                        audit_creds: workload_api_vsock::AuditCredentials::from_node_env(
+                            spec.spec.audit_sink.is_some(),
+                        ),
+                        audit_creds_served: std::sync::Arc::default(),
                     },
-                    // The broker capability, minted per pod and served ONCE. See
-                    // `handle_fetch_broker_secret`: this is what lets the host
-                    // tell the mediating proxy from every other guest process.
-                    broker_secret: Some(broker_serve.into_served()),
-                    // Served WITH the capability, not separately — the proxy
-                    // needs both to reach the broker and neither is useful alone.
-                    broker_port: state.broker_vsock_port,
-                    broker_secret_served: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(
-                        false,
-                    )),
-                    // The S3 audit-sink credentials, served once over this
-                    // socket instead of riding the world-readable kernel
-                    // command line (the C1 exposure). Same source the cmdline
-                    // emission read: the node's ambient AWS environment.
-                    // Provisioned only when the pod has an audit sink, and only
-                    // as a pair — an access key id without its secret (or the
-                    // reverse) is not a credential, so `None` beats half of one.
-                    audit_creds: spec.spec.audit_sink.as_ref().and_then(|_| {
-                        let id = std::env::var("AWS_ACCESS_KEY_ID").ok()?;
-                        let key = std::env::var("AWS_SECRET_ACCESS_KEY").ok()?;
-                        Some(workload_api_vsock::AuditCredentials {
-                            access_key_id: id,
-                            secret_access_key: key,
-                            session_token: std::env::var("AWS_SESSION_TOKEN").ok(),
-                        })
-                    }),
-                    audit_creds_served: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(
-                        false,
-                    )),
-                },
-                // Only when jailed: unjailed Firecracker runs as this same user
-                // and can already connect. Passing an owner there would hand our
-                // own socket away for no reason.
-                jail_layout
-                    .as_ref()
-                    .map(|_| (state.jailer_uid, state.jailer_gid)),
-            )
-            .await
-            {
-                Ok(b) => {
-                    info!(
-                        "started workload API vsock bridge at {} for pod {}",
-                        b.socket_path().display(),
-                        id
-                    );
-                    Some(b)
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        "failed to start workload API vsock bridge for pod {}: {}",
-                        id,
-                        e
-                    );
-                    None
-                }
+                    // Only when jailed: unjailed Firecracker runs as this same user
+                    // and can already connect. Passing an owner there would hand our
+                    // own socket away for no reason.
+                    jail_layout
+                        .as_ref()
+                        .map(|_| (state.jailer_uid, state.jailer_gid)),
+                )
+                .await
+                {
+                    Ok(b) => {
+                        info!(
+                            "started workload API vsock bridge at {} for pod {}",
+                            b.socket_path().display(),
+                            id
+                        );
+                        Some(b)
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            "failed to start workload API vsock bridge for pod {}: {}",
+                            id,
+                            e
+                        );
+                        None
+                    }
+                };
+
+                info!(
+                    "registered identity {} for pod {}",
+                    identity.to_spiffe_uri(),
+                    id
+                );
+
+                (Some(identity), Some(manager.clone()), bridge)
+            } else {
+                (None, None, None)
             };
-
-            info!(
-                "registered identity {} for pod {}",
-                identity.to_spiffe_uri(),
-                id
-            );
-
-            (Some(identity), Some(manager.clone()), bridge)
-        } else {
-            (None, None, None)
-        };
 
         if let Err(err) = wait_for_proxy_health(health_addr).await {
             if let Some(proxy) = signed_proxy {

--- a/crates/nucleus-node/src/snapshot.rs
+++ b/crates/nucleus-node/src/snapshot.rs
@@ -169,6 +169,10 @@ pub const PER_POD_SECRET_KEYS: &[&str] = &[
     "nucleus.task_token_hex",
     "nucleus.task_token_issuer",
     "nucleus.task_token_nonce",
+    // The three audit-sink credentials are NO LONGER EMITTED (they ride
+    // `FETCH_AUDIT_CREDENTIALS` over the workload API now) but stay listed:
+    // the denylist is categorical, so a regression that puts them back on the
+    // command line is refused here rather than silently clonable.
     "nucleus.aws_access_key_id",
     "nucleus.aws_secret_access_key",
     "nucleus.aws_session_token",
@@ -382,26 +386,35 @@ mod tests {
     /// [`snapshot_safety`] becomes satisfiable by construction. **That was
     /// wrong**, and this test is what makes the error visible instead of
     /// discovering it when the warm pool is built. Phase 1 deleted exactly one
-    /// key — `nucleus.auth_secret` — and EIGHT remain.
+    /// key — `nucleus.auth_secret` — and FIVE remain.
     ///
-    /// Eight, not five: the earlier version of this test scanned only for
-    /// `nucleus.key=` and asserted five. It **silently missed the three AWS
+    /// The count has been wrong before, in the dangerous direction: an earlier
+    /// version of this test scanned only for `nucleus.key=` and asserted five
+    /// while EIGHT were emitted. It **silently missed the three AWS
     /// audit credentials** (`nucleus.aws_access_key_id` /
-    /// `_secret_access_key` / `_session_token`), because they are emitted not as
-    /// a `format!("… nucleus.aws_…={val}")` literal but through a table LOOP
-    /// (`for (env_key, arg_key) in [("AWS_ACCESS_KEY_ID", "nucleus.aws_access_key_id"), …]`),
-    /// so the literal `nucleus.aws_access_key_id=` never appears in the source.
+    /// `_secret_access_key` / `_session_token`), because they were emitted not
+    /// as a `format!("… nucleus.aws_…={val}")` literal but through a table LOOP
+    /// (`for (env_key, arg_key) in [("AWS_ACCESS_KEY_ID", …), …]`),
+    /// so the literal `nucleus.aws_access_key_id=` never appeared in the source.
     /// A real secret — long-lived cloud credentials — rode the world-readable
     /// `/proc/cmdline` uncounted by the very gate meant to track it. (An earlier
     /// miscount for a different reason — a shell pipeline deduplicating
     /// `nucleus.task_token_nonce` — is why this pins the SET, not a number.)
     ///
     /// So this scan matches emission in EITHER form: a direct `{key}=` literal
-    /// (the `format!` sites) OR a quoted `"{key}"` table entry (the audit-cred
-    /// loop). Comments here use backticks, not double quotes, so the quoted-form
-    /// match does not re-introduce the false positive the `=`-only scan avoided
-    /// (`nucleus.auth_secret` appears only in prose and matches neither form,
-    /// which is correct — it is no longer emitted).
+    /// (the `format!` sites) OR a quoted `"{key}"` table entry (the form the
+    /// audit-cred loop used while it existed). Comments here use backticks, not
+    /// double quotes, so the quoted-form match does not re-introduce the false
+    /// positive the `=`-only scan avoided (`nucleus.auth_secret` appears only
+    /// in prose and matches neither form, which is correct — it is no longer
+    /// emitted).
+    ///
+    /// **Back to five (2026-08-08):** the three AWS audit credentials now ride
+    /// the workload API (`FETCH_AUDIT_CREDENTIALS`, served once before any
+    /// workload exists) and are no longer emitted onto the command line. They
+    /// STAY in [`PER_POD_SECRET_KEYS`]: the denylist is categorical, so a
+    /// regression that re-emits them is refused by `snapshot_safety` at runtime
+    /// and re-counted here at test time.
     ///
     /// A ratchet in both directions, and it is also the only guard on the
     /// **confidentiality** exposure the C1 ledger row was demoted for: every key
@@ -409,13 +422,14 @@ mod tests {
     /// per-pod secret fails here; removing one is progress and forces this list
     /// to be re-stated rather than quietly drifting.
     #[test]
-    fn the_remaining_distance_to_a_snapshottable_base_is_eight_keys() {
+    fn the_remaining_distance_to_a_snapshottable_base_is_five_keys() {
         let src = include_str!("firecracker_config.rs");
         let mut emitted: Vec<&str> = Vec::new();
         for key in PER_POD_SECRET_KEYS {
-            // Direct `{key}=` (format! sites) OR quoted `"{key}"` (the audit-cred
-            // table loop). The second disjunct is the fix: without it the AWS
-            // credentials, emitted via the loop, were never counted.
+            // Direct `{key}=` (format! sites) OR quoted `"{key}"` (a table-loop
+            // entry). The second disjunct is the fix that first caught the AWS
+            // credentials: emitted via a loop, the `{key}=` literal never
+            // appeared in the source.
             if src.contains(&format!("{key}=")) || src.contains(&format!("\"{key}\"")) {
                 emitted.push(key);
             }
@@ -424,9 +438,6 @@ mod tests {
 
         let expected = [
             "nucleus.approval_secret",
-            "nucleus.aws_access_key_id",
-            "nucleus.aws_secret_access_key",
-            "nucleus.aws_session_token",
             "nucleus.sandbox_token",
             "nucleus.task_token_hex",
             "nucleus.task_token_issuer",

--- a/crates/nucleus-node/src/workload_api_protocol.rs
+++ b/crates/nucleus-node/src/workload_api_protocol.rs
@@ -124,6 +124,22 @@ pub enum WorkloadApiCommand {
     /// `nucleus.auth_secret` and `nucleus.approval_secret` arrive today. Neither
     /// is a proxy-only capability for exactly that reason.
     FetchBrokerSecret,
+    /// `FETCH_AUDIT_CREDENTIALS` — request the cloud credentials for this pod's
+    /// S3 audit sink.
+    ///
+    /// # Served exactly ONCE per pod, like `FETCH_BROKER_SECRET`
+    ///
+    /// These are real, long-lived cloud credentials the host holds so the
+    /// in-guest tool-proxy can ship its audit log to S3. They used to ride the
+    /// kernel command line (`nucleus.aws_access_key_id` etc.), where
+    /// `/proc/cmdline` made them readable by the very workload the audit trail
+    /// is meant to witness — the C1 exposure. Moving them here restores the
+    /// intended split: `nucleus-guest-init` fetches before `exec_proxy`, so
+    /// before any workload exists, and the one-shot refuses whoever asks
+    /// second. A workload that steals the audit creds can erase its own trail,
+    /// so this gets the broker secret's delivery discipline, not the task
+    /// token's.
+    FetchAuditCredentials,
 }
 
 impl WorkloadApiCommand {
@@ -143,6 +159,7 @@ impl WorkloadApiCommand {
             WorkloadApiCommand::FetchDlcAdmission => "FETCH_DLC_ADMISSION",
             WorkloadApiCommand::FetchBrokerSecret => "FETCH_BROKER_SECRET",
             WorkloadApiCommand::FetchPodCallerToken => "FETCH_POD_CALLER_TOKEN",
+            WorkloadApiCommand::FetchAuditCredentials => "FETCH_AUDIT_CREDENTIALS",
         }
     }
 }
@@ -209,6 +226,7 @@ pub fn parse_command(frame: &[u8]) -> Result<WorkloadApiCommand, CommandParseErr
         "FETCH_DLC_ADMISSION" => Ok(WorkloadApiCommand::FetchDlcAdmission),
         "FETCH_BROKER_SECRET" => Ok(WorkloadApiCommand::FetchBrokerSecret),
         "FETCH_POD_CALLER_TOKEN" => Ok(WorkloadApiCommand::FetchPodCallerToken),
+        "FETCH_AUDIT_CREDENTIALS" => Ok(WorkloadApiCommand::FetchAuditCredentials),
         other => Err(CommandParseError::Unknown(other.to_string())),
     }
 }
@@ -226,6 +244,7 @@ mod tests {
             WorkloadApiCommand::FetchSvid,
             WorkloadApiCommand::FetchBundle,
             WorkloadApiCommand::Ping,
+            WorkloadApiCommand::FetchAuditCredentials,
         ] {
             assert_eq!(parse_command(cmd.as_wire().as_bytes()), Ok(cmd));
             // Trailing newline (the on-wire form) and surrounding whitespace
@@ -381,6 +400,7 @@ mod tests {
                 WorkloadApiCommand::FetchDlcAdmission => "FETCH_DLC_ADMISSION",
                 WorkloadApiCommand::FetchBrokerSecret => "FETCH_BROKER_SECRET",
                 WorkloadApiCommand::FetchPodCallerToken => "FETCH_POD_CALLER_TOKEN",
+                WorkloadApiCommand::FetchAuditCredentials => "FETCH_AUDIT_CREDENTIALS",
             }
         }
         for cmd in [
@@ -388,6 +408,7 @@ mod tests {
             WorkloadApiCommand::FetchBundle,
             WorkloadApiCommand::FetchDlcAdmission,
             WorkloadApiCommand::FetchBrokerSecret,
+            WorkloadApiCommand::FetchAuditCredentials,
             WorkloadApiCommand::Ping,
         ] {
             assert_eq!(assert_known(cmd), cmd.as_wire());

--- a/crates/nucleus-node/src/workload_api_vsock.rs
+++ b/crates/nucleus-node/src/workload_api_vsock.rs
@@ -65,6 +65,19 @@ pub struct DlcAdmissionMaterial {
     pub credentials: String,
 }
 
+/// Cloud credentials for the pod's S3 audit sink, served over
+/// `FETCH_AUDIT_CREDENTIALS` exactly once per pod.
+///
+/// Deliberately NO `Debug` derive: these are long-lived cloud credentials, and
+/// a derived `Debug` would put them one `{material:?}` away from a log line.
+#[derive(Clone)]
+pub struct AuditCredentials {
+    pub access_key_id: String,
+    pub secret_access_key: String,
+    /// Present only for temporary (STS) credentials.
+    pub session_token: Option<String>,
+}
+
 impl std::fmt::Debug for WorkloadApiVsockBridge {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("WorkloadApiVsockBridge")
@@ -105,6 +118,12 @@ pub struct PodMaterial {
     /// this listener accepts — a per-connection flag would make "once" mean
     /// "once per connection", which is not a restriction.
     pub broker_secret_served: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    /// The S3 audit-sink credentials, off the kernel command line at last.
+    /// `None` when the pod has no audit sink or the node holds no credentials.
+    pub audit_creds: Option<AuditCredentials>,
+    /// Whether the audit credentials have been served — one flag across every
+    /// connection, for the same reason as `broker_secret_served`.
+    pub audit_creds_served: std::sync::Arc<std::sync::atomic::AtomicBool>,
 }
 
 impl WorkloadApiVsockBridge {
@@ -135,14 +154,12 @@ impl WorkloadApiVsockBridge {
         material: PodMaterial,
         jail_owner: Option<(u32, u32)>,
     ) -> std::io::Result<Self> {
-        let PodMaterial {
-            task_token,
-            caller_token,
-            dlc_admission,
-            broker_secret,
-            broker_secret_served,
-            broker_port,
-        } = material;
+        // One Arc over the whole bundle rather than a per-field clone into
+        // `handle_connection`: the parameter list crossed clippy's
+        // `too_many_arguments` line when the audit credentials arrived, and the
+        // fields are read-only anyway — the one-shot flags inside are already
+        // their own `Arc<AtomicBool>`s, so sharing the bundle shares them.
+        let material = std::sync::Arc::new(material);
         // Firecracker naming convention: {uds_path}_{port}
         let socket_path = PathBuf::from(format!("{}_{}", vsock_uds_path.as_ref().display(), port));
 
@@ -204,26 +221,15 @@ impl WorkloadApiVsockBridge {
                         match accept_result {
                             Ok((stream, _)) => {
                                 let manager = identity_manager.clone();
-                                let task_token = task_token.clone();
-                                let dlc_admission = dlc_admission.clone();
-                                let broker_secret = broker_secret.clone();
-                                // Arc, so the one-shot flag is SHARED across every
-                                // connection this listener accepts. A per-connection
-                                // flag would make "once" mean "once per connection",
-                                // which is not a restriction at all.
-                                let broker_secret_served = std::sync::Arc::clone(&broker_secret_served);
-                                let caller_token = caller_token.clone();
+                                // The SAME Arc for every connection, so the
+                                // one-shot flags inside stay one flag each. A
+                                // per-connection flag would make "once" mean
+                                // "once per connection", which is not a
+                                // restriction at all.
+                                let material = std::sync::Arc::clone(&material);
                                 tokio::spawn(async move {
-                                    if let Err(err) = handle_connection(
-                                        stream, manager, pod_id, task_token, caller_token,
-                                        dlc_admission,
-                                        BrokerHandout {
-                                            secret: broker_secret,
-                                            port: broker_port,
-                                            served: broker_secret_served,
-                                        },
-                                    )
-                                    .await
+                                    if let Err(err) =
+                                        handle_connection(stream, manager, pod_id, material).await
                                     {
                                         debug!("workload API connection closed: {err}");
                                     }
@@ -298,19 +304,6 @@ impl WorkloadApiVsockBridge {
 ///
 /// `Acquire`/`AcqRel` via `swap` rather than a load-then-store: two concurrent
 /// connections must not both observe "not yet served".
-/// The broker capability as one connection sees it.
-///
-/// Three fields that are one thing: the secret, where to use it, and whether it
-/// has already been handed out. Grouping them is not only clippy's argument
-/// count — it is that delivering any of them without the others produces a proxy
-/// that can sign but not connect, or connect but not sign, and the one-shot flag
-/// must be the SAME flag across every connection or "once" means "once each".
-struct BrokerHandout {
-    secret: Option<String>,
-    port: u32,
-    served: std::sync::Arc<std::sync::atomic::AtomicBool>,
-}
-
 fn handle_fetch_broker_secret(
     secret: Option<&str>,
     port: u32,
@@ -342,6 +335,39 @@ fn handle_fetch_dlc_admission(material: Option<&DlcAdmissionMaterial>) -> String
     }
 }
 
+/// Serve the S3 audit-sink credentials EXACTLY ONCE.
+///
+/// Same mechanism and same reasoning as [`handle_fetch_broker_secret`]: any
+/// guest process can open `AF_VSOCK`, so the only thing distinguishing the
+/// mediating tool-proxy from the workload it audits is that `nucleus-guest-init`
+/// asks FIRST, before `exec_proxy`. These credentials write the audit trail; a
+/// workload holding them could erase or forge its own record, which is exactly
+/// the C1 exposure that existed while they rode the world-readable kernel
+/// command line. A refusal for an absent credential set must not consume the
+/// one-shot (a pod with no audit sink asks and is told no, harmlessly).
+fn handle_fetch_audit_credentials(
+    creds: Option<&AuditCredentials>,
+    already_served: &std::sync::atomic::AtomicBool,
+) -> String {
+    use std::sync::atomic::Ordering;
+    let Some(creds) = creds else {
+        return r#"{"error":"no audit credentials provisioned for this pod"}"#.to_string();
+    };
+    if already_served.swap(true, Ordering::AcqRel) {
+        tracing::warn!(
+            "refused a repeat FETCH_AUDIT_CREDENTIALS — the credentials are served once, before \
+             the workload exists; a second request is a bug or an attempt to obtain them"
+        );
+        return r#"{"error":"audit credentials already served"}"#.to_string();
+    }
+    serde_json::json!({
+        "access_key_id": creds.access_key_id,
+        "secret_access_key": creds.secret_access_key,
+        "session_token": creds.session_token,
+    })
+    .to_string()
+}
+
 fn handle_fetch_task_token(token: Option<&crate::session_mint::MintedTaskToken>) -> String {
     match token {
         Some(t) => serde_json::json!({
@@ -358,10 +384,7 @@ async fn handle_connection(
     stream: tokio::net::UnixStream,
     manager: IdentityManager,
     pod_id: uuid::Uuid,
-    task_token: Option<crate::session_mint::MintedTaskToken>,
-    caller_token: Option<String>,
-    dlc_admission: Option<DlcAdmissionMaterial>,
-    broker: BrokerHandout,
+    material: std::sync::Arc<PodMaterial>,
 ) -> std::io::Result<()> {
     let (reader, mut writer) = stream.into_split();
     let mut reader = BufReader::new(reader);
@@ -390,24 +413,36 @@ async fn handle_connection(
                 debug!("workload API FETCH_POD_CALLER_TOKEN for pod {}", pod_id);
                 // Served for the pod bound to THIS socket. The request carries no
                 // pod id and could not be believed if it did.
-                match &caller_token {
+                match &material.caller_token {
                     Some(t) => format!(r#"{{"caller_token":"{t}"}}"#),
                     None => r#"{"error":"no caller token minted for this pod"}"#.to_string(),
                 }
             }
             Ok(WorkloadApiCommand::FetchTaskToken) => {
                 debug!("workload API FETCH_TASK_TOKEN for pod {}", pod_id);
-                handle_fetch_task_token(task_token.as_ref())
+                handle_fetch_task_token(material.task_token.as_ref())
             }
             Ok(WorkloadApiCommand::FetchDlcAdmission) => {
                 debug!("workload API FETCH_DLC_ADMISSION for pod {}", pod_id);
-                handle_fetch_dlc_admission(dlc_admission.as_ref())
+                handle_fetch_dlc_admission(material.dlc_admission.as_ref())
             }
             Ok(WorkloadApiCommand::FetchBrokerSecret) => {
                 // Value never logged, at any level: this is the one workload-API
                 // payload whose possession IS the capability.
                 debug!("workload API FETCH_BROKER_SECRET for pod {}", pod_id);
-                handle_fetch_broker_secret(broker.secret.as_deref(), broker.port, &broker.served)
+                handle_fetch_broker_secret(
+                    material.broker_secret.as_deref(),
+                    material.broker_port,
+                    &material.broker_secret_served,
+                )
+            }
+            Ok(WorkloadApiCommand::FetchAuditCredentials) => {
+                // Like the broker secret: never log the value, at any level.
+                debug!("workload API FETCH_AUDIT_CREDENTIALS for pod {}", pod_id);
+                handle_fetch_audit_credentials(
+                    material.audit_creds.as_ref(),
+                    &material.audit_creds_served,
+                )
             }
             Err(err) => {
                 debug!("workload API rejected command for pod {}: {err}", pod_id);
@@ -920,6 +955,81 @@ mod tests {
         assert_eq!(
             parse_command(b"FETCH_BROKER_SECRET\n").unwrap(),
             WorkloadApiCommand::FetchBrokerSecret
+        );
+    }
+
+    fn audit_creds() -> AuditCredentials {
+        AuditCredentials {
+            access_key_id: "AKIAEXAMPLE".to_string(),
+            secret_access_key: "hunter2secret".to_string(),
+            session_token: Some("ststoken".to_string()),
+        }
+    }
+
+    /// **The audit credentials get the broker secret's discipline.** They write
+    /// the audit trail; a workload holding them can erase its own record. Only
+    /// "asked first" distinguishes the proxy from the workload, so serving
+    /// twice hands the trail's keys to whoever asks second.
+    #[test]
+    fn the_audit_credentials_are_served_exactly_once() {
+        let served = AtomicBool::new(false);
+        let first = handle_fetch_audit_credentials(Some(&audit_creds()), &served);
+        let v: serde_json::Value = serde_json::from_str(&first).unwrap();
+        assert_eq!(v["access_key_id"], "AKIAEXAMPLE");
+        assert_eq!(v["secret_access_key"], "hunter2secret");
+        assert_eq!(v["session_token"], "ststoken");
+
+        let second = handle_fetch_audit_credentials(Some(&audit_creds()), &served);
+        assert!(
+            second.contains("already served"),
+            "a second request must be refused: {second}"
+        );
+        assert!(
+            !second.contains("hunter2secret"),
+            "and must not leak the credentials in the refusal: {second}"
+        );
+    }
+
+    /// Long-lived keys without an STS session token are the common static-cred
+    /// case; the reply must carry an explicit null, not omit the field, so the
+    /// guest client can tell "no session token" from "truncated reply".
+    #[test]
+    fn static_credentials_serve_a_null_session_token() {
+        let served = AtomicBool::new(false);
+        let reply = handle_fetch_audit_credentials(
+            Some(&AuditCredentials {
+                session_token: None,
+                ..audit_creds()
+            }),
+            &served,
+        );
+        let v: serde_json::Value = serde_json::from_str(&reply).unwrap();
+        assert!(v["session_token"].is_null(), "got: {reply}");
+        assert_eq!(v["access_key_id"], "AKIAEXAMPLE");
+    }
+
+    /// A pod with no audit sink asks (guest-init always asks) and must be told
+    /// no WITHOUT burning the one-shot — otherwise a misprovisioned pod could
+    /// consume its own capability before the proxy exists to want it.
+    #[test]
+    fn an_absent_credential_set_does_not_consume_the_one_shot() {
+        let served = AtomicBool::new(false);
+        let r = handle_fetch_audit_credentials(None, &served);
+        assert!(r.contains("error"), "got: {r}");
+        assert!(
+            !served.load(std::sync::atomic::Ordering::Acquire),
+            "a refusal for an absent credential set must not mark it served"
+        );
+    }
+
+    /// `FETCH_AUDIT_CREDENTIALS` must be a command the parser knows, or the
+    /// guest client fails closed far from the cause.
+    #[test]
+    fn the_audit_credentials_command_round_trips_through_the_parser() {
+        use crate::workload_api_protocol::{parse_command, WorkloadApiCommand};
+        assert_eq!(
+            parse_command(b"FETCH_AUDIT_CREDENTIALS\n").unwrap(),
+            WorkloadApiCommand::FetchAuditCredentials
         );
     }
 }

--- a/crates/nucleus-node/src/workload_api_vsock.rs
+++ b/crates/nucleus-node/src/workload_api_vsock.rs
@@ -65,6 +65,23 @@ pub struct DlcAdmissionMaterial {
     pub credentials: String,
 }
 
+impl DlcAdmissionMaterial {
+    /// Pod-scoped DLC-D admission provisioning from the PodSpec labels.
+    ///
+    /// Partial labels still provision — the proxy's parser fails CLOSED, so
+    /// misconfiguration narrows rather than widens.
+    // The only caller is inside spawn_firecracker_pod's target_os = "linux"
+    // block; on Linux the dead-code detector stays live for it.
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+    pub fn from_labels(labels: &std::collections::BTreeMap<String, String>) -> Option<Self> {
+        labels.get("dlc_trusted_keys").map(|keys| Self {
+            trusted_keys: keys.clone(),
+            issuer: labels.get("dlc_issuer").cloned().unwrap_or_default(),
+            credentials: labels.get("dlc_credentials").cloned().unwrap_or_default(),
+        })
+    }
+}
+
 /// Cloud credentials for the pod's S3 audit sink, served over
 /// `FETCH_AUDIT_CREDENTIALS` exactly once per pod.
 ///
@@ -76,6 +93,31 @@ pub struct AuditCredentials {
     pub secret_access_key: String,
     /// Present only for temporary (STS) credentials.
     pub session_token: Option<String>,
+}
+
+impl AuditCredentials {
+    /// The credentials for a pod's audit sink, from the node's ambient AWS
+    /// environment — the same source the kernel-cmdline emission used to read.
+    ///
+    /// `None` unless the pod has an audit sink, and only ever a PAIR: an access
+    /// key id without its secret (or the reverse) is not a credential, so
+    /// `None` beats half of one. The session token alone is optional (absent
+    /// for long-lived keys).
+    // The only caller is inside spawn_firecracker_pod's target_os = "linux"
+    // block; on Linux the dead-code detector stays live for it.
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+    pub fn from_node_env(pod_has_audit_sink: bool) -> Option<Self> {
+        if !pod_has_audit_sink {
+            return None;
+        }
+        let access_key_id = std::env::var("AWS_ACCESS_KEY_ID").ok()?;
+        let secret_access_key = std::env::var("AWS_SECRET_ACCESS_KEY").ok()?;
+        Some(Self {
+            access_key_id,
+            secret_access_key,
+            session_token: std::env::var("AWS_SESSION_TOKEN").ok(),
+        })
+    }
 }
 
 impl std::fmt::Debug for WorkloadApiVsockBridge {

--- a/docs/north-star.md
+++ b/docs/north-star.md
@@ -95,19 +95,21 @@ What each status means, and what it deliberately does not:
   and it is **falsified today by a channel FM-5 does not model**: the guest
   kernel command line (`/proc/cmdline`) is world-readable inside the VM, and
   `firecracker_config.rs` emits `nucleus.approval_secret` there on **every** pod
-  (~line 631; the code comment at ~615 states outright that the agent can read
-  it), plus the AWS credentials (`aws_access_key_id` / `_secret_access_key` /
-  `_session_token`) whenever an audit sink is configured. A workload that reads
-  `/proc/cmdline` learns a real secret Nucleus holds on its behalf, so "cannot
-  learn the secrets" is not established. Also unmodeled: mounts,
+  (the code comment at the emission site states outright that the agent can
+  read it). A workload that reads `/proc/cmdline` learns a real secret Nucleus
+  holds on its behalf, so "cannot learn the secrets" is not established. The
+  AWS audit-sink credentials used to ride the same channel; as of 2026-08-08
+  they are fetched over the workload API instead (`FETCH_AUDIT_CREDENTIALS`,
+  served once before any workload exists), and the cmdline-secret ratchet in
+  `snapshot.rs` pins them as no-longer-emitted. Also unmodeled: mounts,
   `/proc/<pid>/environ`, `/etc/nucleus/*`; and the `_ => OrdinaryData`
-  classifier fallthrough is trusted, not proved. **Re-earning C1** requires:
-  get `approval_secret` off the cmdline (needs a host-side or drand-only
-  approval tier — the HMAC key is used *in the guest* today), move the AWS
-  creds to a non-cmdline channel, and add the cmdline as a modelled channel to
-  `ChannelAdmissionExtracted` so any Secret-on-cmdline becomes a red theorem.
-  The task-token cmdline copies are not secrets (public issuer + host-pinned
-  nonce) and are not the blocker here.
+  classifier fallthrough is trusted, not proved. **Re-earning C1** still
+  requires: get `approval_secret` off the cmdline (signature-based approvals —
+  the guest verifying an approver's Ed25519 signature against a *public* key
+  removes the shared HMAC secret entirely), and add the cmdline as a modelled
+  channel to `ChannelAdmissionExtracted` so any Secret-on-cmdline becomes a red
+  theorem. The task-token cmdline copies are not secrets (public issuer +
+  host-pinned nonce) and are not the blocker here.
 - **C2 (NOT-YET)** — no artifact in the corpus mentions a second pod; the host
   is outside every model. `docs/cross-pod-view.md` is the design.
 - **C3 (PROVED)** — the two-run noninterference theorem over the reference pod


### PR DESCRIPTION
## What

The three AWS audit-sink credentials rode the guest kernel command line (`nucleus.aws_access_key_id` / `_secret_access_key` / `_session_token`), world-readable via `/proc/cmdline` by the very workload the audit trail exists to witness. This is the decided 2A step of the C1 (confidentiality) arc: the credentials now ride the workload API as `FETCH_AUDIT_CREDENTIALS`, host-origin over vsock.

## How

- **Delivery discipline = the broker secret's, not the task token's**: served exactly once per pod; `nucleus-guest-init` fetches before `exec_proxy`, so before any workload exists; a second request is refused; a refusal for an absent credential set does not consume the one-shot. These credentials *write* the audit trail — a workload holding them can erase its own record.
- Only the 3 credentials moved. S3 bucket/prefix/region/endpoint are per-fleet config, not secrets — they stay on the cmdline (classified `SHARED_CONFIG_KEYS`).
- `handle_connection` now takes one `Arc<PodMaterial>` instead of a growing positional list; the one-shot flags inside are already `Arc<AtomicBool>`s, so sharing the bundle shares them.
- The cmdline-secret ratchet shrinks **8 → 5** (`the_remaining_distance_to_a_snapshottable_base_is_five_keys`). The AWS keys stay in `PER_POD_SECRET_KEYS`: the denylist is categorical, so re-emitting them is refused at runtime and re-counted at test time.
- North-star C1 prose updated to match; **C1 stays NOT-YET** (`nucleus.approval_secret` is still on the cmdline — signed approvals are the next step).

## Verified

- Linux (OrbStack VM, the Firecracker path is not compiled on macOS): `cargo clippy --all-targets --all-features -- -D warnings` clean; `cargo test -p nucleus-node -p nucleus-guest-init --all-features` 339 passed / 0 failed.
- `cargo fmt --all --check` clean.
- Failure mode if creds don't arrive in-guest is audit degradation, not brick/leak: the tool-proxy's S3 sink init is non-fatal on missing credentials.

## Merge discipline

**Do NOT auto-merge.** quickstart-boot / boot-a-real-pod is not a required check; this touches the boot path, so merge manually only after boot-a-real-pod x86_64 is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UA8kchV3eadjGv6BmJXfqm