### PR TITLE
security(cli): runtime default-deny tool gate replaces the denylist as the boundary

### DIFF
--- a/crates/nucleus-cli/src/constants.rs
+++ b/crates/nucleus-cli/src/constants.rs
@@ -10,10 +10,13 @@
 ///
 /// COMPLETE-MEDIATION INVARIANT: every code path that launches the assistant
 /// with `--dangerously-skip-permissions` / `bypassPermissions` (`run`, `shell`)
-/// MUST also pass this list. Omitting it lets the built-in Bash/Write/WebFetch/
-/// etc. run OUTSIDE the kernel — an in-band path that skips the monitor. The
-/// two launch sites referencing this constant keep the boundary identical by
-/// construction; do not inline the list.
+/// MUST also pass this list AND install the runtime allowlist hook
+/// (`crate::mediation`). This list is defence in depth: it cannot be complete
+/// (a built-in tool added or renamed after it was written is not on it), so
+/// the BOUNDARY is the `PreToolUse` hook, which denies every tool that is not
+/// an explicitly granted nucleus MCP tool. Omitting either lets a built-in
+/// run OUTSIDE the kernel — an in-band path that skips the monitor. The two
+/// launch sites keep the boundary identical by construction; do not inline.
 pub const DISALLOWED_BUILTIN_TOOLS: &str =
     "Bash,Read,Write,Edit,Glob,Grep,WebFetch,WebSearch,NotebookEdit,Agent";
 

--- a/crates/nucleus-cli/src/main.rs
+++ b/crates/nucleus-cli/src/main.rs
@@ -35,6 +35,7 @@ mod lineage;
 mod lineage_verify;
 mod lockdown;
 mod manifest;
+mod mediation;
 mod node;
 mod observe;
 mod profiles;
@@ -148,6 +149,11 @@ enum Commands {
 
     /// Verify an attested SVID against expected measurements (relying party, C9)
     VerifyAttestation(verify_attestation::VerifyAttestationArgs),
+
+    /// PreToolUse hook installed by `run`/`shell`: default-deny every tool
+    /// that is not an allowed nucleus MCP tool (internal; see `mediation`).
+    #[command(name = "mediation-hook", hide = true)]
+    MediationHook,
 }
 
 fn init_logging(verbose: bool) {
@@ -206,5 +212,8 @@ async fn main() -> Result<()> {
         Commands::EnvelopeVerify(args) => envelope_verify::execute(args),
         Commands::Bundle(args) => bundle::execute(args).await,
         Commands::VerifyAttestation(args) => verify_attestation::execute(args),
+        // The hook's whole contract is its exit status; nothing else may
+        // reach stdout/stderr after the decision is printed.
+        Commands::MediationHook => std::process::exit(i32::from(mediation::run_hook())),
     }
 }

