### PR TITLE
C2 increment 4 — verify pod lineage on a RUNNING node (create records it, listing serves it)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,6 +257,30 @@ jobs:
         shell: bash
         run: scripts/check-extracted-callsites.sh
 
+  # C2 — the node records pod lineage on the LIVE path. Boots the real
+  # nucleus-node with the KVM-free local-driver (so no Firecracker/KVM is needed),
+  # creates two sibling pods and a child through the real signed POST /v1/pods,
+  # and asserts the listing serves the recorded parent_pod_id — the input the
+  # cross-pod scoping filter reads. The scoped filter itself is function-tested
+  # (pod_api ownership tests); this covers the lineage it depends on, end to end.
+  cross-pod-lineage:
+    name: The node records pod lineage on the live path (C2)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
+        with:
+          cache: true
+      - name: Build node (local-driver) + cli + tool-proxy
+        run: cargo build -p nucleus-node --features local-driver -p nucleus-cli -p nucleus-tool-proxy
+      - name: The create API records lineage the listing serves
+        run: |
+          NUCLEUS_NODE_BIN=target/debug/nucleus-node \
+          NUCLEUS_CLI_BIN=target/debug/nucleus \
+          NUCLEUS_TOOL_PROXY_BIN=target/debug/nucleus-tool-proxy \
+            scripts/cross-pod-lineage-check.sh
+
   # Every gate above is a claim that something is checked. This checks the claim.
   #
   # It needs full history and a clean tree because it PERTURBS real files and

