### PR TITLE
ci(gatehouse): pin who this repository trusts, and authenticate the shadow report

### DIFF
--- a/.gatehouse/trust.toml
+++ b/.gatehouse/trust.toml
@@ -1,0 +1,42 @@
+# Who this repository trusts to say a gate held.
+#
+# A gatehouse receipt is accepted only while its signer is in this file AND the signer's
+# `KeyEvent::Add` leaf is included in a cosigned checkpoint of the log below — the two-direction
+# pin. Nothing in nucleus reads this file yet: the shadow workflow still builds a throwaway
+# developer trust snapshot per run, and the merge queue is still GitHub's. It becomes
+# load-bearing at the cut, when `gatehouse/required` is the only required context and the
+# verifier reads this file to decide whose receipts count. It is committed now so the keys are
+# reviewed in the open, on their own, rather than inside the cut PR.
+#
+# Rotation: a new key is added here in the same change that provisions it; the old key's
+# `valid_to` is set to the index of its rotation leaf and its receipts stay valid inside the
+# window. A signer a re-run refutes is quarantined by the control plane and its receipts are
+# void from that leaf on, whatever this file says — the file grants trust, it cannot restore it.
+
+tenant = "nucleus"
+# The SPIFFE trust domain the tenant is (ADR 0001): identities the control plane issues are
+# named under it.
+trust_domain = "spiffe://gatehouse/nucleus"
+
+[log]
+# The receipt log's origin line and its C2SP signed-note verifier key (name+hex key id+base64
+# of 0x01 ‖ public key). Checkpoints that do not verify under this key are not this log's.
+origin = "gatehouse.coproduct.one/nucleus/v1"
+vkey = "nucleus-log+3ec0c8fd+AfSJG+jQ0AfWvKGGNDn7uR190MoWEhDMR7/31LOB0Ldj"
+public_key_hex = "f4891be8d0d007d6bca1863439fbb91d7dd0ca161210cc47bff7d4b381d0b763"
+
+# Witness cosignatures are not required yet: no witness is provisioned (assurance row A-6 is
+# NOT-YET). When one is, `k` rises above zero and `witnesses` lists their vkeys.
+[log.policy]
+k = 0
+witnesses = []
+
+# The certificate authority whose job credentials make a run NodeAttested. The control plane
+# holds the private half; a pod never sees it, only the signed statement binding its one-run
+# key to (job, gate definition, environment, tree, substrate, agent).
+[[ca]]
+kid = "nucleus-node-ca"
+public_key_hex = "96a8dbdee21f5fc3cc21babf3ccf767d23dec7d58fe2ba662eabfd86e7a8a7d9"
+kind = "node"
+tier = "node_attested"
+valid_from = 0

--- a/.github/workflows/gatehouse-shadow.yml
+++ b/.github/workflows/gatehouse-shadow.yml
@@ -128,9 +128,9 @@ jobs:
       - name: Report the observation to the gatehouse control plane (only when one is named)
         # docs (gatehouse) hard-cut.md §3: the shadow week is measured per gate by the control
         # plane's shadow report; the verdict pair is posted here, agreement is computed there.
-        # GATEHOUSE_CONTROL_URL / GATEHOUSE_TENANT are repository VARIABLES (not secrets): the
-        # endpoint is informational and unauthenticated for now. A failed post is a warning,
-        # never a red — nothing required depends on this job.
+        # GATEHOUSE_CONTROL_URL / GATEHOUSE_TENANT are repository VARIABLES (not secrets); the
+        # write routes on the control plane need the GATEHOUSE_AGENT_TOKEN SECRET. A failed
+        # post is a warning, never a red — nothing required depends on this job.
         if: steps.tok.outputs.present == 'true' && vars.GATEHOUSE_CONTROL_URL != ''
         env:
           CONTROL_URL: ${{ vars.GATEHOUSE_CONTROL_URL }}
@@ -139,11 +139,13 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           GH_HELD: ${{ steps.agree.outputs.gh }}
           GITHUB_VERDICT: ${{ steps.agree.outputs.github }}
+          AGENT_TOKEN: ${{ secrets.GATEHOUSE_AGENT_TOKEN }}
         run: |
           case "$GH_HELD" in HELD) GATEHOUSE=held;; *) GATEHOUSE=not-held;; esac
           BODY="$(jq -cn --argjson pr "$PR" --arg head "$HEAD_SHA" --arg gate "$GATE_NAME" --arg gh "$GATEHOUSE" --arg github "$GITHUB_VERDICT" \
             '{pr: $pr, head_sha: $head, gate: $gate, gatehouse: $gh, github: $github}')"
           if curl -sS --fail-with-body --max-time 20 -H 'content-type: application/json' \
+               ${AGENT_TOKEN:+-H "Authorization: Bearer $AGENT_TOKEN"} \
                -X POST --data "$BODY" "${CONTROL_URL%/}/v1/$TENANT/shadow"; then
             echo "reported: $BODY"
           else


### PR DESCRIPTION
Two small, separable things on the road to the cut.

**`.gatehouse/trust.toml`** records the receipt log's origin (`gatehouse.coproduct.one/nucleus/v1`, the value `gatehouse_tlog::origin` builds) with its C2SP signed-note verifier key, and the node CA whose job credentials make a run `NodeAttested`. Nothing reads it yet: the shadow workflow still builds a throwaway developer trust snapshot per run, and the merge queue is still GitHub's. It becomes load-bearing at the cut, when `gatehouse/required` is the only required context. Committed on its own so the keys get reviewed as keys, not as a footnote in the cut PR.

The witness policy is `k = 0` because no witness is provisioned — assurance row A-6 is still `NOT-YET`. The file says that rather than implying a quorum that does not exist.

**The shadow report is authenticated.** The control plane's write routes now require a bearer (constant-time, `503` when no token is configured — closed, never open). The job sends `GATEHOUSE_AGENT_TOKEN` when the secret exists; without it the post is attempted unauthenticated and the existing `::warning::` fires. Nothing required depends on this job either way.

actionlint and `scripts/check-ci-spec.sh` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZaH5waz88vL1qfNpFNfZ4