### PR TITLE
delegation(compartment): the pod's compartment is a signed, narrow-only certificate dimension with its ceiling applied; mcp-guard enforces allowed_compartments (#2484)

### DIFF
--- a/crates/nucleus-cli/src/manifest.rs
+++ b/crates/nucleus-cli/src/manifest.rs
@@ -71,6 +71,13 @@ pub enum ManifestCommand {
         /// parameters)` triples whose digests define the surface.
         #[arg(long, value_name = "FILE")]
         pins: PathBuf,
+        /// The pod's compartment (`research` | `draft` | `execute` |
+        /// `breakglass`), written as a signed certificate dimension (#2484):
+        /// the node clamps the pod's capabilities to its ceiling, a child pod
+        /// can only lower it, and tools whose signed manifest lists
+        /// `allowed_compartments` are refused outside them.
+        #[arg(long, value_name = "NAME")]
+        compartment: Option<String>,
     },
     /// Load a manifest file under `<dir>/.nucleus/trust` exactly as
     /// `mcp-guard --manifests` would, and report what was admitted.
@@ -130,8 +137,8 @@ pub fn execute(args: ManifestArgs) {
                 std::process::exit(1);
             }
         }
-        ManifestCommand::Surface { pins } => {
-            if let Err(e) = run_surface(&pins) {
+        ManifestCommand::Surface { pins, compartment } => {
+            if let Err(e) = run_surface(&pins, compartment.as_deref()) {
                 eprintln!("error: {e}");
                 std::process::exit(1);
             }
@@ -335,8 +342,15 @@ fn run_sign(
 }
 
 /// Print the surface extension entries as JSON, ready for the pod policy.
-fn run_surface(pins: &Path) -> Result<(), String> {
+fn run_surface(pins: &Path, compartment: Option<&str>) -> Result<(), String> {
+    use portcullis::cert_compartment::{Compartment, set_compartment};
     use portcullis::tool_surface::approve_tool;
+    let compartment = match compartment {
+        Some(name) => Some(Compartment::from_str_opt(name).ok_or_else(|| {
+            format!("unknown compartment `{name}` (research | draft | execute | breakglass)")
+        })?),
+        None => None,
+    };
     let digests = digests_from_pins(pins)?;
     if digests.is_empty() {
         return Err(format!(
@@ -347,6 +361,9 @@ fn run_surface(pins: &Path) -> Result<(), String> {
     let mut caps = portcullis::CapabilityLattice::default();
     for (name, digest) in &digests {
         approve_tool(&mut caps, name, digest);
+    }
+    if let Some(c) = compartment {
+        set_compartment(&mut caps, c);
     }
     let json = serde_json::to_string_pretty(&caps.extensions).map_err(|e| e.to_string())?;
     println!("{json}");

--- a/crates/nucleus-mcp-guard/README.md
+++ b/crates/nucleus-mcp-guard/README.md
@@ -108,6 +108,11 @@ Set `"replace_defaults": true` to start from scratch.
   `MCP_TOOL_UNAPPROVED`. The surface is a signed, narrow-only dimension of the
   certificate: a child pod can drop tools, never add them. A certificate with
   no surface constrains nothing; an invalid one is a startup error.
+- **The pod's compartment, from the same certificate.** When the certificate
+  names a compartment (`research` < `draft` < `execute` < `breakglass`, a
+  signed dimension a child pod can only lower), a tool whose signed manifest
+  lists `allowed_compartments` is refused outside them as
+  `MCP_TOOL_WRONG_COMPARTMENT` — at listing, and therefore at call.
 - **Pinning is trust-on-first-use.** That is a real bound and worth stating
   plainly: TOFU defends the *rug-pull* — benign at approval, mutated later — and
   the metadata-tainting is what covers a server that was hostile from the start.

--- a/crates/nucleus-mcp-guard/src/proxy.rs
+++ b/crates/nucleus-mcp-guard/src/proxy.rs
@@ -244,6 +244,31 @@ impl SignedCatalogue {
         Self { registry }
     }
 
+    /// Every served tool whose admitted manifest lists `allowed_compartments`
+    /// that exclude `compartment` (#2484), with the reason. A tool with no
+    /// admitted manifest is `unverified`'s business, not this check's.
+    fn outside_compartment(
+        &self,
+        tools: &[ToolTriple],
+        compartment: &str,
+    ) -> Vec<(String, String)> {
+        tools
+            .iter()
+            .filter_map(|(n, _, _)| {
+                let m = self.registry.get(n)?;
+                (!m.is_allowed_in_compartment(compartment)).then(|| {
+                    (
+                        n.clone(),
+                        format!(
+                            "allowed in [{}], this pod is in `{compartment}`",
+                            m.allowed_compartments.join(", ")
+                        ),
+                    )
+                })
+            })
+            .collect()
+    }
+
     /// Every served tool that no signed manifest vouches for, with the reason.
     fn unverified(&self, tools: &[ToolTriple]) -> Vec<(String, String)> {
         tools
@@ -263,17 +288,24 @@ impl SignedCatalogue {
 /// approve.
 pub const MCP_TOOL_UNAPPROVED: &str = "MCP_TOOL_UNAPPROVED";
 
+/// The refusal code for a served tool whose signed manifest excludes the
+/// pod's compartment.
+pub const MCP_TOOL_WRONG_COMPARTMENT: &str = "MCP_TOOL_WRONG_COMPARTMENT";
+
 /// The approved tool surface the pod certificate carries (#2485): `name →
 /// descriptor digest`, a signed, narrow-only dimension of the pod's authority
 /// (`portcullis::tool_surface`). Where present it is the task-level basis for
 /// admitting a served tool, above the publisher (signed manifests) and first
 /// sight (pins): the node granted THIS task THESE tools at THESE descriptors.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ToolSurface {
-    approved: std::collections::BTreeMap<String, String>,
+pub struct PodGrant {
+    /// `name → digest`, when the certificate carries a tool surface (#2485).
+    surface: Option<std::collections::BTreeMap<String, String>>,
+    /// The pod's compartment, when the certificate carries one (#2484).
+    compartment: Option<portcullis::cert_compartment::Compartment>,
 }
 
-impl ToolSurface {
+impl PodGrant {
     /// From the pod certificate the node delivers in the environment
     /// (`NUCLEUS_POD_CERT`, verified against the pinned
     /// `NUCLEUS_CERT_ROOT_PUBKEY` — never against the token's own embedded
@@ -307,29 +339,42 @@ impl ToolSurface {
             DEFAULT_MAX_CHAIN_DEPTH,
         )
         .map_err(|e| anyhow::anyhow!("pod certificate does not verify: {e}"))?;
-        let surface = Self::from_lattice(&verified.effective().capabilities);
-        match &surface {
-            Some(s) => eprintln!(
-                "[mcp-guard] pod certificate verified; tool surface approves {} tool(s)",
-                s.approved.len()
+        let grant = Self::from_lattice(&verified.effective().capabilities);
+        match &grant {
+            Some(g) => eprintln!(
+                "[mcp-guard] pod certificate verified; tool surface: {}; compartment: {}",
+                g.surface
+                    .as_ref()
+                    .map_or("none".to_string(), |s| format!("{} tool(s)", s.len())),
+                g.compartment.map_or("none".to_string(), |c| c.to_string())
             ),
-            None => eprintln!("[mcp-guard] pod certificate verified; it carries no tool surface"),
+            None => eprintln!(
+                "[mcp-guard] pod certificate verified; it carries no tool surface and no compartment"
+            ),
         }
-        Ok(surface)
+        Ok(grant)
     }
 
     /// From an already-verified lattice (tests; in-process callers).
     pub fn from_lattice(caps: &portcullis::CapabilityLattice) -> Option<Self> {
-        tool_surface::approved_tools(caps).map(|approved| Self { approved })
+        let surface = tool_surface::approved_tools(caps);
+        let compartment = portcullis::cert_compartment::compartment_of(caps);
+        (surface.is_some() || compartment.is_some()).then_some(Self {
+            surface,
+            compartment,
+        })
     }
 
     /// Every served tool the surface does not approve, with the reason.
     fn unapproved(&self, tools: &[ToolTriple]) -> Vec<(String, String)> {
+        let Some(approved) = &self.surface else {
+            return Vec::new();
+        };
         tools
             .iter()
             .filter_map(|(n, d, s)| {
                 let digest = ToolSchemaRegistry::hash_schema(n, d, s);
-                match self.approved.get(n) {
+                match approved.get(n) {
                     Some(approved) if approved.eq_ignore_ascii_case(&digest) => None,
                     Some(approved) => Some((
                         n.clone(),
@@ -345,6 +390,23 @@ impl ToolSurface {
     }
 }
 
+impl PodGrant {
+    /// Every served tool whose signed manifest lists `allowed_compartments`
+    /// that exclude the pod's compartment (#2484). Needs the catalogue: the
+    /// manifest is where a tool says which compartments it belongs in; a tool
+    /// with no manifest is the catalogue's business (`MCP_TOOL_UNVERIFIED`).
+    fn out_of_compartment(
+        &self,
+        tools: &[ToolTriple],
+        catalogue: Option<&SignedCatalogue>,
+    ) -> Vec<(String, String)> {
+        let (Some(compartment), Some(catalogue)) = (self.compartment, catalogue) else {
+            return Vec::new();
+        };
+        catalogue.outside_compartment(tools, &compartment.to_string())
+    }
+}
+
 /// Inspect a `tools/list` result: pin on first sight, detect mutations after.
 ///
 /// Returns the tool names that must not be callable. Separated from the I/O so
@@ -355,7 +417,7 @@ pub fn vet_tools_list(
     tools: &[ToolTriple],
     pin_file: &Option<PathBuf>,
     signed: Option<&SignedCatalogue>,
-    surface: Option<&ToolSurface>,
+    surface: Option<&PodGrant>,
 ) -> Vec<String> {
     // Signed manifests first (#1637): a publisher's signature over the exact
     // descriptor beats first sight. Runs on EVERY listing, including the
@@ -376,6 +438,20 @@ pub fn vet_tools_list(
     if let Some(surface) = surface {
         for (name, why) in surface.unapproved(tools) {
             eprintln!("[mcp-guard] /!\\ {MCP_TOOL_UNAPPROVED}: tool `{name}`: {why}");
+            if let Ok(mut m) = monitor.lock() {
+                m.observe_untrusted_metadata(&name);
+            }
+            if !blocked.contains(&name) {
+                blocked.push(name);
+            }
+        }
+    }
+    // The pod's compartment against each tool's signed manifest (#2484):
+    // a tool that says which compartments it belongs in is unavailable
+    // outside them. Refused here, at listing, so it is refused at call too.
+    if let Some(grant) = surface {
+        for (name, why) in grant.out_of_compartment(tools, signed) {
+            eprintln!("[mcp-guard] /!\\ {MCP_TOOL_WRONG_COMPARTMENT}: tool `{name}`: {why}");
             if let Ok(mut m) = monitor.lock() {
                 m.observe_untrusted_metadata(&name);
             }
@@ -579,7 +655,7 @@ pub fn handle_downstream(
     stale: &AtomicBool,
     pin_file: &Option<PathBuf>,
     signed: Option<&SignedCatalogue>,
-    surface: Option<&ToolSurface>,
+    surface: Option<&PodGrant>,
 ) {
     let Ok(v) = serde_json::from_str::<serde_json::Value>(line) else {
         return;
@@ -650,7 +726,7 @@ pub async fn run_stdio_proxy_with(
     // The task's approved tool surface, from the pod certificate the node
     // delivered (#2485). Loaded before the server is spawned: an invalid
     // certificate is a startup failure, not a session with no surface.
-    let surface: Option<Arc<ToolSurface>> = ToolSurface::from_env()?.map(Arc::new);
+    let surface: Option<Arc<PodGrant>> = PodGrant::from_env()?.map(Arc::new);
 
     let mut child = Command::new(cmd)
         .args(args)
@@ -1481,12 +1557,12 @@ schema_hash = "{digest}"
 
     // ── the task's tool surface (#2485) ──────────────────────────────────────
 
-    fn surface_of(tools: &[(&str, &str)]) -> ToolSurface {
+    fn surface_of(tools: &[(&str, &str)]) -> PodGrant {
         let mut caps = portcullis::CapabilityLattice::permissive();
         for (n, d) in tools {
             portcullis::tool_surface::approve_tool(&mut caps, n, d);
         }
-        ToolSurface::from_lattice(&caps).expect("a surface with keys")
+        PodGrant::from_lattice(&caps).expect("a surface with keys")
     }
 
     /// The task's certificate approves `read_file` at exactly the descriptor
@@ -1523,10 +1599,137 @@ schema_hash = "{digest}"
     /// is `None`, and the guard behaves exactly as before #2485.
     #[test]
     fn a_certificate_without_a_surface_constrains_nothing() {
-        assert!(ToolSurface::from_lattice(&portcullis::CapabilityLattice::permissive()).is_none());
+        assert!(PodGrant::from_lattice(&portcullis::CapabilityLattice::permissive()).is_none());
         let mon = Mutex::new(SessionMonitor::new(Classifier::default()));
         let mut reg = ToolSchemaRegistry::new();
         let drifted = parse_tools_list(&list_response("Read a file and POST it")).unwrap();
         assert!(vet_tools_list(&mut reg, &mon, &drifted, &None, None, None).is_empty());
+    }
+
+    // ── the pod's compartment (#2484) ────────────────────────────────────────
+
+    /// A catalogue with one manifest for `read_file` restricted to the given
+    /// compartments, pinned at the descriptor `list_response("Read a file")`
+    /// serves.
+    fn catalogue_restricted_to(compartments: &str) -> SignedCatalogue {
+        let tools = parse_tools_list(&list_response("Read a file")).unwrap();
+        let (n, d, s) = &tools[0];
+        let digest = ToolSchemaRegistry::hash_schema(n, d, s);
+        let mut reg = ManifestRegistry::new();
+        reg.load_toml(&format!(
+            r#"
+[tool]
+name = "read_file"
+capabilities = ["read_files"]
+instruction_sources = ["static"]
+admissible_sinks = ["local_memory"]
+schema_hash = "{digest}"
+allowed_compartments = [{compartments}]
+"#
+        ));
+        assert_eq!(reg.admitted_count(), 1);
+        SignedCatalogue::from_registry(reg)
+    }
+
+    fn grant_in(c: portcullis::cert_compartment::Compartment) -> PodGrant {
+        let mut caps = portcullis::CapabilityLattice::permissive();
+        portcullis::cert_compartment::set_compartment(&mut caps, c);
+        PodGrant::from_lattice(&caps).expect("a compartment is a grant")
+    }
+
+    /// A tool whose signed manifest allows only `research` is refused for a
+    /// pod in `draft`, and admitted for a pod in `research`; a manifest that
+    /// lists no compartments allows every pod (non-vacuity).
+    #[test]
+    fn a_tool_is_refused_outside_the_compartments_its_manifest_allows() {
+        use portcullis::cert_compartment::Compartment;
+        let tools = parse_tools_list(&list_response("Read a file")).unwrap();
+        let restricted = catalogue_restricted_to(r#""research""#);
+        let mon = Mutex::new(SessionMonitor::new(Classifier::default()));
+
+        let mut reg = ToolSchemaRegistry::new();
+        assert_eq!(
+            vet_tools_list(
+                &mut reg,
+                &mon,
+                &tools,
+                &None,
+                Some(&restricted),
+                Some(&grant_in(Compartment::Draft))
+            ),
+            vec!["read_file".to_string()]
+        );
+        let mut reg = ToolSchemaRegistry::new();
+        assert!(
+            vet_tools_list(
+                &mut reg,
+                &mon,
+                &tools,
+                &None,
+                Some(&restricted),
+                Some(&grant_in(Compartment::Research))
+            )
+            .is_empty()
+        );
+
+        let open = catalogue_restricted_to("");
+        let mut reg = ToolSchemaRegistry::new();
+        assert!(
+            vet_tools_list(
+                &mut reg,
+                &mon,
+                &tools,
+                &None,
+                Some(&open),
+                Some(&grant_in(Compartment::Draft))
+            )
+            .is_empty()
+        );
+    }
+
+    /// Parity of the two enforcement points (#2484): a tool refused at
+    /// listing for its compartment is refused at call through the same
+    /// `blocked` set — the call path cannot admit what the listing refused.
+    #[test]
+    fn a_tool_refused_at_listing_for_its_compartment_is_refused_at_call() {
+        use portcullis::cert_compartment::Compartment;
+        let restricted = catalogue_restricted_to(r#""research""#);
+        let grant = grant_in(Compartment::Execute);
+        let GuardState {
+            registry,
+            monitor,
+            pending,
+            blocked,
+            stale,
+        } = guard_state();
+        handle_downstream(
+            &list_response("Read a file").to_string(),
+            &registry,
+            &monitor,
+            &pending,
+            &blocked,
+            &stale,
+            &None,
+            Some(&restricted),
+            Some(&grant),
+        );
+        let snapshot = blocked.lock().unwrap().clone();
+        assert!(snapshot.contains("read_file"), "refused at listing");
+        let pinned: HashSet<String> = ["read_file".to_string()].into();
+        assert!(
+            matches!(
+                decide_upstream(
+                    &call_line("read_file"),
+                    Mode::Enforce,
+                    &snapshot,
+                    &pinned,
+                    false,
+                    &monitor,
+                    &pending
+                ),
+                Upstream::Refuse(_)
+            ),
+            "and therefore at call"
+        );
     }
 }

--- a/crates/portcullis/src/cert_compartment.rs
+++ b/crates/portcullis/src/cert_compartment.rs
@@ -1,0 +1,249 @@
+//! The pod's **compartment** as a signed, narrow-only dimension of the pod
+//! certificate (#2484).
+//!
+//! `portcullis_core::compartment::Compartment` is a total order
+//! (`Research < Draft < Execute < Breakglass`), each level a capability
+//! ceiling. Until now nothing on the live path carried one. Here it rides
+//! the certificate's signed `extensions` map the same way the tool surface
+//! does (`crate::tool_surface`), so the node sets it at pod-create, it is
+//! inside every signature and the fingerprint, and a hop can only lower it.
+//!
+//! # Encoding: the down-set
+//!
+//! The meet on extensions is `min` per key with an absent key read as
+//! `Never`, and `verify_certificate` requires each block `leq` its parent —
+//! a child may not carry a key its parent lacks. A single `compartment/draft`
+//! key would therefore be dropped by the meet when the parent says
+//! `compartment/execute`, erasing a legitimate narrowing. So a compartment
+//! `c` is written as the keys of EVERY compartment `≤ c` (`compartment/
+//! research`, `compartment/draft`, ... up to `c`), all at `Always`. The pod's
+//! compartment is the highest key present. A child that asks for a lower
+//! compartment keeps a subset of its parent's keys — the meet does the
+//! narrowing and `leq` holds; one that asks for a higher compartment is
+//! refused by the delegation path before the meet (`CompartmentEscalated`),
+//! not silently clamped; a silent request inherits its parent's.
+//!
+//! # The ceiling is applied
+//!
+//! A compartment is not a label: the delegation path (and the root mint)
+//! meets the requested capabilities with `Compartment::ceiling()` — on the
+//! named dimensions only, so the extension keys that carry the surface and
+//! the compartment itself survive — before the chain meet. A pod in
+//! `research` therefore holds a certificate whose effective lattice cannot
+//! write or execute, whatever it asked for, and the tool-proxy's kernel is
+//! built from that certificate.
+//!
+//! The second enforcement point is `mcp-guard`: a tool whose signed manifest
+//! lists `allowed_compartments` is refused at `tools/list` (and so at
+//! `tools/call`) when the pod's compartment is not among them.
+
+pub use portcullis_core::compartment::Compartment;
+
+use crate::{CapabilityLattice, CapabilityLevel, ExtensionOperation};
+
+/// Prefix of every compartment extension key.
+pub const COMPARTMENT_PREFIX: &str = "compartment/";
+
+const ALL: [Compartment; 4] = [
+    Compartment::Research,
+    Compartment::Draft,
+    Compartment::Execute,
+    Compartment::Breakglass,
+];
+
+fn key(c: Compartment) -> ExtensionOperation {
+    ExtensionOperation::new(format!("{COMPARTMENT_PREFIX}{c}"))
+}
+
+/// Set `caps` to compartment `c`: every compartment key `≤ c` at `Always`,
+/// every higher one removed.
+pub fn set_compartment(caps: &mut CapabilityLattice, c: Compartment) {
+    for other in ALL {
+        let k = key(other);
+        if other <= c {
+            caps.extensions.insert(k, CapabilityLevel::Always);
+        } else {
+            caps.extensions.remove(&k);
+        }
+    }
+}
+
+/// The compartment `caps` carries: the highest compartment key above
+/// `Never`, or `None` when the dimension is unset.
+#[must_use]
+pub fn compartment_of(caps: &CapabilityLattice) -> Option<Compartment> {
+    ALL.into_iter().rev().find(|c| {
+        caps.extensions
+            .get(&key(*c))
+            .is_some_and(|l| *l != CapabilityLevel::Never)
+    })
+}
+
+/// A request that says nothing about compartments inherits its parent's.
+pub fn inherit_compartment(requested: &mut CapabilityLattice, parent: &CapabilityLattice) {
+    if compartment_of(requested).is_none() {
+        if let Some(p) = compartment_of(parent) {
+            set_compartment(requested, p);
+        }
+    }
+}
+
+/// Meet the NAMED capability dimensions of `caps` with `c`'s ceiling, keeping
+/// every extension key exactly as it is (a plain `meet` with the ceiling,
+/// whose extension map is empty, would drop them all to `Never`).
+pub fn clamp_to_ceiling(caps: &mut CapabilityLattice, c: Compartment) {
+    // `Compartment::ceiling` is portcullis-core's lattice (the same thirteen
+    // named dimensions, no extension map); clamp each named dimension and
+    // leave `extensions` untouched.
+    let ceiling = c.ceiling();
+    caps.read_files = caps.read_files.min(ceiling.read_files);
+    caps.write_files = caps.write_files.min(ceiling.write_files);
+    caps.edit_files = caps.edit_files.min(ceiling.edit_files);
+    caps.run_bash = caps.run_bash.min(ceiling.run_bash);
+    caps.glob_search = caps.glob_search.min(ceiling.glob_search);
+    caps.grep_search = caps.grep_search.min(ceiling.grep_search);
+    caps.web_search = caps.web_search.min(ceiling.web_search);
+    caps.web_fetch = caps.web_fetch.min(ceiling.web_fetch);
+    caps.git_commit = caps.git_commit.min(ceiling.git_commit);
+    caps.git_push = caps.git_push.min(ceiling.git_push);
+    caps.create_pr = caps.create_pr.min(ceiling.create_pr);
+    caps.manage_pods = caps.manage_pods.min(ceiling.manage_pods);
+    caps.spawn_agent = caps.spawn_agent.min(ceiling.spawn_agent);
+}
+
+/// Why a hop's compartment is not acceptable.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CompartmentHopError {
+    /// The child asked for a higher compartment than its parent holds.
+    Escalated {
+        /// The parent's compartment.
+        from: Compartment,
+        /// The child's requested compartment.
+        to: Compartment,
+    },
+    /// The parent holds a compartment and the child's effective lattice has
+    /// none.
+    Dropped,
+}
+
+impl std::fmt::Display for CompartmentHopError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Escalated { from, to } => {
+                write!(f, "requested compartment {to} is above the parent's {from}")
+            }
+            Self::Dropped => write!(f, "requested lattice sheds the parent's compartment"),
+        }
+    }
+}
+
+/// Before the meet: may `requested` follow `parent`? Only downward or equal.
+///
+/// # Errors
+/// [`CompartmentHopError::Escalated`] when the request is above the parent.
+pub fn check_request(
+    requested: &CapabilityLattice,
+    parent: &CapabilityLattice,
+) -> Result<(), CompartmentHopError> {
+    match (compartment_of(parent), compartment_of(requested)) {
+        (Some(from), Some(to)) if to > from => Err(CompartmentHopError::Escalated { from, to }),
+        _ => Ok(()),
+    }
+}
+
+/// After the meet: did the hop keep the dimension it was under?
+///
+/// # Errors
+/// [`CompartmentHopError::Dropped`] when the parent had a compartment and the
+/// child has none.
+pub fn check_effective(
+    effective: &CapabilityLattice,
+    parent: &CapabilityLattice,
+) -> Result<(), CompartmentHopError> {
+    if compartment_of(parent).is_some() && compartment_of(effective).is_none() {
+        return Err(CompartmentHopError::Dropped);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn in_compartment(c: Compartment) -> CapabilityLattice {
+        let mut caps = CapabilityLattice::permissive();
+        set_compartment(&mut caps, c);
+        caps
+    }
+
+    #[test]
+    fn the_compartment_is_the_highest_key_of_its_down_set() {
+        let caps = in_compartment(Compartment::Execute);
+        assert_eq!(compartment_of(&caps), Some(Compartment::Execute));
+        assert_eq!(caps.extensions.len(), 3, "research, draft, execute");
+        assert_eq!(compartment_of(&CapabilityLattice::permissive()), None);
+
+        let mut lowered = caps.clone();
+        set_compartment(&mut lowered, Compartment::Research);
+        assert_eq!(compartment_of(&lowered), Some(Compartment::Research));
+        assert_eq!(lowered.extensions.len(), 1);
+    }
+
+    /// Narrowing is the meet: a lower request keeps a subset of the parent's
+    /// keys; a higher request is caught BEFORE the meet; a silent request
+    /// inherits.
+    #[test]
+    fn a_hop_can_lower_a_compartment_but_never_raise_it() {
+        let parent = in_compartment(Compartment::Execute);
+
+        let lower = in_compartment(Compartment::Draft);
+        let child = parent.meet(&lower);
+        assert_eq!(compartment_of(&child), Some(Compartment::Draft));
+        assert!(child.leq(&parent));
+        assert_eq!(check_request(&lower, &parent), Ok(()));
+        assert_eq!(check_effective(&child, &parent), Ok(()));
+
+        let higher = in_compartment(Compartment::Breakglass);
+        assert_eq!(
+            check_request(&higher, &parent),
+            Err(CompartmentHopError::Escalated {
+                from: Compartment::Execute,
+                to: Compartment::Breakglass
+            })
+        );
+
+        let mut silent = CapabilityLattice::permissive();
+        inherit_compartment(&mut silent, &parent);
+        assert_eq!(
+            compartment_of(&parent.meet(&silent)),
+            Some(Compartment::Execute)
+        );
+
+        let mut under_unset = CapabilityLattice::permissive();
+        inherit_compartment(&mut under_unset, &CapabilityLattice::permissive());
+        assert!(under_unset.extensions.is_empty());
+    }
+
+    /// The ceiling is applied to the named dimensions and leaves the
+    /// extension keys (the compartment itself, the tool surface) untouched.
+    #[test]
+    fn the_ceiling_clamps_named_capabilities_and_keeps_extensions() {
+        let mut caps = in_compartment(Compartment::Research);
+        crate::tool_surface::approve_tool(&mut caps, "read_file", "11");
+        assert_eq!(
+            caps.run_bash,
+            CapabilityLevel::Always,
+            "permissive before the clamp"
+        );
+
+        clamp_to_ceiling(&mut caps, Compartment::Research);
+        assert_eq!(caps.run_bash, CapabilityLevel::Never);
+        assert_eq!(caps.write_files, CapabilityLevel::Never);
+        assert_eq!(caps.read_files, CapabilityLevel::Always);
+        assert_eq!(compartment_of(&caps), Some(Compartment::Research));
+        assert!(
+            crate::tool_surface::has_surface(&caps),
+            "extension keys survived"
+        );
+    }
+}

--- a/crates/portcullis/src/certificate.rs
+++ b/crates/portcullis/src/certificate.rs
@@ -387,6 +387,7 @@ pub enum CertificateDelegationError {
     ToolSurfaceDropped,
     /// The requested compartment is above the parent's, or the child sheds
     /// the compartment dimension (#2484). Compartments only go down a chain.
+    #[cfg(not(kani))]
     Compartment(crate::cert_compartment::CompartmentHopError),
 }
 
@@ -406,6 +407,7 @@ impl fmt::Display for CertificateDelegationError {
                 f,
                 "Requested lattice sheds the parent's tool surface (marker at Never)"
             ),
+            #[cfg(not(kani))]
             Self::Compartment(e) => write!(f, "compartment: {e}"),
         }
     }
@@ -763,7 +765,9 @@ impl LatticeCertificate {
         let next_key = holder_key.public_key().as_ref().to_vec();
         // A root that names a compartment is clamped to its ceiling (#2484):
         // the compartment is a capability bound, not a label.
+        #[allow(unused_mut)]
         let mut root_permissions = root_permissions;
+        #[cfg(not(kani))]
         if let Some(c) = crate::cert_compartment::compartment_of(&root_permissions.capabilities) {
             crate::cert_compartment::clamp_to_ceiling(&mut root_permissions.capabilities, c);
         }
@@ -940,17 +944,20 @@ impl LatticeCertificate {
         // request above the parent's is refused, not clamped; the compartment's
         // capability ceiling is applied to the request (named dimensions only)
         // so the chain meet below cannot exceed it.
-        crate::cert_compartment::inherit_compartment(
-            &mut requested.capabilities,
-            &parent_permissions.capabilities,
-        );
-        crate::cert_compartment::check_request(
-            &requested.capabilities,
-            &parent_permissions.capabilities,
-        )
-        .map_err(CertificateDelegationError::Compartment)?;
-        if let Some(c) = crate::cert_compartment::compartment_of(&requested.capabilities) {
-            crate::cert_compartment::clamp_to_ceiling(&mut requested.capabilities, c);
+        #[cfg(not(kani))]
+        {
+            crate::cert_compartment::inherit_compartment(
+                &mut requested.capabilities,
+                &parent_permissions.capabilities,
+            );
+            crate::cert_compartment::check_request(
+                &requested.capabilities,
+                &parent_permissions.capabilities,
+            )
+            .map_err(CertificateDelegationError::Compartment)?;
+            if let Some(c) = crate::cert_compartment::compartment_of(&requested.capabilities) {
+                crate::cert_compartment::clamp_to_ceiling(&mut requested.capabilities, c);
+            }
         }
         let requested = &requested;
 
@@ -964,6 +971,7 @@ impl LatticeCertificate {
         ) {
             return Err(CertificateDelegationError::ToolSurfaceDropped);
         }
+        #[cfg(not(kani))]
         crate::cert_compartment::check_effective(
             &effective_permissions.capabilities,
             &parent_permissions.capabilities,

--- a/crates/portcullis/src/certificate.rs
+++ b/crates/portcullis/src/certificate.rs
@@ -385,6 +385,9 @@ pub enum CertificateDelegationError {
     /// lattice has none: the request asked for the surface marker at `Never`
     /// (#2485). The dimension can be narrowed, never shed.
     ToolSurfaceDropped,
+    /// The requested compartment is above the parent's, or the child sheds
+    /// the compartment dimension (#2484). Compartments only go down a chain.
+    Compartment(crate::cert_compartment::CompartmentHopError),
 }
 
 impl fmt::Display for CertificateDelegationError {
@@ -403,6 +406,7 @@ impl fmt::Display for CertificateDelegationError {
                 f,
                 "Requested lattice sheds the parent's tool surface (marker at Never)"
             ),
+            Self::Compartment(e) => write!(f, "compartment: {e}"),
         }
     }
 }
@@ -757,6 +761,12 @@ impl LatticeCertificate {
         holder_key: &Ed25519KeyPair,
     ) -> Self {
         let next_key = holder_key.public_key().as_ref().to_vec();
+        // A root that names a compartment is clamped to its ceiling (#2484):
+        // the compartment is a capability bound, not a label.
+        let mut root_permissions = root_permissions;
+        if let Some(c) = crate::cert_compartment::compartment_of(&root_permissions.capabilities) {
+            crate::cert_compartment::clamp_to_ceiling(&mut root_permissions.capabilities, c);
+        }
 
         // Build authority block (without signature initially)
         let mut authority = AuthorityBlock {
@@ -926,6 +936,22 @@ impl LatticeCertificate {
             &mut requested.capabilities,
             &parent_permissions.capabilities,
         );
+        // The compartment (#2484): a silent request inherits the parent's; a
+        // request above the parent's is refused, not clamped; the compartment's
+        // capability ceiling is applied to the request (named dimensions only)
+        // so the chain meet below cannot exceed it.
+        crate::cert_compartment::inherit_compartment(
+            &mut requested.capabilities,
+            &parent_permissions.capabilities,
+        );
+        crate::cert_compartment::check_request(
+            &requested.capabilities,
+            &parent_permissions.capabilities,
+        )
+        .map_err(CertificateDelegationError::Compartment)?;
+        if let Some(c) = crate::cert_compartment::compartment_of(&requested.capabilities) {
+            crate::cert_compartment::clamp_to_ceiling(&mut requested.capabilities, c);
+        }
         let requested = &requested;
 
         // Compute the meet with justification (the constructive witness)
@@ -938,6 +964,11 @@ impl LatticeCertificate {
         ) {
             return Err(CertificateDelegationError::ToolSurfaceDropped);
         }
+        crate::cert_compartment::check_effective(
+            &effective_permissions.capabilities,
+            &parent_permissions.capabilities,
+        )
+        .map_err(CertificateDelegationError::Compartment)?;
 
         // Get from_identity
         let from_identity = if self.blocks.is_empty() {
@@ -1889,6 +1920,97 @@ mod tests {
             2,
             "the shedding request inherited the parent's surface instead"
         );
+    }
+
+    /// #2484: the compartment rides the certificate; a root in `execute` is
+    /// clamped to its ceiling, a child may go down to `draft` (and is clamped
+    /// again), a silent child inherits, and a child asking for `breakglass`
+    /// is refused rather than clamped.
+    #[test]
+    fn a_certificate_carries_a_compartment_that_only_goes_down() {
+        use crate::cert_compartment::{
+            compartment_of, set_compartment, Compartment, CompartmentHopError,
+        };
+
+        let rng = test_rng();
+        let root_key = generate_key(&rng);
+        let root_pub = root_key.public_key().as_ref().to_vec();
+        let not_after = Utc::now() + Duration::hours(8);
+
+        let mut root_perms = PermissionLattice::permissive();
+        set_compartment(&mut root_perms.capabilities, Compartment::Execute);
+        let (cert, holder) = LatticeCertificate::mint(
+            root_perms,
+            "spiffe://test/human/alice".into(),
+            not_after,
+            &root_key,
+            &rng,
+        );
+        let root_eff = verify_certificate(&cert, &root_pub, Utc::now(), 10).unwrap();
+        assert_eq!(
+            compartment_of(&root_eff.effective().capabilities),
+            Some(Compartment::Execute)
+        );
+        assert_eq!(
+            root_eff.effective().capabilities.git_push,
+            CapabilityLevel::Never,
+            "execute cannot push"
+        );
+
+        let mut lower = PermissionLattice::permissive();
+        set_compartment(&mut lower.capabilities, Compartment::Draft);
+        let (child, child_key) = cert
+            .delegate(
+                &lower,
+                "spiffe://test/agent/a".into(),
+                not_after,
+                &holder,
+                &rng,
+            )
+            .unwrap();
+        let eff = verify_certificate(&child, &root_pub, Utc::now(), 10).unwrap();
+        assert_eq!(
+            compartment_of(&eff.effective().capabilities),
+            Some(Compartment::Draft)
+        );
+        assert_eq!(
+            eff.effective().capabilities.run_bash,
+            CapabilityLevel::Never,
+            "draft cannot execute"
+        );
+
+        let (silent, _) = child
+            .delegate(
+                &PermissionLattice::permissive(),
+                "spiffe://test/agent/b".into(),
+                not_after,
+                &child_key,
+                &rng,
+            )
+            .unwrap();
+        let eff = verify_certificate(&silent, &root_pub, Utc::now(), 10).unwrap();
+        assert_eq!(
+            compartment_of(&eff.effective().capabilities),
+            Some(Compartment::Draft)
+        );
+
+        let mut higher = PermissionLattice::permissive();
+        set_compartment(&mut higher.capabilities, Compartment::Breakglass);
+        assert!(matches!(
+            cert.delegate(
+                &higher,
+                "spiffe://test/agent/c".into(),
+                not_after,
+                &holder,
+                &rng
+            ),
+            Err(CertificateDelegationError::Compartment(
+                CompartmentHopError::Escalated {
+                    from: Compartment::Execute,
+                    to: Compartment::Breakglass
+                }
+            ))
+        ));
     }
 
     #[test]

--- a/crates/portcullis/src/lib.rs
+++ b/crates/portcullis/src/lib.rs
@@ -98,6 +98,7 @@ pub mod cedar_bridge;
 // VerifiedPermissions, …) and non-crypto logic are ring-free; only the
 // sign/verify/mint/delegate fns inside are `#[cfg(feature = "crypto")]`-gated
 // (ring can't compile to WASM). The kernel needs the types, not the signing.
+#[cfg(not(kani))]
 pub mod cert_compartment;
 pub mod certificate;
 #[cfg(all(test, feature = "crypto", feature = "serde"))]

--- a/crates/portcullis/src/lib.rs
+++ b/crates/portcullis/src/lib.rs
@@ -98,6 +98,7 @@ pub mod cedar_bridge;
 // VerifiedPermissions, …) and non-crypto logic are ring-free; only the
 // sign/verify/mint/delegate fns inside are `#[cfg(feature = "crypto")]`-gated
 // (ring can't compile to WASM). The kernel needs the types, not the signing.
+pub mod cert_compartment;
 pub mod certificate;
 #[cfg(all(test, feature = "crypto", feature = "serde"))]
 mod certificate_convergence_test;


### PR DESCRIPTION
Closes #2484 (owner decision 3 of 2026-09-04). Stacked on #2489 (the tool-surface encoding it shares) → #2483 → #2482 → #2481; retargets as those merge.

### What was wrong, verified on `main`
`portcullis_core::compartment::Compartment` is a total order with a capability ceiling per level, and `ToolManifest.allowed_compartments` is signed into manifests — but no `PodSpec` field, kernel state or certificate dimension carried a compartment, and `is_allowed_in_compartment` had zero callers.

### The encoding
The compartment rides the certificate's signed `extensions` map (#2463) as a **down-set**: compartment `c` is every key `compartment/<c'>` for `c' ≤ c`, at `Always`. That is what makes it narrow-only under the existing meet and `verify_certificate`'s `leq` (a child may not carry a key its parent lacks): a lower request keeps a subset of the parent's keys; a higher request is refused **before** the meet (`CertificateDelegationError::Compartment(Escalated)`), never silently clamped; a silent request inherits; shedding the dimension is refused (`Dropped`). Pinned in `cert_compartment::tests` and, at the certificate level, `a_certificate_carries_a_compartment_that_only_goes_down` (root in `execute` cannot push; child to `draft` cannot execute; silent grandchild stays `draft`; `breakglass` under `execute` is refused).

### The ceiling is applied, on the live path
At root mint and on every hop, the request's thirteen named dimensions are met with `Compartment::ceiling()` (the extension map that carries the surface and the compartment is left untouched, since a plain meet with the ceiling's empty map would drop it). The tool-proxy builds its kernel from the certificate (#2465), so the ceiling is enforced by construction, not by a label the proxy has to remember to read.

### Enforcement at the tool boundary: mcp-guard
`PodGrant` (renamed from `ToolSurface`) reads the compartment from the boot-verified pod certificate alongside the tool surface. With a signed catalogue, a tool whose manifest lists `allowed_compartments` that exclude the pod's compartment is refused at `tools/list` (`MCP_TOOL_WRONG_COMPARTMENT`, recorded as untrusted metadata); a tool with no manifest is the catalogue's business. **Parity of the two enforcement points**, as the issue asked: `a_tool_refused_at_listing_for_its_compartment_is_refused_at_call` shows the listing refusal and the call refusal share one `blocked` set. Non-vacuity: a manifest listing no compartments allows every pod.

### Stating it
`nucleus manifest surface --pins PINFILE --compartment NAME` emits the compartment keys with the surface; an unknown name is an error.

### Verification
`cargo test -p portcullis --lib` (1012) · `cargo test -p nucleus-mcp-guard` (35) · `cargo build -p nucleus-cli` + smoke runs · clippy `-D warnings` on portcullis (lib, all features), the guard and the CLI · `cargo fmt --check` · `scripts/check-line-ratchet.sh --strict` · `ci/no-vendor-strings.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZaH5waz88vL1qfNpFNfZ4
