### PR TITLE
adversary-probe: exercise an active attacker inside a nucleus pod (brick 1)

### DIFF
--- a/.github/workflows/adversary-probe.yml
+++ b/.github/workflows/adversary-probe.yml
@@ -1,0 +1,59 @@
+name: Adversary probe contains a live attacker (falsifier)
+
+# The in-guest ADVERSARIAL workload (nucleus-adversary-probe) earns its real
+# verdict inside a booted microVM, where it runs as the pod workload and actively
+# attacks the sandbox — the offensive twin of the benign nucleus-workload-probe.
+# That boot assertion (brick 2) lands in quickstart-boot.yml's x86_64-KVM job,
+# which is non-required.
+#
+# This lane is the always-on guard, no boot needed: scripts/check-adversary-
+# probe.sh reconstructs each attack surface hermetically (via the env overrides the
+# probe exposes) and asserts the campaign's verdict logic distinguishes the three
+# states a real attacker-containment probe must —
+#
+#   CONFINED        -> CONTAINED
+#   SECRET/ROOTFS/EGRESS reachable -> BREACH:<stage>   (reds-on-regression)
+#   CONTROL DEAD    -> INCONCLUSIVE, never CONTAINED    (anti-vacuity)
+#
+# plus a meta-anti-leak check that a reported breach never echoes the secret VALUE
+# to the host-readable console (the reporter must not become the exfil channel). A
+# refactor that made the probe always-CONTAINED, dropped the control, or leaked the
+# value reds here on every PR, even though the boot gate is unenforced.
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "crates/nucleus-adversary-probe/**"
+      - "scripts/check-adversary-probe.sh"
+      - ".github/workflows/adversary-probe.yml"
+  pull_request:
+    paths:
+      - "crates/nucleus-adversary-probe/**"
+      - "scripts/check-adversary-probe.sh"
+      - ".github/workflows/adversary-probe.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: adversary-probe-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  adversary-probe-falsifier:
+    name: adversary probe distinguishes contained / breach / inconclusive
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+        with:
+          toolchain: stable
+      - name: Build the adversary probe
+        run: cargo build --release -p nucleus-adversary-probe
+      - name: Falsify — the campaign must distinguish all three verdict states
+        run: |
+          ADVERSARY_PROBE_BIN=target/release/nucleus-adversary-probe \
+            scripts/check-adversary-probe.sh

--- a/.github/workflows/quickstart-boot.yml
+++ b/.github/workflows/quickstart-boot.yml
@@ -282,7 +282,7 @@ jobs:
           cargo build --release --target x86_64-unknown-linux-musl \
             -p nucleus-cli -p nucleus-node -p nucleus-guest-init \
             -p nucleus-tool-proxy -p nucleus-net-probe -p nucleus-workload-probe \
-            -p nucleus-egress-probe
+            -p nucleus-egress-probe -p nucleus-adversary-probe
 
       - name: Build the guest rootfs
         run: |
@@ -392,6 +392,45 @@ jobs:
             exit 1
           }
           echo "in-guest egress backstop: PASS present, FAIL absent"
+
+      - name: The in-guest adversary was contained (active attacker, presence + verdict)
+        run: |
+          # nucleus-adversary-probe runs as the same booted workload — an ACTIVE
+          # attacker that tries to steal a mediator secret from PID 1, tamper the
+          # read-only rootfs, and exfiltrate. It emits NUCLEUS_ADVERSARY: CONTAINED
+          # only if a live positive control AND every stage attempted AND every
+          # attack was blocked. Same fail-closed + anti-vacuity shape as the other
+          # probes, plus the mid-crash guard: assert CONTAINED present, BREACH
+          # absent, the positive control live, and every expected stage line
+          # present (a probe that died after stage 1 is missing later stages and
+          # must not read as contained).
+          state=/var/lib/nucleus/state
+          sudo grep -rq "NUCLEUS_ADVERSARY: CONTAINED" "$state" || {
+            echo "::error::in-guest adversary probe did not report CONTAINED (did it run? was it contained?)"
+            echo "--- adversary markers across all pod logs (empty ⇒ the probe never ran) ---"
+            sudo grep -rhaE 'NUCLEUS_ADVERSARY' "$state" | head -40 || true
+            echo "--- last 60 lines of each guest log ---"
+            sudo find "$state" -name firecracker.log -exec sh -c 'echo "== $1 =="; tail -60 "$1"' _ {} \; || true
+            exit 1
+          }
+          if sudo grep -rqE "NUCLEUS_ADVERSARY: BREACH" "$state"; then
+            echo "::error::in-guest adversary BREACHED the sandbox — an attack succeeded on the live guest"
+            sudo grep -rhaE 'NUCLEUS_ADVERSARY' "$state" | head -40 || true
+            exit 1
+          fi
+          sudo grep -rq "NUCLEUS_ADVERSARY_CONTROL: live" "$state" || {
+            echo "::error::adversary positive control was not live — a dead attacker cannot certify containment"
+            exit 1
+          }
+          # Every stage must have run: a crash after stage 1 would be missing later
+          # stage lines, and CONTAINED-with-missing-stages is the mid-crash hole.
+          for stage in pid1-secret-theft rootfs-tamper exfil; do
+            sudo grep -rq "NUCLEUS_ADVERSARY_STAGE $stage: attempted=yes" "$state" || {
+              echo "::error::adversary stage '$stage' did not run (attempted=yes line absent) — the campaign was incomplete"
+              exit 1
+            }
+          done
+          echo "in-guest adversary: CONTAINED present, BREACH absent, control live, all stages attempted"
 
       - name: Delivery conformance (observed inventory vs the extracted oracle)
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6560,6 +6560,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "nucleus-adversary-probe"
+version = "1.0.0"
+
+[[package]]
 name = "nucleus-agent-card"
 version = "1.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "crates/nucleus-net-probe", # TCP probe for network policy tests
     "crates/nucleus-workload-probe", # in-guest FM-5 posture probe (runs as the pod workload)
     "crates/nucleus-egress-probe", # in-guest egress-confinement probe (C6 phase 2 backstop)
