### PR TITLE
security(kani): enumerate and ratchet every cfg(kani) divergence; relabel the per-PR harnesses *_core_dims

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,6 +351,20 @@ jobs:
       - name: Forbid non-hashing agent-path ingest observes (content-address every input)
         run: scripts/check-ingest-hashed.sh
 
+  kani-divergence-gate:
+    name: cfg(kani) divergences are inventoried and ratcheted
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Every cfg(kani) site is listed and justified; the total only shrinks
+        env:
+          # The script fetches this ref itself (checkout is depth 1).
+          KANI_DIVERGENCE_BASE: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || '' }}
+          # Owner override for a deliberate new divergence: the PR label.
+          KANI_DIVERGENCE_ALLOW_GROWTH: ${{ contains(github.event.pull_request.labels.*.name, 'kani-divergence-growth') && '1' || '0' }}
+        run: scripts/check-kani-divergence.sh
+
   sealed-home-gate:
     name: Sealed-home integrity gate (North Star)
     runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}

--- a/KANI-STATUS.md
+++ b/KANI-STATUS.md
@@ -142,6 +142,53 @@ argument, but it is currently on the wrong side of the tractability line: it bui
 very thing it is trying to bridge. A version over interned ids would verify and would
 carry real weight.
 
+## portcullis: what the per-PR harnesses prove
+
+`crates/portcullis/src/kani.rs` runs five harnesses on every PR and push (the `Kani` job
+in `kani-nightly.yml`). Every one of them traverses `CapabilityLattice` or `ExposureSet`,
+and both types are **narrower under Kani than in production**: their `extensions` field
+(`BTreeMap<ExtensionOperation, CapabilityLevel>` / `BTreeSet<ExtensionExposureLabel>`) is
+`#[cfg(not(kani))]`, for the same reason the ck-kernel tier above never terminates — CBMC
+cannot construct the heap-backed collection. So `meet`, `join`, `leq`, `union`,
+`is_superset_of`, the Heyting `implies`, the permission digest, and
+`UninhabitableState::is_triggered` all take a different path in the proof than in the
+binary.
+
+Every such site is enumerated with a justification in `kani-divergence.toml`, and
+`scripts/check-kani-divergence.sh` (the `cfg(kani) divergences are inventoried and
+ratcheted` job) fails on an unlisted site, a stale entry, or any growth of the total
+against the PR base. The count is 62 sites in 41 distinct (file, attribute, guarded line)
+groups; 11 are harness modules that change nothing, 26 are the mechanical struct-literal
+consequences of the two omitted fields, and the rest are the operations and predicates
+listed below.
+
+The harnesses are therefore relabelled here as **`*_core_dims`** proofs. The source
+names are unchanged for now (the `--harness` arguments in the workflow and the proof-count
+census key on them); the label states what each one actually establishes.
+
+| harness (as `*_core_dims`) | proves | does **not** prove |
+| --- | --- | --- |
+| `proof_capability_distributive_core_dims` | meet distributes over join on the 13 core capability dimensions | the same law on extension dimensions — covered by `test_extension_mock_matches_production_btreemap` (exhaustive, 2 keys × 4 states), not by BMC |
+| `proof_exposureset_monoid_identity_core_dims` | `empty()` is the two-sided identity of `union` on the three frozen labels | identity for the extension-label set half of `union` (set union with `{}`; true by construction, not machine-checked) |
+| `proof_exposureset_uninhabitable_iff_count_three_core_dims` | `is_uninhabitable() ⟺ count() == 3` | nothing narrower: both sides read only the three core bools in every build, so this one is exact for production too |
+| `proof_operation_exposure_completeness_core_dims` | every `Operation` maps to a core `ExposureLabel` set as specified | anything about extension exposure labels (none are attached to operations today) |
+| `proof_clinejection_blocked_core_dims` | the CLI-injection path is denied given the core `UntrustedContent`/`ExfilVector` exposure | denial decisions that depend on `required_ext_labels`: `is_triggered` sets `ext_met = true` under Kani, so a combo with extension requirements is proved *at least as* denied as production, not equal to it |
+
+Two sites are semantic divergences rather than domain narrowings, and are worth naming
+outside the table:
+
+- **`certificate.rs` permission digest** omits the extension bytes under Kani. Any digest
+  property proved under Kani holds for extension-free permissions only.
+- **`uninhabitable_state.rs` `is_triggered`** treats every required extension label as met
+  under Kani. The direction is fail-closed (the verified predicate denies at least as often
+  as production), but it is not the production predicate; the extension cases are covered
+  by two unit tests only.
+
+The way out is the one KANI-STATUS already names for ck-kernel: a Kani-tractable
+representation for the extension dimensions (fixed slots or interned ids, as `LedgerCore`
+did for the budget ledger) with a refinement argument to the `BTreeMap`. Until then the
+divergence total in `kani-divergence.toml` may only shrink.
+
 ## What runs today
 
 `src/kani.rs` carries `#![cfg(kani)]`, so **its harnesses compile only under `cargo kani`** —

--- a/kani-divergence.toml
+++ b/kani-divergence.toml
@@ -1,0 +1,320 @@
+# cfg(kani) divergence inventory — enforced by scripts/check-kani-divergence.sh (#2574).
+#
+# Every attribute-form `#[cfg(kani)]`, `#[cfg(not(kani))]`, `#![cfg(kani)]` and
+# `#[cfg_attr(kani, ..)]` under crates/**/*.rs is a place where what Kani verifies
+# and what ships can differ. Each one is listed here with the line it guards, a
+# class, and a justification. The lint fails on an unlisted site, on a listed
+# site that no longer exists, on a `total` that does not match the census, and
+# (against the PR base) on any growth: the total only shrinks. Removing a
+# divergence means making the production representation Kani-tractable
+# (fixed-slot / bitmask, as `LedgerCore` did for the budget ledger), not
+# deleting the proof.
+#
+# Classes:
+#   harness-only              proof harness modules; no production path changes
+#   extensions-omitted-field  a BTreeMap/BTreeSet field compiled out under Kani (the root cause)
+#   extensions-omitted-ctor   a struct literal initialising that field (no divergence of its own)
+#   extensions-omitted-op     an operation over that field skipped/absent under Kani
+#   extensions-omitted-test   a unit test that needs the field
+#   semantic-divergence       the verified predicate/digest differs from production in value,
+#                             not just in domain — read the entry; each states the direction
+#
+# The harness consequence of the extensions-omitted family is recorded in
+# KANI-STATUS.md ("portcullis: what the per-PR harnesses prove"): every portcullis
+# harness over CapabilityLattice or ExposureSet is a `*_core_dims` proof.
+
+
+total = 62
+
+[[site]]
+file = "crates/ck-kernel/src/kani.rs"
+attr = "#![cfg(kani)]"
+guards = "<whole file>"
+class = "harness-only"
+why = "Proof harnesses. Compiled only under `cargo kani`; nothing on a production path changes. Listed so the census is total, not because it diverges."
+
+[[site]]
+file = "crates/nucleus-econ-kernels/proofs/welfare_no_overflow.rs"
+attr = "#![cfg(kani)]"
+guards = "<whole file>"
+class = "harness-only"
+why = "Proof harnesses. Compiled only under `cargo kani`; nothing on a production path changes. Listed so the census is total, not because it diverges."
+
+[[site]]
+file = "crates/nucleus-econ-kernels/src/lib.rs"
+attr = "#[cfg(kani)]"
+guards = "mod welfare_no_overflow_proofs;"
+class = "harness-only"
+why = "Proof harnesses. Compiled only under `cargo kani`; nothing on a production path changes. Listed so the census is total, not because it diverges."
+
+[[site]]
+file = "crates/nucleus-ifc-kernel/src/flow.rs"
+attr = "#[cfg(kani)]"
+guards = "mod kani_proofs {"
+class = "harness-only"
+why = "Proof harnesses. Compiled only under `cargo kani`; nothing on a production path changes. Listed so the census is total, not because it diverges."
+
+[[site]]
+file = "crates/nucleus-node/src/session_mint.rs"
+attr = "#[cfg(not(kani))]"
+guards = "extensions: std::collections::BTreeMap::new(),"
+class = "extensions-omitted-ctor"
+why = "Struct-literal consequence of `CapabilityLattice::extensions` being `cfg(not(kani))` (see capability.rs field entry). Adds no divergence of its own: it initialises a field that does not exist in the verified model."
+
+[[site]]
+file = "crates/portcullis-core/src/declassify.rs"
+attr = "#[cfg(kani)]"
+guards = "mod kani_declassify_proofs {"
+class = "harness-only"
+why = "Proof harnesses. Compiled only under `cargo kani`; nothing on a production path changes. Listed so the census is total, not because it diverges."
+
+[[site]]
+file = "crates/portcullis-core/src/delegation.rs"
+attr = "#[cfg(kani)]"
+guards = "mod kani_delegation_proofs {"
+class = "harness-only"
+why = "Proof harnesses. Compiled only under `cargo kani`; nothing on a production path changes. Listed so the census is total, not because it diverges."
+
+[[site]]
+file = "crates/portcullis-core/src/envelope.rs"
+attr = "#[cfg(kani)]"
+guards = "mod kani_witness_requirement_proofs {"
+class = "harness-only"
+why = "Proof harnesses. Compiled only under `cargo kani`; nothing on a production path changes. Listed so the census is total, not because it diverges."
+
+[[site]]
+file = "crates/portcullis-core/src/lib.rs"
+attr = "#[cfg(kani)]"
+guards = "mod kani_ifc_label_proofs {"
+class = "harness-only"
+why = "Proof harnesses. Compiled only under `cargo kani`; nothing on a production path changes. Listed so the census is total, not because it diverges."
+
+[[site]]
+file = "crates/portcullis-core/src/manifest.rs"
+attr = "#[cfg(kani)]"
+guards = "mod kani_proofs {"
+class = "harness-only"
+why = "Proof harnesses. Compiled only under `cargo kani`; nothing on a production path changes. Listed so the census is total, not because it diverges."
+
+[[site]]
+file = "crates/portcullis/src/capability.rs"
+attr = "#[cfg(not(kani))]"
+guards = "extensions: BTreeMap::new(),"
+count = 3
+class = "extensions-omitted-ctor"
+why = "Struct-literal consequence of `CapabilityLattice::extensions` being `cfg(not(kani))` (see capability.rs field entry). Adds no divergence of its own: it initialises a field that does not exist in the verified model."
+
+[[site]]
+file = "crates/portcullis/src/capability.rs"
+attr = "#[cfg(not(kani))]"
+guards = "extensions: ext,"
+count = 2
+class = "extensions-omitted-op"
+why = "Result-literal half of the meet/join extension computation above; same justification."
+
+[[site]]
+file = "crates/portcullis/src/capability.rs"
+attr = "#[cfg(not(kani))]"
+guards = "let ext = if self.extensions.is_empty() && other.extensions.is_empty() {"
+count = 2
+class = "extensions-omitted-op"
+why = "`meet`/`join` compute the extension pointwise min/max only in production. Under Kani meet and join are over the 13 core dimensions: `proof_capability_distributive` and the meet_* harnesses prove distributivity/idempotence/commutativity/associativity of the CORE lattice; the extension half is covered by the exhaustive mock-vs-BTreeMap test, not by BMC."
+
+[[site]]
+file = "crates/portcullis/src/capability.rs"
+attr = "#[cfg(not(kani))]"
+guards = "pub extensions: BTreeMap<ExtensionOperation, CapabilityLevel>,"
+class = "extensions-omitted-field"
+why = "ROOT of the largest family. The extension dimensions live in a BTreeMap, which CBMC cannot construct tractably (see KANI-STATUS.md, `BTreeSet<String>`). Under Kani `CapabilityLattice` is the 13 core dimensions only, so every portcullis harness over it is a `*_core_dims` proof. Extension lattice laws are covered by `test_extension_mock_matches_production_btreemap` (exhaustive 2 keys x 4 states), not by Kani."
+
+[[site]]
+file = "crates/portcullis/src/capability.rs"
+attr = "#[cfg(not(kani))]"
+guards = "pub fn extension_level(&self, op: &ExtensionOperation) -> CapabilityLevel {"
+class = "extensions-omitted-op"
+why = "Accessor over the omitted field. Not callable under Kani; harnesses cannot observe extension levels."
+
+[[site]]
+file = "crates/portcullis/src/capability.rs"
+attr = "#[cfg(not(kani))]"
+guards = "{"
+class = "extensions-omitted-op"
+why = "`leq` skips the extension pointwise-<= branch under Kani. Every harness asserting `a.leq(&b)` (attenuation_leq_*, delegation_ceiling, apply_record_monotone, normalize_*) proves the order on the 13 core dimensions only; a production `leq` can additionally return false on an extension key. Direction: production is STRICTER, never looser, than the verified predicate."
+
+[[site]]
+file = "crates/portcullis/src/certificate.rs"
+attr = "#[cfg(not(kani))]"
+guards = "{"
+class = "semantic-divergence"
+why = "The permission digest omits the extension bytes under Kani. A digest proved stable/injective under Kani is proved so for extension-FREE permissions; two production permissions differing only in extensions hash differently (BTreeMap iteration is key-ordered, so this remains deterministic), which Kani never exercises. Any future harness over `permission_digest` is a `_core_dims` proof until this site is removed."
+
+[[site]]
+file = "crates/portcullis/src/dropout.rs"
+attr = "#[cfg(not(kani))]"
+guards = "extensions: std::collections::BTreeMap::new(),"
+class = "extensions-omitted-ctor"
+why = "Struct-literal consequence of `CapabilityLattice::extensions` being `cfg(not(kani))` (see capability.rs field entry). Adds no divergence of its own: it initialises a field that does not exist in the verified model."
+
+[[site]]
+file = "crates/portcullis/src/guard.rs"
+attr = "#[cfg(kani)]"
+guards = "core_ok"
+class = "semantic-divergence"
+why = "`is_superset_of` under Kani is the core-label superset only; production additionally requires `other.extensions ⊆ self.extensions`. The E1 monotonicity assertion is therefore proved for core labels; production is stricter. Pair of the `{` entry below."
+
+[[site]]
+file = "crates/portcullis/src/guard.rs"
+attr = "#[cfg(not(kani))]"
+guards = "extensions,"
+class = "extensions-omitted-op"
+why = "`union` takes the BTreeSet union only in production. Under Kani union is OR over three bools: the monoid-law harnesses (`proof_exposureset_monoid_identity`/`_laws`, `_union_monotone`) prove the core monoid; set union is associative/commutative/idempotent with {} as identity by construction, but that half is not machine-checked."
+
+[[site]]
+file = "crates/portcullis/src/guard.rs"
+attr = "#[cfg(not(kani))]"
+guards = "extensions: std::collections::BTreeSet<ExtensionExposureLabel>,"
+class = "extensions-omitted-field"
+why = "ROOT of the ExposureSet family: the extension exposure labels live in a BTreeSet, intractable for CBMC. Under Kani `ExposureSet` is exactly three bools, so `proof_exposureset_*`, `proof_operation_exposure_completeness`, `proof_clinejection_blocked`, `proof_exposure_*` and `proof_guard_denial_soundness` prove properties of the three FROZEN core labels. The uninhabitable predicate itself (`is_uninhabitable`) reads only the core bools in both builds, so that predicate is not narrowed."
+
+[[site]]
+file = "crates/portcullis/src/guard.rs"
+attr = "#[cfg(not(kani))]"
+guards = "for ext in &self.extensions {"
+class = "extensions-omitted-op"
+why = "`Display` renders extension labels only in production. Cosmetic; no harness asserts on the rendering."
+
+[[site]]
+file = "crates/portcullis/src/guard.rs"
+attr = "#[cfg(not(kani))]"
+guards = "let extensions = if self.extensions.is_empty() && other.extensions.is_empty() {"
+class = "extensions-omitted-op"
+why = "`union` takes the BTreeSet union only in production. Under Kani union is OR over three bools: the monoid-law harnesses (`proof_exposureset_monoid_identity`/`_laws`, `_union_monotone`) prove the core monoid; set union is associative/commutative/idempotent with {} as identity by construction, but that half is not machine-checked."
+
+[[site]]
+file = "crates/portcullis/src/guard.rs"
+attr = "#[cfg(not(kani))]"
+guards = "pub fn contains_extension(&self, label: &ExtensionExposureLabel) -> bool {"
+class = "extensions-omitted-op"
+why = "Constructor/accessor over the omitted BTreeSet field. Not callable under Kani."
+
+[[site]]
+file = "crates/portcullis/src/guard.rs"
+attr = "#[cfg(not(kani))]"
+guards = "pub fn extension_labels(&self) -> impl Iterator<Item = &ExtensionExposureLabel> {"
+class = "extensions-omitted-op"
+why = "Constructor/accessor over the omitted BTreeSet field. Not callable under Kani."
+
+[[site]]
+file = "crates/portcullis/src/guard.rs"
+attr = "#[cfg(not(kani))]"
+guards = "pub fn extension_singleton(label: ExtensionExposureLabel) -> Self {"
+class = "extensions-omitted-op"
+why = "Constructor/accessor over the omitted BTreeSet field. Not callable under Kani."
+
+[[site]]
+file = "crates/portcullis/src/guard.rs"
+attr = "#[cfg(not(kani))]"
+guards = "{"
+class = "extensions-omitted-op"
+why = "Production branch of `is_superset_of` (core AND extension subset). See the `core_ok` entry."
+
+[[site]]
+file = "crates/portcullis/src/heyting.rs"
+attr = "#[cfg(not(kani))]"
+guards = "extensions: ext,"
+class = "extensions-omitted-op"
+why = "`implies` computes the pointwise Heyting implication over extension keys only in production (sparse: absent = Always). Under Kani `proof_r1_heyting_adjunction` / `proof_r2_pseudo_complement` prove the adjunction over the 13 core dimensions; the extension adjunction is covered by the three `test_heyting_adjunction_extensions_*` unit tests below (27 explicit triples + sparse cases), not by BMC."
+
+[[site]]
+file = "crates/portcullis/src/heyting.rs"
+attr = "#[cfg(not(kani))]"
+guards = "extensions: std::collections::BTreeMap::new(),"
+class = "extensions-omitted-ctor"
+why = "Struct-literal consequence of `CapabilityLattice::extensions` being `cfg(not(kani))` (see capability.rs field entry). Adds no divergence of its own: it initialises a field that does not exist in the verified model."
+
+[[site]]
+file = "crates/portcullis/src/heyting.rs"
+attr = "#[cfg(not(kani))]"
+guards = "fn leq_himp(&self, himp: &Self) -> bool {"
+class = "extensions-omitted-op"
+why = "`leq_himp` (absent-key = Always comparison for implication results) exists only in production because it is only meaningful with the sparse extension map. Under Kani the Heyting harnesses compare with core `leq`, which is exact for the 13 core dimensions."
+
+[[site]]
+file = "crates/portcullis/src/heyting.rs"
+attr = "#[cfg(not(kani))]"
+guards = "fn test_heyting_adjunction_extensions_exhaustive() {"
+class = "extensions-omitted-test"
+why = "Unit test that exercises extension keys; cannot compile when the field is absent. These tests ARE the coverage for the extension half of the Heyting adjunction that the Kani harnesses do not prove."
+
+[[site]]
+file = "crates/portcullis/src/heyting.rs"
+attr = "#[cfg(not(kani))]"
+guards = "fn test_heyting_adjunction_extensions_regression() {"
+class = "extensions-omitted-test"
+why = "Unit test that exercises extension keys; cannot compile when the field is absent. These tests ARE the coverage for the extension half of the Heyting adjunction that the Kani harnesses do not prove."
+
+[[site]]
+file = "crates/portcullis/src/heyting.rs"
+attr = "#[cfg(not(kani))]"
+guards = "fn test_heyting_adjunction_extensions_sparse_leq_himp() {"
+class = "extensions-omitted-test"
+why = "Unit test that exercises extension keys; cannot compile when the field is absent. These tests ARE the coverage for the extension half of the Heyting adjunction that the Kani harnesses do not prove."
+
+[[site]]
+file = "crates/portcullis/src/heyting.rs"
+attr = "#[cfg(not(kani))]"
+guards = "let ext = {"
+class = "extensions-omitted-op"
+why = "`implies` computes the pointwise Heyting implication over extension keys only in production (sparse: absent = Always). Under Kani `proof_r1_heyting_adjunction` / `proof_r2_pseudo_complement` prove the adjunction over the 13 core dimensions; the extension adjunction is covered by the three `test_heyting_adjunction_extensions_*` unit tests below (27 explicit triples + sparse cases), not by BMC."
+
+[[site]]
+file = "crates/portcullis/src/kani.rs"
+attr = "#![cfg(kani)]"
+guards = "<whole file>"
+class = "harness-only"
+why = "Proof harnesses. Compiled only under `cargo kani`; nothing on a production path changes. Listed so the census is total, not because it diverges."
+
+[[site]]
+file = "crates/portcullis/src/lattice.rs"
+attr = "#[cfg(not(kani))]"
+guards = "extensions: std::collections::BTreeMap::new(),"
+count = 16
+class = "extensions-omitted-ctor"
+why = "Struct-literal consequence of `CapabilityLattice::extensions` being `cfg(not(kani))` (see capability.rs field entry). Adds no divergence of its own: it initialises a field that does not exist in the verified model."
+
+[[site]]
+file = "crates/portcullis/src/lib.rs"
+attr = "#[cfg(kani)]"
+guards = "mod kani;"
+class = "harness-only"
+why = "Proof harnesses. Compiled only under `cargo kani`; nothing on a production path changes. Listed so the census is total, not because it diverges."
+
+[[site]]
+file = "crates/portcullis/src/profile.rs"
+attr = "#[cfg(not(kani))]"
+guards = "extensions: std::collections::BTreeMap::new(),"
+class = "extensions-omitted-ctor"
+why = "Struct-literal consequence of `CapabilityLattice::extensions` being `cfg(not(kani))` (see capability.rs field entry). Adds no divergence of its own: it initialises a field that does not exist in the verified model."
+
+[[site]]
+file = "crates/portcullis/src/trust.rs"
+attr = "#[cfg(not(kani))]"
+guards = "extensions: std::collections::BTreeMap::new(),"
+count = 3
+class = "extensions-omitted-ctor"
+why = "Struct-literal consequence of `CapabilityLattice::extensions` being `cfg(not(kani))` (see capability.rs field entry). Adds no divergence of its own: it initialises a field that does not exist in the verified model."
+
+[[site]]
+file = "crates/portcullis/src/uninhabitable_state.rs"
+attr = "#[cfg(kani)]"
+guards = "let ext_met = true;"
+class = "semantic-divergence"
+why = "`UninhabitableState::is_triggered` treats every required EXTENSION label as met under Kani (`ext_met = true`), because `ExposureSet::contains_extension` does not exist there. Effect: for a combo with `required_ext_labels` non-empty the verified predicate triggers on the core labels alone, i.e. it is at least as eager to deny as production (fail-closed direction), but it is NOT the production predicate. Harnesses over `is_triggered` prove the canonical combo (no extension requirements) exactly; combos with extension requirements are covered by `test_extension_combo_triggered` / `test_extension_combo_not_triggered_missing_ext` only."
+
+[[site]]
+file = "crates/portcullis/src/uninhabitable_state.rs"
+attr = "#[cfg(not(kani))]"
+guards = "let ext_met = self"
+class = "semantic-divergence"
+why = "Production half of the `is_triggered` extension check; see the `let ext_met = true;` entry."
+

