### PR TITLE
fix(trace-check): tell "the model has no rule for this" from "the queue broke the invariant"

### DIFF
--- a/crates/ci-spec/src/queue.rs
+++ b/crates/ci-spec/src/queue.rs
@@ -150,6 +150,22 @@ impl State {
         self.checks[i] = b;
     }
 
+    /// **Not a transition of the model.** The replay harness calls this to continue past a
+    /// re-enqueue-after-ejection, which GitHub performs routinely and `step` has no rule for:
+    /// `CiSpec.Queue.step` acts on `.enqueue p` only when `loc p = .waiting`, and nothing returns
+    /// `.ejected` to `.waiting` (`push` does exactly that for `.queued`, so the omission is
+    /// specific). PR #2755 was ejected and re-enqueued TWICE on 2026-09-10 before merging.
+    ///
+    /// This exists so the harness can distinguish "the model has no rule for this" from "the queue
+    /// broke the invariant" and keep checking the rest of the trace. It deliberately does NOT
+    /// widen the spec: `step` is unchanged, the Lean side is unchanged, and every use is counted
+    /// and reported. Widening the model means re-proving T4/T5/T6/T7 over a state space where a PR
+    /// can enter `enqLog` more than once — and T4, "merges in enqueue order", is the one that may
+    /// genuinely fail. See gatehouse `FINDINGS.md` F-47.
+    pub fn unmodelled_requeue(&mut self, p: u32) {
+        self.set_loc(p, Loc::Waiting);
+    }
+
     /// `eject s p`.
     fn eject(&mut self, p: u32) {
         self.set_loc(p, Loc::Ejected);

--- a/crates/ci-spec/src/trace.rs
+++ b/crates/ci-spec/src/trace.rs
@@ -58,6 +58,10 @@ pub struct Replay {
     pub ejections: usize,
     /// Transitions the model rejected, with the event and the reason.
     pub violations: Vec<String>,
+    /// Transitions GitHub performed that the model has no rule for, as opposed to transitions it
+    /// forbids. Counted and reported, never silently dropped: a harness that cannot tell the two
+    /// apart trains its readers to ignore it, which is exactly what happened for 23 hours.
+    pub unmodelled: Vec<String>,
     /// The window contained too little to check anything.
     pub vacuous: Option<String>,
 }
@@ -120,6 +124,7 @@ pub fn replay(events: &[TraceEvent]) -> Replay {
     let model = to_model_events(events);
     let mut s = State::init();
     let mut r = Replay {
+        unmodelled: Vec::new(),
         events: events.len(),
         enqueues: 0,
         merges: 0,
@@ -147,6 +152,23 @@ pub fn replay(events: &[TraceEvent]) -> Replay {
                 ) || matches!(why, Illegal::EmptyQueue) && s.enq_log.is_empty();
                 if truncated {
                     s = same;
+                    continue;
+                }
+                // Re-enqueue after ejection: the model has no rule for it, GitHub does it
+                // routinely. Record it as unmodelled, apply it anyway, and keep checking the rest
+                // of the trace — otherwise one missing rule cascades into every later event for
+                // that PR and fifteen reports share one cause. See gatehouse FINDINGS F-47.
+                if let (Ev::Enqueue(p), Illegal::NotWaiting(q)) = (*ev, &why)
+                    && *q == p
+                    && same.loc(p) == Loc::Ejected
+                {
+                    let mut fixed = same.clone();
+                    fixed.unmodelled_requeue(p);
+                    r.unmodelled.push(format!(
+                        "{} PR #{} re-enqueued after ejection — the model has no rule for this",
+                        src.at, src.pr
+                    ));
+                    s = try_step(fixed, *ev).unwrap_or_else(|b| b.0);
                     continue;
                 }
                 r.violations.push(format!(
@@ -245,5 +267,63 @@ mod tests {
         let r = replay(&t);
         assert!(r.violations.is_empty(), "{:?}", r.violations);
         assert_eq!(r.exit_code(), 0);
+    }
+
+    /// GitHub ejects a PR and adds it back. `CiSpec.Queue.step` has no rule for that, so the
+    /// harness must say "no rule" rather than "invariant broken" — and must keep going, or one
+    /// missing rule cascades into every later event for that PR.
+    #[test]
+    fn re_enqueue_after_ejection_is_unmodelled_not_a_violation() {
+        let t = vec![
+            ev("2026-09-10T01:00:00Z", 1, Kind::Added),
+            ev(
+                "2026-09-10T02:00:00Z",
+                1,
+                Kind::Removed {
+                    reason: "merge_conflict".into(),
+                },
+            ),
+            ev("2026-09-10T03:00:00Z", 1, Kind::Added),
+            ev("2026-09-10T04:00:00Z", 1, Kind::Merged),
+        ];
+        let r = replay(&t);
+        assert_eq!(r.unmodelled.len(), 1, "{:?}", r.unmodelled);
+        assert!(
+            r.violations.is_empty(),
+            "a missing rule was reported as a violation: {:?}",
+            r.violations
+        );
+        assert_eq!(r.exit_code(), 0);
+    }
+
+    /// The risk this classification carries, tested rather than asserted: a genuine out-of-order
+    /// merge must STILL fail. If compensating for the missing rule also swallowed real violations,
+    /// the check would be worse than the red it replaced.
+    #[test]
+    fn a_real_out_of_order_merge_still_fails_after_the_compensation() {
+        let t = vec![
+            ev("2026-09-10T01:00:00Z", 1, Kind::Added),
+            ev("2026-09-10T01:30:00Z", 2, Kind::Added),
+            // #2 merges while #1 is the head: the queue merging out of enqueue order.
+            ev("2026-09-10T02:00:00Z", 2, Kind::Merged),
+        ];
+        let r = replay(&t);
+        assert!(
+            !r.violations.is_empty(),
+            "an out-of-order merge was not reported"
+        );
+        assert_ne!(r.exit_code(), 0);
+    }
+
+    /// And the two must not be confusable: an out-of-order merge is never filed as unmodelled.
+    #[test]
+    fn a_real_violation_is_not_filed_as_unmodelled() {
+        let t = vec![
+            ev("2026-09-10T01:00:00Z", 1, Kind::Added),
+            ev("2026-09-10T01:30:00Z", 2, Kind::Added),
+            ev("2026-09-10T02:00:00Z", 2, Kind::Merged),
+        ];
+        let r = replay(&t);
+        assert!(r.unmodelled.is_empty(), "{:?}", r.unmodelled);
     }
 }

--- a/crates/xtask/src/ci_spec.rs
+++ b/crates/xtask/src/ci_spec.rs
@@ -459,6 +459,20 @@ pub fn trace_check(github: &str, since_hours: u64, json: bool) -> Result<()> {
         for v in &r.violations {
             println!("  VIOLATION: {v}");
         }
+        // Separated on purpose. A transition the model has no RULE for is a different fact from a
+        // transition it FORBIDS, and a report that conflates them is one its readers learn to
+        // ignore — which is what happened here for 23 hours. See gatehouse FINDINGS F-47.
+        for u in &r.unmodelled {
+            println!("  UNMODELLED: {u}");
+        }
+        if !r.unmodelled.is_empty() {
+            println!(
+                "  note: {} transition(s) the model has no rule for (re-enqueue after ejection). \
+                 The queue did not break an invariant; CiSpec.Queue cannot express this yet, and \
+                 T4_merge_order is proved where a PR enters enqLog at most once.",
+                r.unmodelled.len()
+            );
+        }
         if let Some(v) = &r.vacuous {
             println!("  UNDECIDED: {v}");
         }


### PR DESCRIPTION
`trace-check` has been red since 2026-09-10 with 15 rejected transitions, and the report gave no way
to tell which *kind* of fact they were. **It was ignored for 23+ hours.** A report that conflates
*"I cannot express this"* with *"you violated an invariant"* is one its readers learn to skip — and
that is exactly what happened.

## The cause, from both sides

`ci/lean/CiSpec/Queue.lean:88` acts on `.enqueue p` only `if s.loc p = .waiting`; `eject` (`:83`)
sets `.ejected`; **nothing returns `.ejected` to `.waiting`** — while `push` does exactly that for
`.queued`, so the omission is *specific*, not a general absence. `queue.rs:264` mirrors it faithfully,
so the Rust was never the defect and **the trace reconstruction was never lossy** (my earlier
hypothesis, recorded and now corrected in gatehouse `FINDINGS.md` F-45/F-47).

GitHub re-enqueues ejected PRs constantly. PR #2755:

```
Added 05:30 → Removed(merge_conflict) 08:24 → Added 15:20
            → Removed(merge_conflict) 18:36 → Added 04:47 → merged 05:44
```

## The result

Over 48h and 199 events: **18 unmodelled re-enqueues across 10 PRs, and ZERO violations.** Every one
of the original 15 was downstream of this single missing rule. **The queue never broke an
invariant.**

## This does not widen the spec

`step` is unchanged, Lean is unchanged, and `unmodelled_requeue` is named and documented as *not* a
transition of the model. Widening it means re-proving T4/T5/T6/T7 over a state space where a PR can
enter `enqLog` more than once — and **T4, "merges in enqueue order", is the one that may genuinely
fail**. That decision is not this change's to make. The count prints on every run so the gap cannot
go quiet.

## Tests — the second is the one that matters

The risk here is that compensating for a missing rule also swallows real defects.

1. Re-enqueue after ejection is unmodelled, not a violation, and the trace continues.
2. **A genuine out-of-order merge still fails.**
3. …and is never filed as unmodelled.

Driven red by removing the guard so everything is classified unmodelled: four tests fail, including
both of those. **My first perturbation — widening the `Loc::Ejected` condition — did not bite**,
because that is not the condition doing the protecting; the `Enqueue`/`NotWaiting` match is. Worth
saying, since a probe that does not bite is how a suite comes to certify nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)