### PR TITLE
dx(delegation): `nucleus run --goal` compiles intent into a minimum-authority grant a person can read (milestone 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,6 +245,20 @@ jobs:
         shell: bash
         run: scripts/check-extracted-callsites.sh
 
+  # The delegation compiler (crates/nucleus-task-compiler) turns a goal into
+  # a minimum-authority grant and must never open a socket: an LLM-backed
+  # proposer is a child process outside nucleus, not a dependency of the
+  # compiler. Text-level so the gate-of-gates can probe it without cargo.
+  task-compiler-offline:
+    name: The task compiler is offline by construction
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: No network crate in its dependency tables, no socket type in its sources
+        shell: bash
+        run: scripts/check-task-compiler-offline.sh
+
   # CI-1: the CI configuration itself is sound. A typed model of every
   # workflow, the required-check ledger (ci/required-checks.txt) and the
   # merge-queue pin (ci/merge-queue.toml), and the invariants the queue relies

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6604,6 +6604,7 @@ dependencies = [
  "nucleus-node-binding",
  "nucleus-proto",
  "nucleus-spec",
+ "nucleus-task-compiler",
  "portcullis",
  "rand 0.10.2",
  "rcgen",
@@ -7413,6 +7414,21 @@ dependencies = [
  "serde_json",
  "tokio",
  "x509-parser",
+]
+
+[[package]]
+name = "nucleus-task-compiler"
+version = "1.0.0"
+dependencies = [
+ "chrono",
+ "portcullis",
+ "rust_decimal",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "tempfile",
+ "thiserror 2.0.20",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/nucleus-pca",           # PCA: the unified verify() SDK facade
     "crates/nucleus",        # Enforcement: wraps OS APIs with policy checks
     "crates/nucleus-cli",    # CLI: distributed executor with enforcement
+    "crates/nucleus-task-compiler", # DX: goal → minimum-authority task grant (offline by construction)
     "crates/nucleus-client", # Client signing utilities
     "crates/nucleus-spec",   # Shared PodSpec definitions
     "crates/nucleus-proto",  # Generated gRPC/Protobuf types

--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ cargo install --git https://github.com/coproduct-opensource/nucleus nucleus-cli
 
 nucleus audit [PATH]                # Tier 0: scan agent configs, no runtime (CI exit codes)
 nucleus run --local "your task"     # Tier 1: run with enforced permissions (process-level, no VM)
+nucleus run --goal "fix the failing CI build" --dry-run
+                                    # State the outcome; nucleus proposes the minimum
+                                    # authority (Can / Cannot / Limits / Risk) and runs
+                                    # after one confirmation. See docs/permissions.md.
 ```
 
 ### Tier 2 — real microVM isolation (macOS)

--- a/crates/nucleus-cli/Cargo.toml
+++ b/crates/nucleus-cli/Cargo.toml
@@ -19,6 +19,7 @@ path = "src/main.rs"
 # Core enforcement
 portcullis = { path = "../portcullis", features = ["spec", "dlc"] }
 nucleus-spec = { path = "../nucleus-spec" }
+nucleus-task-compiler = { path = "../nucleus-task-compiler" }
 nucleus-client = { path = "../nucleus-client" }
 nucleus-identity = { path = "../nucleus-identity" }
 nucleus-proto = { path = "../nucleus-proto" }

--- a/crates/nucleus-cli/src/goal.rs
+++ b/crates/nucleus-cli/src/goal.rs
@@ -1,0 +1,175 @@
+//! `nucleus run --goal "…"`: intent → proposed minimum authority → one
+//! confirmation → execution.
+//!
+//! The person states the outcome. The compiler (`nucleus-task-compiler`)
+//! derives the semantic effects the goal needs from the repository it is
+//! stated in, lowers them to a permission lattice, meets that with the
+//! `--ceiling` profile so the grant can never be wider than the ceiling, and
+//! renders the result as five lines a person can approve:
+//!
+//! ```text
+//! Goal:    fix the failing CI build
+//! Can:     read CI logs and workflow runs · read and search workspace files · …
+//! Cannot:  open a pull request (outside ceiling safe-pr-fixer) · push to remote branches · …
+//! Limits:  $5.00 · 2h · api.github.com only · no .aws, .env, .ssh
+//! Risk:    2 of 3 exposure legs (private data + untrusted content); exfiltration absent → …
+//! ```
+//!
+//! One decision, then the existing run path executes under the compiled
+//! lattice. Without a TTY the command refuses to run unless `--yes` names
+//! the decision explicitly: an unattended run must not acquire authority by
+//! default. `--dry-run` prints the grant and stops.
+
+use std::collections::BTreeSet;
+use std::io::{self, BufRead, IsTerminal, Write};
+use std::path::PathBuf;
+
+use anyhow::{Context, Result, anyhow, bail};
+use nucleus_task_compiler::{
+    CompileInput, EffectProposer, ExternalCommandProposer, LimitOverrides, RuleProposer, compile,
+};
+use portcullis::{
+    Disclosure, EffectCatalog, EffectId, TaskGrant, WeakeningCostConfig, render_grant,
+};
+use rust_decimal::Decimal;
+
+use crate::config::Config;
+use crate::profiles;
+use crate::run::{self, RunArgs};
+
+/// Exit status when a confirmation is required but no TTY can give one.
+pub const EXIT_NEEDS_CONFIRMATION: i32 = 2;
+
+/// Entry point, reached from `run::execute` when `--goal` is set.
+pub async fn execute(args: RunArgs, global_config_path: &str) -> Result<()> {
+    let goal = args
+        .goal
+        .as_deref()
+        .map(str::trim)
+        .filter(|g| !g.is_empty())
+        .ok_or_else(|| anyhow!("--goal cannot be empty"))?
+        .to_string();
+
+    let work_dir = shellexpand::tilde(&args.dir).to_string();
+    let work_dir = PathBuf::from(&work_dir)
+        .canonicalize()
+        .with_context(|| format!("working directory {}", args.dir))?;
+
+    let grant = compile_goal(&args, &goal, &work_dir)?;
+    let catalog = load_catalog(&work_dir)?;
+    let mut level: Disclosure = args.explain.parse().map_err(|e: String| anyhow!(e))?;
+
+    if let Some(path) = &args.save_grant {
+        let json = serde_json::to_string_pretty(&grant)?;
+        std::fs::write(path, json).with_context(|| format!("writing {}", path.display()))?;
+        eprintln!("grant written to {}", path.display());
+    }
+
+    if args.dry_run {
+        print!("{}", render_grant(&grant, &catalog, level));
+        return Ok(());
+    }
+
+    if args.yes {
+        print!("{}", render_grant(&grant, &catalog, level));
+    } else {
+        if !io::stdin().is_terminal() {
+            eprint!("{}", render_grant(&grant, &catalog, level));
+            eprintln!();
+            eprintln!(
+                "nucleus: this grant needs a confirmation and there is no terminal to give one."
+            );
+            eprintln!("         Re-run with --yes to accept it, or --dry-run to only show it.");
+            std::process::exit(EXIT_NEEDS_CONFIRMATION);
+        }
+        loop {
+            print!("{}", render_grant(&grant, &catalog, level));
+            print!("\n[R]un · [d]etails · [a]bort: ");
+            io::stdout().flush()?;
+            let mut line = String::new();
+            io::stdin().lock().read_line(&mut line)?;
+            match line.trim().to_ascii_lowercase().as_str() {
+                "r" | "run" | "y" | "yes" => break,
+                "d" | "details" => {
+                    level = match level {
+                        Disclosure::Plain => Disclosure::Technical,
+                        Disclosure::Technical => Disclosure::PolicyTrace,
+                        Disclosure::PolicyTrace => Disclosure::Plain,
+                    };
+                    println!();
+                }
+                _ => bail!("aborted: the grant was not accepted"),
+            }
+        }
+    }
+
+    // Everything from here is the ordinary run path with the compiled
+    // lattice in place of a profile: same modes, same enforcement.
+    let global_config = Config::load(global_config_path)?;
+    let resolved = run::resolve_config(&args, &global_config)?;
+    run::dispatch(&args, resolved, &grant.lattice, &work_dir, &goal).await
+}
+
+fn load_catalog(work_dir: &std::path::Path) -> Result<EffectCatalog> {
+    let mut catalog = EffectCatalog::builtin()?;
+    catalog.load_from_dir(&work_dir.join(".nucleus/effects"))?;
+    Ok(catalog)
+}
+
+/// Compile the goal under the ceiling named by the args.
+fn compile_goal(args: &RunArgs, goal: &str, work_dir: &std::path::Path) -> Result<TaskGrant> {
+    let ctx = nucleus_task_compiler::probe(work_dir)
+        .with_context(|| format!("probing {}", work_dir.display()))?;
+    let catalog = load_catalog(work_dir)?;
+
+    let ceiling = profiles::resolve(&args.ceiling).ok_or_else(|| {
+        anyhow!(
+            "unknown ceiling profile '{}' (see `nucleus profiles`)",
+            args.ceiling
+        )
+    })?;
+
+    let mut explicit = BTreeSet::new();
+    for raw in &args.effects {
+        let raw = raw.trim();
+        if raw.is_empty() {
+            continue;
+        }
+        let id: EffectId = raw.parse().map_err(|e| anyhow!("--effects: {e}"))?;
+        if catalog.get(&id).is_none() {
+            bail!("--effects: unknown effect '{id}'");
+        }
+        explicit.insert(id);
+    }
+
+    let rules = RuleProposer;
+    let external = args
+        .proposer
+        .clone()
+        .map(|program| ExternalCommandProposer { program });
+    let mut proposers: Vec<&dyn EffectProposer> = vec![&rules];
+    if let Some(ext) = &external {
+        proposers.push(ext);
+    }
+
+    let limits = LimitOverrides {
+        max_cost_usd: args
+            .max_cost
+            .map(|c| Decimal::try_from(c).map_err(|e| anyhow!("--max-cost: {e}")))
+            .transpose()?,
+        duration_hours: None,
+    };
+
+    let grant = compile(CompileInput {
+        goal,
+        ctx: &ctx,
+        catalog: &catalog,
+        ceiling_profile: &args.ceiling,
+        ceiling: &ceiling,
+        proposers: &proposers,
+        explicit: &explicit,
+        limits,
+        cost_config: &WeakeningCostConfig::default(),
+    })?;
+    Ok(grant)
+}

--- a/crates/nucleus-cli/src/main.rs
+++ b/crates/nucleus-cli/src/main.rs
@@ -28,6 +28,7 @@ mod constants;
 mod doctor;
 mod envelope;
 mod envelope_verify;
+mod goal;
 mod guard;
 mod identity;
 mod keychain;

--- a/crates/nucleus-cli/src/run.rs
+++ b/crates/nucleus-cli/src/run.rs
@@ -24,7 +24,7 @@ use crate::keychain::{SecretKind, SecretStore};
 use crate::profiles;
 
 /// Resolved configuration from args, config file, and Keychain
-struct ResolvedConfig {
+pub(crate) struct ResolvedConfig {
     node_url: String,
     /// mTLS, when the identity `nucleus setup` provisions (Move A step 6) is
     /// present — the preferred path, and the only one that still works
@@ -43,7 +43,7 @@ struct ResolvedConfig {
 /// Resolve configuration from multiple sources (args > keychain > config > defaults).
 ///
 /// Returns `None` when `--local` is set (no node config needed).
-fn resolve_config(args: &RunArgs, config: &Config) -> Result<Option<ResolvedConfig>> {
+pub(crate) fn resolve_config(args: &RunArgs, config: &Config) -> Result<Option<ResolvedConfig>> {
     if args.local {
         return Ok(None);
     }
@@ -128,8 +128,42 @@ fn resolve_config(args: &RunArgs, config: &Config) -> Result<Option<ResolvedConf
 /// to run the tool-proxy as a local subprocess instead (suitable for CI).
 #[derive(Args, Debug)]
 pub struct RunArgs {
-    /// Task prompt (use - for stdin)
-    pub prompt: String,
+    /// Task prompt (use - for stdin). Not needed with --goal.
+    #[arg(required_unless_present = "goal")]
+    pub prompt: Option<String>,
+
+    /// State the outcome you want instead of a profile: nucleus compiles the
+    /// goal into the minimum authority it needs (met with --ceiling), shows
+    /// what the agent can and cannot do, and runs after one confirmation.
+    #[arg(long, conflicts_with_all = ["config"])]
+    pub goal: Option<String>,
+
+    /// The profile a --goal grant may never exceed. The one knob that widens.
+    #[arg(long, default_value = "codegen")]
+    pub ceiling: String,
+
+    /// Effects to grant in addition to what the goal implies (comma-separated
+    /// ids such as github/read-ci-logs). See `nucleus profiles`.
+    #[arg(long, value_delimiter = ',')]
+    pub effects: Vec<String>,
+
+    /// Accept the compiled grant without prompting (required without a TTY).
+    #[arg(long)]
+    pub yes: bool,
+
+    /// How much of the grant to show: plain | technical | policy-trace.
+    #[arg(long, default_value = "plain")]
+    pub explain: String,
+
+    /// An external effect proposer: a program that reads {goal, context,
+    /// catalog} as JSON on stdin and writes {effects: [...]} on stdout. Its
+    /// output is validated against the catalog and clamped under --ceiling.
+    #[arg(long, value_name = "PROGRAM")]
+    pub proposer: Option<PathBuf>,
+
+    /// Write the compiled grant as JSON (with --goal).
+    #[arg(long, value_name = "PATH")]
+    pub save_grant: Option<PathBuf>,
 
     /// Working directory (default: current directory)
     #[arg(short = 'd', long, default_value = ".")]
@@ -238,6 +272,10 @@ pub struct RunArgs {
 
 /// Execute the run command
 pub async fn execute(args: RunArgs, global_config_path: &str) -> Result<()> {
+    if args.goal.is_some() {
+        return crate::goal::execute(args, global_config_path).await;
+    }
+
     // Load global config
     let global_config = Config::load(global_config_path)?;
 
@@ -245,12 +283,14 @@ pub async fn execute(args: RunArgs, global_config_path: &str) -> Result<()> {
     let resolved = resolve_config(&args, &global_config)?;
 
     // Read prompt from stdin if "-"
-    let prompt = if args.prompt == "-" {
-        let mut buffer = String::new();
-        io::stdin().read_to_string(&mut buffer)?;
-        buffer.trim().to_string()
-    } else {
-        args.prompt.clone()
+    let prompt = match args.prompt.as_deref() {
+        Some("-") => {
+            let mut buffer = String::new();
+            io::stdin().read_to_string(&mut buffer)?;
+            buffer.trim().to_string()
+        }
+        Some(p) => p.to_string(),
+        None => String::new(),
     };
 
     if prompt.is_empty() {
@@ -318,26 +358,37 @@ pub async fn execute(args: RunArgs, global_config_path: &str) -> Result<()> {
             println!("  Rootfs read-only: {}", args.rootfs_read_only);
         }
         println!();
-        println!("Capabilities:");
-        println!("  read_files: {:?}", policy.capabilities.read_files);
-        println!("  write_files: {:?}", policy.capabilities.write_files);
-        println!("  run_bash: {:?}", policy.capabilities.run_bash);
-        println!("  git_push: {:?}", policy.capabilities.git_push);
-        println!("  web_fetch: {:?}", policy.capabilities.web_fetch);
+        print!(
+            "{}",
+            portcullis::render_capabilities(&policy, "Capabilities:")
+        );
         return Ok(());
     }
 
+    dispatch(&args, resolved, &policy, &work_dir, &prompt).await
+}
+
+/// Run `prompt` under `policy` in whichever mode the args select. Shared by
+/// the profile path and the `--goal` path, which differ only in where the
+/// policy came from.
+pub(crate) async fn dispatch(
+    args: &RunArgs,
+    resolved: Option<ResolvedConfig>,
+    policy: &PermissionLattice,
+    work_dir: &Path,
+    prompt: &str,
+) -> Result<()> {
     if args.hook {
-        return run_hook(&args, &policy, &work_dir, &prompt).await;
+        return run_hook(args, policy, work_dir, prompt).await;
     }
 
     if args.local {
-        run_local(&args, &policy, &work_dir, &prompt).await
+        run_local(args, policy, work_dir, prompt).await
     } else {
         let resolved = resolved.ok_or_else(|| {
             anyhow!("node config required for Firecracker mode. Use --local for CI.")
         })?;
-        run_enforced(&args, &resolved, &policy, &work_dir, &prompt).await
+        run_enforced(args, &resolved, policy, work_dir, prompt).await
     }
 }
 

--- a/crates/nucleus-cli/tests/goal_dry_run.rs
+++ b/crates/nucleus-cli/tests/goal_dry_run.rs
@@ -1,0 +1,131 @@
+//! `nucleus run --goal` end to end at the CLI boundary: the preview renders
+//! the five lines, and an unattended run without `--yes` refuses before it
+//! spawns anything.
+
+use std::fs;
+use std::process::{Command, Stdio};
+
+fn repo() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    fs::write(
+        root.join("Cargo.toml"),
+        "[package]\nname='x'\nversion='0.1.0'\n",
+    )
+    .unwrap();
+    fs::create_dir_all(root.join(".github/workflows")).unwrap();
+    fs::write(root.join(".github/workflows/ci.yml"), "on: push\n").unwrap();
+    fs::create_dir_all(root.join(".git")).unwrap();
+    fs::write(
+        root.join(".git/config"),
+        "[remote \"origin\"]\n\turl = https://github.com/acme/widgets.git\n",
+    )
+    .unwrap();
+    dir
+}
+
+fn nucleus() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_nucleus"))
+}
+
+#[test]
+fn dry_run_prints_the_five_lines() {
+    let dir = repo();
+    let out = nucleus()
+        .args([
+            "run",
+            "--goal",
+            "fix the failing CI build",
+            "--dry-run",
+            "--local",
+            "--ceiling",
+            "safe-pr-fixer",
+            "-d",
+        ])
+        .arg(dir.path())
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(out.status.success(), "stdout:\n{stdout}\nstderr:\n{stderr}");
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert_eq!(lines.len(), 5, "{stdout}");
+    assert!(lines[0].starts_with("Goal:    fix the failing CI build"));
+    assert!(lines[1].contains("read CI logs"), "{stdout}");
+    assert!(lines[2].contains("push to remote branches"), "{stdout}");
+    assert!(lines[3].starts_with("Limits:"));
+    assert!(lines[4].starts_with("Risk:"));
+}
+
+#[test]
+fn technical_disclosure_adds_the_grid() {
+    let dir = repo();
+    let out = nucleus()
+        .args([
+            "run",
+            "--goal",
+            "fix the failing CI build",
+            "--dry-run",
+            "--local",
+            "--explain",
+            "technical",
+            "-d",
+        ])
+        .arg(dir.path())
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(out.status.success(), "{stdout}");
+    assert!(
+        stdout.contains("Capabilities (ceiling: codegen)"),
+        "{stdout}"
+    );
+    assert!(stdout.contains("read_files:"), "{stdout}");
+}
+
+#[test]
+fn without_a_tty_and_without_yes_it_refuses_before_running() {
+    let dir = repo();
+    let out = nucleus()
+        .args([
+            "run",
+            "--goal",
+            "fix the failing CI build",
+            "--local",
+            "--tool-proxy-path",
+            "/definitely/not/a/binary",
+            "-d",
+        ])
+        .arg(dir.path())
+        .stdin(Stdio::null())
+        .output()
+        .unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("Goal:    fix the failing CI build"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("--yes"), "{stderr}");
+}
+
+#[test]
+fn an_unrecognised_goal_fails_closed() {
+    let dir = repo();
+    let out = nucleus()
+        .args(["run", "--goal", "hello there", "--dry-run", "--local", "-d"])
+        .arg(dir.path())
+        .output()
+        .unwrap();
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("nothing in the goal was recognised"),
+        "{stderr}"
+    );
+}

--- a/crates/nucleus-task-compiler/Cargo.toml
+++ b/crates/nucleus-task-compiler/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "nucleus-task-compiler"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "The delegation compiler: a natural-language goal plus repository context compiled into a minimum-authority task grant, meet-clamped under a ceiling profile"
+repository = "https://github.com/coproduct-opensource/nucleus"
+readme = "README.md"
+keywords = ["ai", "security", "agents", "least-privilege", "delegation"]
+categories = ["development-tools", "command-line-utilities"]
+
+# Deliberately offline: this crate reads the repository and the effect
+# catalog and never opens a socket. `scripts/check-task-compiler-offline.sh`
+# fails CI if a network crate is added here; the pluggable proposer is a
+# child process precisely so that an LLM-backed proposer lives outside
+# nucleus (CLAUDE.md vendor neutrality) and outside this closure.
+[dependencies]
+portcullis = { path = "../portcullis", features = ["spec"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
+rust_decimal = { workspace = true }
+chrono = { workspace = true }
+uuid = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/nucleus-task-compiler/README.md
+++ b/crates/nucleus-task-compiler/README.md
@@ -1,0 +1,17 @@
+# nucleus-task-compiler
+
+The delegation compiler behind `nucleus run --goal`.
+
+A goal ("fix the failing CI build") plus the repository it is stated in
+(ecosystem, CI system, git remotes, MCP configs) compiles to a `TaskGrant`:
+the semantic effects the task needs, lowered to a permission lattice and met
+with a ceiling profile so it can never be wider than the ceiling. The grant
+renders as five lines a person can approve (Goal / Can / Cannot / Limits /
+Risk).
+
+Effect proposal is deterministic and explainable (`rules.rs`). An
+orchestrator may add a proposer as a child process (`ExternalCommandProposer`);
+its output is validated against the catalog and clamped like everything
+else, so a proposer can only narrow or starve a goal, never widen it.
+
+This crate is offline by construction and CI enforces it.

--- a/crates/nucleus-task-compiler/src/compile.rs
+++ b/crates/nucleus-task-compiler/src/compile.rs
@@ -1,0 +1,229 @@
+//! `compile`: proposals → lowered authority → met with the ceiling → grant.
+
+use std::collections::BTreeSet;
+
+use chrono::Utc;
+use portcullis::task_grant::{ClippedEffect, CompilerProvenance, GrantLimits, summarise_risk};
+use portcullis::{
+    BudgetLattice, CapabilityLevel, EffectCatalog, EffectCatalogError, EffectId, PermissionLattice,
+    TaskGrant, TimeLattice, WeakeningCostConfig,
+};
+use rust_decimal::Decimal;
+use uuid::Uuid;
+
+use crate::proposer::{EffectProposer, Proposal, ProposerError};
+use crate::repo_context::RepoContext;
+
+/// `<crate>/<version>`, recorded in every grant's provenance.
+pub const COMPILER_NAME: &str = concat!("nucleus-task-compiler/", env!("CARGO_PKG_VERSION"));
+
+/// Bounds the caller may tighten. Anything not given comes from the ceiling.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct LimitOverrides {
+    /// Spend ceiling in USD.
+    pub max_cost_usd: Option<Decimal>,
+    /// Lifetime in hours.
+    pub duration_hours: Option<u32>,
+}
+
+/// Everything `compile` needs.
+pub struct CompileInput<'a> {
+    /// The goal as stated.
+    pub goal: &'a str,
+    /// The repository.
+    pub ctx: &'a RepoContext,
+    /// The effect vocabulary.
+    pub catalog: &'a EffectCatalog,
+    /// Name of the ceiling profile (recorded).
+    pub ceiling_profile: &'a str,
+    /// The ceiling itself; the grant is never wider.
+    pub ceiling: &'a PermissionLattice,
+    /// Proposers, consulted in order; their proposals are unioned.
+    pub proposers: &'a [&'a dyn EffectProposer],
+    /// Explicit effects to add to the proposals (e.g. from `--effects`).
+    pub explicit: &'a BTreeSet<EffectId>,
+    /// Limit overrides.
+    pub limits: LimitOverrides,
+    /// Cost model for the policy trace.
+    pub cost_config: &'a WeakeningCostConfig,
+}
+
+/// Compilation failures. None of them falls back to a wider grant.
+#[derive(Debug, thiserror::Error)]
+pub enum CompileError {
+    /// No rule and no proposer recognised the goal.
+    #[error(
+        "nothing in the goal was recognised: '{goal}'. Name the effects with --effects <id,...> or pick a profile with --profile."
+    )]
+    NothingRecognised {
+        /// The goal.
+        goal: String,
+    },
+    /// Every proposed effect was clipped by the ceiling.
+    #[error("every proposed effect is outside the ceiling profile '{ceiling}': {clipped}")]
+    NothingWithinCeiling {
+        /// The ceiling.
+        ceiling: String,
+        /// What was clipped, comma-separated.
+        clipped: String,
+    },
+    /// The catalog rejected something.
+    #[error(transparent)]
+    Catalog(#[from] EffectCatalogError),
+    /// A proposer failed.
+    #[error(transparent)]
+    Proposer(#[from] ProposerError),
+    /// The compiled lattice was not delegable from the ceiling. This is a
+    /// bug guard: `meet` makes it impossible, and the check is kept so a
+    /// future change cannot make it possible silently.
+    #[error("compiled grant is not within its ceiling: {0}")]
+    NotWithinCeiling(String),
+}
+
+/// Compile a goal into a [`TaskGrant`].
+pub fn compile(input: CompileInput<'_>) -> Result<TaskGrant, CompileError> {
+    // 1. Propose. Union across proposers; explicit effects are a proposal too.
+    let mut proposed: BTreeSet<EffectId> = input.explicit.clone();
+    let mut proposers = Vec::new();
+    let mut rules_fired = Vec::new();
+    if !input.explicit.is_empty() {
+        proposers.push("explicit".to_string());
+    }
+    for p in input.proposers {
+        let Proposal {
+            proposer,
+            effects,
+            rules_fired: fired,
+        } = p.propose(input.goal, input.ctx, input.catalog)?;
+        proposers.push(proposer);
+        rules_fired.extend(fired);
+        proposed.extend(effects);
+    }
+    if proposed.is_empty() {
+        return Err(CompileError::NothingRecognised {
+            goal: input.goal.to_string(),
+        });
+    }
+
+    // 2. Lower: exactly the union of the proposed effects, nothing else.
+    let lowered = input.catalog.lower(&proposed)?;
+
+    // 3. Build the requested lattice around the lowered capabilities. Paths
+    //    and commands come from the ceiling (the compiler does not know the
+    //    repository's sensitive paths better than the profile author does);
+    //    budget and time from the overrides, else the ceiling.
+    let max_cost_usd = input
+        .limits
+        .max_cost_usd
+        .unwrap_or(input.ceiling.budget.max_cost_usd);
+    let budget = BudgetLattice {
+        max_cost_usd,
+        consumed_usd: Decimal::ZERO,
+        max_input_tokens: input.ceiling.budget.max_input_tokens,
+        max_output_tokens: input.ceiling.budget.max_output_tokens,
+    };
+    let time = match input.limits.duration_hours {
+        Some(h) => TimeLattice::hours(i64::from(h)),
+        None => input.ceiling.time.clone(),
+    };
+    let requested = PermissionLattice::builder()
+        .description(format!("task: {}", input.goal))
+        .capabilities(lowered.capabilities.clone())
+        .paths(input.ceiling.paths.clone())
+        .commands(input.ceiling.commands.clone())
+        .budget(budget)
+        .time(time)
+        .uninhabitable_constraint(true)
+        .created_by(COMPILER_NAME)
+        .build();
+
+    // 4. Clamp. `meet` is the whole safety argument: the result is ≤ both.
+    let mut lattice = input.ceiling.meet(&requested).normalize();
+    lattice.description = format!("task: {}", input.goal);
+
+    // 5. Attribute: an effect whose lowering the ceiling clipped is reported,
+    //    never silently granted (it isn't) or silently dropped.
+    let mut can = BTreeSet::new();
+    let mut cannot = Vec::new();
+    for id in &proposed {
+        let spec = input
+            .catalog
+            .get(id)
+            .ok_or_else(|| EffectCatalogError::Unknown(id.to_string()))?;
+        let clipped: Vec<String> = spec
+            .operations
+            .iter()
+            .filter(|op| lattice.capabilities.level_for(**op) < CapabilityLevel::LowRisk)
+            .map(|op| op.to_string())
+            .collect();
+        if clipped.is_empty() {
+            can.insert(id.clone());
+        } else {
+            cannot.push(ClippedEffect {
+                id: id.clone(),
+                reason: format!(
+                    "outside ceiling {}: {} is never",
+                    input.ceiling_profile,
+                    clipped.join(", ")
+                ),
+            });
+        }
+    }
+    if can.is_empty() {
+        return Err(CompileError::NothingWithinCeiling {
+            ceiling: input.ceiling_profile.to_string(),
+            clipped: cannot
+                .iter()
+                .map(|c| c.id.to_string())
+                .collect::<Vec<_>>()
+                .join(", "),
+        });
+    }
+
+    // Hosts: only those of effects that survived the ceiling.
+    let granted = input.catalog.lower(&can)?;
+
+    // 6. The guard the whole design rests on.
+    input
+        .ceiling
+        .delegate_to(&lattice, "task grant")
+        .map_err(|e| CompileError::NotWithinCeiling(e.to_string()))?;
+
+    let gap = input
+        .cost_config
+        .compute_gap(&PermissionLattice::restrictive(), &lattice);
+    let risk = summarise_risk(&lattice, gap);
+
+    let created_at = Utc::now();
+    let not_after = lattice.time.valid_until;
+    let duration_secs = (not_after - created_at).num_seconds().max(0) as u64;
+    let mut blocked_paths: Vec<String> = lattice.paths.blocked.iter().cloned().collect();
+    blocked_paths.sort();
+
+    Ok(TaskGrant {
+        version: TaskGrant::VERSION,
+        id: Uuid::new_v4(),
+        goal: input.goal.to_string(),
+        goal_digest: TaskGrant::digest_goal(input.goal),
+        ceiling_profile: input.ceiling_profile.to_string(),
+        can,
+        cannot,
+        limits: GrantLimits {
+            max_cost_usd: lattice.budget.max_cost_usd,
+            duration_secs,
+            hosts: granted.hosts.into_iter().collect(),
+            blocked_paths,
+            commands: granted.commands.into_iter().collect(),
+        },
+        risk,
+        lattice,
+        provenance: CompilerProvenance {
+            compiler: COMPILER_NAME.to_string(),
+            proposers,
+            rules_fired,
+            repo_context_digest: input.ctx.digest.clone(),
+        },
+        created_at,
+        not_after,
+    })
+}

--- a/crates/nucleus-task-compiler/src/compile.rs
+++ b/crates/nucleus-task-compiler/src/compile.rs
@@ -196,7 +196,7 @@ pub fn compile(input: CompileInput<'_>) -> Result<TaskGrant, CompileError> {
 
     let created_at = Utc::now();
     let not_after = lattice.time.valid_until;
-    let duration_secs = (not_after - created_at).num_seconds().max(0) as u64;
+    let duration_secs = u64::try_from((not_after - created_at).num_seconds()).unwrap_or(0);
     let mut blocked_paths: Vec<String> = lattice.paths.blocked.iter().cloned().collect();
     blocked_paths.sort();
 

--- a/crates/nucleus-task-compiler/src/lib.rs
+++ b/crates/nucleus-task-compiler/src/lib.rs
@@ -1,0 +1,35 @@
+//! The delegation compiler: goal → required effects → minimum authority.
+//!
+//! ```text
+//! goal ──► [proposers] ──► effects ──► lower ──► meet(ceiling) ──► TaskGrant
+//!             │                                      │
+//!        rules over repo context          never wider than the ceiling
+//!        (+ optional child process)
+//! ```
+//!
+//! The compiler is the layer that lets the lattice, sink scopes and egress
+//! lists become internals: a person states an outcome and reviews meaning
+//! (Can / Cannot / Limits / Risk), and the kernel keeps enforcing the lattice
+//! the grant lowers to. Two properties hold by construction and are tested:
+//!
+//! - **Clamped**: `compile(..).lattice ≤ ceiling` for every goal and every
+//!   ceiling ([`compile`] meets with the ceiling and asserts delegability).
+//! - **Fail-closed**: a goal nothing recognises is
+//!   [`CompileError::NothingRecognised`], never a fallback to a permissive
+//!   profile; an effect the ceiling clips is reported in `cannot`, never
+//!   silently dropped or silently granted.
+//!
+//! The crate never opens a socket. The pluggable [`EffectProposer`] is a
+//! child process so an LLM-backed proposer stays outside nucleus.
+
+pub mod compile;
+pub mod proposer;
+pub mod repo_context;
+pub mod rules;
+
+pub use compile::{COMPILER_NAME, CompileError, CompileInput, LimitOverrides, compile};
+pub use proposer::{
+    EffectProposer, ExternalCommandProposer, Proposal, ProposerError, RuleProposer,
+};
+pub use repo_context::{CiSystem, Ecosystem, GitRemote, RepoContext, probe};
+pub use rules::{RULES, Requires, Rule, apply};

--- a/crates/nucleus-task-compiler/src/proposer.rs
+++ b/crates/nucleus-task-compiler/src/proposer.rs
@@ -1,0 +1,213 @@
+//! Effect proposers: the seam between "what the goal needs" and the
+//! deterministic compiler that clamps it.
+//!
+//! [`RuleProposer`] is the built-in, offline proposer. An orchestrator that
+//! wants an LLM's judgement implements the child-process protocol of
+//! [`ExternalCommandProposer`] *outside* nucleus; the compiler validates its
+//! output against the catalog and meets it with the ceiling, so an external
+//! proposer can only narrow or starve a goal, never widen it.
+
+use std::collections::BTreeSet;
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+use portcullis::{EffectCatalog, EffectId};
+use serde::{Deserialize, Serialize};
+
+use crate::repo_context::RepoContext;
+
+/// A proposer's answer.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Proposal {
+    /// Who proposed it.
+    pub proposer: String,
+    /// The effects.
+    pub effects: BTreeSet<EffectId>,
+    /// Rule ids (for [`RuleProposer`]) or free-form reasons.
+    pub rules_fired: Vec<String>,
+}
+
+/// Proposer failures.
+#[derive(Debug, thiserror::Error)]
+pub enum ProposerError {
+    /// The child process could not be run.
+    #[error("proposer {program}: {source}")]
+    Spawn {
+        /// The program.
+        program: String,
+        /// The error.
+        #[source]
+        source: std::io::Error,
+    },
+    /// The child exited non-zero.
+    #[error("proposer {program} exited with {status}: {stderr}")]
+    Failed {
+        /// The program.
+        program: String,
+        /// Exit status.
+        status: String,
+        /// Captured stderr (trimmed).
+        stderr: String,
+    },
+    /// The child's output was not the expected JSON.
+    #[error("proposer {program} returned malformed output: {detail}")]
+    Malformed {
+        /// The program.
+        program: String,
+        /// What was wrong.
+        detail: String,
+    },
+}
+
+/// Something that proposes effects for a goal.
+pub trait EffectProposer {
+    /// Name recorded in provenance.
+    fn name(&self) -> String;
+    /// Propose. Unknown effect ids are the compiler's problem, not the
+    /// proposer's: return them and they are dropped with a warning.
+    fn propose(
+        &self,
+        goal: &str,
+        ctx: &RepoContext,
+        catalog: &EffectCatalog,
+    ) -> Result<Proposal, ProposerError>;
+}
+
+/// The built-in rule table.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct RuleProposer;
+
+impl EffectProposer for RuleProposer {
+    fn name(&self) -> String {
+        "rules".into()
+    }
+
+    fn propose(
+        &self,
+        goal: &str,
+        ctx: &RepoContext,
+        _catalog: &EffectCatalog,
+    ) -> Result<Proposal, ProposerError> {
+        Ok(crate::rules::apply(goal, ctx))
+    }
+}
+
+/// What an external proposer reads on stdin.
+#[derive(Debug, Serialize)]
+struct ExternalRequest<'a> {
+    goal: &'a str,
+    context: &'a RepoContext,
+    /// Every effect the proposer may name, with its title and risk.
+    catalog: Vec<ExternalEffect>,
+}
+
+#[derive(Debug, Serialize)]
+struct ExternalEffect {
+    id: String,
+    title: String,
+    risk: String,
+}
+
+/// What an external proposer writes on stdout.
+#[derive(Debug, Deserialize)]
+struct ExternalResponse {
+    #[serde(default)]
+    effects: Vec<String>,
+    #[serde(default)]
+    reasons: Vec<String>,
+}
+
+/// A proposer that is a program: JSON request on stdin, JSON response on
+/// stdout. The protocol is deliberately tiny so the program can be a shell
+/// script, a service client, or anything else that lives outside nucleus.
+#[derive(Debug, Clone)]
+pub struct ExternalCommandProposer {
+    /// The program to run.
+    pub program: PathBuf,
+}
+
+impl EffectProposer for ExternalCommandProposer {
+    fn name(&self) -> String {
+        format!("external:{}", self.program.display())
+    }
+
+    fn propose(
+        &self,
+        goal: &str,
+        ctx: &RepoContext,
+        catalog: &EffectCatalog,
+    ) -> Result<Proposal, ProposerError> {
+        let program = self.program.display().to_string();
+        let request = ExternalRequest {
+            goal,
+            context: ctx,
+            catalog: catalog
+                .iter()
+                .map(|e| ExternalEffect {
+                    id: e.id.to_string(),
+                    title: e.title.clone(),
+                    risk: e.risk.as_str().to_string(),
+                })
+                .collect(),
+        };
+        let input = serde_json::to_vec(&request).map_err(|e| ProposerError::Malformed {
+            program: program.clone(),
+            detail: format!("could not encode request: {e}"),
+        })?;
+
+        let mut child = Command::new(&self.program)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|source| ProposerError::Spawn {
+                program: program.clone(),
+                source,
+            })?;
+        if let Some(mut stdin) = child.stdin.take() {
+            stdin
+                .write_all(&input)
+                .map_err(|source| ProposerError::Spawn {
+                    program: program.clone(),
+                    source,
+                })?;
+        }
+        let output = child
+            .wait_with_output()
+            .map_err(|source| ProposerError::Spawn {
+                program: program.clone(),
+                source,
+            })?;
+        if !output.status.success() {
+            return Err(ProposerError::Failed {
+                program,
+                status: output.status.to_string(),
+                stderr: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+            });
+        }
+        let response: ExternalResponse =
+            serde_json::from_slice(&output.stdout).map_err(|e| ProposerError::Malformed {
+                program: program.clone(),
+                detail: e.to_string(),
+            })?;
+
+        // Unknown ids are dropped here, not errors: a proposer that names
+        // something the catalog lacks cannot make the grant wider by it.
+        let mut effects = BTreeSet::new();
+        let mut reasons = response.reasons;
+        for raw in response.effects {
+            match raw.parse::<EffectId>() {
+                Ok(id) if catalog.get(&id).is_some() => {
+                    effects.insert(id);
+                }
+                _ => reasons.push(format!("ignored unknown effect '{raw}'")),
+            }
+        }
+        Ok(Proposal {
+            proposer: self.name(),
+            effects,
+            rules_fired: reasons,
+        })
+    }
+}

--- a/crates/nucleus-task-compiler/src/repo_context.rs
+++ b/crates/nucleus-task-compiler/src/repo_context.rs
@@ -1,0 +1,338 @@
+//! Deterministic, read-only probes of the repository a goal is stated in.
+//!
+//! The context is what lets the rules be specific: "fix CI" in a repository
+//! with `.github/workflows/` means "read GitHub Actions logs", and in one
+//! without it means nothing network-shaped at all. Every probe is a file
+//! read; nothing here executes a program or opens a socket.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+/// A language ecosystem detected from its manifest file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Ecosystem {
+    /// `Cargo.toml`
+    Cargo,
+    /// `package.json`
+    Npm,
+    /// `pyproject.toml`, `requirements.txt`, `setup.py`
+    Python,
+    /// `go.mod`
+    Go,
+}
+
+/// A CI system detected from its configuration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CiSystem {
+    /// `.github/workflows/*.yml`
+    GithubActions,
+    /// `.gitlab-ci.yml`
+    GitlabCi,
+    /// `.circleci/config.yml`
+    CircleCi,
+}
+
+/// One git remote, parsed from `.git/config`.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct GitRemote {
+    /// Remote name (`origin`).
+    pub name: String,
+    /// Host (`github.com`).
+    pub host: String,
+    /// `owner/repo` when the URL had that shape.
+    pub owner_repo: Option<String>,
+}
+
+/// What the compiler knows about the repository.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RepoContext {
+    /// Canonical root.
+    pub root: PathBuf,
+    /// Detected ecosystems.
+    pub ecosystems: BTreeSet<Ecosystem>,
+    /// Detected CI systems.
+    pub ci: BTreeSet<CiSystem>,
+    /// Git remotes.
+    pub remotes: Vec<GitRemote>,
+    /// Whether the root is a git work tree.
+    pub has_git: bool,
+    /// Names of MCP servers declared in known config locations.
+    pub mcp_servers: BTreeSet<String>,
+    /// Whether `.nucleus/egress.toml` exists.
+    pub has_egress_policy: bool,
+    /// `sha256` over the facts above (not the root path), so two checkouts
+    /// of the same repository compile the same goal to the same grant.
+    pub digest: String,
+}
+
+impl RepoContext {
+    /// Whether any remote is on `host` (exact or subdomain).
+    pub fn has_remote_host(&self, host: &str) -> bool {
+        self.remotes
+            .iter()
+            .any(|r| r.host == host || r.host.ends_with(&format!(".{host}")))
+    }
+}
+
+/// MCP config locations, matching `nucleus audit`.
+const MCP_CONFIG_LOCATIONS: &[&str] = &[
+    ".mcp.json",
+    "mcp.json",
+    "mcp_config.json",
+    ".vscode/mcp.json",
+    ".cursor/mcp.json",
+];
+
+/// Probe `root`.
+pub fn probe(root: &Path) -> std::io::Result<RepoContext> {
+    let root = root.canonicalize()?;
+    let exists = |rel: &str| root.join(rel).exists();
+
+    let mut ecosystems = BTreeSet::new();
+    if exists("Cargo.toml") {
+        ecosystems.insert(Ecosystem::Cargo);
+    }
+    if exists("package.json") {
+        ecosystems.insert(Ecosystem::Npm);
+    }
+    if exists("pyproject.toml") || exists("requirements.txt") || exists("setup.py") {
+        ecosystems.insert(Ecosystem::Python);
+    }
+    if exists("go.mod") {
+        ecosystems.insert(Ecosystem::Go);
+    }
+
+    let mut ci = BTreeSet::new();
+    if has_yaml(&root.join(".github/workflows")) {
+        ci.insert(CiSystem::GithubActions);
+    }
+    if exists(".gitlab-ci.yml") {
+        ci.insert(CiSystem::GitlabCi);
+    }
+    if exists(".circleci/config.yml") {
+        ci.insert(CiSystem::CircleCi);
+    }
+
+    let has_git = root.join(".git").exists();
+    let remotes = if has_git {
+        parse_remotes(&root)
+    } else {
+        Vec::new()
+    };
+
+    let mut mcp_servers = BTreeSet::new();
+    for loc in MCP_CONFIG_LOCATIONS {
+        if let Ok(content) = fs::read_to_string(root.join(loc))
+            && let Ok(value) = serde_json::from_str::<serde_json::Value>(&content)
+            && let Some(servers) = value.get("mcpServers").and_then(|v| v.as_object())
+        {
+            mcp_servers.extend(servers.keys().cloned());
+        }
+    }
+
+    let has_egress_policy = exists(".nucleus/egress.toml");
+
+    let mut ctx = RepoContext {
+        root,
+        ecosystems,
+        ci,
+        remotes,
+        has_git,
+        mcp_servers,
+        has_egress_policy,
+        digest: String::new(),
+    };
+    ctx.digest = digest_of(&ctx);
+    Ok(ctx)
+}
+
+fn has_yaml(dir: &Path) -> bool {
+    fs::read_dir(dir).is_ok_and(|rd| {
+        rd.filter_map(Result::ok).any(|e| {
+            e.path()
+                .extension()
+                .is_some_and(|x| x == "yml" || x == "yaml")
+        })
+    })
+}
+
+/// Parse `[remote "<name>"] url = <url>` from `.git/config` (or the
+/// `gitdir:` target of a worktree's `.git` file).
+fn parse_remotes(root: &Path) -> Vec<GitRemote> {
+    let git = root.join(".git");
+    let config_path = if git.is_dir() {
+        git.join("config")
+    } else {
+        match fs::read_to_string(&git) {
+            Ok(s) => match s.trim().strip_prefix("gitdir:") {
+                Some(dir) => {
+                    let dir = dir.trim();
+                    let p = if Path::new(dir).is_absolute() {
+                        PathBuf::from(dir)
+                    } else {
+                        root.join(dir)
+                    };
+                    // A linked worktree's gitdir is <repo>/.git/worktrees/<n>.
+                    p.parent()
+                        .and_then(Path::parent)
+                        .map(|common| common.join("config"))
+                        .unwrap_or(p.join("config"))
+                }
+                None => return Vec::new(),
+            },
+            Err(_) => return Vec::new(),
+        }
+    };
+    let Ok(content) = fs::read_to_string(config_path) else {
+        return Vec::new();
+    };
+    let mut remotes = Vec::new();
+    let mut current: Option<String> = None;
+    for line in content.lines() {
+        let line = line.trim();
+        if let Some(rest) = line.strip_prefix("[remote \"")
+            && let Some(name) = rest.strip_suffix("\"]")
+        {
+            current = Some(name.to_string());
+            continue;
+        }
+        if line.starts_with('[') {
+            current = None;
+            continue;
+        }
+        if let Some(name) = &current
+            && let Some(url) = line.strip_prefix("url")
+        {
+            let url = url.trim_start().trim_start_matches('=').trim();
+            if let Some((host, owner_repo)) = parse_remote_url(url) {
+                remotes.push(GitRemote {
+                    name: name.clone(),
+                    host,
+                    owner_repo,
+                });
+            }
+        }
+    }
+    remotes.sort();
+    remotes
+}
+
+/// `https://github.com/o/r.git`, `git@github.com:o/r.git`, `ssh://git@host/o/r`.
+fn parse_remote_url(url: &str) -> Option<(String, Option<String>)> {
+    let (host, path) = if let Some(rest) = url.split_once("://").map(|(_, r)| r) {
+        let rest = rest.rsplit('@').next().unwrap_or(rest);
+        let (host, path) = rest.split_once('/')?;
+        (host.split(':').next()?.to_string(), path.to_string())
+    } else if let Some((userhost, path)) = url.split_once(':') {
+        let host = userhost.rsplit('@').next().unwrap_or(userhost);
+        (host.to_string(), path.to_string())
+    } else {
+        return None;
+    };
+    if host.is_empty() {
+        return None;
+    }
+    let path = path.trim_end_matches('/').trim_end_matches(".git");
+    let parts: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
+    let owner_repo = if parts.len() >= 2 {
+        Some(format!(
+            "{}/{}",
+            parts[parts.len() - 2],
+            parts[parts.len() - 1]
+        ))
+    } else {
+        None
+    };
+    Some((host.to_ascii_lowercase(), owner_repo))
+}
+
+fn digest_of(ctx: &RepoContext) -> String {
+    let facts = serde_json::json!({
+        "ecosystems": ctx.ecosystems,
+        "ci": ctx.ci,
+        "remotes": ctx.remotes,
+        "has_git": ctx.has_git,
+        "mcp_servers": ctx.mcp_servers,
+        "has_egress_policy": ctx.has_egress_policy,
+    });
+    let bytes = serde_json::to_vec(&facts).unwrap_or_default();
+    let hash = Sha256::digest(&bytes);
+    hash.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_common_remote_urls() {
+        assert_eq!(
+            parse_remote_url("https://github.com/acme/widgets.git"),
+            Some(("github.com".into(), Some("acme/widgets".into())))
+        );
+        assert_eq!(
+            parse_remote_url("git@github.com:acme/widgets.git"),
+            Some(("github.com".into(), Some("acme/widgets".into())))
+        );
+        assert_eq!(
+            parse_remote_url("ssh://git@gitlab.example.com:2222/acme/widgets"),
+            Some(("gitlab.example.com".into(), Some("acme/widgets".into())))
+        );
+        assert_eq!(parse_remote_url("nonsense"), None);
+    }
+
+    #[test]
+    fn probe_detects_ecosystem_ci_and_remote() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        fs::write(root.join("Cargo.toml"), "[package]\nname='x'\n").unwrap();
+        fs::create_dir_all(root.join(".github/workflows")).unwrap();
+        fs::write(root.join(".github/workflows/ci.yml"), "on: push\n").unwrap();
+        fs::create_dir_all(root.join(".git")).unwrap();
+        fs::write(
+            root.join(".git/config"),
+            "[core]\n\tbare = false\n[remote \"origin\"]\n\turl = git@github.com:acme/widgets.git\n\tfetch = +refs/heads/*:refs/remotes/origin/*\n",
+        )
+        .unwrap();
+        fs::write(
+            root.join(".mcp.json"),
+            r#"{"mcpServers":{"github":{"command":"x"},"fs":{"command":"y"}}}"#,
+        )
+        .unwrap();
+        let ctx = probe(root).unwrap();
+        assert!(ctx.ecosystems.contains(&Ecosystem::Cargo));
+        assert!(ctx.ci.contains(&CiSystem::GithubActions));
+        assert!(ctx.has_remote_host("github.com"));
+        assert_eq!(ctx.remotes[0].owner_repo.as_deref(), Some("acme/widgets"));
+        assert_eq!(ctx.mcp_servers.len(), 2);
+        assert_eq!(ctx.digest.len(), 64);
+
+        // The digest is over facts, not the path: a second checkout agrees.
+        let dir2 = tempfile::tempdir().unwrap();
+        let root2 = dir2.path();
+        fs::write(root2.join("Cargo.toml"), "[package]\nname='y'\n").unwrap();
+        fs::create_dir_all(root2.join(".github/workflows")).unwrap();
+        fs::write(root2.join(".github/workflows/ci.yml"), "on: push\n").unwrap();
+        fs::create_dir_all(root2.join(".git")).unwrap();
+        fs::copy(root.join(".git/config"), root2.join(".git/config")).unwrap();
+        fs::copy(root.join(".mcp.json"), root2.join(".mcp.json")).unwrap();
+        let ctx2 = probe(root2).unwrap();
+        assert_eq!(ctx.digest, ctx2.digest);
+    }
+
+    #[test]
+    fn empty_directory_is_a_valid_context() {
+        let dir = tempfile::tempdir().unwrap();
+        let ctx = probe(dir.path()).unwrap();
+        assert!(ctx.ecosystems.is_empty());
+        assert!(ctx.ci.is_empty());
+        assert!(!ctx.has_git);
+        assert!(ctx.remotes.is_empty());
+    }
+}

--- a/crates/nucleus-task-compiler/src/rules.rs
+++ b/crates/nucleus-task-compiler/src/rules.rs
@@ -1,0 +1,413 @@
+//! The deterministic proposer: goal phrases × repository context → effects.
+//!
+//! Rules are data, and every one that fires is named in the grant's
+//! provenance, so "why did it grant that?" always has an answer a person can
+//! read. A rule is a set of phrases (matched as whole-word sequences in the
+//! lowercased goal), an optional requirement on the repository context, and
+//! the effects it proposes. Rules only ever *add* effects; the ceiling is
+//! what removes them, and that happens in [`crate::compile`].
+
+use std::collections::BTreeSet;
+
+use portcullis::EffectId;
+
+use crate::proposer::Proposal;
+use crate::repo_context::{CiSystem, Ecosystem, RepoContext};
+
+/// A requirement on the repository context for a rule to fire.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Requires {
+    /// The ecosystem is present.
+    Ecosystem(Ecosystem),
+    /// The CI system is present.
+    Ci(CiSystem),
+    /// Some remote is on this host.
+    RemoteHost(&'static str),
+    /// The root is a git work tree.
+    Git,
+}
+
+impl Requires {
+    fn holds(self, ctx: &RepoContext) -> bool {
+        match self {
+            Self::Ecosystem(e) => ctx.ecosystems.contains(&e),
+            Self::Ci(c) => ctx.ci.contains(&c),
+            Self::RemoteHost(h) => ctx.has_remote_host(h),
+            Self::Git => ctx.has_git,
+        }
+    }
+}
+
+/// One rule.
+#[derive(Debug, Clone, Copy)]
+pub struct Rule {
+    /// Stable id, recorded in provenance.
+    pub id: &'static str,
+    /// Any of these phrases in the goal fires the rule.
+    pub any_of: &'static [&'static str],
+    /// Context requirement, if any.
+    pub requires: Option<Requires>,
+    /// Effects proposed.
+    pub effects: &'static [&'static str],
+}
+
+/// Effects every recognised goal gets: reading the workspace, and reading
+/// git history when there is one. A goal that fires no other rule is not
+/// recognised (see [`apply`]).
+const BASE_EFFECTS: &[(&str, Option<Requires>)] = &[
+    ("fs/read-workspace", None),
+    ("git/read-history", Some(Requires::Git)),
+];
+
+/// The rule table.
+pub const RULES: &[Rule] = &[
+    Rule {
+        id: "ci-logs",
+        any_of: &[
+            "ci",
+            "ci build",
+            "pipeline",
+            "workflow",
+            "github actions",
+            "failing build",
+            "build failing",
+            "build is failing",
+            "checks failing",
+            "failing checks",
+            "red build",
+        ],
+        requires: Some(Requires::Ci(CiSystem::GithubActions)),
+        effects: &["github/read-ci-logs"],
+    },
+    Rule {
+        id: "fix",
+        any_of: &[
+            "fix",
+            "repair",
+            "bug",
+            "broken",
+            "failing",
+            "resolve",
+            "make it pass",
+        ],
+        requires: None,
+        effects: &["fs/edit-workspace", "shell/run-tests", "git/commit"],
+    },
+    Rule {
+        id: "implement",
+        any_of: &[
+            "implement",
+            "add",
+            "write",
+            "create",
+            "refactor",
+            "rename",
+            "change",
+            "update the code",
+        ],
+        requires: None,
+        effects: &[
+            "fs/edit-workspace",
+            "shell/run-tests",
+            "shell/run-build",
+            "git/commit",
+        ],
+    },
+    Rule {
+        id: "test",
+        any_of: &["test", "tests", "testing", "coverage"],
+        requires: None,
+        effects: &["shell/run-tests"],
+    },
+    Rule {
+        id: "build",
+        any_of: &["build", "compile"],
+        requires: None,
+        effects: &["shell/run-build"],
+    },
+    Rule {
+        id: "lint",
+        any_of: &["lint", "clippy", "format", "fmt", "warnings"],
+        requires: None,
+        effects: &["shell/run-lint", "fs/edit-workspace"],
+    },
+    Rule {
+        id: "deps-cargo",
+        any_of: &[
+            "upgrade",
+            "bump",
+            "dependency",
+            "dependencies",
+            "update deps",
+        ],
+        requires: Some(Requires::Ecosystem(Ecosystem::Cargo)),
+        effects: &[
+            "web/package-registry-crates",
+            "fs/edit-workspace",
+            "shell/run-build",
+            "shell/run-tests",
+            "git/commit",
+        ],
+    },
+    Rule {
+        id: "deps-npm",
+        any_of: &[
+            "upgrade",
+            "bump",
+            "dependency",
+            "dependencies",
+            "update deps",
+        ],
+        requires: Some(Requires::Ecosystem(Ecosystem::Npm)),
+        effects: &[
+            "web/package-registry-npm",
+            "fs/edit-workspace",
+            "shell/run-build",
+            "shell/run-tests",
+            "git/commit",
+        ],
+    },
+    Rule {
+        id: "deps-pypi",
+        any_of: &[
+            "upgrade",
+            "bump",
+            "dependency",
+            "dependencies",
+            "update deps",
+        ],
+        requires: Some(Requires::Ecosystem(Ecosystem::Python)),
+        effects: &[
+            "web/package-registry-pypi",
+            "fs/edit-workspace",
+            "shell/run-tests",
+            "git/commit",
+        ],
+    },
+    Rule {
+        id: "issue",
+        any_of: &["issue", "ticket"],
+        requires: Some(Requires::RemoteHost("github.com")),
+        effects: &["github/read-issue"],
+    },
+    Rule {
+        id: "pr-read",
+        any_of: &["review", "pull request", "pr", "prs", "pull requests"],
+        requires: Some(Requires::RemoteHost("github.com")),
+        effects: &["github/read-pull-request"],
+    },
+    Rule {
+        id: "pr-open",
+        any_of: &[
+            "open a pr",
+            "open a pull request",
+            "create a pr",
+            "create a pull request",
+            "submit a pr",
+            "submit a pull request",
+            "send a pr",
+            "push",
+        ],
+        requires: Some(Requires::RemoteHost("github.com")),
+        effects: &["github/open-pr", "git/push-branch", "git/commit"],
+    },
+    Rule {
+        id: "pr-comment",
+        any_of: &["comment", "reply"],
+        requires: Some(Requires::RemoteHost("github.com")),
+        effects: &["github/comment"],
+    },
+    Rule {
+        id: "merge",
+        any_of: &["merge"],
+        requires: Some(Requires::RemoteHost("github.com")),
+        effects: &["github/merge-pr"],
+    },
+    Rule {
+        id: "docs",
+        any_of: &["docs", "documentation", "readme", "document", "changelog"],
+        requires: None,
+        effects: &["fs/edit-workspace", "git/commit"],
+    },
+    Rule {
+        id: "research",
+        any_of: &[
+            "research",
+            "investigate",
+            "explore",
+            "understand",
+            "explain",
+            "audit",
+            "summarize",
+            "summarise",
+            "what does",
+        ],
+        requires: None,
+        effects: &[],
+    },
+    Rule {
+        id: "web-search",
+        any_of: &["search the web", "look up online", "web search", "google"],
+        requires: None,
+        effects: &["web/search"],
+    },
+];
+
+/// Run every rule against the goal. Returns an empty proposal (no rules
+/// fired, no effects) when nothing recognises the goal; the base effects
+/// are added only when at least one rule fired.
+pub fn apply(goal: &str, ctx: &RepoContext) -> Proposal {
+    let words = tokenize(goal);
+    let mut effects = BTreeSet::new();
+    let mut fired = Vec::new();
+    for rule in RULES {
+        if !rule
+            .any_of
+            .iter()
+            .any(|phrase| contains_phrase(&words, phrase))
+        {
+            continue;
+        }
+        if let Some(req) = rule.requires
+            && !req.holds(ctx)
+        {
+            continue;
+        }
+        fired.push(rule.id.to_string());
+        for e in rule.effects {
+            effects.insert(parse(e));
+        }
+    }
+    if !fired.is_empty() {
+        for (e, req) in BASE_EFFECTS {
+            if req.is_none_or(|r| r.holds(ctx)) {
+                effects.insert(parse(e));
+            }
+        }
+    }
+    Proposal {
+        proposer: "rules".to_string(),
+        effects,
+        rules_fired: fired,
+    }
+}
+
+fn parse(s: &str) -> EffectId {
+    s.parse().expect("RULES names only well-formed effect ids")
+}
+
+/// Lowercase alphanumeric words; punctuation splits.
+fn tokenize(s: &str) -> Vec<String> {
+    s.to_lowercase()
+        .split(|c: char| !c.is_alphanumeric() && c != '-' && c != '_')
+        .filter(|w| !w.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+fn contains_phrase(words: &[String], phrase: &str) -> bool {
+    let p = tokenize(phrase);
+    if p.is_empty() || words.len() < p.len() {
+        return false;
+    }
+    words.windows(p.len()).any(|w| w == p.as_slice())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn ctx(ci: bool, github: bool, cargo: bool) -> RepoContext {
+        let mut c = RepoContext {
+            root: PathBuf::from("/tmp/x"),
+            ecosystems: BTreeSet::new(),
+            ci: BTreeSet::new(),
+            remotes: Vec::new(),
+            has_git: true,
+            mcp_servers: BTreeSet::new(),
+            has_egress_policy: false,
+            digest: "d".into(),
+        };
+        if ci {
+            c.ci.insert(CiSystem::GithubActions);
+        }
+        if github {
+            c.remotes.push(crate::repo_context::GitRemote {
+                name: "origin".into(),
+                host: "github.com".into(),
+                owner_repo: Some("a/b".into()),
+            });
+        }
+        if cargo {
+            c.ecosystems.insert(Ecosystem::Cargo);
+        }
+        c
+    }
+
+    fn has(p: &Proposal, e: &str) -> bool {
+        p.effects.contains(&e.parse().unwrap())
+    }
+
+    #[test]
+    fn every_rule_names_valid_effects_in_the_builtin_catalog() {
+        let catalog = portcullis::EffectCatalog::builtin().unwrap();
+        for rule in RULES {
+            for e in rule.effects {
+                let id: EffectId = e.parse().unwrap();
+                assert!(
+                    catalog.get(&id).is_some(),
+                    "rule {} names unknown {e}",
+                    rule.id
+                );
+            }
+        }
+        for (e, _) in BASE_EFFECTS {
+            assert!(catalog.get(&e.parse().unwrap()).is_some());
+        }
+    }
+
+    #[test]
+    fn fix_ci_with_actions_reads_ci_logs() {
+        let p = apply("fix the failing CI build", &ctx(true, true, true));
+        assert!(has(&p, "github/read-ci-logs"));
+        assert!(has(&p, "fs/edit-workspace"));
+        assert!(has(&p, "shell/run-tests"));
+        assert!(has(&p, "fs/read-workspace"));
+        assert!(has(&p, "git/read-history"));
+        assert!(!has(&p, "github/open-pr"), "fix does not imply publishing");
+        assert!(p.rules_fired.contains(&"ci-logs".to_string()));
+    }
+
+    #[test]
+    fn context_requirements_gate_rules() {
+        let p = apply("fix the failing CI build", &ctx(false, true, true));
+        assert!(!has(&p, "github/read-ci-logs"), "no CI system, no CI logs");
+        let p = apply("upgrade axum and fix the tests", &ctx(true, true, false));
+        assert!(
+            !has(&p, "web/package-registry-crates"),
+            "no Cargo.toml, no crates.io"
+        );
+        let p = apply("upgrade axum and fix the tests", &ctx(true, true, true));
+        assert!(has(&p, "web/package-registry-crates"));
+    }
+
+    #[test]
+    fn unrecognised_goal_proposes_nothing() {
+        let p = apply("hello there", &ctx(true, true, true));
+        assert!(p.effects.is_empty());
+        assert!(p.rules_fired.is_empty());
+    }
+
+    #[test]
+    fn phrases_match_whole_words() {
+        let p = apply("clarify the spec", &ctx(true, true, true));
+        assert!(
+            !has(&p, "github/read-ci-logs"),
+            "'ci' inside 'clarify' is not CI"
+        );
+        let p = apply("push a branch and open a PR", &ctx(true, true, true));
+        assert!(has(&p, "github/open-pr"));
+        assert!(has(&p, "git/push-branch"));
+    }
+}

--- a/crates/nucleus-task-compiler/tests/fixtures/greedy-proposer.sh
+++ b/crates/nucleus-task-compiler/tests/fixtures/greedy-proposer.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+# A deliberately greedy external proposer: whatever the goal, ask for the
+# widest GitHub effects plus one the catalog does not know. The compiler
+# must clamp the former under the ceiling and drop the latter.
+cat >/dev/null
+printf '%s\n' '{"effects":["github/merge-pr","github/open-pr","git/push-branch","github/delete-repo","fs/read-workspace"],"reasons":["greedy"]}'

--- a/crates/nucleus-task-compiler/tests/goal_corpus.rs
+++ b/crates/nucleus-task-compiler/tests/goal_corpus.rs
@@ -1,0 +1,272 @@
+//! The two properties the compiler exists for, over a goal corpus and every
+//! canonical ceiling:
+//!
+//! 1. **Clamped**: the compiled lattice is ≤ the ceiling, always.
+//! 2. **Fail-closed**: unrecognised goals and out-of-ceiling proposals are
+//!    reported, never granted.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use nucleus_task_compiler::{
+    CompileError, CompileInput, EffectProposer, ExternalCommandProposer, LimitOverrides,
+    RuleProposer, compile,
+};
+use portcullis::profile::ProfileRegistry;
+use portcullis::{CapabilityLevel, EffectCatalog, EffectId, Operation, WeakeningCostConfig};
+
+const GOALS: &[&str] = &[
+    "fix the failing CI build",
+    "fix the flaky test in the keystore",
+    "upgrade axum and fix the tests",
+    "add a --json flag to the status command",
+    "refactor the parser into a separate module",
+    "run the tests and report what fails",
+    "make clippy happy",
+    "update the README for the new CLI",
+    "investigate why the build is slow",
+    "review the open pull requests",
+    "open a PR with the fix",
+    "merge the dependency PR",
+    "comment on issue 42 with the root cause",
+    "explain what the kernel does",
+    "implement the feature described in issue 17",
+];
+
+fn repo_with_ci_and_github() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    fs::write(
+        root.join("Cargo.toml"),
+        "[package]\nname='x'\nversion='0.1.0'\n",
+    )
+    .unwrap();
+    fs::create_dir_all(root.join(".github/workflows")).unwrap();
+    fs::write(root.join(".github/workflows/ci.yml"), "on: push\n").unwrap();
+    fs::create_dir_all(root.join(".git")).unwrap();
+    fs::write(
+        root.join(".git/config"),
+        "[remote \"origin\"]\n\turl = https://github.com/acme/widgets.git\n",
+    )
+    .unwrap();
+    dir
+}
+
+fn ceilings() -> Vec<(String, portcullis::PermissionLattice)> {
+    let registry = ProfileRegistry::canonical().unwrap();
+    let mut names: Vec<String> = registry.names().iter().map(|s| s.to_string()).collect();
+    names.sort();
+    names
+        .into_iter()
+        .map(|n| {
+            let l = registry.resolve(&n).unwrap();
+            (n, l)
+        })
+        .collect()
+}
+
+#[test]
+fn every_goal_under_every_ceiling_is_clamped_and_attributed() {
+    let dir = repo_with_ci_and_github();
+    let ctx = nucleus_task_compiler::probe(dir.path()).unwrap();
+    let catalog = EffectCatalog::builtin().unwrap();
+    let cost = WeakeningCostConfig::default();
+    let rules = RuleProposer;
+    let proposers: [&dyn EffectProposer; 1] = [&rules];
+    let explicit = BTreeSet::new();
+
+    for goal in GOALS {
+        for (name, ceiling) in ceilings() {
+            let result = compile(CompileInput {
+                goal,
+                ctx: &ctx,
+                catalog: &catalog,
+                ceiling_profile: &name,
+                ceiling: &ceiling,
+                proposers: &proposers,
+                explicit: &explicit,
+                limits: LimitOverrides::default(),
+                cost_config: &cost,
+            });
+            let grant = match result {
+                Ok(g) => g,
+                Err(CompileError::NothingWithinCeiling { .. }) => continue,
+                Err(e) => panic!("{goal:?} under {name}: {e}"),
+            };
+            assert!(
+                grant.lattice.leq(&ceiling),
+                "{goal:?} under {name}: grant is not ≤ ceiling"
+            );
+            assert!(grant.assert_within(&ceiling).is_ok());
+            for id in &grant.can {
+                assert!(catalog.get(id).is_some(), "granted unknown effect {id}");
+            }
+            // Everything proposed is either in `can` or in `cannot`, never lost.
+            let proposed = nucleus_task_compiler::apply(goal, &ctx).effects;
+            for id in &proposed {
+                let in_can = grant.can.contains(id);
+                let in_cannot = grant.cannot.iter().any(|c| &c.id == id);
+                assert!(
+                    in_can ^ in_cannot,
+                    "{id} under {name}: must be in exactly one of can/cannot"
+                );
+            }
+            // Hosts come only from granted effects.
+            for h in &grant.limits.hosts {
+                assert!(
+                    grant
+                        .can
+                        .iter()
+                        .any(|id| catalog.get(id).unwrap().hosts.contains(h)),
+                    "host {h} not vouched for by a granted effect"
+                );
+            }
+            assert_eq!(grant.goal_digest, portcullis::TaskGrant::digest_goal(goal));
+        }
+    }
+}
+
+#[test]
+fn fix_ci_under_safe_pr_fixer_reads_logs_but_cannot_publish() {
+    let dir = repo_with_ci_and_github();
+    let ctx = nucleus_task_compiler::probe(dir.path()).unwrap();
+    let catalog = EffectCatalog::builtin().unwrap();
+    let registry = ProfileRegistry::canonical().unwrap();
+    let ceiling = registry.resolve("safe-pr-fixer").unwrap();
+    let rules = RuleProposer;
+    let proposers: [&dyn EffectProposer; 1] = [&rules];
+    let grant = compile(CompileInput {
+        goal: "fix the failing CI build",
+        ctx: &ctx,
+        catalog: &catalog,
+        ceiling_profile: "safe-pr-fixer",
+        ceiling: &ceiling,
+        proposers: &proposers,
+        explicit: &BTreeSet::new(),
+        limits: LimitOverrides::default(),
+        cost_config: &WeakeningCostConfig::default(),
+    })
+    .unwrap();
+    let id = |s: &str| s.parse::<EffectId>().unwrap();
+    assert!(grant.can.contains(&id("github/read-ci-logs")));
+    assert!(grant.can.contains(&id("shell/run-tests")));
+    assert!(grant.can.contains(&id("fs/edit-workspace")));
+    assert!(!grant.can.contains(&id("github/open-pr")));
+    assert_eq!(
+        grant.lattice.capabilities.level_for(Operation::GitPush),
+        CapabilityLevel::Never
+    );
+    assert_eq!(
+        grant.lattice.capabilities.level_for(Operation::CreatePr),
+        CapabilityLevel::Never
+    );
+    assert_eq!(grant.limits.hosts, vec!["api.github.com".to_string()]);
+    assert!(
+        grant
+            .provenance
+            .rules_fired
+            .contains(&"ci-logs".to_string())
+    );
+    let text = portcullis::render_grant(&grant, &catalog, portcullis::Disclosure::Plain);
+    assert!(text.contains("read CI logs"), "{text}");
+    assert!(text.contains("push to remote branches"), "{text}");
+}
+
+#[test]
+fn unrecognised_goal_fails_closed() {
+    let dir = repo_with_ci_and_github();
+    let ctx = nucleus_task_compiler::probe(dir.path()).unwrap();
+    let catalog = EffectCatalog::builtin().unwrap();
+    let registry = ProfileRegistry::canonical().unwrap();
+    let ceiling = registry.resolve("codegen").unwrap();
+    let rules = RuleProposer;
+    let proposers: [&dyn EffectProposer; 1] = [&rules];
+    let err = compile(CompileInput {
+        goal: "hello there",
+        ctx: &ctx,
+        catalog: &catalog,
+        ceiling_profile: "codegen",
+        ceiling: &ceiling,
+        proposers: &proposers,
+        explicit: &BTreeSet::new(),
+        limits: LimitOverrides::default(),
+        cost_config: &WeakeningCostConfig::default(),
+    })
+    .unwrap_err();
+    assert!(
+        matches!(err, CompileError::NothingRecognised { .. }),
+        "{err}"
+    );
+}
+
+#[test]
+fn a_greedy_external_proposer_is_clamped_and_unknown_effects_dropped() {
+    let dir = repo_with_ci_and_github();
+    let ctx = nucleus_task_compiler::probe(dir.path()).unwrap();
+    let catalog = EffectCatalog::builtin().unwrap();
+    let registry = ProfileRegistry::canonical().unwrap();
+    let ceiling = registry.resolve("safe-pr-fixer").unwrap();
+    let fixture: PathBuf =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/greedy-proposer.sh");
+    let greedy = ExternalCommandProposer { program: fixture };
+    let proposers: [&dyn EffectProposer; 1] = [&greedy];
+    let grant = compile(CompileInput {
+        goal: "anything at all",
+        ctx: &ctx,
+        catalog: &catalog,
+        ceiling_profile: "safe-pr-fixer",
+        ceiling: &ceiling,
+        proposers: &proposers,
+        explicit: &BTreeSet::new(),
+        limits: LimitOverrides::default(),
+        cost_config: &WeakeningCostConfig::default(),
+    })
+    .unwrap();
+    let id = |s: &str| s.parse::<EffectId>().unwrap();
+    assert!(grant.can.contains(&id("fs/read-workspace")));
+    for wide in ["github/merge-pr", "github/open-pr", "git/push-branch"] {
+        assert!(!grant.can.contains(&id(wide)), "{wide} must be clipped");
+        assert!(
+            grant.cannot.iter().any(|c| c.id == id(wide)),
+            "{wide} must be reported"
+        );
+    }
+    assert!(grant.lattice.leq(&ceiling));
+    assert!(grant.provenance.proposers[0].starts_with("external:"));
+    assert!(
+        grant
+            .provenance
+            .rules_fired
+            .iter()
+            .any(|r| r.contains("github/delete-repo"))
+    );
+}
+
+#[test]
+fn limit_overrides_only_tighten() {
+    let dir = repo_with_ci_and_github();
+    let ctx = nucleus_task_compiler::probe(dir.path()).unwrap();
+    let catalog = EffectCatalog::builtin().unwrap();
+    let registry = ProfileRegistry::canonical().unwrap();
+    let ceiling = registry.resolve("codegen").unwrap();
+    let rules = RuleProposer;
+    let proposers: [&dyn EffectProposer; 1] = [&rules];
+    let grant = compile(CompileInput {
+        goal: "fix the tests",
+        ctx: &ctx,
+        catalog: &catalog,
+        ceiling_profile: "codegen",
+        ceiling: &ceiling,
+        proposers: &proposers,
+        explicit: &BTreeSet::new(),
+        limits: LimitOverrides {
+            max_cost_usd: Some(rust_decimal::Decimal::new(100_000, 2)),
+            duration_hours: Some(1000),
+        },
+        cost_config: &WeakeningCostConfig::default(),
+    })
+    .unwrap();
+    assert!(grant.limits.max_cost_usd <= ceiling.budget.max_cost_usd);
+    assert!(grant.not_after <= ceiling.time.valid_until);
+}

