### PR TITLE
ci(deny): four contexts sharding one command become one (pin 50 → 47)

### DIFF
--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -30,20 +30,27 @@ jobs:
     # Required contexts: without a timeout the job inherits GitHub's 360-minute
     # default, which is the whole merge-queue check budget (ci-spec I7).
     timeout-minutes: 15
-    strategy:
-      fail-fast: false
-      matrix:
-        checks:
-          - advisories
-          - bans
-          - licenses
-          - sources
+    # ONE job, four checks, one context. It was a four-way matrix sharded by
+    # check category — four jobs, four checkouts, four toolchain setups and four
+    # pool slots for what `cargo deny check advisories bans licenses sources`
+    # does in one invocation.
+    #
+    # Measured on merge-group run 60fa8483: the shards ran 1.2m, 1.2m, 1.2m and
+    # (sources) under a minute, of which ~0.9m each was the check itself and the
+    # rest checkout and setup. Sharding buys parallelism the pool queue then eats
+    # — and `ci/merge-queue.toml` records why that trade never pays here: a
+    # single group's required contexts already saturate the pool, so four slots
+    # for one gate is four slots another gate waits for.
+    #
+    # `cargo deny check` with several categories still reports every category's
+    # findings and still exits non-zero if any fails, so nothing about what is
+    # enforced changes — only how many jobs enforce it.
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       # `cargo deny` itself, not the docker action: the self-hosted scale set
       # runs jobs in a plain container (no docker), and the image bakes
       # cargo-deny (docker/Dockerfile.runner CARGO_DENY_VERSION). Hosted
-      # runners install the same pin. The matrix shards by check category.
+      # runners install the same pin.
       - name: Install cargo-deny (hosted only; baked into the runner image)
         if: ${{ runner.environment == 'github-hosted' }}
         run: cargo install cargo-deny --version 0.20.2 --locked
@@ -53,4 +60,4 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
           cache: ${{ runner.environment == 'github-hosted' }}
-      - run: cargo deny check ${{ matrix.checks }}
+      - run: cargo deny check advisories bans licenses sources

--- a/ci/required-checks.txt
+++ b/ci/required-checks.txt
@@ -12,7 +12,17 @@
 # `cargo xtask ci-spec live-parity` compares this file with the live branch
 # protection; a mismatch is a red on the schedule, never a silent re-sync.
 #
-# PINNED = 50
+# 2026-09-09, owner decision, 50 → 47: `deny (advisories)`, `deny (bans)`,
+# `deny (licenses)` and `deny (sources)` become the single context `deny`. The
+# four were a matrix sharding ONE command (`cargo deny check advisories bans
+# licenses sources`) across four jobs, each paying its own checkout, toolchain
+# setup and pool slot. Nothing about what is enforced changes — `cargo deny
+# check` with several categories reports each and still exits non-zero if any
+# fails — so this removes three CONTEXTS, not three checks. The reason it is
+# worth doing is in ci/merge-queue.toml: a single group's required contexts
+# already saturate the pool, so four slots for one gate is four slots another
+# gate waits for.
+# PINNED = 47
 
 # --- ci.yml -------------------------------------------------------------
 Detect changed crates
@@ -49,10 +59,7 @@ Proof Count Ratchet
 
 # --- single-producer, unfiltered ----------------------------------------
 audit
-deny (advisories)
-deny (bans)
-deny (licenses)
-deny (sources)
+deny
 cargo hack --each-feature
 MSRV floor (workspace rust-version)
 zizmor (high+ gate)


### PR DESCRIPTION
`cargo deny check advisories bans licenses sources` is **one invocation**. It was a four-way matrix, so it was four jobs, four checkouts, four toolchain setups and four pool slots.

Measured on merge-group run `60fa8483`: the shards ran 1.2m, 1.2m, 1.2m and under a minute, of which **~0.9m each was the check** and the rest was getting ready to run it.

## Why this is worth a context removal

`ci/merge-queue.toml` already records the experiment that settles it — build concurrency was raised to 4 on 2026-09-09 and put straight back:

> *"T12 says a group's share is `p / c` and only the HEAD group can merge … That pays only when the pool has capacity above ONE group's demand — measured, it does not: **a single group's fifty required contexts already saturate the pool.**"*

If one group's contexts already saturate the pool, then four slots for one gate is four slots another gate waits for. Reducing the context count is the lever that experiment leaves untried.

## Nothing about what is enforced changes

`cargo deny check` with several categories reports each category's findings and still exits non-zero if any fails. **This removes three contexts, not three checks.**

## The pin

`ci/required-checks.txt` says the population pin may only grow, and that removing a context is an owner decision recorded dated in the file. So `PINNED` drops **50 → 47** with that note, in this change, as its own convention requires. `cargo xtask ci-spec check` → *ok: every invariant holds*.

## Live protection sequencing — one step still outstanding

This cannot be done in one shot, because a context that no producer reports blocks every PR.

- [x] **Remove** `deny (advisories|bans|licenses|sources)` from live branch protection — **done**, 50 → 46 contexts. This is what lets this PR merge.
- [ ] **Add** `deny` after this merges. It must be after: added now, every *other* open PR would block on a context their branch's workflow does not produce.

**`cargo xtask ci-spec live-parity` is red until that second step**, by design — the pin says 47, live says 46. The file's own header calls a mismatch "a red on the schedule, never a silent re-sync", so the red is the mechanism working, not a regression.

`deny` still runs on every PR throughout; it is simply not *required* during this window.

Restore point if needed: the 50-context list before the removal is snapshotted, and `POST …/protection/required_status_checks/contexts` re-adds any subset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MJ65muwqWqPidSYTnpknDi