### PR TITLE
feat(node): mint the node's own SVID for self-issued gRPC TLS (Move A step 2)

### DIFF
--- a/crates/nucleus-node/src/grpc_tls.rs
+++ b/crates/nucleus-node/src/grpc_tls.rs
@@ -37,7 +37,6 @@ pub struct GrpcTlsConfig {
 
 /// Error type for TLS configuration.
 #[derive(Debug, thiserror::Error)]
-#[allow(dead_code)] // Certificate variant may be used for future validation errors
 pub enum TlsConfigError {
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
@@ -83,8 +82,9 @@ impl GrpcTlsConfig {
 
     /// Creates a TLS configuration from a nucleus-identity WorkloadCertificate.
     ///
-    /// This is useful when using SPIRE to obtain certificates dynamically.
-    #[allow(dead_code)] // Used in tests, will be used when SPIRE integration is wired
+    /// Live path: `--grpc-tls-self-issued` in `main.rs` uses this with the
+    /// node's own SVID (`IdentityManager::node_certificate`). Also usable
+    /// with a SPIRE-obtained certificate once that integration is wired.
     pub fn from_workload_cert(
         cert: &WorkloadCertificate,
         trust_bundle: Option<&TrustBundle>,
@@ -119,6 +119,29 @@ impl GrpcTlsConfig {
             server_identity,
             client_ca,
         })
+    }
+
+    /// Builds a server-only gRPC TLS config from the node's own self-issued
+    /// SVID (`--grpc-tls-self-issued`), instead of externally-provided cert
+    /// files.
+    ///
+    /// Always `trust_bundle: None` (server-only, not mTLS): the CLI has no
+    /// SVID of its own to present yet, so requiring one here would refuse
+    /// every existing client. HMAC auth still applies on top, same as the
+    /// plaintext default this opts out of.
+    pub async fn from_node_identity(
+        manager: &crate::identity::IdentityManager,
+    ) -> Result<Self, TlsConfigError> {
+        let cert = manager
+            .node_certificate()
+            .await
+            .map_err(TlsConfigError::Certificate)?;
+        let config = Self::from_workload_cert(&cert, None)?;
+        info!(
+            node_identity = %manager.node_identity().to_spiffe_uri(),
+            "gRPC self-issued TLS enabled (server-only)"
+        );
+        Ok(config)
     }
 
     /// Builds a tonic ServerTlsConfig from this configuration.

--- a/crates/nucleus-node/src/identity.rs
+++ b/crates/nucleus-node/src/identity.rs
@@ -192,6 +192,36 @@ impl IdentityManager {
         Identity::new(&self.trust_domain, namespace, sa)
     }
 
+    /// The node's own SPIFFE identity: `spiffe://<trust_domain>/ns/system/sa/node`.
+    ///
+    /// Stable across restarts by construction (it is a pure function of
+    /// `trust_domain`, not of any generated material), so a certificate
+    /// minted under it is reusable across a restart as long as the CA root
+    /// is also persisted — see [`Self::new_with_persistent_ca`]. Namespace
+    /// `system` / service account `node` deliberately does not collide with
+    /// any pod identity (`identity_for_pod` uses the pod's own namespace) or
+    /// with `AuthorizationPolicy`'s orchestrator/CI-CD prefixes in `auth.rs`,
+    /// which describe CLIENTS this node accepts, not the node's own identity.
+    pub fn node_identity(&self) -> Identity {
+        Identity::new(&self.trust_domain, "system", "node")
+    }
+
+    /// Fetches (minting and caching on first call) the node's own workload
+    /// certificate, signed by this manager's CA. Reuses `SecretManager`'s
+    /// existing cache and refresh machinery — same path pod certificates
+    /// take, just for [`Self::node_identity`] instead of a pod's.
+    ///
+    /// This is what makes the node's own SVID as durable as the CA root
+    /// itself: the identity is fixed, the CA persists (see
+    /// [`Self::new_with_persistent_ca`]), so a certificate minted under it
+    /// verifies across a restart for any peer that cached the CA's trust
+    /// bundle — not just for the process that happened to mint it.
+    pub async fn node_certificate(
+        &self,
+    ) -> Result<std::sync::Arc<nucleus_identity::WorkloadCertificate>, String> {
+        self.fetch_certificate(&self.node_identity()).await
+    }
+
     /// Rebuild the VM registry from the pods already on disk.
     ///
     /// # Why derive instead of journalling
@@ -351,7 +381,8 @@ impl IdentityManager {
     /// Fetches a certificate for the given identity, returning the certificate.
     ///
     /// Uses the cache if available, otherwise generates a new certificate.
-    #[allow(dead_code)]
+    /// Live path: `--grpc-tls-self-issued` reaches this via
+    /// [`Self::node_certificate`].
     pub async fn fetch_certificate(
         &self,
         identity: &Identity,
@@ -708,6 +739,59 @@ mod tests {
 
         verify_svid_chain(cert.leaf(), &first_bundle).expect(
             "an SVID issued after a simulated restart must verify against the pre-restart root",
+        );
+    }
+
+    /// The node's own identity is stable (a pure function of trust domain,
+    /// not of generated material) and `node_certificate` mints under it.
+    /// This is what `--grpc-tls-self-issued` relies on in `main.rs`.
+    #[tokio::test]
+    async fn node_certificate_is_minted_under_the_stable_node_identity() {
+        let manager = IdentityManager::new("nucleus.local", Duration::from_secs(3600)).unwrap();
+
+        let identity = manager.node_identity();
+        assert_eq!(
+            identity.to_spiffe_uri(),
+            "spiffe://nucleus.local/ns/system/sa/node"
+        );
+
+        let cert = manager.node_certificate().await.unwrap();
+        assert_eq!(cert.identity(), &identity);
+    }
+
+    /// Combines the node-identity and CA-persistence properties: a
+    /// self-issued cert minted AFTER a simulated restart verifies against a
+    /// trust bundle built from the PRE-restart root, because both the
+    /// identity (pure function of trust domain) and the CA root (persisted,
+    /// see `a_node_restart_keeps_issuing_under_the_same_root`) survive it.
+    #[tokio::test]
+    async fn a_self_issued_node_certificate_survives_a_restart() {
+        use nucleus_identity::certificate::Certificate;
+        use nucleus_identity::{TrustBundle, verify_svid_chain};
+
+        let dir = tempfile::tempdir().unwrap();
+        let ca_dir = dir.path().join("ca");
+
+        let first = IdentityManager::new_with_persistent_ca(
+            "nucleus.local",
+            Duration::from_secs(3600),
+            &ca_dir,
+        )
+        .unwrap();
+        let first_root_pem = first.ca().trust_bundle().roots()[0].to_pem().to_string();
+        let first_bundle = TrustBundle::new(vec![Certificate::from_pem(&first_root_pem).unwrap()]);
+
+        let second = IdentityManager::new_with_persistent_ca(
+            "nucleus.local",
+            Duration::from_secs(3600),
+            &ca_dir,
+        )
+        .unwrap();
+        let cert = second.node_certificate().await.unwrap();
+
+        verify_svid_chain(cert.leaf(), &first_bundle).expect(
+            "a self-issued node cert minted after a simulated restart must verify against \
+             the pre-restart root",
         );
     }
 

--- a/crates/nucleus-node/src/main.rs
+++ b/crates/nucleus-node/src/main.rs
@@ -283,6 +283,19 @@ struct Args {
     /// When set, clients must present valid certificates signed by this CA.
     #[arg(long, env = "NUCLEUS_NODE_GRPC_TLS_CA")]
     grpc_tls_ca: Option<PathBuf>,
+    /// Serve gRPC TLS using the node's OWN SPIFFE identity instead of
+    /// externally-provided cert files, when neither `--grpc-tls-cert` nor
+    /// `--grpc-tls-key` is set. Requires `--identity-workload-api-socket` (the
+    /// flag that enables the identity manager). Server-only TLS, not mTLS:
+    /// clients are not required to present a certificate — HMAC auth still
+    /// applies, same as the plaintext default. This does not change what an
+    /// unset default does; it opts a node into a self-issued alternative.
+    #[arg(
+        long,
+        env = "NUCLEUS_NODE_GRPC_TLS_SELF_ISSUED",
+        default_value_t = false
+    )]
+    grpc_tls_self_issued: bool,
 
     // GitHub OIDC configuration
     /// Enable GitHub OIDC token exchange for CI/CD authentication.
@@ -854,6 +867,22 @@ async fn main() -> Result<(), ApiError> {
                     "both --grpc-tls-cert and --grpc-tls-key must be provided for TLS".to_string(),
                 ));
             }
+            (None, None) if args.grpc_tls_self_issued => match &state.identity_manager {
+                Some(manager) => Some(
+                    grpc_tls::GrpcTlsConfig::from_node_identity(manager)
+                        .await
+                        .map_err(|e| {
+                            ApiError::Driver(format!("gRPC self-issued TLS config failed: {e}"))
+                        })?,
+                ),
+                None => {
+                    return Err(ApiError::Driver(
+                        "--grpc-tls-self-issued requires --identity-workload-api-socket \
+                         (no identity manager configured)"
+                            .to_string(),
+                    ));
+                }
+            },
             (None, None) => None,
         };
 