--- a/crates/portcullis/effects/fs.toml
+++ b/crates/portcullis/effects/fs.toml
@@ -1,0 +1,33 @@
+# Built-in semantic effects: the workspace filesystem.
+#
+# An effect is the unit of authority a person reads and approves ("edit
+# workspace files"), not the lattice dimension it lowers to. The compiler
+# (crates/nucleus-task-compiler) lowers a set of effects into the 13-dim
+# CapabilityLattice + sinks + hosts; the reverse indexes (`matches`) let a
+# trace be attributed back to the effect that authorised it.
+
+[plugin]
+name = "fs"
+version = 1
+
+[[effect]]
+id = "read-workspace"
+title = "Read and search workspace files"
+risk = "read"
+level = "always"
+[effect.lowers]
+operations = ["read_files", "glob_search", "grep_search"]
+[effect.matches]
+mcp_tools = ["read", "glob", "grep", "read_file", "list_directory", "search_files"]
+commands = ["cat", "ls", "find", "rg", "grep", "head", "tail", "sed -n", "wc"]
+
+[[effect]]
+id = "edit-workspace"
+title = "Edit workspace files"
+risk = "write_local"
+[effect.lowers]
+operations = ["write_files", "edit_files"]
+sinks = ["workspace_write"]
+[effect.matches]
+mcp_tools = ["write", "edit", "write_file", "edit_file", "create_directory", "move_file"]
+commands = ["sed -i", "tee", "mv", "cp", "mkdir", "touch"]

