### PR TITLE
fix(node): the proxy.health_wait span was attached to the wrong function

### DIFF
--- a/.github/workflows/manifest-guards.yml
+++ b/.github/workflows/manifest-guards.yml
@@ -109,3 +109,10 @@ jobs:
       # `spiffe://` SAN, which the X.509-SVID standard requires be rejected.
       - name: One X.509-SVID validator
         run: bash ci/one-svid-validator.sh
+      # `wait_for_proxy_health` moved modules and its boot.stage attribute stayed
+      # behind, silently reattaching to `serve_grpc` — so the largest span in a
+      # pod launch had no instrumentation and 92% of the boot trace was
+      # `unaccounted` (#2374). Rust binds attributes to the next item regardless
+      # of the blank line between them, so nothing failed.
+      - name: boot.stage spans annotate the item they measure
+        run: bash ci/boot-stage-spans-are-attached.sh

--- a/ci/boot-stage-spans-are-attached.sh
+++ b/ci/boot-stage-spans-are-attached.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# A `boot.stage` span must annotate the function it claims to measure.
+#
+# WHY: `wait_for_proxy_health` moved out of main.rs into guest_diagnosis (#2355)
+# and its `#[tracing::instrument(... boot.stage = "proxy.health_wait")]` stayed
+# behind. Rust attributes bind to the FOLLOWING item regardless of blank lines
+# between them, so the attribute silently reattached to `serve_grpc` — a server
+# that runs for the node's whole lifetime.
+#
+# That compiled, ran, and produced a boot trace in which 92% of pod-create wall
+# time was `unaccounted` (#2374): the largest span in a launch had no
+# instrumentation, and a long-lived task was mislabelled as a boot stage.
+#
+# Two mechanical checks. Neither can prove a span measures the RIGHT work, but
+# both catch the way this actually broke.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+fail=0
+files=$(grep -rl 'boot.stage' --include='*.rs' crates/ || true)
+[ -n "$files" ] || { echo "::error::no boot.stage attributes found at all; the scan looks broken"; exit 1; }
+
+# 1. A blank line between the attribute and its item. Legal Rust, and exactly how
+#    the attribute got orphaned onto the wrong function.
+# shellcheck disable=SC2086  # $files is a newline-separated list; splitting is intended
+detached=$(awk '
+  /#\[tracing::instrument.*boot\.stage/ { pending = 1; line = FILENAME ":" FNR; next }
+  pending && /^[[:space:]]*$/ { print line "  (blank line before the item it annotates)"; pending = 0; next }
+  pending { pending = 0 }
+' $files)
+
+if [ -n "$detached" ]; then
+  echo "::error::boot.stage attributes separated from the item they annotate:"
+  printf '%s\n' "$detached" | awk '{ print "  " $0 }'
+  echo "  Rust binds an attribute to the next item regardless, so this is how a span"
+  echo "  ends up measuring a function nobody meant to measure."
+  fail=1
+fi
+
+# 2. Two functions claiming one stage name double-count it in the breakdown.
+stages=$(grep -rhoE 'boot\.stage = "[a-z0-9_.]+"' --include='*.rs' crates/ | sed 's/.*= "//;s/"//' | sort)
+n=$(printf '%s\n' "$stages" | wc -l | tr -d ' ')
+if [ "$n" -lt 8 ]; then
+  echo "::error::only $n boot.stage declarations parsed; the scan looks broken"
+  exit 1
+fi
+dupes=$(printf '%s\n' "$stages" | uniq -d)
+if [ -n "$dupes" ]; then
+  echo "::error::boot.stage names claimed more than once (they double-count):"
+  printf '%s\n' "$dupes" | awk '{ print "  " $0 }'
+  fail=1
+fi
+
+[ "$fail" -eq 0 ] && echo "ok: $n boot.stage spans, each attached to its item, names unique"
+exit $fail

--- a/crates/nucleus-node/src/guest_diagnosis.rs
+++ b/crates/nucleus-node/src/guest_diagnosis.rs
@@ -120,6 +120,23 @@ pub(crate) fn diagnose(console_path: &Path) -> Option<String> {
     ))
 }
 
