### PR TITLE
delegation(token): the session task token names the certificate it was derived from; the proxy refuses a mismatch (#2486)

### DIFF
--- a/crates/nucleus-audit/src/main.rs
+++ b/crates/nucleus-audit/src/main.rs
@@ -251,6 +251,10 @@ enum Command {
         /// The executor's Ed25519 public key, hex-encoded (32 bytes).
         #[arg(long, requires = "attestation")]
         executor_pubkey: Option<String>,
+        /// Require every record to be decided under this certificate fingerprint
+        /// (hex): the pod's `fingerprint` in the node's `authority.json` (#2437).
+        #[arg(long)]
+        authority_fingerprint: Option<String>,
     },
     /// Verify a log of signed MediationReceipts and render a scoreboard.
     ///
@@ -642,27 +646,20 @@ fn main() -> Result<(), AuditError> {
             json,
             attestation,
             executor_pubkey,
+            authority_fingerprint,
         } => {
             let mut report =
                 verify_art12::verify_art12_log(&log, secret.as_ref().map(|s| s.as_bytes()))?;
+            verify_art12::apply_authority_requirement(
+                &mut report,
+                authority_fingerprint.as_deref(),
+            )?;
 
             if let (Some(att_path), Some(pubkey_hex)) = (attestation, executor_pubkey) {
                 let att: portcullis::art12_record::Art12Attestation =
                     serde_json::from_str(&std::fs::read_to_string(&att_path)?)
                         .map_err(|e| AuditError::Json { line: 0, source: e })?;
-                let key_bytes: [u8; 32] = hex::decode(&pubkey_hex)
-                    .ok()
-                    .and_then(|v| v.try_into().ok())
-                    .ok_or_else(|| AuditError::Invalid {
-                        line: 0,
-                        message: "--executor-pubkey must be 32 hex-encoded bytes".to_string(),
-                    })?;
-                let key = ed25519_dalek::VerifyingKey::from_bytes(&key_bytes).map_err(|_| {
-                    AuditError::Invalid {
-                        line: 0,
-                        message: "--executor-pubkey is not a valid Ed25519 public key".to_string(),
-                    }
-                })?;
+                let key = verify_art12::executor_pubkey_from_hex(&pubkey_hex)?;
                 verify_art12::check_attestation(&att, &report.chain_head, &key)?;
                 report.attestation_checked = true;
                 report

--- a/crates/nucleus-audit/src/verify_art12.rs
+++ b/crates/nucleus-audit/src/verify_art12.rs
@@ -64,6 +64,13 @@ pub struct Art12Report {
     pub signatures_checked: bool,
     /// Whether an executor attestation was checked against the computed head.
     pub attestation_checked: bool,
+    /// How many records name the certificate they were decided under
+    /// (`authority.fingerprint`, #2437). A pod created since the certificate
+    /// convergence binds every record; a shortfall is listed as a limitation.
+    pub authority_bound: u64,
+    /// The distinct certificate fingerprints named, in first-seen order. One
+    /// per session is the expected shape: a pod holds one certificate.
+    pub authority_fingerprints: Vec<String>,
     /// What this run did NOT establish. Never empty.
     pub limitations: Vec<String>,
 }
@@ -181,6 +188,8 @@ pub fn verify_art12_log(path: &Path, secret: Option<&[u8]>) -> Result<Art12Repor
         verdicts: BTreeMap::new(),
         signatures_checked: secret.is_some(),
         attestation_checked: false,
+        authority_bound: 0,
+        authority_fingerprints: Vec::new(),
         limitations: base_limitations(secret.is_some()),
     };
 
@@ -256,6 +265,12 @@ pub fn verify_art12_log(path: &Path, secret: Option<&[u8]>) -> Result<Art12Repor
         }
 
         report.records += 1;
+        if let Some(fp) = rec.authority_fingerprint() {
+            report.authority_bound += 1;
+            if !report.authority_fingerprints.iter().any(|f| f == fp) {
+                report.authority_fingerprints.push(fp.to_string());
+            }
+        }
         report.first_timestamp.get_or_insert(rec.timestamp_unix);
         report.last_timestamp = Some(rec.timestamp_unix);
         if rec.actor.spiffe_id.as_ref().is_some_and(|s| !s.is_empty()) {
@@ -268,9 +283,95 @@ pub fn verify_art12_log(path: &Path, secret: Option<&[u8]>) -> Result<Art12Repor
     }
 
     report.chain_head = prev_hash.unwrap_or_default();
+    if report.authority_bound < report.records {
+        report.limitations.push(format!(
+            "{} of {} records name no authority (no `authority.fingerprint`): they cannot be tied \
+             to the certificate — and so the root key — that authorized the deciding kernel. \
+             Expected only for pods created before the node issued certificates.",
+            report.records - report.authority_bound,
+            report.records
+        ));
+    }
     Ok(report)
 }
 
+/// Require every record to have been decided under exactly `expected_hex` —
+/// the fingerprint of the certificate the node issued this pod (from its
+/// `pods/<id>/authority.json`). This is what ties a log to the root public
+/// key with no side channel: the node verified that chain against its root
+/// when it issued it, and every record here names it inside the signed
+/// preimage.
+///
+/// # Errors
+/// If any record names no authority, or any names a different one.
+pub fn require_authority(report: &Art12Report, expected_hex: &str) -> Result<(), AuditError> {
+    if report.authority_bound != report.records {
+        return Err(AuditError::Invalid {
+            line: 0,
+            message: format!(
+                "{} of {} records name no authority; --authority-fingerprint requires every record \
+                 to be bound",
+                report.records - report.authority_bound,
+                report.records
+            ),
+        });
+    }
+    let expected = expected_hex.trim().to_ascii_lowercase();
+    if let Some(other) = report
+        .authority_fingerprints
+        .iter()
+        .find(|fp| fp.to_ascii_lowercase() != expected)
+    {
+        return Err(AuditError::Invalid {
+            line: 0,
+            message: format!(
+                "a record names authority {other}, not the expected {expected} -- it was decided \
+                 under a certificate this node did not issue to this pod"
+            ),
+        });
+    }
+    Ok(())
+}
+
+/// Parse `--executor-pubkey` (32 hex-encoded bytes) into a verifying key.
+///
+/// # Errors
+/// If the hex is not 32 bytes or is not a valid Ed25519 point.
+pub fn executor_pubkey_from_hex(
+    pubkey_hex: &str,
+) -> Result<ed25519_dalek::VerifyingKey, AuditError> {
+    let key_bytes: [u8; 32] = hex::decode(pubkey_hex)
+        .ok()
+        .and_then(|v| v.try_into().ok())
+        .ok_or_else(|| AuditError::Invalid {
+            line: 0,
+            message: "--executor-pubkey must be 32 hex-encoded bytes".to_string(),
+        })?;
+    ed25519_dalek::VerifyingKey::from_bytes(&key_bytes).map_err(|_| AuditError::Invalid {
+        line: 0,
+        message: "--executor-pubkey is not a valid Ed25519 public key".to_string(),
+    })
+}
+
+/// Apply `--authority-fingerprint`, when given: every record must be bound to
+/// it ([`require_authority`]), after which the "name no authority" limitation
+/// no longer applies.
+///
+/// # Errors
+/// Those of [`require_authority`].
+pub fn apply_authority_requirement(
+    report: &mut Art12Report,
+    expected_hex: Option<&str>,
+) -> Result<(), AuditError> {
+    let Some(expected) = expected_hex else {
+        return Ok(());
+    };
+    require_authority(report, expected)?;
+    report
+        .limitations
+        .retain(|l| !l.contains("name no authority"));
+    Ok(())
+}
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -597,5 +698,41 @@ mod tests {
             format!("{err}").contains("unknown attestation kind"),
             "got: {err}"
         );
