### PR TITLE
feat(identity,node): embed the mediator-key binding in the attested SVID (live key≡SVID)

### DIFF
--- a/crates/nucleus-identity/src/ca/mod.rs
+++ b/crates/nucleus-identity/src/ca/mod.rs
@@ -143,6 +143,32 @@ pub trait CaClient: Send + Sync {
             .await
     }
 
+    /// Signs a CSR with launch attestation AND a mediator-key binding (OID .1.4).
+    ///
+    /// Binds the attested SVID to the Ed25519 key that signs this pod's forensic
+    /// `MediationReceipt`s: `mediator_pubkey_sha256` is `SHA-256(that public key)`,
+    /// embedded so a relying party can require the receipts to be signed by exactly
+    /// that key (`verify_attested_receipt`), not merely by a key handed in beside
+    /// the attestation.
+    ///
+    /// # Default Implementation
+    ///
+    /// Falls back to `sign_attested_csr()` (ignoring the binding), so a CA that
+    /// does not embed nucleus extensions degrades to a plain attested cert rather
+    /// than failing.
+    async fn sign_attested_and_bound_csr(
+        &self,
+        csr: &str,
+        private_key: &str,
+        identity: &Identity,
+        ttl: Duration,
+        attestation: &LaunchAttestation,
+        _mediator_pubkey_sha256: &[u8; 32],
+    ) -> Result<WorkloadCertificate> {
+        self.sign_attested_csr(csr, private_key, identity, ttl, attestation)
+            .await
+    }
+
     /// Signs a CSR and returns only the certificate chain (not the private key).
     ///
     /// This is used for OIDC token exchange flows where the client generates
@@ -229,6 +255,27 @@ impl CaClient for Arc<dyn CaClient> {
                 ttl,
                 attestation,
                 permission_fingerprint,
+            )
+            .await
+    }
+
+    async fn sign_attested_and_bound_csr(
+        &self,
+        csr: &str,
+        private_key: &str,
+        identity: &Identity,
+        ttl: Duration,
+        attestation: &LaunchAttestation,
+        mediator_pubkey_sha256: &[u8; 32],
+    ) -> Result<WorkloadCertificate> {
+        (**self)
+            .sign_attested_and_bound_csr(
+                csr,
+                private_key,
+                identity,
+                ttl,
+                attestation,
+                mediator_pubkey_sha256,
             )
             .await
     }

