### PR TITLE
fix(portcullis): imports gated with the blocks they serve, and a gate that sees it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -715,6 +715,24 @@ jobs:
         run: wasm-pack build sdks/verifier-js --target web --release
       - name: cargo clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
+      # …and once WITHOUT them, crate-scoped (#2746).
+      #
+      # `--all-features` and `--workspace` both hide this class. Under
+      # `--workspace`, feature unification means some other member turns on
+      # portcullis's `cel`/`testing`, so code gated on them compiles and the
+      # imports it needs are used. Alone, at its own defaults
+      # (`serde`/`crypto`/`cedar`), those blocks vanish and their imports become
+      # unused — four errors that CI could not see.
+      #
+      # It matters because crate-scoped is the command this repo asks people to
+      # run: a contributor doing `cargo clippy -p portcullis --all-targets` got
+      # four errors unrelated to their change, and learns to ignore clippy here.
+      #
+      # Scoped to portcullis rather than looped over every member: this is the
+      # crate where feature-gated test blocks are dense enough for the class to
+      # bite, and a per-crate loop would rebuild the world once per member.
+      - name: cargo clippy (portcullis, default features)
+        run: cargo clippy -p portcullis --all-targets -- -D warnings
 
   a2a-example:
     name: A2A example server (examples/a2a-server)

--- a/crates/portcullis/tests/adversarial.rs
+++ b/crates/portcullis/tests/adversarial.rs
@@ -5,9 +5,14 @@
 
 #![allow(clippy::field_reassign_with_default)]
 
-use portcullis::{
-    BudgetLattice, CapabilityLevel, CommandLattice, Operation, PathLattice, PermissionLattice,
-};
+// `CapabilityLevel` and `Operation` are imported by the functions that use them,
+// not here. Every use sits inside a `#[cfg(feature = ...)]` block — `testing` for
+// the uninhabitable-state tests, `cel` for the obligation tests — and neither is
+// a default feature, so a top-level import is unused whenever `cargo clippy -p
+// portcullis --all-targets` runs at the crate's own defaults (#2746). A
+// `cfg(any(...))` on the import would work today and break again the moment a
+// third feature grows a use; a local import cannot drift from its use.
+use portcullis::{BudgetLattice, CommandLattice, PathLattice, PermissionLattice};
 use rust_decimal::Decimal;
 use std::path::Path;
 #[cfg(unix)]
@@ -61,6 +66,8 @@ fn uninhabitable_bypass_via_deserialization_rejected() {
 #[test]
 #[cfg(feature = "testing")]
 fn uninhabitable_cannot_be_disabled_through_meet() {
+    use portcullis::{CapabilityLevel, Operation};
+
     // Create permission set with uninhabitable_state constraint enabled
     let mut enabled = PermissionLattice::default();
     enabled.capabilities.read_files = CapabilityLevel::Always;

--- a/crates/portcullis/tests/proptest_math_framework.rs
+++ b/crates/portcullis/tests/proptest_math_framework.rs
@@ -12,7 +12,7 @@ use portcullis::{
     graded::{Graded, RiskGrade},
     heyting::HeytingAlgebra,
     isolation::{FileIsolation, IsolationLattice, NetworkIsolation, ProcessIsolation},
-    CapabilityLattice, CapabilityLevel, Operation, PermissionLattice, StateRisk,
+    CapabilityLattice, CapabilityLevel, PermissionLattice, StateRisk,
 };
 use proptest::prelude::*;
 
@@ -409,6 +409,12 @@ proptest! {
 // ============================================
 // Constraint Nucleus Laws (CEL feature)
 // ============================================
+
+// Gated with the block it serves. At the crate's default features this section
+// is compiled out, and a top-level import of `Operation` would be unused —
+// which is what made `cargo clippy -p portcullis --all-targets` red (#2746).
+#[cfg(feature = "cel")]
+use portcullis::Operation;
 
 #[cfg(feature = "cel")]
 fn arb_operation() -> impl Strategy<Value = Operation> {


### PR DESCRIPTION
Closes #2746.

`cargo clippy -p portcullis --all-targets -- -D warnings` fails on `main` with four unused-import errors in `tests/adversarial.rs` and `tests/proptest_math_framework.rs`.

The imports aren't dead — `adversarial.rs` names `Operation` fifteen times. Every use sits inside a `#[cfg(feature = ...)]` block: `testing` for the uninhabitable-state tests, `cel` for the obligation tests. Neither is a default feature (`serde`, `crypto`, `cedar` are), so at the crate's own defaults the blocks vanish and the top-level import is unused.

## Correcting the issue's own diagnosis

I filed #2746 assuming `--all-features` was the whole reason CI couldn't see it. **It isn't — `--workspace` hides it too, and independently.** Measured both:

```
cargo clippy --workspace --all-targets -- -D warnings     # portcullis clean
cargo clippy -p portcullis --all-targets -- -D warnings   # 4 errors
```

Under `--workspace`, feature unification means another member enables portcullis's `cel`/`testing`, so the gated blocks compile and their imports are used. The breakage exists **only** in the crate-scoped, default-feature run — which is precisely the command this repo asks people to run. A contributor doing `cargo clippy -p portcullis --all-targets` gets four errors unrelated to their change, and learns to ignore clippy in this crate. That's the actual cost.

## Fix

**Option 2, not option 1.** The imports move to the blocks that use them, rather than growing a `cfg(any(feature = "testing", feature = "cel"))` on the top-level `use`. The `cfg(any(...))` form is correct today and breaks again the moment a third feature grows a use; an import beside its use cannot drift from it. `adversarial.rs` already did this in two places (`use portcullis::Operation;` inside the `cel` modules at 638 and 674) — this finishes the job.

**Option 3, narrowly.** `ci.yml`'s clippy job gains a second invocation, `cargo clippy -p portcullis --all-targets -- -D warnings`. Scoped to portcullis rather than looped over every member: this is the crate where feature-gated test blocks are dense enough for the class to bite, and a per-crate loop would rebuild the world once per member.

Whether *other* crates have the same latent break under their own crate-scoped run is a real question. I measured the workspace form, not a per-crate sweep, and am not claiming an answer.

## Verified at both feature sets

Since this class is precisely about one configuration's silence not being the property:

| command | result |
|---|---|
| `cargo clippy -p portcullis --all-targets -- -D warnings` | 0 errors |
| `cargo clippy -p portcullis --all-targets --all-features -- -D warnings` | 0 errors |
| `cargo test -p portcullis` | 1028 + 33 + 23 + 6 passed, 0 failed |
| `cargo test -p portcullis --all-features` | 1200 + 36 + 24 + 6 + 2 + 8 + 6 + 12 passed, 0 failed |
| `cargo fmt --check -p portcullis` | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G5M7Aj6CFhHjmMep2rv9R8