### PR TITLE
C9 Inc 2: enforce a live assurance floor on the tool-proxy relying-party path

### DIFF
--- a/crates/nucleus-identity/src/assurance.rs
+++ b/crates/nucleus-identity/src/assurance.rs
@@ -32,9 +32,10 @@ use crate::Result;
 ///
 /// The level is *derived* for policy convenience (e.g. "require ≥ `L2Device`");
 /// [`VerifiedAttestation::proves`] / `not_proven` are the authoritative ground truth.
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash, Default)]
 pub enum AssuranceLevel {
     /// No hardware; bearer / OIDC. Baseline, for migration.
+    #[default]
     L0Bearer = 0,
     /// Non-exportable hardware key + single-vendor *online* attestation, app/instance
     /// scope, no stable device identity — or first-party *software* measurement.
@@ -50,6 +51,24 @@ impl AssuranceLevel {
     /// The level as its ordinal, for wire encoding and comparison.
     pub fn as_u8(self) -> u8 {
         self as u8
+    }
+}
+
+impl std::str::FromStr for AssuranceLevel {
+    type Err = String;
+
+    /// Parses `l0`/`l1`/`l2`/`l3` or a bare ordinal `0`..=`3` (case-insensitive),
+    /// for CLI/config authoring of an assurance floor.
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "l0" | "l0bearer" | "0" | "bearer" => Ok(Self::L0Bearer),
+            "l1" | "l1software" | "1" | "software" => Ok(Self::L1Software),
+            "l2" | "l2device" | "2" | "device" => Ok(Self::L2Device),
+            "l3" | "l3measuredboot" | "3" | "measuredboot" => Ok(Self::L3MeasuredBoot),
+            other => Err(format!(
+                "invalid assurance level {other:?} (expected one of L0..L3)"
+            )),
+        }
     }
 }
 

--- a/crates/nucleus-identity/src/tpm_devid.rs
+++ b/crates/nucleus-identity/src/tpm_devid.rs
@@ -401,25 +401,20 @@ fn leaf_ec_point(cert_der: &[u8]) -> Result<Vec<u8>> {
 #[derive(Debug, Clone, Copy, Default)]
 pub struct TpmDevidBackend;
 
-impl SvidAttestationBackend for TpmDevidBackend {
-    fn id(&self) -> &'static str {
-        "tpm-devid-residency"
-    }
-
-    fn assurance(&self) -> AssuranceLevel {
-        AssuranceLevel::L1Software
-    }
-
-    fn verify_svid(
-        &self,
-        chain_pem: &str,
-        _requirements: &AttestationRequirements,
+impl TpmDevidBackend {
+    /// The PEM-free core of [`Self::verify_svid`]: verify a leaf certificate's TPM
+    /// residency proof and **bind it to the leaf's own key**, working directly on
+    /// DER (what a relying party holds after a TLS handshake). Kept as the single
+    /// source of truth for the load-bearing binding check so a live gate and the
+    /// SVID trait path cannot drift.
+    ///
+    /// `require_attestation`: when set, an absent residency extension is a hard
+    /// error (fail-closed); when cleared, absence yields `Ok(None)`. A present but
+    /// invalid, or replayed, proof is **always** an `Err`.
+    pub fn verify_leaf_der(
+        cert_der: &[u8],
         require_attestation: bool,
     ) -> Result<Option<VerifiedAttestation>> {
-        let leaf =
-            pem::parse(chain_pem).map_err(|e| vfail(format!("cert PEM parse failed: {e}")))?;
-        let cert_der = leaf.contents();
-
         let evidence = match extract_residency_evidence(cert_der) {
             Some(ev) => ev,
             None if require_attestation => {
@@ -446,6 +441,61 @@ impl SvidAttestationBackend for TpmDevidBackend {
             ));
         }
         Ok(Some(va))
+    }
+}
+
+impl SvidAttestationBackend for TpmDevidBackend {
+    fn id(&self) -> &'static str {
+        "tpm-devid-residency"
+    }
+
+    fn assurance(&self) -> AssuranceLevel {
+        AssuranceLevel::L1Software
+    }
+
+    fn verify_svid(
+        &self,
+        chain_pem: &str,
+        _requirements: &AttestationRequirements,
+        require_attestation: bool,
+    ) -> Result<Option<VerifiedAttestation>> {
+        let leaf =
+            pem::parse(chain_pem).map_err(|e| vfail(format!("cert PEM parse failed: {e}")))?;
+        Self::verify_leaf_der(leaf.contents(), require_attestation)
+    }
+}
+
+/// The effective assurance a served SVID's leaf certificate carries, for a
+/// relying-party **assurance floor** (North Star C9 live enforcement).
+///
+/// `launch_verified` is the caller's already-computed self-measured
+/// launch-attestation result — [`AssuranceLevel::L1Software`] when the cert's
+/// [`crate::LaunchAttestation`] matched the configured requirements, else the
+/// baseline. This adds the TPM-residency contribution:
+///
+/// * **absent** residency evidence ⇒ the launch-derived base level (no change);
+/// * **present and valid** (verifies *and* binds to the leaf key) ⇒ raised to the
+///   residency backend's level;
+/// * **present but invalid or replayed** ⇒ a hard [`Err`] — a floor can never be
+///   satisfied by malformed residency evidence (fail-closed).
+///
+/// Residency alone is [`AssuranceLevel::L1Software`] (it proves
+/// [`Claim::KeyNonExportable`], not hardware rooting). Reaching
+/// [`AssuranceLevel::L2Device`] additionally requires anchoring the AK to a
+/// manufacturer-signed EK (a later increment), so an `L2Device` floor currently
+/// refuses **every** SVID — correct fail-closed behavior, not a defect.
+pub fn effective_assurance(cert_der: &[u8], launch_verified: bool) -> Result<AssuranceLevel> {
+    let base = if launch_verified {
+        AssuranceLevel::L1Software
+    } else {
+        AssuranceLevel::L0Bearer
+    };
+    // `require_attestation = false`: an SVID may carry its assurance via launch
+    // attestation instead of residency, so *absence* is not itself a failure —
+    // but a present-yet-invalid proof still errs (verify_leaf_der is fail-closed).
+    match TpmDevidBackend::verify_leaf_der(cert_der, false)? {
+        Some(va) => Ok(base.max(va.assurance)),
+        None => Ok(base),
     }
 }
 
@@ -650,5 +700,69 @@ mod tests {
             .verify_svid(&pem, &AttestationRequirements::any(), false)
             .expect("absent-not-required ok")
             .is_none());
+    }
+
+    // ── Inc 2 (live floor): effective_assurance for a relying-party gate ───────
+
+    fn der_of(pem: &str) -> Vec<u8> {
+        pem::parse(pem).expect("pem").contents().to_vec()
+    }
+
+    /// A valid residency proof bound to the leaf key raises the effective level to
+    /// L1Software — so an `L1Software` floor ADMITS it (the positive teeth).
+    #[test]
+    fn effective_assurance_admits_valid_residency_at_l1() {
+        let der = der_of(&build_cert(
+            &point_of(&subj_pub()),
+            Some(&evidence().encode()),
+        ));
+        let level = effective_assurance(&der, false).expect("valid residency");
+        assert_eq!(level, AssuranceLevel::L1Software);
+        assert!(level >= AssuranceLevel::L1Software);
+    }
+
+    /// With no residency evidence, the level is exactly the launch-derived base:
+    /// L0Bearer without launch attestation, L1Software with it. An `L1Software`
+    /// floor therefore REFUSES a bare bearer SVID (the negative teeth).
+    #[test]
+    fn effective_assurance_falls_back_to_launch_base_when_absent() {
+        let der = der_of(&build_cert(&point_of(&subj_pub()), None));
+        assert_eq!(
+            effective_assurance(&der, false).expect("ok"),
+            AssuranceLevel::L0Bearer
+        );
+        assert_eq!(
+            effective_assurance(&der, true).expect("ok"),
+            AssuranceLevel::L1Software
+        );
+    }
+
+    /// FAIL-CLOSED — a valid proof REPLAYED into a cert whose key is a different key
+    /// must make the floor decision err, never silently pass at the base level.
+    #[test]
+    fn effective_assurance_fails_closed_on_replayed_proof() {
+        let der = der_of(&build_cert(
+            &point_of(&ak_pub()),
+            Some(&evidence().encode()),
+        ));
+        // Even claiming a launch base of true must not rescue a replayed proof.
+        assert!(effective_assurance(&der, true).is_err());
+    }
+
+    /// HONEST CEILING — residency alone is L1Software, so an `L2Device` floor
+    /// refuses even a valid device-resident SVID today (genuine-silicon needs the
+    /// EK-manufacturer root, a later increment). This asserts the gate never
+    /// over-admits an L2 claim the evidence cannot back.
+    #[test]
+    fn effective_assurance_l2_floor_refuses_residency_only() {
+        let der = der_of(&build_cert(
+            &point_of(&subj_pub()),
+            Some(&evidence().encode()),
+        ));
+        let level = effective_assurance(&der, false).expect("valid residency");
+        assert!(
+            level < AssuranceLevel::L2Device,
+            "residency-only must not satisfy an L2 floor"
+        );
     }
 }

