### PR TITLE
C2 increment 3 — cross-pod isolation over the live request path (auth + filter + forgery)

### DIFF
--- a/crates/nucleus-node/src/pod_api.rs
+++ b/crates/nucleus-node/src/pod_api.rs
@@ -282,7 +282,10 @@ mod ownership_tests {
 
         // (2) Filter: identified as B, the listing excludes sibling A and A's
         // child, and keeps B itself.
-        assert!(!caller_may_manage(Some(b), a, None), "B must not see sibling A");
+        assert!(
+            !caller_may_manage(Some(b), a, None),
+            "B must not see sibling A"
+        );
         assert!(
             !caller_may_manage(Some(b), a_child, Some(a)),
             "B must not see A's child"
@@ -299,7 +302,10 @@ mod ownership_tests {
         );
         assert!(caller_may_manage(Some(a), a, None));
         assert!(caller_may_manage(Some(a), a_child, Some(a)));
-        assert!(!caller_may_manage(Some(a), b, None), "A must not see sibling B");
+        assert!(
+            !caller_may_manage(Some(a), b, None),
+            "A must not see sibling B"
+        );
     }
 
     /// A grandchild is NOT reachable: the rule is direct children, not the

--- a/crates/nucleus-node/src/pod_api.rs
+++ b/crates/nucleus-node/src/pod_api.rs
@@ -245,6 +245,63 @@ mod ownership_tests {
         );
     }
 
+    /// **C2 cross-pod isolation, exercised over the live request path.** A pod's
+    /// listing is filtered by lineage — but only if the two functions a request
+    /// actually traverses agree: the node must (1) identify the caller from the
+    /// token it minted, then (2) filter by that identity. The `caller_may_manage`
+    /// tests above cover (2) in isolation; the `pod_caller_identity` tests cover
+    /// (1). This drives BOTH together through the pod-B-cannot-observe-pod-A
+    /// scenario, INCLUDING the forgery `identify_caller` exists to stop — a pod
+    /// that could claim another's identity would bypass the filter entirely.
+    ///
+    /// It is the request-path integration of the same relation `PodCrossView.lean`
+    /// proves and increment 2 pinned to the shipped predicate: auth binds the
+    /// caller, the filter isolates by lineage, and forgery is rejected. (VM-level
+    /// guest isolation and a fully-booted-node HTTP e2e are separate.)
+    #[test]
+    fn pod_b_cannot_observe_pod_a_across_the_auth_and_filter_path() {
+        use crate::pod_caller_identity::{derive_token, identify_caller};
+        const SECRET: &[u8] = b"node-wide-management-secret";
+        // A and B are node-created siblings — neither is the other's parent.
+        let (a, b, a_child) = (a(), b(), child_of_a());
+
+        // (1) Auth: B presents its OWN token and is identified as B.
+        let b_token = derive_token(SECRET, b);
+        assert_eq!(
+            identify_caller(SECRET, Some(&b.to_string()), Some(&b_token)),
+            Ok(b),
+            "B's own token must identify it as B"
+        );
+
+        // The attack the whole mechanism exists to stop: B, holding only its own
+        // token, cannot CLAIM to be A — else the lineage filter below is bypassed.
+        assert!(
+            identify_caller(SECRET, Some(&a.to_string()), Some(&b_token)).is_err(),
+            "B's token must NOT authenticate as A"
+        );
+
+        // (2) Filter: identified as B, the listing excludes sibling A and A's
+        // child, and keeps B itself.
+        assert!(!caller_may_manage(Some(b), a, None), "B must not see sibling A");
+        assert!(
+            !caller_may_manage(Some(b), a_child, Some(a)),
+            "B must not see A's child"
+        );
+        assert!(caller_may_manage(Some(b), b, None), "B still sees itself");
+
+        // Symmetric non-vacuity: A, correctly identified from its own token, DOES
+        // see A and A's child — so the isolation is not the vacuous "nobody sees
+        // anything" — but still not sibling B.
+        let a_token = derive_token(SECRET, a);
+        assert_eq!(
+            identify_caller(SECRET, Some(&a.to_string()), Some(&a_token)),
+            Ok(a)
+        );
+        assert!(caller_may_manage(Some(a), a, None));
+        assert!(caller_may_manage(Some(a), a_child, Some(a)));
+        assert!(!caller_may_manage(Some(a), b, None), "A must not see sibling B");
+    }
+
     /// A grandchild is NOT reachable: the rule is direct children, not the
     /// descendant closure. Pinned so the narrower scope is a decision on record
     /// rather than something a later reader assumes is a bug.

