### PR TITLE
ci(lean): install elan on any runner that lacks it, across all Lean workflows

### DIFF
--- a/.github/workflows/aeneas-certchain.yml
+++ b/.github/workflows/aeneas-certchain.yml
@@ -173,9 +173,14 @@ jobs:
           done
           echo "generated-certchain/ canonicalized from the fresh extraction; theorem builds against it."
 
-      - name: Install elan (Lean toolchain)
-        if: runner.environment == 'github-hosted'
+      - name: Install elan (Lean toolchain) unless the runner already has it
+        shell: bash
         run: |
+          if command -v lake >/dev/null 2>&1; then
+            echo "lake already present: $(command -v lake)"
+            exit 0
+          fi
+          echo "lake not on PATH; installing elan"
           # elan v4.2.4 as its release binary, checksum-verified before it runs; no downloaded
           # script is handed to an interpreter (Scorecard Pinned-Dependencies).
           curl -sSfL https://github.com/leanprover/elan/releases/download/v4.2.4/elan-x86_64-unknown-linux-gnu.tar.gz -o /tmp/elan.tar.gz

--- a/.github/workflows/aeneas-ifc-scoped.yml
+++ b/.github/workflows/aeneas-ifc-scoped.yml
@@ -436,9 +436,15 @@ jobs:
           echo "CANONICAL-FUNS-END"
 
       # --- Build the theorem + capture the REAL axiom set ---
-      - name: Install elan (Lean toolchain)
-        if: steps.scope.outputs.relevant == 'true' && runner.environment == 'github-hosted'
+      - name: Install elan (Lean toolchain) unless the runner already has it
+        if: steps.scope.outputs.relevant == 'true'
+        shell: bash
         run: |
+          if command -v lake >/dev/null 2>&1; then
+            echo "lake already present: $(command -v lake)"
+            exit 0
+          fi
+          echo "lake not on PATH; installing elan"
           # elan v4.2.4 as its release binary, checksum-verified before it runs; no downloaded
           # script is handed to an interpreter (Scorecard Pinned-Dependencies).
           curl -sSfL https://github.com/leanprover/elan/releases/download/v4.2.4/elan-x86_64-unknown-linux-gnu.tar.gz -o /tmp/elan.tar.gz

--- a/.github/workflows/aeneas-oidc-spiffe.yml
+++ b/.github/workflows/aeneas-oidc-spiffe.yml
@@ -242,9 +242,15 @@ jobs:
           echo "CANONICAL-FUNS-END"
 
       # --- Build the theorem + capture the REAL axiom set ---
-      - name: Install elan (Lean toolchain)
-        if: steps.scope.outputs.relevant == 'true' && runner.environment == 'github-hosted'
+      - name: Install elan (Lean toolchain) unless the runner already has it
+        if: steps.scope.outputs.relevant == 'true'
+        shell: bash
         run: |
+          if command -v lake >/dev/null 2>&1; then
+            echo "lake already present: $(command -v lake)"
+            exit 0
+          fi
+          echo "lake not on PATH; installing elan"
           # elan v4.2.4 as its release binary, checksum-verified before it runs; no downloaded
           # script is handed to an interpreter (Scorecard Pinned-Dependencies).
           curl -sSfL https://github.com/leanprover/elan/releases/download/v4.2.4/elan-x86_64-unknown-linux-gnu.tar.gz -o /tmp/elan.tar.gz

--- a/.github/workflows/aeneas.yml
+++ b/.github/workflows/aeneas.yml
@@ -257,9 +257,14 @@ jobs:
           fi
 
       # --- Verify proofs type-check ---
-      - name: Install elan (Lean toolchain)
-        if: runner.environment == 'github-hosted'
+      - name: Install elan (Lean toolchain) unless the runner already has it
+        shell: bash
         run: |
+          if command -v lake >/dev/null 2>&1; then
+            echo "lake already present: $(command -v lake)"
+            exit 0
+          fi
+          echo "lake not on PATH; installing elan"
           # elan v4.2.4 as its release binary, checksum-verified before it runs; no downloaded
           # script is handed to an interpreter (Scorecard Pinned-Dependencies).
           curl -sSfL https://github.com/leanprover/elan/releases/download/v4.2.4/elan-x86_64-unknown-linux-gnu.tar.gz -o /tmp/elan.tar.gz

