### PR TITLE
keyless auth: vendor-neutral RFC 7523 token-exchange client + Bearer seam for the red-team adversary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6903,6 +6903,7 @@ dependencies = [
  "thiserror 2.0.19",
  "tokio",
  "tracing",
+ "wiremock",
 ]
 
 [[package]]

--- a/crates/nucleus-github-oidc/Cargo.toml
+++ b/crates/nucleus-github-oidc/Cargo.toml
@@ -14,6 +14,13 @@ readme = "README.md"
 [lints]
 workspace = true
 
+[features]
+# The keyless-auth primitive (src/token_exchange.rs): a generic RFC 7523
+# jwt-bearer exchange. Off by default so the base identity crate builds
+# network-free (no reqwest on any production path); the exchange pulls reqwest in
+# only when a consumer opts in.
+token-exchange = ["dep:reqwest"]
+
 [dependencies]
 base64 = { workspace = true }
 jsonwebtoken = { workspace = true }
@@ -23,6 +30,9 @@ serde_json = { workspace = true }
 nucleus-oidc-core = { path = "../nucleus-oidc-core" }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+# Only for the `token-exchange` feature (the HTTP exchange). Optional so the
+# default build stays network-free.
+reqwest = { workspace = true, optional = true }
 
 [dev-dependencies]
 # `rt-multi-thread` for the example's `#[tokio::main]`; `reqwest` for the live
@@ -39,6 +49,9 @@ rustls = { workspace = true }
 # to the Aeneas-extractable `extracted/` mirror (byte-identical across random
 # Unicode), plus the lossiness/collision finding.
 proptest = { workspace = true }
+# Hermetic mock HTTP for the token-exchange fail-closed tests (same version the
+# rest of the workspace uses). Plain HTTP; no crypto provider needed to serve.
+wiremock = "0.6"
 
 [[example]]
 name = "keyless_oidc_prototype"

--- a/crates/nucleus-github-oidc/src/lib.rs
+++ b/crates/nucleus-github-oidc/src/lib.rs
@@ -27,6 +27,10 @@ mod claims;
 /// code in [`claims`] is bound to it by parity proptests. See the module docs
 /// for the trust chain and the (honest) lossiness/collision finding.
 pub mod extracted;
+/// Generic RFC 7523 JWT-bearer token exchange (the keyless-auth primitive).
+/// Behind the `token-exchange` feature so the base crate stays network-free.
+#[cfg(feature = "token-exchange")]
+pub mod token_exchange;
 mod validator;
 
 pub use claims::{derive_spiffe_id, GitHubClaims};

