### PR TITLE
ci: route the Lean builds, coverage/mutation and manifest guards to the scale set; Lean cache keys carry runner.arch

### DIFF
--- a/.github/workflows/a2a-tck.yml
+++ b/.github/workflows/a2a-tck.yml
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
-          cache: true
+          cache: ${{ runner.environment == 'github-hosted' }}
           cache-workspaces: examples/a2a-server
       - name: Build the transport-conformance target
         working-directory: examples/a2a-server

--- a/.github/workflows/aeneas-certchain.yml
+++ b/.github/workflows/aeneas-certchain.yml
@@ -60,6 +60,10 @@ jobs:
 
       - name: Rust / cargo cache (Charon target dir)
         uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2.9.1
+        # Hosted only: the self-hosted scale set has persistent registry and
+        # sccache mounts, and this action's restore of a hosted x86 cache blob
+        # was observed hanging runner jobs for 15+ minutes.
+        if: ${{ runner.environment == 'github-hosted' }}
         with:
           workspaces: crates/portcullis-core
           key: charon-certchain-${{ env.CHARON_NIGHTLY }}-${{ env.AENEAS_RELEASE }}

--- a/.github/workflows/aeneas-decide-pure.yml
+++ b/.github/workflows/aeneas-decide-pure.yml
@@ -90,6 +90,10 @@ jobs:
 
       - name: Rust / cargo cache (Charon target dir)
         uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2.9.1
+        # Hosted only: the self-hosted scale set has persistent registry and
+        # sccache mounts, and this action's restore of a hosted x86 cache blob
+        # was observed hanging runner jobs for 15+ minutes.
+        if: ${{ runner.environment == 'github-hosted' }}
         with:
           workspaces: crates/nucleus-ifc-kernel
           key: charon-decide-${{ env.CHARON_NIGHTLY }}-${{ env.AENEAS_RELEASE }}

--- a/.github/workflows/aeneas-ifc-scoped.yml
+++ b/.github/workflows/aeneas-ifc-scoped.yml
@@ -125,9 +125,8 @@ jobs:
           components: rustc-dev,llvm-tools-preview,rust-src
 
       - name: Rust / cargo cache (Charon target dir)
-        if: steps.scope.outputs.relevant == 'true'
+        if: ${{ runner.environment == 'github-hosted' && (steps.scope.outputs.relevant == 'true') }}
         uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2.9.1
-        if: ${{ runner.environment == 'github-hosted' }}
         with:
           workspaces: crates/nucleus-ifc-kernel
           key: charon-ifc-${{ env.CHARON_NIGHTLY }}-${{ env.AENEAS_RELEASE }}

--- a/.github/workflows/aeneas-ifc-scoped.yml
+++ b/.github/workflows/aeneas-ifc-scoped.yml
@@ -127,6 +127,7 @@ jobs:
       - name: Rust / cargo cache (Charon target dir)
         if: steps.scope.outputs.relevant == 'true'
         uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2.9.1
+        if: ${{ runner.environment == 'github-hosted' }}
         with:
           workspaces: crates/nucleus-ifc-kernel
           key: charon-ifc-${{ env.CHARON_NIGHTLY }}-${{ env.AENEAS_RELEASE }}

--- a/.github/workflows/aeneas-oidc-spiffe.yml
+++ b/.github/workflows/aeneas-oidc-spiffe.yml
@@ -104,9 +104,8 @@ jobs:
           components: rustc-dev,llvm-tools-preview,rust-src
 
       - name: Rust / cargo cache (Charon target dir)
-        if: steps.scope.outputs.relevant == 'true'
+        if: ${{ runner.environment == 'github-hosted' && (steps.scope.outputs.relevant == 'true') }}
         uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2.9.1
-        if: ${{ runner.environment == 'github-hosted' }}
         with:
           key: charon-oidc-${{ env.CHARON_NIGHTLY }}-${{ env.AENEAS_RELEASE }}
           save-if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/aeneas-oidc-spiffe.yml
+++ b/.github/workflows/aeneas-oidc-spiffe.yml
@@ -106,6 +106,7 @@ jobs:
       - name: Rust / cargo cache (Charon target dir)
         if: steps.scope.outputs.relevant == 'true'
         uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2.9.1
+        if: ${{ runner.environment == 'github-hosted' }}
         with:
           key: charon-oidc-${{ env.CHARON_NIGHTLY }}-${{ env.AENEAS_RELEASE }}
           save-if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/aeneas.yml
+++ b/.github/workflows/aeneas.yml
@@ -61,6 +61,10 @@ jobs:
       # publishes no artifacts (it merely also runs on `release published`).
       - name: Rust / cargo cache (Charon target dir)
         uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2.9.1 # zizmor: ignore[cache-poisoning]
