### PR TITLE
security: enforce the egress allowlist on every redirect hop (fix SSRF/exfil)

### DIFF
--- a/crates/nucleus-tool-proxy/src/main.rs
+++ b/crates/nucleus-tool-proxy/src/main.rs
@@ -1548,14 +1548,8 @@ async fn main() -> Result<(), ApiError> {
 
     let audit = build_audit_log(&args, &auth).await?;
 
-    // Build HTTP client for web fetch
-    let web_client = reqwest::Client::builder()
-        .timeout(Duration::from_secs(args.web_fetch_timeout_secs))
-        .user_agent("nucleus-tool-proxy/0.1")
-        .build()
-        .map_err(|e| ApiError::Spec(format!("failed to build HTTP client: {e}")))?;
-
-    // Extract DNS and URL allow lists from spec
+    // Extract DNS and URL allow lists from spec (needed BEFORE the client is
+    // built, so the redirect policy can re-check every hop against them).
     let dns_allow = spec
         .spec
         .network
@@ -1568,6 +1562,17 @@ async fn main() -> Result<(), ApiError> {
         .as_ref()
         .map(|n| n.url_allow.clone())
         .unwrap_or_default();
+
+    // Build the web_fetch HTTP client with the allowlist-enforcing redirect
+    // policy (see `web_fetch_policy::build_web_fetch_client` — every redirect
+    // hop is re-checked, closing the SSRF/exfil vector where an allowlisted
+    // host redirects the fetch to a host the policy never authorized).
+    let web_client = web_fetch_policy::build_web_fetch_client(
+        Duration::from_secs(args.web_fetch_timeout_secs),
+        dns_allow.clone(),
+        url_allow.clone(),
+    )
+    .map_err(|e| ApiError::Spec(format!("failed to build HTTP client: {e}")))?;
 
     // Build attestation verifier
     let attestation_config = {
@@ -4418,6 +4423,9 @@ async fn build_audit_log(args: &Args, auth: &AuthConfig) -> Result<Arc<AuditLog>
     let webhook = if let Some(url) = args.audit_webhook.as_ref() {
         let client = reqwest::Client::builder()
             .timeout(Duration::from_secs(10))
+            // Never chase a redirect when shipping audit records — a webhook
+            // that 3xx's to another host would leak the audit stream there.
+            .redirect(reqwest::redirect::Policy::none())
             .build()
             .map_err(|e| ApiError::Spec(format!("failed to build webhook client: {e}")))?;
         info!("audit webhook configured: {}", url);

--- a/crates/nucleus-tool-proxy/src/web_fetch_policy.rs
+++ b/crates/nucleus-tool-proxy/src/web_fetch_policy.rs
@@ -117,6 +117,53 @@ pub fn check_mime_type(content_type: &str) -> Result<(), String> {
     }
 }
 
+/// Whether a redirect hop to `url` may be followed under the pod's egress
+/// policy — the SAME `dns_allow` + `url_allow` the initial request is checked
+/// against.
+///
+/// This is the fix for the SSRF/exfil vector: reqwest follows redirects by
+/// default, and checking only the initial and final URL lets an allowlisted
+/// host `302` the fetch through an INTERMEDIATE host the policy never
+/// authorized (attacker data in the redirect URL reaches it before any content
+/// check). Every hop is now gated by this, so a redirect that escapes the
+/// allowlist is refused before the request is sent. Empty allowlists mean
+/// "open", matching the initial-request semantics.
+pub fn redirect_hop_allowed(dns_allow: &[String], url_allow: &[String], url: &url::Url) -> bool {
+    let host = url.host_str().unwrap_or("");
+    let port = url.port_or_known_default().unwrap_or(443);
+    check_dns_allowlist(dns_allow, host, port).is_ok()
+        && check_url_allowlist(url_allow, url.as_str()).is_ok()
+}
+
+/// Build the web_fetch HTTP client with a redirect policy that re-checks EVERY
+/// hop against the pod's `dns_allow`/`url_allow` (via [`redirect_hop_allowed`]).
+/// A redirect escaping the allowlist fails the request; the chain is bounded to
+/// 10 hops as defense in depth. This is the SSRF/exfil fix — without it reqwest
+/// follows redirects by default and only the first and last URL are validated.
+pub fn build_web_fetch_client(
+    timeout: std::time::Duration,
+    dns_allow: Vec<String>,
+    url_allow: Vec<String>,
+) -> reqwest::Result<reqwest::Client> {
+    reqwest::Client::builder()
+        .timeout(timeout)
+        .user_agent("nucleus-tool-proxy/0.1")
+        .redirect(reqwest::redirect::Policy::custom(move |attempt| {
+            if attempt.previous().len() >= 10 {
+                return attempt.error("too many redirects");
+            }
+            let target = attempt.url().clone();
+            if redirect_hop_allowed(&dns_allow, &url_allow, &target) {
+                attempt.follow()
+            } else {
+                attempt.error(format!(
+                    "redirect to {target} is blocked by the pod's egress policy"
+                ))
+            }
+        }))
+        .build()
+}
+
 /// Validate the final URL after redirects against the DNS allowlist.
 /// This prevents open-redirect bypass attacks where an allowlisted domain
 /// redirects to a non-allowlisted domain.
@@ -198,5 +245,40 @@ mod tests {
         assert!(check_mime_type("application/octet-stream").is_err());
         assert!(check_mime_type("image/png").is_err());
         assert!(check_mime_type("application/zip").is_err());
+    }
+
+    /// **The redirect-hop gate refuses an escape from the allowlist.** An
+    /// allowlisted host that 302s to a non-allowlisted host must be blocked
+    /// before the intermediate request is sent — the SSRF/exfil vector.
+    #[test]
+    fn a_redirect_hop_outside_the_allowlist_is_refused() {
+        let url_allow = vec!["https://docs.rs/*".to_string()];
+        let dns_allow = vec!["docs.rs".to_string()];
+        let evil = url::Url::parse("https://evil.example/steal?data=secret").unwrap();
+        assert!(
+            !redirect_hop_allowed(&dns_allow, &url_allow, &evil),
+            "a redirect to a host outside the allowlist must not be followed"
+        );
+        let metadata = url::Url::parse("http://169.254.169.254/latest/meta-data/").unwrap();
+        assert!(!redirect_hop_allowed(&dns_allow, &url_allow, &metadata));
+    }
+
+    /// A redirect that STAYS inside the allowlist is still followed — the gate
+    /// tightens escapes, it does not break legitimate same-policy redirects.
+    #[test]
+    fn a_redirect_hop_inside_the_allowlist_is_followed() {
+        // `**` spans path separators; `*` does not (see url_glob_match).
+        let url_allow = vec!["https://docs.rs/**".to_string()];
+        let dns_allow = vec!["docs.rs".to_string()];
+        let ok = url::Url::parse("https://docs.rs/crate/serde/latest").unwrap();
+        assert!(redirect_hop_allowed(&dns_allow, &url_allow, &ok));
+    }
+
+    /// Empty allowlists mean "open" — a pod with no egress policy follows
+    /// redirects anywhere, matching how its initial request is unrestricted.
+    #[test]
+    fn empty_allowlists_permit_any_redirect_hop() {
+        let any = url::Url::parse("https://anywhere.example/x").unwrap();
+        assert!(redirect_hop_allowed(&[], &[], &any));
     }
 }


### PR DESCRIPTION
**North Star red-team finding G1 — a live, undisclosed authority bypass.**

## The bug
`web_client` (`tool-proxy/main.rs`) was built with reqwest's **default redirect policy**, so it follows up to 10 redirects while the egress allowlist is checked only on the **initial** and **final** URL. An allowlisted host that returns a `302` redirects the fetch through an **intermediate** host the pod's `dns_allow`/`url_allow` never authorized — attacker data in the redirect URL reaches that host *before* any content check. On Tier 1 (`--local`, no netns) that includes arbitrary hosts (`169.254.169.254`, loopback). It contradicts the flagship corollary **"no exfiltration without an explicit sink capability."** The in-code comment "Prevents open-redirect bypass" only blocked the returned *content*, never the outbound *requests*.

## The fix
`web_fetch_policy::build_web_fetch_client` installs a custom redirect policy that re-checks **every hop** against the same `dns_allow`/`url_allow` (via the new pure, tested `redirect_hop_allowed`), fails the request on an escape, and bounds the chain to 10. Empty allowlists still mean "open" (matches initial-request semantics). The audit-webhook client is set to `Policy::none()` — audit records must not chase a redirect to another host.

## Tests
- `a_redirect_hop_outside_the_allowlist_is_refused` (including `169.254.169.254`)
- `a_redirect_hop_inside_the_allowlist_is_followed`
- `empty_allowlists_permit_any_redirect_hop`

## Verified
Linux `clippy -D warnings` + tool-proxy tests green; `fmt --all --check` + line-ratchet pass (the client builder was extracted to `web_fetch_policy` to stay under the ceiling).

## Follow-ups (separate PR — ledger honesty fixes from the same audit)
G2 (C5 PROVED→NOT-YET + false declassify prose), G3/G4 (C9 TESTED→NOT-YET), G6 (C4 gate precision), G7 (authority-monotonicity prose). This PR is the only *code/security* fix of the set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UA8kchV3eadjGv6BmJXfqm