### PR TITLE
Phase 1: extend FlowGraph to a superset of FlowTracker's egress aggregates (additive, no egress change)

### DIFF
--- a/crates/portcullis/src/flow_graph.rs
+++ b/crates/portcullis/src/flow_graph.rs
@@ -14,10 +14,14 @@ use portcullis_core::flow::{
     check_flow, intrinsic_label, propagate_label, FlowNode, FlowVerdict, NodeId, NodeKind,
     QuarantineVerdict, TrustAncestryResult, MAX_PARENTS,
 };
+use portcullis_core::ifc_api::SafetyCheck;
 use portcullis_core::receipt::{
     build_receipt, FlowReceipt, TombstonedAncestor, MAX_RECEIPT_ANCESTORS,
 };
-use portcullis_core::{default_sink_class, IFCLabel, Operation, SinkClass};
+use portcullis_core::{
+    default_sink_class, ConfLevel, ContentHash, DerivationClass, IFCLabel, IntegLevel, Operation,
+    SinkClass,
+};
 
 /// Errors during graph operations.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -343,6 +347,31 @@ pub struct FlowGraph {
     /// `field_lineage`: the node struct is `Copy` and most nodes have no
     /// scope.
     declass_scopes: HashMap<NodeId, DeclassScope>,
+    /// Per-node content hash of the bytes an observation carried
+    /// (InputsAuthorized brick 1), mirroring `FlowTracker`'s 4th node element.
+    /// Recorded only by [`observe_with_content_hash`](Self::observe_with_content_hash);
+    /// purely additive — no existing label, ceiling, or verdict reads it. Stored
+    /// in a side map (like `field_lineage`) so the `Copy` extracted `FlowNode`
+    /// is untouched.
+    content_hashes: HashMap<NodeId, ContentHash>,
+    /// Monotonic session taint ceiling — the join of every observed node's
+    /// `derivation`. A **ratchet field updated at observe time**, not a scan of
+    /// live nodes, so `maybe_compact()` tombstoning can never launder it. Mirrors
+    /// [`FlowTracker::session_taint_ceiling`](portcullis_core::ifc_api::FlowTracker::session_taint_ceiling).
+    session_taint_ceiling: DerivationClass,
+    /// Monotonic session confidentiality ceiling — `max(node.confidentiality)`
+    /// over every observation. Ratchet (anti-laundering). Mirrors
+    /// `FlowTracker::session_conf_ceiling`; backs [`session_exfiltration_check`](Self::session_exfiltration_check).
+    session_conf_ceiling: ConfLevel,
+    /// Monotonic "any observation carried `Adversarial` integrity" flag, backing
+    /// [`is_tainted`](Self::is_tainted). A ratchet rather than a live-node scan:
+    /// `FlowTracker` never compacts, so its scan means "ever adversarial"; this
+    /// flag preserves that meaning under `FlowGraph` compaction.
+    session_adversarial: bool,
+    /// Fail-closed poison flag, mirroring `FlowTracker::poisoned`: set when an
+    /// ingest observation is dropped, so taint state is unprovable and the
+    /// egress gate must deny until a human-authorized cleanse.
+    poisoned: bool,
 }
 
 /// A node's declassification scope: the released view and the signed sink
@@ -370,6 +399,12 @@ impl FlowGraph {
             field_lineage: HashMap::new(),
             frozen: BTreeSet::new(),
             declass_scopes: HashMap::new(),
+            content_hashes: HashMap::new(),
+            // Bottom of each lattice / clean session (mirrors FlowTracker::new).
+            session_taint_ceiling: DerivationClass::Deterministic,
+            session_conf_ceiling: ConfLevel::Public,
+            session_adversarial: false,
+            poisoned: false,
         }
     }
 
@@ -549,12 +584,89 @@ impl FlowGraph {
             self.declass_scopes.insert(id, s);
         }
 
