### PR TITLE
ci(assurance): required-check ledger and merge-queue pin held in lockstep with GitHub (live-parity on a schedule)

### DIFF
--- a/.github/workflows/ci-assurance.yml
+++ b/.github/workflows/ci-assurance.yml
@@ -1,0 +1,87 @@
+name: CI assurance
+
+# The tree's two claims about GitHub's configuration — ci/required-checks.txt
+# (the required status-check contexts) and ci/merge-queue.toml (the
+# merge-queue ruleset constants) — held in lockstep with what GitHub
+# actually enforces. Every ci-spec invariant reasons from those files; drift
+# means the invariants are about a configuration nobody runs.
+#
+# Runs on a schedule (a UI edit to branch protection or the ruleset has no
+# commit to trigger on), on dispatch, and on a push to main that touches
+# either ledger. Drift opens or updates an issue, so a silent UI change
+# becomes a visible red within 30 minutes.
+#
+# TOKEN: reading branch protection needs repository "Administration: read",
+# which GITHUB_TOKEN does not have. The job uses the CI_ASSURANCE_TOKEN
+# secret (a fine-grained PAT: Administration read + Metadata read). Without
+# it the check exits 2 — "could not look" — and the job is RED, never green:
+# a parity check that passes because it could not see would be the vacuity
+# it exists to find.
+
+on:
+  schedule:
+    - cron: "17,47 * * * *"
+  workflow_dispatch:
+  push:
+    branches: ["main"]
+    paths:
+      - "ci/required-checks.txt"
+      - "ci/merge-queue.toml"
+      - "crates/ci-spec/src/live.rs"
+      - ".github/workflows/ci-assurance.yml"
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: ci-assurance-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  live-parity:
+    name: Required-check ledger and merge-queue pin match GitHub
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
+        with:
+          cache: ${{ runner.environment == 'github-hosted' }}
+      - name: Ledger == branch protection; queue pin == ruleset
+        id: parity
+        shell: bash
+        env:
+          # Falls back to GITHUB_TOKEN, which CANNOT read protection: the
+          # step then exits 2 and the job is red with the reason printed.
+          GH_TOKEN: ${{ secrets.CI_ASSURANCE_TOKEN || github.token }}
+        run: |
+          set -o pipefail
+          rc=0
+          cargo run -q -p xtask -- ci-spec live-parity 2>&1 | tee /tmp/live-parity.txt || rc=$?
+          echo "rc=$rc" >> "$GITHUB_OUTPUT"
+          if [ "$rc" -eq 2 ]; then
+            echo "::error::live-parity could not look (exit 2) — not a pass. Is CI_ASSURANCE_TOKEN set?"
+            exit 1
+          fi
+          if [ "$rc" -ne 0 ]; then
+            echo "::error::the required-check ledger or the merge-queue pin drifted from GitHub (exit $rc)"
+            exit 1
+          fi
+      - name: Open or update the drift issue
+        if: ${{ failure() && github.event_name != 'pull_request' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RC: ${{ steps.parity.outputs.rc }}
+        run: |
+          title="ci-assurance: required-check ledger / merge-queue pin drifted from GitHub"
+          body="$(printf '%s\n\n```\n%s\n```\n\nRun: %s\n' \
+            "Scheduled live-parity found drift (exit ${RC:-?}; 2 = could not look, usually a missing CI_ASSURANCE_TOKEN)." \
+            "$(tail -60 /tmp/live-parity.txt 2>/dev/null || echo '(no output captured)')" \
+            "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}")"
+          n=$(gh issue list --state open --search "\"$title\" in:title" --json number --jq '.[0].number' || true)
+          if [ -n "$n" ]; then
+            gh issue comment "$n" --body "$body"
+          else
+            gh issue create --title "$title" --label ci --body "$body" || gh issue create --title "$title" --body "$body"
+          fi

--- a/ci/inline-gates.txt
+++ b/ci/inline-gates.txt
@@ -41,6 +41,7 @@ aeneas-oidc-spiffe.yml::aeneas-oidc-spiffe::Reject sorry (proof holes) | UNCOVER
 aeneas.yml::aeneas-translate::Aeneas Lean 4 translation | UNCOVERED: no falsifier yet
 aeneas.yml::aeneas-translate::Verify generated Lean matches committed | UNCOVERED: no falsifier yet
 aeneas.yml::aeneas-translate::Reject sorry (proof holes) | UNCOVERED: no falsifier yet
+ci-assurance.yml::live-parity::Ledger == branch protection; queue pin == ruleset | falsified by crates/ci-spec/tests/live_parity.rs (CI-LP-MISSING/EXTRA/QUEUE/STRICT/VACUOUS fixtures); exit 2 is red in the step
 ck-policy-aeneas.yml::ck-policy-aeneas::Verify generated Lean matches committed (drift gate) | UNCOVERED: no falsifier yet
 ck-policy-aeneas.yml::ck-policy-aeneas::Ban sorry / admit / native_decide in our proof file | UNCOVERED: no falsifier yet
 ck-policy-lean.yml::ck-policy-lean::Ban sorry / admit / native_decide / sorryAx in ck-policy Lean | UNCOVERED: no falsifier yet

--- a/crates/ci-spec/src/lib.rs
+++ b/crates/ci-spec/src/lib.rs
@@ -48,6 +48,7 @@ use serde::Serialize;
 
 pub mod expr;
 pub mod invariants;
+pub mod live;
 pub mod loader;
 pub mod model;
 

--- a/crates/ci-spec/src/live.rs
+++ b/crates/ci-spec/src/live.rs
@@ -1,0 +1,280 @@
+//! Live parity: the tree's ledgers against what GitHub actually enforces.
+//!
+//! Two files in the tree claim to describe GitHub's configuration —
+//! `ci/required-checks.txt` (the required status-check contexts) and
+//! `ci/merge-queue.toml` (the merge-queue ruleset constants). Every
+//! invariant in this crate reasons from those files; if they drift from the
+//! live settings, the invariants are about a configuration nobody runs.
+//! The North Star ledger has the same discipline ("a status table cannot
+//! outrun its wiring"); this is the CI version of it.
+//!
+//! Observation is NOT here — the caller (`cargo xtask ci-spec live-parity`)
+//! fetches `GET /repos/{o}/{r}/branches/main/protection` and
+//! `GET /repos/{o}/{r}/rulesets/{id}` with `gh api` and hands the JSON in.
+//! This module only parses and decides, so it is testable without a network
+//! and without an admin token. A fetch that fails is exit 2 ("could not
+//! look") at the caller, never a pass.
+
+use serde::Deserialize;
+
+use crate::invariants::finding;
+use crate::model::Model;
+use crate::{Finding, Severity};
+
+/// What `GET /branches/{branch}/protection` says about required checks.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LiveProtection {
+    pub strict: bool,
+    pub contexts: Vec<String>,
+}
+
+/// What `GET /rulesets/{id}` says about the merge queue.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct LiveQueue {
+    pub check_response_timeout_minutes: u64,
+    pub max_entries_to_build: u64,
+    pub max_entries_to_merge: u64,
+    pub min_entries_to_merge: u64,
+    pub min_entries_to_merge_wait_minutes: u64,
+    pub grouping_strategy: String,
+    pub merge_method: String,
+}
+
+#[derive(Deserialize)]
+struct ProtectionJson {
+    required_status_checks: Option<RscJson>,
+}
+#[derive(Deserialize)]
+struct RscJson {
+    strict: bool,
+    #[serde(default)]
+    contexts: Vec<String>,
+    #[serde(default)]
+    checks: Vec<CheckJson>,
+}
+#[derive(Deserialize)]
+struct CheckJson {
+    context: String,
+}
+
+/// Parse the branch-protection response. The `checks[].context` list is
+/// authoritative (it is what the merge rollup evaluates); `contexts` is the
+/// legacy mirror and is unioned in so a partial response cannot read as
+/// fewer requirements.
+pub fn parse_protection(json: &str) -> Result<LiveProtection, String> {
+    let p: ProtectionJson =
+        serde_json::from_str(json).map_err(|e| format!("protection JSON: {e}"))?;
+    let Some(r) = p.required_status_checks else {
+        return Err("branch protection has no required_status_checks block".into());
+    };
+    let mut contexts: Vec<String> = r.checks.into_iter().map(|c| c.context).collect();
+    for c in r.contexts {
+        if !contexts.contains(&c) {
+            contexts.push(c);
+        }
+    }
+    contexts.sort();
+    Ok(LiveProtection {
+        strict: r.strict,
+        contexts,
+    })
+}
+
+#[derive(Deserialize)]
+struct RulesetJson {
+    id: u64,
+    enforcement: String,
+    rules: Vec<RuleJson>,
+}
+#[derive(Deserialize)]
+struct RuleJson {
+    #[serde(rename = "type")]
+    kind: String,
+    parameters: Option<serde_json::Value>,
+}
+
+/// Parse the ruleset response: the one `merge_queue` rule's parameters.
+pub fn parse_ruleset(json: &str, expected_id: u64) -> Result<LiveQueue, String> {
+    let r: RulesetJson = serde_json::from_str(json).map_err(|e| format!("ruleset JSON: {e}"))?;
+    if r.id != expected_id {
+        return Err(format!("ruleset id {} ≠ pinned {expected_id}", r.id));
+    }
+    if r.enforcement != "active" {
+        return Err(format!(
+            "ruleset {} enforcement is {:?}, not active",
+            r.id, r.enforcement
+        ));
+    }
+    let mq: Vec<&RuleJson> = r.rules.iter().filter(|x| x.kind == "merge_queue").collect();
+    if mq.len() != 1 {
+        return Err(format!(
+            "ruleset has {} merge_queue rules, expected 1",
+            mq.len()
+        ));
+    }
+    let params = mq[0]
+        .parameters
+        .clone()
+        .ok_or_else(|| "merge_queue rule has no parameters".to_string())?;
+    serde_json::from_value(params).map_err(|e| format!("merge_queue parameters: {e}"))
+}
+
+/// Decide parity: ledger == live protection, and the queue pin == the
+/// live ruleset. Both directions on the contexts — a live requirement the
+/// ledger does not know about means every invariant here was decided over
+/// an incomplete set.
+pub fn parity(m: &Model, live: &LiveProtection, queue: &LiveQueue) -> Vec<Finding> {
+    let mut out = Vec::new();
+    const F: &str = "ci/required-checks.txt";
+
+    if live.contexts.len() < 2 {
+        out.push(finding(
+            "CI-LP-VACUOUS",
+            Severity::Undecided,
+            F,
+            0,
+            "live protection",
+            format!(
+                "GitHub reports {} required context(s) — either protection was removed or the \
+                 response was partial; nothing below can be compared",
+                live.contexts.len()
+            ),
+            "check the token's permissions and the branch-protection settings",
+        ));
+        return out;
+    }
+
+    for c in &m.ledger.contexts {
+        if !live.contexts.contains(c) {
+            out.push(finding(
+                "CI-LP-MISSING",
+                Severity::Critical,
+                F,
+                0,
+                c,
+                "the ledger lists this context as required but GitHub does not enforce it: \
+                 every invariant decided over the ledger assumes a gate the merge rollup never \
+                 consults"
+                    .into(),
+                "add it to branch protection (`gh api -X PATCH …/protection/required_status_checks`) \
+                 or, if it was retired on purpose, remove it from the ledger with a dated note and \
+                 lower the pin",
+            ));
+        }
+    }
+    for c in &live.contexts {
+        if !m.is_required(c) {
+            out.push(finding(
+                "CI-LP-EXTRA",
+                Severity::Critical,
+                F,
+                0,
+                c,
+                "GitHub requires this context but the ledger does not list it: the producer, \
+                 twin and merge_group invariants were never checked for it"
+                    .into(),
+                "add it to ci/required-checks.txt and raise the pin",
+            ));
+        }
+    }
+
+    const Q: &str = "ci/merge-queue.toml";
+    let p = &m.queue;
+    let diffs: Vec<(&str, String, String)> = [
+        (
+            "check_response_timeout_minutes",
+            p.check_response_timeout_minutes.to_string(),
+            queue.check_response_timeout_minutes.to_string(),
+        ),
+        (
+            "max_entries_to_build",
+            p.max_entries_to_build.to_string(),
+            queue.max_entries_to_build.to_string(),
+        ),
+        (
+            "max_entries_to_merge",
+            p.max_entries_to_merge.to_string(),
+            queue.max_entries_to_merge.to_string(),
+        ),
+        (
+            "min_entries_to_merge",
+            p.min_entries_to_merge.to_string(),
+            queue.min_entries_to_merge.to_string(),
+        ),
+        (
+            "min_entries_to_merge_wait_minutes",
+            p.min_entries_to_merge_wait_minutes.to_string(),
+            queue.min_entries_to_merge_wait_minutes.to_string(),
+        ),
+        (
+            "grouping_strategy",
+            p.grouping_strategy.clone(),
+            queue.grouping_strategy.clone(),
+        ),
+        (
+            "merge_method",
+            p.merge_method.clone(),
+            queue.merge_method.clone(),
+        ),
+    ]
+    .into_iter()
+    .filter(|(_, a, b)| a != b)
+    .collect();
+    for (k, pinned, live_v) in diffs {
+        out.push(finding(
+            "CI-LP-QUEUE",
+            Severity::Critical,
+            Q,
+            0,
+            k,
+            format!(
+                "pinned {k} = {pinned} but the live ruleset says {live_v}: the capacity theorem's \
+                 hypotheses and the timeout invariant (I7) are about a queue that is not the one \
+                 running"
+            ),
+            "change the pin in the same PR that justifies the new setting, or revert the UI edit",
+        ));
+    }
+    if p.strict != live.strict {
+        out.push(finding(
+            "CI-LP-STRICT",
+            Severity::Critical,
+            Q,
+            0,
+            "strict",
+            format!(
+                "pinned strict = {} but branch protection says {}: `strict = true` with a queue \
+                 forces a rebase before every merge, the livelock of 2026-09-04",
+                p.strict, live.strict
+            ),
+            "align the pin and the setting",
+        ));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn protection_unions_checks_and_contexts() {
+        let j = r#"{"required_status_checks":{"strict":false,"contexts":["A","B"],"checks":[{"context":"B","app_id":1},{"context":"C","app_id":1}]}}"#;
+        let p = parse_protection(j).unwrap();
+        assert_eq!(p.contexts, vec!["A", "B", "C"]);
+        assert!(!p.strict);
+    }
+
+    #[test]
+    fn ruleset_requires_one_active_merge_queue_rule() {
+        let j = r#"{"id":1,"enforcement":"active","rules":[{"type":"merge_queue","parameters":{"check_response_timeout_minutes":360,"grouping_strategy":"ALLGREEN","max_entries_to_build":1,"max_entries_to_merge":1,"merge_method":"SQUASH","min_entries_to_merge":1,"min_entries_to_merge_wait_minutes":0}}]}"#;
+        let q = parse_ruleset(j, 1).unwrap();
+        assert_eq!(q.max_entries_to_build, 1);
+        assert!(parse_ruleset(j, 2).is_err(), "wrong id must not parse");
+        let off = j.replace("\"active\"", "\"disabled\"");
+        assert!(
+            parse_ruleset(&off, 1).is_err(),
+            "a disabled ruleset is not a queue"
+        );
+    }
+}

--- a/crates/ci-spec/tests/live_parity.rs
+++ b/crates/ci-spec/tests/live_parity.rs
@@ -1,0 +1,158 @@
+//! Live parity, tested on the drift shapes it exists for: a context the
+//! ledger lists that GitHub does not require (the three contexts PR #2642
+//! introduced, before the admin step), a context GitHub requires that the
+//! ledger never heard of, a queue constant edited in the UI (the 60-minute
+//! timeout of 2026-09-04), and `strict` flipped.
+
+use ci_spec::Severity;
+use ci_spec::live::{LiveProtection, LiveQueue, parity};
+use ci_spec::loader::from_parts;
+
+const QUEUE: &str = r#"
+ruleset_id = 22351600
+check_response_timeout_minutes = 360
+max_entries_to_build = 1
+max_entries_to_merge = 1
+min_entries_to_merge = 1
+min_entries_to_merge_wait_minutes = 0
+grouping_strategy = "ALLGREEN"
+merge_method = "SQUASH"
+strict = false
+"#;
+
+const WF: &str = r#"
+name: CI
+on:
+  pull_request:
+  merge_group:
+jobs:
+  a:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - run: cargo fmt --check
+  b:
+    name: Clippy
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - run: cargo clippy
+"#;
+
+fn model(ledger: &[&str]) -> ci_spec::model::Model {
+    let mut l = format!("# PINNED = {}\n", ledger.len());
+    for c in ledger {
+        l.push_str(c);
+        l.push('\n');
+    }
+    from_parts(
+        &[
+            (".github/workflows/ci.yml".into(), WF.into()),
+            (
+                ".github/workflows/other.yml".into(),
+                WF.replace("name: CI", "name: Other")
+                    .replace("Rustfmt", "X")
+                    .replace("Clippy", "Y"),
+            ),
+        ],
+        &l,
+        QUEUE,
+        "# UNCOVERED_CEILING = 0\n",
+        "",
+        vec![],
+    )
+    .unwrap()
+}
+
+fn live(contexts: &[&str], strict: bool) -> LiveProtection {
+    LiveProtection {
+        strict,
+        contexts: contexts.iter().map(|s| s.to_string()).collect(),
+    }
+}
+
+fn queue() -> LiveQueue {
+    LiveQueue {
+        check_response_timeout_minutes: 360,
+        max_entries_to_build: 1,
+        max_entries_to_merge: 1,
+        min_entries_to_merge: 1,
+        min_entries_to_merge_wait_minutes: 0,
+        grouping_strategy: "ALLGREEN".into(),
+        merge_method: "SQUASH".into(),
+    }
+}
+
+fn rules(f: &[ci_spec::Finding]) -> Vec<&'static str> {
+    let mut v: Vec<&'static str> = f.iter().map(|x| x.rule).collect();
+    v.sort_unstable();
+    v.dedup();
+    v
+}
+
+#[test]
+fn lockstep_is_clean() {
+    let f = parity(
+        &model(&["Rustfmt", "Clippy"]),
+        &live(&["Clippy", "Rustfmt"], false),
+        &queue(),
+    );
+    assert!(f.is_empty(), "{f:#?}");
+}
+
+#[test]
+fn ledger_context_github_does_not_require_is_missing() {
+    let f = parity(
+        &model(&["Rustfmt", "Clippy", "Detect changed crates"]),
+        &live(&["Clippy", "Rustfmt"], false),
+        &queue(),
+    );
+    assert_eq!(rules(&f), vec!["CI-LP-MISSING"]);
+    assert_eq!(f[0].subject, "Detect changed crates");
+    assert_eq!(f[0].severity, Severity::Critical);
+}
+
+#[test]
+fn github_context_the_ledger_never_heard_of_is_extra() {
+    let f = parity(
+        &model(&["Rustfmt", "Clippy"]),
+        &live(&["Clippy", "Rustfmt", "Mystery"], false),
+        &queue(),
+    );
+    assert_eq!(rules(&f), vec!["CI-LP-EXTRA"]);
+}
+
+#[test]
+fn a_ui_edit_to_the_queue_timeout_is_drift() {
+    let mut q = queue();
+    q.check_response_timeout_minutes = 60;
+    let f = parity(
+        &model(&["Rustfmt", "Clippy"]),
+        &live(&["Clippy", "Rustfmt"], false),
+        &q,
+    );
+    assert_eq!(rules(&f), vec!["CI-LP-QUEUE"]);
+    assert!(f[0].why.contains("60"));
+}
+
+#[test]
+fn strict_flipped_is_drift() {
+    let f = parity(
+        &model(&["Rustfmt", "Clippy"]),
+        &live(&["Clippy", "Rustfmt"], true),
+        &queue(),
+    );
+    assert_eq!(rules(&f), vec!["CI-LP-STRICT"]);
+}
+
+#[test]
+fn a_partial_protection_response_is_undecided_not_clean() {
+    let f = parity(
+        &model(&["Rustfmt", "Clippy"]),
+        &live(&["Rustfmt"], false),
+        &queue(),
+    );
+    assert_eq!(rules(&f), vec!["CI-LP-VACUOUS"]);
+    assert_eq!(f[0].severity, Severity::Undecided);
+}

