### PR TITLE
ci(gatehouse): the repository's proof-carrying pipeline (.gatehouse/pipeline.writ, 5 gates, admissibility kernel-checked) + informational plan-check workflow

### DIFF
--- a/.gatehouse/pipeline.writ
+++ b/.gatehouse/pipeline.writ
@@ -1,0 +1,22 @@
+-- nucleus's gatehouse pipeline (informational until the executor and the queue land; see
+-- .github/workflows/gatehouse-plan.yml). Five gates over the tree, each with its inputs as
+-- scope globs, a pinned environment, a hermetic capability, its command and timeout. The
+-- admissibility proof at the bottom is computed by evaluation and checked by the writ kernel.
+-- Tuples follow gatehouse's prelude/ci.writ:
+--   Cap  = (net, exec, wallMs, cpuMs, memMb, fsRead, fsWrite, secrets)   net tag 3 0 = None, exec tag 3 1 = Scoped
+--   Gate = (name, hash, scope, env, cap, cmd, timeoutMs, outputs)         hash is filled by the elaborator (zeroed when hashed)
+-- env = the rust:1.96.1-slim-bookworm image index digest (rust-toolchain.toml pins 1.96.1).
+import "sha256:2a14b3be34215e3e5afe1b7828ffcf85be2e77969a002262402e13588f12c0dc" as ci
+let env : Digest = #d"e18a79fc84dfcfc3ab5ba72290398a644c135c97eaa881447fddc354ee4701a3"
+let ceiling : ci.Cap = (tag 3 0, tag 3 1, 3600000, 3600000, 16384, [#b"Cargo.toml", #b"Cargo.lock", #b"rust-toolchain.toml", #b"crates/**", #b"tests/**", #b"benchmarks/**", #b"crates/portcullis-core/lean/**", #b".github/workflows/**", #b"ci/**", #b"crates/ci-spec/**", #b"scripts/check-ci-spec.sh"] : Bytes, [#b"target/**", #b"crates/portcullis-core/lean/.lake/**"] : Bytes, [] : Bytes)
+let rcap : ci.Cap = (tag 3 0, tag 3 1, 3600000, 3600000, 8192, [#b"Cargo.toml", #b"Cargo.lock", #b"rust-toolchain.toml", #b"crates/**", #b"tests/**", #b"benchmarks/**"] : Bytes, [#b"target/**"] : Bytes, [] : Bytes)
+let lcap : ci.Cap = (tag 3 0, tag 3 1, 3600000, 3600000, 16384, [#b"crates/portcullis-core/lean/**"] : Bytes, [#b"crates/portcullis-core/lean/.lake/**"] : Bytes, [] : Bytes)
+let scap : ci.Cap = (tag 3 0, tag 3 1, 900000, 900000, 4096, [#b"Cargo.toml", #b"Cargo.lock", #b"rust-toolchain.toml", #b".github/workflows/**", #b"ci/**", #b"crates/ci-spec/**", #b"scripts/check-ci-spec.sh"] : Bytes, [#b"target/**"] : Bytes, [] : Bytes)
+let fmt : ci.Gate = (#b"fmt", #d"0000000000000000000000000000000000000000000000000000000000000001", [#b"Cargo.toml", #b"Cargo.lock", #b"rust-toolchain.toml", #b"crates/**", #b"tests/**", #b"benchmarks/**"] : Bytes, env, rcap, [#b"cargo", #b"fmt", #b"--all", #b"--", #b"--check"] : Bytes, 300000, [] : Bytes)
+let clippy : ci.Gate = (#b"clippy", #d"0000000000000000000000000000000000000000000000000000000000000002", [#b"Cargo.toml", #b"Cargo.lock", #b"rust-toolchain.toml", #b"crates/**", #b"tests/**", #b"benchmarks/**"] : Bytes, env, rcap, [#b"cargo", #b"clippy", #b"--all-targets", #b"--all-features", #b"--", #b"-D", #b"warnings"] : Bytes, 2400000, [] : Bytes)
+let testCore : ci.Gate = (#b"test-core", #d"0000000000000000000000000000000000000000000000000000000000000003", [#b"Cargo.toml", #b"Cargo.lock", #b"rust-toolchain.toml", #b"crates/**", #b"tests/**", #b"benchmarks/**"] : Bytes, env, rcap, [#b"cargo", #b"test", #b"--all-features", #b"--lib", #b"--bins", #b"--tests"] : Bytes, 3600000, [] : Bytes)
+let leanBuild : ci.Gate = (#b"lean-build", #d"0000000000000000000000000000000000000000000000000000000000000004", [#b"crates/portcullis-core/lean/**"] : Bytes, env, lcap, [#b"lake", #b"build", #b"PortcullisCoreBridge"] : Bytes, 3600000, [] : Bytes)
+let ciSpec : ci.Gate = (#b"ci-spec", #d"0000000000000000000000000000000000000000000000000000000000000005", [#b"Cargo.toml", #b"Cargo.lock", #b"rust-toolchain.toml", #b".github/workflows/**", #b"ci/**", #b"crates/ci-spec/**", #b"scripts/check-ci-spec.sh"] : Bytes, env, scap, [#b"scripts/check-ci-spec.sh"] : Bytes, 900000, [] : Bytes)
+let pipeline : ci.Pipeline = ([fmt, clippy, testCore, leanBuild, ciSpec] : ci.Gate, [(1, 0), (2, 0)] : ci.Edge)
+let policy : ci.Policy = (ceiling, [#b"fmt", #b"clippy", #b"test-core", #b"lean-build", #b"ci-spec"] : Bytes, 14400000, 64)
+let admissible : So (ci.admissible_b pipeline policy) = oh

--- a/.github/workflows/gatehouse-plan.yml
+++ b/.github/workflows/gatehouse-plan.yml
@@ -1,0 +1,71 @@
+# gatehouse plan check — INFORMATIONAL (not a required context).
+#
+# .gatehouse/pipeline.writ is this repository's proof-carrying pipeline: every gate with its
+# inputs as scope globs, a pinned environment, a hermetic capability, its command and timeout,
+# and an admissibility proof (acyclic, hermetic, inside the policy ceiling, required gates
+# covered, inside the queue budget) that `gate plan check` elaborates and kernel-checks.
+# gatehouse is a private repository, so the check runs only when the GATEHOUSE_TOKEN secret
+# exists (a fine-grained token with contents:read on coproduct-private/gatehouse); without it
+# the job says so and passes, because it decides nothing yet. It becomes a gate when the
+# gatehouse executor and queue take over (milestone 5 of the gatehouse plan).
+name: gatehouse plan
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".gatehouse/**"
+      - ".github/workflows/gatehouse-plan.yml"
+  pull_request:
+    paths:
+      - ".gatehouse/**"
+      - ".github/workflows/gatehouse-plan.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  plan-check:
+    name: The pipeline elaborates and its admissibility proof checks (gatehouse, informational)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      # The gatehouse commit whose `gate` checks the plan (its embedded prelude must match the
+      # import hash in .gatehouse/pipeline.writ).
+      GATEHOUSE_REF: 564e9ed27f490cb6fc14f7df9f815e5e2ea9cc4e
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Is the gatehouse token available?
+        id: tok
+        env:
+          T: ${{ secrets.GATEHOUSE_TOKEN }}
+        run: |
+          if [ -n "$T" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::GATEHOUSE_TOKEN is not set: the plan check cannot look (informational; see the header of this workflow)"
+          fi
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: steps.tok.outputs.present == 'true'
+        with:
+          repository: coproduct-private/gatehouse
+          ref: ${{ env.GATEHOUSE_REF }}
+          token: ${{ secrets.GATEHOUSE_TOKEN }}
+          path: gatehouse
+          persist-credentials: false
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
+        if: steps.tok.outputs.present == 'true'
+        with:
+          cache: false
+      - name: gate plan check .gatehouse/pipeline.writ
+        if: steps.tok.outputs.present == 'true'
+        run: |
+          cargo build --locked --manifest-path gatehouse/Cargo.toml -p gate
+          gatehouse/target/debug/gate plan check .gatehouse/pipeline.writ


### PR DESCRIPTION
The repository's proof-carrying pipeline, as gatehouse milestone 3's definition of done asks: `.gatehouse/pipeline.writ` with five gates (fmt, clippy, test-core, lean-build, ci-spec), each with its inputs as scope globs over this tree, a pinned environment digest, a hermetic capability inside a policy ceiling, its command and timeout — and an admissibility proof (acyclic, hermetic, bounded by the ceiling, required gates covered, inside the queue budget) computed by evaluation and checked by the writ kernel.

Checked locally with `gate` from gatehouse `564e9ed`: 5 gates, every gate hash and the plan hash reported, root `admissible` kernel-checked.

**Informational.** `.github/workflows/gatehouse-plan.yml` runs `gate plan check` on changes under `.gatehouse/` — but gatehouse is a private repository, so the job needs a `GATEHOUSE_TOKEN` secret (a fine-grained token with contents:read on coproduct-private/gatehouse). Without it the job says so and passes; it is not a required context. **Owner action:** create the secret when convenient; nothing else changes.

Local gates: `scripts/check-ci-spec.sh` ok, actionlint, `ci/no-vendor-strings.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZaH5waz88vL1qfNpFNfZ4
