### PR TITLE
The distance to ADR 0006's four objects, as a number that only shrinks

### DIFF
--- a/.convergence-ratchet.toml
+++ b/.convergence-ratchet.toml
@@ -1,0 +1,89 @@
+# How far the tree is from ADR 0006's "four objects, composed".
+#
+#     Principal --Delegation--> Authority --Allocation--> Permit<Act> --Execution--> Receipt
+#
+# ADR 0006 measured this once, in prose, on 2026-09-09. That table is an audit;
+# this is the standing version of two of its rows, so the distance can be read
+# rather than re-derived, and so it can only shrink.
+#
+# WHY ONLY TWO ROWS, AND WHY THESE TWO.
+#
+# ADR 0006's A-20 draws the line this file obeys: a population is trustworthy
+# only where it is ENUMERATED FROM A SOURCE THAT DEFINES IT. Two of the four
+# arrows have such a source and two do not:
+#
+#   linearity      YES — "#[must_use] and not Clone" is a computable predicate
+#                  over the tree. The author declared affine intent in the type;
+#                  the question is whether the calling convention honours it.
+#   act_coverage   YES — the untargeted surface is a closed set of spellings
+#                  (`spend(Operation::..)`, `check(Operation::..)`,
+#                  `GuardedAction<Operation>`, `GuardedAction<String>`), each
+#                  of which the collapse replaces.
+#   attenuation    NO  — "every site that narrows authority" has no definition
+#                  in the tree. ADR 0006 counts ~24 hand-rolled clamps, and a
+#                  hand-listed denominator is the metric equivalent of a gate
+#                  that cannot fail. Left out deliberately.
+#   lineage        NO  — same reason. ~28 chains, 9 never walked, none of it
+#                  computable from a source.
+#
+# So this file measures the distance it can measure, and says so. A convergence
+# number that silently included two hand-maintained rows would be exactly the
+# vacuity ADR 0007 I-1 forbids, one level up.
+#
+# WHAT IT DOES NOT TELL YOU: whether four objects is the right decomposition.
+# A score climbing toward zero is the kind of number that starts substituting
+# for that judgement, and it must not.
+
+# ── linearity: a one-shot right is taken by value ───────────────────────────
+#
+# ADR 0007 C-4, and `f7f9719b` is its load-bearing example: `DischargedBundle`
+# was `!Clone`, `!Copy` and `#[must_use]` — every affine signal Rust offers —
+# and replayable anyway, because three signatures took it by `&`.
+#
+# Measured 2026-09-11 by `cargo xtask convergence`, over the production region of
+# every tracked crate as `law_mechanisms::production_region` extracts it:
+#
+#   DecisionToken      31   ADR 0006 C2.5 already names it: inert outside
+#                           `debug_assert`. Nearly the whole number is one type.
+#   DischargedBundle    4
+#                      --
+#                      35   over a population of 7 affine types
+#
+# SEEDED FROM THE GATE, NOT FROM A PROBE. A scratch script written while scoping
+# this said 34 across three types, because it tracked `#[cfg(test)]` line by line
+# instead of by brace depth and so mis-drew the production boundary. The gate and
+# its number have to come from the same code or the number is about the probe.
+# `.clippy-ratchet.toml` records the same lesson from the other direction: a
+# ceiling seeded on macOS that CI counted differently red on its own PR.
+#
+# `SessionCleanseToken` is NOT in this population and is worth naming: it was
+# fixed today (taken by value, probed with a paired doctest) but carries no
+# `#[must_use]`, so the predicate does not see it. The population is what the
+# types declare, not what carries affine intent in someone's head — which is
+# also why adding `#[must_use]` to a type can RAISE this number. That is
+# correct: it means the tree started admitting a claim it was not honouring.
+[linearity]
+ceiling = 35
+target = 0
+
+# ── act_coverage: the protected boundary carries its target ─────────────────
+#
+# ADR 0006 C2. `Operation` is 13 untargeted verbs — `ReadFiles`, not
+# `Read(path)` — so `subject: &str` was threaded through 47 signatures and
+# re-parsed by each gate. `Act` carries the target with the verb.
+#
+# Measured 2026-09-11:
+#
+#   Authority::spend(Operation::..)   1   the transitional surface beside
+#                                         `spend_on(self, &Act)`
+#   GuardedAction<Operation>          1
+#   GuardedAction<String>             1
+#   guard.check(Operation::..)        0   C2.2 landed; already converged
+#                                    --
+#                                     3
+#
+# One of the four spellings is already at zero, which is the evidence that this
+# row tracks real progress rather than sitting at a constant.
+[act_coverage]
+ceiling = 3
+target = 0

--- a/.github/workflows/manifest-guards.yml
+++ b/.github/workflows/manifest-guards.yml
@@ -130,6 +130,13 @@ jobs:
       # decides all seven in one place, and adds the two properties no copy could state:
       # a pattern that matches NOTHING has stopped watching (and prints PASSED either way),
       # and an allowlist may only shrink.
+      # ADR 0006's own measurement, made standing. Two of its four arrows have a
+      # population that can be enumerated from a source — "#[must_use] and not
+      # Clone" for linearity, a closed set of spellings for act coverage — so
+      # those two are ratcheted and the other two are excluded by name rather
+      # than averaged in from a hand-written list.
+      - name: The distance to ADR 0006's four objects only shrinks
+        run: cargo run -q -p xtask -- convergence
       - name: The scan-vs-allowlist family, decided once
         run: cargo run -q -p xtask -- allowlist-gates
       # The port is only worth having if it decides the same thing the scripts do. Agreement

--- a/crates/xtask/src/convergence.rs
+++ b/crates/xtask/src/convergence.rs
@@ -1,0 +1,439 @@
+//! `cargo xtask convergence` — how far the tree is from ADR 0006's four objects.
+//!
+//! ADR 0006 measured its own distance once, in prose, on 2026-09-09. That table
+//! is an audit. This is the standing version of the two rows whose population
+//! can be ENUMERATED FROM A SOURCE, so the distance can be read rather than
+//! re-derived, and so it can only shrink.
+//!
+//! # Why two rows and not four
+//!
+//! ADR 0006's A-20 draws the line: a population is trustworthy only where
+//! something in the tree defines it. `linearity` has one — "`#[must_use]` and
+//! not `Clone`" is computable. `act_coverage` has one — the untargeted surface
+//! is a closed set of spellings. `attenuation` and `lineage` do not: "every site
+//! that narrows authority" is a hand-listed denominator, which is the metric
+//! equivalent of a gate that cannot fail. They are excluded, and
+//! `.convergence-ratchet.toml` says so rather than quietly averaging them in.
+//!
+//! # What this does not establish
+//!
+//! That four objects is the right decomposition. A score falling toward zero is
+//! the kind of number that starts substituting for that judgement.
+//!
+//! Also: this is SYNTACTIC. It reads signatures, not semantics. A type aliased
+//! to a watched name is invisible, and a by-reference parameter that is
+//! genuinely read-only — `discharge_witness(bundle: &DischargedBundle) ->
+//! String` renders one for the audit log — counts against the number anyway.
+//! That is the safe direction (it over-counts debt, never under-counts it), but
+//! it means the target of 0 may end with a small declared residue rather than a
+//! literal zero.
+
+use anyhow::{Context, Result, bail};
+use serde::Deserialize;
+use std::collections::BTreeMap;
+
+use crate::law_mechanisms::{is_production_path, production_region, tracked};
+
+pub const RATCHET: &str = ".convergence-ratchet.toml";
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Ratchet {
+    pub linearity: Row,
+    pub act_coverage: Row,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Row {
+    pub ceiling: usize,
+    pub target: usize,
+}
+
+/// Parse the ratchet, refusing a shape that could not gate.
+///
+/// A ceiling BELOW its target is incoherent and would make the row unfailable
+/// in one direction; a missing row is a silently dropped measurement. Both bail
+/// rather than defaulting, because a default here is a number nobody chose.
+pub fn parse(text: &str) -> Result<Ratchet> {
+    let r: Ratchet = toml::from_str(text).context("parsing the convergence ratchet")?;
+    for (name, row) in [
+        ("linearity", &r.linearity),
+        ("act_coverage", &r.act_coverage),
+    ] {
+        if row.ceiling < row.target {
+            bail!(
+                "{name}: ceiling {} is below target {}",
+                row.ceiling,
+                row.target
+            );
+        }
+    }
+    Ok(r)
+}
+
+/// Types whose author declared affine intent: `#[must_use]` and not `Clone`.
+///
+/// Computed rather than listed, which is the whole reason this row is in the
+/// file. Adding `#[must_use]` to a type ENLARGES the population and can raise
+/// the number — correct, because it means the tree started making a claim it
+/// was not honouring.
+pub fn affine_types(corpus: &BTreeMap<String, String>) -> Vec<String> {
+    let mut declared: BTreeMap<String, String> = BTreeMap::new();
+    for (path, src) in corpus {
+        let lines: Vec<&str> = src.lines().collect();
+        for (i, line) in lines.iter().enumerate() {
+            if !line.trim_start().starts_with("#[must_use") {
+                continue;
+            }
+            // The declaration may sit a few attributes below the marker.
+            for probe in lines.iter().take((i + 8).min(lines.len())).skip(i + 1) {
+                if let Some(name) = struct_or_enum_name(probe) {
+                    declared.insert(name, path.clone());
+                    break;
+                }
+            }
+        }
+    }
+    let all: String = corpus.values().cloned().collect::<Vec<_>>().join("\n");
+    declared
+        .into_keys()
+        .filter(|t| !is_clone(&all, corpus, t))
+        .collect()
+}
+
+fn struct_or_enum_name(line: &str) -> Option<String> {
+    let t = line.trim_start();
+    let rest = t
+        .strip_prefix("pub struct ")
+        .or_else(|| t.strip_prefix("pub enum "))?;
+    let name: String = rest
+        .chars()
+        .take_while(|c| c.is_alphanumeric() || *c == '_')
+        .collect();
+    (!name.is_empty()).then_some(name)
+}
+
+/// Is `ty` `Clone`, by hand-written impl or by derive above its declaration?
+fn is_clone(all: &str, corpus: &BTreeMap<String, String>, ty: &str) -> bool {
+    if all.contains(&format!("impl Clone for {ty}")) {
+        return true;
+    }
+    for src in corpus.values() {
+        let lines: Vec<&str> = src.lines().collect();
+        for (i, line) in lines.iter().enumerate() {
+            if struct_or_enum_name(line).as_deref() != Some(ty) {
+                continue;
+            }
+            let from = i.saturating_sub(8);
+            if lines[from..i]
+                .iter()
+                .any(|l| l.contains("derive") && l.contains("Clone"))
+            {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Count parameters that take an affine type BY REFERENCE.
+///
+/// Comment lines are skipped: `authority.rs`'s module doc says "Today every
+/// effect takes `proof: &DischargedBundle`", and counting prose as a signature
+/// would put the defect's own description into the defect count.
+pub fn count_linearity(
+    corpus: &BTreeMap<String, String>,
+    types: &[String],
+) -> BTreeMap<String, usize> {
+    let mut out = BTreeMap::new();
+    for ty in types {
+        let mut n = 0usize;
+        for src in corpus.values() {
+            for line in src.lines() {
+                if line.trim_start().starts_with("//") {
+                    continue;
+                }
+                if takes_by_reference(line, ty) {
+                    n += 1;
+                }
+            }
+        }
+        if n > 0 {
+            out.insert(ty.clone(), n);
+        }
+    }
+    out
+}
+
+/// `: &Ty` or `: &mut Ty`, with an optional path prefix.
+fn takes_by_reference(line: &str, ty: &str) -> bool {
+    let mut rest = line;
+    while let Some(at) = rest.find(": &") {
+        let after = rest[at + 3..].trim_start();
+        let after = after.strip_prefix("mut ").unwrap_or(after).trim_start();
+        // Skip any `a::b::` qualification before the name.
+        let tail = after.rsplit("::").next().unwrap_or(after);
+        let name: String = tail
+            .chars()
+            .take_while(|c| c.is_alphanumeric() || *c == '_')
+            .collect();
+        if name == ty {
+            return true;
+        }
+        rest = &rest[at + 3..];
+    }
+    false
+}
+
+/// The untargeted-authority spellings the `Act` collapse replaces.
+///
+/// A closed set on purpose: each is a call shape that names a verb without its
+/// target. `guard.check(Operation::..)` and `GuardedAction<Operation>` are
+/// already at zero, which is the evidence this row tracks progress rather than
+/// sitting at a constant.
+pub fn count_act_coverage(corpus: &BTreeMap<String, String>) -> BTreeMap<String, usize> {
+    let shapes: [(&str, fn(&str) -> bool); 4] = [
+        ("Authority::spend(Operation::..)", |l| {
+            l.contains(".spend(") && l.contains("Operation::")
+        }),
+        ("guard.check(Operation::..)", |l| {
+            l.contains(".check(") && l.contains("Operation::")
+        }),
+        ("GuardedAction<Operation>", |l| {
+            l.contains("GuardedAction<Operation>")
+        }),
+        ("GuardedAction<String>", |l| {
+            l.contains("GuardedAction<String>")
+        }),
+    ];
+    let mut out = BTreeMap::new();
+    for (name, pred) in shapes {
+        let mut n = 0usize;
+        for src in corpus.values() {
+            for line in src.lines() {
+                if line.trim_start().starts_with("//") {
+                    continue;
+                }
+                if pred(line) {
+                    n += 1;
+                }
+            }
+        }
+        out.insert(name.to_string(), n);
+    }
+    out
+}
+
+/// Is this the gate harness rather than the enforcement path?
+///
+/// `law_mechanisms::is_production_path` accepts all of `crates/**`, `xtask`
+/// included — correct for its own question and wrong for this one twice over.
+///
+/// First, ADR 0006's four objects are about the runtime that enforces what an
+/// agent may do. `xtask` is build tooling; it holds no authority and delegates
+/// none, so counting it would put CI plumbing into a number about the
+/// enforcement path.
+///
+/// Second, and this is how it was found: this module NAMES the shapes it counts.
+/// `GuardedAction<Operation>` and `.spend(Operation::..)` appear here as pattern
+/// definitions, so the gate counted itself and `act_coverage` read 10 instead of
+/// 3 — a gate measuring its own source. It stayed invisible until the first
+/// commit, because `tracked` reads `git ls-files` and an uncommitted file is not
+/// tracked. The gate-of-gates caught it on the next run: "still failing (exit 1)
+/// after restore".
+fn is_gate_harness(path: &str) -> bool {
+    path.starts_with("crates/xtask/")
+}
+
+pub struct Finding {
+    pub row: &'static str,
+    pub found: usize,
+    pub ceiling: usize,
+}
+
+/// Pure decision: a row fails when it is ABOVE its ceiling.
+///
+/// Below the ceiling is not a failure — it is a notice to lower it in the same
+/// change, the convention `.clippy-ratchet.toml` already uses.
+pub fn decide(r: &Ratchet, linearity: usize, act: usize) -> Vec<Finding> {
+    let mut f = Vec::new();
+    if linearity > r.linearity.ceiling {
+        f.push(Finding {
+            row: "linearity",
+            found: linearity,
+            ceiling: r.linearity.ceiling,
+        });
+    }
+    if act > r.act_coverage.ceiling {
+        f.push(Finding {
+            row: "act_coverage",
+            found: act,
+            ceiling: r.act_coverage.ceiling,
+        });
+    }
+    f
+}
+
+pub fn run() -> Result<i32> {
+    let text = std::fs::read_to_string(RATCHET).with_context(|| format!("reading {RATCHET}"))?;
+    let ratchet = parse(&text)?;
+
+    // Production region only, and `git ls-files` rather than a filesystem walk —
+    // the repo root carries an untracked worktree copy with a full `crates/`
+    // tree, and a walk over-counted a sibling gate's number by 64%.
+    let corpus: BTreeMap<String, String> = tracked(is_production_path)?
+        .into_iter()
+        .filter(|(p, _)| !is_gate_harness(p))
+        .map(|(p, s)| (p, production_region(&s)))
+        .collect();
+
+    let types = affine_types(&corpus);
+    let per_type = count_linearity(&corpus, &types);
+    let linearity: usize = per_type.values().sum();
+    let per_shape = count_act_coverage(&corpus);
+    let act: usize = per_shape.values().sum();
+
+    println!("convergence toward ADR 0006's four objects (two measurable arrows):");
+    println!(
+        "  linearity      {linearity:4} by-reference site(s) on {} affine type(s), ceiling {}, target {}",
+        types.len(),
+        ratchet.linearity.ceiling,
+        ratchet.linearity.target
+    );
+    for (t, n) in &per_type {
+        println!("                      {n:4}  {t}");
+    }
+    println!(
+        "  act_coverage   {act:4} untargeted-authority site(s), ceiling {}, target {}",
+        ratchet.act_coverage.ceiling, ratchet.act_coverage.target
+    );
+    for (s, n) in &per_shape {
+        println!("                      {n:4}  {s}");
+    }
+    println!("  attenuation       -  no enumerable population; excluded (see {RATCHET})");
+    println!("  lineage           -  no enumerable population; excluded (see {RATCHET})");
+
+    let findings = decide(&ratchet, linearity, act);
+    if findings.is_empty() {
+        for (row, found, ceiling) in [
+            ("linearity", linearity, ratchet.linearity.ceiling),
+            ("act_coverage", act, ratchet.act_coverage.ceiling),
+        ] {
+            if found < ceiling {
+                println!(
+                    "::notice::{row} fell to {found}, below the ceiling of {ceiling}. Lower it in \
+                     this change to keep the gain."
+                );
+            }
+        }
+        println!("OK: every measurable arrow is at or below its ceiling.");
+        return Ok(0);
+    }
+    for f in &findings {
+        eprintln!(
+            "::error::{} rose to {}, above the ceiling of {}. The tree moved AWAY from the four \
+             objects on this arrow.",
+            f.row, f.found, f.ceiling
+        );
+    }
+    Ok(1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn corpus(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+        pairs
+            .iter()
+            .map(|(p, s)| ((*p).to_string(), (*s).to_string()))
+            .collect()
+    }
+
+    /// The population is what the TYPES declare. A `#[must_use]` type that is
+    /// `Clone` is not affine and must not be counted.
+    #[test]
+    fn the_population_is_must_use_and_not_clone() {
+        let c = corpus(&[(
+            "crates/a/src/lib.rs",
+            "#[must_use]\npub struct Sealed;\n\
+             #[derive(Clone)]\n#[must_use]\npub struct Copied;\n",
+        )]);
+        let t = affine_types(&c);
+        assert!(t.contains(&"Sealed".to_string()), "{t:?}");
+        assert!(
+            !t.contains(&"Copied".to_string()),
+            "a Clone type is not affine: {t:?}"
+        );
+    }
+
+    /// Prose is not a signature. `authority.rs`'s module doc describes the very
+    /// defect this counts, and counting it would put the description into the
+    /// count.
+    #[test]
+    fn a_comment_describing_the_defect_is_not_the_defect() {
+        let c = corpus(&[(
+            "crates/a/src/lib.rs",
+            "//! Today every effect takes `proof: &DischargedBundle`.\n\
+             fn real(proof: &DischargedBundle) {}\n",
+        )]);
+        let n = count_linearity(&c, &["DischargedBundle".to_string()]);
+        assert_eq!(
+            n.get("DischargedBundle"),
+            Some(&1),
+            "only the signature counts: {n:?}"
+        );
+    }
+
+    /// `&mut T` defeats the affine discipline exactly as `&T` does.
+    #[test]
+    fn a_mutable_reference_counts_too() {
+        let c = corpus(&[("crates/a/src/lib.rs", "fn f(r: &mut PreflightResult) {}\n")]);
+        let n = count_linearity(&c, &["PreflightResult".to_string()]);
+        assert_eq!(n.get("PreflightResult"), Some(&1));
+    }
+
+    /// A qualified path is the same type.
+    #[test]
+    fn a_qualified_path_is_the_same_type() {
+        let c = corpus(&[(
+            "crates/a/src/lib.rs",
+            "fn f(p: &crate::discharge::DischargedBundle) {}\n",
+        )]);
+        let n = count_linearity(&c, &["DischargedBundle".to_string()]);
+        assert_eq!(n.get("DischargedBundle"), Some(&1));
+    }
+
+    /// Above the ceiling fails; at or below does not. Below is a notice, not an
+    /// error — the same convention `.clippy-ratchet.toml` uses.
+    #[test]
+    fn only_rising_above_a_ceiling_is_a_finding() {
+        let r = parse(
+            "[linearity]\nceiling = 3\ntarget = 0\n[act_coverage]\nceiling = 1\ntarget = 0\n",
+        )
+        .expect("parses");
+        assert!(
+            decide(&r, 3, 1).is_empty(),
+            "at the ceiling is not a finding"
+        );
+        assert!(
+            decide(&r, 1, 0).is_empty(),
+            "below the ceiling is not a finding"
+        );
+        assert_eq!(decide(&r, 4, 1).len(), 1, "above on one row");
+        assert_eq!(decide(&r, 4, 2).len(), 2, "above on both");
+    }
+
+    /// A ceiling below its target could never be satisfied in one direction and
+    /// is a shape nobody chose. Refused rather than defaulted.
+    #[test]
+    fn an_incoherent_ratchet_is_refused() {
+        assert!(
+            parse(
+                "[linearity]\nceiling = 0\ntarget = 5\n[act_coverage]\nceiling = 1\ntarget = 0\n"
+            )
+            .is_err()
+        );
+    }
+}

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -130,6 +130,13 @@ enum Command {
     /// not wired to the enforcement path — the general case of the class C8
     /// gates for the Aeneas predicates.
     LawMechanisms,
+    /// How far the tree is from ADR 0006's four objects, on the two arrows
+    /// whose population can be enumerated from a source: `linearity` (a
+    /// one-shot right taken by value) and `act_coverage` (a protected boundary
+    /// carrying its target). `attenuation` and `lineage` are excluded because a
+    /// hand-listed denominator is the metric equivalent of a gate that cannot
+    /// fail — see `.convergence-ratchet.toml`.
+    Convergence,
     /// A witness accepted and dropped is a gate that is present but does
     /// nothing. Every `_`-bound authority/attestation parameter in the
     /// production region must be declared in
@@ -305,6 +312,7 @@ mod ci_otel;
 mod ci_spec;
 mod ci_timings;
 mod clippy_config;
+mod convergence;
 mod coverage_floor;
 mod fly_pools;
 mod gatehouse_pin;
@@ -367,6 +375,10 @@ fn main() -> Result<()> {
         Command::KaniCoverage => kani_coverage::check(&std::env::current_dir()?),
         // Exit code mapped here rather than inside the check, so a unit test
         // calling `run()` survives — the SelfPin arm's reasoning.
+        Command::Convergence => match convergence::run()? {
+            0 => Ok(()),
+            code => std::process::exit(code),
+        },
         Command::LawMechanisms => match law_mechanisms::run()? {
             0 => Ok(()),
             code => std::process::exit(code),

--- a/scripts/check-gates-can-fail.sh
+++ b/scripts/check-gates-can-fail.sh
@@ -636,6 +636,15 @@ perturb_fly_pool_volumes() {
     sed -i.bak 's/"requires_volume":false/"requires_volume":true/' "$1" && rm -f "$1.bak"
 }
 
+# One more by-reference site on an affine type: the calling convention defeating
+# the affine intent the type declares, which is the whole of what `linearity`
+# counts. ADR 0007 C-4, and `f7f9719b` is the defect it generalises.
+perturb_convergence_linearity() {
+    append_line "$1" 'fn _gate_of_gates_affine(_a: &portcullis_effects::Authority) {}'
+}
+
+probe_xtask convergence crates/nucleus-tool-proxy/src/run_gate.rs \
+    "one more affine type taken by reference" perturb_convergence_linearity
 probe_xtask assurance-required ci/assurance-required-ratchet.txt \
     "a claim whose falsifier the merge queue does not gate on, past the pin" perturb_assurance_required_pin
 probe_xtask pin-parity ci/lean/lean-toolchain \


### PR DESCRIPTION
Stacked on #2826.

ADR 0006 measured its own distance **once**, in prose, on 2026-09-09. That table is an audit — it has no way to notice the tree moving. This is the standing version of the two rows whose population can be enumerated from a source.

```
linearity      35  by-reference sites on 7 affine types   (ceiling 35)
act_coverage    3  untargeted-authority sites             (ceiling 3)
attenuation     -  excluded
lineage         -  excluded
```

## Why two rows and not four

This is the part that decides whether the number means anything. **ADR 0006's own A-20 draws the line**: a population is trustworthy only where something in the tree *defines* it.

| arrow | enumerable? | |
|---|---|---|
| `linearity` | **yes** | `#[must_use]` ∧ `!Clone` is computable; the question is whether the calling convention honours the affine intent the type declares |
| `act_coverage` | **yes** | the untargeted surface is a closed set of spellings, each replaced by the `Act` collapse |
| `attenuation` | no | "every site that narrows authority" is a hand-listed denominator — the metric equivalent of a gate that cannot fail |
| `lineage` | no | same |

A convergence score that quietly averaged in two hand-maintained rows would be **ADR 0007's I-1 one level up**: a number whose green is indistinguishable from vacuity. The gate prints `-` for those two and says why.

**What it does not tell you:** whether four objects is the right decomposition. A score falling toward zero is exactly the kind of number that starts substituting for that judgement.

## What the numbers say

`DecisionToken` is **31 of the 35**, and ADR 0006 C2.5 already names it: inert outside `debug_assert`. Nearly the whole linearity debt is one type.

On the other row, `guard.check(Operation::..)` is already **0** — C2.2 converged it. That's the evidence this tracks real progress rather than sitting at a constant.

## Two things the discipline caught in this change

**The number is seeded from the gate, not from a probe.** A scratch script written while scoping said 34 across three types; the gate says 35 across two, because the script tracked `#[cfg(test)]` line by line while `law_mechanisms::production_region` tracks brace depth. The gate and its number have to come from the same code, or the number is about the script.

**The gate counted itself, and the gate-of-gates found it.** This module *names* the shapes it counts — `GuardedAction<Operation>`, `.spend(Operation::..)` — so with `crates/xtask/**` inside `is_production_path`, `act_coverage` read **10** instead of 3. It was invisible until the first commit, because `tracked` reads `git ls-files` and an uncommitted file isn't tracked. The next `check-gates-can-fail.sh` run said *"still failing (exit 1) after restore"*. `is_gate_harness` excludes the tooling — right on its own terms anyway, since `xtask` holds no authority and delegates none.

## Shape

Rust, not shell, per `CLAUDE.md`'s mandate — pure `parse`, pure `count_*`, pure `decide`, and a `run()` that does the I/O. Six unit tests cover the population rule, that prose describing the defect is not the defect, `&mut` and qualified paths, that only *rising* above a ceiling is a finding, and that an incoherent ratchet is refused rather than defaulted.

## Probes

```
one more &Authority parameter     → linearity    35 → 36  ::error
one more GuardedAction<String>    → act_coverage  3 → 4   ::error
restored                          → OK
```

`check-gates-can-fail.sh` now reports **36 probed** and *"every probed gate REDs on its own subject and GREENs when restored."*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016t7JSuCtg4dC54HZjFgBjr