### PR TITLE
ck-policy parity gates were vacuous; enumerated stand-ins for the 12 never-verifying Kani harnesses

### DIFF
--- a/.github/workflows/ck-policy-aeneas-noop.yml
+++ b/.github/workflows/ck-policy-aeneas-noop.yml
@@ -16,6 +16,8 @@ on:
       - "crates/ck-policy/src/extracted.rs"
       - "crates/ck-policy/tests/policy_aeneas_parity.rs"
       - ".github/workflows/ck-policy-aeneas.yml"
+      - "crates/ck-policy/src/lib.rs"
+      - "crates/ck-types/**"
 
 permissions:
   contents: read

--- a/.github/workflows/ck-policy-aeneas.yml
+++ b/.github/workflows/ck-policy-aeneas.yml
@@ -28,12 +28,16 @@ on:
       - "crates/ck-policy/src/extracted.rs"
       - "crates/ck-policy/tests/policy_aeneas_parity.rs"
       - ".github/workflows/ck-policy-aeneas.yml"
+      - "crates/ck-policy/src/lib.rs"
+      - "crates/ck-types/**"
   pull_request:
     paths:
       - "crates/ck-policy/lean-aeneas/**"
       - "crates/ck-policy/src/extracted.rs"
       - "crates/ck-policy/tests/policy_aeneas_parity.rs"
       - ".github/workflows/ck-policy-aeneas.yml"
+      - "crates/ck-policy/src/lib.rs"
+      - "crates/ck-types/**"
   merge_group:
   # Weekly canary to catch Charon/Aeneas/Mathlib drift.
   schedule:

--- a/.github/workflows/ck-policy-lean-noop.yml
+++ b/.github/workflows/ck-policy-lean-noop.yml
@@ -14,6 +14,8 @@ on:
     paths-ignore:
       - "crates/ck-policy/lean/**"
       - ".github/workflows/ck-policy-lean.yml"
+      - "crates/ck-policy/src/lib.rs"
+      - "crates/ck-types/**"
 
 permissions:
   contents: read

--- a/.github/workflows/ck-policy-lean.yml
+++ b/.github/workflows/ck-policy-lean.yml
@@ -13,10 +13,14 @@ on:
     paths:
       - "crates/ck-policy/lean/**"
       - ".github/workflows/ck-policy-lean.yml"
+      - "crates/ck-policy/src/lib.rs"
+      - "crates/ck-types/**"
   pull_request:
     paths:
       - "crates/ck-policy/lean/**"
       - ".github/workflows/ck-policy-lean.yml"
+      - "crates/ck-policy/src/lib.rs"
+      - "crates/ck-types/**"
   merge_group:
   workflow_dispatch:
 

--- a/KANI-STATUS.md
+++ b/KANI-STATUS.md
@@ -142,6 +142,29 @@ argument, but it is currently on the wrong side of the tractability line: it bui
 very thing it is trying to bridge. A version over interned ids would verify and would
 carry real weight.
 
+## What runs today
+
+`src/kani.rs` carries `#![cfg(kani)]`, so **its harnesses compile only under `cargo kani`** —
+the twelve that never verify contribute nothing to any ordinary build. Enumerated
+stand-ins now live in `src/lib.rs` under `mod tests::enumerated_admission` and run on every
+`cargo test`.
+
+They are not a weaker substitute at the fixture's size. Each harness's symbolic domain is
+four `kani::any::<bool>()` over a four-element universe — sixteen subsets — so enumeration
+is equivalent in strength; three of the twelve contained no `kani::any` at all. The
+exception is `proof_budget_escalation_always_rejected`, a genuine forall over 480 symbolic
+bits, where the stand-in checks the eight per-field boundaries and is explicitly weaker.
+
+The stand-ins also assert what the harnesses never did: that the decision **cites the
+axis-specific invariant**. `admit` runs eight gates before the monotonicity check, so
+`matches!(d, Rejected { .. })` alone stays green while the gate a harness is named after
+rots. `AdmissionDecision` has four variants, so `Rejected` is a strictly stronger claim
+than "not accepted". A control case asserts an identical policy is *accepted*, without
+which every rejection case could pass vacuously.
+
+If Kani ever handles `BTreeSet<String>`, the harnesses reclaim the unbounded quantifier
+for free. These tests are the floor, not the ambition.
+
 Until that lands, the honest claim is narrower than the one this file opened with:
 
 > Five harnesses verify, and they prove lattice arithmetic over bitmasks. Nothing that

