### PR TITLE
ci(fly): refuse an image that will not fit a Fly Machine, at build time

### DIFF
--- a/ci/fly-runner/Dockerfile
+++ b/ci/fly-runner/Dockerfile
@@ -120,4 +120,22 @@ RUN printf '#!/bin/sh\nexec cc -fuse-ld=lld "$@"\n' > /usr/local/bin/cc-lld && c
  && chown runner:runner /home/runner/.cargo/config.toml && cc-lld --version | head -1
 COPY --chmod=755 ci/fly-runner/entrypoint.sh /usr/local/bin/fly-runner
 COPY --chmod=755 ci/fly-runner/job-started.sh ci/fly-runner/job-completed.sh /usr/local/bin/
+
+# A Fly Machine rootfs is capped at 8 GB UNCOMPRESSED, and exceeding it is not a build error: the
+# push succeeds, and every machine that pulls the image logs "Not enough space to unpack image"
+# and sits in `starting` forever. The fleet then looks like a slow boot, not a failure — 24
+# machines wedged for 46 minutes the day this image grew past the cap. Registry size is no guide:
+# the image that broke it was 2.54 GB compressed and the one that boots is 1.78 GB.
+#
+# So measure the thing the cap is actually on, here, where it can still refuse. The budget leaves
+# room for the layers below this one and for the job's own scratch space.
+ARG ROOTFS_BUDGET_MB=7000
+RUN set -eux; \
+    used="$(du -sxm --exclude=/proc --exclude=/sys --exclude=/dev / | cut -f1)"; \
+    echo "rootfs: ${used} MB used of a ${ROOTFS_BUDGET_MB} MB budget (Fly caps the machine at 8192)"; \
+    if [ "$used" -gt "$ROOTFS_BUDGET_MB" ]; then \
+        echo "REFUSING: this image does not fit a Fly Machine. Trim it or move the weight to a volume." >&2; \
+        exit 1; \
+    fi
+
 ENTRYPOINT ["/usr/local/bin/fly-runner"]


### PR DESCRIPTION
Exceeding Fly's 8 GB **uncompressed** rootfs cap is not a build error. The push succeeds; every machine that pulls the image logs

```
Not enough space to unpack image, possibly exceeds maximum of 8GB uncompressed
```

and then sits in `starting` forever with no further events. The fleet reads as a slow boot rather than a failure, which is how 24 machines stayed wedged for 46 minutes with the pool down to two usable runners before anyone read a machine's log.

Registry size is no guide — measured on this app: **1.11 GB and 1.78 GB compressed boot; 2.54 GB compressed does not.** So this measures the thing the cap is actually on (`du -sxm /`) in the last layer, where the build can still refuse, with a 7000 MB budget leaving room for the job's own scratch.

Also fixes #2719's fate: the Charon/Aeneas image is what blew the cap, and with this in place that build would have failed instead of taking CI down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JYc8hPky7z1FvG57wAaRMc