### PR TITLE
fix(ci): give every CI push its own credential, and gate the class

### DIFF
--- a/.github/workflows/aeneas-decide-pure.yml
+++ b/.github/workflows/aeneas-decide-pure.yml
@@ -226,6 +226,8 @@ jobs:
       # --- Auto-commit the regenerated Lean back to the branch ---
       # [skip ci] prevents a regenerate->push->regenerate loop.
       - name: Commit regenerated decide_pure extraction
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -248,5 +250,8 @@ jobs:
           # GITHUB_TOKEN-created PR would never trigger the required
           # checks. So: push a bot branch and surface a notice; a human
           # (or operator tooling with user credentials) opens the PR.
+          # Own credential, not the checkout's: see clippy-ratchet.yml for the
+          # `includeIf.gitdir` / symlinked-workspace failure this avoids.
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git push --force origin "HEAD:refs/heads/bot/decide-pure-extraction"
           echo "::notice::decide_pure extraction drifted — pushed to bot/decide-pure-extraction; open a PR from that branch to land it (direct push to ${GITHUB_REF_NAME} is blocked by branch protection)."

--- a/.github/workflows/clippy-ratchet.yml
+++ b/.github/workflows/clippy-ratchet.yml
@@ -145,6 +145,13 @@ jobs:
           # branch outlives the PR and a plain push is rejected with "fetch
           # first" on EVERY later push to main — which is how this job was red
           # for a full day with four orphaned chore/clippy-ratchet-* branches.
+          # Authenticate the push explicitly instead of relying on the credential
+          # actions/checkout left behind. That one is wired with `includeIf.gitdir`, which
+          # matches on the PATH the git directory is reached by -- and entrypoint.sh
+          # symlinks /home/runner/_work onto the mounted volume, so the workspace has two
+          # names and the push resolved the one the credential was not written for:
+          # `fatal: could not read Username for 'https://github.com'`, 34 runs in a row.
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git push -f -u origin "$BRANCH"
 
           gh pr create \

--- a/.github/workflows/manifest-guards.yml
+++ b/.github/workflows/manifest-guards.yml
@@ -109,6 +109,14 @@ jobs:
       - name: The committed runner-pool default is one the manager accepts
         run: cargo run -q -p xtask -- fly-pools
 
+      # `actions/checkout` leaves a credential wired with `includeIf.gitdir`, which matches on
+      # the PATH the git directory is reached by. entrypoint.sh symlinks /home/runner/_work onto
+      # the mounted volume, so the workspace has two names and a push can resolve the one the
+      # credential was not written for. The clippy ratchet failed that way 34 runs in a row --
+      # green on every PR the whole time, because the pushing job only runs on `push` to main.
+      - name: Every `git push` in CI carries its own credential
+        run: cargo run -q -p xtask -- push-auth
+
       # Seven scan-vs-allowlist gates lived in four shell scripts, each with its own copy
       # of the same `#[cfg(test)]`-stripping awk program -- five copies, four of them
       # differing byte-for-byte, one carrying a false negative its own comment names. This

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -516,8 +516,15 @@ jobs:
         if: ${{ steps.brew_gate.outputs.enabled == 'true' }}
         env:
           VERSION: ${{ steps.shas.outputs.version }}
+          TAP: ${{ secrets.HOMEBREW_TAP }}
+          TAP_TOKEN: ${{ secrets.HOMEBREW_TOKEN }}
         run: |
           cd tap
           git add Formula/nucleus-node.rb
           git commit -m "nucleus-node ${VERSION}"
