### PR TITLE
ci(probes): every boot-gated probe is a requireable context; runner unavailability is red, never green (#2604)

### DIFF
--- a/.github/workflows/adversary-probe-noop.yml
+++ b/.github/workflows/adversary-probe-noop.yml
@@ -1,0 +1,29 @@
+name: Adversary probe contains a live attacker (falsifier)
+
+# The requireable twin of adversary-probe.yml (#2604): same job NAME, runs only
+# on pull_request events whose changed paths are OUTSIDE the probe's declared
+# inputs (paths-ignore mirrors adversary-probe.yml's paths exactly), and passes
+# vacuously. It does NOT run in the merge queue: there the real workflow runs
+# and decides scope from the group's diff.
+on:
+  pull_request:
+    paths-ignore:
+      - "crates/nucleus-adversary-probe/**"
+      - "scripts/check-adversary-probe.sh"
+      - ".github/workflows/adversary-probe.yml"
+
+concurrency:
+  group: adversary-probe-noop-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  adversary-probe-falsifier:
+    name: adversary probe distinguishes contained / breach / inconclusive
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 5
+    steps:
+      - name: No-op (probe inputs not touched)
+        run: echo "no adversary-probe inputs changed - gate vacuously green; the real falsifier ran on the PR that touched them"

--- a/.github/workflows/adversary-probe.yml
+++ b/.github/workflows/adversary-probe.yml
@@ -32,14 +32,20 @@ on:
       - "crates/nucleus-adversary-probe/**"
       - "scripts/check-adversary-probe.sh"
       - ".github/workflows/adversary-probe.yml"
+  # `paths:` under merge_group is ignored by GitHub; the scope step below
+  # re-derives it from the group's diff (ci/merge-group-scope-parity.sh keeps the
+  # two in agreement).
+  merge_group:
   workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: adversary-probe-${{ github.ref }}
-  cancel-in-progress: true
+  group: adversary-probe-${{ github.head_ref || github.ref }}
+  # Only pull_request runs are superseded; a merge_group run is a queue entry's
+  # own check and a main push is a landed commit's signal.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   adversary-probe-falsifier:
@@ -48,12 +54,40 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      - name: Is this change in scope?
+        id: scope
+        env:
+          # Never interpolate ${{ }} into a run script (zizmor hardening).
+          EVENT: ${{ github.event_name }}
+          BASE: ${{ github.event.merge_group.base_sha }}
+          HEAD: ${{ github.event.merge_group.head_sha }}
+          PATTERN: '^\.github/workflows/adversary\-probe\.yml$|^crates/nucleus\-adversary\-probe/|^scripts/check\-adversary\-probe\.sh$'
+        run: |
+          set -euo pipefail
+          if [ "$EVENT" != "merge_group" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ -z "${BASE:-}" ] || [ -z "${HEAD:-}" ]; then
+            # Fail OPEN: an unknown range must run, never skip.
+            echo "relevant=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if git diff --name-only "$BASE" "$HEAD" | grep -qE "$PATTERN"; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"; echo "in scope -- running."
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+            echo "nothing in this merge group touches the probe's inputs; skipping (the PR that touched them ran it)"
+          fi
       - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+        if: steps.scope.outputs.relevant == 'true'
         with:
           toolchain: stable
       - name: Build the adversary probe
+        if: steps.scope.outputs.relevant == 'true'
         run: cargo build --release -p nucleus-adversary-probe
       - name: Falsify — the campaign must distinguish all three verdict states
+        if: steps.scope.outputs.relevant == 'true'
         run: |
           ADVERSARY_PROBE_BIN=target/release/nucleus-adversary-probe \
             scripts/check-adversary-probe.sh

--- a/.github/workflows/podlist-probe-noop.yml
+++ b/.github/workflows/podlist-probe-noop.yml
@@ -1,0 +1,36 @@
+name: podlist-probe
+
+# The requireable twin of podlist-probe.yml (#2604): same job NAME, runs only on
+# pull_request events whose changed paths are OUTSIDE the probe's declared
+# inputs (paths-ignore mirrors podlist-probe.yml's paths exactly), and passes
+# vacuously. It does NOT run in the merge queue: there the real workflow runs
+# and decides scope from the group's diff, so an unavailable KVM runner shows
+# as red, never as this twin's green.
+on:
+  pull_request:
+    paths-ignore:
+      - "crates/nucleus-podlist-probe/**"
+      - "crates/nucleus-node/**"
+      - "crates/nucleus-tool-proxy/**"
+      - "crates/nucleus-guest-init/**"
+      - "examples/openclaw-demo/podlist-probe-pod.yaml"
+      - "scripts/firecracker/podlist-boot-check.sh"
+      - "scripts/firecracker/build-rootfs.sh"
+      - "scripts/cross-build.sh"
+      - ".github/workflows/podlist-probe.yml"
+
+concurrency:
+  group: podlist-probe-noop-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  podlist-probe:
+    name: the C2 podlist probe is served a lineage-scoped listing on a real guest (x86_64)
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 5
+    steps:
+      - name: No-op (probe inputs not touched)
+        run: echo "no podlist-probe inputs changed - gate vacuously green; the real boot ran on the PR that touched them"

--- a/.github/workflows/podlist-probe.yml
+++ b/.github/workflows/podlist-probe.yml
@@ -113,14 +113,18 @@ jobs:
       - name: Install this build as the Tier 2 host (firecracker, jailer, kernel)
         if: steps.scope.outputs.relevant == 'true'
         run: |
+          # Stage the guest image and node BEFORE `nucleus setup`: with
+          # --artifacts local the installer RENAMES the working-tree rootfs
+          # and node into /var/lib/nucleus/artifacts (provision.rs installs
+          # by rename, not copy), so a copy after setup finds nothing.
+          mkdir -p "$HOME/fc"
+          cp build/firecracker/x86_64/rootfs.ext4 "$HOME/fc/podlist-rootfs.ext4"
+          cp target/x86_64-unknown-linux-musl/release/nucleus-node "$HOME/fc/nucleus-node"
           sudo cp target/x86_64-unknown-linux-musl/release/nucleus /usr/local/bin/nucleus
           nucleus setup --skip-verify --artifacts local
           kernel=$(sudo find /var/lib/nucleus /etc/nucleus "$HOME/.nucleus" -name 'vmlinux*' -type f 2>/dev/null | head -1)
           test -n "$kernel" || { echo "::error::nucleus setup left no vmlinux to boot"; exit 1; }
-          mkdir -p "$HOME/fc"
           sudo cp "$kernel" "$HOME/fc/vmlinux"; sudo chown "$(id -u)" "$HOME/fc/vmlinux"
-          cp build/firecracker/x86_64/rootfs.ext4 "$HOME/fc/podlist-rootfs.ext4"
-          cp target/x86_64-unknown-linux-musl/release/nucleus-node "$HOME/fc/nucleus-node"
           ls -la "$HOME/fc"
       - name: Boot A, spawn child C and sibling B, assert the scoped listing
         if: steps.scope.outputs.relevant == 'true'

--- a/.github/workflows/podlist-probe.yml
+++ b/.github/workflows/podlist-probe.yml
@@ -126,11 +126,17 @@ jobs:
           test -n "$kernel" || { echo "::error::nucleus setup left no vmlinux to boot"; exit 1; }
           sudo cp "$kernel" "$HOME/fc/vmlinux"; sudo chown "$(id -u)" "$HOME/fc/vmlinux"
           ls -la "$HOME/fc"
+      - name: Build the operator's cert minter (nucleus-identity example, host target)
+        if: steps.scope.outputs.relevant == 'true'
+        # The node's HTTP API is mTLS-only; the harness mints the operator's client
+        # cert from the node's own CA with this example.
+        run: cargo build -p nucleus-identity --example mint_test_client_cert
       - name: Boot A, spawn child C and sibling B, assert the scoped listing
         if: steps.scope.outputs.relevant == 'true'
         run: |
           FC_DIR="$HOME/fc" KERNEL="$HOME/fc/vmlinux" ROOTFS="$HOME/fc/podlist-rootfs.ext4" \
-          NODE_BIN="$HOME/fc/nucleus-node" \
+          NODE_BIN="$HOME/fc/nucleus-node" CLI=/usr/local/bin/nucleus \
+          MINT=target/debug/examples/mint_test_client_cert \
             bash scripts/firecracker/podlist-boot-check.sh
       - name: Show the guest logs on failure
         if: failure() && steps.scope.outputs.relevant == 'true'

--- a/.github/workflows/podlist-probe.yml
+++ b/.github/workflows/podlist-probe.yml
@@ -94,6 +94,10 @@ jobs:
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y -qq musl-tools e2fsprogs
+          # The build runs on the toolchain rust-toolchain.toml pins, not `stable`,
+          # so the musl target must be added to THAT toolchain (as quickstart-boot does).
+          rustup target add x86_64-unknown-linux-musl
+          rustup target list --installed | grep -q x86_64-unknown-linux-musl
           rootfs_pkgs=$(bash scripts/cross-build.sh --list-packages | sed 's/^/-p /' | tr '\n' ' ')
           echo "rootfs packages: $rootfs_pkgs"
           # shellcheck disable=SC2086

--- a/.github/workflows/podlist-probe.yml
+++ b/.github/workflows/podlist-probe.yml
@@ -1,0 +1,130 @@
+name: podlist-probe
+
+# The C2 cross-pod backstop on a REAL guest (#2604): pod A, booted under
+# Firecracker with a jailer, calls the scoped POD_LIST over its own vsock and the
+# host asserts the listing is confined to A's lineage (A and its child C, never
+# sibling B). `scripts/firecracker/podlist-boot-check.sh` is the harness;
+# `crates/nucleus-podlist-probe` is the in-guest workload. Until this workflow
+# existed the probe had no CI lane at all — it was baked and never booted.
+#
+# Boot-gated like quickstart-boot.yml: x86_64 hosted runners have /dev/kvm; the
+# job REFUSES a runner without it rather than skipping, so runner unavailability
+# is red, never green. The noop twin (podlist-probe-noop.yml) passes only when
+# the declared paths are untouched on a pull_request; in the merge queue this
+# workflow runs and decides scope itself from the group's diff.
+#
+# What this does not cover: aarch64 Firecracker (no hosted arm64 runner has
+# KVM; the weekly metal job in quickstart-boot.yml does) and Apple Silicon's
+# `vz` driver, which is a different driver and not Firecracker coverage.
+on:
+  pull_request:
+    paths:
+      - "crates/nucleus-podlist-probe/**"
+      - "crates/nucleus-node/**"
+      - "crates/nucleus-tool-proxy/**"
+      - "crates/nucleus-guest-init/**"
+      - "examples/openclaw-demo/podlist-probe-pod.yaml"
+      - "scripts/firecracker/podlist-boot-check.sh"
+      - "scripts/firecracker/build-rootfs.sh"
+      - "scripts/cross-build.sh"
+      - ".github/workflows/podlist-probe.yml"
+  # `paths:` under merge_group is ignored by GitHub; the scope step re-derives
+  # it from the group's diff (ci/merge-group-scope-parity.sh keeps the two in
+  # agreement).
+  merge_group:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: podlist-probe-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  podlist-probe:
+    name: the C2 podlist probe is served a lineage-scoped listing on a real guest (x86_64)
+    # KVM: hosted x86_64 runners expose /dev/kvm; the self-hosted arm64 scale set
+    # does not, so this job is deliberately NOT behind vars.CI_RUNNER.
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      - name: Is this change in scope?
+        id: scope
+        env:
+          # Never interpolate ${{ }} into a run script (zizmor hardening).
+          EVENT: ${{ github.event_name }}
+          BASE: ${{ github.event.merge_group.base_sha }}
+          HEAD: ${{ github.event.merge_group.head_sha }}
+          PATTERN: '^\.github/workflows/podlist\-probe\.yml$|^crates/nucleus\-podlist\-probe/|^crates/nucleus\-node/|^crates/nucleus\-tool\-proxy/|^crates/nucleus\-guest\-init/|^examples/openclaw\-demo/podlist\-probe\-pod\.yaml$|^scripts/firecracker/podlist\-boot\-check\.sh$|^scripts/firecracker/build\-rootfs\.sh$|^scripts/cross\-build\.sh$'
+        run: |
+          set -euo pipefail
+          if [ "$EVENT" != "merge_group" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ -z "${BASE:-}" ] || [ -z "${HEAD:-}" ]; then
+            # Fail OPEN: an unknown range must run, never skip.
+            echo "relevant=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if git diff --name-only "$BASE" "$HEAD" | grep -qE "$PATTERN"; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"; echo "in scope -- running."
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+            echo "nothing in this merge group touches the probe's inputs; skipping (the PR that touched them ran it)"
+          fi
+      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+        if: steps.scope.outputs.relevant == 'true'
+        with:
+          toolchain: stable
+          targets: x86_64-unknown-linux-musl
+      - name: This runner must actually have KVM and vsock (refuse, never skip)
+        if: steps.scope.outputs.relevant == 'true'
+        run: |
+          test -e /dev/kvm || { echo "::error::no /dev/kvm on this runner — the probe cannot boot; this is RED, not a skip"; exit 1; }
+          sudo chmod 666 /dev/kvm
+          sudo modprobe vhost_vsock
+          test -e /dev/vhost-vsock || { echo "::error::no /dev/vhost-vsock"; exit 1; }
+      - name: Build the host, guest and probe binaries (musl)
+        if: steps.scope.outputs.relevant == 'true'
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq musl-tools e2fsprogs
+          rootfs_pkgs=$(bash scripts/cross-build.sh --list-packages | sed 's/^/-p /' | tr '\n' ' ')
+          echo "rootfs packages: $rootfs_pkgs"
+          # shellcheck disable=SC2086
+          cargo build --release --target x86_64-unknown-linux-musl \
+            -p nucleus-cli -p nucleus-node -p nucleus-podlist-probe $rootfs_pkgs
+      - name: Build the podlist guest rootfs (probe baked, orchestrator pod spec)
+        if: steps.scope.outputs.relevant == 'true'
+        run: |
+          POD_SPEC="$PWD/examples/openclaw-demo/podlist-probe-pod.yaml" \
+          PODLIST_PROBE_BIN="$PWD/target/x86_64-unknown-linux-musl/release/nucleus-podlist-probe" \
+            ARCH=x86_64 bash ./scripts/firecracker/build-rootfs.sh
+          test -s build/firecracker/x86_64/rootfs.ext4
+      - name: Install this build as the Tier 2 host (firecracker, jailer, kernel)
+        if: steps.scope.outputs.relevant == 'true'
+        run: |
+          sudo cp target/x86_64-unknown-linux-musl/release/nucleus /usr/local/bin/nucleus
+          nucleus setup --skip-verify --artifacts local
+          kernel=$(sudo find /var/lib/nucleus /etc/nucleus "$HOME/.nucleus" -name 'vmlinux*' -type f 2>/dev/null | head -1)
+          test -n "$kernel" || { echo "::error::nucleus setup left no vmlinux to boot"; exit 1; }
+          mkdir -p "$HOME/fc"
+          sudo cp "$kernel" "$HOME/fc/vmlinux"; sudo chown "$(id -u)" "$HOME/fc/vmlinux"
+          cp build/firecracker/x86_64/rootfs.ext4 "$HOME/fc/podlist-rootfs.ext4"
+          cp target/x86_64-unknown-linux-musl/release/nucleus-node "$HOME/fc/nucleus-node"
+          ls -la "$HOME/fc"
+      - name: Boot A, spawn child C and sibling B, assert the scoped listing
+        if: steps.scope.outputs.relevant == 'true'
+        run: |
+          FC_DIR="$HOME/fc" KERNEL="$HOME/fc/vmlinux" ROOTFS="$HOME/fc/podlist-rootfs.ext4" \
+          NODE_BIN="$HOME/fc/nucleus-node" \
+            bash scripts/firecracker/podlist-boot-check.sh
+      - name: Show the guest logs on failure
+        if: failure() && steps.scope.outputs.relevant == 'true'
+        run: |
+          find "$HOME/fc" -name '*.log' -exec sh -c 'echo "== $1 =="; tail -80 "$1"' _ {} \; 2>/dev/null || true

--- a/.github/workflows/quickstart-boot-noop.yml
+++ b/.github/workflows/quickstart-boot-noop.yml
@@ -37,7 +37,6 @@ on:
       - "scripts/firecracker/**"
       - "scripts/lima/**"
       - ".github/workflows/quickstart-boot.yml"
-  merge_group:
 
 concurrency:
   # Supersede a PR's older in-flight runs; NEVER cancel anything else.
@@ -56,5 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: No-op (boot paths not touched, or in the merge queue)
-        run: echo "no boot-affecting paths changed (or merge_group) — gate vacuously green; the real boot ran on the PR that touched them"
+      - name: No-op (boot paths not touched)
+        run: |
+          echo "no boot-affecting paths changed - gate vacuously green."
+          echo "In the merge queue the REAL workflow runs and decides scope itself (#2604); an unavailable KVM runner is red there, never green."

--- a/.github/workflows/quickstart-boot.yml
+++ b/.github/workflows/quickstart-boot.yml
@@ -50,6 +50,11 @@ on:
       - "scripts/firecracker/**"
       - "scripts/lima/**"
       - ".github/workflows/quickstart-boot.yml"
+  # `paths:` under merge_group is ignored by GitHub; each job's scope step
+  # re-derives it from the group's diff, so the merge queue boots a pod exactly
+  # when a queued change touches the boot inputs (ci/merge-group-scope-parity.sh
+  # keeps PATTERN and the list above in agreement).
+  merge_group:
   push:
     branches: [main]
   schedule:
@@ -85,12 +90,40 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      - name: Is this change in scope?
+        id: scope
+        env:
+          # Never interpolate ${{ }} into a run script (zizmor hardening).
+          EVENT: ${{ github.event_name }}
+          BASE: ${{ github.event.merge_group.base_sha }}
+          HEAD: ${{ github.event.merge_group.head_sha }}
+          PATTERN: '^\.github/workflows/quickstart\-boot\.yml$|^crates/nucleus\-cli/|^crates/nucleus\-node/|^crates/nucleus\-spec/|^crates/nucleus\-guest\-init/|^crates/nucleus\-tool\-proxy/|^crates/nucleus\-workload\-probe/|^crates/nucleus\-egress\-probe/|^scripts/check\-egress\-probe\.sh$|^examples/openclaw\-demo/probe\-pod\.yaml$|^scripts/firecracker/|^scripts/lima/'
+        run: |
+          set -euo pipefail
+          if [ "$EVENT" != "merge_group" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ -z "${BASE:-}" ] || [ -z "${HEAD:-}" ]; then
+            # Fail OPEN: an unknown range must run, never skip.
+            echo "relevant=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if git diff --name-only "$BASE" "$HEAD" | grep -qE "$PATTERN"; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"; echo "in scope -- running."
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+            echo "nothing in this merge group touches the probe's inputs; skipping (the PR that touched them ran it)"
+          fi
       - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+        if: steps.scope.outputs.relevant == 'true'
         with:
           toolchain: stable
       - name: Build the egress probe
+        if: steps.scope.outputs.relevant == 'true'
         run: cargo build --release -p nucleus-egress-probe
       - name: Falsify — the probe must track the fence in all three states
+        if: steps.scope.outputs.relevant == 'true'
         run: |
           # iptables is present on ubuntu-24.04; the script uses sudo for netns.
           EGRESS_PROBE_BIN=target/release/nucleus-egress-probe \
@@ -101,16 +134,44 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      - name: Is this change in scope?
+        id: scope
+        env:
+          # Never interpolate ${{ }} into a run script (zizmor hardening).
+          EVENT: ${{ github.event_name }}
+          BASE: ${{ github.event.merge_group.base_sha }}
+          HEAD: ${{ github.event.merge_group.head_sha }}
+          PATTERN: '^\.github/workflows/quickstart\-boot\.yml$|^crates/nucleus\-cli/|^crates/nucleus\-node/|^crates/nucleus\-spec/|^crates/nucleus\-guest\-init/|^crates/nucleus\-tool\-proxy/|^crates/nucleus\-workload\-probe/|^crates/nucleus\-egress\-probe/|^scripts/check\-egress\-probe\.sh$|^examples/openclaw\-demo/probe\-pod\.yaml$|^scripts/firecracker/|^scripts/lima/'
+        run: |
+          set -euo pipefail
+          if [ "$EVENT" != "merge_group" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ -z "${BASE:-}" ] || [ -z "${HEAD:-}" ]; then
+            # Fail OPEN: an unknown range must run, never skip.
+            echo "relevant=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if git diff --name-only "$BASE" "$HEAD" | grep -qE "$PATTERN"; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"; echo "in scope -- running."
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+            echo "nothing in this merge group touches the probe's inputs; skipping (the PR that touched them ran it)"
+          fi
       - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+        if: steps.scope.outputs.relevant == 'true'
         with:
           toolchain: stable
       - name: Print the pin manifest
+        if: steps.scope.outputs.relevant == 'true'
         id: pins
         run: |
           cargo run -q -p nucleus-cli -- verify --pins > pins.json
           cat pins.json
 
       - name: Kernels must resolve and match their baked digest
+        if: steps.scope.outputs.relevant == 'true'
         run: |
           set -euo pipefail
           fail=0
@@ -143,6 +204,7 @@ jobs:
           exit $fail
 
       - name: Release assets — missing is an error, unpublished is a notice
+        if: steps.scope.outputs.relevant == 'true'
         run: |
           set -euo pipefail
           version=$(jq -r 'map(select(.release)) | .[0].release' pins.json)
@@ -249,7 +311,33 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      - name: Is this change in scope?
+        id: scope
+        env:
+          # Never interpolate ${{ }} into a run script (zizmor hardening).
+          EVENT: ${{ github.event_name }}
+          BASE: ${{ github.event.merge_group.base_sha }}
+          HEAD: ${{ github.event.merge_group.head_sha }}
+          PATTERN: '^\.github/workflows/quickstart\-boot\.yml$|^crates/nucleus\-cli/|^crates/nucleus\-node/|^crates/nucleus\-spec/|^crates/nucleus\-guest\-init/|^crates/nucleus\-tool\-proxy/|^crates/nucleus\-workload\-probe/|^crates/nucleus\-egress\-probe/|^scripts/check\-egress\-probe\.sh$|^examples/openclaw\-demo/probe\-pod\.yaml$|^scripts/firecracker/|^scripts/lima/'
+        run: |
+          set -euo pipefail
+          if [ "$EVENT" != "merge_group" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ -z "${BASE:-}" ] || [ -z "${HEAD:-}" ]; then
+            # Fail OPEN: an unknown range must run, never skip.
+            echo "relevant=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if git diff --name-only "$BASE" "$HEAD" | grep -qE "$PATTERN"; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"; echo "in scope -- running."
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+            echo "nothing in this merge group touches the probe's inputs; skipping (the PR that touched them ran it)"
+          fi
       - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+        if: steps.scope.outputs.relevant == 'true'
         with:
           # `toolchain` is REQUIRED when the action is pinned by SHA: the tag name
           # is what would otherwise supply it, and a SHA carries no tag.
@@ -263,6 +351,7 @@ jobs:
           toolchain: stable
 
       - name: This runner must actually have KVM
+        if: steps.scope.outputs.relevant == 'true'
         run: |
           # Asserted, not assumed. Without /dev/kvm Firecracker does not start,
           # and every later step would fail for a reason that looks like nucleus.
@@ -278,6 +367,7 @@ jobs:
           ls -l /dev/vhost-vsock
 
       - name: Build the guest and host binaries
+        if: steps.scope.outputs.relevant == 'true'
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y -qq musl-tools e2fsprogs
@@ -299,6 +389,7 @@ jobs:
             -p nucleus-cli -p nucleus-node $rootfs_pkgs
 
       - name: Build the guest rootfs
+        if: steps.scope.outputs.relevant == 'true'
         run: |
           # The CA bundle this installs is load-bearing: without it the
           # tool-proxy's drand client fails and, as PID 1, takes the guest
@@ -318,6 +409,7 @@ jobs:
           test -s build/firecracker/x86_64/rootfs.ext4
 
       - name: Install this build as the Tier 2 host
+        if: steps.scope.outputs.relevant == 'true'
         run: |
           sudo cp target/x86_64-unknown-linux-musl/release/nucleus /usr/local/bin/nucleus
           # --artifacts local: gate THIS commit, not the last release. Using
@@ -325,6 +417,7 @@ jobs:
           nucleus setup --skip-verify --artifacts local
 
       - name: Plant a canary in the NODE's environment
+        if: steps.scope.outputs.relevant == 'true'
         shell: bash
         run: |
           # The node's environment holds every HMAC secret the runtime has, and
@@ -343,6 +436,7 @@ jobs:
           echo "NUCLEUS_E2E_CANARY=$CANARY" >> "$GITHUB_ENV"
 
       - name: Boot a real pod and assert what the guest did
+        if: steps.scope.outputs.relevant == 'true'
         shell: bash
         run: |
           # The whole point. Asserts, in order: the pod is created; a permitted
@@ -352,6 +446,7 @@ jobs:
           nucleus verify --tier2 --here
 
       - name: The in-guest posture probe actually ran (presence, not just verdict)
+        if: steps.scope.outputs.relevant == 'true'
         run: |
           # verify's probe needle is conditional on the sentinel appearing, so it
           # cannot fail vacuously — but a probe that failed to EXEC (missing from
@@ -380,6 +475,7 @@ jobs:
           echo "in-guest workload probe: PASS present, FAIL absent"
 
       - name: The in-guest egress backstop actually held (C6 phase 2, presence + verdict)
+        if: steps.scope.outputs.relevant == 'true'
         run: |
           # The egress probe runs as the same booted workload (network.allow: []),
           # so the pod is under net::apply_default_deny. It asserts, from inside
@@ -408,6 +504,7 @@ jobs:
           echo "in-guest egress backstop: PASS present, FAIL absent"
 
       - name: The in-guest adversary was contained (active attacker, presence + verdict)
+        if: steps.scope.outputs.relevant == 'true'
         run: |
           # nucleus-adversary-probe runs as the same booted workload — an ACTIVE
           # attacker that tries to steal a mediator secret from PID 1, tamper the
@@ -447,6 +544,7 @@ jobs:
           echo "in-guest adversary: CONTAINED present, BREACH absent, control live, all stages attempted"
 
       - name: A signed MediationReceipt was emitted on the live path (presence + shape)
+        if: steps.scope.outputs.relevant == 'true'
         run: |
           # The end-to-end tooth for the receipt arc: `verify --tier2` runs a
           # PERMITTED command (allow) and a FORBIDDEN command (deny) through the
@@ -474,6 +572,7 @@ jobs:
           printf '%s\n' "$markers" | head -8
 
       - name: A relying party verifies the pod's receipts against a node-anchored key
+        if: steps.scope.outputs.relevant == 'true'
         run: |
           # The marker step above proves receipts were EMITTED. This one is the
           # host-side relying-party check: recover the FULL signed receipts from
@@ -552,6 +651,7 @@ jobs:
           fi
 
       - name: Delivery conformance (observed inventory vs the extracted oracle)
+        if: steps.scope.outputs.relevant == 'true'
         run: |
           # The probe emits its observed environment inventory
           # (NUCLEUS_WORKLOAD_ENV: <name>, names only) into the guest log. This

--- a/crates/nucleus-podlist-probe/README.md
+++ b/crates/nucleus-podlist-probe/README.md
@@ -35,3 +35,17 @@ drains stderr into the guest console, where the harness greps it back):
   listing; `ids=` is the host's to check.
 - `NUCLEUS_PODLIST_PROBE: FAIL: <reason>` (exit 1) — missing/empty/malformed
   reply, a refusal object, or self absent (an unscoped/failed query).
+
+## CI lane
+
+`.github/workflows/podlist-probe.yml` boots this probe on a real x86_64
+Firecracker guest on every pull request that touches its inputs (the probe, the
+node, the tool proxy, guest-init, the pod spec, the harness, the rootfs build)
+and in the merge queue, where it decides scope from the group's diff. Its
+requireable twin, `podlist-probe-noop.yml`, passes only when those inputs are
+untouched on a pull request; a runner without `/dev/kvm` is red in the real
+lane, never green (#2604).
+
+Coverage boundary: hosted arm64 runners have no KVM, so aarch64 Firecracker is
+the weekly metal job in `quickstart-boot.yml` only; Apple Silicon's `vz` driver
+(`nucleus setup` on a Mac) is a different driver, not Firecracker coverage.

--- a/scripts/firecracker/podlist-boot-check.sh
+++ b/scripts/firecracker/podlist-boot-check.sh
@@ -35,6 +35,12 @@ FC_DIR="${FC_DIR:-$HOME/fc}"
 KERNEL="${KERNEL:-$FC_DIR/vmlinux}"
 ROOTFS="${ROOTFS:-$FC_DIR/podlist-rootfs.ext4}"
 NODE_BIN="${NODE_BIN:-$FC_DIR/nucleus-node}"
+# The node's HTTP API is mTLS-only (no HMAC fallback since the certificate
+# convergence): the operator is `nucleus node …` with a client cert minted from
+# the node's own CA by nucleus-identity's mint_test_client_cert example.
+CLI="${CLI:-$(command -v nucleus || true)}"
+MINT="${MINT:-target/debug/examples/mint_test_client_cert}"
+TRUST_DOMAIN="${TRUST_DOMAIN:-nucleus.local}"   # the node's --identity-trust-domain default
 STATE_DIR="${STATE_DIR:-$FC_DIR/state-podlist-check}"
 # Keep this base SHORT: the jailer nests the per-pod vsock socket at
 # <base>/firecracker/<uuid>/root/vsock.sock_<port>, and a long base overruns the
@@ -47,6 +53,12 @@ SECRET="${AUTH_SECRET:-harness-node-secret}"
 
 die() { echo "podlist-boot-check: $*" >&2; exit 1; }
 for f in "$KERNEL" "$ROOTFS" "$NODE_BIN"; do [ -s "$f" ] || die "missing input $f"; done
+[ -x "$CLI" ] || die "missing nucleus CLI (set CLI=…)"
+if [ ! -x "$MINT" ]; then
+    echo "podlist-boot-check: building nucleus-identity's mint_test_client_cert example…"
+    cargo build -p nucleus-identity --example mint_test_client_cert >/dev/null 2>&1 || die "mint_test_client_cert build failed"
+fi
+[ -x "$MINT" ] || die "missing $MINT"
 [ -e /dev/kvm ] || die "no /dev/kvm — this must run on a Linux host with KVM"
 command -v firecracker >/dev/null || die "firecracker is not on PATH"
 command -v jailer >/dev/null || die "jailer is not on PATH (needed for concurrent pods)"
@@ -66,51 +78,64 @@ sudo -b env RUST_LOG="${RUST_LOG:-warn}" \
     NUCLEUS_JAILER_PATH="$(command -v jailer)" \
     NUCLEUS_JAILER_CHROOT_BASE="$JAIL_DIR" \
     NUCLEUS_FIRECRACKER_NETNS=false \
-    "$NODE_BIN" --listen "$ADDR" --state-dir "$STATE_DIR" --auth-secret "$SECRET" \
+    "$NODE_BIN" --listen "$ADDR" --state-dir "$STATE_DIR" \
     --proxy-auth-secret "$SECRET" --proxy-approval-secret "$SECRET" \
     --identity-workload-api-socket "$FC_DIR/wapi.sock" > "$FC_DIR/node-podlist-check.log" 2>&1
 sleep 5
 pgrep -x nucleus-node >/dev/null || { tail -20 "$FC_DIR/node-podlist-check.log"; die "node did not start"; }
 
-# create <name> <rootfs> [parent_pod_id] -> prints pod id
-create() {
-    local name=$1 rootfs=$2 parent=${3:-}
+# The operator identity: the node's default root minter is
+# spiffe://<trust-domain>/ns/system/sa/cli, so mint exactly that from the CA
+# the node just persisted (it runs as root; copy the CA dir out to read it).
+IDENTITY_DIR="$FC_DIR/cli-identity"; sudo rm -rf "$IDENTITY_DIR" "$FC_DIR/ca-copy"
+ca_ready=0
+for _ in $(seq 1 60); do sudo test -f "$STATE_DIR/ca/ca-key.pem" && { ca_ready=1; break; }; sleep 0.5; done
+[ "$ca_ready" = 1 ] || { tail -20 "$FC_DIR/node-podlist-check.log"; die "node never persisted its CA under $STATE_DIR/ca"; }
+sudo cp -r "$STATE_DIR/ca" "$FC_DIR/ca-copy" && sudo chown -R "$(id -u)" "$FC_DIR/ca-copy"
+"$MINT" --ca-dir "$FC_DIR/ca-copy" --trust-domain "$TRUST_DOMAIN" \
+    --namespace system --service-account cli --out-dir "$IDENTITY_DIR" > "$FC_DIR/mint.log" 2>&1 \
+    || { cat "$FC_DIR/mint.log"; die "minting the operator client cert failed"; }
+N() {
+    "$CLI" node --url "https://$ADDR" \
+        --tls-cert "$IDENTITY_DIR/cert.pem" --tls-key "$IDENTITY_DIR/key.pem" \
+        --trust-bundle "$IDENTITY_DIR/trust-bundle.pem" "$@" 2>/dev/null | grep -viE "Starting nucleus|config_path"
+}
+ready=0
+for _ in $(seq 1 60); do N health >/dev/null 2>&1 && { ready=1; break; }; sleep 0.5; done
+[ "$ready" = 1 ] || { tail -20 "$FC_DIR/node-podlist-check.log"; die "node not healthy over mTLS"; }
+
+# spec <name> <rootfs> -> writes $FC_DIR/<name>.json
+spec() {
+    local name=$1 rootfs=$2
     cat > "$FC_DIR/$name.json" <<JSON
 {"apiVersion":"nucleus/v1","kind":"Pod","metadata":{"name":"$name","labels":{"enable_pod_mgmt":"true"}},"spec":{"work_dir":"/work","timeout_seconds":120,"policy":{"type":"profile","name":"orchestrator"},"image":{"kernel_path":"$KERNEL","rootfs_path":"$rootfs","read_only":false},"vsock":{"guest_cid":3,"port":5005}}}
 JSON
-    PARENT="$parent" python3 - "$FC_DIR/$name.json" "$SECRET" "$ADDR" <<'PY'
-import hmac,hashlib,sys,os,time,json,urllib.request,urllib.error
-spec,secret,addr=sys.argv[1],sys.argv[2].encode(),sys.argv[3]
-body=open(spec,"rb").read(); ts,actor=str(int(time.time())),"boot-harness"
-sig=hmac.new(secret,ts.encode()+b"."+actor.encode()+b"."+body,hashlib.sha256).hexdigest()
-h={"content-type":"application/json","x-nucleus-timestamp":ts,"x-nucleus-actor":actor,"x-nucleus-signature":sig}
-p=os.environ.get("PARENT","")
-if p: h["x-nucleus-parent-pod-id"]=p   # operator-set lineage: node records parent=A
-req=urllib.request.Request(f"http://{addr}/v1/pods",data=body,method="POST",headers=h)
-try: print(json.load(urllib.request.urlopen(req,timeout=120))["id"])
-except urllib.error.HTTPError as e: sys.stderr.write("CREATE %d %s\n"%(e.code,e.read().decode()[:300])); sys.exit(1)
-PY
 }
-
+# create <name> <rootfs> -> prints "<id> <proxy_addr>" (operator-created, no parent)
+create() {
+    spec "$1" "$2"
+    N create "$FC_DIR/$1.json" | python3 -c 'import sys,json; d=json.load(sys.stdin); print(d["id"], d.get("proxy_addr",""))'
+}
+# create_child <name> <rootfs> <parent_proxy_addr> -> prints pod id; the node
+# records parent = the pod whose proxy asked (lineage proven by the proxy path,
+# exactly as scripts/cross-pod-scoped-check.sh does on the local driver).
+create_child() {
+    spec "$1" "$2"
+    local payload; payload="$(python3 -c "import json,sys; print(json.dumps({'spec_yaml': open(sys.argv[1]).read(), 'reason': 'podlist boot check: A creates its own child C'}))" "$FC_DIR/$1.json")"
+    curl -s -X POST "$3/v1/pod/create" -H 'content-type: application/json' -d "$payload" \
+        | python3 -c 'import sys,json; print(json.load(sys.stdin)["pod_id"])'
+}
 operator_ids() {
-    python3 - "$SECRET" "$ADDR" <<'PY'
-import hmac,hashlib,sys,time,json,urllib.request,urllib.error
-secret,addr=sys.argv[1].encode(),sys.argv[2]
-ts,actor=str(int(time.time())),"boot-harness"
-sig=hmac.new(secret,ts.encode()+b"."+actor.encode()+b".",hashlib.sha256).hexdigest()
-req=urllib.request.Request(f"http://{addr}/v1/pods",method="GET",headers={"x-nucleus-timestamp":ts,"x-nucleus-actor":actor,"x-nucleus-signature":sig})
-try:
-    d=json.load(urllib.request.urlopen(req,timeout=30)); pods=d if isinstance(d,list) else d.get("pods",[])
-    print(",".join(sorted(p["id"] for p in pods)))
-except urllib.error.HTTPError as e: sys.stderr.write("OP %d %s\n"%(e.code,e.read().decode()[:200]))
-PY
+    N pods | python3 -c 'import sys,json; d=json.load(sys.stdin); pods=d if isinstance(d,list) else d.get("pods",[]); print(",".join(sorted(p["id"] for p in pods)))'
 }
 
 echo "podlist-boot-check: booting A (orchestrator, the probe)"
-A="$(create orch-a "$FC_DIR/rootfs-check-a.ext4")"; [ -n "$A" ] || die "A was not created"
-echo "podlist-boot-check: booting child C + sibling B in parallel"
-( create child-c "$FC_DIR/rootfs-check-c.ext4" "$A" > "$FC_DIR/c.id" 2>"$FC_DIR/c.err" ) &
-( create sibling-b "$FC_DIR/rootfs-check-b.ext4"           > "$FC_DIR/b.id" 2>"$FC_DIR/b.err" ) &
+read -r A APROXY <<<"$(create orch-a "$FC_DIR/rootfs-check-a.ext4")"
+[ -n "$A" ] || die "A was not created"
+[ -n "$APROXY" ] || die "A has no proxy_addr — cannot create its child through its own proxy"
+echo "podlist-boot-check: booting child C (via A's proxy) + sibling B in parallel"
+( create_child child-c "$FC_DIR/rootfs-check-c.ext4" "$APROXY" > "$FC_DIR/c.id" 2>"$FC_DIR/c.err" ) &
+( create sibling-b "$FC_DIR/rootfs-check-b.ext4" | cut -d' ' -f1 > "$FC_DIR/b.id" 2>"$FC_DIR/b.err" ) &
 wait
 C="$(cat "$FC_DIR/c.id" 2>/dev/null)"; B="$(cat "$FC_DIR/b.id" 2>/dev/null)"
 [ -n "$C" ] || die "child C was not created: $(cat "$FC_DIR/c.err" 2>/dev/null)"

--- a/scripts/firecracker/podlist-boot-check.sh
+++ b/scripts/firecracker/podlist-boot-check.sh
@@ -116,25 +116,25 @@ create() {
     spec "$1" "$2"
     N create "$FC_DIR/$1.json" | python3 -c 'import sys,json; d=json.load(sys.stdin); print(d["id"], d.get("proxy_addr",""))'
 }
-# create_child <name> <rootfs> <parent_proxy_addr> -> prints pod id; the node
-# records parent = the pod whose proxy asked (lineage proven by the proxy path,
-# exactly as scripts/cross-pod-scoped-check.sh does on the local driver).
+# create_child <name> <rootfs> <parent_pod_id> -> prints pod id. Operator-set
+# lineage: the CLI sends `x-nucleus-parent-pod-id`, which the node honours for
+# a non-pod caller (pod_api::resolve_parent_pod_id) and records parent = A.
+# (A's own tool-proxy is not reachable from the host for a Firecracker pod —
+# it fronts the guest over vsock — so the local-driver trick of creating C
+# through A's proxy does not apply here.)
 create_child() {
     spec "$1" "$2"
-    local payload; payload="$(python3 -c "import json,sys; print(json.dumps({'spec_yaml': open(sys.argv[1]).read(), 'reason': 'podlist boot check: A creates its own child C'}))" "$FC_DIR/$1.json")"
-    curl -s -X POST "$3/v1/pod/create" -H 'content-type: application/json' -d "$payload" \
-        | python3 -c 'import sys,json; print(json.load(sys.stdin)["pod_id"])'
+    N create "$FC_DIR/$1.json" --parent-pod-id "$3" | python3 -c 'import sys,json; print(json.load(sys.stdin)["id"])'
 }
 operator_ids() {
     N pods | python3 -c 'import sys,json; d=json.load(sys.stdin); pods=d if isinstance(d,list) else d.get("pods",[]); print(",".join(sorted(p["id"] for p in pods)))'
 }
 
 echo "podlist-boot-check: booting A (orchestrator, the probe)"
-read -r A APROXY <<<"$(create orch-a "$FC_DIR/rootfs-check-a.ext4")"
+read -r A _APROXY <<<"$(create orch-a "$FC_DIR/rootfs-check-a.ext4")"
 [ -n "$A" ] || die "A was not created"
-[ -n "$APROXY" ] || die "A has no proxy_addr — cannot create its child through its own proxy"
-echo "podlist-boot-check: booting child C (via A's proxy) + sibling B in parallel"
-( create_child child-c "$FC_DIR/rootfs-check-c.ext4" "$APROXY" > "$FC_DIR/c.id" 2>"$FC_DIR/c.err" ) &
+echo "podlist-boot-check: booting child C (parent A, operator-set) + sibling B in parallel"
+( create_child child-c "$FC_DIR/rootfs-check-c.ext4" "$A" > "$FC_DIR/c.id" 2>"$FC_DIR/c.err" ) &
 ( create sibling-b "$FC_DIR/rootfs-check-b.ext4" | cut -d' ' -f1 > "$FC_DIR/b.id" 2>"$FC_DIR/b.err" ) &
 wait
 C="$(cat "$FC_DIR/c.id" 2>/dev/null)"; B="$(cat "$FC_DIR/b.id" 2>/dev/null)"


### PR DESCRIPTION
Closes #2604.

## What
- **`adversary-probe.yml`** gains `merge_group` + a scope step (PATTERN derived from its `paths:`; `ci/merge-group-scope-parity.sh` agrees) and a noop twin **`adversary-probe-noop.yml`** that runs only on `pull_request` outside those paths. Its concurrency no longer cancels merge-group or main-push runs.
- **`quickstart-boot.yml`** gains `merge_group` + scope steps on its three jobs, so the merge queue boots a real pod exactly when a queued change touches the boot inputs. **`quickstart-boot-noop.yml`** no longer runs in the merge queue: an unavailable KVM runner there leaves the real job unreported (red), instead of the twin's vacuous green.
- **`podlist-probe.yml`** (new): boots the C2 cross-pod probe on a real x86_64 guest via `scripts/firecracker/podlist-boot-check.sh` (A sees itself and child C, never sibling B). The probe was baked into rootfs images but had no CI lane. Same scope/twin pattern (**`podlist-probe-noop.yml`**); the job **refuses** a runner without `/dev/kvm` rather than skipping, and is deliberately not behind `vars.CI_RUNNER` (the arm64 scale set has no KVM).
- Probe README: coverage boundary — aarch64 Firecracker is the weekly metal job only; Apple Silicon's `vz` driver is a different driver, not Firecracker coverage.

## Acceptance (from the issue)
- Each probe has a requireable context: `adversary probe distinguishes contained / breach / inconclusive`, `a real nucleus pod boots and is enforced (x86_64)`, `the C2 podlist probe is served a lineage-scoped listing on a real guest (x86_64)` — each reported on every PR (real or twin) and in every merge group (real, scope-gated). Adding them to the required list is a one-line branch-protection change after this lands.
- Runner unavailability is red: the twins never run in the merge queue, and the real KVM jobs fail on a runner without `/dev/kvm`.

This PR touches `podlist-probe.yml`, so its own CI runs the new lane end to end.

actionlint, `ci/merge-group-scope-parity.sh` and zizmor (high+) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZaH5waz88vL1qfNpFNfZ4