--- a/crates/nucleus-tool-proxy/Cargo.toml
+++ b/crates/nucleus-tool-proxy/Cargo.toml
@@ -64,7 +64,9 @@ chrono = { workspace = true, features = ["serde"] }
 
 nucleus = { path = "../nucleus" }
 nucleus-spec = { path = "../nucleus-spec" }
-nucleus-identity = { path = "../nucleus-identity" }
+# tpm-devid: compile the TPM residency verifier into the relying-party binary so
+# the assurance floor (--min-assurance) enforces on the live path (North Star C9).
+nucleus-identity = { path = "../nucleus-identity", features = ["tpm-devid"] }
 nucleus-client = { path = "../nucleus-client", features = ["async-drand"] }
 nucleus-proto = { path = "../nucleus-proto" }
 portcullis = { path = "../portcullis", features = ["serde", "spec", "crypto", "dlc"] }

--- a/crates/nucleus-tool-proxy/src/attestation.rs
+++ b/crates/nucleus-tool-proxy/src/attestation.rs
@@ -21,7 +21,7 @@
 //! If no allowed hashes are specified but attestation is required, any valid
 //! attestation is accepted (useful for logging without enforcement).
 
-use nucleus_identity::LaunchAttestation;
+use nucleus_identity::{AssuranceLevel, LaunchAttestation};
 use std::collections::HashSet;
 use std::sync::Arc;
 use tracing::{debug, info, warn};
@@ -45,6 +45,13 @@ pub struct AttestationConfig {
     /// Set of allowed config hashes (SHA-256, hex-encoded).
     /// Empty means any config hash is allowed.
     pub allowed_config_hashes: HashSet<String>,
+    /// Minimum normalized assurance level a request's SVID must carry (North Star
+    /// C9). `L0Bearer` (the default) imposes no floor. A floor above `L0Bearer`
+    /// makes attestation effectively required and refuses any SVID whose verified
+    /// assurance is below it — fail-closed on absent/invalid evidence. Note a
+    /// `L2Device`+ floor refuses every SVID until the EK-manufacturer root lands
+    /// (residency alone is `L1Software`).
+    pub min_assurance: AssuranceLevel,
 }
 
 impl AttestationConfig {
@@ -85,6 +92,16 @@ impl AttestationConfig {
             if !hash.is_empty() {
                 self.allowed_config_hashes.insert(hash);
             }
+        }
+        self
+    }
+
+    /// Sets the minimum assurance floor. A floor above `L0Bearer` also makes
+    /// attestation required (a floor cannot be checked without a client cert).
+    pub fn with_min_assurance(mut self, level: AssuranceLevel) -> Self {
+        self.min_assurance = level;
+        if level > AssuranceLevel::L0Bearer {
+            self.require_attestation = true;
         }
         self
     }
@@ -343,6 +360,35 @@ impl AttestationVerifier {
     pub fn is_required(&self) -> bool {
         self.config.require_attestation
     }
+
+    /// Enforces the assurance floor (North Star C9) for a request whose launch
+    /// attestation already passed.
+    ///
+    /// The launch attestation establishes at most `L1Software`; TPM residency
+    /// evidence carried by the client certificate can raise the effective level,
+    /// and a present-but-invalid or replayed proof makes this err (fail-closed).
+    /// Returns `Err(reason)` when the SVID's verified assurance is below the floor.
+    /// A no-op (`Ok`) when the floor is `L0Bearer`.
+    pub fn enforce_floor(
+        &self,
+        client_cert_der: Option<&[u8]>,
+        attestation_result: &AttestationResult,
+    ) -> Result<(), String> {
+        let min = self.config.min_assurance;
+        if min <= AssuranceLevel::L0Bearer {
+            return Ok(());
+        }
+        let cert_der = client_cert_der
+            .ok_or_else(|| "assurance floor requires an mTLS client certificate".to_string())?;
+        let launch_verified =
+            attestation_result.attestation_present && attestation_result.matches_requirements;
+        let level = nucleus_identity::tpm_devid::effective_assurance(cert_der, launch_verified)
+            .map_err(|e| format!("residency evidence invalid: {e}"))?;
+        if level < min {
+            return Err(format!("assurance {level:?} below required floor {min:?}"));
+        }
+        Ok(())
+    }
 }
 
 /// Extracts attestation from a DER-encoded X.509 certificate.
