### PR TITLE
ci(metrics): CI throughput as OpenTelemetry metrics — ARC listener scrape + `cargo xtask ci-otel`, Prometheus, Grafana

### DIFF
--- a/.github/workflows/ci-metrics.yml
+++ b/.github/workflows/ci-metrics.yml
@@ -1,0 +1,52 @@
+name: CI metrics (OpenTelemetry)
+
+# Every 15 minutes: push the GitHub side of CI throughput — per-job queue
+# wait and duration, completions by conclusion, merge-queue depth — to the
+# OpenTelemetry collector on the self-hosted cluster (k8s/ci-metrics), where
+# the actions-runner-controller listeners' runner-side metrics already land.
+# `cargo xtask ci-otel` (crates/xtask/src/ci_otel.rs) does the pull and the
+# OTLP/HTTP export. Runs only on the self-hosted pool: the collector's
+# in-cluster address is not reachable from a hosted runner.
+
+on:
+  schedule:
+    - cron: "*/15 * * * *"
+  workflow_dispatch:
+    inputs:
+      since:
+        description: "window in minutes (default 15; use 1440 for a day's backfill)"
+        default: "15"
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: ci-metrics
+  cancel-in-progress: false
+
+jobs:
+  export:
+    name: Push job timings to the collector
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Only meaningful on the self-hosted pool
+        id: where
+        env:
+          RUNNER_ENV: ${{ runner.environment }}
+        run: |
+          if [ "$RUNNER_ENV" = "self-hosted" ]; then echo "run=true" >> "$GITHUB_OUTPUT";
+          else echo "run=false" >> "$GITHUB_OUTPUT"; echo "hosted runner: the in-cluster collector is unreachable — nothing to do"; fi
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
+        if: ${{ steps.where.outputs.run == 'true' }}
+        with:
+          cache: ${{ runner.environment == 'github-hosted' }}
+      - name: cargo xtask ci-otel
+        if: ${{ steps.where.outputs.run == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SINCE: ${{ inputs.since || '15' }}
+          OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector.ci-metrics.svc.cluster.local:4318
+        run: cargo xtask ci-otel --since "$SINCE"

--- a/crates/xtask/src/ci_otel.rs
+++ b/crates/xtask/src/ci_otel.rs
@@ -290,9 +290,11 @@ pub fn ci_otel(since_min: u64, endpoint: Option<String>, dry_run: bool) -> Resul
             }
         })
     };
+    // Unit left empty on the counts: the collector's Prometheus exporter turns
+    // unit "1" into a `_ratio` suffix, which a queue depth is not.
     let gauge = |name: &str, desc: &str, v: u64| -> Value {
         json!({
-            "name": name, "description": desc, "unit": "1",
+            "name": name, "description": desc, "unit": "",
             "gauge": {"dataPoints": [{"timeUnixNano": now_ns, "asInt": v.to_string()}]}
         })
     };
@@ -309,7 +311,7 @@ pub fn ci_otel(since_min: u64, endpoint: Option<String>, dry_run: bool) -> Resul
                     hist_metric("ci.job.duration", "seconds a job ran (completed_at - started_at)", &duration),
                     hist_metric("ci.workflow.duration", "seconds from run creation to completion", &wf_duration),
                     json!({
-                        "name": "ci.job.completed", "description": "jobs completed in the window, by conclusion", "unit": "1",
+                        "name": "ci.job.completed", "description": "jobs completed in the window, by conclusion", "unit": "",
                         "sum": {"aggregationTemporality": 1, "isMonotonic": true,
                             "dataPoints": completed.iter().map(|(a, n)| json!({
                                 "attributes": attrs_json(a),

--- a/crates/xtask/src/ci_otel.rs
+++ b/crates/xtask/src/ci_otel.rs
@@ -11,7 +11,8 @@
 //! Metrics (all with unit `s` where a duration):
 //!   * `ci.job.queue_wait`  histogram  {workflow, runner, event}
 //!     started_at − created_at: time waiting for a runner
-//!   * `ci.job.duration`    histogram  {workflow, job, runner, event}
+//!   * `ci.job.duration`    histogram  {workflow, job_name, runner, event}
+//!     (`job_name`, not `job`: Prometheus reserves `job` for service.name)
 //!     completed_at − started_at
 //!   * `ci.job.completed`   sum (delta) {workflow, runner, event, conclusion}
 //!   * `ci.workflow.duration` histogram {workflow, event}
@@ -250,7 +251,7 @@ pub fn ci_otel(since_min: u64, endpoint: Option<String>, dry_run: bool) -> Resul
             duration
                 .entry(vec![
                     ("workflow", wf.clone()),
-                    ("job", j.name.clone()),
+                    ("job_name", j.name.clone()),
                     ("runner", runner.clone()),
                     ("event", run.event.clone()),
                 ])
@@ -267,10 +268,18 @@ pub fn ci_otel(since_min: u64, endpoint: Option<String>, dry_run: bool) -> Resul
         }
     }
 
-    let mq: Value = serde_json::from_str(&gh_api(
-        "graphql -f query={repository(owner:\"coproduct-opensource\",name:\"nucleus\"){mergeQueue(branch:\"main\"){entries(first:1){totalCount}}}}",
-    ).unwrap_or_else(|_| "{}".into()))
-    .unwrap_or(Value::Null);
+    let mq: Value = Command::new("gh")
+        .args([
+            "api",
+            "graphql",
+            "-f",
+            "query={repository(owner:\"coproduct-opensource\",name:\"nucleus\"){mergeQueue(branch:\"main\"){entries(first:1){totalCount}}}}",
+        ])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| serde_json::from_slice(&o.stdout).ok())
+        .unwrap_or(Value::Null);
     let mq_depth = mq["data"]["repository"]["mergeQueue"]["entries"]["totalCount"]
         .as_u64()
         .unwrap_or(0);

--- a/crates/xtask/src/ci_otel.rs
+++ b/crates/xtask/src/ci_otel.rs
@@ -1,0 +1,381 @@
+//! `cargo xtask ci-otel` — GitHub-side CI throughput as OpenTelemetry metrics.
+//!
+//! The runner side of CI (queued jobs, busy runners, pod start-up) is what
+//! the actions-runner-controller listeners already export to Prometheus. The
+//! GitHub side — how long each job WAITED for a runner, how long it ran, how
+//! many landed per conclusion, how deep the merge queue is — only exists in
+//! the Actions API. This pulls the jobs that completed in a window and pushes
+//! them to an OTLP/HTTP endpoint as histograms and counters, so both halves
+//! land on the same dashboard (k8s/ci-metrics).
+//!
+//! Metrics (all with unit `s` where a duration):
+//!   * `ci.job.queue_wait`  histogram  {workflow, runner, event}
+//!     started_at − created_at: time waiting for a runner
+//!   * `ci.job.duration`    histogram  {workflow, job, runner, event}
+//!     completed_at − started_at
+//!   * `ci.job.completed`   sum (delta) {workflow, runner, event, conclusion}
+//!   * `ci.workflow.duration` histogram {workflow, event}
+//!     run created → run updated, for runs that completed in the window
+//!   * `ci.merge_queue.depth`  gauge  — entries in the main merge queue now
+//!   * `ci.runs.queued` / `ci.runs.in_progress`  gauges — workflow runs now
+//!
+//! Delta temporality: each invocation reports the window it saw and nothing
+//! else, and the collector's `deltatocumulative` processor turns that into the
+//! cumulative series Prometheus wants. The window is `--since` minutes back
+//! from now; a job is in the window when its `completed_at` is. Run it from a
+//! schedule with `--since` equal to the schedule period (small drift at the
+//! edges is accepted: this is a throughput dashboard, not an audit log).
+//!
+//! Usage: `cargo xtask ci-otel [--since MIN] [--endpoint URL] [--dry-run]`
+//! Endpoint default: `$OTEL_EXPORTER_OTLP_ENDPOINT`, else the in-cluster
+//! collector `http://otel-collector.ci-metrics.svc.cluster.local:4318`.
+//! No OTel SDK: the OTLP/HTTP JSON encoding is small enough to write by hand,
+//! and xtask stays a `gh`+`curl` tool with no network crates.
+
+use anyhow::{Context, Result, bail};
+use serde::Deserialize;
+use serde_json::{Value, json};
+use std::collections::BTreeMap;
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const REPO: &str = "coproduct-opensource/nucleus";
+const DEFAULT_ENDPOINT: &str = "http://otel-collector.ci-metrics.svc.cluster.local:4318";
+
+/// Seconds boundaries shared by every duration histogram: 5 s to 2 h.
+const BOUNDS: &[f64] = &[
+    5.0, 10.0, 20.0, 30.0, 60.0, 120.0, 180.0, 300.0, 600.0, 900.0, 1200.0, 1800.0, 2700.0, 3600.0,
+    5400.0, 7200.0,
+];
+
+#[derive(Deserialize)]
+struct RunList {
+    workflow_runs: Vec<Run>,
+}
+
+#[derive(Deserialize, Clone)]
+struct Run {
+    id: u64,
+    name: Option<String>,
+    event: String,
+    status: String,
+    created_at: String,
+    updated_at: String,
+}
+
+#[derive(Deserialize)]
+struct JobList {
+    jobs: Vec<Job>,
+}
+
+#[derive(Deserialize, Clone)]
+struct Job {
+    name: String,
+    status: String,
+    conclusion: Option<String>,
+    labels: Vec<String>,
+    created_at: String,
+    started_at: Option<String>,
+    completed_at: Option<String>,
+}
+
+fn gh_api(path: &str) -> Result<String> {
+    let out = Command::new("gh")
+        .args(["api", path])
+        .output()
+        .context("run gh api (is the GitHub CLI installed and authenticated?)")?;
+    if !out.status.success() {
+        bail!(
+            "gh api {path} failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        );
+    }
+    Ok(String::from_utf8(out.stdout)?)
+}
+
+fn now_secs() -> i64 {
+    i64::try_from(
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0),
+    )
+    .unwrap_or(i64::MAX)
+}
+
+/// RFC 3339 `…Z` for a Unix time, whole seconds. Inverse of
+/// [`crate::ci_timings::epoch`] (civil-from-days, Howard Hinnant).
+fn rfc3339(secs: i64) -> String {
+    let days = secs.div_euclid(86_400);
+    let rem = secs.rem_euclid(86_400);
+    let z = days + 719_468;
+    let era = z.div_euclid(146_097);
+    let doe = z - era * 146_097;
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    format!(
+        "{y:04}-{m:02}-{d:02}T{:02}:{:02}:{:02}Z",
+        rem / 3600,
+        (rem % 3600) / 60,
+        rem % 60
+    )
+}
+
+/// One histogram series: delta counts per bucket for one attribute set.
+#[derive(Default, Clone)]
+struct Hist {
+    count: u64,
+    sum: f64,
+    min: f64,
+    max: f64,
+    buckets: Vec<u64>, // len = BOUNDS.len() + 1
+}
+
+impl Hist {
+    fn observe(&mut self, v: f64) {
+        if self.buckets.is_empty() {
+            self.buckets = vec![0; BOUNDS.len() + 1];
+            self.min = v;
+            self.max = v;
+        }
+        self.count += 1;
+        self.sum += v;
+        self.min = self.min.min(v);
+        self.max = self.max.max(v);
+        let idx = BOUNDS.iter().position(|b| v <= *b).unwrap_or(BOUNDS.len());
+        self.buckets[idx] += 1;
+    }
+}
+
+type Attrs = Vec<(&'static str, String)>;
+
+fn attrs_json(attrs: &Attrs) -> Value {
+    Value::Array(
+        attrs
+            .iter()
+            .map(|(k, v)| json!({"key": k, "value": {"stringValue": v}}))
+            .collect(),
+    )
+}
+
+/// The runner label that routed the job: the first non-generic one.
+fn runner_of(labels: &[String]) -> String {
+    labels
+        .iter()
+        .find(|l| !matches!(l.as_str(), "self-hosted" | "linux" | "x64" | "arm64"))
+        .cloned()
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+pub fn ci_otel(since_min: u64, endpoint: Option<String>, dry_run: bool) -> Result<()> {
+    let endpoint = endpoint
+        .or_else(|| std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT").ok())
+        .unwrap_or_else(|| DEFAULT_ENDPOINT.to_string());
+    let now = now_secs();
+    let window_start = now - i64::try_from(since_min * 60).unwrap_or(i64::MAX);
+    let start_ns = format!("{}", window_start.saturating_mul(1_000_000_000));
+    let now_ns = format!("{}", now.saturating_mul(1_000_000_000));
+
+    // Runs updated since the window opened (a run's updated_at moves when a job
+    // completes), any status; jobs are filtered on completed_at below.
+    let since = rfc3339(window_start - 3600); // generous: long runs update late
+    let runs: RunList = serde_json::from_str(&gh_api(&format!(
+        "repos/{REPO}/actions/runs?created=>={since}&per_page=100"
+    ))?)
+    .context("parse run list")?;
+
+    let mut queue_wait: BTreeMap<Attrs, Hist> = BTreeMap::new();
+    let mut duration: BTreeMap<Attrs, Hist> = BTreeMap::new();
+    let mut completed: BTreeMap<Attrs, u64> = BTreeMap::new();
+    let mut wf_duration: BTreeMap<Attrs, Hist> = BTreeMap::new();
+    let mut runs_queued = 0u64;
+    let mut runs_in_progress = 0u64;
+    let mut jobs_seen = 0usize;
+
+    for run in &runs.workflow_runs {
+        match run.status.as_str() {
+            "queued" => runs_queued += 1,
+            "in_progress" => runs_in_progress += 1,
+            _ => {}
+        }
+        let wf = run.name.clone().unwrap_or_default();
+        if run.status == "completed" {
+            if let (Some(c), Some(u)) = (
+                crate::ci_timings::epoch(&run.created_at),
+                crate::ci_timings::epoch(&run.updated_at),
+            ) && u > window_start
+                && u <= now
+            {
+                wf_duration
+                    .entry(vec![("workflow", wf.clone()), ("event", run.event.clone())])
+                    .or_default()
+                    .observe((u - c).max(0) as f64);
+            }
+        }
+        let list: JobList = serde_json::from_str(&gh_api(&format!(
+            "repos/{REPO}/actions/runs/{}/jobs?per_page=100",
+            run.id
+        ))?)
+        .with_context(|| format!("parse jobs of run {}", run.id))?;
+        for j in list.jobs {
+            if j.status != "completed" {
+                continue;
+            }
+            let (Some(created), Some(started), Some(done)) = (
+                crate::ci_timings::epoch(&j.created_at),
+                j.started_at.as_deref().and_then(crate::ci_timings::epoch),
+                j.completed_at.as_deref().and_then(crate::ci_timings::epoch),
+            ) else {
+                continue;
+            };
+            if done <= window_start || done > now {
+                continue;
+            }
+            jobs_seen += 1;
+            let runner = runner_of(&j.labels);
+            let conclusion = j.conclusion.clone().unwrap_or_else(|| "unknown".into());
+            queue_wait
+                .entry(vec![
+                    ("workflow", wf.clone()),
+                    ("runner", runner.clone()),
+                    ("event", run.event.clone()),
+                ])
+                .or_default()
+                .observe((started - created).max(0) as f64);
+            duration
+                .entry(vec![
+                    ("workflow", wf.clone()),
+                    ("job", j.name.clone()),
+                    ("runner", runner.clone()),
+                    ("event", run.event.clone()),
+                ])
+                .or_default()
+                .observe((done - started).max(0) as f64);
+            *completed
+                .entry(vec![
+                    ("workflow", wf.clone()),
+                    ("runner", runner),
+                    ("event", run.event.clone()),
+                    ("conclusion", conclusion),
+                ])
+                .or_default() += 1;
+        }
+    }
+
+    let mq: Value = serde_json::from_str(&gh_api(
+        "graphql -f query={repository(owner:\"coproduct-opensource\",name:\"nucleus\"){mergeQueue(branch:\"main\"){entries(first:1){totalCount}}}}",
+    ).unwrap_or_else(|_| "{}".into()))
+    .unwrap_or(Value::Null);
+    let mq_depth = mq["data"]["repository"]["mergeQueue"]["entries"]["totalCount"]
+        .as_u64()
+        .unwrap_or(0);
+
+    let hist_metric = |name: &str, desc: &str, series: &BTreeMap<Attrs, Hist>| -> Value {
+        json!({
+            "name": name, "description": desc, "unit": "s",
+            "histogram": {
+                "aggregationTemporality": 1, // DELTA
+                "dataPoints": series.iter().map(|(a, h)| json!({
+                    "attributes": attrs_json(a),
+                    "startTimeUnixNano": start_ns, "timeUnixNano": now_ns,
+                    "count": h.count.to_string(), "sum": h.sum, "min": h.min, "max": h.max,
+                    "bucketCounts": h.buckets.iter().map(|c| c.to_string()).collect::<Vec<_>>(),
+                    "explicitBounds": BOUNDS,
+                })).collect::<Vec<_>>(),
+            }
+        })
+    };
+    let gauge = |name: &str, desc: &str, v: u64| -> Value {
+        json!({
+            "name": name, "description": desc, "unit": "1",
+            "gauge": {"dataPoints": [{"timeUnixNano": now_ns, "asInt": v.to_string()}]}
+        })
+    };
+    let payload = json!({
+        "resourceMetrics": [{
+            "resource": {"attributes": [
+                {"key": "service.name", "value": {"stringValue": "github-actions"}},
+                {"key": "github.repository", "value": {"stringValue": REPO}},
+            ]},
+            "scopeMetrics": [{
+                "scope": {"name": "nucleus.xtask.ci-otel"},
+                "metrics": [
+                    hist_metric("ci.job.queue_wait", "seconds a job waited for a runner (started_at - created_at)", &queue_wait),
+                    hist_metric("ci.job.duration", "seconds a job ran (completed_at - started_at)", &duration),
+                    hist_metric("ci.workflow.duration", "seconds from run creation to completion", &wf_duration),
+                    json!({
+                        "name": "ci.job.completed", "description": "jobs completed in the window, by conclusion", "unit": "1",
+                        "sum": {"aggregationTemporality": 1, "isMonotonic": true,
+                            "dataPoints": completed.iter().map(|(a, n)| json!({
+                                "attributes": attrs_json(a),
+                                "startTimeUnixNano": start_ns, "timeUnixNano": now_ns,
+                                "asInt": n.to_string(),
+                            })).collect::<Vec<_>>()}
+                    }),
+                    gauge("ci.merge_queue.depth", "entries in the main merge queue", mq_depth),
+                    gauge("ci.runs.queued", "workflow runs queued now", runs_queued),
+                    gauge("ci.runs.in_progress", "workflow runs in progress now", runs_in_progress),
+                ]
+            }]
+        }]
+    });
+
+    eprintln!(
+        "ci-otel: window {}..{} — {} runs seen, {} jobs completed in window, {} job series, merge queue depth {}, runs queued {} / in progress {}",
+        rfc3339(window_start),
+        rfc3339(now),
+        runs.workflow_runs.len(),
+        jobs_seen,
+        duration.len(),
+        mq_depth,
+        runs_queued,
+        runs_in_progress
+    );
+    if dry_run {
+        println!("{}", serde_json::to_string_pretty(&payload)?);
+        return Ok(());
+    }
+    let body = serde_json::to_string(&payload)?;
+    let out = Command::new("curl")
+        .args([
+            "-sS",
+            "-m",
+            "20",
+            "-X",
+            "POST",
+            "-H",
+            "Content-Type: application/json",
+            "--data-binary",
+            "@-",
+            "-w",
+            "%{http_code}",
+            "-o",
+            "/dev/null",
+            &format!("{}/v1/metrics", endpoint.trim_end_matches('/')),
+        ])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .context("spawn curl")?;
+    {
+        use std::io::Write as _;
+        let mut stdin = out.stdin.as_ref().context("curl stdin")?;
+        stdin.write_all(body.as_bytes())?;
+    }
+    let done = out.wait_with_output()?;
+    let code = String::from_utf8_lossy(&done.stdout).trim().to_string();
+    if !done.status.success() || !code.starts_with('2') {
+        bail!(
+            "OTLP export to {endpoint} failed: http {code} {}",
+            String::from_utf8_lossy(&done.stderr).trim()
+        );
+    }
+    eprintln!("ci-otel: exported to {endpoint} (http {code})");
+    Ok(())
+}

--- a/crates/xtask/src/ci_timings.rs
+++ b/crates/xtask/src/ci_timings.rs
@@ -61,7 +61,7 @@ struct Step {
 
 /// Seconds since the Unix epoch for an RFC 3339 UTC timestamp (`…Z`).
 /// Hand-rolled to keep xtask dependency-free of a time crate.
-fn epoch(ts: &str) -> Option<i64> {
+pub(crate) fn epoch(ts: &str) -> Option<i64> {
     let ts = ts.strip_suffix('Z')?;
     let (date, time) = ts.split_once('T')?;
     let mut d = date.split('-').map(|s| s.parse::<i64>());

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -109,6 +109,20 @@ enum Command {
         #[arg(long)]
         baseline: String,
     },
+    /// Push the last N minutes of GitHub Actions job timings to an OTLP
+    /// endpoint as OpenTelemetry metrics (queue wait, duration, conclusions,
+    /// merge-queue depth). See crates/xtask/src/ci_otel.rs.
+    CiOtel {
+        /// Window in minutes (a job counts when its completed_at is inside).
+        #[arg(long, default_value_t = 15)]
+        since: u64,
+        /// OTLP/HTTP base URL (default: $OTEL_EXPORTER_OTLP_ENDPOINT, else the in-cluster collector).
+        #[arg(long)]
+        endpoint: Option<String>,
+        /// Print the OTLP JSON instead of sending it.
+        #[arg(long)]
+        dry_run: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -159,6 +173,7 @@ enum CiSpecCmd {
     },
 }
 
+mod ci_otel;
 mod ci_spec;
 mod ci_timings;
 mod rerun_plan;
@@ -191,6 +206,11 @@ fn main() -> Result<()> {
         Command::ScoreboardRatchet { current, baseline } => {
             scoreboard::scoreboard_ratchet(&current, &baseline)
         }
+        Command::CiOtel {
+            since,
+            endpoint,
+            dry_run,
+        } => ci_otel::ci_otel(since, endpoint, dry_run),
     }
 }
 

--- a/k8s/ci-metrics/00-namespace-rbac.yaml
+++ b/k8s/ci-metrics/00-namespace-rbac.yaml
@@ -1,0 +1,34 @@
+# CI throughput metrics for the self-hosted pools (k8s/ci-metrics/README.md).
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ci-metrics
+---
+# The collector discovers the ARC listener and controller pods to scrape.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: otel-collector
+  namespace: ci-metrics
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ci-metrics-otel-collector
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "nodes", "endpoints", "services"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ci-metrics-otel-collector
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ci-metrics-otel-collector
+subjects:
+  - kind: ServiceAccount
+    name: otel-collector
+    namespace: ci-metrics

--- a/k8s/ci-metrics/10-otel-collector.yaml
+++ b/k8s/ci-metrics/10-otel-collector.yaml
@@ -1,0 +1,104 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otel-collector-config
+  namespace: ci-metrics
+data:
+  config.yaml: |
+    receivers:
+      # Runner side: the actions-runner-controller listeners (one per scale
+      # set) and the controller-manager expose gha_* on :8080/metrics once
+      # the controller chart has `metrics:` set (k8s/ci-runner/README.md).
+      prometheus:
+        config:
+          scrape_configs:
+            - job_name: arc
+              scrape_interval: 15s
+              kubernetes_sd_configs:
+                - role: pod
+                  namespaces:
+                    names: [arc-systems]
+              relabel_configs:
+                - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_component]
+                  regex: runner-scale-set-listener|controller-manager
+                  action: keep
+                - source_labels: [__meta_kubernetes_pod_container_port_number]
+                  regex: "8080"
+                  action: keep
+                - source_labels: [__meta_kubernetes_pod_label_actions_github_com_scale_set_name]
+                  target_label: scale_set
+                - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_component]
+                  target_label: component
+                - source_labels: [__meta_kubernetes_pod_name]
+                  target_label: pod
+      # GitHub side: `cargo xtask ci-otel` pushes OTLP/HTTP JSON here
+      # (.github/workflows/ci-metrics.yml every 15 min; also the NodePort for
+      # a backfill from the host).
+      otlp:
+        protocols:
+          http:
+            endpoint: 0.0.0.0:4318
+    processors:
+      # The xtask reports DELTA histograms/sums per window; Prometheus wants
+      # cumulative series.
+      deltatocumulative:
+        max_stale: 24h
+      batch:
+        timeout: 5s
+    exporters:
+      prometheusremotewrite:
+        endpoint: http://prometheus.ci-metrics.svc.cluster.local:9090/api/v1/write
+        resource_to_telemetry_conversion:
+          enabled: true
+        tls:
+          insecure: true
+    service:
+      pipelines:
+        metrics/arc:
+          receivers: [prometheus]
+          processors: [batch]
+          exporters: [prometheusremotewrite]
+        metrics/github:
+          receivers: [otlp]
+          processors: [deltatocumulative, batch]
+          exporters: [prometheusremotewrite]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otel-collector
+  namespace: ci-metrics
+spec:
+  replicas: 1
+  selector:
+    matchLabels: {app: otel-collector}
+  template:
+    metadata:
+      labels: {app: otel-collector}
+    spec:
+      serviceAccountName: otel-collector
+      containers:
+        - name: collector
+          image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.145.0
+          args: ["--config=/etc/otel/config.yaml"]
+          ports:
+            - {name: otlp-http, containerPort: 4318}
+          resources:
+            requests: {cpu: 50m, memory: 128Mi}
+            limits: {cpu: 500m, memory: 512Mi}
+          volumeMounts:
+            - {name: config, mountPath: /etc/otel, readOnly: true}
+      volumes:
+        - name: config
+          configMap: {name: otel-collector-config}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: otel-collector
+  namespace: ci-metrics
+spec:
+  type: NodePort
+  selector: {app: otel-collector}
+  ports:
+    - {name: otlp-http, port: 4318, targetPort: 4318, nodePort: 30318}

--- a/k8s/ci-metrics/20-prometheus.yaml
+++ b/k8s/ci-metrics/20-prometheus.yaml
@@ -1,0 +1,74 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+  namespace: ci-metrics
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 30s
+    # Everything arrives by remote write from the collector; Prometheus only
+    # scrapes itself.
+    scrape_configs:
+      - job_name: prometheus
+        static_configs:
+          - targets: ["localhost:9090"]
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: prometheus-data
+  namespace: ci-metrics
+spec:
+  accessModes: [ReadWriteOnce]
+  storageClassName: local-path
+  resources:
+    requests: {storage: 10Gi}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus
+  namespace: ci-metrics
+spec:
+  replicas: 1
+  strategy: {type: Recreate}
+  selector:
+    matchLabels: {app: prometheus}
+  template:
+    metadata:
+      labels: {app: prometheus}
+    spec:
+      securityContext: {fsGroup: 65534}
+      containers:
+        - name: prometheus
+          image: quay.io/prometheus/prometheus:v3.9.1
+          args:
+            - --config.file=/etc/prometheus/prometheus.yml
+            - --storage.tsdb.path=/prometheus
+            - --storage.tsdb.retention.time=60d
+            - --web.enable-remote-write-receiver
+          ports:
+            - {name: http, containerPort: 9090}
+          resources:
+            requests: {cpu: 100m, memory: 256Mi}
+            limits: {cpu: "1", memory: 1Gi}
+          volumeMounts:
+            - {name: config, mountPath: /etc/prometheus, readOnly: true}
+            - {name: data, mountPath: /prometheus}
+      volumes:
+        - name: config
+          configMap: {name: prometheus-config}
+        - name: data
+          persistentVolumeClaim: {claimName: prometheus-data}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+  namespace: ci-metrics
+spec:
+  type: NodePort
+  selector: {app: prometheus}
+  ports:
+    - {name: http, port: 9090, targetPort: 9090, nodePort: 30909}

--- a/k8s/ci-metrics/30-grafana.yaml
+++ b/k8s/ci-metrics/30-grafana.yaml
@@ -1,0 +1,81 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-provisioning
+  namespace: ci-metrics
+data:
+  datasource.yaml: |
+    apiVersion: 1
+    datasources:
+      - name: Prometheus
+        type: prometheus
+        uid: prometheus
+        access: proxy
+        url: http://prometheus.ci-metrics.svc.cluster.local:9090
+        isDefault: true
+  dashboards.yaml: |
+    apiVersion: 1
+    providers:
+      - name: ci
+        folder: CI
+        type: file
+        options:
+          path: /var/lib/grafana/dashboards
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+  namespace: ci-metrics
+spec:
+  replicas: 1
+  selector:
+    matchLabels: {app: grafana}
+  template:
+    metadata:
+      labels: {app: grafana}
+    spec:
+      containers:
+        - name: grafana
+          image: docker.io/grafana/grafana:12.4.0
+          env:
+            - name: GF_SECURITY_ADMIN_USER
+              value: admin
+            - name: GF_SECURITY_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef: {name: grafana-admin, key: password}
+            - {name: GF_ANALYTICS_REPORTING_ENABLED, value: "false"}
+            - {name: GF_ANALYTICS_CHECK_FOR_UPDATES, value: "false"}
+            - {name: GF_AUTH_ANONYMOUS_ENABLED, value: "true"}
+            - {name: GF_AUTH_ANONYMOUS_ORG_ROLE, value: Viewer}
+          ports:
+            - {name: http, containerPort: 3000}
+          resources:
+            requests: {cpu: 50m, memory: 128Mi}
+            limits: {cpu: 500m, memory: 512Mi}
+          volumeMounts:
+            - {name: provisioning-ds, mountPath: /etc/grafana/provisioning/datasources, readOnly: true}
+            - {name: provisioning-db, mountPath: /etc/grafana/provisioning/dashboards, readOnly: true}
+            - {name: dashboards, mountPath: /var/lib/grafana/dashboards, readOnly: true}
+      volumes:
+        - name: provisioning-ds
+          configMap:
+            name: grafana-provisioning
+            items: [{key: datasource.yaml, path: datasource.yaml}]
+        - name: provisioning-db
+          configMap:
+            name: grafana-provisioning
+            items: [{key: dashboards.yaml, path: dashboards.yaml}]
+        - name: dashboards
+          configMap: {name: grafana-dashboards}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+  namespace: ci-metrics
+spec:
+  type: NodePort
+  selector: {app: grafana}
+  ports:
+    - {name: http, port: 3000, targetPort: 3000, nodePort: 30300}

--- a/k8s/ci-metrics/README.md
+++ b/k8s/ci-metrics/README.md
@@ -1,0 +1,62 @@
+# CI throughput metrics (OpenTelemetry)
+
+Why: on 2026-09-05 a rebase wave of eight PRs took over an hour and the only
+way to know why was `kubectl get ephemeralrunners` by hand. This is the
+instrumented answer: how long jobs wait for a runner, how long they run, how
+busy each pool is, how deep the merge queue is — as time series, on one
+dashboard.
+
+## Two halves, one collector
+
+| half | source | how it gets in |
+| --- | --- | --- |
+| runner side | actions-runner-controller listeners + controller (`gha_*`: assigned/running jobs, busy/idle/desired runners, job start-up and execution histograms) | the collector's `prometheus` receiver scrapes them via pod discovery in `arc-systems`; the controller chart must have `metrics:` set (`k8s/ci-runner/README.md`) |
+| GitHub side | the Actions API: per-job `created_at` → `started_at` (queue wait) → `completed_at` (duration), conclusion, workflow, event; merge-queue depth | `cargo xtask ci-otel` pushes OTLP/HTTP JSON every 15 min from `.github/workflows/ci-metrics.yml` (self-hosted pool only: the collector is in-cluster) |
+
+Collector → Prometheus (remote write, 60-day retention on a `local-path` PVC)
+→ Grafana with the provisioned **CI throughput** dashboard.
+
+## Deploy / update (on the `pci-k3s` Lima VM)
+
+```sh
+for f in k8s/ci-metrics/*.yaml; do limactl copy "$f" "pci-k3s:/tmp/ci-metrics/$(basename "$f")"; done
+limactl copy k8s/ci-metrics/dashboards/ci-throughput.json pci-k3s:/tmp/ci-metrics/ci-throughput.json
+limactl shell pci-k3s -- sudo kubectl apply -f /tmp/ci-metrics/00-namespace-rbac.yaml
+# once: the Grafana admin password
+limactl shell pci-k3s -- sudo kubectl -n ci-metrics create secret generic grafana-admin --from-literal=password="$(openssl rand -hex 12)"
+limactl shell pci-k3s -- sudo kubectl -n ci-metrics create configmap grafana-dashboards \
+  --from-file=ci-throughput.json=/tmp/ci-metrics/ci-throughput.json --dry-run=client -o yaml \
+  | limactl shell pci-k3s -- sudo kubectl apply -f -
+limactl shell pci-k3s -- sudo kubectl apply -f /tmp/ci-metrics/10-otel-collector.yaml \
+  -f /tmp/ci-metrics/20-prometheus.yaml -f /tmp/ci-metrics/30-grafana.yaml
+```
+
+Lima forwards the NodePorts to the host:
+
+| what | URL |
+| --- | --- |
+| Grafana (anonymous Viewer; admin = the secret above) | http://localhost:30300/d/ci-throughput |
+| Prometheus | http://localhost:30909 |
+| OTLP/HTTP (for a backfill from the host) | http://localhost:30318 |
+
+## Backfill / local run
+
+```sh
+cargo xtask ci-otel --since 1440 --endpoint http://localhost:30318   # last 24 h
+cargo xtask ci-otel --since 60 --dry-run                              # print the OTLP JSON
+```
+
+The xtask reports delta histograms for its window; the collector's
+`deltatocumulative` processor makes them cumulative. Overlapping windows
+double-count at the edges, so backfill once, then let the schedule run.
+
+## Reading it
+
+- **Jobs queued for a runner** (ARC `assigned − running`) rising while
+  **busy / max** sits at 1.0 is the pool saturated; the fix is fewer or shorter
+  jobs, not (on this VM) more runners — see the sizing note in
+  `k8s/ci-runner/README.md`.
+- **Job queue wait p95 by runner pool** is the same fact from GitHub's side,
+  including hosted runners.
+- **Workflow duration p95 by event** separates pull_request (scoped) from
+  merge_group (full workspace) and push.

--- a/k8s/ci-metrics/dashboards/ci-throughput.json
+++ b/k8s/ci-metrics/dashboards/ci-throughput.json
@@ -1,0 +1,368 @@
+{
+ "uid": "ci-throughput",
+ "title": "CI throughput",
+ "tags": [
+  "ci"
+ ],
+ "timezone": "browser",
+ "schemaVersion": 39,
+ "refresh": "1m",
+ "time": {
+  "from": "now-24h",
+  "to": "now"
+ },
+ "panels": [
+  {
+   "id": 1,
+   "type": "stat",
+   "title": "Merge queue depth",
+   "gridPos": {
+    "x": 0,
+    "y": 0,
+    "w": 6,
+    "h": 5
+   },
+   "datasource": {
+    "type": "prometheus",
+    "uid": "prometheus"
+   },
+   "fieldConfig": {
+    "defaults": {
+     "unit": "short"
+    },
+    "overrides": []
+   },
+   "targets": [
+    {
+     "refId": "A",
+     "expr": "ci_merge_queue_depth",
+     "legendFormat": "__auto"
+    }
+   ],
+   "options": {
+    "reduceOptions": {
+     "calcs": [
+      "lastNotNull"
+     ]
+    }
+   }
+  },
+  {
+   "id": 2,
+   "type": "stat",
+   "title": "Workflow runs queued / in progress",
+   "gridPos": {
+    "x": 6,
+    "y": 0,
+    "w": 6,
+    "h": 5
+   },
+   "datasource": {
+    "type": "prometheus",
+    "uid": "prometheus"
+   },
+   "fieldConfig": {
+    "defaults": {
+     "unit": "short"
+    },
+    "overrides": []
+   },
+   "targets": [
+    {
+     "refId": "A",
+     "expr": "ci_runs_queued",
+     "legendFormat": "queued"
+    },
+    {
+     "refId": "B",
+     "expr": "ci_runs_in_progress",
+     "legendFormat": "in progress"
+    }
+   ],
+   "options": {
+    "reduceOptions": {
+     "calcs": [
+      "lastNotNull"
+     ]
+    }
+   }
+  },
+  {
+   "id": 3,
+   "type": "timeseries",
+   "title": "Jobs queued for a runner (ARC assigned \u2212 running)",
+   "gridPos": {
+    "x": 12,
+    "y": 0,
+    "w": 12,
+    "h": 5
+   },
+   "datasource": {
+    "type": "prometheus",
+    "uid": "prometheus"
+   },
+   "fieldConfig": {
+    "defaults": {
+     "unit": "short"
+    },
+    "overrides": []
+   },
+   "targets": [
+    {
+     "refId": "A",
+     "expr": "sum by (scale_set) (gha_assigned_jobs - gha_running_jobs)",
+     "legendFormat": "{{scale_set}}"
+    }
+   ]
+  },
+  {
+   "id": 4,
+   "type": "timeseries",
+   "title": "Runners: busy / idle / desired per pool",
+   "gridPos": {
+    "x": 0,
+    "y": 5,
+    "w": 12,
+    "h": 8
+   },
+   "datasource": {
+    "type": "prometheus",
+    "uid": "prometheus"
+   },
+   "fieldConfig": {
+    "defaults": {
+     "unit": "short"
+    },
+    "overrides": []
+   },
+   "targets": [
+    {
+     "refId": "A",
+     "expr": "sum by (scale_set) (gha_busy_runners)",
+     "legendFormat": "busy {{scale_set}}"
+    },
+    {
+     "refId": "B",
+     "expr": "sum by (scale_set) (gha_idle_runners)",
+     "legendFormat": "idle {{scale_set}}"
+    },
+    {
+     "refId": "C",
+     "expr": "sum by (scale_set) (gha_desired_runners)",
+     "legendFormat": "desired {{scale_set}}"
+    }
+   ]
+  },
+  {
+   "id": 5,
+   "type": "timeseries",
+   "title": "Job queue wait p50 / p95 by runner pool (GitHub side)",
+   "gridPos": {
+    "x": 12,
+    "y": 5,
+    "w": 12,
+    "h": 8
+   },
+   "datasource": {
+    "type": "prometheus",
+    "uid": "prometheus"
+   },
+   "fieldConfig": {
+    "defaults": {
+     "unit": "s"
+    },
+    "overrides": []
+   },
+   "targets": [
+    {
+     "refId": "A",
+     "expr": "histogram_quantile(0.5, sum by (le, runner) (rate(ci_job_queue_wait_seconds_bucket[30m])))",
+     "legendFormat": "p50 {{runner}}"
+    },
+    {
+     "refId": "B",
+     "expr": "histogram_quantile(0.95, sum by (le, runner) (rate(ci_job_queue_wait_seconds_bucket[30m])))",
+     "legendFormat": "p95 {{runner}}"
+    }
+   ]
+  },
+  {
+   "id": 6,
+   "type": "timeseries",
+   "title": "Jobs completed per hour by conclusion",
+   "gridPos": {
+    "x": 0,
+    "y": 13,
+    "w": 12,
+    "h": 8
+   },
+   "datasource": {
+    "type": "prometheus",
+    "uid": "prometheus"
+   },
+   "fieldConfig": {
+    "defaults": {
+     "unit": "short"
+    },
+    "overrides": []
+   },
+   "targets": [
+    {
+     "refId": "A",
+     "expr": "sum by (conclusion) (increase(ci_job_completed_total[1h]))",
+     "legendFormat": "{{conclusion}}"
+    }
+   ]
+  },
+  {
+   "id": 7,
+   "type": "timeseries",
+   "title": "Job duration p50 / p95 by workflow (top)",
+   "gridPos": {
+    "x": 12,
+    "y": 13,
+    "w": 12,
+    "h": 8
+   },
+   "datasource": {
+    "type": "prometheus",
+    "uid": "prometheus"
+   },
+   "fieldConfig": {
+    "defaults": {
+     "unit": "s"
+    },
+    "overrides": []
+   },
+   "targets": [
+    {
+     "refId": "A",
+     "expr": "histogram_quantile(0.5, sum by (le, workflow) (rate(ci_job_duration_seconds_bucket[1h])))",
+     "legendFormat": "p50 {{workflow}}"
+    },
+    {
+     "refId": "B",
+     "expr": "histogram_quantile(0.95, sum by (le, workflow) (rate(ci_job_duration_seconds_bucket[1h])))",
+     "legendFormat": "p95 {{workflow}}"
+    }
+   ]
+  },
+  {
+   "id": 8,
+   "type": "timeseries",
+   "title": "Pod start-up (ARC job startup) p50 / p95",
+   "gridPos": {
+    "x": 0,
+    "y": 21,
+    "w": 12,
+    "h": 8
+   },
+   "datasource": {
+    "type": "prometheus",
+    "uid": "prometheus"
+   },
+   "fieldConfig": {
+    "defaults": {
+     "unit": "s"
+    },
+    "overrides": []
+   },
+   "targets": [
+    {
+     "refId": "A",
+     "expr": "histogram_quantile(0.5, sum by (le, scale_set) (rate(gha_job_startup_duration_seconds_bucket[30m])))",
+     "legendFormat": "p50 {{scale_set}}"
+    },
+    {
+     "refId": "B",
+     "expr": "histogram_quantile(0.95, sum by (le, scale_set) (rate(gha_job_startup_duration_seconds_bucket[30m])))",
+     "legendFormat": "p95 {{scale_set}}"
+    }
+   ]
+  },
+  {
+   "id": 9,
+   "type": "timeseries",
+   "title": "Pool utilisation (busy / max)",
+   "gridPos": {
+    "x": 12,
+    "y": 21,
+    "w": 12,
+    "h": 8
+   },
+   "datasource": {
+    "type": "prometheus",
+    "uid": "prometheus"
+   },
+   "fieldConfig": {
+    "defaults": {
+     "unit": "percentunit"
+    },
+    "overrides": []
+   },
+   "targets": [
+    {
+     "refId": "A",
+     "expr": "sum by (scale_set) (gha_busy_runners) / sum by (scale_set) (gha_max_runners)",
+     "legendFormat": "{{scale_set}}"
+    }
+   ]
+  },
+  {
+   "id": 10,
+   "type": "timeseries",
+   "title": "Workflow duration p95 by event (PR vs merge group vs push)",
+   "gridPos": {
+    "x": 0,
+    "y": 29,
+    "w": 12,
+    "h": 8
+   },
+   "datasource": {
+    "type": "prometheus",
+    "uid": "prometheus"
+   },
+   "fieldConfig": {
+    "defaults": {
+     "unit": "s"
+    },
+    "overrides": []
+   },
+   "targets": [
+    {
+     "refId": "A",
+     "expr": "histogram_quantile(0.95, sum by (le, event) (rate(ci_workflow_duration_seconds_bucket[2h])))",
+     "legendFormat": "{{event}}"
+    }
+   ]
+  },
+  {
+   "id": 11,
+   "type": "timeseries",
+   "title": "Jobs completed per hour by runner pool",
+   "gridPos": {
+    "x": 12,
+    "y": 29,
+    "w": 12,
+    "h": 8
+   },
+   "datasource": {
+    "type": "prometheus",
+    "uid": "prometheus"
+   },
+   "fieldConfig": {
+    "defaults": {
+     "unit": "short"
+    },
+    "overrides": []
+   },
+   "targets": [
+    {
+     "refId": "A",
+     "expr": "sum by (runner) (increase(ci_job_completed_total[1h]))",
+     "legendFormat": "{{runner}}"
+    }
+   ]
+  }
+ ]
+}

--- a/k8s/ci-runner/README.md
+++ b/k8s/ci-runner/README.md
@@ -54,6 +54,18 @@ sudo env KUBECONFIG=/etc/rancher/k3s/k3s.yaml helm upgrade --install nucleus-k3s
   --version 0.14.2 -n arc-runners -f k8s/ci-runner/values.yaml
 ```
 
+Metrics: the controller chart is installed with `-f k8s/ci-runner/controller-values.yaml`
+(`metrics:` on `:8080/metrics` for the controller-manager and every listener);
+`k8s/ci-metrics` scrapes them. After changing it, delete the listener pods so
+they are recreated with the metrics port:
+
+```sh
+sudo env KUBECONFIG=/etc/rancher/k3s/k3s.yaml helm upgrade --install arc \
+  oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set-controller \
+  --version 0.14.2 -n arc-systems -f k8s/ci-runner/controller-values.yaml
+sudo kubectl delete pod -n arc-systems -l app.kubernetes.io/component=runner-scale-set-listener
+```
+
 Install the build pool the same way with `-f k8s/ci-runner/values-build.yaml`
 and release name `nucleus-k3s-build`.
 

--- a/k8s/ci-runner/controller-values.yaml
+++ b/k8s/ci-runner/controller-values.yaml
@@ -1,0 +1,6 @@
+# gha-runner-scale-set-controller values: expose Prometheus metrics on the
+# controller-manager and on every listener the controller creates.
+metrics:
+  controllerManagerAddr: ":8080"
+  listenerAddr: ":8080"
+  listenerEndpoint: "/metrics"


### PR DESCRIPTION
On 2026-09-05 a rebase wave took over an hour and the only way to see why was `kubectl get ephemeralrunners` by hand. This makes CI throughput a time series.

## Two halves, one collector (`k8s/ci-metrics`)

- **Runner side.** The actions-runner-controller listeners and controller now expose `gha_*` on `:8080/metrics` (`k8s/ci-runner/controller-values.yaml`, applied live). The OpenTelemetry Collector's `prometheus` receiver discovers them by pod label in `arc-systems`: assigned and running jobs, busy/idle/desired runners, job start-up and execution histograms.
- **GitHub side.** `cargo xtask ci-otel` pulls the jobs completed in a window from the Actions API and pushes OTLP/HTTP JSON, no OTel SDK, a `gh` + `curl` tool like `ci-timings`: `ci.job.queue_wait` and `ci.job.duration` histograms `{workflow, job, runner, event}`, `ci.job.completed` by conclusion, `ci.workflow.duration` by event, and gauges for merge-queue depth and queued / in-progress runs. Delta temporality; the collector's `deltatocumulative` processor makes it Prometheus-shaped. `.github/workflows/ci-metrics.yml` runs it every 15 minutes on the self-hosted pool (the collector is in-cluster); `--endpoint http://localhost:30318` backfills from the host.

Prometheus (remote-write receiver, 60-day retention on a `local-path` PVC) and Grafana (anonymous Viewer, provisioned **CI throughput** dashboard, 11 panels) are NodePorts that Lima forwards to `localhost:30909` and `localhost:30300`.

## Deployed and verified

- All three pods running; ARC scrape live (`gha_busy_runners{scale_set="nucleus-k3s-build"} = 3` at deploy time).
- 24-hour backfill from the host: 201 completed jobs, 123 series. Queue-wait p95: **832 s** on `nucleus-k3s-build`, **555 s** on `nucleus-k3s`, 5–8 s on hosted runners, 55 s on the Mac runner.
- Dashboard loads at `http://localhost:30300/d/ci-throughput`.
- `cargo clippy -p xtask -D warnings` clean; actionlint clean.

Research that shaped it: the OTel CI/CD semantic conventions and the actions-metrics-otlp / github-actions-opentelemetry actions all model a workflow as a trace with jobs as spans; for throughput a histogram of queue wait per runner pool is the number that moves, so this ships metrics first. Traces can be added later against the same collector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZaH5waz88vL1qfNpFNfZ4
