### PR TITLE
ci(conformance): run the independent implementation, and gate its corpus

### DIFF
--- a/.github/workflows/manifest-guards.yml
+++ b/.github/workflows/manifest-guards.yml
@@ -118,6 +118,14 @@ jobs:
       # `spiffe://` SAN, which the X.509-SVID standard requires be rejected.
       - name: One X.509-SVID validator
         run: bash ci/one-svid-validator.sh
+      # The independent implementation behind the open-commerce claim was never
+      # run by anything (#2736) — the only references to it in the repo were
+      # prose. It is the check that found the truncating-payout defect in #2359.
+      # Tree-only: python3 over a checked-in corpus, no cargo. The other half of
+      # #2736, that the corpus matches what the generator emits, is a Rust test
+      # next to the generator.
+      - name: Independent conformance implementation agrees
+        run: bash ci/independent-conformance.sh
       # `wait_for_proxy_health` moved modules and its boot.stage attribute stayed
       # behind, silently reattaching to `serve_grpc` — so the largest span in a
       # pod launch had no instrumentation and 92% of the boot trace was

--- a/ci/independent-conformance.sh
+++ b/ci/independent-conformance.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# The independent implementation must actually be RUN, and must agree.
+#
+# WHY: `examples/independent-conformance/conform.py` is the artifact behind the
+# open-commerce claim — a re-implementation that checks the vectors without
+# executing nucleus code. Nothing ran it (#2736). `grep -rl conform.py` over
+# `.github/`, `scripts/`, `ci/` and the justfile returned nothing; the only
+# references were prose, including `corpus_is_load_bearing.rs` citing it as
+# "Demonstrated, not hypothesised". A doc comment is not an execution.
+#
+# It is not a decorative artifact. Per #2359 it FOUND a defect: a truncating
+# payout implementation passed the old 14-case corpus and fails the current one,
+# including `payout/remainder-dust-dropped`, where truncation said ACCEPT to an
+# operator skimming a micro-USD per split. If nucleus's verdicts drift from the
+# independent implementation again, this is what notices.
+#
+# Tree-only by design: python3 and a checked-in JSON file, no cargo, so it runs
+# in the fast guard job rather than behind a build. The other half of #2736 —
+# that the checked-in corpus matches what the generator emits — is a Rust test
+# (`the_checked_in_vectors_are_what_the_generator_emits`) rather than a step
+# here, because it belongs next to the generator it guards.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+CORPUS="examples/independent-conformance/vectors.json"
+IMPL="examples/independent-conformance/conform.py"
+
+# Anti-vacuity floor, and the reason this is not just `python3 conform.py`.
+# `evaluate` returns None for a case the independent implementation cannot
+# re-derive (`disclosure_required` is an IFC decision these fields do not carry),
+# and those are skipped, not failed. So a corpus in which every case skipped
+# would print "agreement on every checked vector" over an empty set and exit 0.
+# 13 is what the current 16-case corpus checks.
+#
+# RATCHET UP as the corpus grows. Never lower this to make a run pass: a drop
+# means either the corpus lost cases or `evaluate` stopped deciding ones it used
+# to, and both are the finding.
+MIN_CHECKED=13
+
+for f in "$CORPUS" "$IMPL"; do
+  if [ ! -f "$f" ]; then
+    echo "::error::$f is missing — the open-commerce claim rests on it"
+    exit 1
+  fi
+done
+
+if ! python3 "$IMPL" "$CORPUS" --min-checked="$MIN_CHECKED"; then
+  echo "::error::the independent implementation disagrees with the nucleus corpus"
+  echo "  This is the check that found the truncating-payout defect in #2359."
+  echo "  A disagreement means one of the two moved: either nucleus changed a"
+  echo "  verdict, or $IMPL no longer re-derives it. Do not"
+  echo "  silence this by editing the corpus to match the implementation."
+  exit 1
+fi

