### PR TITLE
security(portcullis): certificate convergence PR 1 — sign every attenuating dimension, budget ledger, caller-owned holder keys, verify_strict

### DIFF
--- a/SECURITY_TODO.md
+++ b/SECURITY_TODO.md
@@ -320,7 +320,12 @@ Deficiency
 - Exploitability varies by site: certificate DELEGATION `next_key` travels in-band (attacker-influenced) → highest concern; `verify_certificate` root key, `TrustStore`, and token/receipt keys are caller-pinned (lower, but still weak-binding).
 
 TODO
-- [ ] Owner decision required — not fixed here (out of M-3's stated dalek/`verify_strict` scope; it is a load-bearing crypto change). Options: (a) add an explicit small-order/canonical-encoding rejection of the public key and `R` around each ring verify; or (b) migrate these trust-path verifies to `ed25519-dalek::verify_strict`. Either way, extend `scripts/check-verify-strict.sh` to cover the ring paths once a canonical form is chosen.
+- [x] Option (b) chosen: migrate trust-path verifies to `ed25519-dalek::verify_strict`, signing stays on `ring`.
+  - [x] `token_sign.rs`, `receipt_sign.rs` — migrated (earlier).
+  - [x] `certificate.rs` (authority / per-block / proof-of-possession, the highest-concern in-band `next_key` site) — migrated in the certificate-convergence PR 1; `verify_ed25519_strict` is the single verify helper, pinned by `certificate_convergence_tests::small_order_root_key_forgery_rejected`, which asserts (non-vacuously) that `ring` still accepts the identity triple and `verify_certificate` now refuses it.
+  - [ ] `manifest_registry.rs:98/139` — still `ring`.
+  - [ ] Extend `scripts/check-verify-strict.sh` to cover the migrated ring paths.
+- `nucleus-identity::approval_bundle.rs:425` is **ECDSA P-256** (`ECDSA_P256_SHA256_FIXED`), not Ed25519; the small-order Ed25519 concern does not apply there. Listed in error by the original sweep.
 
 Status
-- [OPEN] Reported by the M-3 sweep; deliberately left unfixed pending owner triage.
+- [PARTIAL] Three of four Ed25519 sites migrated; `manifest_registry.rs` open.

--- a/crates/nucleus-cli/src/token.rs
+++ b/crates/nucleus-cli/src/token.rs
@@ -21,7 +21,7 @@ use clap::{Args, Subcommand};
 use ring::signature::{Ed25519KeyPair, KeyPair};
 
 use portcullis::PermissionLattice;
-use portcullis::certificate::LatticeCertificate;
+use portcullis::certificate::{LatticeCertificate, SinkScope};
 use portcullis::profile::ProfileRegistry;
 use portcullis::token::AttenuationToken;
 
@@ -67,10 +67,17 @@ pub struct MintArgs {
     #[arg(short, long)]
     pub output: Option<PathBuf>,
 
-    /// Also write the root signing key (PKCS#8 PEM) for later delegation.
-    /// WARNING: Keep this key secure — it is the root of trust.
+    /// Also write the HOLDER key (PKCS#8 PEM) — the key `nucleus token
+    /// delegate --key` needs to extend this chain. (Previously this wrote the
+    /// root signing key, which cannot delegate: the chain expects the holder
+    /// key, so every `delegate` off a minted token failed with KeyMismatch.)
     #[arg(long)]
     pub write_key: Option<PathBuf>,
+
+    /// Also write the ROOT signing key (PKCS#8 PEM). This is the trust
+    /// anchor, not a delegation key. WARNING: keep it secure.
+    #[arg(long)]
+    pub write_root_key: Option<PathBuf>,
 }
 
 #[derive(Args)]
@@ -153,6 +160,20 @@ fn write_output(data: &str, path: Option<&PathBuf>) -> Result<()> {
     Ok(())
 }
 
+/// Write a PKCS#8 key as PEM, owner-read-only.
+fn write_key_pem(path: &PathBuf, pkcs8_bytes: &[u8]) -> Result<()> {
+    let pem = pkcs8_to_pem(pkcs8_bytes);
+    std::fs::write(path, &pem)
+        .with_context(|| format!("Failed to write key to {}", path.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+            .with_context(|| format!("Failed to restrict permissions on {}", path.display()))?;
+    }
+    Ok(())
+}
+
 /// Encode a PKCS#8 key as PEM.
 fn pkcs8_to_pem(pkcs8_bytes: &[u8]) -> String {
     let b64 = base64::engine::general_purpose::STANDARD.encode(pkcs8_bytes);
@@ -199,13 +220,22 @@ fn mint(args: MintArgs) -> Result<()> {
         .map_err(|e| anyhow::anyhow!("Failed to parse generated key: {}", e))?;
     let root_pub = root_key.public_key().as_ref().to_vec();
 
+    // Generate the holder keypair OURSELVES so it can be written out: a
+    // `ring` keypair cannot export its seed, so the one `mint` would
+    // generate internally is unpersistable.
+    let holder_pkcs8 = Ed25519KeyPair::generate_pkcs8(&rng)
+        .map_err(|e| anyhow::anyhow!("Failed to generate holder key: {}", e))?;
+    let holder_key = Ed25519KeyPair::from_pkcs8(holder_pkcs8.as_ref())
+        .map_err(|e| anyhow::anyhow!("Failed to parse generated holder key: {}", e))?;
+
     // Mint root certificate
-    let (cert, _holder_key) = LatticeCertificate::mint(
+    let cert = LatticeCertificate::mint_with_holder_key(
         permissions,
         args.identity.clone(),
         not_after,
+        None,
         &root_key,
-        &rng,
+        &holder_key,
     );
 
     // Seal into token
@@ -216,11 +246,12 @@ fn mint(args: MintArgs) -> Result<()> {
 
     write_output(&encoded, args.output.as_ref())?;
 
-    // Optionally write the signing key
     if let Some(key_path) = &args.write_key {
-        let pem = pkcs8_to_pem(root_pkcs8.as_ref());
-        std::fs::write(key_path, &pem)
-            .with_context(|| format!("Failed to write key to {}", key_path.display()))?;
+        write_key_pem(key_path, holder_pkcs8.as_ref())?;
+        eprintln!("Holder (delegation) key written to {}", key_path.display());
+    }
+    if let Some(key_path) = &args.write_root_key {
+        write_key_pem(key_path, root_pkcs8.as_ref())?;
         eprintln!("Root signing key written to {}", key_path.display());
     }
 
@@ -250,14 +281,27 @@ fn delegate(args: DelegateArgs) -> Result<()> {
     let not_after = Utc::now() + Duration::hours(args.expires_hours as i64);
     let rng = ring::rand::SystemRandom::new();
 
-    let cert = parent_token.certificate().clone();
-    let (child_cert, _child_key) = cert
-        .delegate(
+    // Generate the child's key OURSELVES so `--write-key` writes the key the
+    // new block actually expects. (Previously a fresh, unrelated key was
+    // written, so the next `delegate` failed with KeyMismatch.)
+    let child_pkcs8 = Ed25519KeyPair::generate_pkcs8(&rng)
+        .map_err(|e| anyhow::anyhow!("Failed to generate child key: {}", e))?;
+    let child_key = Ed25519KeyPair::from_pkcs8(child_pkcs8.as_ref())
+        .map_err(|e| anyhow::anyhow!("Failed to parse generated child key: {}", e))?;
+
+    // `mint_child_*` (not `delegate`): a request for more budget than the
+    // parent has remaining, or against an expired parent lattice, is
+    // REFUSED rather than silently clamped (#2432).
+    let child_cert = parent_token
+        .certificate()
+        .mint_child_with_scope_using_key(
             &child_permissions,
             args.identity.clone(),
             not_after,
+            "nucleus token delegate",
+            SinkScope::unrestricted(),
             &holder_key,
-            &rng,
+            &child_key,
         )
         .map_err(|e| anyhow::anyhow!("Delegation failed: {}", e))?;
 
@@ -269,15 +313,9 @@ fn delegate(args: DelegateArgs) -> Result<()> {
 
     write_output(&encoded, args.output.as_ref())?;
 
-    // Optionally write child key
     if let Some(key_path) = &args.write_key {
-        // Generate a new ephemeral key for the child
-        let child_pkcs8 = Ed25519KeyPair::generate_pkcs8(&rng)
-            .map_err(|e| anyhow::anyhow!("Failed to generate child key: {}", e))?;
-        let pem = pkcs8_to_pem(child_pkcs8.as_ref());
-        std::fs::write(key_path, &pem)
-            .with_context(|| format!("Failed to write key to {}", key_path.display()))?;
-        eprintln!("Child signing key written to {}", key_path.display());
+        write_key_pem(key_path, child_pkcs8.as_ref())?;
+        eprintln!("Child holder key written to {}", key_path.display());
     }
 
     eprintln!(
@@ -423,6 +461,7 @@ mod tests {
             expires_hours: 2,
             output: Some(token_path.clone()),
             write_key: Some(key_path.clone()),
+            write_root_key: None,
         };
 
         mint(args).unwrap();
@@ -453,6 +492,7 @@ mod tests {
             expires_hours: 1,
             output: Some(token_path.clone()),
             write_key: None,
+            write_root_key: None,
         };
 
         mint(args).unwrap();
@@ -481,6 +521,7 @@ mod tests {
             expires_hours: 1,
             output: None,
             write_key: None,
+            write_root_key: None,
         };
 
         assert!(mint(args).is_err());
@@ -498,6 +539,7 @@ mod tests {
             expires_hours: 1,
             output: Some(token_path.clone()),
             write_key: None,
+            write_root_key: None,
         };
         mint(mint_args).unwrap();
 
@@ -517,6 +559,7 @@ mod tests {
             expires_hours: 1,
             output: Some(token_path.clone()),
             write_key: None,
+            write_root_key: None,
         };
         mint(mint_args).unwrap();
 
@@ -559,5 +602,82 @@ mod tests {
             let result = resolve_profile(name);
             assert!(result.is_ok(), "Profile '{}' should resolve", name);
         }
+    }
+}
+
+/// The keys `--write-key` writes must be the keys the chain expects at the
+/// next hop. Before this, `mint` wrote the ROOT signing key (which cannot
+/// delegate) and `delegate` wrote a fresh unrelated key, so no chain longer
+/// than one hop could ever be built with the CLI.
+#[cfg(test)]
+mod chain_tests {
+    use super::*;
+
+    #[test]
+    fn written_keys_extend_the_chain_across_two_hops() {
+        let dir = tempfile::tempdir().unwrap();
+        let root_token = dir.path().join("root.b64");
+        let holder_key = dir.path().join("holder.pem");
+        let root_key = dir.path().join("root.pem");
+        mint(MintArgs {
+            profile: "read-only".into(),
+            identity: "spiffe://test/human/alice".into(),
+            expires_hours: 3,
+            output: Some(root_token.clone()),
+            write_key: Some(holder_key.clone()),
+            write_root_key: Some(root_key.clone()),
+        })
+        .unwrap();
+        assert!(
+            std::fs::read_to_string(&root_key)
+                .unwrap()
+                .contains("BEGIN PRIVATE KEY")
+        );
+
+        let child_token = dir.path().join("child.b64");
+        let child_key = dir.path().join("child.pem");
+        delegate(DelegateArgs {
+            token: root_token.clone(),
+            key: holder_key,
+            identity: "spiffe://test/agent/a".into(),
+            profile: "read-only".into(),
+            expires_hours: 2,
+            output: Some(child_token.clone()),
+            write_key: Some(child_key.clone()),
+        })
+        .unwrap();
+
+        let grandchild_token = dir.path().join("grandchild.b64");
+        delegate(DelegateArgs {
+            token: child_token,
+            key: child_key,
+            identity: "spiffe://test/agent/b".into(),
+            profile: "read-only".into(),
+            expires_hours: 1,
+            output: Some(grandchild_token.clone()),
+            write_key: None,
+        })
+        .unwrap();
+
+        let token = AttenuationToken::from_base64(
+            std::fs::read_to_string(&grandchild_token).unwrap().trim(),
+        )
+        .unwrap();
+        assert_eq!(token.chain_depth(), 2);
+        assert_eq!(token.leaf_identity(), "spiffe://test/agent/b");
+        token.verify_default(Utc::now()).unwrap();
+
+        // The root signing key is the trust anchor, not a holder key: using
+        // it to delegate is a KeyMismatch, not a silent success.
+        let with_root = delegate(DelegateArgs {
+            token: root_token,
+            key: root_key,
+            identity: "spiffe://test/agent/c".into(),
+            profile: "read-only".into(),
+            expires_hours: 1,
+            output: Some(dir.path().join("never.b64")),
+            write_key: None,
+        });
+        assert!(with_root.is_err(), "root signing key must not delegate");
     }
 }

--- a/crates/portcullis/src/budget.rs
+++ b/crates/portcullis/src/budget.rs
@@ -97,8 +97,16 @@ impl BudgetLattice {
     }
 
     /// Check if this lattice is less than or equal to another (partial order).
+    ///
+    /// `consumed_usd` participates with the order REVERSED: more already
+    /// spent means less remaining, i.e. more restrictive, so `self ≤ other`
+    /// requires `self.consumed_usd ≥ other.consumed_usd`. This is the order
+    /// `meet` (max of consumed) and `join` (min of consumed) already used;
+    /// before it was in `leq`, a chain hop could reset `consumed_usd` to zero
+    /// and still pass the certificate's monotone check.
     pub fn leq(&self, other: &Self) -> bool {
         self.max_cost_usd <= other.max_cost_usd
+            && self.consumed_usd >= other.consumed_usd
             && self.max_input_tokens <= other.max_input_tokens
             && self.max_output_tokens <= other.max_output_tokens
     }
@@ -260,6 +268,29 @@ mod tests {
 
         assert!(smaller.leq(&larger));
         assert!(!larger.leq(&smaller));
+    }
+
+    /// A hop that resets `consumed_usd` to zero is an escalation: it grants
+    /// back everything the parent already spent. `leq` must refuse it, and
+    /// `meet`/`join` must stay consistent with that order (glb/lub laws).
+    #[test]
+    fn test_budget_leq_consumed_is_reverse_ordered() {
+        let mut spent = BudgetLattice::with_cost_limit(10.0);
+        spent.charge(Decimal::from(4));
+        let fresh = BudgetLattice::with_cost_limit(10.0);
+
+        assert!(spent.leq(&fresh), "having spent more is more restrictive");
+        assert!(
+            !fresh.leq(&spent),
+            "resetting consumed_usd to zero must not be ≤ the spent parent"
+        );
+
+        let glb = spent.meet(&fresh);
+        assert!(glb.leq(&spent) && glb.leq(&fresh));
+        assert_eq!(glb.consumed_usd, Decimal::from(4));
+        let lub = spent.join(&fresh);
+        assert!(spent.leq(&lub) && fresh.leq(&lub));
+        assert_eq!(lub.consumed_usd, Decimal::ZERO);
     }
 
     #[test]

--- a/crates/portcullis/src/budget_ledger.rs
+++ b/crates/portcullis/src/budget_ledger.rs
@@ -1,0 +1,471 @@
+//! Budget conservation across spawn (#2426, #2445).
+//!
+//! # Why a ledger, not a token field
+//!
+//! A [`LatticeCertificate`](crate::certificate::LatticeCertificate) carries
+//! `budget.max_cost_usd` as an attenuating dimension, and
+//! [`PermissionLattice::delegate_to`](crate::PermissionLattice::delegate_to)
+//! refuses a child that asks for more than the parent has remaining. But
+//! `delegate_to` takes `&self`: it *reads* the parent's remaining budget and
+//! decrements nothing. A parent that spawns N children each within its
+//! remaining budget hands out up to N× that budget. No stateless credential
+//! can conserve a counter — the IETF attenuating-agent-token draft says as
+//! much and pushes quotas to "deployment-specific shared state". That shared
+//! state is this ledger, held by the one enforcement point that actually
+//! creates pods.
+//!
+//! # The invariant
+//!
+//! For a parent with `max` and `consumed` (`consumed ≤ max`):
+//!
+//! ```text
+//!   Σ live child allocations + consumed ≤ max        (at all times)
+//! ```
+//!
+//! [`LedgerCore::try_allocate`] admits a child only while that holds;
+//! [`LedgerCore::release`] retires a child's allocation, folding what the
+//! child actually spent into `consumed` (never more than was allocated) and
+//! refunding the rest. Proven over the shipped type by
+//! `proof_budget_ledger_conserves` / `proof_budget_ledger_release_conserves`
+//! in `kani.rs`.
+//!
+//! # Shape
+//!
+//! [`LedgerCore`] is the proof subject: fixed-slot, integer micro-USD, no
+//! heap. `BTreeMap` is intractable for bounded model checking (the same
+//! reason `CapabilityLattice::extensions` is `cfg(not(kani))`), and
+//! `rust_decimal::Decimal` arithmetic is far more expensive to unroll than
+//! `u64`. [`BudgetLedger`] is the production face: a `Decimal` boundary over
+//! the same core, with rounding chosen so that every conversion errs toward
+//! *less* budget for the child, never more.
+
+use rust_decimal::prelude::ToPrimitive;
+use rust_decimal::Decimal;
+
+use crate::BudgetLattice;
+
+/// Identifier of a child allocation. Callers use `Uuid::as_u128()`.
+pub type ChildId = u128;
+
+/// Slot capacity of the production [`BudgetLedger`]. The node's per-parent
+/// fan-out cap is enforced *before* allocation (via
+/// [`BudgetLedger::live_children`]) and is expected to sit well under this.
+pub const LEDGER_SLOTS: usize = 32;
+
+const MICRO_PER_USD: u64 = 1_000_000;
+
+/// Why an allocation or release was refused.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LedgerError {
+    /// `requested` exceeds what the parent has left after existing
+    /// allocations and its own consumption.
+    InsufficientBudget {
+        /// Micro-USD requested.
+        requested_micro: u64,
+        /// Micro-USD the parent could still allocate.
+        available_micro: u64,
+    },
+    /// Every slot is taken.
+    TooManyChildren {
+        /// Slot capacity.
+        max: usize,
+    },
+    /// A live allocation already exists for this child.
+    DuplicateChild,
+    /// No live allocation exists for this child.
+    UnknownChild,
+    /// A `Decimal` amount was negative or not representable in micro-USD.
+    UnrepresentableAmount,
+}
+
+impl core::fmt::Display for LedgerError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::InsufficientBudget {
+                requested_micro,
+                available_micro,
+            } => write!(
+                f,
+                "budget conservation: requested {requested_micro} µUSD, parent can allocate {available_micro} µUSD"
+            ),
+            Self::TooManyChildren { max } => write!(f, "ledger full ({max} slots)"),
+            Self::DuplicateChild => write!(f, "child already has a live allocation"),
+            Self::UnknownChild => write!(f, "no live allocation for child"),
+            Self::UnrepresentableAmount => write!(f, "amount is negative or not representable"),
+        }
+    }
+}
+
+impl std::error::Error for LedgerError {}
+
+/// The proof subject: a fixed-slot allocation ledger in micro-USD.
+///
+/// Construct with [`LedgerCore::new`]; the invariant
+/// `allocated + consumed ≤ max` is established there (a `consumed > max`
+/// parent is clamped to `max`, so it can allocate nothing) and preserved by
+/// every method.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LedgerCore<const N: usize> {
+    parent_max_micro: u64,
+    parent_consumed_micro: u64,
+    slots: [Option<(ChildId, u64)>; N],
+}
+
+impl<const N: usize> LedgerCore<N> {
+    /// A ledger for a parent with `parent_max_micro` total and
+    /// `parent_consumed_micro` already spent.
+    pub const fn new(parent_max_micro: u64, parent_consumed_micro: u64) -> Self {
+        let consumed = if parent_consumed_micro > parent_max_micro {
+            parent_max_micro
+        } else {
+            parent_consumed_micro
+        };
+        Self {
+            parent_max_micro,
+            parent_consumed_micro: consumed,
+            slots: [None; N],
+        }
+    }
+
+    /// The parent's total budget.
+    pub fn parent_max_micro(&self) -> u64 {
+        self.parent_max_micro
+    }
+
+    /// What the parent itself (plus retired children) has spent.
+    pub fn parent_consumed_micro(&self) -> u64 {
+        self.parent_consumed_micro
+    }
+
+    /// Σ live child allocations.
+    pub fn allocated_micro(&self) -> u64 {
+        let mut total: u64 = 0;
+        let mut i = 0;
+        while i < N {
+            if let Some((_, amount)) = self.slots[i] {
+                total = total.saturating_add(amount);
+            }
+            i += 1;
+        }
+        total
+    }
+
+    /// What the parent could still hand to a new child.
+    pub fn available_micro(&self) -> u64 {
+        self.parent_max_micro
+            .saturating_sub(self.parent_consumed_micro)
+            .saturating_sub(self.allocated_micro())
+    }
+
+    /// Number of live child allocations.
+    pub fn live_children(&self) -> usize {
+        let mut n = 0;
+        let mut i = 0;
+        while i < N {
+            if self.slots[i].is_some() {
+                n += 1;
+            }
+            i += 1;
+        }
+        n
+    }
+
+    /// The live allocation for `child`, if any.
+    pub fn allocation_of(&self, child: ChildId) -> Option<u64> {
+        let mut i = 0;
+        while i < N {
+            if let Some((id, amount)) = self.slots[i] {
+                if id == child {
+                    return Some(amount);
+                }
+            }
+            i += 1;
+        }
+        None
+    }
+
+    /// Reserve `amount_micro` for `child`. Succeeds iff the invariant still
+    /// holds afterwards; on any error nothing changes.
+    pub fn try_allocate(&mut self, child: ChildId, amount_micro: u64) -> Result<(), LedgerError> {
+        if self.allocation_of(child).is_some() {
+            return Err(LedgerError::DuplicateChild);
+        }
+        let available = self.available_micro();
+        if amount_micro > available {
+            return Err(LedgerError::InsufficientBudget {
+                requested_micro: amount_micro,
+                available_micro: available,
+            });
+        }
+        let mut i = 0;
+        while i < N {
+            if self.slots[i].is_none() {
+                self.slots[i] = Some((child, amount_micro));
+                return Ok(());
+            }
+            i += 1;
+        }
+        Err(LedgerError::TooManyChildren { max: N })
+    }
+
+    /// Retire `child`'s allocation. `consumed_micro` is what the child
+    /// actually spent; it is folded into the parent's consumption capped at
+    /// the allocation (a child cannot have spent what it was never given).
+    /// Returns the refunded remainder.
+    pub fn release(&mut self, child: ChildId, consumed_micro: u64) -> Result<u64, LedgerError> {
+        let mut i = 0;
+        while i < N {
+            if let Some((id, amount)) = self.slots[i] {
+                if id == child {
+                    let spent = if consumed_micro > amount {
+                        amount
+                    } else {
+                        consumed_micro
+                    };
+                    self.slots[i] = None;
+                    self.parent_consumed_micro = self.parent_consumed_micro.saturating_add(spent);
+                    return Ok(amount - spent);
+                }
+            }
+            i += 1;
+        }
+        Err(LedgerError::UnknownChild)
+    }
+
+    /// Record the parent's OWN spending (not a child's). Clamped so the
+    /// invariant holds: a parent cannot record more than it could have spent
+    /// after what it has already handed to children.
+    pub fn record_parent_consumed(&mut self, micro: u64) -> u64 {
+        let ceiling = self.parent_max_micro.saturating_sub(self.allocated_micro());
+        let new_total = self.parent_consumed_micro.saturating_add(micro);
+        self.parent_consumed_micro = if new_total > ceiling {
+            ceiling
+        } else {
+            new_total
+        };
+        self.parent_consumed_micro
+    }
+
+    /// The invariant, as a predicate (used by the Kani harnesses and tests).
+    pub fn conserves(&self) -> bool {
+        self.allocated_micro()
+            .saturating_add(self.parent_consumed_micro)
+            <= self.parent_max_micro
+    }
+}
+
+/// Production face of [`LedgerCore`]: `Decimal` USD in, `Decimal` USD out.
+///
+/// Rounding is deliberately asymmetric so every conversion errs against the
+/// child: the parent's `max` rounds DOWN, a child's requested amount rounds
+/// UP, and a child's reported consumption rounds UP.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BudgetLedger {
+    core: LedgerCore<LEDGER_SLOTS>,
+}
+
+impl BudgetLedger {
+    /// A ledger for a parent whose authority carries `budget`.
+    pub fn for_parent(budget: &BudgetLattice) -> Self {
+        let max = usd_to_micro_floor(budget.max_cost_usd).unwrap_or(0);
+        let consumed = usd_to_micro_ceil(budget.consumed_usd).unwrap_or(u64::MAX);
+        Self {
+            core: LedgerCore::new(max, consumed),
+        }
+    }
+
+    /// The underlying proof subject.
+    pub fn core(&self) -> &LedgerCore<LEDGER_SLOTS> {
+        &self.core
+    }
+
+    /// See [`LedgerCore::try_allocate`].
+    pub fn try_allocate(&mut self, child: ChildId, amount_usd: Decimal) -> Result<(), LedgerError> {
+        let micro = usd_to_micro_ceil(amount_usd).ok_or(LedgerError::UnrepresentableAmount)?;
+        self.core.try_allocate(child, micro)
+    }
+
+    /// See [`LedgerCore::release`]. Returns the refunded USD.
+    pub fn release(
+        &mut self,
+        child: ChildId,
+        consumed_usd: Decimal,
+    ) -> Result<Decimal, LedgerError> {
+        let micro = usd_to_micro_ceil(consumed_usd).ok_or(LedgerError::UnrepresentableAmount)?;
+        self.core.release(child, micro).map(micro_to_usd)
+    }
+
+    /// See [`LedgerCore::record_parent_consumed`].
+    pub fn record_parent_consumed(&mut self, usd: Decimal) -> Result<Decimal, LedgerError> {
+        let micro = usd_to_micro_ceil(usd).ok_or(LedgerError::UnrepresentableAmount)?;
+        Ok(micro_to_usd(self.core.record_parent_consumed(micro)))
+    }
+
+    /// USD the parent could still hand to a new child.
+    pub fn available(&self) -> Decimal {
+        micro_to_usd(self.core.available_micro())
+    }
+
+    /// Σ live child allocations, in USD.
+    pub fn allocated(&self) -> Decimal {
+        micro_to_usd(self.core.allocated_micro())
+    }
+
+    /// Number of live child allocations.
+    pub fn live_children(&self) -> usize {
+        self.core.live_children()
+    }
+
+    /// The live allocation for `child`, in USD.
+    pub fn allocation_of(&self, child: ChildId) -> Option<Decimal> {
+        self.core.allocation_of(child).map(micro_to_usd)
+    }
+}
+
+fn usd_to_micro_floor(usd: Decimal) -> Option<u64> {
+    if usd.is_sign_negative() {
+        return None;
+    }
+    (usd * Decimal::from(MICRO_PER_USD)).floor().to_u64()
+}
+
+fn usd_to_micro_ceil(usd: Decimal) -> Option<u64> {
+    if usd.is_sign_negative() {
+        return None;
+    }
+    (usd * Decimal::from(MICRO_PER_USD)).ceil().to_u64()
+}
+
+fn micro_to_usd(micro: u64) -> Decimal {
+    Decimal::from(micro) / Decimal::from(MICRO_PER_USD)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    fn usd(s: &str) -> Decimal {
+        Decimal::from_str(s).unwrap()
+    }
+
+    /// The defect this module exists to close: a parent with $5 remaining
+    /// could previously hand $5 to each of N children. With the ledger the
+    /// second such child is refused.
+    #[test]
+    fn fan_out_cannot_multiply_the_parent_budget() {
+        let parent = BudgetLattice::with_cost_limit(5.0);
+        let mut ledger = BudgetLedger::for_parent(&parent);
+
+        ledger.try_allocate(1, usd("5")).expect("first child fits");
+        let second = ledger.try_allocate(2, usd("5"));
+        assert!(
+            matches!(second, Err(LedgerError::InsufficientBudget { .. })),
+            "second full-budget child must be refused, got {second:?}"
+        );
+        assert_eq!(ledger.available(), Decimal::ZERO);
+        assert!(ledger.core().conserves());
+
+        // Non-vacuity: the lattice-level check alone still admits the
+        // second child, because `delegate_to` reads and never decrements.
+        let mut request = crate::PermissionLattice::permissive();
+        request.budget = BudgetLattice::with_cost_limit(5.0);
+        let mut parent_perms = crate::PermissionLattice::permissive();
+        parent_perms.budget = parent.clone();
+        assert!(parent_perms.delegate_to(&request, "first").is_ok());
+        assert!(
+            parent_perms.delegate_to(&request, "second").is_ok(),
+            "the pre-existing gap: delegate_to alone admits both — otherwise this test \
+             no longer demonstrates what the ledger adds"
+        );
+    }
+
+    #[test]
+    fn allocations_split_the_parent_and_release_refunds_the_unspent_part() {
+        let mut ledger = BudgetLedger::for_parent(&BudgetLattice::with_cost_limit(10.0));
+        ledger.try_allocate(1, usd("4")).unwrap();
+        ledger.try_allocate(2, usd("6")).unwrap();
+        assert_eq!(ledger.live_children(), 2);
+        assert_eq!(ledger.available(), Decimal::ZERO);
+
+        // Child 1 spent $1 of its $4: $3 comes back, $1 is now the parent's consumption.
+        let refund = ledger.release(1, usd("1")).unwrap();
+        assert_eq!(refund, usd("3"));
+        assert_eq!(ledger.available(), usd("3"));
+        assert_eq!(ledger.core().parent_consumed_micro(), 1_000_000);
+        assert!(ledger.core().conserves());
+
+        // A child cannot report having spent more than it was given.
+        let refund = ledger.release(2, usd("100")).unwrap();
+        assert_eq!(refund, Decimal::ZERO);
+        assert_eq!(ledger.core().parent_consumed_micro(), 7_000_000);
+        assert!(ledger.core().conserves());
+    }
+
+    #[test]
+    fn errors_leave_the_ledger_unchanged() {
+        let mut ledger = BudgetLedger::for_parent(&BudgetLattice::with_cost_limit(1.0));
+        ledger.try_allocate(7, usd("0.5")).unwrap();
+        let before = ledger.clone();
+
+        assert_eq!(
+            ledger.try_allocate(7, usd("0.1")),
+            Err(LedgerError::DuplicateChild)
+        );
+        assert!(matches!(
+            ledger.try_allocate(8, usd("0.6")),
+            Err(LedgerError::InsufficientBudget { .. })
+        ));
+        assert_eq!(ledger.release(9, usd("0")), Err(LedgerError::UnknownChild));
+        assert_eq!(
+            ledger.try_allocate(8, usd("-1")),
+            Err(LedgerError::UnrepresentableAmount)
+        );
+        assert_eq!(ledger, before);
+    }
+
+    #[test]
+    fn a_full_ledger_refuses_rather_than_overwrites() {
+        let mut core = LedgerCore::<2>::new(100, 0);
+        core.try_allocate(1, 10).unwrap();
+        core.try_allocate(2, 10).unwrap();
+        assert_eq!(
+            core.try_allocate(3, 10),
+            Err(LedgerError::TooManyChildren { max: 2 })
+        );
+        assert_eq!(core.allocated_micro(), 20);
+    }
+
+    #[test]
+    fn rounding_errs_against_the_child() {
+        // Parent max rounds DOWN; child request rounds UP.
+        let mut budget = BudgetLattice::with_cost_limit_decimal(usd("1.0000004"));
+        budget.consumed_usd = Decimal::ZERO;
+        let mut ledger = BudgetLedger::for_parent(&budget);
+        assert_eq!(ledger.core().parent_max_micro(), 1_000_000);
+        assert!(matches!(
+            ledger.try_allocate(1, usd("1.0000001")),
+            Err(LedgerError::InsufficientBudget { .. })
+        ));
+        ledger.try_allocate(1, usd("1")).unwrap();
+    }
+
+    #[test]
+    fn an_overspent_parent_can_allocate_nothing() {
+        let mut budget = BudgetLattice::with_cost_limit(1.0);
+        budget.consumed_usd = usd("3");
+        let mut ledger = BudgetLedger::for_parent(&budget);
+        assert_eq!(ledger.available(), Decimal::ZERO);
+        assert!(ledger.core().conserves());
+        assert!(ledger.try_allocate(1, usd("0.000001")).is_err());
+    }
+
+    #[test]
+    fn parent_consumption_is_clamped_by_live_allocations() {
+        let mut core = LedgerCore::<4>::new(10, 0);
+        core.try_allocate(1, 6).unwrap();
+        // Parent tries to record $8 of its own spend with only $4 left to it.
+        assert_eq!(core.record_parent_consumed(8), 4);
+        assert!(core.conserves());
+    }
+}

--- a/crates/portcullis/src/certificate.rs
+++ b/crates/portcullis/src/certificate.rs
@@ -88,7 +88,7 @@ use chrono::{DateTime, Utc};
 #[cfg(feature = "crypto")]
 use ring::rand::SecureRandom;
 #[cfg(feature = "crypto")]
-use ring::signature::{self, Ed25519KeyPair, KeyPair};
+use ring::signature::{Ed25519KeyPair, KeyPair};
 use sha2::{Digest, Sha256};
 use std::fmt;
 
@@ -124,6 +124,16 @@ pub struct AuthorityBlock {
     pub signature: Vec<u8>,
     /// Public key for verifying the next block (or proof-of-possession if no delegations).
     pub next_key: Vec<u8>,
+    /// Fingerprint of the certificate this authority was *re-rooted* from.
+    ///
+    /// When an issuer mints a fresh root on behalf of a caller who proved its
+    /// own chain (the caller's leaf identity becomes this block's
+    /// `root_identity`, and `root_permissions` is the caller's effective
+    /// lattice narrowed by the request), this records which chain that was —
+    /// token-exchange semantics, the `act` claim of RFC 8693. `None` for a
+    /// genuine root. Signature-covered via [`signing_payload`](Self::signing_payload).
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub provenance: Option<[u8; 32]>,
 }
 
 /// A delegation block recording one hop in the permission chain.
@@ -491,7 +501,16 @@ fn subset_check(parent: &[String], child: &[String]) -> bool {
 pub fn canonical_permissions_hash(perms: &PermissionLattice) -> Vec<u8> {
     let mut hasher = Sha256::new();
 
-    // Capabilities (12 dimensions, each as u8)
+    // Capabilities (13 named dimensions, each as u8, then the extension map).
+    //
+    // `spawn_agent` and `extensions` were outside this digest until the
+    // certificate convergence work: they rode inside the signed *struct* but
+    // outside the signed *bytes*, so anyone who could edit the serialized JSON
+    // could raise them on every block without invalidating a single Ed25519
+    // signature — and `verify_certificate`'s monotone check compared the same
+    // tampered values. `spawn_agent` is precisely the dimension that gates
+    // sub-pod creation, so that hole sat on the authority this certificate
+    // exists to attest. Pinned by `spawn_agent_is_signature_covered`.
     hasher.update([perms.capabilities.read_files as u8]);
     hasher.update([perms.capabilities.write_files as u8]);
     hasher.update([perms.capabilities.edit_files as u8]);
@@ -504,6 +523,17 @@ pub fn canonical_permissions_hash(perms: &PermissionLattice) -> Vec<u8> {
     hasher.update([perms.capabilities.git_push as u8]);
     hasher.update([perms.capabilities.create_pr as u8]);
     hasher.update([perms.capabilities.manage_pods as u8]);
+    hasher.update([perms.capabilities.spawn_agent as u8]);
+    #[cfg(not(kani))]
+    {
+        // BTreeMap iterates in key order, so this is deterministic.
+        hasher.update((perms.capabilities.extensions.len() as u32).to_le_bytes());
+        for (op, level) in &perms.capabilities.extensions {
+            hasher.update(op.0.as_bytes());
+            hasher.update([0]);
+            hasher.update([*level as u8]);
+        }
+    }
 
     // Obligations (sorted set of operation indices for determinism)
     let mut ops: Vec<u8> = perms
@@ -538,8 +568,13 @@ pub fn canonical_permissions_hash(perms: &PermissionLattice) -> Vec<u8> {
         hasher.update([0]);
     }
 
-    // Budget
+    // Budget. `consumed_usd` is signature-covered too: a chain hop that
+    // carries budget forward carries what has already been spent against
+    // it, and an unsigned `consumed_usd` would let a holder reset it to zero.
     hasher.update(perms.budget.max_cost_usd.to_string().as_bytes());
+    hasher.update([0]);
+    hasher.update(perms.budget.consumed_usd.to_string().as_bytes());
+    hasher.update([0]);
     hasher.update(perms.budget.max_input_tokens.to_le_bytes());
     hasher.update(perms.budget.max_output_tokens.to_le_bytes());
 
@@ -572,14 +607,24 @@ pub fn canonical_permissions_hash(perms: &PermissionLattice) -> Vec<u8> {
 impl AuthorityBlock {
     /// Compute the canonical payload for signing.
     #[cfg(feature = "crypto")]
-    fn signing_payload(&self) -> Vec<u8> {
+    pub(crate) fn signing_payload(&self) -> Vec<u8> {
         let mut payload = Vec::new();
-        payload.extend_from_slice(b"lattice-cert-authority-v1:");
+        // v2: canonical hash now covers spawn_agent/extensions/consumed_usd,
+        // and the payload carries `provenance`. Tokens issued under v1 do not
+        // verify — none exist outside this tree.
+        payload.extend_from_slice(b"lattice-cert-authority-v2:");
         payload.extend_from_slice(self.root_identity.as_bytes());
         payload.push(0); // separator
         payload.extend_from_slice(&self.not_after.timestamp().to_le_bytes());
         payload.extend_from_slice(&canonical_permissions_hash(&self.root_permissions));
         payload.extend_from_slice(&self.next_key);
+        match self.provenance {
+            Some(fp) => {
+                payload.push(1);
+                payload.extend_from_slice(&fp);
+            }
+            None => payload.push(0),
+        }
         payload
     }
 
@@ -596,9 +641,10 @@ impl AuthorityBlock {
 impl DelegationBlock {
     /// Compute the canonical payload for signing.
     #[cfg(feature = "crypto")]
-    fn signing_payload(&self) -> Vec<u8> {
+    pub(crate) fn signing_payload(&self) -> Vec<u8> {
         let mut payload = Vec::new();
-        payload.extend_from_slice(b"lattice-cert-delegation-v2:");
+        // v3: canonical hash now covers spawn_agent/extensions/consumed_usd.
+        payload.extend_from_slice(b"lattice-cert-delegation-v3:");
         payload.extend_from_slice(self.from_identity.as_bytes());
         payload.push(0);
         payload.extend_from_slice(self.to_identity.as_bytes());
@@ -669,6 +715,39 @@ impl LatticeCertificate {
         let holder_key =
             Ed25519KeyPair::from_pkcs8(holder_pkcs8.as_ref()).expect("Ed25519 key parse failed");
 
+        let cert = Self::mint_with_holder_key(
+            root_permissions,
+            root_identity,
+            not_after,
+            None,
+            signing_key,
+            &holder_key,
+        );
+
+        (cert, holder_key)
+    }
+
+    /// Mint a root authority certificate whose holder key the CALLER owns.
+    ///
+    /// [`Self::mint`] generates the holder key internally and hands back only
+    /// the `ring` keypair, which cannot export its seed — so nothing minted
+    /// that way can persist its holder key across a restart or hand it to
+    /// another process. An issuer that must keep `(certificate, holder key)`
+    /// per pod (the node's per-pod authority registry) generates the PKCS#8
+    /// document itself, keeps it, and mints through this constructor.
+    ///
+    /// `provenance` records the fingerprint of the chain this root was
+    /// re-rooted from (see [`AuthorityBlock::provenance`]); pass `None` for a
+    /// genuine root.
+    #[cfg(feature = "crypto")]
+    pub fn mint_with_holder_key(
+        root_permissions: PermissionLattice,
+        root_identity: String,
+        not_after: DateTime<Utc>,
+        provenance: Option<[u8; 32]>,
+        signing_key: &Ed25519KeyPair,
+        holder_key: &Ed25519KeyPair,
+    ) -> Self {
         let next_key = holder_key.public_key().as_ref().to_vec();
 
         // Build authority block (without signature initially)
@@ -678,6 +757,7 @@ impl LatticeCertificate {
             not_after,
             signature: Vec::new(),
             next_key,
+            provenance,
         };
 
         // Sign the canonical payload
@@ -688,13 +768,11 @@ impl LatticeCertificate {
         let pop_payload = Self::pop_payload_for_block_hash(&authority.block_hash());
         let final_signature = holder_key.sign(&pop_payload).as_ref().to_vec();
 
-        let cert = Self {
+        Self {
             authority,
             blocks: Vec::new(),
             final_signature,
-        };
-
-        (cert, holder_key)
+        }
     }
 
     /// Delegate permissions to a sub-agent, producing a new certificate.
@@ -747,6 +825,42 @@ impl LatticeCertificate {
         current_holder_key: &Ed25519KeyPair,
         rng: &dyn SecureRandom,
     ) -> Result<(Self, Ed25519KeyPair), CertificateDelegationError> {
+        // Generate ephemeral key pair for the delegatee
+        let delegatee_pkcs8 = Ed25519KeyPair::generate_pkcs8(rng)
+            .map_err(|_| CertificateDelegationError::KeyGenerationFailed)?;
+        let delegatee_key = Ed25519KeyPair::from_pkcs8(delegatee_pkcs8.as_ref())
+            .map_err(|_| CertificateDelegationError::KeyGenerationFailed)?;
+
+        let cert = self.delegate_with_scope_using_key(
+            requested,
+            to_identity,
+            not_after,
+            sink_scope,
+            current_holder_key,
+            &delegatee_key,
+        )?;
+        Ok((cert, delegatee_key))
+    }
+
+    /// [`Self::delegate_with_scope`] where the CALLER owns the delegatee's
+    /// holder key.
+    ///
+    /// The `rng` variants generate the delegatee key internally and return
+    /// only the `ring` keypair, which cannot export its seed — so the caller
+    /// can never persist it. An issuer that has to keep the delegatee's key
+    /// (to delegate again on that holder's behalf later, after a restart)
+    /// generates the PKCS#8 document itself, keeps it, and delegates through
+    /// this variant with the parsed keypair.
+    #[cfg(feature = "crypto")]
+    pub fn delegate_with_scope_using_key(
+        &self,
+        requested: &PermissionLattice,
+        to_identity: String,
+        not_after: DateTime<Utc>,
+        sink_scope: SinkScope,
+        current_holder_key: &Ed25519KeyPair,
+        delegatee_key: &Ed25519KeyPair,
+    ) -> Result<Self, CertificateDelegationError> {
         // Check chain depth
         if self.blocks.len() >= DEFAULT_MAX_CHAIN_DEPTH {
             return Err(CertificateDelegationError::ChainTooDeep {
@@ -805,12 +919,6 @@ impl LatticeCertificate {
             self.blocks.last().unwrap().to_identity.clone()
         };
 
-        // Generate ephemeral key pair for the delegatee
-        let delegatee_pkcs8 = Ed25519KeyPair::generate_pkcs8(rng)
-            .map_err(|_| CertificateDelegationError::KeyGenerationFailed)?;
-        let delegatee_key = Ed25519KeyPair::from_pkcs8(delegatee_pkcs8.as_ref())
-            .map_err(|_| CertificateDelegationError::KeyGenerationFailed)?;
-
         let next_key = delegatee_key.public_key().as_ref().to_vec();
 
         // Build delegation block
@@ -839,13 +947,11 @@ impl LatticeCertificate {
         let pop_payload = Self::pop_payload_for_block_hash(&last_hash);
         let final_signature = delegatee_key.sign(&pop_payload).as_ref().to_vec();
 
-        let cert = Self {
+        Ok(Self {
             authority: self.authority.clone(),
             blocks: new_blocks,
             final_signature,
-        };
-
-        Ok((cert, delegatee_key))
+        })
     }
 
     /// Mint a child certificate, validated at BOTH layers: the lattice's own
@@ -893,15 +999,72 @@ impl LatticeCertificate {
         current_holder_key: &Ed25519KeyPair,
         rng: &dyn SecureRandom,
     ) -> Result<(Self, Ed25519KeyPair), CertificateMintChildError> {
-        self.effective_permissions()
-            .delegate_to(requested, reason)
-            .map_err(CertificateMintChildError::Lattice)?;
-        self.delegate(
+        self.mint_child_with_scope(
             requested,
             child_identity,
             not_after,
+            reason,
+            SinkScope::unrestricted(),
             current_holder_key,
             rng,
+        )
+    }
+
+    /// [`Self::mint_child`] with an explicit sink scope (the child's scope
+    /// must be ⊆ the parent's, exactly as in [`Self::delegate_with_scope`]).
+    #[cfg(feature = "crypto")]
+    #[allow(clippy::too_many_arguments)]
+    pub fn mint_child_with_scope(
+        &self,
+        requested: &PermissionLattice,
+        child_identity: String,
+        not_after: DateTime<Utc>,
+        reason: &str,
+        sink_scope: SinkScope,
+        current_holder_key: &Ed25519KeyPair,
+        rng: &dyn SecureRandom,
+    ) -> Result<(Self, Ed25519KeyPair), CertificateMintChildError> {
+        self.effective_permissions()
+            .delegate_to(requested, reason)
+            .map_err(CertificateMintChildError::Lattice)?;
+        self.delegate_with_scope(
+            requested,
+            child_identity,
+            not_after,
+            sink_scope,
+            current_holder_key,
+            rng,
+        )
+        .map_err(CertificateMintChildError::Chain)
+    }
+
+    /// [`Self::mint_child_with_scope`] where the CALLER owns the child's
+    /// holder key — the issuer-side constructor, for the same reason as
+    /// [`Self::mint_with_holder_key`]: `ring` keypairs cannot export their
+    /// seed, so an issuer that must persist the child's holder key generates
+    /// the PKCS#8 document itself and passes the parsed keypair in.
+    #[cfg(feature = "crypto")]
+    #[allow(clippy::too_many_arguments)]
+    pub fn mint_child_with_scope_using_key(
+        &self,
+        requested: &PermissionLattice,
+        child_identity: String,
+        not_after: DateTime<Utc>,
+        reason: &str,
+        sink_scope: SinkScope,
+        current_holder_key: &Ed25519KeyPair,
+        child_key: &Ed25519KeyPair,
+    ) -> Result<Self, CertificateMintChildError> {
+        self.effective_permissions()
+            .delegate_to(requested, reason)
+            .map_err(CertificateMintChildError::Lattice)?;
+        self.delegate_with_scope_using_key(
+            requested,
+            child_identity,
+            not_after,
+            sink_scope,
+            current_holder_key,
+            child_key,
         )
         .map_err(CertificateMintChildError::Chain)
     }
@@ -982,13 +1145,20 @@ impl LatticeCertificate {
         let mut hasher = Sha256::new();
 
         // Domain separation to prevent cross-protocol confusion
-        hasher.update(b"lattice-cert-fingerprint-v1:");
+        hasher.update(b"lattice-cert-fingerprint-v2:");
 
         // Authority block
         hasher.update(self.authority.root_identity.as_bytes());
         hasher.update([0]); // separator
         hasher.update(self.authority.not_after.timestamp().to_le_bytes());
         hasher.update(canonical_permissions_hash(&self.authority.root_permissions));
+        match self.authority.provenance {
+            Some(fp) => {
+                hasher.update([1]);
+                hasher.update(fp);
+            }
+            None => hasher.update([0]),
+        }
         hasher.update(&self.authority.signature);
 
         // Delegation blocks
@@ -1017,6 +1187,21 @@ impl LatticeCertificate {
 // ═══════════════════════════════════════════════════════════════════════════
 // VERIFICATION — THE REFERENCE MONITOR
 // ═══════════════════════════════════════════════════════════════════════════
+
+/// Ed25519 verify on the strict (RFC 8032, `s < ℓ`, no small-order keys)
+/// semantics — `ed25519_dalek::verify_strict`, NOT `ring`'s cofactored
+/// verify. Ring's verify accepts the small-order identity-key forgery (see
+/// `small_order_root_key_forgery_rejected`), and this chain is the credential
+/// the runtime's authority rests on. Unifies the cert chain with the rest of
+/// the attest stack (`token_sign`, `receipt_sign`) and removes `ring` from the
+/// verify TCB (SECURITY_TODO #16). Signing stays on `ring`.
+#[cfg(feature = "crypto")]
+fn verify_ed25519_strict(public_key: &[u8], message: &[u8], sig: &[u8]) -> Result<(), ()> {
+    let vk_bytes: [u8; 32] = public_key.try_into().map_err(|_| ())?;
+    let vk = ed25519_dalek::VerifyingKey::from_bytes(&vk_bytes).map_err(|_| ())?;
+    let sig = ed25519_dalek::Signature::from_slice(sig).map_err(|_| ())?;
+    vk.verify_strict(message, &sig).map_err(|_| ())
+}
 
 /// Verify an attested delegation certificate.
 ///
@@ -1059,10 +1244,12 @@ pub fn verify_certificate(
 
     // 2. Verify authority block signature
     let authority_payload = cert.authority.signing_payload();
-    let root_verifier = signature::UnparsedPublicKey::new(&signature::ED25519, root_public_key);
-    root_verifier
-        .verify(&authority_payload, &cert.authority.signature)
-        .map_err(|_| CertificateError::InvalidSignature { block_index: 0 })?;
+    verify_ed25519_strict(
+        root_public_key,
+        &authority_payload,
+        &cert.authority.signature,
+    )
+    .map_err(|_| CertificateError::InvalidSignature { block_index: 0 })?;
 
     // 3. Check authority expiry
     if now > cert.authority.not_after {
@@ -1083,11 +1270,8 @@ pub fn verify_certificate(
         }
 
         // 4b. Verify Ed25519 signature
-        let verifier_key =
-            signature::UnparsedPublicKey::new(&signature::ED25519, prev_next_key.as_slice());
         let block_payload = block.signing_payload();
-        verifier_key
-            .verify(&block_payload, &block.signature)
+        verify_ed25519_strict(prev_next_key, &block_payload, &block.signature)
             .map_err(|_| CertificateError::InvalidSignature { block_index })?;
 
         // 4c. Verify monotone attenuation
@@ -1118,10 +1302,7 @@ pub fn verify_certificate(
 
     // 5. Verify proof-of-possession
     let pop_payload = LatticeCertificate::pop_payload_for_block_hash(&prev_hash);
-    let final_verifier =
-        signature::UnparsedPublicKey::new(&signature::ED25519, prev_next_key.as_slice());
-    final_verifier
-        .verify(&pop_payload, &cert.final_signature)
+    verify_ed25519_strict(prev_next_key, &pop_payload, &cert.final_signature)
         .map_err(|_| CertificateError::InvalidProofOfPossession)?;
 
     // 6. Return sealed verified permissions

--- a/crates/portcullis/src/certificate_convergence_tests.rs
+++ b/crates/portcullis/src/certificate_convergence_tests.rs
@@ -1,0 +1,324 @@
+//! Certificate-convergence tests: signature coverage of every attenuating
+//! dimension, strict Ed25519 verification, and the caller-owned-key
+//! constructors an issuer needs to persist per-pod authority.
+//!
+//! Lives beside `certificate.rs` (like `kernel_tests.rs`) rather than inside
+//! it so the module stays under the line ratchet; it uses the same
+//! `pub(crate)` test-only accessors.
+
+use crate::certificate::*;
+use crate::{CapabilityLevel, PermissionLattice};
+use chrono::{Duration, Utc};
+use ring::rand::{SecureRandom, SystemRandom};
+use ring::signature::{Ed25519KeyPair, KeyPair};
+
+fn generate_key(rng: &dyn SecureRandom) -> Ed25519KeyPair {
+    let pkcs8 = Ed25519KeyPair::generate_pkcs8(rng).unwrap();
+    Ed25519KeyPair::from_pkcs8(pkcs8.as_ref()).unwrap()
+}
+
+fn minted() -> (LatticeCertificate, Ed25519KeyPair, Vec<u8>, SystemRandom) {
+    let rng = SystemRandom::new();
+    let root_key = generate_key(&rng);
+    let root_pub = root_key.public_key().as_ref().to_vec();
+    let mut perms = PermissionLattice::restrictive();
+    perms.capabilities.spawn_agent = CapabilityLevel::Never;
+    perms.budget.max_cost_usd = rust_decimal::Decimal::from(5);
+    let (cert, holder) = LatticeCertificate::mint(
+        perms,
+        "spiffe://test/human/alice".into(),
+        Utc::now() + Duration::hours(8),
+        &root_key,
+        &rng,
+    );
+    (cert, holder, root_pub, rng)
+}
+
+/// The signature-coverage hole: `spawn_agent` was inside the signed struct
+/// but outside the signed bytes, so raising it on the serialized
+/// certificate invalidated nothing. It is exactly the dimension that gates
+/// sub-pod creation.
+#[test]
+fn spawn_agent_is_signature_covered() {
+    let (mut cert, _holder, root_pub, _rng) = minted();
+    assert!(verify_certificate(&cert, &root_pub, Utc::now(), DEFAULT_MAX_CHAIN_DEPTH).is_ok());
+
+    cert.authority_mut()
+        .root_permissions
+        .capabilities
+        .spawn_agent = CapabilityLevel::Always;
+    let result = verify_certificate(&cert, &root_pub, Utc::now(), DEFAULT_MAX_CHAIN_DEPTH);
+    assert!(
+        matches!(
+            result,
+            Err(CertificateError::InvalidSignature { block_index: 0 })
+        ),
+        "raising spawn_agent must break the authority signature, got {result:?}"
+    );
+}
+
+#[test]
+fn extension_capabilities_are_signature_covered() {
+    let (mut cert, _holder, root_pub, _rng) = minted();
+    cert.authority_mut()
+        .root_permissions
+        .capabilities
+        .extensions
+        .insert(
+            crate::capability::ExtensionOperation::new("deploy"),
+            CapabilityLevel::Always,
+        );
+    assert!(matches!(
+        verify_certificate(&cert, &root_pub, Utc::now(), DEFAULT_MAX_CHAIN_DEPTH),
+        Err(CertificateError::InvalidSignature { block_index: 0 })
+    ));
+}
+
+/// Resetting `consumed_usd` grants back everything already spent.
+#[test]
+fn consumed_usd_is_signature_covered_and_monotone() {
+    let (cert, holder, root_pub, rng) = minted();
+    let mut spent = cert.effective_permissions().clone();
+    spent.budget.charge(rust_decimal::Decimal::from(2));
+    let (mut child, _k) = cert
+        .delegate(
+            &spent,
+            "spiffe://test/agent/a".into(),
+            Utc::now() + Duration::hours(1),
+            &holder,
+            &rng,
+        )
+        .unwrap();
+    assert!(verify_certificate(&child, &root_pub, Utc::now(), DEFAULT_MAX_CHAIN_DEPTH).is_ok());
+
+    // Tamper: pretend nothing was spent. Signature breaks first.
+    child.blocks_mut()[0]
+        .effective_permissions
+        .budget
+        .consumed_usd = rust_decimal::Decimal::ZERO;
+    assert!(matches!(
+        verify_certificate(&child, &root_pub, Utc::now(), DEFAULT_MAX_CHAIN_DEPTH),
+        Err(CertificateError::InvalidSignature { block_index: 1 })
+    ));
+
+    // And independently of the signature, the lattice order refuses it.
+    let mut reset = spent.clone();
+    reset.budget.consumed_usd = rust_decimal::Decimal::ZERO;
+    assert!(!reset.leq(&spent), "a consumed_usd reset is an escalation");
+}
+
+#[test]
+fn provenance_is_signature_covered_and_fingerprinted() {
+    let rng = SystemRandom::new();
+    let root_key = generate_key(&rng);
+    let root_pub = root_key.public_key().as_ref().to_vec();
+    let holder = generate_key(&rng);
+    let fp = [7u8; 32];
+    let cert = LatticeCertificate::mint_with_holder_key(
+        PermissionLattice::restrictive(),
+        "spiffe://test/agent/rerooted".into(),
+        Utc::now() + Duration::hours(1),
+        Some(fp),
+        &root_key,
+        &holder,
+    );
+    assert_eq!(cert.authority().provenance, Some(fp));
+    assert!(verify_certificate(&cert, &root_pub, Utc::now(), DEFAULT_MAX_CHAIN_DEPTH).is_ok());
+    let fingerprint_with = cert.fingerprint();
+
+    let mut stripped = cert.clone();
+    stripped.authority_mut().provenance = None;
+    assert!(matches!(
+        verify_certificate(&stripped, &root_pub, Utc::now(), DEFAULT_MAX_CHAIN_DEPTH),
+        Err(CertificateError::InvalidSignature { block_index: 0 })
+    ));
+    assert_ne!(stripped.fingerprint(), fingerprint_with);
+}
+
+/// The point of the caller-owned-key constructors: a key the issuer
+/// generated itself (and can therefore persist) is the key the chain
+/// expects at the next hop.
+#[test]
+fn issuer_owned_keys_delegate_across_hops() {
+    let rng = SystemRandom::new();
+    let root_key = generate_key(&rng);
+    let root_pub = root_key.public_key().as_ref().to_vec();
+
+    let holder_pkcs8 = Ed25519KeyPair::generate_pkcs8(&rng).unwrap();
+    let holder = Ed25519KeyPair::from_pkcs8(holder_pkcs8.as_ref()).unwrap();
+    let cert = LatticeCertificate::mint_with_holder_key(
+        PermissionLattice::permissive(),
+        "spiffe://test/root".into(),
+        Utc::now() + Duration::hours(8),
+        None,
+        &root_key,
+        &holder,
+    );
+
+    // "Restart": re-parse the persisted document and delegate with it.
+    let holder_again = Ed25519KeyPair::from_pkcs8(holder_pkcs8.as_ref()).unwrap();
+    let child_pkcs8 = Ed25519KeyPair::generate_pkcs8(&rng).unwrap();
+    let child_key = Ed25519KeyPair::from_pkcs8(child_pkcs8.as_ref()).unwrap();
+    // One expiry for every hop: a second `Utc::now()` is already later and
+    // `delegate_with_scope` checks expiry before anything else of interest.
+    let hop_expiry = Utc::now() + Duration::hours(1);
+    let child = cert
+        .mint_child_with_scope_using_key(
+            &PermissionLattice::restrictive(),
+            "spiffe://test/pod/1".into(),
+            hop_expiry,
+            "spawn",
+            SinkScope::unrestricted(),
+            &holder_again,
+            &child_key,
+        )
+        .expect("persisted holder key must match next_key");
+    assert_eq!(
+        child.delegation_blocks()[0].next_key,
+        child_key.public_key().as_ref()
+    );
+
+    let grandchild_key = generate_key(&rng);
+    let grandchild = child
+        .mint_child_with_scope_using_key(
+            &PermissionLattice::restrictive(),
+            "spiffe://test/pod/2".into(),
+            hop_expiry,
+            "spawn",
+            SinkScope::unrestricted(),
+            &child_key,
+            &grandchild_key,
+        )
+        .expect("the child key the issuer kept delegates again");
+    let verified =
+        verify_certificate(&grandchild, &root_pub, Utc::now(), DEFAULT_MAX_CHAIN_DEPTH).unwrap();
+    assert_eq!(verified.chain_depth(), 2);
+    assert_eq!(verified.leaf_identity(), "spiffe://test/pod/2");
+
+    // A key the issuer did NOT mint the hop with is still refused.
+    let stranger = generate_key(&rng);
+    assert!(matches!(
+        child.mint_child_with_scope_using_key(
+            &PermissionLattice::restrictive(),
+            "spiffe://test/pod/3".into(),
+            hop_expiry,
+            "spawn",
+            SinkScope::unrestricted(),
+            &stranger,
+            &grandchild_key,
+        ),
+        Err(CertificateMintChildError::Chain(
+            CertificateDelegationError::KeyMismatch
+        ))
+    ));
+}
+
+#[test]
+fn mint_child_with_scope_narrows_scope_and_budget() {
+    let (cert, holder, root_pub, rng) = minted();
+    let scope = SinkScope {
+        allowed_paths: vec!["src/**".into()],
+        ..SinkScope::unrestricted()
+    };
+    let hop_expiry = Utc::now() + Duration::hours(1);
+    let (child, child_key) = cert
+        .mint_child_with_scope(
+            &PermissionLattice::restrictive(),
+            "spiffe://test/pod/1".into(),
+            hop_expiry,
+            "spawn",
+            scope.clone(),
+            &holder,
+            &rng,
+        )
+        .unwrap();
+    let verified =
+        verify_certificate(&child, &root_pub, Utc::now(), DEFAULT_MAX_CHAIN_DEPTH).unwrap();
+    assert_eq!(verified.sink_scope().allowed_paths, scope.allowed_paths);
+
+    // Widening the scope at the next hop is refused at mint time.
+    let widened = child.mint_child_with_scope(
+        &PermissionLattice::restrictive(),
+        "spiffe://test/pod/2".into(),
+        hop_expiry,
+        "spawn",
+        SinkScope::unrestricted(),
+        &child_key,
+        &rng,
+    );
+    assert!(
+        matches!(
+            widened,
+            Err(CertificateMintChildError::Chain(
+                CertificateDelegationError::SinkScopeExceedsParent
+            ))
+        ),
+        "expected SinkScopeExceedsParent, got {widened:?}"
+    );
+
+    // And so is a budget past the parent's.
+    let mut greedy = PermissionLattice::restrictive();
+    greedy.budget.max_cost_usd = rust_decimal::Decimal::from(1_000);
+    let over = child.mint_child_with_scope(
+        &greedy,
+        "spiffe://test/pod/2".into(),
+        hop_expiry,
+        "spawn",
+        scope,
+        &child_key,
+        &rng,
+    );
+    assert!(
+        matches!(
+            over,
+            Err(CertificateMintChildError::Lattice(
+                crate::DelegationError::InsufficientBudget { .. }
+            ))
+        ),
+        "expected InsufficientBudget, got {over:?}"
+    );
+}
+
+/// SECURITY_TODO #16: the chain verify must reject the small-order
+/// identity-key forgery that `ring`'s cofactored verify accepts. Under the
+/// identity key A = R the cofactored equation `[s]B == R + [k]A` reduces to
+/// `identity == identity` for EVERY message.
+#[test]
+fn small_order_root_key_forgery_rejected() {
+    let (mut cert, _holder, _root_pub, _rng) = minted();
+    let mut identity_vk = [0u8; 32];
+    identity_vk[0] = 1; // compressed Edwards identity: y = 1
+    let mut identity_sig = [0u8; 64];
+    identity_sig[..32].copy_from_slice(&identity_vk); // R = identity, s = 0
+
+    let payload = cert.authority().signing_payload();
+    // Non-vacuity: this IS a forgery ring accepts.
+    let ring_verifier =
+        ring::signature::UnparsedPublicKey::new(&ring::signature::ED25519, identity_vk);
+    assert!(
+        ring_verifier.verify(&payload, &identity_sig).is_ok(),
+        "ring's cofactored verify accepts the identity triple; if this ever fails the \
+         test no longer distinguishes strict from cofactored verification"
+    );
+
+    cert.authority_mut().signature = identity_sig.to_vec();
+    assert!(matches!(
+        verify_certificate(&cert, &identity_vk, Utc::now(), DEFAULT_MAX_CHAIN_DEPTH),
+        Err(CertificateError::InvalidSignature { block_index: 0 })
+    ));
+}
+
+#[test]
+fn authority_block_without_provenance_field_still_deserializes() {
+    // Older serialized certificates carry no `provenance`; serde(default)
+    // reads them as None (they will then fail signature verification under
+    // the v2 payload, by design — but they must parse).
+    let (cert, _h, _p, _r) = minted();
+    let mut json: serde_json::Value = serde_json::from_slice(&cert.to_bytes().unwrap()).unwrap();
+    json["authority"]
+        .as_object_mut()
+        .unwrap()
+        .remove("provenance");
+    let parsed = LatticeCertificate::from_bytes(&serde_json::to_vec(&json).unwrap()).unwrap();
+    assert_eq!(parsed.authority().provenance, None);
+}

--- a/crates/portcullis/src/kani.rs
+++ b/crates/portcullis/src/kani.rs
@@ -2232,3 +2232,87 @@ fn proof_compartment_transition_no_leak() {
         "fresh graph should have at most the sentinel node"
     );
 }
+
+// ═══════════════════════════════════════════════════════════════════════════
+// E-series: Budget conservation across spawn (#2426, #2445)
+//
+// The ledger is the shipped type (`budget_ledger::LedgerCore`), not a model:
+// fixed-slot, `u64` micro-USD, no heap — see the module doc for why that
+// shape was chosen so the proof and production share one implementation.
+// Amounts are symbolic `u8`s: the arithmetic is the same at any width, and
+// the small domain keeps the unwinding cheap.
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// **E1 — Allocation conserves the parent's budget**:
+///
+/// For any parent `(max, consumed)` and ANY sequence of three allocation
+/// attempts (symbolic child ids and amounts, each of which may succeed or
+/// be refused), `Σ live allocations + consumed ≤ max` holds after every
+/// attempt. This is the invariant `PermissionLattice::delegate_to` alone
+/// cannot give (it reads the parent's remaining budget and decrements
+/// nothing), and the reason a fan-out of N children could previously be
+/// granted N× the parent's budget.
+#[kani::proof]
+#[kani::unwind(8)]
+#[kani::solver(cadical)]
+fn proof_budget_ledger_conserves() {
+    let max: u8 = kani::any();
+    let consumed: u8 = kani::any();
+    let mut ledger = crate::budget_ledger::LedgerCore::<4>::new(max as u64, consumed as u64);
+    assert!(
+        ledger.conserves(),
+        "constructor must establish the invariant"
+    );
+
+    let mut step = 0u8;
+    while step < 3 {
+        let child: u8 = kani::any();
+        let amount: u8 = kani::any();
+        let _ = ledger.try_allocate(child as u128, amount as u64);
+        assert!(
+            ledger.conserves(),
+            "Σ allocations + consumed must never exceed max"
+        );
+        step += 1;
+    }
+}
+
+/// **E2 — Release never manufactures budget**:
+///
+/// After a child is released with ANY reported consumption, the invariant
+/// still holds, the parent's consumption grew by at most that child's
+/// allocation, and the refund plus the folded-in spend equals exactly the
+/// allocation (nothing is created, nothing is lost).
+#[kani::proof]
+#[kani::unwind(8)]
+#[kani::solver(cadical)]
+fn proof_budget_ledger_release_conserves() {
+    let max: u8 = kani::any();
+    let consumed: u8 = kani::any();
+    let mut ledger = crate::budget_ledger::LedgerCore::<4>::new(max as u64, consumed as u64);
+
+    let amount: u8 = kani::any();
+    let other: u8 = kani::any();
+    let _ = ledger.try_allocate(1, amount as u64);
+    let _ = ledger.try_allocate(2, other as u64);
+
+    let consumed_before = ledger.parent_consumed_micro();
+    let allocation = ledger.allocation_of(1);
+    let reported: u8 = kani::any();
+    let result = ledger.release(1, reported as u64);
+
+    match (allocation, result) {
+        (Some(a), Ok(refund)) => {
+            let folded = ledger.parent_consumed_micro() - consumed_before;
+            assert!(
+                folded <= a,
+                "parent consumption grows by at most the allocation"
+            );
+            assert!(refund + folded == a, "refund + folded spend == allocation");
+        }
+        (None, Err(_)) => {}
+        _ => panic!("release must succeed exactly when the child was allocated"),
+    }
+    assert!(ledger.conserves());
+    assert!(ledger.allocation_of(1).is_none(), "released child is gone");
+}

--- a/crates/portcullis/src/lib.rs
+++ b/crates/portcullis/src/lib.rs
@@ -90,6 +90,7 @@ pub mod audit;
 #[cfg(feature = "serde")]
 pub mod audit_backend;
 mod budget;
+pub mod budget_ledger;
 mod capability;
 #[cfg(feature = "cedar")]
 pub mod cedar_bridge;
@@ -98,6 +99,8 @@ pub mod cedar_bridge;
 // sign/verify/mint/delegate fns inside are `#[cfg(feature = "crypto")]`-gated
 // (ring can't compile to WASM). The kernel needs the types, not the signing.
 pub mod certificate;
+#[cfg(all(test, feature = "crypto", feature = "serde"))]
+mod certificate_convergence_tests;
 mod command;
 pub mod constraint;
 pub mod trace_monitor;
@@ -213,6 +216,7 @@ pub mod workspace;
 mod kani;
 
 pub use budget::BudgetLattice;
+pub use budget_ledger::{BudgetLedger, LedgerCore, LedgerError};
 pub use capability::{
     default_sink_class, CapabilityLattice, CapabilityLevel, ExtensionOperation,
     IncompatibilityConstraint, Obligations, Operation, OperationParseError, SinkClass, StateRisk,


### PR DESCRIPTION
## Certificate convergence, PR 1 of 5 (portcullis primitives)

Groundwork for converging all authority onto `LatticeCertificate` (epics #2424 / #2425 / #2426; sub-issues #2445, #2432 follow-up). Nothing here is wired into a live path yet — the node PR (per-pod authority + budget ledger) and the tool-proxy PR (kernel-from-certificate, reserve-on-spawn) that follow depend on every item below. Each item is a real gap, not a refactor.

### Signature coverage
- `canonical_permissions_hash` now covers **`spawn_agent`**, the **extension map**, and **`budget.consumed_usd`**. All three rode inside the signed struct but outside the signed bytes: anyone who could edit the serialized JSON could raise `spawn_agent` — the dimension that gates sub-pod creation — on every block without invalidating a single Ed25519 signature, and `verify_certificate`'s monotone check compared the same tampered values. Pinned by `spawn_agent_is_signature_covered`, `extension_capabilities_are_signature_covered`, `consumed_usd_is_signature_covered_and_monotone`.
- `BudgetLattice::leq` now orders `consumed_usd` (reversed: more spent = more restrictive), matching what `meet`/`join` already did. A hop that reset `consumed_usd` to zero previously passed the monotone check.
- Payload tags bumped (`lattice-cert-authority-v2`, `-delegation-v3`, `-fingerprint-v2`). No fixture, doc, or out-of-tree token pins the old tags; older serialized certs still *parse* (`serde(default)` on the new field) and then fail signature verification by design.

### Re-rooting with provenance
- `AuthorityBlock.provenance: Option<[u8;32]>` — signature- and fingerprint-covered — records the caller chain a root was minted on behalf of (RFC 8693 `act` semantics). The node will use this for external callers who prove their own chain.

### Caller-owned holder keys
- `mint_with_holder_key`, `delegate_with_scope_using_key`, `mint_child_with_scope`, `mint_child_with_scope_using_key`. `ring` keypairs cannot export their seed and the existing constructors drop the PKCS#8 document, so an issuer that must persist per-pod `(certificate, holder key)` had no way to. The existing `mint` / `delegate*` are now thin wrappers. `issuer_owned_keys_delegate_across_hops` simulates a restart (re-parse the persisted document, delegate again) and checks a stranger key is still `KeyMismatch`.

### Budget conservation primitive (#2426, #2445)
- `budget_ledger::LedgerCore<N>` — fixed-slot, `u64` micro-USD, no heap — is the proof subject; `BudgetLedger` is the `Decimal` face, rounding always against the child. Invariant: **Σ live allocations + consumed ≤ max**. Kani **E1/E2** (`proof_budget_ledger_conserves`, `proof_budget_ledger_release_conserves`) prove it over the shipped type, not a model.
- `fan_out_cannot_multiply_the_parent_budget` pins, non-vacuously, that `delegate_to` alone admits the second full-budget child (it reads and never decrements) and the ledger refuses it.

### `verify_strict` on the certificate chain (SECURITY_TODO #16)
- The three `ring` `UnparsedPublicKey` verify sites become one `verify_ed25519_strict`. `small_order_root_key_forgery_rejected` asserts that `ring` still accepts the identity triple (so the test distinguishes strict from cofactored) and that `verify_certificate` now refuses it. SECURITY_TODO #16 updated: `manifest_registry.rs` stays open; `approval_bundle.rs` was ECDSA P-256 all along and is struck from the finding.

### `nucleus token`
- `mint --write-key` wrote the **root signing key**, which cannot delegate (the chain expects the holder key), and `delegate --write-key` wrote a **fresh unrelated key** — so no CLI chain longer than one hop was ever buildable. Both now write the key the chain expects (`--write-root-key` added for the anchor, keys written 0600), `delegate` goes through `mint_child_*` so over-budget requests are refused rather than clamped, and `written_keys_extend_the_chain_across_two_hops` round-trips mint → delegate → delegate.

### Layout
New tests live in `certificate_convergence_tests.rs` (the `kernel_tests.rs` pattern) to keep `certificate.rs` under the 2500-line ratchet.

### Verification
- `cargo test -p portcullis` — all targets (1003 lib + every integration binary) green
- `cargo test -p nucleus-cli token::` — 9 green
- `cargo clippy -p portcullis -p nucleus-cli --all-targets --all-features -- -D warnings` clean
- `cargo fmt --check`, `scripts/check-line-ratchet.sh --strict`, `ci/no-vendor-strings.sh` clean
- `cargo check` on `nucleus-node`, `nucleus-tool-proxy`, `nucleus-pca`, `nucleus-policy-cert`, `nucleus` (API consumers) clean
- `cargo kani` on E1/E2 + `proof_delegation_ceiling` + `proof_attenuation_leq_parent`: running locally at PR-open time; CI's Kani tier is authoritative

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZaH5waz88vL1qfNpFNfZ4
