### PR TITLE
declassify: Phase 4 — unify the two mint policies onto one governed release (boot-gated, DO NOT MERGE)

### DIFF
--- a/crates/nucleus-tool-proxy/src/memory.rs
+++ b/crates/nucleus-tool-proxy/src/memory.rs
@@ -21,7 +21,7 @@
 //! lives in the two `*_core` functions so it is unit-testable without a full
 //! `AppState`.
 
-use nucleus::portcullis::flow_graph::FlowGraph;
+use nucleus::portcullis::flow_graph::{FlowGraph, ReleaseAuth};
 use nucleus::portcullis::NodeKind;
 use nucleus_provenance_memory::{
     declassify, memory_ifc_label, ContentHash, MemoryDerivation, MemoryLabel, MemoryRecord,
@@ -112,9 +112,56 @@ pub fn memory_write_core(
     }
 }
 
+/// The 32-byte one-shot authorization id for a k-of-n release: a SHA-256 over
+/// the `SignedDeclassify` artifact (the witness bytes plus the sorted
+/// cosignatures). Same fixed width as the Ed25519 token id (`release_burn_id` in
+/// `kernel/declassify_authority.rs`) so BOTH mint policies burn against the one
+/// shared `FlowGraph::release_burn_ledger` (Phase 4). A distinct quorum
+/// re-authorization (a different witness or signature set) yields a different id
+/// and may release again — exactly as a distinct Ed25519 token may.
+fn kofn_release_burn_id(signed: &SignedDeclassify) -> [u8; 32] {
+    use sha2::{Digest, Sha256};
+    let mut sigs: Vec<(&[u8; 32], &Vec<u8>)> = signed
+        .signatures
+        .iter()
+        .map(|(pk, sig)| (pk, sig))
+        .collect();
+    sigs.sort_by(|a, b| a.0.cmp(b.0).then_with(|| a.1.cmp(b.1)));
+    let mut h = Sha256::new();
+    h.update(b"nucleus.declassify.kofn.v1");
+    let wb = signed.witness.canonical_bytes();
+    h.update((wb.len() as u32).to_le_bytes());
+    h.update(&wb);
+    h.update((sigs.len() as u32).to_le_bytes());
+    for (pk, sig) in sigs {
+        h.update(pk);
+        h.update((sig.len() as u32).to_le_bytes());
+        h.update(sig);
+    }
+    h.finalize().into()
+}
+
 /// Core recall logic: resolve the record, apply any declassification, and
 /// observe the effective label into the authoritative `graph` so the live IFC
