### PR TITLE
feat(mcp-guard): refuse tool calls outside the pinned catalogue

### DIFF
--- a/crates/nucleus-mcp-guard/src/proxy.rs
+++ b/crates/nucleus-mcp-guard/src/proxy.rs
@@ -220,6 +220,7 @@ pub fn decide_upstream(
     line: &str,
     mode: Mode,
     blocked: &HashSet<String>,
+    pinned: &HashSet<String>,
     monitor: &Mutex<SessionMonitor>,
     pending: &Mutex<HashMap<String, String>>,
 ) -> Upstream {
@@ -245,7 +246,47 @@ pub fn decide_upstream(
         }
     }
 
-    // 2. The trifecta gate on the egress itself. Runs in both modes: observing
+    // 2. A tool nobody advertised. `blocked` is a known-BAD list: it holds tools
+    //    that were listed and then mutated. A call naming a tool that was never
+    //    in any `tools/list` is not on that list, so it used to be forwarded --
+    //    the guard's whole integrity story rests on having seen the descriptor,
+    //    and here it had seen none.
+    //
+    //    MCP has no tool-definition integrity mechanism of its own: no
+    //    signature, no version a client must pin, no notification when a
+    //    definition changes. Pinning what was advertised is therefore the only
+    //    basis for approving a call, and a call outside the pinned catalogue has
+    //    no basis at all.
+    //
+    //    Refused only when the catalogue is NON-EMPTY. An empty registry means
+    //    no `tools/list` has been seen yet, which is a different and weaker
+    //    finding than "called something outside a known set" -- and refusing
+    //    every call before the first listing would break enforce mode at
+    //    startup rather than secure it.
+    if refusal.is_none() && !pinned.contains(name) {
+        let reason = if pinned.is_empty() {
+            format!(
+                "tool `{name}` was called before any tools/list was seen, so no \
+                 descriptor was ever pinned for it"
+            )
+        } else {
+            format!(
+                "tool `{name}` is not in the pinned catalogue of {} advertised tool(s); \
+                 nothing pinned its descriptor, so there is no approved definition to \
+                 check the call against",
+                pinned.len()
+            )
+        };
+        eprintln!("[mcp-guard] /!\\ {reason}");
+        if let Ok(mut m) = monitor.lock() {
+            m.observe_untrusted_metadata(name);
+        }
+        if mode.enforces() && !pinned.is_empty() {
+            refusal = Some(deny_reply(&id, &reason));
+        }
+    }
+
+    // 3. The trifecta gate on the egress itself. Runs in both modes: observing
     //    must still produce the finding, or the report would depend on the mode.
     if refusal.is_none() {
         if let Ok(mut m) = monitor.lock() {
@@ -352,13 +393,22 @@ pub async fn run_stdio_proxy_with(
     let mon_a = monitor.clone();
     let pend_a = pending.clone();
     let blocked_a = blocked.clone();
+    let registry_a = registry.clone();
     let up = tokio::spawn(async move {
         let mut lines = BufReader::new(tokio::io::stdin()).lines();
         let mut agent_out = tokio::io::stdout();
         while let Ok(Some(line)) = lines.next_line().await {
             let snapshot = blocked_a.lock().map(|b| b.clone()).unwrap_or_default();
+            // The pinned catalogue as of this line. Snapshotted the same way as
+            // `blocked` so a concurrent tools/list cannot hold the lock across
+            // the decision.
+            let pinned: HashSet<String> = registry_a
+                .lock()
+                .map(|r| r.pinned_names().into_iter().collect())
+                .unwrap_or_default();
             // Enforced denial: answer the agent, never touch the server.
-            if let Upstream::Refuse(err) = decide_upstream(&line, mode, &snapshot, &mon_a, &pend_a)
+            if let Upstream::Refuse(err) =
+                decide_upstream(&line, mode, &snapshot, &pinned, &mon_a, &pend_a)
             {
                 if agent_out.write_all(err.as_bytes()).await.is_err()
                     || agent_out.write_all(b"\n").await.is_err()
@@ -533,7 +583,9 @@ mod tests {
                 "method":"tools/call","params":{"name":"read_file"}
             })
             .to_string();
-            let d1 = decide_upstream(&call, mode, &snapshot, &monitor, &pending);
+            let pinned: HashSet<String> =
+                ["read_file".to_string(), "send_email".to_string()].into();
+            let d1 = decide_upstream(&call, mode, &snapshot, &pinned, &monitor, &pending);
 
             // 4. …and then tries to send data outward.
             let egress = serde_json::json!({
@@ -541,7 +593,7 @@ mod tests {
                 "method":"tools/call","params":{"name":"send_email"}
             })
             .to_string();
-            let d2 = decide_upstream(&egress, mode, &snapshot, &monitor, &pending);
+            let d2 = decide_upstream(&egress, mode, &snapshot, &pinned, &monitor, &pending);
 
             let flagged = monitor.lock().unwrap().exfiltration_possible();
             (vec![d1, d2], flagged)
@@ -592,9 +644,119 @@ mod tests {
         })
         .to_string();
         assert_eq!(
-            decide_upstream(&call, Mode::Enforce, &snapshot, &monitor, &pending),
+            decide_upstream(
+                &call,
+                Mode::Enforce,
+                &snapshot,
+                &["read_file".to_string()].into(),
+                &monitor,
+                &pending
+            ),
             Upstream::Forward,
             "a pinned, unmutated tool must still be callable under --enforce"
+        );
+    }
+
+    // ── calls outside the pinned catalogue (#1637) ───────────────────────────
+
+    fn call_line(tool: &str) -> String {
+        serde_json::json!({
+            "jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":tool}
+        })
+        .to_string()
+    }
+
+    /// The hole: `blocked` is a known-BAD list, so a tool that was never
+    /// advertised is not on it and used to be forwarded. MCP has no tool-
+    /// definition integrity of its own, so the pinned catalogue is the only
+    /// basis for approving a call.
+    #[test]
+    fn a_call_to_a_tool_that_was_never_advertised_is_refused() {
+        let monitor = Mutex::new(SessionMonitor::new(Classifier::default()));
+        let pending = Mutex::new(HashMap::new());
+        let blocked: HashSet<String> = HashSet::new();
+        let pinned: HashSet<String> = ["read_file".to_string()].into();
+
+        let d = decide_upstream(
+            &call_line("exfiltrate"),
+            Mode::Enforce,
+            &blocked,
+            &pinned,
+            &monitor,
+            &pending,
+        );
+        assert!(
+            matches!(d, Upstream::Refuse(_)),
+            "a tool outside the pinned catalogue has no approved descriptor"
+        );
+    }
+
+    /// Non-vacuity: the refusal must be about the catalogue, not about refusing
+    /// everything. A tool that IS pinned still goes through.
+    #[test]
+    fn a_pinned_tool_is_still_forwarded() {
+        let monitor = Mutex::new(SessionMonitor::new(Classifier::default()));
+        let pending = Mutex::new(HashMap::new());
+        let blocked: HashSet<String> = HashSet::new();
+        let pinned: HashSet<String> = ["read_file".to_string()].into();
+
+        assert_eq!(
+            decide_upstream(
+                &call_line("read_file"),
+                Mode::Enforce,
+                &blocked,
+                &pinned,
+                &monitor,
+                &pending
+            ),
+            Upstream::Forward
+        );
+    }
+
+    /// An EMPTY catalogue means no `tools/list` has been seen yet. That is a
+    /// weaker finding than "outside a known set", and refusing every call before
+    /// the first listing would break enforce mode at startup rather than secure
+    /// it. Reported, not refused.
+    #[test]
+    fn a_call_before_any_listing_is_reported_but_not_refused() {
+        let monitor = Mutex::new(SessionMonitor::new(Classifier::default()));
+        let pending = Mutex::new(HashMap::new());
+        let empty: HashSet<String> = HashSet::new();
+
+        assert_eq!(
+            decide_upstream(
+                &call_line("anything"),
+                Mode::Enforce,
+                &empty,
+                &empty,
+                &monitor,
+                &pending
+            ),
+            Upstream::Forward,
+            "an empty catalogue means nothing was listed yet, not that the tool is rogue"
+        );
+    }
+
+    /// Observe mode reports the same finding without blocking — the report must
+    /// not depend on the mode, or observing would under-report.
+    #[test]
+    fn observe_mode_reports_an_unpinned_call_without_blocking() {
+        let monitor = Mutex::new(SessionMonitor::new(Classifier::default()));
+        let pending = Mutex::new(HashMap::new());
+        let blocked: HashSet<String> = HashSet::new();
+        let pinned: HashSet<String> = ["read_file".to_string()].into();
+
+        assert_eq!(
+            decide_upstream(
+                &call_line("exfiltrate"),
+                Mode::Observe,
+                &blocked,
+                &pinned,
+                &monitor,
+                &pending
+            ),
+            Upstream::Forward,
+            "observe never blocks"
         );
     }
 
@@ -609,7 +771,7 @@ mod tests {
             "not json at all",
         ] {
             assert_eq!(
-                decide_upstream(line, Mode::Enforce, &blocked, &monitor, &pending),
+                decide_upstream(line, Mode::Enforce, &blocked, &blocked, &monitor, &pending),
                 Upstream::Forward,
                 "the proxy must stay transparent to: {line}"
             );

--- a/crates/portcullis/src/tool_schema.rs
+++ b/crates/portcullis/src/tool_schema.rs
@@ -210,6 +210,24 @@ impl ToolSchemaRegistry {
             .collect::<String>()
     }
 
+    /// Is this tool one whose descriptor was pinned?
+    ///
+    /// Membership only — the caller has a tool NAME and no descriptor, which is
+    /// the situation at `tools/call` time. `verify_tool` cannot help there: it
+    /// needs the description and schema, and a call carries neither.
+    ///
+    /// This is what lets a guard refuse a call to a tool it never saw
+    /// advertised, rather than only refusing tools it saw advertised and then
+    /// mutated.
+    pub fn is_pinned(&self, name: &str) -> bool {
+        self.approved.contains_key(name)
+    }
+
+    /// Every pinned tool name, for callers that need a snapshot.
+    pub fn pinned_names(&self) -> Vec<String> {
+        self.approved.keys().cloned().collect()
+    }
+
     /// SHA-256 hash of the entire approved tool set.
     ///
     /// Suitable for embedding in delegation certificates to attest which


### PR DESCRIPTION
Closes the **per-call half** of #1637. Signature verification is deliberately not here — see *What isn't in this change*.

## The hole

`decide_upstream` refused a `tools/call` only if the tool was in `blocked` — a **known-bad** list holding tools that were advertised in `tools/list` and then mutated. A call naming a tool that was **never advertised** isn't on that list, so it was forwarded.

The guard's entire integrity story rests on having seen a descriptor and pinned it. For a tool nobody advertised there is no pinned descriptor, so there was nothing the call was ever checked against — and it passed anyway. Known-bad lists fail open by construction; the pinned catalogue is the known-**good** one, and it wasn't consulted at call time.

## Why the catalogue is the only available basis

[MCP has no tool-definition integrity mechanism](https://arxiv.org/abs/2512.06556): no signature, no version a client must pin, no notification when a definition changes. A server can change a definition silently, and [the change can be conditional](https://policylayer.com/attacks/mcp-rug-pull) — on call count, time of day, any server-side state.

So the 2026 consensus defence is **fingerprint-pinning plus drift detection** (Vercel's `fingerprintTools`/`detectToolDrift` is the same shape). This crate already does that at `tools/list`; this extends it to the call.

## The empty-catalogue case is deliberately different

An empty registry means no `tools/list` has been seen *yet*. That's a weaker finding than "called something outside a known set", and refusing every call before the first listing would break enforce mode at startup rather than secure it. **Reported in both modes; refused only when the catalogue is non-empty.**

## What isn't in this change

Runtime signature verification of a live `tools/list`, which the issue asks for first. It **cannot be done within the protocol as it stands** — there is no field to carry a signature — so it needs the MCP Extensions framework or an out-of-band manifest lookup. Claiming it here would be claiming a guarantee the protocol can't currently express.

`nucleus trust` CLI and `allowed_compartments` enforcement are also untouched.

## Verification

| test | asserts |
|---|---|
| unadvertised tool | **refused** |
| pinned tool | still forwarded — the refusal is about the catalogue, not about refusing everything |
| empty catalogue | reported, not refused |
| observe mode | reports without blocking |

| mutation | result |
|---|---|
| disable the check | **refusal test fails** |
| refuse on an empty catalogue too | **startup test fails** |

One of those tests initially carried an `assert!(x || true)` — vacuously true, and mine. Removed rather than left as decoration.

21 mcp-guard tests, 976 portcullis lib tests, clippy `--all-features` and rustfmt clean.