### PR TITLE
security(#16): last ring Ed25519 verifies -> verify_strict; gate the regression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2177,6 +2177,7 @@ dependencies = [
  "base64 0.23.1",
  "blake3",
  "chrono",
+ "ed25519-dalek 3.0.0",
  "pretty_assertions",
  "ring",
  "serde",

--- a/SECURITY_TODO.md
+++ b/SECURITY_TODO.md
@@ -323,9 +323,10 @@ TODO
 - [x] Option (b) chosen: migrate trust-path verifies to `ed25519-dalek::verify_strict`, signing stays on `ring`.
   - [x] `token_sign.rs`, `receipt_sign.rs` — migrated (earlier).
   - [x] `certificate.rs` (authority / per-block / proof-of-possession, the highest-concern in-band `next_key` site) — migrated in the certificate-convergence PR 1; `verify_ed25519_strict` is the single verify helper, pinned by `certificate_convergence_test::small_order_root_key_forgery_rejected`, which asserts (non-vacuously) that `ring` still accepts the identity triple and `verify_certificate` now refuses it.
-  - [ ] `manifest_registry.rs:98/139` — still `ring`.
-  - [ ] Extend `scripts/check-verify-strict.sh` to cover the migrated ring paths.
+  - [x] `manifest_registry.rs` (`TrustStore::verify`, `verify_manifest_signature`) — migrated to the shared `certificate::verify_ed25519_strict`; pinned by `manifest_registry::tests::crypto_tests::small_order_identity_triple_rejected` (asserts `ring` still accepts the identity triple, then that the trust store and the manifest verify refuse it).
+  - [x] `ck-types::witness.rs` (witness-bundle signatures) and `ck-kernel::lib.rs` (human governance signatures) — found by the sweep below; migrated to `ck_types::witness::verify_ed25519_strict` (dalek `verify_strict`, single-variant `InvalidSignature` error).
+  - [x] `scripts/check-verify-strict.sh` now has a second scan: any production reference to `ring::signature::ED25519` (the cofactored verifier) fails the gate, no allowlist, `#[cfg(test)]` blocks and `*_test.rs` files excluded. Verified to FAIL on the pre-migration tree and PASS after.
 - `nucleus-identity::approval_bundle.rs:425` is **ECDSA P-256** (`ECDSA_P256_SHA256_FIXED`), not Ed25519; the small-order Ed25519 concern does not apply there. Listed in error by the original sweep.
 
 Status
-- [PARTIAL] Three of four Ed25519 sites migrated; `manifest_registry.rs` open.
+- CLOSED (2026-09-04). Every Ed25519 re-verify in the workspace is `verify_strict`; `ring` remains for signing only. The only production `ring::signature::ED25519` references left are inside test modules, which the gate strips.

--- a/crates/ck-kernel/src/lib.rs
+++ b/crates/ck-kernel/src/lib.rs
@@ -504,10 +504,10 @@ impl Kernel {
                 continue;
             };
 
-            // Verify Ed25519 signature
-            let public_key =
-                ring::signature::UnparsedPublicKey::new(&ring::signature::ED25519, pub_key_bytes);
-            if public_key.verify(&payload, &sig.signature).is_err() {
+            // Verify Ed25519 signature (strict: SECURITY_TODO #16)
+            if ck_types::witness::verify_ed25519_strict(pub_key_bytes, &payload, &sig.signature)
+                .is_err()
+            {
                 reasons.push(RejectionReason {
                     invariant: ConstitutionalInvariant::GovernanceMonotonicity,
                     message: format!(

--- a/crates/ck-types/Cargo.toml
+++ b/crates/ck-types/Cargo.toml
@@ -11,6 +11,7 @@ base64 = { workspace = true }
 blake3 = "1"
 chrono = { version = "0.4", features = ["serde"] }
 ring = { workspace = true }
+ed25519-dalek = { workspace = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"

--- a/crates/ck-types/src/witness.rs
+++ b/crates/ck-types/src/witness.rs
@@ -13,6 +13,41 @@ use crate::digest::ArtifactDigest;
 use crate::manifest::PolicyManifest;
 use crate::{ConstitutionalInvariant, PatchClass};
 
+/// Strict Ed25519 verification for every ck trust-path re-verify.
+///
+/// `ed25519_dalek::VerifyingKey::verify_strict` rejects small-order and
+/// non-canonical public keys and `R` points, which `ring`'s cofactored
+/// `UnparsedPublicKey::verify` accepts (the "identity triple" verifies under
+/// the identity key). A witness or human signature must bind to exactly one
+/// key, so this is the only verifier the kernel may use (SECURITY_TODO #16).
+/// Signing stays on `ring`.
+pub fn verify_ed25519_strict(
+    public_key: &[u8],
+    message: &[u8],
+    sig: &[u8],
+) -> Result<(), InvalidSignature> {
+    let vk_bytes: [u8; 32] = public_key.try_into().map_err(|_| InvalidSignature)?;
+    let vk = ed25519_dalek::VerifyingKey::from_bytes(&vk_bytes).map_err(|_| InvalidSignature)?;
+    let sig = ed25519_dalek::Signature::from_slice(sig).map_err(|_| InvalidSignature)?;
+    vk.verify_strict(message, &sig)
+        .map_err(|_| InvalidSignature)
+}
+
+/// The single failure of [`verify_ed25519_strict`]: malformed key, malformed
+/// signature, small-order/non-canonical point, or a signature that does not
+/// verify. Deliberately one variant — a verifier must not tell an attacker
+/// WHICH check failed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InvalidSignature;
+
+impl std::fmt::Display for InvalidSignature {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("Ed25519 signature did not verify (strict)")
+    }
+}
+
+impl std::error::Error for InvalidSignature {}
+
 /// Canonical witness bundle for an amendment transition.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WitnessBundle {
@@ -166,10 +201,7 @@ impl SignatureVerifier {
                 }
             };
 
-            let public_key =
-                ring::signature::UnparsedPublicKey::new(&ring::signature::ED25519, pub_key_bytes);
-
-            match public_key.verify(&payload, &sig_bytes) {
+            match verify_ed25519_strict(pub_key_bytes, &payload, &sig_bytes) {
                 Ok(()) => {
                     valid_count += 1;
                     distinct_keys.insert(pub_key_bytes.clone());

--- a/crates/portcullis/src/certificate.rs
+++ b/crates/portcullis/src/certificate.rs
@@ -1196,7 +1196,11 @@ impl LatticeCertificate {
 /// the attest stack (`token_sign`, `receipt_sign`) and removes `ring` from the
 /// verify TCB (SECURITY_TODO #16). Signing stays on `ring`.
 #[cfg(feature = "crypto")]
-fn verify_ed25519_strict(public_key: &[u8], message: &[u8], sig: &[u8]) -> Result<(), ()> {
+pub(crate) fn verify_ed25519_strict(
+    public_key: &[u8],
+    message: &[u8],
+    sig: &[u8],
+) -> Result<(), ()> {
     let vk_bytes: [u8; 32] = public_key.try_into().map_err(|_| ())?;
     let vk = ed25519_dalek::VerifyingKey::from_bytes(&vk_bytes).map_err(|_| ())?;
     let sig = ed25519_dalek::Signature::from_slice(sig).map_err(|_| ())?;

--- a/crates/portcullis/src/manifest_registry.rs
+++ b/crates/portcullis/src/manifest_registry.rs
@@ -29,6 +29,9 @@ use portcullis_core::manifest::{
 use portcullis_core::{AuthorityLevel, ConfLevel, IntegLevel, Operation};
 use serde::Deserialize;
 
+#[cfg(feature = "crypto")]
+use crate::certificate::verify_ed25519_strict;
+
 /// A loaded and validated manifest registry.
 #[derive(Debug, Default)]
 pub struct ManifestRegistry {
@@ -90,17 +93,14 @@ impl TrustStore {
     /// Verify a signature against any trusted key.
     ///
     /// Returns true if the signature is valid for at least one trusted key.
+    /// Strict (`ed25519_dalek::verify_strict`) — a small-order or non-canonical
+    /// key never verifies, so a signature cannot be made to check under an
+    /// identity other than the one that produced it (SECURITY_TODO #16).
     #[cfg(feature = "crypto")]
     pub fn verify(&self, message: &[u8], signature: &[u8]) -> bool {
-        use ring::signature::{self, UnparsedPublicKey};
-
-        for key_bytes in &self.keys {
-            let public_key = UnparsedPublicKey::new(&signature::ED25519, key_bytes);
-            if public_key.verify(message, signature).is_ok() {
-                return true;
-            }
-        }
-        false
+        self.keys
+            .iter()
+            .any(|key_bytes| verify_ed25519_strict(key_bytes, message, signature).is_ok())
     }
 
     /// Number of trusted keys.
@@ -118,8 +118,6 @@ pub fn verify_manifest_signature(
     manifest: &ToolManifest,
     trust_store: &TrustStore,
 ) -> Result<(), AdmissionDenyReason> {
-    use ring::signature::{self, UnparsedPublicKey};
-
     let (sig, key) = match (manifest.signature.as_ref(), manifest.signing_key.as_ref()) {
         (Some(s), Some(k)) => (s, k),
         _ => return Err(AdmissionDenyReason::UnsignedManifest),
@@ -134,11 +132,9 @@ pub fn verify_manifest_signature(
         return Err(AdmissionDenyReason::InvalidSignature);
     }
 
-    // Second check: the signature must verify against canonical bytes
+    // Second check: the signature must verify (strictly) against canonical bytes
     let canonical = manifest.canonical_bytes();
-    let public_key = UnparsedPublicKey::new(&signature::ED25519, key.as_slice());
-    public_key
-        .verify(&canonical, sig.as_slice())
+    verify_ed25519_strict(key.as_slice(), &canonical, sig.as_slice())
         .map_err(|_| AdmissionDenyReason::InvalidSignature)
 }
 
@@ -638,6 +634,44 @@ signing_key = "bb"
             manifest.signature = Some(sig_bytes);
             manifest.signing_key = Some(pub_bytes);
             manifest
+        }
+
+        /// SECURITY_TODO #16 regression: the identity triple (small-order key,
+        /// `R` = identity, `s` = 0) is a signature `ring`'s cofactored verify
+        /// accepts under the identity key. A trust store pinned to that key,
+        /// or a manifest carrying it, must now refuse it. The `ring` half is
+        /// asserted first so the test cannot pass vacuously.
+        #[test]
+        fn small_order_identity_triple_rejected() {
+            let mut identity_vk = [0u8; 32];
+            identity_vk[0] = 1; // compressed Edwards identity: y = 1
+            let mut identity_sig = [0u8; 64];
+            identity_sig[..32].copy_from_slice(&identity_vk); // R = identity, s = 0
+
+            let kp = test_keypair();
+            let mut manifest = signed_manifest(&kp);
+            let canonical = manifest.canonical_bytes();
+
+            let ring_verifier =
+                ring::signature::UnparsedPublicKey::new(&ring::signature::ED25519, identity_vk);
+            assert!(
+                ring_verifier.verify(&canonical, &identity_sig).is_ok(),
+                "ring accepts the identity triple; if this fails the test no longer \
+                 distinguishes strict from cofactored verification"
+            );
+
+            let trust = make_trust_store(&identity_vk);
+            assert!(
+                !trust.verify(&canonical, &identity_sig),
+                "TrustStore::verify must reject a small-order key"
+            );
+
+            manifest.signature = Some(identity_sig);
+            manifest.signing_key = Some(identity_vk);
+            assert_eq!(
+                verify_manifest_signature(&manifest, &trust),
+                Err(AdmissionDenyReason::InvalidSignature)
+            );
         }
 
         #[test]

--- a/scripts/check-gates-can-fail.sh
+++ b/scripts/check-gates-can-fail.sh
@@ -168,6 +168,13 @@ perturb_verify_strict() {
     append_line "$1" 'fn _gate_of_gates_weak(k: &ed25519_dalek::VerifyingKey, m: &[u8], s: ed25519_dalek::Signature) -> bool { k.verify(m, &s).is_ok() }'
 }
 
+perturb_ring_ed25519() {
+    # SECURITY_TODO #16 sibling scan: a cofactored `ring::signature::ED25519`
+    # verify on a production path. The gate matches the algorithm constant
+    # itself, so the probe names it in a plain (non-test) function.
+    append_line "$1" 'fn _gate_of_gates_ring(k: &[u8], m: &[u8], s: &[u8]) -> bool { ring::signature::UnparsedPublicKey::new(&ring::signature::ED25519, k).verify(m, s).is_ok() }'
+}
+
 perturb_failclosed() {
     # A VERIFIER that reports success on a platform where it cannot check. The
     # gate matches a `cfg(not(target_os = ...))` stub whose name starts with
@@ -353,6 +360,8 @@ probe check-sealed-home.sh    "" crates/portcullis-effects/src/lib.rs \
       "an un-allowlisted spawn in the sealed home" perturb_sealed_home
 probe check-verify-strict.sh  "" crates/nucleus-identity/src/lib.rs \
       "a non-strict dalek .verify()"          perturb_verify_strict
+probe check-verify-strict.sh  "" crates/ck-types/src/witness.rs \
+      "a cofactored ring ED25519 verify"      perturb_ring_ed25519
 probe check-failclosed-verifiers.sh "" crates/nucleus-identity/src/lib.rs \
       "a verifier returning Ok where it cannot check" perturb_failclosed
 probe check-ingest-hashed.sh  "" crates/nucleus-tool-proxy/src/egress.rs \

--- a/scripts/check-verify-strict.sh
+++ b/scripts/check-verify-strict.sh
@@ -133,3 +133,76 @@ if [[ "${#hits[@]}" -gt 0 ]]; then
 fi
 
 echo "M-3 verify-strict gate PASSED: no non-strict dalek .verify(...) on any trust path."
+
+# ── SECURITY_TODO #16 sibling: no `ring` Ed25519 verify on any production path ──
+#
+# `ring::signature::ED25519` is the cofactored verifier: it accepts the
+# small-order "identity triple" (empirically confirmed under the pinned `ring`,
+# see SECURITY_TODO #16), and `ring` has no strict variant. Every trust-path
+# Ed25519 re-verify in the workspace was migrated to `verify_strict`
+# (portcullis `certificate.rs` / `token_sign.rs` / `receipt_sign.rs` /
+# `manifest_registry.rs`, ck-types `witness.rs`, ck-kernel `lib.rs`); signing
+# stays on `ring` (`Ed25519KeyPair`, which this scan does not match). A
+# reference to the `ED25519` verification algorithm in production code is a
+# regression, full stop — there is no allowlist for it. Test code is excluded
+# the same way as above (`#[cfg(test)]` blocks stripped) plus `*_test.rs` /
+# `*_tests.rs` files, which the crate roots declare under `#[cfg(test)]`.
+list_ring_files() {
+    if command -v rg >/dev/null 2>&1; then
+        rg -l --glob '*.rs' 'signature::ED25519([^_A-Za-z0-9]|$)' crates
+    else
+        grep -rlE --include='*.rs' 'signature::ED25519([^_A-Za-z0-9]|$)' crates
+    fi \
+        | grep -vE '/(tests|benches)/' \
+        | grep -vE '_tests?\.rs$'
+}
+
+read -r -d '' AWK_RING <<'AWK' || true
+BEGIN { skip=0; brace=0; pending=0 }
+{
+    line=$0
+    tmp=line; no=gsub(/\{/,"{",tmp)
+    tmp=line; nc=gsub(/\}/,"}",tmp)
+    if (skip==1) {
+        brace += no - nc
+        if (brace <= 0) { skip=0; brace=0 }
+        next
+    }
+    if (line ~ /#\[cfg\(test\)\]/) { pending=1; next }
+    if (pending==1) {
+        if (no>0) {
+            skip=1
+            brace = no - nc
+            pending=0
+            if (brace <= 0) { skip=0; brace=0 }
+            next
+        }
+        if (line ~ /;/) { pending=0 }
+    }
+    stripped=line; sub(/^[[:space:]]+/,"",stripped)
+    if (stripped ~ /^\/\//) { next }
+    if (line ~ /signature::ED25519([^_A-Za-z0-9]|$)/) {
+        printf "%s:%d:%s\n", FILENAME, FNR, line
+    }
+}
+AWK
+
+ring_hits=()
+while IFS= read -r f; do
+    [[ -z "$f" ]] && continue
+    while IFS= read -r rec; do
+        [[ -z "$rec" ]] && continue
+        ring_hits+=("$rec")
+    done < <(awk "$AWK_RING" "$f")
+done < <(list_ring_files || true)
+
+if [[ "${#ring_hits[@]}" -gt 0 ]]; then
+    echo "#16 ring-Ed25519 gate FAILED: cofactored ring::signature::ED25519 verify on a production path:" >&2
+    printf '  %s\n' "${ring_hits[@]}" >&2
+    echo >&2
+    echo "Fix: verify with ed25519_dalek::VerifyingKey::verify_strict (see portcullis" >&2
+    echo "certificate::verify_ed25519_strict or ck_types::witness::verify_ed25519_strict)." >&2
+    exit 1
+fi
+
+echo "#16 ring-Ed25519 gate PASSED: no ring::signature::ED25519 verify on any production path."

--- a/scripts/exemplar-baseline.json
+++ b/scripts/exemplar-baseline.json
@@ -6,7 +6,7 @@
     "lean_theorems_GUARD": 891, "clean_axiom_footprint": "n/a"
   },
   "rust_craft": {
-    "permissive_verify": 17, "verify_calls_GUARD": 47,
+    "permissive_verify": 13, "verify_calls_GUARD": 44,
     "unsafe_blocks": 6,
     "crates_total": 67, "crates_lints_workspace": 41,
     "lints_adoption_pct": 61


### PR DESCRIPTION
## Summary
- Closes SECURITY_TODO #16: `manifest_registry.rs` (`TrustStore::verify`, `verify_manifest_signature`) now verifies with the shared `certificate::verify_ed25519_strict` instead of `ring`'s cofactored `UnparsedPublicKey`.
- The sweep found two more cofactored Ed25519 trust-path verifies: ck-types witness-bundle signatures and ck-kernel human governance signatures. Both migrated to a new `ck_types::witness::verify_ed25519_strict` (single-variant `InvalidSignature` error). Signing stays on `ring`.
- `scripts/check-verify-strict.sh` gains a second scan that fails on any production `ring::signature::ED25519` reference, no allowlist. Verified RED on the pre-migration tree (4 hits) and GREEN after; a `check-gates-can-fail.sh` probe pins both directions.
- Non-vacuity test `small_order_identity_triple_rejected`: asserts `ring` still accepts the identity triple, then that the trust store and manifest verify refuse it.
- Exemplar baseline re-derived 17/47 → 13/44: the four production `.verify(` sites were replaced by strict verification, not deleted.

## Test plan
- [x] `cargo test -p portcullis --all-features`, `-p ck-types -p ck-kernel --all-features`
- [x] `cargo clippy --all-targets --all-features -D warnings` on the three crates; `cargo fmt --check`
- [x] `scripts/check-verify-strict.sh` (PASS here, FAIL on main's tree), `scripts/check-gates-can-fail.sh` (rc 0)
- [x] line ratchet, clippy cast ratchet, `ci/no-vendor-strings.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZaH5waz88vL1qfNpFNfZ4