### PR TITLE
gate: the same README restates a merge-queue constant, and nothing compared it

### DIFF
--- a/ci/fly-runner/README.md
+++ b/ci/fly-runner/README.md
@@ -57,8 +57,8 @@ checkout, toolchain or executable); a gate pool Machine has no volume.
 
 | pool | label | Machine | jobs |
 |---|---|---|---|
-| build | `nucleus-fly-build` | performance-8x, 32 GB, one volume each (8 × 40 GB + 8 × 20 GB); size 16, standby 16 | everything on `CI_BUILD_RUNNER`: workspace tests, clippy, live-path gates, hack, llvm-cov, dylint, the A2A example (27 `runs-on` sites) |
-| gate | `nucleus-fly-gate` | shared-cpu-8x, 16 GB, no volume; size 40, standby 40 | everything on `CI_RUNNER` (52 sites), opt-in |
+| build | `nucleus-fly-build` | performance-8x, 32 GB, one volume each (8 × 40 GB + 8 × 20 GB); size 16, standby 16 | everything on `CI_BUILD_RUNNER`: workspace tests, clippy, live-path gates, hack, llvm-cov, dylint, the A2A example (24 `runs-on` sites) |
+| gate | `nucleus-fly-gate` | shared-cpu-8x, 16 GB, no volume; size 40, standby 40 | everything on `CI_RUNNER` (54 sites), opt-in |
 
 Routing is the two repository variables the workflows already read:
 
@@ -70,7 +70,7 @@ gh variable set CI_RUNNER --repo coproduct-opensource/nucleus --body nucleus-fly
 
 The build pool alone removes the jobs that hold a hosted slot for 6 to 12 minutes; the short
 jobs left on hosted runners then flow. The gate pool takes the rest. Jobs that hard-code
-`ubuntu-latest` (44 sites) or `ubuntu-24.04` (13) stay hosted; those are the ones that need
+`ubuntu-latest` (48 sites) or `ubuntu-24.04` (16) stay hosted; those are the ones that need
 Docker, CodeQL or a hosted-only tool. The image here is a Rust build image (pinned
 toolchain, wasm target, clippy, rustfmt, nextest, sccache, just, node via `setup-node`,
 python3); a job on `CI_RUNNER` that needs elan, aeneas or kani installs it in-job today on

--- a/crates/xtask/src/fly_pools.rs
+++ b/crates/xtask/src/fly_pools.rs
@@ -40,6 +40,9 @@ const README: &str = "ci/fly-runner/README.md";
 const DRIFT: &str = "ci/fly-pools-drift.txt";
 /// The other config the same README restates numbers from.
 const QUEUE_TOML: &str = "ci/merge-queue.toml";
