### PR TITLE
feat(commerce): settlement attestation — bind the rail-side fact to the signed claim

### DIFF
--- a/crates/nucleus-lineage/src/edge.rs
+++ b/crates/nucleus-lineage/src/edge.rs
@@ -532,9 +532,14 @@ impl LineageEdge {
     /// full. Encoding it as a string keeps the attribute map `BTreeMap<String,String>`
     /// and keeps JSON number coercion out of a money path.
     ///
-    /// As with [`Self::allocation`], the *authoritative* binding is `content_hash_hex`
-    /// (which `canonical_edge_bytes` signs); the amount in `attrs` is a convenience for
-    /// readers and is NOT covered by the signature. Never verify against it.
+    /// `content_hash_hex` MUST be
+    /// `nucleus_recompute::settlement_attestation::attestation_content_hash_hex` of the
+    /// attestation this edge records. That is not a stylistic preference: this edge's own
+    /// `tx_ref` and `rail` are NOT covered by the signature (only `kind_tag` is — see
+    /// `settlement_tx_ref_and_attrs_are_outside_the_signature`), and neither is `attrs`.
+    /// The attestation is where those facts are tamper-evident, so a verifier must read
+    /// the amount and the transaction id from it, never from this edge. The amount in
+    /// `attrs` is a convenience for human readers only.
     pub fn settlement(
         child: CallSpiffeId,
         parents: Vec<CallSpiffeId>,

--- a/crates/nucleus-recompute/Cargo.toml
+++ b/crates/nucleus-recompute/Cargo.toml
@@ -55,6 +55,8 @@ ifc-envelope = ["dep:nucleus-receipt", "nucleus-ifc/decision"]
 [dev-dependencies]
 # Fixed-key signing in the envelope end-to-end + tamper tests.
 ed25519-dalek = { workspace = true }
+# The payout_lifecycle example builds a split from the proven commons kernel.
+nucleus-econ-kernels = { path = "../nucleus-econ-kernels", version = "1.0.0" }
 
 [lints]
 workspace = true

--- a/crates/nucleus-recompute/examples/payout_lifecycle.rs
+++ b/crates/nucleus-recompute/examples/payout_lifecycle.rs
@@ -1,0 +1,134 @@
+//! The whole payout lifecycle, offline and runnable:
+//!
+//! ```text
+//! cargo run -p nucleus-recompute --example payout_lifecycle
+//! ```
+//!
+//! clearing → payout → settlement attestations → verification, and then four
+//! attacks, each caught by a different check. Nothing here talks to a network:
+//! every verdict is a recomputation a payee could run itself.
+
+use nucleus_econ_kernels::commons::CommonsShare;
+use nucleus_recompute::payout::{issue_payout, verify_payout, Attribution};
+use nucleus_recompute::settlement_attestation::{
+    issue_settlement_attestation, verify_settlement, verify_settlement_set, SettlementSetOutcome,
+};
+use nucleus_recompute::{issue_settlement, verify_receipt};
+
+fn main() {
+    // ── 1. A cleared sale. Full delivery, so the whole price is distributable.
+    let clearing = issue_settlement(1_000_000, 10_000); // $1.00, 100% delivered
+    println!("clearing recomputes: {:?}", verify_receipt(&clearing));
+
+    // ── 2. The split. Bps must sum to 10_000 — the proven kernel refuses
+    //       anything else, so a skim cannot produce a standing receipt.
+    let shares = vec![
+        CommonsShare {
+            destination: "seller".into(),
+            bps: 7_000,
+        },
+        CommonsShare {
+            destination: "runtime".into(),
+            bps: 2_500,
+        },
+        CommonsShare {
+            destination: "commons".into(),
+            bps: 500,
+        },
+    ];
+    let attribution = Attribution {
+        workload_spiffe_id: "spiffe://nucleus.local/runtime/acme".into(),
+        assurance: 1,
+        offer_hash_hex: String::new(),
+        disclosure_hash_hex: String::new(),
+    };
+    let payout = issue_payout(clearing, shares, attribution).expect("well-formed");
+
+    println!("\npayout ({:?}):", verify_payout(&payout));
+    for a in &payout.allocations {
+        println!("  {:>8}  {:>9} µUSD", a.destination, a.amount_micro);
+    }
+    let total: u64 = payout.allocations.iter().map(|a| a.amount_micro).sum();
+    println!(
+        "  {:>8}  {total:>9} µUSD   (routed_conserves: nothing skimmed)",
+        "TOTAL"
+    );
+
+    // ── 3. Settle every payee, and check the SET — not just one receipt.
+    let attestations: Vec<_> = payout
+        .allocations
+        .iter()
+        .map(|a| {
+            issue_settlement_attestation(&payout, &a.destination, "x402-evm", "0xdeadbeef")
+                .expect("known destination")
+        })
+        .collect();
+    println!(
+        "\nsettlement set: {:?}",
+        verify_settlement_set(&attestations, &payout)
+    );
+
+    // ── 4. Four attacks. Each is caught by a different check, which is the
+    //       point: no single one of them is doing all the work.
+    println!("\nattacks:");
+
+    // (a) The operator rounds a payee down by one micro-USD.
+    let mut short = attestations[0].clone();
+    short.amount_micro_usd_signed -= 1;
+    println!(
+        "  short-pay a payee     → {:?}",
+        verify_settlement(&short, &payout)
+    );
+
+    // (b) The operator pays a wallet the split does not owe.
+    let mut stranger = attestations[0].clone();
+    stranger.destination = "spiffe://attacker.example/wallet".into();
+    println!(
+        "  pay a stranger        → {:?}",
+        verify_settlement(&stranger, &payout)
+    );
+
+    // (c) The operator pays two of three, and shows each payee its own receipt.
+    //     Every receipt verifies alone; the SET does not.
+    let partial = &attestations[..2];
+    for a in partial {
+        assert!(
+            verify_settlement(a, &payout).is_match(),
+            "each verifies alone"
+        );
+    }
+    match verify_settlement_set(partial, &payout) {
+        SettlementSetOutcome::Unsettled { destinations } => {
+            println!("  pay 2 of 3            → Unsettled {destinations:?}  (each receipt verified alone!)");
+        }
+        other => println!("  pay 2 of 3            → {other:?}"),
+    }
+
+    // (d) The operator re-points a settlement at a cheaper payout.
+    let cheaper = issue_payout(
+        issue_settlement(1_000_000, 5_000), // half delivered → half the pool
+        vec![CommonsShare {
+            destination: "seller".into(),
+            bps: 10_000,
+        }],
+        Attribution {
+            workload_spiffe_id: "spiffe://nucleus.local/runtime/acme".into(),
+            assurance: 1,
+            offer_hash_hex: String::new(),
+            disclosure_hash_hex: String::new(),
+        },
+    )
+    .expect("well-formed");
+    let outcome = verify_settlement(&attestations[0], &cheaper);
+    println!(
+        "  re-point the payout   → {}",
+        match outcome {
+            nucleus_recompute::settlement_attestation::SettlementOutcome::PayoutMismatch {
+                ..
+            } => "PayoutMismatch (the attestation names its payout by hash)".to_string(),
+            other => format!("{other:?}"),
+        }
+    );
+
+    println!("\nNothing above consulted a network. A payee runs exactly this.");
+}

--- a/crates/nucleus-recompute/src/lib.rs
+++ b/crates/nucleus-recompute/src/lib.rs
@@ -52,6 +52,15 @@ use portcullis_core::extracted::ifc_integrity::{imeet, IntegLevel};
 /// conservation theorem.
 pub mod payout;
 
+/// Settlement attestation — the rail-side fact that a payout was actually paid,
+/// bound into something the signature covers.
+///
+/// `EdgeKind::Settlement` carries `tx_ref` and `rail`, but `canonical_edge_bytes`
+/// signs only the kind DISCRIMINANT, so those fields are outside the signature.
+/// The settlement facts therefore have to live in the object the edge's
+/// `content_hash_hex` commits to — this one.
+pub mod settlement_attestation;
+
 /// Domain separator for the canonical receipt bytes (versioned).
 const RECEIPT_DOMAIN: &[u8] = b"nucleus-recompute/clearing-receipt/v1\0";
 

--- a/crates/nucleus-recompute/src/settlement_attestation.rs
+++ b/crates/nucleus-recompute/src/settlement_attestation.rs
@@ -1,0 +1,465 @@
+//! # Settlement attestation — binding the rail-side fact to the signed claim
+//!
+//! [`verify_payout`](crate::payout::verify_payout) proves a split is the proven
+//! function of a real pool. It says nothing about whether anyone was *paid*.
+//! This module closes that gap, and it exists in this shape because of a
+//! specific defect found while building the payout layer.
+//!
+//! ## Why this is not just a field on the lineage edge
+//!
+//! `nucleus_lineage::EdgeKind::Settlement` already carries `tx_ref` and `rail`,
+//! and it would be natural to treat those as the record of payment. They are
+//! not trustworthy for that purpose: `canonical_edge_bytes` signs
+//! `kind_tag(&kind)` — the **discriminant only** — so a `Settlement` edge's
+//! `tx_ref` and `rail` are outside the signature, as is `attrs`. Two settlement
+//! edges differing only in rail-side transaction id produce byte-identical
+//! canonical bytes. (Pinned by `settlement_tx_ref_and_attrs_are_outside_the_signature`
+//! in `nucleus-lineage`.)
+//!
+//! The edge's *authoritative* field is `content_hash_hex`, which **is** signed.
+//! So the settlement facts have to live inside the object that hash commits to.
+//! That object is this one.
+//!
+//! ## What a verified settlement means
+//!
+//! [`verify_settlement`] answers: *does this payment discharge the obligation
+//! this payout created?* It checks three things, and nothing else:
+//!
+//! 1. the attestation names **this** payout, by content hash;
+//! 2. its destination is one the payout actually allocates to;
+//! 3. its amount is exactly that allocation — a payer cannot round a payee down.
+//!
+//! [`verify_settlement_set`] asks the harder question a payee actually cares
+//! about: *was **everyone** paid, exactly once?* One attestation verifying in
+//! isolation is compatible with an operator that paid two of three payees and
+//! showed you only your own receipt.
+//!
+//! ## What this does NOT claim
+//!
+//! **The rail is not consulted.** Nothing here reaches out to a chain, a card
+//! network, or a bank to confirm `tx_ref` exists or moved what it says. A
+//! settlement attestation is the payer's signed *statement* about a rail-side
+//! fact, bound so it cannot be altered afterwards and checked for internal
+//! consistency against the proven split. Confirming it against the rail is a
+//! separate step requiring a rail client, and it is deliberately not smuggled
+//! in here — an offline verifier that silently did network I/O would be worse
+//! than one that admits it cannot.
+//!
+//! What this *does* remove is the payer's freedom to misreport the split it was
+//! settling. That is the part a recomputation can decide.
+//!
+//! **Partial refunds are not modelled.** A reversal must be full: the magnitude
+//! equals the allocation. Partial reversal needs a running balance across
+//! attestations, which is a ledger, not a check.
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::BTreeSet;
+
+use crate::payout::{payout_content_hash_hex, PayoutClaim};
+
+/// Domain separator for the canonical settlement-attestation bytes (versioned).
+const SETTLEMENT_DOMAIN: &[u8] = b"nucleus-recompute/settlement-attestation/v1\0";
+
+/// A payer's signed statement that it moved money on a rail to discharge one
+/// allocation of a payout.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SettlementAttestation {
+    /// The payout being discharged, by [`payout_content_hash_hex`]. Naming the
+    /// payout by hash is what stops a settlement being re-pointed at a
+    /// different, more favourable split after the fact.
+    pub payout_hash_hex: String,
+    /// The settlement protocol: `"x402-evm"`, `"stripe-connect"`, `"ach"`, ….
+    pub rail: String,
+    /// The rail-side transaction id — an onchain tx hash, a Stripe `ch_…`, an
+    /// ACH trace number.
+    pub tx_ref: String,
+    /// Which payee this settles. Must be one the payout allocates to.
+    pub destination: String,
+    /// Amount moved, micro-USD, signed. Positive pays the destination; negative
+    /// reverses a prior payment to it. Signed because a refund is not a distinct
+    /// kind — it is a settlement in the opposite direction, matching
+    /// `EdgeKind::Settlement`'s documented refund semantics.
+    pub amount_micro_usd_signed: i64,
+}
+
+/// The result of checking one attestation against its payout.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SettlementOutcome {
+    /// The attestation discharges its allocation exactly.
+    Match,
+    /// The attestation names a different payout than the one supplied.
+    PayoutMismatch {
+        /// The hash the attestation claims.
+        claimed: String,
+        /// The hash the supplied payout actually has.
+        actual: String,
+    },
+    /// The destination is not one this payout allocates to — money moved, but
+    /// not to anyone this split owes.
+    UnknownDestination {
+        /// The destination named by the attestation.
+        destination: String,
+    },
+    /// The amount does not discharge the allocation. This is the case that
+    /// matters most: it is how a payer rounding a payee down is caught.
+    AmountMismatch {
+        /// The destination whose payment is wrong.
+        destination: String,
+        /// What the attestation says was moved.
+        claimed: i64,
+        /// What the proven split says is owed (negated for a reversal).
+        expected: i64,
+    },
+}
+
+impl SettlementOutcome {
+    /// `true` only for [`SettlementOutcome::Match`].
+    pub fn is_match(&self) -> bool {
+        matches!(self, SettlementOutcome::Match)
+    }
+}
+
+/// Check that one attestation discharges its allocation in the given payout.
+///
+/// The payout is passed in rather than fetched: this is an offline check, and a
+/// verifier that resolved hashes over the network would be making a trust
+/// decision it did not disclose.
+pub fn verify_settlement(
+    attestation: &SettlementAttestation,
+    payout: &PayoutClaim,
+) -> SettlementOutcome {
+    let actual = payout_content_hash_hex(payout);
+    if attestation.payout_hash_hex != actual {
+        return SettlementOutcome::PayoutMismatch {
+            claimed: attestation.payout_hash_hex.clone(),
+            actual,
+        };
+    }
+
+    let Some(alloc) = payout
+        .allocations
+        .iter()
+        .find(|a| a.destination == attestation.destination)
+    else {
+        return SettlementOutcome::UnknownDestination {
+            destination: attestation.destination.clone(),
+        };
+    };
+
+    // A reversal must be full: its magnitude is the allocation, its sign is
+    // negative. Partial reversal is not modelled (see the module docs).
+    let owed = i64::try_from(alloc.amount_micro).unwrap_or(i64::MAX);
+    let expected = if attestation.amount_micro_usd_signed < 0 {
+        -owed
+    } else {
+        owed
+    };
+
+    if attestation.amount_micro_usd_signed != expected {
+        return SettlementOutcome::AmountMismatch {
+            destination: attestation.destination.clone(),
+            claimed: attestation.amount_micro_usd_signed,
+            expected,
+        };
+    }
+    SettlementOutcome::Match
+}
+
+/// Why a set of attestations does not fully discharge a payout.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SettlementSetOutcome {
+    /// Every allocation is discharged exactly once, and nothing else was paid.
+    Complete,
+    /// One attestation failed on its own terms.
+    Invalid(SettlementOutcome),
+    /// Allocations with no settlement — someone was not paid.
+    ///
+    /// This is the failure a per-attestation check cannot see, and the one a
+    /// payee should care about: an operator can pay two of three payees and show
+    /// each of them a receipt that verifies.
+    Unsettled {
+        /// Destinations still owed.
+        destinations: Vec<String>,
+    },
+    /// The same destination settled more than once. Not necessarily fraud — it
+    /// is how a reversal appears — but it means the set no longer says "paid
+    /// exactly once", so a naive sum over it would be wrong.
+    Duplicate {
+        /// The destination settled more than once.
+        destination: String,
+    },
+}
+
+/// Check that a set of attestations discharges **every** allocation of a payout,
+/// exactly once.
+///
+/// Reversals are deliberately rejected here rather than netted: a set containing
+/// a payment and its reversal is not "complete", it is a payment that was undone,
+/// and collapsing the two would report the payee as paid. Netting belongs in a
+/// ledger that carries balances over time, not in a check that answers one
+/// question about one payout.
+pub fn verify_settlement_set(
+    attestations: &[SettlementAttestation],
+    payout: &PayoutClaim,
+) -> SettlementSetOutcome {
+    let mut seen: BTreeSet<&str> = BTreeSet::new();
+    for a in attestations {
+        match verify_settlement(a, payout) {
+            SettlementOutcome::Match => {}
+            other => return SettlementSetOutcome::Invalid(other),
+        }
+        if !seen.insert(a.destination.as_str()) {
+            return SettlementSetOutcome::Duplicate {
+                destination: a.destination.clone(),
+            };
+        }
+    }
+
+    let unsettled: Vec<String> = payout
+        .allocations
+        .iter()
+        .filter(|a| !seen.contains(a.destination.as_str()))
+        .map(|a| a.destination.clone())
+        .collect();
+
+    if unsettled.is_empty() {
+        SettlementSetOutcome::Complete
+    } else {
+        SettlementSetOutcome::Unsettled {
+            destinations: unsettled,
+        }
+    }
+}
+
+/// Issue an attestation for one allocation — the producer dual of
+/// [`verify_settlement`].
+///
+/// The amount is **not** a parameter: it is read from the payout's proven
+/// allocation. A payer therefore cannot mint an attestation for an amount it did
+/// not owe, which is the same "honest by construction" discipline the `issue_*`
+/// functions follow. Returns `None` if the destination is not one this payout
+/// allocates to.
+pub fn issue_settlement_attestation(
+    payout: &PayoutClaim,
+    destination: &str,
+    rail: impl Into<String>,
+    tx_ref: impl Into<String>,
+) -> Option<SettlementAttestation> {
+    let alloc = payout
+        .allocations
+        .iter()
+        .find(|a| a.destination == destination)?;
+    Some(SettlementAttestation {
+        payout_hash_hex: payout_content_hash_hex(payout),
+        rail: rail.into(),
+        tx_ref: tx_ref.into(),
+        destination: destination.to_string(),
+        amount_micro_usd_signed: i64::try_from(alloc.amount_micro).unwrap_or(i64::MAX),
+    })
+}
+
+/// Canonical, domain-tagged bytes for an attestation.
+pub fn attestation_canonical_bytes(a: &SettlementAttestation) -> Vec<u8> {
+    let mut out = Vec::with_capacity(SETTLEMENT_DOMAIN.len() + 256);
+    out.extend_from_slice(SETTLEMENT_DOMAIN);
+    // Infallible for this concrete, map-free type.
+    serde_json::to_writer(&mut out, a).expect("attestation serialization is infallible");
+    out
+}
+
+/// `sha256` over [`attestation_canonical_bytes`], hex-encoded.
+///
+/// **This is the value a `Settlement` lineage edge's `content_hash_hex` must
+/// carry** — not the payout's hash, and not a hash of the amount. It is the only
+/// part of that edge the signature covers, so it is the only place the `tx_ref`
+/// and amount are tamper-evident.
+pub fn attestation_content_hash_hex(a: &SettlementAttestation) -> String {
+    let mut h = Sha256::new();
+    h.update(attestation_canonical_bytes(a));
+    hex::encode(h.finalize())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::payout::{issue_payout, tests_support::*};
+
+    fn payout() -> PayoutClaim {
+        issue_payout(
+            crate::issue_settlement(1_000_000, 10_000),
+            shares(),
+            attribution(),
+        )
+        .expect("well-formed")
+    }
+
+    fn attest(p: &PayoutClaim, dest: &str) -> SettlementAttestation {
+        issue_settlement_attestation(p, dest, "x402-evm", "0xabc").expect("known destination")
+    }
+
+    #[test]
+    fn an_issued_attestation_discharges_its_allocation() {
+        let p = payout();
+        let a = attest(&p, "spiffe://vendor.example/seller");
+        assert_eq!(verify_settlement(&a, &p), SettlementOutcome::Match);
+    }
+
+    /// THE BITE. A payer rounds a payee down by one micro-USD and reports the
+    /// rest. Recomputation against the proven split catches it.
+    #[test]
+    fn shorting_a_payee_is_caught() {
+        let p = payout();
+        let mut a = attest(&p, "spiffe://vendor.example/seller");
+        a.amount_micro_usd_signed -= 1;
+
+        match verify_settlement(&a, &p) {
+            SettlementOutcome::AmountMismatch {
+                claimed, expected, ..
+            } => assert_eq!(expected - claimed, 1),
+            other => panic!("a short payment must not verify, got {other:?}"),
+        }
+    }
+
+    /// The attestation names its payout by hash, so it cannot be re-pointed at a
+    /// different, more favourable split after the fact. This is the property the
+    /// whole module exists for: the lineage edge's own `tx_ref` is unsigned, so
+    /// the binding has to live here.
+    #[test]
+    fn an_attestation_cannot_be_repointed_at_another_payout() {
+        let p = payout();
+        let a = attest(&p, "spiffe://vendor.example/seller");
+
+        // A different payout — same parties, half the delivery, so smaller
+        // obligations. An operator would love to claim it settled THIS one.
+        let cheaper = issue_payout(
+            crate::issue_settlement(1_000_000, 5_000),
+            shares(),
+            attribution(),
+        )
+        .expect("well-formed");
+
+        match verify_settlement(&a, &cheaper) {
+            SettlementOutcome::PayoutMismatch { .. } => {}
+            other => panic!("must not verify against another payout, got {other:?}"),
+        }
+    }
+
+    /// Paying someone the split does not owe is not a discharge of anything.
+    #[test]
+    fn paying_a_stranger_discharges_nothing() {
+        let p = payout();
+        let mut a = attest(&p, "spiffe://vendor.example/seller");
+        a.destination = "spiffe://attacker.example/wallet".into();
+
+        match verify_settlement(&a, &p) {
+            SettlementOutcome::UnknownDestination { destination } => {
+                assert!(destination.contains("attacker"));
+            }
+            other => panic!("expected UnknownDestination, got {other:?}"),
+        }
+    }
+
+    /// A reversal is a settlement in the opposite direction, and must be full.
+    #[test]
+    fn a_full_reversal_verifies_and_a_partial_one_does_not() {
+        let p = payout();
+        let mut full = attest(&p, "commons");
+        full.amount_micro_usd_signed = -full.amount_micro_usd_signed;
+        assert_eq!(verify_settlement(&full, &p), SettlementOutcome::Match);
+
+        let mut partial = full.clone();
+        partial.amount_micro_usd_signed += 1; // less than a full reversal
+        assert!(
+            !verify_settlement(&partial, &p).is_match(),
+            "partial reversal is not modelled and must not silently pass"
+        );
+    }
+
+    /// **The question a payee actually cares about.** Each attestation below
+    /// verifies on its own — an operator could show any single payee a receipt
+    /// that checks out — but the set does not discharge the payout.
+    #[test]
+    fn paying_two_of_three_payees_is_caught_only_by_the_set_check() {
+        let p = payout();
+        let paid = [
+            attest(&p, "spiffe://nucleus.local/runtime/acme"),
+            attest(&p, "spiffe://vendor.example/seller"),
+        ];
+
+        // Individually honest.
+        for a in &paid {
+            assert_eq!(verify_settlement(a, &p), SettlementOutcome::Match);
+        }
+
+        // Collectively incomplete.
+        match verify_settlement_set(&paid, &p) {
+            SettlementSetOutcome::Unsettled { destinations } => {
+                assert_eq!(destinations, vec!["commons".to_string()]);
+            }
+            other => panic!("an unpaid payee must surface, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn settling_every_allocation_once_is_complete() {
+        let p = payout();
+        let all: Vec<_> = p
+            .allocations
+            .iter()
+            .map(|a| attest(&p, &a.destination))
+            .collect();
+        assert_eq!(
+            verify_settlement_set(&all, &p),
+            SettlementSetOutcome::Complete
+        );
+    }
+
+    /// A payment and its reversal is not "everyone was paid". Netting them would
+    /// report a payee as settled when the money came back.
+    #[test]
+    fn a_payment_and_its_reversal_do_not_net_to_complete() {
+        let p = payout();
+        let pay = attest(&p, "commons");
+        let mut back = pay.clone();
+        back.amount_micro_usd_signed = -back.amount_micro_usd_signed;
+        back.tx_ref = "0xreversal".into();
+
+        match verify_settlement_set(&[pay, back], &p) {
+            SettlementSetOutcome::Duplicate { destination } => assert_eq!(destination, "commons"),
+            other => panic!("a reversal must not read as payment, got {other:?}"),
+        }
+    }
+
+    /// The producer cannot mint an attestation for money it did not owe: the
+    /// amount comes from the proven allocation, never from the caller.
+    #[test]
+    fn an_attestation_cannot_be_issued_for_an_unowed_destination() {
+        let p = payout();
+        assert!(issue_settlement_attestation(&p, "nobody", "x402-evm", "0x1").is_none());
+    }
+
+    /// The attestation hash covers the rail-side facts — which is the entire
+    /// reason this type exists, given the lineage edge's `tx_ref` is unsigned.
+    #[test]
+    fn the_hash_covers_tx_ref_and_amount() {
+        let p = payout();
+        let a = attest(&p, "commons");
+
+        let mut other_tx = a.clone();
+        other_tx.tx_ref = "0xdifferent".into();
+        assert_ne!(
+            attestation_content_hash_hex(&a),
+            attestation_content_hash_hex(&other_tx),
+            "tx_ref must be inside the commitment"
+        );
+
+        let mut other_amt = a.clone();
+        other_amt.amount_micro_usd_signed += 1;
+        assert_ne!(
+            attestation_content_hash_hex(&a),
+            attestation_content_hash_hex(&other_amt),
+            "amount must be inside the commitment"
+        );
+    }
+}

--- a/examples/x402-sepolia/Cargo.lock
+++ b/examples/x402-sepolia/Cargo.lock
@@ -525,7 +525,7 @@ checksum = "86052fdcec72d37ca4aa4b66254601e7453c45a6e1c70aa4561033d002fb80cc"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
- "base64",
+ "base64 0.22.1",
  "derive_more",
  "futures",
  "futures-utils-wasm",
@@ -779,45 +779,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
-name = "asn1-rs"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
-dependencies = [
- "asn1-rs-derive",
- "asn1-rs-impl",
- "displaydoc",
- "nom",
- "num-traits",
- "rusticata-macros",
- "thiserror",
- "time",
-]
-
-[[package]]
-name = "asn1-rs-derive"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "synstructure",
-]
-
-[[package]]
-name = "asn1-rs-impl"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -960,6 +921,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -971,7 +938,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec 0.8.0",
+ "bit-vec",
 ]
 
 [[package]]
@@ -979,15 +946,6 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
-
-[[package]]
-name = "bit-vec"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "bitcoin-io"
@@ -1388,12 +1346,12 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "5.0.0-pre.6"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335f1947f241137a14106b6f5acc5918a5ede29c9d71d3f2cb1678d5075d9fc3"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures 0.3.0",
  "curve25519-dalek-derive",
  "digest 0.11.3",
  "fiat-crypto",
@@ -1463,12 +1421,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "data-encoding"
-version = "2.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
-
-[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1479,17 +1431,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "der-parser"
-version = "10.0.0"
+name = "der"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
 dependencies = [
- "asn1-rs",
- "displaydoc",
- "nom",
- "num-bigint",
- "num-traits",
- "rusticata-macros",
+ "const-oid 0.10.2",
+ "pem-rfc7468",
+ "zeroize",
 ]
 
 [[package]]
@@ -1597,13 +1546,13 @@ version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der",
+ "der 0.7.10",
  "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "serdect",
  "signature 2.2.0",
- "spki",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -1612,18 +1561,21 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
 dependencies = [
+ "pkcs8 0.11.0",
  "signature 3.0.0",
 ]
 
 [[package]]
 name = "ed25519-dalek"
-version = "3.0.0-pre.7"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20449acd54b660981ae5caa2bcb56d1fe7f25f2e37a38ec507400fab034d4bb6"
+checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
+ "serde",
  "sha2 0.11.0",
+ "signature 3.0.0",
  "subtle",
  "zeroize",
 ]
@@ -1661,7 +1613,7 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
- "pkcs8",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
  "sec1",
  "serdect",
@@ -2177,7 +2129,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -2538,12 +2490,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2633,12 +2579,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "mio"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2650,23 +2590,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
-]
-
-[[package]]
 name = "nucleus-agent-card"
 version = "1.0.0"
 dependencies = [
- "base64",
+ "base64 0.23.1",
  "nucleus-envelope",
- "nucleus-identity",
  "nucleus-lineage",
+ "p256",
  "serde",
  "serde_jcs",
  "serde_json",
@@ -2674,10 +2604,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "nucleus-econ-kernels"
+version = "1.0.0"
+dependencies = [
+ "hex",
+ "nucleus-econ-types",
+ "nucleus-externality",
+ "serde",
+ "sha2 0.11.0",
+ "thiserror",
+]
+
+[[package]]
+name = "nucleus-econ-types"
+version = "1.0.0"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "nucleus-envelope"
 version = "1.0.0"
 dependencies = [
- "base64",
+ "base64 0.23.1",
  "chrono",
  "ed25519-dalek",
  "hex",
@@ -2689,29 +2638,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "nucleus-identity"
+name = "nucleus-externality"
 version = "1.0.0"
 dependencies = [
- "async-trait",
- "base64",
- "chrono",
+ "base64 0.23.1",
+ "ed25519-dalek",
  "hex",
- "pem",
- "portcullis-core",
- "prost",
- "rcgen",
- "ring",
- "rustls",
- "rustls-webpki",
+ "nucleus-lineage",
  "serde",
  "serde_json",
  "sha2 0.11.0",
  "thiserror",
- "time",
- "tokio",
- "tokio-rustls",
- "tracing",
- "x509-parser",
 ]
 
 [[package]]
@@ -2719,13 +2656,18 @@ name = "nucleus-ifc"
 version = "1.0.0"
 dependencies = [
  "portcullis-core",
+ "serde",
 ]
+
+[[package]]
+name = "nucleus-ifc-kernel"
+version = "1.0.0"
 
 [[package]]
 name = "nucleus-lineage"
 version = "1.0.0"
 dependencies = [
- "base64",
+ "base64 0.23.1",
  "chrono",
  "ct-merkle",
  "ed25519-dalek",
@@ -2739,14 +2681,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "nucleus-recompute"
+version = "1.0.0"
+dependencies = [
+ "hex",
+ "nucleus-econ-kernels",
+ "nucleus-ifc",
+ "portcullis-core",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror",
+]
+
+[[package]]
 name = "nucleus-verify-commerce"
 version = "1.0.0"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.23.1",
  "nucleus-agent-card",
  "nucleus-envelope",
- "nucleus-identity",
  "nucleus-ifc",
  "nucleus-lineage",
  "portcullis-core",
@@ -2837,15 +2792,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "oid-registry"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
-dependencies = [
- "asn1-rs",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2856,6 +2802,18 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
 
 [[package]]
 name = "parity-scale-codec"
@@ -2915,13 +2873,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
-name = "pem"
-version = "3.0.6"
+name = "pem-rfc7468"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
 dependencies = [
- "base64",
- "serde_core",
+ "base64ct",
 ]
 
 [[package]]
@@ -2978,13 +2935,26 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.10",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
+dependencies = [
+ "der 0.8.1",
+ "spki 0.8.0",
 ]
 
 [[package]]
 name = "portcullis-core"
 version = "1.0.0"
+dependencies = [
+ "nucleus-ifc-kernel",
+]
 
 [[package]]
 name = "potential_utf"
@@ -3018,6 +2988,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -3078,7 +3057,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
- "bit-vec 0.8.0",
+ "bit-vec",
  "bitflags",
  "num-traits",
  "rand 0.9.4",
@@ -3088,29 +3067,6 @@ dependencies = [
  "rusty-fork",
  "tempfile",
  "unarray",
-]
-
-[[package]]
-name = "prost"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
-dependencies = [
- "bytes",
- "prost-derive",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
-dependencies = [
- "anyhow",
- "itertools 0.14.0",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -3320,20 +3276,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rcgen"
-version = "0.14.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
-dependencies = [
- "pem",
- "ring",
- "rustls-pki-types",
- "time",
- "x509-parser",
- "yasna",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3406,7 +3348,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -3599,15 +3541,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rusticata-macros"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3627,9 +3560,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
- "log",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -3788,9 +3719,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
- "der",
+ "der 0.7.10",
  "generic-array",
- "pkcs8",
+ "pkcs8 0.10.2",
  "serdect",
  "subtle",
  "zeroize",
@@ -3967,7 +3898,7 @@ version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bs58",
  "chrono",
  "hex",
@@ -4115,7 +4046,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
+]
+
+[[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "base64ct",
+ "der 0.8.1",
 ]
 
 [[package]]
@@ -5210,6 +5151,8 @@ dependencies = [
  "alloy-signer-local",
  "anyhow",
  "axum",
+ "nucleus-econ-kernels",
+ "nucleus-recompute",
  "nucleus-verify-commerce",
  "reqwest",
  "serde_json",
@@ -5228,41 +5171,13 @@ checksum = "19ad28de8b4d3c7e0f885dc8724c24a7e117246d64ba9e3ba4d724a110fd29dd"
 dependencies = [
  "alloy-primitives",
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "regex",
  "rust_decimal",
  "serde",
  "serde_json",
  "serde_with",
  "thiserror",
-]
-
-[[package]]
-name = "x509-parser"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
-dependencies = [
- "asn1-rs",
- "data-encoding",
- "der-parser",
- "lazy_static",
- "nom",
- "oid-registry",
- "ring",
- "rusticata-macros",
- "thiserror",
- "time",
-]
-
-[[package]]
-name = "yasna"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
-dependencies = [
- "bit-vec 0.9.1",
- "time",
 ]
 
 [[package]]

--- a/examples/x402-sepolia/Cargo.toml
+++ b/examples/x402-sepolia/Cargo.toml
@@ -38,3 +38,7 @@ anyhow = "1"
 # The nucleus trust layer that makes this more than a plain x402 paywall:
 # the IFC gate + signed receipt on the paid route.
 nucleus-verify-commerce = { path = "../../crates/nucleus-verify-commerce" }
+# The paid route emits a recompute-verifiable payout + settlement attestation, so
+# the buyer can check its own share offline instead of trusting this seller.
+nucleus-recompute = { path = "../../crates/nucleus-recompute" }
+nucleus-econ-kernels = { path = "../../crates/nucleus-econ-kernels" }

--- a/examples/x402-sepolia/src/bin/buyer.rs
+++ b/examples/x402-sepolia/src/bin/buyer.rs
@@ -16,8 +16,9 @@ use x402_reqwest::{ReqwestWithPayments, ReqwestWithPaymentsBuild, X402Client};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let key = std::env::var("X402_PRIVATE_KEY")
-        .map_err(|_| anyhow::anyhow!("set X402_PRIVATE_KEY (a TESTNET key with Base Sepolia USDC)"))?;
+    let key = std::env::var("X402_PRIVATE_KEY").map_err(|_| {
+        anyhow::anyhow!("set X402_PRIVATE_KEY (a TESTNET key with Base Sepolia USDC)")
+    })?;
     let target =
         std::env::var("TARGET_URL").unwrap_or_else(|_| "http://127.0.0.1:4021/paid".into());
 

--- a/examples/x402-sepolia/src/bin/seller.rs
+++ b/examples/x402-sepolia/src/bin/seller.rs
@@ -113,11 +113,105 @@ async fn ifc_pregate(
 /// The paid work. By the time we get here the IFC gate has ALLOWED (and stashed
 /// the verdict) and x402 has verified payment. We echo the result + the verdict
 /// the gate made the call under.
-async fn paid_handler(Extension(verdict): Extension<IfcVerdict>) -> Json<serde_json::Value> {
+async fn paid_handler(
+    Extension(verdict): Extension<IfcVerdict>,
+    headers: axum::http::HeaderMap,
+) -> Json<serde_json::Value> {
     let body = b"{\"summary\":\"<paid result>\"}";
+
+    // The rail-side transaction reference, taken from the x402 payment the
+    // middleware just accepted. If the header is missing or unparseable we say
+    // so rather than inventing a reference — an attestation naming a
+    // transaction that does not exist would be worse than no attestation.
+    let tx_ref = headers
+        .get("x-payment")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|h| nucleus_verify_commerce::x402::parse_payment_header(h).ok())
+        .map(|p| p.reference)
+        .unwrap_or_else(|| "<no x-payment header>".to_string());
+
+    let payout_bundle = build_payout(&tx_ref);
+
     Json(serde_json::json!({
         "result": "paid result delivered",
         "body_sha256": body_sha256_hex(body),
         "ifc_verdict": verdict,
+        "payout": payout_bundle,
     }))
+}
+
+/// Build the recompute-verifiable payout for one paid call, plus the settlement
+/// attestation that says it was paid.
+///
+/// The buyer does not have to trust any of this: `verify_payout` re-derives the
+/// split from the proven kernels, and `verify_settlement_set` checks every payee
+/// was discharged exactly once. A seller that quietly reweighted the split, or
+/// paid two of three payees, is caught client-side.
+///
+/// The split below is a DEMO constant. A real deployment reads it from the offer
+/// the buyer accepted — that is slice S3, and pretending otherwise here would
+/// make the example claim more than it does.
+fn build_payout(tx_ref: &str) -> serde_json::Value {
+    use nucleus_econ_kernels::commons::CommonsShare;
+    use nucleus_recompute::payout::{issue_payout, Attribution};
+    use nucleus_recompute::settlement_attestation::{
+        issue_settlement_attestation, verify_settlement_set,
+    };
+    use nucleus_recompute::{issue_settlement, verify_receipt};
+
+    // Price in micro-USD. The demo price is 0.01 USDC; delivery is full, so the
+    // whole price is distributable.
+    let price_micro: u64 = std::env::var("PRICE_USDC")
+        .ok()
+        .and_then(|p| p.parse::<f64>().ok())
+        .map(|usd| (usd * 1_000_000.0) as u64)
+        .unwrap_or(10_000);
+
+    let clearing = issue_settlement(price_micro, 10_000);
+    let shares = vec![
+        CommonsShare {
+            destination: "seller".into(),
+            bps: 7_000,
+        },
+        CommonsShare {
+            destination: "runtime".into(),
+            bps: 2_500,
+        },
+        CommonsShare {
+            destination: "commons".into(),
+            bps: 500,
+        },
+    ];
+    let attribution = Attribution {
+        workload_spiffe_id: "spiffe://nucleus.local/example/x402-seller".into(),
+        assurance: 0, // demo: no attestation backend wired, and it says so
+        offer_hash_hex: String::new(),
+        disclosure_hash_hex: String::new(),
+    };
+
+    let Ok(payout) = issue_payout(clearing.clone(), shares, attribution) else {
+        return serde_json::json!({ "error": "payout could not be issued" });
+    };
+
+    let attestations: Vec<_> = payout
+        .allocations
+        .iter()
+        .filter_map(|a| issue_settlement_attestation(&payout, &a.destination, "x402-evm", tx_ref))
+        .collect();
+
+    // Self-check before serving: never hand a buyer a receipt this seller has
+    // not itself verified.
+    let clearing_ok = verify_receipt(&clearing).is_match();
+    let set = verify_settlement_set(&attestations, &payout);
+
+    serde_json::json!({
+        "payout": payout,
+        "settlements": attestations,
+        "self_check": {
+            "clearing_recomputes": clearing_ok,
+            "settlement_set": format!("{set:?}"),
+        },
+        "how_to_verify": "POST {receipt, verifying_key_hex} to /v1/payout/verify, \
+                          or run verifySignedPayout() in the browser — neither trusts this seller",
+    })
 }


### PR DESCRIPTION
> **Stacked on #2336.** Base is `feat/payout-receipt`, so the diff here is only S2. Retarget to `main` once #2336 merges — merging *this* while it is based on a branch lands nothing on main.

## The defect this exists to fix

`verify_payout` (#2336) proves a split is the proven function of a real pool. It says nothing about whether anyone was **paid**.

The natural place to record that is `EdgeKind::Settlement`, which already carries `tx_ref` and `rail`. Those fields are not trustworthy for it. `canonical_edge_bytes` signs `kind_tag(&kind)` — **the discriminant only** — so a `Settlement` edge's `tx_ref` and `rail` sit outside the signature, as does `attrs`. Two settlement edges differing only in transaction id produce byte-identical canonical bytes. (Pinned in #2336 by `settlement_tx_ref_and_attrs_are_outside_the_signature`.)

The edge's authoritative field is `content_hash_hex`, which **is** signed. So the settlement facts have to live inside the object that hash commits to. `SettlementAttestation` is that object, and `LineageEdge::settlement`'s docs now say so explicitly rather than gesturing at it.

## Two checks, answering different questions

`verify_settlement` — *does this payment discharge the obligation?* Three things: the attestation names **this** payout by content hash; its destination is one the split actually owes; its amount is exactly that allocation. A payer cannot round a payee down, and cannot re-point a settlement at a cheaper payout after the fact.

`verify_settlement_set` — *was **everyone** paid, exactly once?* This is the one a payee actually cares about. An operator can pay two of three payees and show each of them a receipt that verifies **in isolation**; only the set check sees it. A payment and its reversal come back as `Duplicate` rather than netted — collapsing them would report a payee as paid when the money came back.

`issue_settlement_attestation` takes **no amount**. It reads it from the proven allocation, so a payer cannot mint an attestation for money it did not owe.

## Mutation-tested

Each check was disabled in turn, and exactly the expected test reds:

| perturbation | test that reds |
|---|---|
| drop the payout-hash binding | `an_attestation_cannot_be_repointed_at_another_payout` |
| drop the amount check | `shorting_a_payee_is_caught`, `a_full_reversal_verifies_and_a_partial_one_does_not` |
| drop the set-completeness check | `paying_two_of_three_payees_is_caught_only_by_the_set_check` |

## Runnable

```
$ cargo run -p nucleus-recompute --example payout_lifecycle

settlement set: Complete

attacks:
  short-pay a payee     → AmountMismatch { destination: "seller", claimed: 699999, expected: 700000 }
  pay a stranger        → UnknownDestination { destination: "spiffe://attacker.example/wallet" }
  pay 2 of 3            → Unsettled ["commons"]  (each receipt verified alone!)
  re-point the payout   → PayoutMismatch (the attestation names its payout by hash)
```

Four attacks, each caught by a **different** check — no single one is doing all the work. Entirely offline.

The `x402-sepolia` seller now emits a payout plus attestations on every paid call, taking `tx_ref` from the accepted `X-PAYMENT` header — and reporting `<no x-payment header>` rather than inventing a reference when it is absent. It self-checks before serving. The demo split is a constant and the code says so; reading it from the accepted offer is S3.

## What this does NOT claim

**The rail is not consulted.** Nothing here confirms `tx_ref` exists or moved what it claims — that needs a rail client, and it is deliberately not smuggled into an offline verifier. What this removes is the payer's freedom to **misreport the split it was settling**, which is the part a recomputation can decide.

**Partial reversals are not modelled.** A reversal must be full; partial needs a running balance, which is a ledger rather than a check.

## Verification

Pre-flight run **before** pushing this time — the lesson from #2336: `cargo fmt` across all four workspaces, `clippy -D warnings`, `wasm32-unknown-unknown` purity, and CI's **literal** exemplar-ratchet logic. All green; no baseline change needed.

`nucleus-recompute` 73, `nucleus-lineage` 193, zero clippy.
