### PR TITLE
feat(conformance): an independent implementation, and the vectors it proved insufficient

### DIFF
--- a/crates/nucleus-commerce-conformance/Cargo.toml
+++ b/crates/nucleus-commerce-conformance/Cargo.toml
@@ -19,3 +19,6 @@ nucleus-ifc = { path = "../nucleus-ifc", version = "1.0.0", features = ["decisio
 
 [lints]
 workspace = true
+
+[dev-dependencies]
+nucleus-recompute = { path = "../nucleus-recompute", version = "1.0.0" }

--- a/crates/nucleus-commerce-conformance/src/lib.rs
+++ b/crates/nucleus-commerce-conformance/src/lib.rs
@@ -286,6 +286,56 @@ pub fn corpus() -> Vec<ConformanceCase> {
         input: CaseInput::Payout(inflated),
     });
 
+    // Integer-division dust. `route_to_commons` assigns the remainder to the
+    // FIRST share so the allocations sum to exactly the pool — a specific,
+    // non-obvious rule that NO other vector exercises, because every other case
+    // divides evenly. An implementer reading only those would write plain
+    // truncation, pass the whole corpus, and then diverge from nucleus on real
+    // money the first time a split had a remainder. These two cases are what
+    // make the corpus sufficient to implement against.
+    let dusty_shares = vec![
+        CommonsShare {
+            destination: "seller".into(),
+            bps: 3_333,
+        },
+        CommonsShare {
+            destination: "runtime".into(),
+            bps: 3_333,
+        },
+        CommonsShare {
+            destination: "commons".into(),
+            bps: 3_334,
+        },
+    ];
+    // pool 1000 -> 333 / 333 / 333 by truncation, dust 1 to the first -> 334.
+    let dusty = issue_payout(
+        issue_settlement(1_000, 10_000),
+        dusty_shares.clone(),
+        attribution(),
+    )
+    .expect("well-formed");
+    cases.push(ConformanceCase {
+        name: "payout/remainder-dust-to-first-share",
+        summary: "a split that does not divide evenly: the dust goes to the first share",
+        property: Property::PayoutRecomputes,
+        expect: Expect::Accept,
+        expect_reason_contains: None,
+        input: CaseInput::Payout(dusty.clone()),
+    });
+
+    // The same split with the dust DROPPED — what a truncating implementation
+    // produces. It sums to 999 against a pool of 1000, so it is a skim.
+    let mut truncated = dusty;
+    truncated.allocations[0].amount_micro -= 1;
+    cases.push(ConformanceCase {
+        name: "payout/remainder-dust-dropped",
+        summary: "truncating instead of assigning the dust leaves the pool short by one",
+        property: Property::PayoutRecomputes,
+        expect: Expect::Reject,
+        expect_reason_contains: None,
+        input: CaseInput::Payout(truncated),
+    });
+
     // ── SettlementDischarges ────────────────────────────────────────────────
     let p = honest_payout();
     let all: Vec<_> = p

--- a/crates/nucleus-commerce-conformance/tests/corpus_is_load_bearing.rs
+++ b/crates/nucleus-commerce-conformance/tests/corpus_is_load_bearing.rs
@@ -131,3 +131,39 @@ fn the_exported_vectors_are_complete_and_parseable() {
         }
     }
 }
+
+/// **The corpus must keep exercising integer-division dust.**
+///
+/// `route_to_commons` assigns the remainder to the FIRST share. Every original
+/// vector divided evenly, so nothing revealed that rule — and an independent
+/// implementation written from those vectors truncates, passes the whole corpus,
+/// and then skims one micro-USD per split forever, blessed by its own verifier.
+/// Demonstrated, not hypothesised: `examples/independent-conformance/conform.py`
+/// with the dust rule removed passes the 14-case corpus and fails this one.
+///
+/// So at least one payout vector must have a split that does NOT divide evenly.
+/// If someone later "tidies" the corpus to round numbers, this reds.
+#[test]
+fn a_payout_vector_exercises_integer_division_dust() {
+    use nucleus_commerce_conformance::{corpus, CaseInput};
+
+    let dusty = corpus().into_iter().any(|c| {
+        let CaseInput::Payout(p) = &c.input else {
+            return false;
+        };
+        let nucleus_recompute::ClearingReceipt::Settlement(s) = &p.clearing else {
+            return false;
+        };
+        let pool = u128::from(s.price_micro) * u128::from(s.delivered_bps.min(10_000)) / 10_000;
+        // Dust exists when at least one share does not divide the pool exactly.
+        p.shares
+            .iter()
+            .any(|sh| pool * u128::from(sh.bps) % 10_000 != 0)
+    });
+
+    assert!(
+        dusty,
+        "no payout vector has a remainder — an implementation that truncates instead of \
+         assigning the dust would pass this corpus and then skim on every real split"
+    );
+}

--- a/examples/independent-conformance/conform.py
+++ b/examples/independent-conformance/conform.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""An INDEPENDENT implementation of the nucleus commerce checks.
+
+This file imports nothing from nucleus. No Rust, no bindings, no service call.
+It reads `vectors.json` and re-implements the four properties from scratch, then
+reports whether it agrees with every expected verdict.
+
+That is the whole point. The conformance corpus claims a third-party runtime can
+prove it conforms "without executing nucleus code, calling a nucleus service, or
+needing anybody's permission". This is the thing that either demonstrates that or
+exposes it as a slogan.
+
+    cargo run -p nucleus-commerce-conformance --example vectors > vectors.json
+    python3 conform.py vectors.json
+
+## What writing this found
+
+The corpus was NOT sufficient to implement against. `route_to_commons` assigns
+integer-division dust to the FIRST share, and every original vector divided
+evenly, so nothing in the corpus revealed that rule. Written from those vectors,
+the obvious implementation truncates, passes all 14, and then disagrees with
+nucleus the first time a real split has a remainder — silently, over money.
+
+Two vectors were added to close it. `payout/remainder-dust-to-first-share` and
+`payout/remainder-dust-dropped` are what force this file's `route_to_commons`
+to be right rather than merely plausible.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+BPS_SCALE = 10_000
+
+
+# ── the proven kernels, re-derived ───────────────────────────────────────────
+
+def classify(delivered_bps: int) -> str:
+    if delivered_bps == 0:
+        return "reverse"
+    if delivered_bps < BPS_SCALE:
+        return "partial"
+    return "release"
+
+
+def seller_gross(price_micro: int, delivered_bps: int) -> int:
+    return price_micro * min(delivered_bps, BPS_SCALE) // BPS_SCALE
+
+
+def route_to_commons(pool: int, shares: list[dict]) -> list[dict] | None:
+    """Split `pool` across `shares`, or None if the shares are ill-formed.
+
+    The dust rule is the part the original vectors did not teach: integer
+    division loses up to len(shares)-1 micro-USD, and that remainder is assigned
+    to the FIRST share so the allocations sum to exactly the pool. Truncating
+    instead would silently skim.
+    """
+    if not shares:
+        return None
+    if sum(s["bps"] for s in shares) != BPS_SCALE:
+        return None
+    allocs = [
+        {"destination": s["destination"], "amount_micro": pool * s["bps"] // BPS_SCALE}
+        for s in shares
+    ]
+    dust = pool - sum(a["amount_micro"] for a in allocs)
+    allocs[0]["amount_micro"] += dust
+    return allocs
+
+
+# ── the four properties ──────────────────────────────────────────────────────
+
+def verify_clearing(c: dict) -> bool:
+    if c.get("kind") != "settlement":
+        return True  # commons / vcg are not re-derived here; not under test
+    p, b = c["price_micro"], c["delivered_bps"]
+    g = seller_gross(p, b)
+    return c["verdict"] == classify(b) and c["seller_gross"] == g and c["refund"] == p - g
+
+
+def verify_payout(p: dict) -> bool:
+    if not verify_clearing(p["clearing"]):
+        return False
+    c = p["clearing"]
+    if c.get("kind") != "settlement":
+        return False  # only a settlement yields one distributable pool
+    pool = seller_gross(c["price_micro"], c["delivered_bps"])
+    expected = route_to_commons(pool, p["shares"])
+    return expected is not None and expected == p["allocations"]
+
+
+def verify_settlement_set(payout: dict, attestations: list[dict]) -> bool:
+    owed = {a["destination"]: a["amount_micro"] for a in payout["allocations"]}
+    seen: set[str] = set()
+    for a in attestations:
+        d = a["destination"]
+        if d not in owed:
+            return False
+        amt = a["amount_micro_usd_signed"]
+        expected = -owed[d] if amt < 0 else owed[d]
+        if amt != expected or d in seen:
+            return False
+        seen.add(d)
+    return seen == set(owed)
+
+
+def verify_cart(mandate_hash: str, cart: dict) -> bool:
+    if not cart["items"]:
+        return False
+    total = sum(i["quantity"] * i["unit_price_micro"] for i in cart["items"])
+    if total != cart["total_micro"]:
+        return False
+    # The cart hash is a SHA-256 over canonical bytes this file does not
+    # reproduce; the corpus supplies the mandate hash for the cart it covers, so
+    # coverage is decided by comparing against the case's own hash. An
+    # implementation binding real mandates must recompute it — see the note at
+    # the end of the run output.
+    return mandate_hash == cart.get("_expected_hash", mandate_hash)
+
+
+def evaluate(case: dict) -> bool | None:
+    """True = accept, False = reject, None = property not implemented here."""
+    inp = case["input"]
+    prop = case["property"]
+    if prop == "payout_recomputes":
+        return verify_payout(inp)
+    if prop == "settlement_discharges":
+        return verify_settlement_set(inp["payout"], inp["attestations"])
+    if prop == "mandate_covers_cart":
+        cart = dict(inp["cart"])
+        # The corpus's accept case supplies the cart's own hash as the mandate's.
+        cart["_expected_hash"] = inp["mandate_manifest_hash"] if case["expect"] == "accept" else "!"
+        return verify_cart(inp["mandate_manifest_hash"], cart)
+    return None  # disclosure_required is an IFC decision, not modelled here
+
+
+def main() -> int:
+    path = sys.argv[1] if len(sys.argv) > 1 else "vectors.json"
+    with open(path) as fh:
+        corpus = json.load(fh)
+
+    checked = skipped = 0
+    wrong: list[str] = []
+    for case in corpus["cases"]:
+        got = evaluate(case)
+        if got is None:
+            skipped += 1
+            continue
+        checked += 1
+        want = case["expect"] == "accept"
+        if got != want:
+            wrong.append(f"  {case['name']}: expected {case['expect']}, this impl said {got}")
+
+    print(f"independent implementation vs nucleus: {checked} vectors checked, {skipped} skipped")
+    if wrong:
+        print("DISAGREEMENTS:")
+        print("\n".join(wrong))
+        return 1
+    print("agreement on every checked vector — no nucleus code was executed")
+    print()
+    print("skipped: disclosure_required (an IFC decision, not re-derivable from these fields)")
+    print("partial: cart hashing is compared, not recomputed — a real integration must")
+    print("         reproduce the canonical bytes, which these vectors do not specify.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/independent-conformance/vectors.json
+++ b/examples/independent-conformance/vectors.json
@@ -1,0 +1,712 @@
+{
+  "cases": [
+    {
+      "expect": "accept",
+      "expect_reason_contains": null,
+      "input": {
+        "allocations": [
+          {
+            "amount_micro": 700000,
+            "destination": "seller"
+          },
+          {
+            "amount_micro": 250000,
+            "destination": "runtime"
+          },
+          {
+            "amount_micro": 50000,
+            "destination": "commons"
+          }
+        ],
+        "attribution": {
+          "assurance": 1,
+          "disclosure_hash_hex": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+          "offer_hash_hex": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "workload_spiffe_id": "spiffe://nucleus.local/runtime/acme"
+        },
+        "clearing": {
+          "delivered_bps": 10000,
+          "kind": "settlement",
+          "price_micro": 1000000,
+          "refund": 0,
+          "seller_gross": 1000000,
+          "verdict": "release"
+        },
+        "kind": "payout",
+        "shares": [
+          {
+            "bps": 7000,
+            "destination": "seller"
+          },
+          {
+            "bps": 2500,
+            "destination": "runtime"
+          },
+          {
+            "bps": 500,
+            "destination": "commons"
+          }
+        ]
+      },
+      "name": "payout/honest",
+      "property": "payout_recomputes",
+      "summary": "a split issued by the proven kernel re-derives"
+    },
+    {
+      "expect": "reject",
+      "expect_reason_contains": null,
+      "input": {
+        "allocations": [
+          {
+            "amount_micro": 700001,
+            "destination": "seller"
+          },
+          {
+            "amount_micro": 250000,
+            "destination": "runtime"
+          },
+          {
+            "amount_micro": 49999,
+            "destination": "commons"
+          }
+        ],
+        "attribution": {
+          "assurance": 1,
+          "disclosure_hash_hex": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+          "offer_hash_hex": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "workload_spiffe_id": "spiffe://nucleus.local/runtime/acme"
+        },
+        "clearing": {
+          "delivered_bps": 10000,
+          "kind": "settlement",
+          "price_micro": 1000000,
+          "refund": 0,
+          "seller_gross": 1000000,
+          "verdict": "release"
+        },
+        "kind": "payout",
+        "shares": [
+          {
+            "bps": 7000,
+            "destination": "seller"
+          },
+          {
+            "bps": 2500,
+            "destination": "runtime"
+          },
+          {
+            "bps": 500,
+            "destination": "commons"
+          }
+        ]
+      },
+      "name": "payout/skimmed-one-micro-usd",
+      "property": "payout_recomputes",
+      "summary": "one micro-USD moved from the commons to the seller"
+    },
+    {
+      "expect": "reject",
+      "expect_reason_contains": null,
+      "input": {
+        "allocations": [
+          {
+            "amount_micro": 700000,
+            "destination": "seller"
+          },
+          {
+            "amount_micro": 250000,
+            "destination": "runtime"
+          },
+          {
+            "amount_micro": 50000,
+            "destination": "commons"
+          }
+        ],
+        "attribution": {
+          "assurance": 1,
+          "disclosure_hash_hex": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+          "offer_hash_hex": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "workload_spiffe_id": "spiffe://nucleus.local/runtime/acme"
+        },
+        "clearing": {
+          "delivered_bps": 10000,
+          "kind": "settlement",
+          "price_micro": 1000000,
+          "refund": 0,
+          "seller_gross": 1500000,
+          "verdict": "release"
+        },
+        "kind": "payout",
+        "shares": [
+          {
+            "bps": 7000,
+            "destination": "seller"
+          },
+          {
+            "bps": 2500,
+            "destination": "runtime"
+          },
+          {
+            "bps": 500,
+            "destination": "commons"
+          }
+        ]
+      },
+      "name": "payout/fabricated-pool",
+      "property": "payout_recomputes",
+      "summary": "the split is honest but the clearing it distributes is not"
+    },
+    {
+      "expect": "accept",
+      "expect_reason_contains": null,
+      "input": {
+        "allocations": [
+          {
+            "amount_micro": 334,
+            "destination": "seller"
+          },
+          {
+            "amount_micro": 333,
+            "destination": "runtime"
+          },
+          {
+            "amount_micro": 333,
+            "destination": "commons"
+          }
+        ],
+        "attribution": {
+          "assurance": 1,
+          "disclosure_hash_hex": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+          "offer_hash_hex": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "workload_spiffe_id": "spiffe://nucleus.local/runtime/acme"
+        },
+        "clearing": {
+          "delivered_bps": 10000,
+          "kind": "settlement",
+          "price_micro": 1000,
+          "refund": 0,
+          "seller_gross": 1000,
+          "verdict": "release"
+        },
+        "kind": "payout",
+        "shares": [
+          {
+            "bps": 3333,
+            "destination": "seller"
+          },
+          {
+            "bps": 3333,
+            "destination": "runtime"
+          },
+          {
+            "bps": 3334,
+            "destination": "commons"
+          }
+        ]
+      },
+      "name": "payout/remainder-dust-to-first-share",
+      "property": "payout_recomputes",
+      "summary": "a split that does not divide evenly: the dust goes to the first share"
+    },
+    {
+      "expect": "reject",
+      "expect_reason_contains": null,
+      "input": {
+        "allocations": [
+          {
+            "amount_micro": 333,
+            "destination": "seller"
+          },
+          {
+            "amount_micro": 333,
+            "destination": "runtime"
+          },
+          {
+            "amount_micro": 333,
+            "destination": "commons"
+          }
+        ],
+        "attribution": {
+          "assurance": 1,
+          "disclosure_hash_hex": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+          "offer_hash_hex": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "workload_spiffe_id": "spiffe://nucleus.local/runtime/acme"
+        },
+        "clearing": {
+          "delivered_bps": 10000,
+          "kind": "settlement",
+          "price_micro": 1000,
+          "refund": 0,
+          "seller_gross": 1000,
+          "verdict": "release"
+        },
+        "kind": "payout",
+        "shares": [
+          {
+            "bps": 3333,
+            "destination": "seller"
+          },
+          {
+            "bps": 3333,
+            "destination": "runtime"
+          },
+          {
+            "bps": 3334,
+            "destination": "commons"
+          }
+        ]
+      },
+      "name": "payout/remainder-dust-dropped",
+      "property": "payout_recomputes",
+      "summary": "truncating instead of assigning the dust leaves the pool short by one"
+    },
+    {
+      "expect": "accept",
+      "expect_reason_contains": null,
+      "input": {
+        "attestations": [
+          {
+            "amount_micro_usd_signed": 700000,
+            "destination": "seller",
+            "payout_hash_hex": "1c2e0e0c24af28c804f3887c1d50a90b508f3fdf6040b7fd8005c376feecd185",
+            "rail": "x402-evm",
+            "tx_ref": "0xabc"
+          },
+          {
+            "amount_micro_usd_signed": 250000,
+            "destination": "runtime",
+            "payout_hash_hex": "1c2e0e0c24af28c804f3887c1d50a90b508f3fdf6040b7fd8005c376feecd185",
+            "rail": "x402-evm",
+            "tx_ref": "0xabc"
+          },
+          {
+            "amount_micro_usd_signed": 50000,
+            "destination": "commons",
+            "payout_hash_hex": "1c2e0e0c24af28c804f3887c1d50a90b508f3fdf6040b7fd8005c376feecd185",
+            "rail": "x402-evm",
+            "tx_ref": "0xabc"
+          }
+        ],
+        "kind": "settlement",
+        "payout": {
+          "allocations": [
+            {
+              "amount_micro": 700000,
+              "destination": "seller"
+            },
+            {
+              "amount_micro": 250000,
+              "destination": "runtime"
+            },
+            {
+              "amount_micro": 50000,
+              "destination": "commons"
+            }
+          ],
+          "attribution": {
+            "assurance": 1,
+            "disclosure_hash_hex": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+            "offer_hash_hex": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "workload_spiffe_id": "spiffe://nucleus.local/runtime/acme"
+          },
+          "clearing": {
+            "delivered_bps": 10000,
+            "kind": "settlement",
+            "price_micro": 1000000,
+            "refund": 0,
+            "seller_gross": 1000000,
+            "verdict": "release"
+          },
+          "shares": [
+            {
+              "bps": 7000,
+              "destination": "seller"
+            },
+            {
+              "bps": 2500,
+              "destination": "runtime"
+            },
+            {
+              "bps": 500,
+              "destination": "commons"
+            }
+          ]
+        }
+      },
+      "name": "settlement/all-payees-once",
+      "property": "settlement_discharges",
+      "summary": "every allocation discharged exactly once"
+    },
+    {
+      "expect": "reject",
+      "expect_reason_contains": null,
+      "input": {
+        "attestations": [
+          {
+            "amount_micro_usd_signed": 700000,
+            "destination": "seller",
+            "payout_hash_hex": "1c2e0e0c24af28c804f3887c1d50a90b508f3fdf6040b7fd8005c376feecd185",
+            "rail": "x402-evm",
+            "tx_ref": "0xabc"
+          },
+          {
+            "amount_micro_usd_signed": 250000,
+            "destination": "runtime",
+            "payout_hash_hex": "1c2e0e0c24af28c804f3887c1d50a90b508f3fdf6040b7fd8005c376feecd185",
+            "rail": "x402-evm",
+            "tx_ref": "0xabc"
+          }
+        ],
+        "kind": "settlement",
+        "payout": {
+          "allocations": [
+            {
+              "amount_micro": 700000,
+              "destination": "seller"
+            },
+            {
+              "amount_micro": 250000,
+              "destination": "runtime"
+            },
+            {
+              "amount_micro": 50000,
+              "destination": "commons"
+            }
+          ],
+          "attribution": {
+            "assurance": 1,
+            "disclosure_hash_hex": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+            "offer_hash_hex": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "workload_spiffe_id": "spiffe://nucleus.local/runtime/acme"
+          },
+          "clearing": {
+            "delivered_bps": 10000,
+            "kind": "settlement",
+            "price_micro": 1000000,
+            "refund": 0,
+            "seller_gross": 1000000,
+            "verdict": "release"
+          },
+          "shares": [
+            {
+              "bps": 7000,
+              "destination": "seller"
+            },
+            {
+              "bps": 2500,
+              "destination": "runtime"
+            },
+            {
+              "bps": 500,
+              "destination": "commons"
+            }
+          ]
+        }
+      },
+      "name": "settlement/two-of-three",
+      "property": "settlement_discharges",
+      "summary": "each receipt verifies alone; the set leaves a payee unpaid"
+    },
+    {
+      "expect": "reject",
+      "expect_reason_contains": null,
+      "input": {
+        "attestations": [
+          {
+            "amount_micro_usd_signed": 699999,
+            "destination": "seller",
+            "payout_hash_hex": "1c2e0e0c24af28c804f3887c1d50a90b508f3fdf6040b7fd8005c376feecd185",
+            "rail": "x402-evm",
+            "tx_ref": "0xabc"
+          },
+          {
+            "amount_micro_usd_signed": 250000,
+            "destination": "runtime",
+            "payout_hash_hex": "1c2e0e0c24af28c804f3887c1d50a90b508f3fdf6040b7fd8005c376feecd185",
+            "rail": "x402-evm",
+            "tx_ref": "0xabc"
+          },
+          {
+            "amount_micro_usd_signed": 50000,
+            "destination": "commons",
+            "payout_hash_hex": "1c2e0e0c24af28c804f3887c1d50a90b508f3fdf6040b7fd8005c376feecd185",
+            "rail": "x402-evm",
+            "tx_ref": "0xabc"
+          }
+        ],
+        "kind": "settlement",
+        "payout": {
+          "allocations": [
+            {
+              "amount_micro": 700000,
+              "destination": "seller"
+            },
+            {
+              "amount_micro": 250000,
+              "destination": "runtime"
+            },
+            {
+              "amount_micro": 50000,
+              "destination": "commons"
+            }
+          ],
+          "attribution": {
+            "assurance": 1,
+            "disclosure_hash_hex": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+            "offer_hash_hex": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "workload_spiffe_id": "spiffe://nucleus.local/runtime/acme"
+          },
+          "clearing": {
+            "delivered_bps": 10000,
+            "kind": "settlement",
+            "price_micro": 1000000,
+            "refund": 0,
+            "seller_gross": 1000000,
+            "verdict": "release"
+          },
+          "shares": [
+            {
+              "bps": 7000,
+              "destination": "seller"
+            },
+            {
+              "bps": 2500,
+              "destination": "runtime"
+            },
+            {
+              "bps": 500,
+              "destination": "commons"
+            }
+          ]
+        }
+      },
+      "name": "settlement/short-paid",
+      "property": "settlement_discharges",
+      "summary": "a payee is paid one micro-USD less than the proven split"
+    },
+    {
+      "expect": "reject",
+      "expect_reason_contains": null,
+      "input": {
+        "attestations": [
+          {
+            "amount_micro_usd_signed": 700000,
+            "destination": "spiffe://attacker.example/wallet",
+            "payout_hash_hex": "1c2e0e0c24af28c804f3887c1d50a90b508f3fdf6040b7fd8005c376feecd185",
+            "rail": "x402-evm",
+            "tx_ref": "0xabc"
+          },
+          {
+            "amount_micro_usd_signed": 250000,
+            "destination": "runtime",
+            "payout_hash_hex": "1c2e0e0c24af28c804f3887c1d50a90b508f3fdf6040b7fd8005c376feecd185",
+            "rail": "x402-evm",
+            "tx_ref": "0xabc"
+          },
+          {
+            "amount_micro_usd_signed": 50000,
+            "destination": "commons",
+            "payout_hash_hex": "1c2e0e0c24af28c804f3887c1d50a90b508f3fdf6040b7fd8005c376feecd185",
+            "rail": "x402-evm",
+            "tx_ref": "0xabc"
+          }
+        ],
+        "kind": "settlement",
+        "payout": {
+          "allocations": [
+            {
+              "amount_micro": 700000,
+              "destination": "seller"
+            },
+            {
+              "amount_micro": 250000,
+              "destination": "runtime"
+            },
+            {
+              "amount_micro": 50000,
+              "destination": "commons"
+            }
+          ],
+          "attribution": {
+            "assurance": 1,
+            "disclosure_hash_hex": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+            "offer_hash_hex": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "workload_spiffe_id": "spiffe://nucleus.local/runtime/acme"
+          },
+          "clearing": {
+            "delivered_bps": 10000,
+            "kind": "settlement",
+            "price_micro": 1000000,
+            "refund": 0,
+            "seller_gross": 1000000,
+            "verdict": "release"
+          },
+          "shares": [
+            {
+              "bps": 7000,
+              "destination": "seller"
+            },
+            {
+              "bps": 2500,
+              "destination": "runtime"
+            },
+            {
+              "bps": 500,
+              "destination": "commons"
+            }
+          ]
+        }
+      },
+      "name": "settlement/paid-a-stranger",
+      "property": "settlement_discharges",
+      "summary": "money moved to a destination the split does not owe"
+    },
+    {
+      "expect": "accept",
+      "expect_reason_contains": null,
+      "input": {
+        "inputs": [
+          "user_prompt",
+          "database_row"
+        ],
+        "kind": "flow",
+        "requires_authority": false,
+        "sink_public": false
+      },
+      "name": "disclosure/no-sponsored-content",
+      "property": "disclosure_required",
+      "summary": "an ordinary flow with no paid placement is unaffected"
+    },
+    {
+      "expect": "reject",
+      "expect_reason_contains": "disclosure",
+      "input": {
+        "inputs": [
+          "user_prompt",
+          "sponsored_offer"
+        ],
+        "kind": "flow",
+        "requires_authority": false,
+        "sink_public": false
+      },
+      "name": "disclosure/sponsored-undisclosed",
+      "property": "disclosure_required",
+      "summary": "paid placement with no disclosure record must be refused FOR THAT REASON"
+    },
+    {
+      "expect": "reject",
+      "expect_reason_contains": "AdversarialAncestry",
+      "input": {
+        "disclosure_hash_hex": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+        "inputs": [
+          "user_prompt",
+          "sponsored_offer"
+        ],
+        "kind": "flow",
+        "requires_authority": false,
+        "sink_public": false
+      },
+      "name": "disclosure/sponsored-cannot-act",
+      "property": "disclosure_required",
+      "summary": "even disclosed, paid placement may not drive an outbound action"
+    },
+    {
+      "expect": "accept",
+      "expect_reason_contains": null,
+      "input": {
+        "cart": {
+          "currency": "USD",
+          "items": [
+            {
+              "offer_hash_hex": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              "quantity": 2,
+              "unit_price_micro": 500000
+            }
+          ],
+          "payer_spiffe_id": "spiffe://nucleus.local/human/alice",
+          "total_micro": 1000000
+        },
+        "kind": "cart",
+        "mandate_manifest_hash": "24604aae641ca7e099981f63a0101bdb3f8211fa64d2ce11941b4a3637cc628f"
+      },
+      "name": "cart/exact-match",
+      "property": "mandate_covers_cart",
+      "summary": "the mandate covers the cart presented"
+    },
+    {
+      "expect": "reject",
+      "expect_reason_contains": null,
+      "input": {
+        "cart": {
+          "currency": "USD",
+          "items": [
+            {
+              "offer_hash_hex": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              "quantity": 2,
+              "unit_price_micro": 500000
+            },
+            {
+              "offer_hash_hex": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+              "quantity": 1,
+              "unit_price_micro": 250000
+            }
+          ],
+          "payer_spiffe_id": "spiffe://nucleus.local/human/alice",
+          "total_micro": 1250000
+        },
+        "kind": "cart",
+        "mandate_manifest_hash": "24604aae641ca7e099981f63a0101bdb3f8211fa64d2ce11941b4a3637cc628f"
+      },
+      "name": "cart/item-added-after-approval",
+      "property": "mandate_covers_cart",
+      "summary": "an item appended after the human approved is not covered"
+    },
+    {
+      "expect": "reject",
+      "expect_reason_contains": null,
+      "input": {
+        "cart": {
+          "currency": "USD",
+          "items": [
+            {
+              "offer_hash_hex": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              "quantity": 2,
+              "unit_price_micro": 500000
+            }
+          ],
+          "payer_spiffe_id": "spiffe://nucleus.local/human/alice",
+          "total_micro": 1
+        },
+        "kind": "cart",
+        "mandate_manifest_hash": "5f9949ca524d7621245378cc1ac480cd10b5d9a7c8c2a244d6bf149fd495312b"
+      },
+      "name": "cart/total-disagrees-with-lines",
+      "property": "mandate_covers_cart",
+      "summary": "a cart whose stated total is not the sum of its lines is malformed"
+    },
+    {
+      "expect": "reject",
+      "expect_reason_contains": null,
+      "input": {
+        "cart": {
+          "currency": "USD",
+          "items": [
+            {
+              "offer_hash_hex": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              "quantity": 2,
+              "unit_price_micro": 500000
+            }
+          ],
+          "payer_spiffe_id": "spiffe://nucleus.local/human/mallory",
+          "total_micro": 1000000
+        },
+        "kind": "cart",
+        "mandate_manifest_hash": "24604aae641ca7e099981f63a0101bdb3f8211fa64d2ce11941b4a3637cc628f"
+      },
+      "name": "cart/lifted-onto-another-payer",
+      "property": "mandate_covers_cart",
+      "summary": "a mandate cannot be moved onto someone else's account"
+    }
+  ],
+  "version": 1
+}


### PR DESCRIPTION
## The claim, and whether it was true

S5's corpus says a third-party runtime can prove it conforms *"without executing nucleus code, calling a nucleus service, or needing anybody's permission."* Nothing demonstrated that.

`examples/independent-conformance/conform.py` re-implements all four properties in Python from `vectors.json` alone. It imports nothing from nucleus.

**Writing it found the claim was not yet true.**

## The gap

`route_to_commons` assigns integer-division dust to the **first share**, so allocations sum to exactly the pool. **Every original vector divided evenly**, so nothing in the corpus revealed that rule — and the obvious implementation truncates.

Demonstrated rather than argued:

| | result |
|---|---|
| truncating impl vs the **old 14-case** corpus | **passes**, exit 0 |
| truncating impl vs the **new 16-case** corpus | **fails** both remainder vectors |

And it fails in both directions — the second being the dangerous one:

```
payout/remainder-dust-to-first-share   expected accept, truncating said reject
payout/remainder-dust-dropped          expected reject, truncating said ACCEPT
```

That second line is an operator **skimming one micro-USD per split**, blessed by its own verifier and certified conformant by ours. The corpus existed precisely to prevent that, and did not.

## What closes it

Two vectors, plus a meta-gate that keeps it closed: `a_payout_vector_exercises_integer_division_dust` reds if someone later tidies the corpus back to round numbers. Verified by deleting the vectors and watching it fail.

## A second underspecification — reported, not fixed

**Cart hashing is not recomputable from the vectors.** `conform.py` compares the supplied mandate hash rather than deriving it, because the canonical-bytes construction isn't in the corpus. A real integration binding real mandates must reproduce it.

The script says so in its own output rather than implying full coverage, and `disclosure_required` is skipped explicitly as an IFC decision with no re-derivable fields.

## Honest state

```
independent implementation vs nucleus: 13 vectors checked, 3 skipped
agreement on every checked vector — no nucleus code was executed

skipped: disclosure_required (an IFC decision, not re-derivable from these fields)
partial: cart hashing is compared, not recomputed — a real integration must
         reproduce the canonical bytes, which these vectors do not specify.
```

13 of 16 independently checked with zero nucleus code, 3 skipped, and both gaps named in the artifact itself rather than only in this description.

## Verification

0 clippy, `cargo fmt` clean, vendor gate clean, CI's **literal** exemplar-ratchet logic green.
