### PR TITLE
fix(release): the floating major tag must not trigger a release of itself

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,21 @@ name: Release
 on:
   push:
     tags:
-      - "v*"
+      # `v*.*.*`, NOT `v*`. This workflow MOVES the floating major tag `v2` as
+      # its last step, and a ref update is a tag push -- so `v*` made the
+      # workflow trigger ITSELF on `v2`, build every asset again, and publish a
+      # second GitHub Release literally named "v2".
+      #
+      # That release is created after the real one, so it becomes "Latest", and
+      # `/releases/latest` is exactly what scripts/install.sh resolves. The
+      # one-liner would install a release named after a floating pointer instead
+      # of the version, and the real v2.2.0 would stop being Latest.
+      #
+      # It had never happened before only because the `git push origin v2` that
+      # moved the tag ALWAYS FAILED on a token permission (see the floating-tag
+      # step below). Fixing that push is what made this reachable: the bug was
+      # masked by a different bug. Observed 2026-09-02, cleaned up by hand.
+      - "v*.*.*"
       - "nucleus-node-v*"
   # DRY RUN. Five of the last seven release attempts failed, because every job
   # below runs ONLY when a tag is pushed — so they rot between releases and the

--- a/ci/release-builds-rootfs-inputs.sh
+++ b/ci/release-builds-rootfs-inputs.sh
@@ -90,5 +90,26 @@ elif printf %s "$float_step" | grep -qE '^[^#]*git push'; then
   fail=1
 fi
 
+# The tag trigger must NOT match the floating major tag this workflow moves.
+# `v*` matches `v2`, so the workflow triggers itself on the tag it just moved,
+# rebuilds everything, and publishes a Release named "v2" that becomes Latest --
+# which is what scripts/install.sh resolves. Observed 2026-09-02.
+tag_filters=$(awk '
+  /^  push:/       { in_push = 1; next }
+  in_push && /^  [a-z_-]+:/ { exit }
+  in_push && /^      - "/   { print }
+' "$RELEASE_YML")
+
+if [ -z "$tag_filters" ]; then
+  echo "::error::$RELEASE_YML has no push tag filters; cannot tell what triggers a release."
+  fail=1
+elif printf %s "$tag_filters" | grep -qE '^\s*- "v\*"\s*$'; then
+  echo "::error::$RELEASE_YML triggers on the bare glob \"v*\", which matches the"
+  echo "  floating major tag (v2) that this workflow moves itself. That publishes a"
+  echo "  second Release named after the floating tag, and it becomes Latest."
+  echo "  Use \"v*.*.*\" so only versioned tags cut a release."
+  fail=1
+fi
+
 [ "$fail" -eq 0 ] && echo "ok: release.yml builds and uploads all $n rootfs inputs"
 exit $fail


### PR DESCRIPTION
`release.yml` triggered on `v*`. Its **last step moves the floating major tag `v2`** — and a ref update *is* a tag push. So the workflow triggered itself on `v2`, rebuilt every asset, and published a second GitHub Release literally named **"v2"**.

That release is created after the real one, so GitHub marks it **Latest**. And `/releases/latest` is exactly what `scripts/install.sh` resolves — so the one-liner would install a release named after a floating pointer, and the actual v2.2.0 would stop being Latest.

## Why this never bit before, and why it does now

The `git push origin v2 --force` that moved the tag **always failed** on a token permission (`GITHUB_TOKEN` can't push a ref whose `.github/workflows/` differs from a branch tip). So the tag never moved, no `v2` push event ever fired, and no `v2` release was ever created.

**#2370 fixed that push** — moving the tag through the refs API instead. Fixing it is what made this reachable. The bug was masked by a different bug, and repairing the first exposed the second on the very next release.

## Observed, not theorised

Moving `v2` to the v2.2.0 commit produced run `33673340564`: a full 35-minute build and a `v2` release holding 26 assets that displaced v2.2.0 as Latest.

Already cleaned up by hand — the spurious release is deleted, `v2.2.0` is Latest again, and `/releases/latest` resolves to it with both rootfs assets. The **`v2` tag itself was preserved** at `8a452030`, since consumers pin `coproduct-opensource/nucleus@v2` for the composite Action.

## The fix

`v*` → `v*.*.*`. Verified against real tag shapes rather than by reading the glob:

| tag | matches `v*.*.*` | |
|---|---|---|
| `v2.2.0` | yes | still releases |
| `v2.1.0-rc.1` | yes | still releases |
| `v10.0.1` | yes | still releases |
| `v2` | **no** | floating tag, no longer self-triggers |
| `v3` | **no** | |
| `v2.2` | **no** | |

`release-builds-rootfs-inputs.sh` now fails if the bare `v*` glob returns, or if the push tag filters disappear entirely.

| mutation | result |
|---|---|
| baseline | exit 0 |
| revert trigger to `v*` | **exit 1** |
| restored | exit 0 |

`actionlint` and `shellcheck` clean.