### PR TITLE
ci: stop fetching 3.3 GiB of dead history, and bake the tool that wasn't baked

### DIFF
--- a/.github/workflows/adversary-probe.yml
+++ b/.github/workflows/adversary-probe.yml
@@ -56,6 +56,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          filter: blob:none
       - name: Is this change in scope?
         id: scope
         env:

--- a/.github/workflows/aeneas-decide-pure.yml
+++ b/.github/workflows/aeneas-decide-pure.yml
@@ -83,6 +83,7 @@ jobs:
         with:
           # Full history + persisted credentials so we can push the regen back.
           fetch-depth: 0
+          filter: blob:none
 
       # --- Rust nightly for Charon MIR extraction ---
       - name: Install Rust nightly for Charon

--- a/.github/workflows/aeneas-ifc-scoped.yml
+++ b/.github/workflows/aeneas-ifc-scoped.yml
@@ -84,6 +84,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          filter: blob:none
       # `paths:` under `merge_group:` parses and is then IGNORED by GitHub, so
       # the scoping declared above holds on pull_request and is silently dropped
       # in the merge queue -- where speculative batches multiply it by the queue

--- a/.github/workflows/aeneas-oidc-spiffe.yml
+++ b/.github/workflows/aeneas-oidc-spiffe.yml
@@ -58,6 +58,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          filter: blob:none
       # `paths:` under `merge_group:` parses and is then IGNORED by GitHub, so
       # the scoping declared above holds on pull_request and is silently dropped
       # in the merge queue -- where speculative batches multiply it by the queue

--- a/.github/workflows/ci-spec-lean.yml
+++ b/.github/workflows/ci-spec-lean.yml
@@ -45,6 +45,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          filter: blob:none
       # `paths:` under `merge_group:` is accepted by the YAML schema and then
       # IGNORED by GitHub, so the scoping above holds on pull_request and is
       # dropped in the queue. This restores it for merge_group only; on every

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          filter: blob:none
       - name: Determine changed crates
         id: detect
         # Pass event/base data via env (never interpolate ${{ }} directly into
@@ -359,6 +360,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          filter: blob:none
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
           targets: wasm32-unknown-unknown
@@ -731,6 +733,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          filter: blob:none
       # Scope: on pull_request, the crates the diff touches closed under
       # reverse dependencies (scripts/affected-crates.sh); anything else, or a
       # workspace-wide change, is the full run. Outputs: full=true|false and
@@ -798,6 +801,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          filter: blob:none
       # Scope: on pull_request, the crates the diff touches closed under
       # reverse dependencies (scripts/affected-crates.sh); anything else, or a
       # workspace-wide change, is the full run. Outputs: full=true|false and

--- a/.github/workflows/ck-admit.yml
+++ b/.github/workflows/ck-admit.yml
@@ -49,6 +49,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0 # need the base ref to diff PolicyManifest.toml
+          filter: blob:none
       # `paths:` under `merge_group:` parses and is then IGNORED by GitHub, so
       # the scoping declared above holds on pull_request and is silently dropped
       # in the merge queue -- where speculative batches multiply it by the queue

--- a/.github/workflows/ck-policy-aeneas.yml
+++ b/.github/workflows/ck-policy-aeneas.yml
@@ -75,6 +75,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          filter: blob:none
       # `paths:` under `merge_group:` parses and is then IGNORED by GitHub, so
       # the scoping declared above holds on pull_request and is silently dropped
       # in the merge queue -- where speculative batches multiply it by the queue

--- a/.github/workflows/ck-policy-lean.yml
+++ b/.github/workflows/ck-policy-lean.yml
@@ -44,6 +44,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          filter: blob:none
       # WHY THIS EXISTS: `paths:` under `merge_group:` is accepted by the YAML
       # schema and then IGNORED by GitHub — path filtering is not supported for
       # merge_group events. So the scoping declared above holds on pull_request

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -42,6 +42,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          filter: blob:none
       # `paths:` under `merge_group:` parses and is then IGNORED by GitHub, so
       # the scoping declared above holds on pull_request and is silently dropped
       # in the merge queue -- where speculative batches multiply it by the queue

--- a/.github/workflows/coverage-matrix.yml
+++ b/.github/workflows/coverage-matrix.yml
@@ -41,6 +41,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          filter: blob:none
       - name: Detect changed crates
         id: detect
         # Pass event name / base ref via env (never interpolate ${{ }} into a
@@ -198,6 +199,7 @@ jobs:
         if: ${{ needs.changed-crates.outputs.all == 'true' || needs.changed-crates.outputs.crates != '' }}
         with:
           fetch-depth: 0
+          filter: blob:none
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         if: ${{ needs.changed-crates.outputs.all == 'true' || needs.changed-crates.outputs.crates != '' }}
         with:

--- a/.github/workflows/coverage-matrix.yml
+++ b/.github/workflows/coverage-matrix.yml
@@ -204,9 +204,14 @@ jobs:
         if: ${{ needs.changed-crates.outputs.all == 'true' || needs.changed-crates.outputs.crates != '' }}
         with:
           cache: ${{ runner.environment == 'github-hosted' }}
