### PR TITLE
perf(tool-proxy): checkpoints for the startup stretches spans could not reach

### DIFF
--- a/crates/nucleus-tool-proxy/src/main.rs
+++ b/crates/nucleus-tool-proxy/src/main.rs
@@ -1426,6 +1426,7 @@ async fn main() -> Result<(), ApiError> {
     }
 
     let args = Args::parse();
+    st.mark("logging_init");
 
     // === Auth-secret sanity (fail-closed on a world-known key) ===
     // `auth_secret` is a required arg, but an EMPTY string satisfies "present"
@@ -1506,6 +1507,7 @@ async fn main() -> Result<(), ApiError> {
         move |request: &ApprovalRequest| approvals.consume(request.operation())
     });
     let runtime = runtime.with_approver(Arc::new(approver))?;
+    st.mark("runtime_build");
 
     let auth = AuthConfig::new(
         args.auth_secret.as_bytes(),
@@ -1900,6 +1902,7 @@ async fn main() -> Result<(), ApiError> {
         session_task_token,
     };
 
+    st.mark("state_build");
     if let Err(err) = st
         .timed("boot_report", boot_report::emit_boot_report_bounded(&state))
         .await
@@ -2071,6 +2074,7 @@ async fn main() -> Result<(), ApiError> {
         return Ok(());
     }
 
+    st.mark("serve_prep");
     let listener = st.timed("bind", TcpListener::bind(&args.listen)).await?;
     st.report();
     let addr = listener.local_addr()?;

--- a/crates/nucleus-tool-proxy/src/startup_trace.rs
+++ b/crates/nucleus-tool-proxy/src/startup_trace.rs
@@ -107,14 +107,19 @@ struct Milestone {
 /// Records how long each phase of tool-proxy startup took.
 pub(crate) struct Startup {
     start: Instant,
+    /// When the last milestone ended, so a checkpoint can measure the stretch
+    /// since it rather than since process start.
+    last: Instant,
     milestones: Vec<Milestone>,
 }
 
 impl Startup {
     /// Start the clock. Call as the first statement of `main`.
     pub(crate) fn new() -> Self {
+        let now = Instant::now();
         Self {
-            start: Instant::now(),
+            start: now,
+            last: now,
             milestones: Vec::new(),
         }
     }
@@ -143,7 +148,33 @@ impl Startup {
             self.start.elapsed().as_millis()
         );
         self.milestones.push(Milestone { name, millis });
+        // Reset the checkpoint clock too, so a later `mark` measures the stretch
+        // AFTER this phase rather than counting this phase again. Without this,
+        // marks and timed phases overlap and the milestones stop partitioning
+        // the timeline -- the sum could exceed the total.
+        self.last = Instant::now();
         out
+    }
+
+    /// Record the stretch since the previous milestone, without wrapping a call.
+    ///
+    /// `timed` needs a future to wrap. Most of startup is straight-line
+    /// statements with `?` and `await` interleaved, which cannot be wrapped
+    /// without restructuring code that has nothing to do with measurement -- so
+    /// those stretches went unmeasured, and `unaccounted` was 83% of the trace.
+    /// A checkpoint attributes the same time with one inserted line and no
+    /// change to control flow.
+    ///
+    /// Measures from the last milestone, not from process start, so consecutive
+    /// checkpoints partition the timeline instead of nesting.
+    pub(crate) fn mark(&mut self, name: &'static str) {
+        let millis = self.last.elapsed().as_millis();
+        self.last = Instant::now();
+        println!(
+            "nucleus-startup-phase {name}={millis}ms at={}ms",
+            self.start.elapsed().as_millis()
+        );
+        self.milestones.push(Milestone { name, millis });
     }
 
     /// The breakdown, as one line on the console the host captures.


### PR DESCRIPTION
`nucleus-startup-trace total=477ms unaccounted=398ms` — **83% of tool-proxy startup unattributed**, despite six phases already being timed. The phases were not wrong, they were *sparse*. Reading the `at=` offsets localised the missing time to four stretches **between** them:

| stretch | ~cost |
| --- | --- |
| process start → `sandbox_proof` | ~105 ms |
| `spec_read` → `audit_log` | ~109 ms |
| `audit_log` → `boot_report` | ~117 ms |
| `boot_report` → `bind` | ~37 ms |

## Why `timed` could not cover them

It wraps a future. Those stretches are straight-line statements with `?` and `await` interleaved — rustls provider install, tracing-subscriber init, arg parsing, runtime and approver construction, attestation verifier, node client, credential loading. Wrapping them means restructuring code that has nothing to do with measurement, and the restructuring is where mistakes get made.

`mark` measures the stretch since the previous milestone instead, so attributing a region costs **one inserted line** and no change to control flow.

## The subtle part

`timed` now also resets the checkpoint clock. Without it, a `mark` following a timed phase would count that phase a second time — the milestones would stop partitioning the timeline and the parts could sum to more than the total. That is worse than no trace, because it looks precise.

## Scope

Rubric iteration 9 (target `unaccounted` under 15%). Measured effect to follow in a comment. What this changes regardless: the remaining unaccounted time is now bounded by named checkpoints rather than spread across the whole of `main`.

370 tests pass. Clippy clean under **both** `-p` and `--all-targets` — the flag difference that let a dead-code error through to CI on #2408.