### PR TITLE
ci(codeql): run the rust analysis nightly, off the merge-queue path

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,7 +6,8 @@ on:
   pull_request:
   merge_group:
   schedule:
-    - cron: "30 4 * * 1"
+    # Nightly. `Analyze (rust)` runs on this trigger only — see the job comment.
+    - cron: "30 4 * * *"
 
 concurrency:
   # Supersede a PR's older in-flight runs; NEVER cancel anything else.
@@ -21,7 +22,7 @@ permissions:
 
 jobs:
   # Workflow files: the supply-chain surface. The context name `Analyze` is required on main
-  # (ci/required-checks.txt); keep it stable.
+  # (ci/required-checks.txt); keep it stable. 48s, so it is free to keep on the queue path.
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
@@ -37,10 +38,17 @@ jobs:
 
   # The runtime itself. Build-free extraction (no cargo build), so it costs extraction time
   # only; it is what makes CodeQL a SAST tool for this repo rather than a linter for its CI
-  # (Scorecard SAST). Not a required context: advisory until its runtime on this workspace
-  # is measured.
+  # (Scorecard SAST). Not a required context.
+  #
+  # NIGHTLY ONLY, and that is load-bearing. The merge queue ruleset uses grouping_strategy
+  # ALLGREEN, which waits for *every* check on the merge group -- not only the required ones.
+  # At ~30 min this job was therefore the merge cadence: the slowest required check is Code
+  # Coverage at ~7.4 min, but observed inter-merge gaps sat at ~30 min, matching this job.
+  # Advisory findings do not justify gating every merge on them, so it runs on the schedule
+  # instead, off the queue path entirely.
   analyze-rust:
     name: Analyze (rust)
+    if: github.event_name == 'schedule'
     runs-on: ubuntu-latest
     timeout-minutes: 90
     permissions:


### PR DESCRIPTION
## What

`Analyze (rust)` moves to the nightly schedule. `Analyze` (actions, required, 48s) is untouched and stays on the queue path.

## Why

`Analyze (rust)` is advisory — it is not in `ci/required-checks.txt` — and runs ~30 min. It was nonetheless setting the merge cadence.

Measured on merge group `571672f6`:

| Check | Duration | Required? |
|---|---:|---|
| `Analyze (rust)` | **29.6 min** | no |
| Code Coverage (llvm-cov) | 7.4 min | yes |
| Workspace build + tests | 6.4 min | no |
| Fuzz | 3.6 min | yes |
| Clippy | 3.4 min | yes |
| `Analyze` (actions) | 0.8 min | yes |

The slowest **required** context is Code Coverage at ~7.4 min; everything else required is ≤3.6 min. But the median inter-merge gap over the last 30 merges is ~30 min — matching `Analyze (rust)` and nothing required. The queue does not merge faster than the slowest check on the group finishes reporting, so an advisory job at 4x the required critical path buys the whole queue its own runtime.

Throughput 09-03..09-09: 150 merges, ~21/day. Expected effect: cadence moves from ~30 min toward the required critical path of ~7.4 min, with Code Coverage becoming the new long pole.

### On the mechanism, stated narrowly

The ruleset pins `grouping_strategy = ALLGREEN`. I am **not** claiming the queue requires every check green — a red `fmt` shadow gate was present on merge group `571672f6` and the 20 merges of 09-09 happened anyway, which contradicts that reading. What the evidence supports is the timing above: the slowest reporting check paces the queue. The change follows from the timing alone.

## Trade

Rust SAST findings surface within a day of landing rather than on the PR. Acceptable for a context that was never required. Schedule runs execute on the default branch, so the code-scanning alert baseline is unaffected.

## Verification

- `cargo xtask ci-spec check` → `ok: every invariant holds`
- `cargo test -p ci-spec` → 36 passed
- ci-spec I3 governs required contexts only; this job is not in the ledger, so a job-level `if:` is outside its scope
- `ci/merge-queue.toml` constants unchanged — the capacity theorem's hypotheses are untouched

## Separately

The `fmt` shadow gate is currently **red on merge groups** (`ci-spec` green, `clippy` still running). Advisory, but it is noise on the queue path and worth its own look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbnXYc8hcHELnfVXGMwRPn