### PR TITLE
C6 phase 1b — enforce the mediation lint at zero over the sealed effect boundary

### DIFF
--- a/.github/workflows/dylint-separation.yml
+++ b/.github/workflows/dylint-separation.yml
@@ -24,17 +24,27 @@ name: Dylint (mediation + CB4A separation + identity isolation)
 # `DYLD_*` from child processes. Both passes' READMEs record this; it is why
 # neither has a committed UI baseline. On Linux there is no such problem.
 #
-# WHY NON-BLOCKING TODAY (`continue-on-error`)
+# WHY `mediated` IS NOW ENFORCING (C6 phase 1b)
 #
-# `mediated` has 15 known open findings on `portcullis-effects`, recorded in its
-# README and not yet acted on. Making this job required would either block every
-# unrelated pull request or force those findings to be suppressed to get green —
-# and a suppressed lint is worse than an unrun one, because it looks clean.
+# The pass is scoped to the MEDIATED SET — the sealed agent-effect boundary
+# `portcullis_effects` (`MEDIATED_CRATES` in the lint). Over that set it reports
+# ZERO unmediated-I/O findings today: every raw sink in the effect home is
+# reached only after an `Authority` is demanded by value and spent. So the job
+# gates on that count staying zero, exactly like `cb4a_separation` and
+# `identity-isolation`.
 #
-# So the job reports, and the ratchet below is what makes it mean something: the
-# CB4A pass must stay at ZERO, which it is today. That half IS enforced. When the
-# mediation findings are closed, drop the `continue-on-error` and delete this
-# comment.
+# The earlier "15 open findings" were the host runtime's own infrastructure I/O
+# in transitive workspace deps (config loaders, audit/lineage persistence,
+# keyless-identity fetch, attestation clients, sandbox setup) — NOT
+# agent-attributed effect, and out of scope by the same reasoning that puts
+# jailer spawn and HTTP serving out of scope. Scoping the finding to the effect
+# home makes the enforced claim precise instead of suppressing anything: the
+# closure/unresolved-call reports remain emitted for every crate as an ADVISORY
+# signal, and the gate deliberately does not count them (a higher-order call is a
+# call-graph observation, not an unmediated sink).
+#
+# The gate lives in scripts/check-mediation-dylint.sh (one source of truth), and
+# its `--self-test` proves reds-on-revert on the pinned toolchain every run.
 
 on:
   push:
@@ -139,10 +149,9 @@ jobs:
           fi
 
   mediated:
-    name: mediated (reporting only — see workflow comment)
+    name: mediated (enforced at zero over the sealed effect boundary)
     runs-on: ubuntu-latest
     timeout-minutes: 45
-    continue-on-error: true
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -168,15 +177,25 @@ jobs:
           cp libnucleus_mediation_lint.so \
              "libnucleus_mediation_lint@nightly-2026-04-16-${host}.so"
 
-      - name: Run mediated over the mediated crate set
+      # REDS-ON-REVERT FIRST. The gate proves it can fail on its own subject
+      # before it is trusted to pass: an unmediated raw-I/O sink appended to the
+      # effect home must push the count non-zero. A gate that cannot fail is not
+      # a gate. This runs on the pinned toolchain (the scripts/check-gates-can-fail.sh
+      # job has only stable Rust and cannot exercise a dylint gate).
+      - name: Prove the gate reds on a reverted discharge
         env:
           DYLINT_LIBRARY_PATH: ${{ github.workspace }}/tools/nucleus-mediation-lint/target/debug
-        run: |
-          for crate in portcullis-effects nucleus-node; do
-            echo "::group::$crate"
-            cargo dylint --lib nucleus_mediation_lint -- -p "$crate" 2>&1 || true
-            echo "::endgroup::"
-          done
+        run: scripts/check-mediation-dylint.sh --self-test
+
+      # ZERO unmediated-I/O findings over the mediated set, ENFORCED. `cargo
+      # dylint` exits 0 even when the `Warn` pass reports, so the script counts
+      # the findings rather than trusting exit status, and guards the
+      # compile-failure false-green. Closure/unresolved-call reports are printed
+      # but NOT counted (advisory).
+      - name: Enforce zero unmediated I/O in the sealed effect boundary
+        env:
+          DYLINT_LIBRARY_PATH: ${{ github.workspace }}/tools/nucleus-mediation-lint/target/debug
+        run: scripts/check-mediation-dylint.sh
 
   identity-isolation:
     name: workload_identity_isolation (enforced at zero)