+        // Raise the monotonic session aggregates (mirrors FlowTracker's
+        // observe path exactly). These are ratchet fields, updated here at the
+        // single ingest chokepoint, so `maybe_compact()` can never launder
+        // them. Purely additive: no existing FlowGraph verdict reads them.
+        self.session_taint_ceiling = self.session_taint_ceiling.join(label.derivation);
+        if label.confidentiality > self.session_conf_ceiling {
+            self.session_conf_ceiling = label.confidentiality;
+        }
+        if label.integrity == IntegLevel::Adversarial {
+            self.session_adversarial = true;
+        }
+
         // Propagate quarantine to the new observation node
         if any_parent_quarantined {
             self.quarantined.insert(id);
         }
 
         Ok(id)
+    }
+
+    /// Observe a data-source node and record the [`ContentHash`] of the bytes
+    /// it carried (InputsAuthorized brick 1) — the `FlowGraph` analogue of
+    /// [`FlowTracker::observe_with_content_hash`](portcullis_core::ifc_api::FlowTracker::observe_with_content_hash).
+    ///
+    /// Wraps [`insert_observation`](Self::insert_observation) (so the label,
+    /// declass-scope inheritance, quarantine propagation and session ratchets
+    /// are computed identically) and additionally stores the hash, retrievable
+    /// via [`content_hash`](Self::content_hash). Purely additive — existing
+    /// `insert_observation` behavior is unchanged.
+    pub fn observe_with_content_hash(
+        &mut self,
+        kind: NodeKind,
+        parents: &[NodeId],
+        now: u64,
+        hash: ContentHash,
+    ) -> Result<NodeId, FlowGraphError> {
+        let id = self.insert_observation(kind, parents, now)?;
+        self.content_hashes.insert(id, hash);
+        Ok(id)
+    }
+
+    /// The recorded content hash of an observation, or `None` if the node was
+    /// created without one. Mirrors `FlowTracker::content_hash`.
+    pub fn content_hash(&self, id: NodeId) -> Option<ContentHash> {
+        self.content_hashes.get(&id).copied()
+    }
+
+    /// The current monotonic session taint ceiling — the join of every observed
+    /// node's `derivation`. Mirrors `FlowTracker::session_taint_ceiling`.
+    pub fn session_taint_ceiling(&self) -> DerivationClass {
+        self.session_taint_ceiling
+    }
+
+    /// `true` if any observation in this session carried `Adversarial`
+    /// integrity. Mirrors `FlowTracker::is_tainted`; ratchet-backed so
+    /// compaction cannot launder a past adversarial ingest.
+    pub fn is_tainted(&self) -> bool {
+        self.session_adversarial
+    }
+
+    /// Session-level confidentiality downflow check for an outbound sink:
+    /// deny if the session ceiling exceeds what the sink may carry. Byte-for-byte
+    /// the same rule as `FlowTracker::session_exfiltration_check` — the clause
+    /// the live egress gate consults for outbound operations.
+    pub fn session_exfiltration_check(&self, sink_max_conf: ConfLevel) -> SafetyCheck {
+        if self.session_conf_ceiling > sink_max_conf {
+            return SafetyCheck::ConfidentialityViolation {
+                data_conf: self.session_conf_ceiling,
+                sink_max_conf,
+            };
+        }
+        SafetyCheck::Safe
+    }
+
+    /// Mark the session poisoned (fail-closed): an ingest observation was
+    /// dropped, so taint state is unprovable. Mirrors `FlowTracker::poison`.
+    pub fn poison(&mut self) {
+        self.poisoned = true;
+    }
+
+    /// Whether the session is poisoned. Mirrors `FlowTracker::is_poisoned`.
+    pub fn is_poisoned(&self) -> bool {
+        self.poisoned
     }
 
     /// Atomic check-and-insert for action nodes.

