### PR TITLE
security(scorecard): pin every base image by digest, pin elan-init by tag+checksum, scope decide-pure's write permission

### DIFF
--- a/.github/workflows/aeneas-certchain.yml
+++ b/.github/workflows/aeneas-certchain.yml
@@ -153,8 +153,10 @@ jobs:
       - name: Install elan (Lean toolchain)
         if: runner.environment == 'github-hosted'
         run: |
-          curl -sSf https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
-            | sh -s -- -y --no-modify-path
+          # elan-init pinned by tag AND checksum (Scorecard: no download-then-run).
+          curl -sSf https://raw.githubusercontent.com/leanprover/elan/v4.2.4/elan-init.sh -o /tmp/elan-init.sh
+          echo "a620ff1641616222c8d37c54845492004bb84d6877cdbc944dd65c1aa685bf53  /tmp/elan-init.sh" | sha256sum -c -
+          sh /tmp/elan-init.sh -y --no-modify-path
           echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
 
       - name: "Lean toolchain + Mathlib cache (hosted: elan + cache action)"

--- a/.github/workflows/aeneas-decide-pure.yml
+++ b/.github/workflows/aeneas-decide-pure.yml
@@ -52,7 +52,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
-  contents: write
+  contents: read
 
 env:
   # Pin to the Aeneas prebuilt nightly that does scoped extraction cleanly
@@ -71,6 +71,9 @@ env:
 
 jobs:
   aeneas-decide-pure:
