### PR TITLE
receipt: add Projection::Ci, the CI gate-verdict projection

### DIFF
--- a/crates/nucleus-receipt/src/lib.rs
+++ b/crates/nucleus-receipt/src/lib.rs
@@ -108,6 +108,12 @@ pub enum Projection {
     Flow(serde_json::Value),
     /// Economic functor — a bid+match record with Clarke-pivot payments.
     Economic(serde_json::Value),
+    /// CI functor — a continuous-integration gate verdict: the gate definition,
+    /// scope and environment digests it is keyed on, the tree it ran at, the
+    /// verdict, and the log/output digests. The typed body lives in the
+    /// consuming CI system; this crate keeps it as `serde_json::Value` like
+    /// every other projection.
+    Ci(serde_json::Value),
 }
 
 impl Projection {
@@ -118,6 +124,7 @@ impl Projection {
             Projection::Capability(_) => "capability",
             Projection::Flow(_) => "flow",
             Projection::Economic(_) => "economic",
+            Projection::Ci(_) => "ci",
         }
     }
 }
@@ -366,6 +373,7 @@ mod tests {
             Projection::Economic(serde_json::Value::Null).kind(),
             "economic"
         );
+        assert_eq!(Projection::Ci(serde_json::Value::Null).kind(), "ci");
     }
 
     #[test]


### PR DESCRIPTION
## What

A fifth `Projection` kind, `"ci"`: a continuous-integration gate verdict keyed on the gate definition, scope and environment digests, the tree it ran at, the verdict, and the log/output digests. The typed body lives in the consuming CI system; this crate keeps it as `serde_json::Value` like every other projection.

## Why

A CI verdict is a claim about a session's work exactly like the identity, capability, flow and economic projections are; giving it a projection kind lets a receipt carry it under the same JCS canonicalization and `verify_strict` signature, verifiable by the existing JS/Python SDKs (they surface `projection_kinds` as strings and dispatch on nothing).

## Compatibility

`Projection` is `#[non_exhaustive]`, so this is a non-breaking minor addition. `kind()` gains the arm; the pinned wire-name test covers `"ci"`. No consumer in the workspace matches the enum exhaustively (the JS SDK test asserts the kinds of a fixture, unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZaH5waz88vL1qfNpFNfZ4