-      - name: Install cargo-mutants (baked into the self-hosted image when present)
+      # The self-hosted image bakes it (docker/Dockerfile.runner
+      # CARGO_MUTANTS_VERSION); this is the hosted-runner fallback, pinned to the
+      # same version so the two environments run the same tool. It was unpinned,
+      # which both floated the version and — because nothing baked it — spent
+      # ~0.9m of a 1.4m job installing on every run of the SCARCEST pool.
+      - name: Install cargo-mutants (baked into the self-hosted image)
         if: ${{ needs.changed-crates.outputs.all == 'true' || needs.changed-crates.outputs.crates != '' }}
-        run: command -v cargo-mutants >/dev/null || cargo install cargo-mutants --locked
+        run: command -v cargo-mutants >/dev/null || cargo install cargo-mutants --version 27.1.0 --locked
       # A full run of the six modules is ~30 min of a gate runner and ran on
       # every rebase of every PR. On pull_request and merge_group only the
       # mutants overlapping the change are tried (`--in-diff`, cargo-mutants'

--- a/.github/workflows/econ-lean.yml
+++ b/.github/workflows/econ-lean.yml
@@ -43,6 +43,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          filter: blob:none
       # WHY THIS EXISTS: `paths:` under `merge_group:` is accepted by the YAML
       # schema and then IGNORED by GitHub — path filtering is not supported for
       # merge_group events. So the scoping declared above holds on pull_request

--- a/.github/workflows/feature-matrix.yml
+++ b/.github/workflows/feature-matrix.yml
@@ -37,6 +37,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          filter: blob:none
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
           cache: ${{ runner.environment == 'github-hosted' }}
@@ -92,6 +93,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          filter: blob:none
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
           # Must match [workspace.package] rust-version. Set by wasmtime 48

--- a/.github/workflows/ifc-lean.yml
+++ b/.github/workflows/ifc-lean.yml
@@ -39,6 +39,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          filter: blob:none
 
       # GitHub ignores `paths:` for merge_group events, so the scope is
       # re-implemented here as a regex over the group's diff (ci/merge-group-

--- a/.github/workflows/podlist-probe.yml
+++ b/.github/workflows/podlist-probe.yml
@@ -54,6 +54,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          filter: blob:none
       - name: Is this change in scope?
         id: scope
         env:

--- a/.github/workflows/portcullis-core-proven-lean.yml
+++ b/.github/workflows/portcullis-core-proven-lean.yml
@@ -54,6 +54,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          filter: blob:none
       # WHY THIS EXISTS: `paths:` under `merge_group:` is accepted by the YAML
       # schema and then IGNORED by GitHub — path filtering is not supported for
       # merge_group events. So the scoping declared above holds on pull_request

--- a/.github/workflows/quickstart-boot.yml
+++ b/.github/workflows/quickstart-boot.yml
@@ -92,6 +92,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          filter: blob:none
       - name: Is this change in scope?
         id: scope
         env:
@@ -136,6 +137,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          filter: blob:none
       - name: Is this change in scope?
         id: scope
         env:
@@ -313,6 +315,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          filter: blob:none
       - name: Is this change in scope?
         id: scope
         env:

--- a/.github/workflows/rubric-lean.yml
+++ b/.github/workflows/rubric-lean.yml
@@ -39,6 +39,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          filter: blob:none
       # WHY THIS EXISTS: `paths:` under `merge_group:` is accepted by the YAML
       # schema and then IGNORED by GitHub — path filtering is not supported for
       # merge_group events. So the scoping declared above holds on pull_request

--- a/.github/workflows/trust-registry.yml
+++ b/.github/workflows/trust-registry.yml
@@ -43,6 +43,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0   # need the base ref for the diff + incumbent compile.
+          filter: blob:none
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@d1031067263f94b142dd6c0ce24c5eb9d02d52a0 # stable

--- a/.github/workflows/uniform-primitive-lean.yml
+++ b/.github/workflows/uniform-primitive-lean.yml
@@ -42,6 +42,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          filter: blob:none
       # WHY THIS EXISTS: `paths:` under `merge_group:` is accepted by the YAML
       # schema and then IGNORED by GitHub — path filtering is not supported for
       # merge_group events. So the scoping declared above holds on pull_request

--- a/.github/workflows/wasm-pure-crates.yml
+++ b/.github/workflows/wasm-pure-crates.yml
@@ -60,6 +60,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          filter: blob:none
       # `paths:` under `merge_group:` parses and is then IGNORED by GitHub, so
       # the scoping declared above holds on pull_request and is silently dropped
       # in the merge queue -- where speculative batches multiply it by the queue

