### PR TITLE
exemplar: strip inline #[cfg(test)] bodies so the scoreboard stops over-counting verify calls

### DIFF
--- a/scripts/exemplar-baseline.json
+++ b/scripts/exemplar-baseline.json
@@ -6,7 +6,7 @@
     "lean_theorems_GUARD": 891, "clean_axiom_footprint": "n/a"
   },
   "rust_craft": {
-    "permissive_verify": 59, "verify_calls_GUARD": 58,
+    "permissive_verify": 22, "verify_calls_GUARD": 51,
     "unsafe_blocks": 6,
     "crates_total": 67, "crates_lints_workspace": 41,
     "lints_adoption_pct": 61

--- a/scripts/exemplar-scoreboard.sh
+++ b/scripts/exemplar-scoreboard.sh
@@ -20,7 +20,24 @@ OUT="${1:-scoreboard.json}"
 
 RS=(--include='*.rs' --exclude-dir=target --exclude-dir=.lake --exclude-dir=.claude)
 LN=(--include='*.lean' --exclude-dir=.lake --exclude-dir=.claude)
-nt() { grep -rnE "$1" "${RS[@]}" crates 2>/dev/null | grep -vE '/tests/|_test\.rs|#\[cfg\(test\)\]|//|///'; }
+# "non-test" match. Beyond the coarse per-LINE filters (test files, comment
+# lines), strip whole inline `#[cfg(test)]` module/item BODIES. The old filter
+# dropped only the `#[cfg(test)]` attribute LINE, so a verify_strict-backed
+# `.verify()` inside an inline test module in a normal .rs file leaked into the
+# "non-test" counts and repeatedly inflated permissive_verify. Track brace depth
+# from the attribute through its guarded item's closing brace (fresh awk per file,
+# so no cross-file bleed). Verified to keep production `.verify(` and drop only
+# test-module bodies.
+nt() {
+    grep -rlE "$1" "${RS[@]}" crates 2>/dev/null | while IFS= read -r f; do
+        awk '
+            state==0 && $0 ~ /#\[cfg\(test\)\]/ { state=1; next }
+            state==1 { o=gsub(/\{/,"{"); c=gsub(/\}/,"}"); if (o>0){ depth=o-c; state=(depth>0?2:0) } next }
+            state==2 { depth += gsub(/\{/,"{") - gsub(/\}/,"}"); if (depth<=0) state=0; next }
+            { print FILENAME ":" FNR ":" $0 }
+        ' "$f"
+    done | grep -E "$1" | grep -vE '/tests/|_test\.rs|//|///'
+}
 
 # ── Formal verification ──────────────────────────────────────────────────────
 # extraction frontier: proven-over-EXTRACTED-Rust vs hand-model (the machine-


### PR DESCRIPTION
## The weakness (I hit it twice this week)

`exemplar-scoreboard.sh`'s `nt()` test-exclusion was **per-line** (`grep -vE '#[cfg(test)]'`), so it dropped only the *attribute line* — a `verify_strict`-backed `.verify()` inside an inline `#[cfg(test)]` module in a normal `.rs` file leaked into the "non-test" counts. It was counting **37 test-module verify calls as production**, and forced two benign baseline bumps this week alone.

## The fix

`nt()` now strips whole inline `#[cfg(test)]` module/item **bodies** via brace-depth tracking (fresh awk per file — no cross-file bleed). **Audited:** it keeps every production `.verify(` (verified against e.g. `tpm_devid.rs` `verify_residency`) and drops only lines inside a `#[cfg(test)]` scope (8/8 spot-checked removals sit under a `cfg(test)` marker).

Baseline reset to the now-honest counts: **`permissive_verify` 58 → 21**, `verify_calls_GUARD` 58 → 50 (unsafe_blocks unchanged). The paired guard drops in lockstep — it's the true production verify-call count, not a deletion — and the categorical `check-verify-strict.sh` gate is unaffected. Full ratchet green.

## Note on ordering
This edits `scripts/exemplar-baseline.json`, which #2276 also touches. Not arming auto-merge — I'll rebase this on top of #2276 once it lands and set the final baseline (the fix makes #2276's `+1` land at 22, not 59), so the two don't collide in the queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148ebbw4UXypRjhMw3xAQzj