### PR TITLE
security: a writable rootfs is the shared artifact, so isolation is the default

### DIFF
--- a/crates/nucleus-cli/src/verify.rs
+++ b/crates/nucleus-cli/src/verify.rs
@@ -392,6 +392,14 @@ struct CreatePodResponse {
 async fn create_pod(admission: &AdmissionMaterial) -> Result<Pod> {
     let issuer = &admission.issuer_hex;
     let creds = &admission.credentials;
+    // `read_only: true` (#2784). This pod boots from the SHARED installed
+    // artifact, and a writable rootfs is hard-linked into the jail rather than
+    // copied — so `verify --tier2` was writing through to the very artifact
+    // whose digest `nucleus setup` pinned and `verify-attestation` compares
+    // against `--expect-rootfs`. The reporter measured it: the installed rootfs
+    // went from `7739f5cd…` to `b7c40744…` across tier-2 runs. Read-only boots
+    // since #2379 put the SVID on tmpfs, so verifying the node no longer
+    // invalidates the thing being verified.
     let body = format!(
         r#"{{"apiVersion":"nucleus/v1","kind":"Pod",
             "metadata":{{"name":"nucleus-verify",
@@ -402,7 +410,7 @@ async fn create_pod(admission: &AdmissionMaterial) -> Result<Pod> {
               "policy":{{"type":"profile","name":"codegen"}},
               "image":{{"kernel_path":"{HOST_ARTIFACTS_DIR}/vmlinux",
                         "rootfs_path":"{HOST_ARTIFACTS_DIR}/rootfs.ext4",
-                        "read_only":false}},
+                        "read_only":true}},
               "vsock":{{"guest_cid":3,"port":5005}}}}}}"#
     );
 

--- a/crates/nucleus-node/src/firecracker_config.rs
+++ b/crates/nucleus-node/src/firecracker_config.rs
@@ -203,7 +203,17 @@ pub(crate) fn jail_resources(image: &nucleus_spec::ImageSpec, spec: &PodSpec) ->
             in_jail: in_jail::ROOTFS,
             // Mirrors `lower_drives`' `is_read_only: image.read_only` exactly. If
             // these two ever disagree, a writable rootfs gets copied and the
