### PR TITLE
fix(ci): the enforcement-core axiom audit has never run

### DIFF
--- a/.github/workflows/portcullis-core-proven-lean.yml
+++ b/.github/workflows/portcullis-core-proven-lean.yml
@@ -216,7 +216,24 @@ jobs:
           # A hole anywhere in the dependency graph surfaces as `sorryAx` even
           # if the textual scan missed it. `Lean.ofReduceBool` (native_decide)
           # is expected/disclosed and is NOT a failure.
-          cat > PrintAxioms.lean <<'EOF'
+          #
+          # WHY THREE FILES AND NOT ONE. Every Aeneas extraction opens `namespace
+          # nucleus_ifc_kernel` and re-emits the shared Rust types reachable from its
+          # own signatures, so two extractions that both see (say) `extracted::egress::Dest`
+          # cannot be imported into one Lean environment:
+          #
+          #   import PortcullisCoreChannel.Types failed, environment already contains
+          #   'nucleus_ifc_kernel.extracted.egress.Dest.rec' from PortcullisCoreIFC.Types
+          #
+          # PortcullisCoreIFC, PortcullisCoreCapQuantale and PortcullisCoreChannel are
+          # pairwise incompatible (a triangle), so three groups is the MINIMUM; the base
+          # PortcullisCore extraction is compatible with all three and stays in group 1.
+          # Each theorem appears in exactly one group, so the counts still sum to the total.
+          #
+          # This is a property of the extraction, not a defect to fix here. What matters is
+          # that the audit RUNS: with a single file it did not, and `|| true` hid that.
+
+          cat > PrintAxioms1.lean <<'EOF'
           import FlowProofs
           import DeclassifyProofs
           import SessionCeilingProofs
@@ -226,7 +243,6 @@ jobs:
           import DelegationProofs
           import ExposureProofs
           import IntegrityNoninterferenceExtracted
-          import CapabilityResiduatedQuantaleProofs
           import AssuranceCoverage
           import UniversalDetection
           import ExposureLoopFixpointProofs
@@ -249,7 +265,6 @@ jobs:
           import GkatKleeneProofs
           import SnapshotCloneSafetyProofs
           import DerivationCascadeAdmissible
-          import SnapshotChannelBindingProofs
           #print axioms FlowProofs.authority_confinement_left
           #print axioms GkatSyntax.salomaa_solutions_agree
           #print axioms GkatGS.sound
@@ -329,7 +344,6 @@ jobs:
           #print axioms GkatKleene.loop2Aut_expressible
           #print axioms GkatKleene.loopAut_expressible
           #print axioms IntegrityNoninterferenceExtracted.web_tainted_never_git_pushes
-          #print axioms CapabilityResiduatedQuantaleProofs.residuation_adjunction
           #print axioms Nucleus.Assurance.suite_not_full
           #print axioms PortcullisCore.UniversalDetection.universal_detection_impossibility
           #print axioms ExposureLoop.loop_admissible
@@ -339,38 +353,57 @@ jobs:
           #print axioms GkatWhile.solution_unique
           #print axioms SnapshotCloneSafety.unsafe_persists_under_superset
           #print axioms DerivationCascade.user_cascade_ratchets
+          EOF
+
+          cat > PrintAxioms2.lean <<'EOF'
+          import CapabilityResiduatedQuantaleProofs
+          #print axioms CapabilityResiduatedQuantaleProofs.residuation_adjunction
+          EOF
+
+          cat > PrintAxioms3.lean <<'EOF'
+          import SnapshotChannelBindingProofs
           #print axioms SnapshotChannelBinding.mappable_keys_never_reach_workload_via_cmdline
           EOF
-          # Defence 1 — the declaration above IS the gate. The heredoc names N theorems; the
-          # audit must report on N of them. This is the defence that survives someone re-adding
-          # `|| true`, and it is what catches a renamed or deleted audited theorem: `lake env
-          # lean` exits 1 on `error(lean.unknownIdentifier)`, and that paren form is exactly what
-          # a naive grep misses.
-          EXPECTED=$(grep -c '^#print axioms' PrintAxioms.lean)
 
