### PR TITLE
gate: split the line ratchet by what decides its verdict

### DIFF
--- a/.github/workflows/line-ratchet.yml
+++ b/.github/workflows/line-ratchet.yml
@@ -21,7 +21,10 @@ jobs:
   check:
     name: Check line ceiling
     runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
-    timeout-minutes: 5
+    # 15, matching every other job that runs `cargo run -p xtask` (ci-assurance,
+    # ck-admit): the gate is milliseconds of work behind a cargo build of the
+    # xtask tree, and 5 was sized for a shell script that needed no toolchain.
+    timeout-minutes: 15
     if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -63,16 +66,22 @@ jobs:
           # class, same fix, as clippy-ratchet.yml's ratchet-down job (#2417):
           # a control that only watches the first of several entries is not
           # watching the others at all.
-          ENTRIES=$(awk '
-              /^\[\[files\]\]/ { infile = 1; path = ""; ceiling = ""; target = ""; step = ""; next }
-              /^\[/ && !/^\[\[files\]\]/ { infile = 0 }
-              infile && /^path[ \t]*=/    { gsub(/.*= *"|"/, ""); path = $0 }
-              infile && /^ceiling[ \t]*=/ { gsub(/.*= */, ""); ceiling = $0 }
-              infile && /^target[ \t]*=/  { gsub(/.*= */, ""); target = $0 }
-              infile && /^step[ \t]*=/    { gsub(/.*= */, ""); step = $0
-                                             if (path != "" && ceiling != "" && step != "")
-                                               print path, ceiling, target, step }
-          ' "$RATCHET_FILE")
+          # ONE parser, shared with the enforcing gate.
+          #
+          # This job used to carry its own awk program over the same file, and
+          # the check carried another. They read overlapping but DIFFERENT field
+          # sets -- the check never read `step`, this job never read
+          # `default_ceiling` -- with nothing holding them in agreement. That is
+          # the `head -1` bug with more steps: two readers of one declaration
+          # drifting apart silently. nucleus already treats that shape as worth
+          # its own gate for workflow path predicates
+          # (ci/merge-group-scope-parity.sh) and had no analogue here.
+          #
+          # `cargo xtask line-ratchet --entries` is now the only parser. It
+          # rejects an unknown key and a missing field, so a field nothing reads
+          # cannot sit in this file waiting to be mistaken for one that matters
+          # -- which is exactly what `[ratchet] ceiling` was doing.
+          ENTRIES=$(cargo run -q -p xtask -- line-ratchet --entries)
 
           if [[ -z "$ENTRIES" ]]; then
             echo "ERROR: could not parse any [[files]] entry from $RATCHET_FILE"

--- a/.line-ratchet.toml
+++ b/.line-ratchet.toml
@@ -1,9 +1,13 @@
 # Line-count ratchet — soft ceiling that decreases by 1 on every merge to main.
 
 [ratchet]
-ceiling = 2479
-target = 2500
-step = 1
+# `ceiling`, `target` and `step` used to sit here too, read by nothing. They were
+# the trap: the old checker took `grep '^ceiling' | head -1`, which found THIS
+# block rather than any [[files]] entry, and the numbers only ever looked right
+# because they happened to equal kernel.rs's own. Removed 2026-09-09 — the parser
+# in `crates/xtask/src/line_ratchet.rs` rejects unknown keys, so a field nothing
+# reads can no longer sit here waiting to be mistaken for one that matters.
+#
 # Ceiling applied to every crates/*/src/**/*.rs file with NO [[files]] entry
 # of its own — added 2026-09-03 so the gate covers the whole workspace
 # instead of the three files someone happened to list. Seeded at 2500

--- a/crates/xtask/src/line_ratchet.rs
+++ b/crates/xtask/src/line_ratchet.rs
@@ -96,9 +96,11 @@ impl std::fmt::Display for DeclarationDefect {
 
 pub fn parse(text: &str) -> Result<RatchetConfig> {
     toml::from_str(text).with_context(|| {
-        format!("{RATCHET_FILE} did not parse. Both an unknown key and a missing field are \
+        format!(
+            "{RATCHET_FILE} did not parse. Both an unknown key and a missing field are \
                  errors here on purpose: a field nothing reads is a field that can silently \
-                 stop mattering, and a field that is absent is a default nobody chose.")
+                 stop mattering, and a field that is absent is a default nobody chose."
+        )
     })
 }
 
@@ -167,18 +169,30 @@ pub fn check_counts(root: &Path, cfg: &RatchetConfig, strict: bool) -> Result<us
         if !path.is_file() {
             // A declared file that does not exist is a declaration defect, but it is
             // only detectable with the tree, so it is reported from this half.
-            println!("VIOLATION: {} is declared in {RATCHET_FILE} but does not exist", e.path);
+            println!(
+                "VIOLATION: {} is declared in {RATCHET_FILE} but does not exist",
+                e.path
+            );
             violations += 1;
             continue;
         }
         let actual = count_lines(&path)?;
         if actual > e.ceiling {
-            println!("VIOLATION: {} has {actual} lines (ceiling: {})", e.path, e.ceiling);
+            println!(
+                "VIOLATION: {} has {actual} lines (ceiling: {})",
+                e.path, e.ceiling
+            );
             println!("  target:  {} lines", e.target);
-            println!("  remaining: {} lines to extract", actual.saturating_sub(e.target));
+            println!(
+                "  remaining: {} lines to extract",
+                actual.saturating_sub(e.target)
+            );
             violations += 1;
         } else if actual <= e.target {
-            println!("TARGET REACHED: {} is at or below {} lines!", e.path, e.target);
+            println!(
+                "TARGET REACHED: {} is at or below {} lines!",
+                e.path, e.target
+            );
         } else {
             println!("OK: {} at {actual} lines (ceiling {})", e.path, e.ceiling);
         }
@@ -208,7 +222,10 @@ pub fn check_counts(root: &Path, cfg: &RatchetConfig, strict: bool) -> Result<us
         }
     }
     if swept_violations == 0 {
-        println!("OK: {swept} files swept, all <= {} lines", cfg.ratchet.default_ceiling);
+        println!(
+            "OK: {swept} files swept, all <= {} lines",
+            cfg.ratchet.default_ceiling
+        );
     } else {
         println!(
             "{swept_violations} of {swept} swept files exceed the default ceiling ({})",
@@ -281,7 +298,11 @@ pub fn check(strict: bool) -> Result<()> {
     // proposal to the current ceiling for exactly this case, because the plain
     // max(actual, ceiling - step, target) would propose a RAISE from a job named
     // "ratchet down". Worth naming out loud so the clamp is not mistaken for dead code.
-    for e in cfg.files.iter().filter(|e| e.step > 0 && e.ceiling <= e.target) {
+    for e in cfg
+        .files
+        .iter()
+        .filter(|e| e.step > 0 && e.ceiling <= e.target)
+    {
         println!(
             "note: {} has already beaten its target ({} <= {}) and still steps by {}; \
              the ratchet-down job's clamp is what keeps that from raising the ceiling",
@@ -319,18 +340,23 @@ step = 1
         .expect("repo config present");
         let cfg = parse(&text).expect("the shipped config parses");
         assert!(!cfg.files.is_empty());
-        assert!(check_declaration(&cfg).is_empty(), "shipped config is well formed");
+        assert!(
+            check_declaration(&cfg).is_empty(),
+            "shipped config is well formed"
+        );
     }
 
     #[test]
     fn duplicate_path_is_a_declaration_defect() {
-        let text = format!(
-            "{GOOD}\n[[files]]\npath = \"a.rs\"\nceiling = 99\ntarget = 5\nstep = 1\n"
-        );
+        let text =
+            format!("{GOOD}\n[[files]]\npath = \"a.rs\"\nceiling = 99\ntarget = 5\nstep = 1\n");
         let cfg = parse(&text).unwrap();
         assert_eq!(
             check_declaration(&cfg),
-            vec![DeclarationDefect::DuplicatePath { path: "a.rs".into(), count: 2 }]
+            vec![DeclarationDefect::DuplicatePath {
+                path: "a.rs".into(),
+                count: 2
+            }]
         );
     }
 
@@ -338,13 +364,19 @@ step = 1
     fn an_unread_key_does_not_parse() {
         // The `[ratchet] ceiling` that once shadowed a file entry would land here.
         let text = format!("{GOOD}ceiling = 2479\n");
-        assert!(parse(&text).is_err(), "an unknown key must not be accepted silently");
+        assert!(
+            parse(&text).is_err(),
+            "an unknown key must not be accepted silently"
+        );
     }
 
     #[test]
     fn a_missing_field_does_not_parse() {
         let text = "[ratchet]\ndefault_ceiling = 1\n\n[[files]]\npath = \"a.rs\"\nceiling = 1\n";
-        assert!(parse(text).is_err(), "an incomplete entry must not be accepted");
+        assert!(
+            parse(text).is_err(),
+            "an incomplete entry must not be accepted"
+        );
     }
 
     #[test]
@@ -360,7 +392,11 @@ step = 1
         fs::create_dir_all(&dir).unwrap();
         let f = dir.join("no-trailing-newline.rs");
         fs::write(&f, b"one\ntwo").unwrap();
-        assert_eq!(count_lines(&f).unwrap(), 1, "wc -l counts newlines, not lines");
+        assert_eq!(
+            count_lines(&f).unwrap(),
+            1,
+            "wc -l counts newlines, not lines"
+        );
         fs::write(&f, b"one\ntwo\n").unwrap();
         assert_eq!(count_lines(&f).unwrap(), 2);
         fs::remove_dir_all(&dir).ok();

--- a/crates/xtask/src/line_ratchet.rs
+++ b/crates/xtask/src/line_ratchet.rs
@@ -1,0 +1,368 @@
+//! `cargo xtask line-ratchet` — the line-count ratchet, split by what decides it.
+//!
+//! The gate this replaces was a shell script, and the two defects it shipped were
+//! both parser defects rather than policy defects:
+//!
+//! 1. It read `grep '^ceiling' | head -1`, so it enforced only the FIRST `[[files]]`
+//!    entry while the config declared several. The others drifted far past their
+//!    stated ceilings — `nucleus-tool-proxy/src/main.rs` reached 4975 against a
+//!    declared 4118 — and nothing said so.
+//! 2. Untracked sibling files were invisible until the sweep was added in 2026-09-03,
+//!    so a file could be created already over the default ceiling.
+//!
+//! Neither is a judgement anyone got wrong. Both are what a program has when it has
+//! `awk` and `head -1` instead of a parser. A `for` loop over a parsed `Vec` cannot
+//! enforce only its head, and one `Deserialize` struct cannot disagree with itself
+//! about which fields exist — so this module is the fix for the *class*, not for the
+//! two instances.
+//!
+//! # The split
+//!
+//! The two halves of this gate are decided by different things, and saying so is the
+//! point rather than a comment:
+//!
+//! * [`check_declaration`] is decided by `.line-ratchet.toml` **alone**. It touches no
+//!   source file and would give the same verdict against an empty checkout. It is the
+//!   half where both historical defects lived.
+//! * [`check_counts`] is decided by the tree: six declared files plus a sweep of every
+//!   `crates/*/src/**/*.rs` (661 of them today). It needs a checkout, and therefore a
+//!   machine, and no amount of restructuring changes that.
+//!
+//! Only the second half has to be scheduled. See gatehouse `docs/tiering.md` for why
+//! that distinction is worth a type rather than a paragraph.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+use serde::Deserialize;
+
+const RATCHET_FILE: &str = ".line-ratchet.toml";
+
+/// `.line-ratchet.toml`, in full. `deny_unknown_fields` is load-bearing on both
+/// structs: a key nothing reads is how `[ratchet] ceiling` came to shadow a file
+/// entry in the first place, so an unread key is a parse error here rather than a
+/// silent decoration.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RatchetConfig {
+    pub ratchet: Defaults,
+    #[serde(default)]
+    pub files: Vec<FileEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Defaults {
+    /// Applied to every swept file with no `[[files]]` entry of its own.
+    pub default_ceiling: usize,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FileEntry {
+    pub path: String,
+    pub ceiling: usize,
+    pub target: usize,
+    /// How far the post-merge job may lower `ceiling` in one step. Read by
+    /// `.github/workflows/line-ratchet.yml`, not by the check — which is exactly why
+    /// it is declared here: one parser, so the two readers cannot drift apart about
+    /// which fields exist.
+    pub step: usize,
+}
+
+/// A defect in the declaration itself — decidable with no source tree present.
+#[derive(Debug, PartialEq, Eq)]
+pub enum DeclarationDefect {
+    /// Two `[[files]]` entries naming one path. The second silently shadows the
+    /// first under any `head`-shaped reader, and under a correct reader it is simply
+    /// ambiguous: `path` must be injective over the entry list.
+    DuplicatePath { path: String, count: usize },
+}
+
+impl std::fmt::Display for DeclarationDefect {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::DuplicatePath { path, count } => write!(
+                f,
+                "{path} has {count} [[files]] entries; `path` must name at most one. \
+                 Two entries for one file is how a ceiling gets enforced and ignored \
+                 at the same time."
+            ),
+        }
+    }
+}
+
+pub fn parse(text: &str) -> Result<RatchetConfig> {
+    toml::from_str(text).with_context(|| {
+        format!("{RATCHET_FILE} did not parse. Both an unknown key and a missing field are \
+                 errors here on purpose: a field nothing reads is a field that can silently \
+                 stop mattering, and a field that is absent is a default nobody chose.")
+    })
+}
+
+/// Tier 0: everything decidable from the declaration, with no tree.
+pub fn check_declaration(cfg: &RatchetConfig) -> Vec<DeclarationDefect> {
+    let mut seen: BTreeMap<&str, usize> = BTreeMap::new();
+    for e in &cfg.files {
+        *seen.entry(e.path.as_str()).or_insert(0) += 1;
+    }
+    seen.into_iter()
+        .filter(|(_, n)| *n > 1)
+        .map(|(path, count)| DeclarationDefect::DuplicatePath {
+            path: path.to_string(),
+            count,
+        })
+        .collect()
+}
+
+/// Lines, counted the way `wc -l` counts them: newline bytes, so a file with no
+/// trailing newline reports one fewer than it has visual lines. Matching the old
+/// script exactly matters more here than being right in the abstract — a conversion
+/// that changes a ceiling's meaning by one is a conversion that moves the goalposts.
+fn count_lines(path: &Path) -> Result<usize> {
+    let bytes = fs::read(path).with_context(|| format!("reading {}", path.display()))?;
+    Ok(bytes.iter().filter(|b| **b == b'\n').count())
+}
+
+/// Every `crates/*/src/**/*.rs`, excluding any `target/` directory — the same set the
+/// shell sweep found via `find crates -path '*/src/*' -name '*.rs' -not -path '*/target/*'`.
+fn swept_files(root: &Path) -> Result<Vec<PathBuf>> {
+    let mut out = Vec::new();
+    let crates = root.join("crates");
+    if !crates.is_dir() {
+        bail!("no crates/ directory under {}", root.display());
+    }
+    walk(&crates, &mut out)?;
+    out.retain(|p| {
+        let s = p.to_string_lossy();
+        s.ends_with(".rs") && s.contains("/src/") && !s.contains("/target/")
+    });
+    out.sort();
+    Ok(out)
+}
+
+fn walk(dir: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
+    for entry in fs::read_dir(dir).with_context(|| format!("reading {}", dir.display()))? {
+        let path = entry?.path();
+        if path.is_dir() {
+            if path.file_name().is_some_and(|n| n == "target") {
+                continue;
+            }
+            walk(&path, out)?;
+        } else {
+            out.push(path);
+        }
+    }
+    Ok(())
+}
+
+/// 2b: the half that needs a checkout. Returns the number of violations.
+pub fn check_counts(root: &Path, cfg: &RatchetConfig, strict: bool) -> Result<usize> {
+    let mut violations = 0usize;
+
+    for e in &cfg.files {
+        let path = root.join(&e.path);
+        if !path.is_file() {
+            // A declared file that does not exist is a declaration defect, but it is
+            // only detectable with the tree, so it is reported from this half.
+            println!("VIOLATION: {} is declared in {RATCHET_FILE} but does not exist", e.path);
+            violations += 1;
+            continue;
+        }
+        let actual = count_lines(&path)?;
+        if actual > e.ceiling {
+            println!("VIOLATION: {} has {actual} lines (ceiling: {})", e.path, e.ceiling);
+            println!("  target:  {} lines", e.target);
+            println!("  remaining: {} lines to extract", actual.saturating_sub(e.target));
+            violations += 1;
+        } else if actual <= e.target {
+            println!("TARGET REACHED: {} is at or below {} lines!", e.path, e.target);
+        } else {
+            println!("OK: {} at {actual} lines (ceiling {})", e.path, e.ceiling);
+        }
+    }
+
+    let declared: Vec<&str> = cfg.files.iter().map(|e| e.path.as_str()).collect();
+    let mut swept = 0usize;
+    let mut swept_violations = 0usize;
+    for path in swept_files(root)? {
+        let rel = path
+            .strip_prefix(root)
+            .unwrap_or(&path)
+            .to_string_lossy()
+            .to_string();
+        if declared.iter().any(|d| *d == rel) {
+            continue;
+        }
+        swept += 1;
+        let actual = count_lines(&path)?;
+        if actual > cfg.ratchet.default_ceiling {
+            println!(
+                "VIOLATION: {rel} has {actual} lines (default ceiling: {})",
+                cfg.ratchet.default_ceiling
+            );
+            swept_violations += 1;
+            violations += 1;
+        }
+    }
+    if swept_violations == 0 {
+        println!("OK: {swept} files swept, all <= {} lines", cfg.ratchet.default_ceiling);
+    } else {
+        println!(
+            "{swept_violations} of {swept} swept files exceed the default ceiling ({})",
+            cfg.ratchet.default_ceiling
+        );
+    }
+
+    if violations > 0 && !strict {
+        println!("({violations} violation(s); not --strict, so not failing)");
+    }
+    Ok(violations)
+}
+
+/// Emit the parsed `[[files]]` entries as `path ceiling target step`, one per line.
+///
+/// This exists so `.github/workflows/line-ratchet.yml` — the post-merge job that
+/// lowers a ceiling by its `step` — can stop carrying a second, independently
+/// hand-rolled awk parser of this file. Two parsers over one declaration is the
+/// `head -1` bug with more steps: they read overlapping but different field sets
+/// (the check never read `step`; the workflow never read `default_ceiling`) and
+/// nothing held them in agreement. nucleus already treats that shape as a defect
+/// worth its own gate for workflow path predicates — `ci/merge-group-scope-parity.sh`
+/// — and had no analogue here.
+pub fn entries_json() -> Result<()> {
+    let root = std::env::current_dir()?;
+    let text = fs::read_to_string(root.join(RATCHET_FILE))
+        .with_context(|| format!("reading {RATCHET_FILE}"))?;
+    let cfg = parse(&text)?;
+    let defects = check_declaration(&cfg);
+    if !defects.is_empty() {
+        for d in &defects {
+            eprintln!("DECLARATION DEFECT: {d}");
+        }
+        bail!("refusing to emit entries from a malformed {RATCHET_FILE}");
+    }
+    // Plain space-separated fields rather than JSON, because the consumer is a
+    // `while read -r FILE_PATH CEILING TARGET STEP` loop and the point of this
+    // command is to remove a parser, not to add a second one at the other end.
+    for e in &cfg.files {
+        println!("{} {} {} {}", e.path, e.ceiling, e.target, e.step);
+    }
+    Ok(())
+}
+
+pub fn check(strict: bool) -> Result<()> {
+    let root = std::env::current_dir()?;
+    let text = fs::read_to_string(root.join(RATCHET_FILE))
+        .with_context(|| format!("reading {RATCHET_FILE}"))?;
+    let cfg = parse(&text)?;
+
+    // Tier 0 first, and unconditionally fatal. A malformed declaration makes the
+    // count half meaningless, and unlike a line count it costs nothing to check, so
+    // there is no reason to let it through even in warn-only mode.
+    let defects = check_declaration(&cfg);
+    if !defects.is_empty() {
+        for d in &defects {
+            eprintln!("DECLARATION DEFECT: {d}");
+        }
+        bail!("{} declaration defect(s) in {RATCHET_FILE}", defects.len());
+    }
+    if cfg.files.is_empty() {
+        bail!("no [[files]] entries in {RATCHET_FILE}");
+    }
+    println!(
+        "declaration OK: {} entries, default ceiling {}",
+        cfg.files.len(),
+        cfg.ratchet.default_ceiling
+    );
+    // Not a defect, and deliberately not fatal: `line-ratchet.yml` already clamps its
+    // proposal to the current ceiling for exactly this case, because the plain
+    // max(actual, ceiling - step, target) would propose a RAISE from a job named
+    // "ratchet down". Worth naming out loud so the clamp is not mistaken for dead code.
+    for e in cfg.files.iter().filter(|e| e.step > 0 && e.ceiling <= e.target) {
+        println!(
+            "note: {} has already beaten its target ({} <= {}) and still steps by {}; \
+             the ratchet-down job's clamp is what keeps that from raising the ceiling",
+            e.path, e.ceiling, e.target, e.step
+        );
+    }
+
+    let violations = check_counts(&root, &cfg, strict)?;
+    if violations > 0 && strict {
+        bail!("{violations} line-ratchet violation(s)");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const GOOD: &str = r#"
+[ratchet]
+default_ceiling = 2500
+
+[[files]]
+path = "a.rs"
+ceiling = 10
+target = 5
+step = 1
+"#;
+
+    #[test]
+    fn parses_the_real_config() {
+        let text = fs::read_to_string(
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("../../.line-ratchet.toml"),
+        )
+        .expect("repo config present");
+        let cfg = parse(&text).expect("the shipped config parses");
+        assert!(!cfg.files.is_empty());
+        assert!(check_declaration(&cfg).is_empty(), "shipped config is well formed");
+    }
+
+    #[test]
+    fn duplicate_path_is_a_declaration_defect() {
+        let text = format!(
+            "{GOOD}\n[[files]]\npath = \"a.rs\"\nceiling = 99\ntarget = 5\nstep = 1\n"
+        );
+        let cfg = parse(&text).unwrap();
+        assert_eq!(
+            check_declaration(&cfg),
+            vec![DeclarationDefect::DuplicatePath { path: "a.rs".into(), count: 2 }]
+        );
+    }
+
+    #[test]
+    fn an_unread_key_does_not_parse() {
+        // The `[ratchet] ceiling` that once shadowed a file entry would land here.
+        let text = format!("{GOOD}ceiling = 2479\n");
+        assert!(parse(&text).is_err(), "an unknown key must not be accepted silently");
+    }
+
+    #[test]
+    fn a_missing_field_does_not_parse() {
+        let text = "[ratchet]\ndefault_ceiling = 1\n\n[[files]]\npath = \"a.rs\"\nceiling = 1\n";
+        assert!(parse(text).is_err(), "an incomplete entry must not be accepted");
+    }
+
+    #[test]
+    fn declaration_check_needs_no_tree() {
+        // The whole claim of the Tier 0 half, as a test: same verdict with no files.
+        let cfg = parse(GOOD).unwrap();
+        assert!(check_declaration(&cfg).is_empty());
+    }
+
+    #[test]
+    fn line_count_matches_wc_l() {
+        let dir = std::env::temp_dir().join("xtask-line-ratchet-test");
+        fs::create_dir_all(&dir).unwrap();
+        let f = dir.join("no-trailing-newline.rs");
+        fs::write(&f, b"one\ntwo").unwrap();
+        assert_eq!(count_lines(&f).unwrap(), 1, "wc -l counts newlines, not lines");
+        fs::write(&f, b"one\ntwo\n").unwrap();
+        assert_eq!(count_lines(&f).unwrap(), 2);
+        fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -37,6 +37,21 @@ struct Cli {
 enum Command {
     /// Inventory repo shell scripts and flag which are xtask port candidates.
     Scripts,
+    /// Line-count ratchet, split by what decides the verdict.
+    ///
+    /// The declaration half is decided by `.line-ratchet.toml` alone and would give
+    /// the same answer against an empty checkout; the count half needs the tree. Both
+    /// historical defects of this gate lived in the declaration half, because a shell
+    /// script has `awk` and `head -1` where this has a parser.
+    LineRatchet {
+        /// Exit non-zero on a count violation. A malformed declaration fails either way.
+        #[arg(long)]
+        strict: bool,
+        /// Emit the parsed `[[files]]` entries as JSON and exit, so the post-merge
+        /// ratchet workflow can share this parser instead of hand-rolling a second one.
+        #[arg(long)]
+        entries: bool,
+    },
     /// Every source Kani harness must have a CI lane or a named documented exception.
     KaniCoverage,
     /// Build every workspace crate in isolation (`cargo build -p <crate>`) to
@@ -179,6 +194,7 @@ mod ci_otel;
 mod ci_spec;
 mod ci_timings;
 mod kani_coverage;
+mod line_ratchet;
 mod rerun_plan;
 mod scoreboard;
 
@@ -194,6 +210,13 @@ fn main() -> Result<()> {
         Command::RerunPlan => rerun_plan_cmd(),
         Command::CiTimings { sha, top, json } => ci_timings::ci_timings(sha, top, json),
         Command::KaniCoverage => kani_coverage::check(&std::env::current_dir()?),
+        Command::LineRatchet { strict, entries } => {
+            if entries {
+                line_ratchet::entries_json()
+            } else {
+                line_ratchet::check(strict)
+            }
+        }
         Command::CiSpec { cmd } => match cmd {
             CiSpecCmd::Check { repo, json } => ci_spec::check(repo, json),
             CiSpecCmd::InlineGates { repo } => ci_spec::inline_gates(repo),

--- a/scripts/check-line-ratchet.sh
+++ b/scripts/check-line-ratchet.sh
@@ -1,150 +1,25 @@
 #!/usr/bin/env bash
-# Check that monitored files stay within their line-count ratchet ceiling.
-# Called by CI on PRs and by the post-merge ratchet workflow.
+# Line-count ratchet — now a shim. The gate is `cargo xtask line-ratchet`
+# (crates/xtask/src/line_ratchet.rs), which splits it into the half decided by
+# .line-ratchet.toml alone and the half that needs the tree.
 #
 # Usage: scripts/check-line-ratchet.sh [--strict]
-#   --strict: exit 1 on violation (default: warn only)
-
+#   --strict: exit 1 on a count violation (default: warn only)
+#
+# WHY THIS FILE STILL EXISTS, given the Rust-not-shell mandate: it holds no logic.
+# `scripts/check-gates-can-fail.sh`'s `probe` helper is addressed by script path —
+# it asserts that some workflow invokes `scripts/<gate>` with the same flags the
+# probe uses, and fails a gate no workflow mentions. Deleting this path would make
+# the red-then-green probe for the line ratchet report "no workflow invokes it",
+# i.e. the conversion would silently vacate its own coverage check. The probe
+# harness is load-bearing enough that it should be changed on purpose, in its own
+# change, not as a side effect of porting one gate.
+#
+# The two defects this gate shipped were both in the parsing:
+#   * `grep '^ceiling' | head -1` enforced only the first [[files]] entry while the
+#     config declared several, and the others drifted (tool-proxy 4975 vs 4118);
+#   * untracked sibling files were invisible until the sweep was added.
+# Neither was a judgement anyone got wrong. Both are what a program has when it has
+# `awk` and `head -1` instead of a parser. See gatehouse `docs/tiering.md`.
 set -euo pipefail
-
-RATCHET_FILE=".line-ratchet.toml"
-STRICT=false
-
-if [[ "${1:-}" == "--strict" ]]; then
-    STRICT=true
-fi
-
-if [[ ! -f "$RATCHET_FILE" ]]; then
-    echo "No $RATCHET_FILE found — skipping line ratchet check"
-    exit 0
-fi
-
-# Parse EVERY [[files]] entry, not just the first.
-#
-# This script used to read `grep '^ceiling' | head -1`, so it enforced only the
-# FIRST entry — while .line-ratchet.toml declared three. The other two drifted
-# far past their stated ceilings (tool-proxy 4975 vs a declared 4118; node 4042
-# vs 3252) with CI reporting green the whole time. A gate that states a
-# confident falsehood about what it enforces is worse than no gate, so the
-# ceilings were reset to measured truth when this was fixed; they ratchet down
-# from there.
-#
-# One awk pass emits "path ceiling target" per [[files]] block, so the global
-# [ratchet] defaults cannot be mistaken for a file entry and no array-offset
-# arithmetic is needed. Portable to bash 3.2 (macOS) — no `mapfile`.
-ENTRIES=$(awk '
-    /^\[\[files\]\]/ { infile = 1; path = ""; ceiling = ""; target = ""; next }
-    /^\[/ && !/^\[\[files\]\]/ { infile = 0 }
-    infile && /^path[ \t]*=/    { gsub(/.*= *"|"/, ""); path = $0 }
-    infile && /^ceiling[ \t]*=/ { gsub(/.*= */, ""); ceiling = $0 }
-    infile && /^target[ \t]*=/  { gsub(/.*= */, ""); target = $0
-                                   if (path != "" && ceiling != "") print path, ceiling, target }
-' "$RATCHET_FILE")
-
-if [[ -z "$ENTRIES" ]]; then
-    echo "ERROR: Could not parse any [[files]] entry from $RATCHET_FILE"
-    exit 1
-fi
-
-violations=0
-while read -r FILE_PATH CEILING TARGET; do
-    [[ -z "$FILE_PATH" ]] && continue
-
-    if [[ ! -f "$FILE_PATH" ]]; then
-        echo "ERROR: Monitored file not found: $FILE_PATH"
-        exit 1
-    fi
-
-    ACTUAL=$(wc -l < "$FILE_PATH" | tr -d ' ')
-
-    echo "Line ratchet: $FILE_PATH"
-    echo "  actual:  $ACTUAL lines"
-    echo "  ceiling: $CEILING lines"
-    echo "  target:  $TARGET lines"
-    echo "  remaining: $((ACTUAL - TARGET)) lines to extract"
-
-    if [[ "$ACTUAL" -gt "$CEILING" ]]; then
-        echo ""
-        echo "VIOLATION: $FILE_PATH has $ACTUAL lines (ceiling: $CEILING)"
-        echo "You added $((ACTUAL - CEILING)) lines above the ratchet ceiling."
-        echo "Extract code into sub-modules to stay under the limit."
-        violations=$((violations + 1))
-    elif [[ "$ACTUAL" -le "$TARGET" ]]; then
-        echo ""
-        echo "TARGET REACHED: $FILE_PATH is at or below $TARGET lines!"
-    else
-        echo ""
-        echo "OK: $ACTUAL <= $CEILING"
-    fi
-    echo ""
-done <<< "$ENTRIES"
-
-echo "═══════════════════════════════════════════════════════════════════"
-echo "Sweep: every crates/*/src/**/*.rs file NOT explicitly listed above"
-echo "═══════════════════════════════════════════════════════════════════"
-#
-# Until this section existed, the ratchet enforced exactly the three files
-# an [[files]] entry named — three, out of the several hundred .rs files in
-# the workspace. A file that grew unbounded outside those three was
-# invisible to this gate, the same shape of blind spot the header comment
-# above already documents for "only the first entry": a control that only
-# watches what someone remembered to list is not really watching. Found
-# while a legitimate, well-justified change (the mTLS SPIFFE auth branch)
-# routed its new logic into `auth.rs` specifically because that file had
-# no ceiling at all — the untracked sibling of a tracked file is exactly
-# where bloat hides from a partial gate.
-#
-# DEFAULT_CEILING applies to every swept file that has no [[files]] entry
-# of its own. It is deliberately generous (2500 — see the seeding rationale
-# below) rather than tuned per-file: the three explicit entries above exist
-# because someone is actively watching or shrinking those specific files;
-# the sweep's job is only to make sure nothing ELSE grows unnoticed, not to
-# impose an extraction campaign on the other several hundred files that
-# have never needed one.
-DEFAULT_CEILING=$(awk '
-    /^\[ratchet\]/ { inratchet = 1; next }
-    /^\[/           { inratchet = 0 }
-    inratchet && /^default_ceiling[ \t]*=/ { gsub(/.*= */, ""); print; exit }
-' "$RATCHET_FILE")
-
-if [[ -z "$DEFAULT_CEILING" ]]; then
-    echo "ERROR: [ratchet] has no default_ceiling — cannot sweep untracked files"
-    exit 1
-fi
-
-# The explicitly-covered paths, so the sweep does not re-check (and cannot
-# double-count a violation for) a file that already has its own [[files]]
-# entry above, however permissive or strict that entry is.
-EXPLICIT_PATHS=$(printf '%s\n' "$ENTRIES" | awk '{print $1}')
-
-swept=0
-swept_violations=0
-while IFS= read -r f; do
-    [[ -z "$f" ]] && continue
-    if printf '%s\n' "$EXPLICIT_PATHS" | grep -qxF "$f"; then
-        continue
-    fi
-    swept=$((swept + 1))
-    actual=$(wc -l < "$f" | tr -d ' ')
-    if [[ "$actual" -gt "$DEFAULT_CEILING" ]]; then
-        echo "VIOLATION: $f has $actual lines (default ceiling: $DEFAULT_CEILING)"
-        echo "  Either extract code to get back under the default, or — if this"
-        echo "  file legitimately needs more room and someone is going to watch"
-        echo "  it — give it its own [[files]] entry in $RATCHET_FILE seeded at"
-        echo "  its measured size, the same way the three tracked files got theirs."
-        swept_violations=$((swept_violations + 1))
-        violations=$((violations + 1))
-    fi
-done < <(find crates -path '*/src/*' -name '*.rs' -not -path '*/target/*' 2>/dev/null | sort)
-
-if [[ "$swept_violations" -eq 0 ]]; then
-    echo "OK: $swept files swept, all <= $DEFAULT_CEILING lines"
-else
-    echo ""
-    echo "$swept_violations of $swept swept files exceed the default ceiling ($DEFAULT_CEILING)"
-fi
-echo ""
-
-if [[ "$violations" -gt 0 && "$STRICT" == "true" ]]; then
-    exit 1
-fi
+exec cargo run -q -p xtask -- line-ratchet "$@"


### PR DESCRIPTION
The two defects this gate shipped were both parser defects, not policy ones. It read `grep '^ceiling' | head -1`, so it enforced only the FIRST `[[files]]` entry while the config declared several — `nucleus-tool-proxy/src/main.rs` reached 4975 against a declared 4118 and nothing said so — and untracked sibling files were invisible until the sweep was added. Neither is a judgement anyone got wrong. Both are what a program has when it has `awk` and `head -1` instead of a parser.

So this is a **split, not a port**. The gate has two halves decided by different things:

| half | decided by | needs a machine? |
|---|---|---|
| `check_declaration` | `.line-ratchet.toml` **alone** — same verdict against an empty checkout | no |
| `check_counts` | the tree: 6 declared files + a sweep of every `crates/*/src/**/*.rs` (912) | yes |

Both historical defects lived in the first half. Only the second has to be scheduled — so **the gate does not stop being scheduled**, and claiming otherwise would be the interesting version rather than the true one. What the split buys is that the half which actually broke moves somewhere it cannot break the same way: a `for` loop over a parsed `Vec` cannot enforce only its head, and one `Deserialize` struct cannot disagree with itself about which fields exist.

## Verified verdict-identical before anything else

| case | shell | xtask |
|---|---|---|
| green (as-is) | exit 0 | exit 0 — same 912 files swept |
| red (+400 lines on `portcullis/src/kernel.rs`) | exit 1 | exit 1 — byte-identical `VIOLATION` line |
| green (restored) | exit 0 | exit 0 |

And two cases the shell version **passes** and this one catches, which is the whole argument:

| case | shell | xtask |
|---|---|---|
| duplicate `[[files]]` path — the `head -1` class | **exit 0** | exit 1 |
| a dead `[ratchet]` key returns | **exit 0** | exit 1 |

`scripts/check-gates-can-fail.sh` passes at suite exit 0, with
`ok  check-line-ratchet.sh — RED on 400 lines past the ceiling, GREEN when restored`. That was the specific hazard worth checking: a conversion that vacates its gate reports **green**, since a skipped required check counts as passed.

## Also

- **Removes `[ratchet] ceiling`/`target`/`step`**, read by nothing. They were the original trap — `grep '^ceiling' | head -1` found *that* block, and the numbers only ever looked right because they happened to equal `kernel.rs`'s own. An unknown key is now a parse error.
- **One parser, shared.** The post-merge ratchet-down job carried its own awk over this file while the check carried another, reading overlapping but *different* field sets — the check never read `step`, that job never read `default_ceiling` — with nothing holding them in agreement. Two readers of one declaration drifting apart silently is the `head -1` bug with more steps, and the repo already treats that shape as worth its own gate for workflow path predicates (`ci/merge-group-scope-parity.sh`) with no analogue here. It now reads `cargo xtask line-ratchet --entries`.
- **`scripts/check-line-ratchet.sh` stays as a shim holding no logic**, because `check-gates-can-fail.sh`'s `probe` is addressed by script path and fails a gate no workflow mentions. Deleting the path would make the conversion silently vacate its own coverage check; that harness should change on purpose, in its own change.
- **check job `timeout-minutes` 5 → 15**, matching every other job that runs `cargo xtask` (`ci-assurance`, `ck-admit`). 5 was sized for a script that needed no toolchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MJ65muwqWqPidSYTnpknDi