### PR TITLE
fix(risk): say what the combination permits, and stop claiming the floor is safe

### DIFF
--- a/crates/nucleus-task-compiler/src/compile.rs
+++ b/crates/nucleus-task-compiler/src/compile.rs
@@ -189,10 +189,11 @@ pub fn compile(input: CompileInput<'_>) -> Result<TaskGrant, CompileError> {
         .delegate_to(&lattice, "task grant")
         .map_err(|e| CompileError::NotWithinCeiling(e.to_string()))?;
 
-    let gap = input
-        .cost_config
-        .compute_gap(&PermissionLattice::restrictive(), &lattice);
-    let risk = summarise_risk(&lattice, gap);
+    let risk = summarise_risk(
+        &PermissionLattice::restrictive(),
+        &lattice,
+        input.cost_config,
+    );
 
     let created_at = Utc::now();
     let not_after = lattice.time.valid_until;

--- a/crates/portcullis/src/exposure_mechanism.rs
+++ b/crates/portcullis/src/exposure_mechanism.rs
@@ -1,0 +1,281 @@
+//! What a combination of exposure legs *permits*.
+//!
+//! Every disclosure level said the same two things about risk: a grade, and a
+//! count of legs.
+//!
+//! ```text
+//! Risk:    2 of 3 exposure legs (private data + untrusted content); exfiltration absent → no approval prompts expected
+//! ```
+//!
+//! Two of three what? The sentence a person actually needs — *this combination
+//! permits repository data to leave the sandbox* — existed at no level, in no
+//! renderer. Yet the material was all there and thrown away: [`state_risk`]
+//! computes the three legs as named booleans and collapses them to a count on
+//! the next line, and [`UninhabitableState`] carries a `name` for exactly this
+//! purpose that no renderer has ever read.
+//!
+//! This module keeps the identities. [`mechanism`] answers "what does *this*
+//! combination let the agent do", for all eight subsets, and [`risk_line`]
+//! renders the whole line from a [`RiskSummary`].
+//!
+//! # Why the legs are separate from the grade
+//!
+//! [`StateRisk`] is ordered and load-bearing: the kernel gates on it and the
+//! Lean development reasons about it. Nothing here changes what it computes.
+//! The mechanism is rendering — an English gloss on a set — and is kept out of
+//! the grade's way on purpose.
+//!
+//! [`state_risk`]: crate::IncompatibilityConstraint::state_risk
+//! [`UninhabitableState`]: crate::uninhabitable_state::UninhabitableState
+
+use crate::task_grant::RiskSummary;
+use crate::ExposureLabel;
+
+/// What the combination of legs permits, in one clause.
+///
+/// The eight subsets are spelled out rather than composed from per-leg
+/// fragments, because the interesting content is in the *joins*: "the agent
+/// can read private data" and "the agent can reach the network" are two facts,
+/// and "whatever it reads can leave" is the third fact that only exists when
+/// both hold. A generated sentence would have said the first two and lost the
+/// one worth reading.
+///
+/// Written as a match on the triple with no catch-all: a fourth leg would fail
+/// to compile here rather than quietly inherit the nearest sentence.
+#[must_use]
+pub fn mechanism(legs: &[ExposureLabel]) -> &'static str {
+    let private = legs.contains(&ExposureLabel::PrivateData);
+    let untrusted = legs.contains(&ExposureLabel::UntrustedContent);
+    let exfil = legs.contains(&ExposureLabel::ExfilVector);
+
+    match (private, untrusted, exfil) {
+        (false, false, false) => "nothing the agent can reach is private, untrusted or outbound",
+        (true, false, false) => {
+            "the agent can read private data, but nothing steers what it reads and nothing carries it out"
+        }
+        (false, true, false) => {
+            "the agent can read untrusted content, but holds nothing private and has no way out"
+        }
+        (false, false, true) => {
+            "the agent can send data out of the sandbox, but has nothing private to send and nothing directing it"
+        }
+        (true, true, false) => {
+            "untrusted content can steer what the agent reads, but nothing granted carries what it reads out of the sandbox"
+        }
+        (true, false, true) => {
+            "whatever the agent can read can leave the sandbox, but nothing untrusted directs what it reads"
+        }
+        (false, true, true) => {
+            "untrusted content can direct what the agent sends out of the sandbox, but it holds no private data to send"
+        }
+        (true, true, true) => {
+            "untrusted content can direct the agent to read private data and send it out of the sandbox"
+        }
+    }
+}
+
+/// The whole `Risk:` line.
+///
+/// Three clauses: which legs are present, what that combination permits, and
+/// whether the kernel will stop to ask.
+///
+/// The third clause is read from `approval_gated`, which is the actual list of
+/// operations carrying an obligation. It used to be inferred from the leg
+/// count — three legs meant "the kernel asks", fewer meant the flat assertion
+/// `no approval prompts expected`. That is a claim about the obligations made
+/// without looking at them, and it is false for any grant whose obligations
+/// were set by some route other than the trifecta: an effect pack that gates
+/// an operation, a ceiling profile that does, a narrowed grant that inherited
+/// one. Such a grant promised the person no prompts and then prompted.
+#[must_use]
+pub fn risk_line(risk: &RiskSummary) -> String {
+    let legs = risk.exposure_legs.len();
+    let present: Vec<&str> = risk.exposure_legs.iter().map(|l| leg_name(*l)).collect();
+
+    let mut line = if legs == 3 {
+        format!("all 3 exposure legs present ({})", present.join(" + "))
+    } else {
+        let missing: Vec<&str> = [
+            ExposureLabel::PrivateData,
+            ExposureLabel::UntrustedContent,
+            ExposureLabel::ExfilVector,
+        ]
+        .iter()
+        .filter(|l| !risk.exposure_legs.contains(l))
+        .map(|l| leg_name(*l))
+        .collect();
+        let with = if present.is_empty() {
+            String::new()
+        } else {
+            format!(" ({})", present.join(" + "))
+        };
+        format!(
+            "{legs} of 3 exposure legs{with}; {} absent",
+            missing.join(" and ")
+        )
+    };
+
+    line.push_str(" → ");
+    line.push_str(mechanism(&risk.exposure_legs));
+
+    if risk.approval_gated.is_empty() {
+        line.push_str("; no approval prompts expected");
+    } else {
+        let gated: Vec<String> = risk
+            .approval_gated
+            .iter()
+            .map(std::string::ToString::to_string)
+            .collect();
+        line.push_str("; the kernel asks for approval before ");
+        line.push_str(&gated.join(", "));
+    }
+    line
+}
+
+fn leg_name(l: ExposureLabel) -> &'static str {
+    match l {
+        ExposureLabel::PrivateData => "private data",
+        ExposureLabel::UntrustedContent => "untrusted content",
+        ExposureLabel::ExfilVector => "exfiltration",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::uninhabitable_state::UninhabitableState;
+    use crate::{Operation, StateRisk, WeakeningGap};
+
+    const ALL: [ExposureLabel; 3] = [
+        ExposureLabel::PrivateData,
+        ExposureLabel::UntrustedContent,
+        ExposureLabel::ExfilVector,
+    ];
+
+    fn subsets() -> Vec<Vec<ExposureLabel>> {
+        (0u8..8)
+            .map(|mask| {
+                ALL.iter()
+                    .enumerate()
+                    .filter(|(i, _)| mask & (1 << i) != 0)
+                    .map(|(_, l)| *l)
+                    .collect()
+            })
+            .collect()
+    }
+
+    fn summary(legs: Vec<ExposureLabel>, gated: Vec<Operation>) -> RiskSummary {
+        RiskSummary {
+            before: StateRisk::Safe,
+            after: StateRisk::Safe,
+            exposure_legs: legs,
+            approval_gated: gated,
+            gap: WeakeningGap::default(),
+        }
+    }
+
+    /// THE property this module exists for. Every subset says something about
+    /// what the combination *permits*, and no two subsets say the same thing —
+    /// so the sentence carries the identity of the legs, not just their count.
+    ///
+    /// The count could never do this: there are three two-leg combinations and
+    /// they permit three different things, one of which (private + exfil) is
+    /// the exfiltration path and two of which are not.
+    #[test]
+    fn every_combination_permits_something_different() {
+        let mut seen: Vec<&str> = subsets().iter().map(|s| mechanism(s)).collect();
+        assert_eq!(seen.len(), 8, "there are eight subsets of three legs");
+        seen.sort_unstable();
+        let before = seen.len();
+        seen.dedup();
+        assert_eq!(
+            before,
+            seen.len(),
+            "two combinations permit the same thing, so the sentence is only counting"
+        );
+    }
+
+    /// The mechanism is about the join, not the parts. The two-leg combination
+    /// that permits exfiltration must say so, and the two that do not must not
+    /// — this is the distinction the count erased.
+    #[test]
+    fn only_the_combinations_with_a_path_out_say_data_leaves() {
+        let leaves = |legs: &[ExposureLabel]| {
+            let m = mechanism(legs);
+            m.contains("can leave the sandbox") || m.contains("send it out of the sandbox")
+        };
+        assert!(leaves(&[
+            ExposureLabel::PrivateData,
+            ExposureLabel::ExfilVector
+        ]));
+        assert!(leaves(&ALL));
+        assert!(!leaves(&[
+            ExposureLabel::PrivateData,
+            ExposureLabel::UntrustedContent
+        ]));
+        assert!(!leaves(&[
+            ExposureLabel::UntrustedContent,
+            ExposureLabel::ExfilVector
+        ]));
+        assert!(!leaves(&[ExposureLabel::PrivateData]));
+        assert!(!leaves(&[]));
+    }
+
+    /// The bug this replaces. A grant with obligations but fewer than three
+    /// legs used to be told, flatly, that no approval would be asked for.
+    #[test]
+    fn a_gated_operation_is_reported_however_many_legs_there_are() {
+        for legs in subsets() {
+            let n = legs.len();
+            let line = risk_line(&summary(legs, vec![Operation::GitPush]));
+            assert!(
+                line.contains("asks for approval before git_push"),
+                "{n} legs and an obligation, yet: {line}"
+            );
+            assert!(
+                !line.contains("no approval prompts expected"),
+                "{n} legs: promised no prompts while holding an obligation: {line}"
+            );
+        }
+    }
+
+    /// Non-vacuity for the test above: with no obligation the line still says
+    /// so, at every leg count, so the assertion is not passing because the
+    /// clause is always present.
+    #[test]
+    fn an_ungated_grant_is_told_no_prompts_at_every_leg_count() {
+        for legs in subsets() {
+            let line = risk_line(&summary(legs, Vec::new()));
+            assert!(line.contains("no approval prompts expected"), "{line}");
+        }
+    }
+
+    /// The canonical combination is the one the constraint system already
+    /// names. Reading `.name` here is the first time any renderer has: the
+    /// field has carried "which combination is dangerous and what is it
+    /// called" since it was introduced, unread.
+    #[test]
+    fn the_three_leg_line_describes_the_combination_the_nucleus_names() {
+        let canonical = UninhabitableState::canonical();
+        assert_eq!(canonical.risk_grade, StateRisk::Uninhabitable);
+        assert_eq!(canonical.required_core_labels.len(), 3);
+        let line = risk_line(&summary(ALL.to_vec(), vec![Operation::GitPush]));
+        assert!(line.starts_with("all 3 exposure legs present"), "{line}");
+        assert!(
+            line.contains("read private data and send it out of the sandbox"),
+            "the trifecta line must say what the trifecta permits: {line}"
+        );
+    }
+
+    /// A line always names which legs are present, so a person can check the
+    /// mechanism sentence against the grant rather than trusting it.
+    #[test]
+    fn every_line_names_the_legs_it_reasons_from() {
+        for legs in subsets() {
+            let line = risk_line(&summary(legs.clone(), Vec::new()));
+            for l in &legs {
+                assert!(line.contains(leg_name(*l)), "{line} omits {l:?}");
+            }
+        }
+    }
+}

