### PR TITLE
ci: scoped test runs on bin-only crates — no --lib for nextest, doctests only where a library target exists

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -407,7 +407,10 @@ jobs:
           PK: ${{ steps.affected.outputs.pk }}
         run: |
           read -ra PK_ARR <<< "$PK"
-          cargo nextest run --all-features --lib --bins --tests --no-fail-fast "${PK_ARR[@]}"
+          # No target filters: nextest already runs every test binary (lib, bins, tests),
+          # and `--lib` makes cargo refuse a scoped run that names only a bin-only crate
+          # ("no library targets found in package `xtask`" failed Tests on #2655).
+          cargo nextest run --all-features --no-fail-fast "${PK_ARR[@]}"
       # Node tests run the WASM bindings against the cross-language golden seal
       # and the accept/reject smoke fixtures; the Python SDK is its own
       # workspace (the root cargo test never reaches it) and runs the shared
@@ -435,7 +438,23 @@ jobs:
           PK: ${{ steps.affected.outputs.pk }}
         run: |
           read -ra PK_ARR <<< "$PK"
-          cargo test --all-features --doc "${PK_ARR[@]}"
+          # `cargo test --doc` refuses a package without a library target, and a scoped run
+          # may name only bin-only crates (xtask). Keep the affected packages that have one;
+          # when none does there are no doctests to run and that is a pass, not a skip.
+          if [ "${#PK_ARR[@]}" -eq 0 ]; then
+            cargo test --all-features --doc
+          else
+            libs="$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(any(.targets[]; any(.kind[]; test("^(lib|rlib|dylib|proc-macro)$")))) | .name')"
+            doc=()
+            for ((i = 1; i < ${#PK_ARR[@]}; i += 2)); do
+              if printf '%s\n' "$libs" | grep -qx -- "${PK_ARR[i]}"; then doc+=(-p "${PK_ARR[i]}"); fi
+            done
+            if [ "${#doc[@]}" -eq 0 ]; then
+              echo "no affected crate has a library target; no doctests to run"
+            else
+              cargo test --all-features --doc "${doc[@]}"
+            fi
+          fi
       - name: OWASP LLM Top 10 gauntlet (portcullis)
         id: owasp
         if: ${{ steps.affected.outputs.full == 'true' || contains(steps.affected.outputs.list, ' portcullis ') }}


### PR DESCRIPTION
Since #2635 a PR's Tests/Doctests run only the affected crates. When the only affected crate is bin-only (xtask), both `cargo nextest run --lib --bins --tests -p xtask` and `cargo test --doc -p xtask` refuse with "no library targets found in package", and the Report relays turn Tests and Doctests red — #2655 is the first casualty.

- nextest: no target filters; its default set is every test binary (lib unit tests, bins, integration tests), the same as before.
- doctests: keep the affected packages that have a library target (from `cargo metadata`); when none does, there are no doctests to run and the step passes.

Verified: `scripts/check-ci-spec.sh` ok, actionlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZaH5waz88vL1qfNpFNfZ4