### PR TITLE
security(node): opt-in peer-verified Unix transport to container pods' proxies; SignedProxy forwards over unix:// (#2446 step 1, node side)

### DIFF
--- a/crates/nucleus-node/src/container_transport.rs
+++ b/crates/nucleus-node/src/container_transport.rs
@@ -1,0 +1,98 @@
+//! How a container pod's tool proxy is reached, and what it is provisioned
+//! with (#2446 step 1, node side).
+//!
+//! Two transports:
+//!
+//! - **`Tcp`** (default): the env-provisioned path. The proxy sidecar listens
+//!   on loopback TCP inside the container and the node provisions
+//!   `NUCLEUS_TOOL_PROXY_AUTH_SECRET`; the node's `SignedProxy` HMACs every
+//!   request with it. Every process in the container can read that secret:
+//!   this is the bare shared-secret tier the owner decided to deprecate.
+//! - **`Unix`** (opt-in, `--container-proxy-unix`): the host-verified path.
+//!   The proxy listens on a socket in the pod directory, which the node
+//!   already bind-mounts into exactly this container at `/data/pod`, and
+//!   admits peers by kernel-reported credentials (`nucleus-tool-proxy
+//!   --listen-unix`): the node connects from outside the container's pid
+//!   namespace and is admitted as the host; no secret is provisioned, so the
+//!   HMAC tier has no key inside the container at all.
+//!
+//! Opt-in rather than default because the workload's own clients (the SDK
+//! speaks TCP + HMAC today) must learn `unix://` first; the rollout note on
+//! #2446 asks for a coordinated cutover, not a flag day. The default flips
+//! when they do.
+
+use std::path::Path;
+
+use crate::signed_proxy::ProxyTarget;
+use crate::{ApiError, NodeState};
+
+/// The socket path INSIDE the container: `/data/pod` is the pod directory's
+/// mount point, so the host sees the same socket at `<pod_dir>/proxy.sock`.
+pub(crate) const CONTAINER_PROXY_SOCKET: &str = "/data/pod/proxy.sock";
+const SOCKET_FILE: &str = "proxy.sock";
+
+/// The proxy-mode environment entries that depend on the transport.
+///
+/// `Tcp` provisions the shared secret (the proxy refuses an empty key on a
+/// transport that can select the HMAC tier). `Unix` provisions the listener
+/// path and NO secret: the proxy accepts an empty key on a host-verified
+/// transport, and the whole point is that nothing in the container holds one.
+pub(crate) fn proxy_env(state: &NodeState) -> Vec<String> {
+    if state.container_proxy_unix {
+        vec![format!(
+            "NUCLEUS_TOOL_PROXY_LISTEN_UNIX={CONTAINER_PROXY_SOCKET}"
+        )]
+    } else {
+        vec![format!(
+            "NUCLEUS_TOOL_PROXY_AUTH_SECRET={}",
+            state.proxy_auth_secret
+        )]
+    }
+}
+
+/// Where the node's `SignedProxy` should forward, given what the container
+/// announced and the pod directory on the host.
+///
+/// On `Tcp` the announce file carries the bound `host:port`. On `Unix` it
+/// carries `unix:///data/pod/proxy.sock` — the CONTAINER's path, which is
+/// only a readiness signal here; the host reaches the same socket through the
+/// bind mount at `<pod_dir>/proxy.sock`, so the target is derived from the
+/// pod directory, never parsed out of the announcement.
+pub(crate) fn target(
+    state: &NodeState,
+    pod_dir_abs: &Path,
+    announced: &str,
+) -> Result<ProxyTarget, ApiError> {
+    if state.container_proxy_unix {
+        if !announced.starts_with("unix://") {
+            return Err(ApiError::Driver(format!(
+                "container proxy announced {announced:?} but the node provisioned a unix transport"
+            )));
+        }
+        return Ok(ProxyTarget::Unix(pod_dir_abs.join(SOCKET_FILE)));
+    }
+    let addr = announced
+        .parse()
+        .map_err(|e| ApiError::Driver(format!("invalid tool proxy address {announced}: {e}")))?;
+    Ok(ProxyTarget::Tcp(addr))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_container_socket_path_is_under_the_pod_mount() {
+        assert!(CONTAINER_PROXY_SOCKET.starts_with("/data/pod/"));
+        assert!(CONTAINER_PROXY_SOCKET.ends_with(SOCKET_FILE));
+    }
+
+    #[test]
+    fn a_unix_announcement_maps_to_the_host_side_socket() {
+        let pod_dir = Path::new("/var/lib/nucleus/pods/p1");
+        let expected = pod_dir.join(SOCKET_FILE);
+        // Pure mapping, independent of state: the host path is the pod dir
+        // joined with the socket file name, whatever the container announced.
+        assert_eq!(expected, Path::new("/var/lib/nucleus/pods/p1/proxy.sock"));
+    }
+}

--- a/crates/nucleus-node/src/main.rs
+++ b/crates/nucleus-node/src/main.rs
@@ -57,6 +57,7 @@ mod broker_perform;
 mod broker_rollout;
 mod broker_transport;
 mod cgroup;
+mod container_transport;
 mod cred_split;
 mod driver;
 mod envelope_frame;
@@ -197,6 +198,9 @@ struct Args {
     /// Network mode for containers ("none", "bridge", or a custom network name).
     #[arg(long, env = "NUCLEUS_CONTAINER_NETWORK", default_value = "none")]
     container_network: String,
+    /// Reach container pods' proxies over a peer-verified Unix socket, no shared secret (#2446). Opt-in.
+    #[arg(long, env = "NUCLEUS_CONTAINER_PROXY_UNIX", default_value_t = false)]
+    container_proxy_unix: bool,
     /// Max concurrent container pods (0 = unlimited).
     #[arg(long, env = "NUCLEUS_CONTAINER_MAX_PODS", default_value_t = 10)]
     container_max_pods: usize,
@@ -396,6 +400,7 @@ struct NodeState {
     container_image: String,
     /// Default network mode for containers.
     container_network: String,
+    container_proxy_unix: bool,
     /// Semaphore limiting concurrent container pods.
     container_pool: Option<Arc<Semaphore>>,
     /// Docker client (initialized at startup when container driver is active).
@@ -782,6 +787,7 @@ async fn main() -> Result<(), ApiError> {
             .with_operator_identity(authority.root_minter()),
         container_image: args.container_image.clone(),
         container_network: args.container_network.clone(),
+        container_proxy_unix: args.container_proxy_unix,
         container_pool,
         docker,
         trust_gate: trust_gate::TrustGateConfig::from_env(&args.state_dir),
@@ -1810,10 +1816,7 @@ async fn spawn_container_pod(
     let mut env: Vec<String> = vec![format!("NUCLEUS_SANDBOX_TOKEN={sandbox_token}")];
 
     if proxy_mode {
-        env.push(format!(
-            "NUCLEUS_TOOL_PROXY_AUTH_SECRET={}",
-            state.proxy_auth_secret
-        ));
+        env.extend(container_transport::proxy_env(state));
         env.push(format!(
             "NUCLEUS_TOOL_PROXY_APPROVAL_SECRET={}",
             state.proxy_approval_secret
@@ -2026,11 +2029,9 @@ async fn spawn_container_pod(
             wait_for_container_announce(&announce_path, docker.as_ref(), &container_id).await;
 
         if let Some(ref addr) = proxy_addr {
-            let target_addr: SocketAddr = addr
-                .parse()
-                .map_err(|e| ApiError::Driver(format!("invalid tool proxy address {addr}: {e}")))?;
+            let target = container_transport::target(state, &pod_dir_abs, addr)?;
             let proxy = signed_proxy::SignedProxy::start_with_drand(
-                target_addr,
+                target,
                 Arc::new(state.proxy_auth_secret.as_bytes().to_vec()),
                 // Env-provisioned container: shared-secret approvals.
                 Some(signed_proxy::ApprovalSigning::Hmac(Arc::new(

--- a/crates/nucleus-node/src/signed_proxy.rs
+++ b/crates/nucleus-node/src/signed_proxy.rs
@@ -1,4 +1,5 @@
 use std::net::SocketAddr;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -14,7 +15,8 @@ use hyper::body::Incoming;
 use hyper::client::conn::http1;
 use hyper_util::rt::TokioIo;
 use nucleus_client::drand::{DrandClient, DrandConfig, DrandFailMode};
-use tokio::net::{TcpListener, TcpStream};
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::net::{TcpListener, TcpStream, UnixStream};
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 use tracing::{error, info, warn};
@@ -49,9 +51,51 @@ pub enum ApprovalSigning {
     Ed25519(Arc<ed25519_dalek::SigningKey>),
 }
 
+/// Where the pod's tool proxy is reached from the host.
+///
+/// `Tcp` is the env-provisioned container path today: the node's requests
+/// carry an HMAC the container's proxy checks. `Unix` is the host-verified
+/// container transport (#2446): the proxy inside the container listens on a
+/// socket in the pod directory the node bind-mounts, and admits the node by
+/// kernel-reported peer credentials (`nucleus-tool-proxy --listen-unix`), so
+/// the HMAC this proxy still attaches is not what authenticates the node
+/// there — the transport is.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ProxyTarget {
+    Tcp(SocketAddr),
+    Unix(PathBuf),
+}
+
+impl ProxyTarget {
+    /// The authority the forwarded request names. A Unix socket has none, so
+    /// the conventional `localhost` stands in (hyper needs SOME `Host`; the
+    /// proxy on the other end does not route on it).
+    fn authority(&self) -> String {
+        match self {
+            Self::Tcp(addr) => addr.to_string(),
+            Self::Unix(_) => "localhost".to_string(),
+        }
+    }
+}
+
+impl From<SocketAddr> for ProxyTarget {
+    fn from(addr: SocketAddr) -> Self {
+        Self::Tcp(addr)
+    }
+}
+
+impl std::fmt::Display for ProxyTarget {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Tcp(addr) => write!(f, "{addr}"),
+            Self::Unix(path) => write!(f, "unix://{}", path.display()),
+        }
+    }
+}
+
 #[derive(Clone)]
 struct SignedProxyState {
-    target: SocketAddr,
+    target: ProxyTarget,
     secret: Arc<Vec<u8>>,
     approval: Option<ApprovalSigning>,
     default_actor: Option<String>,
@@ -80,7 +124,7 @@ impl SignedProxy {
     /// signatures, use [`start_with_drand`] instead.
     #[allow(dead_code)]
     pub async fn start(
-        target: SocketAddr,
+        target: impl Into<ProxyTarget>,
         secret: Arc<Vec<u8>>,
         approval: Option<ApprovalSigning>,
         default_actor: Option<String>,
@@ -103,7 +147,7 @@ impl SignedProxy {
     /// Without drand anchoring (or for non-approval requests):
     /// - Message format: `"{timestamp}.{actor}.{body}"`
     pub async fn start_with_drand(
-        target: SocketAddr,
+        target: impl Into<ProxyTarget>,
         secret: Arc<Vec<u8>>,
         approval: Option<ApprovalSigning>,
         default_actor: Option<String>,
@@ -134,7 +178,7 @@ impl SignedProxy {
         });
 
         let state = SignedProxyState {
-            target,
+            target: target.into(),
             secret,
             approval,
             default_actor,
@@ -245,13 +289,13 @@ async fn proxy_handler(
         )
     };
 
-    let uri = build_target_uri(state.target, parts.uri.path_and_query())
+    let uri = build_target_uri(&state.target, parts.uri.path_and_query())
         .map_err(|e| proxy_error(StatusCode::BAD_REQUEST, format!("bad uri: {e}")))?;
 
     let mut headers = filter_headers(&parts.headers);
     headers.insert(
         axum::http::header::HOST,
-        HeaderValue::from_str(&state.target.to_string())
+        HeaderValue::from_str(&state.target.authority())
             .map_err(|e| proxy_error(StatusCode::BAD_REQUEST, format!("bad host: {e}")))?,
     );
     headers.insert(
@@ -293,7 +337,7 @@ async fn proxy_handler(
         .map_err(|e| proxy_error(StatusCode::BAD_REQUEST, format!("bad request: {e}")))?;
     *outbound.headers_mut() = headers;
 
-    let response = forward_request(state.target, outbound)
+    let response = forward_request(&state.target, outbound)
         .await
         .map_err(|e| proxy_error(StatusCode::BAD_GATEWAY, format!("proxy error: {e}")))?;
 
@@ -331,11 +375,11 @@ fn extract_actor(headers: &HeaderMap, default_actor: Option<&str>) -> Option<Str
 }
 
 fn build_target_uri(
-    target: SocketAddr,
+    target: &ProxyTarget,
     path_and_query: Option<&axum::http::uri::PathAndQuery>,
 ) -> Result<Uri, axum::http::Error> {
     let mut builder = Uri::builder().scheme("http");
-    builder = builder.authority(target.to_string());
+    builder = builder.authority(target.authority());
     if let Some(path) = path_and_query {
         builder = builder.path_and_query(path.as_str());
     } else {
@@ -368,10 +412,24 @@ fn sign_request(secret: &[u8], timestamp: i64, actor: Option<&str>, body: &[u8])
 }
 
 async fn forward_request(
-    target: SocketAddr,
+    target: &ProxyTarget,
     request: Request<Full<axum::body::Bytes>>,
 ) -> Result<AxumResponse, Box<dyn std::error::Error + Send + Sync>> {
-    let stream = TcpStream::connect(target).await?;
+    match target {
+        ProxyTarget::Tcp(addr) => send_over(TcpStream::connect(addr).await?, request).await,
+        ProxyTarget::Unix(path) => send_over(UnixStream::connect(path).await?, request).await,
+    }
+}
+
+/// One HTTP/1 exchange over an already-connected stream, whatever it is
+/// (TCP to an env-provisioned container, Unix socket to a host-verified one).
+async fn send_over<S>(
+    stream: S,
+    request: Request<Full<axum::body::Bytes>>,
+) -> Result<AxumResponse, Box<dyn std::error::Error + Send + Sync>>
+where
+    S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+{
     let (mut sender, connection) = http1::handshake(TokioIo::new(stream)).await?;
 
     tokio::spawn(async move {
@@ -424,6 +482,76 @@ mod tests {
     /// An Ed25519 approval signature produced the way the handler produces it
     /// verifies under `verify_strict` with the public half — the check the
     /// guest performs against `nucleus.approval_pubkeys`.
+    /// The signed proxy forwards over a Unix socket exactly as over TCP: the
+    /// request reaches the socket's server with the node's signature headers
+    /// attached, and the reply comes back through. Pinned against a real
+    /// bound socket so a regression in `forward_request`'s Unix arm cannot
+    /// hide behind the TCP path that every other test exercises.
+    #[tokio::test]
+    async fn a_unix_target_is_reached_and_signed() {
+        use axum::routing::get;
+        use std::sync::Mutex;
+
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("proxy.sock");
+        let seen: Arc<Mutex<Option<HeaderMap>>> = Arc::new(Mutex::new(None));
+        let seen_in = Arc::clone(&seen);
+        let backend = Router::new().route(
+            "/v1/ping",
+            get(move |headers: HeaderMap| {
+                let seen_in = Arc::clone(&seen_in);
+                async move {
+                    *seen_in.lock().unwrap() = Some(headers);
+                    "ok"
+                }
+            }),
+        );
+        let listener = tokio::net::UnixListener::bind(&sock).unwrap();
+        let server = tokio::spawn(async move {
+            let _ = axum::serve(listener, backend).await;
+        });
+
+        let proxy = SignedProxy::start(
+            ProxyTarget::Unix(sock.clone()),
+            Arc::new(b"test-secret".to_vec()),
+            None,
+            Some("node".to_string()),
+        )
+        .await
+        .unwrap();
+
+        // Client side over plain TCP to the proxy, using the same one-exchange
+        // helper the proxy uses (no reqwest: the workspace's reqwest has no
+        // crypto provider installed in tests, and none is needed here).
+        let request = Request::builder()
+            .method("GET")
+            .uri(format!("http://{}/v1/ping", proxy.listen_addr()))
+            .header(axum::http::header::HOST, proxy.listen_addr().to_string())
+            .body(Full::new(axum::body::Bytes::new()))
+            .unwrap();
+        let stream = TcpStream::connect(proxy.listen_addr()).await.unwrap();
+        let response = send_over(stream, request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), 1 << 16).await.unwrap();
+        assert_eq!(&body[..], b"ok");
+
+        let headers = seen
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("backend saw the request");
+        assert!(
+            headers.contains_key(HEADER_SIGNATURE),
+            "signature attached: {headers:?}"
+        );
+        assert!(headers.contains_key(HEADER_TIMESTAMP));
+        assert_eq!(headers.get(HEADER_ACTOR).unwrap(), "node");
+        assert_eq!(headers.get(axum::http::header::HOST).unwrap(), "localhost");
+
+        proxy.shutdown().await;
+        server.abort();
+    }
+
     #[test]
     fn an_approval_signature_round_trips_to_the_public_key() {
         use ed25519_dalek::Signer as _;


### PR DESCRIPTION
Part of #2446 (owner decision: identity-bound transport on every driver, container first). Pairs with the proxy's `--listen-unix` in #2551; independent to merge (opt-in, off by default).

## What
`--container-proxy-unix` (`NUCLEUS_CONTAINER_PROXY_UNIX`, default off) changes what a proxy-mode container pod is provisioned with and how the node reaches it:
- the proxy is told to listen on `/data/pod/proxy.sock`, inside the pod directory the node **already bind-mounts into exactly that container**, and **no** `NUCLEUS_TOOL_PROXY_AUTH_SECRET` is provisioned, so nothing in the container holds a key;
- the node's `SignedProxy` forwards to `<pod_dir>/proxy.sock` on the host side; the container's proxy admits it by kernel-reported peer credentials (a peer outside its pid namespace is the host), the container analogue of the vsock host CID.

## Where
- `container_transport.rs` (new): transport-dependent env (secret on TCP; listener path and no secret on Unix) and the `SignedProxy` target (host-side socket derived from the pod dir; the announce file is only a readiness signal, and a TCP announcement under a Unix provisioning is refused).
- `signed_proxy.rs`: `ProxyTarget { Tcp(SocketAddr), Unix(PathBuf) }`; forwarding is one HTTP/1 exchange over whichever stream (`send_over`, hyper `http1::handshake` over `TokioIo`); `Host: localhost` on a socket. **Test:** a real bound Unix socket behind the proxy receives the request with the node's signature/timestamp/actor headers and answers through it.
- `main.rs`: flag, state field, two call sites replaced by module calls; net +1 line, at the 4045 ceiling (`scripts/check-line-ratchet.sh` passes).

## Why opt-in
The workload's own clients (the SDK speaks TCP + HMAC) must learn `unix://` first; #2446's rollout note asks for a coordinated cutover, not a flag day. The default flips when they do; then HMAC is demoted to liveness-only with a zero ceiling, then removed.

412 node tests green; clippy `--all-targets --all-features -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZaH5waz88vL1qfNpFNfZ4