--- a/.github/workflows/ci-spec-lean.yml
+++ b/.github/workflows/ci-spec-lean.yml
@@ -82,9 +82,15 @@ jobs:
             echo "as a required status check."
           fi
 
-      - name: Install elan (Lean toolchain)
-        if: runner.environment == 'github-hosted' && (steps.scope.outputs.relevant == 'true')
+      - name: Install elan (Lean toolchain) unless the runner already has it
+        if: (steps.scope.outputs.relevant == 'true')
+        shell: bash
         run: |
+          if command -v lake >/dev/null 2>&1; then
+            echo "lake already present: $(command -v lake)"
+            exit 0
+          fi
+          echo "lake not on PATH; installing elan"
           # elan v4.2.4 as its release binary, checksum-verified before it runs; no downloaded
           # script is handed to an interpreter (Scorecard Pinned-Dependencies).
           curl -sSfL https://github.com/leanprover/elan/releases/download/v4.2.4/elan-x86_64-unknown-linux-gnu.tar.gz -o /tmp/elan.tar.gz

--- a/.github/workflows/ck-policy-aeneas.yml
+++ b/.github/workflows/ck-policy-aeneas.yml
@@ -235,9 +235,15 @@ jobs:
           echo "No drift — committed generated Lean matches the Charon+Aeneas output."
 
       # --- Build the proofs over the generated core ---
-      - name: Install elan (Lean toolchain)
-        if: steps.scope.outputs.relevant == 'true' && runner.environment == 'github-hosted'
+      - name: Install elan (Lean toolchain) unless the runner already has it
+        if: steps.scope.outputs.relevant == 'true'
+        shell: bash
         run: |
+          if command -v lake >/dev/null 2>&1; then
+            echo "lake already present: $(command -v lake)"
+            exit 0
+          fi
+          echo "lake not on PATH; installing elan"
           # elan v4.2.4 as its release binary, checksum-verified before it runs; no downloaded
           # script is handed to an interpreter (Scorecard Pinned-Dependencies).
           curl -sSfL https://github.com/leanprover/elan/releases/download/v4.2.4/elan-x86_64-unknown-linux-gnu.tar.gz -o /tmp/elan.tar.gz

--- a/.github/workflows/ck-policy-lean.yml
+++ b/.github/workflows/ck-policy-lean.yml
@@ -91,9 +91,15 @@ jobs:
       # Mathlib-free project: install elan directly (the repo's established
       # pattern — see rubric-lean.yml / econ-lean.yml) and run `lake build`. No
       # mathlib cache fetch needed; the whole tree builds in seconds.
-      - name: Install elan (Lean toolchain)
-        if: runner.environment == 'github-hosted' && (steps.scope.outputs.relevant == 'true')
+      - name: Install elan (Lean toolchain) unless the runner already has it
+        if: (steps.scope.outputs.relevant == 'true')
+        shell: bash
         run: |
+          if command -v lake >/dev/null 2>&1; then
+            echo "lake already present: $(command -v lake)"
+            exit 0
+          fi
+          echo "lake not on PATH; installing elan"
           # elan v4.2.4 as its release binary, checksum-verified before it runs; no downloaded
           # script is handed to an interpreter (Scorecard Pinned-Dependencies).
           curl -sSfL https://github.com/leanprover/elan/releases/download/v4.2.4/elan-x86_64-unknown-linux-gnu.tar.gz -o /tmp/elan.tar.gz

--- a/.github/workflows/econ-lean.yml
+++ b/.github/workflows/econ-lean.yml
@@ -90,9 +90,15 @@ jobs:
       # Mathlib-free project: install elan directly (the repo's established
       # pattern — see aeneas.yml / aeneas-ifc-scoped.yml) and run `lake build`.
       # No mathlib cache fetch needed; the whole tree builds in seconds.
-      - name: Install elan (Lean toolchain)
-        if: runner.environment == 'github-hosted' && (steps.scope.outputs.relevant == 'true')
+      - name: Install elan (Lean toolchain) unless the runner already has it
+        if: (steps.scope.outputs.relevant == 'true')
+        shell: bash
         run: |
+          if command -v lake >/dev/null 2>&1; then
+            echo "lake already present: $(command -v lake)"
+            exit 0
+          fi
+          echo "lake not on PATH; installing elan"
           # elan v4.2.4 as its release binary, checksum-verified before it runs; no downloaded
           # script is handed to an interpreter (Scorecard Pinned-Dependencies).
           curl -sSfL https://github.com/leanprover/elan/releases/download/v4.2.4/elan-x86_64-unknown-linux-gnu.tar.gz -o /tmp/elan.tar.gz

