### PR TITLE
security(tool-proxy): peer-verified Unix-socket transport, the container driver's host-verified channel (#2446 step 1)

### DIFF
--- a/crates/nucleus-tool-proxy/src/auth.rs
+++ b/crates/nucleus-tool-proxy/src/auth.rs
@@ -111,12 +111,15 @@ pub enum AuthMethod {
     HmacDrand,
     /// SPIFFE mTLS certificate (no shared secrets).
     SpiffeMtls,
-    /// The request arrived on a vsock listener that accepts only the host.
+    /// The request arrived on a host-verified transport: a vsock listener that
+    /// accepts only the host, or (#2446) a Unix socket whose peers the kernel
+    /// identifies and `host_socket::PeerPolicy` admits.
     ///
     /// No shared secret and no certificate: the guest kernel sets the peer CID
-    /// on an accepted AF_VSOCK connection and a guest process cannot forge it,
-    /// so "this came from the host" is enforced below the application rather
-    /// than asserted by it. See `pod_mgmt::peer_is_host`.
+    /// on an accepted AF_VSOCK connection (or the peer credentials on an
+    /// AF_UNIX one) and a guest process cannot forge them, so "this came from
+    /// an admitted peer" is enforced below the application rather than
+    /// asserted by it. See `pod_mgmt::peer_is_host` and `host_socket`.
     HostVsock,
     /// Ed25519 signature against a configured PUBLIC key, drand-anchored.
     ///

--- a/crates/nucleus-tool-proxy/src/host_socket.rs
+++ b/crates/nucleus-tool-proxy/src/host_socket.rs
@@ -1,0 +1,391 @@
+//! Host-verified Unix-socket transport: the container driver's replacement for
+//! the shared-secret tier (#2446, step 1).
+//!
+//! # The problem this solves
+//!
+//! A Firecracker pod's proxy serves over vsock, and the guest kernel stamps
+//! every accepted connection with the peer CID — "this came from the host" is
+//! a kernel fact, so the HMAC tier is unreachable there
+//! (`pod_mgmt::peer_is_host`). A container pod has no vsock: its proxy sidecar
+//! listens on loopback TCP and the only thing separating the host's requests
+//! from the agent's is `NUCLEUS_TOOL_PROXY_AUTH_SECRET`, a key delivered in the
+//! container's environment, which every process in the container can read.
+//! That is the bare shared-secret tier the owner decided to deprecate.
+//!
+//! # What replaces it
+//!
+//! A Unix domain socket whose peers are identified by the kernel
+//! (`SO_PEERCRED` / `LOCAL_PEERCRED`), never by a secret:
+//!
+//! - the socket lives in a directory the node bind-mounts into exactly one
+//!   container, so possession of the path is already scoped to that pod and
+//!   the host;
+//! - every accepted connection's peer credentials are read from the kernel and
+//!   checked by [`PeerPolicy::admits`] BEFORE the stream reaches the router.
+//!   An untrusted peer is dropped at accept, so the request layer never sees
+//!   it and `AppState::host_verified_transport` is a sound description of
+//!   every request it does see;
+//! - on Linux a peer outside the proxy's pid namespace reports `pid == 0`
+//!   (the kernel translates the peer's pid into the receiver's namespace and
+//!   yields 0 when it is not visible there). Through a socket mounted only
+//!   into this container, "not in my pid namespace" is "the host": that is the
+//!   analogue of the vsock host CID. A peer INSIDE the namespace is admitted
+//!   only when its uid is the proxy's own or one the operator listed
+//!   (`--peer-uids`), which is the same-container loopback trust the HMAC tier
+//!   stood in for, now enforced below the application instead of by a key the
+//!   agent can read.
+//!
+//! # What this does and does not claim
+//!
+//! - It binds the TRANSPORT to a kernel-verified peer. It does not bind an
+//!   identity a delegation certificate can act for: like `HostVsock`, this
+//!   tier has `DelegationAuthority::Unbound` (`pod_cert::delegation_authority`)
+//!   and a certificate presented on it is refused.
+//! - Off Linux, `pid` is a real pid (or absent), so the "outside my namespace"
+//!   host rule never fires and only the uid rule admits; the container driver
+//!   runs on Linux, and the tests pin both rules.
+//! - `--listen-unix` and a vsock binding are mutually exclusive: one
+//!   host-verified transport per proxy, so the audit record's `AuthMethod`
+//!   names the transport that actually carried the request.
+
+use std::path::{Path, PathBuf};
+
+use axum::Router;
+use tokio::net::{UnixListener, UnixStream};
+use tracing::{info, warn};
+
+use crate::ApiError;
+use crate::pod_mgmt::{self, BoundVsock, VsockConfig};
+use crate::startup_trace::Startup;
+use crate::workload::BoundProxy;
+
+/// Where to bind and whom to admit; resolved from the CLI before the state is
+/// built, like `pod_mgmt::resolve_vsock`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct UnixConfig {
+    pub(crate) path: PathBuf,
+    pub(crate) peer_uids: Vec<u32>,
+}
+
+/// Resolve the Unix-socket binding from the CLI. `None` when not configured.
+///
+/// Refuses the combination with a vsock binding: two host-verified transports
+/// on one proxy would make `AuthMethod` ambiguous in the audit record.
+pub(crate) fn resolve_unix(
+    listen_unix: Option<&Path>,
+    peer_uids: &[u32],
+    vsock: Option<&VsockConfig>,
+) -> Result<Option<UnixConfig>, ApiError> {
+    let Some(path) = listen_unix else {
+        if !peer_uids.is_empty() {
+            return Err(ApiError::Spec(
+                "--peer-uids requires --listen-unix".to_string(),
+            ));
+        }
+        return Ok(None);
+    };
+    if vsock.is_some() {
+        return Err(ApiError::Spec(
+            "--listen-unix and a vsock binding are mutually exclusive: one host-verified transport per proxy"
+                .to_string(),
+        ));
+    }
+    if !path.is_absolute() {
+        return Err(ApiError::Spec(format!(
+            "--listen-unix must be an absolute path, got {}",
+            path.display()
+        )));
+    }
+    Ok(Some(UnixConfig {
+        path: path.to_path_buf(),
+        peer_uids: peer_uids.to_vec(),
+    }))
+}
+
+/// The admission rule for a peer, over facts the kernel reports.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PeerPolicy {
+    /// The proxy's own effective uid: a same-container peer running as the
+    /// proxy itself (the usual sidecar layout) is admitted.
+    own_uid: u32,
+    /// Operator-listed additional uids (e.g. an agent running as a dedicated
+    /// unprivileged user in the same container).
+    peer_uids: Vec<u32>,
+}
+
+impl PeerPolicy {
+    pub(crate) fn new(own_uid: u32, peer_uids: Vec<u32>) -> Self {
+        Self { own_uid, peer_uids }
+    }
+
+    /// Is a peer with these kernel-reported credentials admitted?
+    ///
+    /// - `pid == Some(0)`: the peer is outside this pid namespace. Through a
+    ///   socket mounted only into this container that is the host — the
+    ///   container analogue of `peer_is_host` on vsock.
+    /// - otherwise the peer is inside the namespace and is admitted only by
+    ///   uid: the proxy's own, or an operator-listed one.
+    ///
+    /// `pid == None` (a platform that does not report it) falls through to the
+    /// uid rule, never to the host rule.
+    pub(crate) fn admits(&self, uid: u32, pid: Option<i32>) -> bool {
+        if pid == Some(0) {
+            return true;
+        }
+        uid == self.own_uid || self.peer_uids.contains(&uid)
+    }
+}
+
+/// A bound, listening Unix socket with its admission policy.
+pub(crate) struct BoundUnix {
+    listener: UnixListener,
+    path: PathBuf,
+    policy: PeerPolicy,
+}
+
+/// Bind the socket (replacing a stale file from a previous run), write the
+/// announce file if asked, and attach the admission policy.
+pub(crate) async fn bind_unix(
+    cfg: UnixConfig,
+    announce_path: Option<PathBuf>,
+) -> Result<BoundUnix, ApiError> {
+    if let Some(parent) = cfg.path.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+    match tokio::fs::remove_file(&cfg.path).await {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => return Err(e.into()),
+    }
+    let listener = UnixListener::bind(&cfg.path)?;
+    if let Some(path) = announce_path {
+        tokio::fs::write(path, unix_url(&cfg.path)).await?;
+    }
+    let policy = PeerPolicy::new(current_uid(), cfg.peer_uids);
+    Ok(BoundUnix {
+        listener,
+        path: cfg.path,
+        policy,
+    })
+}
+
+/// The URL form the workload and the announce file carry for a Unix socket.
+pub(crate) fn unix_url(path: &Path) -> String {
+    format!("unix://{}", path.display())
+}
+
+fn current_uid() -> u32 {
+    // SAFETY: `geteuid` has no preconditions and cannot fail.
+    unsafe { libc::geteuid() }
+}
+
+/// The axum listener that enforces [`PeerPolicy`] at accept time.
+struct PeerVerifiedUnixListener {
+    inner: UnixListener,
+    policy: PeerPolicy,
+}
+
+impl axum::serve::Listener for PeerVerifiedUnixListener {
+    type Io = UnixStream;
+    type Addr = tokio::net::unix::SocketAddr;
+
+    async fn accept(&mut self) -> (Self::Io, Self::Addr) {
+        loop {
+            match self.inner.accept().await {
+                Ok((stream, addr)) => {
+                    // FAIL CLOSED ON PEER IDENTITY, before the router sees the
+                    // stream. The facts come from the kernel; if it cannot
+                    // report them the peer is not admitted.
+                    let cred = match stream.peer_cred() {
+                        Ok(c) => c,
+                        Err(err) => {
+                            warn!(
+                                "rejecting unix-socket connection: peer credentials unavailable: {err}"
+                            );
+                            drop(stream);
+                            continue;
+                        }
+                    };
+                    if !self.policy.admits(cred.uid(), cred.pid()) {
+                        warn!(
+                            peer_uid = cred.uid(),
+                            peer_pid = ?cred.pid(),
+                            "rejecting unix-socket connection from an unadmitted peer"
+                        );
+                        drop(stream);
+                        continue;
+                    }
+                    return (stream, addr);
+                }
+                Err(err) => {
+                    tracing::error!("unix-socket accept error: {err}");
+                }
+            }
+        }
+    }
+
+    fn local_addr(&self) -> std::io::Result<Self::Addr> {
+        self.inner.local_addr()
+    }
+}
+
+/// Serve the router over the bound socket until the listener errors out.
+pub(crate) async fn serve_unix(app: Router, bound: BoundUnix) -> Result<(), ApiError> {
+    info!(
+        "nucleus-tool-proxy listening on unix socket {} (peer-credential admission)",
+        bound.path.display()
+    );
+    let listener = PeerVerifiedUnixListener {
+        inner: bound.listener,
+        policy: bound.policy,
+    };
+    axum::serve(listener, app).await?;
+    Ok(())
+}
+
+/// The one host-verified transport a proxy may serve on: vsock in a microVM,
+/// a peer-verified Unix socket in a container. `main` binds whichever is
+/// configured and serves it the same way; the HMAC tier is unreachable on both
+/// (`auth::select_auth_tier`).
+pub(crate) enum HostBound {
+    Vsock(BoundVsock),
+    Unix(BoundUnix),
+}
+
+impl HostBound {
+    /// What the workload's `NUCLEUS_TOOL_PROXY_URL` should name.
+    pub(crate) fn proxy(&self) -> BoundProxy {
+        match self {
+            Self::Vsock(b) => BoundProxy::Vsock {
+                cid: b.cid(),
+                port: b.port(),
+            },
+            Self::Unix(b) => BoundProxy::Unix(b.path.clone()),
+        }
+    }
+
+    pub(crate) async fn serve(self, app: Router) -> Result<(), ApiError> {
+        match self {
+            Self::Vsock(b) => pod_mgmt::serve_vsock(app, b).await,
+            Self::Unix(b) => serve_unix(app, b).await,
+        }
+    }
+}
+
+/// Bind the configured host-verified transport, if any, recording the bind in
+/// the startup trace under the transport's own mark.
+pub(crate) async fn bind_host_verified(
+    vsock: Option<VsockConfig>,
+    unix: Option<UnixConfig>,
+    announce_path: Option<PathBuf>,
+    st: &mut Startup,
+) -> Result<Option<HostBound>, ApiError> {
+    if let Some(v) = vsock {
+        let bound = st
+            .timed("vsock_bind", pod_mgmt::bind_vsock(v, announce_path))
+            .await?;
+        return Ok(Some(HostBound::Vsock(bound)));
+    }
+    if let Some(u) = unix {
+        let bound = st.timed("unix_bind", bind_unix(u, announce_path)).await?;
+        return Ok(Some(HostBound::Unix(bound)));
+    }
+    Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    #[test]
+    fn the_host_rule_is_pid_zero_only() {
+        let p = PeerPolicy::new(1000, vec![]);
+        assert!(p.admits(0, Some(0)), "outside-namespace peer is the host");
+        assert!(p.admits(65534, Some(0)), "even an unmapped uid, if outside");
+        assert!(!p.admits(0, Some(1)), "in-namespace root is NOT the host");
+        assert!(!p.admits(0, None), "no pid never means host");
+    }
+
+    #[test]
+    fn the_uid_rule_admits_self_and_listed_only() {
+        let p = PeerPolicy::new(1000, vec![2000]);
+        assert!(p.admits(1000, Some(42)));
+        assert!(p.admits(2000, Some(42)));
+        assert!(p.admits(1000, None));
+        assert!(!p.admits(3000, Some(42)));
+        assert!(!p.admits(0, Some(42)));
+    }
+
+    #[test]
+    fn resolve_refuses_ambiguous_and_relative_configs() {
+        let v = VsockConfig { cid: 3, port: 5000 };
+        let err = resolve_unix(Some(Path::new("/run/x.sock")), &[], Some(&v)).unwrap_err();
+        assert!(err.to_string().contains("mutually exclusive"), "{err}");
+        let err = resolve_unix(Some(Path::new("rel.sock")), &[], None).unwrap_err();
+        assert!(err.to_string().contains("absolute"), "{err}");
+        let err = resolve_unix(None, &[7], None).unwrap_err();
+        assert!(err.to_string().contains("requires --listen-unix"), "{err}");
+        assert_eq!(resolve_unix(None, &[], None).unwrap(), None);
+        let ok = resolve_unix(Some(Path::new("/run/x.sock")), &[7, 8], None)
+            .unwrap()
+            .unwrap();
+        assert_eq!(ok.peer_uids, vec![7, 8]);
+    }
+
+    #[test]
+    fn unix_url_names_the_path() {
+        assert_eq!(
+            unix_url(Path::new("/run/nucleus/proxy.sock")),
+            "unix:///run/nucleus/proxy.sock"
+        );
+    }
+
+    /// The admission is enforced at accept: a connection from an unadmitted
+    /// peer is closed before any byte is answered, an admitted one is served.
+    /// Both directions are exercised against a real bound socket, in-process
+    /// (so the peer uid is our own and the pid is a real in-namespace pid).
+    #[tokio::test]
+    async fn accept_drops_unadmitted_peers_and_serves_admitted_ones() {
+        async fn bind_with(policy: PeerPolicy) -> (PathBuf, tokio::task::JoinHandle<()>) {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("p.sock");
+            let listener = UnixListener::bind(&path).unwrap();
+            let app = Router::new().route("/ping", axum::routing::get(|| async { "pong" }));
+            let l = PeerVerifiedUnixListener {
+                inner: listener,
+                policy,
+            };
+            let h = tokio::spawn(async move {
+                let _keep = dir;
+                let _ = axum::serve(l, app).await;
+            });
+            (path, h)
+        }
+
+        async fn get_ping(path: &Path) -> std::io::Result<String> {
+            let mut s = UnixStream::connect(path).await?;
+            s.write_all(b"GET /ping HTTP/1.0\r\nHost: x\r\n\r\n")
+                .await?;
+            let mut buf = String::new();
+            s.read_to_string(&mut buf).await?;
+            Ok(buf)
+        }
+
+        // Admitted: our own uid.
+        let (path, h) = bind_with(PeerPolicy::new(current_uid(), vec![])).await;
+        let reply = get_ping(&path).await.unwrap();
+        assert!(reply.contains("200") && reply.ends_with("pong"), "{reply}");
+        h.abort();
+
+        // Unadmitted: a policy whose own uid is not ours and lists nobody.
+        let foreign = current_uid().wrapping_add(1);
+        let (path, h) = bind_with(PeerPolicy::new(foreign, vec![])).await;
+        let reply = get_ping(&path).await.unwrap_or_default();
+        assert!(
+            !reply.contains("pong"),
+            "an unadmitted peer must never be answered, got {reply:?}"
+        );
+        h.abort();
+    }
+}

