### PR TITLE
dx(delegation): ρ and C(T) in the exit report, the session summary, and the run's last line (milestone 5)

### DIFF
--- a/crates/nucleus-cli/src/goal.rs
+++ b/crates/nucleus-cli/src/goal.rs
@@ -130,9 +130,11 @@ pub async fn execute(args: RunArgs, global_config_path: &str) -> Result<()> {
     }
 
     let mut args = args;
+    args.task_grant_id = Some(grant.id.to_string());
     let trace = default_trace(&mut args, grant.id)?;
     run_under(&args, global_config_path, &grant.lattice, &work_dir, &goal).await?;
-    learn_from_run(&args, &grant, &catalog, trace.as_deref())
+    // One confirmation: the person decided, at the prompt or with --yes.
+    learn_from_run(&args, &grant, &catalog, trace.as_deref(), 1)
 }
 
 /// Entry point, reached from `run::execute` when `--grant` is set: verify
@@ -168,9 +170,11 @@ pub async fn execute_grant(args: RunArgs, global_config_path: &str) -> Result<()
     let goal = grant.goal.clone();
     let grant = grant.clone();
     let mut args = args;
+    args.task_grant_id = Some(grant.id.to_string());
     let trace = default_trace(&mut args, grant.id)?;
     run_under(&args, global_config_path, &grant.lattice, &work_dir, &goal).await?;
-    learn_from_run(&args, &grant, &catalog, trace.as_deref())
+    // Zero confirmations: the decision was sealed earlier (C(T) = 0).
+    learn_from_run(&args, &grant, &catalog, trace.as_deref(), 0)
 }
 
 /// A goal or grant run always leaves a trace to learn from: unless
