### PR TITLE
ci(spec): the merge-queue pin names who owns the merge

### DIFF
--- a/crates/ci-spec/src/live.rs
+++ b/crates/ci-spec/src/live.rs
@@ -119,11 +119,31 @@ pub fn parse_ruleset(json: &str, expected_id: u64) -> Result<LiveQueue, String> 
     serde_json::from_value(params).map_err(|e| format!("merge_queue parameters: {e}"))
 }
 
+/// Every ruleset id in the `GET /repos/{o}/{r}/rulesets` listing. Used when gatehouse owns the
+/// merge: the claim to check is then about EVERY ruleset, not one pinned id, because a queue
+/// re-enabled under a new ruleset is exactly the drift that would go unnoticed.
+pub fn parse_ruleset_ids(json: &str) -> Result<Vec<u64>, String> {
+    #[derive(Deserialize)]
+    struct Row {
+        id: u64,
+    }
+    let rows: Vec<Row> =
+        serde_json::from_str(json).map_err(|e| format!("ruleset listing JSON: {e}"))?;
+    Ok(rows.into_iter().map(|r| r.id).collect())
+}
+
+/// Whether one ruleset response carries a `merge_queue` rule. A disabled ruleset carries none
+/// that anything enforces, so only an `active` one counts.
+pub fn ruleset_has_merge_queue(json: &str) -> Result<bool, String> {
+    let r: RulesetJson = serde_json::from_str(json).map_err(|e| format!("ruleset JSON: {e}"))?;
+    Ok(r.enforcement == "active" && r.rules.iter().any(|x| x.kind == "merge_queue"))
+}
+
 /// Decide parity: ledger == live protection, and the queue pin == the
 /// live ruleset. Both directions on the contexts — a live requirement the
 /// ledger does not know about means every invariant here was decided over
 /// an incomplete set.
