### PR TITLE
feat(ci-spec): name the advisory contexts, so a gap reads as a gap

### DIFF
--- a/crates/xtask/src/ci_spec.rs
+++ b/crates/xtask/src/ci_spec.rs
@@ -25,6 +25,76 @@ pub fn check(repo: Option<String>, json: bool) -> Result<()> {
     Ok(())
 }
 
+/// `ci-spec advisory`: every check context a workflow produces that the
+/// required-check ledger does not list.
+///
+/// A required check blocks a merge; everything else is advisory, and an advisory
+/// gate can be red on `main` indefinitely with nothing to notice. That is not a
+/// hypothetical here: `a real nucleus pod boots and is enforced (x86_64)` --
+/// the only lane that boots a real microVM and proves the enforcement end to end
+/// -- went red on `main` on 2026-09-11 and a PR was enqueued past it.
+///
+/// This does NOT say every context should be required. Release jobs, nightly
+/// lanes, the explicitly "informational" shadow gates and scheduled workflows are
+/// advisory on purpose. It says what the set IS, so the ones that are advisory by
+/// accident can be told from the ones that are advisory by decision -- the same
+/// thing `ci/inline-gates.txt` does for gate steps, and the same reason ADR 0007
+/// gives for naming an enforcement tier on every rule: so a gap reads as a gap
+/// rather than as coverage.
+///
+/// Contexts still carrying an unexpanded `${{ ... }}` are reported separately.
+/// They are matrix jobs the model could not expand (`matrix_opaque`), so their
+/// real context names are unknown -- and "unknown" is not "unrequired" (A-2).
+pub fn advisory(repo: Option<String>) -> Result<()> {
+    let root = repo_root(repo)?;
+    let model = ci_spec::loader::from_repo(&root)?;
+    let required: std::collections::BTreeSet<&str> =
+        model.ledger.contexts.iter().map(String::as_str).collect();
+
+    let mut produced = std::collections::BTreeSet::new();
+    for w in &model.workflows {
+        for j in &w.jobs {
+            for c in j.contexts() {
+                produced.insert(c);
+            }
+        }
+    }
+
+    let (opaque, concrete): (Vec<&String>, Vec<&String>) = produced
+        .iter()
+        .filter(|c| !required.contains(c.as_str()))
+        .partition(|c| c.contains("${{"));
+
+    println!(
+        "# Check contexts produced by a workflow and NOT listed in\n\
+         # ci/required-checks.txt. Advisory: nothing blocks a merge on them.\n\
+         #\n\
+         # Not a to-do list. Release, nightly and shadow lanes belong here. The\n\
+         # point is that the set is visible, so advisory-by-accident can be told\n\
+         # from advisory-by-decision."
+    );
+    println!(
+        "#\n# produced={} required={} advisory={} unexpanded={}",
+        produced.len(),
+        required.len(),
+        concrete.len(),
+        opaque.len()
+    );
+    for c in &concrete {
+        println!("{c}");
+    }
+    if !opaque.is_empty() {
+        println!(
+            "\n# Unexpanded matrix contexts -- the model could not resolve these names,\n\
+             # so whether they are required is UNKNOWN, which is not the same as no."
+        );
+        for c in &opaque {
+            println!("# ?  {c}");
+        }
+    }
+    Ok(())
+}
+
 /// `ci-spec inline-gates`: print the inline-gate inventory in
 /// `ci/inline-gates.txt` shape, carrying forward any falsifier already on
 /// record so regenerating never loses an annotation.

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -219,6 +219,15 @@ enum CiSpecCmd {
         json: bool,
     },
     /// Print the inline-gate inventory (ci/inline-gates.txt shape).
