### PR TITLE
fix: three commands on the first Tier-2 walk reported a cause that was not true

### DIFF
--- a/crates/nucleus-cli/src/start.rs
+++ b/crates/nucleus-cli/src/start.rs
@@ -4,6 +4,7 @@
 
 use anyhow::{Context, Result, bail};
 use clap::Args;
+use std::net::{SocketAddr, TcpStream};
 use std::process::Command;
 use std::thread;
 use std::time::Duration;
@@ -239,45 +240,91 @@ fn start_nucleus_node_service(vm_name: &str) -> Result<()> {
     Ok(())
 }
 
+/// The node's address, and the health route on it.
+///
+/// The node's HTTP listener requires mTLS unconditionally -- there is no
+/// plaintext mode left to default to (`nucleus node --help`, `--url`). A plain
+/// `GET /health` is therefore not a health check of it; it is a corrupt TLS
+/// record. This probe used to send one every 500 ms for 60 s, the node logged
+/// an `InvalidContentType` handshake failure for each, and the command then
+/// reported the *node* unhealthy and pointed the user at those 120 lines
+/// (#2788). The route is `/v1/health`, not `/health`.
+const NODE_ADDR: &str = "127.0.0.1:8080";
+const HEALTH_URL: &str = "https://127.0.0.1:8080/v1/health";
+
+/// How the probe talks to the node.
+enum Probe {
+    /// A real `GET /v1/health` over mTLS, presenting the identity
+    /// `nucleus setup` provisioned. Proves the node is *serving*.
+    Mtls(Box<reqwest::blocking::Client>),
+    /// No provisioned CLI identity to present, so the strongest honest signal
+    /// left is that the listener accepts a connection. Weaker, but it can
+    /// never report a healthy node unhealthy because of something on this
+    /// side -- which is the failure this probe is being fixed for.
+    Listening,
+}
+
+impl Probe {
+    /// `Ok(true)` when the node answered, `Ok(false)` when it is not ready
+    /// yet. Failures of the probe's own making are not the node's verdict.
+    fn poll(&self) -> Result<bool, String> {
+        match self {
+            Probe::Mtls(client) => match client.get(HEALTH_URL).send() {
+                Ok(response) if response.status().is_success() => Ok(true),
+                Ok(response) => Err(format!("status {}", response.status().as_u16())),
+                Err(_) => Ok(false),
+            },
+            Probe::Listening => {
+                let addr: SocketAddr = NODE_ADDR
+                    .parse()
+                    .expect("NODE_ADDR is a literal socket address");
+                Ok(TcpStream::connect_timeout(&addr, Duration::from_secs(2)).is_ok())
+            }
+        }
+    }
+}
+
 fn wait_for_health_check(args: &StartArgs) -> Result<()> {
     println!("Waiting for nucleus-node to be ready...");
 
-    let endpoint = "http://127.0.0.1:8080/health";
+    let probe = match crate::provision::mtls_blocking_client_from_provisioned_identity() {
+        Ok(client) => Probe::Mtls(Box::new(client)),
+        Err(_) => {
+            println!(
+                "  (no provisioned CLI identity found -- checking that the node's\n   \
+                 listener is accepting connections. For an authenticated check,\n   \
+                 run `nucleus setup`, then `nucleus node health`.)"
+            );
+            Probe::Listening
+        }
+    };
+
     let timeout = Duration::from_secs(u64::from(args.timeout));
     let start = std::time::Instant::now();
     let poll_interval = Duration::from_millis(500);
 
-    // Create agent with timeout
-    let config = ureq::Agent::config_builder()
-        .timeout_global(Some(Duration::from_secs(2)))
-        .build();
-    let agent: ureq::Agent = config.into();
-
     loop {
         if start.elapsed() > timeout {
             bail!(
-                "Health check timed out after {} seconds. Check: limactl shell {} -- journalctl -u nucleus-node",
+                "nucleus-node did not become ready within {} seconds.\n  \
+                 Check the node: limactl shell {} -- journalctl -u nucleus-node\n  \
+                 Check it directly: nucleus node health",
                 args.timeout,
                 args.vm_name
             );
         }
 
-        match agent.get(endpoint).call() {
-            Ok(response) if response.status().as_u16() == 200 => {
+        match probe.poll() {
+            Ok(true) => {
                 println!("\nnucleus-node is ready!");
                 return Ok(());
             }
-            Ok(response) => {
-                // Non-200 response, keep waiting
-                eprintln!(
-                    "  Health check returned status {}, retrying...",
-                    response.status().as_u16()
-                );
-            }
-            Err(_) => {
-                // Connection failed, keep waiting
+            Ok(false) => {
                 print!(".");
                 std::io::Write::flush(&mut std::io::stdout()).ok();
+            }
+            Err(detail) => {
+                eprintln!("  Health check returned {detail}, retrying...");
             }
         }
 
@@ -285,24 +332,36 @@ fn wait_for_health_check(args: &StartArgs) -> Result<()> {
     }
 }
 
+/// The banner printed on success.
+///
+/// Built as a string so it can be asserted on: every line here used to name
+/// something a user could not reach -- `http://` on an mTLS-only listener, a
+/// metrics port nothing in `nucleus-node` binds, and a `curl` that could only
+/// ever produce the same handshake failure the health probe did (#2788).
+fn success_message() -> String {
+    let mut out = String::new();
+    out.push_str("\nNucleus is running!\n");
+    out.push_str("===================\n\n");
+    out.push_str("Endpoints:\n");
+    out.push_str(&format!(
+        "  HTTP API: https://{NODE_ADDR}  (mTLS -- a client certificate is required)\n"
+    ));
+    out.push_str("  gRPC:     https://127.0.0.1:9180\n\n");
+    out.push_str("Commands:\n");
+    out.push_str("  nucleus run \"Your task here\"    # Run a task\n");
+    out.push_str("  nucleus node health             # Ask the node how it is\n");
+    out.push_str("  nucleus node pods               # List pods\n");
+    out.push_str("  nucleus stop                    # Stop nucleus\n");
+    out.push_str("  nucleus doctor                  # Check status\n\n");
+    out.push_str("API Example:\n");
+    out.push_str(
+        "  nucleus node health             # a raw curl needs the provisioned client cert\n\n",
+    );
+    out
+}
+
 fn print_success_message() {
-    println!();
-    println!("Nucleus is running!");
-    println!("===================");
-    println!();
-    println!("Endpoints:");
-    println!("  HTTP API: http://127.0.0.1:8080");
-    println!("  Metrics:  http://127.0.0.1:9080");
-    println!("  gRPC:     http://127.0.0.1:9180");
-    println!();
-    println!("Commands:");
-    println!("  nucleus run \"Your task here\"    # Run a task");
-    println!("  nucleus stop                    # Stop nucleus");
-    println!("  nucleus doctor                  # Check status");
-    println!();
-    println!("API Example:");
-    println!("  curl http://127.0.0.1:8080/v1/pods");
-    println!();
+    print!("{}", success_message());
 }
 
 #[cfg(test)]
@@ -320,5 +379,47 @@ mod tests {
         assert_eq!(args.vm_name, "nucleus");
         assert!(!args.no_wait);
         assert!(args.auto_start_vm);
+    }
+
+    /// The probe must speak the protocol the node speaks. It sent plaintext
+    /// `GET /health` to an mTLS-only listener, so it timed out on every
+    /// healthy node (#2788).
+    #[test]
+    fn the_health_probe_addresses_the_listener_the_node_actually_has() {
+        assert!(
+            HEALTH_URL.starts_with("https://"),
+            "the node's listener requires mTLS; a plaintext probe is a corrupt \
+             TLS record, not a health check: {HEALTH_URL}"
+        );
+        assert!(
+            HEALTH_URL.ends_with("/v1/health"),
+            "the health route is /v1/health, not /health: {HEALTH_URL}"
+        );
+        assert!(
+            NODE_ADDR.parse::<SocketAddr>().is_ok(),
+            "the listening probe parses this as a socket address: {NODE_ADDR}"
+        );
+    }
+
+    /// Every endpoint the banner names must be one a user can reach.
+    #[test]
+    fn the_banner_advertises_nothing_unreachable() {
+        let banner = success_message();
+        assert!(
+            !banner.contains("http://"),
+            "no plaintext endpoint is served; banner was:\n{banner}"
+        );
+        assert!(
+            !banner.contains("9080"),
+            "nothing in nucleus-node binds 9080; banner was:\n{banner}"
+        );
+        assert!(
+            !banner.contains("curl http"),
+            "a bare curl cannot complete the mTLS handshake; banner was:\n{banner}"
+        );
+        assert!(
+            banner.contains("nucleus node health"),
+            "the banner should name a command that works; banner was:\n{banner}"
+        );
     }
 }

--- a/crates/nucleus-tool-proxy/src/main.rs
+++ b/crates/nucleus-tool-proxy/src/main.rs
@@ -3608,13 +3608,14 @@ async fn glob_search(
         .map_err(|e| ApiError::Spec(format!("sandbox root not accessible: {e}")))?;
 
     let search_root = if let Some(ref dir) = req.directory {
-        // Reject absolute paths immediately
-        if Path::new(dir).is_absolute() {
-            return Err(ApiError::Nucleus(NucleusError::SandboxEscape {
-                path: PathBuf::from(dir),
-            }));
-        }
-        let resolved = sandbox_root.join(dir);
+        // An absolute directory under the root names the same directory as its
+        // relative spelling; one outside it is still an escape (#2787).
+        let dir = state
+            .runtime
+            .sandbox()
+            .root_relative(Path::new(dir))
+            .map_err(ApiError::Nucleus)?;
+        let resolved = sandbox_root.join(&dir);
         // Canonicalize to resolve symlinks and .. components (path must exist)
         let canonical = resolved.canonicalize().map_err(|_| {
             ApiError::Nucleus(NucleusError::SandboxEscape {
@@ -3780,14 +3781,15 @@ async fn grep_search(
 
     // Collect files to search
     let files: Vec<std::path::PathBuf> = if let Some(ref path) = req.path {
-        // Reject absolute paths immediately
-        if Path::new(path).is_absolute() {
-            return Err(ApiError::Nucleus(NucleusError::SandboxEscape {
-                path: PathBuf::from(path),
-            }));
-        }
+        // An absolute path under the root names the same file as its relative
+        // spelling; one outside it is still an escape (#2787).
+        let path = state
+            .runtime
+            .sandbox()
+            .root_relative(Path::new(path))
+            .map_err(ApiError::Nucleus)?;
         // Search single file
-        let full_path = sandbox_root.join(path);
+        let full_path = sandbox_root.join(&path);
         // Canonicalize to verify we're within sandbox (handles symlinks and ..)
         let canonical = full_path.canonicalize().map_err(|_| {
             ApiError::Nucleus(NucleusError::SandboxEscape {

--- a/crates/nucleus-tool-proxy/src/mcp.rs
+++ b/crates/nucleus-tool-proxy/src/mcp.rs
@@ -1425,10 +1425,16 @@ mod tests {
     }
 
     #[test]
-    fn build_term_grep_search_maps_to_glob() {
-        // GrepSearch maps to GlobSearch PrimitiveAction (same file-pattern semantic)
+    fn build_term_grep_search_stays_grep_search() {
+        // This asserted `GlobSearch`, on the reasoning that grep and glob share
+        // a file-pattern semantic. They do not share an AUTHORITY: the profiles
+        // grant `grep_search` and `glob_search` separately, and
+        // `WithinDelegationCeiling` compares a term's own operation against the
+        // one its authority names. Lowering grep to a glob primitive made those
+        // two disagree for every grep, so grep was denied under `codegen`, which
+        // grants `grep_search: always` (#2790).
         let term = build_action_term(Operation::GrepSearch, "TODO");
-        assert_eq!(term.operation(), Operation::GlobSearch);
+        assert_eq!(term.operation(), Operation::GrepSearch);
     }
 
     #[test]
@@ -1444,9 +1450,13 @@ mod tests {
     }
 
     #[test]
-    fn build_term_manage_pods() {
+    fn build_term_manage_pods_stays_manage_pods() {
+        // Same collapse as grep above, and the same consequence: `manage_pods`
+        // and `spawn_agent` are separately granted, so a ManagePods term whose
+        // action reported `SpawnAgent` could not pass the ceiling check against
+        // its own authority (#2790).
         let term = build_action_term(Operation::ManagePods, "pod-123");
-        assert_eq!(term.operation(), Operation::SpawnAgent); // ManagePods maps to SpawnAgent
+        assert_eq!(term.operation(), Operation::ManagePods);
     }
 
     // ── ActionTerm derives correct obligations ─────────────────────────

--- a/crates/nucleus-tool-proxy/tests/roguepilot_integration.rs
+++ b/crates/nucleus-tool-proxy/tests/roguepilot_integration.rs
@@ -235,7 +235,9 @@ fn test_path_traversal_blocked() {
     let mut kernel = Kernel::new(policy.clone());
     let sandbox = Sandbox::new(&policy, &sandbox_dir).unwrap();
 
-    // Absolute path — rejected by policy (check_policy rejects absolute paths)
+    // Absolute path outside the sandbox root — rejected. (An absolute path
+    // *under* the root is accepted as the same file as its relative
+    // spelling since #2787; this one is a genuine escape.)
     let tok = dt(&mut kernel, Operation::ReadFiles, "/etc/passwd");
     let result = sandbox.read_to_string(
         "/etc/passwd",
@@ -367,7 +369,7 @@ fn test_credential_isolation() {
 
     // The env var LLM_API_TOKEN should NOT be readable via file tools.
     // Even if an attacker tries to read /proc/self/environ (Linux) or
-    // similar, the sandbox blocks absolute paths.
+    // similar, the sandbox blocks paths outside its root.
     let tok = dt(&mut kernel, Operation::ReadFiles, "/proc/self/environ");
     let result = sandbox.read_to_string(
         "/proc/self/environ",

--- a/crates/nucleus/src/sandbox.rs
+++ b/crates/nucleus/src/sandbox.rs
@@ -170,6 +170,7 @@ impl Sandbox {
     }
 
     fn open_internal(&self, path: &Path, approval: Option<&ApprovalToken>) -> Result<File> {
+        let path = &self.root_relative(path)?;
         self.check_read_capability(path, approval)?;
         self.check_policy(path)?;
 
@@ -225,6 +226,7 @@ impl Sandbox {
         options: &OpenOptions,
         approval: Option<&ApprovalToken>,
     ) -> Result<File> {
+        let path = &self.root_relative(path)?;
         // OpenOptions can include write or truncation; conservatively treat as edit.
         self.check_edit_capability(path, approval)?;
         self.check_policy(path)?;
@@ -270,6 +272,7 @@ impl Sandbox {
     }
 
     fn create_internal(&self, path: &Path, approval: Option<&ApprovalToken>) -> Result<File> {
+        let path = &self.root_relative(path)?;
         self.check_write_capability(path, approval)?;
         self.check_policy(path)?;
 
@@ -312,6 +315,7 @@ impl Sandbox {
     }
 
     fn read_internal(&self, path: &Path, approval: Option<&ApprovalToken>) -> Result<Vec<u8>> {
+        let path = &self.root_relative(path)?;
         self.check_read_capability(path, approval)?;
         self.check_policy(path)?;
 
@@ -358,6 +362,7 @@ impl Sandbox {
         path: &Path,
         approval: Option<&ApprovalToken>,
     ) -> Result<String> {
+        let path = &self.root_relative(path)?;
         self.check_read_capability(path, approval)?;
         self.check_policy(path)?;
 
@@ -461,6 +466,7 @@ impl Sandbox {
         contents: impl AsRef<[u8]>,
         approval: Option<&ApprovalToken>,
     ) -> Result<()> {
+        let path = &self.root_relative(path)?;
         self.check_policy(path)?;
         self.check_write_or_edit_capability(path, approval)?;
 
@@ -503,6 +509,7 @@ impl Sandbox {
     }
 
     fn create_dir_internal(&self, path: &Path, approval: Option<&ApprovalToken>) -> Result<()> {
+        let path = &self.root_relative(path)?;
         self.check_write_capability(path, approval)?;
         self.check_policy(path)?;
 
@@ -545,6 +552,7 @@ impl Sandbox {
     }
 
     fn create_dir_all_internal(&self, path: &Path, approval: Option<&ApprovalToken>) -> Result<()> {
+        let path = &self.root_relative(path)?;
         self.check_write_capability(path, approval)?;
         self.check_policy(path)?;
 
@@ -587,6 +595,7 @@ impl Sandbox {
     }
 
     fn remove_file_internal(&self, path: &Path, approval: Option<&ApprovalToken>) -> Result<()> {
+        let path = &self.root_relative(path)?;
         self.check_edit_capability(path, approval)?;
         self.check_policy(path)?;
 
@@ -629,6 +638,7 @@ impl Sandbox {
     }
 
     fn remove_dir_internal(&self, path: &Path, approval: Option<&ApprovalToken>) -> Result<()> {
+        let path = &self.root_relative(path)?;
         self.check_edit_capability(path, approval)?;
         self.check_policy(path)?;
 
@@ -663,6 +673,10 @@ impl Sandbox {
     }
 
     fn exists_internal(&self, path: &Path, approval: Option<&ApprovalToken>) -> bool {
+        let Ok(path) = self.root_relative(path) else {
+            return false;
+        };
+        let path = &path;
         if self.check_read_capability(path, approval).is_err() {
             return false;
         }
@@ -690,6 +704,7 @@ impl Sandbox {
     ///
     /// Returns `Err` for paths outside the sandbox or unreadable files.
     pub fn read_to_string_for_search(&self, path: &Path, authority: Authority) -> Result<String> {
+        let path = &self.root_relative(path)?;
         self.spend_as(authority, Operation::GrepSearch, SinkClass::AuditLogAppend)?;
         self.check_policy(path)?;
         self.root
@@ -697,23 +712,44 @@ impl Sandbox {
             .map_err(|e| classify_path_io(path.to_path_buf(), &e))
     }
 
+    /// Interpret a caller-supplied path against the sandbox root.
+    ///
+    /// A relative path is returned unchanged. An absolute path that is
+    /// lexically under the root is returned with the root stripped, so the two
+    /// spellings of the same file behave identically -- which is what every
+    /// agent harness fronting this sandbox assumes, and what `/work/hello.txt`
+    /// vs `hello.txt` used to disagree about (#2787). An absolute path that is
+    /// *not* under the root keeps its refusal, and only now is the error's own
+    /// claim ("resolves outside sandbox root") true: before this, the root was
+    /// never consulted.
+    ///
+    /// Stripping cannot widen what is reachable. The result is fed through
+    /// exactly the checks a relative path already faced -- the path policy
+    /// here, and `cap-std`'s containment on the `Dir` handle at the point of
+    /// I/O, which is what actually refuses `..` traversal and symlinks out.
+    pub fn root_relative(&self, path: &Path) -> Result<PathBuf> {
+        if !path.is_absolute() {
+            return Ok(path.to_path_buf());
+        }
+        path.strip_prefix(&self.root_path)
+            .map(Path::to_path_buf)
+            .map_err(|_| NucleusError::SandboxEscape {
+                path: path.to_path_buf(),
+            })
+    }
+
     /// Check if a path is allowed by the policy.
     fn check_policy(&self, path: &Path) -> Result<()> {
-        // First, check for obvious escapes
+        // Absolute paths are interpreted against the root first; what survives
+        // is relative, or a genuine escape.
+        let path = self.root_relative(path)?;
         let path_str = path.to_string_lossy();
-
-        // Reject absolute paths
-        if path.is_absolute() {
-            return Err(NucleusError::SandboxEscape {
-                path: path.to_path_buf(),
-            });
-        }
 
         // Check against portcullis policy
         // Note: We pass the relative path to the policy checker
-        if !self.policy.can_access(path) {
+        if !self.policy.can_access(&path) {
             return Err(NucleusError::PathDenied {
-                path: path.to_path_buf(),
+                path: path.clone(),
                 reason: format!("blocked by path policy: {}", path_str),
             });
         }
@@ -860,6 +896,7 @@ impl Sandbox {
     }
 
     fn open_dir_internal(&self, path: &Path, approval: Option<&ApprovalToken>) -> Result<Sandbox> {
+        let path = &self.root_relative(path)?;
         self.check_read_capability(path, approval)?;
         self.check_policy(path)?;
 
@@ -1286,6 +1323,128 @@ mod tests {
             )
             .unwrap();
         assert_eq!(contents, "nested");
+    }
+
+    // ── Absolute paths under the root (#2787) ────────────────────────────
+
+    /// The measured symptom: the same file, refused by its absolute spelling
+    /// and accepted by its relative one.
+    #[test]
+    fn an_absolute_path_under_the_root_is_the_same_file_as_the_relative_one() {
+        let tmp = tempdir().unwrap();
+        let policy = permissive_policy();
+        let mut kernel = Kernel::new(policy.clone());
+        let sandbox = Sandbox::new(&policy, tmp.path()).unwrap();
+
+        let wt = token(&mut kernel, Operation::WriteFiles, "hello.txt");
+        sandbox
+            .write(
+                "hello.txt",
+                b"hello from the host",
+                &wt,
+                Authority::new(allowed_bundle()),
+            )
+            .unwrap();
+
+        // Read it back by the absolute spelling an agent harness would use.
+        let absolute = sandbox.root_path().join("hello.txt");
+        let rt = token(&mut kernel, Operation::ReadFiles, "hello.txt");
+        let contents = sandbox
+            .read_to_string(
+                &absolute,
+                &rt,
+                Authority::new(bundle_for(Operation::ReadFiles, SinkClass::AuditLogAppend)),
+            )
+            .expect("an absolute path under the root is not an escape");
+        assert_eq!(contents, "hello from the host");
+    }
+
+    /// Writing by absolute path lands in the same place as writing by relative.
+    #[test]
+    fn an_absolute_write_lands_at_the_relative_path() {
+        let tmp = tempdir().unwrap();
+        let policy = permissive_policy();
+        let mut kernel = Kernel::new(policy.clone());
+        let sandbox = Sandbox::new(&policy, tmp.path()).unwrap();
+
+        let absolute = sandbox.root_path().join("written.txt");
+        let wt = token(&mut kernel, Operation::WriteFiles, "written.txt");
+        sandbox
+            .write(&absolute, b"body", &wt, Authority::new(allowed_bundle()))
+            .expect("absolute write under the root should be accepted");
+
+        let rt = token(&mut kernel, Operation::ReadFiles, "written.txt");
+        let via_relative = sandbox
+            .read_to_string(
+                "written.txt",
+                &rt,
+                Authority::new(bundle_for(Operation::ReadFiles, SinkClass::AuditLogAppend)),
+            )
+            .unwrap();
+        assert_eq!(via_relative, "body");
+    }
+
+    /// Accepting absolute paths must not accept absolute paths that leave the
+    /// root -- including one spelled as a traversal *through* the root, which
+    /// strips to a relative `..` and must still be refused at the `Dir`.
+    #[test]
+    fn an_absolute_path_outside_the_root_is_still_refused() {
+        let tmp = tempdir().unwrap();
+        let policy = permissive_policy();
+        let mut kernel = Kernel::new(policy.clone());
+        let sandbox = Sandbox::new(&policy, tmp.path()).unwrap();
+
+        // Plainly outside.
+        let rt = token(&mut kernel, Operation::ReadFiles, "/etc/passwd");
+        assert!(
+            sandbox
+                .read_to_string(
+                    "/etc/passwd",
+                    &rt,
+                    Authority::new(bundle_for(Operation::ReadFiles, SinkClass::AuditLogAppend)),
+                )
+                .is_err(),
+            "an absolute path outside the root must stay refused"
+        );
+
+        // Traversal that passes through the root on its way out.
+        let escaping = sandbox.root_path().join("../etc/passwd");
+        let rt2 = token(&mut kernel, Operation::ReadFiles, "../etc/passwd");
+        assert!(
+            sandbox
+                .read_to_string(
+                    &escaping,
+                    &rt2,
+                    Authority::new(bundle_for(Operation::ReadFiles, SinkClass::AuditLogAppend)),
+                )
+                .is_err(),
+            "stripping the root must not turn a traversal into an accepted read"
+        );
+    }
+
+    /// `root_relative` is the whole rule, and is idempotent on relative input.
+    #[test]
+    fn root_relative_strips_the_root_and_leaves_relative_paths_alone() {
+        let tmp = tempdir().unwrap();
+        let policy = permissive_policy();
+        let sandbox = Sandbox::new(&policy, tmp.path()).unwrap();
+
+        assert_eq!(
+            sandbox.root_relative(Path::new("a/b.txt")).unwrap(),
+            Path::new("a/b.txt")
+        );
+        assert_eq!(
+            sandbox
+                .root_relative(&sandbox.root_path().join("a/b.txt"))
+                .unwrap(),
+            Path::new("a/b.txt")
+        );
+        // The root itself is the empty relative path, not an escape.
+        assert_eq!(
+            sandbox.root_relative(sandbox.root_path()).unwrap(),
+            Path::new("")
+        );
+        assert!(sandbox.root_relative(Path::new("/etc/passwd")).is_err());
     }
 }
 

--- a/crates/portcullis/src/action_term.rs
+++ b/crates/portcullis/src/action_term.rs
@@ -100,6 +100,18 @@ pub enum PrimitiveAction {
         /// Glob pattern (e.g., `src/**/*.rs`).
         pattern: String,
     },
+    /// Search file *contents* for a regular expression.
+    ///
+    /// Distinct from [`PrimitiveAction::GlobSearch`] even though both take a
+    /// pattern, because [`ActionTerm::operation`] is how the kernel recovers
+    /// which authority a term spends. Collapsing grep onto glob made
+    /// `from_operation(GrepSearch, _).operation()` answer `GlobSearch`, and
+    /// the obligation check compares that against the authority the caller
+    /// asked for — so grep could not be granted by any profile. See #2790.
+    GrepSearch {
+        /// Regular expression matched against file contents.
+        pattern: String,
+    },
     /// Fetch the body of a URL.
     WebFetch {
         /// URL to fetch.
@@ -133,6 +145,16 @@ pub enum PrimitiveAction {
         endpoint: String,
         /// Serialized payload size in bytes.
         payload_bytes: usize,
+    },
+    /// Manage pods (create, stop, inspect).
+    ///
+    /// Was collapsed onto [`PrimitiveAction::SpawnAgent`] for the same reason
+    /// grep was collapsed onto glob, with the same consequence: a caller
+    /// holding `manage_pods` authority presented a term that reported itself
+    /// as `SpawnAgent`. See #2790.
+    ManagePods {
+        /// Pod or pod-set the request names.
+        target: String,
     },
 }
 
@@ -288,6 +310,7 @@ impl ActionTerm {
                 | PrimitiveAction::ReadFile { .. }
                 | PrimitiveAction::WriteFile { .. }
                 | PrimitiveAction::GlobSearch { .. }
+                | PrimitiveAction::GrepSearch { .. }
         ) {
             obs.push(ProofObligation::FsPathAllowed);
         }
@@ -364,12 +387,14 @@ impl ActionTerm {
             PrimitiveAction::ReadFile { .. } => Operation::ReadFiles,
             PrimitiveAction::WriteFile { .. } => Operation::WriteFiles,
             PrimitiveAction::GlobSearch { .. } => Operation::GlobSearch,
+            PrimitiveAction::GrepSearch { .. } => Operation::GrepSearch,
             PrimitiveAction::WebFetch { .. } => Operation::WebFetch,
             PrimitiveAction::WebSearch { .. } => Operation::WebSearch,
             PrimitiveAction::GitCommit { .. } => Operation::GitCommit,
             PrimitiveAction::GitPush { .. } => Operation::GitPush,
             PrimitiveAction::CreatePr { .. } => Operation::CreatePr,
             PrimitiveAction::SpawnAgent { .. } => Operation::SpawnAgent,
+            PrimitiveAction::ManagePods { .. } => Operation::ManagePods,
         }
     }
 
@@ -380,13 +405,16 @@ impl ActionTerm {
             | PrimitiveAction::ReadFile { path }
             | PrimitiveAction::WriteFile { path } => path,
             PrimitiveAction::RunCommand { command } => command,
-            PrimitiveAction::GlobSearch { pattern } => pattern,
+            PrimitiveAction::GlobSearch { pattern } | PrimitiveAction::GrepSearch { pattern } => {
+                pattern
+            }
             PrimitiveAction::WebFetch { url } => url,
             PrimitiveAction::WebSearch { query } => query,
             PrimitiveAction::GitCommit { message } => message,
             PrimitiveAction::GitPush { remote, .. } => remote,
             PrimitiveAction::CreatePr { title } => title,
             PrimitiveAction::SpawnAgent { endpoint, .. } => endpoint,
+            PrimitiveAction::ManagePods { target } => target,
         }
     }
 
@@ -420,7 +448,10 @@ impl ActionTerm {
             Operation::RunBash => PrimitiveAction::RunCommand {
                 command: subject.to_string(),
             },
-            Operation::GlobSearch | Operation::GrepSearch => PrimitiveAction::GlobSearch {
+            Operation::GlobSearch => PrimitiveAction::GlobSearch {
+                pattern: subject.to_string(),
+            },
+            Operation::GrepSearch => PrimitiveAction::GrepSearch {
                 pattern: subject.to_string(),
             },
             Operation::WebSearch => PrimitiveAction::WebSearch {
@@ -439,9 +470,12 @@ impl ActionTerm {
             Operation::CreatePr => PrimitiveAction::CreatePr {
                 title: subject.to_string(),
             },
-            Operation::ManagePods | Operation::SpawnAgent => PrimitiveAction::SpawnAgent {
+            Operation::SpawnAgent => PrimitiveAction::SpawnAgent {
                 endpoint: subject.to_string(),
                 payload_bytes: 0,
+            },
+            Operation::ManagePods => PrimitiveAction::ManagePods {
+                target: subject.to_string(),
             },
         };
 
@@ -625,10 +659,27 @@ pub fn preflight_action(term: &ActionTerm, ctx: &PreflightContext<'_>) -> Prefli
                 }
             }
             ProofObligation::WithinDelegationCeiling => {
-                let available = ctx.permissions.capabilities.level_for(term.operation());
-                if term.authority.operation != term.operation()
-                    || term.authority.requested_level > available
-                {
+                let acting = term.operation();
+                let available = ctx.permissions.capabilities.level_for(acting);
+                if term.authority.operation != acting {
+                    // Not a ceiling failure at all. The term's action and the
+                    // authority it carries name different operations, so there
+                    // is no single operation whose ceiling could be compared --
+                    // and `available` above was looked up for the wrong one.
+                    // Reporting this as "exceeds available" sent readers to
+                    // raise a grant the check had never consulted (#2790).
+                    push_failure(
+                        &mut result,
+                        obligation.clone(),
+                        format!(
+                            "term action is {acting:?} but its authority names \
+                             {claimed:?}; these must agree before a ceiling can \
+                             be compared",
+                            claimed = term.authority.operation
+                        ),
+                        PreflightVerdict::Deny,
+                    );
+                } else if term.authority.requested_level > available {
                     push_failure(
                         &mut result,
                         obligation.clone(),
@@ -1120,5 +1171,96 @@ mod tests {
         );
         assert_eq!(spawn.operation(), Operation::SpawnAgent);
         assert_eq!(spawn.subject(), "http://child");
+    }
+
+    // ── Operation identity round-trips (#2790) ──────────────────────────
+
+    /// The law the collapsed arms broke: lowering an operation and reading it
+    /// back must give the same operation.
+    ///
+    /// `from_operation` mapped `GrepSearch` onto a `GlobSearch` primitive and
+    /// `ManagePods` onto a `SpawnAgent` one, so for those two the term's
+    /// action and the authority it carries named *different* operations. The
+    /// `WithinDelegationCeiling` check compares exactly those, so grep could
+    /// not be granted by any profile -- `codegen`'s `grep_search: always`
+    /// included. This is the test the issue notes would have failed on day one.
+    #[test]
+    fn from_operation_round_trips_every_operation() {
+        for op in Operation::ALL {
+            let term = ActionTerm::from_operation(op, "subject");
+            assert_eq!(
+                term.operation(),
+                op,
+                "from_operation({op:?}) lowered to an action that reads back as {:?}",
+                term.operation()
+            );
+            assert_eq!(
+                term.authority.operation,
+                term.operation(),
+                "term for {op:?} carries an authority naming a different operation"
+            );
+            assert_eq!(term.subject(), "subject", "subject lost for {op:?}");
+        }
+    }
+
+    /// The onboarding symptom: grep is denied under a profile that grants it.
+    #[test]
+    fn grep_preflights_clean_when_granted() {
+        let perms = PermissionLattice::permissive();
+        let ctx = PreflightContext::new(&perms);
+        let term = ActionTerm::from_operation(Operation::GrepSearch, "hello");
+
+        let result = preflight_action(&term, &ctx);
+        assert_eq!(
+            result.verdict,
+            PreflightVerdict::Pass,
+            "grep denied despite being granted: {:?}",
+            result.failures
+        );
+    }
+
+    /// An operation mismatch is a kernel inconsistency, and must not be
+    /// reported as a ceiling that was exceeded -- the levels are fine, and the
+    /// old text sent readers to raise a grant the check never consulted.
+    #[test]
+    fn operation_mismatch_reports_the_mismatch_not_the_ceiling() {
+        let perms = PermissionLattice::permissive();
+        let ctx = PreflightContext::new(&perms);
+        // Deliberately disagree: a glob action carrying grep authority.
+        let mut term = ActionTerm::from_operation(Operation::GlobSearch, "*.txt");
+        term.authority = CapabilityRequest::new(Operation::GrepSearch, CapabilityLevel::LowRisk);
+
+        let result = preflight_action(&term, &ctx);
+        assert_eq!(result.verdict, PreflightVerdict::Deny);
+        let failure = result
+            .failures
+            .iter()
+            .find(|f| f.obligation == ProofObligation::WithinDelegationCeiling)
+            .expect("ceiling obligation should have failed");
+        assert!(
+            failure.detail.contains("GlobSearch") && failure.detail.contains("GrepSearch"),
+            "detail should name both operations, got: {}",
+            failure.detail
+        );
+        assert!(
+            !failure.detail.contains("exceeds available"),
+            "a mismatch is not a ceiling overrun, got: {}",
+            failure.detail
+        );
+    }
+
+    /// grep keeps the path obligation glob has; the new variant must not have
+    /// quietly dropped it.
+    #[test]
+    fn grep_derives_path_allowed_like_glob() {
+        let grep = make_term(
+            PrimitiveAction::GrepSearch {
+                pattern: "hello".to_string(),
+            },
+            Operation::GrepSearch,
+        );
+        assert!(grep
+            .derive_obligations()
+            .contains(&ProofObligation::FsPathAllowed));
     }
 }


### PR DESCRIPTION
Closes #2790, #2787, #2788.

## What this is

Three of the four concrete defects from the measured Tier-2 walk (#2791) share a shape: the software refused or failed, and then reported a cause that had not happened. Each is fixed here, with the false statement itself treated as the defect.

- **#2790 — grep cannot be granted by any profile.** `ActionTerm::from_operation` lowered `GrepSearch` to a `GlobSearch` primitive, so a grep term's action reported itself as `GlobSearch` while the authority it carried named `GrepSearch`. `WithinDelegationCeiling` compares exactly those two, so every grep was denied — under `codegen`, which grants `grep_search: always`. The receipt then formatted only the *other* disjunct, with `available` looked up for the glob operation: `requested GrepSearch@LowRisk exceeds available Always`. `LowRisk` does not exceed `Always`; a user trusting that text would go raise a grant the check never consulted.

  The round-trip law the issue proposes — `from_operation(op, s).operation() == op` for every `Operation::ALL` — finds a **second instance the issue did not name**: `ManagePods` was collapsed onto `SpawnAgent` identically. Both are fixed, and the law is now a test.

- **#2787 — every absolute path was a "sandbox escape".** The check was `path.is_absolute()`, and the error said the path "resolves outside sandbox root". It did not resolve outside the root; the root was never consulted. `/work/hello.txt` was refused while `hello.txt` was served, same file, same root. `docs/perf/RUBRIC-LEDGER.md` row 2c already records a reviewer misled by this exact text.

- **#2788 — `nucleus start` always reported a health-check timeout on a healthy node.** It probed the mTLS-only listener with plaintext `GET http://…/health` (also the wrong route; the node serves `/v1/health`). Each probe was a corrupt TLS record, so the node logged an `InvalidContentType` handshake failure for every one — and the error then pointed the user at `journalctl`, i.e. at the 120 WARN lines their own probe had just produced.

**Not in this PR:** #2789 (`/work` read-only without a hand-supplied `scratch_path`). Its fix is provisioning a per-pod ext4 scratch disk in the node, which I can't verify without a real Firecracker VM. #2791 is the umbrella and stays open until #2789 lands.

## The product test

**More easily** — C(T) falls, sharply, at the first contact a user has with the system. Three of the first commands in the quick start failed or lied; a grant the README recommends for coding could not authorise the third thing a coding agent does. Secondarily **more confidence**: each receipt now describes the decision that was actually made.

## Invariants kept

**No default widened and no ceiling raised.** Worth stating explicitly for the two that touch authority:

- **#2790 does not grant anything new.** It makes a term's action and its authority agree so the ceiling comparison is *possible*; grep is still refused wherever `grep_search` is not granted. The mismatch case is now denied with an honest message rather than denied with a misleading one — `Deny` either way. `GrepSearch` was added to the `FsPathAllowed` derivation alongside `GlobSearch`, so the new variant does not quietly drop grep's path obligation.
- **#2787 widens the accepted *spelling*, not the reachable set.** An absolute path lexically under the root is stripped to its relative form and then fed through exactly the checks a relative path already faced — the path policy, and cap-std's containment on the `Dir` handle, which is what actually refuses traversal and symlinks. A path spelled to traverse *through* the root (`<root>/../etc/passwd`) strips to `../etc/passwd` and is still refused at the `Dir`; that case is pinned by a test. Absolute paths outside the root keep their refusal, and only now is the error's own claim true. The tool proxy's `glob` and `grep` carried a hand-rolled copy of the same rule; both now call the shared one, so the three sites cannot drift.

## Validation

All on the pushed head, `4144f55`.

**TESTED.**

- New tests red on the real defect, green restored (A-19 discipline), verified by reintroducing each defect and re-running:
  - `from_operation_round_trips_every_operation`, `grep_preflights_clean_when_granted` — FAILED with the collapsed arm, pass without it.
  - `the_health_probe_addresses_the_listener_the_node_actually_has`, `the_banner_advertises_nothing_unreachable` — FAILED with the old endpoint and banner, pass without them.
- `cargo test -p portcullis` — 1035 + 22 suites, 0 failed.
- `cargo test -p nucleus` — 3 suites, 0 failed.
- `cargo test -p nucleus-tool-proxy` — 404 + 7 suites, 0 failed. Includes the adversarial suite that pins #2787: `test_path_traversal_blocked`, `test_symlink_read_blocked_capstd`, `test_symlink_write_blocked`, `test_symlink_read_mcp_parity`, `test_credential_isolation`, `test_full_rogue_pilot_chain` — all pass unchanged.
- `cargo test -p nucleus-cli` — 190 + 6 suites, 0 failed.
- `cargo fmt --all -- --check` clean; `cargo clippy` on the four crates, `--all-targets`, no warnings.
- `scripts/check-line-ratchet.sh` — all declared files under ceiling, 662 files swept. `nucleus-tool-proxy/src/main.rs` 4775/4975 (down: the hand-rolled checks were replaced by a call).
- `scripts/check-clippy-ratchet.sh` — 345, ceiling 345; no new tracked casts.

**Pre-existing, not from this change:** `cargo check --workspace --all-targets` fails in `portcullis-core/src/prov_export.rs:413` (`cannot find module or crate serde_json`). Reproduced identically on pristine `origin/main` in the same tree; `cargo check -p portcullis-core --all-targets` alone passes, so it is a workspace feature-resolution effect. Untouched by this PR — happy to file it separately.

**Not claimed:** none of this was run against a live Firecracker pod or a Lima VM; the #2788 fix is verified by construction and by unit tests over the endpoint and banner, not by a measured `nucleus start` on macOS.

---
_Generated by [Claude Code](https://claude.ai/code/session_011XqKAavF6twdyXTgzTHg6r)_