### PR TITLE
feat(identity): SVID mediator-key binding (OID .1.4) — makes the receipt key-binding consumable

### DIFF
--- a/crates/nucleus-identity/src/assurance.rs
+++ b/crates/nucleus-identity/src/assurance.rs
@@ -138,14 +138,16 @@ pub struct VerifiedAttestation {
     /// must be signed by THIS key, not merely by some key the relying party was
     /// handed alongside the attestation.
     ///
-    /// `None` when the backend attests something that is not an Ed25519 signing
-    /// key comparable to a receipt signer — a self-measured launch (an artifact,
-    /// not a key), or a TPM-resident key named by a TPM Name (a hash over the TPM
-    /// public area, not the bare public key). A relying party that needs the
-    /// key-binding must treat `None` as "cannot establish", never as "waived":
-    /// `verify_attested_receipt` enforces the binding only when this is `Some`,
-    /// and its contract requires the caller to have obtained `signer_pubkey` from
-    /// the attested SVID itself when it is `None`.
+    /// `Some` when the SVID names a bound Ed25519 signing key: the self-measured
+    /// backend reads it from the mediator-key-binding extension (OID .1.4) the node
+    /// embeds at issuance, and a future backend may bind a key directly. `None`
+    /// when no such binding is present — including a TPM-resident key named only by
+    /// a TPM Name (a hash over the TPM public area, not a bare public key). A
+    /// relying party that needs the key-binding must treat `None` as "cannot
+    /// establish", never as "waived": `verify_attested_receipt` enforces the
+    /// binding only when this is `Some`, and its contract requires the caller to
+    /// have obtained `signer_pubkey` from the attested SVID itself when it is
+    /// `None`.
     pub subject_key_sha256: Option<[u8; 32]>,
     /// Claims the backend affirmatively established.
     pub proves: BTreeSet<Claim>,
@@ -244,13 +246,20 @@ impl SvidAttestationBackend for SelfMeasuredBackend {
         match verify_attested_svid(chain_pem, requirements, require_attestation)? {
             Some(launch) => {
                 let (proves, not_proven) = Self::claim_profile();
+                // Self-measurement attests the launched artifact, not a key — but
+                // the node can ALSO bind a mediator signing key to this SVID via
+                // the mediator-key-binding extension (OID .1.4). When present,
+                // surface it so `verify_attested_receipt` can require the receipt
+                // to be signed by exactly that key; absent, the binding is simply
+                // not established (`None`).
+                let subject_key_sha256 = pem::parse(chain_pem).ok().and_then(|leaf| {
+                    crate::attestation::extract_mediation_key_binding(leaf.contents())
+                });
                 Ok(Some(VerifiedAttestation {
                     backend: self.id(),
                     assurance: self.assurance(),
                     subject: AttestedSubject::SelfMeasuredNode,
-                    // Self-measurement attests the launched artifact, not an
-                    // Ed25519 signing key, so it cannot bind a receipt signer.
-                    subject_key_sha256: None,
+                    subject_key_sha256,
                     proves,
                     not_proven,
                     launch: Some(launch),

--- a/crates/nucleus-identity/src/attestation.rs
+++ b/crates/nucleus-identity/src/attestation.rs
@@ -731,6 +731,28 @@ pub fn extract_launch_attestation(cert_der: &[u8]) -> Option<LaunchAttestation> 
     None
 }
 
+/// Extract the mediator-key binding from an X.509 certificate extension.
+///
+/// Looks for OID `1.3.6.1.4.1.57212.1.4` (Nucleus mediator-key binding) and
+/// returns the embedded `SHA-256(mediator Ed25519 public key)`. This is the value
+/// a relying party places in [`VerifiedAttestation::subject_key_sha256`] so
+/// `verify_attested_receipt` can require the receipt to be signed by exactly this
+/// key. The wire shape is identical to the permission fingerprint (a
+/// version-tagged 32-byte octet string), so the same DER parser reads it.
+///
+/// Returns `None` if the extension is absent or cannot be parsed.
+pub fn extract_mediation_key_binding(cert_der: &[u8]) -> Option<[u8; 32]> {
+    use x509_parser::prelude::{FromDer, X509Certificate};
+
+    let (_, cert) = X509Certificate::from_der(cert_der).ok()?;
+    for ext in cert.extensions() {
+        if ext.oid.as_bytes() == crate::oid::OID_NUCLEUS_MEDIATION_KEY_BINDING_BYTES {
+            return parse_permission_fingerprint_der(ext.value);
+        }
+    }
+    None
+}
+
 /// Relying-party verification of an attested SVID served over `FETCH_SVID`.
 ///
 /// This is the *outside* verifier for the North Star C9 leg: given the PEM cert

--- a/crates/nucleus-identity/src/ca/self_signed.rs
+++ b/crates/nucleus-identity/src/ca/self_signed.rs
@@ -375,6 +375,36 @@ impl SelfSignedCa {
         ext
     }
 
+    /// Creates a custom X.509 extension binding the SVID to a mediator signing key.
+    ///
+    /// OID: 1.3.6.1.4.1.57212.1.4 (Nucleus mediator-key binding)
+    /// Content: DER-encoded SEQUENCE { INTEGER(version=1), OCTET STRING(32 bytes) }
+    /// where the 32 bytes are `SHA-256(mediator Ed25519 public key)`.
+    ///
+    /// This binds the attested identity to the specific key that signs this pod's
+    /// forensic `MediationReceipt`s, so a relying party can reject a receipt signed
+    /// by any other key (see `verify_attested_receipt`). Same wire shape as the
+    /// permission-fingerprint extension — a version-tagged 32-byte octet string.
+    #[allow(dead_code)]
+    fn create_mediation_key_binding_extension(pubkey_sha256: &[u8; 32]) -> CustomExtension {
+        let mut content = vec![
+            0x02, // INTEGER tag
+            0x01, // length 1
+            0x01, // version 1
+            0x04, // OCTET STRING tag
+            0x20, // length 32
+        ];
+        content.extend_from_slice(pubkey_sha256);
+
+        let mut der = vec![0x30, content.len() as u8];
+        der.extend_from_slice(&content);
+
+        let mut ext =
+            CustomExtension::from_oid_content(oid::OID_NUCLEUS_MEDIATION_KEY_BINDING_TUPLE, der);
+        ext.set_criticality(false);
+        ext
+    }
+
     /// Signs a certificate using only a public key (no private key needed).
     ///
     /// This is used for CSR-only signing flows (like OIDC) where the client
@@ -1068,6 +1098,85 @@ mod tests {
             extracted.is_none(),
             "standard cert without fingerprint extension should return None"
         );
+    }
+
+    /// **Brick E2 round-trip.** An SVID carrying the mediator-key-binding
+    /// extension (OID .1.4) makes the bound key visible to the relying party:
+    /// `extract_mediation_key_binding` returns it, and the self-measured backend
+    /// surfaces it as `VerifiedAttestation::subject_key_sha256` — the value
+    /// `verify_attested_receipt` then requires the receipt to be signed under.
+    #[tokio::test]
+    async fn a_mediator_key_binding_extension_is_surfaced_by_the_verifier() {
+        use crate::assurance::{SelfMeasuredBackend, SvidAttestationBackend};
+        use crate::attestation::{extract_mediation_key_binding, AttestationRequirements};
+
+        let ca = SelfSignedCa::new("nucleus.local").unwrap();
+        let identity = Identity::new("nucleus.local", "default", "mediator-agent");
+        let cert_sign = crate::CsrOptions::new(identity.to_spiffe_uri())
+            .generate()
+            .unwrap();
+        let key_pair = KeyPair::from_pem(cert_sign.private_key()).unwrap();
+
+        let attestation = LaunchAttestation::from_hashes([1u8; 32], [2u8; 32], [3u8; 32]);
+        let binding = [0x42u8; 32]; // stand-in for SHA-256(mediator pubkey)
+        let att_ext = SelfSignedCa::create_attestation_extension(&attestation);
+        let bind_ext = SelfSignedCa::create_mediation_key_binding_extension(&binding);
+        let chain = ca
+            .sign_with_keypair_and_extensions(
+                &key_pair,
+                &identity,
+                Duration::from_secs(3600),
+                vec![att_ext, bind_ext],
+            )
+            .unwrap();
+        let leaf = &chain[0];
+
+        assert_eq!(
+            extract_mediation_key_binding(leaf.der()),
+            Some(binding),
+            "the binding must be extractable straight from the leaf DER"
+        );
+        let va = SelfMeasuredBackend
+            .verify_svid(leaf.to_pem(), &AttestationRequirements::any(), true)
+            .unwrap()
+            .expect("an attested leaf verifies");
+        assert_eq!(
+            va.subject_key_sha256,
+            Some(binding),
+            "the verifier must surface the bound key as subject_key_sha256"
+        );
+    }
+
+    /// The control: an attested SVID WITHOUT the binding extension surfaces
+    /// `subject_key_sha256 = None` — so the key-binding is "not established", never
+    /// silently waived.
+    #[tokio::test]
+    async fn an_svid_without_the_binding_surfaces_no_bound_key() {
+        use crate::assurance::{SelfMeasuredBackend, SvidAttestationBackend};
+        use crate::attestation::AttestationRequirements;
+
+        let ca = SelfSignedCa::new("nucleus.local").unwrap();
+        let identity = Identity::new("nucleus.local", "default", "plain-agent");
+        let cert_sign = crate::CsrOptions::new(identity.to_spiffe_uri())
+            .generate()
+            .unwrap();
+        let key_pair = KeyPair::from_pem(cert_sign.private_key()).unwrap();
+        let attestation = LaunchAttestation::from_hashes([1u8; 32], [2u8; 32], [3u8; 32]);
+        let att_ext = SelfSignedCa::create_attestation_extension(&attestation);
+        let chain = ca
+            .sign_with_keypair_and_extensions(
+                &key_pair,
+                &identity,
+                Duration::from_secs(3600),
+                vec![att_ext],
+            )
+            .unwrap();
+
+        let va = SelfMeasuredBackend
+            .verify_svid(chain[0].to_pem(), &AttestationRequirements::any(), true)
+            .unwrap()
+            .expect("an attested leaf verifies");
+        assert_eq!(va.subject_key_sha256, None);
     }
 
     #[test]

--- a/crates/nucleus-identity/src/oid.rs
+++ b/crates/nucleus-identity/src/oid.rs
@@ -71,6 +71,29 @@ pub const OID_NUCLEUS_TPM_RESIDENCY_BYTES: &[u8] = &[
 
 pub const OID_NUCLEUS_TPM_RESIDENCY_TUPLE: &[u64] = &[1, 3, 6, 1, 4, 1, 57212, 1, 3];
 
+/// OID for Nucleus mediator-key binding (same PEN arc, component .1.4).
+///
+/// OID: 1.3.6.1.4.1.57212.1.4
+/// - PEN: 57212 (same unregistered placeholder)
+/// - Component: .1.4 (attestation.mediation_key_binding)
+///
+/// The extension carries `SHA-256(mediator Ed25519 public key)`, binding the
+/// attested SVID to the specific key that signs this pod's forensic
+/// [`MediationReceipt`](crate)s. It is what lets a relying party close the
+/// key-substitution hole: a receipt claiming this SVID's attestation must be
+/// signed by the key named here, not merely by a key handed in beside it (see
+/// `verify_attested_receipt` / [`VerifiedAttestation::subject_key_sha256`]).
+///
+/// **INTERNAL / no interop commitment.** Like the rest of the 57212 arc, this is
+/// an in-tree format; external interoperability (and PEN registration) is a
+/// separate outward-facing decision.
+pub const OID_NUCLEUS_MEDIATION_KEY_BINDING_BYTES: &[u8] = &[
+    0x2b, 0x06, 0x01, 0x04, 0x01, 0x83, 0xbe, 0x7c, // 1.3.6.1.4.1.57212
+    0x01, 0x04, // .1.4 (attestation.mediation_key_binding)
+];
+
+pub const OID_NUCLEUS_MEDIATION_KEY_BINDING_TUPLE: &[u64] = &[1, 3, 6, 1, 4, 1, 57212, 1, 4];
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -129,5 +152,31 @@ mod tests {
         );
         assert_eq!(OID_NUCLEUS_PERMISSION_FINGERPRINT_TUPLE[8], 2);
         assert_eq!(OID_NUCLEUS_ATTESTATION_TUPLE[8], 1);
+    }
+
+    #[test]
+    fn test_mediation_key_binding_oid_consistency() {
+        // Shares the PEN arc, distinct component .1.4.
+        assert_eq!(
+            &OID_NUCLEUS_MEDIATION_KEY_BINDING_BYTES[..8],
+            &OID_NUCLEUS_ATTESTATION_BYTES[..8],
+            "mediation-key-binding OID must share the same PEN arc"
+        );
+        assert_eq!(OID_NUCLEUS_MEDIATION_KEY_BINDING_BYTES[8], 0x01); // .1
+        assert_eq!(OID_NUCLEUS_MEDIATION_KEY_BINDING_BYTES[9], 0x04); // .4
+        assert_eq!(OID_NUCLEUS_MEDIATION_KEY_BINDING_TUPLE.len(), 9);
+        assert_eq!(
+            &OID_NUCLEUS_MEDIATION_KEY_BINDING_TUPLE[..8],
+            &OID_NUCLEUS_ATTESTATION_TUPLE[..8]
+        );
+        assert_eq!(OID_NUCLEUS_MEDIATION_KEY_BINDING_TUPLE[8], 4);
+        // Distinct from every other allocated component in the arc.
+        for other in [
+            OID_NUCLEUS_ATTESTATION_BYTES,
+            OID_NUCLEUS_PERMISSION_FINGERPRINT_BYTES,
+            OID_NUCLEUS_TPM_RESIDENCY_BYTES,
+        ] {
+            assert_ne!(OID_NUCLEUS_MEDIATION_KEY_BINDING_BYTES, other);
+        }
     }
 }


### PR DESCRIPTION
## What

Brick E (merged) landed the *primitive*: `verify_attested_receipt` enforces a signing-key binding when the attestation carries `subject_key_sha256`. This lands the **wire format + verifier** that lets a real attested SVID *provide* that value — the OID you greenlit under PEN 57212.

## How

- **OID `1.3.6.1.4.1.57212.1.4`** (mediator-key binding) — next free component in the arc; carries `SHA-256(mediator Ed25519 pubkey)` as a version-tagged 32-byte octet string (identical shape to the permission fingerprint `.1.2`).
- `SelfSignedCa::create_mediation_key_binding_extension` — issuance helper.
- `attestation::extract_mediation_key_binding` — relying-party extractor.
- `SelfMeasuredBackend::verify_svid` now reads the extension from the served leaf and surfaces it as `VerifiedAttestation::subject_key_sha256`. Absent ⇒ `None` (*"cannot establish"*, never waived).

## Tests

Round-trip: an SVID carrying the extension surfaces the bound key through `verify_svid` (and straight from the leaf DER); a control SVID without it surfaces `None`; OID consistency + distinctness from the other `.1.x` components.

## Follow-on (the LIVE wiring — boot-affecting, next brick)

The node embedding the actual per-pod mediation pubkey at real SVID issuance (thread it through the fused-CSR path), plus a relying party fetching the SVID and calling `verify_attested_receipt` on the live path. `create_mediation_key_binding_extension` is `#[allow(dead_code)]` until that call-site lands — the format and verifier are deliberately ready ahead of it.

## Not boot-affecting

Touches only `nucleus-identity`; no boot-lane path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148ebbw4UXypRjhMw3xAQzj