### PR TITLE
proof(ifc): name the read-path confidentiality noninterference (#1249, brick 1)

### DIFF
--- a/crates/portcullis-core/lean/ConfidentialityNoninterferenceExtracted.lean
+++ b/crates/portcullis-core/lean/ConfidentialityNoninterferenceExtracted.lean
@@ -172,6 +172,25 @@ theorem secret_tainted_never_flows_public (ops : List CL) :
   · decide
   · decide
 
+/-- **Read-path instantiation (issue #1249): a file-read session can NEVER reach a
+    public sink**, over the GENERATED defs. `NucleusRuntime::read_file` returns
+    `Labeled<Vec<u8>, Trusted, Internal>` — file contents carry `Internal`
+    confidentiality (rank 1). This theorem names the guarantee the runtime facade's
+    type already claims: `Internal` file data is never admitted at a `Public`
+    ceiling (rank 0 — the true-egress sinks like HTTPEgress impose), over ANY
+    operation sequence. It is the anti-exfiltration half of the labeled read: what
+    a file read produced cannot leave through a public channel.
+    Non-vacuous: `h_joined = 1 ≤ 1`, `h_blocked = 0 < 1`. -/
+theorem file_read_internal_never_flows_public (ops : List CL) :
+    ¬ cadmitted (crun ops .Internal) .Public := by
+  apply confidentiality_sink_never_admitted
+    (L_src := .Internal)
+    (eff := .Internal)
+    (ceiling := .Public)
+    (ops := ops)
+  · decide
+  · decide
+
 end ConfidentialityNoninterferenceExtracted
 
 /-
@@ -184,3 +203,4 @@ end ConfidentialityNoninterferenceExtracted
 -/
 #print axioms ConfidentialityNoninterferenceExtracted.confidentiality_sink_never_admitted
 #print axioms ConfidentialityNoninterferenceExtracted.secret_tainted_never_flows_public
+#print axioms ConfidentialityNoninterferenceExtracted.file_read_internal_never_flows_public


### PR DESCRIPTION
## What

First brick of taking **#1249 (type-level IFC in the runtime API) to proof level.** The runtime facade already returns labeled data — `NucleusRuntime::read_file` gives `Labeled<Vec<u8>, Trusted, Internal>` — so the *wiring* the stale issue asks for exists. What was missing is a **Lean theorem that names the read-path guarantee** that type claims.

Adds `file_read_internal_never_flows_public` to `ConfidentialityNoninterferenceExtracted.lean`: over the Aeneas-**extracted** Rust defs, an `Internal`-confidentiality source (rank 1 — what a file read carries) is **never** admitted at a `Public` ceiling (rank 0) over **any** operation sequence. It's the anti-exfiltration half of the labeled read: what a file read produced cannot leave through a public channel.

The generic `confidentiality_sink_never_admitted` was previously instantiated only at `Secret→Public`; this adds the file-read `Internal→Public` case (a trivial instantiation, `h_joined 1≤1`, `h_blocked 0<1`).

## Verified

`lake build ConfidentialityNoninterferenceExtracted` clean; `#print axioms` = `[propext, Classical.choice, Quot.sound]` — no `sorry`, no Aeneas `External` opaque axiom — so it passes the proven-tier clean-axiom gate. (The Aeneas-std `sorry` warnings are upstream stdlib in unused slice ops, not this proof.)

## Context

The fetch-path integrity dual already exists (`web_tainted_never_git_pushes`: `Adversarial ⇏ Trusted`), so the read/fetch pair is now both named and machine-proven.

**Remaining #1249 bricks:** (2) bind the `Labeled<T,I,C>` newtype to this extracted `ConfLevel` lattice; (3) gate the Rust facade's label assignment (`flow.rs::intrinsic_label`: FileRead→Internal/Trusted) against these proofs, and de-vacuify `read_file_returns_labeled_with_correct_tags` (it currently skips its assertions on `Err`). Then close #1249.

Not boot-affecting (Lean only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148ebbw4UXypRjhMw3xAQzj