### PR TITLE
fix(node): close the HMAC replay window with a nonce and a fail-closed cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6702,6 +6702,7 @@ dependencies = [
  "thiserror 2.0.20",
  "tokio",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/nucleus-client/Cargo.toml
+++ b/crates/nucleus-client/Cargo.toml
@@ -15,6 +15,9 @@ categories = ["authentication", "development-tools"]
 hmac = { workspace = true }
 sha2 = { workspace = true }
 hex = { workspace = true }
+# v4 UUIDs are the per-request nonce that lets an otherwise-identical request
+# repeat inside the node's replay window (#1631).
+uuid = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/nucleus-client/src/lib.rs
+++ b/crates/nucleus-client/src/lib.rs
@@ -124,12 +124,14 @@ pub const HEADER_POD_TOKEN: &str = "x-nucleus-pod-token";
 pub fn sign_http_headers(secret: &[u8], actor: Option<&str>, body: &[u8]) -> SignedHeaders {
     let timestamp = now_unix();
     let actor_value = actor.unwrap_or("");
-    let message = build_message(timestamp, actor_value, body);
+    let nonce = fresh_nonce();
+    let message = build_message(timestamp, actor_value, Some(&nonce), body);
     let signature = sign_message(secret, &message);
 
     let mut headers = vec![
         ("x-nucleus-timestamp".to_string(), timestamp.to_string()),
         ("x-nucleus-signature".to_string(), signature),
+        ("x-nucleus-nonce".to_string(), nonce),
     ];
 
     if !actor_value.is_empty() {
@@ -149,12 +151,14 @@ pub fn sign_http_headers(secret: &[u8], actor: Option<&str>, body: &[u8]) -> Sig
 pub fn sign_grpc_headers(secret: &[u8], actor: Option<&str>, method: &str) -> SignedHeaders {
     let timestamp = now_unix();
     let actor_value = actor.unwrap_or("");
-    let message = format!("{timestamp}.{actor_value}.{method}");
+    let nonce = fresh_nonce();
+    let message = format!("{timestamp}.{actor_value}.{nonce}.{method}");
     let signature = sign_message(secret, message.as_bytes());
 
     let mut headers = vec![
         ("x-nucleus-timestamp".to_string(), timestamp.to_string()),
         ("x-nucleus-signature".to_string(), signature),
+        ("x-nucleus-nonce".to_string(), nonce),
         ("x-nucleus-method".to_string(), method.to_string()),
     ];
 
@@ -285,10 +289,17 @@ pub fn verify_drand_signature(
 }
 
 /// Verify a standard (non-drand) signature.
+/// Verify a request signature.
+///
+/// `nonce` must be whatever the signer sent in `x-nucleus-nonce`, or `None` if
+/// it sent none. It is a parameter rather than an assumption because the nonce
+/// is part of the signed bytes: guessing wrong here does not weaken the check,
+/// it just fails to verify a legitimate signature.
 pub fn verify_signature(
     secret: &[u8],
     timestamp: i64,
     actor: Option<&str>,
+    nonce: Option<&str>,
     body: &[u8],
     signature: &str,
 ) -> bool {
@@ -297,20 +308,37 @@ pub fn verify_signature(
         return false;
     }
     let actor_value = actor.unwrap_or("");
-    let message = build_message(timestamp, actor_value, body);
+    let message = build_message(timestamp, actor_value, nonce, body);
     let expected = sign_message(secret, &message);
 
     constant_time_eq(signature.as_bytes(), expected.as_bytes())
 }
 
-fn build_message(timestamp: i64, actor: &str, body: &[u8]) -> Vec<u8> {
-    let mut message = Vec::with_capacity(body.len() + actor.len() + 32);
+/// `{ts}.{actor}.{nonce}.{tail}` — must stay byte-identical to the node's
+/// `auth::build_message`, which reconstructs this to check the signature.
+fn build_message(timestamp: i64, actor: &str, nonce: Option<&str>, body: &[u8]) -> Vec<u8> {
+    let nonce_len = nonce.map_or(0, |n| n.len() + 1);
+    let mut message = Vec::with_capacity(body.len() + actor.len() + nonce_len + 32);
     message.extend_from_slice(timestamp.to_string().as_bytes());
     message.push(b'.');
     message.extend_from_slice(actor.as_bytes());
     message.push(b'.');
+    if let Some(nonce) = nonce {
+        message.extend_from_slice(nonce.as_bytes());
+        message.push(b'.');
+    }
     message.extend_from_slice(body);
     message
+}
+
+/// A fresh per-request nonce.
+///
+/// Without one, two byte-identical requests in the same second produce the same
+/// signature, and the node cannot tell the second from a replay — so it refuses
+/// it. Polling the same endpoint twice a second is a normal thing for a client
+/// to do, so the client always sends a nonce.
+fn fresh_nonce() -> String {
+    uuid::Uuid::new_v4().simple().to_string()
 }
 
 fn build_drand_message(drand_round: u64, timestamp: i64, actor: &str, body: &[u8]) -> Vec<u8> {
@@ -489,15 +517,15 @@ mod tests {
         let ts = now_unix();
         let body = b"payload";
         // World-known empty-key signature over the exact message the verifier builds.
-        let forged = sign_message(b"", &build_message(ts, "", body));
+        let forged = sign_message(b"", &build_message(ts, "", None, body));
         assert!(
-            !verify_signature(b"", ts, None, body, &forged),
+            !verify_signature(b"", ts, None, None, body, &forged),
             "empty auth secret must never verify a request signature (fail-closed)"
         );
         // No regression: a real secret verifies.
         let real: &[u8] = b"a-real-16byte-secret!!";
-        let sig = sign_message(real, &build_message(ts, "", body));
-        assert!(verify_signature(real, ts, None, body, &sig));
+        let sig = sign_message(real, &build_message(ts, "", None, body));
+        assert!(verify_signature(real, ts, None, None, body, &sig));
     }
 
     #[test]
@@ -643,13 +671,37 @@ mod tests {
             .map(|(_, v)| v.as_str())
             .unwrap();
 
+        let nonce = headers
+            .headers
+            .iter()
+            .find(|(k, _)| k == "x-nucleus-nonce")
+            .map(|(_, v)| v.as_str());
+        // The signer always sends a nonce now; if it stopped, this would be
+        // None and the round-trip below would still have to hold.
+        assert!(nonce.is_some(), "sign_http_headers must emit a nonce");
+
         assert!(verify_signature(
             secret,
             headers.timestamp,
             Some("actor"),
+            nonce,
             body,
             signature
         ));
+
+        // The nonce is inside the signed bytes: verifying without it must fail,
+        // which is what stops a nonce header from being stripped in transit.
+        assert!(
+            !verify_signature(
+                secret,
+                headers.timestamp,
+                Some("actor"),
+                None,
+                body,
+                signature
+            ),
+            "a stripped nonce must not verify"
+        );
     }
 
     #[test]

--- a/crates/nucleus-node/src/auth.rs
+++ b/crates/nucleus-node/src/auth.rs
@@ -1,5 +1,6 @@
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use axum::http::HeaderMap;
@@ -11,6 +12,84 @@ use tracing::warn;
 const HEADER_TIMESTAMP: &str = "x-nucleus-timestamp";
 const HEADER_SIGNATURE: &str = "x-nucleus-signature";
 const HEADER_ACTOR: &str = "x-nucleus-actor";
+/// Optional per-request uniqueness token. When present it is bound into the
+/// signed message, so it cannot be stripped: removing the header changes the
+/// message the server reconstructs and the signature stops verifying.
+const HEADER_NONCE: &str = "x-nucleus-nonce";
+
+/// Default bound on remembered signatures. At the 30 s window the node ships
+/// with, this is far more than a real client produces, and reaching it means
+/// something is flooding — see `ReplayCache::remember` for why that fails
+/// closed rather than evicting.
+const DEFAULT_REPLAY_CAPACITY: usize = 8192;
+
+/// Remembers recently-accepted signatures so a captured request cannot be sent
+/// again inside the timestamp window.
+///
+/// # Why the key is the signature
+///
+/// A replay is byte-identical to the original, so it produces the identical
+/// signature and collides here. A *legitimate* repeat that carries a fresh
+/// `x-nucleus-nonce` signs a different message, so it does not. One key handles
+/// both cases, and clients that do not send a nonce still get replay protection
+/// — they merely cannot repeat a byte-identical request inside the window,
+/// which is indistinguishable from a replay anyway.
+///
+/// # Why it is not a plain LRU
+///
+/// A bounded LRU evicts the oldest entry to make room. That reopens the exact
+/// hole this closes: flood the cache with fresh signatures, push a captured
+/// signature out while its timestamp is still inside the acceptance window, and
+/// replay it. So an entry is only ever dropped once it is **expired** — once
+/// `ensure_skew` would reject its timestamp anyway. If the cache is full of
+/// still-live entries, the request is refused rather than making room.
+#[derive(Debug)]
+pub struct ReplayCache {
+    seen: Mutex<HashMap<String, i64>>,
+    capacity: usize,
+}
+
+impl ReplayCache {
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            seen: Mutex::new(HashMap::new()),
+            capacity,
+        }
+    }
+
+    /// Record a signature as used. `Err(AuthError::Replay)` if it was already
+    /// seen inside the window.
+    ///
+    /// Callers MUST verify the signature first. Remembering unverified
+    /// signatures would let anyone fill the cache with garbage and trip the
+    /// capacity refusal below — turning a replay defence into a denial of
+    /// service.
+    fn remember(&self, signature: &str, timestamp: i64, window: Duration) -> Result<(), AuthError> {
+        let now = unix_now();
+        let mut seen = self.seen.lock().unwrap_or_else(|e| e.into_inner());
+
+        // Expired entries can never be replayed again — `ensure_skew` rejects
+        // their timestamp — so dropping them is free.
+        let window = window.as_secs() as i64;
+        seen.retain(|_, ts| now.saturating_sub(*ts) <= window);
+
+        if seen.contains_key(signature) {
+            return Err(AuthError::Replay);
+        }
+        if seen.len() >= self.capacity {
+            // Everything still held is live. Evicting to make room is what
+            // would let a flood push a capturable signature out early.
+            return Err(AuthError::ReplayCapacity);
+        }
+        seen.insert(signature.to_string(), timestamp);
+        Ok(())
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.seen.lock().unwrap_or_else(|e| e.into_inner()).len()
+    }
+}
 
 /// Global flag to suppress repeated HMAC deprecation warnings after the first few.
 static HMAC_DEPRECATION_WARNED: AtomicBool = AtomicBool::new(false);
@@ -92,6 +171,7 @@ impl AuthMethod {
 pub struct AuthConfig {
     secret: Arc<Vec<u8>>,
     max_skew: Duration,
+    replay: Arc<ReplayCache>,
 }
 
 impl AuthConfig {
@@ -99,7 +179,14 @@ impl AuthConfig {
         Self {
             secret: Arc::new(secret.as_ref().to_vec()),
             max_skew,
+            replay: Arc::new(ReplayCache::new(DEFAULT_REPLAY_CAPACITY)),
         }
+    }
+
+    #[cfg(test)]
+    pub fn with_replay_capacity(mut self, capacity: usize) -> Self {
+        self.replay = Arc::new(ReplayCache::new(capacity));
+        self
     }
 
     pub fn max_skew(&self) -> Duration {
@@ -161,6 +248,10 @@ pub enum AuthError {
     InvalidSignature,
     #[error("timestamp skew too large")]
     Skew,
+    #[error("request replayed")]
+    Replay,
+    #[error("replay cache is full of live entries; retry after the skew window")]
+    ReplayCapacity,
 }
 
 pub fn verify_http(
@@ -176,17 +267,16 @@ pub fn verify_http(
         .map(|s| s.to_string());
     let actor_value = actor.clone().unwrap_or_default();
 
+    let nonce = headers.get(HEADER_NONCE).and_then(|v| v.to_str().ok());
+
     let timestamp = parse_timestamp(ts)?;
     ensure_skew(timestamp, auth.max_skew())?;
 
-    let mut message = Vec::with_capacity(ts.len() + actor_value.len() + 2 + body.len());
-    message.extend_from_slice(ts.as_bytes());
-    message.push(b'.');
-    message.extend_from_slice(actor_value.as_bytes());
-    message.push(b'.');
-    message.extend_from_slice(body);
-
+    let message = build_message(ts.as_bytes(), actor_value.as_bytes(), nonce, body);
     verify_signature(&auth.secret, &message, sig)?;
+
+    // Only now, with the signature proven, is this signature worth remembering.
+    auth.replay.remember(sig, timestamp, auth.max_skew())?;
 
     Ok(AuthContext::from_hmac(actor, timestamp))
 }
@@ -210,13 +300,43 @@ pub fn verify_grpc(
         .map(|s| s.to_string());
     let actor_value = actor.clone().unwrap_or_default();
 
+    let nonce = metadata.get(HEADER_NONCE).and_then(|v| v.to_str().ok());
+
     let timestamp = parse_timestamp(ts)?;
     ensure_skew(timestamp, auth.max_skew())?;
 
-    let message = format!("{ts}.{actor_value}.{method}");
-    verify_signature(&auth.secret, message.as_bytes(), sig)?;
+    let message = build_message(
+        ts.as_bytes(),
+        actor_value.as_bytes(),
+        nonce,
+        method.as_bytes(),
+    );
+    verify_signature(&auth.secret, &message, sig)?;
+
+    auth.replay.remember(sig, timestamp, auth.max_skew())?;
 
     Ok(AuthContext::from_hmac(actor, timestamp))
+}
+
+/// `{ts}.{actor}.{tail}`, or `{ts}.{actor}.{nonce}.{tail}` when a nonce is sent.
+///
+/// The nonce sits INSIDE the signed bytes on purpose. A stripped nonce header
+/// makes the server rebuild the shorter form, which no longer matches the
+/// signature — so an attacker cannot downgrade a nonce-bearing request into a
+/// replayable one.
+fn build_message(ts: &[u8], actor: &[u8], nonce: Option<&str>, tail: &[u8]) -> Vec<u8> {
+    let nonce_len = nonce.map_or(0, |n| n.len() + 1);
+    let mut message = Vec::with_capacity(ts.len() + actor.len() + 2 + nonce_len + tail.len());
+    message.extend_from_slice(ts);
+    message.push(b'.');
+    message.extend_from_slice(actor);
+    message.push(b'.');
+    if let Some(nonce) = nonce {
+        message.extend_from_slice(nonce.as_bytes());
+        message.push(b'.');
+    }
+    message.extend_from_slice(tail);
+    message
 }
 
 fn header_value<'a>(headers: &'a HeaderMap, name: &'static str) -> Result<&'a str, AuthError> {
@@ -226,16 +346,20 @@ fn header_value<'a>(headers: &'a HeaderMap, name: &'static str) -> Result<&'a st
         .ok_or(AuthError::MissingHeader(name))
 }
 
+fn unix_now() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64
+}
+
 fn parse_timestamp(ts: &str) -> Result<i64, AuthError> {
     ts.parse::<i64>()
         .map_err(|_| AuthError::InvalidHeader(HEADER_TIMESTAMP))
 }
 
 fn ensure_skew(timestamp: i64, max_skew: Duration) -> Result<(), AuthError> {
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs() as i64;
+    let now = unix_now();
     let skew = (now - timestamp).unsigned_abs();
     if skew > max_skew.as_secs() {
         return Err(AuthError::Skew);
@@ -574,6 +698,117 @@ pub fn authorize_grpc_operation<T>(
 
 #[cfg(test)]
 mod tests {
+
+    // ── replay protection (#1631) ──────────────────────────────────────────
+
+    fn hdrs(ts: &str, sig: &str, nonce: Option<&str>) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        h.insert(HEADER_TIMESTAMP, ts.parse().unwrap());
+        h.insert(HEADER_SIGNATURE, sig.parse().unwrap());
+        h.insert(HEADER_ACTOR, "tester".parse().unwrap());
+        if let Some(n) = nonce {
+            h.insert(HEADER_NONCE, n.parse().unwrap());
+        }
+        h
+    }
+
+    fn signed(secret: &[u8], ts: i64, nonce: Option<&str>, body: &[u8]) -> HeaderMap {
+        let ts = ts.to_string();
+        let msg = build_message(ts.as_bytes(), b"tester", nonce, body);
+        hdrs(&ts, &sign_message(secret, &msg), nonce)
+    }
+
+    #[test]
+    fn an_identical_request_replayed_inside_the_window_is_refused() {
+        let secret = b"s3cret";
+        let auth = AuthConfig::new(secret, Duration::from_secs(30));
+        let body = b"{\"kind\":\"Pod\"}";
+        let h = signed(secret, unix_now(), None, body);
+
+        // Non-vacuity: the FIRST send must succeed, or "refused" below would be
+        // proving nothing more than that the request was malformed.
+        assert!(verify_http(&h, body, &auth).is_ok(), "first send must pass");
+        assert!(matches!(
+            verify_http(&h, body, &auth),
+            Err(AuthError::Replay)
+        ));
+    }
+
+    #[test]
+    fn a_nonce_lets_an_otherwise_identical_request_repeat() {
+        let secret = b"s3cret";
+        let auth = AuthConfig::new(secret, Duration::from_secs(30));
+        let body = b"{}";
+        let ts = unix_now();
+        // Same timestamp, same actor, same body — only the nonce differs.
+        assert!(verify_http(&signed(secret, ts, Some("n1"), body), body, &auth).is_ok());
+        assert!(verify_http(&signed(secret, ts, Some("n2"), body), body, &auth).is_ok());
+    }
+
+    #[test]
+    fn stripping_the_nonce_header_does_not_downgrade_the_request() {
+        let secret = b"s3cret";
+        let auth = AuthConfig::new(secret, Duration::from_secs(30));
+        let body = b"{}";
+        let ts = unix_now().to_string();
+        let msg = build_message(ts.as_bytes(), b"tester", Some("n1"), body);
+        let sig = sign_message(secret, &msg);
+        // Signature made over the nonce-bearing message, nonce header removed.
+        let stripped = hdrs(&ts, &sig, None);
+        assert!(matches!(
+            verify_http(&stripped, body, &auth),
+            Err(AuthError::InvalidSignature)
+        ));
+    }
+
+    #[test]
+    fn a_full_cache_refuses_rather_than_evicting_a_live_entry() {
+        let secret = b"s3cret";
+        let auth = AuthConfig::new(secret, Duration::from_secs(30)).with_replay_capacity(2);
+        let body = b"{}";
+        let ts = unix_now();
+        assert!(verify_http(&signed(secret, ts, Some("a"), body), body, &auth).is_ok());
+        let victim = signed(secret, ts, Some("b"), body);
+        assert!(verify_http(&victim, body, &auth).is_ok());
+
+        // Cache is now full of LIVE entries. A plain LRU would evict "a" here,
+        // which is precisely how a flood would make room to replay it.
+        assert!(matches!(
+            verify_http(&signed(secret, ts, Some("c"), body), body, &auth),
+            Err(AuthError::ReplayCapacity)
+        ));
+        // And the entry a flood would have evicted is still remembered.
+        assert!(matches!(
+            verify_http(&victim, body, &auth),
+            Err(AuthError::Replay)
+        ));
+    }
+
+    #[test]
+    fn expired_entries_are_dropped_because_skew_already_refuses_them() {
+        let cache = ReplayCache::new(8);
+        let window = Duration::from_secs(30);
+        // An entry older than the window can never be replayed: ensure_skew
+        // rejects its timestamp before the cache is consulted.
+        cache.remember("old", unix_now() - 600, window).unwrap();
+        assert_eq!(cache.len(), 1);
+        cache.remember("fresh", unix_now(), window).unwrap();
+        assert_eq!(cache.len(), 1, "the expired entry should have been pruned");
+    }
+
+    #[test]
+    fn an_unsigned_request_never_reaches_the_cache() {
+        let secret = b"s3cret";
+        let auth = AuthConfig::new(secret, Duration::from_secs(30)).with_replay_capacity(1);
+        let body = b"{}";
+        let ts = unix_now().to_string();
+        // Garbage signature: if this were remembered, one anonymous request
+        // would fill a capacity-1 cache and lock out every real caller.
+        let bogus = hdrs(&ts, &"ab".repeat(32), None);
+        assert!(verify_http(&bogus, body, &auth).is_err());
+        assert!(verify_http(&signed(secret, unix_now(), None, body), body, &auth).is_ok());
+    }
+
     use super::*;
 
     #[test]

--- a/crates/nucleus-node/src/main.rs
+++ b/crates/nucleus-node/src/main.rs
@@ -577,6 +577,9 @@ impl IntoResponse for ApiError {
             ApiError::Io(_) => StatusCode::INTERNAL_SERVER_ERROR,
             ApiError::Serde(_) => StatusCode::BAD_REQUEST,
             ApiError::Driver(_) => StatusCode::BAD_REQUEST,
+            // Capacity is a server condition, not a credential problem: the
+            // caller should retry, not re-authenticate.
+            ApiError::Auth(AuthError::ReplayCapacity) => StatusCode::SERVICE_UNAVAILABLE,
             ApiError::Auth(_) => StatusCode::UNAUTHORIZED,
             ApiError::Body(_) => StatusCode::BAD_REQUEST,
         };


### PR DESCRIPTION
Closes #1631 (HIGH-3) — the last open child of #1625 (Tier 1).

## The hole

The node accepted any correctly-signed request whose timestamp was inside the skew window. Nothing remembered that a signature had already been used, so a captured request could be replayed verbatim for the full 30 s.

## The key is the signature, not a composite

A replay is byte-identical to the original, so it reproduces the identical signature and collides. A *legitimate* repeat carrying a fresh `x-nucleus-nonce` signs different bytes, so it doesn't. One key covers both — and a client that sends no nonce still gets protection: it merely can't repeat a byte-identical request inside the window, which is indistinguishable from a replay anyway.

The nonce is bound **inside** the signed message rather than sent alongside it, so it can't be stripped — removing the header changes the message the server reconstructs and the signature stops verifying. There's a test for that downgrade specifically.

## Why this isn't the "bounded LRU" the issue asked for

An LRU evicts the oldest entry to make room. That reopens the hole: flood with fresh signatures, push a captured signature out while its timestamp is *still inside the acceptance window*, replay it. **The eviction boundary is the attack.**

This credits the point [raised on the issue](https://github.com/coproduct-opensource/nucleus/issues/1631) — eviction and expiry must share one bound.

So an entry is dropped only once it has **expired**, i.e. once `ensure_skew` would refuse its timestamp anyway and replay is already impossible. If the cache is full of still-live entries the request is refused (`503`, retry after the window) rather than making room.

Ordering matters too: the signature is verified **before** anything is remembered. Remembering unverified signatures would let an anonymous flood fill the cache and trip that refusal — turning a replay defence into a DoS. Tested.

## Compatibility

`build_message` with no nonce emits bytes **identical** to the previous format, so every existing signer keeps verifying — confirmed by the 11 pre-existing auth tests passing untouched. `nucleus-client` now always sends a nonce, since polling the same endpoint twice in one second is normal and would otherwise look like a replay.

`nucleus_client::verify_signature` gained a `nonce` parameter. Without it the crate would ship a verifier that cannot verify what its own signer produces — worth the signature change.

## Verification

6 new tests, mutation-tested rather than assumed:

| mutation | result |
|---|---|
| baseline | 17 pass |
| drop the replay check entirely | **2 fail** |
| swap fail-closed refusal for a plain LRU | **eviction test fails** |
| restored | 17 pass |

The replay test asserts the **first** send succeeds before asserting the second is refused, so it can't pass vacuously on a malformed request.

`cargo test -p nucleus-client -p nucleus-node`: 36 + 369 pass. Clippy and rustfmt clean on both crates.