### PR TITLE
ci(#2430): prerequisite — merge_group trigger + required-check-safe noop twin for Kani fast-tier

### DIFF
--- a/.github/workflows/kani-nightly-noop.yml
+++ b/.github/workflows/kani-nightly-noop.yml
@@ -1,0 +1,49 @@
+name: Kani BMC
+
+# NO-OP TWIN of kani-nightly.yml's fast-tier jobs (`Kani`, `Kani
+# (constitutional kernel)`), so they can be REQUIRED status checks (#2430).
+# Branch protection evaluates required contexts on the PR itself; the real
+# workflow is path-filtered on pull_request, so a PR not touching its paths
+# would never report the context and block forever. This twin has the SAME
+# workflow name and SAME job names, with `paths-ignore` exactly mirroring the
+# real workflow's `paths`: exactly one of the twins reports each context on
+# every PR. (merge_group is NOT twinned — the real workflow now runs
+# unconditionally there; see its own `on:` block.)
+#
+# Keep this list in exact sync with kani-nightly.yml's `pull_request.paths` —
+# aeneas-ifc-scoped-noop.yml's own history has a scar from exactly this: two
+# paths present in the real workflow's list but missing here, so a PR fired
+# BOTH twins under the same context name instead of exactly one.
+
+on:
+  pull_request:
+    paths-ignore:
+      - "crates/portcullis/src/**"
+      - "crates/ck-*/src/**"
+      - ".kani-minimum-proofs"
+      - ".github/workflows/kani-nightly.yml"
+
+concurrency:
+  # Supersede a PR's older in-flight runs; NEVER cancel anything else.
+  group: kani-nightly-noop-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  kani-fast:
+    name: Kani
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: No-op (paths not touched)
+        run: echo "no relevant paths changed — gate vacuously green"
+
+  kani-constitutional:
+    name: Kani (constitutional kernel)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: No-op (paths not touched)
+        run: echo "no relevant paths changed — gate vacuously green"

--- a/.github/workflows/kani-nightly.yml
+++ b/.github/workflows/kani-nightly.yml
@@ -14,6 +14,11 @@ on:
       - "crates/ck-*/src/**"
       - ".kani-minimum-proofs"
       - ".github/workflows/kani-nightly.yml"
+  # Bare, unfiltered: the merge queue's own re-validation of the fast-tier
+  # jobs (#2430 — required status checks). Not path-filtered like push/
+  # pull_request above; kani-nightly-noop.yml is pull_request-only (its own
+  # comment explains why merge_group needs no twin).
+  merge_group:
   schedule:
     - cron: "17 3 * * *"
   workflow_dispatch:


### PR DESCRIPTION
## Summary

Prerequisite for #2430 (make the Kani proof suite a required branch-protection status check). Not the branch-protection change itself — that's staged as a deliberate follow-up (see below).

Two gaps had to close first, or requiring `Kani`/`Kani (constitutional kernel)` would deadlock every future PR merge rather than gate it:

1. **No `merge_group` trigger** on `kani-nightly.yml` — unlike every other workflow already in the required-checks list. Without it, the merge queue's own re-validation of a merge commit never gets a status from these jobs. Added `merge_group:` (bare, unfiltered, matching `aeneas-ifc-scoped.yml`'s precedent).
2. **Path-filtered `pull_request.paths`, no noop twin** — a PR touching none of `crates/portcullis/src/**`/`crates/ck-*/src/**`/etc. would never get a status from a required "Kani" context and block forever. This codebase already has the fix for exactly this (`aeneas-ifc-scoped-noop.yml`), so I followed that template: `kani-nightly-noop.yml`, same workflow/job names, triggered on `paths-ignore` exactly mirroring the real workflow's `paths`.

## Verification

- `actionlint` on both files: no errors (only pre-existing shellcheck style nits elsewhere in the repo).
- The noop's `paths-ignore` list diffed line-for-line against the real workflow's `paths` — the aeneas precedent's own scar-tissue comment documents a past bug from exactly this kind of mismatch.
- Observed timing on real recent runs: `Kani` and `Kani (constitutional kernel)` complete in ~1.5–2 minutes each against a 15-minute timeout — well within budget to require.

## Deliberately NOT in this PR

The branch-protection API change itself. Flipping `required_status_checks.contexts` before the noop twin has been exercised live risks blocking every future PR merge if there's a bug in it — worse than a harness simply not being required yet. Once this merges, I'll confirm the noop fires correctly on a subsequent PR that doesn't touch the relevant paths, then make the required-check change as its own step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)