### PR TITLE
docs(perf): record what stages A and B actually measured

### DIFF
--- a/docs/perf/RUBRIC-LEDGER.md
+++ b/docs/perf/RUBRIC-LEDGER.md
@@ -22,9 +22,9 @@ guest rootfs and harness must be built from one tree; skew presents as
 | 4 | TODO | | |
 | 5 | TODO | | |
 | 6 | TODO | | |
-| 7 | TODO | | |
-| 8 | TODO | | |
-| 9 | TODO | | |
+| 7 | PASS | 2026-09-03 | Refusals now carry a cause, and an errno no longer masquerades as one. Fourteen sites in `sandbox.rs` mapped EVERY filesystem error to `PathDenied`, so a live pod reported `access denied: path 'audit': Is a directory (os error 21)` with `kind=path_denied` and a 403 -- nothing had denied anything. Now classified by what the OS said: `PermissionDenied` -> `PathDenied` 403 (a real denial), `NotFound` -> 404, else 400. Same defect Linux hit from the other side (apparmor returned ENOENT when it denied). #2407, merged. Prerequisite was #2401, which made the reason visible at all -- before that this could not be judged. |
+| 8 | PARTIAL | 2026-09-03 | Leak classes measured on a host with ZERO live Firecrackers: **2 leaked netns** (`nuc-f45b3cc8`, `nuc-59c6d719`), 0 cgroups, 0 taps, 189 state dirs. The two namespaces were exactly the pods whose guests kernel-panicked; every clean boot reaped its own -- so cleanup ran on the paths somebody remembered, and not on the late ones (config-serialise, health-wait). Fixed with a drop guard rather than more enumerated arms (#2408). The 189 state dirs are audit material (`lifecycle.log`, receipts) with no rotation policy -- a separate RETENTION question, deliberately not "fixed" by deleting audit data. 20-call sequence still to run. |
+| 9 | PASS | 2026-09-03 | `unaccounted` 83% -> **13.5%** (target <15%). 398/477ms -> 94/443ms (#2410, checkpoints for stretches `timed` cannot wrap) -> 62/458ms (#2411, the 36ms `router_build` hole plus splitting the biggest phase). Attribution: state_build=109ms, runtime_build=92ms, args_parse=68ms, sandbox_proof=35ms, router_build=32ms, tracing_init=21ms, crypto_provider=14ms. **Those first three are 269ms of 458ms and are the Stage C targets.** |
 | 10 | TODO | | |
 | 11 | TODO | | |
 | 12 | TODO | | |

--- a/docs/perf/agent-tool-call-isolation.md
+++ b/docs/perf/agent-tool-call-isolation.md
@@ -27,7 +27,12 @@ Measured 2026-09-02 on aarch64 / KVM / 4 vCPU / 7.9 GiB, with
 | resident memory per pod | **50 MiB** (512 MiB configured — 10x over-estimate) |
 | N=10 with the stock 30s health timeout | 0/10 started |
 | N=10 with the timeout raised | 10/10 started, 74 s |
-| guest startup accounted for by instrumentation | **11%** (`unaccounted=76,081ms of 85,858ms`) |
+| guest startup accounted for by instrumentation | **86.5%** as of 2026-09-03 (`unaccounted=62ms of 458ms`). Was 11% when this rubric was written; see ledger row 9. |
+
+**Update 2026-09-03:** the last row is now 86.5% -- iteration 9 is met, and the
+boot breaks down as state_build 109ms, runtime_build 92ms, args_parse 68ms,
+sandbox_proof 35ms, router_build 32ms. Those first three are 269ms of a 458ms
+boot and are where Stage C should aim.
 
 A tool call that takes 5.6 seconds is unusable; a plausible target is **under
 250 ms p50**. That target is not arbitrary: production agent
@@ -93,7 +98,7 @@ Optimising while 89% of the boot is untimed is guessing. This stage buys sight.
 | 9 | **Close the instrumentation gap.** Add spans until `unaccounted` is under 15% of guest startup. | `nucleus-startup-trace` shows `unaccounted` < 15%. |
 | 10 | **Split the host-side timeline.** Attribute submit → running across admission, Firecracker spawn, kernel, guest init, health check. | Every phase has a number; they sum to within 10% of the total. |
 | 11 | **Name the top three costs.** | Ledger names them with measured milliseconds, not adjectives. |
-| 12 | **Batch the guest vsock handshake.** The boot path makes four-plus sequential fetches (identity, broker secret, mediation key, caller token, pod id, session token). | One round trip carries them all; measured saving recorded; each item still verified as before. |
+| 12 | ~~**Batch the guest vsock handshake.**~~ **DROPPED — refuted by measurement.** | The five sequential fetches were timed (#2409) and cost **26 ms of a 458 ms boot, about 5%**. Batching them has a 26 ms ceiling, so it is not worth the protocol change. Also measured: `handshake_total` is 85 ms, so 59 ms of it is the work BETWEEN the fetches, not the transport. Kept in the table rather than deleted -- the reasoning that made it look worthwhile is the useful part, and deleting it invites someone to propose it again. |
 | 13 | **Take the health check off the hot path.** A fixed 30 s poll gates every start. | Readiness is edge-triggered or the guest announces itself; N=10 passes with the *stock* timeout. |
 | 14 | **Per-call latency budget.** Publish a budget that sums to the target. | Budget committed; every line has an owner phase from #10. |
 | 15 | **A latency regression gate.** | CI fails when single-pod p50 regresses >20% against the ledger. |


### PR DESCRIPTION
The ledger said `TODO` for iterations **7, 8 and 9** while all three had been run and shipped, and the rubric still listed **iteration 12** as work worth doing after it had been refuted. A loop that does not record its results will redo them — the next tick would have started by re-deriving things already measured.

## What is now recorded

- **7 PASS** — an errno no longer masquerades as an authorization decision. Fourteen sites mapped every filesystem error to `PathDenied`, so a pod reported `access denied: path 'audit': Is a directory` with a 403 when nothing had denied anything (#2407). Could not be judged before #2401 made the reason visible.

- **8 PARTIAL** — 2 leaked netns, 0 cgroups, 0 taps, 189 state dirs, measured on a host with zero live Firecrackers. The two namespaces belonged to exactly the pods whose guests panicked, so cleanup ran on the arms somebody had remembered and not the late ones (#2408). The state dirs are audit material with no rotation policy — a **retention** question, deliberately not "fixed" by deleting audit data. The 20-call sequence is still to run.

- **9 PASS** — `unaccounted` 83% → **13.5%**, against a 15% target.

- **12 DROPPED.** The five vsock fetches cost **26 ms of a 458 ms boot**, so batching them has a 26 ms ceiling. **Struck through rather than deleted** — the reasoning that made it look worthwhile is the useful part, and a deleted row invites someone to propose it again next quarter.

## Also

The headline table's "11% accounted for" is now **86.5%**, with a pointer to the row that changed it.

And the three phases worth attacking are recorded where Stage C will look: `state_build` 109 ms, `runtime_build` 92 ms, `args_parse` 68 ms — **269 ms of a 458 ms boot**.

Documentation only.