### PR TITLE
ci: run OIDC parity proofs for production crate changes

### DIFF
--- a/.github/workflows/aeneas-oidc-spiffe-noop.yml
+++ b/.github/workflows/aeneas-oidc-spiffe-noop.yml
@@ -12,11 +12,7 @@ name: Aeneas OIDC→SPIFFE (scoped extraction + derivation properties)
 on:
   pull_request:
     paths-ignore:
-      - "crates/nucleus-github-oidc/src/extracted/**"
-      - "crates/nucleus-github-oidc/lean/generated/**"
-      - "crates/nucleus-github-oidc/lean/OidcSpiffeProofs.lean"
-      - "crates/nucleus-github-oidc/lean/JwtSvidClaimsProofs.lean"
-      - "crates/nucleus-github-oidc/lean/lakefile.lean"
+      - "crates/nucleus-github-oidc/**"
       - ".github/workflows/aeneas-oidc-spiffe.yml"
 
 concurrency:

--- a/.github/workflows/aeneas-oidc-spiffe.yml
+++ b/.github/workflows/aeneas-oidc-spiffe.yml
@@ -16,19 +16,11 @@ on:
   push:
     branches: ["main"]
     paths:
-      - "crates/nucleus-github-oidc/src/extracted/**"
-      - "crates/nucleus-github-oidc/lean/generated/**"
-      - "crates/nucleus-github-oidc/lean/OidcSpiffeProofs.lean"
-      - "crates/nucleus-github-oidc/lean/JwtSvidClaimsProofs.lean"
-      - "crates/nucleus-github-oidc/lean/lakefile.lean"
+      - "crates/nucleus-github-oidc/**"
       - ".github/workflows/aeneas-oidc-spiffe.yml"
   pull_request:
     paths:
-      - "crates/nucleus-github-oidc/src/extracted/**"
-      - "crates/nucleus-github-oidc/lean/generated/**"
-      - "crates/nucleus-github-oidc/lean/OidcSpiffeProofs.lean"
-      - "crates/nucleus-github-oidc/lean/JwtSvidClaimsProofs.lean"
-      - "crates/nucleus-github-oidc/lean/lakefile.lean"
+      - "crates/nucleus-github-oidc/**"
       - ".github/workflows/aeneas-oidc-spiffe.yml"
   merge_group:
   workflow_dispatch:
@@ -79,7 +71,7 @@ jobs:
           EVENT: ${{ github.event_name }}
           BASE: ${{ github.event.merge_group.base_sha }}
           HEAD: ${{ github.event.merge_group.head_sha }}
-          PATTERN: '^\.github/workflows/aeneas\-oidc\-spiffe\.yml$|^crates/nucleus\-github\-oidc/lean/OidcSpiffeProofs\.lean$|^crates/nucleus\-github\-oidc/lean/JwtSvidClaimsProofs\.lean$|^crates/nucleus\-github\-oidc/lean/generated/|^crates/nucleus\-github\-oidc/lean/lakefile\.lean$|^crates/nucleus\-github\-oidc/src/extracted/'
+          PATTERN: '^\.github/workflows/aeneas\-oidc\-spiffe\.yml$|^crates/nucleus\-github\-oidc/'
         run: |
           set -euo pipefail
           if [ "$EVENT" != "merge_group" ]; then


### PR DESCRIPTION
Production OIDC derivation changes could skip the parity tests and extraction proofs because the workflow only watched extracted code and selected Lean files. Watch the entire `nucleus-github-oidc` crate on PRs and pushes, and match that scope in the no-op twin and merge-group regex.

Closes #2566.

Validation: actionlint passes for both workflows; merge-group scope parity passes; the existing local xtask binary reports all CI-spec invariants hold. Explicit path probes confirm `src/lib.rs`, `Cargo.toml`, and Lean proofs select the real gate while unrelated README changes stay out of scope. Full extraction/proof execution remains for CI.
