### PR TITLE
ci: no-op twin so boot-a-real-pod can become a required check

### DIFF
--- a/.github/workflows/quickstart-boot-noop.yml
+++ b/.github/workflows/quickstart-boot-noop.yml
@@ -1,0 +1,52 @@
+name: quickstart-boot
+
+# NO-OP TWIN of quickstart-boot.yml's `boot-a-real-pod` job, so that job can be a
+# REQUIRED status check. Branch protection evaluates required contexts on the PR;
+# the real job is path-filtered on pull_request, so a PR not touching its paths
+# would never report the context and would block forever. This twin has the SAME
+# workflow name (`quickstart-boot`) and SAME job name, with `paths-ignore`
+# mirroring the real job's `paths`: exactly one of the two reports the context on
+# every PR.
+#
+# WHY THIS TWIN ALSO COVERS merge_group (unlike the aeneas-*-noop twins)
+#
+# The other required path-filtered gates run their REAL workflow on `merge_group`
+# too, so their twins deliberately skip it. `quickstart-boot.yml` does NOT —
+# booting a real Firecracker/KVM microVM on every queued PR is the cost/flakiness
+# that kept this gate non-required in the first place. So the real boot runs on
+# boot-affecting PULL REQUESTS (enforced there), and this twin carries the
+# merge_group context as a no-op: the queue trusts the PR's boot result rather
+# than re-booting. Net: a boot-affecting PR cannot merge without the real boot
+# passing, and the merge queue never stalls on (or pays for) a re-boot.
+#
+# To actually enforce it, add `quickstart-boot / a real nucleus pod boots and is
+# enforced (x86_64)` to the branch-protection required set (a GitHub-side toggle).
+
+on:
+  pull_request:
+    paths-ignore:
+      - "crates/nucleus-cli/**"
+      - "crates/nucleus-node/**"
+      - "crates/nucleus-spec/**"
+      - "crates/nucleus-guest-init/**"
+      - "crates/nucleus-tool-proxy/**"
+      - "crates/nucleus-workload-probe/**"
+      - "crates/nucleus-egress-probe/**"
+      - "scripts/check-egress-probe.sh"
+      - "examples/openclaw-demo/probe-pod.yaml"
+      - "scripts/firecracker/**"
+      - "scripts/lima/**"
+      - ".github/workflows/quickstart-boot.yml"
+  merge_group:
+
+permissions:
+  contents: read
+
+jobs:
+  boot-a-real-pod:
+    name: a real nucleus pod boots and is enforced (x86_64)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: No-op (boot paths not touched, or in the merge queue)
+        run: echo "no boot-affecting paths changed (or merge_group) — gate vacuously green; the real boot ran on the PR that touched them"


### PR DESCRIPTION
## Why

Per the assurance review + your call: the only live Firecracker/KVM enforcement lane (`boot-a-real-pod` — canary-doesn't-leak-to-guest, forbidden-command-denied, in-guest egress backstop holds) is **non-required + path-filtered with no twin**, so a regression to real-pod isolation can merge green.

## What

`quickstart-boot-noop.yml` mirrors the boot job (same workflow name `quickstart-boot`, same job name, `paths-ignore` == the real job's `paths` — verified identical) so **exactly one reports the context on every PR** — the repo's established requireable-gate mechanism.

**One deliberate difference from the aeneas-*-noop twins:** it also carries the **`merge_group`** context as a no-op. The real `quickstart-boot.yml` has no `merge_group` trigger — booting a real KVM microVM on every queued PR is the cost/flakiness that kept this non-required. So: the real boot runs on **boot-affecting pull requests** (enforced there), and the queue trusts that result rather than re-booting. Net: a boot-affecting PR can't merge without the real boot passing, and the merge queue never stalls on (or pays for) a re-boot.

## To actually enforce
Merging this changes nothing until you add `quickstart-boot / a real nucleus pod boots and is enforced (x86_64)` to the branch-protection required set (GitHub-side toggle). This PR just makes that toggle safe to flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148ebbw4UXypRjhMw3xAQzj