### PR TITLE
test(effects): install the rustls provider in the test that needs it

### DIFF
--- a/crates/portcullis-effects/src/lib.rs
+++ b/crates/portcullis-effects/src/lib.rs
@@ -2118,6 +2118,15 @@ mod tests {
         use crate::receipt::EffectOutcome;
         use portcullis_core::{Operation as Op, SinkClass as Sink};
 
+        // The workspace reqwest uses `rustls-no-provider`, so `Client::new()`
+        // panics unless a provider is installed first. Every test that builds
+        // one must do this ITSELF: nextest runs each test in its own process,
+        // so the install in `net_fetch_denied_when_policy_never` is not in
+        // scope here, and this test passed under `cargo test` — which shares a
+        // process — while failing under the runner CI actually uses.
+        // Idempotent; the already-set Err is the expected second answer.
+        let _ = rustls::crypto::ring::default_provider().install_default();
+
         let fx = PolicyEnforced {
             inner: RecordingEffects::new(),
             receipts: Arc::new(crate::receipt::ReceiptLog::new()),


### PR DESCRIPTION
`the_deferred_spend_methods_are_witnessed_where_they_spend` builds a `reqwest::Client`, and the workspace reqwest uses `rustls-no-provider`, so the build panics unless a provider is installed first. **The install existed only in `net_fetch_denied_when_policy_never` — a different test.**

Under `cargo test` that is invisible: one process, and whichever test ran first installed the provider for everyone else. CI runs `cargo nextest`, which runs **each test in its own process**, so this one gets whatever its own process installed — nothing:

```
No rustls crypto provider is configured. When using the `rustls-no-provider`
feature you must install a crypto provider before building a Client.
```

It surfaces as an intermittent `Tests` failure (it hit #2690, whose diff does not touch this crate) because whether it bites depends on how nextest shards.

The install is idempotent, and `crates/portcullis-effects/Cargo.toml` already carries rustls as a dev-dependency with a comment saying exactly why. Each test that builds a Client now does it itself, so neither ordering nor sharding is load-bearing.

**Not falsifiable locally**, and I'd rather say so than imply otherwise: with only `-p portcullis-effects` compiled, `ring` is the sole provider and rustls selects it unaided. The panic needs the workspace's unified feature set, which is what CI builds — so CI is the check on this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JYc8hPky7z1FvG57wAaRMc