### PR TITLE
gatehouse: the shadow runs through the one-step action, identified by its OIDC token

### DIFF
--- a/.github/actions/gatehouse/README.md
+++ b/.github/actions/gatehouse/README.md
@@ -1,0 +1,47 @@
+# gatehouse, in one step
+
+```yaml
+permissions:
+  contents: read
+  id-token: write
+
+steps:
+  - uses: actions/checkout@v5
+  - uses: coproduct-opensource/nucleus/.github/actions/gatehouse@main
+    with:
+      run: cargo test --workspace
+```
+
+That runs the command the gatehouse way and reports, in the step summary:
+
+- the verdict (`held` / `failed`), from a run over the scope materialized from the commit
+  (nothing outside it exists), with the declared environment and the command's own timeout;
+- a receipt signed by a key this run alone holds, included in a hosted transparency log with
+  an inclusion proof, and **verified on this runner** against the tenant's trust;
+- whether the same command run plainly agreed (the shadow line), and the run attempt, so
+  re-runs and flips are counted per gate on the control plane.
+
+The run's identity is its GitHub OIDC token: no key, no secret, no prior account. The tenant
+is named after the repository. The step fails only when it could not look (no OIDC token, a
+refused exchange, a runner that errored, a receipt that could not be verified); a gate that
+does not hold is reported, never a red, until you make it required.
+
+| input | default | |
+|---|---|---|
+| `run` | required | the shell line to run |
+| `name` | the job id | the gate's name |
+| `scope` | `**` | newline-separated globs the command may read |
+| `timeout` | `3600` | seconds |
+| `env` | | `KEY=VALUE` lines the command sees (declared, hashed); `PATH`, `HOME`, and `RUSTUP_HOME`/`CARGO_HOME` when present are set |
+| `git-history` | `false` | let the command read git history |
+| `compare` | `true` | also run the command plainly and report agreement |
+| `control-url` | `https://gatehouse-controld.fly.dev` | the control plane |
+| `version` / `binaries` | `v0.1.0` / `coproduct-opensource/gatehouse-action` | the release the static binaries come from, checked against its `SHA256SUMS` |
+| `bin-dir` | | use `gate` and `gatehouse-runner` from this directory instead (a build from source) |
+
+Outputs: `verdict`, `verified`, `receipt_index`, `agree`, `tenant`.
+
+What it is not: the receipt is developer tier, and the party trusts the hosted log's checkpoint
+on first use. Installing the gatehouse App runs the gates in the service's own sandboxes at
+NodeAttested; `gate trust adopt` lets you hold your own witnessed checkpoint. Both are upgrades,
+neither is a prerequisite.

--- a/.github/actions/gatehouse/action.yml
+++ b/.github/actions/gatehouse/action.yml
@@ -1,0 +1,96 @@
+name: gatehouse
+description: >-
+  Run a CI command the gatehouse way: the scope materialized from the commit, the declared
+  environment, the command under its timeout, a receipt signed by a key this run alone holds,
+  included in a hosted transparency log with a proof, and verified on this runner. Informational
+  until you make it required; the step fails only when it could not look.
+author: coproduct
+branding:
+  icon: shield
+  color: green
+
+inputs:
+  run:
+    description: "The command to run (a shell line)."
+    required: true
+  name:
+    description: "The gate's name. Default: the job id."
+    required: false
+    default: ""
+  scope:
+    description: "Newline-separated globs of what the command may read (materialized from the commit; nothing else exists). Default `**`."
+    required: false
+    default: "**"
+  timeout:
+    description: "Seconds the command may take."
+    required: false
+    default: "3600"
+  env:
+    description: "Newline-separated KEY=VALUE lines the command sees (declared, hashed into the environment digest). PATH and HOME are always set; RUSTUP_HOME and CARGO_HOME are declared when present."
+    required: false
+    default: ""
+  git-history:
+    description: "Whether the command may read git history (keys the receipt on the commit, not the tree)."
+    required: false
+    default: "false"
+  compare:
+    description: "Also run the command plainly on this runner and report whether the two verdicts agree."
+    required: false
+    default: "true"
+  control-url:
+    description: "The gatehouse control plane."
+    required: false
+    default: "https://gatehouse-controld.fly.dev"
+  version:
+    description: "The gatehouse release to run (a tag of the binaries repository)."
+    required: false
+    default: "v0.1.0"
+  binaries:
+    description: "The public repository whose releases carry the binaries."
+    required: false
+    default: "coproduct-opensource/gatehouse-action"
+  bin-dir:
+    description: "A directory holding gate and gatehouse-runner already (a build from source); when set, nothing is downloaded."
+    required: false
+    default: ""
+
+outputs:
+  verdict:
+    description: "held | failed | errored"
+    value: ${{ steps.gate.outputs.verdict }}
+  verified:
+    description: "true when the receipt verified against the hosted log on this runner"
+    value: ${{ steps.gate.outputs.verified }}
+  receipt_index:
+    description: "The receipt's index in the tenant's log"
+    value: ${{ steps.gate.outputs.receipt_index }}
+  agree:
+    description: "true | false | skipped — whether the plain run agreed"
+    value: ${{ steps.gate.outputs.agree }}
+  tenant:
+    description: "The tenant the receipt landed in"
+    value: ${{ steps.gate.outputs.tenant }}
+
+runs:
+  using: composite
+  steps:
+    - id: gate
+      shell: bash
+      env:
+        GH_RUN: ${{ inputs.run }}
+        GH_NAME: ${{ inputs.name }}
+        GH_SCOPE: ${{ inputs.scope }}
+        GH_TIMEOUT: ${{ inputs.timeout }}
+        GH_ENV: ${{ inputs.env }}
+        GH_GIT_HISTORY: ${{ inputs.git-history }}
+        GH_COMPARE: ${{ inputs.compare }}
+        GH_CONTROL: ${{ inputs.control-url }}
+        GH_VERSION: ${{ inputs.version }}
+        GH_BINARIES: ${{ inputs.binaries }}
+        GH_BIN_DIR: ${{ inputs.bin-dir }}
+        GH_JOB: ${{ github.job }}
+        GH_PR: ${{ github.event.pull_request.number || 0 }}
+        GH_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        GH_RUN_ATTEMPT: ${{ github.run_attempt }}
+        GH_REPOSITORY: ${{ github.repository }}
+      run: bash "${{ github.action_path }}/gatehouse.sh"

--- a/.github/actions/gatehouse/gatehouse.sh
+++ b/.github/actions/gatehouse/gatehouse.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# The one step, in order: the binaries (checked against the release's SHA256SUMS), this run's
+# key, its OIDC token traded for a tenant and a credential, the gate definition from the
+# inputs, the runner, the receipt pushed to the hosted log and verified here against the
+# tenant's trust and the proof that came back, the plain run for comparison, the observation
+# posted, the summary. Exit 1 only when something could not be looked at; a gate that does not
+# hold, or disagrees with the plain run, is reported, never a red.
+set -euo pipefail
+
+say() { echo "gatehouse: $*"; }
+die() { echo "::error::gatehouse: $*"; exit 1; }
+out() { echo "$1=$2" >> "$GITHUB_OUTPUT"; }
+
+W="$(mktemp -d)"
+NAME="${GH_NAME:-$GH_JOB}"
+CONTROL="${GH_CONTROL%/}"
+
+# ── 1. The binaries, from the release the caller pinned, checked before anything runs ──────
+case "$(uname -m)" in
+  x86_64) TARGET=x86_64-unknown-linux-musl ;;
+  aarch64|arm64) TARGET=aarch64-unknown-linux-musl ;;
+  *) die "no gatehouse build for $(uname -m)" ;;
+esac
+BIN="$RUNNER_TEMP/gatehouse-$GH_VERSION/bin"
+if [ -n "${GH_BIN_DIR:-}" ]; then
+  BIN="$(cd "$GH_BIN_DIR" && pwd)"
+  [ -x "$BIN/gate" ] && [ -x "$BIN/gatehouse-runner" ] || die "bin-dir $BIN has no gate and gatehouse-runner"
+elif [ ! -x "$BIN/gate" ]; then
+  mkdir -p "$BIN"
+  BASE="https://github.com/$GH_BINARIES/releases/download/$GH_VERSION"
+  curl -sSfL --retry 3 -o "$W/tarball.tgz" "$BASE/gatehouse-$TARGET.tar.gz" || die "cannot fetch $BASE/gatehouse-$TARGET.tar.gz"
+  curl -sSfL --retry 3 -o "$W/SHA256SUMS" "$BASE/SHA256SUMS" || die "cannot fetch $BASE/SHA256SUMS"
+  WANT="$(grep " gatehouse-$TARGET.tar.gz\$" "$W/SHA256SUMS" | cut -d' ' -f1)"
+  [ -n "$WANT" ] || die "SHA256SUMS names no gatehouse-$TARGET.tar.gz"
+  HAVE="$(sha256sum "$W/tarball.tgz" | cut -d' ' -f1)"
+  [ "$WANT" = "$HAVE" ] || die "gatehouse-$TARGET.tar.gz does not match SHA256SUMS ($HAVE, want $WANT)"
+  tar -C "$BIN" -xzf "$W/tarball.tgz"
+fi
+GATE="$BIN/gate"; RUNNER="$BIN/gatehouse-runner"
+RUNNER_DIGEST="$(sha256sum "$RUNNER" | cut -d' ' -f1)"
+
+# ── 2. This run's key, and its identity: the OIDC token GitHub minted for this audience ────
+"$GATE" key new --out "$W/key.json" >/dev/null
+VK="$(jq -r .verifying_key_hex "$W/key.json")"; SK="$(jq -r .signing_key_hex "$W/key.json")"
+[ -n "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ] || die "no OIDC token: the job needs 'permissions: id-token: write'"
+ID_TOKEN="$(curl -sSf -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+  "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${CONTROL}" | jq -r .value)"
+[ -n "$ID_TOKEN" ] && [ "$ID_TOKEN" != null ] || die "the OIDC token request returned nothing"
+EXCHANGE="$(curl -sS --fail-with-body --max-time 30 -H 'content-type: application/json' -X POST \
+  --data "$(jq -cn --arg t "$ID_TOKEN" --arg vk "$VK" '{id_token: $t, verifying_key_hex: $vk}')" \
+  "$CONTROL/v1/github/oidc/credential")" || die "the control plane refused this run's token: $EXCHANGE"
+TENANT="$(jq -r .tenant <<<"$EXCHANGE")"; KID="$(jq -r .kid <<<"$EXCHANGE")"; BEARER="$(jq -r .bearer <<<"$EXCHANGE")"
+say "tenant $TENANT, key $KID (developer tier, trusted from log size $(jq -r .log.size <<<"$EXCHANGE"))"
+
+# ── 3. The gate, from the inputs: what it reads, what it sees, what it runs, how long ──────
+INCLUDE="$(printf '%s\n' "$GH_SCOPE" | sed '/^[[:space:]]*$/d' | jq -R . | jq -sc .)"
+ENVJ="$(printf '%s\n' "$GH_ENV" | sed '/^[[:space:]]*$/d' | jq -Rn '[inputs | capture("^(?<k>[^=]+)=(?<v>.*)$")] | from_entries')"
+for v in RUSTUP_HOME CARGO_HOME; do
+  if [ -n "${!v:-}" ]; then ENVJ="$(jq -c --arg k "$v" --arg val "${!v}" '. + {($k): $val}' <<<"$ENVJ")"; fi
+done
+# The environment digest names this runner's image, as a Developer-tier claim about where the
+# command ran; a hosted executor names an OCI image by digest instead.
+IMAGE="sha256:$(printf '%s' "${ImageOS:-unknown}/${ImageVersion:-unknown}" | sha256sum | cut -d' ' -f1)"
+TIMEOUT_MS=$(( GH_TIMEOUT * 1000 ))
+jq -n --argjson inc "$INCLUDE" --argjson env "$ENVJ" --arg img "$IMAGE" --arg run "$GH_RUN" \
+   --argjson t "$GH_TIMEOUT" --argjson tms "$TIMEOUT_MS" --argjson hist "$( [ "$GH_GIT_HISTORY" = true ] && echo true || echo false )" '
+  { scope: {include: $inc, exclude: [], external: [], git_history: $hist},
+    env: {image: $img, platform: "linux/amd64", toolchains: {}, env_vars: $env},
+    cap: {net: "none", fs_read: $inc, fs_write: ["**"], exec: "scoped", wall_ms: $tms, cpu_ms: $tms, mem_mb: 8192, secrets: []},
+    cmd: ["bash", "-c", $run], cwd: "", timeout_s: $t, outputs: [],
+    resources: {cpus: 2, mem_mb: 8192, disk_mb: 16384}, falsifier: null }' > "$W/gate.json"
+PLAN="$(printf 'p%.0s' $(seq 1 64))"
+jq -n --arg plan "$PLAN" --arg kid "$KID" --arg sk "$SK" --arg rd "$RUNNER_DIGEST" --arg repo "$GH_REPOSITORY" \
+  --slurpfile g "$W/gate.json" --arg gn "$NAME" \
+  '{repo: $repo, repo_path: ".", tree_spec: "HEAD", plan: $plan, gate_name: $gn, gate: $g[0], canary: null,
+    kid: $kid, signing_key_hex: $sk, substrate: "developer", credential_kind: "dev_credential",
+    credential_tier: "developer", runner_digest: $rd, binding: null}' > "$W/job.json"
+
+# ── 4. The runner: materialize, run, sign ──────────────────────────────────────────────────
+set +e; "$RUNNER" "$W/job.json" "$W/receipt.json"; RC=$?; set -e
+case "$RC" in 0) VERDICT=held ;; 1) VERDICT=failed ;; *) die "the runner errored (exit $RC): the gate could not be run" ;; esac
+say "gate $NAME: $VERDICT"
+
+# ── 5. The receipt into the hosted log, and verified here against the tenant's trust ───────
+PUSH="$(curl -sS --fail-with-body --max-time 30 -H 'content-type: application/json' -X POST \
+  --data @"$W/receipt.json" "$CONTROL/v1/$TENANT/receipts")" || die "the log refused the receipt: $PUSH"
+INDEX="$(jq -r .index <<<"$PUSH")"
+jq -c .inclusion <<<"$PUSH" > "$W/proof.json"
+curl -sSf --max-time 30 "$CONTROL/v1/$TENANT/trust" > "$W/trust.json"
+"$GATE" expect "$W/gate.json" --repo . --tree HEAD --class optional --plan "$PLAN" --out "$W/expect.json" >/dev/null
+set +e
+VOUT="$("$GATE" receipt verify "$W/receipt.json" --trust "$W/trust.json" --expect "$W/expect.json" --inclusion "$W/proof.json")"; VC=$?
+set -e
+case "$VC" in
+  0) VERIFIED=true; HELD=held ;;
+  1) VERIFIED=true; HELD=not-held ;;
+  *) die "could not verify the receipt against the log: $VOUT" ;;
+esac
+say "receipt $INDEX in $(jq -r .log.origin <<<"$EXCHANGE"): $VOUT"
+
+# ── 6. The plain run, for the agreement line ───────────────────────────────────────────────
+AGREE=skipped; GITHUB=unknown
+if [ "$GH_COMPARE" = true ]; then
+  set +e; bash -c "$GH_RUN" >/dev/null 2>&1; FC=$?; set -e
+  if [ "$FC" -eq 0 ]; then GITHUB=pass; else GITHUB=fail; fi
+  if { [ "$HELD" = held ] && [ "$GITHUB" = pass ]; } || { [ "$HELD" = not-held ] && [ "$GITHUB" = fail ]; }; then AGREE=true; else AGREE=false; fi
+fi
+
+# ── 7. The observation (informational; a failed post is a warning) ─────────────────────────
+if [ "$GITHUB" != unknown ]; then
+  BODY="$(jq -cn --argjson pr "$GH_PR" --arg head "$GH_HEAD_SHA" --arg gate "$NAME" --arg gh "$HELD" --arg github "$GITHUB" \
+    --argjson attempt "$GH_RUN_ATTEMPT" --argjson idx "$INDEX" \
+    '{pr: $pr, head_sha: $head, gate: $gate, gatehouse: $gh, github: $github, run_attempt: $attempt, receipt_index: $idx}')"
+  curl -sS --fail-with-body --max-time 20 -H 'content-type: application/json' -H "Authorization: Bearer $BEARER" \
+    -X POST --data "$BODY" "$CONTROL/v1/$TENANT/shadow" >/dev/null \
+    || echo "::warning::gatehouse: the observation could not be reported (informational)"
+fi
+
+# ── 8. Outputs and the summary ─────────────────────────────────────────────────────────────
+out verdict "$VERDICT"; out verified "$VERIFIED"; out receipt_index "$INDEX"; out agree "$AGREE"; out tenant "$TENANT"
+{
+  echo "### gatehouse: \`$NAME\` $VERDICT"
+  echo
+  echo "| | |"; echo "|---|---|"
+  echo "| receipt | \`$INDEX\` in \`$(jq -r .log.origin <<<"$EXCHANGE")\`, proof verified on this runner: **$VERIFIED** |"
+  echo "| signer | \`$KID\`, developer tier, this run's own key |"
+  [ "$AGREE" != skipped ] && echo "| plain run | $GITHUB, agree: **$AGREE** |"
+  echo "| attempt | $GH_RUN_ATTEMPT |"
+  echo
+  echo "Developer tier, trust on first use of the hosted log. Install the App for sandboxed runs at NodeAttested; adopt a witnessed checkpoint to hold your own trust."
+} >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/gatehouse-shadow.yml
+++ b/.github/workflows/gatehouse-shadow.yml
@@ -1,14 +1,16 @@
 # gatehouse shadow mode — INFORMATIONAL (not a required context).
 #
