### PR TITLE
fix: close the four low-severity audit findings (#4-#7)

### DIFF
--- a/.github/workflows/quickstart-boot.yml
+++ b/.github/workflows/quickstart-boot.yml
@@ -39,6 +39,10 @@ on:
       - "crates/nucleus-spec/**"
       - "crates/nucleus-guest-init/**"
       - "crates/nucleus-tool-proxy/**"
+      # The empirical FM-5 checker whose PASS/FAIL sentinel this gate reads —
+      # a PR weakening only the probe or its spec must re-trigger the boot gate.
+      - "crates/nucleus-workload-probe/**"
+      - "examples/openclaw-demo/probe-pod.yaml"
       - "scripts/firecracker/**"
       - "scripts/lima/**"
       - ".github/workflows/quickstart-boot.yml"

--- a/crates/nucleus-node/src/main.rs
+++ b/crates/nucleus-node/src/main.rs
@@ -3723,9 +3723,10 @@ impl NodeService for GrpcService {
                     0u32
                 }
             }
-            Some(proto::lockdown_request::Scope::LabelSelector(_)) => {
-                // TODO: implement label matching on pods
-                pods.len() as u32
+            Some(proto::lockdown_request::Scope::LabelSelector(selector)) => {
+                pods.values()
+                    .filter(|p| matches_label_selector(&p.spec.metadata.labels, selector))
+                    .count() as u32
             }
             None => pods.len() as u32,
         };

--- a/crates/nucleus-tool-proxy/src/main.rs
+++ b/crates/nucleus-tool-proxy/src/main.rs
@@ -2081,6 +2081,11 @@ async fn main() -> Result<(), ApiError> {
             .await?;
     }
 
+    // Flush batched OTLP spans before exit — the batch exporter would otherwise
+    // drop everything still pending at teardown. See `telemetry::shutdown_otel`.
+    #[cfg(feature = "otel")]
+    telemetry::shutdown_otel();
+
     write_exit_report(
         &exit_audit,
         &exit_work_dir,

--- a/crates/nucleus-tool-proxy/src/telemetry.rs
+++ b/crates/nucleus-tool-proxy/src/telemetry.rs
@@ -110,9 +110,9 @@ pub fn init_otel_layer() -> Option<
 
 /// Shutdown OpenTelemetry (flush pending spans).
 /// Replaces the global provider with a noop, dropping the real one which
-/// triggers flush of all pending spans.
+/// triggers flush of all pending spans. Called on the tool-proxy's exit path
+/// after the server future completes.
 #[cfg(feature = "otel")]
-#[allow(dead_code)]
 pub fn shutdown_otel() {
     let noop = opentelemetry::trace::noop::NoopTracerProvider::new();
     opentelemetry::global::set_tracer_provider(noop);

--- a/crates/portcullis-python/src/lib.rs
+++ b/crates/portcullis-python/src/lib.rs
@@ -694,7 +694,12 @@ impl Labeled {
         Ok(pyo3::types::PyBytes::new(py, &self.raw))
     }
 
-    /// Explicitly accept adversarial data. Reason is audit-logged.
+    /// Explicitly accept adversarial data.
+    ///
+    /// The `reason` is written to the host log (stderr), which the runtime
+    /// captures in the pod log — a record that a human accepted the risk. It is
+    /// a plain log line, not an entry in the tool-proxy's tamper-evident HMAC
+    /// chain, so treat it as a breadcrumb rather than a signed attestation.
     ///
     /// Returns the raw bytes without raising `UntrustedAccess`.
     fn acknowledge<'py>(
@@ -702,7 +707,11 @@ impl Labeled {
         py: Python<'py>,
         reason: &str,
     ) -> Bound<'py, pyo3::types::PyBytes> {
-        let _ = reason; // TODO: emit audit event
+        // Record the acknowledgement rather than silently dropping the reason.
+        eprintln!(
+            "portcullis: adversarial data acknowledged (len={}, reason={reason:?})",
+            self.raw.len()
+        );
         pyo3::types::PyBytes::new(py, &self.raw)
     }
 


### PR DESCRIPTION
The remaining four (all Low) from the skeptical audit — the `#1-#3` cluster landed in #2220.

## #4 — Python SDK `acknowledge()` false audit claim — `portcullis-python/lib.rs`
`Labeled.acknowledge(reason)` dropped `reason` behind `// TODO: emit audit event` while its docstring promised it was "audit-logged." Now writes the reason to the host log (stderr → captured in the pod log), and the docstring states precisely what that record is (a breadcrumb, **not** a signed HMAC-chain entry) rather than over-promising.

## #5 — Lockdown `affected_pods` count placeholder — `nucleus-node/main.rs`
Returned `pods.len()` for any `LabelSelector` (a TODO), over-reporting a label-scoped lockdown and disagreeing with the audit loop 30 lines below. Now counts pods matching the selector via the same `matches_label_selector` the audit loop uses.

## #6 — `shutdown_otel()` never called — `nucleus-tool-proxy`
The OTLP batch exporter never flushed at exit, dropping spans pending at teardown. Now called on the exit path after the server future completes (under the `otel` feature); its false `#[allow(dead_code)]` removed.

## #7 — `quickstart-boot` path filter gap — `.github/workflows/quickstart-boot.yml`
The per-PR filter omitted `crates/nucleus-workload-probe/**` and `examples/openclaw-demo/probe-pod.yaml` — the empirical FM-5 checker whose sentinel the gate reads — so a PR weakening only the probe wouldn't re-trigger the boot gate. Both paths added (verified they exist).

## Verified
`nucleus-node` + `nucleus-tool-proxy` build clean; fmt + line-ratchet pass. Completes the 2026-08-08 audit punch-list.

**Note:** touches `nucleus-tool-proxy/main.rs` and `nucleus-node/main.rs` in different regions from #2220 — no textual conflict; the tool-proxy line-ceiling lands at exactly 4975 (`<=`) when both merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UA8kchV3eadjGv6BmJXfqm