### PR TITLE
ci(clippy-ratchet): force-push the bot branch so ratchet-down is idempotent; ceiling 466 → 455

### DIFF
--- a/.clippy-ratchet.toml
+++ b/.clippy-ratchet.toml
@@ -27,6 +27,6 @@ lints = [
 # push to main snaps this down to the real count (457 measured here, three
 # identical consecutive runs), so an over-generous seed
 # self-corrects within one commit rather than hiding a regression forever.
-ceiling = 466
+ceiling = 455
 target = 0
 step = 5

--- a/.github/workflows/clippy-ratchet.yml
+++ b/.github/workflows/clippy-ratchet.yml
@@ -132,7 +132,12 @@ jobs:
           git checkout -b "$BRANCH"
           git add "$RATCHET_FILE"
           git commit -m "chore(clippy-ratchet): ceiling $CEILING -> $NEW (actual $ACTUAL)"
-          git push -u origin "$BRANCH"
+          # Force: the branch is bot-owned and single-commit. When an earlier
+          # run pushed it but never got its PR open (or the PR was closed), the
+          # branch outlives the PR and a plain push is rejected with "fetch
+          # first" on EVERY later push to main — which is how this job was red
+          # for a full day with four orphaned chore/clippy-ratchet-* branches.
+          git push -f -u origin "$BRANCH"
 
           gh pr create \
             --base main --head "$BRANCH" \


### PR DESCRIPTION
Every push to main since 2026-09-05 02:37 has failed at **Ratchet ceiling down**: the bot branch `chore/clippy-ratchet-455` already existed from an earlier run whose PR never opened, so `git push -u` was rejected with "fetch first". Four orphaned `chore/clippy-ratchet-*` branches (455, 457, 464, 465) were left behind the same way, none with a PR; they are deleted alongside this PR.

- The branch is bot-owned and single-commit, so the job now pushes with `--force`.
- The ceiling drop the bot has been trying to land (466 → 455; actual 455 on linux CI) is carried here so the job has nothing to do after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZaH5waz88vL1qfNpFNfZ4
