### PR TITLE
node: extract driver dispatch into a `driver` module + add DriverKind::AppleVz

### DIFF
--- a/crates/nucleus-node/src/driver.rs
+++ b/crates/nucleus-node/src/driver.rs
@@ -1,0 +1,54 @@
+//! Substrate driver seam — which isolation backend a pod runs under.
+//!
+//! The `DriverKind` selected here pairs with a `portcullis::enforcement::
+//! BackendCapability` (chosen in `trust_gate::isolation_backend`), which declares
+//! the isolation levels the backend can enforce and clamps enforced ≥ requested.
+//! Extracted from `main.rs` so a new substrate is an additive module, not a
+//! growth of the node's already-ratcheted entrypoint.
+
+use crate::{ApiError, DriverState, NodeState};
+use clap::ValueEnum;
+use nucleus_spec::PodSpec;
+use std::path::{Path, PathBuf};
+use uuid::Uuid;
+
+/// The isolation substrate the node launches pods under.
+#[derive(Clone, Debug, ValueEnum)]
+pub(crate) enum DriverKind {
+    /// No VM isolation — process-only. Dev/test; refused in production.
+    #[cfg(feature = "local-driver")]
+    Local,
+    /// Firecracker microVM (Linux/KVM). The production default.
+    Firecracker,
+    /// Container runtime.
+    Container,
+    /// Apple Virtualization.framework (macOS-native). Its enforcement capability
+    /// is already declared (`BackendCapability::APPLE_VZ`, selected by
+    /// `trust_gate::isolation_backend` for the `apple-vz` backend); the boot
+    /// driver is [`spawn_vz_pod`].
+    AppleVz,
+}
+
+/// Launch a pod under Apple Virtualization.framework. **macOS-native, not yet
+/// implemented** — the landing spot for the VZ boot.
+///
+/// When implemented it boots a `VZVirtualMachine`, carries the workload API over
+/// VZ's virtio-socket (Firecracker's vsock/jailer assumptions do not port), and
+/// sources the mediator key from the Secure Enclave. The enforcement clamp is
+/// already in place via `BackendCapability::APPLE_VZ`, so this fills the driver
+/// half of a seam whose enforcement half is done. Returns an error until then, so
+/// selecting the driver fails loudly rather than silently no-op'ing.
+#[allow(clippy::unused_async)] // the real VZ boot is async; the stub returns immediately
+pub(crate) async fn spawn_vz_pod(
+    state: &NodeState,
+    pod_dir: &Path,
+    spec: &PodSpec,
+    id: Uuid,
+) -> Result<(DriverState, Option<String>, PathBuf), ApiError> {
+    let _ = (state, pod_dir, spec, id);
+    Err(ApiError::Driver(
+        "Apple VZ driver not yet implemented (macOS-native, Virtualization.framework) \
+         — see docs/plugin-surface.md"
+            .to_string(),
+    ))
+}

--- a/crates/nucleus-node/src/main.rs
+++ b/crates/nucleus-node/src/main.rs
@@ -11,7 +11,8 @@ use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response as AxumResponse};
 use axum::routing::{get, post};
 use axum::{middleware, Json, Router};
-use clap::{Parser, ValueEnum};
+use clap::Parser;
+use driver::DriverKind;
 use nucleus_client::drand::{DrandConfig, DrandFailMode};
 #[cfg(target_os = "linux")]
 use nucleus_spec::NetworkSpec;
@@ -49,6 +50,7 @@ mod broker_rollout;
 mod broker_transport;
 mod cgroup;
 mod cred_split;
+mod driver;
 mod envelope_frame;
 mod guest_socket;
 mod lifecycle;
@@ -302,14 +304,6 @@ struct Args {
         default_value_t = 3600
     )]
     oidc_github_cert_ttl_secs: u64,
-}
-
-#[derive(Clone, Debug, ValueEnum)]
-enum DriverKind {
-    #[cfg(feature = "local-driver")]
-    Local,
-    Firecracker,
-    Container,
 }
 
 #[derive(Clone)]
@@ -1128,6 +1122,7 @@ async fn create_pod_internal(
         DriverKind::Container => {
             spawn_container_pod(state, &pod_dir, &spec, id, raw_yaml.as_deref()).await?
         }
+        DriverKind::AppleVz => driver::spawn_vz_pod(state, &pod_dir, &spec, id).await?,
     };
     boot_trace::log_guest_console_timeline(&log_path).await;
 


### PR DESCRIPTION
## What

First Linux-CI-safe brick of the **Apple Virtualization.framework substrate driver** (plugin-surface axis 3).

The enforcement half of this seam is already wired and tested: `BackendCapability::APPLE_VZ` is defined, and `trust_gate::isolation_backend()` selects it for the `apple-vz` backend, so `require_isolation` clamps a VZ pod's enforced isolation exactly as it does a Firecracker pod's. This PR fills the **node driver** half's foundation.

- Lifts `enum DriverKind` out of the ratcheted `main.rs` into a new `driver` module — paying for the addition by extraction (`main.rs` 4041 → 4036, under the 4042 ceiling).
- Adds the `DriverKind::AppleVz` variant and a `spawn_vz_pod` landing spot.
- The stub returns `ApiError::Driver(...)` rather than silently no-op'ing, so selecting the driver before the boot lands **fails loudly**.

## What this is *not*

The real VZ boot — a `VZVirtualMachine` over VZ's virtio-socket (Firecracker's vsock/jailer assumptions do not port), with a Secure-Enclave-sourced mediator key — is macOS-only and lands in a follow brick. It is not exercised on Linux CI. No outward "runs on Apple silicon" claim is made here.

## Verification

`cargo clippy -p nucleus-node --all-targets --all-features -- -D warnings` is **clean on Linux** (the cfg set CI runs — verified via OrbStack). The macOS `from_spec`/dead-code diagnostics are the known `cfg(target_os = "linux")` artifacts (`nucleus-node`'s Firecracker path is linux-gated), unchanged by this commit. `cargo fmt --check` clean; line ratchet green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148ebbw4UXypRjhMw3xAQzj