### PR TITLE
security(#2450): seal VerifiedPermissions/VerifiedCard/VerifiedAttestation/AuthenticatedPrincipal with the sealed-constructor pattern

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7303,11 +7303,13 @@ dependencies = [
 name = "nucleus-policy-cert"
 version = "1.0.0"
 dependencies = [
+ "chrono",
  "dlc-core",
  "ed25519-dalek 3.0.0",
  "nucleus-policy-kernel",
  "portcullis",
  "proptest",
+ "ring",
  "serde",
  "serde_json",
  "sha2 0.10.9",

--- a/crates/nucleus-agent-card/examples/agent_sign.rs
+++ b/crates/nucleus-agent-card/examples/agent_sign.rs
@@ -104,12 +104,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let verified = verify_card(&signed, &resolved_key)?;
     let profile = verified
-        .claims
+        .claims()
         .runtime_guarantees
         .as_ref()
         .expect("the verified card carries its IFC profile");
     println!("\nverified ✓  — IFC profile is authentic + untampered:");
-    println!("  spiffe_id        = {}", verified.claims.spiffe_id);
+    println!("  spiffe_id        = {}", verified.claims().spiffe_id);
     println!("  tracked_sources  = {:?}", profile.tracked_sources);
     for rule in &profile.enforcement_rules {
         println!("  rule             = {} — {}", rule.name, rule.description);

--- a/crates/nucleus-agent-card/src/conformance_tests.rs
+++ b/crates/nucleus-agent-card/src/conformance_tests.rs
@@ -529,7 +529,7 @@ fn unmodeled_member_signed_by_a_newer_producer_verifies_via_the_json_path() {
     let verified =
         verify_card_json(&raw, &jwk).expect("unmodeled member must not break verification");
     assert_eq!(
-        verified.claims.did,
+        verified.claims().did,
         "did:web:golden.conformance.example.com"
     );
 

--- a/crates/nucleus-agent-card/src/envelope.rs
+++ b/crates/nucleus-agent-card/src/envelope.rs
@@ -95,13 +95,13 @@ pub struct CardClaims {
 impl From<&VerifiedCard> for CardClaims {
     fn from(verified: &VerifiedCard) -> Self {
         CardClaims {
-            spiffe_id: verified.claims.spiffe_id.clone(),
-            did: verified.claims.did.clone(),
+            spiffe_id: verified.claims().spiffe_id.clone(),
+            did: verified.claims().did.clone(),
             supported_envelope_schema_versions: verified
-                .claims
+                .claims()
                 .supported_envelope_schema_versions
                 .clone(),
-            runtime_guarantees: verified.claims.runtime_guarantees.clone(),
+            runtime_guarantees: verified.claims().runtime_guarantees.clone(),
             advertised_jwks_kids: verified
                 .advertised_jwks()
                 .keys
@@ -256,14 +256,22 @@ mod tests {
         .unwrap()
     }
 
-    /// In-crate test shortcut: `VerifiedCard`'s fields are public within
-    /// the crate's API, but the END-TO-END test (sign_verify path, feature
-    /// `sign`) is the one that goes through `verify_card` for real.
+    /// In-crate test shortcut: `VerifiedCard::new` is `pub(crate)` (#2450),
+    /// so this crate's own tests can still build one directly — but the
+    /// END-TO-END test (sign_verify path, feature `sign`) is the one that
+    /// goes through `verify_card` for real.
     fn verified() -> VerifiedCard {
-        VerifiedCard {
-            card: sample_card(),
-            claims: sample_claims(),
-        }
+        VerifiedCard::new(sample_card(), sample_claims())
+    }
+
+    /// Same as [`verified`], but with `runtime_guarantees` cleared —
+    /// `VerifiedCard`'s fields are private (#2450), so a test that used to
+    /// mutate `.claims.runtime_guarantees` after construction now builds
+    /// the claims it wants up front instead.
+    fn verified_without_runtime_guarantees() -> VerifiedCard {
+        let mut claims = sample_claims();
+        claims.runtime_guarantees = None;
+        VerifiedCard::new(sample_card(), claims)
     }
 
     /// The round-trip law: narrow ∘ lift = id on the lifted claims.
@@ -301,8 +309,7 @@ mod tests {
 
     #[test]
     fn absent_profile_is_omitted_from_the_wire() {
-        let mut v = verified();
-        v.claims.runtime_guarantees = None;
+        let v = verified_without_runtime_guarantees();
         let Projection::Capability(body) = to_capability_projection(&v) else {
             panic!("lift must produce a capability projection");
         };

--- a/crates/nucleus-agent-card/src/sign_verify_tests.rs
+++ b/crates/nucleus-agent-card/src/sign_verify_tests.rs
@@ -84,7 +84,7 @@ fn sign_then_verify_happy_path() {
     let (der, pub_jwk) = p256_keypair();
     let signed = sign_card(sample_card(), &der, "card-key-1").unwrap();
     let verified = verify_card(&signed, &pub_jwk).expect("freshly-signed card must verify");
-    assert_eq!(verified.claims.did, "did:web:coder.prod.example.com");
+    assert_eq!(verified.claims().did, "did:web:coder.prod.example.com");
     assert_eq!(verified.advertised_jwks().keys.len(), 1);
 }
 
@@ -243,7 +243,7 @@ fn sign_and_verify_with_runtime_guarantees_roundtrip() {
     let signed = sign_card(card, &der, "card-key-1").unwrap();
     let verified = verify_card(&signed, &pub_jwk).expect("card with profile must verify");
     let prof = verified
-        .claims
+        .claims()
         .runtime_guarantees
         .as_ref()
         .expect("profile present");

--- a/crates/nucleus-agent-card/src/verify.rs
+++ b/crates/nucleus-agent-card/src/verify.rs
@@ -58,21 +58,59 @@ use crate::{Error, Result};
 /// A card whose signature verified against the caller's out-of-band key,
 /// together with its extracted [`NucleusClaims`].
 ///
+/// Sealed (#2450): fields are private, and the only constructor
+/// ([`Self::new`]) is `pub(crate)` — callable as a function from anywhere
+/// in this crate (so [`verify_card`]/[`verify_card_json`] and this crate's
+/// own tests can build one), but no struct literal compiles, even within
+/// this crate. Same tier of rigor as
+/// `nucleus_tool_proxy::session_token::VerifiedSessionToken` (private
+/// fields, `pub(crate)`-scoped) — not the fully module-private tier
+/// `DischargedBundle` uses, because unlike that type this one legitimately
+/// needs building from more than one module in the crate (`envelope.rs`'s
+/// own tests, matching the doc comment that USED to justify the public
+/// fields this replaces).
+///
 /// Holding a `VerifiedCard` is the proof obligation: you may only call
 /// [`Self::advertised_jwks`] (and thence build a TrustAnchor) once the
 /// card's authenticity has been established.
+///
+/// ```compile_fail
+/// // This code does NOT compile — the fields are private and `new` is
+/// // `pub(crate)`, invisible outside this crate.
+/// use nucleus_agent_card::verify::VerifiedCard;
+/// use nucleus_agent_card::card::{AgentCard, NucleusClaims};
+/// let forged = VerifiedCard {
+///     card: unimplemented!(),
+///     claims: unimplemented!(),
+/// };
+/// ```
 #[derive(Debug, Clone)]
 pub struct VerifiedCard {
     /// The verified identity document (v1.0 card, signatures included).
-    pub card: AgentCard,
+    card: AgentCard,
 
     /// The nucleus claims extracted from the card's
     /// [`NUCLEUS_EXTENSION_URI`](crate::card::NUCLEUS_EXTENSION_URI)
     /// extension — covered by the verified signature.
-    pub claims: NucleusClaims,
+    claims: NucleusClaims,
 }
 
 impl VerifiedCard {
+    /// Private outside this crate — see the struct's own doc comment.
+    pub(crate) fn new(card: AgentCard, claims: NucleusClaims) -> Self {
+        Self { card, claims }
+    }
+
+    /// The verified identity document.
+    pub fn card(&self) -> &AgentCard {
+        &self.card
+    }
+
+    /// The extracted nucleus claims.
+    pub fn claims(&self) -> &NucleusClaims {
+        &self.claims
+    }
+
     /// The JWKS the (now-verified) card advertises as authoritative for
     /// its provenance bundles. Feed this to
     /// [`crate::anchor::trust_anchor_from_card`].
@@ -225,7 +263,7 @@ pub fn verify_card_bound_to_peer(
 /// when either side is empty — an empty id must never compare equal to another
 /// empty id and let an unidentified peer through.
 pub fn bind_to_peer(verified: VerifiedCard, peer_spiffe_id: &str) -> Result<VerifiedCard> {
-    let declared = verified.claims.spiffe_id.trim();
+    let declared = verified.claims().spiffe_id.trim();
     let presented = peer_spiffe_id.trim();
 
     if declared.is_empty() || presented.is_empty() {
@@ -310,7 +348,7 @@ fn apply_nucleus_policy(card: AgentCard) -> Result<VerifiedCard> {
         ))
     })?;
 
-    Ok(VerifiedCard { card, claims })
+    Ok(VerifiedCard::new(card, claims))
 }
 
 /// §8.4.3 over the whole `signatures` array: succeed if ANY entry both
@@ -495,7 +533,7 @@ mod tests {
             .expect("claims parse")
             .expect("the test card carries nucleus claims");
         claims.spiffe_id = spiffe_id.to_string();
-        VerifiedCard { card, claims }
+        VerifiedCard::new(card, claims)
     }
 
     const PEER: &str = "spiffe://prod.example.com/ns/agents/sa/coder";

--- a/crates/nucleus-cli/src/token.rs
+++ b/crates/nucleus-cli/src/token.rs
@@ -320,58 +320,58 @@ fn verify(args: VerifyArgs) -> Result<()> {
             let fingerprint = hex::encode(token.fingerprint());
             println!("Token VERIFIED");
             println!("{}", "=".repeat(50));
-            println!("Chain depth:       {}", verified.chain_depth);
-            println!("Root identity:     {}", verified.root_identity);
-            println!("Leaf identity:     {}", verified.leaf_identity);
+            println!("Chain depth:       {}", verified.chain_depth());
+            println!("Root identity:     {}", verified.root_identity());
+            println!("Leaf identity:     {}", verified.leaf_identity());
             println!("Fingerprint:       {}", fingerprint);
             println!("Effective perms:");
             println!(
                 "  read_files:      {:?}",
-                verified.effective.capabilities.read_files
+                verified.effective().capabilities.read_files
             );
             println!(
                 "  write_files:     {:?}",
-                verified.effective.capabilities.write_files
+                verified.effective().capabilities.write_files
             );
             println!(
                 "  edit_files:      {:?}",
-                verified.effective.capabilities.edit_files
+                verified.effective().capabilities.edit_files
             );
             println!(
                 "  run_bash:        {:?}",
-                verified.effective.capabilities.run_bash
+                verified.effective().capabilities.run_bash
             );
             println!(
                 "  glob_search:     {:?}",
-                verified.effective.capabilities.glob_search
+                verified.effective().capabilities.glob_search
             );
             println!(
                 "  grep_search:     {:?}",
-                verified.effective.capabilities.grep_search
+                verified.effective().capabilities.grep_search
             );
             println!(
                 "  web_search:      {:?}",
-                verified.effective.capabilities.web_search
+                verified.effective().capabilities.web_search
             );
             println!(
                 "  web_fetch:       {:?}",
-                verified.effective.capabilities.web_fetch
+                verified.effective().capabilities.web_fetch
             );
             println!(
                 "  git_commit:      {:?}",
-                verified.effective.capabilities.git_commit
+                verified.effective().capabilities.git_commit
             );
             println!(
                 "  git_push:        {:?}",
-                verified.effective.capabilities.git_push
+                verified.effective().capabilities.git_push
             );
             println!(
                 "  create_pr:       {:?}",
-                verified.effective.capabilities.create_pr
+                verified.effective().capabilities.create_pr
             );
             println!(
                 "  manage_pods:     {:?}",
-                verified.effective.capabilities.manage_pods
+                verified.effective().capabilities.manage_pods
             );
             Ok(())
         }
@@ -439,7 +439,7 @@ mod tests {
 
         // Token should verify
         let verified = token.verify_default(Utc::now()).unwrap();
-        assert_eq!(verified.root_identity, "spiffe://test/human/alice");
+        assert_eq!(verified.root_identity(), "spiffe://test/human/alice");
     }
 
     #[test]
@@ -463,12 +463,12 @@ mod tests {
 
         // local-dev profile should have read_files=Always
         assert_eq!(
-            verified.effective.capabilities.read_files,
+            verified.effective().capabilities.read_files,
             portcullis::CapabilityLevel::Always
         );
         // local-dev should NOT have web_fetch
         assert_eq!(
-            verified.effective.capabilities.web_fetch,
+            verified.effective().capabilities.web_fetch,
             portcullis::CapabilityLevel::Never
         );
     }

--- a/crates/nucleus-cli/src/verify_attestation.rs
+++ b/crates/nucleus-cli/src/verify_attestation.rs
@@ -81,19 +81,15 @@ pub fn execute(args: VerifyAttestationArgs) -> Result<()> {
     let backend = SelfMeasuredBackend;
     match backend.verify_svid(&chain, &req, args.require_attestation) {
         Ok(Some(va)) => {
-            let measurement = va
-                .launch
-                .as_ref()
-                .map(|l| l.to_hex_summary())
-                .unwrap_or_default();
+            let measurement = va.launch().map(|l| l.to_hex_summary()).unwrap_or_default();
             println!(
                 "OK: attested SVID verified via '{}' (assurance L{}) — {}",
-                va.backend,
+                va.backend(),
                 va.assurance().as_u8(),
                 measurement
             );
-            println!("  proves:     {}", fmt_claims(&va.proves));
-            println!("  not proven: {}", fmt_claims(&va.not_proven));
+            println!("  proves:     {}", fmt_claims(va.proven_claims()));
+            println!("  not proven: {}", fmt_claims(va.unproven_claims()));
             println!(
                 "NOTE: node-signed SOFTWARE launch attestation (no hardware root); \
                  trust is conditional on the node's signing key."

--- a/crates/nucleus-control-plane-server/src/auth.rs
+++ b/crates/nucleus-control-plane-server/src/auth.rs
@@ -88,27 +88,74 @@ impl SpiffeAuthConfig {
 
 /// Information the verifier extracts from a valid JWT-SVID. Handlers
 /// downstream may inspect `sub` for fine-grained federation decisions.
+///
+/// Sealed (#2450): fields are private, and a private `_seal: Seal`
+/// marker field means no struct literal compiles even from elsewhere in
+/// this crate — the tightest tier used for any of the four #2450 types,
+/// matching this type's tighter acceptance bar ("no code outside
+/// `crate::auth`"). The only constructors, [`Self::new`] (the real
+/// `verify_jwt_svid` path) and [`Self::unauthenticated`] (the honest
+/// auth-disabled sentinel), are private to this module — same rigor as
+/// `nucleus_ifc_kernel::discharge::DischargedBundle`.
+///
+/// ```compile_fail
+/// // This code does NOT compile — the fields are private, `_seal`'s type
+/// // is unnameable outside this module, and both constructors are private.
+/// use nucleus_control_plane_server::AuthenticatedPrincipal;
+/// let forged = AuthenticatedPrincipal {
+///     sub: "spiffe://prod.example.com/ns/agents/sa/forged".to_string(),
+///     aud: vec!["https://control.nucleus.local/api".to_string()],
+///     authenticated: true,
+/// };
+/// ```
 #[derive(Debug, Clone)]
 pub struct AuthenticatedPrincipal {
     /// SPIFFE subject id. `spiffe://...` URL.
-    pub sub: String,
+    sub: String,
     /// All `aud` values from the token.
-    pub aud: Vec<String>,
+    aud: Vec<String>,
     /// True iff verification was performed against a configured trust
     /// JWKS. False when auth is disabled (synthetic admit path).
-    pub authenticated: bool,
+    authenticated: bool,
+    _seal: Seal,
 }
 
+/// Unnameable outside this module — see [`AuthenticatedPrincipal`]'s doc comment.
+#[derive(Debug, Clone)]
+struct Seal;
+
 impl AuthenticatedPrincipal {
+    /// Private to this module — see the struct's own doc comment.
+    fn new(sub: String, aud: Vec<String>, authenticated: bool) -> Self {
+        Self {
+            sub,
+            aud,
+            authenticated,
+            _seal: Seal,
+        }
+    }
+
     /// Synthetic admit path for auth-disabled deployments. The `sub`
     /// is the literal string `"<unauthenticated>"` so handlers that
     /// log it can't be tricked into reading it as a real SPIFFE id.
-    pub fn unauthenticated() -> Self {
-        Self {
-            sub: "<unauthenticated>".to_string(),
-            aud: Vec::new(),
-            authenticated: false,
-        }
+    fn unauthenticated() -> Self {
+        Self::new("<unauthenticated>".to_string(), Vec::new(), false)
+    }
+
+    /// SPIFFE subject id. `spiffe://...` URL (or the literal
+    /// `"<unauthenticated>"` sentinel — see [`Self::unauthenticated`]).
+    pub fn sub(&self) -> &str {
+        &self.sub
+    }
+
+    /// All `aud` values from the token.
+    pub fn aud(&self) -> &[String] {
+        &self.aud
+    }
+
+    /// True iff verification was performed against a configured trust JWKS.
+    pub fn authenticated(&self) -> bool {
+        self.authenticated
     }
 }
 
@@ -291,11 +338,7 @@ pub fn verify_jwt_svid(
         return Err(AuthError::SubjectPrefixMismatch { sub: claims.sub });
     }
 
-    Ok(AuthenticatedPrincipal {
-        sub: claims.sub,
-        aud: auds,
-        authenticated: true,
-    })
+    Ok(AuthenticatedPrincipal::new(claims.sub, auds, true))
 }
 
 /// Outcome of bootstrap-time SPIFFE config resolution from optional
@@ -531,10 +574,10 @@ mod tests {
         let cfg = config(f.jwks());
         let principal = verify_jwt_svid(&token, &cfg).unwrap();
         assert_eq!(
-            principal.sub,
+            principal.sub(),
             "spiffe://prod.example.com/ns/agents/sa/coder"
         );
-        assert!(principal.authenticated);
+        assert!(principal.authenticated());
     }
 
     /// M-3 strong-binding regression for the control-plane JWT-SVID trust
@@ -778,6 +821,6 @@ mod tests {
 
         let cfg = config(f.jwks());
         let p = verify_jwt_svid(&token, &cfg).unwrap();
-        assert_eq!(p.aud.len(), 2);
+        assert_eq!(p.aud().len(), 2);
     }
 }

--- a/crates/nucleus-control-plane-server/src/routes.rs
+++ b/crates/nucleus-control-plane-server/src/routes.rs
@@ -60,7 +60,7 @@ pub async fn submit_job(
     // already-verified SPIFFE subject `RequireSpiffeAuth` extracted above.
     // Carried forward unchanged through every subsequent state transition
     // in `spawn_job`/`run_job_blocking`; never re-derived.
-    let owner = principal.sub.clone();
+    let owner = principal.sub().to_string();
     // Look up the driver up front so we fail fast on unknown drivers
     // rather than after queueing the job.
     if state.runners.get(&spec.agent_driver.name).is_none() {

--- a/crates/nucleus-identity/Cargo.toml
+++ b/crates/nucleus-identity/Cargo.toml
@@ -20,6 +20,12 @@ spire = ["dep:spiffe", "dep:futures-util"]
 # The AK↔EK credential-activation binder (Inc 3 brick 2) additionally needs raw
 # AES-128-CFB (the one primitive ring does not expose); pulled in only here.
 tpm-devid = ["dep:aes", "dep:cfb-mode"]
+# Expose `VerifiedAttestation::for_test`, a synthetic constructor that bypasses
+# all backend verification (#2450 sealing). Meant only for another crate's
+# `[dev-dependencies]` (resolver v2 keeps this out of that crate's published
+# artifact) so its tests can unit-test a `VerifiedAttestation` consumer against
+# controlled field combinations without standing up a real SVID chain.
+test-helpers = []
 # Enable HTTP-based did:web resolution (requires network)
 resolver = ["dep:reqwest"]
 

--- a/crates/nucleus-identity/src/assurance.rs
+++ b/crates/nucleus-identity/src/assurance.rs
@@ -363,15 +363,15 @@ impl SvidAttestationBackend for SelfMeasuredBackend {
                 let subject_key_sha256 = pem::parse(chain_pem).ok().and_then(|leaf| {
                     crate::attestation::extract_mediation_key_binding(leaf.contents())
                 });
-                Ok(Some(VerifiedAttestation {
-                    backend: self.id(),
-                    assurance: self.assurance(),
-                    subject: AttestedSubject::SelfMeasuredNode,
+                Ok(Some(VerifiedAttestation::new(
+                    self.id(),
+                    self.assurance(),
+                    AttestedSubject::SelfMeasuredNode,
                     subject_key_sha256,
                     proves,
                     not_proven,
-                    launch: Some(launch),
-                }))
+                    Some(launch),
+                )))
             }
             None => Ok(None),
         }

--- a/crates/nucleus-identity/src/assurance.rs
+++ b/crates/nucleus-identity/src/assurance.rs
@@ -123,14 +123,43 @@ pub enum AttestedSubject {
 ///
 /// `not_proven` is carried deliberately: it is what makes over-reading unsayable
 /// rather than merely undocumented.
+///
+/// Sealed (#2450): fields are private. The production constructor
+/// ([`Self::new`]) is `pub(crate)` — callable from anywhere in this crate
+/// (this module's own backends, and [`crate::tpm_devid`]'s residency/L2
+/// composition), but no struct literal compiles outside it, even within this
+/// crate. A second constructor, [`Self::for_test`], is gated behind
+/// `#[cfg(any(test, feature = "test-helpers"))]`: it exists so that A
+/// DIFFERENT crate's tests (`nucleus-tool-proxy`, which unit-tests
+/// `verify_attested_receipt` against controlled field combinations) can build
+/// a synthetic attestation without standing up a real SVID chain, while
+/// staying unreachable from any normal build — a crate must opt into
+/// `test-helpers` in its `[dev-dependencies]` to reach it at all.
+///
+/// ```compile_fail
+/// // This code does NOT compile — the fields are private and both
+/// // constructors are inaccessible here (`new` is `pub(crate)`; `for_test`
+/// // needs `test-helpers`, which this doctest does not enable).
+/// use nucleus_identity::assurance::{AssuranceLevel, AttestedSubject, VerifiedAttestation};
+/// use std::collections::BTreeSet;
+/// let forged = VerifiedAttestation {
+///     backend: "self-measured",
+///     assurance: AssuranceLevel::L3MeasuredBoot,
+///     subject: AttestedSubject::SelfMeasuredNode,
+///     subject_key_sha256: None,
+///     proves: BTreeSet::new(),
+///     not_proven: BTreeSet::new(),
+///     launch: None,
+/// };
+/// ```
 #[derive(Clone, Debug)]
 pub struct VerifiedAttestation {
     /// Stable backend identifier (e.g. `"self-measured"`).
-    pub backend: &'static str,
+    backend: &'static str,
     /// Normalized assurance this result carries.
-    pub assurance: AssuranceLevel,
+    assurance: AssuranceLevel,
     /// What the backend names as the attested subject.
-    pub subject: AttestedSubject,
+    subject: AttestedSubject,
     /// SHA-256 of the attested subject's **signing key** — the 32-byte Ed25519
     /// public key that this subject signs on its own behalf with — when the
     /// backend binds such a key. This is what lets a relying party close the
@@ -148,16 +177,81 @@ pub struct VerifiedAttestation {
     /// binding only when this is `Some`, and its contract requires the caller to
     /// have obtained `signer_pubkey` from the attested SVID itself when it is
     /// `None`.
-    pub subject_key_sha256: Option<[u8; 32]>,
+    subject_key_sha256: Option<[u8; 32]>,
     /// Claims the backend affirmatively established.
-    pub proves: BTreeSet<Claim>,
+    proves: BTreeSet<Claim>,
     /// Claims the backend explicitly could NOT establish.
-    pub not_proven: BTreeSet<Claim>,
+    not_proven: BTreeSet<Claim>,
     /// The launch measurement, when this backend is measurement-based.
-    pub launch: Option<LaunchAttestation>,
+    launch: Option<LaunchAttestation>,
 }
 
 impl VerifiedAttestation {
+    /// Private outside this crate — see the struct's own doc comment.
+    pub(crate) fn new(
+        backend: &'static str,
+        assurance: AssuranceLevel,
+        subject: AttestedSubject,
+        subject_key_sha256: Option<[u8; 32]>,
+        proves: BTreeSet<Claim>,
+        not_proven: BTreeSet<Claim>,
+        launch: Option<LaunchAttestation>,
+    ) -> Self {
+        Self {
+            backend,
+            assurance,
+            subject,
+            subject_key_sha256,
+            proves,
+            not_proven,
+            launch,
+        }
+    }
+
+    /// Test-only synthetic constructor — see the struct's own doc comment.
+    /// Bypasses all backend verification; never reachable from a normal build.
+    #[cfg(any(test, feature = "test-helpers"))]
+    pub fn for_test(
+        backend: &'static str,
+        assurance: AssuranceLevel,
+        subject: AttestedSubject,
+        subject_key_sha256: Option<[u8; 32]>,
+        proves: BTreeSet<Claim>,
+        not_proven: BTreeSet<Claim>,
+        launch: Option<LaunchAttestation>,
+    ) -> Self {
+        Self::new(
+            backend,
+            assurance,
+            subject,
+            subject_key_sha256,
+            proves,
+            not_proven,
+            launch,
+        )
+    }
+
+    /// Stable backend identifier (e.g. `"self-measured"`).
+    pub fn backend(&self) -> &'static str {
+        self.backend
+    }
+
+    /// What the backend names as the attested subject.
+    pub fn subject(&self) -> &AttestedSubject {
+        &self.subject
+    }
+
+    /// SHA-256 of the attested subject's bound signing key, when the backend
+    /// established one. See the field's own doc comment for the `None` contract.
+    pub fn subject_key_sha256(&self) -> Option<[u8; 32]> {
+        self.subject_key_sha256
+    }
+
+    /// The launch measurement, when this backend is measurement-based.
+    pub fn launch(&self) -> Option<&LaunchAttestation> {
+        self.launch.as_ref()
+    }
+
     /// True iff the backend affirmatively proved `claim`.
     pub fn proves(&self, claim: Claim) -> bool {
         self.proves.contains(&claim)
@@ -172,6 +266,20 @@ impl VerifiedAttestation {
     /// The normalized assurance level.
     pub fn assurance(&self) -> AssuranceLevel {
         self.assurance
+    }
+
+    /// The full set of claims the backend affirmatively established. Prefer
+    /// [`Self::proves`] for a single membership check; this is for whole-set
+    /// operations (e.g. disjointness with [`Self::unproven_claims`]).
+    pub fn proven_claims(&self) -> &BTreeSet<Claim> {
+        &self.proves
+    }
+
+    /// The full set of claims the backend explicitly could NOT establish. Prefer
+    /// [`Self::cannot_prove`] for a single membership check; this is for
+    /// whole-set operations.
+    pub fn unproven_claims(&self) -> &BTreeSet<Claim> {
+        &self.not_proven
     }
 }
 
@@ -328,9 +436,9 @@ mod tests {
             .expect("verify ok")
             .expect("attestation present");
 
-        assert_eq!(va.backend, "self-measured");
+        assert_eq!(va.backend(), "self-measured");
         assert_eq!(va.assurance(), AssuranceLevel::L1Software);
-        assert_eq!(va.subject, AttestedSubject::SelfMeasuredNode);
+        assert_eq!(va.subject(), &AttestedSubject::SelfMeasuredNode);
         // Proves exactly the artifact match…
         assert!(va.proves(Claim::UnmodifiedArtifact));
         // …and is explicit about the hardware-root gap it CANNOT close.

--- a/crates/nucleus-identity/src/ca/self_signed.rs
+++ b/crates/nucleus-identity/src/ca/self_signed.rs
@@ -1314,7 +1314,7 @@ mod tests {
             .unwrap()
             .expect("an attested leaf verifies");
         assert_eq!(
-            va.subject_key_sha256,
+            va.subject_key_sha256(),
             Some(binding),
             "the verifier must surface the bound key as subject_key_sha256"
         );
@@ -1358,7 +1358,7 @@ mod tests {
             .verify_svid(cert.leaf().to_pem(), &AttestationRequirements::any(), true)
             .unwrap()
             .expect("attested");
-        assert_eq!(va.subject_key_sha256, Some(binding));
+        assert_eq!(va.subject_key_sha256(), Some(binding));
     }
 
     /// The control: an attested SVID WITHOUT the binding extension surfaces
@@ -1390,7 +1390,7 @@ mod tests {
             .verify_svid(chain[0].to_pem(), &AttestationRequirements::any(), true)
             .unwrap()
             .expect("an attested leaf verifies");
-        assert_eq!(va.subject_key_sha256, None);
+        assert_eq!(va.subject_key_sha256(), None);
     }
 
     #[test]

--- a/crates/nucleus-identity/src/tpm_devid.rs
+++ b/crates/nucleus-identity/src/tpm_devid.rs
@@ -296,21 +296,21 @@ pub fn verify_residency(
         Claim::ContinuousLiveness,
         Claim::UnmodifiedArtifact,
     ]);
-    Ok(VerifiedAttestation {
-        backend: "tpm-devid-residency",
-        assurance: AssuranceLevel::L1Software,
-        subject: AttestedSubject::TpmResidentKey {
+    Ok(VerifiedAttestation::new(
+        "tpm-devid-residency",
+        AssuranceLevel::L1Software,
+        AttestedSubject::TpmResidentKey {
             ak_name_sha256: sha256_32(&ak_name),
             subject_name_sha256: sha256_32(&subject_name),
         },
         // A TPM Name is a hash over the TPM public area, not the bare Ed25519
         // public key a receipt signer presents, so this residency proof cannot
         // bind a receipt signer directly (that binding is a later brick).
-        subject_key_sha256: None,
+        None,
         proves,
         not_proven,
-        launch: None,
-    })
+        None,
+    ))
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -715,7 +715,7 @@ pub fn compose_l2(
     ek: &EkIdentity,
     binding: &AkEkBound,
 ) -> Result<VerifiedAttestation> {
-    let ak_name_sha256 = match &residency.subject {
+    let ak_name_sha256 = match residency.subject() {
         AttestedSubject::TpmResidentKey { ak_name_sha256, .. } => *ak_name_sha256,
         _ => return Err(vfail("residency attestation is not a TPM resident key")),
     };
@@ -747,17 +747,17 @@ pub fn compose_l2(
         Claim::ContinuousLiveness,
         Claim::UnmodifiedArtifact,
     ]);
-    Ok(VerifiedAttestation {
-        backend: "tpm-devid-l2",
-        assurance: AssuranceLevel::L2Device,
-        subject: residency.subject.clone(),
+    Ok(VerifiedAttestation::new(
+        "tpm-devid-l2",
+        AssuranceLevel::L2Device,
+        residency.subject().clone(),
         // Inherits residency's key-binding: still a TPM Name, not a bare
         // Ed25519 receipt-signer key.
-        subject_key_sha256: residency.subject_key_sha256,
+        residency.subject_key_sha256(),
         proves,
         not_proven,
-        launch: None,
-    })
+        None,
+    ))
 }
 
 #[cfg(test)]
@@ -767,18 +767,18 @@ mod l2_composition_tests {
     use std::collections::BTreeSet;
 
     fn residency(ak: [u8; 32]) -> VerifiedAttestation {
-        VerifiedAttestation {
-            backend: "tpm-devid-residency",
-            assurance: AssuranceLevel::L1Software,
-            subject: AttestedSubject::TpmResidentKey {
+        VerifiedAttestation::new(
+            "tpm-devid-residency",
+            AssuranceLevel::L1Software,
+            AttestedSubject::TpmResidentKey {
                 ak_name_sha256: ak,
                 subject_name_sha256: [0u8; 32],
             },
-            subject_key_sha256: None,
-            proves: BTreeSet::from([Claim::KeyNonExportable]),
-            not_proven: BTreeSet::from([Claim::HardwareRootedKey, Claim::StableDeviceIdentity]),
-            launch: None,
-        }
+            None,
+            BTreeSet::from([Claim::KeyNonExportable]),
+            BTreeSet::from([Claim::HardwareRootedKey, Claim::StableDeviceIdentity]),
+            None,
+        )
     }
     fn ek() -> EkIdentity {
         EkIdentity {
@@ -808,7 +808,7 @@ mod l2_composition_tests {
             assert!(va.proves(c), "must prove {c:?}");
         }
         assert!(va.cannot_prove(Claim::MeasuredBoot), "MeasuredBoot is L3");
-        assert!(va.proves.is_disjoint(&va.not_proven));
+        assert!(va.proven_claims().is_disjoint(va.unproven_claims()));
     }
 
     /// **Coherence bite — wrong AK.** A binding for a different AK than the
@@ -839,8 +839,21 @@ mod l2_composition_tests {
     #[test]
     fn residency_without_nonexportable_is_refused() {
         let ak = [7u8; 32];
-        let mut r = residency(ak);
-        r.proves = BTreeSet::new(); // strip KeyNonExportable
+        // Same shape as `residency(ak)`, but with `proves` stripped of
+        // KeyNonExportable — private fields mean this must be built fresh
+        // rather than mutated post-construction.
+        let r = VerifiedAttestation::new(
+            "tpm-devid-residency",
+            AssuranceLevel::L1Software,
+            AttestedSubject::TpmResidentKey {
+                ak_name_sha256: ak,
+                subject_name_sha256: [0u8; 32],
+            },
+            None,
+            BTreeSet::new(),
+            BTreeSet::from([Claim::HardwareRootedKey, Claim::StableDeviceIdentity]),
+            None,
+        );
         let e = ek();
         let b = AkEkBound {
             ak_name_sha256: ak,
@@ -1358,7 +1371,7 @@ pub fn effective_assurance_with_roots(
         ek_spki_sha256: hw.ek_spki_sha256,
     };
     let l2 = compose_l2(&residency, &ek, &binding)?;
-    Ok(base_level.max(l2.assurance))
+    Ok(base_level.max(l2.assurance()))
 }
 
 fn effective_assurance_residency_only(
@@ -1374,7 +1387,7 @@ fn effective_assurance_residency_only(
     // attestation instead of residency, so *absence* is not itself a failure —
     // but a present-yet-invalid proof still errs (verify_leaf_der is fail-closed).
     match TpmDevidBackend::verify_leaf_der(cert_der, false)? {
-        Some(va) => Ok(base.max(va.assurance)),
+        Some(va) => Ok(base.max(va.assurance())),
         None => Ok(base),
     }
 }
@@ -1420,8 +1433,11 @@ mod tests {
         // The residency proof must NOT be read as hardware rooting.
         assert!(va.cannot_prove(Claim::HardwareRootedKey));
         assert!(va.cannot_prove(Claim::StableDeviceIdentity));
-        assert!(va.proves.is_disjoint(&va.not_proven));
-        assert!(matches!(va.subject, AttestedSubject::TpmResidentKey { .. }));
+        assert!(va.proven_claims().is_disjoint(va.unproven_claims()));
+        assert!(matches!(
+            va.subject(),
+            AttestedSubject::TpmResidentKey { .. }
+        ));
     }
 
     /// RED (revert detector for fixedParent) — clearing the subject's fixedParent
@@ -1665,7 +1681,10 @@ mod tests {
             .expect("attested");
         assert!(va.proves(Claim::KeyNonExportable));
         assert!(va.cannot_prove(Claim::HardwareRootedKey));
-        assert!(matches!(va.subject, AttestedSubject::TpmResidentKey { .. }));
+        assert!(matches!(
+            va.subject(),
+            AttestedSubject::TpmResidentKey { .. }
+        ));
     }
 
     /// RED (anti-replay) — the SAME valid residency proof embedded in a cert whose

--- a/crates/nucleus-policy-cert/Cargo.toml
+++ b/crates/nucleus-policy-cert/Cargo.toml
@@ -72,3 +72,13 @@ portcullis = { path = "../portcullis", version = "1.0.0", default-features = fal
 ed25519-dalek = { workspace = true }
 proptest = { workspace = true }
 serde_json = { workspace = true }
+# Test-only: `portcullis::certificate::VerifiedPermissions` is sealed (#2450)
+# and can only be produced by `verify_certificate`, which needs `ring`
+# (portcullis's own Ed25519 primitive, distinct from this crate's own
+# `crypto` feature's `ed25519-dalek`) and `chrono` for cert timestamps. Only
+# unified into the `crypto`/`portcullis` feature combination during `cargo
+# test` (resolver v2 dev-dependency feature unification) — the published
+# leaf build is unaffected.
+ring = { workspace = true }
+chrono = { workspace = true }
+portcullis = { path = "../portcullis", features = ["crypto"] }

--- a/crates/nucleus-policy-cert/src/lib.rs
+++ b/crates/nucleus-policy-cert/src/lib.rs
@@ -1024,9 +1024,9 @@ pub mod portcullis_bridge {
     /// Project a verified portcullis delegation into the unified outcome.
     pub fn delegation_outcome(verified: &VerifiedPermissions) -> AuthorityOutcome {
         AuthorityOutcome::Delegation {
-            chain_depth: verified.chain_depth as u32,
-            root_identity: verified.root_identity.clone(),
-            leaf_identity: verified.leaf_identity.clone(),
+            chain_depth: verified.chain_depth() as u32,
+            root_identity: verified.root_identity().to_string(),
+            leaf_identity: verified.leaf_identity().to_string(),
         }
     }
 
@@ -1046,17 +1046,63 @@ pub mod portcullis_bridge {
     #[cfg(test)]
     mod tests {
         use super::*;
+        use chrono::{Duration, Utc};
         use portcullis::PermissionLattice;
-        use portcullis::certificate::{SinkScope, VerifiedPermissions};
+        use portcullis::certificate::{
+            LatticeCertificate, VerifiedPermissions, verify_certificate,
+        };
+        use ring::rand::SystemRandom;
+        use ring::signature::{Ed25519KeyPair, KeyPair};
 
+        /// Mint a real `depth`-hop delegation chain and verify it —
+        /// `VerifiedPermissions` is sealed (#2450) and can only be produced
+        /// by `verify_certificate` now, matching every other producer in
+        /// this codebase (`nucleus-tool-proxy::cert_bridge`'s
+        /// `mint_and_verify`/`mint_delegate_and_verify`,
+        /// `portcullis/tests/kernel_sink_scope.rs`'s `verified_with_scope`).
+        /// Only `depth` 1 and 2 are used by the tests below.
         fn verified(depth: usize) -> VerifiedPermissions {
-            VerifiedPermissions::new(
+            assert!(
+                depth >= 1,
+                "a mint-only chain has depth 0, not a hop count this helper supports"
+            );
+            let rng = SystemRandom::new();
+            let root_pkcs8 = Ed25519KeyPair::generate_pkcs8(&rng).unwrap();
+            let root_key = Ed25519KeyPair::from_pkcs8(root_pkcs8.as_ref()).unwrap();
+            let root_pub = root_key.public_key().as_ref().to_vec();
+            let not_after = Utc::now() + Duration::hours(8);
+
+            let (mut cert, mut holder_key) = LatticeCertificate::mint(
                 PermissionLattice::restrictive(),
-                depth,
-                "spiffe://nucleus.local/human/alice".into(),
-                "spiffe://nucleus.local/agent/coder-042".into(),
-                SinkScope::default(),
-            )
+                "spiffe://nucleus.local/human/alice".to_string(),
+                not_after,
+                &root_key,
+                &rng,
+            );
+            for hop in 1..depth {
+                let (next_cert, next_key) = cert
+                    .delegate(
+                        &PermissionLattice::restrictive(),
+                        format!("spiffe://nucleus.local/intermediate/{hop}"),
+                        not_after,
+                        &holder_key,
+                        &rng,
+                    )
+                    .unwrap();
+                cert = next_cert;
+                holder_key = next_key;
+            }
+            let (cert, _leaf_key) = cert
+                .delegate(
+                    &PermissionLattice::restrictive(),
+                    "spiffe://nucleus.local/agent/coder-042".to_string(),
+                    not_after,
+                    &holder_key,
+                    &rng,
+                )
+                .unwrap();
+
+            verify_certificate(&cert, &root_pub, Utc::now(), 10).unwrap()
         }
 
         #[test]

--- a/crates/nucleus-tool-proxy/Cargo.toml
+++ b/crates/nucleus-tool-proxy/Cargo.toml
@@ -134,6 +134,11 @@ wiremock = "0.6"
 # corpus; already transitive via `portcullis`. Dev-only — production graph
 # unchanged. Used by tests/attack_corpus.rs.
 portcullis-core = { path = "../portcullis-core", features = ["test-helpers"] }
+# VerifiedAttestation::for_test (#2450 sealing) — synthetic attestations for
+# unit-testing verify_attested_receipt's cross-check logic in src/attestation.rs.
+# Resolver v2 keeps this test-only feature out of the published binary's
+# dependency graph; the real `[dependencies]` entry above stays unchanged.
+nucleus-identity = { path = "../nucleus-identity", features = ["tpm-devid", "test-helpers"] }
 
 [lints]
 workspace = true

--- a/crates/nucleus-tool-proxy/src/attestation.rs
+++ b/crates/nucleus-tool-proxy/src/attestation.rs
@@ -428,10 +428,11 @@ pub fn verify_attested_receipt(
 
     // 2. The self-claim must EQUAL the independently-verified attestation — the
     //    load-bearing check. Backend first, then the assurance level.
-    if receipt.signer_backend != attestation.backend {
+    if receipt.signer_backend != attestation.backend() {
         return Err(format!(
             "signer backend claim {:?} does not match verified attestation backend {:?}",
-            receipt.signer_backend, attestation.backend
+            receipt.signer_backend,
+            attestation.backend()
         ));
     }
     if receipt.signer_assurance != attestation.assurance().as_u8() {
@@ -452,7 +453,7 @@ pub fn verify_attested_receipt(
     //    TPM Name that is not a bare Ed25519 key), the binding cannot be checked
     //    here; the caller's contract is then to have obtained `signer_pubkey`
     //    from the attested SVID itself.
-    if let Some(expected) = attestation.subject_key_sha256 {
+    if let Some(expected) = attestation.subject_key_sha256() {
         let mut hasher = Sha256::new();
         hasher.update(signer_pubkey.to_bytes());
         let got: [u8; 32] = hasher.finalize().into();
@@ -736,15 +737,18 @@ mod tests {
         level: AssuranceLevel,
         key_fp: Option<[u8; 32]>,
     ) -> VerifiedAttestation {
-        VerifiedAttestation {
+        // Synthetic — see VerifiedAttestation::for_test's own doc comment
+        // (#2450 sealing; gated behind nucleus-identity's `test-helpers`
+        // dev-dependency feature, enabled only for this crate's tests).
+        VerifiedAttestation::for_test(
             backend,
-            assurance: level,
-            subject: AttestedSubject::SelfMeasuredNode,
-            subject_key_sha256: key_fp,
-            proves: BTreeSet::new(),
-            not_proven: BTreeSet::new(),
-            launch: None,
-        }
+            level,
+            AttestedSubject::SelfMeasuredNode,
+            key_fp,
+            BTreeSet::new(),
+            BTreeSet::new(),
+            None,
+        )
     }
 
     /// The common case in these tests: no key-binding declared.

--- a/crates/nucleus-tool-proxy/src/cert_bridge.rs
+++ b/crates/nucleus-tool-proxy/src/cert_bridge.rs
@@ -44,7 +44,7 @@ use std::collections::HashSet;
 ///
 /// A dimension is included in the bid if ANY constituent capability is non-Never.
 pub fn certificate_to_bid(verified: &VerifiedPermissions) -> PermissionBid {
-    let caps = &verified.effective.capabilities;
+    let caps = &verified.effective().capabilities;
     let mut requested = Vec::new();
 
     // Filesystem: read_files, write_files, edit_files, glob_search, grep_search
@@ -72,21 +72,21 @@ pub fn certificate_to_bid(verified: &VerifiedPermissions) -> PermissionBid {
     }
 
     // Approval: meta-dimension, present if there are obligations
-    if !verified.effective.obligations.is_empty() {
+    if !verified.effective().obligations.is_empty() {
         requested.push(PermissionDimension::Approval);
     }
 
-    let trust_tier = chain_depth_to_trust_tier(verified.chain_depth);
+    let trust_tier = chain_depth_to_trust_tier(verified.chain_depth());
 
     let value_estimate = verified
-        .effective
+        .effective()
         .budget
         .max_cost_usd
         .to_f64()
         .unwrap_or(0.0);
 
     PermissionBid {
-        skill_id: verified.leaf_identity.clone(),
+        skill_id: verified.leaf_identity().to_string(),
         requested,
         value_estimate,
         trust_tier,
@@ -198,20 +198,20 @@ pub fn dimensions_to_ceiling(dimensions: &[PermissionDimension]) -> PermissionLa
 
 /// Intersect a market grant with certificate-attested permissions.
 ///
-/// The effective permissions are `verified.effective ∧ ceiling(granted)`,
+/// The effective permissions are `verified.effective() ∧ ceiling(granted)`,
 /// using the lattice meet operation. This preserves all invariants
 /// (uninhabitable_state enforcement, obligations, paths, budget, commands, time)
 /// and is provably correct: meet is monotone and deflationary.
 ///
 /// # Security Invariant
 ///
-/// The result is always ≤ `verified.effective` AND ≤ `ceiling(granted)`.
+/// The result is always ≤ `verified.effective()` AND ≤ `ceiling(granted)`.
 pub fn intersect_grant_with_certificate(
     grant: &PermissionGrant,
     verified: &VerifiedPermissions,
 ) -> PermissionLattice {
     let ceiling = dimensions_to_ceiling(&grant.granted);
-    verified.effective.meet(&ceiling)
+    verified.effective().meet(&ceiling)
 }
 
 /// Extract the set of market dimensions from a `PermissionLattice`.
@@ -560,8 +560,8 @@ mod tests {
 
         // Step 3: Verify the certificate
         let verified = verify_certificate(&cert, &root_pub, Utc::now(), 10).unwrap();
-        assert_eq!(verified.chain_depth, 1);
-        assert_eq!(verified.leaf_identity, "spiffe://nucleus/agent/coder-042");
+        assert_eq!(verified.chain_depth(), 1);
+        assert_eq!(verified.leaf_identity(), "spiffe://nucleus/agent/coder-042");
 
         // Step 4: Convert to market bid (α)
         let bid = certificate_to_bid(&verified);
@@ -580,7 +580,7 @@ mod tests {
         let effective = intersect_grant_with_certificate(&grant, &verified);
 
         // Step 7: Verify the result is bounded by both certificate and grant
-        assert!(effective.leq(&verified.effective));
+        assert!(effective.leq(verified.effective()));
     }
 
     // ═══════════════════════════════════════════════════════════════════════
@@ -689,7 +689,7 @@ mod tests {
         for grant in &grants {
             let effective = intersect_grant_with_certificate(grant, &verified);
             assert!(
-                effective.leq(&verified.effective),
+                effective.leq(verified.effective()),
                 "Intersection exceeded certificate for grant: {:?}",
                 grant.granted
             );

--- a/crates/nucleus-tool-proxy/src/main.rs
+++ b/crates/nucleus-tool-proxy/src/main.rs
@@ -2437,12 +2437,12 @@ async fn auth_middleware(
                 };
             } else {
                 context.identity_binding = auth::IdentityBinding::DelegationVerified {
-                    leaf_identity: certified.verified.leaf_identity.clone(),
+                    leaf_identity: certified.verified.leaf_identity().to_string(),
                 };
             }
         } else {
             context.identity_binding = auth::IdentityBinding::DelegationVerified {
-                leaf_identity: certified.verified.leaf_identity.clone(),
+                leaf_identity: certified.verified.leaf_identity().to_string(),
             };
         }
         (Some(grant), Some(certified))
@@ -2540,7 +2540,7 @@ pub(crate) struct CertifiedPermissions {
 /// 1. Decode base64 certificate from `x-nucleus-delegation-cert`
 /// 2. Verify Ed25519 chain against root public key
 /// 3. **Identity binding**: if `authenticated_spiffe_id` is Some, reject if
-///    `verified.leaf_identity != spiffe_id` (prevents privilege escalation)
+///    `verified.leaf_identity() != spiffe_id` (prevents privilege escalation)
 /// 4. Convert `VerifiedPermissions` → `PermissionBid` via α
 /// 5. Evaluate bid against market → `PermissionGrant`
 /// 6. Intersect grant with certificate → effective `PermissionLattice`
@@ -2592,11 +2592,11 @@ fn evaluate_delegation_cert_with_identity(
     // verify that the delegation certificate's leaf identity matches.
     // This prevents privilege escalation where agent-A presents agent-B's cert.
     if let Some(spiffe_id) = authenticated_spiffe_id
-        && verified.leaf_identity != spiffe_id
+        && verified.leaf_identity() != spiffe_id
     {
         tracing::warn!(
             authenticated_id = %spiffe_id,
-            cert_leaf_id = %verified.leaf_identity,
+            cert_leaf_id = %verified.leaf_identity(),
             event = "identity_mismatch_rejected",
             "delegation cert leaf_identity does not match authenticated SPIFFE ID"
         );
@@ -2623,8 +2623,8 @@ fn evaluate_delegation_cert_with_identity(
     let effective = cert_bridge::intersect_grant_with_certificate(&grant, &verified);
 
     tracing::info!(
-        leaf_identity = %verified.leaf_identity,
-        chain_depth = verified.chain_depth,
+        leaf_identity = %verified.leaf_identity(),
+        chain_depth = verified.chain_depth(),
         trust_tier = ?bid.trust_tier,
         granted = grant.granted.len(),
         denied = grant.denied.len(),

--- a/crates/nucleus-verifier-service/tests/integration.rs
+++ b/crates/nucleus-verifier-service/tests/integration.rs
@@ -879,7 +879,7 @@ async fn well_known_agent_card_verifies_against_matching_key() {
     let returned: AgentCard = serde_json::from_value(body).unwrap();
     let verified = verify_card(&returned, &resolved_key)
         .expect("served agent card must verify against the matching out-of-band key");
-    assert_eq!(verified.claims.did, "did:web:verifier.test.nucleus.local");
+    assert_eq!(verified.claims().did, "did:web:verifier.test.nucleus.local");
 }
 
 #[tokio::test]

--- a/crates/nucleus-verify-commerce/src/card_verifier.rs
+++ b/crates/nucleus-verify-commerce/src/card_verifier.rs
@@ -49,7 +49,7 @@ impl CallerVerifier for AgentCardVerifier {
             .map_err(|e| CommerceError::Unverified(format!("agent card did not verify: {e}")))?;
 
         Ok(VerifiedCaller {
-            spiffe_id: verified.claims.spiffe_id.clone(),
+            spiffe_id: verified.claims().spiffe_id.clone(),
         })
     }
 }

--- a/crates/portcullis/src/certificate.rs
+++ b/crates/portcullis/src/certificate.rs
@@ -78,7 +78,7 @@
 //! // Any verifier can check the certificate
 //! let root_pub = root_key.public_key().as_ref();
 //! let verified = verify_certificate(&cert, root_pub, Utc::now(), 10).unwrap();
-//! assert_eq!(verified.chain_depth, 1);
+//! assert_eq!(verified.chain_depth(), 1);
 //! ```
 
 use chrono::{DateTime, Utc};
@@ -171,28 +171,54 @@ pub struct LatticeCertificate {
     final_signature: Vec<u8>,
 }
 
+/// Marker type that makes [`VerifiedPermissions`] unforgeable outside this
+/// module — see the struct's own doc comment. Named distinctly from other
+/// sealed types in this codebase (`nucleus_ifc_kernel::discharge::Seal`,
+/// `nucleus_tool_proxy::session_token`'s own marker) since each lives in a
+/// different crate; there is no shared "the" seal type.
+#[derive(Clone)]
+struct CertificateSeal;
+
 /// Result of successful certificate verification.
 ///
-/// Only [`verify_certificate`] can produce this type, guaranteeing that the
-/// permissions were cryptographically verified.
-#[non_exhaustive]
+/// Sealed (#2450): every field is private, the only constructor
+/// ([`Self::new`]) is private to this module, and the `_seal` field holds a
+/// [`CertificateSeal`] that cannot be named outside it — so no
+/// `VerifiedPermissions` struct literal compiles in another crate, even one
+/// naming all five public-looking fields (see the `compile_fail` doctest
+/// below). Only [`verify_certificate`] produces one, guaranteeing that the
+/// permissions were cryptographically verified. Same pattern as
+/// `nucleus_ifc_kernel::discharge::DischargedBundle`.
+///
+/// ```compile_fail
+/// // This code does NOT compile — CertificateSeal is not accessible, and
+/// // the fields are private even ignoring that.
+/// use portcullis::certificate::VerifiedPermissions;
+/// use portcullis::PermissionLattice;
+/// let verified = VerifiedPermissions {
+///     effective: PermissionLattice::restrictive(),
+///     chain_depth: 0,
+///     root_identity: "spiffe://attacker/forged".to_string(),
+///     leaf_identity: "spiffe://attacker/forged".to_string(),
+///     sink_scope: Default::default(),
+///     // no `_seal`: the field is private, and CertificateSeal is
+///     // unnameable outside this module regardless.
+/// };
+/// ```
 #[derive(Clone)]
 pub struct VerifiedPermissions {
-    /// The effective permissions at the end of the chain.
-    pub effective: PermissionLattice,
-    /// Number of delegation hops from root to leaf.
-    pub chain_depth: usize,
-    /// Identity of the root authority.
-    pub root_identity: String,
-    /// Identity of the leaf holder.
-    pub leaf_identity: String,
-    /// Effective sink scope at the end of the chain (#594).
-    pub sink_scope: SinkScope,
+    effective: PermissionLattice,
+    chain_depth: usize,
+    root_identity: String,
+    leaf_identity: String,
+    sink_scope: SinkScope,
+    _seal: CertificateSeal,
 }
 
 impl VerifiedPermissions {
-    /// Construct verified permissions (typically from certificate chain verification).
-    pub fn new(
+    /// Private constructor — only callable from within this module (the
+    /// verifier, and this module's own tests).
+    fn new(
         effective: PermissionLattice,
         chain_depth: usize,
         root_identity: String,
@@ -205,7 +231,33 @@ impl VerifiedPermissions {
             root_identity,
             leaf_identity,
             sink_scope,
+            _seal: CertificateSeal,
         }
+    }
+
+    /// The effective permissions at the end of the chain.
+    pub fn effective(&self) -> &PermissionLattice {
+        &self.effective
+    }
+
+    /// Number of delegation hops from root to leaf.
+    pub fn chain_depth(&self) -> usize {
+        self.chain_depth
+    }
+
+    /// Identity of the root authority.
+    pub fn root_identity(&self) -> &str {
+        &self.root_identity
+    }
+
+    /// Identity of the leaf holder.
+    pub fn leaf_identity(&self) -> &str {
+        &self.leaf_identity
+    }
+
+    /// Effective sink scope at the end of the chain (#594).
+    pub fn sink_scope(&self) -> &SinkScope {
+        &self.sink_scope
     }
 }
 
@@ -996,13 +1048,13 @@ pub fn verify_certificate(
         .map(|b| b.sink_scope.clone())
         .unwrap_or_default();
 
-    Ok(VerifiedPermissions {
-        effective: prev_permissions.clone(),
-        chain_depth: cert.blocks.len(),
-        root_identity: cert.authority.root_identity.clone(),
+    Ok(VerifiedPermissions::new(
+        prev_permissions.clone(),
+        cert.blocks.len(),
+        cert.authority.root_identity.clone(),
         leaf_identity,
-        sink_scope: effective_sink_scope,
-    })
+        effective_sink_scope,
+    ))
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/crates/portcullis/src/certificate.rs
+++ b/crates/portcullis/src/certificate.rs
@@ -217,7 +217,12 @@ pub struct VerifiedPermissions {
 
 impl VerifiedPermissions {
     /// Private constructor — only callable from within this module (the
-    /// verifier, and this module's own tests).
+    /// verifier, and this module's own tests). Gated behind `crypto`, same as
+    /// its one caller ([`verify_certificate`]): without that feature `new` is
+    /// genuinely unreachable, and leaving it ungated produces a dead-code
+    /// warning in any crate that depends on `portcullis` with
+    /// `default-features = false` and no other path to `crypto`.
+    #[cfg(feature = "crypto")]
     fn new(
         effective: PermissionLattice,
         chain_depth: usize,

--- a/crates/portcullis/src/enforcement.rs
+++ b/crates/portcullis/src/enforcement.rs
@@ -449,16 +449,47 @@ mod tests {
     /// policy decision.
     #[test]
     fn require_enforced_accepts_a_verified_portcullis_delegation() {
-        use crate::certificate::{SinkScope, VerifiedPermissions};
+        use crate::certificate::{verify_certificate, LatticeCertificate};
         use crate::PermissionLattice;
+        use chrono::{Duration, Utc};
+        use ring::rand::SystemRandom;
+        use ring::signature::{Ed25519KeyPair, KeyPair};
 
-        let delegation = VerifiedPermissions::new(
+        // `VerifiedPermissions` is sealed (#2450): only `verify_certificate`
+        // produces one, so this test mints and delegates a REAL two-hop
+        // chain instead of constructing a `VerifiedPermissions` directly.
+        let rng = SystemRandom::new();
+        let root_pkcs8 = Ed25519KeyPair::generate_pkcs8(&rng).unwrap();
+        let root_key = Ed25519KeyPair::from_pkcs8(root_pkcs8.as_ref()).unwrap();
+        let root_pub = root_key.public_key().as_ref().to_vec();
+        let not_after = Utc::now() + Duration::hours(8);
+
+        let (cert, holder_key) = LatticeCertificate::mint(
             PermissionLattice::restrictive(),
-            2,
-            "spiffe://nucleus.local/human/alice".into(),
-            "spiffe://nucleus.local/agent/coder-042".into(),
-            SinkScope::default(),
+            "spiffe://nucleus.local/human/alice".to_string(),
+            not_after,
+            &root_key,
+            &rng,
         );
+        let (cert, intermediate_key) = cert
+            .delegate(
+                &PermissionLattice::restrictive(),
+                "spiffe://nucleus.local/agent/intermediate".to_string(),
+                not_after,
+                &holder_key,
+                &rng,
+            )
+            .unwrap();
+        let (cert, _leaf_key) = cert
+            .delegate(
+                &PermissionLattice::restrictive(),
+                "spiffe://nucleus.local/agent/coder-042".to_string(),
+                not_after,
+                &intermediate_key,
+                &rng,
+            )
+            .unwrap();
+        let delegation = verify_certificate(&cert, &root_pub, Utc::now(), 10).unwrap();
 
         let authorized = require_enforced(
             delegation,
@@ -468,9 +499,9 @@ mod tests {
         .expect("a verified delegation + an enforceable posture → authorized");
 
         // The delegation rides through intact …
-        assert_eq!(authorized.authority.chain_depth, 2);
+        assert_eq!(authorized.authority.chain_depth(), 2);
         assert_eq!(
-            authorized.authority.leaf_identity,
+            authorized.authority.leaf_identity(),
             "spiffe://nucleus.local/agent/coder-042"
         );
         // … and the posture was strengthened (Filtered → Airgapped), not weakened.

--- a/crates/portcullis/src/kernel.rs
+++ b/crates/portcullis/src/kernel.rs
@@ -998,14 +998,14 @@ impl Kernel {
         let now = chrono::Utc::now().timestamp() as u64;
         let provenance = SessionProvenance {
             certificate_fingerprint,
-            root_identity: verified.root_identity.clone(),
-            leaf_identity: verified.leaf_identity.clone(),
-            chain_depth: verified.chain_depth,
+            root_identity: verified.root_identity().to_string(),
+            leaf_identity: verified.leaf_identity().to_string(),
+            chain_depth: verified.chain_depth(),
         };
-        let initial_hash = verified.effective.checksum();
+        let initial_hash = verified.effective().checksum();
         // Capture sink scope before moving effective permissions.
         // A fully-unrestricted scope (all vecs empty) is stored as None.
-        let scope = verified.sink_scope;
+        let scope = verified.sink_scope().clone();
         let sink_scope = if scope.allowed_paths.is_empty()
             && scope.allowed_hosts.is_empty()
             && scope.allowed_git_refs.is_empty()
@@ -1016,7 +1016,7 @@ impl Kernel {
         };
         Self {
             session_id: Uuid::new_v4(),
-            effective: verified.effective,
+            effective: verified.effective().clone(),
             initial_hash,
             isolation: IsolationLattice::localhost(),
             trace: Vec::new(),
@@ -1060,12 +1060,12 @@ impl Kernel {
         let now = chrono::Utc::now().timestamp() as u64;
         let provenance = SessionProvenance {
             certificate_fingerprint,
-            root_identity: verified.root_identity.clone(),
-            leaf_identity: verified.leaf_identity.clone(),
-            chain_depth: verified.chain_depth,
+            root_identity: verified.root_identity().to_string(),
+            leaf_identity: verified.leaf_identity().to_string(),
+            chain_depth: verified.chain_depth(),
         };
-        let initial_hash = verified.effective.checksum();
-        let scope = verified.sink_scope;
+        let initial_hash = verified.effective().checksum();
+        let scope = verified.sink_scope().clone();
         let sink_scope = if scope.allowed_paths.is_empty()
             && scope.allowed_hosts.is_empty()
             && scope.allowed_git_refs.is_empty()
@@ -1076,7 +1076,7 @@ impl Kernel {
         };
         Self {
             session_id: Uuid::new_v4(),
-            effective: verified.effective,
+            effective: verified.effective().clone(),
             initial_hash,
             isolation,
             trace: Vec::new(),

--- a/crates/portcullis/src/token.rs
+++ b/crates/portcullis/src/token.rs
@@ -71,7 +71,7 @@
 //! // Recipient verifies and creates kernel
 //! let restored = AttenuationToken::from_bytes(&wire_bytes).unwrap();
 //! let verified = restored.verify(Utc::now(), 10).unwrap();
-//! assert_eq!(verified.chain_depth, 1);
+//! assert_eq!(verified.chain_depth(), 1);
 //! ```
 
 // chrono is only consumed by the crypto-gated verify path (and unit
@@ -363,9 +363,9 @@ mod tests {
         let token = AttenuationToken::seal(cert, root_pub);
         let verified = token.verify(Utc::now(), 10).unwrap();
 
-        assert_eq!(verified.chain_depth, 1);
-        assert_eq!(verified.root_identity, "spiffe://test/human/alice");
-        assert_eq!(verified.leaf_identity, "spiffe://test/agent/coder-042");
+        assert_eq!(verified.chain_depth(), 1);
+        assert_eq!(verified.root_identity(), "spiffe://test/human/alice");
+        assert_eq!(verified.leaf_identity(), "spiffe://test/agent/coder-042");
     }
 
     #[test]
@@ -438,8 +438,8 @@ mod tests {
         let restored = AttenuationToken::from_bytes(&bytes).unwrap();
 
         let verified = restored.verify(Utc::now(), 10).unwrap();
-        assert_eq!(verified.chain_depth, 1);
-        assert_eq!(verified.root_identity, "spiffe://test/human/alice");
+        assert_eq!(verified.chain_depth(), 1);
+        assert_eq!(verified.root_identity(), "spiffe://test/human/alice");
     }
 
     #[cfg(feature = "serde")]
@@ -453,7 +453,7 @@ mod tests {
         let restored = AttenuationToken::from_base64(&encoded).unwrap();
 
         let verified = restored.verify(Utc::now(), 10).unwrap();
-        assert_eq!(verified.chain_depth, 1);
+        assert_eq!(verified.chain_depth(), 1);
     }
 
     #[test]
@@ -467,9 +467,9 @@ mod tests {
 
         let provenance = SessionProvenance {
             certificate_fingerprint: fingerprint,
-            root_identity: verified.root_identity.clone(),
-            leaf_identity: verified.leaf_identity.clone(),
-            chain_depth: verified.chain_depth,
+            root_identity: verified.root_identity().to_string(),
+            leaf_identity: verified.leaf_identity().to_string(),
+            chain_depth: verified.chain_depth(),
         };
 
         assert_eq!(provenance.root_identity, "spiffe://test/human/alice");
@@ -555,11 +555,11 @@ mod tests {
         let token = AttenuationToken::seal(cert, root_pub);
         let verified = token.verify(Utc::now(), 10).unwrap();
 
-        assert_eq!(verified.chain_depth, 3);
-        assert_eq!(verified.root_identity, "spiffe://test/human/alice");
-        assert_eq!(verified.leaf_identity, "spiffe://test/agent/test");
+        assert_eq!(verified.chain_depth(), 3);
+        assert_eq!(verified.root_identity(), "spiffe://test/human/alice");
+        assert_eq!(verified.leaf_identity(), "spiffe://test/agent/test");
 
         // Effective perms are ≤ root (monotone attenuation)
-        assert!(verified.effective.leq(&root_perms));
+        assert!(verified.effective().leq(&root_perms));
     }
 }

--- a/crates/portcullis/tests/certificate_tests.rs
+++ b/crates/portcullis/tests/certificate_tests.rs
@@ -136,7 +136,7 @@ proptest! {
             .unwrap();
 
         let verified = verify_certificate(&cert, &root_pub, Utc::now(), 10).unwrap();
-        prop_assert_eq!(verified.chain_depth, 1);
+        prop_assert_eq!(verified.chain_depth(), 1);
     }
 
     /// After delegation, effective_permissions.leq(parent_permissions) always holds.
@@ -221,12 +221,12 @@ proptest! {
 
         // Verify the full chain
         let verified = verify_certificate(&cert, &root_pub, Utc::now(), 10).unwrap();
-        prop_assert_eq!(verified.chain_depth, 2);
+        prop_assert_eq!(verified.chain_depth(), 2);
 
         // Transitivity: leaf ≤ mid ≤ root
-        prop_assert!(verified.effective.leq(&mid_perms));
+        prop_assert!(verified.effective().leq(&mid_perms));
         prop_assert!(mid_perms.leq(&root_perms));
-        prop_assert!(verified.effective.leq(&root_perms));
+        prop_assert!(verified.effective().leq(&root_perms));
     }
 }
 
@@ -288,11 +288,11 @@ fn test_pajamas_attack_blocked_by_certificate() {
     // But the coder's effective permissions can't exceed the orchestrator's ceiling
     // Specifically: write_files and git_push should be Never (inherited from read_only)
     assert_eq!(
-        verified.effective.capabilities.write_files,
+        verified.effective().capabilities.write_files,
         CapabilityLevel::Never
     );
     assert_eq!(
-        verified.effective.capabilities.git_push,
+        verified.effective().capabilities.git_push,
         CapabilityLevel::Never
     );
 }
@@ -379,6 +379,6 @@ proptest! {
 
         // Must still verify
         let verified = verify_certificate(&restored, &root_pub, Utc::now(), 10).unwrap();
-        prop_assert_eq!(verified.chain_depth, 1);
+        prop_assert_eq!(verified.chain_depth(), 1);
     }
 }

--- a/crates/portcullis/tests/kernel_sink_scope.rs
+++ b/crates/portcullis/tests/kernel_sink_scope.rs
@@ -4,11 +4,16 @@
 //! These tests verify that the kernel enforces SinkScope constraints
 //! from verified permission certificates (path, host, and git ref scoping).
 
-use portcullis::certificate::{SinkScope, VerifiedPermissions};
+use chrono::{Duration, Utc};
+use portcullis::certificate::{
+    verify_certificate, LatticeCertificate, SinkScope, VerifiedPermissions,
+};
 use portcullis::kernel::{DenyReason, Kernel, Verdict};
 use portcullis::{
     BudgetLattice, CapabilityLattice, IsolationLattice, Obligations, Operation, PermissionLattice,
 };
+use ring::rand::SystemRandom;
+use ring::signature::{Ed25519KeyPair, KeyPair};
 
 /// Build a fully permissive lattice with NO obligations and NO
 /// uninhabitable constraint — purely for testing sink scope checks
@@ -28,15 +33,38 @@ fn permissive_no_obligations() -> PermissionLattice {
     lattice
 }
 
-/// Helper: create a VerifiedPermissions with the given SinkScope.
+/// Helper: create a `VerifiedPermissions` with the given `SinkScope`, through
+/// a REAL mint + delegate + verify — `VerifiedPermissions` is sealed (#2450)
+/// and can only be produced by [`verify_certificate`] now, matching every
+/// other producer in this codebase (see `nucleus-tool-proxy::cert_bridge`'s
+/// `mint_and_verify`/`mint_delegate_and_verify` for the same pattern).
 fn verified_with_scope(scope: SinkScope) -> VerifiedPermissions {
-    VerifiedPermissions::new(
-        permissive_no_obligations(),
-        1,
+    let rng = SystemRandom::new();
+    let root_pkcs8 = Ed25519KeyPair::generate_pkcs8(&rng).unwrap();
+    let root_key = Ed25519KeyPair::from_pkcs8(root_pkcs8.as_ref()).unwrap();
+    let root_pub = root_key.public_key().as_ref().to_vec();
+    let not_after = Utc::now() + Duration::hours(8);
+
+    let ceiling = permissive_no_obligations();
+    let (cert, holder_key) = LatticeCertificate::mint(
+        ceiling.clone(),
         "root".to_string(),
-        "leaf".to_string(),
-        scope,
-    )
+        not_after,
+        &root_key,
+        &rng,
+    );
+    let (cert, _delegatee_key) = cert
+        .delegate_with_scope(
+            &ceiling,
+            "leaf".to_string(),
+            not_after,
+            scope,
+            &holder_key,
+            &rng,
+        )
+        .unwrap();
+
+    verify_certificate(&cert, &root_pub, Utc::now(), 10).unwrap()
 }
 
 #[test]

--- a/examples/a2a-server/tests/e2e.rs
+++ b/examples/a2a-server/tests/e2e.rs
@@ -154,10 +154,10 @@ async fn discover_gate_serve_receipt() {
     let server_card: AgentCard = serde_json::from_value(card_json.clone()).unwrap();
     let verified = verify_card(&server_card, &card_jwk).expect("server card verifies");
     assert_eq!(
-        verified.claims.spiffe_id,
+        verified.claims().spiffe_id,
         "spiffe://summarizer.example.com/ns/agents/sa/summarizer"
     );
-    assert!(verified.claims.runtime_guarantees.is_some());
+    assert!(verified.claims().runtime_guarantees.is_some());
     // §4.6.1: the receipt extension is declared, optional.
     let receipt_ext = server_card
         .capabilities

--- a/sdks/verifier-js/src/lib.rs
+++ b/sdks/verifier-js/src/lib.rs
@@ -446,10 +446,10 @@ fn agent_card_verdict(
         serde_json::from_str(resolved_jwk_json).map_err(|e| format!("resolved JWK JSON: {e}"))?;
     match nucleus_agent_card::verify_card_json(signed_card_json, &jwk) {
         Ok(verified) => Ok(CardVerdict::Verified {
-            spiffe_id: verified.claims.spiffe_id.clone(),
-            did: verified.claims.did.clone(),
+            spiffe_id: verified.claims().spiffe_id.clone(),
+            did: verified.claims().did.clone(),
             supported_envelope_schema_versions: verified
-                .claims
+                .claims()
                 .supported_envelope_schema_versions
                 .clone(),
             trust_jwks_kids: verified
@@ -458,7 +458,7 @@ fn agent_card_verdict(
                 .iter()
                 .map(|k| k.kid.clone())
                 .collect(),
-            runtime_guarantees: verified.claims.runtime_guarantees.as_ref().map(|p| {
+            runtime_guarantees: verified.claims().runtime_guarantees.as_ref().map(|p| {
                 RuntimeGuaranteeSummary {
                     profile_version: p.profile_version.clone(),
                     tracked_sources: p.tracked_sources.clone(),


### PR DESCRIPTION
## Summary

Closes #2450. Four "verified" types were unforgeable in name only — public fields and/or a plain public constructor meant a value of the type proved nothing about whether the real check ever ran. This PR reshapes all four to the codebase's existing sealed-constructor pattern, in the tier of rigor each type's acceptance bar calls for:

| Type | Crate | Tier | Commit |
|---|---|---|---|
| `VerifiedPermissions` | `portcullis` | `DischargedBundle` (full module-privacy, `_seal` marker) | cf425ba5 |
| `VerifiedCard` | `nucleus-agent-card` | `VerifiedSessionToken` (private fields, `pub(crate)` ctor) | 07b53206 |
| `VerifiedAttestation` | `nucleus-identity` | `VerifiedSessionToken` + a `test-helpers`-gated cross-crate test ctor | 8a2b9118 |
| `AuthenticatedPrincipal` | `nucleus-control-plane-server` | `DischargedBundle` (tightest bar: "no code outside `crate::auth`") | fd0d6940 |

Each type now has:
- Private fields — no external struct literal compiles.
- The real verifier as the sole (or effectively sole) constructor.
- Getters preserving every accessor that used to be a direct field read.
- A `compile_fail` doctest on the struct proving the seal is real, not just documented.

## Fallout

Sealing a previously-public-fielded type breaks every direct field-read and every synthetic-construction call site across the whole dependency graph, not just the type's own crate. Each commit's body documents exactly what broke and how it was fixed, crate by crate — 12 files across `portcullis`, `portcullis-core`, `nucleus-policy-cert`, `nucleus-tool-proxy`, `nucleus-cli`, `nucleus-agent-card`, `nucleus-verify-commerce`, `nucleus-identity`, `nucleus-spiffe-hail`, and `nucleus-control-plane-server`.

The one genuinely new piece: `nucleus-tool-proxy`'s tests needed to build fully synthetic `VerifiedAttestation` values (arbitrary `{backend, assurance, subject_key_sha256}` combinations) to unit-test `verify_attested_receipt`'s cross-check logic, from a different crate than the sealed type. Resolved with the house `test-helpers` feature pattern (already used by `portcullis-core`): a `pub` constructor gated `#[cfg(any(test, feature = "test-helpers"))]`, enabled only in `nucleus-tool-proxy`'s `[dev-dependencies]` — resolver v2 keeps it out of the published binary.

## No behavior change

Every current call site already went through the real verifier; this PR does not change what any of them do, only what the compiler will let a *new* call site get away with.

## Verification

- `cargo test` across all 10 touched crates with `--all-features`: every suite green, 0 failures, including all four `compile_fail` doctests genuinely failing to compile a bypass.
- `cargo clippy --all-targets --all-features` across all 10 crates: clean.
- `cargo fmt --check` across all 10 crates: clean.
- `cargo check --workspace --exclude nucleus-verifier-service`: clean.
- Vendor-neutrality grep and the line-ratchet gate: clean on the full diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)