--- a/.github/workflows/ifc-lean.yml
+++ b/.github/workflows/ifc-lean.yml
@@ -73,10 +73,22 @@ jobs:
             echo "as a required status check."
           fi
 
-      - name: Install elan (Lean toolchain)
-        # Hosted only: the self-hosted runner image bakes elan and the pinned toolchain.
-        if: runner.environment == 'github-hosted' && (steps.scope.outputs.relevant == 'true')
+      - name: Install elan (Lean toolchain) unless the runner already has it
+        # Runs everywhere and no-ops where lake is already baked in: the self-hosted
+        # pool is not uniformly carrying elan.
+        if: (steps.scope.outputs.relevant == 'true')
+        shell: bash
         run: |
+          # The guard is #2739's: the self-hosted pool is not uniformly carrying elan, so
+          # this runs everywhere and no-ops where lake is baked in. The INSTALL below is
+          # main's, deliberately: #2739 predates the hardening and its body would have put
+          # back `curl .../elan/master/elan-init.sh | sh`, whose `master` is a mutable ref.
+          # Taking either side whole loses one of the two fixes.
+          if command -v lake >/dev/null 2>&1; then
+            echo "lake already present: $(command -v lake)"
+            exit 0
+          fi
+          echo "lake not on PATH; installing elan"
           # elan v4.2.4 as its release binary, checksum-verified before it runs; no downloaded
           # script is handed to an interpreter (Scorecard Pinned-Dependencies).
           #

--- a/.github/workflows/portcullis-core-proven-lean.yml
+++ b/.github/workflows/portcullis-core-proven-lean.yml
@@ -103,9 +103,15 @@ jobs:
           python3 crates/portcullis-core/lean/check_compiler_overrides.py --self-test
           python3 crates/portcullis-core/lean/check_compiler_overrides.py
 
-      - name: Install elan (Lean toolchain)
-        if: runner.environment == 'github-hosted' && (steps.scope.outputs.relevant == 'true')
+      - name: Install elan (Lean toolchain) unless the runner already has it
+        if: (steps.scope.outputs.relevant == 'true')
+        shell: bash
         run: |
+          if command -v lake >/dev/null 2>&1; then
+            echo "lake already present: $(command -v lake)"
+            exit 0
+          fi
+          echo "lake not on PATH; installing elan"
           # elan v4.2.4 as its release binary, checksum-verified before it runs; no downloaded
           # script is handed to an interpreter (Scorecard Pinned-Dependencies).
           curl -sSfL https://github.com/leanprover/elan/releases/download/v4.2.4/elan-x86_64-unknown-linux-gnu.tar.gz -o /tmp/elan.tar.gz

--- a/.github/workflows/research-lean-build.yml
+++ b/.github/workflows/research-lean-build.yml
@@ -47,10 +47,16 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Install elan (Lean toolchain)
-        # Hosted only: the runner image bakes elan + the pinned Lean toolchain.
-        if: ${{ runner.environment == 'github-hosted' }}
+      - name: Install elan (Lean toolchain) unless the runner already has it
+        # Runs everywhere and no-ops where lake is already baked in: the self-hosted
+        # pool is not uniformly carrying elan.
+        shell: bash
         run: |
+          if command -v lake >/dev/null 2>&1; then
+            echo "lake already present: $(command -v lake)"
+            exit 0
+          fi
+          echo "lake not on PATH; installing elan"
           # elan v4.2.4 as its release binary, checksum-verified before it runs; no downloaded
           # script is handed to an interpreter (Scorecard Pinned-Dependencies).
           curl -sSfL https://github.com/leanprover/elan/releases/download/v4.2.4/elan-x86_64-unknown-linux-gnu.tar.gz -o /tmp/elan.tar.gz

--- a/.github/workflows/rubric-lean.yml
+++ b/.github/workflows/rubric-lean.yml
@@ -86,9 +86,15 @@ jobs:
       # Mathlib-free project: install elan directly (the repo's established
       # pattern — see econ-lean.yml / aeneas.yml) and run `lake build`. No mathlib
       # cache fetch needed; the whole tree builds in seconds.
-      - name: Install elan (Lean toolchain)
-        if: runner.environment == 'github-hosted' && (steps.scope.outputs.relevant == 'true')
+      - name: Install elan (Lean toolchain) unless the runner already has it
+        if: (steps.scope.outputs.relevant == 'true')
+        shell: bash
         run: |
+          if command -v lake >/dev/null 2>&1; then
+            echo "lake already present: $(command -v lake)"
+            exit 0
+          fi
+          echo "lake not on PATH; installing elan"
           # elan v4.2.4 as its release binary, checksum-verified before it runs; no downloaded
           # script is handed to an interpreter (Scorecard Pinned-Dependencies).
           curl -sSfL https://github.com/leanprover/elan/releases/download/v4.2.4/elan-x86_64-unknown-linux-gnu.tar.gz -o /tmp/elan.tar.gz

--- a/.github/workflows/uniform-primitive-lean.yml
+++ b/.github/workflows/uniform-primitive-lean.yml
@@ -86,9 +86,15 @@ jobs:
           fi
 
 
-      - name: Install elan (Lean toolchain)
+      - name: Install elan (Lean toolchain) unless the runner already has it
         if: steps.scope.outputs.relevant == 'true'
+        shell: bash
         run: |
+          if command -v lake >/dev/null 2>&1; then
+            echo "lake already present: $(command -v lake)"
+            exit 0
+          fi
+          echo "lake not on PATH; installing elan"
           # elan v4.2.4 as its release binary, checksum-verified before it runs; no downloaded
           # script is handed to an interpreter (Scorecard Pinned-Dependencies).
           curl -sSfL https://github.com/leanprover/elan/releases/download/v4.2.4/elan-x86_64-unknown-linux-gnu.tar.gz -o /tmp/elan.tar.gz


### PR DESCRIPTION
Follow-up to #2737, which fixed **two** workflows. It turns out to be **twelve**.

Thirteen workflows install elan, and twelve gated it on `runner.environment == 'github-hosted'` — so each assumed every machine in the self-hosted pool carries a baked elan. That stopped being true when the fleet was rebuilt after the #2719 rootfs incident:

| run | runner | `lake build` |
|---|---|---|
| main | `nucleus-fly-build-9` | ✅ |
| #2690 | `nucleus-fly-build-4` | ❌ **exit 127** |

Same commit, same label, same runner group. A pool is not homogeneous just because its label is.

**What showed the first fix was too narrow:** after #2737, #2690 failed the same way in a *third* workflow, `aeneas.yml`. Rather than chase them one incident at a time, this covers all thirteen.

## Why the failure reads as a broken proof

Wherever the self-hosted branch runs `lake exe cache get || true`, that `|| true` swallows the *first* missing-`lake` error. The run then dies a step later on a bare `Process completed with exit code 127` that never mentions `lake`, sitting next to a wall of unrelated "generated Funs.lean drifted" warnings.

## Change

```bash
if command -v lake >/dev/null 2>&1; then
  echo "lake already present: $(command -v lake)"
  exit 0
fi
```

One `command -v` where elan is baked, self-healing where it isn't. Same pinned elan v4.2.4 tarball and SHA-256 check — supply-chain posture unchanged (Scorecard Pinned-Dependencies still satisfied).

`uniform-primitive-lean.yml` already installed unconditionally, so the pattern had precedent here; it gains the guard so a baked image skips the download it was doing every run.

## Scope conditions preserved

A step keeps its `steps.scope.outputs.relevant` clause and loses only the hosted one. Steps whose *only* condition was the hosted clause become unconditional. I verified after the rewrite that no elan step still gates on `github-hosted` and that every scope condition survived — that check is what caught my first pass reading `aeneas-ifc-scoped.yml` as unconditional when it had in fact kept its clause.

## Verified

```
YAML parse: all 73 workflows OK
actionlint 1.7.12 -shellcheck= -pyflakes=: clean
```

Same version and flags `manifest-guards.yml` runs.

## Flagged, not fixed

`ifc-lean.yml` installs elan by piping `elan-init.sh` from raw.githubusercontent into a shell, while the other twelve use the checksum-verified tarball *specifically so no downloaded script is handed to an interpreter*. That inconsistency predates this change and belongs in its own PR.

Also corrects two comments that now said the opposite of the code ("Hosted only: the runner image bakes elan").

Unblocks the Lean/Aeneas checks on #2690 and #2685, which are otherwise at the mercy of which machine they land on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4LNSNppsdYdWBh76xYaGW

---
_Generated by [Claude Code](https://claude.ai/code/session_01E4LNSNppsdYdWBh76xYaGW)_