--- a/crates/portcullis/src/grant_usage.rs
+++ b/crates/portcullis/src/grant_usage.rs
@@ -359,8 +359,7 @@ pub fn narrow(grant: &TaskGrant, usage: &UsageReport, name: &str) -> Narrowed {
     }
 
     let restrictive = PermissionLattice::restrictive();
-    let gap = WeakeningCostConfig::default().compute_gap(&restrictive, &lattice);
-    let risk = summarise_risk(&lattice, gap);
+    let risk = summarise_risk(&restrictive, &lattice, &WeakeningCostConfig::default());
 
     let mut provenance = grant.provenance.clone();
     provenance

--- a/crates/portcullis/src/lib.rs
+++ b/crates/portcullis/src/lib.rs
@@ -157,6 +157,12 @@ pub mod escalation;
 #[cfg(all(feature = "spec", not(kani)))]
 pub mod escalation_proposal;
 pub mod exposure_core;
+/// The task grant a goal compiles to, and its progressive-disclosure
+/// rendering (Goal / Can / Cannot / Limits / Risk).
+///
+/// Requires the `spec` feature.
+#[cfg(feature = "spec")]
+pub mod exposure_mechanism;
 pub mod flow_graph;
 pub mod frame;
 pub mod galois;
@@ -213,11 +219,6 @@ pub mod says_admission;
 /// Requires the `spec` feature; sealing and verifying need `crypto` too.
 #[cfg(all(feature = "spec", not(kani)))]
 pub mod sealed_grant;
-/// The task grant a goal compiles to, and its progressive-disclosure
-/// rendering (Goal / Can / Cannot / Limits / Risk).
-///
-/// Requires the `spec` feature.
-#[cfg(feature = "spec")]
 pub mod task_grant;
 #[cfg(feature = "crypto")]
 pub use receipt_sign::{receipt_hash, sign_receipt, verify_receipt};

--- a/crates/portcullis/src/lib.rs
+++ b/crates/portcullis/src/lib.rs
@@ -219,6 +219,11 @@ pub mod says_admission;
 /// Requires the `spec` feature; sealing and verifying need `crypto` too.
 #[cfg(all(feature = "spec", not(kani)))]
 pub mod sealed_grant;
+/// Requires the `spec` feature: it imports `effect_catalog`, which is itself
+/// `#[cfg(feature = "spec")]`. This gate was dropped when `exposure_mechanism`
+/// was added below, and `spec` is NOT a default feature, so the module then
+/// compiled by default with an unresolvable import.
+#[cfg(feature = "spec")]
 pub mod task_grant;
 #[cfg(feature = "crypto")]
 pub use receipt_sign::{receipt_hash, sign_receipt, verify_receipt};

--- a/crates/portcullis/src/task_grant.rs
+++ b/crates/portcullis/src/task_grant.rs
@@ -245,51 +245,13 @@ fn render_plain(out: &mut String, grant: &TaskGrant, catalog: &EffectCatalog) {
     }
     let _ = writeln!(out, "Limits:  {}", join_dot(limits));
 
