### PR TITLE
C9 Phase 0: un-nail IdentityManager from SelfSignedCa (dyn CaClient seam)

### DIFF
--- a/crates/nucleus-identity/src/ca/mod.rs
+++ b/crates/nucleus-identity/src/ca/mod.rs
@@ -30,6 +30,7 @@ use crate::certificate::WorkloadCertificate;
 use crate::identity::Identity;
 use crate::Result;
 use async_trait::async_trait;
+use std::sync::Arc;
 use std::time::Duration;
 
 /// A Certificate Authority client that can sign CSRs.
@@ -174,4 +175,73 @@ pub trait CaClient: Send + Sync {
 
     /// Returns the trust domain this CA serves.
     fn trust_domain(&self) -> &str;
+}
+
+/// Blanket impl so a runtime-selected `Arc<dyn CaClient>` satisfies `CaClient`
+/// anywhere a concrete CA is required (e.g. `SecretManager<Arc<dyn CaClient>>`). This
+/// is the seam that lets a host choose its attestation root at runtime instead of
+/// being monomorphized to one CA type.
+///
+/// Every method — INCLUDING the defaulted `sign_attested_csr` / `sign_fused_csr` — is
+/// forwarded through the trait object, so the inner concrete CA's overrides are what
+/// runs. This matters: if the defaults were inherited here, an `Arc<dyn CaClient>`
+/// wrapping a `SelfSignedCa` would silently drop the attestation extension and serve
+/// a plain cert. The `attested_svid_is_served_*` round-trip test guards against that.
+#[async_trait]
+impl CaClient for Arc<dyn CaClient> {
+    async fn sign_csr(
+        &self,
+        csr: &str,
+        private_key: &str,
+        identity: &Identity,
+        ttl: Duration,
+    ) -> Result<WorkloadCertificate> {
+        (**self).sign_csr(csr, private_key, identity, ttl).await
+    }
+
+    async fn sign_attested_csr(
+        &self,
+        csr: &str,
+        private_key: &str,
+        identity: &Identity,
+        ttl: Duration,
+        attestation: &LaunchAttestation,
+    ) -> Result<WorkloadCertificate> {
+        (**self)
+            .sign_attested_csr(csr, private_key, identity, ttl, attestation)
+            .await
+    }
+
+    async fn sign_fused_csr(
+        &self,
+        csr: &str,
+        private_key: &str,
+        identity: &Identity,
+        ttl: Duration,
+        attestation: &LaunchAttestation,
+        permission_fingerprint: &[u8; 32],
+    ) -> Result<WorkloadCertificate> {
+        (**self)
+            .sign_fused_csr(
+                csr,
+                private_key,
+                identity,
+                ttl,
+                attestation,
+                permission_fingerprint,
+            )
+            .await
+    }
+
+    async fn sign_csr_only(&self, csr: &str, identity: &Identity, ttl: Duration) -> Result<String> {
+        (**self).sign_csr_only(csr, identity, ttl).await
+    }
+
+    fn trust_bundle(&self) -> &crate::certificate::TrustBundle {
+        (**self).trust_bundle()
+    }
+
+    fn trust_domain(&self) -> &str {
+        (**self).trust_domain()
+    }
 }

