### PR TITLE
feat(profiles): a bad indent in a security profile now fails the build, not a pod

### DIFF
--- a/crates/portcullis/Cargo.toml
+++ b/crates/portcullis/Cargo.toml
@@ -142,3 +142,8 @@ required-features = ["crypto"]
 [[test]]
 name = "kernel_dlc_admission"
 required-features = ["dlc"]
+
+[build-dependencies]
+# The profile provider validates profiles/*.yaml at BUILD time, so a malformed
+# built-in profile fails `cargo build` instead of panicking in a booting pod.
+serde_yaml = { workspace = true }

--- a/crates/portcullis/build.rs
+++ b/crates/portcullis/build.rs
@@ -1,3 +1,215 @@
+//! Build-time provider for the built-in permission profiles.
+//!
+//! # Why this exists
+//!
+//! The ten YAML files in `profiles/` decide what an agent may do. They were
+//! `include_str!`'d and parsed at process start, behind:
+//!
+//! ```ignore
+//! Self::canonical().expect("canonical profiles must parse")
+//! ```
+//!
+//! so a malformed built-in profile was a **runtime panic in a booting pod**,
+//! discovered on a production node rather than in the build that shipped it.
+//! That is the "a bad indent breaks at runtime" pattern, sitting in the security
+//! kernel of a runtime whose whole purpose is to be the opposite of that.
+//!
+//! This is the F#-type-provider move, in the form Rust offers: read the external
+//! artifact at BUILD time, validate it, and materialise types the compiler can
+//! see. A malformed profile now fails `cargo build`, with the file named.
+//!
+//! # What is checked here, and what is not
+//!
+//! `build.rs` cannot use `portcullis`'s own types — it runs before the crate is
+//! compiled — so validation here is STRUCTURAL: the file parses as YAML, is a
+//! mapping, declares a `name` matching its filename, and carries no key
+//! `ProfileSpec` would not accept. That catches the whole syntax-and-typo class,
+//! which is the class that used to reach production.
+//!
+//! Full type-level validation (does `capabilities.read_files: low_risk` name a
+//! real level?) needs the real serde types, so it lives in a test —
+//! `every_builtin_profile_parses` — which runs in CI against
+//! `ProfileName::ALL`. Between them: a bad indent fails the build, a bad value
+//! fails the tests, and neither reaches a pod.
+
+use std::collections::BTreeSet;
+use std::fmt::Write as _;
+use std::path::Path;
+
+/// Top-level keys `ProfileSpec` accepts. Anything else in a profile is a typo
+/// that would be silently ignored by serde's default behaviour.
+const KNOWN_KEYS: &[&str] = &[
+    "name",
+    "description",
+    "capabilities",
+    "obligations",
+    "paths",
+    "budget",
+    "time",
+];
+
 fn main() {
     println!("cargo:rustc-check-cfg=cfg(kani)");
+    generate_profile_names();
+}
+
+/// `safe-pr-fixer` -> `SafePrFixer`
+fn variant_ident(name: &str) -> String {
+    name.split(['-', '_'])
+        .filter(|s| !s.is_empty())
+        .map(|s| {
+            let mut c = s.chars();
+            match c.next() {
+                Some(f) => f.to_uppercase().collect::<String>() + &c.as_str().to_lowercase(),
+                None => String::new(),
+            }
+        })
+        .collect()
+}
+
+fn generate_profile_names() {
+    let dir = Path::new("profiles");
+    println!("cargo:rerun-if-changed={}", dir.display());
+
+    let mut entries: Vec<(String, String)> = Vec::new(); // (declared name, file stem)
+    let mut files: Vec<_> = std::fs::read_dir(dir)
+        .unwrap_or_else(|e| panic!("cannot read {}: {e}", dir.display()))
+        .filter_map(Result::ok)
+        .map(|e| e.path())
+        .filter(|p| p.extension().is_some_and(|x| x == "yaml"))
+        .collect();
+    files.sort();
+
+    for path in &files {
+        println!("cargo:rerun-if-changed={}", path.display());
+        let stem = path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or_else(|| panic!("non-utf8 profile filename: {}", path.display()))
+            .to_string();
+        let text = std::fs::read_to_string(path)
+            .unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()));
+
+        // 1. It must be YAML at all. This is the bad-indent case, and the error
+        //    carries serde_yaml's line/column.
+        let value: serde_yaml::Value = serde_yaml::from_str(&text)
+            .unwrap_or_else(|e| panic!("{}: not valid YAML: {e}", path.display()));
+
+        let map = value
+            .as_mapping()
+            .unwrap_or_else(|| panic!("{}: a profile must be a mapping", path.display()));
+
+        // 2. No key ProfileSpec would silently ignore.
+        let known: BTreeSet<&str> = KNOWN_KEYS.iter().copied().collect();
+        for k in map.keys() {
+            let key = k
+                .as_str()
+                .unwrap_or_else(|| panic!("{}: non-string key", path.display()));
+            if !known.contains(key) {
+                panic!(
+                    "{}: unknown key `{key}` — a profile accepts only {:?}. \
+                     Left as-is this would be silently ignored.",
+                    path.display(),
+                    KNOWN_KEYS
+                );
+            }
+        }
+
+        // 3. The declared name must match the filename, or `ProfileName::Codegen`
+        //    would resolve to a file called something else.
+        let declared = map
+            .get(serde_yaml::Value::from("name"))
+            .and_then(|v| v.as_str())
+            .unwrap_or_else(|| panic!("{}: missing required `name`", path.display()));
+        if declared != stem {
+            panic!(
+                "{}: declares name `{declared}` but the file is `{stem}.yaml`. \
+                 They must agree — the generated variant is derived from both.",
+                path.display()
+            );
+        }
+        entries.push((declared.to_string(), stem));
+    }
+
+    assert!(
+        entries.len() >= 5,
+        "found only {} built-in profiles; the provider has stopped seeing the \
+         directory and would generate an empty enum",
+        entries.len()
+    );
+
+    let mut out = String::new();
+    out.push_str(
+        "// @generated by build.rs from profiles/*.yaml — do not edit.\n\
+         /// A built-in profile, one variant per file in `profiles/`.\n\
+         ///\n\
+         /// Generated at build time, so a name that is not a built-in profile is\n\
+         /// a compile error rather than a runtime `PolicyError`.\n\
+         #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]\n\
+         pub enum ProfileName {\n",
+    );
+    for (name, _) in &entries {
+        let _ = writeln!(out, "    /// `{name}`\n    {},", variant_ident(name));
+    }
+    out.push_str("}\n\nimpl ProfileName {\n");
+
+    let _ = writeln!(
+        out,
+        "    /// Every built-in profile.\n    pub const ALL: [ProfileName; {}] = [{}];\n",
+        entries.len(),
+        entries
+            .iter()
+            .map(|(n, _)| format!("ProfileName::{}", variant_ident(n)))
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+
+    out.push_str("    /// The canonical name, as written in the YAML.\n");
+    out.push_str("    pub fn as_str(&self) -> &'static str {\n        match self {\n");
+    for (name, _) in &entries {
+        let _ = writeln!(
+            out,
+            "            ProfileName::{} => \"{name}\",",
+            variant_ident(name)
+        );
+    }
+    out.push_str("        }\n    }\n\n");
+
+    out.push_str(
+        "    /// The profile's YAML source, embedded at build time.\n\
+         \x20   pub fn yaml(&self) -> &'static str {\n        match self {\n",
+    );
+    for (name, stem) in &entries {
+        let _ = writeln!(
+            out,
+            "            ProfileName::{} => include_str!(\"{}/profiles/{stem}.yaml\"),",
+            variant_ident(name),
+            env!("CARGO_MANIFEST_DIR")
+        );
+    }
+    out.push_str("        }\n    }\n\n");
+
+    // Hyphen/underscore aliasing, generated rather than hand-maintained: the old
+    // resolver spelled every pair out by hand (`"pr_review" | "pr-review"`) and
+    // had to be kept in sync with this directory by memory.
+    out.push_str(
+        "    /// Resolve a name, accepting `-` and `_` interchangeably.\n\
+         \x20   ///\n\
+         \x20   /// Returns the candidate list on failure so the caller can say what\n\
+         \x20   /// WAS valid — a bare \"unknown profile\" is how a typo becomes a\n\
+         \x20   /// support ticket.\n\
+         \x20   pub fn parse(s: &str) -> Result<ProfileName, Vec<&'static str>> {\n\
+         \x20       let norm = s.trim().to_lowercase().replace('_', \"-\");\n\
+         \x20       for p in ProfileName::ALL {\n\
+         \x20           if p.as_str() == norm {\n\
+         \x20               return Ok(p);\n\
+         \x20           }\n\
+         \x20       }\n\
+         \x20       Err(ProfileName::ALL.iter().map(|p| p.as_str()).collect())\n\
+         \x20   }\n",
+    );
+    out.push_str("}\n");
+
+    let dest = std::path::PathBuf::from(std::env::var("OUT_DIR").unwrap()).join("profile_names.rs");
+    std::fs::write(&dest, out).unwrap_or_else(|e| panic!("cannot write {}: {e}", dest.display()));
 }

--- a/crates/portcullis/src/profile.rs
+++ b/crates/portcullis/src/profile.rs
@@ -453,16 +453,7 @@ impl ProfileSpec {
 
 // ── Canonical profiles (embedded at compile time) ─────────────────────
 
-const SAFE_PR_FIXER_YAML: &str = include_str!("../profiles/safe-pr-fixer.yaml");
-const DOC_EDITOR_YAML: &str = include_str!("../profiles/doc-editor.yaml");
-const TEST_RUNNER_YAML: &str = include_str!("../profiles/test-runner.yaml");
-const TRIAGE_BOT_YAML: &str = include_str!("../profiles/triage-bot.yaml");
-const CODE_REVIEW_YAML: &str = include_str!("../profiles/code-review.yaml");
-const CODEGEN_YAML: &str = include_str!("../profiles/codegen.yaml");
-const RELEASE_YAML: &str = include_str!("../profiles/release.yaml");
-const RESEARCH_WEB_YAML: &str = include_str!("../profiles/research-web.yaml");
-const READ_ONLY_YAML: &str = include_str!("../profiles/read-only.yaml");
-const LOCAL_DEV_YAML: &str = include_str!("../profiles/local-dev.yaml");
+include!(concat!(env!("OUT_DIR"), "/profile_names.rs"));
 
 /// A profile entry with its specification and provenance.
 #[derive(Debug, Clone)]
@@ -504,20 +495,12 @@ impl ProfileRegistry {
     /// profiles are available immediately.
     pub fn canonical() -> Result<Self, ProfileError> {
         let mut registry = Self::empty();
-        let builtins = vec![
-            ProfileSpec::from_yaml(SAFE_PR_FIXER_YAML)?,
-            ProfileSpec::from_yaml(DOC_EDITOR_YAML)?,
-            ProfileSpec::from_yaml(TEST_RUNNER_YAML)?,
-            ProfileSpec::from_yaml(TRIAGE_BOT_YAML)?,
-            ProfileSpec::from_yaml(CODE_REVIEW_YAML)?,
-            ProfileSpec::from_yaml(CODEGEN_YAML)?,
-            ProfileSpec::from_yaml(RELEASE_YAML)?,
-            ProfileSpec::from_yaml(RESEARCH_WEB_YAML)?,
-            ProfileSpec::from_yaml(READ_ONLY_YAML)?,
-            ProfileSpec::from_yaml(LOCAL_DEV_YAML)?,
-        ];
-        for spec in builtins {
-            registry.register_with_source(spec, ProfileSource::Builtin);
+        // Driven by the build-time provider rather than a hand-written list: a
+        // profile added to `profiles/` appears here without anyone remembering
+        // to add it, and one that does not parse failed `cargo build` already.
+        for name in ProfileName::ALL {
+            registry
+                .register_with_source(ProfileSpec::from_yaml(name.yaml())?, ProfileSource::Builtin);
         }
         Ok(registry)
     }
@@ -1206,5 +1189,114 @@ capabilities:
         assert_eq!(registry.len(), 2);
         assert!(registry.resolve("alpha").is_ok());
         assert!(registry.resolve("beta").is_ok());
+    }
+}
+
+#[cfg(test)]
+mod builtin_profile_provider {
+    //! The built-in profiles decide what an agent may do, and they used to be
+    //! YAML parsed at process start behind
+    //! `Self::canonical().expect("canonical profiles must parse")` — so a
+    //! malformed one was a runtime panic in a booting pod.
+    //!
+    //! `build.rs` now reads `profiles/` at BUILD time, refuses a file that is not
+    //! YAML, is not a mapping, carries an unknown top-level key, or whose
+    //! declared `name` disagrees with its filename, and generates
+    //! [`ProfileName`] from what survives. A bad indent fails `cargo build`.
+    //!
+    //! `build.rs` cannot use this crate's types, so its validation is
+    //! structural. The type-level half is here.
+
+    use super::*;
+
+    /// The half `build.rs` cannot do: every built-in profile parses into the
+    /// real `ProfileSpec`, with the real capability levels.
+    ///
+    /// Together with the build-time structural check this closes the loop — a
+    /// bad indent fails the build, a bad *value* fails here, and neither reaches
+    /// a pod.
+    #[test]
+    fn every_builtin_profile_parses_with_the_real_types() {
+        for name in ProfileName::ALL {
+            let spec = ProfileSpec::from_yaml(name.yaml()).unwrap_or_else(|e| {
+                panic!("built-in profile `{}` does not parse: {e}", name.as_str())
+            });
+            assert_eq!(
+                spec.name,
+                name.as_str(),
+                "the generated variant and the YAML disagree on the name"
+            );
+        }
+    }
+
+    /// Non-vacuity: the loop above must actually iterate. An empty `ALL` would
+    /// make it pass while checking nothing — the failure mode that has bitten
+    /// this repo repeatedly.
+    #[test]
+    fn the_provider_found_the_profiles() {
+        assert!(
+            ProfileName::ALL.len() >= 10,
+            "expected the ten built-in profiles, generator produced {}",
+            ProfileName::ALL.len()
+        );
+    }
+
+    /// The registry is driven by the provider, so every generated name resolves.
+    #[test]
+    fn canonical_registry_contains_exactly_the_generated_profiles() {
+        let registry = ProfileRegistry::canonical().expect("canonical must build");
+        for name in ProfileName::ALL {
+            assert!(
+                registry.resolve(name.as_str()).is_ok(),
+                "`{}` is generated but not registered",
+                name.as_str()
+            );
+        }
+        assert_eq!(
+            registry.names().len(),
+            ProfileName::ALL.len(),
+            "the registry and the provider disagree on how many built-ins exist"
+        );
+    }
+
+    /// Hyphen and underscore are interchangeable — the behaviour the old
+    /// hand-written `"pr_review" | "pr-review"` table provided, now generated so
+    /// it cannot drift from the directory.
+    #[test]
+    fn underscores_and_hyphens_are_interchangeable() {
+        assert_eq!(
+            ProfileName::parse("safe-pr-fixer"),
+            Ok(ProfileName::SafePrFixer)
+        );
+        assert_eq!(
+            ProfileName::parse("safe_pr_fixer"),
+            Ok(ProfileName::SafePrFixer)
+        );
+        assert_eq!(
+            ProfileName::parse("  Safe_PR_Fixer  "),
+            Ok(ProfileName::SafePrFixer)
+        );
+    }
+
+    /// A typo must not resolve, and must say what WAS valid. "unknown profile"
+    /// with no candidate list is how a typo becomes a support ticket.
+    #[test]
+    fn a_typo_is_refused_and_the_candidates_are_offered() {
+        let err = ProfileName::parse("codgen").expect_err("a typo must not resolve");
+        assert!(
+            err.contains(&"codegen"),
+            "the error must offer the real names, got {err:?}"
+        );
+    }
+
+    /// The point of the whole exercise: a name is checked by the compiler, not
+    /// at pod boot. `ProfileName::Codgen` does not compile — there is no such
+    /// variant — which is not something a runtime test can demonstrate, so this
+    /// asserts the reachable half: the variant exists and denotes the profile.
+    #[test]
+    fn a_profile_name_is_a_type_not_a_string() {
+        let p: ProfileName = ProfileName::Codegen;
+        assert_eq!(p.as_str(), "codegen");
+        assert!(ProfileSpec::from_yaml(p.yaml()).is_ok());
     }
 }


### PR DESCRIPTION
The ten YAML files in `portcullis/profiles/` decide what an agent may do. They were parsed at process start, behind this:

```rust
Self::canonical().expect("canonical profiles must parse")
```

A malformed built-in profile was a **runtime panic in a booting pod** — discovered on a production node rather than in the build that shipped it. The "bad indent breaks at runtime" pattern, sitting in the security kernel of a runtime whose entire purpose is to be the opposite of that.

## The type-provider move, in the form Rust offers

`build.rs` now reads `profiles/` at **build** time — the F# type-provider shape: consume an external artifact during compilation and materialise types the checker can see. It refuses a file that

- is not valid YAML (with serde_yaml's line and column),
- is not a mapping,
- carries a top-level key `ProfileSpec` would silently ignore,
- declares a `name` disagreeing with its filename,

and generates `ProfileName` from what survives — one variant per file, plus `ALL`, `as_str()`, `yaml()`, and a `parse()` accepting `-`/`_` interchangeably that returns the candidate list on failure.

`canonical()` iterates `ProfileName::ALL` instead of a hand-written `vec![]` of ten `from_yaml` calls, so a profile added to the directory appears without anyone remembering to add it. The ten now-redundant `const *_YAML` lines are gone.

## Demonstrated, not asserted

Three mutations, each failing `cargo build`:

| mutation | build error |
| --- | --- |
| bad indent | `profiles/codegen.yaml: not valid YAML: mapping values are not allowed in this context at line 5 column 15` |
| unknown key | ``profiles/codegen.yaml: unknown key `capabilties` — a profile accepts only [...]. Left as-is this would be silently ignored.`` |
| name/file mismatch | ``profiles/codegen.yaml: declares name `codgen` but the file is `codegen.yaml`.`` |

## What `build.rs` cannot check, and where that lives instead

`build.rs` runs before the crate compiles, so it cannot use `ProfileSpec` — its validation is structural. The type-level half is a test, `every_builtin_profile_parses_with_the_real_types`, parsing each `ProfileName::ALL` entry with the real serde types.

Between them: **a bad indent fails the build, a bad *value* fails the tests, neither reaches a pod.** The tests also assert `ALL.len() >= 10`, so an empty generated enum cannot pass vacuously.

## Scope correction to my own plan

The plan said to replace the ~20-arm `match name.as_str()` in `nucleus-spec` with the generated resolver. **That would have been wrong, and is not done.**

Those arms resolve `PermissionLattice` *constructors*, and most have no YAML file at all — `default`, `demo`, `fix_issue`, `permissive`, `restrictive`, `orchestrator`, `pr_review`, `pr_approve`, `database_client`, `edit_only`, `network_only`, `web_research`, `filesystem_readonly`. Swapping in `ProfileName::parse` would have broken every one.

Worth recording as its own finding: **nucleus has two overlapping profile namespaces** — ten YAML files and ~20 lattice constructors, sharing six names. This change neither creates nor fixes that; it's a latent confusion someone should decide about.

## Verification

```
portcullis / nucleus-spec / nucleus-cli / nucleus-node   all green, 0 failures
6 new provider tests
clippy --all-targets --all-features -D warnings   clean
cargo fmt --all --check                            clean
```

Second of the "make invalid states unrepresentable" items; #2346 was the first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUeXMiQMvNkToXafRkAzVi