### PR TITLE
ADR 0006/0007: two enforcement fixes, three gates, and four claims that had stopped being true

### DIFF
--- a/crates/ck-policy/src/lib.rs
+++ b/crates/ck-policy/src/lib.rs
@@ -13,6 +13,15 @@
 //!    Checked UNCONDITIONALLY — never gated on any flag, because a gated check
 //!    could itself be disarmed one level up, letting the coup recur.
 
+// ADR 0007 B-3/E-2: a wildcard arm over an enum silently absorbs variants added
+// later, which is how a sum type loses a case without anyone reading the diff.
+// Denied here rather than workspace-wide because the workspace baseline is ~200
+// sites; this crate measured ZERO on 2026-09-11, so the deny costs no cleanup
+// and only forbids a regression. A crate-level attribute rather than a
+// `[lints.clippy]` table because cargo rejects that alongside the
+// `[lints] workspace = true` these crates already carry.
+#![deny(clippy::wildcard_enum_match_arm)]
+
 /// Aeneas-extractable, self-contained CORE mirror of the monotonicity gate's
 /// verdict (integer/bool/array-only — no `BTreeSet`/`String`/generics). Charon +
 /// Aeneas translate this module to Lean (`lean-aeneas/generated/`) for the

--- a/crates/nucleus-cred-broker/src/lib.rs
+++ b/crates/nucleus-cred-broker/src/lib.rs
@@ -43,6 +43,15 @@
 //! accurate `unused-wrapper` warning for the entry in `deny.toml`: the
 //! permission is declared ahead of its first use.
 
+// ADR 0007 B-3/E-2: a wildcard arm over an enum silently absorbs variants added
+// later, which is how a sum type loses a case without anyone reading the diff.
+// Denied here rather than workspace-wide because the workspace baseline is ~200
+// sites; this crate measured ZERO on 2026-09-11, so the deny costs no cleanup
+// and only forbids a regression. A crate-level attribute rather than a
+// `[lints.clippy]` table because cargo rejects that alongside the
+// `[lints] workspace = true` these crates already carry.
+#![deny(clippy::wildcard_enum_match_arm)]
+
 pub use nucleus_cred_protocol::TaskRequestEnvelope;
 
 /// Who is asking, **as established by the host**.

--- a/crates/nucleus-node/src/firecracker_api.rs
+++ b/crates/nucleus-node/src/firecracker_api.rs
@@ -193,7 +193,9 @@ pub(crate) mod stub_vmm;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stub_vmm::{Seen, StubVmm, sample_config};
+    use stub_vmm::{Seen, StubVmm};
+    #[cfg(target_os = "linux")]
+    use stub_vmm::sample_config;
 
     /// A socket that never appears fails by naming the path, not by hanging.
     ///
