### PR TITLE
ci: enforce named Kani coverage and schedule missing proof lanes

### DIFF
--- a/.github/workflows/feature-matrix.yml
+++ b/.github/workflows/feature-matrix.yml
@@ -153,4 +153,4 @@ jobs:
           toolchain: "1.93"
           cache: ${{ runner.environment == 'github-hosted' }}
       - name: Check the Kani-verified crates on Kani's toolchain
-        run: cargo +1.93 check -p ck-kernel -p portcullis -p portcullis-core --locked
+        run: cargo +1.93 check -p ck-kernel -p portcullis -p portcullis-core -p nucleus-econ-kernels --locked

--- a/.github/workflows/kani-nightly-noop.yml
+++ b/.github/workflows/kani-nightly-noop.yml
@@ -21,6 +21,9 @@ on:
       - "crates/portcullis/src/**"
       - "crates/ck-*/src/**"
       - "crates/nucleus-ifc-kernel/src/**"
+      - "crates/portcullis-core/**"
+      - "crates/nucleus-econ-kernels/**"
+      - "scripts/kani-bounded.sh"
       - ".kani-minimum-proofs"
       - ".github/workflows/kani-nightly.yml"
 
@@ -55,3 +58,11 @@ jobs:
     steps:
       - name: No-op (paths not touched)
         run: echo "no relevant paths changed — gate vacuously green"
+
+  kani-core-fast:
+    name: Kani (portcullis-core fast)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: No-op (paths not touched)
+        run: echo "no relevant paths changed"

--- a/.github/workflows/kani-nightly.yml
+++ b/.github/workflows/kani-nightly.yml
@@ -69,6 +69,7 @@ jobs:
           # upgrading Kani.
           key: kani-toolchain-${{ runner.os }}-kani-0.67.0
       - name: Run Kani (fast harnesses)
+        id: verify
         uses: model-checking/kani-github-action@f838096619a707b0f6b2118cf435eaccfa33e51f # v1.1
         with:
           # Pin the verifier version for reproducible proofs (default is
@@ -88,23 +89,21 @@ jobs:
           # One census, counted by scripts/check-kani-proof-count.sh (#2561): the
           # inlined grep -rc on a DIRECTORY printed per-file lines, the arithmetic
           # errored, PROOF_COUNT was never set, and the gate passed on "".
-          PROOF_COUNT=$(scripts/check-kani-proof-count.sh --count)
-          MINIMUM=$(tr -d '[:space:]' < .kani-minimum-proofs)
           scripts/check-kani-proof-count.sh --strict
       - name: Summary
         if: always()
+        env:
+          KANI_OUTCOME: ${{ steps.verify.outcome }}
         run: |
