### PR TITLE
cli: nucleus trust keygen|add|list|remove and manifest sign|verify; registry reads [[tools]] files (#1637)

### DIFF
--- a/crates/nucleus-cli/src/main.rs
+++ b/crates/nucleus-cli/src/main.rs
@@ -47,6 +47,7 @@ mod shell;
 mod start;
 mod stop;
 mod token;
+mod trust;
 // Completeness by 2-safety: the observation function, the canonicaliser and the
 // comparison. Reached from `nucleus two-safety` via `twosafety_boot`, which is
 // the implementation of its `Boot` trait that boots real pods.
@@ -77,6 +78,9 @@ struct Cli {
 enum Commands {
     /// Audit agent configurations for security risks (Tier 0)
     Audit(audit::AuditArgs),
+
+    /// Manage the trusted publisher keys for signed MCP tool manifests
+    Trust(trust::TrustArgs),
 
     /// Secure your MCP servers — audit, policy, enforce
     Guard(guard::GuardArgs),
@@ -204,6 +208,7 @@ async fn main() -> Result<()> {
         Commands::Observe(args) => observe::execute(args),
         Commands::Replay(args) => replay::execute(args),
         Commands::Token(args) => token::execute(args),
+        Commands::Trust(args) => trust::execute(args),
         Commands::Identity(args) => identity::execute(args),
         Commands::Node(args) => node::execute(args).await,
         Commands::Lineage(args) => lineage::execute(args),

--- a/crates/nucleus-cli/src/manifest.rs
+++ b/crates/nucleus-cli/src/manifest.rs
@@ -1,7 +1,18 @@
-//! `nucleus manifest` subcommand — generate and manage MCP tool manifests.
+//! `nucleus manifest` subcommand — generate, sign, and verify MCP tool
+//! manifests.
+//!
+//! `sign` fills each entry's `schema_hash` (the descriptor digest the
+//! publisher vouches for — from an `mcp-guard --pin-file`, or given
+//! explicitly), signs `canonical_bytes()` with the publisher seed, and writes
+//! `signature` / `signing_key` back. `verify` loads the file under the trust
+//! store exactly as `mcp-guard --manifests` would and says what was admitted.
 
 use clap::{Args, Subcommand};
-use std::path::PathBuf;
+use portcullis::manifest_registry::{
+    ManifestRegistry, TrustStore, parse_manifest_toml, sign_manifest,
+};
+use portcullis::tool_schema::ToolSchemaRegistry;
+use std::path::{Path, PathBuf};
 
 #[derive(Args)]
 pub struct ManifestArgs {
@@ -29,6 +40,34 @@ pub enum ManifestCommand {
         /// Output directory (default: .nucleus/manifests/).
         #[arg(long, default_value = ".nucleus/manifests")]
         output_dir: PathBuf,
+    },
+    /// Sign a manifest file: set each entry's `schema_hash`, sign it with a
+    /// publisher seed (`nucleus trust keygen`), and write the signature back.
+    Sign {
+        /// The manifest TOML (`[tool]` or `[[tools]]`). Rewritten in place
+        /// unless `--out` is given. Comments are not preserved.
+        file: PathBuf,
+        /// Hex Ed25519 seed file from `nucleus trust keygen`.
+        #[arg(long, value_name = "FILE")]
+        key: PathBuf,
+        /// An `mcp-guard --pin-file`: the vetted `(name, description,
+        /// parameters)` triples whose digests become each entry's `schema_hash`.
+        #[arg(long, value_name = "FILE", conflicts_with = "schema_hash")]
+        pins: Option<PathBuf>,
+        /// The descriptor digest to pin, for a single-tool manifest.
+        #[arg(long, value_name = "HEX")]
+        schema_hash: Option<String>,
+        /// Write here instead of in place.
+        #[arg(long, value_name = "FILE")]
+        out: Option<PathBuf>,
+    },
+    /// Load a manifest file under `<dir>/.nucleus/trust` exactly as
+    /// `mcp-guard --manifests` would, and report what was admitted.
+    Verify {
+        file: PathBuf,
+        /// Project directory holding `.nucleus/trust/`.
+        #[arg(long, default_value = ".")]
+        dir: PathBuf,
     },
 }
 
@@ -62,6 +101,32 @@ pub fn execute(args: ManifestArgs) {
                 std::process::exit(1);
             }
         }
+        ManifestCommand::Sign {
+            file,
+            key,
+            pins,
+            schema_hash,
+            out,
+        } => {
+            if let Err(e) = run_sign(
+                &file,
+                &key,
+                pins.as_deref(),
+                schema_hash.as_deref(),
+                out.as_deref(),
+            ) {
+                eprintln!("error: {e}");
+                std::process::exit(1);
+            }
+        }
+        ManifestCommand::Verify { file, dir } => match run_verify(&file, &dir) {
+            Ok(true) => {}
+            Ok(false) => std::process::exit(1),
+            Err(e) => {
+                eprintln!("error: {e}");
+                std::process::exit(1);
+            }
+        },
     }
 }
 
@@ -144,6 +209,149 @@ fn run_init(
     eprintln!("Review security annotations before deploying.");
 
     Ok(())
+}
+
+/// Descriptor digests from an `mcp-guard --pin-file`: name → hash.
+fn digests_from_pins(path: &Path) -> Result<std::collections::BTreeMap<String, String>, String> {
+    let content = std::fs::read_to_string(path)
+        .map_err(|e| format!("failed to read {}: {e}", path.display()))?;
+    let pins: Vec<(String, String, String)> = serde_json::from_str(&content)
+        .map_err(|e| format!("{} is not an mcp-guard pin file: {e}", path.display()))?;
+    Ok(pins
+        .iter()
+        .map(|(n, d, s)| (n.clone(), ToolSchemaRegistry::hash_schema(n, d, s)))
+        .collect())
+}
+
+/// The entries of a manifest document, whichever shape it has.
+fn entries_mut(doc: &mut toml::Value) -> Result<Vec<&mut toml::Value>, String> {
+    let table = doc.as_table_mut().ok_or("manifest is not a TOML table")?;
+    if table.contains_key("tool") {
+        return Ok(vec![table.get_mut("tool").expect("checked")]);
+    }
+    match table.get_mut("tools").and_then(toml::Value::as_array_mut) {
+        Some(arr) => Ok(arr.iter_mut().collect()),
+        None => Err("no `[tool]` table or `[[tools]]` array found".to_string()),
+    }
+}
+
+fn run_sign(
+    file: &Path,
+    key: &Path,
+    pins: Option<&Path>,
+    schema_hash: Option<&str>,
+    out: Option<&Path>,
+) -> Result<(), String> {
+    let seed_hex = std::fs::read_to_string(key)
+        .map_err(|e| format!("failed to read {}: {e}", key.display()))?;
+    let seed: [u8; 32] = hex::decode(seed_hex.trim())
+        .ok()
+        .and_then(|b| b.try_into().ok())
+        .ok_or_else(|| format!("{} is not a 32-byte hex seed", key.display()))?;
+
+    let content = std::fs::read_to_string(file)
+        .map_err(|e| format!("failed to read {}: {e}", file.display()))?;
+    let mut manifests = parse_manifest_toml(&content)?;
+    let mut doc: toml::Value =
+        toml::from_str(&content).map_err(|e| format!("{}: {e}", file.display()))?;
+    let entries = entries_mut(&mut doc)?;
+    if entries.len() != manifests.len() {
+        return Err("manifest entries could not all be converted".to_string());
+    }
+    if schema_hash.is_some() && manifests.len() != 1 {
+        return Err(
+            "--schema-hash applies to a single-tool manifest; use --pins for several".to_string(),
+        );
+    }
+    let digests = match pins {
+        Some(p) => digests_from_pins(p)?,
+        None => std::collections::BTreeMap::new(),
+    };
+
+    for (manifest, entry) in manifests.iter_mut().zip(entries) {
+        let name = manifest.name.as_str().to_string();
+        let digest_hex = match (schema_hash, digests.get(&name)) {
+            (Some(h), _) => h.trim().to_ascii_lowercase(),
+            (None, Some(h)) => h.clone(),
+            (None, None) if manifest.schema_hash != [0u8; 32] => hex::encode(manifest.schema_hash),
+            (None, None) => {
+                return Err(format!(
+                    "tool `{name}`: no descriptor digest — pass --pins (an mcp-guard pin file that \
+                     lists it) or --schema-hash; a signed manifest that pins no descriptor vouches \
+                     for nothing"
+                ));
+            }
+        };
+        let digest: [u8; 32] = hex::decode(&digest_hex)
+            .ok()
+            .and_then(|b| b.try_into().ok())
+            .ok_or_else(|| format!("tool `{name}`: schema_hash is not 32 hex bytes"))?;
+        manifest.schema_hash = digest;
+        let public = sign_manifest(manifest, &seed);
+        let signature = manifest.signature.expect("just signed");
+
+        let t = entry
+            .as_table_mut()
+            .ok_or_else(|| format!("tool `{name}`: entry is not a table"))?;
+        t.insert("schema_hash".into(), toml::Value::String(digest_hex));
+        t.insert(
+            "signature".into(),
+            toml::Value::String(hex::encode(signature)),
+        );
+        t.insert(
+            "signing_key".into(),
+            toml::Value::String(hex::encode(public)),
+        );
+        eprintln!(
+            "signed: {name} (schema_hash {}…)",
+            &hex::encode(digest)[..16]
+        );
+    }
+
+    let rendered =
+        toml::to_string_pretty(&doc).map_err(|e| format!("serialising manifest: {e}"))?;
+    let dest = out.unwrap_or(file);
+    std::fs::write(dest, rendered)
+        .map_err(|e| format!("failed to write {}: {e}", dest.display()))?;
+    eprintln!("wrote {}", dest.display());
+    Ok(())
+}
+
+/// `Ok(true)` when every entry was admitted under the trust store.
+fn run_verify(file: &Path, dir: &Path) -> Result<bool, String> {
+    let content = std::fs::read_to_string(file)
+        .map_err(|e| format!("failed to read {}: {e}", file.display()))?;
+    let trust = TrustStore::load_from_dir(dir);
+    if trust.is_empty() {
+        return Err(format!(
+            "no trusted keys in {}/.nucleus/trust; `nucleus trust add` one first (a verifier with no \
+             keys would admit everything)",
+            dir.display()
+        ));
+    }
+    let expected = parse_manifest_toml(&content)?;
+    let mut reg = ManifestRegistry::new();
+    reg.load_toml_with_trust(&content, &trust);
+    let mut all_ok = true;
+    for m in &expected {
+        let name = m.name.as_str();
+        let status = if reg.get(name).is_some() {
+            if m.schema_hash == [0u8; 32] {
+                all_ok = false;
+                "admitted, but pins NO descriptor (schema_hash absent): vouches for nothing"
+            } else {
+                "admitted: signature verified, descriptor pinned"
+            }
+        } else if reg.is_rejected(name).is_some() {
+            all_ok = false;
+            "REJECTED by admission control"
+        } else {
+            all_ok = false;
+            "UNSIGNED or not signed by a trusted key"
+        };
+        println!("{name}\t{status}");
+    }
+    Ok(all_ok)
 }
 
 /// Heuristic classification of a tool by its name.
@@ -233,5 +441,83 @@ mod tests {
         ]"#;
         let tools: Vec<McpTool> = serde_json::from_str(json).unwrap();
         assert_eq!(tools.len(), 2);
+    }
+
+    /// The publisher loop end to end: keygen → sign against guard pins →
+    /// trust the public key → verify admits, and the signed digest is the one
+    /// the guard computes for the pinned descriptor.
+    #[test]
+    fn sign_then_verify_round_trip_pins_the_guard_digest() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = dir.path().join("srv.toml");
+        std::fs::write(
+            &manifest,
+            r#"
+[[tools]]
+name = "read_file"
+capabilities = ["read_files"]
+instruction_sources = ["static"]
+admissible_sinks = ["local_memory"]
+
+[[tools]]
+name = "list_dir"
+capabilities = ["read_files"]
+instruction_sources = ["static"]
+admissible_sinks = ["local_memory"]
+"#,
+        )
+        .unwrap();
+        let pins = dir.path().join("pins.json");
+        std::fs::write(
+            &pins,
+            serde_json::to_string(&vec![
+                (
+                    "read_file",
+                    "Read a file",
+                    r#"{"inputSchema":{"path":"string"}}"#,
+                ),
+                ("list_dir", "List", "{}"),
+            ])
+            .unwrap(),
+        )
+        .unwrap();
+        let seed_hex = hex::encode([5u8; 32]);
+        let key = dir.path().join("pub.key");
+        std::fs::write(&key, &seed_hex).unwrap();
+
+        // Unsigned and unpinned: nothing to vouch with.
+        assert!(run_sign(&manifest, &key, None, None, None).is_err());
+
+        run_sign(&manifest, &key, Some(&pins), None, None).unwrap();
+        let signed = std::fs::read_to_string(&manifest).unwrap();
+        let expected = ToolSchemaRegistry::hash_schema(
+            "read_file",
+            "Read a file",
+            r#"{"inputSchema":{"path":"string"}}"#,
+        );
+        assert!(
+            signed.contains(&expected),
+            "the guard's digest is what was signed"
+        );
+
+        // Nobody trusted yet: verify refuses to run rather than admit blindly.
+        assert!(run_verify(&manifest, dir.path()).is_err());
+
+        let public = portcullis::manifest_registry::public_key_for_seed(&[5u8; 32]);
+        crate::trust::add(dir.path(), &hex::encode(public), Some("pub")).unwrap();
+        assert!(
+            run_verify(&manifest, dir.path()).unwrap(),
+            "both entries admitted"
+        );
+
+        // The served-descriptor check the guard performs, against this file.
+        let mut reg = ManifestRegistry::new();
+        reg.load_toml_with_trust(&signed, &TrustStore::load_from_dir(dir.path()));
+        assert_eq!(reg.verify_served_tool("read_file", &expected), Ok(()));
+
+        // A different key is not trusted: verify fails closed.
+        std::fs::write(&key, hex::encode([6u8; 32])).unwrap();
+        run_sign(&manifest, &key, Some(&pins), None, None).unwrap();
+        assert!(!run_verify(&manifest, dir.path()).unwrap());
     }
 }