@@ -396,6 +442,61 @@ mod tests {
         assert!(!config.require_attestation);
         assert!(config.allowed_kernel_hashes.is_empty());
         assert!(config.allowed_rootfs_hashes.is_empty());
+        // No floor by default — existing deployments are unaffected.
+        assert_eq!(config.min_assurance, AssuranceLevel::L0Bearer);
+    }
+
+    #[test]
+    fn enforce_floor_admits_refuses_and_fails_closed() {
+        // Any DER works here: with no residency extension the effective assurance is
+        // exactly the launch base, so this exercises the floor RESULT mapping without
+        // TPM fixtures. (A garbage DER simply parses to "no residency" → base level.)
+        let dummy_cert = [0x30u8, 0x00];
+        let launch_ok = AttestationResult {
+            attestation_present: true,
+            attestation: None,
+            matches_requirements: true, // launch verified → base L1Software
+            rejection_reason: None,
+        };
+        let bearer = AttestationResult {
+            attestation_present: false,
+            attestation: None,
+            matches_requirements: false, // no launch → base L0Bearer
+            rejection_reason: None,
+        };
+
+        // No floor → always Ok, even without a client cert.
+        let v0 = AttestationVerifier::new(AttestationConfig::default());
+        assert!(v0.enforce_floor(None, &bearer).is_ok());
+
+        // L1 floor: a launch-verified SVID is admitted; a bare bearer is refused.
+        let v1 = AttestationVerifier::new(
+            AttestationConfig::default().with_min_assurance(AssuranceLevel::L1Software),
+        );
+        assert!(v1.enforce_floor(Some(&dummy_cert), &launch_ok).is_ok());
+        assert!(v1.enforce_floor(Some(&dummy_cert), &bearer).is_err());
+        // A floor with no client certificate fails closed.
+        assert!(v1.enforce_floor(None, &launch_ok).is_err());
+
+        // L2 floor refuses even a launch-verified SVID: residency-only tops out at
+        // L1Software until the EK-manufacturer root lands (never over-admits L2).
+        let v2 = AttestationVerifier::new(
+            AttestationConfig::default().with_min_assurance(AssuranceLevel::L2Device),
+        );
+        assert!(v2.enforce_floor(Some(&dummy_cert), &launch_ok).is_err());
+    }
+
+    #[test]
+    fn test_min_assurance_floor_implies_required() {
+        // A floor above L0 makes attestation required (can't check a floor without
+        // a client cert); an L0 floor leaves require_attestation untouched.
+        let floored = AttestationConfig::default().with_min_assurance(AssuranceLevel::L2Device);
+        assert_eq!(floored.min_assurance, AssuranceLevel::L2Device);
+        assert!(floored.require_attestation);
+
+        let no_floor = AttestationConfig::default().with_min_assurance(AssuranceLevel::L0Bearer);
+        assert_eq!(no_floor.min_assurance, AssuranceLevel::L0Bearer);
+        assert!(!no_floor.require_attestation);
     }
 
     #[test]

