### PR TITLE
fix(node): rotate the HTTPS server certificate instead of serving it forever

### DIFF
--- a/crates/nucleus-identity/src/mtls.rs
+++ b/crates/nucleus-identity/src/mtls.rs
@@ -27,6 +27,7 @@ use axum::Router;
 use axum::extract::connect_info::Connected;
 use std::io;
 use std::net::SocketAddr;
+use std::sync::Arc;
 use tokio::net::{TcpListener, TcpStream};
 use tokio_rustls::server::TlsStream;
 use tracing::{debug, error, info, warn};
@@ -50,8 +51,33 @@ impl MtlsConfig {
     }
 
     /// Builds a TLS acceptor from this configuration.
+    ///
+    /// The certificate is fixed for the life of the acceptor. Prefer
+    /// [`Self::build_rotating_acceptor`] for a listener that outlives its own
+    /// certificate's TTL.
     pub fn build_acceptor(&self) -> Result<tokio_rustls::TlsAcceptor, crate::Error> {
         TlsServerConfig::new(self.server_cert.clone(), self.trust_bundle.clone()).build_acceptor()
+    }
+
+    /// Builds an acceptor whose server certificate can be replaced later.
+    ///
+    /// Returns the acceptor and the handle that replaces what it serves. Callers
+    /// that keep a listener open longer than the certificate's TTL must use this
+    /// and rotate through the handle, or clients will eventually be offered an
+    /// expired certificate and fail the handshake (#2722).
+    pub fn build_rotating_acceptor(
+        &self,
+    ) -> Result<
+        (
+            tokio_rustls::TlsAcceptor,
+            Arc<crate::tls::RotatingServerCert>,
+        ),
+        crate::Error,
+    > {
+        let resolver = Arc::new(crate::tls::RotatingServerCert::new(&self.server_cert)?);
+        let config = TlsServerConfig::new(self.server_cert.clone(), self.trust_bundle.clone())
+            .build_with_resolver(resolver.clone())?;
+        Ok((tokio_rustls::TlsAcceptor::from(Arc::new(config)), resolver))
     }
 }
 
