### PR TITLE
proof(ck-policy): the deductive bridge was behind the gate it certifies

### DIFF
--- a/crates/ck-policy/lean-aeneas/CkPolicyAeneas.lean
+++ b/crates/ck-policy/lean-aeneas/CkPolicyAeneas.lean
@@ -94,7 +94,9 @@ theorem passed_core_decomp
     (pf cf : Array Bool 3#usize)
     (pcap ccap pio cio ppr cpr : Slice U32)
     (pb cb : Array U64 8#usize)
-    (h : ck_policy.extracted.passed_core pf cf pcap ccap pio cio ppr cpr pb cb = ok true) :
+    (psig csig : Std.U32)
+    (h : ck_policy.extracted.passed_core pf cf pcap ccap pio cio ppr cpr pb cb psig csig
+         = ok true) :
     (∃ f0, pf.index_usize 0#usize = ok f0 ∧
         ck_policy.extracted.cap_violated f0 ccap pcap = ok false) ∧
     (∃ f1, pf.index_usize 1#usize = ok f1 ∧
@@ -102,7 +104,7 @@ theorem passed_core_decomp
     (ck_policy.extracted.budget_violated cb pb = ok false) ∧
     (∃ f2, pf.index_usize 2#usize = ok f2 ∧
         ck_policy.extracted.proofreq_violated f2 cpr ppr = ok false) ∧
-    (ck_policy.extracted.rules_non_weakening pf cf = ok true) := by
+    (ck_policy.extracted.rules_non_weakening pf cf psig csig = ok true) := by
   unfold ck_policy.extracted.passed_core at h
   obtain ⟨v1, e1, h⟩ := bind_eq_ok _ _ _ h    -- v1 = pf[0]
   obtain ⟨v2, e2, h⟩ := bind_eq_ok _ _ _ h    -- v2 = cap_violated v1
@@ -203,23 +205,34 @@ theorem budget_not_violated
    anti-self-weakening property carried by the SHIPPED gate.
    ─────────────────────────────────────────────────────────────────────────── -/
 
-/-- `weakensFlags parent child`: the child DISABLES a governance flag the parent
-    had ON, on at least one of the three amendment-rule axes (cap/io/proofreq).
-    This is exactly what the unconditional `rules_non_weakening` must forbid. -/
-def weakensFlags (parent child : Array Bool 3#usize) : Prop :=
+/-- `weakensFlags parent child parent_sigs child_sigs`: the child DISABLES a
+    governance flag the parent had ON (cap/io/proofreq), OR lowers the
+    human-signature threshold.
+
+    The numeric disjunct is the one this bridge was missing. Lowering
+    `constitutional_human_signatures` disarms the review that would police the
+    NEXT amendment while every boolean flag stays set — the same coup, spelled
+    numerically. Production gained the axis in #2332; until now the extracted
+    core did not, so this theorem certified a gate strictly weaker than the one
+    that ships. -/
+def weakensFlags (parent child : Array Bool 3#usize)
+    (parent_sigs child_sigs : Std.U32) : Prop :=
   (parent.val[0]! = true ∧ child.val[0]! = false) ∨
   (parent.val[1]! = true ∧ child.val[1]! = false) ∨
-  (parent.val[2]! = true ∧ child.val[2]! = false)
+  (parent.val[2]! = true ∧ child.val[2]! = false) ∨
+  (child_sigs < parent_sigs)
 
 /-- The GENERATED `rules_non_weakening` evaluates (via three literal-index reads
     of length-3 arrays) to the boolean conjunction
     `(¬p0 ∨ c0) ∧ (¬p1 ∨ c1) ∧ (¬p2 ∨ c2)` over the array elements. This pins
     the generated def's value to the elementwise flags it reads. -/
-theorem rules_non_weakening_val (parent child : Array Bool 3#usize) :
-    ck_policy.extracted.rules_non_weakening parent child =
+theorem rules_non_weakening_val (parent child : Array Bool 3#usize)
+    (parent_sigs child_sigs : Std.U32) :
+    ck_policy.extracted.rules_non_weakening parent child parent_sigs child_sigs =
       ok (((!parent.val[0]! || child.val[0]!) &&
            (!parent.val[1]! || child.val[1]!) &&
-           (!parent.val[2]! || child.val[2]!))) := by
+           (!parent.val[2]! || child.val[2]!) &&
+           (parent_sigs <= child_sigs))) := by
   have hp := parent.property
   have hc := child.property
   -- Length-3 arrays: name the three elements of each carrier list.
@@ -245,15 +258,23 @@ theorem rules_non_weakening_val (parent child : Array Bool 3#usize) :
     image, over the EXTRACTED def, of the unconditional non-weakening conjunct
     that closes the two-step coup. -/
 theorem rules_non_weakening_sound (parent child : Array Bool 3#usize)
-    (h : ck_policy.extracted.rules_non_weakening parent child = ok true) :
-    ¬ weakensFlags parent child := by
+    (parent_sigs child_sigs : Std.U32)
+    (h : ck_policy.extracted.rules_non_weakening parent child parent_sigs child_sigs
+         = ok true) :
+    ¬ weakensFlags parent child parent_sigs child_sigs := by
   rw [rules_non_weakening_val] at h
   have hb : ((!parent.val[0]! || child.val[0]!) &&
              (!parent.val[1]! || child.val[1]!) &&
-             (!parent.val[2]! || child.val[2]!)) = true := by injection h
+             (!parent.val[2]! || child.val[2]!) &&
+             (parent_sigs <= child_sigs)) = true := by injection h
+  simp only [Bool.and_eq_true, decide_eq_true_eq] at hb
+  obtain ⟨⟨⟨h0, h1⟩, h2⟩, hsig⟩ := hb
   intro hw
-  rcases hw with ⟨hp, hc⟩ | ⟨hp, hc⟩ | ⟨hp, hc⟩ <;>
-    rw [hp, hc] at hb <;> simp at hb
+  rcases hw with ⟨hp, hc⟩ | ⟨hp, hc⟩ | ⟨hp, hc⟩ | hs
+  · rw [hp, hc] at h0; simp at h0
+  · rw [hp, hc] at h1; simp at h1
+  · rw [hp, hc] at h2; simp at h2
+  · exact absurd hs (not_lt.mpr hsig)
 
 /- ───────────────────────────────────────────────────────────────────────────
    THEOREM T1 — soundness of the EXTRACTED gate (PROVED, 0 sorry, 0 native_decide)
@@ -284,7 +305,9 @@ theorem T1_extracted_gate_sound
     (pf cf : Array Bool 3#usize)
     (pcap ccap pio cio ppr cpr : Slice U32)
     (pb cb : Array U64 8#usize)
-    (h : ck_policy.extracted.passed_core pf cf pcap ccap pio cio ppr cpr pb cb = ok true) :
+    (psig csig : Std.U32)
+    (h : ck_policy.extracted.passed_core pf cf pcap ccap pio cio ppr cpr pb cb psig csig
+         = ok true) :
     (pf.index_usize 0#usize = ok true →
         ck_policy.extracted.subset_u32 ccap pcap = ok true) ∧
     (pf.index_usize 1#usize = ok true →
@@ -292,9 +315,9 @@ theorem T1_extracted_gate_sound
     (ck_policy.extracted.budget_within cb pb = ok true) ∧
     (pf.index_usize 2#usize = ok true →
         ck_policy.extracted.dropped_u32 cpr ppr = ok false) ∧
-    (¬ weakensFlags pf cf) := by
+    (¬ weakensFlags pf cf psig csig) := by
   obtain ⟨⟨f0, e0, hcap⟩, ⟨f1, e1, hio⟩, hbud, ⟨f2, e2, hpr⟩, hrules⟩ :=
-    passed_core_decomp pf cf pcap ccap pio cio ppr cpr pb cb h
+    passed_core_decomp pf cf pcap ccap pio cio ppr cpr pb cb psig csig h
   refine ⟨?_, ?_, ?_, ?_, ?_⟩
   · -- capability axis
     intro hflag
@@ -314,7 +337,7 @@ theorem T1_extracted_gate_sound
     subst this
     exact proofreq_not_violated_flag_on cpr ppr hpr
   · -- amendment-rules non-weakening — UNCONDITIONAL
-    exact rules_non_weakening_sound pf cf hrules
+    exact rules_non_weakening_sound pf cf psig csig hrules
 
 /- ───────────────────────────────────────────────────────────────────────────
    #print axioms — kernel-checked axiom-hygiene audit (no sorryAx, no

--- a/crates/ck-policy/lean-aeneas/generated/CkPolicy/Funs.lean
+++ b/crates/ck-policy/lean-aeneas/generated/CkPolicy/Funs.lean
@@ -201,10 +201,11 @@ def extracted.budget_within
   extracted.budget_within_loop child parent 0#usize true
 
 /-- [ck_policy::extracted::rules_non_weakening]:
-    Source: 'crates/ck-policy/src/extracted.rs', lines 130:0-135:1
+    Source: 'crates/ck-policy/src/extracted.rs', lines 137:0-148:1
     Visibility: public -/
 def extracted.rules_non_weakening
-  (parent : Array Bool 3#usize) (child : Array Bool 3#usize) :
+  (parent : Array Bool 3#usize) (child : Array Bool 3#usize)
+  (parent_sigs : Std.U32) (child_sigs : Std.U32) :
   Result Bool
   := do
   let b ← Array.index_usize parent 0#usize
@@ -220,13 +221,16 @@ def extracted.rules_non_weakening
                       then Array.index_usize child 2#usize
                       else ok true
   if cap_ok
-  then if io_ok
-       then ok proofreq_ok
-       else ok false
+  then
+    if io_ok
+    then if proofreq_ok
+         then ok (parent_sigs <= child_sigs)
+         else ok false
+    else ok false
   else ok false
 
 /-- [ck_policy::extracted::cap_violated]:
-    Source: 'crates/ck-policy/src/extracted.rs', lines 143:0-149:1
+    Source: 'crates/ck-policy/src/extracted.rs', lines 156:0-162:1
     Visibility: public -/
 def extracted.cap_violated
   (parent_flag : Bool) (child : Slice Std.U32) (parent : Slice Std.U32) :
@@ -238,7 +242,7 @@ def extracted.cap_violated
   else ok false
 
 /-- [ck_policy::extracted::io_violated]:
-    Source: 'crates/ck-policy/src/extracted.rs', lines 152:0-158:1
+    Source: 'crates/ck-policy/src/extracted.rs', lines 165:0-171:1
     Visibility: public -/
 def extracted.io_violated
   (parent_flag : Bool) (child : Slice Std.U32) (parent : Slice Std.U32) :
@@ -250,7 +254,7 @@ def extracted.io_violated
   else ok false
 
 /-- [ck_policy::extracted::proofreq_violated]:
-    Source: 'crates/ck-policy/src/extracted.rs', lines 162:0-168:1
+    Source: 'crates/ck-policy/src/extracted.rs', lines 175:0-181:1
     Visibility: public -/
 def extracted.proofreq_violated
   (parent_flag : Bool) (child : Slice Std.U32) (parent : Slice Std.U32) :
@@ -261,7 +265,7 @@ def extracted.proofreq_violated
   else ok false
 
 /-- [ck_policy::extracted::budget_violated]:
-    Source: 'crates/ck-policy/src/extracted.rs', lines 171:0-173:1
+    Source: 'crates/ck-policy/src/extracted.rs', lines 184:0-186:1
     Visibility: public -/
 def extracted.budget_violated
   (child : Array Std.U64 8#usize) (parent : Array Std.U64 8#usize) :
@@ -271,7 +275,7 @@ def extracted.budget_violated
   ok (¬ b)
 
 /-- [ck_policy::extracted::passed_core]:
-    Source: 'crates/ck-policy/src/extracted.rs', lines 196:0-214:1
+    Source: 'crates/ck-policy/src/extracted.rs', lines 211:0-231:1
     Visibility: public -/
 def extracted.passed_core
   (parent_flags : Array Bool 3#usize) (child_flags : Array Bool 3#usize)
@@ -279,7 +283,8 @@ def extracted.passed_core
   (parent_io : Slice Std.U32) (child_io : Slice Std.U32)
   (parent_proof : Slice Std.U32) (child_proof : Slice Std.U32)
   (parent_budget : Array Std.U64 8#usize)
-  (child_budget : Array Std.U64 8#usize) :
+  (child_budget : Array Std.U64 8#usize) (parent_sigs : Std.U32)
+  (child_sigs : Std.U32) :
   Result Bool
   := do
   let b ← Array.index_usize parent_flags 0#usize
@@ -289,7 +294,9 @@ def extracted.passed_core
   let b4 ← extracted.budget_violated child_budget parent_budget
   let b5 ← Array.index_usize parent_flags 2#usize
   let b6 ← extracted.proofreq_violated b5 child_proof parent_proof
-  let rules_ok ← extracted.rules_non_weakening parent_flags child_flags
+  let rules_ok ←
+    extracted.rules_non_weakening parent_flags child_flags parent_sigs
+      child_sigs
   if ¬ b1
   then
     if ¬ b3

--- a/crates/ck-policy/lean-aeneas/generated/CkPolicy/Funs.lean
+++ b/crates/ck-policy/lean-aeneas/generated/CkPolicy/Funs.lean
@@ -16,7 +16,7 @@ set_option maxRecDepth 2048
 namespace ck_policy
 
 /-- [ck_policy::extracted::subset_u32]: loop body 1:
-    Source: 'crates/ck-policy/src/extracted.rs', lines 62:8-67:9
+    Source: 'crates/ck-policy/src/extracted.rs', lines 73:8-78:9
     Visibility: public -/
 @[rust_loop_body]
 def extracted.subset_u32_loop0_loop0.body
@@ -35,7 +35,7 @@ def extracted.subset_u32_loop0_loop0.body
   else ok (done found)
 
 /-- [ck_policy::extracted::subset_u32]: loop 1:
-    Source: 'crates/ck-policy/src/extracted.rs', lines 62:8-67:9
+    Source: 'crates/ck-policy/src/extracted.rs', lines 73:8-78:9
     Visibility: public -/
 @[rust_loop]
 def extracted.subset_u32_loop0_loop0
@@ -48,7 +48,7 @@ def extracted.subset_u32_loop0_loop0
     (found, j)
 
 /-- [ck_policy::extracted::subset_u32]: loop body 0:
-    Source: 'crates/ck-policy/src/extracted.rs', lines 58:4-74:1
+    Source: 'crates/ck-policy/src/extracted.rs', lines 69:4-85:1
     Visibility: public -/
 @[rust_loop_body]
 def extracted.subset_u32_loop0.body
@@ -67,7 +67,7 @@ def extracted.subset_u32_loop0.body
   else ok (done true)
 
 /-- [ck_policy::extracted::subset_u32]: loop 0:
-    Source: 'crates/ck-policy/src/extracted.rs', lines 58:4-74:1
+    Source: 'crates/ck-policy/src/extracted.rs', lines 69:4-85:1
     Visibility: public -/
 @[rust_loop]
 def extracted.subset_u32_loop0
@@ -79,7 +79,7 @@ def extracted.subset_u32_loop0
     i
 
 /-- [ck_policy::extracted::subset_u32]:
-    Source: 'crates/ck-policy/src/extracted.rs', lines 56:0-74:1
+    Source: 'crates/ck-policy/src/extracted.rs', lines 67:0-85:1
     Visibility: public -/
 @[reducible]
 def extracted.subset_u32
@@ -87,7 +87,7 @@ def extracted.subset_u32
   extracted.subset_u32_loop0 child parent 0#usize
 
 /-- [ck_policy::extracted::dropped_u32]: loop body 1:
-    Source: 'crates/ck-policy/src/extracted.rs', lines 86:8-91:9
+    Source: 'crates/ck-policy/src/extracted.rs', lines 97:8-102:9
     Visibility: public -/
 @[rust_loop_body]
 def extracted.dropped_u32_loop0_loop0.body
@@ -106,7 +106,7 @@ def extracted.dropped_u32_loop0_loop0.body
   else ok (done found)
 
 /-- [ck_policy::extracted::dropped_u32]: loop 1:
-    Source: 'crates/ck-policy/src/extracted.rs', lines 86:8-91:9
+    Source: 'crates/ck-policy/src/extracted.rs', lines 97:8-102:9
     Visibility: public -/
 @[rust_loop]
 def extracted.dropped_u32_loop0_loop0
@@ -119,7 +119,7 @@ def extracted.dropped_u32_loop0_loop0
     (found, j)
 
 /-- [ck_policy::extracted::dropped_u32]: loop body 0:
-    Source: 'crates/ck-policy/src/extracted.rs', lines 82:4-98:1
+    Source: 'crates/ck-policy/src/extracted.rs', lines 93:4-109:1
     Visibility: public -/
 @[rust_loop_body]
 def extracted.dropped_u32_loop0.body
@@ -138,7 +138,7 @@ def extracted.dropped_u32_loop0.body
   else ok (done false)
 
 /-- [ck_policy::extracted::dropped_u32]: loop 0:
-    Source: 'crates/ck-policy/src/extracted.rs', lines 82:4-98:1
+    Source: 'crates/ck-policy/src/extracted.rs', lines 93:4-109:1
     Visibility: public -/
 @[rust_loop]
 def extracted.dropped_u32_loop0
@@ -150,7 +150,7 @@ def extracted.dropped_u32_loop0
     i
 
 /-- [ck_policy::extracted::dropped_u32]:
-    Source: 'crates/ck-policy/src/extracted.rs', lines 80:0-98:1
+    Source: 'crates/ck-policy/src/extracted.rs', lines 91:0-109:1
     Visibility: public -/
 @[reducible]
 def extracted.dropped_u32
@@ -158,7 +158,7 @@ def extracted.dropped_u32
   extracted.dropped_u32_loop0 child parent 0#usize
 
 /-- [ck_policy::extracted::budget_within]: loop body 0:
-    Source: 'crates/ck-policy/src/extracted.rs', lines 110:4-115:5
+    Source: 'crates/ck-policy/src/extracted.rs', lines 121:4-126:5
     Visibility: public -/
 @[rust_loop_body]
 def extracted.budget_within_loop.body
@@ -178,7 +178,7 @@ def extracted.budget_within_loop.body
   else ok (done ok1)
 
 /-- [ck_policy::extracted::budget_within]: loop 0:
-    Source: 'crates/ck-policy/src/extracted.rs', lines 110:4-115:5
+    Source: 'crates/ck-policy/src/extracted.rs', lines 121:4-126:5
     Visibility: public -/
 @[rust_loop]
 def extracted.budget_within_loop
@@ -191,7 +191,7 @@ def extracted.budget_within_loop
     (i, ok1)
 
 /-- [ck_policy::extracted::budget_within]:
-    Source: 'crates/ck-policy/src/extracted.rs', lines 107:0-117:1
+    Source: 'crates/ck-policy/src/extracted.rs', lines 118:0-128:1
     Visibility: public -/
 @[reducible]
 def extracted.budget_within
@@ -201,7 +201,7 @@ def extracted.budget_within
   extracted.budget_within_loop child parent 0#usize true
 
 /-- [ck_policy::extracted::rules_non_weakening]:
-    Source: 'crates/ck-policy/src/extracted.rs', lines 137:0-148:1
+    Source: 'crates/ck-policy/src/extracted.rs', lines 148:0-159:1
     Visibility: public -/
 def extracted.rules_non_weakening
   (parent : Array Bool 3#usize) (child : Array Bool 3#usize)
@@ -230,7 +230,7 @@ def extracted.rules_non_weakening
   else ok false
 
 /-- [ck_policy::extracted::cap_violated]:
-    Source: 'crates/ck-policy/src/extracted.rs', lines 156:0-162:1
+    Source: 'crates/ck-policy/src/extracted.rs', lines 167:0-173:1
     Visibility: public -/
 def extracted.cap_violated
   (parent_flag : Bool) (child : Slice Std.U32) (parent : Slice Std.U32) :
@@ -242,7 +242,7 @@ def extracted.cap_violated
   else ok false
 
 /-- [ck_policy::extracted::io_violated]:
-    Source: 'crates/ck-policy/src/extracted.rs', lines 165:0-171:1
+    Source: 'crates/ck-policy/src/extracted.rs', lines 176:0-182:1
     Visibility: public -/
 def extracted.io_violated
   (parent_flag : Bool) (child : Slice Std.U32) (parent : Slice Std.U32) :
@@ -254,7 +254,7 @@ def extracted.io_violated
   else ok false
 
 /-- [ck_policy::extracted::proofreq_violated]:
-    Source: 'crates/ck-policy/src/extracted.rs', lines 175:0-181:1
+    Source: 'crates/ck-policy/src/extracted.rs', lines 186:0-192:1
     Visibility: public -/
 def extracted.proofreq_violated
   (parent_flag : Bool) (child : Slice Std.U32) (parent : Slice Std.U32) :
@@ -265,7 +265,7 @@ def extracted.proofreq_violated
   else ok false
 
 /-- [ck_policy::extracted::budget_violated]:
-    Source: 'crates/ck-policy/src/extracted.rs', lines 184:0-186:1
+    Source: 'crates/ck-policy/src/extracted.rs', lines 195:0-197:1
     Visibility: public -/
 def extracted.budget_violated
   (child : Array Std.U64 8#usize) (parent : Array Std.U64 8#usize) :
@@ -275,7 +275,7 @@ def extracted.budget_violated
   ok (¬ b)
 
 /-- [ck_policy::extracted::passed_core]:
-    Source: 'crates/ck-policy/src/extracted.rs', lines 211:0-231:1
+    Source: 'crates/ck-policy/src/extracted.rs', lines 222:0-242:1
     Visibility: public -/
 def extracted.passed_core
   (parent_flags : Array Bool 3#usize) (child_flags : Array Bool 3#usize)

--- a/crates/ck-policy/lean/Ck.lean
+++ b/crates/ck-policy/lean/Ck.lean
@@ -1,2 +1,3 @@
 -- Constitutional Kernel monotonicity-gate soundness proofs root (see lakefile.lean).
 import Ck.Policy
+import Ck.PolicyMulti

--- a/crates/ck-policy/lean/Ck/Policy.lean
+++ b/crates/ck-policy/lean/Ck/Policy.lean
@@ -19,6 +19,20 @@
   (`new_gate_rejects_coup`), and transitive anti-coup soundness across a 2-step
   chain (`strengthened_gate_closes_it`).
 
+  # ARITY CAVEAT — read `Ck.PolicyMulti` alongside this file
+
+  This model collapses each authority group to ONE `Names` carrier. The
+  production types do not: `CapabilitySet` is five `BTreeSet<String>` plus a
+  numeric axis, `IoSurface` is five, `ProofRequirements` is three. That collapse
+  is NOT faithful — a capability that moves between axes leaves the union
+  unchanged, so this model ADMITS a pair the production gate REJECTS
+  (`Ck.PolicyMulti.flattening_admits_what_per_axis_rejects`, proved by `rfl`).
+
+  Consequently `T1_gate_sound` below is a theorem about the flattened sets, and
+  its conclusion does not by itself entail per-axis non-escalation.
+  `Ck.PolicyMulti.T1_gate_sound_multi` is the version that does, and
+  `flat_is_a_special_case` pins this file to it so the two cannot drift.
+
   # EXTRACTION-GAP CAVEAT
 
   These theorems are proved about the Lean MODEL. The parity proptest binds the

--- a/crates/ck-policy/lean/Ck/PolicyMulti.lean
+++ b/crates/ck-policy/lean/Ck/PolicyMulti.lean
@@ -1,0 +1,386 @@
+/-
+  Ck / PolicyMulti  (the monotonicity gate at the arity the CODE has)
+
+  **STATUS: PROVED (0 `sorry`).** Mathlib-free, same discipline as `Ck.Policy`.
+
+  # Why this file exists
+
+  `Ck.Policy` models each authority group as ONE `Names` carrier. The production
+  types are not one carrier: `ck_types::manifest::CapabilitySet` is FIVE
+  `BTreeSet<String>` plus a numeric axis, `IoSurface` is five, and
+  `ProofRequirements` is three. The Rust parity mirror ORs the per-axis predicate
+  and its comment asserts that this is "the faithful boolean image".
+
+  It is not, and the failure is not subtle:
+
+  ```
+                  filesystem_read   network_allow
+      parent      {}                {"x"}
+      child       {"x"}             {}
+  ```
+
+  Per axis — what `check_monotonicity` computes — `filesystem_read` escalates, so
+  the gate REJECTS. Flattened, the child's union `{"x"}` is a subset of the
+  parent's union `{"x"}`, so the single-carrier model sees NO escalation and
+  ADMITS. `flattening_admits_what_per_axis_rejects` below is that pair, proved by
+  `rfl`.
+
+  So the flattened model is strictly MORE PERMISSIVE than the code, and
+  `Ck.Policy.T1_gate_sound`'s conclusion `¬ capEscalates c p` — a statement about
+  the unioned sets — does not entail per-axis non-escalation. Read as a claim
+  about a real `PolicyManifest`, it over-claims.
+
+  To be exact about the blast radius: this is a PROOF-TRANSFER defect, not a live
+  vulnerability. The shipped Rust is per-axis and strict, and #2334 proved its two
+  spellings (`is_subset_of` and `escalations_over`) agree. The code was always
+  fine; the theorem did not reach it.
+
+  This file restates the model at the real arity and reproves T1 there, so the
+  theorem's subject is the shape the code actually has. `Ck.Policy` is retained as
+  the readable single-axis specification and is pinned to this one by
+  `flat_is_a_special_case`, so the two cannot drift apart silently.
+
+  # The structures are exhaustive on purpose
+
+  `CapAxes` / `IoAxes` / `ProofAxes` name every field of their Rust counterpart.
+  Adding an axis in Rust without adding it here leaves this file's constructors
+  incomplete, which is a compile error rather than a silent gap — the Lean
+  analogue of the no-`..` destructuring tripwire in
+  `ck_types::manifest::subset_agrees_with_no_escalation`.
+-/
+
+import Ck.Policy
+
+namespace Ck.Policy
+
+/- ───────────────────────────────────────────────────────────────────────────
+   The axes, as the production structs actually have them
+   ─────────────────────────────────────────────────────────────────────────── -/
+
+/-- `ck_types::manifest::CapabilitySet`: five name sets and a numeric bound. -/
+structure CapAxes where
+  filesystemRead : Names
+  filesystemWrite : Names
+  networkAllow : Names
+  toolsAllow : Names
+  secretClasses : Names
+  maxParallelTasks : Nat
+deriving Repr
+
+/-- `ck_types::manifest::IoSurface`: five name sets. -/
+structure IoAxes where
+  outboundDomains : Names
+  localFileRoots : Names
+  envVarsReadable : Names
+  toolNamespaces : Names
+  repoWriteTargets : Names
+deriving Repr
+
+/-- `ck_types::manifest::ProofRequirements`: three patch classes. -/
+structure ProofAxes where
+  configPatch : Names
+  controllerPatch : Names
+  evaluatorPatch : Names
+deriving Repr
+
+/-- A `PolicyManifest` at the arity the gate reads. -/
+structure MultiManifest where
+  caps : CapAxes
+  ioSurface : IoAxes
+  proofReqs : ProofAxes
+  budget : Budget
+  rules : Rules
+deriving Repr
+
+/- ───────────────────────────────────────────────────────────────────────────
+   The crux: the flattening is NOT faithful
+   ─────────────────────────────────────────────────────────────────────────── -/
+
+/-- The union a single-carrier model implicitly takes. -/
+def flattenCaps (a : CapAxes) : Names :=
+  a.filesystemRead ++ a.filesystemWrite ++ a.networkAllow ++
+    a.toolsAllow ++ a.secretClasses
+
+/-- Any capability axis escalating, ignoring the parent flag. -/
+def capEscalatesAnyB (c p : CapAxes) : Bool :=
+  escalatesB c.filesystemRead p.filesystemRead ||
+  escalatesB c.filesystemWrite p.filesystemWrite ||
+  escalatesB c.networkAllow p.networkAllow ||
+  escalatesB c.toolsAllow p.toolsAllow ||
+  escalatesB c.secretClasses p.secretClasses ||
+  decide (p.maxParallelTasks < c.maxParallelTasks)
+
+/-- Parent: nothing readable, `"x"` reachable on the network. -/
+def crossAxisParent : CapAxes :=
+  { filesystemRead := [], filesystemWrite := [], networkAllow := ["x"],
+    toolsAllow := [], secretClasses := [], maxParallelTasks := 0 }
+
+/-- Child: `"x"` READABLE, nothing reachable. The same name, a different axis —
+    a real escalation of `filesystem_read`. -/
+def crossAxisChild : CapAxes :=
+  { filesystemRead := ["x"], filesystemWrite := [], networkAllow := [],
+    toolsAllow := [], secretClasses := [], maxParallelTasks := 0 }
+
+/-- **The flattening admits what the per-axis gate rejects.**
+
+    This is why the rest of this file exists. A single-carrier model cannot see a
+    capability that moved between axes, because the union is unchanged; the
+    production gate, which compares axis by axis, sees it immediately.
+
+    Kept as a constructive witness (same role as `weak_gate_admits_coup`) so that
+    "simplifying" the model back to one carrier fails a proof rather than
+    quietly restoring the hole. -/
+theorem flattening_admits_what_per_axis_rejects :
+    capEscalatesAnyB crossAxisChild crossAxisParent = true ∧
+    escalatesB (flattenCaps crossAxisChild) (flattenCaps crossAxisParent) = false := by
+  constructor <;> rfl
+
+/- ───────────────────────────────────────────────────────────────────────────
+   The gate, per axis
+   ─────────────────────────────────────────────────────────────────────────── -/
+
+/-- Any io axis widening. -/
+def ioEscalatesAnyB (c p : IoAxes) : Bool :=
+  escalatesB c.outboundDomains p.outboundDomains ||
+  escalatesB c.localFileRoots p.localFileRoots ||
+  escalatesB c.envVarsReadable p.envVarsReadable ||
+  escalatesB c.toolNamespaces p.toolNamespaces ||
+  escalatesB c.repoWriteTargets p.repoWriteTargets
+
+/-- Any proof requirement dropped. -/
+def proofDropsAnyB (c p : ProofAxes) : Bool :=
+  dropsB c.configPatch p.configPatch ||
+  dropsB c.controllerPatch p.controllerPatch ||
+  dropsB c.evaluatorPatch p.evaluatorPatch
+
+/-- Capability axis violated? Gated on the PARENT flag, as in the Rust. -/
+def capViolatedM (p c : MultiManifest) : Bool :=
+  if p.rules.cap then capEscalatesAnyB c.caps p.caps else false
+
+/-- I/O axis violated? Gated on the PARENT flag. -/
+def ioViolatedM (p c : MultiManifest) : Bool :=
+  if p.rules.io then ioEscalatesAnyB c.ioSurface p.ioSurface else false
+
+/-- Budget violated? ALWAYS checked — no gating flag exists in the Rust. -/
+def budgetViolatedM (p c : MultiManifest) : Bool :=
+  !budgetWithin c.budget p.budget
+
+/-- Proof-requirement axis violated? Gated on the PARENT flag. -/
+def proofReqViolatedM (p c : MultiManifest) : Bool :=
+  if p.rules.proofreq then proofDropsAnyB c.proofReqs p.proofReqs else false
+
+/-- The child does not disable a governance flag the parent set, and does not
+    lower the human-signature threshold. Reuses `Ck.Policy.Rules` unchanged: the
+    amendment rules were never the part that was flattened. -/
+def rulesNonWeakeningM (c p : MultiManifest) : Bool :=
+  (!p.rules.cap || c.rules.cap) &&
+  (!p.rules.io || c.rules.io) &&
+  (!p.rules.proofreq || c.rules.proofreq) &&
+  (decide (p.rules.sigs ≤ c.rules.sigs))
+
+/-- The child turns OFF a governance flag the parent had ON, or lowers the
+    signature threshold. The `MultiManifest` image of `Ck.Policy.weakensRules`;
+    identical, because the amendment rules were never the flattened part. -/
+def weakensRulesM (c p : MultiManifest) : Prop :=
+  (p.rules.cap = true ∧ c.rules.cap = false) ∨
+  (p.rules.io = true ∧ c.rules.io = false) ∨
+  (p.rules.proofreq = true ∧ c.rules.proofreq = false) ∨
+  (c.rules.sigs < p.rules.sigs)
+
+/-- `passedM p c` models the shipped `check_monotonicity(parent=p, child=c).passed`
+    at the real arity. -/
+def passedM (p c : MultiManifest) : Bool :=
+  !capViolatedM p c && !ioViolatedM p c && !budgetViolatedM p c &&
+    !proofReqViolatedM p c && rulesNonWeakeningM c p
+
+/- ───────────────────────────────────────────────────────────────────────────
+   Prop-level facts, PER AXIS (what soundness now rules out)
+   ─────────────────────────────────────────────────────────────────────────── -/
+
+/-- Some capability axis grants what the parent did not. Unlike the flattened
+    `capEscalates`, a name that moved between axes is an escalation here. -/
+def CapEscalatesM (c p : CapAxes) : Prop :=
+  ¬ Subset c.filesystemRead p.filesystemRead ∨
+  ¬ Subset c.filesystemWrite p.filesystemWrite ∨
+  ¬ Subset c.networkAllow p.networkAllow ∨
+  ¬ Subset c.toolsAllow p.toolsAllow ∨
+  ¬ Subset c.secretClasses p.secretClasses ∨
+  p.maxParallelTasks < c.maxParallelTasks
+
+/-- Some io axis is wider on the child. -/
+def IoEscalatesM (c p : IoAxes) : Prop :=
+  ¬ Subset c.outboundDomains p.outboundDomains ∨
+  ¬ Subset c.localFileRoots p.localFileRoots ∨
+  ¬ Subset c.envVarsReadable p.envVarsReadable ∨
+  ¬ Subset c.toolNamespaces p.toolNamespaces ∨
+  ¬ Subset c.repoWriteTargets p.repoWriteTargets
+
+/-- Some proof requirement the parent carried is missing from the child. -/
+def ProofDropsM (c p : ProofAxes) : Prop :=
+  ¬ Subset p.configPatch c.configPatch ∨
+  ¬ Subset p.controllerPatch c.controllerPatch ∨
+  ¬ Subset p.evaluatorPatch c.evaluatorPatch
+
+/- ───────────────────────────────────────────────────────────────────────────
+   Bridge lemmas: the per-axis boolean scans decode to the Prop-level facts
+   ─────────────────────────────────────────────────────────────────────────── -/
+
+theorem capEscalatesAnyB_false (c p : CapAxes) (h : capEscalatesAnyB c p = false) :
+    ¬ CapEscalatesM c p := by
+  unfold capEscalatesAnyB at h
+  simp only [Bool.or_eq_false_iff] at h
+  obtain ⟨⟨⟨⟨⟨h1, h2⟩, h3⟩, h4⟩, h5⟩, h6⟩ := h
+  intro hbad
+  rcases hbad with hb | hb | hb | hb | hb | hb
+  · exact hb ((escalatesB_false_iff_subset _ _).mp h1)
+  · exact hb ((escalatesB_false_iff_subset _ _).mp h2)
+  · exact hb ((escalatesB_false_iff_subset _ _).mp h3)
+  · exact hb ((escalatesB_false_iff_subset _ _).mp h4)
+  · exact hb ((escalatesB_false_iff_subset _ _).mp h5)
+  · exact absurd (decide_eq_true hb) (by simp [h6])
+
+theorem ioEscalatesAnyB_false (c p : IoAxes) (h : ioEscalatesAnyB c p = false) :
+    ¬ IoEscalatesM c p := by
+  unfold ioEscalatesAnyB at h
+  simp only [Bool.or_eq_false_iff] at h
+  obtain ⟨⟨⟨⟨h1, h2⟩, h3⟩, h4⟩, h5⟩ := h
+  intro hbad
+  rcases hbad with hb | hb | hb | hb | hb
+  · exact hb ((escalatesB_false_iff_subset _ _).mp h1)
+  · exact hb ((escalatesB_false_iff_subset _ _).mp h2)
+  · exact hb ((escalatesB_false_iff_subset _ _).mp h3)
+  · exact hb ((escalatesB_false_iff_subset _ _).mp h4)
+  · exact hb ((escalatesB_false_iff_subset _ _).mp h5)
+
+theorem proofDropsAnyB_false (c p : ProofAxes) (h : proofDropsAnyB c p = false) :
+    ¬ ProofDropsM c p := by
+  unfold proofDropsAnyB at h
+  simp only [Bool.or_eq_false_iff] at h
+  obtain ⟨⟨h1, h2⟩, h3⟩ := h
+  intro hbad
+  rcases hbad with hb | hb | hb
+  · exact hb ((dropsB_false_iff_subset _ _).mp h1)
+  · exact hb ((dropsB_false_iff_subset _ _).mp h2)
+  · exact hb ((dropsB_false_iff_subset _ _).mp h3)
+
+/- ───────────────────────────────────────────────────────────────────────────
+   THEOREM T1-MULTI — soundness at the arity the code has (PROVED, 0 sorry)
+   ─────────────────────────────────────────────────────────────────────────── -/
+
+/-- **THEOREM T1 (multi-axis).** `Ck.Policy.T1_gate_sound`, restated over the
+    real per-axis manifest.
+
+    Same shape as the single-carrier version — the flag-gated axes stay
+    conditional, budget and non-weakening stay unconditional — but every
+    conclusion is now per axis. That is the difference that makes it transfer:
+    `¬ CapEscalatesM` rules out an escalation on `filesystem_read` specifically,
+    which the flattened `¬ capEscalates` does not
+    (`flattening_admits_what_per_axis_rejects`). -/
+theorem T1_gate_sound_multi (p c : MultiManifest) (h : passedM p c = true) :
+    (p.rules.cap = true → ¬ CapEscalatesM c.caps p.caps) ∧
+    (p.rules.io = true → ¬ IoEscalatesM c.ioSurface p.ioSurface) ∧
+    (budgetWithin c.budget p.budget = true) ∧
+    (p.rules.proofreq = true → ¬ ProofDropsM c.proofReqs p.proofReqs) ∧
+    (¬ weakensRulesM c p) := by
+  unfold passedM capViolatedM ioViolatedM budgetViolatedM proofReqViolatedM
+    rulesNonWeakeningM at h
+  simp only [Bool.and_eq_true, Bool.not_eq_true'] at h
+  obtain ⟨⟨⟨⟨hcap, hio⟩, hbud⟩, hproof⟩, ⟨⟨⟨hrw_cap, hrw_io⟩, hrw_proof⟩, hrw_sigs⟩⟩ := h
+  refine ⟨?_, ?_, ?_, ?_, ?_⟩
+  · intro hflag
+    rw [hflag] at hcap
+    simp only [if_true] at hcap
+    exact capEscalatesAnyB_false _ _ hcap
+  · intro hflag
+    rw [hflag] at hio
+    simp only [if_true] at hio
+    exact ioEscalatesAnyB_false _ _ hio
+  · simpa using hbud
+  · intro hflag
+    rw [hflag] at hproof
+    simp only [if_true] at hproof
+    exact proofDropsAnyB_false _ _ hproof
+  · intro hw
+    rcases hw with ⟨hp, hc⟩ | ⟨hp, hc⟩ | ⟨hp, hc⟩ | hsig
+    · rw [hp, hc] at hrw_cap; simp at hrw_cap
+    · rw [hp, hc] at hrw_io; simp at hrw_io
+    · rw [hp, hc] at hrw_proof; simp at hrw_proof
+    · have : p.rules.sigs ≤ c.rules.sigs := of_decide_eq_true hrw_sigs
+      omega
+
+/- ───────────────────────────────────────────────────────────────────────────
+   Non-vacuity: the multi-axis gate ADMITS a legitimate child
+   ─────────────────────────────────────────────────────────────────────────── -/
+
+/-- An all-empty capability set. -/
+def emptyCaps : CapAxes :=
+  { filesystemRead := [], filesystemWrite := [], networkAllow := [],
+    toolsAllow := [], secretClasses := [], maxParallelTasks := 0 }
+
+def emptyIo : IoAxes :=
+  { outboundDomains := [], localFileRoots := [], envVarsReadable := [],
+    toolNamespaces := [], repoWriteTargets := [] }
+
+def emptyProof : ProofAxes :=
+  { configPatch := [], controllerPatch := [], evaluatorPatch := [] }
+
+def strictParent : MultiManifest :=
+  { caps := crossAxisParent, ioSurface := emptyIo, proofReqs := emptyProof,
+    budget := zeroBudget, rules := { cap := true, io := true, proofreq := true, sigs := 2 } }
+
+/-- A child identical to its parent: no escalation anywhere, flags preserved. -/
+def identicalChild : MultiManifest := strictParent
+
+/-- **Non-vacuity.** `T1_gate_sound_multi` would be trivially true if `passedM`
+    were never `true`. It is not: an identical child passes. Without this, the
+    theorem and the counterexample above are both compatible with a gate that
+    refuses everything. -/
+theorem identical_child_is_admitted : passedM strictParent identicalChild = true := by
+  rfl
+
+/-- And the cross-axis child — the counterexample's — is REJECTED by the
+    multi-axis gate. This is the pair the flattened model admitted. -/
+theorem cross_axis_child_is_rejected :
+    passedM strictParent { strictParent with caps := crossAxisChild } = false := by
+  rfl
+
+/- ───────────────────────────────────────────────────────────────────────────
+   Pinning the single-carrier model to this one
+   ─────────────────────────────────────────────────────────────────────────── -/
+
+/-- The single-axis model of `Ck.Policy` is the special case of this one in which
+    every group has exactly one axis populated. Stated so `Ck.Policy` remains a
+    readable specification rather than an independent claim that could drift.
+
+    Note what this does NOT say: it does not say the flattening is faithful in
+    general — `flattening_admits_what_per_axis_rejects` is the proof that it is
+    not. It says only that the one-axis instance agrees, which is the sense in
+    which the old model was ever right. -/
+theorem flat_is_a_special_case (caps ioS pr : Names) (b : Budget) (r : Rules) :
+    let m : MultiManifest :=
+      { caps := { emptyCaps with filesystemRead := caps },
+        ioSurface := { emptyIo with outboundDomains := ioS },
+        proofReqs := { emptyProof with configPatch := pr },
+        budget := b, rules := r }
+    passedM m m = passed { caps := caps, ioSurface := ioS, proofReqs := pr,
+                           budget := b, rules := r }
+                         { caps := caps, ioSurface := ioS, proofReqs := pr,
+                           budget := b, rules := r } := by
+  intro m
+  unfold passedM passed passedWeak capViolatedM ioViolatedM budgetViolatedM
+    proofReqViolatedM rulesNonWeakeningM capViolated ioViolated budgetViolated
+    proofReqViolated rulesNonWeakening capEscalatesAnyB ioEscalatesAnyB
+    proofDropsAnyB
+  simp [escalatesB, dropsB, m, emptyCaps, emptyIo, emptyProof]
+
+/- ───────────────────────────────────────────────────────────────────────────
+   #print axioms — axiom-hygiene audit
+   ─────────────────────────────────────────────────────────────────────────── -/
+
+#print axioms flattening_admits_what_per_axis_rejects
+#print axioms T1_gate_sound_multi
+#print axioms identical_child_is_admitted
+#print axioms cross_axis_child_is_rejected
+#print axioms flat_is_a_special_case
+
+end Ck.Policy

--- a/crates/ck-policy/src/extracted.rs
+++ b/crates/ck-policy/src/extracted.rs
@@ -27,6 +27,17 @@
 //!   (`tests/policy_aeneas_parity.rs`), which sample agreement over randomized
 //!   manifests. A proptest is NOT a proof; it narrows the gap probabilistically.
 //!
+//! ## Coverage note (kept current on purpose)
+//!
+//! This core must track the production gate's axes or the deductive bridge
+//! certifies something weaker than what ships. It did not, once: production
+//! gained numeric monotonicity on `constitutional_human_signatures` in #2332
+//! and this core kept only the three booleans, so `T1_extracted_gate_sound`
+//! proved soundness of a gate that could not see the numeric coup. The axis is
+//! now here, in the extracted Lean, and VARIED by the parity proptest — which
+//! previously hard-coded the threshold to 2 and therefore could not have
+//! observed it either.
+//!
 //! The honest end-to-end claim is therefore: *a self-contained, monomorphized
 //! core that faithfully mirrors the gate's verdict was extracted by Charon+Aeneas
 //! and proven in Lean; that core is bound to the production `check_monotonicity`
@@ -127,11 +138,24 @@ pub fn budget_within(child: &[u64; 8], parent: &[u64; 8]) -> bool {
 ///
 /// This is checked UNCONDITIONALLY by the gate — it is never itself gated on any
 /// flag, because a gated anti-coup check could be disarmed one level up.
-pub fn rules_non_weakening(parent: [bool; 3], child: [bool; 3]) -> bool {
+/// The `sigs` arguments are `constitutional_human_signatures`, and they are here
+/// because the boolean flags are not the whole of the anti-coup check. Lowering
+/// the human-signature threshold disarms the review that would police the NEXT
+/// amendment while leaving every boolean untouched — the same coup, spelled
+/// numerically. Production gained this axis in #2332; this core did not, so the
+/// deductive bridge was proving soundness of a gate strictly weaker than the one
+/// that ships. Monotone UPWARD: raising is admitted, lowering is a weakening.
+pub fn rules_non_weakening(
+    parent: [bool; 3],
+    child: [bool; 3],
+    parent_sigs: u32,
+    child_sigs: u32,
+) -> bool {
     let cap_ok = !parent[0] || child[0];
     let io_ok = !parent[1] || child[1];
     let proofreq_ok = !parent[2] || child[2];
-    cap_ok && io_ok && proofreq_ok
+    let sigs_ok = parent_sigs <= child_sigs;
+    cap_ok && io_ok && proofreq_ok && sigs_ok
 }
 
 // ── Per-axis "violated" verdicts (cap/io/proofreq gated on the PARENT flag) ───
@@ -182,12 +206,14 @@ pub fn budget_violated(child: &[u64; 8], parent: &[u64; 8]) -> bool {
 ///   * the budget is within bounds (ALWAYS checked), AND
 ///   * no proof requirement was dropped (gated on `parent_flags[2]`), AND
 ///   * the amendment rules are not weakened (`rules_non_weakening`, checked
-///     UNCONDITIONALLY — the anti-coup fix).
+///     UNCONDITIONALLY — the anti-coup fix), INCLUDING the numeric
+///     human-signature threshold.
 ///
 /// Arguments are the monomorphized projections the gate reads:
 ///   * `parent_flags` / `child_flags`: `[cap, io, proofreq]` governance flags.
 ///   * `*_caps` / `*_io` / `*_proof`: interned-id sets for each authority axis.
 ///   * `*_budget`: the 8 budget bounds.
+///   * `*_sigs`: `constitutional_human_signatures`, monotone upward only.
 ///
 /// `parent_flags` gates cap/io/proofreq; `child_flags` feeds the unconditional
 /// `rules_non_weakening` check. This composition is the structural image of the
@@ -204,12 +230,14 @@ pub fn passed_core(
     child_proof: &[u32],
     parent_budget: &[u64; 8],
     child_budget: &[u64; 8],
+    parent_sigs: u32,
+    child_sigs: u32,
 ) -> bool {
     let cap_ok = !cap_violated(parent_flags[0], child_caps, parent_caps);
     let io_ok = !io_violated(parent_flags[1], child_io, parent_io);
     let budget_ok = !budget_violated(child_budget, parent_budget);
     let proof_ok = !proofreq_violated(parent_flags[2], child_proof, parent_proof);
-    let rules_ok = rules_non_weakening(parent_flags, child_flags);
+    let rules_ok = rules_non_weakening(parent_flags, child_flags, parent_sigs, child_sigs);
     cap_ok && io_ok && budget_ok && proof_ok && rules_ok
 }
 
@@ -285,18 +313,18 @@ mod tests {
         // parent_flag -> child_flag on each axis.
         for &p in &[false, true] {
             for &c in &[false, true] {
-                let ok = rules_non_weakening([p, false, false], [c, false, false]);
+                let ok = rules_non_weakening([p, false, false], [c, false, false], 0, 0);
                 // non-weakening iff NOT(parent ON and child OFF), i.e. parent -> child.
                 assert_eq!(ok, !p || c);
             }
         }
         // enabling a flag the parent didn't require is fine
-        assert!(rules_non_weakening([false, false, false], ALL_ON));
+        assert!(rules_non_weakening([false, false, false], ALL_ON, 0, 0));
         // disabling any required flag is a weakening
-        assert!(!rules_non_weakening(ALL_ON, [false, true, true]));
-        assert!(!rules_non_weakening(ALL_ON, [true, false, true]));
-        assert!(!rules_non_weakening(ALL_ON, [true, true, false]));
-        assert!(rules_non_weakening(ALL_ON, ALL_ON));
+        assert!(!rules_non_weakening(ALL_ON, [false, true, true], 0, 0));
+        assert!(!rules_non_weakening(ALL_ON, [true, false, true], 0, 0));
+        assert!(!rules_non_weakening(ALL_ON, [true, true, false], 0, 0));
+        assert!(rules_non_weakening(ALL_ON, ALL_ON, 0, 0));
     }
 
     #[test]
@@ -313,6 +341,8 @@ mod tests {
             &[4, 5],
             &[10; 8],
             &[10; 8],
+            0,
+            0,
         ));
     }
 
@@ -330,6 +360,8 @@ mod tests {
             &[4, 5], // child proof (superset = stricter, nothing dropped)
             &[10; 8],
             &[5; 8], // tighter budget
+            0,
+            0,
         ));
     }
 
@@ -346,6 +378,8 @@ mod tests {
             &[],
             &Z,
             &Z,
+            0,
+            0,
         ));
     }
 
@@ -363,6 +397,8 @@ mod tests {
             &[],
             &Z,
             &Z,
+            0,
+            0,
         ));
     }
 
@@ -382,6 +418,8 @@ mod tests {
             &[],
             &Z,
             &child_b,
+            0,
+            0,
         ));
     }
 
@@ -398,6 +436,8 @@ mod tests {
             &[1], // child dropped proof req 2
             &Z,
             &Z,
+            0,
+            0,
         ));
     }
 
@@ -414,6 +454,8 @@ mod tests {
             &[],
             &Z,
             &Z,
+            0,
+            0,
         ));
     }
 
@@ -432,6 +474,8 @@ mod tests {
             &[],
             &Z,
             &Z,
+            0,
+            0,
         ));
     }
 
@@ -450,6 +494,8 @@ mod tests {
             &[],
             &Z,
             &Z,
+            0,
+            0,
         ));
     }
 
@@ -467,6 +513,8 @@ mod tests {
             &[],
             &Z,
             &Z,
+            0,
+            0,
         ));
     }
 }

--- a/crates/ck-policy/tests/policy_aeneas_parity.rs
+++ b/crates/ck-policy/tests/policy_aeneas_parity.rs
@@ -230,6 +230,8 @@ fn core_verdict(parent: &PolicyManifest, child: &PolicyManifest) -> bool {
         &child_proof,
         &parent_budget,
         &child_budget,
+        parent.amendment_rules.constitutional_human_signatures,
+        child.amendment_rules.constitutional_human_signatures,
     )
 }
 
@@ -269,6 +271,7 @@ fn manifest(
     proof_bits: u32,
     budget_vals: [u64; 8],
     parallel: u32,
+    sigs: u32,
     flag_cap: bool,
     flag_io: bool,
     flag_proof: bool,
@@ -318,7 +321,7 @@ fn manifest(
             require_monotone_capabilities: flag_cap,
             require_monotone_io: flag_io,
             require_monotone_proofreq: flag_proof,
-            constitutional_human_signatures: 2,
+            constitutional_human_signatures: sigs,
         },
     }
 }
@@ -344,9 +347,13 @@ proptest! {
         cpar in 0u32..6,
         pf_cap in any::<bool>(), pf_io in any::<bool>(), pf_proof in any::<bool>(),
         cf_cap in any::<bool>(), cf_io in any::<bool>(), cf_proof in any::<bool>(),
+        // The numeric governance axis. Held at a constant 2 until now, which is
+        // why this proptest could not observe it: a gate ignoring the threshold
+        // entirely passed all 2048 cases.
+        psigs in 0u32..4, csigs in 0u32..4,
     ) {
-        let parent = manifest(pcaps, pio, ppr, pbud, ppar, pf_cap, pf_io, pf_proof);
-        let child = manifest(ccaps, cio, cpr, cbud, cpar, cf_cap, cf_io, cf_proof);
+        let parent = manifest(pcaps, pio, ppr, pbud, ppar, psigs, pf_cap, pf_io, pf_proof);
+        let child = manifest(ccaps, cio, cpr, cbud, cpar, csigs, cf_cap, cf_io, cf_proof);
 
         let prod = check_monotonicity(&parent, &child).passed;
         let core = core_verdict(&parent, &child);
@@ -364,7 +371,7 @@ proptest! {
 fn meta_gap_coup_parity() {
     let zero = [0u64; 8];
     // fullParent: every monotone flag ON, empty projections.
-    let parent = manifest(0, 0, 0, zero, 0, true, true, true);
+    let parent = manifest(0, 0, 0, zero, 0, 2, true, true, true);
     // disarmingChild: identical projections, capability flag OFF.
     let mut child = parent.clone();
     child.amendment_rules.require_monotone_capabilities = false;
@@ -419,6 +426,8 @@ fn core_verdict_broken_no_parallel(parent: &PolicyManifest, child: &PolicyManife
         &child_proof,
         &budget_arr(&parent.budget_bounds),
         &budget_arr(&child.budget_bounds),
+        parent.amendment_rules.constitutional_human_signatures,
+        child.amendment_rules.constitutional_human_signatures,
     )
 }
 
@@ -427,8 +436,8 @@ fn adapter_binding_is_load_bearing() {
     // Parent allows 1 parallel task; child wants 3 → a capability ESCALATION.
     // Parent has the capability monotonicity flag ON, so production REJECTS.
     let zero = [0u64; 8];
-    let parent = manifest(0, 0, 0, zero, 1, true, true, true);
-    let child = manifest(0, 0, 0, zero, 3, true, true, true);
+    let parent = manifest(0, 0, 0, zero, 1, 2, true, true, true);
+    let child = manifest(0, 0, 0, zero, 3, 2, true, true, true);
 
     let prod = check_monotonicity(&parent, &child).passed;
     assert!(!prod, "production must reject the parallel-task escalation");


### PR DESCRIPTION
Closing the model↔Rust gap turned up something better than the gap itself, plus a correction I owe to my own framing.

## The correction

I proposed *building* an Aeneas extraction of the monotonicity gate. **One already exists** — `crates/ck-policy/src/extracted.rs` (472 lines), extracted by the pinned Charon+Aeneas into `lean-aeneas/generated/`, with `T1_extracted_gate_sound` proved over it and a byte-for-byte drift gate in CI. My survey missed it. The deductive bridge was not missing; it was **stale**.

I also claimed the extracted path flattens five capability axes into one and so carries the same over-permissiveness as the hand model. **That is wrong.** The adapter namespaces every id by sub-axis (`ns(axis, id) = axis*1024 + id`), so its flattening is tag-separated and faithful. The flaw is real only for the hand-written `Ck.Policy` model, which has no namespacing.

## What was actually broken

```rust
pub fn rules_non_weakening(parent: [bool; 3], child: [bool; 3]) -> bool
```

Three booleans, and nothing else. Production gained numeric monotonicity on `constitutional_human_signatures` in #2332; **the extracted core did not.** So the strongest formal artifact in the repo certified soundness of a gate that could not see the numeric coup closed the same day — an amendment lowering the threshold from 2 to 0 disarms the human review that would police the *next* amendment, with every boolean flag untouched.

The parity proptest could not have caught it: the threshold was **hard-coded to 2 on both sides**, so `2 <= 2` held in all 2048 cases and the missing conjunct was invisible. That is the same defect #2332 fixed in the *other* parity test — the one I didn't touch then.

## What changed

| | |
| --- | --- |
| `extracted.rs` | `rules_non_weakening` / `passed_core` take `parent_sigs`/`child_sigs`; conjunct is `parent_sigs <= child_sigs` |
| generated Lean | **regenerated** by the pinned toolchain (charon `nightly-2026-06-01` + aeneas `d71d2e3`), now carrying `(parent_sigs : Std.U32) (child_sigs : Std.U32)` and `ok (parent_sigs <= child_sigs)` |
| `CkPolicyAeneas.lean` | `weakensFlags` gains the numeric disjunct; `rules_non_weakening_val/_sound`, `passed_core_decomp`, `T1_extracted_gate_sound` reproved. Axioms unchanged, no `sorryAx` |
| `policy_aeneas_parity.rs` | the generator **varies** the threshold (`psigs`/`csigs in 0..4`) instead of pinning it |

Crucially the drift gate passes on **genuine Aeneas output, not a hand edit** — I verified the local toolchain reproduces the committed extraction byte-for-byte *before* changing anything, then regenerated after.

## And the hand model, which really was over-permissive

`Ck.Policy` collapses each group to one carrier with no namespacing, so a capability that *moves between axes* leaves the union unchanged:

| | `filesystem_read` | `network_allow` |
| --- | --- | --- |
| parent | `{}` | `{"x"}` |
| child | `{"x"}` | `{}` |

Per axis the child escalates and the gate **rejects**; flattened, `{"x"} ⊆ {"x"}` and the model **admits**. New `Ck/PolicyMulti.lean` proves that by `rfl` (`flattening_admits_what_per_axis_rejects`, axiom-free), restates the model at the real arity (5 cap / 5 io / 3 proofreq), and reproves T1 there as `T1_gate_sound_multi`. `flat_is_a_special_case` pins the old model to the new one. Non-vacuity both ways: an identical child is admitted, the cross-axis child is rejected.

## Verified by mutation

- Make the extracted core ignore the threshold (the pre-change state) → `production_passed_agrees_with_extracted_core` **FAILS**. Before this commit the same mutation passed all 2048 cases.
- Regeneration reproduces the committed Lean exactly — checked *before* editing, to establish the local toolchain matches CI.

## Still open, unchanged

The extracted core is a monomorphized mirror bound to production by a proptest, **not** the literal `check_monotonicity` — `BTreeSet<String>` remains beyond Charon. The three honesty tiers documented in `extracted.rs` are still the accurate description, and I've added a coverage note there about keeping the core's axes current.

## Verification

```
ck-policy 4 suites   ck-types 2   ck-kernel 3
clippy --all-targets --all-features -D warnings   clean
cargo fmt --all --check                            clean
lake build (hand model)      green, no sorryAx
lake build CkPolicyAeneas    green, no sorryAx
charon+aeneas drift gate     byte-identical
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUeXMiQMvNkToXafRkAzVi