### PR TITLE
gate: a SHA of this repo pinned by this repo must still match the tree

### DIFF
--- a/.github/workflows/manifest-guards.yml
+++ b/.github/workflows/manifest-guards.yml
@@ -83,6 +83,13 @@ jobs:
       - name: Docker Rust base >= workspace MSRV
         run: bash ci/docker-rust-matches-msrv.sh
 
+      # scan.yml runs THIS repo's own composite action by SHA. Pinning is right, but a
+      # pin to yourself can drift from the tree it lives in, and when it does the
+      # integration test exercises a copy of the action nobody ships -- and passes.
+      # The pin is currently 404 commits old and matches; nothing was keeping it that way.
+      - name: A SHA of this repo pinned by this repo still matches the tree
+        run: cargo run -q -p xtask -- self-pin
+
       # `.gitignore` said `/target/` — anchored to the root, so every nested
       # target/ escaped it, and tools/nucleus-mediation-lint/target was
       # committed: 2664 files, 1269 MB, 98% of the HEAD tree. The same mistake

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -52,6 +52,8 @@ enum Command {
         #[arg(long)]
         entries: bool,
     },
+    /// A SHA of this repo pinned by this repo must still match the working tree.
+    SelfPin,
     /// Every source Kani harness must have a CI lane or a named documented exception.
     KaniCoverage,
     /// Build every workspace crate in isolation (`cargo build -p <crate>`) to
@@ -197,6 +199,7 @@ mod kani_coverage;
 mod line_ratchet;
 mod rerun_plan;
 mod scoreboard;
