### PR TITLE
oidc-provider(keystore): pin the scrypt work factor so reopen does not depend on two CPU calibrations agreeing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -256,3 +256,15 @@ risc0-zkvm = "3.0"
 # Build
 tonic-prost-build = "0.14"
 protoc-bin-vendored = "3.2"
+
+# The OIDC keystore file is passphrase-wrapped with scrypt at a pinned work
+# factor (see nucleus-oidc-provider/src/keystore/file.rs). scrypt's ROMix loop
+# is memory-hard by design; unoptimized it is ~30x slower, which turns every
+# keystore open in a debug test binary into half a minute of CPU. Optimizing
+# the KDF crates alone keeps the tests on the production code path and the
+# production work factor without the debug-build penalty.
+[profile.dev.package.scrypt]
+opt-level = 3
+
+[profile.dev.package.salsa20]
+opt-level = 3

--- a/crates/nucleus-oidc-provider/src/keystore/file.rs
+++ b/crates/nucleus-oidc-provider/src/keystore/file.rs
@@ -34,6 +34,17 @@ use zeroize::Zeroize;
 use super::memory::DEFAULT_GRACE_WINDOW;
 use super::{JwtKeyStore, KeyStoreError, RotateOutcome, SignedBytes, VerifyKey, rfc7638_kid};
 
+/// scrypt work factor (`N = 2^18`) the keystore file is written with. age's
+/// own "roughly one second on a modern machine" figure, pinned so the file
+/// is the same on every host and does not encode the writer's CPU speed.
+const SCRYPT_LOG_N: u8 = 18;
+
+/// Largest scrypt work factor an existing keystore file is allowed to ask
+/// for. Files written before the pin carried whatever age calibrated on the
+/// writing host (typically 2^18–2^21); 2^22 accepts all of those while still
+/// refusing a file crafted to burn unbounded memory and time.
+const SCRYPT_MAX_LOG_N: u8 = 22;
+
 /// File-backed, encrypted-at-rest key store.
 /// (#55 LOW-3) Hard cap on the verify-set's grace-window entries. With
 /// rotation cadence < grace window the `previous` map grows linearly
@@ -155,8 +166,15 @@ impl FileKeyStore {
             fs::read(path).map_err(|e| KeyStoreError::Backend(format!("read {path:?}: {e}")))?;
         let decryptor = age::Decryptor::new(encrypted.as_slice())
             .map_err(|e| KeyStoreError::Backend(format!("age decryptor: {e}")))?;
-        let identity =
+        let mut identity =
             age::scrypt::Identity::new(age::secrecy::SecretString::from(passphrase.to_string()));
+        // Fixed ceiling instead of age's default (`target + 4`, where `target`
+        // is re-measured against this host's CPU at every open): a file
+        // written by a faster or less-throttled CPU than the one opening it
+        // would otherwise be refused as "excessive work" even with the right
+        // passphrase. The ceiling still bounds the memory and time an
+        // operator-supplied file can demand (2^22: ~4 GiB, seconds).
+        identity.set_max_work_factor(SCRYPT_MAX_LOG_N);
         let mut reader = decryptor
             .decrypt(std::iter::once(&identity as &dyn age::Identity))
             .map_err(|e| KeyStoreError::Backend(format!("age decrypt: {e}")))?;
@@ -240,8 +258,13 @@ impl FileKeyStore {
         let plaintext = serde_json::to_vec(&persisted)
             .map_err(|e| KeyStoreError::Backend(format!("json encode: {e}")))?;
 
-        let recipient =
+        let mut recipient =
             age::scrypt::Recipient::new(age::secrecy::SecretString::from(passphrase.to_string()));
+        // Pinned, not calibrated: `Recipient::new` times scrypt on this host
+        // and picks whatever reaches ~1 s, so the same passphrase yields a
+        // different work factor on every machine (and on the same machine
+        // under CPU throttling), which is what made reopen fail in CI.
+        recipient.set_work_factor(SCRYPT_LOG_N);
         let encryptor =
             age::Encryptor::with_recipients(std::iter::once(&recipient as &dyn age::Recipient))
                 .map_err(|e| KeyStoreError::Backend(format!("age encryptor: {e}")))?;


### PR DESCRIPTION
`keystore::file::tests::reopen_recovers_active_kid_across_process_restart` went red on #2663 (a dependabot bump of a GitHub Action, nothing near this crate) with:

```
age decrypt: Excessive work parameter for passphrase.
Decryption would take around 32 seconds.
```

for a file the same test had written seconds earlier with the right passphrase. The #2669 description mentions a third merge-queue ejection in that window that was "a real test failure"; this is the mechanism.

## Why

age picks the scrypt work factor at **encryption** by timing scrypt on the host until one iteration reaches about a second. At **decryption** it refuses any work factor above a ceiling it re-measures the same way, plus four. On a cgroup-throttled runner the two measurements drifted by five doublings within one test, so the file the writer had just produced was "excessive" to the reader. The same thing happens outside CI to a real keystore written on a fast host and opened on a slow one.

## What changed

- `encrypt_and_write` pins `log_n = 18` (the reference implementation's default). The file no longer encodes the writer's CPU speed, and every persist stops paying age's ~1 s calibration.
- `decrypt_and_load` sets a fixed ceiling of `2^22` (also the reference default) instead of the host-relative one. Files written by earlier builds (age-calibrated, typically 2^18–2^21) still open; a crafted file still cannot demand unbounded memory or time.
- Workspace `[profile.dev.package]` builds `scrypt` and `salsa20` at `opt-level = 3`. age's calibration had been hiding that an unoptimized 2^18 ROMix costs ~30 s of CPU. With the factor pinned, every keystore open in a debug test binary would have paid it, and `rotate_persists_grace_window_entry` (60 s window, three opens) expired mid-test on the first local run. Optimized, the 24 keystore tests run in 4 s, on the production code path at the production work factor.

## Validation

- `cargo test -p nucleus-oidc-provider --all-features keystore`: 24 passed, 4.00 s (was 159 s with one failure before the profile override).
- `cargo clippy -p nucleus-oidc-provider --all-features --all-targets -- -D warnings`: clean.
- `cargo metadata --no-deps` with empty stderr and `ci/no-vendor-strings.sh`: clean (the Manifest Guards steps that touch `Cargo.toml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QqBdBgCoVTtbe7gLNQh532

---
_Generated by [Claude Code](https://claude.ai/code/session_01QqBdBgCoVTtbe7gLNQh532)_