### PR TITLE
perf(ci): mutation testing runs when portcullis changes, not when any file does

### DIFF
--- a/.github/workflows/coverage-matrix.yml
+++ b/.github/workflows/coverage-matrix.yml
@@ -37,6 +37,9 @@ jobs:
     outputs:
       all: ${{ steps.detect.outputs.all }}
       crates: ${{ steps.detect.outputs.crates }}
+      # Mutation testing mutates `portcullis` and nothing else, so it needs a
+      # narrower trigger than `all`. See the step below.
+      mutate: ${{ steps.detect.outputs.mutate }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -88,8 +91,37 @@ jobs:
           # of correctly skipping the heavy jobs below.
           crates="$(printf '%s\n' "$changed" | grep -oE '^crates/[^/]+' | sed 's#^crates/##' | sort -u | paste -sd' ' - || true)"
 
+          # Mutation testing runs `cargo mutants --package portcullis`. It mutates
+          # THAT crate and no other, so `all` is the wrong trigger for it: `all` is
+          # forced by any change under .github/, .cargo/ or scripts/, and a workflow
+          # file cannot change what portcullis does. Measured cost of getting this
+          # wrong: commit dabbad79b (#2773) touched manifest-guards.yml, Cargo.lock,
+          # manager.toml and three xtask files -- zero portcullis -- and mutation
+          # testing ran for 46.2 minutes as the SOLE critical path of a 72.1-minute
+          # wall.
+          #
+          # It runs when something that can change a portcullis mutant's outcome
+          # changes: the crate itself, the workspace dependency table or toolchain it
+          # compiles against, or this workflow (which owns the invocation and the
+          # --file list).
+          #
+          # Cargo.lock is DELIBERATELY not in that list, and the first version of this
+          # had it. #2773's entire lock diff was `+ "ci-fly-runner"` -- a dependency
+          # added to xtask -- so including the lock left the 46 minutes exactly where
+          # they were. A lock change that can move a portcullis mutant almost always
+          # arrives with a Cargo.toml change, which IS here. The residue -- a bare
+          # `cargo update` shifting a portcullis dependency -- is covered by the
+          # nightly full run above, which retries every mutant of all six modules.
+          mutate=false
+          if [ "$EVENT_NAME" != "pull_request" ] && [ "$EVENT_NAME" != "merge_group" ]; then
+            mutate=true                       # push/dispatch/schedule: no diff to narrow by
+          elif printf '%s\n' "$changed" | grep -qE '^crates/portcullis/|^(Cargo\.toml|rust-toolchain\.toml)$|^\.github/workflows/coverage-matrix\.yml$'; then
+            mutate=true
+          fi
+
           echo "all=$all" >> "$GITHUB_OUTPUT"
           echo "crates=$crates" >> "$GITHUB_OUTPUT"
+          echo "mutate=$mutate" >> "$GITHUB_OUTPUT"
 
           {
             echo "## Changed Crates Detection"
@@ -97,6 +129,7 @@ jobs:
             echo "- event: \`$EVENT_NAME\`"
             echo "- full run forced: \`$all\`"
             echo "- changed crates: \`${crates:-none}\`"
+            echo "- mutation testing: \`$mutate\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
   # Layer 1: LLVM source-based code coverage with threshold enforcement
@@ -193,15 +226,15 @@ jobs:
     if: github.event.pull_request.draft != true
     steps:
       - name: No-op twin (no relevant crate changes)
-        if: ${{ !(needs.changed-crates.outputs.all == 'true' || needs.changed-crates.outputs.crates != '') }}
+        if: ${{ needs.changed-crates.outputs.mutate != 'true' }}
         run: echo "No crate or CI configuration changes in this diff."
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        if: ${{ needs.changed-crates.outputs.all == 'true' || needs.changed-crates.outputs.crates != '' }}
+        if: ${{ needs.changed-crates.outputs.mutate == 'true' }}
         with:
           fetch-depth: 0
           filter: blob:none
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
-        if: ${{ needs.changed-crates.outputs.all == 'true' || needs.changed-crates.outputs.crates != '' }}
+        if: ${{ needs.changed-crates.outputs.mutate == 'true' }}
         with:
           cache: ${{ runner.environment == 'github-hosted' }}
       # The self-hosted image bakes it (docker/Dockerfile.runner
@@ -210,7 +243,7 @@ jobs:
       # which both floated the version and — because nothing baked it — spent
       # ~0.9m of a 1.4m job installing on every run of the SCARCEST pool.
       - name: Install cargo-mutants (baked into the self-hosted image)
-        if: ${{ needs.changed-crates.outputs.all == 'true' || needs.changed-crates.outputs.crates != '' }}
+        if: ${{ needs.changed-crates.outputs.mutate == 'true' }}
         run: command -v cargo-mutants >/dev/null || cargo install cargo-mutants --version 27.1.0 --locked
       # A full run of the six modules is ~30 min of a gate runner and ran on
       # every rebase of every PR. On pull_request and merge_group only the
@@ -222,7 +255,7 @@ jobs:
       # took the whole group down with it (2026-09-06). push, the nightly
       # schedule and workflow_dispatch still run everything.
       - name: Scope to the diff of the change under review
-        if: ${{ needs.changed-crates.outputs.all == 'true' || needs.changed-crates.outputs.crates != '' }}
+        if: ${{ needs.changed-crates.outputs.mutate == 'true' }}
         id: mutscope
         env:
           EVENT_NAME: ${{ github.event_name }}
@@ -247,7 +280,7 @@ jobs:
           { echo "run=$run"; echo "in_diff=$in_diff"; } >> "$GITHUB_OUTPUT"
           echo "mutants: run=$run ${in_diff:+(diff-scoped)}"
       - name: Run mutation tests on security-critical modules
-        if: ${{ (needs.changed-crates.outputs.all == 'true' || needs.changed-crates.outputs.crates != '') && (steps.mutscope.outputs.run == 'true') }}
+        if: ${{ (needs.changed-crates.outputs.mutate == 'true') && (steps.mutscope.outputs.run == 'true') }}
         shell: bash
         env:
           IN_DIFF: ${{ steps.mutscope.outputs.in_diff }}
@@ -274,7 +307,7 @@ jobs:
             --output mutants-report 2>&1 | tee /tmp/mutants.txt || rc=$?
           echo "cargo mutants exit: $rc"
       - name: The gate reads the machine report, not the console (#2562)
-        if: ${{ (needs.changed-crates.outputs.all == 'true' || needs.changed-crates.outputs.crates != '') && (always() && steps.mutscope.outputs.run == 'true') }}
+        if: ${{ (needs.changed-crates.outputs.mutate == 'true') && (always() && steps.mutscope.outputs.run == 'true') }}
         shell: bash
         run: |
           # `Mutation Testing` passed runs whose log said "cargo build failed in
@@ -290,10 +323,10 @@ jobs:
             exit 1
           fi
       - name: The mutants gate goes red on a saved failure log and a survivor
-        if: ${{ (needs.changed-crates.outputs.all == 'true' || needs.changed-crates.outputs.crates != '') && (always()) }}
+        if: ${{ (needs.changed-crates.outputs.mutate == 'true') && (always()) }}
         run: scripts/check-mutants-report.sh --self-test
       - name: Mutation summary
-        if: ${{ (needs.changed-crates.outputs.all == 'true' || needs.changed-crates.outputs.crates != '') && (always()) }}
+        if: ${{ (needs.changed-crates.outputs.mutate == 'true') && (always()) }}
         shell: bash
         env:
           RUN: ${{ steps.mutscope.outputs.run }}


### PR DESCRIPTION
**Mutation Testing is the sole critical path.** Measured on `dabbad79b`: **46.2 minutes of a 72.1-minute wall**, starting 25 minutes in. Everything else finished in its shadow.

It ran on a commit that touched **zero portcullis files** — `manifest-guards.yml`, `Cargo.lock`, `manager.toml`, three xtask files. `cargo mutants --package portcullis` mutates that crate and no other, but the job was guarded on `all == 'true' || crates != ''`, and `all` is forced by any change under `.github/`, `.cargo/` or `scripts/`. **A workflow file cannot change what portcullis does.**

New `mutate` output on the detector, true when something that can actually move a portcullis mutant's outcome changes.

## The Cargo.lock question, and why the first version of this was wrong

I included `Cargo.lock` initially. Testing the rule against the real file list showed `dabbad79b` **still evaluating true** — its entire lock diff was `+ "ci-fly-runner"`, a dependency added to *xtask*. Including the lock would have left the 46 minutes exactly where they were and shipped a change that measured as an improvement while saving nothing.

A lock change that can move a portcullis mutant almost always arrives with a `Cargo.toml` change, which **is** in the list. The residue — a bare `cargo update` shifting a portcullis dependency — is covered by the **nightly full run in this same workflow**, which retries every mutant of all six modules.

## Decision table, tested against real file lists

| change | mutate |
|---|---|
| `dabbad79b` (the 46.2m run) | **false** ← the saving |
| `crates/portcullis/src/*.rs` | true |
| `Cargo.toml` | true |
| `rust-toolchain.toml` | true |
| `.github/workflows/coverage-matrix.yml` | true |
| `Cargo.lock` alone | false (nightly covers it) |
| an unrelated workflow | false |

## Kept deliberately

- **The no-op twin** keeps its side of the condition, so the required context still reports either way — an absent required check is a silent block, not a pass (gatehouse `FINDINGS.md` F-28).
- **llvm-cov keeps the workspace-wide guard.** It measures the whole workspace; `all` is the right trigger for it.

`cargo xtask ci-spec check` → `ok: every invariant holds`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MJ65muwqWqPidSYTnpknDi