### PR TITLE
C2 (cross-pod NI) — mechanize podView + unwinding conditions over `pods` (C2 stays NOT-YET)

### DIFF
--- a/.github/workflows/portcullis-core-proven-lean.yml
+++ b/.github/workflows/portcullis-core-proven-lean.yml
@@ -107,6 +107,7 @@ jobs:
             AssuranceCoverage \
             UniversalDetection \
             PodMachineSpike \
+            PodCrossView \
             IdentityOracleMirror \
             ConfidentialityOracleMirror \
             IntegrityOracleMirror \

--- a/crates/portcullis-core/lean/PodCrossView.lean
+++ b/crates/portcullis-core/lean/PodCrossView.lean
@@ -1,0 +1,165 @@
+/-
+  C2 (cross-pod noninterference), increment X-2 — the pod-view relation, mechanized.
+
+  C2 is the North Star clause "*nor those of any other pod*": whatever an agent
+  workload does, it cannot learn the secrets of any OTHER pod. Until now C2's only
+  evidence was a design document (`docs/cross-pod-view.md`); the corpus had no view
+  over STATE, only trace projections. This file turns the design's `podView`
+  relation into a kernel-checked two-run theorem.
+
+  Method (from the design doc, after Nickel, OSDI 2018): the view relation is
+  UNTRUSTED — a too-coarse relation must FAIL the proof rather than silently pass.
+  The relation is squeezed by two unwinding conditions:
+    * output-consistency (lower bound): anything a pod reads back through the API
+      is DETERMINED by its own view — else the relation is too coarse;
+    * local-respect (upper bound): anything another pod's action writes is
+      EXCLUDED from the view — else the relation is too fine.
+
+  Scope of THIS increment. The design classifies all 38 `NodeState` fields: 27
+  structural (constants, no pod-distinguishing content), 3 secret (never reach a
+  pod), 8 shared-mutable (the subject). It mechanizes the ONE shared-mutable field
+  introduced first — `pods` — "because it is the only shared-mutable field
+  mediated by design" (server-side lineage filter, #2199). The structural 27 fold
+  to a shared constant (omitted here); the secret 3 are absent by construction
+  (`caller_secret` et al. — a pod cannot name them). The remaining shared-mutable
+  surfaces, and the two fields excluded because their code is currently defective
+  (`lockdown_tx` → #2203; the identity registry → #2197/#2198/#2204), are NOT
+  modelled here and are named in the ledger note as the reason C2 stays NOT-YET.
+
+  Mathlib-free by design (pure `List`/`Nat`), so it kernel-checks fast and carries
+  the clean `[propext, Classical.choice, Quot.sound]`-or-fewer axiom profile the
+  proven-tier gate requires.
+-/
+
+namespace PodCrossView
+
+/-- A pod identifier. `0` is the node/root (parent of top-level pods). -/
+abbrev PodId := Nat
+
+/-- Opaque per-pod secret content. Abstract on purpose: the theorem must hold for
+    ARBITRARY values, so a pod's secret is an uninterpreted `Nat` the view relation
+    never inspects across a lineage boundary. -/
+abbrev Label := Nat
+
+/-- A pod on the shared substrate: its id, the id of the pod that created it
+    (its `parent`; `0` = node-created top-level), and its own secret content. -/
+structure Pod where
+  id : PodId
+  parent : PodId
+  secret : Label
+deriving DecidableEq, Repr
+
+/-- `ownedBy p q` — pod `q` is in `p`'s lineage view: `q` is `p` itself, or a
+    child `p` created. This is the server-side filter's predicate (`q.parent = p ∨
+    q = p`), verbatim from `docs/cross-pod-view.md`. -/
+def ownedBy (p : PodId) (q : Pod) : Bool := q.parent == p || q.id == p
+
+/-- The shared substrate, restricted to the one shared-mutable field this
+    increment mechanizes. See the header for why the other 37 fields are folded,
+    absent, or deferred. -/
+structure HostState where
+  pods : List Pod
+deriving Repr
+
+/-- What a pod observes of the shared substrate. The design's `Observation` has
+    three fields (`ownPods`, `ownMaterials`, `ownEvents`); this increment
+    mechanizes `ownPods`, the projection over `pods`. -/
+structure Observation where
+  ownPods : List Pod
+deriving DecidableEq, Repr
+
+/-- The view relation, verbatim from `docs/cross-pod-view.md`: a pod sees exactly
+    its own lineage-filtered slice of `pods`, and nothing of any other pod. -/
+def podView (p : PodId) (σ : HostState) : Observation :=
+  { ownPods := σ.pods.filter (ownedBy p) }
+
+/-- The mediated transition on the shared surface: the node creates a pod. -/
+def createPod (child : Pod) (σ : HostState) : HostState :=
+  { σ with pods := child :: σ.pods }
+
+/-! ## The two unwinding conditions -/
+
+/-- **Output-consistency (lower bound).** A pod's view is DETERMINED by its own
+    lineage slice of `pods`: two states that agree on `p`'s owned pods give `p`
+    the same observation, whatever any other pod holds. If the relation dropped a
+    field a pod can read back, this would be unprovable. -/
+theorem output_consistency (p : PodId) (σ₁ σ₂ : HostState)
+    (h : σ₁.pods.filter (ownedBy p) = σ₂.pods.filter (ownedBy p)) :
+    podView p σ₁ = podView p σ₂ := by
+  simp only [podView, h]
+
+/-- **Local-respect (upper bound).** Another pod's write to `pods` — creating a
+    pod that is neither `A` nor `A`'s child — is EXCLUDED from `A`'s view. This is
+    the theorem with teeth: it is what makes the lineage filter load-bearing. -/
+theorem local_respect (A : PodId) (σ : HostState) (child : Pod)
+    (hpar : child.parent ≠ A) (hid : child.id ≠ A) :
+    podView A (createPod child σ) = podView A σ := by
+  have ho : ownedBy A child = false := by
+    unfold ownedBy
+    have h1 : (child.parent == A) = false := beq_eq_false_iff_ne.mpr hpar
+    have h2 : (child.id == A) = false := beq_eq_false_iff_ne.mpr hid
+    rw [h1, h2]; rfl
+  simp [podView, createPod, ho]
+
+/-! ## Cross-pod noninterference (the two-run payoff) -/
+
+/-- **Cross-pod noninterference.** Pod `A`'s observable is independent of every
+    other pod's content: two host states that agree on `A`'s owned pods yield the
+    same `podView A`, no matter how their other pods (and those pods' secrets)
+    differ. A genuine two-run theorem over state; its non-vacuity is pinned by the
+    witnesses below (two states that DO differ in another pod's secret, same view). -/
+theorem cross_pod_noninterference (A : PodId) (σ₁ σ₂ : HostState)
+    (h : σ₁.pods.filter (ownedBy A) = σ₂.pods.filter (ownedBy A)) :
+    podView A σ₁ = podView A σ₂ :=
+  output_consistency A σ₁ σ₂ h
+
+/-! ## Non-vacuity — the separating witnesses
+
+If the model were vacuous (view constant, or another pod's write leaking in),
+these would be false. They pin that the view does real work AND that the NI
+theorem has content. All are closed by `decide` over concrete `Nat`s. -/
+
+/-- A itself (node-created), and one of A's own children. -/
+def podA : Pod := { id := 1, parent := 0, secret := 100 }
+def podAchild : Pod := { id := 3, parent := 1, secret := 111 }
+/-- Pod B (a sibling of A, also node-created), carried at two different secrets. -/
+def podB_lo : Pod := { id := 2, parent := 0, secret := 0 }
+def podB_hi : Pod := { id := 2, parent := 0, secret := 999 }
+/-- A child B created. -/
+def podBchild : Pod := { id := 4, parent := 2, secret := 222 }
+
+/-- **Secret-blind (positive).** Two states differing ONLY in another pod (B)'s
+    secret give A the SAME view — B's secret does not move A's observable. -/
+example :
+    podView 1 { pods := [podA, podB_lo] } = podView 1 { pods := [podA, podB_hi] } := by
+  decide
+
+/-- **Non-triviality.** A creating A's OWN child DOES change A's view, so the
+    relation is not the vacuous constant that would make NI trivially true. -/
+example :
+    podView 1 (createPod podAchild { pods := [podA] }) ≠ podView 1 { pods := [podA] } := by
+  decide
+
+/-- **Local-respect has teeth.** A pod B created is provably ABSENT from A's view. -/
+example :
+    podBchild ∉ (podView 1 (createPod podBchild { pods := [podA] })).ownPods := by
+  decide
+
+/-! ## The coarse-relation-fails guardrail (Nickel discipline, executable)
+
+The whole point of an untrusted view relation is that WEAKENING it must break the
+proof, not silently pass. Here is that made concrete: a `podView` with the lineage
+filter DROPPED admits another pod's write into A's view, so `local_respect` is
+FALSE for it. Shipping a too-coarse relation is therefore a proof failure. -/
+
+/-- The deliberately-coarsened relation: every pod visible to everyone. -/
+def podViewCoarse (_p : PodId) (σ : HostState) : Observation := { ownPods := σ.pods }
+
+/-- **Coarse-relation-fails.** Under `podViewCoarse`, B's write (creating B's
+    child) DOES change A's view — i.e. `local_respect` does not hold for it. So the
+    lineage filter is not decoration: remove it and the unwinding condition breaks. -/
+example :
+    podViewCoarse 1 (createPod podBchild { pods := [podA] }) ≠ podViewCoarse 1 { pods := [podA] } := by
+  decide
+
+end PodCrossView

--- a/crates/portcullis-core/lean/lakefile.lean
+++ b/crates/portcullis-core/lean/lakefile.lean
@@ -155,6 +155,9 @@ lean_lib «UnwindingNoninterference» where
 lean_lib «PodMachineSpike» where
   roots := #[`PodMachineSpike]
 