--- a/crates/nucleus-github-oidc/src/token_exchange.rs
+++ b/crates/nucleus-github-oidc/src/token_exchange.rs
@@ -1,0 +1,260 @@
+//! Generic OAuth JWT-bearer token exchange (RFC 7523), behind the
+//! `token-exchange` feature so the base identity crate stays network-free.
+//!
+//! This is the keyless-auth primitive: a workload presents an OIDC JWT (a GitHub
+//! Actions token, or a SPIFFE JWT-SVID) and exchanges it for a short-lived Bearer
+//! access token, with no static API key. It is the mechanism behind vendor
+//! Workload Identity Federation (e.g. Anthropic's Claude API WIF is exactly an
+//! RFC 7523 `jwt-bearer` grant), but this client is **vendor-neutral**: the token
+//! endpoint, audience, and grant type are all inputs — there is no vendor host or
+//! token literal in this module.
+//!
+//! # Fail-closed
+//!
+//! The exchange returns a usable token ONLY on an unambiguous success: a 2xx
+//! response whose body carries an `access_token` and a `token_type` of `Bearer`.
+//! A non-2xx status, a missing `access_token`, or any other `token_type` is an
+//! `Err` — never a token. A relying party can therefore treat a returned
+//! [`ExchangedToken`] as "the IdP federated this workload", nothing weaker.
+
+use reqwest::Client;
+
+/// Percent-encode one `application/x-www-form-urlencoded` value (RFC 3986
+/// unreserved set stays literal; everything else becomes `%XX`).
+fn form_encode(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for b in s.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                out.push(b as char)
+            }
+            _ => out.push_str(&format!("%{b:02X}")),
+        }
+    }
+    out
+}
+
+/// The RFC 7523 grant type most IdPs (and vendor WIF) accept.
+pub const GRANT_JWT_BEARER: &str = "urn:ietf:params:oauth:grant-type:jwt-bearer";
+
+/// A short-lived Bearer token minted by the exchange.
+#[derive(Debug, Clone)]
+pub struct ExchangedToken {
+    /// The `access_token`, to be sent as `Authorization: Bearer <token>`.
+    pub bearer: String,
+    /// Seconds until expiry, as reported by the endpoint (0 if unstated).
+    pub expires_in: u64,
+}
+
+/// Why an exchange did not yield a usable Bearer token.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExchangeError {
+    /// The HTTP request itself failed (connect/TLS/timeout).
+    Http(String),
+    /// The endpoint returned a non-2xx status (with a truncated body).
+    Status(u16, String),
+    /// The 2xx body was not the expected JSON.
+    Body(String),
+    /// A required field was absent from the success body.
+    Missing(&'static str),
+    /// The `token_type` was present but not `Bearer` — refuse it.
+    NotBearer(String),
+}
+
+impl std::fmt::Display for ExchangeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Http(e) => write!(f, "token exchange HTTP error: {e}"),
+            Self::Status(c, b) => write!(f, "token exchange returned status {c}: {b}"),
+            Self::Body(e) => write!(f, "token exchange body was not valid JSON: {e}"),
+            Self::Missing(field) => write!(f, "token exchange success body missing `{field}`"),
+            Self::NotBearer(t) => write!(f, "token exchange returned token_type {t:?}, not Bearer"),
+        }
+    }
+}
+
+impl std::error::Error for ExchangeError {}
+
+/// Exchange an OIDC JWT for a short-lived Bearer token via an RFC 7523
+/// `jwt-bearer` grant. `endpoint`, `audience`, and `grant` are inputs so this is
+/// vendor-neutral (pass [`GRANT_JWT_BEARER`] for the standard grant).
+///
+/// Fail-closed: only a 2xx body with `access_token` and `token_type == "Bearer"`
+/// yields `Ok`.
+pub async fn exchange_jwt_bearer(
+    http: &Client,
+    endpoint: &str,
+    subject_jwt: &str,
+    audience: &str,
+    grant: &str,
+) -> Result<ExchangedToken, ExchangeError> {
+    // application/x-www-form-urlencoded, RFC 3986 percent-encoding, no extra deps.
+    let body = format!(
+        "grant_type={}&assertion={}&audience={}",
+        form_encode(grant),
+        form_encode(subject_jwt),
+        form_encode(audience),
+    );
+    let resp = http
+        .post(endpoint)
+        .header("content-type", "application/x-www-form-urlencoded")
+        .body(body)
+        .send()
+        .await
+        .map_err(|e| ExchangeError::Http(e.to_string()))?;
+
+    let status = resp.status();
+    let text = resp
+        .text()
+        .await
+        .map_err(|e| ExchangeError::Http(e.to_string()))?;
+
+    if !status.is_success() {
+        let mut body = text;
+        body.truncate(200);
+        return Err(ExchangeError::Status(status.as_u16(), body));
+    }
+
+    let v: serde_json::Value =
+        serde_json::from_str(&text).map_err(|e| ExchangeError::Body(e.to_string()))?;
+
+    // Refuse anything that is not explicitly a Bearer token — a relying party must
+    // not carry a token whose type the IdP did not affirm as Bearer.
+    match v.get("token_type").and_then(serde_json::Value::as_str) {
+        Some(t) if t.eq_ignore_ascii_case("bearer") => {}
+        Some(other) => return Err(ExchangeError::NotBearer(other.to_string())),
+        None => return Err(ExchangeError::Missing("token_type")),
+    }
+
+    let bearer = v
+        .get("access_token")
+        .and_then(serde_json::Value::as_str)
+        .ok_or(ExchangeError::Missing("access_token"))?
+        .to_string();
+    let expires_in = v
+        .get("expires_in")
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(0);
+
+    Ok(ExchangedToken { bearer, expires_in })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{body_string_contains, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn client() -> Client {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        Client::new()
+    }
+
+    /// Success — a well-formed exchange returns the Bearer the endpoint minted.
+    /// The mock ONLY matches when the request body carries the `jwt-bearer`
+    /// grant_type AND the assertion JWT, so a green here proves the client
+    /// actually SENT the exchange (assert-on-received), not merely returned Ok.
+    #[tokio::test]
+    async fn exchanges_a_jwt_for_the_endpoints_bearer() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/oauth/token"))
+            .and(body_string_contains("grant_type=urn"))
+            .and(body_string_contains("jwt-bearer"))
+            .and(body_string_contains("assertion=the.subject.jwt"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": "sk-oat-minted-by-endpoint",
+                "token_type": "Bearer",
+                "expires_in": 900
+            })))
+            .mount(&server)
+            .await;
+
+        let tok = exchange_jwt_bearer(
+            &client(),
+            &format!("{}/oauth/token", server.uri()),
+            "the.subject.jwt",
+            "https://rp.example/api",
+            GRANT_JWT_BEARER,
+        )
+        .await
+        .expect("a well-formed exchange yields a token");
+
+        // The returned Bearer is the MINTED token, never the subject JWT — a
+        // client that forwarded the raw assertion instead would fail here.
+        assert_eq!(tok.bearer, "sk-oat-minted-by-endpoint");
+        assert_ne!(tok.bearer, "the.subject.jwt");
+        assert_eq!(tok.expires_in, 900);
+    }
+
+    /// FAIL-CLOSED — a non-2xx status yields no token.
+    #[tokio::test]
+    async fn a_rejected_exchange_is_an_error_not_a_token() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(
+                ResponseTemplate::new(403).set_body_string("federation rule did not match"),
+            )
+            .mount(&server)
+            .await;
+
+        let err = exchange_jwt_bearer(
+            &client(),
+            &format!("{}/oauth/token", server.uri()),
+            "j",
+            "a",
+            GRANT_JWT_BEARER,
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(err, ExchangeError::Status(403, _)), "{err}");
+    }
+
+    /// FAIL-CLOSED — a 2xx body with no `access_token` yields no token.
+    #[tokio::test]
+    async fn a_success_body_without_access_token_is_an_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "token_type": "Bearer", "expires_in": 900
+            })))
+            .mount(&server)
+            .await;
+
+        let err = exchange_jwt_bearer(
+            &client(),
+            &format!("{}/oauth/token", server.uri()),
+            "j",
+            "a",
+            GRANT_JWT_BEARER,
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err, ExchangeError::Missing("access_token"));
+    }
+
+    /// FAIL-CLOSED — a token the endpoint does not call `Bearer` is refused, even
+    /// with an `access_token` present. A client that accepted any token_type
+    /// would go green here — this is the mutation-red guard.
+    #[tokio::test]
+    async fn a_non_bearer_token_type_is_refused() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": "opaque", "token_type": "mac", "expires_in": 900
+            })))
+            .mount(&server)
+            .await;
+
+        let err = exchange_jwt_bearer(
+            &client(),
+            &format!("{}/oauth/token", server.uri()),
+            "j",
+            "a",
+            GRANT_JWT_BEARER,
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err, ExchangeError::NotBearer("mac".to_string()));
+    }
+}

--- a/crates/nucleus-tool-proxy/tests/red_team_harness.rs
+++ b/crates/nucleus-tool-proxy/tests/red_team_harness.rs
@@ -59,6 +59,52 @@ const ENV_API_URL: &str = "LLM_API_URL";
 const ENV_API_KEY: &str = "LLM_API_KEY";
 const ENV_MODEL: &str = "LLM_MODEL";
 const ENV_API_VERSION: &str = "LLM_API_VERSION";
+const ENV_AUTH_SCHEME: &str = "LLM_AUTH_SCHEME";
+
+/// How the backend is authenticated. `ApiKey` sends `x-api-key` (the default,
+/// back-compat); `Bearer` sends `Authorization: Bearer <token>` — for a token
+/// minted by a keyless RFC 7523 exchange (workload identity federation), so the
+/// harness can run keyless with a SPIFFE/OIDC-derived token instead of a static
+/// key. The credential itself is still supplied via `LLM_API_KEY`.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum AuthScheme {
+    ApiKey,
+    Bearer,
+}
+
+impl AuthScheme {
+    fn from_env() -> Self {
+        match std::env::var(ENV_AUTH_SCHEME).ok().as_deref() {
+            Some(s) if s.eq_ignore_ascii_case("bearer") => Self::Bearer,
+            _ => Self::ApiKey,
+        }
+    }
+}
+
+/// The single auth header for a scheme + credential. A pure function, unit-tested
+/// without a network: `(header_name, value)`.
+fn auth_headers(scheme: AuthScheme, credential: &str) -> (&'static str, String) {
+    match scheme {
+        AuthScheme::ApiKey => ("x-api-key", credential.to_string()),
+        AuthScheme::Bearer => ("authorization", format!("Bearer {credential}")),
+    }
+}
+
+#[test]
+fn auth_headers_bearer_scheme_uses_authorization_not_api_key() {
+    // ApiKey (the default / back-compat) is unchanged.
+    let (name, value) = auth_headers(AuthScheme::ApiKey, "sk-static-key");
+    assert_eq!(name, "x-api-key");
+    assert_eq!(value, "sk-static-key");
+
+    // Bearer (a keyless-exchange token) is carried as Authorization: Bearer, and
+    // never as x-api-key — a token minted by workload-identity federation is an
+    // OAuth Bearer, not an API key.
+    let (name, value) = auth_headers(AuthScheme::Bearer, "sk-ant-oat01-minted");
+    assert_eq!(name, "authorization");
+    assert_eq!(value, "Bearer sk-ant-oat01-minted");
+    assert_ne!(name, "x-api-key");
+}
 
 const MAX_TOOL_CALLS: usize = 20;
 const MAX_TOKENS: usize = 4096;
