### PR TITLE
gate: the committed runner-pool default must be one the manager accepts

### DIFF
--- a/.github/workflows/manifest-guards.yml
+++ b/.github/workflows/manifest-guards.yml
@@ -101,6 +101,13 @@ jobs:
       # is excluded on purpose: those are upstream packages' own pins and differ legitimately.
       - name: One fact, one value (elan, aeneas/charon, lean-toolchain)
         run: cargo run -q -p xtask -- pin-parity
+      # The manager validates POOLS at startup and nothing validated the COMMITTED
+      # default, so it had drifted into a config the manager refuses: requires_volume
+      # with zero volumes for eight machines. That is the value a fresh deployment
+      # falls back to before `fly secrets set POOLS=...`, so it was a default that
+      # could not start. Runs the manager's own validator, not a copy of the rule.
+      - name: The committed runner-pool default is one the manager accepts
+        run: cargo run -q -p xtask -- fly-pools
 
       # `.gitignore` said `/target/` — anchored to the root, so every nested
       # target/ escaped it, and tools/nucleus-mediation-lint/target was

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13719,6 +13719,7 @@ name = "xtask"
 version = "1.0.0"
 dependencies = [
  "anyhow",
+ "ci-fly-runner",
  "ci-spec",
  "ck-kernel",
  "ck-types",

--- a/ci/fly-runner/manager.toml
+++ b/ci/fly-runner/manager.toml
@@ -27,9 +27,17 @@ primary_region = "iad"
   # Lean builds (ci-spec-lean, ck-policy-lean, econ-lean, ifc-lean, rubric-lean), `ci/test`,
   # `doctests`, `owasp-gauntlet` and `gates-can-fail` are on that label too, which is why it is
   # shared-cpu-8x with 16 GB and not the 2x/4 GB a pure script pool would want. Volumes are
-  # per build Machine and set with `fly secrets set POOLS=...` when the ids are known; this
-  # tracked default has none, so a fresh deployment works without them (cold caches).
-  POOLS = '[{"label":"nucleus-fly-build","guest":{"cpu_kind":"performance","cpus":8,"memory_mb":32768},"size":8,"standby":8,"requires_volume":true,"env":{"CARGO_BUILD_JOBS":"8","SCCACHE_CACHE_SIZE":"20G"}},{"label":"nucleus-fly-gate","guest":{"cpu_kind":"shared","cpus":8,"memory_mb":16384},"size":16,"standby":16}]'
+  # per build Machine and set with `fly secrets set POOLS=...` when the ids are known.
+  # This tracked default has none, and therefore declares `requires_volume: false`:
+  # with `true` and no ids the manager REFUSES the config outright -- "requires_volume,
+  # but 0 volumes for 8 machines" -- so the default a fresh deployment falls back to was
+  # one that could not start. The comment here used to claim the opposite. Corrected
+  # 2026-09-10 and now gated by `cargo xtask fly-pools`, which runs the manager's own
+  # validator over this value. The DEPLOYED POOLS secret carries `requires_volume: true`
+  # alongside the real ids, which is where that safety property belongs: it caps `size`
+  # at the volume count, and a compile pool without a volume fills the 8 GB rootfs
+  # (`ld terminated with signal 7`, then ENOSPC, then four ejected required checks).
+  POOLS = '[{"label":"nucleus-fly-build","guest":{"cpu_kind":"performance","cpus":8,"memory_mb":32768},"size":8,"standby":8,"requires_volume":false,"env":{"CARGO_BUILD_JOBS":"8","SCCACHE_CACHE_SIZE":"20G"}},{"label":"nucleus-fly-gate","guest":{"cpu_kind":"shared","cpus":8,"memory_mb":16384},"size":16,"standby":16}]'
 [[vm]]
   cpu_kind = "shared"
   cpus = 1

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -22,6 +22,9 @@ ck-kernel = { path = "../ck-kernel" }
 ck-types = { path = "../ck-types" }
 # CI configuration invariants (`cargo xtask ci-spec`).
 ci-spec = { path = "../ci-spec" }
+# `fly-pools` validates the committed POOLS default with the MANAGER's own validator,
+# rather than a second copy of the rule that could drift from it.
+ci-fly-runner = { path = "../ci-fly-runner" }
 
 # Parse the actual Rust attributes and workflow arguments for Kani coverage.
 syn = { version = "2", features = ["full", "visit"] }

--- a/crates/xtask/src/fly_pools.rs
+++ b/crates/xtask/src/fly_pools.rs
@@ -1,0 +1,123 @@
+//! `cargo xtask fly-pools` — the committed runner-pool default must be one the manager accepts.
+//!
+//! `ci/fly-runner/manager.toml` carries a `POOLS` default that a fresh deployment uses
+//! until `fly secrets set POOLS=...` replaces it with the real volume ids. The manager
+//! validates that JSON at startup (`ci_fly_runner::parse_pools`), and nothing validated
+//! the committed copy — so the tracked default could be, and was, a configuration the
+//! manager refuses:
+//!
+//! ```text
+//! "size":8,"standby":8,"requires_volume":true      and no "volumes" key
+//! ```
+//!
+//! `requires_volume` with zero volumes for eight machines is rejected by
+//! `crates/ci-fly-runner/src/lib.rs`, whose message explains why it must be:
+//! machines past the end of the volume list "would compile onto the root filesystem and
+//! run out of disk". That failure is not hypothetical — `requires_volume`'s own doc
+//! records it costing four required checks, ejected from the merge queue while looking
+//! clean, after `ld terminated with signal 7 [Bus error]` and then ENOSPC.
+//!
+//! The comment two lines above the value asserted the opposite: "this tracked default
+//! has none, so a fresh deployment works without them (cold caches)." It could not.
+//!
+//! This calls **the manager's own validator**. A second implementation of the rule would
+//! be a second thing to drift, which is the failure this whole family of gates exists to
+//! refuse.
+//!
+//! # What decides this
+//!
+//! One committed TOML file. No source tree, no Fly API, no network.
+
+use std::fs;
+use std::path::Path;
+
+use anyhow::{Context, Result, bail};
+
+const MANAGER_TOML: &str = "ci/fly-runner/manager.toml";
+
+/// The `POOLS = '...'` value, as the manager would receive it.
+pub fn pools_json(manager_toml: &str) -> Result<String> {
+    for line in manager_toml.lines() {
+        let t = line.trim();
+        if let Some(rest) = t.strip_prefix("POOLS") {
+            let rest = rest.trim_start();
+            let Some(rest) = rest.strip_prefix('=') else {
+                continue;
+            };
+            let rest = rest.trim();
+            // Single-quoted TOML literal string: no escapes, so the value is what is between.
+            if let Some(inner) = rest.strip_prefix('\'').and_then(|r| r.rsplit_once('\'')) {
+                return Ok(inner.0.to_string());
+            }
+            if let Some(inner) = rest.strip_prefix('"').and_then(|r| r.rsplit_once('"')) {
+                return Ok(inner.0.to_string());
+            }
+            bail!("{MANAGER_TOML}: POOLS is not a quoted string");
+        }
+    }
+    bail!("{MANAGER_TOML}: no POOLS assignment")
+}
+
+pub fn check(root: &Path) -> Result<()> {
+    let text = fs::read_to_string(root.join(MANAGER_TOML))
+        .with_context(|| format!("reading {MANAGER_TOML}"))?;
+    let json = pools_json(&text)?;
+
+    match ci_fly_runner::parse_pools(&json) {
+        Ok(pools) => {
+            for p in &pools {
+                println!(
+                    "ok: {} — size {} standby {} volumes {} requires_volume {}",
+                    p.label,
+                    p.size,
+                    p.standby,
+                    p.volumes.len(),
+                    p.requires_volume
+                );
+            }
+            if pools.is_empty() {
+                bail!("{MANAGER_TOML}: POOLS parsed to no pools at all");
+            }
+            Ok(())
+        }
+        Err(e) => bail!(
+            "{MANAGER_TOML}'s POOLS default is a configuration the manager REFUSES:\n  {e}\n\
+             This is the value a fresh deployment uses until `fly secrets set POOLS=...`\n\
+             replaces it, so a default the manager rejects is a deployment that does not start."
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn root() -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("../..")
+    }
+
+    #[test]
+    fn the_committed_default_is_one_the_manager_accepts() {
+        check(&root()).expect("the tracked POOLS default must validate");
+    }
+
+    #[test]
+    fn extracts_the_single_quoted_value() {
+        let t = "FLY_REGION = \"iad\"\nPOOLS = '[{\"label\":\"a\"}]'\n";
+        assert_eq!(pools_json(t).unwrap(), "[{\"label\":\"a\"}]");
+    }
+
+    #[test]
+    fn a_missing_pools_assignment_is_an_error() {
+        assert!(pools_json("FLY_REGION = \"iad\"\n").is_err());
+    }
+
+    #[test]
+    fn the_defect_this_gate_was_written_for_is_refused() {
+        // requires_volume with no volumes: what the tracked default actually held.
+        let bad = r#"[{"label":"b","guest":{"cpu_kind":"performance","cpus":8,"memory_mb":32768},"size":8,"standby":8,"requires_volume":true}]"#;
+        let e = ci_fly_runner::parse_pools(bad).expect_err("must be refused");
+        assert!(e.contains("requires_volume"), "message names the rule: {e}");
+    }
+}

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -211,8 +211,8 @@ enum CiSpecCmd {
 mod ci_otel;
 mod ci_spec;
 mod ci_timings;
-mod gatehouse_pin;
 mod fly_pools;
+mod gatehouse_pin;
 mod kani_coverage;
 mod line_ratchet;
 mod pin_parity;

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -67,6 +67,9 @@ enum Command {
     /// checksum, the aeneas/charon pins, the first-party lean-toolchain files. Decided
     /// from committed declarations alone — no source tree, no toolchain.
     PinParity,
+    /// The committed `POOLS` default in ci/fly-runner/manager.toml must be a
+    /// configuration the manager accepts, checked with the manager's own validator.
+    FlyPools,
     /// Every source Kani harness must have a CI lane or a named documented exception.
     KaniCoverage,
     /// Build every workspace crate in isolation (`cargo build -p <crate>`) to
@@ -209,6 +212,7 @@ mod ci_otel;
 mod ci_spec;
 mod ci_timings;
 mod gatehouse_pin;
+mod fly_pools;
 mod kani_coverage;
 mod line_ratchet;
 mod pin_parity;
@@ -234,6 +238,7 @@ fn main() -> Result<()> {
             self_pin::Outcome::Clean => Ok(()),
         },
         Command::PinParity => pin_parity::check(&std::env::current_dir()?),
+        Command::FlyPools => fly_pools::check(&std::env::current_dir()?),
         Command::KaniCoverage => kani_coverage::check(&std::env::current_dir()?),
         Command::GatehousePin { gatehouse } => {
             gatehouse_pin::check(&std::env::current_dir()?, gatehouse)


### PR DESCRIPTION
`ci/fly-runner/manager.toml` carries the `POOLS` value a fresh deployment uses until `fly secrets set POOLS=…` replaces it with the real volume ids. It declared:

```
"size":8,"standby":8,"requires_volume":true      and no "volumes" key
```

`ci_fly_runner::parse_pools` **rejects exactly that**:

> `requires_volume, but 0 volumes for 8 machines — the machines past the end of the list would compile onto the root filesystem and run out of disk`

So the default a fresh deployment falls back to was one the manager refuses to start on. The comment two lines above asserted the opposite: *"this tracked default has none, so a fresh deployment works without them (cold caches)."*

## The gap is the shape, not the value

The manager validates `POOLS` at **startup**, against a value chosen at **authoring time**, and nothing sat between them. `cargo xtask fly-pools` closes it by calling **the manager's own validator** — a second implementation of the rule would be a second thing to drift, which is the failure this family of gates exists to refuse.

## The fix to the default

`requires_volume: false`, which is what a volume-less default means. The **deployed** secret carries `true` beside the real ids, and that is where the safety property belongs: it caps `size` at the volume count, and a compile pool without a volume fills the 8 GB rootfs — `ld terminated with signal 7 [Bus error]`, then ENOSPC, then **four required checks ejected from the queue while looking clean**.

## A-19

The gate was written **first** and was RED on the live tree, quoting the manager's own message, before the default was corrected. Exit 1 then, exit 0 now. A unit test pins the refusal independently of the file, so the gate keeps its subject if the file is ever fixed a different way.

Lives in Manifest Guards beside the other "two things that must agree" checks. `cargo xtask ci-spec check` → `ok: every invariant holds`.

gatehouse `FINDINGS.md` F-22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MJ65muwqWqPidSYTnpknDi