### PR TITLE
C2 G4: close the self-only vacuity hole in the KVM-free cross-pod gate

### DIFF
--- a/scripts/cross-pod-scoped-check.sh
+++ b/scripts/cross-pod-scoped-check.sh
@@ -56,6 +56,14 @@
 # x-nucleus-pod-id/token → node `auth_middleware` (node-auth HMAC + identify) →
 # `pod_api::collect_pod_infos` → `caller_may_manage(Some(A), …)` server-side filter.
 #
+# THE LINEAGE TOOTH (why a third pod C exists). B-exclusion + "strict subset of
+# operator" is satisfied even by a filter broken to SELF-ONLY: {A} ⊊ {A,B} holds
+# and B is absent, yet nothing lineage-scoped was proven. So A also creates its
+# OWN child C (through A's proxy, so the node records parent=A), and the check
+# asserts C ∈ A's listing. A self-only filter drops C and reds here; only a
+# genuinely lineage-scoped filter passes. This is the discrimination the live G4
+# boot must also make — hence C, not just B.
+#
 # Usage: scripts/cross-pod-scoped-check.sh
 set -uo pipefail
 cd "$(git rev-parse --show-toplevel 2>/dev/null || echo .)"
@@ -116,6 +124,18 @@ spec:
   budget_model: { base_cost_usd: 0.000001, cost_per_second_usd: 0.0001 }
   seccomp: { mode: default }
 YAML
+# Pod C: A's OWN child, created THROUGH A's proxy so the node records parent=A.
+cat > "$WORK/c.yaml" <<YAML
+apiVersion: nucleus/v1
+kind: Pod
+metadata: { name: child-c }
+spec:
+  work_dir: .
+  timeout_seconds: 120
+  policy: { type: profile, name: read-only }
+  budget_model: { base_cost_usd: 0.000001, cost_per_second_usd: 0.0001 }
+  seccomp: { mode: default }
+YAML
 
 RA="$(N create "$WORK/a.yaml")"
 A="$(printf '%s' "$RA" | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])" 2>/dev/null)"
@@ -124,40 +144,54 @@ RB="$(N create "$WORK/b.yaml")"
 B="$(printf '%s' "$RB" | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])" 2>/dev/null)"
 [[ -n "$A" && -n "$B" && "$A" != "$B" && -n "$APROXY" ]] || { echo "ERROR: pod creation failed (A=$A B=$B proxy=$APROXY)"; tail -20 "$WORK/node.log"; exit 1; }
 
+# A creates its own child C through its proxy's /v1/pod/create — the node records
+# parent=A from A's authenticated identity, so C is genuinely in A's lineage (the
+# tooth a self-only filter cannot satisfy). Same proxy path as the list call, so
+# no request-borne auth: A's identity is baked into its proxy.
+CPAYLOAD="$(python3 -c "import json; print(json.dumps({'spec_yaml': open('$WORK/c.yaml').read(), 'reason': 'g4 lineage control: A creates its own child C'}))")"
+RC="$(curl -s -X POST "$APROXY/v1/pod/create" -H 'content-type: application/json' -d "$CPAYLOAD" 2>/dev/null)"
+C="$(printf '%s' "$RC" | python3 -c "import sys,json; print(json.load(sys.stdin)['pod_id'])" 2>/dev/null)"
+[[ -n "$C" && "$C" != "$A" && "$C" != "$B" ]] || { echo "ERROR: child C creation via A's proxy failed (C=$C): $RC"; tail -20 "$WORK/node.log"; exit 1; }
+
 N pods > "$WORK/operator.json"
 curl -s -X POST "$APROXY/v1/pod/list" -H 'content-type: application/json' -d '{}' > "$WORK/scoped.json" 2>/dev/null
 
 cat > "$WORK/check.py" <<'PY'
 import sys, json
-a, b, op_path, sc_path = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
+a, b, c, op_path, sc_path = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4], sys.argv[5]
 def ids(path):
     d = json.load(open(path))
     pods = d if isinstance(d, list) else d.get("pods", [])
     return {p["id"] for p in pods}
 op, sc = ids(op_path), ids(sc_path)
 errs = []
-# Positive control 1: B genuinely exists (the exclusion isn't "B never booted").
+# Positive controls: A, B, and C genuinely exist (so any absence below is
+# EXCLUSION by the filter, not "never created").
 if a not in op: errs.append("operator listing missing A (%s)" % a)
 if b not in op: errs.append("operator listing missing sibling B (%s) -- cannot conclude B was excluded vs never created" % b)
