### PR TITLE
cmdline: stop writing the task-token copy for identity-bearing pods (last per-pod secret off /proc/cmdline)

### DIFF
--- a/crates/nucleus-guest-init/src/identity.rs
+++ b/crates/nucleus-guest-init/src/identity.rs
@@ -273,7 +273,14 @@ pub fn fetch_pod_caller_token(port: u32) -> Result<String, String> {
         .ok_or_else(|| "no caller_token in response".to_string())
 }
 
-pub fn fetch_task_token(port: u32) -> Result<TaskTokenResponse, String> {
+/// Fetch this pod's live-path session capability token.
+///
+/// `Ok(None)` when the host minted no token for this pod (a degraded but
+/// legitimate state — the tool-proxy then records the token as Missing and
+/// fails closed at verify). `Err` is reserved for a real transport or
+/// protocol failure, which the caller treats as fatal on the identity path
+/// where the kernel-cmdline fallback no longer exists.
+pub fn fetch_task_token(port: u32) -> Result<Option<TaskTokenResponse>, String> {
     let mut stream = VsockStream::connect_with_cid_port(VMADDR_CID_HOST, port)
         .map_err(|e| format!("failed to connect to workload API: {e}"))?;
     stream
@@ -290,14 +297,25 @@ pub fn fetch_task_token(port: u32) -> Result<TaskTokenResponse, String> {
         .map_err(|e| format!("failed to read task token response: {e}"))?;
 
     // The host answers a pod with no minted token with `{"error": ...}` rather
-    // than an empty token, so a parse failure here is a real protocol problem
-    // and not the ordinary "this pod has none" case.
-    serde_json::from_str::<TaskTokenResponse>(&response).map_err(|e| {
+    // than an empty token — the ordinary degraded case, distinguished HERE from
+    // a real protocol problem so the caller can make only the latter fatal.
+    if let Ok(t) = serde_json::from_str::<TaskTokenResponse>(&response) {
+        return Ok(Some(t));
+    }
+    let v: serde_json::Value = serde_json::from_str(&response).map_err(|e| {
         format!(
             "failed to parse task token response ({e}): {}",
             response.trim()
         )
-    })
+    })?;
+    if v.get("error").and_then(|e| e.as_str()).is_some() {
+        // Explicit "no token minted" — not a failure.
+        return Ok(None);
+    }
+    Err(format!(
+        "task token response had neither a token nor an error: {}",
+        response.trim()
+    ))
 }
 
 /// Fetches the workload certificate from the host via vsock.

--- a/crates/nucleus-guest-init/src/main.rs
+++ b/crates/nucleus-guest-init/src/main.rs
@@ -200,21 +200,30 @@ fn run() -> Result<(), String> {
         }
 
         match identity::fetch_task_token(port) {
-            Ok(t) => {
+            Ok(Some(t)) => {
                 std::env::set_var("NUCLEUS_TASK_TOKEN", &t.token);
                 std::env::set_var("NUCLEUS_TASK_TOKEN_NONCE", &t.nonce);
                 std::env::set_var("NUCLEUS_TASK_TOKEN_ISSUER", &t.issuer);
                 token_from_vsock = true;
                 eprintln!("fetched session task token over vsock");
             }
+            // No token was minted for this pod: a degraded but legitimate
+            // state. The tool-proxy records the token as Missing and fails
+            // closed at verify, exactly as it did when the cmdline carried no
+            // token — so this is not fatal.
+            Ok(None) => {
+                eprintln!("no session task token was minted for this pod");
+            }
+            // A real transport/protocol failure, and now FATAL: the node no
+            // longer writes a cmdline copy for an identity-bearing pod (that
+            // was the last per-pod secret on `/proc/cmdline`), so vsock is the
+            // ONLY source. Failing here names the cause; letting it slide would
+            // surface as a fail-closed proxy four layers away, at first use.
             Err(err) => {
-                // Not fatal, and deliberately so: the command-line path below is
-                // still in place, so a node that has not been updated still
-                // works. When the cmdline copy is removed this must become the
-                // only source, and THEN a failure here should be fatal — the
-                // tool-proxy would otherwise start with no token and fail closed
-                // later, far from the cause.
-                eprintln!("failed to fetch session task token over vsock: {err}");
+                return Err(format!(
+                    "failed to fetch session task token over vsock, and there is no \
+                     kernel-cmdline fallback for an identity-bearing pod: {err}"
+                ));
             }
         }
     }

--- a/crates/nucleus-node/src/firecracker_config.rs
+++ b/crates/nucleus-node/src/firecracker_config.rs
@@ -745,32 +745,42 @@ impl FirecrackerConfig {
             };
         }
 
-        // Inject the live-path session capability token via the kernel cmdline,
-        // for nucleus-guest-init to forward to the in-VM tool-proxy as
-        // NUCLEUS_TASK_TOKEN{,_NONCE,_ISSUER}.
+        // Inject the live-path session capability token via the kernel cmdline
+        // — ONLY for a pod that will NOT have an identity, mirroring the
+        // `sandbox_token` conditional above and gated on the same predicate.
         //
-        // The token JSON is **hex-encoded** here (`nucleus.task_token_hex`)
-        // because the kernel cmdline is whitespace-delimited and quote-sensitive;
-        // raw JSON (braces/quotes) is unsafe to embed. guest-init hex-decodes it
-        // back to the exact JSON the tool-proxy verify half expects. Nonce and
-        // issuer are already hex. This is a scoped capability + PUBLIC issuer key
-        // — NOT a secret — so riding the world-readable cmdline (M-4 caveat,
-        // same channel as nucleus.auth_secret) is acceptable; the anti-replay /
-        // anti-truncation defense rests on the host-pinned nonce, not secrecy.
-        if let Some(tok) = task_token {
-            let token_hex = hex::encode(tok.token_json.as_bytes());
-            boot_args = match boot_args.take() {
-                Some(args) => Some(format!(
-                    "{args} nucleus.task_token_hex={token_hex} \
-                     nucleus.task_token_nonce={} nucleus.task_token_issuer={}",
-                    tok.nonce_hex, tok.issuer_hex
-                )),
-                None => Some(format!(
-                    "nucleus.task_token_hex={token_hex} \
-                     nucleus.task_token_nonce={} nucleus.task_token_issuer={}",
-                    tok.nonce_hex, tok.issuer_hex
-                )),
-            };
+        // An identity-bearing pod fetches this token over the workload API
+        // (`FETCH_TASK_TOKEN`, per-pod socket, after boot), and guest-init
+        // already prefers that source (`token_from_vsock`). So for the
+        // configuration nucleus actually ships, this copy was redundant — and
+        // it was the LAST per-pod material of any kind on an identity-bearing
+        // pod's `/proc/cmdline`. The task token is defended by a host-pinned
+        // nonce rather than by secrecy, but `MaterialKind::TaskToken` is
+        // `Secret` in the FM-5 model, and a Secret on the world-readable
+        // cmdline is exactly what blocks C1 — so the copy is DELETED here
+        // rather than argued harmless. That argument would have had to be
+        // re-made every time `session_mint` changed; deleting the copy retires
+        // it.
+        //
+        // The identity-LESS path keeps the cmdline copy: it has no workload
+        // API socket to fetch over, so this is its only source, exactly as
+        // `sandbox_token` is its only proof.
+        if workload_api_port.is_none() {
+            if let Some(tok) = task_token {
+                let token_hex = hex::encode(tok.token_json.as_bytes());
+                boot_args = match boot_args.take() {
+                    Some(args) => Some(format!(
+                        "{args} nucleus.task_token_hex={token_hex} \
+                         nucleus.task_token_nonce={} nucleus.task_token_issuer={}",
+                        tok.nonce_hex, tok.issuer_hex
+                    )),
+                    None => Some(format!(
+                        "nucleus.task_token_hex={token_hex} \
+                         nucleus.task_token_nonce={} nucleus.task_token_issuer={}",
+                        tok.nonce_hex, tok.issuer_hex
+                    )),
+                };
+            }
         }
 
         // Pure lowering seams (property-tested in `mod tests`): the money/boot
@@ -1083,6 +1093,17 @@ mod tests {
     /// vsock accept path behind a `cfg` nobody compiled.
     #[cfg(target_os = "linux")]
     fn boot_args_with_identity(will_have_identity: bool) -> String {
+        boot_args_with_identity_and_token(will_have_identity, None)
+    }
+
+    /// Like [`boot_args_with_identity`] but with a real minted task token, so a
+    /// test can prove the token is EXCLUDED from an identity-bearing pod's
+    /// cmdline rather than merely absent because none was passed.
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+    fn boot_args_with_identity_and_token(
+        will_have_identity: bool,
+        task_token: Option<&crate::session_mint::MintedTaskToken>,
+    ) -> String {
         let config = FirecrackerConfig::from_spec(
             &base_spec(),
             std::path::Path::new("/unused/firecracker.log"),
@@ -1092,10 +1113,19 @@ mod tests {
             "auth-secret",
             "aa00bb11-approval-pubkeys",
             will_have_identity.then_some(15012),
-            None,
+            task_token,
             None,
         );
         config.boot_source.boot_args.unwrap_or_default()
+    }
+
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+    fn sample_task_token() -> crate::session_mint::MintedTaskToken {
+        crate::session_mint::MintedTaskToken {
+            token_json: r#"{"task":"demo"}"#.to_string(),
+            nonce_hex: "0011223344556677".to_string(),
+            issuer_hex: "aabbccdd".to_string(),
+        }
     }
 
     /// **A pod that will hold an SVID gets no Tier 3 token.**
@@ -1112,6 +1142,54 @@ mod tests {
             !args.contains("nucleus.sandbox_token"),
             "a pod with a workload identity reaches Tier 1/2 from its SVID and does \
              not need the Tier 3 token: {args}"
+        );
+    }
+
+    /// **An identity-bearing pod carries NO task token on its cmdline either.**
+    /// It fetches the token over the workload API (`FETCH_TASK_TOKEN`), so the
+    /// cmdline copy — the last per-pod Secret-labelled material on an
+    /// identity-bearing pod's `/proc/cmdline` — is gone. Uses a real minted
+    /// token so this proves exclusion, not absence-of-input.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn an_identity_bearing_pod_carries_no_task_token() {
+        let tok = sample_task_token();
+        let args = boot_args_with_identity_and_token(true, Some(&tok));
+        assert!(
+            !args.contains("nucleus.task_token_hex"),
+            "an identity-bearing pod fetches its task token over vsock; the cmdline \
+             copy must be gone: {args}"
+        );
+        assert!(!args.contains("nucleus.task_token_nonce"), "{args}");
+        assert!(!args.contains("nucleus.task_token_issuer"), "{args}");
+    }
+
+    /// **THE CATEGORICAL GATE, and the Rust half of the future Lean theorem.**
+    /// Over an identity-bearing pod's actual boot args, NO key classified
+    /// per-pod-secret may appear — not "no task token", not "no sandbox token",
+    /// but the whole [`snapshot::PER_POD_SECRET_KEYS`] set at once, so a per-pod
+    /// secret nobody has invented yet is caught the moment it is emitted here.
+    /// Reuses the snapshot key parser so the two cannot disagree on what a key
+    /// is.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn an_identity_bearing_pod_cmdline_carries_no_per_pod_secret() {
+        let tok = sample_task_token();
+        let args = boot_args_with_identity_and_token(true, Some(&tok));
+        let emitted: Vec<&str> = args
+            .split_whitespace()
+            .map(|t| t.split('=').next().unwrap_or(t))
+            .collect();
+        let leaked: Vec<&str> = crate::snapshot::PER_POD_SECRET_KEYS
+            .iter()
+            .copied()
+            .filter(|k| emitted.contains(k))
+            .collect();
+        assert!(
+            leaked.is_empty(),
+            "an identity-bearing pod's /proc/cmdline carries per-pod secret material \
+             {leaked:?} — this is the C1 exposure. Deliver it over the workload API \
+             instead. Full args: {args}"
         );
     }
 
@@ -1160,6 +1238,21 @@ mod tests {
         );
     }
 