@@ -196,6 +200,7 @@ fn learn_from_run(
     grant: &TaskGrant,
     catalog: &EffectCatalog,
     trace: Option<&Path>,
+    confirmations: u64,
 ) -> Result<()> {
     let Some(trace) = trace else {
         return Ok(());
@@ -210,6 +215,16 @@ fn learn_from_run(
     let usage = portcullis::attribute_usage(grant, catalog, &observations);
     println!();
     print!("{}", portcullis::render_usage(&usage, catalog));
+
+    // ρ over dimensions and C(T) (ADR 0004): the same numbers the exit
+    // report and the MCP session summary carry, from the same trace.
+    let decisions = portcullis::decisions_in_trace(&text);
+    if !decisions.is_empty() {
+        let mut summary = portcullis::summarise_authority(&grant.lattice, &decisions);
+        summary.confirmations = confirmations;
+        summary.task_grant_id = Some(grant.id.to_string());
+        println!("  {}", summary.render());
+    }
     println!("  trace:   {}", trace.display());
 
     // Every denial, as a proposal: what would have allowed it, and what it

--- a/crates/nucleus-cli/src/run.rs
+++ b/crates/nucleus-cli/src/run.rs
@@ -181,6 +181,11 @@ pub struct RunArgs {
     #[arg(long = "grant-signer", value_name = "HEX")]
     pub grant_signers: Vec<String>,
 
+    /// The task grant this run executes under (set by --goal / --grant, not a
+    /// flag): carried in the pod spec so the exit report names it.
+    #[arg(skip)]
+    pub task_grant_id: Option<String>,
+
     /// Working directory (default: current directory)
     #[arg(short = 'd', long, default_value = ".")]
     pub dir: String,
@@ -711,7 +716,7 @@ fn build_local_pod_spec(
         })
     };
 
-    Ok(SpecPodSpec::new(PodSpecInner {
+    let mut spec = SpecPodSpec::new(PodSpecInner {
         work_dir: work_dir.to_path_buf(),
         timeout_seconds: args.timeout,
         policy: PolicySpec::Inline {
@@ -728,7 +733,9 @@ fn build_local_pod_spec(
         cgroup: None,
         audit_sink: None,
         credentials,
-    }))
+    });
+    spec.metadata.task_grant_id = args.task_grant_id.clone();
+    Ok(spec)
 }
 
 async fn run_enforced(
@@ -822,7 +829,7 @@ fn build_pod_spec(
     kernel_path: &str,
     rootfs_path: &str,
 ) -> Result<SpecPodSpec> {
-    Ok(SpecPodSpec::new(PodSpecInner {
+    let mut spec = SpecPodSpec::new(PodSpecInner {
         work_dir: work_dir.to_path_buf(),
         timeout_seconds: args.timeout,
         policy: PolicySpec::Inline {
@@ -848,7 +855,9 @@ fn build_pod_spec(
         cgroup: None,
         audit_sink: None,
         credentials: None,
-    }))
+    });
+    spec.metadata.task_grant_id = args.task_grant_id.clone();
+    Ok(spec)
 }
 
 fn write_pod_spec(spec_path: &Path, spec: &SpecPodSpec) -> Result<()> {

--- a/crates/nucleus-mcp/src/main.rs
+++ b/crates/nucleus-mcp/src/main.rs
@@ -656,6 +656,9 @@ impl TraceWriter {
     /// Write a summary line and flush on session end.
     fn finish(&self, kernel: &Kernel) {
         if let Some(ref f) = self.file {
+            // ρ and the decision counts (ADR 0004): what this session was
+            // granted against what it used, from the same trace.
+            let authority = portcullis::summarise_authority(kernel.effective(), kernel.trace());
             let summary = json!({
                 "type": "session_summary",
                 "session_id": kernel.session_id().to_string(),
@@ -663,6 +666,7 @@ impl TraceWriter {
                 "consumed_usd": kernel.consumed_usd().to_string(),
                 "remaining_usd": kernel.remaining_usd().to_string(),
                 "initial_hash": kernel.initial_hash(),
+                "authority": authority,
             });
             if let Ok(line) = serde_json::to_string(&summary) {
                 let mut writer = f.borrow_mut();
@@ -2132,6 +2136,11 @@ mod tests {
         assert_eq!(summary["type"], "session_summary");
         assert_eq!(summary["decisions"], 1);
         assert_eq!(summary["consumed_usd"], "0.05");
+        // ρ and the decision counts ride in the same line (ADR 0004).
+        assert_eq!(summary["authority"]["allowed"], 1);
+        assert_eq!(summary["authority"]["denied"], 0);
+        assert_eq!(summary["authority"]["used_dimensions"][0], "read_files");
+        assert!(summary["authority"]["overhead"].as_f64().unwrap() >= 1.0);
     }
 
     #[test]

--- a/crates/nucleus-node/src/trust_gate.rs
+++ b/crates/nucleus-node/src/trust_gate.rs
@@ -1146,6 +1146,7 @@ mod tests {
             art12_chain_head: "head".to_string(),
             art12_records: 5,
             art12_dropped: 0,
+            authority: None,
         }
     }
 

--- a/crates/nucleus-spec/src/lib.rs
+++ b/crates/nucleus-spec/src/lib.rs
@@ -76,6 +76,10 @@ pub struct Metadata {
     /// Optional labels.
     #[serde(default)]
     pub labels: BTreeMap<String, String>,
+    /// The task grant this pod runs under (ADR 0004), when it runs under one.
+    /// Carried into the exit report's authority summary.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub task_grant_id: Option<String>,
 }
 
 /// Inner spec fields.
@@ -764,6 +768,14 @@ pub struct ExitReport {
     pub art12_records: u64,
     #[serde(default)]
     pub art12_dropped: u64,
+
+    // ── Authority (ADR 0004, written by the tool proxy at shutdown) ──────
+    /// What the session was granted and what it used: the dimensions above
+    /// `Never`, the dimensions decisions exercised, ρ (granted ÷ used),
+    /// allowed / denied / approval-gated decision counts, and the task grant
+    /// it ran under. `None` on a report written before this field existed.
+    #[serde(default)]
+    pub authority: Option<portcullis::AuthoritySummary>,
 }
 
 /// An upstream the workload may call without holding the credential.
@@ -1607,6 +1619,32 @@ spec:
             }
             _ => panic!("expected PermissionDenied"),
         }
+    }
+
+    #[test]
+    fn metadata_task_grant_id_round_trips_and_is_absent_by_default() {
+        let bare = Metadata::default();
+        let yaml = serde_yaml::to_string(&bare).expect("serialize");
+        assert!(!yaml.contains("task_grant_id"), "{yaml}");
+        let with = Metadata {
+            task_grant_id: Some("6f1c0000-0000-0000-0000-000000000001".into()),
+            ..Default::default()
+        };
+        let yaml = serde_yaml::to_string(&with).expect("serialize");
+        let back: Metadata = serde_yaml::from_str(&yaml).expect("parse");
+        assert_eq!(
+            back.task_grant_id.as_deref(),
+            Some("6f1c0000-0000-0000-0000-000000000001")
+        );
+    }
+
+    #[test]
+    fn an_exit_report_without_an_authority_summary_still_parses() {
+        let json = r#"{"workspace_hash":"w","audit_tail_hash":"t","audit_entry_count":0,"timestamp_unix":1}"#;
+        let report: ExitReport = serde_json::from_str(json).expect("older report parses");
+        assert!(report.authority.is_none());
+        let json = serde_json::to_string(&report).unwrap();
+        assert!(json.contains("\"authority\":null"), "{json}");
     }
 
     #[test]

--- a/crates/nucleus-tool-proxy/src/exit_report.rs
+++ b/crates/nucleus-tool-proxy/src/exit_report.rs
@@ -5,10 +5,15 @@
 //! captures the audit chain tail, writing this as the final audit log entry.
 //! The host (nucleus-node) reads this to build an `ExecutionReceipt`.
 
+use nucleus::portcullis::kernel::Kernel;
 use nucleus_spec::{ExitReport, sha256_bytes_hex};
 use portcullis::trace_monitor::TraceMonitor;
 use sha2::{Digest, Sha256};
 use std::path::Path;
+use std::sync::Arc;
+use tracing::{info, warn};
+
+use crate::AuditLog;
 
 /// Compute a deterministic SHA-256 hash of a directory's contents.
 ///
@@ -128,7 +133,27 @@ pub fn build_exit_report(
         art12_chain_head: String::new(),
         art12_records: 0,
         art12_dropped: 0,
+        // Populated by `apply_authority` from the kernel at shutdown.
+        authority: None,
     }
+}
+
+/// Fold what the kernel granted and what the session used into the report:
+/// ρ and the decision counts (ADR 0004). `task_grant_id` is the grant the
+/// pod's spec named, if any.
+pub fn apply_authority(report: &mut ExitReport, kernel: &Kernel, task_grant_id: Option<String>) {
+    let mut summary = portcullis::summarise_authority(kernel.effective(), kernel.trace());
+    summary.task_grant_id = task_grant_id;
+    info!(
+        granted = summary.granted_dimensions.len(),
+        used = summary.used_dimensions.len(),
+        overhead = ?summary.overhead,
+        allowed = summary.allowed,
+        denied = summary.denied,
+        approvals = summary.approvals_requested,
+        "exit report: authority summary captured"
+    );
+    report.authority = Some(summary);
 }
 
 /// Fold the Article 12 log's chain head into the report, for the host to sign.
@@ -192,10 +217,105 @@ pub fn apply_exposure(
     );
 }
 
+/// Write the exit report on shutdown (including verified exposure data and
+/// the authority summary). Lives here rather than in main.rs so the report's
+/// inputs are all in one place and main.rs stays under its line ratchet.
+pub async fn write_exit_report(
+    audit: &AuditLog,
+    work_dir_path: &Path,
+    exposure_guard: &std::sync::RwLock<Option<Arc<portcullis::GradedExposureGuard>>>,
+    monitor: &portcullis::trace_monitor::TraceMonitor,
+    art12_log: Option<&Arc<crate::art12::Art12Log>>,
+    kernel: &Arc<tokio::sync::Mutex<Kernel>>,
+    task_grant_id: Option<String>,
+) {
+    let workspace_hash = match hash_workspace(work_dir_path).await {
+        Ok(h) => h,
+        Err(e) => {
+            warn!("failed to hash workspace for exit report: {e}");
+            return;
+        }
+    };
+
+    let (tail_hash, count) = audit.tail_hash_and_count();
+    let mut report = build_exit_report(workspace_hash, tail_hash, count, None, monitor);
+    if !report.monitor_violations.is_empty() || report.monitor_violations_dropped > 0 {
+        warn!(
+            violations = ?report.monitor_violations,
+            dropped = report.monitor_violations_dropped,
+            "exit report: decision-stream properties were violated during this session"
+        );
+    }
+
+    apply_exposure(&mut report, exposure_guard);
+    apply_art12(&mut report, art12_log);
+    {
+        let kernel = kernel.lock().await;
+        apply_authority(&mut report, &kernel, task_grant_id);
+    }
+
+    let report_path = work_dir_path.join(".nucleus-exit-report.json");
+    match serde_json::to_string_pretty(&report) {
+        Ok(json) => {
+            if let Err(e) = tokio::fs::write(&report_path, json).await {
+                warn!(
+                    "failed to write exit report to {}: {e}",
+                    report_path.display()
+                );
+            } else {
+                info!(
+                    path = %report_path.display(),
+                    entries = count,
+                    event = "exit_report_written",
+                    "exit report written"
+                );
+            }
+        }
+        Err(e) => warn!("failed to serialize exit report: {e}"),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use tempfile::TempDir;
+
+    /// The report says what the kernel granted and what the session used,
+    /// and names the grant the spec named.
+    #[test]
+    #[allow(deprecated)] // `decide` is the shortest way to a real trace
+    fn the_authority_summary_comes_from_the_kernel_and_names_the_grant() {
+        use portcullis::{Operation, PermissionLattice};
+        let mut kernel = Kernel::new(PermissionLattice::restrictive());
+        kernel.decide(Operation::ReadFiles, "src/main.rs");
+        kernel.decide(Operation::GitPush, "origin main");
+        let mut report = ExitReport {
+            workspace_hash: "w".into(),
+            audit_tail_hash: "t".into(),
+            audit_entry_count: 2,
+            timestamp_unix: 1,
+            input_tokens: 0,
+            output_tokens: 0,
+            cache_read_tokens: 0,
+            cost_usd: 0.0,
+            observed_exposure_labels: Vec::new(),
+            observed_risk_tier: String::new(),
+            uninhabitable_reached: false,
+            monitor_violations: Vec::new(),
+            monitor_violations_dropped: 0,
+            art12_chain_head: String::new(),
+            art12_records: 0,
+            art12_dropped: 0,
+            authority: None,
+        };
+        apply_authority(&mut report, &kernel, Some("grant-1".into()));
+        let a = report.authority.expect("summary");
+        assert_eq!(a.task_grant_id.as_deref(), Some("grant-1"));
+        assert_eq!(a.allowed, 1);
+        assert_eq!(a.denied, 1);
+        assert_eq!(a.used_dimensions, vec!["read_files"]);
+        assert!(a.overhead.is_some());
+    }
 
     #[tokio::test]
     async fn test_hash_workspace_empty() {

--- a/crates/nucleus-tool-proxy/src/main.rs
+++ b/crates/nucleus-tool-proxy/src/main.rs
@@ -2130,6 +2130,8 @@ async fn main() -> Result<(), ApiError> {
     let exit_exposure = state.exposure_guard.clone();
     let exit_monitor = state.trace_monitor.clone();
     let exit_art12 = state.art12_log.clone();
+    let exit_kernel = state.kernel.clone();
+    let exit_grant = spec.metadata.task_grant_id.clone();
 
     let app = app
         .with_state(state.clone())
@@ -2170,12 +2172,14 @@ async fn main() -> Result<(), ApiError> {
         let _workload = start_and_drain_workload(&spec, bound.proxy(), &args.auth_secret)?;
         st.report();
         bound.serve(app).await?;
-        write_exit_report(
+        exit_report::write_exit_report(
             &exit_audit,
             &exit_work_dir,
             &exit_exposure,
             &exit_monitor,
             exit_art12.as_ref(),
+            &exit_kernel,
+            exit_grant.clone(),
         )
         .await;
         return Ok(());
@@ -2232,12 +2236,14 @@ async fn main() -> Result<(), ApiError> {
     #[cfg(feature = "otel")]
     telemetry::shutdown_otel();
 
-    write_exit_report(
+    exit_report::write_exit_report(
         &exit_audit,
         &exit_work_dir,
         &exit_exposure,
         &exit_monitor,
         exit_art12.as_ref(),
+        &exit_kernel,
+        exit_grant,
     )
     .await;
 
@@ -2269,57 +2275,6 @@ fn fail_closed_panic_response(err: Box<dyn std::any::Any + Send + 'static>) -> R
         "denied: internal enforcement error (fail-closed)",
     )
         .into_response()
-}
-
-/// Write the exit report on shutdown (including verified exposure data).
-async fn write_exit_report(
-    audit: &AuditLog,
-    work_dir_path: &Path,
-    exposure_guard: &std::sync::RwLock<Option<Arc<portcullis::GradedExposureGuard>>>,
-    monitor: &portcullis::trace_monitor::TraceMonitor,
-    art12_log: Option<&Arc<crate::art12::Art12Log>>,
-) {
-    let workspace_hash = match exit_report::hash_workspace(work_dir_path).await {
-        Ok(h) => h,
-        Err(e) => {
-            warn!("failed to hash workspace for exit report: {e}");
-            return;
-        }
-    };
-
-    let (tail_hash, count) = audit.tail_hash_and_count();
-    let mut report =
-        exit_report::build_exit_report(workspace_hash, tail_hash, count, None, monitor);
-    if !report.monitor_violations.is_empty() || report.monitor_violations_dropped > 0 {
-        warn!(
-            violations = ?report.monitor_violations,
-            dropped = report.monitor_violations_dropped,
-            "exit report: decision-stream properties were violated during this session"
-        );
-    }
-
-    exit_report::apply_exposure(&mut report, exposure_guard);
-    exit_report::apply_art12(&mut report, art12_log);
-
-    let report_path = work_dir_path.join(".nucleus-exit-report.json");
-    match serde_json::to_string_pretty(&report) {
-        Ok(json) => {
-            if let Err(e) = tokio::fs::write(&report_path, json).await {
-                warn!(
-                    "failed to write exit report to {}: {e}",
-                    report_path.display()
-                );
-            } else {
-                info!(
-                    path = %report_path.display(),
-                    entries = count,
-                    event = "exit_report_written",
-                    "exit report written"
-                );
-            }
-        }
-        Err(e) => warn!("failed to serialize exit report: {e}"),
-    }
 }
 
 /// Builds mTLS configuration from CLI arguments.

--- a/crates/portcullis/src/authority_metrics.rs
+++ b/crates/portcullis/src/authority_metrics.rs
@@ -1,0 +1,221 @@
+//! The two numbers ADR 0004 asks every run to report (milestone 5).
+//!
+//! - **Authority overhead** ρ = authority granted ÷ authority used, over the
+//!   13 core dimensions. ρ → 1 is the goal: a grant that holds nothing the
+//!   run did not use. It is undefined, not infinite, when nothing was used.
+//! - **Delegation clicks** C(T) = the confirmations a person gave before the
+//!   run plus the approvals the kernel asked for during it. One for a new
+//!   task, zero for a previously sealed grant, and every extra one is a
+//!   prompt that was ceremony or a boundary the task needed moved.
+//!
+//! Both are computed from what the kernel already keeps: its effective
+//! lattice and its append-only decision trace. The tool-proxy folds the
+//! result into the exit report, the MCP server into its session summary,
+//! and the CLI prints it after a run. This module is feature-free so every
+//! one of them can use it; only reading a trace back from JSONL needs
+//! `serde`.
+
+use std::collections::BTreeSet;
+
+use crate::kernel::{Decision, Verdict};
+use crate::{CapabilityLevel, Operation, PermissionLattice};
+
+/// Snake-case name of a core operation (the trace vocabulary).
+fn operation_name(op: Operation) -> &'static str {
+    match op {
+        Operation::ReadFiles => "read_files",
+        Operation::WriteFiles => "write_files",
+        Operation::EditFiles => "edit_files",
+        Operation::RunBash => "run_bash",
+        Operation::GlobSearch => "glob_search",
+        Operation::GrepSearch => "grep_search",
+        Operation::WebSearch => "web_search",
+        Operation::WebFetch => "web_fetch",
+        Operation::GitCommit => "git_commit",
+        Operation::GitPush => "git_push",
+        Operation::CreatePr => "create_pr",
+        Operation::ManagePods => "manage_pods",
+        Operation::SpawnAgent => "spawn_agent",
+    }
+}
+
+/// What a session was granted and what it used, in the two ADR metrics.
+#[derive(Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct AuthoritySummary {
+    /// Core dimensions the effective lattice holds above `Never`.
+    pub granted_dimensions: Vec<String>,
+    /// Core dimensions at least one allowed decision used.
+    pub used_dimensions: Vec<String>,
+    /// ρ = granted ÷ used over dimensions; `None` when nothing was used.
+    pub overhead: Option<f64>,
+    /// Decisions the kernel allowed.
+    pub allowed: u64,
+    /// Decisions the kernel denied.
+    pub denied: u64,
+    /// Decisions the kernel gated on approval.
+    pub approvals_requested: u64,
+    /// Confirmations a person gave before the run (1 for a new goal, 0 for
+    /// a sealed grant). Set by whoever asked.
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub confirmations: u64,
+    /// The task grant the session ran under, when it ran under one.
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub task_grant_id: Option<String>,
+}
+
+impl AuthoritySummary {
+    /// C(T): confirmations before the run plus approvals during it.
+    #[must_use]
+    pub fn delegation_clicks(&self) -> u64 {
+        self.confirmations.saturating_add(self.approvals_requested)
+    }
+
+    /// One line for a run summary.
+    #[must_use]
+    pub fn render(&self) -> String {
+        let rho = match self.overhead {
+            Some(r) => format!("ρ = {r:.2}"),
+            None => "ρ undefined (nothing used)".to_string(),
+        };
+        format!(
+            "authority: {} of {} granted dimensions used · {rho} · C(T) = {} ({} confirmation{}, {} approval{} during the run) · {} allowed · {} denied",
+            self.used_dimensions.len(),
+            self.granted_dimensions.len(),
+            self.delegation_clicks(),
+            self.confirmations,
+            if self.confirmations == 1 { "" } else { "s" },
+            self.approvals_requested,
+            if self.approvals_requested == 1 { "" } else { "s" },
+            self.allowed,
+            self.denied
+        )
+    }
+}
+
+/// Summarise `trace` against `effective`.
+#[must_use]
+pub fn summarise_authority(effective: &PermissionLattice, trace: &[Decision]) -> AuthoritySummary {
+    let granted: BTreeSet<Operation> = Operation::ALL
+        .iter()
+        .copied()
+        .filter(|op| effective.capabilities.level_for(*op) != CapabilityLevel::Never)
+        .collect();
+    let mut used: BTreeSet<Operation> = BTreeSet::new();
+    let (mut allowed, mut denied, mut approvals) = (0u64, 0u64, 0u64);
+    for d in trace {
+        match &d.verdict {
+            Verdict::Allow => {
+                allowed += 1;
+                used.insert(d.operation);
+            }
+            Verdict::RequiresApproval => {
+                approvals += 1;
+                used.insert(d.operation);
+            }
+            Verdict::Deny(_) => denied += 1,
+        }
+    }
+    let used_granted = used.iter().filter(|op| granted.contains(op)).count();
+    let overhead = (used_granted > 0).then(|| {
+        // At most 13 of each: exact in f64.
+        f64::from(u32::try_from(granted.len()).unwrap_or(u32::MAX))
+            / f64::from(u32::try_from(used_granted).unwrap_or(u32::MAX))
+    });
+    AuthoritySummary {
+        granted_dimensions: granted
+            .iter()
+            .map(|op| operation_name(*op).to_string())
+            .collect(),
+        used_dimensions: used
+            .iter()
+            .map(|op| operation_name(*op).to_string())
+            .collect(),
+        overhead,
+        allowed,
+        denied,
+        approvals_requested: approvals,
+        confirmations: 0,
+        task_grant_id: None,
+    }
+}
+
+/// Every `Decision` line in a kernel trace (`--kernel-trace` JSONL), in
+/// order. Lines that are not decisions (the session summary, garbage) are
+/// skipped.
+#[cfg(feature = "serde")]
+#[must_use]
+pub fn decisions_in_trace(jsonl: &str) -> Vec<Decision> {
+    jsonl
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .filter_map(|l| serde_json::from_str::<Decision>(l).ok())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kernel::Kernel;
+
+    #[test]
+    #[allow(deprecated)] // `decide` is the shortest way to a real trace
+    fn overhead_and_clicks_come_from_the_kernel_trace() {
+        let mut lattice = PermissionLattice::restrictive();
+        lattice.capabilities.run_bash = CapabilityLevel::LowRisk;
+        let mut kernel = Kernel::new(lattice);
+        kernel.decide(Operation::ReadFiles, "src/main.rs");
+        kernel.decide(Operation::ReadFiles, "Cargo.toml");
+        kernel.decide(Operation::GitPush, "origin main"); // denied: never
+
+        let mut s = summarise_authority(kernel.effective(), kernel.trace());
+        // restrictive: read, glob, grep at Always; plus run_bash = 4 granted.
+        assert_eq!(s.granted_dimensions.len(), 4, "{:?}", s.granted_dimensions);
+        assert_eq!(s.used_dimensions, vec!["read_files"]);
+        assert!((s.overhead.unwrap() - 4.0).abs() < 1e-9);
+        assert_eq!(s.allowed, 2);
+        assert_eq!(s.denied, 1);
+        assert_eq!(s.approvals_requested, 0);
+        assert_eq!(s.delegation_clicks(), 0);
+        s.confirmations = 1;
+        assert_eq!(s.delegation_clicks(), 1);
+        let line = s.render();
+        assert!(line.contains("1 of 4 granted dimensions used"), "{line}");
+        assert!(line.contains("ρ = 4.00"), "{line}");
+        assert!(
+            line.contains("C(T) = 1 (1 confirmation, 0 approvals"),
+            "{line}"
+        );
+    }
+
+    #[test]
+    fn nothing_used_has_no_overhead() {
+        let s = summarise_authority(&PermissionLattice::restrictive(), &[]);
+        assert_eq!(s.overhead, None);
+        assert!(s.render().contains("ρ undefined"));
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    #[allow(deprecated)]
+    fn a_trace_reads_back_and_the_summary_round_trips() {
+        let mut kernel = Kernel::new(PermissionLattice::restrictive());
+        kernel.decide(Operation::ReadFiles, "a");
+        kernel.decide(Operation::GitPush, "b");
+        let jsonl = kernel
+            .trace()
+            .iter()
+            .map(|d| serde_json::to_string(d).unwrap())
+            .collect::<Vec<_>>()
+            .join("\n")
+            + "\n{\"type\":\"session_summary\"}\n";
+        let decisions = decisions_in_trace(&jsonl);
+        assert_eq!(decisions.len(), 2);
+        let s = summarise_authority(kernel.effective(), &decisions);
+        assert_eq!(s.allowed, 1);
+        assert_eq!(s.denied, 1);
+        let json = serde_json::to_string(&s).unwrap();
+        let back: AuthoritySummary = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, s);
+    }
+}

--- a/crates/portcullis/src/lib.rs
+++ b/crates/portcullis/src/lib.rs
@@ -98,6 +98,9 @@ pub mod cedar_bridge;
 // VerifiedPermissions, …) and non-crypto logic are ring-free; only the
 // sign/verify/mint/delegate fns inside are `#[cfg(feature = "crypto")]`-gated
 // (ring can't compile to WASM). The kernel needs the types, not the signing.
+/// The two run metrics ADR 0004 names, ρ and C(T), from the kernel's
+/// effective lattice and decision trace. Feature-free.
+pub mod authority_metrics;
 #[cfg(not(kani))]
 pub mod cert_compartment;
 pub mod certificate;
@@ -339,6 +342,9 @@ pub use audit::{
     AuditEntry, AuditLog, ChainVerificationError, IdentityAuditSummary, PermissionEvent,
     RetentionPolicy,
 };
+#[cfg(feature = "serde")]
+pub use authority_metrics::decisions_in_trace;
+pub use authority_metrics::{summarise_authority, AuthoritySummary};
 pub use certificate::{
     canonical_permissions_hash, CertificateDelegationError, CertificateError,
     CertificateMintChildError, LatticeCertificate, SinkScope, VerifiedPermissions,

--- a/docs/adr/0004-delegation-compiler.md
+++ b/docs/adr/0004-delegation-compiler.md
@@ -108,5 +108,5 @@ with two invariants DX work may not violate:
 | 2 | `effect/` certificate keys (`effect_surface`), `SealedTaskGrant` (grant + signed certificate, binding keys), `nucleus run --save-grant` / `--grant`, `nucleus grant seal|show` (C(T)=0) | this PR |
 | 3 | Trace → effect attribution (`grant_usage`), ρ over dimensions and effects, post-run usage lines and "save a narrower profile", `nucleus observe --grant --narrow --save`, user profiles in `~/.config/nucleus/profiles` (never wider than a canonical name) | this PR |
 | 4 | `EscalationProposal` (`escalation_proposal`): attempt, reason, minimum effect and raised dimensions, risk delta, scopes (always / this run), outside-ceiling and repair outcomes; `denials_in_trace`; post-run proposals; `nucleus grant propose\|widen`. Carriage inside MCP / tool-proxy / hook / SDK denial payloads is the next step | this PR |
-| 5 | ρ and C(T) in `ExitReport` and the run summary | |
+| 5 | `AuthoritySummary` (`authority_metrics`, feature-free): ρ over dimensions, C(T) = confirmations + approvals, decision counts; in `ExitReport.authority`, the MCP `session_summary`, and the run's closing line; `PodSpec.metadata.task_grant_id` | this PR |
 | 6 | Per-effect enforcement at the credential boundary (method+path) | |

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -412,6 +412,27 @@ milestone (the lattice, the host list and the command prefixes); attributing
 receipts to effects and enforcing per effect at the credential boundary are the
 milestones after this one.
 
+### Two numbers every run reports: ρ and C(T)
+
+The exit report (`.nucleus-exit-report.json`, written by the tool proxy), the MCP
+server's `session_summary` trace line, and the line a `--goal` / `--grant` run
+ends with all carry the same `authority` summary, computed from the kernel's
+effective lattice and its decision trace:
+
+```
+authority: 3 of 6 granted dimensions used · ρ = 2.00 · C(T) = 1 (1 confirmation, 0 approvals during the run) · 41 allowed · 1 denied
+```
+
+- **ρ (authority overhead)** = granted dimensions ÷ used dimensions. ρ → 1 is
+  the goal; it is undefined, not infinite, when nothing was used.
+- **C(T) (delegation clicks)** = confirmations before the run (1 for a new goal,
+  0 for a sealed grant) + approvals the kernel asked for during it. Every click
+  beyond one is either ceremony or a boundary the task needed moved, and the
+  proposals below say which.
+
+A pod spec may name the grant it runs under (`metadata.task_grant_id`); `--goal`
+and `--grant` runs set it, and the exit report carries it back.
+
 ### When something is denied: every denial is a proposal
 
 A denial answers four questions, not one: what the agent tried, why exactly it


### PR DESCRIPTION
## What this is

Milestone 5 of ADR 0004, stacked on #2678 → #2677 → #2676 → #2675. The base retargets down the stack as each merges; the diff here is milestone 5 alone.

The ADR names two numbers a run should be judged by. Until now they lived only in the CLI's post-run lines. They are now computed once, from what the kernel already keeps (its effective lattice and its decision trace), and carried everywhere a run reports on itself:

```
authority: 3 of 6 granted dimensions used · ρ = 2.00 · C(T) = 1 (1 confirmation, 0 approvals during the run) · 41 allowed · 1 denied
```

- **ρ (authority overhead)** = granted dimensions ÷ used dimensions. ρ → 1 is the goal. It is undefined, not infinite, when nothing was used.
- **C(T) (delegation clicks)** = confirmations before the run (1 for a new goal, 0 for a sealed grant) + approvals the kernel asked for during it.

## Pieces

- **`portcullis::authority_metrics`** (feature-free, so every consumer can use it): `summarise_authority(effective, trace) -> AuthoritySummary`, `delegation_clicks()`, `render()`, and `decisions_in_trace` for reading a kernel trace back.
- **`nucleus-spec`**: `ExitReport.authority: Option<AuthoritySummary>` (serde default, so older reports still parse) and `Metadata.task_grant_id` so a pod spec can name the grant it runs under.
- **`nucleus-tool-proxy`**: `write_exit_report` moves from main.rs into exit_report.rs (main.rs was two lines under its line-ratchet ceiling) and takes the kernel; at shutdown `apply_authority` folds the summary in, naming the spec's task grant.
- **`nucleus-mcp`**: the `session_summary` trace line carries the same `authority` object.
- **`nucleus-cli`**: `--goal` and `--grant` runs stamp `metadata.task_grant_id` into the pod spec (a hidden `RunArgs` field, not a flag) and end with the authority line.

## Invariants kept

- Nothing here changes a decision; it reports on decisions already made. No new dependencies, no new `cfg(kani)` site (72), zero cast-ratchet sites in the new code, vendor-neutral.
- Wire compatibility: an exit report or pod spec written before this PR parses unchanged.

## Validation

- `cargo test -p portcullis --all-features --lib -- authority_metrics` (3 new); `cargo test -p nucleus-spec` (65, 2 new); tool-proxy `the_authority_summary_comes_from_the_kernel_and_names_the_grant`; MCP `test_kernel_trace_is_append_only` extended; CLI `goal_dry_run`, `grant_reuse`
- `cargo clippy --all-features --all-targets -- -D warnings` on portcullis, nucleus-spec, nucleus-tool-proxy, nucleus-mcp, nucleus-cli, nucleus-node: clean
- `cargo fmt --all --check`, `scripts/check-kani-divergence.sh`, `scripts/check-line-ratchet.sh --strict` (tool-proxy main.rs 4928 ≤ 4975), `ci/no-vendor-strings.sh`, `cargo metadata --no-deps` with empty stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QqBdBgCoVTtbe7gLNQh532

---
_Generated by [Claude Code](https://claude.ai/code/session_01QqBdBgCoVTtbe7gLNQh532)_