### PR TITLE
ci(runner): rustup's mutable state is per pod; only toolchains are shared (image 0.1.2)

### DIFF
--- a/docker/Dockerfile.runner
+++ b/docker/Dockerfile.runner
@@ -91,7 +91,7 @@ RUN set -eux; \
     cargo install cargo-zigbuild --version ${CARGO_ZIGBUILD_VERSION} --locked; \
     rm -rf /home/runner/.cargo/registry /home/runner/.cargo/git /home/runner/.cargo/.package-cache; \
     mkdir -p /home/runner/.cargo/registry /home/runner/.cargo/git; \
-    cargo dylint --version; cargo audit --version; cargo llvm-cov --version; cargo hack --version; cargo nextest --version; cargo deny --version; cargo zigbuild --version
+    cargo dylint --version; cargo audit --version; cargo llvm-cov --version; cargo hack --version; cargo nextest --version; cargo deny --version; cargo-zigbuild --version
 
 
 # ── Pure-arm64 CI (2026-09-05): what used to keep lanes on hosted x86 ─────────

--- a/docker/Dockerfile.runner
+++ b/docker/Dockerfile.runner
@@ -45,8 +45,9 @@ RUN set -eux; \
 # ~/.cargo/bin is shared between pods: the first cohort runs shared them on a
 # host-path mount and one job's `rustup override`, plus a concurrent reinstall
 # of the rustup binary, intermittently broke every other job ("rustup: command
-# not found", wrong toolchain). Only the cargo registry/git caches and the
-# sccache/Mathlib stores are mounted (values.yaml). Everything the workflows
+# not found", wrong toolchain). Only the immutable cargo caches (registry
+# cache + index, git db) and the sccache/Mathlib stores are mounted
+# (values.yaml); registry/src is extracted per pod. Everything the workflows
 # pin is here: 1.96.1 (rust-toolchain.toml), stable, 1.95/1.93 (MSRV and Kani
 # floors), the dylint nightly with rustc-dev, and the musl/wasm targets.
 USER runner

--- a/docker/Dockerfile.runner
+++ b/docker/Dockerfile.runner
@@ -10,7 +10,7 @@
 # k8s/ci-runner/warm.sh ahead of time.
 #
 # Build for the node's own architecture (arm64 today):
-#   podman build -f docker/Dockerfile.runner -t localhost/nucleus-ci-runner:0.2.1 .
+#   podman build -f docker/Dockerfile.runner -t localhost/nucleus-ci-runner:0.2.2 .
 # then import into k3s's containerd (k8s/ci-runner/README.md).
 FROM ghcr.io/actions/actions-runner:2.337.0
 
@@ -24,7 +24,8 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         build-essential clang lld llvm pkg-config cmake \
         libssl-dev protobuf-compiler musl-tools e2fsprogs \
-        git zstd xz-utils python3 python-is-python3 ca-certificates \
+        git zstd xz-utils python3 python-is-python3 python3-requests ca-certificates \
+        swtpm tpm2-tools \
     && rm -rf /var/lib/apt/lists/*
 
 # sccache: the cross-job compile cache (RUSTC_WRAPPER=sccache, store on the
@@ -75,16 +76,62 @@ RUN set -eux; \
 # image rebuild is a deliberate bump, not a drift.
 ARG CARGO_DYLINT_VERSION=6.0.1
 ARG CARGO_AUDIT_VERSION=0.22.0
-ARG CARGO_LLVM_COV_VERSION=0.6.20
-ARG CARGO_HACK_VERSION=0.6.38
-ARG CARGO_NEXTEST_VERSION=0.9.104
+ARG CARGO_LLVM_COV_VERSION=0.9.0
+ARG CARGO_HACK_VERSION=0.6.45
+ARG CARGO_NEXTEST_VERSION=0.9.143
+ARG CARGO_DENY_VERSION=0.20.2
+ARG CARGO_ZIGBUILD_VERSION=0.23.4
 RUN set -eux; \
     cargo install cargo-dylint dylint-link --version ${CARGO_DYLINT_VERSION} --locked; \
     cargo +stable install cargo-audit --version ${CARGO_AUDIT_VERSION} --locked --no-default-features; \
     cargo install cargo-llvm-cov --version ${CARGO_LLVM_COV_VERSION} --locked; \
     cargo install cargo-hack --version ${CARGO_HACK_VERSION} --locked; \
     cargo install cargo-nextest --version ${CARGO_NEXTEST_VERSION} --locked; \
+    cargo install cargo-deny --version ${CARGO_DENY_VERSION} --locked; \
+    cargo install cargo-zigbuild --version ${CARGO_ZIGBUILD_VERSION} --locked; \
     rm -rf /home/runner/.cargo/registry /home/runner/.cargo/git /home/runner/.cargo/.package-cache; \
     mkdir -p /home/runner/.cargo/registry /home/runner/.cargo/git; \
-    cargo dylint --version; cargo audit --version; cargo llvm-cov --version; cargo hack --version; cargo nextest --version
+    cargo dylint --version; cargo audit --version; cargo llvm-cov --version; cargo hack --version; cargo nextest --version; cargo deny --version; cargo zigbuild --version
 
+
+# ── Pure-arm64 CI (2026-09-05): what used to keep lanes on hosted x86 ─────────
+#
+# zig: a C cross-compiler with bundled musl for every target, so the x86_64
+# musl type-check (`cargo zigbuild --target x86_64-unknown-linux-musl`) runs
+# here instead of on a hosted x86 runner that had x86_64-linux-musl-gcc.
+ARG ZIG_VERSION=0.16.0
+ARG ZIG_SHA256=ea4b09bfb22ec6f6
+USER root
+RUN set -eux; \
+    curl -fsSL "https://ziglang.org/download/${ZIG_VERSION}/zig-aarch64-linux-${ZIG_VERSION}.tar.xz" -o /tmp/zig.tar.xz; \
+    echo "$(sha256sum /tmp/zig.tar.xz | cut -c1-16)" | grep -qx "${ZIG_SHA256}"; \
+    mkdir -p /opt/zig && tar xJf /tmp/zig.tar.xz -C /opt/zig --strip-components=1; \
+    ln -s /opt/zig/zig /usr/local/bin/zig; rm -f /tmp/zig.tar.xz; zig version
+
+# Charon + Aeneas (the Rust → Lean extraction lanes) at the workflows' pins:
+# the release tarball bundles `aeneas`, `charon`, `charon-driver` and the
+# `rust-toolchain` Charon drives; Charon's nightly (with rustc-dev) is baked
+# next to the others so no job downloads a toolchain.
+ARG AENEAS_RELEASE=nightly-2026.06.10
+ARG CHARON_NIGHTLY=nightly-2026-06-01
+RUN set -eux; \
+    curl -fsSL "https://github.com/AeneasVerif/aeneas/releases/download/${AENEAS_RELEASE}/aeneas-linux-aarch64.tar.gz" -o /tmp/aeneas.tar.gz; \
+    mkdir -p /opt/aeneas && tar xzf /tmp/aeneas.tar.gz -C /opt/aeneas; rm -f /tmp/aeneas.tar.gz; \
+    chown -R runner:runner /opt/aeneas; /opt/aeneas/aeneas -version
+USER runner
+RUN set -eux; \
+    rustup toolchain install ${CHARON_NIGHTLY} --profile minimal -c rustc-dev -c llvm-tools-preview -c rust-src; \
+    rustup target add x86_64-unknown-linux-musl --toolchain stable
+
+# elan + the one Lean toolchain every lean project pins (lean-toolchain files),
+# per runner user like rustup: the Lean jobs stop downloading a 300 MB
+# toolchain each run, and the arch-blind cache key that once restored an x86
+# toolchain over an arm64 mount has nothing left to restore.
+ARG LEAN_TOOLCHAIN=leanprover/lean4:v4.30.0-rc2
+ARG ELAN_VERSION=v4.2.4
+ENV ELAN_HOME=/home/runner/.elan \
+    PATH=/home/runner/.elan/bin:/home/runner/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+RUN set -eux; \
+    curl -fsSL "https://raw.githubusercontent.com/leanprover/elan/${ELAN_VERSION}/elan-init.sh" -o /tmp/elan-init.sh; \
+    sh /tmp/elan-init.sh -y --no-modify-path --default-toolchain "${LEAN_TOOLCHAIN}"; \
+    rm -f /tmp/elan-init.sh; lean --version; lake --version

--- a/docker/Dockerfile.runner
+++ b/docker/Dockerfile.runner
@@ -24,7 +24,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         build-essential clang lld llvm pkg-config cmake \
         libssl-dev protobuf-compiler musl-tools e2fsprogs \
-        git zstd xz-utils python3 ca-certificates \
+        git zstd xz-utils python3 python-is-python3 ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
 # sccache: the cross-job compile cache (RUSTC_WRAPPER=sccache, store on the

--- a/docker/Dockerfile.runner
+++ b/docker/Dockerfile.runner
@@ -10,7 +10,7 @@
 # k8s/ci-runner/warm.sh ahead of time.
 #
 # Build for the node's own architecture (arm64 today):
-#   podman build -f docker/Dockerfile.runner -t localhost/nucleus-ci-runner:0.2.2 .
+#   podman build -f docker/Dockerfile.runner -t localhost/nucleus-ci-runner:0.2.3 .
 # then import into k3s's containerd (k8s/ci-runner/README.md).
 FROM ghcr.io/actions/actions-runner:2.337.0
 
@@ -143,3 +143,15 @@ RUN set -eux; \
     curl -fsSL "https://raw.githubusercontent.com/leanprover/elan/${ELAN_VERSION}/elan-init.sh" -o /tmp/elan-init.sh; \
     sh /tmp/elan-init.sh -y --no-modify-path --default-toolchain "${LEAN_TOOLCHAIN}"; \
     rm -f /tmp/elan-init.sh; lean --version; lake --version
+
+# Late layer (cheap to rebuild): the small CLIs individual jobs reach for.
+# xxd — scripts/tpm-credential-activation-check.sh; gh — release downloads
+# the hosted path uses and any `gh api` a gate script makes.
+USER root
+RUN set -eux; \
+    apt-get update; apt-get install -y --no-install-recommends xxd; \
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg -o /usr/share/keyrings/githubcli-archive-keyring.gpg; \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list; \
+    apt-get update; apt-get install -y --no-install-recommends gh; \
+    rm -rf /var/lib/apt/lists/*; gh --version | head -1; xxd -v
+USER runner

--- a/docker/Dockerfile.runner
+++ b/docker/Dockerfile.runner
@@ -10,7 +10,7 @@
 # k8s/ci-runner/warm.sh ahead of time.
 #
 # Build for the node's own architecture (arm64 today):
-#   podman build -f docker/Dockerfile.runner -t localhost/nucleus-ci-runner:0.2.4 .
+#   podman build -f docker/Dockerfile.runner -t localhost/nucleus-ci-runner:0.2.5 .
 # then import into k3s's containerd (k8s/ci-runner/README.md).
 FROM ghcr.io/actions/actions-runner:2.337.0
 
@@ -166,3 +166,17 @@ RUN set -eux; \
     printf '#!/bin/sh\nexec cc -fuse-ld=lld "$@"\n' > /usr/local/bin/cc-lld; chmod 0755 /usr/local/bin/cc-lld; \
     ls /usr/lib/aarch64-linux-gnu/libpython3*.so >/dev/null; cc-lld --version | head -1
 USER runner
+
+# bc — the Aeneas lanes' axiom-audit script does arithmetic with it.
+# leantar — the aarch64 Lean release tarball ships an x86-64 `leantar`
+# (Mathlib's `lake exe cache get` then dies with a shell "Syntax error");
+# replace it with the aarch64 build from leangz.
+ARG LEANTAR_VERSION=v0.1.20
+USER root
+RUN set -eux; apt-get update; apt-get install -y --no-install-recommends bc; rm -rf /var/lib/apt/lists/*
+USER runner
+RUN set -eux; \
+    tc=/home/runner/.elan/toolchains/leanprover--lean4---v4.30.0-rc2/bin; \
+    curl -fsSL "https://github.com/digama0/leangz/releases/download/${LEANTAR_VERSION}/leantar-${LEANTAR_VERSION}-aarch64-unknown-linux-musl.tar.gz" | tar xz -C /tmp; \
+    install -m 0755 "$(find /tmp -name leantar -type f | head -1)" "$tc/leantar"; \
+    "$tc/leantar" --version; rm -rf /tmp/leantar*

--- a/docker/Dockerfile.runner
+++ b/docker/Dockerfile.runner
@@ -164,5 +164,5 @@ USER root
 RUN set -eux; \
     apt-get update; apt-get install -y --no-install-recommends python3-dev; rm -rf /var/lib/apt/lists/*; \
     printf '#!/bin/sh\nexec cc -fuse-ld=lld "$@"\n' > /usr/local/bin/cc-lld; chmod 0755 /usr/local/bin/cc-lld; \
-    python3-config --libs | grep -q python3; cc-lld --version | head -1
+    ls /usr/lib/aarch64-linux-gnu/libpython3*.so >/dev/null; cc-lld --version | head -1
 USER runner

--- a/docker/Dockerfile.runner
+++ b/docker/Dockerfile.runner
@@ -10,7 +10,7 @@
 # k8s/ci-runner/warm.sh ahead of time.
 #
 # Build for the node's own architecture (arm64 today):
-#   podman build -f docker/Dockerfile.runner -t localhost/nucleus-ci-runner:0.2.3 .
+#   podman build -f docker/Dockerfile.runner -t localhost/nucleus-ci-runner:0.2.4 .
 # then import into k3s's containerd (k8s/ci-runner/README.md).
 FROM ghcr.io/actions/actions-runner:2.337.0
 
@@ -154,4 +154,15 @@ RUN set -eux; \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list; \
     apt-get update; apt-get install -y --no-install-recommends gh; \
     rm -rf /var/lib/apt/lists/*; gh --version | head -1; xxd -v
+USER runner
+
+# python3-dev: the Python SDK's pyo3 tests link -lpython3.12 (first
+# merge-group run of #2617 failed on it). cc-lld: a linker wrapper the pod's
+# cargo config names as `linker`, so lld is used even by jobs that set
+# RUSTFLAGS (which overrides config rustflags, e.g. `RUSTFLAGS: -D warnings`).
+USER root
+RUN set -eux; \
+    apt-get update; apt-get install -y --no-install-recommends python3-dev; rm -rf /var/lib/apt/lists/*; \
+    printf '#!/bin/sh\nexec cc -fuse-ld=lld "$@"\n' > /usr/local/bin/cc-lld; chmod 0755 /usr/local/bin/cc-lld; \
+    python3-config --libs | grep -q python3; cc-lld --version | head -1
 USER runner

--- a/docker/Dockerfile.runner
+++ b/docker/Dockerfile.runner
@@ -121,7 +121,7 @@ RUN set -eux; \
     # the x86-64 dynamic loader (/lib64/ld-linux-x86-64.so.2 — a packaging
     # slip in the release); point them at the real one.
     for b in charon charon-driver; do patchelf --set-interpreter /lib/ld-linux-aarch64.so.1 /opt/aeneas/$b; done; \
-    chown -R runner:runner /opt/aeneas; /opt/aeneas/aeneas -version; /opt/aeneas/charon --version
+    chown -R runner:runner /opt/aeneas; /opt/aeneas/aeneas -version; /opt/aeneas/charon version
 USER runner
 RUN set -eux; \
     # Everything the tarball's rust-toolchain file names, so rustup has nothing

--- a/docker/Dockerfile.runner
+++ b/docker/Dockerfile.runner
@@ -25,7 +25,7 @@ RUN apt-get update \
         build-essential clang lld llvm pkg-config cmake \
         libssl-dev protobuf-compiler musl-tools e2fsprogs \
         git zstd xz-utils python3 python-is-python3 python3-requests ca-certificates \
-        swtpm tpm2-tools \
+        swtpm tpm2-tools patchelf \
     && rm -rf /var/lib/apt/lists/*
 
 # sccache: the cross-job compile cache (RUSTC_WRAPPER=sccache, store on the
@@ -117,10 +117,18 @@ ARG CHARON_NIGHTLY=nightly-2026-06-01
 RUN set -eux; \
     curl -fsSL "https://github.com/AeneasVerif/aeneas/releases/download/${AENEAS_RELEASE}/aeneas-linux-aarch64.tar.gz" -o /tmp/aeneas.tar.gz; \
     mkdir -p /opt/aeneas && tar xzf /tmp/aeneas.tar.gz -C /opt/aeneas; rm -f /tmp/aeneas.tar.gz; \
-    chown -R runner:runner /opt/aeneas; /opt/aeneas/aeneas -version
+    # Upstream's aarch64 charon/charon-driver are AArch64 code that REQUEST
+    # the x86-64 dynamic loader (/lib64/ld-linux-x86-64.so.2 — a packaging
+    # slip in the release); point them at the real one.
+    for b in charon charon-driver; do patchelf --set-interpreter /lib/ld-linux-aarch64.so.1 /opt/aeneas/$b; done; \
+    chown -R runner:runner /opt/aeneas; /opt/aeneas/aeneas -version; /opt/aeneas/charon --version
 USER runner
 RUN set -eux; \
-    rustup toolchain install ${CHARON_NIGHTLY} --profile minimal -c rustc-dev -c llvm-tools-preview -c rust-src; \
+    # Everything the tarball's rust-toolchain file names, so rustup has nothing
+    # to auto-install when charon selects it (miri + the cross targets included).
+    rustup toolchain install ${CHARON_NIGHTLY} --profile minimal -c rustc-dev -c llvm-tools-preview -c rust-src -c miri \
+      -t x86_64-unknown-linux-gnu -t x86_64-apple-darwin -t x86_64-pc-windows-msvc -t aarch64-apple-darwin \
+      -t i686-unknown-linux-gnu -t powerpc64-unknown-linux-gnu -t riscv64gc-unknown-none-elf; \
     rustup target add x86_64-unknown-linux-musl --toolchain stable
 
 # elan + the one Lean toolchain every lean project pins (lean-toolchain files),

--- a/docker/Dockerfile.runner
+++ b/docker/Dockerfile.runner
@@ -10,7 +10,7 @@
 # k8s/ci-runner/warm.sh ahead of time.
 #
 # Build for the node's own architecture (arm64 today):
-#   podman build -f docker/Dockerfile.runner -t localhost/nucleus-ci-runner:0.1.2 .
+#   podman build -f docker/Dockerfile.runner -t localhost/nucleus-ci-runner:0.2.0 .
 # then import into k3s's containerd (k8s/ci-runner/README.md).
 FROM ghcr.io/actions/actions-runner:2.337.0
 
@@ -41,29 +41,27 @@ RUN set -eux; \
       | tar xz -C /usr/local/bin just; \
     sccache --version; just --version
 
-# The runner does NOT hand its own PATH to job steps: it reads `.path` (and
-# `.env`) from its root directory and uses that as every step's PATH — which is
-# how the hosted images expose their toolchains. Without this file the first
-# cohort run failed four jobs with `cargo: command not found` / `rustup: command
-# not found` / sccache unreachable as RUSTC_WRAPPER.
-RUN printf '%s\n' "/home/runner/.cargo/bin:/home/runner/.elan/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" > /home/runner/.path \
-    && printf '%s\n' "RUSTUP_HOME=/home/runner/.rustup" "CARGO_HOME=/home/runner/.cargo" "ELAN_HOME=/home/runner/.elan" > /home/runner/.env \
-    && chown runner:runner /home/runner/.path /home/runner/.env
-
-# rustup's mutable state (settings.toml: default toolchain, per-directory
-# overrides) is PER POD, baked here; only `toolchains/` is a shared mount. The
-# first cohort run shared all of ~/.rustup and one job's `rustup override set
-# 1.93` in the checkout directory leaked rustc 1.93 into every other job on
-# every runner (wasm build, parity, clippy ceiling all failed on the wrong
-# toolchain).
-RUN mkdir -p /home/runner/.rustup/toolchains /home/runner/.rustup/downloads /home/runner/.rustup/tmp /home/runner/.rustup/update-hashes \
-    && printf '%s\n' 'version = "12"' 'default_toolchain = "1.96.1-aarch64-unknown-linux-gnu"' 'profile = "default"' > /home/runner/.rustup/settings.toml \
-    && chown -R runner:runner /home/runner/.rustup
-
+# Toolchains are IN THE IMAGE, per runner user, and nothing under ~/.rustup or
+# ~/.cargo/bin is shared between pods: the first cohort runs shared them on a
+# host-path mount and one job's `rustup override`, plus a concurrent reinstall
+# of the rustup binary, intermittently broke every other job ("rustup: command
+# not found", wrong toolchain). Only the cargo registry/git caches and the
+# sccache/Mathlib stores are mounted (values.yaml). Everything the workflows
+# pin is here: 1.96.1 (rust-toolchain.toml), stable, 1.95/1.93 (MSRV and Kani
+# floors), the dylint nightly with rustc-dev, and the musl/wasm targets.
 USER runner
-# The persistent mounts land here; the PATH entries make whatever they hold
-# visible to the runner process itself (steps get theirs from `.path` above).
 ENV RUSTUP_HOME=/home/runner/.rustup \
     CARGO_HOME=/home/runner/.cargo \
-    ELAN_HOME=/home/runner/.elan \
-    PATH=/home/runner/.cargo/bin:/home/runner/.elan/bin:/usr/local/bin:/usr/bin:/bin
+    PATH=/home/runner/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+RUN set -eux; \
+    curl -fsSL https://sh.rustup.rs | sh -s -- -y --no-modify-path --profile minimal \
+      --default-toolchain 1.96.1 -c clippy -c rustfmt; \
+    rustup toolchain install stable 1.95 1.93 --profile minimal -c clippy -c rustfmt; \
+    rustup toolchain install nightly-2026-04-16 --profile minimal -c rustc-dev -c llvm-tools-preview -c clippy -c rustfmt; \
+    rustup target add x86_64-unknown-linux-musl wasm32-unknown-unknown --toolchain 1.96.1; \
+    rustup target add wasm32-unknown-unknown --toolchain stable; \
+    rustup default 1.96.1; \
+    rustc --version; cargo --version; \
+    rm -rf /home/runner/.cargo/registry /home/runner/.cargo/git; \
+    mkdir -p /home/runner/.cargo/registry /home/runner/.cargo/git /home/runner/.cache
+

--- a/docker/Dockerfile.runner
+++ b/docker/Dockerfile.runner
@@ -10,7 +10,7 @@
 # k8s/ci-runner/warm.sh ahead of time.
 #
 # Build for the node's own architecture (arm64 today):
-#   podman build -f docker/Dockerfile.runner -t localhost/nucleus-ci-runner:0.1.1 .
+#   podman build -f docker/Dockerfile.runner -t localhost/nucleus-ci-runner:0.1.2 .
 # then import into k3s's containerd (k8s/ci-runner/README.md).
 FROM ghcr.io/actions/actions-runner:2.337.0
 
@@ -49,6 +49,16 @@ RUN set -eux; \
 RUN printf '%s\n' "/home/runner/.cargo/bin:/home/runner/.elan/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" > /home/runner/.path \
     && printf '%s\n' "RUSTUP_HOME=/home/runner/.rustup" "CARGO_HOME=/home/runner/.cargo" "ELAN_HOME=/home/runner/.elan" > /home/runner/.env \
     && chown runner:runner /home/runner/.path /home/runner/.env
+
+# rustup's mutable state (settings.toml: default toolchain, per-directory
+# overrides) is PER POD, baked here; only `toolchains/` is a shared mount. The
+# first cohort run shared all of ~/.rustup and one job's `rustup override set
+# 1.93` in the checkout directory leaked rustc 1.93 into every other job on
+# every runner (wasm build, parity, clippy ceiling all failed on the wrong
+# toolchain).
+RUN mkdir -p /home/runner/.rustup/toolchains /home/runner/.rustup/downloads /home/runner/.rustup/tmp /home/runner/.rustup/update-hashes \
+    && printf '%s\n' 'version = "12"' 'default_toolchain = "1.96.1-aarch64-unknown-linux-gnu"' 'profile = "default"' > /home/runner/.rustup/settings.toml \
+    && chown -R runner:runner /home/runner/.rustup
 
 USER runner
 # The persistent mounts land here; the PATH entries make whatever they hold

--- a/docker/Dockerfile.runner
+++ b/docker/Dockerfile.runner
@@ -10,7 +10,7 @@
 # k8s/ci-runner/warm.sh ahead of time.
 #
 # Build for the node's own architecture (arm64 today):
-#   podman build -f docker/Dockerfile.runner -t localhost/nucleus-ci-runner:0.2.0 .
+#   podman build -f docker/Dockerfile.runner -t localhost/nucleus-ci-runner:0.2.1 .
 # then import into k3s's containerd (k8s/ci-runner/README.md).
 FROM ghcr.io/actions/actions-runner:2.337.0
 
@@ -65,4 +65,26 @@ RUN set -eux; \
     rustc --version; cargo --version; \
     rm -rf /home/runner/.cargo/registry /home/runner/.cargo/git; \
     mkdir -p /home/runner/.cargo/registry /home/runner/.cargo/git /home/runner/.cache
+
+# The cargo tools the routed workflows install at job start, baked instead:
+# `cargo xtask ci-timings` on PR #2617 showed "Install cargo-dylint" at 1.9 min
+# in each of four dylint jobs and cargo-llvm-cov / cargo-hack / cargo-audit
+# installs of 1–2.5 min per job — runner time spent rebuilding the same
+# binaries every PR. Versions mirror the workflows' pins (dylint 6.0.1,
+# cargo-audit 0.22.0); the rest are `--locked` at the versions below so an
+# image rebuild is a deliberate bump, not a drift.
+ARG CARGO_DYLINT_VERSION=6.0.1
+ARG CARGO_AUDIT_VERSION=0.22.0
+ARG CARGO_LLVM_COV_VERSION=0.6.20
+ARG CARGO_HACK_VERSION=0.6.38
+ARG CARGO_NEXTEST_VERSION=0.9.104
+RUN set -eux; \
+    cargo install cargo-dylint dylint-link --version ${CARGO_DYLINT_VERSION} --locked; \
+    cargo +stable install cargo-audit --version ${CARGO_AUDIT_VERSION} --locked --no-default-features; \
+    cargo install cargo-llvm-cov --version ${CARGO_LLVM_COV_VERSION} --locked; \
+    cargo install cargo-hack --version ${CARGO_HACK_VERSION} --locked; \
+    cargo install cargo-nextest --version ${CARGO_NEXTEST_VERSION} --locked; \
+    rm -rf /home/runner/.cargo/registry /home/runner/.cargo/git /home/runner/.cargo/.package-cache; \
+    mkdir -p /home/runner/.cargo/registry /home/runner/.cargo/git; \
+    cargo dylint --version; cargo audit --version; cargo llvm-cov --version; cargo hack --version; cargo nextest --version
 

--- a/k8s/ci-runner/README.md
+++ b/k8s/ci-runner/README.md
@@ -11,13 +11,16 @@ back to hosted runners.
 
 | Piece | Location |
 |---|---|
-| Runner image | `docker/Dockerfile.runner` (OS deps + sccache + just; nothing else) |
+| Runner image | `docker/Dockerfile.runner` (OS deps, sccache, just, and every pinned Rust toolchain baked in per runner user) |
 | Scale-set values | `values.yaml` (no credential; references the `gh-token` secret) |
-| Persistent mounts | `/var/lib/nucleus-ci/{rustup,cargo,cache,elan}` on the node, uid 1001 |
+| Persistent mounts | `/var/lib/nucleus-ci/cargo/{registry,git}` and `/var/lib/nucleus-ci/cache` on the node, uid 1001 (caches only) |
 | Warm-up | `warm.sh` (installs rustup 1.96.1 + elan/Lean v4.30.0-rc2 into the mounts) |
 
-The toolchains and caches are on the mounts, not in the image, so an image
-rebuild never invalidates a cache and a toolchain bump never needs one.
+Toolchains are in the image and nothing mutable under `~/.rustup` or
+`~/.cargo/bin` is shared: the first cohort runs shared them and one job's
+`rustup override`, plus a concurrent rustup reinstall, intermittently broke
+every other job. Only the caches are on the mounts, so an image rebuild never
+invalidates a cache.
 `sccache` (`RUSTC_WRAPPER`) is the cross-job compile cache; the cargo registry
 and the Mathlib `lake exe cache` store are persistent for the same reason.
 
@@ -28,8 +31,8 @@ and the Mathlib `lake exe cache` store are persistent for the same reason.
 sudo apt-get install -y podman
 
 # 1. build the image for the node's architecture and hand it to k3s
-podman build -f docker/Dockerfile.runner -t localhost/nucleus-ci-runner:0.1.2 .
-podman save localhost/nucleus-ci-runner:0.1.2 | sudo k3s ctr -n k8s.io images import -
+podman build -f docker/Dockerfile.runner -t localhost/nucleus-ci-runner:0.2.0 .
+podman save localhost/nucleus-ci-runner:0.2.0 | sudo k3s ctr -n k8s.io images import -
 
 # 2. persistent mounts + toolchains
 sudo bash k8s/ci-runner/warm.sh

--- a/k8s/ci-runner/README.md
+++ b/k8s/ci-runner/README.md
@@ -28,8 +28,8 @@ and the Mathlib `lake exe cache` store are persistent for the same reason.
 sudo apt-get install -y podman
 
 # 1. build the image for the node's architecture and hand it to k3s
-podman build -f docker/Dockerfile.runner -t localhost/nucleus-ci-runner:0.1.1 .
-podman save localhost/nucleus-ci-runner:0.1.1 | sudo k3s ctr -n k8s.io images import -
+podman build -f docker/Dockerfile.runner -t localhost/nucleus-ci-runner:0.1.2 .
+podman save localhost/nucleus-ci-runner:0.1.2 | sudo k3s ctr -n k8s.io images import -
 
 # 2. persistent mounts + toolchains
 sudo bash k8s/ci-runner/warm.sh

--- a/k8s/ci-runner/README.md
+++ b/k8s/ci-runner/README.md
@@ -33,8 +33,8 @@ and the Mathlib `lake exe cache` store are persistent for the same reason.
 sudo apt-get install -y podman
 
 # 1. build the image for the node's architecture and hand it to k3s
-podman build -f docker/Dockerfile.runner -t localhost/nucleus-ci-runner:0.2.4 .
-podman save localhost/nucleus-ci-runner:0.2.4 | sudo k3s ctr -n k8s.io images import -
+podman build -f docker/Dockerfile.runner -t localhost/nucleus-ci-runner:0.2.5 .
+podman save localhost/nucleus-ci-runner:0.2.5 | sudo k3s ctr -n k8s.io images import -
 
 # 2. persistent mounts + toolchains
 sudo bash k8s/ci-runner/warm.sh

--- a/k8s/ci-runner/README.md
+++ b/k8s/ci-runner/README.md
@@ -33,8 +33,8 @@ and the Mathlib `lake exe cache` store are persistent for the same reason.
 sudo apt-get install -y podman
 
 # 1. build the image for the node's architecture and hand it to k3s
-podman build -f docker/Dockerfile.runner -t localhost/nucleus-ci-runner:0.2.2 .
-podman save localhost/nucleus-ci-runner:0.2.2 | sudo k3s ctr -n k8s.io images import -
+podman build -f docker/Dockerfile.runner -t localhost/nucleus-ci-runner:0.2.3 .
+podman save localhost/nucleus-ci-runner:0.2.3 | sudo k3s ctr -n k8s.io images import -
 
 # 2. persistent mounts + toolchains
 sudo bash k8s/ci-runner/warm.sh

--- a/k8s/ci-runner/README.md
+++ b/k8s/ci-runner/README.md
@@ -15,6 +15,8 @@ back to hosted runners.
 | Scale-set values | `values.yaml` (no credential; references the `gh-token` secret) |
 | Persistent mounts | `/var/lib/nucleus-ci/cargo/registry/{cache,index}` and `/var/lib/nucleus-ci/cache` on the node, uid 1001 (immutable caches only; `registry/src` and the whole cargo git db are per pod) |
 | Warm-up | `warm.sh` (installs rustup 1.96.1 + elan/Lean v4.30.0-rc2 into the mounts) |
+| Job hooks | `hooks/job-started.sh`, `hooks/job-completed.sh` (ConfigMap `runner-hooks`; sccache hit rate and cgroup peaks per job) |
+| Timing report | `cargo xtask ci-timings --sha <commit>` (per-label run/queue distributions, critical path, longest steps) |
 
 Toolchains are in the image and nothing mutable under `~/.rustup` or
 `~/.cargo/bin` is shared: the first cohort runs shared them and one job's
@@ -37,7 +39,12 @@ podman save localhost/nucleus-ci-runner:0.2.0 | sudo k3s ctr -n k8s.io images im
 # 2. persistent mounts + toolchains
 sudo bash k8s/ci-runner/warm.sh
 
-# 3. the scale set (controller `arc` in arc-systems is already installed)
+# 3. the job hooks (per-job sccache hit rate + pod resource peaks in every job log)
+sudo env KUBECONFIG=/etc/rancher/k3s/k3s.yaml k3s kubectl create configmap runner-hooks \
+  -n arc-runners --from-file=k8s/ci-runner/hooks/ --dry-run=client -o yaml \
+  | sudo env KUBECONFIG=/etc/rancher/k3s/k3s.yaml k3s kubectl apply -f -
+
+# 4. the scale set (controller `arc` in arc-systems is already installed)
 sudo env KUBECONFIG=/etc/rancher/k3s/k3s.yaml helm upgrade --install nucleus-k3s \
   oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set \
   --version 0.14.2 -n arc-runners -f k8s/ci-runner/values.yaml

--- a/k8s/ci-runner/README.md
+++ b/k8s/ci-runner/README.md
@@ -13,7 +13,7 @@ back to hosted runners.
 |---|---|
 | Runner image | `docker/Dockerfile.runner` (OS deps, sccache, just, and every pinned Rust toolchain baked in per runner user) |
 | Scale-set values | `values.yaml` (no credential; references the `gh-token` secret) |
-| Persistent mounts | `/var/lib/nucleus-ci/cargo/registry/{cache,index}`, `/var/lib/nucleus-ci/cargo/git/db` and `/var/lib/nucleus-ci/cache` on the node, uid 1001 (immutable caches only; `registry/src` and `git/checkouts` are per pod) |
+| Persistent mounts | `/var/lib/nucleus-ci/cargo/registry/{cache,index}` and `/var/lib/nucleus-ci/cache` on the node, uid 1001 (immutable caches only; `registry/src` and the whole cargo git db are per pod) |
 | Warm-up | `warm.sh` (installs rustup 1.96.1 + elan/Lean v4.30.0-rc2 into the mounts) |
 
 Toolchains are in the image and nothing mutable under `~/.rustup` or

--- a/k8s/ci-runner/README.md
+++ b/k8s/ci-runner/README.md
@@ -40,6 +40,10 @@ podman save localhost/nucleus-ci-runner:0.2.2 | sudo k3s ctr -n k8s.io images im
 sudo bash k8s/ci-runner/warm.sh
 
 # 3. the job hooks (per-job sccache hit rate + pod resource peaks in every job log)
+#    and the per-pod cargo config (lld for the host target; see cargo-config.toml)
+sudo env KUBECONFIG=/etc/rancher/k3s/k3s.yaml k3s kubectl create configmap runner-cargo-config \
+  -n arc-runners --from-file=config.toml=k8s/ci-runner/cargo-config.toml --dry-run=client -o yaml \
+  | sudo env KUBECONFIG=/etc/rancher/k3s/k3s.yaml k3s kubectl apply -f -
 sudo env KUBECONFIG=/etc/rancher/k3s/k3s.yaml k3s kubectl create configmap runner-hooks \
   -n arc-runners --from-file=k8s/ci-runner/hooks/ --dry-run=client -o yaml \
   | sudo env KUBECONFIG=/etc/rancher/k3s/k3s.yaml k3s kubectl apply -f -

--- a/k8s/ci-runner/README.md
+++ b/k8s/ci-runner/README.md
@@ -33,8 +33,8 @@ and the Mathlib `lake exe cache` store are persistent for the same reason.
 sudo apt-get install -y podman
 
 # 1. build the image for the node's architecture and hand it to k3s
-podman build -f docker/Dockerfile.runner -t localhost/nucleus-ci-runner:0.2.3 .
-podman save localhost/nucleus-ci-runner:0.2.3 | sudo k3s ctr -n k8s.io images import -
+podman build -f docker/Dockerfile.runner -t localhost/nucleus-ci-runner:0.2.4 .
+podman save localhost/nucleus-ci-runner:0.2.4 | sudo k3s ctr -n k8s.io images import -
 
 # 2. persistent mounts + toolchains
 sudo bash k8s/ci-runner/warm.sh

--- a/k8s/ci-runner/README.md
+++ b/k8s/ci-runner/README.md
@@ -12,7 +12,7 @@ back to hosted runners.
 | Piece | Location |
 |---|---|
 | Runner image | `docker/Dockerfile.runner` (OS deps, sccache, just, and every pinned Rust toolchain baked in per runner user) |
-| Scale-set values | `values.yaml` (no credential; references the `gh-token` secret) |
+| Scale-set values | `values.yaml` (the `nucleus-k3s` gate pool, 8 small runners) and `values-build.yaml` (the `nucleus-k3s-build` pool, 3 big runners; DERIVED by `render-build-values.sh`, never hand-edited); no credential, both reference the `gh-token` secret |
 | Persistent mounts | `/var/lib/nucleus-ci/cargo/registry/{cache,index}` and `/var/lib/nucleus-ci/cache` on the node, uid 1001 (immutable caches only; `registry/src` and the whole cargo git db are per pod) |
 | Warm-up | `warm.sh` (installs rustup 1.96.1 + elan/Lean v4.30.0-rc2 into the mounts) |
 | Job hooks | `hooks/job-started.sh`, `hooks/job-completed.sh` (ConfigMap `runner-hooks`; sccache hit rate and cgroup peaks per job) |
@@ -33,8 +33,8 @@ and the Mathlib `lake exe cache` store are persistent for the same reason.
 sudo apt-get install -y podman
 
 # 1. build the image for the node's architecture and hand it to k3s
-podman build -f docker/Dockerfile.runner -t localhost/nucleus-ci-runner:0.2.0 .
-podman save localhost/nucleus-ci-runner:0.2.0 | sudo k3s ctr -n k8s.io images import -
+podman build -f docker/Dockerfile.runner -t localhost/nucleus-ci-runner:0.2.1 .
+podman save localhost/nucleus-ci-runner:0.2.1 | sudo k3s ctr -n k8s.io images import -
 
 # 2. persistent mounts + toolchains
 sudo bash k8s/ci-runner/warm.sh
@@ -50,7 +50,13 @@ sudo env KUBECONFIG=/etc/rancher/k3s/k3s.yaml helm upgrade --install nucleus-k3s
   --version 0.14.2 -n arc-runners -f k8s/ci-runner/values.yaml
 ```
 
-Then set the repo variable: `gh variable set CI_RUNNER --body nucleus-k3s`.
+Install the build pool the same way with `-f k8s/ci-runner/values-build.yaml`
+and release name `nucleus-k3s-build`.
+
+Then set the repo variables: `gh variable set CI_RUNNER --body nucleus-k3s` and
+`gh variable set CI_BUILD_RUNNER --body nucleus-k3s-build`. Heavy jobs spell
+`runs-on: ${{ vars.CI_BUILD_RUNNER || vars.CI_RUNNER || 'ubuntu-latest' }}`, so
+unsetting `CI_BUILD_RUNNER` alone folds them back into the gate pool.
 
 ## What runs here and what stays hosted
 

--- a/k8s/ci-runner/README.md
+++ b/k8s/ci-runner/README.md
@@ -33,8 +33,8 @@ and the Mathlib `lake exe cache` store are persistent for the same reason.
 sudo apt-get install -y podman
 
 # 1. build the image for the node's architecture and hand it to k3s
-podman build -f docker/Dockerfile.runner -t localhost/nucleus-ci-runner:0.2.1 .
-podman save localhost/nucleus-ci-runner:0.2.1 | sudo k3s ctr -n k8s.io images import -
+podman build -f docker/Dockerfile.runner -t localhost/nucleus-ci-runner:0.2.2 .
+podman save localhost/nucleus-ci-runner:0.2.2 | sudo k3s ctr -n k8s.io images import -
 
 # 2. persistent mounts + toolchains
 sudo bash k8s/ci-runner/warm.sh

--- a/k8s/ci-runner/README.md
+++ b/k8s/ci-runner/README.md
@@ -13,7 +13,7 @@ back to hosted runners.
 |---|---|
 | Runner image | `docker/Dockerfile.runner` (OS deps, sccache, just, and every pinned Rust toolchain baked in per runner user) |
 | Scale-set values | `values.yaml` (no credential; references the `gh-token` secret) |
-| Persistent mounts | `/var/lib/nucleus-ci/cargo/{registry,git}` and `/var/lib/nucleus-ci/cache` on the node, uid 1001 (caches only) |
+| Persistent mounts | `/var/lib/nucleus-ci/cargo/registry/{cache,index}`, `/var/lib/nucleus-ci/cargo/git/db` and `/var/lib/nucleus-ci/cache` on the node, uid 1001 (immutable caches only; `registry/src` and `git/checkouts` are per pod) |
 | Warm-up | `warm.sh` (installs rustup 1.96.1 + elan/Lean v4.30.0-rc2 into the mounts) |
 
 Toolchains are in the image and nothing mutable under `~/.rustup` or

--- a/k8s/ci-runner/cargo-config.toml
+++ b/k8s/ci-runner/cargo-config.toml
@@ -10,6 +10,9 @@
 # (CARGO_PROFILE_DEV_DEBUG in values.yaml) finished in 6.3 min cold /
 # 3.6 min warm under an 8 GiB limit. lld ships in the runner image.
 [target.aarch64-unknown-linux-gnu]
+# `linker` survives a job-level RUSTFLAGS (which replaces config rustflags);
+# cc-lld is `cc -fuse-ld=lld` from the runner image.
+linker = "cc-lld"
 rustflags = ["-C", "link-arg=-fuse-ld=lld"]
 
 # Dependencies carry no debuginfo at all; workspace crates keep line tables

--- a/k8s/ci-runner/cargo-config.toml
+++ b/k8s/ci-runner/cargo-config.toml
@@ -11,3 +11,10 @@
 # 3.6 min warm under an 8 GiB limit. lld ships in the runner image.
 [target.aarch64-unknown-linux-gnu]
 rustflags = ["-C", "link-arg=-fuse-ld=lld"]
+
+# Dependencies carry no debuginfo at all; workspace crates keep line tables
+# (CARGO_PROFILE_DEV_DEBUG in values.yaml). Each heavy job's per-pod target/
+# measured ~20 GB with line tables everywhere — four concurrent pods filled
+# the node's disk and kubelet evicted the runners for DiskPressure.
+[profile.dev.package."*"]
+debug = false

--- a/k8s/ci-runner/cargo-config.toml
+++ b/k8s/ci-runner/cargo-config.toml
@@ -1,0 +1,13 @@
+# Mounted at /home/runner/.cargo/config.toml on every self-hosted runner pod
+# (ConfigMap `runner-cargo-config`, k8s/ci-runner/values.yaml). Cargo merges
+# this with the repository's .cargo/config.toml; nothing in-repo sets
+# build.rustflags or a target-level rustflags for the host, so this applies.
+#
+# lld instead of GNU ld for the host target: measured 2026-09-05 on the CI
+# node, GNU ld reached 2.75-3.4 GB RSS per test binary with full debuginfo
+# and two parallel links OOM-killed 4.5-7 GiB pods (Tests, Doctests,
+# Mutation Testing). The same build with lld + line-tables debuginfo
+# (CARGO_PROFILE_DEV_DEBUG in values.yaml) finished in 6.3 min cold /
+# 3.6 min warm under an 8 GiB limit. lld ships in the runner image.
+[target.aarch64-unknown-linux-gnu]
+rustflags = ["-C", "link-arg=-fuse-ld=lld"]

--- a/k8s/ci-runner/hooks/job-completed.sh
+++ b/k8s/ci-runner/hooks/job-completed.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# ACTIONS_RUNNER_HOOK_JOB_COMPLETED — runs as a synchronous step at the end of
+# every job on the self-hosted scale set. Prints the job's sccache hit rate
+# (counters zeroed by job-started.sh) and the pod's peak memory, so the two
+# questions a slow job raises — "did the cache help?" and "was it starved?" —
+# are answered in the job log itself, not by exec'ing into a pod that is
+# already gone. Exit 0 always: instrumentation never fails a job.
+set -u
+echo "::group::sccache (this job)"
+SCCACHE_DIR=/home/runner/.cache/sccache sccache --show-stats 2>/dev/null \
+  | grep -E "Compile requests|Cache hits|Cache misses|Non-cacheable|Average" || echo "sccache: no server (job ran no rustc)"
+echo "::endgroup::"
+echo "::group::pod resources"
+echo "memory.peak=$(awk '{printf "%.2fGi", $1/1073741824}' /sys/fs/cgroup/memory.peak 2>/dev/null || echo n/a) memory.max=$(cat /sys/fs/cgroup/memory.max 2>/dev/null || echo n/a)"
+echo "cpu.stat: $(tr '\n' ' ' < /sys/fs/cgroup/cpu.stat 2>/dev/null | cut -c1-160)"
+echo "disk: $(df -h /home/runner/_work 2>/dev/null | tail -1 | awk '{print $3" used of "$2}')"
+echo "::endgroup::"
+exit 0

--- a/k8s/ci-runner/hooks/job-started.sh
+++ b/k8s/ci-runner/hooks/job-started.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# ACTIONS_RUNNER_HOOK_JOB_STARTED — runs as a synchronous step at the start of
+# every job on the self-hosted scale set (k8s/ci-runner/values.yaml mounts it
+# from the `runner-hooks` ConfigMap). Output lands in the job log.
+#
+# Instrumentation, not policy: it records what the pod looks like so a slow
+# job can be read against its environment, and zeroes the sccache counters so
+# the completed hook reports THIS job's hit rate rather than the pod's history.
+set -u
+echo "::group::runner pod"
+echo "pod=$(hostname) nproc=$(nproc) mem=$(awk '/MemTotal/ {printf "%.1fGi", $2/1048576}' /proc/meminfo)"
+echo "cgroup cpu.max=$(cat /sys/fs/cgroup/cpu.max 2>/dev/null || echo n/a) memory.max=$(cat /sys/fs/cgroup/memory.max 2>/dev/null || echo n/a)"
+echo "sccache store: $(du -sh /home/runner/.cache/sccache 2>/dev/null | cut -f1 || echo n/a) at $(date -u +%FT%TZ)"
+echo "::endgroup::"
+SCCACHE_DIR=/home/runner/.cache/sccache sccache --zero-stats >/dev/null 2>&1 || true
+exit 0

--- a/k8s/ci-runner/render-build-values.sh
+++ b/k8s/ci-runner/render-build-values.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Render values-build.yaml (the `nucleus-k3s-build` pool) from values.yaml.
+# Helm replaces YAML lists wholesale, so the build pool cannot be a small
+# overlay on top of the base file: it is the base file with the pool name,
+# runner count, cargo parallelism and resources swapped. Re-run after editing
+# values.yaml; ci checks the two do not drift (k8s/ci-runner/README.md).
+set -euo pipefail
+cd "$(dirname "$0")"
+{
+  cat <<'HDR'
+# DERIVED from values.yaml by k8s/ci-runner/render-build-values.sh — do not
+# hand-edit. The `nucleus-k3s-build` pool: 3 big runners for the compile-class
+# jobs (see values.yaml for the two-pool rationale).
+#
+#   helm upgrade --install nucleus-k3s-build \
+#     oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set \
+#     --version 0.14.2 -n arc-runners -f k8s/ci-runner/values-build.yaml
+HDR
+  sed -e 's/^runnerScaleSetName: nucleus-k3s$/runnerScaleSetName: nucleus-k3s-build/' \
+      -e 's/^maxRunners: 8$/maxRunners: 3/' \
+      -e '/name: CARGO_BUILD_JOBS/{n;s/value: "2"/value: "3"/;}' \
+      -e '/^          requests:$/,/^          limits:$/{s/cpu: "500m"/cpu: "2500m"/;s/memory: 1Gi/memory: 5Gi/;}' \
+      -e '/^          limits:$/,/^        volumeMounts:$/{s/cpu: "2"/cpu: "4"/;s/memory: 3Gi/memory: 8Gi/;}' \
+      values.yaml
+} > values-build.yaml
+echo "rendered values-build.yaml"

--- a/k8s/ci-runner/values-build.yaml
+++ b/k8s/ci-runner/values-build.yaml
@@ -47,7 +47,7 @@ template:
       - name: runner
         # Built from docker/Dockerfile.runner and imported into k3s's
         # containerd (README.md); never pulled from a registry.
-        image: localhost/nucleus-ci-runner:0.2.4
+        image: localhost/nucleus-ci-runner:0.2.5
         imagePullPolicy: Never
         command: ["/home/runner/run.sh"]
         env:

--- a/k8s/ci-runner/values-build.yaml
+++ b/k8s/ci-runner/values-build.yaml
@@ -60,6 +60,11 @@ template:
             value: 30G
           - name: CARGO_INCREMENTAL
             value: "0"
+          # Debuginfo the linker can afford: full DWARF made GNU ld take
+          # 2.75-3.4 GB per test binary and OOM-killed the heavy jobs; line
+          # tables keep panics readable. Pairs with cargo-config.toml (lld).
+          - name: CARGO_PROFILE_DEV_DEBUG
+            value: line-tables-only
           # Two cargo jobs per runner: memory scales with parallel rustc/ld
           # processes, and the limit below is sized for two.
           - name: CARGO_BUILD_JOBS
@@ -96,6 +101,10 @@ template:
           - name: runner-hooks
             mountPath: /home/runner/hooks
             readOnly: true
+          - name: runner-cargo-config
+            mountPath: /home/runner/.cargo/config.toml
+            subPath: config.toml
+            readOnly: true
     volumes:
       # Host-path directories on the k3s node, owned by uid 1001 (the image's
       # `runner` user): created by k8s/ci-runner/README.md's setup step.
@@ -115,3 +124,7 @@ template:
         configMap:
           name: runner-hooks
           defaultMode: 0755
+      # `kubectl create configmap runner-cargo-config --from-file=config.toml=k8s/ci-runner/cargo-config.toml`
+      - name: runner-cargo-config
+        configMap:
+          name: runner-cargo-config

--- a/k8s/ci-runner/values-build.yaml
+++ b/k8s/ci-runner/values-build.yaml
@@ -47,7 +47,7 @@ template:
       - name: runner
         # Built from docker/Dockerfile.runner and imported into k3s's
         # containerd (README.md); never pulled from a registry.
-        image: localhost/nucleus-ci-runner:0.2.2
+        image: localhost/nucleus-ci-runner:0.2.3
         imagePullPolicy: Never
         command: ["/home/runner/run.sh"]
         env:

--- a/k8s/ci-runner/values-build.yaml
+++ b/k8s/ci-runner/values-build.yaml
@@ -47,7 +47,7 @@ template:
       - name: runner
         # Built from docker/Dockerfile.runner and imported into k3s's
         # containerd (README.md); never pulled from a registry.
-        image: localhost/nucleus-ci-runner:0.2.1
+        image: localhost/nucleus-ci-runner:0.2.2
         imagePullPolicy: Never
         command: ["/home/runner/run.sh"]
         env:

--- a/k8s/ci-runner/values-build.yaml
+++ b/k8s/ci-runner/values-build.yaml
@@ -47,7 +47,7 @@ template:
       - name: runner
         # Built from docker/Dockerfile.runner and imported into k3s's
         # containerd (README.md); never pulled from a registry.
-        image: localhost/nucleus-ci-runner:0.2.3
+        image: localhost/nucleus-ci-runner:0.2.4
         imagePullPolicy: Never
         command: ["/home/runner/run.sh"]
         env:

--- a/k8s/ci-runner/values-build.yaml
+++ b/k8s/ci-runner/values-build.yaml
@@ -1,3 +1,10 @@
+# DERIVED from values.yaml by k8s/ci-runner/render-build-values.sh — do not
+# hand-edit. The `nucleus-k3s-build` pool: 3 big runners for the compile-class
+# jobs (see values.yaml for the two-pool rationale).
+#
+#   helm upgrade --install nucleus-k3s-build \
+#     oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set \
+#     --version 0.14.2 -n arc-runners -f k8s/ci-runner/values-build.yaml
 # Helm values for the `nucleus-k3s` runner scale set (gha-runner-scale-set
 # 0.14.2) on the Lima `pci-k3s` VM. The GitHub credential is NOT here: it is
 # the pre-existing `gh-token` secret in the arc-runners namespace.
@@ -11,7 +18,7 @@
 # variable CI_RUNNER sends everything back to hosted runners in one place.
 githubConfigUrl: https://github.com/coproduct-opensource/nucleus
 githubConfigSecret: gh-token
-runnerScaleSetName: nucleus-k3s
+runnerScaleSetName: nucleus-k3s-build
 
 # TWO POOLS on one node (the Lima VM at 12 vCPU / 28 GiB; `limactl edit
 # pci-k3s --cpus 12 --memory 28`, VM stopped):
@@ -32,7 +39,7 @@ runnerScaleSetName: nucleus-k3s
 # CARGO_BUILD_JOBS parallel rustc/ld processes — an unbounded cargo under a
 # 6 GiB limit OOM-killed the linker; Lake needs LEAN_NUM_THREADS capped too.
 minRunners: 0
-maxRunners: 8
+maxRunners: 3
 
 template:
   spec:
@@ -56,7 +63,7 @@ template:
           # Two cargo jobs per runner: memory scales with parallel rustc/ld
           # processes, and the limit below is sized for two.
           - name: CARGO_BUILD_JOBS
-            value: "2"
+            value: "3"
           # Job hooks (k8s/ci-runner/hooks/): per-job sccache hit rate and pod
           # resource peaks in every job log. `kubectl create configmap
           # runner-hooks --from-file=k8s/ci-runner/hooks/` keeps them current.
@@ -66,11 +73,11 @@ template:
             value: /home/runner/hooks/job-completed.sh
         resources:
           requests:
-            cpu: "500m"
-            memory: 1Gi
+            cpu: "2500m"
+            memory: 5Gi
           limits:
-            cpu: "2"
-            memory: 3Gi
+            cpu: "4"
+            memory: 8Gi
         volumeMounts:
           # Only IMMUTABLE caches are shared: the registry's .crate files and
           # index. `registry/src` is extracted per pod — sharing it let one

--- a/k8s/ci-runner/values.yaml
+++ b/k8s/ci-runner/values.yaml
@@ -13,14 +13,15 @@ githubConfigUrl: https://github.com/coproduct-opensource/nucleus
 githubConfigSecret: gh-token
 runnerScaleSetName: nucleus-k3s
 
-# Scale-to-zero; four at most. The node is the Lima VM at 12 vCPU / 28 GiB
-# (`limactl edit pci-k3s --cpus 12 --memory 28`). Each runner is held to 3
-# cargo jobs (CARGO_BUILD_JOBS below) and a 6 GiB memory limit: the first
-# smoke run let cargo use every core under a 6 GiB limit and the memory cgroup
-# OOM-killed the linker mid-build. Four runners x 3 jobs saturates the CPU;
-# four x 6 GiB fits the node with the runner's own overhead.
+# Scale-to-zero; six at most. The node is the Lima VM at 12 vCPU / 28 GiB
+# (`limactl edit pci-k3s --cpus 12 --memory 28`, VM stopped). Most cohort jobs
+# are seconds-long gates where per-job overhead dominates, so more, smaller
+# runners beat fewer, bigger ones: each runner is held to 2 cargo jobs
+# (CARGO_BUILD_JOBS below) and a 4.5 GiB memory limit (six x 4.5 GiB fits the
+# node). The first smoke run let cargo use every core under a 6 GiB limit and
+# the memory cgroup OOM-killed the linker mid-build; the limit is sized for two.
 minRunners: 0
-maxRunners: 4
+maxRunners: 6
 
 template:
   spec:
@@ -41,16 +42,16 @@ template:
             value: 30G
           - name: CARGO_INCREMENTAL
             value: "0"
-          # A quarter of the node's cores per runner: memory scales with
-          # parallel rustc/ld processes, and the limit below is sized for three.
+          # Two cargo jobs per runner: memory scales with parallel rustc/ld
+          # processes, and the limit below is sized for two.
           - name: CARGO_BUILD_JOBS
-            value: "3"
+            value: "2"
         resources:
           requests:
-            cpu: "2500m"
-            memory: 3Gi
+            cpu: "1500m"
+            memory: 2Gi
           limits:
-            memory: 6Gi
+            memory: 4500Mi
         volumeMounts:
           # Only caches are shared. Toolchains live in the image (Dockerfile).
           - name: cargo-registry

--- a/k8s/ci-runner/values.yaml
+++ b/k8s/ci-runner/values.yaml
@@ -40,7 +40,7 @@ template:
       - name: runner
         # Built from docker/Dockerfile.runner and imported into k3s's
         # containerd (README.md); never pulled from a registry.
-        image: localhost/nucleus-ci-runner:0.2.2
+        image: localhost/nucleus-ci-runner:0.2.3
         imagePullPolicy: Never
         command: ["/home/runner/run.sh"]
         env:

--- a/k8s/ci-runner/values.yaml
+++ b/k8s/ci-runner/values.yaml
@@ -40,7 +40,7 @@ template:
       - name: runner
         # Built from docker/Dockerfile.runner and imported into k3s's
         # containerd (README.md); never pulled from a registry.
-        image: localhost/nucleus-ci-runner:0.2.1
+        image: localhost/nucleus-ci-runner:0.2.2
         imagePullPolicy: Never
         command: ["/home/runner/run.sh"]
         env:

--- a/k8s/ci-runner/values.yaml
+++ b/k8s/ci-runner/values.yaml
@@ -27,7 +27,7 @@ template:
       - name: runner
         # Built from docker/Dockerfile.runner and imported into k3s's
         # containerd (README.md); never pulled from a registry.
-        image: localhost/nucleus-ci-runner:0.1.1
+        image: localhost/nucleus-ci-runner:0.1.2
         imagePullPolicy: Never
         command: ["/home/runner/run.sh"]
         env:
@@ -59,8 +59,10 @@ template:
           limits:
             memory: 8Gi
         volumeMounts:
+          # Only the toolchains are shared; rustup's settings.toml (default
+          # toolchain, directory overrides) stays per pod, baked in the image.
           - name: rustup
-            mountPath: /home/runner/.rustup
+            mountPath: /home/runner/.rustup/toolchains
           - name: cargo
             mountPath: /home/runner/.cargo
           - name: cache
@@ -72,7 +74,7 @@ template:
       # `runner` user): created by k8s/ci-runner/README.md's setup step.
       - name: rustup
         hostPath:
-          path: /var/lib/nucleus-ci/rustup
+          path: /var/lib/nucleus-ci/rustup/toolchains
           type: Directory
       - name: cargo
         hostPath:

--- a/k8s/ci-runner/values.yaml
+++ b/k8s/ci-runner/values.yaml
@@ -54,16 +54,17 @@ template:
             memory: 4500Mi
         volumeMounts:
           # Only IMMUTABLE caches are shared: the registry's .crate files and
-          # index, and cargo's bare git db. `registry/src` and `git/checkouts`
-          # are extracted per pod — sharing them let one job's re-extraction
-          # yank a source tree out from under another job's sccache hash
-          # ("Failed to open file for hashing: …/registry/src/…/host.rs").
+          # index. `registry/src` is extracted per pod — sharing it let one
+          # job's re-extraction yank a source tree out from under another
+          # job's sccache hash ("Failed to open file for hashing"). Cargo's
+          # git db is per pod too: four dylint jobs cloning rust-clippy into
+          # one shared db at once failed with "failed to clone into
+          # …/git/db/rust-clippy-…: no error"; a clone is seconds on this
+          # downlink, a shared-db race is a red job.
           - name: cargo-registry-cache
             mountPath: /home/runner/.cargo/registry/cache
           - name: cargo-registry-index
             mountPath: /home/runner/.cargo/registry/index
-          - name: cargo-git-db
-            mountPath: /home/runner/.cargo/git/db
           - name: cache
             mountPath: /home/runner/.cache
     volumes:
@@ -76,10 +77,6 @@ template:
       - name: cargo-registry-index
         hostPath:
           path: /var/lib/nucleus-ci/cargo/registry/index
-          type: DirectoryOrCreate
-      - name: cargo-git-db
-        hostPath:
-          path: /var/lib/nucleus-ci/cargo/git/db
           type: DirectoryOrCreate
       - name: cache
         hostPath:

--- a/k8s/ci-runner/values.yaml
+++ b/k8s/ci-runner/values.yaml
@@ -40,7 +40,7 @@ template:
       - name: runner
         # Built from docker/Dockerfile.runner and imported into k3s's
         # containerd (README.md); never pulled from a registry.
-        image: localhost/nucleus-ci-runner:0.2.3
+        image: localhost/nucleus-ci-runner:0.2.4
         imagePullPolicy: Never
         command: ["/home/runner/run.sh"]
         env:

--- a/k8s/ci-runner/values.yaml
+++ b/k8s/ci-runner/values.yaml
@@ -53,6 +53,11 @@ template:
             value: 30G
           - name: CARGO_INCREMENTAL
             value: "0"
+          # Debuginfo the linker can afford: full DWARF made GNU ld take
+          # 2.75-3.4 GB per test binary and OOM-killed the heavy jobs; line
+          # tables keep panics readable. Pairs with cargo-config.toml (lld).
+          - name: CARGO_PROFILE_DEV_DEBUG
+            value: line-tables-only
           # Two cargo jobs per runner: memory scales with parallel rustc/ld
           # processes, and the limit below is sized for two.
           - name: CARGO_BUILD_JOBS
@@ -89,6 +94,10 @@ template:
           - name: runner-hooks
             mountPath: /home/runner/hooks
             readOnly: true
+          - name: runner-cargo-config
+            mountPath: /home/runner/.cargo/config.toml
+            subPath: config.toml
+            readOnly: true
     volumes:
       # Host-path directories on the k3s node, owned by uid 1001 (the image's
       # `runner` user): created by k8s/ci-runner/README.md's setup step.
@@ -108,3 +117,7 @@ template:
         configMap:
           name: runner-hooks
           defaultMode: 0755
+      # `kubectl create configmap runner-cargo-config --from-file=config.toml=k8s/ci-runner/cargo-config.toml`
+      - name: runner-cargo-config
+        configMap:
+          name: runner-cargo-config

--- a/k8s/ci-runner/values.yaml
+++ b/k8s/ci-runner/values.yaml
@@ -40,7 +40,7 @@ template:
       - name: runner
         # Built from docker/Dockerfile.runner and imported into k3s's
         # containerd (README.md); never pulled from a registry.
-        image: localhost/nucleus-ci-runner:0.2.4
+        image: localhost/nucleus-ci-runner:0.2.5
         imagePullPolicy: Never
         command: ["/home/runner/run.sh"]
         env:

--- a/k8s/ci-runner/values.yaml
+++ b/k8s/ci-runner/values.yaml
@@ -46,6 +46,13 @@ template:
           # processes, and the limit below is sized for two.
           - name: CARGO_BUILD_JOBS
             value: "2"
+          # Job hooks (k8s/ci-runner/hooks/): per-job sccache hit rate and pod
+          # resource peaks in every job log. `kubectl create configmap
+          # runner-hooks --from-file=k8s/ci-runner/hooks/` keeps them current.
+          - name: ACTIONS_RUNNER_HOOK_JOB_STARTED
+            value: /home/runner/hooks/job-started.sh
+          - name: ACTIONS_RUNNER_HOOK_JOB_COMPLETED
+            value: /home/runner/hooks/job-completed.sh
         resources:
           requests:
             cpu: "1500m"
@@ -67,6 +74,9 @@ template:
             mountPath: /home/runner/.cargo/registry/index
           - name: cache
             mountPath: /home/runner/.cache
+          - name: runner-hooks
+            mountPath: /home/runner/hooks
+            readOnly: true
     volumes:
       # Host-path directories on the k3s node, owned by uid 1001 (the image's
       # `runner` user): created by k8s/ci-runner/README.md's setup step.
@@ -82,3 +92,7 @@ template:
         hostPath:
           path: /var/lib/nucleus-ci/cache
           type: Directory
+      - name: runner-hooks
+        configMap:
+          name: runner-hooks
+          defaultMode: 0755

--- a/k8s/ci-runner/values.yaml
+++ b/k8s/ci-runner/values.yaml
@@ -53,23 +53,33 @@ template:
           limits:
             memory: 4500Mi
         volumeMounts:
-          # Only caches are shared. Toolchains live in the image (Dockerfile).
-          - name: cargo-registry
-            mountPath: /home/runner/.cargo/registry
-          - name: cargo-git
-            mountPath: /home/runner/.cargo/git
+          # Only IMMUTABLE caches are shared: the registry's .crate files and
+          # index, and cargo's bare git db. `registry/src` and `git/checkouts`
+          # are extracted per pod — sharing them let one job's re-extraction
+          # yank a source tree out from under another job's sccache hash
+          # ("Failed to open file for hashing: …/registry/src/…/host.rs").
+          - name: cargo-registry-cache
+            mountPath: /home/runner/.cargo/registry/cache
+          - name: cargo-registry-index
+            mountPath: /home/runner/.cargo/registry/index
+          - name: cargo-git-db
+            mountPath: /home/runner/.cargo/git/db
           - name: cache
             mountPath: /home/runner/.cache
     volumes:
       # Host-path directories on the k3s node, owned by uid 1001 (the image's
       # `runner` user): created by k8s/ci-runner/README.md's setup step.
-      - name: cargo-registry
+      - name: cargo-registry-cache
         hostPath:
-          path: /var/lib/nucleus-ci/cargo/registry
+          path: /var/lib/nucleus-ci/cargo/registry/cache
           type: DirectoryOrCreate
-      - name: cargo-git
+      - name: cargo-registry-index
         hostPath:
-          path: /var/lib/nucleus-ci/cargo/git
+          path: /var/lib/nucleus-ci/cargo/registry/index
+          type: DirectoryOrCreate
+      - name: cargo-git-db
+        hostPath:
+          path: /var/lib/nucleus-ci/cargo/git/db
           type: DirectoryOrCreate
       - name: cache
         hostPath:

--- a/k8s/ci-runner/values.yaml
+++ b/k8s/ci-runner/values.yaml
@@ -28,7 +28,7 @@ template:
       - name: runner
         # Built from docker/Dockerfile.runner and imported into k3s's
         # containerd (README.md); never pulled from a registry.
-        image: localhost/nucleus-ci-runner:0.1.2
+        image: localhost/nucleus-ci-runner:0.2.0
         imagePullPolicy: Never
         command: ["/home/runner/run.sh"]
         env:
@@ -45,14 +45,6 @@ template:
           # parallel rustc/ld processes, and the limit below is sized for three.
           - name: CARGO_BUILD_JOBS
             value: "3"
-          # Where dtolnay/rust-toolchain and elan-init install to; both are
-          # persistent mounts, so a warm pod starts with the toolchains present.
-          - name: RUSTUP_HOME
-            value: /home/runner/.rustup
-          - name: CARGO_HOME
-            value: /home/runner/.cargo
-          - name: ELAN_HOME
-            value: /home/runner/.elan
         resources:
           requests:
             cpu: "2500m"
@@ -60,32 +52,25 @@ template:
           limits:
             memory: 6Gi
         volumeMounts:
-          # Only the toolchains are shared; rustup's settings.toml (default
-          # toolchain, directory overrides) stays per pod, baked in the image.
-          - name: rustup
-            mountPath: /home/runner/.rustup/toolchains
-          - name: cargo
-            mountPath: /home/runner/.cargo
+          # Only caches are shared. Toolchains live in the image (Dockerfile).
+          - name: cargo-registry
+            mountPath: /home/runner/.cargo/registry
+          - name: cargo-git
+            mountPath: /home/runner/.cargo/git
           - name: cache
             mountPath: /home/runner/.cache
-          - name: elan
-            mountPath: /home/runner/.elan
     volumes:
       # Host-path directories on the k3s node, owned by uid 1001 (the image's
       # `runner` user): created by k8s/ci-runner/README.md's setup step.
-      - name: rustup
+      - name: cargo-registry
         hostPath:
-          path: /var/lib/nucleus-ci/rustup/toolchains
-          type: Directory
-      - name: cargo
+          path: /var/lib/nucleus-ci/cargo/registry
+          type: DirectoryOrCreate
+      - name: cargo-git
         hostPath:
-          path: /var/lib/nucleus-ci/cargo
-          type: Directory
+          path: /var/lib/nucleus-ci/cargo/git
+          type: DirectoryOrCreate
       - name: cache
         hostPath:
           path: /var/lib/nucleus-ci/cache
-          type: Directory
-      - name: elan
-        hostPath:
-          path: /var/lib/nucleus-ci/elan
           type: Directory

--- a/k8s/ci-runner/values.yaml
+++ b/k8s/ci-runner/values.yaml
@@ -13,13 +13,14 @@ githubConfigUrl: https://github.com/coproduct-opensource/nucleus
 githubConfigSecret: gh-token
 runnerScaleSetName: nucleus-k3s
 
-# Scale-to-zero; two at most. The node has 8 vCPU / 16 GiB. Each runner is
-# held to 4 cargo jobs (CARGO_BUILD_JOBS below) and an 8 GiB memory limit: the
-# first smoke run let cargo use all 8 cores under a 6 GiB limit and the memory
-# cgroup OOM-killed the linker mid-build. Two runners x 4 jobs saturates the
-# CPU; two x 8 GiB fits the node with the runner's own overhead.
+# Scale-to-zero; four at most. The node is the Lima VM at 12 vCPU / 28 GiB
+# (`limactl edit pci-k3s --cpus 12 --memory 28`). Each runner is held to 3
+# cargo jobs (CARGO_BUILD_JOBS below) and a 6 GiB memory limit: the first
+# smoke run let cargo use every core under a 6 GiB limit and the memory cgroup
+# OOM-killed the linker mid-build. Four runners x 3 jobs saturates the CPU;
+# four x 6 GiB fits the node with the runner's own overhead.
 minRunners: 0
-maxRunners: 2
+maxRunners: 4
 
 template:
   spec:
@@ -40,10 +41,10 @@ template:
             value: 30G
           - name: CARGO_INCREMENTAL
             value: "0"
-          # Half the node's cores per runner: memory scales with parallel
-          # rustc/ld processes, and the limit below is sized for four.
+          # A quarter of the node's cores per runner: memory scales with
+          # parallel rustc/ld processes, and the limit below is sized for three.
           - name: CARGO_BUILD_JOBS
-            value: "4"
+            value: "3"
           # Where dtolnay/rust-toolchain and elan-init install to; both are
           # persistent mounts, so a warm pod starts with the toolchains present.
           - name: RUSTUP_HOME
@@ -54,10 +55,10 @@ template:
             value: /home/runner/.elan
         resources:
           requests:
-            cpu: "3"
-            memory: 4Gi
+            cpu: "2500m"
+            memory: 3Gi
           limits:
-            memory: 8Gi
+            memory: 6Gi
         volumeMounts:
           # Only the toolchains are shared; rustup's settings.toml (default
           # toolchain, directory overrides) stays per pod, baked in the image.

--- a/k8s/ci-runner/warm.sh
+++ b/k8s/ci-runner/warm.sh
@@ -11,7 +11,7 @@
 # exactly what a runner pod sees.
 set -euo pipefail
 
-IMAGE="${IMAGE:-localhost/nucleus-ci-runner:0.1.1}"
+IMAGE="${IMAGE:-localhost/nucleus-ci-runner:0.1.2}"
 ROOT="${ROOT:-/var/lib/nucleus-ci}"
 RUST_TOOLCHAIN="${RUST_TOOLCHAIN:-1.96.1}"   # rust-toolchain.toml
 LEAN_TOOLCHAIN="${LEAN_TOOLCHAIN:-leanprover/lean4:v4.30.0-rc2}"  # every lean-toolchain in the tree

--- a/k8s/ci-runner/warm.sh
+++ b/k8s/ci-runner/warm.sh
@@ -11,7 +11,7 @@
 # exactly what a runner pod sees.
 set -euo pipefail
 
-IMAGE="${IMAGE:-localhost/nucleus-ci-runner:0.1.2}"
+IMAGE="${IMAGE:-localhost/nucleus-ci-runner:0.2.0}"
 ROOT="${ROOT:-/var/lib/nucleus-ci}"
 RUST_TOOLCHAIN="${RUST_TOOLCHAIN:-1.96.1}"   # rust-toolchain.toml
 LEAN_TOOLCHAIN="${LEAN_TOOLCHAIN:-leanprover/lean4:v4.30.0-rc2}"  # every lean-toolchain in the tree


### PR DESCRIPTION
Second cohort run on `nucleus-k3s`: the wasm build failed with `rustc 1.93.1 is not supported`, the K4 parity and clippy-ceiling jobs went red, and the shared `~/.rustup/settings.toml` showed why: one job's `rustup override set 1.93` in the checkout directory (the Kani-floor job) was visible to every other job on every runner through the shared mount, as was whichever `rustup default` ran last.

Now the image bakes `/home/runner/.rustup/settings.toml` (default 1.96.1, no overrides) and the scale set mounts only `~/.rustup/toolchains`; downloads/tmp are pod-local. A job can still override, but only for its own pod's lifetime. Image 0.1.2 is built and applied on the node (scale-set revision bumped); this PR records it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZaH5waz88vL1qfNpFNfZ4