### PR TITLE
fix(lean): reject compiler overrides and retire finite native proofs

### DIFF
--- a/.github/workflows/portcullis-core-proven-lean.yml
+++ b/.github/workflows/portcullis-core-proven-lean.yml
@@ -16,10 +16,9 @@ name: Portcullis-Core Proven Lean
 #   3. runs a `#print axioms` audit on the enforcement core to catch any
 #      `sorryAx` that a textual grep would miss via the proof dependency graph.
 #
-# `native_decide` is NOT banned here (unlike the Mathlib-free ck-policy/rubric/
-# econ trees): it is load-bearing in FlowGraphProofs.lean. It is instead
-# DISCLOSED — the #print axioms step surfaces `Lean.ofReduceBool` (native-
-# compiler TCB) so the trust boundary is visible, not hidden.
+# Native evaluation is admitted only by the per-theorem exception list.
+# FlowGraphProofs uses kernel-checked decide; owned compiler overrides are
+# rejected before any build or axiom audit.
 
 on:
   push:
@@ -96,6 +95,12 @@ jobs:
             echo "as a required status check."
           fi
 
+
+      - name: Reject compiler overrides (with planted-override falsifiers)
+        if: steps.scope.outputs.relevant == 'true'
+        run: |
+          python3 crates/portcullis-core/lean/check_compiler_overrides.py --self-test
+          python3 crates/portcullis-core/lean/check_compiler_overrides.py
 
       - name: Install elan (Lean toolchain)
         if: runner.environment == 'github-hosted' && (steps.scope.outputs.relevant == 'true')

--- a/FORMAL_METHODS.md
+++ b/FORMAL_METHODS.md
@@ -218,10 +218,13 @@ files — see `crates/portcullis-core/lean/CONJECTURES.md`). The
 `portcullis-core-proven-lean.yml` CI gate `lake build`s the proven tier and
 fails if any proof hole appears outside that manifest.
 
-(†) `FlowGraphProofs.lean` uses `native_decide` in 3 of its 15 theorems, which
-trusts the **native compiler** (`Lean.ofReduceBool` axiom) — `sorry`-free but
-outside the pure Lean kernel. The CI gate discloses this via `#print axioms`
-rather than hiding it.
+(†) `FlowGraphProofs.lean` now uses kernel-checked `decide` for its three
+finite examples. Remaining native-evaluation exceptions are named per theorem
+in `crates/portcullis-core/lean/.axiom-audit-exceptions`; the generated axiom
+audit rejects native evaluation outside that list. Before auditing a project,
+CI also rejects `implemented_by`, `extern`, and `csimp` attributes in its owned
+Lean sources, including generated Aeneas code. Dependencies under `.lake` are
+outside this source lint, so native evaluation still trusts their compiled code.
 
 ## Claude Code Hook — What's Verified vs Not
 

--- a/ci/inline-gates.txt
+++ b/ci/inline-gates.txt
@@ -104,3 +104,4 @@ trust-registry.yml::enrollment-gate::Determine the single claimed domain | UNCOV
 trust-registry.yml::enrollment-gate::Request OIDC proof-of-control token | UNCOVERED: no falsifier yet
 uniform-primitive-lean.yml::uniform-primitive-lean::Reject sorry / admit (the spine must stay sorry-free) | UNCOVERED: no falsifier yet
 uniform-primitive-lean.yml::uniform-primitive-lean::Axiom ratchet (layer-bridge count = distance-to-done; may only drop) | UNCOVERED: no falsifier yet
+portcullis-core-proven-lean.yml::portcullis-core-proven-lean::Reject compiler overrides (with planted-override falsifiers) | falsified by check_compiler_overrides.py --self-test in the same step: implemented_by, extern, csimp each rejected

--- a/ci/inline-gates.txt
+++ b/ci/inline-gates.txt
@@ -104,4 +104,3 @@ trust-registry.yml::enrollment-gate::Determine the single claimed domain | UNCOV
 trust-registry.yml::enrollment-gate::Request OIDC proof-of-control token | UNCOVERED: no falsifier yet
 uniform-primitive-lean.yml::uniform-primitive-lean::Reject sorry / admit (the spine must stay sorry-free) | UNCOVERED: no falsifier yet
 uniform-primitive-lean.yml::uniform-primitive-lean::Axiom ratchet (layer-bridge count = distance-to-done; may only drop) | UNCOVERED: no falsifier yet
