### PR TITLE
chore: pay down three named debts, and correct one that was not a debt

### DIFF
--- a/crates/nucleus-oidc-core/Cargo.toml
+++ b/crates/nucleus-oidc-core/Cargo.toml
@@ -21,9 +21,9 @@ base64 = { workspace = true }
 # If a no-default-features dalek is genuinely wanted, it has to be set at the
 # WORKSPACE level with consumers opting back in — a change to every dalek
 # consumer's feature resolution, which deserves its own PR rather than being
-# smuggled in as tidying. Nothing here needs it today: nucleus-oidc-core is not
-# in the wasm-pure set (see .github/workflows/wasm-pure-crates.yml), so the
-# smaller-tree argument does not apply to it.
+# smuggled in as tidying. Nothing here needs it today: this crate is not in the
+# workspace's wasm-pure crate set, so the smaller-tree argument does not apply
+# to it.
 ed25519-dalek = { workspace = true }
 # JWT-SVID signature verification (RS/PS/ES allowlist). Workspace-pinned to
 # the same `rust_crypto` (RustCrypto) backend the rest of the workspace uses,

--- a/crates/nucleus-oidc-core/Cargo.toml
+++ b/crates/nucleus-oidc-core/Cargo.toml
@@ -13,7 +13,18 @@ categories = ["cryptography", "authentication"]
 [dependencies]
 async-trait = { workspace = true }
 base64 = { workspace = true }
-ed25519-dalek = { workspace = true, default-features = false }
+# NOTE: this deliberately does NOT say `default-features = false`. It used to,
+# and it never did anything: a member cannot turn off defaults the workspace
+# turned on, so cargo ignored it and warned on every build that this may become
+# a hard error. Removing it makes the manifest state what actually happens.
+#
+# If a no-default-features dalek is genuinely wanted, it has to be set at the
+# WORKSPACE level with consumers opting back in — a change to every dalek
+# consumer's feature resolution, which deserves its own PR rather than being
+# smuggled in as tidying. Nothing here needs it today: nucleus-oidc-core is not
+# in the wasm-pure set (see .github/workflows/wasm-pure-crates.yml), so the
+# smaller-tree argument does not apply to it.
+ed25519-dalek = { workspace = true }
 # JWT-SVID signature verification (RS/PS/ES allowlist). Workspace-pinned to
 # the same `rust_crypto` (RustCrypto) backend the rest of the workspace uses,
 # so this adds no new crypto backend to the supply chain.

