### PR TITLE
fix: the three commands that diagnose an install could not pass on a correct one

### DIFF
--- a/crates/nucleus-cli/src/config.rs
+++ b/crates/nucleus-cli/src/config.rs
@@ -447,6 +447,72 @@ mod tests {
         );
     }
 
+    /// `nucleus_dir()` exists because `dirs::config_dir()` is
+    /// `~/Library/Application Support` on macOS while every nucleus path is
+    /// `~/.config/nucleus`. That drift has now been found twice: in `main.rs`
+    /// (2026-07-29, recorded in `nucleus_dir()`'s own doc comment) and in
+    /// `doctor::check_config` (#2734), which reported "not found" about a file
+    /// `setup` had just written. The first fix added
+    /// `the_cli_default_and_setups_output_are_the_same_file`, but that pins two
+    /// named constants against each other — it cannot see a third caller
+    /// resolving the path its own way, which is exactly how doctor drifted.
+    ///
+    /// So pin the property that actually failed: nothing in this crate resolves
+    /// a nucleus path through `dirs::config_dir()`.
+    ///
+    /// `keychain.rs` is the one allowed file, and deliberately named rather
+    /// than pattern-matched:
+    ///
+    /// * `secret_file_path` is `#[cfg(not(target_os = "macos"))]` — it only
+    ///   compiles where the two resolvers agree.
+    /// * `MetadataStore::metadata_path` is NOT cfg-gated, so on macOS the
+    ///   rotation metadata does live outside `nucleus_dir()`. It is
+    ///   self-consistent (the same function reads and writes it) so nothing
+    ///   misreports today, but it is a real divergence from this module's
+    ///   "one directory on every platform" claim. Moving it would relocate an
+    ///   existing file on a platform CI does not walk, so it is left alone
+    ///   here and called out rather than quietly covered by this test.
+    #[test]
+    fn no_nucleus_path_is_resolved_through_dirs_config_dir() {
+        let src = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let mut offenders = Vec::new();
+        let mut scanned = 0usize;
+        for entry in std::fs::read_dir(&src).expect("src/ is readable") {
+            let path = entry.expect("readable entry").path();
+            if path.extension().is_none_or(|e| e != "rs") {
+                continue;
+            }
+            let name = path.file_name().unwrap().to_string_lossy().to_string();
+            scanned += 1;
+            if name == "keychain.rs" || name == "config.rs" {
+                continue;
+            }
+            let body = std::fs::read_to_string(&path).expect("readable source");
+            for (i, line) in body.lines().enumerate() {
+                // Skip prose: every mention in this crate's comments is an
+                // explanation of why NOT to call it.
+                let code = line.trim_start();
+                if code.starts_with("//") || code.starts_with("///") {
+                    continue;
+                }
+                if code.contains("dirs::config_dir()") {
+                    offenders.push(format!("{name}:{}", i + 1));
+                }
+            }
+        }
+        // Non-vacuity: a test that scanned nothing would pass silently.
+        assert!(
+            scanned > 10,
+            "only {scanned} sources scanned — the sweep is not reading the crate"
+        );
+        assert!(
+            offenders.is_empty(),
+            "these resolve a nucleus path through dirs::config_dir(), which is \
+             ~/Library/Application Support on macOS and so is not the directory \
+             the rest of the CLI uses — call config::nucleus_dir() instead: {offenders:?}"
+        );
+    }
+
     /// Artifacts must sit beside the config, not under a second root.
     #[test]
     fn artifacts_live_under_the_same_nucleus_directory_as_the_config() {

--- a/crates/nucleus-cli/src/doctor.rs
+++ b/crates/nucleus-cli/src/doctor.rs
@@ -1,7 +1,6 @@
 //! Doctor command - diagnose nucleus environment issues
 
 use anyhow::Result;
-use std::path::PathBuf;
 use std::process::Command;
 
 use crate::keychain::{self, SecretKind, SecretStore};
@@ -634,9 +633,20 @@ fn check_config() -> bool {
     println!("Configuration");
     println!("-------------");
 
-    let config_path = dirs::config_dir()
-        .map(|d| d.join("nucleus").join("config.toml"))
-        .unwrap_or_else(|| PathBuf::from("~/.config/nucleus/config.toml"));
+    // `config::default_config_path()`, NOT `dirs::config_dir()`. The two agree
+    // on Linux and disagree on macOS, where `dirs::config_dir()` is
+    // `~/Library/Application Support` and nothing in nucleus ever writes there
+    // — so doctor reported "not found" about a file `setup` had just written,
+    // and named a path no other command uses (#2734). `nucleus_dir()`'s own doc
+    // comment records this same defect being found in `main.rs` on 2026-07-29;
+    // doctor was the third caller, outside the guard that was added then.
+    let Ok(config_path) = crate::config::default_config_path() else {
+        return print_check(
+            "Config file",
+            Status::Warning,
+            "could not determine the home directory",
+        );
+    };
 
     let config_path_str = config_path.display().to_string();
     print_check(
@@ -658,17 +668,35 @@ async fn check_node_connectivity() -> bool {
     println!("Node Connectivity");
     println!("-----------------");
 
-    // Try to connect to default node URL
-    let node_url = "http://127.0.0.1:8080/health";
+    // The node's listener is mTLS-only with no plaintext mode, and its health
+    // route is `/v1/health`. This probe sent plaintext `GET /health`, so it
+    // reported "not reachable" about every healthy node and told the user to
+    // start a node that was already running — the same defect as #2788 in
+    // `start.rs`, in the command that #2734 notes is what `setup` and every
+    // failure message point at to check an install.
+    let node_url = "https://127.0.0.1:8080/v1/health";
 
-    // Create agent with timeout
-    let config = ureq::Agent::config_builder()
-        .timeout_global(Some(std::time::Duration::from_secs(2)))
-        .build();
-    let agent: ureq::Agent = config.into();
+    let client = match crate::provision::mtls_client_from_provisioned_identity() {
+        Ok(client) => client,
+        Err(_) => {
+            // No provisioned identity means this probe cannot complete a
+            // handshake with ANY node, healthy or not. Say that, rather than
+            // reporting the node unreachable for a reason on this side.
+            return print_check(
+                "nucleus-node",
+                Status::Warning,
+                "no CLI identity to check with (run: nucleus setup)",
+            );
+        }
+    };
 
-    match agent.get(node_url).call() {
-        Ok(resp) if resp.status().as_u16() == 200 => {
+    match client
+        .get(node_url)
+        .timeout(std::time::Duration::from_secs(2))
+        .send()
+        .await
+    {
+        Ok(resp) if resp.status().is_success() => {
             print_check("nucleus-node", Status::Ok, "reachable")
         }
         Ok(resp) => print_check(
@@ -679,7 +707,7 @@ async fn check_node_connectivity() -> bool {
         Err(_) => print_check(
             "nucleus-node",
             Status::Warning,
-            "not reachable (start with: nucleus-node)",
+            "not reachable (start with: nucleus start)",
         ),
     }
 }

--- a/crates/nucleus-cli/src/provision.rs
+++ b/crates/nucleus-cli/src/provision.rs
@@ -740,7 +740,87 @@ pub async fn provision_mtls_identity(
     trust_domain: &str,
 ) -> Result<MtlsIdentityPaths> {
     let ca = load_or_seed_host_ca(host, trust_domain)?;
-    mint_cli_identity(&ca, trust_domain, &crate::config::Config::identity_dir()?).await
+    let paths =
+        mint_cli_identity(&ca, trust_domain, &crate::config::Config::identity_dir()?).await?;
+    install_identity_on_tier2_host(host, &paths)?;
+    Ok(paths)
+}
+
+/// Where `verify --tier2` looks for the CLI identity on the Tier 2 host.
+///
+/// `verify --tier2` re-invokes the Linux CLI as root on that host
+/// (`limactl shell <vm> -- sudo /usr/local/bin/nucleus verify --tier2 --here`),
+/// and `Config::identity_dir()` evaluated as root is this path. It is written
+/// out rather than computed because the process that computes it runs on the
+/// other machine — on macOS, `Config::identity_dir()` here resolves under the
+/// operator's own home, which is what #2715 was.
+const TIER2_IDENTITY_DIR: &str = "/root/.config/nucleus/identity";
+
+/// Put the identity just minted where the Tier 2 host will look for it.
+///
+/// # Why this is a second write and not a different destination
+///
+/// `mint_cli_identity` writes into `Config::identity_dir()`, which resolves on
+/// the machine running `setup`. On macOS that is the operator's Mac, while
+/// `verify --tier2` runs the CLI inside the Lima VM as root — so setup minted
+/// an identity, verification looked somewhere else, and the error it printed
+/// was `run: nucleus setup`, the command that had just run (#2715). The CA root
+/// was already seeded in the VM by `load_or_seed_host_ca`, so the identity was
+/// the only missing piece; both are needed and both belong on that host.
+///
+/// The operator's own copy stays where it is: `nucleus node` on the Mac reads
+/// it, so this adds a destination rather than moving one. On a Linux host where
+/// `setup` already runs as root the two paths coincide and the write is an
+/// idempotent rewrite of identical bytes.
+///
+/// # Why the key goes into the VM at all
+///
+/// It is the operator's own credential and the VM is the operator's own
+/// machine, already holding the CA **private key** that can mint more of them
+/// (`{HOST_CA_DIR}/ca-key.pem`). Writing a leaf key beside a root key it is
+/// derived from adds no reachable authority. It is written by root, `umask 077`
+/// before creation and `chmod 0600` after, matching how the CA key is written.
+fn install_identity_on_tier2_host(host: &Tier2Host, paths: &MtlsIdentityPaths) -> Result<()> {
+    let read = |p: &Path| {
+        std::fs::read_to_string(p).with_context(|| format!("failed to read {}", p.display()))
+    };
+    let script = tier2_identity_install_script(
+        &read(&paths.cli_cert)?,
+        &read(&paths.cli_key)?,
+        &read(&paths.trust_bundle)?,
+    );
+    host.sh(&script).with_context(|| {
+        format!(
+            "failed to install the CLI identity into {TIER2_IDENTITY_DIR} on {} — \
+             `nucleus verify --tier2` reads it from there",
+            host.describe()
+        )
+    })?;
+    Ok(())
+}
+
+/// The pure half of [`install_identity_on_tier2_host`]: the script, built from
+/// the three PEMs, with no `Tier2Host` involved so a test can read it.
+///
+/// Split for the same reason `mint_cli_identity` is split from
+/// `load_or_seed_host_ca` — the half that runs real shell commands is exercised
+/// by review, and the half that decides WHAT to run is exercised by a test.
+fn tier2_identity_install_script(cert_pem: &str, key_pem: &str, bundle_pem: &str) -> String {
+    // `set -e` so a failed mkdir cannot leave a later `cat` writing into the
+    // wrong directory, and `umask 077` so the key is never briefly world-readable
+    // between creation and chmod.
+    format!(
+        "set -e
+         mkdir -p {TIER2_IDENTITY_DIR}
+         umask 077
+         cat > {TIER2_IDENTITY_DIR}/cli-cert.pem <<'NUCLEUS_CLI_CERT_EOF'
+{cert_pem}NUCLEUS_CLI_CERT_EOF
+         cat > {TIER2_IDENTITY_DIR}/cli-key.pem <<'NUCLEUS_CLI_KEY_EOF'
+{key_pem}NUCLEUS_CLI_KEY_EOF
+         cat > {TIER2_IDENTITY_DIR}/trust-bundle.pem <<'NUCLEUS_TRUST_BUNDLE_EOF'
+{bundle_pem}NUCLEUS_TRUST_BUNDLE_EOF
+         chmod 0600 {TIER2_IDENTITY_DIR}/cli-key.pem"
+    )
 }
 
 /// The `Tier2Host`-touching half: load the CA root already at `HOST_CA_DIR`
@@ -1236,5 +1316,64 @@ mod tests {
         assert_eq!(resp.status(), 200);
 
         server_handle.await.unwrap();
+    }
+
+    /// The whole of #2715 in one assertion: the directory setup writes into
+    /// must be the directory the root CLI on the Tier 2 host reads from.
+    /// Computed here from `Config::identity_dir()`'s own shape rather than
+    /// restated, so changing `nucleus_dir()` moves both or fails loudly — the
+    /// two drifting apart is exactly the bug.
+    #[test]
+    fn the_tier2_identity_dir_is_where_the_root_cli_will_look() {
+        let home = dirs::home_dir().expect("home directory");
+        let local = crate::config::Config::identity_dir().expect("identity dir");
+        let under_home = local
+            .strip_prefix(&home)
+            .expect("the identity dir is under the home directory");
+        assert_eq!(
+            std::path::Path::new(TIER2_IDENTITY_DIR),
+            std::path::Path::new("/root").join(under_home),
+            "setup would write the identity somewhere `verify --tier2` does not read"
+        );
+    }
+
+    /// The three filenames are not free: `node.rs::provisioned_identity_paths_in`
+    /// requires all three to be present before it will default the node client's
+    /// flags, and treats a partial set as none. A script that wrote two of them
+    /// would leave `verify --tier2` failing exactly as it did before.
+    #[test]
+    fn the_install_script_writes_all_three_files_the_node_client_requires() {
+        let script = tier2_identity_install_script("CERT\n", "KEY\n", "BUNDLE\n");
+        for name in ["cli-cert.pem", "cli-key.pem", "trust-bundle.pem"] {
+            assert!(
+                script.contains(&format!("{TIER2_IDENTITY_DIR}/{name}")),
+                "{name} is never written, so the identity stays partial: {script}"
+            );
+        }
+        for pem in ["CERT", "KEY", "BUNDLE"] {
+            assert!(script.contains(pem), "{pem} never reaches the host");
+        }
+    }
+
+    /// The key is a private key on a shared filesystem. `umask 077` must come
+    /// before the first `cat`, or it exists world-readable for the window
+    /// between creation and `chmod`.
+    #[test]
+    fn the_install_script_never_exposes_the_key() {
+        let script = tier2_identity_install_script("CERT\n", "KEY\n", "BUNDLE\n");
+        let umask = script.find("umask 077").expect("umask is set");
+        let first_write = script.find("cat >").expect("something is written");
+        assert!(
+            umask < first_write,
+            "umask must precede the first write or the key is briefly world-readable"
+        );
+        assert!(
+            script.contains(&format!("chmod 0600 {TIER2_IDENTITY_DIR}/cli-key.pem")),
+            "the key is left at the umask default rather than explicitly restricted"
+        );
+        assert!(
+            script.starts_with("set -e"),
+            "a failed mkdir must stop the script"
+        );
     }
 }

--- a/crates/nucleus-cli/src/verify.rs
+++ b/crates/nucleus-cli/src/verify.rs
@@ -784,10 +784,16 @@ fn check_credential_absent_from_guest(host: &Tier2Host, pod: &Pod) -> Result<()>
 
     let log = format!("{HOST_STATE_DIR}/pods/{}/firecracker.log", pod.id);
     let contents = host.sh(&format!("cat {log}"))?;
-    assess_leak_sweep(&contents, &canary)?;
-    println!(
-        "  [OK] no node-held secret surfaced in the guest (sweep read its sites; canary absent)"
-    );
+    match assess_leak_sweep(&contents, &canary)? {
+        LeakSweep::Clean => println!(
+            "  [OK] no node-held secret surfaced in the guest (sweep read its sites; canary absent)"
+        ),
+        LeakSweep::NoProbeWorkload => println!(
+            "  [OK] the node's canary is absent from the guest console\n       \
+             (this pod carries no probe workload, so the four-site sweep did not run; \
+             the probe-pod boot lane in CI is what asserts that sweep)"
+        ),
+    }
     Ok(())
 }
 
@@ -849,16 +855,36 @@ fn resolve_canary(host: &Tier2Host) -> Result<String> {
 /// (`looked=yes` on the always-readable ones — otherwise "no canary" means "no
 /// look"), then that no site saw the canary, and finally that the canary value does
 /// not appear anywhere on the console (a path the four sites might not enumerate).
-fn assess_leak_sweep(contents: &str, canary: &str) -> Result<()> {
+fn assess_leak_sweep(contents: &str, canary: &str) -> Result<LeakSweep> {
     let sweep: Vec<&str> = contents
         .lines()
         .filter(|l| l.contains("NUCLEUS_E2E_LEAK"))
         .collect();
     if sweep.is_empty() {
-        bail!(
-            "the guest log has no NUCLEUS_E2E_LEAK lines: the in-guest leak sweep never \
-             ran, so 'the canary was not found' would mean 'nobody looked'."
-        );
+        // Whether this is a failure depends on whether the pod could have
+        // answered. `NUCLEUS_E2E_LEAK` lines come only from
+        // `nucleus-workload-probe`, which a pod emits only when it runs the
+        // probe AS ITS WORKLOAD — and the guest takes its workload from the
+        // spec baked into the image (`build-rootfs.sh` copies `POD_SPEC` to
+        // /etc/nucleus/pod.yaml), not from the API request. The demo rootfs
+        // that `verify --tier2` boots has no `workload:` block at all, so it
+        // cannot produce these lines however healthy it is (#2717).
+        //
+        // The probe's OTHER sentinel, `NUCLEUS_WORKLOAD_PROBE`, tells the two
+        // cases apart, and the neighbouring check in `check_guest_facts`
+        // already gates on exactly that for exactly this reason.
+        if contents.contains("NUCLEUS_WORKLOAD_PROBE") {
+            bail!(
+                "the guest ran the workload probe but its log has no NUCLEUS_E2E_LEAK \
+                 lines: the in-guest leak sweep never ran, so 'the canary was not \
+                 found' would mean 'nobody looked'."
+            );
+        }
+        // Still worth doing on a pod with no probe: the sweep enumerates four
+        // sites, but the canary appearing ANYWHERE on the console is a leak on
+        // a path those sites do not cover, and that check needs no probe.
+        assert_canary_absent_from_console(contents, canary)?;
+        return Ok(LeakSweep::NoProbeWorkload);
     }
 
     // Non-vacuity: the always-readable sites must report looked=yes.
@@ -886,6 +912,23 @@ fn assess_leak_sweep(contents: &str, canary: &str) -> Result<()> {
 
     // Belt-and-suspenders: the canary VALUE must not appear anywhere on the console,
     // catching a leak on any path the four enumerated sites do not cover.
+    assert_canary_absent_from_console(contents, canary)?;
+    Ok(LeakSweep::Clean)
+}
+
+/// What the guest log could establish about the leak sweep.
+#[derive(Debug, PartialEq, Eq)]
+enum LeakSweep {
+    /// The sweep ran, read its sites, and saw nothing.
+    Clean,
+    /// This pod carries no probe workload, so there was no sweep to read. The
+    /// console-wide canary check still ran and passed.
+    NoProbeWorkload,
+}
+
+/// The canary VALUE must not appear anywhere on the guest console. Applies to
+/// any pod, probe or not, because it needs no cooperation from the guest.
+fn assert_canary_absent_from_console(contents: &str, canary: &str) -> Result<()> {
     if contents.contains(canary) {
         bail!(
             "the node's canary value appears in the guest console log — a leak on a path \
@@ -1048,16 +1091,58 @@ mod leak_sweep {
     /// that refused every sweep would satisfy all of them while being useless.
     #[test]
     fn a_clean_sweep_passes() {
-        assert!(assess_leak_sweep(&clean_sweep(), CANARY).is_ok());
+        assert_eq!(
+            assess_leak_sweep(&clean_sweep(), CANARY).expect("a clean sweep passes"),
+            LeakSweep::Clean
+        );
     }
 
-    /// The probe never ran the sweep, so nothing was inspected. This is the state
-    /// that used to be indistinguishable from success.
+    /// The probe RAN and still swept nothing, so nothing was inspected. This is
+    /// the state that used to be indistinguishable from success, and it is still
+    /// a refusal — the anti-vacuity fence is the point of this function.
     #[test]
-    fn a_sweep_that_never_ran_is_refused() {
-        let err = assess_leak_sweep("some unrelated boot log\n", CANARY)
+    fn a_probe_that_swept_nothing_is_refused() {
+        let ran_but_silent = "NUCLEUS_WORKLOAD_PROBE: PASS\nsome unrelated boot log\n";
+        let err = assess_leak_sweep(ran_but_silent, CANARY)
             .expect_err("no NUCLEUS_E2E_LEAK lines means nobody looked");
         assert!(format!("{err}").contains("nobody looked"));
+    }
+
+    /// A pod with no probe workload cannot emit sweep lines however healthy it
+    /// is: the guest reads its workload from the spec baked into the image, and
+    /// the demo rootfs `verify --tier2` boots has no `workload:` block. Asking
+    /// it for sweep evidence made `verify --tier2` exit 1 after 16 passing
+    /// checks on a correct install (#2717).
+    #[test]
+    fn a_pod_with_no_probe_workload_is_not_asked_for_a_sweep() {
+        assert_eq!(
+            assess_leak_sweep("some unrelated boot log\n", CANARY)
+                .expect("a demo pod cannot answer, so it is not asked"),
+            LeakSweep::NoProbeWorkload
+        );
+    }
+
+    /// ...but "not asked for a sweep" is not "not checked". The console-wide
+    /// canary check needs no cooperation from the guest, so it still runs — a
+    /// real leak on a probe-less pod is still caught, and still without
+    /// printing the secret.
+    #[test]
+    fn a_leak_on_a_probe_less_pod_is_still_caught() {
+        let leaked = format!("some unrelated boot log\nSECRET={CANARY}\n");
+        let err =
+            assess_leak_sweep(&leaked, CANARY).expect_err("the canary value is on the console");
+        let msg = format!("{err}");
+        assert!(
+            !msg.contains(CANARY),
+            "the failure printed the secret it exists to protect"
+        );
+        // It must be refused for the LEAK, not for the absent sweep — otherwise
+        // this passes on the very behaviour #2717 is about, and would stop
+        // catching the leak the moment that behaviour changed.
+        assert!(
+            msg.contains("appears in the guest console log"),
+            "refused for the wrong reason, so this is not evidence the leak was seen: {msg}"
+        );
     }
 
     /// A required site reports `looked=no` — its read or search is broken, so its


### PR DESCRIPTION
Closes #2734, #2717, #2715. Second batch from the measured Tier-2 walk (#2791), continuing #2792.

## What this is

Three more commands from the same walk, sharing the same shape as the last batch: on a **correct** install each reported a failure that had not happened, and two of them named a next step the user had already taken.

- **#2715 — `setup` could not pass its own verification.** It minted the CLI identity into `Config::identity_dir()`, which resolves on the machine running `setup` — the operator's Mac. `verify --tier2` runs the CLI inside the Lima VM as root, where that path is `/root/.config/nucleus/identity`. Nothing wrote there, so verification failed with `run: nucleus setup` — the command that was running when it printed. The CA root was already seeded on that host, so the identity was the only missing piece; this writes it there too, reusing the heredoc pattern `load_or_seed_host_ca` already uses for the CA beside it.

- **#2717 — `verify --tier2` exited 1 after 16 passing checks.** The leak sweep demanded `NUCLEUS_E2E_LEAK` lines that only `nucleus-workload-probe` emits, and only when a pod runs it *as its workload*. The guest reads its workload from the spec baked into the image, and the default has no `workload:` block — so the rootfs `verify --tier2` boots cannot produce those lines however healthy it is. Its exit code was unusable as a gate.

- **#2734 — `doctor` checked a different install than the one it was run on.** `check_config` resolved the path through `dirs::config_dir()` (`~/Library/Application Support` on macOS), so it reported "not found" about the file `setup` had written minutes earlier, and named a path no other command uses.

**What the fix found that the issues didn't.** #2734 is only half of doctor's problem. `check_node_connectivity` sends plaintext `GET http://127.0.0.1:8080/health` to a listener that is mTLS-only, at a route the node does not serve — that is **#2788, which #2792 fixes in `start.rs`, living a second life in the command that diagnoses the first**. So on a correct macOS install `doctor` reported *both* "config not found" *and* "node not reachable (start with: nucleus-node)". Fixed here too.

## The product test

**More easily** — C(T) falls at the point where a user finds out whether their install works. All three of these commands are what `setup`, the README, and every failure message point at, and none of them could report success on a correct Tier-2 install. Secondarily **more confidence**: `verify --tier2`'s exit code becomes usable as a gate, which is the whole reason it exists.

## Invariants kept

**No default widened, no ceiling raised, and the anti-vacuity fence is not weakened.** The two that touch security properties:

- **#2717 aims the refusal, it does not soften it.** The old code conflated two cases; the probe's other sentinel (`NUCLEUS_WORKLOAD_PROBE`) separates them. A probe that ran and swept nothing is **still refused, with the same message** — that is the state once indistinguishable from success, and it stays caught. Only a pod with no probe workload is not asked, because there is nothing it could answer with. And "not asked for a sweep" is not "not checked": the canary value must still be absent from the whole console, which needs no cooperation from the guest, so a real leak on a probe-less pod is still caught — pinned by a test asserting the refusal names *the leak* rather than the absent sweep, so it cannot pass for the wrong reason.
- **#2715 writes a private key into the VM, deliberately.** It is the operator's own credential, and that host already holds the CA **private key** it was minted from (`/var/lib/nucleus/state/ca/ca-key.pem`), which can mint more of them. A leaf beside the root it derives from adds no reachable authority. Written by root, `umask 077` before creation and `chmod 0600` after — the same handling the CA key gets, with a test asserting the umask *precedes the first write* rather than trusting the chmod to close the window. The operator's own copy is unaffected: this adds a destination rather than moving one.

`#2734`'s guard is new and worth naming: `nucleus_dir()`'s doc comment already records this drift being found once, in `main.rs` on 2026-07-29. The fix then pinned two named constants against each other, which cannot see a third caller resolving the path its own way — and doctor was the third caller. So this pins the property that actually failed twice: nothing in the crate resolves a nucleus path through `dirs::config_dir()`.

## Validation

All on the pushed head, `d0ed5d8`. **TESTED.**

- Every new test confirmed red on the real defect and green when restored (A-19), by reintroducing each defect:
  - `no_nucleus_path_is_resolved_through_dirs_config_dir` — FAILED naming `doctor.rs:643`.
  - `a_pod_with_no_probe_workload_is_not_asked_for_a_sweep` and `a_leak_on_a_probe_less_pod_is_still_caught` — both FAILED against the ungated code.
  - `the_tier2_identity_dir_is_where_the_root_cli_will_look` — FAILED on a drifted path, printing both sides.
- `cargo test -p nucleus-cli` — 194 + 5 suites, 0 failed (was 189; +5 new).
- `cargo fmt --all -- --check` clean; `cargo clippy -p nucleus-cli --all-targets` no warnings.
- `scripts/check-line-ratchet.sh` — 667 files swept, all under ceiling.
- `scripts/check-clippy-ratchet.sh --strict` — 337, ceiling 345.

**Not claimed:** none of this ran against a real Lima VM or Firecracker pod — I have no macOS host. #2715 in particular is verified by construction: the script's content, and that its destination is derived from `Config::identity_dir()`'s own shape rather than restated. The end-to-end claim in #2715 (that copying those three files takes verification through 16 checks) is the reporter's, already recorded in the issue.

**Called out, deliberately not fixed:** `keychain.rs`'s `MetadataStore::metadata_path` also resolves through `dirs::config_dir()` and is **not** `cfg`-gated, so on macOS the rotation metadata really does live outside `nucleus_dir()`. It is self-consistent — the same function reads and writes it — so nothing misreports today, but it is a genuine divergence from that module's "one directory on every platform" claim. Relocating a file on a platform CI does not walk is not this fix's business, so the new guard names it as an exception rather than quietly covering it. Happy to file it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011XqKAavF6twdyXTgzTHg6r

---
_Generated by [Claude Code](https://claude.ai/code/session_011XqKAavF6twdyXTgzTHg6r)_