### PR TITLE
C9 increment 1 — serve an attested SVID and verify it from the outside (KVM-free)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6607,6 +6607,7 @@ dependencies = [
  "nucleus-bundle-cas",
  "nucleus-client",
  "nucleus-envelope",
+ "nucleus-identity",
  "nucleus-lineage",
  "nucleus-proto",
  "nucleus-spec",

--- a/crates/nucleus-cli/Cargo.toml
+++ b/crates/nucleus-cli/Cargo.toml
@@ -20,6 +20,7 @@ path = "src/main.rs"
 portcullis = { path = "../portcullis", features = ["spec", "dlc"] }
 nucleus-spec = { path = "../nucleus-spec" }
 nucleus-client = { path = "../nucleus-client" }
+nucleus-identity = { path = "../nucleus-identity" }
 nucleus-proto = { path = "../nucleus-proto" }
 nucleus-lineage = { path = "../nucleus-lineage" }
 nucleus-envelope = { path = "../nucleus-envelope" }

--- a/crates/nucleus-cli/src/main.rs
+++ b/crates/nucleus-cli/src/main.rs
@@ -52,6 +52,7 @@ mod token;
 mod twosafety;
 mod twosafety_boot;
 mod verify;
+mod verify_attestation;
 
 /// Nucleus CLI - policy-aware wrapper (tool enforcement via proxy)
 #[derive(Parser)]
@@ -144,6 +145,9 @@ enum Commands {
 
     /// Content-addressed bundle transfer over iroh-blobs (publish/fetch)
     Bundle(bundle::BundleArgs),
+
+    /// Verify an attested SVID against expected measurements (relying party, C9)
+    VerifyAttestation(verify_attestation::VerifyAttestationArgs),
 }
 
 fn init_logging(verbose: bool) {
@@ -201,5 +205,6 @@ async fn main() -> Result<()> {
         Commands::Envelope(args) => envelope::execute(args),
         Commands::EnvelopeVerify(args) => envelope_verify::execute(args),
         Commands::Bundle(args) => bundle::execute(args).await,
+        Commands::VerifyAttestation(args) => verify_attestation::execute(args),
     }
 }

--- a/crates/nucleus-cli/src/verify_attestation.rs
+++ b/crates/nucleus-cli/src/verify_attestation.rs
@@ -1,0 +1,183 @@
+//! Relying-party verification of an attested SVID (North Star C9).
+//!
+//! `nucleus verify-attestation` is the *outside* verifier: given the PEM certificate
+//! chain a pod serves over `FETCH_SVID` and the measurements an operator expects, it
+//! decides whether to trust the pod. This is the production caller for
+//! [`nucleus_identity::verify_attested_svid`] — the shipped library entrypoint that
+//! extracts the launch attestation from the leaf certificate and checks it.
+//!
+//! Two teeth, matching the library:
+//! * **fail-closed on absent** — `--require-attestation` (default) makes a served
+//!   cert that carries no attestation extension an error, not a vacuous pass.
+//! * **drift** — a measurement outside the `--expect-*` allow-lists is an error.
+//!
+//! # Trust boundary (read this)
+//!
+//! The measurement is the *node's own* SHA-256 of the kernel+rootfs it launched,
+//! signed by the node's CA key — first-party **software** launch attestation, NOT
+//! hardware-rooted. There is no TPM/SEV-SNP/TDX quote and no UDS-in-ROM DICE
+//! identity, so the guarantee is conditional: *IF you trust this node's key, THEN
+//! the pod ran an artifact with these measurements.*
+
+use anyhow::{anyhow, bail, Context, Result};
+use clap::Args;
+use nucleus_identity::{verify_attested_svid, AttestationRequirements};
+
+#[derive(Args)]
+pub struct VerifyAttestationArgs {
+    /// Path to the served SVID certificate chain (PEM).
+    #[arg(long)]
+    cert: std::path::PathBuf,
+
+    /// Expected kernel measurement (hex SHA-256). Repeatable; any listed value passes.
+    #[arg(long = "expect-kernel")]
+    expect_kernel: Vec<String>,
+
+    /// Expected rootfs measurement (hex SHA-256). Repeatable; any listed value passes.
+    #[arg(long = "expect-rootfs")]
+    expect_rootfs: Vec<String>,
+
+    /// Expected config measurement (hex SHA-256). Repeatable; any listed value passes.
+    #[arg(long = "expect-config")]
+    expect_config: Vec<String>,
+
+    /// Fail closed if the served cert carries no attestation extension (default on).
+    #[arg(long, default_value_t = true, action = clap::ArgAction::Set)]
+    require_attestation: bool,
+}
+
+fn parse_hash(hex_str: &str) -> Result<[u8; 32]> {
+    let bytes = hex::decode(hex_str.trim())
+        .with_context(|| format!("invalid hex measurement '{hex_str}'"))?;
+    bytes.as_slice().try_into().map_err(|_| {
+        anyhow!(
+            "measurement must be 32 bytes (64 hex chars), got {}",
+            bytes.len()
+        )
+    })
+}
+
+pub fn execute(args: VerifyAttestationArgs) -> Result<()> {
+    let chain = std::fs::read_to_string(&args.cert)
+        .with_context(|| format!("reading cert chain {}", args.cert.display()))?;
+
+    let mut req = AttestationRequirements::any();
+    for h in &args.expect_kernel {
+        req = req.allow_kernel(parse_hash(h)?);
+    }
+    for h in &args.expect_rootfs {
+        req = req.allow_rootfs(parse_hash(h)?);
+    }
+    for h in &args.expect_config {
+        req = req.allow_config(parse_hash(h)?);
+    }
+
+    match verify_attested_svid(&chain, &req, args.require_attestation) {
+        Ok(Some(att)) => {
+            println!("OK: attested SVID verified — {}", att.to_hex_summary());
+            println!(
+                "NOTE: node-signed SOFTWARE launch attestation (no hardware root); \
+                 trust is conditional on the node's signing key."
+            );
+            Ok(())
+        }
+        Ok(None) => {
+            println!("OK: served SVID carries no attestation and none was required.");
+            Ok(())
+        }
+        Err(e) => bail!("attestation verification FAILED: {e}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nucleus_identity::{CaClient, CsrOptions, Identity, LaunchAttestation, SelfSignedCa};
+    use std::io::Write;
+    use std::time::Duration;
+
+    /// Mint a real leaf cert via the shipping SelfSignedCa, optionally attested.
+    async fn mint(attested: bool) -> (tempfile::NamedTempFile, LaunchAttestation) {
+        let ca = SelfSignedCa::new("test.local").unwrap();
+        let identity = Identity::for_pod("test.local", "pod-1");
+        let cs = CsrOptions::new(identity.to_spiffe_uri())
+            .generate()
+            .unwrap();
+        let att = LaunchAttestation::from_hashes([1u8; 32], [2u8; 32], [3u8; 32]);
+        let cert = if attested {
+            ca.sign_attested_csr(
+                cs.csr(),
+                cs.private_key(),
+                &identity,
+                Duration::from_secs(3600),
+                &att,
+            )
+            .await
+            .unwrap()
+        } else {
+            ca.sign_csr(
+                cs.csr(),
+                cs.private_key(),
+                &identity,
+                Duration::from_secs(3600),
+            )
+            .await
+            .unwrap()
+        };
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        f.write_all(cert.chain_pem().as_bytes()).unwrap();
+        (f, att)
+    }
+
+    fn args(
+        f: &tempfile::NamedTempFile,
+        k: &[u8; 32],
+        r: &[u8; 32],
+        c: &[u8; 32],
+    ) -> VerifyAttestationArgs {
+        VerifyAttestationArgs {
+            cert: f.path().to_path_buf(),
+            expect_kernel: vec![hex::encode(k)],
+            expect_rootfs: vec![hex::encode(r)],
+            expect_config: vec![hex::encode(c)],
+            require_attestation: true,
+        }
+    }
+
+    // The CLI production entrypoint verifies a correct attested cert, reds on
+    // measurement drift, and fails closed on an absent extension (C9 Inc 1).
+    #[tokio::test]
+    async fn cli_verifies_attested_and_reds_on_drift_and_absent() {
+        let (f, att) = mint(true).await;
+
+        // Positive control — correct measurement verifies (non-vacuous).
+        assert!(execute(args(
+            &f,
+            att.kernel_hash(),
+            att.rootfs_hash(),
+            att.config_hash()
+        ))
+        .is_ok());
+
+        // Drift — one wrong expected hash reds the CLI verdict.
+        let mut wrong = *att.kernel_hash();
+        wrong[0] ^= 0x01;
+        assert!(execute(args(&f, &wrong, att.rootfs_hash(), att.config_hash())).is_err());
+
+        // Absent — a plain cert with require_attestation fails closed.
+        let (plain, _) = mint(false).await;
+        assert!(execute(args(
+            &plain,
+            att.kernel_hash(),
+            att.rootfs_hash(),
+            att.config_hash()
+        ))
+        .is_err());
+    }
+
+    #[test]
+    fn rejects_malformed_hex_measurement() {
+        assert!(parse_hash("not-hex").is_err());
+        assert!(parse_hash("ab").is_err()); // too short
+    }
+}

--- a/crates/nucleus-identity/src/attestation.rs
+++ b/crates/nucleus-identity/src/attestation.rs
@@ -1,23 +1,27 @@
 //! Launch attestation for Firecracker VM integrity verification.
 //!
-//! This module provides attestation primitives that cryptographically bind
-//! SPIFFE identities to specific VM configurations. Attestation proves:
+//! This module provides attestation primitives that bind SPIFFE identities to the
+//! measurements the *node* computed for a VM's components. Each attestation carries:
 //!
-//! - **Kernel integrity**: SHA-256 hash of the kernel image
-//! - **Rootfs integrity**: SHA-256 hash of the root filesystem
-//! - **Configuration integrity**: SHA-256 hash of PodSpec + portcullis policy
+//! - **Kernel measurement**: SHA-256 hash of the kernel image
+//! - **Rootfs measurement**: SHA-256 hash of the root filesystem
+//! - **Configuration measurement**: SHA-256 hash of PodSpec + portcullis policy
 //!
-//! # TCG DICE Compliance
+//! # Trust boundary — NOT hardware-rooted
 //!
-//! The attestation encoding follows the TCG DICE Attestation Architecture,
-//! using proper ASN.1 DER encoding with OIDs from the TCG namespace.
+//! These are **first-party, software** measurements: the node hashes what it
+//! launched and signs the result with its own CA key. There is **no hardware root**
+//! — no TPM / SEV-SNP / TDX quote, no UDS-in-ROM DICE identity binding the signing
+//! key to silicon. A compromised node can sign any measurement, so the guarantee is
+//! conditional: *IF you trust the node's key, THEN the pod ran an artifact with
+//! these measurements.* Do not label this "hardware attestation" or "DICE measured
+//! boot."
 //!
-//! OID hierarchy:
-//! - `2.23.133` - TCG root
-//! - `2.23.133.5.4` - tcg-dice
-//! - `2.23.133.5.4.1` - DiceTcbInfo
+//! # DICE-format-compatible encoding
 //!
-//! See: [DICE Attestation Architecture v1.2](https://trustedcomputinggroup.org/wp-content/uploads/DICE-Attestation-Architecture-v1.2_pub.pdf)
+//! The DER encoding borrows the TCG DICE `DiceTcbInfo` *format* (FWID hash
+//! entries) so off-the-shelf ASN.1 tooling can parse it — it is not a hardware DICE
+//! layer. See: [DICE Attestation Architecture v1.2](https://trustedcomputinggroup.org/wp-content/uploads/DICE-Attestation-Architecture-v1.2_pub.pdf)
 //!
 //! # How It Works
 //!
@@ -703,6 +707,70 @@ fn parse_permission_fingerprint_der(der: &[u8]) -> Option<[u8; 32]> {
     let mut fingerprint = [0u8; 32];
     fingerprint.copy_from_slice(&der[pos..pos + 32]);
     Some(fingerprint)
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// LAUNCH ATTESTATION EXTRACTION + RELYING-PARTY VERIFICATION (North Star C9)
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Extract a launch attestation from an X.509 certificate (DER).
+///
+/// Looks for OID `1.3.6.1.4.1.57212.1.1` (Nucleus Launch Attestation) among the
+/// certificate's extensions and parses the embedded [`LaunchAttestation`].
+///
+/// Returns `None` if the extension is absent or cannot be parsed.
+pub fn extract_launch_attestation(cert_der: &[u8]) -> Option<LaunchAttestation> {
+    use x509_parser::prelude::{FromDer, X509Certificate};
+
+    let (_, cert) = X509Certificate::from_der(cert_der).ok()?;
+    for ext in cert.extensions() {
+        if ext.oid.as_bytes() == crate::oid::OID_NUCLEUS_ATTESTATION_BYTES {
+            return LaunchAttestation::from_der(ext.value).ok();
+        }
+    }
+    None
+}
+
+/// Relying-party verification of an attested SVID served over `FETCH_SVID`.
+///
+/// This is the *outside* verifier for the North Star C9 leg: given the PEM cert
+/// chain a pod serves and the measurements an operator expects, decide whether to
+/// trust the pod. It parses the leaf certificate, extracts the embedded launch
+/// attestation, and checks it against `requirements`. Two teeth:
+///
+/// * **fail-closed on absent** — with `require_attestation` set, a served leaf that
+///   carries no launch-attestation extension is an `Err`, NOT a vacuous pass.
+///   (`AttestationRequirements::any().verify` would accept anything; this refuses a
+///   cert that carries no measurement at all.) With `require_attestation` cleared,
+///   an absent extension yields `Ok(None)`.
+/// * **drift** — a present measurement outside `requirements` is an `Err`.
+///
+/// # Trust boundary (read this)
+///
+/// The measurement is the *node's own* SHA-256 of the kernel+rootfs it launched,
+/// signed by the node's CA key. There is **no hardware root**: no TPM / SEV-SNP /
+/// TDX quote, no UDS-in-ROM DICE identity binding the signing key to silicon. The
+/// guarantee is therefore strictly conditional — *IF you trust this node's key,
+/// THEN the pod was launched from an artifact with these measurements.* A
+/// compromised node can sign any measurement. This is first-party **software**
+/// launch attestation, not hardware attestation.
+pub fn verify_attested_svid(
+    chain_pem: &str,
+    requirements: &AttestationRequirements,
+    require_attestation: bool,
+) -> Result<Option<LaunchAttestation>> {
+    let leaf = pem::parse(chain_pem)
+        .map_err(|e| Error::VerificationFailed(format!("cert PEM parse failed: {e}")))?;
+    match extract_launch_attestation(leaf.contents()) {
+        Some(att) => {
+            requirements.verify(&att)?;
+            Ok(Some(att))
+        }
+        None if require_attestation => Err(Error::VerificationFailed(
+            "served SVID carries no launch-attestation extension (fail-closed)".to_string(),
+        )),
+        None => Ok(None),
+    }
 }
 
 #[cfg(test)]

--- a/crates/nucleus-identity/src/lib.rs
+++ b/crates/nucleus-identity/src/lib.rs
@@ -50,7 +50,9 @@ pub mod workload_api;
 pub use approval_bundle::{
     ApprovalBundleBuilder, ApprovalBundleClaims, ApprovalBundleHeader, ApprovalBundleVerifier,
 };
-pub use attestation::{AttestationRequirements, LaunchAttestation};
+pub use attestation::{
+    extract_launch_attestation, verify_attested_svid, AttestationRequirements, LaunchAttestation,
+};
 #[cfg(feature = "spire")]
 pub use ca::{auto_detect_ca, SpireCaClient, DEFAULT_SPIRE_SOCKET, SPIFFE_ENDPOINT_ENV};
 pub use ca::{CaClient, SelfSignedCa};

--- a/crates/nucleus-identity/src/manager.rs
+++ b/crates/nucleus-identity/src/manager.rs
@@ -153,6 +153,25 @@ impl<C: CaClient + 'static> SecretManager<C> {
         self.fetch_new_certificate(identity).await
     }
 
+    /// Warms the certificate cache with a pre-signed certificate for an identity.
+    ///
+    /// This is how an *attested* certificate (one carrying an embedded
+    /// launch-attestation X.509 extension, signed out-of-band via
+    /// `CaClient::sign_attested_csr`) reaches the served `FETCH_SVID` fast-path,
+    /// which reads this same cache in [`Self::fetch_certificate`]. Without warming
+    /// the cache, an attested cert is signed and then dropped — the fast-path keeps
+    /// serving the plain cert and the measurement never leaves the node.
+    pub async fn cache_certificate(&self, identity: &Identity, cert: Arc<WorkloadCertificate>) {
+        let mut certs = self.certs.write().await;
+        certs.insert(
+            identity.clone(),
+            CertState::Available {
+                cert,
+                last_refresh_attempt: Instant::now(),
+            },
+        );
+    }
+
     /// Fetches a session-scoped certificate derived from a parent workload identity.
     ///
     /// Session certificates enable audit correlation across multiple tool calls within

--- a/crates/nucleus-node/src/identity.rs
+++ b/crates/nucleus-node/src/identity.rs
@@ -265,9 +265,10 @@ impl IdentityManager {
 
     /// Fetches an attested certificate for the given identity and pod.
     ///
-    /// If attestation exists for the pod, it will be embedded in the certificate
-    /// as an X.509 extension.
-    #[allow(dead_code)]
+    /// If attestation exists for the pod, it will be embedded in the certificate as
+    /// an X.509 extension, and the result is written into the shared certificate
+    /// cache so the served `FETCH_SVID` path returns the *attested* cert rather than
+    /// a plain one. If no attestation is registered, falls back to a standard cert.
     #[tracing::instrument(skip_all, fields(boot.stage = "cert.issue"))]
     pub async fn fetch_attested_certificate(
         &self,
@@ -306,7 +307,13 @@ impl IdentityManager {
                     .await
                     .map_err(|e| format!("attested signing failed: {e}"))?;
 
-                Ok(Arc::new(cert))
+                // Warm the cache so the served FETCH_SVID fast-path returns THIS
+                // attested cert (carrying the measurement), not the plain one.
+                let cert = std::sync::Arc::new(cert);
+                self.secret_manager
+                    .cache_certificate(identity, cert.clone())
+                    .await;
+                Ok(cert)
             }
             None => {
                 warn!(
@@ -341,6 +348,97 @@ mod tests {
     async fn test_identity_manager_creation() {
         let manager = IdentityManager::new("test.local", Duration::from_secs(3600)).unwrap();
         assert_eq!(manager.trust_domain(), "test.local");
+    }
+
+    /// North Star C9 (Inc 1): an attested SVID is served over the real cache path a
+    /// pod's `FETCH_SVID` reads, and a shipped relying-party verifier reds on
+    /// measurement drift and on an absent extension (fail-closed) — while passing
+    /// the correct measurement (non-vacuous). KVM-free: exercises the same
+    /// `fetch_certificate` fast-path the workload API serves, minus the UDS
+    /// transport and a real Firecracker rootfs (named gaps in the ledger).
+    #[tokio::test]
+    async fn attested_svid_is_served_and_verifier_reds_on_drift_and_absent() {
+        use nucleus_identity::{verify_attested_svid, AttestationRequirements};
+        use std::io::Write;
+
+        let manager = IdentityManager::new("test.local", Duration::from_secs(3600)).unwrap();
+
+        // Two temp "images" the node measures, plus a config blob.
+        let mut kernel = tempfile::NamedTempFile::new().unwrap();
+        kernel.write_all(b"kernel-image-bytes").unwrap();
+        let mut rootfs = tempfile::NamedTempFile::new().unwrap();
+        rootfs.write_all(b"rootfs-image-bytes").unwrap();
+        let config = b"pod-config-blob";
+
+        // Attested pod: measure, then issue+cache the attested cert.
+        let attested_pod = Uuid::new_v4();
+        let attested_id = manager.identity_for_pod(attested_pod, "default", "attested");
+        let att = manager
+            .compute_attestation(
+                &attested_pod.to_string(),
+                kernel.path(),
+                rootfs.path(),
+                config,
+            )
+            .await
+            .expect("attestation computes");
+        manager
+            .fetch_attested_certificate(&attested_id, &attested_pod.to_string())
+            .await
+            .expect("attested cert issues");
+
+        // The SERVED path: fetch_certificate is exactly what FETCH_SVID calls. After
+        // caching it must return the ATTESTED cert (carrying the measurement).
+        let chain = manager
+            .fetch_certificate(&attested_id)
+            .await
+            .expect("served cert")
+            .chain_pem();
+
+        let expected = AttestationRequirements::exact(
+            *att.kernel_hash(),
+            *att.rootfs_hash(),
+            *att.config_hash(),
+        );
+
+        // (i) POSITIVE CONTROL — correct expectation verifies (proves it is not
+        //     always-red: teeth (ii)/(iii) below then mean something).
+        assert!(
+            verify_attested_svid(&chain, &expected, true)
+                .expect("correct measurement verifies")
+                .is_some(),
+            "served SVID must carry the launch attestation"
+        );
+
+        // (ii) TEETH — one byte of drift in the expected artifact reds the verifier.
+        let mut wrong_kernel = *att.kernel_hash();
+        wrong_kernel[0] ^= 0x01;
+        let drifted =
+            AttestationRequirements::exact(wrong_kernel, *att.rootfs_hash(), *att.config_hash());
+        assert!(
+            verify_attested_svid(&chain, &drifted, true).is_err(),
+            "one byte of measurement drift must red the verifier"
+        );
+
+        // (iii) TEETH — a plain (unattested) pod's SVID fails closed when required,
+        //       and yields no attestation (not a spurious one) when not required.
+        let plain_pod = Uuid::new_v4();
+        let plain_id = manager.identity_for_pod(plain_pod, "default", "plain");
+        let plain_chain = manager
+            .fetch_certificate(&plain_id)
+            .await
+            .expect("plain cert")
+            .chain_pem();
+        assert!(
+            verify_attested_svid(&plain_chain, &AttestationRequirements::any(), true).is_err(),
+            "absent extension + require_attestation must fail closed"
+        );
+        assert!(
+            verify_attested_svid(&plain_chain, &AttestationRequirements::any(), false)
+                .expect("absent-not-required is ok")
+                .is_none(),
+            "absent extension without requirement yields no attestation"
+        );
     }
 
     #[tokio::test]

--- a/crates/nucleus-node/src/main.rs
+++ b/crates/nucleus-node/src/main.rs
@@ -2718,13 +2718,18 @@ async fn spawn_firecracker_pod(
                             id,
                             attestation.to_hex_summary()
                         );
-                        // Fetch attested certificate (includes attestation in X.509 extension)
+                        // Issue + cache the attested certificate so the served
+                        // FETCH_SVID path carries the measurement. If this fails the
+                        // pod keeps a plain (unattested) cert — a relying party that
+                        // requires attestation will then refuse it (fail-closed at
+                        // the verifier), so name that consequence here.
                         if let Err(e) = manager
                             .fetch_attested_certificate(&identity, &pod_id_str)
                             .await
                         {
                             tracing::warn!(
-                                "failed to fetch attested certificate for pod {}: {}",
+                                "pod {} will serve a PLAIN (unattested) SVID; attesting \
+                                 relying parties will refuse it: {}",
                                 id,
                                 e
                             );

--- a/crates/nucleus-node/src/main.rs
+++ b/crates/nucleus-node/src/main.rs
@@ -2687,148 +2687,141 @@ async fn spawn_firecracker_pod(
         // guest held a capability the verifier had never seen.
         let (broker_serve, broker_verify) = broker_launch::BrokerCapability::mint();
 
-        let (pod_identity, identity_manager, workload_api_bridge) =
-            if let Some(manager) = identity_source {
-                // Use pod metadata for namespace/service_account context
-                let namespace = spec.metadata.namespace.as_deref().unwrap_or("default");
-                let service_account = spec.metadata.name.as_deref().unwrap_or("");
-                let identity = manager.identity_for_pod(id, namespace, service_account);
+        let (pod_identity, identity_manager, workload_api_bridge) = if let Some(manager) =
+            identity_source
+        {
+            // Use pod metadata for namespace/service_account context
+            let namespace = spec.metadata.namespace.as_deref().unwrap_or("default");
+            let service_account = spec.metadata.name.as_deref().unwrap_or("");
+            let identity = manager.identity_for_pod(id, namespace, service_account);
 
-                // Register the pod identity
-                let registry_key = id.to_string();
-                identity_registry_key = Some(registry_key.clone());
-                manager.register_pod(registry_key, identity.clone()).await;
+            // Register the pod identity
+            let registry_key = id.to_string();
+            identity_registry_key = Some(registry_key.clone());
+            manager.register_pod(registry_key, identity.clone()).await;
 
-                // Compute launch attestation for this pod
-                // This captures integrity measurements of kernel, rootfs, and config
-                let pod_id_str = id.to_string();
-                let config_bytes = serde_json::to_vec(spec).unwrap_or_default();
-                match manager
-                    .compute_attestation(
-                        &pod_id_str,
-                        &image.kernel_path,
-                        &image.rootfs_path,
-                        &config_bytes,
-                    )
-                    .await
-                {
-                    Ok(attestation) => {
-                        info!(
-                            "computed launch attestation for pod {}: {}",
-                            id,
-                            attestation.to_hex_summary()
-                        );
-                        // Issue + cache the attested certificate so the served
-                        // FETCH_SVID path carries the measurement. If this fails the
-                        // pod keeps a plain (unattested) cert — a relying party that
-                        // requires attestation will then refuse it (fail-closed at
-                        // the verifier), so name that consequence here.
-                        if let Err(e) = manager
-                            .fetch_attested_certificate(&identity, &pod_id_str)
-                            .await
-                        {
-                            tracing::warn!(
-                                "pod {} will serve a PLAIN (unattested) SVID; attesting \
-                                 relying parties will refuse it: {}",
-                                id,
-                                e
-                            );
-                        }
+            // Compute launch attestation for this pod
+            // This captures integrity measurements of kernel, rootfs, and config
+            let pod_id_str = id.to_string();
+            let config_bytes = serde_json::to_vec(spec).unwrap_or_default();
+            match manager
+                .compute_attestation(
+                    &pod_id_str,
+                    &image.kernel_path,
+                    &image.rootfs_path,
+                    &config_bytes,
+                )
+                .await
+            {
+                Ok(attestation) => {
+                    info!(
+                        "computed launch attestation for pod {}: {}",
+                        id,
+                        attestation.to_hex_summary()
+                    );
+                    // Cache the attested cert so the served FETCH_SVID carries the measurement;
+                    // else the pod serves a plain SVID an attesting relying party refuses.
+                    if let Err(e) = manager
+                        .fetch_attested_certificate(&identity, &pod_id_str)
+                        .await
+                    {
+                        tracing::warn!("pod {id} serves a PLAIN (unattested) SVID; attesting relying parties refuse it: {e}");
                     }
-                    Err(e) => {
-                        tracing::warn!(
+                }
+                Err(e) => {
+                    tracing::warn!(
                         "failed to compute attestation for pod {}, using standard certificate: {}",
                         id,
                         e
                     );
-                        // Fall back to standard certificate without attestation
-                        if let Err(e) = manager.prefetch_certificate(&identity).await {
-                            tracing::warn!("failed to prefetch certificate for pod {}: {}", id, e);
-                        }
+                    // Fall back to standard certificate without attestation
+                    if let Err(e) = manager.prefetch_certificate(&identity).await {
+                        tracing::warn!("failed to prefetch certificate for pod {}: {}", id, e);
                     }
                 }
+            }
 
-                // Start workload API vsock bridge for this pod
-                // Uses Firecracker's naming convention: {vsock_uds_path}_{port}
-                // Guest connects to CID 2 (host) on the workload API port via AF_VSOCK
-                let bridge = match workload_api_vsock::WorkloadApiVsockBridge::start(
-                    &vsock_path,
-                    state.identity_vsock_port,
-                    id,
-                    manager.clone(),
-                    workload_api_vsock::PodMaterial {
-                        // The same token that rides the kernel command line today.
-                        // Serving it here is what lets the cmdline copy go: a value
-                        // fetched after boot is not baked into a snapshot base.
-                        task_token: task_token.clone(),
-                        // This pod's caller identity for the management API, derived
-                        // from a NODE-ONLY secret. Deliberately not `auth_secret`:
-                        // every proxy already holds that one, so deriving from it
-                        // would let any pod compute any other pod's token and the
-                        // mechanism would prove nothing.
-                        caller_token: Some(pod_caller_identity::derive_token(
-                            state.caller_secret.as_ref(),
-                            id,
-                        )),
-                        // Pod-scoped DLC-D admission provisioning (PodSpec labels).
-                        dlc_admission: workload_api_vsock::DlcAdmissionMaterial::from_labels(
-                            &spec.metadata.labels,
-                        ),
-                        // The broker capability, minted per pod and served ONCE. See
-                        // `handle_fetch_broker_secret`: this is what lets the host
-                        // tell the mediating proxy from every other guest process.
-                        broker_secret: Some(broker_serve.into_served()),
-                        // Served WITH the capability, not separately — the proxy
-                        // needs both to reach the broker and neither is useful alone.
-                        broker_port: state.broker_vsock_port,
-                        broker_secret_served: std::sync::Arc::new(
-                            std::sync::atomic::AtomicBool::new(false),
-                        ),
-                        // The S3 audit-sink credentials, served once over this
-                        // socket instead of riding the world-readable kernel
-                        // command line (the C1 exposure).
-                        audit_creds: workload_api_vsock::AuditCredentials::from_node_env(
-                            spec.spec.audit_sink.is_some(),
-                        ),
-                        audit_creds_served: std::sync::Arc::default(),
-                    },
-                    // Only when jailed: unjailed Firecracker runs as this same user
-                    // and can already connect. Passing an owner there would hand our
-                    // own socket away for no reason.
-                    jail_layout
-                        .as_ref()
-                        .map(|_| (state.jailer_uid, state.jailer_gid)),
-                )
-                .await
-                {
-                    Ok(b) => {
-                        info!(
-                            "started workload API vsock bridge at {} for pod {}",
-                            b.socket_path().display(),
-                            id
-                        );
-                        Some(b)
-                    }
-                    Err(e) => {
-                        tracing::warn!(
-                            "failed to start workload API vsock bridge for pod {}: {}",
-                            id,
-                            e
-                        );
-                        None
-                    }
-                };
-
-                info!(
-                    "registered identity {} for pod {}",
-                    identity.to_spiffe_uri(),
-                    id
-                );
-
-                (Some(identity), Some(manager.clone()), bridge)
-            } else {
-                (None, None, None)
+            // Start workload API vsock bridge for this pod
+            // Uses Firecracker's naming convention: {vsock_uds_path}_{port}
+            // Guest connects to CID 2 (host) on the workload API port via AF_VSOCK
+            let bridge = match workload_api_vsock::WorkloadApiVsockBridge::start(
+                &vsock_path,
+                state.identity_vsock_port,
+                id,
+                manager.clone(),
+                workload_api_vsock::PodMaterial {
+                    // The same token that rides the kernel command line today.
+                    // Serving it here is what lets the cmdline copy go: a value
+                    // fetched after boot is not baked into a snapshot base.
+                    task_token: task_token.clone(),
+                    // This pod's caller identity for the management API, derived
+                    // from a NODE-ONLY secret. Deliberately not `auth_secret`:
+                    // every proxy already holds that one, so deriving from it
+                    // would let any pod compute any other pod's token and the
+                    // mechanism would prove nothing.
+                    caller_token: Some(pod_caller_identity::derive_token(
+                        state.caller_secret.as_ref(),
+                        id,
+                    )),
+                    // Pod-scoped DLC-D admission provisioning (PodSpec labels).
+                    dlc_admission: workload_api_vsock::DlcAdmissionMaterial::from_labels(
+                        &spec.metadata.labels,
+                    ),
+                    // The broker capability, minted per pod and served ONCE. See
+                    // `handle_fetch_broker_secret`: this is what lets the host
+                    // tell the mediating proxy from every other guest process.
+                    broker_secret: Some(broker_serve.into_served()),
+                    // Served WITH the capability, not separately — the proxy
+                    // needs both to reach the broker and neither is useful alone.
+                    broker_port: state.broker_vsock_port,
+                    broker_secret_served: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(
+                        false,
+                    )),
+                    // The S3 audit-sink credentials, served once over this
+                    // socket instead of riding the world-readable kernel
+                    // command line (the C1 exposure).
+                    audit_creds: workload_api_vsock::AuditCredentials::from_node_env(
+                        spec.spec.audit_sink.is_some(),
+                    ),
+                    audit_creds_served: std::sync::Arc::default(),
+                },
+                // Only when jailed: unjailed Firecracker runs as this same user
+                // and can already connect. Passing an owner there would hand our
+                // own socket away for no reason.
+                jail_layout
+                    .as_ref()
+                    .map(|_| (state.jailer_uid, state.jailer_gid)),
+            )
+            .await
+            {
+                Ok(b) => {
+                    info!(
+                        "started workload API vsock bridge at {} for pod {}",
+                        b.socket_path().display(),
+                        id
+                    );
+                    Some(b)
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "failed to start workload API vsock bridge for pod {}: {}",
+                        id,
+                        e
+                    );
+                    None
+                }
             };
+
+            info!(
+                "registered identity {} for pod {}",
+                identity.to_spiffe_uri(),
+                id
+            );
+
+            (Some(identity), Some(manager.clone()), bridge)
+        } else {
+            (None, None, None)
+        };
 
         if let Err(err) = wait_for_proxy_health(health_addr).await {
             if let Some(proxy) = signed_proxy {

--- a/docs/north-star.md
+++ b/docs/north-star.md
@@ -87,7 +87,7 @@ status is a visible event, not an edit.
 | C6 | "every mediated channel" | TESTED | `crates/nucleus-ifc-kernel/src/egress_channel.rs#no_channel_is_an_open_hole`, `crates/portcullis-core/lean/MediationScopeExtracted.lean#no_sink_reachable_without_discharge`, `crates/nucleus-ifc-kernel/src/egress_channel.rs#documented_inventory_equals_the_enum`, `scripts/check-egress-probe.sh`, `docs/architecture/mediated-set.md` | `scripts/check-egress-probe.sh` |
 | C7 | "a theorem about the code that ships" | TESTED | `.github/workflows/aeneas-ifc-scoped.yml`, `crates/nucleus-ifc-kernel/src/extracted/identity.rs` | `.github/workflows/aeneas-ifc-scoped.yml` |
 | C8 | "re-checked on every change" | TESTED | `.github/workflows/aeneas-ifc-scoped.yml`, `scripts/check-extracted-callsites.sh`, `scripts/extracted-callsites-manifest.txt` | `scripts/check-extracted-callsites.sh` |
-| C9 | "verify from the outside" | NOT-YET | `crates/nucleus-identity/src/attestation.rs`, `crates/nucleus-node/src/posture.rs#admit_posture` | — |
+| C9 | "verify from the outside" | NOT-YET | `crates/nucleus-identity/src/attestation.rs#verify_attested_svid`, `crates/nucleus-node/src/identity.rs#attested_svid_is_served_and_verifier_reds_on_drift_and_absent`, `crates/nucleus-cli/src/verify_attestation.rs`, `crates/nucleus-node/src/posture.rs#admit_posture` | — |
 *The clause fragments quote the sentence above, whose exclusions travel with
 them: the claim covers explicit flows only, excluding timing, cache, and other
 microarchitectural channels, and excluding availability and resource-contention
@@ -362,28 +362,40 @@ What each status means, and what it deliberately does not:
   and the base flows-to relations (`iflows_to`/`cflows_to`) are exercised
   transitively by the decision predicates. TESTED, not PROVED: the correspondence
   is a build-system + grep-gate check, not a proof.
-- **C9 (NOT-YET — demoted 2026-08-08, was TESTED).** The external-verification
-  leg is not wired end to end, so a relying party CANNOT yet verify from the
-  outside. Concretely: `FETCH_SVID` serves a plain certificate
-  (`manager.fetch_certificate` → `sign_csr`) with **no** DICE attestation
-  extension; the only producer that would embed measurements,
-  `fetch_attested_certificate`, is `#[allow(dead_code)]` and, at its single call
-  site, its success value is **discarded** (only the error arm is handled), and
-  no CA implements `sign_attested_csr` — every backend falls through to plain
-  `sign_csr`. So no served cert carries a measurement. On the consumer side,
-  `AttestationRequirements::verify` / `LaunchAttestation::from_der` have no
-  production caller, so no shipped relying party extracts and checks a launch
-  attestation. What DOES exist and is real: `admit_posture` verifies a claimed
-  `posture@digest` against a self-measured rootfs digest, fail-closed and
-  perturbation-tested (`admit_posture_one_byte_of_drift_reds_the_gate`) — but it
-  is the pod's own self-characterization at admission, not outside verification,
-  and it is inert unless a pod carries a `dlc_posture` label (no shipped spec or
-  the CI probe emits one, so the boot gate never exercises it — which is also
-  why the former `quickstart-boot.yml` falsifier could not red on a regression).
-  Re-earning C9 needs: embed the measurement on the served SVID (implement
-  `sign_attested_csr`, stop discarding the attested cert), a shipped
-  relying-party verifier that checks it, and signed provenance binding the
-  artifact digest to the theorem set.
+- **C9 (NOT-YET — demoted 2026-08-08, was TESTED; Inc 1 landed 2026-08-11).**
+  Increment 1 wired the first end-to-end vertical, but the leg is not yet fully
+  earned. **What now holds (node-signed *software* launch attestation):** the
+  producer no longer discards the attested cert — `fetch_attested_certificate`
+  caches it (`SecretManager::cache_certificate`) so the served `FETCH_SVID`
+  fast-path (`manager.fetch_certificate`) returns the cert carrying the
+  measurement, and `SelfSignedCa::sign_attested_csr` really does embed the DICE
+  extension (the prior note's "no CA implements `sign_attested_csr`" and
+  "`#[allow(dead_code)]`/discarded" facts are now false for the shipping path). A
+  **shipped relying party** exists — `nucleus_identity::verify_attested_svid`
+  (extract `LaunchAttestation` from the leaf, check against
+  `AttestationRequirements`) with a production CLI caller `nucleus
+  verify-attestation`. The teeth are exercised over the real serve path:
+  `identity::tests::attested_svid_is_served_and_verifier_reds_on_drift_and_absent`
+  proves (i) correct measurement verifies (non-vacuous), (ii) one byte of drift
+  reds, (iii) an absent extension fails closed under `require_attestation`;
+  `cli_verifies_attested_and_reds_on_drift_and_absent` proves the same through
+  the CLI entrypoint. **Trust boundary (why still NOT-YET, not overclaim):** the
+  measurement is the node's own SHA-256 of the kernel+rootfs it launched, signed
+  by the node's CA key — there is **no hardware root** (no TPM/SEV-SNP/TDX quote,
+  no UDS-in-ROM DICE identity), so the guarantee is conditional on trusting the
+  node key; a compromised node can sign any measurement. **Remaining for TESTED:**
+  (a) the verifier must run on a *live request/admission* path (peer mTLS gate /
+  node admission, fail-closed), not only a CLI self-check — the tool-proxy
+  `sandbox_proof.rs` verifier is still dead; (b) the served-attestation path is
+  exercised on the Firecracker driver only (a local-driver pod has no VM image to
+  measure) and the round-trip test drives the real cache→serve fast-path minus the
+  UDS transport; (c) signed provenance binding the artifact digest to the theorem
+  set (in-toto-style: subject = rootfs/kernel digest, predicate = ledger commit);
+  (d) the hardware-root gap named above. The adjacent real thing remains
+  `admit_posture` (self-measured rootfs digest, fail-closed,
+  `admit_posture_one_byte_of_drift_reds_the_gate`) — same TCB boundary, now also
+  exposed to an *outside* verifier. Note: OID PEN 57212 is an unregistered
+  placeholder; register it before any external-interop claim.
 
 The cross-pod leg is the open one, and it is deliberately sequenced audit-first:
 a lookup keyed on something a guest can forge is a far likelier defect than a


### PR DESCRIPTION
First end-to-end vertical for the North Star **C9 "verify from the outside"** leg, framed honestly as **node-signed _software_ launch attestation** (no hardware root). **C9 stays NOT-YET** — promotion is reserved.

## What the prior ledger note got wrong (now corrected)
- "no CA implements `sign_attested_csr`" — false for the shipping path: `SelfSignedCa::sign_attested_csr` embeds the DICE extension.
- "`fetch_attested_certificate` is `#[allow(dead_code)]` and its success is discarded" — the real gap was **cache/serve**, not signing: the attested cert was signed then dropped, so `FETCH_SVID` kept serving the plain cert.

## Producer — serve the measurement
`fetch_attested_certificate` now warms the shared cert cache (`SecretManager::cache_certificate`) so the served `FETCH_SVID` fast-path (`manager.fetch_certificate`) returns the cert carrying the launch-attestation X.509 extension. The pod-spawn call site names the fail-closed consequence (a plain-cert pod is refused by an attesting relying party).

## Verifier — a shipped relying party with a production caller
`nucleus_identity::verify_attested_svid` extracts the `LaunchAttestation` from the leaf and checks it against `AttestationRequirements`. Two teeth:
- **drift** — a measurement outside the expected set reds.
- **fail-closed on absent** — with `require_attestation`, a cert with no extension is an error, not the vacuous pass `AttestationRequirements::any().verify` would give.

Production caller: `nucleus verify-attestation --cert <chain.pem> --expect-kernel/-rootfs/-config <hex>`.

## Teeth (KVM-free, over the real serve path)
- `nucleus-node::identity::tests::attested_svid_is_served_and_verifier_reds_on_drift_and_absent` — positive control (non-vacuous), one-byte drift reds, absent fails closed. Exercises the real cache→`fetch_certificate` serve path (what `FETCH_SVID` calls), minus the UDS transport.
- `nucleus-cli::verify_attestation::tests::cli_verifies_attested_and_reds_on_drift_and_absent` — same through the production CLI entrypoint, over real attested certs minted by `SelfSignedCa`.

## Trust boundary (why still NOT-YET, not an overclaim)
The measurement is the node's own SHA-256 of the kernel+rootfs it launched, signed by the node's CA key. **No hardware root** — no TPM/SEV-SNP/TDX quote, no UDS-in-ROM DICE identity. The guarantee is conditional: *IF you trust the node's key, THEN the pod ran an artifact with these measurements.* Reframed the attestation module header + docs accordingly, softened the "TCG DICE Compliance" wording to "DICE-format-compatible encoding", and flagged the unregistered OID PEN 57212.

**Remaining for TESTED** (all named in the ledger note): (a) verifier enforced on a live request/admission path (peer mTLS / admission), not only a CLI self-check — the tool-proxy `sandbox_proof.rs` verifier is still dead; (b) real UDS/Firecracker transport (local-driver has no VM image to measure); (c) signed provenance binding the artifact digest to the theorem set; (d) hardware-root gap.

## Gates
- Linux `cargo clippy --all-targets --all-features -- -D warnings` ✅ (the removed `#[allow(dead_code)]` is covered — `--all-targets` compiles the test that calls the method)
- Linux `cargo test -p nucleus-node --features local-driver` (round-trip) ✅ · `cargo test -p nucleus-cli` ✅
- `cargo fmt --check` ✅ · `scripts/check-north-star-ledger.sh` ✅ (9 clauses, 2 NOT-YET pinned)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148ebbw4UXypRjhMw3xAQzj