### PR TITLE
dx(delegation): a run's trace narrows its grant into a reusable profile (milestone 3)

### DIFF
--- a/crates/nucleus-cli/src/goal.rs
+++ b/crates/nucleus-cli/src/goal.rs
@@ -129,7 +129,10 @@ pub async fn execute(args: RunArgs, global_config_path: &str) -> Result<()> {
         }
     }
 
-    run_under(&args, global_config_path, &grant.lattice, &work_dir, &goal).await
+    let mut args = args;
+    let trace = default_trace(&mut args, grant.id)?;
+    run_under(&args, global_config_path, &grant.lattice, &work_dir, &goal).await?;
+    learn_from_run(&args, &grant, &catalog, trace.as_deref())
 }
 
 /// Entry point, reached from `run::execute` when `--grant` is set: verify
@@ -163,7 +166,92 @@ pub async fn execute_grant(args: RunArgs, global_config_path: &str) -> Result<()
         return Ok(());
     }
     let goal = grant.goal.clone();
-    run_under(&args, global_config_path, &grant.lattice, &work_dir, &goal).await
+    let grant = grant.clone();
+    let mut args = args;
+    let trace = default_trace(&mut args, grant.id)?;
+    run_under(&args, global_config_path, &grant.lattice, &work_dir, &goal).await?;
+    learn_from_run(&args, &grant, &catalog, trace.as_deref())
+}
+
+/// A goal or grant run always leaves a trace to learn from: unless
+/// `--kernel-trace` named one, `~/.config/nucleus/traces/<grant id>.jsonl`.
+/// Only the MCP-mediated modes write it (hook mode has no kernel trace).
+fn default_trace(args: &mut RunArgs, grant_id: uuid::Uuid) -> Result<Option<PathBuf>> {
+    if args.hook {
+        return Ok(args.kernel_trace.clone());
+    }
+    if args.kernel_trace.is_none() {
+        let dir = crate::config::nucleus_dir()?.join("traces");
+        std::fs::create_dir_all(&dir).with_context(|| format!("creating {}", dir.display()))?;
+        args.kernel_trace = Some(dir.join(format!("{grant_id}.jsonl")));
+    }
+    Ok(args.kernel_trace.clone())
+}
+
+/// After a run: attribute its trace to the grant, print the usage lines,
+/// and (at a terminal) offer to keep a profile with the unused authority
+/// removed. Learning only narrows; nothing here can widen the grant.
+fn learn_from_run(
+    args: &RunArgs,
+    grant: &TaskGrant,
+    catalog: &EffectCatalog,
+    trace: Option<&Path>,
+) -> Result<()> {
+    let Some(trace) = trace else {
+        return Ok(());
+    };
+    let Ok(text) = std::fs::read_to_string(trace) else {
+        return Ok(());
+    };
+    let observations = portcullis::observe::parse_jsonl_observations(&text);
+    if observations.is_empty() {
+        return Ok(());
+    }
+    let usage = portcullis::attribute_usage(grant, catalog, &observations);
+    println!();
+    print!("{}", portcullis::render_usage(&usage, catalog));
+    println!("  trace:   {}", trace.display());
+
+    let nothing_to_drop = usage.unused.is_empty()
+        && usage
+            .operations_granted
+            .iter()
+            .all(|op| usage.operations_used.contains(op));
+    if nothing_to_drop || args.yes || !io::stdin().is_terminal() {
+        if !nothing_to_drop {
+            println!(
+                "  narrower profile: nucleus observe --grant <grant> --input {} --narrow NAME --save",
+                trace.display()
+            );
+        }
+        return Ok(());
+    }
+
+    print!(
+        "
+Save a profile with the unused authority removed? name (empty to skip): "
+    );
+    io::stdout().flush()?;
+    let mut line = String::new();
+    io::stdin().lock().read_line(&mut line)?;
+    let name = line.trim();
+    if name.is_empty() {
+        return Ok(());
+    }
+    if !crate::profiles::is_valid_profile_name(name) {
+        bail!("{name}: {}", crate::profiles::PROFILE_NAME_HELP);
+    }
+    let narrowed = portcullis::narrow_grant(grant, &usage, name);
+    let yaml = narrowed.profile.to_yaml().map_err(|e| anyhow!("{e}"))?;
+    let path = crate::observe::install_profile(name, &yaml)?;
+    println!(
+        "profile '{name}' installed at {} ({} effects and {} dimensions removed); \
+         next time: nucleus run --profile {name} … or --ceiling {name}",
+        path.display(),
+        narrowed.dropped_effects.len(),
+        narrowed.dropped_operations.len()
+    );
+    Ok(())
 }
 
 /// Everything from here is the ordinary run path with a compiled lattice in

--- a/crates/nucleus-cli/src/grant.rs
+++ b/crates/nucleus-cli/src/grant.rs
@@ -19,7 +19,9 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result, anyhow, bail};
 use chrono::Utc;
 use clap::{Args, Subcommand};
-use portcullis::{Disclosure, EffectCatalog, SealedTaskGrant, VerifiedGrant, render_grant};
+use portcullis::{
+    Disclosure, EffectCatalog, SealedTaskGrant, TaskGrant, VerifiedGrant, render_grant,
+};
 use ring::signature::{Ed25519KeyPair, KeyPair};
 
 use crate::config::nucleus_dir;
@@ -245,6 +247,19 @@ pub fn write_sealed(sealed: &SealedTaskGrant, path: &Path) -> Result<()> {
 }
 
 // ── show / verify ─────────────────────────────────────────────────────────
