### PR TITLE
fix(ci): give the workspace coverage floor headroom

### DIFF
--- a/.github/workflows/coverage-matrix.yml
+++ b/.github/workflows/coverage-matrix.yml
@@ -143,10 +143,28 @@ jobs:
         # measured, so it was a claim, not a floor. Set to the floor of the
         # measurement; it may only go UP, in the change that earns it (the
         # line-ratchet's "reset to measured truth" convention).
+        #
+        # 83 -> 82.5, 2026-09-10, DELIBERATELY DOWN and against that convention, so
+        # the reason is here rather than implied. Setting the floor at the floor of
+        # the measurement left 0.47 points of margin; the workspace has since grown
+        # to 155 808 lines and the margin eroded to 0.07 -- about 110 lines. At that
+        # width any PR adding ~900 lines of feature code at normal coverage is red
+        # by arithmetic rather than by anything it did: #2765 (needs 392 more covered
+        # lines) and #2716 (420) were both blocked that way, neither having done
+        # anything wrong.
+        #
+        # 82.5 restores ~889 lines of margin against the same measurement. The
+        # direction of travel is unchanged -- this goes UP as coverage improves, and
+        # the next move should be up. What changed is that the floor stops being set
+        # to exactly the measured value, which is what made it a coin flip.
+        #
+        # The portcullis floor below is NOT touched: measured 89.93 % against 87, a
+        # 2.93-point margin, so it has the headroom this one lost. Checked before
+        # assuming both needed the same treatment.
         run: |
           cargo llvm-cov --workspace --all-features \
             --exclude nucleus-verifier-service \
-            --fail-under-lines 83 \
+            --fail-under-lines 82.5 \
             --ignore-filename-regex '(tests/|kani\.rs|main\.rs)' 2>&1 | tee /tmp/workspace-cov.txt
       - name: portcullis coverage (security-critical threshold)
         if: ${{ needs.changed-crates.outputs.all == 'true' || needs.changed-crates.outputs.crates != '' }}


### PR DESCRIPTION
See the commit message — it carries the full reasoning, the measurements, and what was deliberately left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MJ65muwqWqPidSYTnpknDi