### PR TITLE
ci(aeneas): install Charon and Aeneas on the machine's volume, not the rootfs

### DIFF
--- a/.github/workflows/aeneas-certchain.yml
+++ b/.github/workflows/aeneas-certchain.yml
@@ -103,14 +103,37 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
       - name: Add Aeneas to PATH
-        # Self-hosted: the runner image bakes the same release at /opt/aeneas
-        # (docker/Dockerfile.runner AENEAS_RELEASE) — no download, no cache.
+        # Self-hosted: use the baked copy when the image has one, and otherwise
+        # install to the machine's persistent volume.
         run: |
-          if [ -x /opt/aeneas/aeneas ] && [ "${{ runner.environment }}" != "github-hosted" ]; then
+          set -euo pipefail
+          if [ "${{ runner.environment }}" = "github-hosted" ]; then
+            echo "/tmp/aeneas-bin" >> "$GITHUB_PATH"
+          elif [ -x /opt/aeneas/aeneas ]; then
             echo "/opt/aeneas" >> "$GITHUB_PATH"
           else
-            echo "/tmp/aeneas-bin" >> "$GITHUB_PATH"
+            # Not baked, and on the Fly pool it cannot be: Charon + Aeneas do not
+            # fit under Fly's 8 GB uncompressed rootfs cap, which is why the
+            # image that tried took the pool down (#2719, #2721). The machine's
+            # 40 GB volume has room, so this downloads once per MACHINE rather
+            # than once per job, and falls back to scratch where there is no
+            # volume so the lane never depends on one existing.
+            dir="${AENEAS_CACHE:-/data/cache/aeneas}/$AENEAS_RELEASE"
+            mkdir -p "$dir" 2>/dev/null || dir="${RUNNER_TEMP:-/tmp}/aeneas/$AENEAS_RELEASE"
+            mkdir -p "$dir"
+            if [ ! -x "$dir/aeneas" ]; then
+              tmp="$(mktemp -d)"
+              gh release download "$AENEAS_RELEASE" \
+                --repo AeneasVerif/aeneas \
+                --pattern "aeneas-linux-$(uname -m).tar.gz" \
+                --dir "$tmp"
+              tar xzf "$tmp/aeneas-linux-$(uname -m).tar.gz" -C "$dir"
+              rm -rf "$tmp"
+            fi
+            echo "$dir" >> "$GITHUB_PATH"
           fi
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Verify tools
         run: |

--- a/.github/workflows/aeneas-decide-pure.yml
+++ b/.github/workflows/aeneas-decide-pure.yml
@@ -124,14 +124,37 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
       - name: Add Aeneas to PATH
-        # Self-hosted: the runner image bakes the same release at /opt/aeneas
-        # (docker/Dockerfile.runner AENEAS_RELEASE) — no download, no cache.
+        # Self-hosted: use the baked copy when the image has one, and otherwise
+        # install to the machine's persistent volume.
         run: |
-          if [ -x /opt/aeneas/aeneas ] && [ "${{ runner.environment }}" != "github-hosted" ]; then
+          set -euo pipefail
+          if [ "${{ runner.environment }}" = "github-hosted" ]; then
+            echo "/tmp/aeneas-bin" >> "$GITHUB_PATH"
+          elif [ -x /opt/aeneas/aeneas ]; then
             echo "/opt/aeneas" >> "$GITHUB_PATH"
           else
-            echo "/tmp/aeneas-bin" >> "$GITHUB_PATH"
+            # Not baked, and on the Fly pool it cannot be: Charon + Aeneas do not
+            # fit under Fly's 8 GB uncompressed rootfs cap, which is why the
+            # image that tried took the pool down (#2719, #2721). The machine's
+            # 40 GB volume has room, so this downloads once per MACHINE rather
+            # than once per job, and falls back to scratch where there is no
+            # volume so the lane never depends on one existing.
+            dir="${AENEAS_CACHE:-/data/cache/aeneas}/$AENEAS_RELEASE"
+            mkdir -p "$dir" 2>/dev/null || dir="${RUNNER_TEMP:-/tmp}/aeneas/$AENEAS_RELEASE"
+            mkdir -p "$dir"
+            if [ ! -x "$dir/aeneas" ]; then
+              tmp="$(mktemp -d)"
+              gh release download "$AENEAS_RELEASE" \
+                --repo AeneasVerif/aeneas \
+                --pattern "aeneas-linux-$(uname -m).tar.gz" \
+                --dir "$tmp"
+              tar xzf "$tmp/aeneas-linux-$(uname -m).tar.gz" -C "$dir"
+              rm -rf "$tmp"
+            fi
+            echo "$dir" >> "$GITHUB_PATH"
           fi
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Verify tools
         run: |

--- a/.github/workflows/aeneas-ifc-scoped.yml
+++ b/.github/workflows/aeneas-ifc-scoped.yml
@@ -169,13 +169,37 @@ jobs:
 
       - name: Add Aeneas to PATH
         if: steps.scope.outputs.relevant == 'true'
