### PR TITLE
fix(gatehouse): the prelude pin named a library that no longer exists

### DIFF
--- a/.gatehouse/pipeline.writ
+++ b/.gatehouse/pipeline.writ
@@ -6,7 +6,15 @@
 --   Cap  = (net, exec, wallMs, cpuMs, memMb, fsRead, fsWrite, secrets)   net tag 3 0 = None, exec tag 3 1 = Scoped
 --   Gate = (name, hash, scope, env, cap, cmd, timeoutMs, outputs)         hash is filled by the elaborator (zeroed when hashed)
 -- env = the rust:1.96.1-slim-bookworm image index digest (rust-toolchain.toml pins 1.96.1).
-import "sha256:3180b3306a5a4ecd77485a0ea2e086df2a3ab0cb7bef20973bec2197c7d2c031" as ci
+-- The `ci` prelude is pinned by digest, which is what makes this plan hermetic -- and what makes
+-- the pin go stale in silence. gatehouse's cf535ce added `imagePinsEnv_b` to prelude/ci.writ;
+-- that definition has no caller and enforces nothing, but importing it moved the prelude's
+-- digest, so the previous pin (sha256:3180b330...) named a library gatehouse no longer ships and
+-- `gate plan check` errored "no library for import" before elaborating anything. Nothing red:
+-- .github/workflows/gatehouse-plan.yml is informational, not a required context, and skips
+-- entirely unless GATEHOUSE_TOKEN is set. Bumped 2026-09-09 after checking the plan is still
+-- admissible under the new prelude (nodes=5317 red=10780 sub=7579, "admissible: proved").
+import "sha256:2476e955fd994059e1b4ecd9d6741faabd63cb56e6f80fa5003af9478dcae2e8" as ci
 let env : Digest = #d"e18a79fc84dfcfc3ab5ba72290398a644c135c97eaa881447fddc354ee4701a3"
 let ceiling : ci.Cap = (tag 3 0, tag 3 1, 3600000, 3600000, 16384, [#b"Cargo.toml", #b"Cargo.lock", #b"rust-toolchain.toml", #b"crates/**", #b"tests/**", #b"benchmarks/**", #b"crates/portcullis-core/lean/**", #b"scripts/**", #b"sdks/verifier-js/**", #b".github/workflows/**", #b"ci/**", #b"crates/ci-spec/**", #b"scripts/check-ci-spec.sh"] : Bytes, [#b"target/**", #b"sdks/verifier-js/pkg/**", #b"sdks/verifier-js/target/**", #b"crates/portcullis-core/lean/.lake/**"] : Bytes, [] : Bytes)
 let rcap : ci.Cap = (tag 3 0, tag 3 1, 3600000, 3600000, 8192, [#b"Cargo.toml", #b"Cargo.lock", #b"rust-toolchain.toml", #b"crates/**", #b"tests/**", #b"benchmarks/**", #b"scripts/**", #b"sdks/verifier-js/**"] : Bytes, [#b"target/**", #b"sdks/verifier-js/pkg/**", #b"sdks/verifier-js/target/**"] : Bytes, [] : Bytes)


### PR DESCRIPTION
`.gatehouse/pipeline.writ` imports the `ci` prelude **by digest**, which is what makes the plan hermetic — and what makes the pin go stale in silence.

gatehouse's `cf535ce` added `imagePinsEnv_b` to `prelude/ci.writ`. That definition has no caller and enforces nothing, but importing it moved the prelude's digest, so our pin (`sha256:3180b330…`) named a library gatehouse no longer ships:

```
error at byte 751: no library for import "sha256:3180b3306a5a4ecd..."
```

`gate plan check` fails there, before elaborating anything.

**Nothing caught it.** `.github/workflows/gatehouse-plan.yml` is informational rather than a required context, and skips entirely unless `GATEHOUSE_TOKEN` is set. The last green run (2026-09-08, `nodes=5298`) predates the change, so no later run could red.

## Verified before bumping

Checked against gatehouse at `2476e955` that the plan is still **admissible**, not merely parseable:

```
admissible: proved by `admissible`
ok: 13 definition(s), 5 gate(s), plan hashed, admissibility proved;
    root `admissible` kernel-checked;
    nodes=5317 ctxs=1268 ty=4779 red=10780 sub=7579 shift=1027
```

So this is a stale pin, not a broken plan.

The rationale is recorded beside the import, because the next person hits this the same way: **an unwired predicate is not free**, and a hermetic pin with no updater behind an informational gate goes stale without a signal. Recorded as gatehouse `FINDINGS.md` F-21; the longer-term fix — something that fails when a pinned prelude stops existing — is not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MJ65muwqWqPidSYTnpknDi