### PR TITLE
chore(clippy): grind the ratchet 462 → 341, all of it provably lossless

### DIFF
--- a/.clippy-ratchet.toml
+++ b/.clippy-ratchet.toml
@@ -60,6 +60,12 @@ lints = [
 # value-preserving. The other four lints (truncation 352, wrap 68, precision 57,
 # sign_loss 55 raw sites) each need a decision per site about what the right
 # behaviour IS, and are left for `step` and for changes that can reason about them.
-ceiling = 341
+# Pinned from CI's count, not the local one. First attempt set this to 341, which
+# was measured on macOS; CI (linux) counted 345 and red the gate on this very PR.
+# The seeding comment above already said why -- "clippy counts can differ by
+# platform and feature resolution, and CI (linux) is the authority" -- and it was
+# not followed. The four-site gap is platform/feature resolution, not a regression:
+# the same 117 cast_lossless fixes are in the tree either way.
+ceiling = 345
 target = 0
 step = 5

--- a/.clippy-ratchet.toml
+++ b/.clippy-ratchet.toml
@@ -43,6 +43,23 @@ lints = [
 # left for `step` to grind down rather than reworked in a change about the wasm
 # embed. The number to remember is that 455 was never the workspace's real
 # count; it was the count of the crates that happened to build.
-ceiling = 462
+# Ground 462 -> 341 on 2026-09-10 by applying clippy's own machine-applicable
+# `cast_lossless` fixes across the workspace: `x as u64` becomes `u64::from(x)`,
+# which is the same value by definition of the lint. 43 files, 117 sites. The
+# workspace was at 458 against a ceiling of 462 -- four of headroom -- so any PR
+# adding a handful of casts red the gate, and two open PRs were failing on it for
+# that reason rather than for anything wrong with them.
+#
+# Four files clippy offered to fix were REVERTED and are not in this change:
+# nucleus-econ-kernels/src/extracted/{commons,pigou,settlement}_aeneas.rs and
+# nucleus-ifc-kernel/src/extracted/egress.rs. Those feed the charon+aeneas
+# extraction, so editing the Rust drifts the committed Lean, and a cast cleanup
+# is not the change that should carry an extraction regeneration.
+#
+# Only `cast_lossless` was touched -- the class where the fix is provably
+# value-preserving. The other four lints (truncation 352, wrap 68, precision 57,
+# sign_loss 55 raw sites) each need a decision per site about what the right
+# behaviour IS, and are left for `step` and for changes that can reason about them.
+ceiling = 341
 target = 0
 step = 5

--- a/crates/ck-policy/tests/policy_aeneas_parity.rs
+++ b/crates/ck-policy/tests/policy_aeneas_parity.rs
@@ -138,7 +138,7 @@ fn budget_arr(b: &BudgetBounds) -> [u64; 8] {
         b.max_network_calls,
         b.max_files_touched,
         b.max_dollar_spend_millicents,
-        b.max_patch_attempts as u64,
+        u64::from(b.max_patch_attempts),
     ]
 }
 

--- a/crates/ctf-mcp/src/main.rs
+++ b/crates/ctf-mcp/src/main.rs
@@ -278,7 +278,7 @@ impl VaultCtfServer {
         }
 
         let max_possible_score = 500 + 6 * 100;
-        let pct = (total_score as f64 / max_possible_score as f64 * 100.0) as u32;
+        let pct = (f64::from(total_score) / f64::from(max_possible_score) * 100.0) as u32;
         let defenses_vec: Vec<String> = all_defenses.into_iter().collect();
         let what_you_learned = build_takeaways(&defenses_vec);
         let summary = format!(

--- a/crates/ctf-server/src/main.rs
+++ b/crates/ctf-server/src/main.rs
@@ -402,7 +402,7 @@ async fn run_challenge(
 
     // Max score: 6 defenses * 100 per level that has them + 500 for L1 flag
     let max_possible_score = 500 + 6 * 100;
-    let pct = (total_score as f64 / max_possible_score as f64 * 100.0) as u32;
+    let pct = (f64::from(total_score) / f64::from(max_possible_score) * 100.0) as u32;
 
     let defenses_vec: Vec<String> = all_defenses.into_iter().collect();
     let what_you_learned = build_takeaways(&defenses_vec);

--- a/crates/ctf-server/src/mcp.rs
+++ b/crates/ctf-server/src/mcp.rs
@@ -275,7 +275,7 @@ impl VaultCtfMcp {
         }
 
         let max_possible_score = 500 + 6 * 100;
-        let pct = (total_score as f64 / max_possible_score as f64 * 100.0) as u32;
+        let pct = (f64::from(total_score) / f64::from(max_possible_score) * 100.0) as u32;
         let defenses_vec: Vec<String> = all_defenses.into_iter().collect();
         let what_you_learned = build_takeaways(&defenses_vec);
 

--- a/crates/nucleus-bundle-cas/src/lib.rs
+++ b/crates/nucleus-bundle-cas/src/lib.rs
@@ -119,8 +119,8 @@ impl BundleHash {
         let mut s = String::with_capacity(BUNDLE_HASH_LEN * 2);
         for b in self.0 {
             // Two lowercase hex nibbles per byte.
-            s.push(char::from_digit((b >> 4) as u32, 16).unwrap());
-            s.push(char::from_digit((b & 0x0f) as u32, 16).unwrap());
+            s.push(char::from_digit(u32::from(b >> 4), 16).unwrap());
+            s.push(char::from_digit(u32::from(b & 0x0f), 16).unwrap());
         }
         s
     }

--- a/crates/nucleus-cli/src/start.rs
+++ b/crates/nucleus-cli/src/start.rs
@@ -243,7 +243,7 @@ fn wait_for_health_check(args: &StartArgs) -> Result<()> {
     println!("Waiting for nucleus-node to be ready...");
 
     let endpoint = "http://127.0.0.1:8080/health";
-    let timeout = Duration::from_secs(args.timeout as u64);
+    let timeout = Duration::from_secs(u64::from(args.timeout));
     let start = std::time::Instant::now();
     let poll_interval = Duration::from_millis(500);
 

--- a/crates/nucleus-control-plane-server/src/webhook.rs
+++ b/crates/nucleus-control-plane-server/src/webhook.rs
@@ -193,7 +193,7 @@ fn backoff_for_attempt(attempt: u32) -> Duration {
     // simultaneous retry waves across the wall clock.
     let jitter_ms = (std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.subsec_nanos() as u64)
+        .map(|d| u64::from(d.subsec_nanos()))
         .unwrap_or(0)
         / 1_000_000)
         % 1_000;

--- a/crates/nucleus-creditworthiness/src/crdt.rs
+++ b/crates/nucleus-creditworthiness/src/crdt.rs
@@ -276,7 +276,7 @@ mod tests {
             let mut hash = [0u8; 32];
             hash[0..8].copy_from_slice(&weight.to_le_bytes());
             hash[8] = dim_sel as u8;
-            hash[9] = pol as u8;
+            hash[9] = u8::from(pol);
             CreditEvent {
                 dimension: CreditDimension::ALL[dim_sel],
                 polarity: if pol { Polarity::Credit } else { Polarity::Debit },

--- a/crates/nucleus-econ-kernels/src/commons.rs
+++ b/crates/nucleus-econ-kernels/src/commons.rs
@@ -73,7 +73,8 @@ pub fn route_to_commons(
         .iter()
         .map(|s| CommonsAllocation {
             destination: s.destination.clone(),
-            amount_micro: ((pool_micro as u128 * s.bps as u128) / COMMONS_BPS_SCALE as u128) as u64,
+            amount_micro: ((u128::from(pool_micro) * u128::from(s.bps))
+                / u128::from(COMMONS_BPS_SCALE)) as u64,
         })
         .collect();
 

--- a/crates/nucleus-econ-kernels/src/rational.rs
+++ b/crates/nucleus-econ-kernels/src/rational.rs
@@ -75,7 +75,7 @@ impl Rational {
     /// kernel-side micro-USD value without precision loss.
     pub fn from_micro_usd(micro: u64) -> Self {
         Self {
-            num: micro as i128,
+            num: i128::from(micro),
             // SAFETY: 1_000_000 is non-zero.
             den: NonZeroU64::new(1_000_000).expect("1_000_000 is nonzero"),
         }
@@ -85,11 +85,11 @@ impl Rational {
     /// a new `Rational`; original is unchanged. O(log min(|num|, den)).
     pub fn reduce(&self) -> Self {
         let abs_num = self.num.unsigned_abs();
-        let g = gcd_u128(abs_num, self.den.get() as u128);
+        let g = gcd_u128(abs_num, u128::from(self.den.get()));
         if g == 0 || g == 1 {
             return *self;
         }
-        let new_den_u64 = (self.den.get() as u128 / g) as u64;
+        let new_den_u64 = (u128::from(self.den.get()) / g) as u64;
         // SAFETY: g divides den.get() so the quotient is at least 1.
         let new_den = NonZeroU64::new(new_den_u64)
             .expect("reduced denominator is at least 1 because g divides den");
@@ -109,8 +109,8 @@ impl Rational {
     /// monotone projection so the ordering is preserved at the
     /// saturation boundary.
     pub fn cmp_cross(&self, other: &Self) -> Ordering {
-        let lhs = self.num.saturating_mul(other.den.get() as i128);
-        let rhs = other.num.saturating_mul(self.den.get() as i128);
+        let lhs = self.num.saturating_mul(i128::from(other.den.get()));
+        let rhs = other.num.saturating_mul(i128::from(self.den.get()));
         lhs.cmp(&rhs)
     }
 }

--- a/crates/nucleus-econ-kernels/src/settlement.rs
+++ b/crates/nucleus-econ-kernels/src/settlement.rs
@@ -49,8 +49,8 @@ pub fn classify(delivered_bps: u64) -> Verdict {
 /// The seller's payout for a cleared `price_micro` at `delivered_bps` (clamped to
 /// 100%). Mirrors Lean `sellerGross`; `u128` math avoids overflow.
 pub fn seller_gross(price_micro: u64, delivered_bps: u64) -> u64 {
-    let bps = delivered_bps.min(BPS_SCALE) as u128;
-    ((price_micro as u128 * bps) / BPS_SCALE as u128) as u64
+    let bps = u128::from(delivered_bps.min(BPS_SCALE));
+    ((u128::from(price_micro) * bps) / u128::from(BPS_SCALE)) as u64
 }
 
 /// The bidder's refund: the residual after the seller's payout. Defined as

--- a/crates/nucleus-econ-kernels/tests/lagrangian_convergence.rs
+++ b/crates/nucleus-econ-kernels/tests/lagrangian_convergence.rs
@@ -75,8 +75,8 @@ fn midpoint(lo: &Rational, hi: &Rational) -> Rational {
     let d = hi.den.get();
     let g = gcd_u64(b, d);
     // lo / gcd_factor terms — both fit in u64 since they divide b or d.
-    let lo_factor = (d / g) as i128;
-    let hi_factor = (b / g) as i128;
+    let lo_factor = i128::from(d / g);
+    let hi_factor = i128::from(b / g);
     // Numerator at the common LCM scale: lcm = b·d/g.
     let common_num = lo
         .num
@@ -84,7 +84,7 @@ fn midpoint(lo: &Rational, hi: &Rational) -> Rational {
         .saturating_add(hi.num.saturating_mul(hi_factor));
     // Midpoint denominator = 2 · lcm = 2 · b · d / g. The 2× factor is
     // the "÷2" of (a+c)/2 absorbed into the denominator.
-    let lcm_u128 = (b as u128 / g as u128).saturating_mul(d as u128);
+    let lcm_u128 = (u128::from(b) / u128::from(g)).saturating_mul(u128::from(d));
     let den_u128 = lcm_u128.saturating_mul(2);
     let den_u64 = u64::try_from(den_u128).expect("LCM*2 fits in u64 for bisection depth ≤63");
     let den = NonZeroU64::new(den_u64.max(1)).unwrap();
@@ -133,13 +133,14 @@ fn within_eps_of(lambda: &Rational, lambda_star: &Rational, eps: &Rational) -> b
     // Compute lambda_star ± eps as Rationals with denominator =
     // lambda_star.den · eps.den. For lambda_star = 3/1 and eps = 1/10^9
     // that's 1 · 10^9 = 10^9, well below u64::MAX.
-    let s_den = lambda_star.den.get() as i128;
-    let e_den = eps.den.get() as i128;
+    let s_den = i128::from(lambda_star.den.get());
+    let e_den = i128::from(eps.den.get());
     let common_num_scale = lambda_star.num.saturating_mul(e_den);
     let eps_num_scaled = eps.num.saturating_mul(s_den);
     let lower_num = common_num_scale - eps_num_scaled;
     let upper_num = common_num_scale + eps_num_scaled;
-    let combined_den_u128 = (lambda_star.den.get() as u128).saturating_mul(eps.den.get() as u128);
+    let combined_den_u128 =
+        u128::from(lambda_star.den.get()).saturating_mul(u128::from(eps.den.get()));
     let combined_den =
         NonZeroU64::new(u64::try_from(combined_den_u128).expect("ε denominator fits in u64"))
             .unwrap();

--- a/crates/nucleus-econ-kernels/tests/sequential_parity_vs_lean.rs
+++ b/crates/nucleus-econ-kernels/tests/sequential_parity_vs_lean.rs
@@ -61,9 +61,15 @@ fn empty_sequence_yields_zero_welfare() {
     let seq: Vec<(u64, u64, u64)> = Vec::new();
     let pigou_sum: u128 = seq
         .iter()
-        .map(|(b, r, e)| effective_minus_pigou_micro(*b, &one_dim_profile(*e), &rates(*r)) as u128)
+        .map(|(b, r, e)| {
+            u128::from(effective_minus_pigou_micro(
+                *b,
+                &one_dim_profile(*e),
+                &rates(*r),
+            ))
+        })
         .sum();
-    let raw_sum: u128 = seq.iter().map(|(b, _, _)| *b as u128).sum();
+    let raw_sum: u128 = seq.iter().map(|(b, _, _)| u128::from(*b)).sum();
     assert_eq!(pigou_sum, 0);
     assert_eq!(raw_sum, 0);
 }
@@ -78,9 +84,15 @@ fn zero_rate_sequence_preserves_raw_sum() {
     ];
     let pigou_sum: u128 = seq
         .iter()
-        .map(|(b, r, e)| effective_minus_pigou_micro(*b, &one_dim_profile(*e), &rates(*r)) as u128)
+        .map(|(b, r, e)| {
+            u128::from(effective_minus_pigou_micro(
+                *b,
+                &one_dim_profile(*e),
+                &rates(*r),
+            ))
+        })
         .sum();
-    let raw_sum: u128 = seq.iter().map(|(b, _, _)| *b as u128).sum();
+    let raw_sum: u128 = seq.iter().map(|(b, _, _)| u128::from(*b)).sum();
     assert_eq!(pigou_sum, raw_sum, "zero-rate must be sum-preserving");
 }
 
@@ -91,9 +103,15 @@ fn nonzero_rate_strictly_decreases_welfare() {
     let seq = [(1_000_000u64, 100u64, 2_000_000u64); 5];
     let pigou_sum: u128 = seq
         .iter()
-        .map(|(b, r, e)| effective_minus_pigou_micro(*b, &one_dim_profile(*e), &rates(*r)) as u128)
+        .map(|(b, r, e)| {
+            u128::from(effective_minus_pigou_micro(
+                *b,
+                &one_dim_profile(*e),
+                &rates(*r),
+            ))
+        })
         .sum();
-    let raw_sum: u128 = seq.iter().map(|(b, _, _)| *b as u128).sum();
+    let raw_sum: u128 = seq.iter().map(|(b, _, _)| u128::from(*b)).sum();
     assert!(
         pigou_sum < raw_sum,
         "positive rate × positive ext must reduce welfare: pigou={pigou_sum} raw={raw_sum}"
@@ -122,10 +140,10 @@ proptest! {
         let pigou_sum: u128 = seq
             .iter()
             .map(|(b, r, e)| {
-                effective_minus_pigou_micro(*b, &one_dim_profile(*e), &rates(*r)) as u128
+                u128::from(effective_minus_pigou_micro(*b, &one_dim_profile(*e), &rates(*r)))
             })
             .sum();
-        let raw_sum: u128 = seq.iter().map(|(b, _, _)| *b as u128).sum();
+        let raw_sum: u128 = seq.iter().map(|(b, _, _)| u128::from(*b)).sum();
         prop_assert!(
             pigou_sum <= raw_sum,
             "Lean F6.1 violated: pigou_sum={pigou_sum} raw_sum={raw_sum}",
@@ -150,14 +168,14 @@ proptest! {
         let low: u128 = seq
             .iter()
             .map(|(b, r, e)| {
-                effective_minus_pigou_micro(*b, &one_dim_profile(*e), &rates(*r)) as u128
+                u128::from(effective_minus_pigou_micro(*b, &one_dim_profile(*e), &rates(*r)))
             })
             .sum();
         let seq_high = [(bid, rate_high, ext); 4];
         let high: u128 = seq_high
             .iter()
             .map(|(b, r, e)| {
-                effective_minus_pigou_micro(*b, &one_dim_profile(*e), &rates(*r)) as u128
+                u128::from(effective_minus_pigou_micro(*b, &one_dim_profile(*e), &rates(*r)))
             })
             .sum();
         prop_assert!(

--- a/crates/nucleus-econ-types/src/lib.rs
+++ b/crates/nucleus-econ-types/src/lib.rs
@@ -168,7 +168,7 @@ impl From<MicroUsd> for u64 {
 impl From<MicroUsd> for u128 {
     #[inline]
     fn from(m: MicroUsd) -> Self {
-        m.0 as u128
+        u128::from(m.0)
     }
 }
 
@@ -491,10 +491,10 @@ mod laws {
         #[test]
         fn saturating_from_u128_clamps(v in any::<u128>()) {
             let got = MicroUsd::saturating_from_u128(v);
-            if v > u64::MAX as u128 {
+            if v > u128::from(u64::MAX) {
                 prop_assert_eq!(got, MicroUsd::MAX);
             } else {
-                prop_assert_eq!(got.get() as u128, v);
+                prop_assert_eq!(u128::from(got.get()), v);
             }
         }
 

--- a/crates/nucleus-eval/src/lib.rs
+++ b/crates/nucleus-eval/src/lib.rs
@@ -239,7 +239,7 @@ fn scaled_weight(declared_magnitude_micro: u64, passed: u64, total: u64) -> u64 
     if total == 0 {
         return 0;
     }
-    let scaled = (declared_magnitude_micro as u128 * passed as u128) / total as u128;
+    let scaled = (u128::from(declared_magnitude_micro) * u128::from(passed)) / u128::from(total);
     // passed <= total ⇒ scaled <= declared_magnitude_micro <= u64::MAX.
     scaled as u64
 }

--- a/crates/nucleus-identity/src/attestation.rs
+++ b/crates/nucleus-identity/src/attestation.rs
@@ -508,7 +508,7 @@ fn decode_integer(data: &[u8], pos: &mut usize) -> Result<i64> {
     let mut value: i64 = 0;
     let is_negative = data[*pos] & 0x80 != 0;
     for i in 0..len {
-        value = (value << 8) | (data[*pos + i] as i64);
+        value = (value << 8) | i64::from(data[*pos + i]);
     }
     if is_negative {
         // Sign extend for negative numbers

--- a/crates/nucleus-identity/src/session.rs
+++ b/crates/nucleus-identity/src/session.rs
@@ -245,7 +245,7 @@ impl SessionId {
             bytes[11] = ((millis >> 32) & 0xff) as u8;
             bytes[12] = ((millis >> 40) & 0xff) as u8;
             // XOR with process ID for additional entropy
-            let pid = std::process::id() as u64;
+            let pid = u64::from(std::process::id());
             bytes[13] = (pid & 0xff) as u8;
             bytes[14] = ((pid >> 8) & 0xff) as u8;
             bytes[15] = ((pid >> 16) & 0xff) as u8;
@@ -300,12 +300,12 @@ impl SessionId {
             return None;
         }
 
-        let millis = ((self.0[0] as u64) << 40)
-            | ((self.0[1] as u64) << 32)
-            | ((self.0[2] as u64) << 24)
-            | ((self.0[3] as u64) << 16)
-            | ((self.0[4] as u64) << 8)
-            | (self.0[5] as u64);
+        let millis = (u64::from(self.0[0]) << 40)
+            | (u64::from(self.0[1]) << 32)
+            | (u64::from(self.0[2]) << 24)
+            | (u64::from(self.0[3]) << 16)
+            | (u64::from(self.0[4]) << 8)
+            | u64::from(self.0[5]);
 
         Some(millis)
     }

--- a/crates/nucleus-ifc-kernel/src/exposure.rs
+++ b/crates/nucleus-ifc-kernel/src/exposure.rs
@@ -88,7 +88,7 @@ impl ExposureSet {
 
     /// Number of active exposure legs (0..=3).
     pub fn count(&self) -> u8 {
-        self.private_data as u8 + self.untrusted_content as u8 + self.exfil_vector as u8
+        u8::from(self.private_data) + u8::from(self.untrusted_content) + u8::from(self.exfil_vector)
     }
 }
 

--- a/crates/nucleus-oracle/examples/dogfood_coalition_settlement.rs
+++ b/crates/nucleus-oracle/examples/dogfood_coalition_settlement.rs
@@ -44,7 +44,7 @@ fn shapley(n: usize, value: impl Fn(u32) -> u64) -> Vec<u64> {
             }
             let size = (s.count_ones()) as usize;
             let weight = fact(size) * fact(n - size - 1); // numerator; /n! at the end
-            let marginal = value(s | (1 << i)).saturating_sub(value(s)) as u128;
+            let marginal = u128::from(value(s | (1 << i)).saturating_sub(value(s)));
             acc += weight * marginal;
         }
         *slot = acc / nfact;

--- a/crates/nucleus-oracle/examples/dogfood_three_agent_settlement.rs
+++ b/crates/nucleus-oracle/examples/dogfood_three_agent_settlement.rs
@@ -42,7 +42,7 @@ fn shapley(n: usize, value: impl Fn(u32) -> u64) -> Vec<u64> {
             }
             let size = s.count_ones() as usize;
             let weight = fact(size) * fact(n - size - 1);
-            let marginal = value(s | (1 << i)).saturating_sub(value(s)) as u128;
+            let marginal = u128::from(value(s | (1 << i)).saturating_sub(value(s)));
             *a += weight * marginal;
         }
     }

--- a/crates/nucleus-oracle/src/lib.rs
+++ b/crates/nucleus-oracle/src/lib.rs
@@ -536,7 +536,7 @@ impl RubricInputs {
 
 /// Saturating `u64 → u32`.
 fn sat_u32(v: u64) -> u32 {
-    v.min(u32::MAX as u64) as u32
+    v.min(u64::from(u32::MAX)) as u32
 }
 
 /// Turn a [`GradeReceipt`] into rubric criteria + grades, applying THE

--- a/crates/nucleus-oracle/src/summary.rs
+++ b/crates/nucleus-oracle/src/summary.rs
@@ -43,11 +43,11 @@ pub fn summarize(receipts: &[GradeReceipt]) -> PortfolioSummary {
     let mean_pass_permille: u32 = if exact_total == 0 {
         0
     } else {
-        let scaled = (exact_matched as u128) * 1000u128;
-        let permille = scaled / (exact_total as u128);
+        let scaled = u128::from(exact_matched) * 1000u128;
+        let permille = scaled / u128::from(exact_total);
         // permille is at most 1000 when matched <= total, but clamp defensively
         // so a malformed receipt (matched > total) can never overflow u32.
-        if permille > u32::MAX as u128 {
+        if permille > u128::from(u32::MAX) {
             u32::MAX
         } else {
             permille as u32
@@ -72,7 +72,7 @@ impl PortfolioSummary {
         let mean_pass_permille = if exact_total == 0 {
             0
         } else {
-            ((1000u128 * exact_matched as u128) / exact_total as u128) as u32
+            ((1000u128 * u128::from(exact_matched)) / u128::from(exact_total)) as u32
         };
         PortfolioSummary {
             submissions: self.submissions.saturating_add(other.submissions),

--- a/crates/nucleus-oracle/tests/merge_func.rs
+++ b/crates/nucleus-oracle/tests/merge_func.rs
@@ -47,7 +47,7 @@ fn summary(
     let permille = if exact_total == 0 {
         0
     } else {
-        ((1000u128 * exact_matched as u128) / exact_total as u128) as u32
+        ((1000u128 * u128::from(exact_matched)) / u128::from(exact_total)) as u32
     };
     PortfolioSummary {
         submissions,
@@ -172,7 +172,7 @@ fn merge_large_permille_uses_u128_intermediate() {
     let half = u64::MAX / 2;
     let a = summary(0, 0, 0, half, u64::MAX);
     let m = a.merge(&PortfolioSummary::default());
-    let expected = ((1000u128 * half as u128) / u64::MAX as u128) as u32;
+    let expected = ((1000u128 * u128::from(half)) / u128::from(u64::MAX)) as u32;
     assert_eq!(m.mean_pass_permille, expected);
     assert_eq!(expected, 499);
 }

--- a/crates/nucleus-oracle/tests/summarize_heldout.rs
+++ b/crates/nucleus-oracle/tests/summarize_heldout.rs
@@ -230,7 +230,7 @@ fn large_values_require_u128_intermediate() {
     let rs = [receipt("big", matched, total, false)];
     let s = summarize(&rs);
 
-    let expected: u32 = ((1000u128 * matched as u128) / total as u128) as u32;
+    let expected: u32 = ((1000u128 * u128::from(matched)) / u128::from(total)) as u32;
     // Sanity: this is ~499 (just under half).
     assert_eq!(expected, 499);
     assert_eq!(s.exact_matched, matched);

--- a/crates/nucleus-permission-market/src/market.rs
+++ b/crates/nucleus-permission-market/src/market.rs
@@ -231,7 +231,7 @@ mod tests {
     fn lambda_monotonically_increases() {
         let mut prev = 0.0;
         for i in 0..=100 {
-            let util = i as f64 / 100.0;
+            let util = f64::from(i) / 100.0;
             let l = compute_lambda(util);
             assert!(
                 l >= prev,
@@ -251,7 +251,7 @@ mod tests {
     #[test]
     fn lambda_finite_for_all_inputs() {
         for i in 0..=100 {
-            let util = i as f64 / 100.0;
+            let util = f64::from(i) / 100.0;
             assert!(compute_lambda(util).is_finite());
         }
     }

--- a/crates/nucleus-rubric/src/lib.rs
+++ b/crates/nucleus-rubric/src/lib.rs
@@ -321,8 +321,8 @@ pub fn faithful_total(rubric: &Rubric, sc: &Scorecard) -> u128 {
         .rv_indices()
         .into_iter()
         .map(|i| {
-            let g = sc.grades.get(i).copied().unwrap_or(0) as u128;
-            rubric.weight_at(i) as u128 * g
+            let g = u128::from(sc.grades.get(i).copied().unwrap_or(0));
+            u128::from(rubric.weight_at(i)) * g
         })
         .sum()
 }
@@ -564,7 +564,7 @@ impl CounterfactualReceipt {
     /// `u64::MAX` (the `CreditEvent` weight domain); `u128` totals make that
     /// effectively unreachable for realistic grades/weights.
     pub fn mint_reward(&self) -> CreditEvent {
-        let weight = self.marginal.min(u64::MAX as u128) as u64;
+        let weight = self.marginal.min(u128::from(u64::MAX)) as u64;
         CreditEvent::honest_settlement(weight, self.receipt_hash())
     }
 }
@@ -576,7 +576,7 @@ impl CounterfactualReceipt {
 /// Saturates at `u32::MAX`.
 pub fn grade_from_eval(run: &nucleus_eval::EvalRun) -> u32 {
     let (passed, _total) = run.deterministic.recompute();
-    passed.min(u32::MAX as u64) as u32
+    passed.min(u64::from(u32::MAX)) as u32
 }
 
 #[cfg(test)]
@@ -917,11 +917,11 @@ mod tests {
 
         let ev = receipt.mint_reward();
         assert_eq!(ev.polarity, Polarity::Credit);
-        assert_eq!(ev.weight_micro as u128, receipt.marginal);
+        assert_eq!(u128::from(ev.weight_micro), receipt.marginal);
         assert_eq!(ev.receipt_hash, receipt.receipt_hash());
 
         let file = CreditFile::from_events(&[ev]);
-        assert_eq!(file.reputation_micro() as u128, receipt.marginal);
+        assert_eq!(u128::from(file.reputation_micro()), receipt.marginal);
     }
 
     // ── Edge cases ────────────────────────────────────────────────────────────

--- a/crates/nucleus-rubric/tests/rubric_lean_parity.rs
+++ b/crates/nucleus-rubric/tests/rubric_lean_parity.rs
@@ -64,8 +64,8 @@ fn lean_columns(rubric: &Rubric, sc: &Scorecard) -> Vec<(Provenance, u128, u128)
         .iter()
         .enumerate()
         .map(|(i, c)| {
-            let g = sc.grades.get(i).copied().unwrap_or(0) as u128;
-            (c.provenance, c.weight as u128, g)
+            let g = u128::from(sc.grades.get(i).copied().unwrap_or(0));
+            (c.provenance, u128::from(c.weight), g)
         })
         .collect()
 }

--- a/crates/nucleus-verifier-service/src/witness.rs
+++ b/crates/nucleus-verifier-service/src/witness.rs
@@ -237,7 +237,7 @@ mod tests {
                 peer_pubkey_hex: format!("{i:02x}"),
                 sth_json: "{}".to_string(),
                 signature_b64: "".to_string(),
-                accepted_at_ms: i as i64,
+                accepted_at_ms: i64::from(i),
             });
         }
         assert_eq!(ring.len(), 2);

--- a/crates/portcullis-core/src/manifest.rs
+++ b/crates/portcullis-core/src/manifest.rs
@@ -156,7 +156,7 @@ impl ToolManifest {
         }
 
         // remote_fetch
-        buf.push(self.remote_fetch as u8);
+        buf.push(u8::from(self.remote_fetch));
 
         // instruction_sources (count + discriminants)
         buf.extend_from_slice(&(self.instruction_sources.len() as u32).to_le_bytes());
@@ -187,7 +187,7 @@ impl ToolManifest {
         }
 
         // authority_to_instruct
-        buf.push(self.authority_to_instruct as u8);
+        buf.push(u8::from(self.authority_to_instruct));
 
         // memory_behavior
         buf.push(self.memory_behavior as u8);

--- a/crates/portcullis-core/src/quarantine.rs
+++ b/crates/portcullis-core/src/quarantine.rs
@@ -331,7 +331,7 @@ fn shannon_entropy_bits(s: &str) -> u32 {
     let mut entropy: f64 = 0.0;
     for &c in &counts {
         if c > 0 {
-            let p = c as f64 / len;
+            let p = f64::from(c) / len;
             entropy -= p * p.log2();
         }
     }

--- a/crates/portcullis-core/src/task_shield.rs
+++ b/crates/portcullis-core/src/task_shield.rs
@@ -124,7 +124,7 @@ fn task_hash_of(text: &str) -> [u8; 32] {
     for (round, &seed) in SEEDS.iter().enumerate() {
         let mut h = FNV_BASIS.wrapping_add(seed);
         for &b in bytes {
-            h ^= b as u64;
+            h ^= u64::from(b);
             h = h.wrapping_mul(FNV_PRIME);
         }
         // Also mix in the seed to ensure round independence

--- a/crates/portcullis/src/capability.rs
+++ b/crates/portcullis/src/capability.rs
@@ -269,7 +269,7 @@ impl IncompatibilityConstraint {
             || caps.create_pr >= CapabilityLevel::LowRisk
             || caps.run_bash >= CapabilityLevel::LowRisk;
 
-        let count = has_private_access as u8 + has_untrusted as u8 + has_exfil as u8;
+        let count = u8::from(has_private_access) + u8::from(has_untrusted) + u8::from(has_exfil);
         match count {
             0 => StateRisk::Safe,
             1 => StateRisk::Low,

--- a/crates/portcullis/src/certificate.rs
+++ b/crates/portcullis/src/certificate.rs
@@ -621,7 +621,7 @@ pub fn canonical_permissions_hash(perms: &PermissionLattice) -> Vec<u8> {
     hasher.update(perms.time.valid_until.timestamp().to_le_bytes());
 
     //  UninhabitableState constraint
-    hasher.update([perms.uninhabitable_constraint as u8]);
+    hasher.update([u8::from(perms.uninhabitable_constraint)]);
 
     hasher.finalize().to_vec()
 }

--- a/crates/portcullis/src/constraint/context.rs
+++ b/crates/portcullis/src/constraint/context.rs
@@ -239,7 +239,7 @@ impl PolicyContext {
         ctx.add_variable("has_approval", self.has_approval).ok();
 
         // Request rate
-        ctx.add_variable("request_rate", self.request_rate as i64)
+        ctx.add_variable("request_rate", i64::from(self.request_rate))
             .ok();
 
         // Isolation as a proper nested object

--- a/crates/portcullis/src/dropout.rs
+++ b/crates/portcullis/src/dropout.rs
@@ -499,7 +499,7 @@ pub fn dropout_pipeline(
         stages_skipped,
         load_bearing_dimensions: load_bearing,
         trivial_dimensions: trivial,
-        evaluation_fraction: active_stages as f64 / total_stages as f64,
+        evaluation_fraction: f64::from(active_stages) / f64::from(total_stages),
     };
 
     (trace, report)

--- a/crates/portcullis/src/egress_policy.rs
+++ b/crates/portcullis/src/egress_policy.rs
@@ -200,7 +200,9 @@ fn ip_in_cidr(ip: IpAddr, network: IpAddr, prefix_len: u8) -> bool {
             }
             let ip_bits = u32::from(ip);
             let net_bits = u32::from(net);
-            let mask = u32::MAX.checked_shl(32 - prefix_len as u32).unwrap_or(0);
+            let mask = u32::MAX
+                .checked_shl(32 - u32::from(prefix_len))
+                .unwrap_or(0);
             (ip_bits & mask) == (net_bits & mask)
         }
         (IpAddr::V6(ip), IpAddr::V6(net)) => {
@@ -209,7 +211,9 @@ fn ip_in_cidr(ip: IpAddr, network: IpAddr, prefix_len: u8) -> bool {
             }
             let ip_bits = u128::from(ip);
             let net_bits = u128::from(net);
-            let mask = u128::MAX.checked_shl(128 - prefix_len as u32).unwrap_or(0);
+            let mask = u128::MAX
+                .checked_shl(128 - u32::from(prefix_len))
+                .unwrap_or(0);
             (ip_bits & mask) == (net_bits & mask)
         }
         // IPv4 vs IPv6 mismatch

--- a/crates/portcullis/src/guard.rs
+++ b/crates/portcullis/src/guard.rs
@@ -831,8 +831,9 @@ impl ExposureSet {
 
     /// Convert to the corresponding StateRisk level.
     pub fn to_risk(&self) -> StateRisk {
-        let count =
-            self.private_data as u8 + self.untrusted_content as u8 + self.exfil_vector as u8;
+        let count = u8::from(self.private_data)
+            + u8::from(self.untrusted_content)
+            + u8::from(self.exfil_vector);
         match count {
             0 => StateRisk::Safe,
             1 => StateRisk::Low,
@@ -852,7 +853,7 @@ impl ExposureSet {
 
     /// Number of active exposure legs.
     pub fn count(&self) -> u8 {
-        self.private_data as u8 + self.untrusted_content as u8 + self.exfil_vector as u8
+        u8::from(self.private_data) + u8::from(self.untrusted_content) + u8::from(self.exfil_vector)
     }
 
     /// Check if this exposure set is a superset of another.

--- a/crates/portcullis/src/progress.rs
+++ b/crates/portcullis/src/progress.rs
@@ -344,7 +344,7 @@ impl ProgressLattice {
 
     /// Fraction of progress toward the terminal object (0.0 to 1.0).
     pub fn completion_fraction(&self) -> f64 {
-        self.height() as f64 / Self::top().height() as f64
+        f64::from(self.height()) / f64::from(Self::top().height())
     }
 }
 

--- a/crates/portcullis/src/trust.rs
+++ b/crates/portcullis/src/trust.rs
@@ -557,7 +557,7 @@ mod tests {
     #[test]
     fn reputation_score_no_cliffs() {
         // Verify there are no sudden jumps across a small delta
-        let scores: Vec<f64> = (0..100).map(|i| i as f64 / 100.0).collect();
+        let scores: Vec<f64> = (0..100).map(|i| f64::from(i) / 100.0).collect();
         for window in scores.windows(2) {
             let a = TrustProfile::from_reputation_score(window[0]);
             let b = TrustProfile::from_reputation_score(window[1]);

--- a/crates/portcullis/tests/declassify_scope.rs
+++ b/crates/portcullis/tests/declassify_scope.rs
@@ -275,7 +275,7 @@ fn authorize_release_value_binding_matches_the_extracted_decision() {
         a[0] = b;
         a
     };
-    let tag = |a: &[u8; 32]| a[0] as u64;
+    let tag = |a: &[u8; 32]| u64::from(a[0]);
 
     // committed == recorded (both non-zero) ⇒ Authorized AND value_authorized true.
     for (committed, recorded) in [(v(7), v(7)), (v(7), v(9)), (v(9), v(7))] {
@@ -334,7 +334,7 @@ fn four_run_released_value_is_not_attacker_steerable() {
         a[0] = b;
         a
     };
-    let tag = |a: &[u8; 32]| a[0] as u64;
+    let tag = |a: &[u8; 32]| u64::from(a[0]);
 
     // Governor-signed commitment — fixed across all runs (attacker-independent).
     let committed = v(7);

--- a/crates/portcullis/tests/kernel_executable_spec.rs
+++ b/crates/portcullis/tests/kernel_executable_spec.rs
@@ -395,7 +395,7 @@ proptest! {
         let mut prev_remaining = kernel.remaining_usd();
 
         for charge_cents in charges {
-            let amount = Decimal::new(charge_cents as i64, 2);
+            let amount = Decimal::new(i64::from(charge_cents), 2);
             match kernel.charge(amount) {
                 Ok(remaining) => {
                     // Remaining must not increase

--- a/crates/portcullis/tests/lattice_conformance.rs
+++ b/crates/portcullis/tests/lattice_conformance.rs
@@ -71,9 +71,9 @@ fn model_has_exfiltration(caps: &CapabilityLattice) -> bool {
 
 /// Reference implementation of `uninhabitable_state_count(c)`: sum of 3 bools
 fn model_uninhabitable_count(caps: &CapabilityLattice) -> u8 {
-    model_has_private_access(caps) as u8
-        + model_has_untrusted_content(caps) as u8
-        + model_has_exfiltration(caps) as u8
+    u8::from(model_has_private_access(caps))
+        + u8::from(model_has_untrusted_content(caps))
+        + u8::from(model_has_exfiltration(caps))
 }
 
 /// Reference implementation of `state_risk_level(c)`: equals uninhabitable_state_count

--- a/crates/portcullis/tests/proptest_permissive.rs
+++ b/crates/portcullis/tests/proptest_permissive.rs
@@ -63,9 +63,9 @@ fn arb_permission_lattice() -> impl Strategy<Value = PermissionLattice> {
 
 fn arb_weakening_cost() -> impl Strategy<Value = WeakeningCost> {
     (
-        (0u32..100u32).prop_map(|n| Decimal::new(n as i64, 2)),
-        (1u32..10u32).prop_map(|n| Decimal::new(n as i64, 0)),
-        (1u32..5u32).prop_map(|n| Decimal::new(n as i64, 0)),
+        (0u32..100u32).prop_map(|n| Decimal::new(i64::from(n), 2)),
+        (1u32..10u32).prop_map(|n| Decimal::new(i64::from(n), 0)),
+        (1u32..5u32).prop_map(|n| Decimal::new(i64::from(n), 0)),
     )
         .prop_map(|(base, uninhabitable_state, isolation)| WeakeningCost {
             base,
@@ -179,8 +179,8 @@ proptest! {
     fn cost_total_monotonic_in_base(base1: u32, base2: u32) {
         let (small, large) = if base1 <= base2 { (base1, base2) } else { (base2, base1) };
 
-        let cost_small = WeakeningCost::new(Decimal::new(small as i64, 2));
-        let cost_large = WeakeningCost::new(Decimal::new(large as i64, 2));
+        let cost_small = WeakeningCost::new(Decimal::new(i64::from(small), 2));
+        let cost_large = WeakeningCost::new(Decimal::new(i64::from(large), 2));
 
         prop_assert!(cost_small.total() <= cost_large.total());
     }


### PR DESCRIPTION
The workspace sat at **458 against a ceiling of 462**. Four of headroom on a shrink-only, workspace-global counter means any PR adding a handful of numeric casts reds the gate — and two open PRs (#2765, #2759) were failing on exactly that, not for anything wrong with them. A ratchet with no room is a coin flip, not a gate.

Applied clippy's own **machine-applicable `cast_lossless` fixes**: `x as u64` becomes `u64::from(x)`, the same value by definition of the lint. **43 files, 117 sites, 458 → 341.**

## Only one lint class, deliberately

`cast_lossless` is the class where the fix is *provably* value-preserving. The other four ratcheted lints — truncation (352 raw sites), wrap (68), precision (57), sign_loss (55) — each need a decision per site about what the right behaviour **is**. A mechanical rewrite of those would be a behaviour change wearing a cleanup's clothes. They are left for `step` and for changes that can reason about them.

## Four files clippy offered to fix are NOT here

```
nucleus-econ-kernels/src/extracted/{commons,pigou,settlement}_aeneas.rs
nucleus-ifc-kernel/src/extracted/egress.rs
```

Those feed the charon+aeneas extraction, so editing the Rust drifts the committed Lean. A cast cleanup is not the change that should carry an extraction regeneration.

## Verification

- `cargo check --workspace --all-targets` clean, apart from `portcullis-core`'s test targets — which **do not compile on clean main either**, checked by stashing. Pre-existing, not caused here.
- Tests pass on every safety-critical crate touched: `portcullis`, `nucleus-ifc-kernel`, `nucleus-econ-kernels`, `nucleus-identity`.
- `scripts/check-clippy-ratchet.sh --strict` → `341 (ceiling 341)`, exit 0.

## One thing worth recording separately

Because a crate that does not compile is never analysed, **`portcullis-core`'s cast sites are probably not in the 458 at all**. That is the same defect the ceiling comment already documents for `nucleus-verifier-service`: *"455 was never the workspace's real count; it was the count of the crates that happened to build."* Fixing `portcullis-core`'s test compilation would likely raise the true count — coverage going up, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MJ65muwqWqPidSYTnpknDi