### PR TITLE
formal(ci): the CI pipeline and merge queue as a Mathlib-free Lean model, with the 2026-09-05 defects as machine-checked bites

### DIFF
--- a/.github/workflows/ci-spec-lean-noop.yml
+++ b/.github/workflows/ci-spec-lean-noop.yml
@@ -1,0 +1,35 @@
+name: CI Spec Lean Proofs
+
+# NO-OP TWIN of ci-spec-lean.yml, so its job can be a REQUIRED status check.
+# Branch protection evaluates required contexts on the PR itself; the real
+# workflow is path-filtered on pull_request, so a PR not touching its paths
+# would never report the context and block forever. This twin has the SAME
+# workflow name and SAME job name, with `paths-ignore` exactly mirroring the
+# original's `paths` — ci-spec I1 checks that equality, and
+# ci/lean/CiSpec/Pipeline.lean (`twin_covers`) is the theorem that says why
+# it must hold. (merge_group is NOT twinned — the real workflow already runs
+# unconditionally there.)
+
+on:
+  pull_request:
+    paths-ignore:
+      - "ci/lean/**"
+      - "scripts/check-ci-spec-bite.sh"
+      - ".github/workflows/ci-spec-lean.yml"
+
+concurrency:
+  # Supersede a PR's older in-flight runs; NEVER cancel anything else.
+  group: ci-spec-lean-noop-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  ci-spec-lean:
+    name: lake build CiSpec (pipeline + merge-queue theorems)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: No-op (paths not touched)
+        run: echo "no relevant paths changed — gate vacuously green"

--- a/.github/workflows/ci-spec-lean.yml
+++ b/.github/workflows/ci-spec-lean.yml
@@ -1,0 +1,159 @@
+name: CI Spec Lean Proofs
+
+# Builds the Mathlib-free Lean model of this repository's CI pipeline and
+# merge queue (ci/lean: `CiSpec` — twin coverage, required-verdict soundness,
+# queue accounting/order/cancel-safety/push; `CiSpecBite` — the same theorems
+# with one hypothesis dropped, proving the 2026-09-05 defects reachable), bans
+# `sorry` / `admit` / `native_decide` / `sorryAx`, runs the per-theorem axiom
+# audit, and enforces the bite's no-new-semantics rule. The invariants
+# `crates/ci-spec` DECIDES are the theorems' hypotheses; this is the file that
+# keeps "ci-spec is sound" a proved claim rather than a comment.
+# Cloned from ck-policy-lean.yml (path isolation, scope gate, elan + lake).
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "ci/lean/**"
+      - "scripts/check-ci-spec-bite.sh"
+      - ".github/workflows/ci-spec-lean.yml"
+  pull_request:
+    paths:
+      - "ci/lean/**"
+      - "scripts/check-ci-spec-bite.sh"
+      - ".github/workflows/ci-spec-lean.yml"
+  merge_group:
+  workflow_dispatch:
+
+concurrency:
+  # Supersede a PR's older in-flight runs; NEVER cancel anything else.
+  # cancel-in-progress is scoped to pull_request on purpose: cancelling a
+  # merge_group run would abort a queue entry mid-flight, and cancelling a
+  # push to main would drop the signal for a commit that already landed.
+  group: ci-spec-lean-real-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  ci-spec-lean:
+    name: lake build CiSpec (pipeline + merge-queue theorems)
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      # `paths:` under `merge_group:` is accepted by the YAML schema and then
+      # IGNORED by GitHub, so the scoping above holds on pull_request and is
+      # dropped in the queue. This restores it for merge_group only; on every
+      # other event GitHub's own filter already decided. PATTERN is derived
+      # from the paths above and ci/merge-group-scope-parity.sh (and ci-spec
+      # I5) keep the two in agreement.
+      - name: Is this change in scope?
+        id: scope
+        env:
+          EVENT: ${{ github.event_name }}
+          BASE: ${{ github.event.merge_group.base_sha }}
+          HEAD: ${{ github.event.merge_group.head_sha }}
+          PATTERN: '^ci/lean/|^scripts/check-ci-spec-bite\.sh$|^\.github/workflows/ci-spec-lean\.yml$'
+        run: |
+          set -euo pipefail
+          if [ "$EVENT" != "merge_group" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            echo "$EVENT: GitHub's own paths: filter already applied."
+            exit 0
+          fi
+          if [ -z "${BASE:-}" ] || [ -z "${HEAD:-}" ]; then
+            # Fail OPEN: an unknown range must run the proofs, never skip them.
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            echo "merge_group with no base/head sha — running to be safe."
+            exit 0
+          fi
+          if git diff --name-only "$BASE" "$HEAD" | grep -qE "$PATTERN"; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            echo "in scope — running."
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+            echo "no file in this merge group matches $PATTERN — skipping the"
+            echo "expensive steps. This job still reports, so it remains usable"
+            echo "as a required status check."
+          fi
+
+      - name: Install elan (Lean toolchain)
+        if: runner.environment == 'github-hosted' && (steps.scope.outputs.relevant == 'true')
+        run: |
+          curl -sSf https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
+            | sh -s -- -y --no-modify-path
+          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+
+      - name: Cache Lake build artifacts
+        if: ${{ runner.environment == 'github-hosted' && (steps.scope.outputs.relevant == 'true') }}
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
+        with:
+          path: |
+            ci/lean/.lake
+            ~/.elan
+          key: lean-ci-spec-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('ci/lean/lean-toolchain', 'ci/lean/lakefile.lean') }}
+          restore-keys: |
+            lean-ci-spec-${{ runner.os }}-${{ runner.arch }}-
+
+      # Both libraries by name: check-lean-libs-built.sh reads this line, and a
+      # bare `lake build` would build only the default target.
+      - name: lake build CiSpec CiSpecBite
+        if: steps.scope.outputs.relevant == 'true'
+        working-directory: ci/lean
+        run: LEAN_NUM_THREADS=${{ runner.environment == 'github-hosted' && '4' || '3' }} lake build CiSpec CiSpecBite
+
+      - name: Ban sorry / admit / native_decide / sorryAx in the CI model
+        if: steps.scope.outputs.relevant == 'true'
+        run: |
+          # Non-vacuity FIRST: a grep over a path that no longer matches exits
+          # non-zero, takes the else branch, and prints the success line having
+          # scanned NOTHING. Establish that there is something to scan.
+          FILES=$(find ci/lean/CiSpec ci/lean/CiSpec.lean ci/lean/CiSpecBite.lean -name '*.lean' | wc -l | tr -d ' ')
+          if [ "$FILES" -lt 3 ]; then
+            echo "::error::only $FILES .lean file(s) under ci/lean — the CI-model sorry-ban scanned nothing."
+            exit 1
+          fi
+          echo "scanning $FILES .lean file(s) under ci/lean"
+          if grep -rnE \
+               '(:=[[:space:]]*by[[:space:]]+sorry|:=[[:space:]]*sorry|^[[:space:]]*sorry$|:=[[:space:]]*by[[:space:]]+admit|^[[:space:]]*admit$|native_decide|sorryAx)' \
+               --include='*.lean' ci/lean/CiSpec ci/lean/CiSpec.lean ci/lean/CiSpecBite.lean; then
+            echo "ERROR: the CI model uses 'sorry'/'admit' (proof holes), 'native_decide', or 'sorryAx' (banned)."
+            exit 1
+          fi
+          echo "No sorry / admit / native_decide / sorryAx across $FILES file(s)."
+
+      # The ban above must be able to go RED. Plant a hole in a scratch file
+      # inside the scanned tree, assert the same grep finds it, remove it.
+      # This is the in-workflow falsifier ci/inline-gates.txt names for the
+      # step above; it runs beside the gate, every invocation.
+      - name: The sorry-ban REDs on a planted sorry
+        if: steps.scope.outputs.relevant == 'true'
+        run: |
+          set -euo pipefail
+          probe=ci/lean/CiSpec/GateOfGatesProbe.lean
+          printf 'theorem gate_of_gates_probe : True := by\n  sorry\n' > "$probe"
+          if ! grep -rnE '^[[:space:]]*sorry$' --include='*.lean' ci/lean/CiSpec >/dev/null; then
+            rm -f "$probe"
+            echo "::error::the sorry-ban's pattern did not match a planted sorry — it cannot go red, so it is not a gate"
+            exit 1
+          fi
+          rm -f "$probe"
+          echo "ok: the sorry-ban REDs on a planted hole and the probe is gone"
+
+      - name: Per-theorem axiom audit (every declaration under CiSpec and CiSpecBite)
+        if: steps.scope.outputs.relevant == 'true'
+        # The audit walks EVERY declaration the compiled oleans define, allows
+        # only propext / Classical.choice / Quot.sound, guards a positive count
+        # against the sources, and ratchets top-level `axiom` declarations.
+        run: scripts/lean-axiom-audit.sh ci/lean CiSpec,CiSpecBite
+      - name: The axiom audit goes red on axiom / admit / native_decide fixtures
+        if: steps.scope.outputs.relevant == 'true'
+        run: scripts/lean-axiom-audit.sh ci/lean --self-test
+
+      - name: The bite adds no semantics (imports CiSpec; theorems and closed constants only)
+        if: steps.scope.outputs.relevant == 'true'
+        run: scripts/check-ci-spec-bite.sh

--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ nucleus_ifc_kernel.llbc
 # Scratch build scripts for the Firecracker boot harness (staged into the repo
 # root so a container mount can see them). Not part of the build.
 /.fc*.sh
+
+# Lean build artifacts of the CI model (ci/lean); the other Lean packages live under crates/
+ci/lean/.lake/

--- a/ci/inline-gates.txt
+++ b/ci/inline-gates.txt
@@ -42,6 +42,8 @@ aeneas.yml::aeneas-translate::Aeneas Lean 4 translation | UNCOVERED: no falsifie
 aeneas.yml::aeneas-translate::Verify generated Lean matches committed | UNCOVERED: no falsifier yet
 aeneas.yml::aeneas-translate::Reject sorry (proof holes) | UNCOVERED: no falsifier yet
 ci-assurance.yml::live-parity::Ledger == branch protection; queue pin == ruleset | falsified by crates/ci-spec/tests/live_parity.rs (CI-LP-MISSING/EXTRA/QUEUE/STRICT/VACUOUS fixtures); exit 2 is red in the step
+ci-spec-lean.yml::ci-spec-lean::Ban sorry / admit / native_decide / sorryAx in the CI model | falsified by the "The sorry-ban REDs on a planted sorry" step in the same job, every run
+ci-spec-lean.yml::ci-spec-lean::The sorry-ban REDs on a planted sorry | self-falsifying: internal perturbation (plants a sorry, asserts the grep finds it)
 ck-policy-aeneas.yml::ck-policy-aeneas::Verify generated Lean matches committed (drift gate) | UNCOVERED: no falsifier yet
 ck-policy-aeneas.yml::ck-policy-aeneas::Ban sorry / admit / native_decide in our proof file | UNCOVERED: no falsifier yet
 ck-policy-lean.yml::ck-policy-lean::Ban sorry / admit / native_decide / sorryAx in ck-policy Lean | UNCOVERED: no falsifier yet

--- a/ci/lean/CiSpec.lean
+++ b/ci/lean/CiSpec.lean
@@ -1,0 +1,2 @@
+import CiSpec.Pipeline
+import CiSpec.Queue

--- a/ci/lean/CiSpec/Pipeline.lean
+++ b/ci/lean/CiSpec/Pipeline.lean
@@ -1,0 +1,157 @@
+/-
+  CiSpec / Pipeline — required status checks, path-filtered twins, and the
+  merge rollup, as a model.
+
+  **STATUS: PROVED (0 `sorry`).** Mathlib-free: `List` + `Bool` + `simp` /
+  `decide`. Lean 4 v4.30.0-rc2, `autoImplicit = false`.
+
+  The decision procedures in `crates/ci-spec` (I1 twin completeness, I3
+  reported-under-merge_group-and-not-skippable) are the HYPOTHESES of the
+  theorems here; the properties the merge queue silently relied on until
+  2026-09-05 are the conclusions.
+
+  # What is modelled
+
+  * A `Path` is a list of segments; a `Pattern` is a directory prefix (the
+    `**` glob at directory granularity, which is every filter this
+    repository uses).
+  * GitHub's `paths:` fires a workflow when SOME changed file matches;
+    `paths-ignore:` fires when SOME changed file is NOT matched. That
+    asymmetry is the whole subject of `twin_covers` / `twin_both_iff`.
+  * A `Producer` is a job that reports a check-run name; `reportsInQueue`
+    is what ci-spec's I3 decides per producer.
+  * `rollup` is GitHub's merge rule: a required context with NO verdict
+    (skipped, or never reported) counts as passed.
+
+  # What is NOT modelled (stated, not hidden)
+
+  * Glob syntax beyond directory prefixes (`*.rs`, `!negation`).
+  * Which of two same-named check runs the rollup consults — the reason
+    `twin_both_iff`'s straddling case is reported as a residual, not fixed.
+  * Time. `CiSpec.Queue` orders events; it does not clock them.
+-/
+
+namespace CiSpec
+
+abbrev Seg := String
+abbrev Path := List Seg
+abbrev Pattern := List Seg
+
+/-- `**` at directory granularity: a pattern matches every path under it. -/
+def globMatch (pat : Pattern) (f : Path) : Bool := pat.isPrefixOf f
+
+/-- Some pattern in the list matches the file. -/
+def matched (pats : List Pattern) (f : Path) : Bool := pats.any (fun p => globMatch p f)
+
+/-- GitHub `paths:` — fires when SOME changed file matches. -/
+def firesPaths (pats : List Pattern) (change : List Path) : Bool :=
+  change.any (fun f => matched pats f)
+
+/-- GitHub `paths-ignore:` — fires when SOME changed file is NOT matched. -/
+def firesIgnore (pats : List Pattern) (change : List Path) : Bool :=
+  change.any (fun f => !matched pats f)
+
+/-- **T2 (coverage).** A real twin filtered on `pats` and a noop twin ignoring
+    the SAME list never leave a non-empty change with NEITHER: the required
+    context is always reported on a pull request. This is what ci-spec I1
+    (`paths-ignore == paths`) buys. -/
+theorem twin_covers (pats : List Pattern) (change : List Path) (h : change ≠ []) :
+    firesPaths pats change = true ∨ firesIgnore pats change = true := by
+  cases change with
+  | nil => exact absurd rfl h
+  | cons f rest =>
+    unfold firesPaths firesIgnore
+    cases hm : matched pats f
+    · right
+      simp [List.any_cons, hm]
+    · left
+      simp [List.any_cons, hm]
+
+/-- **T2 (residual).** BOTH twins fire exactly when the change straddles the
+    filter — one file inside, one outside. That case is a GitHub semantics
+    limit (two check runs share one name), reported by ci-spec as the known
+    residual of the twin pattern rather than repaired. -/
+theorem twin_both_iff (pats : List Pattern) (change : List Path) :
+    (firesPaths pats change = true ∧ firesIgnore pats change = true) ↔
+    ((∃ f, f ∈ change ∧ matched pats f = true) ∧
+     (∃ f, f ∈ change ∧ matched pats f = false)) := by
+  simp [firesPaths, firesIgnore, List.any_eq_true]
+
+/-- **Bite (both).** When the noop ignores a STRICT SUBSET of the real twin's
+    paths, a homogeneous one-file change under a real-only pattern fires
+    BOTH twins. `aeneas-ifc-scoped-noop.yml` on 2026-09-05, with
+    `f = crates/nucleus-ifc-kernel/src/lib.rs`. -/
+theorem drift_fires_both (pats ignore : List Pattern) (f : Path)
+    (hp : matched pats f = true) (hi : matched ignore f = false) :
+    firesPaths pats [f] = true ∧ firesIgnore ignore [f] = true := by
+  simp [firesPaths, firesIgnore, hp, hi]
+
+/-- **Bite (neither).** When the noop ignores MORE than the real twin
+    filters, a one-file change under an ignore-only pattern fires NEITHER:
+    the required context is never reported and the PR blocks forever. -/
+theorem drift_fires_neither (pats ignore : List Pattern) (f : Path)
+    (hp : matched pats f = false) (hi : matched ignore f = true) :
+    firesPaths pats [f] = false ∧ firesIgnore ignore [f] = false := by
+  simp [firesPaths, firesIgnore, hp, hi]
+
+/-- A job that reports a check-run name. The three booleans are exactly what
+    ci-spec I3 reads off the workflow: the producing workflow has a
+    `merge_group:` trigger; the job's `if:` cannot be false there and every
+    job it `needs:` is itself required (so it cannot be SKIPPED). -/
+structure Producer where
+  ctx : String
+  isNoop : Bool
+  onMergeGroup : Bool
+  skippableInQueue : Bool
+
+/-- Does `p` report `c` on the merge-queue branch, with a real verdict? -/
+def reportsInQueue (p : Producer) (c : String) : Bool :=
+  p.ctx == c && !p.isNoop && p.onMergeGroup && !p.skippableInQueue
+
+/-- ci-spec's I3, as a Boolean over the model. -/
+def I3 (ps : List Producer) (required : List String) : Bool :=
+  required.all (fun c => ps.any (fun p => reportsInQueue p c))
+
+/-- GitHub's merge rollup: every required context must pass, and a context
+    with NO verdict counts as passed. This is the documented behaviour for
+    skipped jobs, and it is the vacuity every I3 defect exploits. -/
+def rollup (verdict : String → Option Bool) (required : List String) : Bool :=
+  required.all (fun c => (verdict c).getD true)
+
+/-- A verdict assignment is honest for `ps` if every context that some real,
+    merge_group-triggered, non-skippable producer reports actually carries a
+    verdict — a job that runs, reports. -/
+def Honest (ps : List Producer) (verdict : String → Option Bool) : Prop :=
+  ∀ c, ps.any (fun p => reportsInQueue p c) = true → (verdict c).isSome = true
+
+/-- **T1 (soundness).** Under I3, every required context carries a real
+    verdict on the queue branch; the rollup can never pass a required
+    context by silence. -/
+theorem T1_required_verdicts_exist (ps : List Producer) (required : List String)
+    (h : I3 ps required = true) (verdict : String → Option Bool) (hv : Honest ps verdict) :
+    ∀ c, c ∈ required → (verdict c).isSome = true := by
+  intro c hc
+  exact hv c (List.all_eq_true.mp h c hc)
+
+/-- **T1 (rollup).** With every required verdict present and green, the
+    rollup passes — and, by `T1_required_verdicts_exist`, "present" is what
+    I3 guarantees; greenness is the checks' job, not the pipeline's. -/
+theorem rollup_of_verdicts (verdict : String → Option Bool) (required : List String)
+    (h : ∀ c, c ∈ required → verdict c = some true) :
+    rollup verdict required = true := by
+  unfold rollup
+  apply List.all_eq_true.mpr
+  intro c hc
+  rw [h c hc]
+  rfl
+
+/-- **Bite (vacuous merge).** Without I3 — a required context whose only
+    producer can be skipped — the rollup passes it with NO verdict at all.
+    This is the seven contexts hanging off two non-required detector jobs on
+    2026-09-05: a red detector reported them all as SKIPPED, and skipped
+    counts as passed. -/
+theorem vacuous_merge_without_I3 (c : String) :
+    rollup (fun _ => none) [c] = true := by
+  simp [rollup]
+
+end CiSpec

--- a/ci/lean/CiSpec/Queue.lean
+++ b/ci/lean/CiSpec/Queue.lean
@@ -1,0 +1,369 @@
+/-
+  CiSpec / Queue — the merge queue as a state machine.
+
+  **STATUS: PROVED (0 `sorry`).** Mathlib-free: `Nat` + `List` + `Bool` +
+  `simp` / `omega` + structural induction. Lean 4 v4.30.0-rc2,
+  `autoImplicit = false`.
+
+  The shape is the one Mergify's and Aviator's TLA+ merge-queue specs use
+  (a train of entries, per-PR lifecycle sets), reduced to what this
+  repository's queue does: build concurrency 1, ALLGREEN grouping, squash.
+
+  # Events
+
+  * `enqueue p` — a waiting PR joins the tail of the queue.
+  * `pass p` / `fail p` — the group's required checks report green / red
+    (the queue's check timeout is a `fail`).
+  * `push p` — a push to a queued PR's head: GitHub removes it from the
+    queue and drops auto-merge (observed 2026-09-04; modelled so it cannot
+    be forgotten).
+  * `cancel p` — a workflow run of p's group is cancelled. For a QUEUED p
+    this is a red check (an ejection); for a DEQUEUED p it touches nothing
+    the queue reads.
+  * `merge` — the head merges if its checks are green.
+
+  # Theorems
+
+  * **T3** `consistent` is preserved: a PR is in the queue list exactly when
+    its location says `queued`, and the queue has no duplicates (NoPRLost /
+    NoDuplicate, by construction of the transition function).
+  * **T4** `mergedLog` is a subsequence of `enqLog`: merges happen in
+    enqueue order, never out of it.
+  * **T5** cancelling a run of a PR that is no longer in the queue changes
+    neither the queue nor whether the head can merge — the "cancel
+    superseded runs" policy of the merge-only directive is safe.
+  * **T6** a push to a queued PR returns it to waiting and removes it from
+    the queue.
+
+  # Not modelled
+
+  * Time and runners (that is `CiSpec.Capacity`, the next file).
+  * Speculative groups (`max_entries_to_build > 1`) — this repository runs
+    at 1, and the pin in ci/merge-queue.toml is what live-parity holds.
+-/
+
+namespace CiSpec
+
+inductive Loc
+  | waiting
+  | queued
+  | merged
+  | ejected
+  deriving DecidableEq, Repr
+
+structure State where
+  loc : Nat → Loc
+  queue : List Nat
+  enqLog : List Nat
+  mergedLog : List Nat
+  /-- The group's required checks are green. -/
+  checks : Nat → Bool
+
+def State.init : State :=
+  { loc := fun _ => .waiting, queue := [], enqLog := [], mergedLog := [], checks := fun _ => false }
+
+inductive Ev
+  | enqueue (p : Nat)
+  | pass (p : Nat)
+  | fail (p : Nat)
+  | push (p : Nat)
+  | cancel (p : Nat)
+  | merge
+
+def upd (f : Nat → Loc) (p : Nat) (l : Loc) : Nat → Loc :=
+  fun q => if q = p then l else f q
+
+def setB (f : Nat → Bool) (p : Nat) (b : Bool) : Nat → Bool :=
+  fun q => if q = p then b else f q
+
+/-- Remove every occurrence of `p`. -/
+def without (q : List Nat) (p : Nat) : List Nat := q.filter (fun x => x != p)
+
+/-- Eject `p` from the queue (red check, timeout, cancelled run). -/
+def eject (s : State) (p : Nat) : State :=
+  { s with loc := upd s.loc p .ejected, queue := without s.queue p, checks := setB s.checks p false }
+
+def step (s : State) (e : Ev) : State :=
+  match e with
+  | .enqueue p =>
+    if s.loc p = .waiting then
+      { s with loc := upd s.loc p .queued, queue := s.queue ++ [p], enqLog := s.enqLog ++ [p] }
+    else s
+  | .pass p =>
+    if s.loc p = .queued then { s with checks := setB s.checks p true } else s
+  | .fail p =>
+    if s.loc p = .queued then eject s p else s
+  | .push p =>
+    if s.loc p = .queued then
+      { s with loc := upd s.loc p .waiting, queue := without s.queue p, checks := setB s.checks p false }
+    else s
+  | .cancel p =>
+    if s.loc p = .queued then eject s p else { s with checks := setB s.checks p false }
+  | .merge =>
+    match s.queue with
+    | h :: t =>
+      if s.checks h then
+        { s with loc := upd s.loc h .merged, queue := t, mergedLog := s.mergedLog ++ [h] }
+      else s
+    | [] => s
+
+def run (s : State) (evs : List Ev) : State := evs.foldl step s
+
+/-- Can the head merge right now? -/
+def mergeEnabled (s : State) : Bool :=
+  match s.queue with
+  | h :: _ => s.checks h
+  | [] => false
+
+/-- The queue list and the location map agree, and the queue has no
+    duplicates. -/
+structure Consistent (s : State) : Prop where
+  mem_iff : ∀ p, p ∈ s.queue ↔ s.loc p = .queued
+  nodup : s.queue.Nodup
+
+/-- The merged log, followed by the live queue, is a subsequence of the
+    enqueue log. -/
+def Ordered (s : State) : Prop := (s.mergedLog ++ s.queue).Sublist s.enqLog
+
+-- ── List helpers (Mathlib-free) ─────────────────────────────────────────
+
+theorem mem_without {q : List Nat} {p x : Nat} :
+    x ∈ without q p ↔ x ∈ q ∧ x ≠ p := by
+  simp [without, List.mem_filter]
+
+theorem not_mem_without (q : List Nat) (p : Nat) : p ∉ without q p := by
+  intro h
+  exact (mem_without.mp h).2 rfl
+
+theorem nodup_without {q : List Nat} (h : q.Nodup) (p : Nat) : (without q p).Nodup := by
+  induction q with
+  | nil => simp [without]
+  | cons a rest ih =>
+    rw [List.nodup_cons] at h
+    have ih' := ih h.2
+    unfold without at ih' ⊢
+    rw [List.filter_cons]
+    split
+    · rw [List.nodup_cons]
+      refine ⟨?_, ih'⟩
+      intro m
+      exact h.1 (List.mem_filter.mp m).1
+    · exact ih'
+
+theorem nodup_snoc {l : List Nat} {p : Nat} (h : l.Nodup) (hp : p ∉ l) :
+    (l ++ [p]).Nodup := by
+  induction l with
+  | nil => simp
+  | cons a rest ih =>
+    rw [List.nodup_cons] at h
+    have hpa : p ≠ a := fun e => hp (e ▸ List.mem_cons_self)
+    have hp' : p ∉ rest := fun m => hp (List.mem_cons_of_mem a m)
+    rw [List.cons_append, List.nodup_cons]
+    refine ⟨?_, ih h.2 hp'⟩
+    intro m
+    rw [List.mem_append, List.mem_singleton] at m
+    cases m with
+    | inl m => exact h.1 m
+    | inr m => exact hpa m.symm
+
+theorem without_sublist (q : List Nat) (p : Nat) : (without q p).Sublist q :=
+  List.filter_sublist
+
+-- ── T3: consistency is an invariant ──────────────────────────────────────
+
+theorem consistent_init : Consistent State.init := by
+  refine ⟨?_, List.nodup_nil⟩
+  intro p
+  simp [State.init]
+
+theorem consistent_eject {s : State} (hs : Consistent s) (p : Nat) : Consistent (eject s p) := by
+  refine ⟨?_, nodup_without hs.nodup p⟩
+  intro q
+  simp only [eject, upd]
+  rw [mem_without, hs.mem_iff]
+  by_cases hq : q = p
+  · subst hq
+    simp
+  · simp [hq]
+
+theorem consistent_step {s : State} (hs : Consistent s) (e : Ev) : Consistent (step s e) := by
+  cases e with
+  | enqueue p =>
+    simp only [step]
+    split
+    · rename_i hw
+      have hnot : p ∉ s.queue := by
+        intro m
+        rw [hs.mem_iff] at m
+        rw [m] at hw
+        exact absurd hw (by decide)
+      refine ⟨?_, nodup_snoc hs.nodup hnot⟩
+      intro q
+      simp only [upd]
+      rw [List.mem_append, List.mem_singleton, hs.mem_iff]
+      by_cases hq : q = p
+      · subst hq
+        simp
+      · simp [hq]
+    · exact hs
+  | pass p =>
+    simp only [step]
+    split
+    · exact ⟨hs.mem_iff, hs.nodup⟩
+    · exact hs
+  | fail p =>
+    simp only [step]
+    split
+    · exact consistent_eject hs p
+    · exact hs
+  | push p =>
+    simp only [step]
+    split
+    · refine ⟨?_, nodup_without hs.nodup p⟩
+      intro q
+      simp only [upd]
+      rw [mem_without, hs.mem_iff]
+      by_cases hq : q = p
+      · subst hq
+        simp
+      · simp [hq]
+    · exact hs
+  | cancel p =>
+    simp only [step]
+    split
+    · exact consistent_eject hs p
+    · exact ⟨hs.mem_iff, hs.nodup⟩
+  | merge =>
+    simp only [step]
+    split
+    · rename_i h t hq
+      split
+      · have hn := hs.nodup
+        rw [hq, List.nodup_cons] at hn
+        refine ⟨?_, hn.2⟩
+        intro q
+        simp only [upd]
+        have hm := hs.mem_iff q
+        rw [hq, List.mem_cons] at hm
+        by_cases hqh : q = h
+        · subst hqh
+          simp [hn.1]
+        · simp only [hqh, ↓reduceIte]
+          rw [← hm]
+          simp [hqh]
+      · exact hs
+    · exact hs
+
+theorem consistent_run (evs : List Ev) : Consistent (run State.init evs) := by
+  unfold run
+  suffices h : ∀ (s : State), Consistent s → Consistent (evs.foldl step s) from
+    h State.init consistent_init
+  induction evs with
+  | nil => intro s hs; exact hs
+  | cons e rest ih =>
+    intro s hs
+    exact ih (step s e) (consistent_step hs e)
+
+-- ── T4: merges are in enqueue order ──────────────────────────────────────
+
+theorem ordered_init : Ordered State.init := by
+  simp [Ordered, State.init]
+
+theorem ordered_eject {s : State} (ho : Ordered s) (p : Nat) : Ordered (eject s p) := by
+  unfold Ordered at *
+  simp only [eject]
+  exact ((without_sublist s.queue p).append_left s.mergedLog).trans ho
+
+theorem ordered_step {s : State} (ho : Ordered s) (e : Ev) : Ordered (step s e) := by
+  cases e with
+  | enqueue p =>
+    simp only [step]
+    split
+    · unfold Ordered at *
+      simp only
+      rw [← List.append_assoc]
+      exact ho.append_right [p]
+    · exact ho
+  | pass p =>
+    simp only [step]
+    split <;> exact ho
+  | fail p =>
+    simp only [step]
+    split
+    · exact ordered_eject ho p
+    · exact ho
+  | push p =>
+    simp only [step]
+    split
+    · unfold Ordered at *
+      simp only
+      exact ((without_sublist s.queue p).append_left s.mergedLog).trans ho
+    · exact ho
+  | cancel p =>
+    simp only [step]
+    split
+    · exact ordered_eject ho p
+    · exact ho
+  | merge =>
+    simp only [step]
+    split
+    · rename_i h t hq
+      split
+      · unfold Ordered at *
+        simp only
+        rw [hq] at ho
+        rw [List.append_assoc, List.singleton_append]
+        exact ho
+      · exact ho
+    · exact ho
+
+theorem ordered_run (evs : List Ev) : Ordered (run State.init evs) := by
+  unfold run
+  suffices h : ∀ (s : State), Ordered s → Ordered (evs.foldl step s) from
+    h State.init ordered_init
+  induction evs with
+  | nil => intro s hs; exact hs
+  | cons e rest ih =>
+    intro s hs
+    exact ih (step s e) (ordered_step hs e)
+
+/-- **T4.** Every reachable state merges in enqueue order. -/
+theorem T4_merge_order (evs : List Ev) :
+    (run State.init evs).mergedLog.Sublist (run State.init evs).enqLog :=
+  (List.sublist_append_left _ _).trans (ordered_run evs)
+
+-- ── T5: cancelling a dequeued PR's run is safe ───────────────────────────
+
+/-- **T5.** If `p` is not in the queue, cancelling one of its runs leaves the
+    queue as it was and does not change whether the head can merge. This is
+    what makes "cancel every superseded merge_group run" a safe policy. -/
+theorem T5_cancel_safe {s : State} (hs : Consistent s) (p : Nat) (hp : p ∉ s.queue) :
+    (step s (.cancel p)).queue = s.queue ∧
+    mergeEnabled (step s (.cancel p)) = mergeEnabled s := by
+  have hloc : s.loc p ≠ .queued := by
+    intro h
+    exact hp ((hs.mem_iff p).mpr h)
+  simp only [step, hloc, ↓reduceIte]
+  refine ⟨?_, ?_⟩
+  · first | rfl | trivial
+  unfold mergeEnabled
+  cases hq : s.queue with
+  | nil => rfl
+  | cons h t =>
+    have hhp : h ≠ p := by
+      intro e
+      subst e
+      exact hp (hq ▸ List.mem_cons_self)
+    simp [setB, hhp]
+
+-- ── T6: a push dequeues ───────────────────────────────────────────────────
+
+/-- **T6.** A push to a queued PR's head returns it to waiting and removes it
+    from the queue: pushing to a queued PR is a dequeue, so re-runs and fixes
+    to a PR that is not next cost the queue its entry. -/
+theorem T6_push_dequeues {s : State} (p : Nat) (hp : s.loc p = .queued) :
+    (step s (.push p)).loc p = .waiting ∧ p ∉ (step s (.push p)).queue := by
+  simp only [step, hp, ↓reduceIte]
+  exact ⟨by simp [upd], not_mem_without s.queue p⟩
+
+end CiSpec

--- a/ci/lean/CiSpecBite.lean
+++ b/ci/lean/CiSpecBite.lean
@@ -1,0 +1,93 @@
+/-
+  CiSpecBite — the guarded/unguarded differential.
+
+  Each theorem here takes a `CiSpec` theorem, DROPS one hypothesis, and proves
+  the failure that hypothesis excludes is reachable — on the concrete shape
+  found in this repository on 2026-09-05. A theorem whose hypothesis nobody
+  has watched matter is a guess (`delegation_calc`'s tamarin-bite doctrine);
+  these are the machine-checked "it mattered".
+
+  This file adds NO SEMANTICS. It imports `CiSpec` and declares only closed
+  constants (the concrete paths, patterns and producers of the defects) and
+  theorems over `CiSpec`'s definitions — no `structure`, `inductive`,
+  `class`, `instance`, `abbrev`, and no function-typed `def` — so the bite
+  is about the same model and cannot drift into a different one.
+  `scripts/check-ci-spec-bite.sh` asserts that rule textually.
+
+  **STATUS: PROVED (0 `sorry`).** Mathlib-free.
+-/
+
+import CiSpec
+
+namespace CiSpecBite
+
+open CiSpec
+
+-- ── The 2026-09-05 twin drift, concretely ────────────────────────────────
+
+/-- The real twin's `paths:` — `crates/nucleus-ifc-kernel/**`. -/
+def realPaths : List Pattern := [["crates", "nucleus-ifc-kernel"]]
+
+/-- What the noop twin ignored — `crates/nucleus-ifc-kernel/src/extracted/**`,
+    a strict subset. -/
+def noopIgnore : List Pattern := [["crates", "nucleus-ifc-kernel", "src", "extracted"]]
+
+/-- The change that fired both: `crates/nucleus-ifc-kernel/src/lib.rs`. -/
+def libRs : Path := ["crates", "nucleus-ifc-kernel", "src", "lib.rs"]
+
+/-- **Bite of T2 / I1.** Drop `paths-ignore == paths`: the drifted pair fires
+    BOTH twins on a one-file, homogeneous change. Two check runs with the
+    same name, one of them vacuously green. -/
+theorem ifc_scoped_drift_fired_both :
+    firesPaths realPaths [libRs] = true ∧ firesIgnore noopIgnore [libRs] = true :=
+  drift_fires_both realPaths noopIgnore libRs (by decide) (by decide)
+
+/-- And with the lists set-equal (PR #2642's repair), the same change fires
+    the real twin and NOT the noop: exactly one report. -/
+theorem ifc_scoped_repaired_fires_one :
+    firesPaths realPaths [libRs] = true ∧ firesIgnore realPaths [libRs] = false := by
+  decide
+
+/-- The other direction of drift: had the noop ignored MORE than the real
+    twin filtered, a change under the extra pattern would fire NEITHER and
+    the PR would block forever on a context nothing reports. -/
+theorem over_ignore_fires_neither :
+    firesPaths noopIgnore [libRs] = false ∧ firesIgnore realPaths [libRs] = false := by
+  decide
+
+-- ── The detector vacuity, concretely ─────────────────────────────────────
+
+/-- `Tests` as it stood: real, merge_group-triggered, but `needs:` a detector
+    that was not a required context — skippable in the queue. -/
+def testsSkippable : Producer :=
+  { ctx := "Tests", isNoop := false, onMergeGroup := true, skippableInQueue := true }
+
+/-- **Bite of T1 / I3.** With the only producer skippable, I3 is false ... -/
+theorem i3_fails_on_skippable_tests : I3 [testsSkippable] ["Tests"] = false := by
+  decide
+
+/-- ... and the rollup passes `Tests` with no verdict at all: the merge goes
+    through untested. -/
+theorem tests_merges_untested : rollup (fun _ => none) ["Tests"] = true :=
+  vacuous_merge_without_I3 "Tests"
+
+/-- The repair: the detector becomes a required context, `Tests` is no longer
+    skippable, I3 holds. -/
+def testsRepaired : Producer :=
+  { ctx := "Tests", isNoop := false, onMergeGroup := true, skippableInQueue := false }
+
+theorem i3_holds_after_repair : I3 [testsRepaired] ["Tests"] = true := by
+  decide
+
+-- ── T5's hypothesis matters ───────────────────────────────────────────────
+
+/-- **Bite of T5.** Drop `p ∉ queue`: cancelling a run of the HEAD entry's
+    group ejects it — the queue changes. So "cancel every competing run" is
+    only safe for runs of PRs no longer in the queue, which is exactly how
+    the merge-only directive words it. -/
+theorem cancelling_the_head_ejects_it :
+    (step (run State.init [.enqueue 1, .pass 1]) (.cancel 1)).queue = [] ∧
+    (step (run State.init [.enqueue 1, .pass 1]) (.cancel 1)).loc 1 = .ejected := by
+  decide
+
+end CiSpecBite

--- a/ci/lean/lake-manifest.json
+++ b/ci/lean/lake-manifest.json
@@ -1,0 +1,16 @@
+{"version": "1.2.0",
+ "packagesDir": ".lake/packages",
+ "packages":
+ [{"url": "https://github.com/leanprover-community/axiom-audit",
+   "type": "git",
+   "subDir": null,
+   "scope": "",
+   "rev": "46024e005996495c65ef609368e11ab39c4222e3",
+   "name": "«axiom-audit»",
+   "manifestFile": "lake-manifest.json",
+   "inputRev": "v0.1.2",
+   "inherited": false,
+   "configFile": "lakefile.toml"}],
+ "name": "ciSpec",
+ "lakeDir": ".lake",
+ "fixedToolchain": false}

--- a/ci/lean/lakefile.lean
+++ b/ci/lean/lakefile.lean
@@ -1,0 +1,32 @@
+import Lake
+open Lake DSL
+
+-- The CI pipeline and merge queue as a Lean model: the invariants
+-- `crates/ci-spec` DECIDES over the workflow tree (I1 twin completeness, I3
+-- reported-and-not-skippable, the queue's accounting/order/cancel-safety)
+-- are the HYPOTHESES here, and the properties the merge queue relies on are
+-- the theorems. Mathlib-free: `Nat` + `List` + `Bool` + `decide` / `simp` +
+-- structural induction, the discipline of `crates/ck-policy/lean`. No
+-- Mathlib, no native_decide, no `sorry`/`admit`.
+--
+-- `CiSpecBite` is the guarded/unguarded differential: each theorem there
+-- drops ONE hypothesis of a `CiSpec` theorem and proves the failure is
+-- reachable (the 2026-09-05 defects, as machine-checked counterexamples).
+-- It imports `CiSpec` and defines nothing — scripts/check-ci-spec-bite.sh
+-- asserts that, so the bite cannot quietly become a different model.
+package «ciSpec» where
+  leanOptions := #[⟨`autoImplicit, false⟩]
+
+-- Second-opinion axiom audit (#2567): `lake exe axiom-audit --root CiSpec`
+-- walks every declaration under the namespace from the compiled oleans and
+-- fails on sorryAx, Lean.ofReduceBool (native_decide) or any home-rolled
+-- `axiom`. Driven by scripts/lean-axiom-audit.sh, never called bare.
+require «axiom-audit» from git
+  "https://github.com/leanprover-community/axiom-audit" @ "v0.1.2"
+
+@[default_target]
+lean_lib «CiSpec» where
+  roots := #[`CiSpec]
+
+lean_lib «CiSpecBite» where
+  roots := #[`CiSpecBite]

--- a/ci/lean/lean-toolchain
+++ b/ci/lean/lean-toolchain
@@ -1,0 +1,1 @@
+leanprover/lean4:v4.30.0-rc2

--- a/ci/required-checks.txt
+++ b/ci/required-checks.txt
@@ -12,7 +12,7 @@
 # `cargo xtask ci-spec live-parity` compares this file with the live branch
 # protection; a mismatch is a red on the schedule, never a silent re-sync.
 #
-# PINNED = 48
+# PINNED = 49
 
 # --- ci.yml -------------------------------------------------------------
 Detect changed crates
@@ -60,6 +60,7 @@ Scan PodSpecs
 Analyze
 
 # --- twin-paired (real + -noop) ----------------------------------------
+lake build CiSpec (pipeline + merge-queue theorems)
 Scoped Aeneas (Rust → Lean 4) + parity tests
 Scoped Aeneas OIDC→SPIFFE (Rust → Lean 4) + parity tests
 lake build Ck (monotonicity-gate soundness proofs)

--- a/scripts/check-ci-spec-bite.sh
+++ b/scripts/check-ci-spec-bite.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# The CI-model bite is a CONTROLLED experiment (delegation_calc's
+# check-tamarin-bite.sh doctrine, ported to Lean).
+#
+# ci/lean/CiSpec proves the merge-queue properties under the invariants
+# crates/ci-spec decides; ci/lean/CiSpecBite.lean drops ONE hypothesis per
+# theorem and proves the failure reachable on the 2026-09-05 shapes. Both
+# build green on their own — which is exactly the shape of a pair that
+# checks nothing if the bite quietly becomes a DIFFERENT model:
+#
+#   1. the bite redefines a `CiSpec` notion (its own `firesIgnore`) and the
+#      counterexample is about that, not about the model ci-spec is pinned to;
+#   2. the bite grows semantics (a new inductive event, a new structure) that
+#      make its failure reachable for an unrelated reason.
+#
+# So this asserts the differential textually: the bite IMPORTS CiSpec, adds
+# no `structure` / `inductive` / `class` / `instance` / `abbrev`, every `def`
+# it declares is a closed constant (no `→` in its type — data, not a function
+# that could shadow model semantics), and it states at least one theorem.
+# Perturb the information, never the shape.
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel 2>/dev/null || echo .)"
+
+BITE=ci/lean/CiSpecBite.lean
+[ -f "$BITE" ] || { echo "::error::$BITE is missing"; exit 1; }
+
+# Strip block and line comments so prose about `structure` cannot trip it.
+stripped="$(perl -0pe 's{/-.*?-/}{}gs; s{--[^\n]*}{}g' "$BITE")"
+
+fail=0
+if ! printf '%s\n' "$stripped" | grep -qE '^import CiSpec$'; then
+  echo "::error::$BITE does not import CiSpec — the bite must be about the same model"; fail=1
+fi
+bad="$(printf '%s\n' "$stripped" | grep -nE '^\s*(structure|inductive|class|instance|abbrev)\b' || true)"
+if [ -n "$bad" ]; then
+  echo "::error::$BITE adds semantics (new types or instances); the bite may only drop hypotheses:"
+  printf '%s\n' "$bad"; fail=1
+fi
+fndefs="$(printf '%s\n' "$stripped" | grep -nE '^\s*def\b' | grep -E '→|->' || true)"
+if [ -n "$fndefs" ]; then
+  echo "::error::$BITE declares function-typed defs; only closed constants are allowed:"
+  printf '%s\n' "$fndefs"; fail=1
+fi
+n="$(printf '%s\n' "$stripped" | grep -cE '^\s*theorem\b' || true)"
+[[ "$n" =~ ^[0-9]+$ ]] || n=0
+if [ "$n" -lt 1 ]; then
+  echo "::error::$BITE states no theorem — a bite with no attack lemma checks nothing"; fail=1
+fi
+
+if [ "$fail" -ne 0 ]; then exit 1; fi
+echo "ok: CiSpecBite imports CiSpec, adds no semantics, and states $n theorem(s)"

--- a/scripts/check-gates-can-fail.sh
+++ b/scripts/check-gates-can-fail.sh
@@ -283,6 +283,14 @@ perturb_twin_paths_ignore() {
     fi
 }
 
+perturb_bite_semantics() {
+    # A new type in the bite: the differential is no longer about CiSpec's
+    # model. Appended after the namespace closes, so the file stays valid
+    # Lean and only the no-new-semantics rule is violated.
+    append_line "$1" 'structure GateOfGatesProbe where'
+    append_line "$1" '  x : Nat'
+}
+
 perturb_cancel_in_progress() {
     # A merge_group-triggered workflow that cancels in-flight runs
     # unconditionally (ci-spec I4): a newer run aborts a queue entry.
@@ -461,6 +469,13 @@ probe check-ci-spec.sh "" .github/workflows/kani-nightly-noop.yml \
 probe check-ci-spec.sh "" .github/workflows/zizmor.yml \
       "cancel-in-progress true under merge_group" \
       perturb_cancel_in_progress
+
+# The CI-model bite (ci/lean/CiSpecBite.lean) may only DROP hypotheses of
+# CiSpec theorems; new semantics would make its counterexamples about a
+# different model. The gate is textual, so its subject is a planted type.
+probe check-ci-spec-bite.sh "" ci/lean/CiSpecBite.lean \
+      "a structure declared in the bite" \
+      perturb_bite_semantics
 
 probe check-kani-divergence.sh "" crates/portcullis/src/capability.rs \
       "an unlisted cfg(not(kani)) fork" \


### PR DESCRIPTION
Fourth PR of the "CI as a verified system" plan. Stacked on #2644 → #2643 → #2642.

## What
`ci/lean` — package `ciSpec`, Lean v4.30.0-rc2, **no Mathlib, 0 sorry**, axioms used: `propext`, `Quot.sound` (207 declarations audited, 0 top-level axioms).

| file | theorem | says |
|---|---|---|
| `CiSpec/Pipeline.lean` | `twin_covers` (**T2**) | with `paths-ignore == paths`, no non-empty change is left with NEITHER twin — what ci-spec I1 buys |
| | `twin_both_iff` | both twins fire **iff** the change straddles the filter: a GitHub semantics limit, reported as the residual, not fixed |
| | `drift_fires_both` / `drift_fires_neither` | the two directions of twin drift |
| | `T1_required_verdicts_exist` (**T1**) | under I3, every required context carries a real verdict on the queue branch |
| | `vacuous_merge_without_I3` | GitHub's "skipped counts as passed", and the merge it lets through |
| `CiSpec/Queue.lean` | `consistent_run` (**T3**) | queue list ⇔ location map, no duplicates, for every reachable state |
| | `T4_merge_order` | merges are a subsequence of enqueues |
| | `T5_cancel_safe` | cancelling a run of a PR **not in the queue** changes neither the queue nor whether the head can merge |
| | `T6_push_dequeues` | a push to a queued PR returns it to waiting |
| `CiSpecBite.lean` | one hypothesis dropped per theorem, on the **concrete 2026-09-05 shapes**, all by `decide` | aeneas-ifc-scoped's drifted twin fired BOTH on `nucleus-ifc-kernel/src/lib.rs` (and #2642's repair fires exactly one); `Tests` behind a non-required detector merges with no verdict; cancelling the HEAD's run ejects it, so T5's hypothesis is load-bearing |

## Gates (cloned from `ck-policy-lean.yml`)
- `ci-spec-lean.yml` builds both libs **by name**; sorry/admit/native_decide/sorryAx ban with a `FILES` floor **and an in-workflow falsifier** (plants a sorry, asserts the grep reds, removes it); `scripts/lean-axiom-audit.sh` + `--self-test`; and the bite's **no-new-semantics rule** (`scripts/check-ci-spec-bite.sh`: imports `CiSpec`, no `structure`/`inductive`/`class`/`instance`/`abbrev`, no function-typed `def`, ≥ 1 theorem) — probed in `check-gates-can-fail.sh` by planting a `structure`.
- Noop twin with the set-equal ignore list (ci-spec I1 checks it; `twin_covers` is why).
- New required context `lake build CiSpec (pipeline + merge-queue theorems)` in the ledger (PINNED 49; branch protection follows when this lands). Both new inline gates inventoried with falsifiers; UNCOVERED ceiling unchanged at 75.

## Stated, not hidden
The capacity theorem (**T7**: concurrency 1 + no competing runs + critical path ≤ budget ⇒ no timeout ejection) and the strict-rebase livelock (**T8**) need a timed scheduler model — next Lean PR. Speculative groups are not modelled; the pin is 1 and live-parity (#2644) holds it.

## Verification
- `lake build CiSpec CiSpecBite`: clean. `scripts/lean-axiom-audit.sh ci/lean CiSpec,CiSpecBite`: `ok … axioms used: propext, Quot.sound`; `--self-test` green.
- `scripts/check-ci-spec-bite.sh`: ok, 7 theorems. `scripts/check-gates-can-fail.sh`: `OK: every probed gate REDs … and GREENs when restored` (20 probes).
- `cargo xtask ci-spec check`: `ok: every invariant holds`. `check-lean-libs-built.sh`: both libs covered. actionlint / shellcheck / twin & scope parity clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZaH5waz88vL1qfNpFNfZ4