-portcullis-core-proven-lean.yml::portcullis-core-proven-lean::Reject compiler overrides (with planted-override falsifiers) | falsified by check_compiler_overrides.py --self-test in the same step: implemented_by, extern, csimp each rejected

--- a/crates/portcullis-core/lean/.axiom-audit-exceptions
+++ b/crates/portcullis-core/lean/.axiom-audit-exceptions
@@ -6,9 +6,6 @@
 # Theorems that merely depend on one of these inherit the disclosure; a NEW
 # native_decide anywhere else must be added here, by name, with a reason.
 ChannelAdmission.admission_is_pinned_per_channel
-FlowGraphProofs.invariant_exploit_dag_blocked
-FlowGraphProofs.single_adversarial_taints_chain
-FlowGraphProofs.clean_chain_preserves_trust
 IdentityMaterialNoninterference.delivery_is_flows_to_against_the_ceiling
 
 # External-model axioms (`axiom <name>`): declarations Aeneas emits in a

--- a/crates/portcullis-core/lean/FlowGraphProofs.lean
+++ b/crates/portcullis-core/lean/FlowGraphProofs.lean
@@ -127,7 +127,7 @@ theorem invariant_exploit_dag_blocked :
     let intrinsic : IFCLabel := ⟨.Internal, .Trusted, .Directive⟩
     let plan : IFCLabel := [issue, repo].foldl IFCLabel.join intrinsic
     plan.integ = .Adversarial ∧ plan.auth = .NoAuthority ∧ plan.conf = .Internal := by
-  native_decide
+  decide
 
 -- ═══════════════════════════════════════════════════════════════════════
 -- Theorem 11: Propagation through multiple tainted sources
@@ -141,7 +141,7 @@ theorem single_adversarial_taints_chain :
     let intrinsic : IFCLabel := ⟨.Internal, .Trusted, .Directive⟩
     let result : IFCLabel := [trusted, trusted, adversarial, trusted].foldl IFCLabel.join intrinsic
     result.integ = .Adversarial ∧ result.auth = .NoAuthority := by
-  native_decide
+  decide
 
 -- ═══════════════════════════════════════════════════════════════════════
 -- Theorem 12: Clean propagation preserves trust
@@ -155,6 +155,6 @@ theorem clean_chain_preserves_trust :
     let intrinsic : IFCLabel := ⟨.Internal, .Trusted, .Directive⟩
     let result : IFCLabel := [user, file].foldl IFCLabel.join intrinsic
     result.integ = .Trusted ∧ result.auth = .Directive := by
-  native_decide
+  decide
 
 end FlowGraphProofs

