### PR TITLE
feat(verifier-py): the commerce surface, and the reason this SDK had no tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -422,6 +422,19 @@ jobs:
       - name: Node tests (golden seal + smoke) against built wasm
         working-directory: sdks/verifier-js
         run: npm test
+      # The Python SDK is its own workspace, so the root `cargo test` above does
+      # not reach it — and until now NOTHING did: it had no CI at all, which is
+      # how it stayed untestable (`extension-module` was unconditional, so every
+      # test target failed to link) and how its commerce bindings went missing
+      # while the JS SDK gained them. Its tests run the shared conformance
+      # corpus, so a drift between the Python surface and the proven kernels
+      # fails here rather than in someone's integration.
+      - name: Python SDK tests (conformance corpus through the bindings)
+        working-directory: sdks/verifier-py
+        run: cargo test
+      - name: Python SDK clippy
+        working-directory: sdks/verifier-py
+        run: cargo clippy --all-targets -- -D warnings
 
   a2a-example:
     name: A2A example server (examples/a2a-server)

--- a/sdks/verifier-py/Cargo.lock
+++ b/sdks/verifier-py/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -25,15 +31,34 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "base64"
-version = "0.22.1"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "blake3"
+version = "1.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9e454fc11f76977dc803893aff6304ed33d6a26efae8696573bea74baa27ae"
+dependencies = [
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures",
+]
 
 [[package]]
 name = "block-buffer"
@@ -73,8 +98,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link",
 ]
 
@@ -85,19 +112,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "cpufeatures"
@@ -131,12 +155,12 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "5.0.0-pre.6"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335f1947f241137a14106b6f5acc5918a5ede29c9d71d3f2cb1678d5075d9fc3"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
@@ -157,6 +181,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -173,18 +208,21 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
 dependencies = [
+ "pkcs8",
  "signature",
 ]
 
 [[package]]
 name = "ed25519-dalek"
-version = "3.0.0-pre.7"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20449acd54b660981ae5caa2bcb56d1fe7f25f2e37a38ec507400fab034d4bb6"
+checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
+ "serde",
  "sha2",
+ "signature",
  "subtle",
  "zeroize",
 ]
