### PR TITLE
fix(docker): the images pinned rust 1.88 while the workspace needs 1.95

### DIFF
--- a/.github/workflows/manifest-guards.yml
+++ b/.github/workflows/manifest-guards.yml
@@ -70,6 +70,11 @@ jobs:
       # release is cut, which is why it survived from July to v2.2.0.
       - name: Release builds every rootfs input
         run: bash ci/release-builds-rootfs-inputs.sh
+      # The Dockerfiles pinned rust:1.88 while the workspace needs 1.95, so
+      # `cargo chef cook` refused to build. docker.yml runs on `v*` tags only,
+      # so the images are built when a release is cut and never between.
+      - name: Docker Rust base >= workspace MSRV
+        run: bash ci/docker-rust-matches-msrv.sh
 
       # `.gitignore` said `/target/` — anchored to the root, so every nested
       # target/ escaped it, and tools/nucleus-mediation-lint/target was

--- a/ci/docker-rust-matches-msrv.sh
+++ b/ci/docker-rust-matches-msrv.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# The Dockerfiles' Rust base must be at least the workspace MSRV.
+#
+# WHY: they pinned `rust:1.88-bookworm` while the workspace requires 1.95, so
+# `cargo chef cook` died with:
+#
+#   portcullis@0.0.1 requires rustc 1.93
+#   portcullis-effects@0.0.1 requires rustc 1.95
+#
+# Both image builds had been failing since the MSRV moved past 1.88. Nobody saw
+# it because docker.yml runs on `v*` tags only, so the images are built when a
+# release is cut and at no other time — the same reason the rootfs inputs and
+# the macOS build could rot unnoticed.
+#
+# Two facts in two files that must agree: `rust-version` in Cargo.toml and the
+# base image tag. That is the shape that drifts.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+msrv=$(grep -m1 '^rust-version = ' Cargo.toml | sed 's/.*"\(.*\)".*/\1/')
+[ -n "$msrv" ] || { echo "::error::could not read rust-version from Cargo.toml"; exit 1; }
+msrv_major=${msrv%%.*}; msrv_minor=$(echo "$msrv" | cut -d. -f2)
+
+fail=0
+checked=0
+for f in docker/Dockerfile*; do
+  while read -r ver; do
+    checked=$((checked + 1))
+    maj=${ver%%.*}; min=$(echo "$ver" | cut -d. -f2)
+    if [ "$maj" -lt "$msrv_major" ] || { [ "$maj" -eq "$msrv_major" ] && [ "$min" -lt "$msrv_minor" ]; }; then
+      echo "::error::$f pins rust:$ver but the workspace MSRV is $msrv — cargo will refuse to build"
+      fail=1
+    fi
+  done < <(grep -oE '^FROM rust:[0-9]+\.[0-9]+' "$f" 2>/dev/null | sed 's/^FROM rust://')
+done
+
+# Non-vacuity: there ARE Rust stages. A parse that finds none would otherwise
+# pass by checking nothing.
+if [ "$checked" -eq 0 ]; then
+  echo "::error::no 'FROM rust:<version>' stages found in docker/ — this check would be vacuous"
+  exit 1
+fi
+
+[ "$fail" -eq 0 ] && echo "ok: all $checked Rust stages are >= MSRV $msrv"
+exit $fail

--- a/docker/Dockerfile.node
+++ b/docker/Dockerfile.node
@@ -18,7 +18,7 @@
 #     nucleus-node
 
 # ── Planner (cargo-chef recipe) ───────────────────────────────────────
-FROM rust:1.88-bookworm@sha256:af306cfa71d987911a781c37b59d7d67d934f49684058f96cf72079c3626bfe0 AS planner
+FROM rust:1.95-bookworm@sha256:6258907abe69656e41cd992e0b705cdcfabcbbe3db374f92ed2d47121282d4a1 AS planner
 
 RUN cargo install cargo-chef --locked
 WORKDIR /build
