### PR TITLE
feat(egress): a pod cannot build a client for a host its own policy forbids

### DIFF
--- a/crates/nucleus-client/src/drand.rs
+++ b/crates/nucleus-client/src/drand.rs
@@ -363,7 +363,22 @@ mod async_client {
         /// # Panics
         ///
         /// Panics if the public key is configured but invalid.
-        pub fn new(config: DrandConfig) -> Result<Self, String> {
+        /// # Egress admission
+        ///
+        /// Takes an [`Admitted`](crate::egress::Admitted) — an unforgeable proof
+        /// that the pod's policy allows the beacon host. There is no way to
+        /// build this client for a host the policy forbids, because there is no
+        /// way to construct the proof.
+        ///
+        /// That is the defect this closes. A pod runs under default-deny egress,
+        /// so the fetch to `api.drand.sh` could not succeed — and it was still
+        /// well-typed, and still cost **5044 ms of a 5497 ms startup**, measured,
+        /// on every pod boot. `reqwest::Client` is ambient authority: nothing in
+        /// its type mentions where it may connect.
+        pub fn new(
+            config: DrandConfig,
+            _admitted: crate::egress::Admitted,
+        ) -> Result<Self, String> {
             let client = reqwest::Client::builder()
                 .timeout(Duration::from_secs(5))
                 .build()
@@ -592,9 +607,14 @@ mod constructor_tests {
     /// which reqwest reports as an `Err`, and which the old `.expect` turned
     /// into a kernel panic. Binding the function to its type is what keeps that
     /// `.expect` from coming back.
+    ///
+    /// The signature now also carries an [`Admitted`](crate::egress::Admitted):
+    /// pinning it here means a future edit cannot quietly drop the egress proof
+    /// and restore ambient authority to the beacon fetch.
     #[test]
     fn the_constructor_hands_failure_back_instead_of_expecting() {
-        let _shape: fn(DrandConfig) -> Result<DrandClient, String> = DrandClient::new;
+        let _shape: fn(DrandConfig, crate::egress::Admitted) -> Result<DrandClient, String> =
+            DrandClient::new;
     }
 }
 

--- a/crates/nucleus-client/src/egress.rs
+++ b/crates/nucleus-client/src/egress.rs
@@ -1,0 +1,191 @@
+//! A proof that the pod's egress policy admits a host.
+//!
+//! # The bug this exists to make unwritable
+//!
+//! A pod runs under **default-deny egress**. The audit log anchored every entry
+//! to the drand beacon by fetching `https://api.drand.sh/public/latest` with a
+//! 5-second timeout — a request the pod's own network policy forbids. It could
+//! not succeed. Not "usually failed": *could not succeed*. Measured on an M5
+//! Pro, that single call was **5044 ms of a 5497 ms tool-proxy startup**, paid
+//! by every pod, forever, before it would serve a single request.
+//!
+//! Nothing was broken. Nothing logged. The call compiled because
+//! `reqwest::Client` is **ambient authority**: its type says nothing about where
+//! it may connect, and the policy that forbade the destination was a runtime
+//! value living in another crate.
+//!
+//! # The shape of the fix
+//!
+//! [`Admitted`] has **no public constructor**. The only way to obtain one is
+//! [`EgressPolicy::admit`], which consults the pod's resolved allowlists. A
+//! client that takes an `Admitted` therefore cannot be built for a host the
+//! policy forbids — there is no term to pass.
+//!
+//! This is the idiom the repo already uses for authority elsewhere:
+//! `SessionCleanseToken` is "unforgeable outside `nucleus-ifc-kernel`, mintable
+//! only with a `DischargedBundle`", and `Authority::spend` refuses an
+//! unwitnessed authority. Egress had no equivalent, so the drand call was
+//! well-typed.
+//!
+//! # What this does and does not buy
+//!
+//! It does not make the fetch fast, and it does not replace the deadline that
+//! now bounds the boot report — an *admitted* host can still be slow. What it
+//! removes is the case where the destination was never reachable in the first
+//! place, which is the one that cost five seconds a boot.
+//!
+//! It is also not airtight on its own: `reqwest::Client::builder()` remains
+//! callable by anyone. Closing that needs the companion source check
+//! (`no_unpoliced_http_clients`) that refuses raw client construction outside
+//! the blessed constructors. The witness is the type; the check is what makes
+//! the type the only door.
+
+/// Proof that the egress policy admits a host.
+///
+/// Construct only via [`EgressPolicy::admit`]. The private field is what makes
+/// this unforgeable from outside this module — a `pub struct` with all-public
+/// fields would be a comment, not a guarantee.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Admitted {
+    host: String,
+}
+
+impl Admitted {
+    /// The host this proof is about.
+    pub fn host(&self) -> &str {
+        &self.host
+    }
+}
+
+/// The pod's resolved egress allowlists.
+///
+/// Built from `nucleus_spec::NetworkSpec`'s `dns_allow` / `url_allow` by the
+/// caller that has them; this crate is a leaf and deliberately does not depend
+/// on the spec types.
+#[derive(Debug, Clone, Default)]
+pub struct EgressPolicy {
+    dns_allow: Vec<String>,
+}
+
+impl EgressPolicy {
+    /// A policy admitting exactly these hosts.
+    ///
+    /// An empty allowlist admits **nothing**. That is the default-deny posture a
+    /// pod actually runs under, and making it the natural reading of an empty
+    /// `Vec` is deliberate: the alternative — empty means "unrestricted" — is
+    /// how allowlists become decorative.
+    pub fn new(dns_allow: Vec<String>) -> Self {
+        Self { dns_allow }
+    }
+
+    /// A policy admitting everything, for a caller that is **not** under pod
+    /// egress policy.
+    ///
+    /// The node process is the host: it is not sandboxed, and its outbound
+    /// calls (OIDC, JWKS, the beacon it serves to pods) are not what
+    /// default-deny constrains. Naming that explicitly is the point — an
+    /// unrestricted policy should be a visible decision at the call site, not
+    /// the accidental default that ambient `reqwest::Client` gave everyone.
+    ///
+    /// Do NOT use this inside the guest tool-proxy.
+    pub fn unrestricted_host_process() -> Self {
+        Self {
+            dns_allow: vec!["*".to_string()],
+        }
+    }
+
+    /// Mint a proof that `host` is admitted, or `None`.
+    ///
+    /// Matching is exact or single-level wildcard (`*.example.com`), case
+    /// insensitive. It deliberately does NOT accept a bare `*` as "everything"
+    /// unless the operator wrote `*`, and a leading-dot suffix match is not
+    /// supported, because `evilexample.com` must not match `example.com`.
+    pub fn admit(&self, host: &str) -> Option<Admitted> {
+        let host = host.trim().to_lowercase();
+        if host.is_empty() {
+            return None;
+        }
+        for pattern in &self.dns_allow {
+            let p = pattern.trim().to_lowercase();
+            if p == "*" || p == host {
+                return Some(Admitted { host });
+            }
+            if let Some(suffix) = p.strip_prefix("*.") {
+                // `*.example.com` matches `api.example.com`, and must NOT match
+                // `example.com` itself nor `notexample.com`.
+                if let Some(rest) = host.strip_suffix(suffix) {
+                    if rest.ends_with('.') && rest.len() > 1 {
+                        return Some(Admitted { host });
+                    }
+                }
+            }
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The drand case, exactly: a default-deny pod cannot mint a proof for the
+    /// beacon, so a client requiring one cannot be built.
+    #[test]
+    fn a_default_deny_pod_admits_nothing() {
+        let policy = EgressPolicy::default();
+        assert!(policy.admit("api.drand.sh").is_none());
+        assert!(policy.admit("example.com").is_none());
+    }
+
+    /// Non-vacuity: an operator who allows the beacon gets a proof, so the
+    /// refusal above is about the policy and not about `admit` always failing.
+    #[test]
+    fn an_allowed_host_is_admitted() {
+        let policy = EgressPolicy::new(vec!["api.drand.sh".into()]);
+        let a = policy.admit("api.drand.sh").expect("explicitly allowed");
+        assert_eq!(a.host(), "api.drand.sh");
+    }
+
+    #[test]
+    fn wildcards_match_a_subdomain_but_not_the_apex_or_a_prefix_collision() {
+        let policy = EgressPolicy::new(vec!["*.example.com".into()]);
+        assert!(policy.admit("api.example.com").is_some());
+        assert!(
+            policy.admit("example.com").is_none(),
+            "`*.example.com` must not admit the apex"
+        );
+        assert!(
+            policy.admit("notexample.com").is_none(),
+            "a suffix match would admit an attacker-registered lookalike"
+        );
+        assert!(
+            policy.admit("evil.com").is_none(),
+            "an unrelated host must not be admitted"
+        );
+    }
+
+    #[test]
+    fn matching_is_case_and_whitespace_insensitive() {
+        let policy = EgressPolicy::new(vec!["  API.Example.COM ".into()]);
+        assert!(policy.admit("api.example.com").is_some());
+    }
+
+    #[test]
+    fn an_empty_host_is_never_admitted() {
+        let policy = EgressPolicy::new(vec!["*".into()]);
+        assert!(policy.admit("").is_none());
+        assert!(policy.admit("   ").is_none());
+    }
+
+    /// `Admitted` must be unforgeable outside this module. This test documents
+    /// the property; the compiler enforces it, because the field is private and
+    /// there is no other constructor.
+    #[test]
+    fn admitted_has_no_public_constructor() {
+        let policy = EgressPolicy::new(vec!["a.example".into()]);
+        let a = policy.admit("a.example").unwrap();
+        // The only way to get here was through `admit`. A caller outside this
+        // module cannot write `Admitted { host: .. }`.
+        assert_eq!(a.host(), "a.example");
+    }
+}

--- a/crates/nucleus-client/src/lib.rs
+++ b/crates/nucleus-client/src/lib.rs
@@ -42,6 +42,8 @@ use hmac::{digest::KeyInit, Hmac, Mac};
 use sha2::Sha256;
 
 pub mod drand;
+/// Egress admission proofs: a host the pod's policy allows.
+pub mod egress;
 
 /// Signed headers for an HTTP request.
 #[derive(Debug, Clone)]

--- a/crates/nucleus-node/src/signed_proxy.rs
+++ b/crates/nucleus-node/src/signed_proxy.rs
@@ -108,20 +108,25 @@ impl SignedProxy {
         let listen_addr = listener.local_addr()?;
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
 
-        let drand_client =
-            drand_config
-                .filter(|c| c.enabled)
-                .and_then(|c| match DrandClient::new(c) {
-                    Ok(client) => Some(Arc::new(client)),
-                    Err(why) => {
-                        // The node is not PID 1, so it degrades rather than exiting.
-                        // Escalation still refuses without drand — see the `else`
-                        // arm in the tool-proxy's escalation handler — so this is a
-                        // loud degradation, not a silent bypass.
-                        tracing::error!("drand disabled for signed proxy: {why}");
-                        None
-                    }
-                });
+        let drand_client = drand_config.filter(|c| c.enabled).and_then(|c| {
+            // The NODE is the host process, not a sandboxed pod: pod
+            // egress policy does not apply to it. Stated at the call
+            // site rather than assumed.
+            let admitted = nucleus_client::egress::EgressPolicy::unrestricted_host_process()
+                .admit("api.drand.sh")
+                .expect("an unrestricted policy admits every host");
+            match DrandClient::new(c, admitted) {
+                Ok(client) => Some(Arc::new(client)),
+                Err(why) => {
+                    // The node is not PID 1, so it degrades rather than exiting.
+                    // Escalation still refuses without drand — see the `else`
+                    // arm in the tool-proxy's escalation handler — so this is a
+                    // loud degradation, not a silent bypass.
+                    tracing::error!("drand disabled for signed proxy: {why}");
+                    None
+                }
+            }
+        });
 
         let state = SignedProxyState {
             target,

--- a/crates/nucleus-tool-proxy/src/drand_setup.rs
+++ b/crates/nucleus-tool-proxy/src/drand_setup.rs
@@ -1,0 +1,89 @@
+//! Building the drand client, and the egress proof it now requires.
+//!
+//! Extracted from `main` when the client gained an egress admission argument:
+//! `main.rs` sits on its line ratchet, so the policy check had to buy its own
+//! room — which is what the ratchet is for.
+//!
+//! The substance is the `admit` call. A pod runs under default-deny egress, so
+//! the beacon at `api.drand.sh` is unreachable by construction; the old code
+//! built a client anyway and spent a five-second timeout per boot discovering
+//! it (measured on an M5 Pro: 5044 ms of a 5497 ms startup). Now the pod's own
+//! allowlist decides, and without an `Admitted` there is no client to build.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tracing::{error, info, warn};
+
+use nucleus_client::drand::{DrandClient, DrandConfig, DrandFailMode};
+
+use crate::Args;
+
+/// Build the audit log's drand client, if the pod is allowed to reach the beacon.
+pub(crate) fn build_drand_client(args: &Args, dns_allow: &[String]) -> Option<Arc<DrandClient>> {
+    // Set up drand client for cryptographic time anchoring if drand is enabled
+    if !args.drand_enabled {
+        return None;
+    }
+    {
+        let fail_mode = match args.drand_fail_mode.to_lowercase().as_str() {
+            "cached" => DrandFailMode::Cached,
+            _ => DrandFailMode::Strict,
+        };
+        let config = DrandConfig {
+            enabled: true,
+            api_url: args.drand_url.clone(),
+            round_tolerance: args.drand_tolerance,
+            cache_ttl: Duration::from_secs(25),
+            fail_mode,
+            chain_hash: None, // Use default
+            public_key: None, // Use default
+        };
+        info!(
+            "drand anchoring enabled for audit logs (url={}, tolerance={})",
+            args.drand_url, args.drand_tolerance
+        );
+        // Exit with the reason rather than panicking. In a microVM this process
+        // is PID 1: a panic here kills init and panics the kernel, so the
+        // operator sees a reqwest error inside a kernel backtrace instead of the
+        // one sentence that tells them what to do.
+        //
+        // Refusing to start (rather than degrading to `None`) is deliberate: the
+        // operator asked for drand anchoring, and a pod that ran without it
+        // while reporting success would be a claim outrunning its wiring. The
+        // escalation path already refuses when drand is absent; this makes the
+        // refusal legible at the moment it is decided.
+        // The pod's OWN egress policy decides whether the beacon is reachable.
+        // Under default-deny it is not, and there is then no `Admitted` to pass
+        // — so the client cannot be built, rather than being built and spending
+        // five seconds per boot discovering it (measured: 5044ms of 5497ms).
+        let beacon_host = config
+            .api_url
+            .split("://")
+            .nth(1)
+            .and_then(|rest| rest.split('/').next())
+            .unwrap_or_default()
+            .to_string();
+        let admitted =
+            nucleus_client::egress::EgressPolicy::new(dns_allow.to_vec()).admit(&beacon_host);
+        match admitted {
+            None => {
+                warn!(
+                    host = %beacon_host,
+                    "drand anchoring requested, but this pod's egress policy does not \
+                     admit the beacon host, so anchoring is unavailable. Add the host \
+                     to dns_allow if the workload genuinely needs anchored approvals."
+                );
+                None
+            }
+            Some(admitted) => match DrandClient::new(config, admitted) {
+                Ok(c) => Some(Arc::new(c)),
+                Err(why) => {
+                    error!("{why}");
+                    eprintln!("FATAL: {why}");
+                    std::process::exit(1);
+                }
+            },
+        }
+    }
+}

--- a/crates/nucleus-tool-proxy/src/main.rs
+++ b/crates/nucleus-tool-proxy/src/main.rs
@@ -34,6 +34,7 @@ mod broker_client;
 mod cert_bridge;
 mod declassify;
 mod dlc_admission;
+mod drand_setup;
 mod egress;
 mod escalate;
 mod exit_report;
@@ -1569,8 +1570,6 @@ async fn main() -> Result<(), ApiError> {
         }
     };
 
-    let audit = st.timed("audit_log", build_audit_log(&args, &auth)).await?;
-
     // Resolve all web_fetch enforcement inputs (DNS/URL allowlists + per-pod
     // MIME and response-cap overrides) BEFORE building the client, so its
     // redirect policy can re-check every hop against the allowlists.
@@ -1582,6 +1581,10 @@ async fn main() -> Result<(), ApiError> {
     let url_allow = web_fetch_cfg.url_allow;
     let web_fetch_mime_allow = web_fetch_cfg.mime_allow;
     let web_fetch_max_bytes = web_fetch_cfg.max_bytes;
+
+    let audit = st
+        .timed("audit_log", build_audit_log(&args, &auth, &dns_allow))
+        .await?;
 
     // Client re-checks every redirect hop against the allowlists (see
     // `web_fetch_policy::build_web_fetch_client`) — closes the SSRF/exfil hop.
@@ -4425,9 +4428,11 @@ fn resolve_approval_expiry(
 
 // Pod management handlers live in pod_mgmt.rs
 
-async fn build_audit_log(args: &Args, auth: &AuthConfig) -> Result<Arc<AuditLog>, ApiError> {
-    use nucleus_client::drand::{DrandClient, DrandConfig, DrandFailMode};
-
+async fn build_audit_log(
+    args: &Args,
+    auth: &AuthConfig,
+    dns_allow: &[String],
+) -> Result<Arc<AuditLog>, ApiError> {
     let path = args.audit_log.clone();
 
     // Ensure parent directory exists (e.g., /var/log/nucleus/ or the pod state dir).
@@ -4469,46 +4474,7 @@ async fn build_audit_log(args: &Args, auth: &AuthConfig) -> Result<Arc<AuditLog>
         None
     };
 
-    // Set up drand client for cryptographic time anchoring if drand is enabled
-    let drand_client = if args.drand_enabled {
-        let fail_mode = match args.drand_fail_mode.to_lowercase().as_str() {
-            "cached" => DrandFailMode::Cached,
-            _ => DrandFailMode::Strict,
-        };
-        let config = DrandConfig {
-            enabled: true,
-            api_url: args.drand_url.clone(),
-            round_tolerance: args.drand_tolerance,
-            cache_ttl: Duration::from_secs(25),
-            fail_mode,
-            chain_hash: None, // Use default
-            public_key: None, // Use default
-        };
-        info!(
-            "drand anchoring enabled for audit logs (url={}, tolerance={})",
-            args.drand_url, args.drand_tolerance
-        );
-        // Exit with the reason rather than panicking. In a microVM this process
-        // is PID 1: a panic here kills init and panics the kernel, so the
-        // operator sees a reqwest error inside a kernel backtrace instead of the
-        // one sentence that tells them what to do.
-        //
-        // Refusing to start (rather than degrading to `None`) is deliberate: the
-        // operator asked for drand anchoring, and a pod that ran without it
-        // while reporting success would be a claim outrunning its wiring. The
-        // escalation path already refuses when drand is absent; this makes the
-        // refusal legible at the moment it is decided.
-        match DrandClient::new(config) {
-            Ok(c) => Some(Arc::new(c)),
-            Err(why) => {
-                tracing::error!("{why}");
-                eprintln!("FATAL: {why}");
-                std::process::exit(1);
-            }
-        }
-    } else {
-        None
-    };
+    let drand_client = drand_setup::build_drand_client(args, dns_allow);
 
     // Set up S3 sink for deletion-resistant audit storage
     #[cfg(feature = "remote-audit")]


### PR DESCRIPTION
Item 3 of the make-invalid-states-unrepresentable arc — the one aimed at the bug that started it.

## The defect, restated as a type problem

A pod runs under **default-deny egress**. The audit log anchored every entry to the drand beacon by fetching `https://api.drand.sh/public/latest` with a 5 s timeout — a request the pod's own network policy forbids. It could not succeed. Not "usually failed": *could not*. Measured on an M5 Pro, that one call was **5044 ms of a 5497 ms tool-proxy startup**, paid by every pod, before it served anything.

Nothing was broken and nothing logged. The call compiled because `reqwest::Client` is **ambient authority**: nothing in its type says where it may connect, and the policy forbidding the destination was a runtime value in another crate.

#2344 bounded the symptom with a deadline. **This removes the call's well-typedness.**

## The witness

`nucleus_client::egress::Admitted` has **no public constructor**. The only way to obtain one is `EgressPolicy::admit(host)`, which consults the pod's resolved `dns_allow`. `DrandClient::new` now takes one — so there is no way to build the client for a forbidden host, because there is no term to pass.

This is the idiom the repo already uses for authority: `SessionCleanseToken` is *"unforgeable outside `nucleus-ifc-kernel`, mintable only with a `DischargedBundle`"*, and `Authority::spend` refuses an unwitnessed authority. Egress had no equivalent, which is exactly why the drand call type-checked.

## The compiler found both call sites, and they want opposite answers

| | |
| --- | --- |
| **guest tool-proxy** | mints from its own `dns_allow`. Under default-deny there is no proof, so anchoring is unavailable **and says so** — instead of costing five seconds to discover the same thing. |
| **node** | is the host process, not a sandboxed pod; pod egress policy does not apply. Calls `EgressPolicy::unrestricted_host_process()`, named so "unrestricted" is a *visible decision* at the call site rather than the accidental default ambient `reqwest::Client` gave everyone. |

## Matching is deliberately narrow

`*.example.com` admits `api.example.com` and refuses **both** `example.com` and `notexample.com` — a suffix match would admit an attacker-registered lookalike. An empty allowlist admits **nothing**, because the alternative reading (empty means unrestricted) is how allowlists become decorative.

## Verified by mutation

Make `admit` return `Some` unconditionally — ambient authority restored — and **3 of the 6 egress tests fail**. The existing signature-pin test `the_constructor_hands_failure_back_instead_of_expecting` now also pins the `Admitted` parameter, so a future edit cannot quietly drop the proof.

## Honest limits

`reqwest::Client::builder()` is **still callable by anyone** — there are 24 construction sites across 15 files. The witness is the type; a lint making it the only door is the follow-up. Without that, this is a strong convention on one path rather than a closed boundary, and I'd rather say so than imply the class is closed.

## Ratchet

`build_drand_client` extracted to `drand_setup.rs` — the policy check bought its own room. `main.rs` 5004 → 4940, ceiling 4975.

## Verification

```
nucleus-tool-proxy 358 passed    nucleus-client 35 + 6 new
clippy --all-targets --all-features -D warnings   clean on both
cargo fmt --all --check                            clean
```

`nucleus-node`'s 9 `--all-features` clippy errors are **pre-existing on main** — verified against a stashed tree, not assumed.

Completes the arc: #2346 (strict specs), #2347 (profile provider), this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUeXMiQMvNkToXafRkAzVi