### PR TITLE
Close C1 inbound gaps B+D and re-promote C1 to PROVED

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,6 +184,26 @@ jobs:
         shell: bash
         run: scripts/check-declassify-governor-keys-sealed.sh
 
+  # C1 ("cannot learn the secrets Nucleus holds on its behalf") is proven over
+  # the seven inbound channels in Lean, but the RUNTIME must withhold for that to
+  # hold on the live path. This gate runs the conformance the re-promotion rests
+  # on: the workload always runs as a distinct unprivileged uid (never the
+  # runtime's — /proc/<pid>/environ fence B), any unclassified NUCLEUS_* key is
+  # refused at admission (fail-closed classifier fence D), and no per-pod secret
+  # rides the guest cmdline. Reverting fence B or D reds this.
+  c1-inbound-fences-enforced:
+    name: C1 inbound fences are enforced
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
+        with:
+          cache: true
+      - name: uid distinctness, reserved-namespace, and cmdline fences hold
+        shell: bash
+        run: scripts/check-c1-inbound-fences.sh
+
   # The North Star doc's status table is the project's public claim of what is
   # PROVED, TESTED, and NOT-YET. It drifted once: a row claimed "tested on the
   # live path" for the declassification token while the dormancy gate above —

--- a/crates/nucleus-tool-proxy/src/workload.rs
+++ b/crates/nucleus-tool-proxy/src/workload.rs
@@ -281,6 +281,36 @@ impl WorkloadLaunch {
             }
         }
 
+        // Reserved-namespace fail-safe — closes the `_ => OrdinaryData`
+        // fallthrough in `env_classifier`. A `NUCLEUS_*` key the classifier does
+        // not recognise falls through to `OrdinaryData` (Public), which the
+        // relation below happily delivers. So a future secret added to the
+        // workload overlay WITHOUT a classifier arm would reach the workload
+        // silently — and the dual-classifier corpus test cannot catch it,
+        // because both classifiers share that same `OrdinaryData` default (a
+        // differential check is blind to a shortcut both sides take). Refuse any
+        // unrecognised reserved-namespace key here instead. The only public
+        // value the runtime injects under this prefix is allowlisted; every
+        // other `NUCLEUS_*` name must be classified deliberately (as a secret
+        // material kind if it carries identity, or added to this allowlist if it
+        // is genuinely public runtime config) before it may cross.
+        const PUBLIC_RESERVED: &[&str] = &["NUCLEUS_TOOL_PROXY_URL"];
+        for entry in &self.classified {
+            if entry.key.starts_with("NUCLEUS_")
+                && entry.material == MaterialKind::OrdinaryData
+                && !PUBLIC_RESERVED.contains(&entry.key.as_str())
+            {
+                return Err(Refused(format!(
+                    "environment variable `{}` is in the reserved `NUCLEUS_` namespace but the \
+                     classifier does not recognise it, so it falls through to OrdinaryData \
+                     (public) and would be delivered to the workload. Classify it in \
+                     `env_classifier.rs` (a secret material kind if it carries identity, or add \
+                     it to PUBLIC_RESERVED if it is genuinely public runtime config).",
+                    entry.key
+                )));
+            }
+        }
+
         // Every entry must be admissible to the workload under the proved
         // relation. This is the structural form of FM-5: not "we kept identity
         // material out", but "nothing that was not admitted can cross, because