-# Runs this repository's CHEAP gates (.gatehouse/gates/{fmt,clippy,ci-spec}.json; test-core and
-# lean-build are defined there too but are not shadowed on the hosted runner yet — an hour of
-# tests and a Lean build are the executor's job) the gatehouse way on the hosted runner: the scope materialized from HEAD (nothing outside it exists in the sandbox), the
-# declared environment, the command under its timeout, a receipt signed by a developer credential,
-# pushed to a local log with an inclusion proof, and verified — then runs `cargo fmt --all --
-# --check` directly and prints whether the two agree. Seven days of agreement is the evidence the
-# gatehouse plan asks for before any gate becomes required (milestone 4 → 5). gatehouse is a
-# private repository, so the job runs only when the GATEHOUSE_TOKEN secret exists; without it the
-# job says so and passes. It never fails on disagreement — only when the loop itself errors.
+# Runs this repository's CHEAP gates (fmt, clippy, ci-spec; test-core and lean-build are defined
+# in .gatehouse/gates too but an hour of tests and a Lean build are the executor's job) through
+# the one-step gatehouse action (.github/actions/gatehouse): the scope materialized from HEAD,
+# the declared environment, the command under its timeout, a receipt signed by a key this run
+# alone holds, pushed to the hosted log and verified here against the tenant's trust and the
+# proof that came back, then the same command run plainly and the agreement line. The run's
+# identity is its OIDC token (no secret of ours); the binaries come from a gatehouse build in
+# this job while the public release does not exist yet (`bin-dir`), which is why the private
+# checkout and its token are still here. It never fails on disagreement — only when the loop
+# itself errors, which includes the control plane refusing the exchange (deploy it with
+# GATEHOUSE_ACTIONS_CA_KEY first; docs/ops/fly.md in gatehouse).
 name: gatehouse shadow
 
 on:
@@ -22,6 +24,7 @@ concurrency:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   shadow:
@@ -35,14 +38,36 @@ jobs:
           - gate: fmt
             github: cargo fmt --all -- --check
             components: rustfmt
+            scope: |
+              Cargo.toml
+              Cargo.lock
+              rust-toolchain.toml
+              crates/**
+              tests/**
+              benchmarks/**
           - gate: clippy
             github: cargo clippy --all-targets --all-features -- -D warnings
             components: clippy
+            scope: |
+              Cargo.toml
+              Cargo.lock
+              rust-toolchain.toml
+              crates/**
+              tests/**
+              benchmarks/**
           - gate: ci-spec
             github: scripts/check-ci-spec.sh
             components: rustfmt
+            scope: |
+              Cargo.toml
+              Cargo.lock
+              rust-toolchain.toml
+              .github/workflows/**
+              ci/**
+              crates/ci-spec/**
+              scripts/check-ci-spec.sh
     env:
-      GATEHOUSE_REF: cf8462d6c2999e31aefcc02db774923f940c2a17
+      GATEHOUSE_REF: 7326bfa9ea3f490c20bb406941527ac0484410c5
       GATE_NAME: ${{ matrix.gate }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -82,79 +107,27 @@ jobs:
       - name: Build gate and gatehouse-runner
         if: steps.tok.outputs.present == 'true'
         run: cargo build --locked --manifest-path gatehouse/Cargo.toml -p gate -p gatehouse-runner
-      - name: The gate, the gatehouse way
+      - name: The gate, the gatehouse way, verified against the hosted log
         if: steps.tok.outputs.present == 'true'
         id: gh
-        env:
-          GATE: gatehouse/target/debug/gate
-          RUNNER: gatehouse/target/debug/gatehouse-runner
-        run: |
-          set -euo pipefail
-          W="$(mktemp -d)"
-          CA_KEY="$(od -An -N32 -tx1 /dev/urandom | tr -d ' \n')"
-          "$GATE" login --dev --ca-key "$CA_KEY" --ca-kid dev-ca --subject shadow --out "$W/dev.json"
-          KID="$(jq -r .credential.body.kid "$W/dev.json")"; SK="$(jq -r .signing_key_hex "$W/dev.json")"
-          jq --arg rh "${RUSTUP_HOME:-$HOME/.rustup}" --arg ch "${CARGO_HOME:-$HOME/.cargo}" \
-            '.env.env_vars = {RUSTUP_HOME: $rh, CARGO_HOME: $ch}' ".gatehouse/gates/$GATE_NAME.json" > "$W/gate.json"
-          PLAN="$(printf 'p%.0s' $(seq 1 64))"
-          jq -n --arg plan "$PLAN" --arg kid "$KID" --arg sk "$SK" --arg rd "$(sha256sum "$RUNNER" | cut -d' ' -f1)" \
-            --slurpfile g "$W/gate.json" --arg gn "$GATE_NAME" \
-            '{repo: "coproduct-opensource/nucleus", repo_path: ".", tree_spec: "HEAD", plan: $plan, gate_name: $gn,
-              gate: $g[0], canary: null, kid: $kid, signing_key_hex: $sk, substrate: "developer",
-              credential_kind: "dev_credential", credential_tier: "developer", runner_digest: $rd, binding: null}' > "$W/job.json"
-          set +e
-          "$RUNNER" "$W/job.json" "$W/receipt.json"; RC=$?
-          set -e
-          echo "runner exit $RC (0 held, 1 failed, 2 errored)"
-          [ "$RC" -ne 2 ] || { echo "::error::the runner errored"; exit 1; }
-          "$GATE" receipt push "$W/receipt.json" --log "$W/log.json" --proof "$W/proof.json"
-          "$GATE" trust dev "$W/dev.json" --ca-key "$CA_KEY" --log "$W/log.json" --out "$W/trust.json"
-          "$GATE" expect "$W/gate.json" --repo . --tree HEAD --class optional --plan "$PLAN" --out "$W/expect.json"
-          set +e
-          OUT="$("$GATE" receipt verify "$W/receipt.json" --trust "$W/trust.json" --expect "$W/expect.json" --inclusion "$W/proof.json")"; VC=$?
-          set -e
-          echo "$OUT"
-          case "$VC" in 0) echo "held=HELD" >> "$GITHUB_OUTPUT";; 1) echo "held=not-held" >> "$GITHUB_OUTPUT";; *) echo "::error::verify could not look: $OUT"; exit 1;; esac
-      - name: The same check, the GitHub way, and the agreement line
+        uses: ./.github/actions/gatehouse
+        with:
+          run: ${{ matrix.github }}
+          name: ${{ matrix.gate }}
+          scope: ${{ matrix.scope }}
+          timeout: "2700"
+          bin-dir: gatehouse/target/debug
+          control-url: ${{ vars.GATEHOUSE_CONTROL_URL || 'https://gatehouse-controld.fly.dev' }}
+      - name: The agreement line
         if: steps.tok.outputs.present == 'true'
         env:
-          GH_HELD: ${{ steps.gh.outputs.held }}
-          GITHUB_WAY: ${{ matrix.github }}
+          GATE_NAME: ${{ matrix.gate }}
+          VERDICT: ${{ steps.gh.outputs.verdict }}
+          VERIFIED: ${{ steps.gh.outputs.verified }}
+          AGREE: ${{ steps.gh.outputs.agree }}
+          INDEX: ${{ steps.gh.outputs.receipt_index }}
+          TENANT: ${{ steps.gh.outputs.tenant }}
         run: |
-          set +e
-          bash -c "$GITHUB_WAY" >/dev/null 2>&1; FC=$?
-          set -e
-          if [ "$FC" -eq 0 ]; then GITHUB=pass; else GITHUB=fail; fi
-          if { [ "$GH_HELD" = HELD ] && [ "$GITHUB" = pass ]; } || { [ "$GH_HELD" = not-held ] && [ "$GITHUB" = fail ]; }; then AGREE=true; else AGREE=false; fi
-          LINE="shadow: gate=$GATE_NAME gatehouse=$GH_HELD github=$GITHUB agree=$AGREE"
+          LINE="shadow: gate=$GATE_NAME gatehouse=$VERDICT verified=$VERIFIED agree=$AGREE receipt=$INDEX tenant=$TENANT"
           echo "$LINE"
           echo "$LINE" >> "$GITHUB_STEP_SUMMARY"
-          echo "gh=$GH_HELD" >> "$GITHUB_OUTPUT"
-          echo "github=$GITHUB" >> "$GITHUB_OUTPUT"
-        id: agree
-      - name: Report the observation to the gatehouse control plane (only when one is named)
-        # docs (gatehouse) hard-cut.md §3: the shadow week is measured per gate by the control
-        # plane's shadow report; the verdict pair is posted here, agreement is computed there.
-        # GATEHOUSE_CONTROL_URL / GATEHOUSE_TENANT are repository VARIABLES (not secrets); the
-        # write routes on the control plane need the GATEHOUSE_AGENT_TOKEN SECRET. A failed
-        # post is a warning, never a red — nothing required depends on this job.
-        if: steps.tok.outputs.present == 'true' && vars.GATEHOUSE_CONTROL_URL != ''
-        env:
-          CONTROL_URL: ${{ vars.GATEHOUSE_CONTROL_URL }}
-          TENANT: ${{ vars.GATEHOUSE_TENANT || 'nucleus' }}
-          PR: ${{ github.event.pull_request.number || 0 }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-          GH_HELD: ${{ steps.agree.outputs.gh }}
-          GITHUB_VERDICT: ${{ steps.agree.outputs.github }}
-          AGENT_TOKEN: ${{ secrets.GATEHOUSE_AGENT_TOKEN }}
-        run: |
-          case "$GH_HELD" in HELD) GATEHOUSE=held;; *) GATEHOUSE=not-held;; esac
-          BODY="$(jq -cn --argjson pr "$PR" --arg head "$HEAD_SHA" --arg gate "$GATE_NAME" --arg gh "$GATEHOUSE" --arg github "$GITHUB_VERDICT" \
-            '{pr: $pr, head_sha: $head, gate: $gate, gatehouse: $gh, github: $github}')"
-          if curl -sS --fail-with-body --max-time 20 -H 'content-type: application/json' \
-               ${AGENT_TOKEN:+-H "Authorization: Bearer $AGENT_TOKEN"} \
-               -X POST --data "$BODY" "${CONTROL_URL%/}/v1/$TENANT/shadow"; then
-            echo "reported: $BODY"
-          else
-            echo "::warning::the shadow observation could not be reported to $CONTROL_URL (informational)"
-          fi


### PR DESCRIPTION
## What

`.github/actions/gatehouse` is the one step of gatehouse's self-service onboarding (rung 0): `run:` a command, get a receipt signed by a key the run alone holds, pushed to the hosted transparency log and verified on the runner against the tenant's trust and the proof that came back, plus the plain run and the agreement line, all in the step summary. The run's identity is its GitHub OIDC token, traded at the control plane's `POST /v1/github/oidc/credential` (gatehouse PR #13) for a tenant named after the repository, a developer credential and a one-hour bearer for the observation route. No secret of ours is involved.

```yaml
permissions: { contents: read, id-token: write }
steps:
  - uses: actions/checkout@v5
  - uses: coproduct-opensource/nucleus/.github/actions/gatehouse@main
    with:
      run: cargo test --workspace
```

The shadow workflow now uses it for `fmt`, `clippy` and `ci-spec`, each with its gate's scope, and prints the same `shadow:` line as before with the receipt index, the tenant and whether the proof verified. The private gatehouse checkout stays only to build the binaries (`bin-dir`) until the public release exists.

## Before merging

The control plane must be deployed from gatehouse PR #13 with `GATEHOUSE_ACTIONS_CA_KEY` set, or the exchange answers 503 and the shadow job is red (informational, but red). The pinned `GATEHOUSE_REF` is that PR's head.

## What it is and is not

Developer tier, trust on first use of the hosted log's checkpoint. Installing the App (rung 1) runs the gates in the service's own sandboxes at NodeAttested; `gate trust adopt` lets a repository hold its own witnessed checkpoint. Both are upgrades, neither a prerequisite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YyphycvXskbi2kKi9KjYY

---
_Generated by [Claude Code](https://claude.ai/code/session_019YyphycvXskbi2kKi9KjYY)_