+    /// Every check context a workflow produces that ci/required-checks.txt does
+    /// NOT list. Advisory contexts block nothing, so one can be red on main
+    /// indefinitely -- which happened on 2026-09-11. Prints the set so
+    /// advisory-by-accident can be told from advisory-by-decision.
+    Advisory {
+        /// Repository root (defaults to the current directory).
+        #[arg(long)]
+        repo: Option<String>,
+    },
     InlineGates {
         #[arg(long)]
         repo: Option<String>,
@@ -326,6 +335,7 @@ fn main() -> Result<()> {
         }
         Command::CiSpec { cmd } => match cmd {
             CiSpecCmd::Check { repo, json } => ci_spec::check(repo, json),
+            CiSpecCmd::Advisory { repo } => ci_spec::advisory(repo),
             CiSpecCmd::InlineGates { repo } => ci_spec::inline_gates(repo),
             CiSpecCmd::LiveParity { repo, github, json } => {
                 ci_spec::live_parity(repo, &github, json)


### PR DESCRIPTION
A required check blocks a merge. Everything else is advisory — and an advisory gate can be red on `main` indefinitely with nothing to notice.

**Not hypothetical.** On 2026-09-11 `a real nucleus pod boots and is enforced (x86_64)` — the only lane that boots a real microVM and proves the enforcement end to end — went red on `main` after #2758 changed a wire format the check was scraping, and a PR was enqueued straight past it. Finding that took reading a job log. Nothing in the tree could answer *"which gates block, and which only report?"*

## What lands

`cargo xtask ci-spec advisory`, from the model `ci-spec` already builds:

```
produced=166  required=48  advisory=113  unexpanded=5
```

The 113 include release, nightly and shadow lanes that are advisory **on purpose**. They also include, measured today:

| context | what it is |
|---|---|
| `CI configuration is sound (CI-1)` | the invariant checker itself |
| `Check line ceiling` / `Check clippy ceiling` | the ratchets `CLAUDE.md`'s mandate rests on |
| `Required-check ledger and merge-queue pin match GitHub` | live-parity — the ledger drift detector |
| `Vendor-neutrality gate` | `CLAUDE.md`'s *first* mandate |
| `Dylint passes (one pod)` | ADR 0007 **C-4**'s enforcement |
| `Kani (IFC kernel: anti-prompt-injection flow harnesses)` | the prompt-injection proofs |
| `a real nucleus pod boots and is enforced (x86_64)` | the end-to-end Tier-2 proof |
| `Live-path gates (one pod)` | |
| `adversary probe distinguishes contained / breach / inconclusive` | |

## What this deliberately does not claim

**It is not a to-do list, and it does not say those should all be required.** Making a context required is a branch-protection decision with the sequencing #2755 documents at length — add one before every branch can produce it and you block every open PR.

It says what the set **is**, so advisory-by-accident can be told from advisory-by-decision. That is exactly what `ci/inline-gates.txt` does for gate steps, and the reason ADR 0007 names an enforcement tier on every rule:

> the tier is named on every rule so that "review" is on the record as a gap rather than mistaken for coverage.

## The five unexpanded contexts

Reported **separately** and never counted as advisory:

```
# ?  Build (${{ matrix.target }})
# ?  The ${{ matrix.gate }} gate, run the gatehouse way, agrees ...
```

These are matrix jobs the model could not expand (`matrix_opaque`), so their real context names are unknown — and **unknown is not unrequired**. ADR 0007 **A-2**: "I could not look" is never "I looked and it was fine". Folding them into the advisory count would have inflated it by five and made the number a guess.

## Validation

Rust, per the gates-are-Rust mandate, reusing `Job::contexts()` and the ledger the model already carries rather than re-parsing either.

`xtask` and `ci-spec` green; `clippy --all-targets --all-features -- -D warnings` clean; `fmt --check` clean; `cargo xtask ci-spec check` → *ok: every invariant holds*; `check-line-ratchet.sh --strict` passes, 680 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011XqKAavF6twdyXTgzTHg6r

---
_Generated by [Claude Code](https://claude.ai/code/session_011XqKAavF6twdyXTgzTHg6r)_