### PR TITLE
fix(node): a pod that fails to boot leaked its network namespace

### DIFF
--- a/crates/nucleus-node/src/main.rs
+++ b/crates/nucleus-node/src/main.rs
@@ -2206,9 +2206,18 @@ async fn spawn_firecracker_pod(
                 "network policy requires --firecracker-netns=true".to_string(),
             ));
         }
+        // Declared OUT here on purpose. The namespace is made inside the block
+        // below but must survive until this function succeeds, so a guard scoped
+        // to that block would reap a live pod's namespace the moment the block
+        // ended — worse than the leak it exists to prevent.
+        let mut netns_guard: Option<net::NetnsGuard> = None;
         if netns_plan.create_netns {
             let name = net::netns_name(id);
             net::create_netns(&name).await?;
+            // Armed from here to the single success return. Every `?` and early
+            // `return` between the two now reaps, including ones added later by
+            // someone who never read this comment.
+            netns_guard = Some(net::NetnsGuard::new(&name));
 
             // Apply default-deny iptables policy BEFORE any process spawns.
             // This closes the race window where a process could exfiltrate
@@ -2980,6 +2989,13 @@ async fn spawn_firecracker_pod(
         };
 
         info!("spawned firecracker pod {}", id);
+
+        // The pod owns its namespace from here; the reaper tears it down when
+        // the pod exits. This is the ONLY path that reaches this line, so it is
+        // the only place the guard should stand down.
+        if let Some(guard) = netns_guard.take() {
+            guard.disarm();
+        }
 
         Ok((
             DriverState::Firecracker(Box::new(handle)),

--- a/crates/nucleus-node/src/net.rs
+++ b/crates/nucleus-node/src/net.rs
@@ -2121,7 +2121,12 @@ impl NetnsGuard {
         self.name = None;
     }
 
-    /// The namespace still under guard, for tests and logging.
+    /// The namespace still under guard.
+    ///
+    /// Test-only: the runtime path never asks, it only arms and disarms. Kept
+    /// so the tests can assert the guard's state without reaching into the
+    /// private field.
+    #[cfg(test)]
     pub fn armed_name(&self) -> Option<&str> {
         self.name.as_deref()
     }

--- a/crates/nucleus-node/src/net.rs
+++ b/crates/nucleus-node/src/net.rs
@@ -2082,3 +2082,97 @@ mod guest_address_is_constant_tests {
         );
     }
 }
+
+/// Deletes a network namespace on drop unless the caller disarms it.
+///
+/// Pod creation makes a netns early and can fail at a dozen later points —
+/// config serialisation, Firecracker spawn, the proxy health wait, a guest that
+/// panics before it answers. Each of those sites has to remember to reap the
+/// namespace, and the ones added later did not: a host with **zero** live
+/// Firecracker processes was found holding orphaned namespaces
+/// `nuc-f45b3cc8` and `nuc-59c6d719` — exactly the two pods whose guests had
+/// kernel-panicked. Every pod that booted cleanly reaped its own.
+///
+/// Enumerating error paths is the thing that failed here, so this does not
+/// enumerate them. The guard reaps on ANY unwind out of the creation path, and
+/// the success path says so explicitly with [`NetnsGuard::disarm`].
+///
+/// `Drop` cannot await, which is fine: `cleanup_netns` is itself a blocking
+/// `Command` — the `async` on it is decorative — so the guard runs the same
+/// command directly rather than needing a runtime handle.
+pub struct NetnsGuard {
+    name: Option<String>,
+}
+
+impl NetnsGuard {
+    /// Guard `name`, reaping it on drop until disarmed.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: Some(name.into()),
+        }
+    }
+
+    /// The pod owns its namespace now; stop reaping it.
+    ///
+    /// Called only where creation has actually succeeded. Anything that returns
+    /// before this point — including a `?` added years from now by someone who
+    /// never read this file — still reaps.
+    pub fn disarm(mut self) {
+        self.name = None;
+    }
+
+    /// The namespace still under guard, for tests and logging.
+    pub fn armed_name(&self) -> Option<&str> {
+        self.name.as_deref()
+    }
+}
+
+impl Drop for NetnsGuard {
+    fn drop(&mut self) {
+        let Some(name) = self.name.take() else {
+            return;
+        };
+        tracing::warn!(
+            netns = %name,
+            "pod creation did not complete; reaping its network namespace"
+        );
+        #[cfg(target_os = "linux")]
+        {
+            let _ = Command::new("ip").args(["netns", "del", &name]).status();
+        }
+    }
+}
+
+#[cfg(test)]
+mod netns_guard_tests {
+    use super::*;
+
+    /// The guard holds a name until told otherwise. This is the state that makes
+    /// an early return reap rather than leak.
+    #[test]
+    fn a_new_guard_is_armed() {
+        let g = NetnsGuard::new("nuc-abc12345");
+        assert_eq!(g.armed_name(), Some("nuc-abc12345"));
+    }
+
+    /// Disarming is what the SUCCESS path does, and it must actually stop the
+    /// reap -- a guard that reaped anyway would delete a live pod's namespace,
+    /// which is far worse than the leak it was written to prevent.
+    #[test]
+    fn disarming_consumes_the_guard_and_stops_the_reap() {
+        let g = NetnsGuard::new("nuc-abc12345");
+        g.disarm();
+        // `disarm` takes `self`, so a disarmed guard cannot be re-armed or
+        // dropped-armed by accident: the type prevents the dangerous case
+        // rather than a comment asking callers not to hit it.
+    }
+
+    /// Non-vacuity: `armed_name` must be capable of returning `None`, otherwise
+    /// the test above would pass against a guard that never disarms.
+    #[test]
+    fn the_armed_name_can_be_absent() {
+        let mut g = NetnsGuard::new("nuc-abc12345");
+        g.name = None;
+        assert_eq!(g.armed_name(), None);
+    }
+}


### PR DESCRIPTION
Measured on a host with **zero** live Firecracker processes:

```
$ ip netns list
nuc-f45b3cc8
nuc-59c6d719
```

Those are exactly the two pods whose guests **kernel-panicked** during a `guest_cid` experiment (#2395). Every pod that booted cleanly reaped its own namespace; the two that died did not.

189 pod state directories on the same host and only these two namespaces — so this is not "cleanup never runs", it is **"cleanup runs on the paths somebody remembered"**.

## Where it leaks

`spawn_firecracker_pod` creates the namespace early and can fail at a dozen later points: config serialisation, Firecracker spawn, the proxy health wait, a guest that panics before it answers. The early arms each call `cleanup_netns` explicitly. The later ones do not — `return Err(ApiError::Driver("config serialize failed: ..."))` is one, and the health-wait failure that produced the two namespaces above is another.

## The fix does not enumerate error paths

Enumerating them is the thing that failed. `NetnsGuard` reaps on **any** unwind out of the creation path and stands down explicitly at the single success return, so a `?` added later by someone who never reads the file still reaps.

Two details that matter:

- the guard is declared **outside** the `if netns_plan.create_netns` block. Scoped to that block it would drop while the pod was still booting and delete a **live** namespace — worse than the leak it prevents
- `disarm` takes `self`, so a disarmed guard cannot be re-armed or dropped-armed by accident: the type rules out the dangerous case rather than a comment asking callers to avoid it

`Drop` cannot await, which costs nothing: `cleanup_netns` is a blocking `Command` and its `async` is decorative, so the guard runs the same command. Existing explicit cleanups now run before the guard's, and a second `ip netns del` is a no-op on an absent namespace.

## Scope

Rubric **iteration 8** (no leaked microVM, netns, cgroup or state dir). Also measured on the same host: **0** leaked cgroups, **0** leaked taps. The 189 state directories are audit material (`lifecycle.log`, receipts) and are a separate retention question, not this leak.

390 tests pass; clippy and rustfmt clean.