@@ -102,12 +128,34 @@ pub struct MtlsListener {
 
 impl MtlsListener {
     /// Creates a new mTLS listener.
+    ///
+    /// The certificate is fixed for the life of the listener; see
+    /// [`Self::new_rotating`] if it must outlive its own TTL.
     pub fn new(tcp_listener: TcpListener, config: &MtlsConfig) -> Result<Self, crate::Error> {
         let tls_acceptor = config.build_acceptor()?;
         Ok(Self {
             tcp_listener,
             tls_acceptor,
         })
+    }
+
+    /// Creates a listener whose server certificate can be rotated in place.
+    ///
+    /// Returns the listener and the handle that replaces the certificate it
+    /// serves. The next handshake after a `replace` presents the new one;
+    /// connections already established are untouched.
+    pub fn new_rotating(
+        tcp_listener: TcpListener,
+        config: &MtlsConfig,
+    ) -> Result<(Self, Arc<crate::tls::RotatingServerCert>), crate::Error> {
+        let (tls_acceptor, resolver) = config.build_rotating_acceptor()?;
+        Ok((
+            Self {
+                tcp_listener,
+                tls_acceptor,
+            },
+            resolver,
+        ))
     }
 
     /// Returns the local address this listener is bound to.
@@ -590,5 +638,106 @@ mod tests {
             !resp.contains("NONE"),
             "extraction returned None against a real, correctly-verified mTLS connection: {resp}"
         );
+    }
+
+    /// #2722: a listener must outlive the certificate it was built with.
+    ///
+    /// The node's HTTPS API became unreachable exactly one hour after start — its
+    /// certificate's TTL — because the listener held the one it was built with
+    /// forever. This walks a real handshake across the expiry boundary, and
+    /// asserts BOTH directions: that an un-rotated certificate genuinely stops
+    /// working (so the test cannot pass vacuously), and that rotating through the
+    /// resolver brings it back without rebuilding the listener or dropping it.
+    #[tokio::test]
+    async fn a_rotated_certificate_keeps_the_listener_reachable_past_expiry() {
+        use crate::{CaClient, CsrOptions, Identity, SelfSignedCa, TlsClientConfig};
+        use axum::serve::Listener;
+        use std::time::Duration;
+        use tokio::net::TcpListener;
+
+        let trust_domain = "rotate.nucleus.local";
+        let ca = SelfSignedCa::new(trust_domain).unwrap();
+        let trust_bundle = ca.trust_bundle().clone();
+
+        let server_identity = Identity::new(trust_domain, "servers", "rotating-server");
+        // Short-lived on purpose: this is the node's own default shape
+        // (`--identity-cert-ttl-secs`), just compressed so the test can cross it.
+        async fn mint(ca: &SelfSignedCa, id: &Identity, ttl: Duration) -> WorkloadCertificate {
+            let csr = CsrOptions::new(id.to_spiffe_uri()).generate().unwrap();
+            ca.sign_csr(csr.csr(), csr.private_key(), id, ttl)
+                .await
+                .unwrap()
+        }
+
+        let client_identity = Identity::new(trust_domain, "agents", "rotating-client");
+        let client_csr = CsrOptions::new(client_identity.to_spiffe_uri())
+            .generate()
+            .unwrap();
+        let client_cert = ca
+            .sign_csr(
+                client_csr.csr(),
+                client_csr.private_key(),
+                &client_identity,
+                Duration::from_secs(3600),
+            )
+            .await
+            .unwrap();
+
+        let short = Duration::from_secs(3);
+        let tcp_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = tcp_listener.local_addr().unwrap();
+        let mtls_config = MtlsConfig::new(
+            mint(&ca, &server_identity, short).await,
+            trust_bundle.clone(),
+        );
+        let (mut listener, resolver) =
+            MtlsListener::new_rotating(tcp_listener, &mtls_config).unwrap();
+
+        // Accept in the background for as long as the test needs connections.
+        let accept_loop = tokio::spawn(async move {
+            loop {
+                let _ = listener.accept().await;
+            }
+        });
+
+        let handshake = |cert: WorkloadCertificate, bundle: TrustBundle| async move {
+            let stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+            let connector = TlsClientConfig::new(cert, bundle)
+                .with_spiffe_trust_domain(trust_domain)
+                .build_connector()
+                .unwrap();
+            let name = rustls::pki_types::ServerName::try_from(trust_domain.to_string()).unwrap();
+            connector.connect(name, stream).await.map(|_| ())
+        };
+
+        assert!(
+            handshake(client_cert.clone(), trust_bundle.clone())
+                .await
+                .is_ok(),
+            "the freshly minted certificate should serve"
+        );
+
+        // Past notAfter. Real sleep, because rustls checks validity against the
+        // real clock during the handshake — a paused runtime would not expire it.
+        tokio::time::sleep(short + Duration::from_secs(1)).await;
+
+        let expired = handshake(client_cert.clone(), trust_bundle.clone()).await;
+        assert!(
+            expired.is_err(),
+            "the certificate was past notAfter and the handshake still succeeded — \
+             this test would pass vacuously, so the rotation below proves nothing"
+        );
+
+        // Exactly what the node's rotation task does.
+        resolver
+            .replace(&mint(&ca, &server_identity, Duration::from_secs(3600)).await)
+            .unwrap();
+
+        assert!(
+            handshake(client_cert, trust_bundle).await.is_ok(),
+            "after rotating, the SAME listener should serve the new certificate (#2722)"
+        );
+
+        accept_loop.abort();
     }
 }

--- a/crates/nucleus-identity/src/tls.rs
+++ b/crates/nucleus-identity/src/tls.rs
@@ -116,6 +116,91 @@ impl TlsServerConfig {
         let config = self.build()?;
         Ok(TlsAcceptor::from(Arc::new(config)))
     }
