### PR TITLE
Exposure reporting reads the object that accumulated it

### DIFF
--- a/crates/nucleus-tool-proxy/src/exit_report.rs
+++ b/crates/nucleus-tool-proxy/src/exit_report.rs
@@ -177,17 +177,27 @@ pub fn apply_art12(report: &mut ExitReport, log: Option<&std::sync::Arc<crate::a
 /// strings the trust gate scores on is testable, and so main.rs stays under its
 /// line ratchet. The guard is read here rather than passed pre-extracted: the
 /// point of the field is what the guard actually held at shutdown.
+/// `kernel_exposure` is the fallback, and on an HTTP pod it is the ONLY source.
+/// `exposure_guard` is written by `NucleusMcpServer::new` alone, and the two
+/// transports are mutually exclusive, so an HTTP pod reached both `return`s
+/// below and shipped an exit report with `observed_exposure_labels` empty — for
+/// its entire life, and indistinguishable from a session that was never exposed
+/// to anything. The kernel is what actually accumulates exposure and gates on
+/// it, so its set is the honest answer when the MCP guard is absent.
 pub fn apply_exposure(
     report: &mut ExitReport,
     exposure_guard: &std::sync::RwLock<Option<std::sync::Arc<portcullis::GradedExposureGuard>>>,
+    kernel_exposure: &portcullis::guard::ExposureSet,
 ) {
-    let Ok(guard_opt) = exposure_guard.read() else {
-        return;
+    let exposure = match exposure_guard.read() {
+        Ok(guard_opt) => match guard_opt.as_ref() {
+            Some(guard) => guard.exposure(),
+            None => kernel_exposure.clone(),
+        },
+        // A poisoned lock is not "clean": fall back to the kernel rather than
+        // returning, which would report no exposure at all.
+        Err(_) => kernel_exposure.clone(),
     };
-    let Some(guard) = guard_opt.as_ref() else {
-        return;
-    };
-    let exposure = guard.exposure();
     for (label, name) in [
         (portcullis::guard::ExposureLabel::PrivateData, "PrivateData"),
         (
@@ -247,11 +257,14 @@ pub async fn write_exit_report(
         );
     }
 
-    apply_exposure(&mut report, exposure_guard);
     apply_art12(&mut report, art12_log);
     {
         let kernel = kernel.lock().await;
         apply_authority(&mut report, &kernel, task_grant_id);
+        // Moved inside this block so the kernel's own exposure is available as
+        // the fallback. It is read at shutdown either way, which is the point of
+        // the field.
+        apply_exposure(&mut report, exposure_guard, kernel.exposure());
     }
 
     let report_path = work_dir_path.join(".nucleus-exit-report.json");
@@ -439,6 +452,94 @@ mod tests {
             dirty.monitor_violations,
             vec!["OutcomeWithoutDecision", "OutcomeWithoutDecision"],
             "the report must carry the violations the monitor observed"
+        );
+    }
+
+    /// **An HTTP pod's exit report records the exposure it actually accumulated.**
+    ///
+    /// `exposure_guard` is written by `NucleusMcpServer::new` alone, and the two
+    /// transports are mutually exclusive (`main.rs`: `if args.mcp { return … }`),
+    /// so on an HTTP pod the slot is `None` for the pod's whole life. Before this,
+    /// `apply_exposure` returned early on that `None` and the report shipped with
+    /// `observed_exposure_labels` empty — indistinguishable from a session that
+    /// touched nothing, for every HTTP pod ever run.
+    ///
+    /// The kernel is what accumulates exposure and gates on it, so it is the
+    /// honest source when the MCP guard is absent.
+    #[test]
+    fn an_http_pod_reports_the_kernels_exposure_not_an_empty_set() {
+        use portcullis::guard::{ExposureLabel, ExposureSet};
+
+        let no_mcp_guard = std::sync::RwLock::new(None);
+
+        // The control: nothing accumulated anywhere is still an empty report, so
+        // the assertion below is about the SOURCE and not about the mapping.
+        let mut clean = build_exit_report("w".into(), "t".into(), 1, None, &clean_monitor());
+        apply_exposure(&mut clean, &no_mcp_guard, &ExposureSet::empty());
+        assert!(
+            clean.observed_exposure_labels.is_empty(),
+            "an unexposed session must file an empty report, or the assertion below proves nothing"
+        );
+
+        // The kernel saw private data and untrusted content. With no MCP guard,
+        // that is what the report must carry.
+        let kernel_exposure = ExposureSet::singleton(ExposureLabel::PrivateData)
+            .union(&ExposureSet::singleton(ExposureLabel::UntrustedContent));
+        let mut report = build_exit_report("w".into(), "t".into(), 1, None, &clean_monitor());
+        apply_exposure(&mut report, &no_mcp_guard, &kernel_exposure);
+
+        assert!(
+            report
+                .observed_exposure_labels
+                .contains(&"PrivateData".to_string()),
+            "the kernel's PrivateData exposure must reach the exit report: {:?}",
+            report.observed_exposure_labels
+        );
+        assert!(
+            report
+                .observed_exposure_labels
+                .contains(&"UntrustedContent".to_string()),
+            "the kernel's UntrustedContent exposure must reach the exit report: {:?}",
+            report.observed_exposure_labels
+        );
+        assert!(
+            !report
+                .observed_exposure_labels
+                .contains(&"ExfilVector".to_string()),
+            "a leg the kernel did not record must not appear: {:?}",
+            report.observed_exposure_labels
+        );
+    }
+
+    /// A poisoned guard lock is not "clean" either.
+    ///
+    /// The early `return` on a failed read had the same shape as the `None` arm:
+    /// it filed a report saying no exposure was observed. Under-reporting taint
+    /// is the direction that makes a session look safer than it was.
+    #[test]
+    fn a_poisoned_guard_still_reports_the_kernels_exposure() {
+        use portcullis::guard::{ExposureLabel, ExposureSet};
+
+        let poisoned = std::sync::RwLock::new(None);
+        let _ = std::panic::catch_unwind(|| {
+            let _g = poisoned.write().expect("lock");
+            panic!("poison it");
+        });
+        assert!(
+            poisoned.read().is_err(),
+            "the lock must actually be poisoned"
+        );
+
+        let kernel_exposure = ExposureSet::singleton(ExposureLabel::ExfilVector);
+        let mut report = build_exit_report("w".into(), "t".into(), 1, None, &clean_monitor());
+        apply_exposure(&mut report, &poisoned, &kernel_exposure);
+
+        assert!(
+            report
+                .observed_exposure_labels
+                .contains(&"ExfilVector".to_string()),
+            "a poisoned MCP guard must fall back to the kernel, not to silence: {:?}",
+            report.observed_exposure_labels
         );
     }
 

--- a/crates/nucleus-tool-proxy/src/main.rs
+++ b/crates/nucleus-tool-proxy/src/main.rs
@@ -462,6 +462,10 @@ pub(crate) struct AppState {
     cert_root_pubkey: Option<Arc<Vec<u8>>>,
     /// Session exposure guard for exit report (set when MCP server starts).
     exposure_guard: Arc<std::sync::RwLock<Option<Arc<portcullis::GradedExposureGuard>>>>,
+    /// Mirror of the kernel's accumulated `ExposureSet`, updated at the one site
+    /// that holds the kernel lock. The sink and the exit report read this when
+    /// `exposure_guard` is `None`, which on an HTTP pod is always.
+    kernel_exposure: Arc<std::sync::RwLock<portcullis::guard::ExposureSet>>,
     /// File-based lockdown flag. Set by the signal file watcher.
     file_lockdown: Arc<std::sync::atomic::AtomicBool>,
     /// gRPC stream-based lockdown flag. Set by the lockdown streaming client.
@@ -1651,6 +1655,15 @@ async fn main() -> Result<(), ApiError> {
     let stream_lockdown = Arc::new(std::sync::atomic::AtomicBool::new(false));
     let exposure_guard: Arc<std::sync::RwLock<Option<Arc<portcullis::GradedExposureGuard>>>> =
         Arc::new(std::sync::RwLock::new(None));
+    // The kernel's accumulated exposure, mirrored out of `decide_and_record`
+    // while it holds the kernel lock. `exposure_guard` above is written only by
+    // `NucleusMcpServer::new`, and the transports are mutually exclusive, so on
+    // an HTTP pod it stays `None` and the telemetry read four false flags. The
+    // kernel is the thing that actually accumulates exposure and gates on it;
+    // this is how the reporting side gets to see the same set.
+    let kernel_exposure: Arc<std::sync::RwLock<portcullis::guard::ExposureSet>> = Arc::new(
+        std::sync::RwLock::new(portcullis::guard::ExposureSet::empty()),
+    );
 
     // DLC-D verified admission: provisioned from NUCLEUS_DLC_* env (inert when
     // unset). The SAME provisioning is applied to both transports' kernels, and
@@ -1717,6 +1730,7 @@ async fn main() -> Result<(), ApiError> {
         policy_checksum.clone(),
         session_id.clone(),
         dlc_provisioned,
+        kernel_exposure.clone(),
         art12_log.clone(),
         art12_shipper.clone(),
         art12_sink::mediation_receipt_log_path(args.art12_log.as_deref(), &spec.spec.work_dir),
@@ -1861,6 +1875,7 @@ async fn main() -> Result<(), ApiError> {
         pod_cert,
         proposals,
         exposure_guard,
+        kernel_exposure: kernel_exposure.clone(),
         file_lockdown,
         stream_lockdown,
         policy_checksum,
@@ -2654,6 +2669,16 @@ async fn http_kernel_decide(
     // The kernel-decision record names the same actor the handler's own
     // records do; it used to hardcode `Unknown` while the sibling record in
     // the same handler carried the SPIFFE ID.
+    // Mirror the kernel's exposure out for the reporting side. PRE-state first:
+    // the verdict `decide_and_record` is about to write should carry the exposure
+    // the decision was made AGAINST, which is what `exposure_transition`'s
+    // `pre_count` in the same record means. POST-state after, so the exit report
+    // and the next verdict see this decision's own contribution. Two writes
+    // rather than one because those are two different questions and a single
+    // mirror would answer the wrong one for whichever consumer read it.
+    if let Ok(mut cell) = state.kernel_exposure.write() {
+        *cell = kernel.exposure().clone();
+    }
     let decided = mediation::decide_and_record(
         mediation::MediationEnv {
             sink: state.verdict_sink.as_ref(),
@@ -2666,6 +2691,12 @@ async fn http_kernel_decide(
         operation,
         subject,
     );
+
+    // POST-state. The kernel has applied this operation's contribution, so the
+    // exit report and the next verdict see it.
+    if let Ok(mut cell) = state.kernel_exposure.write() {
+        *cell = kernel.exposure().clone();
+    }
 
     // The moment of denial is the only moment the affordance is useful. The
     // proposal used to be rebuilt after the run, from a trace file, at the CLI

--- a/crates/nucleus-tool-proxy/src/pod_mgmt.rs
+++ b/crates/nucleus-tool-proxy/src/pod_mgmt.rs
@@ -203,6 +203,13 @@ pub(crate) async fn create_sub_pod(
     // request aimed at a URL I choose". See clamp_credentialed_egress.
     clamp_credentialed_egress(&mut spec, &state.credentialed_egress);
 
+    // 4d. STRIP any audit sink the requester asked for. Same reasoning as 4b and
+    // 4c, with the payload being the audit trail itself: the node lowers this
+    // field into the child's KERNEL BOOT ARGS, so leaving it through lets an
+    // agent send the record of what its child did to a destination it chose, and
+    // keep it from the operator. See strip_requested_audit_sink.
+    strip_requested_audit_sink(&mut spec);
+
     // 5. Inject credentials from orchestrator's env (transparent to agent)
     let mut creds = spec.spec.credentials.take().unwrap_or_default();
     for (key, val) in &state.orchestrator_credentials {
@@ -239,6 +246,7 @@ pub(crate) async fn create_sub_pod(
         workload: _workload, // 4b stripped
         credentialed_egress: _credentialed_egress, // 4c clamped to the parent's upstreams
         credentials: _credentials, // 5  orchestrator env merged in
+        audit_sink: _audit_sink, // 4d stripped
 
         // ── Forwarded as the requester wrote them ───────────────────────────
         // Each line is a standing decision to delegate that field unclamped.
@@ -251,11 +259,10 @@ pub(crate) async fn create_sub_pod(
         resources: _resources,       // cpu/memory the child asks the node for
         network: _network,           // egress shape; `credentialed_egress` is the
         // separate field clamped at 4c, not this one
-        image: _image,           // the child names its own kernel and rootfs
-        vsock: _vsock,           // guest-host socket configuration
-        seccomp: _seccomp,       // syscall filter — a child may ask for a weaker one
-        cgroup: _cgroup,         // cgroup limits
-        audit_sink: _audit_sink, // where the child's audit record is written
+        image: _image,     // the child names its own kernel and rootfs
+        vsock: _vsock,     // guest-host socket configuration
+        seccomp: _seccomp, // syscall filter — a child may ask for a weaker one
+        cgroup: _cgroup,   // cgroup limits
     } = &spec.spec;
 
     // `metadata` is a sibling of `spec` on `PodSpec`, so the destructure above
@@ -772,6 +779,36 @@ pub(crate) fn clamp_credentialed_egress(
     spec.spec.credentialed_egress = kept;
 }
 
+/// STRIP any audit sink the requester asked for.
+///
+/// `AuditSinkSpec` is an S3 bucket, prefix, region and a **custom endpoint URL**,
+/// and `nucleus-node` turns it into KERNEL BOOT ARGS for the child VM
+/// (`firecracker_config.rs`: `nucleus.audit_s3_bucket=...`, `..._endpoint=...`).
+/// So an agent-authored sub-pod spec chooses where the child's audit record is
+/// written, which is two things at once: the record of what the child did never
+/// reaches the operator, and the records themselves are shipped to a destination
+/// the agent named.
+///
+/// That is the same shape as `clamp_credentialed_egress` guards against —
+/// "a request aimed at a URL I choose" — with the payload being the audit trail.
+/// It is STRIPPED rather than clamped because, unlike credentialed egress, the
+/// tool-proxy holds no parent sink to narrow against: its own audit goes to
+/// `state.audit` / `state.art12_log`, which are different mechanisms. Where the
+/// child's audit is written is the node's decision, not the requester's.
+///
+/// Stripped rather than rejected so a spec that carries one is still usable, and
+/// logged so the attempt is visible — the same treatment `workload` gets.
+pub(crate) fn strip_requested_audit_sink(spec: &mut PodSpec) {
+    if let Some(sink) = spec.spec.audit_sink.take() {
+        tracing::warn!(
+            bucket = %sink.s3_bucket,
+            endpoint = %sink.s3_endpoint.as_deref().unwrap_or("<default>"),
+            "sub-pod request specified an audit sink; stripped -- ManagePods does not confer \
+             the choice of where a pod's own audit record is written"
+        );
+    }
+}
+
 pub(crate) fn strip_requested_workload(spec: &mut PodSpec) {
     if spec.spec.workload.take().is_some() {
         tracing::warn!(
@@ -949,6 +986,65 @@ spec:
         assert_eq!(spec.spec.work_dir, work_dir);
         assert_eq!(spec.metadata.name.as_deref(), Some("sub"));
     }
+
+    fn spec_with_audit_sink() -> PodSpec {
+        let yaml = r#"
+apiVersion: nucleus/v1
+kind: Pod
+metadata:
+  name: sub
+spec:
+  work_dir: /w
+  audit_sink:
+    s3_bucket: attacker-bucket
+    s3_prefix: p/
+    s3_region: us-west-2
+    s3_endpoint: https://attacker.example
+"#;
+        serde_yaml::from_str(yaml).expect("spec parses")
+    }
+
+    /// **`ManagePods` must not confer the choice of where audit goes.**
+    /// `nucleus-node` lowers `audit_sink` into the child's KERNEL BOOT ARGS
+    /// (`firecracker_config.rs`: `nucleus.audit_s3_bucket=`, `..._endpoint=`), so
+    /// a surviving sink is two failures at once: the record of what the child did
+    /// never reaches the operator, and the records are shipped to a destination
+    /// the agent named. Same shape as the credentialed-egress clamp guards
+    /// against, with the audit trail as the payload.
+    #[test]
+    fn a_requested_audit_sink_is_stripped() {
+        let mut spec = spec_with_audit_sink();
+        assert!(
+            spec.spec.audit_sink.is_some(),
+            "the fixture must actually carry an audit sink, or the assertion below proves nothing"
+        );
+        strip_requested_audit_sink(&mut spec);
+        assert!(
+            spec.spec.audit_sink.is_none(),
+            "an agent-requested audit sink must not survive into the sub-pod spec"
+        );
+    }
+
+    /// Stripping the sink leaves the rest of the spec alone, and stripping a
+    /// spec that never named one is a no-op rather than an error — a sub-pod
+    /// request that asked for nothing unusual must still work.
+    #[test]
+    fn stripping_the_audit_sink_is_narrow_and_idempotent() {
+        let mut spec = spec_with_audit_sink();
+        let work_dir = spec.spec.work_dir.clone();
+        strip_requested_audit_sink(&mut spec);
+        assert_eq!(spec.spec.work_dir, work_dir);
+        assert_eq!(spec.metadata.name.as_deref(), Some("sub"));
+
+        // Second pass over an already-stripped spec changes nothing.
+        strip_requested_audit_sink(&mut spec);
+        assert!(spec.spec.audit_sink.is_none());
+
+        let mut clean = spec_with_workload();
+        assert!(clean.spec.audit_sink.is_none());
+        strip_requested_audit_sink(&mut clean);
+        assert_eq!(clean.metadata.name.as_deref(), Some("sub"));
+    }
 }
 
 #[cfg(test)]
@@ -1106,6 +1202,33 @@ spec:
         );
     }
 
+    /// The handler's own body, with comments removed.
+    ///
+    /// Both structural guards below read this function's source text, and until
+    /// now neither could fail. Two bugs, both found by probing them:
+    ///
+    /// 1. The terminator read `"\n pub(crate) "` — with a leading space, which a
+    ///    top-level item never has. `find` returned `None` every time, `unwrap_or`
+    ///    fell through to `handler.len()`, and "the body" became the whole
+    ///    remaining 43k characters of the file. Every function DEFINITION was in
+    ///    scope, so `contains("clamp_credentialed_egress")` held whether or not
+    ///    the handler called it.
+    /// 2. Scoped correctly, the handler's own COMMENTS still name the functions —
+    ///    step 4c says "See clamp_credentialed_egress" — so a deleted call left
+    ///    its explanation behind and the grep matched that.
+    ///
+    /// Measured: with either bug present, deleting a call left both tests green.
+    /// ADR 0006 C4.2 credits these guards with noticing "a call being deleted";
+    /// they could not, which means the exhaustive destructure it proposes has
+    /// been carrying this alone.
+    fn handler_body(handler: &str) -> String {
+        handler[..handler.find("\npub(crate) ").unwrap_or(handler.len())]
+            .lines()
+            .filter(|l| !l.trim_start().starts_with("//"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
     /// STRUCTURAL: the handler must actually call the clamp. The unit tests
     /// above prove the function is correct; nothing else proves it is wired, and
     /// an unwired security check is the failure shape this repo keeps finding.
@@ -1116,7 +1239,12 @@ spec:
             .split("pub(crate) async fn create_sub_pod(")
             .nth(1)
             .expect("create_sub_pod must exist");
-        let body = &handler[..handler.find("\n pub(crate) ").unwrap_or(handler.len())];
+        let body = handler_body(handler);
+        assert!(
+            body.contains("strip_requested_audit_sink"),
+            "create_sub_pod no longer strips audit_sink — an agent-authored sub-pod spec can \
+             send the record of what the child did to a destination it chose, by kernel arg"
+        );
         assert!(
             body.contains("clamp_credentialed_egress"),
             "create_sub_pod no longer clamps credentialed_egress — an agent-authored \
@@ -1135,7 +1263,17 @@ spec:
             .split("pub(crate) async fn create_sub_pod(")
             .nth(1)
             .expect("create_sub_pod must exist");
-        let body = &handler[..handler.find("\n pub(crate) ").unwrap_or(handler.len())];
+        // The needle has NO leading space. It used to read "\n pub(crate) ", which
+        // never matches — a top-level item starts at column 0 — so `unwrap_or`
+        // fell through to `handler.len()` and "the handler body" was the whole
+        // remaining 43k characters of the file, function DEFINITIONS included.
+        // `contains` was then true whether or not the call existed, and both of
+        // these tests passed with the call deleted. Probed: deleting
+        // `strip_requested_audit_sink(&mut spec);` left them green.
+        //
+        // ADR 0006 C4.2 says of these guards "They can notice a call being
+        // deleted." They could not. They can now.
+        let body = handler_body(handler);
         assert!(
             body.contains("narrow_to_ceiling("),
             "narrowing must be unconditional"

--- a/crates/nucleus-tool-proxy/src/verdict_sink.rs
+++ b/crates/nucleus-tool-proxy/src/verdict_sink.rs
@@ -28,6 +28,17 @@ pub struct ToolProxyVerdictSink {
     exposure_guard: Arc<std::sync::RwLock<Option<Arc<GradedExposureGuard>>>>,
     policy_checksum: String,
     session_id: String,
+    /// The KERNEL's accumulated exposure, mirrored by `decide_and_record`.
+    ///
+    /// `exposure_guard` above is populated only by `NucleusMcpServer::new`, and
+    /// the two transports are mutually exclusive (`main.rs`: `if args.mcp {
+    /// return ... }`). On an HTTP pod that slot is `None` for the pod's whole
+    /// life, so `read_exposure` reported four false flags — not because nothing
+    /// was measured, but because it read the wrong object. The decision is made
+    /// by `portcullis::kernel::Kernel`, which accumulates its own `ExposureSet`
+    /// and gates on it (kernel step 7). This mirrors that set so the telemetry
+    /// reports the exposure the decision was actually made against.
+    kernel_exposure: Arc<std::sync::RwLock<portcullis::guard::ExposureSet>>,
     /// Whether DLC-D verified admission is provisioned on this pod's kernels.
     /// When true, every `Allow` this sink records has — by kernel construction
     /// (the dlc gate is consulted before any Allow can emerge from
@@ -87,6 +98,7 @@ pub fn build_monitored_sink(
     policy_checksum: String,
     session_id: String,
     dlc_provisioned: bool,
+    kernel_exposure: Arc<std::sync::RwLock<portcullis::guard::ExposureSet>>,
     art12_log: Option<Arc<crate::art12::Art12Log>>,
     art12_shipper: Option<Arc<crate::art12_shipper::Art12Shipper>>,
     mediation_receipt_log: Option<std::path::PathBuf>,
@@ -100,6 +112,7 @@ pub fn build_monitored_sink(
         policy_checksum.clone(),
         session_id.clone(),
         dlc_provisioned,
+        kernel_exposure,
     ));
 
     // Article 12 record-keeping, when configured. INSIDE the monitor, so the
@@ -144,8 +157,10 @@ impl ToolProxyVerdictSink {
         policy_checksum: String,
         session_id: String,
         dlc_provisioned: bool,
+        kernel_exposure: Arc<std::sync::RwLock<portcullis::guard::ExposureSet>>,
     ) -> Self {
         Self {
+            kernel_exposure,
             consecutive_denials: AtomicU32::new(0),
             denial_budget: denial_budget_from_env(),
             file_lockdown,
@@ -261,7 +276,11 @@ impl ToolProxyVerdictSink {
                     is_uninhabitable: exp.is_uninhabitable(),
                 }
             } else {
-                telemetry::VerdictExposure::default()
+                // No MCP guard: this is an HTTP pod. Report the KERNEL's
+                // exposure — the set the decision was actually made against —
+                // rather than `default()`, four false flags that read as
+                // "measured, and clean".
+                self.read_kernel_exposure()
             }
         } else {
             tracing::error!("exposure_guard RwLock poisoned — reporting uninhabitable");
@@ -271,6 +290,29 @@ impl ToolProxyVerdictSink {
                 exfil_vector: true,
                 is_uninhabitable: true,
             }
+        }
+    }
+
+    /// The kernel's accumulated exposure, as telemetry.
+    ///
+    /// Fails CLOSED on a poisoned lock for the reason `read_exposure` does: a
+    /// torn set could under-report taint, and under-reporting is the direction
+    /// that makes a session look safer than it is.
+    fn read_kernel_exposure(&self) -> telemetry::VerdictExposure {
+        let Ok(exp) = self.kernel_exposure.read() else {
+            tracing::error!("kernel_exposure RwLock poisoned — reporting uninhabitable");
+            return telemetry::VerdictExposure {
+                private_data: true,
+                untrusted_content: true,
+                exfil_vector: true,
+                is_uninhabitable: true,
+            };
+        };
+        telemetry::VerdictExposure {
+            private_data: exp.contains(portcullis::guard::ExposureLabel::PrivateData),
+            untrusted_content: exp.contains(portcullis::guard::ExposureLabel::UntrustedContent),
+            exfil_vector: exp.contains(portcullis::guard::ExposureLabel::ExfilVector),
+            is_uninhabitable: exp.is_uninhabitable(),
         }
     }
 }
@@ -497,6 +539,9 @@ mod tests {
             "test-checksum".to_string(),
             "test-session".to_string(),
             false,
+            Arc::new(std::sync::RwLock::new(
+                portcullis::guard::ExposureSet::empty(),
+            )),
         )
     }
 
@@ -615,6 +660,9 @@ mod tests {
             "test-checksum".to_string(),
             "test-session".to_string(),
             false,
+            Arc::new(std::sync::RwLock::new(
+                portcullis::guard::ExposureSet::empty(),
+            )),
             None,
             None,
             None,
@@ -670,6 +718,9 @@ mod tests {
             "test-checksum".to_string(),
             "test-session".to_string(),
             false,
+            Arc::new(std::sync::RwLock::new(
+                portcullis::guard::ExposureSet::empty(),
+            )),
             None,
             None,
             None,


### PR DESCRIPTION
Stacked on #2818. **This corrects a claim I made in the proposal that led to it.**

## What I got wrong

I proposed wiring a session-keyed `GradedExposureGuard` into the HTTP path, on the premise that "the lethal-trifecta gate never fires on HTTP." That premise is **false**, and measuring it changed the work.

`portcullis::kernel::Kernel` keeps its own `ExposureSet`, projects each operation into it, and **gates on it** — step 7, the dynamic exposure gate, which denies exfil operations once the uninhabitable state is reached. The HTTP path holds one kernel in `state.kernel` for the pod's lifetime and routes every decision through `mediation::decide_and_record`. Enforcement was never missing.

Wiring a second `GradedExposureGuard` would have added a *second exposure accumulator beside the one that decides* — the exact defect ADR 0006 is about.

## What is actually broken

**Reporting**, not enforcement.

`state.exposure_guard` is written in exactly one place — `NucleusMcpServer::new` (`mcp.rs:316`) — and the transports are mutually exclusive (`main.rs`: `if args.mcp { return mcp::run_mcp_server(..).await; }`). So on an HTTP pod that slot is `None` **for the pod's entire life**, and both consumers treated `None` as clean:

- `ToolProxyVerdictSink::read_exposure` → `VerdictExposure::default()`, four false flags on every verdict
- `exit_report::apply_exposure` → early `return`, shipping `observed_exposure_labels` empty

An exit report saying "no exposure observed" was indistinguishable from a session that touched nothing. The exposure existed the whole time; nobody asked the object that had it.

## The fix

Read the object that decides.

`AppState` gains a mirror of the kernel's `ExposureSet`, written at the single site that holds the kernel lock — **twice, deliberately**. PRE-decision, so the verdict `decide_and_record` writes carries the exposure the decision was made *against* (which is what `exposure_transition.pre_count` in the same record means); POST, so the exit report and the next verdict see this decision's own contribution. One mirror answers the wrong question for one of them.

The exit report needed no mirror: its caller already locks the kernel eight lines later for `apply_authority`. `apply_exposure` moved into that block and takes the kernel's set as its fallback.

Both fall back to the kernel on a **poisoned** lock rather than returning, for the reason the surrounding code already gives for failing closed — under-reporting taint is the direction that makes a session look safer than it was.

## Probe

Restoring the `None => return` arm reds `an_http_pod_reports_the_kernels_exposure_not_an_empty_set`; putting it back greens both new tests. The control asserts an unexposed session *still* files an empty report, so the test is about the **source**, not the label mapping.

## Verification

`cargo test -p nucleus-tool-proxy` 435 passed, 0 failed · clippy `--all-targets --all-features -- -D warnings` clean · `cargo fmt --all --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016t7JSuCtg4dC54HZjFgBjr