### PR TITLE
ci(gatehouse-shadow): all five pipeline gates as gate JSONs; the shadow job is a matrix over the cheap ones

### DIFF
--- a/.gatehouse/gates/ci-spec.json
+++ b/.gatehouse/gates/ci-spec.json
@@ -1,0 +1,56 @@
+{
+  "scope": {
+    "include": [
+      "Cargo.toml",
+      "Cargo.lock",
+      "rust-toolchain.toml",
+      ".github/workflows/**",
+      "ci/**",
+      "crates/ci-spec/**",
+      "scripts/check-ci-spec.sh"
+    ],
+    "exclude": [],
+    "external": [],
+    "git_history": false
+  },
+  "env": {
+    "image": "sha256:e18a79fc84dfcfc3ab5ba72290398a644c135c97eaa881447fddc354ee4701a3",
+    "platform": "linux/amd64",
+    "toolchains": {
+      "rust": "1.96.1"
+    },
+    "env_vars": {}
+  },
+  "cap": {
+    "net": "none",
+    "fs_read": [
+      "Cargo.toml",
+      "Cargo.lock",
+      "rust-toolchain.toml",
+      ".github/workflows/**",
+      "ci/**",
+      "crates/ci-spec/**",
+      "scripts/check-ci-spec.sh"
+    ],
+    "fs_write": [
+      "target/**"
+    ],
+    "exec": "scoped",
+    "wall_ms": 900000,
+    "cpu_ms": 900000,
+    "mem_mb": 4096,
+    "secrets": []
+  },
+  "cmd": [
+    "scripts/check-ci-spec.sh"
+  ],
+  "cwd": "",
+  "timeout_s": 900,
+  "outputs": [],
+  "resources": {
+    "cpus": 2,
+    "mem_mb": 4096,
+    "disk_mb": 4096
+  },
+  "falsifier": null
+}

--- a/.gatehouse/gates/clippy.json
+++ b/.gatehouse/gates/clippy.json
@@ -1,0 +1,60 @@
+{
+  "scope": {
+    "include": [
+      "Cargo.toml",
+      "Cargo.lock",
+      "rust-toolchain.toml",
+      "crates/**",
+      "tests/**",
+      "benchmarks/**"
+    ],
+    "exclude": [],
+    "external": [],
+    "git_history": false
+  },
+  "env": {
+    "image": "sha256:e18a79fc84dfcfc3ab5ba72290398a644c135c97eaa881447fddc354ee4701a3",
+    "platform": "linux/amd64",
+    "toolchains": {
+      "rust": "1.96.1"
+    },
+    "env_vars": {}
+  },
+  "cap": {
+    "net": "none",
+    "fs_read": [
+      "Cargo.toml",
+      "Cargo.lock",
+      "rust-toolchain.toml",
+      "crates/**",
+      "tests/**",
+      "benchmarks/**"
+    ],
+    "fs_write": [
+      "target/**"
+    ],
+    "exec": "scoped",
+    "wall_ms": 2400000,
+    "cpu_ms": 2400000,
+    "mem_mb": 8192,
+    "secrets": []
+  },
+  "cmd": [
+    "cargo",
+    "clippy",
+    "--all-targets",
+    "--all-features",
+    "--",
+    "-D",
+    "warnings"
+  ],
+  "cwd": "",
+  "timeout_s": 2400,
+  "outputs": [],
+  "resources": {
+    "cpus": 2,
+    "mem_mb": 8192,
+    "disk_mb": 4096
+  },
+  "falsifier": null
+}

--- a/.gatehouse/gates/lean-build.json
+++ b/.gatehouse/gates/lean-build.json
@@ -1,0 +1,46 @@
+{
+  "scope": {
+    "include": [
+      "crates/portcullis-core/lean/**"
+    ],
+    "exclude": [],
+    "external": [],
+    "git_history": false
+  },
+  "env": {
+    "image": "sha256:e18a79fc84dfcfc3ab5ba72290398a644c135c97eaa881447fddc354ee4701a3",
+    "platform": "linux/amd64",
+    "toolchains": {
+      "rust": "1.96.1"
+    },
+    "env_vars": {}
+  },
+  "cap": {
+    "net": "none",
+    "fs_read": [
+      "crates/portcullis-core/lean/**"
+    ],
+    "fs_write": [
+      "crates/portcullis-core/lean/.lake/**"
+    ],
+    "exec": "scoped",
+    "wall_ms": 3600000,
+    "cpu_ms": 3600000,
+    "mem_mb": 16384,
+    "secrets": []
+  },
+  "cmd": [
+    "lake",
+    "build",
+    "PortcullisCoreBridge"
+  ],
+  "cwd": "",
+  "timeout_s": 3600,
+  "outputs": [],
+  "resources": {
+    "cpus": 2,
+    "mem_mb": 16384,
+    "disk_mb": 4096
+  },
+  "falsifier": null
+}

