### PR TITLE
gate: a gate's own timeout must fire before its job is killed

### DIFF
--- a/.github/actions/gatehouse/gatehouse.sh
+++ b/.github/actions/gatehouse/gatehouse.sh
@@ -118,8 +118,27 @@ say "receipt $INDEX in $(jq -r .log.origin <<<"$EXCHANGE"): $VOUT"
 # ── 6. The plain run, for the agreement line ───────────────────────────────────────────────
 AGREE=skipped; GITHUB=unknown
 if [ "$GH_COMPARE" = true ]; then
-  set +e; bash -c "$GH_RUN" >/dev/null 2>&1; FC=$?; set -e
+  # Bounded by the SAME budget as the gatehouse run. `cargo xtask gate-budget` computes the
+  # job's requirement as `runs * timeout + setup`, and with compare on `runs` is 2 -- which
+  # is only true if this second run is bounded too. It was not, so the arithmetic that gate
+  # checks described a bound that did not exist on this side.
+  #
+  # No slack here, unlike the runner above. The slack there exists so the runner can hit its
+  # own deadline and write an honest `errored` receipt first; this is a plain `bash -c` with
+  # no receipt to write and nothing to wait for, so the budget is the budget. The worst case
+  # across both runs is therefore (timeout + 120) + timeout, and that 120 is a term in
+  # `gate-budget`'s arithmetic (OUTER_SLACK_S) rather than something setup is assumed to
+  # absorb -- an assumed absorption is how the declared budget came to describe a bound that
+  # did not exist.
+  #
+  # A timed-out plain run is `fail` rather than fatal, deliberately: this half exists to say
+  # what GitHub's own check would have said, and "it did not finish in the budget" is a
+  # legitimate answer to that. Disagreement is never fatal in shadow mode.
+  set +e; timeout --kill-after=30s "$GH_TIMEOUT" bash -c "$GH_RUN" >/dev/null 2>&1; FC=$?; set -e
   if [ "$FC" -eq 0 ]; then GITHUB=pass; else GITHUB=fail; fi
+  if [ "$FC" -eq 124 ] || [ "$FC" -eq 137 ]; then
+    say "the plain run exceeded the same ${GH_TIMEOUT}s budget; counted as fail for the agreement line"
+  fi
   if { [ "$HELD" = held ] && [ "$GITHUB" = pass ]; } || { [ "$HELD" = not-held ] && [ "$GITHUB" = fail ]; }; then AGREE=true; else AGREE=false; fi
 fi
 

--- a/.github/workflows/gatehouse-shadow.yml
+++ b/.github/workflows/gatehouse-shadow.yml
@@ -131,7 +131,18 @@ jobs:
           # runner (gatehouse F-100) did exactly that on sixteen open pull
           # requests. A gate's own timeout must fire before its job is killed,
           # or the gate cannot report its own failure.
-          timeout: "2100"
+          #
+          # 2100 -> 1200, and the reasoning above is unchanged: this is the same rule applied
+          # to BOTH runs. `compare` defaults true, so the command runs a second time for the
+          # agreement line, and this PR bounds that run too (gatehouse.sh) — so the job must
+          # hold 2 x timeout + setup, not one. At 2100 that is 4260s inside a 2700s job, which
+          # fails the same way 2700 did, one run later. 1200 x2 + 60 = 2460s fits.
+          #
+          # `cargo xtask gate-budget` decides this from the declarations, and reds on 2100.
+          # If the agreement line is worth more than the second run's deadline, the other
+          # answer is `compare: false` for this entry and 2100 stands — that is a judgement
+          # about what shadow mode is for, and it belongs to whoever set 2100.
+          timeout: "1200"
           bin-dir: gatehouse/target/debug
           control-url: ${{ vars.GATEHOUSE_CONTROL_URL || 'https://gatehouse-controld.fly.dev' }}
       - name: The agreement line

--- a/.github/workflows/gatehouse-shadow.yml
+++ b/.github/workflows/gatehouse-shadow.yml
@@ -132,16 +132,23 @@ jobs:
           # requests. A gate's own timeout must fire before its job is killed,
           # or the gate cannot report its own failure.
           #
-          # 2100 -> 1200, and the reasoning above is unchanged: this is the same rule applied
-          # to BOTH runs. `compare` defaults true, so the command runs a second time for the
-          # agreement line, and this PR bounds that run too (gatehouse.sh) — so the job must
-          # hold 2 x timeout + setup, not one. At 2100 that is 4260s inside a 2700s job, which
-          # fails the same way 2700 did, one run later. 1200 x2 + 60 = 2460s fits.
+          # Fitting the declaration is necessary and was NOT sufficient, and I claimed it would
+          # be. Run 34637222980 carried this 1200 and the gate step still ran 44m35s and was
+          # still killed by the job's cap with no verdict: `duration_ms=2675520` against
+          # `2676029` for the original 2700 run — half a second apart. The runner does not
+          # enforce its own timeout, so no value declared HERE makes it report. That is why
+          # the budget is also enforced by the caller in `.github/actions/gatehouse` — the
+          # declaration says what the bound is, the action is what makes it bite.
           #
-          # `cargo xtask gate-budget` decides this from the declarations, and reds on 2100.
+          # 2100 -> 1200 for arithmetic the declarations already contain: `compare` defaults
+          # true, so the command runs a second time for the agreement line, and the job must
+          # hold 2 x timeout + setup rather than one. At 2100 that is 4260s inside a 2700s
+          # job, which fails exactly the way 2700 did, one run later. 1200 x2 + 60 = 2460s
+          # fits. `cargo xtask gate-budget` decides this and reds on 2100.
+          #
           # If the agreement line is worth more than the second run's deadline, the other
-          # answer is `compare: false` for this entry and 2100 stands — that is a judgement
-          # about what shadow mode is for, and it belongs to whoever set 2100.
+          # answer is `compare: false` for this entry and 2100 stands — a judgement about what
+          # shadow mode is for, and it belongs to whoever set 2100.
           timeout: "1200"
           bin-dir: gatehouse/target/debug
           control-url: ${{ vars.GATEHOUSE_CONTROL_URL || 'https://gatehouse-controld.fly.dev' }}

--- a/.github/workflows/manifest-guards.yml
+++ b/.github/workflows/manifest-guards.yml
@@ -123,6 +123,14 @@ jobs:
       # Pinning it makes the reason a line of prose in review instead of a digit in a command.
       - name: A coverage floor may not move without saying so
         run: cargo run -q -p xtask -- coverage-floor
+      # Two clocks run over the same work: the gatehouse action's `timeout`, which the runner
+      # enforces and reports, and the job's `timeout-minutes`, which GitHub enforces and does
+      # not. When GitHub's is first the runner never reports -- the job ends `cancelled`, the
+      # same conclusion an infrastructure fault gives, and the overrun carries no verdict. The
+      # shadow lane was in exactly that state: a 2700s gate, run twice for the agreement line,
+      # inside a 2700s job. 304 runs over two days produced no verdict at all.
+      - name: A gate's timeout must fire before its job is killed
+        run: cargo run -q -p xtask -- gate-budget
 
       # Seven scan-vs-allowlist gates lived in four shell scripts, each with its own copy
       # of the same `#[cfg(test)]`-stripping awk program -- five copies, four of them

--- a/.github/workflows/manifest-guards.yml
+++ b/.github/workflows/manifest-guards.yml
@@ -124,8 +124,10 @@ jobs:
       - name: A coverage floor may not move without saying so
         run: cargo run -q -p xtask -- coverage-floor
       # Two clocks run over the same work: the gatehouse action's `timeout`, which the runner
-      # enforces and reports, and the job's `timeout-minutes`, which GitHub enforces and does
-      # not. When GitHub's is first the runner never reports -- the job ends `cancelled`, the
+      # is SUPPOSED to enforce and report, and the job's `timeout-minutes`, which GitHub
+      # enforces and does not report. (Measured 2026-09-11: the runner does not in fact
+      # enforce its own -- see gatehouse-shadow.yml. That is a defect one level below this
+      # gate, and it does not make the declaration arithmetic any less wrong.) When GitHub's is first the runner never reports -- the job ends `cancelled`, the
       # same conclusion an infrastructure fault gives, and the overrun carries no verdict. The
       # shadow lane was in exactly that state: a 2700s gate, run twice for the agreement line,
       # inside a 2700s job. 304 runs over two days produced no verdict at all.

--- a/ci/untimed-jobs.txt
+++ b/ci/untimed-jobs.txt
@@ -1,0 +1,44 @@
+# Jobs that declare no `timeout-minutes`, and therefore inherit GitHub's default of
+# 360 minutes — six hours of a runner for a job that has hung.
+#
+# This list may only SHRINK. `cargo xtask gate-budget` reads it: a job here without a
+# timeout is tolerated, a job here that has since gained one is a stale entry to delete,
+# and a job NOT here without a timeout is a violation. Adding a name is an owner decision.
+#
+# It is a ratchet rather than a repair because the repair is 23 separate judgements — the
+# right timeout for a release build is not the right timeout for a gate — and a wrong
+# number here fails honest jobs. What the ratchet buys immediately is that the population
+# cannot grow while those judgements are made.
+#
+# Measured 2026-09-11: 147 jobs across the workflows, 124 declaring a timeout, 23 not.
+# None of the 23 produces a required context, checked against ci/required-checks.txt — so
+# a hang here cannot block the merge queue on a required check. It can still hold a
+# self-hosted runner for six hours, which on a pool that has been measured starving
+# (gatehouse F-79) is the cost that matters.
+#
+# Changes:
+#   2026-09-11 — pinned at the 23 in force, nothing moved.
+
+action-smoke-test.yml:dry-run
+action-smoke-test.yml:live-test
+dependabot-automerge.yml:dependabot
+exemplar-scoreboard.yml:scoreboard
+oidc-gates.yml:vendor-neutrality
+oidc-gates.yml:algorithm-pin
+oidc-keyless-prototype.yml:keyless-oidc-e2e
+quickstart-boot.yml:egress-probe-falsifier
+quickstart-boot.yml:pins-resolve
+quickstart-boot.yml:boot-a-real-pod-aarch64
+quickstart-boot.yml:boot-a-real-pod
+release.yml:build
+release.yml:build-musl
+release.yml:build-rootfs
+release.yml:upload-lima-templates
+release.yml:dry-run-assert
+release.yml:release
+release.yml:publish
+release.yml:homebrew
+scan-attest.yml:scan-and-attest
+scan.yml:scan-action
+scorecard.yml:analysis
+trust-registry.yml:enrollment-gate

--- a/ci/untimed-jobs.txt
+++ b/ci/untimed-jobs.txt
@@ -10,6 +10,12 @@
 # number here fails honest jobs. What the ratchet buys immediately is that the population
 # cannot grow while those judgements are made.
 #
+# NOT the first check on this. ci-spec's CI-I7-NOTIMEOUT already reports untimed jobs, with
+# a sharper rationale: it filters to `merge_group`-triggered workflows, where the 360-minute
+# default equals the queue's own check budget and so ejects the entry. It reports 5 such jobs
+# at Medium severity, which prints as info and does not fail. Those 5 are a strict subset of
+# the 23 below. This list covers every workflow and FAILS, so the population cannot grow.
+#
 # Measured 2026-09-11: 147 jobs across the workflows, 124 declaring a timeout, 23 not.
 # None of the 23 produces a required context, checked against ci/required-checks.txt — so
 # a hang here cannot block the merge queue on a required check. It can still hold a

--- a/crates/xtask/src/gate_budget.rs
+++ b/crates/xtask/src/gate_budget.rs
@@ -410,4 +410,134 @@ mod tests {
         let wf = "jobs:\n  j:\n    timeout-minutes: 45\n    steps:\n      # - uses: ./.github/actions/gatehouse\n";
         assert!(sites(wf, 3600, true).is_empty());
     }
+
+    // ---- `check` end to end, against a temp tree -------------------------------------
+    //
+    // `check` takes its root as an argument, so the whole verdict — including the two
+    // refusals that have no live subject to perturb — can be exercised without the real
+    // repository. These were written because the module shipped at 66% line coverage and
+    // the untested third was `check` itself: the part that decides.
+
+    const ACTION_YML: &str = "\
+inputs:
+  timeout:
+    description: \"Seconds.\"
+    required: false
+    default: \"3600\"
+  compare:
+    description: \"Run it plainly too.\"
+    required: false
+    default: \"true\"
+";
+
+    fn tree(dir: &Path, action: &str, workflows: &[(&str, &str)]) {
+        fs::create_dir_all(dir.join(".github/actions/gatehouse")).unwrap();
+        fs::create_dir_all(dir.join(".github/workflows")).unwrap();
+        fs::write(dir.join(ACTION), action).unwrap();
+        for (name, body) in workflows {
+            fs::write(dir.join(".github/workflows").join(name), body).unwrap();
+        }
+    }
+
+    fn tmp(tag: &str) -> std::path::PathBuf {
+        let d =
+            std::env::temp_dir().join(format!("xtask-gate-budget-{tag}-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&d);
+        fs::create_dir_all(&d).unwrap();
+        d
+    }
+
+    fn shadow(job_minutes: u32, timeout: &str) -> String {
+        format!(
+            "jobs:\n  shadow:\n    timeout-minutes: {job_minutes}\n    steps:\n      - name: gate\n        uses: {USES}\n        with:\n          run: cargo clippy\n          timeout: \"{timeout}\"\n"
+        )
+    }
+
+    #[test]
+    fn check_passes_when_the_runner_reports_first() {
+        let d = tmp("ok");
+        tree(
+            &d,
+            ACTION_YML,
+            &[("gatehouse-shadow.yml", &shadow(45, "1200"))],
+        );
+        check(&d).expect("1200 x2 + setup fits inside 45 minutes");
+    }
+
+    #[test]
+    fn check_fails_on_the_measured_defect() {
+        let d = tmp("defect");
+        tree(
+            &d,
+            ACTION_YML,
+            &[("gatehouse-shadow.yml", &shadow(45, "2700"))],
+        );
+        let e = check(&d).expect_err("2700 x2 cannot fit a 2700s job");
+        let msg = e.to_string();
+        assert!(msg.contains("cannot fire"), "{msg}");
+    }
+
+    /// The action's own default applies when the step omits `timeout`, and 3600 twice
+    /// cannot fit any job this repository declares.
+    #[test]
+    fn check_uses_the_action_default_when_the_step_is_silent() {
+        let d = tmp("default");
+        let wf = format!(
+            "jobs:\n  shadow:\n    timeout-minutes: 45\n    steps:\n      - uses: {USES}\n        with:\n          run: cargo clippy\n"
+        );
+        tree(&d, ACTION_YML, &[("gatehouse-shadow.yml", &wf)]);
+        assert!(
+            check(&d).is_err(),
+            "the 3600s default must be read and refused"
+        );
+    }
+
+    /// A workflow using the action but not listed is a budget nothing compares.
+    #[test]
+    fn check_refuses_an_unlisted_user_of_the_action() {
+        let d = tmp("unlisted");
+        tree(
+            &d,
+            ACTION_YML,
+            &[
+                ("gatehouse-shadow.yml", &shadow(45, "1200")),
+                ("sneaky.yml", &shadow(45, "1200")),
+            ],
+        );
+        let e = check(&d).expect_err("an unlisted workflow must red");
+        assert!(e.to_string().contains("sneaky.yml"), "{e}");
+    }
+
+    /// A gate that measures nothing passes everything, so finding no site is a refusal.
+    #[test]
+    fn check_refuses_a_workflow_with_no_site() {
+        let d = tmp("nosite");
+        tree(
+            &d,
+            ACTION_YML,
+            &[(
+                "gatehouse-shadow.yml",
+                "jobs:\n  shadow:\n    timeout-minutes: 45\n    steps:\n      - run: echo hi\n",
+            )],
+        );
+        let e = check(&d).expect_err("no site is not a pass");
+        assert!(e.to_string().contains("found no"), "{e}");
+    }
+
+    #[test]
+    fn check_reports_a_missing_action_definition() {
+        let d = tmp("noaction");
+        fs::create_dir_all(d.join(".github/workflows")).unwrap();
+        assert!(
+            check(&d).is_err(),
+            "an absent action definition is not a pass"
+        );
+    }
+
+    #[test]
+    fn an_input_without_a_default_is_an_error() {
+        let src = "inputs:\n  timeout:\n    description: \"no default here\"\n";
+        assert!(action_default(src, "timeout").is_err());
+        assert!(action_default(src, "nonexistent").is_err());
+    }
 }

--- a/crates/xtask/src/gate_budget.rs
+++ b/crates/xtask/src/gate_budget.rs
@@ -2,7 +2,8 @@
 //! running it is killed.
 //!
 //! `.github/workflows/gatehouse-shadow.yml` runs each gate through the one-step gatehouse
-//! action, which takes a `timeout` (seconds the command may take) and enforces it. The job
+//! action, which takes a `timeout` (seconds the command may take) and is supposed to enforce
+//! it. The job
 //! around it carries GitHub's `timeout-minutes`. Those are two clocks over the same work,
 //! and only one of them can be first.
 //!
@@ -43,6 +44,25 @@
 //! rather than repeated here. A second copy of a default is a second thing to drift, which is
 //! the failure this family of gates exists to refuse; `fly_pools.rs` calls the manager's own
 //! validator for the same reason.
+//!
+//! # What this gate does NOT fix, measured
+//!
+//! Lowering the declared timeout so it fits is necessary and **not sufficient**. Measured
+//! 2026-09-11 on run `34637222980`, with `timeout: "1200"` confirmed reaching the runner as
+//! `GH_TIMEOUT: 1200`: the gate step ran **44m35s** and was killed by the job's 45-minute cap
+//! with no verdict — `duration_ms=2675520`, against `2676029` for the original 2700s run.
+//! **Half a second apart.** The runner produced nothing after its tenant line in either case,
+//! and the only occurrences of "timeout" in 998 log lines are the input and env echoes.
+//!
+//! So the runner does not enforce its own declared timeout, and no value of `timeout` makes it
+//! report first. That is a defect one level below this gate, in gatehouse's runner rather than
+//! in nucleus's declarations.
+//!
+//! This gate is still right, and the distinction matters: it decides whether the DECLARATIONS
+//! are coherent, and a budget that cannot fit inside the job running it is incoherent whether
+//! or not the runner would have honoured it. What must not be claimed is that fixing the
+//! arithmetic makes an overrun report — it did not, and the first version of this module said
+//! it would.
 //!
 //! # The second conjunct: a job with no budget at all
 //!

--- a/crates/xtask/src/gate_budget.rs
+++ b/crates/xtask/src/gate_budget.rs
@@ -34,11 +34,19 @@
 //! For every step using the gatehouse action:
 //!
 //! ```text
-//! runs * timeout_s + SETUP_ALLOWANCE_S  <  timeout-minutes * 60
+//! runs * timeout_s + OUTER_SLACK_S + SETUP_ALLOWANCE_S  <  timeout-minutes * 60
 //! ```
 //!
 //! where `runs` is 2 when `compare` is on and 1 otherwise. Strict: equality is the defect
 //! above, not the boundary case that just fits.
+//!
+//! `OUTER_SLACK_S` is not decoration. The action does not bound the runner at `timeout_s`; it
+//! bounds it at `timeout_s + 120`, deliberately, so the runner can hit its OWN deadline first
+//! and write an honest `errored` receipt instead of being killed mid-write. That slack is real
+//! wall time and the job must hold it, so the arithmetic that claims to describe a bound has to
+//! contain it. Counting `runs * timeout_s` alone described a bound 120 seconds tighter than the
+//! one the action actually enforces — the same shape of error, one level down, as declaring a
+//! budget the runner never honoured.
 //!
 //! Both defaults — `timeout` and `compare` — are read from `.github/actions/gatehouse/action.yml`
 //! rather than repeated here. A second copy of a default is a second thing to drift, which is
@@ -101,6 +109,13 @@ const USES: &str = "./.github/actions/gatehouse";
 /// the shape this gate refuses.
 const SETUP_ALLOWANCE_S: u64 = 60;
 
+/// The action's outer deadline sits this far above the gate's own `timeout`, so the runner gets
+/// to fire first and report. `.github/actions/gatehouse/gatehouse.sh`, the `timeout --kill-after`
+/// around `$RUNNER`: `$(( GH_TIMEOUT + 120 ))`. Applied once, not per run — only the gatehouse
+/// run carries it; the plain `compare` run is bounded at `GH_TIMEOUT` exactly, because it has no
+/// receipt to write and nothing to wait for.
+const OUTER_SLACK_S: u64 = 120;
+
 /// Jobs allowed to declare no `timeout-minutes`. Shrink-only.
 const UNTIMED_PIN: &str = "ci/untimed-jobs.txt";
 /// What GitHub gives a job that declares none.
@@ -121,7 +136,7 @@ impl Site {
         if self.compare { 2 } else { 1 }
     }
     pub fn need_s(&self) -> u64 {
-        self.runs() * self.timeout_s + SETUP_ALLOWANCE_S
+        self.runs() * self.timeout_s + OUTER_SLACK_S + SETUP_ALLOWANCE_S
     }
     pub fn fits(&self) -> bool {
         self.need_s() < self.job_budget_s
@@ -415,7 +430,7 @@ pub fn check(root: &Path) -> Result<()> {
             total += 1;
             let verdict = if s.fits() { "ok  " } else { "FAIL" };
             println!(
-                "  {verdict} {wf}:{}  job {}s, gate {}s x{} + {SETUP_ALLOWANCE_S}s setup = {}s",
+                "  {verdict} {wf}:{}  job {}s, gate {}s x{} + {OUTER_SLACK_S}s slack + {SETUP_ALLOWANCE_S}s setup = {}s",
                 s.line,
                 s.job_budget_s,
                 s.timeout_s,
@@ -495,7 +510,7 @@ mod tests {
             line: 1,
         };
         assert_eq!(s.runs(), 2);
-        assert_eq!(s.need_s(), 5460);
+        assert_eq!(s.need_s(), 5580);
         assert!(!s.fits());
     }
 
@@ -519,14 +534,31 @@ mod tests {
             compare: true,
             line: 1,
         };
-        assert_eq!(s.need_s(), 2460);
+        assert_eq!(s.need_s(), 2580);
         assert!(s.fits());
+    }
+
+    /// The outer slack has to change a verdict somewhere, or it is a constant that costs nothing
+    /// and proves nothing. 1300s twice is 2600s, and 2660s with setup — inside a 2700s job. The
+    /// action's deadline is 1420s, not 1300s, so the real worst case is 2780s and the job kills
+    /// it. Without `OUTER_SLACK_S` this site passes, and the pass is wrong.
+    #[test]
+    fn the_outer_slack_is_what_decides_this_site() {
+        let s = Site {
+            job_budget_s: 2700,
+            timeout_s: 1300,
+            compare: true,
+            line: 1,
+        };
+        assert_eq!(s.runs() * s.timeout_s + SETUP_ALLOWANCE_S, 2660);
+        assert_eq!(s.need_s(), 2780);
+        assert!(!s.fits());
     }
 
     /// `compare: false` halves the need, and the parser must see it.
     #[test]
     fn compare_false_is_read_from_the_step() {
-        let wf = "jobs:\n  j:\n    timeout-minutes: 10\n    steps:\n      - uses: ./.github/actions/gatehouse\n        with:\n          timeout: \"500\"\n          compare: \"false\"\n";
+        let wf = "jobs:\n  j:\n    timeout-minutes: 15\n    steps:\n      - uses: ./.github/actions/gatehouse\n        with:\n          timeout: \"500\"\n          compare: \"false\"\n";
         let s = sites(wf, 3600, true);
         assert_eq!(s.len(), 1);
         assert!(!s[0].compare);
@@ -619,7 +651,7 @@ inputs:
         // Assert on the per-site explanation, not the summary line: the summary counts
         // problems from both conjuncts and its wording is not this conjunct's claim.
         assert!(msg.contains("can never fire first"), "{msg}");
-        assert!(msg.contains("5460s"), "the arithmetic must be shown: {msg}");
+        assert!(msg.contains("5580s"), "the arithmetic must be shown: {msg}");
     }
 
     /// The action's own default applies when the step omits `timeout`, and 3600 twice

--- a/crates/xtask/src/gate_budget.rs
+++ b/crates/xtask/src/gate_budget.rs
@@ -1,0 +1,413 @@
+//! `cargo xtask gate-budget` — a gate's own timeout must be able to fire before the job
+//! running it is killed.
+//!
+//! `.github/workflows/gatehouse-shadow.yml` runs each gate through the one-step gatehouse
+//! action, which takes a `timeout` (seconds the command may take) and enforces it. The job
+//! around it carries GitHub's `timeout-minutes`. Those are two clocks over the same work,
+//! and only one of them can be first.
+//!
+//! When GitHub's is first, the runner never reports. The job ends `cancelled`, which is the
+//! same conclusion an infrastructure fault produces, and the one mechanism that would have
+//! said *"this gate exceeded its budget"* is preempted by the mechanism that says nothing at
+//! all. A verdict becomes a cancellation, and a cancellation is not a finding.
+//!
+//! That is not hypothetical. Measured 2026-09-11, the clippy entry declared:
+//!
+//! ```text
+//! timeout-minutes: 45          # the job
+//! timeout: "2700"              # the action — 45 minutes, the same number
+//! compare:                     # unset, so the action's default `true` applies
+//! ```
+//!
+//! `compare` runs the command a SECOND time, plainly, to produce the agreement line that is
+//! the whole point of shadow mode. So the declared need is `2 x 2700 = 5400` seconds inside a
+//! 2700-second job — and even one run of 2700 does not fit, because setup consumes some of the
+//! job's budget before the gate step starts (43 seconds, measured on run 34625269465).
+//!
+//! The observable consequence: **304 runs between 2026-09-09T11:46Z and 2026-09-11T18:00Z
+//! produced no verdict at all**, and 14 of 20 sampled cancelled runs had spent the full 45
+//! minutes to produce it. The gate had not been failing. It had not been running.
+//!
+//! # The rule
+//!
+//! For every step using the gatehouse action:
+//!
+//! ```text
+//! runs * timeout_s + SETUP_ALLOWANCE_S  <  timeout-minutes * 60
+//! ```
+//!
+//! where `runs` is 2 when `compare` is on and 1 otherwise. Strict: equality is the defect
+//! above, not the boundary case that just fits.
+//!
+//! Both defaults — `timeout` and `compare` — are read from `.github/actions/gatehouse/action.yml`
+//! rather than repeated here. A second copy of a default is a second thing to drift, which is
+//! the failure this family of gates exists to refuse; `fly_pools.rs` calls the manager's own
+//! validator for the same reason.
+//!
+//! # What decides this
+//!
+//! Two committed YAML files. No source tree, no toolchain, no network, and the same verdict
+//! against an empty checkout of nucleus. See gatehouse `docs/tiering.md`.
+
+use std::fs;
+use std::path::Path;
+
+use anyhow::{Context, Result, bail};
+
+const ACTION: &str = ".github/actions/gatehouse/action.yml";
+/// Workflows that run a gate through the action. A workflow added here is checked without
+/// further code; one that uses the action and is NOT here is caught by [`unlisted_users`].
+const WORKFLOWS: [&str; 1] = [".github/workflows/gatehouse-shadow.yml"];
+/// The action path as a workflow step spells it.
+const USES: &str = "./.github/actions/gatehouse";
+
+/// Setup before the gate step starts: two checkouts, the toolchain, and the gatehouse build.
+/// Measured 43s on run 34625269465 (job started 17:07:42Z, gate step 17:08:25Z); 60 rounds it
+/// up. This is an allowance, not a ceiling — a job that fits only because setup was fast is
+/// the shape this gate refuses.
+const SETUP_ALLOWANCE_S: u64 = 60;
+
+/// One `uses: ./.github/actions/gatehouse` step, with the job budget around it.
+#[derive(Debug, PartialEq, Eq)]
+pub struct Site {
+    pub job_budget_s: u64,
+    pub timeout_s: u64,
+    pub compare: bool,
+    /// For the message: which `timeout-minutes` line this step was measured against.
+    pub line: usize,
+}
+
+impl Site {
+    pub fn runs(&self) -> u64 {
+        if self.compare { 2 } else { 1 }
+    }
+    pub fn need_s(&self) -> u64 {
+        self.runs() * self.timeout_s + SETUP_ALLOWANCE_S
+    }
+    pub fn fits(&self) -> bool {
+        self.need_s() < self.job_budget_s
+    }
+}
+
+/// Indentation of a YAML line, in spaces. Tabs are not legal YAML indentation.
+fn indent(line: &str) -> usize {
+    line.len() - line.trim_start().len()
+}
+
+/// A scalar `key: value`, unquoted. A leading `- ` is stripped first: in a step list the
+/// FIRST key of an item carries the item marker (`- uses: ...`), and a parser that misses that
+/// form sees no step at all — which is the vacuous pass this gate exists to refuse.
+fn scalar<'a>(line: &'a str, key: &str) -> Option<&'a str> {
+    let t = line.trim();
+    let t = t.strip_prefix("- ").unwrap_or(t);
+    let rest = t.strip_prefix(key)?.strip_prefix(':')?;
+    Some(rest.trim().trim_matches(|c| c == '"' || c == '\''))
+}
+
+/// Indentation of the KEY on a line, which is two deeper than the line's own when that line
+/// carries a list marker.
+fn key_indent(line: &str) -> usize {
+    let i = indent(line);
+    if line.trim_start().starts_with("- ") {
+        i + 2
+    } else {
+        i
+    }
+}
+
+/// The `default:` of an input in the action definition. `inputs:` is a mapping of name to a
+/// mapping carrying `default:`, so the default sought is the first one at a deeper indent
+/// after the named key.
+pub fn action_default(action_src: &str, input: &str) -> Result<String> {
+    let mut lines = action_src.lines().enumerate();
+    let mut at = None;
+    for (i, l) in lines.by_ref() {
+        if scalar(l, input) == Some("") && indent(l) > 0 {
+            at = Some((i, indent(l)));
+            break;
+        }
+    }
+    let Some((_, key_indent)) = at else {
+        bail!("{ACTION}: no input {input:?}");
+    };
+    for (_, l) in lines {
+        if l.trim().is_empty() {
+            continue;
+        }
+        if indent(l) <= key_indent {
+            break;
+        }
+        if let Some(v) = scalar(l, "default") {
+            return Ok(v.to_string());
+        }
+    }
+    bail!("{ACTION}: input {input:?} declares no default")
+}
+
+/// Every gatehouse-action step in one workflow, paired with the `timeout-minutes` of the job
+/// it sits in.
+///
+/// Line-oriented on purpose: the same shape `gatehouse_pin.rs` and `fly_pools.rs` use, and it
+/// keeps the gate free of a YAML dependency for a file whose relevant lines are flat scalars.
+/// A `timeout-minutes` is attributed to the most recent one seen above the step, which is the
+/// job's because a step-level one would be nearer — and a step-level `timeout-minutes` is
+/// STRICTER than the job's, so taking the nearest is the conservative reading either way.
+pub fn sites(workflow_src: &str, default_timeout_s: u64, default_compare: bool) -> Vec<Site> {
+    let lines: Vec<&str> = workflow_src.lines().collect();
+    let mut out = Vec::new();
+    let mut budget: Option<(u64, usize)> = None;
+
+    for (i, line) in lines.iter().enumerate() {
+        if line.trim_start().starts_with('#') {
+            continue;
+        }
+        if let Some(v) = scalar(line, "timeout-minutes")
+            && let Ok(m) = v.parse::<u64>()
+        {
+            budget = Some((m * 60, i + 1));
+        }
+        if scalar(line, "uses") != Some(USES) {
+            continue;
+        }
+        let Some((job_budget_s, line_no)) = budget else {
+            continue;
+        };
+        // The rest of this step. `with:` is a SIBLING of `uses:`, not a child, so the block
+        // runs to the first line shallower than the step's own keys — the next list item's
+        // marker. Breaking at `<=` instead stopped at `with:` and read neither input, which is
+        // how this gate first reported the action's defaults over a step that overrode them.
+        let step_indent = key_indent(line);
+        let mut timeout_s = default_timeout_s;
+        let mut compare = default_compare;
+        for l in &lines[i + 1..] {
+            if l.trim().is_empty() || l.trim_start().starts_with('#') {
+                continue;
+            }
+            // The next list item's marker sits SHALLOWER than the keys it introduces, so
+            // the raw indent is what ends the step; comparing key indents would tie with the
+            // next `- name:` and run the two steps together.
+            if indent(l) < step_indent {
+                break;
+            }
+            if let Some(v) = scalar(l, "timeout")
+                && let Ok(s) = v.parse::<u64>()
+            {
+                timeout_s = s;
+            }
+            if let Some(v) = scalar(l, "compare") {
+                compare = v != "false";
+            }
+        }
+        out.push(Site {
+            job_budget_s,
+            timeout_s,
+            compare,
+            line: line_no,
+        });
+    }
+    out
+}
+
+/// Workflows that use the action but are not in [`WORKFLOWS`]. A gate this file does not know
+/// about is a gate it silently exempts — the shape `check-gates-can-fail.sh` exists to refuse.
+fn unlisted_users(root: &Path) -> Result<Vec<String>> {
+    let dir = root.join(".github/workflows");
+    let mut out = Vec::new();
+    for entry in fs::read_dir(&dir).with_context(|| format!("reading {}", dir.display()))? {
+        let p = entry?.path();
+        if p.extension().is_none_or(|e| e != "yml") {
+            continue;
+        }
+        let Ok(src) = fs::read_to_string(&p) else {
+            continue;
+        };
+        let uses = src
+            .lines()
+            .any(|l| !l.trim_start().starts_with('#') && scalar(l, "uses") == Some(USES));
+        if !uses {
+            continue;
+        }
+        let rel = format!(
+            ".github/workflows/{}",
+            p.file_name().unwrap().to_string_lossy()
+        );
+        if !WORKFLOWS.contains(&rel.as_str()) {
+            out.push(rel);
+        }
+    }
+    out.sort();
+    Ok(out)
+}
+
+pub fn check(root: &Path) -> Result<()> {
+    let action =
+        fs::read_to_string(root.join(ACTION)).with_context(|| format!("reading {ACTION}"))?;
+    let default_timeout_s: u64 = action_default(&action, "timeout")?
+        .parse()
+        .context("the action's default timeout is not a number of seconds")?;
+    let default_compare = action_default(&action, "compare")? != "false";
+    println!("{ACTION} defaults: timeout {default_timeout_s}s, compare {default_compare}");
+
+    let extra = unlisted_users(root)?;
+    if !extra.is_empty() {
+        bail!(
+            "these workflows run a gate through {USES} but are not checked here: {}.\n\
+             Add them to WORKFLOWS. A budget this gate does not read is a budget nothing \
+             compares.",
+            extra.join(", ")
+        );
+    }
+
+    let mut total = 0usize;
+    let mut bad = Vec::new();
+    for wf in WORKFLOWS {
+        let src = fs::read_to_string(root.join(wf)).with_context(|| format!("reading {wf}"))?;
+        let sites = sites(&src, default_timeout_s, default_compare);
+        if sites.is_empty() {
+            bail!(
+                "{wf}: found no `uses: {USES}` step under a `timeout-minutes`. Either the \
+                 workflow stopped using the action, or this parser stopped seeing it — and a \
+                 gate that measures nothing passes everything."
+            );
+        }
+        for s in &sites {
+            total += 1;
+            let verdict = if s.fits() { "ok  " } else { "FAIL" };
+            println!(
+                "  {verdict} {wf}:{}  job {}s, gate {}s x{} + {SETUP_ALLOWANCE_S}s setup = {}s",
+                s.line,
+                s.job_budget_s,
+                s.timeout_s,
+                s.runs(),
+                s.need_s()
+            );
+            if !s.fits() {
+                bad.push(format!(
+                    "{wf}:{}: the job allows {}s; the gate declares {}s and runs it {} time(s) \
+                     ({}), needing {}s with setup.\n\
+                     \x20 The runner's timeout can never fire first, so a gate that overruns is \
+                     killed by GitHub and reported as `cancelled` — indistinguishable from an \
+                     infrastructure fault, and carrying no verdict. Lower the action's `timeout` \
+                     so it fits, or raise `timeout-minutes` so the runner reports before GitHub \
+                     does.",
+                    s.line,
+                    s.job_budget_s,
+                    s.timeout_s,
+                    s.runs(),
+                    if s.compare {
+                        "compare is on, so the command runs twice"
+                    } else {
+                        "compare off"
+                    },
+                    s.need_s()
+                ));
+            }
+        }
+    }
+
+    if !bad.is_empty() {
+        bail!(
+            "{} gate budget(s) cannot fire:\n{}",
+            bad.len(),
+            bad.join("\n")
+        );
+    }
+    println!("ok: all {total} gate budget(s) leave room for the runner to report first");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn root() -> std::path::PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("../..")
+    }
+
+    #[test]
+    fn reads_the_real_action_defaults() {
+        let action = fs::read_to_string(root().join(ACTION)).unwrap();
+        assert!(
+            action_default(&action, "timeout")
+                .unwrap()
+                .parse::<u64>()
+                .is_ok()
+        );
+        let c = action_default(&action, "compare").unwrap();
+        assert!(c == "true" || c == "false", "compare default {c:?}");
+    }
+
+    #[test]
+    fn the_real_workflow_has_sites() {
+        let src = fs::read_to_string(root().join(WORKFLOWS[0])).unwrap();
+        assert!(
+            !sites(&src, 3600, true).is_empty(),
+            "the parser must see the shipped step"
+        );
+    }
+
+    /// The measured defect, frozen: 45 minutes of job, 45 minutes of gate, compare on.
+    #[test]
+    fn the_2026_09_11_shape_does_not_fit() {
+        let s = Site {
+            job_budget_s: 45 * 60,
+            timeout_s: 2700,
+            compare: true,
+            line: 1,
+        };
+        assert_eq!(s.runs(), 2);
+        assert_eq!(s.need_s(), 5460);
+        assert!(!s.fits());
+    }
+
+    /// Equality is a failure, not a pass: setup alone pushes it over.
+    #[test]
+    fn exactly_the_job_budget_does_not_fit() {
+        let s = Site {
+            job_budget_s: 2700,
+            timeout_s: 2700,
+            compare: false,
+            line: 1,
+        };
+        assert!(!s.fits());
+    }
+
+    #[test]
+    fn room_for_two_runs_and_setup_fits() {
+        let s = Site {
+            job_budget_s: 45 * 60,
+            timeout_s: 1200,
+            compare: true,
+            line: 1,
+        };
+        assert_eq!(s.need_s(), 2460);
+        assert!(s.fits());
+    }
+
+    /// `compare: false` halves the need, and the parser must see it.
+    #[test]
+    fn compare_false_is_read_from_the_step() {
+        let wf = "jobs:\n  j:\n    timeout-minutes: 10\n    steps:\n      - uses: ./.github/actions/gatehouse\n        with:\n          timeout: \"500\"\n          compare: \"false\"\n";
+        let s = sites(wf, 3600, true);
+        assert_eq!(s.len(), 1);
+        assert!(!s[0].compare);
+        assert_eq!(s[0].timeout_s, 500);
+        assert!(s[0].fits());
+    }
+
+    /// An omitted `timeout` takes the action's default, which is larger than most jobs.
+    #[test]
+    fn an_omitted_timeout_takes_the_action_default() {
+        let wf = "jobs:\n  j:\n    timeout-minutes: 45\n    steps:\n      - uses: ./.github/actions/gatehouse\n        with:\n          run: cargo test\n";
+        let s = sites(wf, 3600, true);
+        assert_eq!(s[0].timeout_s, 3600);
+        assert!(!s[0].fits(), "3600s twice cannot fit a 45-minute job");
+    }
+
+    /// A commented-out step is not a step.
+    #[test]
+    fn commented_lines_are_not_sites() {
+        let wf = "jobs:\n  j:\n    timeout-minutes: 45\n    steps:\n      # - uses: ./.github/actions/gatehouse\n";
+        assert!(sites(wf, 3600, true).is_empty());
+    }
+}

--- a/crates/xtask/src/gate_budget.rs
+++ b/crates/xtask/src/gate_budget.rs
@@ -78,6 +78,25 @@
 //! **360 minutes** — six hours of a runner held by a job that has hung. On a self-hosted
 //! pool already measured starving (gatehouse F-79), that is the cost that matters.
 //!
+//! **What already existed, and what this adds.** `ci-spec`'s `CI-I7-NOTIMEOUT`
+//! (`crates/ci-spec/src/invariants/timeouts.rs`) already finds untimed jobs, and its rationale
+//! is sharper than this one: it filters to workflows triggered by `merge_group`, because those
+//! are the jobs whose 360-minute default equals the queue's own `check_response_timeout_minutes`
+//! and therefore ejects a queue entry. It founds that on a real stall (2026-09-04/05). It
+//! reports **5** such jobs at `Severity::Medium`, which prints as `info` and does **not** fail.
+//!
+//! So this conjunct is not the first to look. It differs in two ways worth stating plainly:
+//! it covers every workflow rather than only `merge_group` ones (23 against those 5, which are
+//! a strict subset), and being a pinned population it **fails** rather than advising, so the
+//! set cannot grow while the 23 individual judgements are made.
+//!
+//! A correction belongs here too, because the wrong belief is more useful than the fix: two
+//! loops before this was written I tested the 360-minute tie, asked whether any REQUIRED
+//! context came from an untimed job, found none, and concluded it was not live. The right
+//! population was `merge_group`-triggered jobs, not required contexts — there are 5, and
+//! `CI-I7` had been saying so. Checking the wrong set and reading the empty answer as absence
+//! is the same error as trusting a gate's name over its log.
+//!
 //! Measured 2026-09-11: **147 jobs, 124 declaring a timeout, 23 not.** None of the 23
 //! produces a required context, so a hang there cannot block the merge queue on a required
 //! check — which is why this is a ratchet (`ci/untimed-jobs.txt`, shrink-only) rather than a

--- a/crates/xtask/src/gate_budget.rs
+++ b/crates/xtask/src/gate_budget.rs
@@ -44,11 +44,25 @@
 //! the failure this family of gates exists to refuse; `fly_pools.rs` calls the manager's own
 //! validator for the same reason.
 //!
+//! # The second conjunct: a job with no budget at all
+//!
+//! `timeout-minutes` is optional, and a job that omits it inherits GitHub's default of
+//! **360 minutes** — six hours of a runner held by a job that has hung. On a self-hosted
+//! pool already measured starving (gatehouse F-79), that is the cost that matters.
+//!
+//! Measured 2026-09-11: **147 jobs, 124 declaring a timeout, 23 not.** None of the 23
+//! produces a required context, so a hang there cannot block the merge queue on a required
+//! check — which is why this is a ratchet (`ci/untimed-jobs.txt`, shrink-only) rather than a
+//! repair. The repair is 23 separate judgements about the right timeout for each job, and a
+//! wrong number fails honest jobs. The ratchet buys the thing that is urgent: the population
+//! cannot GROW while those judgements are made.
+//!
 //! # What decides this
 //!
 //! Two committed YAML files. No source tree, no toolchain, no network, and the same verdict
 //! against an empty checkout of nucleus. See gatehouse `docs/tiering.md`.
 
+use std::collections::BTreeSet;
 use std::fs;
 use std::path::Path;
 
@@ -66,6 +80,11 @@ const USES: &str = "./.github/actions/gatehouse";
 /// up. This is an allowance, not a ceiling — a job that fits only because setup was fast is
 /// the shape this gate refuses.
 const SETUP_ALLOWANCE_S: u64 = 60;
+
+/// Jobs allowed to declare no `timeout-minutes`. Shrink-only.
+const UNTIMED_PIN: &str = "ci/untimed-jobs.txt";
+/// What GitHub gives a job that declares none.
+const GITHUB_DEFAULT_MINUTES: u64 = 360;
 
 /// One `uses: ./.github/actions/gatehouse` step, with the job budget around it.
 #[derive(Debug, PartialEq, Eq)]
@@ -239,6 +258,108 @@ fn unlisted_users(root: &Path) -> Result<Vec<String>> {
     Ok(out)
 }
 
+/// Every job in one workflow that declares no job-level `timeout-minutes`.
+///
+/// A job key sits at indent 2 under a column-0 `jobs:`; its own keys are at indent 4. A
+/// `timeout-minutes` deeper than that belongs to a STEP, and a step's timeout does not bound
+/// the job — so the match is anchored to indent 4 exactly.
+pub fn jobs_without_timeout(workflow_src: &str) -> Vec<String> {
+    let lines: Vec<&str> = workflow_src.lines().collect();
+    let Some(start) = lines.iter().position(|l| l.trim_end() == "jobs:") else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    let mut current: Option<(String, bool)> = None;
+    for l in &lines[start + 1..] {
+        if !l.is_empty() && !l.starts_with(' ') && !l.starts_with('#') {
+            break;
+        }
+        let job_key = l
+            .strip_prefix("  ")
+            .filter(|r| !r.starts_with(' ') && !r.starts_with('#'))
+            .and_then(|r| r.strip_suffix(':'))
+            .filter(|n| !n.is_empty());
+        if let Some(name) = job_key {
+            if let Some((n, seen)) = current.take()
+                && !seen
+            {
+                out.push(n);
+            }
+            current = Some((name.to_string(), false));
+        } else if l.starts_with("    timeout-minutes:")
+            && let Some((_, seen)) = current.as_mut()
+        {
+            *seen = true;
+        }
+    }
+    if let Some((n, seen)) = current
+        && !seen
+    {
+        out.push(n);
+    }
+    out
+}
+
+/// `file.yml:job` lines, `#` comments ignored.
+pub fn untimed_pin(src: &str) -> Vec<String> {
+    src.lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty() && !l.starts_with('#'))
+        .map(str::to_string)
+        .collect()
+}
+
+/// The second conjunct. Returns failure messages; empty when it holds.
+fn check_untimed(root: &Path) -> Result<Vec<String>> {
+    let pin_src = fs::read_to_string(root.join(UNTIMED_PIN))
+        .with_context(|| format!("reading {UNTIMED_PIN}"))?;
+    let allowed: BTreeSet<String> = untimed_pin(&pin_src).into_iter().collect();
+    // An empty pin is NOT refused: it is where a shrink-only ratchet is trying to get, and
+    // a gate that reds on its own success state teaches people to keep a spare entry. The
+    // non-vacuity that matters is the file existing at all, which `read_to_string` enforces
+    // above, plus the stale-entry direction below.
+
+    let dir = root.join(".github/workflows");
+    let mut files: Vec<_> = fs::read_dir(&dir)
+        .with_context(|| format!("reading {}", dir.display()))?
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.extension().is_some_and(|e| e == "yml"))
+        .collect();
+    files.sort();
+    if files.is_empty() {
+        bail!(".github/workflows: no workflows read — a sweep of nothing allows everything");
+    }
+
+    let mut found = BTreeSet::new();
+    for f in &files {
+        let name = f.file_name().unwrap().to_string_lossy().to_string();
+        for job in jobs_without_timeout(&fs::read_to_string(f)?) {
+            found.insert(format!("{name}:{job}"));
+        }
+    }
+
+    let mut out = Vec::new();
+    for j in found.difference(&allowed) {
+        out.push(format!(
+            "{j} declares no `timeout-minutes`, so it inherits GitHub's {GITHUB_DEFAULT_MINUTES}-minute default — six hours of a runner for a job that has hung. Give it a timeout; if it genuinely needs none, add it to {UNTIMED_PIN} and say why, dated."
+        ));
+    }
+    for j in allowed.difference(&found) {
+        out.push(format!(
+            "{UNTIMED_PIN} lists {j}, which now declares a timeout or no longer exists. Delete the line — this list may only shrink, and a stale entry is slack the next job inherits."
+        ));
+    }
+    // Only when it HOLDS. Printing "all pinned" beside a failure is a gate reporting the
+    // opposite of its own verdict, which is the shape this whole family exists to refuse.
+    if out.is_empty() {
+        println!(
+            "  ok   {} job(s) without a timeout, all pinned",
+            found.len()
+        );
+    }
+    Ok(out)
+}
+
 pub fn check(root: &Path) -> Result<()> {
     let action =
         fs::read_to_string(root.join(ACTION)).with_context(|| format!("reading {ACTION}"))?;
@@ -305,12 +426,10 @@ pub fn check(root: &Path) -> Result<()> {
         }
     }
 
+    bad.extend(check_untimed(root)?);
+
     if !bad.is_empty() {
-        bail!(
-            "{} gate budget(s) cannot fire:\n{}",
-            bad.len(),
-            bad.join("\n")
-        );
+        bail!("{} budget problem(s):\n{}", bad.len(), bad.join("\n"));
     }
     println!("ok: all {total} gate budget(s) leave room for the runner to report first");
     Ok(())
@@ -433,10 +552,13 @@ inputs:
     fn tree(dir: &Path, action: &str, workflows: &[(&str, &str)]) {
         fs::create_dir_all(dir.join(".github/actions/gatehouse")).unwrap();
         fs::create_dir_all(dir.join(".github/workflows")).unwrap();
+        fs::create_dir_all(dir.join("ci")).unwrap();
         fs::write(dir.join(ACTION), action).unwrap();
         for (name, body) in workflows {
             fs::write(dir.join(".github/workflows").join(name), body).unwrap();
         }
+        // Every job in these fixtures declares a timeout, so the pin is legitimately empty.
+        fs::write(dir.join(UNTIMED_PIN), "# no untimed jobs in this fixture\n").unwrap();
     }
 
     fn tmp(tag: &str) -> std::path::PathBuf {
@@ -474,7 +596,10 @@ inputs:
         );
         let e = check(&d).expect_err("2700 x2 cannot fit a 2700s job");
         let msg = e.to_string();
-        assert!(msg.contains("cannot fire"), "{msg}");
+        // Assert on the per-site explanation, not the summary line: the summary counts
+        // problems from both conjuncts and its wording is not this conjunct's claim.
+        assert!(msg.contains("can never fire first"), "{msg}");
+        assert!(msg.contains("5460s"), "the arithmetic must be shown: {msg}");
     }
 
     /// The action's own default applies when the step omits `timeout`, and 3600 twice
@@ -531,6 +656,57 @@ inputs:
         assert!(
             check(&d).is_err(),
             "an absent action definition is not a pass"
+        );
+    }
+
+    // ---- the second conjunct: jobs with no budget at all ---------------------------
+
+    #[test]
+    fn a_job_without_a_timeout_is_found() {
+        let wf = "jobs:\n  a:\n    runs-on: x\n  b:\n    timeout-minutes: 5\n    runs-on: x\n";
+        assert_eq!(jobs_without_timeout(wf), vec!["a".to_string()]);
+    }
+
+    /// A STEP's timeout does not bound the job, so it must not count as one.
+    #[test]
+    fn a_step_level_timeout_does_not_count_for_the_job() {
+        let wf = "jobs:\n  a:\n    runs-on: x\n    steps:\n      - run: echo\n        timeout-minutes: 5\n";
+        assert_eq!(jobs_without_timeout(wf), vec!["a".to_string()]);
+    }
+
+    /// The `jobs:` mapping ends at the next column-0 key; nothing after it is a job.
+    #[test]
+    fn keys_after_the_jobs_mapping_are_not_jobs() {
+        let wf = "jobs:\n  a:\n    timeout-minutes: 5\n    runs-on: x\nconcurrency:\n  group: g\n";
+        assert!(jobs_without_timeout(wf).is_empty());
+    }
+
+    #[test]
+    fn a_workflow_with_no_jobs_key_yields_nothing() {
+        assert!(jobs_without_timeout("name: x\non: push\n").is_empty());
+    }
+
+    #[test]
+    fn the_last_job_is_not_dropped() {
+        let wf = "jobs:\n  a:\n    timeout-minutes: 5\n  b:\n    runs-on: x\n";
+        assert_eq!(jobs_without_timeout(wf), vec!["b".to_string()]);
+    }
+
+    #[test]
+    fn the_pin_ignores_comments_and_blanks() {
+        let p = untimed_pin("# note\n\na.yml:one\nb.yml:two\n");
+        assert_eq!(p, vec!["a.yml:one".to_string(), "b.yml:two".to_string()]);
+    }
+
+    /// The shipped tree: the pin and the sweep agree, in both directions.
+    #[test]
+    fn the_shipped_pin_matches_the_shipped_workflows() {
+        let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+        let problems = check_untimed(&root).expect("the pin must be readable");
+        assert!(
+            problems.is_empty(),
+            "the shipped pin and the shipped workflows disagree:\n  {}",
+            problems.join("\n  ")
         );
     }
 

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -105,6 +105,10 @@ enum Command {
     /// ci/coverage-floor.txt, so moving a coverage floor has to be written down. Decided
     /// from two committed files; measures no coverage.
     CoverageFloor,
+    /// A gate's own timeout must fire before the job running it is killed, or a gate
+    /// that overruns is reported as `cancelled` and carries no verdict. Decided from the
+    /// workflow and the action definition alone.
+    GateBudget,
     /// A claim's falsifier must produce a REQUIRED context. A gate CI runs, that goes red, and
     /// that the merge queue merges past anyway enforces nothing — it is a red light beside an
     /// open gate. Ratcheted, not driven to zero: whether a given check should be required is a
@@ -307,6 +311,7 @@ mod ci_timings;
 mod clippy_config;
 mod coverage_floor;
 mod fly_pools;
+mod gate_budget;
 mod gatehouse_pin;
 mod inert_authority;
 mod kani_coverage;
@@ -355,6 +360,7 @@ fn main() -> Result<()> {
         Command::FlyPools => fly_pools::check(&std::env::current_dir()?),
         Command::PushAuth => push_auth::check(&std::env::current_dir()?),
         Command::CoverageFloor => coverage_floor::check(&std::env::current_dir()?),
+        Command::GateBudget => gate_budget::check(&std::env::current_dir()?),
         Command::AssuranceRequired => assurance_required::check(&std::env::current_dir()?),
         Command::AllowlistGates { parity } => {
             let root = std::env::current_dir()?;

--- a/scripts/check-gates-can-fail.sh
+++ b/scripts/check-gates-can-fail.sh
@@ -629,6 +629,16 @@ perturb_coverage_floor() {
     sed -i.bak -E 's/(--fail-under-lines )[0-9.]+/\182.4/' "$1" && rm -f "$1.bak"
 }
 
+perturb_gate_budget_timeout() {
+    # The live 2026-09-11 defect: the action's timeout as large as the job's own, so GitHub
+    # kills the job before the runner can report and the overrun comes back `cancelled`.
+    # Matches the KEY and rewrites the value, never matching the value -- the 2026-09-07
+    # incident where a probe keyed on a literal silently stopped perturbing anything when
+    # the subject moved. `timeout-minutes` is untouched: it has a hyphen, so `timeout: `
+    # cannot match it.
+    sed -i.bak -E 's/^( *)timeout: "[0-9]+"/\1timeout: "9999"/' "$1" && rm -f "$1.bak"
+}
+
 perturb_fly_pool_volumes() {
     # The exact configuration the manager refuses, and the one that was committed:
     # requires_volume with no volumes for eight machines, so the machines past the
@@ -650,6 +660,8 @@ probe_xtask push-auth .github/workflows/clippy-ratchet.yml \
     "a CI push relying on the checkout's ambient credential" perturb_push_auth_strip
 probe_xtask coverage-floor .github/workflows/coverage-matrix.yml \
     "a coverage floor lowered without moving its pin" perturb_coverage_floor
+probe_xtask gate-budget .github/workflows/gatehouse-shadow.yml \
+    "a gate timeout its job kills before the runner can report" perturb_gate_budget_timeout
 
 probe check-line-ratchet.sh   "--strict" crates/portcullis/src/kernel.rs \
       "400 lines past the ceiling"            perturb_line_ratchet

--- a/scripts/check-gates-can-fail.sh
+++ b/scripts/check-gates-can-fail.sh
@@ -738,6 +738,17 @@ perturb_gate_budget_timeout() {
     sed -i.bak -E 's/^( *)timeout: "[0-9]+"/\1timeout: "9999"/' "$1" && rm -f "$1.bak"
 }
 
+perturb_dep_ceiling_raise() {
+    # The OTHER direction of this gate, and the one its uncovered entry did not see.
+    # "needs a real duplicate crate version" is true for the drift half -- you cannot
+    # conjure a second `sha2` line from a shell script. But the gate also fails when a
+    # watched crate sits STRICTLY BELOW its ceiling, because an unclaimed win is debt
+    # the next PR inherits. Raising a ceiling above the actual count exercises exactly
+    # that half, and the declaration it perturbs is committed. Matches the KEY (the
+    # crate name) and rewrites whatever count follows, never matching the count.
+    sed -i.bak -E 's/^([[:space:]]*"[a-z0-9_-]+) [0-9]+"/\1 9"/' "$1" && rm -f "$1.bak"
+}
+
 gen_exemplar_scoreboard() {
     bash scripts/exemplar-scoreboard.sh "$1" >/dev/null 2>&1
 }
@@ -781,6 +792,8 @@ probe_xtask gate-budget .github/workflows/gatehouse-shadow.yml \
 
 probe check-line-ratchet.sh   "--strict" crates/portcullis/src/kernel.rs \
       "400 lines past the ceiling"            perturb_line_ratchet
+probe check-dep-ceiling.sh    "" scripts/check-dep-ceiling.sh \
+      "a ceiling above the count it caps"     perturb_dep_ceiling_raise
 probe check-law-mechanisms.sh "" crates/portcullis/src/lattice.rs \
       "a declared-dead mechanism gains a production call site" perturb_law_mechanism_wired
 probe check-law-mechanisms.sh "" crates/portcullis/src/budget.rs \
@@ -878,7 +891,6 @@ probe check-kani-divergence.sh "" crates/portcullis/src/capability.rs \
 # A perturbation for these needs a duplicate crate version or a non-wasm
 # dependency — a real lockfile change, which this script will not make.
 UNCOVERED=(
-    "check-dep-ceiling.sh          needs a real duplicate crate version"
     "check-wasm-closure.sh         needs a non-wasm dependency added"
     # 2026-09-11: the xtask half of the domain became VISIBLE today. These eight
     # were never exempted by decision — they were outside the glob, so nothing
@@ -912,7 +924,14 @@ UNCOVERED=(
 # refused it. `probe_xtask_generated` keeps that guard -- it asserts CI's flags are
 # exactly what the probe claims -- and allows the probe's flags to differ only in the
 # generated path, which is named rather than inferred. The generator costs 4s.
-UNCOVERED_CEILING=7
+#
+# 2026-09-11, 7 -> 6: `check-dep-ceiling.sh` gets a probe. Its stated obstacle --
+# "needs a real duplicate crate version" -- was true for only ONE of the two things
+# it checks. The gate also fails when a watched crate sits strictly BELOW its
+# ceiling, and raising a ceiling above the actual count exercises that half from a
+# committed declaration. The same shape as scoreboard-ratchet above: the exemption
+# named a real obstacle and stopped there.
+UNCOVERED_CEILING=6
 
 # ── Self-falsified elsewhere, not here ────────────────────────────────────
 #

--- a/scripts/check-gates-can-fail.sh
+++ b/scripts/check-gates-can-fail.sh
@@ -238,6 +238,101 @@ probe_xtask() {
     fi
 }
 
+# probe_xtask for a subcommand CI invokes WITH FLAGS, where one of those flags
+# names a file the job generates and the tree does not carry.
+#
+# `probe_xtask` refuses this shape on purpose: probing bare what CI runs with
+# arguments tests a command CI never runs. The answer is not to relax that, it is
+# to state both invocations and check they correspond. So this takes the flags CI
+# is asserted to pass and the flags the probe will pass, requires the first to be
+# exactly what the workflow declares, and requires the two to differ ONLY in the
+# generated path -- which is named, not inferred. A drift in CI's flags fails here
+# rather than being silently probed around.
+#
+# probe_xtask_generated <sub> <target> <desc> <ci_flags> <generated> <local_path> <gen_fn> <perturb_fn>
+probe_xtask_generated() {
+    local sub="$1" target="$2" desc="$3" ci_flags="$4" generated="$5" local_path="$6" gen_fn="$7" perturb_fn="$8"
+
+    local invocations
+    invocations="$(grep -rhE "xtask -- $sub" .github/workflows/*.yml 2>/dev/null \
+        | grep -vE '^[[:space:]]*#' \
+        | grep -oE "xtask -- ${sub}[^\"'\`|]*" \
+        | sed -E "s/xtask -- $sub//; s/^[[:space:]]+//; s/[[:space:]]+\$//")"
+    if [[ -z "$(printf '%s' "$invocations")" ]]; then
+        echo "  FAIL  xtask $sub — no workflow invokes it"
+        failures=$((failures + 1))
+        return
+    fi
+    # CI-PARITY, kept rather than waived: the declared flags must be what CI runs.
+    # `--` ends option parsing: $ci_flags begins with `--`, and without it grep reads
+    # the pattern as its own flags and dies with "invalid option".
+    if ! printf '%s\n' "$invocations" | grep -qxF -- "$ci_flags"; then
+        echo "  FAIL  xtask $sub — CI invokes it as: $(printf '%s' "$invocations" | head -1)"
+        echo "        but this probe claims parity with: $ci_flags"
+        echo "        Update the probe to match CI, or CI to match the probe."
+        failures=$((failures + 1))
+        return
+    fi
+    # ...and the probe's own flags may differ ONLY by the generated file's path.
+    local expected_local="${ci_flags/$generated/$local_path}"
+    if [[ "$expected_local" == "$ci_flags" ]]; then
+        echo "  FAIL  xtask $sub — '$generated' does not appear in CI's flags, so there is"
+        echo "        nothing for the probe to substitute; use probe_xtask instead."
+        failures=$((failures + 1))
+        return
+    fi
+
+    if ! "$gen_fn" "$local_path"; then
+        echo "  FAIL  xtask $sub — could not generate $local_path for the probe"
+        failures=$((failures + 1))
+        return
+    fi
+    if [[ ! -s "$local_path" ]]; then
+        echo "  FAIL  xtask $sub — $gen_fn produced nothing; an empty input is not a probe"
+        failures=$((failures + 1))
+        return
+    fi
+    if [[ ! -f "$target" ]]; then
+        echo "  ERROR: $target does not exist"
+        failures=$((failures + 1))
+        return
+    fi
+
+    RESTORE_TO="$target"
+    RESTORE_FROM="$(mktemp)"
+    cp "$target" "$RESTORE_FROM"
+
+    "$perturb_fn" "$target"
+
+    if cmp -s "$target" "$RESTORE_FROM"; then
+        echo "  FAIL  xtask $sub — the perturbation for '$desc' changed $target not at all"
+        restore
+        RESTORE_FROM=""
+        failures=$((failures + 1))
+        return
+    fi
+
+    local perturbed_rc=0
+    # shellcheck disable=SC2086
+    cargo run -q -p xtask -- "$sub" $expected_local >/dev/null 2>&1 || perturbed_rc=$?
+    restore
+    RESTORE_FROM=""
+    local restored_rc=0
+    # shellcheck disable=SC2086
+    cargo run -q -p xtask -- "$sub" $expected_local >/dev/null 2>&1 || restored_rc=$?
+
+    covered=$((covered + 1))
+    if [[ "$perturbed_rc" -eq 0 ]]; then
+        echo "  FAIL  xtask $sub — $desc did NOT fail the gate (exit 0)"
+        failures=$((failures + 1))
+    elif [[ "$restored_rc" -ne 0 ]]; then
+        echo "  FAIL  xtask $sub — still failing (exit $restored_rc) after restore"
+        failures=$((failures + 1))
+    else
+        echo "  ok    xtask $sub — RED on $desc, GREEN when restored"
+    fi
+}
+
 # ── Perturbations ─────────────────────────────────────────────────────────
 # Each introduces a real violation of the gate's OWN stated property, not a
 # syntax error that would fail any check.
@@ -643,6 +738,18 @@ perturb_gate_budget_timeout() {
     sed -i.bak -E 's/^( *)timeout: "[0-9]+"/\1timeout: "9999"/' "$1" && rm -f "$1.bak"
 }
 
+gen_exemplar_scoreboard() {
+    bash scripts/exemplar-scoreboard.sh "$1" >/dev/null 2>&1
+}
+
+perturb_exemplar_baseline() {
+    # Claim a perfect score the tree does not have. `sorry_admit` is lower-is-better,
+    # so a baseline of 0 makes the CURRENT count a regression against it -- which is
+    # the gate's own rule, not a malformed file. Matches the KEY and rewrites whatever
+    # number follows, never matching the value.
+    sed -i.bak -E 's/("sorry_admit"[[:space:]]*:[[:space:]]*)[0-9]+/\10/' "$1" && rm -f "$1.bak"
+}
+
 perturb_fly_pool_volumes() {
     # The exact configuration the manager refuses, and the one that was committed:
     # requires_volume with no volumes for eight machines, so the machines past the
@@ -660,6 +767,11 @@ probe_xtask allowlist-gates ci/allowlist-gates.txt \
     "an allowlist grown past its pinned size" perturb_allowlist_pin
 probe_xtask fly-pools ci/fly-runner/manager.toml \
     "the committed POOLS default the manager refuses" perturb_fly_pool_volumes
+probe_xtask_generated scoreboard-ratchet scripts/exemplar-baseline.json \
+    "a baseline claiming a score the tree does not have" \
+    "--current scoreboard.json --baseline scripts/exemplar-baseline.json" \
+    "scoreboard.json" "$(mktemp -t scoreboard).json" \
+    gen_exemplar_scoreboard perturb_exemplar_baseline
 probe_xtask push-auth .github/workflows/clippy-ratchet.yml \
     "a CI push relying on the checkout's ambient credential" perturb_push_auth_strip
 probe_xtask coverage-floor .github/workflows/coverage-matrix.yml \
@@ -777,7 +889,6 @@ UNCOVERED=(
     "xtask lean-action-builds      needs a Lean toolchain to reach its verdict"
     "xtask line-ratchet            probed through scripts/check-line-ratchet.sh, which is the same decision procedure"
     "xtask policy-gate             runs ck-kernel admission on a manifest amendment; needs a real amendment"
-    "xtask scoreboard-ratchet      perturbation not yet written"
 )
 # Was 5. Three were paid down once their detection was read rather than guessed
 # at. The remaining two need a Cargo.lock change, which this script will not make.
@@ -793,7 +904,15 @@ UNCOVERED=(
 # versions reds it; self-pin resolves a `uses: .../nucleus/<dir>@<sha>` against
 # the clone, so a SHA that does not exist reds it (exit 2, "could not look",
 # which is the right red -- a pin nobody can resolve is not a pin).
-UNCOVERED_CEILING=8
+#
+# 2026-09-11, 8 -> 7: `scoreboard-ratchet` gets a probe. It was the only entry whose
+# stated reason was "perturbation not yet written" rather than a named obstacle, and
+# the obstacle turned out to be real but surmountable: CI passes `--current
+# scoreboard.json`, a file the job generates, so `probe_xtask`'s CI-parity guard
+# refused it. `probe_xtask_generated` keeps that guard -- it asserts CI's flags are
+# exactly what the probe claims -- and allows the probe's flags to differ only in the
+# generated path, which is named rather than inferred. The generator costs 4s.
+UNCOVERED_CEILING=7
 
 # ── Self-falsified elsewhere, not here ────────────────────────────────────
 #
@@ -942,7 +1061,9 @@ done < <(
 
 for sub in "${XTASK_GATES[@]}"; do
     gate="xtask $sub"
-    grep -qE "^probe_xtask[[:space:]]+$sub([[:space:]]|$)" "$0" && continue
+    # Both probe forms count as coverage: probe_xtask for a bare invocation,
+    # probe_xtask_generated for one CI runs with flags naming a generated file.
+    grep -qE "^probe_xtask(_generated)?[[:space:]]+$sub([[:space:]]|$)" "$0" && continue
     printf '%s\n' "${UNCOVERED[@]}" | grep -q "^${gate}[[:space:]]" && continue
     UNACCOUNTED+=("$gate")
 done

--- a/scripts/check-gates-can-fail.sh
+++ b/scripts/check-gates-can-fail.sh
@@ -96,7 +96,7 @@ probe() {
     # two ways — `--count` inside a $(...) and `--strict` as the gate — is
     # probed as the gate, so ANY invocation may match the probe's flags.
     local invocations in_ci
-    invocations="$(grep -rhE "scripts/$gate" .github/workflows/ 2>/dev/null | grep -vE '^[[:space:]]*#' | grep -oE "scripts/$gate[^\"'\`)]*" | sed "s|scripts/$gate||" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//' || true)"
+    invocations="$(grep -rhE "scripts/$gate" .github/workflows/ 2>/dev/null | grep -vE '^[[:space:]]*#' | grep -oE "scripts/${gate}[^\"'\`)]*" | sed "s|scripts/$gate||" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//' || true)"
     if ! printf '%s\n' "$invocations" | grep -qxF -- "$ci_flags"; then
         in_ci="$(printf '%s\n' "$invocations" | head -1)"
         echo "  FAIL  $gate — CI invokes it as '$gate $in_ci' but this probe uses '$gate $ci_flags'"
@@ -136,7 +136,11 @@ probe() {
     fi
 
     local perturbed_rc=0
-    # shellcheck disable=SC2086 — ci_flags is a deliberate word-split.
+    # ci_flags is a deliberate word-split. The directive below carries no trailing
+    # prose: shellcheck parses the rest of the line as more key=value pairs, so an
+    # em-dash and a sentence made it emit SC1125 and IGNORE the disable entirely --
+    # a suppression that suppressed nothing.
+    # shellcheck disable=SC2086
     bash "scripts/$gate" $ci_flags >/dev/null 2>&1 || perturbed_rc=$?
 
     restore
@@ -173,7 +177,7 @@ probe_xtask() {
     local invocations
     invocations="$(grep -rhE "xtask -- $sub" .github/workflows/*.yml 2>/dev/null \
         | grep -vE '^[[:space:]]*#' \
-        | grep -oE "xtask -- $sub[^\"'\`|]*" \
+        | grep -oE "xtask -- ${sub}[^\"'\`|]*" \
         | sed -E "s/xtask -- $sub//; s/^[[:space:]]+//; s/[[:space:]]+\$//")"
     if [[ -z "$(printf '%s' "$invocations")" ]] && ! grep -rhE "xtask -- $sub" .github/workflows/*.yml 2>/dev/null | grep -qvE '^[[:space:]]*#'; then
         echo "  FAIL  xtask $sub — no workflow invokes it"
@@ -901,8 +905,8 @@ for path in scripts/check-*.sh; do
     fi
 
     grep -qE "^probe[[:space:]]+$gate([[:space:]]|$)" "$0" && continue
-    printf '%s\n' "${UNCOVERED[@]}" | grep -q "^$gate[[:space:]]" && continue
-    printf '%s\n' "${SELF_FALSIFIED[@]}" | grep -q "^$gate[[:space:]]" && continue
+    printf '%s\n' "${UNCOVERED[@]}" | grep -q "^${gate}[[:space:]]" && continue
+    printf '%s\n' "${SELF_FALSIFIED[@]}" | grep -q "^${gate}[[:space:]]" && continue
     UNACCOUNTED+=("$gate")
 done
 
@@ -939,7 +943,7 @@ done < <(
 for sub in "${XTASK_GATES[@]}"; do
     gate="xtask $sub"
     grep -qE "^probe_xtask[[:space:]]+$sub([[:space:]]|$)" "$0" && continue
-    printf '%s\n' "${UNCOVERED[@]}" | grep -q "^$gate[[:space:]]" && continue
+    printf '%s\n' "${UNCOVERED[@]}" | grep -q "^${gate}[[:space:]]" && continue
     UNACCOUNTED+=("$gate")
 done
 


### PR DESCRIPTION
Three open PRs all showed the same red check. It was **one root cause, it was on main, and no PR had caused it** — the shadow lane's clippy entry had not been failing. It had not been running.

## What was wrong

Two clocks ran over the same work, and nothing compared them:

| clock | who enforces it | does it report? |
|---|---|---|
| the gatehouse action's `timeout` | the runner | **yes** — a verdict |
| the job's `timeout-minutes` | GitHub | no — a `cancelled` conclusion |

The clippy entry declared `timeout: "2700"` inside a `timeout-minutes: 45` job — the same 2700 seconds — and `compare` defaults to `true`, so the command runs a **second** time to produce the agreement line that is the whole point of shadow mode. The declared need was 5460s inside a 2700s job. Even one run did not fit: setup spends 43s before the gate step starts (measured, run 34625269465).

So GitHub was always first, and every overrun came back `cancelled` — the same conclusion an infrastructure fault gives. The one mechanism that would have said *"this gate exceeded its budget"* was preempted by the one that says nothing at all.

## What it cost

Measured, not estimated:

- Last green run **2026-09-09T11:46:49Z**. Between then and 2026-09-11T18:00Z, **304 runs produced no verdict** (252 `cancelled`, 52 `failure`).
- **14 of 20** sampled cancelled runs had spent the **full 45 minutes** to produce nothing; the other 6 were superseded by `cancel-in-progress`.
- The earlier 52 were a different, now-resolved cause: `curl: (22) ... 404` → *"the control plane refused this run's token"*. Today's runs get past trust and hang in the command.
- Sibling matrix entries are unaffected and prove the parser sees a real difference: `fmt` and `ci-spec` finish in **1 minute**.

## The gate

`cargo xtask gate-budget`, decided from declarations alone — the workflow and the action definition. No source tree, no toolchain, no network, same verdict against an empty checkout. For each step using the action:

```
runs * timeout_s + setup  <  timeout-minutes * 60
```

strictly, with `runs = 2` when `compare` is on. Equality is the defect above, not a boundary case that just fits.

Both defaults are **read from `.github/actions/gatehouse/action.yml`** rather than copied into the gate. A second copy of a default is a second thing to drift, which is the failure this family exists to refuse — `fly_pools.rs` calls the manager's own validator for the same reason. It also reds if a workflow starts using the action without being listed, and if the parser stops finding any step at all: a gate that measures nothing passes everything.

## The fix, stated narrowly

`timeout: "1200"` — 1200 x2 + setup = 2460s, inside the job's 2700s, so the **runner** reports first.

This does **not** claim clippy now passes. It has never once completed, so nobody knows what it costs. It claims the opposite is no longer possible: an overrun now produces a timeout verdict at 20 minutes instead of a silent cancellation at 45 — and costs less runner time while doing it. **The number it reports is the measurement that was missing.** If 20 minutes turns out to be too little, that is a finding this lane can finally produce.

## Verification

- Driven **RED on the live defect** before green (A-19): `EXIT=1` on the shipped 2700/45 declaration, `EXIT=0` after the fix.
- Probed in `scripts/check-gates-can-fail.sh`; verified red→restore→green with the tree clean afterwards, and `timeout-minutes` untouched.
- `cargo test -p xtask` RC=0 (8 new tests), `cargo fmt --all -- --check` RC=0, `cargo clippy -p xtask --all-targets -- -D warnings` RC=0.

One parser bug was caught during development and is worth recording: the gate first reported the action's *default* 3600s over a step that plainly declared 2700. `with:` is a **sibling** of `uses:`, not a child, so the block scan ended before reading either input. It was caught only because the printed number disagreed with the declaration read by eye — a gate reporting a plausible wrong number is the failure mode this whole family is built against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)