### PR TITLE
red-team nightly lane: run the live-LLM adversary keyless, with anti-vacuity teeth

### DIFF
--- a/.github/workflows/red-team-agent.yml
+++ b/.github/workflows/red-team-agent.yml
@@ -1,0 +1,119 @@
+name: Red-team adversary (nightly, live-LLM)
+
+# A live-LLM adversary: an LLM tries to exfiltrate a planted canary from a
+# Portcullis-defended sandbox (crates/nucleus-tool-proxy/tests/red_team_harness.rs),
+# and any exfiltration reds the run. Nightly rather than per-PR because it is
+# non-deterministic and costs a model call — the DETERMINISTIC in-pod adversary
+# (nucleus-adversary-probe, adversary-probe.yml + the boot lane) is the per-PR gate.
+#
+# KEYLESS: when a workload-identity-federation endpoint is configured
+# (`vars.LLM_OAUTH_TOKEN_URL`), the adversary authenticates with a short-lived
+# Bearer minted by exchanging THIS workflow's GitHub OIDC token (RFC 7523
+# jwt-bearer, via the in-tree nucleus-github-oidc token_exchange client) — no
+# static LLM key in CI. Otherwise it falls back to an `LLM_API_KEY` secret; if
+# neither is set, it does not run.
+#
+# ANTI-VACUITY: the token-exchange client's fail-closed tests run EVERY night
+# (non-vacuous even with no backend), and a final gate fails unless the live lane
+# resolved to a KNOWN state — live-ran, or explicitly-skipped-with-a-notice — so a
+# broken lane that neither runs nor cleanly skips reds instead of silent-greening.
+# (The live tests are `#[ignore]`, so they never vacuously pass in the per-PR job.)
+
+on:
+  schedule:
+    - cron: "37 4 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: red-team-agent-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  exchange-client:
+    name: keyless token-exchange client is fail-closed (hermetic, every night)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+        with:
+          toolchain: stable
+      # Runs unconditionally: proves the keyless-auth primitive still refuses a
+      # non-2xx / missing-access_token / non-Bearer response, so the nightly is
+      # never entirely vacuous even when no live backend is configured.
+      - name: The RFC 7523 exchange client refuses a malformed token
+        run: cargo test -p nucleus-github-oidc --features token-exchange token_exchange
+
+  live-adversary:
+    name: live-LLM adversary vs Portcullis (keyless when WIF is configured)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      id-token: write # to fetch a GitHub OIDC token for the keyless exchange
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+        with:
+          toolchain: stable
+
+      - name: Resolve the LLM backend (keyless WIF, or key secret, or none)
+        id: backend
+        env:
+          LLM_OAUTH_TOKEN_URL: ${{ vars.LLM_OAUTH_TOKEN_URL }}
+          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+        run: |
+          if [ -n "${LLM_OAUTH_TOKEN_URL:-}" ]; then
+            echo "mode=wif" >> "$GITHUB_OUTPUT"
+          elif [ -n "${LLM_API_KEY:-}" ]; then
+            echo "mode=key" >> "$GITHUB_OUTPUT"
+          else
+            echo "mode=none" >> "$GITHUB_OUTPUT"
+            echo "::notice::no LLM backend configured — set the LLM_OAUTH_TOKEN_URL variable (keyless WIF) or the LLM_API_KEY secret to run the live adversary. The token-exchange client test still ran."
+          fi
+
+      - name: Mint a keyless Bearer from the GitHub OIDC token (WIF mode)
+        id: keyless
+        if: steps.backend.outputs.mode == 'wif'
+        env:
+          LLM_OAUTH_TOKEN_URL: ${{ vars.LLM_OAUTH_TOKEN_URL }}
+          LLM_OAUTH_AUDIENCE: ${{ vars.LLM_OAUTH_AUDIENCE }}
+        run: |
+          set -euo pipefail
+          # Fetch this job's GitHub OIDC token for the configured audience, then
+          # exchange it for a short-lived Bearer via the in-tree RFC 7523 client.
+          oidc=$(curl -sS -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=${LLM_OAUTH_AUDIENCE}" | jq -r '.value')
+          bearer=$(LLM_OIDC_JWT="$oidc" cargo run -q -p nucleus-github-oidc \
+            --features token-exchange --example keyless_token)
+          echo "::add-mask::$bearer"
+          echo "bearer=$bearer" >> "$GITHUB_OUTPUT"
+
+      - name: Run the live-LLM adversary (keyless Bearer, or API-key secret)
+        if: steps.backend.outputs.mode != 'none'
+        env:
+          LLM_API_URL: ${{ vars.LLM_API_URL }}
+          LLM_MODEL: ${{ vars.LLM_MODEL }}
+          LLM_API_VERSION: ${{ vars.LLM_API_VERSION }}
+          # WIF -> a keyless Bearer carried via LLM_AUTH_SCHEME=bearer; else the key.
+          LLM_AUTH_SCHEME: ${{ steps.backend.outputs.mode == 'wif' && 'bearer' || 'apikey' }}
+          LLM_API_KEY: ${{ steps.keyless.outputs.bearer || secrets.LLM_API_KEY }}
+        run: |
+          cargo test -p nucleus-tool-proxy --features red-team --test red_team_harness \
+            -- --ignored --nocapture
+
+      - name: Anti-vacuity — the lane resolved to a known state (never silent-green)
+        run: |
+          mode="${{ steps.backend.outputs.mode }}"
+          case "$mode" in
+            wif) echo "live adversary ran keyless (WIF-minted Bearer)" ;;
+            key) echo "live adversary ran with an API-key secret" ;;
+            none) echo "explicitly skipped: no backend configured (notice emitted above)" ;;
+            *)
+              echo "::error::backend resolution produced no mode ('$mode') — the lane neither ran nor explicitly skipped"
+              exit 1
+              ;;
+          esac