--- a/crates/nucleus-tool-proxy/src/main.rs
+++ b/crates/nucleus-tool-proxy/src/main.rs
@@ -192,6 +192,11 @@ struct Args {
     /// If empty, any config hash is accepted when attestation is present.
     #[arg(long, env = "NUCLEUS_TOOL_PROXY_ALLOWED_CONFIG_HASHES")]
     allowed_config_hashes: Option<String>,
+    /// Minimum assurance floor an SVID must carry (North Star C9): `L0`..`L3`. `L0`
+    /// (default) imposes no floor; above `L0` makes attestation required and refuses
+    /// SVIDs below it (fail-closed). See `AttestationVerifier::enforce_floor`.
+    #[arg(long, env = "NUCLEUS_TOOL_PROXY_MIN_ASSURANCE", default_value = "L0")]
+    min_assurance: nucleus_identity::AssuranceLevel,
 
     // === Sandbox Proof Configuration ===
     /// Path to identity certificate PEM for sandbox proof (tier 1/2).
@@ -1593,6 +1598,7 @@ async fn main() -> Result<(), ApiError> {
         if let Some(ref hashes) = args.allowed_config_hashes {
             config = config.with_config_hashes(hashes);
         }
+        config = config.with_min_assurance(args.min_assurance); // C9 floor (>L0 ⇒ required)
         config
     };
     let attestation_verifier = AttestationVerifier::new(attestation_config);
@@ -2327,6 +2333,14 @@ async fn auth_middleware(
                 .unwrap_or_else(|| "unknown attestation failure".to_string());
             return Err(ApiError::AttestationFailed(reason));
         }
+
+        // North Star C9 — enforce the assurance floor on the live path (fail-closed
+        // on absent/invalid/replayed residency evidence). No-op when the floor is
+        // L0Bearer. Logic lives in `AttestationVerifier::enforce_floor` (unit-tested).
+        state
+            .attestation_verifier
+            .enforce_floor(client_cert_der, &attestation_result)
+            .map_err(ApiError::AttestationFailed)?;
 
         // Log successful attestation verification
         if let Some(ref info) = attestation_result.attestation {


### PR DESCRIPTION
## What

North Star **C9 (verify-from-outside)** had its TPM-DevID residency machinery *verified* but consumed only by tests/CLI — **nothing on a live path refused an under-attested identity**. This puts the verifier on the live tool-proxy relying-party gate, fail-closed.

### `nucleus-identity`
- **`TpmDevidBackend::verify_leaf_der`** — factored out of `verify_svid` as the single source of truth for the load-bearing SVID **key-binding** (the anti-replay check), callable on DER (what a relying party holds post-handshake), so the live gate and the trait path cannot drift.
- **`effective_assurance(cert_der, launch_verified)`** — the max assurance an SVID carries. Absent residency ⇒ launch-derived base; present-and-valid ⇒ raised to the residency level; **present-but-invalid or replayed ⇒ hard `Err` (fail-closed)**.
- `AssuranceLevel`: derive `Default` (`L0Bearer`) + `FromStr` (`L0..L3`) for CLI authoring.

### `nucleus-tool-proxy`
- Enable `nucleus-identity/tpm-devid` so the verifier is **compiled into the live binary** (it was behind a feature the proxy didn't enable).
- `AttestationConfig.min_assurance` + `with_min_assurance` (a floor `>L0` implies `require_attestation`) + **`--min-assurance`** CLI/env.
- **`AttestationVerifier::enforce_floor`** consulted in `auth_middleware` after the launch hash-match: refuse any SVID below the floor; fail-closed on absent cert / invalid evidence.

## Honest ceiling (tested, not hidden)

Residency alone is `L1Software` (it proves `KeyNonExportable`, not genuine silicon). So **today**:
- an **`L1` floor** admits an attested SVID and refuses a bare bearer (real teeth), and
- an **`L2` floor** refuses *every* SVID — correct **never-over-admit** behavior, not a bug.

Reaching `L2Device` needs anchoring the AK to a manufacturer-signed EK — **C9 Inc 3**. Embedding residency evidence into node-issued SVIDs (so the residency path fires in production, not just the launch-attestation path) is a disclosed follow-brick (node-side TPM issuance).

## Reserved for you
The **C9 ledger clause stays NOT-YET** and any outward *"hardware-attested / L2 / genuine-silicon"* wording remains your call. This PR advances the *wiring* that would justify a future C9→TESTED promotion; it does not make the claim.

## Verification (Linux, CI cfg — via OrbStack)
- `effective_assurance` matrix: admits-valid-residency-at-L1, falls-back-to-launch-base, **fails-closed-on-replay**, **L2-refuses-residency-only** — 4/4.
- `enforce_floor` result test (admit / refuse / no-cert-fail-closed / L2-refuses) + config tests.
- `clippy --all-targets --all-features -- -D warnings` clean; line ratchet green; fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148ebbw4UXypRjhMw3xAQzj