### PR TITLE
docs(adr-0007): C-4's enforcement is wired, not proposed — and says what it covers

### DIFF
--- a/docs/adr/0007-make-the-defect-unwritable.md
+++ b/docs/adr/0007-make-the-defect-unwritable.md
@@ -205,8 +205,28 @@ The single most instructive record in the corpus, and the origin of this ADR.
 `f7f9719b`: `DischargedBundle` was `!Clone`, `!Copy`, `#[must_use]`, and replayable,
 because three methods took it by reference. Affine intent expressed with a non-affine
 calling convention.
-*Enforcement: dylint (proposed `authority_by_reference`) over the types in
-`portcullis-effects` that carry `#[must_use]` and lack `Clone`.*
+*Enforcement: **dylint, already wired — not proposed.** Corrected 2026-09-11; the
+line below used to read "proposed `authority_by_reference`", which understated what
+exists and would have had someone build a second pass beside a working one.*
+
+`tools/nucleus-mediation-lint` enforces the by-value half of this rule today. It
+closes a call graph and flags a publicly reachable path that reaches raw I/O
+without demanding an `Authority` **by value** — `&Authority` is explicitly not a
+boundary, and the pass carries a UI fixture named
+`borrowed_authority_is_not_a_boundary` for exactly that case.
+
+What it covers, precisely, because "dylint" alone reads as more than it is:
+
+| | |
+|---|---|
+| gates on | `MEDIATED_CRATES = ["portcullis_effects"]` — the sealed effect boundary, and the crate the Lean Tier-A mediation theorem is stated over |
+| advisory elsewhere | by design: outside that set a higher-order call is "a call-graph observation, not an unmediated sink", and the job deliberately does not gate on it |
+| not covered | a `&` on an affine type away from an effect boundary. That is the residue a narrower `authority_by_reference` would close, and it is the only part still proposed |
+| CI context | `Dylint passes (one pod)` — **not in `ci/required-checks.txt`.** So even the gating half reports through a context the merge rollup does not consult |
+
+Measured 2026-09-11: **0** `&Authority` in production code across `crates/`. The
+only occurrence in the tree is the lint's own UI fixture. C-4 holds today; what is
+missing is not compliance but a gate that would notice if it stopped holding.
 
 **C-5 — Capability and authority types are `!Clone`, `!Copy`, `#[must_use]`.**
 Necessary and — per C-4 — not sufficient. Stated separately so the derive list is


### PR DESCRIPTION
`CLAUDE.md` now calls **C-4** *"the one to know by heart, because it is the reason the ADR exists."* Its enforcement line said:

> *Enforcement: dylint (**proposed** `authority_by_reference`) …*

That understates what already exists, in the direction that costs work. `tools/nucleus-mediation-lint` enforces the by-value half **today** — someone reading "proposed" would have built a second pass beside a working one.

The lint closes a call graph and flags a publicly reachable path that reaches raw I/O without demanding an `Authority` **by value**. `&Authority` is explicitly not a boundary — the pass ships a UI fixture named `borrowed_authority_is_not_a_boundary` for exactly that case.

## What it actually covers

"dylint" alone reads as more than it is, so the correction spells out the scope:

| | |
|---|---|
| **gates on** | `MEDIATED_CRATES = ["portcullis_effects"]` — the sealed effect boundary, and the crate the Lean Tier-A mediation theorem is stated over |
| **advisory elsewhere** | by design: outside that set a higher-order call is *"a call-graph observation, not an unmediated sink"*, and the job deliberately does not gate on it |
| **not covered** | a `&` on an affine type *away from* an effect boundary — the residue a narrower `authority_by_reference` would close, and the only part still genuinely proposed |
| **CI context** | `Dylint passes (one pod)` — **not in `ci/required-checks.txt`** |

## The row worth acting on

That last one: even the gating half reports through a context the merge rollup does not consult. The lint enforcing the ADR's flagship rule can go red without blocking anything.

**This PR does not act on it**, deliberately. Adding a context to branch protection is an owner decision with the sequencing #2755 documents at length — add it before every branch can produce it and you block all open PRs. It is recorded here so it reads as a gap rather than as coverage, which is the convention this ADR states for its own enforcement column:

> the tier is named on every rule so that "review" is on the record as a gap rather than mistaken for coverage.

## Measured

**0** `&Authority` in production across `crates/`. The only occurrence in the tree is the lint's own UI fixture. `Authority::spend` and `spend_on` both take `self` by value, so the type is affine in its API as well as its derives.

**C-4 holds today. What is missing is not compliance but a gate that would notice if it stopped holding.**

## Validation

Documentation only — no code, no gate, no default changed. `check-line-ratchet.sh --strict` (680 files) and `ci/no-vendor-strings.sh` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011XqKAavF6twdyXTgzTHg6r

---
_Generated by [Claude Code](https://claude.ai/code/session_011XqKAavF6twdyXTgzTHg6r)_