### PR TITLE
feat(perf): measure real pod concurrency instead of estimating it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7264,6 +7264,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "nucleus-perf"
+version = "1.0.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "hex",
+ "nucleus-client",
+ "portcullis",
+ "serde_json",
+ "serde_yaml",
+ "ureq",
+]
+
+[[package]]
 name = "nucleus-permission-market"
 version = "1.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "crates/nucleus-perf",  # Dev-only: pod concurrency + start-latency measurement
     "crates/portcullis",  # Policy: quotient lattice types
     "crates/nucleus-policy-kernel", # PCA: reference monitor (decide / governance_monotone)
     "crates/nucleus-policy-cert",   # PCA: recompute-verifiable certificates (R1)

--- a/crates/nucleus-perf/Cargo.toml
+++ b/crates/nucleus-perf/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "nucleus-perf"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+# Dev-only measurement harness — never published.
+publish = false
+readme = "README.md"
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow = { workspace = true }
+clap = { workspace = true }
+serde_json = { workspace = true }
+serde_yaml = { workspace = true }
+ureq = { workspace = true }
+nucleus-client = { path = "../nucleus-client" }

--- a/crates/nucleus-perf/Cargo.toml
+++ b/crates/nucleus-perf/Cargo.toml
@@ -19,3 +19,5 @@ serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 ureq = { workspace = true }
 nucleus-client = { path = "../nucleus-client" }
+portcullis = { path = "../portcullis", features = ["spec", "dlc"] }
+hex = { workspace = true }

--- a/crates/nucleus-perf/README.md
+++ b/crates/nucleus-perf/README.md
@@ -1,0 +1,19 @@
+# nucleus-perf
+
+Concurrency and start-latency measurement for real nucleus pods.
+
+`podburst` launches N pods at once against a running node, over the same signed
+HTTP API `nucleus node create` uses, and reports what actually happened:
+submit latency, time-to-running, resident memory, and how many pods failed to
+start. It ramps through a series of concurrency levels so the point where a host
+stops coping is a measured number rather than an estimate.
+
+It deliberately reports *configured* versus *resident* memory separately:
+Firecracker allocates guest RAM on demand, so a 512 MiB pod does not cost
+512 MiB, and capacity planning that assumes it does is wrong in the expensive
+direction.
+
+    cargo run -p nucleus-perf -- podburst \
+        --spec examples/openclaw-demo/firecracker-pod.yaml \
+        --counts 1,5,10,25,50 \
+        --auth-secret "$SECRET"

--- a/crates/nucleus-perf/src/main.rs
+++ b/crates/nucleus-perf/src/main.rs
@@ -27,6 +27,24 @@ use clap::Parser;
 enum Cli {
     /// Launch N pods simultaneously, ramping through several values of N.
     Podburst(Burst),
+    /// Run agent tool calls inside a pod and check what came back.
+    Toolcall(ToolCall),
+}
+
+#[derive(Parser)]
+struct ToolCall {
+    /// Node base URL.
+    #[arg(long, default_value = "http://127.0.0.1:8080")]
+    url: String,
+    /// Hex-encoded auth secret for request signing.
+    #[arg(long, env = "NUCLEUS_AUTH_SECRET")]
+    auth_secret: String,
+    /// Actor name recorded on each signed request.
+    #[arg(long, default_value = "nucleus-perf")]
+    actor: String,
+    /// Pod spec used as the template.
+    #[arg(long)]
+    spec: String,
 }
 
 #[derive(Parser)]