--- a/crates/portcullis/tests/flowgraph_flowtracker_parity.rs
+++ b/crates/portcullis/tests/flowgraph_flowtracker_parity.rs
@@ -1,0 +1,211 @@
+//! Phase 1 evidence for the declassification-unification arc: the kernel's
+//! proven `FlowGraph` is a **superset** of the tool-proxy's `FlowTracker` for
+//! every aggregate the live egress gate consults.
+//!
+//! The live egress verdict (`exposure_core::ifc_egress_verdict`,
+//! `kernel/ifc.rs`) reads exactly three things off the session tracker:
+//! `is_tainted()`, `is_poisoned()`, and `session_exfiltration_check(sink)`
+//! (plus per-node `content_hash` for the value-binding to come). Before Phase 2
+//! can switch the tool-proxy from `FlowTracker` onto `FlowGraph`, those answers
+//! must agree on identical ingest sequences. These tests are that proof — and a
+//! regression guard: if the two implementations ever diverge, Phase 2 is unsafe.
+//!
+//! Node ids deliberately are NOT compared: `FlowTracker` ids are 1-based dense,
+//! `FlowGraph` ids are sentinel-offset — an internal representation difference,
+//! not a semantic one. Only the egress-relevant *answers* are asserted equal.
+
+use portcullis::flow_graph::FlowGraph;
+use portcullis_core::flow::NodeKind;
+use portcullis_core::ifc_api::FlowTracker;
+use portcullis_core::{ConfLevel, ContentHash};
+
+const NOW: u64 = 42;
+
+/// Drive the same observe sequence through both trackers and return their
+/// egress-relevant aggregate answers side by side.
+fn observe_both(kinds: &[NodeKind]) -> (FlowTracker, FlowGraph) {
+    let mut ft = FlowTracker::new();
+    let mut fg = FlowGraph::new();
+    for &k in kinds {
+        ft.observe_with_parents(k, &[])
+            .expect("flow_tracker observe");
+        fg.insert_observation(k, &[], NOW)
+            .expect("flow_graph observe");
+    }
+    (ft, fg)
+}
+
+fn assert_aggregates_agree(ft: &FlowTracker, fg: &FlowGraph, ctx: &str) {
+    assert_eq!(
+        ft.is_tainted(),
+        fg.is_tainted(),
+        "{ctx}: is_tainted diverged"
+    );
+    assert_eq!(
+        ft.session_taint_ceiling(),
+        fg.session_taint_ceiling(),
+        "{ctx}: session_taint_ceiling diverged"
+    );
+    for sink in [ConfLevel::Public, ConfLevel::Internal, ConfLevel::Secret] {
+        assert_eq!(
+            ft.session_exfiltration_check(sink).is_safe(),
+            fg.session_exfiltration_check(sink).is_safe(),
+            "{ctx}: session_exfiltration_check({sink:?}) diverged"
+        );
+    }
+    assert_eq!(
+        ft.is_poisoned(),
+        fg.is_poisoned(),
+        "{ctx}: is_poisoned diverged"
+    );
+}
+
+#[test]
+fn aggregate_parity_across_an_observe_sequence() {
+    // A mixed sequence that exercises every axis: a clean prompt, an AI-derived
+    // Internal write, an ADVERSARIAL web-content node (trips is_tainted), and a
+    // SECRET env var (raises the confidentiality ceiling to Secret).
+    let seq = [
+        NodeKind::UserPrompt,
+        NodeKind::MemoryWrite,
+        NodeKind::WebContent,
+        NodeKind::EnvVar,
+    ];
+
+    // Parity must hold at EVERY prefix, not just the end.
+    for len in 0..=seq.len() {
+        let (ft, fg) = observe_both(&seq[..len]);
+        assert_aggregates_agree(&ft, &fg, &format!("prefix len {len}"));
+    }
+
+    // Non-vacuity: the sequence actually flips each axis on BOTH trackers, so
+    // the equalities above are not the trivial "both always false/safe".
+    let (empty_ft, empty_fg) = observe_both(&[]);
+    assert!(
+        !empty_ft.is_tainted() && !empty_fg.is_tainted(),
+        "empty untainted"
+    );
+    assert!(
+        empty_ft
+            .session_exfiltration_check(ConfLevel::Public)
+            .is_safe()
+            && empty_fg
+                .session_exfiltration_check(ConfLevel::Public)
+                .is_safe(),
+        "empty session may exfiltrate to a Public sink"
+    );
+
+    let (adv_ft, adv_fg) = observe_both(&[NodeKind::WebContent]);
+    assert!(
+        adv_ft.is_tainted() && adv_fg.is_tainted(),
+        "web content taints both"
+    );
+
+    let (sec_ft, sec_fg) = observe_both(&[NodeKind::EnvVar]);
+    assert!(
+        !sec_ft
+            .session_exfiltration_check(ConfLevel::Public)
+            .is_safe()
+            && !sec_fg
+                .session_exfiltration_check(ConfLevel::Public)
+                .is_safe(),
+        "a Secret env var must block a Public-sink exfiltration on BOTH trackers"
+    );
+    assert!(
+        sec_ft
+            .session_exfiltration_check(ConfLevel::Secret)
+            .is_safe()
+            && sec_fg
+                .session_exfiltration_check(ConfLevel::Secret)
+                .is_safe(),
+        "a Secret sink still admits Secret data on BOTH trackers"
+    );
+}
+
+#[test]
+fn content_hash_records_and_matches_flowtracker() {
+    let hash = ContentHash::from_bytes([7u8; 32]);
+    let mut ft = FlowTracker::new();
+    let mut fg = FlowGraph::new();
+
+    let ft_id = ft
+        .observe_with_content_hash(NodeKind::WebContent, hash)
+        .expect("ft observe_with_content_hash");
+    let fg_id = fg
+        .observe_with_content_hash(NodeKind::WebContent, &[], NOW, hash)
+        .expect("fg observe_with_content_hash");
+
+    assert_eq!(ft.content_hash(ft_id), Some(hash));
+    assert_eq!(fg.content_hash(fg_id), Some(hash));
+    assert_eq!(
+        ft.content_hash(ft_id),
+        fg.content_hash(fg_id),
+        "content hash must round-trip identically on both trackers"
+    );
+
+    // A plain observation records no hash on either.
+    let mut ft2 = FlowTracker::new();
+    let mut fg2 = FlowGraph::new();
+    let a = ft2.observe(NodeKind::UserPrompt).expect("ft observe");
+    let b = fg2
+        .insert_observation(NodeKind::UserPrompt, &[], NOW)
+        .expect("fg observe");
+    assert_eq!(ft2.content_hash(a), None);
+    assert_eq!(fg2.content_hash(b), None);
+}
+
+#[test]
+fn poison_parity() {
+    let (mut ft, mut fg) = observe_both(&[NodeKind::UserPrompt]);
+    assert!(
+        !ft.is_poisoned() && !fg.is_poisoned(),
+        "clean session is unpoisoned"
+    );
+    ft.poison();
+    fg.poison();
+    assert!(
+        ft.is_poisoned() && fg.is_poisoned(),
+        "poison sets the fail-closed flag on both"
+    );
+}
+
+/// The load-bearing anti-laundering test. `FlowGraph` compacts (tombstones old
+/// nodes) at `MAX_GRAPH_NODES = 10_000`; `FlowTracker` never does. If
+/// `is_tainted`/`session_taint_ceiling` were a scan of *live* nodes, compaction
+/// would silently launder a past adversarial ingest to `false`. Because they
+/// are monotonic ratchet fields, the taint survives. This test fails the moment
+/// anyone "simplifies" the aggregates back to a live-node scan.
+#[test]
+fn taint_survives_compaction_the_ratchet_beats_a_live_scan() {
+    let mut fg = FlowGraph::new();
+
+    // One adversarial ingest at the very start.
+    fg.insert_observation(NodeKind::WebContent, &[], NOW)
+        .expect("adversarial observe");
+    assert!(fg.is_tainted(), "adversarial node taints the session");
+
+    // Bury it under enough clean nodes to force compaction to tombstone it.
+    for _ in 0..(10_000 + 200) {
+        fg.insert_observation(NodeKind::UserPrompt, &[], NOW)
+            .expect("clean observe");
+    }
+
+    // Guard against vacuity: the test only distinguishes a ratchet from a
+    // live-node scan if the adversarial node (id 1) was actually tombstoned.
+    // If it were still live, a scan would pass too and prove nothing.
+    assert!(
+        fg.get(1).is_none(),
+        "compaction must have tombstoned the adversarial node for this test to bite"
+    );
+
+    // The original adversarial node is now tombstoned, yet the taint persists.
+    assert!(
+        fg.is_tainted(),
+        "is_tainted must survive compaction — the ratchet, not a live-node scan"
+    );
+    assert!(
+        !fg.session_exfiltration_check(ConfLevel::Public).is_safe()
+            || fg.session_taint_ceiling() != portcullis_core::DerivationClass::Deterministic,
+        "session taint ceiling must also survive compaction"
+    );
+}