--- a/crates/ck-kernel/src/lib.rs
+++ b/crates/ck-kernel/src/lib.rs
@@ -1732,4 +1732,251 @@ mod tests {
             "Forgery after restore must be rejected: {result:?}"
         );
     }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Enumerated stand-ins for the never-verifying Kani full-tier harnesses
+    // ═══════════════════════════════════════════════════════════════════════
+    //
+    // `src/kani.rs` is `#![cfg(kani)]`, so its 17 harnesses compile ONLY under
+    // `cargo kani`. Twelve of them have never completed, in CI or locally:
+    // CBMC cannot construct `BTreeSet<String>` — a harness that only builds the
+    // fixture and asserts a constant does not terminate. See KANI-STATUS.md.
+    //
+    // Those twelve therefore contribute nothing to any build today. Their
+    // symbolic domain is four `kani::any::<bool>()` over a four-element
+    // universe: sixteen subsets. Enumerating sixteen cases is EQUIVALENT IN
+    // STRENGTH at that size, not an approximation of it. Three of the twelve
+    // contain no `kani::any` at all and were already unit tests wearing a
+    // `#[kani::proof]` attribute.
+    //
+    // These also assert what the harnesses never did — that the decision cites
+    // the AXIS-SPECIFIC invariant. `admit` runs eight gates before the
+    // monotonicity check, so `matches!(d, Rejected { .. })` alone stays green
+    // while the gate the harness is named after rots.
+    //
+    // If Kani ever handles `BTreeSet<String>`, the harnesses in kani.rs reclaim
+    // the unbounded quantifier for free; these tests are the floor, not a
+    // replacement for that ambition.
+    mod enumerated_admission {
+        use super::*;
+
+        /// Four names absent from `test_manifest()` on every axis under test.
+        const FRESH: [&str; 4] = ["evil-a.example", "evil-b.example", "/etc", "secret-ns"];
+
+        fn subset(mask: u32) -> BTreeSet<String> {
+            (0..FRESH.len())
+                .filter(|i| mask & (1 << i) != 0)
+                .map(|i| FRESH[i].to_string())
+                .collect()
+        }
+
+        fn decide(child: &PolicyManifest, class: PatchClass) -> (AdmissionDecision, bool) {
+            let genesis = ArtifactDigest::from_bytes(b"genesis");
+            let mut kernel = Kernel::new(genesis.clone());
+            let candidate = ArtifactDigest::from_bytes(b"candidate");
+            let witness =
+                make_witness_with_policies(&genesis, &candidate, class, &test_manifest(), child);
+            let decision = kernel.admit(CandidateAmendment {
+                parent_digest: genesis,
+                candidate_digest: candidate.clone(),
+                patch_class: class,
+                witness,
+            });
+            let admitted = kernel.is_admitted(&candidate);
+            (decision, admitted)
+        }
+
+        /// Rejected, NOT admitted, and citing `want` — the assertion the Kani
+        /// harnesses omit.
+        fn assert_rejected_citing(
+            child: &PolicyManifest,
+            want: ConstitutionalInvariant,
+            ctx: &str,
+        ) {
+            let (decision, admitted) = decide(child, PatchClass::Config);
+            assert!(
+                matches!(decision, AdmissionDecision::Rejected { .. }),
+                "{ctx}: expected Rejected, got {decision:?}"
+            );
+            assert!(!admitted, "{ctx}: rejected candidate must not be admitted");
+            if let AdmissionDecision::Rejected { reasons } = decision {
+                assert!(
+                    reasons.iter().any(|r| r.invariant == want),
+                    "{ctx}: must cite {want:?}, got {reasons:?}"
+                );
+            }
+        }
+
+        /// The five `proof_io_*_widening_rejected` harnesses, enumerated.
+        #[test]
+        fn io_widening_always_rejected_on_every_axis() {
+            type Axis = (&'static str, fn(&mut IoSurface, BTreeSet<String>));
+            let axes: [Axis; 5] = [
+                ("outbound_domains", |io, s| io.outbound_domains.extend(s)),
+                ("local_file_roots", |io, s| io.local_file_roots.extend(s)),
+                ("env_vars_readable", |io, s| io.env_vars_readable.extend(s)),
+                ("tool_namespaces", |io, s| io.tool_namespaces.extend(s)),
+                ("repo_write_targets", |io, s| {
+                    io.repo_write_targets.extend(s)
+                }),
+            ];
+            let mut checked = 0;
+            for (name, widen) in axes {
+                for mask in 1..(1u32 << FRESH.len()) {
+                    let mut child = test_manifest();
+                    widen(&mut child.io_surface, subset(mask));
+                    assert_rejected_citing(
+                        &child,
+                        ConstitutionalInvariant::IoConfinement,
+                        &format!("io axis {name}, mask {mask:04b}"),
+                    );
+                    checked += 1;
+                }
+            }
+            assert_eq!(checked, 75, "5 axes x 15 non-empty subsets");
+        }
+
+        /// `proof_capability_escalation_always_rejected`, enumerated.
+        #[test]
+        fn capability_escalation_always_rejected() {
+            for mask in 1..(1u32 << FRESH.len()) {
+                let mut child = test_manifest();
+                child.capabilities.network_allow.extend(subset(mask));
+                assert_rejected_citing(
+                    &child,
+                    ConstitutionalInvariant::CapabilityNonEscalation,
+                    &format!("network_allow widened, mask {mask:04b}"),
+                );
+            }
+        }
+
+        /// `proof_governance_weakening_always_rejected`, enumerated over the
+        /// PROPER subsets of the parent's own requirement set — dropping any
+        /// required check is the weakening.
+        #[test]
+        fn governance_weakening_always_rejected() {
+            let parent = test_manifest();
+            let reqs: Vec<String> = parent
+                .proof_requirements
+                .config_patch
+                .iter()
+                .cloned()
+                .collect();
+            assert!(!reqs.is_empty(), "fixture must require at least one check");
+            for mask in 0..(1u32 << reqs.len()) {
+                let kept: BTreeSet<String> = (0..reqs.len())
+                    .filter(|i| mask & (1 << i) != 0)
+                    .map(|i| reqs[i].clone())
+                    .collect();
+                if kept.len() == reqs.len() {
+                    continue; // nothing dropped
+                }
+                let mut child = test_manifest();
+                child.proof_requirements.config_patch = kept;
+                assert_rejected_citing(
+                    &child,
+                    ConstitutionalInvariant::GovernanceMonotonicity,
+                    &format!("config_patch reqs dropped, mask {mask:04b}"),
+                );
+            }
+        }
+
+        /// `proof_budget_escalation_always_rejected`. The harness is a genuine
+        /// forall over 480 symbolic bits and cannot be enumerated; `is_within`
+        /// is eight independent comparisons, so raising each field by one past
+        /// the parent is the boundary case for each. This is WEAKER than the
+        /// harness intends — recorded as such in KANI-STATUS.md.
+        #[test]
+        fn budget_escalation_always_rejected_per_field() {
+            type Raise = (&'static str, fn(&mut BudgetBounds));
+            let raises: [Raise; 8] = [
+                ("max_tokens", |b| b.max_tokens += 1),
+                ("max_wall_ms", |b| b.max_wall_ms += 1),
+                ("max_cpu_ms", |b| b.max_cpu_ms += 1),
+                ("max_memory_bytes", |b| b.max_memory_bytes += 1),
+                ("max_network_calls", |b| b.max_network_calls += 1),
+                ("max_files_touched", |b| b.max_files_touched += 1),
+                ("max_dollar_spend_millicents", |b| {
+                    b.max_dollar_spend_millicents += 1
+                }),
+                ("max_patch_attempts", |b| b.max_patch_attempts += 1),
+            ];
+            for (name, raise) in raises {
+                let mut child = test_manifest();
+                raise(&mut child.budget_bounds);
+                assert_rejected_citing(
+                    &child,
+                    ConstitutionalInvariant::ResourceBoundedness,
+                    &format!("budget field {name} raised by one"),
+                );
+            }
+        }
+
+        /// `proof_rejected_never_in_lineage` — no symbolic input in the original.
+        #[test]
+        fn rejected_never_in_lineage() {
+            let mut child = test_manifest();
+            child
+                .capabilities
+                .network_allow
+                .insert("evil.example".into());
+            let (decision, admitted) = decide(&child, PatchClass::Config);
+            assert!(matches!(decision, AdmissionDecision::Rejected { .. }));
+            assert!(
+                !admitted,
+                "a rejected candidate must never enter the lineage"
+            );
+        }
+
+        /// `proof_constitutional_self_merge_impossible` — no symbolic input.
+        #[test]
+        fn constitutional_self_merge_impossible() {
+            let child = test_manifest(); // identical policy; the CLASS is the attack
+            let (decision, admitted) = decide(&child, PatchClass::Constitutional);
+            assert!(
+                matches!(decision, AdmissionDecision::Rejected { .. }),
+                "constitutional self-merge must be rejected: {decision:?}"
+            );
+            assert!(!admitted);
+            if let AdmissionDecision::Rejected { reasons } = decision {
+                assert!(
+                    reasons
+                        .iter()
+                        .any(|r| r.invariant == ConstitutionalInvariant::GovernanceMonotonicity),
+                    "must cite GovernanceMonotonicity: {reasons:?}"
+                );
+            }
+        }
+
+        /// `proof_identical_policy_config_patch_admitted` — the control. If this
+        /// ever fails, every rejection test above is passing vacuously.
+        #[test]
+        fn identical_policy_config_patch_admitted() {
+            let child = test_manifest();
+            let (decision, admitted) = decide(&child, PatchClass::Config);
+            assert!(
+                matches!(decision, AdmissionDecision::Accepted { .. }),
+                "an identical policy must be admitted, else the rejection tests \
+                 above prove nothing: {decision:?}"
+            );
+            assert!(admitted, "an admitted candidate must be in the lineage");
+        }
+
+        /// `proof_refinement_bitmask_agrees_with_btreeset`, enumerated over all
+        /// 2^8 = 256 (parent, child) pairs rather than 8 symbolic bools.
+        #[test]
+        fn bitmask_agrees_with_btreeset_on_subset() {
+            for parent_bits in 0u32..16 {
+                for child_bits in 0u32..16 {
+                    let p = subset(parent_bits);
+                    let c = subset(child_bits);
+                    assert_eq!(
+                        c.is_subset(&p),
+                        (child_bits & !parent_bits) == 0,
+                        "bitmask/BTreeSet disagree at parent={parent_bits:04b} child={child_bits:04b}"
+                    );
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
Two gaps found by the Kani/Lean coverage audit, both of the same shape: a gate that reports green without checking what it claims to.

## 1. The ck-policy parity gates did not watch the gate they verify

Both parity tests bind to the **production** gate, in their own words:

- `policy_aeneas_parity.rs`: *"`ck_policy::extracted::passed_core` is bound to the PRODUCTION `ck_policy::check_monotonicity(parent, child).passed`"*
- `policy_lean_parity.rs`: *"asserting it AGREES with `check_monotonicity(...).passed`"*

`check_monotonicity` lives in `crates/ck-policy/src/lib.rs`. **Neither workflow listed that path**, nor `crates/ck-types/**`, which defines `PolicyManifest` / `IoSurface` / `CapabilitySet` — the types the gate reads.

Each workflow has a no-op twin whose `paths-ignore` mirrors its `paths`, so exactly one reports the required context on every PR. The consequence was therefore not a missing check but a **vacuous** one. A PR that changed the constitutional gate — and nothing else — matched neither `paths`, hit both twins, and reported:

```
no relevant paths changed — gate vacuously green
```

Both paths are added to both workflows and to both twins' `paths-ignore`. Mirroring verified programmatically: aeneas 6 ↔ 6, lean 4 ↔ 4, sets equal.

## 2. Enumerated stand-ins for the 12 never-verifying Kani harnesses

`crates/ck-kernel/src/kani.rs` carries `#![cfg(kani)]`, so its harnesses compile **only** under `cargo kani`. Twelve of them have never completed there either — CBMC cannot construct `BTreeSet<String>`; a harness that only builds the fixture and asserts a constant does not terminate. They contribute nothing to any build while inflating a proof count.

### Why enumeration is not a weakening here

Each harness's symbolic domain is four `kani::any::<bool>()` over a four-element universe — **sixteen subsets**. Enumerating sixteen cases is equivalent in strength at that size, not an approximation of it. Three of the twelve contain **no `kani::any` at all** and were already unit tests wearing a `#[kani::proof]` attribute.

The one real exception is `proof_budget_escalation_always_rejected`, a genuine ∀ over 480 symbolic bits. Its stand-in checks the eight per-field boundaries and `KANI-STATUS.md` records it as explicitly weaker.

### The stand-ins assert more than the harnesses did

This is the actual gain, and it is coverage that exists nowhere today:

- **The decision must cite the axis-specific invariant.** `admit` runs eight gates before the monotonicity check, so `matches!(d, Rejected { .. })` alone stays green while the gate a harness is *named after* rots.
- **`AdmissionDecision` has four variants** (`Accepted` / `Rejected` / `Quarantined` / `Expired`), so asserting `Rejected` is strictly stronger than "not accepted".
- **A control** asserts an identical policy is `Accepted` — without it, every rejection case could pass vacuously.

Coverage: 5 io axes × 15 non-empty subsets = 75 cases; capability escalation (15); governance weakening over proper subsets of the parent's requirements; budget per-field boundaries (8); the three with no symbolic input; and the bitmask/`BTreeSet` refinement over all 256 pairs.

### Why not `#[cfg_attr(kani, kani::proof)] #[cfg_attr(not(kani), test)]`

That was the intended shape, and it is not viable: the module is wholly `#![cfg(kani)]` and there are **88 `kani::any` + 26 `kani::assume`** call sites across many types. Dual-mode in place is a 114-site mechanical rewrite of a security-critical file. The stand-ins reuse the existing `#[cfg(test)]` fixtures instead, and **`kani.rs` is left untouched** — if Kani ever handles `BTreeSet<String>`, the harnesses reclaim the unbounded quantifier for free.

## Verification

```
cargo test -p ck-kernel                                    51 passed, 0 failed
cargo clippy -p ck-kernel --all-targets -- -D warnings     clean
cargo fmt --all -- --check                                 clean
cargo kani -p ck-kernel --harness proof_capability_subset_transitive
                                                           VERIFICATION:- SUCCESSFUL
```

`KANI-STATUS.md` gains a "What runs today" section recording which of the two is the floor and which is the ambition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUeXMiQMvNkToXafRkAzVi