### PR TITLE
audit: ignore RUSTSEC-2026-0253 (lru unsound, transitive)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -25,6 +25,16 @@ ignore = [
     # successor yet; drops when age/i18n-embed-fl migrate off it.
     "RUSTSEC-2026-0173",
 
+    # lru unsound (RUSTSEC-2026-0253, filed 2026-05-12) — potential use-after-free
+    # from lack of panic safety in `LruCache::pop()`. `unsound` class, not a
+    # directly exploitable vulnerability; the UAF requires a panic inside pop() in
+    # a specific usage. Nucleus does not use lru directly — it is transitive via
+    # iroh-blobs (→ nucleus-cli) and ratatui-core (→ exposure-playground, a dev TUI),
+    # both of which pin lru 0.18, so there is no patched version reachable without
+    # an upstream iroh/ratatui bump. Same unsound/transitive/no-patched class as the
+    # rand and proc-macro-error ignores; drops when iroh/ratatui move to a fixed lru.
+    "RUSTSEC-2026-0253",
+
     # tracing-subscriber ANSI escape (RUSTSEC-2025-0055) — transitive via
     # risc0-zkvm → ark-relations. Feature-gated behind `zkvm`, not in default build.
     "RUSTSEC-2025-0055",

--- a/deny.toml
+++ b/deny.toml
@@ -34,6 +34,13 @@ ignore = [
   # version. Not exploitable here: no custom logger in these deps calls rand::rng().
   "RUSTSEC-2026-0097",
 
+  # lru unsound — use-after-free from lack of panic safety in `LruCache::pop()`.
+  # `unsound` class, not directly exploitable (needs a panic inside pop()).
+  # Transitive via iroh-blobs (→ nucleus-cli) and ratatui-core (→ exposure-playground,
+  # a dev TUI), both pinning lru 0.18 — no patched version reachable without an
+  # upstream bump. Drops when iroh/ratatui move to a fixed lru.
+  "RUSTSEC-2026-0253",
+
   # rustls-webpki 0.101.x URI name-constraint / wildcard-name vulns (2026-04-14).
   # Transitive via aws-smithy-http-client 1.1.12 → rustls 0.21 → rustls-webpki 0.101.
   # AWS SDK fix path: BehaviorVersion v2025_01_17+ (hyper 1.x + rustls 0.23).


### PR DESCRIPTION
The strict \`audit\` CI check (actions-rust-lang/audit → cargo-audit) started reddening every PR after the advisory-db picked up **RUSTSEC-2026-0253** — an *unsound* advisory in \`lru\` (\`LruCache::pop()\` lacks panic safety → potential use-after-free). Not caused by any feature PR; it's a transitive-dep advisory.

- **Not directly exploitable** (unsound class; needs a panic inside \`pop()\`).
- **Transitive only** via iroh-blobs (→ nucleus-cli) and ratatui-core (→ exposure-playground, a dev TUI); both pin lru 0.18, so no patched version is reachable without an upstream iroh/ratatui bump.
- Same unsound/transitive/no-patched-version class as the existing \`rand\`/\`proc-macro-error\` ignores.

Added to both \`.cargo/audit.toml\` (read by the strict \`audit\` action) and \`deny.toml\` (Cargo Deny) for consistency. \`cargo audit\` is clean after. Drops when iroh/ratatui adopt a fixed lru.

🤖 Generated with [Claude Code](https://claude.com/claude-code)