--- a/crates/nucleus-tool-proxy/src/main.rs
+++ b/crates/nucleus-tool-proxy/src/main.rs
@@ -41,6 +41,7 @@ mod drand_setup;
 mod egress;
 mod escalate;
 mod exit_report;
+mod host_socket;
 mod identity_fusion;
 mod ingest;
 mod lockdown_client;
@@ -86,6 +87,14 @@ struct Args {
     /// Optional path to write the bound address for discovery.
     #[arg(long, env = "NUCLEUS_TOOL_PROXY_ANNOUNCE")]
     announce_path: Option<PathBuf>,
+    /// Serve on a Unix socket whose peers the kernel identifies (#2446): the
+    /// container driver's host-verified transport. Exclusive with vsock.
+    #[arg(long, env = "NUCLEUS_TOOL_PROXY_LISTEN_UNIX")]
+    listen_unix: Option<PathBuf>,
+    /// Extra in-namespace peer uids admitted on `--listen-unix` (own uid is
+    /// always admitted; an out-of-namespace peer is the host).
+    #[arg(long, env = "NUCLEUS_TOOL_PROXY_PEER_UIDS", value_delimiter = ',')]
+    peer_uids: Vec<u32>,
     /// Optional vsock CID override.
     #[arg(long, env = "NUCLEUS_TOOL_PROXY_VSOCK_CID")]
     vsock_cid: Option<u32>,
@@ -1927,9 +1936,15 @@ async fn main() -> Result<(), ApiError> {
     // describe how this server will actually be bound, not be patched in later.
     // A request can never influence it.
     let vsock_binding = pod_mgmt::resolve_vsock(&args, &spec)?;
+    let unix_binding = host_socket::resolve_unix(
+        args.listen_unix.as_deref(),
+        &args.peer_uids,
+        vsock_binding.as_ref(),
+    )?;
+    let host_verified = vsock_binding.is_some() || unix_binding.is_some();
 
     // === Auth-secret sanity, transport-aware (fail-closed where it matters) ===
-    enforce_hmac_key_quality(&args.auth_secret, vsock_binding.is_some());
+    enforce_hmac_key_quality(&args.auth_secret, host_verified);
 
     let receipts = Arc::new(portcullis_effects::receipt::ReceiptLog::new());
     let state = AppState {
@@ -1942,7 +1957,7 @@ async fn main() -> Result<(), ApiError> {
         auth,
         approval_auth,
         approval_verifier,
-        host_verified_transport: vsock_binding.is_some(),
+        host_verified_transport: host_verified,
         approval_nonces: Arc::new(ApprovalNonceCache::default()),
         approval_rate_limiter: Arc::new(ApprovalRateLimiter::default()),
         web_client,
@@ -2135,29 +2150,24 @@ async fn main() -> Result<(), ApiError> {
     // up as a 36ms hole before `vsock_bind` — the largest single gap left in the
     // trace.
     st.mark("router_build");
-    if let Some(vsock) = vsock_binding {
-        // THE GUEST PATH. In a booted microVM the proxy serves over vsock and
+    if let Some(bound) = host_socket::bind_host_verified(
+        vsock_binding,
+        unix_binding,
+        args.announce_path.clone(),
+        &mut st,
+    )
+    .await?
+    {
+        // THE GUEST PATH: vsock in a microVM, a peer-verified Unix socket in a
+        // container (#2446). The proxy serves the host-verified transport and
         // `main` returns right here — everything below this block is host/TCP
         // only. The workload therefore starts on this path (between bind and
         // serve, so its proxy URL names a socket that exists); before run 4's
         // diagnosis it started only below, and an in-guest pod's workload never
         // ran at all.
-        let bound = st
-            .timed(
-                "vsock_bind",
-                pod_mgmt::bind_vsock(vsock, args.announce_path),
-            )
-            .await?;
-        let _workload = start_and_drain_workload(
-            &spec,
-            workload::BoundProxy::Vsock {
-                cid: bound.cid(),
-                port: bound.port(),
-            },
-            &args.auth_secret,
-        )?;
+        let _workload = start_and_drain_workload(&spec, bound.proxy(), &args.auth_secret)?;
         st.report();
-        pod_mgmt::serve_vsock(app, bound).await?;
+        bound.serve(app).await?;
         write_exit_report(
             &exit_audit,
             &exit_work_dir,

--- a/crates/nucleus-tool-proxy/src/workload.rs
+++ b/crates/nucleus-tool-proxy/src/workload.rs
@@ -754,6 +754,9 @@ pub(crate) enum BoundProxy {
     /// client speaks vsock, not TCP, so the URL is `vsock://cid:port` — the
     /// same form the announce file uses.
     Vsock { cid: u32, port: u32 },
+    /// The container path (#2446): a peer-verified Unix socket. The URL is
+    /// `unix://<path>`, the same form the announce file uses.
+    Unix(std::path::PathBuf),
 }
 
 impl BoundProxy {
@@ -761,6 +764,7 @@ impl BoundProxy {
         match self {
             Self::Tcp(addr) => format!("http://{addr}"),
             Self::Vsock { cid, port } => format!("vsock://{cid}:{port}"),
+            Self::Unix(path) => crate::host_socket::unix_url(path),
         }
     }
 }

--- a/docs/plugin-surface.md
+++ b/docs/plugin-surface.md
@@ -65,7 +65,12 @@ isolation ≥ requested; `not_proven` makes over-reading an attestation unsayabl
   lift trust off the operator to a witness quorum; SIEM sinks.
 
 ### 6. Transport / discovery / mesh (where the seam lives on the wire)
-- **Seam:** transport kind (`http` | `mcp`), vsock (guest↔host), iroh
+- **Seam:** transport kind (`http` | `mcp`), vsock (guest↔host), peer-verified
+  Unix socket (container pod↔host/agent, `nucleus-tool-proxy --listen-unix`), iroh
+  (dial-by-`EndpointID`, Pkarr/DNS discovery).
+- **Shipped:** vsock workload API, peer-credential Unix-socket transport for the
+  proxy (#2446 step 1; node wiring and clients follow), HTTP/MCP, iroh (the
+  "call SPIFFE agents anywhere" spike).| `mcp`), vsock (guest↔host), iroh
   (dial-by-`EndpointID`, Pkarr/DNS discovery).
 - **Shipped:** vsock workload API, HTTP/MCP, iroh (the "call SPIFFE agents anywhere"
   spike).


### PR DESCRIPTION
Part of #2446 (owner decision 2026-09-04: deprecate the shared-secret tier and replace it with an identity-bound transport on every driver; container driver first).

## Why
A Firecracker pod's proxy serves over vsock; the guest kernel stamps the peer CID, so the HMAC tier is unreachable there. A container pod's proxy listens on loopback TCP, and the only thing separating the host from the agent is `NUCLEUS_TOOL_PROXY_AUTH_SECRET`, delivered in the container environment and readable by every process in it. That is the bare shared-secret tier.

## What
`--listen-unix PATH` (`NUCLEUS_TOOL_PROXY_LISTEN_UNIX`): the proxy serves on a Unix socket and admits peers by the credentials the kernel reports (`SO_PEERCRED`), **before** the stream reaches the router (`host_socket.rs`):
- a peer outside the proxy's pid namespace (Linux reports `pid == 0`) is the host: through a socket bind-mounted only into this container, this is the analogue of the vsock host CID;
- a peer inside the namespace is admitted only by uid, the proxy's own or an operator-listed one (`--peer-uids`): the same-container trust the HMAC tier stood in for, now enforced by the kernel;
- an unadmitted peer is dropped at accept, so `host_verified_transport` is a sound description of every request the router sees, and the HMAC tier is unreachable on this listener exactly as on vsock (`select_auth_tier` unchanged).

vsock and Unix bindings are mutually exclusive. `main.rs`'s vsock branch is generalised into `HostBound` (bind → workload with `unix://<path>` → serve → exit report), which shrank it; `BoundProxy::Unix` carries the URL to the workload and the announce file uses the same form. `AuthMethod::HostVsock`'s doc now says it covers both host-verified transports (a separate variant would cost main.rs lines the ratchet does not have; the transport is logged at bind).

## Tests
- the two admission rules: pid-zero-only host rule (in-namespace root is **not** the host; no pid never means host), own/listed uid rule;
- config refusals: ambiguous with vsock, relative path, `--peer-uids` without a socket;
- an in-process bind that answers an admitted peer (own uid) and closes on an unadmitted one before any byte is answered.

389 proxy tests green; clippy `--all-targets --all-features -D warnings` clean; main.rs 4971/4975 under the line ratchet.

## Not in this PR (next steps on #2446)
1. node container driver: per-pod socket dir bind-mounted into the container, `NUCLEUS_TOOL_PROXY_LISTEN_UNIX` set, no secret provisioned;
2. `signed_proxy` (node) and the SDK/client speaking `unix://`;
3. HMAC tier demoted to liveness-only with a zero capability ceiling; then removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZaH5waz88vL1qfNpFNfZ4