+    "crates/nucleus-adversary-probe", # in-guest ACTIVE attacker: proves the pod contains a live adversary
     "crates/nucleus-podlist-probe", # in-guest cross-pod-listing probe (C2 G4)
     "crates/nucleus-mcp", # MCP server bridging Claude to tool-proxy
     "crates/nucleus-audit", # Audit log verifier CLI

--- a/crates/nucleus-adversary-probe/Cargo.toml
+++ b/crates/nucleus-adversary-probe/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "nucleus-adversary-probe"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+description = "In-guest ADVERSARIAL workload: an active attacker that tries to steal secrets, tamper the rootfs, and exfiltrate — and proves the pod contained it (the offensive twin of nucleus-workload-probe)"
+repository = "https://github.com/coproduct-opensource/nucleus"
+readme = "README.md"
+
+[[bin]]
+name = "nucleus-adversary-probe"
+path = "src/main.rs"
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/crates/nucleus-adversary-probe/README.md
+++ b/crates/nucleus-adversary-probe/README.md
@@ -1,0 +1,12 @@
+# nucleus-adversary-probe
+
+An **active attacker** run as a pod's workload — the offensive twin of
+`nucleus-workload-probe`. From inside the guest it campaigns against the sandbox
+(steal a mediator secret from PID 1, tamper the read-only rootfs, exfiltrate over
+the network) and reports whether the pod **contained** every attempt:
+`NUCLEUS_ADVERSARY: CONTAINED | BREACH:<stage> | INCONCLUSIVE`.
+
+Zero-dependency static musl binary; booleans only (never a stolen value). Its
+verdict logic is gated on every PR (no boot needed) by
+`scripts/check-adversary-probe.sh`, which reconstructs each attack surface
+hermetically and asserts the three verdict states plus a meta-anti-leak check.

