### PR TITLE
docs(perf): record iteration 13 — the wall moved from 5 pods to 10

### DIFF
--- a/docs/perf/RUBRIC-LEDGER.md
+++ b/docs/perf/RUBRIC-LEDGER.md
@@ -28,7 +28,7 @@ guest rootfs and harness must be built from one tree; skew presents as
 | 10 | TODO | | |
 | 11 | PASS | 2026-09-03 | Named, with milliseconds rather than adjectives: **state_build 109ms** (attestation verifier, node client, delegation ceiling, credential loading), **runtime_build 92ms**, **args_parse 68ms** (49 clap args, all using `env =`). Together 269ms of a 458ms boot. Next three: sandbox_proof 35ms, router_build 32ms, tracing_init 21ms. Caveat recorded honestly -- `mark` measures wall-clock, and on a 1-vCPU guest a single sample cannot separate CPU cost from descheduling, so these rank the phases rather than prove their CPU cost. |
 | 12 | TODO | | |
-| 13 | TODO | | |
+| 13 | PARTIAL | 2026-09-03 | The measured failure is gone; the clause it was written around is met. With NO explicit override, **N=10 goes 0/10 -> 10/10 in 74.6s** (#2415, health budget scales with live microVMs, capped 8x). Regression side clean: N=1 3,011 -> 3,013ms, N=5 10,902 -> 10,384ms -- both inside the +/-3% run-to-run noise, so scaling the deadline did not disturb the uncontended path. `largest clean burst` 5 -> 10. **Still PARTIAL**: iteration 13 asks for edge-triggered readiness, and this is an adaptive deadline instead -- the host still polls. N=25/50 unmeasured against this change, so the ceiling has moved, not gone. |
 | 14 | TODO | | |
 | 15 | TODO | | |
 | 16 | TODO | | |


### PR DESCRIPTION
With **no explicit timeout override**, N=10 goes from **0/10 to 10/10 in 74.6 s** (#2415). That is the clause iteration 13 states: *"N=10 passes with the stock timeout."*

## Both halves recorded, because only one is the interesting part

**Retest** — the fix works:

| N | before | after |
| --- | --- | --- |
| 10 | 0/10 | **10/10, 74.6 s** |

**Regression** — nothing else broke:

| N | before | after |
| --- | --- | --- |
| 1 | 3,011 ms | **3,013 ms** |
| 5 | 10,902 ms | **10,384 ms** |

Both inside the ±3% run-to-run noise established earlier. That is the check worth keeping: the obvious failure mode of "scale the timeout with load" is that it destabilises the uncontended path — and it did not.

## Recorded PARTIAL, not PASS

Iteration 13 asks for **edge-triggered readiness**. This is an adaptive deadline, and the host still polls. The measured failure is gone; the mechanism the iteration actually names is not built.

And explicitly **not** claimed: N=25 and N=50 are unmeasured against this change, so `largest clean burst` moving 5 → 10 means the ceiling **moved**, not that it disappeared. A row saying PASS here would read, six months from now, as though 100 pods had been demonstrated.

Documentation only.