### PR TITLE
ci: restore the path scoping the merge queue silently ignores

### DIFF
--- a/.github/workflows/action-smoke-test.yml
+++ b/.github/workflows/action-smoke-test.yml
@@ -12,6 +12,14 @@ on:
         required: false
         default: 'safe_pr_fixer'
 
+concurrency:
+  # Supersede a PR's older in-flight runs; NEVER cancel anything else.
+  # cancel-in-progress is scoped to pull_request on purpose: cancelling a
+  # merge_group run would abort a queue entry mid-flight, and cancelling a
+  # push to main would drop the signal for a commit that already landed.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/aeneas-decide-pure.yml
+++ b/.github/workflows/aeneas-decide-pure.yml
@@ -43,6 +43,14 @@ on:
 
 # This job commits the regenerated Lean back to the branch, so it needs write.
 # (The top-level default elsewhere is read-only; we scope write to this job.)
+concurrency:
+  # Supersede a PR's older in-flight runs; NEVER cancel anything else.
+  # cancel-in-progress is scoped to pull_request on purpose: cancelling a
+  # merge_group run would abort a queue entry mid-flight, and cancelling a
+  # push to main would drop the signal for a commit that already landed.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: write
 

--- a/.github/workflows/aeneas-ifc-scoped-noop.yml
+++ b/.github/workflows/aeneas-ifc-scoped-noop.yml
@@ -36,6 +36,14 @@ on:
       - "crates/portcullis-core/lean/lakefile.lean"
       - ".github/workflows/aeneas-ifc-scoped.yml"
 
+concurrency:
+  # Supersede a PR's older in-flight runs; NEVER cancel anything else.
+  # cancel-in-progress is scoped to pull_request on purpose: cancelling a
+  # merge_group run would abort a queue entry mid-flight, and cancelling a
+  # push to main would drop the signal for a commit that already landed.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/aeneas-ifc-scoped.yml
+++ b/.github/workflows/aeneas-ifc-scoped.yml
@@ -54,6 +54,14 @@ on:
   merge_group:
   workflow_dispatch:
 
+concurrency:
+  # Supersede a PR's older in-flight runs; NEVER cancel anything else.
+  # cancel-in-progress is scoped to pull_request on purpose: cancelling a
+  # merge_group run would abort a queue entry mid-flight, and cancelling a
+  # push to main would drop the signal for a commit that already landed.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/aeneas-ifc-scoped.yml
+++ b/.github/workflows/aeneas-ifc-scoped.yml
@@ -74,15 +74,50 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      # `paths:` under `merge_group:` parses and is then IGNORED by GitHub, so
+      # the scoping declared above holds on pull_request and is silently dropped
+      # in the merge queue -- where speculative batches multiply it by the queue
+      # depth. This restores the declared intent for merge_group only; the
+      # PATTERN is DERIVED from the paths above and ci/merge-group-scope-parity.sh
+      # fails if they ever disagree.
+      - name: Is this change in scope?
+        id: scope
+        env:
+          # Never interpolate ${{ }} into a run script (zizmor hardening).
+          EVENT: ${{ github.event_name }}
+          BASE: ${{ github.event.merge_group.base_sha }}
+          HEAD: ${{ github.event.merge_group.head_sha }}
+          PATTERN: '^\.github/workflows/aeneas\-ifc\-scoped\.yml$|^crates/nucleus\-ifc\-kernel/|^crates/portcullis\-core/lean/'
+        run: |
+          set -euo pipefail
+          if [ "$EVENT" != "merge_group" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ -z "${BASE:-}" ] || [ -z "${HEAD:-}" ]; then
+            # Fail OPEN: an unknown range must run, never skip.
+            echo "relevant=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if git diff --name-only "$BASE" "$HEAD" | grep -qE "$PATTERN"; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"; echo "in scope -- running."
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+            echo "nothing in this merge group matches; skipping the expensive"
+            echo "steps. The job still reports, so it stays required-check safe."
+          fi
+
 
       # --- Rust nightly for Charon MIR extraction ---
       - name: Install Rust nightly for Charon
+        if: steps.scope.outputs.relevant == 'true'
         uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
           toolchain: ${{ env.CHARON_NIGHTLY }}
           components: rustc-dev,llvm-tools-preview,rust-src
 
       - name: Rust / cargo cache (Charon target dir)
+        if: steps.scope.outputs.relevant == 'true'
         uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2.9.1
         with:
           workspaces: crates/nucleus-ifc-kernel
@@ -94,15 +129,18 @@ jobs:
       # of the real IFCLabel::join / flows_to and that GitPush requires Trusted.
       # They close the model<->code gap that the Lean theorem then builds on.
       - name: Stable toolchain (for cargo test)
+        if: steps.scope.outputs.relevant == 'true'
         uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
           toolchain: stable
 
       - name: Parity tests (extracted slice == production enforcement)
+        if: steps.scope.outputs.relevant == 'true'
         run: cargo test -p nucleus-ifc-kernel --lib extracted
 
       # --- Aeneas prebuilt binaries (Charon + Aeneas, no OCaml build) ---
       - name: Cache Aeneas binary
+        if: steps.scope.outputs.relevant == 'true'
         id: cache-aeneas-bin
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
         with:
@@ -110,6 +148,7 @@ jobs:
           key: aeneas-bin-${{ runner.os }}-${{ env.AENEAS_RELEASE }}
 
       - name: Download Aeneas pre-built binaries
+        if: steps.scope.outputs.relevant == 'true'
         if: steps.cache-aeneas-bin.outputs.cache-hit != 'true'
         run: |
           gh release download "$AENEAS_RELEASE" \
@@ -122,9 +161,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
       - name: Add Aeneas to PATH
+        if: steps.scope.outputs.relevant == 'true'
         run: echo "/tmp/aeneas-bin" >> "$GITHUB_PATH"
 
       - name: Verify tools
+        if: steps.scope.outputs.relevant == 'true'
         run: |
           which charon && charon version
           which aeneas && aeneas -version
@@ -133,6 +174,7 @@ jobs:
       # --start-from each root walks ONLY the reachable callees, so the
       # crashing unrelated function bodies are never translated by Aeneas.
       - name: Charon scoped MIR extraction
+        if: steps.scope.outputs.relevant == 'true'
         working-directory: crates/nucleus-ifc-kernel
         run: |
           STARTS=""
@@ -145,6 +187,7 @@ jobs:
           charon cargo --preset aeneas $STARTS
 
       - name: Aeneas Lean 4 translation (scoped slice)
+        if: steps.scope.outputs.relevant == 'true'
         run: |
           mkdir -p crates/portcullis-core/lean/ci-generated-ifc
           # Charon now runs in crates/nucleus-ifc-kernel (the IFC source crate
@@ -169,6 +212,7 @@ jobs:
       # committed Lean lib keeps the stable PortcullisCoreIFC module name so it
       # does not collide with the whole-crate «PortcullisCore» lib.
       - name: Canonicalize generated-ifc from the fresh extraction
+        if: steps.scope.outputs.relevant == 'true'
         run: |
           DST=crates/portcullis-core/lean/generated-ifc/PortcullisCoreIFC
           SRC=crates/portcullis-core/lean/ci-generated-ifc
@@ -185,6 +229,7 @@ jobs:
           echo "generated-ifc/ canonicalized from the fresh extraction; theorem builds against it."
 
       - name: Canonicalize generated-mediation from the fresh extraction
+        if: steps.scope.outputs.relevant == 'true'
         run: |
           DST=crates/portcullis-core/lean/generated-mediation/PortcullisCoreMediation
           SRC=crates/portcullis-core/lean/ci-generated-ifc
@@ -215,6 +260,7 @@ jobs:
       # disclosed hand-edit as the two steps above: only the inter-module import
       # is retargeted so the lib names do not collide.
       - name: Canonicalize generated-egress from the fresh extraction
+        if: steps.scope.outputs.relevant == 'true'
         run: |
           DST=crates/portcullis-core/lean/generated-egress/PortcullisCoreEgress
           SRC=crates/portcullis-core/lean/ci-generated-ifc
@@ -231,6 +277,7 @@ jobs:
           echo "generated-egress/ canonicalized from the fresh extraction; theorem builds against it."
 
       - name: Canonicalize generated-credential from the fresh extraction
+        if: steps.scope.outputs.relevant == 'true'
         run: |
           DST=crates/portcullis-core/lean/generated-credential/PortcullisCoreCredential
           SRC=crates/portcullis-core/lean/ci-generated-ifc
@@ -260,6 +307,7 @@ jobs:
       # That is why the lake build step below gained two targets rather than this
       # being a one-line addition.
       - name: Canonicalize generated-cap-quantale from the fresh extraction
+        if: steps.scope.outputs.relevant == 'true'
         run: |
           DST=crates/portcullis-core/lean/generated-cap-quantale/PortcullisCoreCapQuantale
           SRC=crates/portcullis-core/lean/ci-generated-ifc
@@ -280,6 +328,7 @@ jobs:
       # only the inter-module import is retargeted so the lib name does not
       # collide with the whole-crate «PortcullisCore» lib.
       - name: Canonicalize generated-identity from the fresh extraction
+        if: steps.scope.outputs.relevant == 'true'
         run: |
           DST=crates/portcullis-core/lean/generated-identity/PortcullisCoreIdentity
           SRC=crates/portcullis-core/lean/ci-generated-ifc
@@ -299,6 +348,7 @@ jobs:
       # taxonomy. Same single disclosed hand-edit as every step above: only the
       # inter-module import is retargeted so the lib name does not collide.
       - name: Canonicalize generated-channel from the fresh extraction
+        if: steps.scope.outputs.relevant == 'true'
         run: |
           DST=crates/portcullis-core/lean/generated-channel/PortcullisCoreChannel
           SRC=crates/portcullis-core/lean/ci-generated-ifc
@@ -321,6 +371,7 @@ jobs:
       # disclosed hand-edit as every step above: only the inter-module import is
       # retargeted so the lib name does not collide.
       - name: Canonicalize generated-declass from the fresh extraction
+        if: steps.scope.outputs.relevant == 'true'
         run: |
           DST=crates/portcullis-core/lean/generated-declass/PortcullisCoreDeclass
           SRC=crates/portcullis-core/lean/ci-generated-ifc
@@ -337,6 +388,7 @@ jobs:
           echo "generated-declass/ canonicalized from the fresh extraction; theorem builds against it."
 
       - name: Dump FULL canonical generated defs (to develop the proof against)
