### PR TITLE
test(snapshot): gate the clone-safety key partition as directly disjoint

### DIFF
--- a/crates/nucleus-node/src/snapshot.rs
+++ b/crates/nucleus-node/src/snapshot.rs
@@ -243,6 +243,28 @@ mod tests {
         );
     }
 
+    /// **The two classifications PARTITION — they are disjoint.** No key is both
+    /// per-pod-secret and shared-config. This is the soundness heart of
+    /// `SafeToClone`: a key in BOTH lists would be refused by `snapshot_safety`
+    /// (per-pod is checked first) yet read as clonable by a reviewer who added it
+    /// to the shared list — an ambiguous classification is the exact seam a
+    /// per-pod secret slips through onto a cloned base. It was caught only
+    /// INDIRECTLY (a both-listed key would fail `shared_configuration_does_not_block_a_base`);
+    /// this makes the partition a DIRECT, exhaustive property, so the two lists
+    /// can never disagree about a key even as they grow. Finite domain, so the
+    /// check is a complete proof of disjointness, not a sample.
+    #[test]
+    fn the_two_key_classifications_are_disjoint() {
+        for k in PER_POD_SECRET_KEYS {
+            assert!(
+                !SHARED_CONFIG_KEYS.contains(k),
+                "{k} is classified BOTH per-pod-secret and shared-config — a key must be \
+                 exactly one, and the 'shared' reading leaks it to every clone restored \
+                 from a snapshot base"
+            );
+        }
+    }
+
     /// Shared config must NOT block snapshotting, or no base is ever buildable
     /// and the guard is just an off switch.
     #[test]


### PR DESCRIPTION
## What

First step of the **clone-safety** arc. The per-pod-secret vs shared-config classification is the soundness heart of `SafeToClone`, but its **disjointness** was only caught *indirectly* (a key in both lists would fail `shared_configuration_does_not_block_a_base`). A both-classified key is the exact ambiguity a per-pod secret slips through: `snapshot_safety` refuses it (per-pod checked first) while a reviewer who added it to the shared list reads it as clonable.

`the_two_key_classifications_are_disjoint` asserts, **exhaustively over the finite key domain**, that no key is both — a complete proof of the partition property, so the two lists can never disagree about a key even as they grow.

## Honest scope

This is the decidable partition core. **The full proof-level lift is bigger than the IFC arc**, and I want to be straight about that: clone-safety's classifier is string-based (`snapshot_safety` parses `boot_args`) and the emitter builds strings, so a machine-checked Lean theorem needs *extracting string classification*, not instantiating an existing algebraic theorem the way #1249 did. The classification is already solidly Rust-tested (per-pod refused, shared admitted, whole-key matching, empty-value, drift-guard, and now disjointness); the authoritative live guard is `firecracker_config::no_pod_cmdline_carries_any_per_pod_secret` (behavioural, over the real generated args for every identity outcome).

Node-bin tests run on Linux CI (the `from_spec` gate blocks them on mac). Not boot-affecting behaviourally (test-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148ebbw4UXypRjhMw3xAQzj