@@ -825,6 +855,55 @@ mod tests {
             env.get("NUCLEUS_TOOL_PROXY_AUTH_SECRET")
                 .map(String::as_str),
             Some("s3cret")
+        );
+    }
+
+    /// **The reserved-namespace fail-safe.** An unrecognised `NUCLEUS_*`
+    /// variable falls through the classifier to `OrdinaryData` (public) and
+    /// would be delivered to the workload — the exact hole a future secret would
+    /// slip through, and one the dual-classifier corpus test cannot catch
+    /// because both classifiers share that `OrdinaryData` default. `admit` must
+    /// refuse it at the boundary, where the fence actually bites.
+    #[test]
+    fn an_unclassified_reserved_namespace_key_is_refused() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let url = "http://127.0.0.1:8080";
+
+        // A novel NUCLEUS_* name the classifier does not recognise.
+        let refused = WorkloadLaunch::build(
+            &spec_with(&[("NUCLEUS_FUTURE_SECRET", "sensitive")]),
+            url,
+            "s3cret",
+            dir.path(),
+            &[],
+        )
+        .admit();
+        assert!(
+            refused.is_err(),
+            "an unclassified NUCLEUS_* key must be refused, not delivered as OrdinaryData"
+        );
+
+        // Control 1: the one public reserved name the runtime injects
+        // (NUCLEUS_TOOL_PROXY_URL) is allowlisted and must still admit.
+        assert!(
+            WorkloadLaunch::build(&spec_with(&[]), url, "s3cret", dir.path(), &[])
+                .admit()
+                .is_ok(),
+            "NUCLEUS_TOOL_PROXY_URL is public runtime config and must still admit"
+        );
+
+        // Control 2: an ordinary (non-reserved) operator var is unaffected.
+        assert!(
+            WorkloadLaunch::build(
+                &spec_with(&[("MY_APP_SETTING", "value")]),
+                url,
+                "s3cret",
+                dir.path(),
+                &[],
+            )
+            .admit()
+            .is_ok(),
+            "a non-NUCLEUS_ operator var must be unaffected by the reserved-namespace fence"
         );
     }
 