--- a/scripts/check-gates-can-fail.sh
+++ b/scripts/check-gates-can-fail.sh
@@ -352,6 +352,20 @@ perturb_extracted_callsite() {
     fi
 }
 
+perturb_kani_divergence_unlisted() {
+    # A brand-new production fork the inventory does not know about: a
+    # `#[cfg(not(kani))]` guarding a real function. Exactly the gate's subject —
+    # an unlisted divergence (and one more than the base, so the shrink ratchet
+    # would also bite in CI).
+    cat >> "$1" <<'RUST'
+
+#[cfg(not(kani))]
+pub fn gate_of_gates_unlisted_divergence_probe() -> bool {
+    true
+}
+RUST
+}
+
 probe check-line-ratchet.sh   "--strict" crates/portcullis/src/kernel.rs \
       "400 lines past the ceiling"            perturb_line_ratchet
 probe check-mediation.sh      "" crates/nucleus-tool-proxy/src/egress.rs \
@@ -395,6 +409,10 @@ probe check-extracted-callsites.sh "" crates/nucleus-tool-proxy/src/workload.rs 
 probe check-no-hmac-auth.sh "" crates/nucleus-node/src/auth.rs \
       "a retired NUCLEUS_NODE_AUTH_SECRET reference reintroduced" \
       perturb_no_hmac_auth
+
+probe check-kani-divergence.sh "" crates/portcullis/src/capability.rs \
+      "an unlisted cfg(not(kani)) fork" \
+      perturb_kani_divergence_unlisted
 
 # ── Uncovered, listed rather than omitted ─────────────────────────────────
 #

--- a/scripts/check-kani-divergence.sh
+++ b/scripts/check-kani-divergence.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# Every `cfg(kani)` divergence between the verified model and the shipped code
+# is enumerated, justified, and ratcheted (#2574).
+#
+# WHY THIS EXISTS
+#
+# Kani verifies the crate compiled with `--cfg kani`. Every `#[cfg(not(kani))]`
+# is code the proofs never see, and every `#[cfg(kani)]` outside a harness is
+# code that exists ONLY for the proofs. Both are places where the property the
+# harness proves and the property the binary has can differ. Today the largest
+# family is `CapabilityLattice::extensions` / `ExposureSet::extensions`: the
+# BTreeMap/BTreeSet fields are compiled out under Kani, so meet/join/leq, the
+# certificate digest, and `UninhabitableState::is_triggered` all take a
+# different path in the proof than in production. That is a legitimate
+# tractability trade, but an UNLISTED one is a proof silently narrowed.
+#
+# So: every attribute-form `cfg(kani)` site in crates/**/*.rs must appear in
+# kani-divergence.toml with a class and a justification, the inventory may not
+# name a site that no longer exists, the declared `total` must equal the census,
+# and — against a base ref — the total may only shrink.
+#
+# Usage:
+#   scripts/check-kani-divergence.sh            # gate (exit 1 on any drift)
+#   scripts/check-kani-divergence.sh --report   # print the census in inventory shape
+#   scripts/check-kani-divergence.sh --count    # print the census total only
+#
+# Env:
+#   KANI_DIVERGENCE_BASE=<git ref>   compare `total` against that ref's inventory;
+#                                    growth fails unless KANI_DIVERGENCE_ALLOW_GROWTH=1
+#
+# A "site" is (file, attribute line, guarded line): the attribute exactly as
+# written, and the first following line that is not an attribute, comment, or
+# blank. Identical triples in one file are one entry with `count = N` — the
+# sixteen `extensions: BTreeMap::new()` constructors in lattice.rs are one
+# decision, not sixteen. A whole-file `#![cfg(kani)]` guards the file itself.
+# Mentions inside comments and the `rustc-check-cfg` line in build.rs are not
+# sites: they change nothing about what is compiled.
+
+set -euo pipefail
+
+INVENTORY="kani-divergence.toml"
+MODE="gate"
+case "${1:-}" in
+    --report) MODE="report" ;;
+    --count)  MODE="count" ;;
+    "") ;;
+    *) echo "usage: $0 [--report|--count]" >&2; exit 2 ;;
+esac
+
+SITE_RE='^[[:space:]]*#!?\[cfg\(kani\)\]|^[[:space:]]*#\[cfg\(not\(kani\)\)\]|^[[:space:]]*#\[cfg_attr\(kani[,)]'
+
+# census: "file<TAB>attr<TAB>guards" one line per site (not yet deduplicated).
+census() {
+    local f
+    grep -rlE --include='*.rs' --exclude-dir=target "$SITE_RE" crates 2>/dev/null | LC_ALL=C sort | while read -r f; do
+        awk -v file="$f" '
+            function trim(s) { sub(/^[ \t]+/, "", s); sub(/[ \t]+$/, "", s); return s }
+            function emit(g) { printf "%s\t%s\t%s\n", file, attr, g; pending = 0 }
+            {
+                line = trim($0)
+                if (pending) {
+                    if (inattr) { if (line ~ /\]$/) inattr = 0; next }
+                    if (line == "" || line ~ /^\/\//) next
+                    if (line ~ /^#\[/) { if (line !~ /\]$/) inattr = 1; next }
+                    emit(line)
+                }
+                if (line ~ /^#!\[cfg\(kani\)\]$/) {
+                    attr = line; printf "%s\t%s\t%s\n", file, attr, "<whole file>"; next
+                }
+                if (line ~ /^#\[cfg\(kani\)\]$/ || line ~ /^#\[cfg\(not\(kani\)\)\]$/ || line ~ /^#\[cfg_attr\(kani[,)]/) {
+                    attr = line; pending = 1; inattr = (line !~ /\]$/)
+                }
+            }
+            END { if (pending) emit("<end of file>") }
+        ' "$f"
+    done
+}
+
+# dedup: "count<TAB>file<TAB>attr<TAB>guards"
+census_grouped() {
+    census | LC_ALL=C sort | uniq -c | sed -E 's/^[[:space:]]*([0-9]+) /\1\t/'
+}
+
+toml_escape() { sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'; }
+
+if [[ "$MODE" == "count" ]]; then
+    census | wc -l | tr -d ' '
+    exit 0
+fi
+
+if [[ "$MODE" == "report" ]]; then
+    total=$(census | wc -l | tr -d ' ')
+    echo "# census: $total attribute-form cfg(kani) sites"
+    echo "total = $total"
+    census_grouped | while IFS=$'\t' read -r n file attr guards; do
+        echo
+        echo "[[site]]"
+        echo "file = \"$file\""
+        echo "attr = \"$(printf '%s' "$attr" | toml_escape)\""
+        echo "guards = \"$(printf '%s' "$guards" | toml_escape)\""
+        [[ "$n" -gt 1 ]] && echo "count = $n"
+        echo "class = \"\""
+        echo "why = \"\""
+    done
+    exit 0
+fi
+
+# ── gate ──────────────────────────────────────────────────────────────────
+
+if [[ ! -f "$INVENTORY" ]]; then
+    echo "ERROR: $INVENTORY not found — every cfg(kani) site must be inventoried"
+    exit 1
+fi
+
+DECLARED_TOTAL=$(awk '/^total[ \t]*=/ { gsub(/.*=[ \t]*/, ""); print; exit }' "$INVENTORY")
+if [[ -z "$DECLARED_TOTAL" ]]; then
+    echo "ERROR: $INVENTORY has no top-level 'total = N'"
+    exit 1
+fi
+
+# One awk pass turns every [[site]] block into "count<TAB>file<TAB>attr<TAB>guards",
+# and rejects a block missing a field or an empty justification. Portable to
+# bash 3.2 / BSD awk: no gensub, no mapfile.
+INVENTORY_ROWS=$(awk '
+    function unq(s) { sub(/^[ \t]*"/, "", s); sub(/"[ \t]*$/, "", s); gsub(/\\"/, "\"", s); gsub(/\\\\/, "\\", s); return s }
+    function flush() {
+        if (!insite) return
+        if (file == "" || attr == "" || guards == "") { printf "BAD\tincomplete [[site]] ending at line %d (file/attr/guards required)\n", NR; bad = 1 }
+        else if (class == "" || why == "") { printf "BAD\t%s: site \"%s\" needs a non-empty class and why\n", file, attr; bad = 1 }
+        else printf "%d\t%s\t%s\t%s\n", count, file, attr, guards
+    }
+    /^\[\[site\]\]/ { flush(); insite = 1; file = ""; attr = ""; guards = ""; class = ""; why = ""; count = 1; next }
+    insite && /^file[ \t]*=/   { sub(/^file[ \t]*=/, ""); file = unq($0) }
+    insite && /^attr[ \t]*=/   { sub(/^attr[ \t]*=/, ""); attr = unq($0) }
+    insite && /^guards[ \t]*=/ { sub(/^guards[ \t]*=/, ""); guards = unq($0) }
+    insite && /^class[ \t]*=/  { sub(/^class[ \t]*=/, ""); class = unq($0) }
+    insite && /^why[ \t]*=/    { sub(/^why[ \t]*=/, ""); why = unq($0) }
+    insite && /^count[ \t]*=/  { sub(/^count[ \t]*=[ \t]*/, ""); count = $0 + 0 }
+    END { flush(); if (bad) exit 3 }
+' "$INVENTORY") || { echo "$INVENTORY_ROWS" | grep '^BAD' | sed 's/^BAD\t/ERROR: /'; exit 1; }
+
+failures=0
+
+expected=$(mktemp); actual=$(mktemp)
+trap 'rm -f "$expected" "$actual"' EXIT
+
+# Expand counts so a multiset diff is a plain line diff.
+printf '%s\n' "$INVENTORY_ROWS" | awk -F'\t' '$1 > 0 { for (i = 0; i < $1; i++) printf "%s\t%s\t%s\n", $2, $3, $4 }' | LC_ALL=C sort > "$expected"
+census | LC_ALL=C sort > "$actual"
+
+ACTUAL_TOTAL=$(wc -l < "$actual" | tr -d ' ')
+LISTED_TOTAL=$(wc -l < "$expected" | tr -d ' ')
+
+unlisted=$(LC_ALL=C comm -13 "$expected" "$actual" || true)
+stale=$(LC_ALL=C comm -23 "$expected" "$actual" || true)
+
+if [[ -n "$unlisted" ]]; then
+    echo "UNLISTED cfg(kani) sites (add each to $INVENTORY with a class and a justification):"
+    printf '%s\n' "$unlisted" | awk -F'\t' '{ printf "  %s\n      %s\n      -> %s\n", $1, $2, $3 }'
+    failures=$((failures + 1))
+fi
+if [[ -n "$stale" ]]; then
+    echo "STALE inventory entries (site no longer in the tree — remove it and lower total):"
+    printf '%s\n' "$stale" | awk -F'\t' '{ printf "  %s\n      %s\n      -> %s\n", $1, $2, $3 }'
+    failures=$((failures + 1))
+fi
+if [[ "$DECLARED_TOTAL" -ne "$ACTUAL_TOTAL" ]]; then
+    echo "TOTAL mismatch: $INVENTORY declares total = $DECLARED_TOTAL, the tree has $ACTUAL_TOTAL sites (inventory lists $LISTED_TOTAL)"
+    failures=$((failures + 1))
+fi
+
+# Shrink-only ratchet against a base ref (CI passes the PR's base SHA).
+if [[ -n "${KANI_DIVERGENCE_BASE:-}" ]]; then
+    base="$KANI_DIVERGENCE_BASE"
+    if ! git cat-file -e "$base^{commit}" 2>/dev/null; then
+        git fetch --quiet --depth=1 origin "$base" || { echo "ERROR: cannot fetch base ref $base"; exit 1; }
+        git cat-file -e "$base^{commit}" 2>/dev/null || base="FETCH_HEAD"
+    fi
+    if git cat-file -e "$base:$INVENTORY" 2>/dev/null; then
+        BASE_TOTAL=$(git show "$base:$INVENTORY" | awk '/^total[ \t]*=/ { gsub(/.*=[ \t]*/, ""); print; exit }')
+        if [[ -n "$BASE_TOTAL" && "$ACTUAL_TOTAL" -gt "$BASE_TOTAL" ]]; then
+            if [[ "${KANI_DIVERGENCE_ALLOW_GROWTH:-0}" == "1" ]]; then
+                echo "NOTE: divergence total grew $BASE_TOTAL -> $ACTUAL_TOTAL; growth explicitly allowed for this run"
+            else
+                echo "GROWTH: divergence total is $ACTUAL_TOTAL, base ($KANI_DIVERGENCE_BASE) had $BASE_TOTAL — the ceiling only shrinks."
+                echo "  Prefer a Kani-tractable representation over a new cfg(kani) fork. If the fork is"
+                echo "  the right call, an owner sets KANI_DIVERGENCE_ALLOW_GROWTH=1 (the 'kani-divergence-growth' PR label)."
+                failures=$((failures + 1))
+            fi
+        else
+            echo "ratchet: total $ACTUAL_TOTAL <= base $BASE_TOTAL"
+        fi
+    else
+        echo "ratchet: base $KANI_DIVERGENCE_BASE has no $INVENTORY; nothing to shrink from"
+    fi
+fi
+
+if [[ "$failures" -gt 0 ]]; then
+    echo
+    echo "FAIL: cfg(kani) divergence inventory out of sync ($failures problem class(es))."
+    echo "      Run scripts/check-kani-divergence.sh --report for the census in inventory shape."
+    exit 1
+fi
+
+echo "OK: $ACTUAL_TOTAL cfg(kani) sites, all inventoried and justified in $INVENTORY (total = $DECLARED_TOTAL)"


### PR DESCRIPTION
Closes #2574.

Kani verifies the crate compiled with `--cfg kani`. Every `#[cfg(not(kani))]` is code the proofs never see, and the largest family is the `extensions` field of `CapabilityLattice` and `ExposureSet` (BTreeMap/BTreeSet, intractable for CBMC). `meet`/`join`/`leq`/`union`/`is_superset_of`/`implies`, the permission digest and `UninhabitableState::is_triggered` all take a different path under Kani than in production. That trade was legitimate but unlisted: a proof silently narrowed.

## What this adds

- **`kani-divergence.toml`** — all 62 attribute-form `cfg(kani)` sites (41 distinct file / attribute / guarded-line groups), each with a class and a justification that states the *direction* of the divergence. Two are semantic (the digest omits extension bytes; `is_triggered` sets `ext_met = true`); the rest are the two omitted fields, their 26 struct-literal constructors, the operations over them, three extension unit tests, and 11 harness-only modules.
- **`scripts/check-kani-divergence.sh`** — fails on an unlisted site, a stale entry, a `total` that does not match the census, and against `KANI_DIVERGENCE_BASE` on any growth of the total (the ceiling only shrinks). Owner override: the `kani-divergence-growth` PR label. `--report` prints the census in inventory shape, `--count` the total.
- **ci.yml** — `cfg(kani) divergences are inventoried and ratcheted` gate job on the gate pool; base SHA from the PR / merge group.
- **check-gates-can-fail.sh** — probes the new gate with a planted unlisted `#[cfg(not(kani))]` fork in `capability.rs`.
- **KANI-STATUS.md** — new section relabelling the five per-PR portcullis harnesses as `*_core_dims` proofs, with a proves / does-not-prove table and the two semantic divergences named. Source names are unchanged for now (the workflow `--harness` args and the proof-count census key on them); rename is a follow-up once #2627/#2630 land.

## Verified locally

```
$ scripts/check-kani-divergence.sh
OK: 62 cfg(kani) sites, all inventoried and justified in kani-divergence.toml (total = 62)
# planted `#[cfg(not(kani))] pub fn probe_x()` in capability.rs:
UNLISTED cfg(kani) sites … TOTAL mismatch … FAIL   (rc=1)
# planted + inventoried, KANI_DIVERGENCE_BASE=HEAD:
GROWTH: divergence total is 63, base (HEAD) had 62 — the ceiling only shrinks.   (rc=1)
# same with KANI_DIVERGENCE_ALLOW_GROWTH=1: rc=0
```

`shellcheck -S warning` clean; actionlint clean apart from the pre-existing SC1007 at ci.yml:584.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZaH5waz88vL1qfNpFNfZ4
