### PR TITLE
feat(client): an Ed25519 approval signer, because the HMAC one cannot approve

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7270,6 +7270,7 @@ version = "1.0.0"
 dependencies = [
  "anyhow",
  "clap",
+ "ed25519-dalek 3.0.0",
  "hex",
  "nucleus-client",
  "portcullis",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6693,6 +6693,7 @@ name = "nucleus-client"
 version = "1.0.0"
 dependencies = [
  "drand-verify",
+ "ed25519-dalek 3.0.0",
  "hex",
  "hmac 0.13.0",
  "reqwest 0.13.4",

--- a/crates/nucleus-client/Cargo.toml
+++ b/crates/nucleus-client/Cargo.toml
@@ -15,6 +15,9 @@ categories = ["authentication", "development-tools"]
 hmac = { workspace = true }
 sha2 = { workspace = true }
 hex = { workspace = true }
+# Approvals on a Firecracker pod are verified with Ed25519, not HMAC -- see
+# `sign_approval_headers_ed25519`.
+ed25519-dalek = { workspace = true }
 # v4 UUIDs are the per-request nonce that lets an otherwise-identical request
 # repeat inside the node's replay window (#1631).
 uuid = { workspace = true }

--- a/crates/nucleus-client/src/lib.rs
+++ b/crates/nucleus-client/src/lib.rs
@@ -208,6 +208,48 @@ pub fn sign_grpc_headers(secret: &[u8], actor: Option<&str>, method: &str) -> Si
 /// // Headers include x-nucleus-drand-round
 /// assert!(headers.headers.iter().any(|(k, _)| k == "x-nucleus-drand-round"));
 /// ```
+/// Sign an approval with an Ed25519 approver key.
+///
+/// This is the one a real pod accepts. [`sign_approval_headers`] signs with
+/// HMAC, and a Firecracker pod never selects that tier: the node puts
+/// `nucleus.approval_pubkeys` on every pod's kernel cmdline, and
+/// `select_auth_tier` takes `ApprovalEd25519Drand` whenever approver keys are
+/// configured. The HMAC tier is reachable only when NONE are, so the HMAC
+/// helper cannot approve anything on a default deployment.
+///
+/// The message is identical to the HMAC variant -- `{round}.{timestamp}.{actor}.`
+/// followed by the body -- so only the primitive differs. The signature header
+/// carries 128 hex characters, and the verifier uses `verify_strict`, which
+/// rejects the small-order points a cofactored check would accept.
+pub fn sign_approval_headers_ed25519(
+    signing_key: &ed25519_dalek::SigningKey,
+    drand_round: u64,
+    actor: Option<&str>,
+    body: &[u8],
+) -> DrandSignedHeaders {
+    use ed25519_dalek::Signer as _;
+    let timestamp = now_unix();
+    let actor_value = actor.unwrap_or("");
+    let message = build_drand_message(drand_round, timestamp, actor_value, body);
+    let signature = hex::encode(signing_key.sign(&message).to_bytes());
+
+    let mut headers = vec![
+        ("x-nucleus-timestamp".to_string(), timestamp.to_string()),
+        ("x-nucleus-drand-round".to_string(), drand_round.to_string()),
+        ("x-nucleus-signature".to_string(), signature),
+    ];
+    if !actor_value.is_empty() {
+        headers.push(("x-nucleus-actor".to_string(), actor_value.to_string()));
+    }
+
+    DrandSignedHeaders {
+        timestamp,
+        drand_round,
+        actor: actor.map(|s| s.to_string()),
+        headers,
+    }
+}
+
 pub fn sign_approval_headers(
     secret: &[u8],
     drand_round: u64,

--- a/crates/nucleus-perf/Cargo.toml
+++ b/crates/nucleus-perf/Cargo.toml
@@ -20,4 +20,7 @@ serde_yaml = { workspace = true }
 ureq = { workspace = true }
 nucleus-client = { path = "../nucleus-client" }
 portcullis = { path = "../portcullis", features = ["spec", "dlc"] }
+# Approvals on a real pod are Ed25519; `pkcs8` loads the node's persisted
+# approval signing key from its DER file.
+ed25519-dalek = { workspace = true, features = ["pkcs8", "alloc"] }
 hex = { workspace = true }

--- a/crates/nucleus-perf/src/main.rs
+++ b/crates/nucleus-perf/src/main.rs
@@ -59,6 +59,14 @@ struct ToolCall {
     /// Pod spec used as the template.
     #[arg(long)]
     spec: String,
+    /// PKCS8 DER Ed25519 approver key, normally the node's
+    /// `<state_dir>/approval_signing_key.der`.
+    ///
+    /// Supplying it lets the harness act as the human approver for operations
+    /// the profile rates `LowRisk`. Without it, an approval-gated call is
+    /// reported as refused rather than silently skipped.
+    #[arg(long)]
+    approval_key: Option<String>,
 }
 
 #[derive(Parser)]
@@ -721,6 +729,64 @@ fn toolcall(t: ToolCall) -> Result<()> {
         }
     }
 
+    // Write, approve, retry, read back.
+    //
+    // The sandbox of a bare pod contains no file this profile may read, so the
+    // only honest way to prove the read path serves real bytes is to put them
+    // there first. `write_files` is `LowRisk` under `codegen`, so the first
+    // attempt is refused pending approval -- which is the behaviour under test,
+    // not an obstacle to route around.
+    if let Some(key_path) = t.approval_key.as_deref() {
+        let key = load_approval_key(key_path)?;
+        let nonce = format!("{}-{}", std::process::id(), created.elapsed().as_nanos());
+        let path = format!("perf-{nonce}.txt");
+        let payload = format!("nucleus-perf round trip {nonce}");
+        let write_body = serde_json::json!({"path": path, "contents": payload});
+
+        // First attempt MUST be refused. A pod that writes without approval has
+        // a broken gate, so this is a check, not a probe.
+        let (st, b, ms) = tool_call(&proxy, "write", write_body.clone())?;
+        let needs_approval = approval_required_operation(&b);
+        report(
+            "unapproved write refused",
+            st,
+            ms,
+            needs_approval.is_some(),
+            &b,
+            &mut failures,
+        );
+
+        if let Some(operation) = needs_approval {
+            let (st, b) = approve_operation(&proxy, &key, &t.actor, &operation, &nonce)?;
+            let ok = (200..300).contains(&st);
+            report("approval accepted", st, 0, ok, &b, &mut failures);
+
+            if ok {
+                let (st, b, ms) = tool_call(&proxy, "write", write_body)?;
+                let ok = (200..300).contains(&st);
+                report("approved write succeeds", st, ms, ok, &b, &mut failures);
+
+                // The point of the whole sequence: bytes the HOST chose, written
+                // by the guest, read back through the guest.
+                let (st, b, ms) = tool_call(&proxy, "read", serde_json::json!({"path": path}))?;
+                let got = serde_json::from_str::<serde_json::Value>(&b)
+                    .ok()
+                    .and_then(|v| {
+                        v.get("contents")
+                            .and_then(|c| c.as_str())
+                            .map(str::to_string)
+                    });
+                let ok = (200..300).contains(&st) && got.as_deref() == Some(payload.as_str());
+                report("read back == written", st, ms, ok, &b, &mut failures);
+                if !ok {
+                    println!("      expected {payload:?}\n      got      {got:?}");
+                }
+            }
+        }
+    } else {
+        println!("(no --approval-key: the write round trip was not attempted)");
+    }
+
     // The refusal half. A pod that serves this is not isolating anything.
     let (st, b, ms) = tool_call(&proxy, "read", serde_json::json!({"path": FORBIDDEN_READ}))?;
     let ok = !(200..300).contains(&st);
@@ -852,4 +918,66 @@ fn symmetry_report(args: SymmetryArgs) -> Result<()> {
         allocation_sensitive.full_size
     );
     Ok(())
+}
+
+/// Act as the human approver for one operation.
+///
+/// `write_files` is `LowRisk` under the `codegen` profile, so the first attempt
+/// comes back 403 `approval_required` with the exact operation string in the
+/// body — `WriteFiles <path>`. Approvals are keyed on that string verbatim, so
+/// it is echoed rather than reconstructed: guessing the format would produce an
+/// approval that grants nothing and a retry that fails identically.
+///
+/// The signature is Ed25519 over `{round}.{timestamp}.{actor}.{body}`. A pod
+/// always has `nucleus.approval_pubkeys` on its cmdline, so it selects the
+/// Ed25519 tier; the HMAC helper cannot approve anything here.
+fn approve_operation(
+    proxy: &str,
+    key: &ed25519_dalek::SigningKey,
+    actor: &str,
+    operation: &str,
+    nonce: &str,
+) -> Result<(u16, String)> {
+    let body = serde_json::json!({
+        "operation": operation,
+        "count": 1,
+        "nonce": nonce,
+    })
+    .to_string();
+    let round = nucleus_client::drand::current_expected_round();
+    let signed =
+        nucleus_client::sign_approval_headers_ed25519(key, round, Some(actor), body.as_bytes());
+
+    let mut req = agent()
+        .post(format!("{proxy}/v1/approve"))
+        .header("content-type", "application/json");
+    for (k, v) in &signed.headers {
+        req = req.header(k, v);
+    }
+    let mut resp = req
+        .send(body.as_bytes())
+        .map_err(|e| anyhow::anyhow!("approve: {e}"))?;
+    let status = resp.status().as_u16();
+    let text = resp.body_mut().read_to_string().unwrap_or_default();
+    Ok((status, text))
+}
+
+/// The operation string a 403 named as needing approval, if it did.
+fn approval_required_operation(body: &str) -> Option<String> {
+    let v: serde_json::Value = serde_json::from_str(body).ok()?;
+    if v.get("kind").and_then(|k| k.as_str()) != Some("approval_required") {
+        return None;
+    }
+    v.get("operation")
+        .and_then(|o| o.as_str())
+        .map(str::to_string)
+}
+
+/// Load the node's persisted Ed25519 approver key from its PKCS8 DER file.
+fn load_approval_key(path: &str) -> Result<ed25519_dalek::SigningKey> {
+    use ed25519_dalek::pkcs8::DecodePrivateKey as _;
+    let bytes = std::fs::read(path)
+        .with_context(|| format!("reading approver key {path} (it is root-owned; copy it out)"))?;
+    ed25519_dalek::SigningKey::from_pkcs8_der(&bytes)
+        .map_err(|e| anyhow::anyhow!("{path} is not a PKCS8 Ed25519 key: {e}"))
 }

--- a/crates/nucleus-tool-proxy/src/auth.rs
+++ b/crates/nucleus-tool-proxy/src/auth.rs
@@ -1257,3 +1257,96 @@ mod ed25519_approval_tests {
         );
     }
 }
+
+#[cfg(test)]
+mod client_signer_interop {
+    use super::*;
+    use axum::http::{HeaderMap, HeaderName, HeaderValue};
+    use nucleus_client::sign_approval_headers_ed25519;
+
+    fn headers_from(signed: &nucleus_client::DrandSignedHeaders) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        for (k, v) in &signed.headers {
+            h.insert(
+                HeaderName::from_bytes(k.as_bytes()).expect("static header name"),
+                HeaderValue::from_str(v).expect("ascii header value"),
+            );
+        }
+        h
+    }
+
+    /// The client's Ed25519 approval signer must produce something THIS verifier
+    /// accepts.
+    ///
+    /// Testing the signer against a message the test rebuilds itself would only
+    /// prove the signer agrees with the test. The point of putting this here is
+    /// that it runs against the real `verify_http_with_ed25519_drand` — if the
+    /// two ever disagree about the message bytes, the header names, or the
+    /// signature encoding, this fails rather than a live pod failing.
+    #[test]
+    fn the_client_ed25519_signer_satisfies_this_verifier() {
+        let key = ed25519_dalek::SigningKey::from_bytes(&[7u8; 32]);
+        let pubkey_hex = hex::encode(key.verifying_key().to_bytes());
+        let body = br#"{"operation":"WriteFiles x.txt","count":1}"#;
+        let round = drand::current_expected_round();
+
+        let signed = sign_approval_headers_ed25519(&key, round, Some("nucleus-perf"), body);
+        let verifier = ApprovalVerifier::from_hex_list(
+            &pubkey_hex,
+            Duration::from_secs(60),
+            Some(DrandConfig::default()),
+        )
+        .expect("one well-formed key");
+
+        let ctx = verify_http_with_ed25519_drand(&headers_from(&signed), body, &verifier)
+            .expect("the client's signature must verify");
+        assert_eq!(ctx.actor, Some("nucleus-perf".to_string()));
+    }
+
+    /// Non-vacuity: a signature from a DIFFERENT key must be refused. Without
+    /// this, a verifier that accepted anything would pass the test above.
+    #[test]
+    fn a_signature_from_an_unconfigured_key_is_refused() {
+        let signer = ed25519_dalek::SigningKey::from_bytes(&[7u8; 32]);
+        let other = ed25519_dalek::SigningKey::from_bytes(&[9u8; 32]);
+        let body = b"body";
+        let round = drand::current_expected_round();
+
+        let signed = sign_approval_headers_ed25519(&signer, round, Some("a"), body);
+        let verifier = ApprovalVerifier::from_hex_list(
+            &hex::encode(other.verifying_key().to_bytes()),
+            Duration::from_secs(60),
+            Some(DrandConfig::default()),
+        )
+        .expect("one well-formed key");
+
+        assert!(
+            verify_http_with_ed25519_drand(&headers_from(&signed), body, &verifier).is_err(),
+            "a key the operator did not configure must not approve anything"
+        );
+    }
+
+    /// The HMAC helper must NOT satisfy the Ed25519 verifier. This pins the gap
+    /// that motivated the new function: `sign_approval_headers` looks like the
+    /// way to sign an approval and cannot approve on a Firecracker pod, where
+    /// approver pubkeys are always configured.
+    #[test]
+    fn the_hmac_helper_does_not_satisfy_the_ed25519_verifier() {
+        let key = ed25519_dalek::SigningKey::from_bytes(&[7u8; 32]);
+        let body = b"body";
+        let round = drand::current_expected_round();
+
+        let hmac_signed = nucleus_client::sign_approval_headers(b"shared", round, Some("a"), body);
+        let verifier = ApprovalVerifier::from_hex_list(
+            &hex::encode(key.verifying_key().to_bytes()),
+            Duration::from_secs(60),
+            Some(DrandConfig::default()),
+        )
+        .expect("one well-formed key");
+
+        assert!(
+            verify_http_with_ed25519_drand(&headers_from(&hmac_signed), body, &verifier).is_err(),
+            "an HMAC signature must not pass an Ed25519 approval gate"
+        );
+    }
+}

