### PR TITLE
security(guest-init): boot typestate — exec only from Sealed, load-bearing mounts fail closed, no shell fallback (#2589)

### DIFF
--- a/crates/nucleus-guest-init/Cargo.toml
+++ b/crates/nucleus-guest-init/Cargo.toml
@@ -8,6 +8,10 @@ description = "Guest init for Firecracker images"
 repository = "https://github.com/coproduct-opensource/nucleus"
 readme = "README.md"
 
+[lib]
+name = "nucleus_guest_init"
+path = "src/lib.rs"
+
 [[bin]]
 name = "nucleus-guest-init"
 path = "src/main.rs"

--- a/crates/nucleus-guest-init/src/boot.rs
+++ b/crates/nucleus-guest-init/src/boot.rs
@@ -1,0 +1,336 @@
+//! The guest boot as a typestate: `Booting → Mounted → Provisioned → Sealed`,
+//! and `exec` only from `Sealed` (#2589).
+//!
+//! `run()` used to fetch every secret over vsock, then `remount_root_ro`, then
+//! `exec_proxy`, with the ordering enforced by nothing but the order of the
+//! lines. Reorder them — move the remount after the exec, or forget it — and
+//! the workload starts on a writable rootfs with no compiler, test or gate
+//! noticing. Here the order is the type: [`Boot<Sealed>`] is the only state
+//! with an `exec`, it is only produced by [`Boot::<Provisioned>::seal`], which
+//! is the remount, and `Provisioned` is only produced from `Mounted`. A boot
+//! that skips a step does not compile (see the `compile_fail` doctests in
+//! `lib.rs`).
+//!
+//! Two failure policies live here too, because they are the same kind of
+//! claim ("boot does not proceed on a broken base"):
+//!   * mounts are classified **load-bearing** or optional; a load-bearing
+//!     mount that fails aborts the boot with a named error instead of an
+//!     `eprintln!` the kernel scrolls past;
+//!   * the boot never falls back to a shell, and its error reaches PID 1's
+//!     exit status.
+
+use std::marker::PhantomData;
+
+/// Errors that stop a boot. Each names what failed, so the guest console (the
+/// only place PID 1 can speak) says which invariant broke rather than which
+/// syscall.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BootError {
+    /// A load-bearing mount failed. The rootfs is not a place a workload can
+    /// run without it.
+    LoadBearingMountFailed {
+        target: &'static str,
+        fstype: &'static str,
+        error: String,
+    },
+    /// A directory init needs could not be created.
+    Dir { path: String, error: String },
+    /// No pod spec at either location. There is no shell fallback: a guest
+    /// with nothing to run has nothing to do, and a shell as PID 1 would be
+    /// an unmediated workload.
+    PodSpecMissing { primary: String, fallback: String },
+    /// `remount / read-only` failed: refusing to start the workload rather
+    /// than run it on a writable rootfs.
+    SealFailed(String),
+}
+
+impl std::fmt::Display for BootError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BootError::LoadBearingMountFailed {
+                target,
+                fstype,
+                error,
+            } => write!(
+                f,
+                "load-bearing mount {target} ({fstype}) failed: {error} — boot aborted"
+            ),
+            BootError::Dir { path, error } => write!(f, "create {path}: {error}"),
+            BootError::PodSpecMissing { primary, fallback } => write!(
+                f,
+                "missing pod spec (expected {primary} or {fallback}) — refusing to boot: there is no workload to mediate and a shell as PID 1 would be an unmediated one"
+            ),
+            BootError::SealFailed(err) => write!(
+                f,
+                "remount / read-only failed: {err} — refusing to start the workload rather than run it on a writable rootfs"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for BootError {}
+
+/// Marker: nothing mounted yet.
+pub struct Booting;
+/// Marker: every load-bearing mount is in place.
+pub struct Mounted;
+/// Marker: identity, secrets and the child environment are collected.
+pub struct Provisioned;
+/// Marker: the rootfs is read-only. The only state that can `exec`.
+pub struct Sealed;
+
+/// One guest mount and its policy. `load_bearing` decides what a failure
+/// means: `true` aborts the boot, `false` logs and continues (a read-only or
+/// absent optional volume is a legitimate guest — `workload.rs` allows a
+/// read-only `/work`).
+#[derive(Debug, Clone, Copy)]
+pub struct MountSpec {
+    pub source: &'static str,
+    pub target: &'static str,
+    pub fstype: &'static str,
+    pub load_bearing: bool,
+}
+
+/// The outcome of one mount attempt, reported by the platform layer.
+pub type MountResult = Result<(), String>;
+
+/// The boot, parameterised by how far it has got. Consumed by every
+/// transition, so a state cannot be reused after it has been advanced.
+pub struct Boot<S> {
+    /// Names of the mounts that failed but were optional — carried forward so
+    /// the boot report can say what is missing.
+    pub optional_mount_failures: Vec<&'static str>,
+    _state: PhantomData<S>,
+}
+
+// By hand, not derived: a derive would demand `S: Debug` of the marker
+// types, and the markers carry no data to print.
+impl<S> std::fmt::Debug for Boot<S> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Boot")
+            .field("state", &std::any::type_name::<S>())
+            .field("optional_mount_failures", &self.optional_mount_failures)
+            .finish()
+    }
+}
+
+impl Boot<Booting> {
+    /// A boot starts here and nowhere else.
+    pub fn start() -> Self {
+        Boot {
+            optional_mount_failures: Vec::new(),
+            _state: PhantomData,
+        }
+    }
+
+    /// Mount everything in `mounts` through `mount_one` (the platform
+    /// `mount(2)`, injected so the policy is testable on any host). A failed
+    /// load-bearing mount is the boot's error; a failed optional mount is
+    /// recorded and the boot goes on.
+    pub fn mount_all(
+        mut self,
+        mounts: &[MountSpec],
+        mut mount_one: impl FnMut(&MountSpec) -> MountResult,
+    ) -> Result<Boot<Mounted>, BootError> {
+        for m in mounts {
+            match mount_one(m) {
+                Ok(()) => {}
+                Err(error) if m.load_bearing => {
+                    return Err(BootError::LoadBearingMountFailed {
+                        target: m.target,
+                        fstype: m.fstype,
+                        error,
+                    });
+                }
+                Err(_) => self.optional_mount_failures.push(m.target),
+            }
+        }
+        Ok(Boot {
+            optional_mount_failures: self.optional_mount_failures,
+            _state: PhantomData,
+        })
+    }
+}
+
+impl Boot<Mounted> {
+    /// Identity, secrets and the child environment have been collected. The
+    /// caller does that work between `mount_all` and here; this transition
+    /// records that it happened before sealing, which is the order the
+    /// workload API needs (secrets are read into memory, never onto the
+    /// soon-to-be read-only rootfs).
+    pub fn provisioned(self) -> Boot<Provisioned> {
+        Boot {
+            optional_mount_failures: self.optional_mount_failures,
+            _state: PhantomData,
+        }
+    }
+}
+
+impl Boot<Provisioned> {
+    /// Seal the rootfs read-only through `remount_ro` (the platform remount,
+    /// injected). This is the only way to obtain a [`Boot<Sealed>`], hence
+    /// the only way to `exec`.
+    pub fn seal(
+        self,
+        remount_ro: impl FnOnce() -> Result<(), String>,
+    ) -> Result<Boot<Sealed>, BootError> {
+        remount_ro().map_err(BootError::SealFailed)?;
+        Ok(Boot {
+            optional_mount_failures: self.optional_mount_failures,
+            _state: PhantomData,
+        })
+    }
+}
+
+impl Boot<Sealed> {
+    /// Hand the sealed boot to the workload launcher. `launch` is the platform
+    /// `exec(2)` (it does not return on success); it receives the proof that
+    /// the rootfs was sealed first — this method's existence on `Sealed`
+    /// alone. Returns the launcher's error if `exec` itself fails.
+    pub fn exec<T>(self, launch: impl FnOnce(SealedProof) -> T) -> T {
+        launch(SealedProof { _priv: () })
+    }
+}
+
+/// A token that only [`Boot::<Sealed>::exec`] can mint: the launcher demands
+/// it, so nothing outside this module can call the launcher first.
+pub struct SealedProof {
+    _priv: (),
+}
+
+/// Choose the pod spec: the primary path, else the fallback (copied into
+/// place when possible), else a named error. Never a shell.
+pub fn resolve_pod_spec(
+    primary: &str,
+    fallback: &str,
+    exists: impl Fn(&str) -> bool,
+    copy: impl FnOnce(&str, &str) -> bool,
+) -> Result<String, BootError> {
+    if exists(primary) {
+        return Ok(primary.to_string());
+    }
+    if exists(fallback) {
+        if copy(fallback, primary) {
+            return Ok(primary.to_string());
+        }
+        return Ok(fallback.to_string());
+    }
+    Err(BootError::PodSpecMissing {
+        primary: primary.to_string(),
+        fallback: fallback.to_string(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const LB: MountSpec = MountSpec {
+        source: "proc",
+        target: "/proc",
+        fstype: "proc",
+        load_bearing: true,
+    };
+    const OPT: MountSpec = MountSpec {
+        source: "/dev/vdb",
+        target: "/work",
+        fstype: "ext4",
+        load_bearing: false,
+    };
+
+    /// A failed load-bearing mount aborts the boot with a NAMED error — the
+    /// old `mount_fs` printed and continued for every mount.
+    #[test]
+    fn load_bearing_mount_failure_aborts_with_a_named_error() {
+        let err = Boot::start()
+            .mount_all(&[LB, OPT], |m| {
+                if m.target == "/proc" {
+                    Err("EPERM".into())
+                } else {
+                    Ok(())
+                }
+            })
+            .unwrap_err();
+        assert_eq!(
+            err,
+            BootError::LoadBearingMountFailed {
+                target: "/proc",
+                fstype: "proc",
+                error: "EPERM".into()
+            }
+        );
+        assert!(
+            err.to_string()
+                .contains("load-bearing mount /proc (proc) failed")
+        );
+    }
+
+    /// An optional mount may fail; the boot records it and continues.
+    #[test]
+    fn optional_mount_failure_is_recorded_not_fatal() {
+        let boot = Boot::start()
+            .mount_all(&[LB, OPT], |m| {
+                if m.load_bearing {
+                    Ok(())
+                } else {
+                    Err("no /dev/vdb".into())
+                }
+            })
+            .expect("optional failure must not abort");
+        assert_eq!(boot.optional_mount_failures, vec!["/work"]);
+    }
+
+    /// The seal is the remount; a failed remount never yields `Sealed`.
+    #[test]
+    fn seal_failure_never_yields_sealed() {
+        let boot = Boot::start()
+            .mount_all(&[LB], |_| Ok(()))
+            .unwrap()
+            .provisioned();
+        let err = boot.seal(|| Err("EBUSY".into())).unwrap_err();
+        assert_eq!(err, BootError::SealFailed("EBUSY".into()));
+    }
+
+    /// The full path: exec receives the proof only after a successful seal,
+    /// and the launcher observes the remount happened first.
+    #[test]
+    fn exec_runs_only_after_the_remount() {
+        let remounted = std::cell::Cell::new(false);
+        let launched_after_remount = Boot::start()
+            .mount_all(&[LB], |_| Ok(()))
+            .unwrap()
+            .provisioned()
+            .seal(|| {
+                remounted.set(true);
+                Ok(())
+            })
+            .unwrap()
+            .exec(|_proof: SealedProof| remounted.get());
+        assert!(launched_after_remount);
+    }
+
+    /// No shell fallback: a missing spec is an error that names both paths.
+    #[test]
+    fn missing_spec_is_a_named_error_not_a_shell() {
+        let err = resolve_pod_spec(
+            "/etc/nucleus/pod.yaml",
+            "/pod.yaml",
+            |_| false,
+            |_, _| false,
+        )
+        .unwrap_err();
+        assert!(matches!(err, BootError::PodSpecMissing { .. }));
+        assert!(err.to_string().contains("/etc/nucleus/pod.yaml"));
+        assert!(err.to_string().contains("shell as PID 1"));
+    }
+
+    /// The fallback is copied into place when it can be, else used in place.
+    #[test]
+    fn fallback_spec_is_copied_into_place_when_possible() {
+        let p = "/etc/nucleus/pod.yaml";
+        let f = "/pod.yaml";
+        assert_eq!(resolve_pod_spec(p, f, |x| x == f, |_, _| true).unwrap(), p);
+        assert_eq!(resolve_pod_spec(p, f, |x| x == f, |_, _| false).unwrap(), f);
+        assert_eq!(resolve_pod_spec(p, f, |x| x == p, |_, _| false).unwrap(), p);
+    }
+}

--- a/crates/nucleus-guest-init/src/lib.rs
+++ b/crates/nucleus-guest-init/src/lib.rs
@@ -1,0 +1,48 @@
+//! Library half of the guest init: the boot typestate (`boot`), exposed so its
+//! ordering guarantee is checkable by the compiler in doctests, not only by
+//! reading `main.rs` top to bottom.
+//!
+//! # The guarantee, as compile errors
+//!
+//! `exec` exists only on `Boot<Sealed>`, and `Sealed` is only produced by
+//! `seal` (the read-only remount). Skipping the seal is a type error:
+//!
+//! ```compile_fail
+//! use nucleus_guest_init::boot::{Boot, MountSpec};
+//! let boot = Boot::start().mount_all(&[], |_| Ok(())).unwrap().provisioned();
+//! // no `seal` — `Boot<Provisioned>` has no `exec`
+//! boot.exec(|_proof| ());
+//! ```
+//!
+//! Skipping the mounts is a type error too — `provisioned` exists only on
+//! `Boot<Mounted>`:
+//!
+//! ```compile_fail
+//! use nucleus_guest_init::boot::Boot;
+//! let boot = Boot::start().provisioned();
+//! ```
+//!
+//! And the launcher cannot be reached without the proof only `exec` mints —
+//! `SealedProof` has no public constructor:
+//!
+//! ```compile_fail
+//! use nucleus_guest_init::boot::SealedProof;
+//! let _forged = SealedProof { _priv: () };
+//! ```
+//!
+//! The happy path compiles, and the launcher runs only after the remount:
+//!
+//! ```
+//! use nucleus_guest_init::boot::{Boot, MountSpec};
+//! let remounted = std::cell::Cell::new(false);
+//! let ran_after = Boot::start()
+//!     .mount_all(&[], |_| Ok(()))
+//!     .unwrap()
+//!     .provisioned()
+//!     .seal(|| { remounted.set(true); Ok(()) })
+//!     .unwrap()
+//!     .exec(|_proof| remounted.get());
+//! assert!(ran_after);
+//! ```
+
+pub mod boot;

--- a/crates/nucleus-guest-init/src/main.rs
+++ b/crates/nucleus-guest-init/src/main.rs
@@ -6,6 +6,8 @@ use std::process::Command;
 
 mod identity;
 
+use nucleus_guest_init::boot::{self, Boot, MountSpec, SealedProof};
+
 #[cfg(target_os = "linux")]
 use nix::mount::{MsFlags, mount};
 #[cfg(target_os = "linux")]
@@ -71,7 +73,11 @@ fn timed<T>(name: &str, f: impl FnOnce() -> T) -> T {
 
 fn main() {
     if let Err(err) = run() {
+        // PID 1 exiting panics the kernel: that IS the fail-closed outcome
+        // (#2589), reached deliberately with the reason on the console, not
+        // by the old path of swallowing the error and falling off the end.
         eprintln!("nucleus-guest-init error: {err}");
+        std::process::exit(1);
     }
 }
 
@@ -105,21 +111,44 @@ fn run() -> Result<(), String> {
     ensure_dir("/etc/nucleus")?;
     ensure_dir("/work")?;
 
-    for m in GUEST_MOUNTS {
-        mount_fs(m.source, m.target, m.fstype, m.ms_flags(), None);
+    // Booting → Mounted: every load-bearing mount succeeds or the boot stops
+    // with a named error (#2589). The typestate carries the boot from here to
+    // `exec`; see nucleus_guest_init::boot.
+    let boot = Boot::start()
+        .mount_all(&mount_specs(), |m| {
+            let gm = GUEST_MOUNTS
+                .iter()
+                .find(|g| g.target == m.target)
+                .expect("mount_specs is derived from GUEST_MOUNTS");
+            mount_fs(m.source, m.target, m.fstype, gm.ms_flags(), None)
+        })
+        .map_err(|e| e.to_string())?;
+    for missing in &boot.optional_mount_failures {
+        eprintln!("optional mount {missing} failed — continuing without it");
     }
 
-    if Path::new("/dev/vdb").exists() {
-        mount_fs(
+    // `/work` is optional: a guest without a data volume, or a read-only one,
+    // is legitimate (workload.rs allows a read-only /work).
+    if Path::new("/dev/vdb").exists()
+        && let Err(err) = mount_fs(
             "/dev/vdb",
             "/work",
             "ext4",
             MsFlags::MS_NOSUID | MsFlags::MS_NODEV,
             None,
-        );
+        )
+    {
+        eprintln!("optional mount /work failed — continuing without it: {err}");
     }
 
-    let spec_path = resolve_pod_spec()?;
+    // Never a shell: a missing spec is a named boot error.
+    let spec_path = boot::resolve_pod_spec(
+        POD_SPEC_PATH,
+        FALLBACK_POD_SPEC,
+        |p| Path::new(p).exists(),
+        |from, to| fs::copy(from, to).is_ok(),
+    )
+    .map_err(|e| e.to_string())?;
     let net_config = parse_net_config("/proc/cmdline");
 
     if let Some(net) = net_config.as_ref() {
@@ -468,7 +497,12 @@ fn run() -> Result<(), String> {
         export!("NUCLEUS_TOOL_PROXY_BOOT_REPORT", report);
     }
 
-    remount_root_ro()?;
+    // Mounted → Provisioned → Sealed: the remount is the seal, and `exec`
+    // exists only on the sealed boot — reordering these is a type error.
+    let boot = boot
+        .provisioned()
+        .seal(remount_root_ro)
+        .map_err(|e| e.to_string())?;
 
     // NOTE: the loopback interface is DOWN here. Measured in a booted guest —
     // `/sys/class/net/lo/flags` reads `0x8` (LOOPBACK without IFF_UP) and
@@ -491,8 +525,21 @@ fn run() -> Result<(), String> {
     // Anything that makes the guest bind a TCP socket — a spec without vsock, a
     // second listener, a health endpoint on 127.0.0.1 — reintroduces the need,
     // and `EADDRNOTAVAIL` from PID 1 panics the kernel rather than logging.
-    exec_proxy(&spec_path, child_env);
-    Ok(())
+    let err = boot.exec(|proof| exec_proxy(proof, &spec_path, child_env));
+    Err(format!("failed to exec {PROXY_BIN}: {err}"))
+}
+
+/// The typestate's view of `GUEST_MOUNTS`: which mounts are load-bearing.
+fn mount_specs() -> Vec<MountSpec> {
+    GUEST_MOUNTS
+        .iter()
+        .map(|m| MountSpec {
+            source: m.source,
+            target: m.target,
+            fstype: m.fstype,
+            load_bearing: m.load_bearing,
+        })
+        .collect()
 }
 
 /// One guest mount, with its hardening flags as PLAIN BOOLS.
@@ -511,6 +558,10 @@ pub(crate) struct GuestMount {
     pub nodev: bool,
     /// Binaries cannot be executed from here.
     pub noexec: bool,
+    /// A failed mount of this entry aborts the boot (#2589). Every
+    /// pseudo-filesystem here is load-bearing: the proxy needs /proc and /dev,
+    /// the identity handshake needs /run, the audit fallback needs /tmp.
+    pub load_bearing: bool,
 }
 
 impl GuestMount {
@@ -554,6 +605,7 @@ pub(crate) const GUEST_MOUNTS: &[GuestMount] = &[
         nosuid: true,
         nodev: true,
         noexec: true,
+        load_bearing: true,
     },
     GuestMount {
         source: "sys",
@@ -562,6 +614,7 @@ pub(crate) const GUEST_MOUNTS: &[GuestMount] = &[
         nosuid: true,
         nodev: true,
         noexec: true,
+        load_bearing: true,
     },
     GuestMount {
         source: "dev",
@@ -570,6 +623,7 @@ pub(crate) const GUEST_MOUNTS: &[GuestMount] = &[
         nosuid: true,
         nodev: false,
         noexec: false,
+        load_bearing: true,
     },
     GuestMount {
         source: "tmpfs",
@@ -578,6 +632,7 @@ pub(crate) const GUEST_MOUNTS: &[GuestMount] = &[
         nosuid: true,
         nodev: true,
         noexec: true,
+        load_bearing: true,
     },
     GuestMount {
         source: "tmpfs",
@@ -586,6 +641,7 @@ pub(crate) const GUEST_MOUNTS: &[GuestMount] = &[
         nosuid: true,
         nodev: true,
         noexec: true,
+        load_bearing: true,
     },
 ];
 
@@ -593,17 +649,25 @@ fn ensure_dir(path: &str) -> Result<(), String> {
     fs::create_dir_all(path).map_err(|err| format!("create {path}: {err}"))
 }
 
-fn mount_fs(source: &str, target: &str, fstype: &str, flags: MsFlags, data: Option<&str>) {
+/// One `mount(2)`. The CALLER decides what a failure means (load-bearing
+/// aborts the boot, optional continues); this no longer swallows errors.
+fn mount_fs(
+    source: &str,
+    target: &str,
+    fstype: &str,
+    flags: MsFlags,
+    data: Option<&str>,
+) -> Result<(), String> {
     #[cfg(target_os = "linux")]
     {
         let data_bytes = data.map(|value| value.as_bytes());
-        if let Err(err) = mount(Some(source), target, Some(fstype), flags, data_bytes) {
-            eprintln!("mount {source} -> {target} ({fstype}) failed: {err}");
-        }
+        mount(Some(source), target, Some(fstype), flags, data_bytes)
+            .map_err(|err| format!("mount {source} -> {target} ({fstype}) failed: {err}"))
     }
     #[cfg(not(target_os = "linux"))]
     {
         let _ = (source, target, fstype, flags, data);
+        Ok(())
     }
 }
 
@@ -641,23 +705,6 @@ fn remount_root_ro() -> Result<(), String> {
         })?;
     }
     Ok(())
-}
-
-fn resolve_pod_spec() -> Result<String, String> {
-    if Path::new(POD_SPEC_PATH).exists() {
-        return Ok(POD_SPEC_PATH.to_string());
-    }
-
-    if Path::new(FALLBACK_POD_SPEC).exists() {
-        if fs::copy(FALLBACK_POD_SPEC, POD_SPEC_PATH).is_ok() {
-            return Ok(POD_SPEC_PATH.to_string());
-        }
-        return Ok(FALLBACK_POD_SPEC.to_string());
-    }
-
-    eprintln!("missing pod spec (expected {POD_SPEC_PATH} or {FALLBACK_POD_SPEC})");
-    let _ = Command::new("/bin/sh").status();
-    Err("pod spec missing".to_string())
 }
 
 fn read_secret(path: &str) -> Option<String> {
@@ -758,7 +805,15 @@ fn attest_egress_confinement() {
     }
 }
 
-fn exec_proxy(spec_path: &str, child_env: Vec<(std::ffi::OsString, std::ffi::OsString)>) {
+/// The launcher. It demands a `SealedProof`, which only `Boot<Sealed>::exec`
+/// can mint, so no code path reaches the tool-proxy before the rootfs is
+/// read-only (#2589). `exec(2)` does not return on success; the error is
+/// returned so `run()` can fail the boot.
+fn exec_proxy(
+    _sealed: SealedProof,
+    spec_path: &str,
+    child_env: Vec<(std::ffi::OsString, std::ffi::OsString)>,
+) -> std::io::Error {
     // Article 12 record-keeping ON for the live path (EU AI Act Art. 12): every
     // mediation verdict is recorded, and — when a mediator key was delivered
     // (`fetch_mediation_key` above) — signed into a MediationReceipt. The log
@@ -766,17 +821,16 @@ fn exec_proxy(spec_path: &str, child_env: Vec<(std::ffi::OsString, std::ffi::OsS
     // workload cannot tamper), and NOT under the agent workspace (which the
     // proxy's own path check would refuse). The chain is session-derived when no
     // audit secret is configured — weaker than an operator secret, but present.
+    // Scoped to this child: see `child_env` above.
     attest_egress_confinement();
 
-    let err = Command::new(PROXY_BIN)
+    Command::new(PROXY_BIN)
         .arg("--spec")
         .arg(spec_path)
         .arg("--art12-log")
         .arg("/run/nucleus/art12.jsonl")
-        // Scoped to this child: see `child_env` above.
         .envs(child_env)
-        .exec();
-    eprintln!("failed to exec {PROXY_BIN}: {err}");
+        .exec()
 }
 
 #[derive(Debug)]

--- a/crates/nucleus-guest-init/src/main.rs
+++ b/crates/nucleus-guest-init/src/main.rs
@@ -661,13 +661,57 @@ fn mount_fs(
     #[cfg(target_os = "linux")]
     {
         let data_bytes = data.map(|value| value.as_bytes());
-        mount(Some(source), target, Some(fstype), flags, data_bytes)
-            .map_err(|err| format!("mount {source} -> {target} ({fstype}) failed: {err}"))
+        match mount(Some(source), target, Some(fstype), flags, data_bytes) {
+            Ok(()) => Ok(()),
+            // Already mounted — the kernel mounts devtmpfs on /dev itself when
+            // built with CONFIG_DEVTMPFS_MOUNT, and the guest kernel is. The
+            // old fail-open `mount_fs` hid this behind a log line; the first
+            // load-bearing version aborted every boot on it (the x86_64 boot
+            // lane: "mount dev -> /dev (devtmpfs) failed: EBUSY").
+            //
+            // EBUSY alone is not proof the mount is there, so require the
+            // target to actually be a mount point, and then REMOUNT with our
+            // flags: the kernel's automount carries none of them, and a /dev
+            // without nosuid is not the /dev this list promises.
+            Err(nix::errno::Errno::EBUSY) if is_mountpoint(target) => {
+                eprintln!(
+                    "mount {source} -> {target} ({fstype}): already mounted by the kernel; remounting with the required flags"
+                );
+                mount(
+                    None::<&str>,
+                    target,
+                    None::<&str>,
+                    flags | MsFlags::MS_REMOUNT,
+                    data_bytes,
+                )
+                .map_err(|err| {
+                    format!("remount {target} ({fstype}) with the required flags failed: {err}")
+                })
+            }
+            Err(err) => Err(format!(
+                "mount {source} -> {target} ({fstype}) failed: {err}"
+            )),
+        }
     }
     #[cfg(not(target_os = "linux"))]
     {
         let _ = (source, target, fstype, flags, data);
         Ok(())
+    }
+}
+
+/// True when `path` is the root of a mount: its device differs from its
+/// parent's, or it is `/`. Pure stat, so it works before /proc is mounted.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+pub(crate) fn is_mountpoint(path: &str) -> bool {
+    use std::os::unix::fs::MetadataExt;
+    let Ok(meta) = fs::metadata(path) else {
+        return false;
+    };
+    let parent = Path::new(path).parent().unwrap_or(Path::new("/"));
+    match fs::metadata(parent) {
+        Ok(pmeta) => meta.dev() != pmeta.dev() || meta.ino() == pmeta.ino(),
+        Err(_) => false,
     }
 }
 
@@ -926,6 +970,14 @@ fn parse_cmdline_secret(cmdline: &str, key: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn is_mountpoint_root_yes_fresh_dir_no() {
+        assert!(super::is_mountpoint("/"));
+        let dir = std::env::temp_dir().join(format!("guest-init-mp-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        assert!(!super::is_mountpoint(dir.to_str().unwrap()));
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
 
     /// **Every guest pseudo-filesystem is hardened, and `/tmp` and `/run`
     /// especially.**


### PR DESCRIPTION
Closes #2589 (part of #2558, Wave 1).

## What
- **`nucleus_guest_init::boot`** (new lib target beside the bin): `Boot<Booting> → mount_all → Boot<Mounted> → provisioned → Boot<Provisioned> → seal → Boot<Sealed> → exec`. `seal` *is* the read-only remount and the only way to obtain `Boot<Sealed>`; `exec` exists only there and mints a `SealedProof` (no public constructor) that the launcher `exec_proxy` demands. Reordering remount and exec, skipping the mounts, or forging the proof are **type errors** — three `compile_fail` doctests pin that, and a fourth doctest shows the launcher runs only after the remount.
- **Load-bearing vs optional mounts**: `GuestMount` carries `load_bearing` (all five pseudo-filesystems today); `mount_fs` returns its error instead of printing and continuing; a failed load-bearing mount aborts the boot with `BootError::LoadBearingMountFailed { target, fstype, error }`. `/work` (`/dev/vdb`) stays optional — a read-only or absent data volume is a legitimate guest — and optional failures are recorded on the boot.
- **No `/bin/sh` fallback**: `resolve_pod_spec` returns `BootError::PodSpecMissing` naming both paths ("a shell as PID 1 would be an unmediated workload").
- **`run()` errors propagate**: `main` prints the error and exits 1, so the kernel panic on PID 1 exit is the deliberate fail-closed outcome with its reason on the console, not the by-product of swallowing an error.

## Acceptance
- Compile-time: no path reaches `exec_proxy` without `Sealed` (the launcher's `SealedProof` parameter; doctests).
- A failed load-bearing mount aborts boot with a named error (unit tests over an injected `mount(2)`).

Tests: 6 boot unit tests, 11 existing tests, 4 doctests (3 `compile_fail`); clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZaH5waz88vL1qfNpFNfZ4