### PR TITLE
test(ifc): de-vacuify the labeled-read tag test + tie it to the proof (#1249, brick 3a)

### DIFF
--- a/crates/portcullis-effects/src/runtime.rs
+++ b/crates/portcullis-effects/src/runtime.rs
@@ -2451,16 +2451,22 @@ mod tests {
             let p = rt.preflight_read().unwrap();
             rt.read_file(std::path::Path::new("Cargo.toml"), p)
         };
-        if let Ok(output) = result {
-            assert_eq!(
-                output.data().integrity_level(),
-                portcullis_core::IntegLevel::Trusted
-            );
-            assert_eq!(
-                output.data().conf_level(),
-                portcullis_core::ConfLevel::Internal
-            );
-        }
+        // NOT `if let Ok(output) = result` — that skips every assertion when the
+        // read errors, so the test would pass while proving nothing about the
+        // labels. The read MUST succeed here (Codegen policy + a discharged
+        // preflight proof, reading a file that exists) for the tags to be checkable.
+        let output = result.expect("read_file must succeed so its IFC tags can be asserted");
+        assert_eq!(
+            output.data().integrity_level(),
+            portcullis_core::IntegLevel::Trusted,
+            "a file read carries Trusted integrity"
+        );
+        assert_eq!(
+            output.data().conf_level(),
+            portcullis_core::ConfLevel::Internal,
+            "a file read carries Internal confidentiality (the label the Lean \
+             theorem file_read_internal_never_flows_public proves cannot reach Public)"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

`read_file_returns_labeled_with_correct_tags` wrapped its assertions in `if let Ok(output) = result { … }` — so a read that errored **skipped every assertion** and the test passed while proving nothing. It now `.expect()`s the read (Codegen policy + a discharged preflight, reading a file that exists — verified to succeed locally) so the tag checks always run.

The confidentiality assertion now **names the Lean theorem** `file_read_internal_never_flows_public` (#2297) that proves that exact `Internal` label can never reach a `Public` sink — binding the type the runtime returns, the tag the test asserts, and the theorem that proves it safe into one `Internal`/`Trusted` pair.

Part of taking **#1249** to proof level (brick 3a; brick 1 = the Lean theorem in #2297). Not boot-affecting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148ebbw4UXypRjhMw3xAQzj