### PR TITLE
ifc-kernel: model the kernel command line as a channel — the C1 cmdline lift, proved

### DIFF
--- a/crates/nucleus-ifc-kernel/src/extracted/channel.rs
+++ b/crates/nucleus-ifc-kernel/src/extracted/channel.rs
@@ -35,6 +35,19 @@
 //! to carry a secret token would have to relabel here — turning that change
 //! into a red theorem first, which is the point.
 //!
+//! **`Cmdline` (the guest kernel command line, `/proc/cmdline`) carries public
+//! per-node config only.** It is world-readable inside the guest, so whatever
+//! rides it structurally reaches the workload — there is no "deliver to the
+//! runtime but not the agent" on this channel. Modelled exactly like `Argv`:
+//! admits a material iff it is `Public`. That is faithful because the node now
+//! writes only per-node public configuration there (`approval_pubkeys`, the
+//! audit S3 bucket/region/endpoint, the workload-API port); every per-pod
+//! secret that used to ride it — `auth_secret`, `approval_secret`, the AWS
+//! audit credentials, the task token, the dead Tier-3 `sandbox_token` — was
+//! moved to the workload API or retired. A future change that put a `Secret`
+//! back on the command line would have to relabel it here to type-check the
+//! flagship, turning the regression into a red theorem, which is the point.
+//!
 //! **`Stdio`, `ExtraFd` and `Uid` are material-closed** — they carry no
 //! `MaterialKind` value at all. `Stdio` is `null`/pipe (a disposition, not a
 //! value); `ExtraFd = false` is the formal statement of the `close_range`
@@ -76,6 +89,10 @@ pub enum ChannelKind {
     ExtraFd = 4,
     /// The uid/gid boundary — a number, not material.
     Uid = 5,
+    /// The guest kernel command line (`/proc/cmdline`) — world-readable inside
+    /// the guest, carrying per-node public config only. Reaches the workload
+    /// structurally, so it admits a material iff that material is `Public`.
+    Cmdline = 6,
 }
 
 /// Numeric rank, so no derived comparison reaches the proof as an opaque axiom.
@@ -87,6 +104,7 @@ pub fn chanrank(c: ChannelKind) -> u8 {
         ChannelKind::Stdio => 3,
         ChannelKind::ExtraFd => 4,
         ChannelKind::Uid => 5,
+        ChannelKind::Cmdline => 6,
     }
 }
 
