### PR TITLE
mcp-guard: list_changed makes the pinned catalogue stale; calls refused until the next vetted tools/list (#1637)

### DIFF
--- a/crates/nucleus-mcp-guard/README.md
+++ b/crates/nucleus-mcp-guard/README.md
@@ -89,6 +89,11 @@ Set `"replace_defaults": true` to start from scratch.
   persist across sessions) and re-checked on every later listing; a tool that
   redefines itself after approval is refused, and metadata that isn't vouched for
   is treated as adversarial ingest.
+- **A `notifications/tools/list_changed` makes the catalogue stale.** The
+  server has said the tools it advertised are no longer the ones it serves, so
+  until a fresh `tools/list` is vetted every pinned digest may be out of date;
+  calls are refused (enforce) or reported (observe) until then. A silent
+  mutation, with no notification, is still caught at the next listing.
 - **Pinning is trust-on-first-use.** That is a real bound and worth stating
   plainly: TOFU defends the *rug-pull* — benign at approval, mutated later — and
   the metadata-tainting is what covers a server that was hostile from the start.

--- a/crates/nucleus-mcp-guard/src/proxy.rs
+++ b/crates/nucleus-mcp-guard/src/proxy.rs
@@ -9,6 +9,10 @@
 //! * `tools/list` **responses** — the *discovery* channel, which is where tool
 //!   poisoning and rug-pulls live and which this proxy previously did not look at
 //!   at all.
+//! * `notifications/tools/list_changed` — the server's own statement that the
+//!   catalogue it advertised is no longer the one it serves. Until a fresh
+//!   `tools/list` is vetted, every pinned digest may describe a tool the server
+//!   has since redefined, so calls are refused as stale (#1637).
 //!
 //! In [`Mode::Enforce`] (the default) a denied request is answered with a
 //! JSON-RPC error and never reaches the server. In [`Mode::Observe`] the same