+    /// Non-vacuity for the task token: a pod with no identity has no workload
+    /// API socket to fetch over, so the cmdline copy is its ONLY source and
+    /// must remain. Deleting it outright would brick every identity-less pod.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn a_pod_without_an_identity_keeps_its_cmdline_task_token() {
+        let tok = sample_task_token();
+        let args = boot_args_with_identity_and_token(false, Some(&tok));
+        assert!(
+            args.contains("nucleus.task_token_hex="),
+            "an identity-less pod cannot fetch over vsock, so the cmdline copy is its \
+             only task-token source and must remain: {args}"
+        );
+    }
+
     /// The condition must track the identity predicate rather than merely
     /// correlating with it: `workload_api_port_for` and `identity_registration`
     /// are the same rule stated on the advertising and serving sides, so the
@@ -1176,12 +1269,21 @@ mod tests {
                 }
             };
             let port = net::workload_api_port_for(enabled, &grant, 15012);
-            let args = boot_args_with_identity(port.is_some());
+            let tok = sample_task_token();
+            let args = boot_args_with_identity_and_token(port.is_some(), Some(&tok));
             assert_eq!(
                 args.contains("nucleus.sandbox_token="),
                 port.is_none(),
                 "identity_enabled={enabled} granted={granted}: the Tier 3 token must be \
                  present exactly when the pod will have no SVID"
+            );
+            // The task-token cmdline copy tracks the SAME predicate: present
+            // exactly when there is no vsock socket to fetch it over.
+            assert_eq!(
+                args.contains("nucleus.task_token_hex="),
+                port.is_none(),
+                "identity_enabled={enabled} granted={granted}: the task-token cmdline copy \
+                 must be present exactly when the pod will have no workload API socket"
             );
         }
     }

--- a/docs/north-star.md
+++ b/docs/north-star.md
@@ -102,15 +102,27 @@ What each status means, and what it deliberately does not:
   exists), and approvals are Ed25519 signatures the guest verifies against
   the node's *public* key (`nucleus.approval_pubkeys`) — no shared secret
   exists in the guest, and the cmdline-secret ratchet in `snapshot.rs` pins
-  both removals. C1 stays NOT-YET because the removals are **tested, not
-  proved**: the cmdline is still not a modelled channel, `nucleus.sandbox_token`
-  (a per-pod bearer proof token) still rides it for identity-less pods, and
-  mounts, `/proc/<pid>/environ`, `/etc/nucleus/*` and the `_ => OrdinaryData`
-  classifier fallthrough remain trusted, not proved. **Re-earning C1**
-  requires adding the cmdline as a modelled channel to
-  `ChannelAdmissionExtracted` so any Secret-on-cmdline becomes a red theorem.
-  The task-token cmdline copies are not secrets (public issuer + host-pinned
-  nonce) and are not the blocker here.
+  both removals. The **task-token cmdline copy** (`nucleus.task_token_hex`
+  etc.) is also gone for identity-bearing pods (2026-08-08): the token is
+  fetched over the workload API (`FETCH_TASK_TOKEN`) instead. `MaterialKind::
+  TaskToken` is `Secret` in the FM-5 model, and rather than argue the cmdline
+  copy is harmless — an argument resting on `session_mint` keeping the nonce
+  host-pinned forever — the copy is deleted; deleting it retires the argument.
+  A categorical gate
+  (`an_identity_bearing_pod_cmdline_carries_no_per_pod_secret`) now proves an
+  identity-bearing pod's cmdline carries NO `PER_POD_SECRET_KEYS` member, and
+  is the Rust half of the future Lean theorem. **C1 stays NOT-YET** because the
+  removals are **tested, not proved**: the cmdline is still not a modelled
+  channel. The residual is the identity-LESS configuration only —
+  `nucleus.sandbox_token` and the task-token copy still ride its cmdline,
+  because it has no workload-API socket to fetch over — plus mounts,
+  `/proc/<pid>/environ`, `/etc/nucleus/*` and the `_ => OrdinaryData`
+  classifier fallthrough, which remain trusted rather than proved. **Re-earning
+  C1** requires adding the cmdline as a modelled channel to
+  `ChannelAdmissionExtracted`, parameterized by pod identity: green (proved) for
+  identity-bearing pods, with the identity-less residue stated as an explicit
+  gap theorem so it cannot go silently vacuous and flips green when Tier 3
+  leaves the cmdline too.
 - **C2 (NOT-YET)** — no artifact in the corpus mentions a second pod; the host
   is outside every model. `docs/cross-pod-view.md` is the design.
 - **C3 (PROVED)** — the two-run noninterference theorem over the reference pod


### PR DESCRIPTION
## What

The task token rode the guest kernel command line as `nucleus.task_token_hex`/`_nonce`/`_issuer`. For an identity-bearing Firecracker pod that copy was redundant — the token is fetched over the workload API (`FETCH_TASK_TOKEN`, per-pod socket, after boot) and `nucleus-guest-init` already prefers that source — and it was **the last per-pod material of any kind on such a pod's `/proc/cmdline`**. This is the decided **4A** step: fix reality so the cmdline-channel Lean theorem can later be proved (green) for identity-bearing pods.

**Stacked on #2214 (3B′).** Base is `signed-approvals`; merge after #2214.

## How

- Task-token cmdline emission is gated on `workload_api_port.is_none()`, the same predicate `sandbox_token` uses. `MaterialKind::TaskToken` is `Secret` in the FM-5 model; rather than argue the copy is harmless (an argument resting on `session_mint` keeping the nonce host-pinned forever), the copy is **deleted** — deleting it retires the argument.
- The **identity-less** path keeps its cmdline copy: no workload-API socket to fetch over, so it is that pod's only source (exactly as `sandbox_token` is its only proof).
- `guest-init` makes a failed `FETCH_TASK_TOKEN` **fatal** when a workload API port is present (no cmdline fallback remains), while a pod for which no token was minted (host answers with an explicit error) stays non-fatal. `fetch_task_token` now returns `Result<Option<_>>` to tell the two apart, mirroring `fetch_audit_credentials`.
- **New categorical gate** `an_identity_bearing_pod_cmdline_carries_no_per_pod_secret`: over an identity-bearing pod's actual boot args, NO `snapshot::PER_POD_SECRET_KEYS` member may appear — the whole set at once, so a per-pod secret nobody has invented yet is caught the moment it is emitted. This is the **Rust half of the future Lean cmdline-channel theorem**. Verified it goes red on reverting the guard, naming the three task-token keys.
- The identity-predicate test now tracks the task token too (present exactly when the pod will have no workload API socket).

## C1 status

**Stays NOT-YET** — the cmdline is still not a modelled channel. But the residual is now the **identity-less configuration only** (`sandbox_token` + task-token copy, because it has no socket to fetch over). north-star C1 prose updated; the "task-token cmdline copies are not secrets" line is retired.

## Verified

- Linux (OrbStack VM): `cargo clippy -p nucleus-node -p nucleus-guest-init --all-targets --all-features -- -D warnings` clean; test suites green (nucleus-node 344, guest-init). New gate confirmed **red on the founding-defect revert**.
- Ledger, line-ratchet, fmt gates pass locally.

## Merge discipline

**Do NOT auto-merge — boot path.** Merge #2214 first, retarget to main, then merge manually after **boot-a-real-pod (x86_64)** is green. That boot job IS the end-to-end evidence that vsock task-token delivery works: if it didn't, the tool-proxy would fail closed and the pod would not boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UA8kchV3eadjGv6BmJXfqm