### PR TITLE
fix(identity): an X.509-SVID with two identities is refused, not resolved by DER order

### DIFF
--- a/.github/workflows/manifest-guards.yml
+++ b/.github/workflows/manifest-guards.yml
@@ -99,3 +99,8 @@ jobs:
       # copies of one fact drift, so this fails if they disagree.
       - name: merge_group scope gates match their declared paths
         run: bash ci/merge-group-scope-parity.sh
+      # Exactly one place decides what SPIFFE ID a certificate carries. Six
+      # independent copies of that parse existed, each returning the FIRST
+      # `spiffe://` SAN, which the X.509-SVID standard requires be rejected.
+      - name: One X.509-SVID validator
+        run: bash ci/one-svid-validator.sh

--- a/ci/one-svid-validator.sh
+++ b/ci/one-svid-validator.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# There must be exactly ONE place that decides what SPIFFE ID a certificate
+# carries.
+#
+# WHY: this parse existed in six independent copies, each looping the SAN list
+# and returning the FIRST entry starting with `spiffe://`. The X.509-SVID
+# standard requires exactly one URI SAN and requires validators to REJECT
+# certificates carrying more, so first-match was an impersonation vector: a
+# certificate naming both `spiffe://td/victim` and `spiffe://td/attacker` was
+# accepted and resolved by DER encoding order. Two of those copies —
+# `nucleus-node`'s auth path and the tool-proxy's mTLS path — decide who a peer
+# IS, so two components could disagree about the same peer.
+#
+# Consolidating fixed it once. This stops it growing back: a new local SAN loop
+# reintroduces the bug silently, because the code looks reasonable in isolation.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+# The one legitimate implementation.
+OWNER="crates/nucleus-identity/src/certificate.rs"
+
+# A CSR is not an SVID: it has no cA field and no key usage to check, so
+# `ca/self_signed.rs` extracting a requested SAN from a CertificationRequest is
+# a genuinely different operation and is not covered by this rule.
+CSR_READER="crates/nucleus-identity/src/ca/self_signed.rs"
+
+hits=$(grep -rln 'GeneralName::URI' --include='*.rs' crates/ 2>/dev/null \
+       | grep -v "^${OWNER}$" \
+       | grep -v "^${CSR_READER}$" \
+       || true)
+
+if [ -n "$hits" ]; then
+  echo "::error::a SPIFFE URI SAN is being parsed outside $OWNER:"
+  echo "$hits" | sed 's/^/  /'
+  echo "  Use nucleus_identity::spiffe_uri_from_svid (DER) or"
+  echo "  spiffe_uri_from_parsed_svid (already-parsed cert) instead. They enforce"
+  echo "  the X.509-SVID rules that a local loop will not."
+  exit 1
+fi
+
+# Non-vacuity: if the owner ever stops containing the parse, this check would
+# pass by scanning for something that no longer exists anywhere.
+if ! grep -q 'GeneralName::URI' "$OWNER"; then
+  echo "::error::$OWNER no longer parses URI SANs — this check has nothing to anchor to"
+  exit 1
+fi
+
+echo "ok: one SVID validator ($OWNER)"

--- a/crates/nucleus-cli/examples/spiffe_iroh_full.rs
+++ b/crates/nucleus-cli/examples/spiffe_iroh_full.rs
@@ -194,17 +194,10 @@ fn verify_svid(
     );
 
     // SPIFFE ID from the URI SAN.
-    let spiffe_id = leaf
-        .subject_alternative_name()?
-        .and_then(|san| {
-            san.value.general_names.iter().find_map(|gn| match gn {
-                x509_parser::extensions::GeneralName::URI(u) if u.starts_with("spiffe://") => {
-                    Some(u.to_string())
-                }
-                _ => None,
-            })
-        })
-        .ok_or_else(|| anyhow::anyhow!("SVID has no SPIFFE URI SAN"))?;
+    // An example is read as guidance, so it must not demonstrate the
+    // first-match parse this repo just removed.
+    let spiffe_id = nucleus_identity::spiffe_uri_from_parsed_svid(&leaf)
+        .map_err(|e| anyhow::anyhow!("not a valid X.509-SVID: {e}"))?;
 
     let passport_pk = public_key_from_spki(leaf.public_key().raw)?;
     Ok((spiffe_id, passport_pk))

--- a/crates/nucleus-identity/src/certificate.rs
+++ b/crates/nucleus-identity/src/certificate.rs
@@ -162,29 +162,38 @@ impl Certificate {
         &self.pem
     }
 
-    /// Extracts the SPIFFE identity from the certificate's SAN extension.
+    /// Extracts the SPIFFE identity from an X.509-SVID, enforcing the spec's
+    /// validation rules.
+    ///
+    /// # Why this is strict
+    ///
+    /// This used to return the FIRST SAN entry starting with `spiffe://`. The
+    /// X.509-SVID standard says an SVID "MUST contain exactly one URI SAN", and
+    /// that validators MUST reject certificates carrying more. First-match is
+    /// not a lenient reading of that rule — it is an **impersonation vector**:
+    /// a certificate bearing both `spiffe://td/victim` and `spiffe://td/attacker`
+    /// was accepted, and which identity nucleus believed depended on DER
+    /// encoding order. Two components parsing the same peer could disagree.
+    ///
+    /// That matters because this is an authorization input. `nucleus-node`'s
+    /// `auth` path and the tool-proxy's mTLS path both decide *who a peer is*
+    /// from this value.
+    ///
+    /// # What is checked
+    ///
+    /// Per <https://github.com/spiffe/spiffe/blob/main/standards/X509-SVID.md>:
+    ///
+    /// * exactly one URI SAN (not "the first one that looks right"),
+    /// * `cA` is false — a CA certificate is not an SVID,
+    /// * neither `keyCertSign` nor `cRLSign` is asserted.
+    ///
+    /// The remaining leaf rules — the `spiffe` scheme and a non-root path
+    /// component — are enforced by [`Identity::from_spiffe_uri`], which rejects
+    /// both a foreign scheme and `spiffe://trust.domain/`. They are not
+    /// re-implemented here; one parser owning one rule is the point of this
+    /// function.
     pub fn extract_spiffe_identity(&self) -> Result<Identity> {
-        let (_, cert) = x509_parser::parse_x509_certificate(&self.der)
-            .map_err(|e| Error::Certificate(format!("failed to parse certificate: {e}")))?;
-
-        // Look for Subject Alternative Name extension
-        for ext in cert.extensions() {
-            if let x509_parser::extensions::ParsedExtension::SubjectAlternativeName(san) =
-                ext.parsed_extension()
-            {
-                for name in &san.general_names {
-                    if let x509_parser::extensions::GeneralName::URI(uri) = name {
-                        if uri.starts_with("spiffe://") {
-                            return Identity::from_spiffe_uri(uri);
-                        }
-                    }
-                }
-            }
-        }
-
-        Err(Error::Certificate(
-            "no SPIFFE URI found in certificate SAN".to_string(),
-        ))
+        Identity::from_spiffe_uri(&spiffe_uri_from_svid(&self.der)?)
     }
 
     /// Returns the certificate's not-after (expiry) time.
@@ -350,9 +359,277 @@ fn pem_to_der(pem_str: &str, _expected_label: &str) -> Result<Vec<u8>> {
     Ok(parsed.into_contents())
 }
 
+/// The validated SPIFFE URI of an X.509-SVID.
+///
+/// This is the single place nucleus decides what SPIFFE ID a certificate
+/// carries. It existed in seven copies before — `certificate.rs`, `tls.rs`,
+/// `ca/self_signed.rs`, `nucleus-node`'s `auth`, and the tool-proxy's `mtls`
+/// and `sandbox_proof` — each looping the SAN list and returning the FIRST
+/// entry starting with `spiffe://`.
+///
+/// That is not a lenient reading of the standard, it is an impersonation
+/// vector. The X.509-SVID spec says an SVID "MUST contain exactly one URI SAN"
+/// and that validators MUST reject certificates carrying more; with first-match
+/// a certificate naming both `spiffe://td/victim` and `spiffe://td/attacker`
+/// was accepted, and which identity nucleus believed depended on DER encoding
+/// order. Two of those call sites — `auth` and `mtls` — decide *who a peer is*,
+/// so two components could disagree about the same peer.
+///
+/// Enforced here, per
+/// <https://github.com/spiffe/spiffe/blob/main/standards/X509-SVID.md>:
+///
+/// * exactly one URI SAN,
+/// * `cA` is false,
+/// * neither `keyCertSign` nor `cRLSign` is asserted,
+/// * the URI is a well-formed SPIFFE ID with a non-root path — delegated to
+///   [`Identity::from_spiffe_uri`], which rejects a foreign scheme and a bare
+///   `spiffe://trust.domain/`. The URI is returned as it appeared, so callers
+///   that want the string do not pay for a reserialisation.
+pub fn spiffe_uri_from_svid(cert_der: &[u8]) -> Result<String> {
+    let (_, cert) = x509_parser::parse_x509_certificate(cert_der)
+        .map_err(|e| Error::Certificate(format!("failed to parse certificate: {e}")))?;
+    spiffe_uri_from_parsed_svid(&cert)
+}
+
+/// [`spiffe_uri_from_svid`] for a certificate that is already parsed.
+///
+/// Same rules, no re-parse. Call sites that hold an
+/// `x509_parser::certificate::X509Certificate` (the tool-proxy's sandbox proof,
+/// `nucleus-spiffe-hail`) use this so that converging on one validator does not
+/// cost them a second DER parse.
+pub fn spiffe_uri_from_parsed_svid(
+    cert: &x509_parser::certificate::X509Certificate<'_>,
+) -> Result<String> {
+    use x509_parser::extensions::{GeneralName, ParsedExtension};
+
+    // "Leaf certificates MUST set the cA field to false."
+    if cert.is_ca() {
+        return Err(Error::Certificate(
+            "not an X.509-SVID: cA is true, which is a CA certificate, not a leaf SVID".to_string(),
+        ));
+    }
+
+    // "MUST NOT set keyCertSign or cRLSign." Checked independently of `cA`: a
+    // leaf able to sign certificates or CRLs can mint peers whatever its basic
+    // constraints claim.
+    for ext in cert.extensions() {
+        if let ParsedExtension::KeyUsage(ku) = ext.parsed_extension() {
+            if ku.key_cert_sign() || ku.crl_sign() {
+                return Err(Error::Certificate(
+                    "not an X.509-SVID: key usage asserts keyCertSign or cRLSign".to_string(),
+                ));
+            }
+        }
+    }
+
+    // Collect EVERY URI SAN before deciding. Returning on the first match is
+    // exactly the bug this function exists to remove.
+    let mut uris = Vec::new();
+    for ext in cert.extensions() {
+        if let ParsedExtension::SubjectAlternativeName(san) = ext.parsed_extension() {
+            for name in &san.general_names {
+                if let GeneralName::URI(uri) = name {
+                    uris.push(*uri);
+                }
+            }
+        }
+    }
+
+    match uris.as_slice() {
+        [] => Err(Error::Certificate(
+            "not an X.509-SVID: no URI SAN".to_string(),
+        )),
+        [uri] => {
+            // Parse for validation (scheme, non-root path) but return the URI
+            // as it appeared on the wire.
+            Identity::from_spiffe_uri(uri)?;
+            Ok((*uri).to_string())
+        }
+        many => Err(Error::Certificate(format!(
+            "not an X.509-SVID: {} URI SANs, expected exactly one (a certificate carrying \
+             several identities must be refused, not resolved by order): {}",
+            many.len(),
+            many.join(", ")
+        ))),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ---- X.509-SVID validation --------------------------------------------
+    //
+    // Every case below CONSTRUCTS the offending certificate and asserts it
+    // parses as a certificate first. Without that, a test could pass because
+    // the DER was malformed rather than because the rule fired — a refusal for
+    // the wrong reason proves nothing about the rule.
+
+    use rcgen::{
+        BasicConstraints, CertificateParams, DistinguishedName, DnType, IsCa, KeyPair,
+        KeyUsagePurpose, SanType,
+    };
+
+    /// Build a self-signed leaf with the given URI SANs and knobs.
+    fn svid_like(uris: &[&str], is_ca: bool, key_usages: Vec<KeyUsagePurpose>) -> Vec<u8> {
+        let key = KeyPair::generate_for(&rcgen::PKCS_ECDSA_P256_SHA256).unwrap();
+        let mut params = CertificateParams::new(vec![]).unwrap();
+        let mut dn = DistinguishedName::new();
+        dn.push(DnType::CommonName, "test");
+        params.distinguished_name = dn;
+        params.is_ca = if is_ca {
+            IsCa::Ca(BasicConstraints::Unconstrained)
+        } else {
+            IsCa::NoCa
+        };
+        params.key_usages = key_usages;
+        params.subject_alt_names = uris
+            .iter()
+            .map(|u| SanType::URI(rcgen::string::Ia5String::try_from(u.to_string()).unwrap()))
+            .collect();
+        params.self_signed(&key).unwrap().der().to_vec()
+    }
+
+    fn parses_as_a_certificate(der: &[u8]) {
+        assert!(
+            x509_parser::parse_x509_certificate(der).is_ok(),
+            "fixture is not a parseable certificate, so any rejection would be \
+             meaningless"
+        );
+    }
+
+    /// Non-vacuity for the whole group: a conformant SVID must still be
+    /// ACCEPTED and yield the right identity. Without this, a validator that
+    /// refused everything would pass every other test here.
+    #[test]
+    fn a_conformant_svid_is_accepted_and_yields_its_identity() {
+        let der = svid_like(
+            &["spiffe://nucleus.local/ns/default/sa/web"],
+            false,
+            vec![KeyUsagePurpose::DigitalSignature],
+        );
+        parses_as_a_certificate(&der);
+        let id = Certificate::from_der(der)
+            .extract_spiffe_identity()
+            .unwrap();
+        assert_eq!(id.trust_domain(), "nucleus.local");
+        assert_eq!(id.namespace(), "default");
+        assert_eq!(id.service_account(), "web");
+    }
+
+    /// THE case this hardening exists for. A certificate naming two identities
+    /// must be refused outright — NOT resolved to whichever encodes first.
+    #[test]
+    fn a_certificate_bearing_two_spiffe_ids_is_refused_not_resolved() {
+        let der = svid_like(
+            &[
+                "spiffe://nucleus.local/ns/default/sa/victim",
+                "spiffe://nucleus.local/ns/default/sa/attacker",
+            ],
+            false,
+            vec![KeyUsagePurpose::DigitalSignature],
+        );
+        parses_as_a_certificate(&der);
+
+        let err = Certificate::from_der(der)
+            .extract_spiffe_identity()
+            .expect_err("a two-SAN certificate must be refused");
+        let msg = err.to_string();
+        assert!(msg.contains("expected exactly one"), "{msg}");
+        // The old first-match behaviour returned `victim`. Naming either
+        // identity as the answer is the failure mode, so assert we did not.
+        assert!(
+            !msg.starts_with("spiffe://"),
+            "the error must not resolve to an identity: {msg}"
+        );
+    }
+
+    /// Order independence: the same certificate with the SANs swapped must fail
+    /// identically. If the rule were still order-sensitive, exactly one of these
+    /// two tests would pass.
+    #[test]
+    fn the_refusal_does_not_depend_on_san_order() {
+        let der = svid_like(
+            &[
+                "spiffe://nucleus.local/ns/default/sa/attacker",
+                "spiffe://nucleus.local/ns/default/sa/victim",
+            ],
+            false,
+            vec![KeyUsagePurpose::DigitalSignature],
+        );
+        parses_as_a_certificate(&der);
+        assert!(Certificate::from_der(der)
+            .extract_spiffe_identity()
+            .is_err());
+    }
+
+    /// "Leaf certificates MUST set the cA field to false."
+    #[test]
+    fn a_ca_certificate_is_not_an_svid() {
+        let der = svid_like(
+            &["spiffe://nucleus.local/ns/default/sa/web"],
+            true,
+            vec![KeyUsagePurpose::DigitalSignature],
+        );
+        parses_as_a_certificate(&der);
+        let msg = Certificate::from_der(der)
+            .extract_spiffe_identity()
+            .expect_err("a CA certificate must not validate as an SVID")
+            .to_string();
+        assert!(msg.contains("cA is true"), "{msg}");
+    }
+
+    /// "MUST NOT set keyCertSign or cRLSign" — checked independently of `cA`,
+    /// because a leaf that can sign certificates can mint peers regardless of
+    /// what its basic constraints claim.
+    #[test]
+    fn a_leaf_that_can_sign_certificates_is_not_an_svid() {
+        for usage in [KeyUsagePurpose::KeyCertSign, KeyUsagePurpose::CrlSign] {
+            let der = svid_like(
+                &["spiffe://nucleus.local/ns/default/sa/web"],
+                false,
+                vec![KeyUsagePurpose::DigitalSignature, usage],
+            );
+            parses_as_a_certificate(&der);
+            let msg = Certificate::from_der(der)
+                .extract_spiffe_identity()
+                .expect_err("keyCertSign/cRLSign must disqualify an SVID")
+                .to_string();
+            assert!(msg.contains("keyCertSign or cRLSign"), "{msg}");
+        }
+    }
+
+    /// A certificate with no URI SAN at all is not an SVID.
+    #[test]
+    fn a_certificate_without_a_uri_san_is_not_an_svid() {
+        let der = svid_like(&[], false, vec![KeyUsagePurpose::DigitalSignature]);
+        parses_as_a_certificate(&der);
+        let msg = Certificate::from_der(der)
+            .extract_spiffe_identity()
+            .expect_err("no URI SAN must be refused")
+            .to_string();
+        assert!(msg.contains("no URI SAN"), "{msg}");
+    }
+
+    /// The scheme and non-root-path rules are delegated to
+    /// `Identity::from_spiffe_uri`. Delegation is only safe if it actually
+    /// rejects, so pin that here rather than assuming it.
+    #[test]
+    fn the_delegated_scheme_and_path_rules_still_reject() {
+        for uri in [
+            "https://nucleus.local/ns/default/sa/web", // wrong scheme
+            "spiffe://nucleus.local/",                 // root path only
+        ] {
+            let der = svid_like(&[uri], false, vec![KeyUsagePurpose::DigitalSignature]);
+            parses_as_a_certificate(&der);
+            assert!(
+                Certificate::from_der(der)
+                    .extract_spiffe_identity()
+                    .is_err(),
+                "{uri} must be refused"
+            );
+        }
+    }
 
     #[test]
     fn test_der_to_pem_roundtrip() {

--- a/crates/nucleus-identity/src/lib.rs
+++ b/crates/nucleus-identity/src/lib.rs
@@ -63,7 +63,9 @@ pub use attestation::{
 #[cfg(feature = "spire")]
 pub use ca::{auto_detect_ca, SpireCaClient, DEFAULT_SPIRE_SOCKET, SPIFFE_ENDPOINT_ENV};
 pub use ca::{CaClient, SelfSignedCa};
-pub use certificate::{TrustBundle, WorkloadCertificate};
+pub use certificate::{
+    spiffe_uri_from_parsed_svid, spiffe_uri_from_svid, TrustBundle, WorkloadCertificate,
+};
 pub use cross_agent::{join_cross_agent, CrossAgentExchange, CrossAgentReceipt};
 pub use csr::{CertSign, CsrOptions};
 pub use did::{did_web_to_url, DidDocument, JsonWebKey, ServiceEndpoint, VerificationMethod};

--- a/crates/nucleus-identity/src/tls.rs
+++ b/crates/nucleus-identity/src/tls.rs
@@ -225,33 +225,20 @@ impl SpiffeServerCertVerifier {
         }
     }
 
-    /// Extracts SPIFFE URI from certificate's Subject Alternative Name extension.
+    /// Extracts the SPIFFE URI from an SVID, if it is in the expected trust
+    /// domain.
     ///
-    /// Returns the first SPIFFE URI found that matches the expected trust domain prefix,
-    /// or None if no matching URI is found.
+    /// Two rules, kept apart on purpose. `spiffe_uri_from_svid` decides whether
+    /// this is a well-formed SVID at all — exactly one URI SAN, not a CA, no
+    /// signing key usage. The trust-domain prefix is then a policy question
+    /// about whether we accept *this* SVID. The local SAN loop this replaced
+    /// conflated them: it took the first SAN matching the prefix, so a
+    /// certificate carrying both a foreign identity and one of ours passed as
+    /// ours.
     fn extract_spiffe_uri(&self, cert_der: &[u8]) -> Option<String> {
-        use x509_parser::prelude::FromDer;
-
-        let (_, cert) = x509_parser::parse_x509_certificate(cert_der).ok()?;
-        let expected_prefix = format!("spiffe://{}/", self.trust_domain);
-
-        for ext in cert.extensions() {
-            if ext.oid == x509_parser::oid_registry::OID_X509_EXT_SUBJECT_ALT_NAME {
-                if let Ok((_, san)) =
-                    x509_parser::extensions::SubjectAlternativeName::from_der(ext.value)
-                {
-                    for name in &san.general_names {
-                        // x509_parser uses URI variant (not UniformResourceIdentifier)
-                        if let x509_parser::extensions::GeneralName::URI(uri) = name {
-                            if uri.starts_with(&expected_prefix) {
-                                return Some(uri.to_string());
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        None
+        let uri = crate::certificate::spiffe_uri_from_svid(cert_der).ok()?;
+        uri.starts_with(&format!("spiffe://{}/", self.trust_domain))
+            .then_some(uri)
     }
 }
 

--- a/crates/nucleus-node/src/auth.rs
+++ b/crates/nucleus-node/src/auth.rs
@@ -471,26 +471,11 @@ pub enum AuthorizationError {
 /// The SPIFFE ID is stored in the Subject Alternative Name (SAN) extension
 /// as a URI starting with "spiffe://".
 pub fn extract_spiffe_id_from_cert(cert_der: &[u8]) -> Option<String> {
-    use x509_parser::prelude::*;
-
-    let (_, cert) = X509Certificate::from_der(cert_der).ok()?;
-
-    for ext in cert.extensions() {
-        if ext.oid == oid_registry::OID_X509_EXT_SUBJECT_ALT_NAME {
-            if let Ok((_, san)) =
-                x509_parser::extensions::SubjectAlternativeName::from_der(ext.value)
-            {
-                for name in &san.general_names {
-                    if let x509_parser::extensions::GeneralName::URI(uri) = name {
-                        if uri.starts_with("spiffe://") {
-                            return Some(uri.to_string());
-                        }
-                    }
-                }
-            }
-        }
-    }
-    None
+    // Delegated to nucleus-identity so this AUTHORIZATION path cannot disagree
+    // with any other component about who a peer is. The local copy this
+    // replaced returned the FIRST `spiffe://` SAN, so a certificate naming two
+    // identities was accepted and resolved by DER encoding order.
+    nucleus_identity::spiffe_uri_from_svid(cert_der).ok()
 }
 
 /// Extracts SPIFFE ID from a tonic Request's peer certificates.

--- a/crates/nucleus-spiffe-hail/src/lib.rs
+++ b/crates/nucleus-spiffe-hail/src/lib.rs
@@ -260,19 +260,10 @@ fn verify_svid_chain(
         bail!("SVID leaf is not signed by any trusted CA root");
     }
 
-    let spiffe_id = leaf
-        .subject_alternative_name()
-        .ok()
-        .flatten()
-        .and_then(|san| {
-            san.value.general_names.iter().find_map(|gn| match gn {
-                x509_parser::extensions::GeneralName::URI(u) if u.starts_with("spiffe://") => {
-                    Some(u.to_string())
-                }
-                _ => None,
-            })
-        })
-        .ok_or_else(|| anyhow!("SVID has no spiffe:// URI SAN"))?;
+    // One validator for the whole repo. The find_map this replaced returned the
+    // first `spiffe://` SAN, so a multi-identity certificate was accepted.
+    let spiffe_id = nucleus_identity::spiffe_uri_from_parsed_svid(&leaf)
+        .map_err(|e| anyhow!("not a valid X.509-SVID: {e}"))?;
 
     // The leaf's ed25519 public key is the trailing 32 bytes of its SPKI.
     let raw = leaf.public_key().raw;

--- a/crates/nucleus-tool-proxy/src/mtls.rs
+++ b/crates/nucleus-tool-proxy/src/mtls.rs
@@ -86,26 +86,11 @@ impl ClientCertInfo {
 
 /// Extracts SPIFFE ID from a DER-encoded certificate.
 fn extract_spiffe_id(cert_der: &[u8]) -> Option<String> {
-    use x509_parser::prelude::*;
-
-    let (_, cert) = X509Certificate::from_der(cert_der).ok()?;
-
-    for ext in cert.extensions() {
-        if ext.oid == oid_registry::OID_X509_EXT_SUBJECT_ALT_NAME {
-            if let Ok((_, san)) =
-                x509_parser::extensions::SubjectAlternativeName::from_der(ext.value)
-            {
-                for name in &san.general_names {
-                    if let x509_parser::extensions::GeneralName::URI(uri) = name {
-                        if uri.starts_with("spiffe://") {
-                            return Some(uri.to_string());
-                        }
-                    }
-                }
-            }
-        }
-    }
-    None
+    // Delegated to nucleus-identity so this AUTHORIZATION path cannot disagree
+    // with any other component about who a peer is. The local copy this
+    // replaced returned the FIRST `spiffe://` SAN, so a certificate naming two
+    // identities was accepted and resolved by DER encoding order.
+    nucleus_identity::spiffe_uri_from_svid(cert_der).ok()
 }
 
 /// Custom axum listener that wraps TCP connections with TLS and extracts client certs.

--- a/crates/nucleus-tool-proxy/src/sandbox_proof.rs
+++ b/crates/nucleus-tool-proxy/src/sandbox_proof.rs
@@ -333,20 +333,10 @@ fn try_orchestrator_token(
 
 /// Extract SPIFFE ID from X.509 certificate SAN extension.
 fn extract_spiffe_id(cert: &x509_parser::prelude::X509Certificate<'_>) -> Option<String> {
-    use x509_parser::prelude::*;
-
-    for ext in cert.extensions() {
-        if let ParsedExtension::SubjectAlternativeName(san) = ext.parsed_extension() {
-            for name in &san.general_names {
-                if let GeneralName::URI(uri) = name {
-                    if uri.starts_with("spiffe://") {
-                        return Some(uri.to_string());
-                    }
-                }
-            }
-        }
-    }
-    None
+    // One validator for the whole repo: the local SAN loop this replaced took
+    // the first `spiffe://` entry, so a certificate naming two identities was
+    // resolved by DER order rather than refused.
+    nucleus_identity::spiffe_uri_from_parsed_svid(cert).ok()
 }
 
 /// Decode the first PEM block into DER bytes.

--- a/crates/nucleus-tool-proxy/tests/mtls_integration.rs
+++ b/crates/nucleus-tool-proxy/tests/mtls_integration.rs
@@ -295,27 +295,12 @@ async fn test_client_spiffe_id_extraction() {
 }
 
 /// Helper to extract SPIFFE ID from a DER-encoded certificate.
+///
+/// Delegates rather than reimplementing. The local copy this replaced meant the
+/// test asserted against its OWN loose parse instead of the production one, so
+/// it would have passed even if the real validator regressed.
 fn extract_spiffe_id_from_cert(cert_der: &[u8]) -> Option<String> {
-    use x509_parser::prelude::*;
-
-    let (_, cert) = X509Certificate::from_der(cert_der).ok()?;
-
-    for ext in cert.extensions() {
-        if ext.oid == oid_registry::OID_X509_EXT_SUBJECT_ALT_NAME {
-            if let Ok((_, san)) =
-                x509_parser::extensions::SubjectAlternativeName::from_der(ext.value)
-            {
-                for name in &san.general_names {
-                    if let x509_parser::extensions::GeneralName::URI(uri) = name {
-                        if uri.starts_with("spiffe://") {
-                            return Some(uri.to_string());
-                        }
-                    }
-                }
-            }
-        }
-    }
-    None
+    nucleus_identity::spiffe_uri_from_svid(cert_der).ok()
 }
 
 /// Test concurrent mTLS connections.


### PR DESCRIPTION
## The bug

Nucleus decided what SPIFFE ID a certificate carried in **eight independent places**, and every one looped the SAN list and returned the **first** entry starting with `spiffe://`.

The [X.509-SVID standard](https://github.com/spiffe/spiffe/blob/main/standards/X509-SVID.md) is explicit:

> An X.509 SVID **MUST contain exactly one URI SAN**, and by extension, exactly one SPIFFE ID.

…and validators MUST reject certificates carrying more. First-match is not a lenient reading of that — it is an **impersonation vector**. A certificate bearing both `spiffe://td/victim` and `spiffe://td/attacker` was accepted, and which identity nucleus believed depended on **DER encoding order**. Because each site parsed independently, two components could disagree about the same peer.

**Two of the eight decide who a peer is:**

| site | role |
| --- | --- |
| `nucleus-node/src/auth.rs` | gRPC mTLS peer identity |
| `nucleus-tool-proxy/src/mtls.rs` | tool-proxy mTLS peer identity |

The rest: `nucleus-identity`'s `certificate.rs` and `tls.rs`, the tool-proxy's `sandbox_proof.rs`, `nucleus-spiffe-hail`, a `nucleus-cli` example, and — worst of the set — the tool-proxy's own `mtls_integration` test, which asserted against **its own loose copy** rather than the production path, so it would have passed even if the real validator regressed.

## The fix

`certificate::spiffe_uri_from_svid` is now the single validator, with `spiffe_uri_from_parsed_svid` for call sites already holding a parsed certificate so converging costs them no second parse. It enforces:

- exactly one URI SAN
- `cA` is false
- neither `keyCertSign` nor `cRLSign` asserted

Scheme and non-root-path are delegated to `Identity::from_spiffe_uri`, which already rejects a foreign scheme and a bare `spiffe://trust.domain/`. A test **pins that delegation** rather than assuming it.

**`tls.rs` is worth a look in review.** It filtered SANs by trust-domain prefix, which conflated two questions. Whether this is a well-formed SVID is now separate from whether we accept *this* one — previously a certificate carrying both a foreign identity and one of ours passed as ours.

**Not converged, deliberately:** `ca/self_signed.rs` extracts a requested SAN from a **CSR**. A CSR has no `cA` and no key usage, so it is a genuinely different operation; `ci/one-svid-validator.sh` exempts it by name with that reason.

## Verification

Every test **constructs** the offending certificate with `rcgen` and asserts it *parses* before asserting rejection — a refusal caused by malformed DER would prove nothing about the rule.

- the two-SAN case, asserting the error names **neither** identity
- the same certificate with the SANs **swapped** — if the rule were still order-sensitive, exactly one of the two would pass
- a conformant SVID that must still validate, without which "reject everything" passes the whole group

**Mutation-tested both mechanisms.** Restoring first-match fails exactly the two multi-SAN tests. Reintroducing a local SAN loop anywhere fails `ci/one-svid-validator.sh` — which also refuses to pass if the owning file ever stops containing the parse it anchors to, so it cannot go green by scanning for something that no longer exists.

nucleus-identity **263**, nucleus-tool-proxy **358**, nucleus-spiffe-hail **8** pass. `nucleus-node`'s test binary does not build on macOS for a pre-existing reason (`from_spec`, fixed in #2355) — identical on `origin/main`.

## Scope

This is Phase 1 of two. Phase 2 adds the standard SPIFFE Workload API (`FetchX509SVID` over gRPC, UDS + vsock) so off-the-shelf SPIFFE clients can obtain an SVID from nucleus — today the Workload API is a bespoke JSON-line protocol. Kept separate because this half is the security fix and shouldn't wait on the interop work.

**Risk worth flagging:** strict validation could reject certificates currently in use, most likely from an external SPIRE deployment via `ca/spire.rs`. This should be run against a real SPIRE-issued SVID before merge, not only self-signed fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)