--- a/crates/nucleus-adversary-probe/src/main.rs
+++ b/crates/nucleus-adversary-probe/src/main.rs
@@ -1,0 +1,244 @@
+//! `nucleus-adversary-probe` — an ACTIVE attacker run as a pod's workload.
+//!
+//! `nucleus-workload-probe` is a passive posture reader (it looks at its own
+//! `/proc/self/*` and reports booleans) and `nucleus-egress-probe` tests one axis
+//! (TCP egress). This binary is their offensive twin: baked into a pod as the
+//! `workload.command`, it *actively campaigns* against the sandbox from inside the
+//! guest — trying to steal an identity secret from the mediator (PID 1), tamper
+//! the read-only rootfs, and exfiltrate over the network — and reports whether the
+//! pod **contained** every attempt. It is the microVM analogue of the in-process
+//! `red_team_harness`: where that drives an LLM adversary against an in-process
+//! Portcullis, this drives a scripted adversary against a *real booted pod*.
+//!
+//! # What it proves, and the anti-vacuity discipline
+//!
+//! A security property is an uninhabitedness claim: "the workload cannot reach the
+//! mediator's secrets / cannot write the rootfs / cannot egress." An attacker that
+//! is simply *broken* — one that never really tries — certifies nothing. So the
+//! verdict rests on:
+//!
+//!   * a POSITIVE control (`NUCLEUS_ADVERSARY_CONTROL: live`): the probe can make a
+//!     socket, move bytes, and read its own environment where the mediator planted
+//!     `NUCLEUS_TOOL_PROXY_URL`. A dead attacker (crashed, no environment, no
+//!     sockets) is **INCONCLUSIVE**, never CONTAINED;
+//!   * per-stage `attempted=yes` lines, so a run that crashes after stage 1 is
+//!     missing later stages and cannot look contained (the boot gate greps the
+//!     full fixed stage list back on the host);
+//!   * booleans ONLY — never a stolen value. The probe reporting a leak must not
+//!     itself become the exfil channel to the host-readable console.
+//!
+//! Verdict: `CONTAINED` iff the control is live AND every stage attempted its
+//! attack AND every attack was blocked; otherwise `BREACH:<stage>` (stage name
+//! only) or `INCONCLUSIVE`.
+//!
+//! # Configuration (for the host-side falsifier)
+//!
+//! Each attack surface is overridable by env var so `scripts/check-adversary-
+//! probe.sh` can reconstruct all three verdict states hermetically without a boot
+//! (point a stage at a decoy secret / a writable dir / a live listener to force a
+//! BREACH; withhold the proxy URL to force INCONCLUSIVE). In the real guest the
+//! defaults hit the real surfaces (`/proc/1/environ`, `/`, the public internet).
+
+use std::io::{Read, Write};
+use std::net::TcpStream;
+use std::os::unix::net::UnixStream;
+use std::time::Duration;
+
+/// The FM-5 identity variables the workload must never obtain — kept in sync with
+/// `nucleus-workload-probe`'s `IDENTITY_VARS` and `nucleus-tool-proxy`'s tests.
+const IDENTITY_VARS: &[&str] = &[
+    "NUCLEUS_TOOL_PROXY_BROKER_SECRET",
+    "NUCLEUS_TOOL_PROXY_BROKER_PORT",
+    "NUCLEUS_TASK_TOKEN",
+    "NUCLEUS_TASK_TOKEN_NONCE",
+    "NUCLEUS_TASK_TOKEN_ISSUER",
+    "NUCLEUS_TOOL_PROXY_APPROVAL_SECRET",
+    "NUCLEUS_POD_CALLER_TOKEN",
+    "NUCLEUS_SANDBOX_TOKEN",
+    "NUCLEUS_IDENTITY_CERT",
+    "NUCLEUS_DLC_CREDENTIALS",
+    "NUCLEUS_DLC_TRUSTED_KEYS",
+    "NUCLEUS_DLC_ISSUER",
+];
+
+/// The e2e canary's non-secret PREFIX (the CI plants `NUCLEUS_E2E_CANARY=<prefix>
+/// <hex>` in the NODE env). Matching only the prefix means a positive detection is
+/// still reported as a boolean; the full secret is never echoed.
+const CANARY_PREFIX: &str = "nucleus-e2e-canary-";
+
+fn main() {
+    let mut breaches: Vec<&'static str> = Vec::new();
+    let timeout = Duration::from_millis(
+        env_var("NUCLEUS_ADVERSARY_TIMEOUT_MS")
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(500),
+    );
+
+    // The campaign — each stage attempts a real attack and reports a boolean.
+    stage_pid1_secret_theft(&mut breaches);
+    stage_rootfs_tamper(&mut breaches);
+    stage_exfil(&mut breaches, timeout);
+
+    // The positive control decides whether a "no breach" result means anything.
+    let live = control_live();
+    emit(&format!(
+        "NUCLEUS_ADVERSARY_CONTROL: {}",
+        if live { "live" } else { "dead" }
+    ));
+
+    if !live {
+        // A dead attacker proves nothing — refuse to certify containment.
+        emit("NUCLEUS_ADVERSARY: INCONCLUSIVE");
+        std::process::exit(2);
+    }
+    if let Some(stage) = breaches.first() {
+        emit(&format!("NUCLEUS_ADVERSARY: BREACH:{stage}"));
+        std::process::exit(1);
+    }
+    emit("NUCLEUS_ADVERSARY: CONTAINED");
+}
+
+/// Stage 1 — try to steal an identity secret from the mediator (PID 1). The
+/// workload must never be able to read the tool-proxy's environment; if it can and
+/// an `IDENTITY_VARS` key or the canary prefix is present, that is a BREACH. Report
+/// only booleans, never the value read (the probe must not become the leak).
+fn stage_pid1_secret_theft(breaches: &mut Vec<&'static str>) {
+    let path =
+        env_var("NUCLEUS_ADVERSARY_PID1_ENVIRON").unwrap_or_else(|| "/proc/1/environ".to_string());
+    let (looked, stole) = match std::fs::read(&path) {
+        Ok(bytes) => {
+            let text = String::from_utf8_lossy(&bytes);
+            let has_identity_key = text.split('\0').any(|entry| {
+                let key = entry.split('=').next().unwrap_or("");
+                IDENTITY_VARS.contains(&key)
+            });
+            let has_canary = text.contains(CANARY_PREFIX);
+            (true, has_identity_key || has_canary)
+        }
+        // Could not even read PID 1's environment — the strongest containment.
+        Err(_) => (false, false),
+    };
+    stage_line(
+        "pid1-secret-theft",
+        true,
+        !stole,
+        &format!("looked={}", yn(looked)),
+    );
+    if stole {
+        breaches.push("pid1-secret-theft");
+    }
+}
+
+/// Stage 2 — try to tamper the (read-only) rootfs. A confined workload cannot
+/// write outside its own scratch; a successful write to the target is a BREACH.
+fn stage_rootfs_tamper(breaches: &mut Vec<&'static str>) {
+    let dir = env_var("NUCLEUS_ADVERSARY_WRITE_TARGET").unwrap_or_else(|| "/".to_string());
+    let target = format!("{}/.nucleus-adversary-tamper", dir.trim_end_matches('/'));
+    let wrote = std::fs::write(&target, b"tamper").is_ok();
+    if wrote {
+        // If we somehow could, do not leave the artifact behind.
+        let _ = std::fs::remove_file(&target);
+    }
+    stage_line("rootfs-tamper", true, !wrote, "");
+    if wrote {
+        breaches.push("rootfs-tamper");
+    }
+}
+
+/// Stage 3 — try to exfiltrate over the network. Thin by design: the deep
+/// netns/iptables version is `nucleus-egress-probe`; here egress is one axis of the
+/// campaign. A non-allowlisted TCP connect that SUCCEEDS is a BREACH.
+fn stage_exfil(breaches: &mut Vec<&'static str>, timeout: Duration) {
+    let targets = env_var("NUCLEUS_ADVERSARY_DENY_TARGETS")
+        .unwrap_or_else(|| "1.1.1.1:443,8.8.8.8:53".to_string());
+    let mut probed = 0usize;
+    let mut escaped = false;
+    for target in targets.split(',').map(str::trim).filter(|t| !t.is_empty()) {
+        // Literal IP:port only — the exfil posture must not depend on a resolver.
+        let Ok(addr) = target.parse::<std::net::SocketAddr>() else {
+            continue;
+        };
+        probed += 1;
+        if TcpStream::connect_timeout(&addr, timeout).is_ok() {
+            escaped = true;
+        }
+    }
+    let attempted = probed > 0;
+    stage_line(
+        "exfil",
+        attempted,
+        attempted && !escaped,
+        &format!("targets={probed}"),
+    );
+    if escaped {
+        breaches.push("exfil");
+    } else if !attempted {
+        // No targets probed — the posture would be vacuously "blocked".
+        breaches.push("exfil-no-targets");
+    }
+}
+
+/// The anti-vacuity witness. The attacker must be a live process that can make a
+/// socket, move bytes, and read its own environment (where the mediator planted
+/// `NUCLEUS_TOOL_PROXY_URL`). If any of that fails the attacker is dead and its
+/// "no breach" result is meaningless — the verdict becomes INCONCLUSIVE.
+fn control_live() -> bool {
+    let socket_ok = UnixStream::pair()
+        .and_then(|(mut a, mut b)| {
+            b.set_read_timeout(Some(Duration::from_millis(500)))?;
+            a.write_all(b"live")?;
+            let mut buf = [0u8; 4];
+            b.read_exact(&mut buf)?;
+            Ok(&buf == b"live")
+        })
+        .unwrap_or(false);
+
+    let env_ok = std::fs::read("/proc/self/environ")
+        .map(|bytes| {
+            String::from_utf8_lossy(&bytes)
+                .split('\0')
+                .any(|entry| entry.split('=').next() == Some("NUCLEUS_TOOL_PROXY_URL"))
+        })
+        .unwrap_or(false)
+        // Fallback for the host falsifier, where /proc/self/environ may not reflect
+        // an exported var identically across shells: trust the live process env too.
+        || env_var("NUCLEUS_TOOL_PROXY_URL").is_some();
+
+    socket_ok && env_ok
+}
+
+/// Emit a per-stage line. Booleans only — never a value.
+fn stage_line(name: &str, attempted: bool, blocked: bool, extra: &str) {
+    let line = format!(
+        "NUCLEUS_ADVERSARY_STAGE {name}: attempted={} blocked={}{}",
+        yn(attempted),
+        yn(blocked),
+        if extra.is_empty() {
+            String::new()
+        } else {
+            format!(" {extra}")
+        }
+    );
+    eprintln!("{line}");
+    println!("{line}");
+}
+
+/// The verdict/control lines go to BOTH streams: the tool-proxy drains the child's
+/// stderr into the guest console log (where the boot gate greps it), while a direct
+/// `/v1/run` capture reads stdout.
+fn emit(line: &str) {
+    eprintln!("{line}");
+    println!("{line}");
+}
+
+fn yn(b: bool) -> &'static str {
+    if b {
+        "yes"
+    } else {
+        "no"
+    }
+}
+
+fn env_var(key: &str) -> Option<String> {
+    std::env::var(key).ok().filter(|v| !v.is_empty())
+}

