### PR TITLE
test(ifc): replay documented agent incidents, with the utility half that makes it falsifiable

### DIFF
--- a/crates/nucleus-ifc/tests/incident_replay.rs
+++ b/crates/nucleus-ifc/tests/incident_replay.rs
@@ -1,0 +1,263 @@
+//! Documented 2025–2026 LLM-agent incidents, replayed through the real IFC gate.
+//!
+//! Each case is the [`FlowDeclaration`] an agent would have made during a named,
+//! publicly documented incident, run through `FlowDeclaration::decide()`. Nothing
+//! here is a prediction: the expectations are what the gate returns.
+//!
+//! # Why the suite contains cases the gate ALLOWS
+//!
+//! A suite that only contains wins certifies nothing. Three kinds of non-DENY
+//! case are deliberately kept:
+//!
+//! * [`Expect::KnownGap`] — allowed today because of a labeling gap. When the gap
+//!   closes the verdict flips and **this entry fails**, which is the signal
+//!   wanted: a fixed gap should not pass silently as "still allowed".
+//! * [`Expect::OutOfScope`] — allowed and correct. A different control owns the
+//!   incident, and the entry names which one, so the suite cannot be read as
+//!   claiming coverage it does not have.
+//! * [`Expect::Utility`] — an ordinary, legitimate flow that must NOT be blocked.
+//!
+//! That last kind is the one that makes the suite falsifiable. Measuring only
+//! denial rate rates a gate that denies everything as perfect, which is why
+//! AgentDojo pairs utility tasks with security tasks rather than reporting attack
+//! success alone. The gate here is genuinely restrictive — any observed
+//! `WebContent` denies any outbound action, and a bare `UserPrompt` can never
+//! reach a public sink — so without utility cases pinned, an over-broad tightening
+//! would look like an improvement.
+
+#![cfg(feature = "decision")]
+
+use nucleus_ifc::{DeclaredInput as In, FlowDeclaration as Flow};
+
+/// What the suite asserts about a case, and why a non-DENY is acceptable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Expect {
+    /// A documented attack the gate must refuse, and the violation class it must
+    /// refuse it under. The class matters: two independent mechanisms being
+    /// load-bearing is stronger evidence than one over-broad rule.
+    Denied(&'static str),
+    /// Allowed because of a labeling gap, not because the flow is safe.
+    KnownGap,
+    /// Allowed and correct — a different control owns this incident.
+    OutOfScope(&'static str),
+    /// A legitimate flow the gate must not block.
+    Utility,
+}
+
+struct Case {
+    /// CVE or incident name, so a sceptical reader can look it up.
+    id: &'static str,
+    what: &'static str,
+    flow: Flow,
+    expect: Expect,
+}
+
+fn corpus() -> Vec<Case> {
+    vec![
+        // ── attacks the gate refuses ─────────────────────────────────────────
+        Case {
+            id: "CVE-2025-32711 EchoLeak",
+            what: "M365 Copilot zero-click: injected mail drives secret content to a public sink",
+            flow: Flow::new([In::UserPrompt, In::Secret]).public_sink(),
+            expect: Expect::Denied("ConfidentialityViolation"),
+        },
+        Case {
+            id: "CVE-2025-53773",
+            what: "injection in a PR description reaches a privileged action (RCE)",
+            flow: {
+                let mut f = Flow::new([In::UserPrompt, In::WebContent]);
+                f.requires_authority = true;
+                f
+            },
+            expect: Expect::Denied("AdversarialAncestry"),
+        },
+        Case {
+            id: "GitHub MCP (Invariant Labs)",
+            what: "public-repo injection pulls a private token into an outbound flow",
+            flow: Flow::new([In::UserPrompt, In::WebContent, In::Secret]),
+            expect: Expect::Denied("AdversarialAncestry"),
+        },
+        Case {
+            id: "Cursor .cursor/mcp.json",
+            what: "indirect injection from fetched content reaches a privileged action",
+            flow: {
+                let mut f = Flow::new([In::UserPrompt, In::WebContent]);
+                f.requires_authority = true;
+                f
+            },
+            expect: Expect::Denied("AdversarialAncestry"),
+        },
+        // ── allowed, and the reason is recorded ──────────────────────────────
+        Case {
+            id: "CVE-2025-59536",
+            what: "a repo plants a config that executes when the agent opens it",
+            // Encoded exactly like the legitimate `utility: private file` case
+            // below, because to this API they ARE the same declaration: there is
+            // no input class for "file that came from a repository".
+            // `DeclaredInput::FileRead` is documented as *private file contents*,
+            // i.e. trusted. A `RepoFile`/`UntrustedFile` variant with
+            // WebContent-like adversarial integrity is what separates them.
+            flow: Flow::new([In::UserPrompt, In::FileRead]),
+            expect: Expect::KnownGap,
+        },
+        Case {
+            id: "CVE-2026-22708",
+            what: "poisoned environment, but the action itself is policy-allowlisted",
+            flow: Flow::new([In::UserPrompt, In::ToolResponse]),
+            expect: Expect::OutOfScope("policy allowlist design, not the flow gate"),
+        },
+        Case {
+            id: "postmark-mcp",
+            what: "the MCP SERVER BCCs every mail to the attacker; the agent's flow is innocent",
+            flow: Flow::new([In::UserPrompt, In::ToolResponse]),
+            expect: Expect::OutOfScope("mcp-guard TOFU schema pinning"),
+        },
+        // ── utility: legitimate flows that must keep working ─────────────────
+        Case {
+            id: "utility: plain answer",
+            what: "answer the requester from the prompt alone",
+            flow: Flow::new([In::UserPrompt]),
+            expect: Expect::Utility,
+        },
+        Case {
+            id: "utility: database-backed answer",
+            what: "answer the requester using an internal database row",
+            flow: Flow::new([In::UserPrompt, In::DatabaseRow]),
+            expect: Expect::Utility,
+        },
+        Case {
+            id: "utility: private file to its owner",
+            what: "read a private file and answer the authenticated requester",
+            flow: Flow::new([In::UserPrompt, In::FileRead]),
+            expect: Expect::Utility,
+        },
+        Case {
+            id: "utility: ordinary tool call",
+            what: "call a tool and use the response to answer the requester",
+            flow: Flow::new([In::UserPrompt, In::ToolResponse]),
+            expect: Expect::Utility,
+        },
+        Case {
+            id: "utility: memory recall",
+            what: "recall a memory entry and answer the requester",
+            flow: Flow::new([In::UserPrompt, In::MemoryRead]),
+            expect: Expect::Utility,
+        },
+    ]
+}
+
+#[test]
+fn documented_incidents_get_the_verdicts_this_suite_claims() {
+    let mut failures = Vec::new();
+    for case in corpus() {
+        let v = case.flow.decide();
+        let ok = match case.expect {
+            Expect::Denied(class) => !v.allow && v.reason.contains(class),
+            Expect::KnownGap | Expect::OutOfScope(_) | Expect::Utility => v.allow,
+        };
+        if !ok {
+            failures.push(format!(
+                "{}: expected {:?}, got allow={} reason={}\n    ({})",
+                case.id, case.expect, v.allow, v.reason, case.what
+            ));
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "IFC gate verdicts changed:\n  {}\n\nA KnownGap flipping to DENY is GOOD news — \
+         move it to Denied. A Utility flipping to DENY is a regression: the gate got \
+         broader, not better.",
+        failures.join("\n  ")
+    );
+}
+
+/// The suite must contain both halves, or it proves nothing.
+///
+/// Denials alone are satisfied by a gate that denies everything; utility cases
+/// alone are satisfied by a gate that allows everything.
+#[test]
+fn the_suite_measures_both_security_and_utility() {
+    let c = corpus();
+    let denied = c
+        .iter()
+        .filter(|x| matches!(x.expect, Expect::Denied(_)))
+        .count();
+    let utility = c.iter().filter(|x| x.expect == Expect::Utility).count();
+    assert!(
+        denied >= 4,
+        "only {denied} attack cases; the security half is too thin"
+    );
+    assert!(
+        utility >= 4,
+        "only {utility} utility cases; a deny-everything gate would pass"
+    );
+}
+
+/// Two independent mechanisms must be doing the work.
+///
+/// If every denial came from one rule, that rule being over-broad would be
+/// indistinguishable from the gate being correct.
+#[test]
+fn denials_rest_on_more_than_one_mechanism() {
+    let reasons: Vec<String> = corpus()
+        .iter()
+        .filter(|c| matches!(c.expect, Expect::Denied(_)))
+        .map(|c| c.flow.decide().reason)
+        .collect();
+    let confidentiality = reasons
+        .iter()
+        .filter(|r| r.contains("ConfidentialityViolation"))
+        .count();
+    let ancestry = reasons
+        .iter()
+        .filter(|r| r.contains("AdversarialAncestry"))
+        .count();
+    assert!(
+        confidentiality >= 1 && ancestry >= 1,
+        "denials came from a single mechanism (confidentiality={confidentiality}, \
+         ancestry={ancestry}); one over-broad rule would look identical"
+    );
+}
+
+/// A tool response does not, by itself, make an outbound action adversarial.
+///
+/// `DeclaredInput::ToolResponse` is documented as an *untrusted* MCP/tool
+/// response, and in the lattice it is `IntegLevel::Untrusted` — NOT
+/// `Adversarial`, which is what `WebContent` carries and what triggers
+/// `AdversarialAncestry`. So injection arriving through a tool response is not
+/// caught the way injection arriving through fetched web content is.
+///
+/// Pinned as an observation rather than asserted as a defect: "untrusted" (may
+/// be wrong) and "adversarial" (may be attacker-controlled) are a real
+/// distinction, and a tool response from a server the operator chose to trust is
+/// arguably the former. But tool-response injection is the primary vector the
+/// agent-security benchmarks target, so if this label ever changes, that is a
+/// deliberate decision and this test should be updated with it.
+#[test]
+fn a_tool_response_is_untrusted_but_not_adversarial() {
+    let web = Flow::new([In::UserPrompt, In::WebContent]).decide();
+    let tool = Flow::new([In::UserPrompt, In::ToolResponse]).decide();
+    assert!(!web.allow, "web content must be adversarial");
+    assert!(
+        tool.allow,
+        "if a tool response now denies, the label changed — update this test and \
+         the CVE-2026-22708 / postmark-mcp cases, which depend on it"
+    );
+}
+
+/// Prints the table. `cargo test -p nucleus-ifc --features decision --test
+/// incident_replay -- --ignored --nocapture`
+#[test]
+#[ignore = "reporting only"]
+fn print_the_incident_table() {
+    for case in corpus() {
+        let v = case.flow.decide();
+        println!(
+            "{:<34} {:<6} {:<28} {:?}",
+            case.id,
+            if v.allow { "ALLOW" } else { "DENY" },
+            v.reason.chars().take(28).collect::<String>(),
+            case.expect
+        );
+    }
+}


### PR DESCRIPTION
Closes #2383.

Encodes eight publicly documented 2025–2026 LLM-agent incidents as the `FlowDeclaration` an agent would have made, run through the real `decision::FlowDeclaration::decide()`. The table reproduces exactly what the issue reported:

| incident | verdict | mechanism |
|---|---|---|
| CVE-2025-32711 EchoLeak | **DENY** | `ConfidentialityViolation { Secret → Public }` |
| CVE-2025-53773 | **DENY** | `AdversarialAncestry` |
| GitHub MCP (Invariant Labs) | **DENY** | `AdversarialAncestry` |
| Cursor `.cursor/mcp.json` | **DENY** | `AdversarialAncestry` |
| CVE-2025-59536 | ALLOW | **KnownGap** — labeling |
| CVE-2026-22708 | ALLOW | **OutOfScope** — policy allowlist |
| postmark-mcp | ALLOW | **OutOfScope** — mcp-guard TOFU pinning |
| 5 × utility flows | ALLOW | must not be blocked |

## What the issue asked for

**KnownGap** is encoded with the *identical declaration* as the legitimate "private file to its owner" utility case — because to this API they **are** the same declaration. `FileRead` is documented as private file contents; there's no input class for "file that came from a repository". Putting them side by side is the clearest possible statement of what a `RepoFile` variant would buy. When the gap closes the verdict flips and the entry **fails**, which is the wanted signal.

**OutOfScope** entries each name the control that actually owns the incident, so the suite can't be read as claiming coverage it lacks.

## What the issue didn't ask for, and why it's here

**Five utility cases.** Measuring denial rate alone rates a gate that denies everything as perfect. [AgentDojo](https://www.researchgate.net/publication/397198170_AgentDojo_A_Dynamic_Environment_to_Evaluate_Prompt_Injection_Attacks_and_Defenses_for_LLM_Agents) pairs utility tasks with security tasks for exactly this reason — and it matters more than usual here because of the issue's own **Finding 2**: any observed `WebContent` denies any outbound action, and a bare `UserPrompt` can never reach a public sink. This gate is genuinely restrictive, so without utility pinned, an over-broad tightening would read as an improvement.

Two suite-level tests enforce the balance: ≥4 attack cases **and** ≥4 utility cases, and denials must rest on **more than one mechanism** — if every denial came from one rule, that rule being over-broad would be indistinguishable from the gate being correct.

## An observation the replay surfaced

`DeclaredInput::ToolResponse` is documented as an *untrusted* MCP/tool response, but in the lattice it's `IntegLevel::Untrusted` — **not** `Adversarial`, which is what `WebContent` carries and what triggers `AdversarialAncestry`. So injection arriving via a tool response isn't caught the way injection via fetched web content is, and tool-response injection is the primary vector the agent-security benchmarks target.

Pinned as an **observation, not asserted as a defect**: "untrusted" (may be wrong) and "adversarial" (may be attacker-controlled) are a real distinction, and a response from a server the operator chose to trust is arguably the former. The test says plainly what to update if that label changes.

## Verified

**It actually runs in CI** — `ci.yml:449` is `cargo test --all-features --lib --bins --tests`, and `--all-features` enables `decision`. Checked non-vacuously: without the feature the file runs **0** tests, with it **4**.

| mutation | caught by |
|---|---|
| claim EchoLeak is denied for the wrong mechanism | replay test |
| demote the utility cases | "a deny-everything gate would pass" |
| drop the only confidentiality denial | "single mechanism" |

Clippy `--all-features` and rustfmt clean.