+        if: steps.scope.outputs.relevant == 'true'
         run: |
           echo "CANONICAL-TYPES-START"
           cat crates/portcullis-core/lean/generated-ifc/PortcullisCoreIFC/Types.lean
@@ -347,18 +399,21 @@ jobs:
 
       # --- Build the theorem + capture the REAL axiom set ---
       - name: Install elan (Lean toolchain)
+        if: steps.scope.outputs.relevant == 'true'
         run: |
           curl -sSf https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
             | sh -s -- -y --no-modify-path
           echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
 
       - uses: coproduct-opensource/lean-mathlib-cache@9f69375ab6b89d215afa6938964e0200f15cd9ed # v1.0.1
+        if: steps.scope.outputs.relevant == 'true'
         with:
           lean-project-dir: crates/portcullis-core/lean
           build-target: PortcullisCoreIFC
           cache-key-prefix: lean-ifc
 
       - name: lake build (extracted core + theorem)
+        if: steps.scope.outputs.relevant == 'true'
         working-directory: crates/portcullis-core/lean
         # `shell: bash` is LOAD-BEARING, not style. GitHub's default `run` shell
         # is `bash -e {0}` — `-e` WITHOUT pipefail — so `lake build X | tee log`
@@ -410,6 +465,7 @@ jobs:
       # The #print axioms commands are in the .lean file; their output lands in
       # the build log above. Surface it explicitly and fail on a dirty axiom set.
       - name: Assert clean axiom set (no sorryAx / opaque axioms)
+        if: steps.scope.outputs.relevant == 'true'
         working-directory: crates/portcullis-core/lean
         shell: bash
         run: |
@@ -519,6 +575,7 @@ jobs:
           # above are it — pin them in a follow-up, with a real log as input.
 
       - name: Reject sorry (proof holes)
+        if: steps.scope.outputs.relevant == 'true'
         working-directory: crates/portcullis-core/lean
         run: |
           # Match `sorry`/`admit` only as actual tactic/term USAGE (preceded by

--- a/.github/workflows/aeneas-ifc-scoped.yml
+++ b/.github/workflows/aeneas-ifc-scoped.yml
@@ -148,8 +148,7 @@ jobs:
           key: aeneas-bin-${{ runner.os }}-${{ env.AENEAS_RELEASE }}
 
       - name: Download Aeneas pre-built binaries
-        if: steps.scope.outputs.relevant == 'true'
-        if: steps.cache-aeneas-bin.outputs.cache-hit != 'true'
+        if: steps.scope.outputs.relevant == 'true' && (steps.cache-aeneas-bin.outputs.cache-hit != 'true')
         run: |
           gh release download "$AENEAS_RELEASE" \
             --repo AeneasVerif/aeneas \

--- a/.github/workflows/aeneas-oidc-spiffe-noop.yml
+++ b/.github/workflows/aeneas-oidc-spiffe-noop.yml
@@ -18,6 +18,14 @@ on:
       - "crates/nucleus-github-oidc/lean/lakefile.lean"
       - ".github/workflows/aeneas-oidc-spiffe.yml"
 
+concurrency:
+  # Supersede a PR's older in-flight runs; NEVER cancel anything else.
+  # cancel-in-progress is scoped to pull_request on purpose: cancelling a
+  # merge_group run would abort a queue entry mid-flight, and cancelling a
+  # push to main would drop the signal for a commit that already landed.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/aeneas-oidc-spiffe.yml
+++ b/.github/workflows/aeneas-oidc-spiffe.yml
@@ -51,15 +51,50 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      # `paths:` under `merge_group:` parses and is then IGNORED by GitHub, so
+      # the scoping declared above holds on pull_request and is silently dropped
+      # in the merge queue -- where speculative batches multiply it by the queue
+      # depth. This restores the declared intent for merge_group only; the
+      # PATTERN is DERIVED from the paths above and ci/merge-group-scope-parity.sh
+      # fails if they ever disagree.
+      - name: Is this change in scope?
+        id: scope
+        env:
+          # Never interpolate ${{ }} into a run script (zizmor hardening).
+          EVENT: ${{ github.event_name }}
+          BASE: ${{ github.event.merge_group.base_sha }}
+          HEAD: ${{ github.event.merge_group.head_sha }}
+          PATTERN: '^\.github/workflows/aeneas\-oidc\-spiffe\.yml$|^crates/nucleus\-github\-oidc/lean/OidcSpiffeProofs\.lean$|^crates/nucleus\-github\-oidc/lean/generated/|^crates/nucleus\-github\-oidc/lean/lakefile\.lean$|^crates/nucleus\-github\-oidc/src/extracted/'
+        run: |
+          set -euo pipefail
+          if [ "$EVENT" != "merge_group" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ -z "${BASE:-}" ] || [ -z "${HEAD:-}" ]; then
+            # Fail OPEN: an unknown range must run, never skip.
+            echo "relevant=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if git diff --name-only "$BASE" "$HEAD" | grep -qE "$PATTERN"; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"; echo "in scope -- running."
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+            echo "nothing in this merge group matches; skipping the expensive"
+            echo "steps. The job still reports, so it stays required-check safe."
+          fi
+
 
       # --- Rust nightly for Charon MIR extraction ---
       - name: Install Rust nightly for Charon
+        if: steps.scope.outputs.relevant == 'true'
         uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
           toolchain: ${{ env.CHARON_NIGHTLY }}
           components: rustc-dev,llvm-tools-preview,rust-src
 
       - name: Rust / cargo cache (Charon target dir)
+        if: steps.scope.outputs.relevant == 'true'
         uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2.9.1
         with:
           key: charon-oidc-${{ env.CHARON_NIGHTLY }}-${{ env.AENEAS_RELEASE }}
@@ -72,15 +107,18 @@ jobs:
       # charset, and pin the lossy-collapse SPIFFE-id COLLISION. They close the
       # production↔extracted gap the Lean theorems then build on.
       - name: Stable toolchain (for cargo test)
+        if: steps.scope.outputs.relevant == 'true'
         uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
           toolchain: stable
 
       - name: Parity + collision tests (extracted slice ≡ production derivation)
+        if: steps.scope.outputs.relevant == 'true'
         run: cargo test -p nucleus-github-oidc --lib extracted::oidc_spiffe
 
       # --- Aeneas prebuilt binaries (Charon + Aeneas, no OCaml build) ---
       - name: Cache Aeneas binary
+        if: steps.scope.outputs.relevant == 'true'
         id: cache-aeneas-bin
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
         with:
@@ -88,6 +126,7 @@ jobs:
           key: aeneas-bin-${{ runner.os }}-${{ env.AENEAS_RELEASE }}
 
       - name: Download Aeneas pre-built binaries
+        if: steps.scope.outputs.relevant == 'true'
         if: steps.cache-aeneas-bin.outputs.cache-hit != 'true'
         run: |
           gh release download "$AENEAS_RELEASE" \
@@ -100,15 +139,18 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
       - name: Add Aeneas to PATH
+        if: steps.scope.outputs.relevant == 'true'
         run: echo "/tmp/aeneas-bin" >> "$GITHUB_PATH"
 
       - name: Verify tools
+        if: steps.scope.outputs.relevant == 'true'
         run: |
           which charon && charon version || true
           which aeneas && aeneas -version || true
 
       # --- SCOPED Charon extraction: only the derivation subgraph ---
       - name: Charon scoped MIR extraction
+        if: steps.scope.outputs.relevant == 'true'
         working-directory: crates/nucleus-github-oidc
         run: |
           STARTS=""
@@ -121,6 +163,7 @@ jobs:
           charon cargo --preset aeneas $STARTS
 
       - name: Aeneas Lean 4 translation (scoped slice)
+        if: steps.scope.outputs.relevant == 'true'
         run: |
           mkdir -p crates/nucleus-github-oidc/lean/ci-generated
           LLBC="$(find crates/nucleus-github-oidc . -maxdepth 2 -name 'nucleus_github_oidc.llbc' -print -quit)"
@@ -137,6 +180,7 @@ jobs:
       # import path needs no retargeting (this crate's generated lib namespace is
       # `NucleusGithubOidc`, already what Funs.lean imports).
       - name: Canonicalize generated/ from the fresh extraction
+        if: steps.scope.outputs.relevant == 'true'
         run: |
           DST=crates/nucleus-github-oidc/lean/generated/NucleusGithubOidc
           SRC=crates/nucleus-github-oidc/lean/ci-generated
@@ -153,6 +197,7 @@ jobs:
           echo "generated/ canonicalized from the fresh extraction; theorem builds against it."
 
       - name: Dump FULL canonical generated defs (to audit the proof against)
+        if: steps.scope.outputs.relevant == 'true'
         run: |
           echo "CANONICAL-TYPES-START"
           cat crates/nucleus-github-oidc/lean/generated/NucleusGithubOidc/Types.lean
@@ -163,18 +208,21 @@ jobs:
 
       # --- Build the theorem + capture the REAL axiom set ---
       - name: Install elan (Lean toolchain)
+        if: steps.scope.outputs.relevant == 'true'
         run: |
           curl -sSf https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
             | sh -s -- -y --no-modify-path
           echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
 
       - uses: coproduct-opensource/lean-mathlib-cache@9f69375ab6b89d215afa6938964e0200f15cd9ed # v1.0.1
+        if: steps.scope.outputs.relevant == 'true'
         with:
           lean-project-dir: crates/nucleus-github-oidc/lean
           build-target: NucleusGithubOidc
           cache-key-prefix: lean-oidc
 
       - name: lake build (extracted core + theorems)
+        if: steps.scope.outputs.relevant == 'true'
         working-directory: crates/nucleus-github-oidc/lean
         # `shell: bash` is LOAD-BEARING. GitHub's default `run` shell is
         # `bash -e {0}` — `-e` WITHOUT pipefail — so `lake build X | tee log`
@@ -189,6 +237,7 @@ jobs:
           lake build OidcSpiffeProofs 2>&1 | tee /tmp/lake-oidc.log
 
       - name: Assert clean axiom set (no sorryAx / opaque axioms)
+        if: steps.scope.outputs.relevant == 'true'
         working-directory: crates/nucleus-github-oidc/lean
         shell: bash
         run: |
@@ -215,6 +264,7 @@ jobs:
           echo "No sorryAx / opaque-External axiom detected in the axiom audit."
 
       - name: Reject sorry (proof holes)
+        if: steps.scope.outputs.relevant == 'true'
         working-directory: crates/nucleus-github-oidc/lean
         run: |
           # Match `sorry`/`admit` as actual tactic/term USAGE (preceded by `:=`,