--- a/crates/nucleus-cli/src/node.rs
+++ b/crates/nucleus-cli/src/node.rs
@@ -49,6 +49,12 @@ pub enum NodeCommand {
     Create {
         /// Path to pod spec YAML file
         spec_file: PathBuf,
+        /// Record this pod as a child of the given parent pod id (sets the
+        /// `x-nucleus-parent-pod-id` header). For orchestrator/test use — the
+        /// header is unauthenticated, so a real pod's lineage is instead
+        /// established by the node from the authenticated caller.
+        #[arg(long)]
+        parent_pod_id: Option<String>,
     },
 
     /// Cancel (stop) a pod
@@ -91,8 +97,18 @@ pub async fn execute(args: NodeArgs) -> Result<()> {
     match args.command {
         NodeCommand::Health => health(&args.url, &auth_secret, &args.actor).await,
         NodeCommand::Pods => list_pods(&args.url, &auth_secret, &args.actor).await,
-        NodeCommand::Create { spec_file } => {
-            create_pod(&args.url, &auth_secret, &args.actor, &spec_file).await
+        NodeCommand::Create {
+            spec_file,
+            parent_pod_id,
+        } => {
+            create_pod(
+                &args.url,
+                &auth_secret,
+                &args.actor,
+                &spec_file,
+                parent_pod_id.as_deref(),
+            )
+            .await
         }
         NodeCommand::Cancel { pod_id } => {
             cancel_pod(&args.url, &auth_secret, &args.actor, &pod_id).await
@@ -227,7 +243,13 @@ async fn list_pods(url: &str, secret: &[u8], actor: &str) -> Result<()> {
     }
 }
 
-async fn create_pod(url: &str, secret: &[u8], actor: &str, spec_file: &PathBuf) -> Result<()> {
+async fn create_pod(
+    url: &str,
+    secret: &[u8],
+    actor: &str,
+    spec_file: &PathBuf,
+    parent_pod_id: Option<&str>,
+) -> Result<()> {
     let agent = create_agent();
     let endpoint = format!("{url}/v1/pods");
 
@@ -247,6 +269,9 @@ async fn create_pod(url: &str, secret: &[u8], actor: &str, spec_file: &PathBuf) 
         req = req.header(key, value);
     }
     req = req.header("content-type", "application/json");
+    if let Some(parent) = parent_pod_id {
+        req = req.header("x-nucleus-parent-pod-id", parent);
+    }
 
     match req.send(&body) {
         Ok(mut response) => {

--- a/crates/nucleus-node/src/main.rs
+++ b/crates/nucleus-node/src/main.rs
@@ -514,6 +514,14 @@ struct PodInfo {
     state: PodState,
     proxy_addr: Option<String>,
     labels: BTreeMap<String, String>,
+    /// The pod that created this one (its lineage parent), or `null` for a
+    /// node/orchestrator-created top-level pod. Surfaced because it is the fact
+    /// the management API's cross-pod scoping (`pod_api::caller_may_manage`) reads:
+    /// an operator can see the lineage the filter enforces, and a running-node
+    /// test can assert the create path recorded it. Not agent-controlled — the
+    /// node establishes it from the authenticated caller at creation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    parent_pod_id: Option<Uuid>,
     /// The verified proof-carrying posture (`<posture>:verified`), present only
     /// when the pod carried a `dlc_posture` claim that passed admission against
     /// the host-measured rootfs and the trusted-posture registry. Absent means
@@ -1159,6 +1167,7 @@ impl PodHandle {
             state,
             proxy_addr,
             labels: self.spec.metadata.labels.clone(),
+            parent_pod_id: self.parent_pod_id,
             posture: self.posture_stamp.clone(),
         }
     }

--- a/docs/north-star.md
+++ b/docs/north-star.md
@@ -80,7 +80,7 @@ status is a visible event, not an edit.
 | # | Clause (verbatim from the sentence) | Status | Evidence | Falsified by |
 | --- | --- | --- | --- | --- |
 | C1 | "learn the secrets Nucleus holds on its behalf" | PROVED | `crates/portcullis-core/lean/IdentityMaterialNoninterferenceExtracted.lean#identity_material_never_reaches_the_workload`, `crates/portcullis-core/lean/ChannelAdmissionExtracted.lean#no_channel_delivers_secret_to_the_workload`, `crates/nucleus-tool-proxy/src/workload.rs#DEFAULT_WORKLOAD_UID`, `crates/nucleus-tool-proxy/src/workload.rs#PUBLIC_RESERVED` | `scripts/check-c1-inbound-fences.sh` |
-| C2 | "nor those of any other pod" | NOT-YET | `crates/portcullis-core/lean/PodCrossView.lean#cross_pod_noninterference`, `crates/nucleus-node/src/pod_api.rs#caller_may_manage_matches_the_podview_lineage_filter`, `crates/nucleus-node/src/pod_api.rs#pod_b_cannot_observe_pod_a_across_the_auth_and_filter_path`, `docs/cross-pod-view.md` | `.github/workflows/portcullis-core-proven-lean.yml` |
+| C2 | "nor those of any other pod" | NOT-YET | `crates/portcullis-core/lean/PodCrossView.lean#cross_pod_noninterference`, `crates/nucleus-node/src/pod_api.rs#caller_may_manage_matches_the_podview_lineage_filter`, `crates/nucleus-node/src/pod_api.rs#pod_b_cannot_observe_pod_a_across_the_auth_and_filter_path`, `scripts/cross-pod-lineage-check.sh`, `docs/cross-pod-view.md` | `.github/workflows/portcullis-core-proven-lean.yml` |
 | C3 | "nor influence which of them get released" | PROVED | `crates/portcullis-core/lean/PodMachineSpike.lean#noninterference` | `.github/workflows/portcullis-core-proven-lean.yml` |
 | C4 | "a governor deliberately released with a single-use token" | TESTED | `crates/portcullis-core/lean/DeclassifySinkScopeExtracted.lean#no_second_apply`, `crates/portcullis/src/kernel/declassify_authority.rs#apply_declassification_token_on`, `crates/portcullis/tests/declassify_rehome_egress.rs#c4_flip_back_on_one_graph`, `crates/portcullis/tests/kernel_token.rs` | `scripts/check-declassify-value-bound.sh` |
 | C5 | "cannot steer which value that is" | PROVED | `crates/portcullis-core/lean/DeclassifySinkScopeExtracted.lean#four_run_value_robustness`, `crates/portcullis/src/flow_graph.rs#value_binding_ok`, `crates/portcullis/tests/declassify_scope.rs#four_run_released_value_is_not_attacker_steerable` | `scripts/check-declassify-value-bound.sh` |
@@ -185,11 +185,19 @@ What each status means, and what it deliberately does not:
   tested **over the live request path** — `pod_b_cannot_observe_pod_a_across_the_auth_and_filter_path`
   drives both functions a request traverses (auth `identify_caller` + filter
   `caller_may_manage`) through the B-cannot-observe-A scenario, including the
-  forgery the auth exists to stop. What remains: re-entering the now-unblocked
-  fields, a fully-booted-node HTTP e2e, and VM-level guest isolation (partly
-  covered by `scripts/net-guest-isolation-check.sh`). "Any other pod" is not yet
-  earned end to end — the substrate, first surface, filter parity, and
-  request-path isolation are in; the full booted-node proof is not.
+  forgery the auth exists to stop; (e) the lineage that filter reads is verified
+  on a **running node** — `scripts/cross-pod-lineage-check.sh` boots the real
+  `nucleus-node` (KVM-free local driver), creates two sibling pods and a child of
+  one through the real signed `POST /v1/pods`, and asserts the listing serves the
+  recorded `parent_pod_id` (child→parent; siblings top-level). What remains: the
+  **scoped filter on a fully booted node** (a request carrying a pod's own caller
+  token, which is derived from a node-only secret and served over the per-pod
+  vsock — deliberately unforgeable — so it needs a real Firecracker pod, not the
+  local driver); re-entering the now-unblocked `lockdown_tx`/identity fields; and
+  VM-level guest isolation (partly covered by `net-guest-isolation-check.sh`).
+  "Any other pod" is not yet earned end to end — the substrate, first surface,
+  filter parity, request-path isolation, and live-node lineage are in; the fully
+  booted scoped proof is not.
 - **C3 (PROVED)** — the two-run noninterference theorem over the reference pod
   machine, whose step relation calls the extracted delivery oracle. Scope is
   honest: a coarse monitor LTS with an opaque workload, labelled Phase 0.

--- a/scripts/cross-pod-lineage-check.sh
+++ b/scripts/cross-pod-lineage-check.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# C2 (cross-pod NI) — the node records pod lineage on the LIVE path.
+#
+# WHY THIS EXISTS
+#
+# The cross-pod scoping the management API enforces (`pod_api::caller_may_manage`)
+# is only as sound as the `parent_pod_id` lineage it reads. That predicate is
+# unit-tested, pinned to the `PodCrossView.lean` model, and driven through the
+# auth+filter request path (`pod_b_cannot_observe_pod_a_across_the_auth_and_filter_path`).
+# What none of those exercise is the OTHER half on a RUNNING node: that the real
+# create API, over signed HTTP, actually records the lineage the filter then
+# reads, and that the listing serves it.
+#
+# This boots the real `nucleus-node` process with the KVM-free `local-driver`
+# (so it runs in ordinary CI, no Firecracker), creates three pods through the
+# real signed `POST /v1/pods` — two node-created siblings A and B, and a child of
+# A — and asserts the operator listing serves the recorded lineage: A's child has
+# `parent_pod_id == A`, and A and B are top-level (`parent_pod_id` absent).
+#
+# Scope, stated honestly: this is the create→record→serve half. It does NOT
+# exercise the SCOPED filter on the running node — that needs a pod's own caller
+# token, which is derived from a node-only secret and served over the per-pod
+# vsock (deliberately unforgeable), so it requires a real Firecracker pod. The
+# scoped filter is covered at the function level; this covers the lineage it
+# depends on.
+#
+# Usage: scripts/cross-pod-lineage-check.sh
+set -uo pipefail
+cd "$(git rev-parse --show-toplevel 2>/dev/null || echo .)"
+
+PORT="${NUCLEUS_LINEAGE_TEST_PORT:-8097}"
+URL="http://127.0.0.1:$PORT"
+SECRET="$(printf 'a%.0s' {1..64})"   # 64 hex chars → a usable (non-empty, non-world-known) 32-byte key
+WORK="$(mktemp -d)"
+NODE_PID=""
+
+cleanup() {
+    [[ -n "$NODE_PID" ]] && kill "$NODE_PID" 2>/dev/null
+    rm -rf "$WORK"
+}
+trap cleanup EXIT INT TERM
+
+# ── Binaries ────────────────────────────────────────────────────────────────
+NODE="${NUCLEUS_NODE_BIN:-}"
+CLI="${NUCLEUS_CLI_BIN:-}"
+TP="${NUCLEUS_TOOL_PROXY_BIN:-}"
+if [[ -z "$NODE" || -z "$CLI" || -z "$TP" ]]; then
+    echo "building nucleus-node (local-driver) + nucleus-cli + nucleus-tool-proxy…"
+    cargo build -p nucleus-node --features local-driver -p nucleus-cli -p nucleus-tool-proxy \
+        >/dev/null 2>&1 || { echo "ERROR: build failed"; exit 1; }
+    NODE=target/debug/nucleus-node
+    CLI=target/debug/nucleus
+    TP=target/debug/nucleus-tool-proxy
+fi
+for b in "$NODE" "$CLI" "$TP"; do [[ -x "$b" ]] || { echo "ERROR: missing binary $b"; exit 1; }; done
+TP="$(cd "$(dirname "$TP")" && pwd)/$(basename "$TP")"
+
+# ── Boot the real node (local driver, no KVM) ───────────────────────────────
+"$NODE" --auth-secret "$SECRET" --proxy-auth-secret "$SECRET" --proxy-approval-secret "$SECRET" \
+    --listen "127.0.0.1:$PORT" --state-dir "$WORK/state" --driver local --allow-local-driver \
+    --tool-proxy-path "$TP" >"$WORK/node.log" 2>&1 &
+NODE_PID=$!
+
+ready=0
+for _ in $(seq 1 40); do
+    if [[ "$(curl -s -o /dev/null -w '%{http_code}' "$URL/v1/health" 2>/dev/null)" == "200" ]]; then
+        ready=1; break
+    fi
+    sleep 0.25
+done
+if [[ "$ready" -ne 1 ]]; then
+    echo "ERROR: node did not become healthy on $URL"; tail -20 "$WORK/node.log"; exit 1
+fi
+
+N() { "$CLI" node --url "$URL" --auth-secret "$SECRET" "$@" 2>/dev/null | grep -viE "Starting nucleus|config_path"; }
+
+# A minimal, no-network pod spec (local driver).
+spec() {
+cat <<YAML
+apiVersion: nucleus/v1
+kind: Pod
+metadata:
+  name: $1
+spec:
+  work_dir: .
+  timeout_seconds: 60
+  policy: { type: profile, name: demo }
+  budget_model: { base_cost_usd: 0.000001, cost_per_second_usd: 0.0001 }
+  seccomp: { mode: default }
+YAML
+}
+id_of() { python3 -c "import sys,json; print(json.load(sys.stdin)['id'])"; }
+
+spec pod-a > "$WORK/a.yaml"; spec pod-b > "$WORK/b.yaml"; spec pod-a-child > "$WORK/ac.yaml"
+
+A="$(N create "$WORK/a.yaml" | id_of)"
+B="$(N create "$WORK/b.yaml" | id_of)"
+N create "$WORK/ac.yaml" --parent-pod-id "$A" >/dev/null
+
+[[ -n "$A" && -n "$B" && "$A" != "$B" ]] || { echo "ERROR: pod creation did not yield two distinct ids (A=$A B=$B)"; exit 1; }
+
+# ── The assertion: the listing serves the recorded lineage ──────────────────
+N pods > "$WORK/listing.json"
+LISTING="$(cat "$WORK/listing.json")"
+result="$(python3 - "$A" "$B" "$WORK/listing.json" <<'PY'
+import sys, json
+a, b, path = sys.argv[1], sys.argv[2], sys.argv[3]
+pods = json.load(open(path))
+by_name = {p["name"]: p for p in pods}
+errs = []
+for n in ("pod-a", "pod-b", "pod-a-child"):
+    if n not in by_name:
+        errs.append(f"{n} missing from the listing")
+if not errs:
+    if by_name["pod-a-child"].get("parent_pod_id") != a:
+        errs.append(f"pod-a-child parent_pod_id={by_name['pod-a-child'].get('parent_pod_id')} != A ({a})")
+    if by_name["pod-a"].get("parent_pod_id") is not None:
+        errs.append(f"pod-a is top-level but has parent_pod_id={by_name['pod-a'].get('parent_pod_id')}")
+    if by_name["pod-b"].get("parent_pod_id") is not None:
+        errs.append(f"pod-b is top-level but has parent_pod_id={by_name['pod-b'].get('parent_pod_id')}")
+    # Non-vacuity: A's child's parent is A specifically, and A != B.
+    if by_name["pod-a-child"].get("parent_pod_id") == b:
+        errs.append("pod-a-child's parent is B, not A — lineage was misrecorded")
+print("\n".join(errs) if errs else "OK")
+PY
+)"
+
+if [[ "$result" != "OK" ]]; then
+    echo "FAILED: the running node did not record/serve lineage correctly:"
+    sed 's/^/  /' <<<"$result"
+    echo "--- listing ---"; sed 's/^/  /' <<<"$LISTING"
+    exit 1
+fi
+
+echo "OK: on a live node, POST /v1/pods recorded lineage (pod-a-child.parent == pod-a;"
+echo "pod-a and pod-b top-level) and the listing served it — the input the cross-pod"
+echo "filter (caller_may_manage) reads is correct on the running path."


### PR DESCRIPTION
## What

The achievable "running-node" e2e (your option 2). The cross-pod scoping filter is only as sound as the `parent_pod_id` lineage it reads — and until now nothing exercised, **on a running node**, that the real create API *records* that lineage and the listing *serves* it. **C2 stays NOT-YET.**

## The harness

`scripts/cross-pod-lineage-check.sh` boots the **real `nucleus-node`** with the **KVM-free local driver** (so it runs in ordinary CI — no Firecracker), then through the real signed `POST /v1/pods`:
- creates two node-created siblings A and B, and a child of A (`--parent-pod-id A`);
- asserts the operator listing serves the recorded lineage: `pod-a-child.parent_pod_id == A`, A and B top-level;
- **non-vacuity**: the child's parent is A *specifically*, not B.

**Perturbation-verified**: making `info()` stop serving `parent_pod_id` reds the harness.

## Enabling changes (small, additive)
- `PodInfo` gains `parent_pod_id` — surfaces lineage to operators *and* makes it assertable on the live path. Not agent-controlled (the node sets it from the authenticated caller at creation).
- `nucleus node create` gains `--parent-pod-id` (sets `x-nucleus-parent-pod-id`) for orchestrator/test use.
- `ci.yml` job builds the local-driver binaries + runs the harness.

Named `cross-pod-lineage-check.sh` (not `check-*`) to match `net-guest-isolation-check.sh` — both boot a real node/kernel, outside the lightweight gate-of-gates.

## Why not the scoped filter on a booted node
That's the one thing still requiring a full Firecracker boot: a request must carry a pod's **own caller token**, which is derived from a **node-only secret and served over the per-pod vsock** — deliberately unforgeable, so it needs a real Firecracker pod, not the local driver. The scoped filter itself is function-tested (`pod_b_cannot_observe_pod_a_across_the_auth_and_filter_path`, #2252); this covers the **lineage it depends on**, end to end on a live node.

## Ledger
C2 row: **status unchanged (NOT-YET)**; evidence gains the harness; note leg (e) records live-node lineage. Ledger gate green: **9 clauses, 2 NOT-YET**. Standard (non-local-driver) build + rustfmt verified clean.

## C2 arc status
Substrate (theorem) + filter↔model parity + request-path isolation + **live-node lineage** are in. Remaining: the fully-booted **scoped** proof (Firecracker), re-entering the now-unblocked `lockdown_tx`/identity fields. C2→TESTED is the outward-claim promotion reserved for you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148ebbw4UXypRjhMw3xAQzj