### PR TITLE
feat(identity,tool-proxy): bind a forensic receipt to the attested subject key

### DIFF
--- a/crates/nucleus-identity/src/assurance.rs
+++ b/crates/nucleus-identity/src/assurance.rs
@@ -131,6 +131,22 @@ pub struct VerifiedAttestation {
     pub assurance: AssuranceLevel,
     /// What the backend names as the attested subject.
     pub subject: AttestedSubject,
+    /// SHA-256 of the attested subject's **signing key** — the 32-byte Ed25519
+    /// public key that this subject signs on its own behalf with — when the
+    /// backend binds such a key. This is what lets a relying party close the
+    /// substitution hole: a forensic `MediationReceipt` claiming this attestation
+    /// must be signed by THIS key, not merely by some key the relying party was
+    /// handed alongside the attestation.
+    ///
+    /// `None` when the backend attests something that is not an Ed25519 signing
+    /// key comparable to a receipt signer — a self-measured launch (an artifact,
+    /// not a key), or a TPM-resident key named by a TPM Name (a hash over the TPM
+    /// public area, not the bare public key). A relying party that needs the
+    /// key-binding must treat `None` as "cannot establish", never as "waived":
+    /// `verify_attested_receipt` enforces the binding only when this is `Some`,
+    /// and its contract requires the caller to have obtained `signer_pubkey` from
+    /// the attested SVID itself when it is `None`.
+    pub subject_key_sha256: Option<[u8; 32]>,
     /// Claims the backend affirmatively established.
     pub proves: BTreeSet<Claim>,
     /// Claims the backend explicitly could NOT establish.
@@ -232,6 +248,9 @@ impl SvidAttestationBackend for SelfMeasuredBackend {
                     backend: self.id(),
                     assurance: self.assurance(),
                     subject: AttestedSubject::SelfMeasuredNode,
+                    // Self-measurement attests the launched artifact, not an
+                    // Ed25519 signing key, so it cannot bind a receipt signer.
+                    subject_key_sha256: None,
                     proves,
                     not_proven,
                     launch: Some(launch),

--- a/crates/nucleus-identity/src/tpm_devid.rs
+++ b/crates/nucleus-identity/src/tpm_devid.rs
@@ -303,6 +303,10 @@ pub fn verify_residency(
             ak_name_sha256: sha256_32(&ak_name),
             subject_name_sha256: sha256_32(&subject_name),
         },
+        // A TPM Name is a hash over the TPM public area, not the bare Ed25519
+        // public key a receipt signer presents, so this residency proof cannot
+        // bind a receipt signer directly (that binding is a later brick).
+        subject_key_sha256: None,
         proves,
         not_proven,
         launch: None,
@@ -740,6 +744,9 @@ pub fn compose_l2(
         backend: "tpm-devid-l2",
         assurance: AssuranceLevel::L2Device,
         subject: residency.subject.clone(),
+        // Inherits residency's key-binding: still a TPM Name, not a bare
+        // Ed25519 receipt-signer key.
+        subject_key_sha256: residency.subject_key_sha256,
         proves,
         not_proven,
         launch: None,
@@ -760,6 +767,7 @@ mod l2_composition_tests {
                 ak_name_sha256: ak,
                 subject_name_sha256: [0u8; 32],
             },
+            subject_key_sha256: None,
             proves: BTreeSet::from([Claim::KeyNonExportable]),
             not_proven: BTreeSet::from([Claim::HardwareRootedKey, Claim::StableDeviceIdentity]),
             launch: None,

--- a/crates/nucleus-tool-proxy/src/attestation.rs
+++ b/crates/nucleus-tool-proxy/src/attestation.rs
@@ -24,6 +24,7 @@
 use ed25519_dalek::VerifyingKey;
 use nucleus_identity::{AssuranceLevel, LaunchAttestation, VerifiedAttestation};
 use portcullis::mediation_receipt::MediationReceipt;
+use sha2::{Digest, Sha256};
 use std::collections::HashSet;
 use std::sync::Arc;
 use tracing::{debug, info, warn};
@@ -394,9 +395,12 @@ impl AttestationVerifier {
 }
 
 /// Relying-party cross-check for a forensic [`MediationReceipt`] (North Star C9 /
-/// signed-agent-actions): verify the mediator's signature **and** that the
-/// receipt's self-claimed `{signer_assurance, signer_backend}` **exactly match** an
-/// independently-verified attestation of the signer's SVID.
+/// signed-agent-actions): verify the mediator's signature, that the receipt's
+/// self-claimed `{signer_assurance, signer_backend}` **exactly match** an
+/// independently-verified attestation of the signer's SVID, **and** — when the
+/// attestation names a signing key ([`VerifiedAttestation::subject_key_sha256`]) —
+/// that the receipt was signed by THAT key (the deep key-binding, closing the
+/// key-substitution hole).
 ///
 /// This is what makes the receipt's self-claim non-load-bearing: a receipt is a
 /// perfectly valid signature over whatever assurance the signer *wrote*, so the
@@ -437,6 +441,27 @@ pub fn verify_attested_receipt(
             receipt.signer_assurance,
             attestation.assurance().as_u8()
         ));
+    }
+
+    // 3. The DEEP key-binding, when the attestation names a signing key: the
+    //    receipt must be signed by THAT key, not merely by some key handed in
+    //    alongside the attestation. Without this, a receipt signed by any key
+    //    could borrow a hardware-rooted SVID's backend+assurance by presenting
+    //    that SVID's attestation next to an unrelated `signer_pubkey`. When the
+    //    attestation does NOT name a key (`None` — a self-measured launch, or a
+    //    TPM Name that is not a bare Ed25519 key), the binding cannot be checked
+    //    here; the caller's contract is then to have obtained `signer_pubkey`
+    //    from the attested SVID itself.
+    if let Some(expected) = attestation.subject_key_sha256 {
+        let mut hasher = Sha256::new();
+        hasher.update(signer_pubkey.to_bytes());
+        let got: [u8; 32] = hasher.finalize().into();
+        if got != expected {
+            return Err(
+                "receipt signing key is not the attested subject key -- key substitution rejected"
+                    .to_string(),
+            );
+        }
     }
 
     Ok(attestation.assurance())
@@ -704,15 +729,27 @@ mod tests {
     }
 
     /// An independently-verified attestation — what a relying party derives itself.
-    fn att(backend: &'static str, level: AssuranceLevel) -> VerifiedAttestation {
+    /// `key_fp` binds a specific signing key (the deep key-binding); `None` leaves
+    /// the binding unestablished, as a self-measured or TPM-Name subject does.
+    fn att_bound(
+        backend: &'static str,
+        level: AssuranceLevel,
+        key_fp: Option<[u8; 32]>,
+    ) -> VerifiedAttestation {
         VerifiedAttestation {
             backend,
             assurance: level,
             subject: AttestedSubject::SelfMeasuredNode,
+            subject_key_sha256: key_fp,
             proves: BTreeSet::new(),
             not_proven: BTreeSet::new(),
             launch: None,
         }
+    }
+
+    /// The common case in these tests: no key-binding declared.
+    fn att(backend: &'static str, level: AssuranceLevel) -> VerifiedAttestation {
+        att_bound(backend, level, None)
     }
 
     #[test]
@@ -759,6 +796,62 @@ mod tests {
         )
         .unwrap_err();
         assert!(err.contains("backend"), "{err}");
+    }
+
+    /// SHA-256 of a verifying key's 32 bytes — the same encoding
+    /// `verify_attested_receipt` hashes `signer_pubkey` under.
+    fn key_fp(vk: &VerifyingKey) -> [u8; 32] {
+        let mut h = Sha256::new();
+        h.update(vk.to_bytes());
+        h.finalize().into()
+    }
+
+    /// When the attestation binds THIS signing key, a receipt signed by it is
+    /// admitted — the control for the substitution test below (so that test is
+    /// detecting the mismatch, not a broken binding).
+    #[test]
+    fn attested_receipt_admits_when_the_bound_key_signed_it() {
+        let sk = SigningKey::from_bytes(&[7u8; 32]);
+        let r = signed_receipt(&sk, 1, "self-measured");
+        let level = verify_attested_receipt(
+            &r,
+            &sk.verifying_key(),
+            &att_bound(
+                "self-measured",
+                AssuranceLevel::L1Software,
+                Some(key_fp(&sk.verifying_key())),
+            ),
+        )
+        .expect("the bound key's own receipt is admitted");
+        assert_eq!(level, AssuranceLevel::L1Software);
+    }
+
+    /// **THE deep-key-binding load-bearing test.** A receipt validly signed by
+    /// key K, whose `{backend, assurance}` match the attestation exactly, is still
+    /// REJECTED when the attestation binds a DIFFERENT key K' — the attestation of
+    /// a hardware-rooted identity cannot be borrowed by a receipt some other key
+    /// signed. Both `signer_pubkey` and the receipt's signature are K's here
+    /// (internally consistent), so only the subject-key binding catches it;
+    /// deleting the step turns this green.
+    #[test]
+    fn attested_receipt_rejects_a_receipt_signed_by_a_key_the_attestation_does_not_bind() {
+        let signer = SigningKey::from_bytes(&[7u8; 32]);
+        let attested = SigningKey::from_bytes(&[8u8; 32]); // the key the SVID actually binds
+        let r = signed_receipt(&signer, 1, "self-measured"); // internally valid under `signer`
+        let err = verify_attested_receipt(
+            &r,
+            &signer.verifying_key(),
+            &att_bound(
+                "self-measured",
+                AssuranceLevel::L1Software,
+                Some(key_fp(&attested.verifying_key())),
+            ),
+        )
+        .unwrap_err();
+        assert!(
+            err.contains("substitution") || err.contains("not the attested subject key"),
+            "{err}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

Closes a **latent key-substitution hole** in `verify_attested_receipt`. It verified the mediator signature and cross-checked `{backend, assurance}`, but trusted the caller's `signer_pubkey` — so a receipt signed by *any* key could borrow a hardware-rooted SVID's attestation by presenting that attestation next to an unrelated key.

## How

`VerifiedAttestation` gains `subject_key_sha256: Option<[u8;32]>` — SHA-256 of the attested subject's Ed25519 signing key, when the backend binds one. `verify_attested_receipt`, when it is `Some`, now requires `signer_pubkey` to hash to it: the receipt must be signed by **the attested key**, not merely a key handed in beside the attestation.

`None` means the backend attests something that is not a bare Ed25519 signer (a self-measured *launch*; a TPM *Name* over a public area), so the binding cannot be established here — the field docs and the fn contract require a relying party to treat `None` as *"cannot establish"*, never *"waived"*. **Every current backend declares `None` honestly.**

## Load-bearing test

A receipt validly signed by key K, whose `{backend, assurance}` match the attestation exactly, is **rejected** when the attestation binds a *different* key — with a matching-key control so the test detects the mismatch, not a broken binding. Deleting the binding step turns it green.

## Follow-on (RESERVED — architectural + identity-semantics)

Making the **live** mediation signing key actually equal (or be certified against) the pod's attested SVID leaf key, so a live backend can populate `subject_key_sha256`. Today the per-pod mediation key is distinct from the SVID leaf, so this lands the binding as a **ready, tested primitive** — not yet enforced on the live path. That live wiring touches identity/wire semantics and is left for Brandon.

## Boot-affecting

Touches `crates/nucleus-tool-proxy/**` so the boot lane reruns, but this is the (dead-code) attestation cross-check primitive — no live verdict-path behavior changes. Hand-gated on boot regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148ebbw4UXypRjhMw3xAQzj