### PR TITLE
feat(commerce): the receipt IS the payout claim — recompute-verifiable revenue share

### DIFF
--- a/crates/nucleus-lineage/src/edge.rs
+++ b/crates/nucleus-lineage/src/edge.rs
@@ -695,9 +695,8 @@ mod tests {
             "e".repeat(64),
         );
 
-        let amount = |e: &LineageEdge| -> i64 {
-            e.attrs["amount_micro_usd_signed"].parse().unwrap()
-        };
+        let amount =
+            |e: &LineageEdge| -> i64 { e.attrs["amount_micro_usd_signed"].parse().unwrap() };
         assert_eq!(amount(&charge) + amount(&refund), 0);
         assert!(
             refund.parents.contains(&charge.child),

--- a/crates/nucleus-lineage/src/edge.rs
+++ b/crates/nucleus-lineage/src/edge.rs
@@ -486,6 +486,83 @@ impl LineageEdge {
         }
     }
 
+    /// Construct an **allocation** edge: a market mechanism split `content_hash_hex`'s
+    /// payout among its payees.
+    ///
+    /// The economic `EdgeKind`s have existed since the schema landed with nothing
+    /// constructing them. This is the first producer, and it exists so a payout is
+    /// recorded in the same lineage graph as the work that earned it rather than in
+    /// a separate ledger somebody has to be trusted about.
+    ///
+    /// `content_hash_hex` MUST be `nucleus_recompute::payout::payout_content_hash_hex`
+    /// of the payout being recorded. It is taken as an argument rather than computed
+    /// here so `nucleus-lineage` keeps no dependency on the economic kernels — and,
+    /// more importantly, so the hash that is *signed* is the same one an independent
+    /// verifier recomputes. Binding via `content_hash_hex` and not `attrs` is
+    /// deliberate: `canonical_edge_bytes` signs the content hash and does NOT sign
+    /// `attrs`, so a binding placed in `attrs` would be a false guarantee.
+    pub fn allocation(
+        child: CallSpiffeId,
+        parents: Vec<CallSpiffeId>,
+        market_id: impl Into<String>,
+        mechanism: impl Into<String>,
+        content_hash_hex: impl Into<String>,
+    ) -> Self {
+        Self {
+            child,
+            parents,
+            kind: EdgeKind::Allocation {
+                market_id: market_id.into(),
+                mechanism: mechanism.into(),
+            },
+            content_hash_hex: Some(content_hash_hex.into()),
+            ts: Utc::now(),
+            attrs: BTreeMap::new(),
+            proof: None,
+            verifier_attestation: None,
+        }
+    }
+
+    /// Construct a **settlement** edge: `amount_micro_usd_signed` moved to a payee on
+    /// an external rail, discharging the obligation recorded by `parents`.
+    ///
+    /// `amount` is signed (`i64`) because a refund is not a separate edge kind — it is
+    /// a `Settlement` with a negative amount whose parents include the edge being
+    /// reversed, so the signed sum over a charge is zero exactly when the refund is
+    /// full. Encoding it as a string keeps the attribute map `BTreeMap<String,String>`
+    /// and keeps JSON number coercion out of a money path.
+    ///
+    /// As with [`Self::allocation`], the *authoritative* binding is `content_hash_hex`
+    /// (which `canonical_edge_bytes` signs); the amount in `attrs` is a convenience for
+    /// readers and is NOT covered by the signature. Never verify against it.
+    pub fn settlement(
+        child: CallSpiffeId,
+        parents: Vec<CallSpiffeId>,
+        tx_ref: impl Into<String>,
+        rail: impl Into<String>,
+        amount_micro_usd_signed: i64,
+        content_hash_hex: impl Into<String>,
+    ) -> Self {
+        let mut attrs = BTreeMap::new();
+        attrs.insert(
+            "amount_micro_usd_signed".to_string(),
+            amount_micro_usd_signed.to_string(),
+        );
+        Self {
+            child,
+            parents,
+            kind: EdgeKind::Settlement {
+                tx_ref: tx_ref.into(),
+                rail: rail.into(),
+            },
+            content_hash_hex: Some(content_hash_hex.into()),
+            ts: Utc::now(),
+            attrs,
+            proof: None,
+            verifier_attestation: None,
+        }
+    }
+
     /// Construct a document-retrieval edge: `child` retrieved a document from
     /// `source_url` (content hash `content_hash`, trust class `source_class`).
     /// `parent` is the retrieving identity (the pod/call doing the fetch).
@@ -561,6 +638,114 @@ mod tests {
 
     fn pod() -> CallSpiffeId {
         CallSpiffeId::pod("prod.example.com", "agents", "coder").unwrap()
+    }
+
+    // ── Economic producers ──────────────────────────────────────────────
+    //
+    // The economic EdgeKinds shipped as a schema with nothing constructing them.
+    // These cover the first producers, and — more importantly — pin exactly how
+    // much of an economic edge the signature actually covers.
+
+    /// A payout is recorded in the same lineage graph as the work that earned it.
+    #[test]
+    fn allocation_edge_binds_the_payout_hash() {
+        let p = pod();
+        let payout_hash = "c".repeat(64);
+        let edge = LineageEdge::allocation(
+            p.derive_artifact(b"payout").unwrap(),
+            vec![p],
+            "offer-market",
+            "commons-split",
+            payout_hash.clone(),
+        );
+        assert_eq!(edge.content_hash_hex.as_deref(), Some(payout_hash.as_str()));
+        match &edge.kind {
+            EdgeKind::Allocation {
+                market_id,
+                mechanism,
+            } => {
+                assert_eq!(market_id, "offer-market");
+                assert_eq!(mechanism, "commons-split");
+            }
+            other => panic!("expected Allocation, got {other:?}"),
+        }
+    }
+
+    /// The documented refund semantics, exercised: a refund is not a distinct
+    /// edge kind but a `Settlement` with a negative amount whose parents include
+    /// the edge it reverses. The signed sum over a charge is zero exactly when
+    /// the refund is full.
+    #[test]
+    fn a_full_refund_sums_to_zero_against_its_charge() {
+        let p = pod();
+        let charge = LineageEdge::settlement(
+            p.derive_artifact(b"charge").unwrap(),
+            vec![p.clone()],
+            "0xabc",
+            "x402-evm",
+            1_000_000,
+            "d".repeat(64),
+        );
+        let refund = LineageEdge::settlement(
+            p.derive_artifact(b"refund").unwrap(),
+            vec![charge.child.clone()],
+            "0xdef",
+            "x402-evm",
+            -1_000_000,
+            "e".repeat(64),
+        );
+
+        let amount = |e: &LineageEdge| -> i64 {
+            e.attrs["amount_micro_usd_signed"].parse().unwrap()
+        };
+        assert_eq!(amount(&charge) + amount(&refund), 0);
+        assert!(
+            refund.parents.contains(&charge.child),
+            "a reversal must name the edge it reverses"
+        );
+    }
+
+    /// **The signature covers less of an economic edge than it looks like.**
+    ///
+    /// `canonical_edge_bytes` signs `kind_tag(&kind)` — the discriminant only —
+    /// so a `Settlement`'s `tx_ref` and `rail` are NOT covered, and neither is
+    /// `attrs`. Two settlements differing only in rail-side transaction id
+    /// produce byte-identical canonical bytes.
+    ///
+    /// This is pinned rather than fixed because changing the encoding would
+    /// break every existing signature. The consequence for anything built on
+    /// these edges: the authoritative binding is `content_hash_hex`, and the
+    /// payout receipt behind it must itself carry the settlement reference.
+    /// Verifying a payment against `attrs["amount_micro_usd_signed"]` or against
+    /// the edge's `tx_ref` would be a false guarantee.
+    #[test]
+    fn settlement_tx_ref_and_attrs_are_outside_the_signature() {
+        let p = pod();
+        let child = p.derive_artifact(b"settle").unwrap();
+        let hash = "f".repeat(64);
+        let a = LineageEdge::settlement(
+            child.clone(),
+            vec![p.clone()],
+            "0xaaa",
+            "x402-evm",
+            1_000_000,
+            hash.clone(),
+        );
+        let mut b = LineageEdge::settlement(
+            child,
+            vec![p],
+            "0xbbb", // different rail-side id
+            "x402-evm",
+            999, // different amount in attrs
+            hash,
+        );
+        b.ts = a.ts; // hold the one field that legitimately differs
+
+        assert_eq!(
+            crate::proof::canonical_edge_bytes(&a, None),
+            crate::proof::canonical_edge_bytes(&b, None),
+            "if this ever differs, the encoding changed and the warning above is stale"
+        );
     }
 
     #[test]

--- a/crates/nucleus-recompute/src/lib.rs
+++ b/crates/nucleus-recompute/src/lib.rs
@@ -43,6 +43,15 @@ use nucleus_econ_kernels::{
 // of that theorem, so it recomputes via these exact functions.
 use portcullis_core::extracted::ifc_integrity::{imeet, IntegLevel};
 
+/// Payout — the split of a cleared amount among the parties that earned it.
+///
+/// [`verify_receipt`] answers "did this clearing compute the right number?";
+/// [`payout::verify_payout`] answers "and was that number split as claimed?".
+/// It reuses the proven `route_to_commons` kernel rather than introducing a
+/// second numeric path, so the payout math inherits `Commons.lean`'s
+/// conservation theorem.
+pub mod payout;
+
 /// Domain separator for the canonical receipt bytes (versioned).
 const RECEIPT_DOMAIN: &[u8] = b"nucleus-recompute/clearing-receipt/v1\0";
 

--- a/crates/nucleus-recompute/src/payout.rs
+++ b/crates/nucleus-recompute/src/payout.rs
@@ -1,0 +1,634 @@
+//! # Payout — the receipt IS the payout claim
+//!
+//! [`verify_receipt`](crate::verify_receipt) answers *"did this clearing compute
+//! the right number?"*. This module answers the question one step downstream:
+//! *"and was that number split among the parties the way it was claimed?"*
+//!
+//! ## Why this is the whole design
+//!
+//! Agent-commerce standards (AdCP, AP2, ACP, x402) settle a price. None of them
+//! defines attribution: AdCP's own documentation puts attribution out of scope
+//! and defers it to third-party measurement. The research that *does* build
+//! verifiable agent receipts names its own missing piece — "adoption incentives:
+//! why services would implement receiver attestation" (arXiv 2606.04193).
+//!
+//! The answer here is structural: **the receipt is the payout claim.** A runtime
+//! emits verifiable evidence because that evidence is what its share is computed
+//! from. There is no separate reporting channel to be honest on, and no operator
+//! whose ledger has to be trusted — any party recomputes the split itself.
+//!
+//! ## No new economics
+//!
+//! A revenue split *is* a commons routing. `route_to_commons` is already the
+//! proven kernel (`Commons.lean`'s `routed_conserves`): a pool, a set of
+//! basis-point shares that must sum to exactly 10 000, and a conservation
+//! theorem that the allocations neither skim nor over-allocate. Re-using it
+//! means the payout math inherits a Lean proof instead of acquiring a new
+//! trusted numeric path.
+//!
+//! So [`verify_payout`] is a two-stage recomputation:
+//!
+//! 1. the clearing this payout distributes must itself re-derive
+//!    ([`verify_receipt`](crate::verify_receipt)) — a payout over a fabricated
+//!    price is caught here, before the split is even looked at;
+//! 2. the pool is *derived* from that clearing, never declared separately, and
+//!    `route_to_commons` must reproduce the claimed allocations exactly.
+//!
+//! Stage 1 is the load-bearing one. Letting the payout declare its own pool
+//! would leave the split honest and the number arbitrary.
+//!
+//! ## What this does NOT claim
+//!
+//! Recompute checks that the split is the proven function of the **declared**
+//! inputs. It says nothing about whether those inputs are truthful — the same
+//! honest boundary [`verify_receipt`](crate::verify_receipt) documents.
+//!
+//! Specifically, [`Attribution`] is *carried, not verified* here. That a
+//! particular workload surfaced a particular offer is a claim about the world;
+//! this module binds it into the signed content hash so it cannot be altered
+//! after the fact, and leaves proving it to the layers that can — SPIFFE
+//! attestation for the workload, and the disclosure record for the offer. A
+//! verifier that wants more than "these numbers re-derive" must check the
+//! attribution's `assurance` against an independently derived
+//! `VerifiedAttestation`, exactly as `MediationReceipt` requires.
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use nucleus_econ_kernels::{
+    commons::{route_to_commons, CommonsAllocation, CommonsError, CommonsShare},
+    settlement::seller_gross,
+};
+
+use crate::{mismatch, verify_receipt, ClearingReceipt, RecomputeOutcome};
+
+/// Domain separator for the canonical payout bytes (versioned).
+const PAYOUT_DOMAIN: &[u8] = b"nucleus-recompute/payout-receipt/v1\0";
+
+/// Who earned a payout, and on what evidence.
+///
+/// Every field is a claim *bound* by the payout's content hash, not a claim
+/// *proven* by this crate. Binding is still the point: an operator cannot
+/// re-attribute a settled payout after the fact without producing a different
+/// hash, which breaks the lineage edge that committed to it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Attribution {
+    /// SPIFFE id of the workload that earned this payout.
+    pub workload_spiffe_id: String,
+    /// The workload's attestation assurance level, as
+    /// `nucleus_identity::AssuranceLevel` discriminant (0 = bearer, 1 =
+    /// software, 2 = device, 3 = measured boot).
+    ///
+    /// Self-claimed, exactly as `MediationReceipt.signer_assurance` is. A
+    /// relying party that cares must compare it against a `VerifiedAttestation`
+    /// derived independently; a receipt claiming L3 proves nothing on its own.
+    pub assurance: u8,
+    /// Content hash of the offer that was surfaced, hex SHA-256.
+    pub offer_hash_hex: String,
+    /// Content hash of the disclosure record for that offer, hex SHA-256.
+    ///
+    /// Empty for a payout with no sponsored component. When non-empty it binds
+    /// the payout to the disclosure that accompanied it, so "was this sponsored
+    /// placement disclosed?" is answerable from the receipt alone rather than
+    /// from the operator's word.
+    pub disclosure_hash_hex: String,
+}
+
+/// A payout claim: the clearing being distributed, the declared shares, and the
+/// claimed per-payee allocations.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PayoutClaim {
+    /// Declared input: the clearing whose proceeds are being split. The pool is
+    /// derived from this, never declared on its own.
+    pub clearing: ClearingReceipt,
+    /// Declared input: the payees and their basis-point shares (must sum to
+    /// 10 000 — `route_to_commons` rejects anything else, so a skimmed split
+    /// cannot produce a standing receipt).
+    pub shares: Vec<CommonsShare>,
+    /// Declared input: who earned it, and on what evidence.
+    pub attribution: Attribution,
+    /// Claimed output: the per-payee amounts.
+    pub allocations: Vec<CommonsAllocation>,
+}
+
+/// The pool a clearing makes available to split.
+///
+/// A settlement's distributable proceeds are the seller's gross — the buyer's
+/// refund is not the marketplace's to allocate. `Commons` and `Vcg` clearings
+/// are not distributable pools in this sense and are rejected rather than
+/// guessed at: a `Commons` receipt is *already* a routing (splitting it again
+/// would double-route), and a `Vcg` clearing settles per-winner payments rather
+/// than producing one pool.
+fn pool_of(clearing: &ClearingReceipt) -> Result<u64, String> {
+    match clearing {
+        ClearingReceipt::Settlement(c) => Ok(seller_gross(c.price_micro, c.delivered_bps)),
+        ClearingReceipt::Commons(_) => {
+            Err("a commons receipt is already a routing; splitting it again would double-route"
+                .to_string())
+        }
+        ClearingReceipt::Vcg(_) => {
+            Err("a VCG clearing settles per-winner payments, not one distributable pool"
+                .to_string())
+        }
+    }
+}
+
+/// Re-derive a payout's claimed split from its declared inputs and compare.
+///
+/// Two stages, in this order:
+///
+/// 1. the underlying clearing must recompute — a payout over a fabricated price
+///    fails here, before the split is examined;
+/// 2. the pool is derived from that clearing and `route_to_commons` must
+///    reproduce the claimed allocations exactly.
+///
+/// [`RecomputeOutcome::Match`] iff both hold.
+pub fn verify_payout(payout: &PayoutClaim) -> RecomputeOutcome {
+    // Stage 1. The pool has to be real before the split can be honest.
+    match verify_receipt(&payout.clearing) {
+        RecomputeOutcome::Match => {}
+        other => return other,
+    }
+
+    let pool = match pool_of(&payout.clearing) {
+        Ok(p) => p,
+        Err(e) => return RecomputeOutcome::Invalid(e),
+    };
+
+    // Stage 2. The split is `route_to_commons`, whose conservation is proven.
+    match route_to_commons(pool, &payout.shares) {
+        Ok(allocs) => {
+            if allocs == payout.allocations {
+                RecomputeOutcome::Match
+            } else {
+                mismatch("allocations", &payout.allocations, &allocs)
+            }
+        }
+        Err(e) => RecomputeOutcome::Invalid(e.to_string()),
+    }
+}
+
+/// Issue a payout by running the proven kernels on the declared inputs — the
+/// producer dual of [`verify_payout`].
+///
+/// Honest by construction: the allocations are not supplied by the caller, they
+/// are computed. Errors if the clearing is not a distributable pool or if the
+/// shares are ill-formed, so a malformed split cannot produce a standing receipt.
+pub fn issue_payout(
+    clearing: ClearingReceipt,
+    shares: Vec<CommonsShare>,
+    attribution: Attribution,
+) -> Result<PayoutClaim, PayoutError> {
+    let pool = pool_of(&clearing).map_err(PayoutError::NotDistributable)?;
+    let allocations = route_to_commons(pool, &shares)?;
+    Ok(PayoutClaim {
+        clearing,
+        shares,
+        attribution,
+        allocations,
+    })
+}
+
+/// Why a payout could not be issued.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum PayoutError {
+    /// The clearing does not yield a single distributable pool.
+    #[error("clearing is not a distributable pool: {0}")]
+    NotDistributable(String),
+    /// The declared shares were rejected by the proven routing kernel.
+    #[error(transparent)]
+    Shares(#[from] CommonsError),
+}
+
+/// Canonical, domain-tagged bytes for a payout. Deterministic: the payout types
+/// contain no maps, so serde's field/element order is stable.
+pub fn payout_canonical_bytes(payout: &PayoutClaim) -> Vec<u8> {
+    let mut out = Vec::with_capacity(PAYOUT_DOMAIN.len() + 512);
+    out.extend_from_slice(PAYOUT_DOMAIN);
+    // Infallible for these concrete, map-free types.
+    serde_json::to_writer(&mut out, payout).expect("payout serialization is infallible");
+    out
+}
+
+/// `sha256` over [`payout_canonical_bytes`], hex-encoded — the value a
+/// `nucleus-lineage` `Settlement` or `Allocation` edge's `content_hash_hex`
+/// carries for a payout.
+///
+/// The domain separator differs from the clearing's, so a clearing receipt and a
+/// payout over it can never collide in a content-addressed store even when the
+/// payout embeds that exact clearing.
+pub fn payout_content_hash_hex(payout: &PayoutClaim) -> String {
+    let mut h = Sha256::new();
+    h.update(payout_canonical_bytes(payout));
+    hex::encode(h.finalize())
+}
+
+#[cfg(test)]
+pub(crate) mod tests_support {
+    use super::*;
+
+    pub(crate) fn attribution() -> Attribution {
+        Attribution {
+            workload_spiffe_id: "spiffe://nucleus.local/runtime/acme".into(),
+            assurance: 1,
+            offer_hash_hex: "a".repeat(64),
+            disclosure_hash_hex: "b".repeat(64),
+        }
+    }
+
+    pub(crate) fn shares() -> Vec<CommonsShare> {
+        vec![
+            CommonsShare {
+                destination: "spiffe://nucleus.local/runtime/acme".into(),
+                bps: 3_000,
+            },
+            CommonsShare {
+                destination: "spiffe://vendor.example/seller".into(),
+                bps: 6_500,
+            },
+            CommonsShare {
+                destination: "commons".into(),
+                bps: 500,
+            },
+        ]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::tests_support::*;
+    use super::*;
+    use crate::issue_settlement;
+
+    /// The happy path, and the shape the whole design rests on: a third party
+    /// with nothing but the receipt re-derives every payee's amount.
+    #[test]
+    fn an_issued_payout_reverifies() {
+        let clearing = issue_settlement(1_000_000, 10_000);
+        let payout = issue_payout(clearing, shares(), attribution()).expect("well-formed");
+
+        assert_eq!(verify_payout(&payout), RecomputeOutcome::Match);
+        // Conservation: full delivery means the whole price is distributed.
+        let total: u64 = payout.allocations.iter().map(|a| a.amount_micro).sum();
+        assert_eq!(total, 1_000_000, "routed_conserves — nothing skimmed");
+    }
+
+    /// THE BITE. Tamper with one payee's amount; recomputation must diverge.
+    /// A payout ledger nobody has watched fail is a promise, not a proof.
+    #[test]
+    fn tampering_with_one_allocation_is_caught() {
+        let clearing = issue_settlement(1_000_000, 10_000);
+        let mut payout = issue_payout(clearing, shares(), attribution()).expect("well-formed");
+
+        payout.allocations[0].amount_micro += 1;
+
+        match verify_payout(&payout) {
+            RecomputeOutcome::Mismatch { field, .. } => assert_eq!(field, "allocations"),
+            other => panic!("a skimmed payout must not verify, got {other:?}"),
+        }
+    }
+
+    /// Stage 1 is load-bearing. If the payout could declare its own pool, the
+    /// split would be honest and the number arbitrary — so a payout whose
+    /// underlying clearing lies must fail BEFORE the split is examined.
+    #[test]
+    fn a_payout_over_a_fabricated_clearing_fails_on_the_clearing() {
+        let ClearingReceipt::Settlement(mut claim) = issue_settlement(1_000_000, 10_000) else {
+            panic!("issue_settlement returns a settlement");
+        };
+        // Claim the seller earned more than the proven kernel allows.
+        claim.seller_gross += 500_000;
+        let lying = ClearingReceipt::Settlement(claim);
+
+        // Build the payout by hand — `issue_payout` would recompute honestly.
+        let payout = PayoutClaim {
+            clearing: lying,
+            shares: shares(),
+            attribution: attribution(),
+            allocations: vec![],
+        };
+
+        match verify_payout(&payout) {
+            RecomputeOutcome::Mismatch { field, .. } => {
+                assert_eq!(field, "seller_gross", "must fail on the CLEARING, not the split");
+            }
+            other => panic!("a fabricated pool must not verify, got {other:?}"),
+        }
+    }
+
+    /// A partial delivery splits the seller's gross, not the full price: the
+    /// buyer's refund is not the marketplace's to allocate.
+    #[test]
+    fn the_pool_is_the_sellers_gross_not_the_price() {
+        let clearing = issue_settlement(1_000_000, 5_000); // 50% delivered
+        let payout = issue_payout(clearing, shares(), attribution()).expect("well-formed");
+
+        let total: u64 = payout.allocations.iter().map(|a| a.amount_micro).sum();
+        assert_eq!(total, 500_000, "only the seller's gross is distributable");
+        assert_eq!(verify_payout(&payout), RecomputeOutcome::Match);
+    }
+
+    /// Shares that do not sum to 10 000 bps would skim or over-allocate. The
+    /// proven kernel rejects them, so no standing receipt can be issued.
+    #[test]
+    fn a_skimming_share_set_cannot_be_issued() {
+        let clearing = issue_settlement(1_000_000, 10_000);
+        let skimming = vec![CommonsShare {
+            destination: "operator".into(),
+            bps: 9_000, // 1000 bps unaccounted for
+        }];
+
+        match issue_payout(clearing, skimming, attribution()) {
+            Err(PayoutError::Shares(CommonsError::SharesMustSumTo10000 { got })) => {
+                assert_eq!(got, 9_000);
+            }
+            other => panic!("a skimming split must not issue, got {other:?}"),
+        }
+    }
+
+    /// Re-splitting a commons routing would double-route. Rejected, not guessed.
+    #[test]
+    fn a_commons_receipt_is_not_a_distributable_pool() {
+        let commons = crate::issue_commons(
+            1_000_000,
+            vec![CommonsShare {
+                destination: "d".into(),
+                bps: 10_000,
+            }],
+        )
+        .expect("well-formed");
+
+        assert!(matches!(
+            issue_payout(commons, shares(), attribution()),
+            Err(PayoutError::NotDistributable(_))
+        ));
+    }
+
+    /// The attribution is bound by the hash even though it is not verified here.
+    /// Re-attributing a settled payout must produce a different hash, which
+    /// breaks any lineage edge that committed to the original.
+    #[test]
+    fn re_attributing_a_payout_changes_its_content_hash() {
+        let clearing = issue_settlement(1_000_000, 10_000);
+        let payout = issue_payout(clearing.clone(), shares(), attribution()).expect("ok");
+
+        let mut stolen = attribution();
+        stolen.workload_spiffe_id = "spiffe://nucleus.local/runtime/thief".into();
+        let reattributed = issue_payout(clearing, shares(), stolen).expect("ok");
+
+        assert_ne!(
+            payout_content_hash_hex(&payout),
+            payout_content_hash_hex(&reattributed),
+            "attribution must be inside the commitment"
+        );
+        // ...and both still recompute: binding is not verification, and the
+        // docs must not claim otherwise.
+        assert_eq!(verify_payout(&reattributed), RecomputeOutcome::Match);
+    }
+
+    /// A payout and the clearing it distributes must never collide in a
+    /// content-addressed store, even though the payout embeds that clearing.
+    #[test]
+    fn payout_and_clearing_hashes_are_domain_separated() {
+        let clearing = issue_settlement(1_000_000, 10_000);
+        let payout = issue_payout(clearing.clone(), shares(), attribution()).expect("ok");
+
+        assert_ne!(
+            crate::content_hash_hex(&clearing),
+            payout_content_hash_hex(&payout)
+        );
+    }
+}
+
+/// Travel a payout as a signed receipt (feature `envelope`).
+///
+/// A [`PayoutClaim`] on its own is *unsigned*: verification is pure
+/// recomputation, so it says "this split re-derives" but not "who claimed it".
+/// This module wires it into `nucleus-receipt`'s Ed25519 envelope so one object
+/// carries both guarantees — signature (who) and recompute (the numbers).
+///
+/// ## Wire shape (stable)
+///
+/// A payout rides in `Projection::Economic` under a *different inner
+/// discriminant* from a clearing:
+///
+/// ```json
+/// { "kind": "payout", "payout": { "clearing": {...}, "shares": [...], ... } }
+/// ```
+///
+/// This deliberately uses the extension point the economic projection already
+/// documents — the inner `kind` exists precisely "so other economic bodies can
+/// coexist under the same projection kind". Adding a new `Projection` variant
+/// would have been a wider change to a sealed sum for no additional guarantee.
+#[cfg(feature = "envelope")]
+pub mod envelope {
+    use super::{verify_payout, PayoutClaim};
+    use nucleus_receipt::Projection;
+
+    /// The inner discriminant for a payout body inside `Projection::Economic`.
+    pub const ECONOMIC_PAYOUT_KIND: &str = "payout";
+
+    /// Why a projection could not be narrowed to a [`PayoutClaim`].
+    #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+    pub enum PayoutNarrowError {
+        /// The projection is not `Projection::Economic` at all.
+        #[error("projection kind is `{found}`, expected `economic`")]
+        NotEconomic {
+            /// The wire discriminant of the projection supplied.
+            found: &'static str,
+        },
+        /// The economic body's inner `kind` is not `"payout"`.
+        #[error("economic body kind is `{found}`, expected `payout`")]
+        NotPayout {
+            /// The inner `kind` found, or `<missing>`.
+            found: String,
+        },
+        /// The body claimed to be a payout but does not deserialize as one.
+        #[error("economic payout body is malformed: {0}")]
+        MalformedBody(String),
+    }
+
+    /// Lift a [`PayoutClaim`] into a `Projection::Economic` body.
+    pub fn to_payout_projection(payout: &PayoutClaim) -> Projection {
+        Projection::Economic(serde_json::json!({
+            "kind": ECONOMIC_PAYOUT_KIND,
+            "payout": payout,
+        }))
+    }
+
+    /// Narrow a [`Projection`] back to a typed [`PayoutClaim`].
+    ///
+    /// Narrowing verifies nothing: verify the envelope signature first, and
+    /// [`verify_payout`] the narrowed value after.
+    pub fn payout_from_projection(
+        projection: &Projection,
+    ) -> Result<PayoutClaim, PayoutNarrowError> {
+        let Projection::Economic(body) = projection else {
+            return Err(PayoutNarrowError::NotEconomic {
+                found: projection.kind(),
+            });
+        };
+        match body.get("kind").and_then(serde_json::Value::as_str) {
+            Some(ECONOMIC_PAYOUT_KIND) => {}
+            Some(other) => {
+                return Err(PayoutNarrowError::NotPayout {
+                    found: other.to_string(),
+                })
+            }
+            None => {
+                return Err(PayoutNarrowError::NotPayout {
+                    found: "<missing>".to_string(),
+                })
+            }
+        }
+        let payout = body
+            .get("payout")
+            .ok_or_else(|| PayoutNarrowError::MalformedBody("missing `payout` field".to_string()))?;
+        serde_json::from_value(payout.clone())
+            .map_err(|e| PayoutNarrowError::MalformedBody(e.to_string()))
+    }
+
+    /// The verdict from checking a signed payout.
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub enum SignedPayoutVerdict {
+        /// The Ed25519 signature did not verify — checked FIRST, before any
+        /// recompute. A forged envelope never reaches the kernels.
+        BadSignature,
+        /// Signature verified, but the projection is not a narrowable payout.
+        Malformed(PayoutNarrowError),
+        /// Signature verified + narrowed; the recompute outcome. Fully verified
+        /// iff this is [`RecomputeOutcome::Match`](crate::RecomputeOutcome::Match).
+        Recomputed(crate::RecomputeOutcome),
+    }
+
+    /// Verify a signed payout end to end: signature, then recompute.
+    ///
+    /// This is the function that makes the revenue share trustless. A runtime
+    /// operator can sign whatever it likes; a signature-valid payout claiming a
+    /// share the proven kernels do not produce still comes back
+    /// `Recomputed(Mismatch)`. That is precisely what a signature-only verifier
+    /// cannot catch, and it is why the payee never has to trust the payer.
+    pub fn verify_signed_payout(
+        signed: &nucleus_receipt::Receipt,
+        verifying_key_bytes: &[u8; 32],
+    ) -> SignedPayoutVerdict {
+        if signed.verify(verifying_key_bytes).is_err() {
+            return SignedPayoutVerdict::BadSignature;
+        }
+        match signed.projections.first() {
+            Some(p) => match payout_from_projection(p) {
+                Ok(payout) => SignedPayoutVerdict::Recomputed(verify_payout(&payout)),
+                Err(e) => SignedPayoutVerdict::Malformed(e),
+            },
+            None => SignedPayoutVerdict::Malformed(PayoutNarrowError::NotEconomic {
+                found: "none",
+            }),
+        }
+    }
+}
+
+#[cfg(all(test, feature = "envelope"))]
+mod envelope_tests {
+    use super::envelope::*;
+    use super::tests_support::*;
+    use super::*;
+    use crate::RecomputeOutcome;
+    use ed25519_dalek::SigningKey;
+    use nucleus_receipt::{Receipt, Session};
+
+    fn session() -> Session {
+        Session {
+            session_id: "spiffe://nucleus.local/runtime/acme".into(),
+            issuer_kid: "acme-kid".into(),
+            issued_at_micros: 1_717_000_000_000_000,
+            parent_chain: vec![],
+        }
+    }
+
+    /// The full round trip a third party actually runs: sign, ship, verify the
+    /// signature, narrow, recompute.
+    #[test]
+    fn a_signed_payout_round_trips_and_recomputes() {
+        let sk = SigningKey::from_bytes(&[11u8; 32]);
+        let payout = issue_payout(
+            crate::issue_settlement(1_000_000, 10_000),
+            shares(),
+            attribution(),
+        )
+        .expect("well-formed");
+
+        let signed = Receipt::sign(session(), vec![to_payout_projection(&payout)], &sk);
+        let vk = sk.verifying_key().to_bytes();
+
+        assert_eq!(
+            verify_signed_payout(&signed, &vk),
+            SignedPayoutVerdict::Recomputed(RecomputeOutcome::Match)
+        );
+        assert_eq!(payout_from_projection(&signed.projections[0]).unwrap(), payout);
+    }
+
+    /// **The load-bearing test for the whole revenue-share design.** The operator
+    /// signs honestly — the signature verifies — but claims a share the proven
+    /// kernels do not produce. A signature-only verifier accepts this. Recompute
+    /// must not.
+    #[test]
+    fn a_validly_signed_but_skimmed_payout_is_rejected() {
+        let sk = SigningKey::from_bytes(&[12u8; 32]);
+        let mut payout = issue_payout(
+            crate::issue_settlement(1_000_000, 10_000),
+            shares(),
+            attribution(),
+        )
+        .expect("well-formed");
+
+        // The operator quietly moves 1 micro-USD from the commons to itself.
+        payout.allocations[0].amount_micro += 1;
+        payout.allocations[2].amount_micro -= 1;
+
+        let signed = Receipt::sign(session(), vec![to_payout_projection(&payout)], &sk);
+        let vk = sk.verifying_key().to_bytes();
+
+        // The signature is genuinely good — this is not a forgery test.
+        assert!(signed.verify(&vk).is_ok(), "the envelope really is signed");
+
+        match verify_signed_payout(&signed, &vk) {
+            SignedPayoutVerdict::Recomputed(RecomputeOutcome::Mismatch { field, .. }) => {
+                assert_eq!(field, "allocations");
+            }
+            other => panic!("a skimmed payout must not verify, got {other:?}"),
+        }
+    }
+
+    /// Signature is checked before recompute, so a tampered envelope never
+    /// reaches the kernels.
+    #[test]
+    fn a_wrong_key_fails_before_recompute() {
+        let sk = SigningKey::from_bytes(&[13u8; 32]);
+        let other = SigningKey::from_bytes(&[14u8; 32]);
+        let payout = issue_payout(
+            crate::issue_settlement(1_000_000, 10_000),
+            shares(),
+            attribution(),
+        )
+        .expect("well-formed");
+        let signed = Receipt::sign(session(), vec![to_payout_projection(&payout)], &sk);
+
+        assert_eq!(
+            verify_signed_payout(&signed, &other.verifying_key().to_bytes()),
+            SignedPayoutVerdict::BadSignature
+        );
+    }
+
+    /// A clearing and a payout share the `Economic` projection but not the inner
+    /// discriminant, so neither can be narrowed as the other.
+    #[test]
+    fn a_clearing_projection_is_not_narrowable_as_a_payout() {
+        let clearing = crate::issue_settlement(1_000_000, 10_000);
+        let projection = crate::envelope::to_economic_projection(&clearing);
+
+        match payout_from_projection(&projection) {
+            Err(PayoutNarrowError::NotPayout { found }) => assert_eq!(found, "clearing"),
+            other => panic!("expected NotPayout, got {other:?}"),
+        }
+    }
+}