-        # Self-hosted: the runner image bakes the same release at /opt/aeneas.
+        # Self-hosted: use the baked copy when the image has one, and otherwise
+        # install to the machine's persistent volume.
         run: |
-          if [ -x /opt/aeneas/aeneas ] && [ "${{ runner.environment }}" != "github-hosted" ]; then
+          set -euo pipefail
+          if [ "${{ runner.environment }}" = "github-hosted" ]; then
+            echo "/tmp/aeneas-bin" >> "$GITHUB_PATH"
+          elif [ -x /opt/aeneas/aeneas ]; then
             echo "/opt/aeneas" >> "$GITHUB_PATH"
           else
-            echo "/tmp/aeneas-bin" >> "$GITHUB_PATH"
+            # Not baked, and on the Fly pool it cannot be: Charon + Aeneas do not
+            # fit under Fly's 8 GB uncompressed rootfs cap, which is why the
+            # image that tried took the pool down (#2719, #2721). The machine's
+            # 40 GB volume has room, so this downloads once per MACHINE rather
+            # than once per job, and falls back to scratch where there is no
+            # volume so the lane never depends on one existing.
+            dir="${AENEAS_CACHE:-/data/cache/aeneas}/$AENEAS_RELEASE"
+            mkdir -p "$dir" 2>/dev/null || dir="${RUNNER_TEMP:-/tmp}/aeneas/$AENEAS_RELEASE"
+            mkdir -p "$dir"
+            if [ ! -x "$dir/aeneas" ]; then
+              tmp="$(mktemp -d)"
+              gh release download "$AENEAS_RELEASE" \
+                --repo AeneasVerif/aeneas \
+                --pattern "aeneas-linux-$(uname -m).tar.gz" \
+                --dir "$tmp"
+              tar xzf "$tmp/aeneas-linux-$(uname -m).tar.gz" -C "$dir"
+              rm -rf "$tmp"
+            fi
+            echo "$dir" >> "$GITHUB_PATH"
           fi
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Verify tools
         if: steps.scope.outputs.relevant == 'true'

--- a/.github/workflows/aeneas-oidc-spiffe.yml
+++ b/.github/workflows/aeneas-oidc-spiffe.yml
@@ -144,13 +144,37 @@ jobs:
 
       - name: Add Aeneas to PATH
         if: steps.scope.outputs.relevant == 'true'
-        # Self-hosted: the runner image bakes the same release at /opt/aeneas.
+        # Self-hosted: use the baked copy when the image has one, and otherwise
+        # install to the machine's persistent volume.
         run: |
-          if [ -x /opt/aeneas/aeneas ] && [ "${{ runner.environment }}" != "github-hosted" ]; then
+          set -euo pipefail
+          if [ "${{ runner.environment }}" = "github-hosted" ]; then
+            echo "/tmp/aeneas-bin" >> "$GITHUB_PATH"
+          elif [ -x /opt/aeneas/aeneas ]; then
             echo "/opt/aeneas" >> "$GITHUB_PATH"
           else
-            echo "/tmp/aeneas-bin" >> "$GITHUB_PATH"
+            # Not baked, and on the Fly pool it cannot be: Charon + Aeneas do not
+            # fit under Fly's 8 GB uncompressed rootfs cap, which is why the
+            # image that tried took the pool down (#2719, #2721). The machine's
+            # 40 GB volume has room, so this downloads once per MACHINE rather
+            # than once per job, and falls back to scratch where there is no
+            # volume so the lane never depends on one existing.
+            dir="${AENEAS_CACHE:-/data/cache/aeneas}/$AENEAS_RELEASE"
+            mkdir -p "$dir" 2>/dev/null || dir="${RUNNER_TEMP:-/tmp}/aeneas/$AENEAS_RELEASE"
+            mkdir -p "$dir"
+            if [ ! -x "$dir/aeneas" ]; then
+              tmp="$(mktemp -d)"
+              gh release download "$AENEAS_RELEASE" \
+                --repo AeneasVerif/aeneas \
+                --pattern "aeneas-linux-$(uname -m).tar.gz" \
+                --dir "$tmp"
+              tar xzf "$tmp/aeneas-linux-$(uname -m).tar.gz" -C "$dir"
+              rm -rf "$tmp"
+            fi
+            echo "$dir" >> "$GITHUB_PATH"
           fi
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Verify tools
         if: steps.scope.outputs.relevant == 'true'

--- a/.github/workflows/aeneas.yml
+++ b/.github/workflows/aeneas.yml
@@ -95,14 +95,37 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
       - name: Add Aeneas to PATH
-        # Self-hosted: the runner image bakes the same release at /opt/aeneas
-        # (docker/Dockerfile.runner AENEAS_RELEASE) — no download, no cache.
+        # Self-hosted: use the baked copy when the image has one, and otherwise
+        # install to the machine's persistent volume.
         run: |
-          if [ -x /opt/aeneas/aeneas ] && [ "${{ runner.environment }}" != "github-hosted" ]; then
+          set -euo pipefail
+          if [ "${{ runner.environment }}" = "github-hosted" ]; then
+            echo "/tmp/aeneas-bin" >> "$GITHUB_PATH"
+          elif [ -x /opt/aeneas/aeneas ]; then
             echo "/opt/aeneas" >> "$GITHUB_PATH"
           else
