### PR TITLE
ci: a red workflow on main opens an issue; the ratchet bot can use a token that gets its PR checks

### DIFF
--- a/.github/workflows/ci-red-main.yml
+++ b/.github/workflows/ci-red-main.yml
@@ -1,0 +1,109 @@
+name: main is red
+
+# A red job on main was invisible for a day (the clippy ratchet-down job,
+# 2026-09-05: every push to main failed at "Ratchet ceiling down" and nothing
+# surfaced it). This polls the latest push-to-main run of each load-bearing
+# workflow and keeps ONE open issue per red workflow, labelled `ci-red-main`,
+# closed automatically when the workflow is green again.
+#
+# Polling on a schedule rather than `workflow_run` on purpose: workflow_run is
+# a privileged trigger the zizmor gate flags, and a 20-minute delay is fine
+# for a signal that used to be absent.
+
+on:
+  schedule:
+    - cron: "*/20 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+  issues: write
+
+concurrency:
+  group: ci-red-main
+  cancel-in-progress: false
+
+jobs:
+  watch:
+    name: Open an issue per red workflow on main; close it when green
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 10
+    steps:
+      - name: Reconcile issues with the latest push-to-main conclusions
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          # Workflow FILES to watch: the ones whose red on main means something
+          # shipped broken or a gate stopped gating. Workflows that are red for
+          # a known, tracked reason belong in an issue, not off this list.
+          WATCH: >-
+            ci.yml
+            clippy-ratchet.yml
+            audit.yml
+            coverage-matrix.yml
+            feature-matrix.yml
+            kani-nightly.yml
+            line-ratchet.yml
+            formal-numbers.yml
+            manifest-guards.yml
+            portcullis-core-proven-lean.yml
+            quickstart-boot.yml
+            dep-hygiene.yml
+            deny.yml
+            zizmor.yml
+            dylint-separation.yml
+            aeneas-ifc-scoped.yml
+            ck-policy-lean.yml
+            econ-lean.yml
+            rubric-lean.yml
+        run: |
+          set -euo pipefail
+          gh label create ci-red-main --repo "$REPO" --color B60205 \
+            --description "A load-bearing workflow is red on main (opened/closed by ci-red-main.yml)" \
+            --force >/dev/null
+          red=0
+          for wf in $WATCH; do
+            [ -f ".github/workflows/$wf" ] 2>/dev/null || true   # no checkout; names are what matter
+            latest=$(gh run list --repo "$REPO" --workflow "$wf" --branch main --event push \
+                       --limit 1 --json conclusion,url,headSha,name,createdAt \
+                       --jq '.[0] // empty')
+            [ -n "$latest" ] || continue
+            conclusion=$(jq -r .conclusion <<<"$latest")
+            name=$(jq -r .name <<<"$latest")
+            url=$(jq -r .url <<<"$latest")
+            sha=$(jq -r '.headSha[0:8]' <<<"$latest")
+            title="CI is red on main: $name"
+            open=$(gh issue list --repo "$REPO" --label ci-red-main --state open \
+                     --search "in:title \"$title\"" --json number,title \
+                     --jq --arg t "$title" '.[] | select(.title==$t) | .number' | head -1)
+            case "$conclusion" in
+              failure|timed_out|cancelled)
+                red=$((red+1))
+                if [ -z "$open" ]; then
+                  gh issue create --repo "$REPO" --label ci-red-main --title "$title" \
+                    --body "The latest push-to-main run of **$name** (\`$wf\`) is **$conclusion** at \`$sha\`: $url
+
+Opened by \`.github/workflows/ci-red-main.yml\`; it closes this issue automatically when the workflow is green on main again. Each later red run is added as a comment." >/dev/null
+                  echo "opened: $title ($conclusion, $sha)"
+                else
+                  last=$(gh issue view "$open" --repo "$REPO" --json comments --jq '.comments[-1].body // ""')
+                  if ! grep -q "$sha" <<<"$last"; then
+                    gh issue comment "$open" --repo "$REPO" --body "Still red: **$conclusion** at \`$sha\`: $url" >/dev/null
+                    echo "commented #$open: $title ($conclusion, $sha)"
+                  else
+                    echo "unchanged #$open: $title ($conclusion, $sha)"
+                  fi
+                fi
+                ;;
+              success)
+                if [ -n "$open" ]; then
+                  gh issue close "$open" --repo "$REPO" --comment "Green again at \`$sha\`: $url" >/dev/null
+                  echo "closed #$open: $title"
+                fi
+                ;;
+              *) echo "skip: $name ($conclusion)";;
+            esac
+          done
+          echo "red workflows on main: $red"
+          echo "- red workflows on main: **$red**" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci-red-main.yml
+++ b/.github/workflows/ci-red-main.yml
@@ -58,6 +58,7 @@ jobs:
             econ-lean.yml
             rubric-lean.yml
         run: |
+          # shellcheck disable=SC2016 — jq's $t and the markdown backticks are literal on purpose.
           set -euo pipefail
           gh label create ci-red-main --repo "$REPO" --color B60205 \
             --description "A load-bearing workflow is red on main (opened/closed by ci-red-main.yml)" \

--- a/.github/workflows/ci-red-main.yml
+++ b/.github/workflows/ci-red-main.yml
@@ -58,7 +58,8 @@ jobs:
             econ-lean.yml
             rubric-lean.yml
         run: |
-          # shellcheck disable=SC2016 — jq's $t and the markdown backticks are literal on purpose.
+          # jq's $t and the markdown backticks are literal on purpose.
+          # shellcheck disable=SC2016
           set -euo pipefail
           gh label create ci-red-main --repo "$REPO" --color B60205 \
             --description "A load-bearing workflow is red on main (opened/closed by ci-red-main.yml)" \

--- a/.github/workflows/ci-red-main.yml
+++ b/.github/workflows/ci-red-main.yml
@@ -81,10 +81,8 @@ jobs:
               failure|timed_out|cancelled)
                 red=$((red+1))
                 if [ -z "$open" ]; then
-                  gh issue create --repo "$REPO" --label ci-red-main --title "$title" \
-                    --body "The latest push-to-main run of **$name** (\`$wf\`) is **$conclusion** at \`$sha\`: $url
-
-Opened by \`.github/workflows/ci-red-main.yml\`; it closes this issue automatically when the workflow is green on main again. Each later red run is added as a comment." >/dev/null
+                  body=$(printf 'The latest push-to-main run of **%s** (`%s`) is **%s** at `%s`: %s\n\nOpened by `.github/workflows/ci-red-main.yml`; it closes this issue automatically when the workflow is green on main again. Each later red run is added as a comment.' "$name" "$wf" "$conclusion" "$sha" "$url")
+                  gh issue create --repo "$REPO" --label ci-red-main --title "$title" --body "$body" >/dev/null
                   echo "opened: $title ($conclusion, $sha)"
                 else
                   last=$(gh issue view "$open" --repo "$REPO" --json comments --jq '.comments[-1].body // ""')

--- a/.github/workflows/clippy-ratchet.yml
+++ b/.github/workflows/clippy-ratchet.yml
@@ -73,9 +73,17 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      # CLIPPY_RATCHET_TOKEN: a fine-grained PAT (or App token) with contents
+      # + pull-requests write. A branch pushed and a PR opened with the default
+      # GITHUB_TOKEN never trigger `pull_request` workflows, so the bot's PR
+      # gets no required checks and auto-merge sits pending forever — that is
+      # why four chore/clippy-ratchet-* branches were orphaned. With the
+      # secret set the PR runs CI and auto-merges like any other; without it
+      # everything still works except that last step, which warns.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.CLIPPY_RATCHET_TOKEN || secrets.GITHUB_TOKEN }}
+          persist-credentials: true
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
           components: clippy
@@ -83,7 +91,7 @@ jobs:
 
       - name: Ratchet down
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.CLIPPY_RATCHET_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           RATCHET_FILE=".clippy-ratchet.toml"


### PR DESCRIPTION
CI review item 5. The clippy ratchet-down job was red on every push to main for a day and nothing surfaced it.

- **`ci-red-main.yml`** polls the latest push-to-main run of nineteen load-bearing workflows every 20 minutes and keeps one open issue per red workflow (label `ci-red-main`), commenting on each new red SHA and closing the issue when the workflow is green again. Polling instead of `workflow_run`: that trigger is privileged and the zizmor gate flags it; a 20-minute delay is fine for a signal that used to be absent.
- **`clippy-ratchet.yml`** uses `CLIPPY_RATCHET_TOKEN` when set. A PR opened with `GITHUB_TOKEN` never triggers `pull_request` workflows, so the bot's PR had no checks and auto-merge sat forever, which is how four `chore/clippy-ratchet-*` branches got orphaned. Without the secret the job works as before and warns at the auto-merge step.

**Owner action needed for the second half:** create a fine-grained PAT (or a GitHub App installation token) with *contents: write* and *pull requests: write* on this repo and add it as the repository secret `CLIPPY_RATCHET_TOKEN`. Nothing else changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZaH5waz88vL1qfNpFNfZ4