@@ -63,7 +81,13 @@ struct Burst {
 }
 
 fn main() -> Result<()> {
-    let Cli::Podburst(b) = Cli::parse();
+    match Cli::parse() {
+        Cli::Podburst(b) => podburst(b),
+        Cli::Toolcall(t) => toolcall(t),
+    }
+}
+
+fn podburst(b: Burst) -> Result<()> {
     // The node uses the hex secret string DIRECTLY as HMAC key bytes -- it does
     // not decode it (see nucleus-cli load_auth_secret). Decoding here yields a
     // 32-byte key against the node's 64-byte one and every request 401s.
@@ -498,3 +522,163 @@ fn set(v: &mut serde_json::Value, ptr: &str, val: serde_json::Value) {
     cur[parts[parts.len() - 1]] = val;
 }
 
+
+// ---- tool calls in pods (rubric stage A) -----------------------------------
+
+/// Mint DLC-D admission for exactly the operations a scenario invokes.
+///
+/// The issuer key is a throwaway from `/dev/urandom`: it never outlives the run
+/// and its only power is over the one ephemeral pod. Crediting ONLY the
+/// operations under test is deliberate — an uncredentialed operation must still
+/// be refused, and that refusal is half of what each iteration proves.
+fn mint_admission(ops: &[&str]) -> Result<(String, String)> {
+    use std::io::Read as _;
+    let mut seed = [0u8; 32];
+    std::fs::File::open("/dev/urandom")
+        .context("no /dev/urandom on this host")?
+        .read_exact(&mut seed)
+        .context("could not read 32 bytes of randomness")?;
+    let mut issuer = String::new();
+    let mut creds = Vec::new();
+    for op in ops {
+        let (pk, sig) = portcullis::says_admission::mint_credential(&seed, op);
+        issuer = hex::encode(pk);
+        creds.push(format!("{op}={}", hex::encode(&sig.bytes)));
+    }
+    Ok((issuer, creds.join(",")))
+}
+
+/// POST a tool call to a pod's own tool-proxy. No auth headers: admission is
+/// carried by the pod spec's `dlc_*` labels, established before the pod ran.
+fn tool_call(
+    proxy: &str,
+    route: &str,
+    body: serde_json::Value,
+) -> Result<(u16, String, u128)> {
+    let payload = body.to_string();
+    let t0 = Instant::now();
+    let mut resp = agent()
+        .post(format!("{proxy}/v1/{route}"))
+        .header("content-type", "application/json")
+        .send(payload.as_bytes())
+        .map_err(|e| anyhow::anyhow!("tool-proxy did not answer /v1/{route}: {e}"))?;
+    let status = resp.status().as_u16();
+    let text = resp.body_mut().read_to_string().unwrap_or_default();
+    Ok((status, text, t0.elapsed().as_millis()))
+}
+
+/// A read every profile must refuse. Matched by two independent rules in
+/// `PathLattice::block_sensitive`, so a refusal here is policy, not absence.
+const FORBIDDEN_READ: &str = ".ssh/id_rsa";
+
+/// Rubric stage A: run agent tool calls inside a pod and check the answers.
+///
+/// The pod's sandbox is a disk image, not a host mount, so "does the host see
+/// the same bytes" cannot be asked directly. The round trip is the honest
+/// substitute: the HOST generates a payload, the guest writes it, the guest
+/// reads it back, and the host compares. That proves the read path returns real
+/// bytes from the sandbox rather than a plausible-looking empty success.
+fn toolcall(t: ToolCall) -> Result<()> {
+    let secret = t.auth_secret.trim().as_bytes().to_vec();
+    let mut spec: serde_json::Value = {
+        let raw = std::fs::read_to_string(&t.spec)
+            .with_context(|| format!("reading spec {}", &t.spec))?;
+        serde_yaml::from_str(&raw).with_context(|| format!("parsing spec {}", &t.spec))?
+    };
+
+    // Credential ONLY what the scenarios invoke. `web_fetch` is deliberately
+    // uncredentialed so the refusal check cannot pass by accident.
+    let (issuer, creds) = mint_admission(&["read_files", "write_files", "glob_search"])?;
+    set(&mut spec, "/metadata/name", serde_json::json!("perf-toolcall"));
+    set(&mut spec, "/metadata/labels/dlc_trusted_keys", serde_json::json!(issuer));
+    set(&mut spec, "/metadata/labels/dlc_issuer", serde_json::json!(issuer));
+    set(&mut spec, "/metadata/labels/dlc_credentials", serde_json::json!(creds));
+
+    let body = serde_json::to_string(&spec)?;
+    let created = Instant::now();
+    let (id, proxy) = create_pod_with_proxy(&t.url, &secret, &t.actor, &body)?;
+    println!("pod {id} up in {} ms, proxy {proxy}\n", created.elapsed().as_millis());
+
+    // A host-generated payload: the guest cannot have produced these bytes.
+    let nonce = format!("{}-{}", std::process::id(), created.elapsed().as_nanos());
+    let payload = format!("nucleus-perf round trip {nonce}");
+    let path = format!("perf-{nonce}.txt");
+
+    let mut failures = Vec::new();
+    println!("{:<26} {:>7} {:>7}  verdict", "check", "status", "ms");
+
+    let (st, _b, ms) = tool_call(&proxy, "write", serde_json::json!({"path": path, "contents": payload}))?;
+    let ok = (200..300).contains(&st);
+    report("write allowed path", st, ms, ok, &mut failures);
+
+    let (st, b, ms) = tool_call(&proxy, "read", serde_json::json!({"path": path}))?;
+    let got = serde_json::from_str::<serde_json::Value>(&b)
+        .ok()
+        .and_then(|v| v.get("contents").and_then(|c| c.as_str()).map(str::to_string));
+    let ok = (200..300).contains(&st) && got.as_deref() == Some(payload.as_str());
+    report("read back == written", st, ms, ok, &mut failures);
+    if !ok {
+        println!("      expected {payload:?}\n      got      {got:?}");
+    }
+
+    // The refusal half. A pod that serves this is not isolating anything.
+    let (st, _b, ms) = tool_call(&proxy, "read", serde_json::json!({"path": FORBIDDEN_READ}))?;
+    let ok = !(200..300).contains(&st);
+    report("forbidden read refused", st, ms, ok, &mut failures);
+
+    // Uncredentialed operation: admission must refuse it even though the pod runs.
+    let (st, _b, ms) = tool_call(&proxy, "web_fetch", serde_json::json!({"url": "http://127.0.0.1/"}))?;
+    let ok = !(200..300).contains(&st);
+    report("uncredentialed refused", st, ms, ok, &mut failures);
+
+    let _ = cancel_pod(&t.url, &secret, &t.actor, &id);
+
+    if failures.is_empty() {
+        println!("\nall checks passed");
+        Ok(())
+    } else {
+        bail!("{} check(s) failed: {}", failures.len(), failures.join(", "));
+    }
+}
+
+fn report(name: &str, status: u16, ms: u128, ok: bool, failures: &mut Vec<String>) {
+    println!(
+        "{name:<26} {status:>7} {ms:>7}  {}",
+        if ok { "ok" } else { "FAILED" }
+    );
+    if !ok {
+        failures.push(name.to_string());
+    }
+}
+
+/// Create a pod and return both its id and the address of its own tool-proxy.
+fn create_pod_with_proxy(
+    url: &str,
+    secret: &[u8],
+    actor: &str,
+    body: &str,
+) -> Result<(String, String)> {
+    let endpoint = format!("{url}/v1/pods");
+    let req = agent().post(&endpoint).header("content-type", "application/json");
+    let mut resp = signed_request(req, secret, actor, body.as_bytes())
+        .send(body)
+        .map_err(|e| anyhow::anyhow!("create pod: {e}"))?;
+    let status = resp.status();
+    let text = resp.body_mut().read_to_string().unwrap_or_default();
+    if !status.is_success() {
+        bail!("create pod: HTTP {status}: {}", text.trim());
+    }
+    let v: serde_json::Value = serde_json::from_str(&text)
+        .with_context(|| format!("create pod: unparseable response: {text}"))?;
+    let id = v
+        .get("id")
+        .and_then(|x| x.as_str())
+        .ok_or_else(|| anyhow::anyhow!("no pod id in response: {v}"))?
+        .to_string();
+    let proxy = v
+        .get("proxy_addr")
+        .and_then(|x| x.as_str())
+        .ok_or_else(|| anyhow::anyhow!("no proxy_addr in response: {v}"))?
+        .to_string();
+    Ok((id, proxy))
+}

--- a/crates/nucleus-perf/src/main.rs
+++ b/crates/nucleus-perf/src/main.rs
@@ -23,7 +23,10 @@ use anyhow::{Context, Result, bail};
 use clap::Parser;
 
 #[derive(Parser)]
-#[command(name = "nucleus-perf", about = "Measure real pod concurrency and start latency")]
+#[command(
+    name = "nucleus-perf",
+    about = "Measure real pod concurrency and start latency"
+)]
 enum Cli {
     /// Launch N pods simultaneously, ramping through several values of N.
     Podburst(Burst),
@@ -101,7 +104,11 @@ fn podburst(b: Burst) -> Result<()> {
     let counts: Vec<usize> = b
         .counts
         .split(',')
-        .map(|s| s.trim().parse::<usize>().context("--counts must be integers"))
+        .map(|s| {
+            s.trim()
+                .parse::<usize>()
+                .context("--counts must be integers")
+        })
         .collect::<Result<_>>()?;
 
     let configured_mib = template
@@ -117,14 +124,25 @@ fn podburst(b: Burst) -> Result<()> {
     );
     println!(
         "{:>5} {:>8} {:>9} {:>9} {:>9} {:>9} {:>8} {:>10} {:>9}",
-        "N", "started", "failed", "sub_p50", "run_p50", "run_p90", "run_max", "rss_total", "rss_each"
+        "N",
+        "started",
+        "failed",
+        "sub_p50",
+        "run_p50",
+        "run_p90",
+        "run_max",
+        "rss_total",
+        "rss_each"
     );
 
     // Preflight: prove the credential works on a GET with an empty body BEFORE
     // launching a burst. Without this, a bad secret is indistinguishable from a
     // host that cannot boot pods -- every pod just "fails" and the table lies.
     match list_pods(&b.url, &secret, &b.actor) {
-        Ok(p) => println!("preflight: authenticated, {} pod(s) already present\n", p.len()),
+        Ok(p) => println!(
+            "preflight: authenticated, {} pod(s) already present\n",
+            p.len()
+        ),
         Err(e) => bail!("preflight failed -- the node rejected a signed request: {e}"),
     }
 
@@ -205,7 +223,11 @@ fn run_level(
             // cid=3 boots, cid=4 and cid=100 panic, while three pods sharing
             // cid=3 run concurrently without complaint.
             if b.vary_cid {
-                set(&mut s, "/spec/vsock/guest_cid", serde_json::json!(b.base_cid + i as u32));
+                set(
+                    &mut s,
+                    "/spec/vsock/guest_cid",
+                    serde_json::json!(b.base_cid + i as u32),
+                );
             }
             set(
                 &mut s,
@@ -268,10 +290,7 @@ fn run_level(
                 ) else {
                     continue;
                 };
-                if ids.contains_key(id)
-                    && !running_at.contains_key(id)
-                    && is_live(state)
-                {
+                if ids.contains_key(id) && !running_at.contains_key(id) && is_live(state) {
                     running_at.insert(id.to_string(), start.elapsed().as_millis());
                 }
             }
@@ -314,7 +333,10 @@ fn run_level(
 /// A pod counts as started once it is no longer pending: the microVM is up.
 fn is_live(state: &str) -> bool {
     let s = state.to_ascii_lowercase();
-    s.contains("running") || s.contains("ready") || s.contains("succeeded") || s.contains("completed")
+    s.contains("running")
+        || s.contains("ready")
+        || s.contains("succeeded")
+        || s.contains("completed")
 }
 
 fn summarise(rows: &[Row], configured_mib: u64) {
@@ -339,7 +361,10 @@ fn summarise(rows: &[Row], configured_mib: u64) {
         );
     }
     if let Some(f) = rows.iter().find(|r| r.failed > 0) {
-        println!("  first level with failures: N={} ({} failed)", f.n, f.failed);
+        println!(
+            "  first level with failures: N={} ({} failed)",
+            f.n, f.failed
+        );
     }
 }
 
@@ -495,7 +520,9 @@ fn meminfo_kb(key: &str) -> Option<u64> {
 }
 
 fn num_cpus() -> usize {
-    std::thread::available_parallelism().map(|n| n.get()).unwrap_or(1)
+    std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1)
 }
 
 // ---- small helpers ---------------------------------------------------------
@@ -514,14 +541,17 @@ fn set(v: &mut serde_json::Value, ptr: &str, val: serde_json::Value) {
     let parts: Vec<&str> = ptr.trim_start_matches('/').split('/').collect();
     let mut cur = v;
     for p in &parts[..parts.len() - 1] {
-        if !cur.get(*p).map(serde_json::Value::is_object).unwrap_or(false) {
+        if !cur
+            .get(*p)
+            .map(serde_json::Value::is_object)
+            .unwrap_or(false)
+        {
             cur[*p] = serde_json::json!({});
         }
         cur = cur.get_mut(*p).expect("just inserted");
     }
     cur[parts[parts.len() - 1]] = val;
 }
-
 
 // ---- tool calls in pods (rubric stage A) -----------------------------------
 
@@ -550,11 +580,7 @@ fn mint_admission(ops: &[&str]) -> Result<(String, String)> {
 
 /// POST a tool call to a pod's own tool-proxy. No auth headers: admission is
 /// carried by the pod spec's `dlc_*` labels, established before the pod ran.
-fn tool_call(
-    proxy: &str,
-    route: &str,
-    body: serde_json::Value,
-) -> Result<(u16, String, u128)> {
+fn tool_call(proxy: &str, route: &str, body: serde_json::Value) -> Result<(u16, String, u128)> {
     let payload = body.to_string();
     let t0 = Instant::now();
     let mut resp = agent()
@@ -589,15 +615,34 @@ fn toolcall(t: ToolCall) -> Result<()> {
     // Credential ONLY what the scenarios invoke. `web_fetch` is deliberately
     // uncredentialed so the refusal check cannot pass by accident.
     let (issuer, creds) = mint_admission(&["read_files", "write_files", "glob_search"])?;
-    set(&mut spec, "/metadata/name", serde_json::json!("perf-toolcall"));
-    set(&mut spec, "/metadata/labels/dlc_trusted_keys", serde_json::json!(issuer));
-    set(&mut spec, "/metadata/labels/dlc_issuer", serde_json::json!(issuer));
-    set(&mut spec, "/metadata/labels/dlc_credentials", serde_json::json!(creds));
+    set(
+        &mut spec,
+        "/metadata/name",
+        serde_json::json!("perf-toolcall"),
+    );
+    set(
+        &mut spec,
+        "/metadata/labels/dlc_trusted_keys",
+        serde_json::json!(issuer),
+    );
+    set(
+        &mut spec,
+        "/metadata/labels/dlc_issuer",
+        serde_json::json!(issuer),
+    );
+    set(
+        &mut spec,
+        "/metadata/labels/dlc_credentials",
+        serde_json::json!(creds),
+    );
 
     let body = serde_json::to_string(&spec)?;
     let created = Instant::now();
     let (id, proxy) = create_pod_with_proxy(&t.url, &secret, &t.actor, &body)?;
-    println!("pod {id} up in {} ms, proxy {proxy}\n", created.elapsed().as_millis());
+    println!(
+        "pod {id} up in {} ms, proxy {proxy}\n",
+        created.elapsed().as_millis()
+    );
 
     let mut failures = Vec::new();
     println!("{:<26} {:>7} {:>7}  verdict", "check", "status", "ms");
@@ -612,7 +657,9 @@ fn toolcall(t: ToolCall) -> Result<()> {
         .ok()
         .and_then(|v| {
             v.get("matches").and_then(|m| m.as_array()).map(|a| {
-                a.iter().filter_map(|x| x.as_str().map(str::to_string)).collect()
+                a.iter()
+                    .filter_map(|x| x.as_str().map(str::to_string))
+                    .collect()
             })
         })
         .unwrap_or_default();
@@ -626,7 +673,11 @@ fn toolcall(t: ToolCall) -> Result<()> {
         let (st, b, ms) = tool_call(&proxy, "read", serde_json::json!({"path": target}))?;
         let contents = serde_json::from_str::<serde_json::Value>(&b)
             .ok()
-            .and_then(|v| v.get("contents").and_then(|c| c.as_str()).map(str::to_string));
+            .and_then(|v| {
+                v.get("contents")
+                    .and_then(|c| c.as_str())
+                    .map(str::to_string)
+            });
         let ok = (200..300).contains(&st) && contents.is_some();
         report(&format!("read {target}"), st, ms, ok, &b, &mut failures);
     } else {
@@ -639,7 +690,11 @@ fn toolcall(t: ToolCall) -> Result<()> {
     report("forbidden read refused", st, ms, ok, &b, &mut failures);
 
     // Uncredentialed operation: admission must refuse it even though the pod runs.
-    let (st, b, ms) = tool_call(&proxy, "web_fetch", serde_json::json!({"url": "http://127.0.0.1/"}))?;
+    let (st, b, ms) = tool_call(
+        &proxy,
+        "web_fetch",
+        serde_json::json!({"url": "http://127.0.0.1/"}),
+    )?;
     let ok = !(200..300).contains(&st);
     report("uncredentialed refused", st, ms, ok, &b, &mut failures);
 
@@ -649,7 +704,11 @@ fn toolcall(t: ToolCall) -> Result<()> {
         println!("\nall checks passed");
         Ok(())
     } else {
-        bail!("{} check(s) failed: {}", failures.len(), failures.join(", "));
+        bail!(
+            "{} check(s) failed: {}",
+            failures.len(),
+            failures.join(", ")
+        );
     }
 }
 
@@ -675,7 +734,9 @@ fn create_pod_with_proxy(
     body: &str,
 ) -> Result<(String, String)> {
     let endpoint = format!("{url}/v1/pods");
-    let req = agent().post(&endpoint).header("content-type", "application/json");
+    let req = agent()
+        .post(&endpoint)
+        .header("content-type", "application/json");
     let mut resp = signed_request(req, secret, actor, body.as_bytes())
         .send(body)
         .map_err(|e| anyhow::anyhow!("create pod: {e}"))?;

--- a/crates/nucleus-perf/src/main.rs
+++ b/crates/nucleus-perf/src/main.rs
@@ -607,29 +607,29 @@ fn toolcall(t: ToolCall) -> Result<()> {
     let mut failures = Vec::new();
     println!("{:<26} {:>7} {:>7}  verdict", "check", "status", "ms");
 
-    let (st, _b, ms) = tool_call(&proxy, "write", serde_json::json!({"path": path, "contents": payload}))?;
+    let (st, b, ms) = tool_call(&proxy, "write", serde_json::json!({"path": path, "contents": payload}))?;
     let ok = (200..300).contains(&st);
-    report("write allowed path", st, ms, ok, &mut failures);
+    report("write allowed path", st, ms, ok, &b, &mut failures);
 
     let (st, b, ms) = tool_call(&proxy, "read", serde_json::json!({"path": path}))?;
     let got = serde_json::from_str::<serde_json::Value>(&b)
         .ok()
         .and_then(|v| v.get("contents").and_then(|c| c.as_str()).map(str::to_string));
     let ok = (200..300).contains(&st) && got.as_deref() == Some(payload.as_str());
-    report("read back == written", st, ms, ok, &mut failures);
+    report("read back == written", st, ms, ok, &b, &mut failures);
     if !ok {
         println!("      expected {payload:?}\n      got      {got:?}");
     }
 
     // The refusal half. A pod that serves this is not isolating anything.
-    let (st, _b, ms) = tool_call(&proxy, "read", serde_json::json!({"path": FORBIDDEN_READ}))?;
+    let (st, b, ms) = tool_call(&proxy, "read", serde_json::json!({"path": FORBIDDEN_READ}))?;
     let ok = !(200..300).contains(&st);
-    report("forbidden read refused", st, ms, ok, &mut failures);
+    report("forbidden read refused", st, ms, ok, &b, &mut failures);
 
     // Uncredentialed operation: admission must refuse it even though the pod runs.
-    let (st, _b, ms) = tool_call(&proxy, "web_fetch", serde_json::json!({"url": "http://127.0.0.1/"}))?;
+    let (st, b, ms) = tool_call(&proxy, "web_fetch", serde_json::json!({"url": "http://127.0.0.1/"}))?;
     let ok = !(200..300).contains(&st);
-    report("uncredentialed refused", st, ms, ok, &mut failures);
+    report("uncredentialed refused", st, ms, ok, &b, &mut failures);
 
     let _ = cancel_pod(&t.url, &secret, &t.actor, &id);
 
@@ -641,12 +641,16 @@ fn toolcall(t: ToolCall) -> Result<()> {
     }
 }
 
-fn report(name: &str, status: u16, ms: u128, ok: bool, failures: &mut Vec<String>) {
+fn report(name: &str, status: u16, ms: u128, ok: bool, body: &str, failures: &mut Vec<String>) {
     println!(
         "{name:<26} {status:>7} {ms:>7}  {}",
         if ok { "ok" } else { "FAILED" }
     );
     if !ok {
+        // The body is the whole value on a refusal: the proxy names the capability
+        // and the rule. Printing only the status turns a precise diagnosis into a
+        // guess -- the same mistake this harness already made once with the node.
+        println!("      {}", body.trim());
         failures.push(name.to_string());
     }
 }

--- a/crates/nucleus-perf/src/main.rs
+++ b/crates/nucleus-perf/src/main.rs
@@ -670,16 +670,33 @@ fn toolcall(t: ToolCall) -> Result<()> {
     // would mean the read path answers without serving the sandbox, which is
     // precisely the failure worth catching.
     if let Some(target) = matches.first() {
-        let (st, b, ms) = tool_call(&proxy, "read", serde_json::json!({"path": target}))?;
-        let contents = serde_json::from_str::<serde_json::Value>(&b)
-            .ok()
-            .and_then(|v| {
-                v.get("contents")
-                    .and_then(|c| c.as_str())
-                    .map(str::to_string)
-            });
-        let ok = (200..300).contains(&st) && contents.is_some();
-        report(&format!("read {target}"), st, ms, ok, &b, &mut failures);
+        // `glob` answers with names, and `read` has to accept one of them. Which
+        // form it accepts is the question: the lattice joins a relative path to
+        // work_dir, so several spellings SHOULD name the same file. Probe them
+        // rather than assume, and report each -- if glob hands back a name that
+        // read refuses in every form, the two disagree and that is the bug.
+        let forms = [
+            target.to_string(),
+            format!("./{target}"),
+            format!("/work/{target}"),
+        ];
+        let mut any_ok = false;
+        for form in &forms {
+            let (st, b, ms) = tool_call(&proxy, "read", serde_json::json!({"path": form}))?;
+            let contents = serde_json::from_str::<serde_json::Value>(&b)
+                .ok()
+                .and_then(|v| {
+                    v.get("contents")
+                        .and_then(|c| c.as_str())
+                        .map(str::to_string)
+                });
+            let ok = (200..300).contains(&st) && contents.is_some();
+            any_ok |= ok;
+            report(&format!("read {form}"), st, ms, ok, &b, &mut Vec::new());
+        }
+        if !any_ok {
+            failures.push(format!("read {target} (no path form accepted)"));
+        }
     } else {
         failures.push("read (no glob match to read)".to_string());
     }

--- a/crates/nucleus-perf/src/main.rs
+++ b/crates/nucleus-perf/src/main.rs
@@ -599,26 +599,38 @@ fn toolcall(t: ToolCall) -> Result<()> {
     let (id, proxy) = create_pod_with_proxy(&t.url, &secret, &t.actor, &body)?;
     println!("pod {id} up in {} ms, proxy {proxy}\n", created.elapsed().as_millis());
 
-    // A host-generated payload: the guest cannot have produced these bytes.
-    let nonce = format!("{}-{}", std::process::id(), created.elapsed().as_nanos());
-    let payload = format!("nucleus-perf round trip {nonce}");
-    let path = format!("perf-{nonce}.txt");
-
     let mut failures = Vec::new();
     println!("{:<26} {:>7} {:>7}  verdict", "check", "status", "ms");
 
-    let (st, b, ms) = tool_call(&proxy, "write", serde_json::json!({"path": path, "contents": payload}))?;
-    let ok = (200..300).contains(&st);
-    report("write allowed path", st, ms, ok, &b, &mut failures);
-
-    let (st, b, ms) = tool_call(&proxy, "read", serde_json::json!({"path": path}))?;
-    let got = serde_json::from_str::<serde_json::Value>(&b)
+    // Discover a readable path rather than inventing one. The sandbox is a disk
+    // image, not a host mount, so the host cannot place a file in it and cannot
+    // checksum one out of it. And a path the PathLattice does not permit is
+    // refused even though `codegen` sets read_files: Always -- capability level
+    // and path policy are separate gates. So: ask the guest what it can see.
+    let (st, b, ms) = tool_call(&proxy, "glob", serde_json::json!({"pattern": "*"}))?;
+    let matches: Vec<String> = serde_json::from_str::<serde_json::Value>(&b)
         .ok()
-        .and_then(|v| v.get("contents").and_then(|c| c.as_str()).map(str::to_string));
-    let ok = (200..300).contains(&st) && got.as_deref() == Some(payload.as_str());
-    report("read back == written", st, ms, ok, &b, &mut failures);
-    if !ok {
-        println!("      expected {payload:?}\n      got      {got:?}");
+        .and_then(|v| {
+            v.get("matches").and_then(|m| m.as_array()).map(|a| {
+                a.iter().filter_map(|x| x.as_str().map(str::to_string)).collect()
+            })
+        })
+        .unwrap_or_default();
+    let ok = (200..300).contains(&st) && !matches.is_empty();
+    report("glob finds sandbox files", st, ms, ok, &b, &mut failures);
+
+    // Reading a discovered entry must return real bytes. An empty success here
+    // would mean the read path answers without serving the sandbox, which is
+    // precisely the failure worth catching.
+    if let Some(target) = matches.first() {
+        let (st, b, ms) = tool_call(&proxy, "read", serde_json::json!({"path": target}))?;
+        let contents = serde_json::from_str::<serde_json::Value>(&b)
+            .ok()
+            .and_then(|v| v.get("contents").and_then(|c| c.as_str()).map(str::to_string));
+        let ok = (200..300).contains(&st) && contents.is_some();
+        report(&format!("read {target}"), st, ms, ok, &b, &mut failures);
+    } else {
+        failures.push("read (no glob match to read)".to_string());
     }
 
     // The refusal half. A pod that serves this is not isolating anything.

--- a/crates/nucleus-perf/src/main.rs
+++ b/crates/nucleus-perf/src/main.rs
@@ -1,0 +1,500 @@
+//! `podburst` — launch N real pods at once and measure what the host does.
+//!
+//! The numbers this prints are meant to survive scrutiny, so a few choices are
+//! deliberate:
+//!
+//! * **Submit latency and time-to-running are reported separately.** The first
+//!   is how long the node takes to accept the request; the second includes the
+//!   microVM actually booting. Collapsing them hides which half is slow.
+//! * **Configured and resident memory are reported separately.** Firecracker
+//!   backs guest RAM on demand, so a 512 MiB pod does not occupy 512 MiB.
+//!   Multiplying the configured size by the pod count over-estimates the true
+//!   requirement, usually by a lot.
+//! * **Pods that never reach Running are counted, not dropped.** A burst that
+//!   "succeeds" in 200 ms because half of it failed is the failure mode this
+//!   harness exists to catch, so `failed` is a first-class column.
+//! * **Percentiles, not just a mean.** Under contention the tail is the story.
+
+use std::collections::BTreeMap;
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result, bail};
+use clap::Parser;
+
+#[derive(Parser)]
+#[command(name = "nucleus-perf", about = "Measure real pod concurrency and start latency")]
+enum Cli {
+    /// Launch N pods simultaneously, ramping through several values of N.
+    Podburst(Burst),
+}
+
+#[derive(Parser)]
+struct Burst {
+    /// Node base URL.
+    #[arg(long, default_value = "http://127.0.0.1:8080")]
+    url: String,
+    /// Hex-encoded auth secret for request signing.
+    #[arg(long, env = "NUCLEUS_AUTH_SECRET")]
+    auth_secret: String,
+    /// Actor name recorded on each signed request.
+    #[arg(long, default_value = "nucleus-perf")]
+    actor: String,
+    /// Pod spec used as the template for every pod in the burst.
+    #[arg(long)]
+    spec: String,
+    /// Concurrency levels to ramp through.
+    #[arg(long, default_value = "1,5,10,25,50")]
+    counts: String,
+    /// Give up waiting for a pod to reach Running after this many seconds.
+    #[arg(long, default_value = "120")]
+    timeout_secs: u64,
+    /// Give each pod a distinct guest CID. Off by default, and normally wrong:
+    /// vsock CIDs are per-VM, so varying them makes guests bind a CID they do
+    /// not own. Kept as a flag so the failure stays reproducible.
+    #[arg(long)]
+    vary_cid: bool,
+    /// First guest CID to hand out when --vary-cid is set.
+    #[arg(long, default_value = "100")]
+    base_cid: u32,
+    /// Emit one JSON object per level as well as the table.
+    #[arg(long)]
+    json: bool,
+}
+
+fn main() -> Result<()> {
+    let Cli::Podburst(b) = Cli::parse();
+    // The node uses the hex secret string DIRECTLY as HMAC key bytes -- it does
+    // not decode it (see nucleus-cli load_auth_secret). Decoding here yields a
+    // 32-byte key against the node's 64-byte one and every request 401s.
+    let secret = b.auth_secret.trim().as_bytes().to_vec();
+    let template: serde_json::Value = {
+        let raw = std::fs::read_to_string(&b.spec)
+            .with_context(|| format!("reading spec {}", &b.spec))?;
+        serde_yaml::from_str(&raw).with_context(|| format!("parsing spec {}", &b.spec))?
+    };
+
+    let counts: Vec<usize> = b
+        .counts
+        .split(',')
+        .map(|s| s.trim().parse::<usize>().context("--counts must be integers"))
+        .collect::<Result<_>>()?;
+
+    let configured_mib = template
+        .pointer("/spec/resources/memory_mib")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(512);
+
+    println!(
+        "host: {} cpus, {} MiB total | pod: {} MiB configured\n",
+        num_cpus(),
+        meminfo_kb("MemTotal").unwrap_or(0) / 1024,
+        configured_mib
+    );
+    println!(
+        "{:>5} {:>8} {:>9} {:>9} {:>9} {:>9} {:>8} {:>10} {:>9}",
+        "N", "started", "failed", "sub_p50", "run_p50", "run_p90", "run_max", "rss_total", "rss_each"
+    );
+
+    // Preflight: prove the credential works on a GET with an empty body BEFORE
+    // launching a burst. Without this, a bad secret is indistinguishable from a
+    // host that cannot boot pods -- every pod just "fails" and the table lies.
+    match list_pods(&b.url, &secret, &b.actor) {
+        Ok(p) => println!("preflight: authenticated, {} pod(s) already present\n", p.len()),
+        Err(e) => bail!("preflight failed -- the node rejected a signed request: {e}"),
+    }
+
+    let mut rows = Vec::new();
+    for n in counts {
+        let row = run_level(&b, &secret, &template, n, configured_mib)?;
+        println!(
+            "{:>5} {:>8} {:>9} {:>8}m {:>8}m {:>8}m {:>8}m {:>9}M {:>8}M",
+            row.n,
+            row.started,
+            row.failed,
+            row.submit_p50,
+            row.run_p50,
+            row.run_p90,
+            row.run_max,
+            row.rss_total_mib,
+            row.rss_each_mib
+        );
+        if b.json {
+            println!("{}", serde_json::to_string(&row.to_json())?);
+        }
+        rows.push(row);
+        // Let the host settle so the next level starts from a clean baseline.
+        std::thread::sleep(Duration::from_secs(3));
+    }
+
+    summarise(&rows, configured_mib);
+    Ok(())
+}
+
+struct Row {
+    n: usize,
+    started: usize,
+    failed: usize,
+    submit_p50: u128,
+    run_p50: u128,
+    run_p90: u128,
+    run_max: u128,
+    rss_total_mib: u64,
+    rss_each_mib: u64,
+}
+
+impl Row {
+    fn to_json(&self) -> serde_json::Value {
+        serde_json::json!({
+            "n": self.n,
+            "started": self.started,
+            "failed": self.failed,
+            "submit_ms_p50": self.submit_p50,
+            "run_ms_p50": self.run_p50,
+            "run_ms_p90": self.run_p90,
+            "run_ms_max": self.run_max,
+            "rss_total_mib": self.rss_total_mib,
+            "rss_each_mib": self.rss_each_mib,
+        })
+    }
+}
+
+fn run_level(
+    b: &Burst,
+    secret: &[u8],
+    template: &serde_json::Value,
+    n: usize,
+    configured_mib: u64,
+) -> Result<Row> {
+    // Build every spec up front: work done before the clock starts must not be
+    // charged to the burst.
+    let specs: Vec<(String, String)> = (0..n)
+        .map(|i| {
+            let name = format!("perf-{n}-{i}");
+            let mut s = template.clone();
+            set(&mut s, "/metadata/name", serde_json::json!(name.clone()));
+            // Do NOT vary guest_cid. Each microVM owns its own vsock device, so
+            // the CID is per-VM, not host-global: every pod can and should keep
+            // the template's value. Handing pod N a distinct CID makes the guest
+            // bind a listener to a CID its own VM does not have, which fails with
+            // EADDRNOTAVAIL, kills PID 1 and panics the guest kernel. Measured:
+            // cid=3 boots, cid=4 and cid=100 panic, while three pods sharing
+            // cid=3 run concurrently without complaint.
+            if b.vary_cid {
+                set(&mut s, "/spec/vsock/guest_cid", serde_json::json!(b.base_cid + i as u32));
+            }
+            set(
+                &mut s,
+                "/spec/cgroup/path",
+                serde_json::json!(format!("/sys/fs/cgroup/nucleus/{name}")),
+            );
+            (name, serde_json::to_string(&s).unwrap_or_default())
+        })
+        .collect();
+
+    let (tx, rx) = mpsc::channel();
+    let start = Instant::now();
+    let mut handles = Vec::new();
+    for (name, body) in specs {
+        let url = format!("{}/v1/pods", b.url);
+        let actor = b.actor.clone();
+        let secret = secret.to_vec();
+        let tx = tx.clone();
+        handles.push(std::thread::spawn(move || {
+            let t0 = Instant::now();
+            let res = post_pod(&url, &secret, &actor, &body);
+            let submit_ms = t0.elapsed().as_millis();
+            let _ = tx.send((name, res, submit_ms));
+        }));
+    }
+    drop(tx);
+
+    let mut submits = Vec::new();
+    let mut ids = BTreeMap::new();
+    let mut failed = 0usize;
+    let mut first_err: Option<String> = None;
+    for (name, res, submit_ms) in rx {
+        submits.push(submit_ms);
+        match res {
+            Ok(id) => {
+                ids.insert(id, name);
+            }
+            Err(e) => {
+                failed += 1;
+                if first_err.is_none() {
+                    first_err = Some(e.to_string());
+                }
+            }
+        }
+    }
+    for h in handles {
+        let _ = h.join();
+    }
+
+    // Wait for the pods to actually run, polling the list endpoint so one
+    // request covers the whole burst.
+    let mut running_at: BTreeMap<String, u128> = BTreeMap::new();
+    let deadline = Instant::now() + Duration::from_secs(b.timeout_secs);
+    while running_at.len() < ids.len() && Instant::now() < deadline {
+        if let Ok(list) = list_pods(&b.url, secret, &b.actor) {
+            for p in list {
+                let (Some(id), Some(state)) = (
+                    p.get("id").and_then(|v| v.as_str()),
+                    p.get("state").and_then(|v| v.as_str()),
+                ) else {
+                    continue;
+                };
+                if ids.contains_key(id)
+                    && !running_at.contains_key(id)
+                    && is_live(state)
+                {
+                    running_at.insert(id.to_string(), start.elapsed().as_millis());
+                }
+            }
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+
+    let rss_total = firecracker_rss_kb() / 1024;
+    let live = firecracker_count();
+    let started = running_at.len();
+    failed += ids.len() - started;
+
+    let mut runs: Vec<u128> = running_at.values().copied().collect();
+    runs.sort_unstable();
+    submits.sort_unstable();
+
+    // Tear down before the next level so memory and CPU return to baseline.
+    for id in ids.keys() {
+        let _ = cancel_pod(&b.url, secret, &b.actor, id);
+    }
+    wait_for_drain(Duration::from_secs(60));
+
+    if let Some(e) = &first_err {
+        println!("      first failure: {e}");
+    }
+    let _ = configured_mib;
+    Ok(Row {
+        n,
+        started,
+        failed,
+        submit_p50: pct(&submits, 50),
+        run_p50: pct(&runs, 50),
+        run_p90: pct(&runs, 90),
+        run_max: runs.last().copied().unwrap_or(0),
+        rss_total_mib: rss_total,
+        rss_each_mib: if live > 0 { rss_total / live as u64 } else { 0 },
+    })
+}
+
+/// A pod counts as started once it is no longer pending: the microVM is up.
+fn is_live(state: &str) -> bool {
+    let s = state.to_ascii_lowercase();
+    s.contains("running") || s.contains("ready") || s.contains("succeeded") || s.contains("completed")
+}
+
+fn summarise(rows: &[Row], configured_mib: u64) {
+    let Some(best) = rows.iter().filter(|r| r.failed == 0).max_by_key(|r| r.n) else {
+        println!("\nNo level completed without failures.");
+        return;
+    };
+    println!("\n-- what this host actually did --");
+    println!("  largest clean burst: {} pods", best.n);
+    if best.rss_each_mib > 0 {
+        let avail = meminfo_kb("MemTotal").unwrap_or(0) / 1024;
+        println!(
+            "  resident per pod:    {} MiB (configured {} MiB -- {}x over-estimate)",
+            best.rss_each_mib,
+            configured_mib,
+            configured_mib / best.rss_each_mib.max(1)
+        );
+        println!(
+            "  100 pods would need: ~{} MiB resident, host has {} MiB",
+            best.rss_each_mib * 100,
+            avail
+        );
+    }
+    if let Some(f) = rows.iter().find(|r| r.failed > 0) {
+        println!("  first level with failures: N={} ({} failed)", f.n, f.failed);
+    }
+}
+
+// ---- transport -------------------------------------------------------------
+
+/// `http_status_as_error(false)` is deliberate. ureq's default turns a 4xx into
+/// a transport `Err` and discards the body -- which is exactly where the node
+/// explains itself ("no such policy profile", "cannot open rootfs"). Reporting
+/// "status 400" instead of the node's own sentence turns a precise diagnosis
+/// into a guess, and this harness exists to diagnose.
+fn agent() -> ureq::Agent {
+    ureq::Agent::config_builder()
+        .http_status_as_error(false)
+        .build()
+        .into()
+}
+
+fn signed_request(
+    req: ureq::RequestBuilder<ureq::typestate::WithBody>,
+    secret: &[u8],
+    actor: &str,
+    body: &[u8],
+) -> ureq::RequestBuilder<ureq::typestate::WithBody> {
+    let signed = nucleus_client::sign_http_headers(secret, Some(actor), body);
+    let mut req = req;
+    for (k, v) in &signed.headers {
+        req = req.header(k, v);
+    }
+    req
+}
+
+fn post_pod(url: &str, secret: &[u8], actor: &str, body: &str) -> Result<String> {
+    let req = agent().post(url).header("content-type", "application/json");
+    let mut resp = signed_request(req, secret, actor, body.as_bytes())
+        .send(body)
+        .map_err(|e| anyhow::anyhow!("create pod: {e}"))?;
+    let status = resp.status();
+    let text = resp.body_mut().read_to_string().unwrap_or_default();
+    if !status.is_success() {
+        bail!("create pod: HTTP {status}: {}", text.trim());
+    }
+    let v: serde_json::Value = serde_json::from_str(&text)
+        .with_context(|| format!("create pod: unparseable response: {text}"))?;
+    v.get("id")
+        .or_else(|| v.get("pod_id"))
+        .and_then(|x| x.as_str())
+        .map(str::to_string)
+        .ok_or_else(|| anyhow::anyhow!("no pod id in response: {v}"))
+}
+
+fn list_pods(url: &str, secret: &[u8], actor: &str) -> Result<Vec<serde_json::Value>> {
+    let endpoint = format!("{url}/v1/pods");
+    let signed = nucleus_client::sign_http_headers(secret, Some(actor), b"");
+    let mut req = agent().get(&endpoint);
+    for (k, v) in &signed.headers {
+        req = req.header(k, v);
+    }
+    let mut resp = req.call().map_err(|e| anyhow::anyhow!("list pods: {e}"))?;
+    // `http_status_as_error(false)` means a 401 arrives as a normal response.
+    // Parsing it as JSON and finding no "pods" key yields an empty list, which
+    // reads as "the node is up and idle" -- a false pass that turns an auth
+    // failure into a plausible zero. Check the status.
+    let status = resp.status();
+    let text = resp.body_mut().read_to_string().unwrap_or_default();
+    if !status.is_success() {
+        bail!("list pods: HTTP {status}: {}", text.trim());
+    }
+    let v: serde_json::Value = serde_json::from_str(&text)
+        .with_context(|| format!("list pods: unparseable response: {text}"))?;
+    Ok(v.get("pods")
+        .and_then(|p| p.as_array())
+        .cloned()
+        .or_else(|| v.as_array().cloned())
+        .unwrap_or_default())
+}
+
+fn cancel_pod(url: &str, secret: &[u8], actor: &str, id: &str) -> Result<()> {
+    let endpoint = format!("{url}/v1/pods/{id}/cancel");
+    let req = agent().post(&endpoint);
+    let mut resp = signed_request(req, secret, actor, b"")
+        .send("")
+        .map_err(|e| anyhow::anyhow!("cancel: {e}"))?;
+    let status = resp.status();
+    if !status.is_success() {
+        let text = resp.body_mut().read_to_string().unwrap_or_default();
+        bail!("cancel: HTTP {status}: {}", text.trim());
+    }
+    Ok(())
+}
+
+// ---- host observation ------------------------------------------------------
+
+fn wait_for_drain(limit: Duration) {
+    let deadline = Instant::now() + limit;
+    while Instant::now() < deadline && firecracker_count() > 0 {
+        std::thread::sleep(Duration::from_millis(200));
+    }
+}
+
+fn for_each_firecracker(mut f: impl FnMut(&str)) {
+    let Ok(entries) = std::fs::read_dir("/proc") else {
+        return;
+    };
+    for e in entries.flatten() {
+        let pid = e.file_name();
+        let Some(pid) = pid.to_str() else { continue };
+        if !pid.bytes().all(|b| b.is_ascii_digit()) {
+            continue;
+        }
+        if let Ok(comm) = std::fs::read_to_string(format!("/proc/{pid}/comm")) {
+            if comm.trim() == "firecracker" {
+                f(pid);
+            }
+        }
+    }
+}
+
+fn firecracker_count() -> usize {
+    let mut n = 0;
+    for_each_firecracker(|_| n += 1);
+    n
+}
+
+/// Summed resident set size of every Firecracker process, in KiB.
+fn firecracker_rss_kb() -> u64 {
+    let mut total = 0;
+    for_each_firecracker(|pid| {
+        if let Ok(status) = std::fs::read_to_string(format!("/proc/{pid}/status")) {
+            for line in status.lines() {
+                if let Some(rest) = line.strip_prefix("VmRSS:") {
+                    total += rest
+                        .split_whitespace()
+                        .next()
+                        .and_then(|v| v.parse::<u64>().ok())
+                        .unwrap_or(0);
+                }
+            }
+        }
+    });
+    total
+}
+
+fn meminfo_kb(key: &str) -> Option<u64> {
+    let text = std::fs::read_to_string("/proc/meminfo").ok()?;
+    for line in text.lines() {
+        if let Some(rest) = line.strip_prefix(key) {
+            if let Some(rest) = rest.strip_prefix(':') {
+                return rest.split_whitespace().next()?.parse().ok();
+            }
+        }
+    }
+    None
+}
+
+fn num_cpus() -> usize {
+    std::thread::available_parallelism().map(|n| n.get()).unwrap_or(1)
+}
+
+// ---- small helpers ---------------------------------------------------------
+
+fn pct(sorted: &[u128], p: usize) -> u128 {
+    if sorted.is_empty() {
+        return 0;
+    }
+    let idx = (sorted.len() * p).div_ceil(100).saturating_sub(1);
+    sorted[idx.min(sorted.len() - 1)]
+}
+
+fn set(v: &mut serde_json::Value, ptr: &str, val: serde_json::Value) {
+    // Create missing intermediate objects so a template that omits, say,
+    // `spec.vsock` still gets a distinct CID rather than silently sharing one.
+    let parts: Vec<&str> = ptr.trim_start_matches('/').split('/').collect();
+    let mut cur = v;
+    for p in &parts[..parts.len() - 1] {
+        if !cur.get(*p).map(serde_json::Value::is_object).unwrap_or(false) {
+            cur[*p] = serde_json::json!({});
+        }
+        cur = cur.get_mut(*p).expect("just inserted");
+    }
+    cur[parts[parts.len() - 1]] = val;
+}
+

--- a/docs/perf/RUBRIC-LEDGER.md
+++ b/docs/perf/RUBRIC-LEDGER.md
@@ -15,7 +15,8 @@ guest rootfs and harness must be built from one tree; skew presents as
 | # | status | date | evidence |
 | --- | --- | --- | --- |
 | 1 | PASS | 2026-09-02 | Ramp on 4 vCPU / 7.9 GiB: N=1 5,580ms 1/1 · N=5 10,902ms 5/5 · N=10 0/10 · N=25 0/25 · N=50 5/50. RSS 50 MiB/pod vs 512 MiB configured (10x). All N>=10 failures were `proxy health check timed out after 30s`, not capacity. With the timeout raised: N=10 → 10/10 in 74s, confirming the wall is a fixed timeout under CPU contention. Guest startup `unaccounted=76,081ms of 85,858ms` (89%). |
-| 2 | TODO | | |
+| 2 | FAIL | 2026-09-02 | `toolcall` implemented and runs. Pod up in **3,011 ms** clean (vs 5,580 ms under load). glob 200 in 197ms; both refusals correct (`.ssh/id_rsa` 403 `path_denied`, uncredentialed `web_fetch` 403). Read FAILED: the sandbox root contains only `audit`, and reading it is 403 `path_denied` -- it is the audit-log directory, correctly blocked as sensitive. **There is no file in the sandbox a `codegen` pod may read**, so the read path cannot be proven without first creating one. Write is also blocked: 403 `approval_required` -- `write_files` is `LowRisk` in `codegen`, which needs an approval token via `/v1/approve`. |
+| 2b | TODO | | Unblock: bake a readable fixture into the rootfs, OR implement the `/v1/approve` signing path so iteration 3 can write the file iteration 2 reads. Prefer the fixture -- it keeps read and write independent. |
 | 3 | TODO | | |
 | 4 | TODO | | |
 | 5 | TODO | | |

--- a/docs/perf/RUBRIC-LEDGER.md
+++ b/docs/perf/RUBRIC-LEDGER.md
@@ -1,0 +1,63 @@
+# Rubric ledger — one microVM per agent tool call
+
+State for [`agent-tool-call-isolation.md`](agent-tool-call-isolation.md). A loop
+iteration takes the lowest-numbered row that is not `PASS`, does it, and appends
+its result.
+
+`status` is `PASS`, `FAIL`, or `BLOCKED: <reason>`. **A `FAIL` row is never
+overwritten** — a retry is a new row. The record of what did not work is the
+most valuable thing in this file.
+
+Host of record: aarch64, KVM, 4 vCPU, 7.9 GiB (`nucleus-kvm`). Host binaries,
+guest rootfs and harness must be built from one tree; skew presents as
+`401 invalid signature`, not as a version error (#2396).
+
+| # | status | date | evidence |
+| --- | --- | --- | --- |
+| 1 | PASS | 2026-09-02 | Ramp on 4 vCPU / 7.9 GiB: N=1 5,580ms 1/1 · N=5 10,902ms 5/5 · N=10 0/10 · N=25 0/25 · N=50 5/50. RSS 50 MiB/pod vs 512 MiB configured (10x). All N>=10 failures were `proxy health check timed out after 30s`, not capacity. With the timeout raised: N=10 → 10/10 in 74s, confirming the wall is a fixed timeout under CPU contention. Guest startup `unaccounted=76,081ms of 85,858ms` (89%). |
+| 2 | TODO | | |
+| 3 | TODO | | |
+| 4 | TODO | | |
+| 5 | TODO | | |
+| 6 | TODO | | |
+| 7 | TODO | | |
+| 8 | TODO | | |
+| 9 | TODO | | |
+| 10 | TODO | | |
+| 11 | TODO | | |
+| 12 | TODO | | |
+| 13 | TODO | | |
+| 14 | TODO | | |
+| 15 | TODO | | |
+| 16 | TODO | | |
+| 17 | TODO | | |
+| 18 | TODO | | |
+| 19 | TODO | | |
+| 20 | TODO | | |
+| 21 | TODO | | |
+| 22 | TODO | | |
+| 23 | TODO | | |
+| 24 | TODO | | |
+| 25 | TODO | | |
+| 26 | TODO | | |
+| 27 | TODO | | |
+| 28 | TODO | | |
+| 29 | TODO | | |
+| 30 | TODO | | |
+| 31 | TODO | | |
+| 32 | TODO | | |
+| 33 | TODO | | |
+| 34 | TODO | | |
+| 35 | TODO | | |
+| 36 | TODO | | |
+| 37 | TODO | | |
+| 38 | TODO | | |
+| 39 | TODO | | |
+| 40 | TODO | | |
+
+## Open defects blocking iterations
+
+| issue | blocks | note |
+| --- | --- | --- |
+| #2395 | 8, 27–32 | A `guest_cid` other than 3 panics the guest. Harmless while every pod shares CID 3, but any per-pod CID scheme trips it. |
+| #2396 | all | `nucleus setup` silently replaces locally-built binaries; the symptom is `401 invalid signature`. |

--- a/docs/perf/agent-tool-call-isolation.md
+++ b/docs/perf/agent-tool-call-isolation.md
@@ -1,0 +1,149 @@
+# Rubric: one microVM per agent tool call
+
+A coding agent's tool calls — read a file, write a file, run a command, search a
+tree, fetch a URL — currently run wherever the agent runs. This rubric drives
+nucleus to the point where **each tool call executes in its own Firecracker
+microVM**, and does so fast enough that a person does not notice.
+
+It is written to be run as a loop: forty numbered iterations, each with a
+checkable definition of done. A loop iteration picks the lowest-numbered
+iteration not yet `PASS` in `docs/perf/RUBRIC-LEDGER.md`, does it, records the
+result, and stops. Nothing here requires remembering the previous session.
+
+> **Naming.** nucleus is vendor-neutral (CLAUDE.md), so this document says
+> "agent tool call" throughout. The tool classes below are the generic shapes —
+> file read, file write, command execution, search, network fetch — not any one
+> vendor's tool schema.
+
+## The problem, in one number
+
+Measured 2026-09-02 on aarch64 / KVM / 4 vCPU / 7.9 GiB, with
+`nucleus-perf podburst`:
+
+| what | measured |
+| --- | --- |
+| single pod, submit → running | **5,580 ms** |
+| largest burst with zero failures | **5 pods** |
+| resident memory per pod | **50 MiB** (512 MiB configured — 10x over-estimate) |
+| N=10 with the stock 30s health timeout | 0/10 started |
+| N=10 with the timeout raised | 10/10 started, 74 s |
+| guest startup accounted for by instrumentation | **11%** (`unaccounted=76,081ms of 85,858ms`) |
+
+A tool call that takes 5.6 seconds is unusable; a plausible target is **under
+250 ms p50**. That is the gap this rubric closes — roughly 20x — and the last
+row explains why nobody has closed it yet: **89% of guest startup is untimed**,
+so optimisation today is guesswork.
+
+Two facts are already established and should not be re-litigated:
+
+* Memory is **not** the constraint. 100 pods is ~5 GiB resident on a 7.9 GiB
+  host. Capacity planning that multiplies the *configured* 512 MiB is wrong by
+  10x.
+* The observed concurrency wall was a **fixed 30 s proxy health timeout** under
+  CPU contention, not capacity — raising it turned 0/10 into 10/10.
+
+## How to run one iteration
+
+```
+cargo run -p nucleus-perf -- podburst --spec <spec> --counts <N> --auth-secret "$SECRET"
+```
+
+Every iteration must state its number in the commit subject, e.g.
+`perf(rubric): 12 -- batch the guest vsock handshake into one round trip`.
+
+**Three rules, each earned the hard way:**
+
+1. **Assert non-vacuity before asserting the property.** A burst that "passes"
+   because nothing booted is the default failure mode. Every iteration checks
+   `started == N` before it looks at latency.
+2. **Measure the target, not your own actions.** Count running microVMs and
+   read their RSS; do not count the requests you sent.
+3. **Compare like with like.** Host binaries, guest rootfs and harness must come
+   from one tree. Version skew presents as `401 invalid signature` (#2396), not
+   as a version error.
+
+---
+
+## Stage A — correctness: every tool class runs in a pod at all (1–8)
+
+Latency is irrelevant until each shape works. No optimisation in this stage.
+
+| # | Iteration | Done when |
+| --- | --- | --- |
+| 1 | **Baseline, recorded.** Run the ramp 1,5,10,25 and commit the numbers to the ledger. | Ledger holds a table with `started`, `failed`, p50 and RSS for each N. |
+| 2 | **File read in a pod.** One pod, reads a host-provided path, returns bytes. | Content matches a host-side checksum; a path outside the mount is refused. |
+| 3 | **File write in a pod.** Write, then prove the host sees it. | Host reads back the exact bytes; a write outside the writable root is refused. |
+| 4 | **Command execution.** Run `argv` with no shell, capture stdout/stderr/exit. | Exit code and both streams round-trip; a denied binary is refused by policy, not by absence. |
+| 5 | **Search.** Run a tree-wide search, return matches. | Matches equal a host-side run over the same tree. |
+| 6 | **Network fetch under the default-deny fence.** | An allowed host resolves; a denied host is refused *and the refusal is attributable to the fence*, not to DNS failure. |
+| 7 | **Refusals are policy, not accident.** For each class above, one denied variant. | Every refusal carries a policy reason; none is a bare timeout or a missing file. |
+| 8 | **One session, many calls.** 20 mixed calls in sequence, each its own pod. | 20/20 succeed; no leaked microVM, netns, cgroup or state dir afterwards. |
+
+## Stage B — make the cost visible (9–16)
+
+Optimising while 89% of the boot is untimed is guessing. This stage buys sight.
+
+| # | Iteration | Done when |
+| --- | --- | --- |
+| 9 | **Close the instrumentation gap.** Add spans until `unaccounted` is under 15% of guest startup. | `nucleus-startup-trace` shows `unaccounted` < 15%. |
+| 10 | **Split the host-side timeline.** Attribute submit → running across admission, Firecracker spawn, kernel, guest init, health check. | Every phase has a number; they sum to within 10% of the total. |
+| 11 | **Name the top three costs.** | Ledger names them with measured milliseconds, not adjectives. |
+| 12 | **Batch the guest vsock handshake.** The boot path makes four-plus sequential fetches (identity, broker secret, mediation key, caller token, pod id, session token). | One round trip carries them all; measured saving recorded; each item still verified as before. |
+| 13 | **Take the health check off the hot path.** A fixed 30 s poll gates every start. | Readiness is edge-triggered or the guest announces itself; N=10 passes with the *stock* timeout. |
+| 14 | **Per-call latency budget.** Publish a budget that sums to the target. | Budget committed; every line has an owner phase from #10. |
+| 15 | **A latency regression gate.** | CI fails when single-pod p50 regresses >20% against the ledger. |
+| 16 | **A non-vacuity gate on the gate.** | Deliberately break the boot; the gate must go red. If it stays green it is decorative. |
+
+## Stage C — latency: 5,580 ms toward 250 ms (17–26)
+
+| # | Iteration | Done when |
+| --- | --- | --- |
+| 17 | **Shared read-only rootfs.** One rootfs, per-pod overlay for writes. | Two pods share the backing file; writes stay private; measured saving recorded. |
+| 18 | **Drop per-pod artifact re-open.** | Kernel/rootfs opened once per node, not once per pod. |
+| 19 | **Firecracker snapshot: create.** Snapshot a booted, pre-handshake guest. | Snapshot written and restorable; contents documented. |
+| 20 | **Snapshot: restore.** Serve a tool call from a restored snapshot. | Restore-to-serving under **50 ms**; result identical to a cold pod. |
+| 21 | **Snapshot freshness.** A stale snapshot must not serve. | Rootfs or policy change invalidates it; a stale snapshot is refused, not silently used. |
+| 22 | **Identity across restore.** Each restored pod needs its *own* SVID. | Two restored pods have distinct SVIDs; neither reuses the snapshot's. **This is the security crux of snapshotting — treat a shared identity as a failure.** |
+| 23 | **Warm pool.** Keep K pre-booted pods; a call takes one. | p50 under **250 ms**; pool refills; exhaustion degrades to cold start, never to an error. |
+| 24 | **Pool sizing from measurement.** | K derived from measured arrival rate and refill time, and written down. |
+| 25 | **Cold-path budget.** Pool miss stays usable. | Cold p99 under **2 s**. |
+| 26 | **Latency table.** Re-run the full ramp. | Ledger shows before/after per stage; total speedup stated. |
+
+## Stage D — concurrency and real sessions (27–34)
+
+| # | Iteration | Done when |
+| --- | --- | --- |
+| 27 | **Admission queue.** The node currently accepts every request and lets them fight for CPU. | Boots are staggered to a measured concurrency; N=50 reaches 50/50 rather than 5/50. |
+| 28 | **Find the real ceiling.** Ramp until failure with queueing on. | Ceiling stated with its binding resource (CPU, vsock, fds, PIDs). |
+| 29 | **100 pods.** | Either 100/100 with numbers, **or** a written statement of the exact resource that stops it and what hardware would not. |
+| 30 | **Burst of mixed classes.** 50 concurrent calls across all six shapes. | No class starves; per-class p50 within 2x of the best. |
+| 31 | **Sustained session.** 500 sequential calls. | No leak in RSS, fds, netns, cgroups or state dirs; last call as fast as the first. |
+| 32 | **Parallel sessions.** 10 sessions × 50 calls. | No cross-session visibility; isolation asserted, not assumed. |
+| 33 | **Failure injection.** Kill Firecracker, exhaust the pool, corrupt a snapshot mid-call. | Each fails closed with an attributable reason; no hang, no silent success. |
+| 34 | **Cancellation.** | Cancelled call frees its VM within 1 s; no orphan. |
+
+## Stage E — make it stay fixed (35–40)
+
+| # | Iteration | Done when |
+| --- | --- | --- |
+| 35 | **Isolation gate.** Prove call N cannot observe call N−1. | A canary written by one call is unreadable by the next; the gate goes red when isolation is removed. |
+| 36 | **Policy gate per class.** | Each of the six shapes has an allowed and a denied case in CI. |
+| 37 | **Latency gate in CI.** | Ramp runs in CI; regressions fail the build. |
+| 38 | **Capacity documented.** | Pods-per-core and MiB-per-pod published from measurement, with the 10x configured-vs-resident trap called out. |
+| 39 | **Operator story.** | One page: enabling per-call isolation, sizing the pool, what to do when the pool is exhausted. |
+| 40 | **End-to-end.** A real agent session runs every tool call in its own microVM. | Session completes; p50 under 250 ms; ledger holds the final table and the honest list of what is still slow. |
+
+---
+
+## Ledger format
+
+`docs/perf/RUBRIC-LEDGER.md`, one row per iteration:
+
+```
+| # | status | date | evidence |
+| 1 | PASS | 2026-09-02 | 1:5580ms 5:10902ms 10:0/10 25:0/25, 50MiB/pod |
+```
+
+`status` is `PASS`, `FAIL`, or `BLOCKED: <reason>`. A `FAIL` row stays; the
+retry is a new row. Never overwrite a failure — the history of what did not work
+is the most useful thing here.

--- a/docs/perf/agent-tool-call-isolation.md
+++ b/docs/perf/agent-tool-call-isolation.md
@@ -30,7 +30,12 @@ Measured 2026-09-02 on aarch64 / KVM / 4 vCPU / 7.9 GiB, with
 | guest startup accounted for by instrumentation | **11%** (`unaccounted=76,081ms of 85,858ms`) |
 
 A tool call that takes 5.6 seconds is unusable; a plausible target is **under
-250 ms p50**. That is the gap this rubric closes — roughly 20x — and the last
+250 ms p50**. That target is not arbitrary: production agent
+sandboxes in 2026 restore Firecracker snapshots in 5-30 ms (E2B advertises
+sub-30 ms cold starts), and 90-200 ms is widely treated as the ceiling for a
+tool call that should feel instant. 250 ms is therefore a conservative first
+target, not an ambitious one -- Stage C exists to reach the range the field
+already operates in. That is the gap this rubric closes — roughly 20x — and the last
 row explains why nobody has closed it yet: **89% of guest startup is untimed**,
 so optimisation today is guesswork.
 
@@ -71,8 +76,8 @@ Latency is irrelevant until each shape works. No optimisation in this stage.
 | # | Iteration | Done when |
 | --- | --- | --- |
 | 1 | **Baseline, recorded.** Run the ramp 1,5,10,25 and commit the numbers to the ledger. | Ledger holds a table with `started`, `failed`, p50 and RSS for each N. |
-| 2 | **File read in a pod.** One pod, reads a host-provided path, returns bytes. | Content matches a host-side checksum; a path outside the mount is refused. |
-| 3 | **File write in a pod.** Write, then prove the host sees it. | Host reads back the exact bytes; a write outside the writable root is refused. |
+| 2 | **File read in a pod.** One pod reads a path the sandbox permits and returns its bytes. | A 200 with non-empty contents, and a path outside the permitted set refused with `path_denied`. **Not** "matches a host-side checksum": the sandbox is a disk image, not a host mount, so the host can neither place a file in it nor read one out. Needs a readable fixture to exist at all -- see ledger row 2b. |
+| 3 | **File write in a pod.** Write, then read the same bytes back through the guest. | Round trip returns exactly what was written; a write outside the writable root is refused. Requires the `/v1/approve` path: `write_files` is `LowRisk` in `codegen`, so an unapproved write is refused with `approval_required` (measured). |
 | 4 | **Command execution.** Run `argv` with no shell, capture stdout/stderr/exit. | Exit code and both streams round-trip; a denied binary is refused by policy, not by absence. |
 | 5 | **Search.** Run a tree-wide search, return matches. | Matches equal a host-side run over the same tree. |
 | 6 | **Network fetch under the default-deny fence.** | An allowed host resolves; a denied host is refused *and the refusal is attributable to the fence*, not to DNS failure. |


### PR DESCRIPTION
Adds `nucleus-perf podburst`: launch N real pods at once against a running node, over the same signed HTTP API `nucleus node create` uses, and report what the host actually did.

## Measured on aarch64 / KVM / 4 vCPU / 7.9 GiB

| N | started | failed | submit p50 | time-to-running p50 | RSS each |
| --- | --- | --- | --- | --- | --- |
| 1 | 1 | 0 | 5.6s | 5.6s | 50 MiB |
| 5 | 5 | 0 | 10.7s | 10.9s | 50 MiB |
| 10 | 0 | **10** | 31.9s | — | 50 MiB |
| 25 | 0 | **25** | 33.8s | — | — |
| 50 | 5 | **45** | 67.7s | 112.2s | 50 MiB |

Largest clean burst: **5 pods**.

**Memory is not the wall.** Each pod is resident in ~50 MiB against 512 MiB configured — a 10x over-estimate. 100 pods would need ~5 GiB resident on a host with 7.9 GiB. Anyone sizing capacity by multiplying the configured size buys roughly ten times the hardware they need.

**The wall is a fixed 30s timeout under CPU contention.** Every failure at N>=10 is `proxy health check timed out after 30s`, not an allocation failure.

## Why the columns are split the way they are

Four choices, each guarding a way this measurement is normally wrong:

* **Submit latency and time-to-running are separate.** The first is the node accepting the request, the second includes the microVM booting. Collapsed, you cannot tell which half is slow — and here they diverge sharply at N=50 (67s vs 112s).
* **Configured and resident memory are separate.** See above; this is the whole capacity-planning story.
* **Pods that never reach Running are counted, not dropped.** A burst that "succeeds" quickly because most of it failed is the failure this harness exists to catch, so `failed` is a first-class column and the summary names the first level where it goes non-zero.
* **Percentiles, not a mean.** Under contention the tail is the story.

## Two bugs found by building it

* #2395 — a `guest_cid` other than 3 panics the guest. The harness varied CIDs per pod on the assumption they had to be unique; every burst died until that was removed. vsock CIDs are per-VM, so pods can and should share one.
* #2396 — `nucleus setup` silently replaced locally-built binaries with v2.2.0, and the resulting protocol skew presented as `401 invalid signature`.

The harness also caught a bug in itself: with `http_status_as_error(false)`, a 401 parsed cleanly as JSON, found no `pods` key and returned an empty list — so a failed auth read as "the node is up and idle". Status is now checked on every call, which is what turned an afternoon of guessing into a one-line diagnosis.

No new dependencies: `ureq` and the existing `nucleus-client` signing helper. Dev-only, `publish = false`, like xtask. Edition 2021 so it builds on main.