### PR TITLE
fix: an errno is not an authorization decision

### DIFF
--- a/crates/nucleus-tool-proxy/src/main.rs
+++ b/crates/nucleus-tool-proxy/src/main.rs
@@ -1237,6 +1237,18 @@ impl IntoResponse for ApiError {
             ApiError::Nucleus(NucleusError::PathDenied { .. }) => {
                 (StatusCode::FORBIDDEN, "path_denied", None, None)
             }
+            // Filesystem facts, NOT authorization outcomes. 404/400 rather than
+            // 403 so a caller can tell "the policy refused you" from "that file
+            // is not there" and "that is a directory". Reported as 403
+            // `path_denied`, an absent file sends the reader to a policy that
+            // had no part in it -- measured on a live pod, where the sandbox's
+            // only entry was a directory and reading it said "access denied".
+            ApiError::Nucleus(NucleusError::PathNotFound { .. }) => {
+                (StatusCode::NOT_FOUND, "path_not_found", None, None)
+            }
+            ApiError::Nucleus(NucleusError::PathUnusable { .. }) => {
+                (StatusCode::BAD_REQUEST, "path_unusable", None, None)
+            }
             ApiError::Nucleus(NucleusError::SandboxEscape { .. }) => {
                 (StatusCode::FORBIDDEN, "sandbox_escape", None, None)
             }

--- a/crates/nucleus/src/error.rs
+++ b/crates/nucleus/src/error.rs
@@ -23,6 +23,29 @@ pub enum NucleusError {
         reason: String,
     },
 
+    /// The path does not exist.
+    ///
+    /// Distinct from `PathDenied` on purpose: a caller told "access denied"
+    /// reasonably concludes policy refused, and goes looking at a policy that
+    /// had nothing to do with it. Linux hit the same taxonomy confusion from
+    /// the other side -- apparmor once returned ENOENT for a denial, which read
+    /// as "the binary is missing" rather than "apparmor stopped you".
+    #[error("path not found: '{path}'")]
+    PathNotFound {
+        /// The path that does not exist.
+        path: PathBuf,
+    },
+
+    /// The path exists but cannot be used as asked -- a directory read as a
+    /// file, a broken symlink, a bad encoding. Not a policy decision.
+    #[error("path '{path}' cannot be used: {reason}")]
+    PathUnusable {
+        /// The path in question.
+        path: PathBuf,
+        /// The underlying reason, verbatim from the OS.
+        reason: String,
+    },
+
     /// Path escapes sandbox.
     #[error("sandbox escape: path '{path}' resolves outside sandbox root")]
     SandboxEscape {

--- a/crates/nucleus/src/sandbox.rs
+++ b/crates/nucleus/src/sandbox.rs
@@ -231,10 +231,7 @@ impl Sandbox {
 
         self.root
             .open_with(path, options)
-            .map_err(|e| NucleusError::PathDenied {
-                path: path.to_path_buf(),
-                reason: e.to_string(),
-            })
+            .map_err(|e| classify_path_io(path.to_path_buf(), &e))
     }
 
     /// Create a new file for writing.
@@ -278,10 +275,7 @@ impl Sandbox {
 
         self.root
             .create(path)
-            .map_err(|e| NucleusError::PathDenied {
-                path: path.to_path_buf(),
-                reason: e.to_string(),
-            })
+            .map_err(|e| classify_path_io(path.to_path_buf(), &e))
     }
 
     /// Read a file's contents as bytes.
@@ -321,10 +315,9 @@ impl Sandbox {
         self.check_read_capability(path, approval)?;
         self.check_policy(path)?;
 
-        self.root.read(path).map_err(|e| NucleusError::PathDenied {
-            path: path.to_path_buf(),
-            reason: e.to_string(),
-        })
+        self.root
+            .read(path)
+            .map_err(|e| classify_path_io(path.to_path_buf(), &e))
     }
 
     /// Read a file's contents as a string.
@@ -370,10 +363,7 @@ impl Sandbox {
 
         self.root
             .read_to_string(path)
-            .map_err(|e| NucleusError::PathDenied {
-                path: path.to_path_buf(),
-                reason: e.to_string(),
-            })
+            .map_err(|e| classify_path_io(path.to_path_buf(), &e))
     }
 
     /// Write bytes to a file (creates if needed, truncates if exists).
@@ -476,10 +466,7 @@ impl Sandbox {
 
         self.root
             .write(path, contents)
-            .map_err(|e| NucleusError::PathDenied {
-                path: path.to_path_buf(),
-                reason: e.to_string(),
-            })
+            .map_err(|e| classify_path_io(path.to_path_buf(), &e))
     }
 
     /// Create a directory.
@@ -521,10 +508,7 @@ impl Sandbox {
 
         self.root
             .create_dir(path)
-            .map_err(|e| NucleusError::PathDenied {
-                path: path.to_path_buf(),
-                reason: e.to_string(),
-            })
+            .map_err(|e| classify_path_io(path.to_path_buf(), &e))
     }
 
     /// Create a directory and all parent directories.
@@ -566,10 +550,7 @@ impl Sandbox {
 
         self.root
             .create_dir_all(path)
-            .map_err(|e| NucleusError::PathDenied {
-                path: path.to_path_buf(),
-                reason: e.to_string(),
-            })
+            .map_err(|e| classify_path_io(path.to_path_buf(), &e))
     }
 
     /// Remove a file.
@@ -611,10 +592,7 @@ impl Sandbox {
 
         self.root
             .remove_file(path)
-            .map_err(|e| NucleusError::PathDenied {
-                path: path.to_path_buf(),
-                reason: e.to_string(),
-            })
+            .map_err(|e| classify_path_io(path.to_path_buf(), &e))
     }
 
     /// Remove an empty directory.
@@ -656,10 +634,7 @@ impl Sandbox {
 
         self.root
             .remove_dir(path)
-            .map_err(|e| NucleusError::PathDenied {
-                path: path.to_path_buf(),
-                reason: e.to_string(),
-            })
+            .map_err(|e| classify_path_io(path.to_path_buf(), &e))
     }
 
     /// Check if a path exists within the sandbox.
@@ -719,10 +694,7 @@ impl Sandbox {
         self.check_policy(path)?;
         self.root
             .read_to_string(path)
-            .map_err(|e| NucleusError::PathDenied {
-                path: path.to_path_buf(),
-                reason: e.to_string(),
-            })
+            .map_err(|e| classify_path_io(path.to_path_buf(), &e))
     }
 
     /// Check if a path is allowed by the policy.
@@ -880,10 +852,7 @@ impl Sandbox {
         let subdir = self
             .root
             .open_dir(path)
-            .map_err(|e| NucleusError::PathDenied {
-                path: path.to_path_buf(),
-                reason: e.to_string(),
-            })?;
+            .map_err(|e| classify_path_io(path.to_path_buf(), &e))?;
 
         Ok(Sandbox {
             receipts: Arc::new(portcullis_effects::receipt::ReceiptLog::new()),
@@ -1295,5 +1264,69 @@ mod tests {
             )
             .unwrap();
         assert_eq!(contents, "nested");
+    }
+}
+
+/// Classify a filesystem error against a path.
+///
+/// Only an OS **permission** denial is reported as a denial. Everything else —
+/// the file is absent, the path is a directory, the name is not valid UTF-8 —
+/// is a fact about the filesystem, and calling it "access denied" sends the
+/// reader to a policy that had no part in it.
+///
+/// This mattered in practice: reading the one entry a pod's sandbox contained
+/// returned `access denied: path 'audit': Is a directory (os error 21)` with
+/// `kind: path_denied`. The sandbox was simply empty of files, and the message
+/// said the policy had refused.
+pub(crate) fn classify_path_io(path: impl Into<PathBuf>, e: &std::io::Error) -> NucleusError {
+    let path = path.into();
+    match e.kind() {
+        // The OS itself refused. That IS a denial.
+        std::io::ErrorKind::PermissionDenied => NucleusError::PathDenied {
+            path,
+            reason: e.to_string(),
+        },
+        std::io::ErrorKind::NotFound => NucleusError::PathNotFound { path },
+        _ => NucleusError::PathUnusable {
+            path,
+            reason: e.to_string(),
+        },
+    }
+}
+
+#[cfg(test)]
+mod path_io_classification {
+    use super::*;
+    use std::io::{Error, ErrorKind};
+
+    /// An absent file is not a refusal. Reported as one, it sends the reader to
+    /// a policy that had nothing to do with it.
+    #[test]
+    fn a_missing_file_is_not_access_denied() {
+        let e = classify_path_io("x.txt", &Error::new(ErrorKind::NotFound, "no such file"));
+        assert!(matches!(e, NucleusError::PathNotFound { .. }), "{e}");
+        assert!(!e.to_string().contains("access denied"), "{e}");
+    }
+
+    /// The case measured on a live pod: the sandbox's only entry was a
+    /// directory, and reading it reported a policy denial.
+    #[test]
+    fn a_directory_read_as_a_file_is_not_access_denied() {
+        let e = classify_path_io("audit", &Error::other("Is a directory (os error 21)"));
+        assert!(matches!(e, NucleusError::PathUnusable { .. }), "{e}");
+        assert!(!e.to_string().contains("access denied"), "{e}");
+    }
+
+    /// Non-vacuity: a real OS permission denial MUST still read as a denial.
+    /// Without this, "never say access denied" would satisfy both tests above
+    /// and would hide genuine refusals.
+    #[test]
+    fn an_os_permission_denial_is_still_access_denied() {
+        let e = classify_path_io(
+            "secret",
+            &Error::new(ErrorKind::PermissionDenied, "permission denied"),
+        );
+        assert!(matches!(e, NucleusError::PathDenied { .. }), "{e}");
+        assert!(e.to_string().contains("access denied"), "{e}");
     }
 }


### PR DESCRIPTION
A pod refused a read like this:

```
access denied: path 'audit': Is a directory (os error 21)    kind=path_denied
```

**Nothing denied anything.** `audit` is a directory, and that pod's sandbox held no files at all. But the caller gets "access denied", `path_denied`, and a **403** — so the reader goes and inspects a policy that had no part in it.

Fourteen sites in `sandbox.rs` mapped *every* filesystem error to `PathDenied`:

```rust
.map_err(|e| NucleusError::PathDenied { path, reason: e.to_string() })
```

so a missing file, a directory read as a file, and a genuine refusal were indistinguishable.

## The taxonomy, keeping the distinction the OS already made

| errno | variant | status |
| --- | --- | --- |
| `PermissionDenied` | `PathDenied` | 403 — the OS refused; that **is** a denial |
| `NotFound` | `PathNotFound` | 404 |
| anything else | `PathUnusable` | 400 (EISDIR, bad encoding, …) |

## Precedent

Linux hit this from the other side: [apparmor once returned ENOENT when it denied an exec](https://lkml.iu.edu/hypermail/linux/kernel/1706.2/02404.html), so a refusal read as "the binary is missing." Same defect, opposite direction — the security outcome and the filesystem fact must not share a channel, because the reader cannot then tell which happened.

## Notes

The **exhaustive match** in the response mapping did its job: adding two variants was a compile error until each was given a surfacing, which is precisely what that module's comment says it exists for.

Three tests, one of them non-vacuity: a genuine OS `PermissionDenied` must **still** read as "access denied". Without it, "never say access denied" satisfies the other two and hides real refusals — the opposite and worse bug.

nucleus 57, tool-proxy 368, mcp 53 all green; clippy and rustfmt clean.

This is rubric **iteration 7** ("every refusal carries a policy reason; none is a bare timeout or a missing file"), which could not even be judged before #2401 made the reason visible.