-            // guest's writes vanish — hence the `rw_rootfs_is_hard_link_only` pin.
+            // guest's writes vanish — hence the `rw_rootfs_is_hard_link_only`
+            // pin, which until #2784 was named here and never written.
+            //
+            // The agreement is necessary and NOT sufficient. A hard link means
+            // the guest writes through to `image.rootfs_path` itself, so
+            // `read_only: false` against the shared installed artifact gives
+            // every later pod the previous pod's writes and lets concurrent
+            // pods share one writable block device. That is why
+            // `ImageSpec::read_only` now defaults to TRUE: the placement below
+            // is correct for a private image and unsafe for a shared one, and
+            // nothing here can tell which it was handed.
             placement: if image.read_only {
                 Placement::CopyableIfCrossDevice
             } else {
@@ -1016,6 +1026,63 @@ mod tests {
     fn base_spec() -> PodSpec {
         serde_json::from_str(r#"{"apiVersion":"nucleus/v1","kind":"Pod","spec":{}}"#)
             .expect("base PodSpec must deserialize")
+    }
+
+    /// The pin `jail_resources` has named since it was written, and which
+    /// #2784 found did not exist: `grep -rn rw_rootfs_is_hard_link_only`
+    /// returned exactly one hit, the comment claiming it.
+    ///
+    /// A writable rootfs MUST be hard-linked. Copying it would put the guest's
+    /// writes in a jail-local copy that is discarded when the jail is torn
+    /// down — the writes would vanish silently, which is worse than refusing.
+    /// A read-only rootfs may be copied, because nothing writes through it.
+    #[test]
+    fn rw_rootfs_is_hard_link_only() {
+        let rw = jail_resources(&image(false, false), &base_spec());
+        let rootfs = rw
+            .iter()
+            .find(|r| r.in_jail == in_jail::ROOTFS)
+            .expect("a rootfs resource must be jailed");
+        assert_eq!(
+            rootfs.placement,
+            Placement::HardLinkOnly,
+            "a writable rootfs that gets copied loses every guest write when the \
+             jail is torn down"
+        );
+
+        let ro = jail_resources(&image(true, false), &base_spec());
+        let rootfs = ro
+            .iter()
+            .find(|r| r.in_jail == in_jail::ROOTFS)
+            .expect("a rootfs resource must be jailed");
+        assert_eq!(
+            rootfs.placement,
+            Placement::CopyableIfCrossDevice,
+            "a read-only rootfs is safe to copy, and copying is what lets the \
+             artifact live on a different device from the jail"
+        );
+    }
+
+    /// The consequence the placement above cannot avoid, stated so it is not
+    /// rediscovered: a hard link is the SAME FILE. `read_only: false` therefore
+    /// means the guest writes through to the artifact every other pod boots
+    /// from. Measured in #2784 — the installed rootfs digest changed from
+    /// `7739f5cd…` to `b7c40744…` after `verify --tier2` pod boots, and the
+    /// jail entry shared the artifact's inode with `links=2`.
+    #[test]
+    fn a_writable_rootfs_is_the_artifact_itself_not_a_copy() {
+        let rw = jail_resources(&image(false, false), &base_spec());
+        let rootfs = rw
+            .iter()
+            .find(|r| r.in_jail == in_jail::ROOTFS)
+            .expect("a rootfs resource must be jailed");
+        assert_eq!(
+            rootfs.host_source,
+            PathBuf::from("/var/lib/nucleus/rootfs.ext4"),
+            "the jail entry links the shared artifact, so a writable rootfs is \
+             shared mutable state between pods — the reason the spec default is \
+             now read_only: true"
+        );
     }
 
     fn image(read_only: bool, scratch: bool) -> ImageSpec {

--- a/crates/nucleus-spec/src/lib.rs
+++ b/crates/nucleus-spec/src/lib.rs
@@ -404,6 +404,11 @@ impl NetworkSpec {
     }
 }
 
+/// Rootfs isolation is the default; see [`ImageSpec::read_only`] for why (#2784).
+fn default_read_only() -> bool {
+    true
+}
+
 /// VM image configuration for Firecracker pods.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -416,7 +421,21 @@ pub struct ImageSpec {
     #[serde(default)]
     pub boot_args: Option<String>,
     /// Whether the root filesystem should be mounted read-only.
-    #[serde(default)]
+    ///
+    /// **Defaults to `true`, and the default is load-bearing** (#2784). A
+    /// writable rootfs is hard-linked into the jail rather than copied — it has
+    /// to be, or the guest's writes would go nowhere — so `read_only: false`
+    /// against the shared installed artifact makes that one file mutable state
+    /// behind every pod booted from it: one pod's writes are visible to the
+    /// next, concurrent pods share a writable block device, and the launch
+    /// measurement `verify-attestation` compares against `--expect-rootfs`
+    /// changes underneath the attestation reporting it.
+    ///
+    /// `#[serde(default)]` on a `bool` is `false`, so a spec that simply omitted
+    /// this field got the unsafe value. Omission now means isolation; a caller
+    /// that genuinely wants a writable rootfs must say so, and should give the
+    /// pod a private image or a `scratch_path`.
+    #[serde(default = "default_read_only")]
     pub read_only: bool,
     /// Optional scratch disk image for writable storage.
     #[serde(default)]
@@ -1974,5 +1993,35 @@ spec:
              them is silently ignored:\n  {}",
             offenders.join("\n  ")
         );
+    }
+
+    /// #2784: `#[serde(default)]` on a `bool` is `false`, so a spec that simply
+    /// omitted `read_only` got a WRITABLE rootfs — which is hard-linked into
+    /// the jail, so the guest writes through to the shared installed artifact.
+    /// Omission must mean isolation.
+    #[test]
+    fn an_image_that_omits_read_only_is_read_only() {
+        let spec: ImageSpec = serde_json::from_str(
+            r#"{"kernel_path":"/var/lib/nucleus/vmlinux",
+                "rootfs_path":"/var/lib/nucleus/rootfs.ext4"}"#,
+        )
+        .expect("an image with only its two required paths must deserialize");
+
+        assert!(
+            spec.read_only,
+            "an omitted read_only used to mean `false`, which hard-links the \
+             shared rootfs artifact into the jail and lets one pod's writes \
+             reach the next"
+        );
+    }
+
+    /// The escape hatch still works: a caller that genuinely wants a writable
+    /// rootfs says so, and gets it. The default is a default, not a ban.
+    #[test]
+    fn a_writable_rootfs_can_still_be_asked_for_explicitly() {
+        let spec: ImageSpec =
+            serde_json::from_str(r#"{"kernel_path":"/k","rootfs_path":"/r","read_only":false}"#)
+                .expect("an explicit read_only must deserialize");
+        assert!(!spec.read_only);
     }
 }