+    }
+
+    fn report_with(records: u64, bound: u64, fingerprints: &[&str]) -> Art12Report {
+        Art12Report {
+            records,
+            chain_head: String::new(),
+            first_timestamp: None,
+            last_timestamp: None,
+            identified_actors: 0,
+            verdicts: BTreeMap::new(),
+            signatures_checked: false,
+            attestation_checked: false,
+            authority_bound: bound,
+            authority_fingerprints: fingerprints.iter().map(|s| s.to_string()).collect(),
+            limitations: vec!["N of M records name no authority".to_string()],
+        }
+    }
+
+    /// #2437: `--authority-fingerprint` passes only when EVERY record names
+    /// exactly that certificate; a partial binding or a foreign fingerprint
+    /// fails, and a pass discharges the "name no authority" limitation.
+    #[test]
+    fn the_authority_requirement_is_all_or_nothing() {
+        let mut ok = report_with(3, 3, &["ab"]);
+        apply_authority_requirement(&mut ok, Some("AB")).unwrap();
+        assert!(ok.limitations.is_empty(), "the limitation is discharged");
+
+        let mut partial = report_with(3, 2, &["ab"]);
+        assert!(apply_authority_requirement(&mut partial, Some("ab")).is_err());
+
+        let mut foreign = report_with(3, 3, &["ab", "cd"]);
+        assert!(apply_authority_requirement(&mut foreign, Some("ab")).is_err());
+
+        let mut unasked = report_with(3, 0, &[]);
+        apply_authority_requirement(&mut unasked, None).unwrap();
+        assert_eq!(unasked.limitations.len(), 1, "no flag, no requirement");
     }
 }

--- a/crates/nucleus-node/src/art12_collector.rs
+++ b/crates/nucleus-node/src/art12_collector.rs
@@ -195,12 +195,19 @@ pub async fn art12_append(
     let sig = headers
         .get("X-Nucleus-Signature")
         .and_then(|v| v.to_str().ok());
+    // The session id on this route is the pod id (`provision_pod_env`), so the
+    // node can ask its own registry which certificate it issued this pod.
+    let expected_authority = match uuid::Uuid::parse_str(&sid) {
+        Ok(pod_id) => state.authority.certificate_fingerprint(pod_id).await,
+        Err(_) => None,
+    };
     accept(
         &state.state_dir,
         state.trust_gate.art12_secret(),
         &sid,
         sig,
         &body,
+        expected_authority,
     )
     .await
 }
@@ -222,12 +229,18 @@ pub async fn art12_append(
 /// * storage failure — reported as failure, never as success. A pod told
 ///   "accepted" for a record the host did not keep carries on believing it was
 ///   witnessed.
+/// * wrong authority — when this node issued the pod a certificate
+///   (`expected_authority`), a record that names a different fingerprint, or
+///   none, is refused (#2437). The proxy stamps the certificate it verified at
+///   boot into every record; a mismatch means the record was not produced by
+///   the kernel this node authorized.
 pub async fn accept(
     state_dir: &Path,
     secret: Option<&[u8]>,
     raw_session_id: &str,
     signature: Option<&str>,
     body: &str,
+    expected_authority: Option<[u8; 32]>,
 ) -> (axum::http::StatusCode, &'static str) {
     use axum::http::StatusCode;
 
@@ -254,6 +267,12 @@ pub async fn accept(
         tracing::warn!(%session_id, "rejected an unauthenticated Article 12 record");
         return (StatusCode::UNAUTHORIZED, "bad signature");
     }
+    if let Some(expected) = expected_authority
+        && let Err(reason) = check_authority_binding(body, &expected)
+    {
+        tracing::warn!(%session_id, reason, "rejected an Article 12 record with the wrong authority");
+        return (StatusCode::FORBIDDEN, reason);
+    }
 
     match append_record(state_dir, &session_id, body).await {
         Ok(()) => (StatusCode::NO_CONTENT, ""),
@@ -262,6 +281,30 @@ pub async fn accept(
             (StatusCode::INTERNAL_SERVER_ERROR, "storage failed")
         }
     }
+}
+
+/// Whether a shipped record names the certificate this node issued its pod.
+///
+/// The record is parsed as the shared `Art12Record` type so the check reads the
+/// same field a verifier reads (`authority.fingerprint`, inside the signed
+/// preimage), not a regex over the body.
+fn check_authority_binding(body: &str, expected: &[u8; 32]) -> Result<(), &'static str> {
+    let rec: portcullis::art12_record::Art12Record =
+        serde_json::from_str(body).map_err(|_| "record is not an Article 12 record")?;
+    match rec.authority_fingerprint() {
+        None => Err("record names no authority but this pod holds a certificate"),
+        Some(fp) if fp == hex::encode(expected) => Ok(()),
+        Some(_) => Err("record names an authority this node did not issue to this pod"),
+    }
+}
+
+/// The container driver's Article 12 provisioning: a pod-side log under the
+/// pod's data volume (never the workspace). No ship URL: a container's network
+/// namespace has no guaranteed route back to the node's listener, so — like a
+/// Firecracker pod until vsock shipping lands — the executor attests the head
+/// the POD reported. Until #2437 a container pod kept no Article 12 log at all.
+pub fn provision_container_env(env: &mut Vec<String>) {
+    env.push("NUCLEUS_TOOL_PROXY_ART12_LOG=/data/pod/art12.jsonl".to_string());
 }
 
 #[cfg(test)]