--- a/examples/openclaw-demo/probe-pod.yaml
+++ b/examples/openclaw-demo/probe-pod.yaml
@@ -10,6 +10,11 @@
 #     from inside the booted guest that a non-allowlisted TCP connect FAILS while
 #     a socketpair round-trip (the anti-vacuity positive control) succeeds — i.e.
 #     the netns default-deny is applied on the live guest.
+#   - nucleus-adversary-probe — the offensive twin: an ACTIVE attacker that, from
+#     inside the live guest, tries to steal a mediator secret from PID 1, tamper
+#     the read-only rootfs, and exfiltrate — and reports NUCLEUS_ADVERSARY:
+#     CONTAINED only if every attack was attempted and blocked (exit 0). It runs
+#     LAST so its attacks see the fully-booted, mediated workload environment.
 # The demo pod stays workload-free; this is the boot-gate variant.
 apiVersion: nucleus/v1
 kind: Pod
@@ -31,7 +36,7 @@ spec:
     command: /bin/sh
     args:
       - "-c"
-      - "/usr/local/bin/nucleus-workload-probe; w=$?; /usr/local/bin/nucleus-egress-probe; e=$?; [ $w -eq 0 ] && [ $e -eq 0 ]"
+      - "/usr/local/bin/nucleus-workload-probe; w=$?; /usr/local/bin/nucleus-egress-probe; e=$?; /usr/local/bin/nucleus-adversary-probe; a=$?; [ $w -eq 0 ] && [ $e -eq 0 ] && [ $a -eq 0 ]"
     uid: 65534
   policy:
     type: profile

