### PR TITLE
release(spec): pin the guest to v2.2.0 and raise the floor above 2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,11 @@ nucleus setup --install-deps   # installs Lima if missing, provisions the VM,
                                # POD and asserts what the guest did
 ```
 
-Guest artifacts come from the pinned release **v2.1.0**, the first one able to
-boot a pod at all — everything up to 2.0.2 ships a rootfs with no CA bundle, on
-which the guest panics as PID 1, and `tier2_artifacts::GUEST_RELEASE_FLOOR`
-refuses those rather than installing one. **Measured 48.7 s** from a deleted VM to
+Guest artifacts come from the pinned release **v2.2.0**, the first whose rootfs
+matches a current node. `tier2_artifacts::GUEST_RELEASE_FLOOR` refuses anything
+older rather than installing a pod that cannot boot — everything up to 2.0.2
+ships a rootfs with no CA bundle, on which the guest panics as PID 1, and 2.1.0
+predates the change to how the guest is approved, which panics the same way. **Measured 48.7 s** from a deleted VM to
 a booted pod, with Sigstore build provenance verified on every downloaded
 artifact.
 

--- a/crates/nucleus-spec/src/tier2_artifacts.rs
+++ b/crates/nucleus-spec/src/tier2_artifacts.rs
@@ -85,24 +85,38 @@ pub const RELEASE_REPO: &str = "coproduct-opensource/nucleus";
 /// Both halves of that fix — the fallible constructor and `build-rootfs.sh`
 /// installing a bundle — landed after 2.0.2.
 ///
+/// The same thing has now happened a second time, one release up. #2214
+/// (2026-08-08) replaced the guest's shared approval secret with Ed25519
+/// verification against the node's public key: a current `nucleus-node` sends
+/// `nucleus.approval_pubkeys` and no longer sends `nucleus.approval_secret`,
+/// which the 2.1.0 rootfs's guest-init still requires. It exits, and because it
+/// is PID 1 the kernel panics — the identical failure shape as #2110, from a
+/// different cause. So 2.1.0 joins 2.0.2 below the floor.
+///
 /// So a quickstart pinned below this floor would hand a new user a pod that
 /// cannot boot. `setup` refuses rather than installing one, and says why.
-pub const GUEST_RELEASE_FLOOR: &str = "2.1.0";
+pub const GUEST_RELEASE_FLOOR: &str = "2.2.0";
 
 /// The release `setup` installs guest artifacts from.
 ///
-/// `2.1.0` is the first release containing everything a pod needs to boot: the CA
-/// bundle in the rootfs (#2110), the `ip netns exec` separator fix without which
-/// no pod launches on a default install, and the workload-API socket chown
-/// without which the guest cannot fetch its SVID.
+/// `2.2.0` is the first release whose rootfs matches a post-#2214 node. 2.1.0
+/// was the first release containing everything a pod needed to boot at the time
+/// — the CA bundle in the rootfs (#2110), the `ip netns exec` separator fix
+/// without which no pod launches on a default install, and the workload-API
+/// socket chown without which the guest cannot fetch its SVID — and it stayed
+/// pinned for five weeks after the node moved past it.
 ///
-/// Bumped from `2.1.0-rc.1` in the same change that is released as `2.1.0`, and
-/// deliberately BEFORE the tag is cut: a stable CLI must not pin prerelease guest
-/// images, which is what shipping 2.1.0 with the RC still pinned would do.
+/// Bumped BEFORE the tag is cut, matching how `2.1.0` was bumped from its RC in
+/// the change that was released as `2.1.0`. The ordering is deliberate and it
+/// has a cost worth naming: between this landing and the `v2.2.0` assets being
+/// built, `setup` points at a release that does not exist yet. That window is
+/// inherent to pinning your own next version, and the alternative — tag first,
+/// bump after — ships a release whose CLI pins the *previous* release's guest,
+/// which is precisely the skew being closed.
 ///
 /// `pinned_release_is_at_or_above_the_floor` fails if this ever drops below the
 /// floor; `parse_release` explains why an RC compares equal to its own version.
-pub const GUEST_RELEASE: &str = "2.1.0";
+pub const GUEST_RELEASE: &str = "2.2.0";
 
 /// Something a Tier 2 host needs, published as a release asset.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -257,8 +271,8 @@ mod tests {
     /// numeric core.
     #[test]
     fn a_prerelease_of_an_acceptable_version_is_accepted() {
-        for rc in ["2.1.0-rc.1", "v2.1.0-rc.1", "2.1.0-rc1", "2.1.0+build.7"] {
-            assert_eq!(parse_release(rc), Some((2, 1, 0)), "{rc} core");
+        for rc in ["2.2.0-rc.1", "v2.2.0-rc.1", "2.2.0-rc1", "2.2.0+build.7"] {
+            assert_eq!(parse_release(rc), Some((2, 2, 0)), "{rc} core");
             assert!(release_is_acceptable(rc), "{rc} should be accepted");
         }
     }
@@ -268,7 +282,10 @@ mod tests {
     /// handling would be a way to smuggle a pre-CA-bundle rootfs past the floor.
     #[test]
     fn a_prerelease_of_a_refused_version_is_still_refused() {
-        for rc in ["2.0.2-rc.1", "1.1.0-rc.1", "v2.0.0-beta"] {
+        // `2.1.0` joined this list when the floor rose to 2.2.0: #2214 left its
+        // rootfs unable to boot a current node. If the floor is ever lowered
+        // back, this is the assertion that fails.
+        for rc in ["2.1.0-rc.1", "2.0.2-rc.1", "1.1.0-rc.1", "v2.0.0-beta"] {
             assert!(
                 !release_is_acceptable(rc),
                 "{rc} predates the PID-1 CA-store fix and must stay refused"
@@ -287,8 +304,8 @@ mod tests {
     /// the bare version rather than failing to parse.
     #[test]
     fn a_tag_style_version_parses() {
-        assert_eq!(parse_release("v2.1.0"), parse_release("2.1.0"));
-        assert!(release_is_acceptable("v2.1.0"));
+        assert_eq!(parse_release("v2.2.0"), parse_release("2.2.0"));
+        assert!(release_is_acceptable("v2.2.0"));
     }
 
     #[test]


### PR DESCRIPTION
## The pinned guest has not been bootable for five weeks

`GUEST_RELEASE` has been `2.1.0` since **2026-07-30**. #2214 landed **2026-08-08** and changed how the guest is approved: a current `nucleus-node` sends `nucleus.approval_pubkeys` and no longer sends `nucleus.approval_secret` — which the 2.1.0 rootfs's guest-init still requires.

```text
nucleus-guest-init error: missing approval secret (set nucleus.approval_secret …)
Kernel panic - not syncing: Attempted to kill init! exitcode=0x00000000
```

The guest exits; because it is PID 1 the kernel panics. `setup` installed this anyway.

## This is the failure the floor already exists for

`GUEST_RELEASE_FLOOR` was introduced by #2110: everything up to 2.0.2 ships a rootfs with no CA bundle, the tool-proxy panicked **as PID 1**, and the floor made `setup` refuse rather than install a pod that cannot boot.

Different cause, identical outcome, and the remedy is the one already in the file — **2.1.0 goes below the floor.**

| | before | after |
| --- | --- | --- |
| `GUEST_RELEASE_FLOOR` | 2.1.0 | **2.2.0** |
| `GUEST_RELEASE` | 2.1.0 | **2.2.0** |

## Ordering, and its cost

Bumped **before** the tag is cut, matching how 2.1.0 was bumped from its RC in the change released as 2.1.0. That ordering has a real cost and it is now documented on the constant rather than left implicit: **until the `v2.2.0` assets are built, `setup` points at a release that does not exist.**

The alternative is worse. Tag first and bump after ships a release whose CLI pins the *previous* release's guest — precisely the skew being closed.

**So this PR must be followed promptly by the `v2.2.0` tag.** `release.yml` fires on `v*` and builds the guest binaries and rootfs; `crates-publish.yml` fires on `crates-v*` and is untouched by this, so nothing reaches crates.io.

## Verification

- 58 `nucleus-spec` tests pass.
- Two tests used 2.1.0 as their example of an **acceptable** version and went red. They test suffix parsing, not that version, so they now use 2.2.0.
- The useful half: **2.1.0 was added to `a_prerelease_of_a_refused_version_is_still_refused`.** The floor rise now has teeth — lowering it back fails an assertion instead of passing quietly. Without that, raising the floor would be a constant nothing checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)