-          # One census, counted by scripts/check-kani-proof-count.sh (#2561): the
-          # inlined grep -rc on a DIRECTORY printed per-file lines, the arithmetic
-          # errored, PROOF_COUNT was never set, and the gate passed on "".
-          PROOF_COUNT=$(scripts/check-kani-proof-count.sh --count)
-          MINIMUM=$(tr -d '[:space:]' < .kani-minimum-proofs)
-          echo "## Kani BMC Results (fast tier)" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Harnesses verified:** 5 / $PROOF_COUNT (fast tier)" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Solver:** CaDiCaL" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Minimum required:** $MINIMUM" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Full suite:** nightly + workflow_dispatch" >> "$GITHUB_STEP_SUMMARY"
+          # Report the verifier step, even after failure or cancellation. A
+          # source census is not evidence that any harness actually verified.
+          {
+            echo "## Kani BMC Results (portcullis fast tier)"
+            echo ""
+            echo "- **Verification step outcome:** ${KANI_OUTCOME:-not run}"
+            echo "- **Per-harness results:** see the Run Kani step log."
+            echo "- **Solver:** CaDiCaL"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   # Constitutional Kernel (fast): 5 bitmask / lattice proofs. These touch no
   # BTreeSet<String> and never call Kernel::admit, which is why they finish in
@@ -182,6 +181,7 @@ jobs:
           # upgrading Kani.
           key: kani-toolchain-${{ runner.os }}-kani-0.67.0
       - name: Run Kani (constitutional kernel — fast tier)
+        id: verify
         uses: model-checking/kani-github-action@f838096619a707b0f6b2118cf435eaccfa33e51f # v1.1
         with:
           # Pin the verifier version for reproducible proofs (default is
@@ -198,13 +198,18 @@ jobs:
             --harness proof_capability_subset_transitive
       - name: Summary
         if: always()
+        env:
+          KANI_OUTCOME: ${{ steps.verify.outcome }}
         run: |
-          TOTAL=$(grep -c '#\[kani::proof\]' crates/ck-kernel/src/kani.rs)
-          echo "## Kani BMC — Constitutional Kernel (fast tier)" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Harnesses verified:** 5 / $TOTAL (fast tier — pure bitmask)" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Proved:** budget escalation, capability non-escalation, I/O confinement, combined monotonicity, lattice transitivity" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Nightly:** 11 admission-path harnesses, one job each (see KANI-STATUS.md)" >> "$GITHUB_STEP_SUMMARY"
+          # Report the verifier step, even after failure or cancellation. A
+          # source census is not evidence that any harness actually verified.
+          {
+            echo "## Kani BMC Results (ck-kernel fast tier)"
+            echo ""
+            echo "- **Verification step outcome:** ${KANI_OUTCOME:-not run}"
+            echo "- **Per-harness results:** see the Run Kani step log."
+            echo "- **Solver:** CaDiCaL"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   # Constitutional Kernel (full): every harness, ONE JOB EACH.
   #
@@ -332,6 +337,7 @@ jobs:
           # upgrading Kani.
           key: kani-toolchain-${{ runner.os }}-kani-0.67.0
       - name: Run Kani (all harnesses)
+        id: verify
         uses: model-checking/kani-github-action@f838096619a707b0f6b2118cf435eaccfa33e51f # v1.1
         with:
           # Pin the verifier version for reproducible proofs (default is
@@ -344,19 +350,18 @@ jobs:
           # One census, counted by scripts/check-kani-proof-count.sh (#2561): the
           # inlined grep -rc on a DIRECTORY printed per-file lines, the arithmetic
           # errored, PROOF_COUNT was never set, and the gate passed on "".
-          PROOF_COUNT=$(scripts/check-kani-proof-count.sh --count)
-          MINIMUM=$(tr -d '[:space:]' < .kani-minimum-proofs)
           scripts/check-kani-proof-count.sh --strict
       - name: Summary
         if: always()
+        env:
+          KANI_OUTCOME: ${{ steps.verify.outcome }}
         run: |
-          # One census, counted by scripts/check-kani-proof-count.sh (#2561): the
-          # inlined grep -rc on a DIRECTORY printed per-file lines, the arithmetic
-          # errored, PROOF_COUNT was never set, and the gate passed on "".
-          PROOF_COUNT=$(scripts/check-kani-proof-count.sh --count)
-          MINIMUM=$(tr -d '[:space:]' < .kani-minimum-proofs)
-          echo "## Kani BMC Results (full suite)" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Harnesses verified:** $PROOF_COUNT / $PROOF_COUNT (all)" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Solver:** CaDiCaL" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Minimum required:** $MINIMUM" >> "$GITHUB_STEP_SUMMARY"
+          # Report the verifier step, even after failure or cancellation. A
+          # source census is not evidence that any harness actually verified.
+          {
+            echo "## Kani BMC Results (portcullis full tier)"
+            echo ""
+            echo "- **Verification step outcome:** ${KANI_OUTCOME:-not run}"
+            echo "- **Per-harness results:** see the Run Kani step log."
+            echo "- **Solver:** CaDiCaL"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/kani-nightly.yml
+++ b/.github/workflows/kani-nightly.yml
@@ -444,7 +444,7 @@ jobs:
           kani-version: "0.67.0"
           command: bash scripts/kani-bounded.sh
           args: >-
-            -p portcullis-core --solver cadical
+            -p portcullis-core --features envelope --solver cadical
             -Z unstable-options --harness-timeout 600s
             --harness ${{ matrix.harness }}
 

--- a/.github/workflows/kani-nightly.yml
+++ b/.github/workflows/kani-nightly.yml
@@ -7,6 +7,9 @@ on:
       - "crates/portcullis/src/**"
       - "crates/ck-*/src/**"
       - "crates/nucleus-ifc-kernel/src/**"
+      - "crates/portcullis-core/**"
+      - "crates/nucleus-econ-kernels/**"
+      - "scripts/kani-bounded.sh"
       - ".kani-minimum-proofs"
       - ".github/workflows/kani-nightly.yml"
   pull_request:
@@ -14,6 +17,9 @@ on:
       - "crates/portcullis/src/**"
       - "crates/ck-*/src/**"
       - "crates/nucleus-ifc-kernel/src/**"
+      - "crates/portcullis-core/**"
+      - "crates/nucleus-econ-kernels/**"
+      - "scripts/kani-bounded.sh"
       - ".kani-minimum-proofs"
       - ".github/workflows/kani-nightly.yml"
   # Bare, unfiltered: the merge queue's own re-validation of the fast-tier
@@ -365,3 +371,100 @@ jobs:
             echo "- **Per-harness results:** see the Run Kani step log."
             echo "- **Solver:** CaDiCaL"
           } >> "$GITHUB_STEP_SUMMARY"
+
+  kani-core-fast:
+    name: Kani (portcullis-core fast)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    if: github.event_name != 'schedule'
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
+        with:
+          path: ~/.kani
+          key: kani-toolchain-${{ runner.os }}-kani-0.67.0
+      - name: Verify named harnesses within memory and time budgets
+        uses: model-checking/kani-github-action@f838096619a707b0f6b2118cf435eaccfa33e51f # v1.1
+        with:
+          kani-version: "0.67.0"
+          command: bash scripts/kani-bounded.sh
+          args: >-
+            -p portcullis-core --solver cadical
+            -Z unstable-options --harness-timeout 120s
+            --harness proof_ifc_join_commutative
+            --harness proof_ifc_join_associative
+            --harness proof_ifc_join_idempotent
+            --harness proof_ifc_meet_commutative
+            --harness proof_ifc_meet_idempotent
+
+  kani-core-full:
+    name: "Core full: ${{ matrix.harness }}"
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix:
+        harness:
+          - proof_declassification_only_weakens_restrictions
+          - proof_delegation_chain_monotone
+          - proof_narrow_idempotent
+          - proof_narrow_monotone
+          - proof_ai_derived_never_verified_ready_without_witness
+          - proof_verified_lane_implies_witness_or_deterministic
+          - proof_verified_write_requires_witness
+          - proof_derivation_join_monotone
+          - proof_derivation_no_silent_cleansing
+          - proof_ifc_absorption_join_meet
+          - proof_ifc_absorption_meet_join
+          - proof_ifc_bottom_join_identity
+          - proof_ifc_join_associative
+          - proof_ifc_join_commutative
+          - proof_ifc_join_idempotent
+          - proof_ifc_leq_consistent_with_join
+          - proof_ifc_meet_associative
+          - proof_ifc_meet_commutative
+          - proof_ifc_meet_idempotent
+          - proof_ifc_top_meet_identity
+          - proof_directive_from_transitive_rejected
+          - proof_empty_capabilities_rejected
+          - proof_remote_unlabeled_rejected
+          - proof_safe_local_admitted
+          - proof_trusted_from_remote_rejected
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
+        with:
+          path: ~/.kani
+          key: kani-toolchain-${{ runner.os }}-kani-0.67.0
+      - name: Verify named harnesses within memory and time budgets
+        uses: model-checking/kani-github-action@f838096619a707b0f6b2118cf435eaccfa33e51f # v1.1
+        with:
+          kani-version: "0.67.0"
+          command: bash scripts/kani-bounded.sh
+          args: >-
+            -p portcullis-core --solver cadical
+            -Z unstable-options --harness-timeout 600s
+            --harness ${{ matrix.harness }}
+
+  kani-econ-full:
+    name: Kani (welfare sum overflow)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
+        with:
+          path: ~/.kani
+          key: kani-toolchain-${{ runner.os }}-kani-0.67.0
+      - name: Verify named harnesses within memory and time budgets
+        uses: model-checking/kani-github-action@f838096619a707b0f6b2118cf435eaccfa33e51f # v1.1
+        with:
+          kani-version: "0.67.0"
+          command: bash scripts/kani-bounded.sh
+          args: >-
+            -p nucleus-econ-kernels --solver cadical
+            -Z unstable-options --harness-timeout 600s
+            --harness welfare_sum_bounded

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13715,6 +13715,9 @@ dependencies = [
  "clap",
  "serde",
  "serde_json",
+ "serde_yaml",
+ "syn 2.0.117",
+ "toml 1.1.5+spec-1.1.0",
 ]
 
 [[package]]

--- a/KANI-STATUS.md
+++ b/KANI-STATUS.md
@@ -247,5 +247,9 @@ Local Kani 0.67.0 validation on macOS verified the five PR-lane lattice
 harnesses and `welfare_sum_bounded`. The full core run hit its shorter local
 120-second budget on delegation harnesses (`proof_narrow_idempotent`,
 `proof_delegation_chain_monotone`, and `proof_narrow_monotone`); these results
-are unverified, not passes. The Linux nightly shards use a 600-second budget
+are unverified, not passes. The completed core run reported 18 verified and
+5 timed-out harnesses out of 23 selected; the other timeouts were
+`proof_ifc_leq_consistent_with_join` and `proof_empty_capabilities_rejected`.
+The difference between scheduled source inventory and executable harnesses
+also needs investigation. The Linux nightly shards use a 600-second budget
 and still require execution evidence before #2581 can be considered resolved.

--- a/KANI-STATUS.md
+++ b/KANI-STATUS.md
@@ -250,6 +250,6 @@ harnesses and `welfare_sum_bounded`. The full core run hit its shorter local
 are unverified, not passes. The completed core run reported 18 verified and
 5 timed-out harnesses out of 23 selected; the other timeouts were
 `proof_ifc_leq_consistent_with_join` and `proof_empty_capabilities_rejected`.
-The difference between scheduled source inventory and executable harnesses
-also needs investigation. The Linux nightly shards use a 600-second budget
+The three remaining source harnesses are behind the `envelope` feature;
+the full nightly lane enables that feature explicitly. The Linux nightly shards use a 600-second budget
 and still require execution evidence before #2581 can be considered resolved.

--- a/KANI-STATUS.md
+++ b/KANI-STATUS.md
@@ -222,42 +222,30 @@ Until that lands, the honest claim is narrower than the one this file opened wit
 
 `cargo xtask kani-coverage` matches Rust proof attributes to the package and
 harness selectors in Kani action jobs, including the explicit nightly matrix.
-A package-wide lane covers its `src` harnesses; out-of-target proof files do
+A package-wide lane covers its `src` harnesses and explicit `#[path]` modules; unlinked proof files do
 not get coverage merely because the package is named. This static scheduling
 check does not establish compiler reachability, successful execution, or proof
 success. Those require the per-harness Kani logs. Disabled lanes do not count.
 
-The following missing lanes are explicit debt, not verified coverage. A newly
+Missing lanes must be recorded below as explicit debt, not verified coverage. A newly
 uncovered harness fails the gate unless it gets a lane or a named reason here;
 stale exceptions and exceptions for harnesses that now have lanes also fail.
 
 <!-- KANI-UNSCHEDULED:BEGIN -->
 | Harness | Why it is not scheduled |
 | --- | --- |
-| `crates/nucleus-econ-kernels/proofs/welfare_no_overflow.rs::welfare_sum_bounded` | No Cargo target or nightly lane yet; tracked in #2581. |
-| `crates/portcullis-core/src/declassify.rs::proof_declassification_only_weakens_restrictions` | No matching portcullis-core CI lane yet; tracked in #2581. |
-| `crates/portcullis-core/src/delegation.rs::proof_delegation_chain_monotone` | No matching portcullis-core CI lane yet; tracked in #2581. |
-| `crates/portcullis-core/src/delegation.rs::proof_narrow_idempotent` | No matching portcullis-core CI lane yet; tracked in #2581. |
-| `crates/portcullis-core/src/delegation.rs::proof_narrow_monotone` | No matching portcullis-core CI lane yet; tracked in #2581. |
-| `crates/portcullis-core/src/envelope.rs::proof_ai_derived_never_verified_ready_without_witness` | No matching portcullis-core CI lane yet; tracked in #2581. |
-| `crates/portcullis-core/src/envelope.rs::proof_verified_lane_implies_witness_or_deterministic` | No matching portcullis-core CI lane yet; tracked in #2581. |
-| `crates/portcullis-core/src/envelope.rs::proof_verified_write_requires_witness` | No matching portcullis-core CI lane yet; tracked in #2581. |
-| `crates/portcullis-core/src/lib.rs::proof_derivation_join_monotone` | No matching portcullis-core CI lane yet; tracked in #2581. |
-| `crates/portcullis-core/src/lib.rs::proof_derivation_no_silent_cleansing` | No matching portcullis-core CI lane yet; tracked in #2581. |
-| `crates/portcullis-core/src/lib.rs::proof_ifc_absorption_join_meet` | No matching portcullis-core CI lane yet; tracked in #2581. |
-| `crates/portcullis-core/src/lib.rs::proof_ifc_absorption_meet_join` | No matching portcullis-core CI lane yet; tracked in #2581. |
-| `crates/portcullis-core/src/lib.rs::proof_ifc_bottom_join_identity` | No matching portcullis-core CI lane yet; tracked in #2581. |
-| `crates/portcullis-core/src/lib.rs::proof_ifc_join_associative` | No matching portcullis-core CI lane yet; tracked in #2581. |
-| `crates/portcullis-core/src/lib.rs::proof_ifc_join_commutative` | No matching portcullis-core CI lane yet; tracked in #2581. |
-| `crates/portcullis-core/src/lib.rs::proof_ifc_join_idempotent` | No matching portcullis-core CI lane yet; tracked in #2581. |
-| `crates/portcullis-core/src/lib.rs::proof_ifc_leq_consistent_with_join` | No matching portcullis-core CI lane yet; tracked in #2581. |
-| `crates/portcullis-core/src/lib.rs::proof_ifc_meet_associative` | No matching portcullis-core CI lane yet; tracked in #2581. |
-| `crates/portcullis-core/src/lib.rs::proof_ifc_meet_commutative` | No matching portcullis-core CI lane yet; tracked in #2581. |
-| `crates/portcullis-core/src/lib.rs::proof_ifc_meet_idempotent` | No matching portcullis-core CI lane yet; tracked in #2581. |
-| `crates/portcullis-core/src/lib.rs::proof_ifc_top_meet_identity` | No matching portcullis-core CI lane yet; tracked in #2581. |
-| `crates/portcullis-core/src/manifest.rs::proof_directive_from_transitive_rejected` | No matching portcullis-core CI lane yet; tracked in #2581. |
-| `crates/portcullis-core/src/manifest.rs::proof_empty_capabilities_rejected` | No matching portcullis-core CI lane yet; tracked in #2581. |
-| `crates/portcullis-core/src/manifest.rs::proof_remote_unlabeled_rejected` | No matching portcullis-core CI lane yet; tracked in #2581. |
-| `crates/portcullis-core/src/manifest.rs::proof_safe_local_admitted` | No matching portcullis-core CI lane yet; tracked in #2581. |
-| `crates/portcullis-core/src/manifest.rs::proof_trusted_from_remote_rejected` | No matching portcullis-core CI lane yet; tracked in #2581. |
 <!-- KANI-UNSCHEDULED:END -->
+
+The previously unscheduled 25 portcullis-core harnesses now have individual
+nightly/manual shards, with five finite-domain lattice harnesses also selected
+on PRs and pushes. The welfare proof is already linked into the econ crate
+through `#[path]`; it now has a nightly/manual lane. Each new lane has a
+per-harness timeout and an 8 GiB virtual-memory cap. Scheduling these lanes
+is not evidence of a successful run; their logs establish that separately.
+
+Local Kani 0.67.0 validation on macOS verified the five PR-lane lattice
+harnesses and `welfare_sum_bounded`. The full core run hit its shorter local
+120-second budget on delegation harnesses (`proof_narrow_idempotent`,
+`proof_delegation_chain_monotone`, and `proof_narrow_monotone`); these results
+are unverified, not passes. The Linux nightly shards use a 600-second budget
+and still require execution evidence before #2581 can be considered resolved.

--- a/KANI-STATUS.md
+++ b/KANI-STATUS.md
@@ -257,3 +257,15 @@ and still require execution evidence before #2581 can be considered resolved.
 With `envelope` enabled, all three envelope harnesses verified locally with
 unwind bound 16 and unwinding assertions enabled. The explicit per-harness
 bound prevents unbounded expansion of recursive error cleanup.
+
+A follow-up local run verified `proof_empty_capabilities_rejected` with
+unwind bound 16 and unwinding assertions enabled; that bound is now attached
+to the harness. The three delegation harnesses and
+`proof_ifc_leq_consistent_with_join` still timed out at 120 seconds with that
+bound and remain unverified.
+
+The lattice-order harness also now verifies locally (0.17 seconds): its
+join-equality premise and forward checks omitted the derivation dimension,
+even though `IFCLabel::leq` includes it. Both directions now cover derivation
+without restricting the symbolic inputs. Only the three delegation timeouts
+remain from the local core run.

--- a/KANI-STATUS.md
+++ b/KANI-STATUS.md
@@ -253,3 +253,7 @@ are unverified, not passes. The completed core run reported 18 verified and
 The three remaining source harnesses are behind the `envelope` feature;
 the full nightly lane enables that feature explicitly. The Linux nightly shards use a 600-second budget
 and still require execution evidence before #2581 can be considered resolved.
+
+With `envelope` enabled, all three envelope harnesses verified locally with
+unwind bound 16 and unwinding assertions enabled. The explicit per-harness
+bound prevents unbounded expansion of recursive error cleanup.

--- a/KANI-STATUS.md
+++ b/KANI-STATUS.md
@@ -217,3 +217,47 @@ Until that lands, the honest claim is narrower than the one this file opened wit
 > Five harnesses verify, and they prove lattice arithmetic over bitmasks. Nothing that
 > touches the kernel's actual policy types has been verified, and the bridge between the
 > two representations is unverified too.
+
+## Named scheduling inventory
+
+`cargo xtask kani-coverage` matches Rust proof attributes to the package and
+harness selectors in Kani action jobs, including the explicit nightly matrix.
+A package-wide lane covers its `src` harnesses; out-of-target proof files do
+not get coverage merely because the package is named. This static scheduling
+check does not establish compiler reachability, successful execution, or proof
+success. Those require the per-harness Kani logs. Disabled lanes do not count.
+
+The following missing lanes are explicit debt, not verified coverage. A newly
+uncovered harness fails the gate unless it gets a lane or a named reason here;
+stale exceptions and exceptions for harnesses that now have lanes also fail.
+
+<!-- KANI-UNSCHEDULED:BEGIN -->
+| Harness | Why it is not scheduled |
+| --- | --- |
+| `crates/nucleus-econ-kernels/proofs/welfare_no_overflow.rs::welfare_sum_bounded` | No Cargo target or nightly lane yet; tracked in #2581. |
+| `crates/portcullis-core/src/declassify.rs::proof_declassification_only_weakens_restrictions` | No matching portcullis-core CI lane yet; tracked in #2581. |
+| `crates/portcullis-core/src/delegation.rs::proof_delegation_chain_monotone` | No matching portcullis-core CI lane yet; tracked in #2581. |
+| `crates/portcullis-core/src/delegation.rs::proof_narrow_idempotent` | No matching portcullis-core CI lane yet; tracked in #2581. |
+| `crates/portcullis-core/src/delegation.rs::proof_narrow_monotone` | No matching portcullis-core CI lane yet; tracked in #2581. |
+| `crates/portcullis-core/src/envelope.rs::proof_ai_derived_never_verified_ready_without_witness` | No matching portcullis-core CI lane yet; tracked in #2581. |
+| `crates/portcullis-core/src/envelope.rs::proof_verified_lane_implies_witness_or_deterministic` | No matching portcullis-core CI lane yet; tracked in #2581. |
+| `crates/portcullis-core/src/envelope.rs::proof_verified_write_requires_witness` | No matching portcullis-core CI lane yet; tracked in #2581. |
+| `crates/portcullis-core/src/lib.rs::proof_derivation_join_monotone` | No matching portcullis-core CI lane yet; tracked in #2581. |
+| `crates/portcullis-core/src/lib.rs::proof_derivation_no_silent_cleansing` | No matching portcullis-core CI lane yet; tracked in #2581. |
+| `crates/portcullis-core/src/lib.rs::proof_ifc_absorption_join_meet` | No matching portcullis-core CI lane yet; tracked in #2581. |
+| `crates/portcullis-core/src/lib.rs::proof_ifc_absorption_meet_join` | No matching portcullis-core CI lane yet; tracked in #2581. |
+| `crates/portcullis-core/src/lib.rs::proof_ifc_bottom_join_identity` | No matching portcullis-core CI lane yet; tracked in #2581. |
+| `crates/portcullis-core/src/lib.rs::proof_ifc_join_associative` | No matching portcullis-core CI lane yet; tracked in #2581. |
+| `crates/portcullis-core/src/lib.rs::proof_ifc_join_commutative` | No matching portcullis-core CI lane yet; tracked in #2581. |
+| `crates/portcullis-core/src/lib.rs::proof_ifc_join_idempotent` | No matching portcullis-core CI lane yet; tracked in #2581. |
+| `crates/portcullis-core/src/lib.rs::proof_ifc_leq_consistent_with_join` | No matching portcullis-core CI lane yet; tracked in #2581. |
+| `crates/portcullis-core/src/lib.rs::proof_ifc_meet_associative` | No matching portcullis-core CI lane yet; tracked in #2581. |
+| `crates/portcullis-core/src/lib.rs::proof_ifc_meet_commutative` | No matching portcullis-core CI lane yet; tracked in #2581. |
+| `crates/portcullis-core/src/lib.rs::proof_ifc_meet_idempotent` | No matching portcullis-core CI lane yet; tracked in #2581. |
+| `crates/portcullis-core/src/lib.rs::proof_ifc_top_meet_identity` | No matching portcullis-core CI lane yet; tracked in #2581. |
+| `crates/portcullis-core/src/manifest.rs::proof_directive_from_transitive_rejected` | No matching portcullis-core CI lane yet; tracked in #2581. |
+| `crates/portcullis-core/src/manifest.rs::proof_empty_capabilities_rejected` | No matching portcullis-core CI lane yet; tracked in #2581. |
+| `crates/portcullis-core/src/manifest.rs::proof_remote_unlabeled_rejected` | No matching portcullis-core CI lane yet; tracked in #2581. |
+| `crates/portcullis-core/src/manifest.rs::proof_safe_local_admitted` | No matching portcullis-core CI lane yet; tracked in #2581. |
+| `crates/portcullis-core/src/manifest.rs::proof_trusted_from_remote_rejected` | No matching portcullis-core CI lane yet; tracked in #2581. |
+<!-- KANI-UNSCHEDULED:END -->

--- a/crates/nucleus-econ-kernels/Cargo.toml
+++ b/crates/nucleus-econ-kernels/Cargo.toml
@@ -3,7 +3,8 @@ name = "nucleus-econ-kernels"
 license.workspace = true
 version.workspace = true
 edition.workspace = true
-rust-version.workspace = true
+# Kani 0.67 bundles rustc 1.93; this crate is in the welfare-proof dependency closure.
+rust-version = "1.93"
 authors.workspace = true
 repository.workspace = true
 description = "Integer-only economic kernels (VCG, Ring 0 budget, Lagrangian) lifted from sibling repos with per-file provenance comments. No f64 — see docs/ECON-PRECISION.md."

--- a/crates/nucleus-econ-types/Cargo.toml
+++ b/crates/nucleus-econ-types/Cargo.toml
@@ -3,7 +3,8 @@ name = "nucleus-econ-types"
 license.workspace = true
 version.workspace = true
 edition.workspace = true
-rust-version.workspace = true
+# Kani 0.67 bundles rustc 1.93; this crate is in the welfare-proof dependency closure.
+rust-version = "1.93"
 authors.workspace = true
 repository.workspace = true
 description = "Financially load-bearing newtypes (MicroUsd, AuctionId/AgentId/ProposalId) shared across the Nucleus economic surface. Zero-dependency beyond serde so every money/ID crate can depend on it without pulling in heavy transitive graphs. Wire shape is byte-identical to the bare primitive via serde(transparent)."

--- a/crates/nucleus-externality/Cargo.toml
+++ b/crates/nucleus-externality/Cargo.toml
@@ -3,7 +3,8 @@ name = "nucleus-externality"
 license.workspace = true
 version.workspace = true
 edition.workspace = true
-rust-version.workspace = true
+# Kani 0.67 bundles rustc 1.93; this crate is in the welfare-proof dependency closure.
+rust-version = "1.93"
 authors.workspace = true
 repository.workspace = true
 description = "Coproduct Pigouvian externality layer: signed externality envelopes, OLAP rollup cube, and rate-setter glue between nucleus-econ-kernels VCG clearing and the witness-federation rebate path. SOTA-inspired by arXiv 2106.06060 + 2601.03451 + 2305.01477; ZK/TEE oracle envelopes per Verifiable Carbon Accounting."

--- a/crates/nucleus-lineage/Cargo.toml
+++ b/crates/nucleus-lineage/Cargo.toml
@@ -2,7 +2,8 @@
 name = "nucleus-lineage"
 version.workspace = true
 edition.workspace = true
-rust-version.workspace = true
+# Kani 0.67 bundles rustc 1.93; this crate is in the welfare-proof dependency closure.
+rust-version = "1.93"
 license.workspace = true
 description = "Per-call SPIFFE-derived data lineage for nucleus tool calls"
 repository = "https://github.com/coproduct-opensource/nucleus"

--- a/crates/portcullis-core/src/envelope.rs
+++ b/crates/portcullis-core/src/envelope.rs
@@ -1281,6 +1281,7 @@ mod kani_witness_requirement_proofs {
     /// must NOT be verified-ready. Equivalently: the only derivation class
     /// that can pass `is_verified_ready()` without a witness is Deterministic.
     #[kani::proof]
+    #[kani::unwind(16)]
     #[kani::solver(cadical)]
     fn proof_verified_write_requires_witness() {
         let d = any_derivation();
@@ -1301,6 +1302,7 @@ mod kani_witness_requirement_proofs {
     /// always false when `witness_bundle_id` is None. This is a stronger
     /// statement than DPI-3a for the AI-tainted subset.
     #[kani::proof]
+    #[kani::unwind(16)]
     #[kani::solver(cadical)]
     fn proof_ai_derived_never_verified_ready_without_witness() {
         let v: u8 = kani::any();
@@ -1325,6 +1327,7 @@ mod kani_witness_requirement_proofs {
     /// class must be Deterministic. This ties the storage lane gate to the
     /// envelope verification gate.
     #[kani::proof]
+    #[kani::unwind(16)]
     #[kani::solver(cadical)]
     fn proof_verified_lane_implies_witness_or_deterministic() {
         let d = any_derivation();

--- a/crates/portcullis-core/src/lib.rs
+++ b/crates/portcullis-core/src/lib.rs
@@ -402,7 +402,7 @@ mod kani_ifc_label_proofs {
     /// **L11 — Lattice order is consistent with join.**
     ///
     /// Verifies the core lattice identity: a ≤ b ⟺ a ⊔ b = b,
-    /// restricted to the non-freshness dimensions (conf, integ, auth, prov).
+    /// restricted to the non-freshness dimensions (conf, integ, auth, prov, derivation).
     #[kani::proof]
     #[kani::solver(cadical)]
     fn proof_ifc_leq_consistent_with_join() {
@@ -434,6 +434,7 @@ mod kani_ifc_label_proofs {
             assert_eq!(join_ab.integrity, b.integrity);
             assert_eq!(join_ab.authority, b.authority);
             assert_eq!(join_ab.provenance.bits(), b.provenance.bits());
+            assert_eq!(join_ab.derivation, b.derivation);
         }
 
         // a ⊔ b = b → a ≤ b
@@ -441,6 +442,7 @@ mod kani_ifc_label_proofs {
             && join_ab.integrity == b.integrity
             && join_ab.authority == b.authority
             && join_ab.provenance.bits() == b.provenance.bits()
+            && join_ab.derivation == b.derivation
         {
             assert!(a.leq(b));
         }

--- a/crates/portcullis-core/src/manifest.rs
+++ b/crates/portcullis-core/src/manifest.rs
@@ -446,6 +446,7 @@ mod kani_proofs {
 
     /// **M1 — Empty capabilities always rejected.**
     #[kani::proof]
+    #[kani::unwind(16)]
     fn proof_empty_capabilities_rejected() {
         let manifest = ToolManifest {
             name: ToolName::new("test"),

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -22,3 +22,8 @@ ck-kernel = { path = "../ck-kernel" }
 ck-types = { path = "../ck-types" }
 # CI configuration invariants (`cargo xtask ci-spec`).
 ci-spec = { path = "../ci-spec" }
+
+# Parse the actual Rust attributes and workflow arguments for Kani coverage.
+syn = { version = "2", features = ["full", "visit"] }
+serde_yaml = { workspace = true }
+toml = { workspace = true }

--- a/crates/xtask/src/kani_coverage.rs
+++ b/crates/xtask/src/kani_coverage.rs
@@ -17,9 +17,22 @@ struct Harness {
 }
 
 #[derive(Default)]
-struct Proofs(Vec<String>);
+struct Proofs(Vec<String>, Vec<String>);
 
 impl<'ast> Visit<'ast> for Proofs {
+    fn visit_item_mod(&mut self, item: &'ast syn::ItemMod) {
+        for attr in &item.attrs {
+            if attr.path().is_ident("path")
+                && let syn::Meta::NameValue(value) = &attr.meta
+                && let syn::Expr::Lit(value) = &value.value
+                && let syn::Lit::Str(path) = &value.lit
+            {
+                self.1.push(path.value());
+            }
+        }
+        syn::visit::visit_item_mod(self, item);
+    }
+
     fn visit_item_fn(&mut self, item: &'ast syn::ItemFn) {
         if item.attrs.iter().any(|a| {
             let segments: Vec<_> = a
@@ -53,6 +66,7 @@ fn rust_files(path: &Path, files: &mut Vec<std::path::PathBuf>) -> Result<()> {
 
 fn sources(root: &Path) -> Result<Vec<Harness>> {
     let mut harnesses = Vec::new();
+    let mut linked_sources = BTreeSet::new();
     for entry in std::fs::read_dir(root.join("crates"))? {
         let path = entry?.path();
         if !path.join("Cargo.toml").exists() {
@@ -72,6 +86,14 @@ fn sources(root: &Path) -> Result<Vec<Harness>> {
                     .with_context(|| format!("parsing {}", file.display()))?;
                 let mut proofs = Proofs::default();
                 proofs.visit_file(&ast);
+                if directory == "src" {
+                    for linked in &proofs.1 {
+                        let linked = file.parent().context("source has no parent")?.join(linked);
+                        if linked.exists() {
+                            linked_sources.insert(linked.canonicalize()?);
+                        }
+                    }
+                }
                 for name in proofs.0 {
                     harnesses.push(Harness {
                         key: format!("{}::{name}", file.strip_prefix(root)?.display()),
@@ -82,6 +104,13 @@ fn sources(root: &Path) -> Result<Vec<Harness>> {
                 }
             }
         }
+    }
+    for harness in &mut harnesses {
+        let (file, _) = harness
+            .key
+            .rsplit_once("::")
+            .context("invalid harness key")?;
+        harness.source_target |= linked_sources.contains(&root.join(file).canonicalize()?);
     }
     harnesses.sort_by(|a, b| a.key.cmp(&b.key));
     if harnesses.is_empty() {
@@ -158,6 +187,14 @@ fn workflow_lanes(path: &str, workflow: &Value) -> Result<Vec<Lane>> {
                     .is_some_and(|s| s.starts_with("model-checking/kani-github-action@"))
             {
                 continue;
+            }
+            if let Some(command) = step["with"]["command"].as_str()
+                && !matches!(
+                    command,
+                    "cargo-kani" | "cargo kani" | "bash scripts/kani-bounded.sh"
+                )
+            {
+                bail!("{path}: unsupported Kani action command {command}");
             }
             let args = step["with"]["args"]
                 .as_str()
@@ -279,6 +316,10 @@ mod tests {
         let mut proofs = Proofs::default();
         proofs.visit_file(&file);
         assert_eq!(proofs.0, ["actual"]);
+        let file = syn::parse_file("#[cfg(kani)] #[path = \"../proofs/overflow.rs\"] mod proofs;")
+            .unwrap();
+        proofs.visit_file(&file);
+        assert_eq!(proofs.1, ["../proofs/overflow.rs"]);
     }
 
     #[test]
@@ -308,6 +349,9 @@ mod tests {
         let lanes = workflow_lanes("ci", &yaml).unwrap();
         assert_eq!(lanes.len(), 2);
         assert_eq!(lanes[1].selectors, ["proof_b"]);
+        let mut non_verifier = yaml.clone();
+        non_verifier["jobs"]["proof"]["steps"][0]["with"]["command"] = Value::String("echo".into());
+        assert!(workflow_lanes("ci", &non_verifier).is_err());
         let mut disabled_yaml = yaml;
         disabled_yaml["jobs"]["proof"]["if"] = Value::Bool(false);
         assert!(workflow_lanes("ci", &disabled_yaml).unwrap().is_empty());

--- a/crates/xtask/src/kani_coverage.rs
+++ b/crates/xtask/src/kani_coverage.rs
@@ -1,0 +1,316 @@
+//! Static Kani scheduling inventory. This does not claim proof success or
+//! compiler reachability; those still require Kani's per-harness results.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+
+use anyhow::{Context, Result, bail};
+use serde_yaml::Value;
+use syn::visit::Visit;
+
+#[derive(Debug)]
+struct Harness {
+    key: String,
+    package: String,
+    name: String,
+    source_target: bool,
+}
+
+#[derive(Default)]
+struct Proofs(Vec<String>);
+
+impl<'ast> Visit<'ast> for Proofs {
+    fn visit_item_fn(&mut self, item: &'ast syn::ItemFn) {
+        if item.attrs.iter().any(|a| {
+            let segments: Vec<_> = a
+                .path()
+                .segments
+                .iter()
+                .map(|s| s.ident.to_string())
+                .collect();
+            segments == ["kani", "proof"] || segments == ["kani", "proof_for_contract"]
+        }) {
+            self.0.push(item.sig.ident.to_string());
+        }
+        syn::visit::visit_item_fn(self, item);
+    }
+}
+
+fn rust_files(path: &Path, files: &mut Vec<std::path::PathBuf>) -> Result<()> {
+    if !path.exists() {
+        return Ok(());
+    }
+    for entry in std::fs::read_dir(path)? {
+        let entry = entry?;
+        if entry.file_type()?.is_dir() {
+            rust_files(&entry.path(), files)?;
+        } else if entry.path().extension().is_some_and(|e| e == "rs") {
+            files.push(entry.path());
+        }
+    }
+    Ok(())
+}
+
+fn sources(root: &Path) -> Result<Vec<Harness>> {
+    let mut harnesses = Vec::new();
+    for entry in std::fs::read_dir(root.join("crates"))? {
+        let path = entry?.path();
+        if !path.join("Cargo.toml").exists() {
+            continue;
+        }
+        let manifest: toml::Value =
+            toml::from_str(&std::fs::read_to_string(path.join("Cargo.toml"))?)?;
+        let package = manifest["package"]["name"]
+            .as_str()
+            .context("package name is not explicit")?;
+        for directory in ["src", "tests", "proofs", "examples", "benches"] {
+            let mut files = Vec::new();
+            rust_files(&path.join(directory), &mut files)?;
+            for file in files {
+                let source = std::fs::read_to_string(&file)?;
+                let ast = syn::parse_file(&source)
+                    .with_context(|| format!("parsing {}", file.display()))?;
+                let mut proofs = Proofs::default();
+                proofs.visit_file(&ast);
+                for name in proofs.0 {
+                    harnesses.push(Harness {
+                        key: format!("{}::{name}", file.strip_prefix(root)?.display()),
+                        package: package.to_string(),
+                        name,
+                        source_target: directory == "src",
+                    });
+                }
+            }
+        }
+    }
+    harnesses.sort_by(|a, b| a.key.cmp(&b.key));
+    if harnesses.is_empty() {
+        bail!("no Kani harnesses discovered; inventory would be vacuous");
+    }
+    Ok(harnesses)
+}
+
+#[derive(Debug)]
+struct Lane {
+    label: String,
+    package: String,
+    selectors: Vec<String>,
+}
+
+fn lane(label: &str, args: &str) -> Result<Lane> {
+    if args.contains("${{") || args.contains('$') {
+        bail!("{label}: unresolved Kani argument expression: {args}");
+    }
+    let mut words = args.split_whitespace();
+    let mut package = None;
+    let mut selectors = Vec::new();
+    while let Some(word) = words.next() {
+        let value = match word {
+            "-p" | "--package" | "--harness" => {
+                Some(words.next().context("missing Kani selector value")?)
+            }
+            _ => word.split_once('=').map(|(_, value)| value),
+        };
+        let flag = word.split('=').next().unwrap_or(word);
+        match flag {
+            "-p" | "--package" => {
+                if package.is_some() {
+                    bail!("{label}: multiple package selectors need explicit inventory support");
+                }
+                package = value.map(str::to_string);
+            }
+            "--harness" => selectors.push(value.context("missing harness selector")?.to_string()),
+            "--exclude" | "--workspace" => bail!("{label}: unsupported package selection {word}"),
+            _ => {}
+        }
+    }
+    Ok(Lane {
+        label: label.into(),
+        package: package
+            .with_context(|| format!("{label}: Kani lane needs an explicit package"))?,
+        selectors,
+    })
+}
+
+fn disabled(value: &Value) -> bool {
+    value["if"].as_bool() == Some(false)
+        || value["if"]
+            .as_str()
+            .is_some_and(|s| matches!(s.trim(), "false" | "${{ false }}"))
+}
+
+fn workflow_lanes(path: &str, workflow: &Value) -> Result<Vec<Lane>> {
+    let mut lanes = Vec::new();
+    let jobs = workflow["jobs"]
+        .as_mapping()
+        .context("workflow has no jobs")?;
+    for (id, job) in jobs {
+        if disabled(job) {
+            continue;
+        }
+        let Some(steps) = job["steps"].as_sequence() else {
+            continue;
+        };
+        for step in steps {
+            if disabled(step)
+                || !step["uses"]
+                    .as_str()
+                    .is_some_and(|s| s.starts_with("model-checking/kani-github-action@"))
+            {
+                continue;
+            }
+            let args = step["with"]["args"]
+                .as_str()
+                .context("Kani action has no args")?;
+            let label = format!("{path}::{}", id.as_str().context("job id is not text")?);
+            if args.contains("${{ matrix.harness }}") {
+                if !job["strategy"]["matrix"]["include"].is_null()
+                    || !job["strategy"]["matrix"]["exclude"].is_null()
+                {
+                    bail!("{label}: matrix include/exclude needs explicit inventory support");
+                }
+                let matrix = job["strategy"]["matrix"]["harness"]
+                    .as_sequence()
+                    .context("Kani harness matrix is not explicit")?;
+                for value in matrix {
+                    lanes.push(lane(
+                        &label,
+                        &args.replace(
+                            "${{ matrix.harness }}",
+                            value.as_str().context("matrix harness is not text")?,
+                        ),
+                    )?);
+                }
+            } else {
+                lanes.push(lane(&label, args)?);
+            }
+        }
+    }
+    Ok(lanes)
+}
+
+fn covers(lane: &Lane, harness: &Harness) -> bool {
+    harness.source_target
+        && lane.package == harness.package
+        && (lane.selectors.is_empty() || lane.selectors.iter().any(|s| s == &harness.name))
+}
+
+fn exceptions(text: &str) -> Result<BTreeMap<String, String>> {
+    let mut entries = BTreeMap::new();
+    let Some((_, tail)) = text.split_once("<!-- KANI-UNSCHEDULED:BEGIN -->") else {
+        return Ok(entries);
+    };
+    let (body, _) = tail
+        .split_once("<!-- KANI-UNSCHEDULED:END -->")
+        .context("unclosed Kani exception list")?;
+    for line in body.lines().filter(|l| l.starts_with("| `")) {
+        let columns: Vec<_> = line.split('|').map(str::trim).collect();
+        if columns.len() != 4 || columns[2].is_empty() {
+            bail!("exception needs a named harness and reason: {line}");
+        }
+        let key = columns[1].trim_matches('`').to_string();
+        if entries
+            .insert(key.clone(), columns[2].to_string())
+            .is_some()
+        {
+            bail!("duplicate exception: {key}");
+        }
+    }
+    Ok(entries)
+}
+
+pub fn check(root: &Path) -> Result<()> {
+    let harnesses = sources(root)?;
+    let mut lanes = Vec::new();
+    for entry in std::fs::read_dir(root.join(".github/workflows"))? {
+        let path = entry?.path();
+        if !path.extension().is_some_and(|s| s == "yml" || s == "yaml") {
+            continue;
+        }
+        let workflow: Value = serde_yaml::from_str(&std::fs::read_to_string(&path)?)?;
+        lanes.extend(workflow_lanes(
+            &path.strip_prefix(root)?.display().to_string(),
+            &workflow,
+        )?);
+    }
+    let exceptions = exceptions(&std::fs::read_to_string(root.join("KANI-STATUS.md"))?)?;
+    let keys: BTreeSet<_> = harnesses.iter().map(|h| h.key.as_str()).collect();
+    let mut errors = Vec::new();
+    for key in exceptions.keys() {
+        if !keys.contains(key.as_str()) {
+            errors.push(format!("stale exception: {key}"));
+        }
+    }
+    for harness in &harnesses {
+        let matching: Vec<_> = lanes.iter().filter(|l| covers(l, harness)).collect();
+        if matching.is_empty() {
+            if let Some(reason) = exceptions.get(&harness.key) {
+                println!("UNSCHEDULED {} — {reason}", harness.key);
+            } else {
+                errors.push(format!("uncovered harness: {}", harness.key));
+            }
+        } else if exceptions.contains_key(&harness.key) {
+            errors.push(format!("scheduled harness still excepted: {}", harness.key));
+        } else {
+            println!("scheduled {} — {}", harness.key, matching[0].label);
+        }
+    }
+    if !errors.is_empty() {
+        bail!("{}", errors.join("\n"));
+    }
+    println!(
+        "ok: {} named harnesses accounted for ({} explicitly unscheduled); scheduling is not verification",
+        harnesses.len(),
+        exceptions.len()
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn source_parser_ignores_strings_and_comments() {
+        let file = syn::parse_file(
+            "// #[kani::proof]\nconst S: &str = \"#[kani::proof]\"; #[kani::proof] fn actual() {} ",
+        )
+        .unwrap();
+        let mut proofs = Proofs::default();
+        proofs.visit_file(&file);
+        assert_eq!(proofs.0, ["actual"]);
+    }
+
+    #[test]
+    fn selection_is_package_bound_and_does_not_cover_orphan_proofs() {
+        let selected = lane("ci", "-p core --harness proof_a").unwrap();
+        let mut h = Harness {
+            key: "file::proof_a".into(),
+            name: "proof_a".into(),
+            package: "core".into(),
+            source_target: true,
+        };
+        assert!(covers(&selected, &h));
+        h.name = "new_unrun_proof".into();
+        assert!(!covers(&selected, &h));
+        let all = lane("nightly", "-p core").unwrap();
+        assert!(covers(&all, &h));
+        h.source_target = false;
+        assert!(!covers(&all, &h));
+        h.source_target = true;
+        h.package = "other".into();
+        assert!(!covers(&all, &h));
+    }
+
+    #[test]
+    fn matrix_entries_are_concrete_and_disabled_jobs_do_not_cover() {
+        let yaml: Value = serde_yaml::from_str("jobs:\n  proof:\n    strategy:\n      matrix:\n        harness: [proof_a, proof_b]\n    steps:\n      - uses: model-checking/kani-github-action@pin\n        with:\n          args: '-p core --harness ${{ matrix.harness }}'\n").unwrap();
+        let lanes = workflow_lanes("ci", &yaml).unwrap();
+        assert_eq!(lanes.len(), 2);
+        assert_eq!(lanes[1].selectors, ["proof_b"]);
+        let mut disabled_yaml = yaml;
+        disabled_yaml["jobs"]["proof"]["if"] = Value::Bool(false);
+        assert!(workflow_lanes("ci", &disabled_yaml).unwrap().is_empty());
+        assert!(lane("ci", "-p core --harness ${{ matrix.unknown }}").is_err());
+    }
+}

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -37,6 +37,8 @@ struct Cli {
 enum Command {
     /// Inventory repo shell scripts and flag which are xtask port candidates.
     Scripts,
+    /// Every source Kani harness must have a CI lane or a named documented exception.
+    KaniCoverage,
     /// Build every workspace crate in isolation (`cargo build -p <crate>`) to
     /// catch feature-unification-masked breakages — crates that compile in a
     /// full `--workspace` build but fail standalone (and on `cargo publish`)
@@ -176,6 +178,7 @@ enum CiSpecCmd {
 mod ci_otel;
 mod ci_spec;
 mod ci_timings;
+mod kani_coverage;
 mod rerun_plan;
 mod scoreboard;
 
@@ -190,6 +193,7 @@ fn main() -> Result<()> {
         } => policy_gate(&base, &candidate, changed_files.as_deref()),
         Command::RerunPlan => rerun_plan_cmd(),
         Command::CiTimings { sha, top, json } => ci_timings::ci_timings(sha, top, json),
+        Command::KaniCoverage => kani_coverage::check(&std::env::current_dir()?),
         Command::CiSpec { cmd } => match cmd {
             CiSpecCmd::Check { repo, json } => ci_spec::check(repo, json),
             CiSpecCmd::InlineGates { repo } => ci_spec::inline_gates(repo),

--- a/scripts/check-kani-proof-count.sh
+++ b/scripts/check-kani-proof-count.sh
@@ -67,6 +67,8 @@ case "$MODE" in
         exit 1
     fi
     echo "ok: $total Kani harnesses, census exact"
+    # A census alone cannot detect a harness that no CI job selects (#2580).
+    cargo run -q -p xtask -- kani-coverage
     ;;
   *) echo "usage: $0 --count|--strict|--report"; exit 2 ;;
 esac

--- a/scripts/kani-bounded.sh
+++ b/scripts/kani-bounded.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Linux CI wrapper: the Kani action installs the pinned toolchain, then
+# invokes this command with its args. The child verifier inherits this cap.
+set -euo pipefail
+ulimit -v 8388608 # 8 GiB per process; fail the shard instead of killing the host.
+exec cargo kani "$@"


### PR DESCRIPTION
Kani summaries previously printed fixed success counts regardless of verification outcome, while the source count included harnesses with no CI lane. Report the verification step outcome and gate all 118 named harnesses against workflow package/harness selectors, with explicit debt exceptions for missing lanes. Disabled lanes, unsupported commands, stale exceptions, and new unscheduled harnesses fail the gate.

Add five fast core proofs on PRs and bounded nightly/manual shards for the 25 core harnesses and welfare overflow proof. Recognize the welfare proof's existing `#[path]` module and declare Rust 1.93 compatibility for its four-crate dependency chain, guarded by the feature matrix. New lanes enforce per-harness timeouts and an 8 GiB Linux virtual-memory cap.

Closes #2580. Advances #2581; leave it open until full execution evidence is verified.

Validation: xtask tests and clippy, inventory mutation falsifiers, strict 118-proof gate, workflow actionlint and CI specification checks passed. Local Kani 0.67.0 verified all five fast proofs and welfare_sum_bounded. Rust 1.93 checked the economics dependency chain. The full local core run completed with 18 verified and five timeouts out of 23 selected: three delegation proofs, proof_ifc_leq_consistent_with_join, and proof_empty_capabilities_rejected. They remain unverified, and the executable/source inventory difference requires investigation. Nightly shards use 600 seconds. Linux wrapper execution and full CI results are pending.
