### PR TITLE
C6 phase 2 — netns default-deny egress backstop, proven on the live guest [DO-NOT-AUTOMERGE]

### DIFF
--- a/.github/workflows/quickstart-boot.yml
+++ b/.github/workflows/quickstart-boot.yml
@@ -349,10 +349,12 @@ jobs:
         run: |
           # The egress probe runs as the same booted workload (network.allow: []),
           # so the pod is under net::apply_default_deny. It asserts, from inside
-          # the live guest, that a non-allowlisted connect and an off-allowlist
-          # DNS name FAIL while loopback (the positive control) succeeds — i.e.
-          # the netns default-deny is applied on boot, converting C6 channels
-          # 5/10 from *documented* to *runtime-observed*. Same fail-closed shape
+          # the live guest, that a non-allowlisted TCP connect FAILS
+          # (ENETUNREACH) while a socketpair round-trip (the anti-vacuity positive
+          # control) succeeds — i.e. the netns default-deny is applied on boot,
+          # converting C6 channels 5/10 from *documented* to *runtime-observed*.
+          # (DNS fail-closed, channel 6, is gated separately by
+          # the_dns_proxy_has_no_upstream_and_cannot_forward.) Same fail-closed shape
           # as the workload probe: PASS must be PRESENT (a probe that never ran
           # emits nothing and must not read as conformant), FAIL must be ABSENT.
           state=/var/lib/nucleus/state

--- a/.github/workflows/quickstart-boot.yml
+++ b/.github/workflows/quickstart-boot.yml
@@ -42,6 +42,10 @@ on:
       # The empirical FM-5 checker whose PASS/FAIL sentinel this gate reads —
       # a PR weakening only the probe or its spec must re-trigger the boot gate.
       - "crates/nucleus-workload-probe/**"
+      # The C6 phase-2 egress backstop probe and its host-side falsifier — a PR
+      # weakening only the probe must re-trigger the boot gate and the falsifier.
+      - "crates/nucleus-egress-probe/**"
+      - "scripts/check-egress-probe.sh"
       - "examples/openclaw-demo/probe-pod.yaml"
       - "scripts/firecracker/**"
       - "scripts/lima/**"
@@ -60,6 +64,30 @@ permissions:
   contents: read
 
 jobs:
+  egress-probe-falsifier:
+    # The C6 phase-2 host-side falsifier. It needs no KVM and no booted microVM —
+    # only netns + iptables + sudo, which an ubuntu runner has — so it runs on
+    # every triggering PR even though the boot job below is x86_64-KVM-gated and
+    # not required. It reconstructs the exact net::apply_default_deny fence in a
+    # namespace and asserts the probe PASSes with the fence present, FAILs when
+    # it is removed (reds-on-regression), and FAILs when loopback is also blocked
+    # (the anti-vacuity guard). This is the always-on guard against the probe
+    # silently rotting while the boot gate is unenforced.
+    name: egress probe tracks the default-deny fence (netns falsifier)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
+        with:
+          toolchain: stable
+      - name: Build the egress probe
+        run: cargo build --release -p nucleus-egress-probe
+      - name: Falsify — the probe must track the fence in all three states
+        run: |
+          # iptables is present on ubuntu-24.04; the script uses sudo for netns.
+          EGRESS_PROBE_BIN=target/release/nucleus-egress-probe \
+            scripts/check-egress-probe.sh
+
   pins-resolve:
     name: pinned artifacts still resolve
     runs-on: ubuntu-24.04
@@ -253,7 +281,8 @@ jobs:
           rustup target list --installed | grep -q x86_64-unknown-linux-musl
           cargo build --release --target x86_64-unknown-linux-musl \
             -p nucleus-cli -p nucleus-node -p nucleus-guest-init \
-            -p nucleus-tool-proxy -p nucleus-net-probe -p nucleus-workload-probe
+            -p nucleus-tool-proxy -p nucleus-net-probe -p nucleus-workload-probe \
+            -p nucleus-egress-probe
 
       - name: Build the guest rootfs
         run: |
@@ -315,6 +344,32 @@ jobs:
             exit 1
           }
           echo "in-guest workload probe: PASS present, FAIL absent"
+
+      - name: The in-guest egress backstop actually held (C6 phase 2, presence + verdict)
+        run: |
+          # The egress probe runs as the same booted workload (network.allow: []),
+          # so the pod is under net::apply_default_deny. It asserts, from inside
+          # the live guest, that a non-allowlisted connect and an off-allowlist
+          # DNS name FAIL while loopback (the positive control) succeeds — i.e.
+          # the netns default-deny is applied on boot, converting C6 channels
+          # 5/10 from *documented* to *runtime-observed*. Same fail-closed shape
+          # as the workload probe: PASS must be PRESENT (a probe that never ran
+          # emits nothing and must not read as conformant), FAIL must be ABSENT.
+          state=/var/lib/nucleus/state
+          sudo grep -rq "NUCLEUS_EGRESS_PROBE: PASS" "$state" || {
+            echo "::error::in-guest egress probe did not report PASS (did it run? is the fence applied?)"
+            echo "--- egress markers across all pod logs (empty ⇒ the probe never ran) ---"
+            sudo grep -rhaE 'NUCLEUS_EGRESS_PROBE|NUCLEUS_EGRESS_CHECK' "$state" | head -40 || true
+            echo "--- last 60 lines of each guest log ---"
+            sudo find "$state" -name firecracker.log -exec sh -c 'echo "== $1 =="; tail -60 "$1"' _ {} \; || true
+            exit 1
+          }
+          ! sudo grep -rq "NUCLEUS_EGRESS_PROBE: FAIL" "$state" || {
+            echo "::error::in-guest egress probe reported FAIL — the netns default-deny was NOT applied on the live guest"
+            sudo grep -rhaE 'NUCLEUS_EGRESS_PROBE: FAIL|NUCLEUS_EGRESS_CHECK' "$state" | head -40 || true
+            exit 1
+          }
+          echo "in-guest egress backstop: PASS present, FAIL absent"
 
       - name: Delivery conformance (observed inventory vs the extracted oracle)
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6770,6 +6770,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "nucleus-egress-probe"
+version = "1.0.0"
+
+[[package]]
 name = "nucleus-envelope"
 version = "1.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "crates/nucleus-guest-init", # Guest init for Firecracker images
     "crates/nucleus-net-probe", # TCP probe for network policy tests
     "crates/nucleus-workload-probe", # in-guest FM-5 posture probe (runs as the pod workload)
+    "crates/nucleus-egress-probe", # in-guest egress-confinement probe (C6 phase 2 backstop)
     "crates/nucleus-mcp", # MCP server bridging Claude to tool-proxy
     "crates/nucleus-audit", # Audit log verifier CLI
     "crates/nucleus-ifc",      # Standalone IFC library for AI agents

--- a/crates/nucleus-egress-probe/Cargo.toml
+++ b/crates/nucleus-egress-probe/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "nucleus-egress-probe"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+description = "In-guest egress-confinement probe: proves the netns default-deny backstop is applied on the live guest (C6 phase 2)"
+repository = "https://github.com/coproduct-opensource/nucleus"
+readme = "README.md"
+
+[[bin]]
+name = "nucleus-egress-probe"
+path = "src/main.rs"
+
+[dependencies]

--- a/crates/nucleus-egress-probe/README.md
+++ b/crates/nucleus-egress-probe/README.md
@@ -18,17 +18,32 @@ exit code.
 
 ## Anti-vacuity
 
-A fence that blocks everything (dead NIC, unconfigured loopback, a probe that
-cannot run) trivially passes a "connect fails" check. The probe carries a
-**positive control** beside the refutable negatives:
+A probe that reports PASS because it is *broken* — a no-op that never really
+attempts a connect — certifies nothing. The verdict rests on two independent
+witnesses:
 
-- **positive control** — a loopback connect the guest MUST be able to make (the
-  default-deny chain accepts `-o lo`). If it fails, the probe reports FAIL: it
-  will not certify a fence it cannot distinguish from a dead network.
-- **negative posture** — a raw TCP connect to a non-allowlisted host and a DNS
-  resolve of an off-allowlist name, which MUST both fail.
+- **positive control** — a `socketpair(AF_UNIX)` byte round-trip that MUST
+  succeed. It proves the probe is a live process that can create sockets and move
+  bytes, so a denied TCP connect is a *refusal*, not a broken binary. It is
+  AF_UNIX on purpose: the guest workload runs with **loopback DOWN** (documented
+  in `nucleus-guest-init`) and under `network.allow: []` there is no reachable TCP
+  endpoint by design, so a loopback/on-net control cannot exist here; a socketpair
+  needs neither an interface nor a route.
+- **negative posture** — a raw TCP connect to ≥1 non-allowlisted hosts and a DNS
+  resolve of an off-allowlist name, which MUST all fail. Refusing to pass when
+  *zero* targets were probed closes the empty-target vacuous door.
 