-            echo "/tmp/aeneas-bin" >> "$GITHUB_PATH"
+            # Not baked, and on the Fly pool it cannot be: Charon + Aeneas do not
+            # fit under Fly's 8 GB uncompressed rootfs cap, which is why the
+            # image that tried took the pool down (#2719, #2721). The machine's
+            # 40 GB volume has room, so this downloads once per MACHINE rather
+            # than once per job, and falls back to scratch where there is no
+            # volume so the lane never depends on one existing.
+            dir="${AENEAS_CACHE:-/data/cache/aeneas}/$AENEAS_RELEASE"
+            mkdir -p "$dir" 2>/dev/null || dir="${RUNNER_TEMP:-/tmp}/aeneas/$AENEAS_RELEASE"
+            mkdir -p "$dir"
+            if [ ! -x "$dir/aeneas" ]; then
+              tmp="$(mktemp -d)"
+              gh release download "$AENEAS_RELEASE" \
+                --repo AeneasVerif/aeneas \
+                --pattern "aeneas-linux-$(uname -m).tar.gz" \
+                --dir "$tmp"
+              tar xzf "$tmp/aeneas-linux-$(uname -m).tar.gz" -C "$dir"
+              rm -rf "$tmp"
+            fi
+            echo "$dir" >> "$GITHUB_PATH"
           fi
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Verify tools
         run: |

--- a/.github/workflows/ck-policy-aeneas.yml
+++ b/.github/workflows/ck-policy-aeneas.yml
@@ -145,14 +145,37 @@ jobs:
 
       - name: Add Aeneas to PATH
         if: steps.scope.outputs.relevant == 'true'
-        # Self-hosted: the runner image bakes the same release at /opt/aeneas
-        # (docker/Dockerfile.runner AENEAS_RELEASE) — no download, no cache.
+        # Self-hosted: use the baked copy when the image has one, and otherwise
+        # install to the machine's persistent volume.
         run: |
-          if [ -x /opt/aeneas/aeneas ] && [ "${{ runner.environment }}" != "github-hosted" ]; then
+          set -euo pipefail
+          if [ "${{ runner.environment }}" = "github-hosted" ]; then
+            echo "/tmp/aeneas-bin" >> "$GITHUB_PATH"
+          elif [ -x /opt/aeneas/aeneas ]; then
             echo "/opt/aeneas" >> "$GITHUB_PATH"
           else
-            echo "/tmp/aeneas-bin" >> "$GITHUB_PATH"
+            # Not baked, and on the Fly pool it cannot be: Charon + Aeneas do not
+            # fit under Fly's 8 GB uncompressed rootfs cap, which is why the
+            # image that tried took the pool down (#2719, #2721). The machine's
+            # 40 GB volume has room, so this downloads once per MACHINE rather
+            # than once per job, and falls back to scratch where there is no
+            # volume so the lane never depends on one existing.
+            dir="${AENEAS_CACHE:-/data/cache/aeneas}/$AENEAS_RELEASE"
+            mkdir -p "$dir" 2>/dev/null || dir="${RUNNER_TEMP:-/tmp}/aeneas/$AENEAS_RELEASE"
+            mkdir -p "$dir"
+            if [ ! -x "$dir/aeneas" ]; then
+              tmp="$(mktemp -d)"
+              gh release download "$AENEAS_RELEASE" \
+                --repo AeneasVerif/aeneas \
+                --pattern "aeneas-linux-$(uname -m).tar.gz" \
+                --dir "$tmp"
+              tar xzf "$tmp/aeneas-linux-$(uname -m).tar.gz" -C "$dir"
+              rm -rf "$tmp"
+            fi
+            echo "$dir" >> "$GITHUB_PATH"
           fi
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Verify tools
         if: steps.scope.outputs.relevant == 'true'


### PR DESCRIPTION
Every Aeneas lane guards its install with `runner.environment == 'github-hosted'` and expects a self-hosted image to have the tools baked at `/opt/aeneas`. **The Fly image cannot bake them.** Charon + Aeneas do not fit under Fly's 8 GB uncompressed rootfs cap — the image that tried (#2719) wedged 24 machines in `starting` and took CI down to two runners. Measured on a live runner: `/` is 3.4 GB used of 7.8 GB.

But each build machine already carries a **40 GB volume with 36 GB free**, `/data/cache` owned by `runner`. So on a self-hosted runner with no baked copy the release is downloaded to `/data/cache/aeneas/<release>` — **once per machine, not once per job** — and falls back to `RUNNER_TEMP` where there is no volume, so the lane never depends on one existing. The github-hosted path and the baked-image path are untouched.

Unblocks the Aeneas lanes on #2690 and makes #2719 unnecessary.

This is the **fifth** instance of one class: a workflow installs a tool only when `runner.environment == 'github-hosted'`, and the self-hosted image silently lacks it (elan/`lake`, a missing disk, aeneas twice, and this). #2718 makes the class detectable rather than rediscovered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JYc8hPky7z1FvG57wAaRMc