### PR TITLE
security(kani): run the six flow.rs anti-prompt-injection harnesses per PR (#2563)

### DIFF
--- a/.github/workflows/kani-nightly-noop.yml
+++ b/.github/workflows/kani-nightly-noop.yml
@@ -42,7 +42,7 @@ jobs:
         run: echo "no relevant paths changed — gate vacuously green"
 
   kani-ifc:
-    name: Kani (IFC kernel: anti-prompt-injection flow harnesses)
+    name: "Kani (IFC kernel: anti-prompt-injection flow harnesses)"
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/kani-nightly-noop.yml
+++ b/.github/workflows/kani-nightly-noop.yml
@@ -20,6 +20,7 @@ on:
     paths-ignore:
       - "crates/portcullis/src/**"
       - "crates/ck-*/src/**"
+      - "crates/nucleus-ifc-kernel/src/**"
       - ".kani-minimum-proofs"
       - ".github/workflows/kani-nightly.yml"
 
@@ -40,6 +41,13 @@ jobs:
       - name: No-op (paths not touched)
         run: echo "no relevant paths changed — gate vacuously green"
 
+  kani-ifc:
+    name: Kani (IFC kernel: anti-prompt-injection flow harnesses)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: No-op (paths not touched)
+        run: echo "no relevant paths changed — gate vacuously green"
   kani-constitutional:
     name: Kani (constitutional kernel)
     runs-on: ubuntu-latest

--- a/.github/workflows/kani-nightly.yml
+++ b/.github/workflows/kani-nightly.yml
@@ -121,7 +121,7 @@ jobs:
   # and kernel/ifc.rs are live on. Every other Kani job runs `-p portcullis` or
   # `-p ck-kernel`; until #2563 nothing ran these. All six verify in ~5 s.
   kani-ifc:
-    name: Kani (IFC kernel: anti-prompt-injection flow harnesses)
+    name: "Kani (IFC kernel: anti-prompt-injection flow harnesses)"
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     if: github.event_name != 'schedule'

--- a/.github/workflows/kani-nightly.yml
+++ b/.github/workflows/kani-nightly.yml
@@ -6,12 +6,14 @@ on:
     paths:
       - "crates/portcullis/src/**"
       - "crates/ck-*/src/**"
+      - "crates/nucleus-ifc-kernel/src/**"
       - ".kani-minimum-proofs"
       - ".github/workflows/kani-nightly.yml"
   pull_request:
     paths:
       - "crates/portcullis/src/**"
       - "crates/ck-*/src/**"
+      - "crates/nucleus-ifc-kernel/src/**"
       - ".kani-minimum-proofs"
       - ".github/workflows/kani-nightly.yml"
   # Bare, unfiltered: the merge queue's own re-validation of the fast-tier
@@ -113,6 +115,53 @@ jobs:
   # minutes. The other 12 harnesses are sharded into the nightly matrix below and,
   # as of 2026-08-31, none of them verifies — the dividing line is BTreeSet<String>,
   # not Kernel::admit. See KANI-STATUS.md.
+  # The six anti-prompt-injection harnesses in nucleus-ifc-kernel/src/flow.rs
+  # (no secret exfiltration, authority confinement, no integrity laundering,
+  # propagation monotone ×2, trusted-user allowed) — the claims flow_graph.rs
+  # and kernel/ifc.rs are live on. Every other Kani job runs `-p portcullis` or
+  # `-p ck-kernel`; until #2563 nothing ran these. All six verify in ~5 s.
+  kani-ifc:
+    name: Kani (IFC kernel: anti-prompt-injection flow harnesses)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    if: github.event_name != 'schedule'
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2.9.1
+        if: ${{ runner.environment == 'github-hosted' }}
+        with:
+          cache-on-failure: true
+      - name: Cache Kani toolchain
+        if: ${{ runner.environment == 'github-hosted' }}
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.kani
+          key: kani-toolchain-${{ runner.os }}-kani-0.67.0
+      - name: Run Kani (flow.rs harnesses, per-harness timeout)
+        uses: model-checking/kani-github-action@f838096619a707b0f6b2118cf435eaccfa33e51f # v1.1
+        with:
+          kani-version: "0.67.0"
+          # --harness-timeout is unstable in 0.67 (needs -Z unstable-options):
+          # a harness that stops terminating fails the job instead of hanging
+          # it to the job timeout.
+          args: >-
+            -p nucleus-ifc-kernel
+            --solver cadical
+            -Z unstable-options
+            --harness-timeout 120s
+            --harness proof_no_secret_exfil
+            --harness proof_authority_confinement
+            --harness proof_no_integrity_laundering
+            --harness proof_propagation_monotone
+            --harness proof_propagation_monotone_leq
+            --harness proof_trusted_user_allowed
+      - name: All six flow.rs harnesses are still declared
+        # The harness list above is explicit; if a harness is renamed or
+        # deleted, Kani would silently verify fewer. Pin the count.
+        run: |
+          n=$(grep -c '#\[kani::proof\]' crates/nucleus-ifc-kernel/src/flow.rs)
+          [ "$n" -eq 6 ] || { echo "::error::flow.rs declares $n kani harnesses, this job lists 6 — update the --harness list"; exit 1; }
+
   kani-constitutional:
     name: Kani (constitutional kernel)
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Closes #2563 (part of #2554, Wave 0; related #2423).

- New job `Kani (IFC kernel: anti-prompt-injection flow harnesses)` in `kani-nightly.yml`: `cargo kani -p nucleus-ifc-kernel --solver cadical -Z unstable-options --harness-timeout 120s` over the six harnesses in `crates/nucleus-ifc-kernel/src/flow.rs` (`proof_no_secret_exfil`, `proof_authority_confinement`, `proof_no_integrity_laundering`, `proof_propagation_monotone`, `proof_propagation_monotone_leq`, `proof_trusted_user_allowed`). Locally with kani 0.67.0: all six verified in **5 s** (acceptance: ≤ 3 min).
- `paths:` (push + pull_request) widened to `crates/nucleus-ifc-kernel/src/**`; `kani-nightly-noop.yml` mirrors it and reports the same job name, so the job can join the required set once merged.
- A count pin (`#[kani::proof]` in flow.rs must be 6) so a renamed or deleted harness cannot silently shrink the list.
- Hosted x86 like the other Kani tiers (#2622 covers moving them to the arm64 pool).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZaH5waz88vL1qfNpFNfZ4