### PR TITLE
ci(scan): build nucleus-audit on the build pool

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -20,7 +20,10 @@ permissions:
 jobs:
   scan:
     name: Scan PodSpecs
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    # Compile-class: `cargo build -p nucleus-audit --release` before the scan.
+    # On the gate pool (0.5 CPU request, 2 CPU limit) it was 11 pool-minutes
+    # per PR — the second-largest named consumer in the CI metrics.
+    runs-on: ${{ vars.CI_BUILD_RUNNER || vars.CI_RUNNER || 'ubuntu-latest' }}
     # Required context: without a timeout the job inherits GitHub's 360-minute
     # default, which is the whole merge-queue check budget (ci-spec I7).
     timeout-minutes: 20


### PR DESCRIPTION
Metrics-driven (k8s/ci-metrics): **Scan PodSpecs** does a `cargo build -p nucleus-audit --release` before scanning and was running on the gate pool (0.5 CPU request, 2 CPU limit), where it cost 11 pool-minutes per PR — the second-largest named consumer over the last two hours. Compile-class jobs belong on the build pool; the job moves there, with the hosted fallback unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZaH5waz88vL1qfNpFNfZ4