### PR TITLE
ci(release): exercise the release path daily instead of at the tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,22 @@ on:
     tags:
       - "v*"
       - "nucleus-node-v*"
+  # DRY RUN. Five of the last seven release attempts failed, because every job
+  # below runs ONLY when a tag is pushed — so they rot between releases and the
+  # rot is discovered at the worst moment. v2.2.0 alone hit three: release.yml
+  # built 3 of the 7 guest binaries the rootfs needs (#2366), both macOS jobs
+  # died on `dead_code` promoted by -D warnings (#2367), and the Docker images
+  # pinned rust 1.88 against a 1.95 workspace (#2368). All three had been broken
+  # since v2.1.0 in July.
+  #
+  # A daily run builds everything and publishes NOTHING (see the tag guard on
+  # `release`), so the build path is exercised every day instead of every
+  # release. Deliberately the SAME workflow rather than a copy: a separate
+  # dry-run file would drift from the real one, which is the exact failure mode
+  # being fixed.
+  schedule:
+    - cron: "17 6 * * *"
+  workflow_dispatch:
 
 # Restrict default permissions - jobs declare what they need
 concurrency:
@@ -213,11 +229,67 @@ jobs:
           name: lima-templates
           path: dist/*.yaml
 
+  # The dry run's own non-vacuity check. A scheduled run whose jobs all SKIPPED
+  # would report success while proving nothing — the same "green because it
+  # never ran" shape the dry run exists to catch. So assert the artifacts a
+  # real release needs were actually produced.
+  #
+  # It checks the rootfs images specifically because that is what broke: the
+  # first v2.2.0 attempt published 16 assets with ZERO rootfs, and `setup` needs
+  # exactly those.
+  dry-run-assert:
+    name: The dry run actually built a releasable set
+    runs-on: ubuntu-latest
+    needs: [build, build-musl, build-rootfs, upload-lima-templates]
+    if: always() && !startsWith(github.ref, 'refs/tags/')
+    steps:
+      - name: Every build job must have succeeded
+        env:
+          B: ${{ needs.build.result }}
+          M: ${{ needs.build-musl.result }}
+          R: ${{ needs.build-rootfs.result }}
+          L: ${{ needs.upload-lima-templates.result }}
+        run: |
+          set -euo pipefail
+          fail=0
+          for pair in "build:$B" "build-musl:$M" "build-rootfs:$R" "upload-lima-templates:$L"; do
+            name=${pair%%:*}; res=${pair#*:}
+            if [ "$res" != "success" ]; then
+              echo "::error::$name was '$res' — the release path is broken TODAY, not at the next tag"
+              fail=1
+            fi
+          done
+          exit $fail
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: rootfs-*
+          path: rootfs
+
+      - name: A rootfs image exists for every architecture
+        run: |
+          set -euo pipefail
+          # The pin resolves nucleus-rootfs-<version>-<arch>.ext4.gz for both
+          # arches; anything less and `nucleus setup` cannot install a guest.
+          n=$(find rootfs -name '*.ext4.gz' | wc -l | tr -d ' ')
+          find rootfs -name '*.ext4.gz' | sed 's/^/  built: /'
+          if [ "$n" -lt 2 ]; then
+            echo "::error::only $n rootfs image(s) built; a release needs one per architecture."
+            echo "  This is the v2.2.0 failure exactly: 16 assets published, 0 of them a rootfs."
+            exit 1
+          fi
+          echo "ok: $n rootfs images"
+
   release:
     name: Create Release
     runs-on: ubuntu-latest
     needs: [build, build-musl, build-rootfs, upload-lima-templates]
-    if: always() && needs.build-musl.result == 'success'
+    # PUBLISHING IS TAG-ONLY. A scheduled or dispatched run builds everything and
+    # stops here — no release object, no assets, no attestations, no crates.io,
+    # no Homebrew (`publish` and `homebrew` both `needs: release`, so this one
+    # condition gates all three). A dry run that published would be far worse
+    # than no dry run.
+    if: always() && needs.build-musl.result == 'success' && startsWith(github.ref, 'refs/tags/')
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -325,14 +325,41 @@ jobs:
       # release CANDIDATE would ship unfinished code to those consumers under a
       # reference they have every reason to treat as stable. (The step was also
       # still named "v1" while computing `v2` from the tag.)
+      # Moved through the refs API, NOT `git push`. GITHUB_TOKEN is a GitHub App
+      # token without the `workflows` permission, and git refuses any ref push
+      # whose .github/workflows/ differs from the tip of a branch. A release tag
+      # is almost always a commit or two behind main by the time it builds, so
+      # that condition is the normal case, not an edge case:
+      #
+      #   ! [remote rejected] v2 -> v2 (refusing to allow a GitHub App to create
+      #     or update workflow `.github/workflows/manifest-guards.yml`)
+      #
+      # That is what failed the v2.2.0 release AFTER every asset had uploaded
+      # successfully -- the release was complete and the run still reported
+      # failure, leaving `v2` ten commits stale while `@v2` consumers kept
+      # getting old code.
+      #
+      # The refs API only repoints an existing ref at an existing object, so it
+      # is not subject to that check. Two calls keep the tag ANNOTATED, matching
+      # what `git tag -fa` produced before.
       - name: Update floating major tag
         if: ${{ !contains(github.ref_name, '-') }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          set -euo pipefail
           MAJOR="${GITHUB_REF_NAME%%.*}"
-          git tag -fa "${MAJOR}" -m "Release ${MAJOR}"
-          git push origin "${MAJOR}" --force
+          TAG_OBJ=$(gh api "repos/$REPO/git/tags" \
+            -f tag="$MAJOR" -f message="Release $MAJOR" \
+            -f object="$GITHUB_SHA" -f type=commit --jq .sha)
+          # PATCH updates the ref; if the floating tag does not exist yet (a new
+          # major), POST creates it.
+          gh api -X PATCH "repos/$REPO/git/refs/tags/$MAJOR" \
+            -F sha="$TAG_OBJ" -F force=true --jq .object.sha \
+            || gh api -X POST "repos/$REPO/git/refs" \
+                 -f ref="refs/tags/$MAJOR" -F sha="$TAG_OBJ" --jq .object.sha
+          echo "floating tag $MAJOR -> $GITHUB_SHA"
 
   publish:
     name: Publish to crates.io

--- a/ci/release-builds-rootfs-inputs.sh
+++ b/ci/release-builds-rootfs-inputs.sh
@@ -45,5 +45,28 @@ if [ "$n" -lt 5 ]; then
   exit 1
 fi
 
+# release.yml now also runs on a schedule as a DRY RUN. Publishing must stay
+# tag-only, or a nightly build would cut a release nobody asked for. `publish`
+# and `homebrew` both `needs: release`, so this one guard covers all three.
+# Read the `release` job's OWN if:, not the whole file. The dry-run job carries a
+# NEGATED copy of this same expression, so a file-wide grep is satisfied by the
+# wrong line and the guard passes with the real one deleted (observed).
+release_if=$(awk '
+  /^  release:/            { in_job = 1; next }
+  in_job && /^  [a-z_-]+:/ { exit }
+  in_job && /^    if:/     { print; exit }
+' "$RELEASE_YML")
+
+if printf %s "$release_if" | grep -q -- "!startsWith(github.ref"; then
+  echo "::error::the release job if: NEGATES the tag check: $release_if"
+  echo "  As written, publishing happens on the nightly dry run and NOT on a tag."
+  fail=1
+elif ! printf %s "$release_if" | grep -qF "startsWith(github.ref, 'refs/tags/')"; then
+  echo "::error::$RELEASE_YML no longer gates publishing on a tag. It runs on a"
+  echo "  schedule; without that guard a nightly dry run would publish a release."
+  echo "  release job if: ${release_if:-<none found>}"
+  fail=1
+fi
+
 [ "$fail" -eq 0 ] && echo "ok: release.yml builds and uploads all $n rootfs inputs"
 exit $fail

--- a/ci/release-builds-rootfs-inputs.sh
+++ b/ci/release-builds-rootfs-inputs.sh
@@ -68,5 +68,27 @@ elif ! printf %s "$release_if" | grep -qF "startsWith(github.ref, 'refs/tags/')"
   fail=1
 fi
 
+# The floating major tag must move through the refs API, never `git push`.
+# GITHUB_TOKEN cannot push a ref whose .github/workflows/ differs from a branch
+# tip, which is the normal state of a release tag -- so a `git push` here fails
+# the release AFTER every asset has uploaded. Regressing this is silent until
+# the next release, which is exactly the class of rot the dry run cannot see:
+# the step is tag-only, so no dry run ever executes it.
+float_step=$(awk '
+  /Update floating major tag/ { in_step = 1 }
+  in_step && /^      - name:/ && !/Update floating major tag/ { exit }
+  in_step { print }
+' "$RELEASE_YML")
+
+if [ -z "$float_step" ]; then
+  echo "::error::$RELEASE_YML has no 'Update floating major tag' step; consumers pin @v2."
+  fail=1
+elif printf %s "$float_step" | grep -qE '^[^#]*git push'; then
+  echo "::error::the floating major tag is moved with 'git push' in $RELEASE_YML."
+  echo "  GITHUB_TOKEN is refused when the tag's .github/workflows/ differs from a"
+  echo "  branch tip -- the normal case. Use the git refs API instead."
+  fail=1
+fi
+
 [ "$fail" -eq 0 ] && echo "ok: release.yml builds and uploads all $n rootfs inputs"
 exit $fail


### PR DESCRIPTION
## The problem

Five of the last seven release attempts failed. The cause is structural: every job in `release.yml` runs **only** on a tag push, so the release path rots between releases and the rot is discovered at the worst possible moment.

v2.2.0 hit three separate rots in a single cut — all broken since v2.1.0 in July:

| # | rot | since |
|---|---|---|
| #2366 | built 3 of the 7 guest binaries the rootfs needs | v2.1.0 |
| #2367 | both macOS jobs died on `dead_code` promoted by `-D warnings` | v2.1.0 |
| #2368 | Docker images pinned rust 1.88 against a 1.95 workspace | v2.1.0 |

The user-visible result: a release with **16 assets and zero rootfs images** — precisely the asset `nucleus setup` needs.

## The change

Run the **same** workflow daily. Build everything, publish nothing.

- `schedule: 17 6 * * *` + `workflow_dispatch`
- `release` gated on `startsWith(github.ref, 'refs/tags/')`, which covers `publish` and `homebrew` transitively (both `needs: release`)

Deliberately the same file rather than a dry-run copy — a copy would drift from the real workflow, which is the failure mode being fixed.

`release.yml` has no `pull_request` or `merge_group` trigger, so nothing here becomes a blocking PR check.

## Why this isn't another gate that can't go red

**1. `dry-run-assert`.** A run whose jobs all SKIPPED would report success while proving nothing — the same shape the dry run exists to catch. So it requires all four build jobs to have succeeded, then downloads the artifacts and asserts a rootfs image exists per arch. Aimed at the actual v2.2.0 failure, not at "something was produced".

**2. A tag-only-publishing guard** in `release-builds-rootfs-inputs.sh`, so a later edit can't let the nightly run publish a release nobody asked for.

### The guard's first draft was broken

It grepped the whole file, and **passed with the real tag check deleted** — `dry-run-assert` carries a *negated* copy of the same expression, and the negated copy satisfied the grep. It now reads the `release` job's own `if:` and rejects a negated form explicitly.

Mutation-tested both ways:

| mutation | result |
|---|---|
| baseline | exit 0 |
| delete the tag guard | exit 1 |
| invert it (nightly would publish) | exit 1 |
| restored | exit 0 |

`actionlint` clean under the flags CI uses (`-shellcheck= -pyflakes=`); `shellcheck` clean on the script.

## First real signal

The daily run fires at 06:17 UTC on `main` once merged; `workflow_dispatch` can trigger it sooner.