--- a/crates/nucleus-tool-proxy/src/workload.rs
+++ b/crates/nucleus-tool-proxy/src/workload.rs
@@ -119,6 +119,13 @@ fn env_source(key: &str, spec: &WorkloadSpec) -> EnvSource {
 /// none of the three can carry authority.
 pub(crate) const INHERITED_BY_NAME: [&str; 4] = ["PATH", "HOME", "LANG", "TZ"];
 
+/// The uid a workload runs as when its spec sets none. Deliberately a high,
+/// unprivileged, non-root value: the guest runtime is root and holds every
+/// per-pod secret in its environment, so the workload MUST run as a distinct
+/// uid or it could read that environment via `/proc/<pid>/environ`. A pod may
+/// override with `workload.uid`, but never to the runtime's own uid.
+pub(crate) const DEFAULT_WORKLOAD_UID: u32 = 65534;
+
 #[must_use]
 pub(crate) fn workload_env(
     spec: &WorkloadSpec,
@@ -198,10 +205,6 @@ pub(crate) struct WorkloadLaunch {
     uid: Option<u32>,
     env: BTreeMap<String, String>,
     classified: Vec<ClassifiedEntry>,
-    /// Whether credentialed egress is configured — folded in here so the uid
-    /// coupling that used to live 300 lines away is a field of the thing being
-    /// admitted, not an adjacent call a caller can forget.
-    has_credentialed_egress: bool,
 }
 
 impl WorkloadLaunch {
@@ -246,7 +249,6 @@ impl WorkloadLaunch {
             uid: spec.uid,
             env,
             classified,
-            has_credentialed_egress: !egress.is_empty(),
         }
     }
 
@@ -259,26 +261,26 @@ impl WorkloadLaunch {
     /// reaching this point is refused here rather than trusted to have been kept
     /// out upstream.
     pub(crate) fn admit(self) -> Result<AdmittedWorkloadPlan, Refused> {
-        // The uid coupling, folded in from `reject_credential_readable_workload`.
-        if self.has_credentialed_egress {
-            match self.uid {
-                Some(uid) if uid != nix_getuid() => {}
-                Some(uid) => {
-                    return Err(Refused(format!(
-                        "the workload's uid ({uid}) is the runtime's own, so it can read the \
-                         runtime's environment via /proc and obtain the credentialed-egress \
-                         secret. Give the workload a distinct unprivileged uid."
-                    )));
-                }
-                None => {
-                    return Err(Refused(
-                        "credentialed egress is configured but the workload has no `uid`, so it \
-                         runs as the runtime's user and can read the credential from \
-                         /proc/<pid>/environ. Set `workload.uid` to a distinct unprivileged uid."
-                            .to_string(),
-                    ));
-                }
-            }
+        // The workload must never run as the runtime's uid. The runtime holds
+        // every per-pod secret in its own environment, and Linux lets a process
+        // read `/proc/<pid>/environ` of any process sharing its uid — so a
+        // same-uid workload reads the broker/task/approval/DLC secrets straight
+        // out of the runtime. A distinct unprivileged uid is the boundary, and
+        // it must hold for EVERY pod, not only when credentialed egress is
+        // configured: the runtime holds those secrets regardless of egress (this
+        // supersedes the egress-only coupling in
+        // `reject_credential_readable_workload`, kept as a node-side pre-check).
+        //
+        // A pod that sets no `workload.uid` gets a distinct default unprivileged
+        // uid rather than silently running as the runtime's user; an explicit
+        // uid equal to the runtime's own is refused — it re-opens the hole.
+        let effective_uid = self.uid.unwrap_or(DEFAULT_WORKLOAD_UID);
+        if effective_uid == nix_getuid() {
+            return Err(Refused(format!(
+                "the workload's uid ({effective_uid}) is the runtime's own, so it could read the \
+                 runtime's environment — every per-pod secret — via /proc/<pid>/environ. Set \
+                 `workload.uid` to a distinct unprivileged uid."
+            )));
         }
 
         // Reserved-namespace fail-safe — closes the `_ => OrdinaryData`
@@ -330,7 +332,7 @@ impl WorkloadLaunch {
             command: self.command,
             args: self.args,
             work_dir: self.work_dir,
-            uid: self.uid,
+            uid: Some(effective_uid),
             env: self.env,
             classified: self.classified,
         })
@@ -383,8 +385,28 @@ pub(crate) fn spawn_admitted(
     // guest) after its uid dropped. The run-5 boot proved the ordering the hard
     // way: a hook that tried setgroups itself ran as the ALREADY-dropped uid
     // and got EPERM.
-    let hardened = plan.uid.is_some();
-    if let Some(uid) = plan.uid {
+    // The privilege drop and the scratch-dir chown are only possible as root,
+    // which the guest runtime is. Under a non-root test harness neither syscall
+    // would succeed, so both are skipped there; the admit-time uid logic (which
+    // guarantees `plan.uid` is a distinct unprivileged uid, never the runtime's)
+    // is unit-tested directly. In the guest the workload therefore always runs
+    // as that distinct uid and cannot read the runtime's secret-bearing environ
+    // via `/proc/<pid>/environ`.
+    let drop_uid = if nix_getuid() == 0 { plan.uid } else { None };
+    let hardened = drop_uid.is_some();
+    if let Some(uid) = drop_uid {
+        // Hand the workload ownership of its own (root-created) work dir before
+        // dropping to it, or the unprivileged child could not write its scratch
+        // disk. The runtime is root here and does this once, before exec.
+        std::os::unix::fs::chown(&plan.work_dir, Some(uid), Some(uid)).map_err(|e| {
+            std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                format!(
+                    "cannot chown work dir {} to workload uid {uid}: {e}",
+                    plan.work_dir.display()
+                ),
+            )
+        })?;
         cmd.uid(uid);
         cmd.gid(uid);
     }
@@ -395,7 +417,7 @@ pub(crate) fn spawn_admitted(
     // the runc CVE-2024-21626 lesson. When a uid is set it additionally applies
     // no_new_privs and rlimits — the self-restrictions an unprivileged process
     // may still make. Runs AFTER std's stdio dup2 and privilege drop.
-    harden::apply(&mut cmd, plan.uid);
+    harden::apply(&mut cmd, drop_uid);
 
     tracing::info!(
         command = %plan.command,
@@ -905,6 +927,54 @@ mod tests {
             .is_ok(),
             "a non-NUCLEUS_ operator var must be unaffected by the reserved-namespace fence"
         );
+    }
+
+    /// **The workload never runs as the runtime's uid — for EVERY pod, not only
+    /// under credentialed egress.** The runtime holds every per-pod secret in
+    /// its environment, and Linux lets a same-uid process read it via
+    /// `/proc/<pid>/environ`. A pod that sets no `workload.uid` is assigned a
+    /// distinct default uid rather than silently inheriting the runtime's — the
+    /// case that used to be exposed whenever no credentialed egress was set.
+    #[test]
+    fn admit_assigns_a_distinct_default_uid_when_none_is_set() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let plan = WorkloadLaunch::build(&spec_with(&[]), "u", "s3cret", dir.path(), &[])
+            .admit()
+            .expect("a clean spec admits");
+        assert_eq!(plan.uid, Some(DEFAULT_WORKLOAD_UID));
+        assert_ne!(
+            plan.uid,
+            Some(nix_getuid()),
+            "the default workload uid must never equal the runtime's own"
+        );
+    }
+
+    /// An explicit uid equal to the runtime's own re-opens the /proc/environ
+    /// hole and must be refused — the default cannot be overridden back to root.
+    #[test]
+    fn admit_refuses_a_workload_sharing_the_runtime_uid() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut spec = spec_with(&[]);
+        spec.uid = Some(nix_getuid());
+        assert!(
+            WorkloadLaunch::build(&spec, "u", "s3cret", dir.path(), &[])
+                .admit()
+                .is_err(),
+            "a workload sharing the runtime uid must be refused"
+        );
+    }
+
+    /// A distinct explicit uid is preserved, not overwritten by the default.
+    #[test]
+    fn admit_preserves_an_explicit_distinct_uid() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut spec = spec_with(&[]);
+        let distinct = nix_getuid().wrapping_add(4242);
+        spec.uid = Some(distinct);
+        let plan = WorkloadLaunch::build(&spec, "u", "s3cret", dir.path(), &[])
+            .admit()
+            .expect("a distinct uid admits");
+        assert_eq!(plan.uid, Some(distinct));
     }
 
     /// **The capability does not reach a real child.** This is the property; the

--- a/crates/nucleus-tool-proxy/src/workload.rs
+++ b/crates/nucleus-tool-proxy/src/workload.rs
@@ -395,18 +395,22 @@ pub(crate) fn spawn_admitted(
     let drop_uid = if nix_getuid() == 0 { plan.uid } else { None };
     let hardened = drop_uid.is_some();
     if let Some(uid) = drop_uid {
-        // Hand the workload ownership of its own (root-created) work dir before
-        // dropping to it, or the unprivileged child could not write its scratch
-        // disk. The runtime is root here and does this once, before exec.
-        std::os::unix::fs::chown(&plan.work_dir, Some(uid), Some(uid)).map_err(|e| {
-            std::io::Error::new(
-                std::io::ErrorKind::PermissionDenied,
-                format!(
-                    "cannot chown work dir {} to workload uid {uid}: {e}",
-                    plan.work_dir.display()
-                ),
-            )
-        })?;
+        // Best-effort: hand the workload ownership of its work dir so the
+        // unprivileged child can write its scratch. This is an ERGONOMIC aid,
+        // not the security control — the uid drop below is. It legitimately
+        // fails when the work dir is read-only (a pod with no writable scratch
+        // drive, where `/work` is on the read-only rootfs), and in that case the
+        // workload cannot write it regardless, so the failure is not fatal: log
+        // it and proceed. The privilege drop still happens unconditionally.
+        if let Err(e) = std::os::unix::fs::chown(&plan.work_dir, Some(uid), Some(uid)) {
+            tracing::warn!(
+                work_dir = %plan.work_dir.display(),
+                uid,
+                error = %e,
+                "could not chown the workload work dir to its uid; the workload will run \
+                 without ownership of it (expected when the scratch is read-only)"
+            );
+        }
         cmd.uid(uid);
         cmd.gid(uid);
     }

--- a/docs/north-star.md
+++ b/docs/north-star.md
@@ -79,7 +79,7 @@ status is a visible event, not an edit.
 
 | # | Clause (verbatim from the sentence) | Status | Evidence | Falsified by |
 | --- | --- | --- | --- | --- |
-| C1 | "learn the secrets Nucleus holds on its behalf" | NOT-YET | `crates/portcullis-core/lean/IdentityMaterialNoninterferenceExtracted.lean#identity_material_never_reaches_the_workload`, `crates/portcullis-core/lean/ChannelAdmissionExtracted.lean#no_channel_delivers_secret_to_the_workload`, `crates/nucleus-node/src/firecracker_config.rs` | — |
+| C1 | "learn the secrets Nucleus holds on its behalf" | PROVED | `crates/portcullis-core/lean/IdentityMaterialNoninterferenceExtracted.lean#identity_material_never_reaches_the_workload`, `crates/portcullis-core/lean/ChannelAdmissionExtracted.lean#no_channel_delivers_secret_to_the_workload`, `crates/nucleus-tool-proxy/src/workload.rs#DEFAULT_WORKLOAD_UID`, `crates/nucleus-tool-proxy/src/workload.rs#PUBLIC_RESERVED` | `scripts/check-c1-inbound-fences.sh` |
 | C2 | "nor those of any other pod" | NOT-YET | `docs/cross-pod-view.md` | — |
 | C3 | "nor influence which of them get released" | PROVED | `crates/portcullis-core/lean/PodMachineSpike.lean#noninterference` | `.github/workflows/portcullis-core-proven-lean.yml` |
 | C4 | "a governor deliberately released with a single-use token" | PROVED | `crates/portcullis-core/lean/DeclassifySinkScopeExtracted.lean#no_second_apply`, `crates/portcullis/src/kernel/declassify_authority.rs#apply_declassification_token`, `crates/nucleus-tool-proxy/src/declassify.rs#apply_declassification` | `scripts/check-declassify-sink-scope-enforced.sh` |
@@ -95,7 +95,7 @@ channels.*
 
 What each status means, and what it deliberately does not:
 
-- **C1 (NOT-YET — demoted 2026-08-08, was PROVED).** FM-5 genuinely proves,
+- **C1 (PROVED — re-promoted 2026-08-08; had been demoted earlier the same day).** FM-5 genuinely proves,
   over the seven modelled child-inheritance channels (Env, Argv, Cwd, Stdio,
   ExtraFd, Uid, Cmdline), the 11-kind × 3-principal delivery table,
   Aeneas-extracted, `sorry`-free, axiom-audited — but the *clause* is broader
@@ -127,17 +127,36 @@ What each status means, and what it deliberately does not:
   `no_channel_delivers_secret_to_the_workload` covers it, and
   `the_cmdline_delivers_no_secret_to_the_workload` states it by name — a `Secret`
   re-appearing on the command line is now a RED theorem, not an unmodelled gap.
-  So the specific falsifier that demoted C1 is closed AND proved. **C1 stays
-  NOT-YET** for two reasons that are narrower than before: (1) the Lean proves
-  the delivery *relation*; that the node *obeys* it (writes no Secret on the
-  cmdline) is the Rust behavioural gate `no_pod_cmdline_carries_any_per_pod_secret`,
-  which is TESTED not proved — and C7 ("a theorem about the code that ships") is
-  itself only TESTED, so C1's conformance leg cannot exceed it; (2) mounts,
-  `/proc/<pid>/environ` and `/etc/nucleus/*` remain unmodelled surfaces, and the
-  `_ => OrdinaryData` classifier fallthrough is trusted. **Promoting C1** now
-  turns on a claim-status judgement — whether those residual surfaces are
-  in-scope exclusions (like FM-5's declared mounts fence) or genuine gaps — held
-  for Brandon rather than taken unilaterally on the flagship confidentiality row.
+  So the specific falsifier that demoted C1 is closed AND proved. **C1 is
+  re-promoted to PROVED** after a red-team walk of the four residual inbound
+  surfaces resolved each — two as declared exclusions, two closed fail-closed:
+  - **Bind-mounts (excluded).** Firecracker gives the guest virtio block
+    devices, not a shared host filesystem; the only bind-mounts are host-side
+    jailer-chroot plumbing the guest never sees as files. This is FM-5's existing
+    mount fence (`extracted/channel.rs`), not a new one.
+  - **`/etc/nucleus/*` (excluded).** The legacy secret files (`auth.secret`,
+    `approval.secret`) are written only under a `--legacy-secrets` build flag no
+    shipping path passes; `pod.yaml` is cred-split (no credential *values*); the
+    one runtime-written private key is mode-0600 and folds into the uid fence
+    below.
+  - **`/proc/<pid>/environ` (gap B — now closed).** The runtime holds every
+    per-pod secret in its own environment, and a same-uid workload reads it via
+    `/proc`. The uid fence was wired only under credentialed egress, so a
+    no-egress, no-uid pod ran the workload as the runtime's uid and was exposed.
+    Every workload now runs as a distinct unprivileged uid, never the runtime's
+    (`workload.rs`, `DEFAULT_WORKLOAD_UID`).
+  - **The `_ => OrdinaryData` classifier fallthrough (gap D — now closed).** An
+    unrecognised `NUCLEUS_*` name fell through to Public and was delivered, and
+    the dual-classifier corpus test could not catch it (both classifiers share
+    that default). Any unclassified reserved-namespace key is now refused at
+    admission (`workload.rs`, `PUBLIC_RESERVED`).
+
+  C1's **relation leg** is the Lean noninterference; its **conformance leg** —
+  that the shipping runtime actually withholds — is TESTED and gated by
+  `scripts/check-c1-inbound-fences.sh` (reverting fence B or D reds it). That
+  conformance leg is bounded by C7 ("a theorem about the code that ships"),
+  itself TESTED, so the row records the proven relation with the runtime
+  conformance gated beside it — the same shape as C4.
 - **C2 (NOT-YET)** — no artifact in the corpus mentions a second pod; the host
   is outside every model. `docs/cross-pod-view.md` is the design.
 - **C3 (PROVED)** — the two-run noninterference theorem over the reference pod

--- a/scripts/check-c1-inbound-fences.sh
+++ b/scripts/check-c1-inbound-fences.sh
@@ -56,11 +56,16 @@ cargo test -p nucleus-tool-proxy -- \
 #
 # The node-side construction tests exercise `FirecrackerConfig::from_spec`, which
 # is `#[cfg(target_os = "linux")]` (the Firecracker path compiles on Linux only),
-# so they run under CI's ubuntu runner, not on a macOS dev box. The extracted
-# channel-admission model below is cross-platform.
-cargo test -p nucleus-node -- \
-    no_pod_cmdline_carries_any_per_pod_secret \
-    a_cmdline_that_carries_a_per_pod_secret_is_still_refused
+# so they run under CI's ubuntu runner and are skipped on a macOS dev box (where
+# they would not compile). The extracted channel-admission model below is
+# cross-platform and always runs.
+if [[ "$(uname -s)" == "Linux" ]]; then
+    cargo test -p nucleus-node -- \
+        no_pod_cmdline_carries_any_per_pod_secret \
+        a_cmdline_that_carries_a_per_pod_secret_is_still_refused
+else
+    echo "  (skipping the Linux-only cmdline construction tests on $(uname -s); they run in CI)"
+fi
 cargo test -p nucleus-ifc-kernel --lib -- extracted::channel
 
 echo "OK: the C1 inbound fences (uid distinctness, reserved-namespace, cmdline) are enforced."

--- a/scripts/check-c1-inbound-fences.sh
+++ b/scripts/check-c1-inbound-fences.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# C1 inbound-fence ENFORCEMENT gate — the runtime conformance behind the
+# re-promotion of North Star clause C1 ("cannot learn the secrets Nucleus holds
+# on its behalf").
+#
+# WHY THIS EXISTS
+#
+# C1's relation leg is proven in Lean (identity material and the seven
+# child-inheritance channels — including Cmdline — never deliver a secret to the
+# workload). But the Lean theorem does not say the RUNTIME withholds; that is
+# the conformance leg, and a red-team walk of the residual inbound surfaces
+# (docs/north-star.md, the C1 note) found two that were fenced only
+# conditionally or not at all:
+#
+#   B  /proc/<pid>/environ — the runtime holds every per-pod secret in its own
+#      environment; a workload sharing the runtime's uid reads it. The uid fence
+#      was wired ONLY under credentialed egress, so a no-egress, no-uid pod ran
+#      the workload as root and was exposed.
+#   D  the env classifier's `_ => OrdinaryData` fallthrough — a NUCLEUS_* name it
+#      does not recognise fell through to Public and was delivered, and the
+#      dual-classifier corpus test could not catch it (both classifiers share
+#      the OrdinaryData default).
+#
+# Both are now fail-closed at admission (crates/nucleus-tool-proxy/src/workload.rs):
+# every workload runs as a distinct unprivileged uid (never the runtime's), and
+# any unclassified reserved-namespace key is refused. This gate runs the tests
+# that red if either fence is reverted, plus the Cmdline-channel conformance
+# tests that red if a per-pod secret reappears on the guest command line.
+#
+# So this gate does NOT re-assert the Lean relation (the aeneas / portcullis-core
+# proof workflows do). It asserts the shipping runtime enforces what the relation
+# assumes — which is what makes C1 true on the live path, not just in the model.
+#
+# Usage: scripts/check-c1-inbound-fences.sh
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel 2>/dev/null || echo .)"
+
+echo "Asserting the C1 inbound fences are enforced (not just proven in the model)..."
+
+# B — the workload never runs as the runtime's uid. A no-uid pod is assigned a
+# distinct default; an explicit runtime-uid is refused; a distinct uid is kept.
+# Reverting the fence to the egress-only coupling reds these.
+cargo test -p nucleus-tool-proxy -- \
+    workload::tests::admit_assigns_a_distinct_default_uid_when_none_is_set \
+    workload::tests::admit_refuses_a_workload_sharing_the_runtime_uid \
+    workload::tests::admit_preserves_an_explicit_distinct_uid
+
+# D — an unclassified NUCLEUS_* key is refused at admission, not delivered as
+# OrdinaryData. Reverting the reserved-namespace fence reds this.
+cargo test -p nucleus-tool-proxy -- \
+    workload::tests::an_unclassified_reserved_namespace_key_is_refused
+
+# Cmdline channel conformance — no per-pod secret rides the guest /proc/cmdline
+# (the channel whose omission demoted C1 in the first place), at both the
+# node-side construction and the extracted channel-admission model.
+#
+# The node-side construction tests exercise `FirecrackerConfig::from_spec`, which
+# is `#[cfg(target_os = "linux")]` (the Firecracker path compiles on Linux only),
+# so they run under CI's ubuntu runner, not on a macOS dev box. The extracted
+# channel-admission model below is cross-platform.
+cargo test -p nucleus-node -- \
+    no_pod_cmdline_carries_any_per_pod_secret \
+    a_cmdline_that_carries_a_per_pod_secret_is_still_refused
+cargo test -p nucleus-ifc-kernel --lib -- extracted::channel
+
+echo "OK: the C1 inbound fences (uid distinctness, reserved-namespace, cmdline) are enforced."

--- a/scripts/check-gates-can-fail.sh
+++ b/scripts/check-gates-can-fail.sh
@@ -285,6 +285,24 @@ fn _gate_of_gates_unseal(k: &mut nucleus::portcullis::kernel::Kernel) {
 RS
 }
 
+# Neuter the reserved-namespace fail-safe (C1 fence D): make its OrdinaryData
+# guard always false, so an unclassified NUCLEUS_* key is no longer refused at
+# admission. The gate's `an_unclassified_reserved_namespace_key_is_refused` test
+# then reds. (Fence B, the uid distinctness, is the gate's other subject; one
+# perturbation is enough to prove the gate can fail.)
+perturb_c1_inbound_fence() {
+    local f="$1"
+    sed -i.gate-bak \
+        's/&& entry.material == MaterialKind::OrdinaryData/\&\& false/' \
+        "$f"
+    rm -f "$f.gate-bak"
+    if grep -q '&& entry.material == MaterialKind::OrdinaryData' "$f"; then
+        echo "  ERROR: admit()'s reserved-namespace guard changed shape;"
+        echo "         this perturbation no longer applies and must be updated."
+        return 1
+    fi
+}
+
 probe check-line-ratchet.sh   "--strict" crates/portcullis/src/kernel.rs \
       "400 lines past the ceiling"            perturb_line_ratchet
 probe check-mediation.sh      "" crates/nucleus-tool-proxy/src/egress.rs \
@@ -312,6 +330,9 @@ probe check-declassify-governor-keys-sealed.sh "" crates/nucleus-tool-proxy/src/
 probe check-north-star-ledger.sh "" docs/north-star.md \
       "the original overclaiming declassification status row restored" \
       perturb_ledger_restore_false_row
+probe check-c1-inbound-fences.sh "" crates/nucleus-tool-proxy/src/workload.rs \
+      "the reserved-namespace fence D neutered" \
+      perturb_c1_inbound_fence
 
 # ── Uncovered, listed rather than omitted ─────────────────────────────────
 #

--- a/scripts/north-star-ledger-ratchet.txt
+++ b/scripts/north-star-ledger-ratchet.txt
@@ -31,5 +31,21 @@
 #     attestation. admit_posture is real but is self-characterization, not
 #     outside verification, and is inert without a dlc_posture label no pod emits.
 #   Both re-earning paths are recorded in the C5/C9 notes in docs/north-star.md.
+# 2026-08-08: lowered 6 -> 5. C1 ("cannot learn the secrets Nucleus holds on
+#   its behalf") re-promoted NOT-YET -> PROVED. The channel that demoted it
+#   (world-readable guest /proc/cmdline) is now a modelled ChannelKind::Cmdline
+#   in the closed inbound enum (Aeneas-extracted, sorry-free), and a red-team
+#   walk of the four residual inbound surfaces (bind-mounts, /proc/<pid>/environ,
+#   /etc/nucleus/*, the classifier fallthrough — see the C1 note in
+#   docs/north-star.md) resolved them: bind-mounts and /etc/nucleus/* are the
+#   existing VM/mount fence (block devices, no shared host FS; legacy secret
+#   files are never built; pod.yaml is cred-split), and the two real gaps were
+#   closed fail-closed — B: every workload now runs as a distinct unprivileged
+#   uid, never the runtime's (was wired only under credentialed egress), so it
+#   cannot read the runtime's secret-bearing environ via /proc; D: an
+#   unclassified NUCLEUS_* env key is refused at admission instead of falling
+#   through to OrdinaryData and being delivered. The relation leg is the Lean
+#   noninterference; the runtime conformance leg is TESTED and gated by
+#   scripts/check-c1-inbound-fences.sh (reverting fence B or D reds it).
 CLAUSES=9
-NOT_YET=6
+NOT_YET=5


### PR DESCRIPTION
## What

Closes the two live inbound-confidentiality gaps found in the C1 red-team walk, and re-promotes North Star clause **C1** ("cannot learn the secrets Nucleus holds on its behalf") from NOT-YET to PROVED.

The walk assessed the four residual inbound surfaces:

| Surface | Call | Why |
|---|---|---|
| Bind-mounts | **exclude** | Guest gets virtio block devices, not a shared host FS; host bind-mounts are jailer-chroot-side. Existing FM-5 mount fence. |
| `/etc/nucleus/*` | **exclude** | Legacy secret files never built (no path passes `--legacy-secrets`); `pod.yaml` cred-split; lone private key is 0600 and folds into B. |
| `/proc/<pid>/environ` | **gap B — fixed** | Runtime holds all per-pod secrets in its environ; the uid fence was wired only under credentialed egress. |
| `_ => OrdinaryData` fallthrough | **gap D — fixed** | Unclassified `NUCLEUS_*` fell through to Public and was delivered; the dual-classifier corpus test couldn't catch it (both share the default). |

## The fixes (both fail-closed, in `crates/nucleus-tool-proxy/src/workload.rs`)

- **B:** every workload runs as a distinct unprivileged uid, never the runtime's. A pod with no `workload.uid` gets `DEFAULT_WORKLOAD_UID` (non-breaking — no example spec sets a uid); an explicit runtime-uid is refused. `spawn_admitted` chowns the work-dir to that uid and drops to it, guarded on running as root so the non-root test harness is unchanged.
- **D:** `admit()` refuses any `NUCLEUS_*` key that classifies as `OrdinaryData`, except the one public value the runtime injects (`NUCLEUS_TOOL_PROXY_URL`). A future overlay secret now fails closed instead of shipping silently.

## Ledger

- C1 row NOT-YET → **PROVED**; falsifier `scripts/check-c1-inbound-fences.sh` (new, wired into `ci.yml`) runs the tests that red if fence B or D regresses, plus the cmdline conformance. Ratchet `NOT_YET` 6 → 5, recorded. C1 note rewritten (four-surface walk; relation-PROVED / conformance-TESTED, C7-capped — same shape as C4).
- New gate registered in the "gates must fail on their own subject" meta-gate; verified locally that it **reds when fence D is neutered, green when restored**.

## Verification (local, all green)

`check-north-star-ledger.sh` (9 clauses, 5 NOT-YET) · `check-gates-can-fail.sh` (13 probed, 0 unaccounted) · `check-mediation.sh` · `check-line-ratchet.sh` · `cargo fmt --all --check` · `clippy -p nucleus-tool-proxy` · 17 workload tests.

## ⚠️ Merge gate

**Do not merge until `boot-a-real-pod (x86_64)` passes.** Fix B's privilege drop + work-dir chown only engage as root (the guest) and cannot be exercised without `/dev/kvm`; the unit tests cover the admit-time logic but not the in-guest spawn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)