--- a/docs/north-star.md
+++ b/docs/north-star.md
@@ -80,7 +80,7 @@ status is a visible event, not an edit.
 | # | Clause (verbatim from the sentence) | Status | Evidence | Falsified by |
 | --- | --- | --- | --- | --- |
 | C1 | "learn the secrets Nucleus holds on its behalf" | PROVED | `crates/portcullis-core/lean/IdentityMaterialNoninterferenceExtracted.lean#identity_material_never_reaches_the_workload`, `crates/portcullis-core/lean/ChannelAdmissionExtracted.lean#no_channel_delivers_secret_to_the_workload`, `crates/nucleus-tool-proxy/src/workload.rs#DEFAULT_WORKLOAD_UID`, `crates/nucleus-tool-proxy/src/workload.rs#PUBLIC_RESERVED` | `scripts/check-c1-inbound-fences.sh` |
-| C2 | "nor those of any other pod" | NOT-YET | `crates/portcullis-core/lean/PodCrossView.lean#cross_pod_noninterference`, `crates/nucleus-node/src/pod_api.rs#caller_may_manage_matches_the_podview_lineage_filter`, `docs/cross-pod-view.md` | `.github/workflows/portcullis-core-proven-lean.yml` |
+| C2 | "nor those of any other pod" | NOT-YET | `crates/portcullis-core/lean/PodCrossView.lean#cross_pod_noninterference`, `crates/nucleus-node/src/pod_api.rs#caller_may_manage_matches_the_podview_lineage_filter`, `crates/nucleus-node/src/pod_api.rs#pod_b_cannot_observe_pod_a_across_the_auth_and_filter_path`, `docs/cross-pod-view.md` | `.github/workflows/portcullis-core-proven-lean.yml` |
 | C3 | "nor influence which of them get released" | PROVED | `crates/portcullis-core/lean/PodMachineSpike.lean#noninterference` | `.github/workflows/portcullis-core-proven-lean.yml` |
 | C4 | "a governor deliberately released with a single-use token" | TESTED | `crates/portcullis-core/lean/DeclassifySinkScopeExtracted.lean#no_second_apply`, `crates/portcullis/src/kernel/declassify_authority.rs#apply_declassification_token_on`, `crates/portcullis/tests/declassify_rehome_egress.rs#c4_flip_back_on_one_graph`, `crates/portcullis/tests/kernel_token.rs` | `scripts/check-declassify-value-bound.sh` |
 | C5 | "cannot steer which value that is" | PROVED | `crates/portcullis-core/lean/DeclassifySinkScopeExtracted.lean#four_run_value_robustness`, `crates/portcullis/src/flow_graph.rs#value_binding_ok`, `crates/portcullis/tests/declassify_scope.rs#four_run_released_value_is_not_attacker_steerable` | `scripts/check-declassify-value-bound.sh` |
@@ -172,17 +172,24 @@ What each status means, and what it deliberately does not:
   relation breaks the proof rather than silently passing). Clean axiom profile
   (⊆ `[propext, Classical.choice, Quot.sound]`), gated by the proven-lean
   workflow. **What keeps C2 NOT-YET:** (a) only `pods` of the 8 shared-mutable
