### PR TITLE
docs(adr-0004): D, the five moments, and why a denial explains itself to an agent

### DIFF
--- a/docs/adr/0004-delegation-compiler.md
+++ b/docs/adr/0004-delegation-compiler.md
@@ -29,14 +29,54 @@ exercised, and an observer that synthesizes a narrower profile from a trace.
 
 The DX north star this ADR serves:
 
-> Make least-privilege delegation feel easier than unrestricted execution.
+> Minimize the distance between human intent and safely executing that intent
+> through an agent — that is, **make least-privilege delegation feel easier than
+> unrestricted execution**.
 
-with two invariants DX work may not violate:
+Stated as a quantity, so it can be argued about:
+
+```text
+                   successful delegated work
+    D  =  ────────────────────────────────────────────────────────────────
+          human decisions + configuration + security knowledge + recovery friction
+```
+
+**The invariant: `D` may never improve by widening authority.** This is the same
+shape as ADR 0005's "ℐ may never be raised by weakening ≼", and it is what
+separates this from the field's answer to the same usability cost. Every term in
+the denominator has a cheap fix that consists of granting more, and every one of
+those fixes is forbidden. A DX change that lowers the denominator by raising
+`A_granted` has not improved `D`; it has changed which quantity is being measured.
+
+Two of the denominator's terms were instrumented from the start:
 
 - **Authority overhead** ρ = A_granted / A_observably-required → 1. Usability never
   improves by granting more.
 - **Delegation clicks** C(T) = 1 for a new safe task, 0 for a previously approved one.
   The consequential decision stays intentional; everything else is derived.
+
+`C(T)` counts decisions on the path where the grant was right the first time.
+**Recovery friction** is the term that decides whether a delegation survives being
+wrong — an agent refused something it needed, and how far it is from there back to
+working — and it is measured in `nucleus-perf agency --recovery-goal`. Security
+knowledge is the term nucleus does not yet measure; the proxy for it is whether a
+person ever has to read a lattice dimension to get unstuck.
+
+### The five moments
+
+`D` is spent in five places, and every DX decision in this ADR belongs to one:
+
+| moment | the question | where it is answered |
+|---|---|---|
+| **intent** | how does a person say what they want? | `--goal`, compiled — decision 1 |
+| **grant** | what are they agreeing to? | five lines, rendered by meaning — decision 3 |
+| **friction** | how many decisions does it cost? | C(T) = 1, then 0 — `--save-grant` / `--grant` |
+| **explanation** | when it refuses, what do they learn? | the escalation proposal — milestone 4 |
+| **reuse** | does the second time cost less than the first? | sealed grants, narrowing-only — decision 6 |
+
+The moments are not independent, and the ordering matters: an explanation that
+arrives after the run has ended is not an explanation, it is a post-mortem. That
+distinction is what milestone 7 is about.
 
 ## Decision
 
@@ -82,6 +122,25 @@ with two invariants DX work may not violate:
    and offer a profile with unused authority removed. None of those steps may
    introduce a path that widens authority outside `POST /v1/escalate` and the
    existing approval counters.
+7. **A denial is told to the agent as well as to the person.** The escalation
+   proposal — what was attempted, why it was stopped, the least authority that
+   would have allowed it, the new risk that adds, and the command that grants
+   exactly that — goes to both audiences, in band, on the refusal itself.
+
+   This widens what an agent is told, and the justification is its **trust
+   position**: the agent is *inside* the boundary and holds its own certificate,
+   so it can enumerate its own grant regardless. Telling it what it is missing
+   reveals nothing it could not compute, and withholding it only guarantees that
+   a recoverable refusal is spent thrashing.
+
+   **This is deliberately asymmetric with the token endpoint (#2756), and the two
+   must not be harmonised.** There, the caller is a *remote workload* whose
+   authority is still being decided; a refusal that named the scope it fell short
+   of would be an oracle for probing the ceiling, so it names nothing. The rule is
+   not "explain more" or "explain less" — it is that a refusal may enumerate
+   authority to a principal already inside the boundary, and may not to one still
+   outside it. Anyone reading only one of these two decisions will conclude the
+   other is a bug.
 
 ## Consequences
 
@@ -97,7 +156,15 @@ with two invariants DX work may not violate:
   and at the MCP boundary (tool names), so `github/read-ci-logs` cannot be spent on
   opening a pull request. Shell commands remain bounded by the command lattice.
 - Two metrics become product surfaces: ρ (authority granted ÷ authority used, from
-  receipts) and C(T) (authorization decisions per task).
+  receipts) and C(T) (authorization decisions per task). Recovery friction joins
+  them as a third, measured in the agency harness rather than at runtime, because
+  it is a property of the loop and not of a single run.
+- Effect packs are the lever on both halves at once. A pack that names one effect
+  covering what a person actually meant lowers ρ *and* removes a decision; a pack
+  full of broad effects raises ρ while looking like better DX. **Plugin quality is
+  semantic compression of authority**, and the two ways to measure a pack — ρ over
+  its effects, and how often granting one of them requires a second decision —
+  are the ways to tell the two apart.
 - A new CI gate, "The task compiler is offline by construction", is probed by the
   gate-of-gates like every other script gate.
 
