### PR TITLE
audit(delegation): Article 12 records name the certificate they were decided under; node refuses mismatches; container pods keep a log

### DIFF
--- a/crates/nucleus-audit/src/main.rs
+++ b/crates/nucleus-audit/src/main.rs
@@ -251,6 +251,10 @@ enum Command {
         /// The executor's Ed25519 public key, hex-encoded (32 bytes).
         #[arg(long, requires = "attestation")]
         executor_pubkey: Option<String>,
+        /// Require every record to be decided under this certificate fingerprint
+        /// (hex): the pod's `fingerprint` in the node's `authority.json` (#2437).
+        #[arg(long)]
+        authority_fingerprint: Option<String>,
     },
     /// Verify a log of signed MediationReceipts and render a scoreboard.
     ///
@@ -642,27 +646,20 @@ fn main() -> Result<(), AuditError> {
             json,
             attestation,
             executor_pubkey,
+            authority_fingerprint,
         } => {
             let mut report =
                 verify_art12::verify_art12_log(&log, secret.as_ref().map(|s| s.as_bytes()))?;
+            verify_art12::apply_authority_requirement(
+                &mut report,
+                authority_fingerprint.as_deref(),
+            )?;
 
             if let (Some(att_path), Some(pubkey_hex)) = (attestation, executor_pubkey) {
                 let att: portcullis::art12_record::Art12Attestation =
                     serde_json::from_str(&std::fs::read_to_string(&att_path)?)
                         .map_err(|e| AuditError::Json { line: 0, source: e })?;
-                let key_bytes: [u8; 32] = hex::decode(&pubkey_hex)
-                    .ok()
-                    .and_then(|v| v.try_into().ok())
-                    .ok_or_else(|| AuditError::Invalid {
-                        line: 0,
-                        message: "--executor-pubkey must be 32 hex-encoded bytes".to_string(),
-                    })?;
-                let key = ed25519_dalek::VerifyingKey::from_bytes(&key_bytes).map_err(|_| {
-                    AuditError::Invalid {
-                        line: 0,
-                        message: "--executor-pubkey is not a valid Ed25519 public key".to_string(),
-                    }
-                })?;
+                let key = verify_art12::executor_pubkey_from_hex(&pubkey_hex)?;
                 verify_art12::check_attestation(&att, &report.chain_head, &key)?;
                 report.attestation_checked = true;
                 report

--- a/crates/nucleus-audit/src/verify_art12.rs
+++ b/crates/nucleus-audit/src/verify_art12.rs
@@ -64,6 +64,13 @@ pub struct Art12Report {
     pub signatures_checked: bool,
     /// Whether an executor attestation was checked against the computed head.
     pub attestation_checked: bool,
+    /// How many records name the certificate they were decided under
+    /// (`authority.fingerprint`, #2437). A pod created since the certificate
+    /// convergence binds every record; a shortfall is listed as a limitation.
+    pub authority_bound: u64,
+    /// The distinct certificate fingerprints named, in first-seen order. One
+    /// per session is the expected shape: a pod holds one certificate.
+    pub authority_fingerprints: Vec<String>,
     /// What this run did NOT establish. Never empty.
     pub limitations: Vec<String>,
 }
@@ -181,6 +188,8 @@ pub fn verify_art12_log(path: &Path, secret: Option<&[u8]>) -> Result<Art12Repor
         verdicts: BTreeMap::new(),
         signatures_checked: secret.is_some(),
         attestation_checked: false,
+        authority_bound: 0,
+        authority_fingerprints: Vec::new(),
         limitations: base_limitations(secret.is_some()),
     };
 
@@ -256,6 +265,12 @@ pub fn verify_art12_log(path: &Path, secret: Option<&[u8]>) -> Result<Art12Repor
         }
 
         report.records += 1;
+        if let Some(fp) = rec.authority_fingerprint() {
+            report.authority_bound += 1;
+            if !report.authority_fingerprints.iter().any(|f| f == fp) {
+                report.authority_fingerprints.push(fp.to_string());
+            }
+        }
         report.first_timestamp.get_or_insert(rec.timestamp_unix);
         report.last_timestamp = Some(rec.timestamp_unix);
         if rec.actor.spiffe_id.as_ref().is_some_and(|s| !s.is_empty()) {
@@ -268,9 +283,95 @@ pub fn verify_art12_log(path: &Path, secret: Option<&[u8]>) -> Result<Art12Repor
     }
 
     report.chain_head = prev_hash.unwrap_or_default();