### PR DESCRIPTION
## Phase 1 of the declassification-unification program (additive; no live-egress change)

De-risks the crux (Phase 2, boot-gated, switches the tool-proxy off `FlowTracker` onto the proven `FlowGraph`). This PR makes `FlowGraph` a **superset** of the aggregates the live egress gate reads, and proves parity — the evidence that Phase 2's switch is safe.

### Feasibility spike (done before implementing; no fork needed)
The live egress verdict (`exposure_core::ifc_egress_verdict`, `kernel/ifc.rs`) reads exactly three things off the session tracker, plus one per-node datum for the value-binding to come:

| FlowTracker query | Used at | FlowGraph before | Absorbed how |
|---|---|---|---|
| `is_tainted()` | `exposure_core.rs:142` | absent | monotonic `session_adversarial` ratchet |
| `is_poisoned()` | `kernel/ifc.rs:76` | absent | new `poisoned` flag + `poison()` |
| `session_exfiltration_check(sink)` | `exposure_core.rs:166` | absent | `session_conf_ceiling` ratchet, identical rule |
| `content_hash(id)` | value-binding (Phase 3) | absent | `content_hashes` side map + `observe_with_content_hash` |
| `session_taint_ceiling()` | tool-proxy | absent | `session_taint_ceiling` ratchet (join of derivations) |

