### PR TITLE
fix(nucleus): the decision-scope check is enforced in release, and thirty copies become one

### DIFF
--- a/crates/nucleus/src/command.rs
+++ b/crates/nucleus/src/command.rs
@@ -407,11 +407,7 @@ impl<'a> Executor<'a> {
         decision: &DecisionToken,
         authority: Authority,
     ) -> Result<Output> {
-        debug_assert_eq!(
-            decision.operation(),
-            Operation::RunBash,
-            "DecisionToken operation mismatch"
-        );
+        crate::decision_scope::require_decision_for(decision.operation(), Operation::RunBash)?;
         // Fail-closed isolation gate: refuse unless containment is declared and
         // meets the policy's required isolation (most-paranoid #2).
         self.enforce_isolation()?;
@@ -475,20 +471,50 @@ impl<'a> Executor<'a> {
     ///
     /// Requires an `Authority` (mint via `preflight_action`, then wrap). This is
     /// the executor-proof gate: an un-preflighted spawn is a *compile* error, not a
-    /// runtime check. The following omits the proof and does **not** compile
-    /// (mirrors the sealed-bundle `compile_fail` doctest in
-    /// `nucleus_ifc_kernel::discharge`):
+    /// runtime check.
+    ///
+    /// ## Why the snippet below passes the wrong number of arguments on purpose
+    ///
+    /// This doctest used to omit the last argument entirely:
+    ///
+    /// ```ignore
+    /// let _ = executor.run_args(args, None, None, dt);   // four arguments
+    /// ```
+    ///
+    /// and its comment claimed the snippet failed because "the sealed proof is
+    /// missing". **It did not.** Compiled directly, that snippet reports
+    ///
+    /// ```text
+    /// error[E0061]: this method takes 5 arguments but 4 arguments were supplied
+    /// ```
+    ///
+    /// — measured, not inferred. `compile_fail` passes when a snippet fails for
+    /// ANY reason, so an arity error satisfied it exactly as well as a missing
+    /// authority would: the test would have stayed green if the fifth parameter
+    /// were `verbose: bool`. It pinned the arity of the signature and nothing
+    /// about authorisation (ADR 0007 D-3, and I-1 — a gate whose green is
+    /// indistinguishable from vacuity). The comment also named
+    /// `&DischargedBundle`, a parameter this signature has not had for some time.
+    ///
+    /// So the snippet now supplies the right NUMBER of arguments and the wrong
+    /// KIND, which makes the failure a type error about `Authority` specifically:
     ///
     /// ```compile_fail
     /// use nucleus::Executor;
     /// use nucleus::portcullis::kernel::DecisionToken;
     ///
     /// fn un_preflighted_spawn(executor: &Executor, args: &[String], dt: &DecisionToken) {
-    ///     // No trailing `&DischargedBundle` — the sealed proof is missing, so
-    ///     // this call cannot be typed. There is no way to spawn without one.
-    ///     let _ = executor.run_args(args, None, None, dt);
+    ///     // Right arity, no authority. `()` is not an `Authority`, and an
+    ///     // `Authority` cannot be conjured — `Authority::new` takes a sealed
+    ///     // `DischargedBundle` whose constructor is private to discharge.
+    ///     let _ = executor.run_args(args, None, None, dt, ());
     /// }
     /// ```
+    ///
+    /// Established by perturbation rather than assumed, the discipline the
+    /// `Authority` doctests in `portcullis-effects` already document: pass a real
+    /// `Authority` as that fifth argument and the snippet COMPILES, so the failure
+    /// does depend on the authority and on nothing else.
     pub fn run_args(
         &self,
         args: &[String],
@@ -497,11 +523,7 @@ impl<'a> Executor<'a> {
         decision: &DecisionToken,
         authority: Authority,
     ) -> Result<Output> {
-        debug_assert_eq!(
-            decision.operation(),
-            Operation::RunBash,
-            "DecisionToken operation mismatch"
-        );
+        crate::decision_scope::require_decision_for(decision.operation(), Operation::RunBash)?;
         self.run_args_internal(args, stdin, directory, None, authority)
     }
 
@@ -515,11 +537,7 @@ impl<'a> Executor<'a> {
         approval: &ApprovalToken,
         authority: Authority,
     ) -> Result<Output> {
-        debug_assert_eq!(
-            decision.operation(),
-            Operation::RunBash,
-            "DecisionToken operation mismatch"
-        );
+        crate::decision_scope::require_decision_for(decision.operation(), Operation::RunBash)?;
         self.run_args_internal(args, stdin, directory, Some(approval), authority)
     }
 
@@ -603,11 +621,7 @@ impl<'a> Executor<'a> {
         approval: &ApprovalToken,
         authority: Authority,
     ) -> Result<Output> {
-        debug_assert_eq!(
-            decision.operation(),
-            Operation::RunBash,
-            "DecisionToken operation mismatch"
-        );
+        crate::decision_scope::require_decision_for(decision.operation(), Operation::RunBash)?;
         // Fail-closed isolation gate (most-paranoid #2).
         self.enforce_isolation()?;
         // Check temporal constraints
@@ -668,11 +682,7 @@ impl<'a> Executor<'a> {
         decision: &DecisionToken,
         authority: Authority,
     ) -> Result<Output> {
-        debug_assert_eq!(
-            decision.operation(),
-            Operation::RunBash,
-            "DecisionToken operation mismatch"
-        );
+        crate::decision_scope::require_decision_for(decision.operation(), Operation::RunBash)?;
         // Fail-closed isolation gate (most-paranoid #2).
         self.enforce_isolation()?;
         // Check temporal constraints
@@ -722,11 +732,7 @@ impl<'a> Executor<'a> {
         approval: &ApprovalToken,
         authority: Authority,
     ) -> Result<Output> {
-        debug_assert_eq!(
-            decision.operation(),
-            Operation::RunBash,
-            "DecisionToken operation mismatch"
-        );
+        crate::decision_scope::require_decision_for(decision.operation(), Operation::RunBash)?;
         // Fail-closed isolation gate (most-paranoid #2).
         self.enforce_isolation()?;
         // Check temporal constraints

--- a/crates/nucleus/src/decision_scope.rs
+++ b/crates/nucleus/src/decision_scope.rs
@@ -1,0 +1,101 @@
+//! The decision must be about the operation being performed — in every profile.
+//!
+//! Thirty call sites in `command.rs` and `sandbox.rs` carried this check as
+//!
+//! ```ignore
+//! debug_assert_eq!(decision.operation(), op, "DecisionToken operation mismatch");
+//! ```
+//!
+//! `debug_assert_eq!` compiles to nothing when `debug_assertions` is off, which
+//! is every release build — so in a shipped binary a `DecisionToken` minted for
+//! `ReadFiles` and handed to a `RunBash` entry point was accepted exactly as
+//! readily as the right one. The two paths were indistinguishable at the call
+//! site (ADR 0007 I-3: the error path and the allow path may not share an exit
+//! status), and the `decision` parameter had no consumer at all there
+//! (ADR 0007 B-5: a declaration with no consumer is a defect).
+//!
+//! In a debug build it was not much better: `debug_assert_eq!` **panics**. A
+//! mismatched token aborted the process rather than refusing the operation, so
+//! neither profile did the thing a reference monitor is supposed to do.
+//!
+//! Thirty copies of one rule is also thirty chances for one of them to drift
+//! (ADR 0007 G-1: if a fact is written twice, delete one; D-2: a safety-critical
+//! check is not replicated per call site). This is the one copy.
+//!
+//! # What this does and does not claim
+//!
+//! This is a **defence in depth**, not the primary gate. The authority spend is
+//! the enforcement: `Authority::spend_on` binds a discharged bundle to the
+//! concrete act, and `Sandbox::spend_as` refuses an authority earned for a
+//! different operation. What this adds is that the *decision the reference
+//! monitor made upstream* is also about the operation now being performed, so a
+//! caller cannot present a decision about one act while spending an authority
+//! for another.
+
+use portcullis::Operation;
+
+use crate::error::NucleusError;
+
+/// Refuse a decision that was made about a different operation.
+///
+/// Returns [`NucleusError::ScopeMismatch`] — the same class the authority spend
+/// uses for "earned for a different action", because that is what this is.
+///
+/// Checked in every profile. That is the whole point; see the module docs.
+pub(crate) fn require_decision_for(
+    decision_op: Operation,
+    performing: Operation,
+) -> Result<(), NucleusError> {
+    if decision_op == performing {
+        return Ok(());
+    }
+    Err(NucleusError::ScopeMismatch {
+        reason: format!("decision authorises {decision_op:?}, this effect is {performing:?}"),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_matching_decision_is_accepted() {
+        assert!(require_decision_for(Operation::RunBash, Operation::RunBash).is_ok());
+    }
+
+    /// THE regression. Under `debug_assert_eq!` this case PANICKED in a debug
+    /// build and was SILENTLY ACCEPTED in a release one. It is now a refusal in
+    /// both.
+    #[test]
+    fn a_decision_about_another_operation_is_refused() {
+        let err = require_decision_for(Operation::ReadFiles, Operation::RunBash)
+            .expect_err("a decision about ReadFiles must not authorise RunBash");
+        assert!(
+            matches!(err, NucleusError::ScopeMismatch { .. }),
+            "a decision for the wrong operation is a scope mismatch, got {err:?}"
+        );
+    }
+
+    /// The message has to name BOTH sides, or it sends the reader to inspect
+    /// the wrong one. `15e3530f`'s lesson (ADR 0007 A-4) in a smaller place.
+    #[test]
+    fn the_refusal_names_what_was_held_and_what_was_attempted() {
+        let err = require_decision_for(Operation::ReadFiles, Operation::RunBash)
+            .expect_err("must refuse");
+        let msg = err.to_string();
+        assert!(msg.contains("ReadFiles"), "{msg}");
+        assert!(msg.contains("RunBash"), "{msg}");
+    }
+
+    /// Non-vacuity: the refusal test above would pass against a function that
+    /// refused everything. Every operation must authorise itself.
+    #[test]
+    fn every_operation_authorises_itself() {
+        for op in Operation::ALL {
+            assert!(
+                require_decision_for(op, op).is_ok(),
+                "{op:?} must authorise itself"
+            );
+        }
+    }
+}

--- a/crates/nucleus/src/lib.rs
+++ b/crates/nucleus/src/lib.rs
@@ -64,6 +64,9 @@
 mod approval;
 mod budget;
 mod command;
+/// One enforced check that the decision is about the operation being performed.
+/// Was thirty `debug_assert_eq!` copies, which compile out in release.
+mod decision_scope;
 mod error;
 mod hardening;
 mod pod;

--- a/crates/nucleus/src/sandbox.rs
+++ b/crates/nucleus/src/sandbox.rs
@@ -143,11 +143,7 @@ impl Sandbox {
         decision: &DecisionToken,
         authority: Authority,
     ) -> Result<File> {
-        debug_assert_eq!(
-            decision.operation(),
-            Operation::ReadFiles,
-            "DecisionToken operation mismatch"
-        );
+        crate::decision_scope::require_decision_for(decision.operation(), Operation::ReadFiles)?;
         self.spend_as(authority, Operation::ReadFiles, SinkClass::AuditLogAppend)?;
         self.open_internal(path.as_ref(), None)
     }
@@ -160,11 +156,7 @@ impl Sandbox {
         approval: &ApprovalToken,
         authority: Authority,
     ) -> Result<File> {
-        debug_assert_eq!(
-            decision.operation(),
-            Operation::ReadFiles,
-            "DecisionToken operation mismatch"
-        );
+        crate::decision_scope::require_decision_for(decision.operation(), Operation::ReadFiles)?;
         self.spend_as(authority, Operation::ReadFiles, SinkClass::AuditLogAppend)?;
         self.open_internal(path.as_ref(), Some(approval))
     }
@@ -193,11 +185,7 @@ impl Sandbox {
         decision: &DecisionToken,
         authority: Authority,
     ) -> Result<File> {
-        debug_assert_eq!(
-            decision.operation(),
-            Operation::EditFiles,
-            "DecisionToken operation mismatch"
-        );
+        crate::decision_scope::require_decision_for(decision.operation(), Operation::EditFiles)?;
         self.spend_as(authority, Operation::EditFiles, SinkClass::WorkspaceWrite)?;
         self.open_with_internal(path.as_ref(), options, None)
     }
@@ -211,11 +199,7 @@ impl Sandbox {
         approval: &ApprovalToken,
         authority: Authority,
     ) -> Result<File> {
-        debug_assert_eq!(
-            decision.operation(),
-            Operation::EditFiles,
-            "DecisionToken operation mismatch"
-        );
+        crate::decision_scope::require_decision_for(decision.operation(), Operation::EditFiles)?;
         self.spend_as(authority, Operation::EditFiles, SinkClass::WorkspaceWrite)?;
         self.open_with_internal(path.as_ref(), options, Some(approval))
     }
@@ -245,11 +229,7 @@ impl Sandbox {
         decision: &DecisionToken,
         authority: Authority,
     ) -> Result<File> {
-        debug_assert_eq!(
-            decision.operation(),
-            Operation::WriteFiles,
-            "DecisionToken operation mismatch"
-        );
+        crate::decision_scope::require_decision_for(decision.operation(), Operation::WriteFiles)?;
         self.spend_as(authority, Operation::WriteFiles, SinkClass::WorkspaceWrite)?;
         self.create_internal(path.as_ref(), None)
     }
@@ -262,11 +242,7 @@ impl Sandbox {
         approval: &ApprovalToken,
         authority: Authority,
     ) -> Result<File> {
-        debug_assert_eq!(
-            decision.operation(),
-            Operation::WriteFiles,
-            "DecisionToken operation mismatch"
-        );
+        crate::decision_scope::require_decision_for(decision.operation(), Operation::WriteFiles)?;
         self.spend_as(authority, Operation::WriteFiles, SinkClass::WorkspaceWrite)?;
         self.create_internal(path.as_ref(), Some(approval))
     }
@@ -288,11 +264,7 @@ impl Sandbox {
         decision: &DecisionToken,
         authority: Authority,
     ) -> Result<Vec<u8>> {
-        debug_assert_eq!(
-            decision.operation(),
-            Operation::ReadFiles,
-            "DecisionToken operation mismatch"
-        );
+        crate::decision_scope::require_decision_for(decision.operation(), Operation::ReadFiles)?;
         self.spend_as(authority, Operation::ReadFiles, SinkClass::AuditLogAppend)?;
         self.read_internal(path.as_ref(), None)
     }
@@ -305,11 +277,7 @@ impl Sandbox {
         approval: &ApprovalToken,
         authority: Authority,
     ) -> Result<Vec<u8>> {
-        debug_assert_eq!(
-            decision.operation(),
-            Operation::ReadFiles,
-            "DecisionToken operation mismatch"
-        );
+        crate::decision_scope::require_decision_for(decision.operation(), Operation::ReadFiles)?;
         self.spend_as(authority, Operation::ReadFiles, SinkClass::AuditLogAppend)?;
         self.read_internal(path.as_ref(), Some(approval))
     }
@@ -331,11 +299,7 @@ impl Sandbox {
         decision: &DecisionToken,
         authority: Authority,
     ) -> Result<String> {
-        debug_assert_eq!(
-            decision.operation(),
-            Operation::ReadFiles,
-            "DecisionToken operation mismatch"
-        );
+        crate::decision_scope::require_decision_for(decision.operation(), Operation::ReadFiles)?;
         self.spend_as(authority, Operation::ReadFiles, SinkClass::AuditLogAppend)?;
         self.read_to_string_internal(path.as_ref(), None)
     }
@@ -348,11 +312,7 @@ impl Sandbox {
         approval: &ApprovalToken,
         authority: Authority,
     ) -> Result<String> {
-        debug_assert_eq!(
-            decision.operation(),
-            Operation::ReadFiles,
-            "DecisionToken operation mismatch"
-        );
+        crate::decision_scope::require_decision_for(decision.operation(), Operation::ReadFiles)?;
         self.spend_as(authority, Operation::ReadFiles, SinkClass::AuditLogAppend)?;
         self.read_to_string_internal(path.as_ref(), Some(approval))
     }
@@ -414,7 +374,7 @@ impl Sandbox {
         // minted — "bundle authorises EditFiles/WorkspaceWrite, this effect is
         // WriteFiles/WorkspaceWrite" — measured on a live pod.
         let op = self.write_operation_for(path.as_ref());
-        debug_assert_eq!(decision.operation(), op, "DecisionToken operation mismatch");
+        crate::decision_scope::require_decision_for(decision.operation(), op)?;
         self.spend_as(authority, op, SinkClass::WorkspaceWrite)?;
         self.write_internal(path.as_ref(), contents, None)
     }
@@ -440,7 +400,7 @@ impl Sandbox {
         // minted — "bundle authorises EditFiles/WorkspaceWrite, this effect is
         // WriteFiles/WorkspaceWrite" — measured on a live pod.
         let op = self.write_operation_for(path.as_ref());
-        debug_assert_eq!(decision.operation(), op, "DecisionToken operation mismatch");
+        crate::decision_scope::require_decision_for(decision.operation(), op)?;
         self.spend_as(authority, op, SinkClass::WorkspaceWrite)?;
         self.write_internal(path.as_ref(), contents, Some(approval))
     }
@@ -488,11 +448,7 @@ impl Sandbox {
         decision: &DecisionToken,
         authority: Authority,
     ) -> Result<()> {
-        debug_assert_eq!(
-            decision.operation(),
-            Operation::WriteFiles,
-            "DecisionToken operation mismatch"
-        );
+        crate::decision_scope::require_decision_for(decision.operation(), Operation::WriteFiles)?;
         self.spend_as(authority, Operation::WriteFiles, SinkClass::WorkspaceWrite)?;
         self.create_dir_internal(path.as_ref(), None)
     }
@@ -505,11 +461,7 @@ impl Sandbox {
         approval: &ApprovalToken,
         authority: Authority,
     ) -> Result<()> {
-        debug_assert_eq!(
-            decision.operation(),
-            Operation::WriteFiles,
-            "DecisionToken operation mismatch"
-        );
+        crate::decision_scope::require_decision_for(decision.operation(), Operation::WriteFiles)?;
         self.spend_as(authority, Operation::WriteFiles, SinkClass::WorkspaceWrite)?;
         self.create_dir_internal(path.as_ref(), Some(approval))
     }
@@ -531,11 +483,7 @@ impl Sandbox {
         decision: &DecisionToken,
         authority: Authority,
     ) -> Result<()> {
-        debug_assert_eq!(
-            decision.operation(),
-            Operation::WriteFiles,
-            "DecisionToken operation mismatch"
-        );
+        crate::decision_scope::require_decision_for(decision.operation(), Operation::WriteFiles)?;
         self.spend_as(authority, Operation::WriteFiles, SinkClass::WorkspaceWrite)?;
         self.create_dir_all_internal(path.as_ref(), None)
     }
@@ -548,11 +496,7 @@ impl Sandbox {
         approval: &ApprovalToken,
         authority: Authority,
     ) -> Result<()> {
-        debug_assert_eq!(
-            decision.operation(),
-            Operation::WriteFiles,
-            "DecisionToken operation mismatch"
-        );
+        crate::decision_scope::require_decision_for(decision.operation(), Operation::WriteFiles)?;
         self.spend_as(authority, Operation::WriteFiles, SinkClass::WorkspaceWrite)?;
         self.create_dir_all_internal(path.as_ref(), Some(approval))
     }
@@ -574,11 +518,7 @@ impl Sandbox {
         decision: &DecisionToken,
         authority: Authority,
     ) -> Result<()> {
-        debug_assert_eq!(
-            decision.operation(),
-            Operation::EditFiles,
-            "DecisionToken operation mismatch"
-        );
+        crate::decision_scope::require_decision_for(decision.operation(), Operation::EditFiles)?;
         self.spend_as(authority, Operation::EditFiles, SinkClass::WorkspaceWrite)?;
         self.remove_file_internal(path.as_ref(), None)
     }
@@ -591,11 +531,7 @@ impl Sandbox {
         approval: &ApprovalToken,
         authority: Authority,
     ) -> Result<()> {
-        debug_assert_eq!(
-            decision.operation(),
-            Operation::EditFiles,
-            "DecisionToken operation mismatch"
-        );
+        crate::decision_scope::require_decision_for(decision.operation(), Operation::EditFiles)?;
         self.spend_as(authority, Operation::EditFiles, SinkClass::WorkspaceWrite)?;
         self.remove_file_internal(path.as_ref(), Some(approval))
     }
@@ -617,11 +553,7 @@ impl Sandbox {
         decision: &DecisionToken,
         authority: Authority,
     ) -> Result<()> {
-        debug_assert_eq!(
-            decision.operation(),
-            Operation::EditFiles,
-            "DecisionToken operation mismatch"
-        );
+        crate::decision_scope::require_decision_for(decision.operation(), Operation::EditFiles)?;
         self.spend_as(authority, Operation::EditFiles, SinkClass::WorkspaceWrite)?;
         self.remove_dir_internal(path.as_ref(), None)
     }
@@ -634,11 +566,7 @@ impl Sandbox {
         approval: &ApprovalToken,
         authority: Authority,
     ) -> Result<()> {
-        debug_assert_eq!(
-            decision.operation(),
-            Operation::EditFiles,
-            "DecisionToken operation mismatch"
-        );
+        crate::decision_scope::require_decision_for(decision.operation(), Operation::EditFiles)?;
         self.spend_as(authority, Operation::EditFiles, SinkClass::WorkspaceWrite)?;
         self.remove_dir_internal(path.as_ref(), Some(approval))
     }
@@ -654,13 +582,14 @@ impl Sandbox {
     }
 
     /// Check if a path exists within the sandbox.
-    pub fn exists(&self, path: impl AsRef<Path>, decision: &DecisionToken) -> bool {
-        debug_assert_eq!(
-            decision.operation(),
-            Operation::ReadFiles,
-            "DecisionToken operation mismatch"
-        );
-        self.exists_internal(path.as_ref(), None)
+    ///
+    /// `Result<bool>`, not `bool`: a decision minted for another operation means
+    /// this cannot answer, and "I did not look" must not be returned as "it is
+    /// not there" (ADR 0007 A-2). Before the scope check was enforced there was
+    /// no third answer to return, so there was no reason for the `Result`.
+    pub fn exists(&self, path: impl AsRef<Path>, decision: &DecisionToken) -> Result<bool> {
+        crate::decision_scope::require_decision_for(decision.operation(), Operation::ReadFiles)?;
+        Ok(self.exists_internal(path.as_ref(), None))
     }
 
     /// Check if a path exists within the sandbox with an approval token.
@@ -669,13 +598,9 @@ impl Sandbox {
         path: impl AsRef<Path>,
         decision: &DecisionToken,
         approval: &ApprovalToken,
-    ) -> bool {
-        debug_assert_eq!(
-            decision.operation(),
-            Operation::ReadFiles,
-            "DecisionToken operation mismatch"
-        );
-        self.exists_internal(path.as_ref(), Some(approval))
+    ) -> Result<bool> {
+        crate::decision_scope::require_decision_for(decision.operation(), Operation::ReadFiles)?;
+        Ok(self.exists_internal(path.as_ref(), Some(approval)))
     }
 
     fn exists_internal(&self, path: &Path, approval: Option<&ApprovalToken>) -> bool {
@@ -891,11 +816,7 @@ impl Sandbox {
         decision: &DecisionToken,
         authority: Authority,
     ) -> Result<Sandbox> {
-        debug_assert_eq!(
-            decision.operation(),
-            Operation::ReadFiles,
-            "DecisionToken operation mismatch"
-        );
+        crate::decision_scope::require_decision_for(decision.operation(), Operation::ReadFiles)?;
         self.spend_as(authority, Operation::ReadFiles, SinkClass::AuditLogAppend)?;
         self.open_dir_internal(path.as_ref(), None)
     }
@@ -908,11 +829,7 @@ impl Sandbox {
         approval: &ApprovalToken,
         authority: Authority,
     ) -> Result<Sandbox> {
-        debug_assert_eq!(
-            decision.operation(),
-            Operation::ReadFiles,
-            "DecisionToken operation mismatch"
-        );
+        crate::decision_scope::require_decision_for(decision.operation(), Operation::ReadFiles)?;
         self.spend_as(authority, Operation::ReadFiles, SinkClass::AuditLogAppend)?;
         self.open_dir_internal(path.as_ref(), Some(approval))
     }
@@ -1097,6 +1014,45 @@ mod tests {
     /// effect and recorded nothing. `Authority::spend` now refuses an
     /// unwitnessed spend outright, and these six write tests failing is what
     /// surfaced it.
+    /// A decision minted for one operation must not authorise another, AND the
+    /// refusal has to survive `--release`.
+    ///
+    /// This check used to be `debug_assert_eq!` at thirty call sites. That
+    /// compiles to nothing when `debug_assertions` is off, so in every shipped
+    /// build a `ReadFiles` decision handed to the write path was accepted
+    /// exactly as readily as the right one — the allow path and the error path
+    /// were the same path (ADR 0007 I-3). In a debug build it PANICKED rather
+    /// than refusing, which is not a refusal either.
+    ///
+    /// Run this with `cargo test --release -p nucleus` as well as without. That
+    /// is the falsifier: on the old code the release run let the write through.
+    #[test]
+    fn a_decision_for_another_operation_cannot_authorise_a_write() {
+        let tmp = tempfile::tempdir().unwrap();
+        let policy = PermissionLattice::permissive();
+        let mut kernel = Kernel::new(policy.clone());
+        let sandbox = Sandbox::new(&policy, tmp.path()).unwrap();
+
+        // A decision about READING, presented to the WRITE entry point.
+        let read_token = token(&mut kernel, Operation::ReadFiles, "ok.txt");
+        let err = sandbox
+            .write(
+                "ok.txt",
+                b"nope",
+                &read_token,
+                Authority::new(allowed_bundle()),
+            )
+            .expect_err("a ReadFiles decision must not authorise a write");
+        assert!(
+            matches!(err, NucleusError::ScopeMismatch { .. }),
+            "expected a scope mismatch, got {err:?}"
+        );
+        assert!(
+            !tmp.path().join("ok.txt").exists(),
+            "the refusal must happen BEFORE the bytes land"
+        );
+    }
+
     #[test]
     fn a_sandbox_write_leaves_a_receipt() {
         let tmp = tempfile::tempdir().unwrap();


### PR DESCRIPTION
Two defects, both found by taking ADR 0007 (#2796) at its word and driving the existing gates red first.

## 1. Thirty checks that did nothing in release

`command.rs` and `sandbox.rs` carried this at **thirty** call sites:

```rust
debug_assert_eq!(decision.operation(), op, "DecisionToken operation mismatch");
```

`debug_assert_eq!` compiles to nothing when `debug_assertions` is off — which is every release build. So in a shipped binary, a `DecisionToken` minted for `ReadFiles` and handed to the **write** path was accepted exactly as readily as the right one. The allow path and the error path were the same path (**I-3**), and the `decision` parameter had no consumer there at all (**B-5**).

A debug build was not much better: it **panicked**. Aborting the process is not refusing the operation, so neither profile did what a reference monitor is supposed to do.

Thirty copies of one rule is also thirty chances for one to drift (**G-1**, **D-2**). They become one `decision_scope::require_decision_for`, returning `NucleusError::ScopeMismatch` — the class the authority spend already uses for *"an authority earned for a different action was presented"*, because that is what this is — checked in every profile.

**Scope, stated plainly:** this is defence in depth, not the primary gate, and the module doc says so. The authority spend is the enforcement — `Authority::spend_on` binds the discharged bundle to the concrete act, and `Sandbox::spend_as` refuses one earned elsewhere. What this adds is that the decision the reference monitor made *upstream* is also about the operation now being performed.

## 2. A `compile_fail` doctest that pinned arity

`Executor::run_args`'s doctest omitted the last argument and claimed it failed because *"the sealed proof is missing"*. Compiled directly, that snippet reports:

```
error[E0061]: this method takes 5 arguments but 4 arguments were supplied
```

Measured, not inferred. `compile_fail` passes when a snippet fails for **any** reason, so an arity error satisfied it just as well — the test would have stayed green if the fifth parameter were `verbose: bool`. It pinned the arity of the signature and nothing about authorisation (**D-3**, and **I-1**: a gate whose green is indistinguishable from vacuity). Its comment also named `&DischargedBundle`, a parameter the signature has not had for some time.

The snippet now supplies the right **number** of arguments and the wrong **kind**, making the failure a type error about `Authority` specifically. Established by perturbation rather than assumed — the discipline the `portcullis-effects` `Authority` doctests already document:

| | result |
|---|---|
| `run_args(args, None, None, dt, ())` | does not compile — type error on `Authority` |
| same call with a real `Authority` | **compiles** (positive control, verified) |

## `Sandbox::exists` returns `Result<bool>`

Once the scope check is enforced there is a third answer — *"I did not look"* — and returning it as `false` would be **A-2** exactly: "I could not look" reported as "I looked and it was not there". Both `exists` and `exists_approved` had **zero callers**, so nothing breaks.

## A-19, on the real defect

Not a synthetic violation — the actual `debug_assert`:

| | result |
|---|---|
| restore `debug_assert_eq!` at the write site, `cargo test --release` | **FAILS** — the mismatched decision is accepted and the write goes through |
| the fix | **passes in debug and release** |

That is the whole claim in one experiment: the old check was not merely weaker in release, it was absent.

## Validation

- `nucleus` 75 + 2 green in **both** `--release` and debug.
- `nucleus-node`, `nucleus-tool-proxy` green under `--all-features`.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean, excluding `nucleus-verifier-service` (needs wasm-pack output; fails on `main` too).
- `cargo fmt --check --all` clean; `check-line-ratchet.sh --strict` passes, 673 files.

**Not claimed:** that no other `debug_assert` in the tree guards a security property. This PR covers the thirty sharing the `DecisionToken operation mismatch` message. A sweep for the general shape is a separate piece of work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011XqKAavF6twdyXTgzTHg6r

---
_Generated by [Claude Code](https://claude.ai/code/session_011XqKAavF6twdyXTgzTHg6r)_