### PR TITLE
tool-proxy: land web_fetch redirect-egress + config-wiring fixes (supersedes #2220, #2222)

### DIFF
--- a/crates/nucleus-node/src/main.rs
+++ b/crates/nucleus-node/src/main.rs
@@ -751,6 +751,13 @@ async fn main() -> Result<(), ApiError> {
         lockdown_tx: tokio::sync::broadcast::channel::<proto::LockdownCommand>(16).0,
     };
 
+    // Enroll this executor's Ed25519 public key with the trust-service, once,
+    // before serving. Every receipt POST is signed with the matching private
+    // key (`X-Nucleus-Executor-Sig`) but ships no inline pubkey, so the
+    // trust-service can only verify those signatures if it learned the key from
+    // this enrollment first. A no-op when the trust gate is disabled.
+    trust_gate::register_executor_pubkey(&state.trust_gate, &state.http_client).await;
+
     // Routes that require HMAC auth
     let authenticated_routes = Router::new()
         .route("/v1/pods", post(create_pod).get(pod_api::list_pods))

--- a/crates/nucleus-node/src/trust_gate.rs
+++ b/crates/nucleus-node/src/trust_gate.rs
@@ -1180,10 +1180,11 @@ fn hmac_sha256_hex(secret: &[u8], data: &[u8]) -> String {
 
 /// Register this executor's Ed25519 public key with the trust-service.
 ///
-/// Called once at startup so the trust-service can verify per-executor
-/// signatures on subsequent receipt POSTs. The registration request itself
+/// Called once at startup (from `main`, before serving) so the trust-service
+/// can verify per-executor signatures on subsequent receipt POSTs — those POSTs
+/// carry `X-Nucleus-Executor-Sig` but no inline pubkey, so without this
+/// enrollment the signatures are unverifiable. The registration request itself
 /// is HMAC-authenticated using `receipt_secret`.
-#[allow(dead_code)] // Called at startup when trust gate is enabled
 pub async fn register_executor_pubkey(config: &TrustGateConfig, http_client: &reqwest::Client) {
     if !config.is_enabled() {
         return;

--- a/crates/nucleus-spec/src/lib.rs
+++ b/crates/nucleus-spec/src/lib.rs
@@ -273,12 +273,14 @@ pub struct NetworkSpec {
     /// If non-empty, only URLs matching at least one pattern are permitted.
     #[serde(default)]
     pub url_allow: Vec<String>,
-    /// Override the default MIME type allowlist for web_fetch responses.
-    /// If None, the built-in allowlist (text + structured data) is used.
+    /// Override the built-in MIME-type allowlist for web_fetch responses.
+    /// When `Some`, the listed prefixes REPLACE the built-in list; when `None`,
+    /// the built-in allowlist (text + structured data) is used.
     #[serde(default)]
     pub mime_allow: Option<Vec<String>>,
-    /// Maximum response body size in bytes for web_fetch.
-    /// Defaults to 10 MiB if not specified.
+    /// Per-pod maximum response body size in bytes for web_fetch.
+    /// When `None`, the proxy's configured cap applies
+    /// (`--web-fetch-max-bytes` / `NUCLEUS_TOOL_PROXY_WEB_FETCH_MAX_BYTES`).
     #[serde(default)]
     pub max_response_bytes: Option<u64>,
 }

--- a/crates/nucleus-tool-proxy/src/main.rs
+++ b/crates/nucleus-tool-proxy/src/main.rs
@@ -1548,14 +1548,8 @@ async fn main() -> Result<(), ApiError> {
 
     let audit = build_audit_log(&args, &auth).await?;
 
-    // Build HTTP client for web fetch
-    let web_client = reqwest::Client::builder()
-        .timeout(Duration::from_secs(args.web_fetch_timeout_secs))
-        .user_agent("nucleus-tool-proxy/0.1")
-        .build()
-        .map_err(|e| ApiError::Spec(format!("failed to build HTTP client: {e}")))?;
-
-    // Extract DNS and URL allow lists from spec
+    // Extract DNS and URL allow lists from spec (needed BEFORE the client is
+    // built, so the redirect policy can re-check every hop against them).
     let dns_allow = spec
         .spec
         .network
@@ -1568,6 +1562,17 @@ async fn main() -> Result<(), ApiError> {
         .as_ref()
         .map(|n| n.url_allow.clone())
         .unwrap_or_default();
+
+    // Build the web_fetch HTTP client with the allowlist-enforcing redirect
+    // policy (see `web_fetch_policy::build_web_fetch_client` — every redirect
+    // hop is re-checked, closing the SSRF/exfil vector where an allowlisted
+    // host redirects the fetch to a host the policy never authorized).
+    let web_client = web_fetch_policy::build_web_fetch_client(
+        Duration::from_secs(args.web_fetch_timeout_secs),
+        dns_allow.clone(),
+        url_allow.clone(),
+    )
+    .map_err(|e| ApiError::Spec(format!("failed to build HTTP client: {e}")))?;
 
     // Build attestation verifier
     let attestation_config = {
@@ -4418,6 +4423,9 @@ async fn build_audit_log(args: &Args, auth: &AuthConfig) -> Result<Arc<AuditLog>
     let webhook = if let Some(url) = args.audit_webhook.as_ref() {
         let client = reqwest::Client::builder()
             .timeout(Duration::from_secs(10))
+            // Never chase a redirect when shipping audit records — a webhook
+            // that 3xx's to another host would leak the audit stream there.
+            .redirect(reqwest::redirect::Policy::none())
             .build()
             .map_err(|e| ApiError::Spec(format!("failed to build webhook client: {e}")))?;
         info!("audit webhook configured: {}", url);

--- a/crates/nucleus-tool-proxy/src/main.rs
+++ b/crates/nucleus-tool-proxy/src/main.rs
@@ -361,7 +361,13 @@ pub(crate) struct AppState {
     pub(crate) web_client: reqwest::Client,
     /// Upstreams reachable with a credential the workload never holds.
     pub(crate) credentialed_egress: Vec<nucleus_spec::CredentialedEgressSpec>,
+    /// Effective web_fetch response cap: the pod's `network.max_response_bytes`
+    /// if set, else the proxy's `--web-fetch-max-bytes`. Resolved once at
+    /// startup so every read site enforces the same per-pod value.
     web_fetch_max_bytes: usize,
+    /// The pod's `network.mime_allow` override, if any. `None` means the
+    /// built-in `ALLOWED_MIME_PREFIXES` applies.
+    web_fetch_mime_allow: Option<Vec<String>>,
     dns_allow: Vec<String>,
     /// URL pattern allowlist for web_fetch. If non-empty, URLs must match.
     url_allow: Vec<String>,
@@ -1555,19 +1561,16 @@ async fn main() -> Result<(), ApiError> {
         .build()
         .map_err(|e| ApiError::Spec(format!("failed to build HTTP client: {e}")))?;
 
-    // Extract DNS and URL allow lists from spec
-    let dns_allow = spec
-        .spec
-        .network
-        .as_ref()
-        .map(|n| n.dns_allow.clone())
-        .unwrap_or_default();
-    let url_allow = spec
-        .spec
-        .network
-        .as_ref()
-        .map(|n| n.url_allow.clone())
-        .unwrap_or_default();
+    // All web_fetch enforcement inputs (DNS/URL allowlists + the per-pod MIME
+    // and response-cap overrides) resolved from the spec in one place.
+    let web_fetch_cfg = web_fetch_policy::resolve_web_fetch_config(
+        spec.spec.network.as_ref(),
+        args.web_fetch_max_bytes,
+    );
+    let dns_allow = web_fetch_cfg.dns_allow;
+    let url_allow = web_fetch_cfg.url_allow;
+    let web_fetch_mime_allow = web_fetch_cfg.mime_allow;
+    let web_fetch_max_bytes = web_fetch_cfg.max_bytes;
 
     // Build attestation verifier
     let attestation_config = {
@@ -1842,7 +1845,8 @@ async fn main() -> Result<(), ApiError> {
         approval_nonces: Arc::new(ApprovalNonceCache::default()),
         approval_rate_limiter: Arc::new(ApprovalRateLimiter::default()),
         web_client,
-        web_fetch_max_bytes: args.web_fetch_max_bytes,
+        web_fetch_max_bytes,
+        web_fetch_mime_allow,
         dns_allow,
         url_allow,
         attestation_verifier,
@@ -3577,7 +3581,8 @@ async fn web_fetch(
         .get(reqwest::header::CONTENT_TYPE)
         .and_then(|v| v.to_str().ok())
         .unwrap_or("");
-    web_fetch_policy::check_mime_type(content_type).map_err(ApiError::WebFetch)?;
+    web_fetch_policy::check_mime_type(content_type, state.web_fetch_mime_allow.as_deref())
+        .map_err(ApiError::WebFetch)?;
 
     // Collect response headers + add exposure metadata
     let mut response_headers: HashMap<String, String> = response

--- a/crates/nucleus-tool-proxy/src/mcp.rs
+++ b/crates/nucleus-tool-proxy/src/mcp.rs
@@ -1273,7 +1273,10 @@ impl NucleusMcpServer {
                 .get(reqwest::header::CONTENT_TYPE)
                 .and_then(|v| v.to_str().ok())
                 .unwrap_or("");
-            crate::web_fetch_policy::check_mime_type(content_type)?;
+            crate::web_fetch_policy::check_mime_type(
+                content_type,
+                self.state.web_fetch_mime_allow.as_deref(),
+            )?;
 
             // Bounded streaming read: never allocate the whole upstream body, so a
             // malicious page cannot OOM-kill the enforcement process (audit H-1).

--- a/crates/nucleus-tool-proxy/src/web_fetch_policy.rs
+++ b/crates/nucleus-tool-proxy/src/web_fetch_policy.rs
@@ -117,6 +117,53 @@ pub fn check_mime_type(content_type: &str) -> Result<(), String> {
     }
 }
 
+/// Whether a redirect hop to `url` may be followed under the pod's egress
+/// policy — the SAME `dns_allow` + `url_allow` the initial request is checked
+/// against.
+///
+/// This is the fix for the SSRF/exfil vector: reqwest follows redirects by
+/// default, and checking only the initial and final URL lets an allowlisted
+/// host `302` the fetch through an INTERMEDIATE host the policy never
+/// authorized (attacker data in the redirect URL reaches it before any content
+/// check). Every hop is now gated by this, so a redirect that escapes the
+/// allowlist is refused before the request is sent. Empty allowlists mean
+/// "open", matching the initial-request semantics.
+pub fn redirect_hop_allowed(dns_allow: &[String], url_allow: &[String], url: &url::Url) -> bool {
+    let host = url.host_str().unwrap_or("");
+    let port = url.port_or_known_default().unwrap_or(443);
+    check_dns_allowlist(dns_allow, host, port).is_ok()
+        && check_url_allowlist(url_allow, url.as_str()).is_ok()
+}
+
+/// Build the web_fetch HTTP client with a redirect policy that re-checks EVERY
+/// hop against the pod's `dns_allow`/`url_allow` (via [`redirect_hop_allowed`]).
+/// A redirect escaping the allowlist fails the request; the chain is bounded to
+/// 10 hops as defense in depth. This is the SSRF/exfil fix — without it reqwest
+/// follows redirects by default and only the first and last URL are validated.
+pub fn build_web_fetch_client(
+    timeout: std::time::Duration,
+    dns_allow: Vec<String>,
+    url_allow: Vec<String>,
+) -> reqwest::Result<reqwest::Client> {
+    reqwest::Client::builder()
+        .timeout(timeout)
+        .user_agent("nucleus-tool-proxy/0.1")
+        .redirect(reqwest::redirect::Policy::custom(move |attempt| {
+            if attempt.previous().len() >= 10 {
+                return attempt.error("too many redirects");
+            }
+            let target = attempt.url().clone();
+            if redirect_hop_allowed(&dns_allow, &url_allow, &target) {
+                attempt.follow()
+            } else {
+                attempt.error(format!(
+                    "redirect to {target} is blocked by the pod's egress policy"
+                ))
+            }
+        }))
+        .build()
+}
+
 /// Validate the final URL after redirects against the DNS allowlist.
 /// This prevents open-redirect bypass attacks where an allowlisted domain
 /// redirects to a non-allowlisted domain.
@@ -198,5 +245,40 @@ mod tests {
         assert!(check_mime_type("application/octet-stream").is_err());
         assert!(check_mime_type("image/png").is_err());
         assert!(check_mime_type("application/zip").is_err());
+    }
+
+    /// **The redirect-hop gate refuses an escape from the allowlist.** An
+    /// allowlisted host that 302s to a non-allowlisted host must be blocked
+    /// before the intermediate request is sent — the SSRF/exfil vector.
+    #[test]
+    fn a_redirect_hop_outside_the_allowlist_is_refused() {
+        let url_allow = vec!["https://docs.rs/*".to_string()];
+        let dns_allow = vec!["docs.rs".to_string()];
+        let evil = url::Url::parse("https://evil.example/steal?data=secret").unwrap();
+        assert!(
+            !redirect_hop_allowed(&dns_allow, &url_allow, &evil),
+            "a redirect to a host outside the allowlist must not be followed"
+        );
+        let metadata = url::Url::parse("http://169.254.169.254/latest/meta-data/").unwrap();
+        assert!(!redirect_hop_allowed(&dns_allow, &url_allow, &metadata));
+    }
+
+    /// A redirect that STAYS inside the allowlist is still followed — the gate
+    /// tightens escapes, it does not break legitimate same-policy redirects.
+    #[test]
+    fn a_redirect_hop_inside_the_allowlist_is_followed() {
+        // `**` spans path separators; `*` does not (see url_glob_match).
+        let url_allow = vec!["https://docs.rs/**".to_string()];
+        let dns_allow = vec!["docs.rs".to_string()];
+        let ok = url::Url::parse("https://docs.rs/crate/serde/latest").unwrap();
+        assert!(redirect_hop_allowed(&dns_allow, &url_allow, &ok));
+    }
+
+    /// Empty allowlists mean "open" — a pod with no egress policy follows
+    /// redirects anywhere, matching how its initial request is unrestricted.
+    #[test]
+    fn empty_allowlists_permit_any_redirect_hop() {
+        let any = url::Url::parse("https://anywhere.example/x").unwrap();
+        assert!(redirect_hop_allowed(&[], &[], &any));
     }
 }

--- a/crates/nucleus-tool-proxy/src/web_fetch_policy.rs
+++ b/crates/nucleus-tool-proxy/src/web_fetch_policy.rs
@@ -97,17 +97,73 @@ pub fn check_url_allowlist(url_allow: &[String], url: &str) -> Result<(), String
     }
 }
 
+/// Resolve the effective web_fetch response cap.
+///
+/// The pod's `network.max_response_bytes` overrides the proxy's configured
+/// default (`--web-fetch-max-bytes`); an absent or unrepresentable override
+/// falls back to that default. Kept pure so the override's precedence is
+/// unit-tested rather than trusted at the construction site.
+pub fn resolve_max_response_bytes(spec_override: Option<u64>, configured_default: usize) -> usize {
+    spec_override
+        .and_then(|b| usize::try_from(b).ok())
+        .unwrap_or(configured_default)
+}
+
+/// Every web_fetch enforcement input resolved from the PodSpec's `network`
+/// section, in one place so the construction site does not thread four fields
+/// by hand (and so a new one lands here, not scattered).
+pub struct WebFetchConfig {
+    pub dns_allow: Vec<String>,
+    pub url_allow: Vec<String>,
+    /// Per-pod MIME allowlist override; `None` keeps the built-in list.
+    pub mime_allow: Option<Vec<String>>,
+    /// Effective response cap: the pod's override or `configured_default`.
+    pub max_bytes: usize,
+}
+
+/// Resolve the web_fetch config from a pod's optional `network` spec. The two
+/// allowlists default to empty (open) when absent; the two overrides fall back
+/// to the built-in list / the configured cap.
+pub fn resolve_web_fetch_config(
+    network: Option<&nucleus_spec::NetworkSpec>,
+    configured_default_max_bytes: usize,
+) -> WebFetchConfig {
+    WebFetchConfig {
+        dns_allow: network.map(|n| n.dns_allow.clone()).unwrap_or_default(),
+        url_allow: network.map(|n| n.url_allow.clone()).unwrap_or_default(),
+        mime_allow: network.and_then(|n| n.mime_allow.clone()),
+        max_bytes: resolve_max_response_bytes(
+            network.and_then(|n| n.max_response_bytes),
+            configured_default_max_bytes,
+        ),
+    }
+}
+
 /// Check if a response's Content-Type is in the allowed MIME type list.
 /// Empty content types are allowed (server didn't specify).
-pub fn check_mime_type(content_type: &str) -> Result<(), String> {
+///
+/// `allow_override` is the pod's `network.mime_allow`: when `Some`, its prefixes
+/// REPLACE the built-in [`ALLOWED_MIME_PREFIXES`]; when `None`, the built-in
+/// list applies. An empty override list therefore denies every non-empty
+/// content type, which is the operator explicitly narrowing the surface.
+pub fn check_mime_type(
+    content_type: &str,
+    allow_override: Option<&[String]>,
+) -> Result<(), String> {
     if content_type.is_empty() {
         return Ok(());
     }
 
-    if ALLOWED_MIME_PREFIXES
-        .iter()
-        .any(|prefix| content_type.starts_with(prefix))
-    {
+    let allowed = match allow_override {
+        Some(prefixes) => prefixes
+            .iter()
+            .any(|prefix| content_type.starts_with(prefix.as_str())),
+        None => ALLOWED_MIME_PREFIXES
+            .iter()
+            .any(|prefix| content_type.starts_with(prefix)),
+    };
+
+    if allowed {
         Ok(())
     } else {
         Err(format!(
@@ -188,15 +244,57 @@ mod tests {
 
     #[test]
     fn test_mime_allowed() {
-        assert!(check_mime_type("text/html; charset=utf-8").is_ok());
-        assert!(check_mime_type("application/json").is_ok());
-        assert!(check_mime_type("").is_ok());
+        assert!(check_mime_type("text/html; charset=utf-8", None).is_ok());
+        assert!(check_mime_type("application/json", None).is_ok());
+        assert!(check_mime_type("", None).is_ok());
     }
 
     #[test]
     fn test_mime_blocked() {
-        assert!(check_mime_type("application/octet-stream").is_err());
-        assert!(check_mime_type("image/png").is_err());
-        assert!(check_mime_type("application/zip").is_err());
+        assert!(check_mime_type("application/octet-stream", None).is_err());
+        assert!(check_mime_type("image/png", None).is_err());
+        assert!(check_mime_type("application/zip", None).is_err());
+    }
+
+    /// **The per-pod override actually bites.** A `network.mime_allow` of
+    /// `["image/"]` must ADMIT `image/png` (which the built-in list blocks) and
+    /// REJECT `text/html` (which the built-in list allows) — proving the
+    /// override replaces the built-in set rather than adding to it. Before this
+    /// was wired, the field was parsed and silently ignored.
+    #[test]
+    fn a_pod_mime_override_replaces_the_builtin_list() {
+        let override_list = vec!["image/".to_string()];
+        assert!(check_mime_type("image/png", Some(&override_list)).is_ok());
+        assert!(
+            check_mime_type("text/html", Some(&override_list)).is_err(),
+            "an override must REPLACE the built-in allowlist, not extend it"
+        );
+    }
+
+    /// An empty override is the operator narrowing to nothing: every non-empty
+    /// content type is refused, but an empty content type still passes (the
+    /// server-didn't-say case is orthogonal to the allowlist).
+    #[test]
+    fn an_empty_mime_override_denies_everything_typed() {
+        let empty: Vec<String> = vec![];
+        assert!(check_mime_type("application/json", Some(&empty)).is_err());
+        assert!(check_mime_type("", Some(&empty)).is_ok());
+    }
+
+    /// **The per-pod response cap actually overrides the default.** A spec
+    /// value wins over the configured default; absence falls back to it. Before
+    /// this was wired, `network.max_response_bytes` was parsed and ignored and
+    /// the CLI cap always applied.
+    #[test]
+    fn a_pod_response_cap_overrides_the_configured_default() {
+        assert_eq!(
+            resolve_max_response_bytes(Some(1024), 5 * 1024 * 1024),
+            1024
+        );
+        assert_eq!(
+            resolve_max_response_bytes(None, 5 * 1024 * 1024),
+            5 * 1024 * 1024,
+            "absent override must fall back to the configured cap"
+        );
     }
 }


### PR DESCRIPTION
## What

Consolidates the two stale-and-conflicting web_fetch hardening PRs into one landable change:

- **#2222** — enforce the egress allowlist on **every redirect hop** (fix SSRF/exfil: an allowlisted host 3xx-ing to an unauthorized host was followed).
- **#2220** — wire the **declared-but-dead** `network.max_response_bytes` and `network.mime_allow` config surfaces into `AppState`/`web_fetch`.

## Why one PR

Both refactored the **same** tool-proxy startup block, so they conflicted in the merge queue (`main.rs`), and intervening merges had eaten the line-ratchet headroom — each had gone stale against `main` (each individually now busts the 4975 ceiling). Landing them together resolves the conflict once and lets the combined form be *shorter* than either alone (the old inline client builder and plain DNS/URL extraction both drop out).

## How it stays under the ratchet

`read_body_capped` (+ its rationale and tests' import) moves from `main.rs` into `web_fetch_policy.rs`, where the rest of the web_fetch enforcement lives. **Net: `main.rs` 4971 → 4950** — a reduction, not growth — with all callers requalified.

## Gated behavior (all green locally)

- redirect hop allow / deny / empty-allowlist (SSRF/exfil, #2222)
- pod response-cap override, mime override replaces builtin, empty-mime-denies (#2220)
- `read_body_capped` cap / untruncated (audit H-1), after the move
- `scripts/check-line-ratchet.sh --strict` passes (4950 ≤ 4975)
- `cargo fmt --all --check`, `cargo clippy -p nucleus-tool-proxy --all-targets -D warnings`

Supersedes #2220 and #2222 (kept open until this merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)