### PR DESCRIPTION
Closes #2784.

A pod with `image.read_only: false` writes through to the **shared** rootfs artifact, because the jail entry is a hard link rather than a copy. The reporter measured it:

```
pristine local build (installed, digest matched)   7739f5cd9d83c3ff4c5cc1dfd79c863d…
same file in the VM now, after pod boots           b7c40744a7ed36251f517fc7a7af2c6e…

262290 links=2 /var/lib/nucleus/artifacts/rootfs.ext4
262290 links=2 /srv/jailer/firecracker/<pod-id>/root/rootfs.ext4
```

Four consequences, all live: pod A's writes are visible to pod B; concurrent pods share one writable block device (a 15-pod scaling run did exactly this); `verify-attestation` compares the launch measurement against `--expect-rootfs` allow-lists that go stale after the first boot; and the sha256 `nucleus setup` pinned at install no longer holds.

## The placement is not the bug

Hard-linking a writable rootfs is correct and stays. Copying it would put the guest's writes in a jail-local copy discarded at teardown — they would vanish **silently**, which is worse than refusing. What was missing is anything tying `read_only: false` to a *private* image, so the natural configuration — one installed artifact, many pods — makes that file mutable shared state.

## The default was fail-open

`ImageSpec::read_only` was `#[serde(default)]` on a `bool`, which is `false`. **A spec that simply omitted the field got the unsafe value.** It now defaults to `true`.

Checked before flipping: no YAML or JSON spec in the repo omits the field, and every Rust `ImageSpec` construction sets it explicitly. The default only ever bit externally-authored specs — precisely the case the report describes — so this is low risk in-tree and high value outside it.

**`verify --tier2` passed `false` explicitly**, so the default would not have saved it — and it is the thing that mutated the reporter's artifact. It now asks for `true`. Read-only boots since #2379 put the SVID on tmpfs, so verifying the node no longer invalidates the thing being verified.

## The pin the comment promised did not exist

`jail_resources` cites `rw_rootfs_is_hard_link_only` as what keeps the placement and `is_read_only` in agreement.

```
$ grep -rn rw_rootfs_is_hard_link_only --include=*.rs crates/
crates/nucleus-node/src/firecracker_config.rs:206:  … hence the `rw_rootfs_is_hard_link_only` pin.
```

One hit — the comment claiming it. A reader was told a guard existed where none did, and the invariant it named is exactly the one whose consequences are above.

It is written now, in both directions, plus a second test stating the consequence the placement cannot avoid so it is not rediscovered. The comment also now says what the agreement does **not** cover: it is necessary and not sufficient, because nothing at that point can tell a private image from a shared one.

## Verification

All three changes perturbed to prove their tests bite:

- copying a writable rootfs REDs `rw_rootfs_is_hard_link_only` — *"a writable rootfs that gets copied loses every guest write when the jail is torn down"*
- restoring `#[serde(default)]` REDs `an_image_that_omits_read_only_is_read_only`

Both GREEN on restore. `nucleus-spec` 67, `nucleus-node` and `nucleus-cli` suites green; `cargo fmt --check --all` and `clippy --all-targets --all-features -- -D warnings` clean. The only casts in the touched files are pre-existing, so the clippy ratchet cannot move.

## Not done here

Two of the issue's suggestions are deliberately left, because each is a larger change than this one:

- **Refusing `read_only: false` when another live pod holds the same path.** The node knows both, but this is runtime-state validation rather than spec defaulting.
- **Per-pod copy-on-write**, so `read_only: false` means "writable, privately" rather than "writable, shared". `scratch_path` is already `HardLinkOnly` and is the intended shape for it.

Happy to take either as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011XqKAavF6twdyXTgzTHg6r

---
_Generated by [Claude Code](https://claude.ai/code/session_011XqKAavF6twdyXTgzTHg6r)_