### PR TITLE
fix(aeneas): four gates depended on the runner wiping the target dir

### DIFF
--- a/.github/workflows/aeneas-decide-pure.yml
+++ b/.github/workflows/aeneas-decide-pure.yml
@@ -168,6 +168,14 @@ jobs:
       - name: Charon scoped MIR extraction
         working-directory: crates/nucleus-ifc-kernel
         run: |
+          # `charon cargo` exits 0 and emits NOTHING when cargo has nothing to
+          # recompile: on a warm target directory this extracts nothing, the
+          # regenerate-then-diff downstream finds no diff, and the gate goes
+          # GREEN having checked nothing. The only thing that forced a rebuild
+          # was `rm -rf /data/work` in ci/fly-runner/entrypoint.sh wiping the
+          # target dir every boot — a runner detail, in another file, that this
+          # gate's correctness depended on without saying so.
+          cargo clean -p nucleus-ifc-kernel
           STARTS=""
           IFS=',' read -ra ROOTS <<< "$EXTRACT_ROOTS"
           for r in "${ROOTS[@]}"; do

--- a/.github/workflows/aeneas-ifc-scoped.yml
+++ b/.github/workflows/aeneas-ifc-scoped.yml
@@ -23,9 +23,13 @@ name: Aeneas IFC (scoped extraction + noninterference)
 # extracted::egress ran clean — 4/4 functions translated, 0 opaque.
 #
 # The one real gotcha, which is what a stale build looks like: `charon cargo`
-# exits 0 and emits NOTHING when cargo has nothing to recompile. Run
-# `cargo clean -p nucleus-ifc-kernel` first. The .llbc lands at the REPO ROOT,
-# not in the crate directory.
+# exits 0 and emits NOTHING when cargo has nothing to recompile. The extraction
+# step below now runs `cargo clean -p nucleus-ifc-kernel` first, which is what
+# this comment used to only ADVISE — for a long time the sole thing making the
+# advice unnecessary was `rm -rf /data/work` in ci/fly-runner/entrypoint.sh
+# wiping the target dir every boot, i.e. a runner implementation detail in
+# another file that this gate's correctness quietly rested on. The .llbc lands
+# at the REPO ROOT, not in the crate directory.
 
 on:
   push:
@@ -215,6 +219,14 @@ jobs:
         if: steps.scope.outputs.relevant == 'true'
         working-directory: crates/nucleus-ifc-kernel
         run: |
+          # `charon cargo` exits 0 and emits NOTHING when cargo has nothing to
+          # recompile: on a warm target directory this extracts nothing, the
+          # regenerate-then-diff downstream finds no diff, and the gate goes
+          # GREEN having checked nothing. The only thing that forced a rebuild
+          # was `rm -rf /data/work` in ci/fly-runner/entrypoint.sh wiping the
+          # target dir every boot — a runner detail, in another file, that this
+          # gate's correctness depended on without saying so.
+          cargo clean -p nucleus-ifc-kernel
           STARTS=""
           IFS=',' read -ra ROOTS <<< "$EXTRACT_ROOTS"
           for r in "${ROOTS[@]}"; do

--- a/.github/workflows/aeneas-oidc-spiffe.yml
+++ b/.github/workflows/aeneas-oidc-spiffe.yml
@@ -188,6 +188,14 @@ jobs:
         if: steps.scope.outputs.relevant == 'true'
         working-directory: crates/nucleus-github-oidc
         run: |
+          # `charon cargo` exits 0 and emits NOTHING when cargo has nothing to
+          # recompile: on a warm target directory this extracts nothing, the
+          # regenerate-then-diff downstream finds no diff, and the gate goes
+          # GREEN having checked nothing. The only thing that forced a rebuild
+          # was `rm -rf /data/work` in ci/fly-runner/entrypoint.sh wiping the
+          # target dir every boot — a runner detail, in another file, that this
+          # gate's correctness depended on without saying so.
+          cargo clean -p nucleus-github-oidc
           STARTS=""
           IFS=',' read -ra ROOTS <<< "$EXTRACT_ROOTS"
           for r in "${ROOTS[@]}"; do