--- a/crates/nucleus-cli/src/trust.rs
+++ b/crates/nucleus-cli/src/trust.rs
@@ -1,0 +1,266 @@
+//! `nucleus trust` — the operator-controlled root of trust for signed MCP
+//! tool manifests (#1637).
+//!
+//! The store is `<dir>/.nucleus/trust/*.pub`: one hex-encoded 32-byte Ed25519
+//! public key per file. `portcullis::manifest_registry::TrustStore` reads it,
+//! `mcp-guard --manifests` and `nucleus manifest verify` enforce under it.
+//! Nothing here touches a keychain: the signing seed is a file the publisher
+//! keeps, and only the public half enters the store.
+
+use anyhow::{Context, Result, bail};
+use clap::{Args, Subcommand};
+use std::path::{Path, PathBuf};
+
+#[derive(Args)]
+pub struct TrustArgs {
+    #[command(subcommand)]
+    pub command: TrustCommand,
+}
+
+#[derive(Subcommand)]
+pub enum TrustCommand {
+    /// Generate a publisher signing key. Writes the hex seed to `--out`
+    /// (mode 0600) and the public key to `<out>.pub`; the `.pub` is what
+    /// goes into a trust store.
+    Keygen {
+        /// Where to write the seed. Refuses to overwrite.
+        #[arg(long, value_name = "FILE")]
+        out: PathBuf,
+    },
+    /// Add a publisher public key (a `.pub` file or a 64-char hex string) to
+    /// `<dir>/.nucleus/trust/<name>.pub`.
+    Add {
+        /// Path to a `.pub` file, or the hex key itself.
+        key: String,
+        /// Name for the stored key (default: the file's stem, or `key-<prefix>`).
+        #[arg(long)]
+        name: Option<String>,
+        /// Project directory holding `.nucleus/`.
+        #[arg(long, default_value = ".")]
+        dir: PathBuf,
+    },
+    /// List the trusted publisher keys.
+    List {
+        #[arg(long, default_value = ".")]
+        dir: PathBuf,
+    },
+    /// Remove a trusted publisher key by name.
+    Remove {
+        /// The stored name (the file stem under `.nucleus/trust/`).
+        name: String,
+        #[arg(long, default_value = ".")]
+        dir: PathBuf,
+    },
+}
+
+pub fn execute(args: TrustArgs) -> Result<()> {
+    match args.command {
+        TrustCommand::Keygen { out } => keygen(&out),
+        TrustCommand::Add { key, name, dir } => {
+            let stored = add(&dir, &key, name.as_deref())?;
+            eprintln!("trusted: {}", stored.display());
+            Ok(())
+        }
+        TrustCommand::List { dir } => {
+            let keys = list(&dir)?;
+            if keys.is_empty() {
+                eprintln!(
+                    "no trusted keys in {} (a guard run with --manifests will refuse to start)",
+                    trust_dir(&dir).display()
+                );
+            }
+            for (name, hex) in keys {
+                println!("{name}\t{hex}");
+            }
+            Ok(())
+        }
+        TrustCommand::Remove { name, dir } => {
+            remove(&dir, &name)?;
+            eprintln!("removed: {name}");
+            Ok(())
+        }
+    }
+}
+
+fn trust_dir(dir: &Path) -> PathBuf {
+    dir.join(".nucleus").join("trust")
+}
+
+/// A 32-byte key from hex, or a clear error.
+fn parse_pubkey_hex(s: &str) -> Result<[u8; 32]> {
+    let bytes = hex::decode(s.trim()).context("public key is not hex")?;
+    <[u8; 32]>::try_from(bytes.as_slice())
+        .map_err(|_| anyhow::anyhow!("public key must be 32 bytes ({} given)", bytes.len()))
+}
+
+fn keygen(out: &Path) -> Result<()> {
+    use ring::rand::SecureRandom as _;
+    if out.exists() {
+        bail!(
+            "{} exists; refusing to overwrite a signing key",
+            out.display()
+        );
+    }
+    let mut seed = [0u8; 32];
+    ring::rand::SystemRandom::new()
+        .fill(&mut seed)
+        .map_err(|_| anyhow::anyhow!("system randomness unavailable"))?;
+    let public = portcullis::manifest_registry::public_key_for_seed(&seed);
+
+    write_private(out, &hex::encode(seed))?;
+    let pub_path = out.with_extension("pub");
+    std::fs::write(&pub_path, hex::encode(public))
+        .with_context(|| format!("writing {}", pub_path.display()))?;
+    eprintln!(
+        "seed:   {} (keep private)\npublic: {}\n{}",
+        out.display(),
+        pub_path.display(),
+        hex::encode(public)
+    );
+    Ok(())
+}
+
+#[cfg(unix)]
+fn write_private(path: &Path, content: &str) -> Result<()> {
+    use std::io::Write as _;
+    use std::os::unix::fs::OpenOptionsExt as _;
+    let mut f = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(path)
+        .with_context(|| format!("creating {}", path.display()))?;
+    f.write_all(content.as_bytes())?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn write_private(path: &Path, content: &str) -> Result<()> {
+    std::fs::write(path, content).with_context(|| format!("creating {}", path.display()))
+}
+
+/// Add a key to the store; returns the path written.
+pub fn add(dir: &Path, key: &str, name: Option<&str>) -> Result<PathBuf> {
+    let key_path = Path::new(key);
+    let (hex, default_name) = if key_path.is_file() {
+        let content = std::fs::read_to_string(key_path)
+            .with_context(|| format!("reading {}", key_path.display()))?;
+        let stem = key_path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("key")
+            .to_string();
+        (content, stem)
+    } else {
+        (
+            key.to_string(),
+            format!("key-{}", &key.trim()[..key.trim().len().min(8)]),
+        )
+    };
+    let bytes = parse_pubkey_hex(&hex)?;
+    let name = name.map(str::to_string).unwrap_or(default_name);
+    if name.is_empty()
+        || !name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
+    {
+        bail!("key name `{name}` must be [A-Za-z0-9._-]");
+    }
+    let store = trust_dir(dir);
+    std::fs::create_dir_all(&store).with_context(|| format!("creating {}", store.display()))?;
+    let path = store.join(format!("{name}.pub"));
+    std::fs::write(&path, hex::encode(bytes))
+        .with_context(|| format!("writing {}", path.display()))?;
+    Ok(path)
+}
+
+/// `(name, hex)` for every valid key in the store, sorted by name.
+pub fn list(dir: &Path) -> Result<Vec<(String, String)>> {
+    let store = trust_dir(dir);
+    let mut out = Vec::new();
+    let Ok(entries) = std::fs::read_dir(&store) else {
+        return Ok(out);
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().is_some_and(|e| e == "pub")
+            && let Ok(content) = std::fs::read_to_string(&path)
+            && let Ok(bytes) = parse_pubkey_hex(&content)
+        {
+            let name = path
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("?")
+                .to_string();
+            out.push((name, hex::encode(bytes)));
+        }
+    }
+    out.sort();
+    Ok(out)
+}
+
+pub fn remove(dir: &Path, name: &str) -> Result<()> {
+    let path = trust_dir(dir).join(format!("{name}.pub"));
+    if !path.is_file() {
+        bail!(
+            "no trusted key named `{name}` in {}",
+            trust_dir(dir).display()
+        );
+    }
+    std::fs::remove_file(&path).with_context(|| format!("removing {}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn add_list_remove_round_trip_and_the_store_is_what_portcullis_reads() {
+        let dir = tempfile::tempdir().unwrap();
+        let hex_key = "ab".repeat(32);
+
+        let path = add(dir.path(), &hex_key, Some("publisher")).unwrap();
+        assert!(path.ends_with(".nucleus/trust/publisher.pub"));
+        assert_eq!(
+            list(dir.path()).unwrap(),
+            vec![("publisher".to_string(), hex_key.clone())]
+        );
+
+        // The same store, read by the verifier's own loader.
+        let store = portcullis::manifest_registry::TrustStore::load_from_dir(dir.path());
+        assert_eq!(store.key_count(), 1);
+
+        remove(dir.path(), "publisher").unwrap();
+        assert!(list(dir.path()).unwrap().is_empty());
+        assert!(
+            remove(dir.path(), "publisher").is_err(),
+            "removing twice is an error"
+        );
+    }
+
+    #[test]
+    fn a_malformed_key_is_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(add(dir.path(), "not-hex", None).is_err());
+        assert!(
+            add(dir.path(), &"ab".repeat(31), None).is_err(),
+            "31 bytes is not a key"
+        );
+        assert!(add(dir.path(), &"ab".repeat(32), Some("../escape")).is_err());
+    }
+
+    #[test]
+    fn keygen_writes_a_seed_and_its_public_half() {
+        let dir = tempfile::tempdir().unwrap();
+        let out = dir.path().join("publisher.key");
+        keygen(&out).unwrap();
+        let seed_hex = std::fs::read_to_string(&out).unwrap();
+        let pub_hex = std::fs::read_to_string(dir.path().join("publisher.pub")).unwrap();
+        let seed: [u8; 32] = hex::decode(seed_hex.trim()).unwrap().try_into().unwrap();
+        assert_eq!(
+            hex::encode(portcullis::manifest_registry::public_key_for_seed(&seed)),
+            pub_hex
+        );
+        assert!(keygen(&out).is_err(), "never overwrite a key");
+    }
+}

--- a/crates/portcullis/src/manifest_registry.rs
+++ b/crates/portcullis/src/manifest_registry.rs
@@ -213,6 +213,68 @@ impl ManifestRegistry {
     }
 }
 
