### PR TITLE
flow_graph: Phase 2 dual-write — populate the kernel FlowGraph on the tool-proxy ingest path (verdict-neutral)

### DIFF
--- a/crates/nucleus-tool-proxy/src/ingest.rs
+++ b/crates/nucleus-tool-proxy/src/ingest.rs
@@ -12,6 +12,8 @@
 //! not available at this layer.
 
 use nucleus::portcullis::NodeKind;
+use portcullis::flow_graph::{FlowGraph, FlowGraphError};
+use tokio::sync::Mutex;
 use tracing::warn;
 
 use crate::{ingest_content_hash, AppState};
@@ -72,14 +74,103 @@ pub(crate) async fn http_observe_flow_from(
     parents: &[u64],
 ) -> Option<u64> {
     let hash = ingest_content_hash(bytes);
-    let mut flow = state.flow_tracker.lock().await;
-    match flow.observe_with_parents_and_hash(kind, parents, Some(hash)) {
-        Ok(id) => Some(id),
-        Err(e) => {
-            warn!(?kind, error = %e, "flow-tracker observe failed");
-            None
+    // Authoritative FlowTracker write — this alone governs the live egress
+    // verdict (`kernel/ifc.rs` reads `flow_tracker`). Behaviour UNCHANGED.
+    let observed = {
+        let mut flow = state.flow_tracker.lock().await;
+        match flow.observe_with_parents_and_hash(kind, parents, Some(hash)) {
+            Ok(id) => Some(id),
+            Err(e) => {
+                warn!(?kind, error = %e, "flow-tracker observe failed");
+                None
+            }
         }
+    };
+    // Phase 2 SHADOW dual-write into the kernel `FlowGraph`. Not yet read by
+    // egress, so verdict-neutral. Only mirrored when the authoritative write
+    // landed, keeping the two graphs node-for-node aligned on this chokepoint
+    // (the k-of-n memory path observes into the tracker only and is a separate,
+    // later step — the shadow legitimately lags there until then).
+    if observed.is_some() {
+        shadow_observe(&state.flow_graph, kind, !parents.is_empty(), hash).await;
     }
+    observed
+}
+
+/// Dual-write one ingest observation into the SHADOW [`FlowGraph`] (Phase 2).
+///
+/// This is the FlowGraph half of the tool-proxy ingest chokepoint. It is called
+/// only after the authoritative `FlowTracker` write succeeded, so the two stay
+/// aligned. It NEVER touches the `FlowTracker` and is NEVER consulted by the
+/// egress verdict yet, so it cannot change any live decision — it exists to make
+/// the later, boot-gated egress switch provably safe (the differential canary)
+/// and to make `FlowGraph` actually non-empty in production (the bug being
+/// closed: the tool-proxy never populated it, so declassification resolved
+/// against an empty graph).
+///
+/// Node population is **server-computed**, never client-declared: the parent is
+/// derived here from the shadow graph's OWN `latest_adversarial_node()` — the
+/// same conservative over-approximation `http_observe_authored` uses on the
+/// tracker — rather than by translating a `FlowTracker` id (the two graphs are
+/// not id-locked, because the k-of-n memory path advances the tracker alone).
+/// This preserves the taint STRUCTURE without a hand-maintained id map, and is
+/// verdict-neutral by construction: the egress gate reads only the session
+/// aggregates (`is_tainted`, `is_poisoned`, `session_exfiltration_check`), which
+/// accumulate monotonically at the source node — a parent edge only ever adds
+/// taint that the source already contributed, so the aggregate is invariant to
+/// which specific edge is attached (see `flowgraph_flowtracker_parity`).
+///
+/// FAIL-CLOSED + DETECTABLE: if the shadow write is dropped it must NOT weaken
+/// the tracker (it does not — it never touches it), and it must NOT silently
+/// no-op (that would make the later egress switch fail OPEN). So it POISONS the
+/// shadow, which the future switch's poison gate turns into a fail-closed deny,
+/// and which a test can observe via `FlowGraph::is_poisoned()`.
+pub(crate) async fn shadow_observe(
+    graph: &Mutex<FlowGraph>,
+    kind: NodeKind,
+    derives_from_session: bool,
+    hash: nucleus_ifc_kernel::ContentHash,
+) {
+    let mut fg = graph.lock().await;
+    let now = shadow_now();
+    let parents: Vec<u64> = if derives_from_session {
+        fg.latest_adversarial_node().into_iter().collect()
+    } else {
+        Vec::new()
+    };
+    let result = fg.observe_with_content_hash(kind, &parents, now, hash);
+    poison_shadow_if_dropped(&mut fg, kind, result);
+}
+
+/// Fail-closed handler for a dropped shadow dual-write: poison the shadow graph
+/// so the drop is detectable (and the later egress switch fails closed), logging
+/// the cause. Extracted so the fail-closed branch is unit-testable without
+/// having to provoke a live `FlowGraph` error.
+fn poison_shadow_if_dropped(
+    fg: &mut FlowGraph,
+    kind: NodeKind,
+    result: Result<u64, FlowGraphError>,
+) {
+    if let Err(e) = result {
+        warn!(
+            ?kind,
+            error = ?e,
+            "flow-graph shadow dual-write dropped; poisoning shadow (fail-closed \
+             for the later egress switch; live verdict still reads FlowTracker)"
+        );
+        fg.poison();
+    }
+}
+
+/// Wall-clock seconds for a shadow observation. Feeds only the node label's
+/// freshness metadata, never the exfiltration verdict (which reads the session
+/// aggregates), so its exact value is immaterial to parity — mirrors
+/// `FlowTracker`'s internal clock use.
+fn shadow_now() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
 }
 
 /// The flow node kind command output is observed as.
@@ -129,4 +220,187 @@ pub(crate) async fn http_observe_command_output(state: &AppState, stdout: &[u8],
     bytes.extend_from_slice(stdout);
     bytes.extend_from_slice(stderr);
     http_observe_flow(state, COMMAND_OUTPUT_NODE_KIND, &bytes).await;
+}
+
+#[cfg(test)]
+mod shadow_dual_write_tests {
+    //! Phase 2 dual-write evidence: the SHADOW `FlowGraph`, populated by the real
+    //! `shadow_observe` chokepoint, agrees with the live `FlowTracker` on every
+    //! egress-relevant aggregate for the actual production ingest sequence — the
+    //! in-tree twin of the `flowgraph_flowtracker_parity` differential harness
+    //! (#2229), but now driven by the production dual-write path rather than a
+    //! synthetic one. Plus: the graph is actually non-empty in production (the bug
+    //! being closed), and a dropped dual-write is detectable and fail-closed.
+    use super::*;
+    use portcullis::flow_graph::FlowGraph;
+    use portcullis_core::ifc_api::FlowTracker;
+    use portcullis_core::ConfLevel;
+    use tokio::sync::Mutex;
+
+    fn hash_of(bytes: &[u8]) -> nucleus_ifc_kernel::ContentHash {
+        ingest_content_hash(bytes)
+    }
+
+    /// Drive one ingest through BOTH halves exactly as `http_observe_flow_from`
+    /// does: the authoritative tracker write, then the shadow dual-write.
+    async fn dual(
+        tracker: &Mutex<FlowTracker>,
+        graph: &Mutex<FlowGraph>,
+        kind: NodeKind,
+        bytes: &[u8],
+        parents: &[u64],
+    ) {
+        let h = hash_of(bytes);
+        {
+            let mut ft = tracker.lock().await;
+            ft.observe_with_parents_and_hash(kind, parents, Some(h))
+                .expect("tracker observe");
+        }
+        shadow_observe(graph, kind, !parents.is_empty(), h).await;
+    }
+
+    /// The four aggregates the live egress verdict reads off the session tracker
+    /// (`exposure_core::ifc_egress_verdict` + the `kernel/ifc.rs` poison gate).
+    /// If these agree, switching egress from the tracker to the graph on this
+    /// sequence is verdict-neutral.
+    fn assert_aggregates_agree(ft: &FlowTracker, fg: &FlowGraph, ctx: &str) {
+        assert_eq!(
+            ft.is_tainted(),
+            fg.is_tainted(),
+            "{ctx}: is_tainted diverged"
+        );
+        assert_eq!(
+            ft.session_taint_ceiling(),
+            fg.session_taint_ceiling(),
+            "{ctx}: session_taint_ceiling diverged"
+        );
+        for sink in [ConfLevel::Public, ConfLevel::Internal, ConfLevel::Secret] {
+            assert_eq!(
+                ft.session_exfiltration_check(sink).is_safe(),
+                fg.session_exfiltration_check(sink).is_safe(),
+                "{ctx}: session_exfiltration_check({sink:?}) diverged"
+            );
+        }
+        assert_eq!(
+            ft.is_poisoned(),
+            fg.is_poisoned(),
+            "{ctx}: is_poisoned diverged"
+        );
+    }
+
+    /// The dual-write is verdict-neutral on the real ingest sequence, AND the
+    /// shadow graph is actually populated (the property that makes the later
+    /// egress switch meaningful).
+    #[tokio::test]
+    async fn shadow_matches_tracker_on_a_production_ingest_sequence() {
+        let tracker = Mutex::new(FlowTracker::new());
+        let graph = Mutex::new(FlowGraph::new());
+
+        // A realistic mixed HTTP-path sequence: a confidential file read, an
+        // adversarial web fetch (trips is_tainted), a derived read (non-empty
+        // tracker parents — the authored/laundered-path edge), and more web.
+        dual(&tracker, &graph, NodeKind::FileRead, b"secret config", &[]).await;
+        dual(&tracker, &graph, NodeKind::WebContent, b"<injected>", &[]).await;
+        dual(
+            &tracker,
+            &graph,
+            NodeKind::FileRead,
+            b"derived-from-web",
+            &[1],
+        )
+        .await;
+        dual(&tracker, &graph, NodeKind::WebContent, b"more web", &[]).await;
+
+        let ft = tracker.lock().await;
+        let fg = graph.lock().await;
+        assert_aggregates_agree(&ft, &fg, "production sequence");
+
+        // Non-vacuity: the sequence is not the trivial all-false — it genuinely
+        // trips integrity taint on BOTH trackers, so the equality above has teeth.
+        assert!(
+            ft.is_tainted(),
+            "sequence must trip is_tainted (non-vacuous)"
+        );
+        assert!(
+            fg.is_tainted(),
+            "shadow must also see the taint (non-vacuous)"
+        );
+
+        // The bug this phase closes: on the tool-proxy the FlowGraph was empty, so
+        // declassification resolved against an empty graph. It is now populated.
+        assert!(
+            !fg.is_empty(),
+            "shadow FlowGraph must be non-empty after ingest"
+        );
+        assert_eq!(fg.len(), 4, "one shadow node per mirrored ingest");
+    }
+
+    /// Parity holds at EVERY prefix, not just the end (matches #2229's discipline).
+    #[tokio::test]
+    async fn shadow_matches_tracker_at_every_prefix() {
+        let seq: &[(NodeKind, &[u8])] = &[
+            (NodeKind::UserPrompt, b"hi"),
+            (NodeKind::FileRead, b"file"),
+            (NodeKind::WebContent, b"web"),
+            (NodeKind::EnvVar, b"SECRET=1"),
+        ];
+        let tracker = Mutex::new(FlowTracker::new());
+        let graph = Mutex::new(FlowGraph::new());
+        for (i, (kind, bytes)) in seq.iter().enumerate() {
+            dual(&tracker, &graph, *kind, bytes, &[]).await;
+            let ft = tracker.lock().await;
+            let fg = graph.lock().await;
+            assert_aggregates_agree(&ft, &fg, &format!("prefix len {}", i + 1));
+        }
+    }
+
+    /// A single ingest populates the shadow graph — the minimal live-population
+    /// property.
+    #[tokio::test]
+    async fn single_ingest_populates_the_shadow_graph() {
+        let graph = Mutex::new(FlowGraph::new());
+        assert!(graph.lock().await.is_empty(), "fresh graph is empty");
+        shadow_observe(&graph, NodeKind::WebContent, false, hash_of(b"x")).await;
+        let fg = graph.lock().await;
+        assert_eq!(fg.len(), 1, "one observe → one shadow node");
+        assert!(!fg.is_poisoned(), "a clean observe must not poison");
+    }
+
+    /// Fail-closed: a dropped shadow dual-write poisons the SHADOW (so it is
+    /// detectable and the later egress switch fails closed) and NEVER touches the
+    /// `FlowTracker` that still governs the live verdict.
+    #[test]
+    fn dropped_shadow_write_poisons_the_shadow_never_the_tracker() {
+        let mut fg = FlowGraph::new();
+        let control_tracker = FlowTracker::new();
+        // Provoke a real drop: reference a non-existent parent node.
+        let dropped = fg.observe_with_content_hash(NodeKind::WebContent, &[9999], 0, hash_of(b"x"));
+        assert!(
+            dropped.is_err(),
+            "precondition: an invalid parent must error"
+        );
+
+        poison_shadow_if_dropped(&mut fg, NodeKind::WebContent, dropped);
+
+        assert!(
+            fg.is_poisoned(),
+            "a dropped shadow dual-write must poison the shadow so it is detectable"
+        );
+        assert!(
+            !control_tracker.is_poisoned(),
+            "a shadow drop must never poison or weaken the FlowTracker"
+        );
+    }
+
+    /// The complement: a landed shadow write does not poison — the poison branch
+    /// is not fired spuriously (guards against a fail-closed that denies always).
+    #[test]
+    fn landed_shadow_write_does_not_poison() {
+        let mut fg = FlowGraph::new();
+        let landed = fg.observe_with_content_hash(NodeKind::WebContent, &[], 0, hash_of(b"x"));
+        assert!(landed.is_ok());
+        poison_shadow_if_dropped(&mut fg, NodeKind::WebContent, landed);
+        assert!(!fg.is_poisoned(), "a landed observe must not poison");
+        assert_eq!(fg.len(), 1);
+    }
 }

--- a/crates/nucleus-tool-proxy/src/main.rs
+++ b/crates/nucleus-tool-proxy/src/main.rs
@@ -18,6 +18,7 @@ use nucleus::portcullis::{CapabilityLevel, FlowTracker, NodeKind, Operation, Per
 use nucleus::{ApprovalRequest, CallbackApprover, NucleusError, PodRuntime};
 use nucleus_permission_market::{PermissionBid, PermissionGrant, PermissionMarket};
 use nucleus_spec::PodSpec;
+use portcullis::flow_graph::FlowGraph;
 use portcullis::verdict_sink::{ActorIdentity, VerdictContext, VerdictOutcome};
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
@@ -426,6 +427,17 @@ pub(crate) struct AppState {
     /// blocks outbound for all); true multi-tenancy would require keying the
     /// kernel AND tracker together — out of scope here.
     pub(crate) flow_tracker: Arc<tokio::sync::Mutex<FlowTracker>>,
+    /// Phase 2 SHADOW information-flow graph: the kernel's proven `FlowGraph`,
+    /// dual-written on every ingest alongside `flow_tracker` above. NOT yet
+    /// consulted by the egress verdict (`kernel/ifc.rs` still reads
+    /// `flow_tracker`), so populating it is verdict-neutral. It exists so the
+    /// later, separately boot-gated egress switch onto the one proven graph can
+    /// be proven safe: the differential canary asserts the two agree on the real
+    /// ingest sequence, and the graph is actually non-empty in production (the
+    /// bug this closes is that `FlowGraph` was empty on the tool-proxy). Populated
+    /// only through the server-computed `ingest::shadow_observe` chokepoint—
+    /// never from client-declared lineage.
+    pub(crate) flow_graph: Arc<tokio::sync::Mutex<FlowGraph>>,
     /// Path → the flow node recording the content last written there.
     ///
     /// This is #2135's laundered-path SET, generalised from a boolean into an
@@ -1785,6 +1797,9 @@ async fn main() -> Result<(), ApiError> {
     }));
 
     let flow_tracker = Arc::new(tokio::sync::Mutex::new(FlowTracker::new()));
+    // Phase 2 shadow graph, dual-written with `flow_tracker` but not yet read by
+    // egress (verdict-neutral). Same per-pod-session lifetime as the tracker.
+    let flow_graph = Arc::new(tokio::sync::Mutex::new(FlowGraph::new()));
 
     // Provenance-memory state (next-bet #1). Trusted declassify keys + threshold
     // come from env; absent ⇒ empty/1 ⇒ declassification is fail-closed.
@@ -1873,6 +1888,7 @@ async fn main() -> Result<(), ApiError> {
         trace_monitor,
         kernel,
         flow_tracker,
+        flow_graph,
         provenance_memory,
         memory_transforms,
         declassify_trusted_keys,

--- a/crates/nucleus-tool-proxy/src/mcp.rs
+++ b/crates/nucleus-tool-proxy/src/mcp.rs
@@ -13,6 +13,7 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use portcullis::action_term::ActionTerm;
+use portcullis::flow_graph::FlowGraph;
 use portcullis::kernel::{Kernel, Verdict};
 use portcullis::verdict_sink::{ActorIdentity, VerdictContext, VerdictOutcome, VerdictSink};
 use portcullis::{
@@ -144,6 +145,11 @@ pub struct NucleusMcpServer {
     /// session, outbound actions are denied with `IfcUnsafe` — the lethal
     /// trifecta, enforced in the live Rust runtime (parity with the Python SDK).
     flow_tracker: Arc<tokio::sync::Mutex<FlowTracker>>,
+    /// Phase 2 SHADOW flow graph, dual-written with `flow_tracker` on every
+    /// `observe_flow` but not yet consulted by the kernel — verdict-neutral.
+    /// The MCP transport's own per-session graph, mirroring the HTTP path's
+    /// `AppState::flow_graph`. See `ingest::shadow_observe`.
+    flow_graph: Arc<tokio::sync::Mutex<FlowGraph>>,
 }
 
 /// Convert a tool-level error into a CallToolResult error.
@@ -196,6 +202,7 @@ impl NucleusMcpServer {
             sink,
             kernel,
             flow_tracker: Arc::new(tokio::sync::Mutex::new(FlowTracker::new())),
+            flow_graph: Arc::new(tokio::sync::Mutex::new(FlowGraph::new())),
         }
     }
 
@@ -214,10 +221,22 @@ impl NucleusMcpServer {
     /// is identical to the old bare `observe` — only the content hash is added.
     async fn observe_flow(&self, kind: NodeKind, bytes: &[u8]) {
         let hash = crate::ingest_content_hash(bytes);
-        let mut flow = self.flow_tracker.lock().await;
-        if let Err(e) = flow.observe_with_content_hash(kind, hash) {
-            flow.poison();
-            warn!(?kind, error = %e, "flow-tracker observe failed — session poisoned (fail-closed)");
+        // Authoritative tracker write (governs the live verdict). UNCHANGED.
+        let landed = {
+            let mut flow = self.flow_tracker.lock().await;
+            match flow.observe_with_content_hash(kind, hash) {
+                Ok(_) => true,
+                Err(e) => {
+                    flow.poison();
+                    warn!(?kind, error = %e, "flow-tracker observe failed — session poisoned (fail-closed)");
+                    false
+                }
+            }
+        };
+        // Phase 2 shadow dual-write (verdict-neutral; MCP ingests are always
+        // parent-less data sources). Mirrored only when the tracker write landed.
+        if landed {
+            crate::ingest::shadow_observe(&self.flow_graph, kind, false, hash).await;
         }
     }
 


### PR DESCRIPTION
## What this is

The **riskless first half of Phase 2** of the declassification-unification program (plan: `kind-finding-biscuit.md`; Phase 0 #2227, Phase 1 #2228, preconditions/harness #2229 already on main).

Every tool-proxy ingest now **ALSO** populates the kernel's proven `FlowGraph` alongside the existing `FlowTracker`, while the egress verdict **still reads `FlowTracker`, unchanged**. This closes the bug that `FlowGraph` was empty on the tool-proxy (so `apply_declassification_token`'s `target_node_id` resolved against nothing) — **without changing any live egress decision**.

## Scope — dual-write ONLY

- ✅ Populate the shadow `FlowGraph` at the ingest chokepoints (`ingest::shadow_observe`, called from `http_observe_flow_from` and the MCP `observe_flow`).
- ❌ Does NOT switch egress to `FlowGraph`, does NOT retire `FlowTracker`, does NOT touch the k-of-n memory path — those are later, separately boot-gated steps.

## Why it's verdict-neutral

The egress gate (`kernel/ifc.rs` → `exposure_core::ifc_egress_verdict`) reads only the session aggregates — `is_tainted` / `is_poisoned` / `session_exfiltration_check` — which accumulate **monotonically at the source node**. A parent edge only re-adds taint the source already contributed, so the aggregate is invariant to which specific edge is attached. Node population is **server-computed**: the shadow parent is derived from the graph's own `latest_adversarial_node()`, never by translating a `FlowTracker` id (the two are not id-locked — the k-of-n memory path advances the tracker alone).

## Fail-closed + detectable

A dropped shadow write **poisons the shadow** (so the later egress switch fails closed, and a test observes it via `is_poisoned()`) and **never touches the `FlowTracker`** that governs the live verdict. A silent no-op — which would make the later switch fail **open** — is exactly what this avoids.

## Evidence

- In-tree differential canary (twin of #2229's `flowgraph_flowtracker_parity`, now driven by the **real** dual-write): identical production ingest sequences give byte-identical egress aggregates on both graphs at every prefix.
- The shadow is **non-empty** after ingest (the property that makes the later switch meaningful).
- A dropped write is detectable and never poisons the tracker.
- Gates green locally: `cargo test -p nucleus-tool-proxy` (334), `flowgraph_flowtracker_parity` (9, unchanged), `fmt`, `clippy`, `check-mediation.sh`, `check-north-star-ledger.sh`, `check-ingest-hashed.sh`, `check-verify-strict.sh`. **Aeneas extracted slice untouched.**

## Known precondition for the NEXT step

Before egress reads the graph, the **k-of-n memory path must be mirrored/migrated** (it observes into `FlowTracker` only), else the shadow under-counts its taint and the switch would fail open. Out of scope here; flagged for the switch PR.

## ⚠️ BOOT-GATED — DO NOT AUTOMERGE

The ingest path runs in the guest, so this **requires `boot-a-real-pod (x86_64)` to pass**. `boot-a-real-pod` is not a required check, so **do not enqueue/merge** — the human gates the merge on boot green. The egress-read switch is the next, separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148ebbw4UXypRjhMw3xAQzj