### PR TITLE
ci(spec): the CI configuration as a typed model, and the merge-queue invariants as decision procedures (CI-1)

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -26,6 +26,9 @@ permissions:
 jobs:
   audit:
     runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    # Required context: without a timeout the job inherits GitHub's 360-minute
+    # default, which is the whole merge-queue check budget (ci-spec I7).
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2.9.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -348,6 +348,27 @@ jobs:
         shell: bash
         run: scripts/check-gates-can-fail.sh
 
+  # CI-1: the CI configuration itself is sound. A typed model of every
+  # workflow, the required-check ledger (ci/required-checks.txt) and the
+  # merge-queue pin (ci/merge-queue.toml), and the invariants the queue relies
+  # on decided over it — one producer per required context, twin lists
+  # set-equal, nothing skippable under merge_group, no fail-open gate shape,
+  # timeouts inside the queue budget, every gate wired and inventoried. Each
+  # invariant carries a fixture of the defect it was written for
+  # (crates/ci-spec/tests). Exit 2 ("could not look") is red, never green.
+  ci-spec:
+    name: CI configuration is sound (CI-1)
+    runs-on: ${{ vars.CI_BUILD_RUNNER || vars.CI_RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
+        with:
+          cache: ${{ runner.environment == 'github-hosted' }}
+      - name: Every merge-queue invariant holds over the workflow model
+        shell: bash
+        run: scripts/check-ci-spec.sh
+
   ingest-hash-gate:
     name: No-unwitnessed-ingest gate (InputsAuthorized)
     runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}

--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -27,6 +27,9 @@ permissions:
 jobs:
   deny:
     runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    # Required contexts: without a timeout the job inherits GitHub's 360-minute
+    # default, which is the whole merge-queue check budget (ci-spec I7).
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -21,6 +21,9 @@ jobs:
   scan:
     name: Scan PodSpecs
     runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    # Required context: without a timeout the job inherits GitHub's 360-minute
+    # default, which is the whole merge-queue check budget (ci-spec I7).
+    timeout-minutes: 20
     permissions:
       security-events: write
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2098,6 +2098,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ci-spec"
+version = "1.0.0"
+dependencies = [
+ "anyhow",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "toml 1.1.4+spec-1.1.0",
+]
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13892,6 +13904,7 @@ name = "xtask"
 version = "1.0.0"
 dependencies = [
  "anyhow",
+ "ci-spec",
  "ck-kernel",
  "ck-types",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ members = [
     "crates/nucleus-agent-card",         # Verify-before-you-act: signed Agent Card → TrustAnchor
     "crates/nucleus-trust-registry",     # "Let's Encrypt for agents": PR-rooted, OIDC-attested, transparency-logged SPIFFE federation enrollment
     "crates/xtask",                      # Rust-native dev/CI task runner (cargo xtask <cmd>); migrating scripts/*.sh
+    "crates/ci-spec",                   # CI configuration as a typed model + the merge-queue invariants as decision procedures
     "crates/nucleus-machine",            # MachineDriver: microVM execution-substrate abstraction (mock + Fly skeleton)
     "crates/nucleus-verify-commerce",    # Seller-side verify→serve→receipt middleware for x402/A2A (scaffold)
     "crates/nucleus-marketplace-dashboard", # Real-time verified-agent-marketplace: axum SSE orchestrator over the IFC gate (network-free core)

--- a/ci/gate-integrity-allowlist.txt
+++ b/ci/gate-integrity-allowlist.txt
@@ -1,0 +1,17 @@
+# Gate-integrity findings that are KNOWN and carry a reason, read by
+# `cargo xtask ci-spec check`. Key is `RULE <workflow>::<job>/<step>`.
+#
+# Every entry is checked for staleness: if the finding no longer fires, the
+# entry is itself a finding (CI-ALLOW-STALE) — an allowlist that outlives its
+# subject would silently allow the next real instance.
+#
+# The reasons below are the checker's known limits, not the gates' virtues.
+
+# Cross-STEP dataflow is not modelled. These `Reject sorry` greps name
+# explicit files that the preceding `lake build` step in the SAME job has just
+# compiled, so "the file is missing" cannot reach the grep; and the per-theorem
+# axiom audit (scripts/lean-axiom-audit.sh) in the same job is the
+# authoritative sorry check — this grep is the textual backstop.
+GI002 .github/workflows/aeneas-ifc-scoped.yml::aeneas-ifc-scoped/Reject sorry (proof holes) | files built by the preceding lake build step; axiom audit is authoritative
+GI002 .github/workflows/aeneas-oidc-spiffe.yml::aeneas-oidc-spiffe/Reject sorry (proof holes) | files built by the preceding lake build step; axiom audit is authoritative
+

--- a/ci/inline-gates.txt
+++ b/ci/inline-gates.txt
@@ -1,0 +1,87 @@
+# Every inline gate step (a `run:` containing `exit 1` or `::error::`) and what
+# FALSIFIES it — a `*-falsifier` job, a check-gates-can-fail.sh probe, or a
+# `--self-test` mode — or `UNCOVERED: <reason>`.
+#
+# WHY: scripts/check-gates-can-fail.sh covers scripts/check-*.sh only. Every
+# required gate the 2026-09-05 inventory found green-by-construction (the proof
+# count ratchet, the llvm-cov thresholds) was an INLINE step, outside that
+# domain. This file puts them in one. The domain is derived by ci-spec (I8):
+# an unlisted gate is red, a stale entry is red, and UNCOVERED only shrinks.
+#
+# Regenerate with `cargo xtask ci-spec inline-gates > ci/inline-gates.txt`
+# (annotations are carried forward).
+#
+# UNCOVERED_CEILING = 72
+
+a2a-tck.yml::tck::Start the target on :9999 | UNCOVERED: no falsifier yet
+action-smoke-test.yml::dry-run::Dry-run: safe_pr_fixer profile | UNCOVERED: no falsifier yet
+action-smoke-test.yml::dry-run::Dry-run: all profiles | UNCOVERED: no falsifier yet
+action-smoke-test.yml::dry-run::Dry-run: lattice invariants | UNCOVERED: no falsifier yet
+action-smoke-test.yml::dry-run::Dry-run: entrypoint script validation | UNCOVERED: no falsifier yet
+aeneas-certchain.yml::aeneas-certchain::Aeneas Lean 4 translation (scoped slice) | UNCOVERED: no falsifier yet
+aeneas-certchain.yml::aeneas-certchain::Canonicalize generated-certchain from the fresh extraction | UNCOVERED: no falsifier yet
+aeneas-certchain.yml::aeneas-certchain::Assert clean axiom set (no sorryAx / opaque axioms) | UNCOVERED: no falsifier yet
+aeneas-decide-pure.yml::aeneas-decide-pure::Aeneas Lean 4 translation (scoped slice) | UNCOVERED: no falsifier yet
+aeneas-decide-pure.yml::aeneas-decide-pure::Canonicalize generated-decide from the fresh extraction | UNCOVERED: no falsifier yet
+aeneas-ifc-scoped.yml::aeneas-ifc-scoped::Aeneas Lean 4 translation (scoped slice) | UNCOVERED: no falsifier yet
+aeneas-ifc-scoped.yml::aeneas-ifc-scoped::Canonicalize generated-ifc from the fresh extraction | UNCOVERED: no falsifier yet
+aeneas-ifc-scoped.yml::aeneas-ifc-scoped::Canonicalize generated-mediation from the fresh extraction | UNCOVERED: no falsifier yet
+aeneas-ifc-scoped.yml::aeneas-ifc-scoped::Canonicalize generated-egress from the fresh extraction | UNCOVERED: no falsifier yet
+aeneas-ifc-scoped.yml::aeneas-ifc-scoped::Canonicalize generated-credential from the fresh extraction | UNCOVERED: no falsifier yet
+aeneas-ifc-scoped.yml::aeneas-ifc-scoped::Canonicalize generated-cap-quantale from the fresh extraction | UNCOVERED: no falsifier yet
+aeneas-ifc-scoped.yml::aeneas-ifc-scoped::Canonicalize generated-identity from the fresh extraction | UNCOVERED: no falsifier yet
+aeneas-ifc-scoped.yml::aeneas-ifc-scoped::Canonicalize generated-channel from the fresh extraction | UNCOVERED: no falsifier yet
+aeneas-ifc-scoped.yml::aeneas-ifc-scoped::Canonicalize generated-declass from the fresh extraction | UNCOVERED: no falsifier yet
+aeneas-ifc-scoped.yml::aeneas-ifc-scoped::Assert clean axiom set (no sorryAx / opaque axioms) | UNCOVERED: no falsifier yet
+aeneas-ifc-scoped.yml::aeneas-ifc-scoped::Reject sorry (proof holes) | UNCOVERED: no falsifier yet
+aeneas-oidc-spiffe.yml::aeneas-oidc-spiffe::Aeneas Lean 4 translation (scoped slice) | UNCOVERED: no falsifier yet
+aeneas-oidc-spiffe.yml::aeneas-oidc-spiffe::Canonicalize generated/ from the fresh extraction | UNCOVERED: no falsifier yet
+aeneas-oidc-spiffe.yml::aeneas-oidc-spiffe::Assert clean axiom set (no sorryAx / opaque axioms) | UNCOVERED: no falsifier yet
+aeneas-oidc-spiffe.yml::aeneas-oidc-spiffe::Reject sorry (proof holes) | UNCOVERED: no falsifier yet
+aeneas.yml::aeneas-translate::Aeneas Lean 4 translation | UNCOVERED: no falsifier yet
+aeneas.yml::aeneas-translate::Verify generated Lean matches committed | UNCOVERED: no falsifier yet
+aeneas.yml::aeneas-translate::Reject sorry (proof holes) | UNCOVERED: no falsifier yet
+ck-policy-aeneas.yml::ck-policy-aeneas::Verify generated Lean matches committed (drift gate) | UNCOVERED: no falsifier yet
+ck-policy-aeneas.yml::ck-policy-aeneas::Ban sorry / admit / native_decide in our proof file | UNCOVERED: no falsifier yet
+ck-policy-lean.yml::ck-policy-lean::Ban sorry / admit / native_decide / sorryAx in ck-policy Lean | UNCOVERED: no falsifier yet
+clippy-ratchet.yml::ratchet-falsifier::RED on a ceiling below actual, GREEN when restored | UNCOVERED: no falsifier yet
+coverage-matrix.yml::mutants::Check for survived mutants | UNCOVERED: no falsifier yet
+crates-publish.yml::publish::Publish in dependency order (idempotent) | UNCOVERED: no falsifier yet
+dylint-separation.yml::cb4a-separation::Run cb4a_separation over the broker crates | UNCOVERED: no falsifier yet
+dylint-separation.yml::identity-isolation::Run workload_identity_isolation over the spawn-path crate | UNCOVERED: no falsifier yet
+dylint-separation.yml::unpoliced-http-client::Prove the pass fires (positive control) | UNCOVERED: no falsifier yet
+dylint-separation.yml::unpoliced-http-client::Run unpoliced_http_client over the guest crates | UNCOVERED: no falsifier yet
+econ-lean.yml::econ-lean::Ban sorry / native_decide in econ Lean | UNCOVERED: no falsifier yet
+econ-lean.yml::econ-lean::Golden-vector sync (regenerate Golden.lean from JSON, assert no drift) | UNCOVERED: no falsifier yet
+exemplar-scoreboard.yml::scoreboard::Ratchet against baseline (with anti-Goodhart guards) | UNCOVERED: no falsifier yet
+kani-nightly.yml::kani-ifc::All six flow.rs harnesses are still declared | UNCOVERED: no falsifier yet
+lean-build.yml::lean-build-core::Reject sorry (proof holes) | UNCOVERED: no falsifier yet
+line-ratchet.yml::ratchet-down::Ratchet down | UNCOVERED: no falsifier yet
+manifest-guards.yml::manifest-guards::Cargo metadata smoke (whole workspace parses, empty stderr) | UNCOVERED: no falsifier yet
+oidc-keyless-prototype.yml::keyless-oidc-e2e::Confirm the OIDC request env vars are present | UNCOVERED: no falsifier yet
+portcullis-core-proven-lean.yml::portcullis-core-proven-lean::Proof-hole scan (no sorry/admit outside the research manifest) | UNCOVERED: no falsifier yet
+portcullis-core-proven-lean.yml::portcullis-core-proven-lean::Per-theorem axiom audit (every declaration under every proven-tier root) | UNCOVERED: no falsifier yet
+quickstart-boot.yml::pins-resolve::Kernels must resolve and match their baked digest | UNCOVERED: no falsifier yet
+quickstart-boot.yml::pins-resolve::Release assets — missing is an error, unpublished is a notice | UNCOVERED: no falsifier yet
+quickstart-boot.yml::boot-a-real-pod-aarch64::This runner must be arm64 with KVM and vsock | UNCOVERED: no falsifier yet
+quickstart-boot.yml::boot-a-real-pod::This runner must actually have KVM | UNCOVERED: no falsifier yet
+quickstart-boot.yml::boot-a-real-pod::Build the guest rootfs | UNCOVERED: no falsifier yet
+quickstart-boot.yml::boot-a-real-pod::The in-guest posture probe actually ran (presence, not just verdict) | UNCOVERED: no falsifier yet
+quickstart-boot.yml::boot-a-real-pod::The in-guest egress backstop actually held (C6 phase 2, presence + verdict) | UNCOVERED: no falsifier yet
+quickstart-boot.yml::boot-a-real-pod::The in-guest adversary was contained (active attacker, presence + verdict) | UNCOVERED: no falsifier yet
+quickstart-boot.yml::boot-a-real-pod::A signed MediationReceipt was emitted on the live path (presence + shape) | UNCOVERED: no falsifier yet
+quickstart-boot.yml::boot-a-real-pod::A relying party verifies the pod's receipts against a node-anchored key | UNCOVERED: no falsifier yet
+quickstart-boot.yml::boot-a-real-pod::Delivery conformance (observed inventory vs the extracted oracle) | UNCOVERED: no falsifier yet
+red-team-agent.yml::live-adversary::Anti-vacuity — the lane resolved to a known state (never silent-green) | UNCOVERED: no falsifier yet
+release.yml::dry-run-assert::Every build job must have succeeded | UNCOVERED: no falsifier yet
+release.yml::dry-run-assert::A rootfs image exists for every architecture | UNCOVERED: no falsifier yet
+research-lean-build.yml::research-lean-build::Sorry ratchet (must not exceed baseline) | UNCOVERED: no falsifier yet
+rubric-lean.yml::rubric-lean::Ban sorry / admit / native_decide / sorryAx in rubric Lean | UNCOVERED: no falsifier yet
+scan.yml::scan::Scan example PodSpecs | UNCOVERED: no falsifier yet
+scan.yml::scan-action::Verify verdict | UNCOVERED: no falsifier yet
+tpm-and-net-isolation.yml::tpm-credential-activation::Assert the TPM stack is present | UNCOVERED: no falsifier yet
+tpm-and-net-isolation.yml::guest-net-isolation::Assert netns + iptables are available | UNCOVERED: no falsifier yet
+trust-registry.yml::enrollment-gate::Determine the single claimed domain | UNCOVERED: no falsifier yet
+trust-registry.yml::enrollment-gate::Request OIDC proof-of-control token | UNCOVERED: no falsifier yet
+uniform-primitive-lean.yml::uniform-primitive-lean::Reject sorry / admit (the spine must stay sorry-free) | UNCOVERED: no falsifier yet
+uniform-primitive-lean.yml::uniform-primitive-lean::Axiom ratchet (layer-bridge count = distance-to-done; may only drop) | UNCOVERED: no falsifier yet

--- a/ci/merge-queue.toml
+++ b/ci/merge-queue.toml
@@ -1,0 +1,27 @@
+# The merge-queue ruleset constants, pinned in the tree.
+#
+# These are the numbers the capacity theorem (ci/lean/CiSpec/Capacity.lean)
+# and the timeout invariant (ci-spec I7) reason about. They are ALSO live
+# settings on GitHub, editable in the UI; `cargo xtask ci-spec live-parity`
+# reports drift between this file and `GET /repos/…/rulesets/<ruleset_id>`,
+# so a UI edit is a red on the schedule rather than a silent change of the
+# theorem's hypotheses.
+#
+# History: on 2026-09-04 the check timeout was 60 minutes and build
+# concurrency 2, with pull_request runs sharing the same 4–5 build runners.
+# Entries were ejected by TIMEOUT, not by any red check, and roughly nothing
+# merged for 15 hours. The theorem's bite (CiSpecBite.lean) is that trace.
+
+ruleset_id = 22351600
+check_response_timeout_minutes = 360
+max_entries_to_build = 1
+max_entries_to_merge = 1
+min_entries_to_merge = 1
+min_entries_to_merge_wait_minutes = 0
+grouping_strategy = "ALLGREEN"
+merge_method = "SQUASH"
+
+# Classic branch protection `required_status_checks.strict`. `true` forces a
+# rebase before every merge, which with a queue means a rebase cycle; the
+# queue itself tests the merged result, which is what strict was for.
+strict = false

--- a/ci/required-checks.txt
+++ b/ci/required-checks.txt
@@ -1,0 +1,71 @@
+# The required status-check contexts on `main` — the in-repo copy of what
+# branch protection enforces, read by `cargo xtask ci-spec check`.
+#
+# Until 2026-09-05 this set lived only in GitHub's database, so nothing in
+# the tree could ask "does every required context have exactly one producer,
+# reported in the merge queue, that cannot be skipped?". Now it can.
+#
+# PINNED is the population pin and may only GROW. Removing a context is an
+# owner decision: lower the pin in the same change and record why, dated,
+# here. (The north-star ledger's two-direction convention.)
+#
+# `cargo xtask ci-spec live-parity` compares this file with the live branch
+# protection; a mismatch is a red on the schedule, never a silent re-sync.
+#
+# PINNED = 48
+
+# --- ci.yml -------------------------------------------------------------
+Detect changed crates
+Rustfmt
+Clippy
+Tests
+Fuzz
+OWASP LLM Security Gauntlet
+Ed25519 verify_strict gate (M-3)
+Sandbox trusted-base gate
+Fail-closed verifier gate
+Mediation backstop gate (North Star)
+test-helpers is not reachable from a shipping build
+Every lean_lib is type-checked by something
+Declassify sink scope is enforced
+Declassification is value-bound, single-use, and live
+Governor trusted-key set is not workload-writable
+C1 inbound fences are enforced
+The North Star status table cannot outrun its wiring
+Extracted predicates have live call sites (C8)
+The node records pod lineage on the live path (C2)
+Gates must fail on their own subject
+No-unwitnessed-ingest gate (InputsAuthorized)
+Sealed-home integrity gate (North Star)
+Policy-kernel model↔Rust parity (K4)
+musl type-check (nucleus-node, nucleus-tool-proxy)
+
+# --- coverage-matrix.yml ------------------------------------------------
+Detect Changed Crates
+Code Coverage (llvm-cov)
+Mutation Testing
+Proof Count Ratchet
+
+# --- single-producer, unfiltered ----------------------------------------
+audit
+deny (advisories)
+deny (bans)
+deny (licenses)
+deny (sources)
+cargo hack --each-feature
+MSRV floor (workspace rust-version)
+zizmor (high+ gate)
+Manifest Guards
+Scan PodSpecs
+Analyze
+
+# --- twin-paired (real + -noop) ----------------------------------------
+Scoped Aeneas (Rust → Lean 4) + parity tests
+Scoped Aeneas OIDC→SPIFFE (Rust → Lean 4) + parity tests
+lake build Ck (monotonicity-gate soundness proofs)
+charon+aeneas drift + lake build (extracted-core soundness)
+lake build Nucleus (econ proofs + golden seal)
+lake build Nucleus (rubric scoring proofs)
+version ceiling + wasm closure
+Kani
+Kani (constitutional kernel)

--- a/crates/ci-spec/Cargo.toml
+++ b/crates/ci-spec/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "ci-spec"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "Typed model of nucleus's CI configuration and the invariants the merge queue relies on — a decision procedure, not a linter"
+# Dev/CI tooling — never published.
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow = { workspace = true }
+regex = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+serde_yaml = { workspace = true }
+toml = { workspace = true }

--- a/crates/ci-spec/src/expr.rs
+++ b/crates/ci-spec/src/expr.rs
@@ -1,0 +1,446 @@
+//! A conservative evaluator for the subset of GitHub's expression language
+//! that this repository's `if:` and `cancel-in-progress:` fields use.
+//!
+//! Three-valued: an expression is [`Tri::True`], [`Tri::False`], or
+//! [`Tri::Unknown`] for the given event. Anything the grammar does not cover
+//! is an [`Undecidable`] error, which the caller reports as "could not look"
+//! (exit 2) rather than as a pass — a checker that read an unfamiliar
+//! expression as safe would be the vacuity it exists to find.
+//!
+//! Covered: `${{ }}` wrapping, `||`, `&&`, `!`, parentheses, `==`, `!=`,
+//! single-quoted strings, `true`/`false`, `github.event_name`, `github.ref`,
+//! `github.head_ref`, `always()`/`success()`/`failure()`/`cancelled()`, and
+//! any dotted path (`needs.x.outputs.y`, `vars.X`, `steps.x.outputs.y`,
+//! `runner.environment`, `inputs.x`) as an [`Tri::Unknown`] value whose
+//! reference is recorded so the caller can reason about what it depends on.
+
+use std::fmt;
+
+/// Three-valued truth.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Tri {
+    True,
+    False,
+    Unknown,
+}
+
+impl Tri {
+    fn not(self) -> Tri {
+        match self {
+            Tri::True => Tri::False,
+            Tri::False => Tri::True,
+            Tri::Unknown => Tri::Unknown,
+        }
+    }
+    fn or(self, o: Tri) -> Tri {
+        match (self, o) {
+            (Tri::True, _) | (_, Tri::True) => Tri::True,
+            (Tri::False, Tri::False) => Tri::False,
+            _ => Tri::Unknown,
+        }
+    }
+    fn and(self, o: Tri) -> Tri {
+        match (self, o) {
+            (Tri::False, _) | (_, Tri::False) => Tri::False,
+            (Tri::True, Tri::True) => Tri::True,
+            _ => Tri::Unknown,
+        }
+    }
+}
+
+/// The event the expression is evaluated under.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Event {
+    PullRequest,
+    MergeGroup,
+    Push,
+}
+
+impl Event {
+    fn name(self) -> &'static str {
+        match self {
+            Event::PullRequest => "pull_request",
+            Event::MergeGroup => "merge_group",
+            Event::Push => "push",
+        }
+    }
+    /// A representative `github.ref` for the event.
+    fn git_ref(self) -> &'static str {
+        match self {
+            Event::PullRequest => "refs/pull/1/merge",
+            Event::MergeGroup => "refs/heads/gh-readonly-queue/main/pr-1-0000000000000000",
+            Event::Push => "refs/heads/main",
+        }
+    }
+}
+
+/// The expression could not be evaluated.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Undecidable(pub String);
+
+impl fmt::Display for Undecidable {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "cannot evaluate: {}", self.0)
+    }
+}
+
+/// What an evaluation established.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Eval {
+    pub value: Tri,
+    /// `needs.<job>` ids the expression references.
+    pub needs: Vec<String>,
+    /// Other unknown paths referenced (`vars.X`, `steps.x.outputs.y`, ...).
+    pub unknowns: Vec<String>,
+    /// `always()` appears — the job runs regardless of upstream results.
+    pub always: bool,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+enum Val {
+    Str(String),
+    Bool(Tri),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+enum Tok {
+    Str(String),
+    Ident(String),
+    Or,
+    And,
+    Not,
+    Eq,
+    Ne,
+    LParen,
+    RParen,
+    Call(String),
+}
+
+fn lex(src: &str) -> Result<Vec<Tok>, Undecidable> {
+    let s = src.trim();
+    let s = s
+        .strip_prefix("${{")
+        .and_then(|r| r.strip_suffix("}}"))
+        .unwrap_or(s)
+        .trim();
+    let b: Vec<char> = s.chars().collect();
+    let mut i = 0;
+    let mut out = Vec::new();
+    while i < b.len() {
+        let c = b[i];
+        match c {
+            ' ' | '\t' | '\n' => i += 1,
+            '(' => {
+                out.push(Tok::LParen);
+                i += 1;
+            }
+            ')' => {
+                out.push(Tok::RParen);
+                i += 1;
+            }
+            '!' if b.get(i + 1) == Some(&'=') => {
+                out.push(Tok::Ne);
+                i += 2;
+            }
+            '!' => {
+                out.push(Tok::Not);
+                i += 1;
+            }
+            '=' if b.get(i + 1) == Some(&'=') => {
+                out.push(Tok::Eq);
+                i += 2;
+            }
+            '|' if b.get(i + 1) == Some(&'|') => {
+                out.push(Tok::Or);
+                i += 2;
+            }
+            '&' if b.get(i + 1) == Some(&'&') => {
+                out.push(Tok::And);
+                i += 2;
+            }
+            '\'' => {
+                let mut j = i + 1;
+                let mut lit = String::new();
+                loop {
+                    match b.get(j) {
+                        None => return Err(Undecidable(format!("unterminated string in `{s}`"))),
+                        Some('\'') if b.get(j + 1) == Some(&'\'') => {
+                            lit.push('\'');
+                            j += 2;
+                        }
+                        Some('\'') => {
+                            j += 1;
+                            break;
+                        }
+                        Some(ch) => {
+                            lit.push(*ch);
+                            j += 1;
+                        }
+                    }
+                }
+                out.push(Tok::Str(lit));
+                i = j;
+            }
+            c if c.is_ascii_alphabetic() || c == '_' => {
+                let mut j = i;
+                while j < b.len()
+                    && (b[j].is_ascii_alphanumeric() || b[j] == '_' || b[j] == '.' || b[j] == '-')
+                {
+                    j += 1;
+                }
+                let ident: String = b[i..j].iter().collect();
+                if b.get(j) == Some(&'(') {
+                    // Only nullary status functions are modelled.
+                    if b.get(j + 1) == Some(&')') {
+                        out.push(Tok::Call(ident));
+                        i = j + 2;
+                        continue;
+                    }
+                    return Err(Undecidable(format!(
+                        "function call `{ident}(...)` in `{s}`"
+                    )));
+                }
+                out.push(Tok::Ident(ident));
+                i = j;
+            }
+            other => return Err(Undecidable(format!("unexpected `{other}` in `{s}`"))),
+        }
+    }
+    Ok(out)
+}
+
+struct Parser<'a> {
+    toks: &'a [Tok],
+    pos: usize,
+    event: Event,
+    needs: Vec<String>,
+    unknowns: Vec<String>,
+    always: bool,
+}
+
+impl Parser<'_> {
+    fn peek(&self) -> Option<&Tok> {
+        self.toks.get(self.pos)
+    }
+    fn bump(&mut self) -> Option<&Tok> {
+        let t = self.toks.get(self.pos);
+        self.pos += 1;
+        t
+    }
+
+    fn or(&mut self) -> Result<Val, Undecidable> {
+        let mut l = self.and()?;
+        while self.peek() == Some(&Tok::Or) {
+            self.bump();
+            let r = self.and()?;
+            l = Val::Bool(truth(&l).or(truth(&r)));
+        }
+        Ok(l)
+    }
+    fn and(&mut self) -> Result<Val, Undecidable> {
+        let mut l = self.cmp()?;
+        while self.peek() == Some(&Tok::And) {
+            self.bump();
+            let r = self.cmp()?;
+            l = Val::Bool(truth(&l).and(truth(&r)));
+        }
+        Ok(l)
+    }
+    fn cmp(&mut self) -> Result<Val, Undecidable> {
+        let l = self.unary()?;
+        match self.peek() {
+            Some(Tok::Eq) | Some(Tok::Ne) => {
+                let ne = self.peek() == Some(&Tok::Ne);
+                self.bump();
+                let r = self.unary()?;
+                let eq = match (&l, &r) {
+                    (Val::Str(a), Val::Str(b)) => {
+                        if a == b {
+                            Tri::True
+                        } else {
+                            Tri::False
+                        }
+                    }
+                    (Val::Bool(Tri::Unknown), _) | (_, Val::Bool(Tri::Unknown)) => Tri::Unknown,
+                    (Val::Bool(a), Val::Bool(b)) => {
+                        if a == b {
+                            Tri::True
+                        } else {
+                            Tri::False
+                        }
+                    }
+                    // A string compared with a known boolean: GitHub coerces;
+                    // `'true' == true` is true. Compare textually.
+                    (Val::Str(a), Val::Bool(b)) | (Val::Bool(b), Val::Str(a)) => {
+                        let bs = match b {
+                            Tri::True => "true",
+                            Tri::False => "false",
+                            Tri::Unknown => unreachable!(),
+                        };
+                        if a == bs { Tri::True } else { Tri::False }
+                    }
+                };
+                Ok(Val::Bool(if ne { eq.not() } else { eq }))
+            }
+            _ => Ok(l),
+        }
+    }
+    fn unary(&mut self) -> Result<Val, Undecidable> {
+        if self.peek() == Some(&Tok::Not) {
+            self.bump();
+            let v = self.unary()?;
+            return Ok(Val::Bool(truth(&v).not()));
+        }
+        self.primary()
+    }
+    fn primary(&mut self) -> Result<Val, Undecidable> {
+        match self.bump().cloned() {
+            Some(Tok::LParen) => {
+                let v = self.or()?;
+                if self.bump() != Some(&Tok::RParen) {
+                    return Err(Undecidable("missing `)`".into()));
+                }
+                Ok(v)
+            }
+            Some(Tok::Str(s)) => Ok(Val::Str(s)),
+            Some(Tok::Call(f)) => match f.as_str() {
+                "always" => {
+                    self.always = true;
+                    Ok(Val::Bool(Tri::True))
+                }
+                "success" | "failure" | "cancelled" => Ok(Val::Bool(Tri::Unknown)),
+                other => Err(Undecidable(format!("function `{other}()`"))),
+            },
+            Some(Tok::Ident(id)) => Ok(self.resolve(&id)),
+            Some(t) => Err(Undecidable(format!("unexpected token {t:?}"))),
+            None => Err(Undecidable("unexpected end of expression".into())),
+        }
+    }
+    fn resolve(&mut self, id: &str) -> Val {
+        match id {
+            "true" => Val::Bool(Tri::True),
+            "false" => Val::Bool(Tri::False),
+            "github.event_name" => Val::Str(self.event.name().into()),
+            "github.ref" => Val::Str(self.event.git_ref().into()),
+            "github.head_ref" => Val::Str(
+                if self.event == Event::PullRequest {
+                    "feature-branch"
+                } else {
+                    ""
+                }
+                .into(),
+            ),
+            _ => {
+                if let Some(rest) = id.strip_prefix("needs.") {
+                    let job = rest.split('.').next().unwrap_or(rest).to_string();
+                    if !self.needs.contains(&job) {
+                        self.needs.push(job);
+                    }
+                } else if !self.unknowns.contains(&id.to_string()) {
+                    self.unknowns.push(id.to_string());
+                }
+                Val::Bool(Tri::Unknown)
+            }
+        }
+    }
+}
+
+fn truth(v: &Val) -> Tri {
+    match v {
+        Val::Bool(t) => *t,
+        // A non-empty string is truthy in GitHub's expressions.
+        Val::Str(s) => {
+            if s.is_empty() {
+                Tri::False
+            } else {
+                Tri::True
+            }
+        }
+    }
+}
+
+/// Evaluate `src` under `event`.
+pub fn eval(src: &str, event: Event) -> Result<Eval, Undecidable> {
+    let toks = lex(src)?;
+    if toks.is_empty() {
+        return Err(Undecidable("empty expression".into()));
+    }
+    let mut p = Parser {
+        toks: &toks,
+        pos: 0,
+        event,
+        needs: Vec::new(),
+        unknowns: Vec::new(),
+        always: false,
+    };
+    let v = p.or()?;
+    if p.pos != toks.len() {
+        return Err(Undecidable(format!("trailing tokens in `{src}`")));
+    }
+    Ok(Eval {
+        value: truth(&v),
+        needs: p.needs,
+        unknowns: p.unknowns,
+        always: p.always,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn event_name_comparisons_decide() {
+        let e = eval(
+            "${{ github.event_name == 'pull_request' }}",
+            Event::MergeGroup,
+        )
+        .unwrap();
+        assert_eq!(e.value, Tri::False);
+        let e = eval("github.event_name != 'schedule'", Event::MergeGroup).unwrap();
+        assert_eq!(e.value, Tri::True);
+    }
+
+    #[test]
+    fn needs_outputs_are_unknown_and_recorded() {
+        let e = eval(
+            "${{ needs.changed-crates.outputs.all == 'true' || needs.changed-crates.outputs.crates != '' }}",
+            Event::MergeGroup,
+        )
+        .unwrap();
+        assert_eq!(e.value, Tri::Unknown);
+        assert_eq!(e.needs, vec!["changed-crates".to_string()]);
+    }
+
+    #[test]
+    fn ref_inequality_is_true_under_merge_group() {
+        // The feature-matrix.yml shape: cancels a queue entry.
+        let e = eval("${{ github.ref != 'refs/heads/main' }}", Event::MergeGroup).unwrap();
+        assert_eq!(e.value, Tri::True);
+        let e = eval("${{ github.ref != 'refs/heads/main' }}", Event::Push).unwrap();
+        assert_eq!(e.value, Tri::False);
+    }
+
+    #[test]
+    fn always_is_recorded() {
+        let e = eval(
+            "${{ always() && needs.a.result == 'success' }}",
+            Event::MergeGroup,
+        )
+        .unwrap();
+        assert!(e.always);
+        assert_eq!(e.value, Tri::Unknown);
+    }
+
+    #[test]
+    fn unknown_functions_are_undecidable_not_true() {
+        assert!(eval("${{ contains(github.ref, 'x') }}", Event::Push).is_err());
+        assert!(eval("${{ hashFiles('a') }}", Event::Push).is_err());
+    }
+
+    #[test]
+    fn literal_true_and_false() {
+        assert_eq!(eval("true", Event::Push).unwrap().value, Tri::True);
+        assert_eq!(eval("false", Event::Push).unwrap().value, Tri::False);
+    }
+}

--- a/crates/ci-spec/src/invariants/concurrency.rs
+++ b/crates/ci-spec/src/invariants/concurrency.rs
@@ -1,0 +1,104 @@
+//! I4 — concurrency groups.
+//!
+//! No two workflow files resolve to the same concurrency group (after
+//! substituting `${{ github.workflow }}` with each file's `name:`), and
+//! `cancel-in-progress` is never true under `merge_group` or `push`:
+//! cancelling a merge_group run ejects the queue entry mid-flight, and
+//! cancelling a push-to-main run drops the signal for a commit that already
+//! landed.
+//!
+//! Founding defects: all ten twin pairs once shared `${{ github.workflow }}-…`
+//! and cancelled each other on every PR (#2399); `zizmor.yml` had
+//! `cancel-in-progress: true`, `feature-matrix.yml` had
+//! `github.ref != 'refs/heads/main'` — true for a queue ref.
+
+use std::collections::BTreeMap;
+
+use crate::expr::{self, Event, Tri};
+use crate::model::Model;
+use crate::{Finding, Severity};
+
+use super::finding;
+
+pub fn check(m: &Model) -> Vec<Finding> {
+    let mut out = Vec::new();
+    let mut groups: BTreeMap<String, Vec<(&str, usize)>> = BTreeMap::new();
+    for w in &m.workflows {
+        let Some(c) = &w.concurrency else { continue };
+        let resolved = c.group.replace("${{ github.workflow }}", &w.name);
+        groups
+            .entry(resolved)
+            .or_default()
+            .push((w.path.as_str(), c.line));
+
+        for ev in [Event::MergeGroup, Event::Push] {
+            let applies = match ev {
+                Event::MergeGroup => w.triggers.merge_group,
+                Event::Push => w.triggers.push.is_some(),
+                Event::PullRequest => false,
+            };
+            if !applies {
+                continue;
+            }
+            let v = c.cancel_in_progress.trim();
+            let val = match v {
+                "true" => Ok(Tri::True),
+                "false" => Ok(Tri::False),
+                other => expr::eval(other, ev).map(|e| e.value),
+            };
+            match val {
+                Ok(Tri::True) => out.push(finding(
+                    "CI-I4-CANCEL",
+                    Severity::High,
+                    &w.path,
+                    c.line,
+                    &w.name,
+                    format!(
+                        "`cancel-in-progress: {v}` is TRUE under {}: a newer run in the group \
+                         cancels this one, {}",
+                        match ev {
+                            Event::MergeGroup => "merge_group",
+                            _ => "push",
+                        },
+                        match ev {
+                            Event::MergeGroup =>
+                                "which aborts a queue entry mid-flight and ejects it",
+                            _ => "which drops the CI signal for a commit already on main",
+                        }
+                    ),
+                    "use `cancel-in-progress: ${{ github.event_name == 'pull_request' }}`",
+                )),
+                Ok(_) => {}
+                Err(e) => out.push(finding(
+                    "CI-I4-UNDECIDED",
+                    Severity::Undecided,
+                    &w.path,
+                    c.line,
+                    &w.name,
+                    format!("`cancel-in-progress` {e}"),
+                    "use the house expression",
+                )),
+            }
+        }
+    }
+    for (g, files) in groups {
+        if files.len() > 1 {
+            let names: Vec<&str> = files.iter().map(|(p, _)| *p).collect();
+            out.push(finding(
+                "CI-I4-SHARED",
+                Severity::Critical,
+                files[0].0,
+                files[0].1,
+                &g,
+                format!(
+                    "{} workflows resolve to the same concurrency group {names:?}: whichever \
+                     starts second cancels the first, and a CANCELLED check-run turns the PR \
+                     rollup red for a check that never ran",
+                    files.len()
+                ),
+                "give each file a distinct literal prefix in its group",
+            ));
+        }
+    }
+    out
+}

--- a/crates/ci-spec/src/invariants/gates.rs
+++ b/crates/ci-spec/src/invariants/gates.rs
@@ -1,0 +1,959 @@
+//! I6 — gate integrity: can each inline gate actually fail?
+//!
+//! A port of proofcard's Gate-Integrity rules (GI001–GI005, from the sibling
+//! `proof-carrying` repository, where they were tuned against 30 public
+//! repositories) plus one rule the 2026-09-05 inventory earned:
+//!
+//! | rule | severity | shape |
+//! |---|---|---|
+//! | GI001 | Critical | `V=$(cmd \|\| true)` feeding a verdict that emptiness satisfies |
+//! | GI002 | High | `if grep … ; then exit 1` with nothing establishing the searched content arrived |
+//! | GI003 | High | `cargo/lake/make … \| tee` under the default shell (no pipefail) |
+//! | GI004 | Critical/Medium | `continue-on-error` on a gate (step scope / job scope) |
+//! | GI005 | Medium | a swallowed status guarded by matching known failure text |
+//! | GI006 | Critical/High | a NUMERIC test on an operand nothing proved is a non-empty integer |
+//!
+//! GI006 is the Proof Count Ratchet's bug class, and it corrects a claim in
+//! proofcard: `[ "$V" -ne "$EXPECTED" ]` is NOT fail-closed on an empty `$V`.
+//! `[` prints "integer expression expected", returns 2, and an `if` reads 2
+//! as false — so the `then exit 1` never runs and the gate passes. Only
+//! STRING comparisons (`!=`, `=`) are fail-closed on emptiness. A numeric
+//! verdict needs its operand established first: a producer that cannot yield
+//! anything but an integer (`… | wc -l`, `grep -c` on a file, an `awk … +0`
+//! sum), or an explicit `[[ "$V" =~ ^[0-9]+$ ]] || exit 1`. Critical when the
+//! operand is arithmetic over an unestablished input or a swallowed status
+//! (the ratchet's exact shape); High when it is merely unproven (an empty
+//! pin file read with `cat`).
+//!
+//! Every rule here is heuristic and stated as such; the false-positive
+//! lessons proofcard recorded are kept: a `|| true` on a *search* is
+//! idiomatic; the guard must be about the subject it names, plus one hop of
+//! dataflow; negated greps are fail-closed; a grep for a *failure signature*
+//! is a guard, not a verdict. Known limits: cross-STEP dataflow is not
+//! modelled (a `lake build` in the previous step establishing that the files
+//! a later grep reads exist), so such findings are allowlisted with that
+//! reason rather than "fixed".
+
+use crate::model::{Model, Step};
+use crate::{Finding, Severity};
+
+use super::finding;
+
+// ── shell text ────────────────────────────────────────────────────────────
+
+/// Strip a trailing comment, respecting quotes well enough for one-liners.
+pub fn strip_comment(line: &str) -> &str {
+    let b = line.as_bytes();
+    let (mut sq, mut dq) = (false, false);
+    for i in 0..b.len() {
+        match b[i] {
+            b'\'' if !dq => sq = !sq,
+            b'"' if !sq => dq = !dq,
+            b'#' if !sq && !dq && (i == 0 || b[i - 1].is_ascii_whitespace()) => {
+                return &line[..i];
+            }
+            _ => {}
+        }
+    }
+    line
+}
+
+/// Join backslash-continued lines. Returns `(joined text, original line
+/// offset)` per logical line, so findings still point at the first physical
+/// line. `cargo llvm-cov … \` + `… | tee log` is ONE pipeline; analysing the
+/// halves separately missed exactly the fail-open the inventory found.
+fn logical_lines(script: &str) -> Vec<(String, usize)> {
+    let mut out: Vec<(String, usize)> = Vec::new();
+    let mut acc: Option<(String, usize)> = None;
+    for (i, raw) in script.lines().enumerate() {
+        let trimmed_end = raw.trim_end();
+        let continues = trimmed_end.ends_with('\\');
+        let body = if continues {
+            trimmed_end[..trimmed_end.len() - 1].to_string()
+        } else {
+            raw.to_string()
+        };
+        match acc.take() {
+            None => {
+                if continues {
+                    acc = Some((body, i));
+                } else {
+                    out.push((body, i));
+                }
+            }
+            Some((mut s, start)) => {
+                let end = s.trim_end().len();
+                s.truncate(end);
+                s.push(' ');
+                s.push_str(body.trim_start());
+                if continues {
+                    acc = Some((s, start));
+                } else {
+                    out.push((s, start));
+                }
+            }
+        }
+    }
+    if let Some(a) = acc {
+        out.push(a);
+    }
+    out
+}
+
+fn swallows_exit(s: &str) -> bool {
+    s.contains("|| true") || s.contains("|| :") || s.contains("||true") || s.contains("|| echo")
+}
+
+fn var_name(t: &str) -> Option<String> {
+    let eq = t.find('=')?;
+    let lhs = t[..eq].trim();
+    let name = lhs
+        .trim_start_matches("local ")
+        .trim_start_matches("export ")
+        .trim();
+    if name.is_empty() || !name.bytes().all(|c| c.is_ascii_alphanumeric() || c == b'_') {
+        return None;
+    }
+    Some(name.to_string())
+}
+
+fn rhs_of(t: &str) -> &str {
+    match t.find('=') {
+        Some(eq) => t[eq + 1..].trim(),
+        None => "",
+    }
+}
+
+/// `VAR="$( ... || true)"` — the variable, when the substitution swallows its status.
+fn tainted_assignment(line: &str) -> Option<String> {
+    let t = strip_comment(line).trim();
+    let name = var_name(t)?;
+    let rhs = rhs_of(t);
+    if !rhs.contains("$(") || rhs.starts_with("$((") {
+        return None;
+    }
+    if swallows_exit(rhs) && !searches_only(rhs) {
+        Some(name)
+    } else {
+        None
+    }
+}
+
+/// `VAR=$(...)` or `VAR=$((...))` — an operand of computed shape.
+fn computed_assignment(line: &str) -> Option<String> {
+    let t = strip_comment(line).trim();
+    let name = var_name(t)?;
+    if rhs_of(t).contains("$(") {
+        Some(name)
+    } else {
+        None
+    }
+}
+
+/// Is the swallowed command nothing but a search? `grep` exits non-zero to
+/// mean NO MATCH, so `|| true` restores that case under `set -e`.
+fn searches_only(rhs: &str) -> bool {
+    let body = substitution_body(rhs);
+    matches!(last_command(body), "grep" | "rg" | "egrep" | "fgrep" | "ag")
+}
+
+fn substitution_body(rhs: &str) -> &str {
+    let s = rhs
+        .trim()
+        .trim_start_matches('"')
+        .trim_end_matches('"')
+        .trim();
+    let s = s.strip_prefix("$(").unwrap_or(s);
+    let s = s.strip_suffix(')').unwrap_or(s);
+    s.trim()
+}
+
+/// The command whose status a substitution yields: the pipeline's tail, before `||`.
+fn last_command(body: &str) -> &str {
+    let mut start = 0usize;
+    let (mut sq, mut dq) = (false, false);
+    let b = body.as_bytes();
+    let mut i = 0usize;
+    while i < b.len() {
+        match b[i] {
+            b'\'' if !dq => sq = !sq,
+            b'"' if !sq => dq = !dq,
+            b'|' if !sq && !dq => {
+                if b.get(i + 1).copied() == Some(b'|') {
+                    return body[start..i].split_whitespace().next().unwrap_or("");
+                }
+                start = i + 1;
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    body[start..].split_whitespace().next().unwrap_or("")
+}
+
+/// The last pipeline stage's full text (before any `||`).
+fn last_stage(body: &str) -> &str {
+    let mut start = 0usize;
+    let (mut sq, mut dq) = (false, false);
+    let b = body.as_bytes();
+    let mut i = 0usize;
+    let mut end = b.len();
+    while i < b.len() {
+        match b[i] {
+            b'\'' if !dq => sq = !sq,
+            b'"' if !sq => dq = !dq,
+            b'|' if !sq && !dq => {
+                if b.get(i + 1).copied() == Some(b'|') {
+                    end = i;
+                    break;
+                }
+                start = i + 1;
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    body[start..end].trim()
+}
+
+fn mentions(t: &str, var: &str) -> bool {
+    t.contains(&format!("${var}")) || t.contains(&format!("${{{var}}}"))
+}
+
+const NUMERIC_OPS: [&str; 6] = ["-ne ", "-eq ", "-lt ", "-gt ", "-le ", "-ge "];
+
+/// Does a verdict on `var` pass when `var` is empty?
+///
+/// | verdict | empty input | |
+/// |---|---|---|
+/// | `if … grep -q BAD; then exit 1` | no match, no exit | fail-open |
+/// | `if [ -n "$V" ]; then exit 1` | no exit | fail-open |
+/// | `if [ "$V" -ne "$E" ]; then exit 1` | `[` errors → false → no exit | **fail-open** (GI006) |
+/// | `if [ "$V" != "$E" ]; then exit 1` | `"" != "3"` → exit | fail-closed |
+/// | `if [ -z "$V" ]; then exit 1` | exits | fail-closed |
+fn verdict_passes_on_empty(line: &str, var: &str) -> bool {
+    let t = strip_comment(line);
+    if !mentions(t, var) {
+        return false;
+    }
+    let d = t.trim_start();
+    if !(d.starts_with("if ") || d.starts_with("elif ")) {
+        return false;
+    }
+    if d.contains("-z ") {
+        return false;
+    }
+    for cmp in ["!= ", "== ", " = "] {
+        if d.contains(cmp) {
+            return false;
+        }
+    }
+    if NUMERIC_OPS.iter().any(|op| d.contains(op)) {
+        return true;
+    }
+    d.contains("grep") || d.contains("-n ")
+}
+
+/// How well an operand's source establishes it as an integer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum IntSource {
+    /// Cannot be anything but an integer (`wc -l`, `grep -c FILE`, a literal).
+    Guaranteed,
+    /// Could be empty or non-numeric (`cat pin`, `head -1`, unknown tool).
+    Unproven,
+    /// Arithmetic over an unproven input, or a swallowed status with a
+    /// non-integer shape — the ratchet's own bug.
+    Broken,
+}
+
+/// Classify the value `$(...)` / `$((...))` on the right-hand side.
+/// `self_var` is the variable being assigned, so `total=$((total + n))` reads
+/// as a self-update (its base definition is judged on its own line).
+fn int_source(
+    lines: &[(String, usize)],
+    rhs: &str,
+    depth: usize,
+    self_var: Option<&str>,
+) -> IntSource {
+    if depth > 4 {
+        return IntSource::Unproven;
+    }
+    let rhs = rhs.trim().trim_matches('"');
+    if let Some(inner) = rhs.strip_prefix("$((").and_then(|s| s.strip_suffix("))")) {
+        // Arithmetic: every identifier must itself be an integer.
+        let mut worst = IntSource::Guaranteed;
+        for tok in inner.split(|c: char| !(c.is_ascii_alphanumeric() || c == '_')) {
+            if tok.is_empty() || tok.bytes().all(|b| b.is_ascii_digit()) || Some(tok) == self_var {
+                continue;
+            }
+            let src = source_of_var(lines, tok, depth + 1);
+            worst = match (worst, src) {
+                (_, IntSource::Broken) | (IntSource::Broken, _) => IntSource::Broken,
+                (_, IntSource::Unproven) | (IntSource::Unproven, _) => IntSource::Broken,
+                _ => IntSource::Guaranteed,
+            };
+        }
+        return worst;
+    }
+    if !rhs.contains("$(") {
+        // A literal or a plain variable.
+        if rhs.bytes().all(|b| b.is_ascii_digit()) && !rhs.is_empty() {
+            return IntSource::Guaranteed;
+        }
+        if let Some(v) = rhs.strip_prefix('$') {
+            let v = v.trim_matches(|c| c == '{' || c == '}');
+            return source_of_var(lines, v, depth + 1);
+        }
+        return IntSource::Unproven;
+    }
+    let body = substitution_body(rhs);
+    let swallowed = swallows_exit(body);
+    let stage = last_stage(body);
+    let head = stage.split_whitespace().next().unwrap_or("");
+    // A recursive `grep -c` over a DIRECTORY prints `path:count` per file —
+    // not an integer — and with `|| echo 0` the shape is the ratchet's bug.
+    let first = body.split('|').next().unwrap_or("").trim();
+    let first_head = first.split_whitespace().next().unwrap_or("");
+    if matches!(first_head, "grep" | "egrep" | "fgrep")
+        && first
+            .split_whitespace()
+            .any(|a| a.starts_with('-') && a.contains('r') && a.contains('c'))
+        && first
+            .split_whitespace()
+            .last()
+            .is_some_and(|p| p.ends_with('/') || !p.contains('.'))
+        && stage == first
+    {
+        return IntSource::Broken;
+    }
+    match head {
+        "wc" => IntSource::Guaranteed,
+        "tr" | "xargs" | "sed" | "cut" => {
+            // Post-processing: inherit from the stage before.
+            let prev = body.rsplit(" | ").nth(1).unwrap_or("");
+            let ph = prev.split_whitespace().next().unwrap_or("");
+            match ph {
+                "wc" => IntSource::Guaranteed,
+                "grep"
+                    if prev
+                        .split_whitespace()
+                        .any(|a| a.starts_with('-') && a.contains('c')) =>
+                {
+                    IntSource::Guaranteed
+                }
+                "cat" => IntSource::Unproven,
+                _ => IntSource::Unproven,
+            }
+        }
+        "grep" | "egrep" | "fgrep" => {
+            if stage
+                .split_whitespace()
+                .any(|a| a.starts_with('-') && a.contains('c'))
+            {
+                IntSource::Guaranteed
+            } else if swallowed {
+                IntSource::Broken
+            } else {
+                IntSource::Unproven
+            }
+        }
+        "awk" => {
+            if stage.contains("+0") {
+                IntSource::Guaranteed
+            } else {
+                IntSource::Unproven
+            }
+        }
+        _ => {
+            if swallowed {
+                IntSource::Broken
+            } else {
+                IntSource::Unproven
+            }
+        }
+    }
+}
+
+fn source_of_var(lines: &[(String, usize)], var: &str, depth: usize) -> IntSource {
+    let mut best: Option<IntSource> = None;
+    for (l, _) in lines {
+        let t = strip_comment(l).trim();
+        if var_name(t).as_deref() != Some(var) {
+            continue;
+        }
+        let src = int_source(lines, rhs_of(t), depth, Some(var));
+        best = Some(match best {
+            None => src,
+            Some(b) => {
+                if src == IntSource::Broken || b == IntSource::Broken {
+                    IntSource::Broken
+                } else if src == IntSource::Unproven || b == IntSource::Unproven {
+                    IntSource::Unproven
+                } else {
+                    IntSource::Guaranteed
+                }
+            }
+        });
+    }
+    best.unwrap_or(IntSource::Unproven)
+}
+
+/// Does `var` get established as a non-empty integer somewhere in the block?
+fn integer_guarded(lines: &[(String, usize)], var: &str) -> bool {
+    let texts: Vec<&str> = lines.iter().map(|(l, _)| l.as_str()).collect();
+    for (i, raw) in texts.iter().enumerate() {
+        let t = strip_comment(raw);
+        if !mentions(t, var) {
+            continue;
+        }
+        let d = t.trim_start();
+        if t.contains("=~") && t.contains("[0-9]") {
+            if t.contains("|| exit") || t.contains("|| {") {
+                return true;
+            }
+            if d.starts_with("if ") && then_branch_fails(&texts, i) {
+                return true;
+            }
+        }
+        if d.starts_with("if ") && t.contains("-z ") && then_branch_fails(&texts, i) {
+            return true;
+        }
+        if t.contains("-n ") && (t.contains("|| exit") || t.contains("|| {")) {
+            return true;
+        }
+        if d.starts_with("case ") && t.contains("[!0-9]") {
+            return true;
+        }
+    }
+    false
+}
+
+/// Does the block assert that `subject` is non-empty / present, or count what
+/// it holds against a declared expectation? One hop of dataflow, including
+/// `for x in $SUBJECT`.
+fn has_emptiness_guard(lines: &[(String, usize)], subject: &str) -> bool {
+    if subject.is_empty() {
+        return false;
+    }
+    let texts: Vec<&str> = lines.iter().map(|(l, _)| l.as_str()).collect();
+    let mut derived: Vec<String> = Vec::new();
+    for raw in &texts {
+        let t = strip_comment(raw);
+        if !t.contains(subject) {
+            continue;
+        }
+        if let Some(name) = var_name(t.trim()) {
+            derived.push(format!("${name}"));
+        }
+        let d = t.trim_start();
+        if let Some(rest) = d.strip_prefix("for ") {
+            if let Some(v) = rest.split_whitespace().next() {
+                derived.push(format!("${v}"));
+            }
+        }
+    }
+    let mentions_any =
+        |t: &str| t.contains(subject) || derived.iter().any(|d| t.contains(d.as_str()));
+
+    for (i, raw) in texts.iter().enumerate() {
+        let t = strip_comment(raw);
+        let d = t.trim_start();
+        if !mentions_any(t) {
+            continue;
+        }
+        let fails_after = t.contains("|| exit") || t.contains("|| {");
+        if d.starts_with("if ") && t.contains("-z ") && then_branch_fails(&texts, i) {
+            return true;
+        }
+        if (t.contains("! -s ") || t.contains("! -f "))
+            && d.starts_with("if ")
+            && then_branch_fails(&texts, i)
+        {
+            return true;
+        }
+        if (t.contains("-s ") || t.contains("-f "))
+            && (d.starts_with("if !") && then_branch_fails(&texts, i) || fails_after)
+        {
+            return true;
+        }
+        let grepq = t.contains("grep -q") || t.contains("grep -Eq") || t.contains("grep -qE");
+        if grepq && ((d.starts_with("if !") && then_branch_fails(&texts, i)) || fails_after) {
+            return true;
+        }
+        if compares_against_an_expectation(t) {
+            return true;
+        }
+    }
+    false
+}
+
+/// A count compared against something the author declared they expected.
+/// `-ne 0` is not a guard: zero is what an empty result gives you. A string
+/// comparison against another variable (`[ "$printed" != "$extracted" ]`)
+/// counts too: it is fail-closed on emptiness and pins two measurements to
+/// each other.
+fn compares_against_an_expectation(line: &str) -> bool {
+    for op in ["!= ", " = ", "== "] {
+        let Some(rest) = line.split(op).nth(1) else {
+            continue;
+        };
+        let rhs = rest
+            .split_whitespace()
+            .next()
+            .unwrap_or("")
+            .trim_matches(|c| c == '"' || c == '\'' || c == ']');
+        if rhs.starts_with('$') && line.contains("[ ") {
+            return true;
+        }
+    }
+    for op in NUMERIC_OPS {
+        let Some(rest) = line.split(op).nth(1) else {
+            continue;
+        };
+        let rhs = rest
+            .split_whitespace()
+            .next()
+            .unwrap_or("")
+            .trim_matches(|c| c == '"' || c == '\'');
+        if rhs.starts_with('$') {
+            return true;
+        }
+        if let Ok(n) = rhs.parse::<i64>() {
+            if n != 0 {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+const FAILURE_SIGNATURES: [&str; 3] = [
+    "could not compile",
+    "Compilation failed",
+    "command not found",
+];
+
+fn failure_signature_guard(script: &str) -> bool {
+    FAILURE_SIGNATURES.iter().any(|s| script.contains(s))
+}
+
+/// Does the `then` branch opened at `idx` contain the failure? Stops at the
+/// matching `fi`, and at `else`.
+fn then_branch_fails(lines: &[&str], idx: usize) -> bool {
+    let mut depth = 0i32;
+    for l in &lines[idx..] {
+        let t = strip_comment(l);
+        let d = t.trim();
+        if d.starts_with("if ") {
+            depth += 1;
+        }
+        if d == "fi" || d.starts_with("fi ") || d.starts_with("fi;") {
+            depth -= 1;
+            if depth <= 0 {
+                return false;
+            }
+        }
+        if depth == 1 && (d == "else" || d.starts_with("else")) {
+            return false;
+        }
+        if depth >= 1 && (t.contains("exit 1") || t.contains("::error::")) {
+            return true;
+        }
+    }
+    false
+}
+
+fn is_redirection(tok: &str) -> bool {
+    tok.starts_with('>')
+        || tok.starts_with('<')
+        || tok.starts_with("2>")
+        || tok.starts_with("1>")
+        || tok.starts_with("&>")
+}
+
+/// What this verdict reads: a variable, or the last path/file handed to `grep`.
+fn verdict_subject(line: &str) -> Option<String> {
+    let body = line.trim();
+    for tok in body.split_whitespace() {
+        if let Some(p) = tok.find('$') {
+            let rest = &tok[p + 1..];
+            let name: String = rest
+                .trim_start_matches('{')
+                .chars()
+                .take_while(|c| c.is_ascii_alphanumeric() || *c == '_')
+                .collect();
+            if !name.is_empty() {
+                return Some(format!("${name}"));
+            }
+        }
+    }
+    let head = body.split("; then").next().unwrap_or(body);
+    head.split_whitespace()
+        .rfind(|t| {
+            (t.contains('/') || t.contains('.')) && !t.starts_with('-') && !is_redirection(t)
+        })
+        .map(|t| t.trim_matches('"').to_string())
+}
+
+fn searched_thing(line: &str) -> String {
+    let before = line.split("grep").next().unwrap_or("");
+    for tok in before.split_whitespace() {
+        let c = tok.trim_matches(|c: char| !c.is_ascii_alphanumeric() && c != '$' && c != '_');
+        if let Some(name) = c.strip_prefix('$') {
+            let name = name.trim_matches(|c| c == '{' || c == '}');
+            if !name.is_empty() && name.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'_') {
+                return format!("`${name}`");
+            }
+        }
+    }
+    "the searched input".to_string()
+}
+
+/// A pipeline whose left side does real work.
+fn masks_pipeline_exit(line: &str) -> Option<String> {
+    let t = strip_comment(line).trim();
+    let bar = t.find(" | ")?;
+    let lhs = t[..bar].trim();
+    for safe in [
+        "echo",
+        "printf",
+        "cat",
+        "true",
+        "yes",
+        "ls",
+        "find",
+        "git diff --name-only",
+        "git ls-files",
+    ] {
+        if lhs.starts_with(safe) {
+            return None;
+        }
+    }
+    for verb in [
+        "lake ", "cargo ", "make ", "go ", "npm ", "python", "./", "bash ", "uvx ", "lean ",
+    ] {
+        if lhs.starts_with(verb) || lhs.contains(&format!(" {verb}")) {
+            return Some(lhs.to_string());
+        }
+    }
+    None
+}
+
+/// A grep verdict line, in the non-negated fail-when-found form.
+fn positive_grep_verdict(t: &str) -> bool {
+    let d = t.trim_start();
+    if !d.starts_with("if ") || d.starts_with("if !") {
+        return false;
+    }
+    if t.contains("&& ") {
+        return false;
+    }
+    // A grep for a FAILURE SIGNATURE is a guard (GI005's subject), not a verdict.
+    if FAILURE_SIGNATURES.iter().any(|s| t.contains(s)) {
+        return false;
+    }
+    t.contains("grep -q")
+        || t.contains("grep -Eq")
+        || t.contains("grep -qE")
+        || t.contains("grep -rn")
+        || t.contains("grep -rE")
+        || t.contains("grep -rnE")
+}
+
+// ── the rule engine ───────────────────────────────────────────────────────
+
+/// Analyse one step. `job_coe` is the job's `continue-on-error` line when
+/// set at job scope.
+pub fn check_step(
+    workflow: &str,
+    job_id: &str,
+    job_coe: Option<usize>,
+    step: &Step,
+) -> Vec<Finding> {
+    let mut out = Vec::new();
+    if !step.is_gate() {
+        return out;
+    }
+    let Some(script) = step.run.as_deref() else {
+        return out;
+    };
+    let subject = format!("{job_id}/{}", step.name);
+    let job = job_id.to_string();
+
+    if step.continue_on_error {
+        out.push(
+            finding(
+                "GI004",
+                Severity::Critical,
+                workflow,
+                step.line,
+                &subject,
+                "this step fails deliberately (`exit 1` / `::error::`), but `continue-on-error` \
+                 on the step means the job passes anyway — a gate neutered inside a job that \
+                 otherwise blocks. It reports; it does not gate"
+                    .into(),
+                "remove continue-on-error, or stop calling this a gate",
+            )
+            .in_job(&job),
+        );
+    } else if let Some(l) = job_coe {
+        out.push(
+            finding(
+                "GI004",
+                Severity::Medium,
+                workflow,
+                l,
+                &format!("job `{job_id}`"),
+                format!(
+                    "job `{job_id}` is advisory: nothing it decides can fail the workflow, so \
+                     this gate's `exit 1` changes no outcome"
+                ),
+                "if the advisory period is deliberate, say so where the job is declared and \
+                 give it an end condition; otherwise make the job blocking",
+            )
+            .in_job(&job),
+        );
+    }
+
+    let lines = logical_lines(script);
+    let texts: Vec<&str> = lines.iter().map(|(l, _)| l.as_str()).collect();
+    for (i, (raw, off)) in lines.iter().enumerate() {
+        let lineno = step.line + off + 1;
+        let t = strip_comment(raw);
+
+        // GI001 / GI005 — a swallowed exit code reaching a verdict.
+        if let Some(var) = tainted_assignment(raw) {
+            // One hop UPSTREAM as well: `bad=$(printf '%s' "$flat" | grep …)`
+            // is guarded if `$flat` (or a value derived from it) was pinned
+            // against a declared expectation before `bad` was computed.
+            let upstream: Vec<String> = rhs_of(t.trim())
+                .split(|c: char| !(c.is_ascii_alphanumeric() || c == '_' || c == '$' || c == '{'))
+                .filter_map(|tok| {
+                    tok.strip_prefix('$')
+                        .map(|v| format!("${}", v.trim_start_matches('{')))
+                })
+                .filter(|v| v.len() > 1)
+                .collect();
+            let guarded = has_emptiness_guard(&lines, &format!("${var}"))
+                || upstream.iter().any(|u| has_emptiness_guard(&lines, u));
+            let reaches = texts[i + 1..]
+                .iter()
+                .any(|l| verdict_passes_on_empty(l, &var))
+                && !guarded;
+            if reaches && failure_signature_guard(script) {
+                out.push(
+                    finding(
+                        "GI005",
+                        Severity::Medium,
+                        workflow,
+                        lineno,
+                        &subject,
+                        format!(
+                            "`${var}`'s exit status is discarded, and the guard that compensates \
+                             matches known failure text; a failure printing neither signature \
+                             yields an empty `${var}`, a zero count, and a pass"
+                        ),
+                        "assert the expected result ARRIVED rather than enumerating the ways it \
+                         can fail",
+                    )
+                    .in_job(&job),
+                );
+            } else if reaches {
+                out.push(
+                    finding(
+                        "GI001",
+                        Severity::Critical,
+                        workflow,
+                        lineno,
+                        &subject,
+                        format!(
+                            "`${var}` is assigned from a command substitution whose exit status \
+                             is discarded, then used to decide whether this step passes. If that \
+                             command fails, `${var}` is empty — and the verdict is satisfied BY \
+                             emptiness, so the gate PASSES"
+                        ),
+                        "drop the `|| true` and fail explicitly on a non-zero exit; then assert \
+                         the output is what you expected, not merely that it lacks a bad string",
+                    )
+                    .in_job(&job),
+                );
+            }
+        }
+
+        // GI006 — a numeric verdict on an operand nothing established.
+        if let Some(var) = computed_assignment(raw) {
+            let verdict_at = texts[i + 1..].iter().enumerate().find(|(_, l)| {
+                let lt = strip_comment(l);
+                let d = lt.trim_start();
+                (d.starts_with("if ") || d.starts_with("elif "))
+                    && mentions(lt, &var)
+                    && NUMERIC_OPS.iter().any(|op| lt.contains(op))
+            });
+            if let Some((k, _)) = verdict_at {
+                let fails = then_branch_fails(&texts, i + 1 + k);
+                if fails && !integer_guarded(&lines, &var) {
+                    let src = int_source(&lines, rhs_of(t.trim()), 0, Some(&var));
+                    if src != IntSource::Guaranteed {
+                        let (sev, why) = match src {
+                            IntSource::Broken => (
+                                Severity::Critical,
+                                format!(
+                                    "`${var}` is arithmetic over (or a swallowed status from) a \
+                                     producer that need not yield an integer, then compared \
+                                     numerically. `[ \"\" -lt N ]` prints \"integer expression \
+                                     expected\", returns 2, and `if` reads that as false — the \
+                                     failing branch never runs and the gate PASSES on a broken \
+                                     measurement (the Proof Count Ratchet's exact shape)"
+                                ),
+                            ),
+                            _ => (
+                                Severity::High,
+                                format!(
+                                    "`${var}` is compared numerically but nothing proves it is a \
+                                     non-empty integer (an empty file read with `cat`, a `head` \
+                                     of nothing). `[ \"\" -lt N ]` errors, `if` reads that as \
+                                     false, and the gate PASSES"
+                                ),
+                            ),
+                        };
+                        out.push(
+                            finding(
+                                "GI006",
+                                sev,
+                                workflow,
+                                lineno,
+                                &subject,
+                                why,
+                                "establish the operand first: `[[ \"$V\" =~ ^[0-9]+$ ]] || { echo \
+                                 \"::error::…\"; exit 1; }`",
+                            )
+                            .in_job(&job),
+                        );
+                    }
+                }
+            }
+        }
+
+        // GI002 — a grep verdict where FINDING NOTHING is what passes.
+        if positive_grep_verdict(t) {
+            let searched = searched_thing(t);
+            let guarded = verdict_subject(t).is_some_and(|s| has_emptiness_guard(&lines, &s));
+            if !guarded && then_branch_fails(&texts, i) {
+                out.push(
+                    finding(
+                        "GI002",
+                        Severity::High,
+                        workflow,
+                        lineno,
+                        &subject,
+                        format!(
+                            "this gate fails when the pattern IS found, so finding nothing is what \
+                             makes it pass — and nothing here establishes that {searched} \
+                             contained what it should. An empty or missing producer (a renamed \
+                             file makes grep exit 2, which `if` reads as false) is \
+                             indistinguishable from a clean result"
+                        ),
+                        "assert the expected content arrived — a file-count floor, a `test -s`, \
+                         or a count against a declared expectation — before concluding from \
+                         absence",
+                    )
+                    .in_job(&job),
+                );
+            }
+        }
+
+        // GI003 — a pipeline masking the exit status that matters.
+        if !step.pipefail() {
+            if let Some(lhs) = masks_pipeline_exit(raw) {
+                out.push(
+                    finding(
+                        "GI003",
+                        Severity::High,
+                        workflow,
+                        lineno,
+                        &subject,
+                        format!(
+                            "`{lhs}` is piped, and this step runs under GitHub's DEFAULT shell \
+                             (`bash -e {{0}}`): errexit but NOT pipefail. The pipeline reports \
+                             the LAST command's status, so a failure of `{lhs}` passes"
+                        ),
+                        "add `shell: bash` to the step (GitHub then uses `-eo pipefail`), or \
+                         `set -o pipefail` in the script",
+                    )
+                    .in_job(&job),
+                );
+            }
+        }
+    }
+    out
+}
+
+pub fn check(m: &Model) -> Vec<Finding> {
+    let mut out = Vec::new();
+    for w in &m.workflows {
+        for j in &w.jobs {
+            let job_coe = if j.continue_on_error {
+                Some(j.line)
+            } else {
+                None
+            };
+            let mut seen_job_coe = false;
+            for s in &j.steps {
+                for f in check_step(&w.path, &j.id, job_coe, s) {
+                    if f.rule == "GI004" && f.severity == Severity::Medium {
+                        if seen_job_coe {
+                            continue;
+                        }
+                        seen_job_coe = true;
+                    }
+                    out.push(f);
+                }
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn logical_lines_join_continuations() {
+        let l = logical_lines("cargo x \\\n  --flag 2>&1 | tee log\necho ok");
+        assert_eq!(l.len(), 2);
+        assert_eq!(l[0].0, "cargo x --flag 2>&1 | tee log");
+        assert_eq!(l[0].1, 0);
+        assert_eq!(l[1].1, 2);
+    }
+
+    #[test]
+    fn int_sources() {
+        let lines = logical_lines(
+            "FILES=$(find x -name '*.lean' | wc -l | tr -d ' ')\n\
+             CORE=$(grep -rc '#[kani::proof]' crates/portcullis-core/src/ || echo 0)\n\
+             TOTAL=$((66 + CORE))\n\
+             PIN=$(cat .pin | tr -d '[:space:]')\n\
+             N=$(printf '%s\\n' \"$out\" | grep -c 'warning' || true)",
+        );
+        assert_eq!(source_of_var(&lines, "FILES", 0), IntSource::Guaranteed);
+        assert_eq!(source_of_var(&lines, "CORE", 0), IntSource::Broken);
+        assert_eq!(source_of_var(&lines, "TOTAL", 0), IntSource::Broken);
+        assert_eq!(source_of_var(&lines, "PIN", 0), IntSource::Unproven);
+        assert_eq!(source_of_var(&lines, "N", 0), IntSource::Guaranteed);
+    }
+
+    #[test]
+    fn verdict_subject_skips_redirections_and_flags() {
+        assert_eq!(
+            verdict_subject("if grep -q \"SURVIVED\" /tmp/mutants.txt 2>/dev/null; then")
+                .as_deref(),
+            Some("/tmp/mutants.txt")
+        );
+        assert_eq!(
+            verdict_subject("if grep -rnE 'p' --include='*.lean' crates/ck-policy/lean/Ck; then")
+                .as_deref(),
+            Some("crates/ck-policy/lean/Ck")
+        );
+    }
+}

--- a/crates/ci-spec/src/invariants/merge_group.rs
+++ b/crates/ci-spec/src/invariants/merge_group.rs
@@ -1,0 +1,151 @@
+//! I3 — every required context is reported under `merge_group`, and cannot
+//! be SKIPPED there.
+//!
+//! GitHub counts a skipped required job as passed. A required job is skipped
+//! when its `if:` is false, or when any job in its `needs:` did not succeed
+//! (unless the `if:` uses `always()`). So two obligations:
+//!
+//! 1. the real producer's workflow has `merge_group:` in `on:`, and its
+//!    job-level `if:` is not false under that event;
+//! 2. every job the producer `needs:` is itself a required context, so a red
+//!    upstream BLOCKS instead of vacating — or the producer's `if:` uses
+//!    `always()` and reads the upstream result explicitly.
+//!
+//! Founding defect: Tests, Fuzz, OWASP (ci.yml) and llvm-cov, Mutation
+//! Testing, Proof Count Ratchet (coverage-matrix.yml) all `need` a detector
+//! job (`Detect changed crates` / `Detect Changed Crates`) that was not a
+//! required context, whose `git fetch … || true` could fail the job.
+
+use crate::expr::{self, Event, Tri};
+use crate::model::Model;
+use crate::{Finding, Severity};
+
+use super::finding;
+
+pub fn check(m: &Model) -> Vec<Finding> {
+    let mut out = Vec::new();
+    for ctx in &m.ledger.contexts {
+        let producers = m.producers(ctx);
+        let reals: Vec<_> = producers
+            .iter()
+            .filter(|(wi, _)| !m.workflows[*wi].is_noop())
+            .collect();
+        if producers.is_empty() {
+            continue; // I2 reports it.
+        }
+        if reals.is_empty() {
+            out.push(finding(
+                "CI-I3-NOMG",
+                Severity::Critical,
+                &m.workflows[producers[0].0].path,
+                0,
+                ctx,
+                "only a noop twin produces this context; nothing checks it in the queue".into(),
+                "add the real workflow with a merge_group trigger",
+            ));
+            continue;
+        }
+        for (wi, ji) in reals {
+            let w = &m.workflows[*wi];
+            let j = &w.jobs[*ji];
+            if !w.triggers.merge_group {
+                out.push(finding(
+                    "CI-I3-NOMG",
+                    Severity::Critical,
+                    &w.path,
+                    j.line,
+                    ctx,
+                    "the producing workflow has no `merge_group:` trigger: the context is never \
+                     reported on the queue branch, so the entry waits until the queue timeout \
+                     ejects it (or, if the PR's own run is reused, the merged result was never \
+                     tested against main)"
+                        .into(),
+                    "add `merge_group:` to `on:`",
+                ));
+            }
+            if let Some(cond) = &j.if_expr {
+                match expr::eval(cond, Event::MergeGroup) {
+                    Err(e) => out.push(finding(
+                        "CI-I3-UNDECIDED",
+                        Severity::Undecided,
+                        &w.path,
+                        j.line,
+                        ctx,
+                        format!(
+                            "job `if:` {e} — the checker cannot tell whether this required \
+                                 job can be skipped in the queue"
+                        ),
+                        "simplify the condition to the modelled subset, or extend ci-spec::expr",
+                    )),
+                    Ok(ev) => {
+                        if ev.value == Tri::False {
+                            out.push(finding(
+                                "CI-I3-SKIP",
+                                Severity::Critical,
+                                &w.path,
+                                j.line,
+                                ctx,
+                                format!(
+                                    "job `if: {cond}` is FALSE under merge_group: the required \
+                                     job is skipped in the queue, and skipped counts as passed"
+                                ),
+                                "make the job unconditional under merge_group",
+                            ));
+                        }
+                        // `needs` referenced in the condition are covered by
+                        // the needs check below; `always()` is what exempts.
+                        if !ev.always {
+                            for n in &j.needs {
+                                needs_check(m, w, j, ctx, n, &mut out);
+                            }
+                        }
+                    }
+                }
+            } else {
+                for n in &j.needs {
+                    needs_check(m, w, j, ctx, n, &mut out);
+                }
+            }
+        }
+    }
+    out
+}
+
+fn needs_check(
+    m: &Model,
+    w: &crate::model::Workflow,
+    j: &crate::model::Job,
+    ctx: &str,
+    needed_id: &str,
+    out: &mut Vec<Finding>,
+) {
+    let Some(up) = w.jobs.iter().find(|x| x.id == needed_id) else {
+        out.push(finding(
+            "CI-I3-NEEDS",
+            Severity::Critical,
+            &w.path,
+            j.line,
+            ctx,
+            format!("`needs: {needed_id}` names a job that does not exist in this workflow"),
+            "fix the job id",
+        ));
+        return;
+    };
+    if !m.is_required(up.display_name()) {
+        out.push(finding(
+            "CI-I3-NEEDS",
+            Severity::Critical,
+            &w.path,
+            j.line,
+            ctx,
+            format!(
+                "required job `needs: {needed_id}` (`{}`), which is NOT a required context. If \
+                 that job fails or is cancelled this one is SKIPPED, and a skipped required \
+                 check counts as passed: a red upstream vacates the gate instead of blocking",
+                up.display_name()
+            ),
+            "add the upstream job's name to branch protection and ci/required-checks.txt, or \
+             use `if: always()` and assert the upstream result explicitly",
+        ));
+    }
+}

--- a/crates/ci-spec/src/invariants/mod.rs
+++ b/crates/ci-spec/src/invariants/mod.rs
@@ -1,0 +1,37 @@
+//! The invariants, one module each. Every module's doc comment names the
+//! founding defect it was written for; `tests/founding_defects.rs` carries a
+//! fixture reproducing each and asserts the rule fires on it and is silent
+//! on the repaired shape.
+
+pub mod concurrency;
+pub mod gates;
+pub mod merge_group;
+pub mod producers;
+pub mod scope;
+pub mod timeouts;
+pub mod twins;
+pub mod vacuity;
+pub mod wired;
+
+use crate::{Finding, Severity};
+
+pub(crate) fn finding(
+    rule: &'static str,
+    severity: Severity,
+    file: &str,
+    line: usize,
+    subject: &str,
+    why: String,
+    fix: &str,
+) -> Finding {
+    Finding {
+        rule,
+        severity,
+        file: file.to_string(),
+        line,
+        subject: subject.to_string(),
+        why,
+        fix: fix.to_string(),
+        job: String::new(),
+    }
+}

--- a/crates/ci-spec/src/invariants/producers.rs
+++ b/crates/ci-spec/src/invariants/producers.rs
@@ -1,0 +1,88 @@
+//! I2 — producer injectivity.
+//!
+//! Each required context is produced by exactly one twin pair. GitHub matches
+//! required checks by name; two jobs in different workflows with the same
+//! `name:` produce two same-named check runs, and the rollup takes whichever
+//! it takes — one gate's result can stand in for the other's.
+//!
+//! Founding defect: `Scoped Aeneas (Rust → Lean 4) + parity tests` was
+//! produced by four jobs — the IFC pair and the OIDC→SPIFFE pair (verified
+//! live on PR #2641: two check runs with that exact name).
+
+use std::collections::BTreeSet;
+
+use crate::model::Model;
+use crate::{Finding, Severity};
+
+use super::finding;
+
+pub fn check(m: &Model) -> Vec<Finding> {
+    let mut out = Vec::new();
+    for ctx in &m.ledger.contexts {
+        let producers = m.producers(ctx);
+        if producers.is_empty() {
+            out.push(finding(
+                "CI-I2-NONE",
+                Severity::Critical,
+                "ci/required-checks.txt",
+                0,
+                ctx,
+                "required context has no producing job in any workflow: every PR waits on it \
+                 forever (or, if branch protection was edited to match, the ledger is stale)"
+                    .into(),
+                "add the producing job, or remove the context from branch protection AND the \
+                 ledger (an owner decision, recorded)",
+            ));
+            continue;
+        }
+        let pairs: BTreeSet<String> = producers
+            .iter()
+            .map(|(wi, _)| m.workflows[*wi].pair_key())
+            .collect();
+        if pairs.len() > 1 {
+            let where_: Vec<String> = producers
+                .iter()
+                .map(|(wi, ji)| {
+                    format!(
+                        "{}:{}",
+                        m.workflows[*wi].path, m.workflows[*wi].jobs[*ji].id
+                    )
+                })
+                .collect();
+            out.push(finding(
+                "CI-I2-DUP",
+                Severity::Critical,
+                &m.workflows[producers[0].0].path,
+                m.workflows[producers[0].0].jobs[producers[0].1].line,
+                ctx,
+                format!(
+                    "produced by {} jobs across {} twin pairs ({where_:?}): same-named check runs, \
+                     so either gate's verdict can stand in for the other's",
+                    producers.len(),
+                    pairs.len()
+                ),
+                "give each pair a distinct job `name:` and register both contexts",
+            ));
+        }
+        // Within one pair, more than two producers (e.g. a matrix without a
+        // per-leg name) is also ambiguous.
+        for pair in &pairs {
+            let n = producers
+                .iter()
+                .filter(|(wi, _)| m.workflows[*wi].pair_key() == *pair)
+                .count();
+            if n > 2 {
+                out.push(finding(
+                    "CI-I2-DUP",
+                    Severity::High,
+                    &m.workflows[producers[0].0].path,
+                    0,
+                    ctx,
+                    format!("{n} jobs in pair `{pair}` share this name"),
+                    "one job per context per twin",
+                ));
+            }
+        }
+    }
+    out
+}

--- a/crates/ci-spec/src/invariants/scope.rs
+++ b/crates/ci-spec/src/invariants/scope.rs
@@ -1,0 +1,97 @@
+//! I5 — merge-group scope gates agree with their declared paths.
+//!
+//! `paths:` under `merge_group:` parses and is then ignored by GitHub, so a
+//! path-filtered workflow re-implements its scope as a regex in a step with
+//! `id: scope` and `env.PATTERN`. Two copies of one fact drift: widen
+//! `paths:` and forget the regex, and the queue silently stops running a
+//! proof the PR still runs (#2358). Every declared path prefix must be
+//! matched by PATTERN, and there must be at least one declared path — a gate
+//! whose paths cannot be read is vacuous here.
+//!
+//! This is the second, independent declaration of what
+//! `ci/merge-group-scope-parity.sh` checks; the shell script stays.
+
+use crate::model::Model;
+use crate::{Finding, Severity};
+
+use super::finding;
+
+pub fn check(m: &Model) -> Vec<Finding> {
+    let mut out = Vec::new();
+    for w in &m.workflows {
+        for j in &w.jobs {
+            for s in &j.steps {
+                if s.id.as_deref() != Some("scope") {
+                    continue;
+                }
+                let Some(pattern) = s.env.get("PATTERN") else {
+                    out.push(finding(
+                        "CI-I5-NOPATTERN",
+                        Severity::Critical,
+                        &w.path,
+                        s.line,
+                        &j.id,
+                        "`id: scope` step with no `env.PATTERN`".into(),
+                        "declare PATTERN derived from the pull_request paths",
+                    ));
+                    continue;
+                };
+                let re = match regex::Regex::new(pattern) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        out.push(finding(
+                            "CI-I5-REGEX",
+                            Severity::Critical,
+                            &w.path,
+                            s.line,
+                            &j.id,
+                            format!("PATTERN does not compile: {e}"),
+                            "fix the regex",
+                        ));
+                        continue;
+                    }
+                };
+                let paths: Vec<&str> = w
+                    .triggers
+                    .pull_request
+                    .as_ref()
+                    .map(|p| p.paths.iter().map(String::as_str).collect())
+                    .unwrap_or_default();
+                if paths.is_empty() {
+                    out.push(finding(
+                        "CI-I5-VACUOUS",
+                        Severity::Critical,
+                        &w.path,
+                        s.line,
+                        &j.id,
+                        "scope-gated workflow declares no pull_request paths — the parity check \
+                         has nothing to compare and the gate is vacuous"
+                            .into(),
+                        "declare the paths, or remove the scope gate",
+                    ));
+                }
+                for p in paths {
+                    let probe = p.split('*').next().unwrap_or(p);
+                    if probe.is_empty() {
+                        continue;
+                    }
+                    if !re.is_match(probe) {
+                        out.push(finding(
+                            "CI-I5-PARITY",
+                            Severity::Critical,
+                            &w.path,
+                            s.line,
+                            &j.id,
+                            format!(
+                                "declared path {p:?} is not matched by PATTERN {pattern:?}: a \
+                                 change there runs the proof on the PR but NOT in the merge queue"
+                            ),
+                            "extend PATTERN to cover every declared path",
+                        ));
+                    }
+                }
+            }
+        }
+    }
+    out
+}

--- a/crates/ci-spec/src/invariants/timeouts.rs
+++ b/crates/ci-spec/src/invariants/timeouts.rs
@@ -1,0 +1,100 @@
+//! I7 — timeouts fit the queue.
+//!
+//! The merge queue waits `check_response_timeout_minutes` for every required
+//! check on a group, then assumes failure and ejects the entry. A job that
+//! can legitimately run longer than that — or a `needs:` chain whose
+//! timeouts sum past it — is an ejection waiting for a slow day. A job with
+//! no `timeout-minutes` gets GitHub's default of 360, which is the whole
+//! budget on its own.
+//!
+//! Founding defect: the 2026-09-04/05 stall — the queue timeout was 60 min
+//! while Mutation Testing ran 30–45 min after a queue wait, and entries were
+//! ejected by timeout rather than by any red check.
+
+use std::collections::BTreeMap;
+
+use crate::model::Model;
+use crate::{Finding, Severity};
+
+use super::finding;
+
+pub fn check(m: &Model) -> Vec<Finding> {
+    let mut out = Vec::new();
+    let budget = m.queue.check_response_timeout_minutes;
+    for w in m.workflows.iter().filter(|w| w.triggers.merge_group) {
+        let by_id: BTreeMap<&str, &crate::model::Job> =
+            w.jobs.iter().map(|j| (j.id.as_str(), j)).collect();
+        for j in &w.jobs {
+            let Some(t) = j.timeout_minutes else {
+                out.push(
+                    finding(
+                        "CI-I7-NOTIMEOUT",
+                        Severity::Medium,
+                        &w.path,
+                        j.line,
+                        j.display_name(),
+                        format!(
+                            "no `timeout-minutes`; GitHub's default is 360, which equals the \
+                             queue's {budget}-minute check budget, so a hung job ejects the entry"
+                        ),
+                        "declare a timeout below the queue budget",
+                    )
+                    .in_job(&j.id),
+                );
+                continue;
+            };
+            if t > budget {
+                out.push(
+                    finding(
+                        "CI-I7-EXCEEDS",
+                        Severity::High,
+                        &w.path,
+                        j.line,
+                        j.display_name(),
+                        format!(
+                            "timeout-minutes {t} > queue check budget {budget}: a slow run is \
+                             ejected by the queue before the job's own timeout fires"
+                        ),
+                        "lower the timeout or raise the ruleset budget (ci/merge-queue.toml)",
+                    )
+                    .in_job(&j.id),
+                );
+            }
+            // Critical path through needs.
+            let path = critical_path(&by_id, &j.id, 0);
+            if path > budget {
+                out.push(
+                    finding(
+                        "CI-I7-PATH",
+                        Severity::High,
+                        &w.path,
+                        j.line,
+                        j.display_name(),
+                        format!(
+                            "the `needs:` chain ending here can take {path} min of timeouts, over \
+                             the queue's {budget}-minute budget"
+                        ),
+                        "shorten the chain or its timeouts",
+                    )
+                    .in_job(&j.id),
+                );
+            }
+        }
+    }
+    out
+}
+
+fn critical_path(by_id: &BTreeMap<&str, &crate::model::Job>, id: &str, depth: usize) -> u64 {
+    if depth > 32 {
+        return 0; // cyclic; actionlint rejects those anyway
+    }
+    let Some(j) = by_id.get(id) else { return 0 };
+    let own = j.timeout_minutes.unwrap_or(360);
+    let up = j
+        .needs
+        .iter()
+        .map(|n| critical_path(by_id, n, depth + 1))
+        .max()
+        .unwrap_or(0);
+    own + up
+}

--- a/crates/ci-spec/src/invariants/twins.rs
+++ b/crates/ci-spec/src/invariants/twins.rs
@@ -1,0 +1,179 @@
+//! I1 — twin completeness.
+//!
+//! A path-filtered workflow `X.yml` that produces a required context is
+//! paired with `X-noop.yml`: same workflow `name:`, same job names, and a
+//! `paths-ignore` that is EXACTLY the real twin's `paths`, so that on every
+//! pull request exactly one of the two reports the context. The complement
+//! lemma (`ci/lean/CiSpec/Pipeline.lean`, T2) needs set equality; anything
+//! else fires both twins or neither.
+//!
+//! Founding defects: `aeneas-ifc-scoped-noop.yml` ignored a 24-file strict
+//! subset of the real twin's two globs (both twins fired on
+//! `nucleus-ifc-kernel/src/lib.rs`); `aeneas-oidc-spiffe-noop.yml` was
+//! missing one file; `kani-nightly-noop.yml`'s header records the same scar.
+
+use std::collections::BTreeSet;
+
+use crate::model::Model;
+use crate::{Finding, Severity};
+
+use super::finding;
+
+pub fn check(m: &Model) -> Vec<Finding> {
+    let mut out = Vec::new();
+    for noop in m.workflows.iter().filter(|w| w.is_noop()) {
+        let key = noop.pair_key();
+        let Some(real) = m
+            .workflows
+            .iter()
+            .find(|w| !w.is_noop() && w.pair_key() == key)
+        else {
+            out.push(finding(
+                "CI-I1-ORPHAN",
+                Severity::Critical,
+                &noop.path,
+                0,
+                &key,
+                "a `-noop` twin with no real twin: the context it reports is never actually \
+                 checked"
+                    .into(),
+                "delete the twin or restore the real workflow",
+            ));
+            continue;
+        };
+
+        // The real twin must be path-filtered on pull_request (otherwise the
+        // pair fires both on every PR) and the noop must use paths-ignore.
+        let real_paths: BTreeSet<&str> = real
+            .triggers
+            .pull_request
+            .as_ref()
+            .map(|p| p.paths.iter().map(String::as_str).collect())
+            .unwrap_or_default();
+        let noop_ignore: BTreeSet<&str> = noop
+            .triggers
+            .pull_request
+            .as_ref()
+            .map(|p| p.paths_ignore.iter().map(String::as_str).collect())
+            .unwrap_or_default();
+
+        if real_paths.is_empty() {
+            out.push(finding(
+                "CI-I1-UNFILTERED",
+                Severity::Critical,
+                &real.path,
+                0,
+                &key,
+                "the real twin has no `pull_request.paths` filter, so both twins fire on every \
+                 PR and the context is reported twice"
+                    .into(),
+                "filter the real twin, or delete the noop",
+            ));
+        }
+        if real_paths != noop_ignore {
+            let missing: Vec<&&str> = real_paths.difference(&noop_ignore).collect();
+            let extra: Vec<&&str> = noop_ignore.difference(&real_paths).collect();
+            out.push(finding(
+                "CI-I1-PATHS",
+                Severity::Critical,
+                &noop.path,
+                0,
+                &key,
+                format!(
+                    "`paths-ignore` ≠ real twin's `paths`. Missing from the noop: {missing:?}; \
+                     extra in the noop: {extra:?}. A change matching a missing entry fires BOTH \
+                     twins under one context name; an extra entry can leave a change with \
+                     NEITHER"
+                ),
+                "make the noop's paths-ignore the real twin's paths, verbatim",
+            ));
+        }
+        if noop.name != real.name {
+            out.push(finding(
+                "CI-I1-NAME",
+                Severity::High,
+                &noop.path,
+                0,
+                &key,
+                format!(
+                    "workflow name {:?} ≠ real twin's {:?}; the checks UI and `github.workflow` \
+                     treat them as different workflows",
+                    noop.name, real.name
+                ),
+                "give both twins the same `name:`",
+            ));
+        }
+        let real_jobs: BTreeSet<String> = real.jobs.iter().flat_map(|j| j.contexts()).collect();
+        let noop_jobs: BTreeSet<String> = noop.jobs.iter().flat_map(|j| j.contexts()).collect();
+        // Every noop job must exist in the real twin; the real twin may have
+        // extra (non-required) jobs, but every REQUIRED job of the real twin
+        // must be mirrored, or a PR outside the paths never reports it.
+        for j in noop_jobs.difference(&real_jobs) {
+            out.push(finding(
+                "CI-I1-JOBS",
+                Severity::High,
+                &noop.path,
+                0,
+                j,
+                "noop job with no counterpart in the real twin: a context that is only ever \
+                 vacuously green"
+                    .into(),
+                "mirror the real twin's job names exactly",
+            ));
+        }
+        for j in real_jobs.difference(&noop_jobs) {
+            if m.is_required(j) {
+                out.push(finding(
+                    "CI-I1-JOBS",
+                    Severity::Critical,
+                    &noop.path,
+                    0,
+                    j,
+                    "required context produced by the real twin has no noop mirror: a PR \
+                     outside the paths never reports it and blocks forever"
+                        .into(),
+                    "add the job to the noop twin with the same `name:`",
+                ));
+            }
+        }
+        if let (Some(a), Some(b)) = (&real.concurrency, &noop.concurrency) {
+            if a.group == b.group {
+                out.push(finding(
+                    "CI-I1-GROUP",
+                    Severity::Critical,
+                    &noop.path,
+                    b.line,
+                    &key,
+                    "twins share a concurrency group: when both fire (a PR touching a filtered \
+                     and an unfiltered path) whichever starts second cancels the first, and a \
+                     CANCELLED check-run makes the PR rollup FAILURE (#2399)"
+                        .into(),
+                    "give the twins distinct literal group prefixes",
+                ));
+            }
+        }
+        if noop.triggers.merge_group {
+            // Critical only when a REQUIRED context would get the vacuous
+            // green; a non-required twin that covers the queue on purpose
+            // (quickstart-boot, whose real job needs KVM the queue lacks)
+            // is reported, not failed.
+            let required = noop_jobs.iter().any(|j| m.is_required(j));
+            out.push(finding(
+                "CI-I1-NOOP-MG",
+                if required {
+                    Severity::Critical
+                } else {
+                    Severity::Info
+                },
+                &noop.path,
+                0,
+                &key,
+                "the noop twin runs on merge_group: the queue gets a vacuous green for the \
+                 context alongside (or instead of) the real check"
+                    .into(),
+                "trigger the noop on pull_request only; the real twin runs unfiltered in the queue",
+            ));
+        }
+    }
+    out
+}

--- a/crates/ci-spec/src/invariants/vacuity.rs
+++ b/crates/ci-spec/src/invariants/vacuity.rs
@@ -1,0 +1,84 @@
+//! I9 — the model itself is non-vacuous.
+//!
+//! A checker over an empty domain reports "every invariant holds" having
+//! examined nothing. Founding defect: `check-lean-libs-built.sh`'s first
+//! version used `declare -A` under bash 3.2, errored per library, and still
+//! exited 0 — "a false green in the gate written to find false greens".
+
+use crate::model::Model;
+use crate::{Finding, Severity};
+
+use super::finding;
+
+pub fn check(m: &Model) -> Vec<Finding> {
+    let mut out = Vec::new();
+    if m.workflows.len() < 2 {
+        out.push(finding(
+            "CI-I9-WORKFLOWS",
+            Severity::Undecided,
+            ".github/workflows",
+            0,
+            "workflow set",
+            format!(
+                "{} workflow(s) parsed — the domain is wrong, so nothing below examined anything",
+                m.workflows.len()
+            ),
+            "point the checker at a repository with its workflows",
+        ));
+    }
+    if m.ledger.contexts.len() < 2 {
+        out.push(finding(
+            "CI-I9-LEDGER",
+            Severity::Undecided,
+            "ci/required-checks.txt",
+            0,
+            "required-check ledger",
+            format!(
+                "{} required context(s) parsed — an empty ledger makes every producer check vacuous",
+                m.ledger.contexts.len()
+            ),
+            "populate ci/required-checks.txt from branch protection",
+        ));
+    }
+    match m.ledger.pinned {
+        None => out.push(finding(
+            "CI-I9-PIN",
+            Severity::Undecided,
+            "ci/required-checks.txt",
+            0,
+            "population pin",
+            "no `# PINNED = N` header — a deletable population rewards deleting rows".into(),
+            "add `# PINNED = <count>`; it may only grow",
+        )),
+        Some(p) if p != m.ledger.contexts.len() => out.push(finding(
+            "CI-I9-PIN",
+            Severity::Critical,
+            "ci/required-checks.txt",
+            0,
+            "population pin",
+            format!(
+                "ledger lists {} contexts but PINNED = {p}; a row was added without raising the \
+                 pin, or removed to dodge a red",
+                m.ledger.contexts.len()
+            ),
+            "raise the pin in the same change that adds a context; a removal is an owner \
+             decision recorded as dated prose in the file",
+        )),
+        Some(_) => {}
+    }
+    let mut seen = std::collections::BTreeSet::new();
+    for c in &m.ledger.contexts {
+        if !seen.insert(c) {
+            out.push(finding(
+                "CI-I9-DUP",
+                Severity::Critical,
+                "ci/required-checks.txt",
+                0,
+                c,
+                "context listed twice — double-counted coverage".into(),
+                "list each context once",
+            ));
+        }
+    }
+    out
+}

--- a/crates/ci-spec/src/invariants/wired.rs
+++ b/crates/ci-spec/src/invariants/wired.rs
@@ -1,0 +1,155 @@
+//! I8 — every gate is wired, and every inline gate is accounted for.
+//!
+//! Two domains, both DERIVED rather than declared:
+//!
+//! - every `scripts/check-*.sh` and `ci/*.sh` on disk is invoked by some
+//!   workflow (`check-test-helpers-not-in-production.sh` once shipped invoked
+//!   by zero workflows; `scripts/check-gates-can-fail.sh` catches the first
+//!   directory, this catches both);
+//! - every inline gate step (a `run:` containing `exit 1` / `::error::`) is
+//!   listed in `ci/inline-gates.txt` with the job or probe that falsifies it,
+//!   or as `UNCOVERED: <reason>` under a shrink-only ceiling. The gate of
+//!   gates covers `scripts/check-*.sh` only; every vacuous required gate the
+//!   2026-09-05 inventory found was an inline step, outside its domain.
+
+use std::collections::BTreeSet;
+
+use crate::model::Model;
+use crate::{Finding, Severity};
+
+use super::finding;
+
+/// The inventory key of a step.
+#[must_use]
+pub fn gate_key(workflow: &str, job: &str, step: &str) -> String {
+    let wf = workflow.rsplit('/').next().unwrap_or(workflow);
+    format!("{wf}::{job}::{step}")
+}
+
+/// Every inline gate in the tree, in inventory order.
+#[must_use]
+pub fn inline_gates(m: &Model) -> Vec<(String, usize, String)> {
+    let mut out = Vec::new();
+    for w in &m.workflows {
+        for j in &w.jobs {
+            for s in &j.steps {
+                if s.is_gate() {
+                    out.push((gate_key(&w.path, &j.id, &s.name), s.line, w.path.clone()));
+                }
+            }
+        }
+    }
+    out
+}
+
+pub fn check(m: &Model) -> Vec<Finding> {
+    let mut out = Vec::new();
+
+    for script in &m.gate_scripts {
+        let mentioned = m.workflows.iter().any(|w| w.raw.contains(script.as_str()));
+        if !mentioned {
+            out.push(finding(
+                "CI-I8-UNWIRED",
+                Severity::High,
+                script,
+                0,
+                script,
+                "no workflow invokes this gate script; it can fail locally and never run. A gate \
+                 CI does not call enforces nothing, however carefully it is written"
+                    .into(),
+                "invoke it from a workflow, or delete it",
+            ));
+        }
+    }
+
+    let tree: Vec<(String, usize, String)> = inline_gates(m);
+    let tree_keys: BTreeSet<&str> = tree.iter().map(|(k, _, _)| k.as_str()).collect();
+    let listed: BTreeSet<&str> = m.inline_gates.entries.keys().map(String::as_str).collect();
+
+    if tree.len() < 2 {
+        out.push(finding(
+            "CI-I8-VACUOUS",
+            Severity::Undecided,
+            "ci/inline-gates.txt",
+            0,
+            "inline gates",
+            format!(
+                "{} inline gate(s) found in the tree — the detector examined nothing",
+                tree.len()
+            ),
+            "check the gate heuristic",
+        ));
+        return out;
+    }
+
+    for (k, line, path) in &tree {
+        if !listed.contains(k.as_str()) {
+            out.push(finding(
+                "CI-I8-UNLISTED",
+                Severity::High,
+                path,
+                *line,
+                k,
+                "inline gate step not in ci/inline-gates.txt: nothing records what falsifies it, \
+                 so it can be green because it cannot fail and nobody would know"
+                    .into(),
+                "add it with its falsifier (a `*-falsifier` job or a gates-can-fail probe), or \
+                 as `UNCOVERED: <reason>` and raise the ceiling in the same change",
+            ));
+        }
+    }
+    for k in listed.difference(&tree_keys) {
+        out.push(finding(
+            "CI-I8-STALE",
+            Severity::Medium,
+            "ci/inline-gates.txt",
+            0,
+            k,
+            "listed inline gate no longer exists in the tree (renamed, moved, or its `exit 1` \
+             is gone — which might mean it stopped being a gate)"
+                .into(),
+            "update or remove the entry",
+        ));
+    }
+    let uncovered = m
+        .inline_gates
+        .entries
+        .values()
+        .filter(|v| v.starts_with("UNCOVERED"))
+        .count();
+    match m.inline_gates.uncovered_ceiling {
+        None => out.push(finding(
+            "CI-I8-CEILING",
+            Severity::Undecided,
+            "ci/inline-gates.txt",
+            0,
+            "UNCOVERED_CEILING",
+            "no `# UNCOVERED_CEILING = N` header; the uncovered count is not ratcheted".into(),
+            "add the header at the current count; it may only shrink",
+        )),
+        Some(c) if uncovered > c => out.push(finding(
+            "CI-I8-CEILING",
+            Severity::Critical,
+            "ci/inline-gates.txt",
+            0,
+            "UNCOVERED_CEILING",
+            format!("{uncovered} UNCOVERED inline gates, ceiling {c}: the ratchet only shrinks"),
+            "give the new gate a falsifier instead of listing it uncovered",
+        )),
+        Some(_) => {}
+    }
+    for (k, v) in &m.inline_gates.entries {
+        if v.is_empty() {
+            out.push(finding(
+                "CI-I8-EMPTY",
+                Severity::Medium,
+                "ci/inline-gates.txt",
+                0,
+                k,
+                "entry has no falsifier and no UNCOVERED reason".into(),
+                "name the falsifier or the reason",
+            ));
+        }
+    }
+    out
+}

--- a/crates/ci-spec/src/lib.rs
+++ b/crates/ci-spec/src/lib.rs
@@ -1,0 +1,297 @@
+//! `ci-spec` — the CI configuration as a typed model, and the invariants the
+//! merge queue silently relies on as decision procedures over it.
+//!
+//! # Why this exists
+//!
+//! On 2026-09-05 an inventory of this repository's CI found required status
+//! checks that were green by construction: a proof-count ratchet whose
+//! operand was empty (`[ "" -lt 72 ]` errors, and an erroring `[` reads as
+//! false, so the gate passed); coverage thresholds piped into `tee` under a
+//! shell without `pipefail`; one required context produced by four jobs in two
+//! twin pairs; twin `paths-ignore` lists that had drifted from the real
+//! twin's `paths`; seven required contexts hanging off two NON-required
+//! detector jobs, so a red detector reported them all as SKIPPED — which the
+//! merge rollup counts as passed. None of those invariants was written down
+//! anywhere. This crate writes them down as code, with a fixture for each
+//! founding defect that must go red.
+//!
+//! # The shape
+//!
+//! `loader` → [`model::Model`] → `invariants::*` → [`Report`]. The invariants
+//! are pure functions over the model, so every one is testable from an
+//! in-memory fixture. Observation (reading GitHub's live state) is NOT here;
+//! it belongs to `gh` in a workflow, per the xtask convention that only the
+//! decision is Rust.
+//!
+//! # Exit discipline
+//!
+//! `0` clean, `1` a violation, `2` could not look. The third is load-bearing:
+//! an expression the evaluator does not understand, a ledger that parsed
+//! empty, a tree with one workflow — each is reported as *unmeasured*, never
+//! as *fine*. Reporting "we could not look" as a pass is the exact vacuity
+//! the invariants exist to find.
+//!
+//! # What this does NOT claim
+//!
+//! - It reads YAML; it does not run anything. A gate can be structurally
+//!   sound and assert the wrong thing.
+//! - Gate detection is a heuristic (`exit 1` / `::error::`), inherited from
+//!   proofcard and stated as such.
+//! - The expression evaluator covers the subset this repository uses; the
+//!   rest is exit 2, by design.
+//! - The Lean model (`ci/lean`) proves that the invariants imply the
+//!   properties; this crate only decides the invariants.
+
+#![forbid(unsafe_code)]
+
+use serde::Serialize;
+
+pub mod expr;
+pub mod invariants;
+pub mod loader;
+pub mod model;
+
+/// How bad a finding is.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Severity {
+    /// The property is violated in a way that makes a required check vacuous.
+    Critical,
+    /// A plausible failure passes silently.
+    High,
+    /// Weakens a gate without an evident path to a false pass.
+    Medium,
+    /// Worth knowing; does not fail the check.
+    Info,
+    /// The checker could not decide. Fails with exit 2, never reads as a pass.
+    Undecided,
+}
+
+/// One violated (or undecidable) invariant.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct Finding {
+    /// Stable rule id: `CI-I1-PATHS`, `GI003`, ...
+    pub rule: &'static str,
+    pub severity: Severity,
+    /// Repo-relative file.
+    pub file: String,
+    /// 1-indexed line, or 0 when the finding is about the file as a whole.
+    pub line: usize,
+    /// The job / step / context the finding is about.
+    pub subject: String,
+    /// What goes wrong, concretely.
+    pub why: String,
+    /// What to do about it.
+    pub fix: String,
+    /// The job the finding is about, when it is about one (empty otherwise).
+    /// Used to scope severity: High/Medium findings on jobs that produce no
+    /// required context are reported as Info rather than failing the check.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub job: String,
+}
+
+impl Finding {
+    /// Attribute the finding to a job.
+    #[must_use]
+    pub fn in_job(mut self, job: &str) -> Self {
+        self.job = job.to_string();
+        self
+    }
+
+    /// The key an allowlist entry uses: `RULE file::subject`.
+    #[must_use]
+    pub fn key(&self) -> String {
+        format!("{} {}::{}", self.rule, self.file, self.subject)
+    }
+}
+
+/// What was examined and what was found.
+#[derive(Debug, Clone, Serialize)]
+pub struct Report {
+    pub workflows: usize,
+    pub jobs: usize,
+    pub gates: usize,
+    pub required_contexts: usize,
+    pub findings: Vec<Finding>,
+}
+
+impl Report {
+    /// `0` clean, `1` violation, `2` could not look.
+    #[must_use]
+    pub fn exit_code(&self) -> i32 {
+        let violated = self.findings.iter().any(|f| {
+            matches!(
+                f.severity,
+                Severity::Critical | Severity::High | Severity::Medium
+            )
+        });
+        let undecided = self
+            .findings
+            .iter()
+            .any(|f| f.severity == Severity::Undecided);
+        if violated {
+            1
+        } else if undecided {
+            2
+        } else {
+            0
+        }
+    }
+
+    /// Rule ids present, sorted and deduplicated.
+    #[must_use]
+    pub fn rules(&self) -> Vec<&'static str> {
+        let mut v: Vec<&'static str> = self.findings.iter().map(|f| f.rule).collect();
+        v.sort_unstable();
+        v.dedup();
+        v
+    }
+
+    /// Human-readable rendering.
+    #[must_use]
+    pub fn render(&self) -> String {
+        use std::fmt::Write as _;
+        let mut s = String::new();
+        let _ = writeln!(
+            s,
+            "ci-spec: {} workflows, {} jobs, {} inline gates, {} required contexts",
+            self.workflows, self.jobs, self.gates, self.required_contexts
+        );
+        for f in &self.findings {
+            let sev = match f.severity {
+                Severity::Critical => "CRITICAL",
+                Severity::High => "high",
+                Severity::Medium => "medium",
+                Severity::Info => "info",
+                Severity::Undecided => "UNDECIDED",
+            };
+            let _ = writeln!(
+                s,
+                "  {sev:<9} [{}] {}:{} {}\n            {}\n            fix: {}",
+                f.rule, f.file, f.line, f.subject, f.why, f.fix
+            );
+        }
+        let _ = writeln!(
+            s,
+            "{}",
+            match self.exit_code() {
+                0 => "ok: every invariant holds".to_string(),
+                1 => format!(
+                    "VIOLATION: {} finding(s)",
+                    self.findings
+                        .iter()
+                        .filter(|f| f.severity != Severity::Info)
+                        .count()
+                ),
+                _ => "UNDECIDED: could not evaluate part of the configuration — this is not a pass"
+                    .to_string(),
+            }
+        );
+        s
+    }
+}
+
+/// Run every invariant over the model.
+#[must_use]
+pub fn check(m: &model::Model) -> Report {
+    let mut findings = Vec::new();
+
+    // I9 — non-vacuity of the model itself, first: nothing below may run
+    // over an empty domain and report it as clean.
+    findings.extend(invariants::vacuity::check(m));
+
+    findings.extend(invariants::twins::check(m));
+    findings.extend(invariants::producers::check(m));
+    findings.extend(invariants::merge_group::check(m));
+    findings.extend(invariants::concurrency::check(m));
+    findings.extend(invariants::scope::check(m));
+    findings.extend(invariants::gates::check(m));
+    findings.extend(invariants::timeouts::check(m));
+    findings.extend(invariants::wired::check(m));
+
+    // Severity scoping. A gate inside a job that produces NO required context
+    // cannot make a merge vacuous; its High/Medium findings are reported (so
+    // the inline-gate ledger can ratchet them) but do not fail the check.
+    // Critical stays Critical everywhere: a gate that cannot fail is a false
+    // claim wherever it sits. Workflow-level findings (I4) are scoped by
+    // whether ANY job in the file produces a required context.
+    let required_jobs: std::collections::BTreeSet<(String, String)> = m
+        .workflows
+        .iter()
+        .flat_map(|w| {
+            w.jobs.iter().filter_map(move |j| {
+                if j.contexts().iter().any(|c| m.is_required(c)) {
+                    Some((w.path.clone(), j.id.clone()))
+                } else {
+                    None
+                }
+            })
+        })
+        .collect();
+    let required_files: std::collections::BTreeSet<&str> =
+        required_jobs.iter().map(|(p, _)| p.as_str()).collect();
+    for f in &mut findings {
+        if !matches!(f.severity, Severity::High | Severity::Medium) {
+            continue;
+        }
+        let in_scope = if f.job.is_empty() {
+            !f.file.starts_with(".github/workflows/") || required_files.contains(f.file.as_str())
+        } else {
+            required_jobs.contains(&(f.file.clone(), f.job.clone()))
+        };
+        if !in_scope {
+            f.severity = Severity::Info;
+        }
+    }
+
+    // Allowlist: entries carry a reason and are checked for staleness both
+    // ways — an allowed finding that no longer fires is itself a finding.
+    let mut used = std::collections::BTreeSet::new();
+    findings.retain(|f| {
+        let k = f.key();
+        if m.allowlist.entries.contains_key(&k) {
+            used.insert(k);
+            false
+        } else {
+            true
+        }
+    });
+    for (k, reason) in &m.allowlist.entries {
+        if !used.contains(k) {
+            findings.push(Finding {
+                rule: "CI-ALLOW-STALE",
+                severity: Severity::Medium,
+                file: "ci/gate-integrity-allowlist.txt".into(),
+                line: 0,
+                subject: k.clone(),
+                why: format!(
+                    "allowlisted finding no longer fires (reason on record: {reason:?}); a stale \
+                     entry would silently allow the next real instance"
+                ),
+                fix: "remove the entry".into(),
+                job: String::new(),
+            });
+        }
+    }
+
+    findings.sort_by(|a, b| {
+        a.severity
+            .cmp(&b.severity)
+            .then_with(|| a.file.cmp(&b.file))
+            .then_with(|| a.line.cmp(&b.line))
+    });
+
+    Report {
+        workflows: m.workflows.len(),
+        jobs: m.workflows.iter().map(|w| w.jobs.len()).sum(),
+        gates: m
+            .workflows
+            .iter()
+            .flat_map(|w| w.jobs.iter())
+            .flat_map(|j| j.steps.iter())
+            .filter(|s| s.is_gate())
+            .count(),
+        required_contexts: m.ledger.contexts.len(),
+        findings,
+    }
+}

--- a/crates/ci-spec/src/loader.rs
+++ b/crates/ci-spec/src/loader.rs
@@ -1,0 +1,403 @@
+//! From files to [`Model`].
+//!
+//! The YAML is hand-walked rather than deserialised into a schema: workflow
+//! files carry keys this tool has no model for, and a partial `#[derive]`
+//! would drop steps it did not anticipate — which for a checker means silently
+//! examining less than it reports. Line numbers are recovered by searching the
+//! raw text, since `serde_yaml` drops spans.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use anyhow::{Context, Result, bail};
+use serde_yaml::Value;
+
+use crate::model::{
+    Allowlist, Concurrency, InlineGates, Job, Ledger, Model, PathFilter, QueueConfig, Step,
+    Triggers, Workflow,
+};
+
+/// Look a key up in a mapping, tolerating YAML 1.1's reading of `on` as a
+/// boolean. Whether `on:` parses as the string `"on"` or as `true` depends on
+/// the YAML library's schema; a loader that only tried one of them would read
+/// every workflow as trigger-less.
+fn get<'a>(map: &'a Value, key: &str) -> Option<&'a Value> {
+    let m = map.as_mapping()?;
+    if let Some(v) = m.get(Value::String(key.to_string())) {
+        return Some(v);
+    }
+    if key == "on" {
+        return m.get(Value::Bool(true));
+    }
+    None
+}
+
+fn as_str_list(v: Option<&Value>) -> Vec<String> {
+    match v {
+        Some(Value::Sequence(s)) => s
+            .iter()
+            .filter_map(|x| x.as_str().map(str::to_string))
+            .collect(),
+        Some(Value::String(s)) => vec![s.clone()],
+        _ => Vec::new(),
+    }
+}
+
+fn scalar_string(v: Option<&Value>) -> Option<String> {
+    match v? {
+        Value::String(s) => Some(s.clone()),
+        Value::Bool(b) => Some(b.to_string()),
+        Value::Number(n) => Some(n.to_string()),
+        _ => None,
+    }
+}
+
+fn path_filter(v: &Value) -> PathFilter {
+    PathFilter {
+        paths: as_str_list(get(v, "paths")),
+        paths_ignore: as_str_list(get(v, "paths-ignore")),
+        types: as_str_list(get(v, "types")),
+    }
+}
+
+fn triggers(on: Option<&Value>) -> Triggers {
+    let mut t = Triggers::default();
+    let Some(on) = on else { return t };
+    let mut mark = |name: &str, body: Option<&Value>| match name {
+        "push" => t.push = Some(body.map(path_filter).unwrap_or_default()),
+        "pull_request" => t.pull_request = Some(body.map(path_filter).unwrap_or_default()),
+        "merge_group" => t.merge_group = true,
+        "schedule" => t.schedule = true,
+        "workflow_dispatch" => t.workflow_dispatch = true,
+        other => t.other.push(other.to_string()),
+    };
+    match on {
+        Value::String(s) => mark(s, None),
+        Value::Sequence(seq) => {
+            for e in seq {
+                if let Some(s) = e.as_str() {
+                    mark(s, None);
+                }
+            }
+        }
+        Value::Mapping(m) => {
+            for (k, v) in m {
+                if let Some(s) = k.as_str() {
+                    let body = if v.is_null() { None } else { Some(v) };
+                    mark(s, body);
+                }
+            }
+        }
+        _ => {}
+    }
+    t
+}
+
+/// First 1-indexed line at or after `from` (0-indexed) containing `needle`.
+fn find_line(raw: &[&str], needle: &str, from: usize) -> Option<usize> {
+    raw.iter()
+        .enumerate()
+        .skip(from)
+        .find(|(_, l)| l.contains(needle))
+        .map(|(i, _)| i + 1)
+}
+
+/// Parse one workflow file.
+pub fn parse_workflow(path: &str, text: &str) -> Result<Workflow> {
+    let doc: Value =
+        serde_yaml::from_str(text).with_context(|| format!("{path}: not valid YAML"))?;
+    let raw: Vec<&str> = text.lines().collect();
+
+    let name = scalar_string(get(&doc, "name")).unwrap_or_else(|| path.to_string());
+    let t = triggers(get(&doc, "on"));
+
+    let concurrency = get(&doc, "concurrency").and_then(|c| {
+        let group = scalar_string(get(c, "group"))?;
+        let cancel_in_progress =
+            scalar_string(get(c, "cancel-in-progress")).unwrap_or_else(|| "false".into());
+        let line = find_line(&raw, "concurrency:", 0).unwrap_or(1);
+        Some(Concurrency {
+            group,
+            cancel_in_progress,
+            line,
+        })
+    });
+
+    let default_shell = get(&doc, "defaults")
+        .and_then(|d| get(d, "run"))
+        .and_then(|r| get(r, "shell"))
+        .and_then(|s| s.as_str())
+        .map(str::to_string);
+
+    let mut jobs = Vec::new();
+    if let Some(Value::Mapping(jm)) = get(&doc, "jobs") {
+        let mut cursor = 0usize;
+        for (k, jv) in jm {
+            let id = k.as_str().unwrap_or("<job>").to_string();
+            let line = find_line(&raw, &format!("  {id}:"), cursor).unwrap_or(1);
+            cursor = line;
+            let job_shell = get(jv, "defaults")
+                .and_then(|d| get(d, "run"))
+                .and_then(|r| get(r, "shell"))
+                .and_then(|s| s.as_str())
+                .map(str::to_string)
+                .or_else(|| default_shell.clone());
+            let job_workdir = get(jv, "defaults")
+                .and_then(|d| get(d, "run"))
+                .and_then(|r| get(r, "working-directory"))
+                .and_then(|s| s.as_str())
+                .map(str::to_string);
+            let needs = as_str_list(get(jv, "needs"));
+            let timeout_minutes = get(jv, "timeout-minutes").and_then(Value::as_u64);
+            let continue_on_error = get(jv, "continue-on-error")
+                .and_then(Value::as_bool)
+                .unwrap_or(false);
+
+            let mut steps = Vec::new();
+            let mut scursor = line;
+            if let Some(Value::Sequence(sv)) = get(jv, "steps") {
+                for st in sv {
+                    let sname = scalar_string(get(st, "name"))
+                        .or_else(|| scalar_string(get(st, "uses")).map(|u| format!("uses {u}")))
+                        .unwrap_or_else(|| "<unnamed>".into());
+                    let run = get(st, "run").and_then(|r| r.as_str()).map(str::to_string);
+                    let shell = get(st, "shell")
+                        .and_then(|s| s.as_str())
+                        .map(str::to_string)
+                        .or_else(|| job_shell.clone());
+                    let mut env = BTreeMap::new();
+                    if let Some(Value::Mapping(em)) = get(st, "env") {
+                        for (ek, ev) in em {
+                            if let (Some(k), Some(v)) = (ek.as_str(), scalar_string(Some(ev))) {
+                                env.insert(k.to_string(), v);
+                            }
+                        }
+                    }
+                    // The step's own line: its `- name:` if named, else the
+                    // first line of its script.
+                    let sline = if let Some(uses) = sname.strip_prefix("uses ") {
+                        find_line(&raw, uses, scursor)
+                    } else if sname != "<unnamed>" {
+                        find_line(&raw, &format!("name: {sname}"), scursor)
+                    } else {
+                        run.as_deref()
+                            .and_then(|r| r.lines().next())
+                            .map(str::trim)
+                            .filter(|f| !f.is_empty())
+                            .and_then(|f| find_line(&raw, f, scursor))
+                    }
+                    .unwrap_or(scursor);
+                    scursor = sline;
+                    steps.push(Step {
+                        name: sname,
+                        id: scalar_string(get(st, "id")),
+                        run,
+                        shell,
+                        if_expr: scalar_string(get(st, "if")),
+                        continue_on_error: get(st, "continue-on-error")
+                            .and_then(Value::as_bool)
+                            .unwrap_or(false),
+                        env,
+                        working_directory: get(st, "working-directory")
+                            .and_then(|s| s.as_str())
+                            .map(str::to_string)
+                            .or_else(|| job_workdir.clone()),
+                        line: sline,
+                    });
+                }
+            }
+            // strategy.matrix: cartesian product of the list-valued keys, in
+            // declaration order (GitHub's check-run naming order).
+            let mut matrix: Vec<Vec<(String, String)>> = Vec::new();
+            let mut matrix_opaque = false;
+            if let Some(Value::Mapping(mm)) = get(jv, "strategy").and_then(|s| get(s, "matrix")) {
+                let mut dims: Vec<(String, Vec<String>)> = Vec::new();
+                for (mk, mv) in mm {
+                    let Some(k) = mk.as_str() else { continue };
+                    if k == "include" || k == "exclude" {
+                        matrix_opaque = true;
+                        continue;
+                    }
+                    let vals: Vec<String> = match mv {
+                        Value::Sequence(s) => {
+                            s.iter().filter_map(|x| scalar_string(Some(x))).collect()
+                        }
+                        other => scalar_string(Some(other)).into_iter().collect(),
+                    };
+                    if !vals.is_empty() {
+                        dims.push((k.to_string(), vals));
+                    }
+                }
+                if !dims.is_empty() {
+                    matrix.push(Vec::new());
+                    for (k, vals) in dims {
+                        let mut next = Vec::new();
+                        for combo in &matrix {
+                            for v in &vals {
+                                let mut c = combo.clone();
+                                c.push((k.clone(), v.clone()));
+                                next.push(c);
+                            }
+                        }
+                        matrix = next;
+                    }
+                }
+            }
+            jobs.push(Job {
+                matrix,
+                matrix_opaque,
+                id,
+                name: scalar_string(get(jv, "name")),
+                runs_on: scalar_string(get(jv, "runs-on")).unwrap_or_default(),
+                if_expr: scalar_string(get(jv, "if")),
+                needs,
+                timeout_minutes,
+                continue_on_error,
+                line,
+                steps,
+            });
+        }
+    }
+
+    Ok(Workflow {
+        path: path.to_string(),
+        name,
+        triggers: t,
+        concurrency,
+        default_shell,
+        jobs,
+        raw: text.to_string(),
+    })
+}
+
+/// Parse the required-check ledger: one context per line, `#` comments,
+/// `# PINNED = N` header.
+pub fn parse_ledger(text: &str) -> Ledger {
+    let mut l = Ledger::default();
+    for line in text.lines() {
+        let t = line.trim();
+        if let Some(rest) = t.strip_prefix('#') {
+            let r = rest.trim();
+            if let Some(n) = r.strip_prefix("PINNED") {
+                if let Ok(v) = n.trim().trim_start_matches('=').trim().parse::<usize>() {
+                    l.pinned = Some(v);
+                }
+            }
+            continue;
+        }
+        if !t.is_empty() {
+            l.contexts.push(t.to_string());
+        }
+    }
+    l
+}
+
+/// Parse the inline-gate inventory: `key | falsifier` lines, `#` comments,
+/// `# UNCOVERED_CEILING = N` header.
+pub fn parse_inline_gates(text: &str) -> InlineGates {
+    let mut g = InlineGates::default();
+    for line in text.lines() {
+        let t = line.trim();
+        if let Some(rest) = t.strip_prefix('#') {
+            let r = rest.trim();
+            if let Some(n) = r.strip_prefix("UNCOVERED_CEILING") {
+                if let Ok(v) = n.trim().trim_start_matches('=').trim().parse::<usize>() {
+                    g.uncovered_ceiling = Some(v);
+                }
+            }
+            continue;
+        }
+        if t.is_empty() {
+            continue;
+        }
+        let (k, v) = t.split_once(" | ").unwrap_or((t, ""));
+        g.entries.insert(k.trim().to_string(), v.trim().to_string());
+    }
+    g
+}
+
+/// Parse the gate-integrity allowlist: `RULE workflow::step | reason`.
+pub fn parse_allowlist(text: &str) -> Allowlist {
+    let mut a = Allowlist::default();
+    for line in text.lines() {
+        let t = line.trim();
+        if t.is_empty() || t.starts_with('#') {
+            continue;
+        }
+        let (k, v) = t.split_once(" | ").unwrap_or((t, ""));
+        a.entries.insert(k.trim().to_string(), v.trim().to_string());
+    }
+    a
+}
+
+/// Build the model from an in-memory set of files (what the tests use).
+///
+/// `workflows` are `(path, text)`; `gate_scripts` are the on-disk gate
+/// script paths.
+pub fn from_parts(
+    workflows: &[(String, String)],
+    ledger: &str,
+    queue_toml: &str,
+    inline_gates: &str,
+    allowlist: &str,
+    gate_scripts: Vec<String>,
+) -> Result<Model> {
+    let mut wfs = Vec::new();
+    for (p, t) in workflows {
+        wfs.push(parse_workflow(p, t)?);
+    }
+    let queue: QueueConfig = toml::from_str(queue_toml).context("ci/merge-queue.toml")?;
+    Ok(Model {
+        workflows: wfs,
+        ledger: parse_ledger(ledger),
+        queue,
+        inline_gates: parse_inline_gates(inline_gates),
+        allowlist: parse_allowlist(allowlist),
+        gate_scripts,
+    })
+}
+
+/// Build the model from a repository checkout.
+pub fn from_repo(root: &Path) -> Result<Model> {
+    let wf_dir = root.join(".github/workflows");
+    let mut workflows = Vec::new();
+    let mut names: Vec<_> = std::fs::read_dir(&wf_dir)
+        .with_context(|| format!("reading {}", wf_dir.display()))?
+        .filter_map(Result::ok)
+        .map(|e| e.path())
+        .filter(|p| p.extension().is_some_and(|e| e == "yml" || e == "yaml"))
+        .collect();
+    names.sort();
+    for p in names {
+        let rel = format!(
+            ".github/workflows/{}",
+            p.file_name().and_then(|f| f.to_str()).unwrap_or("?")
+        );
+        let text = std::fs::read_to_string(&p).with_context(|| format!("reading {rel}"))?;
+        workflows.push((rel, text));
+    }
+    let read = |rel: &str| -> Result<String> {
+        std::fs::read_to_string(root.join(rel)).with_context(|| format!("reading {rel}"))
+    };
+    let ledger = read("ci/required-checks.txt")?;
+    let queue = read("ci/merge-queue.toml")?;
+    let inline = read("ci/inline-gates.txt")?;
+    let allow = read("ci/gate-integrity-allowlist.txt").unwrap_or_default();
+
+    let mut gate_scripts = Vec::new();
+    for (dir, prefix) in [("scripts", "check-"), ("ci", "")] {
+        let d = root.join(dir);
+        if !d.is_dir() {
+            bail!("{} is not a directory", d.display());
+        }
+        for e in std::fs::read_dir(&d)?.filter_map(Result::ok) {
+            let f = e.file_name();
+            let f = f.to_string_lossy();
+            if f.starts_with(prefix) && f.ends_with(".sh") {
+                gate_scripts.push(format!("{dir}/{f}"));
+            }
+        }
+    }
+    gate_scripts.sort();
+    from_parts(&workflows, &ledger, &queue, &inline, &allow, gate_scripts)
+}

--- a/crates/ci-spec/src/model.rs
+++ b/crates/ci-spec/src/model.rs
@@ -1,0 +1,235 @@
+//! The typed model of a CI configuration.
+//!
+//! Everything the invariants reason about is a field here. The loader fills
+//! it from `.github/workflows/*.yml`, the required-check ledger and the
+//! merge-queue pin; the invariants never touch YAML or the filesystem again,
+//! which is what makes them unit-testable from in-memory fixtures.
+
+use std::collections::BTreeMap;
+
+/// One `.github/workflows/*.yml` file.
+#[derive(Debug, Clone)]
+pub struct Workflow {
+    /// Repo-relative path, e.g. `.github/workflows/ci.yml`.
+    pub path: String,
+    /// The `name:` — what `${{ github.workflow }}` expands to, and what the
+    /// checks UI groups by. Twins share it on purpose.
+    pub name: String,
+    pub triggers: Triggers,
+    pub concurrency: Option<Concurrency>,
+    /// `defaults.run.shell`, if declared.
+    pub default_shell: Option<String>,
+    pub jobs: Vec<Job>,
+    /// The raw text, kept for line recovery and for "is script X mentioned".
+    pub raw: String,
+}
+
+impl Workflow {
+    /// The twin-pair key: `foo-noop.yml` and `foo.yml` share `foo`.
+    #[must_use]
+    pub fn pair_key(&self) -> String {
+        let base = self.path.rsplit('/').next().unwrap_or(&self.path);
+        let base = base.trim_end_matches(".yml").trim_end_matches(".yaml");
+        base.trim_end_matches("-noop").to_string()
+    }
+
+    /// Is this the `-noop` half of a twin pair?
+    #[must_use]
+    pub fn is_noop(&self) -> bool {
+        let base = self.path.rsplit('/').next().unwrap_or(&self.path);
+        base.ends_with("-noop.yml") || base.ends_with("-noop.yaml")
+    }
+}
+
+/// What fires the workflow.
+#[derive(Debug, Clone, Default)]
+pub struct Triggers {
+    pub push: Option<PathFilter>,
+    pub pull_request: Option<PathFilter>,
+    pub merge_group: bool,
+    pub schedule: bool,
+    pub workflow_dispatch: bool,
+    /// Any other event names, verbatim.
+    pub other: Vec<String>,
+}
+
+/// `paths:` / `paths-ignore:` under one event. Both empty means unfiltered.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PathFilter {
+    pub paths: Vec<String>,
+    pub paths_ignore: Vec<String>,
+    /// `types:` if declared.
+    pub types: Vec<String>,
+}
+
+/// The workflow-level `concurrency:` block.
+#[derive(Debug, Clone)]
+pub struct Concurrency {
+    pub group: String,
+    /// The raw scalar of `cancel-in-progress` — `true`, `false`, or an expression.
+    pub cancel_in_progress: String,
+    pub line: usize,
+}
+
+/// One job.
+#[derive(Debug, Clone)]
+pub struct Job {
+    /// The YAML key.
+    pub id: String,
+    /// `name:` if declared.
+    pub name: Option<String>,
+    pub runs_on: String,
+    /// Job-level `if:`.
+    pub if_expr: Option<String>,
+    pub needs: Vec<String>,
+    pub timeout_minutes: Option<u64>,
+    pub continue_on_error: bool,
+    /// 1-indexed line of the `<id>:` key.
+    pub line: usize,
+    pub steps: Vec<Step>,
+    /// `strategy.matrix` combinations as `(key, value)` lists, in declaration
+    /// order. Empty when the job has no matrix. `include`/`exclude` are not
+    /// expanded; `matrix_opaque` says so.
+    pub matrix: Vec<Vec<(String, String)>>,
+    pub matrix_opaque: bool,
+}
+
+impl Job {
+    /// The status-check context this job reports: `name:` if present, else the id.
+    #[must_use]
+    pub fn display_name(&self) -> &str {
+        self.name.as_deref().unwrap_or(&self.id)
+    }
+
+    /// Every check-run name this job produces. A matrix job produces one per
+    /// combination: `name (v1, v2)`, or the `name:` with `${{ matrix.k }}`
+    /// substituted when it interpolates the matrix.
+    #[must_use]
+    pub fn contexts(&self) -> Vec<String> {
+        let base = self.display_name();
+        if self.matrix.is_empty() {
+            return vec![base.to_string()];
+        }
+        self.matrix
+            .iter()
+            .map(|combo| {
+                if base.contains("${{ matrix.") {
+                    let mut s = base.to_string();
+                    for (k, v) in combo {
+                        s = s.replace(&format!("${{{{ matrix.{k} }}}}"), v);
+                    }
+                    s
+                } else {
+                    let vals: Vec<&str> = combo.iter().map(|(_, v)| v.as_str()).collect();
+                    format!("{base} ({})", vals.join(", "))
+                }
+            })
+            .collect()
+    }
+}
+
+/// One step.
+#[derive(Debug, Clone)]
+pub struct Step {
+    pub name: String,
+    pub id: Option<String>,
+    pub run: Option<String>,
+    /// The step's `shell:`, or the job/workflow default that applies.
+    pub shell: Option<String>,
+    pub if_expr: Option<String>,
+    pub continue_on_error: bool,
+    pub env: BTreeMap<String, String>,
+    pub working_directory: Option<String>,
+    /// 1-indexed line of the step's first line in the file.
+    pub line: usize,
+}
+
+impl Step {
+    /// Can this step deliberately fail? Only such steps are gates; a build
+    /// step is not one. (Heuristic inherited from proofcard; stated as such.)
+    #[must_use]
+    pub fn is_gate(&self) -> bool {
+        self.run
+            .as_deref()
+            .is_some_and(|s| s.contains("exit 1") || s.contains("::error::"))
+    }
+
+    /// Does `pipefail` apply? Naming the shell buys it on GitHub
+    /// (`bash --noprofile --norc -eo pipefail {0}`); so does setting it in
+    /// the script. The default `bash -e {0}` has errexit and NOT pipefail.
+    #[must_use]
+    pub fn pipefail(&self) -> bool {
+        self.shell.is_some() || self.run.as_deref().is_some_and(|s| s.contains("pipefail"))
+    }
+}
+
+/// The merge-queue ruleset constants, pinned in `ci/merge-queue.toml`.
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct QueueConfig {
+    pub ruleset_id: u64,
+    pub check_response_timeout_minutes: u64,
+    pub max_entries_to_build: u64,
+    pub max_entries_to_merge: u64,
+    pub min_entries_to_merge: u64,
+    pub min_entries_to_merge_wait_minutes: u64,
+    pub grouping_strategy: String,
+    pub merge_method: String,
+    /// Classic branch-protection `required_status_checks.strict`.
+    pub strict: bool,
+}
+
+/// The required-check ledger (`ci/required-checks.txt`).
+#[derive(Debug, Clone, Default)]
+pub struct Ledger {
+    pub contexts: Vec<String>,
+    /// `# PINNED = N` — the population pin; grow-only.
+    pub pinned: Option<usize>,
+}
+
+/// The inline-gate inventory (`ci/inline-gates.txt`).
+#[derive(Debug, Clone, Default)]
+pub struct InlineGates {
+    /// key (`workflow::job::step`) → falsifier text (or `UNCOVERED: reason`).
+    pub entries: BTreeMap<String, String>,
+    pub uncovered_ceiling: Option<usize>,
+}
+
+/// The gate-integrity allowlist (`ci/gate-integrity-allowlist.txt`).
+#[derive(Debug, Clone, Default)]
+pub struct Allowlist {
+    /// key (`RULE workflow::step`) → reason.
+    pub entries: BTreeMap<String, String>,
+}
+
+/// Everything the invariants see.
+#[derive(Debug, Clone)]
+pub struct Model {
+    pub workflows: Vec<Workflow>,
+    pub ledger: Ledger,
+    pub queue: QueueConfig,
+    pub inline_gates: InlineGates,
+    pub allowlist: Allowlist,
+    /// Repo-relative paths of every `scripts/check-*.sh` and `ci/*.sh` on disk.
+    pub gate_scripts: Vec<String>,
+}
+
+impl Model {
+    /// Every (workflow index, job index) whose display name is `ctx`.
+    pub fn producers(&self, ctx: &str) -> Vec<(usize, usize)> {
+        let mut out = Vec::new();
+        for (wi, w) in self.workflows.iter().enumerate() {
+            for (ji, j) in w.jobs.iter().enumerate() {
+                if j.contexts().iter().any(|c| c == ctx) {
+                    out.push((wi, ji));
+                }
+            }
+        }
+        out
+    }
+
+    /// Is `name` a required context?
+    #[must_use]
+    pub fn is_required(&self, name: &str) -> bool {
+        self.ledger.contexts.iter().any(|c| c == name)
+    }
+}

--- a/crates/ci-spec/tests/founding_defects.rs
+++ b/crates/ci-spec/tests/founding_defects.rs
@@ -1,0 +1,719 @@
+//! Every invariant, tested on the defect it was written for.
+//!
+//! Each fixture is the shape found live on 2026-09-05 (or in the repo's
+//! history), reduced to the minimum that reproduces it. The assertion is
+//! two-sided, as in `scripts/check-gates-can-fail.sh`: the rule must fire on
+//! the defect, and must be silent on the repaired shape — a rule that fires
+//! on everything detects nothing either.
+
+use ci_spec::loader::from_parts;
+use ci_spec::{Severity, check};
+
+const QUEUE: &str = r#"
+ruleset_id = 1
+check_response_timeout_minutes = 360
+max_entries_to_build = 1
+max_entries_to_merge = 1
+min_entries_to_merge = 1
+min_entries_to_merge_wait_minutes = 0
+grouping_strategy = "ALLGREEN"
+merge_method = "SQUASH"
+strict = false
+"#;
+
+/// A second, always-clean workflow so the model is never vacuous (I9).
+const FILLER: &str = r#"
+name: Filler
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+  merge_group:
+concurrency:
+  group: filler-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+jobs:
+  rustfmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - run: |
+          cargo fmt --check || { echo "::error::fmt"; exit 1; }
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - run: |
+          cargo clippy || { echo "::error::clippy"; exit 1; }
+"#;
+
+const FILLER_GATES: &str = "\
+filler.yml::rustfmt::<unnamed> | falsified by cargo fmt on a misformatted fixture
+filler.yml::clippy::<unnamed> | falsified by a clippy fixture
+";
+
+fn run(workflows: &[(&str, &str)], ledger: &str, inline_gates: &str) -> ci_spec::Report {
+    let mut wfs: Vec<(String, String)> = workflows
+        .iter()
+        .map(|(p, t)| (format!(".github/workflows/{p}"), (*t).to_string()))
+        .collect();
+    wfs.push((".github/workflows/filler.yml".into(), FILLER.into()));
+    let ledger = format!("{ledger}\nRustfmt\nClippy\n");
+    let n = ledger
+        .lines()
+        .filter(|l| !l.trim().is_empty() && !l.starts_with('#'))
+        .count();
+    let ledger = format!("# PINNED = {n}\n{ledger}");
+    let inline = format!("# UNCOVERED_CEILING = 50\n{FILLER_GATES}{inline_gates}");
+    let m = from_parts(&wfs, &ledger, QUEUE, &inline, "", vec![]).expect("model");
+    check(&m)
+}
+
+fn rules(r: &ci_spec::Report) -> Vec<&'static str> {
+    r.findings
+        .iter()
+        .filter(|f| f.severity != Severity::Info)
+        .map(|f| f.rule)
+        .collect()
+}
+
+fn assert_clean(r: &ci_spec::Report) {
+    let bad: Vec<_> = r
+        .findings
+        .iter()
+        .filter(|f| f.severity != Severity::Info)
+        .collect();
+    assert!(bad.is_empty(), "expected clean, got {bad:#?}");
+    assert_eq!(r.exit_code(), 0);
+}
+
+// ── I1 twin completeness ──────────────────────────────────────────────────
+
+const REAL_KANI: &str = r#"
+name: Kani BMC
+on:
+  pull_request:
+    paths:
+      - "crates/portcullis/src/**"
+      - ".kani-minimum-proofs"
+  merge_group:
+concurrency:
+  group: kani-real-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+jobs:
+  kani-fast:
+    name: Kani
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - run: cargo kani
+"#;
+
+fn noop_kani(ignore: &[&str], group: &str, merge_group: bool) -> String {
+    let mut s = String::from("name: Kani BMC\non:\n  pull_request:\n    paths-ignore:\n");
+    for p in ignore {
+        s.push_str(&format!("      - \"{p}\"\n"));
+    }
+    if merge_group {
+        s.push_str("  merge_group:\n");
+    }
+    s.push_str(&format!(
+        "concurrency:\n  group: {group}\n  cancel-in-progress: ${{{{ github.event_name == 'pull_request' }}}}\n\
+         jobs:\n  kani-fast:\n    name: Kani\n    runs-on: ubuntu-latest\n    timeout-minutes: 5\n    steps:\n      - run: echo noop\n"
+    ));
+    s
+}
+
+#[test]
+fn i1_twin_ignore_list_drift_is_red_and_the_mirror_is_green() {
+    // The kani-nightly-noop scar: one path missing from paths-ignore.
+    let drifted = noop_kani(
+        &["crates/portcullis/src/**"],
+        "kani-noop-${{ github.head_ref || github.ref }}",
+        false,
+    );
+    let r = run(
+        &[
+            ("kani-nightly.yml", REAL_KANI),
+            ("kani-nightly-noop.yml", &drifted),
+        ],
+        "Kani",
+        "",
+    );
+    assert!(rules(&r).contains(&"CI-I1-PATHS"), "got {:?}", rules(&r));
+
+    let exact = noop_kani(
+        &["crates/portcullis/src/**", ".kani-minimum-proofs"],
+        "kani-noop-${{ github.head_ref || github.ref }}",
+        false,
+    );
+    let r = run(
+        &[
+            ("kani-nightly.yml", REAL_KANI),
+            ("kani-nightly-noop.yml", &exact),
+        ],
+        "Kani",
+        "",
+    );
+    assert_clean(&r);
+}
+
+#[test]
+fn i1_twins_sharing_a_concurrency_group_is_red() {
+    // #2399: the twins cancelled each other on every PR.
+    let shared = noop_kani(
+        &["crates/portcullis/src/**", ".kani-minimum-proofs"],
+        "kani-real-${{ github.head_ref || github.ref }}",
+        false,
+    );
+    let r = run(
+        &[
+            ("kani-nightly.yml", REAL_KANI),
+            ("kani-nightly-noop.yml", &shared),
+        ],
+        "Kani",
+        "",
+    );
+    assert!(rules(&r).contains(&"CI-I1-GROUP"), "got {:?}", rules(&r));
+}
+
+#[test]
+fn i1_noop_twin_on_merge_group_is_red_when_the_context_is_required() {
+    let mg = noop_kani(
+        &["crates/portcullis/src/**", ".kani-minimum-proofs"],
+        "kani-noop-${{ github.head_ref || github.ref }}",
+        true,
+    );
+    let r = run(
+        &[
+            ("kani-nightly.yml", REAL_KANI),
+            ("kani-nightly-noop.yml", &mg),
+        ],
+        "Kani",
+        "",
+    );
+    assert!(rules(&r).contains(&"CI-I1-NOOP-MG"), "got {:?}", rules(&r));
+}
+
+// ── I2 producer injectivity ───────────────────────────────────────────────
+
+#[test]
+fn i2_one_context_from_two_twin_pairs_is_red() {
+    // "Scoped Aeneas (Rust → Lean 4) + parity tests" from the IFC and the
+    // OIDC→SPIFFE pairs — four jobs, two same-named check runs per PR.
+    let pair = |stem: &str| {
+        let real = format!(
+            "name: {stem}\non:\n  pull_request:\n    paths:\n      - \"crates/{stem}/**\"\n  merge_group:\n\
+             concurrency:\n  group: {stem}-real-${{{{ github.head_ref || github.ref }}}}\n  cancel-in-progress: ${{{{ github.event_name == 'pull_request' }}}}\n\
+             jobs:\n  j:\n    name: Scoped Aeneas\n    runs-on: ubuntu-latest\n    timeout-minutes: 5\n    steps:\n      - run: lake build\n"
+        );
+        let noop = format!(
+            "name: {stem}\non:\n  pull_request:\n    paths-ignore:\n      - \"crates/{stem}/**\"\n\
+             concurrency:\n  group: {stem}-noop-${{{{ github.head_ref || github.ref }}}}\n  cancel-in-progress: ${{{{ github.event_name == 'pull_request' }}}}\n\
+             jobs:\n  j:\n    name: Scoped Aeneas\n    runs-on: ubuntu-latest\n    timeout-minutes: 5\n    steps:\n      - run: echo noop\n"
+        );
+        (real, noop)
+    };
+    let (a, an) = pair("ifc");
+    let (b, bn) = pair("oidc");
+    let r = run(
+        &[
+            ("ifc.yml", &a),
+            ("ifc-noop.yml", &an),
+            ("oidc.yml", &b),
+            ("oidc-noop.yml", &bn),
+        ],
+        "Scoped Aeneas",
+        "",
+    );
+    assert!(rules(&r).contains(&"CI-I2-DUP"), "got {:?}", rules(&r));
+
+    let r = run(
+        &[("ifc.yml", &a), ("ifc-noop.yml", &an)],
+        "Scoped Aeneas",
+        "",
+    );
+    assert_clean(&r);
+}
+
+#[test]
+fn i2_matrix_contexts_have_producers() {
+    let deny = r#"
+name: Deny
+on:
+  pull_request:
+  merge_group:
+jobs:
+  deny:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        checks: [advisories, bans]
+    steps:
+      - run: cargo deny check ${{ matrix.checks }}
+"#;
+    let r = run(&[("deny.yml", deny)], "deny (advisories)\ndeny (bans)", "");
+    assert_clean(&r);
+    let r = run(&[("deny.yml", deny)], "deny (licenses)", "");
+    assert!(rules(&r).contains(&"CI-I2-NONE"), "got {:?}", rules(&r));
+}
+
+// ── I3 reported under merge_group, not skippable ──────────────────────────
+
+const CI_WITH_DETECTOR: &str = r#"
+name: CI
+on:
+  pull_request:
+  merge_group:
+jobs:
+  changed-crates:
+    name: Detect changed crates
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      all: ${{ steps.d.outputs.all }}
+    steps:
+      - id: d
+        run: echo all=true >> "$GITHUB_OUTPUT"
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: changed-crates
+    if: ${{ needs.changed-crates.outputs.all == 'true' || needs.changed-crates.outputs.crates != '' }}
+    steps:
+      - run: cargo test
+"#;
+
+#[test]
+fn i3_required_job_needing_a_non_required_detector_is_red() {
+    let r = run(&[("ci.yml", CI_WITH_DETECTOR)], "Tests", "");
+    assert!(rules(&r).contains(&"CI-I3-NEEDS"), "got {:?}", rules(&r));
+    // Making the detector a required context is the repair.
+    let r = run(
+        &[("ci.yml", CI_WITH_DETECTOR)],
+        "Tests\nDetect changed crates",
+        "",
+    );
+    assert_clean(&r);
+}
+
+#[test]
+fn i3_job_if_false_under_merge_group_is_red() {
+    let wf = r#"
+name: X
+on:
+  pull_request:
+  merge_group:
+jobs:
+  t:
+    name: Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ github.event_name == 'pull_request' }}
+    steps:
+      - run: cargo test
+"#;
+    let r = run(&[("x.yml", wf)], "Tests", "");
+    assert!(rules(&r).contains(&"CI-I3-SKIP"), "got {:?}", rules(&r));
+}
+
+#[test]
+fn i3_missing_merge_group_trigger_is_red() {
+    let wf = "name: X\non:\n  pull_request:\njobs:\n  t:\n    name: Tests\n    runs-on: ubuntu-latest\n    timeout-minutes: 5\n    steps:\n      - run: cargo test\n";
+    let r = run(&[("x.yml", wf)], "Tests", "");
+    assert!(rules(&r).contains(&"CI-I3-NOMG"), "got {:?}", rules(&r));
+}
+
+#[test]
+fn i3_unmodelled_condition_is_undecided_not_green() {
+    let wf = "name: X\non:\n  pull_request:\n  merge_group:\njobs:\n  t:\n    name: Tests\n    runs-on: ubuntu-latest\n    timeout-minutes: 5\n    if: ${{ contains(github.ref, 'x') }}\n    steps:\n      - run: cargo test\n";
+    let r = run(&[("x.yml", wf)], "Tests", "");
+    assert!(r.findings.iter().any(|f| f.rule == "CI-I3-UNDECIDED"));
+    assert_eq!(r.exit_code(), 2);
+}
+
+// ── I4 concurrency ────────────────────────────────────────────────────────
+
+#[test]
+fn i4_cancel_in_progress_true_under_merge_group_is_red() {
+    let z = |cancel: &str| {
+        format!(
+            "name: Z\non:\n  push:\n    branches: [main]\n  pull_request:\n  merge_group:\n\
+             concurrency:\n  group: z-${{{{ github.ref }}}}\n  cancel-in-progress: {cancel}\n\
+             jobs:\n  z:\n    name: zizmor\n    runs-on: ubuntu-latest\n    timeout-minutes: 5\n    steps:\n      - run: uvx zizmor .\n"
+        )
+    };
+    let r = run(&[("zizmor.yml", &z("true"))], "zizmor", "");
+    assert!(rules(&r).contains(&"CI-I4-CANCEL"), "got {:?}", rules(&r));
+    // feature-matrix.yml's shape: true for a queue ref.
+    let r = run(
+        &[("zizmor.yml", &z("${{ github.ref != 'refs/heads/main' }}"))],
+        "zizmor",
+        "",
+    );
+    assert!(rules(&r).contains(&"CI-I4-CANCEL"), "got {:?}", rules(&r));
+    let r = run(
+        &[(
+            "zizmor.yml",
+            &z("${{ github.event_name == 'pull_request' }}"),
+        )],
+        "zizmor",
+        "",
+    );
+    assert_clean(&r);
+}
+
+// ── I5 scope parity ───────────────────────────────────────────────────────
+
+#[test]
+fn i5_widened_paths_not_in_pattern_is_red() {
+    let wf = |paths: &str| {
+        let head = format!("name: L\non:\n  pull_request:\n    paths:\n{paths}  merge_group:\n");
+        let job = "jobs:\n  l:\n    name: lake build Ck\n    runs-on: ubuntu-latest\n    timeout-minutes: 5\n    steps:\n      - id: scope\n        env:\n          PATTERN: '^crates/ck-policy/'\n        run: echo relevant=true\n      - run: lake build\n";
+        format!("{head}{job}")
+    };
+    let r = run(
+        &[(
+            "ck.yml",
+            &wf("      - \"crates/ck-policy/**\"\n      - \"crates/ck-types/**\"\n"),
+        )],
+        "lake build Ck",
+        "",
+    );
+    assert!(rules(&r).contains(&"CI-I5-PARITY"), "got {:?}", rules(&r));
+    let r = run(
+        &[("ck.yml", &wf("      - \"crates/ck-policy/**\"\n"))],
+        "lake build Ck",
+        "",
+    );
+    assert_clean(&r);
+}
+
+// ── I6 gate integrity ─────────────────────────────────────────────────────
+
+fn gate_wf(step: &str) -> String {
+    format!(
+        "name: G\non:\n  pull_request:\n  merge_group:\njobs:\n  g:\n    name: Gate\n    runs-on: ubuntu-latest\n    timeout-minutes: 5\n    steps:\n{step}"
+    )
+}
+
+/// The Proof Count Ratchet as it stood on main on 2026-09-05.
+const RATCHET_BROKEN: &str = r#"      - name: Count Kani proofs
+        run: |
+          PORTCULLIS=$(grep -c '#\[kani::proof\]' crates/portcullis/src/kani.rs)
+          CORE=$(grep -rc '#\[kani::proof\]' crates/portcullis-core/src/ || echo 0)
+          PROOF_COUNT=$((PORTCULLIS + CORE))
+          MINIMUM=$(cat .kani-minimum-proofs | tr -d '[:space:]')
+          if [ "$PROOF_COUNT" -lt "$MINIMUM" ]; then
+            echo "::error::Kani proof count regression"
+            exit 1
+          fi
+"#;
+
+const RATCHET_FIXED: &str = r#"      - name: Count Kani proofs
+        run: |
+          PROOF_COUNT=$(grep -rho '#\[kani::proof\]' crates/portcullis/src crates/portcullis-core/src | wc -l | tr -d ' ')
+          MINIMUM=$(cat .kani-minimum-proofs | tr -d '[:space:]')
+          [[ "$MINIMUM" =~ ^[0-9]+$ ]] || { echo "::error::pin is not an integer"; exit 1; }
+          if [ "$PROOF_COUNT" -lt "$MINIMUM" ]; then
+            echo "::error::Kani proof count regression"
+            exit 1
+          fi
+"#;
+
+#[test]
+fn gi006_the_real_ratchet_is_caught_and_its_repair_is_clean() {
+    let r = run(
+        &[("cov.yml", &gate_wf(RATCHET_BROKEN))],
+        "Gate",
+        "cov.yml::g::Count Kani proofs | probe",
+    );
+    let f: Vec<_> = r.findings.iter().filter(|f| f.rule == "GI006").collect();
+    assert!(!f.is_empty(), "got {:?}", r.rules());
+    assert!(
+        f.iter()
+            .any(|f| f.severity == Severity::Critical && f.why.contains("PROOF_COUNT"))
+    );
+    let r = run(
+        &[("cov.yml", &gate_wf(RATCHET_FIXED))],
+        "Gate",
+        "cov.yml::g::Count Kani proofs | probe",
+    );
+    assert_clean(&r);
+}
+
+/// The llvm-cov threshold steps as they stood on main.
+const TEE_BROKEN: &str = r#"      - name: Workspace coverage (threshold gate)
+        run: |
+          cargo llvm-cov --all-features \
+            --fail-under-lines 85 \
+            --ignore-filename-regex '(tests/|kani\.rs)' 2>&1 | tee /tmp/cov.txt
+          if [ ! -s /tmp/cov.txt ]; then echo "::error::no report"; exit 1; fi
+"#;
+
+#[test]
+fn gi003_tee_under_the_default_shell_is_caught_and_shell_bash_is_clean() {
+    let r = run(
+        &[("cov.yml", &gate_wf(TEE_BROKEN))],
+        "Gate",
+        "cov.yml::g::Workspace coverage (threshold gate) | probe",
+    );
+    assert!(rules(&r).contains(&"GI003"), "got {:?}", rules(&r));
+    let fixed = TEE_BROKEN.replace("        run: |", "        shell: bash\n        run: |");
+    let r = run(
+        &[("cov.yml", &gate_wf(&fixed))],
+        "Gate",
+        "cov.yml::g::Workspace coverage (threshold gate) | probe",
+    );
+    assert_clean(&r);
+}
+
+/// Verbatim from nucleus before the repair (proofcard's REAL_BROKEN): it
+/// gated 93 theorems and could not fail.
+const AXIOM_BROKEN: &str = r#"      - name: Assert enforcement core is sorryAx-free
+        run: |
+          AXIOMS="$(lake env lean PrintAxioms.lean 2>&1 || true)"
+          echo "$AXIOMS"
+          if echo "$AXIOMS" | grep -q 'sorryAx'; then
+            echo "::error::an enforcement-core theorem depends on sorryAx."
+            exit 1
+          fi
+          echo "OK: audited enforcement-core theorems are sorryAx-free."
+"#;
+
+const AXIOM_FIXED: &str = r#"      - name: Assert enforcement core is sorryAx-free
+        run: |
+          EXPECTED=$(grep -c '^#print axioms' PrintAxioms.lean)
+          if ! AXIOMS="$(lake env lean PrintAxioms.lean 2>&1)"; then
+            echo "::error::the axiom audit did not run to completion."
+            exit 1
+          fi
+          REPORTED=$(printf '%s\n' "$AXIOMS" | grep -c "depends on axioms" || true)
+          if [ "$REPORTED" -ne "$EXPECTED" ]; then
+            echo "::error::audit incomplete: declared $EXPECTED theorems, got $REPORTED."
+            exit 1
+          fi
+          if printf '%s\n' "$AXIOMS" | grep -q 'sorryAx'; then
+            echo "::error::an enforcement-core theorem depends on sorryAx."
+            exit 1
+          fi
+"#;
+
+#[test]
+fn gi001_the_real_axiom_gate_is_caught_and_its_repair_is_clean() {
+    let key = "ax.yml::g::Assert enforcement core is sorryAx-free | probe";
+    let r = run(&[("ax.yml", &gate_wf(AXIOM_BROKEN))], "Gate", key);
+    assert!(rules(&r).contains(&"GI001"), "got {:?}", rules(&r));
+    let r = run(&[("ax.yml", &gate_wf(AXIOM_FIXED))], "Gate", key);
+    assert_clean(&r);
+}
+
+/// econ-lean.yml's sorry-ban before PR 0: a grep with no floor.
+const GREP_NO_FLOOR: &str = r#"      - name: Ban sorry
+        run: |
+          if grep -rnE 'sorry' --include='*.lean' crates/econ/lean/Nucleus; then
+            echo "ERROR: sorry"
+            exit 1
+          fi
+"#;
+
+const GREP_WITH_FLOOR: &str = r#"      - name: Ban sorry
+        run: |
+          FILES=$(find crates/econ/lean/Nucleus -name '*.lean' | wc -l | tr -d ' ')
+          if [ "$FILES" -lt 1 ]; then
+            echo "::error::scanned nothing"
+            exit 1
+          fi
+          if grep -rnE 'sorry' --include='*.lean' crates/econ/lean/Nucleus; then
+            echo "ERROR: sorry"
+            exit 1
+          fi
+"#;
+
+#[test]
+fn gi002_grep_verdict_without_a_floor_is_caught_and_the_floor_is_clean() {
+    let key = "e.yml::g::Ban sorry | probe";
+    let r = run(&[("e.yml", &gate_wf(GREP_NO_FLOOR))], "Gate", key);
+    assert!(rules(&r).contains(&"GI002"), "got {:?}", rules(&r));
+    let r = run(&[("e.yml", &gate_wf(GREP_WITH_FLOOR))], "Gate", key);
+    assert_clean(&r);
+}
+
+#[test]
+fn gi004_continue_on_error_on_a_gate_step_is_critical() {
+    let step =
+        "      - name: gate\n        continue-on-error: true\n        run: |\n          exit 1\n";
+    let r = run(
+        &[("c.yml", &gate_wf(step))],
+        "Gate",
+        "c.yml::g::gate | probe",
+    );
+    assert!(
+        r.findings
+            .iter()
+            .any(|f| f.rule == "GI004" && f.severity == Severity::Critical)
+    );
+}
+
+#[test]
+fn severity_is_scoped_to_required_contexts_but_critical_is_not() {
+    // A tee under the default shell in a NON-required job: reported, not failed.
+    let r = run(
+        &[("cov.yml", &gate_wf(TEE_BROKEN))],
+        "",
+        "cov.yml::g::Workspace coverage (threshold gate) | probe",
+    );
+    assert!(
+        r.findings
+            .iter()
+            .any(|f| f.rule == "GI003" && f.severity == Severity::Info)
+    );
+    assert_eq!(r.exit_code(), 0);
+    // A gate that cannot fail is Critical wherever it sits.
+    let r = run(
+        &[("cov.yml", &gate_wf(RATCHET_BROKEN))],
+        "",
+        "cov.yml::g::Count Kani proofs | probe",
+    );
+    assert_eq!(r.exit_code(), 1);
+}
+
+// ── I7 timeouts ───────────────────────────────────────────────────────────
+
+#[test]
+fn i7_missing_and_oversized_timeouts_are_reported() {
+    let wf = |t: &str| {
+        format!(
+            "name: T\non:\n  pull_request:\n  merge_group:\njobs:\n  a:\n    name: Audit\n    runs-on: ubuntu-latest\n{t}    steps:\n      - run: cargo audit\n"
+        )
+    };
+    let r = run(&[("a.yml", &wf(""))], "Audit", "");
+    assert!(
+        rules(&r).contains(&"CI-I7-NOTIMEOUT"),
+        "got {:?}",
+        rules(&r)
+    );
+    let r = run(&[("a.yml", &wf("    timeout-minutes: 400\n"))], "Audit", "");
+    assert!(rules(&r).contains(&"CI-I7-EXCEEDS"), "got {:?}", rules(&r));
+    let r = run(&[("a.yml", &wf("    timeout-minutes: 15\n"))], "Audit", "");
+    assert_clean(&r);
+}
+
+// ── I8 wired / inventoried ────────────────────────────────────────────────
+
+#[test]
+fn i8_unlisted_and_stale_inline_gates_are_reported() {
+    let r = run(
+        &[(
+            "c.yml",
+            &gate_wf(
+                "      - name: g\n        run: |\n          test -f x || { echo \"::error::x\"; exit 1; }\n",
+            ),
+        )],
+        "Gate",
+        "",
+    );
+    assert!(rules(&r).contains(&"CI-I8-UNLISTED"), "got {:?}", rules(&r));
+    let r = run(
+        &[(
+            "c.yml",
+            &gate_wf(
+                "      - name: g\n        run: |\n          test -f x || { echo \"::error::x\"; exit 1; }\n",
+            ),
+        )],
+        "Gate",
+        "c.yml::g::g | probe\nc.yml::g::gone | probe",
+    );
+    assert!(rules(&r).contains(&"CI-I8-STALE"), "got {:?}", rules(&r));
+}
+
+#[test]
+fn i8_unwired_gate_script_is_reported() {
+    let mut wfs = vec![(
+        ".github/workflows/filler.yml".to_string(),
+        FILLER.to_string(),
+    )];
+    wfs.push((".github/workflows/z.yml".into(), "name: Z\non:\n  pull_request:\n  merge_group:\njobs:\n  z:\n    name: Z\n    runs-on: ubuntu-latest\n    timeout-minutes: 5\n    steps:\n      - run: scripts/check-wired.sh\n".into()));
+    let ledger = "# PINNED = 2\nRustfmt\nClippy\n";
+    let inline = format!("# UNCOVERED_CEILING = 0\n{FILLER_GATES}");
+    let m = from_parts(
+        &wfs,
+        ledger,
+        QUEUE,
+        &inline,
+        "",
+        vec![
+            "scripts/check-wired.sh".into(),
+            "scripts/check-orphan.sh".into(),
+        ],
+    )
+    .unwrap();
+    let r = check(&m);
+    let unwired: Vec<_> = r
+        .findings
+        .iter()
+        .filter(|f| f.rule == "CI-I8-UNWIRED")
+        .collect();
+    assert_eq!(unwired.len(), 1);
+    assert_eq!(unwired[0].subject, "scripts/check-orphan.sh");
+}
+
+// ── I9 vacuity ────────────────────────────────────────────────────────────
+
+#[test]
+fn i9_an_empty_ledger_or_missing_pin_is_undecided_not_clean() {
+    let m = from_parts(
+        &[
+            (".github/workflows/filler.yml".into(), FILLER.into()),
+            (".github/workflows/k.yml".into(), REAL_KANI.into()),
+        ],
+        "",
+        QUEUE,
+        "# UNCOVERED_CEILING = 5\n",
+        "",
+        vec![],
+    )
+    .unwrap();
+    let r = check(&m);
+    assert!(r.findings.iter().any(|f| f.rule == "CI-I9-LEDGER"));
+    assert_ne!(r.exit_code(), 0);
+}
+
+#[test]
+fn allowlist_entries_go_stale_loudly() {
+    let wfs = vec![
+        (
+            ".github/workflows/filler.yml".to_string(),
+            FILLER.to_string(),
+        ),
+        (".github/workflows/k.yml".to_string(), REAL_KANI.to_string()),
+        (
+            ".github/workflows/k-noop.yml".to_string(),
+            noop_kani(
+                &["crates/portcullis/src/**", ".kani-minimum-proofs"],
+                "kani-noop-x",
+                false,
+            ),
+        ),
+    ];
+    let inline = format!("# UNCOVERED_CEILING = 0\n{FILLER_GATES}");
+    let m = from_parts(
+        &wfs,
+        "# PINNED = 3\nRustfmt\nClippy\nKani\n",
+        QUEUE,
+        &inline,
+        "GI003 .github/workflows/k.yml::kani-fast/x | no longer exists\n",
+        vec![],
+    )
+    .unwrap();
+    let r = check(&m);
+    assert!(
+        r.findings.iter().any(|f| f.rule == "CI-ALLOW-STALE"),
+        "got {:?}",
+        r.rules()
+    );
+}

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -20,3 +20,5 @@ serde_json = { workspace = true }
 # Constitutional gate: run ck-kernel admission on PolicyManifest amendments.
 ck-kernel = { path = "../ck-kernel" }
 ck-types = { path = "../ck-types" }
+# CI configuration invariants (`cargo xtask ci-spec`).
+ci-spec = { path = "../ci-spec" }

--- a/crates/xtask/src/ci_spec.rs
+++ b/crates/xtask/src/ci_spec.rs
@@ -1,0 +1,84 @@
+//! `cargo xtask ci-spec` — the thin I/O shell around the `ci-spec` crate.
+//!
+//! The decision (are the merge-queue invariants satisfied by this tree?)
+//! lives in `crates/ci-spec` as pure functions over a typed model, tested
+//! from in-memory fixtures. This module only reads the checkout and prints.
+
+use std::path::PathBuf;
+
+use anyhow::Result;
+
+/// `ci-spec check`: exit 0 clean, 1 violation, 2 could not look.
+pub fn check(repo: Option<String>, json: bool) -> Result<()> {
+    let root = repo_root(repo)?;
+    let model = ci_spec::loader::from_repo(&root)?;
+    let report = ci_spec::check(&model);
+    if json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        print!("{}", report.render());
+    }
+    let code = report.exit_code();
+    if code != 0 {
+        std::process::exit(code);
+    }
+    Ok(())
+}
+
+/// `ci-spec inline-gates`: print the inline-gate inventory in
+/// `ci/inline-gates.txt` shape, carrying forward any falsifier already on
+/// record so regenerating never loses an annotation.
+pub fn inline_gates(repo: Option<String>) -> Result<()> {
+    let root = repo_root(repo)?;
+    let model = ci_spec::loader::from_repo(&root)?;
+    let gates = ci_spec::invariants::wired::inline_gates(&model);
+    let mut uncovered = 0usize;
+    let mut lines = Vec::new();
+    for (key, _line, _path) in &gates {
+        let existing = model
+            .inline_gates
+            .entries
+            .get(key)
+            .cloned()
+            .filter(|v| !v.is_empty())
+            .unwrap_or_else(|| "UNCOVERED: no falsifier yet".to_string());
+        if existing.starts_with("UNCOVERED") {
+            uncovered += 1;
+        }
+        lines.push(format!("{key} | {existing}"));
+    }
+    println!(
+        "# Every inline gate step (a `run:` containing `exit 1` or `::error::`) and what\n\
+         # FALSIFIES it — a `*-falsifier` job, a check-gates-can-fail.sh probe, or a\n\
+         # `--self-test` mode — or `UNCOVERED: <reason>`.\n\
+         #\n\
+         # WHY: scripts/check-gates-can-fail.sh covers scripts/check-*.sh only. Every\n\
+         # required gate the 2026-09-05 inventory found green-by-construction (the proof\n\
+         # count ratchet, the llvm-cov thresholds) was an INLINE step, outside that\n\
+         # domain. This file puts them in one. The domain is derived by ci-spec (I8):\n\
+         # an unlisted gate is red, a stale entry is red, and UNCOVERED only shrinks.\n\
+         #\n\
+         # Regenerate with `cargo xtask ci-spec inline-gates > ci/inline-gates.txt`\n\
+         # (annotations are carried forward).\n\
+         #\n\
+         # UNCOVERED_CEILING = {uncovered}\n"
+    );
+    for l in lines {
+        println!("{l}");
+    }
+    Ok(())
+}
+
+fn repo_root(repo: Option<String>) -> Result<PathBuf> {
+    if let Some(r) = repo {
+        return Ok(PathBuf::from(r));
+    }
+    let out = std::process::Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .output()?;
+    if out.status.success() {
+        Ok(PathBuf::from(String::from_utf8(out.stdout)?.trim()))
+    } else {
+        Ok(std::env::current_dir()?)
+    }
+}

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -90,8 +90,35 @@ enum Command {
         #[arg(long)]
         json: bool,
     },
+    /// CI configuration is sound (CI-1): decide the invariants the merge queue
+    /// relies on over a typed model of the workflows, the required-check
+    /// ledger (ci/required-checks.txt) and the merge-queue pin
+    /// (ci/merge-queue.toml). Exit 0 clean, 1 violation, 2 could not look.
+    CiSpec {
+        #[command(subcommand)]
+        cmd: CiSpecCmd,
+    },
 }
 
+#[derive(Subcommand)]
+enum CiSpecCmd {
+    /// Run every invariant and report.
+    Check {
+        /// Repository root (default: the git toplevel).
+        #[arg(long)]
+        repo: Option<String>,
+        /// Emit the report as JSON.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Print the inline-gate inventory (ci/inline-gates.txt shape).
+    InlineGates {
+        #[arg(long)]
+        repo: Option<String>,
+    },
+}
+
+mod ci_spec;
 mod ci_timings;
 mod rerun_plan;
 
@@ -106,6 +133,10 @@ fn main() -> Result<()> {
         } => policy_gate(&base, &candidate, changed_files.as_deref()),
         Command::RerunPlan => rerun_plan_cmd(),
         Command::CiTimings { sha, top, json } => ci_timings::ci_timings(sha, top, json),
+        Command::CiSpec { cmd } => match cmd {
+            CiSpecCmd::Check { repo, json } => ci_spec::check(repo, json),
+            CiSpecCmd::InlineGates { repo } => ci_spec::inline_gates(repo),
+        },
     }
 }
 

--- a/scripts/check-ci-spec.sh
+++ b/scripts/check-ci-spec.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# CI configuration is sound (CI-1): the invariants the merge queue relies on,
+# decided over a typed model of the workflows, the required-check ledger and
+# the merge-queue pin. The decision lives in crates/ci-spec; this wrapper
+# exists so the gate has a `scripts/check-*.sh` identity that
+# check-gates-can-fail.sh can PROBE (perturb a twin's paths-ignore, expect
+# red; restore, expect green).
+#
+# Exit 0 clean, 1 a violation, 2 could not look — the third is never a pass.
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel 2>/dev/null || echo .)"
+exec cargo run -q -p xtask -- ci-spec check "$@"

--- a/scripts/check-gates-can-fail.sh
+++ b/scripts/check-gates-can-fail.sh
@@ -270,6 +270,31 @@ perturb_ledger_restore_false_row() {
     mv "$f.gate-tmp" "$f"
 }
 
+perturb_twin_paths_ignore() {
+    # Drop one entry from the noop twin's paths-ignore. The lists must be
+    # set-equal to the real twin's paths (ci-spec I1); a PR touching the
+    # dropped path now fires BOTH twins under one context name.
+    sed -i.gate-bak '/^      - "\.kani-minimum-proofs"$/d' "$1"
+    rm -f "$1.gate-bak"
+    if grep -q '"\.kani-minimum-proofs"' "$1"; then
+        echo "  ERROR: the kani-nightly-noop paths-ignore entry changed shape;"
+        echo "         this perturbation no longer applies and must be updated."
+        return 1
+    fi
+}
+
+perturb_cancel_in_progress() {
+    # A merge_group-triggered workflow that cancels in-flight runs
+    # unconditionally (ci-spec I4): a newer run aborts a queue entry.
+    sed -i.gate-bak 's/^  cancel-in-progress: .*$/  cancel-in-progress: true/' "$1"
+    rm -f "$1.gate-bak"
+    if ! grep -q '^  cancel-in-progress: true$' "$1"; then
+        echo "  ERROR: the zizmor.yml concurrency block changed shape;"
+        echo "         this perturbation no longer applies and must be updated."
+        return 1
+    fi
+}
+
 echo "Probing whether each gate fails on its own subject..."
 echo
 
@@ -425,6 +450,17 @@ probe check-extracted-callsites.sh "" crates/nucleus-tool-proxy/src/workload.rs 
 probe check-no-hmac-auth.sh "" crates/nucleus-node/src/auth.rs \
       "a retired NUCLEUS_NODE_AUTH_SECRET reference reintroduced" \
       perturb_no_hmac_auth
+
+# CI-1 (crates/ci-spec): the CI configuration itself. Two probes, one per
+# founding-defect class: a twin whose paths-ignore drifted from the real
+# twin's paths (both twins fire, or neither), and a merge_group-triggered
+# workflow that cancels its own in-flight runs (ejects a queue entry).
+probe check-ci-spec.sh "" .github/workflows/kani-nightly-noop.yml \
+      "a noop twin missing one of the real twin's paths" \
+      perturb_twin_paths_ignore
+probe check-ci-spec.sh "" .github/workflows/zizmor.yml \
+      "cancel-in-progress true under merge_group" \
+      perturb_cancel_in_progress
 
 probe check-kani-divergence.sh "" crates/portcullis/src/capability.rs \
       "an unlisted cfg(not(kani)) fork" \


### PR DESCRIPTION
Second PR of the "CI as a verified system" plan. Stacked on #2642 (retargets to `main` when it merges); lands after #2630.

## What

**`crates/ci-spec`** — a typed model of every workflow, the required-check ledger and the merge-queue pin, and nine invariants decided over it as pure functions (no HTTP client; observation stays in `gh`). `cargo xtask ci-spec check` exits 0 clean / 1 violation / **2 could not look** — an expression the evaluator does not model, an empty ledger or a one-workflow tree is reported as *unmeasured*, never as fine.

| | invariant | founding defect (live on 2026-09-05 unless noted) |
|---|---|---|
| I1 | twin `paths-ignore` == real `paths`; same names; distinct groups; noop not on merge_group | aeneas-ifc-scoped-noop ignored a 24-file subset; aeneas-oidc-spiffe-noop missed a file; #2399 |
| I2 | one twin pair per required context | "Scoped Aeneas (Rust → Lean 4)…" from four jobs |
| I3 | reported under merge_group, not skippable: `if:` not false there, every `needs:` itself required | Tests/Fuzz/OWASP/llvm-cov/Mutation/Ratchet hung off two non-required detectors |
| I4 | no shared concurrency group; never cancel merge_group/push | zizmor.yml, feature-matrix.yml |
| I5 | scope PATTERN ⊇ declared paths | #2358 |
| I6 | gate integrity — proofcard GI001–GI005 + **GI006** numeric test on an unestablished operand | Proof Count Ratchet (`grep -rc` on a dir → `$((…))` division by zero → empty → `[ "" -lt 72 ]` → pass); llvm-cov `\| tee` |
| I7 | timeouts inside the queue's check budget, including `needs:` chains | the 60-min timeout ejections of 2026-09-04 |
| I8 | every gate script wired; every **inline** gate inventoried with its falsifier or UNCOVERED under a shrink-only ceiling | `check-test-helpers-not-in-production.sh` invoked by nothing; the gate of gates never saw inline steps |
| I9 | the model is non-vacuous | `check-lean-libs-built.sh`'s bash-3.2 false green |

GI006 corrects a claim in proofcard: `[ "$V" -ne "$E" ]` is **not** fail-closed on an empty `$V` — `[` returns 2 and `if` reads that as false. Only string comparisons are. The rule tracks whether an operand's producer is integer-guaranteed (`wc -l`, `grep -c FILE`) or not (`$(( ))` over a `grep -rc DIR`, `cat pin`).

**Severity is scoped**: Critical fails anywhere (a gate that cannot fail is a false claim wherever it sits); High/Medium fail only on jobs producing a required context and are *reported* elsewhere. The allowlist carries a reason per entry and goes stale loudly.

**Ledgers**: `ci/required-checks.txt` (48 contexts, PINNED grow-only), `ci/merge-queue.toml` (the constants the Lean capacity theorem will take as hypotheses), `ci/inline-gates.txt` (75 inline gates, all UNCOVERED today — honest accounting, ceiling 75, may only shrink), `ci/gate-integrity-allowlist.txt` (5 entries: two cross-step-dataflow limits, three ratchet sites #2630 replaces — those go stale the moment it merges).

**Wiring**: ci.yml job `CI configuration is sound (CI-1)` via `scripts/check-ci-spec.sh`; two probes in `check-gates-can-fail.sh` (drop an entry from a twin's ignore list; make a merge_group workflow cancel unconditionally).

**Tree repairs the checker demanded**: `timeout-minutes` on `audit`, `deny`, `Scan PodSpecs`.

## Verification
- `cargo test -p ci-spec`: 22 founding-defect fixtures, each two-sided (fires on the defect, silent on the repair) — the real ratchet step, the real tee step, proofcard's verbatim broken/fixed axiom gate, the econ grep, the four-producer context, the drifted twins, the detector vacuity, both queue-cancelling expressions.
- `cargo xtask ci-spec check` on this tree (#2642 + this): `ok: every invariant holds`, 60 workflows / 123 jobs / 75 inline gates / 48 contexts. On `main` before #2642 it reports every live defect above.
- `scripts/check-gates-can-fail.sh`: `OK: every probed gate REDs on its own subject and GREENs when restored` (19 probes, UNACCOUNTED = 0).
- `cargo clippy -p ci-spec -p xtask --all-targets -D warnings` clean; actionlint clean.

## Follow-ups (owner, after #2642 merges)
Add the three new required contexts (`Scoped Aeneas OIDC→SPIFFE …`, `Detect changed crates`, `Detect Changed Crates`) to branch protection; the ledger already lists them, and PR 2's `live-parity` job will hold the two in lockstep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZaH5waz88vL1qfNpFNfZ4