-# The property: A's scoped listing has A, excludes B.
+if c not in op: errs.append("operator listing missing child C (%s) -- cannot conclude C-inclusion means anything" % c)
+# The property: A's scoped listing has A, INCLUDES its own child C, EXCLUDES B.
 if a not in sc: errs.append("A's scoped listing does NOT contain A -- the token did not authenticate")
+if c not in sc: errs.append("A's scoped listing does NOT contain its OWN child C (%s) -- the filter is NOT lineage-scoped; a self-only filter looks exactly like this, so excluding B proves nothing about lineage" % c)
 if b in sc: errs.append("A's scoped listing CONTAINS sibling B (%s) -- cross-pod isolation FAILED (token not applied / filter bypassed)" % b)
-# Discriminating: scoped is a STRICT subset of operator (proves scoping happened).
+# Discriminating: scoped is exactly {A,C} here and a STRICT subset of operator
+# {A,B,C} -- so scoping happened AND it kept the lineage member.
 if not sc: errs.append("A's scoped listing is EMPTY -- not a valid positive result")
 elif not (sc < op): errs.append("A's scoped listing (%d) is not a strict subset of operator (%d) -- no scoping occurred" % (len(sc), len(op)))
 print("\n".join(errs) if errs else "OK")
 PY
-result="$(python3 "$WORK/check.py" "$A" "$B" "$WORK/operator.json" "$WORK/scoped.json")"
+result="$(python3 "$WORK/check.py" "$A" "$B" "$C" "$WORK/operator.json" "$WORK/scoped.json")"
 
 if [[ "$result" != "OK" ]]; then
-    echo "FAILED: cross-pod scoped listing did not isolate A from B on the running node:"
+    echo "FAILED: cross-pod scoped listing did not scope A's lineage on the running node:"
     sed 's/^/  /' <<<"$result"
-    echo "  A=$A  B=$B"
+    echo "  A=$A  B=$B  C=$C"
     echo "--- operator ---"; sed 's/^/  /' <<<"$(cat "$WORK/operator.json")"
     echo "--- A scoped ---"; sed 's/^/  /' <<<"$(cat "$WORK/scoped.json")"
     exit 1
 fi
 
 echo "OK: on a running node, pod A's authenticated /v1/pod/list (A's own caller token)"
-echo "returned A but EXCLUDED sibling B — a strict subset of the operator view that sees"
-echo "both. The server-side caller_may_manage filter scoped the listing by A's identity."
+echo "returned A and its OWN child C but EXCLUDED sibling B — a strict subset of the"
+echo "operator view that sees all three. The server-side caller_may_manage filter"
+echo "scoped the listing to A's lineage (self + direct children), not merely to self."


### PR DESCRIPTION
## What

`cross-pod-scoped-check.sh` proved A's scoped listing **excludes sibling B** and is a strict subset of the operator view. But that is satisfied even by a filter broken to **self-only**: `{A} ⊊ {A,B}` holds and B is absent, yet nothing *lineage-scoped* was proven — the check leaned entirely on the separately-unit-tested descendant predicate to cover lineage **inclusion**.

Add the discriminating third pod: **A creates its own child C** through its proxy's `/v1/pod/create` (so the node records `parent=A` from A's authenticated identity), and the check asserts **C ∈ A's listing** as well as B ∉ it. A self-only filter drops C and reds; only a genuinely lineage-scoped filter passes.

## The tooth bites (verified)

Perturbing `caller_may_manage` to `pod_id == caller` (self-only) collapses A's scoped listing to just `[A]` and reds the gate on *"does NOT contain its OWN child C"*. Restored, it's green: A sees `{A, C}`, excludes B, a strict subset of operator `{A, B, C}`.

## Why now

This is the same discrimination the **live G4 boot** (Inc 2) must make over real vsock — the proxy scoping review flagged that the two-pod reference is *latently satisfiable by a self-only filter*. Enforcing C-inclusion here means the per-PR KVM-free gate closes the hole immediately, independent of when the live boot lands. **C2 stays NOT-YET.**

Local-driver only (no KVM); runs in the existing `cross-pod-lineage` CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148ebbw4UXypRjhMw3xAQzj