+mod self_pin;
 
 fn main() -> Result<()> {
     match Cli::parse().command {
@@ -209,6 +212,7 @@ fn main() -> Result<()> {
         } => policy_gate(&base, &candidate, changed_files.as_deref()),
         Command::RerunPlan => rerun_plan_cmd(),
         Command::CiTimings { sha, top, json } => ci_timings::ci_timings(sha, top, json),
+        Command::SelfPin => self_pin::check(&std::env::current_dir()?),
         Command::KaniCoverage => kani_coverage::check(&std::env::current_dir()?),
         Command::LineRatchet { strict, entries } => {
             if entries {

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -212,7 +212,12 @@ fn main() -> Result<()> {
         } => policy_gate(&base, &candidate, changed_files.as_deref()),
         Command::RerunPlan => rerun_plan_cmd(),
         Command::CiTimings { sha, top, json } => ci_timings::ci_timings(sha, top, json),
-        Command::SelfPin => self_pin::check(&std::env::current_dir()?),
+        Command::SelfPin => match self_pin::check(&std::env::current_dir()?)? {
+            // 2 is "could not look", which is never a pass. Mapped here rather than
+            // exited from inside the check, so a unit test calling it survives.
+            self_pin::Outcome::CouldNotLook => std::process::exit(2),
+            self_pin::Outcome::Clean => Ok(()),
+        },
         Command::KaniCoverage => kani_coverage::check(&std::env::current_dir()?),
         Command::LineRatchet { strict, entries } => {
             if entries {

--- a/crates/xtask/src/self_pin.rs
+++ b/crates/xtask/src/self_pin.rs
@@ -1,0 +1,214 @@
+//! `cargo xtask self-pin` — when the repo pins a SHA of itself, that SHA must still be us.
+//!
+//! `.github/workflows/scan.yml` runs the repository's own composite action by full SHA:
+//!
+//! ```yaml
+//! uses: coproduct-opensource/nucleus/scan@a8ae0edb20d9182718632606cf0c83f5d881450a
+//! ```
+//!
+//! Pinning by SHA is right — it is what every other `uses:` here does, and what Scorecard
+//! asks for. But a pin to *someone else's* repo and a pin to *your own* differ in one way
+//! that matters: the working tree also contains that action, and the two can drift. When
+//! they do, the integration test exercises a copy of the action that nobody ships, and
+//! passes. The gate goes on being green while testing the past.
+//!
+//! Today the pinned tree and `scan/` agree. The pin is **404 commits and six weeks** old,
+//! and nothing noticed either fact. That is the same shape as every other pin this repo
+//! gates: one thing written twice, agreeing now, with nothing keeping it that way.
+//!
+//! # What decides this
+//!
+//! Git objects already in the repository, and the workflow file. No network when the
+//! commit is present, no toolchain, no source build. A commit that is genuinely absent
+//! (a shallow clone) is reported as **could not look**, never as a pass — the distinction
+//! `scripts/check-ci-spec.sh` also makes, "exit 0 clean, 1 a violation, 2 could not look —
+//! the third is never a pass."
+
+use std::path::Path;
+use std::process::Command;
+
+use anyhow::{Context, Result, bail};
+
+const OWNER_REPO: &str = "coproduct-opensource/nucleus";
+
+/// One `uses: <owner>/<repo>/<subdir>@<sha>` naming this very repository.
+#[derive(Debug, PartialEq, Eq)]
+pub struct SelfPin {
+    pub workflow: String,
+    pub subdir: String,
+    pub sha: String,
+}
+
+pub fn find(workflows: &[(String, String)]) -> Vec<SelfPin> {
+    let needle = format!("{OWNER_REPO}/");
+    let mut out = Vec::new();
+    for (name, text) in workflows {
+        for line in text.lines() {
+            let t = line.trim();
+            if t.starts_with('#') {
+                continue;
+            }
+            let Some(i) = t.find("uses:") else { continue };
+            let rest = t[i + 5..].trim();
+            let Some(rest) = rest.strip_prefix(&needle) else {
+                continue;
+            };
+            let Some((subdir, sha)) = rest.split_once('@') else {
+                continue;
+            };
+            let sha = sha.split_whitespace().next().unwrap_or(sha);
+            if sha.len() == 40 && sha.bytes().all(|b| b.is_ascii_hexdigit()) {
+                out.push(SelfPin {
+                    workflow: name.clone(),
+                    subdir: subdir.to_string(),
+                    sha: sha.to_string(),
+                });
+            }
+        }
+    }
+    out
+}
+
+fn git(root: &Path, args: &[&str]) -> Result<std::process::Output> {
+    Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(args)
+        .output()
+        .with_context(|| format!("git {}", args.join(" ")))
+}
+
+pub fn check(root: &Path) -> Result<()> {
+    let dir = root.join(".github/workflows");
+    let mut workflows: Vec<(String, String)> = Vec::new();
+    for e in std::fs::read_dir(&dir).with_context(|| format!("reading {}", dir.display()))? {
+        let p = e?.path();
+        if p.extension().is_some_and(|x| x == "yml" || x == "yaml") {
+            let name = p
+                .strip_prefix(root)
+                .unwrap_or(&p)
+                .to_string_lossy()
+                .to_string();
+            workflows.push((name, std::fs::read_to_string(&p)?));
+        }
+    }
+    workflows.sort();
+
+    let pins = find(&workflows);
+    if pins.is_empty() {
+        // Not a pass. If the `uses:` line is reworded or the action moves, this gate would
+        // go quiet exactly when it stopped watching anything.
+        bail!(
+            "no `uses: {OWNER_REPO}/<dir>@<sha>` found in .github/workflows. Either the \
+             self-pin was removed — in which case delete this gate — or its shape changed \
+             and the gate is now watching nothing."
+        );
+    }
+
+    let mut drifted = 0usize;
+    for pin in &pins {
+        let present = git(
+            root,
+            &["cat-file", "-e", &format!("{}^{{commit}}", pin.sha)],
+        )?
+        .status
+        .success();
+        if !present {
+            // Exit 2 semantics: could not look is never a pass.
+            eprintln!(
+                "could not look: {} pins {} at {}, which is not in this clone.\n\
+                 Fetch it (`git fetch origin {}`) or deepen the checkout; a missing commit \
+                 is not agreement.",
+                pin.workflow, pin.subdir, pin.sha, pin.sha
+            );
+            std::process::exit(2);
+        }
+        let out = git(
+            root,
+            &["diff", "--name-only", &pin.sha, "HEAD", "--", &pin.subdir],
+        )?;
+        let changed = String::from_utf8_lossy(&out.stdout);
+        let changed: Vec<&str> = changed.lines().filter(|l| !l.is_empty()).collect();
+        if changed.is_empty() {
+            let behind = git(
+                root,
+                &["rev-list", "--count", &format!("{}..HEAD", pin.sha)],
+            )?;
+            let behind = String::from_utf8_lossy(&behind.stdout).trim().to_string();
+            println!(
+                "ok: {} pins {}/ at {} — identical to HEAD ({behind} commits back)",
+                pin.workflow,
+                pin.subdir,
+                &pin.sha[..12]
+            );
+        } else {
+            drifted += 1;
+            eprintln!(
+                "DRIFT: {} runs {}/ from {}, which differs from HEAD:",
+                pin.workflow,
+                pin.subdir,
+                &pin.sha[..12]
+            );
+            for f in changed {
+                eprintln!("    {f}");
+            }
+            eprintln!(
+                "  The integration test is exercising a copy of the action that is not the \
+                 one this repo ships, and passing. Re-pin to a commit whose {}/ matches, or \
+                 revert the change.",
+                pin.subdir
+            );
+        }
+    }
+
+    if drifted > 0 {
+        bail!("{drifted} self-pinned action(s) differ from the working tree");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn finds_the_shipped_self_pin() {
+        let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+        check(&root).expect("the self-pin must match HEAD");
+    }
+
+    #[test]
+    fn parses_a_self_pin() {
+        let w = vec![(
+            "w.yml".to_string(),
+            format!("        uses: {OWNER_REPO}/scan@{}\n", "a".repeat(40)),
+        )];
+        let p = find(&w);
+        assert_eq!(p.len(), 1);
+        assert_eq!(p[0].subdir, "scan");
+    }
+
+    #[test]
+    fn a_tag_is_not_a_pin() {
+        let w = vec![("w.yml".to_string(), format!("uses: {OWNER_REPO}/scan@v1\n"))];
+        assert!(find(&w).is_empty(), "only a 40-char sha counts as pinned");
+    }
+
+    #[test]
+    fn a_third_party_action_is_not_a_self_pin() {
+        let w = vec![(
+            "w.yml".to_string(),
+            format!("uses: actions/checkout@{}\n", "b".repeat(40)),
+        )];
+        assert!(find(&w).is_empty());
+    }
+
+    #[test]
+    fn a_commented_out_pin_is_not_a_pin() {
+        let w = vec![(
+            "w.yml".to_string(),
+            format!("# uses: {OWNER_REPO}/scan@{}\n", "c".repeat(40)),
+        )];
+        assert!(find(&w).is_empty());
+    }
+}

--- a/crates/xtask/src/self_pin.rs
+++ b/crates/xtask/src/self_pin.rs
@@ -107,17 +107,30 @@ pub fn check(root: &Path) -> Result<()> {
 
     let mut drifted = 0usize;
     for pin in &pins {
-        let present = git(
+        let mut present = git(
             root,
             &["cat-file", "-e", &format!("{}^{{commit}}", pin.sha)],
         )?
         .status
         .success();
         if !present {
+            // CI checks out shallow on purpose -- #2748 removed 3.3 GiB of dead history
+            // fetching -- so the pinned commit is normally absent. Deepening the whole
+            // clone to read one blob would hand that win straight back, so fetch exactly
+            // the one commit instead: depth 1 on a single sha is a few KB.
+            let _ = git(root, &["fetch", "--depth", "1", "origin", &pin.sha]);
+            present = git(
+                root,
+                &["cat-file", "-e", &format!("{}^{{commit}}", pin.sha)],
+            )?
+            .status
+            .success();
+        }
+        if !present {
             // Exit 2 semantics: could not look is never a pass.
             eprintln!(
                 "could not look: {} pins {} at {}, which is not in this clone.\n\
-                 Fetch it (`git fetch origin {}`) or deepen the checkout; a missing commit \
+                 A targeted `git fetch --depth 1 origin {}` did not produce it either; a missing commit \
                  is not agreement.",
                 pin.workflow, pin.subdir, pin.sha, pin.sha
             );

--- a/crates/xtask/src/self_pin.rs
+++ b/crates/xtask/src/self_pin.rs
@@ -31,6 +31,19 @@ use anyhow::{Context, Result, bail};
 
 const OWNER_REPO: &str = "coproduct-opensource/nucleus";
 
+/// What the check concluded. `CouldNotLook` is NOT a pass and NOT a violation: the third
+/// state `scripts/check-ci-spec.sh` insists on ("exit 0 clean, 1 a violation, 2 could not
+/// look — the third is never a pass"). It is returned rather than exited on, because
+/// `check` is called from a unit test and a library function that kills the process kills
+/// the test harness with it — which is exactly how this gate first broke CI.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Outcome {
+    /// Every self-pin matches the tree.
+    Clean,
+    /// A pinned commit is genuinely unavailable, even after a targeted fetch.
+    CouldNotLook,
+}
+
 /// One `uses: <owner>/<repo>/<subdir>@<sha>` naming this very repository.
 #[derive(Debug, PartialEq, Eq)]
 pub struct SelfPin {
@@ -78,7 +91,7 @@ fn git(root: &Path, args: &[&str]) -> Result<std::process::Output> {
         .with_context(|| format!("git {}", args.join(" ")))
 }
 
-pub fn check(root: &Path) -> Result<()> {
+pub fn check(root: &Path) -> Result<Outcome> {
     let dir = root.join(".github/workflows");
     let mut workflows: Vec<(String, String)> = Vec::new();
     for e in std::fs::read_dir(&dir).with_context(|| format!("reading {}", dir.display()))? {
@@ -134,7 +147,7 @@ pub fn check(root: &Path) -> Result<()> {
                  is not agreement.",
                 pin.workflow, pin.subdir, pin.sha, pin.sha
             );
-            std::process::exit(2);
+            return Ok(Outcome::CouldNotLook);
         }
         let out = git(
             root,
@@ -177,7 +190,7 @@ pub fn check(root: &Path) -> Result<()> {
     if drifted > 0 {
         bail!("{drifted} self-pinned action(s) differ from the working tree");
     }
-    Ok(())
+    Ok(Outcome::Clean)
 }
 
 #[cfg(test)]
@@ -185,9 +198,16 @@ mod tests {
     use super::*;
 
     #[test]
-    fn finds_the_shipped_self_pin() {
+    fn the_shipped_self_pin_matches_or_says_it_cannot_look() {
+        // Must not assert Clean: on a shallow clone with no network the honest answer is
+        // CouldNotLook. What it must never do is report drift, and it must never kill the
+        // test binary -- an earlier version called `std::process::exit(2)` here, which
+        // took the whole xtask test harness down with it in CI.
         let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
-        check(&root).expect("the self-pin must match HEAD");
+        match check(&root) {
+            Ok(Outcome::Clean | Outcome::CouldNotLook) => {}
+            Err(e) => panic!("the self-pin drifted from HEAD: {e}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
`.github/workflows/scan.yml:131` runs the repository's **own** composite action by full SHA:

```yaml
uses: coproduct-opensource/nucleus/scan@a8ae0edb20d9182718632606cf0c83f5d881450a
```

Pinning by SHA is right — it's what every other `uses:` here does, and what Scorecard asks for. But a pin to *someone else's* repo and a pin to *your own* differ in one way that matters: **the working tree also contains that action, and the two can drift.** When they do, the integration test exercises a copy of the action nobody ships — and passes. The gate stays green while testing the past.

Today they agree. The pin is **404 commits and six weeks old**, and nothing noticed either fact. Same shape as every other pin this repo gates: one thing written twice, agreeing now, with nothing keeping it that way.

## What decides it

Git objects already in the clone, plus the workflow file. No network when the commit is present, no toolchain, no build.

## A-19 (exit codes checked directly)

| case | exit |
|---|---|
| `scan/` drifts from its pin | **1**, naming every differing file and what the drift costs |
| the `uses:` shape changes | **1** — a gate matching nothing is an error, not a pass, so a reworded pin can't silence it |
| shipped tree | 0, and it prints how old the pin is |

A commit genuinely absent (shallow checkout) exits **2** with "could not look", never 0 — the distinction `scripts/check-ci-spec.sh` makes: *"exit 0 clean, 1 a violation, 2 could not look — the third is never a pass."*

Lives in Manifest Guards with the rest of the two-copies-of-one-fact family. `cargo xtask ci-spec check` → `ok: every invariant holds`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MJ65muwqWqPidSYTnpknDi