### PR TITLE
C2 increment 5 — pod A's SCOPED listing excludes sibling B, on a running node (KVM-free)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,6 +280,12 @@ jobs:
           NUCLEUS_CLI_BIN=target/debug/nucleus \
           NUCLEUS_TOOL_PROXY_BIN=target/debug/nucleus-tool-proxy \
             scripts/cross-pod-lineage-check.sh
+      - name: A pod's own scoped listing excludes a non-lineage sibling (C2)
+        run: |
+          NUCLEUS_NODE_BIN=target/debug/nucleus-node \
+          NUCLEUS_CLI_BIN=target/debug/nucleus \
+          NUCLEUS_TOOL_PROXY_BIN=target/debug/nucleus-tool-proxy \
+            scripts/cross-pod-scoped-check.sh
 
   # Every gate above is a claim that something is checked. This checks the claim.
   #

--- a/crates/nucleus-node/src/main.rs
+++ b/crates/nucleus-node/src/main.rs
@@ -1606,6 +1606,12 @@ async fn spawn_local_pod(
             "NUCLEUS_TOOL_PROXY_NODE_AUTH_SECRET",
             &state.proxy_auth_secret,
         );
+        // Caller identity → tool-proxy scopes the management API (env-parity with guest-init).
+        command.env("NUCLEUS_POD_ID", id.to_string());
+        command.env(
+            "NUCLEUS_POD_CALLER_TOKEN",
+            pod_caller_identity::derive_token(state.caller_secret.as_ref(), id),
+        );
         // Pass delegation ceiling from pod metadata if provided
         if let Some(ceiling) = spec.metadata.labels.get("delegation_ceiling") {
             command.env("NUCLEUS_TOOL_PROXY_DELEGATION_CEILING", ceiling);

--- a/docs/north-star.md
+++ b/docs/north-star.md
@@ -80,7 +80,7 @@ status is a visible event, not an edit.
 | # | Clause (verbatim from the sentence) | Status | Evidence | Falsified by |
 | --- | --- | --- | --- | --- |
 | C1 | "learn the secrets Nucleus holds on its behalf" | PROVED | `crates/portcullis-core/lean/IdentityMaterialNoninterferenceExtracted.lean#identity_material_never_reaches_the_workload`, `crates/portcullis-core/lean/ChannelAdmissionExtracted.lean#no_channel_delivers_secret_to_the_workload`, `crates/nucleus-tool-proxy/src/workload.rs#DEFAULT_WORKLOAD_UID`, `crates/nucleus-tool-proxy/src/workload.rs#PUBLIC_RESERVED` | `scripts/check-c1-inbound-fences.sh` |
-| C2 | "nor those of any other pod" | NOT-YET | `crates/portcullis-core/lean/PodCrossView.lean#cross_pod_noninterference`, `crates/nucleus-node/src/pod_api.rs#caller_may_manage_matches_the_podview_lineage_filter`, `crates/nucleus-node/src/pod_api.rs#pod_b_cannot_observe_pod_a_across_the_auth_and_filter_path`, `scripts/cross-pod-lineage-check.sh`, `docs/cross-pod-view.md` | `.github/workflows/portcullis-core-proven-lean.yml` |
+| C2 | "nor those of any other pod" | NOT-YET | `crates/portcullis-core/lean/PodCrossView.lean#cross_pod_noninterference`, `crates/nucleus-node/src/pod_api.rs#caller_may_manage_matches_the_podview_lineage_filter`, `crates/nucleus-node/src/pod_api.rs#pod_b_cannot_observe_pod_a_across_the_auth_and_filter_path`, `scripts/cross-pod-lineage-check.sh`, `scripts/cross-pod-scoped-check.sh`, `docs/cross-pod-view.md` | `.github/workflows/portcullis-core-proven-lean.yml` |
 | C3 | "nor influence which of them get released" | PROVED | `crates/portcullis-core/lean/PodMachineSpike.lean#noninterference` | `.github/workflows/portcullis-core-proven-lean.yml` |
 | C4 | "a governor deliberately released with a single-use token" | TESTED | `crates/portcullis-core/lean/DeclassifySinkScopeExtracted.lean#no_second_apply`, `crates/portcullis/src/kernel/declassify_authority.rs#apply_declassification_token_on`, `crates/portcullis/tests/declassify_rehome_egress.rs#c4_flip_back_on_one_graph`, `crates/portcullis/tests/kernel_token.rs` | `scripts/check-declassify-value-bound.sh` |
 | C5 | "cannot steer which value that is" | PROVED | `crates/portcullis-core/lean/DeclassifySinkScopeExtracted.lean#four_run_value_robustness`, `crates/portcullis/src/flow_graph.rs#value_binding_ok`, `crates/portcullis/tests/declassify_scope.rs#four_run_released_value_is_not_attacker_steerable` | `scripts/check-declassify-value-bound.sh` |
@@ -189,15 +189,24 @@ What each status means, and what it deliberately does not:
   on a **running node** — `scripts/cross-pod-lineage-check.sh` boots the real
   `nucleus-node` (KVM-free local driver), creates two sibling pods and a child of
   one through the real signed `POST /v1/pods`, and asserts the listing serves the
-  recorded `parent_pod_id` (child→parent; siblings top-level). What remains: the
-  **scoped filter on a fully booted node** (a request carrying a pod's own caller
-  token, which is derived from a node-only secret and served over the per-pod
-  vsock — deliberately unforgeable — so it needs a real Firecracker pod, not the
-  local driver); re-entering the now-unblocked `lockdown_tx`/identity fields; and
-  VM-level guest isolation (partly covered by `net-guest-isolation-check.sh`).
-  "Any other pod" is not yet earned end to end — the substrate, first surface,
-  filter parity, request-path isolation, and live-node lineage are in; the fully
-  booted scoped proof is not.
+  recorded `parent_pod_id` (child→parent; siblings top-level); (f) the **scoped
+  exclusion itself** is verified on a running node — `scripts/cross-pod-scoped-check.sh`
+  boots the real node, creates an orchestrator pod A and a non-lineage sibling B,
+  and drives A's tool-proxy `POST /v1/pod/list` presenting A's OWN node-minted
+  caller token: the node scopes the listing server-side (`caller_may_manage`) so
+  A sees A but **not** B — a strict subset of the operator view that sees both.
+  This runs KVM-free because a pod's caller token is
+  `derive_token(caller_secret, id)` whether delivered as a local-driver env var or
+  over the Firecracker vsock — its unforgeability rests on the node-only
+  `caller_secret`, not on the transport (correcting an earlier over-strong note
+  that this "needs a real Firecracker pod"). What remains: a **two-pod Firecracker
+  boot** exercising the same path with the token delivered over the real vsock
+  (transport + real-guest-origin fidelity, `quickstart-boot`); re-entering the
+  now-unblocked `lockdown_tx`/identity fields; and VM-level guest isolation (partly
+  covered by `net-guest-isolation-check.sh`). "Any other pod" is not yet earned end
+  to end — the substrate, first surface, filter parity, request-path isolation,
+  live-node lineage, and running-node scoped exclusion are in; the Firecracker
+  two-pod boot is not.
 - **C3 (PROVED)** — the two-run noninterference theorem over the reference pod
   machine, whose step relation calls the extracted delivery oracle. Scope is
   honest: a coarse monitor LTS with an opaque workload, labelled Phase 0.

--- a/scripts/cross-pod-scoped-check.sh
+++ b/scripts/cross-pod-scoped-check.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# C2 (cross-pod NI) — pod A's SCOPED listing excludes sibling pod B, on a running
+# node, over the real HTTP request path with a real per-pod caller token.
+#
+# WHY THIS EXISTS
+#
+# `cross-pod-lineage-check.sh` proves the node records the lineage the filter
+# reads; the pod_api ownership tests prove the filter predicate; #2252 drives the
+# auth+filter functions. This is the one that ties them together on a running
+# node: an orchestrator pod A, presenting ITS OWN node-minted caller token, calls
+# the management API and gets a listing SERVER-SIDE-SCOPED to its own lineage —
+# so a non-lineage sibling B is excluded, while an operator (no pod token) sees
+# both.
+#
+# It runs KVM-free: the local driver now presents each orchestrator pod's caller
+# token (NUCLEUS_POD_ID / NUCLEUS_POD_CALLER_TOKEN, env-parity with what guest-init
+# fetches over vsock in Firecracker — the token is `derive_token(caller_secret,id)`
+# either way, so its unforgeability rests on the node-only `caller_secret`, not on
+# the vsock transport). The full Firecracker two-pod boot (token delivered over the
+# REAL vsock) is a separate increment; this exercises the identical auth+filter
+# composition on a booted node in an ordinary CI lane.
+#
+# Path exercised: A's workload → A's tool-proxy `POST /v1/pod/list`
+# (`pod_mgmt::list_sub_pods`) → `node_client.list_pods()` attaching A's
+# x-nucleus-pod-id/token → node `auth_middleware` (node-auth HMAC + identify) →
+# `pod_api::collect_pod_infos` → `caller_may_manage(Some(A), …)` server-side filter.
+#
+# Usage: scripts/cross-pod-scoped-check.sh
+set -uo pipefail
+cd "$(git rev-parse --show-toplevel 2>/dev/null || echo .)"
+
+PORT="${NUCLEUS_SCOPED_TEST_PORT:-8103}"
+URL="http://127.0.0.1:$PORT"
+SECRET="$(printf 'a%.0s' {1..64})"
+WORK="$(mktemp -d)"
+NODE_PID=""
+cleanup() { [[ -n "$NODE_PID" ]] && kill "$NODE_PID" 2>/dev/null; rm -rf "$WORK"; }
+trap cleanup EXIT INT TERM
+
+NODE="${NUCLEUS_NODE_BIN:-}"; CLI="${NUCLEUS_CLI_BIN:-}"; TP="${NUCLEUS_TOOL_PROXY_BIN:-}"
+if [[ -z "$NODE" || -z "$CLI" || -z "$TP" ]]; then
+    echo "building nucleus-node (local-driver) + nucleus-cli + nucleus-tool-proxy…"
+    cargo build -p nucleus-node --features local-driver -p nucleus-cli -p nucleus-tool-proxy \
+        >/dev/null 2>&1 || { echo "ERROR: build failed"; exit 1; }
+    NODE=target/debug/nucleus-node; CLI=target/debug/nucleus; TP=target/debug/nucleus-tool-proxy
+fi
+for b in "$NODE" "$CLI" "$TP"; do [[ -x "$b" ]] || { echo "ERROR: missing binary $b"; exit 1; }; done
+TP="$(cd "$(dirname "$TP")" && pwd)/$(basename "$TP")"
+
+"$NODE" --auth-secret "$SECRET" --proxy-auth-secret "$SECRET" --proxy-approval-secret "$SECRET" \
+    --listen "127.0.0.1:$PORT" --state-dir "$WORK/state" --driver local --allow-local-driver \
+    --tool-proxy-path "$TP" >"$WORK/node.log" 2>&1 &
+NODE_PID=$!
+ready=0
+for _ in $(seq 1 40); do
+    [[ "$(curl -s -o /dev/null -w '%{http_code}' "$URL/v1/health" 2>/dev/null)" == "200" ]] && { ready=1; break; }
+    sleep 0.25
+done
+[[ "$ready" -eq 1 ]] || { echo "ERROR: node not healthy"; tail -20 "$WORK/node.log"; exit 1; }
+
+N() { "$CLI" node --url "$URL" --auth-secret "$SECRET" "$@" 2>/dev/null | grep -viE "Starting nucleus|config_path"; }
+
+# Pod A: an orchestrator (holds manage_pods) with pod-mgmt enabled, so its
+# tool-proxy carries A's caller token and can call the management API.
+cat > "$WORK/a.yaml" <<YAML
+apiVersion: nucleus/v1
+kind: Pod
+metadata: { name: orch-a, labels: { enable_pod_mgmt: "true" } }
+spec:
+  work_dir: .
+  timeout_seconds: 120
+  policy: { type: profile, name: orchestrator }
+  budget_model: { base_cost_usd: 0.000001, cost_per_second_usd: 0.0001 }
+  seccomp: { mode: default }
+YAML
+# Pod B: an ordinary sibling (node-created, NOT A's child).
+cat > "$WORK/b.yaml" <<YAML
+apiVersion: nucleus/v1
+kind: Pod
+metadata: { name: sibling-b }
+spec:
+  work_dir: .
+  timeout_seconds: 120
+  policy: { type: profile, name: read-only }
+  budget_model: { base_cost_usd: 0.000001, cost_per_second_usd: 0.0001 }
+  seccomp: { mode: default }
+YAML
+
+RA="$(N create "$WORK/a.yaml")"
+A="$(printf '%s' "$RA" | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])" 2>/dev/null)"
+APROXY="$(printf '%s' "$RA" | python3 -c "import sys,json; print(json.load(sys.stdin)['proxy_addr'])" 2>/dev/null)"
+RB="$(N create "$WORK/b.yaml")"
+B="$(printf '%s' "$RB" | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])" 2>/dev/null)"
+[[ -n "$A" && -n "$B" && "$A" != "$B" && -n "$APROXY" ]] || { echo "ERROR: pod creation failed (A=$A B=$B proxy=$APROXY)"; tail -20 "$WORK/node.log"; exit 1; }
+
+N pods > "$WORK/operator.json"
+curl -s -X POST "$APROXY/v1/pod/list" -H 'content-type: application/json' -d '{}' > "$WORK/scoped.json" 2>/dev/null
+
+cat > "$WORK/check.py" <<'PY'
+import sys, json
+a, b, op_path, sc_path = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
+def ids(path):
+    d = json.load(open(path))
+    pods = d if isinstance(d, list) else d.get("pods", [])
+    return {p["id"] for p in pods}
+op, sc = ids(op_path), ids(sc_path)
+errs = []
+# Positive control 1: B genuinely exists (the exclusion isn't "B never booted").
+if a not in op: errs.append("operator listing missing A (%s)" % a)
+if b not in op: errs.append("operator listing missing sibling B (%s) -- cannot conclude B was excluded vs never created" % b)
+# The property: A's scoped listing has A, excludes B.
+if a not in sc: errs.append("A's scoped listing does NOT contain A -- the token did not authenticate")
+if b in sc: errs.append("A's scoped listing CONTAINS sibling B (%s) -- cross-pod isolation FAILED (token not applied / filter bypassed)" % b)
+# Discriminating: scoped is a STRICT subset of operator (proves scoping happened).
+if not sc: errs.append("A's scoped listing is EMPTY -- not a valid positive result")
+elif not (sc < op): errs.append("A's scoped listing (%d) is not a strict subset of operator (%d) -- no scoping occurred" % (len(sc), len(op)))
+print("\n".join(errs) if errs else "OK")
+PY
+result="$(python3 "$WORK/check.py" "$A" "$B" "$WORK/operator.json" "$WORK/scoped.json")"
+
+if [[ "$result" != "OK" ]]; then
+    echo "FAILED: cross-pod scoped listing did not isolate A from B on the running node:"
+    sed 's/^/  /' <<<"$result"
+    echo "  A=$A  B=$B"
+    echo "--- operator ---"; sed 's/^/  /' <<<"$(cat "$WORK/operator.json")"
+    echo "--- A scoped ---"; sed 's/^/  /' <<<"$(cat "$WORK/scoped.json")"
+    exit 1
+fi
+
+echo "OK: on a running node, pod A's authenticated /v1/pod/list (A's own caller token)"
+echo "returned A but EXCLUDED sibling B — a strict subset of the operator view that sees"
+echo "both. The server-side caller_may_manage filter scoped the listing by A's identity."


