### PR TITLE
formal(identity): Aeneas-extract the JWT-SVID claims decision; prove it sound, fail-closed and complete over the generated Lean

### DIFF
--- a/.github/workflows/aeneas-oidc-spiffe.yml
+++ b/.github/workflows/aeneas-oidc-spiffe.yml
@@ -19,6 +19,7 @@ on:
       - "crates/nucleus-github-oidc/src/extracted/**"
       - "crates/nucleus-github-oidc/lean/generated/**"
       - "crates/nucleus-github-oidc/lean/OidcSpiffeProofs.lean"
+      - "crates/nucleus-github-oidc/lean/JwtSvidClaimsProofs.lean"
       - "crates/nucleus-github-oidc/lean/lakefile.lean"
       - ".github/workflows/aeneas-oidc-spiffe.yml"
   pull_request:
@@ -26,6 +27,7 @@ on:
       - "crates/nucleus-github-oidc/src/extracted/**"
       - "crates/nucleus-github-oidc/lean/generated/**"
       - "crates/nucleus-github-oidc/lean/OidcSpiffeProofs.lean"
+      - "crates/nucleus-github-oidc/lean/JwtSvidClaimsProofs.lean"
       - "crates/nucleus-github-oidc/lean/lakefile.lean"
       - ".github/workflows/aeneas-oidc-spiffe.yml"
   merge_group:
@@ -49,7 +51,7 @@ env:
   # Charon needs a specific nightly for rustc-dev components.
   CHARON_NIGHTLY: nightly-2026-06-01
   # The scoped extraction roots — name them exactly as Charon sees the paths.
-  EXTRACT_ROOTS: "nucleus_github_oidc::extracted::oidc_spiffe::sanitize_bytes,nucleus_github_oidc::extracted::oidc_spiffe::derive_spiffe_bytes,nucleus_github_oidc::extracted::oidc_spiffe::is_spiffe_byte"
+  EXTRACT_ROOTS: "nucleus_github_oidc::extracted::oidc_spiffe::sanitize_bytes,nucleus_github_oidc::extracted::oidc_spiffe::derive_spiffe_bytes,nucleus_github_oidc::extracted::oidc_spiffe::is_spiffe_byte,nucleus_github_oidc::extracted::jwt_svid_claims::bytes_eq,nucleus_github_oidc::extracted::jwt_svid_claims::has_prefix,nucleus_github_oidc::extracted::jwt_svid_claims::decide_claims"
 
 jobs:
   aeneas-oidc-spiffe:
@@ -74,7 +76,7 @@ jobs:
           EVENT: ${{ github.event_name }}
           BASE: ${{ github.event.merge_group.base_sha }}
           HEAD: ${{ github.event.merge_group.head_sha }}
-          PATTERN: '^\.github/workflows/aeneas\-oidc\-spiffe\.yml$|^crates/nucleus\-github\-oidc/lean/OidcSpiffeProofs\.lean$|^crates/nucleus\-github\-oidc/lean/generated/|^crates/nucleus\-github\-oidc/lean/lakefile\.lean$|^crates/nucleus\-github\-oidc/src/extracted/'
+          PATTERN: '^\.github/workflows/aeneas\-oidc\-spiffe\.yml$|^crates/nucleus\-github\-oidc/lean/OidcSpiffeProofs\.lean$|^crates/nucleus\-github\-oidc/lean/JwtSvidClaimsProofs\.lean$|^crates/nucleus\-github\-oidc/lean/generated/|^crates/nucleus\-github\-oidc/lean/lakefile\.lean$|^crates/nucleus\-github\-oidc/src/extracted/'
         run: |
           set -euo pipefail
           if [ "$EVENT" != "merge_group" ]; then
@@ -241,7 +243,7 @@ jobs:
         shell: bash
         run: |
           lake build NucleusGithubOidc
-          lake build OidcSpiffeProofs 2>&1 | tee /tmp/lake-oidc.log
+          lake build OidcSpiffeProofs JwtSvidClaimsProofs 2>&1 | tee /tmp/lake-oidc.log
 
       - name: Assert clean axiom set (no sorryAx / opaque axioms)
         if: steps.scope.outputs.relevant == 'true'
@@ -279,7 +281,7 @@ jobs:
           # anywhere. Must NOT false-positive on the file's honest prose about
           # `sorry`/`sorry-free`/`partial_fixpoint`.
           if grep -rnE '(:=|=>|\bby\b|<;>|·|;|^)[[:space:]]*(sorry|admit)\b|\bnative_decide\b' \
-               OidcSpiffeProofs.lean \
+               OidcSpiffeProofs.lean JwtSvidClaimsProofs.lean \
                generated/NucleusGithubOidc/ --include='*.lean'; then
             echo "ERROR: proof contains a sorry/admit/native_decide tactic."
             exit 1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6750,6 +6750,7 @@ dependencies = [
  "http-body-util",
  "nucleus-control-plane",
  "nucleus-envelope",
+ "nucleus-github-oidc",
  "nucleus-lineage",
  "nucleus-oidc-core",
  "nucleus-otel-bootstrap",

--- a/crates/nucleus-control-plane-server/Cargo.toml
+++ b/crates/nucleus-control-plane-server/Cargo.toml
@@ -26,6 +26,10 @@ nucleus-lineage = { path = "../nucleus-lineage" }
 nucleus-envelope = { path = "../nucleus-envelope" }
 nucleus-control-plane = { path = "../nucleus-control-plane" }
 nucleus-oidc-core = { path = "../nucleus-oidc-core" }
+# The Aeneas-extracted JWT-SVID claims decision core (`extracted::jwt_svid_claims`)
+# that `auth::verify_jwt_svid` calls on the live path; its theorems are in that
+# crate's lean/ (#2452). Default features only: no token-exchange, no reqwest.
+nucleus-github-oidc = { path = "../nucleus-github-oidc" }
 ed25519-dalek = "=3.0.0"
 base64 = "0.23"
 axum = { version = "0.8", features = ["macros", "json"] }

--- a/crates/nucleus-control-plane-server/src/auth.rs
+++ b/crates/nucleus-control-plane-server/src/auth.rs
@@ -38,6 +38,7 @@ use axum::extract::FromRequestParts;
 use axum::http::{StatusCode, header, request::Parts};
 use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD as B64URL};
 use ed25519_dalek::{Signature, VerifyingKey};
+use nucleus_github_oidc::extracted::jwt_svid_claims::{self, ClaimsVerdict};
 use nucleus_oidc_core::{JwkPublicKey, Jwks};
 use serde::Deserialize;
 use thiserror::Error;
@@ -381,25 +382,46 @@ pub fn verify_jwt_svid(
         .map_err(|_| AuthError::ClockBeforeEpoch)?
         .as_secs();
 
-    if claims.exp + config.clock_skew_secs < now {
-        return Err(AuthError::Expired {
-            exp: claims.exp,
-            now,
-        });
-    }
-    if let Some(nbf) = claims.nbf
-        && nbf > now + config.clock_skew_secs
-    {
-        return Err(AuthError::NotYetValid { nbf, now });
-    }
-
+    // The claims decision (exp/nbf with skew leeway, aud membership, sub
+    // prefix) is the Aeneas-extracted core in `nucleus-github-oidc`
+    // (`extracted::jwt_svid_claims`, #2452): `decide_claims` and the byte
+    // loops are extracted to Lean and their soundness / fail-closed /
+    // completeness theorems proved over the generated defs; `claims_verdict`
+    // is the audience fold (not extractable: nested borrow) composed with
+    // them. This is the call that puts the theorems on the live path. Check
+    // order is the original order, so the first failing predicate is the
+    // error reported.
     let auds = claims.aud.into_vec();
-    if !auds.iter().any(|a| a == &config.allowed_audience) {
-        return Err(AuthError::AudienceMismatch);
-    }
-
-    if !claims.sub.starts_with(&config.allowed_subject_prefix) {
-        return Err(AuthError::SubjectPrefixMismatch { sub: claims.sub });
+    let aud_refs: Vec<&[u8]> = auds.iter().map(|a| a.as_bytes()).collect();
+    match jwt_svid_claims::claims_verdict(
+        claims.exp,
+        claims.nbf,
+        now,
+        config.clock_skew_secs,
+        &aud_refs,
+        config.allowed_audience.as_bytes(),
+        claims.sub.as_bytes(),
+        config.allowed_subject_prefix.as_bytes(),
+    ) {
+        ClaimsVerdict::Admit => {}
+        ClaimsVerdict::Expired => {
+            return Err(AuthError::Expired {
+                exp: claims.exp,
+                now,
+            });
+        }
+        ClaimsVerdict::NotYetValid => {
+            // `NotYetValid` is only raised with `nbf = Some` (Lean:
+            // `not_yet_valid_has_nbf`); the fallback is unreachable.
+            return Err(AuthError::NotYetValid {
+                nbf: claims.nbf.unwrap_or(now),
+                now,
+            });
+        }
+        ClaimsVerdict::AudienceMismatch => return Err(AuthError::AudienceMismatch),
+        ClaimsVerdict::SubjectPrefixMismatch => {
+            return Err(AuthError::SubjectPrefixMismatch { sub: claims.sub });
+        }
     }
 
     Ok(AuthenticatedPrincipal::new(claims.sub, auds, true))

--- a/crates/nucleus-github-oidc/lean/JwtSvidClaimsProofs.lean
+++ b/crates/nucleus-github-oidc/lean/JwtSvidClaimsProofs.lean
@@ -1,0 +1,237 @@
+/-
+  JWT-SVID claims decision — properties proven OVER the Aeneas-EXTRACTED core.
+
+  Aeneas→Lean target #3 in this crate's pipeline (sibling to the OIDC→SPIFFE
+  derivation slice in `OidcSpiffeProofs.lean`). The chain:
+
+      crates/nucleus-github-oidc/src/extracted/jwt_svid_claims.rs   (real Rust)
+        --charon (scoped, --start-from)-->  nucleus_github_oidc.llbc
+        --aeneas -backend lean -split-files-->
+          generated/NucleusGithubOidc/{Types,Funs}.lean   (THIS file's deps)
+        --(this file)-->  properties proven over THOSE generated defs.
+
+  The production caller is `nucleus-control-plane-server::auth::verify_jwt_svid`
+  (#2452): after the EdDSA signature check it CALLS the extracted
+  `decide_claims` (with `has_prefix` on the subject and `bytes_eq` per audience
+  element) for its claims decision, so every theorem here is about the live
+  path, not a mirror of it.
+
+  # The honest trust chain (production ↔ extracted)
+
+  - Production ≡ extracted: `verify_jwt_svid` calls the extracted functions
+    (call-through), and the parity proptests in `jwt_svid_claims.rs`
+    (`claims_verdict_matches_production*`) check the composed call against the
+    pre-refactor inline clause, lifted verbatim as the oracle.
+  - Extracted ≡ generated: Aeneas, re-run by CI on every change; the
+    `#print axioms` audit below is the evidence the theorems ran.
+
+  # What IS proven sorry-free over the generated `decide_claims`
+
+  * `admit_sound` — an `Admit` verdict implies EVERY predicate held: the
+    audience matched, the subject prefix matched, `exp + skew` did not
+    overflow and is not below `now`, and if `nbf` is present then `now + skew`
+    did not overflow and `nbf` is not above it. No admission without all four.
+  * `aud_mismatch_fails_closed` / `sub_mismatch_fails_closed` — a failed
+    audience or subject check can never yield `Admit`, whatever the clock says.
+  * `admit_complete` — when all four predicates hold the verdict IS `Admit`, so
+    the core cannot reject a valid token either (no false 401/403 from the
+    decision).
+  * `not_yet_valid_has_nbf` — `NotYetValid` is only ever raised with
+    `nbf = some _`, which is what licenses the caller's `unwrap_or` when it
+    reports the refused `nbf`.
+  * `verdict_order` — the first failing predicate, in production's order, is
+    the verdict: `Expired` beats `NotYetValid` beats `AudienceMismatch` beats
+    `SubjectPrefixMismatch`.
+
+  # Scope boundary (what is NOT claimed)
+
+  - NOT the signature check (`ed25519-dalek`, outside the extractable subset).
+  - NOT the audience FOLD: `auds.iter().any(...)` is a nested-borrow slice
+    (`&[&[u8]]`), which Aeneas rejects, and the fold itself is the
+    `Iterator::fold` axiom. The fold stays in production; the theorems take its
+    result as `aud_ok`.
+  - NOT the byte loops `bytes_eq` / `has_prefix` as closed theorems: their
+    generated form is the Aeneas `loop` combinator (`partial_fixpoint`), the
+    same gap `OidcSpiffeProofs.lean` discloses; they are covered by the Rust
+    parity proptests (`loops_match_std`) instead.
+  - Overflow: the generated `+` is checked. The theorems are stated with the
+    no-overflow facts as CONCLUSIONS of `admit_sound` (an admission proves the
+    sums were representable) and as HYPOTHESES of `admit_complete`.
+-/
+
+import NucleusGithubOidc.Types
+import NucleusGithubOidc.Funs
+import Aeneas
+import Mathlib.Tactic
+
+open Aeneas Aeneas.Std Result
+
+set_option maxHeartbeats 1000000
+
+namespace JwtSvidClaimsProofs
+
+open nucleus_github_oidc.extracted.jwt_svid_claims
+
+/-! ## Soundness: no admission without every predicate -/
+
+/-- **An `Admit` verdict implies every claims predicate held.** -/
+theorem admit_sound
+    (exp now skew : Std.U64) (nbf : Option Std.U64) (aud_ok sub_ok : Bool)
+    (h : decide_claims exp nbf now skew aud_ok sub_ok = ok ClaimsVerdict.Admit) :
+    aud_ok = true ∧ sub_ok = true
+    ∧ (∃ s, exp + skew = ok s ∧ ¬ s < now)
+    ∧ (∀ n, nbf = some n → ∃ t, now + skew = ok t ∧ ¬ n > t) := by
+  unfold decide_claims at h
+  cases hs : (exp + skew : Result Std.U64) with
+  | fail e => simp [hs] at h
+  | div => simp [hs] at h
+  | ok s =>
+    simp only [hs, bind_tc_ok] at h
+    split at h
+    · simp at h
+    · rename_i hlt
+      cases nbf with
+      | none =>
+        simp only [bind_tc_ok] at h
+        cases aud_ok <;> cases sub_ok <;> simp_all
+      | some n =>
+        cases ht : (now + skew : Result Std.U64) with
+        | fail e => simp [ht] at h
+        | div => simp [ht] at h
+        | ok t =>
+          simp only [ht, bind_tc_ok] at h
+          by_cases hnt : (↑t : ℕ) < ↑n
+          · simp [hnt] at h
+          · simp [hnt] at h
+            cases aud_ok <;> cases sub_ok <;> simp_all
+
+/-! ## Fail-closed: a failed check can never admit -/
+
+/-- **A failed audience check can never yield `Admit`.** -/
+theorem aud_mismatch_fails_closed
+    (exp now skew : Std.U64) (nbf : Option Std.U64) (sub_ok : Bool) :
+    decide_claims exp nbf now skew false sub_ok ≠ ok ClaimsVerdict.Admit := by
+  intro h
+  have := (admit_sound exp now skew nbf false sub_ok h).1
+  simp at this
+
+/-- **A failed subject-prefix check can never yield `Admit`.** -/
+theorem sub_mismatch_fails_closed
+    (exp now skew : Std.U64) (nbf : Option Std.U64) (aud_ok : Bool) :
+    decide_claims exp nbf now skew aud_ok false ≠ ok ClaimsVerdict.Admit := by
+  intro h
+  have := (admit_sound exp now skew nbf aud_ok false h).2.1
+  simp at this
+
+/-! ## Completeness: a valid token is admitted -/
+
+/-- **When every predicate holds, the verdict is `Admit`.** The no-overflow
+    facts are hypotheses here (they are conclusions of `admit_sound`). -/
+theorem admit_complete
+    (exp now skew : Std.U64) (nbf : Option Std.U64)
+    (s : Std.U64) (hs : exp + skew = ok s) (hexp : ¬ s < now)
+    (hnbf : ∀ n, nbf = some n → ∃ t, now + skew = ok t ∧ ¬ n > t) :
+    decide_claims exp nbf now skew true true = ok ClaimsVerdict.Admit := by
+  unfold decide_claims
+  simp only [hs, bind_tc_ok]
+  rw [if_neg hexp]
+  cases nbf with
+  | none => simp
+  | some n =>
+    obtain ⟨t, ht, hnt⟩ := hnbf n rfl
+    have hnt' : ¬ (↑t : ℕ) < ↑n := hnt
+    simp [ht, hnt']
+
+/-! ## Verdict attribution -/
+
+/-- **`NotYetValid` is only raised with `nbf = some _`.** Licenses the caller's
+    `nbf.unwrap_or(..)` when it reports the refused `nbf`. -/
+theorem not_yet_valid_has_nbf
+    (exp now skew : Std.U64) (nbf : Option Std.U64) (aud_ok sub_ok : Bool)
+    (h : decide_claims exp nbf now skew aud_ok sub_ok = ok ClaimsVerdict.NotYetValid) :
+    ∃ n, nbf = some n := by
+  unfold decide_claims at h
+  cases hs : (exp + skew : Result Std.U64) with
+  | fail e => simp [hs] at h
+  | div => simp [hs] at h
+  | ok s =>
+    simp only [hs, bind_tc_ok] at h
+    split at h
+    · simp at h
+    · cases nbf with
+      | none =>
+        simp only [bind_tc_ok] at h
+        cases aud_ok <;> cases sub_ok <;> simp_all
+      | some n => exact ⟨n, rfl⟩
+
+/-! ## Verdict order: the first failing predicate wins -/
+
+/-- **Expiry is reported first**, before any other predicate is consulted. -/
+theorem expired_first
+    (exp now skew : Std.U64) (nbf : Option Std.U64) (aud_ok sub_ok : Bool)
+    (s : Std.U64) (hs : exp + skew = ok s) (hexp : s < now) :
+    decide_claims exp nbf now skew aud_ok sub_ok = ok ClaimsVerdict.Expired := by
+  have hexp' : (↑s : ℕ) < ↑now := hexp
+  unfold decide_claims
+  simp [hs, hexp']
+
+/-- **Not-before is reported second**, before the audience and subject checks. -/
+theorem not_yet_valid_second
+    (exp now skew : Std.U64) (n : Std.U64) (aud_ok sub_ok : Bool)
+    (s : Std.U64) (hs : exp + skew = ok s) (hexp : ¬ s < now)
+    (t : Std.U64) (ht : now + skew = ok t) (hnt : n > t) :
+    decide_claims exp (some n) now skew aud_ok sub_ok = ok ClaimsVerdict.NotYetValid := by
+  have hexp' : ¬ (↑s : ℕ) < ↑now := hexp
+  have hnt' : (↑t : ℕ) < ↑n := hnt
+  unfold decide_claims
+  simp [hs, hexp', ht, hnt']
+
+/-- **Audience is reported third**, before the subject check. -/
+theorem audience_third
+    (exp now skew : Std.U64) (nbf : Option Std.U64) (sub_ok : Bool)
+    (s : Std.U64) (hs : exp + skew = ok s) (hexp : ¬ s < now)
+    (hnbf : ∀ n, nbf = some n → ∃ t, now + skew = ok t ∧ ¬ n > t) :
+    decide_claims exp nbf now skew false sub_ok = ok ClaimsVerdict.AudienceMismatch := by
+  unfold decide_claims
+  simp only [hs, bind_tc_ok]
+  rw [if_neg hexp]
+  cases nbf with
+  | none => simp
+  | some n =>
+    obtain ⟨t, ht, hnt⟩ := hnbf n rfl
+    have hnt' : ¬ (↑t : ℕ) < ↑n := hnt
+    simp [ht, hnt']
+
+/-- **Subject prefix is reported last.** -/
+theorem subject_last
+    (exp now skew : Std.U64) (nbf : Option Std.U64)
+    (s : Std.U64) (hs : exp + skew = ok s) (hexp : ¬ s < now)
+    (hnbf : ∀ n, nbf = some n → ∃ t, now + skew = ok t ∧ ¬ n > t) :
+    decide_claims exp nbf now skew true false = ok ClaimsVerdict.SubjectPrefixMismatch := by
+  unfold decide_claims
+  simp only [hs, bind_tc_ok]
+  rw [if_neg hexp]
+  cases nbf with
+  | none => simp
+  | some n =>
+    obtain ⟨t, ht, hnt⟩ := hnbf n rfl
+    have hnt' : ¬ (↑t : ℕ) < ↑n := hnt
+    simp [ht, hnt']
+
+end JwtSvidClaimsProofs
+
+/-
+  Axiom audit. The CI job captures the real `#print axioms` output and fails on
+  `sorryAx` or any Aeneas-emitted opaque axiom. The expected set is a subset of
+  `[propext, Classical.choice, Quot.sound]` (the trusted Lean kernel set entered
+  via `simp`/`decide`; not proof holes).
+-/
+#print axioms JwtSvidClaimsProofs.admit_sound
+#print axioms JwtSvidClaimsProofs.aud_mismatch_fails_closed
+#print axioms JwtSvidClaimsProofs.sub_mismatch_fails_closed
+#print axioms JwtSvidClaimsProofs.admit_complete
+#print axioms JwtSvidClaimsProofs.not_yet_valid_has_nbf
+#print axioms JwtSvidClaimsProofs.expired_first
+#print axioms JwtSvidClaimsProofs.not_yet_valid_second
+#print axioms JwtSvidClaimsProofs.audience_third
+#print axioms JwtSvidClaimsProofs.subject_last

--- a/crates/nucleus-github-oidc/lean/README.md
+++ b/crates/nucleus-github-oidc/lean/README.md
@@ -50,6 +50,18 @@ kernel-reducible `DecidableEq` for `decide`. So the Lean side proves the per-ste
 root cause (`collapse_lossy_step`); the closed end-to-end collision lives in the
 Rust proptest. No `sorry` claims more than holds.
 
+## Aeneas→Lean target #3: the JWT-SVID claims decision (#2452)
+
+`JwtSvidClaimsProofs.lean` proves, over the generated
+`extracted.jwt_svid_claims.decide_claims` (source:
+`src/extracted/jwt_svid_claims.rs`, called on the live path by the control
+plane's `verify_jwt_svid`): `admit_sound` (no admission without every
+predicate), `aud_mismatch_fails_closed` / `sub_mismatch_fails_closed`,
+`admit_complete`, `not_yet_valid_has_nbf`, and the four verdict-order theorems.
+The audience fold (`&[&[u8]]`, a nested borrow) and the signature check stay in
+production; the byte loops are covered by parity proptests. See
+`docs/verified-claims.md` §10 and `docs/design/identity-verifier-extraction.md`.
+
 ## Reproducing
 
 Extraction + proofs build on Linux CI (`aeneas-oidc-spiffe.yml`) and locally:
@@ -60,11 +72,14 @@ RUSTUP_TOOLCHAIN=nightly-2026-02-07 \
   charon cargo --preset aeneas \
     --start-from nucleus_github_oidc::extracted::oidc_spiffe::sanitize_bytes \
     --start-from nucleus_github_oidc::extracted::oidc_spiffe::derive_spiffe_bytes \
-    --start-from nucleus_github_oidc::extracted::oidc_spiffe::is_spiffe_byte
+    --start-from nucleus_github_oidc::extracted::oidc_spiffe::is_spiffe_byte \
+    --start-from nucleus_github_oidc::extracted::jwt_svid_claims::bytes_eq \
+    --start-from nucleus_github_oidc::extracted::jwt_svid_claims::has_prefix \
+    --start-from nucleus_github_oidc::extracted::jwt_svid_claims::decide_claims
 aeneas -backend lean -split-files nucleus_github_oidc.llbc -dest lean/generated/NucleusGithubOidc
 
 # 2. build the proofs + axiom audit
-cd lean && lake exe cache get && lake build NucleusGithubOidc OidcSpiffeProofs
+cd lean && lake exe cache get && lake build NucleusGithubOidc OidcSpiffeProofs JwtSvidClaimsProofs
 ```
 
 Pins: aeneas `nightly-2026.06.10` (commit `2a12be13…`), Charon nightly

--- a/crates/nucleus-github-oidc/lean/generated/NucleusGithubOidc/Funs.lean
+++ b/crates/nucleus-github-oidc/lean/generated/NucleusGithubOidc/Funs.lean
@@ -15,8 +15,118 @@ set_option maxRecDepth 2048
 
 namespace nucleus_github_oidc
 
+/-- [nucleus_github_oidc::extracted::jwt_svid_claims::bytes_eq]: loop body 0:
+    Source: 'crates/nucleus-github-oidc/src/extracted/jwt_svid_claims.rs', lines 99:4-106:1
+    Visibility: public -/
+@[rust_loop_body]
+def extracted.jwt_svid_claims.bytes_eq_loop.body
+  (a : Slice Std.U8) (b : Slice Std.U8) (i : Std.Usize) :
+  Result (ControlFlow Std.Usize Bool)
+  := do
+  let i1 := Slice.len a
+  if i < i1
+  then
+    let i2 ← Slice.index_usize a i
+    let i3 ← Slice.index_usize b i
+    if i2 != i3
+    then ok (done false)
+    else let i4 ← i + 1#usize
+         ok (cont i4)
+  else ok (done true)
+
+/-- [nucleus_github_oidc::extracted::jwt_svid_claims::bytes_eq]: loop 0:
+    Source: 'crates/nucleus-github-oidc/src/extracted/jwt_svid_claims.rs', lines 99:4-106:1
+    Visibility: public -/
+@[rust_loop]
+def extracted.jwt_svid_claims.bytes_eq_loop
+  (a : Slice Std.U8) (b : Slice Std.U8) (i : Std.Usize) : Result Bool := do
+  loop
+    (fun i1 => extracted.jwt_svid_claims.bytes_eq_loop.body a b i1)
+    i
+
+/-- [nucleus_github_oidc::extracted::jwt_svid_claims::bytes_eq]:
+    Source: 'crates/nucleus-github-oidc/src/extracted/jwt_svid_claims.rs', lines 94:0-106:1
+    Visibility: public -/
+def extracted.jwt_svid_claims.bytes_eq
+  (a : Slice Std.U8) (b : Slice Std.U8) : Result Bool := do
+  let i := Slice.len a
+  let i1 := Slice.len b
+  if i != i1
+  then ok false
+  else extracted.jwt_svid_claims.bytes_eq_loop a b 0#usize
+
+/-- [nucleus_github_oidc::extracted::jwt_svid_claims::has_prefix]: loop body 0:
+    Source: 'crates/nucleus-github-oidc/src/extracted/jwt_svid_claims.rs', lines 114:4-121:1
+    Visibility: public -/
+@[rust_loop_body]
+def extracted.jwt_svid_claims.has_prefix_loop.body
+  (s : Slice Std.U8) (prefix1 : Slice Std.U8) (i : Std.Usize) :
+  Result (ControlFlow Std.Usize Bool)
+  := do
+  let i1 := Slice.len prefix1
+  if i < i1
+  then
+    let i2 ← Slice.index_usize s i
+    let i3 ← Slice.index_usize prefix1 i
+    if i2 != i3
+    then ok (done false)
+    else let i4 ← i + 1#usize
+         ok (cont i4)
+  else ok (done true)
+
+/-- [nucleus_github_oidc::extracted::jwt_svid_claims::has_prefix]: loop 0:
+    Source: 'crates/nucleus-github-oidc/src/extracted/jwt_svid_claims.rs', lines 114:4-121:1
+    Visibility: public -/
+@[rust_loop]
+def extracted.jwt_svid_claims.has_prefix_loop
+  (s : Slice Std.U8) (prefix1 : Slice Std.U8) (i : Std.Usize) :
+  Result Bool
+  := do
+  loop
+    (fun i1 => extracted.jwt_svid_claims.has_prefix_loop.body s prefix1 i1)
+    i
+
+/-- [nucleus_github_oidc::extracted::jwt_svid_claims::has_prefix]:
+    Source: 'crates/nucleus-github-oidc/src/extracted/jwt_svid_claims.rs', lines 109:0-121:1
+    Visibility: public -/
+def extracted.jwt_svid_claims.has_prefix
+  (s : Slice Std.U8) (prefix1 : Slice Std.U8) : Result Bool := do
+  let i := Slice.len prefix1
+  let i1 := Slice.len s
+  if i > i1
+  then ok false
+  else extracted.jwt_svid_claims.has_prefix_loop s prefix1 0#usize
+
+/-- [nucleus_github_oidc::extracted::jwt_svid_claims::decide_claims]:
+    Source: 'crates/nucleus-github-oidc/src/extracted/jwt_svid_claims.rs', lines 130:0-155:1
+    Visibility: public -/
+def extracted.jwt_svid_claims.decide_claims
+  (exp : Std.U64) (nbf : Option Std.U64) (now : Std.U64) (skew : Std.U64)
+  (aud_ok : Bool) (sub_ok : Bool) :
+  Result extracted.jwt_svid_claims.ClaimsVerdict
+  := do
+  let i ← exp + skew
+  if i < now
+  then ok extracted.jwt_svid_claims.ClaimsVerdict.Expired
+  else
+    let not_yet_valid ←
+      match nbf with
+      | none => ok false
+      | some n => do
+                  let i1 ← now + skew
+                  ok (n > i1)
+    if not_yet_valid
+    then ok extracted.jwt_svid_claims.ClaimsVerdict.NotYetValid
+    else
+      if aud_ok
+      then
+        if sub_ok
+        then ok extracted.jwt_svid_claims.ClaimsVerdict.Admit
+        else ok extracted.jwt_svid_claims.ClaimsVerdict.SubjectPrefixMismatch
+      else ok extracted.jwt_svid_claims.ClaimsVerdict.AudienceMismatch
+
 /-- [nucleus_github_oidc::extracted::oidc_spiffe::is_spiffe_byte]:
-    Source: 'crates/nucleus-github-oidc/src/extracted/oidc_spiffe.rs', lines 15:0-22:1
+    Source: 'crates/nucleus-github-oidc/src/extracted/oidc_spiffe.rs', lines 23:0-30:1
     Visibility: public -/
 def extracted.oidc_spiffe.is_spiffe_byte (b : Std.U8) : Result Bool := do
   if b >= 48#u8
@@ -103,11 +213,11 @@ def extracted.oidc_spiffe.is_spiffe_byte (b : Std.U8) : Result Bool := do
              else ok (b = 45#u8)
 
 /-- [nucleus_github_oidc::extracted::oidc_spiffe::DASH]
-    Source: 'crates/nucleus-github-oidc/src/extracted/oidc_spiffe.rs', lines 25:0-25:22 -/
+    Source: 'crates/nucleus-github-oidc/src/extracted/oidc_spiffe.rs', lines 33:0-33:22 -/
 @[global_simps, irreducible] def extracted.oidc_spiffe.DASH : Std.U8 := 45#u8
 
 /-- [nucleus_github_oidc::extracted::oidc_spiffe::sanitize_bytes]: loop body 0:
-    Source: 'crates/nucleus-github-oidc/src/extracted/oidc_spiffe.rs', lines 48:4-60:5
+    Source: 'crates/nucleus-github-oidc/src/extracted/oidc_spiffe.rs', lines 56:4-68:5
     Visibility: public -/
 @[rust_loop_body]
 def extracted.oidc_spiffe.sanitize_bytes_loop0.body
@@ -138,7 +248,7 @@ def extracted.oidc_spiffe.sanitize_bytes_loop0.body
   else ok (done collapsed)
 
 /-- [nucleus_github_oidc::extracted::oidc_spiffe::sanitize_bytes]: loop 0:
-    Source: 'crates/nucleus-github-oidc/src/extracted/oidc_spiffe.rs', lines 48:4-60:5
+    Source: 'crates/nucleus-github-oidc/src/extracted/oidc_spiffe.rs', lines 56:4-68:5
     Visibility: public -/
 @[rust_loop]
 def extracted.oidc_spiffe.sanitize_bytes_loop0
@@ -153,7 +263,7 @@ def extracted.oidc_spiffe.sanitize_bytes_loop0
     (collapsed, prev_dash, i)
 
 /-- [nucleus_github_oidc::extracted::oidc_spiffe::sanitize_bytes]: loop body 1:
-    Source: 'crates/nucleus-github-oidc/src/extracted/oidc_spiffe.rs', lines 65:4-67:5
+    Source: 'crates/nucleus-github-oidc/src/extracted/oidc_spiffe.rs', lines 73:4-75:5
     Visibility: public -/
 @[rust_loop_body]
 def extracted.oidc_spiffe.sanitize_bytes_loop1.body
@@ -172,7 +282,7 @@ def extracted.oidc_spiffe.sanitize_bytes_loop1.body
   else ok (done lo)
 
 /-- [nucleus_github_oidc::extracted::oidc_spiffe::sanitize_bytes]: loop 1:
-    Source: 'crates/nucleus-github-oidc/src/extracted/oidc_spiffe.rs', lines 65:4-67:5
+    Source: 'crates/nucleus-github-oidc/src/extracted/oidc_spiffe.rs', lines 73:4-75:5
     Visibility: public -/
 @[rust_loop]
 def extracted.oidc_spiffe.sanitize_bytes_loop1
@@ -185,7 +295,7 @@ def extracted.oidc_spiffe.sanitize_bytes_loop1
     lo
 
 /-- [nucleus_github_oidc::extracted::oidc_spiffe::sanitize_bytes]: loop body 2:
-    Source: 'crates/nucleus-github-oidc/src/extracted/oidc_spiffe.rs', lines 70:4-72:5
+    Source: 'crates/nucleus-github-oidc/src/extracted/oidc_spiffe.rs', lines 78:4-80:5
     Visibility: public -/
 @[rust_loop_body]
 def extracted.oidc_spiffe.sanitize_bytes_loop2.body
@@ -204,7 +314,7 @@ def extracted.oidc_spiffe.sanitize_bytes_loop2.body
   else ok (done hi)
 
 /-- [nucleus_github_oidc::extracted::oidc_spiffe::sanitize_bytes]: loop 2:
-    Source: 'crates/nucleus-github-oidc/src/extracted/oidc_spiffe.rs', lines 70:4-72:5
+    Source: 'crates/nucleus-github-oidc/src/extracted/oidc_spiffe.rs', lines 78:4-80:5
     Visibility: public -/
 @[rust_loop]
 def extracted.oidc_spiffe.sanitize_bytes_loop2
@@ -217,7 +327,7 @@ def extracted.oidc_spiffe.sanitize_bytes_loop2
     hi
 
 /-- [nucleus_github_oidc::extracted::oidc_spiffe::sanitize_bytes]: loop body 3:
-    Source: 'crates/nucleus-github-oidc/src/extracted/oidc_spiffe.rs', lines 76:4-79:5
+    Source: 'crates/nucleus-github-oidc/src/extracted/oidc_spiffe.rs', lines 84:4-87:5
     Visibility: public -/
 @[rust_loop_body]
 def extracted.oidc_spiffe.sanitize_bytes_loop3.body
@@ -237,7 +347,7 @@ def extracted.oidc_spiffe.sanitize_bytes_loop3.body
   else ok (done out)
 
 /-- [nucleus_github_oidc::extracted::oidc_spiffe::sanitize_bytes]: loop 3:
-    Source: 'crates/nucleus-github-oidc/src/extracted/oidc_spiffe.rs', lines 76:4-79:5
+    Source: 'crates/nucleus-github-oidc/src/extracted/oidc_spiffe.rs', lines 84:4-87:5
     Visibility: public -/
 @[rust_loop]
 def extracted.oidc_spiffe.sanitize_bytes_loop3
@@ -251,7 +361,7 @@ def extracted.oidc_spiffe.sanitize_bytes_loop3
     (out, k)
 
 /-- [nucleus_github_oidc::extracted::oidc_spiffe::sanitize_bytes]:
-    Source: 'crates/nucleus-github-oidc/src/extracted/oidc_spiffe.rs', lines 42:0-81:1
+    Source: 'crates/nucleus-github-oidc/src/extracted/oidc_spiffe.rs', lines 50:0-89:1
     Visibility: public -/
 def extracted.oidc_spiffe.sanitize_bytes
   (input : Slice Std.U8) : Result (alloc.vec.Vec Std.U8) := do
@@ -266,7 +376,7 @@ def extracted.oidc_spiffe.sanitize_bytes
     Std.U8) lo
 
 /-- [nucleus_github_oidc::extracted::oidc_spiffe::append]: loop body 0:
-    Source: 'crates/nucleus-github-oidc/src/extracted/oidc_spiffe.rs', lines 88:4-91:5 -/
+    Source: 'crates/nucleus-github-oidc/src/extracted/oidc_spiffe.rs', lines 96:4-99:5 -/
 @[rust_loop_body]
 def extracted.oidc_spiffe.append_loop.body
   (src : Slice Std.U8) (n : Std.Usize) (dst : alloc.vec.Vec Std.U8)
@@ -283,7 +393,7 @@ def extracted.oidc_spiffe.append_loop.body
   else ok (done dst)
 
 /-- [nucleus_github_oidc::extracted::oidc_spiffe::append]: loop 0:
-    Source: 'crates/nucleus-github-oidc/src/extracted/oidc_spiffe.rs', lines 88:4-91:5 -/
+    Source: 'crates/nucleus-github-oidc/src/extracted/oidc_spiffe.rs', lines 96:4-99:5 -/
 @[rust_loop]
 def extracted.oidc_spiffe.append_loop
   (dst : alloc.vec.Vec Std.U8) (src : Slice Std.U8) (i : Std.Usize)
@@ -295,7 +405,7 @@ def extracted.oidc_spiffe.append_loop
     (dst, i)
 
 /-- [nucleus_github_oidc::extracted::oidc_spiffe::append]:
-    Source: 'crates/nucleus-github-oidc/src/extracted/oidc_spiffe.rs', lines 85:0-92:1 -/
+    Source: 'crates/nucleus-github-oidc/src/extracted/oidc_spiffe.rs', lines 93:0-100:1 -/
 def extracted.oidc_spiffe.append
   (dst : alloc.vec.Vec Std.U8) (src : Slice Std.U8) :
   Result (alloc.vec.Vec Std.U8)
@@ -304,7 +414,7 @@ def extracted.oidc_spiffe.append
   extracted.oidc_spiffe.append_loop dst src 0#usize n
 
 /-- [nucleus_github_oidc::extracted::oidc_spiffe::derive_spiffe_bytes]:
-    Source: 'crates/nucleus-github-oidc/src/extracted/oidc_spiffe.rs', lines 110:0-135:1
+    Source: 'crates/nucleus-github-oidc/src/extracted/oidc_spiffe.rs', lines 118:0-146:1
     Visibility: public -/
 def extracted.oidc_spiffe.derive_spiffe_bytes
   (trust_domain : Slice Std.U8) (owner_sanitized : Slice Std.U8)

--- a/crates/nucleus-github-oidc/lean/generated/NucleusGithubOidc/Types.lean
+++ b/crates/nucleus-github-oidc/lean/generated/NucleusGithubOidc/Types.lean
@@ -14,4 +14,15 @@ set_option maxRecDepth 2048
 
 namespace nucleus_github_oidc
 
+/-- [nucleus_github_oidc::extracted::jwt_svid_claims::ClaimsVerdict]
+    Source: 'crates/nucleus-github-oidc/src/extracted/jwt_svid_claims.rs', lines 80:0-91:1
+    Visibility: public -/
+@[discriminant isize]
+inductive extracted.jwt_svid_claims.ClaimsVerdict where
+| Admit : extracted.jwt_svid_claims.ClaimsVerdict
+| Expired : extracted.jwt_svid_claims.ClaimsVerdict
+| NotYetValid : extracted.jwt_svid_claims.ClaimsVerdict
+| AudienceMismatch : extracted.jwt_svid_claims.ClaimsVerdict
+| SubjectPrefixMismatch : extracted.jwt_svid_claims.ClaimsVerdict
+
 end nucleus_github_oidc

--- a/crates/nucleus-github-oidc/lean/lakefile.lean
+++ b/crates/nucleus-github-oidc/lean/lakefile.lean
@@ -30,3 +30,10 @@ lean_lib «NucleusGithubOidc» where
 -- The OIDC→SPIFFE derivation properties, proven OVER the generated defs above.
 lean_lib «OidcSpiffeProofs» where
   roots := #[`OidcSpiffeProofs]
+
+-- The JWT-SVID claims-decision properties (soundness / fail-closed /
+-- completeness / verdict attribution), proven OVER the generated
+-- `extracted.jwt_svid_claims.decide_claims` (#2452). Same generated lib, its
+-- own theorem file, so each slice's axiom audit stays separately readable.
+lean_lib «JwtSvidClaimsProofs» where
+  roots := #[`JwtSvidClaimsProofs]

--- a/crates/nucleus-github-oidc/src/extracted/jwt_svid_claims.rs
+++ b/crates/nucleus-github-oidc/src/extracted/jwt_svid_claims.rs
@@ -1,0 +1,317 @@
+//! Aeneas-extractable decision core of JWT-SVID claims validation.
+//!
+//! The control plane's `verify_jwt_svid`
+//! (`crates/nucleus-control-plane-server/src/auth.rs`) is two things glued
+//! together: an EdDSA signature check over the compact-JWS input, and a pure
+//! decision over the decoded claims (`exp`/`nbf` against the clock with skew
+//! leeway, `aud` membership, `sub` prefix). The signature half is
+//! `ed25519-dalek` and is outside Aeneas's extractable subset (#2452's
+//! toolchain check). The decision half is pure, and THIS module is its
+//! `String`/iterator-free restatement so the reachable subgraph stays inside
+//! the Charon/Aeneas safe-Rust subset:
+//!
+//! - subject, prefix and audience values are `&[u8]`; equality and prefix
+//!   are index-driven `while` loops ([`bytes_eq`], [`has_prefix`]);
+//! - the temporal + membership decision is a straight-line function
+//!   ([`decide_claims`]) whose check ORDER is the production order, so the
+//!   verdict a caller maps back to `AuthError` is the same one production
+//!   would have raised first.
+//!
+//! # The scope boundary (what stays in production, and why)
+//!
+//! The audience check is `auds.iter().any(|a| a == allowed)`. Its *fold* is
+//! not extracted: a slice of audiences is `&[&[u8]]`, a nested borrow, which
+//! Aeneas rejects outright ("unsupported nested borrows"), and the
+//! `Iterator::any` it would replace is exactly the fold Aeneas emits as an
+//! opaque external axiom. So production keeps the one-line fold and applies
+//! the extracted [`bytes_eq`] per element; the extracted [`decide_claims`]
+//! receives the fold's result as `aud_ok`. The theorems below are therefore
+//! about the decision given membership, not about the membership loop.
+//!
+//! # Where it is hosted, and why
+//!
+//! The control plane owns the function; this crate owns the only
+//! OIDC-family Aeneas pipeline (`.github/workflows/aeneas-oidc-spiffe.yml`,
+//! `lean/`). Hosting the core here reuses that pipeline unchanged rather than
+//! standing up a second one, and the control plane depends on this crate for
+//! the core alone. The generated Lean lands in
+//! `lean/generated/NucleusGithubOidc/` beside the SPIFFE derivation slice, and
+//! the theorems live in `lean/JwtSvidClaimsProofs.lean`.
+//!
+//! # Faithfulness (the honest trust chain)
+//!
+//! - **Call-through.** Production `verify_jwt_svid` CALLS [`decide_claims`]
+//!   (with [`has_prefix`] and per-element [`bytes_eq`]) for its claims
+//!   decision; it does not keep a parallel copy. The theorems are about the
+//!   live path, not a mirror of it.
+//! - **Parity oracle.** The `#[cfg(test)]` block below carries the pre-refactor
+//!   inline clause lifted verbatim as `production_claims_check`, and proptests
+//!   that the composed call ([`claims_verdict`], the exact expression
+//!   production evaluates) agrees with it on random claims, clocks, skews,
+//!   audience lists and subjects — the guard that the refactor changed
+//!   nothing.
+//! - **Overflow.** Production computes `exp + skew` and `now + skew` with
+//!   plain `+`. The core keeps the same expressions; the Aeneas translation
+//!   makes overflow an explicit `fail`, and the Lean theorems are stated
+//!   under the no-overflow hypothesis they surface. The parity generators
+//!   stay below `u64::MAX / 2` for the same reason.
+//!
+//! # What the Lean side proves (over the GENERATED defs, never a hand model)
+//!
+//! - **Soundness:** `decide_claims … = ok Admit` implies every predicate held:
+//!   `now ≤ exp + skew`, `nbf ≤ now + skew` when present, `aud_ok`, `sub_ok`.
+//!   No admission without all four.
+//! - **Fail-closed:** `aud_ok = false` or `sub_ok = false` never yields
+//!   `Admit`, whatever the clock says.
+//! - **Completeness:** when all four hold the verdict is `Admit`, so the core
+//!   cannot reject a valid token either.
+//! - **Verdict attribution:** `NotYetValid` is only ever raised with
+//!   `nbf = Some`, which is what lets the caller report the `nbf` it refused.
+//!
+//! The extraction roots live here so the CI extractor can name them with
+//! `charon … --start-from nucleus_github_oidc::extracted::jwt_svid_claims::<fn>`.
+
+/// Outcome of the pure claims decision, in production's check order.
+///
+/// The control plane maps each variant onto the `AuthError` it raised before
+/// the core existed (`Expired` / `NotYetValid` → 401, the two mismatches →
+/// 403). `Admit` is the only variant that admits.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClaimsVerdict {
+    /// Every claims predicate held.
+    Admit,
+    /// `exp + skew < now`.
+    Expired,
+    /// `nbf` present and `nbf > now + skew`.
+    NotYetValid,
+    /// No `aud` entry equals the configured audience.
+    AudienceMismatch,
+    /// `sub` does not start with the configured prefix.
+    SubjectPrefixMismatch,
+}
+
+/// Byte-slice equality as an index loop (`a == b` on `&[u8]`).
+pub fn bytes_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut i = 0usize;
+    while i < a.len() {
+        if a[i] != b[i] {
+            return false;
+        }
+        i += 1;
+    }
+    true
+}
+
+/// `s.starts_with(prefix)` on byte slices, as an index loop.
+pub fn has_prefix(s: &[u8], prefix: &[u8]) -> bool {
+    if prefix.len() > s.len() {
+        return false;
+    }
+    let mut i = 0usize;
+    while i < prefix.len() {
+        if s[i] != prefix[i] {
+            return false;
+        }
+        i += 1;
+    }
+    true
+}
+
+/// The straight-line claims decision, in production's check order:
+/// expiry, then not-before, then audience, then subject prefix.
+///
+/// `aud_ok` is the audience fold's result (production: `any(bytes_eq)`),
+/// `sub_ok` is [`has_prefix`]. Arithmetic is the production `exp + skew` /
+/// `now + skew`; overflow is a `fail` in the extraction and a panic-or-wrap
+/// in Rust exactly as it was before the refactor.
+pub fn decide_claims(
+    exp: u64,
+    nbf: Option<u64>,
+    now: u64,
+    skew: u64,
+    aud_ok: bool,
+    sub_ok: bool,
+) -> ClaimsVerdict {
+    if exp + skew < now {
+        return ClaimsVerdict::Expired;
+    }
+    let not_yet_valid = match nbf {
+        Some(n) => n > now + skew,
+        None => false,
+    };
+    if not_yet_valid {
+        return ClaimsVerdict::NotYetValid;
+    }
+    if !aud_ok {
+        return ClaimsVerdict::AudienceMismatch;
+    }
+    if !sub_ok {
+        return ClaimsVerdict::SubjectPrefixMismatch;
+    }
+    ClaimsVerdict::Admit
+}
+
+/// The exact composition production evaluates: the audience fold over
+/// [`bytes_eq`], [`has_prefix`] on the subject, then [`decide_claims`].
+///
+/// NOT an extraction root (the `&[&[u8]]` parameter is a nested borrow, see
+/// the module docs); it exists so the control plane and the parity oracle
+/// call one definition of the composition.
+#[allow(clippy::too_many_arguments)]
+pub fn claims_verdict(
+    exp: u64,
+    nbf: Option<u64>,
+    now: u64,
+    skew: u64,
+    auds: &[&[u8]],
+    want_aud: &[u8],
+    sub: &[u8],
+    prefix: &[u8],
+) -> ClaimsVerdict {
+    let aud_ok = auds.iter().any(|a| bytes_eq(a, want_aud));
+    let sub_ok = has_prefix(sub, prefix);
+    decide_claims(exp, nbf, now, skew, aud_ok, sub_ok)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    /// The pre-refactor claims clause of `verify_jwt_svid`
+    /// (`nucleus-control-plane-server/src/auth.rs`), lifted verbatim as the
+    /// parity oracle. Returns the verdict production would have mapped to an
+    /// `AuthError`, in production's order.
+    #[allow(clippy::too_many_arguments)]
+    fn production_claims_check(
+        exp: u64,
+        nbf: Option<u64>,
+        now: u64,
+        clock_skew_secs: u64,
+        auds: &[String],
+        allowed_audience: &str,
+        sub: &str,
+        allowed_subject_prefix: &str,
+    ) -> ClaimsVerdict {
+        if exp + clock_skew_secs < now {
+            return ClaimsVerdict::Expired;
+        }
+        if let Some(nbf) = nbf
+            && nbf > now + clock_skew_secs
+        {
+            return ClaimsVerdict::NotYetValid;
+        }
+        if !auds.iter().any(|a| a == allowed_audience) {
+            return ClaimsVerdict::AudienceMismatch;
+        }
+        if !sub.starts_with(allowed_subject_prefix) {
+            return ClaimsVerdict::SubjectPrefixMismatch;
+        }
+        ClaimsVerdict::Admit
+    }
+
+    #[test]
+    fn loops_agree_with_std_on_edge_cases() {
+        assert!(bytes_eq(b"", b""));
+        assert!(!bytes_eq(b"a", b""));
+        assert!(!bytes_eq(b"ab", b"ac"));
+        assert!(has_prefix(b"spiffe://td/x", b"spiffe://td/"));
+        assert!(has_prefix(b"x", b""));
+        assert!(!has_prefix(b"", b"x"));
+    }
+
+    #[test]
+    fn verdict_order_is_production_order() {
+        // Every predicate false at once: expiry wins, then nbf, then aud, then sub.
+        assert_eq!(
+            decide_claims(0, Some(u64::MAX / 4), 100, 0, false, false),
+            ClaimsVerdict::Expired
+        );
+        assert_eq!(
+            decide_claims(200, Some(u64::MAX / 4), 100, 0, false, false),
+            ClaimsVerdict::NotYetValid
+        );
+        assert_eq!(
+            decide_claims(200, Some(50), 100, 0, false, false),
+            ClaimsVerdict::AudienceMismatch
+        );
+        assert_eq!(
+            decide_claims(200, Some(50), 100, 0, true, false),
+            ClaimsVerdict::SubjectPrefixMismatch
+        );
+        assert_eq!(
+            decide_claims(200, None, 100, 0, true, true),
+            ClaimsVerdict::Admit
+        );
+        // Skew leeway on both edges, exactly as production applies it.
+        assert_eq!(
+            decide_claims(90, None, 100, 10, true, true),
+            ClaimsVerdict::Admit
+        );
+        assert_eq!(
+            decide_claims(89, None, 100, 10, true, true),
+            ClaimsVerdict::Expired
+        );
+        assert_eq!(
+            decide_claims(200, Some(110), 100, 10, true, true),
+            ClaimsVerdict::Admit
+        );
+        assert_eq!(
+            decide_claims(200, Some(111), 100, 10, true, true),
+            ClaimsVerdict::NotYetValid
+        );
+    }
+
+    proptest! {
+        /// PARITY: the byte loops agree with `==` / `starts_with` on random
+        /// strings, including arbitrary Unicode.
+        #[test]
+        fn loops_match_std(a in r"\PC{0,16}", b in r"\PC{0,16}") {
+            prop_assert_eq!(bytes_eq(a.as_bytes(), b.as_bytes()), a == b);
+            prop_assert_eq!(has_prefix(a.as_bytes(), b.as_bytes()), a.starts_with(&b));
+        }
+
+        /// PARITY: the composed decision equals the pre-refactor production
+        /// clause across random claims, clocks and skews. Values stay below
+        /// `u64::MAX / 2` so `exp + skew` / `now + skew` cannot overflow
+        /// (production would panic or wrap there; see module docs).
+        #[test]
+        fn claims_verdict_matches_production(
+            exp in 0u64..(u64::MAX / 2),
+            nbf in prop::option::of(0u64..(u64::MAX / 2)),
+            now in 0u64..(u64::MAX / 2),
+            skew in 0u64..4096u64,
+            auds in prop::collection::vec("[a-z:/.]{0,12}", 0..4),
+            want in "[a-z:/.]{0,12}",
+            sub in "[a-z:/.]{0,16}",
+            prefix in "[a-z:/.]{0,8}",
+        ) {
+            let refs: Vec<&[u8]> = auds.iter().map(|s| s.as_bytes()).collect();
+            let extracted = claims_verdict(exp, nbf, now, skew, &refs, want.as_bytes(), sub.as_bytes(), prefix.as_bytes());
+            let production = production_claims_check(exp, nbf, now, skew, &auds, &want, &sub, &prefix);
+            prop_assert_eq!(extracted, production);
+        }
+
+        /// PARITY, dense: the same with clocks clustered around `exp`/`nbf`
+        /// so the skew edges are actually exercised.
+        #[test]
+        fn claims_verdict_matches_production_near_edges(
+            exp in 1_000u64..2_000u64,
+            nbf in prop::option::of(1_000u64..2_000u64),
+            now in 900u64..2_100u64,
+            skew in 0u64..128u64,
+            aud_ok in any::<bool>(),
+            sub_ok in any::<bool>(),
+        ) {
+            let auds: Vec<String> = if aud_ok { vec!["x".into(), "aud".into()] } else { vec!["x".into()] };
+            let sub = if sub_ok { "spiffe://td/ok" } else { "spiffe://other/ok" };
+            let refs: Vec<&[u8]> = auds.iter().map(|s| s.as_bytes()).collect();
+            let extracted = claims_verdict(exp, nbf, now, skew, &refs, b"aud", sub.as_bytes(), b"spiffe://td/");
+            let production = production_claims_check(exp, nbf, now, skew, &auds, "aud", sub, "spiffe://td/");
+            prop_assert_eq!(extracted, production);
+        }
+    }
+}

--- a/crates/nucleus-github-oidc/src/extracted/mod.rs
+++ b/crates/nucleus-github-oidc/src/extracted/mod.rs
@@ -65,5 +65,10 @@
 //!
 //! The extraction roots live here so the CI extractor can name them with
 //! `charon … --start-from nucleus_github_oidc::extracted::oidc_spiffe::<fn>`.
+//!
+//! [`jwt_svid_claims`] is the second slice through the same pipeline: the pure
+//! claims decision (`exp`/`nbf`/`aud`/`sub`) behind the control plane's
+//! `verify_jwt_svid`, which calls it on the live path (#2452).
 
+pub mod jwt_svid_claims;
 pub mod oidc_spiffe;

--- a/docs/design/identity-verifier-extraction.md
+++ b/docs/design/identity-verifier-extraction.md
@@ -1,0 +1,136 @@
+# Aeneas extraction of the identity/card verifiers (#2452)
+
+*Design note, 2026-09-04. Status: JWT-SVID claims decision landed; the other two
+are scoped here and tracked as follow-ups.*
+
+Three "verified" constructors share the shape of `verify_certificate`: a real
+cryptographic check, then a pure decision, with only Rust module privacy
+between "verified" and "fabricated". The decision (#2452, owner) was to extend
+the existing Aeneas→Lean pipeline to them rather than invent a second proof
+approach, and, per the toolchain check recorded on the issue, to extract the
+**pure decision core** of each with parity tests binding it to production,
+because the pinned Charon 0.1.223 / Aeneas d71d2e3 still emit `Iter::fold` as an
+opaque axiom and the signature primitives (`ed25519-dalek`, `ring`, `sha2`) are
+outside the extractable subset.
+
+This note names, for each verifier, the extraction-safe subset boundary and the
+theorem to prove. It is the first acceptance criterion of #2452; the second
+(one of the three landed as a real extracted, CI-rebuilt, axiom-audited theorem)
+is met by §1.
+
+## The shared recipe
+
+1. **Carve the pure core** into a `String`/iterator/closure-free module under an
+   `extracted/` directory of a crate that already has a pipeline
+   (`nucleus-github-oidc` for the OIDC family, `portcullis-core` for the
+   lattice family). Slices of bytes and integer index loops are fine;
+   **slices of slices are not** (`&[&[u8]]` is a nested borrow, which Aeneas
+   rejects outright) and neither is any `Iterator` adapter.
+2. **Call through**, do not mirror: production calls the extracted core on the
+   live path. A parity proptest keeps the pre-refactor clause, lifted verbatim,
+   as the oracle, so the refactor is checked to have changed nothing.
+3. **State theorems over the generated defs**, never a hand model. Straight-line
+   cores get closed theorems; index loops come out as the Aeneas `loop`
+   combinator (`partial_fixpoint`), which does not reduce under `simp`, so loops
+   are covered by the Rust parity tests and the gap is disclosed, not `sorry`d.
+4. **Gate it**: the workflow re-extracts on every change, builds the theorem
+   against the fresh extraction, requires positive `#print axioms` evidence,
+   and fails on `sorryAx` or any opaque external axiom.
+
+## 1. `verify_jwt_svid` (control plane) — LANDED
+
+**Function.** `nucleus_control_plane_server::auth::verify_jwt_svid`: EdDSA
+signature over the compact-JWS input, then the claims decision.
+
+**Boundary.** Signature verification stays in production. The claims decision
+is extracted as `nucleus_github_oidc::extracted::jwt_svid_claims`:
+`decide_claims(exp, nbf, now, skew, aud_ok, sub_ok)` (straight-line, in
+production's check order), `has_prefix` (subject prefix) and `bytes_eq`
+(per-audience equality). The audience **fold** stays in production because its
+input is `&[&[u8]]`; it applies the extracted `bytes_eq` per element and
+passes the result in as `aud_ok`.
+
+**Theorems** (`crates/nucleus-github-oidc/lean/JwtSvidClaimsProofs.lean`, over
+the generated `decide_claims`):
+
+- `admit_sound`: `Admit` implies the audience matched, the prefix matched,
+  `exp + skew` is representable and not below `now`, and if `nbf` is present
+  then `now + skew` is representable and `nbf` is not above it.
+- `aud_mismatch_fails_closed`, `sub_mismatch_fails_closed`: a failed
+  membership or prefix check never admits.
+- `admit_complete`: all four predicates holding gives `Admit`.
+- `not_yet_valid_has_nbf`: `NotYetValid` is only raised with `nbf = some _`.
+- `expired_first`, `not_yet_valid_second`, `audience_third`, `subject_last`:
+  the first failing predicate, in production's order, is the verdict.
+
+**Not claimed.** The signature check; the audience fold; the byte loops as
+closed Lean theorems (parity proptests cover them).
+
+## 2. `verify_card` / `verify_card_json` (agent card) — scoped, follow-up
+
+**Function.** `nucleus_agent_card::verify::verify_card`: JCS canonicalisation
+of the received document minus `signatures`, detached-JWS ES256 verification of
+*any* signature entry that carries a `kid`, then `apply_nucleus_policy`.
+
+**Boundary.** Canonicalisation (`serde_json` + JCS) and ES256 are outside the
+subset. The pure core to extract is the **acceptance combinator**
+`verify_any_signature`'s decision: given the per-entry outcomes as a slice of
+outcome codes (`u8`: verified / missing-kid / bad-signature / key-mismatch),
+return accept iff the slice is non-empty and some entry verified. The
+per-entry check stays in production. A second, separate core is the nucleus
+claims policy in `apply_nucleus_policy` once it is restated over plain
+booleans/enums (extension present, claims parse, required fields present).
+
+**Theorems.** (a) Fail-closed on emptiness: an empty outcome slice never
+accepts. (b) Soundness: accept implies some entry's outcome is `verified`.
+(c) Single-witness sufficiency: one verified entry accepts regardless of
+other failures (this is the co-signing/rotation property the module docs
+promise). (d) For the policy core: a `VerifiedCard` is constructible only when
+every required claim predicate holds.
+
+**Caveat to surface.** The combinator's decision is over a slice, so it is a
+loop; expect the closed theorems to need the per-step form (as
+`collapse_lossy_step` does for the sanitiser) unless the combinator is restated
+as a fold over a fixed small bound.
+
+## 3. `SvidAttestationBackend::verify_svid` (identity assurance) — scoped, follow-up
+
+**Function.** `SelfMeasuredBackend::verify_svid` (and the TPM DevID backend):
+parse the served SVID chain, extract the launch-attestation extension, check it
+against `AttestationRequirements`, then build a `VerifiedAttestation` carrying
+the backend's declared assurance level, its `proves`/`not_proven` claim
+profile, and the subject key binding.
+
+**Boundary.** PEM/X.509 parsing and extension extraction are outside the
+subset. Two pure cores:
+
+- `AttestationRequirements::verify`: three allow-list membership checks
+  (kernel, rootfs, config hash). Restated over fixed-width byte arrays and
+  index loops, with the allow-lists as flat `&[u8]` plus a stride, since
+  `&[[u8; 32]]` is fine but `&[&[u8]]` is not.
+- The claim-profile normalisation: the result's assurance level equals the
+  backend's declared level, and the `not_proven` set is exactly the profile's
+  complement; nothing is upgraded by the verifier.
+
+**Theorems.** (a) Fail-closed: `require_attestation = true` with no extension
+never yields an attestation (production returns an error; the extracted
+decision returns a refuse code). (b) Requirements soundness: accept implies
+each non-empty allow-list contains the corresponding measured hash. (c)
+Level ceiling: the produced assurance level is never above the backend's
+declared level, and `proves ∩ not_proven = ∅`.
+
+**Finding to record while scoping.** `AttestationRequirements::verify` treats
+an **empty** allow-list as "do not check", so a deployment that sets no
+`allowed_kernel_hashes` accepts any kernel hash. That is the intended
+"unconfigured" semantics, but it is the same empty-means-everything shape that
+was a bug in `PathLattice` (#2474). The extracted theorem (b) makes the
+semantics explicit; whether the default should be fail-closed is an owner call
+and is not changed here.
+
+## Order of work
+
+§1 is done. §2's acceptance combinator is the smaller core and should go next;
+§3's requirements check is mechanical but needs the flat-allow-list restating
+before Charon will accept it. Each lands as its own PR with its own theorem
+file and axiom audit, following the `aeneas-oidc-spiffe.yml` freshness
+pattern.

--- a/docs/verified-claims.md
+++ b/docs/verified-claims.md
@@ -398,3 +398,55 @@ enforcement of IFC constraints.
 | Discharge sealing | Rust types | 1 compile-fail test | No forging of `DischargedBundle` |
 | Type-level IFC | Rust types | 1 compile-fail test | No `Adversarial` -> `Trusted` flow |
 | Confidentiality downflow | Unit tests | 21 tests | No `Secret` -> `Public` flow |
+
+### 10. JWT-SVID claims decision: no admission without every predicate
+
+**Plain English:** When the control plane authenticates a caller's JWT-SVID,
+it checks the signature and then decides on the claims: not expired (with
+clock-skew leeway), not before its `nbf`, the right audience, a subject under
+the allowed SPIFFE prefix. We machine-check that decision: an `Admit` verdict
+can only come out when all four predicates held, a failed audience or subject
+check never admits, a valid token is never refused by the decision, and the
+error reported is the first failing predicate in the documented order.
+
+**Formal statement (proven, sorry-free, over the Aeneas-extracted
+`decide_claims`):**
+- `admit_sound` — `decide_claims … = ok Admit` implies `aud_ok`, `sub_ok`,
+  `exp + skew` representable and `¬ (exp + skew < now)`, and for `nbf = some n`,
+  `now + skew` representable and `¬ (n > now + skew)`.
+- `aud_mismatch_fails_closed` / `sub_mismatch_fails_closed` — with `aud_ok =
+  false` or `sub_ok = false` the verdict is never `Admit`.
+- `admit_complete` — all predicates holding gives `Admit`.
+- `not_yet_valid_has_nbf` — `NotYetValid` is only raised with `nbf = some _`.
+- `expired_first` / `not_yet_valid_second` / `audience_third` / `subject_last`
+  — the first failing predicate, in production's order, is the verdict.
+
+**Trust chain:** production `verify_jwt_svid` (`nucleus-control-plane-server`
+`auth.rs`) CALLS the extracted core on the live path (`decide_claims`, with
+`has_prefix` on the subject and `bytes_eq` per audience element); the parity
+proptests in `extracted/jwt_svid_claims.rs` check the composed call against the
+pre-refactor clause lifted verbatim → Lean via Aeneas.
+
+**Proved in:**
+- Lean 4: [`lean/JwtSvidClaimsProofs.lean`](../crates/nucleus-github-oidc/lean/JwtSvidClaimsProofs.lean) — the nine theorems above (each `#print axioms` ⊆ `[propext, Classical.choice, Quot.sound]`)
+- Rust parity proptests: [`src/extracted/jwt_svid_claims.rs`](../crates/nucleus-github-oidc/src/extracted/jwt_svid_claims.rs) — `claims_verdict_matches_production`, `claims_verdict_matches_production_near_edges`, `loops_match_std`
+
+**CI gate:** the same `Scoped Aeneas (Rust → Lean 4) + parity tests` job as
+§9 (`aeneas-oidc-spiffe.yml`): re-extracts both slices from Rust, builds the
+theorems against the fresh extraction, requires `#print axioms` evidence, fails
+on `sorryAx` / opaque external axioms.
+
+**What it does NOT prove:**
+- NOT the EdDSA signature check (`ed25519-dalek`, outside the extractable
+  subset).
+- NOT the audience fold: `auds.iter().any(..)` takes `&[&[u8]]`, a nested
+  borrow Aeneas rejects; the fold stays in production and its result enters
+  the theorems as `aud_ok`.
+- NOT `bytes_eq` / `has_prefix` as closed Lean theorems (Aeneas `loop`
+  combinator, the §9 gap); the Rust parity proptests cover them.
+- Overflow: the generated `+` is checked, so the theorems carry
+  representability as a conclusion of soundness and a hypothesis of
+  completeness rather than assuming it.
+
+Design note for the other two verifiers in #2452 (`verify_card`, attestation
+backends): [`docs/design/identity-verifier-extraction.md`](design/identity-verifier-extraction.md).


### PR DESCRIPTION
Closes the second acceptance criterion of #2452 (one verifier landed as a real Aeneas-extracted, CI-rebuilt, axiom-audited theorem) and delivers the first (a design note naming the boundary and theorem for all three).

## What changed
**Extracted core** — `nucleus_github_oidc::extracted::jwt_svid_claims` (new): `decide_claims(exp, nbf, now, skew, aud_ok, sub_ok)` in production's check order, plus `has_prefix` and `bytes_eq` as index loops. Hosted in this crate because it owns the only OIDC-family Aeneas pipeline; the control plane depends on it for the core alone (default features, no reqwest).

**Call-through, not a mirror** — `nucleus-control-plane-server::auth::verify_jwt_svid` now calls the core for its claims decision after the EdDSA check. The audience fold stays in production: `&[&[u8]]` is a nested borrow, which Aeneas rejects outright (tried; "unsupported nested borrows"), and the fold is the `Iter::fold` opaque axiom anyway. It applies the extracted `bytes_eq` per element and passes the result in as `aud_ok`.

**Lean** — `lean/JwtSvidClaimsProofs.lean`, over the generated `decide_claims`:
- `admit_sound`: `Admit` ⟹ audience matched ∧ prefix matched ∧ `exp + skew` representable and `¬ < now` ∧ (`nbf = some n` ⟹ `now + skew` representable and `¬ n >` it)
- `aud_mismatch_fails_closed`, `sub_mismatch_fails_closed`
- `admit_complete` (all predicates ⟹ `Admit`)
- `not_yet_valid_has_nbf` (licenses the caller's `unwrap_or`)
- `expired_first`, `not_yet_valid_second`, `audience_third`, `subject_last` (verdict order)

Built locally against the pinned toolchain (charon 0.1.223 / aeneas d71d2e3 / Lean v4.30.0-rc2 + Mathlib): `Build completed successfully`; every `#print axioms` ⊆ `[propext, Classical.choice, Quot.sound]`; CI's sorry-ban regex clean. `generated/` is the fresh extraction (the SPIFFE slice's defs are unchanged; only source-line annotations moved).

**Gate** — `aeneas-oidc-spiffe.yml` gains the three roots, the proof file in `paths:`/scope pattern, the lake target, and the sorry-ban entry; the existing axiom audit covers the new `#print axioms` lines.

**Parity** — the pre-refactor clause is lifted verbatim as `production_claims_check` and the composed call is proptested against it (broad and edge-dense generators); byte loops vs `==`/`starts_with` over random Unicode. Control-plane `auth` tests (17) unchanged and green; both crates' full suites green; clippy `--all-targets --all-features -D warnings` clean.

## Design note (acceptance criterion 1)
`docs/design/identity-verifier-extraction.md`: the shared recipe, then per verifier the extraction-safe boundary and the theorem to prove — `verify_card` (the `verify_any_signature` acceptance combinator over per-entry outcome codes, plus the claims-policy core) and the attestation backends (`AttestationRequirements::verify` over flat allow-lists, and the claim-profile/level ceiling). Records a finding to surface: `AttestationRequirements::verify` treats an **empty** allow-list as "do not check", the same empty-means-everything shape that was a bug in `PathLattice` (#2474); intended here, but an owner call whether it should fail closed. `docs/verified-claims.md` gains §10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZaH5waz88vL1qfNpFNfZ4
