### PR TITLE
security(node): reputation is observed, never an authorization input; isolation clamp on every pod-create

### DIFF
--- a/crates/nucleus-node/src/driver.rs
+++ b/crates/nucleus-node/src/driver.rs
@@ -1,15 +1,18 @@
 //! Substrate driver seam — which isolation backend a pod runs under.
 //!
 //! The `DriverKind` selected here pairs with a `portcullis::enforcement::
-//! BackendCapability` (chosen in `trust_gate::isolation_backend`), which declares
-//! the isolation levels the backend can enforce and clamps enforced ≥ requested.
+//! BackendCapability` (chosen by [`isolation_backend`]), which declares the
+//! isolation levels the backend can enforce; [`clamp_isolation_to_backend`] clamps
+//! enforced ≥ requested on every pod-create, before admission.
 //! Extracted from `main.rs` so a new substrate is an additive module, not a
 //! growth of the node's already-ratcheted entrypoint.
 
 use crate::{ApiError, DriverState, NodeState};
 use clap::ValueEnum;
-use nucleus_spec::PodSpec;
+use nucleus_spec::{PodSpec, PolicySpec};
+use portcullis::enforcement::{BackendCapability, require_isolation};
 use std::path::{Path, PathBuf};
+use tracing::{error, warn};
 use uuid::Uuid;
 
 /// The isolation substrate the node launches pods under.
@@ -24,7 +27,7 @@ pub(crate) enum DriverKind {
     Container,
     /// Apple Virtualization.framework (macOS-native). Its enforcement capability
     /// is already declared (`BackendCapability::APPLE_VZ`, selected by
-    /// `trust_gate::isolation_backend` for the `apple-vz` backend); the boot
+    /// [`isolation_backend`] for the `apple-vz` backend); the boot
     /// driver is [`spawn_vz_pod`].
     AppleVz,
 }
@@ -51,4 +54,199 @@ pub(crate) async fn spawn_vz_pod(
          — see docs/plugin-surface.md"
             .to_string(),
     ))
+}
+
+/// The isolation backend this node enforces with. Defaults to Firecracker
+/// (Linux/KVM — the full lattice); set `NUCLEUS_ISOLATION_BACKEND=apple-vz` on a
+/// macOS `Virtualization.framework` host so un-enforceable levels (no host
+/// egress allowlist, no namespaces tier) are clamped UP to what VZ delivers.
+pub(crate) fn isolation_backend() -> &'static BackendCapability {
+    match std::env::var("NUCLEUS_ISOLATION_BACKEND").as_deref() {
+        Ok("apple-vz") => &BackendCapability::APPLE_VZ,
+        _ => &BackendCapability::FIRECRACKER,
+    }
+}
+
+/// Clamp the pod's requested isolation posture UP to what this node's backend
+/// can actually enforce, recording requested/enforced/backend in the spec's
+/// labels.
+///
+/// Runs on EVERY pod-create, before admission, so the certificate the node
+/// issues — and therefore the policy every driver runs under — already carries
+/// the enforceable posture: a pod never runs believing it holds a guarantee the
+/// platform does not deliver. Until #2438 this clamp lived inside the trust
+/// gate and ran only when a trust API was configured and enforcing; a node
+/// with no trust API skipped it entirely.
+pub(crate) fn clamp_isolation_to_backend(spec: &mut PodSpec) {
+    clamp_isolation_to(spec, isolation_backend());
+}
+
+/// [`clamp_isolation_to_backend`] against an explicit backend (testable
+/// without the environment).
+pub(crate) fn clamp_isolation_to(spec: &mut PodSpec, backend: &'static BackendCapability) {
+    let lattice = match spec.spec.resolve_policy() {
+        Ok(l) => l,
+        Err(e) => {
+            // Admission resolves the same policy and refuses the spec; nothing
+            // to clamp until there is a lattice.
+            warn!(error = %e, "isolation clamp: policy resolution failed");
+            return;
+        }
+    };
+    let enforced = match require_isolation(lattice.effective_minimum_isolation(), backend) {
+        Ok(enforced) => enforced,
+        Err(err) => {
+            // Unreachable for the built-in backends (their top level is always
+            // enforceable); a misconfigured custom backend could reach here.
+            // Fail safe: keep the requested posture and surface the error
+            // rather than silently under-enforcing.
+            error!(
+                backend = backend.name,
+                error = %err,
+                "isolation clamp: required isolation is unenforceable on this backend"
+            );
+            return;
+        }
+    };
+
+    let labels = &mut spec.metadata.labels;
+    labels.insert(
+        "isolation.coproduct.one/requested".to_string(),
+        enforced.requested.to_string(),
+    );
+    labels.insert(
+        "isolation.coproduct.one/enforced".to_string(),
+        enforced.enforced.to_string(),
+    );
+    labels.insert(
+        "isolation.coproduct.one/backend".to_string(),
+        backend.name.to_string(),
+    );
+
+    if enforced.was_strengthened() {
+        warn!(
+            backend = backend.name,
+            requested = %enforced.requested,
+            enforced = %enforced.enforced,
+            "isolation strengthened to the backend-enforceable posture"
+        );
+        spec.spec.policy = PolicySpec::Inline {
+            lattice: Box::new(lattice.with_minimum_isolation(enforced.enforced)),
+        };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use portcullis::{FileIsolation, IsolationLattice, NetworkIsolation, ProcessIsolation};
+
+    fn spec_with(policy: PolicySpec) -> PodSpec {
+        use nucleus_spec::PodSpecInner;
+        use std::path::PathBuf;
+        PodSpec::new(PodSpecInner {
+            work_dir: PathBuf::from("/workspace"),
+            timeout_seconds: 3600,
+            policy,
+            budget_model: None,
+            resources: None,
+            network: None,
+            image: None,
+            credentialed_egress: Vec::new(),
+            workload: None,
+            vsock: None,
+            seccomp: None,
+            cgroup: None,
+            audit_sink: None,
+            credentials: None,
+        })
+    }
+
+    fn label<'a>(spec: &'a PodSpec, key: &str) -> Option<&'a str> {
+        spec.metadata.labels.get(key).map(String::as_str)
+    }
+
+    /// Firecracker enforces the full lattice: the posture labels are written
+    /// on every pod, the request is faithful, and the policy is untouched.
+    #[test]
+    fn firecracker_is_faithful_and_touches_only_labels() {
+        let mut spec = spec_with(PolicySpec::Profile {
+            name: "default".to_string(),
+        });
+        clamp_isolation_to(&mut spec, &BackendCapability::FIRECRACKER);
+
+        assert_eq!(
+            label(&spec, "isolation.coproduct.one/backend"),
+            Some("firecracker")
+        );
+        assert_eq!(
+            label(&spec, "isolation.coproduct.one/requested"),
+            label(&spec, "isolation.coproduct.one/enforced"),
+            "firecracker enforces the full lattice"
+        );
+        match &spec.spec.policy {
+            PolicySpec::Profile { name } => assert_eq!(name, "default"),
+            PolicySpec::Inline { .. } => panic!("a faithful clamp must not rewrite the policy"),
+        }
+    }
+
+    /// Apple VZ has no host-side egress allowlist: a `Filtered` request is
+    /// strengthened to `Airgapped`, and the policy is rewritten so the pod —
+    /// and the certificate minted from this request — carry the posture the
+    /// backend actually delivers.
+    #[test]
+    fn apple_vz_strengthens_and_rewrites_the_policy() {
+        let requested = spec_with(PolicySpec::Profile {
+            name: "default".to_string(),
+        })
+        .spec
+        .resolve_policy()
+        .expect("default profile resolves")
+        .with_minimum_isolation(IsolationLattice::new(
+            ProcessIsolation::MicroVM,
+            FileIsolation::ReadOnly,
+            NetworkIsolation::Filtered,
+        ));
+        let mut spec = spec_with(PolicySpec::Inline {
+            lattice: Box::new(requested),
+        });
+        clamp_isolation_to(&mut spec, &BackendCapability::APPLE_VZ);
+
+        assert_eq!(
+            label(&spec, "isolation.coproduct.one/backend"),
+            Some("apple-vz")
+        );
+        assert_ne!(
+            label(&spec, "isolation.coproduct.one/requested"),
+            label(&spec, "isolation.coproduct.one/enforced"),
+            "the strengthening is recorded"
+        );
+        match &spec.spec.policy {
+            PolicySpec::Inline { lattice } => assert_eq!(
+                lattice.effective_minimum_isolation().network,
+                NetworkIsolation::Airgapped,
+                "Filtered is not enforceable on VZ; clamped up, never down"
+            ),
+            PolicySpec::Profile { .. } => panic!("a strengthened clamp must rewrite the policy"),
+        }
+    }
+
+    /// The clamp is unconditional and precedes admission (#2438): it sits at
+    /// the top level of `create_pod_internal`, not inside the trust-gate branch.
+    #[test]
+    fn the_clamp_is_wired_before_admission_unconditionally() {
+        let main = include_str!("main.rs");
+        let clamp = main
+            .find("driver::clamp_isolation_to_backend(&mut spec)")
+            .expect("the clamp is called from main.rs");
+        let admit = main
+            .find("state.authority.admit(&admission, &spec, id)")
+            .expect("admission is called from main.rs");
+        assert!(clamp < admit, "the clamp must run before admission");
+        let indent = main[..clamp].rsplit('\n').next().unwrap_or("");
+        assert_eq!(
+            indent, "    ",
+            "the clamp must be at function-body level, not under a condition"
+        );
+    }
 }

--- a/crates/nucleus-node/src/main.rs
+++ b/crates/nucleus-node/src/main.rs
@@ -1157,11 +1157,11 @@ async fn create_pod_internal(
     tracing::Span::current().record("pod_id", tracing::field::display(id));
     let created_at = now_unix();
 
-    // ── Trust Gate: verify agent reputation, scope permissions ──────
+    // ── Backend clamp, then the trust gate. Since #2438 the gate only OBSERVES
+    // reputation; what the pod MAY do comes from the certificate below. ──────
+    driver::clamp_isolation_to_backend(&mut spec);
     if state.trust_gate.is_enabled() {
-        let mut verification =
-            trust_gate::verify_agent_trust(&state.trust_gate, &spec, &state.http_client).await;
-        trust_gate::apply_trust_enforcement(&mut verification, &mut spec);
+        trust_gate::observe(&state.trust_gate, &mut spec, &state.http_client).await;
     }
 
     let pod_dir = state.state_dir.join("pods").join(id.to_string());

--- a/crates/nucleus-node/src/trust_gate.rs
+++ b/crates/nucleus-node/src/trust_gate.rs
@@ -1,22 +1,22 @@
-//! Trust Gate — verifies agent attestations against Coproduct Trust API
-//! and derives permission scoping from reputation brackets.
+//! Trust Gate — verifies agent attestations against the Coproduct Trust API
+//! and records the resulting reputation on the pod. **Observational only.**
 //!
-//! Injected into `create_pod_internal()` to scope sandbox permissions
-//! based on the agent's demonstrated reputation. Agents with higher
-//! reputation get broader capabilities; unknown or low-reputation agents
-//! get restricted sandboxes.
+//! Reputation is not a capability check (#2438). What a pod MAY do is decided
+//! once, from the caller's certificate, in `pod_authority::PodAuthority::admit`;
+//! this module never reads or writes the pod's policy. It also owns the node's
+//! role-separated signing keys and the executor's receipt reporting, which
+//! are unrelated to reputation and unaffected by that change.
 //!
 //! # Flow
 //!
 //! ```text
-//! PodSpec arrives
+//! PodSpec arrives (create_pod_internal, before admission)
 //!   → extract agent identity from metadata labels
 //!   → call POST trust_api_url/api/trust/verify (if attestation JWT present)
 //!   → or call POST trust_api_url/api/trust/discount (identity lookup)
 //!   → map bracket → bracket_to_profile()
-//!   → TrustProfile::enforce() on requested permissions
-//!   → log enforcement result
-//!   → return scoped PodSpec
+//!   → record bracket / profile / score as metadata labels; log
+//!   → the spec's policy is untouched
 //! ```
 
 use std::path::Path;
@@ -26,21 +26,17 @@ use base64::Engine as _;
 use ed25519_dalek::pkcs8::{DecodePrivateKey as _, EncodePrivateKey as _};
 use ed25519_dalek::{Signer as _, SigningKey};
 use hmac::{Hmac, Mac, digest::KeyInit};
-use nucleus_spec::{PodSpec, PolicySpec};
-use portcullis::enforcement::{BackendCapability, require_isolation};
-use portcullis::{IsolationLattice, PermissionLattice, TrustProfile};
+use nucleus_spec::PodSpec;
 
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, info, warn};
 
 /// Configuration for the trust gate.
 #[derive(Debug, Clone)]
 pub struct TrustGateConfig {
     /// URL of the Coproduct Trust API (e.g., "https://trust.coproduct.one")
     pub trust_api_url: String,
-    /// Whether to enforce trust profiles (false = log-only mode)
-    pub enforce: bool,
     /// Default bracket for agents without attestations
     pub default_bracket: String,
     /// HMAC-SHA256 key for signing X-Nucleus-Signature on receipt POSTs.
@@ -70,7 +66,6 @@ impl Default for TrustGateConfig {
     fn default() -> Self {
         Self {
             trust_api_url: String::new(),     // Disabled by default
-            enforce: false,                   // Log-only by default
             default_bracket: "C".to_string(), // Adequate — tenant profile
             receipt_secret: None,
             executor_signing_key: Arc::new(generate_signing_key()),
@@ -276,9 +271,6 @@ impl TrustGateConfig {
 
         Self {
             trust_api_url: std::env::var("TRUST_API_URL").unwrap_or_default(),
-            enforce: std::env::var("TRUST_GATE_ENFORCE")
-                .map(|v| v == "true" || v == "1")
-                .unwrap_or(false),
             default_bracket: std::env::var("TRUST_DEFAULT_BRACKET")
                 .unwrap_or_else(|_| "C".to_string()),
             receipt_secret,
@@ -301,17 +293,14 @@ pub struct TrustVerification {
     pub agent_identity: String,
     /// Attestation bracket (A-F)
     pub bracket: String,
-    /// Trust profile name derived from bracket
+    /// Trust profile name derived from bracket (a label, not a policy)
     pub profile_name: String,
-    /// Whether permissions were actually restricted
-    pub was_restricted: bool,
-    /// Whether enforcement is active (vs log-only)
-    pub enforced: bool,
     /// Continuous reputation score in [0.0, 1.0] when available from the
     /// discount endpoint. Preserves full precision of the discount_factor
     /// rather than double-discretizing through bracket → score bracket mapping.
-    /// Falls back to bracket-derived discrete values in apply_trust_enforcement
-    /// when None (e.g., when score was derived from an attestation JWT).
+    /// Falls back to bracket-derived discrete values in
+    /// `record_trust_observation` when None (e.g., when the score was derived
+    /// from an attestation JWT).
     pub continuous_score: Option<f64>,
 }
 
@@ -345,7 +334,7 @@ struct Brackets {
     overall: String,
 }
 
-/// Verify an agent's trust status and return the appropriate TrustProfile.
+/// Verify an agent's trust status and return the observation to record.
 ///
 /// If the trust API is unreachable or returns an error, falls back to
 /// the default bracket (never blocks execution due to trust API failure).
@@ -406,7 +395,6 @@ pub async fn verify_agent_trust(
         bracket = %bracket,
         profile = %profile_name,
         continuous_score = ?continuous_score,
-        enforce = config.enforce,
         "Trust gate: agent verified"
     );
 
@@ -414,25 +402,22 @@ pub async fn verify_agent_trust(
         agent_identity,
         bracket,
         profile_name,
-        was_restricted: false, // Updated after apply_trust_enforcement() is called
-        enforced: config.enforce,
         continuous_score,
     }
 }
 
-/// Apply the trust profile to a PodSpec, scoping permissions.
+/// Record the trust observation on the PodSpec as metadata labels.
 ///
-/// Computes a `TrustProfile` from the continuous reputation score via
-/// `TrustProfile::from_reputation_score()`, then calls `profile.enforce()` to
-/// actually restrict the PodSpec's capability lattice before it is submitted to
-/// the runtime. In enforce mode the PodSpec policy is replaced with an inline
-/// lattice containing the enforced capabilities/isolation/obligations.
-/// In log-only mode the restriction is computed and logged but not applied.
-pub fn apply_trust_enforcement(verification: &mut TrustVerification, spec: &mut PodSpec) {
-    // Use the continuous discount-derived score when available — it preserves
-    // the full resolution of the trust API's discount_factor without the
-    // lossy double-discretization of discount_factor → bracket → score.
-    // Fall back to bracket-derived values for attestation-JWT paths.
+/// This is the whole of what reputation does to a pod (#2438): the bracket,
+/// the profile name and the score are written as labels for dashboards,
+/// receipts and audit, and logged. **Nothing about the pod's authority is
+/// touched.** What a pod MAY do is decided once, from the caller's
+/// certificate, in `pod_authority::PodAuthority::admit`; a score from an
+/// external service is not a capability check and must never narrow — or,
+/// by being absent, fail to narrow — what that certificate grants.
+pub fn record_trust_observation(verification: &TrustVerification, spec: &mut PodSpec) {
+    // Continuous discount-derived score when available; bracket-derived
+    // otherwise (attestation-JWT paths). Observability only.
     let reputation_score =
         verification
             .continuous_score
@@ -444,163 +429,41 @@ pub fn apply_trust_enforcement(verification: &mut TrustVerification, spec: &mut 
                 _ => 0.2,
             });
 
-    // Write metadata labels for downstream observability and auditing.
-    spec.metadata.labels.insert(
+    let labels = &mut spec.metadata.labels;
+    labels.insert(
         "trust.coproduct.one/bracket".to_string(),
         verification.bracket.clone(),
     );
-    spec.metadata.labels.insert(
+    labels.insert(
         "trust.coproduct.one/profile".to_string(),
         verification.profile_name.clone(),
     );
-    spec.metadata.labels.insert(
-        "trust.coproduct.one/enforced".to_string(),
-        verification.enforced.to_string(),
-    );
-    spec.metadata.labels.insert(
+    labels.insert(
         "trust.coproduct.one/reputation-score".to_string(),
         format!("{reputation_score:.4}"),
     );
 
-    // Resolve the PodSpec's requested policy to get the current capability lattice.
-    let current_lattice = match spec.spec.resolve_policy() {
-        Ok(l) => l,
-        Err(e) => {
-            warn!(
-                agent = %verification.agent_identity,
-                error = %e,
-                "Trust gate: policy resolution failed, skipping enforcement"
-            );
-            return;
-        }
-    };
-
-    // Derive the trust profile from the continuous reputation score.
-    // This uses smooth thresholds and transition zones — no discrete cliffs.
-    let profile = TrustProfile::from_reputation_score(reputation_score);
-
-    // Use the existing minimum_isolation as the baseline; default to localhost
-    // (no pre-existing isolation requirement) so the profile floor can only
-    // strengthen, never weaken, the required isolation.
-    let current_isolation = current_lattice
-        .minimum_isolation
-        .unwrap_or_else(IsolationLattice::localhost);
-
-    // Enforce: capabilities ← meet(current, ceiling)
-    //          isolation   ← join(current, floor)
-    //          obligations ← union(current, mandatory)
-    let enforcement = profile.enforce(
-        &current_lattice.capabilities,
-        &current_isolation,
-        &current_lattice.obligations,
+    info!(
+        agent = %verification.agent_identity,
+        bracket = %verification.bracket,
+        profile = %verification.profile_name,
+        score = reputation_score,
+        "Trust gate: reputation observed (not an authorization input)"
     );
-
-    verification.was_restricted = enforcement.was_restricted;
-
-    if enforcement.was_restricted {
-        info!(
-            agent = %verification.agent_identity,
-            profile = %enforcement.profile_name,
-            score = reputation_score,
-            enforced = verification.enforced,
-            "Trust gate: sandbox capabilities restricted by reputation profile"
-        );
-    }
-
-    // ── Backend-enforceability gate ──────────────────────────────────────
-    // The trust profile chose a REQUIRED isolation posture (join of the pod's
-    // current isolation with the profile floor). Clamp it to what THIS node's
-    // backend can actually enforce: on Firecracker this is the full lattice (a
-    // no-op); on a host that can't enforce a level (e.g. Apple VZ exposes no
-    // host-side egress allowlist) the posture is strengthened UP — never
-    // weakened — and the gap is recorded. The sandbox is then configured from
-    // the ENFORCED posture, so a pod never runs believing it has a guarantee
-    // the platform doesn't actually deliver.
-    let backend = isolation_backend();
-    let isolation = match require_isolation(enforcement.isolation, backend) {
-        Ok(enforced) => {
-            spec.metadata.labels.insert(
-                "isolation.coproduct.one/requested".to_string(),
-                enforced.requested.to_string(),
-            );
-            spec.metadata.labels.insert(
-                "isolation.coproduct.one/enforced".to_string(),
-                enforced.enforced.to_string(),
-            );
-            spec.metadata.labels.insert(
-                "isolation.coproduct.one/backend".to_string(),
-                backend.name.to_string(),
-            );
-            if enforced.was_strengthened() {
-                warn!(
-                    agent = %verification.agent_identity,
-                    backend = backend.name,
-                    requested = %enforced.requested,
-                    enforced = %enforced.enforced,
-                    "Trust gate: isolation strengthened to the backend-enforceable posture"
-                );
-            }
-            enforced.enforced
-        }
-        Err(err) => {
-            // Unreachable for the built-in backends (their top level is always
-            // enforceable), but a misconfigured custom backend could reach here.
-            // Fail safe: keep the strongest posture available — the requested
-            // one — and surface the error rather than silently under-enforcing.
-            error!(
-                agent = %verification.agent_identity,
-                backend = backend.name,
-                error = %err,
-                "Trust gate: required isolation is unenforceable on this backend"
-            );
-            enforcement.isolation
-        }
-    };
-    let isolation_strengthened = isolation != enforcement.isolation;
-
-    // In enforce mode, apply the scoped policy to the PodSpec so the runtime
-    // sees the narrowed capabilities + the backend-enforceable isolation before
-    // launching the sandbox. Rewrite whenever the profile restricted the pod OR
-    // the backend clamp strengthened the isolation posture.
-    // In log-only mode we've computed the restriction for audit purposes only.
-    if verification.enforced && (enforcement.was_restricted || isolation_strengthened) {
-        let enforced_lattice = PermissionLattice::builder()
-            .description(format!(
-                "trust-scoped by {} (score={:.4})",
-                enforcement.profile_name, reputation_score
-            ))
-            .capabilities(enforcement.capabilities)
-            .obligations(enforcement.obligations)
-            .paths(current_lattice.paths.clone())
-            .budget(current_lattice.budget.clone())
-            .commands(current_lattice.commands.clone())
-            .time(current_lattice.time.clone())
-            .minimum_isolation(isolation)
-            .created_by("trust-gate")
-            .build();
-
-        spec.spec.policy = PolicySpec::Inline {
-            lattice: Box::new(enforced_lattice),
-        };
-    }
 }
 
-/// The isolation backend this node enforces with. Defaults to Firecracker
-/// (Linux/KVM — the full lattice); set `NUCLEUS_ISOLATION_BACKEND=apple-vz` on a
-/// macOS `Virtualization.framework` host so the trust gate clamps un-enforceable
-/// levels (no host egress allowlist, no namespaces tier) UP to what VZ delivers.
-fn isolation_backend() -> &'static BackendCapability {
-    match std::env::var("NUCLEUS_ISOLATION_BACKEND").as_deref() {
-        Ok("apple-vz") => &BackendCapability::APPLE_VZ,
-        _ => &BackendCapability::FIRECRACKER,
-    }
+/// Look the agent up and record the observation on the spec. The one call
+/// site is `create_pod_internal`, before admission; the pod's authority is
+/// unaffected.
+pub async fn observe(config: &TrustGateConfig, spec: &mut PodSpec, http_client: &reqwest::Client) {
+    let verification = verify_agent_trust(config, spec, http_client).await;
+    record_trust_observation(&verification, spec);
 }
 
-/// Map attestation bracket to portcullis trust profile name.
+/// Map attestation bracket to a portcullis trust profile NAME.
 ///
-/// Used for logging and metadata labels. The actual permission scoping
-/// uses `TrustProfile::from_reputation_score()` for continuous lattice
-/// autonomy (no discrete brackets in enforcement).
+/// Used for logging and metadata labels only. No profile is applied to the
+/// pod (#2438); the name is a coarse summary for dashboards and receipts.
 fn bracket_to_profile(bracket: &str) -> &'static str {
     match bracket.to_uppercase().as_str() {
         "A" => "operator",
@@ -1729,7 +1592,6 @@ mod tests {
     fn test_config_from_env_defaults() {
         let config = TrustGateConfig::default();
         assert!(!config.is_enabled());
-        assert!(!config.enforce);
         assert_eq!(config.default_bracket, "C");
     }
 
@@ -1900,7 +1762,6 @@ mod tests {
         let secret_bytes = b"my-receipt-secret-32-bytes-long!!";
         let config = TrustGateConfig {
             trust_api_url: "https://trust.example.com".to_string(),
-            enforce: true,
             default_bracket: "C".to_string(),
             receipt_secret: Some(Arc::new(secret_bytes.to_vec())),
             ..Default::default()
@@ -2026,17 +1887,14 @@ mod tests {
         assert!(compute_session_score(&best) <= 1.0);
     }
 
-    /// Verify apply_trust_enforcement writes all expected metadata labels.
-    #[test]
-    fn test_apply_trust_enforcement_writes_labels() {
+    fn spec_with_profile(name: &str) -> PodSpec {
         use nucleus_spec::{PodSpecInner, PolicySpec};
         use std::path::PathBuf;
-
-        let spec_inner = PodSpecInner {
+        PodSpec::new(PodSpecInner {
             work_dir: PathBuf::from("/workspace"),
             timeout_seconds: 3600,
             policy: PolicySpec::Profile {
-                name: "default".to_string(),
+                name: name.to_string(),
             },
             budget_model: None,
             resources: None,
@@ -2049,239 +1907,88 @@ mod tests {
             cgroup: None,
             audit_sink: None,
             credentials: None,
-        };
-        let mut spec = PodSpec::new(spec_inner);
+        })
+    }
 
-        let mut verification = TrustVerification {
+    fn verified_as(bracket: &str, profile: &str, score: Option<f64>) -> TrustVerification {
+        TrustVerification {
             agent_identity: "spiffe://nucleus/test".to_string(),
-            bracket: "D".to_string(),
-            profile_name: "untrusted".to_string(),
-            was_restricted: false,
-            enforced: false, // log-only — spec must not be modified
-            continuous_score: None,
-        };
+            bracket: bracket.to_string(),
+            profile_name: profile.to_string(),
+            continuous_score: score,
+        }
+    }
 
-        apply_trust_enforcement(&mut verification, &mut spec);
+    /// The observation is recorded as labels: bracket, profile and score.
+    /// There is no `enforced` label any more — there is nothing to enforce.
+    #[test]
+    fn test_record_trust_observation_writes_labels() {
+        let mut spec = spec_with_profile("default");
+        record_trust_observation(&verified_as("D", "untrusted", None), &mut spec);
 
+        let labels = &spec.metadata.labels;
         assert_eq!(
-            spec.metadata
-                .labels
+            labels
                 .get("trust.coproduct.one/bracket")
                 .map(String::as_str),
             Some("D")
         );
         assert_eq!(
-            spec.metadata
-                .labels
+            labels
                 .get("trust.coproduct.one/profile")
                 .map(String::as_str),
             Some("untrusted")
         );
-        assert!(
-            spec.metadata
-                .labels
-                .contains_key("trust.coproduct.one/reputation-score"),
-            "reputation-score label must be written"
-        );
         assert_eq!(
-            spec.metadata
-                .labels
-                .get("trust.coproduct.one/enforced")
+            labels
+                .get("trust.coproduct.one/reputation-score")
                 .map(String::as_str),
-            Some("false")
+            Some("0.4500")
+        );
+        assert!(
+            !labels.contains_key("trust.coproduct.one/enforced"),
+            "no enforcement label: reputation is observed, not enforced (#2438)"
         );
     }
 
-    /// The enforcement gate is wired into the runtime: `apply_trust_enforcement`
-    /// clamps the required isolation through the node's backend and records the
-    /// requested/enforced/backend posture. On the default Firecracker backend
-    /// the full lattice is enforceable, so `enforced == requested`. (Apple-VZ
-    /// strengthening is covered by `portcullis::enforcement`'s unit tests.)
+    /// #2438: the lowest reputation against the most permissive profile leaves
+    /// the policy exactly as requested. Before this change a score of 0.45
+    /// against `local_dev` rewrote the policy to an inline lattice with
+    /// `write_files = Never`; authority now comes only from the certificate
+    /// (`pod_authority`), so a score can neither narrow nor fail to narrow it.
     #[test]
-    fn test_apply_trust_enforcement_records_backend_isolation() {
-        use nucleus_spec::{PodSpecInner, PolicySpec};
-        use std::path::PathBuf;
+    fn test_reputation_never_narrows_the_policy() {
+        use nucleus_spec::PolicySpec;
 
-        let spec_inner = PodSpecInner {
-            work_dir: PathBuf::from("/workspace"),
-            timeout_seconds: 3600,
-            policy: PolicySpec::Profile {
-                name: "default".to_string(),
-            },
-            budget_model: None,
-            resources: None,
-            network: None,
-            image: None,
-            credentialed_egress: Vec::new(),
-            workload: None,
-            vsock: None,
-            seccomp: None,
-            cgroup: None,
-            audit_sink: None,
-            credentials: None,
-        };
-        let mut spec = PodSpec::new(spec_inner);
-        let mut verification = TrustVerification {
-            agent_identity: "spiffe://nucleus/test".to_string(),
-            bracket: "A".to_string(),
-            profile_name: "trusted".to_string(),
-            was_restricted: false,
-            enforced: true,
-            continuous_score: None,
-        };
+        let mut spec = spec_with_profile("local_dev");
+        record_trust_observation(&verified_as("F", "airgapped", Some(0.0)), &mut spec);
 
-        apply_trust_enforcement(&mut verification, &mut spec);
-
-        let backend = spec
-            .metadata
-            .labels
-            .get("isolation.coproduct.one/backend")
-            .cloned()
-            .expect("backend label must be written");
-        let requested = spec
-            .metadata
-            .labels
-            .get("isolation.coproduct.one/requested")
-            .cloned();
-        let enforced = spec
-            .metadata
-            .labels
-            .get("isolation.coproduct.one/enforced")
-            .cloned();
-        assert!(
-            requested.is_some() && enforced.is_some(),
-            "requested/enforced isolation labels must be written"
-        );
-        // Firecracker (the default, no env override) enforces the full lattice,
-        // so the enforced posture is faithful to the requested one.
-        if backend == "firecracker" {
-            assert_eq!(requested, enforced, "firecracker enforces the full lattice");
+        match &spec.spec.policy {
+            PolicySpec::Profile { name } => assert_eq!(name, "local_dev"),
+            PolicySpec::Inline { .. } => panic!("reputation rewrote the policy"),
         }
     }
 
-    /// Verify apply_trust_enforcement replaces the PodSpec policy in enforce mode
-    /// when the requested capabilities exceed the reputation profile.
+    /// Structural pin for #2438's acceptance criterion: no production code in
+    /// this module assigns the pod's policy, consults a trust profile, or
+    /// clamps isolation. Only the test half of the file may name these.
     #[test]
-    fn test_apply_trust_enforcement_scopes_policy_in_enforce_mode() {
-        use nucleus_spec::{PodSpecInner, PolicySpec};
-        use std::path::PathBuf;
-
-        // Start with the permissive "local_dev" profile and a low-reputation agent.
-        // The agent's score (0.45 for bracket D) should restrict write/bash/push.
-        let spec_inner = PodSpecInner {
-            work_dir: PathBuf::from("/workspace"),
-            timeout_seconds: 3600,
-            policy: PolicySpec::Profile {
-                name: "local_dev".to_string(),
-            },
-            budget_model: None,
-            resources: None,
-            network: None,
-            image: None,
-            credentialed_egress: Vec::new(),
-            workload: None,
-            vsock: None,
-            seccomp: None,
-            cgroup: None,
-            audit_sink: None,
-            credentials: None,
-        };
-        let mut spec = PodSpec::new(spec_inner);
-
-        let mut verification = TrustVerification {
-            agent_identity: "spiffe://nucleus/low-trust".to_string(),
-            bracket: "D".to_string(),
-            profile_name: "untrusted".to_string(),
-            was_restricted: false,
-            enforced: true, // enforce mode — policy must be replaced
-            continuous_score: Some(0.45),
-        };
-
-        apply_trust_enforcement(&mut verification, &mut spec);
-
-        // was_restricted should be set because local_dev is more permissive than score 0.45 allows
-        assert!(
-            verification.was_restricted,
-            "low-reputation agent against permissive profile must be restricted"
-        );
-
-        // The policy should now be an inline lattice
-        match &spec.spec.policy {
-            PolicySpec::Inline { lattice } => {
-                // Score 0.45: write_files threshold is 0.5 → Never
-                use portcullis::CapabilityLevel;
-                assert_eq!(
-                    lattice.capabilities.write_files,
-                    CapabilityLevel::Never,
-                    "write_files must be blocked at score 0.45"
-                );
-                // run_bash threshold is 0.6 → Never
-                assert_eq!(
-                    lattice.capabilities.run_bash,
-                    CapabilityLevel::Never,
-                    "run_bash must be blocked at score 0.45"
-                );
-                // read_files is always allowed
-                assert_eq!(
-                    lattice.capabilities.read_files,
-                    CapabilityLevel::Always,
-                    "read_files must always be allowed"
-                );
-            }
-            PolicySpec::Profile { name } => {
-                panic!("policy was not replaced with inline lattice; still Profile({name:?})");
-            }
-        }
-    }
-
-    /// Verify apply_trust_enforcement does NOT modify the policy in log-only mode.
-    #[test]
-    fn test_apply_trust_enforcement_log_only_does_not_modify_policy() {
-        use nucleus_spec::{PodSpecInner, PolicySpec};
-        use std::path::PathBuf;
-
-        let spec_inner = PodSpecInner {
-            work_dir: PathBuf::from("/workspace"),
-            timeout_seconds: 3600,
-            policy: PolicySpec::Profile {
-                name: "fix_issue".to_string(),
-            },
-            budget_model: None,
-            resources: None,
-            network: None,
-            image: None,
-            credentialed_egress: Vec::new(),
-            workload: None,
-            vsock: None,
-            seccomp: None,
-            cgroup: None,
-            audit_sink: None,
-            credentials: None,
-        };
-        let mut spec = PodSpec::new(spec_inner);
-
-        let mut verification = TrustVerification {
-            agent_identity: "spiffe://nucleus/test".to_string(),
-            bracket: "F".to_string(),
-            profile_name: "airgapped".to_string(),
-            was_restricted: false,
-            enforced: false, // log-only
-            continuous_score: Some(0.1),
-        };
-
-        apply_trust_enforcement(&mut verification, &mut spec);
-
-        // Policy must remain unchanged in log-only mode
-        match &spec.spec.policy {
-            PolicySpec::Profile { name } => {
-                assert_eq!(
-                    name, "fix_issue",
-                    "policy profile must not be mutated in log-only mode"
-                );
-            }
-            PolicySpec::Inline { .. } => {
-                panic!("policy must not be replaced in log-only mode");
-            }
+    fn test_trust_gate_has_no_authorization_path() {
+        let src = include_str!("trust_gate.rs");
+        let production = src
+            .split("#[cfg(test)]")
+            .next()
+            .expect("the module has a test half");
+        for needle in [
+            "spec.spec.policy =",
+            "TrustProfile",
+            "require_isolation",
+            "TRUST_GATE_ENFORCE",
+        ] {
+            assert!(
+                !production.contains(needle),
+                "trust_gate.rs must not contain {needle:?} outside its tests"
+            );
         }
     }
 

--- a/docs/plugin-surface.md
+++ b/docs/plugin-surface.md
@@ -12,8 +12,8 @@ exactly where a vendor slots in, and so no vendor is ever hard-coded in the core
 Each axis below is **a trait or enum with ≥1 shipped implementation and room for
 more**. Where a seam is a *trust or isolation* boundary, it carries a
 **clamp**: the kernel never trusts a backend's self-description upward — a weaker
-backend cannot claim a stronger guarantee (e.g. `trust_gate` auto-clamps enforced
-isolation ≥ requested; `not_proven` makes over-reading an attestation unsayable).
+backend cannot claim a stronger guarantee (e.g. the node's `driver::clamp_isolation_to_backend`
+clamps enforced isolation ≥ requested on every pod-create; `not_proven` makes over-reading an attestation unsayable).
 
 ## The eight axes
 
@@ -96,7 +96,7 @@ fills each axis.
 Apple Virtualization.framework is the macOS-native isolation substrate. The VZ
 substrate is additive behind two existing seams, and **the enforcement half is
 already wired**: `BackendCapability::APPLE_VZ` is defined and tested in
-`portcullis::enforcement`, and `trust_gate::isolation_backend()` already selects
+`portcullis::enforcement`, and `driver::isolation_backend()` already selects
 it when the node runs the `apple-vz` backend (so `require_isolation` clamps a
 VZ pod's enforced isolation exactly as it does a Firecracker pod's). Its
 attested-mediator key comes from axis 2's Apple/SEP backend.


### PR DESCRIPTION
Closes #2438 (epic #2425's last open sub-issue).

### What was wrong, verified on `main`
- `create_pod_internal` called `trust_gate::apply_trust_enforcement` **before** admission when a trust API was configured. In enforce mode it rewrote the requested policy to an inline lattice meet-clamped by a `TrustProfile` derived from an external reputation score; disabled (the default) it did nothing. Either way an external score was an input to what the pod may do — or its absence a reason not to narrow. Since #2464 that decision belongs to the caller's certificate alone.
- The backend-enforceability clamp (`require_isolation` against `BackendCapability`) lived inside that same function, so it ran only when a trust API was configured **and** enforcing. A node with no trust API — every default deployment — never clamped: a pod on a backend that cannot deliver a requested isolation level ran believing it had it.

### The change
- **Trust gate is observational.** `record_trust_observation` writes the bracket / profile / score labels and logs. It does not read or write the policy. `apply_trust_enforcement`, the `enforce` field, `TRUST_GATE_ENFORCE`, `TrustVerification::{was_restricted, enforced}` and the `trust.coproduct.one/enforced` label are removed (no consumer in the tree). `trust_gate::observe` is the single entry point from `create_pod_internal`.
- **Isolation clamp moves to the driver seam and is unconditional.** `driver::clamp_isolation_to_backend` runs on every pod-create, before `PodAuthority::admit`, so the certificate the node issues — and the policy every driver runs under — already carries the enforceable posture. Faithful request: labels only, policy untouched. Strengthened request (Apple VZ, `Filtered → Airgapped`): the policy is rewritten with the stronger minimum isolation, exactly what the old enforce path did, now for everyone.
- Nothing else in `trust_gate.rs` (role-separated keys, receipt reporting, Article 12 attestation) is touched.

### Tests (411 green in `nucleus-node`, both feature sets)
- `test_reputation_never_narrows_the_policy`: score 0.0 / bracket F against `local_dev` leaves the policy as requested — the inverse of the deleted `scopes_policy_in_enforce_mode` test.
- `test_trust_gate_has_no_authorization_path`: structural, over the production half of `trust_gate.rs` — no `spec.spec.policy =`, no `TrustProfile`, no `require_isolation`, no `TRUST_GATE_ENFORCE`. This is the issue's acceptance criterion, made greppable.
- `the_clamp_is_wired_before_admission_unconditionally`: structural, over `main.rs` — the clamp precedes `authority.admit` and sits at function-body indentation, not under a branch.
- `firecracker_is_faithful_and_touches_only_labels`, `apple_vz_strengthens_and_rewrites_the_policy`: the clamp against each built-in backend explicitly, no env dependence.

### Verification
`cargo test -p nucleus-node --features local-driver` · `cargo clippy -p nucleus-node --all-targets -- -D warnings` (with and without `local-driver`) · `cargo fmt --check` · `scripts/check-line-ratchet.sh --strict` (`main.rs` 4044, unchanged) · `ci/no-vendor-strings.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZaH5waz88vL1qfNpFNfZ4