### PR DESCRIPTION
## What

The scoped cross-pod exclusion — pod A's **authenticated** `/v1/pod/list` returns A but **not** a non-lineage sibling B — is now proven on a **running node**, the piece #2253 deferred. **C2 stays NOT-YET.**

And it runs **KVM-free**, correcting an over-strong claim I made in #2253: a pod's caller token is `derive_token(caller_secret, id)` whether delivered as a local-driver env var or over the Firecracker vsock, so its **unforgeability rests on the node-only `caller_secret`, not on the vsock transport**.

## The full live path exercised
A's workload → A's tool-proxy `POST /v1/pod/list` (`pod_mgmt::list_sub_pods`) → `node_client.list_pods()` attaching A's `x-nucleus-pod-id`/`x-nucleus-pod-token` → node `auth_middleware` (node-auth HMAC + `identify_from_headers`) → `collect_pod_infos` → **server-side `caller_may_manage(Some(A), …)`** filter.

## Changes
- **Fidelity fix (enabling change):** `spawn_local_pod` now sets `NUCLEUS_POD_ID` + `NUCLEUS_POD_CALLER_TOKEN` for orchestrator pods — the *same* two env vars guest-init sets in Firecracker after fetching the token over vsock, using the *same* `derive_token`. Without it, local orchestrator pods listed as `caller=None` (operator, unscoped).
- Uses the **existing (legacy) `orchestrator` profile** (`PermissionLattice::orchestrator`, `manage_pods: Always`) — no new profile; inline `PermissionLattice` policies aren't YAML-deserializable and no canonical profile grants `manage_pods`.
- **New harness `scripts/cross-pod-scoped-check.sh`** + a `ci.yml` job (ubuntu, **no KVM**).

## Verification (all local, shown to bite)
- Harness green: A's scoped listing contains A, **excludes B**, is a **strict subset** of the operator view.
- **Positive controls:** operator listing contains **both** A and B (B genuinely exists); A's scoped listing is non-empty and contains A (token authenticated).
- **Perturbation-verified:** disabling the caller-token env → A falls back to operator view → B appears in A's scoped listing → RED.
- Portcullis profile tests green (11); standard (non-local-driver) build + rustfmt clean; ledger gate green (**9 clauses, 2 NOT-YET**).

## Ledger
C2 row: **status unchanged (NOT-YET)**; evidence gains the scoped harness; note leg (f) records the running-node scoped exclusion and corrects the "needs a real Firecracker pod" claim.

## What remains for C2
The **two-pod Firecracker boot** (Inc 2) — same path, token delivered over the **real vsock** (transport + real-guest-origin fidelity, in the `quickstart-boot` KVM lane); re-entering the now-unblocked `lockdown_tx`/identity fields. C2→TESTED is the outward-claim promotion reserved for Brandon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148ebbw4UXypRjhMw3xAQzj