-  fields is mechanized — the rest are not yet in-Lean (all excluded: two pending
-  defect fixes, five availability/cardinality channels the sentence already
-  excludes); (b) two fields are excluded *because their code is currently
-  defective* (`lockdown_tx` broadcast, #2203; the identity registry,
-  #2197/#2198/#2204) and re-enter the model only when fixed; (c) the model↔runtime
-  parity for the `pods` filter is now **tied** — `caller_may_manage_matches_the_podview_lineage_filter`
+  fields is mechanized — the rest are not yet in-Lean (five are
+  availability/cardinality channels the sentence already excludes); (b) the two
+  fields that were excluded *because their code was defective* are now fixed —
+  the `lockdown_tx` broadcast leak (#2203, server-side filter) and the node-wide
+  identity socket handing out an arbitrary cert+key (#2204, retired) both landed —
+  so `lockdown_tx` and the identity registry can now **re-enter** the model in a
+  later increment (they are unblocked, not yet mechanized); (c) the model↔runtime
+  parity for the `pods` filter is **tied** — `caller_may_manage_matches_the_podview_lineage_filter`
   pins the shipped listing/management predicate (`pod_api.rs`, live at #2199) to
-  the abstract `ownedBy` relation exhaustively over its id domain — but the
-  broader serving-path correspondence and (d) a two-pod boot e2e remain. "Any
-  other pod" is not yet earned end to end — this is the substrate, first surface,
-  and its runtime filter parity, honestly scoped.
+  the abstract `ownedBy` relation exhaustively; (d) the cross-pod isolation is now
+  tested **over the live request path** — `pod_b_cannot_observe_pod_a_across_the_auth_and_filter_path`
+  drives both functions a request traverses (auth `identify_caller` + filter
+  `caller_may_manage`) through the B-cannot-observe-A scenario, including the
+  forgery the auth exists to stop. What remains: re-entering the now-unblocked
+  fields, a fully-booted-node HTTP e2e, and VM-level guest isolation (partly
+  covered by `scripts/net-guest-isolation-check.sh`). "Any other pod" is not yet
+  earned end to end — the substrate, first surface, filter parity, and
+  request-path isolation are in; the full booted-node proof is not.
 - **C3 (PROVED)** — the two-run noninterference theorem over the reference pod
   machine, whose step relation calls the extracted delivery oracle. Scope is
   honest: a coarse monitor LTS with an opaque workload, labelled Phase 0.


### PR DESCRIPTION
## What

Increment 3 of the C2 arc. Increment 1 (#2250) proved the NI theorem; increment 2 (#2251) pinned the filter predicate to the model. A real request's isolation depends on **both** functions it traverses agreeing, plus forgery-resistance. This tests that. **C2 stays NOT-YET.**

## The test

`pod_b_cannot_observe_pod_a_across_the_auth_and_filter_path` drives the two live request-path functions together — `identify_caller` (auth) + `caller_may_manage` (filter) — through the B-cannot-observe-A scenario:
- B is identified from **its own** minted token.
- **The attack:** B holding its token **cannot claim to be A** — the forgery `identify_caller` exists to stop; without this the lineage filter is bypassable.
- Identified as B, the listing **excludes** sibling A and A's child, keeps B.
- **Symmetric non-vacuity:** A, correctly identified, sees its own subtree but **not** B — so the isolation isn't the vacuous "nobody sees anything."

This is the request-path integration of the same relation `PodCrossView.lean` proves and increment 2 pinned to the shipped predicate. Logic verified standalone (the sequence composes already-tested properties of the three functions).

## Scope call (why this, not a full Firecracker boot)

The C2 listing-isolation property is **host-side** — the node's `list_pods` filter. A full two-pod Firecracker boot would exercise the *same* host functions with far more ceremony and wouldn't strengthen *this* property; VM-level guest isolation is a *different* property, separately covered by `scripts/net-guest-isolation-check.sh` (#2204). The one thing a full booted-node run adds over this test is the HTTP-layer + create-API-records-lineage wiring — noted as remaining.

## Ledger
- C2 row: **status unchanged (NOT-YET)**; evidence gains the request-path test.
- Note updated: (b) the two defective-field exclusions are now **closed** (#2203/#2204 merged) so `lockdown_tx` + the identity registry can re-enter the model in a later increment; (d) request-path isolation now tested. Ledger gate green: **9 clauses, 2 NOT-YET**.

## Remaining C2 work
Re-enter the now-unblocked `lockdown_tx`/identity fields into `PodCrossView`; a fully-booted-node HTTP e2e; then the C2→TESTED promotion (reserved for Brandon — the flagship cross-pod claim).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148ebbw4UXypRjhMw3xAQzj