### PR TITLE
The node's responses are observed, so the gate can see them

### DIFF
--- a/.observed-ratchet.toml
+++ b/.observed-ratchet.toml
@@ -22,24 +22,17 @@
 #   80  after adding the `FlowGraph` family to the marker set
 #   28  after scoping the ENFORCED finding to `OBSERVED_CRATES`
 #   12  after scoping again to what the AGENT can reach (`AGENT_ROOTS`), the
-#       same move `cb4a_separation` makes with its PDP/CDP roots. The other 17
-#       are boot and shutdown I/O — config loads, exit-report hashing, Article
-#       12 shipping, sandbox proof — still reported, as ADVISORY, and not gated.
+#       same move `cb4a_separation` makes with its PDP/CDP roots
+#    1  after `NodeClient` observes its own responses
 #
-# WHAT THE 12 ARE, and why they are one finding rather than twelve: the agent
-# asks the tool-proxy to manage a pod (`pod_mgmt::{create_sub_pod, list_sub_pods,
-# get_pod_status, get_pod_logs, cancel_sub_pod}`), the proxy asks the node
-# (`node_client::{get_json, post_json, create_pod, list_pods, pod_logs,
-# cancel_pod}`), and the node's response comes back to the agent unobserved.
-# `pod_logs` is the sharp one: a child pod's log content is whatever that pod
-# wrote, and it reaches the model with no flow node.
-#
-# The twelfth is `web_fetch_policy::read_body_capped`, and it is a DIFFERENT
-# question. Its caller `web_fetch` observes, twice. The pass reports at the
-# ingest rather than at an observing ancestor, on purpose — "the observation
-# belongs next to the ingest" — so a leaf whose caller observes still shows up.
-# Fixing it means either observing in the leaf or moving the report location,
-# and those are different answers with different costs.
+# THE LAST ONE IS A REPORT-LOCATION QUESTION, NOT A HOLE.
+# `web_fetch_policy::read_body_capped` reads the fetched body, and its caller
+# `web_fetch` DOES observe — twice. The pass reports at the ingest rather than at
+# an observing ancestor, on purpose: "the observation belongs next to the
+# ingest". Closing it means either observing in the leaf (which would double-
+# observe the same bytes) or changing where the pass reports. Neither is
+# obviously right, so it stays at 1 with the reason written down rather than
+# being driven to 0 by whichever is easier.
 #
 # The 16 ADVISORY are boot and shutdown I/O: exit_report (3), art12_shipper (2),
 # node_identity (2), sandbox_proof (2), and single sites in build_mtls_config,
@@ -51,5 +44,5 @@
 # move is not to lower this by one: it is to decide whether infrastructure
 # ingest inside this crate should be observed too, or given a marker that says
 # it is not agent-attributed. Either answer shrinks this number honestly.
-ceiling = 12
+ceiling = 1
 target = 0

--- a/crates/nucleus-tool-proxy/src/main.rs
+++ b/crates/nucleus-tool-proxy/src/main.rs
@@ -1597,6 +1597,15 @@ async fn main() -> Result<(), ApiError> {
         );
     }
 
+    // The single authoritative information-flow graph the egress verdict reads.
+    //
+    // Declared HERE, ahead of the node client, because the client observes into
+    // it. It used to be built ~170 lines further down, which is why
+    // `NodeClient` had no way to reach it and every node response arrived
+    // unobserved. The graph has no dependencies of its own, so moving it up is
+    // ordering, not restructuring.
+    let flow_graph = Arc::new(tokio::sync::Mutex::new(FlowGraph::new()));
+
     // Build node client for pod management (orchestrator mode). mTLS-only:
     // the node's HTTP listener requires a client cert unconditionally.
     let node_client = if args.enable_pod_mgmt {
@@ -1609,7 +1618,12 @@ async fn main() -> Result<(), ApiError> {
         identity_pem.extend_from_slice(identity.key_pem.as_bytes());
         let bundle_pem = identity.bundle_pem.into_bytes();
         info!("pod management enabled (node_url={})", node_url);
-        match node_client::NodeClient::new(node_url.to_string(), &identity_pem, &bundle_pem) {
+        match node_client::NodeClient::new(
+            node_url.to_string(),
+            &identity_pem,
+            &bundle_pem,
+            flow_graph.clone(),
+        ) {
             Ok(client) => Some(Arc::new(client)),
             Err(e) => {
                 error!("failed to build node client: {e}");
@@ -1773,9 +1787,6 @@ async fn main() -> Result<(), ApiError> {
         }
         k
     }));
-
-    // The single authoritative information-flow graph the egress verdict reads.
-    let flow_graph = Arc::new(tokio::sync::Mutex::new(FlowGraph::new()));
 
     // Provenance-memory state (next-bet #1). Trusted declassify keys + threshold
     // come from env; absent ⇒ empty/1 ⇒ declassification is fail-closed.

--- a/crates/nucleus-tool-proxy/src/node_client.rs
+++ b/crates/nucleus-tool-proxy/src/node_client.rs
@@ -17,6 +17,12 @@
 /// definition is what keeps a typo from silently degrading every caller to
 /// "unidentified" — the fail-open direction, and one that raises no error.
 pub(crate) use nucleus_client::{HEADER_POD_ID, HEADER_POD_TOKEN};
+use portcullis::flow_graph::FlowGraph;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+use crate::ingest::observe_into_graph;
+use nucleus::portcullis::NodeKind;
 
 /// Whether a (pod id, token) pair amounts to an identity — the decision itself,
 /// separated from where the values come from so it can be tested without
@@ -54,6 +60,18 @@ use uuid::Uuid;
 pub struct NodeClient {
     base_url: String,
     http: reqwest::Client,
+    /// The flow graph every node response is observed into.
+    ///
+    /// A response from the node is external bytes entering the session: pod ids,
+    /// statuses, and — for `pod_logs` — whatever a CHILD POD wrote. All of it is
+    /// returned to the agent. Before this, none of it created a flow node, so
+    /// the egress gate could not see any of it; `nucleus-observed-lint` reported
+    /// all four read sites and the pod-management handlers above them.
+    ///
+    /// Held here rather than passed per call because the observation belongs
+    /// next to the ingest, which is the position the lint takes and the reason
+    /// it reports at the reading function rather than at an observing ancestor.
+    flow_graph: Arc<Mutex<FlowGraph>>,
 }
 
 /// Information about a managed pod (mirrors nucleus-node PodInfo).
@@ -116,6 +134,7 @@ impl NodeClient {
         base_url: String,
         identity_pem: &[u8],
         trust_bundle_pem: &[u8],
+        flow_graph: Arc<Mutex<FlowGraph>>,
     ) -> Result<Self, NodeClientError> {
         // Idempotent — see nucleus-cli's `create_client` for why this must
         // run before building any reqwest client on the `rustls-no-provider`
@@ -152,6 +171,7 @@ impl NodeClient {
         Ok(Self {
             base_url: base_url.trim_end_matches('/').to_string(),
             http,
+            flow_graph,
         })
     }
 
@@ -167,6 +187,30 @@ impl NodeClient {
     }
 
     /// Get logs for a specific pod.
+    /// Observe bytes that arrived from the node.
+    ///
+    /// `HTTPResponse` — Internal confidentiality, Untrusted integrity — is the
+    /// truthful label for a control-plane reply from the node that launched this
+    /// pod. It raises the integrity ceiling without tripping `is_tainted`, which
+    /// fires only on `Adversarial`.
+    ///
+    /// A GAP, named rather than papered over: `pod_logs` returns a CHILD POD's
+    /// log content, which is whatever that pod wrote and may include anything it
+    /// fetched. That deserves `Adversarial`, and no `NodeKind` names it — the
+    /// closest, `McpToolResult`, carries the right integrity under a wrong name.
+    /// Adding a variant touches the IFC kernel and its Lean, so it is not folded
+    /// in here. Untrusted is strictly better than the nothing it replaces, and
+    /// this comment is the record of what it still under-calls.
+    async fn observe_node_response(&self, bytes: &[u8]) {
+        observe_into_graph(
+            &self.flow_graph,
+            NodeKind::HTTPResponse,
+            true,
+            crate::ingest_content_hash(bytes),
+        )
+        .await;
+    }
+
     pub async fn pod_logs(&self, id: Uuid) -> Result<String, NodeClientError> {
         let url = format!("{}/v1/pods/{}/logs", self.base_url, id);
         let mut request = self.http.get(&url);
@@ -185,7 +229,13 @@ impl NodeClient {
             });
         }
 
-        response.text().await.map_err(|e| NodeClientError {
+        // A child pod's log content — the most external thing this client
+        // returns. Observed before it is handed back to the agent.
+        let bytes = response.bytes().await.map_err(|e| NodeClientError {
+            message: e.to_string(),
+        })?;
+        self.observe_node_response(&bytes).await;
+        String::from_utf8(bytes.to_vec()).map_err(|e| NodeClientError {
             message: e.to_string(),
         })
     }
@@ -208,6 +258,13 @@ impl NodeClient {
         let response = request.send().await.map_err(|e| NodeClientError {
             message: e.to_string(),
         })?;
+
+        // No body is read here — the status is the whole of what crosses. It is
+        // still information from the node that reaches the agent, as a success
+        // or a refusal, so it is observed on BOTH paths rather than only the
+        // happy one.
+        self.observe_node_response(response.status().as_str().as_bytes())
+            .await;
 
         if !response.status().is_success() {
             return Err(NodeClientError {
@@ -252,7 +309,14 @@ impl NodeClient {
             });
         }
 
-        response.json::<R>().await.map_err(|e| NodeClientError {
+        // Read the body as BYTES so it can be observed before it is parsed. The
+        // previous `response.json::<R>()` consumed the response without ever
+        // exposing what arrived, which is why nothing could observe it.
+        let bytes = response.bytes().await.map_err(|e| NodeClientError {
+            message: e.to_string(),
+        })?;
+        self.observe_node_response(&bytes).await;
+        serde_json::from_slice::<R>(&bytes).map_err(|e| NodeClientError {
             message: e.to_string(),
         })
     }
@@ -281,7 +345,14 @@ impl NodeClient {
             });
         }
 
-        response.json::<R>().await.map_err(|e| NodeClientError {
+        // Read the body as BYTES so it can be observed before it is parsed. The
+        // previous `response.json::<R>()` consumed the response without ever
+        // exposing what arrived, which is why nothing could observe it.
+        let bytes = response.bytes().await.map_err(|e| NodeClientError {
+            message: e.to_string(),
+        })?;
+        self.observe_node_response(&bytes).await;
+        serde_json::from_slice::<R>(&bytes).map_err(|e| NodeClientError {
             message: e.to_string(),
         })
     }
@@ -446,8 +517,13 @@ mod mtls_tests {
             .unwrap();
         });
 
-        let client =
-            NodeClient::new(format!("https://{addr}"), &identity_pem, &bundle_pem).unwrap();
+        let client = NodeClient::new(
+            format!("https://{addr}"),
+            &identity_pem,
+            &bundle_pem,
+            Arc::new(Mutex::new(FlowGraph::new())),
+        )
+        .unwrap();
         let pods = client
             .list_pods()
             .await
@@ -495,8 +571,13 @@ mod mtls_tests {
             let _ = acceptor.accept(stream).await;
         });
 
-        let client =
-            NodeClient::new(format!("https://{addr}"), &identity_pem, &bundle_pem).unwrap();
+        let client = NodeClient::new(
+            format!("https://{addr}"),
+            &identity_pem,
+            &bundle_pem,
+            Arc::new(Mutex::new(FlowGraph::new())),
+        )
+        .unwrap();
         let result = client.list_pods().await;
         assert!(
             result.is_err(),


### PR DESCRIPTION
Stacked on #2824. Option **A1** — and it takes `observed` from **28 → 1**.

## The hole

A response from the node is external bytes entering the session — pod ids, statuses, and for `pod_logs` **whatever a child pod wrote** — and all of it is returned to the agent. None of it created a flow node, so the egress gate could not see any of it.

`nucleus-observed-lint` reported all four read sites plus the five pod-management handlers above them: **11 of its 12 enforced findings were this one path.**

## Why it couldn't observe

`NodeClient` could not reach a `FlowGraph`. It's constructed at `main.rs:1608`; the graph was built ~170 lines later. The graph has no dependencies of its own, so moving its declaration ahead of the client is **ordering, not restructuring**.

## Four read sites, each observing what actually crosses

| site | what crosses |
|---|---|
| `post_json` / `get_json` | body read as **bytes** and observed before parsing — the previous `response.json::<R>()` consumed the response without ever exposing what arrived, which is why nothing could observe it |
| `pod_logs` | a child pod's log content, observed before it is handed back to the agent |
| `cancel_pod` | no body is read, so the **status** is what crosses — observed on *both* paths, not only the happy one |

`HTTPResponse` (Internal / Untrusted) is the truthful label for a control-plane reply from the node that launched this pod. It raises the integrity ceiling without tripping `is_tainted`, which fires only on `Adversarial`.

## A gap, named rather than papered over

`pod_logs` returns a child pod's output, which may include anything that pod fetched. That deserves `Adversarial`. **No `NodeKind` names it** — the closest, `McpToolResult`, carries the right integrity under a wrong name. Adding a variant touches the IFC kernel and its Lean, so it isn't folded in here.

Untrusted is strictly better than the nothing it replaces, and the comment at the call site is the record of what it still under-calls.

## The one that remains

Enforced **12 → 1**. `web_fetch_policy::read_body_capped` is a **report-location question, not a hole**: its caller `web_fetch` observes, twice. Closing it means either observing in the leaf — double-observing the same bytes — or changing where the pass reports. Neither is obviously right, so the ceiling is 1 with the reason written down rather than driven to 0 by whichever is easier.

## Verification

```
clean:      observed: 1 unobserved-ingest finding(s), ceiling 1  → OK
perturbed:  observed: 2 ... → reds-on-revert OK: the gate fires
```

`cargo test -p nucleus-tool-proxy --all-features` 464 passed, 0 failed · clippy `--all-targets --all-features -- -D warnings` clean · `cargo fmt --all --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016t7JSuCtg4dC54HZjFgBjr