@@ -683,6 +729,7 @@ struct LlmConfig {
     model: String,
     /// Optional protocol/version header value, sent as `api-version` when set.
     api_version: Option<String>,
+    auth_scheme: AuthScheme,
 }
 
 impl LlmConfig {
@@ -692,6 +739,7 @@ impl LlmConfig {
             api_key: std::env::var(ENV_API_KEY).map_err(|_| format!("{ENV_API_KEY} required"))?,
             model: std::env::var(ENV_MODEL).map_err(|_| format!("{ENV_MODEL} required"))?,
             api_version: std::env::var(ENV_API_VERSION).ok(),
+            auth_scheme: AuthScheme::from_env(),
         })
     }
 }
@@ -701,6 +749,7 @@ struct LlmClient {
     endpoint: String,
     api_key: String,
     api_version: Option<String>,
+    auth_scheme: AuthScheme,
 }
 
 #[derive(Serialize)]
@@ -752,14 +801,16 @@ impl LlmClient {
             endpoint: config.endpoint.clone(),
             api_key: config.api_key.clone(),
             api_version: config.api_version.clone(),
+            auth_scheme: config.auth_scheme,
         }
     }
 
     async fn send(&self, request: &MessagesRequest) -> Result<MessagesResponse, String> {
+        let (auth_name, auth_value) = auth_headers(self.auth_scheme, &self.api_key);
         let mut builder = self
             .client
             .post(&self.endpoint)
-            .header("x-api-key", &self.api_key)
+            .header(auth_name, auth_value)
             .header("content-type", "application/json");
         if let Some(version) = &self.api_version {
             builder = builder.header("api-version", version);


### PR DESCRIPTION
## What

The substrate for the **live-LLM adversary in CI** (the chosen next big step): a Claude-driven adversary authenticated **keylessly** (SPIFFE → workload-identity federation) instead of with a static API key. This brick makes *keyless* a tested primitive, not a claim.

### `nucleus-github-oidc::token_exchange` (feature-gated)
`exchange_jwt_bearer(http, endpoint, subject_jwt, audience, grant)` — an [RFC 7523 `jwt-bearer`](https://platform.claude.com/docs/en/manage-claude/workload-identity-federation) exchange: POST the OIDC JWT / SPIFFE JWT-SVID, get a short-lived Bearer.
- **Vendor-neutral:** endpoint, audience, and grant are all inputs — no vendor host or token literal. (Anthropic's Claude WIF is exactly this grant; so is any conformant IdP.)
- **Fail-closed:** only a 2xx body with `access_token` and `token_type == "Bearer"` yields `Ok`; non-2xx / missing `access_token` / any other `token_type` → `Err`, never a token.
- Behind a `token-exchange` feature so the base identity crate's own code stays off the network path (`reqwest` optional).

### Teeth (wiremock, hermetic, per-PR via `cargo test --all-features`)
- success **with assert-on-received** — the mock only matches when the request actually carried the `jwt-bearer` grant + assertion, proving the client *sent* the exchange, not merely returned `Ok`;
- three fail-closed cases; the **non-Bearer case is the mutation-red guard** (a client that accepted any `token_type` reds here).

### Red-team harness Bearer seam
`AuthScheme::{ApiKey, Bearer}` (env `LLM_AUTH_SCHEME`, default `ApiKey` for back-compat) + a pure `auth_headers` helper replacing the hardcoded `x-api-key`. Bearer emits `Authorization: Bearer` and never `x-api-key` — so the harness can carry a keyless-exchanged token. Unit-tested.

Verified on Linux (CI cfg): 4 exchange tests + `auth_headers` green; `clippy --all-features -D warnings` clean for both crates. Covered per-PR automatically by `ci.yml`'s existing `--all-features` test + clippy jobs.

## Reserved for you (the follow bricks)
The **WIF federation rule** (mapping this repo's OIDC to a Claude service account), any **live token/key secret**, the actual **nightly live-Claude run**, and any outward **"keyless Claude adversary"** wording. This brick is the mechanism; activation is yours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148ebbw4UXypRjhMw3xAQzj