-    // Risk.
-    let legs = grant.risk.exposure_legs.len();
-    let names: Vec<&str> = grant
-        .risk
-        .exposure_legs
-        .iter()
-        .map(|l| leg_name(*l))
-        .collect();
-    let risk_line = if legs == 3 {
-        let gated: Vec<String> = grant
-            .risk
-            .approval_gated
-            .iter()
-            .map(|o| o.to_string())
-            .collect();
-        if gated.is_empty() {
-            "all 3 exposure legs present (private data + untrusted content + exfiltration)"
-                .to_string()
-        } else {
-            format!(
-                "all 3 exposure legs present → the kernel asks for approval before {}",
-                gated.join(", ")
-            )
-        }
-    } else {
-        let missing: Vec<&str> = [
-            ExposureLabel::PrivateData,
-            ExposureLabel::UntrustedContent,
-            ExposureLabel::ExfilVector,
-        ]
-        .iter()
-        .filter(|l| !grant.risk.exposure_legs.contains(l))
-        .map(|l| leg_name(*l))
-        .collect();
-        let present = if names.is_empty() {
-            String::new()
-        } else {
-            format!(" ({})", names.join(" + "))
-        };
-        format!(
-            "{legs} of 3 exposure legs{present}; {} absent → no approval prompts expected",
-            missing.join(" and ")
-        )
-    };
-    let _ = writeln!(out, "Risk:    {risk_line}");
+    // Risk. One producer, in `exposure_mechanism`: which legs, what the
+    // combination permits, and whether the kernel will stop to ask.
+    let _ = writeln!(
+        out,
+        "Risk:    {}",
+        crate::exposure_mechanism::risk_line(&grant.risk)
+    );
 }
 
 fn render_technical(out: &mut String, grant: &TaskGrant) {
@@ -436,14 +398,6 @@ fn structural_absences(grant: &TaskGrant) -> Vec<String> {
     v
 }
 
-fn leg_name(l: ExposureLabel) -> &'static str {
-    match l {
-        ExposureLabel::PrivateData => "private data",
-        ExposureLabel::UntrustedContent => "untrusted content",
-        ExposureLabel::ExfilVector => "exfiltration",
-    }
-}
-
 fn level_name(l: CapabilityLevel) -> &'static str {
     match l {
         CapabilityLevel::Never => "never",
@@ -507,20 +461,36 @@ pub fn exposure_legs(caps: &crate::CapabilityLattice) -> Vec<ExposureLabel> {
     legs
 }
 
-/// Build the risk summary for a lattice.
-pub fn summarise_risk(lattice: &PermissionLattice, gap: WeakeningGap) -> RiskSummary {
+/// Build the risk summary for a weakening from `from` to `to`.
+///
+/// `before` is computed from `from`, not assumed. It used to be the literal
+/// `StateRisk::Safe` — a claim about the starting point that nothing checked,
+/// and one that was wrong for every caller in the tree. Both weaken from
+/// `PermissionLattice::restrictive()`, which holds the three read capabilities
+/// at `Always`: one exposure leg, `StateRisk::Low`. So every policy trace ever
+/// printed opened with `risk Safe → X` about a run that started from Low.
+///
+/// Taking both lattices and the cost config, rather than a pre-computed gap,
+/// is what makes it checked: the same pair of lattices produces the gap and
+/// both grades, so the trace cannot describe a weakening from one floor while
+/// grading a different one.
+pub fn summarise_risk(
+    from: &PermissionLattice,
+    to: &PermissionLattice,
+    cost: &crate::WeakeningCostConfig,
+) -> RiskSummary {
     let constraint = IncompatibilityConstraint::enforcing();
     let approval_gated: Vec<Operation> = Operation::ALL
         .iter()
         .copied()
-        .filter(|op| lattice.obligations.requires(*op))
+        .filter(|op| to.obligations.requires(*op))
         .collect();
     RiskSummary {
-        before: StateRisk::Safe,
-        after: constraint.state_risk(&lattice.capabilities),
-        exposure_legs: exposure_legs(&lattice.capabilities),
+        before: constraint.state_risk(&from.capabilities),
+        after: constraint.state_risk(&to.capabilities),
+        exposure_legs: exposure_legs(&to.capabilities),
         approval_gated,
-        gap,
+        gap: cost.compute_gap(from, to),
     }
 }
 
@@ -530,8 +500,7 @@ mod tests {
     use crate::effect_catalog::EffectCatalog;
 
     fn grant_for(lattice: PermissionLattice, can: &[&str], hosts: &[&str]) -> TaskGrant {
-        let gap = crate::WeakeningCostConfig::default()
-            .compute_gap(&PermissionLattice::restrictive(), &lattice);
+        let cost = crate::WeakeningCostConfig::default();
         TaskGrant {
             version: TaskGrant::VERSION,
             id: Uuid::nil(),
@@ -550,7 +519,7 @@ mod tests {
                 blocked_paths: vec!["**/.ssh/**".into(), "**/.aws/**".into(), "**/.env".into()],
                 commands: vec!["cargo test".into()],
             },
-            risk: summarise_risk(&lattice, gap),
+            risk: summarise_risk(&PermissionLattice::restrictive(), &lattice, &cost),
             lattice,
             provenance: CompilerProvenance {
                 compiler: "test/0".into(),
@@ -589,7 +558,67 @@ mod tests {
             lines[3].starts_with("Limits:  $5.00 · 2h · api.github.com only · no .aws, .env, .ssh")
         );
         assert!(lines[4].starts_with("Risk:    "));
+        // The Risk line must say what the combination *permits*, not only how
+        // many legs it has. This grant reads the workspace and runs tests with
+        // no network reachable by an effect that carries data out, so the
+        // sentence is the one for private data without a path out. Asserted
+        // through the renderer rather than against a literal: the words live
+        // in `exposure_mechanism`, and this pins that the plain level reaches
+        // them at all.
+        assert_eq!(
+            lines[4],
+            format!(
+                "Risk:    {}",
+                crate::exposure_mechanism::risk_line(&grant.risk)
+            )
+        );
+        assert!(
+            lines[4].contains(crate::exposure_mechanism::mechanism(
+                &grant.risk.exposure_legs
+            )),
+            "the plain grant lost the mechanism sentence: {}",
+            lines[4]
+        );
         assert_eq!(lines.len(), 5, "plain is exactly five lines");
+    }
+
+    /// `before` is read from the lattice the weakening starts at.
+    ///
+    /// The literal it replaced was not merely unchecked, it was **wrong for
+    /// every caller in the tree**: both weaken from `PermissionLattice::
+    /// restrictive()`, and that floor holds `read_files`, `glob_search` and
+    /// `grep_search` at `Always` — one exposure leg, so `StateRisk::Low`. Every
+    /// policy trace ever printed said `risk Safe → X` about a run that started
+    /// from Low. The name "restrictive" is about what it withholds, not about
+    /// the floor being harmless, and the literal quietly assumed otherwise.
+    #[test]
+    fn before_is_computed_from_the_starting_lattice_not_assumed() {
+        let cost = crate::WeakeningCostConfig::default();
+        let floor = PermissionLattice::restrictive();
+        let wide = PermissionLattice::permissive();
+
+        let from_floor = summarise_risk(&floor, &wide, &cost);
+        assert_eq!(
+            from_floor.before,
+            StateRisk::Low,
+            "the restrictive floor can read the workspace; it is not Safe"
+        );
+
+        // The same destination, reached from somewhere that is already exposed.
+        let from_wide = summarise_risk(&wide, &wide, &cost);
+        assert_ne!(
+            from_wide.before,
+            StateRisk::Safe,
+            "a weakening that starts from an exposed lattice must not report Safe"
+        );
+        assert_eq!(
+            from_wide.before, from_wide.after,
+            "weakening a lattice to itself moves no risk"
+        );
+        assert_eq!(
+            from_floor.after, from_wide.after,
+            "`after` depends on the destination alone"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Part C of the DX plan. Independent of #2758 / #2762.

## The gap

Every disclosure level said the same two things about risk — a grade and a count:

```
Risk:    2 of 3 exposure legs (private data + untrusted content); exfiltration absent → no approval prompts expected
```

Two of three **what**? The sentence a person actually needs — *this combination lets repository data leave the sandbox* — existed at no level, in no renderer.

The material was all there and thrown away. `state_risk` computes the three legs as named booleans and collapses them to a count on the next line. `UninhabitableState` has carried a `name` field for exactly this purpose since it was introduced, and no renderer has ever read it.

## What changed

`exposure_mechanism::mechanism` answers "what does *this* combination permit" for all eight subsets, with no catch-all — a fourth leg fails to compile rather than inheriting the nearest sentence.

Before / after, on real lattices:

```
restrictive  1 of 3 exposure legs (private data); untrusted content and exfiltration absent
             → the agent can read private data, but nothing steers what it reads and nothing carries it out; no approval prompts expected
             trace: risk Low → Low

permissive   all 3 exposure legs present (private data + untrusted content + exfiltration)
             → untrusted content can direct the agent to read private data and send it out of the sandbox;
               the kernel asks for approval before run_bash, git_push, create_pr
             trace: risk Low → Uninhabitable
```

The eight subsets are spelled out rather than composed from per-leg fragments, because the content is in the **joins**. "Can read private data" and "can reach the network" are two facts; "whatever it reads can leave" is a third that exists only when both hold. A generated sentence would have said the first two and lost the one worth reading. There are three two-leg combinations permitting three different things — one *is* the exfiltration path, two are not. That is exactly the distinction the count erased, and it is the property the tests pin.

## Two claims that were made without looking

**`before: StateRisk::Safe` was a literal — and wrong for every caller in the tree.** Both callers weaken from `PermissionLattice::restrictive()`, which holds `read_files`, `glob_search` and `grep_search` at `Always`. That is one exposure leg: `StateRisk::Low`. So every policy trace ever printed opened `risk Safe → X` about a run that started from Low. "Restrictive" describes what the floor withholds, not the floor being harmless.

The plan predicted this would be *unchecked*; measuring it showed it was *false*. `summarise_risk` now takes both lattices plus the cost config and derives the gap and both grades from the same pair, so a trace can no longer describe a weakening from one floor while grading a different one.

**`no approval prompts expected` was inferred from the leg count.** Any grant with fewer than three legs was told flatly that nothing would prompt — false for any grant whose obligations came from another route: an effect pack that gates an operation, a ceiling profile that does, a narrowed grant that inherited one. Such a grant promised no prompts and then prompted. It now reads `approval_gated`.

## Scope

`StateRisk` is untouched. The kernel gates on it and the Lean development reasons about it; this is rendering, deliberately kept out of its way. Both the grade's return type and `is_uninhabitable` are unchanged.

`cargo test -p portcullis -p nucleus-task-compiler --all-features` green (1209 + …, 0 failures). Workspace check, clippy, fmt, `check-mediation.sh`, `check-line-ratchet.sh --strict`, `no-vendor-strings.sh` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G5M7Aj6CFhHjmMep2rv9R8