### PR TITLE
fix(node): a failed pod boot now names the cause instead of "timed out"

### DIFF
--- a/crates/nucleus-node/src/firecracker_config.rs
+++ b/crates/nucleus-node/src/firecracker_config.rs
@@ -1031,7 +1031,14 @@ mod tests {
     /// the platform that can run a microVM. These therefore run in CI and in
     /// OrbStack, never on a macOS dev machine — the same trap that once hid the
     /// vsock accept path behind a `cfg` nobody compiled.
-    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+    //
+    // GATED, not merely `allow(dead_code)`: `from_spec` does not EXIST off
+    // Linux, so the old attribute silenced the wrong diagnostic and the helper
+    // still failed to compile. `cargo test -p nucleus-node` was therefore
+    // broken on macOS — every test in this crate, not just these — while CI
+    // stayed green because CI is Linux. A Mac developer could not run the
+    // node's tests at all.
+    #[cfg(target_os = "linux")]
     fn boot_args_with_identity(will_have_identity: bool) -> String {
         let config = FirecrackerConfig::from_spec(
             &base_spec(),
@@ -1196,7 +1203,10 @@ mod tests {
             .find("WorkloadApiVsockBridge::start")
             .expect("the bridge start site");
         let health = src
-            .find("wait_for_proxy_health(health_addr)")
+            // Needle without the closing paren: the call gained a `console`
+            // argument and this guard failed on the punctuation rather than on
+            // the ordering it exists to protect.
+            .find("wait_for_proxy_health(health_addr")
             .expect("the health check site");
         assert!(
             bridge < health,

--- a/crates/nucleus-node/src/guest_diagnosis.rs
+++ b/crates/nucleus-node/src/guest_diagnosis.rs
@@ -63,8 +63,10 @@ const SIGNATURES: &[Signature] = &[
              shared approval secret with Ed25519 verification against the node's public key, \
              so this node sends `nucleus.approval_pubkeys` and no longer sends \
              `nucleus.approval_secret` — which this rootfs's guest-init still requires. \
-             Rebuild the rootfs from this checkout (scripts/firecracker/build-rootfs.sh), or \
-             run a nucleus-node from the same release as the rootfs.",
+             Rebuild the rootfs from this checkout: `bash \
+             scripts/firecracker/build-rootfs.sh` (or `just guest-rootfs`). It preflights \
+             the host tooling first and, on macOS, prints how to run it in the Linux VM. \
+             Or run a nucleus-node from the same release as the rootfs.",
     },
     Signature {
         marker: "failed to fetch identity",
@@ -273,7 +275,7 @@ mod tests {
         );
         assert!(
             d.contains("build-rootfs.sh"),
-            "a diagnosis without an action is half a diagnosis: {d}"
+            "a diagnosis without a runnable action is half a diagnosis: {d}"
         );
     }
 

--- a/crates/nucleus-node/src/guest_diagnosis.rs
+++ b/crates/nucleus-node/src/guest_diagnosis.rs
@@ -1,0 +1,326 @@
+//! Reading the guest console when a pod fails to come up.
+//!
+//! # Why
+//!
+//! A pod that does not become healthy reports `proxy health check timed out`.
+//! That sentence is true and almost never the cause. The cause is in the guest
+//! console, which the node already captures to `firecracker.log` and never
+//! looked at.
+//!
+//! The cost is concrete. Booting a pod from a current `nucleus-node` against
+//! the pinned v2.1.0 rootfs produces:
+//!
+//! ```text
+//! nucleus-guest-init error: missing approval secret (set nucleus.approval_secret …)
+//! Kernel panic - not syncing: Attempted to kill init! exitcode=0x00000000
+//! ```
+//!
+//! because #2214 (2026-08-08) stopped the node injecting
+//! `nucleus.approval_secret` while the July rootfs's guest-init still requires
+//! it. PID 1 exits and the kernel panics. What the operator was told was
+//! "health check timed out". Finding the real reason took mounting the image
+//! and reading a console by hand.
+//!
+//! This turns that into one sentence at the moment of failure.
+//!
+//! # What it is not
+//!
+//! Pattern matching on console text, and deliberately so: it needs no protocol
+//! change, no version marker, and no cooperation from the guest — which matters
+//! precisely because the guests it must diagnose are OLD ones that cannot be
+//! changed. A signature that stops matching degrades to today's behaviour
+//! (the generic message), never to a wrong answer, and
+//! [`the_matcher_still_recognises_its_own_signatures`] fails if one rots.
+
+// Everything here is reached only from the Firecracker spawn path, which is
+// Linux-gated, so on other hosts the whole module is legitimately unreachable.
+// The tests below still exercise `diagnose` on every platform.
+#![cfg_attr(not(target_os = "linux"), allow(dead_code))]
+
+use std::net::SocketAddr;
+use std::path::Path;
+use std::time::Duration;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+use crate::{ApiError, PROXY_HEALTH_TIMEOUT_SECS_DEFAULT};
+
+/// A known failure signature and what it means.
+struct Signature {
+    /// Substring to look for in the guest console.
+    marker: &'static str,
+    /// What the operator should be told.
+    explanation: &'static str,
+}
+
+/// Ordered most-specific first: the first match wins, so a precise cause beats
+/// the generic "init died" that always accompanies it.
+const SIGNATURES: &[Signature] = &[
+    Signature {
+        marker: "missing approval secret",
+        explanation:
+            "the guest rootfs PREDATES this node. #2214 (2026-08-08) replaced the guest's \
+             shared approval secret with Ed25519 verification against the node's public key, \
+             so this node sends `nucleus.approval_pubkeys` and no longer sends \
+             `nucleus.approval_secret` — which this rootfs's guest-init still requires. \
+             Rebuild the rootfs from this checkout (scripts/firecracker/build-rootfs.sh), or \
+             run a nucleus-node from the same release as the rootfs.",
+    },
+    Signature {
+        marker: "failed to fetch identity",
+        explanation: "the guest could not reach the workload API over vsock. Either the node's \
+             WorkloadApiVsockBridge did not start before the guest connected, or the \
+             per-pod socket (vsock.sock_<port>) is missing — check the pod directory for a \
+             `vsock.sock_*` entry alongside `vsock.sock`.",
+    },
+    Signature {
+        marker: "failed to exec",
+        explanation: "guest-init could not start the tool-proxy: the binary is missing from the \
+             rootfs at /usr/local/bin/nucleus-tool-proxy, or is built for the wrong \
+             architecture or libc.",
+    },
+    Signature {
+        marker: "panicked at",
+        explanation: "a guest process panicked. As PID 1 that takes the kernel with it, so the \
+             panic message above is the real failure, not the health-check timeout.",
+    },
+    // Least specific: always present when init dies, so it must sort last.
+    Signature {
+        marker: "Attempted to kill init",
+        explanation:
+            "PID 1 exited, so the guest kernel panicked. The lines immediately above this \
+             in the console are the actual cause.",
+    },
+];
+
+/// Diagnose a failed pod launch from its captured console.
+///
+/// Returns `None` when the console is unreadable or carries no known signature —
+/// in which case the caller's own message stands, unchanged.
+pub(crate) fn diagnose(console_path: &Path) -> Option<String> {
+    let text = std::fs::read_to_string(console_path).ok()?;
+    let hit = SIGNATURES.iter().find(|s| text.contains(s.marker))?;
+
+    // The console line that matched, so the operator sees the evidence and not
+    // only our interpretation of it.
+    let evidence = text
+        .lines()
+        .find(|l| l.contains(hit.marker))
+        .unwrap_or("")
+        .trim()
+        .chars()
+        .take(200)
+        .collect::<String>();
+
+    Some(format!(
+        "guest console says: \"{evidence}\" — {}",
+        hit.explanation
+    ))
+}
+
+pub(crate) async fn wait_for_proxy_health(
+    addr: SocketAddr,
+    console: &Path,
+) -> Result<(), ApiError> {
+    wait_for_proxy_health_within(
+        addr,
+        Duration::from_secs(
+            std::env::var("NUCLEUS_NODE_PROXY_HEALTH_TIMEOUT_SECS")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(PROXY_HEALTH_TIMEOUT_SECS_DEFAULT),
+        ),
+    )
+    .await
+    .map_err(|e| {
+        // The console the node already captured usually says exactly why.
+        // Reporting only "health check timed out" is true and almost never the
+        // cause; finding the real one meant mounting the image by hand.
+        match diagnose(console) {
+            Some(d) => ApiError::Driver(format!("{e}\n\n{d}")),
+            None => e,
+        }
+    })
+}
+
+/// What the last health probe actually saw.
+///
+/// # Why this type exists
+///
+/// The probe used to discard every outcome into one message: "proxy health check
+/// timed out". A refused connection, a guest that answered `401`, a bridge that
+/// answered `502`, and a guest that never came up were indistinguishable — to an
+/// operator and to whoever was debugging it. That is the same defect class as a
+/// panic naming `reqwest` when the real cause was a missing CA store: the
+/// information existed and the code threw it away.
+#[derive(Debug, Clone)]
+enum HealthProbe {
+    /// Nothing has been attempted yet.
+    NotAttempted,
+    /// The TCP connection to the signed proxy was refused or failed.
+    ConnectFailed(String),
+    /// Connected, but the request could not be written.
+    WriteFailed(String),
+    /// Request sent, but no readable response came back.
+    ReadFailed(String),
+    /// The guest answered — with something other than 200.
+    ///
+    /// This is the case worth separating most: it means the whole chain WORKS
+    /// (signed proxy, bridge, guest) and the guest is refusing, which is a
+    /// completely different investigation from "nothing is listening".
+    NotOk { status: String },
+}
+
+impl std::fmt::Display for HealthProbe {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            HealthProbe::NotAttempted => write!(f, "no probe completed"),
+            HealthProbe::ConnectFailed(e) => write!(
+                f,
+                "could not connect to the signed proxy ({e}) — the host-side proxy is not \
+                 accepting, so the guest was never reached"
+            ),
+            HealthProbe::WriteFailed(e) => {
+                write!(f, "connected but could not send the request ({e})")
+            }
+            HealthProbe::ReadFailed(e) => write!(
+                f,
+                "sent the request but got no response ({e}) — the signed proxy accepted and \
+                 then failed to complete, so look at the vsock bridge rather than the guest"
+            ),
+            HealthProbe::NotOk { status } => write!(
+                f,
+                "the guest ANSWERED with `{status}` instead of 200 — the chain works end to \
+                 end and the guest is refusing, so this is an authorization or routing \
+                 question, not a liveness one"
+            ),
+        }
+    }
+}
+
+async fn wait_for_proxy_health_within(addr: SocketAddr, budget: Duration) -> Result<(), ApiError> {
+    let start = std::time::Instant::now();
+    let host = addr.ip();
+    let mut last = HealthProbe::NotAttempted;
+    while start.elapsed() < budget {
+        match tokio::net::TcpStream::connect(addr).await {
+            Ok(mut stream) => {
+                let request =
+                    format!("GET /v1/health HTTP/1.1\r\nHost: {host}\r\nConnection: close\r\n\r\n");
+                if let Err(e) = stream.write_all(request.as_bytes()).await {
+                    last = HealthProbe::WriteFailed(e.to_string());
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                    continue;
+                }
+
+                let mut buf = Vec::new();
+                if let Err(e) = stream.read_to_end(&mut buf).await {
+                    last = HealthProbe::ReadFailed(e.to_string());
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                    continue;
+                }
+                let response = String::from_utf8_lossy(&buf);
+                if response.starts_with("HTTP/1.1 200") || response.starts_with("HTTP/1.0 200") {
+                    return Ok(());
+                }
+                // Keep only the status line. The body may carry guest-influenced
+                // text, and this string ends up in an API error and the node log.
+                let status = response.lines().next().unwrap_or("<empty response>");
+                last = HealthProbe::NotOk {
+                    status: status.chars().take(120).collect(),
+                };
+            }
+            Err(e) => last = HealthProbe::ConnectFailed(e.to_string()),
+        }
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    Err(ApiError::Driver(format!(
+        "proxy health check timed out after {}s: {last}. The guest fetches its SVID and \
+         session token from the host over vsock before it serves, so a slow image can \
+         legitimately exceed this; raise NUCLEUS_NODE_PROXY_HEALTH_TIMEOUT_SECS if the pod \
+         log shows the guest still starting.",
+        budget.as_secs()
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn console(body: &str) -> tempfile::NamedTempFile {
+        let mut f = tempfile::NamedTempFile::new().expect("temp");
+        write!(f, "{body}").expect("write");
+        f
+    }
+
+    /// The failure that motivated this module, end to end.
+    #[test]
+    fn the_version_skew_is_named_not_guessed() {
+        let f = console(
+            "[    1.47] Run /init as init process\n\
+             fetched identity: spiffe://nucleus.local/ns/pods/sa/abc\n\
+             nucleus-guest-init error: missing approval secret (set nucleus.approval_secret …)\n\
+             [    1.58] Kernel panic - not syncing: Attempted to kill init!\n",
+        );
+        let d = diagnose(f.path()).expect("a known signature must be recognised");
+        assert!(d.contains("PREDATES this node"), "{d}");
+        assert!(
+            d.contains("#2214"),
+            "the operator needs the change to look up: {d}"
+        );
+        assert!(
+            d.contains("build-rootfs.sh"),
+            "a diagnosis without an action is half a diagnosis: {d}"
+        );
+    }
+
+    /// Specificity: the kernel panic accompanies every init death, so a precise
+    /// cause must win over it. Without this ordering the module would always
+    /// report "PID 1 exited", which the operator can already see.
+    #[test]
+    fn a_specific_cause_beats_the_generic_panic() {
+        let f = console(
+            "nucleus-guest-init error: missing approval secret\n\
+             Kernel panic - not syncing: Attempted to kill init!\n",
+        );
+        let d = diagnose(f.path()).unwrap();
+        assert!(d.contains("PREDATES this node"));
+        assert!(!d.contains("The lines immediately above"));
+    }
+
+    /// The generic signature still fires when nothing more specific is present —
+    /// otherwise ordering would have made it dead code.
+    #[test]
+    fn the_generic_panic_is_reported_when_it_is_all_there_is() {
+        let f = console("[  1.5] Kernel panic - not syncing: Attempted to kill init!\n");
+        let d = diagnose(f.path()).unwrap();
+        assert!(d.contains("PID 1 exited"));
+    }
+
+    /// A healthy or unknown console must yield nothing, so the caller's own
+    /// message stands. Guessing would be worse than silence.
+    #[test]
+    fn an_unrecognised_console_produces_no_diagnosis() {
+        let f = console("[  1.4] Run /init as init process\nfetched identity: ok\n");
+        assert!(diagnose(f.path()).is_none());
+        assert!(diagnose(Path::new("/nonexistent/firecracker.log")).is_none());
+    }
+
+    /// Non-vacuity for the whole table. A signature whose text drifts out of the
+    /// guest's actual output stops matching silently, and this module would
+    /// quietly return to being useless — the exact failure it exists to fix,
+    /// one level up.
+    #[test]
+    fn the_matcher_still_recognises_its_own_signatures() {
+        for s in SIGNATURES {
+            let f = console(&format!("prelude\n{}\n", s.marker));
+            let d = diagnose(f.path())
+                .unwrap_or_else(|| panic!("signature `{}` no longer matches", s.marker));
+            assert!(!d.is_empty());
+        }
+        assert!(SIGNATURES.len() >= 4, "the table has shrunk unexpectedly");
+    }
+}

--- a/crates/nucleus-node/src/main.rs
+++ b/crates/nucleus-node/src/main.rs
@@ -18,7 +18,7 @@ use nucleus_client::drand::{DrandConfig, DrandFailMode};
 use nucleus_spec::NetworkSpec;
 use nucleus_spec::PodSpec;
 use serde::{Deserialize, Serialize};
-use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncSeekExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufReadExt, AsyncSeekExt, AsyncWriteExt, BufReader};
 #[cfg(any(feature = "local-driver", target_os = "linux"))]
 use tokio::process::Command;
 use tokio::sync::{Mutex, OwnedSemaphorePermit, Semaphore};
@@ -33,6 +33,7 @@ mod art12_collector;
 mod auth;
 mod firecracker_config;
 mod grpc_tls;
+mod guest_diagnosis;
 mod identity;
 mod lockdown;
 mod mediation;
@@ -2825,7 +2826,8 @@ async fn spawn_firecracker_pod(
             (None, None, None)
         };
 
-        if let Err(err) = wait_for_proxy_health(health_addr).await {
+        let console = pod_dir.join("firecracker.log");
+        if let Err(err) = guest_diagnosis::wait_for_proxy_health(health_addr, &console).await {
             if let Some(proxy) = signed_proxy {
                 proxy.shutdown().await;
             }
@@ -3163,127 +3165,10 @@ async fn wait_for_vsock_socket(path: &Path) -> Result<(), ApiError> {
 /// host round-trips during startup, and would be wrong even once the host chain
 /// is fixed. It is not a workaround for that defect and should not be read as
 /// one.
-const PROXY_HEALTH_TIMEOUT_SECS_DEFAULT: u64 = 30;
+pub(crate) const PROXY_HEALTH_TIMEOUT_SECS_DEFAULT: u64 = 30;
 
 #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 #[tracing::instrument(skip_all, fields(boot.stage = "proxy.health_wait"))]
-async fn wait_for_proxy_health(addr: SocketAddr) -> Result<(), ApiError> {
-    wait_for_proxy_health_within(
-        addr,
-        Duration::from_secs(
-            std::env::var("NUCLEUS_NODE_PROXY_HEALTH_TIMEOUT_SECS")
-                .ok()
-                .and_then(|v| v.parse().ok())
-                .unwrap_or(PROXY_HEALTH_TIMEOUT_SECS_DEFAULT),
-        ),
-    )
-    .await
-}
-
-/// What the last health probe actually saw.
-///
-/// # Why this type exists
-///
-/// The probe used to discard every outcome into one message: "proxy health check
-/// timed out". A refused connection, a guest that answered `401`, a bridge that
-/// answered `502`, and a guest that never came up were indistinguishable — to an
-/// operator and to whoever was debugging it. That is the same defect class as a
-/// panic naming `reqwest` when the real cause was a missing CA store: the
-/// information existed and the code threw it away.
-// Only reachable from the Firecracker spawn path, which is Linux-gated — same
-// reason the sibling health helpers carry this.
-#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
-#[derive(Debug, Clone)]
-enum HealthProbe {
-    /// Nothing has been attempted yet.
-    NotAttempted,
-    /// The TCP connection to the signed proxy was refused or failed.
-    ConnectFailed(String),
-    /// Connected, but the request could not be written.
-    WriteFailed(String),
-    /// Request sent, but no readable response came back.
-    ReadFailed(String),
-    /// The guest answered — with something other than 200.
-    ///
-    /// This is the case worth separating most: it means the whole chain WORKS
-    /// (signed proxy, bridge, guest) and the guest is refusing, which is a
-    /// completely different investigation from "nothing is listening".
-    NotOk { status: String },
-}
-
-impl std::fmt::Display for HealthProbe {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            HealthProbe::NotAttempted => write!(f, "no probe completed"),
-            HealthProbe::ConnectFailed(e) => write!(
-                f,
-                "could not connect to the signed proxy ({e}) — the host-side proxy is not \
-                 accepting, so the guest was never reached"
-            ),
-            HealthProbe::WriteFailed(e) => {
-                write!(f, "connected but could not send the request ({e})")
-            }
-            HealthProbe::ReadFailed(e) => write!(
-                f,
-                "sent the request but got no response ({e}) — the signed proxy accepted and \
-                 then failed to complete, so look at the vsock bridge rather than the guest"
-            ),
-            HealthProbe::NotOk { status } => write!(
-                f,
-                "the guest ANSWERED with `{status}` instead of 200 — the chain works end to \
-                 end and the guest is refusing, so this is an authorization or routing \
-                 question, not a liveness one"
-            ),
-        }
-    }
-}
-
-async fn wait_for_proxy_health_within(addr: SocketAddr, budget: Duration) -> Result<(), ApiError> {
-    let start = std::time::Instant::now();
-    let host = addr.ip();
-    let mut last = HealthProbe::NotAttempted;
-    while start.elapsed() < budget {
-        match tokio::net::TcpStream::connect(addr).await {
-            Ok(mut stream) => {
-                let request =
-                    format!("GET /v1/health HTTP/1.1\r\nHost: {host}\r\nConnection: close\r\n\r\n");
-                if let Err(e) = stream.write_all(request.as_bytes()).await {
-                    last = HealthProbe::WriteFailed(e.to_string());
-                    tokio::time::sleep(Duration::from_millis(100)).await;
-                    continue;
-                }
-
-                let mut buf = Vec::new();
-                if let Err(e) = stream.read_to_end(&mut buf).await {
-                    last = HealthProbe::ReadFailed(e.to_string());
-                    tokio::time::sleep(Duration::from_millis(100)).await;
-                    continue;
-                }
-                let response = String::from_utf8_lossy(&buf);
-                if response.starts_with("HTTP/1.1 200") || response.starts_with("HTTP/1.0 200") {
-                    return Ok(());
-                }
-                // Keep only the status line. The body may carry guest-influenced
-                // text, and this string ends up in an API error and the node log.
-                let status = response.lines().next().unwrap_or("<empty response>");
-                last = HealthProbe::NotOk {
-                    status: status.chars().take(120).collect(),
-                };
-            }
-            Err(e) => last = HealthProbe::ConnectFailed(e.to_string()),
-        }
-
-        tokio::time::sleep(Duration::from_millis(100)).await;
-    }
-
-    Err(ApiError::Driver(format!(
-        "proxy health check timed out after {}s: {last}. The guest fetches its SVID and \
-         session token from the host over vsock before it serves, so a slow image can \
-         legitimately exceed this; raise NUCLEUS_NODE_PROXY_HEALTH_TIMEOUT_SECS if the pod \
-         log shows the guest still starting.",
-        budget.as_secs()
-    )))
-}
 
 async fn serve_grpc(
     state: NodeState,

--- a/justfile
+++ b/justfile
@@ -143,3 +143,20 @@ preflight: check
     RUSTFLAGS="-D warnings" cargo hack check --each-feature --no-dev-deps \
         -p portcullis -p portcullis-core -p nucleus-lineage -p nucleus-tool-proxy \
         -p nucleus-ifc -p nucleus-envelope -p nucleus-identity -p nucleus-creditworthiness
+
+# The pinned release rootfs and a current nucleus-node can drift: #2214
+# (2026-08-08) changed how the guest is approved, so a node newer than the
+# rootfs boots to a kernel panic. Building from source is the fix -- and it was
+# only ever a script path nobody could be expected to guess.
+#
+# Needs ext4 tooling, which macOS does not have. The script preflights and says
+# how to run it inside the Lima VM, instead of failing several minutes into a
+# build with `mke2fs: command not found`.
+
+# Build the guest rootfs from THIS checkout (fixes node/rootfs version skew).
+guest-rootfs *args:
+    bash scripts/firecracker/build-rootfs.sh {{args}}
+
+# Check the guest rootfs build prerequisites without building anything.
+guest-rootfs-check:
+    bash scripts/firecracker/build-rootfs.sh --verify

--- a/scripts/firecracker/build-rootfs.sh
+++ b/scripts/firecracker/build-rootfs.sh
@@ -199,9 +199,64 @@ ADVERSARY_PROBE_BIN="${ADVERSARY_PROBE_BIN:-$ROOT_DIR/target/$TARGET/release/nuc
     esac
 done
 
+
+# Host tooling preflight.
+#
+# `--verify` checked the nucleus binaries -- the things that are almost always
+# present -- and not the host tools, which are the things that are actually
+# missing. On a stock Mac neither mke2fs nor docker exists, so this script used
+# to run several minutes of cargo builds and only then die on
+# `mke2fs: command not found`. Check first, and say what to do.
+preflight_host_tooling() {
+    local missing=0
+
+    if ! command -v mke2fs >/dev/null 2>&1; then
+        missing=1
+        echo "MISSING: mke2fs (e2fsprogs) -- needed to write the ext4 image" >&2
+        case "$(uname -s)" in
+            Darwin)
+                cat >&2 <<'HINT'
+  macOS has no ext4 tooling, so this script cannot build a rootfs on the host.
+  Run it inside the Linux VM instead:
+      limactl start nucleus-kvm
+      limactl shell nucleus-kvm -- bash -lc 'cd <repo> && scripts/firecracker/build-rootfs.sh'
+  The repo must be mounted in that VM (lima's `mounts:` in ~/.lima/nucleus-kvm/lima.yaml).
+HINT
+                ;;
+            *)
+                echo "  Install it:  apt-get install e2fsprogs  |  dnf install e2fsprogs" >&2
+                ;;
+        esac
+    fi
+
+    # The base filesystem comes from a Debian tarball, sourced either from a
+    # local file or by exporting a container image.
+    if [ -n "${DEBIAN_TARBALL:-}" ]; then
+        if [ ! -f "$DEBIAN_TARBALL" ]; then
+            missing=1
+            echo "MISSING: DEBIAN_TARBALL is set to '$DEBIAN_TARBALL', which does not exist" >&2
+        fi
+    elif ! command -v docker >/dev/null 2>&1; then
+        missing=1
+        cat >&2 <<'HINT'
+MISSING: a Debian base filesystem -- needs either docker or a prebuilt tarball
+  Either install docker, or point at a tarball you already have:
+      DEBIAN_TARBALL=/path/to/debian-rootfs.tar scripts/firecracker/build-rootfs.sh
+HINT
+    fi
+
+    if [ "$missing" -ne 0 ]; then
+        echo "" >&2
+        echo "Host tooling preflight failed -- nothing was built." >&2
+        return 1
+    fi
+    echo "Host tooling preflight: OK (mke2fs, Debian base source)"
+}
+
 # Verify mode: just check if binaries exist
 if [ "$VERIFY_ONLY" = true ]; then
     echo "Verifying binaries for $ARCH ($TARGET)..."
+    preflight_host_tooling || exit 1
     missing=0
     for bin in "$PROXY_BIN" "$NET_PROBE_BIN" "$WORKLOAD_PROBE_BIN" "$EGRESS_PROBE_BIN"; do
         if [ ! -f "$bin" ]; then
@@ -276,6 +331,8 @@ if [ "$LEGACY_SECRETS" = true ]; then
     fi
     echo "WARNING: --legacy-secrets is deprecated. Secrets should be injected at runtime." >&2
 fi
+
+preflight_host_tooling || exit 1
 
 echo "Building rootfs for architecture: $ARCH"
 echo "  Target: $TARGET"


### PR DESCRIPTION
## The problem

A pod that never becomes healthy reports `proxy health check timed out`. That sentence is true and almost never the cause.

The cause is in the guest console — which the node **already captures** to `firecracker.log` and never looked at. Booting a current `nucleus-node` against the pinned v2.1.0 rootfs produces:

```text
nucleus-guest-init error: missing approval secret (set nucleus.approval_secret …)
Kernel panic - not syncing: Attempted to kill init! exitcode=0x00000000
```

because #2214 (2026-08-08) replaced the guest's shared approval secret with Ed25519 verification against the node's public key. The node now sends `nucleus.approval_pubkeys` and no longer sends `nucleus.approval_secret`, which the July rootfs's guest-init still requires. PID 1 exits, the kernel panics, and the operator is told "health check timed out". Finding the real reason took mounting the image and reading a console by hand.

## The change

`guest_diagnosis::diagnose` scans the captured console for known signatures and appends one sentence naming the cause and the action.

- **Ordered most-specific-first.** `Attempted to kill init` accompanies *every* init death, so it sorts last — otherwise the module would always report "PID 1 exited", which the operator can already see.
- **Enrichment lives in `wait_for_proxy_health`**, where the error is constructed, not at the call site — so a future caller cannot get the bare message by forgetting to wrap it.
- **Text matching, deliberately.** No protocol change, no version marker, no cooperation from the guest — which is the point, because the guests it must diagnose are *old* ones that cannot be changed. A signature that stops matching degrades to today's behaviour, never to a wrong answer.

## Two bugs this surfaced

Both found by making these tests actually run, and both the same class as the bug being fixed — a check that could not be red:

1. **`cargo test -p nucleus-node` did not build on macOS at all.** `boot_args_with_identity` was `cfg_attr(not(linux), allow(dead_code))` but called from an ungated helper. Now `cfg(linux)` — **all 358 tests run**, where previously zero did.
2. **`the_workload_api_bridge_starts_before_the_health_check` broke on punctuation.** It scans main.rs for the literal `wait_for_proxy_health(health_addr)`; the call gained a `console` argument and the guard failed on the paren rather than on the ordering it protects. Needle narrowed.

## Verification

- 358 tests pass (previously the crate did not compile under `cargo test` on macOS).
- `the_matcher_still_recognises_its_own_signatures` feeds every signature's own marker back through `diagnose` and fails if one rots — without it, drift in the guest's wording would silently return this module to being useless, which is the exact failure it exists to fix, one level up.
- `an_unrecognised_console_produces_no_diagnosis` pins the degrade-to-silence behaviour, including an unreadable path.
- Clippy dead-code count is back to the pre-existing baseline of 7 on macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)