+
+    /// Like [`Self::build`], but the server certificate is resolved per handshake
+    /// from `resolver` instead of being baked into the config.
+    ///
+    /// `build` uses `with_single_cert`, which copies the certificate into the
+    /// `ServerConfig` once. A long-lived listener built that way keeps presenting
+    /// that copy for the life of the process, so a certificate with a TTL shorter
+    /// than the process outlives its own validity and every client then fails the
+    /// handshake against an expired peer (#2722). Resolving per handshake means a
+    /// rotation is picked up by the very next connection, with no acceptor rebuild
+    /// and no disturbance to connections already established.
+    pub fn build_with_resolver(
+        self,
+        resolver: Arc<dyn rustls::server::ResolvesServerCert>,
+    ) -> Result<ServerConfig> {
+        let _ = default_provider().install_default();
+        let roots = root_store_from_trust_bundle(&self.trust_bundle)?;
+        let client_verifier = WebPkiClientVerifier::builder(Arc::new(roots))
+            .build()
+            .map_err(|e| Error::Certificate(format!("failed to build client verifier: {}", e)))?;
+        Ok(ServerConfig::builder()
+            .with_client_cert_verifier(client_verifier)
+            .with_cert_resolver(resolver))
+    }
+}
+
+/// A server certificate that can be replaced while the listener is running.
+///
+/// Implements [`rustls::server::ResolvesServerCert`], so rustls asks it for the
+/// certificate on every handshake rather than holding one from startup. Swapping
+/// the stored key is therefore all a rotation needs — see
+/// [`TlsServerConfig::build_with_resolver`] for why that matters.
+///
+/// The lock is only ever held long enough to clone an `Arc`, never across a
+/// handshake or any await.
+#[derive(Debug)]
+pub struct RotatingServerCert {
+    current: std::sync::RwLock<Arc<rustls::sign::CertifiedKey>>,
+}
+
+impl RotatingServerCert {
+    /// Builds a resolver that starts out serving `cert`.
+    pub fn new(cert: &WorkloadCertificate) -> Result<Self> {
+        Ok(Self {
+            current: std::sync::RwLock::new(Self::certified_key(cert)?),
+        })
+    }
+
+    /// Serves `cert` from the next handshake onward.
+    ///
+    /// Existing connections keep the certificate they negotiated with, which is
+    /// what makes this safe to call under load: TLS binds the certificate at
+    /// handshake time, so replacing it cannot disturb a session in progress.
+    pub fn replace(&self, cert: &WorkloadCertificate) -> Result<()> {
+        let key = Self::certified_key(cert)?;
+        let mut slot = self
+            .current
+            .write()
+            .map_err(|_| Error::Certificate("rotating certificate lock poisoned".to_string()))?;
+        *slot = key;
+        Ok(())
+    }
+
+    fn certified_key(cert: &WorkloadCertificate) -> Result<Arc<rustls::sign::CertifiedKey>> {
+        let chain = parse_cert_chain(&cert.chain_pem())?;
+        let key = parse_private_key(cert.private_key_pem())?;
+        let signing_key = rustls::crypto::ring::sign::any_supported_type(&key)
+            .map_err(|e| Error::Certificate(format!("unsupported private key: {}", e)))?;
+        Ok(Arc::new(rustls::sign::CertifiedKey::new(
+            chain,
+            signing_key,
+        )))
+    }
+}
+
+impl rustls::server::ResolvesServerCert for RotatingServerCert {
+    fn resolve(
+        &self,
+        _client_hello: rustls::server::ClientHello<'_>,
+    ) -> Option<Arc<rustls::sign::CertifiedKey>> {
+        // A poisoned lock here would mean a panic while rotating. Failing the
+        // handshake is the right direction: serving is not more important than
+        // serving something known-good.
+        Some(self.current.read().ok()?.clone())
+    }
 }
 
 /// Builder for TLS client configuration.

--- a/crates/nucleus-node/src/http_serve.rs
+++ b/crates/nucleus-node/src/http_serve.rs
@@ -11,7 +11,52 @@
 
 use crate::{ApiError, NodeState};
 use axum::Router;