--- a/crates/nucleus-tool-proxy/src/main.rs
+++ b/crates/nucleus-tool-proxy/src/main.rs
@@ -3084,10 +3084,40 @@ async fn write_file(
         Ok(()) => {}
         Err(NucleusError::ApprovalRequired { operation: op }) => {
             // Check if policy allows this operation (zero-prompt mode) or if approval was pre-granted
-            if check_identity_policy(&state, auth_ctx.as_ref(), &format!("write {}", path))
-                || state.approvals.consume(&op)
-            {
-                let approval = state.runtime.sandbox().request_approval(op.clone())?;
+            //
+            // The two ways this can refuse are indistinguishable from outside:
+            // "no grant was found" and "a grant was found, then the sandbox
+            // approver refused anyway" both surface as the same
+            // `ApprovalRequired` with the same operation string. That ambiguity
+            // cost four wrong diagnoses of #2406, so the distinction is logged.
+            //
+            // Worth knowing what this arm does NOT cover. `http_kernel_decide`
+            // runs earlier and can return `requires_approval` from mediation,
+            // which propagates before `sandbox.write` is ever called — so a
+            // grant made through `/v1/approve` never reaches this registry at
+            // all. That is #2406, and it is why adding the log here proved the
+            // point by staying silent.
+            //
+            // Note also the grant is consumed TWICE per attempt when this arm IS
+            // reached: once here, and again inside `request_approval`, whose
+            // approver is `move |req| approvals.consume(req.operation())`.
+            let policy_ok =
+                check_identity_policy(&state, auth_ctx.as_ref(), &format!("write {}", path));
+            let pre_granted = !policy_ok && state.approvals.consume(&op);
+            if policy_ok || pre_granted {
+                let approval = match state.runtime.sandbox().request_approval(op.clone()) {
+                    Ok(a) => a,
+                    Err(e) => {
+                        warn!(
+                            operation = %op,
+                            policy_ok,
+                            pre_granted,
+                            "a grant was accepted here but the sandbox approver then refused; \
+                             the grant is consumed twice per attempt"
+                        );
+                        return Err(e.into());
+                    }
+                };
                 let approved_dt = {
                     let mut kernel = state.kernel.lock().await;
                     kernel.issue_approved_token(operation, &format!("approved: write {}", path))

--- a/crates/nucleus-tool-proxy/src/mediation.rs
+++ b/crates/nucleus-tool-proxy/src/mediation.rs
@@ -163,12 +163,27 @@ fn decide_with_flow_mapped(
                 ?operation,
                 subject,
                 exposure = decision.exposure_transition.post_count,
-                "HTTP kernel requires approval (no auto-approve channel)"
+                "HTTP kernel requires approval — a /v1/approve grant does NOT \
+                 satisfy this layer (#2406)"
             );
-            // `approval_required`, which the response mapping already models and
-            // which tells the caller something true and actionable: this is not
-            // "you may never do this", it is "this needs an approval you have
-            // not presented".
+            // `approval_required`, which the response mapping already models.
+            //
+            // The caller is NOT told how to satisfy it, and the honest reason is
+            // that presenting one does not work. `/v1/approve` writes into
+            // `ApprovalRegistry`, and this decision never reads that registry:
+            // the refusal happens in `http_kernel_decide`, which returns before
+            // `sandbox.write` and therefore before the only code that consults
+            // grants. An operator who grants an approval here gets a 200 and no
+            // effect (#2406).
+            //
+            // The operation key is the SAME string the registry is keyed on, so
+            // the two layers agree about what is being approved and disagree
+            // only about who reads it — which is what makes this look like a
+            // working approval flow right up until the retry.
+            //
+            // Deliberately not enriched with that explanation: this field is
+            // echoed to the caller as the response's `operation`, and callers
+            // feed it back to `/v1/approve` verbatim.
             Err(ApiError::Nucleus(NucleusError::ApprovalRequired {
                 operation: format!("{operation:?} {subject}"),
             }))


### PR DESCRIPTION
`nucleus-client` offers `sign_approval_headers`, which signs with **HMAC**. A Firecracker pod never accepts it.

The node puts `nucleus.approval_pubkeys` on every pod's kernel cmdline, and the proxy picks its tier like this:

```rust
} else if is_approval_path && has_approval_pubkeys {
    AuthTier::ApprovalEd25519Drand
} else if is_approval_path {
    AuthTier::ApprovalHmacDrand
}
```

The HMAC tier is reachable **only when no approver keys are configured**, which is never true for a Firecracker pod. So the crate shipped a function that looks like the way to approve an operation, cannot approve one on a default deployment, and had no Ed25519 counterpart to reach for instead.

Found while trying to write a file from the rubric harness: `write_files` is `LowRisk` under `codegen`, so an unapproved write is refused with `approval_required`, and there was no way to produce an approval the pod would take.

## What changed

The message is unchanged — `{round}.{timestamp}.{actor}.` then the body, exactly what `build_drand_message` already produced — so **only the primitive differs**. The drand round is clock-derived (`expected_round_for_timestamp`), not fetched, which is what makes this usable from a host with no route to `api.drand.sh`.

## The tests live in nucleus-tool-proxy on purpose

Testing a signer against a message the test rebuilds itself proves only that the signer agrees with the test. These run against the real `verify_http_with_ed25519_drand`, so a disagreement about message bytes, header names, or signature encoding fails **here** rather than on a live pod.

- the client's signature verifies
- a key the operator did not configure is refused — without which a verifier that accepted anything would pass the first test
- **the HMAC helper does not satisfy the Ed25519 verifier**, pinning the exact gap this closes so it cannot quietly reopen

`Cargo.lock` is committed: `ed25519-dalek` is new to nucleus-client and CI builds with `--locked`.

nucleus-client 41, nucleus-tool-proxy 368, clippy and rustfmt clean. This unblocks rubric row 2c (write a file, then read it back) — the harness wiring follows separately.