--- a/crates/portcullis/effects/git.toml
+++ b/crates/portcullis/effects/git.toml
@@ -1,0 +1,43 @@
+# Built-in semantic effects: version control.
+#
+# `commit` and `push-branch` are deliberately separate effects: the canonical
+# safe-pr-fixer profile lets an agent commit locally while a trusted CI
+# wrapper pushes, and the compiler must be able to express exactly that.
+
+[plugin]
+name = "git"
+version = 1
+
+[[effect]]
+id = "read-history"
+title = "Read git history and status"
+risk = "read"
+[effect.lowers]
+operations = ["run_bash"]
+sinks = ["bash_exec"]
+[effect.matches]
+mcp_tools = ["git_status", "git_log", "git_diff", "git_show"]
+commands = ["git status", "git log", "git diff", "git show", "git branch", "git blame", "git rev-parse"]
+
+[[effect]]
+id = "commit"
+title = "Commit changes locally"
+risk = "write_local"
+[effect.lowers]
+operations = ["git_commit"]
+sinks = ["git_commit"]
+[effect.matches]
+mcp_tools = ["git_add", "git_commit"]
+commands = ["git add", "git commit", "git checkout -b", "git switch -c", "git stash"]
+
+[[effect]]
+id = "push-branch"
+title = "Push a branch to the remote"
+risk = "publish"
+[effect.lowers]
+operations = ["git_push"]
+sinks = ["git_push"]
+hosts = ["github.com"]
+[effect.matches]
+mcp_tools = ["git_push", "push_files"]
+commands = ["git push"]

