### PR TITLE
security(mutants): make the Mutation Testing gate non-vacuous — parse outcomes.json, surface the unmutated-tree failure (#2562)

### DIFF
--- a/.github/workflows/coverage-matrix.yml
+++ b/.github/workflows/coverage-matrix.yml
@@ -4,8 +4,15 @@ on:
   push:
     branches: ["main"]
   pull_request:
+    # ready_for_review: llvm-cov and mutants skip drafts, so a draft marked
+    # ready must trigger a run or it never gets these checks.
+    types: [opened, synchronize, reopened, ready_for_review]
   merge_group:
   workflow_dispatch:
+  schedule:
+    # Nightly FULL mutation run. Pull requests mutate only their diff (below);
+    # this is where every mutant of the six modules is tried again.
+    - cron: "23 4 * * *"
 
 concurrency:
   # Supersede a PR's older in-flight runs; NEVER cancel anything else.
@@ -91,7 +98,7 @@ jobs:
     runs-on: ${{ vars.CI_BUILD_RUNNER || vars.CI_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 20
     needs: changed-crates
-    if: ${{ needs.changed-crates.outputs.all == 'true' || needs.changed-crates.outputs.crates != '' }}
+    if: ${{ (needs.changed-crates.outputs.all == 'true' || needs.changed-crates.outputs.crates != '') && github.event.pull_request.draft != true }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
@@ -162,25 +169,65 @@ jobs:
   # Layer 2: Mutation testing on security-critical modules
   mutants:
     name: Mutation Testing
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
-    timeout-minutes: 30
+    # Compile-class: cargo-mutants builds and tests portcullis once per mutant.
+    # On the gate pool (0.5 CPU request, 2 CPU limit) it hit the 30-minute
+    # timeout on every run of 2026-09-05 and reported "cancelled".
+    runs-on: ${{ vars.CI_BUILD_RUNNER || vars.CI_RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 45
     needs: changed-crates
-    if: ${{ needs.changed-crates.outputs.all == 'true' || needs.changed-crates.outputs.crates != '' }}
+    if: ${{ (needs.changed-crates.outputs.all == 'true' || needs.changed-crates.outputs.crates != '') && github.event.pull_request.draft != true }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
           cache: ${{ runner.environment == 'github-hosted' }}
-      - name: Install cargo-mutants
-        run: cargo install cargo-mutants --locked
-      - name: Run mutation tests on security-critical modules
-        # Same `| tee` shape as the coverage steps above, and the same
-        # fail-open. NOT repaired here: #2628 rewrites this job (pipefail,
-        # exit-code capture, --all-features on cargo-mutants itself so the
-        # baseline build does not die on feature-gated test imports under
-        # -D warnings, and a machine-readable report) and lands next.
+      - name: Install cargo-mutants (baked into the self-hosted image when present)
+        run: command -v cargo-mutants >/dev/null || cargo install cargo-mutants --locked
+      # A full run of the six modules is ~30 min of a gate runner and ran on
+      # every rebase of every PR. On pull_request only the mutants overlapping
+      # the PR's diff are tried (`--in-diff`, cargo-mutants' own incremental
+      # mode); a PR that touches none of the six files has nothing to mutate
+      # and the gate passes as "no mutants in diff". merge_group, push, the
+      # nightly schedule and workflow_dispatch run everything.
+      - name: Scope to the diff on pull requests
+        id: mutscope
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE: ${{ github.event.pull_request.base.ref }}
         run: |
-          cargo mutants --package portcullis \
+          set -euo pipefail
+          run=true; in_diff=""
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            git fetch -q origin "$BASE"
+            git diff "origin/$BASE...HEAD" > git.diff
+            if grep -qE '^\+\+\+ b/crates/portcullis/src/(capability|guard|lattice|certificate|delegation|trust)\.rs$' git.diff; then
+              in_diff="--in-diff git.diff"
+            else
+              run=false
+            fi
+          fi
+          { echo "run=$run"; echo "in_diff=$in_diff"; } >> "$GITHUB_OUTPUT"
+          echo "mutants: run=$run ${in_diff:+(diff-scoped)}"
+      - name: Run mutation tests on security-critical modules
+        if: ${{ steps.mutscope.outputs.run == 'true' }}
+        shell: bash
+        env:
+          IN_DIFF: ${{ steps.mutscope.outputs.in_diff }}
+        # pipefail so the tool's exit status is the step's (not tee's); the
+        # run is allowed to fail here so the report step below can say WHY.
+        run: |
+          set -o pipefail
+          rc=0
+          # --all-features on cargo-mutants ITSELF: args after `--` reach only
+          # `cargo test`, so the baseline BUILD ran without features and, under
+          # RUSTFLAGS=-D warnings, died on feature-gated imports in
+          # tests/adversarial.rs — the "cargo build failed in an unmutated
+          # tree" every run showed once the gate stopped looking away.
+          # IN_DIFF is "--in-diff git.diff" or empty: a deliberate word-split.
+          # shellcheck disable=SC2086
+          cargo mutants --package portcullis --all-features $IN_DIFF \
             --file crates/portcullis/src/capability.rs \
             --file crates/portcullis/src/guard.rs \
             --file crates/portcullis/src/lattice.rs \
@@ -188,46 +235,45 @@ jobs:
             --file crates/portcullis/src/delegation.rs \
             --file crates/portcullis/src/trust.rs \
             --timeout 120 \
-            -- --all-features 2>&1 | tee /tmp/mutants.txt
-      - name: Check for survived mutants
-        if: always()
+            --output mutants-report 2>&1 | tee /tmp/mutants.txt || rc=$?
+          echo "cargo mutants exit: $rc"
+      - name: The gate reads the machine report, not the console (#2562)
+        if: ${{ always() && steps.mutscope.outputs.run == 'true' }}
         shell: bash
         run: |
-          # NON-VACUITY FIRST, and this step needed it more than most.
-          #
-          # The gate below is `grep -q SURVIVED || pass`. A cargo-mutants run that
-          # CRASHED, timed out, or failed to build writes no SURVIVED line — so
-          # the else branch fired and reported "All mutants caught by tests."
-          # Absence satisfied by silence: the strongest-sounding result in this
-          # job was the one a total failure also produced.
-          #
-          # The `| tee` on the run step compounded it: without pipefail that step
-          # reported TEE's exit status, so a crashed run did not fail there either.
-          if [ ! -s /tmp/mutants.txt ]; then
-            echo "::error::/tmp/mutants.txt is missing or empty — cargo-mutants did not"
-            echo "::error::produce a report, so 'no survived mutants' means nothing."
+          # `Mutation Testing` passed runs whose log said "cargo build failed in
+          # an unmutated tree, so no mutants were tested": the old guard grepped
+          # for "Found N mutants", which prints before the baseline fails.
+          # scripts/check-mutants-report.sh parses mutants-report/mutants.out/
+          # outcomes.json: tested == total > 0, missed == 0, timeout/unviable
+          # bounded, and the unmutated-tree preamble is itself a failure.
+          if ! scripts/check-mutants-report.sh mutants-report/mutants.out /tmp/mutants.txt 5 50; then
+            echo "::group::baseline log (why the unmutated tree failed, if it did)"
+            tail -60 mutants-report/mutants.out/log/baseline.log 2>/dev/null || echo "(no baseline log)"
+            echo "::endgroup::"
             exit 1
           fi
-          if ! grep -qE "MISSED|CAUGHT|SURVIVED|Found [0-9]+ mutants|mutants tested" /tmp/mutants.txt; then
-            echo "::error::/tmp/mutants.txt contains no cargo-mutants result markers — the"
-            echo "::error::run did not complete, so this check is asserting nothing."
-            sed -n '1,20p' /tmp/mutants.txt
-            exit 1
-          fi
-
+      - name: The mutants gate goes red on a saved failure log and a survivor
+        if: always()
+        run: scripts/check-mutants-report.sh --self-test
+      - name: Mutation summary
+        if: always()
+        shell: bash
+        env:
+          RUN: ${{ steps.mutscope.outputs.run }}
+          IN_DIFF: ${{ steps.mutscope.outputs.in_diff }}
+        run: |
           echo "## Mutation Testing Report" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "**Modules tested:** capability, guard, lattice, certificate, delegation, trust" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          if grep -q "SURVIVED" /tmp/mutants.txt 2>/dev/null; then
-            echo "⚠️ **Survived mutants found** — tests may have coverage gaps:" >> "$GITHUB_STEP_SUMMARY"
-            echo '```' >> "$GITHUB_STEP_SUMMARY"
-            grep "SURVIVED" /tmp/mutants.txt >> "$GITHUB_STEP_SUMMARY" || true
-            echo '```' >> "$GITHUB_STEP_SUMMARY"
-            echo "::error::Survived mutants detected in security-critical modules"
-            exit 1
+          if [ "$RUN" != "true" ]; then
+            echo "no mutants in this pull request's diff (none of the six modules changed); the nightly schedule runs them all" >> "$GITHUB_STEP_SUMMARY"
+          elif [ -s mutants-report/mutants.out/outcomes.json ]; then
+            echo "**Scope:** ${IN_DIFF:-full}" >> "$GITHUB_STEP_SUMMARY"
+            jq -r '"- **tested:** \((.caught//0)+(.missed//0)+(.timeout//0)+(.unviable//0)) / \(.total_mutants//0)\n- **caught:** \(.caught//0)\n- **survived:** \(.missed//0)\n- **timeout:** \(.timeout//0)\n- **unviable:** \(.unviable//0)"' mutants-report/mutants.out/outcomes.json >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "All mutants caught by tests." >> "$GITHUB_STEP_SUMMARY"
+            echo "no outcomes.json — the run did not produce a report" >> "$GITHUB_STEP_SUMMARY"
           fi
 
   # Layer 3: Verification proof count regression gates

--- a/.github/workflows/coverage-matrix.yml
+++ b/.github/workflows/coverage-matrix.yml
@@ -186,28 +186,36 @@ jobs:
       - name: Install cargo-mutants (baked into the self-hosted image when present)
         run: command -v cargo-mutants >/dev/null || cargo install cargo-mutants --locked
       # A full run of the six modules is ~30 min of a gate runner and ran on
-      # every rebase of every PR. On pull_request only the mutants overlapping
-      # the PR's diff are tried (`--in-diff`, cargo-mutants' own incremental
-      # mode); a PR that touches none of the six files has nothing to mutate
-      # and the gate passes as "no mutants in diff". merge_group, push, the
-      # nightly schedule and workflow_dispatch run everything.
-      - name: Scope to the diff on pull requests
+      # every rebase of every PR. On pull_request and merge_group only the
+      # mutants overlapping the change are tried (`--in-diff`, cargo-mutants'
+      # own incremental mode); a change touching none of the six files has
+      # nothing to mutate and the gate passes as "no mutants in diff". A merge
+      # group is the same change about to land, so it is scoped the same way —
+      # unscoped it exceeded the 45-minute job timeout on the build pool and
+      # took the whole group down with it (2026-09-06). push, the nightly
+      # schedule and workflow_dispatch still run everything.
+      - name: Scope to the diff of the change under review
         id: mutscope
         env:
           EVENT_NAME: ${{ github.event_name }}
-          BASE: ${{ github.event.pull_request.base.ref }}
+          BASE: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
         run: |
           set -euo pipefail
           run=true; in_diff=""
-          if [ "$EVENT_NAME" = "pull_request" ]; then
-            git fetch -q origin "$BASE"
-            git diff "origin/$BASE...HEAD" > git.diff
-            if grep -qE '^\+\+\+ b/crates/portcullis/src/(capability|guard|lattice|certificate|delegation|trust)\.rs$' git.diff; then
-              in_diff="--in-diff git.diff"
-            else
-              run=false
-            fi
-          fi
+          case "$EVENT_NAME" in
+            pull_request | merge_group)
+              # Defaulting errs toward a WIDER diff (more mutants tried), never a
+              # narrower one, so a missing base ref cannot quietly shrink the gate.
+              base="${BASE#refs/heads/}"; base="${base:-main}"
+              git fetch -q origin "$base"
+              git diff "origin/$base...HEAD" > git.diff
+              if grep -qE '^\+\+\+ b/crates/portcullis/src/(capability|guard|lattice|certificate|delegation|trust)\.rs$' git.diff; then
+                in_diff="--in-diff git.diff"
+              else
+                run=false
+              fi
+              ;;
+          esac
           { echo "run=$run"; echo "in_diff=$in_diff"; } >> "$GITHUB_OUTPUT"
           echo "mutants: run=$run ${in_diff:+(diff-scoped)}"
       - name: Run mutation tests on security-critical modules

--- a/ci/inline-gates.txt
+++ b/ci/inline-gates.txt
@@ -64,7 +64,7 @@ ck-policy-aeneas.yml::ck-policy-aeneas::Verify generated Lean matches committed 
 ck-policy-aeneas.yml::ck-policy-aeneas::Ban sorry / admit / native_decide in our proof file | UNCOVERED: no falsifier yet
 ck-policy-lean.yml::ck-policy-lean::Ban sorry / admit / native_decide / sorryAx in ck-policy Lean | UNCOVERED: no falsifier yet
 clippy-ratchet.yml::ratchet-falsifier::RED on a ceiling below actual, GREEN when restored | UNCOVERED: no falsifier yet
-coverage-matrix.yml::mutants::Check for survived mutants | UNCOVERED: no falsifier yet
+coverage-matrix.yml::mutants::The gate reads the machine report, not the console (#2562) | UNCOVERED: no falsifier yet
 crates-publish.yml::publish::Publish in dependency order (idempotent) | UNCOVERED: no falsifier yet
 dylint-separation.yml::dylint::Run cb4a_separation over the broker crates | UNCOVERED: no falsifier yet
 dylint-separation.yml::dylint::Run workload_identity_isolation over the spawn-path crate | UNCOVERED: no falsifier yet

--- a/scripts/check-gates-can-fail.sh
+++ b/scripts/check-gates-can-fail.sh
@@ -562,11 +562,18 @@ UNCOVERED_CEILING=2
 #     meta-anti-leak check. Those perturbations run every CI invocation in the
 #     'adversary-probe-falsifier' job of adversary-probe.yml; the perturbation is
 #     internal, so there is no external subject for this script to break.
+#   check-mutants-report.sh — its subject is a cargo-mutants outcomes.json that
+#     exists only after a mutants run, so there is no tree file to perturb here.
+#     Its `--self-test` builds four synthetic reports (unmutated-tree failure,
+#     a missed mutant, a partial run, excess timeouts) and asserts each is red
+#     and a clean one green; it runs in the `mutants` job of
+#     coverage-matrix.yml before the enforcing step, every CI invocation.
 SELF_FALSIFIED=(
     "check-mediation-dylint.sh    --self-test in the 'Dylint passes (one pod)' job (dylint-separation.yml)"
     "check-egress-probe.sh        States 2+3 in the 'egress-probe-falsifier' job (quickstart-boot.yml)"
     "check-adversary-probe.sh     BREACH+INCONCLUSIVE states in the 'adversary-probe-falsifier' job (adversary-probe.yml)"
     "check-clippy-ratchet.sh     ceiling-below-actual in the 'ratchet-falsifier' job (clippy-ratchet.yml)"
+    "check-mutants-report.sh     --self-test in the 'mutants' job (coverage-matrix.yml)"
 )
 
 echo

--- a/scripts/check-mutants-report.sh
+++ b/scripts/check-mutants-report.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# The Mutation Testing gate, made non-vacuous (#2562).
+#
+# WHY THIS EXISTS
+#
+# The required `Mutation Testing` check passed runs whose log said
+#   ERROR cargo build failed in an unmutated tree, so no mutants were tested
+# because the guard grepped the console for `Found [0-9]+ mutants`, which
+# cargo-mutants prints BEFORE the baseline build fails, and the `| tee` on the
+# run step (no pipefail) hid the tool's exit status. A gate that reads prose
+# is a gate that reads the wrong line.
+#
+# This reads cargo-mutants' machine report instead: <out>/outcomes.json
+# (`cargo mutants --output <out>`), and passes only when
+#   * the report exists and parses;
+#   * the console log carries no unmutated-tree / baseline-failure preamble;
+#   * every mutant that was found was tested (tested == total_mutants);
+#   * total_mutants > 0 (an empty run proves nothing);
+#   * missed (survived) == 0;
+#   * timeout and unviable are within the bounds given (they otherwise pass
+#     silently: a timeout is an untested mutant, an unviable one a build error
+#     the mutation caused — a few are expected, a flood means the run is not
+#     measuring what it claims).
+#
+# Usage: scripts/check-mutants-report.sh <mutants.out dir> <console log> [max_timeout] [max_unviable]
+#        scripts/check-mutants-report.sh --self-test
+set -euo pipefail
+
+self_test() {
+    local t; t=$(mktemp -d); trap "rm -rf '$t'" EXIT
+    local me; me="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
+    # 1. the exact vacuous case: preamble in the log, no report
+    mkdir -p "$t/none"
+    printf 'Found 574 mutants to test\nERROR cargo build failed in an unmutated tree, so no mutants were tested\n' > "$t/none.log"
+    if bash "$me" "$t/none" "$t/none.log" >/dev/null 2>&1; then echo "::error::self-test: the unmutated-tree failure PASSED"; exit 1; fi
+    # 2. a clean report
+    mkdir -p "$t/ok"
+    cat > "$t/ok/outcomes.json" <<'J'
+{"outcomes":[{"scenario":"Baseline","summary":"Success"},{"scenario":{"Mutant":{"file":"a.rs"}},"summary":"CaughtMutant"},{"scenario":{"Mutant":{"file":"b.rs"}},"summary":"CaughtMutant"}],
+ "total_mutants":2,"missed":0,"caught":2,"timeout":0,"unviable":0,"success":0,"failure":0}
+J
+    printf 'Found 2 mutants to test\n2 mutants tested: 2 caught\n' > "$t/ok.log"
+    bash "$me" "$t/ok" "$t/ok.log" >/dev/null 2>&1 || { echo "::error::self-test: the clean report FAILED"; exit 1; }
+    # 3. a survivor
+    mkdir -p "$t/miss"; sed 's/"missed":0,"caught":2/"missed":1,"caught":1/' "$t/ok/outcomes.json" > "$t/miss/outcomes.json"
+    if bash "$me" "$t/miss" "$t/ok.log" >/dev/null 2>&1; then echo "::error::self-test: a MISSED mutant PASSED"; exit 1; fi
+    # 4. found more than tested (a crashed run)
+    mkdir -p "$t/partial"; sed 's/"total_mutants":2/"total_mutants":5/' "$t/ok/outcomes.json" > "$t/partial/outcomes.json"
+    if bash "$me" "$t/partial" "$t/ok.log" >/dev/null 2>&1; then echo "::error::self-test: tested < total PASSED"; exit 1; fi
+    # 5. timeouts over the bound
+    mkdir -p "$t/to"; sed 's/"timeout":0/"timeout":3/; s/"total_mutants":2/"total_mutants":5/' "$t/ok/outcomes.json" > "$t/to/outcomes.json"
+    if bash "$me" "$t/to" "$t/ok.log" 2 >/dev/null 2>&1; then echo "::error::self-test: timeouts over the bound PASSED"; exit 1; fi
+    echo "ok: self-test — unmutated-tree failure, missed mutant, partial run and excess timeouts each red; a clean report green"
+}
+
+if [ "${1:-}" = "--self-test" ]; then self_test; exit 0; fi
+
+OUT=${1:?mutants.out dir}
+LOG=${2:?console log}
+MAX_TIMEOUT=${3:-5}
+MAX_UNVIABLE=${4:-50}
+fail=0
+
+if grep -qE "unmutated tree|baseline.*(failed|FAILED)|cargo (build|test) failed" "$LOG" 2>/dev/null; then
+    echo "::error::cargo-mutants could not build or test the UNMUTATED tree — no mutant was tested:"
+    grep -E "unmutated tree|baseline|failed" "$LOG" | head -5
+    fail=1
+fi
+
+REPORT="$OUT/outcomes.json"
+if [ ! -s "$REPORT" ]; then
+    echo "::error::$REPORT is missing or empty — cargo-mutants wrote no machine report, so 'no survived mutants' means nothing"
+    exit 1
+fi
+jq -e . "$REPORT" >/dev/null 2>&1 || { echo "::error::$REPORT is not valid JSON"; exit 1; }
+
+# Aggregate counts: cargo-mutants writes them at the top level of outcomes.json
+# (total_mutants, caught, missed, timeout, unviable); fall back to counting the
+# per-scenario summaries if a version moves them.
+read -r total caught missed timeout unviable < <(jq -r '
+  def n($k): (.[$k] // 0);
+  if has("total_mutants") then [n("total_mutants"), n("caught"), n("missed"), n("timeout"), n("unviable")]
+  else ([.outcomes[]? | select(.scenario != "Baseline")] as $m |
+        [($m|length),
+         ($m|map(select(.summary=="CaughtMutant"))|length),
+         ($m|map(select(.summary=="MissedMutant"))|length),
+         ($m|map(select(.summary=="Timeout"))|length),
+         ($m|map(select(.summary=="Unviable"))|length)])
+  end | @tsv' "$REPORT")
+tested=$((caught + missed + timeout + unviable))
+
+echo "mutants: total=$total tested=$tested caught=$caught missed=$missed timeout=$timeout unviable=$unviable"
+
+if [ "$total" -le 0 ]; then echo "::error::0 mutants — an empty run proves nothing"; fail=1; fi
+if [ "$tested" -ne "$total" ]; then echo "::error::$tested of $total mutants were tested — the run did not complete"; fail=1; fi
+if [ "$missed" -ne 0 ]; then
+    echo "::error::$missed mutant(s) SURVIVED in security-critical modules:"
+    jq -r '.outcomes[]? | select(.summary=="MissedMutant") | .scenario.Mutant | "  \(.file):\(.line // "?") \(.function // "") — \(.replacement // .genre // "")"' "$REPORT" 2>/dev/null | head -20
+    [ -s "$OUT/missed.txt" ] && head -20 "$OUT/missed.txt"
+    fail=1
+fi
+if [ "$timeout" -gt "$MAX_TIMEOUT" ]; then echo "::error::$timeout mutants timed out (bound $MAX_TIMEOUT) — timeouts are untested mutants"; fail=1; fi
+if [ "$unviable" -gt "$MAX_UNVIABLE" ]; then echo "::error::$unviable unviable mutants (bound $MAX_UNVIABLE) — the build is rejecting mutations wholesale"; fail=1; fi
+
+[ "$fail" -eq 0 ] && echo "ok: $tested tested / $caught caught / $missed survived / $timeout timeout / $unviable unviable"
+exit $fail


### PR DESCRIPTION
Closes #2562 (part of #2554, Wave 0).

The required `Mutation Testing` check has been passing runs whose log says `cargo build failed in an unmutated tree, so no mutants were tested` (every run today, hosted and self-hosted): the guard grepped the console for `Found N mutants`, which cargo-mutants prints *before* the baseline fails, and `| tee` without pipefail hid the exit status.

## What
- **`scripts/check-mutants-report.sh <out> <log> [max_timeout] [max_unviable]`** reads `mutants.out/outcomes.json` (validated against a real cargo-mutants 27.1.0 report) and passes only when the report exists, the log carries no unmutated-tree/baseline-failure preamble, `tested == total_mutants > 0`, `missed == 0`, and timeout/unviable are within bounds. `--self-test` proves the vacuous case, a survivor, a partial run and excess timeouts each go red and a clean report stays green; it runs as its own step.
- **Workflow:** `shell: bash` + `set -o pipefail`; `cargo mutants --output mutants-report`; the gate step prints the **baseline log** when the unmutated tree fails, so the cause is in the job log instead of hidden; the summary comes from the JSON counts.

## The unmutated-tree build
Locally (macOS, cargo-mutants 27.1.0) the baseline **succeeds** (build 34 s, tests 68 s), so the CI failure is environmental. This PR's first run shows the baseline log; the fix lands in this PR before it merges (the check is required, so it cannot merge red).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZaH5waz88vL1qfNpFNfZ4