-/// gate governs the next action. Fail-closed: a declassify failure denies (and observes nothing).
+/// gate governs the next action. Fail-closed: a declassify failure denies (and
+/// observes nothing).
+///
+/// **Phase 4 — one enforcement, two mint policies.** A k-of-n witness is only the
+/// AUTHORITY half. Before a promoted (non-tainting) label may be observed, the
+/// release is put through the SAME governed-release enforcement the Ed25519 token
+/// path uses — `FlowGraph::authorize_release`. It is **value-bound** (the
+/// quorum-committed record identity `witness.record_hash` must equal the
+/// monitor-recomputed record hash of the exact bytes recalled, so a value
+/// substituted after the quorum signed cannot ride the witnesses), **sink-scoped**
+/// (recorded as a `DeclassScope`; the k-of-n mint policy grants all sinks —
+/// witness-level sink narrowing is a parked follow-up), and **one-shot** (burned
+/// against the shared `release_burn_ledger`, so a replay of the same quorum
+/// authorization in a session is refused).
+///
+/// Only on `Authorized` is the promoted label observed and the scope recorded;
+/// every refusal is fail-closed and NON-burning. (Ordering matters: the promoted,
+/// non-adversarial label must never be OBSERVED for an un-authorized record — the
+/// adversarial taint ratchet cannot be un-set — so authorization precedes observe.)
 #[allow(clippy::too_many_arguments)]
 pub fn memory_recall_core(
     set: &ProvenanceMemorySet,
@@ -131,31 +178,68 @@ pub fn memory_recall_core(
         .cloned()
         .ok_or_else(|| ApiError::Body("memory record not found".to_string()))?;
 
+    // Content-address the *actual recalled bytes* (`record.value`), recomputed
+    // here from the real record — NEVER the agent-supplied `req.content_hash`
+    // lookup key, which only locates the record and is not trusted as the
+    // ingested content's digest.
+    let content_hash = crate::ingest_content_hash(record.value.as_bytes());
+
     let (effective_label, declassified) = match &req.declassify {
         Some(signed) => {
-            // Fail-closed: an un-quorumed / invalid witness informs NOTHING.
+            // (1) AUTHORITY: an un-quorumed / invalid witness informs NOTHING.
             let promoted = declassify(&record, signed, trusted_keys, threshold)
                 .map_err(|e| ApiError::IfcDenied(format!("declassify refused: {e}")))?;
-            (promoted, true)
+
+            // (2) SHARED GOVERNED-RELEASE ENFORCEMENT (value-bind + sink-scope +
+            //     one-shot), identical to the Ed25519 token path. The committed
+            //     value is the quorum-signed record identity; the monitor-recorded
+            //     value is the record's recomputed content hash. All sinks for the
+            //     k-of-n mint policy (disclosed; witness-level narrowing parked).
+            let committed = *signed.witness.record_hash.as_bytes();
+            let recorded = *record.content_hash().as_bytes();
+            let burn_id = kofn_release_burn_id(signed);
+            let released = memory_ifc_label(&promoted, now);
+            match graph.authorize_release(committed, recorded, released, u16::MAX, burn_id) {
+                ReleaseAuth::Authorized(scope) => {
+                    // The promoted label is non-adversarial, so observing it does
+                    // not taint the session — this is what flips the live egress
+                    // verdict. Empty parents ⇒ this observe cannot fail.
+                    let node = graph
+                        .observe_with_label_and_content_hash(
+                            NodeKind::MemoryRead,
+                            released,
+                            &[],
+                            now,
+                            content_hash,
+                        )
+                        .map_err(|e| {
+                            ApiError::IfcDenied(format!("flow-graph observe failed: {e}"))
+                        })?;
+                    // Record the governed scope on the released node (the shared
+                    // enforcement already burned the one-shot authorization).
+                    graph.record_release_scope(node, scope);
+                    return Ok(MemoryRecallResp {
+                        value: record.value,
+                        label: promoted,
+                        declassified: true,
+                    });
+                }
+                // Fail-closed: a value-substituted, unscoped, or replayed release
+                // is denied. authorize_release did NOT burn on any of these.
+                refusal => {
+                    return Err(ApiError::IfcDenied(format!(
+                        "k-of-n governed release refused: {refusal:?}"
+                    )));
+                }
+            }
         }
         None => (record.label.clone(), false),
     };
 
-    // Observe with the record's OWN (possibly promoted) label — never the fixed
-    // intrinsic memory label, which would launder an adversarial record.
-    //
-    // Brick 3: content-address the *actual recalled bytes* (`record.value`),
-    // recomputed here from the real record — NEVER the agent-supplied
-    // `req.content_hash` lookup key, which is only used to locate the record and
-    // must not be trusted as the ingested content's digest.
+    // Un-declassified path: observe the record's OWN (adversarial) label — never
+    // the fixed intrinsic memory label, which would launder an adversarial
+    // record. This taints the session, so the next privileged action is denied.
     let ifc = memory_ifc_label(&effective_label, now);
-    let content_hash = crate::ingest_content_hash(record.value.as_bytes());
-    // Project the recall's (possibly promoted) label onto the SAME authoritative
-    // graph the egress verdict reads. An un-declassified adversarial recall taints
-    // the graph, so the next privileged action is denied; a k-of-n-promoted recall
-    // does not taint and may inform an action. Both mint policies act on the one
-    // graph. Fail-closed: a dropped graph write denies the recall (observes nothing
-    // usable).
     graph
         .observe_with_label_and_content_hash(NodeKind::MemoryRead, ifc, &[], now, content_hash)
         .map_err(|e| ApiError::IfcDenied(format!("flow-graph observe failed: {e}")))?;
@@ -379,6 +463,119 @@ mod tests {
         assert!(
             ifc_egress_denial(&graph2, Operation::GitPush, NodeKind::OutboundAction).is_none(),
             "the k-of-n release flips the FlowGraph-backed egress verdict to allow (was Deny in step 1)"
+        );
+    }
+
+    use ed25519_dalek::SigningKey;
+    use nucleus_provenance_memory::{
+        DeclassifyWitness, DerivationClass, MemoryAuthority, SignedDeclassify,
+    };
+
+    fn kofn_key(s: u8) -> SigningKey {
+        SigningKey::from_bytes(&[s; 32])
+    }
+
+    fn human_promotion_witness(rec: &MemoryRecord) -> DeclassifyWitness {
+        DeclassifyWitness {
+            record_hash: rec.content_hash(),
+            recompute_verdict: RecomputeVerdict::Match,
+            to_authority: MemoryAuthority::MayInform,
+            to_derivation: DerivationClass::HumanPromoted,
+        }
+    }
+
+    /// **Phase 4 value-binding (k-of-n).** A quorum that cosigned a witness for
+    /// record A cannot release a DIFFERENT record B: the committed record identity
+    /// no longer equals the monitor-recomputed hash of the recalled bytes, so the
+    /// governed release is REFUSED and nothing is observed. If value-binding were
+    /// dropped, the substituted record would be (wrongly) promoted.
+    #[test]
+    fn kofn_release_is_value_bound_substituted_value_refused() {
+        let mut set = ProvenanceMemorySet::new();
+        let rec_a = admit_record(&mut set, "the value the quorum actually signed");
+        let rec_b = admit_record(&mut set, "a DIFFERENT value substituted at recall");
+        let trusted = [
+            kofn_key(1).verifying_key().to_bytes(),
+            kofn_key(2).verifying_key().to_bytes(),
+        ];
+        // The quorum cosigns a witness bound to record A.
+        let signed = SignedDeclassify::new(human_promotion_witness(&rec_a))
+            .cosign(&kofn_key(1))
+            .cosign(&kofn_key(2));
+
+        // …but the agent presents it on a recall of record B → refused, fail-closed.
+        let mut graph = FlowGraph::new();
+        let err = memory_recall_core(
+            &set,
+            &mut graph,
+            &trusted,
+            2,
+            0,
+            MemoryRecallReq {
+                content_hash: rec_b.content_hash().to_hex(),
+                declassify: Some(signed),
+            },
+        )
+        .expect_err("a witness bound to record A must not release record B");
+        assert!(
+            matches!(err, ApiError::IfcDenied(_)),
+            "refusal is IFC-denied"
+        );
+        // Nothing was observed: no laundered promoted node on the graph.
+        assert_eq!(graph.len(), 0, "a refused release observes nothing");
+    }
+
+    /// **Phase 4 one-shot (k-of-n), reds-on-drop.** A quorum authorization is spent
+    /// exactly once against the shared burn ledger: the first declassified recall
+    /// is promoted (not tainting), a SECOND identical recall on the same session
+    /// graph is REFUSED (the authorization is burned) — mirroring the Ed25519
+    /// token's replay verdict. NOTE (semantic change disclosed in the PR): before
+    /// Phase 4 a re-recall re-promoted; it is now one-shot per quorum authorization.
+    #[test]
+    fn kofn_release_is_one_shot_replay_refused() {
+        let mut set = ProvenanceMemorySet::new();
+        let rec = admit_record(&mut set, "promote once, then never again this session");
+        let trusted = [
+            kofn_key(1).verifying_key().to_bytes(),
+            kofn_key(2).verifying_key().to_bytes(),
+        ];
+        let signed = SignedDeclassify::new(human_promotion_witness(&rec))
+            .cosign(&kofn_key(1))
+            .cosign(&kofn_key(2));
+
+        let mut graph = FlowGraph::new();
+        // First release: authorized, promoted, does not taint.
+        let first = memory_recall_core(
+            &set,
+            &mut graph,
+            &trusted,
+            2,
+            0,
+            MemoryRecallReq {
+                content_hash: rec.content_hash().to_hex(),
+                declassify: Some(signed.clone()),
+            },
+        )
+        .expect("first quorum release is authorized");
+        assert!(first.declassified, "first release promotes");
+        assert!(!graph.is_tainted(), "the release does not taint");
+
+        // Second identical release: the authorization is burned → refused.
+        let err = memory_recall_core(
+            &set,
+            &mut graph,
+            &trusted,
+            2,
+            0,
+            MemoryRecallReq {
+                content_hash: rec.content_hash().to_hex(),
+                declassify: Some(signed),
+            },
+        )
+        .expect_err("a replayed quorum authorization must be refused (one-shot)");
+        assert!(
+            matches!(err, ApiError::IfcDenied(ref m) if m.contains("Replayed")),
+            "the second release is refused as a one-shot replay, got {err:?}"
         );
     }
 }

--- a/crates/nucleus-tool-proxy/tests/memory_ifc_e2e.rs
+++ b/crates/nucleus-tool-proxy/tests/memory_ifc_e2e.rs
@@ -21,7 +21,7 @@ use nucleus_provenance_memory::{
     TransformRegistry,
 };
 use portcullis::exposure_core::ifc_egress_denial;
-use portcullis::flow_graph::FlowGraph;
+use portcullis::flow_graph::{FlowGraph, ReleaseAuth};
 use portcullis::{FlowTracker, NodeKind, Operation};
 
 /// A fixed content hash for the recalled bytes on the FlowGraph side — the
@@ -192,5 +192,84 @@ fn declassify_is_fail_closed_under_quorum() {
     assert!(
         declassify(&rec, &signed, &[], 1).is_err(),
         "no trusted keys ⇒ fail closed"
+    );
+}
+
+/// **Phase 4 (C5 for the k-of-n mint policy): the threshold release now goes
+/// through the SAME governed-release enforcement as the Ed25519 token —
+/// `FlowGraph::authorize_release` (value-bound + sink-scoped + one-shot).** This
+/// drives the exact primitives `memory_recall_core` composes (the bin crate has
+/// no lib target, so the endpoint core is exercised in `src/memory.rs`; here we
+/// bind the shared enforcement to the live egress verdict).
+#[test]
+fn kofn_release_is_value_bound_and_one_shot_on_the_live_graph() {
+    let reg = TransformRegistry::new();
+    let mut set = ProvenanceMemorySet::new();
+    let rec = poisoned_web_record();
+    assert!(set.verified_admit(&rec, &reg).is_match());
+
+    let trusted = [
+        key(1).verifying_key().to_bytes(),
+        key(2).verifying_key().to_bytes(),
+    ];
+    let witness = DeclassifyWitness {
+        record_hash: rec.content_hash(),
+        recompute_verdict: RecomputeVerdict::Match,
+        to_authority: MemoryAuthority::MayInform,
+        to_derivation: DerivationClass::HumanPromoted,
+    };
+    let signed = SignedDeclassify::new(witness)
+        .cosign(&key(1))
+        .cosign(&key(2));
+    let promoted = declassify(&rec, &signed, &trusted, 2).expect("2-of-2 quorum declassifies");
+
+    // The shared enforcement inputs the k-of-n mint policy supplies:
+    let committed = *rec.content_hash().as_bytes(); // quorum-committed identity
+    let recorded = *rec.content_hash().as_bytes(); // monitor-recomputed identity
+    let released = memory_ifc_label(&promoted, 0);
+    let burn_id = [0x4du8; 32]; // stands in for SHA-256(SignedDeclassify)
+
+    // (1) VALUE-BINDING: a SUBSTITUTED value (a different recorded hash) is
+    //     refused with ValueMismatch — no scope, and NON-burning.
+    let mut graph = FlowGraph::new();
+    let substituted = *ContentHash::of_canonical_bytes(b"a substituted value").as_bytes();
+    assert_eq!(
+        graph.authorize_release(committed, substituted, released, u16::MAX, burn_id),
+        ReleaseAuth::ValueMismatch,
+        "a value substituted after the quorum signed must be refused (value-bound)"
+    );
+    assert!(
+        !graph.is_release_burned(&burn_id),
+        "a value-mismatch refusal must NOT burn the authorization"
+    );
+
+    // (2) The committed value IS authorized → observe the promoted label → the
+    //     live egress verdict flips to allow.
+    match graph.authorize_release(committed, recorded, released, u16::MAX, burn_id) {
+        ReleaseAuth::Authorized(scope) => {
+            let node = graph
+                .observe_with_label_and_content_hash(
+                    NodeKind::MemoryRead,
+                    released,
+                    &[],
+                    0,
+                    fixed_hash(),
+                )
+                .unwrap();
+            assert!(graph.record_release_scope(node, scope));
+        }
+        other => panic!("the committed value must be authorized, got {other:?}"),
+    }
+    assert!(!graph.is_tainted(), "the governed release does not taint");
+    assert!(
+        ifc_egress_denial(&graph, Operation::GitPush, NodeKind::OutboundAction).is_none(),
+        "the value-bound k-of-n release flips the live egress verdict to allow"
+    );
+
+    // (3) ONE-SHOT: the SAME authorization id is now burned → a replay is refused.
+    assert_eq!(
+        graph.authorize_release(committed, recorded, released, u16::MAX, burn_id),
+        ReleaseAuth::Replayed,
+        "a replayed quorum authorization must be refused (one-shot)"
     );
 }

--- a/crates/portcullis/src/flow_graph.rs
+++ b/crates/portcullis/src/flow_graph.rs
@@ -372,6 +372,36 @@ pub struct FlowGraph {
     /// ingest observation is dropped, so taint state is unprovable and the
     /// egress gate must deny until a human-authorized cleanse.
     poisoned: bool,
+    /// **The shared one-shot ledger for governed declassification releases**
+    /// (Phase 4 — "one enforcement, two mint policies"). A governed release is
+    /// spent exactly once: an authorization id (a 32-byte SHA-256 over the
+    /// authorization artifact — the Ed25519 token signature, or the k-of-n
+    /// `SignedDeclassify` bytes) is inserted here on release and refused on
+    /// replay. It travels with the graph so BOTH mint policies (the kernel's
+    /// Ed25519 `apply_declassification_token` and the tool-proxy's k-of-n
+    /// `memory_recall_core`) burn against the SAME ledger — the graph is the one
+    /// place both reach. (Phase 3 kept this on the kernel keyed by the raw
+    /// signature; Phase 4 relocates it here, widthed to a 32-byte id, so the
+    /// keyless k-of-n path shares it.)
+    release_burn_ledger: BTreeSet<[u8; 32]>,
+}
+
+/// Outcome of the shared governed-release enforcement
+/// [`FlowGraph::authorize_release`] (Phase 4). Every non-`Authorized` variant is
+/// a fail-closed, NON-burning refusal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReleaseAuth {
+    /// Value-bound, sink-scoped, and one-shot checks all passed; the
+    /// authorization has been BURNED. The caller must attach this scope to the
+    /// released node.
+    Authorized(DeclassScope),
+    /// Value-binding failed: the commitment is absent (zero) or does not equal
+    /// the monitor-recorded value identity — a substituted value.
+    ValueMismatch,
+    /// The sink mask is empty (mask 0 admits nothing) — refused.
+    EmptyMask,
+    /// One-shot: this authorization id was already spent in this session.
+    Replayed,
 }
 
 /// A node's declassification scope: the released view and the signed sink
