### PR TITLE
ci: ratchet the numeric-cast clippy lints toward zero

### DIFF
--- a/.clippy-ratchet.toml
+++ b/.clippy-ratchet.toml
@@ -1,0 +1,32 @@
+# Clippy ratchet: a curated lint set whose violation count may only go DOWN.
+#
+# WHY NOT JUST `-W clippy::pedantic`: the workspace has 4726 pedantic warnings.
+# Two thirds are stylistic (must_use_candidate 1788, doc_markdown 1008), and a
+# gate that emits thousands of warnings is one nobody reads. Denying them
+# wholesale is not an option either; that is thousands of edits in one change.
+#
+# So this tracks the subset where a violation is a CORRECTNESS risk in this
+# particular system rather than a style opinion: unchecked numeric casts. This
+# runtime computes budgets, byte counts, ports and policy decisions, and a
+# silent truncation there is a bug, not a nit. 177 of the current 402 are in
+# `portcullis` — the policy kernel.
+#
+# `target = 0` is the real goal. `step` is how much the ceiling drops on each
+# push to main, so the count cannot drift back up and shrinks on its own.
+
+lints = [
+  "clippy::cast_possible_truncation",
+  "clippy::cast_lossless",
+  "clippy::cast_sign_loss",
+  "clippy::cast_possible_wrap",
+  "clippy::cast_precision_loss",
+]
+
+# Seeded ABOVE the locally-measured 402 on purpose: clippy counts can differ by
+# platform and feature resolution, and CI (linux) is the authority. The first
+# push to main snaps this down to the real count (457 measured here, three
+# identical consecutive runs), so an over-generous seed
+# self-corrects within one commit rather than hiding a regression forever.
+ceiling = 470
+target = 0
+step = 5

--- a/.github/workflows/clippy-ratchet.yml
+++ b/.github/workflows/clippy-ratchet.yml
@@ -1,0 +1,73 @@
+name: Clippy Ratchet
+
+on:
+  pull_request:
+  merge_group:
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  check:
+    name: Check clippy ceiling
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
+        with:
+          components: clippy
+          cache: true
+      - name: Check clippy ratchet
+        run: scripts/check-clippy-ratchet.sh --strict
+
+  ratchet-down:
+    name: Ratchet ceiling down
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
+        with:
+          components: clippy
+          cache: true
+
+      - name: Ratchet down
+        run: |
+          set -euo pipefail
+          RATCHET_FILE=".clippy-ratchet.toml"
+
+          CEILING=$(grep '^ceiling' "$RATCHET_FILE" | head -1 | sed 's/.*= *//')
+          TARGET=$(grep '^target' "$RATCHET_FILE" | head -1 | sed 's/.*= *//')
+          STEP=$(grep '^step' "$RATCHET_FILE" | head -1 | sed 's/.*= *//')
+          ACTUAL=$(scripts/check-clippy-ratchet.sh --count)
+
+          # Same rule as the line ratchet: step down, snap to actual when the
+          # code is already better than the step, and never below target.
+          NEW=$((CEILING - STEP))
+          [ "$ACTUAL" -lt "$NEW" ] && NEW=$ACTUAL
+          [ "$NEW" -lt "$TARGET" ] && NEW=$TARGET
+
+          if [ "$NEW" -ge "$CEILING" ]; then
+            echo "ceiling $CEILING already at or below $NEW — nothing to do"
+            exit 0
+          fi
+
+          sed -i "s/^ceiling = .*/ceiling = $NEW/" "$RATCHET_FILE"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add "$RATCHET_FILE"
+          git commit -m "chore(clippy-ratchet): ceiling $CEILING -> $NEW (actual $ACTUAL)"
+          git push

--- a/.github/workflows/clippy-ratchet.yml
+++ b/.github/workflows/clippy-ratchet.yml
@@ -28,6 +28,42 @@ jobs:
       - name: Check clippy ratchet
         run: scripts/check-clippy-ratchet.sh --strict
 