-          # Defence 2 — NO `|| true`. A non-zero lean is a FAILED audit, not an empty one. The
-          # explicit message matters: `set -e` alone would kill the step with no explanation.
-          if ! AXIOMS="$(lake env lean PrintAxioms.lean 2>&1)"; then
+          # Defence 1 - the declarations above ARE the gate. The heredocs name N theorems
+          # in total; the audit must report on N of them. This is the defence that survives
+          # someone re-adding `|| true`, and it is what catches a renamed, deleted or
+          # regrouped theorem: `lake env lean` exits 1 on `error(lean.unknownIdentifier)`,
+          # and that paren form is exactly what a naive grep for 'error' misses.
+          EXPECTED=$(cat PrintAxioms*.lean | grep -c '^#print axioms')
+          REPORTED=0
+          : > AllAxioms.txt
+
+          for f in PrintAxioms*.lean; do
+            # Defence 2 - NO `|| true`. A non-zero lean is a FAILED audit, not an empty
+            # one. The explicit message matters: `set -e` alone would kill the step with
+            # no explanation, which is how the original defect stayed invisible.
+            if ! AXIOMS="$(lake env lean "$f" 2>&1)"; then
+              echo "$AXIOMS"
+              echo "::error::the axiom audit did not run to completion ($f: lean exited non-zero)."
+              exit 1
+            fi
             echo "$AXIOMS"
-            echo "::error::the axiom audit did not run to completion (lean exited non-zero)."
-            exit 1
-          fi
-          echo "$AXIOMS"
-          rm -f PrintAxioms.lean
+            printf '%s\n' "$AXIOMS" >> AllAxioms.txt
+            n=$(printf '%s\n' "$AXIOMS" \
+              | grep -c "depends on axioms\|does not depend on any axioms" || true)
+            echo "  -> $f: $(grep -c '^#print axioms' "$f") declared, $n reported"
+            REPORTED=$((REPORTED + n))
+          done
+          rm -f PrintAxioms*.lean
 
-          REPORTED=$(printf '%s\n' "$AXIOMS" \
-            | grep -c "depends on axioms\|does not depend on any axioms" || true)
           if [ "$REPORTED" -ne "$EXPECTED" ]; then
             echo "::error::audit incomplete: declared $EXPECTED theorems, got $REPORTED axiom reports."
             echo "::error::a theorem was renamed, deleted, or failed to resolve. The audit shrank."
             exit 1
           fi
 
-          if printf '%s\n' "$AXIOMS" | grep -q 'sorryAx'; then
+          if grep -q 'sorryAx' AllAxioms.txt; then
             echo "::error::an enforcement-core theorem depends on sorryAx (an unproven hole)."
             exit 1
           fi
-          if printf '%s\n' "$AXIOMS" | grep -q 'ofReduceBool'; then
-            echo "NOTE: native_decide (Lean.ofReduceBool) is in the TCB of the audited theorems — disclosed, see CONJECTURES.md."
+          if grep -q 'ofReduceBool' AllAxioms.txt; then
+            echo "NOTE: native_decide (Lean.ofReduceBool) is in the TCB of the audited theorems - disclosed, see CONJECTURES.md."
           fi
-          echo "OK: all $EXPECTED audited theorems reported, none depends on sorryAx."
+          rm -f AllAxioms.txt
+          echo "OK: all $EXPECTED audited theorems reported across 3 groups, none depends on sorryAx."

--- a/.github/workflows/portcullis-core-proven-lean.yml
+++ b/.github/workflows/portcullis-core-proven-lean.yml
@@ -341,14 +341,36 @@ jobs:
           #print axioms DerivationCascade.user_cascade_ratchets
           #print axioms SnapshotChannelBinding.mappable_keys_never_reach_workload_via_cmdline
           EOF
-          AXIOMS="$(lake env lean PrintAxioms.lean 2>&1 || true)"
+          # Defence 1 — the declaration above IS the gate. The heredoc names N theorems; the
+          # audit must report on N of them. This is the defence that survives someone re-adding
+          # `|| true`, and it is what catches a renamed or deleted audited theorem: `lake env
+          # lean` exits 1 on `error(lean.unknownIdentifier)`, and that paren form is exactly what
+          # a naive grep misses.
+          EXPECTED=$(grep -c '^#print axioms' PrintAxioms.lean)
+
+          # Defence 2 — NO `|| true`. A non-zero lean is a FAILED audit, not an empty one. The
+          # explicit message matters: `set -e` alone would kill the step with no explanation.
+          if ! AXIOMS="$(lake env lean PrintAxioms.lean 2>&1)"; then
+            echo "$AXIOMS"
+            echo "::error::the axiom audit did not run to completion (lean exited non-zero)."
+            exit 1
+          fi
           echo "$AXIOMS"
           rm -f PrintAxioms.lean
