### PR TITLE
fix(ifc): spawning an agent required no integrity, because it fell into a wildcard

### DIFF
--- a/crates/nucleus-ifc-kernel/src/flow.rs
+++ b/crates/nucleus-ifc-kernel/src/flow.rs
@@ -671,18 +671,51 @@ pub fn required_authority(op: Operation) -> AuthorityLevel {
 }
 
 /// Minimum integrity required for an operation to proceed.
+///
+/// Exhaustive on purpose, and it did not used to be. The final arm was
+/// `_ => IntegLevel::Adversarial` under a comment reading "Read/web operations
+/// have no integrity requirement" -- but `SpawnAgent` is neither read nor web,
+/// and it landed there too. `Adversarial` is `0`, the BOTTOM of the lattice, so
+/// the wildcard handed the weakest possible requirement to anything its own
+/// comment did not describe: spawning an agent was permitted on adversarially
+/// controlled data.
+///
+/// That was the only classifier in the tree that disagreed. `SpawnAgent` is
+/// `is_exfiltration_vector()`, is `is_exfil_operation()`, takes
+/// `AuthorityLevel::Suggestive` from [`required_authority`] directly above --
+/// which is exhaustive and has no wildcard to fall into -- and lowers to
+/// `SinkClass::AgentSpawn`. Every other operation in `is_exfil_operation` has an
+/// explicit arm here. `SpawnAgent` was the one that did not.
+///
+/// ADR 0007 B-3 (a `_ =>` arm in a policy match denies; prefer no fallthrough at
+/// all) and E-2 (a policy enum is matched exhaustively -- a new variant must
+/// break the build). With the wildcard gone, a fourteenth `Operation` is a
+/// compile error here rather than a silent grant.
 pub fn required_integrity(op: Operation) -> IntegLevel {
     match op {
         // Exfil operations require trusted integrity
         Operation::GitPush | Operation::CreatePr => IntegLevel::Trusted,
-        // Write operations require at least untrusted
+        // Write, exec and spawn operations require at least untrusted.
+        //
+        // `SpawnAgent` sits with `ManagePods`: both create an execution context,
+        // and [`required_authority`] already groups them. `Untrusted` rather
+        // than `Trusted` keeps this to the smallest change that closes the hole
+        // -- it refuses adversarial input, which is the defect. Whether spawning
+        // deserves `Trusted` alongside GitPush is a separate policy judgement and
+        // is deliberately not made here.
         Operation::WriteFiles
         | Operation::EditFiles
         | Operation::RunBash
         | Operation::GitCommit
-        | Operation::ManagePods => IntegLevel::Untrusted,
-        // Read/web operations have no integrity requirement
-        _ => IntegLevel::Adversarial,
+        | Operation::ManagePods
+        | Operation::SpawnAgent => IntegLevel::Untrusted,
+        // Read and web operations have no integrity requirement. Listed rather
+        // than defaulted: this is the set the old comment claimed, now stated.
+        Operation::ReadFiles
+        | Operation::GlobSearch
+        | Operation::GrepSearch
+        | Operation::WebSearch
+        | Operation::WebFetch => IntegLevel::Adversarial,
     }
 }
 
@@ -1355,6 +1388,70 @@ pub fn verify_noninterference(input: &ZkFlowInput) -> VerificationResult {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// THE regression. `SpawnAgent` used to fall into a `_ => Adversarial`
+    /// wildcard whose own comment said "Read/web operations", so spawning an
+    /// agent was permitted on adversarially controlled data -- the weakest
+    /// requirement in the lattice, handed out by a default.
+    ///
+    /// The property, not the constant: anything the tree already calls an
+    /// exfiltration operation must require MORE than the bottom. Pinning
+    /// `SpawnAgent => Untrusted` would pass just as happily if a fourteenth
+    /// operation appeared and fell into a new wildcard.
+    #[test]
+    fn no_exfil_operation_may_run_on_adversarial_input() {
+        for op in Operation::ALL {
+            if !crate::ifc_ops::is_exfil_operation(op) {
+                continue;
+            }
+            assert!(
+                required_integrity(op) > IntegLevel::Adversarial,
+                "{op:?} is an exfil operation and requires only {:?}, the bottom of the \
+                 lattice -- it can be performed on adversarially controlled data",
+                required_integrity(op)
+            );
+        }
+    }
+
+    /// Non-vacuity: the test above would pass against a function that demanded
+    /// `Trusted` for everything. Pure observation must stay unrestricted, or the
+    /// fix would have closed the hole by breaking reads.
+    #[test]
+    fn pure_observation_keeps_no_integrity_requirement() {
+        for op in [
+            Operation::ReadFiles,
+            Operation::GlobSearch,
+            Operation::GrepSearch,
+            Operation::WebSearch,
+        ] {
+            assert_eq!(
+                required_integrity(op),
+                IntegLevel::Adversarial,
+                "{op:?} is observation and must not acquire an integrity floor"
+            );
+        }
+    }
+
+    /// The two sibling classifiers must agree about which operations are
+    /// privileged. They disagreed about exactly one, and only because this one
+    /// had a wildcard to fall into and the other did not.
+    #[test]
+    fn required_integrity_and_required_authority_agree_on_what_is_privileged() {
+        for op in Operation::ALL {
+            let privileged_by_authority = required_authority(op) != AuthorityLevel::NoAuthority;
+            let privileged_by_integrity = required_integrity(op) > IntegLevel::Adversarial;
+            if privileged_by_authority && !privileged_by_integrity {
+                assert_eq!(
+                    op,
+                    Operation::WebFetch,
+                    "{op:?} needs authority to instruct but no integrity of input; \
+                     WebFetch is the one documented exception (it can exfiltrate via \
+                     URL params yet reads adversarial content by design)"
+                );
+            }
+        }
+    }
+
     use crate::Freshness;
 
     fn make_node(kind: NodeKind, label: IFCLabel, op: Option<Operation>) -> FlowNode {

--- a/docs/adr/0007-make-the-defect-unwritable.md
+++ b/docs/adr/0007-make-the-defect-unwritable.md
@@ -148,6 +148,22 @@ unconditional*.
 `661606a9`: a total function from an open domain (strings) to a closed one
 (operations), whose fallthrough arm was chosen permissive. Close the domain — parse
 to an enum at the boundary — and the arm disappears.
+
+**Baseline measured 2026-09-11**, because "once the baseline is walked down" was
+written here without a number and a rule nobody can cost is a rule nobody starts:
+
+| crate | wildcard arms | audit result |
+|---|---|---|
+| `nucleus-ifc-kernel` | **9** | **one live grant**, fixed — `required_integrity` returned `IntegLevel::Adversarial`, the bottom of the lattice, for `SpawnAgent`, under a comment reading "Read/web operations". The other eight are accessors and test-helper panics. |
+| `portcullis-core` | **26** | clean. `operation_to_node_kind`'s fallthrough is `NodeKind::OutboundAction` — the most scrutinized kind, so it denies as this rule asks. `promote`'s `_ => {}` is vacuous today: all five `DerivationClass` variants are handled above it. |
+| `portcullis` | **83** | clean. Overwhelmingly test-helper `panic!`, `None`, and no-ops. The `_ => false` predicates (`subject_matches` ×2, `labels_match`) fail closed — no match means not granted. |
+
+So the rule found exactly one live defect in 118 arms, and the cost of turning the
+lint on is dominated by `portcullis`'s 83 — almost none of which are policy
+matches. A scoped lint (policy crates, non-test targets) is therefore much cheaper
+than the raw count suggests, and is the proposed next step rather than a
+workspace-wide deny.
+
 *Enforcement: clippy `wildcard_enum_match_arm`, once the baseline is walked down;
 see §Enforcement for why it is not on today.*
 


### PR DESCRIPTION
ADR 0007 **B-3** and **E-2** both defer to `wildcard_enum_match_arm` *"once the baseline is walked down"*, and neither puts a number on it. Measured, 2026-09-11: `nucleus-ifc-kernel` **9**, `portcullis-core` **26**, `portcullis` **83**. The kernel is both the smallest and the one that actually holds the policy enums, so I read all nine. One is a live security defect.

## The defect

`required_integrity` — *"minimum integrity required for an operation to proceed"* — ended in:

```rust
// Read/web operations have no integrity requirement
_ => IntegLevel::Adversarial,
```

`IntegLevel::Adversarial` is `0`, the **bottom** of the lattice, so that arm hands out the *weakest possible* requirement. And `SpawnAgent` is neither read nor web. It landed there anyway.

**Spawning an agent was permitted on adversarially controlled data.**

Every other classifier in the tree disagrees:

| classifier | `SpawnAgent` |
|---|---|
| `is_exfiltration_vector()` | true — with `WebFetch`/`GitPush`/`CreatePr` |
| `is_exfil_operation()` | true — with `RunBash`/`WriteFiles`/`ManagePods` |
| `required_authority()` | `Suggestive` — grouped with `ManagePods` |
| `default_sink_class()` | `SinkClass::AgentSpawn` |
| **`required_integrity()`** | **`Adversarial`** — the bottom |

`required_authority` sits **directly above this function**, covers the same enum, and is already exhaustive — so it had no wildcard for `SpawnAgent` to fall into, and classified it correctly. Every operation in `is_exfil_operation` has an explicit arm here **except** `SpawnAgent`.

One variant, one missing arm, one permissive default. That is exactly the shape B-3 names (*a `_ =>` arm in a policy match denies*) and E-2 names (*a new variant must break the build*).

## The fix

Both arms spelled out; no wildcard. A fourteenth `Operation` is now a compile error here rather than a silent grant.

`SpawnAgent` joins `ManagePods` at `Untrusted`, not `Trusted` — both create an execution context, `required_authority` already groups them, and `Untrusted` is the smallest change that closes the hole (it refuses adversarial input, which *is* the defect). **Whether spawning deserves `Trusted` alongside `GitPush` is a separate policy judgement and is deliberately not made here.**

## Tests pin the property, not the constant

Pinning `SpawnAgent => Untrusted` would pass just as happily if a fourteenth operation appeared and fell into a new wildcard.

- `no_exfil_operation_may_run_on_adversarial_input` — anything the tree already calls exfil must require more than the bottom.
- `pure_observation_keeps_no_integrity_requirement` — **non-vacuity**: reads must stay unrestricted, so the fix cannot have closed the hole by tightening everything.
- `required_integrity_and_required_authority_agree_on_what_is_privileged` — the two siblings must agree, with `WebFetch` named as the one documented exception.

### A-19, against the real defect

| | result |
|---|---|
| restore the original wildcard | **RED** — `no_exfil_…` and `…agree_on_what_is_privileged` both fail |
| | `SpawnAgent is an exfil operation and requires only Adversarial, the bottom of the lattice -- it can be performed on adversarially controlled data` |
| the fix | **GREEN**, 39 flow tests |

The non-vacuity test stayed green in *both* runs, which is what shows the fix closed the hole rather than blanket-tightening.

## Validation

`nucleus-ifc-kernel` full suite green, including the **`extracted` Aeneas gate** (70); `portcullis-core`, `portcullis`, `nucleus-tool-proxy` green; **no drift in the generated Lean trees**; `clippy -D warnings`, `fmt`, `check-mediation.sh` and `check-line-ratchet.sh --strict` all clean.

## Not in this PR

The lint is **not wired**. `portcullis` alone has 83 wildcard arms, so `wildcard_enum_match_arm` cannot be turned on workspace-wide without walking that baseline down first — which is exactly what the ADR says. This PR fixes the one site among the kernel's nine that was a live grant; the remaining eight are accessors and test helpers, and the other two crates' baselines are now measured rather than unknown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011XqKAavF6twdyXTgzTHg6r

---
_Generated by [Claude Code](https://claude.ai/code/session_011XqKAavF6twdyXTgzTHg6r)_