+
+/// Read a grant from disk for attribution: a sealed grant (its readable
+/// half) or a plain grant JSON. No verification: usage attribution reads
+/// what was granted, it grants nothing.
+pub fn read_grant(path: &Path) -> Result<TaskGrant> {
+    let text = std::fs::read_to_string(path)
+        .with_context(|| format!("reading the grant at {}", path.display()))?;
+    if let Ok(sealed) = serde_json::from_str::<SealedTaskGrant>(&text) {
+        return Ok(sealed.grant);
+    }
+    serde_json::from_str::<TaskGrant>(&text)
+        .with_context(|| format!("{} is neither a sealed nor a plain grant", path.display()))
+}
 
 /// Read a sealed grant from disk.
 pub fn read_sealed(path: &Path) -> Result<SealedTaskGrant> {

--- a/crates/nucleus-cli/src/observe.rs
+++ b/crates/nucleus-cli/src/observe.rs
@@ -2,13 +2,25 @@
 //!
 //! Reads a JSONL log of tool calls (from audit log or stdin) and generates
 //! a minimal policy profile that permits exactly the observed behavior.
+//!
+//! With `--grant FILE` the observations are attributed to the effects of a
+//! grant instead (ADR 0004, milestone 3): the report says which effects the
+//! run used, which it never did, the authority overhead ρ, and what was
+//! denied; `--narrow NAME` emits a profile with the unused authority
+//! removed, never above the grant, and `--save` installs it under
+//! `~/.config/nucleus/profiles/` where `--profile NAME` finds it.
 
 use std::io::Read;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use clap::Args;
 use portcullis::observe::{ObserveSession, format_summary, parse_jsonl_observations};
+use portcullis::{TaskGrant, attribute_usage, narrow_grant, render_usage};
+
+use crate::goal::load_catalog;
+use crate::grant::read_grant;
+use crate::profiles::{PROFILE_NAME_HELP, user_profiles_dir};
 
 /// Observe agent behavior and generate a minimal policy profile.
 #[derive(Args)]
@@ -29,6 +41,26 @@ pub struct ObserveArgs {
     /// Show summary report alongside policy.
     #[arg(long, default_value_t = true)]
     pub summary: bool,
+
+    /// Attribute the observations to this grant's effects (a sealed grant
+    /// from --save-grant / `nucleus grant seal`, or a plain grant JSON).
+    #[arg(long, value_name = "FILE")]
+    pub grant: Option<PathBuf>,
+
+    /// With --grant: emit a profile named NAME with the unused authority
+    /// removed (never above the grant).
+    #[arg(long, value_name = "NAME", requires = "grant")]
+    pub narrow: Option<String>,
+
+    /// With --narrow: install the profile under ~/.config/nucleus/profiles/
+    /// so `--profile NAME` and `--ceiling NAME` find it.
+    #[arg(long, requires = "narrow")]
+    pub save: bool,
+
+    /// Repository whose `.nucleus/effects` should extend the catalog
+    /// (default: current directory).
+    #[arg(short = 'd', long, default_value = ".")]
+    pub dir: String,
 }
 
 pub fn execute(args: ObserveArgs) -> Result<()> {
@@ -63,6 +95,10 @@ pub fn execute(args: ObserveArgs) -> Result<()> {
         return Ok(());
     }
 
+    if let Some(grant_path) = &args.grant {
+        return observe_against_grant(&args, grant_path, &observations);
+    }
+
     // Build session
     let mut session = ObserveSession::new(&args.name);
     for obs in observations {
@@ -93,4 +129,61 @@ pub fn execute(args: ObserveArgs) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// The `--grant` path: usage report, optional narrowing, optional install.
+fn observe_against_grant(
+    args: &ObserveArgs,
+    grant_path: &Path,
+    observations: &[portcullis::observe::Observation],
+) -> Result<()> {
+    let grant: TaskGrant = read_grant(grant_path)?;
+    let work_dir = PathBuf::from(shellexpand::tilde(&args.dir).to_string());
+    let catalog = load_catalog(&work_dir)?;
+    let usage = attribute_usage(&grant, &catalog, observations);
+    print!("{}", render_usage(&usage, &catalog));
+
+    let Some(name) = &args.narrow else {
+        return Ok(());
+    };
+    if !crate::profiles::is_valid_profile_name(name) {
+        bail!("--narrow {name}: {PROFILE_NAME_HELP}");
+    }
+    let narrowed = narrow_grant(&grant, &usage, name);
+    let yaml = narrowed
+        .profile
+        .to_yaml()
+        .context("Failed to serialize the narrowed profile")?;
+    eprintln!(
+        "narrowed: {} effects and {} dimensions removed; the profile stays within the grant",
+        narrowed.dropped_effects.len(),
+        narrowed.dropped_operations.len()
+    );
+
+    if args.save {
+        let path = install_profile(name, &yaml)?;
+        eprintln!(
+            "profile '{name}' installed at {} (use --profile {name} or --ceiling {name})",
+            path.display()
+        );
+    }
+    match &args.output {
+        Some(path) => {
+            std::fs::write(path, &yaml)
+                .with_context(|| format!("Failed to write {}", path.display()))?;
+            eprintln!("Profile written to {}", path.display());
+        }
+        None if !args.save => println!("{yaml}"),
+        None => {}
+    }
+    Ok(())
+}
+
+/// Write `yaml` as `~/.config/nucleus/profiles/<name>.yaml`.
+pub fn install_profile(name: &str, yaml: &str) -> Result<PathBuf> {
+    let dir = user_profiles_dir()?;
+    std::fs::create_dir_all(&dir).with_context(|| format!("creating {}", dir.display()))?;
+    let path = dir.join(format!("{name}.yaml"));
+    std::fs::write(&path, yaml).with_context(|| format!("writing {}", path.display()))?;
+    Ok(path)
 }

--- a/crates/nucleus-cli/src/profiles.rs
+++ b/crates/nucleus-cli/src/profiles.rs
@@ -4,12 +4,40 @@
 //! 1. **Canonical YAML profiles** from [`portcullis::profile::ProfileRegistry`]
 //!    (10 profiles with uninhabitable_state analysis, descriptions, budgets, and time limits)
 //! 2. **Short aliases** that map to canonical names (e.g., "review" → "code-review")
-//! 3. **Legacy profiles** built into [`PermissionLattice`] (for profiles not yet
+//! 3. **User profiles** under `~/.config/nucleus/profiles/*.yaml` — what
+//!    `nucleus observe --grant … --narrow NAME --save` and the post-run
+//!    "save a narrower profile?" prompt write (ADR 0004, milestone 3)
+//! 4. **Legacy profiles** built into [`PermissionLattice`] (for profiles not yet
 //!    migrated to YAML)
+//!
+//! A user profile may carry a canonical name only if it is **not wider**
+//! than the canonical one (`leq`): learning from a run narrows, and a file
+//! on disk cannot quietly widen what `--ceiling codegen` means. A wider
+//! shadow is ignored with a warning.
+
+use std::path::PathBuf;
 
 use anyhow::Result;
 use portcullis::PermissionLattice;
 use portcullis::profile::ProfileRegistry;
+
+use crate::config::nucleus_dir;
+
+/// What a profile name may look like.
+pub const PROFILE_NAME_HELP: &str = "a profile name is lowercase letters, digits and hyphens";
+
+/// `[a-z0-9-]+`, so a name is a file name and a CLI argument and nothing else.
+pub fn is_valid_profile_name(name: &str) -> bool {
+    !name.is_empty()
+        && name
+            .bytes()
+            .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-')
+}
+
+/// Where user profiles live.
+pub fn user_profiles_dir() -> Result<PathBuf> {
+    Ok(nucleus_dir()?.join("profiles"))
+}
 
 /// Resolve a profile name to a [`PermissionLattice`].
 ///
@@ -18,19 +46,49 @@ pub fn resolve(name: &str) -> Option<PermissionLattice> {
     let registry = ProfileRegistry::default();
 
     // 1. Try canonical YAML profiles (handles hyphen/underscore normalization)
-    if let Ok(lattice) = registry.resolve(name) {
-        return Some(lattice);
+    let canonical = registry.resolve(name).ok().or_else(|| {
+        // 2. Try short aliases → canonical names
+        resolve_alias(name).and_then(|c| registry.resolve(c).ok())
+    });
+
+    // 3. A user profile: on its own, or as a narrower shadow of a canonical one.
+    if let Some(user) = resolve_user(name) {
+        return match canonical {
+            Some(c) if !user.leq(&c) => {
+                eprintln!(
+                    "nucleus: ignoring user profile '{name}': it is wider than the canonical \
+                     profile of the same name (a user profile may only narrow it)"
+                );
+                Some(c)
+            }
+            _ => Some(user),
+        };
+    }
+    if canonical.is_some() {
+        return canonical;
     }
 
-    // 2. Try short aliases → canonical names
-    if let Some(canonical) = resolve_alias(name)
-        && let Ok(lattice) = registry.resolve(canonical)
-    {
-        return Some(lattice);
-    }
-
-    // 3. Legacy profiles not (yet) in the registry
+    // 4. Legacy profiles not (yet) in the registry
     resolve_legacy(name)
+}
+
+/// The user's profile directory, if it exists and parses. A directory that
+/// fails to parse is reported once and treated as empty: a broken file must
+/// not make `--profile codegen` fail.
+pub fn user_registry() -> Option<ProfileRegistry> {
+    let dir = user_profiles_dir().ok()?;
+    match ProfileRegistry::load_from_dir(&dir) {
+        Ok(r) if !r.is_empty() => Some(r),
+        Ok(_) => None,
+        Err(e) => {
+            eprintln!("nucleus: user profiles in {} ignored: {e}", dir.display());
+            None
+        }
+    }
+}
+
+fn resolve_user(name: &str) -> Option<PermissionLattice> {
+    user_registry()?.resolve(name).ok()
 }
 
 /// Map short aliases to canonical profile names.
@@ -67,7 +125,7 @@ fn resolve_legacy(name: &str) -> Option<PermissionLattice> {
 /// List available profiles to stdout.
 ///
 /// Canonical profiles are listed first with descriptions from their YAML specs,
-/// followed by legacy profiles.
+/// then the user's own, then legacy profiles.
 pub fn list() -> Result<()> {
     let registry = ProfileRegistry::default();
 
@@ -82,6 +140,23 @@ pub fn list() -> Result<()> {
         if let Some(spec) = registry.get(name) {
             let desc = spec.description.as_deref().unwrap_or("(no description)");
             println!("  {:<18} {}", name, desc);
+        }
+    }
+
+    if let Some(user) = user_registry() {
+        println!();
+        println!(
+            "Your profiles ({}):",
+            user_profiles_dir()
+                .map(|p| p.display().to_string())
+                .unwrap_or_default()
+        );
+        println!();
+        for name in user.names() {
+            if let Some(spec) = user.get(name) {
+                let desc = spec.description.as_deref().unwrap_or("(no description)");
+                println!("  {:<18} {}", name, desc);
+            }
         }
     }
 
@@ -241,5 +316,14 @@ mod tests {
                 name
             );
         }
+    }
+
+    #[test]
+    fn profile_names_are_file_and_flag_safe() {
+        assert!(is_valid_profile_name("ci-tests"));
+        assert!(is_valid_profile_name("x1"));
+        assert!(!is_valid_profile_name(""));
+        assert!(!is_valid_profile_name("CI Tests"));
+        assert!(!is_valid_profile_name("../codegen"));
     }
 }

--- a/crates/nucleus-cli/tests/grant_learning.rs
+++ b/crates/nucleus-cli/tests/grant_learning.rs
@@ -1,0 +1,183 @@
+//! The learning loop at the CLI boundary (ADR 0004, milestone 3): a run's
+//! trace attributed to its grant, a narrower profile that stays within the
+//! grant, and user profiles that `--profile` / `--ceiling` find but that can
+//! never widen a canonical name.
+
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+fn repo() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    fs::write(
+        root.join("Cargo.toml"),
+        "[package]\nname='x'\nversion='0.1.0'\n",
+    )
+    .unwrap();
+    fs::create_dir_all(root.join(".github/workflows")).unwrap();
+    fs::write(root.join(".github/workflows/ci.yml"), "on: push\n").unwrap();
+    fs::create_dir_all(root.join(".git")).unwrap();
+    fs::write(
+        root.join(".git/config"),
+        "[remote \"origin\"]\n\turl = https://github.com/acme/widgets.git\n",
+    )
+    .unwrap();
+    dir
+}
+
+fn nucleus(home: &Path) -> Command {
+    let mut c = Command::new(env!("CARGO_BIN_EXE_nucleus"));
+    // Everything host-side (grant key, profiles, traces) lives under HOME.
+    c.env("HOME", home);
+    c
+}
+
+fn seal(home: &Path, repo: &Path, out: &Path) {
+    let res = nucleus(home)
+        .args([
+            "grant",
+            "seal",
+            "--goal",
+            "fix the failing CI build",
+            "--ceiling",
+            "safe-pr-fixer",
+            "--yes",
+        ])
+        .arg("-o")
+        .arg(out)
+        .arg("-d")
+        .arg(repo)
+        .stdin(Stdio::null())
+        .output()
+        .unwrap();
+    assert!(
+        res.status.success(),
+        "seal failed:\n{}",
+        String::from_utf8_lossy(&res.stderr)
+    );
+}
+
+const TRACE: &str = r#"{"operation":"read_files","subject":"src/main.rs","succeeded":true}
+{"operation":"grep_search","subject":"fn main","succeeded":true}
+{"operation":"run_bash","subject":"cargo test --workspace","succeeded":true}
+{"operation":"git_push","subject":"origin main","succeeded":false}
+"#;
+
+#[test]
+fn a_trace_is_attributed_to_the_grant_and_narrows_into_a_usable_profile() {
+    let dir = repo();
+    let home = tempfile::tempdir().unwrap();
+    let grant = dir.path().join("ci.grant");
+    seal(home.path(), dir.path(), &grant);
+    let trace = dir.path().join("trace.jsonl");
+    fs::write(&trace, TRACE).unwrap();
+
+    // Usage report, and a narrowed profile installed under HOME.
+    let out = nucleus(home.path())
+        .args(["observe", "--grant"])
+        .arg(&grant)
+        .arg("--input")
+        .arg(&trace)
+        .args(["--narrow", "ci-tests", "--save", "-d"])
+        .arg(dir.path())
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(out.status.success(), "stdout:\n{stdout}\nstderr:\n{stderr}");
+    assert!(stdout.contains("authority: used 2 of"), "{stdout}");
+    assert!(stdout.contains("ρ = "), "{stdout}");
+    assert!(stdout.contains("run the test suite (1)"), "{stdout}");
+    assert!(stdout.contains("unused:"), "{stdout}");
+    assert!(
+        stdout.contains("denied:  git_push origin main (1)"),
+        "{stdout}"
+    );
+    assert!(stderr.contains("installed at"), "{stderr}");
+
+    let installed = home.path().join(".config/nucleus/profiles/ci-tests.yaml");
+    let yaml = fs::read_to_string(&installed).unwrap();
+    assert!(yaml.contains("name: ci-tests"), "{yaml}");
+    assert!(yaml.contains("web_fetch: never"), "{yaml}");
+    assert!(yaml.contains("git_commit: never"), "{yaml}");
+    assert!(!yaml.contains("run_bash: never"), "{yaml}");
+
+    // The installed profile is a profile like any other …
+    let out = nucleus(home.path())
+        .args(["run", "--profile", "ci-tests", "--dry-run", "--local", "-d"])
+        .arg(dir.path())
+        .arg("rerun the tests")
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(String::from_utf8_lossy(&out.stdout).contains("ci-tests"));
+
+    // … and a ceiling: a goal compiled under it cannot exceed what was used.
+    let out = nucleus(home.path())
+        .args([
+            "run",
+            "--goal",
+            "fix the failing CI build",
+            "--ceiling",
+            "ci-tests",
+            "--dry-run",
+            "--local",
+            "-d",
+        ])
+        .arg(dir.path())
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        stdout.contains("outside ceiling ci-tests"),
+        "the unused effects are clipped under the learned ceiling:\n{stdout}"
+    );
+}
+
+#[test]
+fn a_user_profile_cannot_widen_a_canonical_name() {
+    let dir = repo();
+    let home = tempfile::tempdir().unwrap();
+    let profiles = home.path().join(".config/nucleus/profiles");
+    fs::create_dir_all(&profiles).unwrap();
+    // A "read-only" that pushes: wider than the canonical read-only.
+    fs::write(
+        profiles.join("read-only.yaml"),
+        "name: read-only\ncapabilities:\n  git_push: always\n  run_bash: always\n",
+    )
+    .unwrap();
+    let out = nucleus(home.path())
+        .args([
+            "run",
+            "--profile",
+            "read-only",
+            "--dry-run",
+            "--local",
+            "--explain",
+            "technical",
+            "-d",
+        ])
+        .arg(dir.path())
+        .arg("look around")
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(out.status.success(), "{stderr}");
+    assert!(stderr.contains("wider than the canonical"), "{stderr}");
+    assert!(
+        !stdout.contains("git_push: always")
+            && !stdout.to_lowercase().contains("git_push       always"),
+        "the canonical read-only won:\n{stdout}"
+    );
+}

--- a/crates/portcullis/src/grant_usage.rs
+++ b/crates/portcullis/src/grant_usage.rs
@@ -1,0 +1,801 @@
+//! Attribute a run's observations back to the grant that authorised it, and
+//! narrow the grant to what was used (ADR 0004, milestone 3).
+//!
+//! The loop the ADR opens is `goal → effects → minimum authority → execute →
+//! receipts → narrower reusable grant`. This module is the last arrow. Given
+//! a [`TaskGrant`] and the observations a run produced (`--kernel-trace`, the
+//! same JSONL `nucleus observe` reads), [`attribute`] says which granted
+//! effects were exercised and which never were, which operations the lattice
+//! admitted that no granted effect explains, and what was denied; it yields
+//! the two product metrics the ADR names:
+//!
+//! - **authority overhead** ρ = authority granted ÷ authority used, over the
+//!   13 core dimensions ([`UsageReport::authority_overhead`]) and over
+//!   effects ([`UsageReport::effect_overhead`]); ρ → 1 is the goal;
+//! - the count of denials, which is what an escalation proposal would have
+//!   turned into a decision.
+//!
+//! [`narrow`] then produces a [`ProfileSpec`] and a [`TaskGrant`] with every
+//! unused core dimension at `Never` and every unused effect dropped. The
+//! result is `≤` the grant by construction (an operation is either kept at
+//! its granted level or set to `Never`), so learning from a run can only
+//! narrow: the ceiling the person approved is never exceeded, and the
+//! threshold problem observed-usage tools have (encode noise as permission,
+//! or refuse the next legitimate run) is bounded on both sides by the grant
+//! itself.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt::Write as _;
+
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::effect_catalog::{command_matches, host_matches, EffectCatalog, EffectId, EffectSpec};
+use crate::observe::Observation;
+use crate::profile::{
+    BudgetSpec, CapabilitiesSpec, ObligationSpec, PathsSpec, ProfileSpec, TimeSpec,
+};
+use crate::task_grant::{summarise_risk, ClippedEffect, TaskGrant};
+use crate::{
+    CapabilityLattice, CapabilityLevel, Operation, PermissionLattice, WeakeningCostConfig,
+};
+
+/// The 13 core dimensions, in the order the grid renders them.
+pub const ALL_OPERATIONS: [Operation; 13] = [
+    Operation::ReadFiles,
+    Operation::GlobSearch,
+    Operation::GrepSearch,
+    Operation::WriteFiles,
+    Operation::EditFiles,
+    Operation::RunBash,
+    Operation::WebSearch,
+    Operation::WebFetch,
+    Operation::GitCommit,
+    Operation::GitPush,
+    Operation::CreatePr,
+    Operation::ManagePods,
+    Operation::SpawnAgent,
+];
+
+/// Snake-case name of a core operation (the trace vocabulary).
+#[must_use]
+pub fn operation_name(op: Operation) -> &'static str {
+    match op {
+        Operation::ReadFiles => "read_files",
+        Operation::WriteFiles => "write_files",
+        Operation::EditFiles => "edit_files",
+        Operation::RunBash => "run_bash",
+        Operation::GlobSearch => "glob_search",
+        Operation::GrepSearch => "grep_search",
+        Operation::WebSearch => "web_search",
+        Operation::WebFetch => "web_fetch",
+        Operation::GitCommit => "git_commit",
+        Operation::GitPush => "git_push",
+        Operation::CreatePr => "create_pr",
+        Operation::ManagePods => "manage_pods",
+        Operation::SpawnAgent => "spawn_agent",
+    }
+}
+
+fn level_of(caps: &CapabilityLattice, op: Operation) -> CapabilityLevel {
+    caps.level_for(op)
+}
+
+fn set_level(caps: &mut CapabilityLattice, op: Operation, level: CapabilityLevel) {
+    let slot = match op {
+        Operation::ReadFiles => &mut caps.read_files,
+        Operation::WriteFiles => &mut caps.write_files,
+        Operation::EditFiles => &mut caps.edit_files,
+        Operation::RunBash => &mut caps.run_bash,
+        Operation::GlobSearch => &mut caps.glob_search,
+        Operation::GrepSearch => &mut caps.grep_search,
+        Operation::WebSearch => &mut caps.web_search,
+        Operation::WebFetch => &mut caps.web_fetch,
+        Operation::GitCommit => &mut caps.git_commit,
+        Operation::GitPush => &mut caps.git_push,
+        Operation::CreatePr => &mut caps.create_pr,
+        Operation::ManagePods => &mut caps.manage_pods,
+        Operation::SpawnAgent => &mut caps.spawn_agent,
+    };
+    *slot = level;
+}
+
+/// An operation seen in the trace, with how often and one example subject.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OperationCount {
+    /// The operation.
+    pub operation: Operation,
+    /// How many observations.
+    pub count: usize,
+    /// One subject, for the report.
+    pub example: String,
+}
+
+/// What a run exercised of the grant that authorised it.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UsageReport {
+    /// The grant the observations were attributed to.
+    pub grant_id: Uuid,
+    /// Observations read.
+    pub observations: usize,
+    /// Observations the policy allowed.
+    pub allowed: usize,
+    /// Observations the policy denied.
+    pub denied: usize,
+    /// Granted effects that were exercised, with how many observations each
+    /// explains (an observation several effects explain counts for each).
+    pub used: BTreeMap<EffectId, usize>,
+    /// Granted effects no observation exercised.
+    pub unused: BTreeSet<EffectId>,
+    /// Allowed operations no granted effect explains: admitted by the
+    /// lattice (a ceiling profile is wider than its effects), not by a
+    /// stated effect. They are kept by [`narrow`], since the run needed them.
+    pub unattributed: Vec<OperationCount>,
+    /// Core dimensions the grant holds above `Never`.
+    pub operations_granted: BTreeSet<Operation>,
+    /// Core dimensions at least one allowed observation used.
+    pub operations_used: BTreeSet<Operation>,
+    /// What was denied (at most [`MAX_DENIALS`] kept).
+    pub denials: Vec<OperationCount>,
+}
+
+/// How many denial rows a report keeps.
+pub const MAX_DENIALS: usize = 20;
+
+impl UsageReport {
+    /// ρ over the 13 core dimensions: granted ÷ used. `None` when nothing
+    /// was used (the ratio is undefined, not infinite).
+    #[must_use]
+    pub fn authority_overhead(&self) -> Option<f64> {
+        let used = self
+            .operations_used
+            .iter()
+            .filter(|op| self.operations_granted.contains(op))
+            .count();
+        (used > 0).then(|| ratio(self.operations_granted.len(), used))
+    }
+
+    /// ρ over effects: granted ÷ exercised. `None` when none was exercised.
+    #[must_use]
+    pub fn effect_overhead(&self) -> Option<f64> {
+        let used = self.used.len();
+        (used > 0).then(|| ratio(self.used.len() + self.unused.len(), used))
+    }
+
+    /// Nothing in the trace could be attributed at all.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.observations == 0
+    }
+}
+
+fn ratio(num: usize, den: usize) -> f64 {
+    // Counts of at most 13 dimensions or a few dozen effects: exact in f64.
+    let num = u32::try_from(num).unwrap_or(u32::MAX);
+    let den = u32::try_from(den).unwrap_or(u32::MAX);
+    f64::from(num) / f64::from(den)
+}
+
+/// The host of a URL-ish subject (`https://api.github.com/repos/x` →
+/// `api.github.com`), or the subject itself when it has no scheme.
+fn host_of(subject: &str) -> Option<String> {
+    let s = subject.trim();
+    if s.is_empty() {
+        return None;
+    }
+    let rest = s.split_once("://").map_or(s, |(_, r)| r);
+    let authority = rest.split(['/', '?', '#']).next()?;
+    let authority = authority.rsplit('@').next()?;
+    let host = authority.split(':').next()?.trim().to_ascii_lowercase();
+    (!host.is_empty()).then_some(host)
+}
+
+/// Does the effect's recognition vocabulary match this observation's
+/// subject? Only meaningful for operations that carry one (hosts for the
+/// web, command prefixes for the shell).
+fn subject_matches(effect: &EffectSpec, obs: &Observation) -> bool {
+    match obs.operation {
+        Operation::WebFetch | Operation::WebSearch => host_of(&obs.subject)
+            .map(|h| effect.hosts.iter().any(|p| host_matches(p, &h)))
+            .unwrap_or(false),
+        Operation::RunBash => effect
+            .commands
+            .iter()
+            .any(|p| command_matches(p, &obs.subject)),
+        _ => false,
+    }
+}
+
+/// Attribute `observations` to the effects `grant` grants.
+///
+/// An allowed observation is explained by every granted effect whose
+/// lowering includes its operation; when some of those also match the
+/// subject (host or command prefix) only those count, so `cargo test` is
+/// `shell/run-tests` and not also `shell/run-build`. An allowed observation
+/// no granted effect explains is `unattributed`. Denied observations are
+/// listed, not attributed.
+#[must_use]
+pub fn attribute(
+    grant: &TaskGrant,
+    catalog: &EffectCatalog,
+    observations: &[Observation],
+) -> UsageReport {
+    let granted: Vec<&EffectSpec> = grant.can.iter().filter_map(|id| catalog.get(id)).collect();
+
+    let mut used: BTreeMap<EffectId, usize> = BTreeMap::new();
+    let mut unattributed: BTreeMap<Operation, OperationCount> = BTreeMap::new();
+    let mut denials: Vec<OperationCount> = Vec::new();
+    let mut operations_used = BTreeSet::new();
+    let mut allowed = 0usize;
+    let mut denied = 0usize;
+
+    for obs in observations {
+        if !obs.succeeded {
+            denied += 1;
+            if let Some(d) = denials.iter_mut().find(|d| d.operation == obs.operation) {
+                d.count += 1;
+            } else if denials.len() < MAX_DENIALS {
+                denials.push(OperationCount {
+                    operation: obs.operation,
+                    count: 1,
+                    example: obs.subject.clone(),
+                });
+            }
+            continue;
+        }
+        allowed += 1;
+        operations_used.insert(obs.operation);
+
+        let candidates: Vec<&EffectSpec> = granted
+            .iter()
+            .copied()
+            .filter(|e| e.operations.contains(&obs.operation))
+            .collect();
+        let specific: Vec<&EffectSpec> = candidates
+            .iter()
+            .copied()
+            .filter(|e| subject_matches(e, obs))
+            .collect();
+        let explained = if specific.is_empty() {
+            candidates
+        } else {
+            specific
+        };
+        if explained.is_empty() {
+            unattributed
+                .entry(obs.operation)
+                .and_modify(|c| c.count += 1)
+                .or_insert_with(|| OperationCount {
+                    operation: obs.operation,
+                    count: 1,
+                    example: obs.subject.clone(),
+                });
+        } else {
+            for e in explained {
+                *used.entry(e.id.clone()).or_insert(0) += 1;
+            }
+        }
+    }
+
+    let unused: BTreeSet<EffectId> = grant
+        .can
+        .iter()
+        .filter(|id| !used.contains_key(*id))
+        .cloned()
+        .collect();
+    let operations_granted: BTreeSet<Operation> = ALL_OPERATIONS
+        .iter()
+        .copied()
+        .filter(|op| level_of(&grant.lattice.capabilities, *op) != CapabilityLevel::Never)
+        .collect();
+
+    UsageReport {
+        grant_id: grant.id,
+        observations: observations.len(),
+        allowed,
+        denied,
+        used,
+        unused,
+        unattributed: unattributed.into_values().collect(),
+        operations_granted,
+        operations_used,
+        denials,
+    }
+}
+
+/// A grant narrowed to what a run used.
+#[derive(Debug, Clone)]
+pub struct Narrowed {
+    /// A reusable profile with every unused dimension at `Never`.
+    pub profile: ProfileSpec,
+    /// The same authority as a grant: the used effects, the narrowed
+    /// lattice, a fresh id, provenance naming the grant it came from.
+    pub grant: TaskGrant,
+    /// Effects the original granted that the run never exercised.
+    pub dropped_effects: BTreeSet<EffectId>,
+    /// Core dimensions set to `Never` because nothing used them.
+    pub dropped_operations: BTreeSet<Operation>,
+}
+
+/// Narrow `grant` to what `usage` says was used. The result is `≤ grant`:
+/// every core dimension is either kept at its granted level (it was used,
+/// whether or not an effect explains it) or set to `Never`; paths, commands,
+/// budget and time are unchanged; effects nothing exercised are dropped.
+///
+/// `name` names the profile (`[a-z0-9-]+`).
+#[must_use]
+pub fn narrow(grant: &TaskGrant, usage: &UsageReport, name: &str) -> Narrowed {
+    let mut lattice = grant.lattice.clone();
+    let mut dropped_operations = BTreeSet::new();
+    for op in ALL_OPERATIONS {
+        if !usage.operations_used.contains(&op)
+            && level_of(&lattice.capabilities, op) != CapabilityLevel::Never
+        {
+            set_level(&mut lattice.capabilities, op, CapabilityLevel::Never);
+            dropped_operations.insert(op);
+        }
+    }
+    lattice.id = Uuid::new_v4();
+    lattice.description = format!("narrowed from grant {} by observed usage", grant.id);
+    lattice.derived_from = Some(grant.lattice.id);
+    let lattice = lattice.normalize();
+    debug_assert!(lattice.leq(&grant.lattice), "narrowing never widens");
+
+    let kept: BTreeSet<EffectId> = usage.used.keys().cloned().collect();
+    let dropped_effects: BTreeSet<EffectId> = grant
+        .can
+        .iter()
+        .filter(|id| !kept.contains(*id))
+        .cloned()
+        .collect();
+
+    let mut cannot = grant.cannot.clone();
+    for id in &dropped_effects {
+        cannot.push(ClippedEffect {
+            id: id.clone(),
+            reason: format!("unused in the observed run of grant {}", grant.id),
+        });
+    }
+
+    let restrictive = PermissionLattice::restrictive();
+    let gap = WeakeningCostConfig::default().compute_gap(&restrictive, &lattice);
+    let risk = summarise_risk(&lattice, gap);
+
+    let mut provenance = grant.provenance.clone();
+    provenance
+        .rules_fired
+        .push(format!("narrowed-from:{}", grant.id));
+
+    let narrowed_grant = TaskGrant {
+        version: TaskGrant::VERSION,
+        id: Uuid::new_v4(),
+        goal: grant.goal.clone(),
+        goal_digest: grant.goal_digest.clone(),
+        ceiling_profile: grant.ceiling_profile.clone(),
+        can: kept,
+        cannot,
+        limits: grant.limits.clone(),
+        lattice: lattice.clone(),
+        risk,
+        provenance,
+        created_at: Utc::now(),
+        not_after: grant.not_after,
+    };
+
+    let profile = profile_from_lattice(
+        name,
+        format!(
+            "Narrowed from goal \"{}\" (grant {}) by observed usage: {} of {} effects used",
+            grant.goal,
+            grant.id,
+            narrowed_grant.can.len(),
+            grant.can.len()
+        ),
+        &lattice,
+        grant.limits.duration_secs,
+    );
+
+    Narrowed {
+        profile,
+        grant: narrowed_grant,
+        dropped_effects,
+        dropped_operations,
+    }
+}
+
+fn obligation_for(op: Operation) -> ObligationSpec {
+    match op {
+        Operation::ReadFiles => ObligationSpec::ReadFiles,
+        Operation::WriteFiles => ObligationSpec::WriteFiles,
+        Operation::EditFiles => ObligationSpec::EditFiles,
+        Operation::RunBash => ObligationSpec::RunBash,
+        Operation::GlobSearch => ObligationSpec::GlobSearch,
+        Operation::GrepSearch => ObligationSpec::GrepSearch,
+        Operation::WebSearch => ObligationSpec::WebSearch,
+        Operation::WebFetch => ObligationSpec::WebFetch,
+        Operation::GitCommit => ObligationSpec::GitCommit,
+        Operation::GitPush => ObligationSpec::GitPush,
+        Operation::CreatePr => ObligationSpec::CreatePr,
+        Operation::ManagePods => ObligationSpec::ManagePods,
+        Operation::SpawnAgent => ObligationSpec::SpawnAgent,
+    }
+}
+
+/// A [`ProfileSpec`] that builds back to `lattice` (capabilities,
+/// obligations, paths, budget) with `duration_secs` as its time bound.
+#[must_use]
+pub fn profile_from_lattice(
+    name: &str,
+    description: String,
+    lattice: &PermissionLattice,
+    duration_secs: u64,
+) -> ProfileSpec {
+    let c = &lattice.capabilities;
+    let mut blocked: Vec<String> = lattice.paths.blocked.iter().cloned().collect();
+    blocked.sort();
+    let mut allowed: Vec<String> = lattice.paths.allowed.iter().cloned().collect();
+    allowed.sort();
+    ProfileSpec {
+        name: name.to_string(),
+        description: Some(description),
+        capabilities: CapabilitiesSpec {
+            read_files: c.read_files,
+            write_files: c.write_files,
+            edit_files: c.edit_files,
+            run_bash: c.run_bash,
+            glob_search: c.glob_search,
+            grep_search: c.grep_search,
+            web_search: c.web_search,
+            web_fetch: c.web_fetch,
+            git_commit: c.git_commit,
+            git_push: c.git_push,
+            create_pr: c.create_pr,
+            manage_pods: c.manage_pods,
+            spawn_agent: c.spawn_agent,
+        },
+        obligations: lattice
+            .obligations
+            .approvals
+            .iter()
+            .map(|op| obligation_for(*op))
+            .collect(),
+        paths: Some(PathsSpec { allowed, blocked }),
+        budget: Some(BudgetSpec {
+            max_cost_usd: lattice.budget.max_cost_usd.to_string(),
+            max_input_tokens: lattice.budget.max_input_tokens,
+            max_output_tokens: lattice.budget.max_output_tokens,
+        }),
+        time: Some(TimeSpec {
+            duration_hours: None,
+            duration_minutes: Some((duration_secs / 60).max(1)),
+        }),
+    }
+}
+
+fn title(catalog: &EffectCatalog, id: &EffectId) -> String {
+    catalog
+        .get(id)
+        .map(|e| {
+            let t = &e.title;
+            let mut chars = t.chars();
+            match chars.next() {
+                Some(f) if !t.starts_with("CI") && !t.starts_with("GitHub") => {
+                    f.to_lowercase().collect::<String>() + chars.as_str()
+                }
+                _ => t.clone(),
+            }
+        })
+        .unwrap_or_else(|| id.to_string())
+}
+
+/// The lines printed after a run.
+#[must_use]
+pub fn render_usage(report: &UsageReport, catalog: &EffectCatalog) -> String {
+    let mut out = String::new();
+    let total = report.used.len() + report.unused.len();
+    let _ = write!(
+        out,
+        "authority: used {} of {} effects",
+        report.used.len(),
+        total
+    );
+    match report.authority_overhead() {
+        Some(rho) => {
+            let _ = write!(
+                out,
+                " · ρ = {rho:.2} ({} of {} granted dimensions used)",
+                report
+                    .operations_used
+                    .iter()
+                    .filter(|op| report.operations_granted.contains(op))
+                    .count(),
+                report.operations_granted.len()
+            );
+        }
+        None => {
+            let _ = write!(out, " · nothing used");
+        }
+    }
+    let _ = writeln!(
+        out,
+        " · {} allowed · {} denied",
+        report.allowed, report.denied
+    );
+
+    if !report.used.is_empty() {
+        let items: Vec<String> = report
+            .used
+            .iter()
+            .map(|(id, n)| format!("{} ({n})", title(catalog, id)))
+            .collect();
+        let _ = writeln!(out, "  used:    {}", items.join(" · "));
+    }
+    if !report.unused.is_empty() {
+        let items: Vec<String> = report.unused.iter().map(|id| title(catalog, id)).collect();
+        let _ = writeln!(out, "  unused:  {}", items.join(" · "));
+    }
+    if !report.unattributed.is_empty() {
+        let items: Vec<String> = report
+            .unattributed
+            .iter()
+            .map(|c| {
+                format!(
+                    "{} ({}, e.g. {})",
+                    operation_name(c.operation),
+                    c.count,
+                    c.example
+                )
+            })
+            .collect();
+        let _ = writeln!(out, "  no effect explains: {}", items.join(" · "));
+    }
+    if !report.denials.is_empty() {
+        let items: Vec<String> = report
+            .denials
+            .iter()
+            .map(|c| {
+                format!(
+                    "{} {} ({})",
+                    operation_name(c.operation),
+                    c.example,
+                    c.count
+                )
+            })
+            .collect();
+        let _ = writeln!(out, "  denied:  {}", items.join(" · "));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::effect_catalog::EffectCatalog;
+    use crate::task_grant::{CompilerProvenance, GrantLimits, RiskSummary};
+    use crate::StateRisk;
+    use chrono::Duration;
+
+    fn catalog() -> EffectCatalog {
+        EffectCatalog::builtin().unwrap()
+    }
+
+    fn id(s: &str) -> EffectId {
+        s.parse().unwrap()
+    }
+
+    /// A grant of fs/read-workspace + shell/run-tests + shell/run-build +
+    /// github/read-ci-logs + git/commit, lowered through the real catalog.
+    fn grant(catalog: &EffectCatalog) -> TaskGrant {
+        let can: BTreeSet<EffectId> = [
+            "fs/read-workspace",
+            "shell/run-tests",
+            "shell/run-build",
+            "github/read-ci-logs",
+            "git/commit",
+        ]
+        .iter()
+        .map(|s| id(s))
+        .collect();
+        let lowered = catalog.lower(&can).unwrap();
+        let now = Utc::now();
+        let not_after = now + Duration::hours(2);
+        let mut lattice = PermissionLattice::restrictive();
+        lattice.capabilities = lowered.capabilities;
+        lattice.time.valid_until = not_after;
+        let gap =
+            WeakeningCostConfig::default().compute_gap(&PermissionLattice::restrictive(), &lattice);
+        TaskGrant {
+            version: TaskGrant::VERSION,
+            id: Uuid::new_v4(),
+            goal: "fix the failing CI build".into(),
+            goal_digest: TaskGrant::digest_goal("fix the failing CI build"),
+            ceiling_profile: "codegen".into(),
+            can,
+            cannot: Vec::new(),
+            limits: GrantLimits {
+                max_cost_usd: rust_decimal::Decimal::new(500, 2),
+                duration_secs: 7200,
+                hosts: lowered.hosts.into_iter().collect(),
+                blocked_paths: Vec::new(),
+                commands: Vec::new(),
+            },
+            lattice,
+            risk: RiskSummary {
+                before: StateRisk::Safe,
+                after: StateRisk::Safe,
+                exposure_legs: Vec::new(),
+                approval_gated: Vec::new(),
+                gap,
+            },
+            provenance: CompilerProvenance {
+                compiler: "test/0".into(),
+                proposers: vec![],
+                rules_fired: vec![],
+                repo_context_digest: "d".into(),
+            },
+            created_at: now,
+            not_after,
+        }
+    }
+
+    fn obs(op: Operation, subject: &str) -> Observation {
+        Observation::new(op, subject)
+    }
+
+    #[test]
+    fn observations_are_attributed_by_operation_then_subject() {
+        let catalog = catalog();
+        let g = grant(&catalog);
+        let trace = [
+            obs(Operation::ReadFiles, "src/main.rs"),
+            obs(Operation::ReadFiles, "Cargo.toml"),
+            obs(Operation::RunBash, "cargo test --workspace"),
+            obs(
+                Operation::WebFetch,
+                "https://api.github.com/repos/o/r/actions/runs",
+            ),
+            Observation::failed(Operation::GitPush, "origin main"),
+        ];
+        let r = attribute(&g, &catalog, &trace);
+        assert_eq!(r.observations, 5);
+        assert_eq!(r.allowed, 4);
+        assert_eq!(r.denied, 1);
+        assert_eq!(r.used[&id("fs/read-workspace")], 2);
+        assert_eq!(
+            r.used[&id("shell/run-tests")],
+            1,
+            "the command prefix picks run-tests over run-build"
+        );
+        assert!(!r.used.contains_key(&id("shell/run-build")));
+        assert_eq!(r.used[&id("github/read-ci-logs")], 1);
+        assert!(r.unused.contains(&id("git/commit")));
+        assert!(r.unused.contains(&id("shell/run-build")));
+        assert!(r.unattributed.is_empty());
+        assert_eq!(r.denials.len(), 1);
+        assert_eq!(r.denials[0].operation, Operation::GitPush);
+        // Granted: read, glob, grep, run_bash, web_fetch, git_commit = 6; used: read, run_bash, web_fetch = 3.
+        assert_eq!(r.operations_granted.len(), 6, "{:?}", r.operations_granted);
+        assert_eq!(r.operations_used.len(), 3);
+        assert!((r.authority_overhead().unwrap() - 2.0).abs() < 1e-9);
+        assert!((r.effect_overhead().unwrap() - 5.0 / 3.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn an_operation_the_lattice_admits_but_no_effect_explains_is_reported() {
+        let catalog = catalog();
+        let mut g = grant(&catalog);
+        // Widen the lattice by hand (as a ceiling profile would): git_push
+        // admitted, no effect vouches for it.
+        g.lattice.capabilities.git_push = CapabilityLevel::LowRisk;
+        let trace = [obs(Operation::GitPush, "origin feature")];
+        let r = attribute(&g, &catalog, &trace);
+        assert_eq!(r.unattributed.len(), 1);
+        assert_eq!(r.unattributed[0].operation, Operation::GitPush);
+        assert!(r.used.is_empty());
+        // Narrowing keeps what the run needed, even unexplained.
+        let n = narrow(&g, &r, "pusher");
+        assert_eq!(
+            n.grant.lattice.capabilities.git_push,
+            CapabilityLevel::LowRisk
+        );
+    }
+
+    #[test]
+    fn nothing_used_has_no_overhead_ratio() {
+        let catalog = catalog();
+        let g = grant(&catalog);
+        let r = attribute(&g, &catalog, &[]);
+        assert!(r.is_empty());
+        assert_eq!(r.authority_overhead(), None);
+        assert_eq!(r.effect_overhead(), None);
+        assert_eq!(r.unused.len(), 5);
+    }
+
+    #[test]
+    fn narrowing_never_widens_and_drops_what_was_unused() {
+        let catalog = catalog();
+        let g = grant(&catalog);
+        let trace = [
+            obs(Operation::ReadFiles, "src/lib.rs"),
+            obs(Operation::RunBash, "cargo test"),
+        ];
+        let r = attribute(&g, &catalog, &trace);
+        let n = narrow(&g, &r, "ci-tests");
+
+        assert!(n.grant.lattice.leq(&g.lattice));
+        assert_eq!(n.grant.can.len(), 2);
+        assert!(n.grant.can.contains(&id("shell/run-tests")));
+        assert_eq!(n.dropped_effects.len(), 3);
+        assert!(n.dropped_operations.contains(&Operation::WebFetch));
+        assert!(n.dropped_operations.contains(&Operation::GitCommit));
+        assert_eq!(
+            n.grant.lattice.capabilities.web_fetch,
+            CapabilityLevel::Never
+        );
+        assert_eq!(
+            n.grant.lattice.capabilities.git_commit,
+            CapabilityLevel::Never
+        );
+        assert_eq!(
+            n.grant.lattice.capabilities.read_files, g.lattice.capabilities.read_files,
+            "a used dimension keeps its granted level"
+        );
+        assert_eq!(
+            n.grant.cannot.len(),
+            3,
+            "dropped effects are listed with a reason"
+        );
+        assert_ne!(n.grant.id, g.id);
+        assert_eq!(n.grant.goal_digest, g.goal_digest);
+
+        // The profile builds back to the narrowed lattice.
+        let built = n.profile.build().unwrap();
+        assert!(built.capabilities.leq(&g.lattice.capabilities));
+        assert_eq!(built.capabilities.web_fetch, CapabilityLevel::Never);
+        assert_eq!(
+            built.capabilities.run_bash,
+            n.grant.lattice.capabilities.run_bash
+        );
+        assert_eq!(n.profile.name, "ci-tests");
+        let yaml = n.profile.to_yaml().unwrap();
+        assert!(yaml.contains("name: ci-tests"));
+    }
+
+    #[test]
+    fn the_usage_lines_read_as_a_person_expects() {
+        let catalog = catalog();
+        let g = grant(&catalog);
+        let trace = [
+            obs(Operation::ReadFiles, "src/lib.rs"),
+            Observation::failed(Operation::GitPush, "origin main"),
+        ];
+        let r = attribute(&g, &catalog, &trace);
+        let text = render_usage(&r, &catalog);
+        assert!(text.starts_with("authority: used 1 of 5 effects"), "{text}");
+        assert!(text.contains("ρ = 6.00"), "{text}");
+        assert!(
+            text.contains("used:    read and search workspace files (1)"),
+            "{text}"
+        );
+        assert!(text.contains("unused:  "), "{text}");
+        assert!(text.contains("denied:  git_push origin main (1)"), "{text}");
+    }
+
+    #[test]
+    fn hosts_are_read_from_url_subjects() {
+        assert_eq!(
+            host_of("https://API.github.com/x").as_deref(),
+            Some("api.github.com")
+        );
+        assert_eq!(
+            host_of("api.github.com:443/x").as_deref(),
+            Some("api.github.com")
+        );
+        assert_eq!(
+            host_of("http://u:p@h.example/").as_deref(),
+            Some("h.example")
+        );
+        assert_eq!(host_of(""), None);
+    }
+}

--- a/crates/portcullis/src/lib.rs
+++ b/crates/portcullis/src/lib.rs
@@ -154,6 +154,12 @@ pub mod galois;
 /// (hard gate / soft gate / none), for EU AI Act Article 12 decision records.
 pub mod gate_class;
 pub mod graded;
+/// Attribute a run's observations to the grant's effects, compute the
+/// authority overhead ρ, and narrow the grant to what was used.
+///
+/// Requires the `spec` feature.
+#[cfg(all(feature = "spec", not(kani)))]
+pub mod grant_usage;
 pub mod guard;
 pub mod heyting;
 /// Verified hook adapter — pure decision pipeline for agent tool-call hooks.
@@ -264,6 +270,11 @@ pub use galois::{
     TrustDomainBridge,
 };
 pub use graded::{Graded, GradedPermissionCheck, GradedPipeline, RiskCost, RiskGrade};
+#[cfg(all(feature = "spec", not(kani)))]
+pub use grant_usage::{
+    attribute as attribute_usage, narrow as narrow_grant, profile_from_lattice, render_usage,
+    Narrowed, OperationCount, UsageReport, ALL_OPERATIONS,
+};
 #[allow(deprecated)]
 pub use guard::{
     operation_exposure, CheckProof, CompositeGuard, ExecuteError, ExposureLabel, ExposureSet,

--- a/docs/adr/0004-delegation-compiler.md
+++ b/docs/adr/0004-delegation-compiler.md
@@ -106,7 +106,7 @@ with two invariants DX work may not violate:
 |---|---|---|
 | 1 | Effect catalog, `TaskGrant` + renderer, `nucleus-task-compiler`, `nucleus run --goal` preview and single confirmation, offline gate | #2675 |
 | 2 | `effect/` certificate keys (`effect_surface`), `SealedTaskGrant` (grant + signed certificate, binding keys), `nucleus run --save-grant` / `--grant`, `nucleus grant seal|show` (C(T)=0) | this PR |
-| 3 | Receipt → effect attribution, ρ, post-run "save narrower profile", `~/.nucleus/profiles` | |
+| 3 | Trace → effect attribution (`grant_usage`), ρ over dimensions and effects, post-run usage lines and "save a narrower profile", `nucleus observe --grant --narrow --save`, user profiles in `~/.config/nucleus/profiles` (never wider than a canonical name) | this PR |
 | 4 | Structured `EscalationProposal` on every denial, carried to MCP / tool-proxy / hook / SDK, `nucleus grant --scope action\|run\|always` | |
 | 5 | ρ and C(T) in `ExitReport` and the run summary | |
 | 6 | Per-effect enforcement at the credential boundary (method+path) | |

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -412,6 +412,44 @@ milestone (the lattice, the host list and the command prefixes); attributing
 receipts to effects and enforcing per effect at the credential boundary are the
 milestones after this one.
 
+### Learning from a run: the grant is the ceiling, the trace is the proposal
+
+Every `--goal` and `--grant` run leaves a kernel trace
+(`~/.config/nucleus/traces/<grant id>.jsonl` unless `--kernel-trace` names one)
+and ends with what the run actually used of what it was granted:
+
+```
+authority: used 3 of 7 effects · ρ = 2.00 (3 of 6 granted dimensions used) · 41 allowed · 1 denied
+  used:    read and search workspace files (12) · run the test suite (2) · read CI logs and workflow runs (1)
+  unused:  edit workspace files · commit changes locally · build the project · read git history and status
+  denied:  git_push origin main (1)
+
+Save a profile with the unused authority removed? name (empty to skip): ci-tests
+profile 'ci-tests' installed at ~/.config/nucleus/profiles/ci-tests.yaml (4 effects and 3 dimensions removed)
+```
+
+ρ is the **authority overhead**, granted ÷ used, over the 13 core dimensions;
+ρ → 1 is the goal, and it is the number a plugin's effect vocabulary is judged
+by. The same report without a terminal, or after the fact:
+
+```
+nucleus observe --grant ci.grant --input trace.jsonl            # the report
+nucleus observe --grant ci.grant --input trace.jsonl --narrow ci-tests --save
+```
+
+Narrowing is bounded on both sides by the grant: an unused dimension goes to
+`never`, a used one keeps the level the grant gave it (even when no effect
+explains it, since the run needed it), and paths, commands, budget and time are
+untouched. The result is `≤` the grant by construction, so the threshold problem
+of observed-usage tools (encode noise as permission, or refuse the next
+legitimate run) cannot widen anything: at worst the next run is denied
+something and says so.
+
+Profiles in `~/.config/nucleus/profiles/*.yaml` resolve like canonical ones,
+for `--profile` and for `--ceiling`. A user profile may carry a canonical name
+only if it is not wider than the canonical one; a wider shadow is ignored with a
+warning, so a file on disk cannot quietly change what `--ceiling codegen` means.
+
 ## Semantic effects
 
 An effect is the unit of authority a person reads. Each lowers to core dimensions,


### PR DESCRIPTION
## What this is

Milestone 3 of ADR 0004, stacked on #2676 (milestone 2), which is stacked on #2675. The base retargets down the stack as each merges; the diff here is milestone 3 alone.

This closes the loop the ADR opens: `goal → effects → minimum authority → execute → receipts → narrower reusable grant`. A run ends by saying what it used of what it was granted, and offers to keep only that. Nothing in this step can widen; the grant a person approved is the ceiling of what it learns.

```
authority: used 3 of 7 effects · ρ = 2.00 (3 of 6 granted dimensions used) · 41 allowed · 1 denied
  used:    read and search workspace files (12) · run the test suite (2) · read CI logs and workflow runs (1)
  unused:  edit workspace files · commit changes locally · build the project · read git history and status
  denied:  git_push origin main (1)

Save a profile with the unused authority removed? name (empty to skip): ci-tests
profile 'ci-tests' installed at ~/.config/nucleus/profiles/ci-tests.yaml (4 effects and 3 dimensions removed)
```

## Pieces

- **`portcullis::grant_usage`**: `attribute(grant, catalog, observations)` explains every allowed observation by the granted effects whose lowering includes its operation, refined by subject (host for the web, command prefix for the shell), so `cargo test` is `shell/run-tests` and not also `shell/run-build`. Operations the lattice admitted that no effect explains are reported separately. ρ, the **authority overhead**, is granted ÷ used over the 13 core dimensions and over effects; it is undefined rather than infinite when nothing was used. `narrow(grant, usage, name)` sets every unused dimension to `Never`, keeps a used one at its granted level (even when unexplained, since the run needed it), leaves paths, commands, budget and time alone, and drops unused effects into `cannot` with the reason. The result is `≤ grant` by construction. `render_usage` produces the lines above.
- **CLI**: every `--goal` and `--grant` run leaves a kernel trace (`~/.config/nucleus/traces/<grant id>.jsonl` unless `--kernel-trace` names one) and ends with the usage lines; at a terminal it offers to install the narrowed profile, otherwise it prints the `nucleus observe` command that does the same. `nucleus observe --grant FILE [--narrow NAME [--save]]` is the non-interactive form.
- **User profiles** in `~/.config/nucleus/profiles/*.yaml` resolve for `--profile` and `--ceiling` and are listed by `nucleus profiles`. A user profile may carry a canonical name only if it is not wider than the canonical one; a wider shadow is ignored with a warning, so a file on disk cannot change what `--ceiling codegen` means. A broken profile directory is reported and treated as empty, never failing an unrelated run.

## Invariants kept

- Learning only narrows. The narrowed lattice is `leq` the grant's; the narrowed profile builds back to exactly that lattice; a learned profile used as a ceiling clips the same goal's unused effects (end-to-end test).
- The threshold problem of observed-usage tools is bounded on both sides by the grant: at worst the next run is denied something and says so.
- No new `cfg(kani)` site (inventory stays at 72), no new dependencies, vendor-neutral.

## Validation

- `cargo test -p portcullis --all-features --lib -- grant_usage` (6 new), CLI `grant_learning` (2 new end-to-end), `grant_reuse` (5), `goal_dry_run` (4), profile resolution unit tests (8): all pass
- `cargo clippy --all-features --all-targets -- -D warnings` on portcullis, nucleus-task-compiler, nucleus-cli: clean; zero cast-ratchet sites in the new code
- `cargo fmt --all --check`, `scripts/check-kani-divergence.sh`, `scripts/check-line-ratchet.sh --strict`, `ci/no-vendor-strings.sh`, `cargo metadata --no-deps` with empty stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QqBdBgCoVTtbe7gLNQh532

---
_Generated by [Claude Code](https://claude.ai/code/session_01QqBdBgCoVTtbe7gLNQh532)_