### PR TITLE
A verdict names the session the kernel decided under

### DIFF
--- a/crates/nucleus-tool-proxy/src/mcp.rs
+++ b/crates/nucleus-tool-proxy/src/mcp.rs
@@ -397,6 +397,10 @@ impl NucleusMcpServer {
         // decision path.
         let graph = self.flow_graph.lock().await;
         let (decision, token) = kernel.decide_term_with_flow(term, Some(&*graph));
+        // Read before the lock goes: the record below names the session the
+        // KERNEL decided under, which is not the sink's own `session_id` (that
+        // one is the PermissionLattice's uuid).
+        let kernel_session_id = kernel.session_id();
         drop(graph);
         drop(kernel);
 
@@ -411,6 +415,7 @@ impl NucleusMcpServer {
             subject,
             ActorIdentity::StdioGuest,
             "mcp",
+            kernel_session_id,
         );
 
         match decision.verdict {

--- a/crates/nucleus-tool-proxy/src/mediation.rs
+++ b/crates/nucleus-tool-proxy/src/mediation.rs
@@ -316,6 +316,7 @@ pub(crate) fn decide_and_record(
         subject,
         actor.clone(),
         transport,
+        kernel.session_id(),
     );
 
     // A deferral that a human grant satisfied is TWO governance events, and the

--- a/crates/nucleus-tool-proxy/src/verdict_sink.rs
+++ b/crates/nucleus-tool-proxy/src/verdict_sink.rs
@@ -462,6 +462,7 @@ pub(crate) fn record_kernel_decision(
     subject: &str,
     actor: ActorIdentity,
     transport: &str,
+    kernel_session_id: uuid::Uuid,
 ) {
     use portcullis::gate_class;
     use portcullis::kernel::Verdict;
@@ -469,6 +470,25 @@ pub(crate) fn record_kernel_decision(
 
     let mut extensions = BTreeMap::new();
     extensions.insert("transport".to_string(), transport.to_string());
+    // The KERNEL's session id, which is not the one this sink carries.
+    //
+    // `ToolProxyVerdictSink.session_id` is `runtime.policy().id` — the
+    // PermissionLattice's uuid, whose own doc calls it "unique identifier for
+    // this permission set". `Kernel.session_id` is a separate `Uuid::new_v4()`,
+    // and it is the one the policy engine sees: `kernel.rs` passes it to Cedar
+    // as the principal. Two fresh uuids, both called a session id, written by
+    // the two objects that record the same decision — so a verdict could not be
+    // correlated with the kernel audit entry for the same call.
+    //
+    // Recorded rather than reconciled. Making one of them adopt the other means
+    // choosing which is the session, and the kernel is constructed AFTER this
+    // sink, so it is not a rename — it is a reordering with its own risk. This
+    // puts both in one record so the join is possible now, and names the
+    // choice for whoever makes it.
+    extensions.insert(
+        "kernel_session_id".to_string(),
+        kernel_session_id.to_string(),
+    );
     extensions.insert(
         "decision_sequence".to_string(),
         decision.sequence.to_string(),
@@ -774,6 +794,10 @@ mod tests {
     /// reframed this chokepoint: a verdict (allow or refusal) must reach the sink,
     /// never just a log line. `record_kernel_decision` is the same call the live
     /// HTTP and MCP paths make.
+    /// A fixed kernel session id, so the assertion below is about the value
+    /// travelling rather than about two `new_v4()`s happening to differ.
+    const KERNEL_SESSION: uuid::Uuid = uuid::uuid!("11111111-2222-3333-4444-555555555555");
+
     #[test]
     fn the_kernel_decision_reaches_the_record() {
         let sink = CapturingSink::default();
@@ -784,6 +808,7 @@ mod tests {
             "s",
             ActorIdentity::Unknown,
             "http",
+            KERNEL_SESSION,
         );
         let recorded = sink.0.lock().unwrap();
         assert_eq!(
@@ -797,6 +822,22 @@ mod tests {
         assert!(
             ext.contains_key("gate_class"),
             "the verdict's gate class must be in the evidence"
+        );
+
+        // The kernel's session id, which is NOT the one this sink carries.
+        //
+        // `ToolProxyVerdictSink.session_id` is the PermissionLattice's uuid;
+        // `Kernel.session_id` is a separate `Uuid::new_v4()` and is what the
+        // policy engine sees as the principal. Both are fresh uuids called a
+        // session id, written by the two objects that record one decision. Until
+        // this, a verdict could not be joined to the kernel audit entry for the
+        // same call. Asserting the exact value is what makes this about the id
+        // TRAVELLING rather than about a key existing.
+        assert_eq!(
+            ext.get("kernel_session_id").map(String::as_str),
+            Some("11111111-2222-3333-4444-555555555555"),
+            "the kernel's session id must reach the record, or a verdict cannot be \
+             correlated with the kernel audit entry for the same decision"
         );
     }
 


### PR DESCRIPTION
Stacked on #2820. Last of the three session steps.

Two fresh uuids in one pod, both called a session id, written by the two objects that record the same decision:

```
ToolProxyVerdictSink.session_id  = runtime.policy().id   (PermissionLattice)
Kernel.session_id                = Uuid::new_v4()        (kernel.rs:452)
```

`PermissionLattice.id`'s own doc calls it *"unique identifier for this permission set"*. `Kernel.session_id` is what the policy engine sees — `kernel.rs:1621` passes it to Cedar as the principal.

So the verdict record and the kernel's own audit entry for one call carried **different session identifiers** and could not be joined.

## Why this is the ADR 0006 shape

Measured while looking for where to put the first `From` edge: the tree has **ten session types across eight crates with zero conversions between any of them** — `SessionId`, `SessionIdentity`, `Session`, `IntentSession`, `ObserveSession`, `SessionProvenance`, `SessionSubgraph`, `SessionReport`, `SessionMonitor`, `SessionCleanseToken`. That is *"identity representations | ~43 | 0 `From` impls"* reproduced.

## Recorded, not reconciled

Making one adopt the other means choosing which *is* the session, and the kernel is constructed **after** this sink in `main.rs` — so it is not a rename, it is a reordering with its own risk and its own review.

This puts both identifiers in one record so the join is possible now, and names the choice for whoever makes it. `decide_and_record` already holds `&mut Kernel`, so the id costs nothing on the HTTP path; the MCP path reads it before dropping the lock.

## Probe

The test asserts the **exact uuid**, not the key's presence — a key that exists proves the map was written, not that the id travelled. Replacing the insert with `let _ = kernel_session_id;` reds it.

Worth noting: the MCP call site is behind the `mcp` feature, so a default-feature clippy run reported clean while the crate would not build with the feature on. Caught by `--all-features`.

## Verification

`cargo test -p nucleus-tool-proxy --all-features` 464 passed, 0 failed · clippy `--all-targets --all-features -- -D warnings` clean · `cargo fmt --all --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016t7JSuCtg4dC54HZjFgBjr