### PR TITLE
fix(rootfs): the CA bundle lookup was Debian-only, so a Mac build shipped an unbootable image

### DIFF
--- a/scripts/firecracker/boot-harness.sh
+++ b/scripts/firecracker/boot-harness.sh
@@ -114,8 +114,38 @@ echo "              one pod launches at a time without the jailer."
 
 # ── Building the inputs ────────────────────────────────────────────────────
 #
-# On a macOS workstation, build in a container and copy only the artifacts in —
-# no Rust toolchain is needed on the KVM host:
+# On a macOS workstation you can build everything NATIVELY — no Docker, no Linux
+# VM for the build itself. Verified on Apple Silicon:
+#
+#   brew install e2fsprogs                      # mke2fs; keg-only, so:
+#   export PATH="$(brew --prefix e2fsprogs)/sbin:$PATH"
+#   cargo install cargo-zigbuild && brew install zig
+#   rustup target add aarch64-unknown-linux-musl
+#   cargo zigbuild --target aarch64-unknown-linux-musl --release \
+#     -p nucleus-guest-init -p nucleus-tool-proxy -p nucleus-net-probe \
+#     -p nucleus-workload-probe -p nucleus-egress-probe \
+#     -p nucleus-podlist-probe -p nucleus-adversary-probe
+#   ARCH=aarch64 DEBIAN_TARBALL=/path/to/debian-arm64.tar.gz \
+#     bash scripts/firecracker/build-rootfs.sh
+#
+# Two things make this work. `mke2fs -d` populates the image from a directory
+# without a loop mount, so no Linux kernel is needed to WRITE an ext4; and zig
+# supplies the musl cross-linker, so no musl-gcc is needed to BUILD for Linux.
+#
+# The Debian base needs no Docker either — the layer is a gzipped tar in a
+# registry, and its sha256 is the manifest digest, so the download is verifiable:
+#
+#   TOK=$(curl -fsSL "https://auth.docker.io/token?service=registry.docker.io\
+#   &scope=repository:arm64v8/debian:pull" | jq -r .token)
+#   # ...fetch the index, select platform.architecture == "arm64", GET that
+#   # manifest, then GET .layers[0].digest from /v2/<repo>/blobs/<digest>.
+#
+# Do NOT put ROOTFS_DIR on a bind mount / virtiofs share: `mke2fs -d` calls
+# llistxattr on every file and those syscalls fail there, with an error that
+# reads like a dangling symlink ("while listing attributes of awk"). A native
+# macOS path is fine; inside a container, use the container filesystem.
+#
+# The container route below still works and is what CI effectively does:
 #
 #   docker run --rm -v "$PWD":/w -w /w rust:1.93-slim bash -c '
 #     apt-get update -qq && apt-get install -y -qq musl-tools e2fsprogs ca-certificates

--- a/scripts/firecracker/build-rootfs.sh
+++ b/scripts/firecracker/build-rootfs.sh
@@ -387,14 +387,58 @@ cp "$POD_SPEC" "$ROOTFS_DIR/etc/nucleus/pod.yaml"
 #
 # Copied from the build host rather than apt-installed, so the rootfs build stays
 # offline and needs no package manager inside the target tree.
-if [ -d /etc/ssl/certs ] && [ -s /etc/ssl/certs/ca-certificates.crt ]; then
+# The source path is NOT universal. Debian/Ubuntu keep the bundle at
+# /etc/ssl/certs/ca-certificates.crt; macOS ships /etc/ssl/cert.pem and has no
+# such file, so hardcoding the Debian path made an Apple Silicon build print a
+# warning and emit an image that panics as PID 1 with
+# `failed to build HTTP client: builder error` -- the exact failure this block
+# exists to prevent, reintroduced by the lookup rather than the copy.
+CA_BUNDLE_SRC="${CA_BUNDLE_SRC:-}"
+if [ -z "$CA_BUNDLE_SRC" ]; then
+    for candidate in \
+        /etc/ssl/certs/ca-certificates.crt \
+        /etc/pki/tls/certs/ca-bundle.crt \
+        /etc/ssl/cert.pem \
+        "${HOMEBREW_PREFIX:-/opt/homebrew}/etc/ca-certificates/cert.pem"
+    do
+        [ -s "$candidate" ] && { CA_BUNDLE_SRC="$candidate"; break; }
+    done
+fi
+
+if [ -n "$CA_BUNDLE_SRC" ]; then
+    # An explicitly-set CA_BUNDLE_SRC that does not exist must say so. Without
+    # this the `cp` below fails under `set -e` and the build dies on a bare
+    # "No such file or directory" naming a path the caller has to guess at.
+    if [ ! -s "$CA_BUNDLE_SRC" ]; then
+        echo "ERROR: CA_BUNDLE_SRC='$CA_BUNDLE_SRC' does not exist or is empty." >&2
+        exit 1
+    fi
     mkdir -p "$ROOTFS_DIR/etc/ssl/certs"