--- a/scripts/check-gates-can-fail.sh
+++ b/scripts/check-gates-can-fail.sh
@@ -368,10 +368,30 @@ UNCOVERED=(
 # at. The remaining two need a Cargo.lock change, which this script will not make.
 UNCOVERED_CEILING=2
 
+# ── Self-falsified elsewhere, not here ────────────────────────────────────
+#
+# These gates PROVE they can fail — but on a toolchain this job does not have, so
+# their reds-on-revert runs in their OWN workflow job rather than through probe()
+# above. They are NOT "uncovered": each has a live falsifier that fails CI if the
+# gate stops detecting its subject. They are listed here so the accounting stays
+# honest (a gate that is neither probed, nor uncovered, nor here would still be
+# flagged UNACCOUNTED) and so the location of each falsifier is on the record.
+#
+#   check-mediation-dylint.sh — needs the pinned dylint nightly + cargo-dylint
+#     (this job runs only stable Rust). Its `--self-test` appends an unmediated
+#     raw-I/O sink to the sealed effect home and asserts the finding count goes
+#     non-zero; it runs in the `mediated` job of dylint-separation.yml, BEFORE the
+#     enforcing run, every CI invocation.
+SELF_FALSIFIED=(
+    "check-mediation-dylint.sh    --self-test in the 'mediated' job (dylint-separation.yml)"
+)
+
 echo
 echo "Covered: $covered gate(s) probed."
 echo "Uncovered: ${#UNCOVERED[@]} (ceiling $UNCOVERED_CEILING) — these have no perturbation yet:"
 for u in "${UNCOVERED[@]}"; do echo "    $u"; done
+echo "Self-falsified in-workflow: ${#SELF_FALSIFIED[@]} — reds-on-revert runs on a toolchain this job lacks:"
+for s in "${SELF_FALSIFIED[@]}"; do echo "    $s"; done
 
 if [[ "${#UNCOVERED[@]}" -gt "$UNCOVERED_CEILING" ]]; then
     echo
@@ -409,6 +429,7 @@ for path in scripts/check-*.sh; do
 
     grep -qE "^probe[[:space:]]+$gate([[:space:]]|$)" "$0" && continue
     printf '%s\n' "${UNCOVERED[@]}" | grep -q "^$gate[[:space:]]" && continue
+    printf '%s\n' "${SELF_FALSIFIED[@]}" | grep -q "^$gate[[:space:]]" && continue
     UNACCOUNTED+=("$gate")
 done
 

--- a/scripts/check-mediation-dylint.sh
+++ b/scripts/check-mediation-dylint.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Enforcing mediation gate (dylint) — the SEALED EFFECT BOUNDARY admits no
+# unmediated raw I/O sink.
+#
+# This is the enforcement half of C6's complete-mediation program. Phase 1a
+# landed the Lean Tier-A theorem (`no_sink_reachable_without_discharge`); this
+# discharges its premise over the real Rust: every publicly reachable path to a
+# raw I/O primitive inside the mediated set passes through a function demanding
+# an `Authority` by value.
+#
+# WHAT IS GATED
+#
+# The `mediated` dylint pass is invoked over `portcullis-effects` — the sealed
+# agent-effect boundary. `cargo dylint -- -p <crate>` compiles and lints the
+# whole workspace dependency closure, but the pass emits the "reaches raw I/O,
+# demands no `Authority`" finding ONLY for crates in its `MEDIATED_CRATES` set
+# (currently `portcullis_effects`). The host runtime's own infrastructure I/O —
+# config loaders, audit/lineage persistence, keyless-identity fetch, attestation
+# clients, sandbox setup — is out of scope by the same reasoning that puts jailer
+# spawn and HTTP serving out of scope: it is not agent-attributed effect. This is
+# a CRATE scope, not a call-site allowlist; within a mediated crate every such
+# site is still reported.
+#
+# WHAT IS NOT GATED (advisory)
+#
+# The pass also reports unresolved calls (`dyn`/fn-pointer/closure) as a
+# call-graph-soundness signal, for EVERY crate. Those are printed but NOT counted
+# here: a higher-order call is a call-graph observation, not an unmediated sink,
+# and the effect home legitimately uses closures (the `harden` spawn hook, the
+# `with_typed_context` callback). Brandon's decision (C6 phase 1b): closure
+# reports stay advisory; only the unmediated-I/O count gates.
+#
+# EXIT-STATUS TRAP
+#
+# `cargo dylint` exits 0 even when the `Warn`-level pass reports, so exit status
+# is NOT the signal — COUNT the findings. A crate that fails to COMPILE reports
+# zero findings, which would be a false green; that is guarded explicitly.
+#
+# REDS-ON-REVERT
+#
+# `--self-test` proves the gate can fail on its own subject: it appends an
+# unmediated raw-I/O sink to the sealed effect home, asserts the count goes
+# non-zero, and restores. Run in the mediated CI job (which has the pinned dylint
+# toolchain) BEFORE the real enforcement. A gate that cannot fail is not a gate.
+#
+# Usage:
+#   DYLINT_LIBRARY_PATH=<dir with built dylib> scripts/check-mediation-dylint.sh
+#   DYLINT_LIBRARY_PATH=<...>                   scripts/check-mediation-dylint.sh --self-test
+set -uo pipefail
+cd "$(git rev-parse --show-toplevel 2>/dev/null || echo .)"
+
+LIB=nucleus_mediation_lint
+# The mediated set's compile entry point. `-p portcullis-effects` compiles and
+# lints portcullis-effects itself plus its whole dependency closure, so the
+# closure's infra crates also pass through the (scoped) pass — which is exactly
+# how we prove the scope holds within it.
+MEDIATED_ENTRY=portcullis-effects
+IO_PATTERN='but demands no `Authority`'
+CLOSURE_PATTERN='cannot see past this'
+
+: "${DYLINT_LIBRARY_PATH:?set DYLINT_LIBRARY_PATH to the directory holding the built ${LIB} dylib}"
+
+# Sets globals IO_TOTAL and COMPILE_FAIL from a run over the mediated entry point.
+count_io() {
+    IO_TOTAL=0
+    COMPILE_FAIL=0
+    local out io clo
+    echo "::group::mediated over ${MEDIATED_ENTRY} (+ dependency closure)"
+    out=$(cargo dylint --lib "$LIB" -- -p "$MEDIATED_ENTRY" 2>&1) || true
+    echo "$out"
+    echo "::endgroup::"
+    if printf '%s\n' "$out" | grep -qE 'could not compile|Compilation failed'; then
+        echo "::error::${MEDIATED_ENTRY} failed to compile under the lint — zero findings would be a false green."
+        COMPILE_FAIL=1
+    fi
+    io=$(printf '%s\n' "$out" | grep -c "$IO_PATTERN" || true)
+    clo=$(printf '%s\n' "$out" | grep -c "$CLOSURE_PATTERN" || true)
+    echo "mediated: ${io} unmediated-I/O finding(s), ${clo} closure/unresolved (advisory, not gated)"
+    IO_TOTAL=$io
+}
+
+self_test() {
+    local target=crates/portcullis-effects/src/lib.rs
+    local backup
+    backup=$(mktemp)
+    cp "$target" "$backup"
+    # Restore on ANY exit — a half-perturbed effect home left behind is worse
+    # than no check.
+    # shellcheck disable=SC2064
+    trap "cp '$backup' '$target'; rm -f '$backup'" EXIT INT TERM
+
+    cat >> "$target" <<'RS'
+
+// --- reds-on-revert probe (appended by scripts/check-mediation-dylint.sh --self-test) ---
+// A publicly reachable raw filesystem sink that demands no Authority — exactly
+// what the enforcing gate exists to forbid inside the sealed effect home. If the
+// gate does NOT red on this, it has stopped detecting its own subject.
+pub fn __mediation_gate_selftest_unmediated_sink(p: &std::path::Path) {
+    let _ = std::fs::write(p, b"");
+}
+RS
+
+    count_io
+    # Restore now so the assertion below runs against a clean tree regardless.
+    cp "$backup" "$target"
+    rm -f "$backup"
+    trap - EXIT INT TERM
+
+    if [ "$COMPILE_FAIL" -ne 0 ]; then
+        echo "::error::self-test could not compile the effect home — cannot prove the gate fires."
+        return 1
+    fi
+    if [ "$IO_TOTAL" -lt 1 ]; then
+        echo "::error::reds-on-revert FAILED: an unmediated raw-I/O sink in portcullis-effects"
+        echo "         produced ${IO_TOTAL} finding(s) (expected >= 1). The enforcing gate"
+        echo "         cannot detect its own subject and is therefore not a gate."
+        return 1
+    fi
+    echo "reds-on-revert OK: an unmediated sink in the effect home produced ${IO_TOTAL} finding(s); the gate fires."
+    return 0
+}
+
+case "${1:-}" in
+    --self-test)
+        self_test
+        exit $?
+        ;;
+    "")
+        count_io
+        if [ "$COMPILE_FAIL" -ne 0 ]; then
+            exit 1
+        fi
+        if [ "$IO_TOTAL" -ne 0 ]; then
+            echo "::error::the sealed effect boundary reached raw I/O without demanding an \
+Authority (${IO_TOTAL} finding(s)). Every path to a raw sink inside portcullis-effects must \
+take an Authority by value and spend it. See tools/nucleus-mediation-lint/README.md."
+            exit 1
+        fi
+        echo "OK: the sealed effect boundary admits no unmediated raw I/O sink (0 findings)."
+        exit 0
+        ;;
+    *)
+        echo "usage: $0 [--self-test]" >&2
+        exit 2
+        ;;
+esac