+/// The host-side wait for the guest to become healthy.
+///
+/// # Why this carries the `proxy.health_wait` stage
+///
+/// It is the single largest span in a pod launch, and until now it had none.
+/// `boot_trace` reported 92% of warm pod-create wall time as `unaccounted`
+/// (~2.3 s of ~2.5 s) because the last measured stage ended at +200 ms and
+/// nothing covered the wait that follows (#2374).
+///
+/// The instrumentation was not missing — it was ATTACHED TO THE WRONG FUNCTION.
+/// When this function moved out of `main.rs` into this module (#2355), its
+/// attributes stayed behind and silently reattached to the next item, which was
+/// `serve_grpc`: a server that runs for the node's entire lifetime. Rust
+/// attributes bind to the following item regardless of the blank line between
+/// them, so this compiled, ran, and mislabelled a long-lived task as a boot
+/// stage while the real stage went unmeasured.
+#[tracing::instrument(skip_all, fields(boot.stage = "proxy.health_wait"))]
 pub(crate) async fn wait_for_proxy_health(
     addr: SocketAddr,
     console: &Path,

--- a/crates/nucleus-node/src/main.rs
+++ b/crates/nucleus-node/src/main.rs
@@ -3174,9 +3174,6 @@ async fn wait_for_vsock_socket(path: &Path) -> Result<(), ApiError> {
 /// one.
 pub(crate) const PROXY_HEALTH_TIMEOUT_SECS_DEFAULT: u64 = 30;
 
-#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
-#[tracing::instrument(skip_all, fields(boot.stage = "proxy.health_wait"))]
-
 async fn serve_grpc(
     state: NodeState,
     listen: String,


### PR DESCRIPTION
Closes #2374.

`boot_trace` reported **92% of warm pod-create wall time as `unaccounted`** — ~2.3 s of 2.5 s, with the last measured stage ending at +200 ms and nothing covering what follows.

**The instrumentation wasn't missing. It was attached to the wrong function.**

`wait_for_proxy_health` moved out of `main.rs` into `guest_diagnosis` in #2355. Its attributes stayed behind:

```rust
#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
#[tracing::instrument(skip_all, fields(boot.stage = "proxy.health_wait"))]

async fn serve_grpc(
```

Rust binds an attribute to the **following item** regardless of the blank line between them. So `proxy.health_wait` silently began measuring `serve_grpc` — a server that runs for the node's entire lifetime — while the real wait, the largest span in a pod launch, had no span at all.

It compiled, it ran, and the only symptom was a residual. That residual *is* #2374: the host side wasn't unmeasured by omission, it was unmeasured because its meter had been moved onto something else.

## What this does and doesn't claim

It does **not** make boot faster. #2175's decomposition (guest kernel ~1.45 s, guest-init, then the tool-proxy) already explains the window; [Firecracker's own spec](https://github.com/firecracker-microvm/firecracker/blob/main/SPECIFICATION.md) puts InstanceStart→guest init at ≤125 ms, which is why `firecracker.spawn` reads 0 ms and the VMM was never the cost.

What was missing was the host-side trace **saying so on every boot** instead of in a commit message. With the wait attributed, `unaccounted_ms` becomes a usable signal rather than a number whose normal value is 92% — which is the issue's second point: a gate on it would have had to be set so loose it could never fire.

## Gate

`ci/boot-stage-spans-are-attached.sh`, two mechanical checks:

- **no blank line** between a `boot.stage` instrument attribute and its item — legal Rust, and exactly how this got orphaned;
- **no stage name claimed twice**, which would double-count it in the breakdown.

Neither can prove a span measures the *right* work. Both catch how this actually broke.

## Verified against the real defect, not just a synthetic one

| target | result |
|---|---|
| unmodified `origin/main` | **exit 1**, names `main.rs:3178` |
| this branch | exit 0 |
| reintroduce the blank line | **exit 1** |
| two functions claiming one stage | **exit 1** |

node 369 tests, clippy and rustfmt clean, `actionlint` clean, builds for `aarch64-unknown-linux-musl`.