+lean_lib «PodCrossView» where
+  roots := #[`PodCrossView]
+
 -- The identity oracle mirrored in plain Lean (no Aeneas/Mathlib), proved faithful
 -- to the extracted `identity_reaches_workload` — the toolchain bridge that lets the
 -- iris-lean pod machine branch on the shipped decision. Plan: graceful-puzzling-beaver.md.

--- a/docs/north-star.md
+++ b/docs/north-star.md
@@ -80,7 +80,7 @@ status is a visible event, not an edit.
 | # | Clause (verbatim from the sentence) | Status | Evidence | Falsified by |
 | --- | --- | --- | --- | --- |
 | C1 | "learn the secrets Nucleus holds on its behalf" | PROVED | `crates/portcullis-core/lean/IdentityMaterialNoninterferenceExtracted.lean#identity_material_never_reaches_the_workload`, `crates/portcullis-core/lean/ChannelAdmissionExtracted.lean#no_channel_delivers_secret_to_the_workload`, `crates/nucleus-tool-proxy/src/workload.rs#DEFAULT_WORKLOAD_UID`, `crates/nucleus-tool-proxy/src/workload.rs#PUBLIC_RESERVED` | `scripts/check-c1-inbound-fences.sh` |
-| C2 | "nor those of any other pod" | NOT-YET | `docs/cross-pod-view.md` | — |
+| C2 | "nor those of any other pod" | NOT-YET | `crates/portcullis-core/lean/PodCrossView.lean#cross_pod_noninterference`, `docs/cross-pod-view.md` | `.github/workflows/portcullis-core-proven-lean.yml` |
 | C3 | "nor influence which of them get released" | PROVED | `crates/portcullis-core/lean/PodMachineSpike.lean#noninterference` | `.github/workflows/portcullis-core-proven-lean.yml` |
 | C4 | "a governor deliberately released with a single-use token" | TESTED | `crates/portcullis-core/lean/DeclassifySinkScopeExtracted.lean#no_second_apply`, `crates/portcullis/src/kernel/declassify_authority.rs#apply_declassification_token_on`, `crates/portcullis/tests/declassify_rehome_egress.rs#c4_flip_back_on_one_graph`, `crates/portcullis/tests/kernel_token.rs` | `scripts/check-declassify-value-bound.sh` |
 | C5 | "cannot steer which value that is" | PROVED | `crates/portcullis-core/lean/DeclassifySinkScopeExtracted.lean#four_run_value_robustness`, `crates/portcullis/src/flow_graph.rs#value_binding_ok`, `crates/portcullis/tests/declassify_scope.rs#four_run_released_value_is_not_attacker_steerable` | `scripts/check-declassify-value-bound.sh` |
@@ -157,8 +157,27 @@ What each status means, and what it deliberately does not:
   conformance leg is bounded by C7 ("a theorem about the code that ships"),
   itself TESTED, so the row records the proven relation with the runtime
   conformance gated beside it — the same shape as C4.
-- **C2 (NOT-YET)** — no artifact in the corpus mentions a second pod; the host
-  is outside every model. `docs/cross-pod-view.md` is the design.
+- **C2 (NOT-YET — first mechanization landed 2026-08-11).** The design
+  (`docs/cross-pod-view.md`, after Nickel/OSDI-2018: the view relation is
+  *untrusted*, so a too-coarse relation fails the proof) is now a kernel-checked
+  two-run theorem for the first shared surface. `PodCrossView.lean` defines
+  `podView : PodId → HostState → Observation` verbatim from the design and proves
+  both unwinding conditions over `pods` — the only shared-mutable field mediated
+  by design (server-side lineage filter, #2199): *output-consistency*
+  (`output_consistency`, a pod's view is determined by its own lineage slice) and
+  *local-respect* (`local_respect`, another pod's write is excluded from the
+  view), with `cross_pod_noninterference` as the two-run payoff. It is non-vacuous
+  by four `decide`-checked witnesses — including the **coarse-relation-fails**
+  guardrail (dropping the lineage filter makes `local_respect` false, so a weaker
+  relation breaks the proof rather than silently passing). Clean axiom profile
+  (⊆ `[propext, Classical.choice, Quot.sound]`), gated by the proven-lean
+  workflow. **What keeps C2 NOT-YET:** (a) only `pods` of the 8 shared-mutable
+  fields is mechanized — the rest are not yet in-Lean; (b) two fields are excluded
+  *because their code is currently defective* (`lockdown_tx` broadcast, #2203; the
+  identity registry, #2197/#2198/#2204) and re-enter the model only when fixed;
+  (c) the model↔runtime parity (abstract `podView` ↔ the shipped `NodeState`
+  serving path) is not yet tied; (d) no two-pod boot e2e. "Any other pod" is not
+  yet earned end to end — this is the substrate + first surface, honestly scoped.
 - **C3 (PROVED)** — the two-run noninterference theorem over the reference pod
   machine, whose step relation calls the extracted delivery oracle. Scope is
   honest: a coarse monitor LTS with an opaque workload, labelled Phase 0.


### PR DESCRIPTION
## What

Opens the **C2** arc ("*nor those of any other pod*"). C2 was the least-developed clause — its only evidence was the design doc `docs/cross-pod-view.md`; the corpus had no view over **state**, only trace projections. This turns the design's `podView` relation into a **kernel-checked two-run theorem** for the first shared surface. **C2 stays NOT-YET** — this is the substrate + first surface, deliberately not a promotion.

## The Lean lib (`PodCrossView.lean`)

Mathlib-free, axioms ⊆ `[propext, Classical.choice, Quot.sound]`, following `PodMachineSpike`'s idiom. Method (per the design, after **Nickel/OSDI-2018**): the view relation is *untrusted* — a too-coarse relation must **fail the proof**, not silently pass.

- **`podView : PodId → HostState → Observation`** — verbatim from the design: a pod sees exactly its lineage-filtered slice of `pods`.
- **`output_consistency`** (lower unwinding bound) — a pod's view is *determined* by its own owned pods.
- **`local_respect`** (upper unwinding bound) — another pod's write to `pods` is *excluded* from the view. The theorem with teeth.
- **`cross_pod_noninterference`** — the two-run payoff.
- **Four `decide`-checked non-vacuity witnesses**, including the **coarse-relation-fails guardrail** (Nickel discipline, executable): dropping the lineage filter makes `local_respect` *false*, so a weaker relation breaks the proof rather than passing vacuously. Plus: secret-blind (another pod's secret doesn't move A's view), non-triviality (A's own child *does* change the view), and local-respect-has-teeth (B's child provably absent from A's view).

Scoped to `pods` — the only shared-mutable field mediated by design (#2199); the 27 structural fields fold to a constant and the 3 secrets are absent by construction, each omission mirroring the doc's classification (with its tracking ticket).

## Ledger
- C2 row: **status unchanged (NOT-YET)**; evidence upgraded `docs/cross-pod-view.md` → `PodCrossView.lean#cross_pod_noninterference`; the previously-**empty** falsifier column filled with the proven-lean workflow.
- The note names exactly what keeps C2 NOT-YET: only `pods` of the 8 shared-mutable fields mechanized; `lockdown_tx`/identity-registry excluded pending #2203/#2204; no model↔runtime parity yet; no two-pod boot e2e.
- Registered in `lakefile.lean` **and** the proven-lean gate's explicit build list (else it'd only be sorry-scanned, not type-checked). Ledger gate green: **9 clauses, 2 NOT-YET**.

## Not in scope (the arc continues)
Model↔runtime parity (abstract `podView` ↔ the shipped `NodeState` serving path), the remaining 7 shared-mutable surfaces, and a two-pod boot e2e are later increments. The enabler PRs #2203/#2204 (which close the two defective-field exclusions) should merge in parallel but aren't this proof brick. **C2→TESTED/PROVED is an outward-claim change reserved for Brandon** — the design doc calls cross-pod the "worst overclaim available to this project," so the bar is high and this increment deliberately doesn't touch the status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148ebbw4UXypRjhMw3xAQzj