### PR TITLE
feat(node): host-side receipt collection channel over vsock (SHIP_RECEIPT)

### DIFF
--- a/crates/nucleus-node/src/main.rs
+++ b/crates/nucleus-node/src/main.rs
@@ -36,10 +36,10 @@ mod grpc_tls;
 mod identity;
 mod lockdown;
 mod mediation;
+mod mediation_receipt_collector;
 mod oidc;
 mod pod_api;
 mod pod_caller_identity;
-
 mod workload_api_protocol;
 mod workload_api_vsock;
 use auth::{AuthConfig, AuthError};
@@ -2770,9 +2770,7 @@ async fn spawn_firecracker_pod(
                     // Served WITH the capability, not separately — the proxy
                     // needs both to reach the broker and neither is useful alone.
                     broker_port: state.broker_vsock_port,
-                    broker_secret_served: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(
-                        false,
-                    )),
+                    broker_secret_served: std::sync::Arc::default(),
                     // The S3 audit-sink credentials, served once over this
                     // socket instead of riding the world-readable kernel
                     // command line (the C1 exposure).
@@ -2785,6 +2783,8 @@ async fn spawn_firecracker_pod(
                     mediation_signing_key: mediation::new_seed_hex(pod_dir),
                     mediation_spiffe_id: Some(mediation::spiffe_id(manager.trust_domain(), id)),
                     mediation_key_served: std::sync::Arc::default(),
+                    // Where the host durably collects SHIP_RECEIPT receipts.
+                    receipt_dir: Some(pod_dir.to_path_buf()),
                     pod_registry: state.pods.clone(),
                 },
                 // Only when jailed: unjailed Firecracker runs as this same user

