### PR TITLE
ci: scope merge-group coverage to its actual diff

### DIFF
--- a/.github/workflows/coverage-matrix.yml
+++ b/.github/workflows/coverage-matrix.yml
@@ -28,8 +28,8 @@ permissions:
 jobs:
   # Detects which crates changed so the heavy coverage/mutation/proof jobs
   # below can skip on PRs with no crate-relevant changes (docs-only, etc).
-  # A skipped required job reports "skipped", which GitHub treats as a
-  # passing status check.
+  # Each required job reports one result: its no-op step for an irrelevant
+  # diff, or its real verification steps for relevant changes.
   changed-crates:
     name: Detect Changed Crates
     runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
@@ -49,6 +49,8 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           BASE: ${{ github.event.pull_request.base.ref }}
+          MERGE_BASE: ${{ github.event.merge_group.base_sha }}
+          MERGE_HEAD: ${{ github.event.merge_group.head_sha }}
         run: |
           set -euo pipefail
 
@@ -67,12 +69,16 @@ jobs:
             # required set so a red here blocks instead of vacating.
             git fetch origin "$BASE"
             changed="$(git diff --name-only "origin/$BASE...HEAD")"
+          elif [ "$EVENT_NAME" = "merge_group" ]; then
+            # Compare the exact synthetic group with its queue base. Missing
+            # refs fail this required detector; they must never skip coverage.
+            changed="$(git diff --name-only "${MERGE_BASE:?missing merge-group base}" "${MERGE_HEAD:?missing merge-group head}")"
           else
-            # merge_group / push / workflow_dispatch: run everything.
+            # push / workflow_dispatch / schedule: run everything.
             all=true
           fi
 
-          if [ "$all" != "true" ] && printf '%s\n' "$changed" | grep -qE '^(Cargo\.toml|Cargo\.lock)$|^\.github/'; then
+          if [ "$all" != "true" ] && printf '%s\n' "$changed" | grep -qE '^(Cargo\.toml|Cargo\.lock|rust-toolchain\.toml|\.kani-minimum-proofs|KANI-STATUS\.md)$|^(\.github|\.cargo|scripts)/'; then
             all=true
           fi
 