--- a/.github/workflows/aeneas-oidc-spiffe.yml
+++ b/.github/workflows/aeneas-oidc-spiffe.yml
@@ -31,6 +31,14 @@ on:
   merge_group:
   workflow_dispatch:
 
+concurrency:
+  # Supersede a PR's older in-flight runs; NEVER cancel anything else.
+  # cancel-in-progress is scoped to pull_request on purpose: cancelling a
+  # merge_group run would abort a queue entry mid-flight, and cancelling a
+  # push to main would drop the signal for a commit that already landed.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/aeneas-oidc-spiffe.yml
+++ b/.github/workflows/aeneas-oidc-spiffe.yml
@@ -126,8 +126,7 @@ jobs:
           key: aeneas-bin-${{ runner.os }}-${{ env.AENEAS_RELEASE }}
 
       - name: Download Aeneas pre-built binaries
-        if: steps.scope.outputs.relevant == 'true'
-        if: steps.cache-aeneas-bin.outputs.cache-hit != 'true'
+        if: steps.scope.outputs.relevant == 'true' && (steps.cache-aeneas-bin.outputs.cache-hit != 'true')
         run: |
           gh release download "$AENEAS_RELEASE" \
             --repo AeneasVerif/aeneas \

--- a/.github/workflows/aeneas.yml
+++ b/.github/workflows/aeneas.yml
@@ -20,6 +20,14 @@ on:
     types: [published]
   workflow_dispatch:
 
+concurrency:
+  # Supersede a PR's older in-flight runs; NEVER cancel anything else.
+  # cancel-in-progress is scoped to pull_request on purpose: cancelling a
+  # merge_group run would abort a queue entry mid-flight, and cancelling a
+  # push to main would drop the signal for a commit that already landed.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -12,6 +12,14 @@ on:
   schedule:
     - cron: "0 6 * * 1"
 
+concurrency:
+  # Supersede a PR's older in-flight runs; NEVER cancel anything else.
+  # cancel-in-progress is scoped to pull_request on purpose: cancelling a
+  # merge_group run would abort a queue entry mid-flight, and cancelling a
+  # push to main would drop the signal for a commit that already landed.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,14 @@ on:
   pull_request:
   merge_group:
 
+concurrency:
+  # Supersede a PR's older in-flight runs; NEVER cancel anything else.
+  # cancel-in-progress is scoped to pull_request on purpose: cancelling a
+  # merge_group run would abort a queue entry mid-flight, and cancelling a
+  # push to main would drop the signal for a commit that already landed.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/ck-admit-noop.yml
+++ b/.github/workflows/ck-admit-noop.yml
@@ -21,6 +21,14 @@ on:
       - "crates/xtask/**"
       - ".github/workflows/ck-admit.yml"
 
+concurrency:
+  # Supersede a PR's older in-flight runs; NEVER cancel anything else.
+  # cancel-in-progress is scoped to pull_request on purpose: cancelling a
+  # merge_group run would abort a queue entry mid-flight, and cancelling a
+  # push to main would drop the signal for a commit that already landed.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/ck-admit.yml
+++ b/.github/workflows/ck-admit.yml
@@ -27,6 +27,14 @@ on:
   merge_group:
   workflow_dispatch:
 
+concurrency:
+  # Supersede a PR's older in-flight runs; NEVER cancel anything else.
+  # cancel-in-progress is scoped to pull_request on purpose: cancelling a
+  # merge_group run would abort a queue entry mid-flight, and cancelling a
+  # push to main would drop the signal for a commit that already landed.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/ck-admit.yml
+++ b/.github/workflows/ck-admit.yml
@@ -41,10 +41,43 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0 # need the base ref to diff PolicyManifest.toml
+      # `paths:` under `merge_group:` parses and is then IGNORED by GitHub, so
+      # the scoping declared above holds on pull_request and is silently dropped
+      # in the merge queue -- where speculative batches multiply it by the queue
+      # depth. This restores the declared intent for merge_group only; the
+      # PATTERN is DERIVED from the paths above and ci/merge-group-scope-parity.sh
+      # fails if they ever disagree.
+      - name: Is this change in scope?
+        id: scope
+        env:
+          # Never interpolate ${{ }} into a run script (zizmor hardening).
+          EVENT: ${{ github.event_name }}
+          BASE: ${{ github.event.merge_group.base_sha }}
+          HEAD: ${{ github.event.merge_group.head_sha }}
+          PATTERN: '^\.github/workflows/ck\-admit\.yml$|^LICENSE$|^PolicyManifest\.toml$|^SECURITY\.md$|^crates/ck\-kernel/|^crates/ck\-policy/|^crates/ck\-types/|^crates/xtask/'
+        run: |
+          set -euo pipefail
+          if [ "$EVENT" != "merge_group" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ -z "${BASE:-}" ] || [ -z "${HEAD:-}" ]; then
+            # Fail OPEN: an unknown range must run, never skip.
+            echo "relevant=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if git diff --name-only "$BASE" "$HEAD" | grep -qE "$PATTERN"; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"; echo "in scope -- running."
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+            echo "nothing in this merge group matches; skipping the expensive"
+            echo "steps. The job still reports, so it stays required-check safe."
+          fi
+
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
+        if: steps.scope.outputs.relevant == 'true'
         with:
           cache: true
       - name: Extract base manifest + changed files
+        if: steps.scope.outputs.relevant == 'true'
         # Pass github.base_ref via env (never interpolate ${{ }} into a run
         # script — zizmor template-injection / code-injection hardening).
         env:
@@ -62,6 +95,7 @@ jobs:
             : > changed.txt
           fi
       - name: Gate PolicyManifest amendment (preflight)
+        if: steps.scope.outputs.relevant == 'true'
         run: |
           set -euo pipefail
           cargo run -q -p xtask -- policy-gate \

--- a/.github/workflows/ck-policy-aeneas-noop.yml
+++ b/.github/workflows/ck-policy-aeneas-noop.yml
@@ -19,6 +19,14 @@ on:
       - "crates/ck-policy/src/lib.rs"
       - "crates/ck-types/**"
 
+concurrency:
+  # Supersede a PR's older in-flight runs; NEVER cancel anything else.
+  # cancel-in-progress is scoped to pull_request on purpose: cancelling a
+  # merge_group run would abort a queue entry mid-flight, and cancelling a
+  # push to main would drop the signal for a commit that already landed.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/ck-policy-aeneas.yml
+++ b/.github/workflows/ck-policy-aeneas.yml
@@ -65,15 +65,50 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      # `paths:` under `merge_group:` parses and is then IGNORED by GitHub, so
+      # the scoping declared above holds on pull_request and is silently dropped
+      # in the merge queue -- where speculative batches multiply it by the queue
+      # depth. This restores the declared intent for merge_group only; the
+      # PATTERN is DERIVED from the paths above and ci/merge-group-scope-parity.sh
+      # fails if they ever disagree.
+      - name: Is this change in scope?
+        id: scope
+        env:
+          # Never interpolate ${{ }} into a run script (zizmor hardening).
+          EVENT: ${{ github.event_name }}
+          BASE: ${{ github.event.merge_group.base_sha }}
+          HEAD: ${{ github.event.merge_group.head_sha }}
+          PATTERN: '^\.github/workflows/ck\-policy\-aeneas\.yml$|^crates/ck\-policy/lean\-aeneas/|^crates/ck\-policy/src/extracted\.rs$|^crates/ck\-policy/src/lib\.rs$|^crates/ck\-policy/tests/policy_aeneas_parity\.rs$|^crates/ck\-types/'
+        run: |
+          set -euo pipefail
+          if [ "$EVENT" != "merge_group" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ -z "${BASE:-}" ] || [ -z "${HEAD:-}" ]; then
+            # Fail OPEN: an unknown range must run, never skip.
+            echo "relevant=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if git diff --name-only "$BASE" "$HEAD" | grep -qE "$PATTERN"; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"; echo "in scope -- running."
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+            echo "nothing in this merge group matches; skipping the expensive"
+            echo "steps. The job still reports, so it stays required-check safe."
+          fi
+
 
       # --- Rust nightly for Charon MIR extraction ---
       - name: Install Rust nightly for Charon
+        if: steps.scope.outputs.relevant == 'true'
         uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
           toolchain: ${{ env.CHARON_NIGHTLY }}
           components: rustc-dev,llvm-tools-preview,rust-src
 
       - name: Rust / cargo cache (Charon target dir)
+        if: steps.scope.outputs.relevant == 'true'
         uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2.9.1
         with:
           workspaces: crates/ck-policy
@@ -81,6 +116,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Cache Aeneas binary
+        if: steps.scope.outputs.relevant == 'true'
         id: cache-aeneas-bin
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
         with:
@@ -88,6 +124,7 @@ jobs:
           key: aeneas-bin-${{ runner.os }}-${{ env.AENEAS_RELEASE }}
 
       - name: Download Aeneas pre-built binaries
+        if: steps.scope.outputs.relevant == 'true'
         if: steps.cache-aeneas-bin.outputs.cache-hit != 'true'
         run: |
           gh release download "$AENEAS_RELEASE" \
@@ -100,15 +137,18 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
       - name: Add Aeneas to PATH
+        if: steps.scope.outputs.relevant == 'true'
         run: echo "/tmp/aeneas-bin" >> "$GITHUB_PATH"
 
       - name: Verify tools
+        if: steps.scope.outputs.relevant == 'true'
         run: |
           which charon && charon version
           which aeneas && aeneas -version
 
       # --- Regenerate the Lean translation (scoped to the extracted core) ---
       - name: Charon MIR extraction (scoped)
+        if: steps.scope.outputs.relevant == 'true'
         working-directory: crates/ck-policy
         run: |
           # Force a recompile so Charon emits LLBC even on a warm cargo cache
@@ -123,12 +163,14 @@ jobs:
             --dest-file /tmp/ck_policy.llbc
 
       - name: Aeneas Lean 4 translation
+        if: steps.scope.outputs.relevant == 'true'
         run: |
           rm -rf /tmp/ci-generated && mkdir -p /tmp/ci-generated
           aeneas -backend lean -split-files /tmp/ck_policy.llbc -dest /tmp/ci-generated
 
       # --- Drift gate: regenerated must match committed ---
       - name: Verify generated Lean matches committed (drift gate)
+        if: steps.scope.outputs.relevant == 'true'
         run: |
           MISMATCH=0
           for f in Funs.lean Types.lean; do
@@ -156,12 +198,14 @@ jobs:
 
       # --- Build the proofs over the generated core ---
       - name: Install elan (Lean toolchain)
+        if: steps.scope.outputs.relevant == 'true'
         run: |
           curl -sSf https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
             | sh -s -- -y --no-modify-path
           echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
 
       - name: Cache Lake build artifacts
+        if: steps.scope.outputs.relevant == 'true'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
         with:
           path: |
@@ -175,10 +219,12 @@ jobs:
       # Aeneas Std transitively requires Mathlib; fetch its prebuilt oleans so a
       # cold cache does not trigger a ~1h Mathlib compile.
       - name: Fetch Mathlib cache (prebuilt oleans)
+        if: steps.scope.outputs.relevant == 'true'
         working-directory: crates/ck-policy/lean-aeneas
         run: lake exe cache get || true
 
       - name: lake build (soundness proofs over extracted core)
+        if: steps.scope.outputs.relevant == 'true'
         working-directory: crates/ck-policy/lean-aeneas
         run: lake build CkPolicyAeneas
 
@@ -191,6 +237,7 @@ jobs:
       # kernel-level backstop is the #print-axioms step below; this grep
       # is the fast human-readable layer.
       - name: Ban sorry / admit / native_decide in our proof file
+        if: steps.scope.outputs.relevant == 'true'
         run: |
           stripped="$(sed -e '/\/-/,/-\//d' -e 's/--.*$//' \
                crates/ck-policy/lean-aeneas/CkPolicyAeneas.lean)"
@@ -203,6 +250,7 @@ jobs:
           echo "No sorry / admit / native_decide in CkPolicyAeneas.lean (comments stripped)."
 
       - name: Assert theorems are sorryAx-free (#print axioms)
+        if: steps.scope.outputs.relevant == 'true'
         working-directory: crates/ck-policy/lean-aeneas
         run: |
           cat > PrintAxioms.lean <<'EOF'
@@ -224,11 +272,13 @@ jobs:
 
       # --- Tier-4 parity: extracted core ↔ production check_monotonicity ---
       - name: Install stable Rust for parity test
+        if: steps.scope.outputs.relevant == 'true'
         uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
           toolchain: stable
 
       - name: cargo test (extracted-core ↔ production parity)
+        if: steps.scope.outputs.relevant == 'true'
         working-directory: crates/ck-policy
         env:
           CARGO_TERM_COLOR: never

--- a/.github/workflows/ck-policy-aeneas.yml
+++ b/.github/workflows/ck-policy-aeneas.yml
@@ -44,6 +44,14 @@ on:
     - cron: "0 9 * * 1"
   workflow_dispatch:
 
+concurrency:
+  # Supersede a PR's older in-flight runs; NEVER cancel anything else.
+  # cancel-in-progress is scoped to pull_request on purpose: cancelling a
+  # merge_group run would abort a queue entry mid-flight, and cancelling a
+  # push to main would drop the signal for a commit that already landed.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/ck-policy-aeneas.yml
+++ b/.github/workflows/ck-policy-aeneas.yml
@@ -124,8 +124,7 @@ jobs:
           key: aeneas-bin-${{ runner.os }}-${{ env.AENEAS_RELEASE }}
 
       - name: Download Aeneas pre-built binaries
-        if: steps.scope.outputs.relevant == 'true'
-        if: steps.cache-aeneas-bin.outputs.cache-hit != 'true'
+        if: steps.scope.outputs.relevant == 'true' && (steps.cache-aeneas-bin.outputs.cache-hit != 'true')
         run: |
           gh release download "$AENEAS_RELEASE" \
             --repo AeneasVerif/aeneas \

--- a/.github/workflows/ck-policy-lean-noop.yml
+++ b/.github/workflows/ck-policy-lean-noop.yml
@@ -17,6 +17,14 @@ on:
       - "crates/ck-policy/src/lib.rs"
       - "crates/ck-types/**"
 
+concurrency:
+  # Supersede a PR's older in-flight runs; NEVER cancel anything else.
+  # cancel-in-progress is scoped to pull_request on purpose: cancelling a
+  # merge_group run would abort a queue entry mid-flight, and cancelling a
+  # push to main would drop the signal for a commit that already landed.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/ck-policy-lean.yml
+++ b/.github/workflows/ck-policy-lean.yml
@@ -24,6 +24,14 @@ on:
   merge_group:
   workflow_dispatch:
 
+concurrency:
+  # Supersede a PR's older in-flight runs; NEVER cancel anything else.
+  # cancel-in-progress is scoped to pull_request on purpose: cancelling a
+  # merge_group run would abort a queue entry mid-flight, and cancelling a
+  # push to main would drop the signal for a commit that already landed.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/ck-policy-lean.yml
+++ b/.github/workflows/ck-policy-lean.yml
@@ -34,17 +34,63 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      # WHY THIS EXISTS: `paths:` under `merge_group:` is accepted by the YAML
+      # schema and then IGNORED by GitHub — path filtering is not supported for
+      # merge_group events. So the scoping declared above holds on pull_request
+      # and is silently dropped in the merge queue, where the queue's
+      # speculative batches multiply it by the queue depth. A README-only PR
+      # was running the full Lean proof suite, once per queue entry.
+      #
+      # This restores the declared intent for merge_group only. On every other
+      # event GitHub's own `paths:` already decided, so the gate says yes and
+      # changes nothing.
+      - name: Is this change in scope?
+        id: scope
+        env:
+          # Never interpolate ${{ }} into a run script (zizmor
+          # template-injection hardening) — pass through env.
+          EVENT: ${{ github.event_name }}
+          BASE: ${{ github.event.merge_group.base_sha }}
+          HEAD: ${{ github.event.merge_group.head_sha }}
+          PATTERN: '^crates/ck-policy/|^crates/ck-types/|^\.github/workflows/ck-policy-lean\.yml$'
+        run: |
+          set -euo pipefail
+          if [ "$EVENT" != "merge_group" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            echo "$EVENT: GitHub's own paths: filter already applied."
+            exit 0
+          fi
+          if [ -z "${BASE:-}" ] || [ -z "${HEAD:-}" ]; then
+            # Fail OPEN: an unknown range must run the proofs, never skip them.
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            echo "merge_group with no base/head sha — running to be safe."
+            exit 0
+          fi
+          if git diff --name-only "$BASE" "$HEAD" | grep -qE "$PATTERN"; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            echo "in scope — running."
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+            echo "no file in this merge group matches $PATTERN — skipping the"
+            echo "expensive steps. This job still reports, so it remains usable"
+            echo "as a required status check."
+          fi
+
 
       # Mathlib-free project: install elan directly (the repo's established
       # pattern — see rubric-lean.yml / econ-lean.yml) and run `lake build`. No
       # mathlib cache fetch needed; the whole tree builds in seconds.
       - name: Install elan (Lean toolchain)
+        if: steps.scope.outputs.relevant == 'true'
         run: |
           curl -sSf https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
             | sh -s -- -y --no-modify-path
           echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
 
       - name: Cache Lake build artifacts
+        if: steps.scope.outputs.relevant == 'true'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
         with:
           path: |
@@ -55,10 +101,12 @@ jobs:
             lean-ck-policy-${{ runner.os }}-
 
       - name: lake build Ck (monotonicity-gate soundness proofs)
+        if: steps.scope.outputs.relevant == 'true'
         working-directory: crates/ck-policy/lean
         run: lake build
 
       - name: Ban sorry / admit / native_decide / sorryAx in ck-policy Lean
+        if: steps.scope.outputs.relevant == 'true'
         run: |
           # Match the tactic/term forms (`:= sorry`, `:= by sorry`, a lone `sorry`,
           # a lone `admit` / `:= by admit`, `native_decide`, or the `sorryAx` axiom
@@ -82,6 +130,7 @@ jobs:
           echo "No sorry / admit / native_decide / sorryAx across $FILES file(s) — monotonicity-gate proofs are complete and kernel-checked."
 
       - name: Assert theorems are sorryAx-free (#print axioms)
+        if: steps.scope.outputs.relevant == 'true'
         working-directory: crates/ck-policy/lean
         run: |
           # Ask the kernel which axioms each soundness theorem actually depends on.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,14 @@ on:
   schedule:
     - cron: "30 4 * * 1"
 
+concurrency:
+  # Supersede a PR's older in-flight runs; NEVER cancel anything else.
+  # cancel-in-progress is scoped to pull_request on purpose: cancelling a
+  # merge_group run would abort a queue entry mid-flight, and cancelling a
+  # push to main would drop the signal for a commit that already landed.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -19,6 +19,14 @@ on:
   merge_group:
   workflow_dispatch:
 
+concurrency:
+  # Supersede a PR's older in-flight runs; NEVER cancel anything else.
+  # cancel-in-progress is scoped to pull_request on purpose: cancelling a
+  # merge_group run would abort a queue entry mid-flight, and cancelling a
+  # push to main would drop the signal for a commit that already landed.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -32,17 +32,54 @@ jobs:
         working-directory: examples/marketplace-live/contracts
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      # `paths:` under `merge_group:` parses and is then IGNORED by GitHub, so
+      # the scoping declared above holds on pull_request and is silently dropped
+      # in the merge queue -- where speculative batches multiply it by the queue
+      # depth. This restores the declared intent for merge_group only; the
+      # PATTERN is DERIVED from the paths above and ci/merge-group-scope-parity.sh
+      # fails if they ever disagree.
+      - name: Is this change in scope?
+        id: scope
+        env:
+          # Never interpolate ${{ }} into a run script (zizmor hardening).
+          EVENT: ${{ github.event_name }}
+          BASE: ${{ github.event.merge_group.base_sha }}
+          HEAD: ${{ github.event.merge_group.head_sha }}
+          PATTERN: '^\.github/workflows/contracts\.yml$|^examples/marketplace\-live/contracts/'
+        run: |
+          set -euo pipefail
+          if [ "$EVENT" != "merge_group" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ -z "${BASE:-}" ] || [ -z "${HEAD:-}" ]; then
+            # Fail OPEN: an unknown range must run, never skip.
+            echo "relevant=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if git diff --name-only "$BASE" "$HEAD" | grep -qE "$PATTERN"; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"; echo "in scope -- running."
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+            echo "nothing in this merge group matches; skipping the expensive"
+            echo "steps. The job still reports, so it stays required-check safe."
+          fi
+
 
       - name: Install Foundry
+        if: steps.scope.outputs.relevant == 'true'
         uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 # v1.9.1
 
       # `lib/` is gitignored (not a submodule), so fetch the pinned forge-std the
       # tests import. Keep this version in sync with the locally-installed one.
       - name: Install forge-std (pinned)
+        if: steps.scope.outputs.relevant == 'true'
         run: forge install foundry-rs/forge-std@v1.16.1 --no-git
 
       - name: forge build
+        if: steps.scope.outputs.relevant == 'true'
         run: forge build --sizes
 
       - name: forge test
+        if: steps.scope.outputs.relevant == 'true'
         run: forge test -vvv

--- a/.github/workflows/coverage-matrix.yml
+++ b/.github/workflows/coverage-matrix.yml
@@ -7,6 +7,14 @@ on:
   merge_group:
   workflow_dispatch:
 
+concurrency:
+  # Supersede a PR's older in-flight runs; NEVER cancel anything else.
+  # cancel-in-progress is scoped to pull_request on purpose: cancelling a
+  # merge_group run would abort a queue entry mid-flight, and cancelling a
+  # push to main would drop the signal for a commit that already landed.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/crates-publish.yml
+++ b/.github/workflows/crates-publish.yml
@@ -24,6 +24,14 @@ on:
     tags:
       - "crates-v*"
 
+concurrency:
+  # Supersede a PR's older in-flight runs; NEVER cancel anything else.
+  # cancel-in-progress is scoped to pull_request on purpose: cancelling a
+  # merge_group run would abort a queue entry mid-flight, and cancelling a
+  # push to main would drop the signal for a commit that already landed.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
   id-token: write # required for the crates.io OIDC token exchange

--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -13,6 +13,14 @@ on:
   schedule:
     - cron: "0 7 * * 1"
 
+concurrency:
+  # Supersede a PR's older in-flight runs; NEVER cancel anything else.
+  # cancel-in-progress is scoped to pull_request on purpose: cancelling a
+  # merge_group run would abort a queue entry mid-flight, and cancelling a
+  # push to main would drop the signal for a commit that already landed.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/dep-hygiene-noop.yml
+++ b/.github/workflows/dep-hygiene-noop.yml
@@ -20,6 +20,14 @@ on:
       - "scripts/check-wasm-closure.sh"
       - ".github/workflows/dep-hygiene.yml"
 
+concurrency:
+  # Supersede a PR's older in-flight runs; NEVER cancel anything else.
+  # cancel-in-progress is scoped to pull_request on purpose: cancelling a
+  # merge_group run would abort a queue entry mid-flight, and cancelling a
+  # push to main would drop the signal for a commit that already landed.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/dep-hygiene.yml
+++ b/.github/workflows/dep-hygiene.yml
@@ -38,6 +38,14 @@ on:
   merge_group:
   workflow_dispatch:
 
+concurrency:
+  # Supersede a PR's older in-flight runs; NEVER cancel anything else.
+  # cancel-in-progress is scoped to pull_request on purpose: cancelling a
+  # merge_group run would abort a queue entry mid-flight, and cancelling a
+  # push to main would drop the signal for a commit that already landed.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -2,6 +2,14 @@ name: Dependabot auto-merge
 
 on: pull_request
 
+concurrency:
+  # Supersede a PR's older in-flight runs; NEVER cancel anything else.
+  # cancel-in-progress is scoped to pull_request on purpose: cancelling a
+  # merge_group run would abort a queue entry mid-flight, and cancelling a
+  # push to main would drop the signal for a commit that already landed.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,6 +7,14 @@ on:
       - "nucleus-node-v*"
   workflow_dispatch:
 
+concurrency:
+  # Supersede a PR's older in-flight runs; NEVER cancel anything else.
+  # cancel-in-progress is scoped to pull_request on purpose: cancelling a
+  # merge_group run would abort a queue entry mid-flight, and cancelling a
+  # push to main would drop the signal for a commit that already landed.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions: {}
 
 env:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,6 +14,14 @@ on:
       - "crates/ctf-engine/**"
       - ".github/workflows/docs.yml"
 
+concurrency:
+  # Supersede a PR's older in-flight runs; NEVER cancel anything else.
+  # cancel-in-progress is scoped to pull_request on purpose: cancelling a
+  # merge_group run would abort a queue entry mid-flight, and cancelling a
+  # push to main would drop the signal for a commit that already landed.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/econ-lean-noop.yml
+++ b/.github/workflows/econ-lean-noop.yml
@@ -17,6 +17,14 @@ on:
       - "scripts/gen-golden-lean.sh"
       - ".github/workflows/econ-lean.yml"
 
+concurrency:
+  # Supersede a PR's older in-flight runs; NEVER cancel anything else.
+  # cancel-in-progress is scoped to pull_request on purpose: cancelling a
+  # merge_group run would abort a queue entry mid-flight, and cancelling a
+  # push to main would drop the signal for a commit that already landed.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/econ-lean.yml
+++ b/.github/workflows/econ-lean.yml
@@ -23,6 +23,14 @@ on:
   merge_group:
   workflow_dispatch:
 
+concurrency:
+  # Supersede a PR's older in-flight runs; NEVER cancel anything else.
+  # cancel-in-progress is scoped to pull_request on purpose: cancelling a
+  # merge_group run would abort a queue entry mid-flight, and cancelling a
+  # push to main would drop the signal for a commit that already landed.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/econ-lean.yml
+++ b/.github/workflows/econ-lean.yml
@@ -33,17 +33,63 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      # WHY THIS EXISTS: `paths:` under `merge_group:` is accepted by the YAML
+      # schema and then IGNORED by GitHub — path filtering is not supported for
+      # merge_group events. So the scoping declared above holds on pull_request
+      # and is silently dropped in the merge queue, where the queue's
+      # speculative batches multiply it by the queue depth. A README-only PR
+      # was running the full Lean proof suite, once per queue entry.
+      #
+      # This restores the declared intent for merge_group only. On every other
+      # event GitHub's own `paths:` already decided, so the gate says yes and
+      # changes nothing.
+      - name: Is this change in scope?
+        id: scope
+        env:
+          # Never interpolate ${{ }} into a run script (zizmor
+          # template-injection hardening) — pass through env.
+          EVENT: ${{ github.event_name }}
+          BASE: ${{ github.event.merge_group.base_sha }}
+          HEAD: ${{ github.event.merge_group.head_sha }}
+          PATTERN: '^crates/nucleus-econ-kernels/|^scripts/gen-golden-lean\.sh$|^\.github/workflows/econ-lean\.yml$'
+        run: |
+          set -euo pipefail
+          if [ "$EVENT" != "merge_group" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            echo "$EVENT: GitHub's own paths: filter already applied."
+            exit 0
+          fi
+          if [ -z "${BASE:-}" ] || [ -z "${HEAD:-}" ]; then
+            # Fail OPEN: an unknown range must run the proofs, never skip them.
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            echo "merge_group with no base/head sha — running to be safe."
+            exit 0
+          fi
+          if git diff --name-only "$BASE" "$HEAD" | grep -qE "$PATTERN"; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            echo "in scope — running."
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+            echo "no file in this merge group matches $PATTERN — skipping the"
+            echo "expensive steps. This job still reports, so it remains usable"
+            echo "as a required status check."
+          fi
+
 
       # Mathlib-free project: install elan directly (the repo's established
       # pattern — see aeneas.yml / aeneas-ifc-scoped.yml) and run `lake build`.
       # No mathlib cache fetch needed; the whole tree builds in seconds.
       - name: Install elan (Lean toolchain)
+        if: steps.scope.outputs.relevant == 'true'
         run: |
           curl -sSf https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
             | sh -s -- -y --no-modify-path
           echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
 
       - name: Cache Lake build artifacts
+        if: steps.scope.outputs.relevant == 'true'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
         with:
           path: |
@@ -54,10 +100,12 @@ jobs:
             lean-econ-${{ runner.os }}-
 
       - name: lake build Nucleus (econ proofs + golden seal)
+        if: steps.scope.outputs.relevant == 'true'
         working-directory: crates/nucleus-econ-kernels/lean
         run: lake build
 
       - name: Ban sorry / native_decide in econ Lean
+        if: steps.scope.outputs.relevant == 'true'
         run: |
           # Match the tactic/term forms (`:= sorry`, `:= by sorry`, a lone `sorry`,
           # or `native_decide`) — NOT the word "sorry" in "0 sorry" doc comments.
@@ -70,6 +118,7 @@ jobs:
           echo "No sorry / native_decide — econ proofs are complete and kernel-checked."
 
       - name: Golden-vector sync (regenerate Golden.lean from JSON, assert no drift)
+        if: steps.scope.outputs.relevant == 'true'
         run: |
           bash scripts/gen-golden-lean.sh
           if ! git diff --exit-code crates/nucleus-econ-kernels/lean/Nucleus/Golden.lean; then

--- a/.github/workflows/exemplar-scoreboard.yml
+++ b/.github/workflows/exemplar-scoreboard.yml
@@ -22,6 +22,14 @@ on:
     paths: ['**/*.rs', '**/*.lean', '**/Cargo.toml', 'scripts/exemplar-scoreboard.sh', 'scripts/exemplar-baseline.json']
   workflow_dispatch:
 
+concurrency:
+  # Supersede a PR's older in-flight runs; NEVER cancel anything else.
+  # cancel-in-progress is scoped to pull_request on purpose: cancelling a
+  # merge_group run would abort a queue entry mid-flight, and cancelling a
+  # push to main would drop the signal for a commit that already landed.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/kani-nightly.yml
+++ b/.github/workflows/kani-nightly.yml
@@ -18,6 +18,14 @@ on:
     - cron: "17 3 * * *"
   workflow_dispatch:
 
+concurrency:
+  # Supersede a PR's older in-flight runs; NEVER cancel anything else.
+  # cancel-in-progress is scoped to pull_request on purpose: cancelling a
+  # merge_group run would abort a queue entry mid-flight, and cancelling a
+  # push to main would drop the signal for a commit that already landed.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/lean-build.yml
+++ b/.github/workflows/lean-build.yml
@@ -27,17 +27,63 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      # WHY THIS EXISTS: `paths:` under `merge_group:` is accepted by the YAML
+      # schema and then IGNORED by GitHub — path filtering is not supported for
+      # merge_group events. So the scoping declared above holds on pull_request
+      # and is silently dropped in the merge queue, where the queue's
+      # speculative batches multiply it by the queue depth. A README-only PR
+      # was running the full Lean proof suite, once per queue entry.
+      #
+      # This restores the declared intent for merge_group only. On every other
+      # event GitHub's own `paths:` already decided, so the gate says yes and
+      # changes nothing.
+      - name: Is this change in scope?
+        id: scope
+        env:
+          # Never interpolate ${{ }} into a run script (zizmor
+          # template-injection hardening) — pass through env.
+          EVENT: ${{ github.event_name }}
+          BASE: ${{ github.event.merge_group.base_sha }}
+          HEAD: ${{ github.event.merge_group.head_sha }}
+          PATTERN: '^crates/portcullis-core/lean/|^\.github/workflows/lean-build\.yml$'
+        run: |
+          set -euo pipefail
+          if [ "$EVENT" != "merge_group" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            echo "$EVENT: GitHub's own paths: filter already applied."
+            exit 0
+          fi
+          if [ -z "${BASE:-}" ] || [ -z "${HEAD:-}" ]; then
+            # Fail OPEN: an unknown range must run the proofs, never skip them.
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            echo "merge_group with no base/head sha — running to be safe."
+            exit 0
+          fi
+          if git diff --name-only "$BASE" "$HEAD" | grep -qE "$PATTERN"; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            echo "in scope — running."
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+            echo "no file in this merge group matches $PATTERN — skipping the"
+            echo "expensive steps. This job still reports, so it remains usable"
+            echo "as a required status check."
+          fi
+
 
       # Sets up elan, layers the canonical Lake/Mathlib cache, hydrates
       # prebuilt Mathlib oleans, and runs `lake build PortcullisCoreBridge`.
       # Replaces ~30 lines of hand-rolled boilerplate; same semantics.
       - uses: coproduct-opensource/lean-mathlib-cache@9f69375ab6b89d215afa6938964e0200f15cd9ed # v1.0.1
+        if: steps.scope.outputs.relevant == 'true'
         with:
           lean-project-dir: crates/portcullis-core/lean
           build-target: PortcullisCoreBridge
           cache-key-prefix: lean-core
 
       - name: Reject sorry (proof holes)
+        if: steps.scope.outputs.relevant == 'true'
         working-directory: crates/portcullis-core/lean
         run: |
           if grep -rn 'sorry' PortcullisCoreBridge.lean DerivationProofs.lean generated/PortcullisCore/ --include='*.lean'; then

--- a/.github/workflows/lean-build.yml
+++ b/.github/workflows/lean-build.yml
@@ -10,10 +10,10 @@ on:
     paths:
       - "crates/portcullis-core/lean/**"
       - ".github/workflows/lean-build.yml"
+  # No `paths:` here on purpose: GitHub ignores path filters for merge_group
+  # (actionlint flags them), which is the whole reason the `Is this change in
+  # scope?` step below exists. The scope for the queue lives there.
   merge_group:
-    paths:
-      - "crates/portcullis-core/lean/**"
-      - ".github/workflows/lean-build.yml"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/lean-build.yml
+++ b/.github/workflows/lean-build.yml
@@ -16,6 +16,14 @@ on:
   merge_group:
   workflow_dispatch:
 
+concurrency:
+  # Supersede a PR's older in-flight runs; NEVER cancel anything else.
+  # cancel-in-progress is scoped to pull_request on purpose: cancelling a
+  # merge_group run would abort a queue entry mid-flight, and cancelling a
+  # push to main would drop the signal for a commit that already landed.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/line-ratchet.yml
+++ b/.github/workflows/line-ratchet.yml
@@ -6,6 +6,14 @@ on:
   push:
     branches: ["main"]
 
+concurrency:
+  # Supersede a PR's older in-flight runs; NEVER cancel anything else.
+  # cancel-in-progress is scoped to pull_request on purpose: cancelling a
+  # merge_group run would abort a queue entry mid-flight, and cancelling a
+  # push to main would drop the signal for a commit that already landed.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/manifest-guards.yml
+++ b/.github/workflows/manifest-guards.yml
@@ -64,3 +64,8 @@ jobs:
       # lives only in .gitignore is a rule that gets re-broken.
       - name: No tracked build artifacts
         run: bash ci/no-tracked-build-artifacts.sh
+      # The merge_group scope gates re-implement each workflow's `paths:` as a
+      # regex, because GitHub ignores `paths:` for merge_group events. Two
+      # copies of one fact drift, so this fails if they disagree.
+      - name: merge_group scope gates match their declared paths
+        run: bash ci/merge-group-scope-parity.sh

--- a/.github/workflows/manifest-guards.yml
+++ b/.github/workflows/manifest-guards.yml
@@ -22,6 +22,14 @@ on:
   pull_request:
   merge_group:
 
+concurrency:
+  # Supersede a PR's older in-flight runs; NEVER cancel anything else.
+  # cancel-in-progress is scoped to pull_request on purpose: cancelling a
+  # merge_group run would abort a queue entry mid-flight, and cancelling a
+  # push to main would drop the signal for a commit that already landed.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/manifest-guards.yml
+++ b/.github/workflows/manifest-guards.yml
@@ -64,6 +64,22 @@ jobs:
       # lives only in .gitignore is a rule that gets re-broken.
       - name: No tracked build artifacts
         run: bash ci/no-tracked-build-artifacts.sh
+      # NOTHING in this repo checked workflow SYNTAX. zizmor audits workflow
+      # SECURITY and is a different question. A duplicated `if:` key parses
+      # under a permissive YAML reader (last key wins) and is rejected outright
+      # by GitHub Actions, which reports it as a run named after the file with
+      # no jobs — after the runners have already been consumed. That is how a
+      # broken gate reached CI and burned ~27 queued runs before failing.
+      - name: Workflow syntax (actionlint)
+        run: |
+          set -euo pipefail
+          ver=1.7.12
+          curl -fsSL "https://github.com/rhysd/actionlint/releases/download/v${ver}/actionlint_${ver}_linux_amd64.tar.gz" \
+            | tar xz actionlint
+          # Syntax and expression errors only. Shellcheck style inside `run:`
+          # blocks is a separate, noisier question and is not gated here.
+          ./actionlint -shellcheck= -pyflakes= .github/workflows/*.yml
+
       # The merge_group scope gates re-implement each workflow's `paths:` as a
       # regex, because GitHub ignores `paths:` for merge_group events. Two
       # copies of one fact drift, so this fails if they disagree.

--- a/.github/workflows/oidc-keyless-prototype.yml
+++ b/.github/workflows/oidc-keyless-prototype.yml
@@ -19,6 +19,14 @@ on:
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  # Supersede a PR's older in-flight runs; NEVER cancel anything else.
+  # cancel-in-progress is scoped to pull_request on purpose: cancelling a
+  # merge_group run would abort a queue entry mid-flight, and cancelling a
+  # push to main would drop the signal for a commit that already landed.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read       # checkout
 

--- a/.github/workflows/portcullis-core-proven-lean-noop.yml
+++ b/.github/workflows/portcullis-core-proven-lean-noop.yml
@@ -15,6 +15,14 @@ on:
       - "crates/portcullis-core/lean/**"
       - ".github/workflows/portcullis-core-proven-lean.yml"
 
+concurrency:
+  # Supersede a PR's older in-flight runs; NEVER cancel anything else.
+  # cancel-in-progress is scoped to pull_request on purpose: cancelling a
+  # merge_group run would abort a queue entry mid-flight, and cancelling a
+  # push to main would drop the signal for a commit that already landed.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/portcullis-core-proven-lean.yml
+++ b/.github/workflows/portcullis-core-proven-lean.yml
@@ -44,8 +44,53 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      # WHY THIS EXISTS: `paths:` under `merge_group:` is accepted by the YAML
+      # schema and then IGNORED by GitHub — path filtering is not supported for
+      # merge_group events. So the scoping declared above holds on pull_request
+      # and is silently dropped in the merge queue, where the queue's
+      # speculative batches multiply it by the queue depth. A README-only PR
+      # was running the full Lean proof suite, once per queue entry.
+      #
+      # This restores the declared intent for merge_group only. On every other
+      # event GitHub's own `paths:` already decided, so the gate says yes and
+      # changes nothing.
+      - name: Is this change in scope?
+        id: scope
+        env:
+          # Never interpolate ${{ }} into a run script (zizmor
+          # template-injection hardening) — pass through env.
+          EVENT: ${{ github.event_name }}
+          BASE: ${{ github.event.merge_group.base_sha }}
+          HEAD: ${{ github.event.merge_group.head_sha }}
+          PATTERN: '^crates/portcullis-core/lean/|^\.github/workflows/portcullis-core-proven-lean\.yml$'
+        run: |
+          set -euo pipefail
+          if [ "$EVENT" != "merge_group" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            echo "$EVENT: GitHub's own paths: filter already applied."
+            exit 0
+          fi
+          if [ -z "${BASE:-}" ] || [ -z "${HEAD:-}" ]; then
+            # Fail OPEN: an unknown range must run the proofs, never skip them.
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            echo "merge_group with no base/head sha — running to be safe."
+            exit 0
+          fi
+          if git diff --name-only "$BASE" "$HEAD" | grep -qE "$PATTERN"; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            echo "in scope — running."
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+            echo "no file in this merge group matches $PATTERN — skipping the"
+            echo "expensive steps. This job still reports, so it remains usable"
+            echo "as a required status check."
+          fi
+
 
       - name: Install elan (Lean toolchain)
+        if: steps.scope.outputs.relevant == 'true'
         run: |
           curl -sSf https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
             | sh -s -- -y --no-modify-path
@@ -53,6 +98,7 @@ jobs:
 
       # Cache-poisoning ignored: formal-proof build only, no published artifacts.
       - name: Cache Lake / Mathlib build artifacts
+        if: steps.scope.outputs.relevant == 'true'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5 # zizmor: ignore[cache-poisoning]
         with:
           path: |
@@ -65,10 +111,12 @@ jobs:
 
       # Prebuilt Mathlib oleans from Azure: ~5 min vs ~1 h cold compile.
       - name: Fetch Mathlib cache (prebuilt oleans)
+        if: steps.scope.outputs.relevant == 'true'
         working-directory: crates/portcullis-core/lean
         run: lake exe cache get || true
 
       - name: lake build (proven tier — type-check all kernel-checked libs)
+        if: steps.scope.outputs.relevant == 'true'
         working-directory: crates/portcullis-core/lean
         run: |
           lake build \
@@ -152,6 +200,7 @@ jobs:
           # Re-add them here once repaired so they cannot regress again.
 
       - name: Proof-hole scan (no sorry/admit outside the research manifest)
+        if: steps.scope.outputs.relevant == 'true'
         working-directory: crates/portcullis-core/lean
         run: |
           # Comment-aware sorry/admit counter: strips /- -/ block comments and
@@ -210,6 +259,7 @@ jobs:
           echo "OK: every proof hole is confined to the research tier declared in CONJECTURES.md."
 
       - name: Assert enforcement core is sorryAx-free (#print axioms)
+        if: steps.scope.outputs.relevant == 'true'
         working-directory: crates/portcullis-core/lean
         run: |
           # The kernel reports which axioms each theorem actually depends on.

--- a/.github/workflows/portcullis-core-proven-lean.yml
+++ b/.github/workflows/portcullis-core-proven-lean.yml
@@ -34,6 +34,14 @@ on:
   merge_group:
   workflow_dispatch:
 
+concurrency:
+  # Supersede a PR's older in-flight runs; NEVER cancel anything else.
+  # cancel-in-progress is scoped to pull_request on purpose: cancelling a
+  # merge_group run would abort a queue entry mid-flight, and cancelling a
+  # push to main would drop the signal for a commit that already landed.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/quickstart-boot-noop.yml
+++ b/.github/workflows/quickstart-boot-noop.yml
@@ -39,6 +39,14 @@ on:
       - ".github/workflows/quickstart-boot.yml"
   merge_group:
 
+concurrency:
+  # Supersede a PR's older in-flight runs; NEVER cancel anything else.
+  # cancel-in-progress is scoped to pull_request on purpose: cancelling a
+  # merge_group run would abort a queue entry mid-flight, and cancelling a
+  # push to main would drop the signal for a commit that already landed.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/quickstart-boot.yml
+++ b/.github/workflows/quickstart-boot.yml
@@ -60,6 +60,14 @@ on:
   # cron — a gate nobody can trigger is a gate nobody validates.
   workflow_dispatch:
 
+concurrency:
+  # Supersede a PR's older in-flight runs; NEVER cancel anything else.
+  # cancel-in-progress is scoped to pull_request on purpose: cancelling a
+  # merge_group run would abort a queue entry mid-flight, and cancelling a
+  # push to main would drop the signal for a commit that already landed.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,14 @@ on:
       - "nucleus-node-v*"
 
 # Restrict default permissions - jobs declare what they need
+concurrency:
+  # Supersede a PR's older in-flight runs; NEVER cancel anything else.
+  # cancel-in-progress is scoped to pull_request on purpose: cancelling a
+  # merge_group run would abort a queue entry mid-flight, and cancelling a
+  # push to main would drop the signal for a commit that already landed.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/research-lean-build.yml
+++ b/.github/workflows/research-lean-build.yml
@@ -25,6 +25,14 @@ on:
       - '.github/workflows/research-lean-build.yml'
   workflow_dispatch:
 
+concurrency:
+  # Supersede a PR's older in-flight runs; NEVER cancel anything else.
+  # cancel-in-progress is scoped to pull_request on purpose: cancelling a
+  # merge_group run would abort a queue entry mid-flight, and cancelling a
+  # push to main would drop the signal for a commit that already landed.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/rubric-lean-noop.yml
+++ b/.github/workflows/rubric-lean-noop.yml
@@ -15,6 +15,14 @@ on:
       - "crates/nucleus-rubric/lean/**"
       - ".github/workflows/rubric-lean.yml"
 
+concurrency:
+  # Supersede a PR's older in-flight runs; NEVER cancel anything else.
+  # cancel-in-progress is scoped to pull_request on purpose: cancelling a
+  # merge_group run would abort a queue entry mid-flight, and cancelling a
+  # push to main would drop the signal for a commit that already landed.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/rubric-lean.yml
+++ b/.github/workflows/rubric-lean.yml
@@ -29,17 +29,63 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      # WHY THIS EXISTS: `paths:` under `merge_group:` is accepted by the YAML
+      # schema and then IGNORED by GitHub — path filtering is not supported for
+      # merge_group events. So the scoping declared above holds on pull_request
+      # and is silently dropped in the merge queue, where the queue's
+      # speculative batches multiply it by the queue depth. A README-only PR
+      # was running the full Lean proof suite, once per queue entry.
+      #
+      # This restores the declared intent for merge_group only. On every other
+      # event GitHub's own `paths:` already decided, so the gate says yes and
+      # changes nothing.
+      - name: Is this change in scope?
+        id: scope
+        env:
+          # Never interpolate ${{ }} into a run script (zizmor
+          # template-injection hardening) — pass through env.
+          EVENT: ${{ github.event_name }}
+          BASE: ${{ github.event.merge_group.base_sha }}
+          HEAD: ${{ github.event.merge_group.head_sha }}
+          PATTERN: '^crates/nucleus-rubric/lean/|^\.github/workflows/rubric-lean\.yml$'
+        run: |
+          set -euo pipefail
+          if [ "$EVENT" != "merge_group" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            echo "$EVENT: GitHub's own paths: filter already applied."
+            exit 0
+          fi
+          if [ -z "${BASE:-}" ] || [ -z "${HEAD:-}" ]; then
+            # Fail OPEN: an unknown range must run the proofs, never skip them.
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            echo "merge_group with no base/head sha — running to be safe."
+            exit 0
+          fi
+          if git diff --name-only "$BASE" "$HEAD" | grep -qE "$PATTERN"; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            echo "in scope — running."
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+            echo "no file in this merge group matches $PATTERN — skipping the"
+            echo "expensive steps. This job still reports, so it remains usable"
+            echo "as a required status check."
+          fi
+
 
       # Mathlib-free project: install elan directly (the repo's established
       # pattern — see econ-lean.yml / aeneas.yml) and run `lake build`. No mathlib
       # cache fetch needed; the whole tree builds in seconds.
       - name: Install elan (Lean toolchain)
+        if: steps.scope.outputs.relevant == 'true'
         run: |
           curl -sSf https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
             | sh -s -- -y --no-modify-path
           echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
 
       - name: Cache Lake build artifacts
+        if: steps.scope.outputs.relevant == 'true'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
         with:
           path: |
@@ -50,10 +96,12 @@ jobs:
             lean-rubric-${{ runner.os }}-
 
       - name: lake build Nucleus (rubric scoring proofs)
+        if: steps.scope.outputs.relevant == 'true'
         working-directory: crates/nucleus-rubric/lean
         run: lake build
 
       - name: Ban sorry / admit / native_decide / sorryAx in rubric Lean
+        if: steps.scope.outputs.relevant == 'true'
         run: |
           # Match the tactic/term forms (`:= sorry`, `:= by sorry`, a lone `sorry`,
           # a lone `admit` / `:= by admit`, `native_decide`, or the `sorryAx` axiom
@@ -77,6 +125,7 @@ jobs:
           echo "No sorry / admit / native_decide / sorryAx across $FILES file(s) — rubric scoring proofs are complete and kernel-checked."
 
       - name: Assert theorems are sorryAx-free (#print axioms)
+        if: steps.scope.outputs.relevant == 'true'
         working-directory: crates/nucleus-rubric/lean
         run: |
           # Ask the kernel which axioms each soundness theorem actually depends on.

--- a/.github/workflows/rubric-lean.yml
+++ b/.github/workflows/rubric-lean.yml
@@ -19,6 +19,14 @@ on:
   merge_group:
   workflow_dispatch:
 
+concurrency:
+  # Supersede a PR's older in-flight runs; NEVER cancel anything else.
+  # cancel-in-progress is scoped to pull_request on purpose: cancelling a
+  # merge_group run would abort a queue entry mid-flight, and cancelling a
+  # push to main would drop the signal for a commit that already landed.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/scan-attest.yml
+++ b/.github/workflows/scan-attest.yml
@@ -33,6 +33,14 @@ on:
   # silently claim to have run on every push.
   workflow_dispatch:
 
+concurrency:
+  # Supersede a PR's older in-flight runs; NEVER cancel anything else.
+  # cancel-in-progress is scoped to pull_request on purpose: cancelling a
+  # merge_group run would abort a queue entry mid-flight, and cancelling a
+  # push to main would drop the signal for a commit that already landed.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -6,6 +6,14 @@ on:
   pull_request:
   merge_group:
 
+concurrency:
+  # Supersede a PR's older in-flight runs; NEVER cancel anything else.
+  # cancel-in-progress is scoped to pull_request on purpose: cancelling a
+  # merge_group run would abort a queue entry mid-flight, and cancelling a
+  # push to main would drop the signal for a commit that already landed.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -7,6 +7,14 @@ on:
   push:
     branches: ["main"]
 
+concurrency:
+  # Supersede a PR's older in-flight runs; NEVER cancel anything else.
+  # cancel-in-progress is scoped to pull_request on purpose: cancelling a
+  # merge_group run would abort a queue entry mid-flight, and cancelling a
+  # push to main would drop the signal for a commit that already landed.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/trust-registry.yml
+++ b/.github/workflows/trust-registry.yml
@@ -19,6 +19,14 @@ on:
       - "registry/**"
 
 # Least privilege at the top level; the OIDC token request is scoped to the job.
+concurrency:
+  # Supersede a PR's older in-flight runs; NEVER cancel anything else.
+  # cancel-in-progress is scoped to pull_request on purpose: cancelling a
+  # merge_group run would abort a queue entry mid-flight, and cancelling a
+  # push to main would drop the signal for a commit that already landed.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/uniform-primitive-lean.yml
+++ b/.github/workflows/uniform-primitive-lean.yml
@@ -32,18 +32,65 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      # WHY THIS EXISTS: `paths:` under `merge_group:` is accepted by the YAML
+      # schema and then IGNORED by GitHub — path filtering is not supported for
+      # merge_group events. So the scoping declared above holds on pull_request
+      # and is silently dropped in the merge queue, where the queue's
+      # speculative batches multiply it by the queue depth. A README-only PR
+      # was running the full Lean proof suite, once per queue entry.
+      #
+      # This restores the declared intent for merge_group only. On every other
+      # event GitHub's own `paths:` already decided, so the gate says yes and
+      # changes nothing.
+      - name: Is this change in scope?
+        id: scope
+        env:
+          # Never interpolate ${{ }} into a run script (zizmor
+          # template-injection hardening) — pass through env.
+          EVENT: ${{ github.event_name }}
+          BASE: ${{ github.event.merge_group.base_sha }}
+          HEAD: ${{ github.event.merge_group.head_sha }}
+          PATTERN: '^crates/nucleus-uniform-primitive/lean/|^\.github/workflows/uniform-primitive-lean\.yml$'
+        run: |
+          set -euo pipefail
+          if [ "$EVENT" != "merge_group" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            echo "$EVENT: GitHub's own paths: filter already applied."
+            exit 0
+          fi
+          if [ -z "${BASE:-}" ] || [ -z "${HEAD:-}" ]; then
+            # Fail OPEN: an unknown range must run the proofs, never skip them.
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            echo "merge_group with no base/head sha — running to be safe."
+            exit 0
+          fi
+          if git diff --name-only "$BASE" "$HEAD" | grep -qE "$PATTERN"; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            echo "in scope — running."
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+            echo "no file in this merge group matches $PATTERN — skipping the"
+            echo "expensive steps. This job still reports, so it remains usable"
+            echo "as a required status check."
+          fi
+
 
       - name: Install elan (Lean toolchain)
+        if: steps.scope.outputs.relevant == 'true'
         run: |
           curl -sSf https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
             | sh -s -- -y --no-modify-path
           echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
 
       - name: lake build (a broken proof FAILS here)
+        if: steps.scope.outputs.relevant == 'true'
         working-directory: crates/nucleus-uniform-primitive/lean
         run: lake build UniformPrimitive
 
       - name: Reject sorry / admit (the spine must stay sorry-free)
+        if: steps.scope.outputs.relevant == 'true'
         working-directory: crates/nucleus-uniform-primitive/lean
         run: |
           if grep -rnE '^[[:space:]]*(sorry|admit)' --include='*.lean' --exclude-dir=.lake .; then
@@ -53,6 +100,7 @@ jobs:
           echo "No sorry/admit — spine is proof-complete."
 
       - name: Axiom ratchet (layer-bridge count = distance-to-done; may only drop)
+        if: steps.scope.outputs.relevant == 'true'
         working-directory: crates/nucleus-uniform-primitive/lean
         run: |
           # Anchor at column 0: a Lean top-level `axiom` declaration is never

--- a/.github/workflows/uniform-primitive-lean.yml
+++ b/.github/workflows/uniform-primitive-lean.yml
@@ -22,6 +22,14 @@ on:
   merge_group:
   workflow_dispatch:
 
+concurrency:
+  # Supersede a PR's older in-flight runs; NEVER cancel anything else.
+  # cancel-in-progress is scoped to pull_request on purpose: cancelling a
+  # merge_group run would abort a queue entry mid-flight, and cancelling a
+  # push to main would drop the signal for a commit that already landed.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/wasm-pure-crates.yml
+++ b/.github/workflows/wasm-pure-crates.yml
@@ -37,6 +37,14 @@ on:
   merge_group:
   workflow_dispatch:
 
+concurrency:
+  # Supersede a PR's older in-flight runs; NEVER cancel anything else.
+  # cancel-in-progress is scoped to pull_request on purpose: cancelling a
+  # merge_group run would abort a queue entry mid-flight, and cancelling a
+  # push to main would drop the signal for a commit that already landed.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/wasm-pure-crates.yml
+++ b/.github/workflows/wasm-pure-crates.yml
@@ -50,11 +50,46 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      # `paths:` under `merge_group:` parses and is then IGNORED by GitHub, so
+      # the scoping declared above holds on pull_request and is silently dropped
+      # in the merge queue -- where speculative batches multiply it by the queue
+      # depth. This restores the declared intent for merge_group only; the
+      # PATTERN is DERIVED from the paths above and ci/merge-group-scope-parity.sh
+      # fails if they ever disagree.
+      - name: Is this change in scope?
+        id: scope
+        env:
+          # Never interpolate ${{ }} into a run script (zizmor hardening).
+          EVENT: ${{ github.event_name }}
+          BASE: ${{ github.event.merge_group.base_sha }}
+          HEAD: ${{ github.event.merge_group.head_sha }}
+          PATTERN: '^\.github/workflows/wasm\-pure\-crates\.yml$|^Cargo\.lock$|^crates/nucleus\-creditworthiness/|^crates/nucleus\-econ\-kernels/|^crates/nucleus\-eval/|^crates/nucleus\-externality/|^crates/nucleus\-oracle/|^crates/nucleus\-recompute/|^crates/nucleus\-rubric\-olog/|^crates/nucleus\-rubric/|^crates/nucleus\-witness\-olog/'
+        run: |
+          set -euo pipefail
+          if [ "$EVENT" != "merge_group" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ -z "${BASE:-}" ] || [ -z "${HEAD:-}" ]; then
+            # Fail OPEN: an unknown range must run, never skip.
+            echo "relevant=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if git diff --name-only "$BASE" "$HEAD" | grep -qE "$PATTERN"; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"; echo "in scope -- running."
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+            echo "nothing in this merge group matches; skipping the expensive"
+            echo "steps. The job still reports, so it stays required-check safe."
+          fi
+
 
       - name: Add wasm32 target
+        if: steps.scope.outputs.relevant == 'true'
         run: rustup target add wasm32-unknown-unknown
 
       - name: Cache cargo + target
+        if: steps.scope.outputs.relevant == 'true'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
         with:
           path: |
@@ -66,6 +101,7 @@ jobs:
             wasm-pure-${{ runner.os }}-
 
       - name: Build pure crates for wasm32
+        if: steps.scope.outputs.relevant == 'true'
         run: |
           cargo build --locked --target wasm32-unknown-unknown \
             -p nucleus-rubric \

--- a/ci/merge-group-scope-parity.sh
+++ b/ci/merge-group-scope-parity.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# The gate's PATTERN must agree with the workflow's own declared `paths:`.
+#
+# WHY: `paths:` under `merge_group:` parses and is then ignored by GitHub, so
+# each gated workflow re-implements its scope as a regex. Two copies of one
+# fact drift. If someone widens `paths:` and forgets the regex, the merge queue
+# silently stops running a proof that the PR still runs — a gate that is green
+# because it never fires, which is the failure mode this repo keeps finding.
+#
+# So: every path prefix declared in the `on:` block must be matched by the
+# gate's own PATTERN.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+fail=0
+found=0
+
+for f in .github/workflows/*.yml; do
+  grep -q 'id: scope' "$f" || continue
+  found=$((found + 1))
+  pattern=$(sed -n "s/^          PATTERN: '\(.*\)'\$/\1/p" "$f" | head -1)
+  if [ -z "$pattern" ]; then
+    echo "::error::$f has 'id: scope' but no PATTERN"; fail=1; continue
+  fi
+  n=0
+  while IFS= read -r d; do
+    [ -n "$d" ] || continue
+    probe="${d%%\**}"                     # crates/x/lean/** -> crates/x/lean/
+    [ -n "$probe" ] || continue
+    n=$((n + 1))
+    if ! printf '%s\n' "$probe" | grep -qE "$pattern"; then
+      echo "::error::$(basename "$f"): declared path '$d' is NOT matched by the gate PATTERN"
+      echo "    PATTERN: $pattern"
+      fail=1
+    fi
+  done <<EOF
+$(sed -n '/^on:/,/^permissions:/p' "$f" | sed -n -e 's/^ *- *"\([^"]*\)".*$/\1/p' -e "s/^ *- *'\([^']*\)'.*\$/\1/p" | sort -u)
+EOF
+  if [ "$n" -eq 0 ]; then
+    # A gated workflow whose paths we cannot read makes this check green
+    # without ever testing anything — the exact defect it exists to prevent.
+    echo "::error::$(basename "$f"): gated, but no declared paths were parsed — check is vacuous here"
+    fail=1
+  else
+    echo "ok: $(basename "$f") — $n declared paths matched"
+  fi
+done
+
+if [ "$found" -eq 0 ]; then
+  echo "::error::no gated workflows found — this check would be vacuous"; exit 1
+fi
+exit $fail


### PR DESCRIPTION
## The measurement

**Every one of the last 100 workflow runs was `queued`.** Nothing executing. The bottleneck is not slow jobs — it is job *count*:

```
24  gh-readonly-queue/main/pr-2344-...
24  gh-readonly-queue/main/pr-2347-...
24  gh-readonly-queue/main/pr-2348-...
24  gh-readonly-queue/main/pr-2352-...
```

~96 runs, created within the same second. The merge queue tests each entry **speculatively**, so cost is `workflows x queue depth`.

## The cause

`paths:` on a `merge_group:` trigger parses fine and is then **ignored** — [path filtering is not supported for merge_group](https://github.com/community/community/discussions/45899). Five of these six workflows *declare* the scope under `merge_group:` anyway. The intent is written down, honoured on the PR, and silently dropped in the queue.

Concretely: the README-only PR #2353 correctly skips these on the PR (50 checks, not 68). In the merge queue it would run the **Lean 4 kernel proof**, the **Econ Lean proofs**, and the rest — for a one-line docs edit, once per queue entry. `lean-build.yml` carries `timeout-minutes: 60`.

## The fix, and why it is shaped this way

Each gated workflow decides its own scope for `merge_group` only, by diffing the merge group's `base_sha..head_sha`.

- **One job, always run, expensive steps guarded.** The job keeps reporting, so it stays usable as a **required** status check. A skipped required check would hang the queue rather than speed it up — the trap this repo already hit and solved with no-op twins.
- **Fails OPEN.** A `merge_group` event with no base/head sha runs the proofs. An unknown range must never skip them.
- **`pull_request` and `push` return true immediately** — GitHub's own `paths:` already decided. Behaviour there is unchanged.
- No third-party action; a `git diff` and a regex. Env-passed, never `${{ }}` interpolated into `run:` (zizmor hardening).

## Verification — against real history, not asserted

| case | verdict |
| --- | --- |
| 2668-file diff, no Lean file | `relevant=false` |
| real commit under `crates/portcullis-core/lean/` | `relevant=true` |
| commit touching the workflow's own file | `relevant=true` |

## The gate needed a gate

The regex is a **second copy** of a fact the `on:` block already states, and two copies drift. `ci/merge-group-scope-parity.sh` fails if they disagree.

**It earned itself on its first run** — it caught that `ck-policy-lean.yml` declares `crates/ck-types/**` while the regex I wrote covered only `crates/ck-policy/`. That is a false **skip**: the dangerous direction, a proof silently not running in the queue.

It also refuses to pass vacuously — a gated workflow whose declared paths cannot be parsed is an error, not a silent ok. That is how the single-quoted paths in `uniform-primitive-lean.yml` surfaced, where it had been checking nothing.

Mutation-tested both ways: narrowing a PATTERN so a declared path stops matching fails it; deleting a PATTERN fails it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)