### PR TITLE
formal(node): device-surface finite set and enforce_pci_off closure over a tokenised cmdline (#2603)

### DIFF
--- a/.github/workflows/portcullis-core-proven-lean.yml
+++ b/.github/workflows/portcullis-core-proven-lean.yml
@@ -141,6 +141,7 @@ jobs:
             DelegationProofs \
             DerivationProofs \
             SessionCeilingProofs \
+            GuestDeviceSurfaceProofs \
             GkatSyntaxProofs \
             GkatGuardedStringProofs \
             GkatInexpressibleProofs \
@@ -299,6 +300,7 @@ jobs:
           import FlowProofs
           import DeclassifyProofs
           import SessionCeilingProofs
+          import GuestDeviceSurfaceProofs
           import ReceiptChainProofs
           import DecidePureProofs
           import CompartmentProofs
@@ -329,6 +331,10 @@ jobs:
           import DerivationCascadeAdmissible
           import CertChainMonotoneExtracted
           #print axioms FlowProofs.authority_confinement_left
+          #print axioms GuestDeviceSurface.Cmdline.enforce_idem
+          #print axioms GuestDeviceSurface.Cmdline.pciOn_not_mem_enforce
+          #print axioms GuestDeviceSurface.Cmdline.enforce_count_pciOff
+          #print axioms GuestDeviceSurface.devices_maximal
           #print axioms CertChainMonotoneExtracted.chain_attenuates_monotone
           #print axioms GkatSyntax.salomaa_solutions_agree
           #print axioms GkatGS.sound

--- a/crates/nucleus-node/src/firecracker_config.rs
+++ b/crates/nucleus-node/src/firecracker_config.rs
@@ -2058,6 +2058,84 @@ mod tests {
         );
     }
 
+    // ── #2603: the shipped String function agrees with the Lean token model ──
+    //
+    // `crates/portcullis-core/lean/GuestDeviceSurfaceProofs.lean` proves
+    // idempotence, `pci=off ∈ enforce x`, `pci=on ∉ enforce x` and
+    // `count pci=off = 1` over a TOKENISED command line (`Cmdline.enforce`).
+    // Aeneas cannot extract the `String` code, so the bridge is this parity
+    // test: a transcription of the Lean model runs beside the real function
+    // on arbitrary token lists, and the two must agree token for token. The
+    // theorems then transfer to `enforce_pci_off` through the equality.
+
+    /// `GuestDeviceSurface.Tok`, transcribed.
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    enum ModelTok {
+        Pci(bool), // `true` = `pci=off`, `false` = any other value (`pci=on`)
+        Other(String),
+    }
+
+    impl ModelTok {
+        /// The Rust token this model token stands for.
+        fn render(&self) -> String {
+            match self {
+                ModelTok::Pci(true) => "pci=off".to_string(),
+                ModelTok::Pci(false) => "pci=on".to_string(),
+                ModelTok::Other(s) => s.clone(),
+            }
+        }
+    }
+
+    /// `GuestDeviceSurface.Cmdline.enforce`, transcribed: keep the non-`pci`
+    /// tokens in order, append one `pci=off`.
+    fn model_enforce(args: &[ModelTok]) -> Vec<ModelTok> {
+        let mut out: Vec<ModelTok> = args
+            .iter()
+            .filter(|t| !matches!(t, ModelTok::Pci(_)))
+            .cloned()
+            .collect();
+        out.push(ModelTok::Pci(true));
+        out
+    }
+
+    fn model_tok_strategy() -> impl proptest::strategy::Strategy<Value = ModelTok> {
+        use proptest::prelude::*;
+        prop_oneof![
+            2 => Just(ModelTok::Pci(true)),
+            2 => Just(ModelTok::Pci(false)),
+            // Opaque tokens never start with `pci=` and never contain
+            // whitespace — the two facts the tokeniser (split_whitespace)
+            // and `Tok.other` rely on.
+            5 => "[a-z0-9._/=-]{1,12}"
+                .prop_filter("not a pci= token", |s| !s.starts_with("pci="))
+                .prop_map(ModelTok::Other),
+        ]
+    }
+
+    proptest::proptest! {
+        /// `enforce_pci_off(join tokens) = join (model_enforce tokens)`.
+        #[test]
+        fn enforce_pci_off_agrees_with_the_token_model(
+            toks in proptest::collection::vec(model_tok_strategy(), 0..12)
+        ) {
+            let line = toks.iter().map(ModelTok::render).collect::<Vec<_>>().join(" ");
+            let expected = model_enforce(&toks)
+                .iter()
+                .map(ModelTok::render)
+                .collect::<Vec<_>>()
+                .join(" ");
+            proptest::prop_assert_eq!(enforce_pci_off(&line), expected);
+            // The Lean theorems, observed on the shipped function.
+            let once = enforce_pci_off(&line);
+            proptest::prop_assert_eq!(enforce_pci_off(&once), once.clone()); // enforce_idem
+            let pci: Vec<&str> = once
+                .split_whitespace()
+                .filter(|t| t.starts_with("pci="))
+                .collect();
+            proptest::prop_assert_eq!(pci, vec!["pci=off"]); // enforce_pci_tokens + count = 1
+        }
+    }
+
     // ── PCI posture: both halves of the CVE-2026-5747 defence ─────────────
 
     /// THE HOST HALF. Firecracker's virtio-PCI transport is opt-in via

--- a/crates/portcullis-core/lean/GuestDeviceSurfaceProofs.lean
+++ b/crates/portcullis-core/lean/GuestDeviceSurfaceProofs.lean
@@ -1,0 +1,241 @@
+/-!
+# Guest device surface and `pci=off` closure  (PROVED — 0 proof-holes, 0 extra axioms)
+
+Tokenised model of two guest-side invariants of `nucleus-node/src/firecracker_config.rs`
+(#2603, part of the #2558 isolation-surface programme):
+
+1. **`enforce_pci_off`** (`firecracker_config.rs`, the `pci=off` floor): strip every
+   `pci=` token from the kernel command line and append `pci=off`. Modelled over a
+   token type rather than `String` — Aeneas string support is weak, and the property
+   is about tokens, not characters. The Rust proptest
+   `enforce_pci_off_agrees_with_the_token_model` pins the shipped string function to
+   `Cmdline.enforce` below.
+2. **The device surface**: Firecracker is told to attach exactly six device classes
+   (`firecracker_device_surface_is_exactly_pinned`). Modelled as a finite `Device`
+   enum and a `Config` whose optional attachments are the ones `from_spec` may omit
+   (`network-interfaces` when there is no net plan, `vsock` when the spec has none).
+
+Mathlib-free; same discipline as `SessionCeilingProofs`.
+-/
+
+namespace GuestDeviceSurface
+
+/-! ## Part 1 — the tokenised command line -/
+
+/-- The value of a `pci=` token. Anything other than the literal `off` is `on`
+    from the posture's point of view: only `off` is the hardened value. -/
+inductive PciVal where
+  | off
+  | on
+  deriving DecidableEq, Repr
+
+/-- One whitespace-separated command-line token: either a `pci=` assignment or
+    anything else (`console=ttyS0`, `init=/init`, `quiet`, …), kept opaque. -/
+inductive Tok where
+  | pci (v : PciVal)
+  | other (s : String)
+  deriving DecidableEq, Repr
+
+namespace Tok
+
+/-- `tok.starts_with("pci=")` in the Rust. -/
+def isPci : Tok → Bool
+  | pci _   => true
+  | other _ => false
+
+@[simp] theorem isPci_pci (v : PciVal) : isPci (pci v) = true := rfl
+@[simp] theorem isPci_other (s : String) : isPci (other s) = false := rfl
+
+end Tok
+
+/-- A command line is its token list. -/
+abbrev Cmdline := List Tok
+
+namespace Cmdline
+
+/-- `enforce_pci_off`: drop every `pci=` token, then append `pci=off`. -/
+def enforce (args : Cmdline) : Cmdline :=
+  args.filter (fun t => !t.isPci) ++ [Tok.pci PciVal.off]
+
+/-- `from_spec`'s later appends (`nucleus.*=` settings, `ipv6.disable=1`, the
+    net plan) never mention `pci=`: this is what "safe to append after the floor"
+    means. -/
+def PciFree (args : Cmdline) : Prop := ∀ t ∈ args, t.isPci = false
+
+/-- The filter half of `enforce` yields a `pci`-free prefix. -/
+theorem filter_pciFree (args : Cmdline) :
+    PciFree (args.filter (fun t => !t.isPci)) := by
+  intro t ht
+  have := List.mem_filter.mp ht
+  cases t with
+  | pci v => simp at this
+  | other s => rfl
+
+/-- A `pci`-free list is unchanged by the filter. -/
+theorem filter_of_pciFree (args : Cmdline) (h : PciFree args) :
+    args.filter (fun t => !t.isPci) = args := by
+  induction args with
+  | nil => rfl
+  | cons t ts ih =>
+    have ht : t.isPci = false := h t (List.mem_cons_self ..)
+    have hts : PciFree ts := fun u hu => h u (List.mem_cons_of_mem _ hu)
+    simp [ht, ih hts]
+
+/-- **(A) Idempotence** — `enforce ∘ enforce = enforce`. Running the floor twice
+    hands the kernel the same line: one `pci=off`, at the end. -/
+theorem enforce_idem (args : Cmdline) : enforce (enforce args) = enforce args := by
+  unfold enforce
+  rw [List.filter_append, filter_of_pciFree _ (filter_pciFree args)]
+  simp
+
+/-- **(B) `pci=off` is present** after the floor, whatever the spec supplied. -/
+theorem pciOff_mem_enforce (args : Cmdline) : Tok.pci PciVal.off ∈ enforce args := by
+  unfold enforce
+  exact List.mem_append_right _ (List.mem_singleton.mpr rfl)
+
+/-- **(C) `pci=on` is absent** after the floor: a spec-supplied `pci=on` (or any
+    non-`off` value) is stripped, not honoured. -/
+theorem pciOn_not_mem_enforce (args : Cmdline) : Tok.pci PciVal.on ∉ enforce args := by
+  unfold enforce
+  intro h
+  rcases List.mem_append.mp h with h | h
+  · have := (List.mem_filter.mp h).2
+    simp at this
+  · simp at h
+
+/-- **(D) Exactly one `pci=` token survives**, and it is `pci=off`: every `pci`
+    token of the output is `pci=off`, and there is exactly one of them
+    (`count = 1`), so the kernel is never handed two values. -/
+theorem filter_isPci_of_pciFree (l : Cmdline) (h : PciFree l) : l.filter Tok.isPci = [] := by
+  induction l with
+  | nil => rfl
+  | cons t ts ih =>
+    have ht : t.isPci = false := h t (List.mem_cons_self ..)
+    have hts : PciFree ts := fun u hu => h u (List.mem_cons_of_mem _ hu)
+    simp [ht, ih hts]
+
+theorem enforce_pci_tokens (args : Cmdline) :
+    (enforce args).filter Tok.isPci = [Tok.pci PciVal.off] := by
+  unfold enforce
+  rw [List.filter_append, filter_isPci_of_pciFree _ (filter_pciFree args)]
+  simp
+
+theorem enforce_count_pciOff (args : Cmdline) :
+    (enforce args).count (Tok.pci PciVal.off) = 1 := by
+  unfold enforce
+  rw [List.count_append, List.count_singleton_self]
+  have h : (args.filter (fun t => !t.isPci)).count (Tok.pci PciVal.off) = 0 := by
+    rw [List.count_eq_zero]
+    intro hmem
+    have := (List.mem_filter.mp hmem).2
+    simp at this
+  omega
+
+/-- **(E) The floor survives `from_spec`'s later appends.** Everything appended
+    after `enforce_pci_off` (`nucleus.approval_pubkeys=…`,
+    `nucleus.workload_api_port=…`, the audit-sink settings) is `pci`-free, so
+    (B) and (C) hold of the line the kernel finally sees. -/
+theorem pciOff_mem_enforce_append (args extra : Cmdline) :
+    Tok.pci PciVal.off ∈ enforce args ++ extra :=
+  List.mem_append_left _ (pciOff_mem_enforce args)
+
+theorem pciOn_not_mem_enforce_append (args extra : Cmdline) (h : PciFree extra) :
+    Tok.pci PciVal.on ∉ enforce args ++ extra := by
+  intro hmem
+  rcases List.mem_append.mp hmem with hmem | hmem
+  · exact pciOn_not_mem_enforce args hmem
+  · have := h _ hmem
+    simp at this
+
+/-- Appending `pci`-free tokens after the floor and re-running the floor changes
+    nothing but token order: the same multiset of non-`pci` tokens and one
+    `pci=off`. Stated as: re-enforcing an already-enforced-then-appended line is
+    the enforced line with the extras spliced before the trailing `pci=off`. -/
+theorem enforce_append_pciFree (args extra : Cmdline) (h : PciFree extra) :
+    enforce (enforce args ++ extra) =
+      args.filter (fun t => !t.isPci) ++ extra ++ [Tok.pci PciVal.off] := by
+  unfold enforce
+  rw [List.filter_append, List.filter_append, filter_of_pciFree _ (filter_pciFree args),
+      filter_of_pciFree _ h]
+  simp
+
+end Cmdline
+
+/-! ## Part 2 — the device surface -/
+
+/-- The six device classes Firecracker may be told to attach: the JSON object
+    keys of the serialised `FirecrackerConfig`. Finite by construction — adding a
+    variant here is the only way to widen the surface. -/
+inductive Device where
+  | bootSource
+  | drives
+  | machineConfig
+  | networkInterfaces
+  | vsock
+  | logger
+  deriving DecidableEq, Repr
+
+/-- The pinned surface: what `firecracker_device_surface_is_exactly_pinned`
+    asserts of a maximal pod. -/
+def pinned : List Device :=
+  [Device.bootSource, Device.drives, Device.machineConfig,
+   Device.networkInterfaces, Device.vsock, Device.logger]
+
+/-- Every `Device` is in the pinned list — the enum IS the surface. -/
+theorem mem_pinned (d : Device) : d ∈ pinned := by
+  cases d <;> simp [pinned]
+
+/-- What `from_spec` may vary: the two attachments it serialises conditionally
+    (`network-interfaces` is `skip_serializing_if = "Vec::is_empty"`, `vsock` is
+    `skip_serializing_if = "Option::is_none"`). `boot-source`, `drives`,
+    `machine-config` are unconditional fields; `logger` is always `Some` in
+    `from_spec`. -/
+structure Config where
+  hasNet   : Bool
+  hasVsock : Bool
+  deriving DecidableEq, Repr
+
+/-- The device classes the serialised config names, in JSON-key order. -/
+def Config.devices (c : Config) : List Device :=
+  [Device.bootSource, Device.drives] ++
+  [Device.machineConfig] ++
+  (if c.hasNet then [Device.networkInterfaces] else []) ++
+  (if c.hasVsock then [Device.vsock] else []) ++
+  [Device.logger]
+
+/-- The maximal pod of the Rust test: every optional device present. -/
+def Config.maximal : Config := ⟨true, true⟩
+
+/-- **(F) `devices(from_spec maximal) = pinned`** — the Rust assertion, as a
+    theorem over the model. -/
+theorem devices_maximal : Config.maximal.devices = pinned := by
+  decide
+
+/-- **(G) Closure**: no configuration names a device outside the pinned six —
+    `from_spec` can only ever *omit* an optional class, never add one. -/
+theorem devices_subset_pinned (c : Config) : ∀ d ∈ c.devices, d ∈ pinned :=
+  fun d _ => mem_pinned d
+
+/-- **(H) The mandatory core is always present**: boot source, drives, machine
+    config and the logger are named by every configuration. -/
+theorem mandatory_mem_devices (c : Config) :
+    Device.bootSource ∈ c.devices ∧ Device.drives ∈ c.devices ∧
+    Device.machineConfig ∈ c.devices ∧ Device.logger ∈ c.devices := by
+  cases c with
+  | mk n v => cases n <;> cases v <;> decide
+
+/-- **(I) Firecracker pods always have vsock**: `spawn_firecracker_pod` requires
+    `spec.vsock`, so on the live path `hasVsock = true` and the vsock device is
+    named — the identity channel is never silently absent. -/
+theorem vsock_mem_devices (c : Config) (h : c.hasVsock = true) :
+    Device.vsock ∈ c.devices := by
+  cases c with
+  | mk n v => subst h; cases n <;> decide
+
+/-- Nothing but the two optional classes can distinguish two configurations. -/
+theorem devices_inj (c₁ c₂ : Config) (h : c₁.devices = c₂.devices) : c₁ = c₂ := by
+  cases c₁ with
+  | mk n₁ v₁ => cases c₂ with
+    | mk n₂ v₂ => cases n₁ <;> cases v₁ <;> cases n₂ <;> cases v₂ <;> first | rfl | (exfalso; simp [Config.devices] at h)
+
+end GuestDeviceSurface

--- a/crates/portcullis-core/lean/lakefile.lean
+++ b/crates/portcullis-core/lean/lakefile.lean
@@ -226,6 +226,12 @@ lean_lib «DeclassifyProofs» where
 lean_lib «SessionCeilingProofs» where
   roots := #[`SessionCeilingProofs]
 
+-- Guest device surface (six classes, finite enum) and the `pci=off` floor of
+-- nucleus-node's firecracker_config.rs over a tokenised cmdline (#2603).
+-- Mathlib-free; parity with the shipped String function is a nucleus-node proptest.
+lean_lib «GuestDeviceSurfaceProofs» where
+  roots := #[`GuestDeviceSurfaceProofs]
+
 -- GKAT syntax + equational axioms (POPL'20 Fig.1) and the single-state Salomaa
 -- reduction (existence via W1/U5/S1/S4, uniqueness via W3) — the base case of the
 -- completeness reduction, done syntactically. General-n existence is open.


### PR DESCRIPTION
Closes #2603 (part of #2558, Wave 2).

## What
- **`crates/portcullis-core/lean/GuestDeviceSurfaceProofs.lean`** (new Mathlib-free `lean_lib`, proven tier): a tokenised model of the guest kernel command line (`Tok = pci PciVal | other String`) with `Cmdline.enforce = filter (¬pci) ++ [pci=off]`, and theorems
  - `enforce_idem` — `enforce ∘ enforce = enforce`
  - `pciOff_mem_enforce` — `pci=off ∈ enforce x`
  - `pciOn_not_mem_enforce` — `pci=on ∉ enforce x`
  - `enforce_pci_tokens` / `enforce_count_pciOff` — exactly one `pci=` token survives and it is `pci=off`
  - `pciOff_mem_enforce_append`, `pciOn_not_mem_enforce_append`, `enforce_append_pciFree` — the floor survives `from_spec`'s later `nucleus.*=` appends (which are `PciFree`).
- A finite `Device` enum (the six JSON keys of `FirecrackerConfig`) and `Config.devices` over the two attachments `from_spec` serialises conditionally: `devices_maximal = pinned` (by `decide`), `devices_subset_pinned` (closure), `mandatory_mem_devices`, `vsock_mem_devices`, `devices_inj`.
- **Parity**: `nucleus-node` proptest `enforce_pci_off_agrees_with_the_token_model` transcribes `Cmdline.enforce` and asserts token-for-token equality with the shipped `String` function on arbitrary token lists, plus idempotence and a single `pci=off` on the real output.
- Registered in `portcullis-core-proven-lean.yml`'s build list and `PrintAxioms1` (4 audited theorems).

## Verified locally
- `lake build GuestDeviceSurfaceProofs` — 0 `sorry`; `#print axioms`: `propext` / `Quot.sound` only, `devices_maximal` axiom-free.
- `cargo test -p nucleus-node --bin nucleus-node pci` — 5 passed; `cargo clippy -p nucleus-node --all-targets -D warnings` clean.
- `scripts/check-lean-libs-built.sh` — OK.

Not Aeneas-extracted: the shipped function is `String`-typed (`split_whitespace`); the tokeniser is the parity test's job, as the issue allows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZaH5waz88vL1qfNpFNfZ4