--- a/crates/nucleus-identity/src/ca/self_signed.rs
+++ b/crates/nucleus-identity/src/ca/self_signed.rs
@@ -385,7 +385,6 @@ impl SelfSignedCa {
     /// forensic `MediationReceipt`s, so a relying party can reject a receipt signed
     /// by any other key (see `verify_attested_receipt`). Same wire shape as the
     /// permission-fingerprint extension — a version-tagged 32-byte octet string.
-    #[allow(dead_code)]
     fn create_mediation_key_binding_extension(pubkey_sha256: &[u8; 32]) -> CustomExtension {
         let mut content = vec![
             0x02, // INTEGER tag
@@ -626,6 +625,54 @@ impl CaClient for SelfSignedCa {
             identity,
             ttl,
             vec![attestation_ext, fingerprint_ext],
+        )?;
+
+        let expiry = chain[0].not_after()?;
+        let private_key_obj = PrivateKey::from_pem(private_key)?;
+
+        Ok(WorkloadCertificate::new(
+            chain,
+            private_key_obj,
+            expiry,
+            identity.clone(),
+        ))
+    }
+
+    async fn sign_attested_and_bound_csr(
+        &self,
+        csr: &str,
+        private_key: &str,
+        identity: &Identity,
+        ttl: Duration,
+        attestation: &LaunchAttestation,
+        mediator_pubkey_sha256: &[u8; 32],
+    ) -> Result<WorkloadCertificate> {
+        let csr_spiffe_uri = self.validate_csr(csr)?;
+        let expected_uri = identity.to_spiffe_uri();
+        if csr_spiffe_uri != expected_uri {
+            return Err(Error::VerificationFailed(format!(
+                "CSR SPIFFE URI mismatch: expected {}, got {}",
+                expected_uri, csr_spiffe_uri
+            )));
+        }
+        if identity.trust_domain() != self.trust_domain {
+            return Err(Error::TrustDomainMismatch {
+                expected: self.trust_domain.clone(),
+                actual: identity.trust_domain().to_string(),
+            });
+        }
+
+        let key_pair = KeyPair::from_pem(private_key)
+            .map_err(|e| Error::CaSigning(format!("failed to load private key: {e}")))?;
+
+        let attestation_ext = Self::create_attestation_extension(attestation);
+        let binding_ext = Self::create_mediation_key_binding_extension(mediator_pubkey_sha256);
+
+        let chain = self.sign_with_keypair_and_extensions(
+            &key_pair,
+            identity,
+            ttl,
+            vec![attestation_ext, binding_ext],
         )?;
 
         let expiry = chain[0].not_after()?;
@@ -1145,6 +1192,47 @@ mod tests {
             Some(binding),
             "the verifier must surface the bound key as subject_key_sha256"
         );
+    }
+
+    /// **The production issuance path.** `sign_attested_and_bound_csr` (what the
+    /// node calls for a pod with a minted mediation key) yields an SVID that
+    /// carries BOTH the launch attestation and the mediator-key binding, and the
+    /// verifier surfaces the bound key.
+    #[tokio::test]
+    async fn sign_attested_and_bound_csr_embeds_a_verifiable_binding() {
+        use crate::assurance::{SelfMeasuredBackend, SvidAttestationBackend};
+        use crate::attestation::{extract_mediation_key_binding, AttestationRequirements};
+        use crate::ca::CaClient;
+
+        let ca = SelfSignedCa::new("nucleus.local").unwrap();
+        let identity = Identity::new("nucleus.local", "default", "mediator-agent");
+        let cert_sign = crate::CsrOptions::new(identity.to_spiffe_uri())
+            .generate()
+            .unwrap();
+        let attestation = LaunchAttestation::from_hashes([1u8; 32], [2u8; 32], [3u8; 32]);
+        let binding = [0x77u8; 32];
+
+        let cert = ca
+            .sign_attested_and_bound_csr(
+                cert_sign.csr(),
+                cert_sign.private_key(),
+                &identity,
+                Duration::from_secs(3600),
+                &attestation,
+                &binding,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            extract_mediation_key_binding(cert.leaf().der()),
+            Some(binding)
+        );
+        let va = SelfMeasuredBackend
+            .verify_svid(cert.leaf().to_pem(), &AttestationRequirements::any(), true)
+            .unwrap()
+            .expect("attested");
+        assert_eq!(va.subject_key_sha256, Some(binding));
     }
 
     /// The control: an attested SVID WITHOUT the binding extension surfaces

--- a/crates/nucleus-node/src/identity.rs
+++ b/crates/nucleus-node/src/identity.rs
@@ -43,6 +43,14 @@ pub struct IdentityManager {
     attestation_registry: Arc<RwLock<HashMap<String, LaunchAttestation>>>,
     /// Default certificate TTL.
     cert_ttl: Duration,
+    /// Base directory holding each pod's node-side state (`<dir>/<pod_id>/…`),
+    /// where the node records `mediator-pubkey.hex` when it mints the pod's
+    /// mediation key. When set, an attested SVID also carries a mediator-key
+    /// binding extension (OID .1.4) bound to that key, so a relying party can
+    /// require the pod's forensic receipts to be signed by exactly it. `None`
+    /// leaves SVIDs unbound (attestation only) — a graceful default, not a
+    /// failure.
+    mediation_binding_dir: Option<std::path::PathBuf>,
 }
 
 impl IdentityManager {
@@ -82,7 +90,32 @@ impl IdentityManager {
             trust_domain,
             attestation_registry: Arc::new(RwLock::new(HashMap::new())),
             cert_ttl,
+            mediation_binding_dir: None,
         }
+    }
+
+    /// Sets the base directory (`<dir>/<pod_id>/mediator-pubkey.hex`) from which an
+    /// attested SVID's mediator-key binding is read at issuance. Chainable so the
+    /// node can wire it at construction; absent, SVIDs are attestation-only.
+    #[must_use]
+    pub fn with_mediation_binding_dir(mut self, dir: std::path::PathBuf) -> Self {
+        self.mediation_binding_dir = Some(dir);
+        self
+    }
+
+    /// The mediator-key binding for a pod: `SHA-256` of the Ed25519 public key the
+    /// node minted for it, read from `mediator-pubkey.hex`. `None` when no binding
+    /// dir is configured or the file is absent/malformed — issuance then falls back
+    /// to an attestation-only SVID rather than failing.
+    fn mediation_binding_for(&self, pod_id: &str) -> Option<[u8; 32]> {
+        use sha2::{Digest, Sha256};
+        let dir = self.mediation_binding_dir.as_ref()?;
+        let hex = std::fs::read_to_string(dir.join(pod_id).join("mediator-pubkey.hex")).ok()?;
+        let pubkey = hex::decode(hex.trim()).ok()?;
+        if pubkey.len() != 32 {
+            return None;
+        }
+        Some(Sha256::digest(&pubkey).into())
     }
 
     /// Returns the trust domain.
@@ -313,18 +346,37 @@ impl IdentityManager {
                     .generate()
                     .map_err(|e| format!("CSR generation failed: {e}"))?;
 
-                // Sign with attestation using configured TTL
-                let cert = self
-                    .ca
-                    .sign_attested_csr(
-                        cert_sign.csr(),
-                        cert_sign.private_key(),
-                        identity,
-                        self.cert_ttl,
-                        &att,
-                    )
-                    .await
-                    .map_err(|e| format!("attested signing failed: {e}"))?;
+                // Sign with attestation using configured TTL. When the pod has a
+                // minted mediation key, ALSO bind it into the SVID (OID .1.4) so a
+                // relying party can require the pod's receipts to be signed by that
+                // exact key; otherwise a plain attested SVID.
+                let cert = match self.mediation_binding_for(pod_id) {
+                    Some(binding) => {
+                        info!("binding mediation key into attested SVID for pod {pod_id}");
+                        self.ca
+                            .sign_attested_and_bound_csr(
+                                cert_sign.csr(),
+                                cert_sign.private_key(),
+                                identity,
+                                self.cert_ttl,
+                                &att,
+                                &binding,
+                            )
+                            .await
+                    }
+                    None => {
+                        self.ca
+                            .sign_attested_csr(
+                                cert_sign.csr(),
+                                cert_sign.private_key(),
+                                identity,
+                                self.cert_ttl,
+                                &att,
+                            )
+                            .await
+                    }
+                }
+                .map_err(|e| format!("attested signing failed: {e}"))?;
 
                 // Warm the cache so the served FETCH_SVID fast-path returns THIS
                 // attested cert (carrying the measurement), not the plain one.
@@ -670,6 +722,88 @@ mod tests {
             .unwrap();
 
         assert_eq!(cert.identity(), &identity);
+    }
+
+    /// **Track-1 live-embed.** When the pod has a minted mediation key (recorded
+    /// as `mediator-pubkey.hex`), its attested SVID carries the mediator-key
+    /// binding (OID .1.4) = SHA-256 of that pubkey — the value a relying party
+    /// then requires the pod's forensic receipts to be signed under.
+    #[tokio::test]
+    async fn an_attested_svid_binds_the_pods_minted_mediation_key() {
+        use nucleus_identity::attestation::extract_mediation_key_binding;
+        use sha2::{Digest, Sha256};
+        use std::io::Write;
+        use tempfile::NamedTempFile;
+
+        let dir = tempfile::tempdir().unwrap();
+        let manager = IdentityManager::new("test.local", Duration::from_secs(3600))
+            .unwrap()
+            .with_mediation_binding_dir(dir.path().to_path_buf());
+
+        let pod_id = "bound-pod";
+        // The node's minted mediator key: record its pubkey where the mint would.
+        let sk = ed25519_dalek::SigningKey::from_bytes(&[5u8; 32]);
+        let pubkey = sk.verifying_key().to_bytes();
+        std::fs::create_dir_all(dir.path().join(pod_id)).unwrap();
+        std::fs::write(
+            dir.path().join(pod_id).join("mediator-pubkey.hex"),
+            format!("{}\n", hex::encode(pubkey)),
+        )
+        .unwrap();
+
+        let mut kernel = NamedTempFile::new().unwrap();
+        kernel.write_all(b"kernel").unwrap();
+        let mut rootfs = NamedTempFile::new().unwrap();
+        rootfs.write_all(b"rootfs").unwrap();
+        manager
+            .compute_attestation(pod_id, kernel.path(), rootfs.path(), b"config")
+            .await
+            .unwrap();
+
+        let identity = Identity::new("test.local", "default", "bound-service");
+        let cert = manager
+            .fetch_attested_certificate(&identity, pod_id)
+            .await
+            .unwrap();
+
+        let expect: [u8; 32] = Sha256::digest(pubkey).into();
+        assert_eq!(
+            extract_mediation_key_binding(cert.leaf().der()),
+            Some(expect),
+            "the attested SVID must bind the pod's minted mediation key"
+        );
+    }
+
+    /// The control: with a binding dir configured but no `mediator-pubkey.hex` for
+    /// the pod, the attested SVID carries NO binding (attestation only) — a missing
+    /// key degrades gracefully, it does not fail issuance or fabricate a binding.
+    #[tokio::test]
+    async fn an_attested_svid_without_a_minted_key_carries_no_binding() {
+        use nucleus_identity::attestation::extract_mediation_key_binding;
+        use std::io::Write;
+        use tempfile::NamedTempFile;
+
+        let dir = tempfile::tempdir().unwrap();
+        let manager = IdentityManager::new("test.local", Duration::from_secs(3600))
+            .unwrap()
+            .with_mediation_binding_dir(dir.path().to_path_buf());
+
+        let pod_id = "unbound-pod";
+        let mut kernel = NamedTempFile::new().unwrap();
+        kernel.write_all(b"kernel").unwrap();
+        let mut rootfs = NamedTempFile::new().unwrap();
+        rootfs.write_all(b"rootfs").unwrap();
+        manager
+            .compute_attestation(pod_id, kernel.path(), rootfs.path(), b"config")
+            .await
+            .unwrap();
+
+        let identity = Identity::new("test.local", "default", "unbound-service");
+        let cert = manager
+            .fetch_attested_certificate(&identity, pod_id)
+            .await
+            .unwrap();
+        assert_eq!(extract_mediation_key_binding(cert.leaf().der()), None);
     }
 }
 

--- a/crates/nucleus-node/src/main.rs
+++ b/crates/nucleus-node/src/main.rs
@@ -611,8 +611,7 @@ async fn main() -> Result<(), ApiError> {
     }
     if args.proxy_approval_secret.trim().is_empty() {
         return Err(ApiError::Driver(
-            "proxy approval secret is required (set NUCLEUS_NODE_PROXY_APPROVAL_SECRET)"
-                .to_string(),
+            "proxy approval secret required (set NUCLEUS_NODE_PROXY_APPROVAL_SECRET)".to_string(),
         ));
     }
 
@@ -620,7 +619,8 @@ async fn main() -> Result<(), ApiError> {
     let identity_manager = if let Some(ref socket_path) = args.identity_workload_api_socket {
         let cert_ttl = Duration::from_secs(args.identity_cert_ttl_secs);
         let manager = identity::IdentityManager::new(&args.identity_trust_domain, cert_ttl)
-            .map_err(|e| ApiError::Driver(format!("failed to create identity manager: {e}")))?;
+            .map_err(|e| ApiError::Driver(format!("failed to create identity manager: {e}")))?
+            .with_mediation_binding_dir(args.state_dir.join("pods"));
 
         // Retired: it served an arbitrary pod's SVID to any local connector.
         // Rationale and the gate live in `identity.rs::retired_surface_tests`.


### PR DESCRIPTION
## What

Makes Brick E/E2's key-binding **live**: a pod's attested SVID now actually carries the binding to the key that signs its forensic receipts, so `verify_attested_receipt` can enforce *"signed by THIS attested key"* end to end. This is the live-wiring you selected (approach b: node certifies the mediation key via the SVID extension).

## How

- **`CaClient::sign_attested_and_bound_csr`** (defaulted → falls back to `sign_attested_csr`, so non-nucleus CAs degrade to plain attested SVIDs). `SelfSignedCa` overrides it to embed attestation (`.1.1`) **and** the mediator-key binding (`.1.4`) together. `create_mediation_key_binding_extension` is no longer dead.
- **`IdentityManager::with_mediation_binding_dir(<state>/pods)`**: `fetch_attested_certificate` reads the pod's minted `mediator-pubkey.hex` (the node writes it at mint, since D2), `SHA-256`s it, and issues a **bound** SVID. Absent ⇒ plain attested SVID (graceful — a missing key never fails issuance nor fabricates a binding).

## Tests

- **CA path** (`sign_attested_and_bound_csr`) issues a cert whose binding extracts and verifies through `verify_svid` — runs on macOS, green.
- **Node path** (`fetch_attested_certificate`) binds the pod's minted key; a pod without a minted key gets no binding (control) — runs on Linux CI (the `from_spec` Firecracker gate blocks node-bin tests on mac).

## Relying-party result

A party that fetches the pod's SVID derives `subject_key_sha256` from it, and `verify_attested_receipt` binds the receipt to that exact key. Still **L1 self-measured** — the SVID's attestation is only as strong as the node's key (no hardware root yet); that honesty is unchanged.

## Boot-affecting

Touches `nucleus-node` (SVID issuance now adds a non-critical `.1.4` extension for pods with a minted key). **Hand-gated on boot** — the guest still fetches its SVID and mTLS is unaffected by the additive extension, but the boot lane confirms it on a real pod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148ebbw4UXypRjhMw3xAQzj