### PR TITLE
ci: pin cargo-audit's dependency tree to unbreak the audit gate

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -29,6 +29,24 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2.9.1
+      # Work around a broken transitive dependency: `actions-rust-lang/audit`
+      # installs cargo-audit via `cargo install cargo-audit --vers 0.22.0`
+      # with no `--locked`, so it re-resolves cargo-audit's own dependency
+      # tree against whatever is newest on crates.io today rather than the
+      # tree cargo-audit 0.22.0 shipped and tested against. tinyvec 1.13.0
+      # (a transitive dep, several hops down) fails to compile under
+      # `no_std` — `TinyVec::Heap` calls the `vec!` macro but the crate only
+      # imports the `alloc::vec` MODULE, not the macro — breaking every
+      # audit run repo-wide since it was published, independent of any
+      # change in this repo. `cargo install` skips reinstalling a version
+      # that's already present, so installing it ourselves with `--locked`
+      # (cargo-audit's own vetted lockfile, which predates the broken
+      # tinyvec release) here makes the action's own install step a no-op.
+      # Safe to remove once upstream re-locks past the tinyvec fix, or once
+      # actions-rust-lang/audit exposes a `--locked` passthrough itself.
+      - name: Pre-install cargo-audit with its own locked dependency tree
+        run: cargo +stable install cargo-audit --version 0.22.0 --locked --no-default-features
+        shell: bash
       - uses: actions-rust-lang/audit@72c09e02f132669d52284a3323acdb503cfc1a24 # v1
         with:
           denyWarnings: true


### PR DESCRIPTION
## Summary

The `audit` workflow has been failing on every open PR since ~21:14 UTC today:

```
error: cannot find macro `vec` in this scope
  --> tinyvec-1.13.0/src/tinyvec.rs:710:21
error: could not compile `tinyvec` (lib) due to 1 previous error
error: failed to compile `cargo-audit v0.22.0`
```

`actions-rust-lang/audit` installs cargo-audit via `cargo install cargo-audit --vers 0.22.0` with no `--locked`, so it re-resolves cargo-audit's dependency tree against whatever is newest on crates.io today rather than the tree 0.22.0 shipped and was tested against. tinyvec 1.13.0 (several hops down) has a real `no_std` bug — `TinyVec::Heap` calls the `vec!` macro but only imports the `alloc::vec` *module* — so it fails to compile for anyone, independent of anything in this repo.

Confirmed locally:
- `cargo install cargo-audit --version 0.22.0 --no-default-features` (no `--locked`, matching the action's own command): fails exactly this way.
- The same command with `--locked`: builds clean in ~40s.

## Fix

The composite action's install step has no version/lock passthrough input, but `cargo install` skips reinstalling a version that's already present. Confirmed locally against a throwaway `CARGO_HOME`: pre-installing `cargo-audit --version 0.22.0 --locked` makes a subsequent unlocked `cargo install cargo-audit --vers 0.22.0` report `Ignored package cargo-audit v0.22.0 is already installed` and exit clean — so adding that pre-install step before the composite action makes its own broken install a no-op.

`denyWarnings: true` is untouched — this only fixes how the audit tool itself gets built, not what's being audited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)