### PR TITLE
fix(cli): setup plants its own canary, and stops blaming the pod for not booting

### DIFF
--- a/crates/nucleus-cli/src/provision.rs
+++ b/crates/nucleus-cli/src/provision.rs
@@ -536,7 +536,17 @@ fn install_binary(host: &Tier2Host, local: &Path, name: &str, bin: &str) -> Resu
 /// reads `NUCLEUS_NODE_LISTEN`), `NUCLEUS_NODE_GRPC_ADDR` (it reads
 /// `NUCLEUS_NODE_GRPC_LISTEN`), and `NUCLEUS_NODE_ARTIFACTS_DIR`, which nothing
 /// reads at all.
-pub fn node_env_body(auth_hex: &str, proxy_hex: &str, approval_hex: &str) -> String {
+/// `canary_hex` is a throwaway value planted so `verify --tier2` has a real
+/// node-held secret to hunt for in the guest. Without one the leak sweep has
+/// nothing to look for and refuses to run — which is correct, but made the check
+/// reachable only from CI, since CI was the only thing that planted a canary.
+/// See #2372.
+pub fn node_env_body(
+    auth_hex: &str,
+    proxy_hex: &str,
+    approval_hex: &str,
+    canary_hex: &str,
+) -> String {
     format!(
         "# Written by `nucleus setup`. Contains HMAC secrets - keep mode 0600.\n\
          NUCLEUS_NODE_LISTEN=0.0.0.0:8080\n\
@@ -548,6 +558,7 @@ pub fn node_env_body(auth_hex: &str, proxy_hex: &str, approval_hex: &str) -> Str
          NUCLEUS_IDENTITY_WORKLOAD_API_SOCKET={WORKLOAD_API_SOCKET}\n\
          NUCLEUS_FIRECRACKER_PATH=/usr/local/bin/firecracker\n\
          NUCLEUS_JAILER_PATH=/usr/local/bin/jailer\n\
+         NUCLEUS_E2E_CANARY=nucleus-e2e-canary-{canary_hex}\n\
          RUST_LOG=info\n"
     )
 }
@@ -609,7 +620,7 @@ mod tests {
     /// attributes.
     #[test]
     fn node_env_uses_the_names_the_node_reads() {
-        let body = node_env_body("aa", "bb", "cc");
+        let body = node_env_body("aa", "bb", "cc", "dd");
         for required in [
             "NUCLEUS_NODE_LISTEN=",
             "NUCLEUS_NODE_GRPC_LISTEN=",
@@ -627,7 +638,7 @@ mod tests {
     /// startup with a message about a missing secret.
     #[test]
     fn node_env_does_not_use_the_names_that_never_worked() {
-        let body = node_env_body("aa", "bb", "cc");
+        let body = node_env_body("aa", "bb", "cc", "dd");
         for wrong in [
             "NUCLEUS_NODE_LISTEN_ADDR",
             "NUCLEUS_NODE_GRPC_ADDR",
@@ -645,7 +656,7 @@ mod tests {
     /// so a partial env file is a node that never comes up.
     #[test]
     fn every_required_secret_reaches_the_env_file() {
-        let body = node_env_body("1111", "2222", "3333");
+        let body = node_env_body("1111", "2222", "3333", "4444");
         assert!(body.contains("NUCLEUS_NODE_AUTH_SECRET=1111"));
         assert!(body.contains("NUCLEUS_NODE_PROXY_AUTH_SECRET=2222"));
         assert!(body.contains("NUCLEUS_NODE_PROXY_APPROVAL_SECRET=3333"));
@@ -663,7 +674,48 @@ mod tests {
     #[test]
     fn artifact_paths_are_guest_absolute_not_host_relative() {
         assert!(HOST_ARTIFACTS_DIR.starts_with('/'));
-        assert!(node_env_body("a", "b", "c").contains(HOST_STATE_DIR));
+        assert!(node_env_body("a", "b", "c", "d").contains(HOST_STATE_DIR));
+    }
+
+    /// The node env file is WRITTEN here and READ back by
+    /// `verify::resolve_canary` with `grep -m1 '^NUCLEUS_E2E_CANARY=' | cut -d= -f2-`.
+    /// Those are two different languages in two different files, so this pins
+    /// the contract: parse the generated body exactly the way the shell does and
+    /// require the planted value to come back out.
+    #[test]
+    fn the_canary_line_round_trips_through_the_shell_parse() {
+        let body = node_env_body("aa", "bb", "cc", "deadbeef");
+
+        let parsed = body
+            .lines()
+            .find(|l| l.starts_with("NUCLEUS_E2E_CANARY="))
+            .and_then(|l| l.split_once('=').map(|(_, v)| v))
+            .unwrap_or_default();
+
+        assert!(
+            parsed.contains("deadbeef"),
+            "the canary must survive the grep/cut the verifier uses; got {parsed:?}"
+        );
+        // One `=` only. A value containing '=' would be truncated by `cut -d=
+        // -f2` without `-f2-`, and would fail here first.
+        assert_eq!(parsed.matches('=').count(), 0);
+    }
+
+    /// A canary equal to a real secret would make a genuine credential leak
+    /// indistinguishable from the decoy, and vice versa.
+    #[test]
+    fn the_canary_is_not_any_of_the_real_secrets() {
+        let body = node_env_body("aaaa", "bbbb", "cccc", "dddd");
+        let canary = body
+            .lines()
+            .find(|l| l.starts_with("NUCLEUS_E2E_CANARY="))
+            .unwrap();
+        for secret in ["aaaa", "bbbb", "cccc"] {
+            assert!(
+                !canary.contains(secret),
+                "canary line must not carry a real secret value"
+            );
+        }
     }
 
     /// The bug this pins: `install_binary` stages a release tarball at

--- a/crates/nucleus-cli/src/setup.rs
+++ b/crates/nucleus-cli/src/setup.rs
@@ -248,8 +248,12 @@ pub async fn execute(args: SetupArgs) -> Result<()> {
     if let (Some(host), false) = (host, args.skip_verify) {
         if let Err(e) = crate::verify::verify_tier2(&host, &args.vm_name) {
             print_setup_summary(&args, &platform, false);
+            // Do NOT name a cause here. This runs for ANY verification failure,
+            // and asserting "the pod could not boot" was wrong on a run where the
+            // pod booted in 2.7 s and passed 16 checks before a later assertion
+            // refused (#2372). `{e}` already says what actually failed.
             bail!(
-                "setup finished, but a nucleus pod could not boot — Tier 2 is not usable yet.\n\
+                "setup finished, but Tier 2 verification did not pass.\n\
                  {e}\n\
                  Re-run the check on its own with: nucleus verify --tier2\n\
                  To skip it: nucleus setup --skip-verify"
@@ -684,7 +688,14 @@ fn provision_tier2_host(args: &SetupArgs, platform: &Platform) -> Result<()> {
     let auth = secret_hex(SecretKind::NodeAuthSecret)?;
     let proxy = secret_hex(SecretKind::ProxyAuthSecret)?;
     let approval = secret_hex(SecretKind::ApprovalSecret)?;
-    provision::install_node_service(&host, &provision::node_env_body(&auth, &proxy, &approval))?;
+    // A fresh canary per setup. It is not a stored secret: it exists only so the
+    // guest leak sweep has something real to fail to find, and rotating it every
+    // run means a value that DID leak once cannot keep passing later (#2372).
+    let canary = hex::encode(rand::random::<[u8; 16]>());
+    provision::install_node_service(
+        &host,
+        &provision::node_env_body(&auth, &proxy, &approval, &canary),
+    )?;
 
     Ok(())
 }

--- a/crates/nucleus-cli/src/verify.rs
+++ b/crates/nucleus-cli/src/verify.rs
@@ -40,7 +40,7 @@ use nucleus_client::sign_http_headers;
 use std::process::Command;
 use std::time::{Duration, Instant};
 
-use crate::provision::{Tier2Host, HOST_ARTIFACTS_DIR, HOST_STATE_DIR};
+use crate::provision::{Tier2Host, HOST_ARTIFACTS_DIR, HOST_STATE_DIR, NODE_ENV_PATH};
 
 /// Verify that Tier 2 actually works on this machine.
 #[derive(Args, Debug)]
@@ -777,16 +777,7 @@ fn check_art12_witnessed(host: &Tier2Host, pod: &Pod) -> Result<()> {
 /// A test that printed the secret into a CI log to prove the secret does not
 /// leak would be self-defeating.
 fn check_credential_absent_from_guest(host: &Tier2Host, pod: &Pod) -> Result<()> {
-    let canary = std::env::var("NUCLEUS_E2E_CANARY").unwrap_or_default();
-    if canary.is_empty() {
-        // Refuse rather than skip. A silent skip is how this check would rot
-        // into a no-op that still prints reassuringly.
-        bail!(
-            "NUCLEUS_E2E_CANARY is not set in this process, so there is no secret to \
-             look for and the absence assertion below would be trivially true. The CI \
-             job must export the same value it wrote into /etc/nucleus/node.env."
-        );
-    }
+    let canary = resolve_canary(host)?;
 
     let log = format!("{HOST_STATE_DIR}/pods/{}/firecracker.log", pod.id);
     let contents = host.sh(&format!("cat {log}"))?;
@@ -795,6 +786,50 @@ fn check_credential_absent_from_guest(host: &Tier2Host, pod: &Pod) -> Result<()>
         "  [OK] no node-held secret surfaced in the guest (sweep read its sites; canary absent)"
     );
     Ok(())
+}
+
+/// Find the node-held secret this check hunts for.
+///
+/// Two sources, process environment first:
+///
+/// * `NUCLEUS_E2E_CANARY` in this process — how CI supplies it.
+/// * `NUCLEUS_E2E_CANARY` in the node's own environment file — how a local
+///   `nucleus setup` supplies it, since setup writes that file.
+///
+/// The file is the better source of the two and exists for a reason beyond
+/// convenience: it is what the node ACTUALLY holds. A process variable that
+/// disagreed with the node's environment would make the sweep hunt for a value
+/// no one is holding, and "not found" would be trivially true again.
+///
+/// It also fixes the reachability bug in #2372. Only CI ever planted a canary,
+/// so on a local `nucleus setup` this check could never run — and its refusal
+/// was reported as the pod having failed to boot.
+///
+/// Still refuses when neither source yields a value. A silent skip is how this
+/// check would rot into a no-op that still prints reassuringly.
+fn resolve_canary(host: &Tier2Host) -> Result<String> {
+    if let Ok(v) = std::env::var("NUCLEUS_E2E_CANARY") {
+        if !v.is_empty() {
+            return Ok(v);
+        }
+    }
+
+    // `|| true` because grep exits 1 on no match, and "the file has no canary"
+    // must reach the error below rather than surface as a shell failure.
+    let script = format!(
+        "grep -m1 '^NUCLEUS_E2E_CANARY=' {NODE_ENV_PATH} 2>/dev/null | cut -d= -f2- || true"
+    );
+    let from_file = host.sh(&script).unwrap_or_default().trim().to_string();
+    if !from_file.is_empty() {
+        return Ok(from_file);
+    }
+
+    bail!(
+        "no NUCLEUS_E2E_CANARY in this process or in {NODE_ENV_PATH}, so there is no \
+         node-held secret to look for and the absence assertion below would be \
+         trivially true. `nucleus setup` plants one; a CI job may instead export the \
+         same value it wrote into {NODE_ENV_PATH}."
+    );
 }
 
 /// The decision, separated from the pod so it can be RUN rather than reasoned


### PR DESCRIPTION
Closes #2372.

`nucleus setup` on a clean macOS host exited 1 with **"a nucleus pod could not boot — Tier 2 is not usable yet."** The pod booted in **2709 ms** and passed **16 checks**, including every substantive Tier 2 assertion. Two separate defects.

## 1. The leak check was reachable only from CI

`check_credential_absent_from_guest` hunts for a node-held secret inside the guest. It **refuses rather than skips** when there's no canary, and that refusal is correct — "the canary was not found" is trivially true when there is no canary. Its own comment says why: *"a silent skip is how this check would rot into a no-op that still prints reassuringly."*

But the canary was planted only by `quickstart-boot.yml`. Nothing planted one on a local `nucleus setup`, so the check could **never run outside CI** — and its refusal surfaced as a boot failure.

Setup now plants one itself: `node_env_body` gains a freshly-randomised `NUCLEUS_E2E_CANARY` line in the same mode-0600 `/etc/nucleus/node.env` the CI step appends to.

`resolve_canary` reads the process environment first (how CI supplies it), then falls back to that file. **The file is the better source, not just a convenience** — it's what the node *actually holds*. A process variable that disagreed with the node's environment would send the sweep hunting for a value nobody holds, and "not found" would be trivially true all over again.

Rotating per run also means a value that leaked once can't keep passing later.

Deliberately **not** routed through `std::env::set_var`: `verify_tier2` re-invokes the CLI *inside* the Lima VM, so a variable set in the workstation process wouldn't survive the hop — and edition 2024 (#2360) makes env mutation `unsafe` anyway.

## 2. The verdict contradicted the evidence directly above it

The bail fires for **any** verification failure but named one cause. On the run in the issue it asserted the pod could not boot, printed directly beneath sixteen `[OK]` lines proving it had. To a new user that reads as "nucleus does not work on my Mac."

It now says verification did not pass and lets `{e}` name the actual failure.

## Verification

Two contract tests, because this file is **written** in `provision.rs` and **read back** by a shell `grep | cut` in `verify.rs` — two languages in two files, free to drift:

- parse the generated body exactly the way the shell does and require the planted value back out, including that it carries no `=` that `cut -d= -f2` would truncate;
- the canary is none of the three real secrets — otherwise a genuine credential leak and the decoy would be indistinguishable.

| | result |
|---|---|
| baseline | 157 pass |
| rename the written key to `NUCLEUS_E2E_CANARY_X` | **both fail** |
| restored | 157 pass |

Clippy and rustfmt clean.

## Not addressed here

The issue also notes the v2.2.0 binary reports `nucleus 1.0.0` for `--version`, because `[workspace.package] version` was never bumped past 1.0.0. That's a separate change with release-wide blast radius — left for its own PR.