--- a/scripts/check-adversary-probe.sh
+++ b/scripts/check-adversary-probe.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# Host-side falsifier for nucleus-adversary-probe.
+#
+# WHY THIS EXISTS
+#
+# The adversary probe's real verdict is earned INSIDE a booted microVM, where it
+# runs as the pod workload and the sandbox is live (brick 2 wires a boot-lane
+# assertion in quickstart-boot.yml). But that job boots on x86_64 CI and is NOT a
+# required check — so on its own the probe could silently rot: a refactor that made
+# it always CONTAINED, or that dropped the anti-vacuity control, would red nothing
+# that blocks a merge.
+#
+# This gate closes that gap WITHOUT a boot, by reconstructing each attack surface
+# hermetically (env overrides the probe exposes for exactly this) and asserting the
+# campaign's verdict logic across the three states a real probe must distinguish:
+#
+#   1. CONFINED           -> CONTAINED  (every attack attempted and blocked)
+#   2a SECRET READABLE    -> BREACH:pid1-secret-theft   (reds-on-regression)
+#   2b ROOTFS WRITABLE    -> BREACH:rootfs-tamper        (reds-on-regression)
+#   2c EGRESS REACHABLE   -> BREACH:exfil                (reds-on-regression)
+#   3. CONTROL DEAD       -> INCONCLUSIVE, never CONTAINED   (anti-vacuity)
+#
+# Plus a META-ANTI-LEAK assertion: in the secret-breach state the probe must report
+# the breach WITHOUT ever echoing the secret VALUE — a probe that leaks the secret
+# to its own (host-readable) console has itself become the exfil channel.
+#
+# Usage: scripts/check-adversary-probe.sh
+set -uo pipefail
+cd "$(git rev-parse --show-toplevel 2>/dev/null || echo .)"
+
+failures=0
+fail() { echo "  FAIL  $1"; failures=$((failures + 1)); }
+ok() { echo "  ok    $1"; }
+
+# ── Locate (or build) the probe binary ──────────────────────────────────────
+BIN="${ADVERSARY_PROBE_BIN:-}"
+if [[ -z "$BIN" ]]; then
+    for cand in \
+        target/release/nucleus-adversary-probe \
+        target/debug/nucleus-adversary-probe \
+        target/*/release/nucleus-adversary-probe \
+        target/*/debug/nucleus-adversary-probe; do
+        [[ -x "$cand" ]] && {
+            BIN="$cand"
+            break
+        }
+    done
+fi
+if [[ -z "$BIN" || ! -x "$BIN" ]]; then
+    echo "building nucleus-adversary-probe…"
+    cargo build -q -p nucleus-adversary-probe || {
+        echo "ERROR: build failed"
+        exit 1
+    }
+    BIN=target/debug/nucleus-adversary-probe
+fi
+echo "probe: $BIN"
+
+WORK="$(mktemp -d)"
+LISTENER_PID=""
+cleanup() {
+    [[ -n "$LISTENER_PID" ]] && kill "$LISTENER_PID" 2>/dev/null
+    rm -rf "$WORK"
+}
+trap cleanup EXIT INT TERM
+
+# Shared safe defaults for a CONFINED run. WRITE_TARGET=/proc gives a path that is
+# non-writable even for root (proc rejects the create), so the confined state holds
+# regardless of the CI uid; the TEST-NET-3 address (RFC 5737) is guaranteed
+# non-routable so the exfil connect fails without a netns.
+CONFINED_ENV=(
+    "NUCLEUS_TOOL_PROXY_URL=http://mediator.invalid"
+    "NUCLEUS_ADVERSARY_PID1_ENVIRON=/dev/null"
+    "NUCLEUS_ADVERSARY_WRITE_TARGET=/proc"
+    "NUCLEUS_ADVERSARY_DENY_TARGETS=203.0.113.1:443"
+    "NUCLEUS_ADVERSARY_TIMEOUT_MS=400"
+)
+
+# run_probe <extra KEY=VAL>... -> writes combined stdout+stderr to $OUT, sets $RC
+run_probe() {
+    OUT="$WORK/out"
+    env -i "${CONFINED_ENV[@]}" "$@" "$BIN" >"$OUT" 2>&1
+    RC=$?
+}
+
+# ── State 1: CONFINED -> CONTAINED (exit 0) ─────────────────────────────────
+run_probe
+if [[ "$RC" -eq 0 ]] && grep -q "NUCLEUS_ADVERSARY: CONTAINED" "$OUT"; then
+    ok "confined campaign -> CONTAINED (exit 0)"
+else
+    fail "confined campaign should be CONTAINED/exit0, got rc=$RC:"
+    sed 's/^/        /' "$OUT"
+fi
+
+# ── State 2a: SECRET READABLE -> BREACH:pid1-secret-theft + meta-anti-leak ───
+SECRET="adversary-falsifier-secret-$RANDOM$RANDOM"
+printf 'NUCLEUS_TASK_TOKEN=%s\0' "$SECRET" >"$WORK/decoy_environ"
+run_probe "NUCLEUS_ADVERSARY_PID1_ENVIRON=$WORK/decoy_environ"
+if [[ "$RC" -eq 1 ]] && grep -q "NUCLEUS_ADVERSARY: BREACH:pid1-secret-theft" "$OUT"; then
+    ok "readable mediator secret -> BREACH:pid1-secret-theft (exit 1)"
+else
+    fail "a stealable secret should be BREACH:pid1-secret-theft/exit1, got rc=$RC:"
+    sed 's/^/        /' "$OUT"
+fi
+if grep -qF "$SECRET" "$OUT"; then
+    fail "META-ANTI-LEAK: the probe echoed the stolen secret VALUE to its console — it became the exfil channel"
+else
+    ok "meta-anti-leak: breach reported without echoing the secret value"
+fi
+
+# ── State 2b: ROOTFS WRITABLE -> BREACH:rootfs-tamper ────────────────────────
+run_probe "NUCLEUS_ADVERSARY_WRITE_TARGET=$WORK"
+if [[ "$RC" -eq 1 ]] && grep -q "NUCLEUS_ADVERSARY: BREACH:rootfs-tamper" "$OUT"; then
+    ok "writable target -> BREACH:rootfs-tamper (exit 1)"
+    [[ -e "$WORK/.nucleus-adversary-tamper" ]] && fail "the probe left its tamper artifact behind"
+else
+    fail "a writable rootfs should be BREACH:rootfs-tamper/exit1, got rc=$RC:"
+    sed 's/^/        /' "$OUT"
+fi
+
+# ── State 2c: EGRESS REACHABLE -> BREACH:exfil ──────────────────────────────
+# Stand up a throwaway TCP listener the probe can actually reach.
+PORT=0
+if command -v python3 >/dev/null; then
+    python3 - "$WORK/port" <<'PY' &
+import socket, sys
+s = socket.socket(); s.bind(("127.0.0.1", 0)); s.listen(16)
+open(sys.argv[1], "w").write(str(s.getsockname()[1]))
+while True:
+    try: c, _ = s.accept(); c.close()
+    except OSError: break
+PY
+    LISTENER_PID=$!
+    for _ in $(seq 1 50); do [[ -s "$WORK/port" ]] && break; sleep 0.1; done
+    PORT="$(cat "$WORK/port" 2>/dev/null || echo 0)"
+fi
+if [[ "$PORT" != "0" ]]; then
+    run_probe "NUCLEUS_ADVERSARY_DENY_TARGETS=127.0.0.1:$PORT"
+    if [[ "$RC" -eq 1 ]] && grep -q "NUCLEUS_ADVERSARY: BREACH:exfil" "$OUT"; then
+        ok "reachable egress -> BREACH:exfil (exit 1)"
+    else
+        fail "a reachable egress target should be BREACH:exfil/exit1, got rc=$RC:"
+        sed 's/^/        /' "$OUT"
+    fi
+else
+    echo "  skip  egress-breach state (no python3 to host a listener) — other states still gate"
+fi
+
+# ── State 3: CONTROL DEAD -> INCONCLUSIVE, never CONTAINED (anti-vacuity) ────
+# Withhold the mediator URL so the positive control cannot go live.
+OUT="$WORK/out"
+env -i \
+    "NUCLEUS_ADVERSARY_PID1_ENVIRON=/dev/null" \
+    "NUCLEUS_ADVERSARY_WRITE_TARGET=/proc" \
+    "NUCLEUS_ADVERSARY_DENY_TARGETS=203.0.113.1:443" \
+    "NUCLEUS_ADVERSARY_TIMEOUT_MS=400" \
+    "$BIN" >"$OUT" 2>&1
+RC=$?
+if [[ "$RC" -eq 2 ]] && grep -q "NUCLEUS_ADVERSARY: INCONCLUSIVE" "$OUT" \
+    && ! grep -q "NUCLEUS_ADVERSARY: CONTAINED" "$OUT"; then
+    ok "dead positive control -> INCONCLUSIVE, not CONTAINED (exit 2)"
+else
+    fail "a dead attacker must be INCONCLUSIVE (never CONTAINED), got rc=$RC:"
+    sed 's/^/        /' "$OUT"
+fi
+
+echo
+if [[ "$failures" -gt 0 ]]; then
+    echo "FAILED: $failures problem(s) — the adversary probe's verdict logic is broken."
+    exit 1
+fi
+echo "OK: the adversary campaign distinguishes CONTAINED / BREACH:<stage> / INCONCLUSIVE,"
+echo "    and reports a breach without leaking the secret value."

