### PR TITLE
ci-spec(I10): a job may not silently assume a tool its runner image provides

### DIFF
--- a/ci/image-dependent-jobs.txt
+++ b/ci/image-dependent-jobs.txt
@@ -1,0 +1,32 @@
+# I10 — jobs that route to a self-hosted runner AND install a tool only when hosted.
+#
+# Each line is a CONTRACT WITH THE RUNNER IMAGE: the job's `if: runner.environment ==
+# 'github-hosted'` step is skipped on the self-hosted fleet, so the image must already provide
+# what that step would have installed. Nothing in this repository can look inside the image, so
+# this file does not prove the contract holds — it makes the assumption visible, and makes adding
+# a new one a decision somebody takes rather than a thing that happens.
+#
+# Adding a line means: you checked ci/fly-runner/Dockerfile (the Fly pool) and
+# docker/Dockerfile.runner (the k3s set) and they provide the tool.
+#
+# Founding defects, 2026-09-09 — the same class three times in six hours, each repaired alone:
+#   lake: command not found          the worker image had no elan
+#   ENOSPC / ld signal 7             build machines had no volume, an 8 GB rootfs filled
+#   Scoped Aeneas, charon drift      the image had no aeneas/charon
+# gatehouse states this as A-10 and now enforces it at admission; nucleus is not a tenant yet.
+aeneas-certchain/aeneas-certchain
+aeneas-decide-pure/aeneas-decide-pure
+aeneas-ifc-scoped/aeneas-ifc-scoped
+aeneas-oidc-spiffe/aeneas-oidc-spiffe
+aeneas/aeneas-translate
+ci-spec-lean/ci-spec-lean
+ci/musl-check
+ci/workspace-tests
+ck-policy-aeneas/ck-policy-aeneas
+ck-policy-lean/ck-policy-lean
+deny/deny
+econ-lean/econ-lean
+ifc-lean/ifc-lean
+portcullis-core-proven-lean/portcullis-core-proven-lean
+research-lean-build/research-lean-build
+rubric-lean/rubric-lean

--- a/crates/ci-spec/src/invariants/mod.rs
+++ b/crates/ci-spec/src/invariants/mod.rs
@@ -8,6 +8,7 @@ pub mod gates;
 pub mod merge_group;
 pub mod producers;
 pub mod scope;
+pub mod self_hosted_tools;
 pub mod timeouts;
 pub mod twins;
 pub mod vacuity;