--- a/crates/xtask/src/ci_spec.rs
+++ b/crates/xtask/src/ci_spec.rs
@@ -82,3 +82,78 @@ fn repo_root(repo: Option<String>) -> Result<PathBuf> {
         Ok(std::env::current_dir()?)
     }
 }
+
+/// `ci-spec live-parity`: the ledgers against GitHub. Exit 0 in lockstep,
+/// 1 drift, 2 could not look (no token, API error, partial response).
+pub fn live_parity(repo: Option<String>, github: &str, json: bool) -> Result<()> {
+    let root = repo_root(repo)?;
+    let model = ci_spec::loader::from_repo(&root)?;
+
+    let fetch = |path: &str| -> Result<String, String> {
+        let out = std::process::Command::new("gh")
+            .args(["api", path])
+            .output()
+            .map_err(|e| format!("run gh api {path}: {e}"))?;
+        if !out.status.success() {
+            return Err(format!(
+                "gh api {path} failed ({}): {}",
+                out.status,
+                String::from_utf8_lossy(&out.stderr).trim()
+            ));
+        }
+        String::from_utf8(out.stdout).map_err(|e| e.to_string())
+    };
+
+    let looked =
+        (|| -> Result<(ci_spec::live::LiveProtection, ci_spec::live::LiveQueue), String> {
+            let prot = fetch(&format!("repos/{github}/branches/main/protection"))?;
+            let rs = fetch(&format!(
+                "repos/{github}/rulesets/{}",
+                model.queue.ruleset_id
+            ))?;
+            Ok((
+                ci_spec::live::parse_protection(&prot)?,
+                ci_spec::live::parse_ruleset(&rs, model.queue.ruleset_id)?,
+            ))
+        })();
+
+    let (live, queue) = match looked {
+        Ok(v) => v,
+        Err(e) => {
+            // "Could not look" is exit 2 and a red job — reporting it as a
+            // pass would be the exact vacuity the parity check exists to find.
+            eprintln!("::error::live-parity could not look: {e}");
+            eprintln!(
+                "  (reading branch protection needs a token with repository Administration: \
+                 read — set CI_ASSURANCE_TOKEN; GITHUB_TOKEN cannot)"
+            );
+            std::process::exit(2);
+        }
+    };
+
+    let findings = ci_spec::live::parity(&model, &live, &queue);
+    let report = ci_spec::Report {
+        workflows: model.workflows.len(),
+        jobs: model.workflows.iter().map(|w| w.jobs.len()).sum(),
+        gates: 0,
+        required_contexts: model.ledger.contexts.len(),
+        findings,
+    };
+    if json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        println!(
+            "live-parity: ledger {} contexts, GitHub {} contexts, strict pinned={} live={}",
+            model.ledger.contexts.len(),
+            live.contexts.len(),
+            model.queue.strict,
+            live.strict
+        );
+        print!("{}", report.render());
+    }
+    let code = report.exit_code();
+    if code != 0 {
+        std::process::exit(code);
+    }
+    Ok(())
+}

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -116,6 +116,19 @@ enum CiSpecCmd {
         #[arg(long)]
         repo: Option<String>,
     },
+    /// Live parity: ci/required-checks.txt == GitHub branch protection, and
+    /// ci/merge-queue.toml == the live merge-queue ruleset. Observation via
+    /// `gh api` (needs a token that can read branch protection); a fetch
+    /// that fails is exit 2, never a pass.
+    LiveParity {
+        #[arg(long)]
+        repo: Option<String>,
+        /// GitHub repository, owner/name.
+        #[arg(long, default_value = "coproduct-opensource/nucleus")]
+        github: String,
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 mod ci_spec;
@@ -136,6 +149,9 @@ fn main() -> Result<()> {
         Command::CiSpec { cmd } => match cmd {
             CiSpecCmd::Check { repo, json } => ci_spec::check(repo, json),
             CiSpecCmd::InlineGates { repo } => ci_spec::inline_gates(repo),
+            CiSpecCmd::LiveParity { repo, github, json } => {
+                ci_spec::live_parity(repo, &github, json)
+            }
         },
     }
 }


### PR DESCRIPTION
Third PR of the "CI as a verified system" plan. Stacked on #2643 (which is stacked on #2642).

## What
`ci/required-checks.txt` and `ci/merge-queue.toml` are the tree's claims about GitHub's configuration, and every `ci-spec` invariant reasons from them. A UI edit to branch protection or the ruleset has no commit to review. This holds the two in lockstep:

- **`ci_spec::live`** — parses `GET /branches/main/protection` (the `checks[].context` list, unioned with the legacy `contexts`, plus `strict`) and `GET /rulesets/22351600` (the one active `merge_queue` rule), then decides: `CI-LP-MISSING`, `CI-LP-EXTRA`, `CI-LP-QUEUE`, `CI-LP-STRICT`, `CI-LP-VACUOUS` (fewer than two live contexts is a partial response, reported as *undecided*, never clean). Pure; six fixtures.
- **`cargo xtask ci-spec live-parity`** — the I/O shell (two `gh api` calls). A fetch that fails is **exit 2 and a red job**: reading branch protection needs repository *Administration: read*, which `GITHUB_TOKEN` lacks, and a parity check that passed because it could not see would be the vacuity it exists to find.
- **`.github/workflows/ci-assurance.yml`** — every 30 min, on dispatch, and on a push to `main` touching either ledger; opens or updates an issue on drift.

## Run against GitHub right now
```
live-parity: ledger 48 contexts, GitHub 45 contexts, strict pinned=false live=false
  CRITICAL [CI-LP-MISSING] Detect changed crates
  CRITICAL [CI-LP-MISSING] Detect Changed Crates
  CRITICAL [CI-LP-MISSING] Scoped Aeneas OIDC→SPIFFE (Rust → Lean 4) + parity tests
```
Exactly the three contexts #2642 introduces; they are added to branch protection when it merges, and this job is what keeps that true afterwards.

## Owner action
Create the repository secret **`CI_ASSURANCE_TOKEN`** (fine-grained PAT: *Administration: read*, *Metadata: read*). Until it exists the scheduled job is red by design, with the reason printed.

## Verification
- `cargo test -p ci-spec`: 39 tests (11 unit, 22 founding-defect, 6 live-parity).
- `cargo xtask ci-spec check`: `ok: every invariant holds`; the new inline gate is inventoried with its falsifier (the fixtures + exit-2-is-red), ceiling unchanged at 75.
- actionlint clean; clippy `-D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZaH5waz88vL1qfNpFNfZ4
