### PR TITLE
ci(runners): pull the runner image from the registry instead of side-loading it

### DIFF
--- a/k8s/ci-runner/README.md
+++ b/k8s/ci-runner/README.md
@@ -32,9 +32,18 @@ and the Mathlib `lake exe cache` store are persistent for the same reason.
 # 0. tools (once): podman to build, k3s's containerd to run
 sudo apt-get install -y podman
 
-# 1. build the image for the node's architecture and hand it to k3s
+# 1. build the image for the node's architecture and PUSH it to the in-cluster
+#    registry. Do not side-load it into containerd with imagePullPolicy: Never:
+#    that has failed twice, silently. kubelet's image GC (85/80) counts an image
+#    as unused when no container references it, and ARC scales the runner set to
+#    ZERO when idle -- so the image is unreferenced almost always and is
+#    collected the moment the node fills. Pods then sit in ErrImageNeverPull,
+#    nothing FAILS, and every PR check stays QUEUED forever. From the registry,
+#    GC is harmless: kubelet fetches it again.
 podman build -f docker/Dockerfile.runner -t localhost/nucleus-ci-runner:0.2.5 .
-podman save localhost/nucleus-ci-runner:0.2.5 | sudo k3s ctr -n k8s.io images import -
+podman tag localhost/nucleus-ci-runner:0.2.5 localhost:30500/nucleus-ci-runner:0.2.5
+podman push --tls-verify=false localhost:30500/nucleus-ci-runner:0.2.5
+# (/etc/rancher/k3s/registries.yaml already declares localhost:30500 insecure.)
 
 # 2. persistent mounts + toolchains
 sudo bash k8s/ci-runner/warm.sh

--- a/k8s/ci-runner/values-build.yaml
+++ b/k8s/ci-runner/values-build.yaml
@@ -52,10 +52,17 @@ template:
   spec:
     containers:
       - name: runner
-        # Built from docker/Dockerfile.runner and imported into k3s's
-        # containerd (README.md); never pulled from a registry.
-        image: localhost/nucleus-ci-runner:0.2.5
-        imagePullPolicy: Never
+        # Built from docker/Dockerfile.runner and pushed to the in-cluster
+        # registry (README.md). NOT side-loaded with imagePullPolicy: Never --
+        # that failed twice, silently. kubelet's image GC (85/80) treats an
+        # image as unused when no container references it, and ARC scales this
+        # set to ZERO when idle, so the image is unreferenced almost always and
+        # is collected the moment the node fills. The pods then sit in
+        # ErrImageNeverPull, nothing FAILS, and every PR check stays QUEUED
+        # forever. Pulling from the registry makes GC harmless: kubelet just
+        # fetches it again.
+        image: localhost:30500/nucleus-ci-runner:0.2.5
+        imagePullPolicy: IfNotPresent
         command: ["/home/runner/run.sh"]
         env:
           # Cross-job compile cache on the persistent ~/.cache mount.

--- a/k8s/ci-runner/values.yaml
+++ b/k8s/ci-runner/values.yaml
@@ -45,10 +45,17 @@ template:
   spec:
     containers:
       - name: runner
-        # Built from docker/Dockerfile.runner and imported into k3s's
-        # containerd (README.md); never pulled from a registry.
-        image: localhost/nucleus-ci-runner:0.2.5
-        imagePullPolicy: Never
+        # Built from docker/Dockerfile.runner and pushed to the in-cluster
+        # registry (README.md). NOT side-loaded with imagePullPolicy: Never --
+        # that failed twice, silently. kubelet's image GC (85/80) treats an
+        # image as unused when no container references it, and ARC scales this
+        # set to ZERO when idle, so the image is unreferenced almost always and
+        # is collected the moment the node fills. The pods then sit in
+        # ErrImageNeverPull, nothing FAILS, and every PR check stays QUEUED
+        # forever. Pulling from the registry makes GC harmless: kubelet just
+        # fetches it again.
+        image: localhost:30500/nucleus-ci-runner:0.2.5
+        imagePullPolicy: IfNotPresent
         command: ["/home/runner/run.sh"]
         env:
           # Cross-job compile cache on the persistent ~/.cache mount.

--- a/k8s/ci-runner/warm.sh
+++ b/k8s/ci-runner/warm.sh
@@ -11,7 +11,7 @@
 # exactly what a runner pod sees.
 set -euo pipefail
 
-IMAGE="${IMAGE:-localhost/nucleus-ci-runner:0.2.0}"
+IMAGE="${IMAGE:-localhost:30500/nucleus-ci-runner:0.2.5}"
 ROOT="${ROOT:-/var/lib/nucleus-ci}"
 RUST_TOOLCHAIN="${RUST_TOOLCHAIN:-1.96.1}"   # rust-toolchain.toml
 LEAN_TOOLCHAIN="${LEAN_TOOLCHAIN:-leanprover/lean4:v4.30.0-rc2}"  # every lean-toolchain in the tree


### PR DESCRIPTION
The runner image has now vanished from the node **twice**. Both times every `arc-runners` pod sat in `ErrImageNeverPull` while **nothing FAILED** and every PR check stayed `QUEUED`. The second time went unnoticed for about ten hours — a queue that never moves looks exactly like a queue that is busy.

## Why

kubelet's image garbage collection defaults to **85/80** and treats an image as *unused* when no container references it. ARC scales this runner set to **zero** when idle, so the image is unreferenced almost all the time — and the moment anything fills the node, it is collected. With `imagePullPolicy: Never` there is no recovery: the pod cannot fetch what was deleted.

(This time the node filler was my own gate-image builds. Next time it will be something else.)

## Why this is cheap

An in-cluster registry was **already running** on NodePort 30500, and `/etc/rancher/k3s/registries.yaml` **already** declares it insecure. Nothing had to be built. Pointing the scale sets at `localhost:30500` with `IfNotPresent` makes GC harmless — kubelet simply fetches the image again.

## What changed

- `k8s/ci-runner/values.yaml` and `values-build.yaml` — **both**, because there are two scale sets (`nucleus-k3s` max 8, `nucleus-k3s-build` max 2) and fixing one leaves half the fleet broken.
- `k8s/ci-runner/warm.sh` — default had drifted to `0.2.0` while the values ran `0.2.5`.
- `k8s/ci-runner/README.md` — the setup steps now push to the registry rather than `ctr images import`, with the failure mode written down so the next person does not reintroduce it.

**Order matters:** push the image to the registry *before* applying these values, or the pods swap `ErrImageNeverPull` for `ImagePullBackOff`. The README says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZaH5waz88vL1qfNpFNfZ4