### PR TITLE
fix(ci): line ratchet only watched 3 of ~770 files; extend it to all of them

### DIFF
--- a/.github/workflows/line-ratchet.yml
+++ b/.github/workflows/line-ratchet.yml
@@ -50,34 +50,90 @@ jobs:
             exit 0
           fi
 
-          CEILING=$(grep '^ceiling' "$RATCHET_FILE" | head -1 | sed 's/.*= *//')
-          TARGET=$(grep '^target' "$RATCHET_FILE" | head -1 | sed 's/.*= *//')
-          STEP=$(grep '^step' "$RATCHET_FILE" | head -1 | sed 's/.*= *//')
-          FILE_PATH=$(grep '^path' "$RATCHET_FILE" | head -1 | sed 's/.*= *"//' | sed 's/"//')
+          # Iterate EVERY [[files]] entry, not just the first.
+          #
+          # This job used to read `grep '^ceiling' | head -1`, which matches
+          # the global [ratchet] block (first in the file) rather than any
+          # specific [[files]] entry, and `grep '^path' | head -1`, which
+          # grabs the FIRST [[files]] entry's path regardless. The two
+          # numbers only ever lined up because [ratchet]'s defaults happened
+          # to equal kernel.rs's own values — so this job could only ever
+          # propose a decrement for kernel.rs, silently, and would have kept
+          # doing so even after that coincidence stopped holding. Same defect
+          # class, same fix, as clippy-ratchet.yml's ratchet-down job (#2417):
+          # a control that only watches the first of several entries is not
+          # watching the others at all.
+          ENTRIES=$(awk '
+              /^\[\[files\]\]/ { infile = 1; path = ""; ceiling = ""; target = ""; step = ""; next }
+              /^\[/ && !/^\[\[files\]\]/ { infile = 0 }
+              infile && /^path[ \t]*=/    { gsub(/.*= *"|"/, ""); path = $0 }
+              infile && /^ceiling[ \t]*=/ { gsub(/.*= */, ""); ceiling = $0 }
+              infile && /^target[ \t]*=/  { gsub(/.*= */, ""); target = $0 }
+              infile && /^step[ \t]*=/    { gsub(/.*= */, ""); step = $0
+                                             if (path != "" && ceiling != "" && step != "")
+                                               print path, ceiling, target, step }
+          ' "$RATCHET_FILE")
 
-          ACTUAL=$(wc -l < "$FILE_PATH" | tr -d ' ')
-
-          # New ceiling: max(actual, ceiling - step, target)
-          NEW_CEILING=$((CEILING - STEP))
-          if [[ "$ACTUAL" -lt "$NEW_CEILING" ]]; then
-            # File is already smaller than the ratcheted ceiling — snap to actual
-            NEW_CEILING=$ACTUAL
+          if [[ -z "$ENTRIES" ]]; then
+            echo "ERROR: could not parse any [[files]] entry from $RATCHET_FILE"
+            exit 1
           fi
-          if [[ "$NEW_CEILING" -lt "$TARGET" ]]; then
-            NEW_CEILING=$TARGET
+
+          any_proposed=false
+          while read -r FILE_PATH CEILING TARGET STEP; do
+            [[ -z "$FILE_PATH" ]] && continue
+            if [[ ! -f "$FILE_PATH" ]]; then
+              echo "ERROR: monitored file not found: $FILE_PATH"
+              exit 1
+            fi
+
+            ACTUAL=$(wc -l < "$FILE_PATH" | tr -d ' ')
+
+            # New ceiling: max(actual, ceiling - step, target), never above
+            # the CURRENT ceiling. That last clamp is not redundant: when a
+            # file has already beaten its own target (kernel.rs, at 2465
+            # against ceiling 2479 / target 2500), the plain
+            # max(actual, ceiling-step, target) computes 2500 — a proposal
+            # to RAISE the ceiling, from a job named "ratchet DOWN". Caught
+            # by running this against the real config while fixing the
+            # only-reads-the-first-entry bug above: kernel.rs is the file
+            # that exposed it, but the bug is in the formula, not specific
+            # to that file — any file that ever overshoots its target would
+            # trip it.
+            NEW_CEILING=$((CEILING - STEP))
+            if [[ "$ACTUAL" -lt "$NEW_CEILING" ]]; then
+              # File is already smaller than the ratcheted ceiling — snap to actual
+              NEW_CEILING=$ACTUAL
+            fi
+            if [[ "$NEW_CEILING" -lt "$TARGET" ]]; then
+              NEW_CEILING=$TARGET
+            fi
+            if [[ "$NEW_CEILING" -gt "$CEILING" ]]; then
+              NEW_CEILING=$CEILING
+            fi
+
+            if [[ "$NEW_CEILING" -eq "$CEILING" ]]; then
+              echo "$FILE_PATH: ceiling unchanged at $CEILING (file: $ACTUAL lines)"
+              continue
+            fi
+
+            any_proposed=true
+            echo "$FILE_PATH: $CEILING -> $NEW_CEILING (file: $ACTUAL lines, target: $TARGET)"
+
+            # Direct pushes to main are rejected (GH006) under the
+            # 25-required-context branch protection, and a bot push can't
+            # go through the merge queue. The ENFORCING job is "Check
+            # line ceiling" on PRs; this job only PROPOSES decrements — land
+            # ceiling updates via an ordinary PR editing $RATCHET_FILE.
+            echo "::notice::Ratchet decrement available for $FILE_PATH: $CEILING -> $NEW_CEILING (file at $ACTUAL lines). Land it via a PR editing $RATCHET_FILE."
+          done <<< "$ENTRIES"
+
+          if [[ "$any_proposed" == "false" ]]; then
+            echo "No file has room to ratchet down."
           fi
 
-          if [[ "$NEW_CEILING" -eq "$CEILING" ]]; then
-            echo "Ceiling unchanged at $CEILING (file: $ACTUAL lines)"
-            exit 0
-          fi
-
-          echo "Ratcheting: $CEILING -> $NEW_CEILING (file: $ACTUAL lines, target: $TARGET)"
-          sed -i "s/^ceiling = $CEILING/ceiling = $NEW_CEILING/" "$RATCHET_FILE"
-
-          # Direct pushes to main are rejected (GH006) under the
-          # 25-required-context branch protection, and a bot push can't
-          # go through the merge queue. The ENFORCING job is "Check
-          # line ceiling" on PRs; this job now only PROPOSES the
-          # decrement — land ceiling updates via an ordinary PR.
-          echo "::notice::Ratchet decrement available: $CEILING -> $NEW_CEILING (file at $ACTUAL lines). Land it via a PR editing $RATCHET_FILE."
+          # The sweep's default_ceiling (crates/*/src/**/*.rs files with no
+          # [[files]] entry) is a static per-file cap, not a per-file
+          # decrement campaign — there is no single "actual" to ratchet it
+          # against, so it is deliberately not proposed here. Lowering it is
+          # a manual, reviewed decision in a PR, same as raising it.

--- a/.line-ratchet.toml
+++ b/.line-ratchet.toml
@@ -4,6 +4,15 @@
 ceiling = 2479
 target = 2500
 step = 1
+# Ceiling applied to every crates/*/src/**/*.rs file with NO [[files]] entry
+# of its own — added 2026-09-03 so the gate covers the whole workspace
+# instead of the three files someone happened to list. Seeded at 2500
+# (matching kernel.rs's own longstanding target/ceiling) after measuring
+# the current tree: exactly 3 files exceed it, and each got its own
+# [[files]] entry below rather than being silently exempted. See
+# `scripts/check-line-ratchet.sh`'s sweep section for the mechanism and the
+# full rationale.
+default_ceiling = 2500
 
 # nucleus-claude-hook removed (moved to nucleus-code product repo)
 
@@ -27,3 +36,28 @@ path = "crates/nucleus-node/src/main.rs"
 ceiling = 4042
 target = 2000
 step = 1
+
+# The three entries below were added 2026-09-03 when the sweep (see
+# `default_ceiling` above) started covering every crates/*/src/**/*.rs file:
+# each already exceeded the 2500 default on the day coverage began. Seeded
+# at their measured size, same convention as the entries above — nobody is
+# actively shrinking these yet, so `step = 0` rather than implying a
+# campaign that isn't happening; raise `step` when one starts.
+
+[[files]]
+path = "crates/portcullis-effects/src/runtime.rs"
+ceiling = 2891
+target = 2500
+step = 0
+
+[[files]]
+path = "crates/portcullis-effects/src/lib.rs"
+ceiling = 2813
+target = 2500
+step = 0
+
+[[files]]
+path = "crates/nucleus-audit/src/main.rs"
+ceiling = 2627
+target = 2500
+step = 0

--- a/scripts/check-line-ratchet.sh
+++ b/scripts/check-line-ratchet.sh
@@ -79,6 +79,72 @@ while read -r FILE_PATH CEILING TARGET; do
     echo ""
 done <<< "$ENTRIES"
 
+echo "═══════════════════════════════════════════════════════════════════"
+echo "Sweep: every crates/*/src/**/*.rs file NOT explicitly listed above"
+echo "═══════════════════════════════════════════════════════════════════"
+#
+# Until this section existed, the ratchet enforced exactly the three files
+# an [[files]] entry named — three, out of the several hundred .rs files in
+# the workspace. A file that grew unbounded outside those three was
+# invisible to this gate, the same shape of blind spot the header comment
+# above already documents for "only the first entry": a control that only
+# watches what someone remembered to list is not really watching. Found
+# while a legitimate, well-justified change (the mTLS SPIFFE auth branch)
+# routed its new logic into `auth.rs` specifically because that file had
+# no ceiling at all — the untracked sibling of a tracked file is exactly
+# where bloat hides from a partial gate.
+#
+# DEFAULT_CEILING applies to every swept file that has no [[files]] entry
+# of its own. It is deliberately generous (2500 — see the seeding rationale
+# below) rather than tuned per-file: the three explicit entries above exist
+# because someone is actively watching or shrinking those specific files;
+# the sweep's job is only to make sure nothing ELSE grows unnoticed, not to
+# impose an extraction campaign on the other several hundred files that
+# have never needed one.
+DEFAULT_CEILING=$(awk '
+    /^\[ratchet\]/ { inratchet = 1; next }
+    /^\[/           { inratchet = 0 }
+    inratchet && /^default_ceiling[ \t]*=/ { gsub(/.*= */, ""); print; exit }
+' "$RATCHET_FILE")
+
+if [[ -z "$DEFAULT_CEILING" ]]; then
+    echo "ERROR: [ratchet] has no default_ceiling — cannot sweep untracked files"
+    exit 1
+fi
+
+# The explicitly-covered paths, so the sweep does not re-check (and cannot
+# double-count a violation for) a file that already has its own [[files]]
+# entry above, however permissive or strict that entry is.
+EXPLICIT_PATHS=$(printf '%s\n' "$ENTRIES" | awk '{print $1}')
+
+swept=0
+swept_violations=0
+while IFS= read -r f; do
+    [[ -z "$f" ]] && continue
+    if printf '%s\n' "$EXPLICIT_PATHS" | grep -qxF "$f"; then
+        continue
+    fi
+    swept=$((swept + 1))
+    actual=$(wc -l < "$f" | tr -d ' ')
+    if [[ "$actual" -gt "$DEFAULT_CEILING" ]]; then
+        echo "VIOLATION: $f has $actual lines (default ceiling: $DEFAULT_CEILING)"
+        echo "  Either extract code to get back under the default, or — if this"
+        echo "  file legitimately needs more room and someone is going to watch"
+        echo "  it — give it its own [[files]] entry in $RATCHET_FILE seeded at"
+        echo "  its measured size, the same way the three tracked files got theirs."
+        swept_violations=$((swept_violations + 1))
+        violations=$((violations + 1))
+    fi
+done < <(find crates -path '*/src/*' -name '*.rs' -not -path '*/target/*' 2>/dev/null | sort)
+
+if [[ "$swept_violations" -eq 0 ]]; then
+    echo "OK: $swept files swept, all <= $DEFAULT_CEILING lines"
+else
+    echo ""
+    echo "$swept_violations of $swept swept files exceed the default ceiling ($DEFAULT_CEILING)"
+fi
+echo ""
+
 if [[ "$violations" -gt 0 && "$STRICT" == "true" ]]; then
     exit 1
 fi


### PR DESCRIPTION
Prompted mid-session while landing Move A step 4: it needed 3 extra lines in `nucleus-node/src/main.rs`, so the new logic went into `auth.rs` instead — which has **no ceiling at all**, because the ratchet only ever enforced whatever a `[[files]]` entry happened to name. That's a loophole in the gate, not a legitimate way to stay under a ceiling.

## The sweep

`scripts/check-line-ratchet.sh` now globs every `crates/*/src/**/*.rs` file after checking the explicit `[[files]]` entries, and checks anything not already covered against a new `default_ceiling` (seeded at 2500 — kernel.rs's own longstanding target). 761 of 767 source files are already under it. The other 3 — `portcullis-effects/{runtime,lib}.rs` and `nucleus-audit/main.rs` — got their own `[[files]]` entries seeded at measured size, `step = 0` (nobody is actively shrinking them yet).

Violation reporting is compact (files-swept / files-violating), not one verbose block per file.

**Verified it can fail**: temporarily set `default_ceiling = 10`, watched 729/761 files violate and exit 1, restored, watched it go green. Re-ran the existing falsifier (`check-gates-can-fail.sh`'s kernel.rs-padding probe) by hand against the extended script — still reds correctly.

## Found while extending it: two more instances of the same defect class

`.github/workflows/line-ratchet.yml`'s `ratchet-down` job had the exact bug already fixed in `clippy-ratchet.yml`'s sibling job (#2417): it only ever read the first `[[files]]` entry (by coincidence, kernel.rs). Fixed by reusing the check script's own per-entry parsing.

Running the fixed version against real config surfaced a **third** bug, in the formula itself: kernel.rs already beats its own target (2465 actual vs. target 2500), and `max(actual, ceiling-step, target)` then proposes **raising** the ceiling to 2500 — from a job named "ratchet down." This bug was latent in the original single-entry version too, just never surfaced. Fixed with an explicit never-above-current-ceiling clamp.

This job only ever emits a `::notice::` (direct pushes to main are rejected under branch protection), so none of this was causing red CI — but a silent "propose raising the ceiling" is exactly the shape of confident-falsehood-from-a-watcher this session's other gate fixes have been about.

## Verified

`actionlint` clean; the extracted `ratchet-down` shell body run standalone against the real config (all 6 entries resolve correctly, no spurious raise); `check-line-ratchet.sh --strict` green; both falsification probes confirmed red-then-green; manual vendor-neutrality grep clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)