-    cp /etc/ssl/certs/ca-certificates.crt "$ROOTFS_DIR/etc/ssl/certs/ca-certificates.crt"
-    echo "Installed CA bundle from build host"
-else
-    echo "WARNING: no CA bundle at /etc/ssl/certs/ca-certificates.crt on the build host." >&2
+    cp "$CA_BUNDLE_SRC" "$ROOTFS_DIR/etc/ssl/certs/ca-certificates.crt"
+    # `-s` only proves non-empty. A truncated or non-PEM file is non-empty and
+    # would sail through to the same PID 1 panic, so count actual certificates.
+    ca_count=$(grep -c 'BEGIN CERTIFICATE' "$ROOTFS_DIR/etc/ssl/certs/ca-certificates.crt" || true)
+    if [ "${ca_count:-0}" -lt 1 ]; then
+        echo "ERROR: $CA_BUNDLE_SRC contains no PEM certificates." >&2
+        exit 1
+    fi
+    echo "Installed CA bundle from build host: $CA_BUNDLE_SRC ($ca_count certificates)"
+elif [ "${ALLOW_NO_CA_BUNDLE:-0}" = "1" ]; then
+    echo "WARNING: no CA bundle found; ALLOW_NO_CA_BUNDLE=1 so continuing." >&2
     echo "         The guest tool-proxy will refuse to start with drand enabled." >&2
-    echo "         Install ca-certificates on the build host, or build with drand off." >&2
+else
+    # Hard failure, not a warning. The old warning produced a rootfs that looked
+    # built and could never boot; a build that cannot succeed should not exit 0.
+    echo "ERROR: no CA bundle found on the build host. Looked in:" >&2
+    echo "         /etc/ssl/certs/ca-certificates.crt   (Debian/Ubuntu)" >&2
+    echo "         /etc/pki/tls/certs/ca-bundle.crt     (RHEL/Fedora)" >&2
+    echo "         /etc/ssl/cert.pem                    (macOS, Alpine)" >&2
+    echo "         \$HOMEBREW_PREFIX/etc/ca-certificates/cert.pem" >&2
+    echo "       The tool-proxy is PID 1 and builds an HTTPS client at startup," >&2
+    echo "       so without a CA store the microVM panics instead of booting." >&2
+    echo "       Point CA_BUNDLE_SRC at a bundle, or set ALLOW_NO_CA_BUNDLE=1 if" >&2
+    echo "       you are deliberately building an image with drand disabled." >&2
+    exit 1
 fi
 
 # Copy network policy files if provided


### PR DESCRIPTION
Found by answering "can we build the rootfs on Apple Silicon?" — the answer is yes, and doing it surfaced this.

## The bug

`build-rootfs.sh` already knew the guest needs a CA store: the tool-proxy is PID 1 and builds an HTTPS client at startup, so without one the microVM panics instead of booting. That was found the hard way — by booting a pod on real KVM — and the fix carries a comment saying so.

The fix only ever looked in one place:

```sh
if [ -d /etc/ssl/certs ] && [ -s /etc/ssl/certs/ca-certificates.crt ]
```

That path is Debian/Ubuntu. **macOS has no such file** — it ships `/etc/ssl/cert.pem`. So on Apple Silicon the build printed a `WARNING`, **exited 0**, and produced a rootfs that dies as PID 1:

```
Error: Spec("failed to build HTTP client: builder error")
[    2.012794] Kernel panic - not syncing: Attempted to kill init! exitcode=0x00000100
```

The exact failure the block exists to prevent, reintroduced by the *lookup* rather than the *copy*. CI never saw it because CI is Ubuntu, where the first candidate matches.

## The change

- Search a candidate list (Debian/Ubuntu, RHEL/Fedora, macOS/Alpine, Homebrew); `CA_BUNDLE_SRC` overrides it.
- **Count `BEGIN CERTIFICATE` in what was copied.** `-s` only proves non-empty, and a truncated or non-PEM file is non-empty — it would reach the same PID 1 panic having passed the check.
- **Make "no bundle found" a hard failure.** A build that cannot produce a bootable image should not exit 0. `ALLOW_NO_CA_BUNDLE=1` keeps the escape hatch for a deliberately drand-disabled image.

**Linux CI behaviour is unchanged** — the Debian path is still the first candidate.

## Verification

Built the aarch64 rootfs natively on Apple Silicon (no Docker, no Linux VM) and booted it under Firecracker on real KVM, through a real `nucleus-node`:

| | result |
|---|---|
| before | `failed to build HTTP client: builder error` → kernel panic, init killed |
| after | fetched identity `spiffe://nucleus.local/ns/pods/sa/<uuid>`, broker capability, mediation key and session token over vsock; `vsock_bind=1ms`; `total=381ms`; **zero panics; pod stays up** |

Each branch exercised rather than argued:

| case | exit |
|---|---|
| auto-discovery (macOS) | 0, `/etc/ssl/cert.pem` (128 certificates) |
| explicit good bundle | 0 |
| explicit missing bundle | 1 |
| explicit non-PEM file | 1 |
| no bundle anywhere *(mutated candidate list)* | 1 |
| same + `ALLOW_NO_CA_BUNDLE=1` | 0 |

The first attempt at that mutation ran the mutated copy from `/tmp`, where the script derived the wrong repo root and failed on missing binaries — the `exit=1` it produced had nothing to do with the CA branch. Re-run in place.

## Coverage this does *not* have

There is no CI runner with macOS **and** KVM, so the macOS path is verified by the manual boot above, not by a gate. The Linux path stays covered as before.