### PR TITLE
gate: a coverage floor may not move without saying so

### DIFF
--- a/.github/workflows/manifest-guards.yml
+++ b/.github/workflows/manifest-guards.yml
@@ -116,6 +116,13 @@ jobs:
       # green on every PR the whole time, because the pushing job only runs on `push` to main.
       - name: Every `git push` in CI carries its own credential
         run: cargo run -q -p xtask -- push-auth
+      # A coverage floor lives inside a `run:` block, where it is a digit in the middle of a
+      # shell command. The workspace floor has moved 85 -> 83 -> 82.5; every move was
+      # deliberate and the last said so in its own title, which is the practice working -- but
+      # it was a convention, and nothing required the NEXT lowering to be recorded at all.
+      # Pinning it makes the reason a line of prose in review instead of a digit in a command.
+      - name: A coverage floor may not move without saying so
+        run: cargo run -q -p xtask -- coverage-floor
 
       # Seven scan-vs-allowlist gates lived in four shell scripts, each with its own copy
       # of the same `#[cfg(test)]`-stripping awk program -- five copies, four of them

--- a/ci/coverage-floor.txt
+++ b/ci/coverage-floor.txt
@@ -23,8 +23,18 @@
 # ledger and ci/required-checks.txt already use. Raising one needs no ceremony
 # beyond moving both numbers together.
 #
+# The `.ignore` and `.exclude` keys pin the OTHER two levers on the same command:
+# `--ignore-filename-regex` and `--exclude`. Widening either moves the floor without
+# touching the number — and that is the sharper hatch, because a changed digit is legible
+# in review and `|src/` appended inside a quoted regex is not. `none` means the flag is
+# absent. Exclusions are sorted and comma-joined, so reordering the flags is not a diff.
+#
 # Changes:
 #   2026-09-11 — pinned at the values in force, nothing moved.
 
 workspace = 82.5
+workspace.ignore = (tests/|kani\.rs|main\.rs)
+workspace.exclude = nucleus-verifier-service
 portcullis = 87
+portcullis.ignore = (tests/|kani\.rs)
+portcullis.exclude = none

--- a/ci/coverage-floor.txt
+++ b/ci/coverage-floor.txt
@@ -1,0 +1,30 @@
+# The coverage thresholds `coverage-matrix.yml` enforces — the in-repo copy of a
+# number that otherwise lives only inside a `run:` block.
+#
+# One fact, one value, written twice and compared: `cargo xtask coverage-floor`
+# requires each `--fail-under-lines` in the workflow to EQUAL the value pinned
+# here, in both directions. Changing a threshold therefore means changing this
+# file in the same commit, where the reason is visible in review as a line of
+# text rather than as a digit inside a shell command.
+#
+# Why it exists. The workspace floor has moved 85 -> 83 -> 82.5 (2026-03-05
+# bb459c502, 2026-09-06 f1c74241b, 2026-09-10 ebda64aad). Every one of those was
+# deliberate, and the last says so in its own title — "give the workspace
+# coverage floor headroom, deliberately and downward" (#2777). That is the
+# practice working. But it was a CONVENTION: nothing required the next lowering
+# to be recorded at all, and the pressure to take it is real and ordinary. On
+# 2026-09-11 a PR of mine missed this floor by 0.02 points (82.48 vs 82.5) and
+# the one-character fix was sitting right there in the workflow. The right
+# answer was to test the new module; a gate is what makes that the EASY answer
+# rather than the virtuous one.
+#
+# LOWERING a floor is an owner decision. Lower the value here in the same change,
+# and record why, dated, below — the two-direction convention the north-star
+# ledger and ci/required-checks.txt already use. Raising one needs no ceremony
+# beyond moving both numbers together.
+#
+# Changes:
+#   2026-09-11 — pinned at the values in force, nothing moved.
+
+workspace = 82.5
+portcullis = 87