+    # The only job that pushes (the bot branch below); write stays job-scoped.
+    permissions:
+      contents: write
     name: Scoped Aeneas (decide_pure) + auto-commit generated-decide/
     runs-on: ${{ vars.CI_BUILD_RUNNER || vars.CI_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 40

--- a/.github/workflows/aeneas-ifc-scoped.yml
+++ b/.github/workflows/aeneas-ifc-scoped.yml
@@ -414,8 +414,10 @@ jobs:
       - name: Install elan (Lean toolchain)
         if: steps.scope.outputs.relevant == 'true' && runner.environment == 'github-hosted'
         run: |
-          curl -sSf https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
-            | sh -s -- -y --no-modify-path
+          # elan-init pinned by tag AND checksum (Scorecard: no download-then-run).
+          curl -sSf https://raw.githubusercontent.com/leanprover/elan/v4.2.4/elan-init.sh -o /tmp/elan-init.sh
+          echo "a620ff1641616222c8d37c54845492004bb84d6877cdbc944dd65c1aa685bf53  /tmp/elan-init.sh" | sha256sum -c -
+          sh /tmp/elan-init.sh -y --no-modify-path
           echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
 
       - name: "Lean toolchain + Mathlib cache (hosted: elan + cache action)"

--- a/.github/workflows/aeneas-oidc-spiffe.yml
+++ b/.github/workflows/aeneas-oidc-spiffe.yml
@@ -225,8 +225,10 @@ jobs:
       - name: Install elan (Lean toolchain)
         if: steps.scope.outputs.relevant == 'true' && runner.environment == 'github-hosted'
         run: |
-          curl -sSf https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
-            | sh -s -- -y --no-modify-path
+          # elan-init pinned by tag AND checksum (Scorecard: no download-then-run).
+          curl -sSf https://raw.githubusercontent.com/leanprover/elan/v4.2.4/elan-init.sh -o /tmp/elan-init.sh
+          echo "a620ff1641616222c8d37c54845492004bb84d6877cdbc944dd65c1aa685bf53  /tmp/elan-init.sh" | sha256sum -c -
+          sh /tmp/elan-init.sh -y --no-modify-path
           echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
 
       - name: "Lean toolchain + Mathlib cache (hosted: elan + cache action)"

--- a/.github/workflows/aeneas.yml
+++ b/.github/workflows/aeneas.yml
@@ -237,8 +237,10 @@ jobs:
       - name: Install elan (Lean toolchain)
         if: runner.environment == 'github-hosted'
         run: |
-          curl -sSf https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
-            | sh -s -- -y --no-modify-path
+          # elan-init pinned by tag AND checksum (Scorecard: no download-then-run).
+          curl -sSf https://raw.githubusercontent.com/leanprover/elan/v4.2.4/elan-init.sh -o /tmp/elan-init.sh
+          echo "a620ff1641616222c8d37c54845492004bb84d6877cdbc944dd65c1aa685bf53  /tmp/elan-init.sh" | sha256sum -c -
+          sh /tmp/elan-init.sh -y --no-modify-path
           echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
 
       # Cache-poisoning ignored: formal-proof build only, no published artifacts.

--- a/.github/workflows/ck-policy-aeneas.yml
+++ b/.github/workflows/ck-policy-aeneas.yml
@@ -214,8 +214,10 @@ jobs:
       - name: Install elan (Lean toolchain)
         if: steps.scope.outputs.relevant == 'true' && runner.environment == 'github-hosted'
         run: |
-          curl -sSf https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
-            | sh -s -- -y --no-modify-path
+          # elan-init pinned by tag AND checksum (Scorecard: no download-then-run).
+          curl -sSf https://raw.githubusercontent.com/leanprover/elan/v4.2.4/elan-init.sh -o /tmp/elan-init.sh
+          echo "a620ff1641616222c8d37c54845492004bb84d6877cdbc944dd65c1aa685bf53  /tmp/elan-init.sh" | sha256sum -c -
+          sh /tmp/elan-init.sh -y --no-modify-path
           echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
 
       - name: Cache Lake build artifacts

--- a/.github/workflows/ck-policy-lean.yml
+++ b/.github/workflows/ck-policy-lean.yml
@@ -93,8 +93,10 @@ jobs:
       - name: Install elan (Lean toolchain)
         if: runner.environment == 'github-hosted' && (steps.scope.outputs.relevant == 'true')
         run: |
-          curl -sSf https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
-            | sh -s -- -y --no-modify-path
+          # elan-init pinned by tag AND checksum (Scorecard: no download-then-run).
+          curl -sSf https://raw.githubusercontent.com/leanprover/elan/v4.2.4/elan-init.sh -o /tmp/elan-init.sh
+          echo "a620ff1641616222c8d37c54845492004bb84d6877cdbc944dd65c1aa685bf53  /tmp/elan-init.sh" | sha256sum -c -
+          sh /tmp/elan-init.sh -y --no-modify-path
           echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
 
       - name: Cache Lake build artifacts

--- a/.github/workflows/econ-lean.yml
+++ b/.github/workflows/econ-lean.yml
@@ -92,8 +92,10 @@ jobs:
       - name: Install elan (Lean toolchain)
         if: runner.environment == 'github-hosted' && (steps.scope.outputs.relevant == 'true')
         run: |
-          curl -sSf https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
-            | sh -s -- -y --no-modify-path
+          # elan-init pinned by tag AND checksum (Scorecard: no download-then-run).
+          curl -sSf https://raw.githubusercontent.com/leanprover/elan/v4.2.4/elan-init.sh -o /tmp/elan-init.sh
+          echo "a620ff1641616222c8d37c54845492004bb84d6877cdbc944dd65c1aa685bf53  /tmp/elan-init.sh" | sha256sum -c -
+          sh /tmp/elan-init.sh -y --no-modify-path
           echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
 
       - name: Cache Lake build artifacts

--- a/.github/workflows/portcullis-core-proven-lean.yml
+++ b/.github/workflows/portcullis-core-proven-lean.yml
@@ -100,8 +100,10 @@ jobs:
       - name: Install elan (Lean toolchain)
         if: runner.environment == 'github-hosted' && (steps.scope.outputs.relevant == 'true')
         run: |
-          curl -sSf https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
-            | sh -s -- -y --no-modify-path
+          # elan-init pinned by tag AND checksum (Scorecard: no download-then-run).
+          curl -sSf https://raw.githubusercontent.com/leanprover/elan/v4.2.4/elan-init.sh -o /tmp/elan-init.sh
+          echo "a620ff1641616222c8d37c54845492004bb84d6877cdbc944dd65c1aa685bf53  /tmp/elan-init.sh" | sha256sum -c -
+          sh /tmp/elan-init.sh -y --no-modify-path
           echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
 
       # Cache-poisoning ignored: formal-proof build only, no published artifacts.

--- a/.github/workflows/research-lean-build.yml
+++ b/.github/workflows/research-lean-build.yml
@@ -47,8 +47,10 @@ jobs:
         # Hosted only: the runner image bakes elan + the pinned Lean toolchain.
         if: ${{ runner.environment == 'github-hosted' }}
         run: |
-          curl -sSf https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
-            | sh -s -- -y --no-modify-path
+          # elan-init pinned by tag AND checksum (Scorecard: no download-then-run).
+          curl -sSf https://raw.githubusercontent.com/leanprover/elan/v4.2.4/elan-init.sh -o /tmp/elan-init.sh
+          echo "a620ff1641616222c8d37c54845492004bb84d6877cdbc944dd65c1aa685bf53  /tmp/elan-init.sh" | sha256sum -c -
+          sh /tmp/elan-init.sh -y --no-modify-path
           echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
 
       - name: Cache Lake / Mathlib build artifacts

--- a/.github/workflows/rubric-lean.yml
+++ b/.github/workflows/rubric-lean.yml
@@ -88,8 +88,10 @@ jobs:
       - name: Install elan (Lean toolchain)
         if: runner.environment == 'github-hosted' && (steps.scope.outputs.relevant == 'true')
         run: |
-          curl -sSf https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
-            | sh -s -- -y --no-modify-path
+          # elan-init pinned by tag AND checksum (Scorecard: no download-then-run).
+          curl -sSf https://raw.githubusercontent.com/leanprover/elan/v4.2.4/elan-init.sh -o /tmp/elan-init.sh
+          echo "a620ff1641616222c8d37c54845492004bb84d6877cdbc944dd65c1aa685bf53  /tmp/elan-init.sh" | sha256sum -c -
+          sh /tmp/elan-init.sh -y --no-modify-path
           echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
 
       - name: Cache Lake build artifacts

--- a/.github/workflows/uniform-primitive-lean.yml
+++ b/.github/workflows/uniform-primitive-lean.yml
@@ -88,8 +88,10 @@ jobs:
       - name: Install elan (Lean toolchain)
         if: steps.scope.outputs.relevant == 'true'
         run: |
-          curl -sSf https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
-            | sh -s -- -y --no-modify-path
+          # elan-init pinned by tag AND checksum (Scorecard: no download-then-run).
+          curl -sSf https://raw.githubusercontent.com/leanprover/elan/v4.2.4/elan-init.sh -o /tmp/elan-init.sh
+          echo "a620ff1641616222c8d37c54845492004bb84d6877cdbc944dd65c1aa685bf53  /tmp/elan-init.sh" | sha256sum -c -
+          sh /tmp/elan-init.sh -y --no-modify-path
           echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
 
       - name: lake build (a broken proof FAILS here)

--- a/crates/ctf-engine/Dockerfile
+++ b/crates/ctf-engine/Dockerfile
@@ -1,7 +1,7 @@
 # Serve pre-built WASM CTF app.
 # Build the WASM locally first: cd crates/ctf-engine && trunk build --release
 # Then deploy from workspace root: fly deploy
-FROM joseluisq/static-web-server:2.41.0-alpine
+FROM joseluisq/static-web-server:2.41.0-alpine@sha256:58e12f1502be7b68cf492e27582a81634583f3389005e94ce44729cc1464a941
 
 # Cache bust: mobile responsive v2
 COPY crates/ctf-engine/dist /public

--- a/crates/ctf-server/Dockerfile
+++ b/crates/ctf-server/Dockerfile
@@ -6,12 +6,12 @@
 # Builder image must satisfy the workspace `rust-version = 1.95` floor
 # (portcullis et al. reject older toolchains). `rust:1-slim` tracks the
 # latest stable 1.x — bump explicitly if a newer floor is set.
-FROM rust:1-slim AS builder
+FROM rust:1-slim@sha256:17d1ba895198f9934c6314ec5346a0d5115372f3243390c3d731e242f35c2f27 AS builder
 WORKDIR /build
 COPY . .
 RUN cargo build --release -p ctf-server
 
-FROM debian:bookworm-slim
+FROM debian:bookworm-slim@sha256:88200866dfff7ea7f5cbcb6ec7c8a701889efe6fe859fe64d6990e4b07ea4171
 RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /build/target/release/ctf-server /usr/local/bin/ctf-server
 COPY crates/ctf-engine/dist /public

--- a/crates/nucleus-control-plane-server/Dockerfile
+++ b/crates/nucleus-control-plane-server/Dockerfile
@@ -3,7 +3,7 @@
 # Build context is the workspace root:
 #   docker build -f crates/nucleus-control-plane-server/Dockerfile -t nucleus-control-plane .
 
-FROM rust:1.95-slim-bookworm AS build
+FROM rust:1.95-slim-bookworm@sha256:d7482085ff5b415f84dba5647ae71606650bdef00db7aeb69f4b3d170c3e4082 AS build
 WORKDIR /work
 # protoc is required at build time by nucleus-proto.
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -15,7 +15,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     cargo build --release --bin nucleus-control-plane-server && \
     cp /work/target/release/nucleus-control-plane-server /usr/local/bin/nucleus-control-plane-server
 
-FROM gcr.io/distroless/cc-debian12:nonroot
+FROM gcr.io/distroless/cc-debian12:nonroot@sha256:9dac0a79194e45a7da0158a9c6da57b217585af0786db3845d1f0ec1a0dd182f
 COPY --from=build /usr/local/bin/nucleus-control-plane-server /usr/local/bin/nucleus-control-plane-server
 EXPOSE 8080
 EXPOSE 9080

--- a/crates/nucleus-oidc-provider/Dockerfile
+++ b/crates/nucleus-oidc-provider/Dockerfile
@@ -2,7 +2,7 @@
 # Final image: ~50 MB distroless-cc base + statically-linked-libc-free binary.
 
 # ─── Stage 1: build ─────────────────────────────────────────────────────
-FROM rust:1.95-bookworm AS builder
+FROM rust:1.95-bookworm@sha256:6258907abe69656e41cd992e0b705cdcfabcbbe3db374f92ed2d47121282d4a1 AS builder
 
 # System deps required to build openssl/rustls/age C crypto.
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -22,7 +22,7 @@ RUN cargo build --release --bin nucleus-oidc-provider -p nucleus-oidc-provider
 
 # ─── Stage 2: runtime ───────────────────────────────────────────────────
 # distroless/cc: minimal — has libssl, libc, ca-certificates, nothing else.
-FROM gcr.io/distroless/cc-debian12:nonroot
+FROM gcr.io/distroless/cc-debian12:nonroot@sha256:9dac0a79194e45a7da0158a9c6da57b217585af0786db3845d1f0ec1a0dd182f
 
 WORKDIR /app
 

--- a/crates/nucleus-verifier-service/Dockerfile
+++ b/crates/nucleus-verifier-service/Dockerfile
@@ -6,7 +6,7 @@
 #
 #   docker build -f crates/nucleus-verifier-service/Dockerfile -t nucleus-verifier .
 
-FROM rust:1.95-slim-bookworm AS build
+FROM rust:1.95-slim-bookworm@sha256:d7482085ff5b415f84dba5647ae71606650bdef00db7aeb69f4b3d170c3e4082 AS build
 WORKDIR /work
 COPY . .
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
@@ -14,7 +14,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     cargo build --release --bin nucleus-verifier-service && \
     cp /work/target/release/nucleus-verifier-service /usr/local/bin/nucleus-verifier-service
 
-FROM gcr.io/distroless/cc-debian12:nonroot
+FROM gcr.io/distroless/cc-debian12:nonroot@sha256:9dac0a79194e45a7da0158a9c6da57b217585af0786db3845d1f0ec1a0dd182f
 COPY --from=build /usr/local/bin/nucleus-verifier-service /usr/local/bin/nucleus-verifier-service
 EXPOSE 8080
 # Default env: bind on all interfaces, DB on the mounted volume. The

--- a/docker/Dockerfile.runner
+++ b/docker/Dockerfile.runner
@@ -12,7 +12,7 @@
 # Build for the node's own architecture (arm64 today):
 #   podman build -f docker/Dockerfile.runner -t localhost/nucleus-ci-runner:0.2.5 .
 # then import into k3s's containerd (k8s/ci-runner/README.md).
-FROM ghcr.io/actions/actions-runner:2.337.0
+FROM ghcr.io/actions/actions-runner:2.337.0@sha256:e5496277be5d09bc968b3d64911b74e219ac4a3f2edce956a3ecf9271bea1ef4
 
 USER root
 ENV DEBIAN_FRONTEND=noninteractive

--- a/docker/Dockerfile.tool-proxy-minimal
+++ b/docker/Dockerfile.tool-proxy-minimal
@@ -4,7 +4,7 @@
 # Build:
 #   cargo build --release -p nucleus-tool-proxy
 #   docker build -f docker/Dockerfile.tool-proxy-minimal -t nucleus-tool-proxy:latest .
-FROM debian:bookworm-slim
+FROM debian:bookworm-slim@sha256:88200866dfff7ea7f5cbcb6ec7c8a701889efe6fe859fe64d6990e4b07ea4171
 RUN apt-get update && apt-get install -y ca-certificates git curl && rm -rf /var/lib/apt/lists/*
 COPY target/release/nucleus-tool-proxy /usr/local/bin/
 RUN mkdir -p /workspace


### PR DESCRIPTION
Addresses 25 of the 41 open [code-scanning alerts](https://github.com/coproduct-opensource/nucleus/security/code-scanning) (all OpenSSF Scorecard) in one pass; 14 more are dismissed with a written reason each; the remaining 2 are process-level (SAST-on-all-commits, code review) plus the aggregate vulnerability alert, which a follow-up PR on the satellite lockfiles addresses.

## Fixed here
- **containerImage not pinned (11 `FROM` lines, 7 Dockerfiles):** every `FROM` now carries the registry's multi-arch index digest fetched today; tags stay for readability.
- **downloadThenRun (11 workflow sites):** `curl …/elan/master/elan-init.sh | sh` becomes download-at-tag-v4.2.4 → `sha256sum -c` against a pinned checksum → `sh`. Same args as before at each site.
- **TokenPermissions (aeneas-decide-pure.yml):** `contents: write` moves from top level to the one job that pushes; workflow default is `contents: read`.

## Dismissed, with reasons on the alerts
- job-scoped `contents: write` the job needs: release asset upload (tag-gated), clippy/line ratchet-down (push to main), dependabot automerge, the manual live-test PR (`permissions: {}` default);
- `wasm-pack build` ×3 (helpers version-pinned by Cargo.lock; no hash surface) and `npm install -g <local path>` ×2 (already verified by `npm ci` lockfile integrity);
- the committed `ctf-engine/dist` wasm (docs.yml rebuilds from source on deploy; `just vault` convenience copy);
- the three `nucleus/*` findings on `examples/` (scanner fixtures asserted by scan.yml).

actionlint clean on every touched workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZaH5waz88vL1qfNpFNfZ4