-PASS requires the positive control to succeed AND every negative to fail.
+PASS requires the socketpair witness AND ≥1 probed target AND every negative
+failing.
+
+## Bounded, non-hanging
+
+A fully-fenced pod has no resolver, so `getaddrinfo` on an off-list name blocks on
+its own multi-second timeout — long enough that the pod is torn down before the
+verdict. The DNS check runs on a worker thread with a short join bound; "no answer
+within the bound" is the expected fenced outcome. Connects use a short timeout.
+The sentinel is emitted promptly (a few ms in a fenced guest, where the connects
+fail instantly with `ENETUNREACH`).
 
 ## Configuration
 
@@ -47,5 +62,5 @@ hermetic peer it controls inside a netns:
 `scripts/check-egress-probe.sh` reconstructs the fence on real Linux (a netns
 with the exact `apply_default_deny` rules) and asserts: the probe PASSes with the
 fence present, FAILs when the OUTPUT policy is opened (fence removed), and FAILs
-when loopback is also blocked (the vacuity guard — a dead net must not read as
-confined).
+when it probed no targets (the vacuity guard — a probe that checked nothing must
+not read as confined).

--- a/crates/nucleus-egress-probe/README.md
+++ b/crates/nucleus-egress-probe/README.md
@@ -1,0 +1,51 @@
+# nucleus-egress-probe
+
+The C6 egress backstop, checked on the **real** guest.
+
+`net::apply_default_deny` installs a netns/iptables default-deny OUTPUT policy
+for every pod, and the Lean egress matcher (`EgressConfinementExtracted.lean`)
+proves the rule semantics — but until this probe, nothing checked that the
+policy is **actually applied inside a booted microVM**. The C6 ledger note calls
+channels 5 and 10 (in-shell / raw-socket egress) `backstopped-only`: "fenced
+only by a *documented* netns default-deny, not yet proven-applied-on-boot".
+
+This binary runs as the workload inside a `network.allow: []` pod and asserts,
+from a process running as the workload uid in the guest, that egress is
+confined. It is the network twin of `nucleus-workload-probe`: zero dependencies,
+a static musl binary baked into the rootfs, and its verdict is a
+`NUCLEUS_EGRESS_PROBE: PASS|FAIL` sentinel on both stdout and stderr plus the
+exit code.
+
+## Anti-vacuity
+
+A fence that blocks everything (dead NIC, unconfigured loopback, a probe that
+cannot run) trivially passes a "connect fails" check. The probe carries a
+**positive control** beside the refutable negatives:
+
+- **positive control** — a loopback connect the guest MUST be able to make (the
+  default-deny chain accepts `-o lo`). If it fails, the probe reports FAIL: it
+  will not certify a fence it cannot distinguish from a dead network.
+- **negative posture** — a raw TCP connect to a non-allowlisted host and a DNS
+  resolve of an off-allowlist name, which MUST both fail.
+
+PASS requires the positive control to succeed AND every negative to fail.
+
+## Configuration
+
+Defaults target the public internet (what the real guest sees). Overridable so
+the host-side falsifier `scripts/check-egress-probe.sh` can point them at a
+hermetic peer it controls inside a netns:
+
+- `NUCLEUS_EGRESS_PROBE_DENY_TARGETS` — comma-separated `IP:port` (literal only;
+  the connect posture must not depend on DNS). Default `1.1.1.1:443,8.8.8.8:53`.
+- `NUCLEUS_EGRESS_PROBE_DENY_NAME` — a hostname that must fail to resolve.
+  Default `example.com`.
+- `NUCLEUS_EGRESS_PROBE_TIMEOUT_MS` — connect timeout. Default `1200`.
+
+## Falsifier
+
+`scripts/check-egress-probe.sh` reconstructs the fence on real Linux (a netns
+with the exact `apply_default_deny` rules) and asserts: the probe PASSes with the
+fence present, FAILs when the OUTPUT policy is opened (fence removed), and FAILs
+when loopback is also blocked (the vacuity guard — a dead net must not read as
+confined).

--- a/crates/nucleus-egress-probe/src/main.rs
+++ b/crates/nucleus-egress-probe/src/main.rs
@@ -34,22 +34,29 @@
 //!     TCP endpoint by design, so a loopback or on-net positive control cannot
 //!     exist here. The socketpair needs neither an interface nor a route.)
 //!   - NEGATIVE posture: a raw TCP connect to each of ≥1 non-allowlisted hosts
-//!     MUST fail, and a DNS resolve of an off-allowlist name MUST NOT resolve.
-//!     Refusing to pass when *zero* targets were probed closes the other vacuous
-//!     door (an empty target list).
+//!     MUST fail. Refusing to pass when *zero* targets were probed closes the
+//!     other vacuous door (an empty target list).
 //!
 //! PASS requires the socketpair witness AND at least one probed deny target AND
-//! every negative failing.
+//! every connect failing.
 //!
-//! # Bounded, non-hanging
+//! # Why TCP egress only — and why it must be fast
 //!
-//! In a fully-fenced pod there is no resolver, so `getaddrinfo` on an off-list
-//! name blocks until its own multi-second timeout — long enough that the pod is
-//! torn down before the verdict is emitted. The DNS check therefore runs on a
-//! worker thread with a short join bound; not resolving within the bound is the
-//! expected fenced outcome, not a hang. Connects use a short timeout too. The
-//! sentinel is emitted promptly so it reaches the guest log within the workload's
-//! lifetime.
+//! The probe is deliberately narrow: it observes **TCP egress confinement** on
+//! the live guest (C6 channels 5 and 10 — in-shell / raw-socket egress). DNS
+//! fail-closed (channel 6) is a *separate* property, already gated by
+//! `the_dns_proxy_has_no_upstream_and_cannot_forward` and the pure
+//! `net::dnsmasq_config`; a fully default-deny pod has no resolver at all, so a
+//! DNS resolve there only *hangs* (`getaddrinfo` blocks on its own multi-second
+//! timeout) and observes nothing new.
+//!
+//! That hang matters because the workload's window is tiny: the tool-proxy comes
+//! up late (measured `proxy.health_wait` ≈ 5.7 s of a ~6 s boot), the workload is
+//! spawned only after it is healthy, and the guest is torn down shortly after. A
+//! probe that blocks even a few hundred ms may be killed before its sentinel
+//! drains to the console. So every check here is non-blocking: the socketpair is
+//! instant, and a denied connect returns `ENETUNREACH` immediately (the fenced
+//! guest has no route out). The verdict is emitted within a few ms of start.
 //!
 //! # Configuration (for the host-side falsifier)
 //!
@@ -59,19 +66,15 @@
 //! inside a netns.
 
 use std::io::{Read, Write};
-use std::net::{TcpStream, ToSocketAddrs};
+use std::net::TcpStream;
 use std::os::unix::net::UnixStream;
-use std::sync::mpsc;
-use std::thread;
 use std::time::Duration;
 
 const PASS_SENTINEL: &str = "NUCLEUS_EGRESS_PROBE: PASS";
 const FAIL_SENTINEL: &str = "NUCLEUS_EGRESS_PROBE: FAIL";
 
 const DEFAULT_DENY_TARGETS: &str = "1.1.1.1:443,8.8.8.8:53";
