### PR TITLE
feat: a codegen pod can write, and the conformance corpus stops depending on the build graph

### DIFF
--- a/crates/nucleus-commerce-conformance/src/lib.rs
+++ b/crates/nucleus-commerce-conformance/src/lib.rs
@@ -524,11 +524,53 @@ pub fn export_vectors() -> String {
             })
         })
         .collect();
-    serde_json::to_string_pretty(&serde_json::json!({
+    serde_json::to_string_pretty(&with_sorted_keys(serde_json::json!({
         "version": 1,
         "cases": cases,
-    }))
+    })))
     .expect("corpus serialization is infallible")
+}
+
+/// Rebuild a `Value` with every object's keys in sorted order.
+///
+/// # Why the bytes need this
+///
+/// `serde_json::Value`'s map type is chosen at COMPILE time: `BTreeMap`
+/// (sorted) normally, `IndexMap` (insertion order) under
+/// `serde_json/preserve_order`. Cedar, via `nucleus-trust-registry`, unifies
+/// that feature ON in full-workspace builds and leaves it OFF in standalone
+/// ones — so two people running the documented regeneration command could
+/// commit different bytes for the same 16 cases, and the whole-file reorder
+/// would read as a corpus change (#2751).
+///
+/// That is not hypothetical here: `nucleus-receipt/Cargo.toml` records the
+/// same hazard one crate over, where the bytes were being SIGNED and the
+/// answer was RFC 8785. These bytes are published and diffed rather than
+/// signed, which is a weaker requirement — so this sorts rather than
+/// canonicalizes, keeping the artifact pretty-printed and readable instead of
+/// collapsing 625 lines into one. Sorting is what the committed file already
+/// is, so this changes no bytes today; it makes that state reproducible
+/// instead of incidental.
+///
+/// Arrays keep their order: `cases` is ordered data from `corpus()`, and
+/// reordering it would be a corpus change rather than a normalization.
+fn with_sorted_keys(value: serde_json::Value) -> serde_json::Value {
+    match value {
+        serde_json::Value::Object(map) => {
+            let mut entries: Vec<_> = map.into_iter().collect();
+            entries.sort_by(|(a, _), (b, _)| a.cmp(b));
+            serde_json::Value::Object(
+                entries
+                    .into_iter()
+                    .map(|(k, v)| (k, with_sorted_keys(v)))
+                    .collect(),
+            )
+        }
+        serde_json::Value::Array(items) => {
+            serde_json::Value::Array(items.into_iter().map(with_sorted_keys).collect())
+        }
+        scalar => scalar,
+    }
 }
 
 /// Does every property carry cases in **both** directions?
@@ -549,4 +591,113 @@ pub fn corpus_covers_both_directions() -> Vec<(Property, Expect)> {
         }
     }
     missing
+}
+
+#[cfg(test)]
+mod export_determinism {
+    use super::*;
+
+    /// Key names in order of appearance, grouped by indentation depth, as they
+    /// appear in the PRETTY-PRINTED bytes — which is the thing that gets
+    /// committed and diffed, and the thing `preserve_order` changes.
+    ///
+    /// Reading the string rather than the parsed `Value` is deliberate: a
+    /// parse hands back whichever map type this build compiled, so asserting
+    /// on it would assert on the very thing under test.
+    fn key_runs_by_depth(json: &str) -> Vec<(usize, Vec<String>)> {
+        let mut runs: Vec<(usize, Vec<String>)> = Vec::new();
+        let mut current: Option<(usize, Vec<String>)> = None;
+        for line in json.lines() {
+            let indent = line.len() - line.trim_start().len();
+            let trimmed = line.trim_start();
+
+            // A brace or bracket ends the object whose keys we were collecting.
+            // Without this, sibling objects in an array — each internally
+            // sorted — merge into one run that looks unsorted (the corpus has
+            // three `{amount_micro, destination}` objects in a row).
+            if trimmed.starts_with('}') || trimmed.starts_with(']') || trimmed.starts_with('{') {
+                if let Some(run) = current.take() {
+                    runs.push(run);
+                }
+                continue;
+            }
+
+            let Some(rest) = trimmed.strip_prefix('"') else {
+                continue;
+            };
+            let Some(end) = rest.find("\":") else {
+                continue;
+            };
+            let key = rest[..end].to_string();
+            match current {
+                Some((d, ref mut keys)) if d == indent => keys.push(key),
+                _ => {
+                    if let Some(run) = current.take() {
+                        runs.push(run);
+                    }
+                    current = Some((indent, vec![key]));
+                }
+            }
+        }
+        if let Some(run) = current {
+            runs.push(run);
+        }
+        runs
+    }
+
+    /// The property #2751 is about: the emitted bytes must not depend on which
+    /// map type `serde_json::Value` was compiled with.
+    ///
+    /// Run this BOTH ways, or it means nothing — with the feature off it
+    /// passes on a `BTreeMap` that was already sorted:
+    ///
+    /// ```text
+    /// cargo test -p nucleus-commerce-conformance
+    /// cargo test -p nucleus-commerce-conformance --features serde_json/preserve_order
+    /// ```
+    ///
+    /// The explicit `--features` is the reliable way to reproduce it. Merely
+    /// selecting a cedar-bearing package alongside this one
+    /// (`-p nucleus-trust-registry --all-features`) does NOT turn the feature
+    /// on — measured, by checking that the pre-fix code still passed under
+    /// that selection and failed under this one. It is a full-workspace build
+    /// that unifies it in practice, which is why CI saw the drift (#2747) and
+    /// a standalone `cargo test -p ...` did not.
+    #[test]
+    fn exported_keys_are_sorted_whatever_the_build_graph_says() {
+        let json = export_vectors();
+        let runs = key_runs_by_depth(&json);
+
+        // Non-vacuity: a scan that found no keys would pass silently.
+        assert!(
+            runs.len() > 10,
+            "only {} key runs found — the scan is not reading the document",
+            runs.len()
+        );
+
+        for (depth, keys) in &runs {
+            let mut sorted = keys.clone();
+            sorted.sort();
+            assert_eq!(
+                keys, &sorted,
+                "keys at indent {depth} are emitted in insertion order rather than sorted, \
+                 so these bytes depend on whether `serde_json/preserve_order` is in this \
+                 build's feature graph: {keys:?}"
+            );
+        }
+    }
+
+    /// The artifact in the repo must be what the generator emits, or the
+    /// documented regeneration command produces a diff that is not a corpus
+    /// change.
+    #[test]
+    fn the_committed_artifact_is_what_the_generator_emits() {
+        let committed = include_str!("../../../examples/independent-conformance/vectors.json");
+        assert_eq!(
+            export_vectors().trim_end(),
+            committed.trim_end(),
+            "examples/independent-conformance/vectors.json is stale — regenerate it with \
+             `cargo run -p nucleus-commerce-conformance --example vectors`"
+        );
+    }
 }