@@ -98,16 +104,23 @@ jobs:
     runs-on: ${{ vars.CI_BUILD_RUNNER || vars.CI_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 20
     needs: changed-crates
-    if: ${{ (needs.changed-crates.outputs.all == 'true' || needs.changed-crates.outputs.crates != '') && github.event.pull_request.draft != true }}
+    if: github.event.pull_request.draft != true
     steps:
+      - name: No-op twin (no relevant crate changes)
+        if: ${{ !(needs.changed-crates.outputs.all == 'true' || needs.changed-crates.outputs.crates != '') }}
+        run: echo "No crate or CI configuration changes in this diff."
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: ${{ needs.changed-crates.outputs.all == 'true' || needs.changed-crates.outputs.crates != '' }}
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
+        if: ${{ needs.changed-crates.outputs.all == 'true' || needs.changed-crates.outputs.crates != '' }}
         with:
           components: llvm-tools-preview
           cache: ${{ runner.environment == 'github-hosted' }}
       - name: Install cargo-llvm-cov (baked into the self-hosted image)
+        if: ${{ needs.changed-crates.outputs.all == 'true' || needs.changed-crates.outputs.crates != '' }}
         run: command -v cargo-llvm-cov >/dev/null || cargo install cargo-llvm-cov --locked
       - name: Workspace coverage (threshold gate)
+        if: ${{ needs.changed-crates.outputs.all == 'true' || needs.changed-crates.outputs.crates != '' }}
         # `shell: bash` gives `-eo pipefail`. GitHub's default `run` shell is
         # `bash -e {0}` WITHOUT pipefail, so `cargo llvm-cov ... | tee` reported
         # TEE's exit status: the --fail-under-lines threshold below could never
@@ -135,13 +148,14 @@ jobs:
             --fail-under-lines 83 \
             --ignore-filename-regex '(tests/|kani\.rs|main\.rs)' 2>&1 | tee /tmp/workspace-cov.txt
       - name: portcullis coverage (security-critical threshold)
+        if: ${{ needs.changed-crates.outputs.all == 'true' || needs.changed-crates.outputs.crates != '' }}
         shell: bash
         run: |
           cargo llvm-cov --all-features -p portcullis \
             --fail-under-lines 87 \
             --ignore-filename-regex '(tests/|kani\.rs)' 2>&1 | tee /tmp/portcullis-cov.txt
       - name: Generate JSON coverage report
-        if: always()
+        if: ${{ (needs.changed-crates.outputs.all == 'true' || needs.changed-crates.outputs.crates != '') && (always()) }}
         # `report` re-reads the profile the portcullis run above just wrote —
         # the previous `cargo llvm-cov -p portcullis --json` re-ran every
         # portcullis test a second time (2.5 min on the self-hosted pool) to
@@ -150,7 +164,7 @@ jobs:
           cargo llvm-cov report --json --output-path /tmp/portcullis-cov.json \
             --ignore-filename-regex '(tests/|kani\.rs)' || true
       - name: Coverage summary
-        if: always()
+        if: ${{ (needs.changed-crates.outputs.all == 'true' || needs.changed-crates.outputs.crates != '') && (always()) }}
         run: |
           echo "## Code Coverage Report" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
@@ -175,15 +189,21 @@ jobs:
     runs-on: ${{ vars.CI_BUILD_RUNNER || vars.CI_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 45
     needs: changed-crates
-    if: ${{ (needs.changed-crates.outputs.all == 'true' || needs.changed-crates.outputs.crates != '') && github.event.pull_request.draft != true }}
+    if: github.event.pull_request.draft != true
     steps:
+      - name: No-op twin (no relevant crate changes)
+        if: ${{ !(needs.changed-crates.outputs.all == 'true' || needs.changed-crates.outputs.crates != '') }}
+        run: echo "No crate or CI configuration changes in this diff."
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: ${{ needs.changed-crates.outputs.all == 'true' || needs.changed-crates.outputs.crates != '' }}
         with:
           fetch-depth: 0
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
+        if: ${{ needs.changed-crates.outputs.all == 'true' || needs.changed-crates.outputs.crates != '' }}
         with:
           cache: ${{ runner.environment == 'github-hosted' }}
       - name: Install cargo-mutants (baked into the self-hosted image when present)
+        if: ${{ needs.changed-crates.outputs.all == 'true' || needs.changed-crates.outputs.crates != '' }}
         run: command -v cargo-mutants >/dev/null || cargo install cargo-mutants --locked
       # A full run of the six modules is ~30 min of a gate runner and ran on
       # every rebase of every PR. On pull_request and merge_group only the
@@ -195,6 +215,7 @@ jobs:
       # took the whole group down with it (2026-09-06). push, the nightly
       # schedule and workflow_dispatch still run everything.
       - name: Scope to the diff of the change under review
+        if: ${{ needs.changed-crates.outputs.all == 'true' || needs.changed-crates.outputs.crates != '' }}
         id: mutscope
         env:
           EVENT_NAME: ${{ github.event_name }}
@@ -219,7 +240,7 @@ jobs:
           { echo "run=$run"; echo "in_diff=$in_diff"; } >> "$GITHUB_OUTPUT"
           echo "mutants: run=$run ${in_diff:+(diff-scoped)}"
       - name: Run mutation tests on security-critical modules
-        if: ${{ steps.mutscope.outputs.run == 'true' }}
+        if: ${{ (needs.changed-crates.outputs.all == 'true' || needs.changed-crates.outputs.crates != '') && (steps.mutscope.outputs.run == 'true') }}
         shell: bash
         env:
           IN_DIFF: ${{ steps.mutscope.outputs.in_diff }}
@@ -246,7 +267,7 @@ jobs:
             --output mutants-report 2>&1 | tee /tmp/mutants.txt || rc=$?
           echo "cargo mutants exit: $rc"
       - name: The gate reads the machine report, not the console (#2562)
-        if: ${{ always() && steps.mutscope.outputs.run == 'true' }}
+        if: ${{ (needs.changed-crates.outputs.all == 'true' || needs.changed-crates.outputs.crates != '') && (always() && steps.mutscope.outputs.run == 'true') }}
         shell: bash
         run: |
           # `Mutation Testing` passed runs whose log said "cargo build failed in
@@ -262,10 +283,10 @@ jobs:
             exit 1
           fi
       - name: The mutants gate goes red on a saved failure log and a survivor
-        if: always()
+        if: ${{ (needs.changed-crates.outputs.all == 'true' || needs.changed-crates.outputs.crates != '') && (always()) }}
         run: scripts/check-mutants-report.sh --self-test
       - name: Mutation summary
-        if: always()
+        if: ${{ (needs.changed-crates.outputs.all == 'true' || needs.changed-crates.outputs.crates != '') && (always()) }}
         shell: bash
         env:
           RUN: ${{ steps.mutscope.outputs.run }}
@@ -293,10 +314,14 @@ jobs:
     runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 5
     needs: changed-crates
-    if: ${{ needs.changed-crates.outputs.all == 'true' || needs.changed-crates.outputs.crates != '' }}
     steps:
+      - name: No-op twin (no relevant crate changes)
+        if: ${{ !(needs.changed-crates.outputs.all == 'true' || needs.changed-crates.outputs.crates != '') }}
+        run: echo "No crate or CI configuration changes in this diff."
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: ${{ needs.changed-crates.outputs.all == 'true' || needs.changed-crates.outputs.crates != '' }}
       - name: Count Kani proofs
+        if: ${{ needs.changed-crates.outputs.all == 'true' || needs.changed-crates.outputs.crates != '' }}
         id: kani-count
         run: |
           # One census, counted by scripts/check-kani-proof-count.sh (#2561): the
@@ -308,13 +333,14 @@ jobs:
           echo "minimum=$MINIMUM" >> "$GITHUB_OUTPUT"
           scripts/check-kani-proof-count.sh --strict
       - name: Count verification artifacts
+        if: ${{ needs.changed-crates.outputs.all == 'true' || needs.changed-crates.outputs.crates != '' }}
         id: counts
         run: |
           CONFORMANCE=$(grep -c 'proptest!' crates/portcullis/tests/verus_conformance.rs)
           echo "conformance=$CONFORMANCE" >> "$GITHUB_OUTPUT"
           echo "Conformance test suites: $CONFORMANCE"
       - name: Ratchet summary
-        if: always()
+        if: ${{ (needs.changed-crates.outputs.all == 'true' || needs.changed-crates.outputs.crates != '') && (always()) }}
         run: |
           echo "## Proof Count Ratchet" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Merge-group entries previously forced full coverage and mutation work, including documentation-only groups. Diff the synthetic group head against its base SHA; keep full runs for pushes, schedules, and manual dispatch. Crates, CI/toolchain configuration, scripts, and Kani inventory/ratchet changes remain relevant.

Each required coverage, mutation, and proof-count job keeps one status context and uses an explicit no-op step for irrelevant diffs. Real verification steps retain their existing failure behavior. Missing group SHAs fail the required detector instead of vacating its dependent checks.

Closes #2586.

Validation: temporary Git fixtures exercise docs-only and crate-changing groups, push/manual full runs, and missing-SHA failures. CI-spec invariants, actionlint schema/expression checks, and diff checks pass. Live merge-group validation remains pending.