--- a/crates/nucleus-node/src/identity.rs
+++ b/crates/nucleus-node/src/identity.rs
@@ -30,9 +30,11 @@ use uuid::Uuid;
 #[derive(Clone)]
 pub struct IdentityManager {
     /// The secret manager for certificate operations.
-    secret_manager: Arc<SecretManager<SelfSignedCa>>,
-    /// The CA client (needed for trust bundle access).
-    ca: Arc<SelfSignedCa>,
+    secret_manager: Arc<SecretManager<Arc<dyn CaClient>>>,
+    /// The CA client (needed for trust bundle access). Held as `dyn` so the node is
+    /// not monomorphized to one CA type — a future hardware-rooted or SPIRE-issued
+    /// root can be injected via [`IdentityManager::with_ca`].
+    ca: Arc<dyn CaClient>,
     /// Registry mapping pod IDs to their SPIFFE identities.
     vm_registry: Arc<VmRegistry>,
     /// Trust domain for this node.
@@ -49,21 +51,38 @@ impl IdentityManager {
     /// For production, this should be replaced with a SPIRE CA client.
     pub fn new(trust_domain: impl Into<String>, cert_ttl: Duration) -> Result<Self, String> {
         let trust_domain = trust_domain.into();
-        let ca = Arc::new(
+        let ca: Arc<dyn CaClient> = Arc::new(
             SelfSignedCa::new(&trust_domain)
                 .map_err(|e| format!("failed to create self-signed CA: {e}"))?,
         );
-        let secret_manager = SecretManager::new(ca.clone(), cert_ttl);
+        Ok(Self::with_ca(trust_domain, cert_ttl, ca))
+    }
+
+    /// Creates an identity manager backed by an arbitrary attestation root.
+    ///
+    /// [`Self::new`] uses a self-signed CA; this constructor lets a host inject any
+    /// [`CaClient`] — a future hardware-rooted backend (TPM DevID, cloud KMS), a
+    /// SPIRE-issued root, etc. — without the node being monomorphized to one CA type.
+    /// The injected CA must override `sign_attested_csr` for attested SVIDs to carry
+    /// a measurement; a CA that only signs plainly yields plain SVIDs (which an
+    /// attesting relying party then refuses, fail-closed).
+    pub fn with_ca(
+        trust_domain: impl Into<String>,
+        cert_ttl: Duration,
+        ca: Arc<dyn CaClient>,
+    ) -> Self {
+        let trust_domain = trust_domain.into();
+        let secret_manager = SecretManager::new(Arc::new(ca.clone()), cert_ttl);
         let vm_registry = Arc::new(RwLock::new(HashMap::new()));
 
-        Ok(Self {
+        Self {
             secret_manager,
             ca,
             vm_registry,
             trust_domain,
             attestation_registry: Arc::new(RwLock::new(HashMap::new())),
             cert_ttl,
-        })
+        }
     }
 
     /// Returns the trust domain.
@@ -348,6 +367,56 @@ mod tests {
     async fn test_identity_manager_creation() {
         let manager = IdentityManager::new("test.local", Duration::from_secs(3600)).unwrap();
         assert_eq!(manager.trust_domain(), "test.local");
+    }
+
+    /// C9 Phase 0: a CA injected via `with_ca` (as `Arc<dyn CaClient>`) flows through
+    /// the `dyn` seam AND still embeds launch attestation — proving the blanket
+    /// `impl CaClient for Arc<dyn CaClient>` forwards `sign_attested_csr` to the
+    /// concrete override rather than the extension-dropping trait default.
+    #[tokio::test]
+    async fn with_ca_injects_a_root_that_still_attests_through_the_dyn_seam() {
+        use nucleus_identity::{verify_attested_svid, AttestationRequirements, SelfSignedCa};
+        use std::io::Write;
+
+        let injected: Arc<dyn CaClient> = Arc::new(SelfSignedCa::new("injected.local").unwrap());
+        let manager =
+            IdentityManager::with_ca("injected.local", Duration::from_secs(3600), injected);
+        assert_eq!(manager.trust_domain(), "injected.local");
+
+        let mut kernel = tempfile::NamedTempFile::new().unwrap();
+        kernel.write_all(b"k").unwrap();
+        let mut rootfs = tempfile::NamedTempFile::new().unwrap();
+        rootfs.write_all(b"r").unwrap();
+
+        let pod = Uuid::new_v4();
+        let id = manager.identity_for_pod(pod, "default", "svc");
+        let att = manager
+            .compute_attestation(&pod.to_string(), kernel.path(), rootfs.path(), b"cfg")
+            .await
+            .expect("attest");
+        manager
+            .fetch_attested_certificate(&id, &pod.to_string())
+            .await
+            .expect("issue attested cert via injected dyn CA");
+
+        // The served cert (from the cache the injected CA wrote through) must carry
+        // the measurement — i.e. the dyn seam did NOT drop the attestation.
+        let chain = manager
+            .fetch_certificate(&id)
+            .await
+            .expect("served")
+            .chain_pem();
+        let req = AttestationRequirements::exact(
+            *att.kernel_hash(),
+            *att.rootfs_hash(),
+            *att.config_hash(),
+        );
+        assert!(
+            verify_attested_svid(&chain, &req, true)
+                .expect("verify ok")
+                .is_some(),
+            "injected dyn CA must still embed the launch attestation"
+        );
     }
 
     /// North Star C9 (Inc 1): an attested SVID is served over the real cache path a


### PR DESCRIPTION
Second Phase-0 keystone of the attested-identity fabric. Makes the node's identity subsystem hold its CA as `Arc<dyn CaClient>` instead of the hardcoded `SelfSignedCa`, so a future hardware-rooted root (TPM DevID, cloud KMS) or SPIRE-issued root can be **injected** without a type-system refactor. Enabling step for wiring a *second* root (C9 Inc 2/3). **C9 stays NOT-YET; default behavior unchanged** (still SelfSignedCa).

## Changes
- **Blanket `impl CaClient for Arc<dyn CaClient>`** (`nucleus-identity/src/ca/mod.rs`) forwarding **all six** methods through the trait object. Forwarding the *defaulted* `sign_attested_csr` / `sign_fused_csr` is load-bearing: inheriting the trait defaults here would make a dyn-wrapped `SelfSignedCa` **silently drop the attestation extension** and serve a plain cert. Documented, and guarded by tests.
- **`IdentityManager`** fields → `Arc<SecretManager<Arc<dyn CaClient>>>` + `Arc<dyn CaClient>`; `new()` delegates to a new **`with_ca(trust_domain, ttl, ca)`** injection constructor. `.ca()` already returned `&dyn CaClient`; callers unaffected.

## Verification
- **New test** `with_ca_injects_a_root_that_still_attests_through_the_dyn_seam`: an externally-built CA injected via `with_ca` still embeds the launch attestation on the served cert — proves the blanket impl forwards to the concrete override, not the extension-dropping default.
- **Existing** `attested_svid_is_served_and_verifier_reds_on_drift_and_absent` now runs *through* the dyn seam and still passes → no silent downgrade.
- Node **boots healthy KVM-free** (local-driver); `nucleus-node` + `nucleus-identity` strict clippy `--all-targets` clean; fmt clean. (Linux node tests + clippy run on OrbStack aarch64.)

## Merge discipline
Touches the boot-critical identity path. The `boot-a-real-pod` CI check is **not a required gate**, so this PR is **not on automerge** — it should be admin-merged only after that boot check is observed green, per the repo's manual-gating norm for boot-affecting changes.

## Scope
Ledger untouched (C9 NOT-YET). Remaining Phase-0 piece: the SPIFFE ID facet `/att/<backend>/<tenant>/<enrollment>`. The payoff of *this* PR lands in Phase 1, where a second root (TPM DevID) is wired via `with_ca`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148ebbw4UXypRjhMw3xAQzj