### PR TITLE
ci: wire the real-TPM activation + guest-net-isolation checks into CI (they ran nowhere)

### DIFF
--- a/.github/workflows/tpm-and-net-isolation.yml
+++ b/.github/workflows/tpm-and-net-isolation.yml
@@ -1,0 +1,92 @@
+name: TPM activation + guest-net isolation (hardware-adjacent checks)
+
+# Two checks that prove things a #[test] cannot, and that were sitting in
+# scripts/ invoked by NO workflow — so the property they guard was never
+# exercised in CI (an assurance review found both unwired):
+#
+#   * tpm-credential-activation-check.sh — the ONLY proof that nucleus's pure
+#     `make_credential_ecc` output is byte-accepted by a REAL TPM's
+#     TPM2_ActivateCredential, and that the AK↔EK binding BITES (a credential for
+#     one AK does not activate on another; a tampered blob is rejected). swtpm is
+#     a userspace software TPM — no KVM/hardware — and is only a producer/verifier
+#     of the blobs, never in nucleus's TCB. This is the producer≠verifier proof
+#     behind the C9 hardware-root arc; the pure unit tests alone cannot establish
+#     it.
+#   * net-guest-isolation-check.sh — two pods whose GUESTS carry the SAME constant
+#     subnet on one host, proving the constant guest address is translated before
+#     it escapes (the #2205 assumption the whole change rests on; unit tests cover
+#     addressing agreement, not real packets).
+#
+# Both scripts SKIP (exit 0) when their tooling is absent, so they could silently
+# pass on a broken install. Here the tooling is installed and REQUIRE flags turn a
+# missing tool into a failure — no false green.
+#
+# Not (yet) in the required set: these run on every relevant PR so the properties
+# are exercised, but promoting them to required is a branch-protection decision.
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "crates/nucleus-identity/**"
+      - "crates/nucleus-node/src/net.rs"
+      - "scripts/tpm-credential-activation-check.sh"
+      - "scripts/net-guest-isolation-check.sh"
+      - ".github/workflows/tpm-and-net-isolation.yml"
+  pull_request:
+    paths:
+      - "crates/nucleus-identity/**"
+      - "crates/nucleus-node/src/net.rs"
+      - "scripts/tpm-credential-activation-check.sh"
+      - "scripts/net-guest-isolation-check.sh"
+      - ".github/workflows/tpm-and-net-isolation.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tpm-net-isolation-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tpm-credential-activation:
+    name: TPM ActivateCredential accepts make_credential_ecc (C9)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
+
+      - name: Install swtpm + tpm2-tools
+        run: sudo apt-get update && sudo apt-get install -y -qq swtpm tpm2-tools
+
+      # Assert the stack is actually present, so a broken install cannot make the
+      # check skip to a false green (belt-and-braces with TPM_REQUIRE below).
+      - name: Assert the TPM stack is present
+        run: |
+          for t in swtpm tpm2_startup tpm2_createek tpm2_createak tpm2_activatecredential; do
+            command -v "$t" >/dev/null || { echo "::error::$t missing after install"; exit 1; }
+          done
+
+      - name: make_credential_ecc is byte-accepted by a real TPM, and the binding bites
+        env:
+          TPM_REQUIRE: "1"
+        run: bash scripts/tpm-credential-activation-check.sh
+
+  guest-net-isolation:
+    name: Constant guest address never reaches the host (#2205)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Assert netns + iptables are available
+        run: |
+          command -v ip >/dev/null || { echo "::error::iproute2 missing"; exit 1; }
+          command -v iptables >/dev/null || { echo "::error::iptables missing"; exit 1; }
+          sudo ip netns add nuc-ci-probe && sudo ip netns del nuc-ci-probe \
+            || { echo "::error::root network namespaces unavailable on this runner"; exit 1; }
+
+      - name: Two same-subnet guests, one host — the constant address is translated
+        run: sudo -E bash scripts/net-guest-isolation-check.sh

--- a/scripts/tpm-credential-activation-check.sh
+++ b/scripts/tpm-credential-activation-check.sh
@@ -16,8 +16,18 @@
 set -uo pipefail
 cd "$(git rev-parse --show-toplevel 2>/dev/null || echo .)"
 
+# In CI set TPM_REQUIRE=1: a missing tool then FAILS (exit 1) instead of SKIPping
+# (exit 0). Without it, a broken swtpm/tpm2-tools install would silently pass —
+# the false-green this check was added to CI to prevent. Locally (unset) it still
+# skips gracefully so `make check` works without a TPM stack installed.
 for t in swtpm tpm2_startup tpm2_createek tpm2_createak tpm2_activatecredential; do
-    command -v "$t" >/dev/null || { echo "SKIP: $t not installed"; exit 0; }
+    command -v "$t" >/dev/null && continue
+    if [[ "${TPM_REQUIRE:-0}" == "1" ]]; then
+        echo "FAIL: $t not installed but TPM_REQUIRE=1 — the activation proof cannot run"
+        exit 1
+    fi
+    echo "SKIP: $t not installed"
+    exit 0
 done
 
 EX="${TPM_MAKECRED_BIN:-}"


### PR DESCRIPTION
## The weakness

Two checks lived in `scripts/` invoked by **no workflow** — so the properties only they can establish were never exercised in CI:

- **`tpm-credential-activation-check.sh`** — the *only* proof that nucleus's pure `make_credential_ecc` output is byte-accepted by a **real TPM's `TPM2_ActivateCredential`**, and that the AK↔EK binding *bites* (a credential for one AK doesn't activate on another; a tampered blob is rejected). Producer = nucleus, verifier = the TPM. The C9 hardware-root arc rests on this; the pure unit tests can't establish it.
- **`net-guest-isolation-check.sh`** — two pods whose guests carry the *same* constant subnet on one host, proving the constant guest address is translated before it escapes (#2205).

Both **SKIP (exit 0) when their tooling is absent** — so they could pass silently on a broken install (a false green).

## The fix

New workflow `tpm-and-net-isolation.yml` with two jobs that **install the tooling** (swtpm + tpm2-tools; iproute2/iptables), **assert it's present** (fail the job otherwise), then run the checks. The TPM script gains a `TPM_REQUIRE=1` guard that turns a missing tool into a **failure, not a skip** — belt-and-braces against the silent-skip false-green. Locally (unset) it still skips gracefully so `make check` works without a TPM stack.

## Validation (both green on Linux)
- TPM: *"make_credential_ecc is accepted by a real TPM's ActivateCredential (secret recovered), and the AK↔EK binding BITES."*
- Net: two same-subnet guests → 2 distinct host-observed source addresses; *"the constant guest address never reached the host."*

## Scope
Runs on every relevant PR so the properties are exercised. **Promoting these to required is a branch-protection decision** — not taken here (they're new lanes; let them bake first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148ebbw4UXypRjhMw3xAQzj