--- a/docker/Dockerfile.runner
+++ b/docker/Dockerfile.runner
@@ -99,6 +99,7 @@ ARG CARGO_HACK_VERSION=0.6.45
 ARG CARGO_NEXTEST_VERSION=0.9.143
 ARG CARGO_DENY_VERSION=0.20.2
 ARG CARGO_ZIGBUILD_VERSION=0.23.4
+ARG CARGO_MUTANTS_VERSION=27.1.0
 RUN set -eux; \
     cargo install cargo-dylint dylint-link --version ${CARGO_DYLINT_VERSION} --locked; \
     cargo +stable install cargo-audit --version ${CARGO_AUDIT_VERSION} --locked --no-default-features; \
@@ -107,9 +108,10 @@ RUN set -eux; \
     cargo install cargo-nextest --version ${CARGO_NEXTEST_VERSION} --locked; \
     cargo install cargo-deny --version ${CARGO_DENY_VERSION} --locked; \
     cargo install cargo-zigbuild --version ${CARGO_ZIGBUILD_VERSION} --locked; \
+    cargo install cargo-mutants --version ${CARGO_MUTANTS_VERSION} --locked; \
     rm -rf /home/runner/.cargo/registry /home/runner/.cargo/git /home/runner/.cargo/.package-cache; \
     mkdir -p /home/runner/.cargo/registry /home/runner/.cargo/git; \
-    cargo dylint --version; cargo audit --version; cargo llvm-cov --version; cargo hack --version; cargo nextest --version; cargo deny --version; cargo-zigbuild --version
+    cargo dylint --version; cargo audit --version; cargo llvm-cov --version; cargo hack --version; cargo nextest --version; cargo deny --version; cargo-zigbuild --version; cargo mutants --version
 
 
 # ── Pure-arm64 CI (2026-09-05): what used to keep lanes on hosted x86 ─────────


### PR DESCRIPTION
Profiled a completed merge-group run with `cargo xtask ci-timings` and then measured the pieces directly. Baseline, `60fa8483` — 31 runs, 79 jobs, wall 7.8m:

```
setup: median 16s, total 21.4m
work:  median  2s, total 24.9m      → setup is 46% of all job time
checkout: 126 steps, 15.8m, mean 7.5s, max 49s
```

Two changes here, both name-preserving — **no required context moves.**

## 1. `filter: blob:none` on all 28 `fetch-depth: 0` sites

Checkout is 63% of *work* time. The cause is not that the history is inherently large:

| | |
|---|---|
| tracked working tree | **26 MB** |
| `.git` | **3.3 GiB** |

Build artifacts were committed at some point and are still in history — `tools/nucleus-mediation-lint/target/debug/deps/libclippy_utils-*.rlib` at 96 MB each, plus 172 MB and 132 MB objects. `ci/no-tracked-build-artifacts.sh` stops new ones; it cannot unsend the old ones. Twenty-eight `fetch-depth: 0` sites drag all of it, per job, forever.

A blobless partial clone fetches commits and trees and defers blobs until something reads one. The dead `target/` objects are read by nothing, so they are never fetched; the live 26 MB is.

**Full history is kept deliberately.** I first assumed these sites were copy-paste and could be shallowed — that was wrong, and checking is what showed it: 18 workflows gate themselves on `git diff --name-only "$BASE" "$HEAD"`, and 2 more use three-dot `origin/$BASE...HEAD`, which needs a merge base. All of that is commits and trees, which a blobless clone still has, so **no changed-files gate changes behaviour.** Shallowing would have broken all twenty.

One workflow takes a content diff (`git diff "origin/$base...HEAD" > git.diff`). Still correct: git lazily fetches exactly the blobs that diff touches.

## 2. Bake `cargo-mutants`, and pin the fallback

`coverage-matrix.yml` said it was "baked into the self-hosted image when present". It is not in `docker/Dockerfile.runner`, so the fallback `cargo install` ran every time — **~0.9m of a 1.4m job, on `nucleus-fly-build`, the pool the wall clock waits on.**

It was also unpinned, unlike every other tool in that image (`CARGO_DENY_VERSION`, `CARGO_NEXTEST_VERSION`, …), so the version floated and hosted and self-hosted runners could disagree about which tool decided a gate. Now `CARGO_MUTANTS_VERSION=27.1.0` in the image and the same pin in the hosted fallback, with `cargo mutants --version` added to the image's verification line.

## Verified

- All 73 workflows parse
- `ci/twin-workflows-have-distinct-concurrency.sh`, `ci/merge-group-scope-parity.sh`, `ci/no-tracked-build-artifacts.sh` all pass
- No job renames, so `ci/required-checks.txt` and the ruleset are untouched

## Not in this PR

Two larger levers need a coordinated ruleset edit and are written up separately: folding `deny` 4→1 (four required contexts become one), and hoisting the in-job scope checks off the build pool — the latter is the actual critical path (`Scoped Aeneas`: **442s wait / 24s run**, because it decides it has nothing to do *after* taking the scarce slot).

I'll re-run `ci-timings` against this baseline once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MJ65muwqWqPidSYTnpknDi