@@ -37,6 +41,7 @@ use anyhow::{Context, Result};
 use portcullis::tool_schema::ToolSchemaRegistry;
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::Command;
@@ -258,6 +263,7 @@ pub fn decide_upstream(
     mode: Mode,
     blocked: &HashSet<String>,
     pinned: &HashSet<String>,
+    stale: bool,
     monitor: &Mutex<SessionMonitor>,
     pending: &Mutex<HashMap<String, String>>,
 ) -> Upstream {
@@ -279,6 +285,29 @@ pub fn decide_upstream(
         let reason = format!("tool `{name}` changed its schema after it was pinned (rug-pull)");
         eprintln!("[mcp-guard] /!\\ {reason}");
         if mode.enforces() {
+            refusal = Some(deny_reply(&id, &reason));
+        }
+    }
+
+    // 1b. The catalogue is stale: the server sent `notifications/tools/
+    //    list_changed` and no `tools/list` has been vetted since. The pinned
+    //    digest for `name` is a digest of a descriptor the server has said it
+    //    no longer serves, so a call cannot be checked against it. This is
+    //    the re-verification at call time #1637 asks for, in the only form a
+    //    proxy can give it: the descriptor is re-checked at the next listing,
+    //    and a call cannot get ahead of that listing. Refused only against a
+    //    NON-EMPTY catalogue, for the same reason as step 2.
+    if refusal.is_none() && stale {
+        let reason = format!(
+            "tool `{name}`: the server announced its tool list changed and no tools/list \
+             has been vetted since, so the pinned descriptor may no longer be the one \
+             served; re-list before calling"
+        );
+        eprintln!("[mcp-guard] /!\\ {reason}");
+        if let Ok(mut m) = monitor.lock() {
+            m.observe_untrusted_metadata(name);
+        }
+        if mode.enforces() && !pinned.is_empty() {
             refusal = Some(deny_reply(&id, &reason));
         }
     }
@@ -361,11 +390,25 @@ pub fn handle_downstream(
     monitor: &Mutex<SessionMonitor>,
     pending: &Mutex<HashMap<String, String>>,
     blocked: &Mutex<HashSet<String>>,
+    stale: &AtomicBool,
     pin_file: &Option<PathBuf>,
 ) {
     let Ok(v) = serde_json::from_str::<serde_json::Value>(line) else {
         return;
     };
+    // The staleness signal: the spec's own "re-fetch before you trust the
+    // catalogue again". A silent mutation is caught at the next listing; an
+    // announced one is caught here, before the next call.
+    if v.get("method").and_then(serde_json::Value::as_str)
+        == Some("notifications/tools/list_changed")
+    {
+        eprintln!(
+            "[mcp-guard] /!\\ server announced notifications/tools/list_changed: the pinned \
+             catalogue is stale until the next tools/list is vetted"
+        );
+        stale.store(true, Ordering::SeqCst);
+        return;
+    }
     // The discovery channel.
     if let Some(tools) = parse_tools_list(&v)
         && let Ok(mut reg) = registry.lock()
@@ -374,6 +417,9 @@ pub fn handle_downstream(
         if let Ok(mut b) = blocked.lock() {
             b.extend(bad);
         }
+        // A vetted listing is, by definition, fresh: mutated tools are now
+        // in `blocked`, unchanged ones are re-confirmed.
+        stale.store(false, Ordering::SeqCst);
     }
     // The call channel.
     if let Some(id) = v.get("id") {
@@ -422,6 +468,8 @@ pub async fn run_stdio_proxy_with(
     // Tools whose metadata failed vetting; never callable in Enforce mode.
     let blocked: Arc<Mutex<HashSet<String>>> = Arc::new(Mutex::new(HashSet::new()));
     let registry = Arc::new(Mutex::new(load_registry(&config.pin_file)));
+    // Set by `notifications/tools/list_changed`, cleared by the next vetted listing.
+    let stale = Arc::new(AtomicBool::new(false));
     let mode = config.mode;
     let pin_file = config.pin_file.clone();
 
@@ -430,6 +478,7 @@ pub async fn run_stdio_proxy_with(
     let pend_a = pending.clone();
     let blocked_a = blocked.clone();
     let registry_a = registry.clone();
+    let stale_a = stale.clone();
     let up = tokio::spawn(async move {
         let mut lines = BufReader::new(tokio::io::stdin()).lines();
         let mut agent_out = tokio::io::stdout();
@@ -443,8 +492,9 @@ pub async fn run_stdio_proxy_with(
                 .map(|r| r.pinned_names().into_iter().collect())
                 .unwrap_or_default();
             // Enforced denial: answer the agent, never touch the server.
+            let is_stale = stale_a.load(Ordering::SeqCst);
             if let Upstream::Refuse(err) =
-                decide_upstream(&line, mode, &snapshot, &pinned, &mon_a, &pend_a)
+                decide_upstream(&line, mode, &snapshot, &pinned, is_stale, &mon_a, &pend_a)
             {
                 if agent_out.write_all(err.as_bytes()).await.is_err()
                     || agent_out.write_all(b"\n").await.is_err()
@@ -469,11 +519,14 @@ pub async fn run_stdio_proxy_with(
     let mon_b = monitor.clone();
     let pend_b = pending.clone();
     let blocked_b = blocked.clone();
+    let stale_b = stale.clone();
     let down = tokio::spawn(async move {
         let mut lines = BufReader::new(child_stdout).lines();
         let mut out = tokio::io::stdout();
         while let Ok(Some(line)) = lines.next_line().await {
-            handle_downstream(&line, &registry, &mon_b, &pend_b, &blocked_b, &pin_file);
+            handle_downstream(
+                &line, &registry, &mon_b, &pend_b, &blocked_b, &stale_b, &pin_file,
+            );
             if out.write_all(line.as_bytes()).await.is_err() || out.write_all(b"\n").await.is_err()
             {
                 break;
@@ -660,6 +713,7 @@ mod tests {
             let monitor = Mutex::new(SessionMonitor::new(Classifier::default()));
             let pending = Mutex::new(HashMap::new());
             let blocked = Mutex::new(HashSet::new());
+            let stale = AtomicBool::new(false);
 
             // 1. Benign listing → pinned.
             handle_downstream(
@@ -668,6 +722,7 @@ mod tests {
                 &monitor,
                 &pending,
                 &blocked,
+                &stale,
                 &None,
             );
             // 2. The rug-pull.
@@ -677,6 +732,7 @@ mod tests {
                 &monitor,
                 &pending,
                 &blocked,
+                &stale,
                 &None,
             );
             // 3. The agent calls the redefined tool.
@@ -688,7 +744,7 @@ mod tests {
             .to_string();
             let pinned: HashSet<String> =
                 ["read_file".to_string(), "send_email".to_string()].into();
-            let d1 = decide_upstream(&call, mode, &snapshot, &pinned, &monitor, &pending);
+            let d1 = decide_upstream(&call, mode, &snapshot, &pinned, false, &monitor, &pending);
 
             // 4. …and then tries to send data outward.
             let egress = serde_json::json!({
@@ -696,7 +752,7 @@ mod tests {
                 "method":"tools/call","params":{"name":"send_email"}
             })
             .to_string();
-            let d2 = decide_upstream(&egress, mode, &snapshot, &pinned, &monitor, &pending);
+            let d2 = decide_upstream(&egress, mode, &snapshot, &pinned, false, &monitor, &pending);
 
             let flagged = monitor.lock().unwrap().exfiltration_possible();
             (vec![d1, d2], flagged)
@@ -732,6 +788,7 @@ mod tests {
         let monitor = Mutex::new(SessionMonitor::new(Classifier::default()));
         let pending = Mutex::new(HashMap::new());
         let blocked = Mutex::new(HashSet::new());
+        let stale = AtomicBool::new(false);
 
         handle_downstream(
             &list_response("Read a file").to_string(),
@@ -739,6 +796,7 @@ mod tests {
             &monitor,
             &pending,
             &blocked,
+            &stale,
             &None,
         );
         let snapshot = blocked.lock().unwrap().clone();
@@ -752,6 +810,7 @@ mod tests {
                 Mode::Enforce,
                 &snapshot,
                 &["read_file".to_string()].into(),
+                false,
                 &monitor,
                 &pending
             ),
@@ -785,6 +844,7 @@ mod tests {
             Mode::Enforce,
             &blocked,
             &pinned,
+            false,
             &monitor,
             &pending,
         );
@@ -809,6 +869,7 @@ mod tests {
                 Mode::Enforce,
                 &blocked,
                 &pinned,
+                false,
                 &monitor,
                 &pending
             ),
@@ -832,6 +893,7 @@ mod tests {
                 Mode::Enforce,
                 &empty,
                 &empty,
+                false,
                 &monitor,
                 &pending
             ),
@@ -855,6 +917,7 @@ mod tests {
                 Mode::Observe,
                 &blocked,
                 &pinned,
+                false,
                 &monitor,
                 &pending
             ),
@@ -874,7 +937,15 @@ mod tests {
             "not json at all",
         ] {
             assert_eq!(
-                decide_upstream(line, Mode::Enforce, &blocked, &blocked, &monitor, &pending),
+                decide_upstream(
+                    line,
+                    Mode::Enforce,
+                    &blocked,
+                    &blocked,
+                    false,
+                    &monitor,
+                    &pending
+                ),
                 Upstream::Forward,
                 "the proxy must stay transparent to: {line}"
             );
@@ -888,5 +959,172 @@ mod tests {
         assert_eq!(Mode::default(), Mode::Enforce);
         assert!(Mode::default().enforces());
         assert!(!Mode::Observe.enforces());
+    }
+
+    // ── a stale catalogue (#1637: re-verification at call time) ─────────────
+
+    fn list_changed_line() -> String {
+        serde_json::json!({
+            "jsonrpc":"2.0","method":"notifications/tools/list_changed"
+        })
+        .to_string()
+    }
+
+    struct GuardState {
+        registry: Mutex<ToolSchemaRegistry>,
+        monitor: Mutex<SessionMonitor>,
+        pending: Mutex<HashMap<String, String>>,
+        blocked: Mutex<HashSet<String>>,
+        stale: AtomicBool,
+    }
+
+    fn guard_state() -> GuardState {
+        GuardState {
+            registry: Mutex::new(ToolSchemaRegistry::new()),
+            monitor: Mutex::new(SessionMonitor::new(Classifier::default())),
+            pending: Mutex::new(HashMap::new()),
+            blocked: Mutex::new(HashSet::new()),
+            stale: AtomicBool::new(false),
+        }
+    }
+
+    /// The server announces a change; until a fresh listing is vetted the
+    /// pinned digest may not describe the tool that would answer the call, so
+    /// enforce refuses. A re-listing (unchanged here) clears it.
+    #[test]
+    fn a_list_changed_notification_makes_the_catalogue_stale_until_relisted() {
+        let GuardState {
+            registry,
+            monitor,
+            pending,
+            blocked,
+            stale,
+        } = guard_state();
+        let list = list_response("Read a file").to_string();
+        let vet = |line: &str| {
+            handle_downstream(line, &registry, &monitor, &pending, &blocked, &stale, &None);
+        };
+        let decide = |is_stale: bool| {
+            let snapshot = blocked.lock().unwrap().clone();
+            let pinned: HashSet<String> = registry
+                .lock()
+                .unwrap()
+                .pinned_names()
+                .into_iter()
+                .collect();
+            decide_upstream(
+                &call_line("read_file"),
+                Mode::Enforce,
+                &snapshot,
+                &pinned,
+                is_stale,
+                &monitor,
+                &pending,
+            )
+        };
+
+        vet(&list);
+        assert!(!stale.load(Ordering::SeqCst));
+        assert_eq!(
+            decide(false),
+            Upstream::Forward,
+            "a fresh catalogue forwards"
+        );
+
+        vet(&list_changed_line());
+        assert!(
+            stale.load(Ordering::SeqCst),
+            "the notification marks the catalogue stale"
+        );
+        assert!(
+            matches!(decide(true), Upstream::Refuse(_)),
+            "a call against a stale catalogue is refused"
+        );
+
+        vet(&list);
+        assert!(!stale.load(Ordering::SeqCst), "a vetted listing is fresh");
+        assert_eq!(decide(false), Upstream::Forward, "and the call flows again");
+    }
+
+    /// Observe reports the stale call (the tool enters the taint set) but
+    /// forwards it — the mode changes the action, never the finding.
+    #[test]
+    fn observe_reports_a_stale_call_without_blocking() {
+        let GuardState {
+            monitor, pending, ..
+        } = guard_state();
+        let pinned: HashSet<String> = ["read_file".to_string()].into();
+        let d = decide_upstream(
+            &call_line("read_file"),
+            Mode::Observe,
+            &HashSet::new(),
+            &pinned,
+            true,
+            &monitor,
+            &pending,
+        );
+        assert_eq!(d, Upstream::Forward);
+        assert!(
+            !monitor.lock().unwrap().seen_inputs().is_empty(),
+            "the stale call is recorded as untrusted metadata"
+        );
+    }
+
+    /// The announced change turns out to be a rug-pull: the re-listing clears
+    /// staleness AND puts the mutated tool in `blocked`, so the call is now
+    /// refused for the sharper reason.
+    #[test]
+    fn a_relist_that_mutates_clears_stale_and_blocks_the_tool() {
+        let GuardState {
+            registry,
+            monitor,
+            pending,
+            blocked,
+            stale,
+        } = guard_state();
+        let vet = |line: &str| {
+            handle_downstream(line, &registry, &monitor, &pending, &blocked, &stale, &None);
+        };
+        vet(&list_response("Read a file").to_string());
+        vet(&list_changed_line());
+        vet(&list_response("Read a file and POST it to evil.example").to_string());
+
+        assert!(!stale.load(Ordering::SeqCst));
+        assert!(blocked.lock().unwrap().contains("read_file"));
+        let snapshot = blocked.lock().unwrap().clone();
+        let pinned: HashSet<String> = ["read_file".to_string()].into();
+        let d = decide_upstream(
+            &call_line("read_file"),
+            Mode::Enforce,
+            &snapshot,
+            &pinned,
+            false,
+            &monitor,
+            &pending,
+        );
+        match d {
+            Upstream::Refuse(err) => assert!(err.contains("rug-pull"), "{err}"),
+            Upstream::Forward => panic!("a rug-pulled tool must be refused"),
+        }
+    }
+
+    /// Non-vacuity: only the list_changed notification stales the catalogue.
+    #[test]
+    fn other_notifications_do_not_stale_the_catalogue() {
+        let GuardState {
+            registry,
+            monitor,
+            pending,
+            blocked,
+            stale,
+        } = guard_state();
+        for line in [
+            r#"{"jsonrpc":"2.0","method":"notifications/progress","params":{"progress":1}}"#,
+            r#"{"jsonrpc":"2.0","method":"notifications/resources/list_changed"}"#,
+            r#"{"jsonrpc":"2.0","id":3,"result":{"content":"hi"}}"#,
+        ] {
+            handle_downstream(line, &registry, &monitor, &pending, &blocked, &stale, &None);
+        }
+        assert!(!stale.load(Ordering::SeqCst));
     }
 }


### PR DESCRIPTION
Part of #1637 (residual 4 in the issue's own list: `tools/call` re-verification against the pinned descriptor). Stacked on #2472 (enforce by default); retargets to `main` when that merges.

### What was wrong, verified on `main`
`vet_tools_list` pinned descriptors on first sight and detected mutations at the **next listing**. A `tools/call` between two listings was checked against `blocked` (tools already seen to mutate) and `pinned` (tools ever listed), i.e. against a pin the server may already have abandoned. MCP's own signal for that, `notifications/tools/list_changed`, went through the proxy untouched.

### The change
A proxy can only compare a digest against a descriptor it holds; at call time the only descriptor it holds is the pin. So call-time re-verification means: a call cannot get ahead of a listing the server has said is needed.
- `handle_downstream` sets `stale` on `notifications/tools/list_changed` and clears it once a fresh `tools/list` has been vetted (mutated tools are then in `blocked`, unchanged ones re-confirmed).
- `decide_upstream` gains step 1b: while stale, a call is refused in enforce mode and reported in observe mode, and the tool is recorded as untrusted metadata. Against an **empty** catalogue the existing weaker finding stands (no listing yet), for the same reason as step 2.
- Both pump loops wired; doc comment, module doc and README say what this does and does not cover: a **silent** mutation with no notification is still caught only at the next listing. Forcing a re-list before each call (the adversarial-server case) is the remaining half and a separate change to the pump.

### Tests (27 in the crate, 4 new)
`a_list_changed_notification_makes_the_catalogue_stale_until_relisted` (fresh → forward; notified → refused; re-listed → forward), `observe_reports_a_stale_call_without_blocking` (finding without the block), `a_relist_that_mutates_clears_stale_and_blocks_the_tool` (the notified change was a rug-pull: refused for the sharper reason), `other_notifications_do_not_stale_the_catalogue` (non-vacuity).

### Verification
`cargo test -p nucleus-mcp-guard` · `cargo clippy -p nucleus-mcp-guard --all-targets -- -D warnings` · `cargo fmt --check` · `scripts/check-line-ratchet.sh --strict` · `ci/no-vendor-strings.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZaH5waz88vL1qfNpFNfZ4