-          if echo "$AXIOMS" | grep -q 'sorryAx'; then
+
+          REPORTED=$(printf '%s\n' "$AXIOMS" \
+            | grep -c "depends on axioms\|does not depend on any axioms" || true)
+          if [ "$REPORTED" -ne "$EXPECTED" ]; then
+            echo "::error::audit incomplete: declared $EXPECTED theorems, got $REPORTED axiom reports."
+            echo "::error::a theorem was renamed, deleted, or failed to resolve. The audit shrank."
+            exit 1
+          fi
+
+          if printf '%s\n' "$AXIOMS" | grep -q 'sorryAx'; then
             echo "::error::an enforcement-core theorem depends on sorryAx (an unproven hole)."
             exit 1
           fi
-          if echo "$AXIOMS" | grep -q 'ofReduceBool'; then
+          if printf '%s\n' "$AXIOMS" | grep -q 'ofReduceBool'; then
             echo "NOTE: native_decide (Lean.ofReduceBool) is in the TCB of the audited theorems — disclosed, see CONJECTURES.md."
           fi
-          echo "OK: audited enforcement-core theorems are sorryAx-free."
+          echo "OK: all $EXPECTED audited theorems reported, none depends on sorryAx."


### PR DESCRIPTION
## The bug, and the much larger thing it was hiding

`portcullis-core-proven-lean.yml` audited the enforcement-core theorems for `sorryAx`, and **could not fail**:

```bash
AXIOMS="$(lake env lean PrintAxioms.lean 2>&1 || true)"
...
if echo "$AXIOMS" | grep -q 'sorryAx'; then
```

The `|| true` discards lean's exit code. If `lake env lean` fails for any reason, `$AXIOMS` is empty, `grep` matches nothing, and the step prints `OK: audited enforcement-core theorems are sorryAx-free.` — satisfied *by the absence of output*.

I opened this PR expecting to have hardened a gate against a hypothetical. **The repaired gate went red on its first run**, and what it caught is worse than the case it was written for:

```
PrintAxioms.lean:1:0: error: import PortcullisCoreCapQuantale.Types failed,
  environment already contains 'nucleus_ifc_kernel.extracted.egress.Dest.rec'
  from PortcullisCoreIFC.Types
```

That error is at **line 1** — the imports. Not one of the 90 `#print axioms` ever executed. The gate was not auditing a *shrinking* set of theorems, it was auditing **zero** of them. `web_tainted_never_git_pushes` and 89 other enforcement-core theorems have never once been checked for `sorryAx` by this gate.

The `|| true` did not merely weaken the audit. It concealed that the audit had never run at all.

## Why it cannot be one file

Every Aeneas extraction opens `namespace nucleus_ifc_kernel` and re-emits the shared Rust types reachable from its own signatures. Two extractions that both see `extracted::egress::Dest` cannot coexist in one Lean environment. Measured pairwise against the real oleans:

| | IFC | CapQuantale | Channel | base |
|---|---|---|---|---|
| **IFC** | — | collide | collide | ok |
| **CapQuantale** | collide | — | collide | ok |
| **Channel** | collide | collide | — | ok |

The three conflict pairwise — a triangle — so **three groups is the minimum**, and the base extraction rides along in group 1. Each theorem appears in exactly one group, so `EXPECTED` and `REPORTED` still sum to 90 and the count defence is unweakened.

This is a property of how the extractions are generated, not something to fix here. What matters is that the audit *runs*.

## The two defences

**1. The declarations are the gate.** `EXPECTED` sums `^#print axioms` across all three heredocs; `REPORTED` sums the per-file axiom reports; a mismatch names the file. Each group also prints its own declared/reported pair, so a shortfall localises immediately. This is the defence that survives someone re-adding `|| true`.

**2. No `|| true` anywhere.** A non-zero lean on any group fails the step and says which one. `set -e` alone would kill the step with no explanation — which is how the original defect stayed invisible.

## On the count

The first revision of this PR said 93 theorems. It is 90. The gate now *computes* the number instead of asserting it, so the two cannot drift again.

## Scope

One workflow file. No Lean changes. The other `Gate-Integrity` findings in this repo (7 High, 3 Medium across `ck-policy-*`, `rubric-lean`, `coverage-matrix`, `dylint-separation`, `aeneas-ifc-scoped`, `a2a-tck`) are the same *class* of weakness and are deliberately **not** touched here — but given what this one turned out to be hiding, they are now worth a sweep rather than a shrug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUeXMiQMvNkToXafRkAzVi