### PR TITLE
ci(kani): shard the nightly full tiers per harness, and record what is actually verified

### DIFF
--- a/.github/workflows/kani-nightly.yml
+++ b/.github/workflows/kani-nightly.yml
@@ -87,9 +87,10 @@ jobs:
           echo "- **Minimum required:** $MINIMUM" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Full suite:** nightly + workflow_dispatch" >> "$GITHUB_STEP_SUMMARY"
 
-  # Constitutional Kernel (fast): 4 concrete-policy proofs — no symbolic BTreeSet
-  # These use only concrete BTreeSets + symbolic u64, finishing in <10 min.
-  # The 7 symbolic BTreeSet proofs (capability, governance, I/O axes) run nightly.
+  # Constitutional Kernel (fast): 5 bitmask / lattice proofs. These touch no
+  # BTreeSet<String> and never call Kernel::admit, which is why they finish in
+  # minutes. The 11 admission-path harnesses are sharded into the nightly matrix
+  # below and, as of 2026-08-31, none of them verifies — see KANI-STATUS.md.
   kani-constitutional:
     name: Kani (constitutional kernel)
     runs-on: ubuntu-24.04
@@ -132,15 +133,48 @@ jobs:
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Harnesses verified:** 5 / $TOTAL (fast tier — pure bitmask)" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Proved:** budget escalation, capability non-escalation, I/O confinement, combined monotonicity, lattice transitivity" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Nightly:** 11 symbolic BTreeSet proofs via admit() pipeline" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Nightly:** 11 admission-path harnesses, one job each (see KANI-STATUS.md)" >> "$GITHUB_STEP_SUMMARY"
 
-  # Constitutional Kernel (full): all 11 harnesses including symbolic BTreeSet proofs
-  # symbolic_set() proofs take 5-15 min each due to BTreeSet node machinery.
+  # Constitutional Kernel (full): every harness, ONE JOB EACH.
+  #
+  # Was a single job running `-p ck-kernel` (all 17 harnesses) under one 60-minute
+  # budget. That job had never once succeeded: it spent the whole budget inside the
+  # FIRST harness it picked up and the other 16 were never attempted, so a nightly
+  # gate reported red with no indication of which proof was at fault.
+  #
+  # Sharding gives each harness its own runner and its own budget, and
+  # `fail-fast: false` stops one slow proof from masking the rest. The matrix is
+  # written out rather than generated so that adding a harness to kani.rs is a
+  # deliberate edit here too — the proof-count gate below catches the omission.
   kani-constitutional-full:
-    name: Kani (constitutional kernel full)
+    name: "CK full: ${{ matrix.harness }}"
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
+    timeout-minutes: 30
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    strategy:
+      fail-fast: false
+      matrix:
+        harness:
+          # Bitmask / lattice tier — no Kernel::admit, verified in minutes.
+          - proof_budget_escalation_detected
+          - proof_capability_escalation_detected_bitmask
+          - proof_io_confinement_detected_bitmask
+          - proof_combined_monotonicity_complete
+          - proof_capability_subset_transitive
+          - proof_refinement_bitmask_agrees_with_btreeset
+          # Admission-path tier — these drive Kernel::admit over BTreeSet<String>
+          # policies. None of them has ever completed in CI; see KANI-STATUS.md.
+          - proof_capability_escalation_always_rejected
+          - proof_governance_weakening_always_rejected
+          - proof_rejected_never_in_lineage
+          - proof_budget_escalation_always_rejected
+          - proof_constitutional_self_merge_impossible
+          - proof_identical_policy_config_patch_admitted
+          - proof_io_outbound_domains_widening_rejected
+          - proof_io_local_file_roots_widening_rejected
+          - proof_io_env_vars_widening_rejected
+          - proof_io_tool_namespaces_widening_rejected
+          - proof_io_repo_write_targets_widening_rejected
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2.9.1
@@ -155,29 +189,51 @@ jobs:
           # Bump this suffix together with the `kani-version` input below when
           # upgrading Kani.
           key: kani-toolchain-${{ runner.os }}-kani-0.67.0
-      - name: Run Kani (constitutional kernel — all harnesses)
+      - name: Run Kani (${{ matrix.harness }})
         uses: model-checking/kani-github-action@f838096619a707b0f6b2118cf435eaccfa33e51f # v1.1
         with:
           # Pin the verifier version for reproducible proofs (default is
           # "latest", which silently changes what Kani checks) and to make the
           # toolchain cache key above stable. Bump both together.
           kani-version: "0.67.0"
-          args: "-p ck-kernel --solver cadical"
-      - name: Summary
-        if: always()
+          args: "-p ck-kernel --solver cadical --harness ${{ matrix.harness }}"
+
+  # Roll the shards up into one required-status-friendly result and record which
+  # harnesses actually verified, so the nightly summary reports what was proved
+  # rather than what was attempted.
+  kani-constitutional-full-summary:
+    name: Kani (constitutional kernel full)
+    runs-on: ubuntu-24.04
+    needs: kani-constitutional-full
+    if: always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Report
+        env:
+          RESULT: ${{ needs.kani-constitutional-full.result }}
         run: |
           TOTAL=$(grep -c '#\[kani::proof\]' crates/ck-kernel/src/kani.rs)
-          echo "## Kani BMC — Constitutional Kernel (full)" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Harnesses verified:** $TOTAL / $TOTAL (all)" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Proved:** ALL constitutional invariants including symbolic BTreeSet proofs" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "## Kani BMC — Constitutional Kernel (full, sharded)"
+            echo ""
+            echo "- **Harnesses in ck-kernel:** $TOTAL, one CI job each"
+            echo "- **Matrix result:** $RESULT"
+            echo ""
+            echo "Per-harness results are in the job list above. A red shard names"
+            echo "exactly one proof; see KANI-STATUS.md for the known-unverified set."
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ "$RESULT" != "success" ]; then
+            echo "::warning::One or more ck-kernel harnesses did not verify — see the per-harness jobs"
+          fi
 
-  # Full tier: all harnesses including normalize_* — nightly and on-demand only
-  # normalize_* harnesses each take 15+ minutes due to large symbolic state space
   kani-full:
     name: Kani (full)
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
+    # Was 60. The job has never reached it: it dies after 3-10 minutes with
+    # exit 143 and "runner has received a shutdown signal", which is the
+    # signature of cbmc exhausting the runner's 16 GB rather than a timeout.
+    # Locally, one admission-path harness reaches 3.2 GB within three minutes.
+    timeout-minutes: 45
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/KANI-STATUS.md
+++ b/KANI-STATUS.md
@@ -1,0 +1,101 @@
+# Kani BMC — what is actually verified
+
+This file exists because the nightly Kani gate reported a coverage claim it had never
+achieved. It records what the model checker has proved, what it has not, and the
+measurements behind the distinction.
+
+> Reconciled 2026-08-31 against Kani 0.67.0 (the version pinned in
+> `.github/workflows/kani-nightly.yml`), run both in CI and locally on the same version.
+
+## Summary
+
+`crates/ck-kernel/src/kani.rs` defines **17** proof harnesses. They fall into two groups,
+and the split is exact:
+
+| group | count | drives `Kernel::admit`? | status |
+| --- | --- | --- | --- |
+| bitmask / lattice tier | 6 | no | **verified** |
+| admission-path tier | 11 | yes | **never verified** |
+
+The five fast-tier harnesses run on every PR and push and are green. The sixth,
+`proof_refinement_bitmask_agrees_with_btreeset`, bridges the bitmask and `BTreeSet`
+representations for the subset check.
+
+**No harness that exercises `Kernel::admit` has ever completed**, in CI or locally.
+
+## What was wrong before
+
+The nightly ran `-p ck-kernel` as a single job under one 60-minute budget. Its last 30
+scheduled runs — every run in the retained history — failed. The log shows why:
+
+```
+09:17:57  Checking harness kani::proof_io_repo_write_targets_widening_rejected...
+10:15:39  ##[error]The operation was canceled.
+```
+
+One harness consumed the entire budget and the other sixteen were never attempted. The
+job summary nonetheless advertised "11 symbolic BTreeSet proofs via admit() pipeline" as
+nightly coverage. The `Kani (full)` job for `portcullis` failed the same way for a
+different reason: it dies after 3–10 minutes with `exit code 143` and "runner has
+received a shutdown signal", which is memory exhaustion, not a timeout.
+
+## Measurements
+
+Run locally on Kani 0.67.0, harness
+`proof_io_repo_write_targets_widening_rejected`:
+
+| variant | result |
+| --- | --- |
+| as committed (4-element symbolic universe) | no result in 10 min; cbmc at **3.2 GB** after 3 min, still climbing |
+| universe reduced to 2 elements (4 subsets) | no result in 10 min |
+| set made **fully concrete** (no `kani::any` at all) | no result in 7 min |
+
+And the simplest harness in the tier, `proof_identical_policy_config_patch_admitted` —
+which uses no `symbolic_set` at all:
+
+| harness | result |
+| --- | --- |
+| `proof_identical_policy_config_patch_admitted` | no result in **10 min** |
+
+The concrete-set row is the informative one. **The symbolic set is not the bottleneck.** With
+every nondeterministic choice removed the harness still does not terminate, so the cost
+is the size of the code under verification — `Kernel::admit` over `BTreeSet<String>`
+policies, with `format!`-built rejection messages and deep `PolicyManifest` clones — not
+the state space. Shrinking the universe or rewriting `symbolic_set` will not fix it.
+
+GitHub-hosted `ubuntu-24.04` runners have 16 GB, which is consistent with the
+`portcullis` job's OOM signature.
+
+## What the sharding changes
+
+`kani-constitutional-full` is now a matrix with **one job per harness** and
+`fail-fast: false`. This does not make an unverified proof verify. It makes the gate
+honest and legible:
+
+- each harness gets its own runner and its own 30-minute budget;
+- a slow proof can no longer prevent the other sixteen from being attempted;
+- a red nightly names exactly which harnesses failed;
+- the rolled-up job keeps the original status name, `Kani (constitutional kernel full)`,
+  so existing branch protection still resolves.
+
+Expect the nightly to stay red until the admission-path tier is addressed. That is the
+correct signal: those proofs are not passing today, and the previous configuration was
+red anyway while reporting a coverage claim it had not earned.
+
+## What a real fix needs
+
+The admission path has to become tractable for CBMC, not merely re-tiered. In rough
+order of promise:
+
+1. **Stubbing** (`-Z stubbing`). Kani's documentation names this situation directly:
+   code that Kani supports but that verifies badly. Candidates are the `format!`
+   rejection-message construction, `chrono::Utc::now()` in `make_witness_for_proof`, and
+   the `PolicyManifest` deep clones — none of which the admission *decision* depends on.
+2. **A narrower entry point.** The properties under proof are about the decision logic.
+   A `#[cfg(kani)]` seam that exercises the invariant checks without constructing a full
+   `WitnessBundle` would shrink the program by a large factor.
+3. **`BTreeSet<String>` → interned ids** in the verified path, with the existing
+   refinement proof extended to cover the encoding.
+
+Until one of these lands, the honest claim is the one at the top of this file: the
+bitmask tier is verified; the admission path is not.