@@ -104,7 +122,9 @@ pub fn is_public(m: MaterialKind) -> bool {
 pub fn channel_admits(c: ChannelKind, m: MaterialKind, p: Principal) -> bool {
     match c {
         ChannelKind::Env => ident_may_deliver(m, p),
-        ChannelKind::Argv | ChannelKind::Cwd => is_public(m) && ident_may_deliver(m, p),
+        ChannelKind::Argv | ChannelKind::Cwd | ChannelKind::Cmdline => {
+            is_public(m) && ident_may_deliver(m, p)
+        }
         ChannelKind::Stdio | ChannelKind::ExtraFd | ChannelKind::Uid => false,
     }
 }
@@ -121,13 +141,14 @@ pub fn channel_reaches_workload(c: ChannelKind, m: MaterialKind) -> bool {
 mod tests {
     use super::*;
 
-    const CHANNELS: [ChannelKind; 6] = [
+    const CHANNELS: [ChannelKind; 7] = [
         ChannelKind::Env,
         ChannelKind::Argv,
         ChannelKind::Cwd,
         ChannelKind::Stdio,
         ChannelKind::ExtraFd,
         ChannelKind::Uid,
+        ChannelKind::Cmdline,
     ];
     const MATERIALS: [MaterialKind; 11] = [
         MaterialKind::SvidCert,
@@ -164,7 +185,7 @@ mod tests {
         }
     }
 
-    /// Exhaustive over the whole domain — 6 channels x 11 materials x 3
+    /// Exhaustive over the whole domain — 7 channels x 11 materials x 3
     /// principals. Small enough to enumerate, so there is no reason to sample.
     #[test]
     fn the_delivery_relation_is_pinned_over_its_entire_domain() {
@@ -173,7 +194,7 @@ mod tests {
                 for p in PRINCIPALS {
                     let expected = match c {
                         ChannelKind::Env => ident_may_deliver(m, p),
-                        ChannelKind::Argv | ChannelKind::Cwd => {
+                        ChannelKind::Argv | ChannelKind::Cwd | ChannelKind::Cmdline => {
                             is_public(m) && ident_may_deliver(m, p)
                         }
                         ChannelKind::Stdio | ChannelKind::ExtraFd | ChannelKind::Uid => false,
@@ -187,6 +208,30 @@ mod tests {
                 }
             }
         }
+    }
+
+    /// **The command line carries no Secret to the workload.** `/proc/cmdline`
+    /// is world-readable in the guest, so the model treats it as reaching the
+    /// workload and admitting a material iff it is `Public` — the same shape as
+    /// argv. This is the FM-5-phase-2 property specialised to the channel the
+    /// C1 ledger row was demoted for, and it is faithful because the node now
+    /// writes only per-node public config there.
+    #[test]
+    fn the_cmdline_carries_no_secret_to_the_workload() {
+        for m in MATERIALS {
+            if mat_label(m) == ConfLevel::Secret {
+                assert!(
+                    !channel_reaches_workload(ChannelKind::Cmdline, m),
+                    "the kernel command line must not deliver Secret material {m:?} to the workload"
+                );
+            }
+        }
+        // Non-vacuity: it still carries public config (the trust bundle is the
+        // Public material a real cmdline value like the CA path would be).
+        assert!(channel_reaches_workload(
+            ChannelKind::Cmdline,
+            MaterialKind::TrustBundle
+        ));
     }
 
     /// The env channel is EXACTLY the FM-5 relation — no fork. If it ever

--- a/crates/portcullis-core/lean/ChannelAdmissionExtracted.lean
+++ b/crates/portcullis-core/lean/ChannelAdmissionExtracted.lean
@@ -28,11 +28,24 @@
   # The modelling decisions, stated so they can be disagreed with
 
   `Env` is the only material-carrying channel and its admission IS
-  `ident_may_deliver` (anti-drift theorem below). `Argv`/`Cwd` carry public
-  operator data only — a future secret-carrying argv would relabel here and turn
-  it red first. `Stdio`/`ExtraFd`/`Uid` are material-closed: `ExtraFd = false` is
-  the `close_range` structural closure the launch builder installs, stated as a
-  theorem.
+  `ident_may_deliver` (anti-drift theorem below). `Argv`/`Cwd`/`Cmdline` carry
+  public operator/node data only — a future secret-carrying argv or command line
+  would relabel here and turn it red first. `Stdio`/`ExtraFd`/`Uid` are
+  material-closed: `ExtraFd = false` is the `close_range` structural closure the
+  launch builder installs, stated as a theorem.
+
+  # The command line (`Cmdline`) is now a modelled channel — the C1 lift
+
+  `/proc/cmdline` is world-readable in the guest, so whatever the node writes
+  there reaches the workload. It USED to carry per-pod secrets (`auth_secret`,
+  `approval_secret`, the AWS audit credentials, the task token, the dead Tier-3
+  `sandbox_token`); every one was moved to the workload API or retired, so the
+  node now writes only per-node PUBLIC config. `Cmdline` is therefore modelled
+  exactly like `Argv` — admits a material iff it is `Public` — and the flagship
+  `no_channel_delivers_secret_to_the_workload` covers it by the same
+  quantification. This is the channel the C1 ledger row was demoted for; with it
+  modelled, a `Secret` re-appearing on the command line is a RED theorem, not an
+  unmodelled gap. See `the_cmdline_carries_no_secret_to_the_workload` below.
 
   # What is NOT claimed
 
@@ -114,6 +127,28 @@ theorem the_env_channel_refuses_every_secret :
     ∧ extracted.channel.channel_reaches_workload extracted.channel.ChannelKind.Env extracted.identity.MaterialKind.DlcCredentials = ok false :=
   ⟨rfl, rfl, rfl, rfl, rfl, rfl, rfl⟩
 
+/-- **The kernel command line delivers no `Secret` to the workload.** This is
+    the C1 lift: `/proc/cmdline` is world-readable in the guest, so the model
+    treats `Cmdline` as reaching the workload, and it admits a material iff that
+    material is `Public`. A `Secret` on the command line therefore fails this —
+    which is exactly the exposure the C1 ledger row was demoted for, now a red
+    theorem rather than an unmodelled channel. Stated over the two secrets that
+    used to ride the command line (the task token and the sandbox token), and
+    covered in full by `no_channel_delivers_secret_to_the_workload`. -/
+theorem the_cmdline_delivers_no_secret_to_the_workload :
+    extracted.channel.channel_reaches_workload extracted.channel.ChannelKind.Cmdline extracted.identity.MaterialKind.TaskToken = ok false
+    ∧ extracted.channel.channel_reaches_workload extracted.channel.ChannelKind.Cmdline extracted.identity.MaterialKind.SandboxToken = ok false
+    ∧ extracted.channel.channel_reaches_workload extracted.channel.ChannelKind.Cmdline extracted.identity.MaterialKind.ApprovalSecret = ok false :=
+  ⟨rfl, rfl, rfl⟩
+
+/-- Non-vacuity for the command line: it still carries PUBLIC config to the
+    workload (the trust bundle stands for a public cmdline value like a CA
+    path). Without this the theorem above is satisfied by a channel that admits
+    nothing. -/
+theorem the_cmdline_still_carries_public_config :
+    extracted.channel.channel_reaches_workload extracted.channel.ChannelKind.Cmdline extracted.identity.MaterialKind.TrustBundle = ok true := by
+  rfl
+
 /-- **The `close_range` structural closure, as a theorem.** No material crosses
     an inherited fd, to any principal — the launch builder shuts every fd above
     the child's own stdio before exec. -/
@@ -162,6 +197,8 @@ or finite case split. -/
 
 #print axioms no_channel_delivers_secret_to_the_workload
 #print axioms the_env_channel_refuses_every_secret
+#print axioms the_cmdline_delivers_no_secret_to_the_workload
+#print axioms the_cmdline_still_carries_public_config
 #print axioms no_fd_carries_anything
 #print axioms stdio_and_uid_carry_no_material
 #print axioms the_carrying_channels_still_carry

--- a/crates/portcullis-core/lean/ChannelOracleMirror.lean
+++ b/crates/portcullis-core/lean/ChannelOracleMirror.lean
@@ -8,14 +8,18 @@
   becomes a three-argument judgement over `(channel, material, principal)`. The
   shipped oracle:
 
-      Env              -> ident_may_deliver m p        (the one channel carrying values)
-      Argv, Cwd        -> is_public m ∧ ident_may_deliver m p   (strictly narrower)
-      Stdio, ExtraFd, Uid -> false                     (material-CLOSED, always)
+      Env                   -> ident_may_deliver m p        (the one channel carrying values)
+      Argv, Cwd, Cmdline    -> is_public m ∧ ident_may_deliver m p   (strictly narrower)
+      Stdio, ExtraFd, Uid   -> false                     (material-CLOSED, always)
 
-  Three of the six channels carry nothing at all, by construction rather than by
+  Three of the seven channels carry nothing at all, by construction rather than by
   policy — `ExtraFd` because `close_range` shuts every inherited descriptor before
   exec, `Uid` because a uid is not a value. That is a different shape from the
   tables mirrored so far: a whole dimension proved empty, not merely restricted.
+
+  `Cmdline` (the guest kernel command line, `/proc/cmdline`) is world-readable, so
+  whatever the node writes there reaches the workload; it is modelled like Argv —
+  Public-only — because the node now writes only per-node public config there.
 
   As with the confidentiality and integrity mirrors, these are plain Lean (no
   Aeneas monad, no Mathlib) so they port to the iris substrate, each carries a
@@ -62,11 +66,11 @@ def mirrorMayDeliver (m : Material) (p : Principal) : Bool :=
 def mirrorChannelAdmits (c : Chan) (m : Material) (p : Principal) : Bool :=
   match c with
   | .Env => mirrorMayDeliver m p
-  | .Argv | .Cwd => mirrorIsPublic m && mirrorMayDeliver m p
+  | .Argv | .Cwd | .Cmdline => mirrorIsPublic m && mirrorMayDeliver m p
   | .Stdio | .ExtraFd | .Uid => false
 
-/-- **Faithfulness of channel admission**, over the full 6 × 11 × 3 product —
-    198 cases, all checked by the kernel. -/
+/-- **Faithfulness of channel admission**, over the full 7 × 11 × 3 product —
+    231 cases, all checked by the kernel. -/
 theorem channel_admits_faithful (c : Chan) (m : Material) (p : Principal) :
     ok (mirrorChannelAdmits c m p) = extracted.channel.channel_admits c m p := by
   cases c <;> cases m <;> cases p <;> rfl

--- a/crates/portcullis-core/lean/generated-channel/PortcullisCoreChannel/Funs.lean
+++ b/crates/portcullis-core/lean/generated-channel/PortcullisCoreChannel/Funs.lean
@@ -93,7 +93,7 @@ def extracted.capability_quantale.capresidual
   else ok c
 
 /-- [nucleus_ifc_kernel::extracted::channel::chanrank]:
-    Source: 'crates/nucleus-ifc-kernel/src/extracted/channel.rs', lines 82:0-91:1
+    Source: 'crates/nucleus-ifc-kernel/src/extracted/channel.rs', lines 95:0-104:1
     Visibility: public -/
 def extracted.channel.chanrank
   (c : extracted.channel.ChannelKind) : Result Std.U8 := do
@@ -104,6 +104,7 @@ def extracted.channel.chanrank
   | extracted.channel.ChannelKind.Stdio => ok 3#u8
   | extracted.channel.ChannelKind.ExtraFd => ok 4#u8
   | extracted.channel.ChannelKind.Uid => ok 5#u8
+  | extracted.channel.ChannelKind.Cmdline => ok 6#u8
 
 /-- [nucleus_ifc_kernel::extracted::identity::mat_label]:
     Source: 'crates/nucleus-ifc-kernel/src/extracted/identity.rs', lines 155:0-169:1
@@ -196,7 +197,7 @@ def extracted.identity.ident_may_deliver
   extracted.ifc_confidentiality.cflows_to cl cl1
 
 /-- [nucleus_ifc_kernel::extracted::channel::channel_admits]:
-    Source: 'crates/nucleus-ifc-kernel/src/extracted/channel.rs', lines 104:0-110:1
+    Source: 'crates/nucleus-ifc-kernel/src/extracted/channel.rs', lines 121:0-130:1
     Visibility: public -/
 def extracted.channel.channel_admits
   (c : extracted.channel.ChannelKind) (m : extracted.identity.MaterialKind)
@@ -219,9 +220,14 @@ def extracted.channel.channel_admits
   | extracted.channel.ChannelKind.Stdio => ok false
   | extracted.channel.ChannelKind.ExtraFd => ok false
   | extracted.channel.ChannelKind.Uid => ok false
+  | extracted.channel.ChannelKind.Cmdline =>
+    let b ← extracted.channel.is_public m
+    if b
+    then extracted.identity.ident_may_deliver m p
+    else ok false
 
 /-- [nucleus_ifc_kernel::extracted::channel::channel_reaches_workload]:
-    Source: 'crates/nucleus-ifc-kernel/src/extracted/channel.rs', lines 116:0-118:1
+    Source: 'crates/nucleus-ifc-kernel/src/extracted/channel.rs', lines 143:0-145:1
     Visibility: public -/
 def extracted.channel.channel_reaches_workload
   (c : extracted.channel.ChannelKind) (m : extracted.identity.MaterialKind) :

--- a/crates/portcullis-core/lean/generated-channel/PortcullisCoreChannel/Types.lean
+++ b/crates/portcullis-core/lean/generated-channel/PortcullisCoreChannel/Types.lean
@@ -24,7 +24,7 @@ inductive extracted.capability_quantale.CapLevel where
 | Always : extracted.capability_quantale.CapLevel
 
 /-- [nucleus_ifc_kernel::extracted::channel::ChannelKind]
-    Source: 'crates/nucleus-ifc-kernel/src/extracted/channel.rs', lines 65:0-79:1
+    Source: 'crates/nucleus-ifc-kernel/src/extracted/channel.rs', lines 78:0-96:1
     Visibility: public -/
 @[discriminant u8]
 inductive extracted.channel.ChannelKind where
@@ -34,6 +34,7 @@ inductive extracted.channel.ChannelKind where
 | Stdio : extracted.channel.ChannelKind
 | ExtraFd : extracted.channel.ChannelKind
 | Uid : extracted.channel.ChannelKind
+| Cmdline : extracted.channel.ChannelKind
 
 /-- [nucleus_ifc_kernel::extracted::ifc_confidentiality::ConfLevel]
     Source: 'crates/nucleus-ifc-kernel/src/extracted/ifc_confidentiality.rs', lines 21:0-28:1

--- a/crates/portcullis-core/lean/lakefile.lean
+++ b/crates/portcullis-core/lean/lakefile.lean
@@ -175,7 +175,7 @@ lean_lib «IntegrityOracleMirror» where
   roots := #[`IntegrityOracleMirror]
 
 -- The CHANNEL dimension (Machine v3 gate 2): delivery becomes a three-argument
--- judgement over (channel, material, principal), and three of the six channels
+-- judgement over (channel, material, principal), and three of the seven channels
 -- are material-closed by construction rather than by policy.
 lean_lib «ChannelOracleMirror» where
   roots := #[`ChannelOracleMirror]

--- a/docs/north-star.md
+++ b/docs/north-star.md
@@ -89,9 +89,10 @@ channels.*
 What each status means, and what it deliberately does not:
 
 - **C1 (NOT-YET — demoted 2026-08-08, was PROVED).** FM-5 genuinely proves,
-  over the six modelled child-inheritance channels (Env, Argv, Cwd, Stdio,
-  ExtraFd, Uid), the 11-kind × 3-principal delivery table, Aeneas-extracted,
-  `sorry`-free, axiom-audited — but the *clause* is broader than that theorem,
+  over the seven modelled child-inheritance channels (Env, Argv, Cwd, Stdio,
+  ExtraFd, Uid, Cmdline), the 11-kind × 3-principal delivery table,
+  Aeneas-extracted, `sorry`-free, axiom-audited — but the *clause* is broader
+  than that theorem,
   and the *clause* was **falsified by a channel FM-5 does not model**: the
   guest kernel command line (`/proc/cmdline`) is world-readable inside the VM,
   and it carried real secrets — `nucleus.approval_secret` (the symmetric HMAC
@@ -114,14 +115,22 @@ What each status means, and what it deliberately does not:
   (`no_pod_cmdline_carries_any_per_pod_secret`) proves it over the real boot
   args for every identity outcome, and it is the Rust half of the Lean channel
   theorem. This also realized the FM-4 snapshot payoff: a realistic
-  identity-bearing pod cmdline is `SafeToClone`. **C1 stays NOT-YET** only
-  because the removals are **tested, not proved**: the cmdline is not yet a
-  modelled channel, and mounts, `/proc/<pid>/environ`, `/etc/nucleus/*` and the
-  `_ => OrdinaryData` classifier fallthrough remain trusted rather than proved.
-  **Re-earning C1** requires adding `Cmdline` to `ChannelAdmissionExtracted` as
-  a Public-only channel (it now carries only per-node config —
-  `approval_pubkeys`, audit S3 config, region, port), turning
-  `no_channel_delivers_secret_to_the_workload` green over it unconditionally.
+  identity-bearing pod cmdline is `SafeToClone`. **The cmdline is now a MODELLED
+  channel** (`ChannelKind::Cmdline`, Aeneas-extracted): the flagship
+  `no_channel_delivers_secret_to_the_workload` covers it, and
+  `the_cmdline_delivers_no_secret_to_the_workload` states it by name — a `Secret`
+  re-appearing on the command line is now a RED theorem, not an unmodelled gap.
+  So the specific falsifier that demoted C1 is closed AND proved. **C1 stays
+  NOT-YET** for two reasons that are narrower than before: (1) the Lean proves
+  the delivery *relation*; that the node *obeys* it (writes no Secret on the
+  cmdline) is the Rust behavioural gate `no_pod_cmdline_carries_any_per_pod_secret`,
+  which is TESTED not proved — and C7 ("a theorem about the code that ships") is
+  itself only TESTED, so C1's conformance leg cannot exceed it; (2) mounts,
+  `/proc/<pid>/environ` and `/etc/nucleus/*` remain unmodelled surfaces, and the
+  `_ => OrdinaryData` classifier fallthrough is trusted. **Promoting C1** now
+  turns on a claim-status judgement — whether those residual surfaces are
+  in-scope exclusions (like FM-5's declared mounts fence) or genuine gaps — held
+  for Brandon rather than taken unilaterally on the flagship confidentiality row.
 - **C2 (NOT-YET)** — no artifact in the corpus mentions a second pod; the host
   is outside every model. `docs/cross-pod-view.md` is the design.
 - **C3 (PROVED)** — the two-run noninterference theorem over the reference pod
@@ -143,9 +152,10 @@ What each status means, and what it deliberately does not:
   the workload cannot steer which value is released. The full four-run
   robustness LTS over the pod machine remains a NOT-YET refinement (the
   executable two-run form ships as `declassify_scope.rs`).
-- **C6 (NOT-YET)** — the six child-inheritance channels are proved total (the
-  quantification is over the channel enum, so a new channel forces a match
-  arm); the effect/API set is enumerated with named exclusions in
+- **C6 (NOT-YET)** — the seven child-inheritance channels (now including the
+  kernel command line) are proved total (the quantification is over the channel
+  enum, so a new channel forces a match arm); the effect/API set is enumerated
+  with named exclusions in
   `docs/architecture/mediated-set.md` with its lint reporting-only; the
   transport channels (vsock, pod-dir socket, in-guest HTTP, netns, DNS, node
   gRPC) have no unified inventory. "Every" is not yet earned.


### PR DESCRIPTION
## What

Adds `ChannelKind::Cmdline` to the Aeneas-extracted channel taxonomy (`crates/nucleus-ifc-kernel/src/extracted/channel.rs`) and its Lean theorem (`ChannelAdmissionExtracted.lean`). This is the final step of the C1 (`/proc/cmdline` confidentiality) arc: the command line is now a **modelled, proved** channel.

**Stacked on #2216 (4B, retire the fallback).** Base is `retire-cmdline-fallback`; merge after that.

## Why it's faithful now

`/proc/cmdline` is world-readable in the guest, so whatever the node writes there reaches the workload. After the secret retirements (2A/3B′/4A/4B), the node writes **only per-node public config** — `approval_pubkeys`, audit S3 bucket/region/endpoint, workload-API port. So `Cmdline` is modelled exactly like `Argv`/`Cwd`: admits a material iff it is `Public`.

## The proof

- The flagship `no_channel_delivers_secret_to_the_workload` now quantifies over all **seven** channels including `Cmdline` — a `Secret` re-appearing on the command line is a **red theorem**, not an unmodelled gap. This closes *and proves* the specific channel the C1 row was demoted for.
- New: `the_cmdline_delivers_no_secret_to_the_workload` (task token, sandbox token, approval secret refused by name) and `the_cmdline_still_carries_public_config` (non-vacuity — the trust bundle still crosses).
- All theorems depend only on `{propext, Classical.choice, Quot.sound}`; **no `sorry`** (`lake build ChannelAdmissionExtracted` axiom-audited locally).

## Extraction provenance

Re-ran `charon --preset aeneas` over the full `EXTRACT_ROOTS` + `aeneas -backend lean` locally. The generated `ChannelKind` variant, `chanrank` arm (`=> ok 6#u8`) and `channel_admits` arm (`is_public`-gated) are applied to `generated-channel/` **verbatim from that fresh extraction** (verified byte-identical), preserving the committed toolchain's declaration ordering to keep the diff minimal. CI's `aeneas-ifc-scoped` job re-extracts and canonicalizes against its pinned toolchain as usual.

## C1 status — deliberately still NOT-YET

The Lean proves the delivery **relation**. That the node **obeys** it (writes no `Secret` on the cmdline) is the Rust behavioural gate `no_pod_cmdline_carries_any_per_pod_secret`, which is **TESTED** — and C7 ("a theorem about the code that ships") is itself only TESTED, so C1's conformance leg cannot exceed it. Mounts, `/proc/<pid>/environ`, `/etc/nucleus/*` also remain unmodelled. **Promoting C1 is a claim-status judgement on the flagship confidentiality row — held for Brandon, not taken unilaterally.**

## Verified

`lake build ChannelAdmissionExtracted` green + axiom-audited; `cargo test -p nucleus-ifc-kernel` green (8 channel tests incl. `the_cmdline_carries_no_secret_to_the_workload`); north-star ledger gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UA8kchV3eadjGv6BmJXfqm