### PR TITLE
declassify: Phase 4.5 — scope-honoring egress on the live graph + re-home the Ed25519 apply (boot-gated, DO NOT MERGE)

### DIFF
--- a/crates/nucleus-tool-proxy/src/declassify.rs
+++ b/crates/nucleus-tool-proxy/src/declassify.rs
@@ -114,8 +114,14 @@ pub(crate) async fn apply_declassification(
         .collect();
     let target = token.target_node_id;
 
-    let mut kernel = state.kernel.lock().await;
-    match kernel.apply_declassification_token(&token) {
+    // Re-home (Phase 4.5): the scope must land on the session's authoritative
+    // `state.flow_graph` — the graph the live egress verdict reads — not the
+    // kernel's separate, never-populated `flow_graph`. Lock order MUST be
+    // (kernel, then flow_graph) to match `http_kernel_decide` and the ingest
+    // path, or the two lock sites could deadlock.
+    let kernel = state.kernel.lock().await;
+    let mut graph = state.flow_graph.lock().await;
+    match kernel.apply_declassification_token_on(&mut graph, &token) {
         Ok(TokenApplyResult::Applied { .. }) => Ok(Json(DeclassifyResponse {
             applied: true,
             target_node_id: target,

--- a/crates/portcullis/Cargo.toml
+++ b/crates/portcullis/Cargo.toml
@@ -136,5 +136,9 @@ name = "kernel_token"
 required-features = ["crypto"]
 
 [[test]]
+name = "declassify_rehome_egress"
+required-features = ["crypto"]
+
+[[test]]
 name = "kernel_dlc_admission"
 required-features = ["dlc"]

--- a/crates/portcullis/src/exposure_core.rs
+++ b/crates/portcullis/src/exposure_core.rs
@@ -45,6 +45,24 @@ pub trait EgressAggregates {
     fn is_tainted(&self) -> bool;
     /// Session confidentiality-ceiling downflow check for an outbound sink (#4).
     fn session_exfiltration_check(&self, sink_max_conf: ConfLevel) -> SafetyCheck;
+
+    /// Scope-aware integrity taint for a specific operation (Phase 4.5). Defaults
+    /// to the operation-agnostic [`is_tainted`](Self::is_tainted), so an
+    /// implementor with no per-node scopes (e.g. `FlowTracker`) is byte-identical
+    /// to the historical gate. `FlowGraph` overrides it to honor per-node declass
+    /// scopes, refining the answer DOWNWARD only under full node visibility.
+    fn effective_is_tainted(&self, _op: Operation) -> bool {
+        self.is_tainted()
+    }
+
+    /// Scope-aware confidentiality downflow check for a specific operation
+    /// (Phase 4.5). Defaults to the operation-agnostic
+    /// [`session_exfiltration_check`](Self::session_exfiltration_check), so an
+    /// implementor with no per-node scopes is byte-identical to the historical
+    /// gate. `FlowGraph` overrides it to honor per-node declass scopes.
+    fn effective_exfiltration_check(&self, _op: Operation, cap: ConfLevel) -> SafetyCheck {
+        self.session_exfiltration_check(cap)
+    }
 }
 
 impl EgressAggregates for FlowTracker {
@@ -74,6 +92,14 @@ impl EgressAggregates for crate::flow_graph::FlowGraph {
     #[inline]
     fn session_exfiltration_check(&self, sink_max_conf: ConfLevel) -> SafetyCheck {
         crate::flow_graph::FlowGraph::session_exfiltration_check(self, sink_max_conf)
+    }
+    #[inline]
+    fn effective_is_tainted(&self, op: Operation) -> bool {
+        crate::flow_graph::FlowGraph::effective_is_tainted(self, op)
+    }
+    #[inline]
+    fn effective_exfiltration_check(&self, op: Operation, cap: ConfLevel) -> SafetyCheck {
+        crate::flow_graph::FlowGraph::effective_exfiltration_check(self, op, cap)
     }
 }
 
@@ -191,7 +217,7 @@ pub fn ifc_egress_verdict<F: EgressAggregates + ?Sized>(
         return EgressVerdict::Pass;
     }
 
-    if is_outbound_action && flow.is_tainted() {
+    if is_outbound_action && flow.effective_is_tainted(op) {
         let detail = format!(
             "session carries adversarial integrity (untrusted/web content was \
              observed); outbound operation {op:?} blocked to prevent exfiltration \
@@ -215,7 +241,7 @@ pub fn ifc_egress_verdict<F: EgressAggregates + ?Sized>(
     }
 
     if flow
-        .session_exfiltration_check(sink_max_conf_for(op))
+        .effective_exfiltration_check(op, sink_max_conf_for(op))
         .is_denied()
     {
         return EgressVerdict::Deny(format!(

--- a/crates/portcullis/src/flow_graph.rs
+++ b/crates/portcullis/src/flow_graph.rs
@@ -384,6 +384,17 @@ pub struct FlowGraph {
     /// signature; Phase 4 relocates it here, widthed to a 32-byte id, so the
     /// keyless k-of-n path shares it.)
     release_burn_ledger: BTreeSet<[u8; 32]>,
+    /// Set once [`maybe_compact`](Self::maybe_compact) has actually tombstoned
+    /// nodes (never merely on reaching the warn threshold). Once true, a live-node
+    /// scan can no longer see every observation, so the scope-aware effective
+    /// aggregates ([`effective_exfiltration_check`](Self::effective_exfiltration_check),
+    /// [`effective_is_tainted`](Self::effective_is_tainted)) STOP refining and
+    /// defer to the monotonic session ratchet — fail-closed: a declass scope on a
+    /// tombstoned node cannot be used to argue egress is safe. Deliberately NOT
+    /// cleared by [`reset_session_ceiling`](Self::reset_session_ceiling): a cleanse
+    /// lowers the taint ceiling but cannot resurrect tombstoned nodes, so the
+    /// scan is still blind and must stay conservative.
+    ever_compacted: bool,
 }
 
 /// Outcome of the shared governed-release enforcement
@@ -436,6 +447,7 @@ impl FlowGraph {
             session_adversarial: false,
             poisoned: false,
             release_burn_ledger: BTreeSet::new(),
+            ever_compacted: false,
         }
     }
 
@@ -782,6 +794,110 @@ impl FlowGraph {
             };
         }
         SafetyCheck::Safe
+    }
+
+    // ── Scope-aware effective aggregates (Phase 4.5) ──────────────────────────
+    //
+    // The plain `session_*` aggregates above are monotonic ratchets: they never
+    // honor a per-node `DeclassScope`, so a signed release that clears a node for
+    // one sink cannot lower the session ceiling the egress gate reads. These
+    // effective variants refine the ratchet DOWNWARD — and only downward — under
+    // full node visibility, routing each live observation node through
+    // `effective_label(id, op)` so a scope admitting `op` contributes its released
+    // view. Every path is fail-closed: the ratchet is the floor, and once
+    // `ever_compacted` a live-node scan is incomplete so the strict ratchet
+    // governs.
+
+    /// The session confidentiality ceiling recomputed over the EFFECTIVE
+    /// (scope-aware) labels of LIVE OBSERVATION nodes for operation `op`: the max
+    /// over each live observation node's `effective_label(id, op).confidentiality`.
+    /// A node carrying a declass scope that admits `op` contributes its RELEASED
+    /// confidentiality; every other node its strict stored confidentiality. Only
+    /// sound when no compaction has tombstoned a node — callers gate on
+    /// `ever_compacted` first.
+    fn effective_conf_ceiling(&self, op: Operation) -> ConfLevel {
+        let mut ceiling = ConfLevel::Public;
+        for (i, slot) in self.nodes.iter().enumerate() {
+            let Some(node) = slot.as_ref() else { continue };
+            // Observation nodes only (`operation.is_none()`); the session
+            // ceiling is the join over INGESTS, and an action node's label is a
+            // derived join, not an independent source.
+            if node.operation.is_some() {
+                continue;
+            }
+            if let Some(label) = self.effective_label(i as NodeId, op) {
+                if label.confidentiality > ceiling {
+                    ceiling = label.confidentiality;
+                }
+            }
+        }
+        ceiling
+    }
+
+    /// Scope-aware confidentiality downflow check for an outbound sink emitting
+    /// operation `op`. Fail-closed and never weaker than
+    /// [`session_exfiltration_check`](Self::session_exfiltration_check):
+    ///
+    /// * `session_conf_ceiling <= sink_max_conf` ⇒ `Safe` (the ratchet already
+    ///   fits; no per-node refinement could raise it).
+    /// * else if `ever_compacted` ⇒ deny (`ConfidentialityViolation`): the
+    ///   live-node scan is blind, so the strict ratchet governs.
+    /// * else recompute the effective ceiling over live observation nodes and deny
+    ///   iff it STILL exceeds the sink — a declass scope admitting `op` can lower
+    ///   the ceiling and clear the release; nothing else can.
+    pub fn effective_exfiltration_check(
+        &self,
+        op: Operation,
+        sink_max_conf: ConfLevel,
+    ) -> SafetyCheck {
+        if self.session_conf_ceiling <= sink_max_conf {
+            return SafetyCheck::Safe;
+        }
+        if self.ever_compacted {
+            return SafetyCheck::ConfidentialityViolation {
+                data_conf: self.session_conf_ceiling,
+                sink_max_conf,
+            };
+        }
+        let eff = self.effective_conf_ceiling(op);
+        if eff > sink_max_conf {
+            SafetyCheck::ConfidentialityViolation {
+                data_conf: eff,
+                sink_max_conf,
+            }
+        } else {
+            SafetyCheck::Safe
+        }
+    }
+
+    /// Scope-aware integrity-taint check for operation `op`. Fail-closed and never
+    /// weaker than [`is_tainted`](Self::is_tainted):
+    ///
+    /// * `!session_adversarial` ⇒ `false` (no adversarial ingest ever occurred).
+    /// * else if `ever_compacted` ⇒ `true`: the live-node scan is blind, so the
+    ///   ratchet governs.
+    /// * else `true` iff some live observation node's `effective_label(id, op)`
+    ///   still carries `Adversarial` integrity — a scope admitting `op` can lower
+    ///   a node's contributed integrity, and nothing else clears the taint.
+    pub fn effective_is_tainted(&self, op: Operation) -> bool {
+        if !self.session_adversarial {
+            return false;
+        }
+        if self.ever_compacted {
+            return true;
+        }
+        for (i, slot) in self.nodes.iter().enumerate() {
+            let Some(node) = slot.as_ref() else { continue };
+            if node.operation.is_some() {
+                continue;
+            }
+            if let Some(label) = self.effective_label(i as NodeId, op) {
+                if label.integrity == IntegLevel::Adversarial {
+                    return true;
+                }
+            }
+        }
+        false
     }
 
     /// Mark the session poisoned (fail-closed): an ingest observation was
@@ -1216,6 +1332,11 @@ impl FlowGraph {
         if count < MAX_GRAPH_NODES {
             return;
         }
+
+        // Past this point compaction actually tombstones nodes: a live-node scan
+        // is no longer complete, so the scope-aware effective aggregates must stop
+        // refining and defer to the monotonic ratchet (fail-closed).
+        self.ever_compacted = true;
 
         warn!(
             nodes = count,

--- a/crates/portcullis/src/kernel/declassify_authority.rs
+++ b/crates/portcullis/src/kernel/declassify_authority.rs
@@ -60,13 +60,57 @@ impl Kernel {
         &mut self,
         token: &portcullis_core::declassify::DeclassificationToken,
     ) -> Result<portcullis_core::declassify::TokenApplyResult, DenyReason> {
+        // Disjoint-field borrow: the trusted-key set and the kernel's own
+        // `flow_graph` are separate fields, so the core can hold a shared borrow
+        // of one and an exclusive borrow of the other simultaneously.
+        Self::apply_declassification_token_core(
+            &self.trusted_public_keys,
+            &mut self.flow_graph,
+            token,
+        )
+    }
+
+    /// Apply a signed declassification token to an EXTERNALLY-SUPPLIED flow graph
+    /// (Phase 4.5 re-home). Same authority and one-shot semantics as
+    /// [`apply_declassification_token`](Self::apply_declassification_token), but
+    /// the scope is recorded on — and the one-shot burn is spent against — the
+    /// `graph` the caller passes, not the kernel's own `flow_graph`.
+    ///
+    /// This is the live path: the tool-proxy's `/v1/declassify` endpoint holds the
+    /// session's authoritative `state.flow_graph` (the graph egress reads), so the
+    /// token must land there. Writing to the kernel's separate, never-populated
+    /// `flow_graph` would record the scope on a graph no verdict ever consults
+    /// (→ `NodeNotFound` on the live graph). Takes `&self` because it only reads
+    /// the trusted-key configuration; all mutation is on the passed graph.
+    #[cfg(feature = "crypto")]
+    pub fn apply_declassification_token_on(
+        &self,
+        graph: &mut crate::flow_graph::FlowGraph,
+        token: &portcullis_core::declassify::DeclassificationToken,
+    ) -> Result<portcullis_core::declassify::TokenApplyResult, DenyReason> {
+        Self::apply_declassification_token_core(&self.trusted_public_keys, graph, token)
+    }
+
+    /// The single-sourced body of the Ed25519 declassification apply, reading and
+    /// mutating the release ledger on the PASSED graph. Both
+    /// [`apply_declassification_token`](Self::apply_declassification_token) (kernel's
+    /// own graph) and [`apply_declassification_token_on`](Self::apply_declassification_token_on)
+    /// (a caller-supplied graph) delegate here, so the authority, value-binding,
+    /// sink-scope, and one-shot semantics are identical on whichever graph the
+    /// scope is recorded.
+    #[cfg(feature = "crypto")]
+    fn apply_declassification_token_core(
+        trusted_public_keys: &[[u8; 32]],
+        graph: &mut crate::flow_graph::FlowGraph,
+        token: &portcullis_core::declassify::DeclassificationToken,
+    ) -> Result<portcullis_core::declassify::TokenApplyResult, DenyReason> {
         let now = chrono::Utc::now().timestamp() as u64;
 
         // Fail-closed (most-paranoid #3): declassification weakens information-flow
         // labels, so it MUST be cryptographically authorized. With no trusted keys
         // configured there is no authority to verify against, so refuse outright
         // rather than applying the token unsigned.
-        if self.trusted_public_keys.is_empty() {
+        if trusted_public_keys.is_empty() {
             tracing::warn!(
                 target_node = token.target_node_id,
                 "declassification refused: no trusted public keys configured (fail-closed)"
@@ -84,17 +128,13 @@ impl Kernel {
         // exercised ⇒ refuse with the dedicated replay verdict, BEFORE recording
         // any scope — a replayed token must not re-run the application.
         let burn_id = release_burn_id(&token.signature);
-        if self.flow_graph.is_release_burned(&burn_id) {
+        if graph.is_release_burned(&burn_id) {
             return Err(DenyReason::DeclassificationReplayed {
                 target_node: token.target_node_id.to_string(),
             });
         }
-        let key_refs: Vec<&[u8]> = self
-            .trusted_public_keys
-            .iter()
-            .map(|k| k.as_slice())
-            .collect();
-        let result = self.flow_graph.apply_token_verified(token, &key_refs, now);
+        let key_refs: Vec<&[u8]> = trusted_public_keys.iter().map(|k| k.as_slice()).collect();
+        let result = graph.apply_token_verified(token, &key_refs, now);
         if matches!(
             result,
             portcullis_core::declassify::TokenApplyResult::InvalidSignature
@@ -113,7 +153,7 @@ impl Kernel {
             result,
             portcullis_core::declassify::TokenApplyResult::Applied { .. }
         ) {
-            self.flow_graph.burn_release(burn_id);
+            graph.burn_release(burn_id);
         }
         Ok(result)
     }

--- a/crates/portcullis/tests/declassify_rehome_egress.rs
+++ b/crates/portcullis/tests/declassify_rehome_egress.rs
@@ -1,0 +1,381 @@
+//! Phase 4.5 — scope-honoring egress on the LIVE graph + the re-homed Ed25519
+//! apply.
+//!
+//! These tests pin the two-part change end to end **on ONE `FlowGraph`** (the
+//! bug the re-home fixes was that the apply wrote to a *separate*, never-read
+//! graph):
+//!
+//! * **C4 flip-back** — a Secret env-var node denies `GitPush`; a governor-signed,
+//!   value-bound, `GitPush`-scoped token applied to that same graph flips the
+//!   verdict to `Pass`, and ONLY for the signed sink and the committed value.
+//! * **Fail-open boundary matrix** — every adversarial variant (substituted
+//!   value, an unsigned sink, replay, a second undeclassified secret, poison)
+//!   stays `Deny`/refused AFTER the apply. This is the load-bearing direction:
+//!   the refinement may only ever *lower* under full visibility, never open a
+//!   hole the ratchet would have closed.
+
+#![cfg(feature = "crypto")]
+
+use portcullis::exposure_core::{ifc_egress_verdict, EgressVerdict};
+use portcullis::flow_graph::FlowGraph;
+use portcullis::kernel::{DenyReason, Kernel};
+use portcullis::token_sign;
+use portcullis::{Operation, PermissionLattice};
+use portcullis_core::declassify::{
+    DeclassificationRule, DeclassificationToken, DeclassifyAction, TokenApplyResult,
+};
+use portcullis_core::flow::NodeKind;
+use portcullis_core::{ConfLevel, ContentHash};
+use ring::rand::SystemRandom;
+use ring::signature::{Ed25519KeyPair, KeyPair};
+
+/// The recorded content identity a value-bound token commits to (non-zero so the
+/// token is value-bound). `H` in the directive.
+const H: [u8; 32] = [0x5Au8; 32];
+/// A DIFFERENT value identity — a substituted value the governor did NOT sign.
+const OTHER: [u8; 32] = [0xA5u8; 32];
+
+fn test_key() -> Ed25519KeyPair {
+    let rng = SystemRandom::new();
+    let pkcs8 = Ed25519KeyPair::generate_pkcs8(&rng).unwrap();
+    Ed25519KeyPair::from_pkcs8(pkcs8.as_ref()).unwrap()
+}
+
+fn public_key_bytes(key: &Ed25519KeyPair) -> [u8; 32] {
+    let mut bytes = [0u8; 32];
+    bytes.copy_from_slice(key.public_key().as_ref());
+    bytes
+}
+
+/// A governor kernel trusting `key`. It never holds the session graph — the
+/// re-home means it applies onto whatever graph the caller passes.
+fn governor_kernel(key: &Ed25519KeyPair) -> Kernel {
+    let mut kernel = Kernel::new(PermissionLattice::safe_pr_fixer());
+    kernel.set_trusted_keys(vec![public_key_bytes(key)]);
+    kernel
+}
+
+/// A Secret env-var observation carrying `hash` as its monitor-recorded content
+/// identity, on a standalone graph.
+fn observe_secret(g: &mut FlowGraph, hash: [u8; 32]) -> u64 {
+    g.observe_with_content_hash(NodeKind::EnvVar, &[], 0, ContentHash::from_bytes(hash))
+        .expect("observe secret env var")
+}
+
+/// A signed, value-bound `Secret -> Public` token scoped to `sinks`, committing
+/// to `commitment`.
+fn signed_token(
+    key: &Ed25519KeyPair,
+    node_id: u64,
+    sinks: Vec<Operation>,
+    commitment: [u8; 32],
+) -> DeclassificationToken {
+    let mut token = DeclassificationToken::new(
+        node_id,
+        DeclassificationRule {
+            action: DeclassifyAction::LowerConfidentiality {
+                from: ConfLevel::Secret,
+                to: ConfLevel::Public,
+            },
+            justification: "governor releases the env var for the signed sink".to_string(),
+        },
+        sinks,
+        u64::MAX,
+        "released env var".to_string(),
+    )
+    .with_content_commitment(commitment);
+    token_sign::sign_token(&mut token, key);
+    token
+}
+
+/// The LIVE gate as `ifc_flow_gate` composes it: poison denies everything, else
+/// the scope-aware egress verdict decides. `ifc_egress_verdict` alone does not
+/// consult poison (by design — poison is a separate, broader gate), so the poison
+/// boundary case must go through this.
+fn gate_denies(g: &FlowGraph, op: Operation) -> bool {
+    if g.is_poisoned() {
+        return true;
+    }
+    matches!(
+        ifc_egress_verdict(g, op, NodeKind::OutboundAction, false),
+        EgressVerdict::Deny(_)
+    )
+}
+
+fn is_deny(g: &FlowGraph, op: Operation) -> bool {
+    matches!(
+        ifc_egress_verdict(g, op, NodeKind::OutboundAction, false),
+        EgressVerdict::Deny(_)
+    )
+}
+
+fn is_pass(g: &FlowGraph, op: Operation) -> bool {
+    matches!(
+        ifc_egress_verdict(g, op, NodeKind::OutboundAction, false),
+        EgressVerdict::Pass
+    )
+}
+
+// ── C4 flip-back ───────────────────────────────────────────────────────────
+
+#[test]
+fn c4_flip_back_on_one_graph() {
+    let key = test_key();
+    let kernel = governor_kernel(&key);
+    let mut g = FlowGraph::new();
+
+    // A Secret env-var node with recorded content hash H.
+    let node = observe_secret(&mut g, H);
+
+    // Before: a secret-bearing session cannot push (Secret > Internal).
+    assert!(
+        is_deny(&g, Operation::GitPush),
+        "a secret env var must deny git push before declassification"
+    );
+
+    // A governor signs a value-bound, GitPush-scoped Secret->Public token and
+    // applies it TO THIS SAME GRAPH (the re-home).
+    let token = signed_token(&key, node, vec![Operation::GitPush], H);
+    let result = kernel
+        .apply_declassification_token_on(&mut g, &token)
+        .expect("verified apply must not error");
+    assert!(
+        matches!(result, TokenApplyResult::Applied { .. }),
+        "expected Applied, got {result:?}"
+    );
+
+    // After: the verdict flips to Pass — the released view opens exactly this
+    // node, for this sink, for the committed value.
+    assert!(
+        is_pass(&g, Operation::GitPush),
+        "git push must PASS after the scoped release lands on the live graph"
+    );
+}
+
+// ── Fail-open boundary matrix — each must stay Deny/refused AFTER apply ───────
+
+/// (a) Substituted value: a token committing to OTHER (≠ H) is refused
+/// `ContentMismatch` and the verdict stays Deny — no scope was recorded.
+#[test]
+fn boundary_a_substituted_value_content_mismatch_stays_deny() {
+    let key = test_key();
+    let kernel = governor_kernel(&key);
+    let mut g = FlowGraph::new();
+    let node = observe_secret(&mut g, H);
+
+    let token = signed_token(&key, node, vec![Operation::GitPush], OTHER);
+    let result = kernel
+        .apply_declassification_token_on(&mut g, &token)
+        .expect("verified apply must not error");
+    assert_eq!(
+        result,
+        TokenApplyResult::ContentMismatch,
+        "a substituted value must be refused ContentMismatch"
+    );
+    assert!(
+        is_deny(&g, Operation::GitPush),
+        "verdict must stay Deny when the value did not match"
+    );
+}
+
+/// (b) Unsigned sink: a token scoped ONLY to GitPush leaves CreatePr denied —
+/// the scope clears its node for the signed sink and no other.
+#[test]
+fn boundary_b_unsigned_sink_stays_deny() {
+    let key = test_key();
+    let kernel = governor_kernel(&key);
+    let mut g = FlowGraph::new();
+    let node = observe_secret(&mut g, H);
+
+    let token = signed_token(&key, node, vec![Operation::GitPush], H);
+    let result = kernel
+        .apply_declassification_token_on(&mut g, &token)
+        .expect("verified apply must not error");
+    assert!(matches!(result, TokenApplyResult::Applied { .. }));
+
+    // GitPush opens (the signed sink)…
+    assert!(is_pass(&g, Operation::GitPush), "signed sink opens");
+    // …but CreatePr (Internal cap, NOT in the mask) stays denied.
+    assert!(
+        is_deny(&g, Operation::CreatePr),
+        "an unsigned sink must stay Deny after a scoped release"
+    );
+}
+
+/// (c) Replay: a second apply of the same token is refused
+/// `DeclassificationReplayed`, and the burn is on THIS graph's ledger.
+#[test]
+fn boundary_c_second_apply_replayed_burn_on_same_graph() {
+    let key = test_key();
+    let kernel = governor_kernel(&key);
+    let mut g = FlowGraph::new();
+    let node = observe_secret(&mut g, H);
+
+    let token = signed_token(&key, node, vec![Operation::GitPush], H);
+    let first = kernel
+        .apply_declassification_token_on(&mut g, &token)
+        .expect("first apply must not error");
+    assert!(matches!(first, TokenApplyResult::Applied { .. }));
+
+    // The one-shot burn landed on THIS graph's shared ledger.
+    let burn_id = {
+        use sha2::{Digest, Sha256};
+        let mut hsh = Sha256::new();
+        hsh.update(b"nucleus.declassify.token.v1");
+        hsh.update(token.signature);
+        let out: [u8; 32] = hsh.finalize().into();
+        out
+    };
+    assert!(
+        g.is_release_burned(&burn_id),
+        "the one-shot burn must be recorded on the graph the apply wrote to"
+    );
+
+    // Replaying the SAME token is refused with the dedicated replay verdict.
+    let second = kernel.apply_declassification_token_on(&mut g, &token);
+    assert!(
+        matches!(second, Err(DenyReason::DeclassificationReplayed { .. })),
+        "a replayed token must be refused, got {second:?}"
+    );
+    // GitPush stays open only because the FIRST release stands — the replay
+    // neither re-ran nor un-did anything.
+    assert!(is_pass(&g, Operation::GitPush));
+}
+
+/// (c') A DIFFERENT signed token targeting the already-declassified node is
+/// refused `AlreadyDeclassified` (a node is declassified at most once).
+#[test]
+fn boundary_c_prime_already_declassified() {
+    let key = test_key();
+    let kernel = governor_kernel(&key);
+    let mut g = FlowGraph::new();
+    let node = observe_secret(&mut g, H);
+
+    let t1 = signed_token(&key, node, vec![Operation::GitPush], H);
+    assert!(matches!(
+        kernel.apply_declassification_token_on(&mut g, &t1),
+        Ok(TokenApplyResult::Applied { .. })
+    ));
+
+    // A fresh token (different signature ⇒ different burn id, so it clears the
+    // replay ledger) still cannot re-declassify the node.
+    let t2 = signed_token(&key, node, vec![Operation::CreatePr], H);
+    let r2 = kernel
+        .apply_declassification_token_on(&mut g, &t2)
+        .expect("apply must not error");
+    assert_eq!(
+        r2,
+        TokenApplyResult::AlreadyDeclassified,
+        "a node is declassified at most once"
+    );
+}
+
+/// (d) A SECOND, non-declassified Secret node keeps GitPush denied — one scoped
+/// release must not clear the whole session's confidentiality ceiling.
+#[test]
+fn boundary_d_second_secret_node_keeps_deny() {
+    let key = test_key();
+    let kernel = governor_kernel(&key);
+    let mut g = FlowGraph::new();
+
+    let node1 = observe_secret(&mut g, H);
+    // A second secret node, committed to a DIFFERENT identity, left undeclassified.
+    let _node2 = observe_secret(&mut g, OTHER);
+
+    let token = signed_token(&key, node1, vec![Operation::GitPush], H);
+    assert!(matches!(
+        kernel.apply_declassification_token_on(&mut g, &token),
+        Ok(TokenApplyResult::Applied { .. })
+    ));
+
+    // node1 is released, but node2's strict Secret still tops the effective
+    // ceiling — GitPush must stay Deny.
+    assert!(
+        is_deny(&g, Operation::GitPush),
+        "a single scoped release must not clear a still-secret second node"
+    );
+}
+
+/// (e) Poison denies regardless — even after a successful release that made
+/// GitPush Pass.
+#[test]
+fn boundary_e_poison_denies_regardless() {
+    let key = test_key();
+    let kernel = governor_kernel(&key);
+    let mut g = FlowGraph::new();
+    let node = observe_secret(&mut g, H);
+
+    let token = signed_token(&key, node, vec![Operation::GitPush], H);
+    assert!(matches!(
+        kernel.apply_declassification_token_on(&mut g, &token),
+        Ok(TokenApplyResult::Applied { .. })
+    ));
+    assert!(is_pass(&g, Operation::GitPush), "release opened git push");
+
+    // Poison the session: a dropped observation makes taint unprovable.
+    g.poison();
+    assert!(
+        gate_denies(&g, Operation::GitPush),
+        "poison must deny regardless of a standing release"
+    );
+}
+
+// ── No-scope parity (property test) ──────────────────────────────────────────
+//
+// For graphs with NO scopes and NO compaction, the effective aggregates must
+// equal the plain session aggregates for every operation — proving the
+// refinement only ever *lowers* under full visibility (it never raises, and with
+// nothing to lower it is byte-identical to the historical gate).
+
+use proptest::prelude::*;
+
+/// A small alphabet of observation kinds spanning the confidentiality/integrity
+/// corners the aggregates care about.
+fn obs_kind(i: u8) -> NodeKind {
+    match i % 6 {
+        0 => NodeKind::WebContent,    // Public, Adversarial
+        1 => NodeKind::EnvVar,        // Secret, Trusted
+        2 => NodeKind::Secret,        // Secret, ...
+        3 => NodeKind::FileRead,      // Internal
+        4 => NodeKind::UserPrompt,    // trusted
+        _ => NodeKind::McpToolResult, // Public, Adversarial
+    }
+}
+
+fn op_of(i: u8) -> Operation {
+    Operation::ALL[(i as usize) % Operation::ALL.len()]
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+
+    #[test]
+    fn no_scope_no_compaction_parity(
+        obs in proptest::collection::vec(0u8..6, 0..40),
+        acts in proptest::collection::vec(0u8..13, 0..20),
+    ) {
+        let mut g = FlowGraph::new();
+        // Observations only — NO tokens, so no declass scope is ever recorded.
+        for &o in &obs {
+            g.insert_observation(obs_kind(o), &[], 0).unwrap();
+        }
+        // A few actions (no parents) exercise action nodes too; still no scopes.
+        for &a in &acts {
+            let _ = g.insert_action(op_of(a), &[], 0);
+        }
+        // Well under MAX_GRAPH_NODES, so nothing compacted.
+
+        for op in Operation::ALL {
+            prop_assert_eq!(
+                g.effective_exfiltration_check(op, portcullis::exposure_core::sink_max_conf_for(op)),
+                g.session_exfiltration_check(portcullis::exposure_core::sink_max_conf_for(op)),
+                "effective_exfiltration_check diverged from session for {:?}", op
+            );
+            prop_assert_eq!(
+                g.effective_is_tainted(op),
+                g.is_tainted(),
+                "effective_is_tainted diverged from is_tainted for {:?}", op
+            );
+        }
+    }
+}


### PR DESCRIPTION
## DO NOT MERGE — boot-gated; a human reviews this.

Two-part change to declassification egress. **Strictly fail-closed-improving:** before this PR the Ed25519 token release was *dead* (the apply wrote to a separate, never-populated graph → `NodeNotFound` on the graph egress reads); after it, a signed release opens EXACTLY the declassified node → its signed sinks → for the committed value, and denies everything else.

### (D) Re-home the apply onto the live graph
- `Kernel::apply_declassification_token` now delegates to a private `apply_declassification_token_core(&trusted_keys, &mut graph, token)` that reads `is_release_burned` / `apply_token_verified` / `burn_release` on the **passed** graph.
- New `Kernel::apply_declassification_token_on(&self, &mut graph, token)` applies onto a caller-supplied graph.
- `POST /v1/declassify` locks **kernel, then flow_graph** (matching `http_kernel_decide` / ingest order — no deadlock) and applies onto `state.flow_graph`, the graph the live egress verdict actually reads.

### (A/B/C) Egress honors per-node `DeclassScope`s, fail-closed
- `FlowGraph::effective_exfiltration_check(op, cap)` and `effective_is_tainted(op)` refine the monotonic session ratchet **downward only**, folding over live *observation* nodes via `effective_label(id, op)` (reusing the extracted `mask_admits`).
- New `ever_compacted` guard: once a live-node scan is incomplete, the strict ratchet governs (a scope on a tombstoned node can never argue egress is safe). Not cleared by `reset_session_ceiling`.
- `EgressAggregates` gains default methods (so `FlowTracker` is byte-identical) overridden for `FlowGraph`; `ifc_egress_verdict` routes both the taint and confidentiality checks through the op-aware variants. `is_poisoned` and the carries-data-out/graded structure are untouched.

### Fail-open boundary matrix (all stay Deny/refused after apply)
| case | result |
|---|---|
| C4 flip-back (signed, value-bound, GitPush-scoped) | GitPush Deny → **Pass** |
| (a) substituted value (commitment ≠ H) | `ContentMismatch`, GitPush still Deny |
| (b) unsigned sink CreatePr (Internal cap) | Deny |
| (c) second apply of same token | `DeclassificationReplayed`, burn on the same graph's ledger |
| (c') different token, same node | `AlreadyDeclassified` |
| (d) a second, undeclassified Secret node | GitPush still Deny |
| (e) `poison()` | Deny regardless |
| no-scope / no-compaction parity (proptest) | effective ≡ session for all ops |

### Verification
- `cargo test -p portcullis --features crypto` — green (incl. new `declassify_rehome_egress`, and `declassify_scope` / `flowgraph_flowtracker_parity` / `kernel_token` still green)
- `cargo test -p nucleus-tool-proxy` + `memory_ifc_e2e` — green
- `cargo fmt --all -- --check`, `cargo clippy` (portcullis lib + tool-proxy) — clean
- `scripts/check-mediation.sh`, `scripts/check-north-star-ledger.sh`, `scripts/check-declassify-sink-scope-enforced.sh` — pass
- The extracted **Aeneas slice is untouched** (`mask_admits` / `effective_label` reused; no `.lean` / `extracted/` files in the diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148ebbw4UXypRjhMw3xAQzj