--- a/crates/portcullis/effects/github.toml
+++ b/crates/portcullis/effects/github.toml
@@ -1,0 +1,97 @@
+# Built-in semantic effects: a GitHub-hosted repository.
+#
+# These are the authority units a person reads ("read CI logs", "open a pull
+# request"), each lowered to core dimensions and pinned to api.github.com.
+# The `http` index is the host→meaning table: one method+path per effect,
+# so a later milestone can enforce the effect at the credential boundary
+# rather than by host alone. Until then the effect is enforced at the MCP
+# tool surface, the egress host list, and the `commands` prefixes.
+
+[plugin]
+name = "github"
+version = 1
+
+[[effect]]
+id = "read-issue"
+title = "Read issues"
+risk = "read"
+[effect.lowers]
+operations = ["web_fetch"]
+sinks = ["http_egress"]
+hosts = ["api.github.com"]
+[effect.matches]
+mcp_tools = ["issue_read", "get_issue", "list_issues", "search_issues"]
+commands = ["gh issue view", "gh issue list"]
+http = [{ method = "GET", host = "api.github.com", path = "/repos/*/issues*" }]
+
+[[effect]]
+id = "read-ci-logs"
+title = "Read CI logs and workflow runs"
+risk = "read"
+[effect.lowers]
+operations = ["web_fetch"]
+sinks = ["http_egress"]
+hosts = ["api.github.com"]
+[effect.matches]
+mcp_tools = ["get_job_logs", "actions_get", "actions_list", "list_workflow_runs", "get_check_run"]
+commands = ["gh run view", "gh run list", "gh run download", "gh api repos/*/actions"]
+http = [
+  { method = "GET", host = "api.github.com", path = "/repos/*/actions/*" },
+  { method = "GET", host = "api.github.com", path = "/repos/*/check-runs/*" },
+  { method = "GET", host = "api.github.com", path = "/repos/*/commits/*/check-runs" },
+]
+
+[[effect]]
+id = "read-pull-request"
+title = "Read pull requests and reviews"
+risk = "read"
+[effect.lowers]
+operations = ["web_fetch"]
+sinks = ["http_egress"]
+hosts = ["api.github.com"]
+[effect.matches]
+mcp_tools = ["pull_request_read", "get_pull_request", "list_pull_requests"]
+commands = ["gh pr view", "gh pr list", "gh pr diff", "gh pr checks"]
+http = [{ method = "GET", host = "api.github.com", path = "/repos/*/pulls*" }]
+
+[[effect]]
+id = "comment"
+title = "Comment on issues and pull requests"
+risk = "publish"
+[effect.lowers]
+operations = ["create_pr"]
+sinks = ["pr_comment_write"]
+hosts = ["api.github.com"]
+[effect.matches]
+mcp_tools = ["add_issue_comment", "add_reply_to_pull_request_comment", "pull_request_review_write"]
+commands = ["gh pr comment", "gh issue comment", "gh pr review"]
+http = [
+  { method = "POST", host = "api.github.com", path = "/repos/*/issues/*/comments" },
+  { method = "POST", host = "api.github.com", path = "/repos/*/pulls/*/reviews" },
+]
+
+[[effect]]
+id = "open-pr"
+title = "Open a pull request"
+risk = "publish"
+[effect.lowers]
+operations = ["create_pr", "git_push"]
+sinks = ["git_push", "pr_comment_write"]
+hosts = ["api.github.com", "github.com"]
+[effect.matches]
+mcp_tools = ["create_pull_request"]
+commands = ["gh pr create"]
+http = [{ method = "POST", host = "api.github.com", path = "/repos/*/pulls" }]
+
+[[effect]]
+id = "merge-pr"
+title = "Merge a pull request"
+risk = "mutate_remote"
+[effect.lowers]
+operations = ["git_push"]
+sinks = ["git_push"]
+hosts = ["api.github.com"]
+[effect.matches]
+mcp_tools = ["merge_pull_request", "enable_pr_auto_merge"]
+commands = ["gh pr merge"]
+http = [{ method = "PUT", host = "api.github.com", path = "/repos/*/pulls/*/merge" }]