--- a/scripts/check-gates-can-fail.sh
+++ b/scripts/check-gates-can-fail.sh
@@ -412,9 +412,17 @@ UNCOVERED_CEILING=2
 #     not probed here because it needs netns + iptables + sudo, and because its
 #     perturbation is internal — there is no external subject for this script to
 #     break.
+#   check-adversary-probe.sh — likewise a self-falsifier for the in-pod adversary:
+#     it reconstructs each attack surface and asserts the probe reports CONTAINED
+#     when confined, BREACH:<stage> when a surface is opened (reds-on-regression),
+#     and INCONCLUSIVE when the positive control is dead (anti-vacuity), plus a
+#     meta-anti-leak check. Those perturbations run every CI invocation in the
+#     'adversary-probe-falsifier' job of adversary-probe.yml; the perturbation is
+#     internal, so there is no external subject for this script to break.
 SELF_FALSIFIED=(
     "check-mediation-dylint.sh    --self-test in the 'mediated' job (dylint-separation.yml)"
     "check-egress-probe.sh        States 2+3 in the 'egress-probe-falsifier' job (quickstart-boot.yml)"
+    "check-adversary-probe.sh     BREACH+INCONCLUSIVE states in the 'adversary-probe-falsifier' job (adversary-probe.yml)"
 )
 
 echo

