### PR TITLE
ledger: pin the dormancy-gate count so the cross-declaration guard can't silently go idle

### DIFF
--- a/docs/north-star.md
+++ b/docs/north-star.md
@@ -73,9 +73,11 @@ tense is how a claim outruns its wiring. This table is a **machine-checked
 ledger** (`scripts/check-north-star-ledger.sh`, run on every change): each row
 names a clause of the sentence verbatim, carries exactly one status from
 {PROVED, TESTED, NOT-YET}, an evidence handle CI can dereference, and the gate
-that reds if the status regresses. The row count and the NOT-YET count are
-pinned (`scripts/north-star-ledger-ratchet.txt`) — deleting a row or demoting a
-status is a visible event, not an edit.
+that reds if the status regresses. The row count, the NOT-YET count, and the
+count of in-tree dormancy gates the ledger is cross-checked against are all
+pinned (`scripts/north-star-ledger-ratchet.txt`) — deleting a row, demoting a
+status, or a dormancy gate silently appearing or disappearing is a visible
+event, not an edit.
 
 | # | Clause (verbatim from the sentence) | Status | Evidence | Falsified by |
 | --- | --- | --- | --- | --- |

--- a/scripts/check-north-star-ledger.sh
+++ b/scripts/check-north-star-ledger.sh
@@ -70,8 +70,14 @@ fi
 # acknowledge by editing this file in the same change.
 clauses_pinned="$(grep -E '^CLAUSES=' "$RATCHET" | cut -d= -f2)"
 not_yet_pinned="$(grep -E '^NOT_YET=' "$RATCHET" | cut -d= -f2)"
-if [[ -z "$clauses_pinned" || -z "$not_yet_pinned" ]]; then
-    echo "ERROR: $RATCHET must pin CLAUSES=<n> and NOT_YET=<n>"
+# The cross-declaration guard below compares the table against in-tree
+# check-*dormant*.sh gates. That domain is pinned too: a dormancy gate silently
+# disappearing (declassify's did, when it went live) is precisely how the guard
+# went idle with nobody noticing — a count that can silently reach zero is a
+# guard that can silently stop guarding.
+dormant_pinned="$(grep -E '^DORMANT_GATES=' "$RATCHET" | cut -d= -f2)"
+if [[ -z "$clauses_pinned" || -z "$not_yet_pinned" || -z "$dormant_pinned" ]]; then
+    echo "ERROR: $RATCHET must pin CLAUSES=<n>, NOT_YET=<n>, and DORMANT_GATES=<n>"
     exit 1
 fi
 
@@ -174,8 +180,10 @@ fi
 # subject is exercised on the live path. This compares two independent
 # declarations that run in the same CI; when they disagree, one of them is
 # lying, and the gate refuses to let the table be the one that wins.
+dormant_gates=0
 for dg in scripts/check-*dormant*.sh; do
     [[ -f "$dg" ]] || continue
+    dormant_gates=$((dormant_gates + 1))
     # Subject word derived from the gate's own filename: check-<subject>-…-dormant.sh
     # Stemmed (trailing 'y' dropped) so "declassify" also matches
     # "declassification" — the noun is how the table talks about it.
@@ -211,6 +219,14 @@ for dg in scripts/check-*dormant*.sh; do
     done <<< "$all_rows"
 done
 
+# The guard's domain must match its pin. A dormancy gate added (a new dormant
+# subject the table must not claim live) or retired (its subject went live, or
+# someone deleted the counterparty) both change what this guard can catch — and
+# the retirement case is exactly how it silently went idle. Force acknowledgment.
+if [[ "$dormant_gates" -ne "$dormant_pinned" ]]; then
+    fail "dormancy-gate count is $dormant_gates but $RATCHET pins DORMANT_GATES=$dormant_pinned — the cross-declaration guard's domain changed (a check-*dormant*.sh was added or retired). Update the pin in the same change; if one was retired, confirm no ledger row still claims live-path for a now-unguarded subject, and if one was added, confirm no row contradicts it."
+fi
+
 echo
 if [[ "$failures" -gt 0 ]]; then
     echo "FAILED: $failures problem(s) in the North Star ledger."
@@ -218,6 +234,11 @@ if [[ "$failures" -gt 0 ]]; then
     echo "the exact overclaim the doc's own preamble warns about."
     exit 1
 fi
+if [[ "$dormant_gates" -gt 0 ]]; then
+    cross="contradicts each of $dormant_gates in-tree dormancy declaration(s)"
+else
+    cross="has no in-tree dormancy gate to cross-check (DORMANT_GATES=0, pinned) — the differential is idle by pin, not by silent drift"
+fi
 echo "OK: every ledger row covers a verbatim clause, resolves its evidence,"
-echo "names its falsifier, and contradicts no in-tree dormancy declaration."
-echo "($valid_rows clauses, $not_yet_count NOT-YET — both pinned by $RATCHET)"
+echo "names its falsifier, and $cross."
+echo "($valid_rows clauses, $not_yet_count NOT-YET, $dormant_gates dormancy gate(s) — all pinned by $RATCHET)"

--- a/scripts/north-star-ledger-ratchet.txt
+++ b/scripts/north-star-ledger-ratchet.txt
@@ -140,5 +140,16 @@
 #   proof-only BY DESIGN (C1's uid/no-channel fence; credential built from node
 #   env not the guest spec) and the gate anchors those constructions. 9 entries,
 #   COUNT pinned. Evidence: scripts/check-extracted-callsites.sh.
+# 2026-08-13: added DORMANT_GATES pin (=0). An assurance review found the
+#   cross-declaration guard in check-north-star-ledger.sh had gone SILENTLY IDLE:
+#   it loops over scripts/check-*dormant*.sh, and when declassify went live its
+#   check-declassify-token-dormant.sh was retired, leaving zero such files — so
+#   the one check built to catch "the table is the thing that's lying" iterated
+#   nothing, while the OK line still advertised it as active. The count is now
+#   pinned like CLAUSES/NOT_YET: a dormancy gate appearing or disappearing must be
+#   acknowledged here in the same change, so the guard can never again go idle
+#   unnoticed. Currently 0 (no path is declared dormant); a future dormant subject
+#   raises it to 1 and re-arms the differential.
 CLAUSES=9
 NOT_YET=2
+DORMANT_GATES=0


### PR DESCRIPTION
## The weakness (from an assurance review of our own gates)

`check-north-star-ledger.sh`'s **cross-declaration guard** — *"no ledger row may claim live-path status for a subject an in-tree `check-*dormant*.sh` gate declares dormant"*, described in the script's own preamble as "the finding that motivated all of this" — had gone **silently idle**. It loops `for dg in scripts/check-*dormant*.sh`; when the declassify path went live its `check-declassify-token-dormant.sh` was retired, leaving **zero** such files. The loop iterated nothing while the OK line still advertised the differential as active. Classic *"nothing contradicts X" is also true when there's nothing to check.*

## The fix (in the script's existing ratchet idiom)

Pin `DORMANT_GATES=<n>` alongside the existing `CLAUSES=`/`NOT_YET=` pins. The script now counts the dormancy gates it actually compared, **fails if the count diverges from the pin (both directions)**, and reports it. A dormancy gate appearing *or disappearing* forces acknowledgment in the same change — so the guard can never again reach zero counterparties unnoticed. The OK line no longer claims a cross-check it didn't perform; it states the differential is *idle by pin, not by silent drift*.

Deliberately **not** faking intrinsic teeth: with zero external dormancy gates the differential genuinely has no counterparty, and a control you can't justify is worse than none. The fix makes the idle state visible and change-detected, which is the actual defect (nobody noticed it went idle).

## Verification
- Passes at count 0 == pin 0 (honest OK message).
- **REDs** when a `check-*-dormant.sh` appears (count 1 ≠ pin 0); restores green.
- Full `check-gates-can-fail.sh` passes (rc=0) — the meta-gate's existing ledger probe is unaffected (row parsing unchanged).
- `docs/north-star.md` updated to list the newly pinned count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148ebbw4UXypRjhMw3xAQzj