--- a/crates/nucleus-github-oidc/Cargo.toml
+++ b/crates/nucleus-github-oidc/Cargo.toml
@@ -56,3 +56,10 @@ wiremock = "0.6"
 [[example]]
 name = "keyless_oidc_prototype"
 # Lives behind `--example` so it never builds in the default workspace pass.
+
+[[example]]
+name = "keyless_token"
+# The keyless entrypoint (OIDC JWT -> Bearer) for the nightly red-team lane. Only
+# builds with the exchange client's feature, so the default workspace pass and any
+# `--examples` build without the feature skip it cleanly.
+required-features = ["token-exchange"]

--- a/crates/nucleus-github-oidc/examples/keyless_token.rs
+++ b/crates/nucleus-github-oidc/examples/keyless_token.rs
@@ -1,0 +1,52 @@
+//! Exchange an OIDC JWT (a GitHub Actions token, or a SPIFFE JWT-SVID) for a
+//! short-lived Bearer via the generic RFC 7523 client — the keyless entrypoint
+//! the nightly red-team lane uses to authenticate a live-LLM adversary WITHOUT a
+//! static API key.
+//!
+//! Reads the subject JWT, the token endpoint, and the audience from the
+//! environment; prints ONLY the Bearer to stdout (so a caller can capture it) and
+//! diagnostics to stderr. Fail-closed: a rejected or malformed exchange exits
+//! non-zero and prints no token.
+//!
+//! ```bash
+//! LLM_OIDC_JWT=<oidc-jwt> LLM_OAUTH_TOKEN_URL=<endpoint> LLM_OAUTH_AUDIENCE=<aud> \
+//!   cargo run -p nucleus-github-oidc --features token-exchange --example keyless_token
+//! ```
+
+use nucleus_github_oidc::token_exchange::{exchange_jwt_bearer, GRANT_JWT_BEARER};
+
+#[tokio::main]
+async fn main() {
+    // Workspace reqwest is rustls-no-provider; install a provider before building
+    // a Client (never exercised against a mock, required at Client-build time).
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let jwt = require_env("LLM_OIDC_JWT");
+    let endpoint = require_env("LLM_OAUTH_TOKEN_URL");
+    let audience = require_env("LLM_OAUTH_AUDIENCE");
+    let grant = std::env::var("LLM_OAUTH_GRANT").unwrap_or_else(|_| GRANT_JWT_BEARER.to_string());
+
+    let client = reqwest::Client::new();
+    match exchange_jwt_bearer(&client, &endpoint, &jwt, &audience, &grant).await {
+        Ok(token) => {
+            eprintln!(
+                "keyless: exchanged an OIDC JWT for a Bearer (expires in {}s)",
+                token.expires_in
+            );
+            // stdout carries ONLY the token, so `TOKEN=$(... example ...)` works.
+            println!("{}", token.bearer);
+        }
+        Err(err) => {
+            // Fail-closed: no token on stdout, non-zero exit.
+            eprintln!("keyless: exchange FAILED (no token minted): {err}");
+            std::process::exit(1);
+        }
+    }
+}
+
+fn require_env(key: &str) -> String {
+    std::env::var(key).unwrap_or_else(|_| {
+        eprintln!("keyless: {key} is required");
+        std::process::exit(2);
+    })
+}