+  # The gate's own falsifier. `check-gates-can-fail.sh` requires every ci/*.sh
+  # gate to prove it can go red; this one cannot be probed there because its
+  # perturbation needs a full workspace clippy run, which that fast job does not
+  # do. So the two-sided perturbation runs here, beside the gate it falsifies,
+  # on every invocation.
+  ratchet-falsifier:
+    name: The ratchet REDs when the ceiling is below actual
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
+        with:
+          components: clippy
+          cache: true
+      - name: RED on a ceiling below actual, GREEN when restored
+        run: |
+          set -euo pipefail
+          cp .clippy-ratchet.toml /tmp/ratchet.bak
+
+          # Perturb: a ceiling of 0 is below any real count.
+          sed -i 's/^ceiling = .*/ceiling = 0/' .clippy-ratchet.toml
+          if scripts/check-clippy-ratchet.sh --strict >/dev/null 2>&1; then
+            echo "::error::the ratchet PASSED with ceiling 0 — it cannot go red, so it is not a gate"
+            cp /tmp/ratchet.bak .clippy-ratchet.toml
+            exit 1
+          fi
+          echo "ok: red on a ceiling below actual"
+
+          # Restore: the real ceiling must pass, or the gate is stuck red and
+          # would block every PR for a reason unrelated to the code.
+          cp /tmp/ratchet.bak .clippy-ratchet.toml
+          scripts/check-clippy-ratchet.sh --strict
+          echo "ok: green when restored"
+
   ratchet-down:
     name: Ratchet ceiling down
     runs-on: ubuntu-latest

--- a/scripts/check-clippy-ratchet.sh
+++ b/scripts/check-clippy-ratchet.sh
@@ -38,7 +38,15 @@ for l in $LINTS; do FLAGS+=(-W "$l"); done
 # report the failures rather than letting either disappear.
 RAW=$(mktemp)
 set +e
-cargo clippy --workspace --all-targets --keep-going --message-format=json -- "${FLAGS[@]}" >"$RAW" 2>/dev/null
+# RUSTFLAGS is cleared for the MEASUREMENT run. CI (setup-rust-toolchain)
+# exports `-D warnings`, which promotes the tracked cast lints from `warning`
+# to `error` — and the jq below selects on level. The count came back 0 on CI
+# for exactly that reason while reading 457 locally: not a clean tree, an
+# ambient flag leaking into a measurement.
+#
+# Counting is not gating. This script decides pass/fail from the count against
+# the ceiling; it must not also inherit someone else's promotion policy.
+RUSTFLAGS= cargo clippy --workspace --all-targets --keep-going --message-format=json -- "${FLAGS[@]}" >"$RAW" 2>/dev/null
 set -e
 
 FAILED=$(jq -r 'select(.reason=="compiler-message") | .message
@@ -50,7 +58,7 @@ FAILED=$(jq -r 'select(.reason=="compiler-message") | .message
 # rebuilds varies -- consecutive runs reported 406 then 404 on an unchanged
 # tree before this dedupe.
 COUNT=$(jq -r 'select(.reason=="compiler-message") | .message
-           | select(.level=="warning")
+           | select(.level=="warning" or .level=="error")
            | select((.code.code // "") | startswith("clippy::cast"))
            | (.spans[] | select(.is_primary)) as $s
            | "\($s.file_name):\($s.line_start):\($s.column_start):\(.code.code)"' "$RAW" \

--- a/scripts/check-clippy-ratchet.sh
+++ b/scripts/check-clippy-ratchet.sh
@@ -66,6 +66,21 @@ fi
 case "${1:---count}" in
   --count) echo "$COUNT" ;;
   --strict)
+    # NON-VACUITY FLOOR. A count of zero is not "the code got clean" — this
+    # workspace has hundreds of tracked cast sites. Zero means the measurement
+    # failed: clippy produced no countable output, which happens when the build
+    # errors out before analysing anything. Without this, the ratchet PASSES on
+    # a broken build, which is a gate that cannot go red.
+    #
+    # Found by its own falsifier (`ratchet-falsifier` in clippy-ratchet.yml):
+    # setting the ceiling to 0 should have RED-ed and did not, because 0 > 0 is
+    # false. The falsifier earned itself on its first CI run.
+    if [ "$COUNT" -eq 0 ]; then
+      echo "::error::the ratcheted-lint count came back 0, which this workspace \
+cannot honestly produce. The clippy run failed to yield countable output — \
+treat this as a broken measurement, not a clean tree."
+      exit 1
+    fi
     CEILING=$(grep '^ceiling' "$RATCHET_FILE" | head -1 | sed 's/.*= *//')
     echo "ratcheted clippy violations: $COUNT (ceiling $CEILING)"
     if [ "$COUNT" -gt "$CEILING" ]; then

--- a/scripts/check-clippy-ratchet.sh
+++ b/scripts/check-clippy-ratchet.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Count violations of the ratcheted clippy lint set and compare to the ceiling.
+#
+# Mirrors scripts/check-line-ratchet.sh: `--strict` fails when the count is
+# ABOVE the ceiling; `--count` just prints the number (used by the ratchet-down
+# job on main).
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+RATCHET_FILE=".clippy-ratchet.toml"
+[ -f "$RATCHET_FILE" ] || { echo "::error::$RATCHET_FILE missing"; exit 1; }
+
+# The lint list lives in the toml so the gate and its documentation cannot drift.
+LINTS=$(sed -n '/^lints = \[/,/^]/p' "$RATCHET_FILE" | grep -oE '"[^"]+"' | tr -d '"')
+[ -n "$LINTS" ] || { echo "::error::no lints parsed from $RATCHET_FILE"; exit 1; }
+
+# Cargo caches per crate, and clippy re-emits warnings ONLY for crates it
+# actually recompiles. Measured directly, three consecutive runs of this script
+# returned 379, 306 and 351 for an unchanged tree — the number tracked cache
+# state, not the code. A ratchet built on that would pass or fail at random.
+#
+# Touching the workspace sources forces every first-party crate to be
+# re-analysed while dependency artifacts stay cached: correct AND fast.
+find crates -name '*.rs' -not -path '*/target/*' -exec touch {} +
+
+FLAGS=(-A clippy::all)
+for l in $LINTS; do FLAGS+=(-W "$l"); done
+
+# `-A clippy::all` first so ONLY the ratcheted lints are counted; without it the
+# ordinary warning set would be mixed in and the number would mean nothing.
+# Count UNIQUE (file, line, column, lint) sites, not raw messages. A file
+# compiled as both lib and test yields the same warning twice, and the split
+# varies with what cargo happens to rebuild -- which made consecutive runs
+# report 406 and 404 for an unchanged tree. A site is the thing being ratcheted.
+# Cargo exits nonzero when any crate fails to compile, and a crate that does
+# not compile is never analysed -- so the count would silently shrink to
+# "however much happened to build". Capture the run, count the sites, and
+# report the failures rather than letting either disappear.
+RAW=$(mktemp)
+set +e
+cargo clippy --workspace --all-targets --keep-going --message-format=json -- "${FLAGS[@]}" >"$RAW" 2>/dev/null
+set -e
+
+FAILED=$(jq -r 'select(.reason=="compiler-message") | .message
+                | select(.level=="error") | (.spans[]? | select(.is_primary) | .file_name)' "$RAW" \
+         | cut -d/ -f2 | sort -u)
+
+# Unique (file, line, column, lint) SITES, not raw messages: a file compiled as
+# both lib and test yields the same warning twice, and which targets cargo
+# rebuilds varies -- consecutive runs reported 406 then 404 on an unchanged
+# tree before this dedupe.
+COUNT=$(jq -r 'select(.reason=="compiler-message") | .message
+           | select(.level=="warning")
+           | select((.code.code // "") | startswith("clippy::cast"))
+           | (.spans[] | select(.is_primary)) as $s
+           | "\($s.file_name):\($s.line_start):\($s.column_start):\(.code.code)"' "$RAW" \
+  | sort -u | wc -l | tr -d ' ')
+rm -f "$RAW"
+
+if [ -n "$FAILED" ]; then
+  # Never report a partial count as if it were whole.
+  echo "::warning::crates that did NOT compile, so were NOT analysed:" >&2
+  echo "$FAILED" | sed 's/^/  /' >&2
+fi
+
+case "${1:---count}" in
+  --count) echo "$COUNT" ;;
+  --strict)
+    CEILING=$(grep '^ceiling' "$RATCHET_FILE" | head -1 | sed 's/.*= *//')
+    echo "ratcheted clippy violations: $COUNT (ceiling $CEILING)"
+    if [ "$COUNT" -gt "$CEILING" ]; then
+      echo "::error::clippy ratchet exceeded: $COUNT > $CEILING."
+      echo "  The tracked lints are numeric-cast lints, where a violation is a"
+      echo "  truncation/sign bug waiting to happen rather than a style nit."
+      echo "  Fix the new cast (or justify it with a scoped #[allow] and a comment)."
+      exit 1
+    fi
+    echo "ok: at or below the ceiling"
+    ;;
+  *) echo "usage: $0 [--strict|--count]"; exit 2 ;;
+esac

--- a/scripts/check-gates-can-fail.sh
+++ b/scripts/check-gates-can-fail.sh
@@ -412,6 +412,13 @@ UNCOVERED_CEILING=2
 #     not probed here because it needs netns + iptables + sudo, and because its
 #     perturbation is internal — there is no external subject for this script to
 #     break.
+#   check-clippy-ratchet.sh — its perturbation needs a full workspace clippy run
+#     (minutes, and `--keep-going` over every crate); this job runs fast greps on
+#     stable Rust and would be the wrong place to spend that. The
+#     `ratchet-falsifier` job in clippy-ratchet.yml lowers the ceiling below the
+#     measured count and asserts `--strict` exits non-zero, then restores it and
+#     asserts zero — the same two-sided perturbation probe() would make, run
+#     every CI invocation beside the gate it falsifies.
 #   check-adversary-probe.sh — likewise a self-falsifier for the in-pod adversary:
 #     it reconstructs each attack surface and asserts the probe reports CONTAINED
 #     when confined, BREACH:<stage> when a surface is opened (reds-on-regression),
@@ -423,6 +430,7 @@ SELF_FALSIFIED=(
     "check-mediation-dylint.sh    --self-test in the 'mediated' job (dylint-separation.yml)"
     "check-egress-probe.sh        States 2+3 in the 'egress-probe-falsifier' job (quickstart-boot.yml)"
     "check-adversary-probe.sh     BREACH+INCONCLUSIVE states in the 'adversary-probe-falsifier' job (adversary-probe.yml)"
+    "check-clippy-ratchet.sh     ceiling-below-actual in the 'ratchet-falsifier' job (clippy-ratchet.yml)"
 )
 
 echo


### PR DESCRIPTION
## Why not just turn on `clippy::pedantic`

The workspace had no clippy configuration beyond `-D warnings` on the default set — `[workspace.lints.clippy]` contained exactly one entry, `type_complexity = "allow"`.

Enabling pedantic produces **4726 warnings** here, and two thirds are style:

| lint | count |
| --- | --- |
| `must_use_candidate` | 1788 |
| `doc_markdown` | 1008 |
| `missing_errors_doc` | 555 |
| `return_self_not_must_use` | 275 |

A gate that emits thousands of warnings is one nobody reads, and denying them outright is thousands of edits in one change. [The research on Clippy adoption](https://arxiv.org/html/2310.11738v1) makes the same point: false positives and churn are why large pre-existing codebases stall on this.

## What this ratchets instead

The subset where a violation is a **correctness** risk in *this* system rather than a style opinion — the numeric-cast lints:

```
212  cast_possible_truncation      35  cast_possible_wrap
 98  cast_lossless                 19  cast_precision_loss
 38  cast_sign_loss
```

This runtime computes budgets, byte counts, ports and policy decisions. A silent truncation there is a bug. **177 of the 457 sites are in `portcullis`** — the policy kernel.

Shape is copied from the existing `line-ratchet.yml`: `--strict` fails a PR above the ceiling; a push to main steps the ceiling down, snapping to actual, floored at `target = 0`.

## Three measurement bugs, each of which would have made this a fake gate

This is the part worth reviewing. Every one produced a number that *looked* fine.

**1. Cargo's per-crate cache.** Clippy re-emits warnings only for crates it recompiles. Three consecutive runs on an **unchanged tree**: `379, 306, 351`. The number tracked cache state, not code. Fixed by touching workspace sources so first-party crates are re-analysed while dependency artifacts stay cached.

**2. Multi-target double counting.** A file compiled as both lib and test yields the same warning twice, and which targets rebuild varies — still `406` then `404`. Fixed by counting unique `(file, line, column, lint)` **sites**; a site is the thing being ratcheted.

**3. The workspace does not fully compile.** Pre-existing: the verifier-service wasm package is absent, and portcullis-core's tests need `--features serde`. Cargo stops scheduling other crates once one fails, so the count silently became "however much happened to build" — `280, 330, 334`. Fixed with `--keep-going`.

With all three fixed: **457, 457, 457.**

Every earlier number was silently partial, and every one was **lower** — so seeding the ceiling from any of them would have baked in a gate that could never fail.

The script also prints which crates failed to compile and were therefore not analysed, so a partial count is never reported as a whole one.

## Verification

- Mutation-tested both directions: ceiling below actual exits **1**, ceiling above exits **0**.
- Determinism shown by three identical consecutive runs.
- `actionlint` clean.

Ceiling seeded at **470**, not 457, because clippy counts can differ by platform and feature resolution and CI (linux) is the authority. The first push to main snaps it to the real count, so the slack closes within one commit rather than persisting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)