+        # Hosted only: the self-hosted scale set has persistent registry and
+        # sccache mounts, and this action's restore of a hosted x86 cache blob
+        # was observed hanging runner jobs for 15+ minutes.
+        if: ${{ runner.environment == 'github-hosted' }}
         with:
           workspaces: crates/nucleus-ifc-kernel
           key: charon-${{ env.CHARON_NIGHTLY }}-${{ env.AENEAS_RELEASE }}

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -25,7 +25,10 @@ permissions:
 
 jobs:
   audit:
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    # Hosted: `actions-rust-lang/audit` runs a python script that imports
+    # `requests`, which the self-hosted runner image does not ship; the job is
+    # small and has no cache to upload, so hosted costs nothing here.
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2.9.1
@@ -51,12 +54,6 @@ jobs:
       - name: Pre-install cargo-audit with its own locked dependency tree
         run: cargo +stable install cargo-audit --version 0.22.0 --locked --no-default-features
         shell: bash
-      # The audit action shells out to `python`; the self-hosted runner image
-      # ships python3 only (python-is-python3 is added in the next image).
-      - name: Ensure a `python` executable exists (self-hosted image)
-        if: ${{ runner.environment != 'github-hosted' }}
-        shell: bash
-        run: command -v python >/dev/null || sudo ln -sf "$(command -v python3)" /usr/local/bin/python
       - uses: actions-rust-lang/audit@72c09e02f132669d52284a3323acdb503cfc1a24 # v1
         with:
           denyWarnings: true

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -51,6 +51,12 @@ jobs:
       - name: Pre-install cargo-audit with its own locked dependency tree
         run: cargo +stable install cargo-audit --version 0.22.0 --locked --no-default-features
         shell: bash
+      # The audit action shells out to `python`; the self-hosted runner image
+      # ships python3 only (python-is-python3 is added in the next image).
+      - name: Ensure a `python` executable exists (self-hosted image)
+        if: ${{ runner.environment != 'github-hosted' }}
+        shell: bash
+        run: command -v python >/dev/null || sudo ln -sf "$(command -v python3)" /usr/local/bin/python
       - uses: actions-rust-lang/audit@72c09e02f132669d52284a3323acdb503cfc1a24 # v1
         with:
           denyWarnings: true

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -29,6 +29,10 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2.9.1
+        # Hosted only: the self-hosted scale set has persistent registry and
+        # sccache mounts, and this action's restore of a hosted x86 cache blob
+        # was observed hanging runner jobs for 15+ minutes.
+        if: ${{ runner.environment == 'github-hosted' }}
       # Work around a broken transitive dependency: `actions-rust-lang/audit`
       # installs cargo-audit via `cargo install cargo-audit --vers 0.22.0`
       # with no `--locked`, so it re-resolves cargo-audit's own dependency

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -534,7 +534,10 @@ jobs:
 
   musl-check:
     name: musl type-check (nucleus-node, nucleus-tool-proxy)
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    # Hosted on purpose: `cargo check --target x86_64-unknown-linux-musl` runs
+    # build scripts (ring) that need x86_64-linux-musl-gcc, which only the
+    # hosted x86 image has; the arm64 scale set cannot cross-compile it.
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     # The release pipeline builds static musl binaries, but every other job here
     # compiles against glibc — so glibc-only code (v2.0.1: __rlimit_resource_t in

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -451,6 +451,12 @@ jobs:
       # (settlement + commons) and the accept/reject smoke fixtures — per-PR, not
       # just on publish, so a binding-layer drift from the proven kernels is caught
       # here. Node is preinstalled on the ubuntu runner.
+      # Hosted runners ship node; the self-hosted image does not (exit 127 on
+      # the first routed run). setup-node downloads it at runner speed and
+      # never uploads a cache.
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "22"
       - name: Node tests (golden seal + smoke) against built wasm
         working-directory: sdks/verifier-js
         run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
-          cache: true
+          cache: ${{ runner.environment == 'github-hosted' }}
       # Deliberately NOT overriding rustflags: the default `-D warnings` is the
       # condition that fails the release, so the gate must run under it too.
       - name: Build the crates release.yml publishes
@@ -106,7 +106,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
           components: rustfmt
-          cache: true
+          cache: ${{ runner.environment == 'github-hosted' }}
       - name: cargo fmt
         run: cargo fmt --all -- --check
 
@@ -163,7 +163,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
-          cache: true
+          cache: ${{ runner.environment == 'github-hosted' }}
       - name: The discharge seal is not reachable from any shipping build
         shell: bash
         run: scripts/check-test-helpers-not-in-production.sh
@@ -201,7 +201,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
-          cache: true
+          cache: ${{ runner.environment == 'github-hosted' }}
       - name: A token clears its node for its signed sinks and only those
         shell: bash
         run: scripts/check-declassify-sink-scope-enforced.sh
@@ -220,7 +220,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
-          cache: true
+          cache: ${{ runner.environment == 'github-hosted' }}
       - name: A token releases only the committed value, once, on the live graph
         shell: bash
         run: scripts/check-declassify-value-bound.sh
@@ -250,7 +250,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
-          cache: true
+          cache: ${{ runner.environment == 'github-hosted' }}
       - name: uid distinctness, reserved-namespace, and cmdline fences hold
         shell: bash
         run: scripts/check-c1-inbound-fences.sh