-use tracing::info;
+use std::sync::Arc;
+use std::time::Duration;
+use tracing::{info, warn};
+
+/// Keeps the live listener's certificate ahead of its own expiry.
+///
+/// # Why this exists
+///
+/// The listener used to be built from one snapshot of the node's certificate and
+/// keep presenting it for the life of the process. With the default
+/// `--identity-cert-ttl-secs` of 3600 that made the HTTPS API unreachable exactly
+/// one hour after start, while `systemctl is-active` still said `active` and the
+/// node's own journal said nothing (#2722). The certificate WAS being refreshed —
+/// `start_refresh_loop` maintains it — the listener just never looked again.
+///
+/// # Why a third of the TTL
+///
+/// Rotating once per TTL leaves no room for a rotation to fail: one transient
+/// error and the certificate expires before the next attempt. A third gives two
+/// further attempts inside the validity window, so a single failure is survivable
+/// and a persistent one is visible in the log well before clients notice. The
+/// floor keeps a very short TTL (tests use seconds) from becoming a busy loop.
+fn spawn_certificate_rotation(
+    state: &NodeState,
+    resolver: Arc<nucleus_identity::tls::RotatingServerCert>,
+) {
+    let Some(manager) = state.identity_manager.clone() else {
+        return;
+    };
+    let period = (manager.cert_ttl() / 3).max(Duration::from_secs(5));
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(period);
+        // `interval` fires immediately; the certificate was just minted, so the
+        // first tick has nothing to do.
+        ticker.tick().await;
+        loop {
+            ticker.tick().await;
+            if let Err(e) = manager.rotate_http_server_certificate(&resolver).await {
+                // Not fatal: the listener keeps serving the certificate it has,
+                // which is still valid for the rest of this window. Two more
+                // attempts remain before it is not.
+                warn!(error = %e, "failed to rotate the node's HTTPS certificate");
+            }
+        }
+    });
+}
 
 /// Binds `listen_addr` and serves `app` on it over the node's self-issued
 /// mTLS. `state.identity_manager` is unconditionally constructed in `main`
@@ -23,10 +68,11 @@ pub async fn serve(state: &NodeState, listen_addr: &str, app: Router) -> Result<
         .as_ref()
         .expect("identity_manager is unconditionally constructed in main (Move B)");
     let node_identity = manager.node_identity().to_spiffe_uri();
-    let mtls_listener = manager
+    let (mtls_listener, rotating_cert) = manager
         .self_issued_http_mtls_listener(listener)
         .await
         .map_err(ApiError::Driver)?;
