### PR TITLE
fix(ci): the two Lean sorry-bans could pass having scanned nothing

### DIFF
--- a/.github/workflows/ck-policy-lean.yml
+++ b/.github/workflows/ck-policy-lean.yml
@@ -63,13 +63,23 @@ jobs:
           # Match the tactic/term forms (`:= sorry`, `:= by sorry`, a lone `sorry`,
           # a lone `admit` / `:= by admit`, `native_decide`, or the `sorryAx` axiom
           # spelled out in source) — NOT the word "sorry" in "0 sorry" doc comments.
+          # Non-vacuity: this gate is a grep, and a grep over a path that no longer
+          # matches exits non-zero, takes the `else` branch, and prints the success
+          # line having scanned NOTHING. Establish that there is something to scan
+          # before letting its silence count as a pass.
+          FILES=$(find crates/ck-policy/lean/Ck -name '*.lean' | wc -l | tr -d ' ')
+          if [ "$FILES" -lt 1 ]; then
+            echo "::error::no .lean files under crates/ck-policy/lean/Ck — the ck-policy sorry-ban scanned nothing."
+            exit 1
+          fi
+          echo "scanning $FILES .lean file(s) under crates/ck-policy/lean/Ck"
           if grep -rnE \
                '(:=[[:space:]]*by[[:space:]]+sorry|:=[[:space:]]*sorry|^[[:space:]]*sorry$|:=[[:space:]]*by[[:space:]]+admit|^[[:space:]]*admit$|native_decide|sorryAx)' \
                --include='*.lean' crates/ck-policy/lean/Ck; then
             echo "ERROR: ck-policy Lean uses 'sorry'/'admit' (proof holes), 'native_decide', or 'sorryAx' (banned)."
             exit 1
           fi
-          echo "No sorry / admit / native_decide / sorryAx — monotonicity-gate proofs are complete and kernel-checked."
+          echo "No sorry / admit / native_decide / sorryAx across $FILES file(s) — monotonicity-gate proofs are complete and kernel-checked."
 
       - name: Assert theorems are sorryAx-free (#print axioms)
         working-directory: crates/ck-policy/lean

--- a/.github/workflows/rubric-lean.yml
+++ b/.github/workflows/rubric-lean.yml
@@ -58,13 +58,23 @@ jobs:
           # Match the tactic/term forms (`:= sorry`, `:= by sorry`, a lone `sorry`,
           # a lone `admit` / `:= by admit`, `native_decide`, or the `sorryAx` axiom
           # spelled out in source) — NOT the word "sorry" in "0 sorry" doc comments.
+          # Non-vacuity: this gate is a grep, and a grep over a path that no longer
+          # matches exits non-zero, takes the `else` branch, and prints the success
+          # line having scanned NOTHING. Establish that there is something to scan
+          # before letting its silence count as a pass.
+          FILES=$(find crates/nucleus-rubric/lean/Nucleus -name '*.lean' | wc -l | tr -d ' ')
+          if [ "$FILES" -lt 1 ]; then
+            echo "::error::no .lean files under crates/nucleus-rubric/lean/Nucleus — the rubric sorry-ban scanned nothing."
+            exit 1
+          fi
+          echo "scanning $FILES .lean file(s) under crates/nucleus-rubric/lean/Nucleus"
           if grep -rnE \
                '(:=[[:space:]]*by[[:space:]]+sorry|:=[[:space:]]*sorry|^[[:space:]]*sorry$|:=[[:space:]]*by[[:space:]]+admit|^[[:space:]]*admit$|native_decide|sorryAx)' \
                --include='*.lean' crates/nucleus-rubric/lean/Nucleus; then
             echo "ERROR: rubric Lean uses 'sorry'/'admit' (proof holes), 'native_decide', or 'sorryAx' (banned)."
             exit 1
           fi
-          echo "No sorry / admit / native_decide / sorryAx — rubric scoring proofs are complete and kernel-checked."
+          echo "No sorry / admit / native_decide / sorryAx across $FILES file(s) — rubric scoring proofs are complete and kernel-checked."
 
       - name: Assert theorems are sorryAx-free (#print axioms)
         working-directory: crates/nucleus-rubric/lean


### PR DESCRIPTION
Fallout from #2331, where a gate turned out to be auditing **zero** theorems while printing `OK`. The obvious follow-up question, asked of its siblings: *what establishes that these gates looked at anything?*

## The shape

`ck-policy-lean.yml` and `rubric-lean.yml` ban proof holes with a bare grep:

```bash
if grep -rnE '(:= *by *sorry|...|sorryAx)' --include='*.lean' <dir>; then
  echo "ERROR: ... (banned)."
  exit 1
fi
echo "No sorry / admit / native_decide / sorryAx — ..."
```

A grep over a path that no longer matches exits **non-zero**, so the `if` is false, so the step prints its success line having read no files at all. Move or rename the directory and the ban keeps passing. The verdict is carried entirely by the *absence* of output — structurally the same defect as #2331, just milder, because `lake build` would probably break too.

## The fix

Count the files first; fail if there are none; and report the number actually scanned, so a shrinking scan shows up in the log instead of passing silently:

```
scanning 3 .lean file(s) under crates/ck-policy/lean/Ck
No sorry / admit / native_decide / sorryAx across 3 file(s) — ...
```

## What this deliberately does *not* do

Not a count-of-theorems check like #2331's. These steps scan sources rather than enumerate declarations, so "at least one file" is the honest non-vacuity claim available here.

And it does not touch the `#print axioms` steps in either file — **those are already fail-closed.** They have no `|| true`, so a non-zero lean fails the step under `bash -e`. Worth stating explicitly, because the `Gate-Integrity` scan flags them as the same class and they are not.

## Sweep result, for the record

The other candidates from that scan did not survive reading:

| gate | verdict |
| --- | --- |
| `dylint-separation` | already defends against exactly this, with a comment naming the failure mode |
| `quickstart-boot` | fail-**closed** — empty markers raise the error |
| `ci.yml` changed-crate detection | `set -e` kills the step if `git diff` fails; the `|| true` only covers a legitimately-empty match |
| `rubric-lean` / `ck-policy-lean` `#print axioms` | fail-closed, no `|| true` |
| `rubric-lean` / `ck-policy-lean` source ban | **this PR** |

So there is no second fail-open gate of #2331's severity. Reporting that as a negative result rather than manufacturing findings to match the scanner's count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUeXMiQMvNkToXafRkAzVi