### PR TITLE
chore(clippy-ratchet): ceiling 470 -> 466

### DIFF
--- a/.clippy-ratchet.toml
+++ b/.clippy-ratchet.toml
@@ -27,6 +27,6 @@ lints = [
 # push to main snaps this down to the real count (457 measured here, three
 # identical consecutive runs), so an over-generous seed
 # self-corrects within one commit rather than hiding a regression forever.
-ceiling = 470
+ceiling = 466
 target = 0
 step = 5


### PR DESCRIPTION
Automated ratchet step (opened manually — the workflow's `GITHUB_TOKEN` cannot create PRs in this repo, see #2417's follow-up note).

Measured violation count on linux CI is **466**; the ceiling drops 470 -> 466. `nucleus-verifier-service` and `portcullis-core` did not compile and were excluded from the count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)