--- a/crates/nucleus-recompute/src/payout.rs
+++ b/crates/nucleus-recompute/src/payout.rs
@@ -122,14 +122,13 @@ pub struct PayoutClaim {
 fn pool_of(clearing: &ClearingReceipt) -> Result<u64, String> {
     match clearing {
         ClearingReceipt::Settlement(c) => Ok(seller_gross(c.price_micro, c.delivered_bps)),
-        ClearingReceipt::Commons(_) => {
-            Err("a commons receipt is already a routing; splitting it again would double-route"
-                .to_string())
-        }
-        ClearingReceipt::Vcg(_) => {
-            Err("a VCG clearing settles per-winner payments, not one distributable pool"
-                .to_string())
-        }
+        ClearingReceipt::Commons(_) => Err(
+            "a commons receipt is already a routing; splitting it again would double-route"
+                .to_string(),
+        ),
+        ClearingReceipt::Vcg(_) => Err(
+            "a VCG clearing settles per-winner payments, not one distributable pool".to_string(),
+        ),
     }
 }
 
@@ -310,7 +309,10 @@ mod tests {
 
         match verify_payout(&payout) {
             RecomputeOutcome::Mismatch { field, .. } => {
-                assert_eq!(field, "seller_gross", "must fail on the CLEARING, not the split");
+                assert_eq!(
+                    field, "seller_gross",
+                    "must fail on the CLEARING, not the split"
+                );
             }
             other => panic!("a fabricated pool must not verify, got {other:?}"),
         }
@@ -481,9 +483,9 @@ pub mod envelope {
                 })
             }
         }