--- a/crates/nucleus-node/src/mediation_receipt_collector.rs
+++ b/crates/nucleus-node/src/mediation_receipt_collector.rs
@@ -1,0 +1,124 @@
+//! Host-side collection of signed `MediationReceipt`s streamed from pods over vsock.
+//!
+//! # Why the host holds a copy
+//!
+//! A Firecracker guest cannot reach the node over HTTP, and its `/run` receipt
+//! file dies with the microVM — so `nucleus-tool-proxy` streams each receipt to
+//! the node over the workload-API vsock as it is produced (the `SHIP_RECEIPT`
+//! command). This is the collector half: the copy the pod cannot retract, so a
+//! host attestation over the receipt set binds what it OBSERVED rather than what
+//! the pod later chose to report. It is the completeness-bounding the console
+//! mirror (the boot lane's channel today) cannot give — the guest shipper is
+//! fail-closed, so a pod whose receipts stop reaching the host stops deciding.
+//!
+//! # What authenticates a shipped receipt
+//!
+//! Two independent things, so this layer stays small:
+//!
+//! * **the connection** — the workload-API vsock connection is already bound to
+//!   ONE pod (the node serves this pod's SVID and secrets over it), so a receipt
+//!   arriving here can only be filed under THAT pod. The collector keys the file
+//!   by the node's own `pod_id`, never anything the guest sends, so there is no
+//!   cross-pod injection to guard against (and no session id to sanitize).
+//! * **the receipt** — its content is an Ed25519 signature over its own fields,
+//!   verified later by `nucleus-audit verify-mediation-receipts` over the
+//!   assembled file. The node does not re-verify here: one implementation of that
+//!   logic, not two that must agree.
+//!
+//! A note on trust granularity: the connection authenticates the *pod*, not the
+//! tool-proxy vs. the workload inside it. A workload that reached this channel
+//! could append receipts it did not sign — but it cannot forge the mediator
+//! Ed25519 signature (the key lives in the tool-proxy, not the workload), so any
+//! such line surfaces as a verification FAILURE in the scoreboard rather than a
+//! trusted receipt. Distinguishing the two senders with a tool-proxy-held secret
+//! is a later hardening, noted rather than pretended.
+
+use std::path::{Path, PathBuf};
+
+use tokio::io::AsyncWriteExt;
+
+/// The collected-receipts log inside a pod's node-side directory.
+///
+/// `pod_dir` is `<state>/pods/<pod_id>` — already per-pod and host-private (the
+/// guest has no path to the node's state dir), and where the node keeps this
+/// pod's other host-side records (`mediator-pubkey.hex`, `firecracker.log`). No
+/// pod-id subkeying and nothing guest-supplied enters the path.
+#[must_use]
+pub fn receipt_log_path(pod_dir: &Path) -> PathBuf {
+    pod_dir.join("collected-receipts.jsonl")
+}
+
+/// Append one shipped receipt line to the pod's collected log.
+///
+/// Flushed AND synced before the caller acks the pod: an accepted receipt that is
+/// only in the page cache is lost by a host crash, and the pod would have been
+/// told it was witnessed.
+///
+/// # Errors
+/// If the directory cannot be created or the append fails — the caller must NOT
+/// ack the pod on error.
+pub async fn append_receipt(pod_dir: &Path, line: &str) -> Result<(), std::io::Error> {
+    let path = receipt_log_path(pod_dir);
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+    let mut f = tokio::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .await?;
+    f.write_all(line.trim_end().as_bytes()).await?;
+    f.write_all(b"\n").await?;
+    f.flush().await?;
+    f.sync_data().await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn shipped_receipts_accumulate_one_per_line_in_order() {
+        let pod_dir = tempfile::tempdir().unwrap();
+        let r1 = r#"{"schema_version":1,"verdict":"allow"}"#;
+        let r2 = r#"{"schema_version":1,"verdict":"deny"}"#;
+        append_receipt(pod_dir.path(), r1).await.unwrap();
+        append_receipt(pod_dir.path(), r2).await.unwrap();
+
+        let stored = std::fs::read_to_string(receipt_log_path(pod_dir.path())).unwrap();
+        let lines: Vec<&str> = stored.lines().collect();
+        assert_eq!(
+            lines,
+            vec![r1, r2],
+            "each receipt is its own JSON line, in order"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_trailing_newline_in_the_shipped_line_is_normalized() {
+        let pod_dir = tempfile::tempdir().unwrap();
+        append_receipt(pod_dir.path(), "{\"verdict\":\"allow\"}\n")
+            .await
+            .unwrap();
+        let stored = std::fs::read_to_string(receipt_log_path(pod_dir.path())).unwrap();
+        assert_eq!(
+            stored, "{\"verdict\":\"allow\"}\n",
+            "exactly one terminating newline"
+        );
+    }
+
+    #[tokio::test]
+    async fn different_pods_collect_into_their_own_dirs() {
+        let a = tempfile::tempdir().unwrap();
+        let b = tempfile::tempdir().unwrap();
+        append_receipt(a.path(), "{\"a\":1}").await.unwrap();
+        append_receipt(b.path(), "{\"b\":1}").await.unwrap();
+        assert!(receipt_log_path(a.path()).exists());
+        assert!(receipt_log_path(b.path()).exists());
+        assert_ne!(
+            std::fs::read_to_string(receipt_log_path(a.path())).unwrap(),
+            std::fs::read_to_string(receipt_log_path(b.path())).unwrap()
+        );
+    }
+}

--- a/crates/nucleus-node/src/workload_api_protocol.rs
+++ b/crates/nucleus-node/src/workload_api_protocol.rs
@@ -178,21 +178,16 @@ pub enum WorkloadApiCommand {
     /// durable, completeness-bounded collection (see [`crate::mediation_receipt_collector`]).
     ///
     /// Unlike every other command here, this one is followed by a SECOND frame:
-    /// the receipt JSON body. It is read separately, under its own larger length
-    /// bound ([`MAX_RECEIPT_BODY_LEN`]), so the 256-byte command guard that
-    /// protects `parse_command` from unbounded buffering is untouched — a receipt
-    /// (~0.5 KB) would not fit a command frame, and widening that bound for every
-    /// command would weaken the OOM guard the fuzz target asserts.
+    /// the receipt JSON body. That body is read by the vsock handler under its own
+    /// larger length bound (`MAX_RECEIPT_BODY_LEN` there), so the 256-byte command
+    /// guard that protects `parse_command` from unbounded buffering is untouched —
+    /// a receipt (~0.5 KB) would not fit a command frame, and widening that bound
+    /// for every command would weaken the OOM guard the fuzz target asserts.
     ///
     /// The Firecracker guest has no HTTP path to the node, so this vsock channel
     /// is how a real pod's receipts reach the host as they are produced.
     ShipReceipt,
 }
-
-/// The largest receipt body the host will buffer from a `SHIP_RECEIPT` frame.
-/// Bounds a single receipt (a fixed-shape JSON object, well under 1 KB) with
-/// headroom, without widening the 256-byte command guard.
-pub const MAX_RECEIPT_BODY_LEN: usize = 8192;
 
 impl WorkloadApiCommand {
     /// The canonical, on-the-wire spelling of this command (no trailing newline).

--- a/crates/nucleus-node/src/workload_api_protocol.rs
+++ b/crates/nucleus-node/src/workload_api_protocol.rs
@@ -173,7 +173,26 @@ pub enum WorkloadApiCommand {
     /// call on the real Firecracker path (C2 cross-pod), which the HTTP route
     /// cannot reach from inside a default-deny netns.
     PodList,
+
+    /// `SHIP_RECEIPT` — stream one signed `MediationReceipt` to the host for
+    /// durable, completeness-bounded collection (see [`crate::mediation_receipt_collector`]).
+    ///
+    /// Unlike every other command here, this one is followed by a SECOND frame:
+    /// the receipt JSON body. It is read separately, under its own larger length
+    /// bound ([`MAX_RECEIPT_BODY_LEN`]), so the 256-byte command guard that
+    /// protects `parse_command` from unbounded buffering is untouched — a receipt
+    /// (~0.5 KB) would not fit a command frame, and widening that bound for every
+    /// command would weaken the OOM guard the fuzz target asserts.
+    ///
+    /// The Firecracker guest has no HTTP path to the node, so this vsock channel
+    /// is how a real pod's receipts reach the host as they are produced.
+    ShipReceipt,
 }
+
+/// The largest receipt body the host will buffer from a `SHIP_RECEIPT` frame.
+/// Bounds a single receipt (a fixed-shape JSON object, well under 1 KB) with
+/// headroom, without widening the 256-byte command guard.
+pub const MAX_RECEIPT_BODY_LEN: usize = 8192;
 
 impl WorkloadApiCommand {
     /// The canonical, on-the-wire spelling of this command (no trailing newline).
@@ -195,6 +214,7 @@ impl WorkloadApiCommand {
             WorkloadApiCommand::FetchAuditCredentials => "FETCH_AUDIT_CREDENTIALS",
             WorkloadApiCommand::FetchMediationKey => "FETCH_MEDIATION_KEY",
             WorkloadApiCommand::PodList => "POD_LIST",
+            WorkloadApiCommand::ShipReceipt => "SHIP_RECEIPT",
         }
     }
 }
@@ -264,6 +284,7 @@ pub fn parse_command(frame: &[u8]) -> Result<WorkloadApiCommand, CommandParseErr
         "FETCH_AUDIT_CREDENTIALS" => Ok(WorkloadApiCommand::FetchAuditCredentials),
         "FETCH_MEDIATION_KEY" => Ok(WorkloadApiCommand::FetchMediationKey),
         "POD_LIST" => Ok(WorkloadApiCommand::PodList),
+        "SHIP_RECEIPT" => Ok(WorkloadApiCommand::ShipReceipt),
         other => Err(CommandParseError::Unknown(other.to_string())),
     }
 }
@@ -443,6 +464,7 @@ mod tests {
                 WorkloadApiCommand::FetchAuditCredentials => "FETCH_AUDIT_CREDENTIALS",
                 WorkloadApiCommand::FetchMediationKey => "FETCH_MEDIATION_KEY",
                 WorkloadApiCommand::PodList => "POD_LIST",
+                WorkloadApiCommand::ShipReceipt => "SHIP_RECEIPT",
             }
         }
         for cmd in [
@@ -475,6 +497,7 @@ mod tests {
             WorkloadApiCommand::FetchAuditCredentials,
             WorkloadApiCommand::FetchMediationKey,
             WorkloadApiCommand::PodList,
+            WorkloadApiCommand::ShipReceipt,
         ];
         let accepted: std::collections::BTreeSet<String> =
             surface.iter().map(|c| c.as_wire().to_string()).collect();
@@ -489,6 +512,7 @@ mod tests {
             "FETCH_AUDIT_CREDENTIALS",
             "FETCH_MEDIATION_KEY",
             "POD_LIST",
+            "SHIP_RECEIPT",
         ]
         .iter()
         .map(|s| s.to_string())
@@ -498,7 +522,7 @@ mod tests {
             "the guest-to-host request surface changed — a command a guest can \
              make the host act on was added, removed or renamed"
         );
-        // No two commands collapsed onto one wire spelling (9 variants → 9 forms).
+        // No two commands collapsed onto one wire spelling (N variants → N forms).
         assert_eq!(
             accepted.len(),
             surface.len(),

--- a/crates/nucleus-node/src/workload_api_vsock.rs
+++ b/crates/nucleus-node/src/workload_api_vsock.rs
@@ -30,9 +30,15 @@ use tokio::task::JoinHandle;
 use tracing::{debug, error, info};
 
 use crate::identity::IdentityManager;
-use crate::workload_api_protocol::{
-    parse_command, WorkloadApiCommand, MAX_COMMAND_LEN, MAX_RECEIPT_BODY_LEN,
-};
+use crate::workload_api_protocol::{parse_command, WorkloadApiCommand, MAX_COMMAND_LEN};
+
+/// The largest receipt body the host buffers from a `SHIP_RECEIPT`'s second frame.
+/// Bounds a single receipt (a fixed-shape JSON object, well under 1 KB) with
+/// headroom, without widening the 256-byte command guard `parse_command` enforces.
+/// Lives here, beside `read_bounded_frame` that applies it, rather than in the
+/// protocol module — which the fuzz target compiles in isolation, where a const
+/// only the handler uses would read as dead.
+const MAX_RECEIPT_BODY_LEN: usize = 8192;
 
 /// Default port for the Workload API vsock server.
 #[allow(dead_code)]

--- a/crates/nucleus-node/src/workload_api_vsock.rs
+++ b/crates/nucleus-node/src/workload_api_vsock.rs
@@ -30,7 +30,9 @@ use tokio::task::JoinHandle;
 use tracing::{debug, error, info};
 
 use crate::identity::IdentityManager;
-use crate::workload_api_protocol::{parse_command, WorkloadApiCommand, MAX_COMMAND_LEN};
+use crate::workload_api_protocol::{
+    parse_command, WorkloadApiCommand, MAX_COMMAND_LEN, MAX_RECEIPT_BODY_LEN,
+};
 
 /// Default port for the Workload API vsock server.
 #[allow(dead_code)]
@@ -178,6 +180,9 @@ pub struct PodMaterial {
     /// Whether the mediation key has been served — one flag across connections,
     /// for the same reason as `broker_secret_served`.
     pub mediation_key_served: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    /// The pod's node-side directory, where shipped `MediationReceipt`s are
+    /// durably collected (`SHIP_RECEIPT`). `None` disables collection.
+    pub receipt_dir: Option<std::path::PathBuf>,
     /// A read-only clone of the node's live pod registry, so a `POD_LIST` over
     /// this pod's socket can be answered without the vsock server holding any
     /// node secret. `PodListView` freezes the caller to the socket's pod id and
@@ -407,6 +412,40 @@ fn handle_fetch_mediation_key(
     serde_json::json!({ "signing_key": signing_key, "spiffe_id": spiffe_id }).to_string()
 }
 
+/// Handle `SHIP_RECEIPT`: read the receipt body frame (its own larger bound) and
+/// durably collect it under this pod's node-side dir.
+///
+/// The connection is already bound to ONE pod, so the receipt can only be filed
+/// under that pod — no session id is read from the guest. A failure returns an
+/// error the guest shipper treats as "not witnessed" (and latches degraded), so a
+/// pod whose receipts stop reaching the host stops deciding.
+async fn handle_ship_receipt<R>(reader: &mut R, receipt_dir: Option<&std::path::Path>) -> String
+where
+    R: AsyncReadExt + Unpin,
+{
+    let Some(dir) = receipt_dir else {
+        return r#"{"error":"receipt collection not configured for this pod"}"#.to_string();
+    };
+    let body = match read_bounded_frame(reader, MAX_RECEIPT_BODY_LEN).await {
+        Ok(Some(frame)) => frame,
+        Ok(None) => return r#"{"error":"no receipt body after SHIP_RECEIPT"}"#.to_string(),
+        Err(e) => {
+            tracing::warn!(error = %e, "SHIP_RECEIPT body frame rejected");
+            return r#"{"error":"receipt body too long or unreadable"}"#.to_string();
+        }
+    };
+    // The body is opaque here: its Ed25519 signature is verified later by
+    // `nucleus-audit verify-mediation-receipts`, not re-implemented on the hot path.
+    let line = String::from_utf8_lossy(&body);
+    match crate::mediation_receipt_collector::append_receipt(dir, line.trim_end()).await {
+        Ok(()) => r#"{"status":"collected"}"#.to_string(),
+        Err(e) => {
+            tracing::error!(error = %e, "could not collect a shipped MediationReceipt");
+            r#"{"error":"receipt storage failed"}"#.to_string()
+        }
+    }
+}
+
 fn handle_fetch_dlc_admission(material: Option<&DlcAdmissionMaterial>) -> String {
     match material {
         Some(m) => serde_json::json!({
@@ -557,6 +596,11 @@ async fn handle_connection(
                 serde_json::to_string(&infos)
                     .unwrap_or_else(|_| r#"{"error":"failed to encode pod list"}"#.to_string())
             }
+            Ok(WorkloadApiCommand::ShipReceipt) => {
+                // Followed by a second frame (the receipt body), read under its own
+                // larger bound. The connection already binds this to `pod_id`.
+                handle_ship_receipt(&mut reader, material.receipt_dir.as_deref()).await
+            }
             Err(err) => {
                 debug!("workload API rejected command for pod {}: {err}", pod_id);
                 // Build the error response via serde so the (attacker-controlled)
@@ -592,6 +636,17 @@ async fn read_command_frame<R>(reader: &mut R) -> std::io::Result<Option<Vec<u8>
 where
     R: AsyncReadExt + Unpin,
 {
+    read_bounded_frame(reader, MAX_COMMAND_LEN).await
+}
+
+/// The OOM-safe newline-frame reader, bounded to `max` buffered bytes. Backs both
+/// [`read_command_frame`] (the 256-byte command guard) and the `SHIP_RECEIPT`
+/// body read (a larger [`MAX_RECEIPT_BODY_LEN`] cap for one receipt) — the same
+/// never-grow-past-the-cap discipline at two different, explicit bounds.
+async fn read_bounded_frame<R>(reader: &mut R, max: usize) -> std::io::Result<Option<Vec<u8>>>
+where
+    R: AsyncReadExt + Unpin,
+{
     let mut frame: Vec<u8> = Vec::with_capacity(16);
     loop {
         let mut byte = [0u8; 1];
@@ -605,10 +660,10 @@ where
         if byte[0] == b'\n' {
             return Ok(Some(frame));
         }
-        if frame.len() > MAX_COMMAND_LEN {
+        if frame.len() > max {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
-                "workload API command exceeds maximum length",
+                "workload API frame exceeds maximum length",
             ));
         }
     }


### PR DESCRIPTION
## What

**Track 2 part 1** — the *receiving* half of live, completeness-bounded receipt collection for Firecracker pods (whose `/run` receipt file the host cannot read and who have no HTTP path to the node). The guest tool-proxy shipper that sends to this channel is the next brick — consistent with how this arc landed the verify *reader* (#2290) before the D1 *writer* (#2291).

## How

- **`mediation_receipt_collector`** — append each shipped receipt to `<pod_dir>/collected-receipts.jsonl`, **flushed + synced before the pod is acked** so a host crash can't drop a receipt the pod believes is witnessed. Keyed by the node's own `pod_id` (the connection identity), never guest input: the vsock connection is already bound to one pod, so there's no cross-pod injection and no session id to sanitize. Receipt *content* stays self-authenticating (ed25519) — verifying it is `verify-mediation-receipts`' job over the assembled file.
- **Protocol** — `SHIP_RECEIPT` is the first **two-frame** command: the command (fits the 256-byte guard) is followed by the receipt body, read under its own larger `MAX_RECEIPT_BODY_LEN` via a shared `read_bounded_frame`, so the OOM guard the fuzz target asserts on `parse_command` is **untouched**. Surface-pin test extended.
- **Dispatch** — `handle_ship_receipt` reads the body frame and collects it; `PodMaterial.receipt_dir` (the pod's node-side dir), `None` disables collection.

## Trust granularity (noted, not pretended)

The connection authenticates the *pod*, not the tool-proxy vs. the workload within it. A workload can't forge the mediator ed25519 signature, so any junk it ships surfaces as a **scoreboard FAILURE**, not a trusted receipt. A tool-proxy-held secret to distinguish the two senders is later hardening.

## Boot-affecting

Touches `nucleus-node`, but the change is **additive** — `SHIP_RECEIPT` exists and is handled, nothing sends it yet — so the boot lane confirms no regression rather than exercising the path. Node-side tests (collector round-trip, surface pin) run on Linux CI (the `from_spec` gate blocks node-bin tests on mac). **Hand-gated on boot.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148ebbw4UXypRjhMw3xAQzj