+    if report.authority_bound < report.records {
+        report.limitations.push(format!(
+            "{} of {} records name no authority (no `authority.fingerprint`): they cannot be tied \
+             to the certificate — and so the root key — that authorized the deciding kernel. \
+             Expected only for pods created before the node issued certificates.",
+            report.records - report.authority_bound,
+            report.records
+        ));
+    }
     Ok(report)
 }
 
+/// Require every record to have been decided under exactly `expected_hex` —
+/// the fingerprint of the certificate the node issued this pod (from its
+/// `pods/<id>/authority.json`). This is what ties a log to the root public
+/// key with no side channel: the node verified that chain against its root
+/// when it issued it, and every record here names it inside the signed
+/// preimage.
+///
+/// # Errors
+/// If any record names no authority, or any names a different one.
+pub fn require_authority(report: &Art12Report, expected_hex: &str) -> Result<(), AuditError> {
+    if report.authority_bound != report.records {
+        return Err(AuditError::Invalid {
+            line: 0,
+            message: format!(
+                "{} of {} records name no authority; --authority-fingerprint requires every record \
+                 to be bound",
+                report.records - report.authority_bound,
+                report.records
+            ),
+        });
+    }
+    let expected = expected_hex.trim().to_ascii_lowercase();
+    if let Some(other) = report
+        .authority_fingerprints
+        .iter()
+        .find(|fp| fp.to_ascii_lowercase() != expected)
+    {
+        return Err(AuditError::Invalid {
+            line: 0,
+            message: format!(
+                "a record names authority {other}, not the expected {expected} -- it was decided \
+                 under a certificate this node did not issue to this pod"
+            ),
+        });
+    }
+    Ok(())
+}
+
+/// Parse `--executor-pubkey` (32 hex-encoded bytes) into a verifying key.
+///
+/// # Errors
+/// If the hex is not 32 bytes or is not a valid Ed25519 point.
+pub fn executor_pubkey_from_hex(
+    pubkey_hex: &str,
+) -> Result<ed25519_dalek::VerifyingKey, AuditError> {
+    let key_bytes: [u8; 32] = hex::decode(pubkey_hex)
+        .ok()
+        .and_then(|v| v.try_into().ok())
+        .ok_or_else(|| AuditError::Invalid {
+            line: 0,
+            message: "--executor-pubkey must be 32 hex-encoded bytes".to_string(),
+        })?;
+    ed25519_dalek::VerifyingKey::from_bytes(&key_bytes).map_err(|_| AuditError::Invalid {
+        line: 0,
+        message: "--executor-pubkey is not a valid Ed25519 public key".to_string(),
+    })
+}
+
+/// Apply `--authority-fingerprint`, when given: every record must be bound to
+/// it ([`require_authority`]), after which the "name no authority" limitation
+/// no longer applies.
+///
+/// # Errors
+/// Those of [`require_authority`].
+pub fn apply_authority_requirement(
+    report: &mut Art12Report,
+    expected_hex: Option<&str>,
+) -> Result<(), AuditError> {
+    let Some(expected) = expected_hex else {
+        return Ok(());
+    };
+    require_authority(report, expected)?;
+    report
+        .limitations
+        .retain(|l| !l.contains("name no authority"));
+    Ok(())
+}
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -597,5 +698,41 @@ mod tests {
             format!("{err}").contains("unknown attestation kind"),
             "got: {err}"
         );
+    }
+
+    fn report_with(records: u64, bound: u64, fingerprints: &[&str]) -> Art12Report {
+        Art12Report {
+            records,
+            chain_head: String::new(),
+            first_timestamp: None,
+            last_timestamp: None,
+            identified_actors: 0,
+            verdicts: BTreeMap::new(),
+            signatures_checked: false,
+            attestation_checked: false,
+            authority_bound: bound,
+            authority_fingerprints: fingerprints.iter().map(|s| s.to_string()).collect(),
+            limitations: vec!["N of M records name no authority".to_string()],
+        }
+    }
+
+    /// #2437: `--authority-fingerprint` passes only when EVERY record names
+    /// exactly that certificate; a partial binding or a foreign fingerprint
+    /// fails, and a pass discharges the "name no authority" limitation.
+    #[test]
+    fn the_authority_requirement_is_all_or_nothing() {
+        let mut ok = report_with(3, 3, &["ab"]);
+        apply_authority_requirement(&mut ok, Some("AB")).unwrap();
+        assert!(ok.limitations.is_empty(), "the limitation is discharged");
+
+        let mut partial = report_with(3, 2, &["ab"]);
+        assert!(apply_authority_requirement(&mut partial, Some("ab")).is_err());
+
+        let mut foreign = report_with(3, 3, &["ab", "cd"]);
+        assert!(apply_authority_requirement(&mut foreign, Some("ab")).is_err());
+
+        let mut unasked = report_with(3, 0, &[]);
+        apply_authority_requirement(&mut unasked, None).unwrap();
+        assert_eq!(unasked.limitations.len(), 1, "no flag, no requirement");
     }
 }

--- a/crates/nucleus-node/src/art12_collector.rs
+++ b/crates/nucleus-node/src/art12_collector.rs
@@ -195,12 +195,19 @@ pub async fn art12_append(
     let sig = headers
         .get("X-Nucleus-Signature")
         .and_then(|v| v.to_str().ok());
+    // The session id on this route is the pod id (`provision_pod_env`), so the
+    // node can ask its own registry which certificate it issued this pod.
+    let expected_authority = match uuid::Uuid::parse_str(&sid) {
+        Ok(pod_id) => state.authority.certificate_fingerprint(pod_id).await,
+        Err(_) => None,
+    };
     accept(
         &state.state_dir,
         state.trust_gate.art12_secret(),
         &sid,
         sig,
         &body,
+        expected_authority,
     )
     .await
 }
@@ -222,12 +229,18 @@ pub async fn art12_append(
 /// * storage failure — reported as failure, never as success. A pod told
 ///   "accepted" for a record the host did not keep carries on believing it was
 ///   witnessed.
+/// * wrong authority — when this node issued the pod a certificate
+///   (`expected_authority`), a record that names a different fingerprint, or
+///   none, is refused (#2437). The proxy stamps the certificate it verified at
+///   boot into every record; a mismatch means the record was not produced by
+///   the kernel this node authorized.
 pub async fn accept(
     state_dir: &Path,
     secret: Option<&[u8]>,
     raw_session_id: &str,
     signature: Option<&str>,
     body: &str,
+    expected_authority: Option<[u8; 32]>,
 ) -> (axum::http::StatusCode, &'static str) {
     use axum::http::StatusCode;
 
@@ -254,6 +267,12 @@ pub async fn accept(
         tracing::warn!(%session_id, "rejected an unauthenticated Article 12 record");
         return (StatusCode::UNAUTHORIZED, "bad signature");
     }
+    if let Some(expected) = expected_authority
+        && let Err(reason) = check_authority_binding(body, &expected)
+    {
+        tracing::warn!(%session_id, reason, "rejected an Article 12 record with the wrong authority");
+        return (StatusCode::FORBIDDEN, reason);
+    }
 
     match append_record(state_dir, &session_id, body).await {
         Ok(()) => (StatusCode::NO_CONTENT, ""),
@@ -262,6 +281,30 @@ pub async fn accept(
             (StatusCode::INTERNAL_SERVER_ERROR, "storage failed")
         }
     }
+}
+
+/// Whether a shipped record names the certificate this node issued its pod.
+///
+/// The record is parsed as the shared `Art12Record` type so the check reads the
+/// same field a verifier reads (`authority.fingerprint`, inside the signed
+/// preimage), not a regex over the body.
+fn check_authority_binding(body: &str, expected: &[u8; 32]) -> Result<(), &'static str> {
+    let rec: portcullis::art12_record::Art12Record =
+        serde_json::from_str(body).map_err(|_| "record is not an Article 12 record")?;
+    match rec.authority_fingerprint() {
+        None => Err("record names no authority but this pod holds a certificate"),
+        Some(fp) if fp == hex::encode(expected) => Ok(()),
+        Some(_) => Err("record names an authority this node did not issue to this pod"),
+    }
+}
+
+/// The container driver's Article 12 provisioning: a pod-side log under the
+/// pod's data volume (never the workspace). No ship URL: a container's network
+/// namespace has no guaranteed route back to the node's listener, so — like a
+/// Firecracker pod until vsock shipping lands — the executor attests the head
+/// the POD reported. Until #2437 a container pod kept no Article 12 log at all.
+pub fn provision_container_env(env: &mut Vec<String>) {
+    env.push("NUCLEUS_TOOL_PROXY_ART12_LOG=/data/pod/art12.jsonl".to_string());
 }
 
 #[cfg(test)]
@@ -376,7 +419,7 @@ mod tests {
     #[tokio::test]
     async fn an_unsigned_record_is_refused_and_not_stored() {
         let dir = tempfile::tempdir().unwrap();
-        let (code, _) = accept(dir.path(), Some(b"k"), "s1", None, "{}").await;
+        let (code, _) = accept(dir.path(), Some(b"k"), "s1", None, "{}", None).await;
         assert_eq!(code, StatusCode::UNAUTHORIZED);
         assert!(
             !session_log_path(dir.path(), "s1").exists(),
@@ -396,6 +439,7 @@ mod tests {
             "s1",
             Some(&sign(b"other", "s1", "{}")),
             "{}",
+            None,
         )
         .await;
         assert_eq!(code, StatusCode::UNAUTHORIZED);
@@ -414,6 +458,7 @@ mod tests {
             "s1",
             Some(&sign(b"k", "s1", body)),
             body,
+            None,
         )
         .await;
         assert_eq!(code, StatusCode::NO_CONTENT);
@@ -429,7 +474,15 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let body = "{}";
         // Even a signature valid under the EMPTY key must not get in.
-        let (code, _) = accept(dir.path(), None, "s1", Some(&sign(b"", "s1", body)), body).await;
+        let (code, _) = accept(
+            dir.path(),
+            None,
+            "s1",
+            Some(&sign(b"", "s1", body)),
+            body,
+            None,
+        )
+        .await;
         assert_eq!(code, StatusCode::SERVICE_UNAVAILABLE);
         assert!(!session_log_path(dir.path(), "s1").exists());
     }
@@ -445,9 +498,92 @@ mod tests {
             "../escaped",
             Some(&sign(b"k", "s1", body)),
             body,
+            None,
         )
         .await;
         assert_eq!(code, StatusCode::BAD_REQUEST);
         assert!(!dir.path().join("../escaped.jsonl").exists());
+    }
+
+    fn bound_record(fingerprint_hex: Option<&str>) -> String {
+        let ext = fingerprint_hex
+            .map(|fp| format!(r#","extensions":{{"authority.fingerprint":"{fp}"}}"#))
+            .unwrap_or_default();
+        format!(
+            r#"{{"schema_version":1,"seq":1,"timestamp_unix":1,"session_id":"s","transport":"http","actor":{{"kind":"unknown"}},"operation":"run_bash","subject":"ls","verdict":"allow","gate_class":"hard","policy_checksum":"c","dlc_admission":"unprovisioned","lockdown_active":false{ext},"prev_hash":"","hash":"","signature":""}}"#
+        )
+    }
+
+    const ISSUED: [u8; 32] = [7u8; 32];
+
+    /// #2437: a record naming the certificate this node issued is stored.
+    #[tokio::test]
+    async fn a_record_naming_the_issued_authority_is_stored() {
+        let dir = tempfile::tempdir().unwrap();
+        let body = bound_record(Some(&hex::encode(ISSUED)));
+        let (code, _) = accept(
+            dir.path(),
+            Some(b"k"),
+            "s1",
+            Some(&sign(b"k", "s1", &body)),
+            &body,
+            Some(ISSUED),
+        )
+        .await;
+        assert_eq!(code, StatusCode::NO_CONTENT);
+        assert!(session_log_path(dir.path(), "s1").exists());
+    }
+
+    /// A validly SIGNED record that names a certificate this node did not issue
+    /// to this pod is refused and not stored: the signature proves the pod sent
+    /// it, the fingerprint proves which kernel decided it, and they disagree.
+    #[tokio::test]
+    async fn a_record_naming_another_authority_is_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let body = bound_record(Some(&hex::encode([8u8; 32])));
+        let (code, reason) = accept(
+            dir.path(),
+            Some(b"k"),
+            "s1",
+            Some(&sign(b"k", "s1", &body)),
+            &body,
+            Some(ISSUED),
+        )
+        .await;
+        assert_eq!(code, StatusCode::FORBIDDEN, "{reason}");
+        assert!(!session_log_path(dir.path(), "s1").exists());
+    }
+
+    /// A pod that holds a certificate cannot ship records that name none: the
+    /// binding is mandatory, not best-effort, once the node has issued one.
+    #[tokio::test]
+    async fn a_record_naming_no_authority_is_refused_when_the_pod_holds_one() {
+        let dir = tempfile::tempdir().unwrap();
+        let body = bound_record(None);
+        let (code, _) = accept(
+            dir.path(),
+            Some(b"k"),
+            "s1",
+            Some(&sign(b"k", "s1", &body)),
+            &body,
+            Some(ISSUED),
+        )
+        .await;
+        assert_eq!(code, StatusCode::FORBIDDEN);
+        assert!(!session_log_path(dir.path(), "s1").exists());
+    }
+
+    /// The container driver keeps an Article 12 log under the pod`s data
+    /// volume, never the workspace (the proxy refuses a workspace path).
+    #[test]
+    fn container_pods_keep_an_article_12_log_outside_the_workspace() {
+        let mut env = Vec::new();
+        provision_container_env(&mut env);
+        let log = env
+            .iter()
+            .find_map(|e| e.strip_prefix("NUCLEUS_TOOL_PROXY_ART12_LOG="))
+            .expect("the container driver provisions an Article 12 log");
+        assert!(log.starts_with("/data/pod/"), "{log}");
+        assert!(!log.starts_with("/workspace"), "{log}");
     }
 }

--- a/crates/nucleus-node/src/main.rs
+++ b/crates/nucleus-node/src/main.rs
@@ -1819,6 +1819,7 @@ async fn spawn_container_pod(
             state.proxy_approval_secret
         ));
         env.push("NUCLEUS_TOOL_PROXY_AUDIT_LOG=/data/pod/audit.log".to_string());
+        art12_collector::provision_container_env(&mut env);
 
         // Pass audit sink config from PodSpec for deletion-resistant remote storage
         if let Some(ref sink) = spec.spec.audit_sink {

--- a/crates/nucleus-node/src/pod_authority.rs
+++ b/crates/nucleus-node/src/pod_authority.rs
@@ -508,6 +508,14 @@ impl PodAuthority {
         })
     }
 
+    /// The fingerprint of the certificate this node issued to `pod_id`, for
+    /// cross-checking the authority a pod's shipped Article 12 records claim
+    /// (#2437). `None` when the node issued this pod nothing.
+    pub async fn certificate_fingerprint(&self, pod_id: Uuid) -> Option<[u8; 32]> {
+        let inner = self.inner.lock().await;
+        Some(inner.pods.get(&pod_id)?.cert.fingerprint())
+    }
+
     /// Retire a pod's certificate and return its budget allocation to the
     /// parent's ledger. Until children report actual spend, the whole
     /// allocation is folded into the parent's consumption (no refund).

--- a/crates/nucleus-tool-proxy/src/art12_sink.rs
+++ b/crates/nucleus-tool-proxy/src/art12_sink.rs
@@ -338,6 +338,45 @@ pub(crate) fn health_json(log: Option<&Arc<Art12Log>>) -> serde_json::Value {
 }
 
 /// Appends an Article 12 record for every verdict, then delegates.
