### PR TITLE
fix(net): br_netfilter is a declared dependency, checked before any interface exists

### DIFF
--- a/.github/workflows/manifest-guards.yml
+++ b/.github/workflows/manifest-guards.yml
@@ -123,3 +123,9 @@ jobs:
       # entirely, and none of the specs CI boots has one.
       - name: run_netns argv names a program
         run: bash ci/netns-argv-names-a-program.sh
+      # br_netfilter was present by accident on hosts running Docker/containerd.
+      # These templates disable containerd deliberately, which removed the thing
+      # that had been loading it, and every pod with a `network` block began
+      # failing mid-launch on a bare `sysctl: cannot stat` (#2382).
+      - name: br_netfilter is a declared dependency
+        run: bash ci/br-netfilter-is-declared.sh

--- a/ci/br-netfilter-is-declared.sh
+++ b/ci/br-netfilter-is-declared.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# br_netfilter must be a DECLARED dependency, in every VM template and in code.
+#
+# WHY: `net::setup_network` sets net.bridge.bridge-nf-call-iptables, and the
+# /proc/sys/net/bridge tree only exists once br_netfilter is loaded. It used to
+# be present by accident — hosts running Docker/containerd load it for their own
+# bridge networking. The nucleus templates disable containerd deliberately, which
+# removed the thing that had been loading it, and every pod spec with a `network`
+# block began failing mid-launch on a bare `sysctl: cannot stat` (#2382).
+#
+# An undeclared dependency borrowed from whatever else happens to be running is
+# exactly what this gate exists to prevent recurring.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+fail=0
+
+# 1. Every Lima template provisions it, and persists it across a reboot.
+shopt -s nullglob
+templates=(scripts/lima/*.yaml)
+if [ "${#templates[@]}" -lt 2 ]; then
+  echo "::error::found ${#templates[@]} Lima template(s) under scripts/lima; the glob looks broken"
+  exit 1
+fi
+
+for t in "${templates[@]}"; do
+  if ! grep -vE '^\s*#' "$t" | grep -q 'modprobe br_netfilter'; then
+    echo "::error::$t never loads br_netfilter — a pod with a \`network\` block will fail mid-launch"
+    fail=1
+  fi
+  # Non-comment lines only. The first version of this check matched the word
+  # "modules-load.d" in a COMMENT explaining why persistence matters, so deleting
+  # the actual command still passed — a gate satisfied by prose about itself.
+  if ! grep -vE '^\s*#' "$t" | grep -q '/etc/modules-load.d'; then
+    echo "::error::$t loads br_netfilter but does not persist it; a bare modprobe does"
+    echo "  not survive a VM restart, which is how #2382 was rediscovered"
+    fail=1
+  fi
+done
+
+# 2. The code refuses BEFORE building interfaces, rather than failing at the
+#    sysctl with a path and no remedy.
+NET_RS="crates/nucleus-node/src/net.rs"
+[ -f "$NET_RS" ] || { echo "::error::$NET_RS missing"; exit 1; }
+
+if ! grep -q 'ensure_bridge_netfilter()' "$NET_RS"; then
+  echo "::error::$NET_RS has no br_netfilter preflight. Without it the failure"
+  echo "  surfaces from inside a half-built namespace after the veth pair, bridge"
+  echo "  and tap already exist."
+  fail=1
+fi
+
+# The preflight must run BEFORE the first interface is created, or it is not a
+# preflight. `run_ip(` is the first thing setup_network does that builds state.
+order=$(awk '
+  /^pub async fn setup_network/ { in_fn = 1 }
+  in_fn && /ensure_bridge_netfilter\(\)/ { print "preflight " NR; exit }
+  in_fn && /run_ip\(/            { print "interface " NR; exit }
+' "$NET_RS")
+case "$order" in
+  preflight*) ;;
+  *) echo "::error::the br_netfilter preflight does not run before the first interface is built ($order)"
+     fail=1 ;;
+esac
+
+[ "$fail" -eq 0 ] && echo "ok: br_netfilter declared in ${#templates[@]} templates and preflighted in code"
+exit $fail

--- a/crates/nucleus-cli/src/doctor.rs
+++ b/crates/nucleus-cli/src/doctor.rs
@@ -340,6 +340,43 @@ fn check_lima() -> bool {
             },
         );
 
+        // br_netfilter, checked here for the same reason /dev/kvm is: it is a
+        // hard requirement that fails LATE and cryptically. Without it a pod
+        // whose spec has a `network` block dies mid-launch on
+        // `sysctl: cannot stat /proc/sys/net/bridge/...` after the veth pair,
+        // bridge and tap already exist (#2382).
+        //
+        // A warning, not an error: pods with no `network` block never touch
+        // this path, so the VM is genuinely usable without it.
+        let brnf_check = Command::new("limactl")
+            .args([
+                "shell",
+                &vm_name(),
+                "--",
+                "test",
+                "-e",
+                "/proc/sys/net/bridge/bridge-nf-call-iptables",
+            ])
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+
+        print_check(
+            "br_netfilter in VM",
+            if brnf_check {
+                Status::Ok
+            } else {
+                Status::Warning
+            },
+            if brnf_check {
+                "loaded (pods with a network block can be filtered)"
+            } else {
+                "MISSING - a pod spec with a `network` block will fail mid-launch. \
+                 Fix: limactl shell nucleus -- sudo modprobe br_netfilter && \
+                 echo br_netfilter | sudo tee /etc/modules-load.d/nucleus.conf"
+            },
+        );
+
         // Check Firecracker version in VM
         let fc_output = Command::new("limactl")
             .args(["shell", &vm_name(), "--", "firecracker", "--version"])

--- a/crates/nucleus-node/src/net.rs
+++ b/crates/nucleus-node/src/net.rs
@@ -495,6 +495,7 @@ pub async fn setup_network(plan: &NetPlan) -> Result<(), ApiError> {
     ensure_command("ip")?;
     ensure_command("iptables")?;
     ensure_command("sysctl")?;
+    ensure_bridge_netfilter()?;
 
     // Two subnets now, and the split is the whole point:
     //   * the LINK subnet (index-derived) addresses the veth pair, both ends of
@@ -1099,6 +1100,47 @@ fn invalid_entry(entry: &str) -> ApiError {
     ))
 }
 
+/// The file whose existence proves `br_netfilter` is loaded.
+///
+/// `setup_network` sets `net.bridge.bridge-nf-call-iptables`, and the whole
+/// `/proc/sys/net/bridge` tree only appears once the module is in the kernel.
+pub(crate) const BRIDGE_NF_PROBE: &str = "/proc/sys/net/bridge/bridge-nf-call-iptables";
+
+/// What to tell the operator when `br_netfilter` is missing.
+///
+/// Pure and not cfg-gated, so the message is testable on a host with no such
+/// kernel. The message is the point: the raw failure was
+///
+///     sysctl: cannot stat /proc/sys/net/bridge/bridge-nf-call-iptables:
+///     No such file or directory
+///
+/// surfacing mid-launch from inside a half-built namespace, naming a path
+/// instead of the module, and offering no remedy (#2382).
+pub(crate) fn bridge_netfilter_remedy() -> String {
+    format!(
+        "the br_netfilter kernel module is not loaded, so {BRIDGE_NF_PROBE} does not \
+         exist and this pod's bridge cannot be filtered by iptables.\n\
+         Load it now:      sudo modprobe br_netfilter\n\
+         Persist a reboot: echo br_netfilter | sudo tee /etc/modules-load.d/nucleus.conf\n\
+         `nucleus setup` provisions both on the Lima VM; a host provisioned before \
+         that, or any other Linux host, needs them once."
+    )
+}
+
+/// Refuse BEFORE any interface exists.
+///
+/// Checked here rather than at the failing `sysctl` because by then the veth
+/// pair, bridge and tap are already built, and the operator gets a `cannot stat`
+/// from inside a namespace that is about to be torn down. kubeadm makes the same
+/// check a preflight for the same reason.
+#[cfg(target_os = "linux")]
+fn ensure_bridge_netfilter() -> Result<(), ApiError> {
+    if std::path::Path::new(BRIDGE_NF_PROBE).exists() {
+        return Ok(());
+    }
+    Err(ApiError::Driver(bridge_netfilter_remedy()))
+}
+
 #[cfg(target_os = "linux")]
 fn ensure_command(command: &str) -> Result<(), ApiError> {
     let mut cmd = Command::new(command);
@@ -1503,6 +1545,57 @@ mod tests {
             }
             .render(),
             vec!["ip", "route", "add", "default", "via", "10.0.0.1"],
+        );
+    }
+
+    // ── br_netfilter preflight (#2382) ───────────────────────────────────────
+
+    /// The raw failure named a PATH and offered no remedy:
+    ///
+    ///     sysctl: cannot stat /proc/sys/net/bridge/bridge-nf-call-iptables:
+    ///     No such file or directory
+    ///
+    /// An operator reading that has to know that this path implies a kernel
+    /// module, and which one. The message must close that gap itself.
+    #[test]
+    fn the_br_netfilter_message_names_the_module_and_how_to_fix_it() {
+        let m = super::bridge_netfilter_remedy();
+        assert!(
+            m.contains("br_netfilter"),
+            "must name the module, not just the path"
+        );
+        assert!(
+            m.contains("modprobe br_netfilter"),
+            "must give the command to run now"
+        );
+        assert!(
+            m.contains("/etc/modules-load.d"),
+            "must say how to survive a reboot -- a bare modprobe does not persist, \
+             which is how this was rediscovered after a VM restart"
+        );
+    }
+
+    /// Non-vacuity: the assertions above must be capable of failing. A message
+    /// that merely echoed the sysctl path would satisfy none of them.
+    #[test]
+    fn the_bare_sysctl_error_would_not_satisfy_that_test() {
+        let bare = format!(
+            "sysctl: cannot stat {}: No such file",
+            super::BRIDGE_NF_PROBE
+        );
+        assert!(!bare.contains("modprobe br_netfilter"));
+        assert!(!bare.contains("/etc/modules-load.d"));
+    }
+
+    /// The probe path and the sysctl the code actually sets must agree. If
+    /// someone changed the sysctl to an ip6tables-only key, this preflight would
+    /// be checking a file unrelated to what fails.
+    #[test]
+    fn the_preflight_probes_the_tree_the_sysctl_writes_into() {
+        assert!(
+            super::BRIDGE_NF_PROBE.starts_with("/proc/sys/net/bridge/"),
+            "the preflight must probe the /proc/sys/net/bridge tree that \
+             net.bridge.bridge-nf-call-iptables lives in"
         );
     }
 

--- a/scripts/lima/nucleus-aarch64.yaml
+++ b/scripts/lima/nucleus-aarch64.yaml
@@ -93,6 +93,23 @@ provision:
         dnsmasq \
         e2fsprogs
 
+      # br_netfilter is a DEPENDENCY, not hygiene. `net::setup_network` sets
+      # net.bridge.bridge-nf-call-iptables, and the whole /proc/sys/net/bridge
+      # tree only exists once this module is loaded — so without it every pod
+      # spec carrying a `network` block failed mid-launch with a bare
+      # `sysctl: cannot stat` (#2382).
+      #
+      # It used to be present by accident: hosts running Docker or containerd
+      # get it loaded for their own bridge networking. This template disables
+      # containerd on purpose (a Firecracker host needs neither), which removed
+      # the thing that had been loading it. An undeclared dependency borrowed
+      # from whatever else happened to be running.
+      #
+      # modprobe for this boot, modules-load.d so it survives a restart. Both,
+      # because the VM does get stopped and started.
+      modprobe br_netfilter || true
+      echo br_netfilter > /etc/modules-load.d/nucleus.conf
+
       mkdir -p /var/lib/nucleus/artifacts /var/lib/nucleus/pods /var/log/nucleus
 
       # Firecracker, the kernel, the rootfs and nucleus-node are installed by

--- a/scripts/lima/nucleus-gpu-aarch64.yaml
+++ b/scripts/lima/nucleus-gpu-aarch64.yaml
@@ -64,6 +64,12 @@ provision:
         dnsmasq \
         e2fsprogs
 
+      # br_netfilter: net::setup_network sets net.bridge.bridge-nf-call-iptables,
+      # and /proc/sys/net/bridge only exists once this module is loaded. Without
+      # it every pod spec with a `network` block fails mid-launch (#2382).
+      modprobe br_netfilter || true
+      echo br_netfilter > /etc/modules-load.d/nucleus.conf
+
       mkdir -p /var/lib/nucleus/artifacts
       mkdir -p /var/lib/nucleus/pods
       mkdir -p /var/log/nucleus

--- a/scripts/lima/nucleus-gpu-x86_64.yaml
+++ b/scripts/lima/nucleus-gpu-x86_64.yaml
@@ -70,6 +70,12 @@ provision:
         e2fsprogs \
         pciutils
 
+      # br_netfilter: net::setup_network sets net.bridge.bridge-nf-call-iptables,
+      # and /proc/sys/net/bridge only exists once this module is loaded. Without
+      # it every pod spec with a `network` block fails mid-launch (#2382).
+      modprobe br_netfilter || true
+      echo br_netfilter > /etc/modules-load.d/nucleus.conf
+
       mkdir -p /var/lib/nucleus/artifacts
       mkdir -p /var/lib/nucleus/pods
       mkdir -p /var/log/nucleus

--- a/scripts/lima/nucleus-x86_64.yaml
+++ b/scripts/lima/nucleus-x86_64.yaml
@@ -89,6 +89,23 @@ provision:
         dnsmasq \
         e2fsprogs
 
+      # br_netfilter is a DEPENDENCY, not hygiene. `net::setup_network` sets
+      # net.bridge.bridge-nf-call-iptables, and the whole /proc/sys/net/bridge
+      # tree only exists once this module is loaded — so without it every pod
+      # spec carrying a `network` block failed mid-launch with a bare
+      # `sysctl: cannot stat` (#2382).
+      #
+      # It used to be present by accident: hosts running Docker or containerd
+      # get it loaded for their own bridge networking. This template disables
+      # containerd on purpose (a Firecracker host needs neither), which removed
+      # the thing that had been loading it. An undeclared dependency borrowed
+      # from whatever else happened to be running.
+      #
+      # modprobe for this boot, modules-load.d so it survives a restart. Both,
+      # because the VM does get stopped and started.
+      modprobe br_netfilter || true
+      echo br_netfilter > /etc/modules-load.d/nucleus.conf
+
       mkdir -p /var/lib/nucleus/artifacts /var/lib/nucleus/pods /var/log/nucleus
 
       # Firecracker, the kernel, the rootfs and nucleus-node are installed by


### PR DESCRIPTION
Closes #2382.

`net::setup_network` sets `net.bridge.bridge-nf-call-iptables`, and the whole `/proc/sys/net/bridge` tree only exists once `br_netfilter` is loaded. Nothing loaded it and nothing checked for it, so every pod spec with a `network` block died mid-launch:

```
sysctl: cannot stat /proc/sys/net/bridge/bridge-nf-call-iptables: No such file or directory
```

I hit this live while verifying #2380 — with the argv fix in place, the launch got past every `ip` command and stopped exactly here.

## It had been borrowed, not declared

Hosts running Docker or containerd load `br_netfilter` for their own bridge networking, which is why CI never saw it. The nucleus Lima templates disable containerd **deliberately** — a Firecracker host needs neither — and that removed the thing that had been loading it. The dependency was real all along; only the accident satisfying it went away.

## Two defects, both fixed

**1. Missing dependency.** All four Lima templates now `modprobe br_netfilter` *and* write `/etc/modules-load.d/nucleus.conf`. Both, not either: a bare modprobe doesn't survive a restart, which is how the reporter rediscovered it after the VM bounced.

**2. No preflight.** `ensure_bridge_netfilter()` runs at the top of `setup_network`, beside the existing `ensure_command` checks and **before** the veth pair, bridge and tap are built. [kubeadm makes this same check a preflight](https://github.com/bottlerocket-os/bottlerocket/issues/3052) for the same reason. The message names the module, the command to run now, and how to persist it — the raw error named only a path.

`nucleus doctor` gains the check as a **warning**, not an error: pods with no `network` block never touch this path, so a VM without the module is genuinely usable.

## Gate

`ci/br-netfilter-is-declared.sh` requires every Lima template to load **and** persist the module, and requires the code to preflight it **before the first `run_ip` call** — a check that runs after the interfaces exist isn't a preflight.

**Its first version passed with the persistence line deleted.** The grep matched the word "modules-load.d" in the *comment explaining why persistence matters* — a gate satisfied by prose about itself. Both template checks now ignore comment lines.

| mutation | result |
|---|---|
| baseline | exit 0 |
| template stops loading the module | **exit 1** |
| loads but doesn't persist | **exit 1** (missed before the fix) |
| preflight removed from code | **exit 1** |
| restored | exit 0 |

## Verified

Builds for `aarch64-unknown-linux-musl` (the preflight is Linux-gated; the message and probe constant are not, so they're testable on any host). Three unit tests: the message names the module + `modprobe` + the persistence path, the bare sysctl error would satisfy none of them (non-vacuity), and the probe path is in the tree the sysctl writes into.

node 372 tests, cli 159, clippy and rustfmt clean, `actionlint` clean.

## Note on stacking

The gate is wired after the SVID gate rather than after `run_netns argv names a program`, since that one is still in unmerged #2384. Trivial adjacency, no conflict expected.