### PR TITLE
fix(node): the macOS release build has been failing on dead_code for months

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,30 @@ jobs:
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
+  # The macOS build was exercised ONCE PER RELEASE and nowhere else:
+  # release.yml was the only workflow with a `macos-` runner. Both Darwin jobs
+  # in v2.2.0 failed on seven `dead_code` errors that had been there for
+  # months — the Firecracker spawn path is `cfg(target_os = "linux")`, so items
+  # it reaches are genuinely dead elsewhere, and setup-rust-toolchain sets
+  # `RUSTFLAGS=-D warnings` by default, which promotes them.
+  #
+  # Building the same crates release.yml publishes, on the same OS, means a
+  # macOS-only regression fails a PR instead of a release. One job: the point is
+  # coverage, not a matrix.
+  darwin-build:
+    name: Build (macOS, release crates)
+    runs-on: macos-14
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
+        with:
+          cache: true
+      # Deliberately NOT overriding rustflags: the default `-D warnings` is the
+      # condition that fails the release, so the gate must run under it too.
+      - name: Build the crates release.yml publishes
+        run: cargo build -p nucleus-node -p nucleus-cli -p nucleus-mcp -p nucleus-audit
+
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest

--- a/crates/nucleus-node/src/identity.rs
+++ b/crates/nucleus-node/src/identity.rs
@@ -42,6 +42,11 @@ pub struct IdentityManager {
     /// Registry mapping pod IDs to their launch attestations.
     attestation_registry: Arc<RwLock<HashMap<String, LaunchAttestation>>>,
     /// Default certificate TTL.
+    // Reached only from the Firecracker spawn path, which is `cfg(target_os = "linux")`.
+    // On other hosts it is genuinely dead, and CI builds release binaries with
+    // `RUSTFLAGS=-D warnings` (setup-rust-toolchain's default), so the warning is an
+    // error that fails the macOS release job.
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
     cert_ttl: Duration,
     /// Base directory holding each pod's node-side state (`<dir>/<pod_id>/…`),
     /// where the node records `mediator-pubkey.hex` when it mints the pod's
@@ -107,6 +112,11 @@ impl IdentityManager {
     /// node minted for it, read from `mediator-pubkey.hex`. `None` when no binding
     /// dir is configured or the file is absent/malformed — issuance then falls back
     /// to an attestation-only SVID rather than failing.
+    // Reached only from the Firecracker spawn path, which is `cfg(target_os = "linux")`.
+    // On other hosts it is genuinely dead, and CI builds release binaries with
+    // `RUSTFLAGS=-D warnings` (setup-rust-toolchain's default), so the warning is an
+    // error that fails the macOS release job. Same pattern as `boot_trace`/`cgroup`.
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
     fn mediation_binding_for(&self, pod_id: &str) -> Option<[u8; 32]> {
         use sha2::{Digest, Sha256};
         let dir = self.mediation_binding_dir.as_ref()?;
@@ -322,6 +332,11 @@ impl IdentityManager {
     /// cache so the served `FETCH_SVID` path returns the *attested* cert rather than
     /// a plain one. If no attestation is registered, falls back to a standard cert.
     #[tracing::instrument(skip_all, fields(boot.stage = "cert.issue"))]
+    // Reached only from the Firecracker spawn path, which is `cfg(target_os = "linux")`.
+    // On other hosts it is genuinely dead, and CI builds release binaries with
+    // `RUSTFLAGS=-D warnings` (setup-rust-toolchain's default), so the warning is an
+    // error that fails the macOS release job.
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
     pub async fn fetch_attested_certificate(
         &self,
         identity: &Identity,

--- a/crates/nucleus-node/src/main.rs
+++ b/crates/nucleus-node/src/main.rs
@@ -357,6 +357,11 @@ struct NodeState {
     /// `/v1/approve`. The PRIVATE half never leaves the node; guests get the
     /// public half as `nucleus.approval_pubkeys`. Persisted in `state_dir` so
     /// pods launched before a node restart can still be approved.
+    // Reached only from the Firecracker spawn path, which is `cfg(target_os = "linux")`.
+    // On other hosts it is genuinely dead, and CI builds release binaries with
+    // `RUSTFLAGS=-D warnings` (setup-rust-toolchain's default), so the warning is an
+    // error that fails the macOS release job. Same pattern as `boot_trace`/`cgroup`.
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
     approval_signer: std::sync::Arc<ed25519_dalek::SigningKey>,
     proxy_actor: Option<String>,
     /// Operator-configured registry of proof-carrying postures a trusted builder

--- a/crates/nucleus-node/src/mediation.rs
+++ b/crates/nucleus-node/src/mediation.rs
@@ -30,6 +30,11 @@
 /// different version that does not satisfy that crate's `CryptoRng` bound. The
 /// bytes are the same either way — a CSPRNG-filled 32-byte seed.
 #[must_use]
+// Reached only from the Firecracker spawn path, which is `cfg(target_os = "linux")`.
+// On other hosts it is genuinely dead, and CI builds release binaries with
+// `RUSTFLAGS=-D warnings` (setup-rust-toolchain's default), so the warning is an
+// error that fails the macOS release job. Same pattern as `boot_trace`/`cgroup`.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 pub(crate) fn new_seed_hex(pod_dir: &std::path::Path) -> Option<String> {
     use rand_core::RngCore;
     let mut seed = [0u8; 32];
@@ -52,6 +57,11 @@ pub(crate) fn new_seed_hex(pod_dir: &std::path::Path) -> Option<String> {
 /// cross-checks the SVID behind it (`verify_attested_receipt`) rather than
 /// trusting the string.
 #[must_use]
+// Reached only from the Firecracker spawn path, which is `cfg(target_os = "linux")`.
+// On other hosts it is genuinely dead, and CI builds release binaries with
+// `RUSTFLAGS=-D warnings` (setup-rust-toolchain's default), so the warning is an
+// error that fails the macOS release job. Same pattern as `boot_trace`/`cgroup`.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 pub(crate) fn spiffe_id(trust_domain: &str, pod_id: impl std::fmt::Display) -> String {
     format!("spiffe://{trust_domain}/mediator/{pod_id}")
 }

--- a/crates/nucleus-node/src/pod_caller_identity.rs
+++ b/crates/nucleus-node/src/pod_caller_identity.rs
@@ -59,6 +59,11 @@ const DOMAIN: &[u8] = b"nucleus-pod-caller-v1\0";
 ///
 /// Hex-encoded HMAC-SHA256. Returned as a `String` because it crosses a wire.
 #[must_use]
+// Reached only from the Firecracker spawn path, which is `cfg(target_os = "linux")`.
+// On other hosts it is genuinely dead, and CI builds release binaries with
+// `RUSTFLAGS=-D warnings` (setup-rust-toolchain's default), so the warning is an
+// error that fails the macOS release job. Same pattern as `boot_trace`/`cgroup`.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 pub(crate) fn derive_token(node_secret: &[u8], pod_id: Uuid) -> String {
     // Built through the crate's own signer so derivation and verification are
     // the same computation by construction, not by two authors agreeing.

--- a/crates/nucleus-node/src/signed_proxy.rs
+++ b/crates/nucleus-node/src/signed_proxy.rs
@@ -41,6 +41,11 @@ pub enum ApprovalSigning {
     /// Ed25519 with the node's approval signing key — Firecracker pods, which
     /// verify against the PUBLIC half (`nucleus.approval_pubkeys`) and hold
     /// no approval secret at all.
+    // Reached only from the Firecracker spawn path, which is `cfg(target_os = "linux")`.
+    // On other hosts it is genuinely dead, and CI builds release binaries with
+    // `RUSTFLAGS=-D warnings` (setup-rust-toolchain's default), so the warning is an
+    // error that fails the macOS release job. Same pattern as `boot_trace`/`cgroup`.
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
     Ed25519(Arc<ed25519_dalek::SigningKey>),
 }
 


### PR DESCRIPTION
## Both Darwin jobs in v2.2.0 failed

```
error: field `approval_signer` is never read
error: field `cert_ttl` is never read
error: methods `mediation_binding_for` and `fetch_attested_certificate` are never used
error: function `new_seed_hex` is never used
error: function `spiffe_id` is never used
error: function `derive_token` is never used
error: variant `Ed25519` is never constructed
```

Reproduced locally in one command, which is the whole problem:

```
RUSTFLAGS="-D warnings" cargo build -p nucleus-node --release
```

The Firecracker spawn path is `cfg(target_os = "linux")`, so items it reaches are genuinely dead on macOS. [`setup-rust-toolchain` sets `RUSTFLAGS=-D warnings` by default](https://github.com/actions-rust-lang/setup-rust-toolchain) — the justfile's `preflight` recipe already documents this — which promotes them to errors.

Each site now carries the annotation this crate **already uses for the same reason** in `boot_trace`, `cgroup` and `firecracker_config`: `#[cfg_attr(not(target_os = "linux"), allow(dead_code))]`. Conditional, so a genuinely dead item on Linux still warns.

## Why it survived, which matters more than the fix

**`release.yml` was the only workflow with a `macos-` runner.** The macOS build ran once per release, and the previous release was v2.1.0 in July. The Darwin jobs could sit broken for as long as nobody cut a release — and cutting one is exactly when you least want to find out.

`ci.yml` now builds the same four crates `release.yml` publishes, on `macos-14`, under the same default `-D warnings`. A macOS-only regression fails a PR instead of a release.

## Second instance of the same shape

This is the **second** failure in the v2.2.0 run with this structure — #2366 fixes the rootfs jobs, which were missing four guest binaries for the same reason. A release-only path is one nobody runs between releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)