--- a/crates/nucleus-node/src/firecracker_config.rs
+++ b/crates/nucleus-node/src/firecracker_config.rs
@@ -111,6 +111,13 @@ pub(crate) struct JailLayout {
 
 /// In-jail names. Fixed, not derived from the host path: a jailed Firecracker
 /// sees `/kernel`, never `/var/lib/nucleus/images/<sha>/vmlinux`.
+/// Default size of a node-provisioned scratch disk. Sparse, so this is a
+/// ceiling on what the guest may write to `/work`, not an upfront cost. Four
+/// GiB is what the #2789 report used by hand to confirm `/work` became
+/// writable. Sizing from the pod's `resources` is the obvious follow-up.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+pub(crate) const DEFAULT_SCRATCH_BYTES: u64 = 4 * 1024 * 1024 * 1024;
+
 #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 pub(crate) mod in_jail {
     pub const KERNEL: &str = "/kernel";
@@ -190,7 +197,11 @@ pub(crate) struct JailResource {
 /// The config file and the log file are NOT here: they are produced rather than
 /// relocated, so `prepare_jail` writes them directly.
 #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
-pub(crate) fn jail_resources(image: &nucleus_spec::ImageSpec, spec: &PodSpec) -> Vec<JailResource> {
+pub(crate) fn jail_resources(
+    image: &nucleus_spec::ImageSpec,
+    spec: &PodSpec,
+    scratch_is_node_provisioned: bool,
+) -> Vec<JailResource> {
     let mut resources = vec![
         JailResource {
             host_source: image.kernel_path.clone(),
@@ -222,13 +233,20 @@ pub(crate) fn jail_resources(image: &nucleus_spec::ImageSpec, spec: &PodSpec) ->
         },
     ];
 
+    // A NODE-PROVISIONED scratch disk is created at its in-jail path already
+    // (see `provision_pod_scratch`), so there is nothing to bring inside and a
+    // `JailResource` for it would try to hard-link the file onto itself. Only a
+    // caller-supplied `scratch_path` names a file that lives elsewhere on the
+    // host and has to be placed.
     if let Some(ref scratch) = image.scratch_path {
-        resources.push(JailResource {
-            host_source: scratch.clone(),
-            in_jail: in_jail::SCRATCH,
-            // `lower_drives` gives scratch `is_read_only: false` unconditionally.
-            placement: Placement::HardLinkOnly,
-        });
+        if !scratch_is_node_provisioned {
+            resources.push(JailResource {
+                host_source: scratch.clone(),
+                in_jail: in_jail::SCRATCH,
+                // `lower_drives` gives scratch `is_read_only: false` unconditionally.
+                placement: Placement::HardLinkOnly,
+            });
+        }
     }
 
     // A custom seccomp filter is opened by Firecracker AFTER the chroot, so the
@@ -285,6 +303,119 @@ fn place_resource(resource: &JailResource, dest: &Path) -> Result<(), String> {
     }
 }
 
+/// The per-pod scratch disk that makes `/work` writable (#2789).
+///
+/// `/work` mounts `/dev/vdb`, which exists only when a scratch drive is
+/// attached — and nothing created one, so a `codegen` pod met `EROFS` on its
+/// first write. The other route to a writable guest, `read_only: false`, is the
+/// one #2784 closed: it writes through the shared rootfs artifact.
+///
+/// BORN INSIDE THE JAIL. Under the jailer `lower_drives` gives the drive a
+/// `path_on_host` of `in_jail::SCRATCH`, resolved after `chroot`, so the file
+/// must exist at `jail_root/scratch.ext4`. Creating it there leaves no
+/// host-side source to bring in — no hard link, so none of the cross-device
+/// failure modes `Placement` exists to reason about. `jail_resources` skips it
+/// for that reason.
+///
+/// FAIL-SAFE. `None`, not an error, when the disk cannot be made (no
+/// `mkfs.ext4`, no space): the caller then boots with no scratch drive, exactly
+/// today's behaviour. This can add a writable `/work`; it cannot turn a pod
+/// that boots into one that does not. The reason is logged, because a silently
+/// read-only `/work` is the bug being fixed. The image is sparse, so 4 GiB
+/// costs what the guest writes, and it is removed with the jail.
+/// Decide what image the pod boots with, and whether its scratch disk is the
+/// node's. Unchanged when the spec names a `scratch_path`, when there is no
+/// jail to make one in, or when making one failed — the last being the fallback
+/// that keeps this unable to break a boot. Here, not at the call site, so the
+/// decision is testable without a node.
+#[cfg(target_os = "linux")]
+pub(crate) fn scratch_for_pod(
+    image: &nucleus_spec::ImageSpec,
+    jail_layout: Option<&JailLayout>,
+    uid: u32,
+    gid: u32,
+) -> (nucleus_spec::ImageSpec, bool) {
+    let mut effective = image.clone();
+    if effective.scratch_path.is_some() {
+        return (effective, false);
+    }
+    let Some(jail) = jail_layout else {
+        return (effective, false);
+    };
+    match provision_pod_scratch(&jail.jail_root, DEFAULT_SCRATCH_BYTES, uid, gid) {
+        Some(path) => {
+            effective.scratch_path = Some(path);
+            (effective, true)
+        }
+        None => (effective, false),
+    }
+}
+
+#[cfg(target_os = "linux")]
+pub(crate) fn provision_pod_scratch(
+    jail_root: &Path,
+    size_bytes: u64,
+    uid: u32,
+    gid: u32,
+) -> Option<std::path::PathBuf> {
+    let path = jail_root.join(in_jail::SCRATCH.trim_start_matches('/'));
+
+    match build_scratch_image(jail_root, &path, size_bytes, uid, gid) {
+        Ok(()) => Some(path),
+        Err(err) => {
+            tracing::warn!(
+                scratch = %path.display(),
+                error = %err,
+                "could not provision a scratch disk; /work will be read-only in this pod.                  Install e2fsprogs (mkfs.ext4) on the node host, or give the spec its own                  image.scratch_path."
+            );
+            // Leave nothing half-made behind for the next boot to trip over.
+            let _ = std::fs::remove_file(&path);
+            None
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn build_scratch_image(
+    jail_root: &Path,
+    path: &Path,
+    size_bytes: u64,
+    uid: u32,
+    gid: u32,
+) -> Result<(), String> {
+    use std::os::unix::fs::chown;
+
+    // `prepare_jail` also does this and the jailer tolerates an existing root;
+    // doing it here lets the disk be made BEFORE the config that declares the
+    // drive is written, which is what keeps the fallback honest.
+    std::fs::create_dir_all(jail_root)
+        .map_err(|e| format!("creating {}: {e}", jail_root.display()))?;
+
+    let file =
+        std::fs::File::create(path).map_err(|e| format!("creating {}: {e}", path.display()))?;
+    file.set_len(size_bytes)
+        .map_err(|e| format!("sizing {} to {size_bytes} bytes: {e}", path.display()))?;
+    drop(file);
+
+    let out = std::process::Command::new("mkfs.ext4")
+        .args(["-q", "-F", &path.display().to_string()])
+        .output()
+        .map_err(|e| format!("running mkfs.ext4: {e}"))?;
+    if !out.status.success() {
+        return Err(format!(
+            "mkfs.ext4 failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        ));
+    }
+
+    // Firecracker runs unprivileged after the jailer's drop, and the guest
+    // writes through this disk — a root-owned image would leave `/work`
+    // read-only for the very workload it exists to serve. Same reasoning, and
+    // the same uid/gid, as every other file `prepare_jail` chowns.
+    chown(path, Some(uid), Some(gid)).map_err(|e| format!("chown {}: {e}", path.display()))?;
+    Ok(())
+}
+
 /// Build the jail's contents so the jailer has something to chroot into.
 ///
 /// ORDERING. This runs BEFORE the jailer is spawned, which is safe because the
@@ -306,6 +437,7 @@ pub(crate) fn prepare_jail(
     config_json: &[u8],
     uid: u32,
     gid: u32,
+    scratch_is_node_provisioned: bool,
 ) -> Result<(), String> {
     use std::os::unix::fs::chown;
 
@@ -318,7 +450,7 @@ pub(crate) fn prepare_jail(
 
     let mut placed: Vec<std::path::PathBuf> = Vec::new();
 
-    for resource in jail_resources(image, spec) {
+    for resource in jail_resources(image, spec, scratch_is_node_provisioned) {
         let dest = layout.host_path(resource.in_jail);
         place_resource(&resource, &dest)?;
         placed.push(dest);
@@ -1038,7 +1170,7 @@ mod tests {
     /// A read-only rootfs may be copied, because nothing writes through it.
     #[test]
     fn rw_rootfs_is_hard_link_only() {
-        let rw = jail_resources(&image(false, false), &base_spec());
+        let rw = jail_resources(&image(false, false), &base_spec(), false);
         let rootfs = rw
             .iter()
             .find(|r| r.in_jail == in_jail::ROOTFS)
@@ -1050,7 +1182,7 @@ mod tests {
              jail is torn down"
         );
 
-        let ro = jail_resources(&image(true, false), &base_spec());
+        let ro = jail_resources(&image(true, false), &base_spec(), false);
         let rootfs = ro
             .iter()
             .find(|r| r.in_jail == in_jail::ROOTFS)
@@ -1071,7 +1203,7 @@ mod tests {
     /// jail entry shared the artifact's inode with `links=2`.
     #[test]
     fn a_writable_rootfs_is_the_artifact_itself_not_a_copy() {
-        let rw = jail_resources(&image(false, false), &base_spec());
+        let rw = jail_resources(&image(false, false), &base_spec(), false);
         let rootfs = rw
             .iter()
             .find(|r| r.in_jail == in_jail::ROOTFS)
@@ -1659,7 +1791,7 @@ mod tests {
         );
         let config_json = serde_json::to_vec_pretty(&config).expect("serialize");
 
-        prepare_jail(&layout, &img, &spec, &config_json, uid, gid).expect("prepare_jail");
+        prepare_jail(&layout, &img, &spec, &config_json, uid, gid, false).expect("prepare_jail");
 
         // Every path the config names, except the vsock socket, which Firecracker
         // creates itself at boot — so what must exist for it is the writable jail
@@ -1691,7 +1823,7 @@ mod tests {
         );
 
         // Re-running must be idempotent: pods get relaunched.
-        prepare_jail(&layout, &img, &spec, &config_json, uid, gid)
+        prepare_jail(&layout, &img, &spec, &config_json, uid, gid, false)
             .expect("prepare_jail must be idempotent");
 
         cleanup_jail(&layout);
@@ -1744,7 +1876,7 @@ mod tests {
         for (read_only, scratch) in [(true, true), (true, false), (false, true), (false, false)] {
             let img = image(read_only, scratch);
             let spec = base_spec();
-            let resources = jail_resources(&img, &spec);
+            let resources = jail_resources(&img, &spec, false);
             let drives = lower_drives(&img, true);
 
             for drive in &drives {
@@ -1812,7 +1944,7 @@ mod tests {
             )),
         );
 
-        let resources = jail_resources(&img, &spec);
+        let resources = jail_resources(&img, &spec, false);
         // Produced inside the jail rather than relocated into it.
         let produced = [in_jail::CONFIG, in_jail::LOG, in_jail::VSOCK];
         let mut known: Vec<&str> = resources.iter().map(|r| r.in_jail).collect();
@@ -2286,5 +2418,82 @@ mod tests {
             once.split_whitespace().filter(|t| *t == "pci=off").count(),
             1
         );
+    }
+
+    // ── Node-provisioned scratch disk (#2789) ────────────────────────────────
+
+    /// Born at its in-jail path already, so placing it would hard-link the file
+    /// onto itself — and having no host-side source is the whole point.
+    #[test]
+    fn a_node_provisioned_scratch_is_not_placed_into_the_jail() {
+        let mut img = image(true, true);
+        img.scratch_path = Some(PathBuf::from("/srv/jailer/.../root/scratch.ext4"));
+
+        let placed = jail_resources(&img, &base_spec(), true);
+        assert!(
+            !placed.iter().any(|r| r.in_jail == in_jail::SCRATCH),
+            "the node already made this file inside the jail; placing it would \
+             hard-link it onto itself: {placed:?}"
+        );
+    }
+
+    /// ...but a CALLER's `scratch_path` lives elsewhere and must still come in by
+    /// hard link: a copy would discard the guest's writes at teardown.
+    #[test]
+    fn a_caller_supplied_scratch_is_still_placed_hard_link_only() {
+        let placed = jail_resources(&image(true, true), &base_spec(), false);
+        let scratch = placed
+            .iter()
+            .find(|r| r.in_jail == in_jail::SCRATCH)
+            .expect("a caller-supplied scratch must be jailed");
+        assert_eq!(
+            scratch.placement,
+            Placement::HardLinkOnly,
+            "a copied scratch loses every guest write when the jail is torn down"
+        );
+    }
+
+    /// Whoever made it, the drive must reach the guest — that is what puts a
+    /// block device behind `/work`, at the in-jail path resolved after `chroot`.
+    #[test]
+    fn a_provisioned_scratch_still_reaches_the_guest_as_a_writable_drive() {
+        let drives = lower_drives(&image(true, true), true);
+        let scratch = drives
+            .iter()
+            .find(|d| d.drive_id == "scratch")
+            .expect("the scratch drive is what /work is mounted from");
+        assert_eq!(scratch.path_on_host, in_jail::SCRATCH);
+        assert!(
+            !scratch.is_read_only,
+            "a read-only scratch is the bug, not the fix"
+        );
+        assert!(!scratch.is_root_device);
+    }
+
+    /// No jail means nowhere to put one; a spec that names one keeps it. Both
+    /// report "not node-provisioned", so a caller's file is still placed.
+    #[test]
+    fn scratch_for_pod_leaves_a_caller_supplied_or_jailless_image_alone() {
+        let declared = image(true, true);
+        let (out, provisioned) = scratch_for_pod(&declared, None, 123, 100);
+        assert_eq!(out.scratch_path, declared.scratch_path);
+        assert!(!provisioned, "the caller's file is not the node's to skip");
+
+        let plain = image(true, false);
+        let (out, provisioned) = scratch_for_pod(&plain, None, 123, 100);
+        assert_eq!(out.scratch_path, None, "no jail, so nothing was made");
+        assert!(!provisioned);
+    }
+
+    /// The fallback IS the safety property: no scratch means no scratch DRIVE, so
+    /// the pod boots as before rather than dying on a drive it cannot open.
+    #[test]
+    fn no_scratch_means_no_drive_rather_than_a_broken_one() {
+        let drives = lower_drives(&image(true, false), true);
+        assert!(
+            !drives.iter().any(|d| d.drive_id == "scratch"),
+            "a declared drive with no file behind it would fail the boot"
+        );
+        assert_eq!(drives.len(), 1, "only the rootfs remains: {drives:?}");
     }
 }

--- a/crates/nucleus-node/src/main.rs
+++ b/crates/nucleus-node/src/main.rs
@@ -2371,6 +2371,16 @@ async fn spawn_firecracker_pod(
             &identity_grant,
             state.identity_vsock_port,
         );
+        // #2789: give the pod a writable `/work`. Decided before the config that
+        // declares the drive, so a disk that cannot be made means no drive
+        // rather than a dead boot.
+        let (effective_image, scratch_is_node_provisioned) = firecracker_config::scratch_for_pod(
+            image,
+            jail_layout.as_ref(),
+            state.jailer_uid.get(),
+            state.jailer_gid,
+        );
+        let image = &effective_image;
         // Live-path: mint the session capability token. It is served to the
         // guest over the workload API (`FETCH_TASK_TOKEN`, per-pod socket) — no
         // longer written to the kernel cmdline — so `from_spec` does not take
@@ -2429,6 +2439,7 @@ async fn spawn_firecracker_pod(
                 &jail_config_json,
                 state.jailer_uid.get(),
                 state.jailer_gid,
+                scratch_is_node_provisioned,
             ) {
                 cleanup_net_resources(
                     &state.network_allocator,


### PR DESCRIPTION
Closes #2789, #2751.

## What this is

- **#2789 — a `codegen` pod cannot write.** `/work` mounts `/dev/vdb`, which exists only when a scratch drive is attached, and nothing ever created one: `setup` installs a kernel and a rootfs and no scratch image, and `run.rs`'s `build_pod_spec` sets `scratch_path: None`. So the first write an agent attempts fails with a raw `EROFS`, and the only supported fix was to know about a field the README never mentions and hand-make an ext4 inside the Lima VM as root. The other route to a writable guest, `read_only: false`, is the one #2784 closed — it writes through the shared rootfs artifact. The node now provisions one when the spec did not.

- **#2751 — a published artifact whose bytes depend on what else is in the build graph.** `export_vectors()` builds a `serde_json::Value`, whose map type is chosen at compile time: `BTreeMap` (sorted) normally, `IndexMap` (insertion order) under `serde_json/preserve_order`, which cedar unifies ON in full-workspace builds. Two people running the documented regeneration command could commit different files for the same 16 cases.

## The product test

**More agency** for #2789: a principal can now delegate work that writes, which is the thing `codegen` exists for and which did not function. **More confidence** for #2751: the corpus a third party reads to demonstrate conformance is reproducible rather than incidentally sorted.

## Invariants kept

No default widened, no ceiling raised. Two things worth checking rather than taking on trust:

**#2789 is fail-safe by construction.** The decision is made after `jail_layout` is known but BEFORE the Firecracker config that declares the drive is written. If the disk cannot be made — no `mkfs.ext4`, no space — `scratch_path` stays `None`, the config declares no scratch drive, and the pod boots exactly as it does today. This can add a writable `/work`; it cannot turn a pod that boots into one that does not. A test pins that no-scratch means no *drive* rather than a declared drive with no file behind it.

**The placement distinction #2786 established is preserved.** A node-provisioned disk is born at its in-jail path (`lower_drives` gives it a `path_on_host` Firecracker resolves after `chroot`), so there is no host-side source, no hard link, and none of the cross-device failure modes `Placement` reasons about — `jail_resources` skips it, and placing it would hard-link the file onto itself. A **caller-supplied** `scratch_path` still names a file elsewhere and is still placed `HardLinkOnly`, because a copy would discard the guest's writes at teardown. Both cases are pinned by separate tests.

The disk is chowned to the jailer uid/gid: Firecracker runs unprivileged after the drop, and a root-owned image would leave `/work` read-only for the very workload it exists to serve — the same reasoning and the same uid as every other file `prepare_jail` chowns. It is sparse, so 4 GiB costs what the guest writes, and it is removed with the jail.

## Validation

On the pushed head, `9420a73`. **TESTED.**

- `cargo test -p nucleus-node` — 448, 0 failed (5 new).
- `cargo test -p nucleus-commerce-conformance` — 0 failed (2 new).
- fmt clean; clippy `--all-targets` clean on both crates.
- `scripts/check-line-ratchet.sh` — OK across 669 files. `nucleus-node/src/main.rs` (4045) and `firecracker_config.rs` (2500) are both **exactly at ceiling**, so the prose in those files is tighter than I would otherwise write; nothing was dropped to fit except my own wording, and no ceiling was raised.
- Red-on-defect confirmed for `a_node_provisioned_scratch_is_not_placed_into_the_jail` (skip removed) and for both #2751 tests.

**#2751's proof needed care, and the obvious reproduction does not work.** Selecting a cedar-bearing package alongside the crate (`-p nucleus-trust-registry --all-features`) does NOT turn `preserve_order` on — the pre-fix code still passes under it. `--features serde_json/preserve_order` does. Measured all four ways:

| | feature off | feature ON |
|---|---|---|
| **without fix** | pass (a `BTreeMap` already sorted) | **both tests FAIL** |
| **with fix** | pass | pass |

so the test is not passing vacuously, and the command in its doc comment is the one that actually reproduces the defect. The artifact is **byte-identical** after this change — the point is to make that state reproducible rather than incidental.

**NOT verified end to end:** I have no KVM host, so no pod was booted with the scratch disk. Verified here are the placement decision, the drive lowering, and the fallback. The `a real nucleus pod boots and is enforced (x86_64)` gate is what proves the rest, and it runs on this PR — if it reds, that is mine to fix.

**One follow-up left open:** the scratch size is a fixed 4 GiB default (what the #2789 report used by hand to confirm `/work` became writable). Sizing it from the pod's `resources` is the obvious next step; a fixed default is what makes the common case work at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011XqKAavF6twdyXTgzTHg6r

---
_Generated by [Claude Code](https://claude.ai/code/session_011XqKAavF6twdyXTgzTHg6r)_