### PR DESCRIPTION
## The gate has never been green

`Kani BMC` has failed **every one of its last 30 scheduled runs** — every run in the retained history. Not a regression: there is no successful nightly in the last 100 runs.

The cause is structural. `kani-constitutional-full` ran all 17 `ck-kernel` harnesses in **one job under one 60-minute budget**:

```
09:17:57  Checking harness kani::proof_io_repo_write_targets_widening_rejected...
10:15:39  ##[error]The operation was canceled.
```

One harness consumed the entire budget; **the other sixteen were never attempted**. Raising the timeout does not help. Meanwhile the job summary advertised *"11 symbolic BTreeSet proofs via admit() pipeline"* as nightly coverage.

`Kani (full)` (portcullis) fails the same nightly for a different reason: it dies after 3–10 minutes with `exit code 143` and *"runner has received a shutdown signal"* — cbmc exhausting the runner's 16 GB, not the 60-minute wall.

## What is actually verified

The 17 harnesses split exactly in two:

| group | count | drives `Kernel::admit`? | status |
| --- | --- | --- | --- |
| bitmask / lattice | 6 | no | **verified** |
| admission path | 11 | yes | **never verified** |

**No proof that exercises the production admission path has ever completed**, in CI or locally. The verified surface is the bitmask abstraction, bridged to `BTreeSet` for the subset check by `proof_refinement_bitmask_agrees_with_btreeset`.

## Measurements

Local runs on Kani 0.67.0 — the version this workflow pins — of `proof_io_repo_write_targets_widening_rejected`:

| variant | result |
| --- | --- |
| as committed (4-element symbolic universe) | no result in 10 min; cbmc at **3.2 GB** after 3 min, still climbing |
| universe reduced to 2 elements (4 subsets) | no result in 10 min |
| set made **fully concrete** (no `kani::any` at all) | no result in 7 min |
| `proof_identical_policy_config_patch_admitted` (no `symbolic_set` at all) | no result in 10 min |

The last two rows are the point. **The symbolic set is not the bottleneck.** With every nondeterministic choice removed the harness still does not terminate, and the harness that never builds a symbolic set does not either. The cost is the size of the code under verification — `Kernel::admit` over `BTreeSet<String>` policies, `format!`-built rejection messages, deep `PolicyManifest` clones — not the state space.

I had intended to rewrite `symbolic_set` and measured first; the measurement refuted it, so **no harness source is touched by this PR.**

## What this changes

- `kani-constitutional-full` becomes a **17-way matrix, one harness per job**, `fail-fast: false`, 30 minutes each.
- A rolled-up job keeps the status name `Kani (constitutional kernel full)`, so existing branch protection still resolves.
- `kani-full` drops 60 → 45 minutes, since it has never reached the old limit.
- Stale coverage claims in the workflow summaries are corrected.
- `KANI-STATUS.md` records what is proved, what is not, the measurements above, and three candidate real fixes.

This does **not** make an unverified proof verify. It stops one slow proof from masking sixteen others and makes a red nightly name the harness at fault.

## Expect the nightly to stay red

That is the correct signal: those 11 proofs do not pass today. The previous configuration was red anyway, while reporting coverage it had not earned. The first sharded run will also give the per-harness data needed to prioritise the real fix — which of the 11 are merely slow, and which are hopeless as written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUeXMiQMvNkToXafRkAzVi