### PR TITLE
ci(dylint): the four passes run on one pod

### DIFF
--- a/.github/workflows/dylint-separation.yml
+++ b/.github/workflows/dylint-separation.yml
@@ -72,26 +72,40 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  cb4a-separation:
-    name: cb4a_separation (enforced at zero)
+  # ONE pod for all four passes (CI review, 2026-09-05). Each pass used to be
+  # its own job: four pods, four nightly installs, and — the expensive part —
+  # four separate builds of the linted crates' dependency graphs under the
+  # dylint driver, which sccache cannot front. Measured 3 min per job on the
+  # build pool, ~12 pool-minutes per PR. Here the nightly is installed once
+  # and the driver's target dir is shared, so the dependency graph compiles
+  # once. The four passes are sequential steps with their original names;
+  # none of them is a required status check, so no context is lost.
+  dylint:
+    name: Dylint passes (one pod)
     runs-on: ${{ vars.CI_BUILD_RUNNER || vars.CI_RUNNER || 'ubuntu-latest' }}
+    if: ${{ github.event.pull_request.draft != true }}
     env:
       # dylint drives rustc through its own driver; sccache cannot wrap it
       # ("could not compile proc-macro2 (build script): No such file or
       # directory" on the self-hosted runners, where RUSTC_WRAPPER is pod-wide).
       RUSTC_WRAPPER: ""
-    timeout-minutes: 45
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # The toolchain is a LOCKSTEP TRIPLE with clippy_utils and dylint_linting;
-      # rust-toolchain.toml inside the lint crate pins it. `rustc-dev` and
+      # rust-toolchain.toml inside each lint crate pins it. `rustc-dev` and
       # `llvm-tools-preview` are mandatory — without them the `extern crate
       # rustc_*` declarations do not resolve.
       - name: Install the pinned nightly
         run: |
           rustup toolchain install nightly-2026-04-16 \
             --component rustc-dev,llvm-tools-preview --profile minimal
+      - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.1
+        # Hosted only: the self-hosted scale set has persistent registry and
+        # sccache mounts, and this action's restore of a hosted x86 cache blob
+        # was observed hanging runner jobs for 15+ minutes.
+        if: ${{ runner.environment == 'github-hosted' }}
 
       # Version-pinned: the crates' manifests call the toolchain, clippy_utils rev
       # and dylint version a LOCKSTEP TRIPLE and say not to bump one in isolation.
@@ -99,6 +113,8 @@ jobs:
       - name: Install cargo-dylint
         run: command -v cargo-dylint >/dev/null && cargo dylint --version | grep -q " 6.0.1" || cargo install cargo-dylint dylint-link --version 6.0.1 --locked
 
+      # ── cb4a_separation (enforced at zero) ──────────────────────────────
+      #
       # `cd` rather than `--manifest-path`: rustup selects a toolchain from the
       # CURRENT DIRECTORY, so building from the repo root would silently use the
       # workspace's stable toolchain and fail to resolve `extern crate rustc_*`.
@@ -153,29 +169,7 @@ jobs:
             exit 1
           fi
 
-  mediated:
-    name: mediated (enforced at zero over the sealed effect boundary)
-    runs-on: ${{ vars.CI_BUILD_RUNNER || vars.CI_RUNNER || 'ubuntu-latest' }}
-    env:
-      # dylint drives rustc through its own driver; sccache cannot wrap it
-      # ("could not compile proc-macro2 (build script): No such file or
-      # directory" on the self-hosted runners, where RUSTC_WRAPPER is pod-wide).
-      RUSTC_WRAPPER: ""
-    timeout-minutes: 45
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Install the pinned nightly
-        run: |
-          rustup toolchain install nightly-2026-04-16 \
-            --component rustc-dev,llvm-tools-preview --profile minimal
-
-      # Version-pinned: the crates' manifests call the toolchain, clippy_utils rev
-      # and dylint version a LOCKSTEP TRIPLE and say not to bump one in isolation.
-      # An unpinned `cargo install` would drift the third leg silently.
-      - name: Install cargo-dylint
-        run: command -v cargo-dylint >/dev/null && cargo dylint --version | grep -q " 6.0.1" || cargo install cargo-dylint dylint-link --version 6.0.1 --locked
-
+      # ── mediated (enforced at zero over the sealed effect boundary) ─────
       - name: Build the pass
         working-directory: tools/nucleus-mediation-lint
         run: cargo build
@@ -207,31 +201,7 @@ jobs:
           DYLINT_LIBRARY_PATH: ${{ github.workspace }}/tools/nucleus-mediation-lint/target/debug
         run: scripts/check-mediation-dylint.sh
 
-  identity-isolation:
-    name: workload_identity_isolation (enforced at zero)
-    runs-on: ${{ vars.CI_BUILD_RUNNER || vars.CI_RUNNER || 'ubuntu-latest' }}
-    env:
-      # dylint drives rustc through its own driver; sccache cannot wrap it
-      # ("could not compile proc-macro2 (build script): No such file or
-      # directory" on the self-hosted runners, where RUSTC_WRAPPER is pod-wide).
-      RUSTC_WRAPPER: ""
-    timeout-minutes: 45
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Install the pinned nightly
-        run: |
-          rustup toolchain install nightly-2026-04-16 \
-            --component rustc-dev,llvm-tools-preview --profile minimal
-
-      # Version-pinned: the crates' manifests call the toolchain, clippy_utils rev
-      # and dylint version a LOCKSTEP TRIPLE and say not to bump one in isolation.
-      # An unpinned `cargo install` would drift the third leg silently.
-      - name: Install cargo-dylint
-        run: command -v cargo-dylint >/dev/null && cargo dylint --version | grep -q " 6.0.1" || cargo install cargo-dylint dylint-link --version 6.0.1 --locked
-
-      # `cd` rather than `--manifest-path`: rustup selects a toolchain from the
-      # CURRENT DIRECTORY — see the cb4a job's comment.
+      # ── workload_identity_isolation (enforced at zero) ──────────────────
       - name: Build the pass
         working-directory: tools/nucleus-identity-lint
         run: cargo build
@@ -269,34 +239,7 @@ jobs:
             exit 1
           fi
 
-  unpoliced-http-client:
-    name: unpoliced_http_client (guest egress)
-    runs-on: ${{ vars.CI_BUILD_RUNNER || vars.CI_RUNNER || 'ubuntu-latest' }}
-    env:
-      # dylint drives rustc through its own driver; sccache cannot wrap it
-      # ("could not compile proc-macro2 (build script): No such file or
-      # directory" on the self-hosted runners, where RUSTC_WRAPPER is pod-wide).
-      RUSTC_WRAPPER: ""
-    timeout-minutes: 40
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      # Same LOCKSTEP TRIPLE as the job above, and installed the same way: plain
-      # rustup, no action. Pinning the toolchain action to a commit hash
-      # would also satisfy zizmor, but the ref was doing nothing here — the
-      # toolchain is chosen by `toolchain:`, not by the action ref — so dropping
-      # the action removes the supply-chain surface instead of pinning it.
-      - name: Install the pinned nightly
-        run: |
-          rustup toolchain install nightly-2026-04-16 \
-            --component rustc-dev,llvm-tools-preview --profile minimal
-      - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2.8.1
-        # Hosted only: the self-hosted scale set has persistent registry and
-        # sccache mounts, and this action's restore of a hosted x86 cache blob
-        # was observed hanging runner jobs for 15+ minutes.
-        if: ${{ runner.environment == 'github-hosted' }}
-      - name: Install dylint
-        run: command -v cargo-dylint >/dev/null && cargo dylint --version | grep -q " 6.0.1" || cargo install cargo-dylint dylint-link --version 6.0.1 --locked
-
+      # ── unpoliced_http_client (guest egress) ────────────────────────────
       - name: Build the pass
         working-directory: tools/nucleus-egress-lint
         run: cargo build

--- a/ci/inline-gates.txt
+++ b/ci/inline-gates.txt
@@ -12,13 +12,6 @@
 # (annotations are carried forward).
 #
 # UNCOVERED_CEILING = 80
-#
-# 2026-09-06: 71 → 80. The build-once consolidation (#2635) reports each of the
-# eight consolidated steps back to its required context through a thin relay
-# step (`case $JOB/$STEP`); each relay is a new inline gate with no falsifier of
-# its own — the step it relays keeps its falsifier under its own key. The ninth
-# is kani-spawn-boundary.yml::kani-argv, an existing inline gate the inventory
-# had never listed. Shrinks again when the relays get a self-test.
 
 a2a-tck.yml::tck::Start the target on :9999 | UNCOVERED: no falsifier yet
 action-smoke-test.yml::dry-run::Dry-run: safe_pr_fixer profile | UNCOVERED: no falsifier yet
@@ -66,10 +59,10 @@ ck-policy-lean.yml::ck-policy-lean::Ban sorry / admit / native_decide / sorryAx 
 clippy-ratchet.yml::ratchet-falsifier::RED on a ceiling below actual, GREEN when restored | UNCOVERED: no falsifier yet
 coverage-matrix.yml::mutants::Check for survived mutants | UNCOVERED: no falsifier yet
 crates-publish.yml::publish::Publish in dependency order (idempotent) | UNCOVERED: no falsifier yet
-dylint-separation.yml::cb4a-separation::Run cb4a_separation over the broker crates | UNCOVERED: no falsifier yet
-dylint-separation.yml::identity-isolation::Run workload_identity_isolation over the spawn-path crate | UNCOVERED: no falsifier yet
-dylint-separation.yml::unpoliced-http-client::Prove the pass fires (positive control) | UNCOVERED: no falsifier yet
-dylint-separation.yml::unpoliced-http-client::Run unpoliced_http_client over the guest crates | UNCOVERED: no falsifier yet
+dylint-separation.yml::dylint::Run cb4a_separation over the broker crates | UNCOVERED: no falsifier yet
+dylint-separation.yml::dylint::Run workload_identity_isolation over the spawn-path crate | UNCOVERED: no falsifier yet
+dylint-separation.yml::dylint::Prove the pass fires (positive control) | UNCOVERED: no falsifier yet
+dylint-separation.yml::dylint::Run unpoliced_http_client over the guest crates | UNCOVERED: no falsifier yet
 econ-lean.yml::econ-lean::Ban sorry / native_decide in econ Lean | UNCOVERED: no falsifier yet
 econ-lean.yml::econ-lean::Golden-vector sync (regenerate Golden.lean from JSON, assert no drift) | UNCOVERED: no falsifier yet
 kani-nightly.yml::kani-ifc::All six flow.rs harnesses are still declared | UNCOVERED: no falsifier yet

--- a/ci/inline-gates.txt
+++ b/ci/inline-gates.txt
@@ -12,6 +12,13 @@
 # (annotations are carried forward).
 #
 # UNCOVERED_CEILING = 80
+#
+# 2026-09-06: 71 → 80. The build-once consolidation (#2635) reports each of the
+# eight consolidated steps back to its required context through a thin relay
+# step (`case $JOB/$STEP`); each relay is a new inline gate with no falsifier of
+# its own — the step it relays keeps its falsifier under its own key. The ninth
+# is kani-spawn-boundary.yml::kani-argv, an existing inline gate the inventory
+# had never listed. Shrinks again when the relays get a self-test.
 
 a2a-tck.yml::tck::Start the target on :9999 | UNCOVERED: no falsifier yet
 action-smoke-test.yml::dry-run::Dry-run: safe_pr_fixer profile | UNCOVERED: no falsifier yet

--- a/scripts/check-gates-can-fail.sh
+++ b/scripts/check-gates-can-fail.sh
@@ -537,7 +537,7 @@ UNCOVERED_CEILING=2
 #   check-mediation-dylint.sh — needs the pinned dylint nightly + cargo-dylint
 #     (this job runs only stable Rust). Its `--self-test` appends an unmediated
 #     raw-I/O sink to the sealed effect home and asserts the finding count goes
-#     non-zero; it runs in the `mediated` job of dylint-separation.yml, BEFORE the
+#     non-zero; it runs in the `dylint` job of dylint-separation.yml, BEFORE the
 #     enforcing run, every CI invocation.
 #   check-egress-probe.sh — is itself a falsifier, not a watcher of an external
 #     subject: it reconstructs the net::apply_default_deny fence in a netns and
@@ -563,7 +563,7 @@ UNCOVERED_CEILING=2
 #     'adversary-probe-falsifier' job of adversary-probe.yml; the perturbation is
 #     internal, so there is no external subject for this script to break.
 SELF_FALSIFIED=(
-    "check-mediation-dylint.sh    --self-test in the 'mediated' job (dylint-separation.yml)"
+    "check-mediation-dylint.sh    --self-test in the 'Dylint passes (one pod)' job (dylint-separation.yml)"
     "check-egress-probe.sh        States 2+3 in the 'egress-probe-falsifier' job (quickstart-boot.yml)"
     "check-adversary-probe.sh     BREACH+INCONCLUSIVE states in the 'adversary-probe-falsifier' job (adversary-probe.yml)"
     "check-clippy-ratchet.sh     ceiling-below-actual in the 'ratchet-falsifier' job (clippy-ratchet.yml)"


### PR DESCRIPTION
First optimization driven by the new CI metrics (k8s/ci-metrics). Over the first 24 hours each of the four Dylint jobs averaged about 3 minutes on the build pool, roughly 12 pool-minutes per PR, and they sat among the top pool-time consumers behind the workspace tests. Each pod installed the nightly and built the linted crates' dependency graph under the dylint driver separately, which is exactly the part sccache cannot front.

Now: one job, one nightly install, one shared driver target dir, and the four passes as sequential steps under their original names. None of them was a required status check, so branch protection is unchanged. Drafts skip the job. The gate-of-gates accounting entry that named the `mediated` job now names this one.

Expected: pool time per PR for Dylint drops from ~12 minutes to roughly 5 to 6; the dashboard's "pool-time by job" panel is the check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZaH5waz88vL1qfNpFNfZ4
