### PR TITLE
feat(action): the shipped CI surface speaks goals, not profiles

### DIFF
--- a/.github/workflows/action-smoke-test.yml
+++ b/.github/workflows/action-smoke-test.yml
@@ -78,6 +78,47 @@ jobs:
           echo "$OUTPUT" | grep -q "read_files: Always" || { echo "::error::read_files should be Always"; exit 1; }
           echo "PASS: safe_pr_fixer profile validates correctly"
 
+      - name: 'Dry-run: a goal compiles into a grant, and the ceiling clips it'
+        run: |
+          set -euo pipefail
+          # The goal path the Action now offers. Nothing here needs an LLM key:
+          # compiling, sealing and rendering a grant is the part that decides
+          # authority, and it happens before any agent runs.
+          export NUCLEUS_GRANT_KEY="${RUNNER_TEMP}/smoke-grant-key.pem"
+          GRANT="${RUNNER_TEMP}/smoke-grant.json"
+
+          nucleus grant seal \
+            --goal 'Fix the failing CI build and open a pull request with the fix' \
+            --ceiling codegen --explain plain --yes \
+            --approver 'github-actions[smoke]' \
+            -o "$GRANT"
+
+          RENDER=$(nucleus grant show "$GRANT" --explain plain)
+          echo "$RENDER"
+
+          # The five lines a person reviews.
+          for LINE in 'Goal:' 'Can:' 'Cannot:' 'Limits:' 'Risk:'; do
+            echo "$RENDER" | grep -q "^${LINE}" || { echo "::error::grant render is missing the ${LINE} line"; exit 1; }
+          done
+
+          # Non-vacuity, and the property that matters: the ceiling is what
+          # bounds a compiled grant, so a goal that asks to open a pull request
+          # under the codegen ceiling must be REFUSED that effect, not granted
+          # it. A render whose Cannot line said nothing would pass the check
+          # above while proving nothing.
+          echo "$RENDER" | grep -q 'outside ceiling codegen' \
+            || { echo "::error::the ceiling clipped nothing — a goal asking for more than codegen allows was not bounded"; exit 1; }
+
+          # The grant, in the job summary, exactly as the Action puts it there.
+          {
+            echo '### Smoke-test grant'
+            echo
+            echo '```'
+            echo "$RENDER"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo 'PASS: a goal compiles, seals, renders, and is bounded by its ceiling'
+
       - name: 'Dry-run: all profiles'
         run: |
           PROFILES="restrictive read-only code-review edit-only local-dev fix-issue safe_pr_fixer release demo full"

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,29 @@ inputs:
   issue-number:
     description: 'GitHub issue number to fix'
     required: true
+  goal:
+    description: |
+      State the outcome you want, and nucleus compiles the minimum authority
+      it needs — met with `ceiling`, which is the only knob that widens.
+      The compiled grant is sealed, shown in the job summary as Can / Cannot /
+      Limits / Risk, and the run executes under it, enforced per effect.
+
+      Leave empty to use `profile` instead. A profile is a fixed authority
+      chosen before anyone knew what the task was; a goal is compiled from
+      this issue, so the same Action grants less for a smaller issue.
+    default: ''
+  ceiling:
+    description: |
+      The profile a compiled grant may never exceed. Only meaningful with
+      `goal`. Widening this is the one decision that widens authority, and
+      it is deliberately a separate, named input rather than a side effect
+      of the goal text.
+    default: 'codegen'
+  explain:
+    description: |
+      How much of the grant to put in the job summary: plain | technical |
+      policy-trace. Only meaningful with `goal`.
+    default: 'plain'
   model:
     description: 'LLM model to use'
     default: 'claude-sonnet-4-20250514'
@@ -16,7 +39,7 @@ inputs:
     description: 'LLM API key (e.g., ANTHROPIC_API_KEY)'
     required: true
   profile:
-    description: 'Nucleus permission profile'
+    description: 'Nucleus permission profile. Ignored when `goal` is set.'
     default: 'safe_pr_fixer'
   timeout:
     description: 'Timeout in seconds'
@@ -29,6 +52,9 @@ inputs:
     default: ''
 
 outputs:
+  grant:
+    description: 'Path to the sealed grant the run executed under (empty unless `goal` was set)'
+    value: ${{ steps.fix.outputs.grant }}
   branch:
     description: 'Branch name created for the fix'
     value: ${{ steps.fix.outputs.branch }}
@@ -84,6 +110,9 @@ runs:
       shell: bash
       env:
         NUCLEUS_PROFILE: ${{ inputs.profile }}
+        NUCLEUS_GOAL: ${{ inputs.goal }}
+        NUCLEUS_CEILING: ${{ inputs.ceiling }}
+        NUCLEUS_EXPLAIN: ${{ inputs.explain }}
         ISSUE_NUMBER: ${{ inputs.issue-number }}
         LLM_API_TOKEN: ${{ inputs.api-key }}
         NUCLEUS_TIMEOUT: ${{ inputs.timeout }}

--- a/scripts/action-entrypoint.sh
+++ b/scripts/action-entrypoint.sh
@@ -1,7 +1,21 @@
 #!/usr/bin/env bash
 # Nucleus Safe PR Fixer — GitHub Action entrypoint
 #
-# The agent runs under the safe_pr_fixer profile, which allows:
+# Two ways in, and the difference is the whole point of the delegation
+# compiler.
+#
+#   NUCLEUS_GOAL set  — state the outcome. Nucleus compiles it into the
+#     minimum authority that outcome needs, met with NUCLEUS_CEILING, seals
+#     the result, and runs under it enforced per effect. The grant is
+#     compiled from *this* issue, so a smaller issue is granted less.
+#
+#   NUCLEUS_GOAL empty — the profile path below, unchanged. A profile is a
+#     fixed authority chosen before anyone knew what the task was.
+#
+# The shipped CI surface used to offer only the second. "One delegation
+# model, many execution surfaces" failed at the first surface it shipped on.
+#
+# Under a profile, the agent runs under safe_pr_fixer, which allows:
 #   - Read all files, write/edit/test with LowRisk
 #   - Commit locally (git_write=LowRisk)
 #   - Web fetch for docs lookup (web_fetch=LowRisk)
@@ -18,6 +32,9 @@ set -euo pipefail
 : "${ISSUE_NUMBER:?ISSUE_NUMBER is required}"
 : "${LLM_API_TOKEN:?LLM_API_TOKEN is required}"
 : "${NUCLEUS_PROFILE:=safe_pr_fixer}"
+: "${NUCLEUS_GOAL:=}"
+: "${NUCLEUS_CEILING:=codegen}"
+: "${NUCLEUS_EXPLAIN:=plain}"
 : "${NUCLEUS_TIMEOUT:=3600}"
 : "${LLM_MODEL:=claude-sonnet-4-20250514}"
 
@@ -43,9 +60,8 @@ fi
 git checkout -b "$BRANCH"
 echo "::endgroup::"
 
-echo "::group::Run Nucleus agent"
-# Build the prompt from the issue
-PROMPT="Fix the following GitHub issue. Read the codebase, understand the problem, implement the fix, and run tests.
+# The task, as the person would state it.
+TASK="Fix the following GitHub issue. Read the codebase, understand the problem, implement the fix, and run tests.
 
 Issue #${ISSUE_NUMBER}: ${ISSUE_TITLE}
 
@@ -53,15 +69,99 @@ ${ISSUE_BODY}
 
 After fixing, commit your changes with a clear commit message referencing issue #${ISSUE_NUMBER}."
 
-# Run under lattice enforcement (local mode — no Firecracker needed in CI)
-nucleus run \
-  --local \
-  --profile "$NUCLEUS_PROFILE" \
-  --timeout "$NUCLEUS_TIMEOUT" \
-  --model "$LLM_MODEL" \
-  --env "LLM_API_TOKEN=${LLM_API_TOKEN}" \
-  "$PROMPT"
-echo "::endgroup::"
+# What the PR's Security section says about how this run was authorised.
+AUTHORITY="Profile: \`${NUCLEUS_PROFILE}\`"
+
+if [ -n "${NUCLEUS_GOAL}" ]; then
+  # ── Goal path ────────────────────────────────────────────────────────────
+  #
+  # Sealing is the confirmation. `grant seal` compiles the goal exactly as
+  # `run --goal` does, renders the five lines, and signs the result; `run
+  # --grant` then executes it with no second decision. That is C(T) = 1 for
+  # a new task and 0 for a repeat, on the CI surface: the sealed grant is a
+  # file, and a workflow that caches it never compiles again.
+  #
+  # Sealed BEFORE the run, and shown from the sealed file rather than
+  # scraped out of the run's output, so the summary says what the run is
+  # authorised to do even when the run fails.
+  GOAL="${NUCLEUS_GOAL}
+
+${TASK}"
+  GRANT_FILE="${RUNNER_TEMP:-/tmp}/nucleus-grant-${ISSUE_NUMBER}.json"
+
+  echo "::group::Compile the goal into a grant"
+  nucleus grant seal \
+    --goal "$GOAL" \
+    --ceiling "$NUCLEUS_CEILING" \
+    --explain "$NUCLEUS_EXPLAIN" \
+    --yes \
+    --approver "github-actions[${GITHUB_WORKFLOW:-workflow}]" \
+    -o "$GRANT_FILE"
+  echo "::endgroup::"
+
+  # The grant, in the job summary, where a reviewer reads it without
+  # unfolding a log group.
+  GRANT_RENDER=$(nucleus grant show "$GRANT_FILE" --explain "$NUCLEUS_EXPLAIN")
+  {
+    echo "### Delegated authority for issue #${ISSUE_NUMBER}"
+    echo
+    echo "Compiled from the goal, met with the \`${NUCLEUS_CEILING}\` ceiling."
+    echo
+    echo '```'
+    echo "$GRANT_RENDER"
+    echo '```'
+  } >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
+
+  echo "grant=${GRANT_FILE}" >> "${GITHUB_OUTPUT:-/dev/null}"
+
+  # A grant's lifetime is set by the ceiling, not by this Action, and the
+  # default here (3600s) is exactly the codegen ceiling's hour. So the default
+  # configuration runs the agent until the moment its authority expires, and
+  # any delay between sealing and starting makes the last stretch of the run
+  # certain to be denied — every tool call refused, no output, and a log that
+  # blames the tool rather than the clock.
+  #
+  # Clamp the timeout to what the grant actually has left. Losing the tail of a
+  # run is better than spending it being refused, and the warning names the
+  # real constraint so the operator raises the ceiling rather than the timeout.
+  NOT_AFTER=$(jq -r '.grant.not_after' "$GRANT_FILE")
+  GRANT_LEFT=$(( $(date -u -d "$NOT_AFTER" +%s) - $(date -u +%s) - 30 ))
+  if [ "$GRANT_LEFT" -lt 1 ]; then
+    echo "::error::The sealed grant has already expired (not_after ${NOT_AFTER})."
+    exit 1
+  fi
+  if [ "$NUCLEUS_TIMEOUT" -gt "$GRANT_LEFT" ]; then
+    echo "::warning::timeout ${NUCLEUS_TIMEOUT}s exceeds the grant's remaining ${GRANT_LEFT}s (ceiling '${NUCLEUS_CEILING}' sets the lifetime); running for ${GRANT_LEFT}s."
+    NUCLEUS_TIMEOUT="$GRANT_LEFT"
+  fi
+  AUTHORITY="Compiled grant, ceiling \`${NUCLEUS_CEILING}\`:
+
+\`\`\`
+${GRANT_RENDER}
+\`\`\`"
+
+  echo "::group::Run Nucleus agent"
+  # No prompt: a sealed grant carries its own goal, and the digest binds the
+  # two together so the run cannot execute a task the grant was not shown for.
+  nucleus run \
+    --local \
+    --grant "$GRANT_FILE" \
+    --timeout "$NUCLEUS_TIMEOUT" \
+    --model "$LLM_MODEL" \
+    --env "LLM_API_TOKEN=${LLM_API_TOKEN}"
+  echo "::endgroup::"
+else
+  # ── Profile path ─────────────────────────────────────────────────────────
+  echo "::group::Run Nucleus agent"
+  nucleus run \
+    --local \
+    --profile "$NUCLEUS_PROFILE" \
+    --timeout "$NUCLEUS_TIMEOUT" \
+    --model "$LLM_MODEL" \
+    --env "LLM_API_TOKEN=${LLM_API_TOKEN}" \
+    "$TASK"
+  echo "::endgroup::"
+fi
 
 # Check if the agent made any commits
 DEFAULT_BRANCH=$(git remote show origin 2>/dev/null | grep 'HEAD branch' | awk '{print $NF}')
@@ -90,7 +190,8 @@ Automated fix for #${ISSUE_NUMBER} by Nucleus safe PR fixer.
 
 ## Security
 
-- Profile: \`${NUCLEUS_PROFILE}\`
+${AUTHORITY}
+
 - The agent could read, write, edit, and commit — but could NOT push or create this PR.
 - This PR was created by the trusted CI script, not the agent.
 - All agent actions were audit-logged with HMAC signatures.


### PR DESCRIPTION
Part D of the DX plan. Independent of #2762 / #2763.

## The gap

`action.yml` took `issue-number` and `profile: safe_pr_fixer`, and set `NUCLEUS_PROFILE`. The one surface nucleus actually ships into other people's repositories taught the abstraction the delegation compiler exists to replace — a fixed authority chosen before anyone knew what the task was.

"One delegation model, many execution surfaces" failed at the first surface.

## What changed

A `goal:` input. When set, the entrypoint compiles *this issue* into the minimum authority it needs, seals it, shows it, and runs under it enforced per effect. `profile:` still works unchanged when `goal:` is empty.

`ceiling:` stays a separate, named input on purpose: widening it is the one decision that widens authority, and it must never become a side effect of goal text.

The grant is sealed **before** the run and rendered from the sealed file rather than scraped out of the run's output, so the job summary shows Can / Cannot / Limits / Risk even when the run fails. The PR's Security section carries those five lines instead of a profile name.

Sealing is also what makes `C(T) = 1` then `0` real here: the grant is a file, and a workflow that caches it never compiles again.

Verified against the real binary, headless:

```
Goal:    Fix the failing CI build and open a pull request with the fix
Can:     read and search workspace files · read git history and status · edit workspace files · commit changes locally · build the project · run the test suite
Cannot:  read CI logs and workflow runs (outside ceiling codegen: web_fetch is never) · open or merge pull requests · reach the network · spawn agents or pods
Limits:  $5.00 · 59m · no network · no .aws, .env, .ssh, …
Risk:    2 of 3 exposure legs (private data + exfiltration); untrusted content absent
```

## Two things measuring it turned up

**The default configuration ran the agent past its own authority.** A grant's lifetime comes from the ceiling, not from this Action, and the `codegen` ceiling's hour is exactly the default `timeout: 3600`. Any delay between sealing and starting made the tail of every run certain to be refused — every tool call denied, no output, and a log blaming the tool rather than the clock. Measured on the real sealed grant: `not_after` leaves 3543s, default timeout 3600s, so it clamps. The warning names the ceiling, so an operator raises the right knob.

**The smoke test's new lane needs no LLM key**, because compiling and sealing is the part that decides authority and it happens before any agent runs. It asserts the five lines — and then asserts the ceiling actually *clipped* something: the goal asks to open a pull request, `codegen` does not allow it, and the render must say so. Without that second check, a grant that granted everything would pass the first. Both assertions run locally against the built binary and hold.

`shellcheck -S info` clean on the entrypoint; `actionlint` reports nothing on the new step (the two pre-existing findings elsewhere in that file are untouched).

## Noted, not fixed

The same file still does `npm install -g` a specific vendor's CLI, which README's own Known Gaps already flags as the vendor-neutrality break. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G5M7Aj6CFhHjmMep2rv9R8