### PR TITLE
proof(ifc): exhaustively bind the Labeled newtype to the lattice (#1249, brick 2)

### DIFF
--- a/crates/portcullis-core/src/labeled.rs
+++ b/crates/portcullis-core/src/labeled.rs
@@ -465,6 +465,53 @@ mod tests {
         assert_eq!(data.conf_level(), crate::ConfLevel::Secret);
     }
 
+    /// **Newtype↔lattice binding (issue #1249, brick 2).** Every phantom tag maps,
+    /// via `runtime_level()`, to the correspondingly-named production lattice level
+    /// — EXHAUSTIVELY. `runtime_levels_match` above checks only `(Trusted, Secret)`,
+    /// leaving `Internal` and `Adversarial` — the exact read/fetch labels the
+    /// noninterference theorems are about — unbound. This is the last hand-off in
+    /// the chain that makes a facade value's compile-time tag the SAME lattice
+    /// point the Lean proof covers:
+    ///
+    /// ```text
+    ///   Labeled<_, I, C>  --runtime_level()-->  production ConfLevel / IntegLevel
+    ///       [THIS test, exhaustive over all 6 tags]
+    ///   production ConfLevel::Internal == extracted ConfLevel::Internal (disc 1)
+    ///       [ifc_confidentiality::tests::discriminants_match_real_conflevel]
+    ///   extracted Internal ⇏ Public over any op sequence
+    ///       [Lean file_read_internal_never_flows_public]
+    /// ```
+    ///
+    /// So `read_file()`'s `Labeled<_, Trusted, Internal>` is provably the `Internal`
+    /// lattice point that can never reach a `Public` sink, and `fetch_url()`'s
+    /// `Labeled<_, Adversarial, Public>` is the `Adversarial` point that can never
+    /// reach a `Trusted` sink (`web_tainted_never_git_pushes`). If a tag's
+    /// `runtime_level()` ever drifted from its name, this test — not a silent
+    /// mislabel — is what fails.
+    #[test]
+    fn every_tag_binds_to_its_named_lattice_level() {
+        // Confidentiality tags → ConfLevel (all three points of the chain).
+        assert_eq!(<Public as ConfTag>::runtime_level(), crate::ConfLevel::Public);
+        assert_eq!(
+            <Internal as ConfTag>::runtime_level(),
+            crate::ConfLevel::Internal
+        );
+        assert_eq!(<Secret as ConfTag>::runtime_level(), crate::ConfLevel::Secret);
+        // Integrity tags → IntegLevel (all three points).
+        assert_eq!(
+            <Adversarial as IntegTag>::runtime_level(),
+            crate::IntegLevel::Adversarial
+        );
+        assert_eq!(
+            <Untrusted as IntegTag>::runtime_level(),
+            crate::IntegLevel::Untrusted
+        );
+        assert_eq!(
+            <Trusted as IntegTag>::runtime_level(),
+            crate::IntegLevel::Trusted
+        );
+    }
+
     // ── Flow constraint trait bounds ────────────────────────────────────
 
     fn requires_trusted_or_higher<I: IntegAtLeast<Trusted>, C: ConfTag>(

--- a/crates/portcullis-core/src/labeled.rs
+++ b/crates/portcullis-core/src/labeled.rs
@@ -491,12 +491,18 @@ mod tests {
     #[test]
     fn every_tag_binds_to_its_named_lattice_level() {
         // Confidentiality tags → ConfLevel (all three points of the chain).
-        assert_eq!(<Public as ConfTag>::runtime_level(), crate::ConfLevel::Public);
+        assert_eq!(
+            <Public as ConfTag>::runtime_level(),
+            crate::ConfLevel::Public
+        );
         assert_eq!(
             <Internal as ConfTag>::runtime_level(),
             crate::ConfLevel::Internal
         );
-        assert_eq!(<Secret as ConfTag>::runtime_level(), crate::ConfLevel::Secret);
+        assert_eq!(
+            <Secret as ConfTag>::runtime_level(),
+            crate::ConfLevel::Secret
+        );
         // Integrity tags → IntegLevel (all three points).
         assert_eq!(
             <Adversarial as IntegTag>::runtime_level(),


### PR DESCRIPTION
## What

Closes the **newtype↔lattice** gap in taking #1249 to proof level. Nothing proved the `Labeled<T,I,C>` phantom tags correspond to the extracted lattice the noninterference theorems are about. The existing `runtime_levels_match` checked only `(Trusted, Secret)` — leaving `Internal` and `Adversarial`, the exact read/fetch labels the theorems cover, **unbound**.

`every_tag_binds_to_its_named_lattice_level` asserts, **exhaustively over all 6 tags**, that `Tag::runtime_level()` equals the correspondingly-named production `ConfLevel`/`IntegLevel`.

## The chain is now complete and gated

```
Labeled<_, I, C> --runtime_level()--> production ConfLevel/IntegLevel   [THIS test, exhaustive]
production ConfLevel::Internal == extracted ConfLevel::Internal (disc 1) [discriminants_match_real_conflevel]
extracted Internal ⇏ Public over any op sequence                        [Lean file_read_internal_never_flows_public, #2297]
```

So `read_file()`'s `Labeled<_, Trusted, Internal>` is provably the `Internal` lattice point that can never reach a `Public` sink; `fetch_url()`'s `Labeled<_, Adversarial, Public>` the `Adversarial` point that can never reach a `Trusted` sink. A tag whose `runtime_level()` drifted from its name now **fails this test**, not a silent mislabel.

## #1249 status

With brick 1 (read-path theorem, #2297), brick 3a (de-vacuified facade test, #2298), and this brick 2, the three proof gaps — **read-path instantiation, newtype↔lattice binding, and the facade tag bound to the proof** — are closed. Runtime and compile-time IFC now meet at the read/fetch boundary as one gated, machine-checked object. Ready to close #1249.

Not boot-affecting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148ebbw4UXypRjhMw3xAQzj