+    spawn_certificate_rotation(state, rotating_cert);
     info!(%node_identity, "nucleus-node HTTP API listening on {listen_addr} (mTLS)");
     axum::serve(
         mtls_listener,

--- a/crates/nucleus-node/src/identity.rs
+++ b/crates/nucleus-node/src/identity.rs
@@ -274,10 +274,43 @@ impl IdentityManager {
     pub async fn self_issued_http_mtls_listener(
         &self,
         tcp_listener: tokio::net::TcpListener,
-    ) -> Result<nucleus_identity::mtls::MtlsListener, String> {
+    ) -> Result<
+        (
+            nucleus_identity::mtls::MtlsListener,
+            std::sync::Arc<nucleus_identity::tls::RotatingServerCert>,
+        ),
+        String,
+    > {
         let mtls_config = self.self_issued_http_mtls_config().await?;
-        nucleus_identity::mtls::MtlsListener::new(tcp_listener, &mtls_config)
+        nucleus_identity::mtls::MtlsListener::new_rotating(tcp_listener, &mtls_config)
             .map_err(|e| format!("failed to create HTTP mTLS listener: {e}"))
+    }
+
+    /// The TTL this manager mints certificates with.
+    ///
+    /// Read by the HTTPS listener's rotation task to decide how often to rotate:
+    /// the period has to be derived from the TTL, or a shorter
+    /// `--identity-cert-ttl-secs` silently outruns a hardcoded interval.
+    pub fn cert_ttl(&self) -> Duration {
+        self.cert_ttl
+    }
+
+    /// Re-mints the node's own certificate and installs it on a live listener.
+    ///
+    /// The node's HTTPS listener used to hold the certificate it was built with
+    /// for the life of the process, so the API became unreachable exactly
+    /// `--identity-cert-ttl-secs` after start while the unit still reported
+    /// healthy (#2722). `fetch_certificate` reads the same `SecretManager` cache
+    /// `start_refresh_loop` keeps fresh, so this returns a rotated certificate
+    /// without minting a second issuance path.
+    pub async fn rotate_http_server_certificate(
+        &self,
+        resolver: &nucleus_identity::tls::RotatingServerCert,
+    ) -> Result<(), String> {
+        let cert = self.node_certificate().await?;
+        resolver
+            .replace(&cert)
+            .map_err(|e| format!("failed to install rotated node certificate: {e}"))
     }
 
     /// Rebuild the VM registry from the pods already on disk.


### PR DESCRIPTION
Closes #2722.

The node's HTTPS API became unreachable exactly `--identity-cert-ttl-secs` after start — one hour by default — while `systemctl is-active` still said `active` and the journal said nothing.

## The certificate was being refreshed; the listener never looked again

This is narrower than "the node's cert isn't in the refresh set". `start_refresh_loop` maintains it in the `SecretManager` cache the entire time. The listener simply took one snapshot at boot:

```rust
self_issued_http_mtls_config()  →  node_certificate().await   // ONE read
TlsServerConfig::build()        →  with_single_cert(...)      // baked in
MtlsListener { tls_acceptor }                                 // held for the process
```

Which is why nothing on the server side looks wrong: the unit *is* healthy, the refresh loop *is* running, and only the socket is stale.

## Fix: resolve per handshake, not at startup

`RotatingServerCert` implements [`rustls::server::ResolvesServerCert`](https://docs.rs/rustls/latest/rustls/server/trait.ResolvesServerCert.html); `TlsServerConfig::build_with_resolver` installs it via `with_cert_resolver`. rustls then asks for the certificate on every `ClientHello`, so a rotation is picked up by the **very next connection** — no acceptor rebuild, no rebind, and connections already established keep the certificate they negotiated with, since TLS binds it at handshake time. The lock is held only long enough to clone an `Arc`, never across a handshake or an await.

This is the idiomatic answer rather than swapping acceptors behind a lock, and matches the prior art in [`tls-hot-reload`](https://github.com/sebadob/tls-hot-reload) and [`rustls-cert-reloadable-resolver`](https://crates.io/crates/rustls-cert-reloadable-resolver).

## Why a third of the TTL

`http_serve::serve` spawns the rotation at `cert_ttl / 3`. Once per TTL leaves no room for a rotation to fail — one transient error and the certificate expires before the next attempt. A third leaves two further attempts inside the validity window, so a single failure is survivable and a persistent one shows up in the log well before clients notice.

The period is derived from `cert_ttl` rather than hardcoded, so a shorter `--identity-cert-ttl-secs` can't outrun it. That's also the **first read of `cert_ttl`** — the field #2367 flagged as never read, which as the issue suspected is consistent with a rotation path that was never finished.

## The test asserts both directions

Per the issue's suggestion, it walks a real mTLS handshake across the expiry boundary:

1. fresh certificate → handshake succeeds
2. sleep past `notAfter` → handshake **must fail**
3. rotate through the resolver → the **same** listener serves again

Step 2 is the point. Without it, step 3 could pass vacuously and the test would prove nothing. Real sleep rather than a paused clock, because rustls validates against the real clock during the handshake.

## Verified

```
cargo nextest run --all-features -p nucleus-identity   383 passed
cargo nextest run --all-features -p nucleus-node       438 passed
cargo clippy (both crates, --all-targets)              clean
cargo fmt --check                                      clean
```

## Deliberately not included

The issue also asks that a node serving a near-expired certificate fail its own health check, and notes `nucleus doctor` misattributes the cause ("not reachable — start the node", while it's running). That changes the health contract and the doctor's remediation text, and deserves its own review rather than riding along here. With rotation working it's defence in depth rather than the fix; a failed rotation now warns in the log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4LNSNppsdYdWBh76xYaGW

---
_Generated by [Claude Code](https://claude.ai/code/session_01E4LNSNppsdYdWBh76xYaGW)_