--- a/crates/portcullis-core/lean/check_compiler_overrides.py
+++ b/crates/portcullis-core/lean/check_compiler_overrides.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Reject compiler overrides in owned Lean sources, including Aeneas output.
+
+Native evaluation must not silently substitute a different implementation for
+the definition checked by the kernel. Dependencies in .lake are outside this
+source lint; the per-theorem axiom audit remains a separate gate.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+
+def code_only(source):
+    """Blank nested comments and strings while preserving diagnostic lines."""
+    out = list(source)
+    i = depth = 0
+    quoted = False
+    while i < len(source):
+        if depth:
+            if source.startswith("/-", i):
+                out[i:i + 2] = "  "
+                depth += 1
+                i += 2
+            elif source.startswith("-/", i):
+                out[i:i + 2] = "  "
+                depth -= 1
+                i += 2
+            else:
+                if source[i] != "\n":
+                    out[i] = " "
+                i += 1
+        elif quoted:
+            if source[i] == "\\":
+                out[i:i + 2] = ["\n" if c == "\n" else " " for c in source[i:i + 2]]
+                i += 2
+            else:
+                quoted = source[i] != '"'
+                if source[i] != "\n":
+                    out[i] = " "
+                i += 1
+        elif source.startswith("/-", i):
+            out[i:i + 2] = "  "
+            depth = 1
+            i += 2
+        elif source.startswith("--", i):
+            end = source.find("\n", i)
+            if end == -1:
+                end = len(source)
+            out[i:end] = " " * (end - i)
+            i = end
+        elif source[i] == '"':
+            quoted = True
+            out[i] = " "
+            i += 1
+        else:
+            i += 1
+    if depth or quoted:
+        raise ValueError("unterminated comment or string")
+    return "".join(out)
+
+
+def violations(source):
+    code = code_only(source)
+    for attribute in re.finditer(r"(?:@\s*|\battribute\s*)\[([^\]]*)\]", code):
+        for forbidden in re.finditer(r"\b(?:implemented_by|extern|csimp)\b", attribute[1]):
+            yield code.count("\n", 0, attribute.start(1) + forbidden.start()) + 1, forbidden[0]
+
+
+def self_test():
+    for attribute in ("implemented_by", "extern", "csimp"):
+        for source in (
+            f"@[{attribute} replacement] def f := 1",
+            f"@[inline,\n /- nested /- comment -/ -/ {attribute} replacement] def f := 1",
+            f"attribute [{attribute} replacement] f",
+            f"local attribute [\n{attribute} replacement] f",
+        ):
+            assert list(violations(source)), source
+    assert not list(violations('''
+/- @[implemented_by f] /- attribute [csimp] f -/ -/
+-- @[extern "f"]
+def exampleText := "@[implemented_by f]"
+@[simp] theorem clean : True := by trivial
+'''))
+    assert list(violations('-- comment\n@[csimp] theorem x := rfl')) == [(2, 'csimp')]
+    for source in ('/- missing end', 'def s := "missing end'):
+        try:
+            list(violations(source))
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("malformed source passed")
+    print("ok: all three planted overrides rejected; comments and strings ignored")
+
+
+def main():
+    if sys.argv[1:] == ["--self-test"]:
+        self_test()
+        return 0
+    root = Path(sys.argv[1]) if len(sys.argv) > 1 else Path(__file__).parent
+    files = sorted(p for p in root.rglob("*.lean") if ".lake" not in p.relative_to(root).parts)
+    if not files:
+        print(f"::error::no Lean sources found in {root}")
+        return 1
+    failed = False
+    for path in files:
+        try:
+            for line, attribute in violations(path.read_text()):
+                print(f"::error file={path},line={line}::compiler override {attribute} is forbidden")
+                failed = True
+        except (OSError, UnicodeError, ValueError) as error:
+            print(f"::error file={path}::{error}")
+            failed = True
+    if not failed:
+        print(f"ok: {len(files)} owned Lean sources contain no compiler overrides")
+    return int(failed)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/lean-axiom-audit.sh
+++ b/scripts/lean-axiom-audit.sh
@@ -42,10 +42,14 @@
 # (scripts/check-gates-can-fail.sh discipline).
 set -euo pipefail
 
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 PROJECT=${1:?project dir}
 MODE=${2:?root list or --self-test}
 cd "$PROJECT"
 PROJECT_ABS=$(pwd)
+
+# Native proofs must not run compiler-substituted owned definitions.
+python3 "$SCRIPT_DIR/../crates/portcullis-core/lean/check_compiler_overrides.py" .
 
 ALLOWED='["propext","Classical.choice","Quot.sound"]'
 EXC_FILE=.axiom-audit-exceptions


### PR DESCRIPTION
Owned Lean definitions could use compiler-substitution attributes while native-evaluation exceptions remained permitted. Add a comment- and string-aware lint for `implemented_by`, `extern`, and `csimp`, covering each audited project's own sources and Aeneas output. Run it before the proven-tier build and from the shared axiom audit, with planted-override falsifiers in CI.

Replace the three finite `FlowGraphProofs` native proofs with kernel-checked `decide`, remove their named exceptions, and correct the trust-boundary documentation. The other two named native exceptions remain unchanged. Dependencies under `.lake` are outside the source lint and remain part of native evaluation's trusted base.

Closes #2583.

Validation:
- Modified `FlowGraphProofs.lean` type-checks with the pinned Lean toolchain.
- Lint passes on all 177 owned crate Lean sources; unit fixtures and CLI probes reject all three forbidden attributes and accept clean source.
- Local existing xtask binary: CI-spec invariants pass; shell syntax and whitespace checks pass.
- Actionlint reports the same pre-existing SC2001/SC1003 findings on original and edited workflows.
- Full proven-tier build and axiom audit remain for CI. Additional local checks of the two unchanged exception-bearing modules hit an incompatible cached Batteries olean; their exceptions were retained.