--- a/crates/ci-spec/src/invariants/self_hosted_tools.rs
+++ b/crates/ci-spec/src/invariants/self_hosted_tools.rs
@@ -1,0 +1,141 @@
+//! I10 — a job routed to a self-hosted runner may not silently assume a tool the image provides.
+//!
+//! The shape. A workflow installs a toolchain behind
+//! `if: runner.environment == 'github-hosted'`, because on the self-hosted fleet the image is
+//! supposed to bake it. That conditional is a CONTRACT WITH AN IMAGE, and nothing checks it: if
+//! the image does not have the tool, the step is skipped, the job runs anyway, and the command
+//! fails with `exit 127`. On a required context that is a `failed` verdict indistinguishable from
+//! the gate's own answer — it ejects the merge-queue entry and invalidates every group behind it.
+//!
+//! Founding defects, all on 2026-09-09, all the same class, found one at a time over six hours
+//! while the queue produced one merge:
+//!
+//! * `lake: command not found` — the new worker image had no elan, so five Lean lanes failed.
+//! * `ENOSPC` and `ld terminated with signal 7` — the same contract for a RESOURCE rather than a
+//!   binary: build machines without a volume, `cargo test --all-features` filling an 8 GB root
+//!   filesystem. Four required contexts failed at once because they relay one job.
+//! * `Scoped Aeneas`, `charon+aeneas drift` — the image had no aeneas/charon.
+//!
+//! Each was repaired on its own and the class recurred anyway, which is the argument for this
+//! file. gatehouse states the same property as A-10 ("in the declared environment") and now
+//! enforces it at admission for gates; nucleus's own CI is not a gatehouse tenant yet, so it
+//! needs its own.
+//!
+//! What is checked. The population of image-dependent jobs — routed to a self-hosted label AND
+//! carrying a hosted-only install step — is PINNED both ways in `ci/image-dependent-jobs.txt`. A
+//! new one is a finding, because somebody must confirm the runner image provides the tool before
+//! the job can rely on it; a stale entry is a finding too, so the file cannot rot into a list
+//! nobody reads. This does not prove the image has the tool — nothing in this repository can see
+//! inside the image — it makes the assumption VISIBLE and dated, which is what was missing.
+
+use std::collections::BTreeSet;
+
+use crate::model::Model;
+use crate::{Finding, Severity};
+
+use super::finding;
+
+/// Where the population lives, relative to the repository root.
+pub const INVENTORY: &str = "ci/image-dependent-jobs.txt";
+
+/// The routing variables that send a job to a self-hosted pool.
+const SELF_HOSTED_VARS: [&str; 3] = [
+    "vars.CI_RUNNER",
+    "vars.CI_BUILD_RUNNER",
+    "vars.ARM64_METAL_RUNNER",
+];
+
+/// The marker that says "the image is expected to have this".
+const HOSTED_ONLY: &str = "runner.environment == 'github-hosted'";
+
+fn routed_self_hosted(runs_on: &str) -> bool {
+    SELF_HOSTED_VARS.iter().any(|v| runs_on.contains(v))
+}
+
+/// A step that DOES something behind the hosted-only guard. A cache step is not a contract with
+/// the image — a cache miss costs time, not a verdict — so only steps that run a command or use
+/// an action that is not a cache count.
+fn is_install(step: &crate::model::Step) -> bool {
+    if step
+        .if_expr
+        .as_deref()
+        .is_none_or(|e| !e.contains(HOSTED_ONLY))
+    {
+        return false;
+    }
+    let name = step.name.to_ascii_lowercase();
+    !name.contains("cache")
+}
+
+/// `workflow/job` for every job that is routed to a self-hosted runner and carries a hosted-only
+/// install step.
+#[must_use]
+pub fn population(m: &Model) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    for w in &m.workflows {
+        for j in &w.jobs {
+            if routed_self_hosted(&j.runs_on) && j.steps.iter().any(is_install) {
+                let stem = std::path::Path::new(&w.path)
+                    .file_stem()
+                    .map_or_else(|| w.path.clone(), |s| s.to_string_lossy().into_owned());
+                out.insert(format!("{stem}/{}", j.id));
+            }
+        }
+    }
+    out
+}
+
+pub fn check(m: &Model) -> Vec<Finding> {
+    let mut out = Vec::new();
+    let live = population(m);
+    let pin = m.image_dependent_pinned.clone();
+
+    for job in live.difference(&pin) {
+        let (wf, id) = job.split_once('/').unwrap_or((job.as_str(), ""));
+        let (path, line) = m
+            .workflows
+            .iter()
+            .find(|w| w.path.contains(wf))
+            .and_then(|w| {
+                w.jobs
+                    .iter()
+                    .find(|j| j.id == id)
+                    .map(|j| (w.path.clone(), j.line))
+            })
+            .unwrap_or_else(|| (INVENTORY.to_string(), 0));
+        out.push(
+            finding(
+                "CI-I10-UNPINNED",
+                Severity::High,
+                &path,
+                line,
+                job,
+                "runs on a self-hosted label and installs a tool only when hosted, so it ASSUMES \
+                 the runner image provides that tool — and nothing here can see inside the image. \
+                 Unprovided, the step is skipped and the command fails with exit 127, which on a \
+                 required context ejects the merge-queue entry"
+                    .to_string(),
+                &format!(
+                    "confirm the runner image (ci/fly-runner/Dockerfile, docker/Dockerfile.runner) \
+                     provides it, then add `{job}` to {INVENTORY}"
+                ),
+            )
+            .in_job(id),
+        );
+    }
+
+    for job in pin.difference(&live) {
+        out.push(finding(
+            "CI-I10-STALE",
+            Severity::Info,
+            INVENTORY,
+            0,
+            job,
+            "pinned as image-dependent, but no such job routes to a self-hosted runner with a \
+             hosted-only install step any more"
+                .to_string(),
+            &format!("remove `{job}` from {INVENTORY}"),
+        ));
+    }
+    out
+}

