### PR TITLE
perf(tool-proxy): close the last big gap, and split the biggest phase

### DIFF
--- a/crates/nucleus-tool-proxy/src/main.rs
+++ b/crates/nucleus-tool-proxy/src/main.rs
@@ -1406,6 +1406,9 @@ async fn main() -> Result<(), ApiError> {
     // Install rustls crypto provider before any TLS connections (web_fetch, etc.).
     let mut st = startup_trace::Startup::new();
     let _ = rustls::crypto::ring::default_provider().install_default();
+    // Eager on purpose -- rustls panics on first TLS use if no provider is
+    // installed, so this cannot simply be deferred to save boot time.
+    st.mark("crypto_provider");
 
     {
         use tracing_subscriber::prelude::*;
@@ -1424,9 +1427,10 @@ async fn main() -> Result<(), ApiError> {
             )
             .init();
     }
+    st.mark("tracing_init");
 
     let args = Args::parse();
-    st.mark("logging_init");
+    st.mark("args_parse");
 
     // === Auth-secret sanity (fail-closed on a world-known key) ===
     // `auth_secret` is a required arg, but an EMPTY string satisfies "present"
@@ -2040,6 +2044,15 @@ async fn main() -> Result<(), ApiError> {
             fail_closed_panic_response,
         ));
 
+    // BEFORE the transport branch on purpose, so it covers both.
+    //
+    // The earlier `serve_prep` sits in front of `TcpListener::bind`, which a
+    // booted microVM never reaches — it serves over vsock and returns inside the
+    // block below. So the router build, the watcher spawns and the layer stack
+    // went unmeasured on the only path that matters for guest boot, and showed
+    // up as a 36ms hole before `vsock_bind` — the largest single gap left in the
+    // trace.
+    st.mark("router_build");
     if let Some(vsock) = vsock_binding {
         // THE GUEST PATH. In a booted microVM the proxy serves over vsock and
         // `main` returns right here — everything below this block is host/TCP


### PR DESCRIPTION
Stacked on #2410 (which took `unaccounted` from 83% to 21%, against a rubric target of 15%).

Working the remaining 94 ms out of the `at=` offsets showed it was **not** spread evenly — one gap held 36 ms of it:

```
gap before sandbox_proof   11ms
gap before audit_log       16ms
gap before vsock_bind      36ms   <- the one worth a line
(five others, 5-10ms each)
```

## Why that gap existed

`serve_prep` sits in front of `TcpListener::bind`, and **a booted microVM never reaches it** — the guest serves over vsock and returns from the block above. So the router build, the watcher spawns and the layer stack went unmeasured on the only path guest boot takes. `router_build` is placed **before** the transport branch so it covers both.

Expected: unaccounted 94 ms → ~58 ms of 443 ms, about **13%**, which would meet the target. Measured numbers to follow in a comment rather than asserted here.

## Splitting the biggest phase

`logging_init` was 96 ms and named three things at once. It is now `crypto_provider` / `tracing_init` / `args_parse`, so whoever optimises it knows which one to attack.

One trap recorded at the site: **the rustls provider install is eager on purpose.** rustls [panics on first TLS use](https://github.com/rustls/rustls/issues/1938) when no provider is installed, so "defer it to save 96 ms" is a footgun, and the comment now says so before someone tries it.

370 tests pass; clippy clean under both `-p` and `--all-targets`.