Everything is derivable from the per-node labels `FlowGraph` already holds. `latest_adversarial_node()` (tool-proxy edge-attachment only, not on the egress path) was intentionally left for Phase 2 — it returns an internal node id whose representation legitimately differs between the two structures.

### Key faithfulness decision (fork, decided async — see below)
The session aggregates are **monotonic ratchet fields updated at the single ingest chokepoint** (`insert_observation`), NOT recomputed from live nodes. Rationale: `FlowGraph` compacts (`maybe_compact()` tombstones old nodes at `MAX_GRAPH_NODES=10_000`); `FlowTracker` never compacts. A live-node scan of `is_tainted` would silently launder a past adversarial ingest to `false` after compaction. The ratchet preserves `FlowTracker`'s "ever adversarial" meaning under compaction. Purely additive: no existing `FlowGraph` verdict reads these fields.

### What changed
- `crates/portcullis/src/flow_graph.rs`: `content_hashes` side map (FlowNode stays `Copy`/untouched, like `field_lineage`); `observe_with_content_hash` + `content_hash(id)`; ratchet fields + readers `is_tainted`/`session_taint_ceiling`/`session_exfiltration_check`/`poison`/`is_poisoned`.
- `crates/portcullis/tests/flowgraph_flowtracker_parity.rs`: 4 tests, including a non-vacuous anti-laundering guard (asserts the adversarial node is genuinely tombstoned, `get(1) is None`, yet `is_tainted()` stays true — fails the moment an aggregate reverts to a live-node scan).

### Green
- 965 portcullis lib tests + 4 parity tests pass; `cargo fmt`/`clippy` clean.
- Touches nothing under the Aeneas extracted slice (`nucleus-ifc-kernel/src/extracted/`), so extraction is unaffected. No boot/`/dev/kvm` needed.
- `FlowTracker` is NOT retired — that is Phase 2 (boot-gated, changes live egress; do not automerge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)