### PR TITLE
fix(verifier-service): put the embedded wasm SDK behind a feature

### DIFF
--- a/.clippy-ratchet.toml
+++ b/.clippy-ratchet.toml
@@ -27,6 +27,22 @@ lints = [
 # push to main snaps this down to the real count (457 measured here, three
 # identical consecutive runs), so an over-generous seed
 # self-corrects within one commit rather than hiding a regression forever.
-ceiling = 455
+# Raised 455 -> 462 2026-09-09, and this is COVERAGE going up, not debt.
+# `nucleus-verifier-service` unconditionally `include_*!`d a wasm-pack artifact
+# that only exists after `wasm-pack build`, so on a bare checkout it failed to
+# compile and the script's own "crates that did NOT compile, so were NOT
+# analysed" warning quietly dropped it from the count. Putting that embed behind
+# a feature (#2730) makes the crate compile by default, and the gate now sees
+# seven cast sites in it that were always there and never counted:
+#
+#   log.rs:232 (test)   merkle.rs:80        routes.rs:594
+#   witness.rs:166      witness.rs:240      integration.rs:176 (x2, test)
+#
+# None are new code and none look dangerous — merkle.rs:80 is u64 -> usize,
+# lossless on any 64-bit target, and three of the seven are in tests. They are
+# left for `step` to grind down rather than reworked in a change about the wasm
+# embed. The number to remember is that 455 was never the workspace's real
+# count; it was the count of the crates that happened to build.
+ceiling = 462
 target = 0
 step = 5

--- a/crates/nucleus-verifier-service/Cargo.toml
+++ b/crates/nucleus-verifier-service/Cargo.toml
@@ -14,6 +14,17 @@ categories = ["web-programming::http-server"]
 name = "nucleus-verifier-service"
 path = "src/main.rs"
 
+[features]
+default = []
+# Embed the wasm-pack-built verifier SDK (sdks/verifier-js/pkg/) into the binary
+# with include_str!/include_bytes!. OFF by default: that directory is gitignored
+# and only `wasm-pack build sdks/verifier-js --target web --release` produces it,
+# so an unconditional embed made a clean checkout fail to compile this crate —
+# and one crate failing takes every other crate's test targets down with it
+# (#2730). CI and release builds turn it on, having built the SDK first; with it
+# off the two /static/wasm/* routes answer 503 and name the command.
+embedded-wasm = []
+
 [dependencies]
 nucleus-envelope = { path = "../nucleus-envelope" }
 nucleus-lineage = { path = "../nucleus-lineage" }

--- a/crates/nucleus-verifier-service/src/routes.rs
+++ b/crates/nucleus-verifier-service/src/routes.rs
@@ -2,6 +2,8 @@
 
 use axum::Json;
 use axum::extract::{Path, State};
+#[cfg(not(feature = "embedded-wasm"))]
+use axum::http::StatusCode;
 use axum::http::{HeaderMap, HeaderValue, header};
 use axum::response::{Html, IntoResponse, Response};
 use nucleus_envelope::{Bundle, TrustAnchor, canonical_bundle_hash, verify_bundle};
@@ -39,10 +41,19 @@ const LANDING_CSS: &str = include_str!("../static/style.css");
 const QUICKSTART_HTML: &str = include_str!("../static/quickstart.html");
 const QUICKSTART_CSS: &str = include_str!("../static/quickstart.css");
 const QUICKSTART_JS: &str = include_str!("../static/quickstart.js");
-/// Vendored copy of the wasm-pack-generated SDK shim. Kept in
-/// `static/wasm/` so it's served from the same origin as the HTML
-/// without needing a separate CDN.
+/// The wasm-pack-generated SDK, embedded so it is served from the same origin as
+/// the HTML without needing a separate CDN.
+///
+/// Behind `embedded-wasm`, off by default, because `sdks/verifier-js/pkg/` is
+/// gitignored and produced only by `wasm-pack build sdks/verifier-js --target web
+/// --release`. Unconditional `include_*!` meant a clean checkout could not compile
+/// this crate, and because one crate failing takes the workspace's test targets
+/// with it, `cargo test --workspace` ran zero tests (#2730). With the feature off
+/// the two routes below answer 503 and say which command produces the artifact;
+/// with it on the behaviour is exactly as before.
+#[cfg(feature = "embedded-wasm")]
 const WASM_JS_SHIM: &str = include_str!("../../../sdks/verifier-js/pkg/nucleus_verifier_wasm.js");
+#[cfg(feature = "embedded-wasm")]
 const WASM_BINARY: &[u8] =
     include_bytes!("../../../sdks/verifier-js/pkg/nucleus_verifier_wasm_bg.wasm");
 
@@ -190,6 +201,9 @@ fn static_response(body: &'static str, content_type: &'static str) -> Response {
     (headers, body).into_response()
 }
 
+// Only the embedded wasm binary is served as raw bytes; without it this has no
+// caller and `-D warnings` would reject the dead function.
+#[cfg(feature = "embedded-wasm")]
 fn static_bytes_response(body: &'static [u8], content_type: &'static str) -> Response {
     let mut headers = HeaderMap::new();
     headers.insert(header::CONTENT_TYPE, HeaderValue::from_static(content_type));
@@ -215,16 +229,54 @@ pub async fn quickstart_js() -> Response {
     static_response(QUICKSTART_JS, "application/javascript; charset=utf-8")
 }
 
+/// What the wasm routes answer when the SDK was not built into this binary.
+///
+/// 503 rather than 404: the route exists and the artifact is missing, which is a
+/// build-configuration fact the operator can act on — so the body names the
+/// command that produces it instead of leaving a bare status.
+#[cfg(not(feature = "embedded-wasm"))]
+fn wasm_unavailable() -> Response {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("text/plain; charset=utf-8"),
+    );
+    // Never cached: the next build may well have the SDK in it.
+    headers.insert(header::CACHE_CONTROL, HeaderValue::from_static("no-store"));
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        headers,
+        "the verifier wasm SDK is not embedded in this build\n\
+         build it with: wasm-pack build sdks/verifier-js --target web --release\n\
+         then rebuild this crate with --features embedded-wasm\n",
+    )
+        .into_response()
+}
+
 /// `GET /static/wasm/nucleus_verifier_wasm.js` — wasm-pack-generated
 /// JS shim.
 pub async fn wasm_js_shim() -> Response {
-    static_response(WASM_JS_SHIM, "application/javascript; charset=utf-8")
+    #[cfg(feature = "embedded-wasm")]
+    {
+        static_response(WASM_JS_SHIM, "application/javascript; charset=utf-8")
+    }
+    #[cfg(not(feature = "embedded-wasm"))]
+    {
+        wasm_unavailable()
+    }
 }
 
 /// `GET /static/wasm/nucleus_verifier_wasm_bg.wasm` — the compiled
 /// verifier module.
 pub async fn wasm_binary() -> Response {
-    static_bytes_response(WASM_BINARY, "application/wasm")
+    #[cfg(feature = "embedded-wasm")]
+    {
+        static_bytes_response(WASM_BINARY, "application/wasm")
+    }
+    #[cfg(not(feature = "embedded-wasm"))]
+    {
+        wasm_unavailable()
+    }
 }
 
 #[allow(dead_code)]
@@ -1296,6 +1348,35 @@ pub async fn credit_standing(
         required_bond_micro: file.required_bond(q.max_defection_gain_micro).0,
         max_defection_gain_micro: q.max_defection_gain_micro,
     }))
+}
+
+#[cfg(all(test, not(feature = "embedded-wasm")))]
+mod wasm_absent_tests {
+    //! #2730. Without `embedded-wasm` the crate must still build and serve — the
+    //! whole point of the feature is that a clean checkout compiles. These assert
+    //! the degradation is the documented one (503 naming the build command), not
+    //! a 404, a panic, or a silently empty 200 that a browser would cache.
+    use super::*;
+    use axum::body::to_bytes;
+
+    #[tokio::test]
+    async fn the_wasm_routes_answer_503_and_name_the_command() {
+        for resp in [wasm_js_shim().await, wasm_binary().await] {
+            assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+            // Must not be cached: the next build may well embed the SDK.
+            assert_eq!(
+                resp.headers().get(header::CACHE_CONTROL).unwrap(),
+                "no-store"
+            );
+            let body = to_bytes(resp.into_body(), 4096).await.unwrap();
+            let body = String::from_utf8(body.to_vec()).unwrap();
+            assert!(
+                body.contains("wasm-pack build sdks/verifier-js"),
+                "the body has to name the command that fixes it, got: {body}"
+            );
+            assert!(body.contains("--features embedded-wasm"), "got: {body}");
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #2730.

`routes.rs` embedded `sdks/verifier-js/pkg/*` with `include_str!`/`include_bytes!` unconditionally. That directory is gitignored and only `wasm-pack build` produces it, so a clean checkout could not compile this crate — and because one crate's failure takes the workspace's test targets down with it, `cargo test --workspace` compiled and ran **zero** tests.

This is **option 2** from the issue: an `embedded-wasm` feature, off by default. The issue notes that shape matches how the repo treats other optional heavy paths (`decision` on `nucleus-ifc`, `persist` on `nucleus-creditworthiness`).

## Behaviour

| build | `/static/wasm/*` |
|---|---|
| `--features embedded-wasm` (CI, release) | unchanged — serves the SDK |
| default (clean checkout) | 503, body names the command |

503 rather than 404 because the route exists and the artifact is missing — a build-configuration fact the operator can act on. The body names both `wasm-pack build sdks/verifier-js --target web --release` and `--features embedded-wasm`, and the response is `no-store` since the next build may well embed the SDK.

## CI needs no change

The lanes that build this crate run *after* `wasm-pack` and already pass `--all-features` — `cargo nextest run --all-features` and `cargo clippy --all-features` — so they pick the new feature up automatically and the embedded path keeps exactly the coverage it had. This was the main risk of option 2 (trading a build failure for silent loss of coverage) and it doesn't apply here.

## Verified

```
cargo check   -p nucleus-verifier-service --all-targets     clean   (was: 2 errors)
cargo clippy  -p nucleus-verifier-service --all-targets     0 warnings
cargo test    -p nucleus-verifier-service --lib wasm_absent 1 passed
```

The new test only compiles when the feature is off, and asserts the degradation is the documented one: both routes 503, both `no-store`, both naming the command. A silently-empty 200 or a 404 would pass a weaker test and mislead a browser.

## Incidental

- `static_bytes_response` is gated too — the wasm binary is its only caller, and `-D warnings` rejects it as dead otherwise.
- Dropped a stale doc comment claiming these files are "kept in `static/wasm/`"; they are read from `sdks/verifier-js/pkg/`.

## Follow-up, deliberately not here

`coverage-matrix.yml` carries `--exclude nucleus-verifier-service` for exactly this reason and could now include the crate. That moves coverage numbers, so it belongs in its own change.

#2731 (the other half of "a clean checkout runs no tests") is #2732.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4LNSNppsdYdWBh76xYaGW

---
_Generated by [Claude Code](https://claude.ai/code/session_01E4LNSNppsdYdWBh76xYaGW)_