--- a/crates/nucleus-commerce-conformance/tests/corpus_is_load_bearing.rs
+++ b/crates/nucleus-commerce-conformance/tests/corpus_is_load_bearing.rs
@@ -167,3 +167,52 @@ fn a_payout_vector_exercises_integer_division_dust() {
          assigning the dust would pass this corpus and then skim on every real split"
     );
 }
+
+/// #2736: the checked-in corpus must be what the generator emits.
+///
+/// `examples/independent-conformance/vectors.json` is generated output —
+/// `cargo run --example vectors` — committed so a third-party implementation can
+/// read it without a Rust toolchain. Generated output under version control
+/// goes stale silently, and this one went stale invisibly twice over: nothing
+/// regenerated it, and nothing compared it.
+///
+/// A stale corpus is worse than no corpus. `conform.py` would keep passing while
+/// validating an independent implementation against a spec nucleus has moved
+/// past — certifying conformance to something nobody enforces. When #2359 grew
+/// the corpus 14 -> 16, only luck kept the file current.
+///
+/// This lives here rather than in `ci/` on purpose: it guards the relationship
+/// between `export_vectors()` and one file, so it belongs next to
+/// `export_vectors()`, where a change to the generator sees it fail immediately.
+#[test]
+fn the_checked_in_vectors_are_what_the_generator_emits() {
+    // `examples/vectors.rs` is `println!("{}", export_vectors())`, so the file on
+    // disk is that string plus the newline `println!` adds.
+    let generated = nucleus_commerce_conformance::export_vectors();
+    let checked_in = include_str!("../../../examples/independent-conformance/vectors.json");
+
+    assert_eq!(
+        generated.trim_end(),
+        checked_in.trim_end(),
+        "examples/independent-conformance/vectors.json is stale.\n\
+         Regenerate it:\n  \
+         cargo run -q -p nucleus-commerce-conformance --example vectors \
+         > examples/independent-conformance/vectors.json\n\
+         Do NOT hand-edit it, and do not delete this test to get green — a \
+         third-party implementation is checking itself against that file."
+    );
+
+    // Non-vacuity: both sides must be a real corpus. A generator that returned
+    // "" against an empty file would satisfy the assert above while proving
+    // nothing, which is the failure shape this whole test exists to catch.
+    let parsed: serde_json::Value =
+        serde_json::from_str(checked_in).expect("the checked-in corpus must be JSON");
+    let cases = parsed["cases"]
+        .as_array()
+        .expect("the corpus must carry a `cases` array");
+    assert!(
+        cases.len() >= 16,
+        "expected at least the 16 cases #2359 established, found {}",
+        cases.len()
+    );
+}

--- a/crates/nucleus-commerce-conformance/tests/corpus_is_load_bearing.rs
+++ b/crates/nucleus-commerce-conformance/tests/corpus_is_load_bearing.rs
@@ -172,8 +172,8 @@ fn a_payout_vector_exercises_integer_division_dust() {
 ///
 /// `examples/independent-conformance/vectors.json` is generated output —
 /// `cargo run --example vectors` — committed so a third-party implementation can
-/// read it without a Rust toolchain. Generated output under version control
-/// goes stale silently, and this one went stale invisibly twice over: nothing
+/// read it without a Rust toolchain. Generated output under version control goes
+/// stale silently, and this one went stale invisibly twice over: nothing
 /// regenerated it, and nothing compared it.
 ///
 /// A stale corpus is worse than no corpus. `conform.py` would keep passing while
@@ -184,30 +184,65 @@ fn a_payout_vector_exercises_integer_division_dust() {
 /// This lives here rather than in `ci/` on purpose: it guards the relationship
 /// between `export_vectors()` and one file, so it belongs next to
 /// `export_vectors()`, where a change to the generator sees it fail immediately.
+///
+/// # Why this compares parsed values and not bytes
+///
+/// Byte-identity is not well defined for this artifact. `export_vectors()`
+/// builds `serde_json::Value` maps via `json!`, and `Value`'s map type is chosen
+/// at compile time: `BTreeMap` (sorted keys) normally, `IndexMap` (insertion
+/// order) under `serde_json/preserve_order`. Cedar, via `nucleus-trust-registry`,
+/// unifies that feature ON in full-workspace builds and leaves it OFF in
+/// standalone ones — the same hazard `nucleus-receipt`'s `Cargo.toml` already
+/// documents for its signing bytes, where the answer was RFC 8785 canonical JSON.
+///
+/// So `cargo test -p nucleus-commerce-conformance` and CI's
+/// `cargo test --workspace --all-features` emit the same corpus with different
+/// key order, and a byte comparison fails in exactly one of them. The property
+/// worth gating is that the corpus is the SAME VECTORS, which is what map
+/// equality says — `conform.py` does `json.load` and never sees key order either.
 #[test]
 fn the_checked_in_vectors_are_what_the_generator_emits() {
-    // `examples/vectors.rs` is `println!("{}", export_vectors())`, so the file on
-    // disk is that string plus the newline `println!` adds.
-    let generated = nucleus_commerce_conformance::export_vectors();
-    let checked_in = include_str!("../../../examples/independent-conformance/vectors.json");
+    let generated: serde_json::Value =
+        serde_json::from_str(&nucleus_commerce_conformance::export_vectors())
+            .expect("the generator must emit JSON");
+    let checked_in: serde_json::Value = serde_json::from_str(include_str!(
+        "../../../examples/independent-conformance/vectors.json"
+    ))
+    .expect("the checked-in corpus must be JSON");
 
-    assert_eq!(
-        generated.trim_end(),
-        checked_in.trim_end(),
-        "examples/independent-conformance/vectors.json is stale.\n\
-         Regenerate it:\n  \
-         cargo run -q -p nucleus-commerce-conformance --example vectors \
-         > examples/independent-conformance/vectors.json\n\
-         Do NOT hand-edit it, and do not delete this test to get green — a \
-         third-party implementation is checking itself against that file."
-    );
+    if generated != checked_in {
+        // A raw `assert_eq!` on two 21 KB documents is unreadable, so name what
+        // moved before dumping anything.
+        let names = |v: &serde_json::Value| -> Vec<String> {
+            v["cases"]
+                .as_array()
+                .map(|a| {
+                    a.iter()
+                        .map(|c| c["name"].as_str().unwrap_or("?").to_string())
+                        .collect()
+                })
+                .unwrap_or_default()
+        };
+        let (g, c) = (names(&generated), names(&checked_in));
+        let only_generated: Vec<_> = g.iter().filter(|n| !c.contains(n)).collect();
+        let only_checked_in: Vec<_> = c.iter().filter(|n| !g.contains(n)).collect();
+        panic!(
+            "examples/independent-conformance/vectors.json is stale.\n\
+             cases only in the generator: {only_generated:?}\n\
+             cases only in the file:      {only_checked_in:?}\n\
+             (both empty means a case CHANGED rather than appeared or vanished)\n\
+             Regenerate it:\n  \
+             cargo run -q -p nucleus-commerce-conformance --example vectors \
+             > examples/independent-conformance/vectors.json\n\
+             Do NOT hand-edit it, and do not delete this test to get green — a \
+             third-party implementation is checking itself against that file."
+        );
+    }
 
-    // Non-vacuity: both sides must be a real corpus. A generator that returned
-    // "" against an empty file would satisfy the assert above while proving
-    // nothing, which is the failure shape this whole test exists to catch.
-    let parsed: serde_json::Value =
-        serde_json::from_str(checked_in).expect("the checked-in corpus must be JSON");
-    let cases = parsed["cases"]
+    // Non-vacuity: both sides must be a real corpus. An empty generator against
+    // an empty file would satisfy the equality above while proving nothing,
+    // which is the failure shape this whole test exists to catch.
+    let cases = checked_in["cases"]
         .as_array()
         .expect("the corpus must carry a `cases` array");
     assert!(

--- a/examples/independent-conformance/conform.py
+++ b/examples/independent-conformance/conform.py
@@ -136,7 +136,22 @@ def evaluate(case: dict) -> bool | None:
 
 
 def main() -> int:
-    path = sys.argv[1] if len(sys.argv) > 1 else "vectors.json"
+    args = [a for a in sys.argv[1:] if not a.startswith("--")]
+    path = args[0] if args else "vectors.json"
+
+    # Anti-vacuity floor. `evaluate` returns None for a case this implementation
+    # cannot re-derive, and those are counted as skipped rather than failed —
+    # correctly, since `disclosure_required` is an IFC decision these fields do
+    # not carry. But that means a corpus in which EVERY case skipped would report
+    # "agreement on every checked vector" over an empty set and exit 0. A CI job
+    # trusting that exit status would then certify conformance having compared
+    # nothing. `--min-checked N` makes the size of the evidence part of the
+    # verdict. Ratchet it UP as the corpus grows; never down to make a run pass.
+    min_checked = 1
+    for a in sys.argv[1:]:
+        if a.startswith("--min-checked="):
+            min_checked = int(a.split("=", 1)[1])
+
     with open(path) as fh:
         corpus = json.load(fh)
 
@@ -153,6 +168,13 @@ def main() -> int:
             wrong.append(f"  {case['name']}: expected {case['expect']}, this impl said {got}")
 
     print(f"independent implementation vs nucleus: {checked} vectors checked, {skipped} skipped")
+    if checked < min_checked:
+        print(
+            f"TOO FEW CHECKED: {checked} < {min_checked}. Agreement over a corpus this "
+            "small is not evidence — either the corpus lost cases, or `evaluate` "
+            "started returning None for cases it used to decide."
+        )
+        return 1
     if wrong:
         print("DISAGREEMENTS:")
         print("\n".join(wrong))


### PR DESCRIPTION
Closes #2736.

Both gaps confirmed exactly as reported: `grep -rl conform.py` over `.github/`, `scripts/`, `ci/` and the justfile returns nothing, and `vectors.json` is generated output under version control with nothing comparing it to its generator. Both correct today, by luck.

## Two gates, in two places

The issue suggested one CI job with three lines. I split it, because the two halves want different homes:

**1. `the_checked_in_vectors_are_what_the_generator_emits`** — a Rust test in `nucleus-commerce-conformance`, not a `ci/` script. It guards the relationship between `export_vectors()` and one file, so it belongs beside `export_vectors()`, where changing the generator fails it immediately rather than in a job the author may never run locally.

**2. `ci/independent-conformance.sh`** — runs `conform.py`. Tree-only (python3 over a checked-in JSON, no cargo), so it goes in the fast **Manifest Guards** job rather than behind a build. ~2 seconds.

Split this way, neither gate needs a toolchain its job doesn't already have.

## The part the issue didn't name

**`python3 conform.py` cannot fail for the reason you'd want it to.**

`evaluate` returns `None` for a case the independent implementation can't re-derive — `disclosure_required` is an IFC decision these fields don't carry — and those count as *skipped*, not failed. So a corpus in which every case skipped prints `agreement on every checked vector` over an empty set and exits **0**. A job trusting that exit status would certify conformance having compared nothing.

So `conform.py` takes `--min-checked=N`, and the gate passes **13** — what the current 16-case corpus actually checks. It ratchets **up** as the corpus grows and must never be lowered to make a run pass: a drop means either the corpus lost cases or `evaluate` stopped deciding ones it used to, and both are the finding.

## Red-checked, not assumed

| perturbation | result |
|---|---|
| drop one case from the corpus | drift test fails, message carries the regeneration command |
| flip every `expect` | `ci/independent-conformance.sh` exits 1 |
| restore | both green |

The drift test also carries a non-vacuity assertion — the corpus must parse and hold at least the 16 cases #2359 established — because an empty generator compared against an empty file would satisfy the equality and prove nothing, which is the exact shape this change exists to catch.

## Local gates

`cargo test -p nucleus-commerce-conformance` — 9 passed / 0 failed · `cargo clippy --all-targets --all-features -- -D warnings` · `cargo fmt --check` · `shellcheck ci/independent-conformance.sh` · `ci/merge-group-scope-parity.sh` · `ci/no-vendor-strings.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G5M7Aj6CFhHjmMep2rv9R8