--- a/crates/portcullis/effects/shell.toml
+++ b/crates/portcullis/effects/shell.toml
@@ -1,0 +1,43 @@
+# Built-in semantic effects: running the project's own toolchain.
+#
+# Every effect here lowers to `run_bash`, which the kernel treats as an
+# exfiltration vector (a shell can reach anything). The `commands` reverse
+# index is what distinguishes "run the tests" from "run anything": it is the
+# vocabulary a later milestone narrows `CommandLattice` with.
+
+[plugin]
+name = "shell"
+version = 1
+
+[[effect]]
+id = "run-tests"
+title = "Run the test suite"
+risk = "execute"
+[effect.lowers]
+operations = ["run_bash"]
+sinks = ["bash_exec"]
+[effect.matches]
+mcp_tools = ["run", "bash", "execute_command"]
+commands = ["cargo test", "cargo nextest", "npm test", "pnpm test", "yarn test", "pytest", "python -m pytest", "go test", "make test", "make check"]
+
+[[effect]]
+id = "run-build"
+title = "Build the project"
+risk = "execute"
+[effect.lowers]
+operations = ["run_bash"]
+sinks = ["bash_exec"]
+[effect.matches]
+mcp_tools = ["run", "bash", "execute_command"]
+commands = ["cargo build", "cargo check", "npm run build", "pnpm build", "yarn build", "go build", "make", "python -m build"]
+
+[[effect]]
+id = "run-lint"
+title = "Run formatters and linters"
+risk = "execute"
+[effect.lowers]
+operations = ["run_bash"]
+sinks = ["bash_exec"]
+[effect.matches]
+mcp_tools = ["run", "bash", "execute_command"]
+commands = ["cargo clippy", "cargo fmt", "npm run lint", "pnpm lint", "eslint", "prettier", "ruff", "black", "go vet", "gofmt"]

--- a/crates/portcullis/effects/web.toml
+++ b/crates/portcullis/effects/web.toml
@@ -1,0 +1,63 @@
+# Built-in semantic effects: the public network.
+#
+# Package registries are named effects because "download Rust dependencies"
+# is what a person means when they approve crates.io, and a host list is not
+# a meaning. `hosts` here is the host→meaning table the compiler and the
+# egress policy share.
+
+[plugin]
+name = "web"
+version = 1
+
+[[effect]]
+id = "package-registry-crates"
+title = "Download Rust dependencies (crates.io)"
+risk = "read"
+[effect.lowers]
+operations = ["web_fetch"]
+sinks = ["http_egress"]
+hosts = ["crates.io", "static.crates.io", "index.crates.io"]
+[effect.matches]
+commands = ["cargo fetch", "cargo update", "cargo add"]
+http = [
+  { method = "GET", host = "crates.io", path = "/*" },
+  { method = "GET", host = "static.crates.io", path = "/*" },
+  { method = "GET", host = "index.crates.io", path = "/*" },
+]
+
+[[effect]]
+id = "package-registry-npm"
+title = "Download JavaScript dependencies (npm)"
+risk = "read"
+[effect.lowers]
+operations = ["web_fetch"]
+sinks = ["http_egress"]
+hosts = ["registry.npmjs.org"]
+[effect.matches]
+commands = ["npm install", "npm ci", "pnpm install", "yarn install"]
+http = [{ method = "GET", host = "registry.npmjs.org", path = "/*" }]
+
+[[effect]]
+id = "package-registry-pypi"
+title = "Download Python dependencies (PyPI)"
+risk = "read"
+[effect.lowers]
+operations = ["web_fetch"]
+sinks = ["http_egress"]
+hosts = ["pypi.org", "files.pythonhosted.org"]
+[effect.matches]
+commands = ["pip install", "uv pip install", "uv sync", "poetry install"]
+http = [
+  { method = "GET", host = "pypi.org", path = "/*" },
+  { method = "GET", host = "files.pythonhosted.org", path = "/*" },
+]
+
+[[effect]]
+id = "search"
+title = "Search the web"
+risk = "read"
+[effect.lowers]
+operations = ["web_search"]
+sinks = ["http_egress"]
+[effect.matches]
+mcp_tools = ["web_search", "search"]

--- a/crates/portcullis/src/effect_catalog.rs
+++ b/crates/portcullis/src/effect_catalog.rs
@@ -1,0 +1,833 @@
+//! Semantic effect catalog: the authority vocabulary a person reads.
+//!
+//! The 13-dimension [`CapabilityLattice`] is the verified core and the unit
+//! the kernel enforces. It is not the unit a person should have to reason
+//! about: "web_fetch: low_risk" says nothing about *what* is fetched, while
+//! "read CI logs" does. An **effect** is that human-sized unit — a named,
+//! titled, risk-graded authority (`github/read-ci-logs`) that *lowers* to
+//! core dimensions, sink classes and hosts, and carries reverse indexes
+//! (`matches`) so an observed tool call, command or HTTP request can be
+//! attributed back to the effect that authorised it.
+//!
+//! Effects are **data**: TOML files with a `[plugin]` header and `[[effect]]`
+//! entries. The built-in catalog (`crates/portcullis/effects/*.toml`) is
+//! embedded at compile time; a repository adds its own under
+//! `.nucleus/effects/`. Adding `github/merge-pr` is a TOML edit, not Rust.
+//!
+//! Lowering is *monotone and fail-closed*: it starts from every dimension at
+//! `Never` and raises only the operations the named effects list, so a set of
+//! effects can never lower to more authority than the union of its members,
+//! and an unknown effect is an error rather than a silent no-op.
+//!
+//! This module does not change the verified core. It is the vocabulary layer
+//! the task compiler (`nucleus-task-compiler`) and the grant renderer
+//! (`task_grant`) speak; the kernel keeps enforcing the lattice it lowers to.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+use std::path::Path;
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    classify_operation, CapabilityLattice, CapabilityLevel, ExposureSet, Operation, SinkClass,
+};
+
+/// The built-in catalog, one `(plugin name, TOML source)` per file under
+/// `crates/portcullis/effects/`. Embedded so a binary never depends on a
+/// checkout to know what "read CI logs" means.
+pub const BUILTIN_CATALOG: &[(&str, &str)] = &[
+    ("fs", include_str!("../effects/fs.toml")),
+    ("shell", include_str!("../effects/shell.toml")),
+    ("git", include_str!("../effects/git.toml")),
+    ("web", include_str!("../effects/web.toml")),
+    ("github", include_str!("../effects/github.toml")),
+];
+
+/// A fully-qualified effect name: `<plugin>/<id>`, both segments
+/// `[a-z0-9-]+`. This is the key a grant carries and a person sees.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(try_from = "String", into = "String")]
+pub struct EffectId {
+    /// The plugin (catalog file) that declares the effect.
+    pub plugin: String,
+    /// The effect's id within its plugin.
+    pub id: String,
+}
+
+impl EffectId {
+    /// Build an id from validated segments.
+    pub fn new(plugin: &str, id: &str) -> Result<Self, EffectCatalogError> {
+        if !is_segment(plugin) || !is_segment(id) {
+            return Err(EffectCatalogError::InvalidId(format!("{plugin}/{id}")));
+        }
+        Ok(Self {
+            plugin: plugin.to_string(),
+            id: id.to_string(),
+        })
+    }
+}
+
+fn is_segment(s: &str) -> bool {
+    !s.is_empty()
+        && s.bytes()
+            .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-')
+        && !s.starts_with('-')
+        && !s.ends_with('-')
+}
+
+impl fmt::Display for EffectId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}/{}", self.plugin, self.id)
+    }
+}
+
+impl FromStr for EffectId {
+    type Err = EffectCatalogError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (plugin, id) = s
+            .split_once('/')
+            .ok_or_else(|| EffectCatalogError::InvalidId(s.to_string()))?;
+        Self::new(plugin, id)
+    }
+}
+
+impl TryFrom<String> for EffectId {
+    type Error = EffectCatalogError;
+
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        s.parse()
+    }
+}
+
+impl From<EffectId> for String {
+    fn from(id: EffectId) -> Self {
+        id.to_string()
+    }
+}
+
+/// How much an effect can change the world, ordered from least to most.
+///
+/// The order is what the renderer sorts by and what a later milestone's
+/// escalation proposal compares against; it is not a lattice level.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EffectRisk {
+    /// Observes only (files, history, logs, registries).
+    Read,
+    /// Changes the workspace or local repository state.
+    WriteLocal,
+    /// Runs the project's own toolchain.
+    Execute,
+    /// Publishes something others can see (a branch, a comment, a PR).
+    Publish,
+    /// Changes remote state that is not simply undone (a merge).
+    MutateRemote,
+    /// Destroys data.
+    Destructive,
+}
+
+impl EffectRisk {
+    /// Stable lowercase name, matching the TOML spelling.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Read => "read",
+            Self::WriteLocal => "write_local",
+            Self::Execute => "execute",
+            Self::Publish => "publish",
+            Self::MutateRemote => "mutate_remote",
+            Self::Destructive => "destructive",
+        }
+    }
+}
+
+/// One HTTP shape an effect covers: the host→meaning table.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct HttpMatch {
+    /// HTTP method, upper case.
+    pub method: String,
+    /// Exact host or `*.example` wildcard, as in the egress policy.
+    pub host: String,
+    /// Path glob: `*` matches any run of characters.
+    pub path: String,
+}
+
+/// A declared effect after validation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EffectSpec {
+    /// Fully-qualified name.
+    pub id: EffectId,
+    /// The line a person reads ("Read CI logs and workflow runs").
+    pub title: String,
+    /// Risk grade, for ordering and for escalation proposals.
+    pub risk: EffectRisk,
+    /// The level the listed operations are raised to when lowered.
+    pub level: CapabilityLevel,
+    /// Core operations the effect needs.
+    pub operations: Vec<Operation>,
+    /// Sink classes the effect writes to.
+    pub sinks: Vec<SinkClass>,
+    /// Hosts the effect needs egress to.
+    pub hosts: Vec<String>,
+    /// MCP tool names that exercise this effect.
+    pub mcp_tools: Vec<String>,
+    /// Shell command prefixes that exercise this effect.
+    pub commands: Vec<String>,
+    /// HTTP shapes that exercise this effect.
+    pub http: Vec<HttpMatch>,
+}
+
+/// What a set of effects lowers to: the raw material for a
+/// [`crate::PermissionLattice`] plus the egress and command vocabulary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LoweredAuthority {
+    /// Core dimensions, every unlisted operation at `Never`.
+    pub capabilities: CapabilityLattice,
+    /// Union of the effects' sink classes (deduplicated, catalog order).
+    pub sinks: Vec<SinkClass>,
+    /// Union of the effects' hosts.
+    pub hosts: BTreeSet<String>,
+    /// Union of the effects' command prefixes.
+    pub commands: BTreeSet<String>,
+    /// Union of the effects' MCP tool names.
+    pub mcp_tools: BTreeSet<String>,
+    /// The exposure legs the lowered operations contribute.
+    pub exposure: ExposureSet,
+}
+
+/// Errors from loading, validating or lowering a catalog.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EffectCatalogError {
+    /// Malformed `<plugin>/<id>`.
+    InvalidId(String),
+    /// TOML did not parse.
+    Parse {
+        /// Where the TOML came from.
+        source: String,
+        /// The parser's message.
+        detail: String,
+    },
+    /// An effect named an unknown operation, sink or host pattern.
+    UnknownVocabulary {
+        /// The effect.
+        effect: String,
+        /// What was unknown.
+        detail: String,
+    },
+    /// The same id was declared twice.
+    Duplicate(String),
+    /// An effect is not in the catalog.
+    Unknown(String),
+    /// A declared effect failed a consistency check.
+    Invalid {
+        /// The effect.
+        effect: String,
+        /// Which check.
+        detail: String,
+    },
+    /// Reading a catalog directory failed.
+    Io(String),
+}
+
+impl fmt::Display for EffectCatalogError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidId(s) => write!(
+                f,
+                "invalid effect id '{s}': expected <plugin>/<id>, each [a-z0-9-]+"
+            ),
+            Self::Parse { source, detail } => write!(f, "effect catalog {source}: {detail}"),
+            Self::UnknownVocabulary { effect, detail } => {
+                write!(f, "effect {effect}: {detail}")
+            }
+            Self::Duplicate(id) => write!(f, "effect {id} declared twice"),
+            Self::Unknown(id) => write!(f, "unknown effect {id}"),
+            Self::Invalid { effect, detail } => write!(f, "effect {effect} is invalid: {detail}"),
+            Self::Io(s) => write!(f, "effect catalog: {s}"),
+        }
+    }
+}
+
+impl std::error::Error for EffectCatalogError {}
+
+// ── TOML shape ────────────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CatalogFile {
+    plugin: PluginHeader,
+    #[serde(default, rename = "effect")]
+    effects: Vec<EffectEntry>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PluginHeader {
+    name: String,
+    #[allow(dead_code)]
+    version: u32,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct EffectEntry {
+    id: String,
+    title: String,
+    risk: EffectRisk,
+    #[serde(default = "default_level")]
+    level: CapabilityLevel,
+    #[serde(default)]
+    lowers: Lowers,
+    #[serde(default)]
+    matches: Matches,
+}
+
+fn default_level() -> CapabilityLevel {
+    CapabilityLevel::LowRisk
+}
+
+#[derive(Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Lowers {
+    #[serde(default)]
+    operations: Vec<String>,
+    #[serde(default)]
+    sinks: Vec<SinkClass>,
+    #[serde(default)]
+    hosts: Vec<String>,
+}
+
+#[derive(Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Matches {
+    #[serde(default)]
+    mcp_tools: Vec<String>,
+    #[serde(default)]
+    commands: Vec<String>,
+    #[serde(default)]
+    http: Vec<HttpMatch>,
+}
+
+// ── Catalog ───────────────────────────────────────────────────────────
+
+/// The loaded, validated set of effects with reverse indexes.
+#[derive(Debug, Clone, Default)]
+pub struct EffectCatalog {
+    effects: BTreeMap<EffectId, EffectSpec>,
+}
+
+impl EffectCatalog {
+    /// An empty catalog.
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    /// The built-in catalog. Validated on every construction so a broken
+    /// built-in file is a test failure, never a silently narrower catalog.
+    pub fn builtin() -> Result<Self, EffectCatalogError> {
+        let mut catalog = Self::empty();
+        for (name, content) in BUILTIN_CATALOG {
+            catalog.load_toml(content, &format!("builtin:{name}"))?;
+        }
+        catalog.validate()?;
+        Ok(catalog)
+    }
+
+    /// Merge one TOML catalog. `source` names it in errors.
+    pub fn load_toml(&mut self, content: &str, source: &str) -> Result<(), EffectCatalogError> {
+        let file: CatalogFile = toml::from_str(content).map_err(|e| EffectCatalogError::Parse {
+            source: source.to_string(),
+            detail: e.to_string(),
+        })?;
+        if !is_segment(&file.plugin.name) {
+            return Err(EffectCatalogError::InvalidId(format!(
+                "{}/ (plugin name in {source})",
+                file.plugin.name
+            )));
+        }
+        for entry in file.effects {
+            let id = EffectId::new(&file.plugin.name, &entry.id)?;
+            let mut operations = Vec::with_capacity(entry.lowers.operations.len());
+            for op in &entry.lowers.operations {
+                let parsed = Operation::try_from(op.as_str()).map_err(|_| {
+                    EffectCatalogError::UnknownVocabulary {
+                        effect: id.to_string(),
+                        detail: format!("unknown operation '{op}'"),
+                    }
+                })?;
+                operations.push(parsed);
+            }
+            for host in &entry.lowers.hosts {
+                if !is_host_pattern(host) {
+                    return Err(EffectCatalogError::UnknownVocabulary {
+                        effect: id.to_string(),
+                        detail: format!("'{host}' is not a host pattern"),
+                    });
+                }
+            }
+            let spec = EffectSpec {
+                id: id.clone(),
+                title: entry.title,
+                risk: entry.risk,
+                level: entry.level,
+                operations,
+                sinks: entry.lowers.sinks,
+                hosts: entry.lowers.hosts,
+                mcp_tools: entry.matches.mcp_tools,
+                commands: entry.matches.commands,
+                http: entry.matches.http,
+            };
+            if self.effects.insert(id.clone(), spec).is_some() {
+                return Err(EffectCatalogError::Duplicate(id.to_string()));
+            }
+        }
+        Ok(())
+    }
+
+    /// Merge every `*.toml` in `dir`, in name order. A missing directory
+    /// is not an error: most repositories declare no effects of their own.
+    pub fn load_from_dir(&mut self, dir: &Path) -> Result<(), EffectCatalogError> {
+        if !dir.is_dir() {
+            return Ok(());
+        }
+        let mut paths: Vec<_> = std::fs::read_dir(dir)
+            .map_err(|e| EffectCatalogError::Io(format!("{}: {e}", dir.display())))?
+            .filter_map(Result::ok)
+            .map(|e| e.path())
+            .filter(|p| p.extension().is_some_and(|x| x == "toml"))
+            .collect();
+        paths.sort();
+        for path in paths {
+            let content = std::fs::read_to_string(&path)
+                .map_err(|e| EffectCatalogError::Io(format!("{}: {e}", path.display())))?;
+            self.load_toml(&content, &path.display().to_string())?;
+        }
+        self.validate()
+    }
+
+    /// Every consistency rule an effect must satisfy:
+    /// - it lowers to at least one operation (an effect that grants nothing
+    ///   would be a phantom line in a grant);
+    /// - every `http` host is also a lowered host (the table cannot describe
+    ///   traffic the effect does not allow);
+    /// - every listed sink is one some listed operation can produce.
+    pub fn validate(&self) -> Result<(), EffectCatalogError> {
+        for (id, spec) in &self.effects {
+            if spec.operations.is_empty() {
+                return Err(EffectCatalogError::Invalid {
+                    effect: id.to_string(),
+                    detail: "lowers to no operation".into(),
+                });
+            }
+            for h in &spec.http {
+                if !spec
+                    .hosts
+                    .iter()
+                    .any(|allowed| host_matches(allowed, &h.host))
+                {
+                    return Err(EffectCatalogError::Invalid {
+                        effect: id.to_string(),
+                        detail: format!("http host '{}' is not among lowers.hosts", h.host),
+                    });
+                }
+            }
+            if !spec.hosts.is_empty()
+                && !spec.operations.iter().any(|op| {
+                    matches!(
+                        op,
+                        Operation::WebFetch
+                            | Operation::GitPush
+                            | Operation::CreatePr
+                            | Operation::RunBash
+                    )
+                })
+            {
+                return Err(EffectCatalogError::Invalid {
+                    effect: id.to_string(),
+                    detail: "names hosts but lowers to no network-capable operation".into(),
+                });
+            }
+        }
+        Ok(())
+    }
+
+    /// Look up one effect.
+    pub fn get(&self, id: &EffectId) -> Option<&EffectSpec> {
+        self.effects.get(id)
+    }
+
+    /// Every effect, in id order.
+    pub fn iter(&self) -> impl Iterator<Item = &EffectSpec> {
+        self.effects.values()
+    }
+
+    /// Number of effects.
+    pub fn len(&self) -> usize {
+        self.effects.len()
+    }
+
+    /// Whether the catalog is empty.
+    pub fn is_empty(&self) -> bool {
+        self.effects.is_empty()
+    }
+
+    /// Effects whose lowered hosts admit `host`.
+    pub fn effects_for_host(&self, host: &str) -> Vec<&EffectSpec> {
+        self.iter()
+            .filter(|e| e.hosts.iter().any(|p| host_matches(p, host)))
+            .collect()
+    }
+
+    /// Effects whose command prefixes cover `command` (first-word aware:
+    /// `cargo test` matches `cargo test -p x`, not `cargo testing`).
+    pub fn effects_for_command(&self, command: &str) -> Vec<&EffectSpec> {
+        let cmd = command.trim();
+        self.iter()
+            .filter(|e| e.commands.iter().any(|p| command_matches(p, cmd)))
+            .collect()
+    }
+
+    /// Effects that name `tool`, or whose name `tool` ends with after an
+    /// `mcp__<server>__` prefix.
+    pub fn effects_for_tool(&self, tool: &str) -> Vec<&EffectSpec> {
+        let bare = tool.rsplit("__").next().unwrap_or(tool);
+        self.iter()
+            .filter(|e| e.mcp_tools.iter().any(|t| t == tool || t == bare))
+            .collect()
+    }
+
+    /// Effects that lower to `op`.
+    pub fn effects_for_operation(&self, op: Operation) -> Vec<&EffectSpec> {
+        self.iter().filter(|e| e.operations.contains(&op)).collect()
+    }
+
+    /// Lower a set of effects. Starts from every dimension at `Never` and
+    /// raises only what the effects list, so the result is exactly the union
+    /// of the members and nothing else. Unknown ids are errors.
+    pub fn lower(&self, ids: &BTreeSet<EffectId>) -> Result<LoweredAuthority, EffectCatalogError> {
+        let mut capabilities = all_never();
+        let mut sinks: Vec<SinkClass> = Vec::new();
+        let mut hosts = BTreeSet::new();
+        let mut commands = BTreeSet::new();
+        let mut mcp_tools = BTreeSet::new();
+        let mut exposure = ExposureSet::empty();
+
+        for id in ids {
+            let spec = self
+                .get(id)
+                .ok_or_else(|| EffectCatalogError::Unknown(id.to_string()))?;
+            for &op in &spec.operations {
+                raise(&mut capabilities, op, spec.level);
+                if let Some(label) = classify_operation(op) {
+                    exposure = exposure.union(&ExposureSet::singleton(label));
+                }
+            }
+            for sink in &spec.sinks {
+                if !sinks.contains(sink) {
+                    sinks.push(*sink);
+                }
+            }
+            hosts.extend(spec.hosts.iter().cloned());
+            commands.extend(spec.commands.iter().cloned());
+            mcp_tools.extend(spec.mcp_tools.iter().cloned());
+        }
+
+        Ok(LoweredAuthority {
+            capabilities,
+            sinks,
+            hosts,
+            commands,
+            mcp_tools,
+            exposure,
+        })
+    }
+}
+
+/// Every core dimension at `Never`; the lowering's starting point.
+///
+/// Built from [`CapabilityLattice::restrictive`] so this module adds no
+/// `cfg(kani)` site of its own: `restrictive` leaves the three read
+/// dimensions at `Always`, which the lowering must earn like any other.
+fn all_never() -> CapabilityLattice {
+    let mut caps = CapabilityLattice::restrictive();
+    caps.read_files = CapabilityLevel::Never;
+    caps.glob_search = CapabilityLevel::Never;
+    caps.grep_search = CapabilityLevel::Never;
+    caps
+}
+
+/// Raise one dimension to at least `level` (never lowers).
+pub fn raise(caps: &mut CapabilityLattice, op: Operation, level: CapabilityLevel) {
+    let slot = match op {
+        Operation::ReadFiles => &mut caps.read_files,
+        Operation::WriteFiles => &mut caps.write_files,
+        Operation::EditFiles => &mut caps.edit_files,
+        Operation::RunBash => &mut caps.run_bash,
+        Operation::GlobSearch => &mut caps.glob_search,
+        Operation::GrepSearch => &mut caps.grep_search,
+        Operation::WebSearch => &mut caps.web_search,
+        Operation::WebFetch => &mut caps.web_fetch,
+        Operation::GitCommit => &mut caps.git_commit,
+        Operation::GitPush => &mut caps.git_push,
+        Operation::CreatePr => &mut caps.create_pr,
+        Operation::ManagePods => &mut caps.manage_pods,
+        Operation::SpawnAgent => &mut caps.spawn_agent,
+    };
+    if *slot < level {
+        *slot = level;
+    }
+}
+
+fn is_host_pattern(s: &str) -> bool {
+    let body = s.strip_prefix("*.").unwrap_or(s);
+    !body.is_empty()
+        && body
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'.' || b == b'-')
+        && !body.starts_with('.')
+        && !body.ends_with('.')
+}
+
+/// Exact match, or `*.example` matching any subdomain of `example`.
+pub fn host_matches(pattern: &str, host: &str) -> bool {
+    let host = host.to_ascii_lowercase();
+    let pattern = pattern.to_ascii_lowercase();
+    match pattern.strip_prefix("*.") {
+        Some(suffix) => host
+            .strip_suffix(suffix)
+            .is_some_and(|rest| rest.ends_with('.') && rest.len() > 1),
+        None => host == pattern,
+    }
+}
+
+/// A prefix match on whole words: `git push` matches `git push origin x` and
+/// `git push`, not `git pushx`. A `*` inside a word matches any run of
+/// characters, and because the pattern is a prefix its last literal may end
+/// the word or a path segment: `gh api repos/*/actions` matches
+/// `gh api repos/o/r/actions/runs`.
+pub fn command_matches(prefix: &str, command: &str) -> bool {
+    let p: Vec<&str> = prefix.split_whitespace().collect();
+    let c: Vec<&str> = command.split_whitespace().collect();
+    if p.is_empty() || c.len() < p.len() {
+        return false;
+    }
+    p.iter().zip(c.iter()).all(|(pw, cw)| word_matches(pw, cw))
+}
+
+fn word_matches(pattern: &str, word: &str) -> bool {
+    if !pattern.contains('*') {
+        return pattern == word;
+    }
+    let parts: Vec<&str> = pattern.split('*').collect();
+    let mut rest = word;
+    for (i, part) in parts.iter().enumerate() {
+        if part.is_empty() {
+            continue;
+        }
+        let Some(pos) = rest.find(part) else {
+            return false;
+        };
+        if i == 0 && pos != 0 {
+            return false;
+        }
+        rest = &rest[pos + part.len()..];
+    }
+    // A command pattern is a prefix of the command, so the last literal
+    // may end the word or end a path segment: `repos/*/actions` admits
+    // `repos/o/r/actions/runs` but not `repos/o/r/actionsx`.
+    let last = parts.last().copied().unwrap_or_default();
+    last.is_empty() || rest.is_empty() || rest.starts_with('/')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn id(s: &str) -> EffectId {
+        s.parse().expect("valid id")
+    }
+
+    #[test]
+    fn builtin_catalog_is_sound() {
+        let catalog = EffectCatalog::builtin().expect("built-in catalog loads and validates");
+        assert!(catalog.len() >= 14, "expected the five built-in plugins");
+        assert!(catalog.get(&id("github/read-ci-logs")).is_some());
+        assert!(catalog.get(&id("fs/read-workspace")).is_some());
+    }
+
+    #[test]
+    fn lowering_is_exactly_the_union_of_members() {
+        let catalog = EffectCatalog::builtin().unwrap();
+        let ids: BTreeSet<EffectId> = [id("github/read-ci-logs")].into_iter().collect();
+        let lowered = catalog.lower(&ids).unwrap();
+        assert_eq!(lowered.capabilities.web_fetch, CapabilityLevel::LowRisk);
+        for op in Operation::ALL {
+            if op != Operation::WebFetch {
+                assert_eq!(
+                    lowered.capabilities.level_for(op),
+                    CapabilityLevel::Never,
+                    "{op} must stay Never"
+                );
+            }
+        }
+        assert!(lowered.hosts.contains("api.github.com"));
+        assert_eq!(lowered.hosts.len(), 1);
+        assert!(lowered.sinks.contains(&SinkClass::HTTPEgress));
+    }
+
+    #[test]
+    fn read_workspace_lowers_to_always() {
+        let catalog = EffectCatalog::builtin().unwrap();
+        let ids: BTreeSet<EffectId> = [id("fs/read-workspace")].into_iter().collect();
+        let lowered = catalog.lower(&ids).unwrap();
+        assert_eq!(lowered.capabilities.read_files, CapabilityLevel::Always);
+        assert_eq!(lowered.capabilities.write_files, CapabilityLevel::Never);
+    }
+
+    #[test]
+    fn unknown_effect_is_an_error_not_a_noop() {
+        let catalog = EffectCatalog::builtin().unwrap();
+        let ids: BTreeSet<EffectId> = [id("github/delete-repo")].into_iter().collect();
+        assert!(matches!(
+            catalog.lower(&ids),
+            Err(EffectCatalogError::Unknown(_))
+        ));
+    }
+
+    #[test]
+    fn reverse_lookups() {
+        let catalog = EffectCatalog::builtin().unwrap();
+        let by_host: Vec<_> = catalog
+            .effects_for_host("api.github.com")
+            .into_iter()
+            .map(|e| e.id.to_string())
+            .collect();
+        assert!(by_host.contains(&"github/read-ci-logs".to_string()));
+        let by_cmd: Vec<_> = catalog
+            .effects_for_command("gh pr merge 42 --squash")
+            .into_iter()
+            .map(|e| e.id.to_string())
+            .collect();
+        assert_eq!(by_cmd, vec!["github/merge-pr".to_string()]);
+        assert!(catalog.effects_for_command("gh prmerge").is_empty());
+        let by_tool: Vec<_> = catalog
+            .effects_for_tool("mcp__github__get_job_logs")
+            .into_iter()
+            .map(|e| e.id.to_string())
+            .collect();
+        assert_eq!(by_tool, vec!["github/read-ci-logs".to_string()]);
+        assert!(!catalog.effects_for_operation(Operation::GitPush).is_empty());
+    }
+
+    #[test]
+    fn invalid_ids_and_vocabulary_are_rejected() {
+        assert!("GitHub/read".parse::<EffectId>().is_err());
+        assert!("github".parse::<EffectId>().is_err());
+        assert!("github/-x".parse::<EffectId>().is_err());
+        let mut catalog = EffectCatalog::empty();
+        let bad_op = r#"
+[plugin]
+name = "x"
+version = 1
+[[effect]]
+id = "a"
+title = "A"
+risk = "read"
+[effect.lowers]
+operations = ["teleport"]
+"#;
+        assert!(matches!(
+            catalog.load_toml(bad_op, "test"),
+            Err(EffectCatalogError::UnknownVocabulary { .. })
+        ));
+        let no_ops = r#"
+[plugin]
+name = "x"
+version = 1
+[[effect]]
+id = "a"
+title = "A"
+risk = "read"
+"#;
+        let mut catalog = EffectCatalog::empty();
+        catalog.load_toml(no_ops, "test").unwrap();
+        assert!(matches!(
+            catalog.validate(),
+            Err(EffectCatalogError::Invalid { .. })
+        ));
+        let foreign_http = r#"
+[plugin]
+name = "x"
+version = 1
+[[effect]]
+id = "a"
+title = "A"
+risk = "read"
+[effect.lowers]
+operations = ["web_fetch"]
+hosts = ["a.example"]
+[effect.matches]
+http = [{ method = "GET", host = "b.example", path = "/*" }]
+"#;
+        let mut catalog = EffectCatalog::empty();
+        catalog.load_toml(foreign_http, "test").unwrap();
+        assert!(matches!(
+            catalog.validate(),
+            Err(EffectCatalogError::Invalid { .. })
+        ));
+    }
+
+    #[test]
+    fn duplicate_ids_are_rejected() {
+        let mut catalog = EffectCatalog::builtin().unwrap();
+        let dup = r#"
+[plugin]
+name = "github"
+version = 1
+[[effect]]
+id = "read-issue"
+title = "again"
+risk = "read"
+[effect.lowers]
+operations = ["web_fetch"]
+"#;
+        assert!(matches!(
+            catalog.load_toml(dup, "test"),
+            Err(EffectCatalogError::Duplicate(_))
+        ));
+    }
+
+    #[test]
+    fn host_and_command_matching() {
+        assert!(host_matches("*.github.com", "api.github.com"));
+        assert!(!host_matches("*.github.com", "github.com"));
+        assert!(host_matches("github.com", "GitHub.com"));
+        assert!(command_matches(
+            "gh api repos/*/actions",
+            "gh api repos/o/r/actions/runs"
+        ));
+        assert!(!command_matches(
+            "gh api repos/*/actions",
+            "gh api repos/o/r/actionsx"
+        ));
+        assert!(command_matches(
+            "gh api repos/*/actions",
+            "gh api repos/o/r/actions"
+        ));
+        assert!(!command_matches("cargo test", "cargo testing"));
+        assert!(command_matches("cargo test", "cargo test"));
+    }
+
+    #[test]
+    fn effect_id_serde_roundtrip() {
+        let e = id("github/open-pr");
+        let json = serde_json::to_string(&e).unwrap();
+        assert_eq!(json, "\"github/open-pr\"");
+        let back: EffectId = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, e);
+        assert!(serde_json::from_str::<EffectId>("\"nope\"").is_err());
+    }
+}

