### PR TITLE
gate: the clippy count may not silently exclude a crate

### DIFF
--- a/.clippy-unanalysed.txt
+++ b/.clippy-unanalysed.txt
@@ -1,0 +1,33 @@
+# Crates clippy could not analyse, so whose ratcheted cast sites are NOT in the
+# count that .clippy-ratchet.toml pins.
+#
+# WHY THIS FILE EXISTS. `scripts/check-clippy-ratchet.sh` says "Never report a
+# partial count as if it were whole" and then does exactly that: it emits a
+# `::warning::` naming the crates that failed to compile, prints the count
+# anyway, and `--strict` passes. A warning nobody fails on is a comment.
+#
+# This has already cost the number its meaning once. The ceiling comment in
+# .clippy-ratchet.toml records it: nucleus-verifier-service `include_*!`d a
+# wasm-pack artifact that only exists after `wasm-pack build`, so on a bare
+# checkout it did not compile and was silently dropped -- "455 was never the
+# workspace's real count; it was the count of the crates that happened to
+# build." Seven cast sites appeared the moment it compiled again.
+#
+# So the set is DECLARED here and checked in both directions:
+#   * a crate that fails to compile and is NOT listed is an error -- the count
+#     just shrank for a reason nobody chose;
+#   * a listed crate that now COMPILES is also an error -- remove it, and expect
+#     the count to RISE, which is coverage going up rather than a regression.
+#     Same convention as ci/gate-integrity-allowlist.txt, where a finding that
+#     no longer fires is itself a finding.
+#
+# PINNED may only SHRINK. Adding a crate here is a deliberate, dated act.
+# PINNED = 1
+
+# portcullis-core's TEST targets do not compile on a default-feature checkout:
+# `unresolved import portcullis_core::witness`, `cannot find prov_export`, and a
+# missing serde_json in a test module. The lib builds; the test targets do not,
+# and --all-targets is what the measurement uses. Its cast sites are therefore
+# absent from the count. Observed 2026-09-10 while grinding the ratchet
+# 462 -> 341; not introduced by that change (verified against a clean main).
+portcullis-core

--- a/scripts/check-clippy-ratchet.sh
+++ b/scripts/check-clippy-ratchet.sh
@@ -65,10 +65,36 @@ COUNT=$(jq -r 'select(.reason=="compiler-message") | .message
   | sort -u | wc -l | tr -d ' ')
 rm -f "$RAW"
 
+# Never report a partial count as if it were whole. The set of crates clippy
+# could not analyse is DECLARED in .clippy-unanalysed.txt and checked both ways:
+# an undeclared failure means the count silently shrank, and a declared crate
+# that now compiles means the declaration is stale and the count is about to
+# rise. Before this, both were a `::warning::` that nothing failed on -- and the
+# ceiling comment in .clippy-ratchet.toml records what that cost:
+# "455 was never the workspace's real count; it was the count of the crates that
+# happened to build."
+UNANALYSED_FILE=".clippy-unanalysed.txt"
+DECLARED=$(grep -vE '^\s*(#|$)' "$UNANALYSED_FILE" 2>/dev/null | sort -u || true)
+UNDECLARED=$(comm -23 <(printf '%s\n' "$FAILED" | grep -v '^$' | sort -u) <(printf '%s\n' "$DECLARED"))
+STALE=$(comm -13 <(printf '%s\n' "$FAILED" | grep -v '^$' | sort -u) <(printf '%s\n' "$DECLARED"))
+
 if [ -n "$FAILED" ]; then
-  # Never report a partial count as if it were whole.
-  echo "::warning::crates that did NOT compile, so were NOT analysed:" >&2
+  echo "::notice::crates not analysed (declared in $UNANALYSED_FILE):" >&2
   echo "$FAILED" | sed 's/^/  /' >&2
+fi
+if [ -n "$UNDECLARED" ]; then
+  echo "::error::these crates did not compile and are NOT declared in $UNANALYSED_FILE:" >&2
+  echo "$UNDECLARED" | sed 's/^/  /' >&2
+  echo "The count below is missing their cast sites. Fix the crate, or declare it" >&2
+  echo "with a dated reason and raise PINNED." >&2
+  exit 1
+fi
+if [ -n "$STALE" ]; then
+  echo "::error::these crates are declared unanalysable in $UNANALYSED_FILE but COMPILE now:" >&2
+  echo "$STALE" | sed 's/^/  /' >&2
+  echo "Remove them and lower PINNED. Expect the count to RISE: that is coverage" >&2
+  echo "going up, not a regression." >&2
+  exit 1
 fi
 
 case "${1:---count}" in


### PR DESCRIPTION
`scripts/check-clippy-ratchet.sh` carries this comment directly above the code that does the opposite:

> `# Never report a partial count as if it were whole.`

It emits a `::warning::` naming the crates that failed to compile, prints the count anyway, and `--strict` passes. **A warning nothing fails on is a comment.**

## This has already cost the number its meaning once

`.clippy-ratchet.toml` records it: `nucleus-verifier-service` `include_*!`d a wasm-pack artifact that only exists after `wasm-pack build`, so on a bare checkout it did not compile and was silently dropped —

> *"455 was never the workspace's real count; it was the count of the crates that happened to build."*

Seven cast sites appeared the moment it compiled again.

**It is happening now with `portcullis-core`**, whose *test* targets do not compile on a default-feature checkout (`unresolved import portcullis_core::witness`, `cannot find prov_export`, a missing `serde_json` in a test module). The measurement uses `--all-targets`, so its cast sites are absent from the count.

## The fix

The set is **declared** in `.clippy-unanalysed.txt` and checked in both directions — the same convention as `ci/gate-integrity-allowlist.txt`, where a finding that no longer fires is itself a finding:

| condition | verdict |
|---|---|
| a crate fails to compile and is **not** declared | **error** — the count just shrank for a reason nobody chose |
| a declared crate **compiles again** | **error** — remove it, and expect the count to **rise**; that is coverage going up, not a regression |

`PINNED = 1`, may only shrink.

## Verification (A-19, both directions, exit codes checked directly)

| case | exit |
|---|---|
| undeclared failure | **1**, naming the crate |
| stale declaration | **1**, naming the crate |
| shipped tree | 0 |

`cargo xtask ci-spec check` → `ok: every invariant holds`.

## Against the Rust-not-shell mandate

This is six lines of set comparison added to an existing shell gate rather than a new xtask command, because splitting one gate's logic across two languages is worse than either. Porting `check-clippy-ratchet.sh` whole — its `jq` dedupe of `(file, line, column, lint)` sites is the substantive part — is the follow-up, not this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MJ65muwqWqPidSYTnpknDi