--- a/.github/workflows/aeneas.yml
+++ b/.github/workflows/aeneas.yml
@@ -135,7 +135,20 @@ jobs:
       # --- Extract + Translate ---
       - name: Charon MIR extraction
         working-directory: crates/nucleus-ifc-kernel
-        run: charon cargo --preset aeneas
+        run: |
+          # `charon cargo` exits 0 and emits NOTHING when cargo has nothing to
+          # recompile, so on a warm target directory this step succeeds having
+          # extracted no LLBC — and the regenerate-then-diff downstream then
+          # finds no diff and the gate goes GREEN having checked nothing.
+          #
+          # Nothing here forced a rebuild. What did was `rm -rf /data/work` in
+          # ci/fly-runner/entrypoint.sh wiping the target dir every boot: a
+          # runner implementation detail, in another repo's file, that this
+          # gate's correctness silently depended on. ck-policy-aeneas.yml has
+          # always defended itself (`touch src/extracted.rs src/lib.rs`); these
+          # four did not.
+          cargo clean -p nucleus-ifc-kernel
+          charon cargo --preset aeneas
 
       - name: Aeneas Lean 4 translation
         run: |


### PR DESCRIPTION
`aeneas-ifc-scoped.yml` has carried this in its header for as long as it has existed:

> *"`charon cargo` exits 0 and emits **NOTHING** when cargo has nothing to recompile. Run `cargo clean -p nucleus-ifc-kernel` first."*

**It never ran it.** `cargo clean` appears nowhere as a *command* in `aeneas.yml`, `aeneas-decide-pure.yml`, `aeneas-ifc-scoped.yml` or `aeneas-oidc-spiffe.yml`. The only occurrence anywhere was that sentence — advising a fix nobody applied.

## What was actually protecting them

One line, in another file:

```bash
rm -rf /data/work && mkdir -p /data/work   # ci/fly-runner/entrypoint.sh
```

The runner wipes the target directory every boot, so cargo always had work to do and charon always emitted LLBC. **Four proof-extraction gates rested on a runner implementation detail, undocumented as a dependency in either place.**

## Why it matters

The failure mode is the bad kind. Charon exits 0 having extracted nothing → the regenerate-then-diff downstream finds no diff *because nothing was regenerated* → the gate reports **green having checked nothing.** A gate that is green because it never fired.

## The fix

All four now `cargo clean -p <crate>` immediately before `charon cargo`, in the same `run:` block so nothing can be reordered between them.

| workflow | crate |
|---|---|
| `aeneas.yml` | `nucleus-ifc-kernel` |
| `aeneas-decide-pure.yml` | `nucleus-ifc-kernel` |
| `aeneas-ifc-scoped.yml` | `nucleus-ifc-kernel` |
| `aeneas-oidc-spiffe.yml` | `nucleus-github-oidc` |

**`ck-policy-aeneas.yml` needed no change, and is why I trust the fix.** It has always defended itself — `touch src/extracted.rs src/lib.rs`, with a comment naming the same footgun ("a cached crate makes charon a <1s no-op"). One of five gates knew; four did not.

The stale header comment in `aeneas-ifc-scoped.yml` is updated too, so it documents what the workflow *does* rather than advising something it doesn't.

## How this was found

While measuring whether the target directory could be **persisted** across boots for speed. sccache reports `Cache misses 0` and `Average compiler 0.000 s` on the three heaviest build-pool jobs:

| job | wall | misses | avg compiler |
|---|---|---|---|
| `cargo hack --each-feature` | 271s | 0 | 0.000s |
| `Code Coverage (llvm-cov)` | 525s | 0 | 0.000s |
| `Workspace build + tests` | 389s | 0 | 0.000s |

So ~95% of their time is cargo fingerprinting and linking — exactly what a warm `target/` removes and sccache cannot. **That change is now unblocked by this one:** it would have silently deleted the only thing keeping these four gates honest.

## Verified

- All four parse; `cargo xtask ci-spec check` → **ok: every invariant holds**
- `ci/merge-group-scope-parity.sh`, `ci/twin-workflows-have-distinct-concurrency.sh` pass
- `cargo clean` precedes `charon cargo` in all four, checked by line number

No job names change, so no required context moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MJ65muwqWqPidSYTnpknDi