--- a/.gatehouse/gates/test-core.json
+++ b/.gatehouse/gates/test-core.json
@@ -1,0 +1,59 @@
+{
+  "scope": {
+    "include": [
+      "Cargo.toml",
+      "Cargo.lock",
+      "rust-toolchain.toml",
+      "crates/**",
+      "tests/**",
+      "benchmarks/**"
+    ],
+    "exclude": [],
+    "external": [],
+    "git_history": false
+  },
+  "env": {
+    "image": "sha256:e18a79fc84dfcfc3ab5ba72290398a644c135c97eaa881447fddc354ee4701a3",
+    "platform": "linux/amd64",
+    "toolchains": {
+      "rust": "1.96.1"
+    },
+    "env_vars": {}
+  },
+  "cap": {
+    "net": "none",
+    "fs_read": [
+      "Cargo.toml",
+      "Cargo.lock",
+      "rust-toolchain.toml",
+      "crates/**",
+      "tests/**",
+      "benchmarks/**"
+    ],
+    "fs_write": [
+      "target/**"
+    ],
+    "exec": "scoped",
+    "wall_ms": 3600000,
+    "cpu_ms": 3600000,
+    "mem_mb": 8192,
+    "secrets": []
+  },
+  "cmd": [
+    "cargo",
+    "test",
+    "--all-features",
+    "--lib",
+    "--bins",
+    "--tests"
+  ],
+  "cwd": "",
+  "timeout_s": 3600,
+  "outputs": [],
+  "resources": {
+    "cpus": 2,
+    "mem_mb": 8192,
+    "disk_mb": 4096
+  },
+  "falsifier": null
+}

--- a/.github/workflows/gatehouse-shadow.yml
+++ b/.github/workflows/gatehouse-shadow.yml
@@ -1,7 +1,8 @@
 # gatehouse shadow mode — INFORMATIONAL (not a required context).
 #
-# Runs this repository's fmt gate (.gatehouse/gates/fmt.json) the gatehouse way on the hosted
-# runner: the scope materialized from HEAD (nothing outside it exists in the sandbox), the
+# Runs this repository's CHEAP gates (.gatehouse/gates/{fmt,clippy,ci-spec}.json; test-core and
+# lean-build are defined there too but are not shadowed on the hosted runner yet — an hour of
+# tests and a Lean build are the executor's job) the gatehouse way on the hosted runner: the scope materialized from HEAD (nothing outside it exists in the sandbox), the
 # declared environment, the command under its timeout, a receipt signed by a developer credential,
 # pushed to a local log with an inclusion proof, and verified — then runs `cargo fmt --all --
 # --check` directly and prints whether the two agree. Seven days of agreement is the evidence the
@@ -23,12 +24,26 @@ permissions:
   contents: read
 
 jobs:
-  shadow-fmt:
-    name: The fmt gate, run the gatehouse way, agrees with the GitHub check (shadow, informational)
+  shadow:
+    name: "The ${{ matrix.gate }} gate, run the gatehouse way, agrees with the GitHub check (shadow, informational)"
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - gate: fmt
+            github: cargo fmt --all -- --check
+            components: rustfmt
+          - gate: clippy
+            github: cargo clippy --all-targets --all-features -- -D warnings
+            components: clippy
+          - gate: ci-spec
+            github: scripts/check-ci-spec.sh
+            components: rustfmt
     env:
       GATEHOUSE_REF: 75ad1b6ef791b48e85d4e479b54e35811ade23c9
+      GATE_NAME: ${{ matrix.gate }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -55,12 +70,12 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         if: steps.tok.outputs.present == 'true'
         with:
-          components: rustfmt
+          components: ${{ matrix.components }}
           cache: false
       - name: Build gate and gatehouse-runner
         if: steps.tok.outputs.present == 'true'
         run: cargo build --locked --manifest-path gatehouse/Cargo.toml -p gate -p gatehouse-runner
-      - name: The fmt gate, the gatehouse way
+      - name: The gate, the gatehouse way
         if: steps.tok.outputs.present == 'true'
         id: gh
         env:
@@ -73,11 +88,11 @@ jobs:
           "$GATE" login --dev --ca-key "$CA_KEY" --ca-kid dev-ca --subject shadow --out "$W/dev.json"
           KID="$(jq -r .credential.body.kid "$W/dev.json")"; SK="$(jq -r .signing_key_hex "$W/dev.json")"
           jq --arg rh "${RUSTUP_HOME:-$HOME/.rustup}" --arg ch "${CARGO_HOME:-$HOME/.cargo}" \
-            '.env.env_vars = {RUSTUP_HOME: $rh, CARGO_HOME: $ch}' .gatehouse/gates/fmt.json > "$W/fmt.json"
+            '.env.env_vars = {RUSTUP_HOME: $rh, CARGO_HOME: $ch}' ".gatehouse/gates/$GATE_NAME.json" > "$W/gate.json"
           PLAN="$(printf 'p%.0s' $(seq 1 64))"
           jq -n --arg plan "$PLAN" --arg kid "$KID" --arg sk "$SK" --arg rd "$(sha256sum "$RUNNER" | cut -d' ' -f1)" \
-            --slurpfile g "$W/fmt.json" \
-            '{repo: "coproduct-opensource/nucleus", repo_path: ".", tree_spec: "HEAD", plan: $plan, gate_name: "fmt",
+            --slurpfile g "$W/gate.json" --arg gn "$GATE_NAME" \
+            '{repo: "coproduct-opensource/nucleus", repo_path: ".", tree_spec: "HEAD", plan: $plan, gate_name: $gn,
               gate: $g[0], canary: null, kid: $kid, signing_key_hex: $sk, substrate: "developer",
               credential_kind: "dev_credential", credential_tier: "developer", runner_digest: $rd, binding: null}' > "$W/job.json"
           set +e
@@ -87,7 +102,7 @@ jobs:
           [ "$RC" -ne 2 ] || { echo "::error::the runner errored"; exit 1; }
           "$GATE" receipt push "$W/receipt.json" --log "$W/log.json" --proof "$W/proof.json"
           "$GATE" trust dev "$W/dev.json" --ca-key "$CA_KEY" --log "$W/log.json" --out "$W/trust.json"
-          "$GATE" expect "$W/fmt.json" --repo . --tree HEAD --class optional --plan "$PLAN" --out "$W/expect.json"
+          "$GATE" expect "$W/gate.json" --repo . --tree HEAD --class optional --plan "$PLAN" --out "$W/expect.json"
           set +e
           OUT="$("$GATE" receipt verify "$W/receipt.json" --trust "$W/trust.json" --expect "$W/expect.json" --inclusion "$W/proof.json")"; VC=$?
           set -e
@@ -97,13 +112,14 @@ jobs:
         if: steps.tok.outputs.present == 'true'
         env:
           GH_HELD: ${{ steps.gh.outputs.held }}
+          GITHUB_WAY: ${{ matrix.github }}
         run: |
           set +e
-          cargo fmt --all -- --check >/dev/null 2>&1; FC=$?
+          bash -c "$GITHUB_WAY" >/dev/null 2>&1; FC=$?
           set -e
           if [ "$FC" -eq 0 ]; then GITHUB=pass; else GITHUB=fail; fi
           if { [ "$GH_HELD" = HELD ] && [ "$GITHUB" = pass ]; } || { [ "$GH_HELD" = not-held ] && [ "$GITHUB" = fail ]; }; then AGREE=true; else AGREE=false; fi
-          LINE="shadow: gatehouse=$GH_HELD github=$GITHUB agree=$AGREE"
+          LINE="shadow: gate=$GATE_NAME gatehouse=$GH_HELD github=$GITHUB agree=$AGREE"
           echo "$LINE"
           echo "$LINE" >> "$GITHUB_STEP_SUMMARY"
           echo "gh=$GH_HELD" >> "$GITHUB_OUTPUT"
@@ -125,8 +141,8 @@ jobs:
           GITHUB_VERDICT: ${{ steps.agree.outputs.github }}
         run: |
           case "$GH_HELD" in HELD) GATEHOUSE=held;; *) GATEHOUSE=not-held;; esac
-          BODY="$(jq -cn --argjson pr "$PR" --arg head "$HEAD_SHA" --arg gh "$GATEHOUSE" --arg github "$GITHUB_VERDICT" \
-            '{pr: $pr, head_sha: $head, gate: "fmt", gatehouse: $gh, github: $github}')"
+          BODY="$(jq -cn --argjson pr "$PR" --arg head "$HEAD_SHA" --arg gate "$GATE_NAME" --arg gh "$GATEHOUSE" --arg github "$GITHUB_VERDICT" \
+            '{pr: $pr, head_sha: $head, gate: $gate, gatehouse: $gh, github: $github}')"
           if curl -sS --fail-with-body --max-time 20 -H 'content-type: application/json' \
                -X POST --data "$BODY" "${CONTROL_URL%/}/v1/$TENANT/shadow"; then
             echo "reported: $BODY"


### PR DESCRIPTION
Stacked on #2658.

- `.gatehouse/gates/{clippy,test-core,lean-build,ci-spec}.json`, derived from `.gatehouse/pipeline.writ` (same scope, environment, capability, command and timeout as the writ gate; `fmt.json`'s shape).
- The shadow job becomes a matrix over the cheap gates (`fmt`, `clippy`, `ci-spec`; `fail-fast: false`), each running the gatehouse way and the GitHub way, printing `shadow: gate=<name> gatehouse=… github=… agree=…`, and posting `gate: <name>` to the control plane when `GATEHOUSE_CONTROL_URL` is set. `test-core` and `lean-build` are defined but not shadowed on the hosted runner yet (the header says why).
- Nothing required changes; actionlint and ci-spec are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZaH5waz88vL1qfNpFNfZ4