### PR TITLE
docs: correct generated Lean counts and economics mirror provenance

### DIFF
--- a/crates/nucleus-econ-kernels/src/extracted/mod.rs
+++ b/crates/nucleus-econ-kernels/src/extracted/mod.rs
@@ -1,43 +1,21 @@
-//! Aeneas-extracted Rust mirrors of the Nucleus Lean specs.
+//! Hand-transcribed Rust mirrors of the Nucleus Lean specifications.
 //!
-//! These files hold Rust functions whose semantics are intended to be
-//! byte-identical to the corresponding Lean definitions in
-//! `formal/Nucleus/Auctions/*.lean`. The substrate's correctness story
-//! depends on this parity: the Lean theorems certify properties of the
-//! Lean definitions, and the parity tests in `tests/lean_model_parity.rs`
-//! turn that into a guarantee about the Rust functions the kernel
-//! actually executes.
+//! The corresponding Lean sources live in
+//! `crates/nucleus-econ-kernels/lean/Nucleus/` (including `Auctions/`).
+//! The historical `extracted` directory and `_aeneas` module names do not
+//! establish that these Rust implementations were generated or verified by
+//! Aeneas. There is no regeneration pipeline for this module today.
 //!
-//! # Current status (A4 wedge)
+//! `crates/nucleus-econ-kernels/tests/lean_model_parity.rs` compares the Rust
+//! implementations with independently written reference models on test inputs.
+//! These tests can detect disagreement; passing them is not a proof of
+//! equivalence to Lean or an exhaustive guarantee about production executions.
+//! Lean theorems establish properties of their Lean definitions only.
 //!
-//! Full Aeneas extraction (Charon → LLBC → Aeneas → Lean-extracted Rust
-//! mirror) lands in Month 8+. Until then this module holds **manually
-//! transcribed** mirrors whose shape is line-for-line faithful to the
-//! Lean source, so any divergence is greppable in code review and
-//! visibly caught by the parity proptests.
-//!
-//! When the full Aeneas pipeline goes live, the
-//! `coproduct-opensource/aeneas-ci@v1` reusable GHA performs a
-//! `git diff --exit-code` regen check that catches Rust↔Lean drift in
-//! CI. The CHARON/AENEAS pipeline reference is
-//! <https://github.com/AeneasVerif/aeneas>.
-//!
-//! # Aeneas subset discipline (AE.2)
-//!
-//! Every function in this module must stay inside the Rust subset Charon +
-//! Aeneas can translate, because `scripts/aeneas-extract.sh` extracts these
-//! roots to Lean (`formal/extracted/`). The subset, as of the pinned
-//! `nightly-2026.05.30` toolchain:
-//!   - integer ops only (saturating `u64`/`u128`), no floats;
-//!   - simple loops / structural recursion (recursion lowers to Lean
-//!     `partial_fixpoint`);
-//!   - NO closures, interior mutability, `unsafe`, concurrency, or advanced
-//!     generics (`for<'a>` nests).
-//!
-//! Extraction is scoped with `charon --start-from <root>` so the reachable
-//! subgraph never drags in non-subset dependency code (e.g. `hybrid-array`,
-//! `typenum`) — a whole-crate `charon cargo` would fail on those. If you add a
-//! root here, add a matching `--start-from` in `scripts/aeneas-extract.sh`.
+//! Keep model changes and parity tests together in review. A registry-backed
+//! hash pin for eligible leaf mirrors is planned in issue #2593; it is not an
+//! active drift gate. Future Aeneas extraction would translate Rust to Lean,
+//! with an explicit, reproducible regeneration check before claiming that link.
 
 pub mod commons_aeneas;
 pub mod pigou_aeneas;

--- a/scripts/lean-census.sh
+++ b/scripts/lean-census.sh
@@ -6,7 +6,7 @@
 #                             7500 sorries" overclaim came from counting these)
 #   .claude/                — transient git worktrees (working copies, not source)
 #   external/, vendor/      — vendored third-party Lean libraries
-#   generated/              — codegen output (reported separately, not as proofs)
+#   generated*/             — codegen output (reported separately, not as proofs)
 #
 # Run from a repo root: scripts/lean-census.sh
 # Purpose: give docs ONE honest source of truth for Lean counts. Any doc citing
@@ -17,10 +17,10 @@ set -uo pipefail
 EX=(--include='*.lean'
     --exclude-dir=.lake --exclude-dir=lake-packages
     --exclude-dir=.claude --exclude-dir=external
-    --exclude-dir=vendor --exclude-dir=generated)
+    --exclude-dir=vendor --exclude-dir='generated*')
 
 fp=$(grep -rlI '' "${EX[@]}" . 2>/dev/null | wc -l | tr -d ' ')
-gen=$(find . -path '*/generated/*' -name '*.lean' \
+gen=$(find . -path '*/generated*/*' -name '*.lean' \
         -not -path '*/.lake/*' -not -path '*/.claude/*' 2>/dev/null | wc -l | tr -d ' ')
 thm=$(grep -rhcE '^[[:space:]]*(theorem|lemma) ' "${EX[@]}" . 2>/dev/null | awk '{s+=$1} END{print s+0}')
 sf=$(grep -rlE '^[[:space:]]*sorry' "${EX[@]}" . 2>/dev/null | wc -l | tr -d ' ')


### PR DESCRIPTION
The Lean census treated `generated-*` directories as first-party sources while the economics mirror documentation described a nonexistent extraction pipeline. Exclude both generated directory forms and identify the economics implementations as hand-transcribed mirrors with parity tests, stating their verification limits and the planned registry drift alarm.

On the current tree, first-party files change from 171 to 147 and generated files from 13 to 37; theorems/lemmas remain 1,504. The existing `scripts/formal-numbers.sh` reference is valid now and remains unchanged.

Validation: fixture with authored, generated, generated-attenuation and vendored files; both repository census runs; documented paths resolve; shell syntax and diff checks pass. No runtime or theorem body changes.

Closes #2577. Closes #2578.