+/// Both shapes a manifest file may take: one `[tool]` table, or a
+/// `[[tools]]` array (what `nucleus manifest init` generates). Each entry
+/// is signed on its own.
+fn parse_entries(content: &str) -> Vec<ToolEntry> {
+    if let Ok(single) = toml::from_str::<ManifestFile>(content) {
+        return vec![single.tool];
+    }
+    if let Ok(multi) = toml::from_str::<MultiManifestFile>(content) {
+        return multi.tools;
+    }
+    Vec::new()
+}
+
+/// Convert every entry of a manifest file to its signable form, in file
+/// order, without admitting anything. For signers and inspectors.
+///
+/// # Errors
+/// If the content is neither shape, or an entry cannot be converted (for
+/// example a malformed `schema_hash`).
+pub fn parse_manifest_toml(content: &str) -> Result<Vec<ToolManifest>, String> {
+    let entries = parse_entries(content);
+    if entries.is_empty() {
+        return Err("no `[tool]` table or `[[tools]]` array found".to_string());
+    }
+    entries
+        .iter()
+        .map(|e| {
+            convert_entry(e).ok_or_else(|| format!("tool `{}`: entry cannot be converted", e.name))
+        })
+        .collect()
+}
+
+/// Sign a manifest with an Ed25519 seed, setting `signature` and
+/// `signing_key`, and return the public key. The payload is
+/// `canonical_bytes()` — the same bytes [`verify_manifest_signature`]
+/// checks, so `schema_hash` must be set BEFORE signing.
+#[cfg(feature = "crypto")]
+pub fn sign_manifest(manifest: &mut ToolManifest, seed: &[u8; 32]) -> [u8; 32] {
+    use ed25519_dalek::Signer as _;
+    let key = ed25519_dalek::SigningKey::from_bytes(seed);
+    let sig = key.sign(&manifest.canonical_bytes());
+    manifest.signature = Some(sig.to_bytes());
+    let public = key.verifying_key().to_bytes();
+    manifest.signing_key = Some(public);
+    public
+}
+
+/// The public key for an Ed25519 seed (for `nucleus trust keygen`).
+#[cfg(feature = "crypto")]
+#[must_use]
+pub fn public_key_for_seed(seed: &[u8; 32]) -> [u8; 32] {
+    ed25519_dalek::SigningKey::from_bytes(seed)
+        .verifying_key()
+        .to_bytes()
+}
+
+/// The `[[tools]]` shape.
+#[derive(Deserialize)]
+struct MultiManifestFile {
+    tools: Vec<ToolEntry>,
+}
+
 /// TOML-deserializable manifest format.
 #[derive(Deserialize)]
 struct ManifestFile {
@@ -322,14 +384,17 @@ impl ManifestRegistry {
     /// the single source of truth for manifest signing payloads. See #837.
     #[cfg_attr(not(feature = "crypto"), allow(unused_variables))]
     pub fn load_toml_with_trust(&mut self, content: &str, trust_store: &TrustStore) {
-        let file: ManifestFile = match toml::from_str(content) {
-            Ok(f) => f,
-            Err(_) => return,
-        };
+        for entry in parse_entries(content) {
+            self.register_entry(&entry, trust_store);
+        }
+    }
 
-        let name = file.tool.name.clone();
+    /// Admit (or refuse) one parsed TOML entry.
+    #[cfg_attr(not(feature = "crypto"), allow(unused_variables))]
+    fn register_entry(&mut self, entry: &ToolEntry, trust_store: &TrustStore) {
+        let name = entry.name.clone();
 
-        let manifest = match convert_entry(&file.tool) {
+        let manifest = match convert_entry(entry) {
             Some(m) => m,
             None => return,
         };
@@ -1017,6 +1082,68 @@ schema_hash = "not-hex"
         assert_eq!(
             reg.verify_served_tool("bad", &"ab".repeat(32)),
             Err(ServedToolError::NoManifest)
+        );
+    }
+
+    /// `nucleus manifest init` writes `[[tools]]`; the registry used to read
+    /// only `[tool]`, so generated manifests loaded as nothing at all.
+    #[test]
+    fn a_tools_array_loads_every_entry() {
+        let mut reg = ManifestRegistry::new();
+        reg.load_toml(
+            r#"
+[[tools]]
+name = "a"
+capabilities = ["read_files"]
+instruction_sources = ["static"]
+admissible_sinks = ["local_memory"]
+
+[[tools]]
+name = "b"
+capabilities = ["read_files"]
+instruction_sources = ["static"]
+admissible_sinks = ["local_memory"]
+"#,
+        );
+        assert_eq!(reg.admitted_count(), 2);
+        assert_eq!(
+            parse_manifest_toml("nonsense = 1")
+                .unwrap_err()
+                .contains("no `[tool]`"),
+            true
+        );
+    }
+
+    /// Sign, then verify under a trust store holding the key: the round trip
+    /// the CLI performs. A tampered `schema_hash` after signing fails, which
+    /// is what makes the signed digest worth anything.
+    #[cfg(feature = "crypto")]
+    #[test]
+    fn a_signed_manifest_verifies_and_a_tampered_schema_hash_does_not() {
+        let seed = [3u8; 32];
+        let mut m = parse_manifest_toml(
+            r#"
+[tool]
+name = "t"
+capabilities = ["read_files"]
+instruction_sources = ["static"]
+admissible_sinks = ["local_memory"]
+"#,
+        )
+        .unwrap()
+        .remove(0);
+        m.schema_hash = [0xabu8; 32];
+        let public = sign_manifest(&mut m, &seed);
+        assert_eq!(public, public_key_for_seed(&seed));
+        let trust = TrustStore {
+            keys: vec![public.to_vec()],
+        };
+        assert!(verify_manifest_signature(&m, &trust).is_ok());
+
+        m.schema_hash = [0xcdu8; 32];
+        assert_eq!(
+            verify_manifest_signature(&m, &trust),
+            Err(AdmissionDenyReason::InvalidSignature)
         );
     }
 }

--- a/crates/portcullis/src/manifest_registry.rs
+++ b/crates/portcullis/src/manifest_registry.rs
@@ -1106,12 +1106,9 @@ admissible_sinks = ["local_memory"]
 "#,
         );
         assert_eq!(reg.admitted_count(), 2);
-        assert_eq!(
-            parse_manifest_toml("nonsense = 1")
-                .unwrap_err()
-                .contains("no `[tool]`"),
-            true
-        );
+        assert!(parse_manifest_toml("nonsense = 1")
+            .unwrap_err()
+            .contains("no `[tool]`"));
     }
 
     /// Sign, then verify under a trust store holding the key: the round trip