@@ -376,7 +419,7 @@ mod tests {
     #[tokio::test]
     async fn an_unsigned_record_is_refused_and_not_stored() {
         let dir = tempfile::tempdir().unwrap();
-        let (code, _) = accept(dir.path(), Some(b"k"), "s1", None, "{}").await;
+        let (code, _) = accept(dir.path(), Some(b"k"), "s1", None, "{}", None).await;
         assert_eq!(code, StatusCode::UNAUTHORIZED);
         assert!(
             !session_log_path(dir.path(), "s1").exists(),
@@ -396,6 +439,7 @@ mod tests {
             "s1",
             Some(&sign(b"other", "s1", "{}")),
             "{}",
+            None,
         )
         .await;
         assert_eq!(code, StatusCode::UNAUTHORIZED);
@@ -414,6 +458,7 @@ mod tests {
             "s1",
             Some(&sign(b"k", "s1", body)),
             body,
+            None,
         )
         .await;
         assert_eq!(code, StatusCode::NO_CONTENT);
@@ -429,7 +474,15 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let body = "{}";
         // Even a signature valid under the EMPTY key must not get in.
-        let (code, _) = accept(dir.path(), None, "s1", Some(&sign(b"", "s1", body)), body).await;
+        let (code, _) = accept(
+            dir.path(),
+            None,
+            "s1",
+            Some(&sign(b"", "s1", body)),
+            body,
+            None,
+        )
+        .await;
         assert_eq!(code, StatusCode::SERVICE_UNAVAILABLE);
         assert!(!session_log_path(dir.path(), "s1").exists());
     }
@@ -445,9 +498,92 @@ mod tests {
             "../escaped",
             Some(&sign(b"k", "s1", body)),
             body,
+            None,
         )
         .await;
         assert_eq!(code, StatusCode::BAD_REQUEST);
         assert!(!dir.path().join("../escaped.jsonl").exists());
+    }
+
+    fn bound_record(fingerprint_hex: Option<&str>) -> String {
+        let ext = fingerprint_hex
+            .map(|fp| format!(r#","extensions":{{"authority.fingerprint":"{fp}"}}"#))
+            .unwrap_or_default();
+        format!(
+            r#"{{"schema_version":1,"seq":1,"timestamp_unix":1,"session_id":"s","transport":"http","actor":{{"kind":"unknown"}},"operation":"run_bash","subject":"ls","verdict":"allow","gate_class":"hard","policy_checksum":"c","dlc_admission":"unprovisioned","lockdown_active":false{ext},"prev_hash":"","hash":"","signature":""}}"#
+        )
+    }
+
+    const ISSUED: [u8; 32] = [7u8; 32];
+
+    /// #2437: a record naming the certificate this node issued is stored.
+    #[tokio::test]
+    async fn a_record_naming_the_issued_authority_is_stored() {
+        let dir = tempfile::tempdir().unwrap();
+        let body = bound_record(Some(&hex::encode(ISSUED)));
+        let (code, _) = accept(
+            dir.path(),
+            Some(b"k"),
+            "s1",
+            Some(&sign(b"k", "s1", &body)),
+            &body,
+            Some(ISSUED),
+        )
+        .await;
+        assert_eq!(code, StatusCode::NO_CONTENT);
+        assert!(session_log_path(dir.path(), "s1").exists());
+    }
+
+    /// A validly SIGNED record that names a certificate this node did not issue
+    /// to this pod is refused and not stored: the signature proves the pod sent
+    /// it, the fingerprint proves which kernel decided it, and they disagree.
+    #[tokio::test]
+    async fn a_record_naming_another_authority_is_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let body = bound_record(Some(&hex::encode([8u8; 32])));
+        let (code, reason) = accept(
+            dir.path(),
+            Some(b"k"),
+            "s1",
+            Some(&sign(b"k", "s1", &body)),
+            &body,
+            Some(ISSUED),
+        )
+        .await;
+        assert_eq!(code, StatusCode::FORBIDDEN, "{reason}");
+        assert!(!session_log_path(dir.path(), "s1").exists());
+    }
+
+    /// A pod that holds a certificate cannot ship records that name none: the
+    /// binding is mandatory, not best-effort, once the node has issued one.
+    #[tokio::test]
+    async fn a_record_naming_no_authority_is_refused_when_the_pod_holds_one() {
+        let dir = tempfile::tempdir().unwrap();
+        let body = bound_record(None);
+        let (code, _) = accept(
+            dir.path(),
+            Some(b"k"),
+            "s1",
+            Some(&sign(b"k", "s1", &body)),
+            &body,
+            Some(ISSUED),
+        )
+        .await;
+        assert_eq!(code, StatusCode::FORBIDDEN);
+        assert!(!session_log_path(dir.path(), "s1").exists());
+    }
+
+    /// The container driver keeps an Article 12 log under the pod`s data
+    /// volume, never the workspace (the proxy refuses a workspace path).
+    #[test]
+    fn container_pods_keep_an_article_12_log_outside_the_workspace() {
+        let mut env = Vec::new();
+        provision_container_env(&mut env);
+        let log = env
+            .iter()
+            .find_map(|e| e.strip_prefix("NUCLEUS_TOOL_PROXY_ART12_LOG="))
+            .expect("the container driver provisions an Article 12 log");
+        assert!(log.starts_with("/data/pod/"), "{log}");
+        assert!(!log.starts_with("/workspace"), "{log}");
     }
 }

--- a/crates/nucleus-node/src/main.rs
+++ b/crates/nucleus-node/src/main.rs
@@ -1819,6 +1819,7 @@ async fn spawn_container_pod(
             state.proxy_approval_secret
         ));
         env.push("NUCLEUS_TOOL_PROXY_AUDIT_LOG=/data/pod/audit.log".to_string());