--- a/crates/ci-spec/src/lib.rs
+++ b/crates/ci-spec/src/lib.rs
@@ -212,6 +212,7 @@ pub fn check(m: &model::Model) -> Report {
     findings.extend(invariants::gates::check(m));
     findings.extend(invariants::timeouts::check(m));
     findings.extend(invariants::wired::check(m));
+    findings.extend(invariants::self_hosted_tools::check(m));
 
     // Severity scoping. A gate inside a job that produces NO required context
     // cannot make a merge vacuous; its High/Medium findings are reported (so

--- a/crates/ci-spec/src/loader.rs
+++ b/crates/ci-spec/src/loader.rs
@@ -342,6 +342,27 @@ pub fn from_parts(
     allowlist: &str,
     gate_scripts: Vec<String>,
 ) -> Result<Model> {
+    from_parts_with_pins(
+        workflows,
+        ledger,
+        queue_toml,
+        inline_gates,
+        allowlist,
+        gate_scripts,
+        "",
+    )
+}
+
+/// [`from_parts`] with the I8 population pin, for tests that exercise it.
+pub fn from_parts_with_pins(
+    workflows: &[(String, String)],
+    ledger: &str,
+    queue_toml: &str,
+    inline_gates: &str,
+    allowlist: &str,
+    gate_scripts: Vec<String>,
+    image_dependent: &str,
+) -> Result<Model> {
     let mut wfs = Vec::new();
     for (p, t) in workflows {
         wfs.push(parse_workflow(p, t)?);
@@ -354,7 +375,17 @@ pub fn from_parts(
         inline_gates: parse_inline_gates(inline_gates),
         allowlist: parse_allowlist(allowlist),
         gate_scripts,
+        image_dependent_pinned: parse_pin_list(image_dependent),
     })
+}
+
+/// One entry per line; blanks and `#` comments ignored.
+fn parse_pin_list(text: &str) -> std::collections::BTreeSet<String> {
+    text.lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty() && !l.starts_with('#'))
+        .map(str::to_string)
+        .collect()
 }
 
 /// Build the model from a repository checkout.
@@ -383,6 +414,7 @@ pub fn from_repo(root: &Path) -> Result<Model> {
     let queue = read("ci/merge-queue.toml")?;
     let inline = read("ci/inline-gates.txt")?;
     let allow = read("ci/gate-integrity-allowlist.txt").unwrap_or_default();
+    let image_dependent = read("ci/image-dependent-jobs.txt").unwrap_or_default();
 
     let mut gate_scripts = Vec::new();
     for (dir, prefix) in [("scripts", "check-"), ("ci", "")] {
@@ -399,5 +431,13 @@ pub fn from_repo(root: &Path) -> Result<Model> {
         }
     }
     gate_scripts.sort();
-    from_parts(&workflows, &ledger, &queue, &inline, &allow, gate_scripts)
+    from_parts_with_pins(
+        &workflows,
+        &ledger,
+        &queue,
+        &inline,
+        &allow,
+        gate_scripts,
+        &image_dependent,
+    )
 }

--- a/crates/ci-spec/src/model.rs
+++ b/crates/ci-spec/src/model.rs
@@ -221,6 +221,10 @@ pub struct Model {
     pub allowlist: Allowlist,
     /// Repo-relative paths of every `scripts/check-*.sh` and `ci/*.sh` on disk.
     pub gate_scripts: Vec<String>,
+    /// The pinned population of image-dependent jobs (I10), from
+    /// `ci/image-dependent-jobs.txt`. Empty when the file is absent, which makes every such job
+    /// read as new — the right answer for a repository that has not pinned it.
+    pub image_dependent_pinned: std::collections::BTreeSet<String>,
 }
 
 impl Model {


### PR DESCRIPTION
Three outages today were the same class, found one at a time over six hours while the merge queue produced a single merge:

| symptom | cause |
|---|---|
| `lake: command not found` | the worker image had no elan |
| `ENOSPC`, `ld terminated with signal 7` | build machines had no volume; an 8 GB rootfs filled |
| `Scoped Aeneas`, `charon+aeneas drift` | the image had no aeneas/charon |

All three are one shape. A workflow installs a toolchain behind `if: runner.environment == 'github-hosted'` because the self-hosted image is supposed to bake it. **That conditional is a contract with an image, and nothing checked it.** When the image lacks the tool the step is skipped, the job runs anyway, and the command exits 127 — on a required context that is a `failed` verdict indistinguishable from the gate's own answer, so it ejects the merge-queue entry and invalidates every group behind it.

I10 pins the population of image-dependent jobs both ways in `ci/image-dependent-jobs.txt` — sixteen today, including every lane that failed. A new one is High; a stale entry is reported so the file cannot rot.

**What it does not do:** nothing here can look inside an image, so this does not prove the contract holds. It makes the assumption visible and makes adding one a decision rather than an accident. gatehouse states the same property as A-10 and now enforces it at admission; nucleus is not a tenant yet.

Non-vacuous in both directions: dropping `econ-lean/econ-lean` reports it UNPINNED by name; an invented entry reports STALE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JYc8hPky7z1FvG57wAaRMc