### PR TITLE
fix: wire three declared-but-dead config surfaces (audit findings #1-#3)

### DIFF
--- a/crates/nucleus-node/src/main.rs
+++ b/crates/nucleus-node/src/main.rs
@@ -751,6 +751,13 @@ async fn main() -> Result<(), ApiError> {
         lockdown_tx: tokio::sync::broadcast::channel::<proto::LockdownCommand>(16).0,
     };
 
+    // Enroll this executor's Ed25519 public key with the trust-service, once,
+    // before serving. Every receipt POST is signed with the matching private
+    // key (`X-Nucleus-Executor-Sig`) but ships no inline pubkey, so the
+    // trust-service can only verify those signatures if it learned the key from
+    // this enrollment first. A no-op when the trust gate is disabled.
+    trust_gate::register_executor_pubkey(&state.trust_gate, &state.http_client).await;
+
     // Routes that require HMAC auth
     let authenticated_routes = Router::new()
         .route("/v1/pods", post(create_pod).get(pod_api::list_pods))

--- a/crates/nucleus-node/src/trust_gate.rs
+++ b/crates/nucleus-node/src/trust_gate.rs
@@ -1180,10 +1180,11 @@ fn hmac_sha256_hex(secret: &[u8], data: &[u8]) -> String {
 
 /// Register this executor's Ed25519 public key with the trust-service.
 ///
-/// Called once at startup so the trust-service can verify per-executor
-/// signatures on subsequent receipt POSTs. The registration request itself
+/// Called once at startup (from `main`, before serving) so the trust-service
+/// can verify per-executor signatures on subsequent receipt POSTs — those POSTs
+/// carry `X-Nucleus-Executor-Sig` but no inline pubkey, so without this
+/// enrollment the signatures are unverifiable. The registration request itself
 /// is HMAC-authenticated using `receipt_secret`.
-#[allow(dead_code)] // Called at startup when trust gate is enabled
 pub async fn register_executor_pubkey(config: &TrustGateConfig, http_client: &reqwest::Client) {
     if !config.is_enabled() {
         return;

--- a/crates/nucleus-spec/src/lib.rs
+++ b/crates/nucleus-spec/src/lib.rs
@@ -273,12 +273,14 @@ pub struct NetworkSpec {
     /// If non-empty, only URLs matching at least one pattern are permitted.
     #[serde(default)]
     pub url_allow: Vec<String>,
-    /// Override the default MIME type allowlist for web_fetch responses.
-    /// If None, the built-in allowlist (text + structured data) is used.
+    /// Override the built-in MIME-type allowlist for web_fetch responses.
+    /// When `Some`, the listed prefixes REPLACE the built-in list; when `None`,
+    /// the built-in allowlist (text + structured data) is used.
     #[serde(default)]
     pub mime_allow: Option<Vec<String>>,
-    /// Maximum response body size in bytes for web_fetch.
-    /// Defaults to 10 MiB if not specified.
+    /// Per-pod maximum response body size in bytes for web_fetch.
+    /// When `None`, the proxy's configured cap applies
+    /// (`--web-fetch-max-bytes` / `NUCLEUS_TOOL_PROXY_WEB_FETCH_MAX_BYTES`).
     #[serde(default)]
     pub max_response_bytes: Option<u64>,
 }

--- a/crates/nucleus-tool-proxy/src/main.rs
+++ b/crates/nucleus-tool-proxy/src/main.rs
@@ -361,7 +361,13 @@ pub(crate) struct AppState {
     pub(crate) web_client: reqwest::Client,
     /// Upstreams reachable with a credential the workload never holds.
     pub(crate) credentialed_egress: Vec<nucleus_spec::CredentialedEgressSpec>,
+    /// Effective web_fetch response cap: the pod's `network.max_response_bytes`
+    /// if set, else the proxy's `--web-fetch-max-bytes`. Resolved once at
+    /// startup so every read site enforces the same per-pod value.
     web_fetch_max_bytes: usize,
+    /// The pod's `network.mime_allow` override, if any. `None` means the
+    /// built-in `ALLOWED_MIME_PREFIXES` applies.
+    web_fetch_mime_allow: Option<Vec<String>>,
     dns_allow: Vec<String>,
     /// URL pattern allowlist for web_fetch. If non-empty, URLs must match.
     url_allow: Vec<String>,
@@ -1555,19 +1561,16 @@ async fn main() -> Result<(), ApiError> {
         .build()
         .map_err(|e| ApiError::Spec(format!("failed to build HTTP client: {e}")))?;
 
-    // Extract DNS and URL allow lists from spec
-    let dns_allow = spec
-        .spec
-        .network
-        .as_ref()
-        .map(|n| n.dns_allow.clone())
-        .unwrap_or_default();
-    let url_allow = spec
-        .spec
-        .network
-        .as_ref()
-        .map(|n| n.url_allow.clone())
-        .unwrap_or_default();
+    // All web_fetch enforcement inputs (DNS/URL allowlists + the per-pod MIME
+    // and response-cap overrides) resolved from the spec in one place.
+    let web_fetch_cfg = web_fetch_policy::resolve_web_fetch_config(
+        spec.spec.network.as_ref(),
+        args.web_fetch_max_bytes,
+    );
+    let dns_allow = web_fetch_cfg.dns_allow;
+    let url_allow = web_fetch_cfg.url_allow;
+    let web_fetch_mime_allow = web_fetch_cfg.mime_allow;
+    let web_fetch_max_bytes = web_fetch_cfg.max_bytes;
 
     // Build attestation verifier
     let attestation_config = {
@@ -1842,7 +1845,8 @@ async fn main() -> Result<(), ApiError> {
         approval_nonces: Arc::new(ApprovalNonceCache::default()),
         approval_rate_limiter: Arc::new(ApprovalRateLimiter::default()),
         web_client,
-        web_fetch_max_bytes: args.web_fetch_max_bytes,
+        web_fetch_max_bytes,
+        web_fetch_mime_allow,
         dns_allow,
         url_allow,
         attestation_verifier,
@@ -3577,7 +3581,8 @@ async fn web_fetch(
         .get(reqwest::header::CONTENT_TYPE)
         .and_then(|v| v.to_str().ok())
         .unwrap_or("");
-    web_fetch_policy::check_mime_type(content_type).map_err(ApiError::WebFetch)?;
+    web_fetch_policy::check_mime_type(content_type, state.web_fetch_mime_allow.as_deref())
+        .map_err(ApiError::WebFetch)?;
 
     // Collect response headers + add exposure metadata
     let mut response_headers: HashMap<String, String> = response

--- a/crates/nucleus-tool-proxy/src/mcp.rs
+++ b/crates/nucleus-tool-proxy/src/mcp.rs
@@ -1273,7 +1273,10 @@ impl NucleusMcpServer {
                 .get(reqwest::header::CONTENT_TYPE)
                 .and_then(|v| v.to_str().ok())
                 .unwrap_or("");
-            crate::web_fetch_policy::check_mime_type(content_type)?;
+            crate::web_fetch_policy::check_mime_type(
+                content_type,
+                self.state.web_fetch_mime_allow.as_deref(),
+            )?;
 
             // Bounded streaming read: never allocate the whole upstream body, so a
             // malicious page cannot OOM-kill the enforcement process (audit H-1).

--- a/crates/nucleus-tool-proxy/src/web_fetch_policy.rs
+++ b/crates/nucleus-tool-proxy/src/web_fetch_policy.rs
@@ -97,17 +97,73 @@ pub fn check_url_allowlist(url_allow: &[String], url: &str) -> Result<(), String
     }
 }
 
+/// Resolve the effective web_fetch response cap.
+///
+/// The pod's `network.max_response_bytes` overrides the proxy's configured
+/// default (`--web-fetch-max-bytes`); an absent or unrepresentable override
+/// falls back to that default. Kept pure so the override's precedence is
+/// unit-tested rather than trusted at the construction site.
+pub fn resolve_max_response_bytes(spec_override: Option<u64>, configured_default: usize) -> usize {
+    spec_override
+        .and_then(|b| usize::try_from(b).ok())
+        .unwrap_or(configured_default)
+}
+
+/// Every web_fetch enforcement input resolved from the PodSpec's `network`
+/// section, in one place so the construction site does not thread four fields
+/// by hand (and so a new one lands here, not scattered).
+pub struct WebFetchConfig {
+    pub dns_allow: Vec<String>,
+    pub url_allow: Vec<String>,
+    /// Per-pod MIME allowlist override; `None` keeps the built-in list.
+    pub mime_allow: Option<Vec<String>>,
+    /// Effective response cap: the pod's override or `configured_default`.
+    pub max_bytes: usize,
+}
+
+/// Resolve the web_fetch config from a pod's optional `network` spec. The two
+/// allowlists default to empty (open) when absent; the two overrides fall back
+/// to the built-in list / the configured cap.
+pub fn resolve_web_fetch_config(
+    network: Option<&nucleus_spec::NetworkSpec>,
+    configured_default_max_bytes: usize,
+) -> WebFetchConfig {
+    WebFetchConfig {
+        dns_allow: network.map(|n| n.dns_allow.clone()).unwrap_or_default(),
+        url_allow: network.map(|n| n.url_allow.clone()).unwrap_or_default(),
+        mime_allow: network.and_then(|n| n.mime_allow.clone()),
+        max_bytes: resolve_max_response_bytes(
+            network.and_then(|n| n.max_response_bytes),
+            configured_default_max_bytes,
+        ),
+    }
+}
+
 /// Check if a response's Content-Type is in the allowed MIME type list.
 /// Empty content types are allowed (server didn't specify).
-pub fn check_mime_type(content_type: &str) -> Result<(), String> {
+///
+/// `allow_override` is the pod's `network.mime_allow`: when `Some`, its prefixes
+/// REPLACE the built-in [`ALLOWED_MIME_PREFIXES`]; when `None`, the built-in
+/// list applies. An empty override list therefore denies every non-empty
+/// content type, which is the operator explicitly narrowing the surface.
+pub fn check_mime_type(
+    content_type: &str,
+    allow_override: Option<&[String]>,
+) -> Result<(), String> {
     if content_type.is_empty() {
         return Ok(());
     }
 
-    if ALLOWED_MIME_PREFIXES
-        .iter()
-        .any(|prefix| content_type.starts_with(prefix))
-    {
+    let allowed = match allow_override {
+        Some(prefixes) => prefixes
+            .iter()
+            .any(|prefix| content_type.starts_with(prefix.as_str())),
+        None => ALLOWED_MIME_PREFIXES
+            .iter()
+            .any(|prefix| content_type.starts_with(prefix)),
+    };
+
+    if allowed {
         Ok(())
     } else {
         Err(format!(
@@ -188,15 +244,57 @@ mod tests {
 
     #[test]
     fn test_mime_allowed() {
-        assert!(check_mime_type("text/html; charset=utf-8").is_ok());
-        assert!(check_mime_type("application/json").is_ok());
-        assert!(check_mime_type("").is_ok());
+        assert!(check_mime_type("text/html; charset=utf-8", None).is_ok());
+        assert!(check_mime_type("application/json", None).is_ok());
+        assert!(check_mime_type("", None).is_ok());
     }
 
     #[test]
     fn test_mime_blocked() {
-        assert!(check_mime_type("application/octet-stream").is_err());
-        assert!(check_mime_type("image/png").is_err());
-        assert!(check_mime_type("application/zip").is_err());
+        assert!(check_mime_type("application/octet-stream", None).is_err());
+        assert!(check_mime_type("image/png", None).is_err());
+        assert!(check_mime_type("application/zip", None).is_err());
+    }
+
+    /// **The per-pod override actually bites.** A `network.mime_allow` of
+    /// `["image/"]` must ADMIT `image/png` (which the built-in list blocks) and
+    /// REJECT `text/html` (which the built-in list allows) — proving the
+    /// override replaces the built-in set rather than adding to it. Before this
+    /// was wired, the field was parsed and silently ignored.
+    #[test]
+    fn a_pod_mime_override_replaces_the_builtin_list() {
+        let override_list = vec!["image/".to_string()];
+        assert!(check_mime_type("image/png", Some(&override_list)).is_ok());
+        assert!(
+            check_mime_type("text/html", Some(&override_list)).is_err(),
+            "an override must REPLACE the built-in allowlist, not extend it"
+        );
+    }
+
+    /// An empty override is the operator narrowing to nothing: every non-empty
+    /// content type is refused, but an empty content type still passes (the
+    /// server-didn't-say case is orthogonal to the allowlist).
+    #[test]
+    fn an_empty_mime_override_denies_everything_typed() {
+        let empty: Vec<String> = vec![];
+        assert!(check_mime_type("application/json", Some(&empty)).is_err());
+        assert!(check_mime_type("", Some(&empty)).is_ok());
+    }
+
+    /// **The per-pod response cap actually overrides the default.** A spec
+    /// value wins over the configured default; absence falls back to it. Before
+    /// this was wired, `network.max_response_bytes` was parsed and ignored and
+    /// the CLI cap always applied.
+    #[test]
+    fn a_pod_response_cap_overrides_the_configured_default() {
+        assert_eq!(
+            resolve_max_response_bytes(Some(1024), 5 * 1024 * 1024),
+            1024
+        );
+        assert_eq!(
+            resolve_max_response_bytes(None, 5 * 1024 * 1024),
+            5 * 1024 * 1024,
+            "absent override must fall back to the configured cap"
+        );
     }
 }


### PR DESCRIPTION
The skeptical audit's top cluster: three places where a declared surface *reads as wired* via its doc-comment / `#[allow]` annotation but had **no consuming call site**. Each is now wired, with a test proving the knob bites.

## 1. `register_executor_pubkey()` was never called — `nucleus-node/trust_gate.rs`
Its `#[allow(dead_code)]` comment falsely said *"Called at startup"*. Every receipt POST is signed with the per-executor Ed25519 key (`X-Nucleus-Executor-Sig`) but ships **no inline pubkey**, so the trust-service could never verify those signatures — it never received the enrollment. **Fix:** called once from `main()` before serving, gated on `is_enabled()`; false `#[allow]` removed. (HMAC auth was unaffected — this was an inert *additive* identity layer, not an auth break.)

## 2. `NetworkSpec.mime_allow` — parsed but never read — `nucleus-spec` / `nucleus-tool-proxy`
The per-pod web_fetch MIME allowlist was **silently ignored**; the built-in `ALLOWED_MIME_PREFIXES` always applied despite a doc-comment promising the override. **Fix:** `check_mime_type` now takes an `Option<&[String]>` override (`Some` **replaces** the built-in list); both call sites (HTTP + MCP) pass `state.web_fetch_mime_allow`.

## 3. `NetworkSpec.max_response_bytes` — parsed but never read
The body cap was always the CLI default, and the doc falsely claimed a **10 MiB** default (real: **5 MiB**). **Fix:** effective cap is now the per-pod value or the CLI default; doc corrected.

## Structure
All web_fetch config resolution (dns/url/mime/max) is consolidated into `web_fetch_policy::resolve_web_fetch_config` so the construction site threads one value, not four — which also keeps `tool-proxy/main.rs` under its line ceiling.

## Tests (the knobs bite)
- `a_pod_mime_override_replaces_the_builtin_list` — an override of `["image/"]` ADMITS `image/png` (built-in blocks) and REJECTS `text/html` (built-in allows).
- `an_empty_mime_override_denies_everything_typed`.
- `a_pod_response_cap_overrides_the_configured_default`.

## Verified
Linux `clippy -D warnings` clean + tests green over `nucleus-node`, `nucleus-tool-proxy`, `nucleus-spec`; `fmt --all --check` + line-ratchet pass.

## Not in this PR
The other 4 audit findings (all Low): Python SDK `acknowledge()` false audit claim, lockdown `affected_pods` count placeholder, `shutdown_otel()` never called, quickstart-boot path-filter gap. Tracked for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UA8kchV3eadjGv6BmJXfqm