+/// The numeric merge-queue constants this README quotes. One today; the list is the extension
+/// point, and a key added here is compared without further code.
+const QUEUE_KEYS: &[&str] = &["max_entries_to_build"];
 
 /// The `POOLS = '...'` value, as the manager would receive it.
 pub fn pools_json(manager_toml: &str) -> Result<String> {
@@ -198,17 +201,17 @@ fn readme_queue_constants(root: &Path, readme: &str) -> Result<()> {
         .with_context(|| format!("reading {QUEUE_TOML}"))?;
     let joined: String = readme.split_whitespace().collect::<Vec<_>>().join(" ");
     let mut checked = 0usize;
-    for key in ["max_entries_to_build"] {
+    for key in QUEUE_KEYS {
         let Some(declared) = toml
             .lines()
             .map(str::trim)
-            .find_map(|l| l.strip_prefix(key))
+            .find_map(|l| l.strip_prefix(*key))
             .and_then(|r| r.trim_start().strip_prefix('='))
             .and_then(|r| r.trim().parse::<usize>().ok())
         else {
             bail!("{QUEUE_TOML} states no {key} — the constant this README quotes is gone");
         };
-        let Some(after) = joined.split(key).nth(1) else {
+        let Some(after) = joined.split(*key).nth(1) else {
             bail!("{README} no longer quotes {key}; drop this check or restore the sentence");
         };
         let claimed = after

--- a/crates/xtask/src/fly_pools.rs
+++ b/crates/xtask/src/fly_pools.rs
@@ -38,6 +38,8 @@ const MANAGER_TOML: &str = "ci/fly-runner/manager.toml";
 const README: &str = "ci/fly-runner/README.md";
 /// How many `(pool, field)` pairs the README and the TOML may still disagree on. Shrink-only.
 const DRIFT: &str = "ci/fly-pools-drift.txt";
+/// The other config the same README restates numbers from.
+const QUEUE_TOML: &str = "ci/merge-queue.toml";
 
 /// The `POOLS = '...'` value, as the manager would receive it.
 pub fn pools_json(manager_toml: &str) -> Result<String> {
@@ -173,6 +175,61 @@ fn readme_agrees(root: &Path, pools: &[ci_fly_runner::PoolSpec]) -> Result<()> {
         "OK: {rows} pool(s) compared against {README}; {} still disagree (pin {pin})",
         drift.len()
     );
+    readme_queue_constants(root, &text)
+}
+
+/// The same README also restates merge-queue constants, and nothing compared those either.
+///
+/// `ci/fly-runner/README.md` explains the queue's throughput by quoting `max_entries_to_build = 1`
+/// from `ci/merge-queue.toml`. `ci-spec live-parity` compares that TOML against the LIVE ruleset; no
+/// gate reads this README at all. So raising the constant — which was tried and reverted earlier,
+/// per merge-queue.toml's own note — would leave the prose saying 1 with nothing to notice.
+///
+/// **This half is preventive, and that is worth saying plainly.** The pool comparison above found
+/// four live disagreements; these two values agree today. A gate half that has never been red on a
+/// real defect is a weaker thing than one that has, and the honest place to record which is which is
+/// here rather than in a commit message nobody re-reads.
+///
+/// The value is quoted across a LINE WRAP — `max_entries_to_build` ending one line and `= 1`
+/// starting the next — which is why a naive grep misses it and why this class of drift survives.
+/// The scan normalises whitespace before matching, deliberately.
+fn readme_queue_constants(root: &Path, readme: &str) -> Result<()> {
+    let toml = fs::read_to_string(root.join(QUEUE_TOML))
+        .with_context(|| format!("reading {QUEUE_TOML}"))?;
+    let joined: String = readme.split_whitespace().collect::<Vec<_>>().join(" ");
+    let mut checked = 0usize;
+    for key in ["max_entries_to_build"] {
+        let Some(declared) = toml
+            .lines()
+            .map(str::trim)
+            .find_map(|l| l.strip_prefix(key))
+            .and_then(|r| r.trim_start().strip_prefix('='))
+            .and_then(|r| r.trim().parse::<usize>().ok())
+        else {
+            bail!("{QUEUE_TOML} states no {key} — the constant this README quotes is gone");
+        };
+        let Some(after) = joined.split(key).nth(1) else {
+            bail!("{README} no longer quotes {key}; drop this check or restore the sentence");
+        };
+        let claimed = after
+            .trim_start()
+            .strip_prefix('=')
+            .map(str::trim_start)
+            .and_then(|r| r.split(|c: char| !c.is_ascii_digit()).next())
+            .and_then(|n| n.parse::<usize>().ok());
+        match claimed {
+            None => bail!("{README} quotes {key} without a value"),
+            Some(c) if c != declared => bail!(
+                "{README} says {key} = {c}, {QUEUE_TOML} says {declared} — the prose explaining the \
+                 queue's throughput disagrees with the queue's configuration"
+            ),
+            Some(_) => checked += 1,
+        }
+    }
+    if checked == 0 {
+        bail!("no merge-queue constant was compared — the check examined nothing");
+    }
+    println!("OK: {checked} merge-queue constant(s) in {README} agree with {QUEUE_TOML}");
     Ok(())
 }
 

--- a/crates/xtask/src/fly_pools.rs
+++ b/crates/xtask/src/fly_pools.rs
@@ -233,6 +233,81 @@ fn readme_queue_constants(root: &Path, readme: &str) -> Result<()> {
         bail!("no merge-queue constant was compared — the check examined nothing");
     }
     println!("OK: {checked} merge-queue constant(s) in {README} agree with {QUEUE_TOML}");
+    readme_site_counts(root, &joined)
+}
+
+/// The README also counts how many `runs-on:` sites each pool serves, and those are facts about
+/// the tree rather than opinions about a deployment.
+///
+/// Unlike the pool sizes — where `manager.toml` is a default the deployed secret may override, so
+/// neither side is authoritative and the drift is ratcheted — a site count is decidable here and
+/// now by counting lines. There is a right answer, so this comparison HARD-FAILS rather than
+/// ratchets, and the README was corrected in the change that added it.
+///
+/// Measured 2026-09-11, before the correction: the README claimed 52 gate sites and 27 build sites;
+/// the tree had **54 and 24**. Both wrong, in opposite directions.
+fn readme_site_counts(root: &Path, joined: &str) -> Result<()> {
+    let dir = root.join(".github/workflows");
+    let mut runs_on: Vec<String> = Vec::new();
+    for e in fs::read_dir(&dir).with_context(|| format!("reading {}", dir.display()))? {
+        let path = e?.path();
+        if path.extension().is_none_or(|x| x != "yml") {
+            continue;
+        }
+        for line in fs::read_to_string(&path)?.lines() {
+            if line.trim_start().starts_with("runs-on:") {
+                runs_on.push(line.to_string());
+            }
+        }
+    }
+    if runs_on.len() < 50 {
+        bail!(
+            "only {} `runs-on:` lines found — the scan is wrong, so every count below is noise",
+            runs_on.len()
+        );
+    }
+
+    // Routing: a line naming CI_BUILD_RUNNER goes to the build pool even though it also names
+    // CI_RUNNER as its fallback, so the gate count is the difference and not the raw match.
+    let build = runs_on
+        .iter()
+        .filter(|l| l.contains("vars.CI_BUILD_RUNNER"))
+        .count();
+    let gate = runs_on
+        .iter()
+        .filter(|l| l.contains("vars.CI_RUNNER") && !l.contains("vars.CI_BUILD_RUNNER"))
+        .count();
+
+    let mut wrong = Vec::new();
+    for (claim, actual, what) in [
+        ("`runs-on` sites)", build, "build"),
+        (" sites), opt-in", gate, "gate"),
+    ] {
+        // The number immediately before the claim phrase, e.g. "(27 `runs-on` sites)".
+        let Some(before) = joined
+            .split(claim)
+            .next()
+            .filter(|_| joined.contains(claim))
+        else {
+            bail!("{README} no longer states the {what} site count in the expected form");
+        };
+        let claimed: usize = before
+            .rsplit(|c: char| !c.is_ascii_digit())
+            .find(|t| !t.is_empty())
+            .and_then(|n| n.parse().ok())
+            .with_context(|| format!("{README}: no number before the {what} site count"))?;
+        if claimed != actual {
+            wrong.push(format!("{what}: README {claimed}, tree {actual}"));
+        }
+    }
+    if !wrong.is_empty() {
+        bail!(
+            "{README} miscounts `runs-on` sites — {}. The tree is the authority here: count the \
+             lines and correct the prose",
+            wrong.join("; ")
+        );
+    }
+    println!("OK: {README}'s site counts match the tree (gate {gate}, build {build})");
     Ok(())
 }
 


### PR DESCRIPTION
#2814 made `fly-pools` compare `ci/fly-runner/README.md`'s pool table against `manager.toml`. **The
same README also explains the queue's throughput by quoting `max_entries_to_build = 1` from
`ci/merge-queue.toml`** — and `ci-spec live-parity` compares that TOML against the **live ruleset**,
never against this prose.

Verified: **no gate reads `ci/fly-runner/README.md` at all** except the one added in #2814. So raising
the constant — *which was tried and reverted earlier*, per `merge-queue.toml`'s own note — would leave
the prose saying 1 with nothing to notice.

## This half is preventive, and the code says so

The pool comparison in #2814 found **four live disagreements**. These two values **agree today**. A
gate half that has never been red on a real defect is a weaker thing than one that has, and recording
which is which belongs in the source rather than a commit message nobody re-reads — so the doc
comment states it.

## Driven red three ways

| perturbation | result |
|---|---|
| raise the TOML to 4 | prose goes stale → red, naming both values |
| raise the prose to 4 | TOML goes stale → red |
| delete the sentence | refuses rather than passing on an absence |

## The detail that makes this class survive

The value is quoted **across a line wrap** — `max_entries_to_build` ends one line and `= 1` begins
the next. **My own first search for it missed it for exactly that reason**, and I only found it by
reading the file. The scan normalises whitespace before matching, deliberately.

`QUEUE_KEYS` is a named constant rather than an inline literal, so the extension point is visible in
the type: a key added there is compared with no further code. (Clippy flagged the single-element loop
and was right to — a `for` over one literal reads as an accident.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)