### PR DESCRIPTION
Part of #1637 (residual 5: trust-store CLI). Stacked on #2482 → #2481 → #2472; retargets as those merge.

### What was wrong, verified on `main`
- `.nucleus/trust/*.pub` was documented as the operator root of trust and read by `TrustStore::load_from_dir`, but nothing created or managed it.
- No signer existed for `ToolManifest`: `manifest init` wrote `# signature = ""  # Add Ed25519 signature after review` and left the publisher to hand-roll `canonical_bytes()`.
- `manifest init` writes `[[tools]]`; `ManifestRegistry` parsed only `[tool]`, so a generated manifest loaded as **zero** tools with no error.

### The change
- **`nucleus trust`**: `keygen --out FILE` (hex seed, mode 0600, refuses to overwrite; `.pub` beside it), `add KEY [--name] [--dir]` (a `.pub` file or hex; validated 32 bytes; name restricted to `[A-Za-z0-9._-]`), `list`, `remove NAME`. Operates on `<dir>/.nucleus/trust`, the exact store the verifier reads (pinned by a test that loads it through `TrustStore::load_from_dir`). No keychain involvement.
- **`nucleus manifest sign FILE --key SEED (--pins PINFILE | --schema-hash HEX) [--out]`**: for every entry, sets `schema_hash` to the guard's own `ToolSchemaRegistry::hash_schema` over the pinned descriptor (so what the publisher signs is literally what `mcp-guard --manifests` will compare), signs, writes `signature`/`signing_key` back as hex. **Refuses** an entry with no digest: a signed manifest that pins nothing vouches for nothing. Comments in the TOML are not preserved (stated in the help).
- **`nucleus manifest verify FILE --dir .`**: loads under the trust store as the guard would and prints per-entry admitted / unsigned / rejected / pins-nothing; exit 1 unless every entry is admitted with a descriptor pinned; an empty trust store is an error.
- **portcullis** `manifest_registry`: `parse_manifest_toml` (public conversion without admission), `sign_manifest`, `public_key_for_seed` (crypto feature); `load_toml_with_trust` accepts both `[tool]` and `[[tools]]`, each entry signed on its own.

### Tests
`sign_then_verify_round_trip_pins_the_guard_digest` (CLI: keygen-equivalent seed → sign against pins → unsigned refused → trust add → verify admits → `verify_served_tool` accepts the guard digest → a different key fails closed), `add_list_remove_round_trip_and_the_store_is_what_portcullis_reads`, `a_malformed_key_is_refused`, `keygen_writes_a_seed_and_its_public_half`; portcullis `a_tools_array_loads_every_entry`, `a_signed_manifest_verifies_and_a_tampered_schema_hash_does_not`.

### Verification
`cargo test -p nucleus-cli` · `cargo test -p portcullis --features spec,crypto --lib manifest_registry` · `cargo clippy -p nucleus-cli --all-targets -- -D warnings` · `cargo clippy -p portcullis --features spec,crypto --lib -- -D warnings` · `cargo fmt --check` · `scripts/check-line-ratchet.sh --strict` · `ci/no-vendor-strings.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZaH5waz88vL1qfNpFNfZ4
