### PR TITLE
ci: stop piping downloaded installers into a shell, and gate against it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -367,8 +367,15 @@ jobs:
       # wasm SDK with `include_str!`/`include_bytes!` on sdks/verifier-js/pkg/*,
       # which only `wasm-pack build` produces. Without it the workspace does not
       # compile and every step below reds for a reason that is not its own.
-      - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      # Pinned prebuilt binary with a checksum, not `curl … init.sh | sh`: that
+      # piped an unpinned remote script straight into a shell on every run, so
+      # the bytes CI executed were whatever the installer held that day and
+      # there was no point at which they could be checked. 0.13.1 is the version
+      # docs.yml already pins. install-action is the same SHA-pinned action this
+      # workflow uses for cargo-nextest.
+      - uses: taiki-e/install-action@5bf6ce016fd2e72eefc647cbca1e4213f65955b8 # v2.87.5
+        with:
+          tool: wasm-pack@0.13.1
       - name: Build wasm SDK (vendored into verifier-service via include_bytes!)
         run: wasm-pack build sdks/verifier-js --target web --release
       - name: "Scope the run (pull_request: affected crates; otherwise the workspace)"
@@ -709,8 +716,15 @@ jobs:
           components: clippy
           targets: wasm32-unknown-unknown
           cache: ${{ runner.environment == 'github-hosted' }}
-      - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      # Pinned prebuilt binary with a checksum, not `curl … init.sh | sh`: that
+      # piped an unpinned remote script straight into a shell on every run, so
+      # the bytes CI executed were whatever the installer held that day and
+      # there was no point at which they could be checked. 0.13.1 is the version
+      # docs.yml already pins. install-action is the same SHA-pinned action this
+      # workflow uses for cargo-nextest.
+      - uses: taiki-e/install-action@5bf6ce016fd2e72eefc647cbca1e4213f65955b8 # v2.87.5
+        with:
+          tool: wasm-pack@0.13.1
       - name: Build wasm SDK (vendored into verifier-service via include_bytes!)
         run: wasm-pack build sdks/verifier-js --target web --release
       - name: cargo clippy

--- a/.github/workflows/ifc-lean.yml
+++ b/.github/workflows/ifc-lean.yml
@@ -76,8 +76,18 @@ jobs:
         # Hosted only: the self-hosted runner image bakes elan and the pinned toolchain.
         if: runner.environment == 'github-hosted' && (steps.scope.outputs.relevant == 'true')
         run: |
-          curl -sSf https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \
-            | sh -s -- -y --no-modify-path
+          # elan v4.2.4 as its release binary, checksum-verified before it runs; no downloaded
+          # script is handed to an interpreter (Scorecard Pinned-Dependencies).
+          #
+          # This step used to `curl .../elan/master/elan-init.sh | sh`. Two problems, and the
+          # `master` is the worse one: it is a MUTABLE ref, so the bytes CI executed were
+          # whatever that branch held at the moment of the run, and the pipe left no point at
+          # which they could be checked. Every other Lean workflow already installs this way;
+          # this one was the last exception.
+          curl -sSfL https://github.com/leanprover/elan/releases/download/v4.2.4/elan-x86_64-unknown-linux-gnu.tar.gz -o /tmp/elan.tar.gz
+          echo "42b94d4244e8353142c456ec0e4ca6528fd898a6c604d4059f494e706e431f63  /tmp/elan.tar.gz" | sha256sum -c -
+          tar -xzf /tmp/elan.tar.gz -C /tmp elan-init
+          /tmp/elan-init -y --no-modify-path
           echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
 
       - name: Cache Lake build artifacts

--- a/.github/workflows/manifest-guards.yml
+++ b/.github/workflows/manifest-guards.yml
@@ -145,3 +145,8 @@ jobs:
       # cancelled check-run turns the PR's rollup FAILURE with nothing broken.
       - name: twin workflows have distinct concurrency groups
         run: bash ci/twin-workflows-have-distinct-concurrency.sh
+
+      # zizmor audits workflow STRUCTURE at --min-severity high; it does not read
+      # shell content inside a `run:` block, which is where `curl … | sh` lives.
+      - name: no workflow pipes a downloaded script into an interpreter
+        run: bash ci/no-piped-installers.sh

