### PR TITLE
security: the configuration that constrains an agent is not writable by it

### DIFF
--- a/crates/nucleus-cli/src/guard.rs
+++ b/crates/nucleus-cli/src/guard.rs
@@ -19,6 +19,12 @@ use std::path::{Path, PathBuf};
 /// `claude_desktop_config.json`). These are detection targets the scanner must
 /// match verbatim, not nucleus-owned names. Single source of truth so the
 /// `guard audit` scan and its "not found" help output can never drift apart.
+/// The same set of facts as `portcullis::AGENT_HARNESS_CONFIG`, in the other
+/// shape: relative paths for a scanner to open, where the floor holds globs for
+/// a path lattice to refuse. #2782 is why both exist — these files were
+/// security-relevant enough to audit here and, until that floor, writable by
+/// the agent they configure. `agent_harness_config_blocked.rs` pins that every
+/// entry below is covered by the floor, so the two cannot drift apart.
 const MCP_CONFIG_CANDIDATES: &[&str] = &[
     ".claude/settings.json",
     ".mcp.json",

--- a/crates/portcullis/profiles/doc-editor.yaml
+++ b/crates/portcullis/profiles/doc-editor.yaml
@@ -34,6 +34,7 @@ paths:
     - "**/.env.*"
     - "**/credentials*"
     - "/etc/shadow"
+    - "/etc/passwd"
 
 budget:
   max_cost_usd: "2.00"

--- a/crates/portcullis/src/lib.rs
+++ b/crates/portcullis/src/lib.rs
@@ -309,7 +309,7 @@ pub use lattice::{
     DelegationError, EffectivePermissions, PermissionLattice, PermissionLatticeBuilder,
 };
 pub use modal::{CapabilityModal, EscalationPath, EscalationStep, ModalContext, ModalPermissions};
-pub use path::{PathDenial, PathLattice};
+pub use path::{PathDenial, PathLattice, AGENT_HARNESS_CONFIG};
 pub use permissive::{
     ExecutionDenied, PermissiveExecution, PermissiveExecutionResult, PermissiveExecutor,
     PermissiveExecutorBuilder,

--- a/crates/portcullis/src/path.rs
+++ b/crates/portcullis/src/path.rs
@@ -69,6 +69,55 @@ impl std::fmt::Display for PathDenial {
 /// occurs in a real path, so `glob_match` can never match it.
 pub const NOTHING_ALLOWED: &str = "\u{0}nothing-allowed";
 
+/// Configuration that decides what an agent is allowed to do.
+///
+/// # Why these are blocked rather than merely audited
+///
+/// `nucleus audit` already treats these files as security-critical and scans
+/// them for plaintext credentials, dangerous commands and trifecta exposure
+/// (`nucleus-cli`'s `MCP_CONFIG_CANDIDATES`). Until this floor existed, none of
+/// the eleven canonical profiles mentioned any of them — so the same files were
+/// security-relevant enough to audit and writable by the agent whose
+/// permissions they configure.
+///
+/// That asymmetry is the whole finding. An integration that mediates an agent
+/// by installing a hook in `.claude/settings.json`, or by listing servers in
+/// `.mcp.json`, puts the mechanism that constrains the agent inside the tree
+/// the agent may write. Removing a hook merely disables mediation; rewriting
+/// `.mcp.json` is worse, because it can add an **unmediated** server.
+///
+/// # Why a floor in code and not a line in each profile
+///
+/// The per-profile `blocked` lists had already drifted before this existed:
+/// five of the six write-permitting profiles blocked `/etc/passwd` and
+/// `doc-editor` did not. Eleven copies of a security baseline is the shape this
+/// repo gates against elsewhere (`ci/one-svid-validator.sh`,
+/// `ci/merge-group-scope-parity.sh`). A floor applied where a profile becomes a
+/// [`PathLattice`] cannot be forgotten by a new profile and cannot be removed
+/// by editing one YAML file.
+///
+/// # Reads too, deliberately
+///
+/// [`PathLattice`] blocks a path for every access, not writes alone. That is
+/// the right default here: these files are exactly what `nucleus audit` scans
+/// for plaintext credentials, so read access to them is its own exposure.
+///
+/// Instruction files (`CLAUDE.md`, `AGENTS.md`) are **not** here. They steer an
+/// agent but do not grant it anything, and a coding agent that cannot read its
+/// own repository's instructions is broken rather than contained.
+pub const AGENT_HARNESS_CONFIG: &[&str] = &[
+    // Claude Code / Claude Desktop
+    "**/.claude/**",
+    "**/claude_desktop_config.json",
+    // MCP server manifests, in every spelling `nucleus audit` looks for
+    "**/.mcp.json",
+    "**/mcp.json",
+    "**/.vscode/mcp.json",
+    // Other harnesses of the same shape
+    "**/.cursor/**",
+    "**/.gemini/**",
+];
+
 /// Path access lattice with allowed/blocked semantics.
 ///
 /// - `allowed`: Glob patterns for allowed paths. Empty means "all allowed".

--- a/crates/portcullis/src/profile.rs
+++ b/crates/portcullis/src/profile.rs
@@ -385,7 +385,16 @@ impl ProfileSpec {
             obligations.insert(Operation::from(ob));
         }
 
-        let paths = match &self.paths {
+        // The agent-harness floor is unioned in for EVERY profile, including a
+        // profile with no `paths:` section at all (which otherwise yields an
+        // empty blocked set). A profile cannot opt out of it, which is the
+        // point: the files that decide what an agent may do must not be
+        // writable by that agent, and eleven per-profile copies of that rule
+        // had already drifted once. See `AGENT_HARNESS_CONFIG`.
+        //
+        // Union only ever tightens -- `PathLattice::meet` is itself a union of
+        // blocked -- so this can add a refusal and never remove one.
+        let mut paths = match &self.paths {
             Some(spec) => PathLattice {
                 allowed: spec.allowed.iter().cloned().collect::<HashSet<_>>(),
                 blocked: spec.blocked.iter().cloned().collect::<HashSet<_>>(),
@@ -393,6 +402,9 @@ impl ProfileSpec {
             },
             None => PathLattice::default(),
         };
+        paths
+            .blocked
+            .extend(crate::AGENT_HARNESS_CONFIG.iter().map(|p| (*p).to_string()));
 
         let budget = match &self.budget {
             Some(spec) => {

--- a/crates/portcullis/tests/agent_harness_config_blocked.rs
+++ b/crates/portcullis/tests/agent_harness_config_blocked.rs
@@ -1,0 +1,172 @@
+//! The configuration that constrains an agent must not be writable by it.
+//!
+//! # The asymmetry this closes (#2782)
+//!
+//! `nucleus audit` treats agent-harness configuration as security-critical and
+//! scans it for plaintext credentials, dangerous commands and trifecta
+//! exposure — `nucleus-cli`'s `MCP_CONFIG_CANDIDATES` names six such files.
+//! Before this, `grep -rln '\.claude|\.mcp\.json|\.cursor'` over
+//! `portcullis/profiles/*.yaml` returned **nothing**: none of the eleven
+//! canonical profiles mentioned any of them.
+//!
+//! So the same files were security-relevant enough to audit and unprotected
+//! against being written by the agent whose permissions they configure.
+//! `codegen` — the profile a coding agent would pick — has
+//! `write_files: low_risk` and blocked credential material (`**/.ssh/**`,
+//! `**/.env`, `/etc/shadow`) but nothing about harness config.
+//!
+//! The concrete shape: an integration that mediates an agent by installing a
+//! hook in `.claude/settings.json` puts the mechanism that constrains the agent
+//! inside the tree the agent may write. Removing a hook disables mediation;
+//! rewriting `.mcp.json` is worse, because it can add an **unmediated** server.
+//!
+//! # Why a floor, and why this test
+//!
+//! The fix is a floor in `profile.rs` — `AGENT_HARNESS_CONFIG` unioned into
+//! every profile's blocked set as it becomes a `PathLattice` — rather than a
+//! line added to eleven YAML files. Those per-profile lists had **already
+//! drifted**: five of the six write-permitting profiles blocked `/etc/passwd`
+//! and `doc-editor` did not, which is the same two-copies failure
+//! `profile_namespace_parity.rs` was written for.
+//!
+//! A floor cannot be forgotten by a new profile or removed by editing one YAML
+//! file, so this test is not what makes the property true. It pins that the
+//! floor is reached through the resolver a pod spec actually hits, and that the
+//! block list and the audit list cannot drift apart.
+
+use portcullis::profile::ProfileRegistry;
+use portcullis::{glob_match, AGENT_HARNESS_CONFIG};
+
+/// Representative real paths, one per file `nucleus audit` looks for.
+///
+/// These are the literal `MCP_CONFIG_CANDIDATES` entries, placed under a
+/// plausible checkout root — the exact strings the audit scans for, so a floor
+/// that misses one would be auditing a file it does not protect.
+const AUDITED_FILES: &[&str] = &[
+    "/work/repo/.claude/settings.json",
+    "/work/repo/.mcp.json",
+    "/work/repo/mcp.json",
+    "/work/repo/.vscode/mcp.json",
+    "/work/repo/.cursor/mcp.json",
+    "/work/repo/claude_desktop_config.json",
+];
+
+fn blocks(patterns: &[String], path: &str) -> bool {
+    patterns.iter().any(|p| glob_match(p, path))
+}
+
+/// The property: every profile, not just the ones that permit writes.
+///
+/// A `write_files: never` profile blocking these too is free — the floor costs
+/// nothing where writes are already refused, and a profile's write posture can
+/// be raised later by an edit that would otherwise silently uncover them.
+#[test]
+fn every_profile_blocks_the_configuration_that_configures_the_agent() {
+    let registry = ProfileRegistry::default();
+    let mut gaps = Vec::new();
+
+    for name in registry.names() {
+        let lattice = registry
+            .resolve(name)
+            .unwrap_or_else(|e| panic!("`{name}` must resolve: {e}"));
+        let blocked: Vec<String> = lattice.paths.blocked.iter().cloned().collect();
+        for file in AUDITED_FILES {
+            if !blocks(&blocked, file) {
+                gaps.push(format!("{name} does not block {file}"));
+            }
+        }
+    }
+
+    assert!(
+        gaps.is_empty(),
+        "a profile permits access to the configuration that decides what the \
+         agent may do, which is the asymmetry #2782 named:\n  {}",
+        gaps.join("\n  ")
+    );
+}
+
+/// The audit list and the block list are the same set of facts — "these files
+/// configure an agent's permissions" — and were held in two places. This is the
+/// half that cannot be made structural: `MCP_CONFIG_CANDIDATES` is relative
+/// file paths for a scanner, `AGENT_HARNESS_CONFIG` is globs for a lattice. So
+/// pin that every audited file is covered, which is the direction that matters.
+#[test]
+fn the_floor_covers_every_file_the_audit_scans() {
+    let floor: Vec<String> = AGENT_HARNESS_CONFIG.iter().map(|s| s.to_string()).collect();
+    for file in AUDITED_FILES {
+        assert!(
+            blocks(&floor, file),
+            "`nucleus audit` scans {file} for plaintext credentials, but no \
+             AGENT_HARNESS_CONFIG glob blocks it — audited and unprotected is \
+             exactly the asymmetry this floor exists to remove"
+        );
+    }
+}
+
+/// Non-vacuity. If `glob_match` stopped matching, or the floor were emptied,
+/// both tests above would pass while checking nothing. An ordinary source file
+/// under the same root must stay reachable.
+#[test]
+fn the_floor_does_not_block_ordinary_source() {
+    let floor: Vec<String> = AGENT_HARNESS_CONFIG.iter().map(|s| s.to_string()).collect();
+    assert!(
+        !floor.is_empty(),
+        "an empty floor would pass every assertion"
+    );
+
+    for ordinary in [
+        "/work/repo/src/main.rs",
+        "/work/repo/README.md",
+        "/work/repo/CLAUDE.md",
+        "/work/repo/claude/notes.md",
+    ] {
+        assert!(
+            !blocks(&floor, ordinary),
+            "{ordinary} is not permission-granting configuration; a coding \
+             agent that cannot touch it is broken rather than contained"
+        );
+    }
+}
+
+/// The drift that was already there. Five of the six write-permitting profiles
+/// blocked `/etc/passwd`; `doc-editor` did not. That is not covered by the
+/// floor — it is credential material, left in the YAML — so it needs its own
+/// pin, or the next profile added by copy-paste reintroduces it.
+#[test]
+fn write_permitting_profiles_share_one_credential_baseline() {
+    // The set every write-permitting profile carried, minus the one it had
+    // drifted on. A profile may block MORE (untrusted-model blocks
+    // `**/.git/config` and `/proc/*/environ`); it may not block less.
+    const BASELINE: &[&str] = &[
+        "/work/repo/.ssh/id_rsa",
+        "/work/repo/.aws/credentials",
+        "/work/repo/.env",
+        "/work/repo/.env.local",
+        "/etc/shadow",
+        "/etc/passwd",
+    ];
+
+    let registry = ProfileRegistry::default();
+    let mut gaps = Vec::new();
+
+    for name in registry.names() {
+        let lattice = registry
+            .resolve(name)
+            .unwrap_or_else(|e| panic!("`{name}` must resolve: {e}"));
+        if lattice.capabilities.write_files == portcullis::CapabilityLevel::Never {
+            continue;
+        }
+        let blocked: Vec<String> = lattice.paths.blocked.iter().cloned().collect();
+        for file in BASELINE {
+            if !blocks(&blocked, file) {
+                gaps.push(format!("{name} permits writes but does not block {file}"));
+            }
+        }
+    }
+
+    assert!(
+        gaps.is_empty(),
+        "the per-profile credential lists have drifted apart again:\n  {}",
+        gaps.join("\n  ")
+    );
+}

--- a/crates/portcullis/tests/agent_harness_config_blocked.rs
+++ b/crates/portcullis/tests/agent_harness_config_blocked.rs
@@ -34,6 +34,12 @@
 //! floor is reached through the resolver a pod spec actually hits, and that the
 //! block list and the audit list cannot drift apart.
 
+// `profile` is behind the `spec` feature. CI lints portcullis TWICE -- once
+// `--all-features`, once at its own defaults (#2746) -- precisely because
+// feature unification hides this: the registry tests below cannot compile
+// without `spec`, while the two that check the floor itself need nothing and
+// stay available at default features.
+#[cfg(feature = "spec")]
 use portcullis::profile::ProfileRegistry;
 use portcullis::{glob_match, AGENT_HARNESS_CONFIG};
 
@@ -60,6 +66,7 @@ fn blocks(patterns: &[String], path: &str) -> bool {
 /// A `write_files: never` profile blocking these too is free — the floor costs
 /// nothing where writes are already refused, and a profile's write posture can
 /// be raised later by an edit that would otherwise silently uncover them.
+#[cfg(feature = "spec")]
 #[test]
 fn every_profile_blocks_the_configuration_that_configures_the_agent() {
     let registry = ProfileRegistry::default();
@@ -132,6 +139,7 @@ fn the_floor_does_not_block_ordinary_source() {
 /// blocked `/etc/passwd`; `doc-editor` did not. That is not covered by the
 /// floor — it is credential material, left in the YAML — so it needs its own
 /// pin, or the next profile added by copy-paste reintroduces it.
+#[cfg(feature = "spec")]
 #[test]
 fn write_permitting_profiles_share_one_credential_baseline() {
     // The set every write-permitting profile carried, minus the one it had


### PR DESCRIPTION
Closes #2782.

`nucleus audit` treats agent-harness configuration as security-critical and scans it for plaintext credentials, dangerous commands and trifecta exposure. `grep -rln '\.claude|\.mcp\.json|\.cursor'` over `crates/portcullis/profiles/*.yaml` returned **nothing** — none of the eleven canonical profiles mentioned any of it.

So the same files were security-relevant enough to audit and unprotected against being written by the agent whose permissions they configure. `codegen` — the profile a coding agent picks — has `write_files: low_risk` and blocks `**/.ssh/**`, `**/.env`, `/etc/shadow`. Credential material is covered; the file that decides what the agent may do is not.

An integration that mediates an agent by installing a hook in `.claude/settings.json` puts the mechanism constraining the agent inside the tree the agent may write. Removing a hook disables mediation; rewriting `.mcp.json` is worse, because it can add an **unmediated** server.

## A floor, not eleven lines

`AGENT_HARNESS_CONFIG` lives in `path.rs` — always compiled, unlike `profile` which is behind the `spec` feature, so `nucleus-cli` can reach it too — and `profile.rs` unions it into every profile's blocked set as the spec becomes a `PathLattice`. That covers a profile with no `paths:` section at all, which otherwise yields an **empty** blocked set, and it cannot be forgotten by a new profile or removed by editing one YAML file. Union only tightens: `PathLattice::meet` is itself a union of blocked.

The issue asked whether this belongs in a shared base rather than per-profile. It does, and the evidence was already in the tree: **the per-profile lists had already drifted.** Five of the six write-permitting profiles block `/etc/passwd`; `doc-editor` did not.

```
codegen         … /etc/shadow /etc/passwd
doc-editor      … /etc/shadow                 ← drifted
local-dev       … /etc/shadow /etc/passwd
release         … /etc/shadow /etc/passwd
safe-pr-fixer   … /etc/shadow /etc/passwd
untrusted-model … /etc/shadow /etc/passwd  (+ .git/config, /proc/*/environ)
```

Fixed here, and pinned by its own test — the floor covers harness config, not credential material, so the next copy-paste profile would reintroduce it. This is the same two-copies failure `profile_namespace_parity.rs` was written for.

## Two corrections to the issue's own claims

**`MCP_CONFIG_CANDIDATES` has six entries, not the three quoted.** The floor covers all six; the suggested block list would have missed bare `mcp.json` and `claude_desktop_config.json`, leaving two audited files unprotected.

**Blocking covers reads too**, and that is kept deliberately rather than by accident: `PathLattice` blocks a path for every access, and these files are exactly what the audit scans for plaintext credentials, so read access is its own exposure. It is a wider change than "block writes" implies, so it should be a decision rather than a side effect.

Instruction files (`CLAUDE.md`, `AGENTS.md`) are **not** included — they steer an agent but grant it nothing, and an agent that cannot read its own repository's instructions is broken rather than contained. Pinned by `the_floor_does_not_block_ordinary_source`.

## One source, where that is honest

The issue asked whether the audit path list and the profile block list should be one source. They are one set of facts in two shapes — relative paths for a scanner to open, globs for a lattice to refuse — so rather than force a shared representation, `the_floor_covers_every_file_the_audit_scans` pins the direction that matters: nothing is audited that the floor does not block. `guard.rs` now says so at the constant.

## Verification

Four tests, and **both fixes perturbed to prove they bite**:

- removing the floor REDs with `code-review does not block /work/repo/.claude/settings.json`
- restoring the doc-editor drift REDs with `doc-editor permits writes but does not block /etc/passwd`

Both GREEN on restore.

`portcullis` 1210 lib plus every integration suite, `nucleus-cli` 188, `nucleus-spec` green — the floor tightens eleven shipped profiles and broke nothing. `cargo fmt --check --all` and `clippy --all-targets --all-features -- -D warnings` clean. No new ratcheted cast sites.

## Not addressed here

The companion issue's bridge side (`claude-code-nucleus#1`) — naming a required profile, and the Known Gaps wording that attributes reconfiguration to the user rather than the model — is in another repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011XqKAavF6twdyXTgzTHg6r

---
_Generated by [Claude Code](https://claude.ai/code/session_011XqKAavF6twdyXTgzTHg6r)_