-        let payout = body
-            .get("payout")
-            .ok_or_else(|| PayoutNarrowError::MalformedBody("missing `payout` field".to_string()))?;
+        let payout = body.get("payout").ok_or_else(|| {
+            PayoutNarrowError::MalformedBody("missing `payout` field".to_string())
+        })?;
         serde_json::from_value(payout.clone())
             .map_err(|e| PayoutNarrowError::MalformedBody(e.to_string()))
     }
@@ -520,9 +522,9 @@ pub mod envelope {
                 Ok(payout) => SignedPayoutVerdict::Recomputed(verify_payout(&payout)),
                 Err(e) => SignedPayoutVerdict::Malformed(e),
             },
-            None => SignedPayoutVerdict::Malformed(PayoutNarrowError::NotEconomic {
-                found: "none",
-            }),
+            None => {
+                SignedPayoutVerdict::Malformed(PayoutNarrowError::NotEconomic { found: "none" })
+            }
         }
     }
 }
@@ -564,7 +566,10 @@ mod envelope_tests {
             verify_signed_payout(&signed, &vk),
             SignedPayoutVerdict::Recomputed(RecomputeOutcome::Match)
         );
-        assert_eq!(payout_from_projection(&signed.projections[0]).unwrap(), payout);
+        assert_eq!(
+            payout_from_projection(&signed.projections[0]).unwrap(),
+            payout
+        );
     }
 
     /// **The load-bearing test for the whole revenue-share design.** The operator

--- a/crates/nucleus-verifier-service/src/app.rs
+++ b/crates/nucleus-verifier-service/src/app.rs
@@ -174,6 +174,9 @@ pub fn build_app(state: AppState) -> Router {
         .route("/healthz", get(routes::healthz))
         .route("/v1/verify", post(routes::verify))
         .route("/v1/clearing/verify", post(routes::clearing_verify))
+        // The payout dual: a payee recomputes its own share rather than
+        // trusting the operator's ledger.
+        .route("/v1/payout/verify", post(routes::payout_verify))
         .route("/v1/credit", post(routes::credit))
         // Stateful credit ledger (503 unless --credit-db is set). `accrue`
         // appends an agent's recompute-verified events to its durable,

--- a/crates/nucleus-verifier-service/src/routes.rs
+++ b/crates/nucleus-verifier-service/src/routes.rs
@@ -367,6 +367,75 @@ pub async fn clearing_verify(
     Ok(Json(ClearingVerifyResponse { verified, verdict }))
 }
 
+/// `POST /v1/payout/verify` request: a signed payout envelope + the issuer's key.
+#[derive(Debug, Deserialize)]
+pub struct PayoutVerifyRequest {
+    /// The signed `nucleus_receipt::Receipt` carrying a payout projection
+    /// (`nucleus_recompute::payout::envelope::to_payout_projection` + `Receipt::sign`).
+    pub receipt: nucleus_receipt::Receipt,
+    /// 32-byte Ed25519 verifying key of the issuer, hex-encoded (no `0x`).
+    pub verifying_key_hex: String,
+}
+
+/// `POST /v1/payout/verify` response: signature + recompute collapsed to one verdict.
+#[derive(Debug, Serialize)]
+pub struct PayoutVerifyResponse {
+    /// `true` iff the signature verified AND the split re-derives from the
+    /// proven kernels.
+    pub verified: bool,
+    /// Machine verdict: `verified` | `bad_signature` | `malformed:<e>` |
+    /// `mismatch:<field>` | `invalid:<e>`.
+    pub verdict: String,
+}
+
+/// `POST /v1/payout/verify` — the public recompute verifier for signed payouts.
+///
+/// This is the endpoint that makes a revenue share trustless. A payee does not
+/// have to trust the operator's ledger: it takes the signed payout, checks the
+/// Ed25519 signature, then RECOMPUTES its own share from the declared inputs via
+/// the proven kernels. A signature-valid payout claiming a split the kernels do
+/// not produce is rejected (`mismatch:allocations`) — exactly what a
+/// signature-only verifier cannot catch.
+///
+/// Two stages run inside, in order: the underlying clearing must itself
+/// re-derive (a payout over a fabricated price fails here), then the split must
+/// match `route_to_commons`, whose conservation is proven in `Commons.lean`.
+///
+/// HONEST SCOPE: this verifies the split is the proven function of the
+/// **declared** inputs. It does not verify the payout's `attribution` — that a
+/// given workload surfaced a given offer is bound into the signed content hash
+/// so it cannot be altered afterwards, but proving it requires checking the
+/// workload's SPIFFE attestation independently.
+pub async fn payout_verify(
+    State(_state): State<AppState>,
+    Json(req): Json<PayoutVerifyRequest>,
+) -> Result<Json<PayoutVerifyResponse>, VerifyApiError> {
+    use nucleus_recompute::payout::envelope::{verify_signed_payout, SignedPayoutVerdict};
+    use nucleus_recompute::RecomputeOutcome;
+
+    let bytes = hex::decode(req.verifying_key_hex.trim().trim_start_matches("0x"))
+        .map_err(|e| VerifyApiError::BadRequest(format!("verifying_key_hex invalid: {e}")))?;
+    let vk: [u8; 32] = bytes.try_into().map_err(|b: Vec<u8>| {
+        VerifyApiError::BadRequest(format!(
+            "verifying_key_hex must decode to 32 bytes, got {}",
+            b.len()
+        ))
+    })?;
+
+    let (verified, verdict) = match verify_signed_payout(&req.receipt, &vk) {
+        SignedPayoutVerdict::Recomputed(RecomputeOutcome::Match) => (true, "verified".to_string()),
+        SignedPayoutVerdict::Recomputed(RecomputeOutcome::Mismatch { field, .. }) => {
+            (false, format!("mismatch:{field}"))
+        }
+        SignedPayoutVerdict::Recomputed(RecomputeOutcome::Invalid(m)) => {
+            (false, format!("invalid:{m}"))
+        }
+        SignedPayoutVerdict::BadSignature => (false, "bad_signature".to_string()),
+        SignedPayoutVerdict::Malformed(e) => (false, format!("malformed:{e}")),
+    };
+    Ok(Json(PayoutVerifyResponse { verified, verdict }))
+}
+
 /// `POST /v1/verify` — run [`verify_bundle`] against the caller-supplied
 /// trust anchor.
 ///

--- a/crates/nucleus-verifier-service/tests/integration.rs
+++ b/crates/nucleus-verifier-service/tests/integration.rs
@@ -1646,3 +1646,108 @@ async fn clearing_verify_recomputes_and_catches_forgery_under_valid_signature() 
     assert_eq!(body["verified"], false, "forged clearing must be rejected");
     assert_eq!(body["verdict"], "mismatch:seller_gross");
 }
+
+/// S1 e2e: the public payout verifier endpoint — the one that makes a revenue
+/// share trustless. A payee POSTs the payout it was sent and learns whether its
+/// own share is what the proven kernels produce, without trusting the operator.
+///
+/// Both directions are exercised: an honest payout verifies, and a payout whose
+/// signature is genuinely valid but whose split has been skimmed is rejected.
+/// The second is the case a signature-only verifier cannot catch.
+#[tokio::test]
+async fn payout_verify_endpoint_verifies_honest_and_rejects_a_skim() {
+    use ed25519_dalek::SigningKey;
+    use nucleus_econ_kernels::commons::CommonsShare;
+    use nucleus_receipt::{Receipt, Session};
+    use nucleus_recompute::issue_settlement;
+    use nucleus_recompute::payout::{envelope::to_payout_projection, issue_payout, Attribution};
+
+    let sk = SigningKey::from_bytes(&[9u8; 32]);
+    let vk_hex = hex::encode(sk.verifying_key().to_bytes());
+    let session = || Session {
+        session_id: "spiffe://test/payout".into(),
+        issuer_kid: "test-kid".into(),
+        issued_at_micros: 1_717_000_000_000_000,
+        parent_chain: vec![],
+    };
+    let attribution = || Attribution {
+        workload_spiffe_id: "spiffe://nucleus.local/runtime/acme".into(),
+        assurance: 1,
+        offer_hash_hex: "a".repeat(64),
+        disclosure_hash_hex: "b".repeat(64),
+    };
+    let shares = || {
+        vec![
+            CommonsShare {
+                destination: "runtime".into(),
+                bps: 3_000,
+            },
+            CommonsShare {
+                destination: "seller".into(),
+                bps: 6_500,
+            },
+            CommonsShare {
+                destination: "commons".into(),
+                bps: 500,
+            },
+        ]
+    };
+
+    async fn post_payout(receipt: &Receipt, vk_hex: &str) -> Value {
+        let resp = build_app(AppState::default())
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/v1/payout/verify")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        serde_json::to_vec(
+                            &json!({"receipt": receipt, "verifying_key_hex": vk_hex}),
+                        )
+                        .unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        read_json(resp.into_body()).await
+    }
+
+    // Honest payout → verified.
+    let honest = issue_payout(issue_settlement(1_000_000, 10_000), shares(), attribution())
+        .expect("well-formed");
+    let signed = Receipt::sign(session(), vec![to_payout_projection(&honest)], &sk);
+    let body = post_payout(&signed, &vk_hex).await;
+    assert_eq!(body["verified"], true, "honest payout must verify: {body}");
+    assert_eq!(body["verdict"], "verified");
+
+    // Skimmed split under a VALID signature → rejected by recompute.
+    let mut skimmed = issue_payout(issue_settlement(1_000_000, 10_000), shares(), attribution())
+        .expect("well-formed");
+    skimmed.allocations[0].amount_micro += 1; // to the runtime
+    skimmed.allocations[2].amount_micro -= 1; // from the commons
+    let signed_skimmed = Receipt::sign(session(), vec![to_payout_projection(&skimmed)], &sk);
+    let body = post_payout(&signed_skimmed, &vk_hex).await;
+    assert_eq!(body["verified"], false, "a skimmed payout must be rejected");
+    assert_eq!(body["verdict"], "mismatch:allocations");
+
+    // A payout over a fabricated clearing fails on the CLEARING, not the split —
+    // the pool has to be real before the split can be honest.
+    let nucleus_recompute::ClearingReceipt::Settlement(mut claim) =
+        issue_settlement(1_000_000, 10_000)
+    else {
+        unreachable!()
+    };
+    claim.seller_gross += 500_000;
+    let lying = nucleus_recompute::payout::PayoutClaim {
+        clearing: nucleus_recompute::ClearingReceipt::Settlement(claim),
+        shares: shares(),
+        attribution: attribution(),
+        allocations: vec![],
+    };
+    let signed_lying = Receipt::sign(session(), vec![to_payout_projection(&lying)], &sk);
+    let body = post_payout(&signed_lying, &vk_hex).await;
+    assert_eq!(body["verified"], false);
+    assert_eq!(body["verdict"], "mismatch:seller_gross");
+}

--- a/scripts/exemplar-baseline.json
+++ b/scripts/exemplar-baseline.json
@@ -6,7 +6,7 @@
     "lean_theorems_GUARD": 891, "clean_axiom_footprint": "n/a"
   },
   "rust_craft": {
-    "permissive_verify": 22, "verify_calls_GUARD": 51,
+    "permissive_verify": 24, "verify_calls_GUARD": 53,
     "unsafe_blocks": 6,
     "crates_total": 67, "crates_lints_workspace": 41,
     "lints_adoption_pct": 61

--- a/sdks/verifier-js/src/lib.rs
+++ b/sdks/verifier-js/src/lib.rs
@@ -321,6 +321,63 @@ pub fn verify_signed_clearing_js(
     serde_wasm_bindgen::to_value(&report).map_err(|e| JsError::new(&e.to_string()))
 }
 
+/// Structured result of [`verify_signed_payout_js`].
+#[derive(serde::Serialize)]
+struct SignedPayoutReport {
+    /// `true` iff the signature verified AND the split re-derives from the
+    /// proven kernels.
+    verified: bool,
+    /// `verified` | `bad_signature` | `malformed:<e>` | `mismatch:<field>` | `invalid:<e>`.
+    verdict: String,
+}
+
+/// Core (natively testable) of [`verify_signed_payout_js`].
+fn signed_payout_verdict(
+    receipt_json: &str,
+    verifying_key_bytes: &[u8],
+) -> Result<SignedPayoutReport, String> {
+    use nucleus_recompute::payout::envelope::{verify_signed_payout, SignedPayoutVerdict};
+    use nucleus_recompute::RecomputeOutcome;
+
+    let receipt: nucleus_receipt::Receipt =
+        serde_json::from_str(receipt_json).map_err(|e| format!("receipt JSON: {e}"))?;
+    let vk: [u8; 32] = verifying_key_bytes
+        .try_into()
+        .map_err(|_| "verifying key must be 32 bytes".to_string())?;
+    let (verified, verdict) = match verify_signed_payout(&receipt, &vk) {
+        SignedPayoutVerdict::Recomputed(RecomputeOutcome::Match) => (true, "verified".to_string()),
+        SignedPayoutVerdict::Recomputed(RecomputeOutcome::Mismatch { field, .. }) => {
+            (false, format!("mismatch:{field}"))
+        }
+        SignedPayoutVerdict::Recomputed(RecomputeOutcome::Invalid(m)) => {
+            (false, format!("invalid:{m}"))
+        }
+        SignedPayoutVerdict::BadSignature => (false, "bad_signature".to_string()),
+        SignedPayoutVerdict::Malformed(e) => (false, format!("malformed:{e}")),
+    };
+    Ok(SignedPayoutReport { verified, verdict })
+}
+
+/// Verify a SIGNED PAYOUT in the browser: the Ed25519 signature, then a
+/// RECOMPUTE of the revenue split via the proven kernels.
+///
+/// This is the function that makes a revenue share trustless. A payee pastes the
+/// payout it was sent and recomputes its own share client-side — no server, no
+/// operator ledger to trust. An operator that signs a skimmed split still gets
+/// `mismatch:allocations`, which is exactly what a signature-only check misses.
+///
+/// Returns `{ verified, verdict }`.
+#[wasm_bindgen(js_name = verifySignedPayout)]
+pub fn verify_signed_payout_js(
+    receipt_json: &str,
+    verifying_key_bytes: &[u8],
+) -> Result<JsValue, JsError> {
+    set_panic_hook();
+    let report =
+        signed_payout_verdict(receipt_json, verifying_key_bytes).map_err(|e| JsError::new(&e))?;
+    serde_wasm_bindgen::to_value(&report).map_err(|e| JsError::new(&e.to_string()))
+}
+
 // ── AGENT CARD: verify the counterparty's signed identity BEFORE acting ───────
 //
 // `verifyBundle` answers WHAT happened (provenance), `verifyReceipt` answers
@@ -1031,6 +1088,69 @@ mod receipt_tests {
         let r = signed_clearing_verdict(&serde_json::to_string(&forged).unwrap(), &vk).unwrap();
         assert!(!r.verified, "forged clearing must be rejected");
         assert_eq!(r.verdict, "mismatch:seller_gross");
+    }
+
+    /// The browser-side half of the revenue-share claim: a payee recomputes its
+    /// own share client-side, and an operator that signs a skimmed split is
+    /// caught even though the signature is genuinely valid.
+    #[test]
+    fn signed_payout_verifies_and_recompute_catches_a_skim() {
+        use nucleus_econ_kernels::commons::CommonsShare;
+        use nucleus_recompute::issue_settlement;
+        use nucleus_recompute::payout::{envelope::to_payout_projection, issue_payout, Attribution};
+
+        let session = || Session {
+            session_id: "spiffe://test/payout".into(),
+            issuer_kid: "test-kid".into(),
+            issued_at_micros: 1_717_000_000_000_000,
+            parent_chain: vec![],
+        };
+        let vk = signing_key().verifying_key().to_bytes();
+        let attribution = || Attribution {
+            workload_spiffe_id: "spiffe://test/runtime".into(),
+            assurance: 1,
+            offer_hash_hex: "a".repeat(64),
+            disclosure_hash_hex: String::new(),
+        };
+        let shares = || {
+            vec![
+                CommonsShare {
+                    destination: "runtime".into(),
+                    bps: 3_000,
+                },
+                CommonsShare {
+                    destination: "seller".into(),
+                    bps: 7_000,
+                },
+            ]
+        };
+
+        // Honest payout → verified (signature + recompute of the split).
+        let honest = issue_payout(issue_settlement(1_000_000, 10_000), shares(), attribution())
+            .expect("well-formed");
+        let signed = Receipt::sign(
+            session(),
+            vec![to_payout_projection(&honest)],
+            &signing_key(),
+        );
+        let r = signed_payout_verdict(&serde_json::to_string(&signed).unwrap(), &vk).unwrap();
+        assert!(r.verified, "honest payout must verify, got {}", r.verdict);
+
+        // The operator moves 1 micro-USD to itself, then signs. Signature is
+        // VALID; the split is not what the proven kernel produces.
+        let mut skimmed =
+            issue_payout(issue_settlement(1_000_000, 10_000), shares(), attribution())
+                .expect("well-formed");
+        skimmed.allocations[0].amount_micro += 1;
+        skimmed.allocations[1].amount_micro -= 1;
+        let signed = Receipt::sign(
+            session(),
+            vec![to_payout_projection(&skimmed)],
+            &signing_key(),
+        );
+        let r = signed_payout_verdict(&serde_json::to_string(&signed).unwrap(), &vk).unwrap();
+        assert!(!r.verified, "a skimmed payout must be rejected");
+        assert_eq!(r.verdict, "mismatch:allocations");
     }
 }
 

--- a/sdks/verifier-js/src/lib.rs
+++ b/sdks/verifier-js/src/lib.rs
@@ -292,7 +292,9 @@ fn signed_clearing_verdict(
         .try_into()
         .map_err(|_| "verifying key must be 32 bytes".to_string())?;
     let (verified, verdict) = match verify_signed_clearing(&receipt, &vk) {
-        SignedClearingVerdict::Recomputed(RecomputeOutcome::Match) => (true, "verified".to_string()),
+        SignedClearingVerdict::Recomputed(RecomputeOutcome::Match) => {
+            (true, "verified".to_string())
+        }
         SignedClearingVerdict::Recomputed(RecomputeOutcome::Mismatch { field, .. }) => {
             (false, format!("mismatch:{field}"))
         }
@@ -1097,7 +1099,9 @@ mod receipt_tests {
     fn signed_payout_verifies_and_recompute_catches_a_skim() {
         use nucleus_econ_kernels::commons::CommonsShare;
         use nucleus_recompute::issue_settlement;
-        use nucleus_recompute::payout::{envelope::to_payout_projection, issue_payout, Attribution};
+        use nucleus_recompute::payout::{
+            envelope::to_payout_projection, issue_payout, Attribution,
+        };
 
         let session = || Session {
             session_id: "spiffe://test/payout".into(),


### PR DESCRIPTION
## The receipt is the payout claim

Agent commerce standardised around **promises**. AdCP's own documentation puts attribution out of scope and defers it to third-party measurement; the research that builds verifiable agent receipts ([arXiv 2606.04193](https://arxiv.org/pdf/2606.04193)) names its own missing piece — *"adoption incentives: why services would implement receiver attestation."*

This answers that structurally: **a runtime emits verifiable evidence because that evidence is what its share is computed from.** There is no separate reporting channel to be honest on, and no operator ledger anyone has to trust.

## No new economics

A revenue split *is* a commons routing. `route_to_commons` is already the proven kernel — `Commons.lean`'s `routed_conserves`: a pool, basis-point shares that must sum to exactly 10 000, and a conservation theorem that the allocations neither skim nor over-allocate. Reusing it means the payout math **inherits a Lean proof** instead of acquiring a new trusted numeric path.

`verify_payout` is two stages, in this order:

1. the underlying clearing must itself re-derive (`verify_receipt`) — a payout over a fabricated price fails **here**, before the split is even examined;
2. the pool is **derived** from that clearing, never declared separately, and `route_to_commons` must reproduce the claimed allocations exactly.

Stage 1 is the load-bearing one. Letting a payout declare its own pool would leave the split honest and the number arbitrary.

Both stages are **mutation-tested**: each was removed in turn, and exactly one test reds — the right one.

## First producers for the economic lineage edges

`EdgeKind::{Bid, Allocation, Settlement, Dispute}` have existed as a schema since they landed, with **nothing constructing them**. `LineageEdge::allocation` and `::settlement` are the first producers, so a payout is recorded in the same lineage graph as the work that earned it.

The documented refund semantics are now exercised rather than only described: a refund is a `Settlement` with a negative signed amount whose parents include the edge it reverses, and the signed sum over a charge is zero exactly when the refund is full.

## Finding: the signature covers less of an economic edge than it looks like

`canonical_edge_bytes` signs `kind_tag(&kind)` — **the discriminant only**. A `Settlement` edge's `tx_ref` and `rail` are not covered, and neither is `attrs`. Two settlements differing only in rail-side transaction id produce byte-identical canonical bytes.

This is **pinned as a test rather than fixed**, because re-encoding would break every existing signature. The consequence for anything built on these edges: the authoritative binding is `content_hash_hex`, and the payout receipt behind it must carry the settlement reference itself. Verifying a payment against `attrs["amount_micro_usd_signed"]` or the edge's `tx_ref` would be a false guarantee.

## Surfaces

- `POST /v1/payout/verify` on `nucleus-verifier-service`
- `verifySignedPayout()` in `sdks/verifier-js` — a payee recomputes its own share **in the browser**, no server, no operator

A payout rides in `Projection::Economic` under inner kind `"payout"`, using the extension point that projection already documents (*"so other economic bodies can coexist under the same projection kind"*) — no change to `nucleus-receipt`'s sealed sum.

## What this does NOT claim

Recompute checks the split is the proven function of the **declared** inputs — the same honest boundary `verify_receipt` documents. `Attribution` (which workload surfaced which offer) is **bound into the signed content hash so it cannot be altered afterwards, but it is carried, not verified.** Proving it requires checking the workload's SPIFFE attestation independently, exactly as `MediationReceipt` already requires. The module docs say this in those words, and a test asserts that re-attributing a payout changes its hash *and still recomputes* — binding is not verification.

## Verification

- `wasm32-unknown-unknown` build verified: the wasm-pure default closure is unchanged (the envelope bridge stays behind the existing `envelope` feature).
- Tests: `nucleus-recompute` 63, `nucleus-lineage` 193, `nucleus-verifier-service` 96, `verifier-js` 19. Zero clippy across all four.
- Load-bearing cases: a *validly signed* but skimmed payout returns `mismatch:allocations`; a payout over a fabricated clearing returns `mismatch:seller_gross`; a share set that doesn't sum to 10 000 bps cannot be issued at all.

## Scope

Additive: one new module, two new edge constructors, one route, one SDK function. No existing behaviour changed. Settlement to a real rail is the next slice — this one stops at the claim.
