### PR TITLE
gate: the third conjunct — fly-pools now compares the volume count it printed

### DIFF
--- a/ci/fly-pools-drift.txt
+++ b/ci/fly-pools-drift.txt
@@ -23,4 +23,19 @@
 # and that is what this pin is for.
 #
 # Lower it in the change that reconciles a number, and say which side moved and why.
-DRIFT=4
+#
+# 4 -> 5, 2026-09-11, and the direction needs its reason stated because this pin is SHRINK-ONLY.
+# Nothing got worse. The gate began comparing a field it had always ignored: the third conjunct of
+# its own specification — "size, standby AND VOLUME COUNT" — which #2814 did not implement
+# (gatehouse FINDINGS.md F-79). The README says the build pool has one volume each,
+# 8 × 40 GB + 8 × 20 GB, so sixteen; POOLS declares `volumes: []`, so zero. That disagreement has
+# been there the whole time, unmeasured.
+#
+#   nucleus-fly-build  volumes  README 16   manager.toml 0
+#
+# The gate pool agrees: the README says "no volume" and POOLS declares none, so it contributes no
+# row. Raising a shrink-only pin to admit a newly-measured field is the same act as
+# check-gates-can-fail.sh's UNCOVERED_CEILING going 2 -> 10 when ten xtask gates entered its
+# domain — not a relaxation, a widening of what is looked at. A rise for any other reason is not
+# this, and should be refused.
+DRIFT=5

--- a/crates/xtask/src/fly_pools.rs
+++ b/crates/xtask/src/fly_pools.rs
@@ -136,6 +136,53 @@ fn readme_agrees(root: &Path, pools: &[ci_fly_runner::PoolSpec]) -> Result<()> {
             );
         };
         rows += 1;
+        // The third conjunct of this gate's specification — "size, standby AND VOLUME COUNT" —
+        // which #2814 did not implement. `FINDINGS.md` F-79 records that omission and the reason it
+        // is a mechanism rather than forgetfulness: a spec with three conjuncts yields a gate that
+        // is green when two hold, and the green output cannot say which.
+        //
+        // The README states volumes as prose, two ways: "no volume", or "one volume each
+        // (8 × 40 GB + 8 × 20 GB)" — a sum of counts, not a single number. Both are read here; a
+        // row saying neither is an error rather than a zero, because a pool whose volume prose
+        // stopped parsing is a pool this gate has silently stopped checking.
+        let claimed_volumes = if row.contains("no volume") {
+            Some(0usize)
+        } else if let Some(inner) = row
+            .split("volume each (")
+            .nth(1)
+            .and_then(|r| r.split(')').next())
+        {
+            // "8 × 40 GB + 8 × 20 GB" — the count is the first number of each `N × …` term.
+            let n: usize = inner
+                .split('+')
+                .filter_map(|term| {
+                    term.trim()
+                        .split(|c: char| !c.is_ascii_digit())
+                        .find(|t| !t.is_empty())
+                        .and_then(|t| t.parse::<usize>().ok())
+                })
+                .sum();
+            Some(n)
+        } else {
+            None
+        };
+        match claimed_volumes {
+            None => bail!(
+                "{README}'s row for {:?} states its volumes in neither form this reads \
+                 (\"no volume\", or \"volume each (N × … + M × …)\") — a row that stopped parsing is a \
+                 pool this gate stopped checking",
+                p.label
+            ),
+            Some(c) if c != p.volumes.len() => {
+                drift.push(format!(
+                    "{} volumes: README {c}, {MANAGER_TOML} {}",
+                    p.label,
+                    p.volumes.len()
+                ));
+            }
+            Some(_) => {}
+        }
+
         for (field, declared) in [("size", p.size), ("standby", p.standby)] {
             let claimed = row
                 .split(&format!("{field} "))


### PR DESCRIPTION
gatehouse **F-79**: this gate's specification was *"assert the README's pool table agrees with
`manager.toml` on **size, standby and volume count**"*. #2814 implemented two of the three, and the
gate mentioned `volumes` **five times, every one in its printout**. **It printed the number it never
checked.**

Now it checks it.

## Reading volumes out of prose

The README states them two ways — `no volume`, or `one volume each (8 × 40 GB + 8 × 20 GB)`, a **sum
of counts** rather than a single number. Both are read.

A row saying **neither** is an **error, not a zero** — a pool whose volume prose stopped parsing is a
pool this gate silently stopped checking, which is the failure this whole family of findings is
about.

## Measured

| pool | README | manager.toml |
|---|---|---|
| `nucleus-fly-build` | 16 volumes | **0** |
| `nucleus-fly-gate` | no volume | 0 — **agrees** |

The gate pool contributing **no** drift row is the evidence that the parser reads rather than
assumes.

## The pin goes 4 → 5, and that direction needs its reason on the record

This ratchet is **shrink-only**. **Nothing got worse.** The disagreement was always there; the gate
began looking at a field it had always ignored.

That is the same act as `check-gates-can-fail.sh`'s `UNCOVERED_CEILING` going 2 → 10 when ten xtask
gates entered its domain — **a widening of what is looked at, not a relaxation.** A rise for any
other reason is not this and should be refused; the ratchet file says so in as many words.

## Driven red two ways

- Reconcile the volume prose → count drops to 4, gate demands the pin move with it.
- Prose in neither readable form → **errors by name** rather than counting as zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)