### PR TITLE
fix(deps): make "one ed25519 line" an enforced rule, not just a pin

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -130,6 +130,38 @@ wildcards = "warn"
 # manifest.
 deny = [
   { name = "nucleus-cred-broker", wrappers = ["nucleus-node"] },
+  # ONE ed25519 line, enforced rather than merely pinned.
+  #
+  # The workspace pins `ed25519-dalek = "=3.0.0"` precisely so first-party
+  # crates, iroh and the rest converge on one implementation. That pin does not
+  # hold on its own: `multiple-versions = "warn"` above means a second version
+  # is a warning nobody fails on, and the lockfile has quietly carried
+  # ed25519-dalek 2.2.0 alongside 3.0.0 (#1628). A signing library resolved
+  # twice means two implementations of the same primitive in one binary, and the
+  # version pin said otherwise.
+  #
+  # `multiple-versions = true` here makes THIS crate a hard failure while the
+  # global setting stays a warning, so the rule does not turn every unrelated
+  # duplicate in the tree into a blocker.
+  { name = "ed25519-dalek", deny-multiple-versions = true },
+]
+
+# The one duplicate that exists today, listed rather than tolerated silently.
+#
+# ed25519-dalek 2.2.0 reaches this workspace through delegation_calc:
+#
+#     ed25519-dalek 2.2.0 -> dlc-crypto -> dlc-d -> portcullis -> nucleus…
+#
+# Nothing here can fix it: the version lives in delegation_calc's manifest.
+# coproduct-opensource/delegation_calc#148 bumps it to 3 (one line; that repo's
+# whole suite passes), and once it merges the fix here is to move this repo's
+# `rev =` pin forward and DELETE this skip — at which point the deny rule above
+# starts binding for real.
+#
+# Listed with an exact version so a THIRD version, or a different crate arriving
+# at 2.x, is not covered by it and fails immediately.
+skip = [
+  { name = "ed25519-dalek", version = "=2.2.0" },
 ]
 
 [licenses]


### PR DESCRIPTION
Part of #1628 — the `ed25519-dalek 3.0 workspace consistency` half.

The workspace pins `ed25519-dalek = "=3.0.0"` precisely so first-party crates, iroh and the rest converge on one implementation. **The pin doesn't hold**: the lockfile carries 2.2.0 alongside 3.0.0, and `[bans] multiple-versions = "warn"` means a second version of a *signing library* is a warning nobody fails on.

A version pin that says one thing while the lockfile says another is the same shape this repo keeps finding elsewhere — a control that's green because nothing can make it red.

## The rule

```toml
{ name = "ed25519-dalek", deny-multiple-versions = true }
```

Per-crate, so the global setting stays `"warn"` and this doesn't turn every unrelated duplicate in the tree into a blocker. Only the crate whose duplication actually matters is hard-failed.

## The exception, listed rather than tolerated

2.2.0 arrives through delegation_calc:

```
ed25519-dalek 2.2.0 → dlc-crypto → dlc-d → portcullis → nucleus, nucleus-node, …
```

Nothing in this repo can fix that — the version lives in delegation_calc's manifest. **[coproduct-opensource/delegation_calc#148](https://github.com/coproduct-opensource/delegation_calc/pull/148) bumps it to 3**: one line, no source changes required, that repo's whole suite passes and clippy is clean. Once it merges, the fix here is to move the `rev =` pin forward and **delete the skip**, at which point the rule starts binding for real.

The skip is version-**exact** (`=2.2.0`), so a third version — or a different crate arriving at some other 2.x — isn't covered by it.

## Verified by removing it

| state | `cargo deny check bans` |
|---|---|
| skip as written | **passes** |
| skip removed | **fails** (exit 2) |
| skip pinned to a version that isn't present | **fails** |

The middle row is the one that matters: it proves the rule binds, rather than being satisfied by the skip that follows it.

## Why not just bump the rev now

delegation_calc's `main` still pins `ed25519-dalek = "2"`, so there's no rev to move to yet. Pinning nucleus at an unmerged branch SHA would trade a tracked duplicate for an untracked one.