### PR DESCRIPTION
Stacked on #2419 (Move A step 1 — persisted CA root). Base branch is `feat/mtls-persist-ca-root`, not `main` — this diffs cleanly against #2419's tip and should be reviewed/merged after it (or the two squashed together, whichever the merge queue prefers).

## What this adds

- `IdentityManager::node_identity()` — a stable identity (`spiffe://<trust_domain>/ns/system/sa/node`, a pure function of trust domain) and `node_certificate()`, minting/caching under it via the same `SecretManager` path pod certs already use.
- `GrpcTlsConfig::from_node_identity`, making `from_workload_cert` (previously dead code, "will be used when SPIRE integration is wired") a live path.
- New flag `--grpc-tls-self-issued` / `NUCLEUS_NODE_GRPC_TLS_SELF_ISSUED`, default `false`. Server-only TLS (not mTLS — the CLI has no SVID yet to present, that's step 5), usable only when neither `--grpc-tls-cert`/`--grpc-tls-key` is set and the identity manager is enabled.

## Why opt-in, not the new default

Move A's stated ordering is "nothing is deleted, both paths work." Flipping every provisioned node's gRPC transport from plaintext to TLS on upgrade by default would be exactly the unannounced behavior change that principle exists to avoid. That question belongs to Move B's clean break, not here.

## SOTA check (asked for explicitly this round)

Searched for `spiffe-rustls`/`rustls-spiffe` before hand-rolling this. Both assume a SPIRE Workload API source (`spiffe::X509Source`), which conflicts with the plan's "nucleus's own CA, no SPIRE dependency" decision, and neither understands nucleus's custom SVID extensions (attestation, mediator-key binding OID `.1.4`) — so staying on the existing hand-rolled infrastructure is the right call, not a shortcut. `cargo audit`: 0 vulnerabilities / 1220 deps. `rcgen`/`rustls` already pinned at latest stable.

## Restart property

Because the node's identity is a pure function of trust domain and the CA root now persists (#2419), a self-issued cert survives a restart the same way pod certs do — proven with the same real webpki chain-verification pattern as #2419's test, not a PEM string comparison: `a_self_issued_node_certificate_survives_a_restart`.

## Line ratchet

The inline version pushed `nucleus-node/src/main.rs` 2 lines over its ceiling (4044 vs 4042). Extracted the self-issued branch into `GrpcTlsConfig::from_node_identity` — both for cohesion (the file's whole purpose is gRPC TLS config) and to settle back under ceiling (4030).

## Verified

`cargo test -p nucleus-node` (398 passed, 2 new); `cargo clippy -p nucleus-node` under both default and `--all-targets`; `cargo check --workspace` clean (apart from the pre-existing unrelated nucleus-verifier-service WASM gap, same as #2419); line ratchet OK; `cargo fmt --check` clean; manual vendor-neutrality grep clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)