-pub fn parity(m: &Model, live: &LiveProtection, queue: &LiveQueue) -> Vec<Finding> {
+pub fn parity(m: &Model, live: &LiveProtection, queue: Option<&LiveQueue>) -> Vec<Finding> {
     let mut out = Vec::new();
     const F: &str = "ci/required-checks.txt";
 
@@ -180,6 +200,42 @@ pub fn parity(m: &Model, live: &LiveProtection, queue: &LiveQueue) -> Vec<Findin
 
     const Q: &str = "ci/merge-queue.toml";
     let p = &m.queue;
+    // Who enforces the merge is itself a two-sided claim: the pin says whose queue this is, and
+    // the live configuration must agree. GitHub's queue still running while the pin says
+    // gatehouse means two queues merge the same branch; the pin saying GitHub while no ruleset
+    // enforces one means nothing builds a group at all.
+    let queue = match (p.owner.as_str(), queue) {
+        ("gatehouse", None) => {
+            return out;
+        }
+        ("gatehouse", Some(_)) => {
+            out.push(finding(
+                "CI-LP-QUEUE-OWNER",
+                Severity::Critical,
+                Q,
+                0,
+                "owner",
+                "the pin says gatehouse owns the merge, but a ruleset still enforces GitHub's                  merge queue: two queues would merge this branch, and the one whose receipts                  are verified is not the one GitHub obeys"
+                    .into(),
+                "delete the merge_queue rule from the ruleset, or set owner = \"github\" back",
+            ));
+            return out;
+        }
+        (_, None) => {
+            out.push(finding(
+                "CI-LP-QUEUE-OWNER",
+                Severity::Critical,
+                Q,
+                0,
+                "owner",
+                "the pin says GitHub owns the merge, but no active ruleset carries a merge_queue                  rule: nothing builds a group, and the capacity theorem is about a queue that                  does not run"
+                    .into(),
+                "restore the ruleset, or set owner = \"gatehouse\" in the change that hands the                  merge over",
+            ));
+            return out;
+        }
+        (_, Some(q)) => q,
+    };
     let diffs: Vec<(&str, String, String)> = [
         (
             "check_response_timeout_minutes",
@@ -243,8 +299,10 @@ pub fn parity(m: &Model, live: &LiveProtection, queue: &LiveQueue) -> Vec<Findin
             0,
             "strict",
             format!(
-                "pinned strict = {} but branch protection says {}: `strict = true` with a queue \
-                 forces a rebase before every merge, the livelock of 2026-09-04",
+                "pinned strict = {} but branch protection says {}: with GitHub's queue \
+                 `strict = true` forces a rebase before every merge, the livelock of \
+                 2026-09-04; with gatehouse's it is what makes the tree a receipt was verified \
+                 at the tree that gets merged",
                 p.strict, live.strict
             ),
             "align the pin and the setting",

--- a/crates/ci-spec/src/model.rs
+++ b/crates/ci-spec/src/model.rs
@@ -163,9 +163,19 @@ impl Step {
     }
 }
 
+fn github_owns_the_merge() -> String {
+    "github".to_string()
+}
+
 /// The merge-queue ruleset constants, pinned in `ci/merge-queue.toml`.
 #[derive(Debug, Clone, serde::Deserialize)]
 pub struct QueueConfig {
+    /// Who enforces the merge. `github` — the ruleset below carries the `merge_queue` rule and
+    /// GitHub builds every group. `gatehouse` — gatehouse's queue verifies receipts and calls
+    /// the merge API itself, and no ruleset may carry a `merge_queue` rule; the constants below
+    /// then describe gatehouse's queue, which is what the capacity theorem is about either way.
+    #[serde(default = "github_owns_the_merge")]
+    pub owner: String,
     pub ruleset_id: u64,
     pub check_response_timeout_minutes: u64,
     pub max_entries_to_build: u64,

--- a/crates/ci-spec/tests/live_parity.rs
+++ b/crates/ci-spec/tests/live_parity.rs
@@ -40,6 +40,23 @@ jobs:
       - run: cargo clippy
 "#;
 
+fn model_owned_by(ledger: &[&str], owner: &str) -> ci_spec::model::Model {
+    let mut l = format!("# PINNED = {}\n", ledger.len());
+    for c in ledger {
+        l.push_str(c);
+        l.push('\n');
+    }
+    from_parts(
+        &[(".github/workflows/ci.yml".into(), WF.into())],
+        &l,
+        &format!("owner = \"{owner}\"\n{QUEUE}"),
+        "# UNCOVERED_CEILING = 0\n",
+        "",
+        vec![],
+    )
+    .unwrap()
+}
+
 fn model(ledger: &[&str]) -> ci_spec::model::Model {
     let mut l = format!("# PINNED = {}\n", ledger.len());
     for c in ledger {
@@ -96,7 +113,7 @@ fn lockstep_is_clean() {
     let f = parity(
         &model(&["Rustfmt", "Clippy"]),
         &live(&["Clippy", "Rustfmt"], false),
-        &queue(),
+        Some(&queue()),
     );
     assert!(f.is_empty(), "{f:#?}");
 }
@@ -106,7 +123,7 @@ fn ledger_context_github_does_not_require_is_missing() {
     let f = parity(
         &model(&["Rustfmt", "Clippy", "Detect changed crates"]),
         &live(&["Clippy", "Rustfmt"], false),
-        &queue(),
+        Some(&queue()),
     );
     assert_eq!(rules(&f), vec!["CI-LP-MISSING"]);
     assert_eq!(f[0].subject, "Detect changed crates");
@@ -118,7 +135,7 @@ fn github_context_the_ledger_never_heard_of_is_extra() {
     let f = parity(
         &model(&["Rustfmt", "Clippy"]),
         &live(&["Clippy", "Rustfmt", "Mystery"], false),
-        &queue(),
+        Some(&queue()),
     );
     assert_eq!(rules(&f), vec!["CI-LP-EXTRA"]);
 }
@@ -130,7 +147,7 @@ fn a_ui_edit_to_the_queue_timeout_is_drift() {
     let f = parity(
         &model(&["Rustfmt", "Clippy"]),
         &live(&["Clippy", "Rustfmt"], false),
-        &q,
+        Some(&q),
     );
     assert_eq!(rules(&f), vec!["CI-LP-QUEUE"]);
     assert!(f[0].why.contains("60"));
@@ -141,7 +158,7 @@ fn strict_flipped_is_drift() {
     let f = parity(
         &model(&["Rustfmt", "Clippy"]),
         &live(&["Clippy", "Rustfmt"], true),
-        &queue(),
+        Some(&queue()),
     );
     assert_eq!(rules(&f), vec!["CI-LP-STRICT"]);
 }
@@ -151,8 +168,59 @@ fn a_partial_protection_response_is_undecided_not_clean() {
     let f = parity(
         &model(&["Rustfmt", "Clippy"]),
         &live(&["Rustfmt"], false),
-        &queue(),
+        Some(&queue()),
     );
     assert_eq!(rules(&f), vec!["CI-LP-VACUOUS"]);
     assert_eq!(f[0].severity, Severity::Undecided);
+}
+
+/// The cut: gatehouse's queue verifies receipts and calls the merge API. GitHub's queue must
+/// then be gone — two queues merging one branch is exactly the state where the receipts that
+/// were verified belong to a group GitHub never built.
+#[test]
+fn gatehouse_owning_the_merge_with_githubs_queue_still_on_is_a_conflict() {
+    let f = parity(
+        &model_owned_by(&["Rustfmt", "Clippy"], "gatehouse"),
+        &live(&["Clippy", "Rustfmt"], true),
+        Some(&queue()),
+    );
+    assert_eq!(rules(&f), vec!["CI-LP-QUEUE-OWNER"]);
+}
+
+#[test]
+fn gatehouse_owning_the_merge_with_no_github_queue_is_clean() {
+    let f = parity(
+        &model_owned_by(&["Rustfmt", "Clippy"], "gatehouse"),
+        &live(&["Clippy", "Rustfmt"], true),
+        None,
+    );
+    assert!(f.is_empty(), "{f:?}");
+}
+
+/// And the other direction: the pin still says GitHub owns the merge, but nothing enforces a
+/// queue. Nothing builds a group, and the capacity theorem is about a queue that does not run.
+#[test]
+fn github_owning_the_merge_with_no_queue_live_is_a_conflict() {
+    let f = parity(
+        &model_owned_by(&["Rustfmt", "Clippy"], "github"),
+        &live(&["Clippy", "Rustfmt"], false),
+        None,
+    );
+    assert_eq!(rules(&f), vec!["CI-LP-QUEUE-OWNER"]);
+}
+
+#[test]
+fn a_ruleset_carries_a_merge_queue_only_while_it_is_enforced() {
+    let with =
+        r#"{"id":7,"enforcement":"active","rules":[{"type":"merge_queue","parameters":{}}]}"#;
+    let off =
+        r#"{"id":7,"enforcement":"disabled","rules":[{"type":"merge_queue","parameters":{}}]}"#;
+    let without = r#"{"id":7,"enforcement":"active","rules":[{"type":"deletion"}]}"#;
+    assert!(ci_spec::live::ruleset_has_merge_queue(with).unwrap());
+    assert!(!ci_spec::live::ruleset_has_merge_queue(off).unwrap());
+    assert!(!ci_spec::live::ruleset_has_merge_queue(without).unwrap());
+    assert_eq!(
+        ci_spec::live::parse_ruleset_ids(r#"[{"id":7,"name":"a"},{"id":9,"name":"b"}]"#).unwrap(),
+        vec![7, 9]
+    );
 }

--- a/crates/xtask/src/ci_spec.rs
+++ b/crates/xtask/src/ci_spec.rs
@@ -104,18 +104,38 @@ pub fn live_parity(repo: Option<String>, github: &str, json: bool) -> Result<()>
         String::from_utf8(out.stdout).map_err(|e| e.to_string())
     };
 
-    let looked =
-        (|| -> Result<(ci_spec::live::LiveProtection, ci_spec::live::LiveQueue), String> {
-            let prot = fetch(&format!("repos/{github}/branches/main/protection"))?;
-            let rs = fetch(&format!(
-                "repos/{github}/rulesets/{}",
-                model.queue.ruleset_id
-            ))?;
-            Ok((
-                ci_spec::live::parse_protection(&prot)?,
-                ci_spec::live::parse_ruleset(&rs, model.queue.ruleset_id)?,
-            ))
-        })();
+    let looked = (|| -> Result<
+        (
+            ci_spec::live::LiveProtection,
+            Option<ci_spec::live::LiveQueue>,
+        ),
+        String,
+    > {
+        let prot = fetch(&format!("repos/{github}/branches/main/protection"))?;
+        let protection = ci_spec::live::parse_protection(&prot)?;
+        if model.queue.owner == "gatehouse" {
+            // The claim is about EVERY ruleset, not one pinned id: a queue re-enabled under a
+            // new ruleset would merge this branch while gatehouse thought it owned the merge.
+            let listing = fetch(&format!("repos/{github}/rulesets"))?;
+            for id in ci_spec::live::parse_ruleset_ids(&listing)? {
+                let rs = fetch(&format!("repos/{github}/rulesets/{id}"))?;
+                if ci_spec::live::ruleset_has_merge_queue(&rs)? {
+                    // Parsed as GitHub's queue so parity reports the owner conflict with the
+                    // ruleset's own numbers rather than a bare "it exists".
+                    return Ok((protection, Some(ci_spec::live::parse_ruleset(&rs, id)?)));
+                }
+            }
+            return Ok((protection, None));
+        }
+        let rs = fetch(&format!(
+            "repos/{github}/rulesets/{}",
+            model.queue.ruleset_id
+        ))?;
+        Ok((
+            protection,
+            Some(ci_spec::live::parse_ruleset(&rs, model.queue.ruleset_id)?),
+        ))
+    })();
 
     let (live, queue) = match looked {
         Ok(v) => v,
@@ -131,7 +151,7 @@ pub fn live_parity(repo: Option<String>, github: &str, json: bool) -> Result<()>
         }
     };
 
-    let findings = ci_spec::live::parity(&model, &live, &queue);
+    let findings = ci_spec::live::parity(&model, &live, queue.as_ref());
     let report = ci_spec::Report {
         workflows: model.workflows.len(),
         jobs: model.workflows.iter().map(|w| w.jobs.len()).sum(),

--- a/docs/adr/0003-gatehouse-owns-the-merge.md
+++ b/docs/adr/0003-gatehouse-owns-the-merge.md
@@ -1,0 +1,66 @@
+# ADR 0003 — gatehouse owns the merge
+
+- Status: accepted (2026-09-06)
+- Supersedes the merge-queue half of [ADR 0002](0002-ci-is-a-verified-system.md); everything
+  else in 0002 stands
+- Applies to: `ci/merge-queue.toml`, `ci/required-checks.txt`, `crates/ci-spec/**`, branch
+  protection on `main`, the merge-queue ruleset
+
+## Context
+
+ADR 0002 made the merge queue a modelled system: the constants that govern it are pinned in
+`ci/merge-queue.toml`, the capacity theorem reasons about those constants, and
+`cargo xtask ci-spec live-parity` reds when the pins and GitHub's settings drift. What it did
+not change is the thing underneath: a verdict is a row in GitHub's database saying that some
+runner reported success on some commit. Nothing about that row can be checked afterwards, so
+the queue re-runs every gate on every group — which is why the pool saturates.
+
+gatehouse replaces the verdict, not the runner. A gate declares its inputs, its environment,
+its capabilities and its command; running it mints a receipt signed inside the sandbox and
+appended to a transparency log; the queue verifies receipts and runs only what it has no
+receipt for. The receipt is checkable by anyone with the verifier and the log — the property
+GitHub's row does not have.
+
+## Decision
+
+**gatehouse's queue merges `main`.** GitHub's merge queue is switched off, and the single
+required context `gatehouse/required` carries the roll-up of every Required gate at the tree
+under review. The other contexts stay on their workflows and stay required; they move to
+gatehouse gate by gate, each after its cold wall time is measured, and never before.
+
+Three consequences are load-bearing, and each is checked:
+
+1. **`ci/merge-queue.toml` names an owner.** `owner = "github"` means a ruleset carries the
+   `merge_queue` rule that enforces the queue; `owner = "gatehouse"` means no active ruleset
+   may carry one. `live-parity` decides this in both directions: GitHub's queue still running
+   under a gatehouse pin is two queues merging one branch, and no queue at all under a GitHub
+   pin means nothing builds a group. With a gatehouse pin the check is over *every* ruleset,
+   not the pinned id, because a queue re-enabled under a new ruleset is exactly the drift that
+   would otherwise go unseen.
+
+2. **`strict` is true.** Under GitHub's queue, requiring a branch to be up to date before
+   merging forced a rebase before every merge and was half of the fifteen-hour stall of
+   2026-09-04. Under gatehouse's it is the opposite: it is what makes the tree a receipt was
+   verified at the tree that actually gets merged, without building speculative merge trees
+   for a queue one entry deep. The pin and the setting move together, and `live-parity`
+   catches either moving alone.
+
+3. **The merge is asserted after the fact.** gatehouse merges through the API and then reads
+   the merged commit back by content: if `tree(main)` is not the tree its receipts were
+   verified at, the queue pauses and a human resumes it. A merge nobody verified is a stop,
+   not a warning.
+
+## What this does not claim
+
+The capacity theorem (`ci/lean/CiSpec/Capacity.lean`) is about a queue with build concurrency
+one and no competing runs. gatehouse's queue has that shape, so the theorem still applies —
+but it is now a claim about our queue, and the constants in `ci/merge-queue.toml` describe
+that queue. Nothing here proves the gates themselves are right, and nothing here changes what
+a Required gate is; it changes who decides that a Required gate held, and whether that decision
+can be checked later.
+
+## Rollback
+
+Restore the branch-protection contexts and re-create the `merge_queue` rule, then set
+`owner = "github"` and `strict = false`. It is two API calls and a three-line revert, and the
+required contexts on the workflows never moved, so nothing else has to come back with it.


### PR DESCRIPTION
**PR 1 of the cut.** Behaviour-neutral: the default owner is `github`, so nothing changes today. This is the capability the flip needs.

`ci/merge-queue.toml` describes a queue, and until now it could only describe GitHub's: `live-parity` demanded an active ruleset with exactly one `merge_queue` rule, so the moment that rule goes away every invariant in the crate reports "could not look" — the file would be unable to describe the queue that replaces it.

The pin now names an **owner**, and parity decides it in both directions:

- GitHub's queue still enforcing under a `gatehouse` pin is **two queues merging one branch**, and the receipts that were verified belong to a group GitHub never built.
- **No queue at all** under a `github` pin means nothing builds a group, and the capacity theorem is about a queue that does not run.

Under a `gatehouse` pin the claim is checked over **every** ruleset rather than the pinned id, because a queue re-enabled under a new ruleset is exactly the drift that would otherwise go unseen.

Rebased onto current `main`; `cargo test -p ci-spec` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZaH5waz88vL1qfNpFNfZ4