@@ -405,6 +435,7 @@ impl FlowGraph {
             session_conf_ceiling: ConfLevel::Public,
             session_adversarial: false,
             poisoned: false,
+            release_burn_ledger: BTreeSet::new(),
         }
     }
 
@@ -1385,19 +1416,106 @@ impl FlowGraph {
         if self.get(token.target_node_id).is_none() {
             return TokenApplyResult::NodeNotFound;
         }
-        if !token.is_value_bound() {
+        // Value-binding via the SINGLE-SOURCED predicate both mint policies share
+        // (Phase 4): the commitment must be present and equal the monitor-recorded
+        // ingest hash of the target node. `recorded = None` (no recorded hash) or a
+        // zero/unequal commitment ⇒ `ContentMismatch`, fail-closed and NON-burning.
+        let recorded = self
+            .content_hash(token.target_node_id)
+            .map(|h| *h.as_bytes());
+        if !Self::value_binding_ok(token.content_commitment, recorded) {
             return TokenApplyResult::ContentMismatch;
-        }
-        match self.content_hash(token.target_node_id) {
-            None => return TokenApplyResult::ContentMismatch,
-            Some(recorded) if recorded.as_bytes() != &token.content_commitment => {
-                return TokenApplyResult::ContentMismatch;
-            }
-            Some(_) => {}
         }
 
         // Delegate to the existing sink-scope / one-shot apply logic.
         self.apply_token(token, now)
+    }
+
+    // ── Shared governed-release enforcement (Phase 4) ─────────────────────────
+    //
+    // "One enforcement, two mint policies." The Ed25519 token and the k-of-n
+    // witness threshold are two AUTHORITY-minting front-ends; the enforcement
+    // they feed — value-binding, sink-scope, one-shot burn — is single-sourced
+    // here so the runtime equals the proven algebra for BOTH.
+
+    /// **The single-sourced value-binding predicate** (mirrors the extracted
+    /// decision `extracted::declassify::value_authorized`: bound ∧ present ∧
+    /// equal). A release is value-bound iff the authority's `committed` value
+    /// identity is present (non-zero) AND equals the monitor-recorded value
+    /// identity `recorded`. `recorded` is a MONITOR-recomputed fact — never
+    /// agent-declared: the Ed25519 path reads it from the target node's ingest
+    /// hash; the k-of-n path recomputes it from the recalled record's bytes.
+    /// A missing recorded value (`None`) or a zero commitment fails closed.
+    pub fn value_binding_ok(committed: [u8; 32], recorded: Option<[u8; 32]>) -> bool {
+        committed != [0u8; 32] && recorded == Some(committed)
+    }
+
+    /// Whether a governed-release authorization id has already been spent in this
+    /// session (the shared one-shot ledger). See [`Self::release_burn_ledger`].
+    pub fn is_release_burned(&self, burn_id: &[u8; 32]) -> bool {
+        self.release_burn_ledger.contains(burn_id)
+    }
+
+    /// Spend a governed-release authorization id (insert into the shared one-shot
+    /// ledger). Called on release ONLY, never on refusal.
+    pub fn burn_release(&mut self, burn_id: [u8; 32]) {
+        self.release_burn_ledger.insert(burn_id);
+    }
+
+    /// **The bundled governed-release enforcement the k-of-n mint policy calls.**
+    ///
+    /// Given the authority's value commitment, the monitor-recomputed value
+    /// identity, the released label, the sink mask, and a one-shot authorization
+    /// id, enforce — ALL fail-closed and NON-burning on refusal:
+    ///   (a) **sink-scope**: an empty mask releases to nothing ⇒ `EmptyMask`;
+    ///   (b) **value-binding**: `committed == recorded` (via
+    ///       [`Self::value_binding_ok`]) ⇒ else `ValueMismatch`;
+    ///   (c) **one-shot**: `burn_id` unspent ⇒ else `Replayed`.
+    /// On success ONLY, the authorization is BURNED and the caller receives the
+    /// authorized [`DeclassScope`] to attach to the node it observes (via
+    /// [`Self::record_release_scope`]). The Ed25519 path composes the SAME three
+    /// primitives (`value_binding_ok` + the shared ledger + the `DeclassScope`
+    /// sink mask) with its own expiry/at-most-once-per-node checks and its
+    /// verified `apply_token`; both write this one ledger.
+    ///
+    /// Note this does NOT itself attach the scope: the k-of-n node does not exist
+    /// until the release is authorized (it must never OBSERVE a promoted label
+    /// for an un-authorized record — the adversarial ratchet cannot be un-set), so
+    /// the caller observes the node only after `Authorized` and then records the
+    /// scope on it.
+    pub fn authorize_release(
+        &mut self,
+        committed: [u8; 32],
+        recorded: [u8; 32],
+        released_label: IFCLabel,
+        sink_mask: u16,
+        burn_id: [u8; 32],
+    ) -> ReleaseAuth {
+        if sink_mask == 0 {
+            return ReleaseAuth::EmptyMask;
+        }
+        if !Self::value_binding_ok(committed, Some(recorded)) {
+            return ReleaseAuth::ValueMismatch;
+        }
+        if self.release_burn_ledger.contains(&burn_id) {
+            return ReleaseAuth::Replayed;
+        }
+        self.release_burn_ledger.insert(burn_id);
+        ReleaseAuth::Authorized(DeclassScope {
+            released_label,
+            sink_mask,
+        })
+    }
+
+    /// Attach an authorized [`DeclassScope`] (from [`Self::authorize_release`]) to
+    /// `node_id`. Fail-closed: returns `false` (records nothing) if the node does
+    /// not exist or already carries a scope — a node is declassified at most once.
+    pub fn record_release_scope(&mut self, node_id: NodeId, scope: DeclassScope) -> bool {
+        if self.get(node_id).is_none() || self.declass_scopes.contains_key(&node_id) {
+            return false;
+        }
+        self.declass_scopes.insert(node_id, scope);
+        true
     }
 
     // ── Trusted ancestry check (#515) ────────────────────────────────

--- a/crates/portcullis/src/kernel.rs
+++ b/crates/portcullis/src/kernel.rs
@@ -534,16 +534,10 @@ pub struct Kernel {
     /// trusted keys are configured.
     #[cfg(feature = "crypto")]
     trusted_public_keys: Vec<[u8; 32]>,
-    /// Signatures of declassification tokens already APPLIED in this session.
-    ///
-    /// Ed25519 is deterministic (RFC 8032), so a token's signature identifies
-    /// exactly one authorization — recording it makes tokens one-shot with
-    /// zero wire-format change. Only successful applications are recorded: a
-    /// token that failed (expired, precondition unmet, node not found) did not
-    /// exercise its authority and is not burnt. `BTreeSet`, not `HashSet`, for
-    /// the deterministic ordering the audit style of this crate relies on.
-    #[cfg(feature = "crypto")]
-    applied_declassifications: std::collections::BTreeSet<[u8; 64]>,
+    // Phase 4: the one-shot declassification-replay ledger moved ONTO the
+    // `flow_graph` (`FlowGraph::release_burn_ledger`) so BOTH mint policies — the
+    // Ed25519 token here and the keyless k-of-n memory path, which has no kernel —
+    // burn against the SAME shared ledger. See `kernel/declassify_authority.rs`.
     /// Optional delegation constraints for this session.
     ///
     /// When present, `SpawnAgent` operations are checked against scope,
@@ -637,7 +631,6 @@ impl Kernel {
             #[cfg(feature = "crypto")]
             trusted_public_keys: Vec::new(),
             #[cfg(feature = "crypto")]
-            applied_declassifications: std::collections::BTreeSet::new(),
             #[cfg(feature = "crypto")]
             signing_key: None,
             receipt_chain: None,
@@ -692,7 +685,6 @@ impl Kernel {
             #[cfg(feature = "crypto")]
             trusted_public_keys: Vec::new(),
             #[cfg(feature = "crypto")]
-            applied_declassifications: std::collections::BTreeSet::new(),
             #[cfg(feature = "crypto")]
             signing_key: None,
             receipt_chain: None,
@@ -1042,7 +1034,6 @@ impl Kernel {
             #[cfg(feature = "crypto")]
             trusted_public_keys: Vec::new(),
             #[cfg(feature = "crypto")]
-            applied_declassifications: std::collections::BTreeSet::new(),
             #[cfg(feature = "crypto")]
             signing_key: None,
             receipt_chain: None,
@@ -1103,7 +1094,6 @@ impl Kernel {
             #[cfg(feature = "crypto")]
             trusted_public_keys: Vec::new(),
             #[cfg(feature = "crypto")]
-            applied_declassifications: std::collections::BTreeSet::new(),
             #[cfg(feature = "crypto")]
             signing_key: None,
             receipt_chain: None,

--- a/crates/portcullis/src/kernel/declassify_authority.rs
+++ b/crates/portcullis/src/kernel/declassify_authority.rs
@@ -1,10 +1,23 @@
 //! The kernel's declassification authority surface: trusted-key configuration
 //! and one-shot token application. Extracted from `kernel.rs` (line ratchet);
 //! a CHILD module of `kernel`, so the impl reaches the kernel's private fields
-//! (`trusted_public_keys`, `applied_declassifications`, `flow_graph`) without
+//! (`trusted_public_keys`, `flow_graph` — incl. its shared release ledger) without
 //! widening their visibility.
 
 use super::{DenyReason, Kernel};
+
+/// The 32-byte one-shot authorization id for an Ed25519 declassification token:
+/// SHA-256 of its deterministic signature. Sharing a fixed-width id with the
+/// k-of-n path lets both mint policies burn against the one
+/// [`FlowGraph::release_burn_ledger`](crate::flow_graph::FlowGraph).
+#[cfg(feature = "crypto")]
+fn release_burn_id(signature: &[u8; 64]) -> [u8; 32] {
+    use sha2::{Digest, Sha256};
+    let mut h = Sha256::new();
+    h.update(b"nucleus.declassify.token.v1");
+    h.update(signature);
+    h.finalize().into()
+}
 
 #[cfg(feature = "crypto")]
 impl Kernel {
@@ -47,8 +60,6 @@ impl Kernel {
         &mut self,
         token: &portcullis_core::declassify::DeclassificationToken,
     ) -> Result<portcullis_core::declassify::TokenApplyResult, DenyReason> {
-        let graph = &mut self.flow_graph;
-
         let now = chrono::Utc::now().timestamp() as u64;
 
         // Fail-closed (most-paranoid #3): declassification weakens information-flow
@@ -66,11 +77,14 @@ impl Kernel {
                     .to_string(),
             });
         }
-        // One-shot (HC-6): the deterministic Ed25519 signature identifies
-        // exactly one authorization. Already exercised ⇒ refuse with the
-        // dedicated replay verdict, BEFORE touching the flow graph — a replayed
-        // token must not re-run any part of the application.
-        if self.applied_declassifications.contains(&token.signature) {
+        // One-shot (HC-6): the deterministic Ed25519 signature identifies exactly
+        // one authorization. Its burn id is a 32-byte SHA-256 over the signature —
+        // the width the SHARED `FlowGraph::release_burn_ledger` uses so the keyless
+        // k-of-n memory path burns against the same ledger (Phase 4). Already
+        // exercised ⇒ refuse with the dedicated replay verdict, BEFORE recording
+        // any scope — a replayed token must not re-run the application.
+        let burn_id = release_burn_id(&token.signature);
+        if self.flow_graph.is_release_burned(&burn_id) {
             return Err(DenyReason::DeclassificationReplayed {
                 target_node: token.target_node_id.to_string(),
             });
@@ -80,7 +94,7 @@ impl Kernel {
             .iter()
             .map(|k| k.as_slice())
             .collect();
-        let result = graph.apply_token_verified(token, &key_refs, now);
+        let result = self.flow_graph.apply_token_verified(token, &key_refs, now);
         if matches!(
             result,
             portcullis_core::declassify::TokenApplyResult::InvalidSignature
@@ -99,7 +113,7 @@ impl Kernel {
             result,
             portcullis_core::declassify::TokenApplyResult::Applied { .. }
         ) {
-            self.applied_declassifications.insert(token.signature);
+            self.flow_graph.burn_release(burn_id);
         }
         Ok(result)
     }

--- a/crates/portcullis/tests/declassify_scope.rs
+++ b/crates/portcullis/tests/declassify_scope.rs
@@ -254,3 +254,60 @@ fn causal_label_for_honors_the_scope() {
         ConfLevel::Secret
     );
 }
+
+/// **Phase 4 parity: the shared governed-release value-binding equals the
+/// extracted decision `value_authorized`.** Both mint policies (Ed25519 token,
+/// k-of-n threshold) route their value-binding through
+/// `FlowGraph::authorize_release`; this binds its runtime decision to the proven
+/// scalar core `bound ∧ present ∧ equal`, so the runtime equals the algebra for
+/// the unified path — and exercises the one-shot burn (a replay is refused).
+#[test]
+fn authorize_release_value_binding_matches_the_extracted_decision() {
+    use portcullis::flow_graph::ReleaseAuth;
+    use portcullis_core::extracted::declassify::value_authorized;
+    use portcullis_core::IFCLabel;
+
+    // The released label is irrelevant to the value-binding / one-shot decision.
+    let released = IFCLabel::bottom();
+    // Opaque 32-byte value identities; the scalar model tags them by first byte.
+    let v = |b: u8| {
+        let mut a = [0u8; 32];
+        a[0] = b;
+        a
+    };
+    let tag = |a: &[u8; 32]| a[0] as u64;
+
+    // committed == recorded (both non-zero) ⇒ Authorized AND value_authorized true.
+    for (committed, recorded) in [(v(7), v(7)), (v(7), v(9)), (v(9), v(7))] {
+        let mut g = FlowGraph::new();
+        let out = g.authorize_release(committed, recorded, released, u16::MAX, [1u8; 32]);
+        let model = value_authorized(
+            committed != [0u8; 32],
+            true,
+            tag(&committed),
+            tag(&recorded),
+        );
+        assert_eq!(
+            matches!(out, ReleaseAuth::Authorized(_)),
+            model,
+            "authorize_release value-binding must equal the extracted decision"
+        );
+    }
+
+    // One-shot: the burned id is refused as Replayed on the second call.
+    let mut g = FlowGraph::new();
+    assert!(matches!(
+        g.authorize_release(v(7), v(7), released, u16::MAX, [2u8; 32]),
+        ReleaseAuth::Authorized(_)
+    ));
+    assert_eq!(
+        g.authorize_release(v(7), v(7), released, u16::MAX, [2u8; 32]),
+        ReleaseAuth::Replayed,
+        "a replayed authorization id is refused (one-shot burn)"
+    );
+    // An empty sink mask releases to nothing.
+    assert_eq!(
+        FlowGraph::new().authorize_release(v(7), v(7), released, 0, [3u8; 32]),
+        ReleaseAuth::EmptyMask,
+    );
+}


### PR DESCRIPTION
## Phase 4 — one enforcement, two mint policies

The locked end state: the **Ed25519 single-use token** and the **k-of-n witness threshold** (memory-recall) now feed the **SAME** governed declassification release — value-bound, sink-scoped, one-shot, against a **shared burn ledger**. Before this, the k-of-n path (`memory_recall_core`) minted a promotion by projecting a quorum-promoted label directly onto the FlowGraph, carrying **none** of the token path's value-binding / one-shot / sink-scope guarantees.

### How both policies now share one enforcement
Single-sourced on `FlowGraph` (`crates/portcullis/src/flow_graph.rs`):
- **`value_binding_ok(committed, recorded)`** — the one value-binding predicate (`bound ∧ present ∧ equal`), mirroring extracted `value_authorized`. The Ed25519 `apply_token_verified` was refactored to use it; the k-of-n path uses it via `authorize_release`.
- **`release_burn_ledger` + `is_release_burned`/`burn_release`** — the one one-shot ledger, **relocated from the kernel** (`applied_declassifications`, now removed) onto the graph, so the keyless k-of-n path (which has no `Kernel`) burns the **same** ledger. Ed25519 burn id = `SHA-256(signature)`; k-of-n burn id = `SHA-256(SignedDeclassify)`.
- **`authorize_release(committed, recorded, released, sink_mask, burn_id)`** — the bundled value-bind + sink-scope + one-shot gate the k-of-n front-end calls; burns on success **only**, fail-closed and non-burning on every refusal (`ValueMismatch`/`EmptyMask`/`Replayed`); returns the `DeclassScope` to attach via `record_release_scope`.

### k-of-n front-end (`crates/nucleus-tool-proxy/src/memory.rs`)
The quorum is only the **authority** half. A promoted (non-tainting) label is **observed only after** `authorize_release` authorizes — authorization precedes observe because the adversarial taint ratchet, once set, cannot be un-set (an un-authorized record must never be observed promoted). Committed = the quorum-signed record identity; recorded = the record's monitor-recomputed content hash.

### Design forks decided (Brandon's revealed preferences; async, reversible)
- **(a) committed value + sink scope:** committed value = the quorum-signed record identity (`witness.record_hash`), bound to the record's recomputed content hash. **Sink scope = all sinks** for the k-of-n mint policy — this preserves current semantics (a promoted record could inform any action); **witness-level sink narrowing is parked** (would need an `allowed_sinks` field on the witness). The sink-scope *enforcement* is identical to the token's; the policies differ only in what they authorize. Runner-up (add a witness sink field now) rejected to avoid a witness wire-format change in this PR.
- **(b) one-shot vs re-release — CHOSE ONE-SHOT (fail-closed):** a quorum authorization is spent exactly once per session against the shared ledger; a second identical declassified recall is refused. **This CHANGES current memory-recall semantics** (a re-recall previously re-promoted). Rationale: leaving re-release in place would give the two policies *different* enforcement, violating the locked "one enforcement" goal; a replayed quorum authorization is exactly the replay the burn prevents; re-release requires a fresh quorum authorization (a different witness/signature set → different burn id), mirroring the token. Runner-up (keep re-release) rejected. Reversibility: high — the burn is keyed by the authorization artifact; removing the insert/check reverts it.
- **(c) authority interface:** the shared path accepts either authority proof (Ed25519 signature verified in `apply_token_verified`; k-of-n quorum verified by `declassify()`), while the enforcement (value/sink/one-shot) is identical — a mint-policy interface.

### The k-of-n release is now value-bound (the requested test)
- `kofn_release_is_value_bound_substituted_value_refused` (`memory.rs`): a witness bound to record A cannot release a substituted record B — refused, nothing observed.
- `kofn_release_is_one_shot_replay_refused` (`memory.rs`): a second identical quorum release is refused.
- `kofn_release_is_value_bound_and_one_shot_on_the_live_graph` (`memory_ifc_e2e.rs`): drives the shared enforcement to the **live egress verdict** — substituted value → `ValueMismatch` (non-burning); committed value → authorized → observed → egress flips to allow; replay → `Replayed`.
- `authorize_release_value_binding_matches_the_extracted_decision` (`declassify_scope.rs`): binds the shared value-binding pointwise to extracted `value_authorized`, plus one-shot + empty-mask.

### Guarantees preserved
Ed25519 path behavior unchanged after the ledger relocation: **16/16** `kernel_token` + **4/4** original `declassify_scope` tests green. Extracted Aeneas slice and Lean unchanged (`value_authorized` reused as-is), so the extraction workflow is not triggered.

### Honest scope / divergence
The **live tool-proxy egress verdict reads session ratchets, not `DeclassScope`s** (unchanged from Phase 2/3), so the recorded scope is dormant on that path; the live k-of-n flip is via label-choice at observe, **now gated behind the shared authorization**. Scope-honoring egress is a separate item. This PR makes both mint policies value-bound + one-shot + sink-scoped through one enforcement and one ledger; it does not (and does not claim to) make the token path live on the tool-proxy egress.

### Gates run locally (green)
`cargo fmt --check`, `cargo clippy` (touched files clean), full `portcullis` (969+ tests) and `nucleus-tool-proxy` suites, `check-mediation.sh`, `check-north-star-ledger.sh`, `check-declassify-sink-scope-enforced.sh`.

### Boot gate
**BOOT-GATED — changes live memory-declass semantics (one-shot).** This PR is opened for CI including `boot-a-real-pod (x86_64)`. **DO NOT MERGE / DO NOT ENQUEUE** — the human gates the merge. Phase 5 (four-run robustness theorem) is next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148ebbw4UXypRjhMw3xAQzj