### PR TITLE
fix(cli): nucleus must not pick a vendor's model for you

### DIFF
--- a/ci/no-vendor-strings.sh
+++ b/ci/no-vendor-strings.sh
@@ -97,6 +97,49 @@ for pattern in "${PATTERNS[@]}"; do
         | grep -v 'vendor-allow:' >>"$tmpfile" || true
 done
 
+# ---------------------------------------------------------------------------
+# Repo-wide pass: hardcoded vendor MODEL IDENTIFIERS.
+#
+# The pattern list above is deliberately scoped to SCAN_PATHS, because names
+# like `.claude/settings.json`, `CLAUDECODE` and `nucleus-claude-hook` are
+# intrinsic interop that legitimately appears across the tree.
+#
+# A hardcoded vendor *model id* is different: it is a defect ANYWHERE. Nucleus
+# does not choose which model runs -- that is the orchestrator's job
+# (CLAUDE.md) -- and a pinned model id also rots the moment the vendor retires
+# that model. This pattern matches `<family>-<something>-<digit>` shapes such
+# as `claude-sonnet-4-20250514` or `gpt-4o`, and provably does NOT match the
+# intrinsic interop names above.
+MODEL_ID_PATTERN='\b(claude|gpt|gemini|llama|mistral|grok)-[a-z0-9]+([.-][a-z0-9]+)*-?[0-9]'
+MODEL_SCAN_ROOTS=("crates" "ci" "scripts" "docs" ".github")
+
+modelfile="$(mktemp)"
+trap 'rm -f "$modelfile"' EXIT
+for root in "${MODEL_SCAN_ROOTS[@]}"; do
+    [[ -e "$root" ]] || continue
+    grep -RHnE -i "$MODEL_ID_PATTERN" \
+        --include="*.rs" --include="*.toml" --include="*.md" \
+        --include="*.yaml" --include="*.yml" --include="*.json" \
+        --exclude-dir=target --exclude-dir=node_modules --exclude-dir=.git \
+        --exclude-dir=.lake \
+        "$root" 2>/dev/null \
+        | grep -v 'vendor-allow:' >>"$modelfile" || true
+done
+
+if [[ -s "$modelfile" ]]; then
+    sort -u "$modelfile" -o "$modelfile"
+    echo "FAIL: hardcoded vendor model id(s) found — $(wc -l <"$modelfile" | tr -d ' ')" >&2
+    echo "" >&2
+    echo "Nucleus must not name a specific vendor model. Take the value from" >&2
+    echo "configuration or leave it unset so the external agent binary applies" >&2
+    echo "its own default; choosing a model is the orchestrator's decision." >&2
+    echo "" >&2
+    echo "Allow-list a line by appending: vendor-allow: <reason>" >&2
+    echo "" >&2
+    cat "$modelfile" >&2
+    exit 1
+fi
+
 if [[ -s "$tmpfile" ]]; then
     # Deduplicate (a line may match multiple patterns).
     sort -u "$tmpfile" >"${tmpfile}.dedup"

--- a/crates/nucleus-cli/src/run.rs
+++ b/crates/nucleus-cli/src/run.rs
@@ -138,10 +138,13 @@ pub struct RunArgs {
     pub timeout: u64,
 
     /// Model identifier to pass to the agent CLI.
-    // Intrinsic interop: the default is a real, non-neutralizable model id
-    // consumed verbatim by the external agent binary's `--model` flag.
-    #[arg(long, default_value = "claude-sonnet-4-20250514")]
-    pub model: String,
+    // Intrinsic interop: the flag name and any value are passed verbatim to the
+    // external agent binary's `--model` flag. Nucleus supplies NO default: which
+    // model to run is the orchestrator's decision, not the runtime's (CLAUDE.md),
+    // and a pinned vendor model id also rots the moment that model is retired.
+    // Unset means the agent binary applies its own default.
+    #[arg(long)]
+    pub model: Option<String>,
 
     /// Output format: text or json
     #[arg(long, default_value = "text")]
@@ -432,10 +435,11 @@ async fn run_hook(
     let start = Instant::now();
 
     let mut cmd = Command::new(crate::constants::AGENT_CLI_BIN);
-    cmd.arg("--print")
-        .arg("--model")
-        .arg(&args.model)
-        .arg("--max-budget-usd")
+    cmd.arg("--print");
+    if let Some(model) = &args.model {
+        cmd.arg("--model").arg(model);
+    }
+    cmd.arg("--max-budget-usd")
         .arg(policy.budget.max_cost_usd.to_string())
         .arg("--settings")
         .arg(&settings_path)
@@ -564,7 +568,7 @@ async fn run_local(
 
     info!(
         allowed_tools = %allowed_tools.join(","),
-        model = %args.model,
+        model = args.model.as_deref().unwrap_or("<agent default>"),
         "Spawning agent CLI (local enforced mode)"
     );
 
@@ -714,7 +718,7 @@ async fn run_enforced(
 
     info!(
         allowed_tools = %allowed_tools.join(","),
-        model = %args.model,
+        model = args.model.as_deref().unwrap_or("<agent default>"),
         "Spawning agent CLI (enforced MCP mode)"
     );
 
@@ -961,10 +965,11 @@ fn run_agent_mcp(
     work_dir: &Path,
 ) -> Result<std::process::Output> {
     let mut cmd = Command::new(crate::constants::AGENT_CLI_BIN);
-    cmd.arg("--print")
-        .arg("--model")
-        .arg(&args.model)
-        .arg("--mcp-config")
+    cmd.arg("--print");
+    if let Some(model) = &args.model {
+        cmd.arg("--model").arg(model);
+    }
+    cmd.arg("--mcp-config")
         .arg(mcp_config_path)
         // Allowed tools come ONLY from the confinement guard, which has already
         // vetted that every one routes through the PermissionLattice. There is


### PR DESCRIPTION
`nucleus run --model` defaulted to a hardcoded vendor model id.

Passing a user-supplied `--model` through verbatim is genuine intrinsic interop. Supplying a *default* is nucleus choosing which vendor's model runs on the user's behalf — the decision CLAUDE.md assigns to the orchestrator, not the runtime. It's also a latent bug: a pinned model id stops resolving once the vendor retires that model, breaking `nucleus run` for anyone who never passed `--model`.

`model` becomes `Option<String>` with no default; `--model` is forwarded only when the caller set it.

### Why the gate missed it

`ci/no-vendor-strings.sh` scanned only the two OIDC crates, so nucleus-cli was never checked — its existing pattern would have matched this line had it ever looked.

Widening every pattern repo-wide is the wrong fix: `.claude/settings.json`, `CLAUDECODE`, `nucleus-claude-hook` and `@anthropic-ai/` are legitimate interop across the tree. A hardcoded vendor **model id** is a defect anywhere, so this adds one repo-wide pass for model-identifier shapes only.

### Verified both directions
- clean tree → gate exits 0
- re-inject `default_value` → gate exits **1**, names `run.rs`
- pattern matches none of the four intrinsic interop names
- repo-wide: exactly one hit, the defect fixed here
- shellcheck clean; clippy clean; 159 tests pass