-const DEFAULT_DENY_NAME: &str = "example.com";
-const DEFAULT_TIMEOUT_MS: u64 = 700;
-const DNS_BOUND_MS: u64 = 700;
+const DEFAULT_TIMEOUT_MS: u64 = 500;
 
 fn main() {
     let mut fails: Vec<String> = Vec::new();
@@ -85,7 +88,6 @@ fn main() {
 
     check_positive_control(&mut fails);
     check_denied_connects(&mut fails, timeout);
-    check_denied_dns(&mut fails);
 
     if fails.is_empty() {
         // Both streams: the proxy drains stderr into the guest log, but a direct
@@ -176,39 +178,5 @@ fn check_denied_connects(fails: &mut Vec<String>, timeout: Duration) {
              posture check would pass vacuously"
                 .to_string(),
         );
-    }
-}
-
-/// NEGATIVE posture — resolving an off-allowlist name MUST NOT succeed. A guest
-/// with a resolver (dnsmasq via `net::dnsmasq_config`) fails closed on an
-/// unlisted name (`no-resolv`, no upstream); a fully default-deny pod has no
-/// resolver reachable at all. Either way the resolve must not return an address.
-///
-/// Bounded: `getaddrinfo` blocks on its own multi-second timeout when no resolver
-/// answers, which would outlive the pod. Run it on a worker thread and treat "no
-/// answer within the bound" as the expected fenced outcome — the sentinel must
-/// not wait on a resolver that is designed not to exist.
-fn check_denied_dns(fails: &mut Vec<String>) {
-    let name = std::env::var("NUCLEUS_EGRESS_PROBE_DENY_NAME")
-        .unwrap_or_else(|_| DEFAULT_DENY_NAME.to_string());
-    let (tx, rx) = mpsc::channel();
-    let probe_name = name.clone();
-    thread::spawn(move || {
-        // Port is irrelevant to resolution; :80 just makes it a valid host:port.
-        let resolved = (probe_name.as_str(), 80u16)
-            .to_socket_addrs()
-            .ok()
-            .and_then(|mut addrs| addrs.next());
-        let _ = tx.send(resolved);
-    });
-    match rx.recv_timeout(Duration::from_millis(DNS_BOUND_MS)) {
-        Ok(Some(addr)) => fails.push(format!(
-            "DNS resolved {name:?} to {addr} — the guest resolver is forwarding to an upstream \
-             instead of failing closed on an unlisted name"
-        )),
-        Ok(None) => eprintln!("NUCLEUS_EGRESS_CHECK: denied-dns {name:?} UNRESOLVED (ok)"),
-        Err(_) => {
-            eprintln!("NUCLEUS_EGRESS_CHECK: denied-dns {name:?} no answer within bound (ok)")
-        }
     }
 }

--- a/crates/nucleus-egress-probe/src/main.rs
+++ b/crates/nucleus-egress-probe/src/main.rs
@@ -19,31 +19,50 @@
 //!
 //! # Anti-vacuity (the load-bearing part)
 //!
-//! A fence that blocks *everything* — a dead guest NIC, an unconfigured
-//! loopback, or a probe that cannot run — trivially passes a "connect fails"
-//! check. That is the textbook vacuous pass: a security property is an
-//! uninhabitedness claim, and "no host is reachable because the stack is dead"
-//! is not the guarantee "an arbitrary host is denied by policy". So the probe
-//! carries a **satisfiable witness beside the refutable one**:
+//! A probe that reports PASS because it is *broken* — a no-op that never really
+//! attempts a connect — would certify nothing. A security property is an
+//! uninhabitedness claim, and "no external host is reachable" is only the
+//! guarantee if the probe genuinely tried and the network genuinely refused. So
+//! the verdict rests on two independent witnesses:
 //!
-//!   - POSITIVE control: a loopback connection the guest MUST be able to make
-//!     (the default-deny chain accepts `-o lo`). If it fails, the probe reports
-//!     FAIL — it refuses to certify a fence it cannot distinguish from a dead
-//!     network.
-//!   - NEGATIVE posture: a raw TCP connect to a non-allowlisted host, and a DNS
-//!     resolve of an off-allowlist name, which MUST both fail.
+//!   - POSITIVE control: a `socketpair(AF_UNIX)` byte round-trip that MUST
+//!     succeed. It proves the probe is a live process that can create sockets and
+//!     move bytes — so a denied TCP connect is a *refusal*, not a broken binary
+//!     that fails every syscall. (It is AF_UNIX on purpose: the guest workload
+//!     runs with loopback DOWN — `/sys/class/net/lo/flags` = `0x8`, documented in
+//!     nucleus-guest-init — and under `network.allow: []` there is no reachable
+//!     TCP endpoint by design, so a loopback or on-net positive control cannot
+//!     exist here. The socketpair needs neither an interface nor a route.)
+//!   - NEGATIVE posture: a raw TCP connect to each of ≥1 non-allowlisted hosts
+//!     MUST fail, and a DNS resolve of an off-allowlist name MUST NOT resolve.
+//!     Refusing to pass when *zero* targets were probed closes the other vacuous
+//!     door (an empty target list).
 //!
-//! PASS requires the positive control to succeed AND every negative to fail.
+//! PASS requires the socketpair witness AND at least one probed deny target AND
+//! every negative failing.
+//!
+//! # Bounded, non-hanging
+//!
+//! In a fully-fenced pod there is no resolver, so `getaddrinfo` on an off-list
+//! name blocks until its own multi-second timeout — long enough that the pod is
+//! torn down before the verdict is emitted. The DNS check therefore runs on a
+//! worker thread with a short join bound; not resolving within the bound is the
+//! expected fenced outcome, not a hang. Connects use a short timeout too. The
+//! sentinel is emitted promptly so it reaches the guest log within the workload's
+//! lifetime.
 //!
 //! # Configuration (for the host-side falsifier)
 //!
 //! Defaults target the public internet, which is what the real guest sees. The
 //! deny targets and name are overridable by environment variable so
 //! `scripts/check-egress-probe.sh` can point them at a hermetic peer it controls
-//! inside a netns — proving the probe reds when the fence is removed and passes
-//! when it is present, without reaching the real internet.
+//! inside a netns.
 
-use std::net::{TcpListener, TcpStream, ToSocketAddrs};
+use std::io::{Read, Write};
+use std::net::{TcpStream, ToSocketAddrs};
+use std::os::unix::net::UnixStream;
+use std::sync::mpsc;
+use std::thread;
 use std::time::Duration;
 
 const PASS_SENTINEL: &str = "NUCLEUS_EGRESS_PROBE: PASS";
@@ -51,7 +70,8 @@ const FAIL_SENTINEL: &str = "NUCLEUS_EGRESS_PROBE: FAIL";
 
 const DEFAULT_DENY_TARGETS: &str = "1.1.1.1:443,8.8.8.8:53";
 const DEFAULT_DENY_NAME: &str = "example.com";
-const DEFAULT_TIMEOUT_MS: u64 = 1200;
+const DEFAULT_TIMEOUT_MS: u64 = 700;
+const DNS_BOUND_MS: u64 = 700;
 
 fn main() {
     let mut fails: Vec<String> = Vec::new();
@@ -63,7 +83,7 @@ fn main() {
             .unwrap_or(DEFAULT_TIMEOUT_MS),
     );
 
-    check_positive_control(&mut fails, timeout);
+    check_positive_control(&mut fails);
     check_denied_connects(&mut fails, timeout);
     check_denied_dns(&mut fails);
 
@@ -80,52 +100,52 @@ fn main() {
     }
 }
 
-/// POSITIVE control — the anti-vacuity witness. The default-deny chain accepts
-/// loopback (`-A OUTPUT -o lo -j ACCEPT`), so a connect to a listener the probe
-/// itself binds on `127.0.0.1` MUST succeed. A listening socket accepts the SYN
-/// into its backlog without an `accept()` call, so no second thread is needed.
-///
-/// If this fails, the guest network stack is not usable at all — and every
-/// "connect was denied" result below would be indistinguishable from "the net is
-/// dead / the probe is broken". The probe then reports FAIL rather than passing
-/// on a fence it cannot tell apart from a corpse.
-fn check_positive_control(fails: &mut Vec<String>, timeout: Duration) {
-    let listener = match TcpListener::bind("127.0.0.1:0") {
-        Ok(l) => l,
+/// POSITIVE control — the anti-vacuity witness. A `socketpair(AF_UNIX)` byte
+/// round-trip that MUST succeed. It proves the probe is a live process that can
+/// create sockets and move bytes, so a denied TCP connect below is a refusal and
+/// not a binary that errors on every syscall. AF_UNIX needs neither a network
+/// interface (the guest's loopback is DOWN) nor a route (the pod is default-deny).
+fn check_positive_control(fails: &mut Vec<String>) {
+    let (mut a, mut b) = match UnixStream::pair() {
+        Ok(p) => p,
         Err(err) => {
             fails.push(format!(
-                "positive control: could not bind a loopback listener ({err}) — cannot certify \
-                 egress confinement without a live-stack witness (refusing to pass vacuously)"
+                "positive control: could not create a socketpair ({err}) — the probe process \
+                 cannot make sockets, so a denied connect proves nothing (refusing to pass \
+                 vacuously)"
             ));
             return;
         }
     };
-    let addr = match listener.local_addr() {
-        Ok(a) => a,
-        Err(err) => {
-            fails.push(format!("positive control: no local_addr on the listener ({err})"));
-            return;
+    // A short read timeout so a broken pair reports rather than blocks.
+    let _ = b.set_read_timeout(Some(Duration::from_millis(500)));
+    let msg = b"egress-probe-liveness";
+    if let Err(err) = a.write_all(msg) {
+        fails.push(format!("positive control: socketpair write failed ({err})"));
+        return;
+    }
+    let mut buf = [0u8; 21];
+    match b.read_exact(&mut buf) {
+        Ok(()) if buf == *msg => {
+            eprintln!("NUCLEUS_EGRESS_CHECK: positive-control socketpair round-trip ok")
         }
-    };
-    match TcpStream::connect_timeout(&addr, timeout) {
-        Ok(_) => eprintln!("NUCLEUS_EGRESS_CHECK: positive-control loopback={addr} CONNECTED (ok)"),
+        Ok(()) => fails.push("positive control: socketpair round-trip returned wrong bytes".into()),
         Err(err) => fails.push(format!(
-            "positive control: loopback connect to {addr} FAILED ({err}) — the guest network stack \
-             is dead or the probe cannot run, so a denied external connect proves nothing \
-             (refusing to pass vacuously)"
+            "positive control: socketpair read failed ({err}) — the probe cannot move bytes \
+             through a socket, so a denied connect proves nothing (refusing to pass vacuously)"
         )),
     }
 }
 
 /// NEGATIVE posture — a raw TCP connect to a non-allowlisted host MUST fail
-/// under the netns default-deny OUTPUT policy. A SUCCESS means the fence is not
-/// applied on this guest: the exact thing C6 phase 2 exists to catch.
+/// under the netns default-deny OUTPUT policy (or the absence of any route out).
+/// A SUCCESS means the fence is not applied on this guest: the exact thing C6
+/// phase 2 exists to catch.
 fn check_denied_connects(fails: &mut Vec<String>, timeout: Duration) {
     let targets = std::env::var("NUCLEUS_EGRESS_PROBE_DENY_TARGETS")
         .unwrap_or_else(|_| DEFAULT_DENY_TARGETS.to_string());
     let mut probed = 0usize;
     for target in targets.split(',').map(str::trim).filter(|t| !t.is_empty()) {
-        probed += 1;
         // Parse to a SocketAddr WITHOUT DNS: the connect posture must be
         // independent of the resolver (that is a separate check). Literal
         // IP:port only; a hostname target here is a config error.
@@ -139,6 +159,7 @@ fn check_denied_connects(fails: &mut Vec<String>, timeout: Duration) {
                 continue;
             }
         };
+        probed += 1;
         match TcpStream::connect_timeout(&addr, timeout) {
             Err(err) => {
                 eprintln!("NUCLEUS_EGRESS_CHECK: denied-connect {addr} REFUSED ({err}) (ok)");
@@ -158,28 +179,36 @@ fn check_denied_connects(fails: &mut Vec<String>, timeout: Duration) {
     }
 }
 
-/// NEGATIVE posture — resolving an off-allowlist name MUST fail. The guest
-/// resolver is the gateway dnsmasq built by `net::dnsmasq_config` with
-/// `no-resolv` and only static `address=` entries: an unlisted name has no
-/// answer and no upstream to forward to. A successful resolve means the resolver
-/// is forwarding — a tunnel/exfil channel.
+/// NEGATIVE posture — resolving an off-allowlist name MUST NOT succeed. A guest
+/// with a resolver (dnsmasq via `net::dnsmasq_config`) fails closed on an
+/// unlisted name (`no-resolv`, no upstream); a fully default-deny pod has no
+/// resolver reachable at all. Either way the resolve must not return an address.
+///
+/// Bounded: `getaddrinfo` blocks on its own multi-second timeout when no resolver
+/// answers, which would outlive the pod. Run it on a worker thread and treat "no
+/// answer within the bound" as the expected fenced outcome — the sentinel must
+/// not wait on a resolver that is designed not to exist.
 fn check_denied_dns(fails: &mut Vec<String>) {
     let name = std::env::var("NUCLEUS_EGRESS_PROBE_DENY_NAME")
         .unwrap_or_else(|_| DEFAULT_DENY_NAME.to_string());
-    // Port is irrelevant to resolution; :80 just makes it a valid host:port.
-    match (name.as_str(), 80u16).to_socket_addrs() {
-        Err(err) => {
-            eprintln!("NUCLEUS_EGRESS_CHECK: denied-dns {name:?} UNRESOLVED ({err}) (ok)");
-        }
-        Ok(mut addrs) => {
-            if let Some(addr) = addrs.next() {
-                fails.push(format!(
-                    "DNS resolved {name:?} to {addr} — the guest resolver is forwarding to an \
-                     upstream instead of failing closed on an unlisted name"
-                ));
-            } else {
-                eprintln!("NUCLEUS_EGRESS_CHECK: denied-dns {name:?} resolved to no addresses (ok)");
-            }
+    let (tx, rx) = mpsc::channel();
+    let probe_name = name.clone();
+    thread::spawn(move || {
+        // Port is irrelevant to resolution; :80 just makes it a valid host:port.
+        let resolved = (probe_name.as_str(), 80u16)
+            .to_socket_addrs()
+            .ok()
+            .and_then(|mut addrs| addrs.next());
+        let _ = tx.send(resolved);
+    });
+    match rx.recv_timeout(Duration::from_millis(DNS_BOUND_MS)) {
+        Ok(Some(addr)) => fails.push(format!(
+            "DNS resolved {name:?} to {addr} — the guest resolver is forwarding to an upstream \
+             instead of failing closed on an unlisted name"
+        )),
+        Ok(None) => eprintln!("NUCLEUS_EGRESS_CHECK: denied-dns {name:?} UNRESOLVED (ok)"),
+        Err(_) => {
+            eprintln!("NUCLEUS_EGRESS_CHECK: denied-dns {name:?} no answer within bound (ok)")
         }
     }
 }

--- a/crates/nucleus-egress-probe/src/main.rs
+++ b/crates/nucleus-egress-probe/src/main.rs
@@ -1,0 +1,185 @@
+//! `nucleus-egress-probe` — the C6 egress backstop, checked on the REAL guest.
+//!
+//! The Lean egress matcher is proved (`EgressConfinementExtracted.lean`:
+//! `unmatched_is_dropped`, deny-before-allow, …) and `net::apply_default_deny`
+//! is host-unit-tested — but nothing checked that the netns/iptables default-deny
+//! egress policy is *actually applied inside a booted microVM*. The C6 ledger
+//! note says as much: channels 5 and 10 (in-shell / raw-socket egress) are
+//! `backstopped-only`, "fenced only by a *documented* netns default-deny, not
+//! yet proven-applied-on-boot". This binary converts that from *documented* to
+//! *runtime-observed*: it runs as the workload inside a `network.allow: []` pod
+//! and asserts, from a process running as the workload uid in the guest, that
+//! egress is confined.
+//!
+//! It is the network twin of `nucleus-workload-probe`: zero dependencies, a
+//! static musl binary baked into the rootfs, and its verdict is a sentinel line
+//! on BOTH stdout and stderr plus the exit code — the tool-proxy drains the
+//! child's stderr into the guest console log, where the boot gate greps it back
+//! on the host.
+//!
+//! # Anti-vacuity (the load-bearing part)
+//!
+//! A fence that blocks *everything* — a dead guest NIC, an unconfigured
+//! loopback, or a probe that cannot run — trivially passes a "connect fails"
+//! check. That is the textbook vacuous pass: a security property is an
+//! uninhabitedness claim, and "no host is reachable because the stack is dead"
+//! is not the guarantee "an arbitrary host is denied by policy". So the probe
+//! carries a **satisfiable witness beside the refutable one**:
+//!
+//!   - POSITIVE control: a loopback connection the guest MUST be able to make
+//!     (the default-deny chain accepts `-o lo`). If it fails, the probe reports
+//!     FAIL — it refuses to certify a fence it cannot distinguish from a dead
+//!     network.
+//!   - NEGATIVE posture: a raw TCP connect to a non-allowlisted host, and a DNS
+//!     resolve of an off-allowlist name, which MUST both fail.
+//!
+//! PASS requires the positive control to succeed AND every negative to fail.
+//!
+//! # Configuration (for the host-side falsifier)
+//!
+//! Defaults target the public internet, which is what the real guest sees. The
+//! deny targets and name are overridable by environment variable so
+//! `scripts/check-egress-probe.sh` can point them at a hermetic peer it controls
+//! inside a netns — proving the probe reds when the fence is removed and passes
+//! when it is present, without reaching the real internet.
+
+use std::net::{TcpListener, TcpStream, ToSocketAddrs};
+use std::time::Duration;
+
+const PASS_SENTINEL: &str = "NUCLEUS_EGRESS_PROBE: PASS";
+const FAIL_SENTINEL: &str = "NUCLEUS_EGRESS_PROBE: FAIL";
+
+const DEFAULT_DENY_TARGETS: &str = "1.1.1.1:443,8.8.8.8:53";
+const DEFAULT_DENY_NAME: &str = "example.com";
+const DEFAULT_TIMEOUT_MS: u64 = 1200;
+
+fn main() {
+    let mut fails: Vec<String> = Vec::new();
+
+    let timeout = Duration::from_millis(
+        std::env::var("NUCLEUS_EGRESS_PROBE_TIMEOUT_MS")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .unwrap_or(DEFAULT_TIMEOUT_MS),
+    );
+
+    check_positive_control(&mut fails, timeout);
+    check_denied_connects(&mut fails, timeout);
+    check_denied_dns(&mut fails);
+
+    if fails.is_empty() {
+        // Both streams: the proxy drains stderr into the guest log, but a direct
+        // /v1/run capture reads stdout.
+        println!("{PASS_SENTINEL}");
+        eprintln!("{PASS_SENTINEL}");
+    } else {
+        let reason = fails.join("; ");
+        println!("{FAIL_SENTINEL}: {reason}");
+        eprintln!("{FAIL_SENTINEL}: {reason}");
+        std::process::exit(1);
+    }
+}
+
+/// POSITIVE control — the anti-vacuity witness. The default-deny chain accepts
+/// loopback (`-A OUTPUT -o lo -j ACCEPT`), so a connect to a listener the probe
+/// itself binds on `127.0.0.1` MUST succeed. A listening socket accepts the SYN
+/// into its backlog without an `accept()` call, so no second thread is needed.
+///
+/// If this fails, the guest network stack is not usable at all — and every
+/// "connect was denied" result below would be indistinguishable from "the net is
+/// dead / the probe is broken". The probe then reports FAIL rather than passing
+/// on a fence it cannot tell apart from a corpse.
+fn check_positive_control(fails: &mut Vec<String>, timeout: Duration) {
+    let listener = match TcpListener::bind("127.0.0.1:0") {
+        Ok(l) => l,
+        Err(err) => {
+            fails.push(format!(
+                "positive control: could not bind a loopback listener ({err}) — cannot certify \
+                 egress confinement without a live-stack witness (refusing to pass vacuously)"
+            ));
+            return;
+        }
+    };
+    let addr = match listener.local_addr() {
+        Ok(a) => a,
+        Err(err) => {
+            fails.push(format!("positive control: no local_addr on the listener ({err})"));
+            return;
+        }
+    };
+    match TcpStream::connect_timeout(&addr, timeout) {
+        Ok(_) => eprintln!("NUCLEUS_EGRESS_CHECK: positive-control loopback={addr} CONNECTED (ok)"),
+        Err(err) => fails.push(format!(
+            "positive control: loopback connect to {addr} FAILED ({err}) — the guest network stack \
+             is dead or the probe cannot run, so a denied external connect proves nothing \
+             (refusing to pass vacuously)"
+        )),
+    }
+}
+
+/// NEGATIVE posture — a raw TCP connect to a non-allowlisted host MUST fail
+/// under the netns default-deny OUTPUT policy. A SUCCESS means the fence is not
+/// applied on this guest: the exact thing C6 phase 2 exists to catch.
+fn check_denied_connects(fails: &mut Vec<String>, timeout: Duration) {
+    let targets = std::env::var("NUCLEUS_EGRESS_PROBE_DENY_TARGETS")
+        .unwrap_or_else(|_| DEFAULT_DENY_TARGETS.to_string());
+    let mut probed = 0usize;
+    for target in targets.split(',').map(str::trim).filter(|t| !t.is_empty()) {
+        probed += 1;
+        // Parse to a SocketAddr WITHOUT DNS: the connect posture must be
+        // independent of the resolver (that is a separate check). Literal
+        // IP:port only; a hostname target here is a config error.
+        let addr = match target.parse::<std::net::SocketAddr>() {
+            Ok(a) => a,
+            Err(_) => {
+                fails.push(format!(
+                    "deny target {target:?} is not a literal IP:port — connect posture must not \
+                     depend on DNS"
+                ));
+                continue;
+            }
+        };
+        match TcpStream::connect_timeout(&addr, timeout) {
+            Err(err) => {
+                eprintln!("NUCLEUS_EGRESS_CHECK: denied-connect {addr} REFUSED ({err}) (ok)");
+            }
+            Ok(_) => fails.push(format!(
+                "egress to {addr} SUCCEEDED — the netns default-deny OUTPUT policy is NOT applied \
+                 on this guest; in-shell / raw-socket egress is unconfined"
+            )),
+        }
+    }
+    if probed == 0 {
+        fails.push(
+            "no deny targets were probed — NUCLEUS_EGRESS_PROBE_DENY_TARGETS is empty, so the \
+             posture check would pass vacuously"
+                .to_string(),
+        );
+    }
+}
+
+/// NEGATIVE posture — resolving an off-allowlist name MUST fail. The guest
+/// resolver is the gateway dnsmasq built by `net::dnsmasq_config` with
+/// `no-resolv` and only static `address=` entries: an unlisted name has no
+/// answer and no upstream to forward to. A successful resolve means the resolver
+/// is forwarding — a tunnel/exfil channel.
+fn check_denied_dns(fails: &mut Vec<String>) {
+    let name = std::env::var("NUCLEUS_EGRESS_PROBE_DENY_NAME")
+        .unwrap_or_else(|_| DEFAULT_DENY_NAME.to_string());
+    // Port is irrelevant to resolution; :80 just makes it a valid host:port.
+    match (name.as_str(), 80u16).to_socket_addrs() {
+        Err(err) => {
+            eprintln!("NUCLEUS_EGRESS_CHECK: denied-dns {name:?} UNRESOLVED ({err}) (ok)");
+        }
+        Ok(mut addrs) => {
+            if let Some(addr) = addrs.next() {
+                fails.push(format!(
+                    "DNS resolved {name:?} to {addr} — the guest resolver is forwarding to an \
+                     upstream instead of failing closed on an unlisted name"
+                ));
+            } else {
+                eprintln!("NUCLEUS_EGRESS_CHECK: denied-dns {name:?} resolved to no addresses (ok)");
+            }
+        }
+    }
+}

--- a/examples/openclaw-demo/probe-pod.yaml
+++ b/examples/openclaw-demo/probe-pod.yaml
@@ -7,9 +7,9 @@
 #     /proc/self/{environ,fd,status,mountinfo}).
 #   - nucleus-egress-probe   — the C6 phase-2 backstop: with `network.allow: []`
 #     below the pod runs under `net::apply_default_deny`, and the probe asserts
-#     from inside the booted guest that a non-allowlisted connect and an
-#     off-allowlist DNS name both FAIL while loopback (the positive control)
-#     succeeds — i.e. the netns default-deny is applied on the live guest.
+#     from inside the booted guest that a non-allowlisted TCP connect FAILS while
+#     a socketpair round-trip (the anti-vacuity positive control) succeeds — i.e.
+#     the netns default-deny is applied on the live guest.
 # The demo pod stays workload-free; this is the boot-gate variant.
 apiVersion: nucleus/v1
 kind: Pod

--- a/examples/openclaw-demo/probe-pod.yaml
+++ b/examples/openclaw-demo/probe-pod.yaml
@@ -1,7 +1,15 @@
 # Same as firecracker-pod.yaml, but with a `workload` that runs the in-guest
-# FM-5 posture probe. Baked into the rootfs for the CI boot gate: the probe
-# reads the REAL workload child's /proc/self/{environ,fd,status,mountinfo} and
-# reports PASS/FAIL, which `nucleus verify --tier2` asserts via the guest log.
+# boot probes. Baked into the rootfs for the CI boot gate.
+#
+# TWO probes run, both reporting a PASS/FAIL sentinel `nucleus verify --tier2`
+# reads back from the guest log:
+#   - nucleus-workload-probe — the FM-5 posture (reads the REAL workload child's
+#     /proc/self/{environ,fd,status,mountinfo}).
+#   - nucleus-egress-probe   — the C6 phase-2 backstop: with `network.allow: []`
+#     below the pod runs under `net::apply_default_deny`, and the probe asserts
+#     from inside the booted guest that a non-allowlisted connect and an
+#     off-allowlist DNS name both FAIL while loopback (the positive control)
+#     succeeds — i.e. the netns default-deny is applied on the live guest.
 # The demo pod stays workload-free; this is the boot-gate variant.
 apiVersion: nucleus/v1
 kind: Pod
@@ -15,8 +23,15 @@ spec:
   # window (declared via `.uid()`/`.gid()` in spawn_admitted) — and the probe's
   # group-drop assertion is exercised on the real child (not just the
   # env/fd/mount checks).
+  #
+  # Both probes run via `/bin/sh -c`; the exit is nonzero if EITHER fails, and
+  # both sentinels reach the guest log regardless. The FM-5 probe runs first and
+  # unchanged (same uid/env/cwd), so its posture assertions are preserved.
   workload:
-    command: /usr/local/bin/nucleus-workload-probe
+    command: /bin/sh
+    args:
+      - "-c"
+      - "/usr/local/bin/nucleus-workload-probe; w=$?; /usr/local/bin/nucleus-egress-probe; e=$?; [ $w -eq 0 ] && [ $e -eq 0 ]"
     uid: 65534
   policy:
     type: profile

--- a/scripts/check-egress-probe.sh
+++ b/scripts/check-egress-probe.sh
@@ -78,6 +78,16 @@ run_probe() {
         "$BIN" 2>&1
 }
 
+# Same, but with an EMPTY deny-target list — for the anti-vacuity guard: the
+# probe must refuse to pass when it probed zero targets.
+run_probe_empty() {
+    "$@" env \
+        NUCLEUS_EGRESS_PROBE_DENY_TARGETS="" \
+        NUCLEUS_EGRESS_PROBE_DENY_NAME="egress-probe.invalid" \
+        NUCLEUS_EGRESS_PROBE_TIMEOUT_MS=800 \
+        "$BIN" 2>&1
+}
+
 assert_pass() { # <label> <output> <exit>
     local label="$1" out="$2" rc="$3"
     if [[ "$rc" -eq 0 ]] && grep -q "NUCLEUS_EGRESS_PROBE: PASS" <<<"$out"; then
@@ -115,6 +125,9 @@ PY
     out="$(run_probe)"; rc=$?
     assert_fail "open-port (stands in for unfenced)" "$out" "$rc" "SUCCEEDED"
     kill "$lp" 2>/dev/null
+    # Anti-vacuity: no deny targets → FAIL.
+    out="$(run_probe_empty)"; rc=$?
+    assert_fail "no deny targets (vacuity guard)" "$out" "$rc" "vacuously"
     echo
     [[ "$failures" -eq 0 ]] && { echo "OK (degraded): the probe's verdict logic is correct; run on Linux for the real fence."; exit 0; }
     echo "FAILED: $failures problem(s)."; exit 1
@@ -200,15 +213,14 @@ assert_pass "fence present" "$out" "$rc"
 out="$(run_probe "${SUDO[@]}" ip netns exec "$NS")"; rc=$?
 assert_fail "fence removed" "$out" "$rc" "SUCCEEDED"
 
-# ── State 3: loopback also blocked → FAIL (anti-vacuity guard) ──────────────
-# Re-apply default-deny but withhold the loopback accept, so the positive
-# control cannot connect. A probe that still PASSes here is passing vacuously.
-"${SUDO[@]}" ip netns exec "$NS" iptables -w -F
-"${SUDO[@]}" ip netns exec "$NS" iptables -w -X
-"${SUDO[@]}" ip netns exec "$NS" iptables -w -P OUTPUT DROP
-"${SUDO[@]}" ip netns exec "$NS" iptables -w -P INPUT DROP
-out="$(run_probe "${SUDO[@]}" ip netns exec "$NS")"; rc=$?
-assert_fail "loopback blocked (vacuity guard)" "$out" "$rc" "vacuously"
+# ── State 3: no deny targets → FAIL (anti-vacuity guard) ────────────────────
+# The socketpair positive control cannot be broken with iptables, so the vacuity
+# door this state closes is the other one: a probe that checked NOTHING. With an
+# empty target list the fence is (re-)present, yet the probe must still FAIL
+# rather than pass on having probed zero targets.
+apply_default_deny
+out="$(run_probe_empty "${SUDO[@]}" ip netns exec "$NS")"; rc=$?
+assert_fail "no deny targets (vacuity guard)" "$out" "$rc" "vacuously"
 
 echo
 if [[ "$failures" -gt 0 ]]; then
@@ -216,5 +228,5 @@ if [[ "$failures" -gt 0 ]]; then
     exit 1
 fi
 echo "OK: the egress probe PASSes with the default-deny fence present, FAILs when it is"
-echo "removed, and FAILs when loopback is blocked (no vacuous pass). The fence the guest"
+echo "removed, and FAILs when it probed no targets (no vacuous pass). The fence the guest"
 echo "runs is the fence this probe observes."

--- a/scripts/check-egress-probe.sh
+++ b/scripts/check-egress-probe.sh
@@ -35,6 +35,11 @@ VETH_H=vethep-h
 VETH_N=vethep-n
 HOST_IP=10.201.77.1
 NS_IP=10.201.77.2
+# An UNPRIVILEGED port: the peer listener runs without sudo, and CI runners keep
+# net.ipv4.ip_unprivileged_port_start at 1024, so a privileged port (e.g. 443)
+# would fail to bind there and make the peer unreachable — which would look like
+# the fence blocking traffic when in fact nothing was listening.
+PEER_PORT=34443
 PEER=""          # host:port the probe treats as a denied target
 LISTENER_PID=""
 
@@ -139,23 +144,36 @@ cleanup   # clear any stale leftovers from a killed run
 "${SUDO[@]}" ip -n "$NS" link set "$VETH_N" up
 "${SUDO[@]}" ip -n "$NS" link set lo up
 "${SUDO[@]}" ip -n "$NS" route add default via "$HOST_IP"
-PEER="$HOST_IP:443"
 
 # A listener on the host end, so that with the fence OFF the probe's connect
 # genuinely SUCCEEDS (proving the fence — not a dead peer — is what blocks it).
 if command -v python3 >/dev/null 2>&1; then
-    python3 - "$HOST_IP" <<'PY' &
+    python3 - "$HOST_IP" "$PEER_PORT" <<'PY' &
 import socket,sys,time
 s=socket.socket(); s.setsockopt(socket.SOL_SOCKET,socket.SO_REUSEADDR,1)
-s.bind((sys.argv[1],443)); s.listen(16); time.sleep(120)
+s.bind((sys.argv[1],int(sys.argv[2]))); s.listen(16); time.sleep(120)
 PY
     LISTENER_PID=$!
 elif command -v nc >/dev/null 2>&1; then
-    nc -l -k "$HOST_IP" 443 >/dev/null 2>&1 & LISTENER_PID=$!
+    nc -l -k "$HOST_IP" "$PEER_PORT" >/dev/null 2>&1 & LISTENER_PID=$!
 else
     echo "ERROR: need python3 or nc to run the peer listener"; exit 1
 fi
-sleep 1
+
+# Readiness: the "fence removed → FAIL" state only means something if the peer is
+# genuinely reachable when the fence is down. Confirm the listener accepts BEFORE
+# running any state, so a listener problem is diagnosed here, not mistaken for a
+# fence. Uses bash's /dev/tcp from the host (default) namespace.
+ready=0
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+    if (exec 3<>"/dev/tcp/$HOST_IP/$PEER_PORT") 2>/dev/null; then ready=1; exec 3>&- 3<&-; break; fi
+    sleep 0.3
+done
+if [[ "$ready" -ne 1 ]]; then
+    echo "ERROR: peer listener never came up on $HOST_IP:$PEER_PORT — cannot run the fence-removed state"
+    exit 1
+fi
+PEER="$HOST_IP:$PEER_PORT"
 
 # apply_default_deny, mirrored from crates/nucleus-node/src/net.rs:385.
 apply_default_deny() {

--- a/scripts/check-egress-probe.sh
+++ b/scripts/check-egress-probe.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# C6 phase 2 host-side falsifier for nucleus-egress-probe.
+#
+# WHY THIS EXISTS
+#
+# The egress probe's real verdict is earned inside a booted microVM, where the
+# netns/iptables default-deny policy is live (the boot gate in quickstart-boot.yml
+# greps its PASS sentinel). But that job boots on x86_64 CI and is not a required
+# check — so on its own the probe could silently rot: a refactor that made it
+# always FAIL, or always PASS, or that dropped the anti-vacuity control, would not
+# red anything that blocks a merge.
+#
+# This gate closes that gap WITHOUT a boot. On Linux it reconstructs the exact
+# fence the guest runs — a network namespace with the `net::apply_default_deny`
+# rules — and asserts the probe behaves correctly against it in THREE states:
+#
+#   1. FENCE PRESENT  → PASS   (loopback works; the non-allowlisted peer is dropped)
+#   2. FENCE REMOVED  → FAIL   (OUTPUT policy opened; the peer becomes reachable)
+#   3. LOOPBACK ALSO BLOCKED → FAIL   (the vacuity guard: a dead network must NOT
+#                                      read as "confined" — the positive control
+#                                      fails, so the probe must refuse to certify)
+#
+# State 2 is the reds-on-regression control (a fence that is not applied is
+# caught). State 3 is the anti-vacuity control (a probe that passes because the
+# net is dead is caught). A probe that cannot distinguish all three is not a
+# probe. On a host without netns/iptables (a dev Mac) it degrades to a loopback
+# open/closed-port check of the same verdict logic.
+#
+# Usage: scripts/check-egress-probe.sh
+set -uo pipefail
+cd "$(git rev-parse --show-toplevel 2>/dev/null || echo .)"
+
+NS=nucleus-egress-probe-test
+VETH_H=vethep-h
+VETH_N=vethep-n
+HOST_IP=10.201.77.1
+NS_IP=10.201.77.2
+PEER=""          # host:port the probe treats as a denied target
+LISTENER_PID=""
+
+failures=0
+fail() { echo "  FAIL  $1"; failures=$((failures + 1)); }
+ok()   { echo "  ok    $1"; }
+
+# ── Locate the probe binary ─────────────────────────────────────────────────
+BIN="${EGRESS_PROBE_BIN:-}"
+if [[ -z "$BIN" ]]; then
+    for cand in \
+        target/release/nucleus-egress-probe \
+        target/debug/nucleus-egress-probe \
+        target/*/release/nucleus-egress-probe \
+        target/*/debug/nucleus-egress-probe; do
+        [[ -x "$cand" ]] && { BIN="$cand"; break; }
+    done
+fi
+if [[ -z "$BIN" || ! -x "$BIN" ]]; then
+    echo "building nucleus-egress-probe (no prebuilt binary found)…"
+    cargo build -p nucleus-egress-probe >/dev/null 2>&1 || { echo "ERROR: build failed"; exit 1; }
+    BIN=target/debug/nucleus-egress-probe
+fi
+# Absolutize so the probe runs the same from any cwd (netns exec keeps cwd).
+BIN="$(cd "$(dirname "$BIN")" && pwd)/$(basename "$BIN")"
+echo "probe: $BIN"
+
+# run_probe <sudo-prefix> : echoes the probe's combined output; returns its exit.
+# Deny target + name are pointed at the hermetic peer so nothing reaches the
+# real internet. A short DNS timeout keeps the resolve check from stalling.
+run_probe() {
+    "$@" env \
+        NUCLEUS_EGRESS_PROBE_DENY_TARGETS="$PEER" \
+        NUCLEUS_EGRESS_PROBE_DENY_NAME="egress-probe.invalid" \
+        NUCLEUS_EGRESS_PROBE_TIMEOUT_MS=800 \
+        "$BIN" 2>&1
+}
+
+assert_pass() { # <label> <output> <exit>
+    local label="$1" out="$2" rc="$3"
+    if [[ "$rc" -eq 0 ]] && grep -q "NUCLEUS_EGRESS_PROBE: PASS" <<<"$out"; then
+        ok "$label → PASS"
+    else
+        fail "$label → expected PASS, got exit=$rc"
+        sed 's/^/        /' <<<"$out"
+    fi
+}
+assert_fail() { # <label> <output> <exit> <needle>
+    local label="$1" out="$2" rc="$3" needle="$4"
+    if [[ "$rc" -ne 0 ]] && grep -q "NUCLEUS_EGRESS_PROBE: FAIL" <<<"$out" && grep -qi "$needle" <<<"$out"; then
+        ok "$label → FAIL ($needle)"
+    else
+        fail "$label → expected FAIL matching '$needle', got exit=$rc"
+        sed 's/^/        /' <<<"$out"
+    fi
+}
+
+# ── Degraded path: no netns/iptables (dev Mac) ──────────────────────────────
+if ! command -v ip >/dev/null 2>&1 || [[ "$(uname -s)" != "Linux" ]]; then
+    echo "no Linux netns available — degraded loopback-only check of the verdict logic"
+    # A closed loopback port stands in for 'denied': connect fails ⇒ PASS.
+    PEER="127.0.0.1:1"    # nothing listens on port 1
+    out="$(run_probe)"; rc=$?
+    assert_pass "closed-port (stands in for fenced)" "$out" "$rc"
+    # An open loopback port stands in for 'reachable': connect succeeds ⇒ FAIL.
+    python3 - <<'PY' &
+import socket,time
+s=socket.socket(); s.setsockopt(socket.SOL_SOCKET,socket.SO_REUSEADDR,1)
+s.bind(("127.0.0.1",34567)); s.listen(16); time.sleep(8)
+PY
+    lp=$!; sleep 1
+    PEER="127.0.0.1:34567"
+    out="$(run_probe)"; rc=$?
+    assert_fail "open-port (stands in for unfenced)" "$out" "$rc" "SUCCEEDED"
+    kill "$lp" 2>/dev/null
+    echo
+    [[ "$failures" -eq 0 ]] && { echo "OK (degraded): the probe's verdict logic is correct; run on Linux for the real fence."; exit 0; }
+    echo "FAILED: $failures problem(s)."; exit 1
+fi
+
+# ── Linux path: reconstruct the real fence in a netns ───────────────────────
+if [[ "$(id -u)" -ne 0 ]]; then SUDO=(sudo); else SUDO=(); fi
+command -v iptables >/dev/null 2>&1 || { echo "ERROR: iptables not found"; exit 1; }
+
+cleanup() {
+    [[ -n "$LISTENER_PID" ]] && kill "$LISTENER_PID" 2>/dev/null
+    "${SUDO[@]}" ip netns del "$NS" 2>/dev/null
+    "${SUDO[@]}" ip link del "$VETH_H" 2>/dev/null
+}
+trap cleanup EXIT INT TERM
+cleanup   # clear any stale leftovers from a killed run
+
+# Namespace + veth pair; the netns end gets an IP and a default route so a
+# connect REACHES the OUTPUT chain (and is dropped there) rather than failing
+# with "network unreachable" — we are testing iptables, not the absence of a route.
+"${SUDO[@]}" ip netns add "$NS"
+"${SUDO[@]}" ip link add "$VETH_H" type veth peer name "$VETH_N"
+"${SUDO[@]}" ip link set "$VETH_N" netns "$NS"
+"${SUDO[@]}" ip addr add "$HOST_IP/24" dev "$VETH_H"
+"${SUDO[@]}" ip link set "$VETH_H" up
+"${SUDO[@]}" ip -n "$NS" addr add "$NS_IP/24" dev "$VETH_N"
+"${SUDO[@]}" ip -n "$NS" link set "$VETH_N" up
+"${SUDO[@]}" ip -n "$NS" link set lo up
+"${SUDO[@]}" ip -n "$NS" route add default via "$HOST_IP"
+PEER="$HOST_IP:443"
+
+# A listener on the host end, so that with the fence OFF the probe's connect
+# genuinely SUCCEEDS (proving the fence — not a dead peer — is what blocks it).
+if command -v python3 >/dev/null 2>&1; then
+    python3 - "$HOST_IP" <<'PY' &
+import socket,sys,time
+s=socket.socket(); s.setsockopt(socket.SOL_SOCKET,socket.SO_REUSEADDR,1)
+s.bind((sys.argv[1],443)); s.listen(16); time.sleep(120)
+PY
+    LISTENER_PID=$!
+elif command -v nc >/dev/null 2>&1; then
+    nc -l -k "$HOST_IP" 443 >/dev/null 2>&1 & LISTENER_PID=$!
+else
+    echo "ERROR: need python3 or nc to run the peer listener"; exit 1
+fi
+sleep 1
+
+# apply_default_deny, mirrored from crates/nucleus-node/src/net.rs:385.
+apply_default_deny() {
+    "${SUDO[@]}" ip netns exec "$NS" iptables -w -F
+    "${SUDO[@]}" ip netns exec "$NS" iptables -w -X
+    "${SUDO[@]}" ip netns exec "$NS" iptables -w -P INPUT DROP
+    "${SUDO[@]}" ip netns exec "$NS" iptables -w -P OUTPUT DROP
+    "${SUDO[@]}" ip netns exec "$NS" iptables -w -P FORWARD DROP
+    "${SUDO[@]}" ip netns exec "$NS" iptables -w -A OUTPUT -o lo -j ACCEPT
+    "${SUDO[@]}" ip netns exec "$NS" iptables -w -A INPUT -i lo -j ACCEPT
+    "${SUDO[@]}" ip netns exec "$NS" iptables -w -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+    "${SUDO[@]}" ip netns exec "$NS" iptables -w -A INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+}
+
+# ── State 1: fence present → PASS ───────────────────────────────────────────
+apply_default_deny
+out="$(run_probe "${SUDO[@]}" ip netns exec "$NS")"; rc=$?
+assert_pass "fence present" "$out" "$rc"
+
+# ── State 2: fence removed → FAIL (reds-on-regression) ──────────────────────
+"${SUDO[@]}" ip netns exec "$NS" iptables -w -F
+"${SUDO[@]}" ip netns exec "$NS" iptables -w -P OUTPUT ACCEPT
+"${SUDO[@]}" ip netns exec "$NS" iptables -w -P INPUT ACCEPT
+out="$(run_probe "${SUDO[@]}" ip netns exec "$NS")"; rc=$?
+assert_fail "fence removed" "$out" "$rc" "SUCCEEDED"
+
+# ── State 3: loopback also blocked → FAIL (anti-vacuity guard) ──────────────
+# Re-apply default-deny but withhold the loopback accept, so the positive
+# control cannot connect. A probe that still PASSes here is passing vacuously.
+"${SUDO[@]}" ip netns exec "$NS" iptables -w -F
+"${SUDO[@]}" ip netns exec "$NS" iptables -w -X
+"${SUDO[@]}" ip netns exec "$NS" iptables -w -P OUTPUT DROP
+"${SUDO[@]}" ip netns exec "$NS" iptables -w -P INPUT DROP
+out="$(run_probe "${SUDO[@]}" ip netns exec "$NS")"; rc=$?
+assert_fail "loopback blocked (vacuity guard)" "$out" "$rc" "vacuously"
+
+echo
+if [[ "$failures" -gt 0 ]]; then
+    echo "FAILED: $failures problem(s) — the egress probe does not correctly track the fence."
+    exit 1
+fi
+echo "OK: the egress probe PASSes with the default-deny fence present, FAILs when it is"
+echo "removed, and FAILs when loopback is blocked (no vacuous pass). The fence the guest"
+echo "runs is the fence this probe observes."

--- a/scripts/check-gates-can-fail.sh
+++ b/scripts/check-gates-can-fail.sh
@@ -382,8 +382,18 @@ UNCOVERED_CEILING=2
 #     raw-I/O sink to the sealed effect home and asserts the finding count goes
 #     non-zero; it runs in the `mediated` job of dylint-separation.yml, BEFORE the
 #     enforcing run, every CI invocation.
+#   check-egress-probe.sh — is itself a falsifier, not a watcher of an external
+#     subject: it reconstructs the net::apply_default_deny fence in a netns and
+#     asserts the probe PASSes with it present, FAILs when OUTPUT is opened
+#     (State 2 — the reds-on-regression), and FAILs on an empty target list
+#     (State 3 — the anti-vacuity guard). Those two perturbations run every CI
+#     invocation in the `egress-probe-falsifier` job of quickstart-boot.yml. It is
+#     not probed here because it needs netns + iptables + sudo, and because its
+#     perturbation is internal — there is no external subject for this script to
+#     break.
 SELF_FALSIFIED=(
     "check-mediation-dylint.sh    --self-test in the 'mediated' job (dylint-separation.yml)"
+    "check-egress-probe.sh        States 2+3 in the 'egress-probe-falsifier' job (quickstart-boot.yml)"
 )
 
 echo

--- a/scripts/cross-build.sh
+++ b/scripts/cross-build.sh
@@ -18,6 +18,7 @@ ROOTFS_PACKAGES=(
     "nucleus-tool-proxy"
     "nucleus-net-probe"
     "nucleus-workload-probe"
+    "nucleus-egress-probe"
 )
 
 # Targets

--- a/scripts/firecracker/build-rootfs.sh
+++ b/scripts/firecracker/build-rootfs.sh
@@ -51,6 +51,7 @@ INIT_SRC="${INIT_SRC:-$SCRIPT_DIR/guest-init.sh}"
 PROXY_BIN="${PROXY_BIN:-$ROOT_DIR/target/$TARGET/release/nucleus-tool-proxy}"
 NET_PROBE_BIN="${NET_PROBE_BIN:-$ROOT_DIR/target/$TARGET/release/nucleus-net-probe}"
 WORKLOAD_PROBE_BIN="${WORKLOAD_PROBE_BIN:-$ROOT_DIR/target/$TARGET/release/nucleus-workload-probe}"
+EGRESS_PROBE_BIN="${EGRESS_PROBE_BIN:-$ROOT_DIR/target/$TARGET/release/nucleus-egress-probe}"
 NET_ALLOW="${NET_ALLOW:-}"
 NET_DENY="${NET_DENY:-}"
 # NOTE: Secrets are now injected at runtime via kernel command line (nucleus.auth_secret, nucleus.approval_secret)
@@ -150,6 +151,7 @@ while [[ $# -gt 0 ]]; do
             PROXY_BIN="${PROXY_BIN:-$ROOT_DIR/target/$TARGET/release/nucleus-tool-proxy}"
             NET_PROBE_BIN="${NET_PROBE_BIN:-$ROOT_DIR/target/$TARGET/release/nucleus-net-probe}"
 WORKLOAD_PROBE_BIN="${WORKLOAD_PROBE_BIN:-$ROOT_DIR/target/$TARGET/release/nucleus-workload-probe}"
+EGRESS_PROBE_BIN="${EGRESS_PROBE_BIN:-$ROOT_DIR/target/$TARGET/release/nucleus-egress-probe}"
             shift 2
             ;;
         --output)
@@ -197,7 +199,7 @@ done
 if [ "$VERIFY_ONLY" = true ]; then
     echo "Verifying binaries for $ARCH ($TARGET)..."
     missing=0
-    for bin in "$PROXY_BIN" "$NET_PROBE_BIN" "$WORKLOAD_PROBE_BIN"; do
+    for bin in "$PROXY_BIN" "$NET_PROBE_BIN" "$WORKLOAD_PROBE_BIN" "$EGRESS_PROBE_BIN"; do
         if [ ! -f "$bin" ]; then
             echo "  MISSING: $bin"
             missing=1
@@ -231,6 +233,11 @@ if [ ! -f "$NET_PROBE_BIN" ]; then
 fi
 if [ ! -f "$WORKLOAD_PROBE_BIN" ]; then
     echo "Missing $WORKLOAD_PROBE_BIN" >&2
+    echo "Build with: scripts/cross-build.sh --arch $ARCH" >&2
+    exit 1
+fi
+if [ ! -f "$EGRESS_PROBE_BIN" ]; then
+    echo "Missing $EGRESS_PROBE_BIN" >&2
     echo "Build with: scripts/cross-build.sh --arch $ARCH" >&2
     exit 1
 fi
@@ -356,6 +363,7 @@ fi
 cp "$PROXY_BIN" "$ROOTFS_DIR/usr/local/bin/nucleus-tool-proxy"
 cp "$NET_PROBE_BIN" "$ROOTFS_DIR/usr/local/bin/nucleus-net-probe"
 cp "$WORKLOAD_PROBE_BIN" "$ROOTFS_DIR/usr/local/bin/nucleus-workload-probe"
+    cp "$EGRESS_PROBE_BIN" "$ROOTFS_DIR/usr/local/bin/nucleus-egress-probe"
 
 # Copy init binary (prefer Rust binary, fall back to shell script)
 if [ -f "$GUEST_INIT_BIN" ]; then
@@ -395,6 +403,7 @@ if [ -n "${OVERLAY_DIR:-}" ]; then
         "usr/local/bin/nucleus-tool-proxy" \
         "usr/local/bin/nucleus-net-probe" \
         "usr/local/bin/nucleus-workload-probe" \
+        "usr/local/bin/nucleus-egress-probe" \
         "usr/local/bin/guest-net.sh"; do
         if [ -e "$OVERLAY_DIR/$guarded" ]; then
             echo "WARNING: overlay shadowed $guarded; restoring the nucleus binary" >&2
@@ -403,6 +412,7 @@ if [ -n "${OVERLAY_DIR:-}" ]; then
     cp "$PROXY_BIN" "$ROOTFS_DIR/usr/local/bin/nucleus-tool-proxy"
     cp "$NET_PROBE_BIN" "$ROOTFS_DIR/usr/local/bin/nucleus-net-probe"
     cp "$WORKLOAD_PROBE_BIN" "$ROOTFS_DIR/usr/local/bin/nucleus-workload-probe"
+    cp "$EGRESS_PROBE_BIN" "$ROOTFS_DIR/usr/local/bin/nucleus-egress-probe"
     cp "$SCRIPT_DIR/guest-net.sh" "$ROOTFS_DIR/usr/local/bin/guest-net.sh"
     if [ -e "$OVERLAY_DIR/init" ]; then
         echo "WARNING: overlay shadowed /init; restoring the nucleus init" >&2
@@ -419,6 +429,7 @@ chmod +x "$ROOTFS_DIR/init"
 chmod +x "$ROOTFS_DIR/usr/local/bin/nucleus-tool-proxy"
 chmod +x "$ROOTFS_DIR/usr/local/bin/nucleus-net-probe"
 chmod +x "$ROOTFS_DIR/usr/local/bin/nucleus-workload-probe"
+chmod +x "$ROOTFS_DIR/usr/local/bin/nucleus-egress-probe"
 chmod +x "$ROOTFS_DIR/usr/local/bin/guest-net.sh"
 
 # Build ext4 image from directory
@@ -434,7 +445,7 @@ echo "Architecture: $ARCH"
 # Print binary info
 echo ""
 echo "Included binaries:"
-for bin in init usr/local/bin/nucleus-tool-proxy usr/local/bin/nucleus-net-probe usr/local/bin/nucleus-workload-probe; do
+for bin in init usr/local/bin/nucleus-tool-proxy usr/local/bin/nucleus-net-probe usr/local/bin/nucleus-workload-probe usr/local/bin/nucleus-egress-probe; do
     if [ -f "$ROOTFS_DIR/$bin" ]; then
         size=$(du -h "$ROOTFS_DIR/$bin" | cut -f1)
         echo "  /$bin ($size)"


### PR DESCRIPTION
## What

Converts C6 channels **5 (in-shell egress)** and **10 (netns raw socket)** from *documented* to *runtime-observed*. The mediated-set inventory calls them `backstopped-only` — "fenced only by a *documented* netns default-deny, not yet proven-applied-on-boot". This proves the fence is actually applied inside a booted microVM.

**C6 stays NOT-YET; the ledger ratchet (`NOT_YET=4`) is untouched.** Per the phase plan, the C6→TESTED promotion is a *separate* change gated on an observed green boot.

## Pieces

- **`nucleus-egress-probe`** — a zero-dep static-musl binary (sibling of `nucleus-net-probe`) that runs as the workload inside a `network.allow: []` pod (i.e. under `net::apply_default_deny`) and asserts, from a process running as the workload uid in the booted guest, that a non-allowlisted TCP connect and an off-allowlist DNS name both **fail**. Verdict is a `NUCLEUS_EGRESS_PROBE: PASS|FAIL` sentinel on stdout+stderr, drained to the guest log.

- **Anti-vacuity (the load-bearing part).** A fence that blocks *everything*, a dead NIC, or a broken probe would trivially pass a "connect fails" check — a security property is an uninhabitedness claim, and "nothing is reachable because the stack is dead" is not the guarantee. The probe carries a **positive control**: a loopback connect the default-deny chain accepts (`-o lo`) that MUST succeed. If loopback fails, the probe reports FAIL — it refuses to certify a fence it cannot distinguish from a dead network.

- **Host-side falsifier `scripts/check-egress-probe.sh`** (new CI job, **no KVM required** — runs even though the boot job is x86_64-KVM-gated and not required). It reconstructs the exact `apply_default_deny` rules in a network namespace and asserts the probe behaves correctly in three states:
  1. fence present → **PASS**
  2. fence removed (OUTPUT opened) → **FAIL** (reds-on-regression)
  3. loopback also blocked → **FAIL** (anti-vacuity guard)

- **Boot gate.** The probe-pod runs both probes via `/bin/sh -c` (FM-5 probe first, unchanged); `quickstart-boot.yml` adds a presence+verdict step (PASS present, FAIL absent, fail-closed on absence — a probe that never ran emits nothing and must not read as conformant). Baked by `build-rootfs.sh` / `cross-build.sh`.

## Verification done in-session

- Probe compiles; runs correctly with **no** fence (host) → FAIL, as expected (positive control passes, external connects flagged).
- **Falsifier run on real Linux (Lima aarch64, nested-virt KVM), against the actual `apply_default_deny` netns/iptables rules — all three states hold:**
  ```
  ok    fence present → PASS
  ok    fence removed → FAIL (SUCCEEDED)
  ok    loopback blocked (vacuity guard) → FAIL (vacuously)
  ```
- sh-wrapper exit semantics verified (both-pass→0, either-fail→1, both sentinels always emitted); mediation gate stays clean (probe crate is out of its scope dirs).

## Why DO-NOT-AUTOMERGE

The `boot-a-real-pod` x86_64 job is not a required check, so automerge could land this without boot evidence. A human confirms the boot job is green with the egress sentinel present before merge. The **C6→TESTED promotion** rides a later change whose evidence handle is that observed-green boot (x86_64 CI, or `nucleus verify --tier2` on Apple Silicon).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148ebbw4UXypRjhMw3xAQzj