@@ -303,7 +303,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
-          cache: true
+          cache: ${{ runner.environment == 'github-hosted' }}
       - name: Build node (local-driver) + cli + tool-proxy
         run: cargo build -p nucleus-node --features local-driver -p nucleus-cli -p nucleus-tool-proxy
       - name: The create API records lineage the listing serves
@@ -335,7 +335,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
-          cache: true
+          cache: ${{ runner.environment == 'github-hosted' }}
       - name: Every gate REDs on a real violation and GREENs when restored
         shell: bash
         run: scripts/check-gates-can-fail.sh
@@ -368,7 +368,7 @@ jobs:
         with:
           components: clippy
           targets: wasm32-unknown-unknown
-          cache: true
+          cache: ${{ runner.environment == 'github-hosted' }}
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Build wasm SDK (vendored into verifier-service via include_bytes!)
@@ -400,7 +400,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
           targets: wasm32-unknown-unknown
-          cache: true
+          cache: ${{ runner.environment == 'github-hosted' }}
       # PREREQUISITE, not boilerplate. `nucleus-verifier-service` vendors the
       # wasm SDK with `include_str!`/`include_bytes!` on sdks/verifier-js/pkg/*,
       # which only `wasm-pack build` produces. Without these two steps the whole
@@ -427,7 +427,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
           targets: wasm32-unknown-unknown
-          cache: true
+          cache: ${{ runner.environment == 'github-hosted' }}
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Build wasm SDK (vendored into verifier-service via include_bytes!)
@@ -486,7 +486,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
           components: rustfmt, clippy
-          cache: true
+          cache: ${{ runner.environment == 'github-hosted' }}
           cache-workspaces: examples/a2a-server
       - name: cargo fmt
         run: cargo fmt --all -- --check
@@ -505,7 +505,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
-          cache: true
+          cache: ${{ runner.environment == 'github-hosted' }}
       - name: Run OWASP LLM Top 10 security tests
         run: cargo test -p portcullis --test owasp_llm_gauntlet --all-features
 
@@ -528,7 +528,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
-          cache: true
+          cache: ${{ runner.environment == 'github-hosted' }}
       - name: cargo test -p nucleus-policy-kernel (parity pin)
         run: cargo test -p nucleus-policy-kernel
 
@@ -550,7 +550,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
           targets: x86_64-unknown-linux-musl
-          cache: true
+          cache: ${{ runner.environment == 'github-hosted' }}
       - name: Install musl-gcc
         run: sudo apt-get update && sudo apt-get install -y musl-tools
       - name: Ensure musl target (cache-safe)
@@ -572,7 +572,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
           toolchain: nightly
-          cache: true
+          cache: ${{ runner.environment == 'github-hosted' }}
       - name: install cargo-fuzz
         # Pin version, but DROP --locked so cargo resolves a rustix newer
         # than the 0.36.5 cargo-fuzz bundles (0.36.5 uses rustc-internal

--- a/.github/workflows/ck-admit.yml
+++ b/.github/workflows/ck-admit.yml
@@ -83,7 +83,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         if: steps.scope.outputs.relevant == 'true'
         with:
-          cache: true
+          cache: ${{ runner.environment == 'github-hosted' }}
       - name: Extract base manifest + changed files
         if: steps.scope.outputs.relevant == 'true'
         # Pass github.base_ref via env (never interpolate ${{ }} into a run

--- a/.github/workflows/ck-policy-aeneas.yml
+++ b/.github/workflows/ck-policy-aeneas.yml
@@ -118,6 +118,7 @@ jobs:
       - name: Rust / cargo cache (Charon target dir)
         if: steps.scope.outputs.relevant == 'true'
         uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2.9.1
+        if: ${{ runner.environment == 'github-hosted' }}
         with:
           workspaces: crates/ck-policy
           key: charon-${{ env.CHARON_NIGHTLY }}-${{ env.AENEAS_RELEASE }}

--- a/.github/workflows/ck-policy-aeneas.yml
+++ b/.github/workflows/ck-policy-aeneas.yml
@@ -116,9 +116,8 @@ jobs:
           components: rustc-dev,llvm-tools-preview,rust-src
 
       - name: Rust / cargo cache (Charon target dir)
-        if: steps.scope.outputs.relevant == 'true'
+        if: ${{ runner.environment == 'github-hosted' && (steps.scope.outputs.relevant == 'true') }}
         uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2.9.1
-        if: ${{ runner.environment == 'github-hosted' }}
         with:
           workspaces: crates/ck-policy
           key: charon-${{ env.CHARON_NIGHTLY }}-${{ env.AENEAS_RELEASE }}

--- a/.github/workflows/ck-policy-lean.yml
+++ b/.github/workflows/ck-policy-lean.yml
@@ -98,7 +98,7 @@ jobs:
           echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
 
       - name: Cache Lake build artifacts
-        if: steps.scope.outputs.relevant == 'true'
+        if: ${{ runner.environment == 'github-hosted' && (steps.scope.outputs.relevant == 'true') }}
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
         with:
           path: |

--- a/.github/workflows/ck-policy-lean.yml
+++ b/.github/workflows/ck-policy-lean.yml
@@ -111,7 +111,7 @@ jobs:
       - name: lake build Ck (monotonicity-gate soundness proofs)
         if: steps.scope.outputs.relevant == 'true'
         working-directory: crates/ck-policy/lean
-        run: lake build
+        run: lake build --jobs=2
 
       - name: Ban sorry / admit / native_decide / sorryAx in ck-policy Lean
         if: steps.scope.outputs.relevant == 'true'

--- a/.github/workflows/ck-policy-lean.yml
+++ b/.github/workflows/ck-policy-lean.yml
@@ -111,7 +111,7 @@ jobs:
       - name: lake build Ck (monotonicity-gate soundness proofs)
         if: steps.scope.outputs.relevant == 'true'
         working-directory: crates/ck-policy/lean
-        run: lake build --jobs=2
+        run: LEAN_NUM_THREADS=2 lake build
 
       - name: Ban sorry / admit / native_decide / sorryAx in ck-policy Lean
         if: steps.scope.outputs.relevant == 'true'

--- a/.github/workflows/ck-policy-lean.yml
+++ b/.github/workflows/ck-policy-lean.yml
@@ -38,7 +38,7 @@ permissions:
 jobs:
   ck-policy-lean:
     name: lake build Ck (monotonicity-gate soundness proofs)
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -104,9 +104,9 @@ jobs:
           path: |
             crates/ck-policy/lean/.lake
             ~/.elan
-          key: lean-ck-policy-${{ runner.os }}-${{ hashFiles('crates/ck-policy/lean/lean-toolchain', 'crates/ck-policy/lean/lakefile.lean') }}
+          key: lean-ck-policy-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('crates/ck-policy/lean/lean-toolchain', 'crates/ck-policy/lean/lakefile.lean') }}
           restore-keys: |
-            lean-ck-policy-${{ runner.os }}-
+            lean-ck-policy-${{ runner.os }}-${{ runner.arch }}-
 
       - name: lake build Ck (monotonicity-gate soundness proofs)
         if: steps.scope.outputs.relevant == 'true'

--- a/.github/workflows/clippy-ratchet.yml
+++ b/.github/workflows/clippy-ratchet.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
           components: clippy
-          cache: true
+          cache: ${{ runner.environment == 'github-hosted' }}
       - name: Check clippy ratchet
         run: scripts/check-clippy-ratchet.sh --strict
 
@@ -43,7 +43,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
           components: clippy
-          cache: true
+          cache: ${{ runner.environment == 'github-hosted' }}
       - name: RED on a ceiling below actual, GREEN when restored
         run: |
           set -euo pipefail
@@ -79,7 +79,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
           components: clippy
-          cache: true
+          cache: ${{ runner.environment == 'github-hosted' }}
 
       - name: Ratchet down
         env:

--- a/.github/workflows/coverage-matrix.yml
+++ b/.github/workflows/coverage-matrix.yml
@@ -25,7 +25,7 @@ jobs:
   # passing status check.
   changed-crates:
     name: Detect Changed Crates
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 5
     outputs:
       all: ${{ steps.detect.outputs.all }}
@@ -81,7 +81,7 @@ jobs:
   # Layer 1: LLVM source-based code coverage with threshold enforcement
   llvm-cov:
     name: Code Coverage (llvm-cov)
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 20
     needs: changed-crates
     if: ${{ needs.changed-crates.outputs.all == 'true' || needs.changed-crates.outputs.crates != '' }}
@@ -129,7 +129,7 @@ jobs:
   # Layer 2: Mutation testing on security-critical modules
   mutants:
     name: Mutation Testing
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 30
     needs: changed-crates
     if: ${{ needs.changed-crates.outputs.all == 'true' || needs.changed-crates.outputs.crates != '' }}
@@ -198,7 +198,7 @@ jobs:
   # conformance suite survives. Here we gate Kani proof harnesses and report counts.
   proof-ratchet:
     name: Proof Count Ratchet
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 5
     needs: changed-crates
     if: ${{ needs.changed-crates.outputs.all == 'true' || needs.changed-crates.outputs.crates != '' }}

--- a/.github/workflows/coverage-matrix.yml
+++ b/.github/workflows/coverage-matrix.yml
@@ -90,7 +90,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
           components: llvm-tools-preview
-          cache: true
+          cache: ${{ runner.environment == 'github-hosted' }}
       - name: Install cargo-llvm-cov
         run: cargo install cargo-llvm-cov --locked
       - name: Workspace coverage (threshold gate)
@@ -137,7 +137,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
-          cache: true
+          cache: ${{ runner.environment == 'github-hosted' }}
       - name: Install cargo-mutants
         run: cargo install cargo-mutants --locked
       - name: Run mutation tests on security-critical modules

--- a/.github/workflows/dep-hygiene.yml
+++ b/.github/workflows/dep-hygiene.yml
@@ -64,6 +64,10 @@ jobs:
           targets: wasm32-unknown-unknown
 
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2.9.1
+        # Hosted only: the self-hosted scale set has persistent registry and
+        # sccache mounts, and this action's restore of a hosted x86 cache blob
+        # was observed hanging runner jobs for 15+ minutes.
+        if: ${{ runner.environment == 'github-hosted' }}
 
       - name: Version-duplication ceiling (ed25519-dalek, sha2)
         run: bash scripts/check-dep-ceiling.sh

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
           toolchain: stable
-          cache: true
+          cache: ${{ runner.environment == 'github-hosted' }}
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24"

--- a/.github/workflows/dylint-separation.yml
+++ b/.github/workflows/dylint-separation.yml
@@ -290,6 +290,10 @@ jobs:
           rustup toolchain install nightly-2026-04-16 \
             --component rustc-dev,llvm-tools-preview --profile minimal
       - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.1
+        # Hosted only: the self-hosted scale set has persistent registry and
+        # sccache mounts, and this action's restore of a hosted x86 cache blob
+        # was observed hanging runner jobs for 15+ minutes.
+        if: ${{ runner.environment == 'github-hosted' }}
       - name: Install dylint
         run: cargo install cargo-dylint dylint-link --version 6.0.1 --locked
 

--- a/.github/workflows/dylint-separation.yml
+++ b/.github/workflows/dylint-separation.yml
@@ -75,6 +75,11 @@ jobs:
   cb4a-separation:
     name: cb4a_separation (enforced at zero)
     runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    env:
+      # dylint drives rustc through its own driver; sccache cannot wrap it
+      # ("could not compile proc-macro2 (build script): No such file or
+      # directory" on the self-hosted runners, where RUSTC_WRAPPER is pod-wide).
+      RUSTC_WRAPPER: ""
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -151,6 +156,11 @@ jobs:
   mediated:
     name: mediated (enforced at zero over the sealed effect boundary)
     runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    env:
+      # dylint drives rustc through its own driver; sccache cannot wrap it
+      # ("could not compile proc-macro2 (build script): No such file or
+      # directory" on the self-hosted runners, where RUSTC_WRAPPER is pod-wide).
+      RUSTC_WRAPPER: ""
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -200,6 +210,11 @@ jobs:
   identity-isolation:
     name: workload_identity_isolation (enforced at zero)
     runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    env:
+      # dylint drives rustc through its own driver; sccache cannot wrap it
+      # ("could not compile proc-macro2 (build script): No such file or
+      # directory" on the self-hosted runners, where RUSTC_WRAPPER is pod-wide).
+      RUSTC_WRAPPER: ""
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -257,6 +272,11 @@ jobs:
   unpoliced-http-client:
     name: unpoliced_http_client (guest egress)
     runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    env:
+      # dylint drives rustc through its own driver; sccache cannot wrap it
+      # ("could not compile proc-macro2 (build script): No such file or
+      # directory" on the self-hosted runners, where RUSTC_WRAPPER is pod-wide).
+      RUSTC_WRAPPER: ""
     timeout-minutes: 40
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/econ-lean.yml
+++ b/.github/workflows/econ-lean.yml
@@ -37,7 +37,7 @@ permissions:
 jobs:
   econ-lean:
     name: lake build Nucleus (econ proofs + golden seal)
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -103,9 +103,9 @@ jobs:
           path: |
             crates/nucleus-econ-kernels/lean/.lake
             ~/.elan
-          key: lean-econ-${{ runner.os }}-${{ hashFiles('crates/nucleus-econ-kernels/lean/lean-toolchain', 'crates/nucleus-econ-kernels/lean/lakefile.lean') }}
+          key: lean-econ-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('crates/nucleus-econ-kernels/lean/lean-toolchain', 'crates/nucleus-econ-kernels/lean/lakefile.lean') }}
           restore-keys: |
-            lean-econ-${{ runner.os }}-
+            lean-econ-${{ runner.os }}-${{ runner.arch }}-
 
       - name: lake build Nucleus (econ proofs + golden seal)
         if: steps.scope.outputs.relevant == 'true'

--- a/.github/workflows/econ-lean.yml
+++ b/.github/workflows/econ-lean.yml
@@ -110,7 +110,7 @@ jobs:
       - name: lake build Nucleus (econ proofs + golden seal)
         if: steps.scope.outputs.relevant == 'true'
         working-directory: crates/nucleus-econ-kernels/lean
-        run: lake build
+        run: lake build --jobs=2
 
       - name: Ban sorry / native_decide in econ Lean
         if: steps.scope.outputs.relevant == 'true'

--- a/.github/workflows/econ-lean.yml
+++ b/.github/workflows/econ-lean.yml
@@ -110,7 +110,7 @@ jobs:
       - name: lake build Nucleus (econ proofs + golden seal)
         if: steps.scope.outputs.relevant == 'true'
         working-directory: crates/nucleus-econ-kernels/lean
-        run: lake build --jobs=2
+        run: LEAN_NUM_THREADS=2 lake build
 
       - name: Ban sorry / native_decide in econ Lean
         if: steps.scope.outputs.relevant == 'true'

--- a/.github/workflows/econ-lean.yml
+++ b/.github/workflows/econ-lean.yml
@@ -97,7 +97,7 @@ jobs:
           echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
 
       - name: Cache Lake build artifacts
-        if: steps.scope.outputs.relevant == 'true'
+        if: ${{ runner.environment == 'github-hosted' && (steps.scope.outputs.relevant == 'true') }}
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
         with:
           path: |

--- a/.github/workflows/feature-matrix.yml
+++ b/.github/workflows/feature-matrix.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
+        with:
+          cache: ${{ runner.environment == 'github-hosted' }}
       - uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2.82.7
         with:
           tool: cargo-hack
@@ -60,6 +62,7 @@ jobs:
           # features. The Kani floor is lower and is enforced by the
           # `kani-msrv` job below — see the comment in the root Cargo.toml.
           toolchain: "1.95"
+          cache: ${{ runner.environment == 'github-hosted' }}
       # nucleus-verifier-service include_str!s the wasm-pack artifact
       # (sdks/verifier-js/pkg/) that only the Tests job builds first;
       # it is excluded here so the MSRV floor checks source, not
@@ -88,5 +91,6 @@ jobs:
         with:
           # Must match the rustc that kani-verifier bundles; bump with Kani.
           toolchain: "1.93"
+          cache: ${{ runner.environment == 'github-hosted' }}
       - name: Check the Kani-verified crates on Kani's toolchain
         run: cargo +1.93 check -p ck-kernel -p portcullis -p portcullis-core --locked

--- a/.github/workflows/kani-nightly.yml
+++ b/.github/workflows/kani-nightly.yml
@@ -47,6 +47,10 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2.9.1
+        # Hosted only: the self-hosted scale set has persistent registry and
+        # sccache mounts, and this action's restore of a hosted x86 cache blob
+        # was observed hanging runner jobs for 15+ minutes.
+        if: ${{ runner.environment == 'github-hosted' }}
         with:
           cache-on-failure: true
       - name: Cache Kani toolchain
@@ -113,6 +117,10 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2.9.1
+        # Hosted only: the self-hosted scale set has persistent registry and
+        # sccache mounts, and this action's restore of a hosted x86 cache blob
+        # was observed hanging runner jobs for 15+ minutes.
+        if: ${{ runner.environment == 'github-hosted' }}
         with:
           cache-on-failure: true
       - name: Cache Kani toolchain
@@ -195,6 +203,10 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2.9.1
+        # Hosted only: the self-hosted scale set has persistent registry and
+        # sccache mounts, and this action's restore of a hosted x86 cache blob
+        # was observed hanging runner jobs for 15+ minutes.
+        if: ${{ runner.environment == 'github-hosted' }}
         with:
           cache-on-failure: true
       - name: Cache Kani toolchain
@@ -255,6 +267,10 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2.9.1
+        # Hosted only: the self-hosted scale set has persistent registry and
+        # sccache mounts, and this action's restore of a hosted x86 cache blob
+        # was observed hanging runner jobs for 15+ minutes.
+        if: ${{ runner.environment == 'github-hosted' }}
         with:
           cache-on-failure: true
       - name: Cache Kani toolchain

--- a/.github/workflows/manifest-guards.yml
+++ b/.github/workflows/manifest-guards.yml
@@ -100,7 +100,9 @@ jobs:
         run: |
           set -euo pipefail
           ver=1.7.12
-          curl -fsSL "https://github.com/rhysd/actionlint/releases/download/v${ver}/actionlint_${ver}_linux_amd64.tar.gz" \
+          # Match the runner's architecture: the self-hosted scale set is arm64.
+          case "$(uname -m)" in aarch64|arm64) arch=arm64 ;; *) arch=amd64 ;; esac
+          curl -fsSL "https://github.com/rhysd/actionlint/releases/download/v${ver}/actionlint_${ver}_linux_${arch}.tar.gz" \
             | tar xz actionlint
           # Syntax and expression errors only. Shellcheck style inside `run:`
           # blocks is a separate, noisier question and is not gated here.

--- a/.github/workflows/manifest-guards.yml
+++ b/.github/workflows/manifest-guards.yml
@@ -36,7 +36,7 @@ permissions:
 jobs:
   manifest-guards:
     name: Manifest Guards
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 10
     env:
       CARGO_TERM_COLOR: never

--- a/.github/workflows/manifest-guards.yml
+++ b/.github/workflows/manifest-guards.yml
@@ -45,7 +45,7 @@ jobs:
 
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
-          cache: true
+          cache: ${{ runner.environment == 'github-hosted' }}
 
       - name: Cargo metadata smoke (whole workspace parses, empty stderr)
         run: |

--- a/.github/workflows/oidc-keyless-prototype.yml
+++ b/.github/workflows/oidc-keyless-prototype.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up Rust toolchain (pinned via rust-toolchain.toml)
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
-          cache: true
+          cache: ${{ runner.environment == 'github-hosted' }}
 
       - name: Confirm the OIDC request env vars are present
         # Sanity check that id-token: write took effect on this runner. We do

--- a/.github/workflows/portcullis-core-proven-lean.yml
+++ b/.github/workflows/portcullis-core-proven-lean.yml
@@ -127,7 +127,7 @@ jobs:
         if: steps.scope.outputs.relevant == 'true'
         working-directory: crates/portcullis-core/lean
         run: |
-          lake build --jobs=2 \
+          LEAN_NUM_THREADS=2 lake build \
             PortcullisCoreBridge \
             PortcullisCoreIFC \
             IntegrityNoninterferenceExtracted \

--- a/.github/workflows/portcullis-core-proven-lean.yml
+++ b/.github/workflows/portcullis-core-proven-lean.yml
@@ -48,7 +48,7 @@ permissions:
 jobs:
   portcullis-core-proven-lean:
     name: lake build + sorry-ban (proven tier)
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -113,9 +113,9 @@ jobs:
             crates/portcullis-core/lean/.lake
             ~/.elan
             ~/.cache/mathlib
-          key: lean-aeneas-${{ runner.os }}-${{ hashFiles('crates/portcullis-core/lean/lean-toolchain', 'crates/portcullis-core/lean/lakefile.lean', 'crates/portcullis-core/lean/lake-manifest.json') }}
+          key: lean-aeneas-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('crates/portcullis-core/lean/lean-toolchain', 'crates/portcullis-core/lean/lakefile.lean', 'crates/portcullis-core/lean/lake-manifest.json') }}
           restore-keys: |
-            lean-aeneas-${{ runner.os }}-
+            lean-aeneas-${{ runner.os }}-${{ runner.arch }}-
 
       # Prebuilt Mathlib oleans from Azure: ~5 min vs ~1 h cold compile.
       - name: Fetch Mathlib cache (prebuilt oleans)

--- a/.github/workflows/portcullis-core-proven-lean.yml
+++ b/.github/workflows/portcullis-core-proven-lean.yml
@@ -106,7 +106,7 @@ jobs:
 
       # Cache-poisoning ignored: formal-proof build only, no published artifacts.
       - name: Cache Lake / Mathlib build artifacts
-        if: steps.scope.outputs.relevant == 'true'
+        if: ${{ runner.environment == 'github-hosted' && (steps.scope.outputs.relevant == 'true') }}
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5 # zizmor: ignore[cache-poisoning]
         with:
           path: |

--- a/.github/workflows/portcullis-core-proven-lean.yml
+++ b/.github/workflows/portcullis-core-proven-lean.yml
@@ -127,7 +127,7 @@ jobs:
         if: steps.scope.outputs.relevant == 'true'
         working-directory: crates/portcullis-core/lean
         run: |
-          lake build \
+          lake build --jobs=2 \
             PortcullisCoreBridge \
             PortcullisCoreIFC \
             IntegrityNoninterferenceExtracted \

--- a/.github/workflows/research-lean-build.yml
+++ b/.github/workflows/research-lean-build.yml
@@ -51,6 +51,10 @@ jobs:
 
       - name: Cache Lake / Mathlib build artifacts
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5 # zizmor: ignore[cache-poisoning]
+        # Hosted only: the self-hosted runners keep their caches on persistent
+        # mounts, and uploading a cache from them was observed pinning a runner in
+        # the save step for 15+ minutes.
+        if: ${{ runner.environment == 'github-hosted' }}
         with:
           path: |
             crates/portcullis-core/lean/.lake

--- a/.github/workflows/research-lean-build.yml
+++ b/.github/workflows/research-lean-build.yml
@@ -71,7 +71,7 @@ jobs:
       - name: lake build (research cluster — type-check; a broken proof FAILS here)
         working-directory: crates/portcullis-core/lean
         run: |
-          lake build --jobs=2 \
+          LEAN_NUM_THREADS=2 lake build \
             MatrixBridge \
             RankNullity \
             AlignmentTaxBridge \

--- a/.github/workflows/research-lean-build.yml
+++ b/.github/workflows/research-lean-build.yml
@@ -39,7 +39,7 @@ permissions:
 jobs:
   research-lean-build:
     name: lake build + sorry-ratchet (research tier)
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -56,9 +56,9 @@ jobs:
             crates/portcullis-core/lean/.lake
             ~/.elan
             ~/.cache/mathlib
-          key: lean-aeneas-${{ runner.os }}-${{ hashFiles('crates/portcullis-core/lean/lean-toolchain', 'crates/portcullis-core/lean/lakefile.lean', 'crates/portcullis-core/lean/lake-manifest.json') }}
+          key: lean-aeneas-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('crates/portcullis-core/lean/lean-toolchain', 'crates/portcullis-core/lean/lakefile.lean', 'crates/portcullis-core/lean/lake-manifest.json') }}
           restore-keys: |
-            lean-aeneas-${{ runner.os }}-
+            lean-aeneas-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Fetch Mathlib cache (prebuilt oleans)
         working-directory: crates/portcullis-core/lean

--- a/.github/workflows/research-lean-build.yml
+++ b/.github/workflows/research-lean-build.yml
@@ -71,7 +71,7 @@ jobs:
       - name: lake build (research cluster — type-check; a broken proof FAILS here)
         working-directory: crates/portcullis-core/lean
         run: |
-          lake build \
+          lake build --jobs=2 \
             MatrixBridge \
             RankNullity \
             AlignmentTaxBridge \

--- a/.github/workflows/rubric-lean.yml
+++ b/.github/workflows/rubric-lean.yml
@@ -33,7 +33,7 @@ permissions:
 jobs:
   rubric-lean:
     name: lake build Nucleus (rubric scoring proofs)
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -99,9 +99,9 @@ jobs:
           path: |
             crates/nucleus-rubric/lean/.lake
             ~/.elan
-          key: lean-rubric-${{ runner.os }}-${{ hashFiles('crates/nucleus-rubric/lean/lean-toolchain', 'crates/nucleus-rubric/lean/lakefile.lean') }}
+          key: lean-rubric-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('crates/nucleus-rubric/lean/lean-toolchain', 'crates/nucleus-rubric/lean/lakefile.lean') }}
           restore-keys: |
-            lean-rubric-${{ runner.os }}-
+            lean-rubric-${{ runner.os }}-${{ runner.arch }}-
 
       - name: lake build Nucleus (rubric scoring proofs)
         if: steps.scope.outputs.relevant == 'true'

--- a/.github/workflows/rubric-lean.yml
+++ b/.github/workflows/rubric-lean.yml
@@ -93,7 +93,7 @@ jobs:
           echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
 
       - name: Cache Lake build artifacts
-        if: steps.scope.outputs.relevant == 'true'
+        if: ${{ runner.environment == 'github-hosted' && (steps.scope.outputs.relevant == 'true') }}
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
         with:
           path: |

--- a/.github/workflows/rubric-lean.yml
+++ b/.github/workflows/rubric-lean.yml
@@ -106,7 +106,7 @@ jobs:
       - name: lake build Nucleus (rubric scoring proofs)
         if: steps.scope.outputs.relevant == 'true'
         working-directory: crates/nucleus-rubric/lean
-        run: lake build --jobs=2
+        run: LEAN_NUM_THREADS=2 lake build
 
       - name: Ban sorry / admit / native_decide / sorryAx in rubric Lean
         if: steps.scope.outputs.relevant == 'true'

--- a/.github/workflows/rubric-lean.yml
+++ b/.github/workflows/rubric-lean.yml
@@ -106,7 +106,7 @@ jobs:
       - name: lake build Nucleus (rubric scoring proofs)
         if: steps.scope.outputs.relevant == 'true'
         working-directory: crates/nucleus-rubric/lean
-        run: lake build
+        run: lake build --jobs=2
 
       - name: Ban sorry / admit / native_decide / sorryAx in rubric Lean
         if: steps.scope.outputs.relevant == 'true'

--- a/.github/workflows/scan-attest.yml
+++ b/.github/workflows/scan-attest.yml
@@ -58,7 +58,7 @@ jobs:
 
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
-          cache: true
+          cache: ${{ runner.environment == 'github-hosted' }}
 
       - name: Build nucleus-audit
         run: cargo build -p nucleus-audit --release

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
-          cache: true
+          cache: ${{ runner.environment == 'github-hosted' }}
 
       - name: Build nucleus-audit
         run: cargo build -p nucleus-audit --release

--- a/.github/workflows/tpm-and-net-isolation.yml
+++ b/.github/workflows/tpm-and-net-isolation.yml
@@ -57,6 +57,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
+        with:
+          cache: ${{ runner.environment == 'github-hosted' }}
 
       - name: Install swtpm + tpm2-tools
         run: sudo apt-get update && sudo apt-get install -y -qq swtpm tpm2-tools

--- a/.github/workflows/wasm-pure-crates.yml
+++ b/.github/workflows/wasm-pure-crates.yml
@@ -97,7 +97,7 @@ jobs:
         run: rustup target add wasm32-unknown-unknown
 
       - name: Cache cargo + target
-        if: steps.scope.outputs.relevant == 'true'
+        if: ${{ runner.environment == 'github-hosted' && (steps.scope.outputs.relevant == 'true') }}
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
         with:
           path: |


### PR DESCRIPTION
The merge queue builds up to five entries in parallel, but each group's wall time is its slowest **hosted** job. Of the required checks still hosted, the Lean builds, coverage and mutation wait 20–30 minutes for a hosted VM; this routes them to `nucleus-k3s` behind the same `vars.CI_RUNNER` switch.

The Lean workflows stayed hosted until now because their `actions/cache` keys were keyed on `runner.os` only, so the first cohort run restored an x86_64 Lean toolchain over an arm64 runner (`Exec format error` in every lake job). Keys and restore-keys now include `runner.arch`. Workflows using the shared `lean-mathlib-cache` action (Aeneas jobs, lean-build) stay hosted: that action's key lacks the arch and the Aeneas jobs need x86-only prebuilt binaries. CodeQL stays hosted.

Still hosted and required after this: Analyze (CodeQL), Kani (constitutional kernel) until #2493 lands its Kani routing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZaH5waz88vL1qfNpFNfZ4