@@ -471,6 +473,7 @@ mod tests {
 
     /// `configure` drives the lowering and leaves the machine NOT started —
     /// which is the property the snapshot path depends on.
+    #[cfg(target_os = "linux")]
     #[tokio::test]
     async fn configure_builds_the_machine_without_starting_it() {
         let vmm = StubVmm::start(vec![]).await;

--- a/crates/nucleus-node/src/firecracker_api.rs
+++ b/crates/nucleus-node/src/firecracker_api.rs
@@ -193,9 +193,9 @@ pub(crate) mod stub_vmm;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use stub_vmm::{Seen, StubVmm};
     #[cfg(target_os = "linux")]
     use stub_vmm::sample_config;
+    use stub_vmm::{Seen, StubVmm};
 
     /// A socket that never appears fails by naming the path, not by hanging.
     ///

--- a/crates/nucleus-node/src/firecracker_config_tests.rs
+++ b/crates/nucleus-node/src/firecracker_config_tests.rs
@@ -1552,6 +1552,7 @@ fn a_provisioned_scratch_still_reaches_the_guest_as_a_writable_drive() {
 
 /// No jail means nowhere to put one; a spec that names one keeps it. Both
 /// report "not node-provisioned", so a caller's file is still placed.
+#[cfg(target_os = "linux")]
 #[test]
 fn scratch_for_pod_leaves_a_caller_supplied_or_jailless_image_alone() {
     let declared = image(true, true);

--- a/crates/nucleus-node/src/pod_receipt.rs
+++ b/crates/nucleus-node/src/pod_receipt.rs
@@ -331,7 +331,11 @@ mod tests {
                 .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
                 .collect::<BTreeMap<_, _>>();
 
-            let child = tokio::process::Command::new(if exit { "/bin/true" } else { "/bin/sleep" })
+            // Resolved through `PATH` rather than by absolute path: `true` lives in
+            // `/usr/bin` on macOS and `/bin` on most Linux distributions, and the
+            // hardcoded `/bin/true` made these five tests fail to spawn on a Mac
+            // the moment the crate became compilable there.
+            let child = tokio::process::Command::new(if exit { "true" } else { "sleep" })
                 .args(if exit { vec![] } else { vec!["30"] })
                 .spawn()
                 .expect("a child spawns");

--- a/crates/nucleus-node/src/snapshot_restore.rs
+++ b/crates/nucleus-node/src/snapshot_restore.rs
@@ -39,15 +39,15 @@
 //! base's ownership for every later pod — and it is unnecessary, because the measurement above
 //! says the guest never writes the file. Read permission is the whole requirement.
 
-#[cfg(any(target_os = "linux", test))]
+#[cfg(target_os = "linux")]
 use std::path::{Path, PathBuf};
 
-#[cfg(any(target_os = "linux", test))]
+#[cfg(target_os = "linux")]
 use crate::firecracker_config::{FirecrackerConfig, JailLayout, in_jail};
 use crate::snapshot_store::HostIdentity;
-#[cfg(any(target_os = "linux", test))]
+#[cfg(target_os = "linux")]
 use crate::snapshot_store::{Derivation, Lookup, SnapshotStore};
-#[cfg(any(target_os = "linux", test))]
+#[cfg(target_os = "linux")]
 use crate::snapshot_vmm::SnapshotArtifacts;
 
 /// Why this launch is cold-booting.
@@ -262,6 +262,7 @@ pub(crate) async fn bring_up(
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(target_os = "linux")]
     use crate::firecracker_api::stub_vmm::{StubVmm, sample_config};
 
     /// Every refusal renders something a human can act on, and none of them is the empty string.
@@ -561,6 +562,7 @@ mod tests {
     // path here opens a socket, so nothing reached them without a VMM.
 
     /// With no base, the machine is built from the configuration and started.
+    #[cfg(target_os = "linux")]
     #[tokio::test]
     async fn bringing_up_without_a_base_configures_then_starts() {
         let vmm = StubVmm::start(vec![]).await;
@@ -586,6 +588,7 @@ mod tests {
     /// With a base, the VMM is told to LOAD rather than configured field by
     /// field — and is resumed, not started. Firecracker rejects `InstanceStart`
     /// on a restored machine, so confusing the two is a boot failure.
+    #[cfg(target_os = "linux")]
     #[tokio::test]
     async fn bringing_up_from_a_base_loads_the_snapshot_and_resumes() {
         let vmm = StubVmm::start(vec![]).await;
@@ -628,6 +631,7 @@ mod tests {
     /// A previous VMM leaves its vsock socket behind and Firecracker re-binds
     /// the same path at load, so the stale file is `EADDRINUSE` from deep inside
     /// device restore. Clearing it is a precondition, not tidying.
+    #[cfg(target_os = "linux")]
     #[tokio::test]
     async fn a_stale_vsock_socket_is_cleared_before_a_restore() {
         let vmm = StubVmm::start(vec![]).await;
@@ -658,6 +662,7 @@ mod tests {
 
     /// A refusal from the VMM during restore reaches the caller rather than
     /// being swallowed into a half-loaded machine.
+    #[cfg(target_os = "linux")]
     #[tokio::test]
     async fn a_refused_snapshot_load_is_reported() {
         let vmm = StubVmm::start(vec![(400, r#"{"fault_message":"mem file truncated"}"#)]).await;
@@ -678,6 +683,7 @@ mod tests {
     /// The tap is the one thing a restore retargets: the base was frozen holding
     /// a different pod's device. An empty override list would silently restore a
     /// VM pointing at a tap that belongs to another pod.
+    #[cfg(target_os = "linux")]
     #[test]
     fn network_overrides_name_this_pods_taps() {
         let cfg = sample_config();

--- a/crates/nucleus-node/src/stub_vmm.rs
+++ b/crates/nucleus-node/src/stub_vmm.rs
@@ -117,6 +117,7 @@ impl StubVmm {
 
 /// A configuration built the way production builds one, so `configure`
 /// drives the real lowering rather than a hand-made request list.
+#[cfg(target_os = "linux")]
 pub(crate) fn sample_config() -> crate::firecracker_config::FirecrackerConfig {
     let spec: nucleus_spec::PodSpec =
         serde_json::from_str(r#"{"apiVersion":"nucleus/v1","kind":"Pod","spec":{}}"#)

--- a/crates/nucleus-policy-kernel/src/lib.rs
+++ b/crates/nucleus-policy-kernel/src/lib.rs
@@ -34,6 +34,15 @@
 //! the property over the **entire** (infinite) request space. No floats, no
 //! `unsafe`, no zkVM toolchain in the default build.
 
+// ADR 0007 B-3/E-2: a wildcard arm over an enum silently absorbs variants added
+// later, which is how a sum type loses a case without anyone reading the diff.
+// Denied here rather than workspace-wide because the workspace baseline is ~200
+// sites; this crate measured ZERO on 2026-09-11, so the deny costs no cleanup
+// and only forbids a regression. A crate-level attribute rather than a
+// `[lints.clippy]` table because cargo rejects that alongside the
+// `[lints] workspace = true` these crates already carry.
+#![deny(clippy::wildcard_enum_match_arm)]
+
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 

--- a/crates/nucleus-tool-proxy/src/pod_mgmt.rs
+++ b/crates/nucleus-tool-proxy/src/pod_mgmt.rs
@@ -235,27 +235,27 @@ pub(crate) async fn create_sub_pod(
     // removal. The two mechanisms catch opposite failures; both are kept.
     let nucleus_spec::PodSpecInner {
         // ── Decided above ───────────────────────────────────────────────────
-        policy: _policy,                           // 4  narrowed to this pod's ceiling
-        workload: _workload,                       // 4b stripped
+        policy: _policy,     // 4  narrowed to this pod's ceiling
+        workload: _workload, // 4b stripped
         credentialed_egress: _credentialed_egress, // 4c clamped to the parent's upstreams
-        credentials: _credentials,                 // 5  orchestrator env merged in
+        credentials: _credentials, // 5  orchestrator env merged in
 
         // ── Forwarded as the requester wrote them ───────────────────────────
         // Each line is a standing decision to delegate that field unclamped.
         // None is an oversight and none is an endorsement: this is the backlog
         // C4.2 exists to work through, in severity order, one change each.
-        work_dir: _work_dir,               // the child names its own working directory
+        work_dir: _work_dir, // the child names its own working directory
         timeout_seconds: _timeout_seconds, // becomes the session-token TTL, uncapped
-                                           // (nucleus-node/src/pod_authority.rs:738)
-        budget_model: _budget_model,       // pricing shape; the AMOUNT is reserved at 5b
-        resources: _resources,             // cpu/memory the child asks the node for
-        network: _network,                 // egress shape; `credentialed_egress` is the
-                                           // separate field clamped at 4c, not this one
-        image: _image,                     // the child names its own kernel and rootfs
-        vsock: _vsock,                     // guest-host socket configuration
-        seccomp: _seccomp,                 // syscall filter — a child may ask for a weaker one
-        cgroup: _cgroup,                   // cgroup limits
-        audit_sink: _audit_sink,           // where the child's audit record is written
+        // (nucleus-node/src/pod_authority.rs:738)
+        budget_model: _budget_model, // pricing shape; the AMOUNT is reserved at 5b
+        resources: _resources,       // cpu/memory the child asks the node for
+        network: _network,           // egress shape; `credentialed_egress` is the
+        // separate field clamped at 4c, not this one
+        image: _image,           // the child names its own kernel and rootfs
+        vsock: _vsock,           // guest-host socket configuration
+        seccomp: _seccomp,       // syscall filter — a child may ask for a weaker one
+        cgroup: _cgroup,         // cgroup limits
+        audit_sink: _audit_sink, // where the child's audit record is written
     } = &spec.spec;
 
     // `metadata` is a sibling of `spec` on `PodSpec`, so the destructure above

--- a/crates/nucleus-tool-proxy/src/pod_mgmt.rs
+++ b/crates/nucleus-tool-proxy/src/pod_mgmt.rs
@@ -214,6 +214,62 @@ pub(crate) async fn create_sub_pod(
         spec.spec.credentials = Some(creds);
     }
 
+    // 5c. THE DELEGATION BOUNDARY, ENFORCED BY THE COMPILER (ADR 0006 C4.2).
+    //
+    // Steps 4-5 decide four of `PodSpecInner`'s fourteen fields. The other ten,
+    // and all four of `Metadata`'s, reach the serialized child spec exactly as
+    // the requester wrote them. That enumeration IS the security boundary, and
+    // until now it was maintained by hand. The comment at 4b says the quiet
+    // part: authority "must be made deliberately, not inherited from a field
+    // being added."
+    //
+    // These destructures are what make that true. Every field is bound by name,
+    // so adding one to either struct fails to compile HERE until someone writes
+    // down what delegation should do with it. They borrow and produce nothing —
+    // the pattern is the mechanism, not the bindings.
+    //
+    // This does NOT subsume `create_sub_pod_still_clamps_credentialed_egress` or
+    // `create_sub_pod_always_narrows_and_reserves`. Those read this function's
+    // own source for the three calls, so they notice a call being DELETED —
+    // which a destructure cannot see, because the binding survives the clamp's
+    // removal. The two mechanisms catch opposite failures; both are kept.
+    let nucleus_spec::PodSpecInner {
+        // ── Decided above ───────────────────────────────────────────────────
+        policy: _policy,                           // 4  narrowed to this pod's ceiling
+        workload: _workload,                       // 4b stripped
+        credentialed_egress: _credentialed_egress, // 4c clamped to the parent's upstreams
+        credentials: _credentials,                 // 5  orchestrator env merged in
+
+        // ── Forwarded as the requester wrote them ───────────────────────────
+        // Each line is a standing decision to delegate that field unclamped.
+        // None is an oversight and none is an endorsement: this is the backlog
+        // C4.2 exists to work through, in severity order, one change each.
+        work_dir: _work_dir,               // the child names its own working directory
+        timeout_seconds: _timeout_seconds, // becomes the session-token TTL, uncapped
+                                           // (nucleus-node/src/pod_authority.rs:738)
+        budget_model: _budget_model,       // pricing shape; the AMOUNT is reserved at 5b
+        resources: _resources,             // cpu/memory the child asks the node for
+        network: _network,                 // egress shape; `credentialed_egress` is the
+                                           // separate field clamped at 4c, not this one
+        image: _image,                     // the child names its own kernel and rootfs
+        vsock: _vsock,                     // guest-host socket configuration
+        seccomp: _seccomp,                 // syscall filter — a child may ask for a weaker one
+        cgroup: _cgroup,                   // cgroup limits
+        audit_sink: _audit_sink,           // where the child's audit record is written
+    } = &spec.spec;
+
+    // `metadata` is a sibling of `spec` on `PodSpec`, so the destructure above
+    // does not reach it. ADR 0006 C4.2 enumerates `metadata.labels` and
+    // `metadata.task_grant_id`; `name` and `namespace` ride through too, which
+    // is the ADR's own hand-maintained list being incomplete — the argument for
+    // this mechanism, made by the list it replaces.
+    let nucleus_spec::Metadata {
+        name: _name,                   // child-chosen pod name
+        namespace: _namespace,         // child-chosen namespace
+        labels: _labels,               // child-chosen labels
+        task_grant_id: _task_grant_id, // child-asserted task grant
+    } = &spec.metadata;
+
     // 5b. Reserve the child's budget from THIS pod's live budget (#2426):
     //     the child's max_cost is debited here, atomically, before the node
     //     call, and mirrored into the kernel so its own BudgetExhausted arm

--- a/crates/portcullis-effects/src/lib.rs
+++ b/crates/portcullis-effects/src/lib.rs
@@ -62,6 +62,14 @@
 //! assert_eq!(fx.calls().len(), 1);
 //! ```
 
+// ADR 0007 C-5: a capability or authority type is `#[must_use]`, and `let _ =`
+// is the one form that discards it without saying so. The live defect this
+// closes was in `runtime.rs::spawn_child`: a discarded `observe` result meant a
+// tainted parent could hand back a child reading as clean. Denied crate-wide
+// because this crate IS the sealed agent-effect boundary; the ten remaining
+// sites are test-only and carry `#[expect]` with their reason.
+#![deny(clippy::let_underscore_must_use)]
+
 pub mod async_traits;
 mod doubles;
 pub mod runtime;
@@ -1502,6 +1510,7 @@ mod tests {
             !matches!(&ok, Err(EffectError::PolicyDenied(m)) if m.contains("scope")),
             "a correctly-scoped write must not be refused on scope: {ok:?}"
         );
+        #[expect(clippy::let_underscore_must_use, reason = "ADR 0007 C-5: best-effort cleanup; the path need not exist")]
         let _ = std::fs::remove_file("/tmp/nucleus-scope-test-ok");
     }
 
@@ -1752,6 +1761,7 @@ mod tests {
         // scope here, and this test passed under `cargo test` — which shares a
         // process — while failing under the runner CI actually uses.
         // Idempotent; the already-set Err is the expected second answer.
+        #[expect(clippy::let_underscore_must_use, reason = "ADR 0007 C-5: idempotent process-global init; Err means another test installed it first")]
         let _ = rustls::crypto::ring::default_provider().install_default();
 
         let fx = PolicyEnforced {
@@ -1797,6 +1807,7 @@ mod tests {
         // This passed until now only because a full-workspace build unified
         // reqwest's `rustls` feature in from nucleus-control-plane-server; a
         // run scoped to a crate set that excludes it has no provider at all.
+        #[expect(clippy::let_underscore_must_use, reason = "ADR 0007 C-5: idempotent process-global init; Err means another test installed it first")]
         let _ = rustls::crypto::ring::default_provider().install_default();
 
         NetEffect::fetch(
@@ -1848,6 +1859,7 @@ mod tests {
             receipts: Arc::new(crate::receipt::ReceiptLog::new()),
             policy: CapabilityLattice::bottom(),
         };
+        #[expect(clippy::let_underscore_must_use, reason = "ADR 0007 C-5: the discarded outcome is not what this test asserts")]
         let _ = denied_by_policy.push("origin", "main", push_auth("origin"));
         assert_eq!(
             denied_by_policy.receipts().entries()[0].outcome,
@@ -1863,6 +1875,7 @@ mod tests {
                 ..CapabilityLattice::bottom()
             },
         };
+        #[expect(clippy::let_underscore_must_use, reason = "ADR 0007 C-5: the discarded outcome is not what this test asserts")]
         let _ = denied_by_scope.push("origin", "main", commit_auth("origin"));
         let e = &denied_by_scope.receipts().entries()[0];
         assert_eq!(e.outcome, EffectOutcome::DeniedByScope);
@@ -1944,11 +1957,14 @@ mod tests {
     #[test]
     fn recording_records_calls_in_order() {
         let fx = RecordingEffects::new();
+        #[expect(clippy::let_underscore_must_use, reason = "ADR 0007 C-5: the discarded outcome is not what this test asserts")]
         let _ = fx.read(Path::new("a.rs"), read_auth());
+        #[expect(clippy::let_underscore_must_use, reason = "ADR 0007 C-5: the discarded outcome is not what this test asserts")]
         let _ = fx.write(Path::new("b.rs"), b"hi", write_auth());
         // `run` spends now, and a spend with no log attached refuses. Used
         // bare here, without the `PolicyEnforced` wrapper that normally
         // attaches one, so the test attaches it.
+        #[expect(clippy::let_underscore_must_use, reason = "ADR 0007 C-5: the discarded outcome is not what this test asserts")]
         let _ = fx.run("echo hello", witnessed(shell_auth("echo hello")));
         let calls = fx.calls();
         assert_eq!(calls.len(), 3);
@@ -2349,6 +2365,7 @@ mod tests {
 
         // The workspace reqwest uses `rustls-no-provider`; install a provider so
         // `Client::new()` can build (idempotent — ignore the already-set Err).
+        #[expect(clippy::let_underscore_must_use, reason = "ADR 0007 C-5: idempotent process-global init; Err means another test installed it first")]
         let _ = rustls::crypto::ring::default_provider().install_default();
         let fx = production_effects_concrete(CapabilityLattice::bottom());
         let client = reqwest::Client::new();

--- a/crates/portcullis-effects/src/lib.rs
+++ b/crates/portcullis-effects/src/lib.rs
@@ -1510,7 +1510,10 @@ mod tests {
             !matches!(&ok, Err(EffectError::PolicyDenied(m)) if m.contains("scope")),
             "a correctly-scoped write must not be refused on scope: {ok:?}"
         );
-        #[expect(clippy::let_underscore_must_use, reason = "ADR 0007 C-5: best-effort cleanup; the path need not exist")]
+        #[expect(
+            clippy::let_underscore_must_use,
+            reason = "ADR 0007 C-5: best-effort cleanup; the path need not exist"
+        )]
         let _ = std::fs::remove_file("/tmp/nucleus-scope-test-ok");
     }
 
@@ -1761,7 +1764,10 @@ mod tests {
         // scope here, and this test passed under `cargo test` — which shares a
         // process — while failing under the runner CI actually uses.
         // Idempotent; the already-set Err is the expected second answer.
-        #[expect(clippy::let_underscore_must_use, reason = "ADR 0007 C-5: idempotent process-global init; Err means another test installed it first")]
+        #[expect(
+            clippy::let_underscore_must_use,
+            reason = "ADR 0007 C-5: idempotent process-global init; Err means another test installed it first"
+        )]
         let _ = rustls::crypto::ring::default_provider().install_default();
 
         let fx = PolicyEnforced {
@@ -1807,7 +1813,10 @@ mod tests {
         // This passed until now only because a full-workspace build unified
         // reqwest's `rustls` feature in from nucleus-control-plane-server; a
         // run scoped to a crate set that excludes it has no provider at all.
-        #[expect(clippy::let_underscore_must_use, reason = "ADR 0007 C-5: idempotent process-global init; Err means another test installed it first")]
+        #[expect(
+            clippy::let_underscore_must_use,
+            reason = "ADR 0007 C-5: idempotent process-global init; Err means another test installed it first"
+        )]
         let _ = rustls::crypto::ring::default_provider().install_default();
 
         NetEffect::fetch(
@@ -1859,7 +1868,10 @@ mod tests {
             receipts: Arc::new(crate::receipt::ReceiptLog::new()),
             policy: CapabilityLattice::bottom(),
         };
-        #[expect(clippy::let_underscore_must_use, reason = "ADR 0007 C-5: the discarded outcome is not what this test asserts")]
+        #[expect(
+            clippy::let_underscore_must_use,
+            reason = "ADR 0007 C-5: the discarded outcome is not what this test asserts"
+        )]
         let _ = denied_by_policy.push("origin", "main", push_auth("origin"));
         assert_eq!(
             denied_by_policy.receipts().entries()[0].outcome,
@@ -1875,7 +1887,10 @@ mod tests {
                 ..CapabilityLattice::bottom()
             },
         };
-        #[expect(clippy::let_underscore_must_use, reason = "ADR 0007 C-5: the discarded outcome is not what this test asserts")]
+        #[expect(
+            clippy::let_underscore_must_use,
+            reason = "ADR 0007 C-5: the discarded outcome is not what this test asserts"
+        )]
         let _ = denied_by_scope.push("origin", "main", commit_auth("origin"));
         let e = &denied_by_scope.receipts().entries()[0];
         assert_eq!(e.outcome, EffectOutcome::DeniedByScope);
@@ -1957,14 +1972,23 @@ mod tests {
     #[test]
     fn recording_records_calls_in_order() {
         let fx = RecordingEffects::new();
-        #[expect(clippy::let_underscore_must_use, reason = "ADR 0007 C-5: the discarded outcome is not what this test asserts")]
+        #[expect(
+            clippy::let_underscore_must_use,
+            reason = "ADR 0007 C-5: the discarded outcome is not what this test asserts"
+        )]
         let _ = fx.read(Path::new("a.rs"), read_auth());
-        #[expect(clippy::let_underscore_must_use, reason = "ADR 0007 C-5: the discarded outcome is not what this test asserts")]
+        #[expect(
+            clippy::let_underscore_must_use,
+            reason = "ADR 0007 C-5: the discarded outcome is not what this test asserts"
+        )]
         let _ = fx.write(Path::new("b.rs"), b"hi", write_auth());
         // `run` spends now, and a spend with no log attached refuses. Used
         // bare here, without the `PolicyEnforced` wrapper that normally
         // attaches one, so the test attaches it.
-        #[expect(clippy::let_underscore_must_use, reason = "ADR 0007 C-5: the discarded outcome is not what this test asserts")]
+        #[expect(
+            clippy::let_underscore_must_use,
+            reason = "ADR 0007 C-5: the discarded outcome is not what this test asserts"
+        )]
         let _ = fx.run("echo hello", witnessed(shell_auth("echo hello")));
         let calls = fx.calls();
         assert_eq!(calls.len(), 3);
@@ -2365,7 +2389,10 @@ mod tests {
 
         // The workspace reqwest uses `rustls-no-provider`; install a provider so
         // `Client::new()` can build (idempotent — ignore the already-set Err).
-        #[expect(clippy::let_underscore_must_use, reason = "ADR 0007 C-5: idempotent process-global init; Err means another test installed it first")]
+        #[expect(
+            clippy::let_underscore_must_use,
+            reason = "ADR 0007 C-5: idempotent process-global init; Err means another test installed it first"
+        )]
         let _ = rustls::crypto::ring::default_provider().install_default();
         let fx = production_effects_concrete(CapabilityLattice::bottom());
         let client = reqwest::Client::new();

--- a/crates/portcullis-effects/src/receipt.rs
+++ b/crates/portcullis-effects/src/receipt.rs
@@ -1056,6 +1056,7 @@ mod witness_tests {
                 EffectOutcome::Allowed,
             );
         }
+        #[expect(clippy::let_underscore_must_use, reason = "ADR 0007 C-5: the discarded outcome is not what this test asserts")]
         let _ = w.witness(&rewritten.sign_checkpoint(&lk), &lvk, 4, &[], &wk);
         assert_eq!(
             w.latest().unwrap(),

--- a/crates/portcullis-effects/src/receipt.rs
+++ b/crates/portcullis-effects/src/receipt.rs
@@ -1056,7 +1056,10 @@ mod witness_tests {
                 EffectOutcome::Allowed,
             );
         }
-        #[expect(clippy::let_underscore_must_use, reason = "ADR 0007 C-5: the discarded outcome is not what this test asserts")]
+        #[expect(
+            clippy::let_underscore_must_use,
+            reason = "ADR 0007 C-5: the discarded outcome is not what this test asserts"
+        )]
         let _ = w.witness(&rewritten.sign_checkpoint(&lk), &lvk, 4, &[], &wk);
         assert_eq!(
             w.latest().unwrap(),

--- a/crates/portcullis-effects/src/runtime.rs
+++ b/crates/portcullis-effects/src/runtime.rs
@@ -2548,7 +2548,10 @@ mod tests {
             .flow_tracker_mut()
             .observe(portcullis_core::flow::NodeKind::WebContent)
             .expect("a parent observes web content");
-        assert!(parent.is_tainted(), "the parent is tainted after observing web content");
+        assert!(
+            parent.is_tainted(),
+            "the parent is tainted after observing web content"
+        );
 
         let child = parent
             .spawn_child(PolicyProfile::ReadOnly, "review")

--- a/crates/portcullis-effects/src/runtime.rs
+++ b/crates/portcullis-effects/src/runtime.rs
@@ -1236,9 +1236,20 @@ impl NucleusRuntime {
             // raises both taint ceiling (OpaqueExternal) and conf ceiling.
             // A more precise approach would set ceilings directly, but
             // the FlowTracker API only allows raising via observation.
-            let _ = child
+            // The result is PROPAGATED, not discarded. This used to be
+            // `let _ = ...` (ADR 0007 C-5). A sentinel that fails to be observed
+            // leaves the child's ceilings BELOW the parent's, so a tainted parent
+            // hands back a child that reads as CLEAN — the taint escape this
+            // branch exists to prevent, and it would be silent. ADR 0007 A-2:
+            // "I could not look" is never "I looked and it was fine."
+            child
                 .flow_tracker_mut()
-                .observe(portcullis_core::flow::NodeKind::WebContent);
+                .observe(portcullis_core::flow::NodeKind::WebContent)
+                .map_err(|e| {
+                    RuntimeError::Config(format!(
+                        "child runtime could not inherit the parent's flow ceilings: {e}"
+                    ))
+                })?;
         }
 
         Ok(child)
@@ -2519,6 +2530,34 @@ mod tests {
         let child = child.unwrap();
         assert!(child.can(RuntimeCapability::ReadFiles));
         assert!(!child.can(RuntimeCapability::WriteFiles)); // ReadOnly has no write
+    }
+
+    /// A tainted parent must hand back a tainted child.
+    ///
+    /// `spawn_child` raises the child's ceilings by observing a sentinel node,
+    /// and that call's result was discarded until ADR 0007 C-5. Nothing asserted
+    /// the propagation, so the discard was invisible: a failed observation would
+    /// have produced a child reading as clean out of a tainted parent. This is
+    /// the property that makes the returned error worth returning.
+    #[test]
+    fn a_tainted_parent_hands_back_a_tainted_child() {
+        let mut parent = NucleusRuntime::builder()
+            .profile(PolicyProfile::Codegen)
+            .build();
+        parent
+            .flow_tracker_mut()
+            .observe(portcullis_core::flow::NodeKind::WebContent)
+            .expect("a parent observes web content");
+        assert!(parent.is_tainted(), "the parent is tainted after observing web content");
+
+        let child = parent
+            .spawn_child(PolicyProfile::ReadOnly, "review")
+            .expect("ReadOnly is under Codegen");
+
+        assert!(
+            child.is_tainted(),
+            "a tainted parent must not hand back a child that reads as clean"
+        );
     }
 
     #[test]

--- a/docs/adr/0006-four-collapses.md
+++ b/docs/adr/0006-four-collapses.md
@@ -1,6 +1,11 @@
 # ADR 0006 — Four collapses: the security surface is compositions of four objects, not sixty-five
 
-- Status: **proposed** (2026-09-10). Nothing in this ADR is implemented.
+- Status: **accepted** (2026-09-10); **partially implemented** (updated 2026-09-11). C0.1, C0.2,
+  C1.1, C1.2, C2.0, C2.1 and C2.2 landed in `d761b1ae6` (#2781) the day after this was written.
+  C2.3–C2.5, C3.1–C3.2 and C4.1–C4.2 remain proposed; the Milestones table below is the per-row
+  status. The original line read "Nothing in this ADR is implemented", which stopped being true
+  within a day and is exactly the drift this ADR is about — a document whose green is
+  indistinguishable from vacuity.
 - Tracks: the 2026-09-09 architectural audit; `SECURITY_TODO.md` items 17–30; PR #2778 (Tiers 1–2)
 - Applies to: `portcullis`, `portcullis-core`, `portcullis-effects`, `nucleus-ifc-kernel`, `nucleus`, `nucleus-node`, `nucleus-tool-proxy` — the ~217k LOC dependency closure of `nucleus-node`
 
@@ -342,17 +347,17 @@ of their stack rather than the end.
 
 | # | Delivers | Folded-in defect | Status |
 |---|---|---|---|
-| C0.1 | `xtask` ratchet on inert authority: `_authority` / `_proof` / `_cert` bindings, seeded exact at the measured 43 of 226, with the genuine no-op impls allow-listed by path and reason | an authority accepted and dropped is a gate that is present but does nothing | proposed |
-| C0.2 | Add `GuardedAction` and `Authorized<A>` to #2778's law-mechanism manifest | `Authorized<A>` is `Clone + Copy` with public fields and zero call sites — unsound *and* dead | proposed |
+| C0.1 | `xtask` ratchet on inert authority: `_authority` / `_proof` / `_cert` bindings, seeded exact at the measured 43 of 226, with the genuine no-op impls allow-listed by path and reason | an authority accepted and dropped is a gate that is present but does nothing | **landed** `d761b1ae6` |
+| C0.2 | Add `GuardedAction` and `Authorized<A>` to #2778's law-mechanism manifest | `Authorized<A>` is `Clone + Copy` with public fields and zero call sites — unsound *and* dead | **landed** `d761b1ae6` |
 | C0.3 | This ADR, renumbered off #2753's 0005, with the three corrections above | the ADR's own claims about `DeclassificationToken`, `max_uses` and parametricity | **this PR** |
-| C1.1 | `LedgerCore<Unit>`: `Unit` trait with stated saturating-arithmetic laws, `PhantomData`, `*_micro` → `*_units`. Drop `const fn new` (const trait methods are unstable at MSRV 1.93). Keep every `while i < N` loop and add no heap — `budget_ledger.rs` has zero `kani-divergence.toml` entries and must keep it | `LedgerError::UnrepresentableAmount` names `Decimal` but is produced only by `BudgetLedger` | proposed |
-| C1.2 | E1/E2 onto the `kani-fast` lane | `FORMAL_METHODS.md` claims budget conservation runs every PR; it runs nightly | proposed |
+| C1.1 | `LedgerCore<Unit>`: `Unit` trait with stated saturating-arithmetic laws, `PhantomData`, `*_micro` → `*_units`. Drop `const fn new` (const trait methods are unstable at MSRV 1.93). Keep every `while i < N` loop and add no heap — `budget_ledger.rs` has zero `kani-divergence.toml` entries and must keep it | `LedgerError::UnrepresentableAmount` names `Decimal` but is produced only by `BudgetLedger` | **landed** `d761b1ae6` |
+| C1.2 | E1/E2 onto the `kani-fast` lane | `FORMAL_METHODS.md` claims budget conservation runs every PR; it runs nightly | **landed** `d761b1ae6` |
 | C1.3 | First two consumers: `BudgetGate` (already micro-USD `u64`) and `AtomicBudget` | `AtomicBudget::reserve` splits token limits by `/2` — *"Give half of remaining"* — which the ledger's law rejects | proposed |
-| C2.0 | MCP path gets the per-request certificate attenuation HTTP has, or a written reason it must not | **the MCP/HTTP divergence** | proposed |
-| C2.1 | The `Act` sum in `portcullis-core`, totality proved against the 27 admissible pairs | `default_sink_class` returns `SecretRead` for 3 of 13 operations — a pair `operation_allowed_for_sink` **rejects** | proposed |
-| C2.2 | `CheckProof` carries the `Act`; `ToolCallGuard::check(Act)` | makes the six untargeted `guard.check(Operation::…)` MCP sites a compile error | proposed |
+| C2.0 | MCP path gets the per-request certificate attenuation HTTP has, or a written reason it must not | **the MCP/HTTP divergence** | **landed** `d761b1ae6` |
+| C2.1 | The `Act` sum in `portcullis-core`, totality proved against the 27 admissible pairs | `default_sink_class` returns `SecretRead` for 3 of 13 operations — a pair `operation_allowed_for_sink` **rejects** | **landed** `d761b1ae6` |
+| C2.2 | `CheckProof` carries the `Act`; `ToolCallGuard::check(Act)` | makes the six untargeted `guard.check(Operation::…)` MCP sites a compile error | **landed** `d761b1ae6` |
 | C2.3 | `GuardedAction<Act>` replaces `GuardedAction<Operation>` / `<String>`; delete `Authorized<A>` | lowers `DEAD_COUNT` from C0.2 | proposed |
-| C2.4 | `Authority::spend(act)`; `EffectCall` stops being `(&'static str, String)` | the `gate()` helper's `Ok(Authority::new(bundle))` re-wrap, which reopens the affine seam it just closed | proposed |
+| C2.4 | `Authority::spend(act)`; `EffectCall` stops being `(&'static str, String)` | the `gate()` helper's `Ok(Authority::new(bundle))` re-wrap, which reopens the affine seam it just closed | **partial** — `spend_on(self, &Act)` exists beside a transitional `spend(self, Operation, SinkClass)` |
 | C2.5 | Effect traits take the witness by value, one trait per PR | `run_args`'s `compile_fail` doctest fails on **arity**, so it pins nothing; `DecisionToken` is inert outside `debug_assert` (item 25) | proposed |
 | C3.1 | The `Ceiling` / `Permit` / `Voucher` split; `Action = Act` | — | proposed |
 | C3.2 | One burn ledger for the five that exist | `SessionCleanseToken` is taken by `&` and never consumed | proposed |

--- a/docs/adr/0007-make-the-defect-unwritable.md
+++ b/docs/adr/0007-make-the-defect-unwritable.md
@@ -478,8 +478,29 @@ line above read "six exist today", which counts crates rather than coverage and 
 membership-versus-enforcement confusion ADR 0006 is about, inside this ADR's own
 enforcement table. `observed` is the source-side dual of `mediated` — it asks whether
 every path that ingests external bytes reaches `FlowTracker::observe*` — so the gap it
-leaves is an antecedent the IFC theorems assume and nothing checks. Wiring it is its own
-change; recorded here so the number is coverage, not inventory.
+leaves is an antecedent the IFC theorems assume and nothing checks.
+
+**Why it is unwired, measured 2026-09-11 rather than assumed.** It builds and runs —
+`cargo dylint --lib nucleus_observed_lint -- -p nucleus-tool-proxy` completes on macOS, so
+the SIP constraint recorded in `dylint-separation.yml:20-25` binds `compiletest` (UI tests)
+and not the pass itself. It reports **85** ingests-without-observe findings over that crate,
+so a gate at zero is not available today. Two distinct causes, both in the lint:
+
+1. **The observe-set names the wrong API.** `OBSERVE_MARKERS` is
+   `["ifc_api::FlowTracker::observe", "FlowTracker::observe"]`, but `nucleus-tool-proxy`
+   observes through `FlowGraph::observe_with_content_hash` — a different type. `read_file`
+   and `run_command` both call `ingest::http_observe_*`, which reaches `FlowGraph::observe*`,
+   and both are reported as unobserved. Adding `FlowGraph::observe` to the set was measured:
+   85 → **80**. Real, and small.
+2. **There is no crate scope.** The remaining 80 are the host runtime's own infrastructure
+   I/O reached through the dependency closure — `build_mtls_config`, `load_last_hash`,
+   `require_node_identity`, `build_audit_log` — which is not agent-attributed ingest. This is
+   exactly what `mediated` faced and answered with `MEDIATED_CRATES` in C6 phase 1b, and
+   `observed` has no equivalent.
+
+So wiring it is not "add a workflow block": it needs the observe-set extended and a crate
+scope decided, each with its own probe. Recorded here with numbers so the next person starts
+from the measurement rather than from the assumption that a built lint is a cheap gate.
 
 ### A-19 applies to every lint in this ADR
 

--- a/docs/adr/0007-make-the-defect-unwritable.md
+++ b/docs/adr/0007-make-the-defect-unwritable.md
@@ -467,8 +467,19 @@ so that "review" is on the record as a gap rather than mistaken for coverage.
 | tier | mechanism | where |
 |---|---|---|
 | **clippy** | a workspace lint, or a `clippy.toml` entry | `clippy.toml` (new in this ADR), `[workspace.lints]` in `Cargo.toml` |
-| **dylint** | a pass with UI tests | `tools/nucleus-*-lint/` — six exist today |
+| **dylint** | a pass with UI tests | `tools/nucleus-*-lint/` — six exist, **four are wired** |
 | **review** | no mechanical check is possible yet | stated, not hidden |
+
+**Which four.** `mediated`, `cb4a_separation`, `identity-isolation` and `egress` run in
+`.github/workflows/dylint-separation.yml`. **`nucleus-observed-lint` and
+`nucleus-guarantee-lint` are built and wired to nothing** — no workflow, no script;
+`guarantee` appears in the tree only as an `exclude` comment in the root manifest. The
+line above read "six exist today", which counts crates rather than coverage and is the
+membership-versus-enforcement confusion ADR 0006 is about, inside this ADR's own
+enforcement table. `observed` is the source-side dual of `mediated` — it asks whether
+every path that ingests external bytes reaches `FlowTracker::observe*` — so the gap it
+leaves is an antecedent the IFC theorems assume and nothing checks. Wiring it is its own
+change; recorded here so the number is coverage, not inventory.
 
 ### A-19 applies to every lint in this ADR
 

--- a/scripts/check-clippy-ratchet.sh
+++ b/scripts/check-clippy-ratchet.sh
@@ -57,9 +57,19 @@ FAILED=$(jq -r 'select(.reason=="compiler-message") | .message
 # both lib and test yields the same warning twice, and which targets cargo
 # rebuilds varies -- consecutive runs reported 406 then 404 on an unchanged
 # tree before this dedupe.
-COUNT=$(jq -r 'select(.reason=="compiler-message") | .message
+# The lint set is the one parsed from the toml at the top of this file, passed
+# in rather than restated. It used to be `startswith("clippy::cast")`, which
+# agreed with the toml only because every tracked lint happened to be a cast:
+# the `-W` flags came from the toml and the COUNT came from a hardcoded prefix,
+# so any non-cast lint added to `lints` would have been warned by clippy and
+# then counted as zero. The ceiling would never move and the gate would report
+# OK while tracking nothing -- a gate that cannot fail, which is exactly what
+# `check-gates-can-fail.sh` exists to forbid.
+COUNT=$(jq -r --arg lints "$LINTS" '($lints | split("\n") | map(select(length > 0))) as $tracked
+           | select(.reason=="compiler-message") | .message
            | select(.level=="warning" or .level=="error")
-           | select((.code.code // "") | startswith("clippy::cast"))
+           | (.code.code // "") as $c
+           | select(($tracked | index($c)) != null)
            | (.spans[] | select(.is_primary)) as $s
            | "\($s.file_name):\($s.line_start):\($s.column_start):\(.code.code)"' "$RAW" \
   | sort -u | wc -l | tr -d ' ')

--- a/scripts/ingest-hashed-allowlist.txt
+++ b/scripts/ingest-hashed-allowlist.txt
@@ -34,8 +34,14 @@ if let Ok(node_id) = kernel.observe(obs_kind, &obs_parents) {
 #   the Labeled type carries the adversarial taint, the observe marks the op.
 .observe(NodeKind::WebContent)
 #
-# ── portcullis-effects: child-ceiling propagation sentinel (runtime.rs :1091) ──
+# ── portcullis-effects: child-ceiling propagation sentinel (runtime.rs :1247) ──
 # WebContent used purely as a SENTINEL to raise a freshly-built child runtime's
 # taint/conf ceilings to the parent's (the FlowTracker API only raises ceilings
 # via observation). No bytes are ingested — it is a ceiling-init, not an input.
-.observe(portcullis_core::flow::NodeKind::WebContent);
+#
+# The trailing `;` is gone because the call is no longer `let _ = ...`: its
+# Result is now propagated, since a sentinel that fails to be observed leaves
+# the child BELOW the parent and a tainted parent would hand back a child
+# reading as clean. This allowlist matches the trimmed line TEXT, so handling
+# the error changed the key — worth knowing before the next edit here.
+.observe(portcullis_core::flow::NodeKind::WebContent)

--- a/tools/nucleus-observed-lint/src/lib.rs
+++ b/tools/nucleus-observed-lint/src/lib.rs
@@ -69,11 +69,20 @@
 //!    correct for a LIBRARY. This target is a BINARY whose handlers are private
 //!    (`async fn run_command`, never `pub`), so the filter hid all of them.
 //!
-//! **Bugs 1 and 2 are present in `nucleus-mediation-lint` today**, which is a
-//! CI gate. It skips closures and has no `ExprKind::Closure` handling at all, so
-//! it cannot see any `async fn` body: 153 of ~571 functions in `nucleus-node`
-//! and 21 of ~376 in `portcullis-effects` are invisible to it. Its green board
-//! is not evidence over that code. Fixing it is a separate change.
+//! **Bugs 1 and 2 WERE present in `nucleus-mediation-lint`, and are fixed.**
+//! When this comment was written that pass skipped closures entirely, so it
+//! could not see any `async fn` body — 153 of ~571 functions in `nucleus-node`
+//! and 21 of ~376 in `portcullis-effects` were invisible to a CI gate, and its
+//! green board was not evidence over that code. `aba8da1c1` ("mediation lint was
+//! blind to every async fn — 14 hidden unmediated paths", #2138) closed it:
+//! `strip_generics` at `nucleus-mediation-lint/src/lib.rs:181` normalises the
+//! path before matching, and `ExprKind::Closure` descent at `:340` walks into
+//! `tcx.hir_body`. Verified 2026-09-11.
+//!
+//! The paragraph is kept rather than deleted because the failure it describes is
+//! the reason this pass handles closures from its first line, and because a lint
+//! that says a live sibling gate is blind when it is not is the same defect in
+//! the other direction.
 //!
 //! # What is deliberately not flagged
 //!


### PR DESCRIPTION
Seven commits against ADR 0006 (four collapses) and ADR 0007 (make the defect unwritable). Two change enforcement, three add or repair gates, two correct claims. Each landed with a red-then-green probe per ADR 0007 A-19.

## The two that change enforcement

**`c4c8af16b` → a tainted parent could hand back a clean child.** `NucleusRuntime::spawn_child` raises a child's ceilings to the parent's by observing a sentinel node — the FlowTracker API only permits raising via observation — and discarded the result:

```rust
let _ = child.flow_tracker_mut().observe(NodeKind::WebContent);
```

`observe` returns `Result<u64, FlowError>`. On the error path the child's ceilings stay **below** the parent's, so a tainted parent returns a child reading as clean and `spawn_child` returns `Ok` — on the taint-propagation path of the sealed agent-effect boundary. ADR 0007 A-2 exactly: "I could not look" rendered as "I looked and it was fine". Three `spawn_child` tests existed and all three tested profile attenuation; nothing asserted taint inheritance, which is why the discard was invisible.

Mapped to `RuntimeError::Config`, not `Denied` — `Denied`'s doc says "denied by the policy" and this is not policy; widening a rejection variant to cover a second failure kind is the defect A-8 is about.

**`bc2f400ee` → a new spec field stops compiling at the delegation boundary.** ADR 0006 C4.2. `create_sub_pod` decides 4 of `PodSpecInner`'s 14 fields; the other 10, and all 4 of `Metadata`'s, reach the serialized child spec as the requester wrote them. That enumeration *is* the security boundary and it was maintained by hand — the comment at step 4b already said authority "must be made deliberately, not inherited from a field being added", and nothing made it so. Two exhaustive destructures now do.

No new clamps here; each forwarded field carries a one-line reason, including that `timeout_seconds` becomes the session-token TTL uncapped. Those are the backlog to work through in severity order.

## The three gates

- **`432871685`** — `check-clippy-ratchet.sh` parsed its lint set from the toml at `:14` and then counted with a hardcoded `startswith("clippy::cast")` at `:62`. They agreed only by coincidence. Any non-cast lint added to `lints` would be warned by clippy and counted as **zero** — a gate reporting OK forever while tracking nothing, inside the mechanism this repo reaches for first to enforce ADR 0007.
- **`ad5493b45`** — `nucleus-node` did not compile on macOS (five tests and a helper called `#[cfg(target_os = "linux")]` items ungated), so `check-clippy-ratchet.sh --strict` could not run on a Mac at all and every ceiling had to be seeded from CI. It now runs locally: **333 against a ceiling of 345 in 47s**.
- **`27f3bad00`** — `wildcard_enum_match_arm` denied in the three crates measured at zero. Two crates the plan named are **not** clean and are excluded with their counts stated (`nucleus-ifc` 9, `nucleus-mcp-guard` 36).

## The two corrections

- **`38b64a127`** — ADR 0006 said "Nothing in this ADR is implemented" while seven milestones had landed; ADR 0007's enforcement table counted six dylint crates as coverage when four are wired; `nucleus-observed-lint` asserted a live sibling gate is blind to every `async fn` when that was fixed in `aba8da1c1`. Each verified against the tree individually.
- **`4ca4b82c2`** — why `observed` is unwired, measured rather than assumed. It builds and runs (the SIP constraint binds `compiletest`, not the pass), but reports **85** ingests-without-observe over `nucleus-tool-proxy`. Two causes, both in the lint: its `OBSERVE_MARKERS` names `FlowTracker::observe` while the crate observes via `FlowGraph::observe_with_content_hash` (adding the marker: 85 → 80, measured), and it has no crate scope, so the rest is host infrastructure I/O — the problem `mediated` solved with `MEDIATED_CRATES`. The lint source is unchanged; only the measurement is committed.

## Probes

| change | red | green |
|---|---|---|
| ratchet counts its lint set | old script + a non-cast lint reads 333 (invisible) | new script reads 564 |
| wildcard-enum deny | injected `_ => 1` arm reds all three crates | removed, clean |
| `let_underscore_must_use` | `let _ = "1".parse::<u32>();` fails the build | removed, clean |
| exhaustive destructure | added field → `E0027` at `pod_mgmt.rs:236` | removed, clean |

## Verification

macOS, after rebase onto `342a48f68`: `cargo clippy -p nucleus-node -p portcullis-effects -p nucleus-tool-proxy -p nucleus-policy-kernel -p ck-policy -p nucleus-cred-broker --all-targets --all-features -- -D warnings` clean; **1093 tests passed, 0 failed**.

Not verifiable locally and left to this PR's CI: the Linux-only dylint passes, and the ratchet's real count on linux (macOS reads 333, CI has historically read higher — `.clippy-ratchet.toml` records a ceiling seeded at 341 locally that CI counted at 345).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016t7JSuCtg4dC54HZjFgBjr