### PR TITLE
fix(guest): the SVID belongs on tmpfs, so a read-only rootfs can actually boot

### DIFF
--- a/crates/nucleus-cli/src/config.rs
+++ b/crates/nucleus-cli/src/config.rs
@@ -224,7 +224,13 @@ impl Default for FirecrackerConfig {
         Self {
             kernel_path: default_kernel_path(),
             rootfs_path: default_rootfs_path(),
-            scratch_path: Some(default_scratch_path()),
+            // None, not "scratch.ext4". `nucleus setup` installs only vmlinux
+            // and rootfs.ext4 into the artifacts dir, and nothing in the CLI
+            // reads this value -- `scratch_path()` has no callers. Naming a
+            // file that is never created and never used sent a user hunting for
+            // a scratch disk to explain why a read-only pod would not boot
+            // (#2373); the real cause was the SVID write path, now on tmpfs.
+            scratch_path: None,
             vsock_cid: default_vsock_cid(),
             vsock_port: default_vsock_port(),
             rootfs_read_only: true,
@@ -237,9 +243,6 @@ fn default_kernel_path() -> String {
 }
 fn default_rootfs_path() -> String {
     "rootfs.ext4".to_string()
-}
-fn default_scratch_path() -> String {
-    "scratch.ext4".to_string()
 }
 fn default_vsock_cid() -> u32 {
     3
@@ -376,6 +379,47 @@ pub fn show(config_path: &str) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
+
+    /// Every artifact the default config NAMES must be one `nucleus setup`
+    /// actually installs.
+    ///
+    /// The default used to name `scratch.ext4`, which setup never creates and
+    /// no code reads. A user debugging why a `read_only: true` pod would not
+    /// boot found that line and reasonably concluded a missing scratch disk was
+    /// the cause (#2373). It was not — the SVID write path was — but the config
+    /// had pointed at a file that does not exist.
+    #[test]
+    fn the_default_config_names_only_artifacts_setup_installs() {
+        // What provision::install_tier2_artifacts puts in the artifacts dir.
+        const INSTALLED: &[&str] = &["vmlinux", "rootfs.ext4"];
+        let fc = FirecrackerConfig::default();
+
+        let mut named = vec![fc.kernel_path.clone(), fc.rootfs_path.clone()];
+        named.extend(fc.scratch_path.clone());
+
+        for path in &named {
+            assert!(
+                INSTALLED.contains(&path.as_str()),
+                "default config names {path:?}, which `nucleus setup` does not install"
+            );
+        }
+
+        // Non-vacuity: the check must reject the value that caused the confusion,
+        // or it would pass for any string.
+        assert!(
+            !INSTALLED.contains(&"scratch.ext4"),
+            "this test proves nothing if scratch.ext4 counts as installed"
+        );
+    }
+
+    /// The read-only default is deliberate and must stay true: it is the whole
+    /// security posture the config advertises as "recommended", and #2373 was
+    /// fixed by making it WORK (SVID on tmpfs), not by weakening it.
+    #[test]
+    fn the_rootfs_read_only_default_stays_on() {
+        assert!(FirecrackerConfig::default().rootfs_read_only);
+    }
+
     use super::*;
 
     /// The defect this pins: `setup` wrote `~/Library/Application

--- a/crates/nucleus-guest-init/src/identity.rs
+++ b/crates/nucleus-guest-init/src/identity.rs
@@ -16,7 +16,34 @@ pub const DEFAULT_WORKLOAD_API_PORT: u32 = 15012;
 const VMADDR_CID_HOST: u32 = 2;
 
 /// Directory to store identity files.
-const IDENTITY_DIR: &str = "/etc/nucleus/identity";
+/// The SVID lives on a tmpfs, NOT on the rootfs.
+///
+/// # Why not /etc
+///
+/// A pod booted with `spec.image.read_only: true` -- which `nucleus setup`
+/// writes into config.toml as "recommended" and `nucleus run` defaults to --
+/// could not boot at all: the guest died here with
+/// `failed to write certificate: Read-only file system (os error 30)` (#2373).
+///
+/// Weakening the default was the wrong repair. A per-boot credential is
+/// **runtime state**, not configuration: /etc is for static config that survives
+/// a boot, /run is defined as variable data that must be cleared at boot. The
+/// SVID was in the wrong place, and the read-only rootfs was right to refuse it.
+///
+/// # What this buys beyond booting
+///
+/// `/run` is one of the tmpfs mounts guest-init makes before this runs, so the
+/// private key now lives in guest RAM and never reaches the rootfs block device.
+/// It cannot outlive the microVM or be recovered from a disk image.
+///
+/// This matches the read-only-base + tmpfs-write-layer pattern Firecracker
+/// itself documents for ephemeral guests, scoped to the one directory the guest
+/// actually writes rather than an overlayfs over the whole root.
+///
+/// The confidentiality property is unchanged: it rests on mode-0600 and uid
+/// distinctness (`reject_credential_readable_workload` is a uid check), never on
+/// the path string.
+const IDENTITY_DIR: &str = "/run/nucleus/identity";
 
 /// Response from FETCH_SVID command.
 #[derive(Debug, serde::Deserialize)]
@@ -565,6 +592,68 @@ mod caller_identity_tests {
     fn a_response_without_a_token_is_refused() {
         assert!(
             parse_caller_identity(r#"{"pod_id":"11111111-1111-4111-8111-111111111111"}"#).is_err()
+        );
+    }
+}
+
+#[cfg(test)]
+mod identity_location_tests {
+    use super::IDENTITY_DIR;
+
+    /// Is `dir` inside one of the guest's tmpfs mounts?
+    fn on_a_tmpfs_mount(dir: &str) -> bool {
+        crate::GUEST_MOUNTS
+            .iter()
+            .filter(|m| m.fstype == "tmpfs")
+            .any(|m| dir.starts_with(&format!("{}/", m.target)))
+    }
+
+    /// The bug in #2373: a `read_only: true` rootfs could not boot, because the
+    /// SVID was written to `/etc/nucleus/identity` on the root block device.
+    ///
+    /// Pinning this to a tmpfs mount is what keeps the fix from silently
+    /// reverting. A path under `/etc` compiles and passes every other test in
+    /// this crate; it only fails on a real read-only boot, which no unit test
+    /// performs.
+    #[test]
+    fn the_svid_directory_lives_on_a_tmpfs_mount() {
+        assert!(
+            on_a_tmpfs_mount(IDENTITY_DIR),
+            "IDENTITY_DIR ({IDENTITY_DIR}) is not under any tmpfs mount in \
+             GUEST_MOUNTS, so writing the SVID there fails on a read-only \
+             rootfs — the #2373 boot failure"
+        );
+    }
+
+    /// Non-vacuity for the test above.
+    ///
+    /// If `on_a_tmpfs_mount` returned true for anything, the assertion would
+    /// pass no matter where the SVID went. So require it to REJECT the exact
+    /// location that caused the bug.
+    #[test]
+    fn the_old_location_would_still_be_rejected() {
+        assert!(
+            !on_a_tmpfs_mount("/etc/nucleus/identity"),
+            "the tmpfs check accepts the path that caused #2373, so it proves nothing"
+        );
+    }
+
+    /// `/run` must be mounted BEFORE the SVID is fetched, or the write lands on
+    /// the (read-only) rootfs underneath the future mountpoint.
+    #[test]
+    fn the_identity_mount_is_declared_in_guest_mounts() {
+        let mount = crate::GUEST_MOUNTS
+            .iter()
+            .filter(|m| m.fstype == "tmpfs")
+            .find(|m| IDENTITY_DIR.starts_with(&format!("{}/", m.target)))
+            .expect("no tmpfs mount covers IDENTITY_DIR");
+        // GUEST_MOUNTS is mounted in main() before identity::fetch_identity is
+        // called; this pins the entry that ordering depends on.
+        assert_eq!(mount.fstype, "tmpfs");
+        assert!(
+            mount.nosuid && mount.nodev,
+            "{} must stay hardened",
+            mount.target
         );
     }
 }

--- a/crates/nucleus-guest-init/src/main.rs
+++ b/crates/nucleus-guest-init/src/main.rs
@@ -103,7 +103,7 @@ fn run() -> Result<(), String> {
                 // POINT THE PROXY AT WHAT WE JUST FETCHED.
                 //
                 // Without this the fetch is decorative: `fetch_identity` writes
-                // the SVID to /etc/nucleus/identity, and the tool-proxy looks
+                // the SVID to /run/nucleus/identity, and the tool-proxy looks
                 // for `--identity-cert` / `NUCLEUS_IDENTITY_CERT`, which nobody
                 // set — so the cert existed on disk and Tier 1/2 still reported
                 // "no identity cert" and the guest died as a naked process.


### PR DESCRIPTION
Closes #2373.

A pod with `spec.image.read_only: true` could not boot. The guest died writing its own identity:

```
failed to fetch identity: failed to write certificate: Read-only file system (os error 30)
```

That is the configuration **the shipped product recommends**. `nucleus setup` writes `rootfs_read_only = true` into config.toml under the comment "(recommended)", and `nucleus run` defaults the flag to true. `verify --tier2` uses `read_only: false`, which is why the boot check stayed green while the documented default did not work.

## Not fixed by weakening the default

Flipping `rootfs_read_only` to false would trade a real security property for a green boot. **The read-only rootfs was right to refuse the write — the write was in the wrong place.**

A per-boot credential is *runtime state*, not configuration. `/etc` is for static config that survives a boot; `/run` is defined as variable data cleared at boot. The SVID had been living in `/etc/nucleus/identity`, on the root block device.

```rust
const IDENTITY_DIR: &str = "/run/nucleus/identity";
```

`/run` is already one of the tmpfs mounts guest-init makes, and it's mounted at `main.rs:67` — before `fetch_identity` at `:100` — so nothing else had to move.

This is the read-only-base + tmpfs-write-layer pattern [Firecracker documents for ephemeral guests](https://github.com/firecracker-microvm/firecracker/discussions/3061), scoped to the one directory the guest actually writes rather than an overlayfs over the whole root.

## What it buys beyond booting

The SVID **private key now lives in guest RAM** and never reaches the rootfs block device, so it can't outlive the microVM or be recovered from a disk image.

The confidentiality property is unchanged: it rests on mode-0600 and uid distinctness — `reject_credential_readable_workload` is a uid check — never on the path string. The IFC kernel's mention of the old path is prose in a doc comment; there's no path literal anywhere in that crate.

## The phantom scratch disk

The default config also named `scratch_path = "scratch.ext4"`. `nucleus setup` never creates that file and **nothing reads the value** — `Config::scratch_path()` has no callers. It sent the reporter hunting for a missing scratch disk to explain the boot failure. Defaulted to `None`.

## Verification

Three tests pin the SVID to a tmpfs mount declared in `GUEST_MOUNTS`, because a path under `/etc` compiles and passes every other test in the crate — it only fails on a real read-only boot, which no unit test performs. One of them asserts the check **rejects** the old `/etc` path, so it can't pass vacuously.

Two config tests: every artifact the default config names must be one setup installs, and the read-only default must stay on.

| mutation | result |
|---|---|
| baseline | 11 + 157 pass |
| revert `IDENTITY_DIR` to `/etc/nucleus/identity` | **2 fail** |
| restored | pass |

Clippy and rustfmt clean.

## Requires a new guest release to take effect

`guest-init` ships inside the rootfs, so a pod booted against the v2.2.0 artifacts still has the old path. **`GUEST_RELEASE_FLOOR` is deliberately not raised here** — raising it would refuse the only rootfs that currently exists. It should rise with the release that carries this change.

## Also in the issue, not addressed here

`nucleus node create` discards the node's error body (`node.rs:215`, `:239`), so a 400 shows as `Create pod failed with status 400` while the node had returned a full guest-console diagnosis. `verify.rs:402` already does this correctly and has a comment explaining why. That's a separate, small PR.