--- a/crates/nucleus-cli/src/mediation.rs
+++ b/crates/nucleus-cli/src/mediation.rs
@@ -1,0 +1,305 @@
+//! Runtime complete mediation: a default-deny tool gate the agent CLI
+//! consults on EVERY tool call.
+//!
+//! # Why a static denylist is not enough
+//!
+//! `run` and `shell` launch the agent with its interactive approval bypassed,
+//! which is safe only under complete mediation: every tool the agent can reach
+//! routes through the nucleus MCP server and therefore the `PermissionLattice`.
+//! Until now that rested on [`crate::constants::DISALLOWED_BUILTIN_TOOLS`], a
+//! hardcoded list of the agent's built-in tools passed as `--disallowedTools`.
+//! A denylist is only as complete as the day it was written: a built-in tool
+//! added, renamed, or aliased after that day is reachable, unmediated, with
+//! approval already bypassed — and nothing in this repo would notice, because
+//! the list is compared against a second copy of itself.
+//!
+//! # The fix: an allowlist enforced at the call edge
+//!
+//! The agent CLI runs a `PreToolUse` hook before every tool call and blocks
+//! the call when the hook exits with status 2. `nucleus` registers ITSELF as
+//! that hook (`nucleus mediation-hook`, hidden), carrying the vetted allowlist
+//! in [`ALLOWED_TOOLS_ENV`]. The hook allows a call iff the tool name is
+//! EXACTLY one of the allowed nucleus MCP tools and denies everything else —
+//! a built-in, a tool the agent CLI grew last week, a nucleus tool the policy
+//! did not grant, a malformed event, a missing allowlist. Unknown is denied,
+//! not passed through.
+//!
+//! The static denylist stays as defence in depth (it also keeps the agent
+//! from wasting tokens on tool definitions it cannot use); the hook is the
+//! boundary. Both launch sites are pinned to install it.
+//!
+//! # Interop note
+//!
+//! The hook event shape (`tool_name` on stdin, exit 2 = block) and the
+//! `--settings` hook registration are the wrapped agent CLI's own contract,
+//! the same intrinsic interop as `--disallowedTools` and `--mcp-config` in the
+//! launch sites. No vendor SDK is involved; the gate is a JSON field and an
+//! exit code.
+
+use anyhow::{Context, Result};
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+/// Environment variable carrying the vetted allowlist (comma-separated tool
+/// names) from the launch site to the hook. Set on the agent CLI's process;
+/// hooks inherit its environment.
+pub const ALLOWED_TOOLS_ENV: &str = "NUCLEUS_MEDIATION_ALLOWED_TOOLS";
+
+/// The hidden subcommand the hook registration invokes.
+pub const HOOK_SUBCOMMAND: &str = "mediation-hook";
+
+/// The `PreToolUse` hook exit status that blocks the tool call and feeds
+/// stderr back to the model. Chosen over the JSON-decision form because it is
+/// the oldest-supported contract: a CLI that does not understand a JSON
+/// decision would treat exit 0 + unparsed stdout as ALLOW (fail-open); exit 2
+/// blocks on every version that has hooks at all.
+const BLOCK_EXIT_CODE: u8 = 2;
+
+/// What the hook decided for one tool call.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Decision {
+    /// The tool is one of the allowed, lattice-routed nucleus MCP tools.
+    Allow,
+    /// Everything else. The reason is fed back to the model.
+    Deny { reason: String },
+}
+
+/// The pure decision: allow iff `tool_name` is EXACTLY in `allowed` AND is a
+/// nucleus MCP tool. An empty allowlist denies everything (the launch site
+/// refuses to start with no allowed tools, so this is only reachable if the
+/// env var was lost — and losing it must fail closed).
+pub fn decide(tool_name: &str, allowed: &[String]) -> Decision {
+    let name = tool_name.trim();
+    if name.is_empty() {
+        return Decision::Deny {
+            reason: "tool call carried no tool name".to_string(),
+        };
+    }
+    if !name.starts_with(crate::run::NUCLEUS_MCP_TOOL_PREFIX) {
+        return Decision::Deny {
+            reason: format!(
+                "`{name}` is not a nucleus-mediated tool; only tools routed through the \
+                 nucleus permission lattice may run in this session"
+            ),
+        };
+    }
+    if !allowed.iter().any(|a| a == name) {
+        return Decision::Deny {
+            reason: format!("`{name}` is not granted by this session's policy"),
+        };
+    }
+    Decision::Allow
+}
+
+/// Parse the allowlist as the launch site serialised it.
+pub fn parse_allowlist(raw: &str) -> Vec<String> {
+    raw.split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+/// Pull `tool_name` out of a `PreToolUse` event. Anything unparseable is
+/// `None`, which the caller denies.
+pub fn tool_name_from_event(event: &str) -> Option<String> {
+    let v: serde_json::Value = serde_json::from_str(event).ok()?;
+    v.get("tool_name")?.as_str().map(str::to_string)
+}
+
+/// The settings document that registers this binary as the `PreToolUse`
+/// hook for every tool (no matcher = all tools).
+pub fn hook_settings(self_exe: &Path) -> serde_json::Value {
+    serde_json::json!({
+        "hooks": {
+            "PreToolUse": [{
+                "hooks": [{
+                    "type": "command",
+                    "command": format!("{} {}", shell_quote(self_exe), HOOK_SUBCOMMAND),
+                }]
+            }]
+        }
+    })
+}
+
+/// Write the hook settings into `dir` and return the path to pass as
+/// `--settings`.
+pub fn write_hook_settings(dir: &Path) -> Result<PathBuf> {
+    let self_exe = std::env::current_exe().context("resolving own executable for the hook")?;
+    let path = dir.join("mediation-hook-settings.json");
+    std::fs::write(
+        &path,
+        serde_json::to_string_pretty(&hook_settings(&self_exe))?,
+    )
+    .with_context(|| format!("writing {}", path.display()))?;
+    Ok(path)
+}
+
+/// Single-quote a path for the hook's shell command line.
+fn shell_quote(p: &Path) -> String {
+    format!("'{}'", p.display().to_string().replace('\'', "'\\''"))
+}
+
+/// The hook entry point: read the event from stdin, decide, and return the
+/// process exit status — 0 (allow) or [`BLOCK_EXIT_CODE`] (deny, reason on
+/// stderr). Never panics on
+/// bad input — a hook that crashes is, on some versions, a hook that allowed.
+pub fn run_hook() -> u8 {
+    let mut raw = String::new();
+    let _ = std::io::stdin().read_to_string(&mut raw);
+    let allowed = std::env::var(ALLOWED_TOOLS_ENV)
+        .map(|s| parse_allowlist(&s))
+        .unwrap_or_default();
+    let decision = match tool_name_from_event(&raw) {
+        Some(name) => decide(&name, &allowed),
+        None => Decision::Deny {
+            reason: "unparseable tool-call event".to_string(),
+        },
+    };
+    match decision {
+        Decision::Allow => 0,
+        Decision::Deny { reason } => {
+            eprintln!("nucleus mediation: denied — {reason}");
+            BLOCK_EXIT_CODE
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn allowed() -> Vec<String> {
+        vec![
+            "mcp__nucleus__read".to_string(),
+            "mcp__nucleus__run".to_string(),
+        ]
+    }
+
+    #[test]
+    fn every_static_denylist_entry_is_denied_by_the_hook() {
+        // The hook must subsume the denylist: nothing the list blocks may
+        // pass the hook.
+        for builtin in crate::constants::DISALLOWED_BUILTIN_TOOLS.split(',') {
+            assert!(
+                matches!(decide(builtin, &allowed()), Decision::Deny { .. }),
+                "{builtin} must be denied"
+            );
+        }
+    }
+
+    #[test]
+    fn a_builtin_the_denylist_never_heard_of_is_denied() {
+        // The whole point: a tool that did not exist when the denylist was
+        // written. Names deliberately absent from DISALLOWED_BUILTIN_TOOLS.
+        for novel in [
+            "Task",
+            "BashOutput",
+            "KillShell",
+            "Skill",
+            "TodoWrite",
+            "NewTool",
+        ] {
+            assert!(
+                !crate::constants::DISALLOWED_BUILTIN_TOOLS
+                    .split(',')
+                    .any(|d| d == novel),
+                "test premise: {novel} is not in the static denylist"
+            );
+            assert!(
+                matches!(decide(novel, &allowed()), Decision::Deny { .. }),
+                "{novel} must be denied without being listed anywhere"
+            );
+        }
+    }
+
+    #[test]
+    fn nucleus_tool_outside_the_policy_grant_is_denied() {
+        assert!(matches!(
+            decide("mcp__nucleus__web_fetch", &allowed()),
+            Decision::Deny { .. }
+        ));
+    }
+
+    #[test]
+    fn granted_nucleus_tools_are_allowed_exactly() {
+        assert_eq!(decide("mcp__nucleus__read", &allowed()), Decision::Allow);
+        assert_eq!(decide("mcp__nucleus__run", &allowed()), Decision::Allow);
+        // Exact match: no prefix/suffix tricks.
+        assert!(matches!(
+            decide("mcp__nucleus__read2", &allowed()),
+            Decision::Deny { .. }
+        ));
+        assert!(matches!(
+            decide("mcp__nucleus__rea", &allowed()),
+            Decision::Deny { .. }
+        ));
+    }
+
+    #[test]
+    fn empty_allowlist_and_empty_name_deny() {
+        assert!(matches!(
+            decide("mcp__nucleus__read", &[]),
+            Decision::Deny { .. }
+        ));
+        assert!(matches!(decide("", &allowed()), Decision::Deny { .. }));
+    }
+
+    #[test]
+    fn event_parsing_is_fail_closed() {
+        assert_eq!(
+            tool_name_from_event(r#"{"tool_name":"mcp__nucleus__read","tool_input":{}}"#)
+                .as_deref(),
+            Some("mcp__nucleus__read")
+        );
+        assert_eq!(tool_name_from_event("not json"), None);
+        assert_eq!(tool_name_from_event(r#"{"tool_input":{}}"#), None);
+        assert_eq!(tool_name_from_event(r#"{"tool_name":7}"#), None);
+    }
+
+    #[test]
+    fn allowlist_round_trips_through_the_env_encoding() {
+        assert_eq!(parse_allowlist(" a , ,b,"), vec!["a", "b"]);
+        assert_eq!(
+            parse_allowlist(&allowed().join(",")),
+            allowed(),
+            "the launch site's join and the hook's split must agree"
+        );
+    }
+
+    #[test]
+    fn settings_register_this_binary_for_every_tool() {
+        let v = hook_settings(Path::new("/opt/nuc leus/nucleus"));
+        let entry = &v["hooks"]["PreToolUse"][0];
+        assert!(entry.get("matcher").is_none(), "no matcher = every tool");
+        let cmd = entry["hooks"][0]["command"].as_str().unwrap();
+        assert_eq!(cmd, "'/opt/nuc leus/nucleus' mediation-hook");
+        assert_eq!(entry["hooks"][0]["type"], "command");
+    }
+
+    /// Structural pin: BOTH launch sites install the hook and hand it the
+    /// allowlist. Mirrors the existing `disallow lists must stay identical`
+    /// regression; a site that drops either line reopens the bypass.
+    #[test]
+    fn both_launch_sites_install_the_hook() {
+        for (name, src) in [
+            ("run.rs", include_str!("run.rs")),
+            ("shell.rs", include_str!("shell.rs")),
+        ] {
+            let launches = src
+                .matches("Command::new(crate::constants::AGENT_CLI_BIN)")
+                .count();
+            assert!(launches > 0, "{name}: no launch site found (test is stale)");
+            assert!(
+                src.contains("mediation::write_hook_settings("),
+                "{name}: launch site does not install the mediation hook"
+            );
+            // rustfmt may split the call; compare without whitespace.
+            let compact: String = src.split_whitespace().collect();
+            assert!(
+                compact.contains(".env(crate::mediation::ALLOWED_TOOLS_ENV,"),
+                "{name}: launch site does not pass the allowlist to the hook"
+            );
+        }
+    }
+}

--- a/crates/nucleus-cli/src/run.rs
+++ b/crates/nucleus-cli/src/run.rs
@@ -946,7 +946,7 @@ pub fn write_mcp_config(
 /// Prefix identifying nucleus MCP tools. Only tools carrying this prefix route
 /// through the `PermissionLattice`-enforcing MCP server; anything else is a
 /// built-in tool that would act OUTSIDE the kernel.
-const NUCLEUS_MCP_TOOL_PREFIX: &str = "mcp__nucleus__";
+pub(crate) const NUCLEUS_MCP_TOOL_PREFIX: &str = "mcp__nucleus__";
 
 /// Capability token proving the *complete-mediation* confinement guard that
 /// makes launching the agent with the approval bypass safe.
@@ -1009,6 +1009,16 @@ fn run_agent_mcp(
     prompt: &str,
     work_dir: &Path,
 ) -> Result<std::process::Output> {
+    // Runtime complete mediation: the PreToolUse hook denies every tool that
+    // is not one of the guard's allowed nucleus MCP tools, so a built-in the
+    // static denylist below has never heard of is still blocked at the call
+    // edge. The settings file lives beside the MCP config.
+    let settings_path = crate::mediation::write_hook_settings(
+        mcp_config_path
+            .parent()
+            .ok_or_else(|| anyhow!("mcp config path has no parent directory"))?,
+    )?;
+
     let mut cmd = Command::new(crate::constants::AGENT_CLI_BIN);
     cmd.arg("--print");
     if let Some(model) = &args.model {
@@ -1029,6 +1039,12 @@ fn run_agent_mcp(
         // `shell.rs`; the two disallow lists MUST stay identical (regression-tested).
         .arg("--disallowedTools")
         .arg(crate::constants::DISALLOWED_BUILTIN_TOOLS)
+        .arg("--settings")
+        .arg(&settings_path)
+        .env(
+            crate::mediation::ALLOWED_TOOLS_ENV,
+            guard.allowed_tools().join(","),
+        )
         .arg("--max-budget-usd")
         .arg(policy.budget.max_cost_usd.to_string())
         .arg(prompt)

--- a/crates/nucleus-cli/src/shell.rs
+++ b/crates/nucleus-cli/src/shell.rs
@@ -251,6 +251,11 @@ pub async fn execute(args: ShellArgs) -> Result<()> {
     // The agent CLI's session env var (intrinsic interop: `CLAUDECODE`) must be
     // removed to allow launching the agent CLI from within an existing agent
     // session (e.g. testing nucleus shell from inside one).
+    // Runtime complete mediation (see `crate::mediation`): the PreToolUse
+    // hook denies every tool that is not an allowed nucleus MCP tool, so the
+    // static denylist above is defence in depth rather than the boundary.
+    let settings_path = crate::mediation::write_hook_settings(&tmp_dir)?;
+
     let mut cmd = Command::new(crate::constants::AGENT_CLI_BIN);
     cmd.arg("--mcp-config")
         .arg(&mcp_config_path)
@@ -258,6 +263,9 @@ pub async fn execute(args: ShellArgs) -> Result<()> {
         .arg(allowed_tools.join(","))
         .arg("--disallowedTools")
         .arg(crate::constants::DISALLOWED_BUILTIN_TOOLS)
+        .arg("--settings")
+        .arg(&settings_path)
+        .env(crate::mediation::ALLOWED_TOOLS_ENV, allowed_tools.join(","))
         .env_remove("CLAUDECODE")
         .current_dir(&work_dir);
 


### PR DESCRIPTION
## Summary
- `run` and `shell` bypass the agent's interactive approval, which is safe only under complete mediation. That rested on `DISALLOWED_BUILTIN_TOOLS`, a hardcoded denylist checked only against a second copy of itself; a built-in tool added or renamed after the list was written is reachable unmediated.
- `nucleus` now registers itself as the agent CLI's `PreToolUse` hook (`nucleus mediation-hook`, hidden) through a per-launch `--settings` file, carrying the vetted allowlist in `NUCLEUS_MEDIATION_ALLOWED_TOOLS`. The hook allows a call iff the tool name is exactly a granted nucleus MCP tool and denies everything else, including malformed events and a missing allowlist. Denial is exit status 2, the oldest-supported block contract.
- The static denylist stays as defence in depth; the hook is the boundary. Both launch sites are structurally pinned to install it.
- Vendor-neutral: the hook event is a JSON field and an exit code, the same intrinsic interop class as the existing `--disallowedTools` / `--mcp-config` flags.

## Test plan
- [x] `cargo test -p nucleus-cli` (183 green; 9 new: denylist subsumed, unlisted built-ins denied, exact match, fail-closed parsing, env round-trip, settings shape, both launch sites wired)
- [x] `cargo clippy -p nucleus-cli --all-targets -D warnings`, `cargo fmt --check`
- [x] `scripts/check-mediation.sh`, exemplar scoreboard (mediation-drift 0), line + cast ratchets, `ci/no-vendor-strings.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZaH5waz88vL1qfNpFNfZ4