### PR TITLE
fix(ci): the -noop twins were cancelling each other on every PR

### DIFF
--- a/.github/workflows/aeneas-ifc-scoped-noop.yml
+++ b/.github/workflows/aeneas-ifc-scoped-noop.yml
@@ -41,7 +41,7 @@ concurrency:
   # cancel-in-progress is scoped to pull_request on purpose: cancelling a
   # merge_group run would abort a queue entry mid-flight, and cancelling a
   # push to main would drop the signal for a commit that already landed.
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: aeneas-ifc-scoped-noop-${{ github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:

--- a/.github/workflows/aeneas-ifc-scoped.yml
+++ b/.github/workflows/aeneas-ifc-scoped.yml
@@ -59,7 +59,7 @@ concurrency:
   # cancel-in-progress is scoped to pull_request on purpose: cancelling a
   # merge_group run would abort a queue entry mid-flight, and cancelling a
   # push to main would drop the signal for a commit that already landed.
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: aeneas-ifc-scoped-real-${{ github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:

--- a/.github/workflows/aeneas-oidc-spiffe-noop.yml
+++ b/.github/workflows/aeneas-oidc-spiffe-noop.yml
@@ -23,7 +23,7 @@ concurrency:
   # cancel-in-progress is scoped to pull_request on purpose: cancelling a
   # merge_group run would abort a queue entry mid-flight, and cancelling a
   # push to main would drop the signal for a commit that already landed.
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: aeneas-oidc-spiffe-noop-${{ github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:

--- a/.github/workflows/aeneas-oidc-spiffe.yml
+++ b/.github/workflows/aeneas-oidc-spiffe.yml
@@ -36,7 +36,7 @@ concurrency:
   # cancel-in-progress is scoped to pull_request on purpose: cancelling a
   # merge_group run would abort a queue entry mid-flight, and cancelling a
   # push to main would drop the signal for a commit that already landed.
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: aeneas-oidc-spiffe-real-${{ github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:

--- a/.github/workflows/ck-admit-noop.yml
+++ b/.github/workflows/ck-admit-noop.yml
@@ -26,7 +26,7 @@ concurrency:
   # cancel-in-progress is scoped to pull_request on purpose: cancelling a
   # merge_group run would abort a queue entry mid-flight, and cancelling a
   # push to main would drop the signal for a commit that already landed.
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ck-admit-noop-${{ github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:

--- a/.github/workflows/ck-admit.yml
+++ b/.github/workflows/ck-admit.yml
@@ -32,7 +32,7 @@ concurrency:
   # cancel-in-progress is scoped to pull_request on purpose: cancelling a
   # merge_group run would abort a queue entry mid-flight, and cancelling a
   # push to main would drop the signal for a commit that already landed.
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ck-admit-real-${{ github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:

--- a/.github/workflows/ck-policy-aeneas-noop.yml
+++ b/.github/workflows/ck-policy-aeneas-noop.yml
@@ -24,7 +24,7 @@ concurrency:
   # cancel-in-progress is scoped to pull_request on purpose: cancelling a
   # merge_group run would abort a queue entry mid-flight, and cancelling a
   # push to main would drop the signal for a commit that already landed.
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ck-policy-aeneas-noop-${{ github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:

--- a/.github/workflows/ck-policy-aeneas.yml
+++ b/.github/workflows/ck-policy-aeneas.yml
@@ -49,7 +49,7 @@ concurrency:
   # cancel-in-progress is scoped to pull_request on purpose: cancelling a
   # merge_group run would abort a queue entry mid-flight, and cancelling a
   # push to main would drop the signal for a commit that already landed.
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ck-policy-aeneas-real-${{ github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:

--- a/.github/workflows/ck-policy-lean-noop.yml
+++ b/.github/workflows/ck-policy-lean-noop.yml
@@ -22,7 +22,7 @@ concurrency:
   # cancel-in-progress is scoped to pull_request on purpose: cancelling a
   # merge_group run would abort a queue entry mid-flight, and cancelling a
   # push to main would drop the signal for a commit that already landed.
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ck-policy-lean-noop-${{ github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:

--- a/.github/workflows/ck-policy-lean.yml
+++ b/.github/workflows/ck-policy-lean.yml
@@ -29,7 +29,7 @@ concurrency:
   # cancel-in-progress is scoped to pull_request on purpose: cancelling a
   # merge_group run would abort a queue entry mid-flight, and cancelling a
   # push to main would drop the signal for a commit that already landed.
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ck-policy-lean-real-${{ github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:

--- a/.github/workflows/dep-hygiene-noop.yml
+++ b/.github/workflows/dep-hygiene-noop.yml
@@ -25,7 +25,7 @@ concurrency:
   # cancel-in-progress is scoped to pull_request on purpose: cancelling a
   # merge_group run would abort a queue entry mid-flight, and cancelling a
   # push to main would drop the signal for a commit that already landed.
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: dep-hygiene-noop-${{ github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:

--- a/.github/workflows/dep-hygiene.yml
+++ b/.github/workflows/dep-hygiene.yml
@@ -43,7 +43,7 @@ concurrency:
   # cancel-in-progress is scoped to pull_request on purpose: cancelling a
   # merge_group run would abort a queue entry mid-flight, and cancelling a
   # push to main would drop the signal for a commit that already landed.
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: dep-hygiene-real-${{ github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:

--- a/.github/workflows/econ-lean-noop.yml
+++ b/.github/workflows/econ-lean-noop.yml
@@ -22,7 +22,7 @@ concurrency:
   # cancel-in-progress is scoped to pull_request on purpose: cancelling a
   # merge_group run would abort a queue entry mid-flight, and cancelling a
   # push to main would drop the signal for a commit that already landed.
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: econ-lean-noop-${{ github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:

--- a/.github/workflows/econ-lean.yml
+++ b/.github/workflows/econ-lean.yml
@@ -28,7 +28,7 @@ concurrency:
   # cancel-in-progress is scoped to pull_request on purpose: cancelling a
   # merge_group run would abort a queue entry mid-flight, and cancelling a
   # push to main would drop the signal for a commit that already landed.
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: econ-lean-real-${{ github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:

--- a/.github/workflows/manifest-guards.yml
+++ b/.github/workflows/manifest-guards.yml
@@ -129,3 +129,10 @@ jobs:
       # failing mid-launch on a bare `sysctl: cannot stat` (#2382).
       - name: br_netfilter is a declared dependency
         run: bash ci/br-netfilter-is-declared.sh
+      # The `-noop` twins carry the SAME workflow name so a required status
+      # context is reported on every PR. That makes `${{ github.workflow }}`
+      # identical for both files, and every one of the ten pairs built its
+      # concurrency group from it — so the twins cancelled each other, and a
+      # cancelled check-run turns the PR's rollup FAILURE with nothing broken.
+      - name: twin workflows have distinct concurrency groups
+        run: bash ci/twin-workflows-have-distinct-concurrency.sh

--- a/.github/workflows/portcullis-core-proven-lean-noop.yml
+++ b/.github/workflows/portcullis-core-proven-lean-noop.yml
@@ -20,7 +20,7 @@ concurrency:
   # cancel-in-progress is scoped to pull_request on purpose: cancelling a
   # merge_group run would abort a queue entry mid-flight, and cancelling a
   # push to main would drop the signal for a commit that already landed.
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: portcullis-core-proven-lean-noop-${{ github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:

--- a/.github/workflows/portcullis-core-proven-lean.yml
+++ b/.github/workflows/portcullis-core-proven-lean.yml
@@ -39,7 +39,7 @@ concurrency:
   # cancel-in-progress is scoped to pull_request on purpose: cancelling a
   # merge_group run would abort a queue entry mid-flight, and cancelling a
   # push to main would drop the signal for a commit that already landed.
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: portcullis-core-proven-lean-real-${{ github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:

--- a/.github/workflows/quickstart-boot-noop.yml
+++ b/.github/workflows/quickstart-boot-noop.yml
@@ -44,7 +44,7 @@ concurrency:
   # cancel-in-progress is scoped to pull_request on purpose: cancelling a
   # merge_group run would abort a queue entry mid-flight, and cancelling a
   # push to main would drop the signal for a commit that already landed.
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: quickstart-boot-noop-${{ github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:

--- a/.github/workflows/quickstart-boot.yml
+++ b/.github/workflows/quickstart-boot.yml
@@ -65,7 +65,7 @@ concurrency:
   # cancel-in-progress is scoped to pull_request on purpose: cancelling a
   # merge_group run would abort a queue entry mid-flight, and cancelling a
   # push to main would drop the signal for a commit that already landed.
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: quickstart-boot-real-${{ github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:

--- a/.github/workflows/rubric-lean-noop.yml
+++ b/.github/workflows/rubric-lean-noop.yml
@@ -20,7 +20,7 @@ concurrency:
   # cancel-in-progress is scoped to pull_request on purpose: cancelling a
   # merge_group run would abort a queue entry mid-flight, and cancelling a
   # push to main would drop the signal for a commit that already landed.
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: rubric-lean-noop-${{ github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:

--- a/.github/workflows/rubric-lean.yml
+++ b/.github/workflows/rubric-lean.yml
@@ -24,7 +24,7 @@ concurrency:
   # cancel-in-progress is scoped to pull_request on purpose: cancelling a
   # merge_group run would abort a queue entry mid-flight, and cancelling a
   # push to main would drop the signal for a commit that already landed.
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: rubric-lean-real-${{ github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:

--- a/ci/twin-workflows-have-distinct-concurrency.sh
+++ b/ci/twin-workflows-have-distinct-concurrency.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# Two workflows may share a NAME. They must not share a CONCURRENCY GROUP.
+#
+# This repo pairs each path-filtered workflow with a `-noop` twin carrying the
+# SAME `name:` and the SAME job name, so a required status context is reported
+# on every PR whether or not the relevant paths changed. That part works.
+#
+# The hazard is that `${{ github.workflow }}` is the DISPLAY NAME, which the
+# twins share by design. A concurrency group built from it is therefore
+# IDENTICAL for both files:
+#
+#     group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+#     cancel-in-progress: <true on pull_request>
+#
+# The twins are meant to be mutually exclusive, but they are not: `paths-ignore`
+# fires whenever ANY changed file falls outside its list, so a PR touching both
+# a filtered path and an unfiltered one triggers BOTH. Sharing a group, whichever
+# starts second cancels the first, and a CANCELLED check-run makes the PR's
+# status rollup FAILURE even though nothing failed.
+#
+# Measured on one branch before the fix — the cancelled twin alternates:
+#
+#     sha 1d33c74e   dep-hygiene CANCELLED   dep-hygiene-noop success
+#     sha c16a57b8   dep-hygiene success     dep-hygiene-noop CANCELLED
+#
+# All ten twin pairs in this repo shared a group. Every one of them could stall
+# a PR on a check that never actually ran.
+#
+# Exit 0 clean, 1 on a collision.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+
+for f in .github/workflows/*.yml .github/workflows/*.yaml; do
+    [[ -e "$f" ]] || continue
+    name="$(grep -m1 '^name:' "$f" 2>/dev/null | sed 's/^name: *//' || true)"
+    group="$(grep -m1 '^  group:' "$f" 2>/dev/null | sed 's/^ *group: *//' || true)"
+    # A workflow with no explicit concurrency group cannot collide on one.
+    [[ -n "$name" && -n "$group" ]] || continue
+    # Tab-separated: the group expression itself contains `||`.
+    printf '%s\t%s\t%s\n' "$name" "$group" "$f" >>"$tmp"
+done
+
+collisions="$(
+    awk -F'\t' '
+        { key = $1 FS $2; files[key] = files[key] " " $3; n[key]++ }
+        END { for (k in n) if (n[k] > 1) { split(k, p, FS); print p[1] "\t" p[2] "\t" files[k] } }
+    ' "$tmp"
+)"
+
+if [[ -n "$collisions" ]]; then
+    echo "FAIL: workflows share a name AND a concurrency group." >&2
+    echo "" >&2
+    echo "They will cancel each other, and a cancelled check-run turns the PR's" >&2
+    echo "status rollup FAILURE even though no test failed." >&2
+    echo "" >&2
+    while IFS=$'\t' read -r name group files; do
+        echo "  name:  ${name}" >&2
+        echo "  group: ${group}" >&2
+        echo "  files:${files}" >&2
+        echo "" >&2
+    done <<<"$collisions"
+    echo "Give each file its own group literal (e.g. 'foo-real-' / 'foo-noop-')," >&2
+    echo "so cancel-in-progress still supersedes a run's OWN older attempts" >&2
+    echo "without the twins killing one another." >&2
+    exit 1
+fi
+
+echo "OK: no two workflows share both a name and a concurrency group."
+exit 0


### PR DESCRIPTION
Ten workflow pairs share a `name:` on purpose — the `-noop` twin reports the same required status context when the real one is filtered out by `paths`. That design is sound. The concurrency group built on top of it is not.

`${{ github.workflow }}` is the **display name**, which the twins share by definition, so both files resolved to the same group:

```yaml
group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
cancel-in-progress: <true on pull_request>
```

The twins are supposed to be mutually exclusive. They are not: **`paths-ignore` fires whenever ANY changed file falls outside its list**, so a PR touching both a filtered and an unfiltered path triggers *both*. Sharing a group, whichever starts second cancels the first — and a `CANCELLED` check-run makes the rollup `FAILURE` even though no test failed.

## Measured

Same branch, consecutive SHAs — note the loser alternates:

| sha | dep-hygiene | dep-hygiene-noop |
| --- | --- | --- |
| 1d33c74e | **CANCELLED** | success |
| c16a57b8 | success | **CANCELLED** |
| e8068be0 | success | success *(after a manual re-run)* |

**All ten pairs shared a group.** This is why PRs here sit `BLOCKED` with nothing red, and why re-running one run "fixes" it — the re-run is just the last writer.

## Fix

Each file gets its own literal (`<base>-real-` / `<base>-noop-`), so `cancel-in-progress` still supersedes a workflow's **own** older attempts — what it was actually for — without the twins killing one another.

## The gate is the half that keeps it fixed

`ci/twin-workflows-have-distinct-concurrency.sh` fails when two workflow files share both a name and a concurrency group. The bug survived in ten pairs precisely because nothing looked.

Verified both directions:
- fixed tree → exit 0
- re-point one twin at its sibling's group → exit **1**, message names the pair and both files
- restore → passes again
- shellcheck clean

## Corrects an earlier diagnosis

These cancellations were previously blamed on GitHub occasionally creating two runs for one event. It does not need to — two different workflow *files* with the same name and one shared group is sufficient, and that is what was happening.