### PR TITLE
perf(ci): decide a YAML question on the pool that is not scarce

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,7 +270,22 @@ jobs:
   # (crates/ci-spec/tests). Exit 2 ("could not look") is red, never green.
   ci-spec:
     name: CI configuration is sound (CI-1)
-    runs-on: ${{ vars.CI_BUILD_RUNNER || vars.CI_RUNNER || 'ubuntu-latest' }}
+    # The GATE pool, not the build pool. This job's verdict is a function of workflow
+    # YAML, ci/required-checks.txt and ci/merge-queue.toml -- `crates/ci-spec/src/lib.rs`
+    # says it outright: "It reads YAML; it does not run anything." What it spends is a
+    # cargo build of xtask, and that build was MEASURED at 449 MB of target directory
+    # against roughly 6 GB of headroom on the gate pool's 8 GB rootfs after the ~1.78 GB
+    # image -- an order of magnitude of margin, so `requires_volume`'s ENOSPC failure mode
+    # (`ld terminated with signal 7`, then four ejected required checks) is not in reach.
+    #
+    # What it buys: the build pool is eight volume-pinned machines, the only part of the
+    # fleet that costs money while idle and the only one that strands on a 412 when a zone
+    # fills. Holding one of those eight for ~65 seconds to decide a YAML question is the
+    # scarce resource paying for the cheap one. The gate pool floats to any zone with room.
+    #
+    # The trade, stated because it is real: shared-cpu-8x is slower than performance-8x, so
+    # the ~65 s may grow. Compare `cargo xtask ci-timings` for this label before and after.
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
`CI configuration is sound (CI-1)` preferred `CI_BUILD_RUNNER`. Its verdict is a function of workflow YAML, `ci/required-checks.txt` and `ci/merge-queue.toml` — `crates/ci-spec/src/lib.rs:36` says it outright:

> "It reads YAML; it does not run anything."

Measured across four recent runs it takes **64, 65, 66 and 66 seconds**, essentially all of it a `cargo build` of xtask.

The build pool is **eight volume-pinned machines**: the only part of the fleet that costs money while idle ($48–72/month standing), and the only one that strands on an HTTP 412 when a zone fills, because a volume pins its machine to a host. Holding one of those eight for ~65 s to decide a YAML question is the scarce resource paying for the cheap one. The gate pool has no volume and floats to any zone with room.

## Measured before moving

`requires_volume` documents exactly how this goes wrong — a compile without a volume filled the 8 GB rootfs, the linker died with `ld terminated with signal 7 [Bus error]`, then ENOSPC, and **four required checks were ejected while looking clean**. So this is not a guess:

| | |
|---|---|
| clean xtask build, target dir | **449 MB** |
| gate pool rootfs | 8 GB, less the ~1.78 GB image ≈ **6 GB free** |

An order of magnitude of margin, not a squeeze.

## The trade, stated

`shared-cpu-8x` is slower than `performance-8x`, so the ~65 s may grow. `cargo xtask ci-timings` on this label is the before/after. Freeing one of eight scarce slots against some wall-clock on a floating pool is the bet; it is measurable, and reversible by reverting one line.

## Not changed, having checked

The eight relay jobs (`Tests`, `Doctests`, `OWASP…`, `K4` and four more), whose bodies are a `case` over another job's output, are **already on the gate pool**. `manager.toml`'s comment that they are "on that label too" means the *gate* label — I read it as the build label first. They cost 4–5 s each on the cheapest pool, so their cost is the queue wait, not the machine, and moving them buys nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MJ65muwqWqPidSYTnpknDi