### PR TITLE
security(portcullis): an empty allow set is the top, not the bottom — fix leq, meet and join of PathLattice and CommandLattice (#2474)

### DIFF
--- a/crates/portcullis/src/certificate.rs
+++ b/crates/portcullis/src/certificate.rs
@@ -2324,4 +2324,77 @@ mod tests {
             "expected ChainTooDeep, got {result:?}"
         );
     }
+
+    /// #2474 regression: a validly signed child block whose paths and commands
+    /// are UNRESTRICTED (empty allow sets) under a parent restricted to
+    /// `src/**` / `cargo test` used to pass the monotone check, because an
+    /// empty set is vacuously a subset of anything. `verify_certificate` must
+    /// refuse it as `MonotoneViolation`, and an honest narrower child must
+    /// still verify.
+    #[test]
+    fn a_child_claiming_unrestricted_paths_or_commands_is_refused() {
+        let rng = test_rng();
+        let root_key = generate_key(&rng);
+        let root_pub = root_key.public_key().as_ref().to_vec();
+        let not_after = Utc::now() + Duration::hours(8);
+
+        let mut root_perms = PermissionLattice::permissive();
+        root_perms.paths.allowed = ["src/**".to_string()].into_iter().collect();
+        root_perms.commands.allowed = ["cargo test".to_string()].into_iter().collect();
+        let (cert, holder) = LatticeCertificate::mint(
+            root_perms.clone(),
+            "spiffe://test/human/alice".into(),
+            not_after,
+            &root_key,
+            &rng,
+        );
+        assert!(verify_certificate(&cert, &root_pub, Utc::now(), 10).is_ok());
+
+        // The escalation: unrestricted paths + commands, signed by the holder.
+        let mut widened = PermissionLattice::permissive();
+        widened.paths.allowed.clear();
+        widened.commands.allowed.clear();
+        widened.commands.allowed_rules.clear();
+        let child_key = generate_key(&rng);
+        let (_, justification) = meet_with_justification(&root_perms, &widened);
+        let mut block = DelegationBlock {
+            effective_permissions: widened,
+            justification,
+            from_identity: cert.authority.root_identity.clone(),
+            to_identity: "spiffe://test/agent/a".into(),
+            not_after,
+            sink_scope: SinkScope::unrestricted(),
+            prev_block_hash: cert.authority.block_hash(),
+            signature: Vec::new(),
+            next_key: child_key.public_key().as_ref().to_vec(),
+        };
+        block.signature = holder.sign(&block.signing_payload()).as_ref().to_vec();
+        let pop = LatticeCertificate::pop_payload_for_block_hash(&block.block_hash());
+        let escalated = LatticeCertificate {
+            authority: cert.authority.clone(),
+            blocks: vec![block],
+            final_signature: child_key.sign(&pop).as_ref().to_vec(),
+        };
+        assert!(
+            matches!(
+                verify_certificate(&escalated, &root_pub, Utc::now(), 10),
+                Err(CertificateError::MonotoneViolation { block_index: 1 })
+            ),
+            "an unrestricted child under a restricted parent is a widening"
+        );
+
+        // The control: an honest narrower child still verifies.
+        let mut narrower = root_perms.clone();
+        narrower.paths.allowed = ["src/lib.rs".to_string()].into_iter().collect();
+        let (child, _) = cert
+            .delegate(
+                &narrower,
+                "spiffe://test/agent/b".into(),
+                not_after,
+                &holder,
+                &rng,
+            )
+            .unwrap();
+        assert!(verify_certificate(&child, &root_pub, Utc::now(), 10).is_ok());
+    }
 }

--- a/crates/portcullis/src/command.rs
+++ b/crates/portcullis/src/command.rs
@@ -5,6 +5,12 @@ use std::collections::HashSet;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
+/// The allow entry that matches NO command: the bottom of the allowed
+/// dimension (#2474). An empty `allowed` set means UNRESTRICTED here, so the
+/// meet of two disjoint restricted sets is written as this one entry rather
+/// than as the empty set. A NUL byte never occurs in a parsed command word.
+pub const NOTHING_ALLOWED: &str = "\u{0}nothing-allowed";
+
 /// Shell command access lattice.
 ///
 /// Controls which shell commands can be executed. Uses a combination of:
@@ -23,6 +29,7 @@ use serde::{Deserialize, Serialize};
 /// - Quoting tricks (`"rm" "-rf"`)
 /// - IFS manipulation
 /// - Argument injection
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct CommandLattice {
@@ -139,7 +146,14 @@ impl CommandLattice {
         } else if other.allowed.is_empty() {
             self.allowed.clone()
         } else {
-            self.allowed.intersection(&other.allowed).cloned().collect()
+            // Disjoint restricted sets meet to NOTHING, not to "unrestricted".
+            let inter: HashSet<String> =
+                self.allowed.intersection(&other.allowed).cloned().collect();
+            if inter.is_empty() {
+                HashSet::from([NOTHING_ALLOWED.to_string()])
+            } else {
+                inter
+            }
         };
 
         let blocked: HashSet<String> = self.blocked.union(&other.blocked).cloned().collect();
@@ -157,7 +171,17 @@ impl CommandLattice {
 
     /// Join operation: union of allowed, intersection of blocked.
     pub fn join(&self, other: &Self) -> Self {
-        let allowed: HashSet<String> = self.allowed.union(&other.allowed).cloned().collect();
+        // Nothing-allowed is the identity of join; UNRESTRICTED (empty) absorbs
+        // (#2474: a plain union read the empty set as the bottom).
+        let allowed: HashSet<String> = if self.allows_nothing() {
+            other.allowed.clone()
+        } else if other.allows_nothing() {
+            self.allowed.clone()
+        } else if self.allowed.is_empty() || other.allowed.is_empty() {
+            HashSet::new()
+        } else {
+            self.allowed.union(&other.allowed).cloned().collect()
+        };
 
         let blocked = if self.blocked.is_empty() || other.blocked.is_empty() {
             HashSet::new()
@@ -359,17 +383,40 @@ impl CommandLattice {
         false
     }
 
+    /// Does this lattice allow no command at all in the `allowed` dimension?
+    #[must_use]
+    pub fn allows_nothing(&self) -> bool {
+        self.allowed.len() == 1 && self.allowed.contains(NOTHING_ALLOWED)
+    }
+
     /// Check if this lattice is less than or equal to another.
+    ///
+    /// An EMPTY `allowed` (or `allowed_rules`) means unrestricted — the TOP of
+    /// that dimension, not the bottom the vacuous subset test would make it.
+    /// An unrestricted `self` is `≤` `other` only when `other` is unrestricted
+    /// in the same dimension (#2474).
     pub fn leq(&self, other: &Self) -> bool {
-        // Our allowed must be subset of other's (or other allows all)
-        let allowed_ok = other.allowed.is_empty() || self.allowed.is_subset(&other.allowed);
+        // Our allowed must be a subset of other's; unrestricted only under unrestricted.
+        let allowed_ok = if self.allows_nothing() {
+            true
+        } else if self.allowed.is_empty() {
+            other.allowed.is_empty()
+        } else {
+            other.allowed.is_empty() || self.allowed.is_subset(&other.allowed)
+        };
         // Other's blocked must be subset of ours
         let blocked_ok = other.blocked.is_subset(&self.blocked);
-        let allowed_rules_ok = other.allowed_rules.is_empty()
-            || self
-                .allowed_rules
-                .iter()
-                .all(|rule| other.allowed_rules.contains(rule));
+        let allowed_rules_ok = if rules_allow_nothing(&self.allowed_rules) {
+            true
+        } else if self.allowed_rules.is_empty() {
+            other.allowed_rules.is_empty()
+        } else {
+            other.allowed_rules.is_empty()
+                || self
+                    .allowed_rules
+                    .iter()
+                    .all(|rule| other.allowed_rules.contains(rule))
+        };
         let blocked_rules_ok = other
             .blocked_rules
             .iter()
@@ -779,6 +826,16 @@ fn is_dangerous_exec_form(program: &str, args: &[String]) -> bool {
     }
 }
 
+/// The rule that matches no command: the bottom of the `allowed_rules`
+/// dimension (#2474), for the same reason as [`NOTHING_ALLOWED`].
+fn nothing_allowed_rule() -> CommandPattern {
+    CommandPattern::exact(NOTHING_ALLOWED, &[] as &[&str])
+}
+
+fn rules_allow_nothing(rules: &[CommandPattern]) -> bool {
+    rules.len() == 1 && rules[0] == nothing_allowed_rule()
+}
+
 fn meet_allowed_rules(a: &[CommandPattern], b: &[CommandPattern]) -> Vec<CommandPattern> {
     if a.is_empty() && b.is_empty() {
         return Vec::new();
@@ -789,18 +846,28 @@ fn meet_allowed_rules(a: &[CommandPattern], b: &[CommandPattern]) -> Vec<Command
     if b.is_empty() {
         return a.to_vec();
     }
-    a.iter().filter(|rule| b.contains(rule)).cloned().collect()
+    let inter: Vec<CommandPattern> = a.iter().filter(|rule| b.contains(rule)).cloned().collect();
+    if inter.is_empty() {
+        // Disjoint rule sets meet to NOTHING, not to "unrestricted".
+        vec![nothing_allowed_rule()]
+    } else {
+        inter
+    }
 }
 
 fn join_allowed_rules(a: &[CommandPattern], b: &[CommandPattern]) -> Vec<CommandPattern> {
     if a.is_empty() && b.is_empty() {
         return Vec::new();
     }
-    if a.is_empty() {
+    if rules_allow_nothing(a) {
         return b.to_vec();
     }
-    if b.is_empty() {
+    if rules_allow_nothing(b) {
         return a.to_vec();
+    }
+    // Unrestricted (empty) absorbs the join (#2474).
+    if a.is_empty() || b.is_empty() {
+        return Vec::new();
     }
     let mut rules = a.to_vec();
     for rule in b {
@@ -1220,5 +1287,87 @@ mod tests {
         // But auth/config still blocked
         assert!(!lattice.can_execute("gh auth login"));
         assert!(!lattice.can_execute("gh config set editor vim"));
+    }
+}
+
+/// #2474: empty `allowed` / `allowed_rules` are UNRESTRICTED — the top of
+/// those dimensions — so the order must never place them below a restricted set.
+#[cfg(test)]
+mod leq_unrestricted_tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    fn with_allowed(cmds: &[&str]) -> CommandLattice {
+        let mut c = CommandLattice {
+            allowed: HashSet::new(),
+            blocked: HashSet::new(),
+            allowed_rules: Vec::new(),
+            blocked_rules: Vec::new(),
+            allow_metacharacters: false,
+        };
+        for cmd in cmds {
+            c.allow(*cmd);
+        }
+        c
+    }
+
+    #[test]
+    fn an_unrestricted_command_lattice_is_never_below_a_restricted_one() {
+        let unrestricted = with_allowed(&[]);
+        let restricted = with_allowed(&["cargo test"]);
+        assert!(!unrestricted.leq(&restricted), "the inversion #2474 found");
+        assert!(restricted.leq(&unrestricted));
+        let m = unrestricted.meet(&restricted);
+        assert_eq!(m.allowed, restricted.allowed);
+        assert!(m.leq(&unrestricted) && m.leq(&restricted));
+
+        // Disjoint restrictions meet to NOTHING: below both, executes nothing.
+        let other = with_allowed(&["git status"]);
+        let none = restricted.meet(&other);
+        assert!(none.allows_nothing(), "{:?}", none.allowed);
+        assert!(none.leq(&restricted) && none.leq(&other) && none.leq(&unrestricted));
+        assert!(!unrestricted.leq(&none));
+        assert!(!none.can_execute("cargo test") && !none.can_execute("git status"));
+        assert_eq!(none.join(&other).allowed, other.allowed);
+        assert!(
+            unrestricted.join(&restricted).allowed.is_empty(),
+            "the top absorbs the join"
+        );
+
+        // Disjoint rule sets meet to a rule that matches nothing.
+        let mut ra = with_allowed(&[]);
+        ra.allow_rule(CommandPattern::exact("cargo", &[] as &[&str]));
+        let mut rb = with_allowed(&[]);
+        rb.allow_rule(CommandPattern::exact("git", &[] as &[&str]));
+        let rn = ra.meet(&rb);
+        assert!(rn.leq(&ra) && rn.leq(&rb) && !rn.can_execute("cargo build"));
+
+        // The same for allowed_rules.
+        let mut ruled = with_allowed(&[]);
+        ruled.allow_rule(CommandPattern::exact("cargo", &[] as &[&str]));
+        assert!(
+            !unrestricted.leq(&ruled),
+            "unrestricted rules are not below a rule set"
+        );
+        assert!(ruled.leq(&unrestricted));
+    }
+
+    proptest! {
+        #[test]
+        fn meet_is_a_lower_bound_and_unrestricted_is_top(
+            a in proptest::collection::hash_set("(cargo|git|ls)", 0..3),
+            b in proptest::collection::hash_set("(cargo|git|ls)", 0..3),
+        ) {
+            let mut ca = with_allowed(&[]); ca.allowed = a.clone();
+            let mut cb = with_allowed(&[]); cb.allowed = b.clone();
+            let m = ca.meet(&cb);
+            prop_assert!(m.leq(&ca));
+            prop_assert!(m.leq(&cb));
+            prop_assert!(ca.leq(&ca));
+            if a.is_empty() && !b.is_empty() {
+                prop_assert!(!ca.leq(&cb));
+                prop_assert!(cb.leq(&ca));
+            }
+        }
     }
 }

--- a/crates/portcullis/src/path.rs
+++ b/crates/portcullis/src/path.rs
@@ -993,9 +993,10 @@ mod leq_unrestricted_tests {
     use proptest::prelude::*;
 
     fn with_allowed(globs: &[&str]) -> PathLattice {
-        let mut p = PathLattice::default();
-        p.allowed = globs.iter().map(|s| s.to_string()).collect();
-        p
+        PathLattice {
+            allowed: globs.iter().map(|s| s.to_string()).collect(),
+            ..PathLattice::default()
+        }
     }
 
     #[test]
@@ -1042,8 +1043,8 @@ mod leq_unrestricted_tests {
             a in proptest::collection::hash_set("[a-c]/\\*\\*", 0..3),
             b in proptest::collection::hash_set("[a-c]/\\*\\*", 0..3),
         ) {
-            let pa = { let mut p = PathLattice::default(); p.allowed = a.clone(); p };
-            let pb = { let mut p = PathLattice::default(); p.allowed = b.clone(); p };
+            let pa = PathLattice { allowed: a.clone(), ..PathLattice::default() };
+            let pb = PathLattice { allowed: b.clone(), ..PathLattice::default() };
             let m = pa.meet(&pb);
             prop_assert!(m.leq(&pa));
             prop_assert!(m.leq(&pb));

--- a/crates/portcullis/src/path.rs
+++ b/crates/portcullis/src/path.rs
@@ -61,6 +61,14 @@ impl std::fmt::Display for PathDenial {
     }
 }
 
+/// The allow pattern that matches NO path: the bottom of the allowed dimension
+/// (#2474). An empty `allowed` set means UNRESTRICTED in this representation,
+/// so the meet of two disjoint restricted sets — whose intersection is empty —
+/// must not be written as the empty set, or two narrow grants would meet to
+/// everything. It is written as this one pattern instead. A NUL byte never
+/// occurs in a real path, so `glob_match` can never match it.
+pub const NOTHING_ALLOWED: &str = "\u{0}nothing-allowed";
+
 /// Path access lattice with allowed/blocked semantics.
 ///
 /// - `allowed`: Glob patterns for allowed paths. Empty means "all allowed".
@@ -72,6 +80,7 @@ impl std::fmt::Display for PathDenial {
 /// - All paths are canonicalized to prevent `../../../.env` traversal attacks
 /// - Symlinks are resolved and checked against the work_dir sandbox
 /// - Paths outside the work_dir are blocked when sandbox is enabled
+
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct PathLattice {
@@ -107,7 +116,14 @@ impl PathLattice {
         } else if other.allowed.is_empty() {
             self.allowed.clone()
         } else {
-            self.allowed.intersection(&other.allowed).cloned().collect()
+            // Disjoint restricted sets meet to NOTHING, not to "unrestricted".
+            let inter: HashSet<String> =
+                self.allowed.intersection(&other.allowed).cloned().collect();
+            if inter.is_empty() {
+                HashSet::from([NOTHING_ALLOWED.to_string()])
+            } else {
+                inter
+            }
         };
 
         let blocked: HashSet<String> = self.blocked.union(&other.blocked).cloned().collect();
@@ -137,7 +153,18 @@ impl PathLattice {
 
     /// Join operation: union of allowed, intersection of blocked.
     pub fn join(&self, other: &Self) -> Self {
-        let allowed: HashSet<String> = self.allowed.union(&other.allowed).cloned().collect();
+        // Nothing-allowed is the identity of join in the allowed dimension, and
+        // UNRESTRICTED (empty) absorbs: joining with the top is the top. A plain
+        // union read the empty set as the bottom (#2474).
+        let allowed: HashSet<String> = if self.allows_nothing() {
+            other.allowed.clone()
+        } else if other.allows_nothing() {
+            self.allowed.clone()
+        } else if self.allowed.is_empty() || other.allowed.is_empty() {
+            HashSet::new()
+        } else {
+            self.allowed.union(&other.allowed).cloned().collect()
+        };
 
         let blocked = if self.blocked.is_empty() || other.blocked.is_empty() {
             HashSet::new()
@@ -310,9 +337,27 @@ impl PathLattice {
         })
     }
 
+    /// Does this lattice allow no path at all (the bottom of the allowed
+    /// dimension, produced by the meet of disjoint restrictions)?
+    #[must_use]
+    pub fn allows_nothing(&self) -> bool {
+        self.allowed.len() == 1 && self.allowed.contains(NOTHING_ALLOWED)
+    }
+
     /// Check if this lattice is less than or equal to another.
+    ///
+    /// An EMPTY `allowed` set means unrestricted (every path allowed), so it
+    /// is the TOP of the allowed dimension — not the bottom the vacuous
+    /// subset test would make it. An unrestricted `self` is therefore `≤`
+    /// `other` only when `other` is unrestricted too (#2474).
     pub fn leq(&self, other: &Self) -> bool {
-        let allowed_ok = other.allowed.is_empty() || self.allowed.is_subset(&other.allowed);
+        let allowed_ok = if self.allows_nothing() {
+            true
+        } else if self.allowed.is_empty() {
+            other.allowed.is_empty()
+        } else {
+            other.allowed.is_empty() || self.allowed.is_subset(&other.allowed)
+        };
         let blocked_ok = other.blocked.is_subset(&self.blocked);
         allowed_ok && blocked_ok
     }
@@ -937,5 +982,76 @@ mod denial_display_tests {
         }
         .to_string();
         assert!(shown.contains("**/.ssh/**"), "got {shown:?}");
+    }
+}
+
+/// #2474: an empty `allowed` set is UNRESTRICTED — the top of that dimension —
+/// so the order must never place it below a restricted set.
+#[cfg(test)]
+mod leq_unrestricted_tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    fn with_allowed(globs: &[&str]) -> PathLattice {
+        let mut p = PathLattice::default();
+        p.allowed = globs.iter().map(|s| s.to_string()).collect();
+        p
+    }
+
+    #[test]
+    fn an_unrestricted_path_lattice_is_never_below_a_restricted_one() {
+        let unrestricted = with_allowed(&[]);
+        let restricted = with_allowed(&["src/**"]);
+        assert!(!unrestricted.leq(&restricted), "the inversion #2474 found");
+        assert!(restricted.leq(&unrestricted));
+        assert!(unrestricted.leq(&unrestricted));
+        assert!(restricted.leq(&restricted));
+        // The meet agrees with the order: meet(unrestricted, restricted) = restricted.
+        let m = unrestricted.meet(&restricted);
+        assert_eq!(m.allowed, restricted.allowed);
+        assert!(m.leq(&unrestricted) && m.leq(&restricted));
+
+        // Disjoint restrictions meet to NOTHING, which is below both and
+        // admits no path — never to "unrestricted".
+        let other = with_allowed(&["docs/**"]);
+        let none = restricted.meet(&other);
+        assert!(none.allows_nothing(), "{:?}", none.allowed);
+        assert!(none.leq(&restricted) && none.leq(&other) && none.leq(&unrestricted));
+        assert!(!unrestricted.leq(&none));
+        assert!(
+            !none.can_access(std::path::Path::new("src/lib.rs")),
+            "denied"
+        );
+        assert!(
+            !none.can_access(std::path::Path::new("docs/x.md")),
+            "denied"
+        );
+        assert_eq!(
+            none.join(&other).allowed,
+            other.allowed,
+            "nothing is the identity of join"
+        );
+    }
+
+    proptest! {
+        /// Over arbitrary small allow sets (empty included): the meet is a
+        /// lower bound of both operands, the order is reflexive, and an
+        /// unrestricted lattice is below a restricted one in no case.
+        #[test]
+        fn meet_is_a_lower_bound_and_unrestricted_is_top(
+            a in proptest::collection::hash_set("[a-c]/\\*\\*", 0..3),
+            b in proptest::collection::hash_set("[a-c]/\\*\\*", 0..3),
+        ) {
+            let pa = { let mut p = PathLattice::default(); p.allowed = a.clone(); p };
+            let pb = { let mut p = PathLattice::default(); p.allowed = b.clone(); p };
+            let m = pa.meet(&pb);
+            prop_assert!(m.leq(&pa));
+            prop_assert!(m.leq(&pb));
+            prop_assert!(pa.leq(&pa));
+            if a.is_empty() && !b.is_empty() {
+                prop_assert!(!pa.leq(&pb));
+                prop_assert!(pb.leq(&pa));
+            }
+        }
     }
 }


### PR DESCRIPTION
Closes #2474 (P0). Based on `main`, independent of the open stacks; #2487's chain-monotonicity theorem is stated over `leq` as given, which is exactly why this had to be fixed at the `leq` level — the parity test there and the regression here are what bind the proof to the real order.

### The defect, verified on `main`
`PathLattice::leq` and `CommandLattice::leq` compute `other.allowed.is_empty() || self.allowed.is_subset(&other.allowed)`. Empty means **unrestricted** in this representation, and the empty set is vacuously a subset of anything, so `unrestricted ≤ restricted` held. `verify_certificate` step 4c uses this composite `leq` as its only monotone check, so a validly signed child block with unrestricted paths or commands under a restricted parent verified. `a_child_claiming_unrestricted_paths_or_commands_is_refused` builds exactly that chain and now gets `MonotoneViolation { block_index: 1 }`; the honest narrower child still verifies.

### The sweep found two more instances in the same types
- **`meet` of disjoint restricted sets** returned the empty intersection, i.e. unrestricted: a child *requesting* a set disjoint from its parent's was granted everything. The property test found this on its first run. Fix: a deny-all sentinel `NOTHING_ALLOWED` (a pattern containing NUL, which no path or parsed command word contains, so it can match nothing) — disjoint meets are the bottom, `allows_nothing()` names it, it is `≤` everything and the identity of `join`; `allowed_rules` gets the same via a rule that matches nothing. `can_access` / `can_execute` refuse under it with no code change, since it simply never matches.
- **`join`** unioned allow sets, so `join(unrestricted, restricted) = restricted`; the top now absorbs. This is what `modal::tests::test_achievability` was silently relying on.
- Checked and sound: `SinkScope::subset_check` (the code refuses an empty child under a restricted parent; only its doc comment claimed the inversion — corrected), `DelegationScope` (empty means nothing, so vacuous subset is right), `BudgetLattice` (#2463), the capability extension map (absent is `Never`).

### Tests
`proptest` over small allow sets in both types: the meet is a lower bound of both operands, `leq` is reflexive, and an unrestricted lattice is never below a restricted one; unit tests for the sentinel (below everything, admits nothing, identity of join) and for the rules dimension. Kani cannot state this over `HashSet<String>`, which is why it is proptest; the issue allowed either.

### Verification
`cargo test -p portcullis` (1008, all targets) · `-p portcullis-core --all-features --lib` · `-p nucleus-tool-proxy --all-features` · `-p nucleus-node --features local-driver` · `cargo clippy -p portcullis --lib --all-features -- -D warnings` · `cargo fmt --check` · `scripts/check-line-ratchet.sh --strict` · `ci/no-vendor-strings.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZaH5waz88vL1qfNpFNfZ4