@@ -27,7 +27,7 @@ COPY crates/ crates/
 RUN cargo chef prepare --recipe-path recipe.json
 
 # ── Cook (compile dependencies only — cached across source changes) ───
-FROM rust:1.88-bookworm@sha256:af306cfa71d987911a781c37b59d7d67d934f49684058f96cf72079c3626bfe0 AS cook
+FROM rust:1.95-bookworm@sha256:6258907abe69656e41cd992e0b705cdcfabcbbe3db374f92ed2d47121282d4a1 AS cook
 
 RUN cargo install cargo-chef --locked
 WORKDIR /build

--- a/docker/Dockerfile.tool-proxy
+++ b/docker/Dockerfile.tool-proxy
@@ -12,7 +12,7 @@
 #   docker build -f docker/Dockerfile.tool-proxy -t nucleus-tool-proxy .
 
 # ── Planner (cargo-chef recipe) ───────────────────────────────────────
-FROM rust:1.88-bookworm@sha256:af306cfa71d987911a781c37b59d7d67d934f49684058f96cf72079c3626bfe0 AS planner
+FROM rust:1.95-bookworm@sha256:6258907abe69656e41cd992e0b705cdcfabcbbe3db374f92ed2d47121282d4a1 AS planner
 
 RUN cargo install cargo-chef --locked
 WORKDIR /build
@@ -21,7 +21,7 @@ COPY crates/ crates/
 RUN cargo chef prepare --recipe-path recipe.json
 
 # ── Cook (compile dependencies only — cached across source changes) ───
-FROM rust:1.88-bookworm@sha256:af306cfa71d987911a781c37b59d7d67d934f49684058f96cf72079c3626bfe0 AS cook
+FROM rust:1.95-bookworm@sha256:6258907abe69656e41cd992e0b705cdcfabcbbe3db374f92ed2d47121282d4a1 AS cook
 
 RUN cargo install cargo-chef --locked
 WORKDIR /build


### PR DESCRIPTION
## Both Docker jobs in v2.2.0 failed

Not on the npm step it looked like at first glance — on the **toolchain**:

```
portcullis@0.0.1         requires rustc 1.93
portcullis-effects@0.0.1 requires rustc 1.95
thread 'main' panicked at cargo-chef-0.1.78/src/recipe.rs:224:27
ERROR: process "cargo chef cook --release ..." exit code: 101
```

`Dockerfile.node` and `Dockerfile.tool-proxy` both pinned `rust:1.88-bookworm` — two stages each. The workspace `rust-version` is **1.95**, so cargo refuses before compiling anything.

Both bumped to `rust:1.95-bookworm`, digest-pinned in the repo's existing style (digest read from the registry, not invented).

## Why nobody saw it

`docker.yml` triggers on `v*` tags **only** — the images are built when a release is cut and at no other time. They have been unbuildable since the MSRV moved past 1.88.

**This is the third failure in one release with that shape:**

| PR | failure | why it hid |
| --- | --- | --- |
| #2366 | rootfs missing 4 guest binaries | rootfs job runs only on a release |
| #2367 | macOS build, 7 `dead_code` errors | `release.yml` was the only macOS runner |
| this | Docker Rust 1.88 vs MSRV 1.95 | `docker.yml` runs on `v*` only |

Previous release: v2.1.0, July.

## Guard

`ci/docker-rust-matches-msrv.sh` compares every `FROM rust:<ver>` stage against `rust-version` in Cargo.toml.

**Mutation-tested both directions:** regressing a stage to 1.88 fails it; raising the MSRV above the images fails it. It refuses to pass if it finds no Rust stages.

Worth recording: my **first mutation attempt didn't apply** — the `sed` pattern omitted the `@sha256:` digest, so nothing changed and the check "passed". A mutation that doesn't mutate proves nothing, and it looks exactly like a real pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)