### PR TITLE
fix(release): build the four guest binaries the rootfs needs and never got

### DIFF
--- a/.github/workflows/manifest-guards.yml
+++ b/.github/workflows/manifest-guards.yml
@@ -57,6 +57,12 @@ jobs:
       - name: Vendor neutrality (no claude/anthropic/openai in source)
         run: bash ci/no-vendor-strings.sh
 
+      # release.yml built 3 of the 7 guest binaries the rootfs needs, so the
+      # rootfs job failed on the first missing one. It only surfaces when a
+      # release is cut, which is why it survived from July to v2.2.0.
+      - name: Release builds every rootfs input
+        run: bash ci/release-builds-rootfs-inputs.sh
+
       # `.gitignore` said `/target/` — anchored to the root, so every nested
       # target/ escaped it, and tools/nucleus-mediation-lint/target was
       # committed: 2664 files, 1269 MB, 98% of the HEAD tree. The same mistake

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,22 @@ jobs:
           cross build -p nucleus-guest-init --release --target ${{ matrix.target }}
           cross build -p nucleus-tool-proxy --release --features remote-audit --target ${{ matrix.target }}
           cross build -p nucleus-net-probe --release --target ${{ matrix.target }}
+          # The rootfs needs SEVEN guest binaries; this step built three, so
+          # `build-rootfs.sh` failed on the first one it could not find:
+          #
+          #   Missing target/<triple>/release/nucleus-workload-probe
+          #
+          # These four were added to the rootfs over time and never added here.
+          # Nobody noticed because the failure only surfaces when a release is
+          # actually cut, and the last one was v2.1.0 in July — so the rootfs
+          # job has been broken for however long that drift has existed.
+          #
+          # It also explains a thing found separately: `nucleus-egress-probe`
+          # was absent from the shipped v2.1.0 rootfs. It was never built.
+          cross build -p nucleus-workload-probe --release --target ${{ matrix.target }}
+          cross build -p nucleus-egress-probe --release --target ${{ matrix.target }}
+          cross build -p nucleus-adversary-probe --release --target ${{ matrix.target }}
+          cross build -p nucleus-podlist-probe --release --target ${{ matrix.target }}
       - name: Build CLI + MCP + Audit + Hook (musl)
         run: |
           cross build -p nucleus-cli --release --target ${{ matrix.target }}
@@ -106,10 +122,19 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: guest-binaries-${{ matrix.arch }}
+          # All seven the rootfs needs. Building them is not enough — the
+          # rootfs job runs on a different runner and only sees what is
+          # uploaded here, so this list and the `cross build` list above must
+          # stay in step. `the_release_builds_every_binary_the_rootfs_needs`
+          # fails if either drifts from build-rootfs.sh.
           path: |
             target/${{ matrix.target }}/release/nucleus-guest-init
             target/${{ matrix.target }}/release/nucleus-tool-proxy
             target/${{ matrix.target }}/release/nucleus-net-probe
+            target/${{ matrix.target }}/release/nucleus-workload-probe
+            target/${{ matrix.target }}/release/nucleus-egress-probe
+            target/${{ matrix.target }}/release/nucleus-adversary-probe
+            target/${{ matrix.target }}/release/nucleus-podlist-probe
 
   # Build pre-built rootfs images
   build-rootfs:

--- a/ci/release-builds-rootfs-inputs.sh
+++ b/ci/release-builds-rootfs-inputs.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Every guest binary the rootfs needs must be BUILT and UPLOADED by release.yml.
+#
+# WHY: `build-rootfs.sh` requires seven guest binaries. `release.yml` built
+# three. The rootfs job runs on a different runner and sees only what the build
+# job uploads, so a binary missing from EITHER list fails the release with:
+#
+#   Missing target/<triple>/release/nucleus-workload-probe
+#
+# Four probes were added to the rootfs over time and never added to the
+# workflow. Nobody noticed because the failure only surfaces when a release is
+# actually cut, and the previous one was v2.1.0 in July — so the rootfs job was
+# broken for however long that drift existed, and v2.2.0 is what found it. It
+# also explains why `nucleus-egress-probe` was absent from the shipped v2.1.0
+# rootfs: it was never built.
+#
+# Two lists that must agree, in two files, is exactly the shape that drifts.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+ROOTFS_SH="scripts/firecracker/build-rootfs.sh"
+RELEASE_YML=".github/workflows/release.yml"
+for f in "$ROOTFS_SH" "$RELEASE_YML"; do
+  [ -f "$f" ] || { echo "::error::$f missing"; exit 1; }
+done
+
+# What the rootfs asks for: the `*_BIN` defaults name each crate's artifact.
+needed=$(grep -oE 'release/nucleus-[a-z-]+' "$ROOTFS_SH" | sed 's|release/||' | sort -u)
+[ -n "$needed" ] || { echo "::error::parsed no binaries from $ROOTFS_SH — check would be vacuous"; exit 1; }
+
+fail=0
+n=0
+for bin in $needed; do
+  n=$((n + 1))
+  grep -q "cross build -p ${bin} " "$RELEASE_YML" \
+    || { echo "::error::$RELEASE_YML never BUILDS ${bin} (needed by $ROOTFS_SH)"; fail=1; }
+  grep -q "release/${bin}$" "$RELEASE_YML" \
+    || { echo "::error::$RELEASE_YML never UPLOADS ${bin} — the rootfs job runs on another runner and will not see it"; fail=1; }
+done
+
+# Non-vacuity: the rootfs genuinely needs several binaries. If this ever parses
+# one or zero, the parse broke rather than the requirement shrinking.
+if [ "$n" -lt 5 ]; then
+  echo "::error::only $n binaries parsed from $ROOTFS_SH; the parse looks broken"
+  exit 1
+fi
+
+[ "$fail" -eq 0 ] && echo "ok: release.yml builds and uploads all $n rootfs inputs"
+exit $fail


### PR DESCRIPTION
## v2.2.0's rootfs jobs failed

```
Missing target/aarch64-unknown-linux-musl/release/nucleus-workload-probe
Build with: scripts/cross-build.sh --arch aarch64
```

`build-rootfs.sh` requires **seven** guest binaries. `release.yml` built **three**.

| needed by the rootfs | built by release.yml (before) |
| --- | --- |
| guest-init, tool-proxy, net-probe | ✅ |
| workload-probe, egress-probe, adversary-probe, podlist-probe | ❌ |

Nobody noticed because the failure only surfaces **when a release is actually cut**, and the previous one was v2.1.0 on 2026-07-30. The rootfs job has been broken for however long that drift existed; v2.2.0 is just the first release since.

It also explains something found separately while verifying the confinement attestation on real hardware: **`nucleus-egress-probe` was absent from the shipped v2.1.0 rootfs**, which forced a hand-injection to test against. It wasn't omitted from the image — it was never built.

## Both halves were broken

The rootfs job runs on a **different runner** and sees only what the build job *uploads*. A binary present in `cross build` but missing from the artifact `path:` fails identically. The upload list was also three.

## Guard

`ci/release-builds-rootfs-inputs.sh` parses the binaries out of `build-rootfs.sh` and fails if `release.yml` does not both **build** and **upload** each one.

Two lists that must agree, in two files, is the shape that drifts — and this one drifted for months in a path nobody exercises between releases.

**Mutation-tested both directions:** deleting a `cross build` line fails it; deleting only an upload `path:` entry fails it too. It also refuses to pass if it parses fewer than five binaries, so a broken parse cannot read as a satisfied requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)