--- a/ci/no-piped-installers.sh
+++ b/ci/no-piped-installers.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# No workflow may pipe a downloaded script into an interpreter.
+#
+# `curl … | sh` hands whatever bytes the remote serves at that instant straight
+# to a shell with the runner's privileges. There is no version, no checksum, and
+# no moment at which the content could be inspected — so the thing CI executes is
+# not a thing anyone reviewed. It is the plainest form of the supply-chain risk
+# this repo otherwise takes seriously: every Lean workflow pins elan v4.2.4 and
+# verifies its SHA-256 first, and the actions are pinned by commit SHA rather
+# than tag.
+#
+# Three instances had survived that convention, and the elan one shows why the
+# gate is worth having rather than the convention alone:
+#
+#     ifc-lean.yml   curl …/elan/MASTER/elan-init.sh | sh -s -- -y
+#     ci.yml  (x2)   curl …/wasm-pack/installer/init.sh -sSf | sh
+#
+# `master` is a MUTABLE ref. Twelve sibling workflows already installed elan from
+# a pinned, checksummed release tarball with a comment naming Scorecard
+# Pinned-Dependencies as the reason; this one kept fetching whatever that branch
+# happened to hold. Nothing caught it, because zizmor runs at `--min-severity
+# high` and audits workflow STRUCTURE (template injection, unpinned `uses:`,
+# permissions) rather than shell content inside a `run:` block.
+#
+# The fixes, both of which are the pattern already used elsewhere in the repo:
+#   - a pinned release + `sha256sum -c -` before executing (elan)
+#   - `taiki-e/install-action` at a pinned SHA with a pinned tool version, which
+#     verifies checksums itself (wasm-pack)
+#
+# Exit 0 clean, 1 on any piped installer.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+# A download (curl/wget) whose output is piped into a shell or interpreter.
+# Deliberately narrow: it matches the pipe itself, not every mention of curl,
+# so fetching to a file and checksumming it — the pattern we WANT — still passes.
+pattern='(curl|wget)[^|]*\|[[:space:]]*(sudo[[:space:]]+)?(ba|z|da)?sh|(curl|wget)[^|]*\|[[:space:]]*(python3?|perl|ruby|node)'
+
+found=0
+for f in .github/workflows/*.yml .github/workflows/*.yaml; do
+    [[ -e "$f" ]] || continue
+    # A comment line is prose ABOUT the pattern, not an instance of it — this
+    # file's own header would otherwise trip the gate it defines, and so would
+    # the `not curl … | sh` note in ci.yml explaining why that install changed.
+    while IFS= read -r hit; do
+        printf '%s\n' "$f:$hit"
+        found=1
+    done < <(grep -nE "$pattern" "$f" | grep -vE '^[0-9]+:[[:space:]]*#')
+done
+
+if [[ "$found" == 1 ]]; then
+    cat >&2 <<'MSG'
+
+ERROR: a workflow pipes a downloaded script into an interpreter.
+
+Fetch to a file and verify it before running it:
+
+    curl -sSfL https://…/tool-v1.2.3.tar.gz -o /tmp/tool.tar.gz
+    echo "<sha256>  /tmp/tool.tar.gz" | sha256sum -c -
+    tar -xzf /tmp/tool.tar.gz -C /tmp
+
+or install it with the SHA-pinned action this repo already uses:
+
+    - uses: taiki-e/install-action@<sha> # vX.Y.Z
+      with:
+        tool: <tool>@<version>
+
+MSG
+    exit 1
+fi
+
+echo "OK: no workflow pipes a downloaded script into an interpreter"


### PR DESCRIPTION
Follow-up to the note I left on #2739.

Three workflow steps fetched a script over the network and piped it straight into a shell. No version, no checksum, no moment at which the content could be inspected — so what CI executed was not what anyone reviewed:

| workflow | step |
|---|---|
| `ifc-lean.yml` | `curl …/elan/`**`master`**`/elan-init.sh \| sh -s -- -y` |
| `ci.yml` (×2) | `curl …/wasm-pack/installer/init.sh -sSf \| sh` |

**The elan one is the worst of the three**, because `master` is a **mutable ref** — the bytes were whatever that branch held at the moment of the run. Twelve sibling Lean workflows already install elan from the pinned v4.2.4 release tarball and `sha256sum -c -` it first, with a comment naming Scorecard Pinned-Dependencies as the reason. `ifc-lean.yml` wasn't a different situation; it was the last exception.

## Fixes — both patterns already in this repo

**elan** → pinned release + checksum verified before execution. I checked the hash against the real v4.2.4 tarball rather than copying it on faith from a sibling workflow:

```
expected: 42b94d4244e8353142c456ec0e4ca6528fd898a6c604d4059f494e706e431f63
actual:   42b94d4244e8353142c456ec0e4ca6528fd898a6c604d4059f494e706e431f63
```

**wasm-pack** → `taiki-e/install-action` at the SHA this workflow already pins for `cargo-nextest`, with `tool: wasm-pack@0.13.1` — the version `docs.yml` already pins. It verifies checksums itself and is faster than compiling from source.

## The gate

The convention alone had already failed three times, so `ci/no-piped-installers.sh` now runs in **Manifest Guards**.

It's narrow on purpose: it matches a download *piped into an interpreter*, so fetching to a file and checksumming it — the pattern we want — still passes. Comment lines are excluded, so prose about the pattern doesn't trip the gate that forbids it.

Verified both directions, because a gate that only ever passes proves nothing:

- **red** when the original elan pipe is restored
- **green** on the fixed tree — including the new `ci.yml` comments that quote `` `curl … | sh` `` verbatim, so the comment-exclusion path is genuinely exercised rather than merely written

## Why nothing caught it

`zizmor` runs at `--min-severity high` and audits workflow **structure** — template injection, unpinned `uses:`, permissions. It doesn't read shell content inside a `run:` block, which is where `curl | sh` lives. The two are complementary; this gate covers what that one doesn't look at.

## Verified

```
YAML parse: all 73 workflows OK
actionlint 1.7.12 -shellcheck= -pyflakes=: clean
ci/no-piped-installers.sh: OK
```

Stacks cleanly with #2739 (which makes the elan *install* runner-agnostic); this one changes *what* is installed and how it's verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4LNSNppsdYdWBh76xYaGW

---
_Generated by [Claude Code](https://claude.ai/code/session_01E4LNSNppsdYdWBh76xYaGW)_