+/// The authority a pod's records are bound to (#2437): what the proxy kept of
+/// its own certificate after the one-time boot verification. Stamped into every
+/// record as the `authority.*` extensions, so the decision names the chain —
+/// and, through the node's copy of that chain, the root public key — that
+/// authorized the kernel which made it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AuthorityBinding {
+    fingerprint_hex: String,
+    chain_depth: usize,
+    root_identity: String,
+}
+
+impl From<&crate::pod_cert::PodCertificate> for AuthorityBinding {
+    fn from(cert: &crate::pod_cert::PodCertificate) -> Self {
+        Self {
+            fingerprint_hex: hex::encode(cert.fingerprint),
+            chain_depth: cert.chain_depth,
+            root_identity: cert.root_identity.clone(),
+        }
+    }
+}
+
+impl AuthorityBinding {
+    fn stamp(&self, ext: &mut std::collections::BTreeMap<String, String>) {
+        use portcullis::art12_record::{
+            EXT_AUTHORITY_CHAIN_DEPTH, EXT_AUTHORITY_FINGERPRINT, EXT_AUTHORITY_ROOT,
+        };
+        ext.insert(
+            EXT_AUTHORITY_FINGERPRINT.to_string(),
+            self.fingerprint_hex.clone(),
+        );
+        ext.insert(
+            EXT_AUTHORITY_CHAIN_DEPTH.to_string(),
+            self.chain_depth.to_string(),
+        );
+        ext.insert(EXT_AUTHORITY_ROOT.to_string(), self.root_identity.clone());
+    }
+}
+
 pub(crate) struct Art12Sink {
     inner: Arc<dyn VerdictSink>,
     log: Arc<Art12Log>,
@@ -353,9 +392,12 @@ pub(crate) struct Art12Sink {
     dlc_provisioned: bool,
     /// Opt-in: issue a signed `MediationReceipt` per verdict (default `None`).
     receipt_signer: Option<ReceiptSigner>,
+    /// The pod's certificate, when it holds one: stamped into every record.
+    authority: Option<AuthorityBinding>,
 }
 
 impl Art12Sink {
+    #[allow(clippy::too_many_arguments)] // one constructor, one place to assemble the chain
     pub(crate) fn new(
         inner: Arc<dyn VerdictSink>,
         log: Arc<Art12Log>,
@@ -364,6 +406,7 @@ impl Art12Sink {
         dlc_provisioned: bool,
         shipper: Option<Arc<crate::art12_shipper::Art12Shipper>>,
         receipt_signer: Option<ReceiptSigner>,
+        authority: Option<AuthorityBinding>,
     ) -> Self {
         Self {
             inner,
@@ -373,6 +416,7 @@ impl Art12Sink {
             policy_checksum,
             dlc_provisioned,
             receipt_signer,
+            authority,
         }
     }
 
@@ -414,7 +458,7 @@ impl Art12Sink {
         // Everything the recorder attached that is not already a named field
         // travels as extensions — including `flow_cross_check` (#2144), so the
         // DAG's second opinion is in the regulatory record and not only in a log.
-        let extensions = ctx
+        let mut extensions: std::collections::BTreeMap<String, String> = ctx
             .extensions
             .iter()
             .filter(|(k, _)| {
@@ -425,6 +469,11 @@ impl Art12Sink {
             })
             .map(|(k, v)| (k.clone(), v.clone()))
             .collect();
+        // The authority this decision was made under (#2437). Stamped LAST so
+        // a recorder cannot claim a different certificate through the context.
+        if let Some(authority) = &self.authority {
+            authority.stamp(&mut extensions);
+        }
 
         Art12Record {
             // Assigned by `Art12Log::append`.
@@ -636,6 +685,7 @@ mod tests {
             false,
             None,
             None,
+            None,
         )
     }
 
@@ -677,6 +727,7 @@ mod tests {
                 emitted: Arc::clone(&emitted),
                 receipt_log: None,
             }),
+            None,
         );
 
         sink.record(ctx(VerdictOutcome::Allow, &[])).unwrap();
@@ -726,6 +777,7 @@ mod tests {
                 emitted: Arc::new(Mutex::new(Vec::new())),
                 receipt_log: Some(ReceiptLog::open(&receipt_path).unwrap()),
             }),
+            None,
         );
 
         sink.record(ctx(VerdictOutcome::Allow, &[])).unwrap();
@@ -906,5 +958,61 @@ mod tests {
         let work = TempDir::new().unwrap();
         let elsewhere = TempDir::new().unwrap();
         assert!(reject_workspace_path(&elsewhere.path().join("a.jsonl"), work.path()).is_ok());
+    }
+
+    /// #2437: a pod that holds a certificate stamps every record with the
+    /// authority the deciding kernel was built from, inside the signed
+    /// preimage; a recorder cannot override it through the context; a pod with
+    /// no certificate stamps nothing (a pre-authority node).
+    #[test]
+    fn every_record_names_the_authority_it_was_decided_under() {
+        use portcullis::art12_record::{
+            EXT_AUTHORITY_CHAIN_DEPTH, EXT_AUTHORITY_FINGERPRINT, EXT_AUTHORITY_ROOT,
+        };
+        let dir = TempDir::new().unwrap();
+        let authority = AuthorityBinding {
+            fingerprint_hex: hex::encode([0xabu8; 32]),
+            chain_depth: 2,
+            root_identity: "spiffe://td/ns/system/sa/cli".to_string(),
+        };
+        let bound = Art12Sink::new(
+            Arc::new(NullSink),
+            open_log(&dir),
+            "sess".to_string(),
+            "checksum".to_string(),
+            false,
+            None,
+            None,
+            Some(authority.clone()),
+        );
+
+        // A recorder claiming a different certificate through the context loses.
+        let rec = bound.project(&ctx(
+            VerdictOutcome::Allow,
+            &[(EXT_AUTHORITY_FINGERPRINT, "deadbeef")],
+        ));
+        assert_eq!(
+            rec.authority_fingerprint(),
+            Some(authority.fingerprint_hex.as_str())
+        );
+        assert_eq!(
+            rec.extensions
+                .get(EXT_AUTHORITY_CHAIN_DEPTH)
+                .map(String::as_str),
+            Some("2")
+        );
+        assert_eq!(
+            rec.extensions.get(EXT_AUTHORITY_ROOT).map(String::as_str),
+            Some("spiffe://td/ns/system/sa/cli")
+        );
+        assert!(
+            rec.canonical_preimage()
+                .contains(&authority.fingerprint_hex),
+            "the binding is inside the signed preimage"
+        );
+
+        let unbound = sink_with(open_log(&dir));
+        let rec = unbound.project(&ctx(VerdictOutcome::Allow, &[]));
+        assert_eq!(rec.authority_fingerprint(), None);
     }
 }

--- a/crates/nucleus-tool-proxy/src/main.rs
+++ b/crates/nucleus-tool-proxy/src/main.rs
@@ -1851,6 +1851,7 @@ async fn main() -> Result<(), ApiError> {
         art12_log.clone(),
         art12_shipper.clone(),
         art12_sink::mediation_receipt_log_path(args.art12_log.as_deref(), &spec.spec.work_dir),
+        pod_cert.as_deref().map(art12_sink::AuthorityBinding::from),
     );
 
     if dlc_provisioned {

--- a/crates/nucleus-tool-proxy/src/verdict_sink.rs
+++ b/crates/nucleus-tool-proxy/src/verdict_sink.rs
@@ -90,6 +90,7 @@ pub fn build_monitored_sink(
     art12_log: Option<Arc<crate::art12::Art12Log>>,
     art12_shipper: Option<Arc<crate::art12_shipper::Art12Shipper>>,
     mediation_receipt_log: Option<std::path::PathBuf>,
+    authority: Option<crate::art12_sink::AuthorityBinding>,
 ) -> (Arc<dyn VerdictSink>, Arc<TraceMonitor>) {
     let inner: Arc<dyn VerdictSink> = Arc::new(ToolProxyVerdictSink::new(
         file_lockdown,
@@ -117,6 +118,9 @@ pub fn build_monitored_sink(
             // The path (when given) is where the full signed receipts are
             // persisted for offline verification — opened only once a key exists.
             crate::art12_sink::ReceiptSigner::from_env(mediation_receipt_log.as_deref()),
+            // The pod's certificate, when it holds one (#2437): every record
+            // names the authority the deciding kernel was built from.
+            authority,
         )) as Arc<dyn VerdictSink>,
         None => inner,
     };
@@ -614,6 +618,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         )
     }
 
@@ -665,6 +670,7 @@ mod tests {
             "test-checksum".to_string(),
             "test-session".to_string(),
             false,
+            None,
             None,
             None,
             None,

--- a/crates/portcullis/src/art12_record.rs
+++ b/crates/portcullis/src/art12_record.rs
@@ -21,6 +21,23 @@ pub const ART12_SCHEMA_VERSION: u32 = 1;
 /// never be confused with another HMAC'd artifact signed by the same secret.
 pub const PREIMAGE_DOMAIN: &str = "nucleus-art12-record-v1";
 
+/// Extension keys binding a record to the AUTHORITY it was decided under
+/// (#2437): the pod certificate the tool-proxy verified at boot against the
+/// node's pinned root key. The kernel that produced the verdict was built from
+/// that certificate (`Kernel::from_certificate`), so these three keys let a
+/// verifier holding the node's `authority.json` for the pod tie every decision
+/// back to the chain — and the root public key — that authorized it, with no
+/// side channel. They travel as extensions so the v1 preimage is unchanged:
+/// extensions are already folded into the hash and signature.
+///
+/// A record written by a pod that holds a certificate carries all three; the
+/// node refuses a shipped record whose fingerprint is not the one it issued.
+pub const EXT_AUTHORITY_FINGERPRINT: &str = "authority.fingerprint";
+/// Hops from the node's root to the pod (`LatticeCertificate` chain depth).
+pub const EXT_AUTHORITY_CHAIN_DEPTH: &str = "authority.chain_depth";
+/// The identity at the root of the pod's chain (its creator).
+pub const EXT_AUTHORITY_ROOT: &str = "authority.root_identity";
+
 /// The identity of whoever caused a decision.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
@@ -103,6 +120,15 @@ pub struct Art12Record {
 }
 
 impl Art12Record {
+    /// The certificate fingerprint this decision was made under, when the
+    /// writing pod held one ([`EXT_AUTHORITY_FINGERPRINT`]).
+    #[must_use]
+    pub fn authority_fingerprint(&self) -> Option<&str> {
+        self.extensions
+            .get(EXT_AUTHORITY_FINGERPRINT)
+            .map(String::as_str)
+    }
+
     /// The canonical preimage: a `|`-joined, field-ordered rendering that both
     /// the writer and any verifier reconstruct **from the record's own fields**.
     ///

--- a/docs/article-12-record-keeping.md
+++ b/docs/article-12-record-keeping.md
@@ -28,6 +28,16 @@ verified-admission state, and the causal DAG's independent opinion of the same
 decision (`flow_cross_check`). Every one of those fields is folded into the
 signed preimage.
 
+When the pod holds a certificate issued by its node (every pod created since the
+certificate convergence, #2464), each record also names the **authority** the
+decision was made under: `authority.fingerprint` (the `LatticeCertificate`
+fingerprint the kernel was built from), `authority.chain_depth` and
+`authority.root_identity`, carried as extensions and therefore inside the signed
+preimage. A verifier holding the node's `pods/<id>/authority.json` can tie every
+decision back to the chain — and the root public key — that authorized it. The
+node refuses a shipped record whose fingerprint is not the one it issued to that
+pod, so a pod cannot claim a different authority than it was granted, nor none.
+
 ## What happens when recording fails
 
 The log latches **degraded** on a write failure and counts what it dropped. The


### PR DESCRIPTION
Closes #2437 (re-scoped; see the issue comment). With #2451 this is the last open item of epic #2424.

### Re-scope
The issue targeted `nucleus_receipt::Session.parent_chain`. Neither the node nor the tool-proxy uses that crate; the live audit trail of a tool call is the **Article 12 record** (hash-chained, HMAC-signed, on for Firecracker and local pods) and the **MediationReceipt** that Ed25519-signs the record's hash. So the certificate binding goes there, and the "opt-in" half of the issue turned out to be one driver: container pods kept no Article 12 log at all.

### What was wrong, verified on `main`
- A record carried `policy_checksum` (which lattice was in force) but nothing about **whose authority** put it in force. Since #2464/#2465 the deciding kernel is built from the pod's certificate, but no artifact said which one.
- `spawn_container_pod` set the audit log env but not `NUCLEUS_TOOL_PROXY_ART12_LOG`; local (`provision_pod_env`) and Firecracker (`guest-init`) both do.

### The change
- **portcullis** `art12_record`: three reserved extension keys, `authority.fingerprint`, `authority.chain_depth`, `authority.root_identity`, plus `Art12Record::authority_fingerprint()`. Extensions are already inside the v1 canonical preimage, so no schema bump and no verifier drift: old logs verify unchanged, new records carry the binding under the hash, the signature, and the receipt.
- **tool-proxy** `Art12Sink` takes an `AuthorityBinding` (from the boot-verified `PodCertificate`) and stamps it into every record **after** the recorder's extensions, so a caller cannot claim a different certificate through the context. Threaded through `build_monitored_sink`, the one constructor.
- **node** `art12_collector::accept` takes the fingerprint the node issued that pod (`PodAuthority::certificate_fingerprint`; the route's session id is the pod id). A validly signed record naming another fingerprint, or none, is **403 and not stored**. Records from pods the node issued nothing are accepted as before.
- **node** container driver: `provision_container_env` adds the Article 12 log under `/data/pod` (never the workspace). No ship URL: a container's network namespace has no guaranteed route to the node's listener, so, like Firecracker until vsock shipping lands, the executor attests the head the pod reported. Said in the doc comment.
- **nucleus-audit** `verify-art12`: the report gains `authority_bound` and `authority_fingerprints`; a shortfall is a stated limitation; `--authority-fingerprint <hex>` requires every record be decided under exactly that certificate. Two small helpers moved out of `main.rs` to keep it under its line ceiling.
- `docs/article-12-record-keeping.md` describes the binding.

### Acceptance, as landed
- *Leaf receipt verifies back to the root public key with no side channel*: the MediationReceipt signs the record hash; the hash covers `authority.fingerprint`; the node refuses any record whose fingerprint is not the chain it verified against its root at issue. `every_record_names_the_authority_it_was_decided_under` (tool-proxy), `a_record_naming_another_authority_is_refused`, `a_record_naming_no_authority_is_refused_when_the_pod_holds_one`, `a_record_naming_the_issued_authority_is_stored` (node), `the_authority_requirement_is_all_or_nothing` (audit).
- *A default-configuration tool call emits a record*: now true on all three drivers. `container_pods_keep_an_article_12_log_outside_the_workspace`.

### Not in this PR
`cargo clippy -p portcullis --all-targets -D warnings` fails on `main` already (`tests/adversarial.rs:9`, unused imports, last touched in #895); confirmed by stashing this change. Untouched here.

### Verification
`cargo test -p nucleus-tool-proxy --all-features` (400) · `-p nucleus-node --features local-driver` (415) · `-p nucleus-audit` · `-p portcullis --lib` · `cargo clippy -p nucleus-node -p nucleus-tool-proxy -p nucleus-audit --all-features --all-targets -- -D warnings` · `cargo fmt --check` · `scripts/check-line-ratchet.sh --strict` · `ci/no-vendor-strings.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZaH5waz88vL1qfNpFNfZ4
