### PR TITLE
gate: the third gatehouse pin, and the skew it was hiding

### DIFF
--- a/.gatehouse/pipeline.writ
+++ b/.gatehouse/pipeline.writ
@@ -6,7 +6,7 @@
 --   Cap  = (net, exec, wallMs, cpuMs, memMb, fsRead, fsWrite, secrets)   net tag 3 0 = None, exec tag 3 1 = Scoped
 --   Gate = (name, hash, scope, env, cap, cmd, timeoutMs, outputs)         hash is filled by the elaborator (zeroed when hashed)
 -- env = the rust:1.96.1-slim-bookworm image index digest (rust-toolchain.toml pins 1.96.1).
-import "sha256:3180b3306a5a4ecd77485a0ea2e086df2a3ab0cb7bef20973bec2197c7d2c031" as ci
+import "sha256:2476e955fd994059e1b4ecd9d6741faabd63cb56e6f80fa5003af9478dcae2e8" as ci
 let env : Digest = #d"e18a79fc84dfcfc3ab5ba72290398a644c135c97eaa881447fddc354ee4701a3"
 let ceiling : ci.Cap = (tag 3 0, tag 3 1, 3600000, 3600000, 16384, [#b"Cargo.toml", #b"Cargo.lock", #b"rust-toolchain.toml", #b"crates/**", #b"tests/**", #b"benchmarks/**", #b"crates/portcullis-core/lean/**", #b"scripts/**", #b"sdks/verifier-js/**", #b".github/workflows/**", #b"ci/**", #b"crates/ci-spec/**", #b"scripts/check-ci-spec.sh"] : Bytes, [#b"target/**", #b"sdks/verifier-js/pkg/**", #b"sdks/verifier-js/target/**", #b"crates/portcullis-core/lean/.lake/**"] : Bytes, [] : Bytes)
 let rcap : ci.Cap = (tag 3 0, tag 3 1, 3600000, 3600000, 8192, [#b"Cargo.toml", #b"Cargo.lock", #b"rust-toolchain.toml", #b"crates/**", #b"tests/**", #b"benchmarks/**", #b"scripts/**", #b"sdks/verifier-js/**"] : Bytes, [#b"target/**", #b"sdks/verifier-js/pkg/**", #b"sdks/verifier-js/target/**"] : Bytes, [] : Bytes)

--- a/.github/workflows/gatehouse-plan.yml
+++ b/.github/workflows/gatehouse-plan.yml
@@ -71,6 +71,17 @@ jobs:
           # gate exists to notice. The GitHub-side commands carry their own denial where they
           # need it (the clippy gate passes `-D warnings` on its own command line).
           rustflags: ''
+      - name: The two pins agree (before spending three minutes on a build)
+        if: steps.tok.outputs.present == 'true'
+        # GATEHOUSE_REF and the plan's import digest are one fact written twice, and the
+        # env comment above has always SAID they must match. Saying it is not checking it:
+        # bumping either alone makes `gate plan check` fail with `no library for import`
+        # about three minutes into the cargo build below. This decides the same thing from
+        # the three declarations in milliseconds, and it also refuses a gatehouse checkout
+        # that is not AT the pinned ref -- reading the mismatch from the wrong side is how
+        # a working pin gets mistaken for a stale one (gatehouse FINDINGS.md F-21).
+        run: cargo run -q -p xtask -- gatehouse-pin --gatehouse gatehouse
+
       - name: gate plan check .gatehouse/pipeline.writ
         if: steps.tok.outputs.present == 'true'
         run: |

--- a/.github/workflows/gatehouse-plan.yml
+++ b/.github/workflows/gatehouse-plan.yml
@@ -34,9 +34,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
-      # The gatehouse commit whose `gate` checks the plan (its embedded prelude must match the
-      # import hash in .gatehouse/pipeline.writ).
-      GATEHOUSE_REF: 4d42510657690b90cf796d57ce277e665fca0989
+      # The gatehouse commit whose `gate` checks the plan. Two things must move WITH it,
+      # and `cargo xtask gatehouse-pin` now refuses the change if either does not:
+      #   * .gatehouse/pipeline.writ's import digest -- this ref's prelude/ci.writ hash;
+      #   * gatehouse-shadow.yml's GATEHOUSE_REF -- a shadow built from a different
+      #     gatehouse than the plan check compares two things that were never the same.
+      # Moved 4d42510 -> 7326bfa9 (a descendant) on 2026-09-10 to close a skew that had
+      # gone unnoticed because nothing compared the two workflows.
+      GATEHOUSE_REF: 7326bfa9ea3f490c20bb406941527ac0484410c5
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13723,9 +13723,11 @@ dependencies = [
  "ck-kernel",
  "ck-types",
  "clap",
+ "hex",
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2 0.11.0",
  "syn 2.0.117",
  "toml 1.1.5+spec-1.1.0",
 ]

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -27,3 +27,6 @@ ci-spec = { path = "../ci-spec" }
 syn = { version = "2", features = ["full", "visit"] }
 serde_yaml = { workspace = true }
 toml = { workspace = true }
+# `gatehouse-pin`: the import digest is a plain SHA-256 of prelude/ci.writ.
+sha2 = { workspace = true }
+hex = { workspace = true }

--- a/crates/xtask/src/gatehouse_pin.rs
+++ b/crates/xtask/src/gatehouse_pin.rs
@@ -1,0 +1,184 @@
+//! `cargo xtask gatehouse-pin` — the two pins that must move together.
+//!
+//! nucleus names gatehouse twice, and the two names have to agree:
+//!
+//! * `.gatehouse/pipeline.writ` imports the `ci` prelude **by digest**
+//!   (`import "sha256:…" as ci`), which is what makes the plan hermetic;
+//! * `.github/workflows/gatehouse-plan.yml` pins `GATEHOUSE_REF` to the gatehouse
+//!   commit whose `gate` binary checks that plan.
+//!
+//! The import digest must be the SHA-256 of `prelude/ci.writ` **at that ref**. The
+//! workflow already says so in a comment — "its embedded prelude must match the import
+//! hash in .gatehouse/pipeline.writ" — and nothing checked it, which is the difference
+//! between a convention and a gate.
+//!
+//! # Why this exists
+//!
+//! Bumping one pin alone breaks the plan check, and the failure is remote and slow: the
+//! job spends ~3 minutes building gatehouse before `gate` reports `no library for import`.
+//! Worse, reading that message from the *wrong* side is how a working pin gets mistaken
+//! for a stale one — a pin refusing a library the pinned build does not have is the pin
+//! doing its job. That mistake was made against this exact pair (gatehouse `FINDINGS.md`
+//! F-21) and produced a PR that moved one pin alone.
+//!
+//! # What decides this
+//!
+//! All three operands are declarations: a workflow `env` value, an import line, and a file
+//! in a repository pinned by SHA. Nothing here reads nucleus's source tree, nothing needs a
+//! toolchain, and the verdict is the same against an empty checkout of nucleus. See
+//! gatehouse `docs/tiering.md` — this is the shape that gate is cheapest.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+use sha2::{Digest, Sha256};
+
+const PIPELINE: &str = ".gatehouse/pipeline.writ";
+const WORKFLOW: &str = ".github/workflows/gatehouse-plan.yml";
+const PRELUDE: &str = "prelude/ci.writ";
+
+/// The `sha256:…` an `import` line names, as lowercase hex without the prefix.
+pub fn imported_digest(pipeline_src: &str) -> Result<String> {
+    for line in pipeline_src.lines() {
+        let line = line.trim_start();
+        if !line.starts_with("import ") {
+            continue;
+        }
+        // `import "sha256:<64 hex>" as ci`
+        let Some(open) = line.find('"') else { continue };
+        let Some(close) = line[open + 1..].find('"') else {
+            continue;
+        };
+        let quoted = &line[open + 1..open + 1 + close];
+        let Some(hex) = quoted.strip_prefix("sha256:") else {
+            bail!("{PIPELINE}: import {quoted:?} is not a sha256: digest");
+        };
+        if hex.len() != 64 || !hex.bytes().all(|b| b.is_ascii_hexdigit()) {
+            bail!("{PIPELINE}: import digest {hex:?} is not 64 hex characters");
+        }
+        // The plan imports one library today. If it ever imports several this must name
+        // WHICH, rather than silently checking the first — the `head -1` failure that
+        // .line-ratchet.toml already paid for once.
+        return Ok(hex.to_ascii_lowercase());
+    }
+    bail!("{PIPELINE}: no `import \"sha256:…\"` line")
+}
+
+/// `GATEHOUSE_REF` as the workflow declares it.
+pub fn pinned_ref(workflow_src: &str) -> Result<String> {
+    for line in workflow_src.lines() {
+        let t = line.trim();
+        if let Some(v) = t.strip_prefix("GATEHOUSE_REF:") {
+            let v = v.trim().trim_matches(|c| c == '"' || c == '\'');
+            if v.len() != 40 || !v.bytes().all(|b| b.is_ascii_hexdigit()) {
+                bail!("{WORKFLOW}: GATEHOUSE_REF {v:?} is not a 40-character commit sha");
+            }
+            return Ok(v.to_ascii_lowercase());
+        }
+    }
+    bail!("{WORKFLOW}: no GATEHOUSE_REF")
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut h = Sha256::new();
+    h.update(bytes);
+    hex::encode(h.finalize())
+}
+
+/// Check the pins. `gatehouse` is a checkout of `coproduct-private/gatehouse`; without one
+/// only the two nucleus-side declarations can be read, which is reported rather than
+/// treated as a pass.
+pub fn check(root: &Path, gatehouse: Option<PathBuf>) -> Result<()> {
+    let pipeline =
+        fs::read_to_string(root.join(PIPELINE)).with_context(|| format!("reading {PIPELINE}"))?;
+    let workflow =
+        fs::read_to_string(root.join(WORKFLOW)).with_context(|| format!("reading {WORKFLOW}"))?;
+
+    let want = imported_digest(&pipeline)?;
+    let gh_ref = pinned_ref(&workflow)?;
+    println!("{PIPELINE} imports sha256:{want}");
+    println!("{WORKFLOW} pins    GATEHOUSE_REF {gh_ref}");
+
+    let Some(dir) = gatehouse else {
+        println!(
+            "no --gatehouse checkout given: the third operand is {PRELUDE} at {gh_ref}, so \
+             this run checked only that both declarations exist and are well formed"
+        );
+        return Ok(());
+    };
+
+    // The checkout must BE the pinned ref, or this compares against the wrong side — the
+    // exact mistake F-21 records.
+    let head = std::process::Command::new("git")
+        .args(["-C", &dir.to_string_lossy(), "rev-parse", "HEAD"])
+        .output()
+        .with_context(|| format!("git rev-parse in {}", dir.display()))?;
+    let head = String::from_utf8_lossy(&head.stdout)
+        .trim()
+        .to_ascii_lowercase();
+    if head != gh_ref {
+        bail!(
+            "the gatehouse checkout at {} is {head}, but {WORKFLOW} pins {gh_ref}.\n\
+             Comparing the prelude against the wrong commit answers a different question \
+             than the one this gate asks.",
+            dir.display()
+        );
+    }
+
+    let prelude = fs::read(dir.join(PRELUDE))
+        .with_context(|| format!("reading {PRELUDE} from {}", dir.display()))?;
+    let got = sha256_hex(&prelude);
+    if got != want {
+        bail!(
+            "the two pins disagree.\n\
+             \x20 {PIPELINE} imports          sha256:{want}\n\
+             \x20 {PRELUDE} at {gh_ref} is sha256:{got}\n\
+             They must move together: bumping GATEHOUSE_REF without the import digest (or the \
+             reverse) makes `gate plan check` fail with `no library for import`, ~3 minutes into \
+             a build. If gatehouse's prelude changed deliberately, bump BOTH in one change, and \
+             re-check the plan is still admissible rather than merely parseable."
+        );
+    }
+    println!("ok: {PRELUDE} at {gh_ref} hashes to the digest the plan imports");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reads_the_real_declarations() {
+        let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+        let pipeline = fs::read_to_string(root.join(PIPELINE)).unwrap();
+        let workflow = fs::read_to_string(root.join(WORKFLOW)).unwrap();
+        let d = imported_digest(&pipeline).expect("the shipped plan names a digest");
+        let r = pinned_ref(&workflow).expect("the shipped workflow pins a ref");
+        assert_eq!(d.len(), 64);
+        assert_eq!(r.len(), 40);
+    }
+
+    #[test]
+    fn a_tag_shaped_import_is_refused() {
+        assert!(imported_digest("import \"rust:1.96\" as ci\n").is_err());
+    }
+
+    #[test]
+    fn a_truncated_digest_is_refused() {
+        assert!(imported_digest("import \"sha256:abc123\" as ci\n").is_err());
+    }
+
+    #[test]
+    fn a_branch_name_is_not_a_pin() {
+        assert!(pinned_ref("    GATEHOUSE_REF: main\n").is_err());
+    }
+
+    #[test]
+    fn the_digest_is_plain_sha256_of_the_file_bytes() {
+        assert_eq!(
+            sha256_hex(b""),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+    }
+}

--- a/crates/xtask/src/gatehouse_pin.rs
+++ b/crates/xtask/src/gatehouse_pin.rs
@@ -5,7 +5,10 @@
 //! * `.gatehouse/pipeline.writ` imports the `ci` prelude **by digest**
 //!   (`import "sha256:…" as ci`), which is what makes the plan hermetic;
 //! * `.github/workflows/gatehouse-plan.yml` pins `GATEHOUSE_REF` to the gatehouse
-//!   commit whose `gate` binary checks that plan.
+//!   commit whose `gate` binary checks that plan;
+//! * `.github/workflows/gatehouse-shadow.yml` pins its OWN `GATEHOUSE_REF`, and must
+//!   name the same commit — a shadow built from a different gatehouse than the plan
+//!   check is comparing two things that were never the same.
 //!
 //! The import digest must be the SHA-256 of `prelude/ci.writ` **at that ref**. The
 //! workflow already says so in a comment — "its embedded prelude must match the import
@@ -35,7 +38,15 @@ use anyhow::{Context, Result, bail};
 use sha2::{Digest, Sha256};
 
 const PIPELINE: &str = ".gatehouse/pipeline.writ";
-const WORKFLOW: &str = ".github/workflows/gatehouse-plan.yml";
+/// Both workflows that build gatehouse pin the ref they build it at. The plan lane's
+/// pin is the one the import digest must agree with; the shadow lane's is checked for
+/// agreement with it, because a shadow running a DIFFERENT gatehouse than the plan
+/// check is comparing two things that were never the same.
+const WORKFLOWS: [&str; 2] = [
+    ".github/workflows/gatehouse-plan.yml",
+    ".github/workflows/gatehouse-shadow.yml",
+];
+const WORKFLOW: &str = WORKFLOWS[0];
 const PRELUDE: &str = "prelude/ci.writ";
 
 /// The `sha256:…` an `import` line names, as lowercase hex without the prefix.
@@ -99,6 +110,29 @@ pub fn check(root: &Path, gatehouse: Option<PathBuf>) -> Result<()> {
     let gh_ref = pinned_ref(&workflow)?;
     println!("{PIPELINE} imports sha256:{want}");
     println!("{WORKFLOW} pins    GATEHOUSE_REF {gh_ref}");
+
+    // The THIRD pin. gatehouse-shadow.yml builds gatehouse too, at its own
+    // GATEHOUSE_REF, and nothing said the two had to be the same commit. They were
+    // not: the plan lane ran 4d42510 while the shadow lane ran 7326bfa9, a descendant
+    // — so the shadow was comparing a gate built from one gatehouse against a plan
+    // checked by another, and calling agreement between them meaningful.
+    let shadow_path = root.join(WORKFLOWS[1]);
+    let shadow_ref = pinned_ref(
+        &fs::read_to_string(&shadow_path).with_context(|| format!("reading {}", WORKFLOWS[1]))?,
+    )?;
+    println!("{} pins  GATEHOUSE_REF {shadow_ref}", WORKFLOWS[1]);
+    if shadow_ref != gh_ref {
+        bail!(
+            "the two workflows build gatehouse at different commits.\n\
+             \x20 {WORKFLOW} pins   {gh_ref}\n\
+             \x20 {} pins {shadow_ref}\n\
+             The shadow gate exists to say whether gatehouse's verdict agrees with \
+             GitHub's. Run against a different gatehouse than the plan check, it answers \
+             a question nobody asked. If the skew is deliberate, say so here and in both \
+             workflows; otherwise move them together.",
+            WORKFLOWS[1]
+        );
+    }
 
     let Some(dir) = gatehouse else {
         println!(

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -37,6 +37,15 @@ struct Cli {
 enum Command {
     /// Inventory repo shell scripts and flag which are xtask port candidates.
     Scripts,
+    /// The two pins naming gatehouse must agree: `.gatehouse/pipeline.writ`'s import
+    /// digest must be the SHA-256 of `prelude/ci.writ` at `gatehouse-plan.yml`'s
+    /// `GATEHOUSE_REF`. Decided from declarations alone; reads no source tree.
+    GatehousePin {
+        /// A checkout of `coproduct-private/gatehouse`, which must be AT the pinned ref.
+        /// Without it only the two nucleus-side declarations can be read.
+        #[arg(long)]
+        gatehouse: Option<std::path::PathBuf>,
+    },
     /// Line-count ratchet, split by what decides the verdict.
     ///
     /// The declaration half is decided by `.line-ratchet.toml` alone and would give
@@ -193,6 +202,7 @@ enum CiSpecCmd {
 mod ci_otel;
 mod ci_spec;
 mod ci_timings;
+mod gatehouse_pin;
 mod kani_coverage;
 mod line_ratchet;
 mod rerun_plan;
@@ -210,6 +220,9 @@ fn main() -> Result<()> {
         Command::RerunPlan => rerun_plan_cmd(),
         Command::CiTimings { sha, top, json } => ci_timings::ci_timings(sha, top, json),
         Command::KaniCoverage => kani_coverage::check(&std::env::current_dir()?),
+        Command::GatehousePin { gatehouse } => {
+            gatehouse_pin::check(&std::env::current_dir()?, gatehouse)
+        }
         Command::LineRatchet { strict, entries } => {
             if entries {
                 line_ratchet::entries_json()

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -364,6 +364,18 @@ fn collect_sh(root: &std::path::Path, dir: &std::path::Path, out: &mut Vec<Strin
             {
                 continue;
             }
+            // Skip anything that is its own checkout. A git WORKTREE (`wt-2630/`,
+            // `wt-hoist/`, …) carries a `.git` FILE rather than a directory, so the
+            // dot-dir rule above does not see it and the walk descends into a second
+            // copy of the whole repository. That is not a cosmetic miscount: this
+            // command IS the port backlog, and it reported "164 total, 150 port
+            // candidates" against a real 90 and 83 — a tracker roughly 2x wrong, in
+            // the direction that makes the remaining work look hopeless. Testing for
+            // `.git` catches worktrees, submodules and stray clones by what they are
+            // rather than by a name pattern that the next worktree will not match.
+            if path.join(".git").exists() {
+                continue;
+            }
             collect_sh(root, &path, out)?;
         } else if name.ends_with(".sh")
             && let Ok(rel) = path.strip_prefix(root)
@@ -505,6 +517,31 @@ fn rerun_plan_cmd() -> Result<()> {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn the_inventory_does_not_descend_into_another_checkout() {
+        // A git worktree carries a `.git` FILE, so the dot-dir rule misses it and the
+        // walk finds a second copy of every script in the repo. This command is the port
+        // backlog, and it read 164/150 against a real 90/83 until that was fixed.
+        let tmp = std::env::temp_dir().join("xtask-collect-sh-test");
+        let _ = std::fs::remove_dir_all(&tmp);
+        let inner = tmp.join("wt-copy");
+        std::fs::create_dir_all(&inner).unwrap();
+        std::fs::write(tmp.join("mine.sh"), "#!/bin/sh\n").unwrap();
+        std::fs::write(inner.join("theirs.sh"), "#!/bin/sh\n").unwrap();
+        // Make `inner` look like a worktree: a `.git` file, not a directory.
+        std::fs::write(inner.join(".git"), "gitdir: /elsewhere\n").unwrap();
+
+        let mut out = Vec::new();
+        super::collect_sh(&tmp, &tmp, &mut out).unwrap();
+        out.sort();
+        assert_eq!(
+            out,
+            vec!["mine.sh".to_string()],
+            "a worktree's scripts are not ours"
+        );
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
     use super::parse_member_names;
 
     #[test]


### PR DESCRIPTION
nucleus names gatehouse in **three** places. This gate covered two.

| | |
|---|---|
| `.gatehouse/pipeline.writ` | imports the `ci` prelude **by digest** |
| `gatehouse-plan.yml` | pins `GATEHOUSE_REF` for the plan check |
| `gatehouse-shadow.yml` | pins its **own** `GATEHOUSE_REF` ← unchecked |

**They had already drifted.** The plan lane built gatehouse at `4d42510`; the shadow lane built `7326bfa9`, a descendant. The shadow gate exists to say whether gatehouse's verdict agrees with GitHub's — run against a *different gatehouse* than the plan check, it answers a question nobody asked. Nothing compared the two workflows, so nobody knew.

The gate now refuses the skew, and this closes it by moving the plan lane forward to the shadow's ref. **That could not be done alone**: `7326bfa9`'s prelude hashes to `2476e955`, not the `3180b330` the plan imported, so the import digest moves in the same commit. Which is the point — the gate makes the coordination mandatory rather than remembered.

## Verified end to end

Against a real gatehouse checkout **at** the pinned commit, and for **admissibility**, not mere parsing:

```
gatehouse-pin (three pins, real checkout)   exit 0
gate plan check .gatehouse/pipeline.writ    exit 0
  admissible: proved by `admissible`
  nodes=5317 ctxs=1268 ty=4779 red=10780 sub=7579 shift=1027
```

A-19: the gate was **red on the live tree** before the bump, naming both refs.

## Also recovers two lost commits

#2767 merged at its `style: cargo fmt` commit. The `gatehouse-pin` gate itself and the port-backlog worktree fix sat only on a local branch — the PR merged without them, and a push that failed reported success. Both are cherry-picked here unchanged.

The port backlog now reads **91 / 84** rather than 164 / 150, once the `wt-2630` worktree stops being counted twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MJ65muwqWqPidSYTnpknDi