@@ -108,6 +175,7 @@ with two invariants DX work may not violate:
 | 1 | Effect catalog, `TaskGrant` + renderer, `nucleus-task-compiler`, `nucleus run --goal` preview and single confirmation, offline gate | #2675 |
 | 2 | `effect/` certificate keys (`effect_surface`), `SealedTaskGrant` (grant + signed certificate, binding keys), `nucleus run --save-grant` / `--grant`, `nucleus grant seal|show` (C(T)=0) | this PR |
 | 3 | Trace → effect attribution (`grant_usage`), ρ over dimensions and effects, post-run usage lines and "save a narrower profile", `nucleus observe --grant --narrow --save`, user profiles in `~/.config/nucleus/profiles` (never wider than a canonical name) | this PR |
-| 4 | `EscalationProposal` (`escalation_proposal`): attempt, reason, minimum effect and raised dimensions, risk delta, scopes (always / this run), outside-ceiling and repair outcomes; `denials_in_trace`; post-run proposals; `nucleus grant propose\|widen`. Carriage inside MCP / tool-proxy / hook / SDK denial payloads is the next step | this PR |
+| 4 | `EscalationProposal` (`escalation_proposal`): attempt, reason, minimum effect and raised dimensions, risk delta, scopes (always / this run), outside-ceiling and repair outcomes; `denials_in_trace`; post-run proposals; `nucleus grant propose\|widen`. Carriage inside the denial payloads themselves lands in milestone 7 | this PR |
 | 5 | `AuthoritySummary` (`authority_metrics`, feature-free): ρ over dimensions, C(T) = confirmations + approvals, decision counts; in `ExitReport.authority`, the MCP `session_summary`, and the run's closing line; `PodSpec.metadata.task_grant_id` | this PR |
 | 6 | Per-effect enforcement from the certificate's `effect/` keys: `EffectCatalog::admits_http` / `admits_tool`; the tool-proxy refuses a `web_fetch` or credentialed-egress request no granted effect vouches for (method + host + path); mcp-guard blocks tools no granted effect names; `--goal` / `--grant` runs hand the sealed certificate to the proxy in local mode | this PR |
+| 7 | The explanation arrives in time to be used: `DenyReason` gets one rendering for all nineteen variants and every surface calls it; a refusal carries its escalation proposal in band (`ApiError::Refused`, `ErrorBody.proposal`, `Error::AccessDenied.proposal`); the risk line says what the combination *permits* rather than counting legs; `action.yml` takes a `goal:`; recovery friction becomes a measured row | #2758, #2762, #2763, #2764, #2765 |


### PR DESCRIPTION
Part F of the DX plan — the write-down for #2758, #2762, #2763, #2764, #2765.

Amends ADR 0004 rather than opening ADR 0006: it is the same decision one level more complete, and a fourth statement of direction is exactly the problem ADR 0005 just fixed.

## What it adds

**The quantity.** The ADR stated the north star as a sentence and two invariants, so "better DX" had no definition anyone could argue with:

```
D = successful delegated work
    ÷ (human decisions + configuration + security knowledge + recovery friction)
```

with the invariant that **`D` may never improve by widening authority** — the same shape as ADR 0005's "ℐ may never be raised by weakening ≼". This matters because every term in that denominator has a cheap fix consisting of granting more, and that is precisely the field's answer to the same usability cost. A change that lowers the denominator by raising `A_granted` has not improved `D`; it has changed which quantity is being measured.

**The terms, and which are measured.** ρ and C(T) were instrumented from the start. C(T) only counts the path where the grant was right the first time — recovery friction is the term that decides whether a delegation survives being *wrong*, and #2765 measures it. Security knowledge is named as the one still unmeasured, with its proxy (does a person ever have to read a lattice dimension to get unstuck), rather than quietly omitted.

**The five moments** — intent / grant / friction / explanation / reuse — with the decision that answers each, so a future DX change has somewhere to belong. The ordering carries the point: an explanation that arrives after the run has ended is not an explanation, it is a post-mortem.

**The plugin claim, sharpened.** Decision 2 already said plugin quality is semantic compression of authority. The Consequences now say how to *tell*: a pack that names one effect covering what a person meant lowers ρ and removes a decision; a pack full of broad effects raises ρ while looking like better DX.

## Decision 7 — the one judgement call

A denial's escalation proposal goes to the agent as well as the person, in band. Justified by the agent's trust position: it is inside the boundary and holds its own certificate, so it can enumerate its grant anyway.

Recorded together with **why it is deliberately the opposite of #2756's token endpoint**, where the caller is a remote workload whose authority is still being decided and a refusal naming the scope it fell short of would be an oracle for probing the ceiling.

The rule is not "explain more" or "explain less". It is that a refusal may enumerate authority to a principal already inside the boundary, and may not to one still outside it. Both are written in one place because anyone reading only one of them will conclude the other is a bug.

Docs-only. `formal-numbers.sh` and `no-vendor-strings.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G5M7Aj6CFhHjmMep2rv9R8