--- a/tools/nucleus-mediation-lint/src/lib.rs
+++ b/tools/nucleus-mediation-lint/src/lib.rs
@@ -60,7 +60,7 @@ extern crate rustc_span;
 
 use clippy_utils::diagnostics::span_lint_and_help;
 use rustc_data_structures::fx::{FxHashMap, FxHashSet};
-use rustc_hir::def_id::{DefId, LocalDefId};
+use rustc_hir::def_id::{DefId, LOCAL_CRATE, LocalDefId};
 use rustc_hir::intravisit::{FnKind, Visitor, walk_expr};
 use rustc_hir::{Expr, ExprKind, FnDecl};
 use rustc_lint::{LateContext, LateLintPass};
@@ -136,6 +136,39 @@ const DENY_SET: &[&str] = &[
 
 /// The type whose by-value presence in a signature marks a mediation boundary.
 const AUTHORITY_PATH_SUFFIX: &str = "authority::Authority";
+
+/// The **mediated set** — the crates whose unmediated-I/O findings are ENFORCED.
+///
+/// This codifies the "defined set" the module docs and README already declare:
+/// *"'Mediated crates' is a defined set, listed in the CI invocation, not
+/// 'everything'."* Because `cargo dylint -- -p <crate>` compiles and lints every
+/// workspace member in the dependency closure, the pass would otherwise report
+/// the host runtime's own infrastructure I/O — config loaders (`load_from_dir`),
+/// audit/lineage persistence (`JsonlSink`, `MerkleSink`), keyless-identity fetch
+/// (`workload_api`), attestation/randomness clients, and sandbox setup — none of
+/// which is *agent-attributed* effect. That surface is out of scope by the same
+/// reasoning that puts jailer spawn and HTTP serving out of scope.
+///
+/// So the **"reaches raw I/O, demands no `Authority`" finding is emitted only for
+/// a crate in this set** (see [`check_crate_post`]). This is a **crate scope, not
+/// a call-site allowlist**: the pass still reports *every* such site within a
+/// mediated crate — there is no per-call exemption, and the "no call-site
+/// allowlist by design" posture is preserved. Widening the guarantee is done by
+/// adding a crate here, in the open, not by suppressing a call site.
+///
+/// The closure-soundness reports (unresolved `dyn`/fn-pointer/closure calls) are
+/// **not** scoped by this set: they remain emitted for every crate as an
+/// advisory signal, and the enforcing CI job deliberately does not gate on them
+/// (a higher-order call is a call-graph observation, not an unmediated sink).
+///
+/// Crate names are the **lib crate** spelling (hyphens become underscores):
+/// package `portcullis-effects` is crate `portcullis_effects`.
+const MEDIATED_CRATES: &[&str] = &[
+    // The sealed agent-effect boundary: every raw sink here is reached only after
+    // an `Authority` is demanded by value and spent. This is the crate the Lean
+    // Tier-A mediation theorem is stated over.
+    "portcullis_effects",
+];
 
 /// Strip generic argument lists from a `def_path_str` rendering.
 ///
@@ -221,7 +254,7 @@ struct CallScan<'a, 'tcx> {
 }
 
 impl<'a, 'tcx> CallScan<'a, 'tcx> {
-    fn record(&mut self, did: DefId, span: Span) {
+    fn record(&mut self, did: DefId, _span: Span) {
         let path = strip_generics(&self.cx.tcx.def_path_str(did));
         if self.direct_io.is_none()
             && let Some(hit) = DENY_SET.iter().find(|p| path.starts_with(**p))
@@ -274,8 +307,10 @@ impl<'a, 'tcx> Visitor<'tcx> for CallScan<'a, 'tcx> {
                 } else {
                     // Calling a value: a function pointer or closure variable. seL4
                     // forbids exactly this so its call graph stays static.
-                    self.unresolved
-                        .push((ex.span, "call through a function pointer or value".to_string()));
+                    self.unresolved.push((
+                        ex.span,
+                        "call through a function pointer or value".to_string(),
+                    ));
                 }
             }
             ExprKind::MethodCall(..) => {
@@ -286,9 +321,10 @@ impl<'a, 'tcx> Visitor<'tcx> for CallScan<'a, 'tcx> {
                         .push((ex.span, "unresolved method call".to_string())),
                 }
             }
-            ExprKind::InlineAsm(_) => self
-                .unresolved
-                .push((ex.span, "inline `asm!` — opaque to the call graph".to_string())),
+            ExprKind::InlineAsm(_) => self.unresolved.push((
+                ex.span,
+                "inline `asm!` — opaque to the call graph".to_string(),
+            )),
             // Descend into closure bodies.
             //
             // An `async fn`'s body in HIR IS a closure, and `check_fn` returns
@@ -335,10 +371,7 @@ impl<'tcx> LateLintPass<'tcx> for Mediated {
         };
         scan.visit_body(body);
 
-        let is_public = cx
-            .tcx
-            .effective_visibilities(())
-            .is_exported(def_id);
+        let is_public = cx.tcx.effective_visibilities(()).is_exported(def_id);
 
         self.facts.borrow_mut().insert(
             def_id,
@@ -361,6 +394,17 @@ impl<'tcx> LateLintPass<'tcx> for Mediated {
     /// has been seen. This is the whole reason the pass accumulates.
     fn check_crate_post(&mut self, cx: &LateContext<'tcx>) {
         let facts = self.facts.borrow();
+
+        // Is the crate currently under compilation in the mediated set? The pass
+        // is invoked once per workspace member in the dependency closure, so this
+        // is the gate that keeps the ENFORCED "unmediated I/O" finding scoped to
+        // the agent-effect boundary rather than the host runtime's own infra I/O.
+        // See [`MEDIATED_CRATES`]. Unresolved-call reports below are NOT scoped by
+        // this — they stay advisory for every crate.
+        let crate_is_mediated = {
+            let name = cx.tcx.crate_name(LOCAL_CRATE);
+            MEDIATED_CRATES.contains(&name.as_str())
+        };
 
         // Least fixpoint of "reaches raw I/O without crossing a boundary".
         //
@@ -394,7 +438,11 @@ impl<'tcx> LateLintPass<'tcx> for Mediated {
             // Report at the crate boundary. An internal helper reaching I/O is
             // fine so long as every public path to it crosses a boundary; the
             // public function is where that stops being true.
-            if f.is_public && unmediated.contains(did) {
+            //
+            // Scoped to the mediated set: outside it, raw I/O is the host
+            // runtime's own infrastructure (config load, audit persistence,
+            // identity/attestation, sandbox setup), not agent-attributed effect.
+            if crate_is_mediated && f.is_public && unmediated.contains(did) {
                 let detail = match &f.direct_io {
                     Some(hit) => format!("reaches raw I/O: {hit}"),
                     None => "reaches raw I/O transitively through its callees".to_string(),


### PR DESCRIPTION
## What

Flips the `mediated` dylint job from advisory (`continue-on-error`) to **enforcing-at-count-zero**, scoped to the agent-effect boundary. This is the enforcement half of C6's complete-mediation program; Phase 1a (#2241) landed the Lean Tier-A theorem `no_sink_reachable_without_discharge`, and this discharges its premise over the real Rust as a machine-checked, reds-on-revert gate.

## The finding set (enumerated on the pinned toolchain)

Ran the pass over the exact CI toolchain (`nightly-2026-04-16` + `cargo-dylint 6.0.1`). Result:

- **`portcullis-effects` and `nucleus-node` are already CLEAN** of unmediated-I/O findings — every raw sink in the effect home is reached only after an `Authority` is demanded by value and spent.
- The 42 `reaches raw I/O` findings the pass surfaced are all in **transitive workspace deps** and are the host runtime's **own infrastructure I/O** — config loaders (`load_from_dir`), audit/lineage persistence (`JsonlSink`/`MerkleSink`), keyless-identity fetch (`workload_api`), attestation/randomness clients, sandbox setup. None is *agent-attributed* effect; it is out of scope by the same reasoning that puts jailer spawn and HTTP serving out of scope.

So the gate is scoped to the **mediated set** (the sealed effect boundary) rather than the whole transitive workspace, and over that set it is at zero today.

## Changes

- **lint** (`tools/nucleus-mediation-lint/src/lib.rs`): add `MEDIATED_CRATES` (seeded with `portcullis_effects`). The `demands no Authority` I/O finding is emitted **only for a crate in that set** — a **crate scope, not a call-site allowlist** (every site inside a mediated crate is still reported; the "no call-site allowlist by design" posture is preserved). Closure / unresolved-call reports remain emitted for every crate as an **advisory** signal.
- **`scripts/check-mediation-dylint.sh`** (new): single source of truth for the gate. Counts only unmediated-I/O findings (compile-failure false-green guarded); prints the advisory closure count without gating on it. `--self-test` proves reds-on-revert.
- **workflow** (`dylint-separation.yml`): `mediated` job is enforcing — runs `--self-test` (reds-on-revert on the pinned toolchain) **before** the enforcing run; `continue-on-error` removed.
- **`scripts/check-gates-can-fail.sh`**: accounts for the dylint gate as *self-falsified in-workflow* (its reds-on-revert needs the pinned toolchain the `gates-can-fail` job lacks), keeping the accounting honest without a false probe.

## Decision (Brandon, relayed)

Scope to the effect home; closure/unresolved-call reports stay **advisory** (not gated) — a higher-order call is a call-graph observation, not an unmediated sink, and the effect home legitimately uses closures (the `harden` spawn hook, the `with_typed_context` callback).

## Verified on a Linux oracle with the exact pinned toolchain

- enforce run: **0** unmediated-I/O findings (green)
- `--self-test`: **1** finding on the injected unmediated sink (gate fires), tree restored clean

The dylint job is CI-only (local != CI), so the `mediated` job's state on this PR is the source of truth — see checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148ebbw4UXypRjhMw3xAQzj