### PR TITLE
ci: bound formal jobs and move research builds to nightly

### DIFF
--- a/.github/workflows/kani-nightly.yml
+++ b/.github/workflows/kani-nightly.yml
@@ -280,6 +280,7 @@ jobs:
   # harnesses actually verified, so the nightly summary reports what was proved
   # rather than what was attempted.
   kani-constitutional-full-summary:
+    timeout-minutes: 5
     name: Kani (constitutional kernel full)
     runs-on: ubuntu-24.04
     needs: kani-constitutional-full

--- a/.github/workflows/research-lean-build.yml
+++ b/.github/workflows/research-lean-build.yml
@@ -7,9 +7,9 @@ name: research-lean-build
 # unnoticed, and the local build is too heavy to verify against (Mathlib closure
 # replay times out >900s). This workflow gives the keystone effort a real
 # verification path on the cloud's warm Mathlib cache:
-#   1. lake-builds the cluster libs — a proof attempt that fails to type-check
+#   1. Nightly/manual only: lake-builds the cluster libs — a proof attempt that fails to type-check
 #      FAILS here (the check the keystone loop needs).
-#   2. counts cluster `sorry`s and RATCHETS: must not exceed the committed
+#   2. Every PR/push and nightly/manual run: counts cluster `sorry`s and RATCHETS: must not exceed the committed
 #      baseline (.research-sorry-baseline). Closing a sorry lowers it (update the
 #      baseline down); a regression / new hole fails.
 
@@ -23,6 +23,8 @@ on:
     paths:
       - 'crates/portcullis-core/lean/**'
       - '.github/workflows/research-lean-build.yml'
+  schedule:
+    - cron: '43 3 * * *'
   workflow_dispatch:
 
 concurrency:
@@ -38,7 +40,9 @@ permissions:
 
 jobs:
   research-lean-build:
-    name: lake build + sorry-ratchet (research tier)
+    name: lake build (research tier)
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    timeout-minutes: 90
     runs-on: ${{ vars.CI_BUILD_RUNNER || vars.CI_RUNNER || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -90,6 +94,13 @@ jobs:
             PACVCBridge \
             UniversalityTheorem \
             CechCohomology
+
+  research-sorry-ratchet:
+    name: sorry-ratchet (research tier)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Sorry ratchet (must not exceed baseline)
         working-directory: crates/portcullis-core/lean

--- a/ci/inline-gates.txt
+++ b/ci/inline-gates.txt
@@ -94,7 +94,7 @@ quickstart-boot.yml::boot-a-real-pod::Delivery conformance (observed inventory v
 red-team-agent.yml::live-adversary::Anti-vacuity — the lane resolved to a known state (never silent-green) | UNCOVERED: no falsifier yet
 release.yml::dry-run-assert::Every build job must have succeeded | UNCOVERED: no falsifier yet
 release.yml::dry-run-assert::A rootfs image exists for every architecture | UNCOVERED: no falsifier yet
-research-lean-build.yml::research-lean-build::Sorry ratchet (must not exceed baseline) | UNCOVERED: no falsifier yet
+research-lean-build.yml::research-sorry-ratchet::Sorry ratchet (must not exceed baseline) | UNCOVERED: no falsifier yet
 rubric-lean.yml::rubric-lean::Ban sorry / admit / native_decide / sorryAx in rubric Lean | UNCOVERED: no falsifier yet
 scan.yml::scan::Scan example PodSpecs | UNCOVERED: no falsifier yet
 scan.yml::scan-action::Verify verdict | UNCOVERED: no falsifier yet


### PR DESCRIPTION
Research Lean changes previously launched a heavy build on every PR with GitHub’s default six-hour timeout. Run that build only nightly or by manual dispatch, capped at 90 minutes, and keep the cheap sorry ratchet in a separate five-minute job on PRs, pushes, and scheduled/manual runs. Add a five-minute timeout to the remaining unbounded Kani summary job and update the inline-gate ledger for the moved ratchet.

Closes #2568.

Validation: current research tree passes the ratchet; a planted proof-hole fixture fails it. Audited every job in Lean/Kani/Aeneas workflows for explicit timeouts. CI-spec invariants, actionlint schema/expression checks, and diff checks pass. Existing Kani summary shellcheck warnings are addressed separately in #2684; full CI is pending.
