### PR TITLE
feat(ck): numeric governance monotonicity, and per-axis policy discrimination

### DIFF
--- a/crates/ck-kernel/src/lib.rs
+++ b/crates/ck-kernel/src/lib.rs
@@ -1836,18 +1836,76 @@ mod tests {
             assert_eq!(checked, 75, "5 axes x 15 non-empty subsets");
         }
 
-        /// `proof_capability_escalation_always_rejected`, enumerated.
+        /// `proof_capability_escalation_always_rejected`, enumerated — and
+        /// widened one axis at a time.
+        ///
+        /// Per-axis isolation is the point: a gate that read `filesystem_read`
+        /// where it meant `network_allow` would pass a test that widens every
+        /// axis together. `policy_lean_parity` shared one membership mask across
+        /// all five capability axes until this change, so every axis held the
+        /// same set in all 2048 cases and the confusion was invisible there too.
         #[test]
-        fn capability_escalation_always_rejected() {
-            for mask in 1..(1u32 << FRESH.len()) {
-                let mut child = test_manifest();
-                child.capabilities.network_allow.extend(subset(mask));
-                assert_rejected_citing(
-                    &child,
-                    ConstitutionalInvariant::CapabilityNonEscalation,
-                    &format!("network_allow widened, mask {mask:04b}"),
-                );
+        fn capability_escalation_always_rejected_on_every_axis() {
+            type Axis = (&'static str, fn(&mut CapabilitySet, BTreeSet<String>));
+            let axes: [Axis; 5] = [
+                ("filesystem_read", |c, s| c.filesystem_read.extend(s)),
+                ("filesystem_write", |c, s| c.filesystem_write.extend(s)),
+                ("network_allow", |c, s| c.network_allow.extend(s)),
+                ("tools_allow", |c, s| c.tools_allow.extend(s)),
+                ("secret_classes", |c, s| c.secret_classes.extend(s)),
+            ];
+            let mut checked = 0;
+            for (name, widen) in axes {
+                for mask in 1..(1u32 << FRESH.len()) {
+                    let mut child = test_manifest();
+                    widen(&mut child.capabilities, subset(mask));
+                    assert_rejected_citing(
+                        &child,
+                        ConstitutionalInvariant::CapabilityNonEscalation,
+                        &format!("cap axis {name}, mask {mask:04b}"),
+                    );
+                    checked += 1;
+                }
             }
+            assert_eq!(checked, 75, "5 axes x 15 non-empty subsets");
+        }
+
+        /// The sixth capability axis is numeric, not a set.
+        #[test]
+        fn raising_max_parallel_tasks_is_an_escalation() {
+            let mut child = test_manifest();
+            child.capabilities.max_parallel_tasks += 1;
+            assert_rejected_citing(
+                &child,
+                ConstitutionalInvariant::CapabilityNonEscalation,
+                "max_parallel_tasks raised by one",
+            );
+        }
+
+        /// The numeric governance axis, end to end through `admit`: lowering the
+        /// human-signature threshold disarms the review that would police the
+        /// NEXT constitutional amendment, with every boolean flag untouched.
+        #[test]
+        fn lowering_human_signature_threshold_is_rejected() {
+            let mut child = test_manifest();
+            let before = child.amendment_rules.constitutional_human_signatures;
+            assert!(before > 0, "fixture must require signatures to weaken");
+            child.amendment_rules.constitutional_human_signatures = before - 1;
+            assert_rejected_citing(
+                &child,
+                ConstitutionalInvariant::AmendmentRulesMonotonicity,
+                &format!("signature threshold {before} -> {}", before - 1),
+            );
+
+            // Raising is admitted — the axis is monotone upward, not frozen.
+            let mut raised = test_manifest();
+            raised.amendment_rules.constitutional_human_signatures = before + 5;
+            let (decision, admitted) = decide(&raised, PatchClass::Config);
+            assert!(
+                matches!(decision, AdmissionDecision::Accepted { .. }),
+                "raising the threshold must be admitted: {decision:?}"
+            );
+            assert!(admitted);
         }
 
         /// `proof_governance_weakening_always_rejected`, enumerated over the

--- a/crates/ck-policy/lean/Ck/Policy.lean
+++ b/crates/ck-policy/lean/Ck/Policy.lean
@@ -117,6 +117,11 @@ structure Rules where
   cap : Bool
   io : Bool
   proofreq : Bool
+  /-- `constitutional_human_signatures`: how many human signatures a
+      constitutional amendment needs. Numeric, and monotone upward only —
+      lowering it disarms the review that would police the NEXT amendment,
+      which is the same coup the booleans above prevent, spelled differently. -/
+  sigs : Nat
 deriving DecidableEq, Repr
 
 /-- The slice of a `PolicyManifest` the monotonicity gate actually reads:
@@ -164,7 +169,8 @@ def passedWeak (p c : Manifest) : Bool :=
 def weakensRules (c p : Manifest) : Prop :=
   (p.rules.cap = true ∧ c.rules.cap = false) ∨
   (p.rules.io = true ∧ c.rules.io = false) ∨
-  (p.rules.proofreq = true ∧ c.rules.proofreq = false)
+  (p.rules.proofreq = true ∧ c.rules.proofreq = false) ∨
+  (c.rules.sigs < p.rules.sigs)
 
 /-- `rulesNonWeakening c p`: the child's flags are pointwise `≥` the parent's —
     i.e. you can ENABLE a monotone flag but never DISABLE one. As a `Bool`:
@@ -174,7 +180,8 @@ def weakensRules (c p : Manifest) : Prop :=
 def rulesNonWeakening (c p : Manifest) : Bool :=
   (!p.rules.cap || c.rules.cap) &&
   (!p.rules.io || c.rules.io) &&
-  (!p.rules.proofreq || c.rules.proofreq)
+  (!p.rules.proofreq || c.rules.proofreq) &&
+  (decide (p.rules.sigs ≤ c.rules.sigs))
 
 /-- `passed p c` models the SHIPPED `check_monotonicity(parent=p, child=c).passed`.
     The verdict is `is_clean()` = no axis violated AND no amendment-rule
@@ -256,7 +263,7 @@ theorem T1_gate_sound (p c : Manifest) (h : passed p c = true) :
   -- unconditional non-weakening part.
   unfold passed passedWeak rulesNonWeakening at h
   simp only [Bool.and_eq_true, Bool.not_eq_true'] at h
-  obtain ⟨⟨⟨⟨hcap, hio⟩, hbud⟩, hproof⟩, ⟨⟨hrw_cap, hrw_io⟩, hrw_proof⟩⟩ := h
+  obtain ⟨⟨⟨⟨hcap, hio⟩, hbud⟩, hproof⟩, ⟨⟨⟨hrw_cap, hrw_io⟩, hrw_proof⟩, hrw_sigs⟩⟩ := h
   refine ⟨?_, ?_, ?_, ?_, ?_⟩
   · -- capability axis
     intro hflag
@@ -285,10 +292,13 @@ theorem T1_gate_sound (p c : Manifest) (h : passed p c = true) :
     exact not_not_intro ((dropsB_false_iff_subset c.proofReqs p.proofReqs).mp hproof)
   · -- amendment-rules non-weakening — UNCONDITIONAL (no flag guard)
     intro hw
-    rcases hw with ⟨hp, hc⟩ | ⟨hp, hc⟩ | ⟨hp, hc⟩
+    rcases hw with ⟨hp, hc⟩ | ⟨hp, hc⟩ | ⟨hp, hc⟩ | hsig
     · rw [hp, hc] at hrw_cap; simp at hrw_cap
     · rw [hp, hc] at hrw_io; simp at hrw_io
     · rw [hp, hc] at hrw_proof; simp at hrw_proof
+    · -- numeric axis: the verdict gave `p.sigs ≤ c.sigs`, contradicting `c < p`
+      have : p.rules.sigs ≤ c.rules.sigs := of_decide_eq_true hrw_sigs
+      omega
 
 /- ───────────────────────────────────────────────────────────────────────────
    THE COUP: the OLD gate admits it; the NEW gate rejects it (PROVED, 0 sorry)
@@ -303,7 +313,7 @@ def zeroBudget : Budget :=
 def fullParent : Manifest :=
   { caps := [], ioSurface := [], proofReqs := []
   , budget := zeroBudget
-  , rules := { cap := true, io := true, proofreq := true } }
+  , rules := { cap := true, io := true, proofreq := true, sigs := 2 } }
 
 /-- The malicious child: IDENTICAL projections (so every escalation/drop scan is
     empty), but it silently turns OFF the capability monotone flag — disarming
@@ -311,7 +321,7 @@ def fullParent : Manifest :=
 def disarmingChild : Manifest :=
   { caps := [], ioSurface := [], proofReqs := []
   , budget := zeroBudget
-  , rules := { cap := false, io := true, proofreq := true } }
+  , rules := { cap := false, io := true, proofreq := true, sigs := 2 } }
 
 /-- **THEOREM weak_gate_admits_coup (PROVED, documentary).** The PRE-FIX hole.
 
@@ -336,6 +346,38 @@ theorem weak_gate_admits_coup : ∃ p c, passedWeak p c = true ∧ weakensRules 
     `rulesNonWeakening` conjunct rejects the disarming step at move ONE, so the
     coup never reaches its second move. -/
 theorem new_gate_rejects_coup : passed fullParent disarmingChild = false := by
+  decide
+
+/-- The NUMERIC coup: identical projections and identical boolean flags, but the
+    child lowers the human-signature threshold from 2 to 0 — disarming the human
+    review that would police the NEXT constitutional amendment. Same shape as
+    `disarmingChild`, spelled numerically instead of as a boolean. -/
+def signatureLoweringChild : Manifest :=
+  { caps := [], ioSurface := [], proofReqs := []
+  , budget := zeroBudget
+  , rules := { cap := true, io := true, proofreq := true, sigs := 0 } }
+
+/-- **The pre-numeric hole, documented.** Every boolean flag is untouched, so a
+    gate that enumerates only the three booleans sees nothing wrong. -/
+theorem signature_lowering_disarms :
+    weakensRules signatureLoweringChild fullParent := by
+  unfold weakensRules
+  exact Or.inr (Or.inr (Or.inr (by decide)))
+
+/-- **THEOREM: the shipped gate rejects the numeric coup.** -/
+theorem new_gate_rejects_signature_lowering :
+    passed fullParent signatureLoweringChild = false := by
+  decide
+
+/-- Raising the threshold is not a weakening — the axis is monotone upward, not
+    frozen. Guards against a fix that simply pins the value. -/
+def signatureRaisingChild : Manifest :=
+  { caps := [], ioSurface := [], proofReqs := []
+  , budget := zeroBudget
+  , rules := { cap := true, io := true, proofreq := true, sigs := 7 } }
+
+theorem raising_signatures_is_admitted :
+    passed fullParent signatureRaisingChild = true := by
   decide
 
 /-- The shipped gate refines the pre-fix gate: anything `passed` admits,

--- a/crates/ck-policy/tests/policy_lean_parity.rs
+++ b/crates/ck-policy/tests/policy_lean_parity.rs
@@ -148,13 +148,16 @@ fn lean_proof_req_violated(p: &PolicyManifest, c: &PolicyManifest) -> bool {
 
 /// Mirror of Lean `rulesNonWeakening c p`: the child's governance flags are
 /// pointwise `≥` the parent's — you may ENABLE a flag but never DISABLE one
-/// (`parent_flag -> child_flag` on each axis). Checked UNCONDITIONALLY.
+/// (`parent_flag -> child_flag` on each axis) — AND the numeric signature
+/// threshold may rise but never fall (`Rules.sigs`, `p.sigs ≤ c.sigs`).
+/// Checked UNCONDITIONALLY.
 fn lean_rules_non_weakening(p: &PolicyManifest, c: &PolicyManifest) -> bool {
     let pr = &p.amendment_rules;
     let cr = &c.amendment_rules;
     (!pr.require_monotone_capabilities || cr.require_monotone_capabilities)
         && (!pr.require_monotone_io || cr.require_monotone_io)
         && (!pr.require_monotone_proofreq || cr.require_monotone_proofreq)
+        && (pr.constitutional_human_signatures <= cr.constitutional_human_signatures)
 }
 
 /// Mirror of the STRENGTHENED Lean `passed p c` (== the proven `checkPlus`):
@@ -194,6 +197,14 @@ fn set_of(items: &[&str], keep: &[bool]) -> BTreeSet<String> {
 }
 
 /// A `PolicyManifest` parameterized by the knobs the gate actually reads.
+/// Slice the `i`-th axis's membership mask out of a flat mask. Short inputs are
+/// tolerated (missing entries read as `false`) so fixtures can pass `&[]`.
+fn axis(flat: &[bool], i: usize, width: usize) -> &[bool] {
+    let start = (i * width).min(flat.len());
+    let end = (start + width).min(flat.len());
+    &flat[start..end]
+}
+
 #[allow(clippy::too_many_arguments)]
 fn manifest(
     caps_keep: &[bool],
@@ -204,32 +215,38 @@ fn manifest(
     flag_cap: bool,
     flag_io: bool,
     flag_proof: bool,
+    sigs: u32,
 ) -> PolicyManifest {
     let cap_pool = ["/a", "/b", "/c", "net1", "tool1", "secretA"];
     let io_pool = ["dom1", "root1", "ENV1", "ns1", "owner/repo"];
     let proof_pool = ["build_pass", "tests_pass", "kani_pass", "replay_pass"];
     PolicyManifest {
         version: 1,
+        // INDEPENDENT mask per axis. Previously every axis in a group shared one
+        // mask, so all five capability sets — and all five io sets — were EQUAL in
+        // all 2048 cases. A gate that read `filesystem_read` where it meant
+        // `network_allow` passed every case, because the two were never different.
+        // Chunking one longer mask gives each axis its own membership.
         capabilities: CapabilitySet {
-            filesystem_read: set_of(&cap_pool, caps_keep),
-            filesystem_write: set_of(&cap_pool, caps_keep),
-            network_allow: set_of(&cap_pool, caps_keep),
-            tools_allow: set_of(&cap_pool, caps_keep),
-            secret_classes: set_of(&cap_pool, caps_keep),
+            filesystem_read: set_of(&cap_pool, axis(caps_keep, 0, cap_pool.len())),
+            filesystem_write: set_of(&cap_pool, axis(caps_keep, 1, cap_pool.len())),
+            network_allow: set_of(&cap_pool, axis(caps_keep, 2, cap_pool.len())),
+            tools_allow: set_of(&cap_pool, axis(caps_keep, 3, cap_pool.len())),
+            secret_classes: set_of(&cap_pool, axis(caps_keep, 4, cap_pool.len())),
             max_parallel_tasks: parallel,
         },
         io_surface: IoSurface {
-            outbound_domains: set_of(&io_pool, io_keep),
-            local_file_roots: set_of(&io_pool, io_keep),
-            env_vars_readable: set_of(&io_pool, io_keep),
-            tool_namespaces: set_of(&io_pool, io_keep),
-            repo_write_targets: set_of(&io_pool, io_keep),
+            outbound_domains: set_of(&io_pool, axis(io_keep, 0, io_pool.len())),
+            local_file_roots: set_of(&io_pool, axis(io_keep, 1, io_pool.len())),
+            env_vars_readable: set_of(&io_pool, axis(io_keep, 2, io_pool.len())),
+            tool_namespaces: set_of(&io_pool, axis(io_keep, 3, io_pool.len())),
+            repo_write_targets: set_of(&io_pool, axis(io_keep, 4, io_pool.len())),
         },
         budget_bounds: budget(budget_vals),
         proof_requirements: ProofRequirements {
-            config_patch: set_of(&proof_pool, proof_keep),
-            controller_patch: set_of(&proof_pool, proof_keep),
-            evaluator_patch: set_of(&proof_pool, proof_keep),
+            config_patch: set_of(&proof_pool, axis(proof_keep, 0, proof_pool.len())),
+            controller_patch: set_of(&proof_pool, axis(proof_keep, 1, proof_pool.len())),
+            evaluator_patch: set_of(&proof_pool, axis(proof_keep, 2, proof_pool.len())),
         },
         amendment_rules: AmendmentRules {
             may_modify: BTreeSet::new(),
@@ -237,7 +254,7 @@ fn manifest(
             require_monotone_capabilities: flag_cap,
             require_monotone_io: flag_io,
             require_monotone_proofreq: flag_proof,
-            constitutional_human_signatures: 2,
+            constitutional_human_signatures: sigs,
         },
     }
 }
@@ -252,12 +269,12 @@ proptest! {
     /// pairs spanning all axes + all flag combinations.
     #[test]
     fn production_passed_agrees_with_lean_model(
-        pc in proptest::collection::vec(any::<bool>(), 6),
-        cc in proptest::collection::vec(any::<bool>(), 6),
-        pio in proptest::collection::vec(any::<bool>(), 5),
-        cio in proptest::collection::vec(any::<bool>(), 5),
-        ppr in proptest::collection::vec(any::<bool>(), 4),
-        cpr in proptest::collection::vec(any::<bool>(), 4),
+        pc in proptest::collection::vec(any::<bool>(), 6 * 5),
+        cc in proptest::collection::vec(any::<bool>(), 6 * 5),
+        pio in proptest::collection::vec(any::<bool>(), 5 * 5),
+        cio in proptest::collection::vec(any::<bool>(), 5 * 5),
+        ppr in proptest::collection::vec(any::<bool>(), 4 * 3),
+        cpr in proptest::collection::vec(any::<bool>(), 4 * 3),
         pbud in proptest::array::uniform8(0u64..8),
         cbud in proptest::array::uniform8(0u64..8),
         ppar in 0u32..8,
@@ -268,13 +285,15 @@ proptest! {
         cflag_cap in any::<bool>(),
         cflag_io in any::<bool>(),
         cflag_proof in any::<bool>(),
+        psigs in 0u32..4,
+        csigs in 0u32..4,
     ) {
         // The parent's flags gate cap/io/proofreq; the child's flags now MATTER
         // too — the SHIPPED gate checks `rulesNonWeakening` UNCONDITIONALLY, so
         // we vary the child's flags in BOTH directions to exercise the anti-coup
         // check (disabling a parent-enabled flag must now be rejected).
-        let parent = manifest(&pc, &pio, &ppr, pbud, ppar, flag_cap, flag_io, flag_proof);
-        let child = manifest(&cc, &cio, &cpr, cbud, cpar, cflag_cap, cflag_io, cflag_proof);
+        let parent = manifest(&pc, &pio, &ppr, pbud, ppar, flag_cap, flag_io, flag_proof, psigs);
+        let child = manifest(&cc, &cio, &cpr, cbud, cpar, cflag_cap, cflag_io, cflag_proof, csigs);
 
         let prod = check_monotonicity(&parent, &child).passed;
         let model = lean_passed(&parent, &child);
@@ -300,7 +319,7 @@ proptest! {
 fn meta_gap_coup_is_now_rejected() {
     let zero = [0u64; 8];
     // fullParent: every monotone flag ON, empty projections.
-    let parent = manifest(&[], &[], &[], zero, 0, true, true, true);
+    let parent = manifest(&[], &[], &[], zero, 0, true, true, true, 2);
     // disarmingChild: identical projections, but capability flag OFF.
     let mut child = parent.clone();
     child.amendment_rules.require_monotone_capabilities = false;
@@ -336,4 +355,53 @@ fn meta_gap_coup_is_now_rejected() {
     // Because step ONE is now rejected, the coup's intended SECOND step (a
     // grandchild escalating capabilities freely under the relaxed flag) is never
     // reachable on the ordinary path — the child never enters the lineage.
+}
+
+/// Rust image of the Lean `new_gate_rejects_signature_lowering` /
+/// `raising_signatures_is_admitted` theorems.
+///
+/// The NUMERIC half of the anti-coup check. Every boolean flag is untouched, so
+/// a gate that enumerates only the three booleans sees nothing wrong — the child
+/// merely lowers the human-signature threshold, disarming the review that would
+/// police the NEXT constitutional amendment.
+#[test]
+fn signature_lowering_is_rejected_and_raising_is_not() {
+    let zero = [0u64; 8];
+    let parent = manifest(&[], &[], &[], zero, 0, true, true, true, 2);
+
+    // Lowering: rejected, citing AmendmentRulesMonotonicity.
+    let mut lowered = parent.clone();
+    lowered.amendment_rules.constitutional_human_signatures = 0;
+    assert_eq!(
+        lowered.amendment_rules.require_monotone_capabilities,
+        parent.amendment_rules.require_monotone_capabilities,
+        "the numeric coup must leave every boolean flag untouched"
+    );
+    let prod = check_monotonicity(&parent, &lowered);
+    assert!(
+        !prod.passed,
+        "lowering the signature threshold must be rejected: {:?}",
+        prod.diff
+    );
+    assert!(
+        prod.diff
+            .violated_invariants
+            .contains(&ck_types::ConstitutionalInvariant::AmendmentRulesMonotonicity),
+        "must cite AmendmentRulesMonotonicity: {:?}",
+        prod.diff.violated_invariants
+    );
+
+    // The model agrees — this is the parity claim, not just the production one.
+    assert_eq!(prod.passed, lean_passed(&parent, &lowered));
+
+    // Raising: admitted. The axis is monotone upward, not frozen.
+    let mut raised = parent.clone();
+    raised.amendment_rules.constitutional_human_signatures = 7;
+    let prod_up = check_monotonicity(&parent, &raised);
+    assert!(
+        prod_up.passed,
+        "raising the threshold must be admitted: {:?}",
+        prod_up.diff
+    );
+    assert_eq!(prod_up.passed, lean_passed(&parent, &raised));
 }

--- a/crates/ck-types/src/manifest.rs
+++ b/crates/ck-types/src/manifest.rs
@@ -320,13 +320,21 @@ impl AmendmentRules {
     /// whole point is to stop an amendment from disarming the very flags that
     /// would police the next amendment.
     ///
-    /// SCOPE (honest): it enumerates exactly the three boolean governance
-    /// monotonicity flags — `require_monotone_{capabilities,io,proofreq}` — which
-    /// are precisely what the Lean model (`Ck.Policy.rulesNonWeakening`) and the
-    /// `policy_lean_parity` proptest are pinned to. It does NOT yet treat a LOWERED
-    /// `constitutional_human_signatures` threshold as a weakening; that numeric
-    /// monotonicity is a separate, deliberate FOLLOW-UP (it would need its own
-    /// model + parity), tracked so this stays parity-exact rather than overclaiming.
+    /// SCOPE: the three boolean governance monotonicity flags —
+    /// `require_monotone_{capabilities,io,proofreq}` — AND the numeric
+    /// `constitutional_human_signatures` threshold, which may be raised but never
+    /// lowered.
+    ///
+    /// The numeric axis was previously excluded and documented as a follow-up. It
+    /// is a coup vector in its own right: an amendment that lowers the threshold
+    /// from 2 to 0 disarms the human review that would police the NEXT
+    /// constitutional amendment, which is exactly what this function exists to
+    /// prevent. Boolean flags and a numeric threshold differ only in how disarming
+    /// is spelled.
+    ///
+    /// Kept parity-exact with the Lean model (`Ck.Policy.rulesNonWeakening`, whose
+    /// `sigs` field carries the same `parent ≤ child` obligation) and with the
+    /// `policy_lean_parity` proptest.
     pub fn weakened_flags_over(&self, parent: &Self) -> Vec<String> {
         let mut weakened = Vec::new();
         let mut check = |name: &str, parent_flag: bool, child_flag: bool| {
@@ -349,6 +357,14 @@ impl AmendmentRules {
             parent.require_monotone_proofreq,
             self.require_monotone_proofreq,
         );
+
+        // Numeric monotonicity: the threshold may RISE but never fall.
+        if self.constitutional_human_signatures < parent.constitutional_human_signatures {
+            weakened.push(format!(
+                "constitutional_human_signatures: {} -> {}",
+                parent.constitutional_human_signatures, self.constitutional_human_signatures
+            ));
+        }
         weakened
     }
 }

--- a/crates/ck-types/src/witness.rs
+++ b/crates/ck-types/src/witness.rs
@@ -665,6 +665,56 @@ mod tests {
         assert!(child_strict.weakened_flags_over(&parent_loose).is_empty());
     }
 
+    /// The numeric governance axis: the human-signature threshold may be RAISED
+    /// but never LOWERED. Lowering it disarms the review that would police the
+    /// next constitutional amendment — the same coup this function blocks on the
+    /// boolean flags.
+    #[test]
+    fn test_lowered_human_signature_threshold_is_a_weakening() {
+        let mut parent = AmendmentRules {
+            may_modify: BTreeSet::new(),
+            may_not_modify: BTreeSet::new(),
+            require_monotone_capabilities: true,
+            require_monotone_io: true,
+            require_monotone_proofreq: true,
+            constitutional_human_signatures: 2,
+        };
+
+        // Lowering is a weakening, and the message names the transition.
+        let mut child = parent.clone();
+        child.constitutional_human_signatures = 0;
+        let w = child.weakened_flags_over(&parent);
+        assert!(
+            w.iter()
+                .any(|m| m.contains("constitutional_human_signatures")),
+            "lowering 2 -> 0 must be reported: {w:?}"
+        );
+
+        // Every strict lowering, not just to zero.
+        for lowered in 0..2u32 {
+            let mut c = parent.clone();
+            c.constitutional_human_signatures = lowered;
+            assert!(
+                !c.weakened_flags_over(&parent).is_empty(),
+                "lowering 2 -> {lowered} must be reported"
+            );
+        }
+
+        // Holding steady and raising are both fine.
+        let mut same = parent.clone();
+        same.constitutional_human_signatures = 2;
+        assert!(same.weakened_flags_over(&parent).is_empty());
+        let mut raised = parent.clone();
+        raised.constitutional_human_signatures = 7;
+        assert!(raised.weakened_flags_over(&parent).is_empty());
+
+        // A parent that required nothing cannot be weakened numerically.
+        parent.constitutional_human_signatures = 0;
+        let mut c0 = parent.clone();
+        c0.constitutional_human_signatures = 0;
+        assert!(c0.weakened_flags_over(&parent).is_empty());
+    }
+
     fn sign_bundle(
         bundle: &WitnessBundle,
         key_pair: &ring::signature::Ed25519KeyPair,


### PR DESCRIPTION
Two gaps surfaced by the Kani/Lean coverage audit. Both have the same shape — *the gate cannot see this class of attack* — and both are closed across all three layers so Rust, Lean and the parity proptest stay parity-exact.

## 1. The human-signature threshold was a coup vector

`AmendmentRules::weakened_flags_over` enumerated exactly three booleans, and said so in its own doc comment:

> *"It does NOT yet treat a LOWERED `constitutional_human_signatures` threshold as a weakening; that numeric monotonicity is a separate, deliberate FOLLOW-UP."*

Honest, and still a live hole. It is the same coup the booleans block, spelled numerically: an amendment that lowers the threshold from 2 to 0 **disarms the human review that would police the next constitutional amendment**, while leaving every boolean flag untouched — so a gate enumerating only booleans sees nothing wrong. The anti-coup theorem was anti-coup on three booleans only.

| layer | change |
| --- | --- |
| **Rust** | `weakened_flags_over` reports a lowered threshold. The gate already raises `AmendmentRulesMonotonicity` on any non-empty result, so this wires in with no call-site change. |
| **Lean** | `Rules` gains `sigs : Nat`; `rulesNonWeakening` gains `p.sigs ≤ c.sigs`; `weakensRules` gains the `c.sigs < p.sigs` disjunct. |
| **Parity** | the mirror gains the conjunct, and the proptest now **varies** the threshold independently for parent and child. |

`T1_gate_sound` still proves, now carrying the numeric axis — axioms unchanged (`[propext, Quot.sound]`, no `sorry`). Three new theorems: `signature_lowering_disarms`, `new_gate_rejects_signature_lowering`, `raising_signatures_is_admitted`.

**The parity test could not previously have observed this axis at all** — `constitutional_human_signatures: 2` was hard-coded in the generator. Raising the threshold stays admitted: monotone upward, not frozen.

## 2. Every axis in a group held the same set

`policy_lean_parity` passed **one** membership mask to all five capability axes, one to all five io axes, and one to all three proof-requirement axes. In all 2048 cases every axis within a group was therefore *equal* — and a gate that read `filesystem_read` where it meant `network_allow` would have passed every single case.

Each axis now gets an independent mask, chunked out of one flat vector. The enumerated kernel tests widen each capability axis in isolation (5 × 15 cases), matching what the io tests already did, plus the numeric `max_parallel_tasks` axis.

### One thing worth recording

The Rust mirror is **per-axis**, while the Lean model flattens each group to a single `List String`. The mirror is therefore *more faithful than the model it claims to transcribe*, and the shared mask is exactly what kept that invisible. The flattening remains unproved — `IoSurface` is five independent `BTreeSet<String>` and `ProofRequirements` three, against one `Names` carrier each in Lean — and is noted in `KANI-STATUS.md`.

## Verification

```
ck-types   37 passed, 0 failed
ck-policy  29 + 3 + 3 passed, 0 failed   (proptest at 2048 cases, axes now independent)
ck-kernel  53 passed, 0 failed
clippy --all-targets -D warnings         clean on all three
lake build (Ck monotonicity-gate soundness proofs)   Build completed successfully
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUeXMiQMvNkToXafRkAzVi