### PR TITLE
ci: route the Fuzz job to the build pool (OOM-killed on the 3 GiB gate pool)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -616,8 +616,12 @@ jobs:
 
   fuzz:
     name: Fuzz
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
-    timeout-minutes: 10
+    # Compile-class (builds every fuzz target from source): the build pool,
+    # like Tests. On the 3 GiB gate pool it only ever passed with a warm
+    # sccache; the first cold run on a fresh node (2026-09-06) was OOM-killed
+    # at 10 min and the job hung as "in progress" with a dead runner.
+    runs-on: ${{ vars.CI_BUILD_RUNNER || vars.CI_RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 20
     needs: changed-crates
     if: ${{ needs.changed-crates.outputs.all == 'true' || needs.changed-crates.outputs.crates != '' }}
     steps:


### PR DESCRIPTION
## Why

`Fuzz` compiles every fuzz target from source — a compile-class job — but was routed to the 3 GiB `nucleus-k3s` gate pool. It had only ever passed there with a warm sccache. The first cold run on the rebuilt node (2026-09-06 02:02 UTC, PR #2643) was OOM-killed at 10 min; the EphemeralRunner stayed "Running" and GitHub showed the job in progress on a dead runner (actions/actions-runner-controller#4155).

## What

- `runs-on: ${{ vars.CI_BUILD_RUNNER || vars.CI_RUNNER || 'ubuntu-latest' }}` — the same expression every other compile-class job in `ci.yml` uses.
- `timeout-minutes: 10 → 20` for the cold-cache case; the merge-queue budget is 360.

No behaviour change on hosted runners (both variables unset → `ubuntu-latest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZaH5waz88vL1qfNpFNfZ4