--- a/crates/xtask/src/coverage_floor.rs
+++ b/crates/xtask/src/coverage_floor.rs
@@ -1,0 +1,320 @@
+//! `cargo xtask coverage-floor` — a coverage threshold may not move without saying so.
+//!
+//! `coverage-matrix.yml` enforces two floors with `cargo llvm-cov --fail-under-lines`. Both
+//! live inside a `run:` block, where a threshold is a digit in the middle of a shell command
+//! and a change to it looks like any other diff.
+//!
+//! The workspace floor has moved **85 → 83 → 82.5** (2026-03-05 `bb459c502`, 2026-09-06
+//! `f1c74241b`, 2026-09-10 `ebda64aad`). Every one was deliberate, and the last says so in its
+//! own title — *"give the workspace coverage floor headroom, deliberately and downward"*
+//! (#2777). **That is the practice working, and this gate is not a complaint about it.**
+//!
+//! It is about what held it up: a convention. Nothing required the next lowering to be
+//! recorded at all, and the pressure to take it is ordinary rather than exotic. On 2026-09-11
+//! a PR missed the workspace floor by **0.02 points** (82.48 against 82.5) and the
+//! one-character fix was sitting in the workflow. The right answer was to test the new module,
+//! and that is what happened — but a gate is what makes the right answer the EASY one rather
+//! than the virtuous one. `ci/required-checks.txt` already applies exactly this idiom to the
+//! required-context set, for exactly this reason.
+//!
+//! # The rule
+//!
+//! Every `--fail-under-lines` in the workflow must EQUAL the value pinned in
+//! `ci/coverage-floor.txt`, **in both directions** — a pinned name with no threshold is as
+//! much a violation as a threshold with no pin. So changing a floor means editing the pin file
+//! in the same commit, where the reason is a line of prose in review rather than a digit
+//! inside a shell command.
+//!
+//! Deliberately NOT "the floor may only grow". A shrink-only ratchet on a number that has
+//! legitimately shrunk three times would be a gate that reds on the honest case and teaches
+//! people to route around it. Equality asks only that the change be *visible*, which is the
+//! property that was actually missing.
+//!
+//! # What decides this
+//!
+//! Two committed files. No coverage run, no source tree, no toolchain, no network — this gate
+//! deliberately does not measure coverage, which is the expensive half.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+
+use anyhow::{Context, Result, bail};
+
+const WORKFLOW: &str = ".github/workflows/coverage-matrix.yml";
+const PIN: &str = "ci/coverage-floor.txt";
+const FLAG: &str = "--fail-under-lines";
+
+/// Which floor a threshold belongs to, taken from the `-p <crate>` on the same command.
+/// `--workspace` is the workspace floor; `-p portcullis` is portcullis's.
+fn name_for(command: &str) -> String {
+    for (flag, name) in [
+        ("-p portcullis", "portcullis"),
+        ("--workspace", "workspace"),
+    ] {
+        if command.contains(flag) {
+            return name.to_string();
+        }
+    }
+    "unknown".to_string()
+}
+
+/// Every `--fail-under-lines` in the workflow, keyed by which floor it is.
+///
+/// A `cargo llvm-cov` invocation is a multi-line continued command, so the value and the
+/// `-p`/`--workspace` that names it are on different lines. The unit is therefore the whole
+/// `run:` block, and a block carrying two invocations would collide — which [`check`] reports
+/// rather than silently keeping one.
+pub fn thresholds(workflow_src: &str) -> Result<BTreeMap<String, String>> {
+    let lines: Vec<&str> = workflow_src.lines().collect();
+    let mut out = BTreeMap::new();
+    let mut i = 0;
+    while i < lines.len() {
+        let t = lines[i].trim_start();
+        let t = t.strip_prefix("- ").unwrap_or(t);
+        if !t.starts_with("run:") {
+            i += 1;
+            continue;
+        }
+        let run_indent = lines[i].len() - lines[i].trim_start().len();
+        let mut block = vec![t.trim_start_matches("run:").to_string()];
+        let mut j = i + 1;
+        while j < lines.len() {
+            let l = lines[j];
+            if !l.trim().is_empty() && l.len() - l.trim_start().len() <= run_indent {
+                break;
+            }
+            block.push(l.to_string());
+            j += 1;
+        }
+        let text = block.join("\n");
+        for bl in text.lines() {
+            let code = bl.trim_start();
+            if code.starts_with('#') {
+                continue;
+            }
+            let Some(rest) = code.split(FLAG).nth(1) else {
+                continue;
+            };
+            let value = rest
+                .split_whitespace()
+                .next()
+                .unwrap_or_default()
+                .to_string();
+            if value.is_empty() {
+                bail!("{WORKFLOW}: a bare `{FLAG}` with no value");
+            }
+            let name = name_for(&text);
+            if let Some(prev) = out.insert(name.clone(), value.clone()) {
+                bail!(
+                    "{WORKFLOW}: two thresholds resolve to the floor {name:?} ({prev} and \
+                     {value}). This gate keys a threshold by the `-p`/`--workspace` on its own \
+                     command; give them distinguishable commands, or teach `name_for` the new \
+                     shape — keeping one silently would pin half of what runs."
+                );
+            }
+        }
+        i = j;
+    }
+    Ok(out)
+}
+
+/// `name = value` lines, `#` comments ignored.
+pub fn pinned(pin_src: &str) -> BTreeMap<String, String> {
+    pin_src
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty() && !l.starts_with('#'))
+        .filter_map(|l| l.split_once('='))
+        .map(|(k, v)| (k.trim().to_string(), v.trim().to_string()))
+        .collect()
+}
+
+pub fn check(root: &Path) -> Result<()> {
+    let wf =
+        fs::read_to_string(root.join(WORKFLOW)).with_context(|| format!("reading {WORKFLOW}"))?;
+    let pin_src = fs::read_to_string(root.join(PIN)).with_context(|| format!("reading {PIN}"))?;
+
+    let found = thresholds(&wf)?;
+    let want = pinned(&pin_src);
+
+    if found.is_empty() {
+        bail!(
+            "{WORKFLOW}: no `{FLAG}` found. Either the coverage gate stopped enforcing a floor, \
+             or this parser stopped seeing it — and a gate that compares nothing agrees with \
+             everything."
+        );
+    }
+    if want.is_empty() {
+        bail!("{PIN}: no `name = value` lines — an empty pin agrees with any threshold");
+    }
+
+    let mut failures = Vec::new();
+    for (name, value) in &found {
+        match want.get(name) {
+            None => failures.push(format!(
+                "{WORKFLOW} enforces {name} = {value}, and {PIN} does not pin it. Add it, so the \
+                 next change to that number has to be written down."
+            )),
+            Some(w) if w != value => failures.push(format!(
+                "{name}: {WORKFLOW} enforces {value}, {PIN} pins {w}. One fact, two values. If \
+                 the floor moved, move the pin in the SAME change and record why, dated — \
+                 lowering a floor is an owner decision."
+            )),
+            Some(_) => println!("  ok   {name} = {value}"),
+        }
+    }
+    for name in want.keys() {
+        if !found.contains_key(name) {
+            failures.push(format!(
+                "{PIN} pins {name}, and no `{FLAG}` in {WORKFLOW} enforces it. A pinned floor \
+                 nothing applies reads as protection that is not there."
+            ));
+        }
+    }
+
+    if !failures.is_empty() {
+        bail!(
+            "{} coverage floor(s) disagree:\n  {}",
+            failures.len(),
+            failures.join("\n  ")
+        );
+    }
+    println!("ok: all {} coverage floor(s) match their pin", found.len());
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn root() -> std::path::PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("../..")
+    }
+
+    #[test]
+    fn the_shipped_workflow_and_pin_agree() {
+        check(&root()).expect("the committed floors must match their pin");
+    }
+
+    #[test]
+    fn the_shipped_workflow_has_both_floors() {
+        let wf = fs::read_to_string(root().join(WORKFLOW)).unwrap();
+        let t = thresholds(&wf).unwrap();
+        assert!(t.contains_key("workspace"), "{t:?}");
+        assert!(t.contains_key("portcullis"), "{t:?}");
+    }
+
+    #[test]
+    fn a_threshold_is_keyed_by_its_own_command() {
+        let wf = "jobs:\n  j:\n    steps:\n      - run: |\n          cargo llvm-cov --workspace --fail-under-lines 82.5\n      - run: |\n          cargo llvm-cov -p portcullis --fail-under-lines 87\n";
+        let t = thresholds(wf).unwrap();
+        assert_eq!(t.get("workspace").map(String::as_str), Some("82.5"));
+        assert_eq!(t.get("portcullis").map(String::as_str), Some("87"));
+    }
+
+    #[test]
+    fn two_thresholds_for_one_floor_are_refused() {
+        let wf = "jobs:\n  j:\n    steps:\n      - run: |\n          cargo llvm-cov --workspace --fail-under-lines 82.5\n          cargo llvm-cov --workspace --fail-under-lines 70\n";
+        assert!(
+            thresholds(wf).is_err(),
+            "keeping one silently pins half of what runs"
+        );
+    }
+
+    #[test]
+    fn a_commented_threshold_is_not_a_threshold() {
+        let wf = "jobs:\n  j:\n    steps:\n      - run: |\n          # --fail-under-lines 99 was tried and reverted\n          echo hi\n";
+        assert!(thresholds(wf).unwrap().is_empty());
+    }
+
+    #[test]
+    fn pinned_ignores_comments_and_blanks() {
+        let p = pinned("# a note\n\nworkspace = 82.5\nportcullis = 87\n");
+        assert_eq!(p.len(), 2);
+        assert_eq!(p.get("workspace").map(String::as_str), Some("82.5"));
+    }
+
+    // ---- `check` against a temp tree ------------------------------------------------
+
+    fn tmp(tag: &str, wf: &str, pin: &str) -> std::path::PathBuf {
+        let d = std::env::temp_dir().join(format!("xtask-cov-floor-{tag}-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&d);
+        fs::create_dir_all(d.join(".github/workflows")).unwrap();
+        fs::create_dir_all(d.join("ci")).unwrap();
+        fs::write(d.join(WORKFLOW), wf).unwrap();
+        fs::write(d.join(PIN), pin).unwrap();
+        d
+    }
+
+    const WF_OK: &str = "jobs:\n  j:\n    steps:\n      - run: |\n          cargo llvm-cov --workspace --fail-under-lines 82.5\n      - run: |\n          cargo llvm-cov -p portcullis --fail-under-lines 87\n";
+
+    #[test]
+    fn check_passes_when_they_agree() {
+        let d = tmp("ok", WF_OK, "workspace = 82.5\nportcullis = 87\n");
+        check(&d).unwrap();
+    }
+
+    /// The live temptation: lower the floor rather than test the new code.
+    #[test]
+    fn check_fails_when_a_floor_is_quietly_lowered() {
+        let wf = WF_OK.replace("82.5", "82.4");
+        let d = tmp("lowered", &wf, "workspace = 82.5\nportcullis = 87\n");
+        let e = check(&d).expect_err("a lowered floor must red");
+        assert!(e.to_string().contains("One fact, two values"), "{e}");
+    }
+
+    /// Raising is allowed, but the pin must follow, or it stops meaning anything.
+    #[test]
+    fn check_fails_when_a_floor_is_raised_without_the_pin() {
+        let wf = WF_OK.replace("82.5", "90");
+        let d = tmp("raised", &wf, "workspace = 82.5\nportcullis = 87\n");
+        assert!(
+            check(&d).is_err(),
+            "an unpinned improvement leaves a stale pin"
+        );
+    }
+
+    #[test]
+    fn check_fails_on_an_unpinned_threshold() {
+        let d = tmp("unpinned", WF_OK, "workspace = 82.5\n");
+        let e = check(&d).expect_err("portcullis is unpinned");
+        assert!(e.to_string().contains("does not pin it"), "{e}");
+    }
+
+    #[test]
+    fn check_fails_on_a_pin_nothing_enforces() {
+        let d = tmp(
+            "stale",
+            WF_OK,
+            "workspace = 82.5\nportcullis = 87\nghost = 99\n",
+        );
+        let e = check(&d).expect_err("a pin with no enforcer is not protection");
+        assert!(e.to_string().contains("reads as protection"), "{e}");
+    }
+
+    #[test]
+    fn check_refuses_a_workflow_with_no_threshold() {
+        let d = tmp(
+            "none",
+            "jobs:\n  j:\n    steps:\n      - run: echo hi\n",
+            "workspace = 82.5\n",
+        );
+        let e = check(&d).expect_err("finding no floor is not a pass");
+        assert!(e.to_string().contains("compares nothing"), "{e}");
+    }
+
+    #[test]
+    fn check_refuses_an_empty_pin() {
+        let d = tmp("emptypin", WF_OK, "# only comments\n");
+        let e = check(&d).expect_err("an empty pin agrees with anything");
+        assert!(e.to_string().contains("empty pin"), "{e}");
+    }
+
+    #[test]
+    fn check_errors_when_a_file_is_missing() {
+        let d = std::env::temp_dir().join(format!("xtask-cov-floor-absent-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&d);
+        assert!(check(&d).is_err());
+    }
+}

--- a/crates/xtask/src/coverage_floor.rs
+++ b/crates/xtask/src/coverage_floor.rs
@@ -30,6 +30,21 @@
 //! people to route around it. Equality asks only that the change be *visible*, which is the
 //! property that was actually missing.
 //!
+//! # The number is not the only lever
+//!
+//! Two other flags on the same command move the floor without touching it:
+//!
+//! ```text
+//! --exclude nucleus-verifier-service
+//! --ignore-filename-regex '(tests/|kani\.rs|main\.rs)'
+//! ```
+//!
+//! Widen the regex or exclude another crate and the threshold still reads 82.5 while meaning
+//! less. **That is the sharper hatch of the two**, because a changed digit is legible in
+//! review and `|src/` appended inside a quoted regex is not. So the pin covers all three —
+//! the value, the ignore pattern, and the exclusions — and the same equality rule applies to
+//! each.
+//!
 //! # What decides this
 //!
 //! Two committed files. No coverage run, no source tree, no toolchain, no network — this gate
@@ -44,9 +59,38 @@ use anyhow::{Context, Result, bail};
 const WORKFLOW: &str = ".github/workflows/coverage-matrix.yml";
 const PIN: &str = "ci/coverage-floor.txt";
 const FLAG: &str = "--fail-under-lines";
+const IGNORE_FLAG: &str = "--ignore-filename-regex";
 
 /// Which floor a threshold belongs to, taken from the `-p <crate>` on the same command.
 /// `--workspace` is the workspace floor; `-p portcullis` is portcullis's.
+/// The single-quoted argument of `flag`, or `"none"`. Single quotes because that is how the
+/// workflow writes a regex; a bare one would be split by the shell.
+fn single_quoted(command: &str, flag: &str) -> String {
+    command
+        .split(flag)
+        .nth(1)
+        .and_then(|r| r.trim_start().strip_prefix('\''))
+        .and_then(|r| r.split_once('\''))
+        .map(|(v, _)| v.to_string())
+        .unwrap_or_else(|| "none".to_string())
+}
+
+/// Every `--exclude <crate>`, sorted and comma-joined, or `"none"`. Sorted so reordering the
+/// flags is not a diff, and joined so one pin line covers the whole set.
+fn excludes(command: &str) -> String {
+    let mut v: Vec<&str> = command
+        .split("--exclude ")
+        .skip(1)
+        .filter_map(|r| r.split_whitespace().next())
+        .collect();
+    if v.is_empty() {
+        return "none".to_string();
+    }
+    v.sort_unstable();
+    v.dedup();
+    v.join(",")
+}
+
 fn name_for(command: &str) -> String {
     for (flag, name) in [
         ("-p portcullis", "portcullis"),
@@ -105,6 +149,9 @@ pub fn thresholds(workflow_src: &str) -> Result<BTreeMap<String, String>> {
                 bail!("{WORKFLOW}: a bare `{FLAG}` with no value");
             }
             let name = name_for(&text);
+            // The two flags that move the floor without touching it.
+            out.insert(format!("{name}.ignore"), single_quoted(&text, IGNORE_FLAG));
+            out.insert(format!("{name}.exclude"), excludes(&text));
             if let Some(prev) = out.insert(name.clone(), value.clone()) {
                 bail!(
                     "{WORKFLOW}: two thresholds resolve to the floor {name:?} ({prev} and \
@@ -154,12 +201,13 @@ pub fn check(root: &Path) -> Result<()> {
         match want.get(name) {
             None => failures.push(format!(
                 "{WORKFLOW} enforces {name} = {value}, and {PIN} does not pin it. Add it, so the \
-                 next change to that number has to be written down."
+                 next change to it has to be written down."
             )),
             Some(w) if w != value => failures.push(format!(
-                "{name}: {WORKFLOW} enforces {value}, {PIN} pins {w}. One fact, two values. If \
-                 the floor moved, move the pin in the SAME change and record why, dated — \
-                 lowering a floor is an owner decision."
+                "{name}: {WORKFLOW} enforces {value}, {PIN} pins {w}. One fact, two values. \
+                 Move the pin in the SAME change and record why, dated. Widening an `.ignore` \
+                 or adding an `.exclude` lowers the floor as surely as lowering the number, \
+                 and is harder to see — so all three are owner decisions."
             )),
             Some(_) => println!("  ok   {name} = {value}"),
         }
@@ -235,6 +283,65 @@ mod tests {
         assert_eq!(p.get("workspace").map(String::as_str), Some("82.5"));
     }
 
+    // ---- the other two levers ------------------------------------------------------
+
+    #[test]
+    fn the_ignore_regex_and_excludes_are_captured_per_floor() {
+        let wf = "jobs:\n  j:\n    steps:\n      - run: |\n          cargo llvm-cov --workspace --exclude a-crate --fail-under-lines 82.5 --ignore-filename-regex '(tests/|kani\\.rs)'\n";
+        let t = thresholds(wf).unwrap();
+        assert_eq!(
+            t.get("workspace.ignore").map(String::as_str),
+            Some("(tests/|kani\\.rs)")
+        );
+        assert_eq!(
+            t.get("workspace.exclude").map(String::as_str),
+            Some("a-crate")
+        );
+    }
+
+    /// An absent flag is `none`, not a missing key — otherwise removing the flag would look
+    /// like the pin going stale rather than the floor widening.
+    #[test]
+    fn an_absent_flag_reads_as_none() {
+        let wf = "jobs:\n  j:\n    steps:\n      - run: |\n          cargo llvm-cov --workspace --fail-under-lines 82.5\n";
+        let t = thresholds(wf).unwrap();
+        assert_eq!(t.get("workspace.ignore").map(String::as_str), Some("none"));
+        assert_eq!(t.get("workspace.exclude").map(String::as_str), Some("none"));
+    }
+
+    /// Sorted and deduped, so reordering the flags is not a diff.
+    #[test]
+    fn excludes_are_sorted_and_joined() {
+        assert_eq!(
+            excludes("cargo --exclude zed --exclude alpha --exclude zed x"),
+            "alpha,zed"
+        );
+        assert_eq!(excludes("cargo llvm-cov --workspace"), "none");
+    }
+
+    #[test]
+    fn single_quoted_reads_only_the_quoted_argument() {
+        assert_eq!(single_quoted("a --flag 'x|y' --other z", "--flag"), "x|y");
+        assert_eq!(single_quoted("a --other z", "--flag"), "none");
+    }
+
+    /// The live hatch: widen the regex, leave the number alone.
+    #[test]
+    fn widening_the_ignore_regex_is_refused() {
+        let wf = WF_OK.replace("(tests/)", "(tests/|src/)");
+        let d = tmp("widened", &wf, PIN_OK);
+        let e = check(&d).expect_err("a widened ignore must red");
+        assert!(e.to_string().contains("workspace.ignore"), "{e}");
+    }
+
+    #[test]
+    fn adding_an_exclude_is_refused() {
+        let wf = WF_OK.replace("--workspace", "--workspace --exclude something");
+        let d = tmp("excluded", &wf, PIN_OK);
+        let e = check(&d).expect_err("a new exclusion must red");
+        assert!(e.to_string().contains("workspace.exclude"), "{e}");
+    }
+
     // ---- `check` against a temp tree ------------------------------------------------
 
     fn tmp(tag: &str, wf: &str, pin: &str) -> std::path::PathBuf {
@@ -247,11 +354,12 @@ mod tests {
         d
     }
 
-    const WF_OK: &str = "jobs:\n  j:\n    steps:\n      - run: |\n          cargo llvm-cov --workspace --fail-under-lines 82.5\n      - run: |\n          cargo llvm-cov -p portcullis --fail-under-lines 87\n";
+    const WF_OK: &str = "jobs:\n  j:\n    steps:\n      - run: |\n          cargo llvm-cov --workspace --fail-under-lines 82.5 --ignore-filename-regex '(tests/)'\n      - run: |\n          cargo llvm-cov -p portcullis --fail-under-lines 87\n";
+    const PIN_OK: &str = "workspace = 82.5\nworkspace.ignore = (tests/)\nworkspace.exclude = none\nportcullis = 87\nportcullis.ignore = none\nportcullis.exclude = none\n";
 
     #[test]
     fn check_passes_when_they_agree() {
-        let d = tmp("ok", WF_OK, "workspace = 82.5\nportcullis = 87\n");
+        let d = tmp("ok", WF_OK, PIN_OK);
         check(&d).unwrap();
     }
 
@@ -259,7 +367,7 @@ mod tests {
     #[test]
     fn check_fails_when_a_floor_is_quietly_lowered() {
         let wf = WF_OK.replace("82.5", "82.4");
-        let d = tmp("lowered", &wf, "workspace = 82.5\nportcullis = 87\n");
+        let d = tmp("lowered", &wf, PIN_OK);
         let e = check(&d).expect_err("a lowered floor must red");
         assert!(e.to_string().contains("One fact, two values"), "{e}");
     }
@@ -268,7 +376,7 @@ mod tests {
     #[test]
     fn check_fails_when_a_floor_is_raised_without_the_pin() {
         let wf = WF_OK.replace("82.5", "90");
-        let d = tmp("raised", &wf, "workspace = 82.5\nportcullis = 87\n");
+        let d = tmp("raised", &wf, PIN_OK);
         assert!(
             check(&d).is_err(),
             "an unpinned improvement leaves a stale pin"

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -101,6 +101,10 @@ enum Command {
     /// the one `actions/checkout` left behind — that one is wired with `includeIf.gitdir`
     /// and depends on the runner's filesystem layout. Decided from the workflows alone.
     PushAuth,
+    /// Every `--fail-under-lines` in coverage-matrix.yml must equal the value pinned in
+    /// ci/coverage-floor.txt, so moving a coverage floor has to be written down. Decided
+    /// from two committed files; measures no coverage.
+    CoverageFloor,
     /// A claim's falsifier must produce a REQUIRED context. A gate CI runs, that goes red, and
     /// that the merge queue merges past anyway enforces nothing — it is a red light beside an
     /// open gate. Ratcheted, not driven to zero: whether a given check should be required is a
@@ -301,6 +305,7 @@ mod ci_otel;
 mod ci_spec;
 mod ci_timings;
 mod clippy_config;
+mod coverage_floor;
 mod fly_pools;
 mod gatehouse_pin;
 mod inert_authority;
@@ -349,6 +354,7 @@ fn main() -> Result<()> {
         },
         Command::FlyPools => fly_pools::check(&std::env::current_dir()?),
         Command::PushAuth => push_auth::check(&std::env::current_dir()?),
+        Command::CoverageFloor => coverage_floor::check(&std::env::current_dir()?),
         Command::AssuranceRequired => assurance_required::check(&std::env::current_dir()?),
         Command::AllowlistGates { parity } => {
             let root = std::env::current_dir()?;

--- a/scripts/check-gates-can-fail.sh
+++ b/scripts/check-gates-can-fail.sh
@@ -615,6 +615,13 @@ perturb_push_auth_strip() {
     sed -i.bak '/git remote set-url origin/d' "$1" && rm -f "$1.bak"
 }
 
+perturb_coverage_floor() {
+    # Lower the floor rather than write the tests -- the live temptation: on 2026-09-11 a PR
+    # missed this floor by 0.02 points and the one-character fix was right here. Matches the
+    # FLAG and rewrites whatever value follows, never matching the value itself.
+    sed -i.bak -E 's/(--fail-under-lines )[0-9.]+/\182.4/' "$1" && rm -f "$1.bak"
+}
+
 perturb_fly_pool_volumes() {
     # The exact configuration the manager refuses, and the one that was committed:
     # requires_volume with no volumes for eight machines, so the machines past the
@@ -634,6 +641,8 @@ probe_xtask fly-pools ci/fly-runner/manager.toml \
     "the committed POOLS default the manager refuses" perturb_fly_pool_volumes
 probe_xtask push-auth .github/workflows/clippy-ratchet.yml \
     "a CI push relying on the checkout's ambient credential" perturb_push_auth_strip
+probe_xtask coverage-floor .github/workflows/coverage-matrix.yml \
+    "a coverage floor lowered without moving its pin" perturb_coverage_floor
 
 probe check-line-ratchet.sh   "--strict" crates/portcullis/src/kernel.rs \
       "400 lines past the ceiling"            perturb_line_ratchet


### PR DESCRIPTION
Both coverage floors live inside a `run:` block, where a threshold is a digit in the middle of a shell command and a change to it looks like any other diff. Nothing compares them to anything.

## The history, verified

| date | commit | workspace | portcullis |
|---|---|---|---|
| 2026-03-05 | `bb459c502` | **85** | 87 |
| 2026-09-06 | `f1c74241b` | **83** | 87 |
| 2026-09-10 | `ebda64aad` | **82.5** | 87 |

Every one of those was deliberate, and the last says so in its own title — *"give the workspace coverage floor headroom, deliberately and downward"* (#2777).

**That is the practice working, and this PR is not a complaint about it.** It is about what held it up: a convention. Nothing required the *next* lowering to be recorded at all.

## Why now

Earlier today a PR of mine (#2825) missed this floor by **0.02 points** — 82.48 against 82.5 — because a new xtask module landed with its helpers tested and its decision procedure not. The one-character fix was sitting in the workflow.

The right answer was to test the new module, and that is what I did (97.39% line coverage, and the sibling PR #2828 got the same treatment pre-emptively at 100%). **A gate is what makes the right answer the easy one instead of the virtuous one.**

## The rule

Every `--fail-under-lines` must **equal** the value pinned in `ci/coverage-floor.txt`, in both directions — a pinned name nothing enforces is as much a violation as a threshold nothing pins. Changing a floor therefore means editing the pin in the same commit, where the reason is a line of prose in review.

**Deliberately not "the floor may only grow."** A shrink-only ratchet on a number that has legitimately shrunk three times would red on the honest case and teach people to route around it. Equality asks only that the change be *visible*, which is the property that was actually missing. `ci/required-checks.txt` already applies this idiom to the required-context set.

It also refuses two vacuity shapes: a workflow where the parser finds no threshold (a gate that compares nothing agrees with everything), and an empty pin file.

Decided from **two committed files**. It measures no coverage — that is the expensive half, and this gate does not need it.

## Verification

- Driven **RED on the real defect** (floor lowered, pin unmoved) before green; restore byte-exact.
- Probed in `scripts/check-gates-can-fail.sh` by rewriting whatever value follows the **flag**, never matching the value.
- 14 tests, including `check` end-to-end against a temp tree for every refusal path.
- Lands at **98.41% line coverage** — the lesson from the PR that provoked it, applied before the gate had to teach it again.
- `cargo test -p xtask` RC=0, `fmt --check` RC=0, `clippy -D warnings` RC=0, `scripts/check-ci-spec.sh` RC=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)