--- a/crates/nucleus-tool-proxy/tests/red_team_harness.rs
+++ b/crates/nucleus-tool-proxy/tests/red_team_harness.rs
@@ -1290,6 +1290,7 @@ fn require_api_key() -> Option<()> {
 }
 
 #[tokio::test]
+#[ignore = "live LLM adversary; nightly red-team lane only (needs a backend: LLM_API_KEY or a keyless WIF token)"]
 async fn red_team_restrictive() {
     if require_api_key().is_none() {
         return;
@@ -1306,6 +1307,7 @@ async fn red_team_restrictive() {
 }
 
 #[tokio::test]
+#[ignore = "live LLM adversary; nightly red-team lane only (needs a backend: LLM_API_KEY or a keyless WIF token)"]
 async fn red_team_web_research() {
     if require_api_key().is_none() {
         return;
@@ -1316,6 +1318,7 @@ async fn red_team_web_research() {
 }
 
 #[tokio::test]
+#[ignore = "live LLM adversary; nightly red-team lane only (needs a backend: LLM_API_KEY or a keyless WIF token)"]
 async fn red_team_fix_issue() {
     if require_api_key().is_none() {
         return;
@@ -1326,6 +1329,7 @@ async fn red_team_fix_issue() {
 }
 
 #[tokio::test]
+#[ignore = "live LLM adversary; nightly red-team lane only (needs a backend: LLM_API_KEY or a keyless WIF token)"]
 async fn red_team_full_uninhabitable() {
     if require_api_key().is_none() {
         return;


### PR DESCRIPTION
## What

Brick 2 of the live-LLM adversary arc (brick 1 = the keyless token-exchange client, #2282). Wires the existing live-LLM `red_team_harness` into a **nightly** CI lane and closes a real vacuity the scoping surfaced.

### Fix the silent-green skips
`red_team_harness.rs`'s four live tests skipped via a bare `return` when no LLM key — a silent pass that proved nothing in the per-PR `--all-features` job. They're now `#[ignore]`, so they never run (or vacuously pass) per-PR; the nightly runs them with `-- --ignored` only when a backend is configured.

### The keyless entrypoint
New example `nucleus-github-oidc/keyless_token` (`required-features = ["token-exchange"]`): reads an OIDC JWT + endpoint + audience, calls `exchange_jwt_bearer`, prints **only** the minted Bearer — fail-closed (no token on a rejected exchange).

### The nightly workflow (`red-team-agent.yml`)
- **`exchange-client` job** runs the hermetic fail-closed `token_exchange` tests **every night** — the lane is never entirely vacuous even with no backend.
- **`live-adversary` job** resolves the backend — keyless WIF (`vars.LLM_OAUTH_TOKEN_URL` → fetch this job's GitHub OIDC token → exchange for a Bearer → `LLM_AUTH_SCHEME=bearer`) → else an `LLM_API_KEY` secret → else none — runs the harness with a backend, and a final **anti-vacuity gate fails unless the lane resolved to a known state** (ran, or explicitly skipped with a `::notice::`). A broken lane reds instead of silent-greening.

The deterministic per-PR gate stays the in-pod `nucleus-adversary-probe` (#2281); this is the non-deterministic nightly complement.

## Reserved for you (activation)
The **WIF federation rule** (repo OIDC → a Claude service account), any **live token/key secret**, and any outward **"keyless Claude adversary"** claim. Without them the lane runs the exchange test and *explicitly* skips the live run — no silent green.

Verified: 4 live tests `ignored` (not vacuous) + `auth_headers` green; example builds under the feature; workflow YAML valid + the anti-vacuity case reds on an unresolved mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148ebbw4UXypRjhMw3xAQzj