### PR TITLE
docs(readme): the first command now works on a stock Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,16 +28,28 @@ On top of that core, Nucleus adds three newer pillars — a **Constitutional Ker
 
 ---
 
-## See it in 90 seconds
+## Quick start — 3 commands, ~4 seconds
 
-Two runnable hooks, nothing to configure ([`just`](https://github.com/casey/just), or run the commands directly):
+Needs [Rust 1.95+](https://rustup.rs) and nothing else. No task runner, no Docker,
+no VM.
 
 ```sh
-just demo     # 30s, in your terminal — information-flow control, 4 scenarios
-just vault    # play "The Vault" in your browser
+git clone --depth 1 https://github.com/coproduct-opensource/nucleus
+cd nucleus
+cargo run -q -p nucleus-ifc --example ifc_demo
 ```
 
-**`just demo`** (`cargo run -p nucleus-ifc --example ifc_demo`) — a prompt-injection write is **denied by adversarial *ancestry***, not by a classifier guessing at strings; a clean flow is allowed; a compartment transition clears taint; a deterministic bind excludes the model from the trust decision:
+`--depth 1` because the full history is ~456 MB; the shallow clone is 29 MB.
+
+**Measured on an Apple M5 Pro:** 3.9 s from an empty `target/` to the output
+below, in a fresh shallow clone, with a warm cargo registry. The demo crate has
+three dependencies — the wait is compiling nucleus, not resolving the internet.
+Clone time is yours to discover; it is 29 MB.
+
+Prefer a task runner? `brew install just` then `just demo` runs exactly the same
+thing, and `just vault` opens **The Vault** in a browser.
+
+The demo runs five scenarios. A prompt-injection write is **denied by adversarial *ancestry***, not by a classifier guessing at strings; a clean flow is allowed; a compartment transition clears taint; a deterministic bind excludes the model from the trust decision:
 
 ```
 ─ Scenario 1: Web injection blocked ─
@@ -51,7 +63,11 @@ just vault    # play "The Vault" in your browser
 
 ---
 
-## Quick Start
+## Using it on your own code
+
+The demo above proves the algebra. To point nucleus at a real workload, install
+the CLI — a larger build (~1400 dependencies), which is why it is not the first
+thing this page asks you to run:
 
 ```bash
 cargo install --git https://github.com/coproduct-opensource/nucleus nucleus-cli

--- a/README.md
+++ b/README.md
@@ -41,10 +41,11 @@ cargo run -q -p nucleus-ifc --example ifc_demo
 
 `--depth 1` because the full history is ~456 MB; the shallow clone is 29 MB.
 
-**Measured on an Apple M5 Pro:** 3.9 s from an empty `target/` to the output
-below, in a fresh shallow clone, with a warm cargo registry. The demo crate has
-three dependencies — the wait is compiling nucleus, not resolving the internet.
-Clone time is yours to discover; it is 29 MB.
+**Measured on an Apple M5 Pro: 1.4 s to clone, 4.0 s to first output — 5.4 s
+total**, from a fresh shallow clone into an empty `target/`, with a warm cargo
+registry and `just` not installed. The demo crate has three dependencies, so
+the wait is compiling nucleus rather than resolving the internet; a first-ever
+Rust build on a machine also downloads the registry and will be slower.
 
 Prefer a task runner? `brew install just` then `just demo` runs exactly the same
 thing, and `just vault` opens **The Vault** in a browser.


### PR DESCRIPTION
The quickstart bar is **zero-to-result in under 60 seconds, five commands or fewer.** Nucleus was already inside it — and the README hid that behind two things that are not.

## The headline command did not exist

```sh
just demo     # 30s, in your terminal
```

**`just` is not installed on a stock Mac.** A new reader's *first* command failed with `command not found`, and the remedy — `brew install just` — spends their first action installing a task runner before seeing anything work.

The thing it wraps needs nothing but Rust:

```sh
cargo run -q -p nucleus-ifc --example ifc_demo
```

**3.9 s from an empty target dir**, measured in a fresh shallow clone on an M5 Pro with a warm cargo registry. `nucleus-ifc` has **three** dependency lines — the wait is compiling nucleus, not resolving the internet.

## `cargo install nucleus-cli` was the "Quick Start"

**1403 dependency lines.** A multi-minute build, and the second thing a *convinced* reader wants — not the first thing an unconvinced one should hit. It moves to "Using it on your own code": still prominent, no longer first, with its cost stated.

## What changed

- a real quickstart: clone (`--depth 1`), `cd`, run. Three commands, every one working with only `rustup` present.
- **prerequisites stated** — Rust 1.95+, the workspace's actual `rust-version`. "Requires X" saves ten minutes of confusing errors.
- `--depth 1` documented *with the reason*: full history ~456 MB, shallow clone 29 MB.
- `just` demoted to what it is — a nicer alias once installed.
- **"4 scenarios" corrected to five.** The demo grew a confused-deputy scenario and the count was never updated.

## Verified by running it, not by reading it

Shallow-cloned this branch to a temp dir and ran the quickstart exactly as written: 29 MB clone, cold `target/`, `All scenarios passed`, **3.95 s**.

Two numbers were corrected against measurement rather than shipped as estimates:

- the checkout is **29 MB**, not the 20 MB the tree size implied;
- an earlier draft quoted "0.3 s to clone" — that was a local `file://` clone and would have been a misleading thing to put in front of someone on a real network. Removed.

**Based on #2351** — the 29 MB figure depends on the artifact removal, so this targets that branch rather than `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUeXMiQMvNkToXafRkAzVi