### PR TITLE
C2 increment 2 — tie the podView lineage filter to the shipped predicate (model↔runtime parity)

### DIFF
--- a/crates/nucleus-node/src/pod_api.rs
+++ b/crates/nucleus-node/src/pod_api.rs
@@ -197,6 +197,54 @@ mod ownership_tests {
         assert!(caller_may_manage(Some(a()), a(), None));
     }
 
+    /// **C2 model↔runtime parity.** The abstract cross-pod noninterference theorem
+    /// (`crates/portcullis-core/lean/PodCrossView.lean`, `cross_pod_noninterference`)
+    /// proves a pod's view is independent of any other pod's secrets over the view
+    /// relation whose lineage filter is `ownedBy p q := q.parent == p || q.id == p`.
+    /// That theorem is only *about the code that ships* if the SHIPPED filter is
+    /// that same predicate. This pins it: exhaustively over a domain of pod ids,
+    /// `caller_may_manage(Some(caller), pod, parent)` — the predicate the live
+    /// listing (`.filter` above, #2199) and the management gate both use — equals
+    /// the abstract `ownedBy` formula. Change the shipped predicate and this reds,
+    /// so the Lean theorem cannot quietly describe a filter the node does not run.
+    ///
+    /// Scope: `Some(caller)` only — a pod is always an identified caller. The
+    /// `caller = None` branch is the node/operator (sees all), which is outside the
+    /// pod-vs-pod subject the theorem is about.
+    #[test]
+    fn caller_may_manage_matches_the_podview_lineage_filter() {
+        let ids = [a(), b(), child_of_a()];
+        let parents = [Some(a()), Some(b()), Some(child_of_a()), None];
+        let mut saw_true = false;
+        let mut saw_false = false;
+        for &caller in &ids {
+            for &pod in &ids {
+                for &parent in &parents {
+                    // PodCrossView `ownedBy caller {id = pod, parent}`:
+                    //   q.parent == p || q.id == p
+                    let abstract_owned = parent == Some(caller) || pod == caller;
+                    let shipped = caller_may_manage(Some(caller), pod, parent);
+                    assert_eq!(
+                        shipped, abstract_owned,
+                        "shipped caller_may_manage diverged from PodCrossView::ownedBy \
+                         at caller={caller}, pod={pod}, parent={parent:?}"
+                    );
+                    if abstract_owned {
+                        saw_true = true;
+                    } else {
+                        saw_false = true;
+                    }
+                }
+            }
+        }
+        // Non-vacuity: the domain must exercise BOTH verdicts, or the equivalence
+        // could hold trivially (a constant predicate would pass a one-sided sweep).
+        assert!(
+            saw_true && saw_false,
+            "parity domain did not exercise both owned and not-owned cases"
+        );
+    }
+
     /// A grandchild is NOT reachable: the rule is direct children, not the
     /// descendant closure. Pinned so the narrower scope is a decision on record
     /// rather than something a later reader assumes is a bug.

--- a/docs/north-star.md
+++ b/docs/north-star.md
@@ -80,7 +80,7 @@ status is a visible event, not an edit.
 | # | Clause (verbatim from the sentence) | Status | Evidence | Falsified by |
 | --- | --- | --- | --- | --- |
 | C1 | "learn the secrets Nucleus holds on its behalf" | PROVED | `crates/portcullis-core/lean/IdentityMaterialNoninterferenceExtracted.lean#identity_material_never_reaches_the_workload`, `crates/portcullis-core/lean/ChannelAdmissionExtracted.lean#no_channel_delivers_secret_to_the_workload`, `crates/nucleus-tool-proxy/src/workload.rs#DEFAULT_WORKLOAD_UID`, `crates/nucleus-tool-proxy/src/workload.rs#PUBLIC_RESERVED` | `scripts/check-c1-inbound-fences.sh` |
-| C2 | "nor those of any other pod" | NOT-YET | `crates/portcullis-core/lean/PodCrossView.lean#cross_pod_noninterference`, `docs/cross-pod-view.md` | `.github/workflows/portcullis-core-proven-lean.yml` |
+| C2 | "nor those of any other pod" | NOT-YET | `crates/portcullis-core/lean/PodCrossView.lean#cross_pod_noninterference`, `crates/nucleus-node/src/pod_api.rs#caller_may_manage_matches_the_podview_lineage_filter`, `docs/cross-pod-view.md` | `.github/workflows/portcullis-core-proven-lean.yml` |
 | C3 | "nor influence which of them get released" | PROVED | `crates/portcullis-core/lean/PodMachineSpike.lean#noninterference` | `.github/workflows/portcullis-core-proven-lean.yml` |
 | C4 | "a governor deliberately released with a single-use token" | TESTED | `crates/portcullis-core/lean/DeclassifySinkScopeExtracted.lean#no_second_apply`, `crates/portcullis/src/kernel/declassify_authority.rs#apply_declassification_token_on`, `crates/portcullis/tests/declassify_rehome_egress.rs#c4_flip_back_on_one_graph`, `crates/portcullis/tests/kernel_token.rs` | `scripts/check-declassify-value-bound.sh` |
 | C5 | "cannot steer which value that is" | PROVED | `crates/portcullis-core/lean/DeclassifySinkScopeExtracted.lean#four_run_value_robustness`, `crates/portcullis/src/flow_graph.rs#value_binding_ok`, `crates/portcullis/tests/declassify_scope.rs#four_run_released_value_is_not_attacker_steerable` | `scripts/check-declassify-value-bound.sh` |
@@ -172,12 +172,17 @@ What each status means, and what it deliberately does not:
   relation breaks the proof rather than silently passing). Clean axiom profile
   (⊆ `[propext, Classical.choice, Quot.sound]`), gated by the proven-lean
   workflow. **What keeps C2 NOT-YET:** (a) only `pods` of the 8 shared-mutable
-  fields is mechanized — the rest are not yet in-Lean; (b) two fields are excluded
-  *because their code is currently defective* (`lockdown_tx` broadcast, #2203; the
-  identity registry, #2197/#2198/#2204) and re-enter the model only when fixed;
-  (c) the model↔runtime parity (abstract `podView` ↔ the shipped `NodeState`
-  serving path) is not yet tied; (d) no two-pod boot e2e. "Any other pod" is not
-  yet earned end to end — this is the substrate + first surface, honestly scoped.
+  fields is mechanized — the rest are not yet in-Lean (all excluded: two pending
+  defect fixes, five availability/cardinality channels the sentence already
+  excludes); (b) two fields are excluded *because their code is currently
+  defective* (`lockdown_tx` broadcast, #2203; the identity registry,
+  #2197/#2198/#2204) and re-enter the model only when fixed; (c) the model↔runtime
+  parity for the `pods` filter is now **tied** — `caller_may_manage_matches_the_podview_lineage_filter`
+  pins the shipped listing/management predicate (`pod_api.rs`, live at #2199) to
+  the abstract `ownedBy` relation exhaustively over its id domain — but the
+  broader serving-path correspondence and (d) a two-pod boot e2e remain. "Any
+  other pod" is not yet earned end to end — this is the substrate, first surface,
+  and its runtime filter parity, honestly scoped.
 - **C3 (PROVED)** — the two-run noninterference theorem over the reference pod
   machine, whose step relation calls the extracted delivery oracle. Scope is
   honest: a coarse monitor LTS with an opaque workload, labelled Phase 0.


### PR DESCRIPTION
## What

Increment 2 of the C2 arc. Increment 1 (#2250) proved `cross_pod_noninterference` over the abstract lineage filter `ownedBy p q := q.parent == p || q.id == p`. A theorem is only about the code that ships if the **shipped** filter is that same predicate — this pins it. **C2 stays NOT-YET.**

## The parity test

`caller_may_manage_matches_the_podview_lineage_filter` (in `pod_api.rs`): exhaustively over a domain of pod ids, `caller_may_manage(Some(caller), pod, parent)` — the predicate the **live pod listing** (`.filter`, #2199) and the management gate both call — equals `PodCrossView::ownedBy`'s formula. Change the shipped predicate and it reds, so the Lean theorem cannot quietly describe a filter the node does not run.

- **Non-vacuity:** the sweep asserts **both** owned and not-owned cases are exercised (a constant predicate would pass a one-sided sweep).
- **Scope:** `Some(caller)` only — the `None` branch is the node/operator (sees all), outside the pod-vs-pod subject.
- **Verification:** logic verified standalone (36 triples, both verdicts exercised). The `nucleus-node` test compiles on Linux CI; local test-build is blocked by the crate's pre-existing macOS Linux-gating (`FirecrackerConfig::from_spec` is `cfg(target_os="linux")`), unrelated to this test.

## Ledger
- C2 row: **status unchanged (NOT-YET)**; evidence gains the parity test handle.
- Note leg (c) updated: the `pods` filter's model↔runtime parity is now **tied**; the broader serving-path correspondence and a two-pod boot e2e remain. Ledger gate green: **9 clauses, 2 NOT-YET**.

## Arc status
`pods` was the only *mediated* shared-mutable field — the other 7 are exclusions (2 defective pending #2203/#2204, 5 availability/cardinality channels the sentence already excludes), so there are no further sound NI-over-a-field proofs to add. The remaining C2 work is: land #2203/#2204 (re-enter the two defective-field exclusions), and a **two-pod boot e2e**. The C2→TESTED promotion stays **reserved for Brandon** (outward claim).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148ebbw4UXypRjhMw3xAQzj