### PR TITLE
fix(nucleus): a malformed command stops being reported as a policy refusal

### DIFF
--- a/crates/nucleus/src/error.rs
+++ b/crates/nucleus/src/error.rs
@@ -60,8 +60,24 @@ pub enum NucleusError {
         reason: String,
     },
 
-    /// Command execution denied by policy.
-    #[error("command denied: '{command}' blocked by policy")]
+    /// Command execution refused. `reason` says by what.
+    ///
+    /// The rendering used to be `"command denied: '{command}' blocked by policy"`
+    /// -- a constant that named POLICY whatever the cause was, with `reason`
+    /// carried in the struct and never printed. Four different reasons reach this
+    /// variant and only two of them are policy:
+    ///
+    ///   blocked by command policy          <- policy
+    ///   blocked by the command lattice     <- policy
+    ///   malformed command (unbalanced quotes)   <- a PARSE error
+    ///   <the argv predicate's own message>      <- a predicate, with detail
+    ///
+    /// So a command with an unbalanced quote was reported as refused by a policy
+    /// that had no part in it. ADR 0007 A-4, and the same shape `15e3530f` fixed
+    /// for paths -- `crates/nucleus-perf/src/main.rs:990` still records the cost
+    /// of that one: "`EISDIR` ... for a long time was reported as `blocked by
+    /// policy`, so it read as a refusal rather than `that is a directory`".
+    #[error("command denied: '{command}': {reason}")]
     CommandDenied {
         /// The command that was denied.
         command: String,
@@ -173,4 +189,68 @@ pub enum NucleusError {
     /// IO error from underlying operation.
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
+}
+
+#[cfg(test)]
+mod command_denied_says_why_tests {
+    use super::*;
+
+    fn rendered(reason: &str) -> String {
+        NucleusError::CommandDenied {
+            command: "grep 'unbalanced".to_string(),
+            reason: reason.to_string(),
+        }
+        .to_string()
+    }
+
+    /// THE regression. `Display` was the constant
+    /// `"command denied: '{command}' blocked by policy"` and `reason` was never
+    /// printed, so a PARSE failure was reported as a policy refusal — sending
+    /// the reader to inspect a policy that had no part in it (ADR 0007 A-4).
+    #[test]
+    fn a_parse_failure_is_not_reported_as_a_policy_refusal() {
+        let msg = rendered("malformed command (unbalanced quotes)");
+        assert!(
+            msg.contains("malformed command"),
+            "the cause must reach the reader: {msg}"
+        );
+        assert!(
+            !msg.contains("blocked by policy"),
+            "a parse error must not claim policy refused it: {msg}"
+        );
+    }
+
+    /// The complement, so the test above is not satisfied by a rendering that
+    /// simply never mentions policy. A real policy refusal must still say so.
+    #[test]
+    fn a_policy_refusal_still_says_policy() {
+        assert!(rendered("blocked by command policy").contains("policy"));
+        assert!(rendered("blocked by the command lattice").contains("lattice"));
+    }
+
+    /// Non-vacuity: both tests above would pass against a rendering that
+    /// dropped the command and printed only the reason. All four reasons that
+    /// reach this variant must render distinctly, and all must carry the
+    /// command, or the message is a constant again in a different disguise.
+    #[test]
+    fn every_reason_renders_distinctly_and_keeps_the_command() {
+        let reasons = [
+            "blocked by command policy",
+            "blocked by the command lattice",
+            "malformed command (unbalanced quotes)",
+            "argv predicate: NUL byte in argument 2",
+        ];
+        let mut seen: Vec<String> = reasons.iter().map(|r| rendered(r)).collect();
+        for m in &seen {
+            assert!(m.contains("grep 'unbalanced"), "the command is lost: {m}");
+        }
+        let before = seen.len();
+        seen.sort();
+        seen.dedup();
+        assert_eq!(
+            before,
+            seen.len(),
+            "two reasons render identically: {seen:?}"
+        );
+    }
 }


### PR DESCRIPTION
## The defect

`CommandDenied` carries a `reason` field. Its `Display` never printed it:

```rust
#[error("command denied: '{command}' blocked by policy")]
CommandDenied { command: String, reason: String }
```

The message was a **constant that named policy whatever the cause was**. Four different reasons reach this variant across sixteen construction sites, and only two of them are policy:

| reason | actually |
|---|---|
| `blocked by command policy` | policy ✓ |
| `blocked by the command lattice` | policy ✓ |
| `malformed command (unbalanced quotes)` | **a parse error** |
| *the argv predicate's own message* | **a predicate, with detail — dropped** |

So a command with an unbalanced quote was reported as refused by a policy that had no part in it. ADR 0007 **A-4** — *"an errno is not an authorization decision"* — and the same shape `15e3530f` fixed for paths.

## How I found it

The cost of that earlier one is still written down in the tree. `crates/nucleus-perf/src/main.rs:990`:

> `EISDIR` — which for a long time was reported as "blocked by policy", so it read as a refusal rather than "that is a directory"

That comment is about the *path* case, which was fixed. The identical shape survived in `CommandDenied`.

## The fix

`Display` renders the reason. **Checked before changing a wire message** — the #2762 lesson, where a probe keyed on a Debug string broke when the string legitimately changed. Nothing in `crates/`, `scripts/`, `.github/` or `tests/` matches the old text.

## Three tests, the third guarding the first two

- `a_parse_failure_is_not_reported_as_a_policy_refusal` — the regression.
- `a_policy_refusal_still_says_policy` — the complement, so a rendering that simply never mentions policy cannot satisfy the first.
- `every_reason_renders_distinctly_and_keeps_the_command` — **non-vacuity**: all four reasons must render *distinctly* and each must still carry the command. Otherwise the message is a constant again in a different disguise, which is precisely what it was.

### A-19, on the real defect

| | result |
|---|---|
| restore the original constant `Display` | **RED**, all three — including non-vacuity, because all four reasons collapse onto one string |
| the fix | **GREEN** |

## Validation

`nucleus`, `nucleus-tool-proxy`, `nucleus-node` green under `--all-features`; `clippy -D warnings` clean; `fmt --check` clean; `check-line-ratchet.sh --strict`, 681 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011XqKAavF6twdyXTgzTHg6r

---
_Generated by [Claude Code](https://claude.ai/code/session_011XqKAavF6twdyXTgzTHg6r)_