@@ -372,6 +410,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
+name = "nucleus-commerce-conformance"
+version = "1.0.0"
+dependencies = [
+ "nucleus-econ-kernels",
+ "nucleus-ifc",
+ "nucleus-recompute",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "nucleus-econ-kernels"
+version = "1.0.0"
+dependencies = [
+ "hex",
+ "nucleus-econ-types",
+ "nucleus-externality",
+ "serde",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
+name = "nucleus-econ-types"
+version = "1.0.0"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "nucleus-envelope"
 version = "1.0.0"
 dependencies = [
@@ -385,6 +453,32 @@ dependencies = [
  "sha2",
  "thiserror",
 ]
+
+[[package]]
+name = "nucleus-externality"
+version = "1.0.0"
+dependencies = [
+ "base64",
+ "ed25519-dalek",
+ "hex",
+ "nucleus-lineage",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
+name = "nucleus-ifc"
+version = "1.0.0"
+dependencies = [
+ "portcullis-core",
+ "serde",
+]
+
+[[package]]
+name = "nucleus-ifc-kernel"
+version = "1.0.0"
 
 [[package]]
 name = "nucleus-lineage"
@@ -404,12 +498,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "nucleus-receipt"
+version = "1.0.0"
+dependencies = [
+ "base64",
+ "blake3",
+ "ed25519-dalek",
+ "hex",
+ "serde",
+ "serde_json",
+ "serde_json_canonicalizer",
+ "thiserror",
+]
+
+[[package]]
+name = "nucleus-recompute"
+version = "1.0.0"
+dependencies = [
+ "hex",
+ "nucleus-econ-kernels",
+ "nucleus-ifc",
+ "nucleus-receipt",
+ "portcullis-core",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror",
+]
+
+[[package]]
 name = "nucleus-verifier-py"
 version = "0.1.0"
 dependencies = [
+ "ed25519-dalek",
  "hex",
+ "nucleus-commerce-conformance",
+ "nucleus-econ-kernels",
  "nucleus-envelope",
  "nucleus-lineage",
+ "nucleus-receipt",
+ "nucleus-recompute",
  "pyo3",
  "serde",
  "serde_json",
@@ -431,16 +559,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkcs8"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portcullis-core"
+version = "1.0.0"
+dependencies = [
+ "nucleus-ifc-kernel",
+]
 
 [[package]]
 name = "prettyplease"
@@ -550,6 +704,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu-js"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04d056b875a9d2e6cb9a61d127afee9ac5999b9f87bcb32079d1318e505be714"
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -599,13 +759,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json_canonicalizer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe52319a927259afbfa5180c5157cd8167edfd3e8c254f9558c7fef44c5649f2"
+dependencies = [
+ "ryu-js",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures",
  "digest",
 ]
 
@@ -626,6 +797,16 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "base64ct",
+ "der",
+]
 
 [[package]]
 name = "subtle"

--- a/sdks/verifier-py/Cargo.toml
+++ b/sdks/verifier-py/Cargo.toml
@@ -18,9 +18,29 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 nucleus-envelope = { path = "../../crates/nucleus-envelope" }
 nucleus-lineage = { path = "../../crates/nucleus-lineage" }
+# The commerce surface: payout / settlement / cart. The Rust and JS verifiers have
+# carried these since the commerce slices landed; Python could only verify bundles,
+# so "any runtime, any language" was not true for a payee checking its own share.
+nucleus-recompute = { path = "../../crates/nucleus-recompute", features = ["envelope"] }
+nucleus-receipt = { path = "../../crates/nucleus-receipt" }
 # abi3-py38 = single wheel covers CPython 3.8 through 3.13+; PyO3 0.28+
 # generates 3.8 ABI-stable bindings.
-pyo3 = { version = "0.28", features = ["abi3-py38", "extension-module"] }
+# `extension-module` is NOT listed here on purpose. It was, and it made the crate
+# impossible to test: `cargo test` builds a normal binary that must link libpython,
+# which `extension-module` suppresses, so every test target failed at link time with
+# "symbol(s) not found". That is why this crate had no tests.
+#
+# maturin supplies the feature itself for the real build — see `features =
+# ["pyo3/extension-module"]` under [tool.maturin] in pyproject.toml — so the wheel is
+# unchanged and `cargo test` now links and runs.
+pyo3 = { version = "0.28", features = ["abi3-py38"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 hex = "0.4"
+
+[dev-dependencies]
+# The conformance corpus, so the Python surface is checked against the SAME
+# vectors a third-party runtime would use rather than against hand-written cases.
+nucleus-commerce-conformance = { path = "../../crates/nucleus-commerce-conformance" }
+nucleus-econ-kernels = { path = "../../crates/nucleus-econ-kernels" }
+ed25519-dalek = "=3.0.0"

--- a/sdks/verifier-py/src/lib.rs
+++ b/sdks/verifier-py/src/lib.rs
@@ -54,8 +54,8 @@ fn build_anchor(input: TrustAnchorInput) -> Result<TrustAnchor, String> {
         anchor = anchor.allow_empty();
     }
     if let Some(hex_str) = input.trust_witness_pubkey_hex {
-        let bytes = hex::decode(hex_str.trim())
-            .map_err(|e| format!("trust_witness_pubkey_hex: {e}"))?;
+        let bytes =
+            hex::decode(hex_str.trim()).map_err(|e| format!("trust_witness_pubkey_hex: {e}"))?;
         if bytes.len() != 32 {
             return Err(format!(
                 "trust_witness_pubkey_hex must decode to 32 bytes, got {}",
@@ -67,8 +67,8 @@ fn build_anchor(input: TrustAnchorInput) -> Result<TrustAnchor, String> {
         anchor = anchor.with_witness_pubkey(arr);
     }
     for hex_str in &input.trusted_witnesses_hex {
-        let bytes = hex::decode(hex_str.trim())
-            .map_err(|e| format!("trusted_witnesses_hex entry: {e}"))?;
+        let bytes =
+            hex::decode(hex_str.trim()).map_err(|e| format!("trusted_witnesses_hex entry: {e}"))?;
         if bytes.len() != 32 {
             return Err(format!(
                 "trusted_witnesses_hex entries must decode to 32 bytes, got {}",
@@ -135,7 +135,10 @@ fn verify_bundle(
     dict.set_item("cosignatures_verified", report.cosignatures_verified)?;
     let witnesses = PyList::new(
         py,
-        report.matched_witness_pubkeys_hex.iter().map(String::as_str),
+        report
+            .matched_witness_pubkeys_hex
+            .iter()
+            .map(String::as_str),
     )?;
     dict.set_item("matched_witness_pubkeys_hex", witnesses)?;
     dict.set_item("payload_binding_verified", report.payload_binding_verified)?;
@@ -157,7 +160,322 @@ fn sdk_version() -> &'static str {
 #[pymodule]
 fn nucleus_verifier(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(verify_bundle, m)?)?;
+    m.add_function(wrap_pyfunction!(verify_payout, m)?)?;
+    m.add_function(wrap_pyfunction!(verify_signed_payout, m)?)?;
+    m.add_function(wrap_pyfunction!(verify_settlement_set, m)?)?;
+    m.add_function(wrap_pyfunction!(verify_mandate_covers_cart, m)?)?;
     m.add_function(wrap_pyfunction!(supported_envelope_schema_version, m)?)?;
     m.add_function(wrap_pyfunction!(sdk_version, m)?)?;
     Ok(())
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// COMMERCE: a payee checks its own share, in Python, offline
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// The JS SDK has carried these since the commerce slices landed; Python could
+// only verify bundles. "Any runtime, any language" is not true while a payee
+// running Python cannot check the split it was paid.
+//
+// Each binding is a thin wrapper over a NATIVE-TESTABLE core fn, the same shape
+// `sdks/verifier-js` uses, so the logic is exercised by `cargo test` rather than
+// only through an interpreter.
+
+/// Core of [`verify_payout`]: does this split re-derive from the proven kernels?
+fn payout_verdict(payout_json: &str) -> Result<(bool, String), String> {
+    use nucleus_recompute::payout::{verify_payout as vp, PayoutClaim};
+    use nucleus_recompute::RecomputeOutcome;
+
+    let payout: PayoutClaim =
+        serde_json::from_str(payout_json).map_err(|e| format!("payout JSON: {e}"))?;
+    Ok(match vp(&payout) {
+        RecomputeOutcome::Match => (true, "verified".to_string()),
+        RecomputeOutcome::Mismatch { field, .. } => (false, format!("mismatch:{field}")),
+        RecomputeOutcome::Invalid(m) => (false, format!("invalid:{m}")),
+    })
+}
+
+/// Core of [`verify_signed_payout`]: signature first, then recompute.
+fn signed_payout_verdict(
+    receipt_json: &str,
+    verifying_key_hex: &str,
+) -> Result<(bool, String), String> {
+    use nucleus_recompute::payout::envelope::{verify_signed_payout as vsp, SignedPayoutVerdict};
+    use nucleus_recompute::RecomputeOutcome;
+
+    let receipt: nucleus_receipt::Receipt =
+        serde_json::from_str(receipt_json).map_err(|e| format!("receipt JSON: {e}"))?;
+    let bytes = hex::decode(verifying_key_hex.trim().trim_start_matches("0x"))
+        .map_err(|e| format!("verifying_key_hex: {e}"))?;
+    let vk: [u8; 32] = bytes
+        .try_into()
+        .map_err(|_| "verifying key must be 32 bytes".to_string())?;
+
+    Ok(match vsp(&receipt, &vk) {
+        SignedPayoutVerdict::Recomputed(RecomputeOutcome::Match) => (true, "verified".into()),
+        SignedPayoutVerdict::Recomputed(RecomputeOutcome::Mismatch { field, .. }) => {
+            (false, format!("mismatch:{field}"))
+        }
+        SignedPayoutVerdict::Recomputed(RecomputeOutcome::Invalid(m)) => {
+            (false, format!("invalid:{m}"))
+        }
+        SignedPayoutVerdict::BadSignature => (false, "bad_signature".into()),
+        SignedPayoutVerdict::Malformed(e) => (false, format!("malformed:{e}")),
+    })
+}
+
+/// Core of [`verify_settlement_set`]: was **everyone** paid, exactly once?
+fn settlement_set_verdict(
+    payout_json: &str,
+    attestations_json: &str,
+) -> Result<(bool, String), String> {
+    use nucleus_recompute::payout::PayoutClaim;
+    use nucleus_recompute::settlement_attestation::{
+        verify_settlement_set as vss, SettlementAttestation, SettlementSetOutcome,
+    };
+
+    let payout: PayoutClaim =
+        serde_json::from_str(payout_json).map_err(|e| format!("payout JSON: {e}"))?;
+    let attestations: Vec<SettlementAttestation> =
+        serde_json::from_str(attestations_json).map_err(|e| format!("attestations JSON: {e}"))?;
+
+    Ok(match vss(&attestations, &payout) {
+        SettlementSetOutcome::Complete => (true, "complete".to_string()),
+        other => (false, format!("{other:?}")),
+    })
+}
+
+/// Core of [`verify_mandate_covers_cart`]: did a human approve *this* cart?
+fn cart_verdict(mandate_manifest_hash: &str, cart_json: &str) -> Result<(bool, String), String> {
+    use nucleus_recompute::cart::{verify_mandate_covers_cart as vmc, Cart, CartOutcome};
+
+    let cart: Cart = serde_json::from_str(cart_json).map_err(|e| format!("cart JSON: {e}"))?;
+    Ok(match vmc(mandate_manifest_hash, &cart) {
+        CartOutcome::Match => (true, "authorized".to_string()),
+        other => (false, format!("{other:?}")),
+    })
+}
+
+fn verdict_dict(py: Python<'_>, key: &str, ok: bool, verdict: String) -> PyResult<Py<PyDict>> {
+    let d = PyDict::new(py);
+    d.set_item(key, ok)?;
+    d.set_item("verdict", verdict)?;
+    Ok(d.into())
+}
+
+/// Re-derive a payout's split from its declared inputs via the proven kernels.
+///
+/// Returns `{"verified": bool, "verdict": str}`. A payout whose underlying
+/// clearing does not itself re-derive fails on the *clearing*, before the split
+/// is examined — a payout over a fabricated price is caught first.
+#[pyfunction]
+#[pyo3(text_signature = "(payout_json, /)")]
+fn verify_payout(py: Python<'_>, payout_json: &str) -> PyResult<Py<PyDict>> {
+    let (ok, v) = payout_verdict(payout_json).map_err(PyValueError::new_err)?;
+    verdict_dict(py, "verified", ok, v)
+}
+
+/// Verify a SIGNED payout: the Ed25519 signature, then a recompute of the split.
+///
+/// This is the one that makes a revenue share trustless from Python. A payee
+/// pastes what it was sent and recomputes its own share — no server, no operator
+/// ledger to trust. An operator that signs a skimmed split still returns
+/// `mismatch:allocations`, which a signature-only check cannot catch.
+#[pyfunction]
+#[pyo3(text_signature = "(receipt_json, verifying_key_hex, /)")]
+fn verify_signed_payout(
+    py: Python<'_>,
+    receipt_json: &str,
+    verifying_key_hex: &str,
+) -> PyResult<Py<PyDict>> {
+    let (ok, v) =
+        signed_payout_verdict(receipt_json, verifying_key_hex).map_err(PyValueError::new_err)?;
+    verdict_dict(py, "verified", ok, v)
+}
+
+/// Was every allocation discharged, exactly once?
+///
+/// The question a per-receipt check cannot answer: an operator can pay two of
+/// three payees and show each of them a receipt that verifies on its own.
+#[pyfunction]
+#[pyo3(text_signature = "(payout_json, attestations_json, /)")]
+fn verify_settlement_set(
+    py: Python<'_>,
+    payout_json: &str,
+    attestations_json: &str,
+) -> PyResult<Py<PyDict>> {
+    let (ok, v) =
+        settlement_set_verdict(payout_json, attestations_json).map_err(PyValueError::new_err)?;
+    verdict_dict(py, "complete", ok, v)
+}
+
+/// Does a mandate authorize this exact cart?
+///
+/// `mandate_manifest_hash` must come from a bundle whose signature has ALREADY
+/// been verified — this checks coverage, not authenticity, and cannot tell a
+/// real mandate from a string.
+#[pyfunction]
+#[pyo3(text_signature = "(mandate_manifest_hash, cart_json, /)")]
+fn verify_mandate_covers_cart(
+    py: Python<'_>,
+    mandate_manifest_hash: &str,
+    cart_json: &str,
+) -> PyResult<Py<PyDict>> {
+    let (ok, v) = cart_verdict(mandate_manifest_hash, cart_json).map_err(PyValueError::new_err)?;
+    verdict_dict(py, "authorized", ok, v)
+}
+
+#[cfg(test)]
+mod commerce_tests {
+    use super::*;
+
+    /// **The test that makes "any runtime, any language" checkable.**
+    ///
+    /// The conformance corpus is the artifact a third-party runtime consumes to
+    /// prove it agrees with nucleus. This runs those exact vectors through the
+    /// Python surface's cores — so the Python SDK is held to the same standard
+    /// an outside integrator would be, rather than to hand-written cases chosen
+    /// by the person who wrote the bindings.
+    ///
+    /// Only the properties this SDK exposes are covered; `disclosure_required`
+    /// is an IFC decision with no Python binding yet, and is skipped explicitly
+    /// rather than silently.
+    #[test]
+    fn the_python_surface_agrees_with_the_conformance_corpus() {
+        use nucleus_commerce_conformance::{corpus, CaseInput, Expect, Property};
+
+        let mut checked = 0;
+        let mut wrong = Vec::new();
+        let mut skipped = Vec::new();
+
+        for case in corpus() {
+            let got = match &case.input {
+                CaseInput::Payout(p) => {
+                    let json = serde_json::to_string(p).unwrap();
+                    payout_verdict(&json).map(|(ok, _)| ok)
+                }
+                CaseInput::Settlement {
+                    payout,
+                    attestations,
+                } => {
+                    let pj = serde_json::to_string(payout).unwrap();
+                    let aj = serde_json::to_string(attestations).unwrap();
+                    settlement_set_verdict(&pj, &aj).map(|(ok, _)| ok)
+                }
+                CaseInput::Cart {
+                    mandate_manifest_hash,
+                    cart,
+                } => {
+                    let cj = serde_json::to_string(cart).unwrap();
+                    cart_verdict(mandate_manifest_hash, &cj).map(|(ok, _)| ok)
+                }
+                CaseInput::Flow(_) => {
+                    skipped.push(case.name);
+                    continue;
+                }
+            }
+            .expect("the corpus's own inputs must parse");
+
+            checked += 1;
+            let want = matches!(case.expect, Expect::Accept);
+            if got != want {
+                wrong.push(format!(
+                    "  {} ({}): expected {:?}, python said {}",
+                    case.name, case.summary, case.expect, got
+                ));
+            }
+        }
+
+        assert!(
+            wrong.is_empty(),
+            "the Python surface disagrees with the corpus:\n{}",
+            wrong.join("\n")
+        );
+        assert!(
+            checked >= 10,
+            "only {checked} vectors exercised — too few to mean anything"
+        );
+        assert!(
+            skipped.iter().all(|n| n.starts_with("disclosure/")),
+            "only the disclosure property may be skipped, got {skipped:?}"
+        );
+        // And the skip is bounded: every OTHER property must be exercised.
+        for p in [
+            Property::PayoutRecomputes,
+            Property::SettlementDischarges,
+            Property::MandateCoversCart,
+        ] {
+            assert!(
+                corpus().iter().any(|c| c.property == p),
+                "{p:?} must be exercised through Python"
+            );
+        }
+    }
+
+    /// A signature-valid but skimmed payout is rejected from Python too — the
+    /// case a signature-only check cannot catch.
+    #[test]
+    fn a_validly_signed_but_skimmed_payout_is_rejected_from_python() {
+        use ed25519_dalek::SigningKey;
+        use nucleus_econ_kernels::commons::CommonsShare;
+        use nucleus_receipt::{Receipt, Session};
+        use nucleus_recompute::issue_settlement;
+        use nucleus_recompute::payout::{
+            envelope::to_payout_projection, issue_payout, Attribution,
+        };
+
+        let sk = SigningKey::from_bytes(&[21u8; 32]);
+        let vk_hex = hex::encode(sk.verifying_key().to_bytes());
+        let shares = vec![
+            CommonsShare {
+                destination: "runtime".into(),
+                bps: 3_000,
+            },
+            CommonsShare {
+                destination: "seller".into(),
+                bps: 7_000,
+            },
+        ];
+        let attribution = Attribution {
+            workload_spiffe_id: "spiffe://test/runtime".into(),
+            assurance: 1,
+            offer_hash_hex: "a".repeat(64),
+            disclosure_hash_hex: String::new(),
+        };
+        let session = || Session {
+            session_id: "spiffe://test/py".into(),
+            issuer_kid: "kid".into(),
+            issued_at_micros: 1_717_000_000_000_000,
+            parent_chain: vec![],
+        };
+
+        let honest = issue_payout(
+            issue_settlement(1_000_000, 10_000),
+            shares.clone(),
+            attribution.clone(),
+        )
+        .expect("well-formed");
+        let signed = Receipt::sign(session(), vec![to_payout_projection(&honest)], &sk);
+        let (ok, verdict) =
+            signed_payout_verdict(&serde_json::to_string(&signed).unwrap(), &vk_hex).unwrap();
+        assert!(ok, "honest payout must verify, got {verdict}");
+
+        let mut skimmed =
+            issue_payout(issue_settlement(1_000_000, 10_000), shares, attribution).expect("ok");
+        skimmed.allocations[0].amount_micro += 1;
+        skimmed.allocations[1].amount_micro -= 1;
+        let signed = Receipt::sign(session(), vec![to_payout_projection(&skimmed)], &sk);
+        let (ok, verdict) =
+            signed_payout_verdict(&serde_json::to_string(&signed).unwrap(), &vk_hex).unwrap();
+        assert!(!ok, "a skimmed payout must be rejected");
+        assert_eq!(verdict, "mismatch:allocations");
+    }
+
+    /// Malformed input is a caller error, not a silent pass.
+    #[test]
+    fn malformed_json_errors_rather_than_verifying() {
+        assert!(payout_verdict("{not json").is_err());
+        assert!(cart_verdict("abc", "{not json").is_err());
+        assert!(signed_payout_verdict("{}", "zz").is_err());
+    }
 }


### PR DESCRIPTION
## "Any runtime, any language" was not true

The Rust and JS verifiers have carried payout / settlement / cart since the commerce slices landed. Python could only `verify_bundle` — so **a payee running Python could not check the split it was paid.**

Four bindings, each a thin wrapper over a **native-testable core** (the shape `sdks/verifier-js` already uses):

```python
verify_payout(payout_json)
verify_signed_payout(receipt_json, verifying_key_hex)
verify_settlement_set(payout_json, attestations_json)
verify_mandate_covers_cart(mandate_manifest_hash, cart_json)
```

## Why this crate had no tests

`extension-module` was listed **unconditionally** in the pyo3 dependency. That feature suppresses linking libpython — correct for the wheel, fatal for `cargo test`: every test target failed at link time with `symbol(s) not found`.

**The crate was untestable as configured**, so nobody had written a test.

Removed from the direct dep. maturin already supplies it via `features = ["pyo3/extension-module"]` in `pyproject.toml`, so the wheel is unchanged and `cargo test` now links and runs.

*(A plain `cargo build --features pyo3/extension-module` still fails on macOS for want of `-undefined dynamic_lookup`. Verified **pre-existing** against unmodified `main`, which fails identically — that's maturin's job, not this change's regression.)*

## And nothing in CI built it

**No workflow referenced `sdks/verifier-py` at all.** That is how an untestable configuration went unnoticed, and how the commerce bindings went missing while the JS SDK gained them.

Added `cargo test` + `cargo clippy -D warnings` steps to the existing `test` job. A test that never runs is barely better than no test.

## The test that matters

`the_python_surface_agrees_with_the_conformance_corpus` runs the **shared conformance vectors** through the Python cores — so this SDK is held to the same standard a third-party integrator would be, rather than to cases chosen by whoever wrote the bindings.

It guards itself two ways: a minimum vector count, so it cannot pass vacuously, and an assertion that the **only** skipped property is `disclosure_required` (no Python binding yet) — skipped explicitly, not silently.

## Mutation-tested

| perturbation | reds |
|---|---|
| payout core always accepts | `the_python_surface_agrees_with_the_conformance_corpus` |
| settlement-set core always complete | same |
| cart core always authorizes | same |

## Verification

`verifier-py` 3 tests, 0 clippy. `cargo fmt` clean in all five workspaces, vendor gate clean, `ci.yml` parses.