--- a/crates/nucleus-spec/src/lib.rs
+++ b/crates/nucleus-spec/src/lib.rs
@@ -205,6 +205,23 @@ pub struct BudgetModelSpec {
 /// insufficient permission bid, this struct describes what payment
 /// would be required to proceed. The actual payment protocol (x402, etc.)
 /// is implemented by the orchestrator, not by nucleus.
+///
+/// # Why these are `f64` when the rest of the econ stack is `MicroUsd`
+///
+/// This is a **reporting** type, not a ledger type. It is constructed to fill in
+/// an HTTP 402 body and is never read back to compute anything — the charging
+/// path is `nucleus::budget::AtomicBudget`, which is integer micro-USD with
+/// `checked_*` arithmetic and rejects NaN, infinity and non-positive amounts
+/// before converting.
+///
+/// So the inconsistency with `nucleus_econ_types::MicroUsd` is real but is not a
+/// precision hazard, and it is recorded here rather than "fixed" because the fix
+/// is a breaking change to a live 402 wire format bought for no safety gain.
+///
+/// **What would change that:** the moment any code reads a field of this struct
+/// back to compute a charge, a split, or a balance, it becomes a ledger type and
+/// must move to `MicroUsd`. Adding such a caller is the trigger, not the passage
+/// of time.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PaymentRequiredInfo {
     /// Amount required in USD.

--- a/scripts/exemplar-baseline.json
+++ b/scripts/exemplar-baseline.json
@@ -6,7 +6,7 @@
     "lean_theorems_GUARD": 891, "clean_axiom_footprint": "n/a"
   },
   "rust_craft": {
-    "permissive_verify": 24, "verify_calls_GUARD": 53,
+    "permissive_verify": 20, "verify_calls_GUARD": 49,
     "unsafe_blocks": 6,
     "crates_total": 67, "crates_lints_workspace": 41,
     "lints_adoption_pct": 61

--- a/scripts/exemplar-scoreboard.sh
+++ b/scripts/exemplar-scoreboard.sh
@@ -28,10 +28,18 @@ LN=(--include='*.lean' --exclude-dir=.lake --exclude-dir=.claude)
 # from the attribute through its guarded item's closing brace (fresh awk per file,
 # so no cross-file bleed). Verified to keep production `.verify(` and drop only
 # test-module bodies.
+#
+# The attribute match covers COMPOUND cfgs — `#[cfg(all(test, feature = "x"))]`,
+# `#[cfg(any(test, ...))]` — not just the bare `#[cfg(test)]`. Matching only the
+# bare form was the same leak this comment already describes, in a new spelling:
+# four feature-gated test modules counted as production and inflated
+# permissive_verify by 4 (24 -> 20) and verify_calls_GUARD by 4 (53 -> 49).
+# Baselines re-derived in the same commit; see the commit message for why a GUARD
+# drop is legitimate HERE and would not be from a code change.
 nt() {
     grep -rlE "$1" "${RS[@]}" crates 2>/dev/null | while IFS= read -r f; do
         awk '
-            state==0 && $0 ~ /#\[cfg\(test\)\]/ { state=1; next }
+            state==0 && $0 ~ /#\[cfg\((test\)|.*[(,][ ]*test[,)])/ { state=1; next }
             state==1 { o=gsub(/\{/,"{"); c=gsub(/\}/,"}"); if (o>0){ depth=o-c; state=(depth>0?2:0) } next }
             state==2 { depth += gsub(/\{/,"{") - gsub(/\}/,"}"); if (depth<=0) state=0; next }
             { print FILENAME ":" FNR ":" $0 }


### PR DESCRIPTION
Three named debts paid, and one thing I'd called a debt that isn't.

## 1. The scoreboard's non-test filter missed compound `cfg`s

`nt()` strips `#[cfg(test)]` module bodies so test code can't inflate "production" counts — but matched only the **bare** form. `#[cfg(all(test, feature = "x"))]` wasn't stripped, so four feature-gated test modules counted as production:

| metric | before | after |
|---|---|---|
| `permissive_verify` | 24 | **20** |
| `verify_calls_GUARD` | 53 | **49** |

This is the same leak the filter's own comment already describes, recurring in a new spelling.

**Why it wasn't fixed in #2336**, where I found it: the fix *drops* a `*_GUARD` metric, and the anti-gaming check correctly refuses that without a deliberate re-baseline. Changing the measuring instrument inside the PR whose number it measures is the wrong way to do that. Here the re-baseline **is** the change and can be reviewed as such.

**Verified not over-stripping.** The four removed lines are all inside `#[cfg(all(test, feature = …))]` modules — three in `nucleus-recompute/src/lib.rs` (ifc-envelope tests), one in `payout.rs` (envelope tests). No production call site is hidden.

## 2. `nucleus-oidc-core` asked for a no-default-features dalek and never got one

`default-features = false` on the member was **silently ignored**, with cargo warning on every build that it may become a hard error.

Two rounds of investigation before landing on the fix: switching the workspace dep to table form doesn't help, and stating `default-features = true` explicitly only changes the warning *text* — because a member **cannot turn off defaults the workspace turned on**.

So the override was unjustifiable as written. Removed, with the reasoning pinned in the manifest: honouring it requires setting no-default-features at the **workspace** level and having every dalek consumer opt back in — a feature-resolution change across the workspace that deserves its own PR rather than being smuggled in as tidying. Nothing needs it today, and `nucleus-oidc-core` isn't in the wasm-pure set, so the smaller-tree argument doesn't apply to it.

Workspace now builds with **zero** dalek warnings; `nucleus-oidc-core`'s 47 tests pass.

## 3. Not a debt — and I said otherwise

The commerce plan flagged `PaymentRequiredInfo.amount_usd: f64` as *"breaks the integer discipline — fix before it touches a payout path."*

Checked rather than assumed: the struct is constructed to fill an HTTP 402 body and is **never read back to compute anything** — its one binding is `#[allow(unused)]`. It's a *reporting* type. The charging path is `AtomicBudget`: integer micro-USD, checked arithmetic, rejecting NaN, infinity and non-positive amounts before converting.

The inconsistency is real; the hazard was overstated. Converting it is a breaking change to a live 402 wire format bought for no safety gain. So it's **documented on the type** instead — including the trigger that *would* make it a debt:

> the moment any code reads a field back to compute a charge, a split, or a balance, it becomes a ledger type and must move to `MicroUsd`. Adding such a caller is the trigger, not the passage of time.

## Verification

`nucleus-oidc-core` 47, `nucleus-spec` 58. `cargo fmt` clean, workspace builds with zero warnings, and CI's **literal** exemplar-ratchet logic green against the re-derived baseline.
