### PR TITLE
fix(rootfs): one derived package list, and a missing probe fails the build

### DIFF
--- a/.github/workflows/quickstart-boot.yml
+++ b/.github/workflows/quickstart-boot.yml
@@ -287,10 +287,16 @@ jobs:
           # the target.
           rustup target add x86_64-unknown-linux-musl
           rustup target list --installed | grep -q x86_64-unknown-linux-musl
+          # The rootfs packages are DERIVED, never listed here. This list was
+          # hand-maintained and missing nucleus-podlist-probe, so the rootfs this
+          # job boots silently had no podlist probe in it -- the THIRD copy of the
+          # same drift, after release.yml (#2366) and cross-build.sh (#2377).
+          # One derivation now feeds all three.
+          rootfs_pkgs=$(bash scripts/cross-build.sh --list-packages | sed 's/^/-p /' | tr '\n' ' ')
+          echo "rootfs packages: $rootfs_pkgs"
+          # shellcheck disable=SC2086
           cargo build --release --target x86_64-unknown-linux-musl \
-            -p nucleus-cli -p nucleus-node -p nucleus-guest-init \
-            -p nucleus-tool-proxy -p nucleus-net-probe -p nucleus-workload-probe \
-            -p nucleus-egress-probe -p nucleus-adversary-probe
+            -p nucleus-cli -p nucleus-node $rootfs_pkgs
 
       - name: Build the guest rootfs
         run: |

--- a/ci/release-builds-rootfs-inputs.sh
+++ b/ci/release-builds-rootfs-inputs.sh
@@ -144,5 +144,25 @@ elif printf %s "$tag_filters" | grep -qE '^\s*- "v\*"\s*$'; then
   fail=1
 fi
 
+# Third consumer: quickstart-boot.yml builds the guest binaries for the rootfs it
+# boots. Its list was ALSO hand-maintained and ALSO missing one -- podlist-probe
+# -- so the pod CI boots had no podlist probe in it. That is the same drift as
+# release.yml (#2366) and cross-build.sh (#2377), a third time.
+#
+# Accept either shape: derive from cross-build.sh (preferred), or name every
+# needed package literally. What is not acceptable is naming SOME of them.
+QUICKSTART_YML=".github/workflows/quickstart-boot.yml"
+if [ ! -f "$QUICKSTART_YML" ]; then
+  echo "::error::$QUICKSTART_YML missing; the booted-rootfs path is unchecked"
+  fail=1
+elif grep -q 'cross-build.sh --list-packages' "$QUICKSTART_YML"; then
+  : # derived — cannot drift
+else
+  for bin in $needed; do
+    grep -q -- "-p ${bin}" "$QUICKSTART_YML" \
+      || { echo "::error::$QUICKSTART_YML never builds ${bin}, so the rootfs it boots will not contain it"; fail=1; }
+  done
+fi
+
 [ "$fail" -eq 0 ] && echo "ok: release.yml builds and uploads all $n rootfs inputs"
 exit $fail

--- a/ci/release-builds-rootfs-inputs.sh
+++ b/ci/release-builds-rootfs-inputs.sh
@@ -90,5 +90,38 @@ elif printf %s "$float_step" | grep -qE '^[^#]*git push'; then
   fail=1
 fi
 
+# release.yml is not the only consumer of this list. `cross-build.sh` builds the
+# same binaries for a LOCAL rootfs, and build-rootfs.sh points users at it by
+# name when one is missing. It hand-maintained its own array, that array omitted
+# nucleus-adversary-probe, and because build-rootfs.sh copies that probe with a
+# bare `[ -f ]` the local rootfs came out exit-0 with the probe absent (#2377).
+#
+# Asked BEHAVIOURALLY -- run the script and compare what it would build -- rather
+# than by grepping its source, so it keeps working whether the list is derived or
+# literal.
+CROSS_SH="scripts/cross-build.sh"
+if [ ! -f "$CROSS_SH" ]; then
+  echo "::error::$CROSS_SH missing; the local rootfs path is unchecked"
+  fail=1
+elif ! cross_list=$(bash "$CROSS_SH" --list-packages 2>/dev/null); then
+  echo "::error::$CROSS_SH --list-packages failed; cannot tell what a local build produces."
+  echo "  That flag is what makes this check behavioural instead of a grep."
+  fail=1
+else
+  # printf '%s\n', not printf %s: without the trailing newline the last element
+  # has no line terminator, which both mangles the report and can hide an entry
+  # from `comm`.
+  cross_sorted=$(printf '%s\n' "$cross_list" | sort -u)
+  needed_sorted=$(printf '%s\n' "$needed" | sort -u)
+  missing_from_cross=$(comm -23 <(printf '%s\n' "$needed_sorted") <(printf '%s\n' "$cross_sorted"))
+  if [ -n "$missing_from_cross" ]; then
+    echo "::error::$CROSS_SH does not build binaries the rootfs needs:"
+    printf '%s\n' "$missing_from_cross" | sed 's/^/  missing: /'
+    echo "  build-rootfs.sh copies some of these with a bare [ -f ], so the rootfs"
+    echo "  would build successfully and simply not contain them."
+    fail=1
+  fi
+fi
+
 [ "$fail" -eq 0 ] && echo "ok: release.yml builds and uploads all $n rootfs inputs"
 exit $fail

--- a/scripts/cross-build.sh
+++ b/scripts/cross-build.sh
@@ -12,15 +12,50 @@ ARCH="${ARCH:-all}"
 # Use 'cross' tool by default, fall back to 'cargo' if cross isn't available
 USE_CROSS="${USE_CROSS:-auto}"
 
-# Packages to build for rootfs
-ROOTFS_PACKAGES=(
-    "nucleus-guest-init"
-    "nucleus-tool-proxy"
-    "nucleus-net-probe"
-    "nucleus-workload-probe"
-    "nucleus-egress-probe"
-    "nucleus-podlist-probe"
-)
+# Packages to build for the rootfs — DERIVED, never hand-listed.
+#
+# This used to be a literal array, and it was missing nucleus-adversary-probe
+# (#2377). build-rootfs.sh only hard-requires five of the seven binaries and
+# copies the rest with `[ -f ]`, so a rootfs built from the short list came out
+# exit-0 and simply had no adversary probe in it. build-rootfs.sh even points
+# users HERE ("Build with: scripts/cross-build.sh --arch $ARCH") four separate
+# times, so following the instructions produced the broken image.
+#
+# That is #2366 in the local path: release.yml had the same two-lists-in-two-
+# files shape and shipped a v2.1.0 rootfs with no egress probe.
+#
+# So there is now ONE list. build-rootfs.sh's `*_BIN` defaults name every binary
+# the rootfs wants, and both this script and ci/release-builds-rootfs-inputs.sh
+# read that same expression. Adding a probe to build-rootfs.sh is now sufficient;
+# nothing here has to be remembered.
+ROOTFS_SH="$ROOT_DIR/scripts/firecracker/build-rootfs.sh"
+if [ ! -f "$ROOTFS_SH" ]; then
+    echo "cross-build: cannot find $ROOTFS_SH to derive the package list from" >&2
+    exit 1
+fi
+
+# Read into the array with a while-read loop, NOT `mapfile`: mapfile is a bash 4
+# builtin and macOS ships bash 3.2, so `mapfile` would fail on exactly the local
+# build path this issue is about.
+ROOTFS_PACKAGES=()
+while IFS= read -r pkg; do
+    [ -n "$pkg" ] && ROOTFS_PACKAGES+=("$pkg")
+done < <(grep -oE 'release/nucleus-[a-z-]+' "$ROOTFS_SH" | sed 's|release/||' | sort -u)
+
+# Non-vacuity. An empty or tiny list would make this script "succeed" while
+# building nothing — the same silent shape the derivation exists to remove.
+if [ "${#ROOTFS_PACKAGES[@]}" -lt 5 ]; then
+    echo "cross-build: derived only ${#ROOTFS_PACKAGES[@]} package(s) from $ROOTFS_SH;" >&2
+    echo "  the parse is broken rather than the rootfs having shrunk." >&2
+    exit 1
+fi
+
+# `--list-packages` exists so the CI gate can compare what this script WOULD
+# build against what the rootfs needs, rather than pattern-matching the source.
+if [ "${1:-}" = "--list-packages" ]; then
+    printf '%s\n' "${ROOTFS_PACKAGES[@]}"
+    exit 0
+fi
 
 # Targets
 AARCH64_TARGET="aarch64-unknown-linux-musl"

--- a/scripts/firecracker/build-rootfs.sh
+++ b/scripts/firecracker/build-rootfs.sh
@@ -301,6 +301,26 @@ if [ ! -f "$EGRESS_PROBE_BIN" ]; then
     exit 1
 fi
 
+# Hard requirements, not `[ -f ]` copies.
+#
+# These two were copied only if they happened to exist, so a rootfs missing them
+# built successfully and shipped quietly without them (#2377). The CI gate
+# ci/release-builds-rootfs-inputs.sh already treats all seven binaries as needed;
+# this makes the script agree with the gate instead of disagreeing silently.
+#
+# ALLOW_MISSING_PROBES=1 is the deliberate escape hatch for building a stripped
+# image on purpose. Absence should be a choice someone made, not an accident.
+if [ "${ALLOW_MISSING_PROBES:-0}" != "1" ]; then
+    for probe in "$PODLIST_PROBE_BIN" "$ADVERSARY_PROBE_BIN"; do
+        if [ ! -f "$probe" ]; then
+            echo "Missing $probe" >&2
+            echo "Build with: scripts/cross-build.sh --arch $ARCH" >&2
+            echo "  (set ALLOW_MISSING_PROBES=1 to build an image without it on purpose)" >&2
+            exit 1
+        fi
+    done
+fi
+
 if [ ! -f "$POD_SPEC" ]; then
     echo "Missing $POD_SPEC" >&2
     exit 1


### PR DESCRIPTION
Closes #2377.

`cross-build.sh` hand-maintained an array of **six** packages. The rootfs wants **seven**. `nucleus-adversary-probe` was the missing one, and `build-rootfs.sh` copies that probe with a bare `[ -f ]` — so a locally built rootfs came out **exit 0**, printed its "Included binaries" list (also `[ -f ]`-guarded, so it didn't report the absence either), and simply had no adversary probe in it.

`build-rootfs.sh` points users at `cross-build.sh` **by name, four separate times**, when a required binary is missing. Following that instruction produced the broken image.

This is #2366 in the local path: `release.yml` had the identical two-lists-in-two-files shape and shipped a v2.1.0 rootfs with no egress probe.

## One list, derived

Adding the seventh entry would have fixed today and left the shape that caused it. The list is now **derived** from `build-rootfs.sh`'s `*_BIN` defaults — the same expression `ci/release-builds-rootfs-inputs.sh` already used to check `release.yml`. Adding a probe to `build-rootfs.sh` is now sufficient; nothing has to be remembered in a second file.

One trap worth naming: `mapfile` is the obvious way to read that into an array and is **wrong here** — it's a bash 4 builtin and macOS ships bash 3.2, so it would have broken the exact local build path this issue is about. Caught by running it, not by review. Uses a `while read` loop instead.

## The gate now covers the local path

`cross-build.sh --list-packages` prints what it would build, and the gate compares that set against what the rootfs needs. Asked **behaviourally** rather than by grepping the source, so it keeps working whether the list is derived or literal.

## A missing probe now fails

`nucleus-podlist-probe` and `nucleus-adversary-probe` were the only two copied conditionally, which is what let the absence ship. Both are hard requirements now, so the script agrees with the gate that already treated all seven as needed. `ALLOW_MISSING_PROBES=1` remains for a deliberately stripped image — absence should be a choice, not an accident.

## Verified by running it, on real artifacts

| check | result |
|---|---|
| derived list on bash 3.2 | 7 packages, adversary probe included |
| real macOS rootfs build | succeeds; image contains all 7 binaries at `0755` (via `debugfs`, not the script's own output) |
| **falsifier — the exact bug**: delete the adversary probe, build | **exit 1**, naming it. Before this change: exit 0, image shipped without it |
| `ALLOW_MISSING_PROBES=1` in that same state | exit 0 |
| **falsifier — the gate**: restore the old six-item hand-written array | **exit 1**, naming the missing probe |

`shellcheck` clean on all three scripts.