+          # Own credential, not the checkout's -- see clippy-ratchet.yml. This job runs
+          # GitHub-hosted today, where the checkout credential does apply; the rule is
+          # unconditional because `runs-on` elsewhere is a repository VARIABLE, changeable
+          # with no commit, so "which runner" is not a fact the tree can rely on.
+          git remote set-url origin "https://x-access-token:${TAP_TOKEN}@github.com/${TAP}.git"
           git push

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -97,6 +97,10 @@ enum Command {
     /// The committed `POOLS` default in ci/fly-runner/manager.toml must be a
     /// configuration the manager accepts, checked with the manager's own validator.
     FlyPools,
+    /// A workflow step that runs `git push` must carry its own credential, rather than
+    /// the one `actions/checkout` left behind — that one is wired with `includeIf.gitdir`
+    /// and depends on the runner's filesystem layout. Decided from the workflows alone.
+    PushAuth,
     /// A claim's falsifier must produce a REQUIRED context. A gate CI runs, that goes red, and
     /// that the merge queue merges past anyway enforces nothing — it is a red light beside an
     /// open gate. Ratcheted, not driven to zero: whether a given check should be required is a
@@ -305,6 +309,7 @@ mod law_mechanisms;
 mod lean_action_builds;
 mod line_ratchet;
 mod pin_parity;
+mod push_auth;
 mod rerun_plan;
 mod schedule_liveness;
 mod scoreboard;
@@ -343,6 +348,7 @@ fn main() -> Result<()> {
             code => std::process::exit(code),
         },
         Command::FlyPools => fly_pools::check(&std::env::current_dir()?),
+        Command::PushAuth => push_auth::check(&std::env::current_dir()?),
         Command::AssuranceRequired => assurance_required::check(&std::env::current_dir()?),
         Command::AllowlistGates { parity } => {
             let root = std::env::current_dir()?;

--- a/crates/xtask/src/push_auth.rs
+++ b/crates/xtask/src/push_auth.rs
@@ -1,0 +1,240 @@
+//! `cargo xtask push-auth` — a workflow that pushes must carry its own credential.
+//!
+//! `actions/checkout` leaves a credential behind for later `git` commands. Since v7 it does
+//! that **indirectly**: the token goes in a temp file and the repository config gains
+//!
+//! ```text
+//! includeIf.gitdir:/home/runner/_work/<owner>/<repo>/.git.path = .../git-credentials-<uuid>.config
+//! ```
+//!
+//! `includeIf.gitdir` matches on the **path the git directory is reached by**, and the two
+//! spellings of one directory do not both match. Reproduced 2026-09-11: a pattern written
+//! against a symlinked path applies when the repo is reached through the symlink and does
+//! **not** apply when the same repo is reached by its real path.
+//!
+//! nucleus's self-hosted runners make exactly those two spellings. `ci/fly-runner/entrypoint.sh`
+//! puts the workspace on the mounted volume:
+//!
+//! ```text
+//! rm -rf /home/runner/_work
+//! ln -s /data/work /home/runner/_work
+//! ```
+//!
+//! so `/home/runner/_work/...` and `/data/work/...` are one directory under two names, the
+//! credential is wired against the first, and a `git push` that resolves the second finds no
+//! credential at all:
+//!
+//! ```text
+//! fatal: could not read Username for 'https://github.com': No such device or address
+//! ```
+//!
+//! Measured 2026-09-11: **34 consecutive failures** of `clippy-ratchet.yml` on `push` to main
+//! since the last success at 2026-09-11T00:49:30Z — every run that had work to do. The job
+//! measured the improvement it could not record: ceiling **345**, actual **338**. Runs on
+//! `pull_request` and `merge_group` were all green throughout, because the pushing job is
+//! `if:`-gated to `push` and was simply skipped. **A workflow can be green on every PR and
+//! totally broken on main.**
+//!
+//! # The rule
+//!
+//! A `run:` step containing `git push` must authenticate explicitly — a remote URL carrying a
+//! token, or an `http.extraheader` passed to git — rather than relying on the credential
+//! `actions/checkout` happened to leave. Ambient credentials are a property of the runner's
+//! filesystem layout; an explicit one is a property of the workflow.
+//!
+//! This is deliberately NOT restricted to jobs whose `runs-on` names the self-hosted pool.
+//! `runs-on` here is `${{ vars.CI_BUILD_RUNNER || vars.CI_RUNNER || 'ubuntu-latest' }}` — a
+//! repository *variable*, changeable in the GitHub UI with no commit. A gate whose verdict
+//! depends on a value not in the tree would go quietly wrong the moment someone flipped it,
+//! which is the failure this family exists to refuse. Every push is required to carry its own
+//! credential, on every runner.
+//!
+//! # What decides this
+//!
+//! The committed workflow files. No source tree, no toolchain, no network.
+
+use std::fs;
+use std::path::Path;
+
+use anyhow::{Context, Result, bail};
+
+const DIR: &str = ".github/workflows";
+
+/// Ways a step can carry its own credential. Any one of these on the same `run:` block as the
+/// push is enough.
+const AUTHENTICATED: [&str; 4] = [
+    "x-access-token:",
+    "http.extraheader",
+    "@github.com/",
+    "GIT_ASKPASS",
+];
+
+/// One `git push` and whether its `run:` block authenticates it.
+#[derive(Debug, PartialEq, Eq)]
+pub struct Push {
+    pub line: usize,
+    pub authenticated: bool,
+}
+
+/// Every `git push` in a `run:` block, with whether that block authenticates.
+///
+/// A `run:` block is the unit, not the whole file: a token set up in a different step does not
+/// reach this one's git invocation, and a file-wide search would call a push safe because some
+/// unrelated job mentioned a token.
+pub fn pushes(workflow_src: &str) -> Vec<Push> {
+    let lines: Vec<&str> = workflow_src.lines().collect();
+    let mut out = Vec::new();
+    let mut i = 0;
+
+    while i < lines.len() {
+        let line = lines[i];
+        let t = line.trim_start();
+        let t = t.strip_prefix("- ").unwrap_or(t);
+        // `run: |`, `run: >`, or a one-liner.
+        if !t.starts_with("run:") {
+            i += 1;
+            continue;
+        }
+        let run_indent = line.len() - line.trim_start().len();
+        let mut block = vec![t.trim_start_matches("run:").to_string()];
+        let start = i;
+        let mut j = i + 1;
+        while j < lines.len() {
+            let l = lines[j];
+            if l.trim().is_empty() {
+                block.push(String::new());
+                j += 1;
+                continue;
+            }
+            if l.len() - l.trim_start().len() <= run_indent {
+                break;
+            }
+            block.push(l.to_string());
+            j += 1;
+        }
+        let text = block.join("\n");
+        for (k, bl) in text.lines().enumerate() {
+            // A comment explaining a push is not a push. This matters here: both offending
+            // workflows carry long comments ABOUT pushing directly above the command.
+            let code = bl.trim_start();
+            if code.starts_with('#') {
+                continue;
+            }
+            if !code.contains("git push") {
+                continue;
+            }
+            out.push(Push {
+                line: start + k + 1,
+                authenticated: AUTHENTICATED.iter().any(|a| text.contains(a)),
+            });
+        }
+        i = j;
+    }
+    out
+}
+
+pub fn check(root: &Path) -> Result<()> {
+    let dir = root.join(DIR);
+    let mut files: Vec<_> = fs::read_dir(&dir)
+        .with_context(|| format!("reading {}", dir.display()))?
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.extension().is_some_and(|e| e == "yml"))
+        .collect();
+    files.sort();
+    if files.is_empty() {
+        bail!("{DIR}: no workflows found — a sweep that reads nothing passes everything");
+    }
+
+    let mut total = 0usize;
+    let mut bad = Vec::new();
+    for f in &files {
+        let src = fs::read_to_string(f)?;
+        let rel = format!("{DIR}/{}", f.file_name().unwrap().to_string_lossy());
+        for p in pushes(&src) {
+            total += 1;
+            if p.authenticated {
+                println!("  ok   {rel}:{} authenticates its push", p.line);
+            } else {
+                bad.push(format!("{rel}:{}", p.line));
+            }
+        }
+    }
+
+    // Non-vacuity: this repo pushes from CI, and a parser that stopped seeing any push would
+    // report a clean sweep. The floor is 1 rather than the current count, per the asymmetry
+    // gatehouse F-47 records — a floor at its exact value turns "find the pushes" into
+    // "lower the floor".
+    if total == 0 {
+        bail!(
+            "found no `git push` in any workflow. This repository pushes from CI (the clippy \
+             ratchet and the aeneas extraction both do), so the parser has stopped seeing them."
+        );
+    }
+
+    if !bad.is_empty() {
+        bail!(
+            "{} `git push` step(s) rely on the credential `actions/checkout` left behind:\n  {}\n\
+             That credential is wired with `includeIf.gitdir`, which matches on the PATH the git \
+             directory is reached by. `ci/fly-runner/entrypoint.sh` symlinks the workspace onto \
+             the mounted volume, so the same directory has two names and the push can resolve the \
+             one the credential was not written for:\n\
+             \x20 fatal: could not read Username for 'https://github.com'\n\
+             Give the push its own credential — a remote URL carrying the token, or \
+             `http.extraheader` — so it does not depend on the runner's filesystem layout.",
+            bad.len(),
+            bad.join("\n  ")
+        );
+    }
+    println!("ok: all {total} `git push` step(s) carry their own credential");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn an_unauthenticated_push_is_found() {
+        let wf = "jobs:\n  j:\n    steps:\n      - name: x\n        run: |\n          git push -f -u origin \"$BRANCH\"\n";
+        let p = pushes(wf);
+        assert_eq!(p.len(), 1);
+        assert!(!p[0].authenticated);
+    }
+
+    #[test]
+    fn a_token_url_in_the_same_block_counts() {
+        let wf = "jobs:\n  j:\n    steps:\n      - run: |\n          git remote set-url origin \"https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git\"\n          git push -f -u origin \"$BRANCH\"\n";
+        let p = pushes(wf);
+        assert_eq!(p.len(), 1);
+        assert!(p[0].authenticated);
+    }
+
+    /// A token set up in a DIFFERENT step does not reach this one's git.
+    #[test]
+    fn a_token_in_another_step_does_not_count() {
+        let wf = "jobs:\n  j:\n    steps:\n      - run: echo https://x-access-token:abc@github.com/o/r.git\n      - run: git push origin HEAD\n";
+        let p = pushes(wf);
+        assert_eq!(p.len(), 1);
+        assert!(!p[0].authenticated, "credentials do not cross steps");
+    }
+
+    /// Both offending workflows carry prose about pushing directly above the command.
+    #[test]
+    fn a_comment_about_pushing_is_not_a_push() {
+        let wf = "jobs:\n  j:\n    steps:\n      - run: |\n          # git push here is rejected by branch protection\n          echo hi\n";
+        assert!(pushes(wf).is_empty());
+    }
+
+    #[test]
+    fn the_real_workflows_contain_pushes() {
+        let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+        let mut n = 0;
+        for e in fs::read_dir(root.join(DIR)).unwrap().flatten() {
+            let p = e.path();
+            if p.extension().is_some_and(|x| x == "yml") {
+                n += pushes(&fs::read_to_string(&p).unwrap()).len();
+            }
+        }
+        assert!(n > 0, "the shipped workflows push from CI");
+    }
+}

--- a/crates/xtask/src/push_auth.rs
+++ b/crates/xtask/src/push_auth.rs
@@ -225,6 +225,75 @@ mod tests {
         assert!(pushes(wf).is_empty());
     }
 
+    // ---- `check` end to end, against a temp tree -------------------------------------
+    //
+    // `check` takes its root as an argument, so the verdict can be exercised without the
+    // real repository — including the empty-directory and no-push refusals, which have no
+    // live subject a probe could perturb. Written because the module would otherwise ship
+    // with its decision procedure as the uncovered part.
+
+    fn tmp(tag: &str) -> std::path::PathBuf {
+        let d = std::env::temp_dir().join(format!("xtask-push-auth-{tag}-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&d);
+        fs::create_dir_all(d.join(".github/workflows")).unwrap();
+        d
+    }
+
+    fn wf(dir: &Path, name: &str, body: &str) {
+        fs::write(dir.join(".github/workflows").join(name), body).unwrap();
+    }
+
+    const AUTHED: &str = "jobs:\n  j:\n    steps:\n      - run: |\n          git remote set-url origin \"https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git\"\n          git push origin HEAD\n";
+    const BARE: &str = "jobs:\n  j:\n    steps:\n      - run: |\n          git push origin HEAD\n";
+
+    #[test]
+    fn check_passes_when_every_push_authenticates() {
+        let d = tmp("ok");
+        wf(&d, "a.yml", AUTHED);
+        check(&d).expect("an authenticated push is fine");
+    }
+
+    #[test]
+    fn check_fails_on_a_bare_push_and_names_the_site() {
+        let d = tmp("bare");
+        wf(&d, "a.yml", AUTHED);
+        wf(&d, "b.yml", BARE);
+        let e = check(&d).expect_err("a bare push must red");
+        let m = e.to_string();
+        assert!(m.contains("b.yml"), "{m}");
+        assert!(
+            !m.contains("a.yml:"),
+            "the authenticated one must not be named: {m}"
+        );
+    }
+
+    /// This repository pushes from CI, so a sweep that finds none has stopped looking.
+    #[test]
+    fn check_refuses_a_tree_with_no_push_at_all() {
+        let d = tmp("nopush");
+        wf(
+            &d,
+            "a.yml",
+            "jobs:\n  j:\n    steps:\n      - run: echo hi\n",
+        );
+        let e = check(&d).expect_err("finding no push is not a pass");
+        assert!(e.to_string().contains("no `git push`"), "{e}");
+    }
+
+    #[test]
+    fn check_refuses_a_directory_with_no_workflows() {
+        let d = tmp("empty");
+        let e = check(&d).expect_err("an empty sweep is not a pass");
+        assert!(e.to_string().contains("no workflows"), "{e}");
+    }
+
+    #[test]
+    fn check_errors_when_the_directory_is_absent() {
+        let d = std::env::temp_dir().join(format!("xtask-push-auth-absent-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&d);
+        assert!(check(&d).is_err());
+    }
+
     #[test]
     fn the_real_workflows_contain_pushes() {
         let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");

--- a/scripts/check-gates-can-fail.sh
+++ b/scripts/check-gates-can-fail.sh
@@ -607,6 +607,14 @@ perturb_allowlist_pin() {
     awk '{ if ($0 ~ /^mediation\/net=/) print "mediation/net=255"; else print }' "$1" > "$1.tmp" && mv "$1.tmp" "$1"
 }
 
+perturb_push_auth_strip() {
+    # Take the push's own credential away, leaving it to rely on whatever actions/checkout
+    # left behind -- the live 2026-09-11 state. Deletes by matching the COMMAND, never the
+    # token expression: a probe keyed on a literal value stops perturbing silently when its
+    # subject moves, which is the 2026-09-07 incident this file already records.
+    sed -i.bak '/git remote set-url origin/d' "$1" && rm -f "$1.bak"
+}
+
 perturb_fly_pool_volumes() {
     # The exact configuration the manager refuses, and the one that was committed:
     # requires_volume with no volumes for eight machines, so the machines past the
@@ -624,6 +632,8 @@ probe_xtask allowlist-gates ci/allowlist-gates.txt \
     "an allowlist grown past its pinned size" perturb_allowlist_pin
 probe_xtask fly-pools ci/fly-runner/manager.toml \
     "the committed POOLS default the manager refuses" perturb_fly_pool_volumes
+probe_xtask push-auth .github/workflows/clippy-ratchet.yml \
+    "a CI push relying on the checkout's ambient credential" perturb_push_auth_strip
 
 probe check-line-ratchet.sh   "--strict" crates/portcullis/src/kernel.rs \
       "400 lines past the ceiling"            perturb_line_ratchet


### PR DESCRIPTION
`clippy-ratchet.yml` has failed **34 times in a row** on `push` to main — every run that had work to do — since the last success at **2026-09-11T00:49:30Z**:

```
fatal: could not read Username for 'https://github.com': No such device or address
```

The job **measured an improvement it could not record**: ceiling `345`, actual `338`.

## Why the credential was missing

Since v7, `actions/checkout` does not write the token into `.git/config` directly. It writes a temp file and includes it:

```
includeIf.gitdir:/home/runner/_work/<owner>/<repo>/.git.path = .../git-credentials-<uuid>.config
```

`includeIf.gitdir` matches on **the path the git directory is reached by**, and the two spellings of one directory do not both match. Reproduced locally: a pattern written against a symlinked path applies when the repo is reached *through* the symlink, and does **not** apply when the same repo is reached by its real path.

nucleus's self-hosted runners make exactly those two spellings — `ci/fly-runner/entrypoint.sh`, when the volume is mounted:

```sh
rm -rf /home/runner/_work
ln -s /data/work /home/runner/_work
```

So the workspace has two names, the credential is wired against one, and the push can resolve the other.

**Stated at its real strength:** the mechanism is reproduced and the symlink is in committed source. That this is the *operative* path on those particular machines is strongly supported by the evidence, not proven from inside the runner. The fix does not depend on settling it.

## The fix

Each push carries **its own** credential via an explicit remote URL, so it no longer depends on the runner's filesystem layout at all. Three sites:

| workflow | pool | state today |
|---|---|---|
| `clippy-ratchet.yml` | self-hosted | **failing, 34/34** |
| `aeneas-decide-pure.yml` | self-hosted | latently exposed |
| `release.yml` (homebrew tap) | GitHub-hosted | working — fixed anyway |

## The part worth keeping

**This workflow was green on every pull request and every merge_group for the entire 34-run streak**, because the pushing job is `if:`-gated to `push` on main and was simply skipped everywhere else.

A workflow can be green on every PR and totally broken on main, and nothing in the PR view says so. Same shape as the shadow-lane finding in #2825: a mechanism that stopped working while continuing to look fine.

## The gate

`cargo xtask push-auth`, decided from the workflows alone — no source tree, no toolchain, no network. A `run:` block containing `git push` must authenticate explicitly.

The unit is the **`run:` block, not the file**: a token set up in a different step does not reach this one's git, and a file-wide search would call a push safe because an unrelated job mentioned a token. Comments are skipped — both offending workflows carry long prose *about* pushing directly above the command.

It is deliberately **not** restricted to jobs whose `runs-on` names the self-hosted pool. `runs-on` here is `${{ vars.CI_BUILD_RUNNER || ... }}` — a repository **variable**, changeable in the UI with no commit. A gate whose verdict depended on it would go quietly wrong the moment someone flipped it, which is the failure this family exists to refuse. That is why `release.yml` is fixed too.

## Verification

- Driven **RED on the live defect** (3 sites) before green: `EXIT=1` → `EXIT=0`.
- Probed in `scripts/check-gates-can-fail.sh` by deleting the push's credential line — matching the **command**, never the token expression, per the 2026-09-07 incident where a probe keyed on a literal stopped perturbing silently.
- Probe verified red→restore→green with the file restored **byte-exact**.
- `scripts/check-ci-spec.sh` RC=0 (it parses every workflow, so the edited YAML is valid).
- `cargo test -p xtask` RC=0, `cargo fmt --all -- --check` RC=0, `cargo clippy -p xtask --all-targets -- -D warnings` RC=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)