### PR TITLE
ci(fly-runner): print WHERE a job ran, beside its cache numbers

### DIFF
--- a/ci/fly-runner/job-completed.sh
+++ b/ci/fly-runner/job-completed.sh
@@ -7,6 +7,21 @@
 # already gone. Exit 0 always: instrumentation never fails a job.
 set -u
 echo "::group::sccache (this job)"
+# WHERE this ran, on the same line-oriented format as the counters below, because
+# `Average cache read hit` is meaningless without it once the pool spans regions.
+#
+# The build pool has to grow across regions: a volume pins its machine to that
+# volume's HOST, so a full iad zone refuses the create (HTTP 412) forever while
+# the volume-less gate pool floats to any zone with room. The 8 GB rootfs cap
+# means a compile pool cannot drop the volume that causes the pin.
+#
+# Cross-region is not free and the size of the penalty is the open question.
+# Tigris caches by request pattern, so a new region should warm up rather than
+# stay slow — but "should" is not a measurement, and the object store is in ONE
+# place while the machine reading it may not be. Baseline before any region but
+# iad existed: 0.037-0.076 s per read at 1127-2558 reads per job, ~8-way
+# parallel. Print the region beside the number so the next reader can subtract.
+echo "placement: region=${FLY_REGION:-unknown} machine=${FLY_MACHINE_ID:-unknown} sccache=${SCCACHE_BUCKET:-local}"
 sccache --show-stats 2>/dev/null \
   | grep -E "Compile requests|Cache hits|Cache misses|Non-cacheable|Average" || echo "sccache: no server (job ran no rustc)"
 echo "::endgroup::"


### PR DESCRIPTION
`Average cache read hit` is about to stop meaning one thing. The build pool has to grow across regions, and then that number is a function of **where the machine was** — which nothing in the log says.

## Why the pool has to span regions

A volume **pins its machine to that volume's host.** A full `iad` zone refuses the create with **HTTP 412** — permanently, ten passes running, the same five indexes — while the volume-less gate pool floats to any zone with room and never sees it.

The compile pool can't drop the volume that causes the pin: Fly's rootfs is capped at **8 GB** (staff confirm the rework *"does not change the amount of ephemeral disk space available"*, and the request to extend it closed unanswered), and `PoolSpec::requires_volume` records what happens without one — `ld terminated with signal 7 [Bus error]`, then `ENOSPC`, then **four required checks ejected while looking clean.**

Probed directly: **`ord` places a `performance-8x` on a fresh volume first try.** The capacity is one region over.

## Why measure rather than assume

Tigris caches by request pattern — *"objects stored in San Jose but requested frequently from Sydney will get cached in Sydney"* — so a new region should **warm** rather than stay slow. But "should" isn't a measurement, and published cross-region figures (~180–220ms p95 vs sub-100ms in-region) are 3–5× what this pool sees today.

Baseline, measured before any region but `iad` existed, on the three heaviest build-pool jobs:

| job | wall | reads | avg read |
|---|---|---|---|
| `cargo hack --each-feature` | 271s | 2558 | 0.037s |
| `Code Coverage (llvm-cov)` | 525s | 1127 | 0.076s |
| `Workspace build + tests` | 389s | 1876 | 0.059s |

That's the number the next reader subtracts from. At ~8-way parallelism a 3× regression costs real seconds per job.

## The change

One line, inside the group that already prints the counters, so region and latency are read together and `cargo xtask ci-timings` can correlate them without a second source:

```
placement: region=iad machine=… sccache=…
```

Unset vars degrade to `unknown`/`local` rather than tripping `set -u` on a hosted runner. Verified with `bash -n` and `shellcheck` (clean), and with the vars explicitly unset.

## Mandate disclosure

This edits a **shell script**, and #2760 sets the mandate that new CI logic is Rust. I'm not going to lawyer it: it's one `echo` with `${VAR:-default}` fallbacks — no branching, no arithmetic, no exit-code inspection, which is exactly that mandate's "what stays shell" clause. But it *is* an addition to a file the mandate schedules for conversion.

The mandate names why these hooks are a special case: `ACTIONS_RUNNER_HOOK_*` must be an executable on the machine and they run before and after the job that would build `xtask`, so they become a small binary baked into `docker/Dockerfile.runner`. **If you'd rather this waited for that conversion, close it** — the measurement matters, the delivery mechanism doesn't, and the baseline above is already recorded here either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MJ65muwqWqPidSYTnpknDi