--- a/crates/portcullis/src/lib.rs
+++ b/crates/portcullis/src/lib.rs
@@ -128,6 +128,12 @@ pub mod art12_record;
 /// Kernel decision engine — complete mediation with monotone session state.
 pub mod delegation;
 pub mod dropout;
+/// Semantic effect catalog: the human-sized authority vocabulary
+/// (`github/read-ci-logs`) that lowers to core dimensions, sinks and hosts.
+///
+/// Requires the `spec` feature (TOML).
+#[cfg(feature = "spec")]
+pub mod effect_catalog;
 /// Bash command egress analysis — detect network exfiltration.
 pub mod egress;
 /// Egress policy — host pattern matching for outbound traffic control.
@@ -182,6 +188,12 @@ pub mod receipt_sign;
 /// (feature `dlc`); consulted by the kernel, composable as a `PolicyCheck`.
 #[cfg(feature = "dlc")]
 pub mod says_admission;
+/// The task grant a goal compiles to, and its progressive-disclosure
+/// rendering (Goal / Can / Cannot / Limits / Risk).
+///
+/// Requires the `spec` feature.
+#[cfg(feature = "spec")]
+pub mod task_grant;
 #[cfg(feature = "crypto")]
 pub use receipt_sign::{receipt_hash, sign_receipt, verify_receipt};
 #[cfg(feature = "remote-audit")]
@@ -227,6 +239,11 @@ pub use capability::{
     IncompatibilityConstraint, Obligations, Operation, OperationParseError, SinkClass, StateRisk,
 };
 pub use command::{ArgPattern, CommandLattice, CommandPattern};
+#[cfg(feature = "spec")]
+pub use effect_catalog::{
+    EffectCatalog, EffectCatalogError, EffectId, EffectRisk, EffectSpec, HttpMatch,
+    LoweredAuthority,
+};
 pub use exposure_core::{apply_record, classify_operation, project_exposure, should_deny};
 pub use frame::{
     verify_nucleus_laws, BoundedLattice, CompleteLattice, ComposedNucleus, DistributiveLattice,
@@ -258,6 +275,11 @@ pub use permissive::{
 };
 pub use progress::{ProgressDimension, ProgressLattice, ProgressLevel};
 pub use region::CodeRegion;
+#[cfg(feature = "spec")]
+pub use task_grant::{
+    render as render_grant, render_capabilities, ClippedEffect, CompilerProvenance, Disclosure,
+    GrantLimits, RiskSummary, TaskGrant,
+};
 pub use time::TimeLattice;
 pub use trust::{EnforcementResult, TrustProfile};
 pub use weakening::{

--- a/crates/portcullis/src/task_grant.rs
+++ b/crates/portcullis/src/task_grant.rs
@@ -1,0 +1,639 @@
+//! The task grant: what a goal compiles to, and how a person reads it.
+//!
+//! A [`TaskGrant`] is the durable object the `nucleus run --goal` loop is
+//! built around. It records the goal (prompt playback), the semantic effects
+//! the compiler granted (`can`) and clipped (`cannot`), the lattice they
+//! lower to — already met with the ceiling profile, so it is never wider —
+//! the limits, and a risk summary derived from the uninhabitable-state
+//! analysis. Later milestones seal it into a certificate and attribute
+//! receipts back to it; this milestone renders it.
+//!
+//! Rendering is progressive disclosure. [`Disclosure::Plain`] is the five
+//! lines everyone reads (Goal / Can / Cannot / Limits / Risk).
+//! [`Disclosure::Technical`] appends the 13-dimension grid in the vocabulary
+//! of `docs/permissions.md`. [`Disclosure::PolicyTrace`] appends the
+//! per-dimension weakening requests the grant is made of, with their cost.
+//! Same object, three depths; the bottom two are why a security engineer
+//! trusts the top one.
+
+use std::collections::BTreeSet;
+use std::fmt::Write as _;
+
+use chrono::{DateTime, Utc};
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+use crate::effect_catalog::{EffectCatalog, EffectId};
+use crate::{
+    CapabilityLevel, DelegationError, ExposureLabel, IncompatibilityConstraint, Operation,
+    PermissionLattice, StateRisk, WeakeningGap,
+};
+
+/// The bounds a grant carries besides its lattice, in the units a person
+/// reads them in.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GrantLimits {
+    /// Spend ceiling in USD.
+    pub max_cost_usd: Decimal,
+    /// Lifetime, seconds from `created_at`.
+    pub duration_secs: u64,
+    /// Hosts the grant admits egress to (empty = none).
+    pub hosts: Vec<String>,
+    /// Path globs the grant blocks.
+    pub blocked_paths: Vec<String>,
+    /// Command prefixes the granted effects vouch for (informational in this
+    /// milestone; the lattice's own command rules still apply).
+    pub commands: Vec<String>,
+}
+
+/// The uninhabitable-state analysis of the grant.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RiskSummary {
+    /// Risk with nothing granted.
+    pub before: StateRisk,
+    /// Risk of the granted lattice.
+    pub after: StateRisk,
+    /// Exposure legs the granted capabilities provide.
+    pub exposure_legs: Vec<ExposureLabel>,
+    /// Operations the kernel will gate on human approval.
+    pub approval_gated: Vec<Operation>,
+    /// Per-dimension weakenings from the restrictive floor, with cost.
+    pub gap: WeakeningGap,
+}
+
+/// Where the grant came from, for the audit trail and for reuse matching.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CompilerProvenance {
+    /// `<crate>/<version>` of the compiler.
+    pub compiler: String,
+    /// Names of the proposers consulted, in order.
+    pub proposers: Vec<String>,
+    /// Ids of the rules that fired.
+    pub rules_fired: Vec<String>,
+    /// Digest of the repository context the goal was compiled against.
+    pub repo_context_digest: String,
+}
+
+/// An effect the compiler proposed but the ceiling did not admit.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ClippedEffect {
+    /// The effect.
+    pub id: EffectId,
+    /// Why it was clipped.
+    pub reason: String,
+}
+
+/// A compiled grant.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TaskGrant {
+    /// Schema version.
+    pub version: u8,
+    /// Unique id.
+    pub id: Uuid,
+    /// The goal as the person stated it.
+    pub goal: String,
+    /// `sha256(goal)`, hex; binds a sealed grant to its playback.
+    pub goal_digest: String,
+    /// The ceiling profile the grant was met with.
+    pub ceiling_profile: String,
+    /// Effects granted.
+    pub can: BTreeSet<EffectId>,
+    /// Effects proposed but clipped by the ceiling.
+    pub cannot: Vec<ClippedEffect>,
+    /// Bounds.
+    pub limits: GrantLimits,
+    /// The lattice the run executes under; `≤ ceiling` by construction.
+    pub lattice: PermissionLattice,
+    /// Risk analysis.
+    pub risk: RiskSummary,
+    /// Provenance.
+    pub provenance: CompilerProvenance,
+    /// When the grant was compiled.
+    pub created_at: DateTime<Utc>,
+    /// When it stops being valid.
+    pub not_after: DateTime<Utc>,
+}
+
+impl TaskGrant {
+    /// Current schema version.
+    pub const VERSION: u8 = 1;
+
+    /// `sha256(goal)` as lowercase hex.
+    pub fn digest_goal(goal: &str) -> String {
+        hex_lower(&Sha256::digest(goal.as_bytes()))
+    }
+
+    /// The grant's lattice must be delegable from the ceiling: this is the
+    /// same check `mint_child` makes, so a grant that passes here is one a
+    /// certificate could carry.
+    pub fn assert_within(&self, ceiling: &PermissionLattice) -> Result<(), DelegationError> {
+        ceiling
+            .delegate_to(&self.lattice, "task grant within ceiling")
+            .map(|_| ())
+    }
+
+    /// Whether the grant has expired.
+    pub fn is_expired(&self) -> bool {
+        Utc::now() > self.not_after
+    }
+}
+
+fn hex_lower(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        let _ = write!(s, "{b:02x}");
+    }
+    s
+}
+
+/// How much of the grant to show.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Disclosure {
+    /// Goal / Can / Cannot / Limits / Risk.
+    Plain,
+    /// Plain plus the 13-dimension capability grid.
+    Technical,
+    /// Technical plus the weakening requests and their cost.
+    PolicyTrace,
+}
+
+impl std::str::FromStr for Disclosure {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_ascii_lowercase().as_str() {
+            "plain" => Ok(Self::Plain),
+            "technical" => Ok(Self::Technical),
+            "policy-trace" | "policy_trace" | "trace" => Ok(Self::PolicyTrace),
+            other => Err(format!(
+                "unknown disclosure level '{other}' (plain | technical | policy-trace)"
+            )),
+        }
+    }
+}
+
+/// Render a grant at the given depth.
+pub fn render(grant: &TaskGrant, catalog: &EffectCatalog, level: Disclosure) -> String {
+    let mut out = String::new();
+    render_plain(&mut out, grant, catalog);
+    if matches!(level, Disclosure::Technical | Disclosure::PolicyTrace) {
+        render_technical(&mut out, grant);
+    }
+    if level == Disclosure::PolicyTrace {
+        render_policy_trace(&mut out, grant);
+    }
+    out
+}
+
+fn render_plain(out: &mut String, grant: &TaskGrant, catalog: &EffectCatalog) {
+    let _ = writeln!(out, "Goal:    {}", grant.goal);
+
+    // Can: titles, ordered by risk then id.
+    let mut can: Vec<_> = grant
+        .can
+        .iter()
+        .map(|id| {
+            let (risk, title) = catalog
+                .get(id)
+                .map(|e| (e.risk, e.title.clone()))
+                .unwrap_or((crate::effect_catalog::EffectRisk::Read, id.to_string()));
+            (risk, id.clone(), title)
+        })
+        .collect();
+    can.sort();
+    let can_line = join_dot(can.iter().map(|(_, _, t)| lower_first(t)));
+    let _ = writeln!(out, "Can:     {can_line}");
+
+    // Cannot: clipped effects first, then structural absences.
+    let mut cannot: Vec<String> = grant
+        .cannot
+        .iter()
+        .map(|c| {
+            let title = catalog
+                .get(&c.id)
+                .map(|e| lower_first(&e.title))
+                .unwrap_or_else(|| c.id.to_string());
+            format!("{title} ({})", c.reason)
+        })
+        .collect();
+    cannot.extend(structural_absences(grant));
+    let _ = writeln!(out, "Cannot:  {}", join_dot(cannot));
+
+    // Limits.
+    let hours = grant.limits.duration_secs as f64 / 3600.0;
+    let mut limits = vec![
+        format!("${:.2}", grant.limits.max_cost_usd),
+        if hours >= 1.0 {
+            format!("{hours:.0}h")
+        } else {
+            format!("{}m", grant.limits.duration_secs / 60)
+        },
+    ];
+    if grant.limits.hosts.is_empty() {
+        limits.push("no network".into());
+    } else {
+        limits.push(format!("{} only", grant.limits.hosts.join(", ")));
+    }
+    if !grant.limits.blocked_paths.is_empty() {
+        limits.push(format!(
+            "no {}",
+            summarise_paths(&grant.limits.blocked_paths).join(", ")
+        ));
+    }
+    let _ = writeln!(out, "Limits:  {}", join_dot(limits));
+
+    // Risk.
+    let legs = grant.risk.exposure_legs.len();
+    let names: Vec<&str> = grant
+        .risk
+        .exposure_legs
+        .iter()
+        .map(|l| leg_name(*l))
+        .collect();
+    let risk_line = if legs == 3 {
+        let gated: Vec<String> = grant
+            .risk
+            .approval_gated
+            .iter()
+            .map(|o| o.to_string())
+            .collect();
+        if gated.is_empty() {
+            "all 3 exposure legs present (private data + untrusted content + exfiltration)"
+                .to_string()
+        } else {
+            format!(
+                "all 3 exposure legs present → the kernel asks for approval before {}",
+                gated.join(", ")
+            )
+        }
+    } else {
+        let missing: Vec<&str> = [
+            ExposureLabel::PrivateData,
+            ExposureLabel::UntrustedContent,
+            ExposureLabel::ExfilVector,
+        ]
+        .iter()
+        .filter(|l| !grant.risk.exposure_legs.contains(l))
+        .map(|l| leg_name(*l))
+        .collect();
+        let present = if names.is_empty() {
+            String::new()
+        } else {
+            format!(" ({})", names.join(" + "))
+        };
+        format!(
+            "{legs} of 3 exposure legs{present}; {} absent → no approval prompts expected",
+            missing.join(" and ")
+        )
+    };
+    let _ = writeln!(out, "Risk:    {risk_line}");
+}
+
+fn render_technical(out: &mut String, grant: &TaskGrant) {
+    let _ = writeln!(out);
+    out.push_str(&render_capabilities(
+        &grant.lattice,
+        &format!("Capabilities (ceiling: {}):", grant.ceiling_profile),
+    ));
+    if !grant.limits.commands.is_empty() {
+        let _ = writeln!(out, "Commands vouched for by the granted effects:");
+        for c in &grant.limits.commands {
+            let _ = writeln!(out, "  {c}");
+        }
+    }
+    let _ = writeln!(
+        out,
+        "Lattice checksum: {}  grant: {}",
+        grant.lattice.checksum(),
+        grant.id
+    );
+}
+
+/// The 13-dimension grid in the vocabulary of `docs/permissions.md`, under
+/// `heading`. Shared by the grant's technical disclosure and `run --dry-run`.
+pub fn render_capabilities(lattice: &PermissionLattice, heading: &str) -> String {
+    let caps = &lattice.capabilities;
+    let mut out = String::new();
+    let _ = writeln!(out, "{heading}");
+    let rows: [[Operation; 3]; 4] = [
+        [
+            Operation::ReadFiles,
+            Operation::WebSearch,
+            Operation::GitPush,
+        ],
+        [
+            Operation::WriteFiles,
+            Operation::WebFetch,
+            Operation::CreatePr,
+        ],
+        [
+            Operation::EditFiles,
+            Operation::GitCommit,
+            Operation::RunBash,
+        ],
+        [
+            Operation::GlobSearch,
+            Operation::GrepSearch,
+            Operation::SpawnAgent,
+        ],
+    ];
+    for row in &rows {
+        let cells: Vec<String> = row
+            .iter()
+            .map(|op| {
+                format!(
+                    "{:<13}{}",
+                    format!("{op}:"),
+                    level_name(caps.level_for(*op))
+                )
+            })
+            .collect();
+        let _ = writeln!(out, "  {:<22}{:<22}{}", cells[0], cells[1], cells[2]);
+    }
+    let _ = writeln!(
+        out,
+        "  {:<13}{}",
+        "manage_pods:",
+        level_name(caps.level_for(Operation::ManagePods))
+    );
+    let gated: Vec<String> = Operation::ALL
+        .iter()
+        .filter(|op| lattice.obligations.requires(**op))
+        .map(|op| op.to_string())
+        .collect();
+    if !gated.is_empty() {
+        let _ = writeln!(out, "  approval required: {}", gated.join(", "));
+    }
+    out
+}
+
+fn render_policy_trace(out: &mut String, grant: &TaskGrant) {
+    let _ = writeln!(out);
+    let _ = writeln!(
+        out,
+        "Policy trace (weakenings from the restrictive floor; risk {:?} → {:?}):",
+        grant.risk.before, grant.risk.after
+    );
+    if grant.risk.gap.is_empty() {
+        let _ = writeln!(out, "  none");
+    }
+    for req in &grant.risk.gap.requests {
+        let _ = writeln!(out, "  {req}");
+    }
+    let _ = writeln!(out, "  total cost: {}", grant.risk.gap.total_cost);
+    if !grant.provenance.rules_fired.is_empty() {
+        let _ = writeln!(
+            out,
+            "Rules fired: {}",
+            grant.provenance.rules_fired.join(", ")
+        );
+    }
+    let _ = writeln!(
+        out,
+        "Compiled by {} (proposers: {}) against repo context {}",
+        grant.provenance.compiler,
+        if grant.provenance.proposers.is_empty() {
+            "none".to_string()
+        } else {
+            grant.provenance.proposers.join(", ")
+        },
+        &grant.provenance.repo_context_digest[..grant.provenance.repo_context_digest.len().min(12)]
+    );
+}
+
+/// The "cannot" lines that follow from dimensions the lattice keeps at
+/// `Never`, in the order a person expects to see them.
+fn structural_absences(grant: &TaskGrant) -> Vec<String> {
+    let caps = &grant.lattice.capabilities;
+    let never = |op: Operation| caps.level_for(op) == CapabilityLevel::Never;
+    let mut v = Vec::new();
+    if never(Operation::GitPush) {
+        v.push("push to remote branches".to_string());
+    }
+    if never(Operation::CreatePr) {
+        v.push("open or merge pull requests".to_string());
+    }
+    if never(Operation::WebFetch) && never(Operation::WebSearch) {
+        v.push("reach the network".to_string());
+    } else if !grant.limits.hosts.is_empty() {
+        v.push(format!(
+            "reach hosts other than {}",
+            grant.limits.hosts.join(", ")
+        ));
+    }
+    if never(Operation::RunBash) {
+        v.push("run shell commands".to_string());
+    }
+    if never(Operation::WriteFiles) && never(Operation::EditFiles) {
+        v.push("modify files".to_string());
+    }
+    if never(Operation::SpawnAgent) && never(Operation::ManagePods) {
+        v.push("spawn agents or pods".to_string());
+    }
+    v
+}
+
+fn leg_name(l: ExposureLabel) -> &'static str {
+    match l {
+        ExposureLabel::PrivateData => "private data",
+        ExposureLabel::UntrustedContent => "untrusted content",
+        ExposureLabel::ExfilVector => "exfiltration",
+    }
+}
+
+fn level_name(l: CapabilityLevel) -> &'static str {
+    match l {
+        CapabilityLevel::Never => "never",
+        CapabilityLevel::LowRisk => "low_risk",
+        CapabilityLevel::Always => "always",
+    }
+}
+
+fn lower_first(s: &str) -> String {
+    let mut c = s.chars();
+    match c.next() {
+        Some(f) if !s.starts_with("CI") && !s.starts_with("GitHub") => {
+            f.to_lowercase().collect::<String>() + c.as_str()
+        }
+        _ => s.to_string(),
+    }
+}
+
+fn join_dot<I: IntoIterator<Item = String>>(items: I) -> String {
+    let v: Vec<String> = items.into_iter().collect();
+    if v.is_empty() {
+        "nothing".to_string()
+    } else {
+        v.join(" · ")
+    }
+}
+
+/// `**/.ssh/**` → `.ssh`, `/etc/shadow` → `/etc/shadow`; first three, then "…".
+fn summarise_paths(patterns: &[String]) -> Vec<String> {
+    let mut out: Vec<String> = patterns
+        .iter()
+        .map(|p| {
+            let t = p.trim_start_matches("**/").trim_end_matches("/**");
+            t.trim_end_matches('*').trim_end_matches('.').to_string()
+        })
+        .filter(|s| !s.is_empty())
+        .collect();
+    out.sort();
+    out.dedup();
+    if out.len() > 3 {
+        out.truncate(3);
+        out.push("…".into());
+    }
+    out
+}
+
+/// Legs a capability lattice provides, using the same thresholds as
+/// [`IncompatibilityConstraint::state_risk`].
+pub fn exposure_legs(caps: &crate::CapabilityLattice) -> Vec<ExposureLabel> {
+    let at_least = |l: CapabilityLevel| l >= CapabilityLevel::LowRisk;
+    let mut legs = Vec::new();
+    if at_least(caps.read_files) || at_least(caps.glob_search) || at_least(caps.grep_search) {
+        legs.push(ExposureLabel::PrivateData);
+    }
+    if at_least(caps.web_fetch) || at_least(caps.web_search) {
+        legs.push(ExposureLabel::UntrustedContent);
+    }
+    if at_least(caps.git_push) || at_least(caps.create_pr) || at_least(caps.run_bash) {
+        legs.push(ExposureLabel::ExfilVector);
+    }
+    legs
+}
+
+/// Build the risk summary for a lattice.
+pub fn summarise_risk(lattice: &PermissionLattice, gap: WeakeningGap) -> RiskSummary {
+    let constraint = IncompatibilityConstraint::enforcing();
+    let approval_gated: Vec<Operation> = Operation::ALL
+        .iter()
+        .copied()
+        .filter(|op| lattice.obligations.requires(*op))
+        .collect();
+    RiskSummary {
+        before: StateRisk::Safe,
+        after: constraint.state_risk(&lattice.capabilities),
+        exposure_legs: exposure_legs(&lattice.capabilities),
+        approval_gated,
+        gap,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::effect_catalog::EffectCatalog;
+
+    fn grant_for(lattice: PermissionLattice, can: &[&str], hosts: &[&str]) -> TaskGrant {
+        let gap = crate::WeakeningCostConfig::default()
+            .compute_gap(&PermissionLattice::restrictive(), &lattice);
+        TaskGrant {
+            version: TaskGrant::VERSION,
+            id: Uuid::nil(),
+            goal: "fix the failing CI build".into(),
+            goal_digest: TaskGrant::digest_goal("fix the failing CI build"),
+            ceiling_profile: "safe-pr-fixer".into(),
+            can: can.iter().map(|s| s.parse().unwrap()).collect(),
+            cannot: vec![ClippedEffect {
+                id: "github/open-pr".parse().unwrap(),
+                reason: "outside ceiling safe-pr-fixer".into(),
+            }],
+            limits: GrantLimits {
+                max_cost_usd: Decimal::new(500, 2),
+                duration_secs: 7200,
+                hosts: hosts.iter().map(|s| s.to_string()).collect(),
+                blocked_paths: vec!["**/.ssh/**".into(), "**/.aws/**".into(), "**/.env".into()],
+                commands: vec!["cargo test".into()],
+            },
+            risk: summarise_risk(&lattice, gap),
+            lattice,
+            provenance: CompilerProvenance {
+                compiler: "test/0".into(),
+                proposers: vec!["rules".into()],
+                rules_fired: vec!["ci-logs".into()],
+                repo_context_digest: "abcdef0123456789".into(),
+            },
+            created_at: Utc::now(),
+            not_after: Utc::now() + chrono::Duration::hours(2),
+        }
+    }
+
+    #[test]
+    fn plain_render_has_the_five_lines_in_order() {
+        let catalog = EffectCatalog::builtin().unwrap();
+        let mut lattice = PermissionLattice::safe_pr_fixer();
+        lattice.capabilities.web_fetch = CapabilityLevel::LowRisk;
+        let grant = grant_for(
+            lattice,
+            &[
+                "fs/read-workspace",
+                "github/read-ci-logs",
+                "shell/run-tests",
+            ],
+            &["api.github.com"],
+        );
+        let text = render(&grant, &catalog, Disclosure::Plain);
+        let lines: Vec<&str> = text.lines().collect();
+        assert!(lines[0].starts_with("Goal:    fix the failing CI build"));
+        assert!(lines[1].starts_with("Can:     "));
+        assert!(lines[1].contains("read CI logs"));
+        assert!(lines[2].starts_with("Cannot:  "));
+        assert!(lines[2].contains("open a pull request (outside ceiling safe-pr-fixer)"));
+        assert!(lines[2].contains("push to remote branches"));
+        assert!(
+            lines[3].starts_with("Limits:  $5.00 · 2h · api.github.com only · no .aws, .env, .ssh")
+        );
+        assert!(lines[4].starts_with("Risk:    "));
+        assert_eq!(lines.len(), 5, "plain is exactly five lines");
+    }
+
+    #[test]
+    fn deeper_disclosure_appends_grid_and_trace() {
+        let catalog = EffectCatalog::builtin().unwrap();
+        let grant = grant_for(PermissionLattice::read_only(), &["fs/read-workspace"], &[]);
+        let technical = render(&grant, &catalog, Disclosure::Technical);
+        assert!(technical.contains("Capabilities (ceiling: safe-pr-fixer)"));
+        assert!(technical.contains("read_files:"));
+        assert!(technical.contains("manage_pods:"));
+        let trace = render(&grant, &catalog, Disclosure::PolicyTrace);
+        assert!(trace.contains("Policy trace"));
+        assert!(trace.contains("Rules fired: ci-logs"));
+        assert!(trace.len() > technical.len());
+    }
+
+    #[test]
+    fn risk_line_names_the_missing_leg() {
+        let catalog = EffectCatalog::builtin().unwrap();
+        let grant = grant_for(PermissionLattice::read_only(), &["fs/read-workspace"], &[]);
+        let text = render(&grant, &catalog, Disclosure::Plain);
+        assert!(text.contains("1 of 3 exposure legs (private data)"));
+        assert!(text.contains("no approval prompts expected"));
+        assert!(text.contains("Limits:  $5.00 · 2h · no network"));
+    }
+
+    #[test]
+    fn assert_within_rejects_a_grant_above_its_ceiling() {
+        let grant = grant_for(PermissionLattice::permissive(), &[], &[]);
+        assert!(grant
+            .assert_within(&PermissionLattice::read_only())
+            .is_err());
+        let grant = grant_for(PermissionLattice::read_only(), &[], &[]);
+        assert!(grant
+            .assert_within(&PermissionLattice::permissive())
+            .is_ok());
+    }
+
+    #[test]
+    fn grant_serde_roundtrip() {
+        let grant = grant_for(PermissionLattice::read_only(), &["fs/read-workspace"], &[]);
+        let json = serde_json::to_string(&grant).unwrap();
+        let back: TaskGrant = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.can, grant.can);
+        assert_eq!(back.goal_digest, grant.goal_digest);
+        assert_eq!(back.lattice.capabilities, grant.lattice.capabilities);
+    }
+}

--- a/crates/portcullis/src/task_grant.rs
+++ b/crates/portcullis/src/task_grant.rs
@@ -222,13 +222,14 @@ fn render_plain(out: &mut String, grant: &TaskGrant, catalog: &EffectCatalog) {
     let _ = writeln!(out, "Cannot:  {}", join_dot(cannot));
 
     // Limits.
-    let hours = grant.limits.duration_secs as f64 / 3600.0;
+    let secs = grant.limits.duration_secs;
     let mut limits = vec![
         format!("${:.2}", grant.limits.max_cost_usd),
-        if hours >= 1.0 {
-            format!("{hours:.0}h")
+        if secs >= 3600 {
+            // Nearest hour, in integers: no float cast to ratchet.
+            format!("{}h", (secs + 1800) / 3600)
         } else {
-            format!("{}m", grant.limits.duration_secs / 60)
+            format!("{}m", secs / 60)
         },
     ];
     if grant.limits.hosts.is_empty() {

--- a/docs/adr/0004-delegation-compiler.md
+++ b/docs/adr/0004-delegation-compiler.md
@@ -1,0 +1,112 @@
+# ADR 0004 — Nucleus is a delegation compiler: intent in, minimum authority out
+
+- Status: accepted (2026-09-08)
+- Applies to: `nucleus run --goal`, `crates/nucleus-task-compiler`, `portcullis::effect_catalog`,
+  `portcullis::task_grant`; every later surface that asks a person to grant an agent authority
+
+## Context
+
+Nucleus's authority model is sophisticated: a 13-dimension capability lattice, sink
+scopes, SPIFFE identity, budgets, egress policy, delegation chains, IFC labels,
+discharges. Until now that model was also the user's interface. To run an agent
+safely a person picked a profile by name, or authored a lattice by hand, and read
+denials as `IFC sink scope violation` and `web_fetch: never`. The security
+architecture was correct and the usability cost of being correct fell on the user.
+
+The rest of the field resolves that cost by widening authority. The common shape in
+September 2026 is a per-action classifier or a two-knob sandbox (`read-only` /
+`workspace-write` × `ask` / `never`), in which a person's stated boundary is a line in
+a transcript that is lost when context is compacted, and in which users approve the
+overwhelming majority of permission prompts because the prompts are ceremony rather
+than a boundary. Research prototypes go the other way — task-scoped authorization
+that treats a submitted task as implicitly authorizing exactly the operations its
+faithful execution requires, and intent certificates that narrow a static tool
+manifest — but nothing shipped compiles a stated goal into a durable, enforced,
+minimum grant *before* execution. That is the open lane, and nucleus already owns
+the substrate for it: signed certificates whose `extensions` narrow by meet,
+`mint_child`, a weakening-gap calculator, receipts that attest which authority was
+exercised, and an observer that synthesizes a narrower profile from a trace.
+
+The DX north star this ADR serves:
+
+> Make least-privilege delegation feel easier than unrestricted execution.
+
+with two invariants DX work may not violate:
+
+- **Authority overhead** ρ = A_granted / A_observably-required → 1. Usability never
+  improves by granting more.
+- **Delegation clicks** C(T) = 1 for a new safe task, 0 for a previously approved one.
+  The consequential decision stays intentional; everything else is derived.
+
+## Decision
+
+1. **Intent is compiled, not classified.** A goal (`nucleus run --goal "fix the failing
+   CI build"`) is input to a deterministic compiler that derives the *effects* the task
+   needs from the goal and the repository it is stated in (ecosystem, CI system, git
+   remotes, MCP configs), lowers them to a `PermissionLattice`, and **meets the result
+   with a ceiling profile**. The grant is `≤ ceiling` by construction and is checked
+   with the same `delegate_to` a certificate mint uses. The ceiling is the only knob a
+   person can widen.
+2. **The unit of authority a person reads is a semantic effect, not a lattice
+   dimension.** `github/read-ci-logs`, `shell/run-tests`, `git/commit` are declared as
+   data (`crates/portcullis/effects/*.toml`, plus a repository's `.nucleus/effects/`),
+   each with a title, a risk grade, what it lowers to (operations, sinks, hosts) and
+   how it is recognised (MCP tool names, command prefixes, HTTP method+host+path).
+   The host→meaning table lives in the catalog, not in comments beside an allowlist.
+   Plugins improve DX and security together by contributing effects: plugin quality is
+   semantic compression of authority.
+3. **The grant is an object, and it is rendered by meaning.** A `TaskGrant` records the
+   goal (prompt playback), `can`, `cannot` (proposed but clipped by the ceiling,
+   with the reason), limits, the lattice, a risk summary from the uninhabitable-state
+   analysis, and provenance (which rules fired, which proposers were consulted, the
+   repository-context digest). It renders as five lines — Goal / Can / Cannot /
+   Limits / Risk — with progressive disclosure below them: the 13-dimension grid, then
+   the per-dimension weakening requests and their cost. Same object, three depths.
+4. **Effect proposal is deterministic and explainable, with a validated seam for
+   more.** The built-in proposer is a rule table over goal phrases × repository
+   context; every rule that fires is named in the grant. An orchestrator may add an
+   `EffectProposer` as a *child process* (JSON in, JSON out). Its output is validated
+   against the catalog and meet-clamped like everything else, so a proposer can only
+   narrow or starve a goal, never widen it. Nucleus links no LLM SDK; the compiler
+   crate is offline by construction and CI enforces that.
+5. **Fail closed at every edge.** A goal nothing recognises is an error that names the
+   remedy (`--effects`, `--profile`); it never falls back to a permissive profile. An
+   effect the ceiling clips is reported in `cannot`, never silently granted or
+   silently dropped. Without a TTY, `--goal` refuses to run unless `--yes` names the
+   decision; an unattended run does not acquire authority by default.
+6. **Improvement is narrowing-only.** The loop this ADR opens is
+   `goal → effects → minimum authority → risk delta → execute → receipts → narrower
+   reusable grant`. Later milestones seal the grant into a certificate (a durable
+   intent, not a transcript line), turn every denial into a structured escalation
+   proposal bounded by the same ceiling, attribute receipts to effects to compute ρ,
+   and offer a profile with unused authority removed. None of those steps may
+   introduce a path that widens authority outside `POST /v1/escalate` and the
+   existing approval counters.
+
+## Consequences
+
+- `nucleus run --goal` is the primary interface; `--profile` and PodSpec YAML remain
+  the expert path. `--dry-run` shows the grant and stops; `--explain technical |
+  policy-trace` deepens it; `--save-grant` writes it.
+- The 13-dimension verified core does not change. Effects are catalog data now and
+  `extensions` keys on the certificate later, following the `tool_surface` pattern.
+- Enforcement of a semantic effect is, in this milestone, the lattice it lowers to
+  plus the host list plus the command prefixes it vouches for. An agent that reaches
+  GitHub with `curl` rather than an MCP tool is bounded by host, not by method+path;
+  per-effect enforcement at the credential boundary is a later milestone and the
+  docs say so.
+- Two metrics become product surfaces: ρ (authority granted ÷ authority used, from
+  receipts) and C(T) (authorization decisions per task).
+- A new CI gate, "The task compiler is offline by construction", is probed by the
+  gate-of-gates like every other script gate.
+
+## Milestones
+
+| # | Delivers | Status |
+|---|---|---|
+| 1 | Effect catalog, `TaskGrant` + renderer, `nucleus-task-compiler`, `nucleus run --goal` preview and single confirmation, offline gate | this ADR's PR |
+| 2 | `effect/` certificate keys, `SealedTaskGrant`, `nucleus run --grant` (C(T)=0) | next |
+| 3 | Receipt → effect attribution, ρ, post-run "save narrower profile", `~/.nucleus/profiles` | |
+| 4 | Structured `EscalationProposal` on every denial, carried to MCP / tool-proxy / hook / SDK, `nucleus grant --scope action\|run\|always` | |
+| 5 | ρ and C(T) in `ExitReport` and the run summary | |
+| 6 | Per-effect enforcement at the credential boundary (method+path) | |

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -335,6 +335,76 @@ time:
 
 ---
 
+## Running by goal
+
+You do not have to pick a profile. State the outcome and nucleus compiles it into
+the minimum authority the task needs, shows it in plain language, and runs after
+one confirmation:
+
+```
+$ nucleus run --goal "fix the failing CI build" --ceiling safe-pr-fixer --dry-run
+Goal:    fix the failing CI build
+Can:     read and search workspace files · read git history and status · read CI logs and workflow runs · edit workspace files · run the test suite · commit changes locally
+Cannot:  push to remote branches · open or merge pull requests · reach hosts other than api.github.com · spawn agents or pods
+Limits:  $5.00 · 2h · api.github.com only · no .aws, .env, .ssh
+Risk:    all 3 exposure legs present → the kernel asks for approval before run_bash
+```
+
+How it is derived, and why it cannot be wider than you allow:
+
+1. The repository is probed (ecosystem, CI system, git remotes, MCP configs) and a
+   rule table maps goal phrases to **semantic effects** (below). Every rule that
+   fired is recorded in the grant (`--explain policy-trace`).
+2. The effects are lowered to the 13 capability dimensions, sinks and hosts.
+3. The result is **met with the `--ceiling` profile** (default `codegen`), so the
+   grant is never wider than the ceiling. An effect the ceiling does not admit is
+   listed under *Cannot* with the reason, never silently dropped or granted.
+4. Without a TTY the run refuses unless you pass `--yes`; `--dry-run` only shows the
+   grant; `--save-grant PATH` writes it as JSON; `--explain technical` adds the grid;
+   `--effects github/read-issue,web/search` adds effects the goal did not imply.
+
+A goal nothing recognises is an error naming the remedy. It never falls back to a
+permissive profile.
+
+An orchestrator may supply its own proposer with `--proposer PROGRAM` (JSON on
+stdin, `{"effects": [...]}` on stdout). Its answer is validated against the catalog
+and clamped under the ceiling like everything else, so it can only narrow.
+
+## Semantic effects
+
+An effect is the unit of authority a person reads. Each lowers to core dimensions,
+sinks and hosts, and carries how it is recognised (MCP tool names, command
+prefixes, HTTP method+host+path), which is what later attributes a run's receipts
+back to the effects that authorised it. The built-in catalog:
+
+| Effect | Means | Lowers to |
+|---|---|---|
+| `fs/read-workspace` | Read and search workspace files | `read_files`, `glob_search`, `grep_search` (always) |
+| `fs/edit-workspace` | Edit workspace files | `write_files`, `edit_files` |
+| `shell/run-tests` | Run the test suite | `run_bash` (`cargo test`, `npm test`, `pytest`, …) |
+| `shell/run-build` | Build the project | `run_bash` (`cargo build`, `npm run build`, …) |
+| `shell/run-lint` | Run formatters and linters | `run_bash` (`cargo clippy`, `ruff`, …) |
+| `git/read-history` | Read git history and status | `run_bash` (`git status`, `git log`, `git diff`, …) |
+| `git/commit` | Commit changes locally | `git_commit` |
+| `git/push-branch` | Push a branch to the remote | `git_push`, host `github.com` |
+| `web/package-registry-crates` | Download Rust dependencies | `web_fetch`, hosts `crates.io`, `static.crates.io`, `index.crates.io` |
+| `web/package-registry-npm` | Download JavaScript dependencies | `web_fetch`, host `registry.npmjs.org` |
+| `web/package-registry-pypi` | Download Python dependencies | `web_fetch`, hosts `pypi.org`, `files.pythonhosted.org` |
+| `web/search` | Search the web | `web_search` |
+| `github/read-issue` | Read issues | `web_fetch`, `GET api.github.com/repos/*/issues*` |
+| `github/read-ci-logs` | Read CI logs and workflow runs | `web_fetch`, `GET api.github.com/repos/*/actions/*` |
+| `github/read-pull-request` | Read pull requests and reviews | `web_fetch`, `GET api.github.com/repos/*/pulls*` |
+| `github/comment` | Comment on issues and pull requests | `create_pr`, `POST …/comments` |
+| `github/open-pr` | Open a pull request | `create_pr`, `git_push`, `POST api.github.com/repos/*/pulls` |
+| `github/merge-pr` | Merge a pull request | `git_push`, `PUT api.github.com/repos/*/pulls/*/merge` |
+
+A repository adds its own under `.nucleus/effects/*.toml` (same format as
+`crates/portcullis/effects/`). In this milestone an effect is enforced by the
+lattice it lowers to, the host list, and the command prefixes it vouches for; an
+agent that reaches a host with `curl` rather than an MCP tool is bounded by host,
+not by method and path. See `docs/adr/0004-delegation-compiler.md` for the
+milestones that close that gap.
+
 ## Delegation (Sub-agents)
 
 When delegating to a sub-agent, permissions can only go **down**, never up:

--- a/scripts/check-gates-can-fail.sh
+++ b/scripts/check-gates-can-fail.sh
@@ -219,6 +219,13 @@ perturb_kani_harness_deleted() {
     awk 'BEGIN{done=0} /#\[kani::proof\]/ && !done {done=1; next} {print}' "$1" > "$tmp"; cat "$tmp" > "$1"; rm -f "$tmp"
 }
 
+perturb_compiler_online() {
+    # A network crate appended to the task compiler's manifest. It lands in
+    # whichever dependency table is last, which is why the gate reads every
+    # table and not only [dependencies].
+    printf '\nreqwest = "0.12"\n' >> "$1"
+}
+
 perturb_test_helpers_in_prod() {
     # `test-helpers` reachable from a SHIPPING build, which is the gate's whole
     # subject: with it on, `discharge::test_helpers::bundle_for` mints a
@@ -453,6 +460,8 @@ probe check-lean-libs-built.sh "" crates/portcullis-core/lean/lakefile.lean \
       "a lean_lib nothing builds"               perturb_lean_lib_unbuilt
 probe check-kani-proof-count.sh "--strict" crates/portcullis/src/kani.rs \
       "a deleted Kani harness"                  perturb_kani_harness_deleted
+probe check-task-compiler-offline.sh "" crates/nucleus-task-compiler/Cargo.toml \
+      "a network crate in the task compiler"    perturb_compiler_online
 probe check-declassify-sink-scope-enforced.sh "" crates/portcullis/src/flow_graph.rs \
       "the applied sink mask widened to admit every sink" \
       perturb_declassify_unscope

--- a/scripts/check-task-compiler-offline.sh
+++ b/scripts/check-task-compiler-offline.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# The delegation compiler is offline by construction.
+#
+# `nucleus-task-compiler` turns a goal into a minimum-authority grant from
+# the repository on disk and the effect catalog. It must never open a socket:
+# the whole point of the pluggable proposer being a child process is that an
+# LLM-backed proposer lives OUTSIDE nucleus (vendor neutrality, CLAUDE.md)
+# and outside this crate's dependency closure. A network crate appearing in
+# any of its dependency tables, or a socket type in its sources, is the
+# compiler acquiring a way to phone home — red, not a warning.
+#
+# Text-level on purpose: no cargo invocation, so the gate-of-gates
+# (scripts/check-gates-can-fail.sh) can perturb Cargo.toml and restore it
+# without touching Cargo.lock.
+#
+# Usage: scripts/check-task-compiler-offline.sh
+
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")/.." && pwd)"
+crate="$root/crates/nucleus-task-compiler"
+manifest="$crate/Cargo.toml"
+src="$crate/src"
+
+if [[ ! -f "$manifest" ]]; then
+    echo "::error::$manifest not found"
+    exit 1
+fi
+
+# Crates that open sockets or embed an async runtime that does.
+NETWORK_CRATES=(reqwest ureq hyper hyper-util tokio tonic iroh curl isahc surf async-std axum h2 rustls)
+
+fail=0
+
+# Every dependency table: [dependencies], [dev-dependencies],
+# [build-dependencies], and target-specific variants.
+tables="$(awk '
+    /^\[.*dependencies.*\]/ { in_deps = 1; next }
+    /^\[/                    { in_deps = 0 }
+    in_deps && /^[A-Za-z0-9_-]+[[:space:]]*=/ { print $1 }
+' "$manifest")"
+
+for c in "${NETWORK_CRATES[@]}"; do
+    if printf '%s\n' "$tables" | grep -qx -- "$c"; then
+        echo "::error::crates/nucleus-task-compiler/Cargo.toml depends on '$c' — the task compiler must stay offline"
+        fail=1
+    fi
+done
+
+if grep -rnE 'std::net|TcpStream|TcpListener|UdpSocket|UnixStream' "$src" >/dev/null; then
+    echo "::error::crates/nucleus-task-compiler/src reaches for a socket type:"
+    grep -rnE 'std::net|TcpStream|TcpListener|UdpSocket|UnixStream' "$src" || true
+    fail=1
+fi
+
+if [[ "$fail" -ne 0 ]]; then
+    exit 1
+fi
+
+echo "OK: nucleus-task-compiler names no network crate and no socket type"


### PR DESCRIPTION
## What this is

Milestone 1 of ADR 0004 (`docs/adr/0004-delegation-compiler.md`): nucleus becomes a delegation compiler. A person states a goal; the compiler derives the semantic effects the task needs from the goal and the repository it is stated in, lowers them to a `PermissionLattice`, meets the result with a ceiling profile, and renders the grant as five lines a person can approve:

```
$ nucleus run --goal "fix the failing CI build" --ceiling safe-pr-fixer --dry-run
Goal:    fix the failing CI build
Can:     read CI logs and workflow runs · read and search workspace files · edit workspace files · run the test suite · commit locally
Cannot:  open a pull request (outside ceiling safe-pr-fixer) · push to remote branches (outside ceiling safe-pr-fixer)
Limits:  $5.00 · 2h · api.github.com only · no .aws, .env, .ssh
Risk:    2 of 3 exposure legs (private data + untrusted content); exfiltration absent → no approval prompts expected
```

Without `--dry-run` the command asks one `[R]un · [d]etails · [a]bort` question (details cycles plain → 13-dimension grid → per-dimension weakening trace) and then executes on the existing run path under the compiled lattice. No TTY and no `--yes` ⇒ exit 2 before anything spawns. A goal nothing recognises is an error that names the remedy (`--effects`, `--profile`); it never falls back to a permissive profile.

## Pieces

- **Effect catalog** (`crates/portcullis/effects/{fs,shell,git,web,github}.toml`, `portcullis::effect_catalog`): semantic effects such as `github/read-ci-logs`, `shell/run-tests`, `git/push-branch`, each with a title, risk grade, what it lowers to (operations, sinks, hosts) and how it is recognised (MCP tool names, command prefixes, HTTP method+host+path). The host→meaning table is data now, not comments beside an allowlist. Repositories add effects under `.nucleus/effects/`. Adding an effect is a TOML edit.
- **`TaskGrant` + renderer** (`portcullis::task_grant`): goal, `can`, `cannot` (proposed but clipped, with the reason), limits, the lattice, a risk summary from the uninhabitable-state analysis and `WeakeningCostConfig::compute_gap`, and provenance (rules fired, proposers consulted, repo-context digest). `render_capabilities` replaces the old `{:?}` five-capability block in `--dry-run` for the profile path too.
- **`nucleus-task-compiler`** (new crate): `probe` for repository context (ecosystems, CI system, git remotes, MCP configs), a deterministic rule table over goal phrases × context, an `EffectProposer` trait with `RuleProposer` and `ExternalCommandProposer` (child process, JSON in/out; unknown ids dropped, output validated and meet-clamped so a proposer can only narrow or starve, never widen), and `compile` which meets the requested lattice with the ceiling and guards the result with the same `delegate_to` a certificate mint uses.
- **CLI**: `--goal`, `--ceiling` (default `codegen`), `--effects`, `--yes`, `--explain plain|technical|policy-trace`, `--proposer`, `--save-grant`.
- **Gate**: `scripts/check-task-compiler-offline.sh` proves the compiler crate names no network crate and no socket type; probed by the gate-of-gates; new CI job "The task compiler is offline by construction". Not added to `ci/required-checks.txt` (owner decision).
- **Docs**: ADR 0004, `docs/permissions.md` "Running by goal" and "Semantic effects", README one-liner.

## Invariants this PR keeps

- The 13-dimension verified core is untouched. No new `cfg(kani)` site (divergence inventory stays at 72).
- The grant is `≤ ceiling` by construction. `tests/goal_corpus.rs` checks 15 goals × every canonical ceiling: `lattice.leq(ceiling)`, `can ⊆ catalog`, every proposed effect lands in exactly one of `can`/`cannot`, every host in limits is vouched for by a granted effect, a greedy external proposer is clamped, and limit overrides can only tighten.
- Vendor-neutral: no LLM SDK linked, no vendor names; `ci/no-vendor-strings.sh` clean.

## Caveat, stated in the docs

Enforcement of a semantic effect in this milestone is the lattice it lowers to plus the host list plus the command prefixes it vouches for. An agent that reaches GitHub with `curl` rather than an MCP tool is bounded by host, not by method+path. Per-effect enforcement at the credential boundary is milestone 6.

## Validation

- `cargo test -p portcullis --all-features --lib -- effect_catalog task_grant` (14 pass), `cargo test -p nucleus-task-compiler` (13 pass), `cargo test -p nucleus-cli --test goal_dry_run` (4 pass)
- `cargo clippy --all-features --all-targets -- -D warnings` on portcullis, nucleus-task-compiler, nucleus-cli: clean
- `cargo fmt --all --check`, `cargo xtask ci-spec check`, `ci/no-vendor-strings.sh`, `ci/merge-group-scope-parity.sh`, `scripts/check-kani-divergence.sh`, `scripts/check-task-compiler-offline.sh`, `scripts/check-gates-can-fail.sh` (new probe RED on a network crate, GREEN when restored), `cargo metadata --no-deps` with empty stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QqBdBgCoVTtbe7gLNQh532

---
_Generated by [Claude Code](https://claude.ai/code/session_01QqBdBgCoVTtbe7gLNQh532)_