### PR TITLE
security(node): gRPC pod-management handlers use the same per-caller ownership scoping as HTTP (#2475)

### DIFF
--- a/crates/nucleus-node/src/main.rs
+++ b/crates/nucleus-node/src/main.rs
@@ -3397,7 +3397,9 @@ impl NodeService for GrpcService {
             auth::Operation::ListPods,
         )?;
 
-        let infos = pod_api::collect_pod_infos(&self.state, None).await;
+        // Scoped to the calling pod exactly as the HTTP listing is (#2475).
+        let caller = pod_api::grpc_caller(self.state.caller_secret.as_ref(), request.metadata());
+        let infos = pod_api::collect_pod_infos(&self.state, caller).await;
         let pods = infos.into_iter().map(pod_info_to_grpc).collect();
         Ok(GrpcResponse::new(proto::ListPodsResponse { pods }))
     }
@@ -3413,11 +3415,8 @@ impl NodeService for GrpcService {
             auth::Operation::StreamLogs,
         )?;
 
-        let id = Uuid::parse_str(&request.into_inner().id)
-            .map_err(|_| Status::invalid_argument("invalid pod id"))?;
-        let pod = pod_api::get_pod(&self.state, id)
-            .await
-            .map_err(|_| Status::not_found("pod not found"))?;
+        let (md, _, req) = request.into_parts();
+        let pod = pod_api::grpc_scoped_pod(&self.state, &md, &req.id).await?;
         let logs = tokio::fs::read_to_string(&pod.log_path)
             .await
             .unwrap_or_default();
@@ -3435,11 +3434,8 @@ impl NodeService for GrpcService {
             auth::Operation::CancelPod,
         )?;
 
-        let id = Uuid::parse_str(&request.into_inner().id)
-            .map_err(|_| Status::invalid_argument("invalid pod id"))?;
-        let pod = pod_api::get_pod(&self.state, id)
-            .await
-            .map_err(|_| Status::not_found("pod not found"))?;
+        let (md, _, req) = request.into_parts();
+        let pod = pod_api::grpc_scoped_pod(&self.state, &md, &req.id).await?;
         pod.cancel()
             .await
             .map_err(|e| Status::internal(e.to_string()))?;
@@ -3459,11 +3455,8 @@ impl NodeService for GrpcService {
             auth::Operation::GetPod,
         )?;
 
-        let id = Uuid::parse_str(&request.into_inner().pod_id)
-            .map_err(|_| Status::invalid_argument("invalid pod id"))?;
-        let handle = pod_api::get_pod(&self.state, id)
-            .await
-            .map_err(|_| Status::not_found("pod not found"))?;
+        let (md, _, req) = request.into_parts();
+        let handle = pod_api::grpc_scoped_pod(&self.state, &md, &req.pod_id).await?;
         let info = handle.info().await;
         Ok(GrpcResponse::new(proto::GetPodResponse {
             pod: Some(pod_info_to_grpc(info)),
@@ -3483,12 +3476,8 @@ impl NodeService for GrpcService {
             auth::Operation::StreamLogs,
         )?;
 
-        let req = request.into_inner();
-        let id =
-            Uuid::parse_str(&req.pod_id).map_err(|_| Status::invalid_argument("invalid pod id"))?;
-        let pod = pod_api::get_pod(&self.state, id)
-            .await
-            .map_err(|_| Status::not_found("pod not found"))?;
+        let (md, _, req) = request.into_parts();
+        let pod = pod_api::grpc_scoped_pod(&self.state, &md, &req.pod_id).await?;
 
         let log_path = pod.log_path.clone();
         let follow = req.follow;
@@ -3519,12 +3508,9 @@ impl NodeService for GrpcService {
             auth::Operation::GetPod,
         )?;
 
-        let req = request.into_inner();
-        let id =
-            Uuid::parse_str(&req.pod_id).map_err(|_| Status::invalid_argument("invalid pod id"))?;
-        let pod = pod_api::get_pod(&self.state, id)
-            .await
-            .map_err(|_| Status::not_found("pod not found"))?;
+        let (md, _, req) = request.into_parts();
+        let pod = pod_api::grpc_scoped_pod(&self.state, &md, &req.pod_id).await?;
+        let id = pod.id;
 
         let include_initial = req.include_initial;
         let pod_id_str = id.to_string();
@@ -3551,12 +3537,10 @@ impl NodeService for GrpcService {
             auth::Operation::GetReceipt,
         )?;
 
-        let pod_id_str = request.into_inner().pod_id;
-        let id =
-            Uuid::parse_str(&pod_id_str).map_err(|_| Status::invalid_argument("invalid pod id"))?;
-        let handle = pod_api::get_pod(&self.state, id)
-            .await
-            .map_err(|_| Status::not_found("pod not found"))?;
+        let (md, _, req) = request.into_parts();
+        let pod_id_str = req.pod_id;
+        let handle = pod_api::grpc_scoped_pod(&self.state, &md, &pod_id_str).await?;
+        let id = handle.id;
 
         // Pod must be exited to have a receipt
         let state = handle.status().await;

--- a/crates/nucleus-node/src/pod_api.rs
+++ b/crates/nucleus-node/src/pod_api.rs
@@ -225,21 +225,58 @@ pub(crate) async fn get_pod(state: &NodeState, id: Uuid) -> Result<Arc<PodHandle
 /// <uuid> exist on this node?" for any caller willing to probe, which is exactly
 /// the fact that filtering the listing withholds. The refusal must not restore
 /// by oracle what the filter removed.
-async fn get_pod_for_caller(
+pub(crate) async fn get_pod_for_caller(
     state: &NodeState,
     id: Uuid,
     caller: Option<Uuid>,
 ) -> Result<Arc<PodHandle>, ApiError> {
     let pod = get_pod(state, id).await?;
-    if !caller_may_manage(caller, pod.id, pod.parent_pod_id) {
+    scoped_lookup(std::slice::from_ref(&pod), id, caller).ok_or_else(|| {
         tracing::warn!(
             %id,
             caller = ?caller,
             "a pod tried to manage a pod it does not own"
         );
-        return Err(ApiError::NotFound);
-    }
-    Ok(pod)
+        ApiError::NotFound
+    })
+}
+
+/// The single-item form of the scoping filter: `id` resolves for `caller` iff
+/// it is present AND `caller_may_manage` admits it. The same predicate as
+/// `scope_to_caller`, so a pod that is filtered OUT of the listing cannot be
+/// reached by id either — over HTTP or gRPC, which both call this.
+fn scoped_lookup<T: Lineage + Clone>(items: &[T], id: Uuid, caller: Option<Uuid>) -> Option<T> {
+    items
+        .iter()
+        .find(|it| {
+            it.lineage_id() == id && caller_may_manage(caller, it.lineage_id(), it.lineage_parent())
+        })
+        .cloned()
+}
+
+/// WHICH pod a gRPC request proves it is, from the same two metadata entries
+/// the HTTP middleware reads — and with the same outcome for an unprovable
+/// claim (`.ok()`: treated as no identity, exactly as `auth_middleware` does),
+/// so the two transports cannot disagree about who is calling (#2475).
+pub(crate) fn grpc_caller(caller_secret: &[u8], md: &tonic::metadata::MetadataMap) -> Option<Uuid> {
+    crate::pod_caller_identity::identify_from_metadata(caller_secret, md).ok()
+}
+
+/// Resolve a pod named on the wire for a gRPC caller: parse the id, identify
+/// the caller, and look the pod up through the SAME ownership-scoped path the
+/// HTTP handlers use. A pod the caller may not manage is `NOT_FOUND`, never a
+/// distinguishable refusal (#2475; the oracle argument on `get_pod_for_caller`).
+pub(crate) async fn grpc_scoped_pod(
+    state: &NodeState,
+    md: &tonic::metadata::MetadataMap,
+    raw_id: &str,
+) -> Result<Arc<PodHandle>, tonic::Status> {
+    let id =
+        Uuid::parse_str(raw_id).map_err(|_| tonic::Status::invalid_argument("invalid pod id"))?;
+    let caller = grpc_caller(state.caller_secret.as_ref(), md);
+    get_pod_for_caller(state, id, caller)
+        .await
+        .map_err(|_| tonic::Status::not_found("pod not found"))
 }
 
 #[cfg(test)]
@@ -510,5 +547,110 @@ mod ownership_tests {
         assert_eq!(recorded, Some(b()), "the proof must win");
         // And it still cannot reach A's child.
         assert!(!caller_may_manage(Some(b()), child_of_a(), Some(a())));
+    }
+
+    // ── #2475: the gRPC surface uses the same ownership predicate ─────────
+
+    /// The HTTP-side property, run against the lookup the gRPC handlers now
+    /// call: pod B cannot resolve A's child by id; A can; the operator can.
+    #[test]
+    fn scoped_lookup_refuses_another_pods_child_by_id() {
+        #[derive(Clone)]
+        struct P {
+            id: Uuid,
+            parent: Option<Uuid>,
+        }
+        impl super::Lineage for P {
+            fn lineage_id(&self) -> Uuid {
+                self.id
+            }
+            fn lineage_parent(&self) -> Option<Uuid> {
+                self.parent
+            }
+        }
+        let (a, b, child) = (a(), b(), child_of_a());
+        let registry = [
+            P {
+                id: a,
+                parent: None,
+            },
+            P {
+                id: child,
+                parent: Some(a),
+            },
+            P {
+                id: b,
+                parent: None,
+            },
+        ];
+        assert!(
+            super::scoped_lookup(&registry, child, Some(b)).is_none(),
+            "B cannot reach A's child"
+        );
+        assert!(
+            super::scoped_lookup(&registry, child, Some(a)).is_some(),
+            "A manages its child"
+        );
+        assert!(
+            super::scoped_lookup(&registry, child, None).is_some(),
+            "the operator sees everything"
+        );
+        assert!(
+            super::scoped_lookup(&registry, a, Some(b)).is_none(),
+            "a sibling is out of reach"
+        );
+        assert!(
+            super::scoped_lookup(&registry, Uuid::new_v4(), None).is_none(),
+            "absent is absent"
+        );
+    }
+
+    /// gRPC identifies the caller from the same two metadata entries the HTTP
+    /// middleware reads, with the same outcome for a claim that does not verify.
+    #[test]
+    fn grpc_caller_mirrors_the_http_middleware() {
+        let secret = [7u8; 32];
+        let pod = a();
+        let token = crate::pod_caller_identity::derive_token(&secret, pod);
+        let mut md = tonic::metadata::MetadataMap::new();
+        assert_eq!(
+            super::grpc_caller(&secret, &md),
+            None,
+            "nothing claimed: operator scope"
+        );
+        md.insert(
+            nucleus_client::HEADER_POD_ID,
+            pod.to_string().parse().unwrap(),
+        );
+        md.insert(nucleus_client::HEADER_POD_TOKEN, token.parse().unwrap());
+        assert_eq!(super::grpc_caller(&secret, &md), Some(pod));
+        assert_eq!(
+            super::grpc_caller(&[8u8; 32], &md),
+            None,
+            "an unprovable claim is no identity, as over HTTP"
+        );
+    }
+
+    /// Structural: no gRPC pod-management handler reaches the registry through
+    /// the unscoped lookup any more, and the listing is scoped.
+    #[test]
+    fn every_grpc_pod_handler_goes_through_the_scoped_lookup() {
+        let main = include_str!("main.rs");
+        let start = main
+            .find("impl NodeService for GrpcService")
+            .expect("the gRPC service impl");
+        let grpc = &main[start..];
+        assert!(
+            !grpc.contains("pod_api::get_pod("),
+            "an unscoped lookup survived in the gRPC impl"
+        );
+        assert!(
+            !grpc.contains("collect_pod_infos(&self.state, None)"),
+            "the gRPC listing is unscoped"
+        );
+        assert!(
+            grpc.matches("grpc_scoped_pod(").count() >= 6,
+            "every id-taking handler is scoped"
+        );
     }
 }


### PR DESCRIPTION
Closes #2475 (P1). Based on `main`.

### What was wrong, verified on `main`
The seven gRPC pod handlers (`list_pods`, `pod_logs`, `cancel_pod`, `get_pod`, `stream_pod_logs`, `watch_pod_state`, `get_receipt`) ran `authorize_grpc_operation` (any identity matching an allowed role prefix) and then the unscoped `pod_api::get_pod` / `collect_pod_infos(&state, None)`. The HTTP handlers scope through `get_pod_for_caller` / `caller_may_manage`. So over gRPC, any identity in an allowed role could read logs of, cancel, watch, or fetch the receipt of any pod on the node.

### The change
- `pod_api::grpc_caller(secret, metadata)`: the same two entries the HTTP middleware reads, through the shared `identify_from_metadata`, with the same outcome for a claim that does not verify (`.ok()`, as `auth_middleware` does), so the transports cannot disagree about who is calling.
- `pod_api::grpc_scoped_pod(state, metadata, raw_id)`: parse, identify, and resolve through `get_pod_for_caller`. That function is now built on `scoped_lookup`, the single-item form of the listing's `scope_to_caller` filter, so a pod filtered out of the listing cannot be reached by id either, over either transport. A non-owner gets `NOT_FOUND`, never a distinguishable refusal (the existing oracle argument).
- All seven handlers rewritten onto it; the listing is scoped to the caller; `main.rs` shrinks by 15 lines.

### Acceptance
- *A test mirroring the HTTP-side case against the gRPC surface*: `scoped_lookup_refuses_another_pods_child_by_id` runs the HTTP property (B cannot reach A's child; A can; the operator can; a sibling is out of reach) against the exact function the gRPC handlers now call; `grpc_caller_mirrors_the_http_middleware` pins the identity derivation; `every_grpc_pod_handler_goes_through_the_scoped_lookup` is structural over the `NodeService` impl (zero unscoped lookups, scoped listing, all id-taking handlers scoped).
- *Reachability*: the listener is off unless `--grpc-listen` / `NUCLEUS_NODE_GRPC_LISTEN` is set, but `nucleus provision` writes `NUCLEUS_NODE_GRPC_LISTEN=0.0.0.0:9180` into a provisioned node's environment, so there it is bound on all interfaces, behind mTLS and the role check. Any pod that can route to the host and holds an SVID in an allowed role could reach it. Live in provisioned deployments; closed either way.

### Verification
`cargo test -p nucleus-node --features local-driver` (412) · `cargo clippy -p nucleus-node --all-targets -- -D warnings` (with and without `local-driver`) · `cargo fmt --check` · `scripts/check-line-ratchet.sh --strict` (`main.rs` 4029) · `ci/no-vendor-strings.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZaH5waz88vL1qfNpFNfZ4