--- a/scripts/firecracker/build-rootfs.sh
+++ b/scripts/firecracker/build-rootfs.sh
@@ -53,6 +53,7 @@ NET_PROBE_BIN="${NET_PROBE_BIN:-$ROOT_DIR/target/$TARGET/release/nucleus-net-pro
 WORKLOAD_PROBE_BIN="${WORKLOAD_PROBE_BIN:-$ROOT_DIR/target/$TARGET/release/nucleus-workload-probe}"
 EGRESS_PROBE_BIN="${EGRESS_PROBE_BIN:-$ROOT_DIR/target/$TARGET/release/nucleus-egress-probe}"
 PODLIST_PROBE_BIN="${PODLIST_PROBE_BIN:-$ROOT_DIR/target/$TARGET/release/nucleus-podlist-probe}"
+ADVERSARY_PROBE_BIN="${ADVERSARY_PROBE_BIN:-$ROOT_DIR/target/$TARGET/release/nucleus-adversary-probe}"
 NET_ALLOW="${NET_ALLOW:-}"
 NET_DENY="${NET_DENY:-}"
 # NOTE: Secrets are now injected at runtime via kernel command line (nucleus.auth_secret, nucleus.approval_secret)
@@ -154,6 +155,7 @@ while [[ $# -gt 0 ]]; do
 WORKLOAD_PROBE_BIN="${WORKLOAD_PROBE_BIN:-$ROOT_DIR/target/$TARGET/release/nucleus-workload-probe}"
 EGRESS_PROBE_BIN="${EGRESS_PROBE_BIN:-$ROOT_DIR/target/$TARGET/release/nucleus-egress-probe}"
 PODLIST_PROBE_BIN="${PODLIST_PROBE_BIN:-$ROOT_DIR/target/$TARGET/release/nucleus-podlist-probe}"
+ADVERSARY_PROBE_BIN="${ADVERSARY_PROBE_BIN:-$ROOT_DIR/target/$TARGET/release/nucleus-adversary-probe}"
             shift 2
             ;;
         --output)
@@ -369,6 +371,10 @@ cp "$EGRESS_PROBE_BIN" "$ROOTFS_DIR/usr/local/bin/nucleus-egress-probe"
 # Only the C2 podlist boot lane builds this probe; the default probe-pod boot
 # does not, so bake it only when it was built (an absent binary is not an error).
 [ -f "$PODLIST_PROBE_BIN" ] && cp "$PODLIST_PROBE_BIN" "$ROOTFS_DIR/usr/local/bin/nucleus-podlist-probe"
+# The adversary probe is baked for the probe-pod boot lane (which builds it and
+# runs it as the workload); guarded like podlist so lanes that do not build it
+# skip cleanly rather than error.
+[ -f "$ADVERSARY_PROBE_BIN" ] && cp "$ADVERSARY_PROBE_BIN" "$ROOTFS_DIR/usr/local/bin/nucleus-adversary-probe"
 
 # Copy init binary (prefer Rust binary, fall back to shell script)
 if [ -f "$GUEST_INIT_BIN" ]; then
@@ -421,6 +427,10 @@ if [ -n "${OVERLAY_DIR:-}" ]; then
     # Conditional for the same reason as the primary copy above (podlist probe is
     # built only by the C2 boot lane).
     [ -f "$PODLIST_PROBE_BIN" ] && cp "$PODLIST_PROBE_BIN" "$ROOTFS_DIR/usr/local/bin/nucleus-podlist-probe"
+# The adversary probe is baked for the probe-pod boot lane (which builds it and
+# runs it as the workload); guarded like podlist so lanes that do not build it
+# skip cleanly rather than error.
+[ -f "$ADVERSARY_PROBE_BIN" ] && cp "$ADVERSARY_PROBE_BIN" "$ROOTFS_DIR/usr/local/bin/nucleus-adversary-probe"
     cp "$SCRIPT_DIR/guest-net.sh" "$ROOTFS_DIR/usr/local/bin/guest-net.sh"
     if [ -e "$OVERLAY_DIR/init" ]; then
         echo "WARNING: overlay shadowed /init; restoring the nucleus init" >&2
@@ -438,6 +448,7 @@ chmod +x "$ROOTFS_DIR/usr/local/bin/nucleus-tool-proxy"
 chmod +x "$ROOTFS_DIR/usr/local/bin/nucleus-net-probe"
 chmod +x "$ROOTFS_DIR/usr/local/bin/nucleus-workload-probe"
 chmod +x "$ROOTFS_DIR/usr/local/bin/nucleus-egress-probe"
+[ -f "$ROOTFS_DIR/usr/local/bin/nucleus-adversary-probe" ] && chmod +x "$ROOTFS_DIR/usr/local/bin/nucleus-adversary-probe"
 chmod +x "$ROOTFS_DIR/usr/local/bin/guest-net.sh"
 
 # Build ext4 image from directory
@@ -453,7 +464,7 @@ echo "Architecture: $ARCH"
 # Print binary info
 echo ""
 echo "Included binaries:"
-for bin in init usr/local/bin/nucleus-tool-proxy usr/local/bin/nucleus-net-probe usr/local/bin/nucleus-workload-probe usr/local/bin/nucleus-egress-probe; do
+for bin in init usr/local/bin/nucleus-tool-proxy usr/local/bin/nucleus-net-probe usr/local/bin/nucleus-workload-probe usr/local/bin/nucleus-egress-probe usr/local/bin/nucleus-adversary-probe; do
     if [ -f "$ROOTFS_DIR/$bin" ]; then
         size=$(du -h "$ROOTFS_DIR/$bin" | cut -f1)
         echo "  /$bin ($size)"


### PR DESCRIPTION
## What

"Can we exercise an agent within a nucleus pod, the way `boot-a-real-pod` does?" — **yes**, adversarially. New crate **`nucleus-adversary-probe`** is the offensive twin of `nucleus-workload-probe`: baked in as a pod's `workload.command`, it campaigns against the sandbox *from inside the guest* and reports whether the pod **contained** every attempt.

Campaign stages (booleans only, never a stolen value):
- **pid1-secret-theft** — try to read an FM-5 identity secret / the e2e canary from the mediator's (PID 1) environment;
- **rootfs-tamper** — try to write the read-only rootfs;
- **exfil** — try a non-allowlisted TCP connect (thin; the deep netns version is `nucleus-egress-probe`).

Verdict: `CONTAINED` iff a live positive control **and** every stage attempted **and** every attack blocked; else `BREACH:<stage>` or `INCONCLUSIVE`. Zero-dep static musl, **zero-unsafe**.

## Anti-vacuity (the load-bearing part)
Mirrors the egress probe. A **dead attacker** (no socket / no environment / no mediator URL) is `INCONCLUSIVE`, never `CONTAINED`. Per-stage `attempted=yes` lines let the boot gate catch a mid-crash. And a **meta-anti-leak**: a reported breach never echoes the stolen VALUE — the reporter must not itself become the exfil channel.

## Brick 1 = teeth on every PR (no boot needed)
`scripts/check-adversary-probe.sh` reconstructs each attack surface hermetically (via the probe's env overrides) and asserts all three verdict states, **reds-on-regression for each stage**, and the meta-anti-leak. Standalone workflow `adversary-probe.yml` runs it — deliberately *not* in `quickstart-boot.yml`, to avoid colliding with the boot-twin path invariant from #2279.

**6/6 falsifier checks green** on the release build; `clippy --all-targets -D warnings` clean; exemplar `lints_adoption_pct` held.

## Brick 2 (the follow, named)
Bake the probe as a 3rd entry in `examples/openclaw-demo/probe-pod.yaml`'s workload chain + a boot-lane assertion in `quickstart-boot.yml` (`NUCLEUS_ADVERSARY: CONTAINED` present, `BREACH:` absent, every stage line present) — so a *real KVM boot* runs the live adversary. Validated on Lima/OrbStack like the C2 lane.

## Design calls (from scoping)
- **SPIFFE is the adversary's TARGET** — it tries to steal the SVID/task-token and proves it can't (FM-5 made adversarial).
- **Claude WIF stays out of the guest** — vendor-neutrality (`CLAUDE.md`) + the guest has no model to call; the JWT-SVID→model exchange is an orchestrator concern, not this in-guest brick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148ebbw4UXypRjhMw3xAQzj