### PR TITLE
approvals: sign with Ed25519 against the node's public key — remove the last forgeable secret from /proc/cmdline

### DIFF
--- a/crates/nucleus-guest-init/src/main.rs
+++ b/crates/nucleus-guest-init/src/main.rs
@@ -228,14 +228,37 @@ fn run() -> Result<(), String> {
     let auth_secret = parse_cmdline_secret(&cmdline, "nucleus.auth_secret")
         .or_else(|| read_secret("/etc/nucleus/auth.secret"));
 
+    // Signature-based approvals: the node delivers the Ed25519 PUBLIC half of
+    // its approval signing key as `nucleus.approval_pubkeys`. A verification
+    // key is safe on the world-readable cmdline — reading it grants no
+    // forging power, which is exactly what the approval SECRET below lacked
+    // (HMAC is symmetric, so the workload could read `/proc/cmdline` and sign
+    // its own approvals). When keys are present the proxy accepts ONLY
+    // signatures; the secret is legacy for pods still provisioned with one.
+    let approval_pubkeys = parse_cmdline_secret(&cmdline, "nucleus.approval_pubkeys");
+    if let Some(ref keys) = approval_pubkeys {
+        std::env::set_var("NUCLEUS_TOOL_PROXY_APPROVAL_PUBKEYS", keys);
+    }
+
     let approval_secret = parse_cmdline_secret(&cmdline, "nucleus.approval_secret")
-        .or_else(|| read_secret("/etc/nucleus/approval.secret"))
-        .ok_or_else(|| "missing approval secret (set nucleus.approval_secret in boot args or /etc/nucleus/approval.secret)".to_string())?;
+        .or_else(|| read_secret("/etc/nucleus/approval.secret"));
+    if approval_pubkeys.is_none() && approval_secret.is_none() {
+        // Fail HERE, near the cause: the tool-proxy would refuse to start
+        // anyway (its approval endpoint would be unauthenticatable), but its
+        // exit is four layers from this missing boot arg.
+        return Err(
+            "missing approval authority (set nucleus.approval_pubkeys or \
+                    nucleus.approval_secret in boot args, or /etc/nucleus/approval.secret)"
+                .to_string(),
+        );
+    }
 
     if let Some(auth_secret) = auth_secret {
         std::env::set_var("NUCLEUS_TOOL_PROXY_AUTH_SECRET", auth_secret);
     }
-    std::env::set_var("NUCLEUS_TOOL_PROXY_APPROVAL_SECRET", approval_secret);
+    if let Some(approval_secret) = approval_secret {
+        std::env::set_var("NUCLEUS_TOOL_PROXY_APPROVAL_SECRET", approval_secret);
+    }
 
     // Sandbox token is optional — Tier 3 fallback when SVID doesn't carry
     // an attestation OID. If absent, tool-proxy uses Tier 1 or Tier 2 proof.

--- a/crates/nucleus-node/src/firecracker_config.rs
+++ b/crates/nucleus-node/src/firecracker_config.rs
@@ -558,7 +558,7 @@ impl FirecrackerConfig {
         image: &nucleus_spec::ImageSpec,
         net_plan: Option<&net::NetPlan>,
         auth_secret: &str,
-        approval_secret: &str,
+        approval_pubkeys: &str,
         workload_api_port: Option<u32>,
         task_token: Option<&crate::session_mint::MintedTaskToken>,
         // When jailed, every path emitted below is IN-JAIL, not host.
@@ -623,14 +623,25 @@ impl FirecrackerConfig {
         // can forge. Firecracker pods always have vsock (`spawn_firecracker_pod`
         // requires `spec.vsock`), so the HMAC tier is unreachable on this path.
         //
-        // `nucleus.approval_secret` REMAINS for now: the approval endpoint is
-        // still drand-anchored HMAC, and dropping its key needs a drand-only
-        // tier first. Freshness is not origin, so the transport cannot replace
-        // it on its own.
+        // `nucleus.approval_secret` is NO LONGER EMITTED either.
+        //
+        // It was the last real secret on this command line: an HMAC key is
+        // symmetric, so the guest's VERIFICATION key was also a signing key,
+        // and any workload that read `/proc/cmdline` could forge approvals
+        // for its own operations — an authority bypass, not just a leak.
+        //
+        // What rides here instead is `nucleus.approval_pubkeys`: the Ed25519
+        // PUBLIC half of the node's approval signing key. The guest verifies
+        // an approver's signature (drand-anchored, `verify_strict`) and can do
+        // nothing else with the key — reading it grants no forging power, so
+        // it is safe on a world-readable channel, and it is per-node config,
+        // so it does not block a snapshot base (see `SHARED_CONFIG_KEYS`).
         let _ = auth_secret;
         boot_args = match boot_args.take() {
-            Some(args) => Some(format!("{args} nucleus.approval_secret={approval_secret}")),
-            None => Some(format!("nucleus.approval_secret={approval_secret}")),
+            Some(args) => Some(format!(
+                "{args} nucleus.approval_pubkeys={approval_pubkeys}"
+            )),
+            None => Some(format!("nucleus.approval_pubkeys={approval_pubkeys}")),
         };
 
         // Inject workload API port if identity management is enabled
@@ -1079,7 +1090,7 @@ mod tests {
             &image(true, false),
             None,
             "auth-secret",
-            "approval-secret",
+            "aa00bb11-approval-pubkeys",
             will_have_identity.then_some(15012),
             None,
             None,
@@ -1509,7 +1520,7 @@ mod tests {
             &img,
             None,
             "auth",
-            "approval",
+            "aa00bb11-approval-pubkeys",
             None,
             None,
             Some(&layout),
@@ -1661,7 +1672,7 @@ mod tests {
             &img,
             None,
             "auth",
-            "approval",
+            "aa00bb11-approval-pubkeys",
             None,
             None,
             Some(&JailLayout::new(

--- a/crates/nucleus-node/src/lifecycle.rs
+++ b/crates/nucleus-node/src/lifecycle.rs
@@ -1,0 +1,63 @@
+//! Node-side pod-lifecycle audit entries.
+
+use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use tokio::io::AsyncWriteExt;
+use tracing::error;
+
+/// Append a node-side pod-lifecycle event to `<pod_dir>/lifecycle.log`.
+///
+/// Ensures every pod — including direct-task pods that never run a tool-proxy —
+/// has at least start/stop entries.
+///
+/// **Deliberately NOT `audit.log`.** These entries are unsigned and unchained;
+/// `audit.log` is the tool-proxy's HMAC-chained log, and interleaving unsigned
+/// lines into it made every local- and container-driver log fail
+/// `nucleus-audit verify` (its `ToolProxyEntry` requires
+/// `prev_hash`/`hash`/`signature`). Keeping the two files separate preserves a
+/// verifiable chain; the lifecycle file is folded into an evidence bundle as
+/// explicitly-unsigned context. The filename lives here, in one place, so the
+/// two cannot drift back together.
+pub(crate) async fn write_lifecycle_audit(pod_dir: &Path, event: &str, pod_id: &str, detail: &str) {
+    let audit_path = pod_dir.join("lifecycle.log");
+    let audit_path = audit_path.as_path();
+    let entry = serde_json::json!({
+        "timestamp_unix": now_unix(),
+        "actor": "nucleus-node",
+        "event": event,
+        "subject": format!("pod:{}", pod_id),
+        "result": detail,
+    });
+    let line = match serde_json::to_string(&entry) {
+        Ok(l) => l,
+        Err(e) => {
+            error!("failed to serialize lifecycle audit entry: {e}");
+            return;
+        }
+    };
+    match tokio::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(audit_path)
+        .await
+    {
+        Ok(mut file) => {
+            let _ = file.write_all(line.as_bytes()).await;
+            let _ = file.write_all(b"\n").await;
+        }
+        Err(e) => {
+            error!(
+                "failed to write lifecycle audit to {}: {e}",
+                audit_path.display()
+            );
+        }
+    }
+}
+
+fn now_unix() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}

--- a/crates/nucleus-node/src/main.rs
+++ b/crates/nucleus-node/src/main.rs
@@ -50,6 +50,7 @@ mod cgroup;
 mod cred_split;
 mod envelope_frame;
 mod guest_socket;
+mod lifecycle;
 mod net;
 mod posture;
 mod session_mint;
@@ -355,6 +356,11 @@ struct NodeState {
     /// pod. See `pod_caller_identity`.
     caller_secret: std::sync::Arc<[u8; 32]>,
     proxy_approval_secret: String,
+    /// Ed25519 key whose signatures Firecracker guests accept on
+    /// `/v1/approve`. The PRIVATE half never leaves the node; guests get the
+    /// public half as `nucleus.approval_pubkeys`. Persisted in `state_dir` so
+    /// pods launched before a node restart can still be approved.
+    approval_signer: std::sync::Arc<ed25519_dalek::SigningKey>,
     proxy_actor: Option<String>,
     /// Operator-configured registry of proof-carrying postures a trusted builder
     /// has proven. Consulted fail-closed at pod admission (`posture.rs`).
@@ -720,6 +726,9 @@ async fn main() -> Result<(), ApiError> {
             std::sync::Arc::new(k)
         },
         proxy_approval_secret: args.proxy_approval_secret.clone(),
+        approval_signer: std::sync::Arc::new(trust_gate::load_or_create_approval_signing_key(
+            &args.state_dir,
+        )),
         proxy_actor: Some(args.proxy_actor.clone()).filter(|actor| !actor.trim().is_empty()),
         trusted_postures: posture::PostureRegistry::from_operator_str(&args.trusted_postures),
         drand_config,
@@ -1105,7 +1114,7 @@ async fn create_pod_internal(
     boot_trace::log_guest_console_timeline(&log_path).await;
 
     // Write lifecycle audit event so even direct-task pods have an audit trail.
-    write_lifecycle_audit(
+    lifecycle::write_lifecycle_audit(
         &pod_dir,
         "pod_started",
         &id.to_string(),
@@ -1600,7 +1609,10 @@ async fn spawn_local_pod(
         let proxy = signed_proxy::SignedProxy::start_with_drand(
             target_addr,
             Arc::new(state.proxy_auth_secret.as_bytes().to_vec()),
-            Some(Arc::new(state.proxy_approval_secret.as_bytes().to_vec())),
+            // Env-provisioned pod: it verifies approvals with the shared secret.
+            Some(signed_proxy::ApprovalSigning::Hmac(Arc::new(
+                state.proxy_approval_secret.as_bytes().to_vec(),
+            ))),
             state.proxy_actor.clone(),
             state.drand_config.clone(),
         )
@@ -1929,7 +1941,10 @@ async fn spawn_container_pod(
             let proxy = signed_proxy::SignedProxy::start_with_drand(
                 target_addr,
                 Arc::new(state.proxy_auth_secret.as_bytes().to_vec()),
-                Some(Arc::new(state.proxy_approval_secret.as_bytes().to_vec())),
+                // Env-provisioned container: shared-secret approvals.
+                Some(signed_proxy::ApprovalSigning::Hmac(Arc::new(
+                    state.proxy_approval_secret.as_bytes().to_vec(),
+                ))),
                 state.proxy_actor.clone(),
                 state.drand_config.clone(),
             )
@@ -2245,7 +2260,8 @@ async fn spawn_firecracker_pod(
             image,
             net_plan.as_ref(),
             &state.proxy_auth_secret,
-            &state.proxy_approval_secret,
+            // The PUBLIC half only — the signing half stays in this process.
+            &hex::encode(state.approval_signer.verifying_key().to_bytes()),
             workload_api_port,
             task_token.as_ref(),
             jail_layout.as_ref(),
@@ -2590,7 +2606,12 @@ async fn spawn_firecracker_pod(
         let proxy = signed_proxy::SignedProxy::start_with_drand(
             bridge.listen_addr(),
             Arc::new(state.proxy_auth_secret.as_bytes().to_vec()),
-            Some(Arc::new(state.proxy_approval_secret.as_bytes().to_vec())),
+            // Firecracker pod: it verifies approvals against the node's PUBLIC
+            // key (nucleus.approval_pubkeys), so approvals are Ed25519-signed
+            // and no approval secret exists in the guest.
+            Some(signed_proxy::ApprovalSigning::Ed25519(Arc::clone(
+                &state.approval_signer,
+            ))),
             state.proxy_actor.clone(),
             state.drand_config.clone(),
         )
@@ -2962,55 +2983,6 @@ fn now_unix() -> u64 {
         .as_secs()
 }
 
-/// Append a node-side pod-lifecycle event to `<pod_dir>/lifecycle.log`.
-///
-/// Ensures every pod — including direct-task pods that never run a tool-proxy —
-/// has at least start/stop entries.
-///
-/// **Deliberately NOT `audit.log`.** These entries are unsigned and unchained;
-/// `audit.log` is the tool-proxy's HMAC-chained log, and interleaving unsigned
-/// lines into it made every local- and container-driver log fail
-/// `nucleus-audit verify` (its `ToolProxyEntry` requires
-/// `prev_hash`/`hash`/`signature`). Keeping the two files separate preserves a
-/// verifiable chain; the lifecycle file is folded into an evidence bundle as
-/// explicitly-unsigned context. The filename lives here, in one place, so the
-/// two cannot drift back together.
-async fn write_lifecycle_audit(pod_dir: &Path, event: &str, pod_id: &str, detail: &str) {
-    let audit_path = pod_dir.join("lifecycle.log");
-    let audit_path = audit_path.as_path();
-    let entry = serde_json::json!({
-        "timestamp_unix": now_unix(),
-        "actor": "nucleus-node",
-        "event": event,
-        "subject": format!("pod:{}", pod_id),
-        "result": detail,
-    });
-    let line = match serde_json::to_string(&entry) {
-        Ok(l) => l,
-        Err(e) => {
-            error!("failed to serialize lifecycle audit entry: {e}");
-            return;
-        }
-    };
-    match tokio::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(audit_path)
-        .await
-    {
-        Ok(mut file) => {
-            let _ = file.write_all(line.as_bytes()).await;
-            let _ = file.write_all(b"\n").await;
-        }
-        Err(e) => {
-            error!(
-                "failed to write lifecycle audit to {}: {e}",
-                audit_path.display()
-            );
-        }
-    }
-}
-
 fn build_firecracker_pool(args: &Args) -> Option<Arc<Semaphore>> {
     if !matches!(&args.driver, DriverKind::Firecracker) || args.firecracker_max_pods == 0 {
         return None;
@@ -3082,8 +3054,13 @@ fn start_pod_reaper(state: NodeState) {
                         _ => "unknown".to_string(),
                     };
                     let pod_dir = pod.log_path.parent().unwrap_or(Path::new("."));
-                    write_lifecycle_audit(pod_dir, "pod_exited", &pod.id.to_string(), &detail)
-                        .await;
+                    lifecycle::write_lifecycle_audit(
+                        pod_dir,
+                        "pod_exited",
+                        &pod.id.to_string(),
+                        &detail,
+                    )
+                    .await;
 
                     exited_ids.push(pod.id);
                     pod.cleanup_after_exit().await;
@@ -3791,7 +3768,7 @@ impl NodeService for GrpcService {
                     "lockdown: pod affected"
                 );
                 let pod_dir = pod.log_path.parent().unwrap_or_else(|| Path::new("."));
-                write_lifecycle_audit(
+                lifecycle::write_lifecycle_audit(
                     pod_dir,
                     action,
                     &pod.id.to_string(),

--- a/crates/nucleus-node/src/signed_proxy.rs
+++ b/crates/nucleus-node/src/signed_proxy.rs
@@ -27,11 +27,28 @@ const HEADER_ACTOR: &str = "x-nucleus-actor";
 const HEADER_DRAND_ROUND: &str = "x-nucleus-drand-round";
 const MAX_PROXY_BODY_BYTES: usize = 10 * 1024 * 1024;
 
+/// How this proxy signs `/v1/approve` requests.
+///
+/// One enum rather than two `Option`s: a proxy holding both an approval
+/// secret and an approval key would have two ways to sign the same request,
+/// and which one the guest accepts is a property of how the POD was
+/// provisioned — the launch path that started this proxy knows, so it picks.
+#[derive(Clone)]
+pub enum ApprovalSigning {
+    /// Shared-secret HMAC — pods provisioned with `approval_secret` (the
+    /// env-delivered container paths).
+    Hmac(Arc<Vec<u8>>),
+    /// Ed25519 with the node's approval signing key — Firecracker pods, which
+    /// verify against the PUBLIC half (`nucleus.approval_pubkeys`) and hold
+    /// no approval secret at all.
+    Ed25519(Arc<ed25519_dalek::SigningKey>),
+}
+
 #[derive(Clone)]
 struct SignedProxyState {
     target: SocketAddr,
     secret: Arc<Vec<u8>>,
-    approval_secret: Option<Arc<Vec<u8>>>,
+    approval: Option<ApprovalSigning>,
     default_actor: Option<String>,
     /// Drand client for anchoring approval signatures.
     drand_client: Option<Arc<DrandClient>>,
@@ -60,10 +77,10 @@ impl SignedProxy {
     pub async fn start(
         target: SocketAddr,
         secret: Arc<Vec<u8>>,
-        approval_secret: Option<Arc<Vec<u8>>>,
+        approval: Option<ApprovalSigning>,
         default_actor: Option<String>,
     ) -> std::io::Result<Self> {
-        Self::start_with_drand(target, secret, approval_secret, default_actor, None).await
+        Self::start_with_drand(target, secret, approval, default_actor, None).await
     }
 
     /// Start the signed proxy with optional drand anchoring for approval requests.
@@ -83,7 +100,7 @@ impl SignedProxy {
     pub async fn start_with_drand(
         target: SocketAddr,
         secret: Arc<Vec<u8>>,
-        approval_secret: Option<Arc<Vec<u8>>>,
+        approval: Option<ApprovalSigning>,
         default_actor: Option<String>,
         drand_config: Option<DrandConfig>,
     ) -> std::io::Result<Self> {
@@ -109,7 +126,7 @@ impl SignedProxy {
         let state = SignedProxyState {
             target,
             secret,
-            approval_secret,
+            approval,
             default_actor,
             drand_client,
         };
@@ -158,28 +175,30 @@ async fn proxy_handler(
     let timestamp = now_unix();
     let path = parts.uri.path();
 
-    // Determine secret and whether to use drand anchoring
     let is_approval = path == "/v1/approve";
-    let secret = if is_approval {
-        state.approval_secret.as_ref().unwrap_or(&state.secret)
-    } else {
-        &state.secret
+
+    // Sign an approval with the approval AUTHORITY — Ed25519 when the pod
+    // verifies against public keys, HMAC when it was provisioned a secret,
+    // the plain auth secret when no approval authority was configured. The
+    // message bytes are identical across primitives (see `build_message`), so
+    // the guest-side verifier changed only its primitive, not its framing.
+    let sign_approval = |round: Option<u64>| -> String {
+        let message = build_message(round, timestamp, actor.as_deref(), &body_bytes);
+        match state.approval {
+            Some(ApprovalSigning::Ed25519(ref key)) => {
+                use ed25519_dalek::Signer as _;
+                hex::encode(key.sign(&message).to_bytes())
+            }
+            Some(ApprovalSigning::Hmac(ref secret)) => sign_message(secret, &message),
+            None => sign_message(&state.secret, &message),
+        }
     };
 
     // For approval requests, try to anchor with drand
     let (signature, drand_round) = if is_approval {
         if let Some(ref drand_client) = state.drand_client {
             match drand_client.current_round().await {
-                Ok(round) => {
-                    let sig = sign_request_with_drand(
-                        secret,
-                        round,
-                        timestamp,
-                        actor.as_deref(),
-                        &body_bytes,
-                    );
-                    (sig, Some(round))
-                }
+                Ok(round) => (sign_approval(Some(round)), Some(round)),
                 Err(e) => {
                     // Handle based on fail mode
                     // Note: The DrandClient handles Cached mode internally by using
@@ -197,25 +216,19 @@ async fn proxy_handler(
                             // its cache, so if we're here, the cache is too old.
                             // We fall back to non-drand signing as a last resort.
                             warn!("drand unavailable and cache expired, falling back to non-anchored signing: {e}");
-                            (
-                                sign_request(secret, timestamp, actor.as_deref(), &body_bytes),
-                                None,
-                            )
+                            (sign_approval(None), None)
                         }
                     }
                 }
             }
         } else {
             // No drand client configured, use standard signing
-            (
-                sign_request(secret, timestamp, actor.as_deref(), &body_bytes),
-                None,
-            )
+            (sign_approval(None), None)
         }
     } else {
-        // Non-approval requests use standard signing
+        // Non-approval requests use standard signing with the plain auth secret.
         (
-            sign_request(secret, timestamp, actor.as_deref(), &body_bytes),
+            sign_request(&state.secret, timestamp, actor.as_deref(), &body_bytes),
             None,
         )
     };
@@ -319,44 +332,27 @@ fn build_target_uri(
     builder.build()
 }
 
-fn sign_request(secret: &[u8], timestamp: i64, actor: Option<&str>, body: &[u8]) -> String {
+/// The bytes both primitives sign: `"{round}.{timestamp}.{actor}.{body}"`
+/// when drand-anchored (the round cannot be predicted, which is what stops
+/// pre-computation), `"{timestamp}.{actor}.{body}"` otherwise.
+fn build_message(round: Option<u64>, timestamp: i64, actor: Option<&str>, body: &[u8]) -> Vec<u8> {
     let actor_value = actor.unwrap_or("");
     let ts = timestamp.to_string();
-    let mut message = Vec::with_capacity(ts.len() + actor_value.len() + 2 + body.len());
+    let mut message = Vec::with_capacity(ts.len() + actor_value.len() + 24 + body.len());
+    if let Some(round) = round {
+        message.extend_from_slice(round.to_string().as_bytes());
+        message.push(b'.');
+    }
     message.extend_from_slice(ts.as_bytes());
     message.push(b'.');
     message.extend_from_slice(actor_value.as_bytes());
     message.push(b'.');
     message.extend_from_slice(body);
-    sign_message(secret, &message)
+    message
 }
 
-/// Sign a request with drand anchoring.
-///
-/// Message format: `"{round}.{timestamp}.{actor}.{body}"`
-///
-/// This prevents pre-computation attacks because the drand round cannot be
-/// predicted in advance.
-fn sign_request_with_drand(
-    secret: &[u8],
-    drand_round: u64,
-    timestamp: i64,
-    actor: Option<&str>,
-    body: &[u8],
-) -> String {
-    let actor_value = actor.unwrap_or("");
-    let round_str = drand_round.to_string();
-    let ts = timestamp.to_string();
-    let mut message =
-        Vec::with_capacity(round_str.len() + ts.len() + actor_value.len() + 3 + body.len());
-    message.extend_from_slice(round_str.as_bytes());
-    message.push(b'.');
-    message.extend_from_slice(ts.as_bytes());
-    message.push(b'.');
-    message.extend_from_slice(actor_value.as_bytes());
-    message.push(b'.');
-    message.extend_from_slice(body);
-    sign_message(secret, &message)
+fn sign_request(secret: &[u8], timestamp: i64, actor: Option<&str>, body: &[u8]) -> String {
+    sign_message(secret, &build_message(None, timestamp, actor, body))
 }
 
 async fn forward_request(
@@ -390,4 +386,43 @@ fn now_unix() -> i64 {
 fn proxy_error(status: StatusCode, message: String) -> AxumResponse {
     info!("signed proxy error: {message}");
     (status, message).into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// **The framing contract with the guest-side verifier, pinned as bytes.**
+    /// The tool-proxy's `auth` module reconstructs exactly
+    /// `"{round}.{timestamp}.{actor}.{body}"` (or without the round) from the
+    /// request headers and verifies the signature over it. The two live in
+    /// different crates, so nothing but this test notices if one side's
+    /// framing drifts — and a drift fails EVERY approval, far from the cause.
+    #[test]
+    fn the_signed_message_framing_matches_the_verifier() {
+        assert_eq!(
+            build_message(Some(42), 1000, Some("op"), b"BODY"),
+            b"42.1000.op.BODY".to_vec()
+        );
+        // No round, no actor: the separators stay (an empty actor is framed
+        // as an empty segment, not an absent one).
+        assert_eq!(build_message(None, 1000, None, b"B"), b"1000..B".to_vec());
+    }
+
+    /// An Ed25519 approval signature produced the way the handler produces it
+    /// verifies under `verify_strict` with the public half — the check the
+    /// guest performs against `nucleus.approval_pubkeys`.
+    #[test]
+    fn an_approval_signature_round_trips_to_the_public_key() {
+        use ed25519_dalek::Signer as _;
+        let key = ed25519_dalek::SigningKey::from_bytes(&[7u8; 32]);
+        let message = build_message(Some(9), 1234, Some("approver"), b"{}");
+        let sig_hex = hex::encode(key.sign(&message).to_bytes());
+        let sig_bytes: [u8; 64] = hex::decode(&sig_hex).unwrap().try_into().unwrap();
+        let signature = ed25519_dalek::Signature::from_bytes(&sig_bytes);
+        assert!(key
+            .verifying_key()
+            .verify_strict(&message, &signature)
+            .is_ok());
+    }
 }

--- a/crates/nucleus-node/src/snapshot.rs
+++ b/crates/nucleus-node/src/snapshot.rs
@@ -81,14 +81,17 @@
 /// from Tier 2 and both satisfy the proof. That is a reason to re-derive the
 /// others rather than inherit their notes:
 ///
-/// * **`nucleus.approval_secret`** — NOT redundant. `select_auth_tier` puts the
-///   approval path on `ApprovalHmacDrand` *above* `HostVsock`, deliberately: a
-///   host-verified transport does not remove the drand anchor from an approval.
-///   A conditional emission would need "this pod can never require approval"
-///   derived from the resolved policy, and `requires_approval` lives on an
-///   autonomy ceiling rather than on `PermissionLattice`. Getting that wrong
-///   fails approvals at the moment a human is meant to be in the loop, which is
-///   a worse failure than the exposure it would close.
+/// * **`nucleus.approval_secret`** — GONE (2026-08-08), replaced rather than
+///   conditionally emitted. The earlier note here argued it could not simply
+///   be dropped because the approval path deliberately keeps its drand anchor
+///   even on a host-verified transport — true, and the replacement keeps it:
+///   approvals are now Ed25519 signatures verified against
+///   `nucleus.approval_pubkeys` (the node's PUBLIC approval key, classified
+///   in [`SHARED_CONFIG_KEYS`]: per-node config, and reading a verification
+///   key grants no forging power — unlike the HMAC key, which was symmetric
+///   and let any `/proc/cmdline` reader sign its own approvals). The key
+///   stays in [`PER_POD_SECRET_KEYS`] so a regression that re-emits a shared
+///   approval secret is refused, not silently clonable.
 /// * **`nucleus.task_token_hex` / `_issuer` / `_nonce`** — these are documented
 ///   at the emission site as *"a scoped capability + PUBLIC issuer key — NOT a
 ///   secret"*, with anti-replay resting on a host-pinned nonce. They are in
@@ -163,6 +166,9 @@
 /// someone has that observation, removing the fallback is a guess dressed as a
 /// simplification.
 pub const PER_POD_SECRET_KEYS: &[&str] = &[
+    // No longer emitted (approvals are Ed25519-verified against
+    // `nucleus.approval_pubkeys` now) but categorically refused: a shared
+    // symmetric approval key on a cloned base is the forgery-enabling case.
     "nucleus.approval_secret",
     "nucleus.auth_secret",
     "nucleus.sandbox_token",
@@ -185,6 +191,10 @@ pub const PER_POD_SECRET_KEYS: &[&str] = &[
 /// unclassified rather than silently assumed safe — see
 /// `every_cmdline_key_is_classified`.
 pub const SHARED_CONFIG_KEYS: &[&str] = &[
+    // The Ed25519 PUBLIC half of the node's approval signing key: identical
+    // for every pod on the node, and useless for forging — the guest verifies
+    // with it and can do nothing else.
+    "nucleus.approval_pubkeys",
     "nucleus.audit_s3_bucket",
     "nucleus.audit_s3_endpoint",
     "nucleus.audit_s3_prefix",
@@ -386,7 +396,7 @@ mod tests {
     /// [`snapshot_safety`] becomes satisfiable by construction. **That was
     /// wrong**, and this test is what makes the error visible instead of
     /// discovering it when the warm pool is built. Phase 1 deleted exactly one
-    /// key — `nucleus.auth_secret` — and FIVE remain.
+    /// key — `nucleus.auth_secret` — and FOUR remain.
     ///
     /// The count has been wrong before, in the dangerous direction: an earlier
     /// version of this test scanned only for `nucleus.key=` and asserted five
@@ -409,11 +419,13 @@ mod tests {
     /// in prose and matches neither form, which is correct — it is no longer
     /// emitted).
     ///
-    /// **Back to five (2026-08-08):** the three AWS audit credentials now ride
+    /// **Down to four (2026-08-08):** the three AWS audit credentials now ride
     /// the workload API (`FETCH_AUDIT_CREDENTIALS`, served once before any
-    /// workload exists) and are no longer emitted onto the command line. They
-    /// STAY in [`PER_POD_SECRET_KEYS`]: the denylist is categorical, so a
-    /// regression that re-emits them is refused by `snapshot_safety` at runtime
+    /// workload exists), and `nucleus.approval_secret` was replaced by
+    /// signature-based approvals (`nucleus.approval_pubkeys` — a public
+    /// verification key, classified shared). All four STAY in
+    /// [`PER_POD_SECRET_KEYS`]: the denylist is categorical, so a regression
+    /// that re-emits any of them is refused by `snapshot_safety` at runtime
     /// and re-counted here at test time.
     ///
     /// A ratchet in both directions, and it is also the only guard on the
@@ -422,7 +434,7 @@ mod tests {
     /// per-pod secret fails here; removing one is progress and forces this list
     /// to be re-stated rather than quietly drifting.
     #[test]
-    fn the_remaining_distance_to_a_snapshottable_base_is_five_keys() {
+    fn the_remaining_distance_to_a_snapshottable_base_is_four_keys() {
         let src = include_str!("firecracker_config.rs");
         let mut emitted: Vec<&str> = Vec::new();
         for key in PER_POD_SECRET_KEYS {
@@ -437,7 +449,6 @@ mod tests {
         emitted.sort_unstable();
 
         let expected = [
-            "nucleus.approval_secret",
             "nucleus.sandbox_token",
             "nucleus.task_token_hex",
             "nucleus.task_token_issuer",
@@ -460,7 +471,7 @@ mod tests {
     #[test]
     fn a_realistic_pod_cmdline_is_still_refused_today() {
         let realistic = format!(
-            "{BASE} nucleus.workload_api_port=15012 nucleus.approval_secret=deadbeef \
+            "{BASE} nucleus.workload_api_port=15012 nucleus.approval_pubkeys=aa00bb11 \
              nucleus.sandbox_token=abc123 nucleus.task_token_hex=7b7d"
         );
         match snapshot_safety(&realistic) {
@@ -471,7 +482,7 @@ mod tests {
             SnapshotSafety::SafeToClone => panic!(
                 "a realistic pod command line reported safe to clone — either the per-pod \
                  material really has been removed (in which case this test and \
-                 `the_remaining_distance_to_a_snapshottable_base_is_five_keys` should both be \
+                 `the_remaining_distance_to_a_snapshottable_base_is_four_keys` should both be \
                  updated, and the warm pool is unblocked), or the guard has stopped matching"
             ),
         }

--- a/crates/nucleus-node/src/tests_main.rs
+++ b/crates/nucleus-node/src/tests_main.rs
@@ -479,17 +479,36 @@ fn the_auth_secret_never_reaches_the_guest_command_line() {
     assert!(!snapshot_safety("console=ttyS0 nucleus.auth_secret=abc").is_safe_to_clone());
 }
 
-/// The approval secret is DELIBERATELY still emitted. Phase 1 removes the key
-/// the transport can replace; the approval endpoint is drand-anchored and
-/// freshness is not origin, so its key needs a drand-only tier first. Asserting
-/// this keeps the remaining exposure visible instead of quietly forgotten.
+/// THE NEGATIVE TEST FOR SIGNED APPROVALS. The approval secret was the last
+/// real secret on the guest command line — and it was worse than a leak: HMAC
+/// is symmetric, so the guest's verification key was also a signing key, and
+/// any workload reading /proc/cmdline could FORGE approvals. What rides now is
+/// `nucleus.approval_pubkeys`, the Ed25519 PUBLIC half of the node's approval
+/// key: verification only, no forging power. (This test previously pinned the
+/// OPPOSITE — "still emitted and tracked" — and failed the moment the emission
+/// was removed, exactly as intended.)
 #[test]
-fn the_approval_secret_is_still_emitted_and_that_is_tracked() {
+fn the_approval_secret_never_reaches_the_guest_command_line() {
+    use crate::snapshot::snapshot_safety;
     let src = include_str!("firecracker_config.rs");
+    let emits_approval_secret = src
+        .lines()
+        .filter(|l| !l.trim_start().starts_with("//"))
+        .any(|l| l.contains("nucleus.approval_secret="));
     assert!(
-        src.contains("nucleus.approval_secret={approval_secret}"),
-        "if the approval secret has been removed, delete this test and the note beside it"
+        !emits_approval_secret,
+        "firecracker_config emits nucleus.approval_secret again — that key lets any \
+         /proc/cmdline reader forge approvals; approvals are Ed25519-verified against \
+         nucleus.approval_pubkeys now"
     );
+    // The pods must still be given the VERIFICATION key, or approvals brick.
+    assert!(
+        src.contains("nucleus.approval_pubkeys={approval_pubkeys}"),
+        "the approval public key is no longer delivered — pods cannot verify approvals"
+    );
+    // And a command line carrying the old secret is still refused as a
+    // snapshot base — the denylist is categorical, not tied to emission.
+    assert!(!snapshot_safety("console=ttyS0 nucleus.approval_secret=abc").is_safe_to_clone());
 }
 
 // ── Proof-carrying admission: the posture gate on a real rootfs ───────────

--- a/crates/nucleus-node/src/trust_gate.rs
+++ b/crates/nucleus-node/src/trust_gate.rs
@@ -103,6 +103,14 @@ const EXECUTOR_KEY_FILE: &str = "executor_signing_key.der";
 /// [`EXECUTOR_KEY_FILE`] so the two trust roles never share a key.
 const TASK_ISSUER_KEY_FILE: &str = "task_issuer_signing_key.der";
 
+/// Filename (under `state_dir`) holding the persisted **approval** signing
+/// key — the key whose signatures the guest tool-proxy accepts on
+/// `/v1/approve`, verified against the PUBLIC half delivered as
+/// `nucleus.approval_pubkeys`. DISTINCT from the other two role keys: the
+/// approval authority must not double as the executor's receipt identity or
+/// the task-token root.
+const APPROVAL_SIGNING_KEY_FILE: &str = "approval_signing_key.der";
+
 /// Generate a fresh Ed25519 signing key from the OS CSPRNG.
 ///
 /// Samples 32 raw bytes via `rand_core 0.6`'s `fill_bytes` and feeds
@@ -147,6 +155,17 @@ pub fn load_or_create_signing_key(state_dir: &Path) -> SigningKey {
 /// is also the executor's receipt identity) never doubles as a token root.
 pub fn load_or_create_task_issuer_signing_key(state_dir: &Path) -> SigningKey {
     load_or_create_key_file(state_dir, TASK_ISSUER_KEY_FILE, "task issuer signing key")
+}
+
+/// Load the dedicated **approval** Ed25519 signing key from `state_dir`,
+/// creating and persisting a fresh one on first run.
+///
+/// Same persistence discipline as the other role keys, and persistence
+/// matters MORE here: a running pod verifies approvals against the public key
+/// it booted with, so a node that minted a fresh key on every restart could
+/// no longer approve anything for pods launched before the restart.
+pub fn load_or_create_approval_signing_key(state_dir: &Path) -> SigningKey {
+    load_or_create_key_file(state_dir, APPROVAL_SIGNING_KEY_FILE, "approval signing key")
 }
 
 /// Shared implementation for the persisted per-node Ed25519 keys. `filename` is

--- a/crates/nucleus-node/src/workload_api_protocol.rs
+++ b/crates/nucleus-node/src/workload_api_protocol.rs
@@ -121,8 +121,10 @@ pub enum WorkloadApiCommand {
     /// # Why not the kernel command line
     ///
     /// `/proc/cmdline` is world-readable in the guest, which is where
-    /// `nucleus.auth_secret` and `nucleus.approval_secret` arrive today. Neither
-    /// is a proxy-only capability for exactly that reason.
+    /// `nucleus.auth_secret` and `nucleus.approval_secret` once arrived —
+    /// neither was a proxy-only capability for exactly that reason, and both
+    /// are gone from the command line now (the transport peer check replaced
+    /// one, signature-based approvals the other).
     FetchBrokerSecret,
     /// `FETCH_AUDIT_CREDENTIALS` — request the cloud credentials for this pod's
     /// S3 audit sink.

--- a/crates/nucleus-tool-proxy/Cargo.toml
+++ b/crates/nucleus-tool-proxy/Cargo.toml
@@ -48,6 +48,10 @@ tracing-subscriber = { workspace = true }
 hmac = { workspace = true }
 sha2 = { workspace = true }
 hex = { workspace = true }
+# Signature-based approvals: the guest verifies an approver's Ed25519
+# signature against configured PUBLIC keys (verify_strict only — see M-3).
+# Was dev-only; promoted when /v1/approve gained the signature tier.
+ed25519-dalek = { workspace = true }
 # The workload-spawn hardening hook (setgroups/setgid/prctl/setrlimit in a
 # pre_exec closure). Same version the `nucleus` crate uses for `hardening.rs`.
 libc = "0.2"
@@ -118,7 +122,6 @@ tokio-vsock = "0.7"
 dlc-crypto = { git = "https://github.com/coproduct-opensource/delegation_calc.git", rev = "34358234cb46279c4ce8a8729736a4135174f65a" }
 dlc-d = { git = "https://github.com/coproduct-opensource/delegation_calc.git", rev = "34358234cb46279c4ce8a8729736a4135174f65a" }
 tempfile = { workspace = true }
-ed25519-dalek = { workspace = true }
 # In-process router driving for the H-3 panic-net regression test
 # (ServiceExt::oneshot). Dev-only; production graph unchanged.
 tower = { version = "0.5", features = ["util"] }

--- a/crates/nucleus-tool-proxy/src/auth.rs
+++ b/crates/nucleus-tool-proxy/src/auth.rs
@@ -118,6 +118,13 @@ pub enum AuthMethod {
     /// so "this came from the host" is enforced below the application rather
     /// than asserted by it. See `pod_mgmt::peer_is_host`.
     HostVsock,
+    /// Ed25519 signature against a configured PUBLIC key, drand-anchored.
+    ///
+    /// The signature-based approval tier: the guest holds only verification
+    /// keys, so — unlike the HMAC tiers — nothing the guest stores lets anyone
+    /// FORGE an approval. This is what lets `nucleus.approval_secret` leave
+    /// the world-readable kernel command line.
+    Ed25519Drand,
 }
 
 /// How the request's identity was bound to its permissions.
@@ -329,6 +336,171 @@ pub fn verify_http_with_drand(
     })
 }
 
+/// The approval verifier's key set plus the freshness policy it inherits.
+///
+/// # Why public keys instead of the approval HMAC secret
+///
+/// The HMAC design put the VERIFICATION key in the guest — and an HMAC
+/// verification key is also the signing key, so any guest process that read it
+/// (it rode the world-readable `/proc/cmdline`) could forge approvals for its
+/// own operations. An Ed25519 verifying key grants no signing power: the guest
+/// can check an approver's signature and can do nothing else with the key.
+/// Secrets and signing keys stay host-side; the guest gets public keys and
+/// host-origin verdicts.
+#[derive(Clone)]
+pub struct ApprovalVerifier {
+    keys: Vec<ed25519_dalek::VerifyingKey>,
+    max_skew: Duration,
+    drand_config: Option<DrandConfig>,
+}
+
+impl ApprovalVerifier {
+    /// Build from a comma-separated list of 64-char-hex Ed25519 verifying
+    /// keys. Malformed entries are REJECTED (`Err`), not skipped: a typo'd
+    /// key silently dropped would leave approvals verifying against fewer
+    /// keys than the operator configured, and the failure would surface as an
+    /// unexplained refusal far from the cause. Startup is the right place to
+    /// stop.
+    pub fn from_hex_list(
+        raw: &str,
+        max_skew: Duration,
+        drand_config: Option<DrandConfig>,
+    ) -> Result<Self, String> {
+        let mut keys = Vec::new();
+        for entry in raw.split(',').map(str::trim).filter(|s| !s.is_empty()) {
+            let bytes = hex::decode(entry)
+                .map_err(|_| format!("approval pubkey is not valid hex: {entry:.16}…"))?;
+            let arr = <[u8; 32]>::try_from(bytes.as_slice())
+                .map_err(|_| format!("approval pubkey is not 32 bytes: {entry:.16}…"))?;
+            let key = ed25519_dalek::VerifyingKey::from_bytes(&arr).map_err(|_| {
+                format!("approval pubkey is not a valid Ed25519 point: {entry:.16}…")
+            })?;
+            keys.push(key);
+        }
+        if keys.is_empty() {
+            return Err("approval pubkey list is empty".to_string());
+        }
+        Ok(Self {
+            keys,
+            max_skew,
+            drand_config,
+        })
+    }
+
+    /// How many keys are configured (for startup logging — never the keys).
+    pub fn key_count(&self) -> usize {
+        self.keys.len()
+    }
+}
+
+/// Verify an approval request signed with an approver's Ed25519 key.
+///
+/// Same message formats and drand semantics as [`verify_http_with_drand`] —
+/// with drand: `"{round}.{timestamp}.{actor}.{body}"`, without:
+/// `"{timestamp}.{actor}.{body}"` (the latter only in `Cached` fail mode or
+/// with drand disabled; `Strict` requires the round). The signature header
+/// carries 128 hex chars (64 bytes), verified with `verify_strict` (M-3:
+/// cofactored verification accepts small-order points — key-substitution)
+/// against EVERY configured key until one matches.
+pub fn verify_http_with_ed25519_drand(
+    headers: &HeaderMap,
+    body: &[u8],
+    verifier: &ApprovalVerifier,
+) -> Result<AuthContext, AuthError> {
+    let ts = header_value(headers, HEADER_TIMESTAMP)?;
+    let sig = header_value(headers, HEADER_SIGNATURE)?;
+    let actor = headers
+        .get(HEADER_ACTOR)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string());
+    let actor_value = actor.clone().unwrap_or_default();
+
+    let timestamp = parse_timestamp(ts)?;
+    ensure_skew(timestamp, verifier.max_skew)?;
+
+    let drand_round = headers
+        .get(HEADER_DRAND_ROUND)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.parse::<u64>().ok());
+
+    if let Some(ref drand_config) = verifier.drand_config {
+        if drand_config.enabled {
+            match drand_round {
+                Some(round) => {
+                    let expected = drand::current_expected_round();
+                    if !drand::validate_round(round, drand_config.round_tolerance) {
+                        return Err(AuthError::DrandRoundExpired {
+                            provided: round,
+                            expected,
+                            tolerance: drand_config.round_tolerance,
+                        });
+                    }
+                    let message = signed_message(format!("{round}.{ts}.{actor_value}."), body);
+                    verify_ed25519_any(&verifier.keys, &message, sig)?;
+                    return Ok(AuthContext {
+                        actor,
+                        timestamp,
+                        drand_round: Some(round),
+                        spiffe_id: None,
+                        auth_method: AuthMethod::Ed25519Drand,
+                        identity_binding: IdentityBinding::PolicyOnly,
+                    });
+                }
+                None => match drand_config.fail_mode {
+                    DrandFailMode::Strict => return Err(AuthError::DrandRequired),
+                    DrandFailMode::Cached => {
+                        tracing::warn!(
+                            "drand anchoring enabled but no round provided, accepting \
+                             signature without anchoring (cached mode)"
+                        );
+                    }
+                },
+            }
+        }
+    }
+
+    let message = signed_message(format!("{ts}.{actor_value}."), body);
+    verify_ed25519_any(&verifier.keys, &message, sig)?;
+    Ok(AuthContext {
+        actor,
+        timestamp,
+        drand_round: None,
+        spiffe_id: None,
+        auth_method: AuthMethod::Ed25519Drand,
+        identity_binding: IdentityBinding::PolicyOnly,
+    })
+}
+
+/// The signed message: a text prefix (`"round.ts.actor."` or `"ts.actor."`)
+/// followed by the raw body bytes — byte-identical to what the HMAC tiers
+/// sign, so the host-side signer changes only its primitive, not its framing.
+fn signed_message(prefix: String, body: &[u8]) -> Vec<u8> {
+    let mut message = prefix.into_bytes();
+    message.extend_from_slice(body);
+    message
+}
+
+/// `verify_strict` against every configured key. Multiple approver keys are a
+/// roster, not a quorum: any single configured approver may approve, exactly
+/// as any holder of the old shared secret could.
+fn verify_ed25519_any(
+    keys: &[ed25519_dalek::VerifyingKey],
+    message: &[u8],
+    signature_hex: &str,
+) -> Result<(), AuthError> {
+    let bytes = hex::decode(signature_hex).map_err(|_| AuthError::InvalidSignature)?;
+    let arr = <[u8; 64]>::try_from(bytes.as_slice()).map_err(|_| AuthError::InvalidSignature)?;
+    let signature = ed25519_dalek::Signature::from_bytes(&arr);
+    if keys
+        .iter()
+        .any(|key| key.verify_strict(message, &signature).is_ok())
+    {
+        Ok(())
+    } else {
+        Err(AuthError::InvalidSignature)
+    }
+}
+
 /// Authenticate a request purely from the transport it arrived on.
 ///
 /// # Why this needs no secret
@@ -410,7 +582,15 @@ pub enum AuthTier {
     /// A client certificate was presented — strongest, and independent of how
     /// the server was bound.
     SpiffeMtls,
-    /// The approval endpoint, which has its own drand-anchored HMAC.
+    /// The approval endpoint with approver PUBLIC keys configured: Ed25519 +
+    /// drand. Takes precedence over the HMAC approval tier — when the guest
+    /// holds verifying keys, a shared-secret signature must not be an
+    /// alternative way in, or the readable-key forgery the keys exist to
+    /// remove is silently reinstated.
+    ApprovalEd25519Drand,
+    /// The approval endpoint, which has its own drand-anchored HMAC. The
+    /// legacy tier, for pods provisioned with a secret instead of keys (the
+    /// env-delivered container path).
     ApprovalHmacDrand,
     /// The transport already proved the peer is the host.
     HostVsock,
@@ -421,14 +601,18 @@ pub enum AuthTier {
 /// Choose the tier from facts about the request and the binding.
 ///
 /// `host_verified_transport` is a property of how the server was STARTED, never
-/// of the request — see `AppState::host_verified_transport`.
+/// of the request — see `AppState::host_verified_transport`. Likewise
+/// `has_approval_pubkeys` is startup configuration, not request content.
 pub fn select_auth_tier(
     has_spiffe_identity: bool,
     is_approval_path: bool,
+    has_approval_pubkeys: bool,
     host_verified_transport: bool,
 ) -> AuthTier {
     if has_spiffe_identity {
         AuthTier::SpiffeMtls
+    } else if is_approval_path && has_approval_pubkeys {
+        AuthTier::ApprovalEd25519Drand
     } else if is_approval_path {
         AuthTier::ApprovalHmacDrand
     } else if host_verified_transport {
@@ -803,7 +987,7 @@ mod auth_tier_precedence_tests {
     #[test]
     fn a_host_verified_transport_skips_the_shared_secret_hmac() {
         assert_eq!(
-            select_auth_tier(false, false, true),
+            select_auth_tier(false, false, false, true),
             AuthTier::HostVsock,
             "a request on a host-only vsock listener must not need the HMAC key"
         );
@@ -813,7 +997,7 @@ mod auth_tier_precedence_tests {
     /// a secret where the transport replaces it, it does not remove auth.
     #[test]
     fn other_transports_still_require_the_hmac() {
-        assert_eq!(select_auth_tier(false, false, false), AuthTier::Hmac);
+        assert_eq!(select_auth_tier(false, false, false, false), AuthTier::Hmac);
     }
 
     /// A certificate outranks the transport: mTLS identifies WHO, the transport
@@ -821,8 +1005,14 @@ mod auth_tier_precedence_tests {
     /// stronger claim.
     #[test]
     fn mtls_outranks_the_transport() {
-        assert_eq!(select_auth_tier(true, false, true), AuthTier::SpiffeMtls);
-        assert_eq!(select_auth_tier(true, true, true), AuthTier::SpiffeMtls);
+        assert_eq!(
+            select_auth_tier(true, false, false, true),
+            AuthTier::SpiffeMtls
+        );
+        assert_eq!(
+            select_auth_tier(true, true, true, true),
+            AuthTier::SpiffeMtls
+        );
     }
 
     /// The approval path keeps its drand anchoring even on a host-verified
@@ -831,31 +1021,239 @@ mod auth_tier_precedence_tests {
     #[test]
     fn the_approval_path_keeps_drand_even_on_a_host_verified_transport() {
         assert_eq!(
-            select_auth_tier(false, true, true),
+            select_auth_tier(false, true, false, true),
             AuthTier::ApprovalHmacDrand,
             "origin is not freshness — approvals must stay drand-anchored"
         );
     }
 
-    /// Exhaustive over all eight inputs, so no combination is unconsidered.
+    /// **When approver public keys are configured, the shared-secret approval
+    /// tier must be UNREACHABLE.** If HMAC stayed accepted alongside, any
+    /// residual copy of the old secret would still forge approvals and the
+    /// keys would have removed nothing.
+    #[test]
+    fn configured_pubkeys_make_the_hmac_approval_tier_unreachable() {
+        assert_eq!(
+            select_auth_tier(false, true, true, false),
+            AuthTier::ApprovalEd25519Drand
+        );
+        assert_eq!(
+            select_auth_tier(false, true, true, true),
+            AuthTier::ApprovalEd25519Drand,
+            "the signature tier must win even on a host-verified transport"
+        );
+    }
+
+    /// Pubkeys configured but the request is NOT for the approval path: the
+    /// keys authorize approvals, nothing else — other paths keep their tiers.
+    #[test]
+    fn approval_pubkeys_do_not_leak_into_other_paths() {
+        assert_eq!(
+            select_auth_tier(false, false, true, true),
+            AuthTier::HostVsock
+        );
+        assert_eq!(select_auth_tier(false, false, true, false), AuthTier::Hmac);
+    }
+
+    /// Exhaustive over all sixteen inputs, so no combination is unconsidered.
     #[test]
     fn every_combination_is_pinned() {
         let cases = [
-            ((false, false, false), AuthTier::Hmac),
-            ((false, false, true), AuthTier::HostVsock),
-            ((false, true, false), AuthTier::ApprovalHmacDrand),
-            ((false, true, true), AuthTier::ApprovalHmacDrand),
-            ((true, false, false), AuthTier::SpiffeMtls),
-            ((true, false, true), AuthTier::SpiffeMtls),
-            ((true, true, false), AuthTier::SpiffeMtls),
-            ((true, true, true), AuthTier::SpiffeMtls),
+            ((false, false, false, false), AuthTier::Hmac),
+            ((false, false, false, true), AuthTier::HostVsock),
+            ((false, false, true, false), AuthTier::Hmac),
+            ((false, false, true, true), AuthTier::HostVsock),
+            ((false, true, false, false), AuthTier::ApprovalHmacDrand),
+            ((false, true, false, true), AuthTier::ApprovalHmacDrand),
+            ((false, true, true, false), AuthTier::ApprovalEd25519Drand),
+            ((false, true, true, true), AuthTier::ApprovalEd25519Drand),
+            ((true, false, false, false), AuthTier::SpiffeMtls),
+            ((true, false, false, true), AuthTier::SpiffeMtls),
+            ((true, false, true, false), AuthTier::SpiffeMtls),
+            ((true, false, true, true), AuthTier::SpiffeMtls),
+            ((true, true, false, false), AuthTier::SpiffeMtls),
+            ((true, true, false, true), AuthTier::SpiffeMtls),
+            ((true, true, true, false), AuthTier::SpiffeMtls),
+            ((true, true, true, true), AuthTier::SpiffeMtls),
         ];
-        for ((spiffe, approval, host), expected) in cases {
+        for ((spiffe, approval, pubkeys, host), expected) in cases {
             assert_eq!(
-                select_auth_tier(spiffe, approval, host),
+                select_auth_tier(spiffe, approval, pubkeys, host),
                 expected,
-                "spiffe={spiffe} approval={approval} host_verified={host}"
+                "spiffe={spiffe} approval={approval} pubkeys={pubkeys} host_verified={host}"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod ed25519_approval_tests {
+    use super::*;
+    use axum::http::HeaderValue;
+    use ed25519_dalek::{Signer, SigningKey};
+
+    fn signing_key(seed: u8) -> SigningKey {
+        SigningKey::from_bytes(&[seed; 32])
+    }
+
+    fn verifier_for(keys: &[&SigningKey], drand: bool) -> ApprovalVerifier {
+        let hex_list = keys
+            .iter()
+            .map(|k| hex::encode(k.verifying_key().to_bytes()))
+            .collect::<Vec<_>>()
+            .join(",");
+        let drand_config = drand.then(DrandConfig::default);
+        ApprovalVerifier::from_hex_list(&hex_list, Duration::from_secs(60), drand_config).unwrap()
+    }
+
+    fn now() -> i64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64
+    }
+
+    fn signed_headers(key: &SigningKey, round: Option<u64>, ts: i64, body: &[u8]) -> HeaderMap {
+        let prefix = match round {
+            Some(r) => format!("{r}.{ts}.approver."),
+            None => format!("{ts}.approver."),
+        };
+        let message = signed_message(prefix, body);
+        let sig = hex::encode(key.sign(&message).to_bytes());
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            HEADER_TIMESTAMP,
+            HeaderValue::from_str(&ts.to_string()).unwrap(),
+        );
+        headers.insert(HEADER_SIGNATURE, HeaderValue::from_str(&sig).unwrap());
+        headers.insert(HEADER_ACTOR, HeaderValue::from_static("approver"));
+        if let Some(r) = round {
+            headers.insert(
+                HEADER_DRAND_ROUND,
+                HeaderValue::from_str(&r.to_string()).unwrap(),
+            );
+        }
+        headers
+    }
+
+    /// The happy path: a drand-anchored signature from a configured approver
+    /// key verifies, and the context records the signature method and round.
+    #[test]
+    fn a_configured_approvers_signature_verifies() {
+        let key = signing_key(1);
+        let round = drand::current_expected_round();
+        let body = b"{\"operation\":\"bash rm\"}";
+        let headers = signed_headers(&key, Some(round), now(), body);
+        let ctx =
+            verify_http_with_ed25519_drand(&headers, body, &verifier_for(&[&key], true)).unwrap();
+        assert_eq!(ctx.auth_method, AuthMethod::Ed25519Drand);
+        assert_eq!(ctx.drand_round, Some(round));
+        assert_eq!(ctx.actor, Some("approver".to_string()));
+    }
+
+    /// **The forgery this tier exists to prevent.** A signature from a key the
+    /// operator never configured — e.g. one a workload minted for itself —
+    /// must be refused. Under the HMAC design the workload could read the
+    /// verification key and pass this check.
+    #[test]
+    fn an_unconfigured_key_cannot_approve() {
+        let approver = signing_key(1);
+        let workload = signing_key(2);
+        let round = drand::current_expected_round();
+        let body = b"body";
+        let headers = signed_headers(&workload, Some(round), now(), body);
+        let result =
+            verify_http_with_ed25519_drand(&headers, body, &verifier_for(&[&approver], true));
+        assert!(matches!(result, Err(AuthError::InvalidSignature)));
+    }
+
+    /// Any configured approver may approve (a roster, not a quorum) — the
+    /// second key in the list is as good as the first.
+    #[test]
+    fn any_key_in_the_roster_may_approve() {
+        let first = signing_key(1);
+        let second = signing_key(2);
+        let round = drand::current_expected_round();
+        let body = b"body";
+        let headers = signed_headers(&second, Some(round), now(), body);
+        let result =
+            verify_http_with_ed25519_drand(&headers, body, &verifier_for(&[&first, &second], true));
+        assert!(result.is_ok(), "got {result:?}");
+    }
+
+    /// Freshness survives the primitive swap: strict drand mode still refuses
+    /// a request with no round — a signature is origin, not freshness.
+    #[test]
+    fn strict_drand_still_requires_a_round() {
+        let key = signing_key(1);
+        let body = b"body";
+        let headers = signed_headers(&key, None, now(), body);
+        let result = verify_http_with_ed25519_drand(&headers, body, &verifier_for(&[&key], true));
+        assert!(matches!(result, Err(AuthError::DrandRequired)));
+    }
+
+    /// And a stale round is refused even with a valid signature over it.
+    #[test]
+    fn a_stale_round_is_refused() {
+        let key = signing_key(1);
+        let round = drand::current_expected_round().saturating_sub(10_000);
+        let body = b"body";
+        let headers = signed_headers(&key, Some(round), now(), body);
+        let result = verify_http_with_ed25519_drand(&headers, body, &verifier_for(&[&key], true));
+        assert!(matches!(result, Err(AuthError::DrandRoundExpired { .. })));
+    }
+
+    /// A signature over one body must not authorize another: the approval's
+    /// operation is IN the body, so accepting a swapped body would let one
+    /// approval authorize a different operation.
+    #[test]
+    fn a_signature_does_not_transfer_to_a_different_body() {
+        let key = signing_key(1);
+        let round = drand::current_expected_round();
+        let headers = signed_headers(&key, Some(round), now(), b"approve ls");
+        let result = verify_http_with_ed25519_drand(
+            &headers,
+            b"approve rm -rf",
+            &verifier_for(&[&key], true),
+        );
+        assert!(matches!(result, Err(AuthError::InvalidSignature)));
+    }
+
+    /// An HMAC-shaped signature (32 bytes, the old primitive) is refused by
+    /// length before any curve math — the legacy secret cannot approve here.
+    #[test]
+    fn an_hmac_signature_is_not_a_valid_ed25519_signature() {
+        let key = signing_key(1);
+        let round = drand::current_expected_round();
+        let ts = now();
+        let body = b"body";
+        let mut headers = signed_headers(&key, Some(round), ts, body);
+        let hmac_sig = sign_message(b"the-old-approval-secret", b"whatever");
+        headers.insert(HEADER_SIGNATURE, HeaderValue::from_str(&hmac_sig).unwrap());
+        let result = verify_http_with_ed25519_drand(&headers, body, &verifier_for(&[&key], true));
+        assert!(matches!(result, Err(AuthError::InvalidSignature)));
+    }
+
+    /// **Malformed keys stop startup, they are not skipped.** A typo'd entry
+    /// silently dropped would verify against fewer keys than the operator
+    /// configured, surfacing as unexplained refusals far from the cause.
+    #[test]
+    fn a_malformed_key_is_an_error_not_a_skip() {
+        let good = hex::encode(signing_key(1).verifying_key().to_bytes());
+        for bad in ["nothex", "aabb", ""] {
+            let raw = format!("{good},{bad}");
+            let result = ApprovalVerifier::from_hex_list(&raw, Duration::from_secs(60), None);
+            if bad.is_empty() {
+                // A trailing comma is tolerated (empty entries are filtered);
+                // the list still has the good key.
+                assert_eq!(result.unwrap().key_count(), 1);
+            } else {
+                assert!(result.is_err(), "{bad:?} must be rejected");
+            }
+        }
+        assert!(
+            ApprovalVerifier::from_hex_list("  ", Duration::from_secs(60), None).is_err(),
+            "an empty list is not a verifier"
+        );
     }
 }

--- a/crates/nucleus-tool-proxy/src/main.rs
+++ b/crates/nucleus-tool-proxy/src/main.rs
@@ -126,9 +126,19 @@ struct Args {
     /// See `art12_shipper` for why this is fail-closed and why it matters.
     #[arg(long, env = "NUCLEUS_TOOL_PROXY_ART12_SHIP_URL")]
     art12_ship_url: Option<String>,
-    /// Approval authority secret (separate from tool auth).
-    #[arg(long, env = "NUCLEUS_TOOL_PROXY_APPROVAL_SECRET")]
+    /// Approval authority secret (separate from tool auth). Legacy: superseded
+    /// by `--approval-pubkeys` wherever that is set. Empty means "not
+    /// provisioned", which is fatal at startup unless pubkeys are.
+    #[arg(long, env = "NUCLEUS_TOOL_PROXY_APPROVAL_SECRET", default_value = "")]
     approval_secret: String,
+    /// Comma-separated 64-char-hex Ed25519 approver PUBLIC keys. When set,
+    /// `/v1/approve` accepts ONLY an approver's signature (drand-anchored);
+    /// no approval secret exists in the guest to steal. This is how
+    /// Firecracker pods are provisioned (`nucleus.approval_pubkeys` — a
+    /// verification key is safe on the world-readable cmdline, and it is
+    /// per-node config, so it does not block a snapshot base).
+    #[arg(long, env = "NUCLEUS_TOOL_PROXY_APPROVAL_PUBKEYS")]
+    approval_pubkeys: Option<String>,
     /// Optional webhook URL for remote audit log delivery.
     /// Entries are POSTed as JSON with HMAC signature in X-Nucleus-Signature header.
     #[arg(long, env = "NUCLEUS_TOOL_PROXY_AUDIT_WEBHOOK")]
@@ -332,6 +342,12 @@ pub(crate) struct AppState {
     receipts: Arc<portcullis_effects::receipt::ReceiptLog>,
     auth: AuthConfig,
     approval_auth: AuthConfig,
+    /// Approver PUBLIC keys for signature-based approvals. `Some` makes the
+    /// Ed25519 tier the ONLY way into `/v1/approve` (the HMAC approval tier
+    /// becomes unreachable — see `auth::select_auth_tier`); `None` keeps the
+    /// legacy shared-secret tier for env-provisioned container pods. Holding
+    /// only verifying keys, the guest cannot forge what it checks.
+    approval_verifier: Option<auth::ApprovalVerifier>,
     /// True when this server was started on a vsock listener that accepts only
     /// the host (`pod_mgmt::peer_is_host`).
     ///
@@ -1483,10 +1499,50 @@ async fn main() -> Result<(), ApiError> {
             args.approval_secret.as_bytes(),
             Duration::from_secs(args.auth_max_skew_secs),
         );
-        if let Some(drand) = drand_config {
-            config.with_drand(drand)
+        if let Some(ref drand) = drand_config {
+            config.with_drand(drand.clone())
         } else {
             config
+        }
+    };
+
+    // Signature-based approvals: approver PUBLIC keys, drand-anchored. A
+    // malformed key list is fatal HERE, not skipped — silently verifying
+    // against fewer keys than configured surfaces as unexplained refusals far
+    // from the cause. And a pod with NEITHER pubkeys nor a secret has an
+    // approval endpoint nobody can authenticate to; that is a provisioning
+    // error, and startup is where it should stop.
+    let approval_verifier = match args.approval_pubkeys.as_deref() {
+        Some(raw) if !raw.trim().is_empty() => {
+            match auth::ApprovalVerifier::from_hex_list(
+                raw,
+                Duration::from_secs(args.auth_max_skew_secs),
+                drand_config.clone(),
+            ) {
+                Ok(v) => {
+                    eprintln!(
+                        "approvals are signature-based: {} approver key(s), no shared secret \
+                         in this guest",
+                        v.key_count()
+                    );
+                    Some(v)
+                }
+                Err(e) => {
+                    eprintln!("FATAL: NUCLEUS_TOOL_PROXY_APPROVAL_PUBKEYS: {e}");
+                    std::process::exit(78);
+                }
+            }
+        }
+        _ => {
+            if args.approval_secret.trim().is_empty() {
+                eprintln!(
+                    "FATAL: no approval authority is provisioned — set \
+                     NUCLEUS_TOOL_PROXY_APPROVAL_PUBKEYS (signature-based) or \
+                     NUCLEUS_TOOL_PROXY_APPROVAL_SECRET (legacy shared secret)"
+                );
+                std::process::exit(78);
+            }
+            None
         }
     };
 
@@ -1781,6 +1837,7 @@ async fn main() -> Result<(), ApiError> {
         audit,
         auth,
         approval_auth,
+        approval_verifier,
         host_verified_transport: vsock_binding.is_some(),
         approval_nonces: Arc::new(ApprovalNonceCache::default()),
         approval_rate_limiter: Arc::new(ApprovalRateLimiter::default()),
@@ -2276,10 +2333,13 @@ async fn auth_middleware(
         auth::select_auth_tier(
             auth::extract_spiffe_id_from_extensions(&parts.extensions).is_some(),
             parts.uri.path() == APPROVE_PATH,
+            state.approval_verifier.is_some(),
             state.host_verified_transport,
         ),
         if auth::extract_spiffe_id_from_extensions(&parts.extensions).is_some() {
             auth::AuthTier::SpiffeMtls
+        } else if parts.uri.path() == APPROVE_PATH && state.approval_verifier.is_some() {
+            auth::AuthTier::ApprovalEd25519Drand
         } else if parts.uri.path() == APPROVE_PATH {
             auth::AuthTier::ApprovalHmacDrand
         } else if state.host_verified_transport {
@@ -2300,7 +2360,15 @@ async fn auth_middleware(
             );
             auth::verify_spiffe_mtls(&spiffe_id)
         } else if parts.uri.path() == APPROVE_PATH {
-            let ctx = auth::verify_http_with_drand(&parts.headers, &bytes, &state.approval_auth)?;
+            // Signature tier FIRST, and exclusively: when approver public keys
+            // are configured, the shared-secret HMAC must not remain an
+            // alternative way in — any residual copy of the old secret would
+            // still forge approvals and the keys would have removed nothing.
+            let ctx = if let Some(ref verifier) = state.approval_verifier {
+                auth::verify_http_with_ed25519_drand(&parts.headers, &bytes, verifier)?
+            } else {
+                auth::verify_http_with_drand(&parts.headers, &bytes, &state.approval_auth)?
+            };
             if ctx.drand_round.is_some() {
                 tracing::info!(
                     drand_round = ctx.drand_round,

--- a/docs/north-star.md
+++ b/docs/north-star.md
@@ -92,24 +92,25 @@ What each status means, and what it deliberately does not:
   over the six modelled child-inheritance channels (Env, Argv, Cwd, Stdio,
   ExtraFd, Uid), the 11-kind × 3-principal delivery table, Aeneas-extracted,
   `sorry`-free, axiom-audited — but the *clause* is broader than that theorem,
-  and it is **falsified today by a channel FM-5 does not model**: the guest
-  kernel command line (`/proc/cmdline`) is world-readable inside the VM, and
-  `firecracker_config.rs` emits `nucleus.approval_secret` there on **every** pod
-  (the code comment at the emission site states outright that the agent can
-  read it). A workload that reads `/proc/cmdline` learns a real secret Nucleus
-  holds on its behalf, so "cannot learn the secrets" is not established. The
-  AWS audit-sink credentials used to ride the same channel; as of 2026-08-08
-  they are fetched over the workload API instead (`FETCH_AUDIT_CREDENTIALS`,
-  served once before any workload exists), and the cmdline-secret ratchet in
-  `snapshot.rs` pins them as no-longer-emitted. Also unmodeled: mounts,
-  `/proc/<pid>/environ`, `/etc/nucleus/*`; and the `_ => OrdinaryData`
-  classifier fallthrough is trusted, not proved. **Re-earning C1** still
-  requires: get `approval_secret` off the cmdline (signature-based approvals —
-  the guest verifying an approver's Ed25519 signature against a *public* key
-  removes the shared HMAC secret entirely), and add the cmdline as a modelled
-  channel to `ChannelAdmissionExtracted` so any Secret-on-cmdline becomes a red
-  theorem. The task-token cmdline copies are not secrets (public issuer +
-  host-pinned nonce) and are not the blocker here.
+  and the *clause* was **falsified by a channel FM-5 does not model**: the
+  guest kernel command line (`/proc/cmdline`) is world-readable inside the VM,
+  and it carried real secrets — `nucleus.approval_secret` (the symmetric HMAC
+  key, so any workload could *forge approvals*, an authority bypass) on every
+  pod, plus the AWS audit-sink credentials whenever an audit sink was
+  configured. Both are closed as of 2026-08-08: the AWS credentials ride the
+  workload API (`FETCH_AUDIT_CREDENTIALS`, served once before any workload
+  exists), and approvals are Ed25519 signatures the guest verifies against
+  the node's *public* key (`nucleus.approval_pubkeys`) — no shared secret
+  exists in the guest, and the cmdline-secret ratchet in `snapshot.rs` pins
+  both removals. C1 stays NOT-YET because the removals are **tested, not
+  proved**: the cmdline is still not a modelled channel, `nucleus.sandbox_token`
+  (a per-pod bearer proof token) still rides it for identity-less pods, and
+  mounts, `/proc/<pid>/environ`, `/etc/nucleus/*` and the `_ => OrdinaryData`
+  classifier fallthrough remain trusted, not proved. **Re-earning C1**
+  requires adding the cmdline as a modelled channel to
+  `ChannelAdmissionExtracted` so any Secret-on-cmdline becomes a red theorem.
+  The task-token cmdline copies are not secrets (public issuer + host-pinned
+  nonce) and are not the blocker here.
 - **C2 (NOT-YET)** — no artifact in the corpus mentions a second pod; the host
   is outside every model. `docs/cross-pod-view.md` is the design.
 - **C3 (PROVED)** — the two-run noninterference theorem over the reference pod


### PR DESCRIPTION
## What

`nucleus.approval_secret` was the last real secret on the guest kernel command line, and it was worse than a leak: HMAC is **symmetric**, so the verification key the guest held was also a signing key. Any workload that read `/proc/cmdline` could **forge approvals** for its own operations — an authority bypass, not just a confidentiality leak. This is the decided **3B′** step of the C1 arc.

## How

- **Firecracker approvals are now signature-based.** The node holds an Ed25519 approval signing key, persisted in `state_dir` beside the other role keys (restart-stable, so pods launched before a node restart can still be approved). Its **public** half rides the cmdline as `nucleus.approval_pubkeys`.
- **The guest verifies, it cannot sign.** `nucleus-tool-proxy` verifies the approver's signature with `verify_strict` (M-3: cofactored verification accepts small-order points → key-substitution) plus the **same drand freshness** the HMAC tier had — a signature is origin, not freshness.
- **When pubkeys are configured, the HMAC approval tier is unreachable** (`select_auth_tier`, exhaustively pinned over all 16 input combinations). A residual copy of the old secret must not remain an alternative way in. Env-provisioned container pods keep the HMAC tier; their secret arrives by env, not a world-readable channel.
- The signed proxy signs `/v1/approve` via one `ApprovalSigning` enum (`Hmac | Ed25519`) — never two `Option`s whose states include "both". Message framing is **byte-identical** across primitives and pinned by test on both the signing (node) and verifying (proxy) sides.
- `nucleus-guest-init` now requires an approval **authority** (pubkeys or legacy secret), failing near the cause instead of four layers later.
- Cmdline-secret ratchet shrinks **5 → 4**; `nucleus.approval_pubkeys` is classified shared (per-node, verification-only → safe to clone). The old "approval secret still emitted and tracked" fidelity test flipped **red** on the removal exactly as designed, and is now the negative test `the_approval_secret_never_reaches_the_guest_command_line`.

## C1 status

**Stays NOT-YET.** Both named cmdline secrets (approval, AWS creds) are now gone, but the removals are **tested, not proved** — modelling the cmdline as a channel in `ChannelAdmissionExtracted` is the remaining step, and it is blocked on the task-token cmdline copy (the next PR).

## Verified

- Linux (OrbStack VM — the Firecracker path is not compiled on macOS): `cargo clippy --all-targets --all-features -- -D warnings` clean over `nucleus-node`, `nucleus-tool-proxy`, `nucleus-guest-init`; full test suites green (nucleus-node 341, nucleus-tool-proxy 336, guest-init).
- `scripts/check-verify-strict.sh` (M-3), `scripts/check-north-star-ledger.sh`, and the line-ratchet gate pass locally. `cargo fmt --all --check` clean.

## Merge discipline

**Do NOT auto-merge.** This touches the boot path; quickstart-boot / boot-a-real-pod is not a required check on main. Merge manually only after **boot-a-real-pod (x86_64)** is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UA8kchV3eadjGv6BmJXfqm