+        art12_collector::provision_container_env(&mut env);
 
         // Pass audit sink config from PodSpec for deletion-resistant remote storage
         if let Some(ref sink) = spec.spec.audit_sink {

--- a/crates/nucleus-node/src/main.rs
+++ b/crates/nucleus-node/src/main.rs
@@ -1588,7 +1588,7 @@ async fn spawn_local_pod(
     // startup (fail-closed). Injected on the same host-controlled env channel as
     // the secrets above; the token itself is a scoped capability + PUBLIC issuer
     // key (not a secret). Names match the tool-proxy verify half exactly.
-    if let Some(minted) = pod_authority::mint_task_token_for_spec(state, spec, id) {
+    if let Some(minted) = pod_authority::mint_task_token_for_spec(state, spec, id).await {
         command.env("NUCLEUS_TASK_TOKEN", &minted.token_json);
         command.env("NUCLEUS_TASK_TOKEN_NONCE", &minted.nonce_hex);
         command.env("NUCLEUS_TASK_TOKEN_ISSUER", &minted.issuer_hex);
@@ -1851,7 +1851,7 @@ async fn spawn_container_pod(
 
         // Live-path session capability token (see spawn_local_pod). Injected in
         // proxy mode — the only container mode that runs the tool-proxy sidecar.
-        if let Some(minted) = pod_authority::mint_task_token_for_spec(state, spec, id) {
+        if let Some(minted) = pod_authority::mint_task_token_for_spec(state, spec, id).await {
             env.push(format!("NUCLEUS_TASK_TOKEN={}", minted.token_json));
             env.push(format!("NUCLEUS_TASK_TOKEN_NONCE={}", minted.nonce_hex));
             env.push(format!("NUCLEUS_TASK_TOKEN_ISSUER={}", minted.issuer_hex));
@@ -2370,7 +2370,7 @@ async fn spawn_firecracker_pod(
         // guest over the workload API (`FETCH_TASK_TOKEN`, per-pod socket) — no
         // longer written to the kernel cmdline — so `from_spec` does not take
         // it; only `PodMaterial` below does.
-        let task_token = pod_authority::mint_task_token_for_spec(state, spec, id);
+        let task_token = pod_authority::mint_task_token_for_spec(state, spec, id).await;
         let pod_certificate = state.authority.boot_certificate(id).await;
         let config = firecracker_config::FirecrackerConfig::from_spec(
             spec,

--- a/crates/nucleus-node/src/pod_authority.rs
+++ b/crates/nucleus-node/src/pod_authority.rs
@@ -508,6 +508,14 @@ impl PodAuthority {
         })
     }
 
+    /// The fingerprint of the certificate this node issued to `pod_id`, for
+    /// cross-checking the authority a pod's shipped Article 12 records claim
+    /// (#2437). `None` when the node issued this pod nothing.
+    pub async fn certificate_fingerprint(&self, pod_id: Uuid) -> Option<[u8; 32]> {
+        let inner = self.inner.lock().await;
+        Some(inner.pods.get(&pod_id)?.cert.fingerprint())
+    }
+
     /// Retire a pod's certificate and return its budget allocation to the
     /// parent's ledger. Until children report actual spend, the whole
     /// allocation is folded into the parent's consumption (no refund).

--- a/crates/nucleus-node/src/pod_authority.rs
+++ b/crates/nucleus-node/src/pod_authority.rs
@@ -711,7 +711,7 @@ fn base64_decode(s: &str) -> Result<Vec<u8>, base64::DecodeError> {
     not(any(feature = "local-driver", target_os = "linux")),
     allow(dead_code)
 )]
-pub(crate) fn mint_task_token_for_spec(
+pub(crate) async fn mint_task_token_for_spec(
     state: &NodeState,
     spec: &PodSpec,
     id: Uuid,
@@ -736,12 +736,16 @@ pub(crate) fn mint_task_token_for_spec(
     };
     // TTL = the pod/session lifetime (the spec's own timeout bound, in seconds).
     let ttl_secs = spec.spec.timeout_seconds;
+    // The certificate this node issued the pod (#2464) — the token names it
+    // (#2486). `None` only for a pod the authority refused to register.
+    let authority = state.authority.certificate_fingerprint(id).await;
     match crate::session_mint::mint_session_task_token(
         &id.to_string(),
         &policy,
         ttl_secs,
         now_unix,
         state.trust_gate.task_issuer_signing_key.as_ref(),
+        authority,
     ) {
         Ok(minted) => Some(minted),
         Err(e) => {

--- a/crates/nucleus-node/src/session_mint.rs
+++ b/crates/nucleus-node/src/session_mint.rs
@@ -84,6 +84,7 @@ pub(crate) fn mint_session_task_token(
     ttl_secs: u64,
     now_unix: u64,
     issuer: &SigningKey,
+    authority: Option<[u8; 32]>,
 ) -> Result<MintedTaskToken, serde_json::Error> {
     // Fresh per-pod nonce from the OS CSPRNG, at the exact width SignedTaskRef
     // pins as the effective nonce.
@@ -95,7 +96,15 @@ pub(crate) fn mint_session_task_token(
     // op). Paths deferred to the next brick — see module docs.
     let scope = TokenScope::new(policy.granted_operations(), Vec::new());
 
-    let token = SignedTaskRef::issue(task_id, scope, nonce, now_unix, ttl_secs, issuer);
+    // Bound to the certificate the node issued this pod (#2486), when it has
+    // one: the token then names the authority its scope was derived from, and
+    // the tool-proxy refuses a token naming another.
+    let token = match authority {
+        Some(fp) => SignedTaskRef::issue_under_authority(
+            task_id, scope, nonce, now_unix, ttl_secs, issuer, fp,
+        ),
+        None => SignedTaskRef::issue(task_id, scope, nonce, now_unix, ttl_secs, issuer),
+    };
     let token_json = serde_json::to_string(&token)?;
 
     Ok(MintedTaskToken {
@@ -128,7 +137,8 @@ mod tests {
         let issuer = issuer_key(3);
         let policy = PermissionLattice::local_dev(); // read/write/edit/bash/glob/grep/commit
 
-        let minted = mint_session_task_token("pod-abc", &policy, TTL, NOW, &issuer).expect("mint");
+        let minted =
+            mint_session_task_token("pod-abc", &policy, TTL, NOW, &issuer, None).expect("mint");
 
         // Reconstruct the verifier inputs from the injected strings exactly as
         // the tool-proxy would.
@@ -183,7 +193,8 @@ mod tests {
             extensions: std::collections::BTreeMap::new(),
         };
 
-        let minted = mint_session_task_token("pod-locked", &policy, TTL, NOW, &issuer).unwrap();
+        let minted =
+            mint_session_task_token("pod-locked", &policy, TTL, NOW, &issuer, None).unwrap();
         let token: SignedTaskRef = serde_json::from_str(&minted.token_json).unwrap();
         let nonce: [u8; 16] = hex::decode(&minted.nonce_hex).unwrap().try_into().unwrap();
         let issuer_pub: [u8; 32] = hex::decode(&minted.issuer_hex).unwrap().try_into().unwrap();
@@ -206,7 +217,7 @@ mod tests {
         let issuer = issuer_key(5);
         let policy = PermissionLattice::pr_review(); // read/glob/grep/web only
 
-        let minted = mint_session_task_token("pod-pr", &policy, TTL, NOW, &issuer).unwrap();
+        let minted = mint_session_task_token("pod-pr", &policy, TTL, NOW, &issuer, None).unwrap();
         let token: SignedTaskRef = serde_json::from_str(&minted.token_json).unwrap();
 
         let scope = token.effective_scope().unwrap();
@@ -222,5 +233,21 @@ mod tests {
         // allowed op (read_files) is present.
         assert!(!scope.allowed_operations.contains(&Operation::RunBash));
         assert!(scope.allowed_operations.contains(&Operation::ReadFiles));
+    }
+
+    /// #2486: a token minted under the pod's certificate carries that
+    /// certificate's fingerprint in the signed root claim.
+    #[test]
+    fn minted_token_names_the_certificate_it_was_derived_from() {
+        let issuer = issuer_key(4);
+        let policy = PermissionLattice::local_dev();
+        let fp = [0x42u8; 32];
+        let minted =
+            mint_session_task_token("pod-fp", &policy, TTL, NOW, &issuer, Some(fp)).unwrap();
+        let token: SignedTaskRef = serde_json::from_str(&minted.token_json).unwrap();
+        assert_eq!(token.authority(), Some(fp));
+        let issuer_pub: [u8; 32] = hex::decode(&minted.issuer_hex).unwrap().try_into().unwrap();
+        let nonce: [u8; 16] = hex::decode(&minted.nonce_hex).unwrap().try_into().unwrap();
+        assert!(token.verify(&issuer_pub, NOW + 1, &nonce).is_ok());
     }
 }

--- a/crates/nucleus-provenance-memory/src/taskref_token.rs
+++ b/crates/nucleus-provenance-memory/src/taskref_token.rs
@@ -134,6 +134,15 @@ pub struct BlockClaim {
     pub ttl: u64,
     /// Ed25519 verifying-key bytes of the block's issuer/attenuator.
     pub issuer_vk: [u8; 32],
+    /// The authority this token was derived from (#2486): the fingerprint of
+    /// the `LatticeCertificate` the issuing node had granted the task. Signed
+    /// (it is inside `signing_bytes`), carried UNCHANGED across attenuation
+    /// hops (`verify` refuses a chain that switches it), and optional so a
+    /// token minted before certificate-bound tokens still verifies: absent
+    /// means "no field", and `skip_serializing_if` keeps its signing bytes
+    /// byte-identical to the v1 layout.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub authority: Option<[u8; 32]>,
 }
 
 /// A [`BlockClaim`] plus the issuer's Ed25519 signature over its
@@ -203,6 +212,8 @@ pub enum TokenError {
     /// (replay / stale token).
     #[error("effective nonce mismatch (replay)")]
     NonceMismatch,
+    #[error("block {block} names a different authority than its parent")]
+    AuthoritySwitched { block: usize },
 }
 
 /// Domain-tagged canonical bytes a block's issuer signs over. Binds the
@@ -239,6 +250,41 @@ impl SignedTaskRef {
         ttl: u64,
         issuer: &SigningKey,
     ) -> Self {
+        Self::issue_with(task_id, scope, nonce, issued_at, ttl, issuer, None)
+    }
+
+    /// [`Self::issue`] bound to an authority: the fingerprint of the
+    /// certificate the issuer had granted the task (#2486). A verifier that
+    /// holds that certificate refuses a token naming another.
+    pub fn issue_under_authority(
+        task_id: impl Into<String>,
+        scope: TokenScope,
+        nonce: [u8; 16],
+        issued_at: u64,
+        ttl: u64,
+        issuer: &SigningKey,
+        authority: [u8; 32],
+    ) -> Self {
+        Self::issue_with(
+            task_id,
+            scope,
+            nonce,
+            issued_at,
+            ttl,
+            issuer,
+            Some(authority),
+        )
+    }
+
+    fn issue_with(
+        task_id: impl Into<String>,
+        scope: TokenScope,
+        nonce: [u8; 16],
+        issued_at: u64,
+        ttl: u64,
+        issuer: &SigningKey,
+        authority: Option<[u8; 32]>,
+    ) -> Self {
         let task_id = task_id.into();
         let claim = BlockClaim {
             scope,
@@ -247,6 +293,7 @@ impl SignedTaskRef {
             issued_at,
             ttl,
             issuer_vk: issuer.verifying_key().to_bytes(),
+            authority,
         };
         let sig = issuer
             .sign(&signing_bytes(&task_id, &claim))
@@ -287,6 +334,8 @@ impl SignedTaskRef {
             issued_at,
             ttl,
             issuer_vk: attenuator.verifying_key().to_bytes(),
+            // The authority is the ROOT's and never changes across hops.
+            authority: parent.claim.authority,
         };
         let sig = attenuator
             .sign(&signing_bytes(&next.task_id, &claim))
@@ -300,6 +349,11 @@ impl SignedTaskRef {
     /// only for an empty (invalid) token.
     pub fn effective_scope(&self) -> Option<&TokenScope> {
         self.blocks.last().map(|b| &b.claim.scope)
+    }
+
+    /// The authority the root block was issued under, if any (#2486).
+    pub fn authority(&self) -> Option<[u8; 32]> {
+        self.blocks.first().and_then(|b| b.claim.authority)
     }
 
     /// **The verification gate.** Returns the effective granted scope, or a
@@ -370,6 +424,11 @@ impl SignedTaskRef {
                 }
                 if !block.claim.scope.is_subset_of(&parent.claim.scope) {
                     return Err(TokenError::ScopeWidened { block: i });
+                }
+                // 5b. The authority is fixed at the root: a hop may not re-home
+                //     the token under another certificate (#2486).
+                if block.claim.authority != parent.claim.authority {
+                    return Err(TokenError::AuthoritySwitched { block: i });
                 }
             }
         }
@@ -629,6 +688,7 @@ mod tests {
             issued_at: 1_000,
             ttl: 500,
             issuer_vk: id,
+            authority: None,
         };
         let token = SignedTaskRef {
             task_id: "task-1".to_string(),
@@ -658,6 +718,7 @@ mod tests {
             issued_at: 1_000,
             ttl: 500,
             issuer_vk: [0u8; 32],
+            authority: None,
         };
         let token = SignedTaskRef {
             task_id: "task-1".to_string(),
@@ -670,5 +731,91 @@ mod tests {
             token.verify(&[0u8; 32], 1_200, &N0),
             Err(TokenError::BadSignature { block: 0 })
         );
+    }
+
+    // ── #2486: the authority claim ──────────────────────────────────────────
+
+    const AUTH: [u8; 32] = [0xaa; 32];
+
+    /// Minted under an authority, the token carries it, verifies, and an
+    /// attenuation hop carries the SAME authority forward.
+    #[test]
+    fn an_authority_bound_token_carries_it_through_attenuation() {
+        let issuer = key(1);
+        let vk = issuer.verifying_key().to_bytes();
+        let token = SignedTaskRef::issue_under_authority(
+            "task-1",
+            root_scope(),
+            N0,
+            1_000,
+            500,
+            &issuer,
+            AUTH,
+        );
+        assert_eq!(token.authority(), Some(AUTH));
+        assert!(token.verify(&vk, 1_200, &N0).is_ok());
+
+        let child = token.attenuate(
+            TokenScope::new(vec![Operation::ReadFiles], vec!["src/**".to_string()]),
+            N1,
+            1_100,
+            300,
+            &key(2),
+        );
+        assert_eq!(child.blocks[1].claim.authority, Some(AUTH));
+        assert!(child.verify(&vk, 1_200, &N1).is_ok());
+
+        // Round-trips through JSON with the field present.
+        let json = serde_json::to_string(&token).unwrap();
+        assert!(json.contains("\"authority\""));
+        let back: SignedTaskRef = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, token);
+    }
+
+    /// A hop that re-homes the token under another authority is refused —
+    /// even when the hop is otherwise honestly signed and narrower.
+    #[test]
+    fn a_hop_that_switches_authority_is_refused() {
+        let issuer = key(1);
+        let vk = issuer.verifying_key().to_bytes();
+        let token = SignedTaskRef::issue_under_authority(
+            "task-1",
+            root_scope(),
+            N0,
+            1_000,
+            500,
+            &issuer,
+            AUTH,
+        );
+        let mut child = token.attenuate(
+            TokenScope::new(vec![Operation::ReadFiles], vec!["src/**".to_string()]),
+            N1,
+            1_100,
+            300,
+            &key(2),
+        );
+        // Re-home and re-sign the hop with its own (attenuator) key.
+        child.blocks[1].claim.authority = Some([0xbb; 32]);
+        child.blocks[1].sig = key(2)
+            .sign(&signing_bytes(&child.task_id, &child.blocks[1].claim))
+            .to_bytes()
+            .to_vec();
+        assert_eq!(
+            child.verify(&vk, 1_200, &N1),
+            Err(TokenError::AuthoritySwitched { block: 1 })
+        );
+    }
+
+    /// Compatibility: a token minted with no authority (the v1 layout) still
+    /// verifies, has no authority, and its JSON carries no field at all —
+    /// so its signing bytes are byte-identical to before #2486.
+    #[test]
+    fn a_token_without_an_authority_still_verifies_and_serializes_as_before() {
+        let issuer = key(1);
+        let vk = issuer.verifying_key().to_bytes();
+        let token = root_token(&issuer);
+        assert_eq!(token.authority(), None);
+        assert!(token.verify(&vk, 1_200, &N0).is_ok());
+        assert!(!serde_json::to_string(&token).unwrap().contains("authority"));
     }
 }

--- a/crates/nucleus-tool-proxy/src/art12_sink.rs
+++ b/crates/nucleus-tool-proxy/src/art12_sink.rs
@@ -338,6 +338,45 @@ pub(crate) fn health_json(log: Option<&Arc<Art12Log>>) -> serde_json::Value {
 }
 
 /// Appends an Article 12 record for every verdict, then delegates.
+/// The authority a pod's records are bound to (#2437): what the proxy kept of
+/// its own certificate after the one-time boot verification. Stamped into every
+/// record as the `authority.*` extensions, so the decision names the chain —
+/// and, through the node's copy of that chain, the root public key — that
+/// authorized the kernel which made it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AuthorityBinding {
+    fingerprint_hex: String,
+    chain_depth: usize,
+    root_identity: String,
+}
+
+impl From<&crate::pod_cert::PodCertificate> for AuthorityBinding {
+    fn from(cert: &crate::pod_cert::PodCertificate) -> Self {
+        Self {
+            fingerprint_hex: hex::encode(cert.fingerprint),
+            chain_depth: cert.chain_depth,
+            root_identity: cert.root_identity.clone(),
+        }
+    }
+}
+
+impl AuthorityBinding {
+    fn stamp(&self, ext: &mut std::collections::BTreeMap<String, String>) {
+        use portcullis::art12_record::{
+            EXT_AUTHORITY_CHAIN_DEPTH, EXT_AUTHORITY_FINGERPRINT, EXT_AUTHORITY_ROOT,
+        };
+        ext.insert(
+            EXT_AUTHORITY_FINGERPRINT.to_string(),
+            self.fingerprint_hex.clone(),
+        );
+        ext.insert(
+            EXT_AUTHORITY_CHAIN_DEPTH.to_string(),
+            self.chain_depth.to_string(),
+        );
+        ext.insert(EXT_AUTHORITY_ROOT.to_string(), self.root_identity.clone());
+    }
+}
+
 pub(crate) struct Art12Sink {
     inner: Arc<dyn VerdictSink>,
     log: Arc<Art12Log>,
@@ -353,9 +392,12 @@ pub(crate) struct Art12Sink {
     dlc_provisioned: bool,
     /// Opt-in: issue a signed `MediationReceipt` per verdict (default `None`).
     receipt_signer: Option<ReceiptSigner>,
+    /// The pod's certificate, when it holds one: stamped into every record.
+    authority: Option<AuthorityBinding>,
 }
 
 impl Art12Sink {
+    #[allow(clippy::too_many_arguments)] // one constructor, one place to assemble the chain
     pub(crate) fn new(
         inner: Arc<dyn VerdictSink>,
         log: Arc<Art12Log>,
@@ -364,6 +406,7 @@ impl Art12Sink {
         dlc_provisioned: bool,
         shipper: Option<Arc<crate::art12_shipper::Art12Shipper>>,
         receipt_signer: Option<ReceiptSigner>,
+        authority: Option<AuthorityBinding>,
     ) -> Self {
         Self {
             inner,
@@ -373,6 +416,7 @@ impl Art12Sink {
             policy_checksum,
             dlc_provisioned,
             receipt_signer,
+            authority,
         }
     }
 
@@ -414,7 +458,7 @@ impl Art12Sink {
         // Everything the recorder attached that is not already a named field
         // travels as extensions — including `flow_cross_check` (#2144), so the
         // DAG's second opinion is in the regulatory record and not only in a log.
-        let extensions = ctx
+        let mut extensions: std::collections::BTreeMap<String, String> = ctx
             .extensions
             .iter()
             .filter(|(k, _)| {
@@ -425,6 +469,11 @@ impl Art12Sink {
             })
             .map(|(k, v)| (k.clone(), v.clone()))
             .collect();
+        // The authority this decision was made under (#2437). Stamped LAST so
+        // a recorder cannot claim a different certificate through the context.
+        if let Some(authority) = &self.authority {
+            authority.stamp(&mut extensions);
+        }
 
         Art12Record {
             // Assigned by `Art12Log::append`.
@@ -636,6 +685,7 @@ mod tests {
             false,
             None,
             None,
+            None,
         )
     }
 
@@ -677,6 +727,7 @@ mod tests {
                 emitted: Arc::clone(&emitted),
                 receipt_log: None,
             }),
+            None,
         );
 
         sink.record(ctx(VerdictOutcome::Allow, &[])).unwrap();
@@ -726,6 +777,7 @@ mod tests {
                 emitted: Arc::new(Mutex::new(Vec::new())),
                 receipt_log: Some(ReceiptLog::open(&receipt_path).unwrap()),
             }),
+            None,
         );
 
         sink.record(ctx(VerdictOutcome::Allow, &[])).unwrap();
@@ -906,5 +958,61 @@ mod tests {
         let work = TempDir::new().unwrap();
         let elsewhere = TempDir::new().unwrap();
         assert!(reject_workspace_path(&elsewhere.path().join("a.jsonl"), work.path()).is_ok());
+    }
+
+    /// #2437: a pod that holds a certificate stamps every record with the
+    /// authority the deciding kernel was built from, inside the signed
+    /// preimage; a recorder cannot override it through the context; a pod with
+    /// no certificate stamps nothing (a pre-authority node).
+    #[test]
+    fn every_record_names_the_authority_it_was_decided_under() {
+        use portcullis::art12_record::{
+            EXT_AUTHORITY_CHAIN_DEPTH, EXT_AUTHORITY_FINGERPRINT, EXT_AUTHORITY_ROOT,
+        };
+        let dir = TempDir::new().unwrap();
+        let authority = AuthorityBinding {
+            fingerprint_hex: hex::encode([0xabu8; 32]),
+            chain_depth: 2,
+            root_identity: "spiffe://td/ns/system/sa/cli".to_string(),
+        };
+        let bound = Art12Sink::new(
+            Arc::new(NullSink),
+            open_log(&dir),
+            "sess".to_string(),
+            "checksum".to_string(),
+            false,
+            None,
+            None,
+            Some(authority.clone()),
+        );
+
+        // A recorder claiming a different certificate through the context loses.
+        let rec = bound.project(&ctx(
+            VerdictOutcome::Allow,
+            &[(EXT_AUTHORITY_FINGERPRINT, "deadbeef")],
+        ));
+        assert_eq!(
+            rec.authority_fingerprint(),
+            Some(authority.fingerprint_hex.as_str())
+        );
+        assert_eq!(
+            rec.extensions
+                .get(EXT_AUTHORITY_CHAIN_DEPTH)
+                .map(String::as_str),
+            Some("2")
+        );
+        assert_eq!(
+            rec.extensions.get(EXT_AUTHORITY_ROOT).map(String::as_str),
+            Some("spiffe://td/ns/system/sa/cli")
+        );
+        assert!(
+            rec.canonical_preimage()
+                .contains(&authority.fingerprint_hex),
+            "the binding is inside the signed preimage"
+        );
+
+        let unbound = sink_with(open_log(&dir));
+        let rec = unbound.project(&ctx(VerdictOutcome::Allow, &[]));
+        assert_eq!(rec.authority_fingerprint(), None);
     }
 }

--- a/crates/nucleus-tool-proxy/src/main.rs
+++ b/crates/nucleus-tool-proxy/src/main.rs
@@ -1915,6 +1915,7 @@ async fn main() -> Result<(), ApiError> {
             args.task_token_nonce.as_deref(),
             args.task_token_issuer.as_deref(),
             elapsed.as_secs(),
+            pod_cert.as_ref().map(|c| c.fingerprint),
         ),
         // Clock before the epoch ⇒ cannot evaluate freshness ⇒ fail closed.
         Err(_) => session_token::SessionTaskToken::Invalid,

--- a/crates/nucleus-tool-proxy/src/main.rs
+++ b/crates/nucleus-tool-proxy/src/main.rs
@@ -1851,6 +1851,7 @@ async fn main() -> Result<(), ApiError> {
         art12_log.clone(),
         art12_shipper.clone(),
         art12_sink::mediation_receipt_log_path(args.art12_log.as_deref(), &spec.spec.work_dir),
+        pod_cert.as_deref().map(art12_sink::AuthorityBinding::from),
     );
 
     if dlc_provisioned {

--- a/crates/nucleus-tool-proxy/src/session_token.rs
+++ b/crates/nucleus-tool-proxy/src/session_token.rs
@@ -74,6 +74,7 @@ impl VerifiedSessionToken {
         nonce_hex: &str,
         issuer_hex: &str,
         now_unix: u64,
+        expected_authority: Option<[u8; 32]>,
     ) -> Result<Self, SessionTokenError> {
         let expected_nonce = parse_fixed::<NONCE_LEN>(nonce_hex).ok_or(SessionTokenError::Nonce)?;
         let root_issuer = parse_fixed::<ISSUER_LEN>(issuer_hex).ok_or(SessionTokenError::Issuer)?;
@@ -86,6 +87,20 @@ impl VerifiedSessionToken {
             .verify(&root_issuer, now_unix, &expected_nonce)
             .map_err(SessionTokenError::Verify)?
             .clone();
+        // #2486: the token must name the certificate THIS pod boot-verified.
+        // A token naming another authority was derived from a different
+        // grant and is refused. A token naming none was minted by a node that
+        // predates certificate-bound tokens: accepted, and said so.
+        match (expected_authority, signed.authority()) {
+            (Some(expected), Some(named)) if expected != named => {
+                return Err(SessionTokenError::AuthorityMismatch);
+            }
+            (Some(_), None) => tracing::warn!(
+                "session task token names no authority; issued by a node that predates \
+                 certificate-bound tokens (#2486)"
+            ),
+            _ => {}
+        }
         Ok(Self {
             scope,
             token: signed,
@@ -117,6 +132,8 @@ pub(crate) enum SessionTokenError {
     /// The token decoded but failed cryptographic verification.
     #[error("session task token failed verification: {0}")]
     Verify(TokenError),
+    #[error("session task token names a different authority than this pod's certificate")]
+    AuthorityMismatch,
 }
 
 /// The startup verification verdict for the injected session task token, held
@@ -174,6 +191,7 @@ pub(crate) fn resolve_session_task_token(
     nonce_hex: Option<&str>,
     issuer_hex: Option<&str>,
     now_unix: u64,
+    expected_authority: Option<[u8; 32]>,
 ) -> SessionTaskToken {
     let (token_serialized, nonce_hex, issuer_hex) = match (token_serialized, nonce_hex, issuer_hex)
     {
@@ -182,7 +200,13 @@ pub(crate) fn resolve_session_task_token(
         _ => return SessionTaskToken::Missing,
     };
 
-    match VerifiedSessionToken::verify(token_serialized, nonce_hex, issuer_hex, now_unix) {
+    match VerifiedSessionToken::verify(
+        token_serialized,
+        nonce_hex,
+        issuer_hex,
+        now_unix,
+        expected_authority,
+    ) {
         Ok(verified) => SessionTaskToken::Verified(verified),
         Err(_) => SessionTaskToken::Invalid,
     }
@@ -237,7 +261,8 @@ mod tests {
         let issuer = issuer_key(1);
         let (token, nonce, issuer_hex) = injected(&issuer, NONCE);
 
-        let state = resolve_session_task_token(Some(&token), Some(&nonce), Some(&issuer_hex), NOW);
+        let state =
+            resolve_session_task_token(Some(&token), Some(&nonce), Some(&issuer_hex), NOW, None);
 
         assert!(state.is_verified(), "honest injected token must verify");
         assert_eq!(state.verified_scope(), Some(&scope()));
@@ -248,7 +273,7 @@ mod tests {
     #[test]
     fn absent_token_is_fail_closed_missing() {
         // Nothing injected at all.
-        let state = resolve_session_task_token(None, None, None, NOW);
+        let state = resolve_session_task_token(None, None, None, NOW, None);
         assert!(matches!(state, SessionTaskToken::Missing));
         assert!(!state.is_verified());
         assert_eq!(state.verified_scope(), None);
@@ -257,7 +282,7 @@ mod tests {
         // ALSO fail-closed Missing — never silently unrestricted.
         let issuer = issuer_key(1);
         let (token, _n, _i) = injected(&issuer, NONCE);
-        let partial = resolve_session_task_token(Some(&token), None, None, NOW);
+        let partial = resolve_session_task_token(Some(&token), None, None, NOW, None);
         assert!(matches!(partial, SessionTaskToken::Missing));
         assert!(!partial.is_verified());
     }
@@ -278,7 +303,7 @@ mod tests {
         let tampered = serde_json::to_string(&token).unwrap();
 
         let state =
-            resolve_session_task_token(Some(&tampered), Some(&nonce), Some(&issuer_hex), NOW);
+            resolve_session_task_token(Some(&tampered), Some(&nonce), Some(&issuer_hex), NOW, None);
         assert!(matches!(state, SessionTaskToken::Invalid));
         assert!(!state.is_verified());
         assert_eq!(state.verified_scope(), None);
@@ -295,8 +320,13 @@ mod tests {
         // ...but the host-pinned issuer is the real root.
         let real_issuer_hex = hex::encode(real_issuer.verifying_key().to_bytes());
 
-        let state =
-            resolve_session_task_token(Some(&token), Some(&nonce), Some(&real_issuer_hex), NOW);
+        let state = resolve_session_task_token(
+            Some(&token),
+            Some(&nonce),
+            Some(&real_issuer_hex),
+            NOW,
+            None,
+        );
         assert!(matches!(state, SessionTaskToken::Invalid));
         assert!(!state.is_verified());
     }
@@ -314,6 +344,7 @@ mod tests {
             Some(&wrong_nonce_hex),
             Some(&issuer_hex),
             NOW,
+            None,
         );
         assert!(matches!(state, SessionTaskToken::Invalid));
     }
@@ -325,7 +356,7 @@ mod tests {
         let (token, nonce, issuer_hex) = injected(&issuer, NONCE);
         // deadline = ISSUED_AT + TTL = 1500; verify at now = 1501 ⇒ expired.
         let state =
-            resolve_session_task_token(Some(&token), Some(&nonce), Some(&issuer_hex), 1_501);
+            resolve_session_task_token(Some(&token), Some(&nonce), Some(&issuer_hex), 1_501, None);
         assert!(matches!(state, SessionTaskToken::Invalid));
     }
 
@@ -338,7 +369,13 @@ mod tests {
 
         // Non-JSON token.
         assert!(matches!(
-            resolve_session_task_token(Some("not-json"), Some(&nonce), Some(&issuer_hex), NOW),
+            resolve_session_task_token(
+                Some("not-json"),
+                Some(&nonce),
+                Some(&issuer_hex),
+                NOW,
+                None
+            ),
             SessionTaskToken::Invalid
         ));
         // Short nonce (8 bytes hex).
@@ -347,13 +384,14 @@ mod tests {
                 Some(&token),
                 Some(&hex::encode([1u8; 8])),
                 Some(&issuer_hex),
-                NOW
+                NOW,
+                None
             ),
             SessionTaskToken::Invalid
         ));
         // Non-hex issuer.
         assert!(matches!(
-            resolve_session_task_token(Some(&token), Some(&nonce), Some("zz"), NOW),
+            resolve_session_task_token(Some(&token), Some(&nonce), Some("zz"), NOW, None),
             SessionTaskToken::Invalid
         ));
     }
@@ -365,20 +403,94 @@ mod tests {
         let (token, nonce, issuer_hex) = injected(&issuer, NONCE);
 
         assert_eq!(
-            VerifiedSessionToken::verify("nope", &nonce, &issuer_hex, NOW).unwrap_err(),
+            VerifiedSessionToken::verify("nope", &nonce, &issuer_hex, NOW, None).unwrap_err(),
             SessionTokenError::Decode
         );
         assert_eq!(
-            VerifiedSessionToken::verify(&token, "zz", &issuer_hex, NOW).unwrap_err(),
+            VerifiedSessionToken::verify(&token, "zz", &issuer_hex, NOW, None).unwrap_err(),
             SessionTokenError::Nonce
         );
         assert_eq!(
-            VerifiedSessionToken::verify(&token, &nonce, "zz", NOW).unwrap_err(),
+            VerifiedSessionToken::verify(&token, &nonce, "zz", NOW, None).unwrap_err(),
             SessionTokenError::Issuer
         );
         assert!(matches!(
-            VerifiedSessionToken::verify(&token, &nonce, &issuer_hex, 1_501).unwrap_err(),
+            VerifiedSessionToken::verify(&token, &nonce, &issuer_hex, 1_501, None).unwrap_err(),
             SessionTokenError::Verify(TokenError::Expired { .. })
         ));
+    }
+
+    // ── #2486: the authority cross-check ────────────────────────────────────
+
+    const CERT: [u8; 32] = [0x5au8; 32];
+
+    fn injected_under(issuer: &SigningKey, authority: [u8; 32]) -> (String, String, String) {
+        let token = SignedTaskRef::issue_under_authority(
+            "live-task",
+            scope(),
+            NONCE,
+            ISSUED_AT,
+            TTL,
+            issuer,
+            authority,
+        );
+        (
+            serde_json::to_string(&token).unwrap(),
+            hex::encode(NONCE),
+            hex::encode(issuer.verifying_key().to_bytes()),
+        )
+    }
+
+    /// A token naming this pod's certificate verifies; one naming another
+    /// certificate is Invalid even though its signature, nonce and issuer are
+    /// all honest — it was derived from a different grant.
+    #[test]
+    fn a_token_must_name_the_certificate_this_pod_holds() {
+        let issuer = issuer_key(1);
+        let (token, nonce, issuer_hex) = injected_under(&issuer, CERT);
+        assert!(
+            resolve_session_task_token(
+                Some(&token),
+                Some(&nonce),
+                Some(&issuer_hex),
+                NOW,
+                Some(CERT)
+            )
+            .is_verified()
+        );
+        assert!(matches!(
+            resolve_session_task_token(
+                Some(&token),
+                Some(&nonce),
+                Some(&issuer_hex),
+                NOW,
+                Some([0xa5u8; 32])
+            ),
+            SessionTaskToken::Invalid
+        ));
+    }
+
+    /// Compatibility, both ways: a pod with a certificate accepts a token
+    /// that names none (an older node), and a pod with no certificate accepts
+    /// a token that names one (the check needs both sides).
+    #[test]
+    fn an_unbound_token_or_an_uncertified_pod_does_not_refuse() {
+        let issuer = issuer_key(1);
+        let (token, nonce, issuer_hex) = injected(&issuer, NONCE);
+        assert!(
+            resolve_session_task_token(
+                Some(&token),
+                Some(&nonce),
+                Some(&issuer_hex),
+                NOW,
+                Some(CERT)
+            )
+            .is_verified()
+        );
+        let (bound, nonce, issuer_hex) = injected_under(&issuer, CERT);
+        assert!(
+            resolve_session_task_token(Some(&bound), Some(&nonce), Some(&issuer_hex), NOW, None)
+                .is_verified()
+        );
     }
 }

--- a/crates/nucleus-tool-proxy/src/verdict_sink.rs
+++ b/crates/nucleus-tool-proxy/src/verdict_sink.rs
@@ -90,6 +90,7 @@ pub fn build_monitored_sink(
     art12_log: Option<Arc<crate::art12::Art12Log>>,
     art12_shipper: Option<Arc<crate::art12_shipper::Art12Shipper>>,
     mediation_receipt_log: Option<std::path::PathBuf>,
+    authority: Option<crate::art12_sink::AuthorityBinding>,
 ) -> (Arc<dyn VerdictSink>, Arc<TraceMonitor>) {
     let inner: Arc<dyn VerdictSink> = Arc::new(ToolProxyVerdictSink::new(
         file_lockdown,
@@ -117,6 +118,9 @@ pub fn build_monitored_sink(
             // The path (when given) is where the full signed receipts are
             // persisted for offline verification — opened only once a key exists.
             crate::art12_sink::ReceiptSigner::from_env(mediation_receipt_log.as_deref()),
+            // The pod's certificate, when it holds one (#2437): every record
+            // names the authority the deciding kernel was built from.
+            authority,
         )) as Arc<dyn VerdictSink>,
         None => inner,
     };
@@ -614,6 +618,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         )
     }
 
@@ -665,6 +670,7 @@ mod tests {
             "test-checksum".to_string(),
             "test-session".to_string(),
             false,
+            None,
             None,
             None,
             None,

--- a/crates/portcullis/src/art12_record.rs
+++ b/crates/portcullis/src/art12_record.rs
@@ -21,6 +21,23 @@ pub const ART12_SCHEMA_VERSION: u32 = 1;
 /// never be confused with another HMAC'd artifact signed by the same secret.
 pub const PREIMAGE_DOMAIN: &str = "nucleus-art12-record-v1";
 
+/// Extension keys binding a record to the AUTHORITY it was decided under
+/// (#2437): the pod certificate the tool-proxy verified at boot against the
+/// node's pinned root key. The kernel that produced the verdict was built from
+/// that certificate (`Kernel::from_certificate`), so these three keys let a
+/// verifier holding the node's `authority.json` for the pod tie every decision
+/// back to the chain — and the root public key — that authorized it, with no
+/// side channel. They travel as extensions so the v1 preimage is unchanged:
+/// extensions are already folded into the hash and signature.
+///
+/// A record written by a pod that holds a certificate carries all three; the
+/// node refuses a shipped record whose fingerprint is not the one it issued.
+pub const EXT_AUTHORITY_FINGERPRINT: &str = "authority.fingerprint";
+/// Hops from the node's root to the pod (`LatticeCertificate` chain depth).
+pub const EXT_AUTHORITY_CHAIN_DEPTH: &str = "authority.chain_depth";
+/// The identity at the root of the pod's chain (its creator).
+pub const EXT_AUTHORITY_ROOT: &str = "authority.root_identity";
+
 /// The identity of whoever caused a decision.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
@@ -103,6 +120,15 @@ pub struct Art12Record {
 }
 
 impl Art12Record {
+    /// The certificate fingerprint this decision was made under, when the
+    /// writing pod held one ([`EXT_AUTHORITY_FINGERPRINT`]).
+    #[must_use]
+    pub fn authority_fingerprint(&self) -> Option<&str> {
+        self.extensions
+            .get(EXT_AUTHORITY_FINGERPRINT)
+            .map(String::as_str)
+    }
+
     /// The canonical preimage: a `|`-joined, field-ordered rendering that both
     /// the writer and any verifier reconstruct **from the record's own fields**.
     ///

--- a/docs/article-12-record-keeping.md
+++ b/docs/article-12-record-keeping.md
@@ -28,6 +28,16 @@ verified-admission state, and the causal DAG's independent opinion of the same
 decision (`flow_cross_check`). Every one of those fields is folded into the
 signed preimage.
 
+When the pod holds a certificate issued by its node (every pod created since the
+certificate convergence, #2464), each record also names the **authority** the
+decision was made under: `authority.fingerprint` (the `LatticeCertificate`
+fingerprint the kernel was built from), `authority.chain_depth` and
+`authority.root_identity`, carried as extensions and therefore inside the signed
+preimage. A verifier holding the node's `pods/<id>/authority.json` can tie every
+decision back to the chain — and the root public key — that authorized it. The
+node refuses a shipped record whose fingerprint is not the one it issued to that
+pod, so a pod cannot claim a different authority than it was granted, nor none.
+
 ## What happens when recording fails
 
 The log latches **degraded** on a write failure and counts what it dropped. The


### PR DESCRIPTION
Closes #2486 (owner decision 6 of 2026-09-04: embed). Stacked on #2480 (it uses `PodAuthority::certificate_fingerprint` from there); retargets to `main` when that merges.

### What was wrong, verified on `main`
Since #2464 the token's scope is the certificate's effective lattice, so there was no authority gap — but the token carried no reference to the certificate, so nothing downstream could tie a task token to the grant it came from. #2480 gave Article 12 records that reference; this gives the token the same, following the RFC 8705 shape (a signed confirmation claim naming a certificate thumbprint) rather than inventing one.

### The change
- **`nucleus-provenance-memory`**: `BlockClaim.authority: Option<[u8; 32]>` is inside `signing_bytes`, carried unchanged across `attenuate`, and `verify` refuses a hop that names a different authority than its parent (`TokenError::AuthoritySwitched`). `issue_under_authority` and `authority()` added; `issue` unchanged for every other caller.
- **Compatibility, pinned**: `serde(default, skip_serializing_if = "Option::is_none")` means a token without the field serializes exactly as before, so its signature bytes are unchanged and old tokens verify under the new code (`a_token_without_an_authority_still_verifies_and_serializes_as_before`). The issue asked for a payload-tag bump as well; I did not do that, since a bump would invalidate every existing token under the new verifier, which is the compatibility the optional field exists to preserve. The field is signed either way.
- **node**: `mint_task_token_for_spec` looks up the fingerprint the authority registry issued the pod and stamps it (`minted_token_names_the_certificate_it_was_derived_from`).
- **tool-proxy**: `resolve_session_task_token` takes the boot-verified certificate's fingerprint. Different → `Invalid`, fail-closed, even with an honest signature, nonce and issuer (`a_token_must_name_the_certificate_this_pod_holds`). Token names none → accepted with a warning naming the cause (older node). Pod has no certificate → no check (`an_unbound_token_or_an_uncertified_pod_does_not_refuse`).
- The token still travels only on the env / workload-API channel; the kernel-cmdline copy the broker work flagged is untouched.

### Verification
`cargo test -p nucleus-provenance-memory` · `-p nucleus-node --features local-driver` (414) · `-p nucleus-tool-proxy --all-features` · clippy `-D warnings` on all three · `cargo build -p portcullis-effects -p nucleus-cli` (the other `SignedTaskRef` consumers) · `cargo fmt --check` · `scripts/check-line-ratchet.sh --strict` · `ci/no-vendor-strings.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZaH5waz88vL1qfNpFNfZ4
