### PR TITLE
docs(compliance): surface EU AI Act Article 12 in the posture map

### DIFF
--- a/docs/compliance-posture.md
+++ b/docs/compliance-posture.md
@@ -17,6 +17,7 @@ remediation is in flight, we link to the tracking task.
 | Framework | Effective | Penalty | Our posture | Notes |
 |---|---|---|---|---|
 | **EU AI Act Article 50** | 2026-08-02 | €15M or 3% global turnover | **Satisfies** machine-readable marking via bundle + C2PA export | See [eu-ai-act-article-50.md](./eu-ai-act-article-50.md) |
+| **EU AI Act Article 12** | 2026-08-02 | €15M or 3% global turnover | **Substantially satisfies (opt-in)**: automatic, hash-chained + HMAC-signed record-keeping of every kernel decision, fail-degraded, with a node **executor attestation** binding the chain head; retention/rotation are the operator's | See [article-12-record-keeping.md](./article-12-record-keeping.md) |
 | **NIS2 (EU 2022/2555)** | 2024-10 (transposition deadline 2024); Member-State enforcement underway through 2026 | up to €10M or 2% global turnover | **Largely satisfies** Article 21 risk-management controls; **opt-in** for Article 23 incident reporting | We are an essential supplier to subject entities; mapped below |
 | **SOC 2 Type II** | Customer-driven (80% of Series B+ require) | Sales gate, not regulatory | **Substantially aligned**; formal Type II audit committed for FY26 | Trust Services Criteria mapping below |
 | **GDPR (EU 2016/679)** | 2018-05 | up to €20M or 4% global turnover | **Satisfies** Article 32 (security of processing) + lawful-basis story for the public log | DPO: `security@coproduct.io` |
@@ -42,6 +43,36 @@ machine-readable-marking requirement at the **upstream provenance
 layer**; downstream pixel-domain watermarking is the caller's
 responsibility (and a complementary market — see the threat-model
 doc's T5 for downgrade detection).
+
+---
+
+## EU AI Act Article 12 — record-keeping
+
+Article 12 requires high-risk AI systems to record events **automatically over
+their lifetime**, in a tamper-evident form supporting traceability. The full
+mapping is in [article-12-record-keeping.md](./article-12-record-keeping.md); the
+table below is the executive summary.
+
+| Article 12 obligation | nucleus surface |
+|---|---|
+| "automatic recording of events (logs) over the lifetime" (§1) | `--art12-log` — one hash-chained, HMAC-signed record per kernel decision (allows, **refusals and deferrals** alike), emitted by a `VerdictSink` in the decision chain with no call-site bypass |
+| events relevant to identifying risk + traceability (§2) | each record folds the operation + subject, the verdict + machine-stable deny code, the gate class, the permission-lattice checksum, the actor, the verified-admission state, and the causal DAG's independent `flow_cross_check` into the signed preimage |
+| tamper-evident (regulator reading of §1) | hash chaining + HMAC; `nucleus-audit verify-art12` reconstructs each preimage **from the record's own fields** and checks sequence continuity, chaining, and the HMAC. A node **executor attestation** (Ed25519, role-separated from the task key, never seen by the pod) signs `(session_id, chain_head, records, dropped, executor_id)` at pod exit — closing the case where a pod that derived its own signing secret could re-sign its own history |
+| fail-safe recording | the log latches **degraded** on a write failure, counts what it dropped, and refuses the next operation before it executes — bounding the invisible gap to what was already lost |
+| the record vs. its subject | a log path inside the agent's workspace is **refused at startup** — a session cannot read or edit its own surveillance record |
+
+**Honestly not established** (carried as data in the verifier's report, so a
+consumer cannot render "verified" without them): **completeness** — a chain
+proves the records present are consecutive and unaltered, never that every
+decision was recorded; **opt-in** — without `--art12-log` no record is kept, so
+this is not compliant-by-default; **retention** — nucleus writes an append-only
+file, but rotation, ≥6-month retention (Article 19), and off-host durability are
+deployment concerns it does not manage; **identification of persons** — only as
+good as the actor the caller authenticated as (the verifier counts anonymous
+records so a log of anonymous decisions is visible, not a green tick).
+
+**Penalty exposure.** Article 99 places Article 12 violations in the same
+€15M / 3% Tier-2 band as Article 50.
 
 ---
 


### PR DESCRIPTION
## What

The Article 12 record-keeping **implementation and its detailed mapping** (`docs/article-12-record-keeping.md`) already exist — automatic, hash-chained + HMAC-signed record-keeping of every kernel decision (allows/refusals/deferrals), a fail-degraded latch, a log path refused inside the agent workspace, and a **node executor attestation** that binds the chain head so a pod cannot re-sign its own history. But `compliance-posture.md` — the executive map compliance teams read — listed Article 50 and **not** Article 12.

This adds the Article 12 row to the TL;DR framework table and a detailed section, mirroring the doc's honest split:
- **Established**: automatic per-decision recording (no call-site bypass), rich traceable fields folded into the signed preimage, tamper-evidence (chain + HMAC + `nucleus-audit verify-art12` + executor attestation), fail-safe degraded latch, subject cannot read/edit its own record.
- **Honestly not established** (carried in the verifier's own report): **completeness**, **opt-in** (no `--art12-log` → no record), **retention** (operator's — rotation / ≥6-month / off-host), **person identification** (only as good as the authenticated actor).

No overclaim beyond what the Article 12 doc and the verifier already state.

## Note

This is **outward compliance wording** — flagged for your review rather than asserted unilaterally. Not on automerge; merge when you're comfortable with the posture phrasing ("Substantially satisfies (opt-in)").

Context: this closes the gap I flagged in the EU agentic-receipt-export review — the Article 12 capability was strong but not surfaced in the posture map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148ebbw4UXypRjhMw3xAQzj