### PR TITLE
scorecard: one card for four defect families, and a badge naming the weakest

### DIFF
--- a/.github/workflows/manifest-guards.yml
+++ b/.github/workflows/manifest-guards.yml
@@ -144,6 +144,11 @@ jobs:
       # surface, because a floor alone rewards deleting enforcement points.
       - name: Declared enforcement stays bound to the live path
         run: cargo run -q -p xtask -- bound
+      # One card over the four families the 2026-09-11 issue census found, with a
+      # badge naming the WEAKEST rather than an average -- an average lets a family
+      # at zero hide behind one at a hundred, which is ADR 0007 I-1 exactly.
+      - name: Every defect family's obligations, on one card
+        run: cargo run -q -p xtask -- scorecard
       - name: The scan-vs-allowlist family, decided once
         run: cargo run -q -p xtask -- allowlist-gates
       # The port is only worth having if it decides the same thing the scripts do. Agreement

--- a/.scorecard-ratchet.toml
+++ b/.scorecard-ratchet.toml
@@ -54,3 +54,37 @@
 # they are reported as `undeclared` rather than counted against the ratio.
 floor_bp = 9941
 population_floor = 172
+
+[family.alg]
+# 110 of 278 (type, law) obligations are discharged by a `lattice_laws!`
+# declaration. The unit is one law of one type, not one type: a per-type census
+# calls six types covered that between them check nine, six, four, four, four and
+# one of the fifteen their traits oblige.
+#
+# 21 types across 3 traits. Lattice obliges 9 laws, BoundedLattice 4 more,
+# DistributiveLattice 2 — exactly what verify_lattice_laws,
+# verify_bounded_lattice_laws and verify_distributive_laws check, counted by
+# reading them.
+#
+# MeetSemilattice and JoinSemilattice are implemented here and have NO verifier,
+# so their obligations are excluded rather than counted as undischarged: mixing
+# "a checker exists and is not wired" with "no checker exists" hides two
+# different debts behind one number. `convergence` made the same call for its
+# two unmeasurable arrows. When a semilattice verifier lands the population
+# rises, which is a number going up because the measurement got honest.
+#
+# 9 types carry meet/join/leq with no lattice trait impl at all -- WasiGrant,
+# WasiWorld, the two CRDT joins, RiskCost/WeakeningCost among them. No generic
+# suite can reach them, so they are reported as `undeclared` rather than counted
+# against the ratio: shape without declaration.
+#
+# UNDERSTATED, ON PURPOSE, FOR A STATED REASON: six types in
+# crates/portcullis/tests/proptest_lattice.rs are law-checked today by hand with
+# generated samples, and this gate cannot see them because it counts
+# declarations, not inferred coverage. Converting them STRENGTHENS those suites
+# from four laws to nine and may turn something red -- PathLattice,
+# CommandLattice, BudgetLattice and TimeLattice have never had associativity or
+# absorption checked -- so it is its own commit. This number rises when that
+# lands.
+floor_bp = 3956
+population_floor = 278

--- a/.scorecard-ratchet.toml
+++ b/.scorecard-ratchet.toml
@@ -1,0 +1,56 @@
+# Scorecard ratchet — one section per defect family, two floors each.
+#
+# Read by `cargo xtask scorecard` (crates/xtask/src/scorecard.rs).
+#
+# WHY THIS FILE EXISTS
+#
+# A census of all 868 nucleus issues (2026-09-11) classified the 120 that are
+# bug-labelled or carry an audit prefix. Four families account for ~90%:
+#
+#   bound  72 (60%)  a mechanism exists and nothing binds it to the live path
+#   alg    15 (13%)  a law of a structure the code already claims to be
+#   life   14 (12%)  unbounded carrier, no durable state, no validity interval
+#   tot     7  (6%)  a function whose type says total, that panics
+#
+# The remaining 10% is genuinely novel and no census here will find it.
+#
+# Each family already had, or could have, its own gate. What did not exist was
+# one card: a place where a family at zero is visible beside a family at a
+# hundred, and where adding a fifth family is a section rather than a redesign.
+#
+# WHAT IS PINNED, AND WHY TWO THINGS
+#
+#   floor_bp          minimum discharged/population in basis points. May only RISE.
+#   population_floor  minimum population. A shrinking surface is a decision.
+#
+# Both, because neither alone is a gate. A floor on the ratio rewards deleting
+# obligations: remove one and numerator and denominator fall together while the
+# ratio rises. A pin on the debt misses a ratio falling at constant debt. This
+# is the trap the neighbouring repo's CCI has, where documenting a known gap
+# lowers the score.
+#
+# THE BADGE NAMES THE WEAKEST FAMILY
+#
+# Not an average. Pooling numerators over pooled denominators gives a number
+# dominated by whichever family has the largest population — `tot` alone
+# measures in the thousands — so a family at 0% would vanish into it. The badge
+# reads `alg 22%`: the lowest-scoring family AND its number, so it moves when
+# the weakest improves, cannot hide a bad family behind a good one, and says
+# where the next hour of work goes. ADR 0007 I-1: a gate whose green is
+# indistinguishable from vacuity.
+#
+# 2026-09-11: seeded at the measured value with one family. `alg`, `tot` and
+# `life` arrive as their own sections. Raising floor_bp is how a family's debt
+# is paid; lowering either pin needs a dated note here saying what went away
+# and who decided.
+
+[family.bound]
+# 171 of 172 witness-accepting parameter sites bind their witness under a name
+# the body can consult. The one remaining is `trait CaClient` in
+# crates/nucleus-identity/src/ca/mod.rs, which performs an act while dropping
+# its witness. 32 further sites are class-N in
+# scripts/inert-authority-manifest.txt — DenyAllEffects::run refuses
+# unconditionally, so it performs no act and correctly consults nothing — and
+# they are reported as `undeclared` rather than counted against the ratio.
+floor_bp = 9941
+population_floor = 172

--- a/crates/portcullis-core/src/category.rs
+++ b/crates/portcullis-core/src/category.rs
@@ -643,6 +643,264 @@ pub fn verify_distributive_laws<L: Lattice + std::fmt::Debug>(samples: &[L]) -> 
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
+// Generated law suites
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Declare that a type discharges the laws its lattice traits oblige.
+///
+/// ```ignore
+/// lattice_laws!(conf_level, ConfLevel, ConfLevel::ALL.to_vec(), [lattice, bounded, distributive]);
+/// ```
+///
+/// generates a `#[cfg(test)] mod conf_level` with one `#[test]` per law family,
+/// each calling the corresponding `verify_*` function above.
+///
+/// # Why a macro and not a blanket impl
+///
+/// The question a gate wants to ask is "for every `impl Lattice for T`, is there
+/// a law check for `T`?", and answering it needs the check's *type argument*
+/// resolved — `verify_lattice_laws::<ConfLevel>` — which is a `typeck` question,
+/// not a grep. A first attempt at the grep attributed `CapabilityLevel`
+/// correctly, missed `ConfLevel`, `IFCLabel`, `Verdict` and `FlowState`, and
+/// picked up a bare generic parameter `L` as though it were a type.
+///
+/// So the covered set is not inferred, it is **declared**: one invocation per
+/// line, naming the type and the law families it discharges. Both sides of the
+/// ratio are then syntax a gate can see without a resolver, which is the
+/// discipline `inert_authority`'s closed `WITNESS` vocabulary already uses.
+///
+/// # The macro cannot over-claim
+///
+/// Listing `bounded` for a type that does not implement [`BoundedLattice`] fails
+/// to compile, because the generated body calls a function with that bound.
+/// Listing too *few* families is possible, and is exactly the gap the gate
+/// measures: population comes from the `impl` lines, discharged from these.
+///
+/// # Equality
+///
+/// The `verify_*` functions compare with `PartialEq`, so a type whose derived
+/// equality is finer than its law equality would report spurious violations. The
+/// tree's answer is to make `PartialEq` *be* the law equality —
+/// `LiteralDelegation` hand-writes it for precisely this reason, since deriving
+/// it "would break join commutativity: `a ∨ b` and `b ∨ a` list elements in
+/// different orders". No separate hook exists because nothing needs one; if a
+/// type ever does, that is the place to add it.
+#[macro_export]
+macro_rules! lattice_laws {
+    ($name:ident, $ty:ty, $samples:expr, [$($law:ident),+ $(,)?]) => {
+        #[cfg(test)]
+        mod $name {
+            #[allow(unused_imports)]
+            use super::*;
+            $( $crate::lattice_law_case!($law, $ty, $samples); )+
+        }
+    };
+}
+
+/// One law family for [`lattice_laws!`]. Not called directly.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! lattice_law_case {
+    (lattice, $ty:ty, $samples:expr) => {
+        #[test]
+        fn lattice() {
+            let samples: ::std::vec::Vec<$ty> = $samples;
+            $crate::category::assert_samples_are_witnesses(&samples, stringify!($ty));
+            let v = $crate::category::verify_lattice_laws(&samples);
+            assert!(
+                v.is_empty(),
+                "{} violates lattice laws: {:?}",
+                stringify!($ty),
+                v
+            );
+        }
+    };
+    (bounded, $ty:ty, $samples:expr) => {
+        #[test]
+        fn bounded() {
+            let samples: ::std::vec::Vec<$ty> = $samples;
+            $crate::category::assert_samples_are_witnesses(&samples, stringify!($ty));
+            let v = $crate::category::verify_bounded_lattice_laws(&samples);
+            assert!(
+                v.is_empty(),
+                "{} violates bounded lattice laws: {:?}",
+                stringify!($ty),
+                v
+            );
+        }
+    };
+    (distributive, $ty:ty, $samples:expr) => {
+        #[test]
+        fn distributive() {
+            let samples: ::std::vec::Vec<$ty> = $samples;
+            $crate::category::assert_samples_are_witnesses(&samples, stringify!($ty));
+            let v = $crate::category::verify_distributive_laws(&samples);
+            assert!(
+                v.is_empty(),
+                "{} violates distributivity: {:?}",
+                stringify!($ty),
+                v
+            );
+        }
+    };
+}
+
+/// Refuse a sample set that would make the law checks pass without testing them.
+///
+/// Every `verify_*` function above returns an empty violation list for an empty
+/// slice, and a one-element slice satisfies commutativity, associativity and
+/// distributivity for free — `a ∧ a = a ∧ a` holds in any structure. A suite
+/// seeded that way is green and proves nothing, which is the failure ADR 0007
+/// I-1 names: a gate whose green is indistinguishable from vacuity.
+///
+/// Three samples, at least two of them distinct: three because the associativity
+/// and distributivity loops are ternary and a shorter slice never varies all
+/// three indices, and two distinct because binary laws over a constant are
+/// tautologies.
+///
+/// # Panics
+///
+/// If `samples` is too short or carries no two distinct values.
+pub fn assert_samples_are_witnesses<L: PartialEq>(samples: &[L], ty: &str) {
+    assert!(
+        samples.len() >= 3,
+        "{ty}: {} sample(s) cannot witness a ternary law; the associativity and \
+         distributivity loops would never vary all three indices and the suite \
+         would be green without testing anything (ADR 0007 I-1)",
+        samples.len()
+    );
+    assert!(
+        samples.iter().any(|a| a != &samples[0]),
+        "{ty}: every sample is equal, so commutativity, associativity and \
+         distributivity hold as tautologies over a constant. The suite would be \
+         green without testing anything (ADR 0007 I-1)"
+    );
+}
+
+// ── Declared law suites ──────────────────────────────────────────────────────
+//
+// One invocation per type, naming the law families it discharges. These replace
+// eight hand-written test functions that called the `verify_*` helpers directly
+// and were, between them, four different spellings of the same three assertions.
+//
+// The families listed are exactly those the hand-written tests checked, so this
+// change is verdict-for-verdict identical. Where a type implements a trait whose
+// laws are NOT listed here — `CapabilityLattice` and `AuthorityLevel` both
+// implement `DistributiveLattice` and neither had a distributivity test — the
+// omission is now visible on one line instead of spread across a test module,
+// which is the point.
+
+lattice_laws!(
+    capability_level_laws,
+    CapabilityLevel,
+    vec![
+        CapabilityLevel::Never,
+        CapabilityLevel::LowRisk,
+        CapabilityLevel::Always,
+    ],
+    [bounded, distributive]
+);
+
+lattice_laws!(
+    capability_lattice_laws,
+    CapabilityLattice,
+    vec![
+        CapabilityLattice::bottom(),
+        CapabilityLattice::default(),
+        CapabilityLattice::top(),
+    ],
+    [bounded]
+);
+
+lattice_laws!(
+    conf_level_laws,
+    ConfLevel,
+    vec![ConfLevel::Public, ConfLevel::Internal, ConfLevel::Secret],
+    [bounded, distributive]
+);
+
+lattice_laws!(
+    integ_level_laws,
+    IntegLevel,
+    vec![
+        IntegLevel::Adversarial,
+        IntegLevel::Untrusted,
+        IntegLevel::Trusted,
+    ],
+    [bounded, distributive]
+);
+
+lattice_laws!(
+    authority_level_laws,
+    AuthorityLevel,
+    vec![
+        AuthorityLevel::NoAuthority,
+        AuthorityLevel::Informational,
+        AuthorityLevel::Suggestive,
+        AuthorityLevel::Directive,
+    ],
+    [bounded]
+);
+
+lattice_laws!(
+    derivation_class_laws,
+    DerivationClass,
+    vec![
+        DerivationClass::Deterministic,
+        DerivationClass::AIDerived,
+        DerivationClass::HumanPromoted,
+        DerivationClass::Mixed,
+        DerivationClass::OpaqueExternal,
+    ],
+    [bounded, distributive]
+);
+
+// Uniform freshness, because `Freshness::leq` has a known inconsistency with
+// `Freshness::meet` around `ttl_secs = 0` — see the NOTE above. Meet and join are
+// correct; only `leq` has the edge case, which is also why `IFCLabel` does not
+// implement `BoundedLattice` and why only `lattice` is listed here.
+lattice_laws!(
+    ifc_label_laws,
+    IFCLabel,
+    {
+        let fresh = Freshness {
+            observed_at: 1000,
+            ttl_secs: 3600,
+        };
+        vec![
+            IFCLabel {
+                freshness: fresh,
+                ..IFCLabel::bottom()
+            },
+            IFCLabel {
+                freshness: fresh,
+                ..IFCLabel::top()
+            },
+            IFCLabel {
+                freshness: fresh,
+                ..IFCLabel::default()
+            },
+            IFCLabel {
+                freshness: fresh,
+                ..IFCLabel::web_content(1000)
+            },
+        ]
+    },
+    [lattice]
+);
+
+lattice_laws!(
+    product_lattice_laws,
+    ProductLattice<ConfLevel, IntegLevel>,
+    vec![
+        ProductLattice(ConfLevel::Public, IntegLevel::Trusted),
+        ProductLattice(ConfLevel::Secret, IntegLevel::Adversarial),
+        ProductLattice(ConfLevel::Internal, IntegLevel::Untrusted),
+    ],
+    [bounded, distributive]
+);
+
+// ═══════════════════════════════════════════════════════════════════════════
 // Functoriality of label propagation
 // ═══════════════════════════════════════════════════════════════════════════
 
@@ -714,103 +972,36 @@ mod tests {
         (h.finish() as usize) % n
     }
 
+    // ── The sample guard, driven both ways ────────────────────────────
+    //
+    // `verify_lattice_laws(&[])` returns no violations, and so does a
+    // single-element slice: `a ∧ a = a ∧ a` holds in any structure. A suite
+    // seeded that way is green and tests nothing. These two are the probe.
+
+    #[test]
+    #[should_panic(expected = "cannot witness a ternary law")]
+    fn two_samples_cannot_witness_a_ternary_law() {
+        assert_samples_are_witnesses(&[ConfLevel::Public, ConfLevel::Secret], "ConfLevel");
+    }
+
+    #[test]
+    #[should_panic(expected = "tautologies over a constant")]
+    fn three_equal_samples_make_every_binary_law_a_tautology() {
+        assert_samples_are_witnesses(
+            &[ConfLevel::Public, ConfLevel::Public, ConfLevel::Public],
+            "ConfLevel",
+        );
+    }
+
+    #[test]
+    fn three_samples_with_two_distinct_are_accepted() {
+        assert_samples_are_witnesses(
+            &[ConfLevel::Public, ConfLevel::Public, ConfLevel::Secret],
+            "ConfLevel",
+        );
+    }
+
     // ── Generic lattice law tests ─────────────────────────────────────
-
-    #[test]
-    fn capability_level_lattice_laws() {
-        let samples = vec![
-            CapabilityLevel::Never,
-            CapabilityLevel::LowRisk,
-            CapabilityLevel::Always,
-        ];
-        let v = verify_bounded_lattice_laws(&samples);
-        assert!(v.is_empty(), "CapabilityLevel violations: {v:?}");
-    }
-
-    #[test]
-    fn capability_lattice_lattice_laws() {
-        let samples = vec![
-            CapabilityLattice::bottom(),
-            CapabilityLattice::default(),
-            CapabilityLattice::top(),
-        ];
-        let v = verify_bounded_lattice_laws(&samples);
-        assert!(v.is_empty(), "CapabilityLattice violations: {v:?}");
-    }
-
-    #[test]
-    fn conf_level_lattice_laws() {
-        let samples = vec![ConfLevel::Public, ConfLevel::Internal, ConfLevel::Secret];
-        let v = verify_bounded_lattice_laws(&samples);
-        assert!(v.is_empty(), "ConfLevel violations: {v:?}");
-    }
-
-    #[test]
-    fn integ_level_lattice_laws() {
-        let samples = vec![
-            IntegLevel::Adversarial,
-            IntegLevel::Untrusted,
-            IntegLevel::Trusted,
-        ];
-        let v = verify_bounded_lattice_laws(&samples);
-        assert!(v.is_empty(), "IntegLevel violations: {v:?}");
-    }
-
-    #[test]
-    fn authority_level_lattice_laws() {
-        let samples = vec![
-            AuthorityLevel::NoAuthority,
-            AuthorityLevel::Informational,
-            AuthorityLevel::Suggestive,
-            AuthorityLevel::Directive,
-        ];
-        let v = verify_bounded_lattice_laws(&samples);
-        assert!(v.is_empty(), "AuthorityLevel violations: {v:?}");
-    }
-
-    #[test]
-    fn derivation_class_lattice_laws() {
-        let samples = vec![
-            DerivationClass::Deterministic,
-            DerivationClass::AIDerived,
-            DerivationClass::HumanPromoted,
-            DerivationClass::Mixed,
-            DerivationClass::OpaqueExternal,
-        ];
-        let v = verify_bounded_lattice_laws(&samples);
-        assert!(v.is_empty(), "DerivationClass violations: {v:?}");
-    }
-
-    #[test]
-    fn ifc_label_lattice_laws() {
-        // Use samples with uniform freshness to avoid the known Freshness::leq
-        // inconsistency around ttl_secs=0 (see NOTE above BoundedLattice comment).
-        // Meet/join are fully correct; only leq has the edge case.
-        let fresh = Freshness {
-            observed_at: 1000,
-            ttl_secs: 3600,
-        };
-        let samples = vec![
-            IFCLabel {
-                freshness: fresh,
-                ..IFCLabel::bottom()
-            },
-            IFCLabel {
-                freshness: fresh,
-                ..IFCLabel::top()
-            },
-            IFCLabel {
-                freshness: fresh,
-                ..IFCLabel::default()
-            },
-            IFCLabel {
-                freshness: fresh,
-                ..IFCLabel::web_content(1000)
-            },
-        ];
-        let v = verify_lattice_laws(&samples);
-        assert!(v.is_empty(), "IFCLabel violations: {v:?}");
-    }
 
     // ── Legacy semilattice law tests (kept for coverage) ──────────────
 
@@ -975,18 +1166,6 @@ mod tests {
     // ── Product lattice tests ─────────────────────────────────────────
 
     #[test]
-    fn product_lattice_laws() {
-        use super::ProductLattice;
-        let samples = vec![
-            ProductLattice(ConfLevel::Public, IntegLevel::Trusted),
-            ProductLattice(ConfLevel::Secret, IntegLevel::Adversarial),
-            ProductLattice(ConfLevel::Internal, IntegLevel::Untrusted),
-        ];
-        let v = verify_bounded_lattice_laws(&samples);
-        assert!(v.is_empty(), "ProductLattice violations: {v:?}");
-    }
-
-    #[test]
     fn product_lattice_pointwise() {
         use super::ProductLattice;
         let a = ProductLattice(CapabilityLevel::LowRisk, ConfLevel::Internal);
@@ -1042,69 +1221,6 @@ mod tests {
     }
 
     // ── Distributive lattice tests ────────────────────────────────────
-
-    #[test]
-    fn capability_level_distributive() {
-        let samples = vec![
-            CapabilityLevel::Never,
-            CapabilityLevel::LowRisk,
-            CapabilityLevel::Always,
-        ];
-        let v = super::verify_distributive_laws(&samples);
-        assert!(
-            v.is_empty(),
-            "CapabilityLevel distributivity violations: {v:?}"
-        );
-    }
-
-    #[test]
-    fn conf_level_distributive() {
-        let samples = vec![ConfLevel::Public, ConfLevel::Internal, ConfLevel::Secret];
-        let v = super::verify_distributive_laws(&samples);
-        assert!(v.is_empty(), "ConfLevel distributivity violations: {v:?}");
-    }
-
-    #[test]
-    fn integ_level_distributive() {
-        let samples = vec![
-            IntegLevel::Adversarial,
-            IntegLevel::Untrusted,
-            IntegLevel::Trusted,
-        ];
-        let v = super::verify_distributive_laws(&samples);
-        assert!(v.is_empty(), "IntegLevel distributivity violations: {v:?}");
-    }
-
-    #[test]
-    fn derivation_class_distributive() {
-        let samples = vec![
-            DerivationClass::Deterministic,
-            DerivationClass::AIDerived,
-            DerivationClass::HumanPromoted,
-            DerivationClass::Mixed,
-            DerivationClass::OpaqueExternal,
-        ];
-        let v = super::verify_distributive_laws(&samples);
-        assert!(
-            v.is_empty(),
-            "DerivationClass distributivity violations: {v:?}"
-        );
-    }
-
-    #[test]
-    fn product_lattice_distributive() {
-        use super::ProductLattice;
-        let samples = vec![
-            ProductLattice(ConfLevel::Public, IntegLevel::Trusted),
-            ProductLattice(ConfLevel::Secret, IntegLevel::Adversarial),
-            ProductLattice(ConfLevel::Internal, IntegLevel::Untrusted),
-        ];
-        let v = super::verify_distributive_laws(&samples);
-        assert!(
-            v.is_empty(),
-            "ProductLattice distributivity violations: {v:?}"
-        );
-    }
 
     // ── Monotone map tests ────────────────────────────────────────────
 

--- a/crates/xtask/src/alg.rs
+++ b/crates/xtask/src/alg.rs
@@ -1,0 +1,592 @@
+//! The `alg` family — laws a declaration already claims.
+//!
+//! # The defect
+//!
+//! Of the 120 audit-and-bug issues the 2026-09-11 census classified, 15 are a
+//! law of a structure the code already says it is. #1222: *"AnyOf combinator is
+//! order-dependent for RequiresApproval — violates join commutativity."* #735:
+//! *"DelegationScope subset check uses string equality — glob subsumption not
+//! evaluated"*, which is an ordering implemented as syntactic equality, the same
+//! bug gatehouse's `writ` fixed by making `globSubsumes` the rule. #747 and #740:
+//! a receipt hash over `format!("{:?}")` and a canonical encoding that admits a
+//! length-extension collision — injectivity and stability.
+//!
+//! None of these needed inventing. They are the laws of the structure the type
+//! declares itself to be, and they arrive with the declaration.
+//!
+//! # Population is (type, law), not (type, trait)
+//!
+//! "Does type `T` have a law check?" scores this tree far too well.
+//! `crates/portcullis/tests/proptest_lattice.rs` covers six types, and not to the
+//! same depth: `CapabilityLattice` has nine laws checked, `BudgetLattice` six,
+//! `CommandLattice`/`PathLattice`/`TimeLattice` four each — commutativity and
+//! idempotence only, no associativity, no absorption, no order laws — and
+//! `PermissionLattice` has one, `normalize_is_idempotent`, against the fifteen
+//! its three traits oblige. A per-type census calls all six covered.
+//!
+//! So the unit is one law of one type, and the obligation table is fixed:
+//!
+//! | trait | laws | which |
+//! |---|---|---|
+//! | `Lattice` | 9 | commutativity, associativity, idempotence for meet and join; two absorption; `leq`/meet consistency |
+//! | `BoundedLattice` | 4 | top and bottom identity, top and bottom annihilator |
+//! | `DistributiveLattice` | 2 | meet-over-join and its dual |
+//!
+//! Those are exactly what [`verify_lattice_laws`], [`verify_bounded_lattice_laws`]
+//! and [`verify_distributive_laws`] check, counted by reading them. A type
+//! implementing all three owes 15.
+//!
+//! [`verify_lattice_laws`]: https://docs.rs/portcullis-core
+//! [`verify_bounded_lattice_laws`]: https://docs.rs/portcullis-core
+//! [`verify_distributive_laws`]: https://docs.rs/portcullis-core
+//!
+//! # Why only these three traits
+//!
+//! `MeetSemilattice` and `JoinSemilattice` are implemented in this tree and have
+//! **no verifier at all**, so counting their obligations would mix "a checker
+//! exists and is not wired" with "no checker exists" — two different debts with
+//! two different fixes. `convergence` made the same call and said so: its two
+//! unmeasurable arrows are *"excluded because a hand-listed denominator is the
+//! metric equivalent of a gate that cannot fail."* When a semilattice verifier
+//! lands, its traits join the table here and the population rises, which is a
+//! number going up because the measurement got honest.
+//!
+//! # Discharged is declared, not inferred
+//!
+//! Asking "is there a law check for `T`?" needs the check's type argument
+//! resolved — a `typeck` question. A grep for it attributed `CapabilityLevel`
+//! correctly, missed `ConfLevel`, `IFCLabel`, `Verdict` and `FlowState`, and
+//! picked up a bare generic parameter `L` as though it were a type. So the
+//! numerator reads `lattice_laws!` invocations, which name their type and their
+//! families on one line, and both sides of the ratio are syntax without a
+//! resolver.
+//!
+//! A consequence to state plainly: **the six types covered by
+//! `proptest_lattice.rs` count as undischarged today.** They are checked, by
+//! hand, with generated samples — but not declared, so this gate cannot see
+//! them. Converting them is a strengthening (four laws to nine) that may turn
+//! something red, which is why it is its own commit rather than folded in here.
+//! Until it lands, the `alg` number understates real coverage for a stated
+//! reason, and it rises when the conversion happens.
+//!
+//! # Undeclared
+//!
+//! Types with `meet`, `join` or `leq` and no lattice trait impl are outside the
+//! population entirely: no generic suite can reach them. `WasiGrant`,
+//! `WasiWorld`, the two CRDT joins and `RiskCost`/`WeakeningCost` — the only
+//! hand-written `PartialOrd`/`Ord` in the workspace, antisymmetry and
+//! transitivity unverified — are the shape without the declaration. They are
+//! reported, not counted against the ratio, for the reason `bound`'s class-`N`
+//! sites are: a number that silently omits its own surface is a numerator with
+//! no denominator.
+
+use anyhow::Result;
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::inert_authority::scope_of;
+use crate::law_mechanisms::production_region;
+use crate::scorecard::{Census, Family};
+
+/// Laws `verify_lattice_laws` checks: commutativity, associativity and
+/// idempotence for meet and join (6), two absorption laws, and the
+/// `a ≤ b ⟺ a ∧ b = a` consistency check.
+const LATTICE_LAWS: usize = 9;
+
+/// Laws `verify_bounded_lattice_laws` adds: `a ∧ ⊤ = a`, `a ∨ ⊥ = a`,
+/// `a ∧ ⊥ = ⊥`, `a ∨ ⊤ = ⊤`.
+const BOUNDED_LAWS: usize = 4;
+
+/// Laws `verify_distributive_laws` checks: `a ∧ (b ∨ c) = (a ∧ b) ∨ (a ∧ c)`
+/// and its dual.
+const DISTRIBUTIVE_LAWS: usize = 2;
+
+/// The traits whose laws a verifier exists for, and what each obliges.
+///
+/// `BoundedLattice: Lattice`, so a bounded type also carries a `Lattice` impl
+/// and the nine arrive once from that row rather than twice.
+const OBLIGATIONS: [(&str, usize); 3] = [
+    ("Lattice", LATTICE_LAWS),
+    ("BoundedLattice", BOUNDED_LAWS),
+    ("DistributiveLattice", DISTRIBUTIVE_LAWS),
+];
+
+/// What one `lattice_laws!` family keyword discharges.
+///
+/// `bounded` discharges thirteen, not four: `verify_bounded_lattice_laws` calls
+/// `verify_lattice_laws` first, so declaring it covers the base lattice laws too.
+fn discharged_by(family: &str) -> usize {
+    match family {
+        "lattice" => LATTICE_LAWS,
+        "bounded" => LATTICE_LAWS + BOUNDED_LAWS,
+        "distributive" => DISTRIBUTIVE_LAWS,
+        _ => 0,
+    }
+}
+
+/// A trait impl found in the tree: which trait, for which type.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Impl {
+    pub trait_name: String,
+    pub type_name: String,
+}
+
+/// Find `impl [<generics>] [path::]Trait for Type` over one source region.
+///
+/// A grep, not a resolver — the trait vocabulary is a closed list for the same
+/// reason `inert_authority`'s witness vocabulary is. The spellings in this tree
+/// are `impl Lattice for X`, `impl crate::frame::Lattice for X` and
+/// `impl crate::category::BoundedLattice for X`, all of which this accepts, and
+/// the type is taken as the head identifier so `ProductLattice<A, B>` is
+/// `ProductLattice`.
+pub fn impls_in(region: &str) -> Vec<Impl> {
+    let mut out = Vec::new();
+    for line in region.lines() {
+        let t = line.trim_start();
+        let Some(rest) = t.strip_prefix("impl") else {
+            continue;
+        };
+        if !rest.starts_with(|c: char| c.is_whitespace() || c == '<') {
+            continue;
+        }
+        let Some(head) = rest.split('{').next() else {
+            continue;
+        };
+        let Some((before, after)) = head.rsplit_once(" for ") else {
+            continue;
+        };
+        // The trait is the last path segment before ` for `.
+        let trait_name = before
+            .rsplit(|c: char| c == ':' || c.is_whitespace())
+            .find(|s| !s.is_empty())
+            .unwrap_or("")
+            .trim_end_matches('>');
+        // Longest match first: `BoundedLattice` must not read as `Lattice`.
+        let Some((matched, _)) = OBLIGATIONS.iter().find(|(name, _)| *name == trait_name) else {
+            continue;
+        };
+        let type_name: String = after
+            .trim()
+            .trim_start_matches('&')
+            .chars()
+            .take_while(|c| c.is_ascii_alphanumeric() || *c == '_')
+            .collect();
+        if type_name.is_empty() {
+            continue;
+        }
+        out.push(Impl {
+            trait_name: (*matched).to_string(),
+            type_name,
+        });
+    }
+    out
+}
+
+/// A `lattice_laws!` invocation: the type it names and the families it lists.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Declaration {
+    pub type_name: String,
+    pub families: Vec<String>,
+}
+
+/// Find `lattice_laws!(name, Type, samples, [families])` over one source region.
+///
+/// Invocations span several lines once rustfmt has had them, so this walks to the
+/// matching `)` rather than reading a line. The type is the head identifier after
+/// the first comma, which is why `ProductLattice<ConfLevel, IntegLevel>` does not
+/// need comma-in-generics handling. The families are the bracketed list of
+/// lowercase identifiers immediately before the closing paren — unambiguous
+/// against the `vec![…]` in the samples argument, whose contents are not all
+/// lowercase.
+pub fn declarations_in(region: &str) -> Vec<Declaration> {
+    const NEEDLE: &str = "lattice_laws!(";
+    let mut out = Vec::new();
+    let mut search = 0usize;
+    while let Some(found) = region[search..].find(NEEDLE) {
+        let open = search + found + NEEDLE.len() - 1;
+        // `lattice_law_case!` and the `macro_rules!` definition do not contain
+        // this needle, but a qualified call `$crate::lattice_laws!(` would; the
+        // head check keeps the needle anchored to an identifier boundary.
+        let prev = region[..search + found].chars().next_back();
+        if matches!(prev, Some(c) if c.is_ascii_alphanumeric() || c == '_') {
+            search = open + 1;
+            continue;
+        }
+        let mut depth = 0usize;
+        let mut close = None;
+        for (i, c) in region[open..].char_indices() {
+            match c {
+                '(' => depth += 1,
+                ')' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        close = Some(open + i);
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+        let Some(close) = close else { break };
+        let span = &region[open + 1..close];
+        search = close + 1;
+
+        let Some((_, after_first_comma)) = span.split_once(',') else {
+            continue;
+        };
+        let type_name: String = after_first_comma
+            .trim_start()
+            .chars()
+            .take_while(|c| c.is_ascii_alphanumeric() || *c == '_')
+            .collect();
+        if type_name.is_empty() {
+            continue;
+        }
+        // The family list: the last bracketed run of lowercase identifiers.
+        let families = span
+            .rmatch_indices('[')
+            .find_map(|(i, _)| {
+                let rest = &span[i + 1..];
+                let end = rest.find(']')?;
+                let inner = &rest[..end];
+                let ok = !inner.is_empty()
+                    && inner.chars().all(|c| {
+                        c.is_ascii_lowercase() || c == '_' || c == ',' || c.is_whitespace()
+                    });
+                ok.then(|| {
+                    inner
+                        .split(',')
+                        .map(str::trim)
+                        .filter(|s| !s.is_empty())
+                        .map(str::to_string)
+                        .collect::<Vec<_>>()
+                })
+            })
+            .unwrap_or_default();
+        if families.is_empty() {
+            continue;
+        }
+        out.push(Declaration {
+            type_name,
+            families,
+        });
+    }
+    out
+}
+
+/// Types carrying a lattice-shaped method, by the impl block they live in.
+///
+/// Reuses `inert_authority::scope_of`, which attributes `impl Trait for Type` to
+/// `Type` — the same reason a type whose `meet` lives inside its trait impl is
+/// found here too, and then cancels out against the declared set.
+pub fn lattice_shaped(region: &str) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    let mut scope = String::from("<free>");
+    for line in region.lines() {
+        if let Some(s) = scope_of(line) {
+            scope = s;
+        }
+        let t = line.trim_start();
+        if (t.starts_with("fn meet") || t.starts_with("fn join") || t.starts_with("fn leq"))
+            && scope != "<free>"
+        {
+            out.insert(scope.clone());
+        }
+    }
+    out
+}
+
+/// The measured state of the family.
+#[derive(Debug, Clone, Default)]
+pub struct Report {
+    /// Obligations per type, summed over its law-bearing trait impls.
+    pub obliged: BTreeMap<String, usize>,
+    /// Obligations per type that a `lattice_laws!` invocation discharges,
+    /// clamped so a declaration can never claim more than the type owes.
+    pub declared: BTreeMap<String, usize>,
+    /// Types with a lattice-shaped method and no law-bearing trait impl.
+    pub undeclared: BTreeSet<String>,
+}
+
+/// The crate a tracked path belongs to, used to key types.
+///
+/// Two distinct types share the name `CapabilityLattice` — one at
+/// `nucleus-ifc-kernel/src/capability_lattice.rs:21` whose impls live in
+/// `portcullis-core`, one at `portcullis/src/capability.rs:115` whose impls live
+/// in `portcullis`. Both implement all three traits, so a bare-name key sums
+/// their obligations to 30 **and lets one declaration discharge both**. That is
+/// unsound in the numerator, which is the half that must never over-report.
+///
+/// Keying by the crate the `impl` or the declaration is written in separates
+/// them. The cost is that a declaration written in a different crate from the
+/// impl reads as undischarged; that direction understates coverage rather than
+/// inventing it, which is the error worth having.
+fn crate_of(path: &str) -> &str {
+    path.strip_prefix("crates/")
+        .and_then(|r| r.split('/').next())
+        .unwrap_or("<unknown>")
+}
+
+fn key(path: &str, type_name: &str) -> String {
+    format!("{}::{type_name}", crate_of(path))
+}
+
+pub fn report(corpus: &BTreeMap<String, String>) -> Report {
+    let mut obliged: BTreeMap<String, usize> = BTreeMap::new();
+    let mut declared: BTreeMap<String, usize> = BTreeMap::new();
+    let mut shaped: BTreeSet<String> = BTreeSet::new();
+
+    for (path, src) in corpus {
+        let region = production_region(src);
+        for i in impls_in(&region) {
+            let laws = OBLIGATIONS
+                .iter()
+                .find(|(n, _)| *n == i.trait_name)
+                .map_or(0, |(_, l)| *l);
+            *obliged.entry(key(path, &i.type_name)).or_insert(0) += laws;
+        }
+        for d in declarations_in(&region) {
+            let sum: usize = d.families.iter().map(|f| discharged_by(f)).sum();
+            *declared.entry(key(path, &d.type_name)).or_insert(0) += sum;
+        }
+        shaped.extend(lattice_shaped(&region).into_iter().map(|t| key(path, &t)));
+    }
+
+    // A declaration cannot discharge more than the type owes. Listing `bounded`
+    // on a type that only implements `Lattice` does not compile, so this clamp
+    // never fires in practice — but a census that could report more discharged
+    // than declared is measuring two different things, and the ratio would be
+    // meaningless rather than merely wrong.
+    for (ty, d) in &mut declared {
+        let cap = obliged.get(ty).copied().unwrap_or(0);
+        *d = (*d).min(cap);
+    }
+
+    let undeclared = shaped
+        .into_iter()
+        .filter(|t| !obliged.contains_key(t))
+        .collect();
+
+    Report {
+        obliged,
+        declared,
+        undeclared,
+    }
+}
+
+pub struct Alg;
+
+impl Family for Alg {
+    fn name(&self) -> &'static str {
+        "alg"
+    }
+
+    fn unit(&self) -> &'static str {
+        "(lattice type, law) obligation"
+    }
+
+    fn census(&self, corpus: &BTreeMap<String, String>) -> Result<Census> {
+        let r = report(corpus);
+        Ok(Census {
+            population: r.obliged.values().sum(),
+            discharged: r.declared.values().sum(),
+            undeclared: r.undeclared.len(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_bare_impl_is_found() {
+        let v = impls_in("impl Lattice for ConfLevel {\n");
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].trait_name, "Lattice");
+        assert_eq!(v[0].type_name, "ConfLevel");
+    }
+
+    #[test]
+    fn a_qualified_impl_is_found() {
+        let v = impls_in("impl crate::frame::Lattice for CommandLattice {\n");
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].type_name, "CommandLattice");
+    }
+
+    #[test]
+    fn bounded_does_not_read_as_lattice() {
+        // The whole obligation table turns on this: `BoundedLattice` owes 4, not
+        // 9, because the 9 arrive from the `Lattice` impl beside it.
+        let v = impls_in("impl BoundedLattice for CapabilityLevel {\n");
+        assert_eq!(v[0].trait_name, "BoundedLattice");
+    }
+
+    #[test]
+    fn generics_do_not_hide_the_trait_or_the_type() {
+        let v = impls_in("impl<A: Lattice, B: Lattice> Lattice for ProductLattice<A, B> {\n");
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].trait_name, "Lattice");
+        assert_eq!(v[0].type_name, "ProductLattice");
+    }
+
+    #[test]
+    fn an_unrelated_trait_is_not_an_obligation() {
+        assert!(impls_in("impl Display for ConfLevel {\n").is_empty());
+        assert!(impls_in("impl LatticeOperation for Foo {\n").is_empty());
+    }
+
+    #[test]
+    fn an_inherent_impl_is_not_a_trait_impl() {
+        assert!(impls_in("impl ConfLevel {\n").is_empty());
+    }
+
+    #[test]
+    fn a_single_line_declaration_parses() {
+        let d = declarations_in("lattice_laws!(conf_laws, ConfLevel, s(), [bounded]);\n");
+        assert_eq!(d.len(), 1);
+        assert_eq!(d[0].type_name, "ConfLevel");
+        assert_eq!(d[0].families, vec!["bounded"]);
+    }
+
+    #[test]
+    fn a_multi_line_declaration_parses() {
+        let src = "\
+lattice_laws!(
+    conf_level_laws,
+    ConfLevel,
+    vec![ConfLevel::Public, ConfLevel::Internal, ConfLevel::Secret],
+    [bounded, distributive]
+);
+";
+        let d = declarations_in(src);
+        assert_eq!(d.len(), 1);
+        assert_eq!(d[0].type_name, "ConfLevel");
+        assert_eq!(d[0].families, vec!["bounded", "distributive"]);
+    }
+
+    #[test]
+    fn a_generic_type_argument_does_not_break_the_comma_split() {
+        // `ProductLattice<ConfLevel, IntegLevel>` carries a comma inside its
+        // generics; taking the head identifier sidesteps it entirely.
+        let src = "lattice_laws!(p, ProductLattice<ConfLevel, IntegLevel>, v(), [bounded]);\n";
+        let d = declarations_in(src);
+        assert_eq!(d[0].type_name, "ProductLattice");
+        assert_eq!(d[0].families, vec!["bounded"]);
+    }
+
+    #[test]
+    fn the_samples_vec_is_not_mistaken_for_the_family_list() {
+        let src = "lattice_laws!(n, T, vec![T::A, T::B, T::C], [lattice]);\n";
+        let d = declarations_in(src);
+        assert_eq!(d[0].families, vec!["lattice"]);
+    }
+
+    #[test]
+    fn bounded_discharges_the_base_laws_too() {
+        // verify_bounded_lattice_laws calls verify_lattice_laws first.
+        assert_eq!(discharged_by("bounded"), LATTICE_LAWS + BOUNDED_LAWS);
+        assert_eq!(discharged_by("lattice"), LATTICE_LAWS);
+        assert_eq!(discharged_by("distributive"), DISTRIBUTIVE_LAWS);
+        assert_eq!(discharged_by("nonsense"), 0);
+    }
+
+    #[test]
+    fn two_types_sharing_a_name_in_different_crates_are_not_one_type() {
+        // `CapabilityLattice` exists twice — nucleus-ifc-kernel and portcullis —
+        // and both implement all three traits. Under a bare-name key their
+        // obligations sum to 30 and ONE declaration discharges both, which
+        // over-reports the numerator. The crate keeps them apart.
+        let corpus = BTreeMap::from([
+            (
+                "crates/alpha/src/lib.rs".to_string(),
+                "impl Lattice for Shared {}\nlattice_laws!(s, Shared, v(), [lattice]);\n"
+                    .to_string(),
+            ),
+            (
+                "crates/beta/src/lib.rs".to_string(),
+                "impl Lattice for Shared {}\n".to_string(),
+            ),
+        ]);
+        let r = report(&corpus);
+        assert_eq!(r.obliged["alpha::Shared"], LATTICE_LAWS);
+        assert_eq!(r.obliged["beta::Shared"], LATTICE_LAWS);
+        assert_eq!(r.declared.get("alpha::Shared"), Some(&LATTICE_LAWS));
+        assert_eq!(
+            r.declared.get("beta::Shared"),
+            None,
+            "alpha's declaration must not discharge beta's obligations"
+        );
+    }
+
+    #[test]
+    fn a_type_with_meet_and_no_trait_impl_is_undeclared() {
+        let corpus = BTreeMap::from([(
+            "crates/demo/src/lib.rs".to_string(),
+            "impl WasiGrant {\n    fn meet(&self, o: &Self) -> Self { todo!() }\n}\n".to_string(),
+        )]);
+        let r = report(&corpus);
+        assert!(r.undeclared.contains("demo::WasiGrant"));
+        assert!(r.obliged.is_empty());
+    }
+
+    #[test]
+    fn a_declared_type_is_not_also_counted_as_undeclared() {
+        let corpus = BTreeMap::from([(
+            "crates/demo/src/lib.rs".to_string(),
+            "impl Lattice for ConfLevel {\n    fn meet(&self, o: &Self) -> Self { todo!() }\n}\n"
+                .to_string(),
+        )]);
+        let r = report(&corpus);
+        assert!(r.undeclared.is_empty());
+        assert_eq!(r.obliged["demo::ConfLevel"], LATTICE_LAWS);
+    }
+
+    #[test]
+    fn a_declaration_cannot_discharge_more_than_the_type_owes() {
+        let corpus = BTreeMap::from([(
+            "crates/demo/src/lib.rs".to_string(),
+            "impl Lattice for T {}\nlattice_laws!(t, T, s(), [bounded, distributive]);\n"
+                .to_string(),
+        )]);
+        let r = report(&corpus);
+        assert_eq!(r.obliged["demo::T"], LATTICE_LAWS);
+        assert_eq!(
+            r.declared["demo::T"], LATTICE_LAWS,
+            "clamped to what is owed"
+        );
+    }
+
+    #[test]
+    fn the_family_entry_point_reports_the_three_numbers_the_card_prints() {
+        // The scorecard calls this, not `report`; an untested adapter is how a
+        // correct census reaches the card wrong.
+        let corpus = BTreeMap::from([(
+            "crates/demo/src/lib.rs".to_string(),
+            "impl Lattice for Declared {}\n\
+             impl BoundedLattice for Declared {}\n\
+             lattice_laws!(d, Declared, v(), [lattice]);\n\
+             impl Orphan {\n    fn meet(&self, o: &Self) -> Self { todo!() }\n}\n"
+                .to_string(),
+        )]);
+        let c = Alg.census(&corpus).expect("the census succeeds");
+        assert_eq!(c.population, LATTICE_LAWS + BOUNDED_LAWS, "9 + 4 obliged");
+        assert_eq!(c.discharged, LATTICE_LAWS, "only `lattice` declared");
+        assert_eq!(c.undeclared, 1, "Orphan has meet and no trait impl");
+        assert_eq!(c.basis_points(), 6_923, "9 of 13");
+    }
+
+    #[test]
+    fn obligations_sum_across_the_traits_a_type_implements() {
+        let corpus = BTreeMap::from([(
+            "crates/demo/src/lib.rs".to_string(),
+            "impl Lattice for T {}\nimpl BoundedLattice for T {}\nimpl DistributiveLattice for T {}\n"
+                .to_string(),
+        )]);
+        let r = report(&corpus);
+        assert_eq!(
+            r.obliged["demo::T"],
+            LATTICE_LAWS + BOUNDED_LAWS + DISTRIBUTIVE_LAWS,
+            "a type implementing all three owes 15"
+        );
+    }
+}

--- a/crates/xtask/src/inert_authority.rs
+++ b/crates/xtask/src/inert_authority.rs
@@ -302,7 +302,7 @@ fn inert_site(line: &str, witness: &[String]) -> bool {
 /// asks is "which implementation drops the witness", and two impls of the same
 /// trait — `RealEffects` and `DenyAllEffects` — are exactly what must not share
 /// a row.
-fn scope_of(line: &str) -> Option<String> {
+pub fn scope_of(line: &str) -> Option<String> {
     let t = line.trim_start();
     if let Some(rest) = t.strip_prefix("impl") {
         if !rest.starts_with(|c: char| c.is_whitespace() || c == '<') {

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -336,6 +336,7 @@ enum CiSpecCmd {
     },
 }
 
+mod alg;
 mod allowlist_gates;
 mod assurance_required;
 mod bound;

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -161,6 +161,22 @@ enum Command {
         #[arg(long)]
         badge: bool,
     },
+    /// One card, one row per defect family, and a badge naming the WEAKEST —
+    /// not an average, which would let a family at zero hide behind one at a
+    /// hundred (ADR 0007 I-1).
+    ///
+    /// Each family reports population (obligations the tree declares),
+    /// discharged (those a mechanism that can fail covers) and undeclared
+    /// (sites with the family's shape that are outside the population). Pinned
+    /// per family in `.scorecard-ratchet.toml`, two floors each: on the ratio,
+    /// so it cannot fall, and on the population, because deleting an obligation
+    /// raises the ratio without discharging anything.
+    Scorecard {
+        #[arg(long)]
+        measure: bool,
+        #[arg(long)]
+        badge: bool,
+    },
     /// Build every workspace crate in isolation (`cargo build -p <crate>`) to
     /// catch feature-unification-masked breakages — crates that compile in a
     /// full `--workspace` build but fail standalone (and on `cargo publish`)
@@ -342,6 +358,7 @@ mod push_auth;
 mod rerun_plan;
 mod schedule_liveness;
 mod scoreboard;
+mod scorecard;
 mod self_pin;
 
 fn main() -> Result<()> {
@@ -406,6 +423,10 @@ fn main() -> Result<()> {
             code => std::process::exit(code),
         },
         Command::Bound { measure, badge } => match bound::run(measure, badge)? {
+            0 => Ok(()),
+            code => std::process::exit(code),
+        },
+        Command::Scorecard { measure, badge } => match scorecard::run(measure, badge)? {
             0 => Ok(()),
             code => std::process::exit(code),
         },

--- a/crates/xtask/src/scorecard.rs
+++ b/crates/xtask/src/scorecard.rs
@@ -1,0 +1,735 @@
+//! Scorecard — one card, one row per defect family, and a badge naming the weakest.
+//!
+//! # The measurement this was built from
+//!
+//! A census of all 868 nucleus issues (2026-09-11) classified the 120 that are
+//! `bug`-labelled or carry an audit prefix (`audit:`, `[CRIT-n]`, `[HIGH-n]`).
+//! Four families account for about 90% of them:
+//!
+//! | family | defects | the defect |
+//! |---|---|---|
+//! | `bound` | 72 (60%) | a mechanism exists and nothing binds it to the live path |
+//! | `alg`   | 15 (13%) | a law of a structure the code already claims to be |
+//! | `life`  | 14 (12%) | unbounded carrier, no durable state, no validity interval |
+//! | `tot`   |  7 (6%)  | a function whose type says total, that panics |
+//!
+//! The remaining 10% is genuinely novel — DX, release infra, an SDK format
+//! mismatch — and no census here will find it.
+//!
+//! 64 of the 72 `bound` defects are security-labelled, **45 of them were found
+//! by a human reading code and none by a gate**, and they close in a median of
+//! 0.1 days against 0.4 for everything else. The fix is one call, one flag, one
+//! `&` removed. They survive for months because nothing is looking.
+//!
+//! The three families beside `bound` are the answer to an objection worth
+//! stating: that a gate cannot find a property nobody thought of. For these,
+//! **nobody has to think of the property** — it is generated from a
+//! declaration. `AnyOf : JoinSemilattice<Verdict>` obliges commutativity, and
+//! #1222 ("AnyOf combinator is order-dependent — violates join commutativity")
+//! is an audit finding that would have been a failing generated test on day one.
+//!
+//! # What a family is
+//!
+//! Every family reports the same three numbers, and the shape is gatehouse's
+//! `trusted-base.txt` principle: *"THE POPULATION IS ENUMERATED, NOT LISTED …
+//! the assumptions are then the COMPLEMENT of what is pinned, over a closed
+//! population — there is no third state and no list to drift."*
+//!
+//! * **population** — obligations the tree declares.
+//! * **discharged** — of those, the ones a mechanism that can fail covers.
+//! * **undeclared** — sites with the family's *shape* that are not declared
+//!   into it, so they sit outside the population entirely.
+//!
+//! The third number is the lesson of `bound`. 32 of its 33 dropped witnesses are
+//! class-`N` legitimate doubles — `DenyAllEffects::run` refuses unconditionally,
+//! so it performs no act and correctly consults nothing — and a census without
+//! that column reads 83.82% where the truth is 99.41%. A number that silently
+//! omits its undeclared surface is the `scripts/law-mechanisms-manifest.txt`
+//! failure: a numerator with no denominator.
+//!
+//! # Why the badge names the weakest family
+//!
+//! Pooling the numerators over the pooled denominators gives one percentage that
+//! is dominated by whichever family has the largest population, and `tot` alone
+//! measures in the thousands. A family at 0% would disappear into that average.
+//! An unweighted mean has the same defect more slowly. Counting families at
+//! target is ungameable but cannot tell 14% from 84%.
+//!
+//! So the badge reads `alg 22%` — the lowest-scoring family **and** its number.
+//! It moves whenever the weakest improves, it cannot hide a bad family behind a
+//! good one, and it says where the next hour of work goes. ADR 0007 I-1: a gate
+//! whose green is indistinguishable from vacuity. An average would be one.
+//!
+//! # Why two pins per family
+//!
+//! `.scorecard-ratchet.toml` carries `floor_bp` and `population_floor` for each
+//! family, the discipline `.bound-ratchet.toml` established. A floor on the ratio
+//! alone rewards deleting enforcement points — remove an obligation and
+//! numerator and denominator fall together while the ratio rises. A pin on the
+//! debt alone misses a ratio falling at constant debt. Neither is sufficient and
+//! together they are, which is why both are required and a missing one is an
+//! error rather than a default.
+
+use anyhow::{Context, Result, bail};
+use std::collections::BTreeMap;
+
+pub const RATCHET: &str = ".scorecard-ratchet.toml";
+
+/// What one family found in the tree.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct Census {
+    /// Obligations the tree declares.
+    pub population: usize,
+    /// Of those, the ones a mechanism that can fail actually covers.
+    pub discharged: usize,
+    /// Sites carrying the family's shape that are not declared into it, and so
+    /// are outside `population`. Not a failure — a statement of how much surface
+    /// the denominator does not reach.
+    pub undeclared: usize,
+}
+
+impl Census {
+    /// `discharged / population` in basis points, so a pin is an integer.
+    ///
+    /// An empty population is zero, never 100%: nothing declared is nothing
+    /// discharged, and rounding it up would let deleting the last obligation
+    /// paint the card green.
+    pub const fn basis_points(self) -> u32 {
+        if self.population == 0 {
+            return 0;
+        }
+        ((self.discharged * 10_000) / self.population) as u32
+    }
+
+    /// Obligations declared and not discharged.
+    pub const fn outstanding(self) -> usize {
+        self.population.saturating_sub(self.discharged)
+    }
+}
+
+/// One defect family, and how to count it.
+pub trait Family {
+    /// The family's name on the card and in the ratchet. Lowercase, stable.
+    fn name(&self) -> &'static str;
+
+    /// What one unit of population is, printed on the card so a reader never has
+    /// to guess what the denominator counts.
+    fn unit(&self) -> &'static str;
+
+    /// Enumerate the family over the production region of `corpus`.
+    fn census(&self, corpus: &BTreeMap<String, String>) -> Result<Census>;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The `bound` family — declared enforcement that reaches the live path.
+//
+// A thin adapter over `crate::bound`, which owns the measurement, the
+// cross-check against `INERT_TOTAL`, and the class-`N` excusal. The scorecard
+// deliberately does not re-implement any of it: two censuses of one population
+// that could disagree is the defect `bound` itself bails on.
+
+pub struct Bound;
+
+impl Family for Bound {
+    fn name(&self) -> &'static str {
+        "bound"
+    }
+
+    fn unit(&self) -> &'static str {
+        "witness-accepting parameter site"
+    }
+
+    fn census(&self, corpus: &BTreeMap<String, String>) -> Result<Census> {
+        let text = std::fs::read_to_string(crate::inert_authority::MANIFEST)
+            .with_context(|| format!("reading {}", crate::inert_authority::MANIFEST))?;
+        let manifest = crate::inert_authority::parse(&text)?;
+        let (report, _) = crate::bound::report(corpus, &manifest)?;
+        let net = report.net();
+        Ok(Census {
+            population: net.declared(),
+            discharged: net.bound,
+            // The class-`N` sites: a witness accepted and dropped where no act is
+            // performed, so nothing was owed. Shape without obligation.
+            undeclared: report.excused,
+        })
+    }
+}
+
+/// Every family on the card, in the order they are printed.
+pub fn families() -> Vec<Box<dyn Family>> {
+    vec![Box::new(Bound)]
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The ratchet
+
+/// The pinned floors for one family.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Pin {
+    /// Minimum `discharged / population`, in basis points. May only rise.
+    pub floor_bp: u32,
+    /// Minimum `population`. A shrinking surface is a decision, not a win.
+    pub population_floor: usize,
+}
+
+/// Parse `.scorecard-ratchet.toml`: `[family.<name>]` sections, two keys each.
+///
+/// Declaration-only, so it is decidable against an empty checkout — the half of
+/// a gate where this repo's ratchet defects have lived.
+pub fn parse_ratchet(text: &str) -> Result<BTreeMap<String, Pin>> {
+    let mut out: BTreeMap<String, Pin> = BTreeMap::new();
+    let mut current: Option<String> = None;
+    let mut floor_bp: Option<u32> = None;
+    let mut population_floor: Option<usize> = None;
+
+    // Close the section under construction, if any.
+    fn close(
+        out: &mut BTreeMap<String, Pin>,
+        name: &Option<String>,
+        floor_bp: Option<u32>,
+        population_floor: Option<usize>,
+    ) -> Result<()> {
+        let Some(name) = name else { return Ok(()) };
+        let floor_bp = floor_bp.with_context(|| {
+            format!("[family.{name}] has no floor_bp; an unpinned ratio gates nothing")
+        })?;
+        let population_floor = population_floor.with_context(|| {
+            format!(
+                "[family.{name}] has no population_floor. A floor on the ratio alone rewards \
+                 deleting obligations: remove one and numerator and denominator fall together \
+                 while the ratio rises."
+            )
+        })?;
+        if floor_bp == 0 {
+            bail!("[family.{name}] floor_bp=0 passes for every tree, including an empty one");
+        }
+        if floor_bp > 10_000 {
+            bail!("[family.{name}] floor_bp={floor_bp} exceeds 10000bp; the gate could never pass");
+        }
+        if population_floor == 0 {
+            bail!("[family.{name}] population_floor=0 passes for a tree with no obligations");
+        }
+        if out
+            .insert(
+                name.clone(),
+                Pin {
+                    floor_bp,
+                    population_floor,
+                },
+            )
+            .is_some()
+        {
+            bail!("[family.{name}] declared twice");
+        }
+        Ok(())
+    }
+
+    for (lineno, raw) in text.lines().enumerate() {
+        let line = raw.split('#').next().unwrap_or("").trim();
+        if line.is_empty() {
+            continue;
+        }
+        if let Some(header) = line.strip_prefix('[').and_then(|s| s.strip_suffix(']')) {
+            close(&mut out, &current, floor_bp, population_floor)?;
+            floor_bp = None;
+            population_floor = None;
+            let name = header.strip_prefix("family.").with_context(|| {
+                format!(
+                    "line {}: only [family.<name>] sections are allowed",
+                    lineno + 1
+                )
+            })?;
+            if name.is_empty() {
+                bail!("line {}: [family.] has no name", lineno + 1);
+            }
+            current = Some(name.to_string());
+            continue;
+        }
+        let Some((key, value)) = line.split_once('=') else {
+            bail!("line {}: not `key = value`: {raw}", lineno + 1);
+        };
+        if current.is_none() {
+            bail!(
+                "line {}: `{}` appears before any [family.<name>] section",
+                lineno + 1,
+                key.trim()
+            );
+        }
+        let value = value.trim();
+        match key.trim() {
+            "floor_bp" => {
+                floor_bp =
+                    Some(value.parse().with_context(|| {
+                        format!("line {}: floor_bp is not a number", lineno + 1)
+                    })?);
+            }
+            "population_floor" => {
+                population_floor = Some(value.parse().with_context(|| {
+                    format!("line {}: population_floor is not a number", lineno + 1)
+                })?);
+            }
+            other => bail!("line {}: unknown key `{other}`", lineno + 1),
+        }
+    }
+    close(&mut out, &current, floor_bp, population_floor)?;
+
+    if out.is_empty() {
+        bail!("{RATCHET} declares no families; the card would be empty and the gate vacuous");
+    }
+    Ok(out)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The decision
+
+/// One disagreement between the ratchet and the tree.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Finding {
+    /// A family's ratio fell below its floor.
+    Fell {
+        family: String,
+        found_bp: u32,
+        floor_bp: u32,
+    },
+    /// A family's declared surface shrank.
+    Shrank {
+        family: String,
+        found: usize,
+        floor: usize,
+    },
+    /// A family's ratio rose and the pin was not raised with it.
+    Slack {
+        family: String,
+        found_bp: u32,
+        floor_bp: u32,
+    },
+    /// A family is on the card with no pin.
+    Unpinned { family: String },
+    /// A pin names a family that is not on the card.
+    Stale { family: String },
+}
+
+impl std::fmt::Display for Finding {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Fell {
+                family,
+                found_bp,
+                floor_bp,
+            } => write!(
+                f,
+                "{family} fell to {} against a floor of {}: an obligation the tree declares \
+                 stopped being discharged.",
+                pct(*found_bp),
+                pct(*floor_bp)
+            ),
+            Self::Shrank {
+                family,
+                found,
+                floor,
+            } => write!(
+                f,
+                "{family}'s population fell to {found} from a floor of {floor}. Deleting an \
+                 obligation raises the ratio without discharging anything; if the deletion is \
+                 intended, lower population_floor in the same edit with a dated note."
+            ),
+            Self::Slack {
+                family,
+                found_bp,
+                floor_bp,
+            } => write!(
+                f,
+                "{family} is at {} but the floor is pinned at {}. Raise floor_bp to the measured \
+                 value: a floor with slack under it has already stopped gating (ADR 0007 I-1).",
+                pct(*found_bp),
+                pct(*floor_bp)
+            ),
+            Self::Unpinned { family } => write!(
+                f,
+                "{family} is on the card and has no [family.{family}] section in {RATCHET}. A \
+                 family nothing pins can fall to zero silently."
+            ),
+            Self::Stale { family } => write!(
+                f,
+                "{RATCHET} pins [family.{family}] and no family by that name is on the card. A \
+                 stale pin is a gate ranging over nothing."
+            ),
+        }
+    }
+}
+
+/// Compare the measured card against the ratchet. Pure and total.
+pub fn decide(pins: &BTreeMap<String, Pin>, card: &[(String, Census)]) -> Vec<Finding> {
+    let mut out = Vec::new();
+    for (family, census) in card {
+        let Some(pin) = pins.get(family) else {
+            out.push(Finding::Unpinned {
+                family: family.clone(),
+            });
+            continue;
+        };
+        let found_bp = census.basis_points();
+        if found_bp < pin.floor_bp {
+            out.push(Finding::Fell {
+                family: family.clone(),
+                found_bp,
+                floor_bp: pin.floor_bp,
+            });
+        } else if found_bp > pin.floor_bp {
+            out.push(Finding::Slack {
+                family: family.clone(),
+                found_bp,
+                floor_bp: pin.floor_bp,
+            });
+        }
+        if census.population < pin.population_floor {
+            out.push(Finding::Shrank {
+                family: family.clone(),
+                found: census.population,
+                floor: pin.population_floor,
+            });
+        }
+    }
+    for family in pins.keys() {
+        if !card.iter().any(|(name, _)| name == family) {
+            out.push(Finding::Stale {
+                family: family.clone(),
+            });
+        }
+    }
+    out
+}
+
+/// The family the badge names: lowest ratio, ties broken by name so the badge is
+/// stable across runs rather than following map iteration order.
+pub fn weakest(card: &[(String, Census)]) -> Option<(&str, Census)> {
+    card.iter()
+        .min_by_key(|(name, c)| (c.basis_points(), name.as_str()))
+        .map(|(name, c)| (name.as_str(), *c))
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Basis points as a percentage, for messages a human reads.
+fn pct(bp: u32) -> String {
+    format!("{}.{:02}%", bp / 100, bp % 100)
+}
+
+fn render(card: &[(String, Census)], families: &[Box<dyn Family>]) -> String {
+    let unit_of = |name: &str| {
+        families
+            .iter()
+            .find(|f| f.name() == name)
+            .map_or("", |f| f.unit())
+    };
+    let unit_w = card
+        .iter()
+        .map(|(n, _)| unit_of(n).len())
+        .chain(std::iter::once(4))
+        .max()
+        .unwrap_or(4);
+    let name_w = card
+        .iter()
+        .map(|(n, _)| n.len())
+        .chain(std::iter::once(6))
+        .max()
+        .unwrap_or(6);
+
+    let mut out = format!(
+        "  {:name_w$}  {:unit_w$}  {:>10}  {:>10}  {:>8}  {:>10}\n",
+        "family", "unit", "population", "discharged", "%", "undeclared"
+    );
+    for (name, c) in card {
+        out.push_str(&format!(
+            "  {:name_w$}  {:unit_w$}  {:>10}  {:>10}  {:>8}  {:>10}\n",
+            name,
+            unit_of(name),
+            c.population,
+            c.discharged,
+            pct(c.basis_points()),
+            c.undeclared
+        ));
+    }
+    out
+}
+
+pub fn run(measure: bool, badge: bool) -> Result<i32> {
+    let corpus = crate::law_mechanisms::tracked(crate::law_mechanisms::is_production_path)?;
+    let families = families();
+    let mut card: Vec<(String, Census)> = Vec::new();
+    for family in &families {
+        let census = family
+            .census(&corpus)
+            .with_context(|| format!("counting the `{}` family", family.name()))?;
+        if census.discharged > census.population {
+            bail!(
+                "the `{}` family reports {} discharged of a population of {}. A census that \
+                 discharges more than it declares is measuring two different things, and the \
+                 ratio below would be meaningless.",
+                family.name(),
+                census.discharged,
+                census.population
+            );
+        }
+        card.push((family.name().to_string(), census));
+    }
+
+    let Some((weak_name, weak)) = weakest(&card) else {
+        bail!("no families on the card; the gate would pass vacuously");
+    };
+
+    if badge {
+        println!(
+            r#"{{"schemaVersion":1,"label":"scorecard","message":"{} {}","color":"{}"}}"#,
+            weak_name,
+            pct(weak.basis_points()),
+            if weak.basis_points() >= 9_900 {
+                "brightgreen"
+            } else if weak.basis_points() >= 7_500 {
+                "yellow"
+            } else {
+                "orange"
+            }
+        );
+        return Ok(0);
+    }
+
+    if measure {
+        println!("  scorecard | {weak_name} {}\n", pct(weak.basis_points()));
+        print!("{}", render(&card, &families));
+        for (name, c) in &card {
+            if c.outstanding() > 0 {
+                println!(
+                    "\n  {name}: {} of {} obligation(s) undischarged",
+                    c.outstanding(),
+                    c.population
+                );
+            }
+        }
+        return Ok(0);
+    }
+
+    let pins = parse_ratchet(
+        &std::fs::read_to_string(RATCHET).with_context(|| format!("reading {RATCHET}"))?,
+    )?;
+    let findings = decide(&pins, &card);
+    if findings.is_empty() {
+        println!(
+            "OK: {} {} on the card, weakest is {weak_name} at {}.",
+            card.len(),
+            if card.len() == 1 {
+                "family"
+            } else {
+                "families"
+            },
+            pct(weak.basis_points())
+        );
+        print!("{}", render(&card, &families));
+        println!(
+            "     The badge names the weakest family rather than an average, so a family at zero \
+             cannot hide behind one at a hundred (ADR 0007 I-1)."
+        );
+        return Ok(0);
+    }
+    println!("FAIL: {} scorecard finding(s).", findings.len());
+    for f in &findings {
+        println!("  {f}");
+    }
+    Ok(1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn c(population: usize, discharged: usize) -> Census {
+        Census {
+            population,
+            discharged,
+            undeclared: 0,
+        }
+    }
+
+    #[test]
+    fn an_empty_population_is_zero_not_a_hundred_percent() {
+        // Deleting the last obligation must not paint the card green.
+        assert_eq!(Census::default().basis_points(), 0);
+    }
+
+    #[test]
+    fn the_badge_names_the_weakest_family_not_the_average() {
+        let card = vec![
+            ("bound".to_string(), c(172, 171)),
+            ("alg".to_string(), c(250, 55)),
+        ];
+        // Pooled, this reads (171+55)/(172+250) = 53%; the weakest is 22%.
+        let (name, census) = weakest(&card).expect("a card with rows has a weakest");
+        assert_eq!(name, "alg");
+        assert_eq!(census.basis_points(), 2_200);
+    }
+
+    #[test]
+    fn ties_break_by_name_so_the_badge_does_not_flicker() {
+        let card = vec![
+            ("zeta".to_string(), c(10, 5)),
+            ("alpha".to_string(), c(100, 50)),
+        ];
+        assert_eq!(weakest(&card).map(|(n, _)| n), Some("alpha"));
+    }
+
+    #[test]
+    fn a_ratio_below_the_floor_fails() {
+        let pins = BTreeMap::from([(
+            "bound".to_string(),
+            Pin {
+                floor_bp: 9_941,
+                population_floor: 172,
+            },
+        )]);
+        let card = vec![("bound".to_string(), c(172, 170))];
+        assert!(matches!(
+            decide(&pins, &card).as_slice(),
+            [Finding::Fell { .. }]
+        ));
+    }
+
+    #[test]
+    fn a_ratio_above_the_floor_also_fails_so_the_pin_cannot_go_slack() {
+        let pins = BTreeMap::from([(
+            "bound".to_string(),
+            Pin {
+                floor_bp: 5_000,
+                population_floor: 172,
+            },
+        )]);
+        let card = vec![("bound".to_string(), c(172, 171))];
+        assert!(matches!(
+            decide(&pins, &card).as_slice(),
+            [Finding::Slack { .. }]
+        ));
+    }
+
+    #[test]
+    fn deleting_obligations_does_not_pass_by_raising_the_ratio() {
+        // 100% of a smaller population. The ratio is perfect and the gate refuses.
+        let pins = BTreeMap::from([(
+            "bound".to_string(),
+            Pin {
+                floor_bp: 9_941,
+                population_floor: 172,
+            },
+        )]);
+        let card = vec![("bound".to_string(), c(100, 100))];
+        let findings = decide(&pins, &card);
+        assert!(findings.iter().any(|f| matches!(f, Finding::Shrank { .. })));
+    }
+
+    #[test]
+    fn a_family_with_no_pin_is_a_finding_not_a_default() {
+        let card = vec![("bound".to_string(), c(172, 171))];
+        assert!(matches!(
+            decide(&BTreeMap::new(), &card).as_slice(),
+            [Finding::Unpinned { .. }]
+        ));
+    }
+
+    #[test]
+    fn a_pin_for_a_family_that_is_not_on_the_card_is_a_finding() {
+        let pins = BTreeMap::from([(
+            "ghost".to_string(),
+            Pin {
+                floor_bp: 1,
+                population_floor: 1,
+            },
+        )]);
+        assert!(matches!(
+            decide(&pins, &[]).as_slice(),
+            [Finding::Stale { .. }]
+        ));
+    }
+
+    #[test]
+    fn both_pins_are_required() {
+        let only_ratio = "[family.bound]\nfloor_bp = 9941\n";
+        assert!(
+            parse_ratchet(only_ratio)
+                .unwrap_err()
+                .to_string()
+                .contains("population_floor")
+        );
+        let only_population = "[family.bound]\npopulation_floor = 172\n";
+        assert!(
+            parse_ratchet(only_population)
+                .unwrap_err()
+                .to_string()
+                .contains("floor_bp")
+        );
+    }
+
+    #[test]
+    fn a_zero_floor_is_rejected_rather_than_passing_vacuously() {
+        let text = "[family.bound]\nfloor_bp = 0\npopulation_floor = 1\n";
+        assert!(
+            parse_ratchet(text)
+                .unwrap_err()
+                .to_string()
+                .contains("every tree")
+        );
+    }
+
+    #[test]
+    fn an_empty_ratchet_is_rejected() {
+        assert!(
+            parse_ratchet("# just a comment\n")
+                .unwrap_err()
+                .to_string()
+                .contains("no families")
+        );
+    }
+
+    #[test]
+    fn two_families_parse_independently() {
+        let text = "\
+[family.bound]
+floor_bp = 9941
+population_floor = 172
+
+[family.alg]
+floor_bp = 2200
+population_floor = 250
+";
+        let pins = parse_ratchet(text).expect("two sections parse");
+        assert_eq!(pins.len(), 2);
+        assert_eq!(pins["alg"].floor_bp, 2_200);
+        assert_eq!(pins["bound"].population_floor, 172);
+    }
+
+    #[test]
+    fn a_key_before_any_section_is_rejected() {
+        assert!(
+            parse_ratchet("floor_bp = 1\n[family.bound]\n")
+                .unwrap_err()
+                .to_string()
+                .contains("before any")
+        );
+    }
+
+    #[test]
+    fn the_committed_ratchet_parses_and_pins_every_family_on_the_card() {
+        // The gate's own configuration is a subject, not an assumption.
+        let text = std::fs::read_to_string(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../",
+            ".scorecard-ratchet.toml"
+        ))
+        .expect("the committed ratchet is readable");
+        let pins = parse_ratchet(&text).expect("the committed ratchet parses");
+        for family in families() {
+            assert!(
+                pins.contains_key(family.name()),
+                "family `{}` is on the card with no pin",
+                family.name()
+            );
+        }
+    }
+}

--- a/crates/xtask/src/scorecard.rs
+++ b/crates/xtask/src/scorecard.rs
@@ -453,13 +453,26 @@ fn render(card: &[(String, Census)], families: &[Box<dyn Family>]) -> String {
     out
 }
 
-pub fn run(measure: bool, badge: bool) -> Result<i32> {
-    let corpus = crate::law_mechanisms::tracked(crate::law_mechanisms::is_production_path)?;
-    let families = families();
+/// Build the card by asking every family to count itself.
+///
+/// Pure over the corpus, so the whole of it is reachable from a test with a
+/// synthetic tree — the same reason `decide` is pure. `run` below is the I/O
+/// shell: read the tree, call this, print.
+///
+/// # Errors
+///
+/// If a family's census fails, or reports more discharged than its population.
+/// The second is not a formality: a census that discharges more than it declares
+/// is counting two different things, and the ratio would be meaningless rather
+/// than merely wrong.
+pub fn card_of(
+    families: &[Box<dyn Family>],
+    corpus: &BTreeMap<String, String>,
+) -> Result<Vec<(String, Census)>> {
     let mut card: Vec<(String, Census)> = Vec::new();
-    for family in &families {
+    for family in families {
         let census = family
-            .census(&corpus)
+            .census(corpus)
             .with_context(|| format!("counting the `{}` family", family.name()))?;
         if census.discharged > census.population {
             bail!(
@@ -473,24 +486,42 @@ pub fn run(measure: bool, badge: bool) -> Result<i32> {
         }
         card.push((family.name().to_string(), census));
     }
+    Ok(card)
+}
+
+/// The shields.io endpoint object for a card, naming its weakest family.
+///
+/// Thresholds are deliberately far apart: a family under three quarters is
+/// orange, because the badge's job is to be uncomfortable while a family is
+/// genuinely undischarged.
+pub fn badge_json(card: &[(String, Census)]) -> Result<String> {
+    let Some((name, weak)) = weakest(card) else {
+        bail!("no families on the card; the badge would name nothing");
+    };
+    let colour = if weak.basis_points() >= 9_900 {
+        "brightgreen"
+    } else if weak.basis_points() >= 7_500 {
+        "yellow"
+    } else {
+        "orange"
+    };
+    Ok(format!(
+        r#"{{"schemaVersion":1,"label":"scorecard","message":"{name} {}","color":"{colour}"}}"#,
+        pct(weak.basis_points())
+    ))
+}
+
+pub fn run(measure: bool, badge: bool) -> Result<i32> {
+    let corpus = crate::law_mechanisms::tracked(crate::law_mechanisms::is_production_path)?;
+    let families = families();
+    let card = card_of(&families, &corpus)?;
 
     let Some((weak_name, weak)) = weakest(&card) else {
         bail!("no families on the card; the gate would pass vacuously");
     };
 
     if badge {
-        println!(
-            r#"{{"schemaVersion":1,"label":"scorecard","message":"{} {}","color":"{}"}}"#,
-            weak_name,
-            pct(weak.basis_points()),
-            if weak.basis_points() >= 9_900 {
-                "brightgreen"
-            } else if weak.basis_points() >= 7_500 {
-                "yellow"
-            } else {
-                "orange"
-            }
-        );
+        println!("{}", badge_json(&card)?);
         return Ok(0);
     }
 
@@ -712,6 +743,197 @@ population_floor = 250
                 .to_string()
                 .contains("before any")
         );
+    }
+
+    // ── The card a human reads ────────────────────────────────────────
+    //
+    // `render` is the gate's only output on a green tree, so an unreadable or
+    // silently-truncated card is a defect that no other test would catch.
+
+    struct Fake(&'static str, &'static str);
+    impl Family for Fake {
+        fn name(&self) -> &'static str {
+            self.0
+        }
+        fn unit(&self) -> &'static str {
+            self.1
+        }
+        fn census(&self, _: &BTreeMap<String, String>) -> Result<Census> {
+            Ok(Census::default())
+        }
+    }
+
+    #[test]
+    fn the_card_names_every_family_its_unit_and_its_numbers() {
+        let families: Vec<Box<dyn Family>> = vec![
+            Box::new(Fake("bound", "witness-accepting parameter site")),
+            Box::new(Fake("alg", "(lattice type, law) obligation")),
+        ];
+        let card = vec![
+            ("bound".to_string(), c(172, 171)),
+            (
+                "alg".to_string(),
+                Census {
+                    population: 278,
+                    discharged: 110,
+                    undeclared: 9,
+                },
+            ),
+        ];
+        let out = render(&card, &families);
+        assert!(out.contains("witness-accepting parameter site"));
+        assert!(out.contains("(lattice type, law) obligation"));
+        assert!(out.contains("99.41%"), "bound's ratio: {out}");
+        assert!(out.contains("39.56%"), "alg's ratio: {out}");
+        assert!(out.contains("278") && out.contains("110") && out.contains('9'));
+        assert_eq!(out.lines().count(), 3, "a header and one line per family");
+    }
+
+    #[test]
+    fn a_family_with_no_matching_unit_still_renders_its_row() {
+        // The card must not drop a row because the unit lookup missed: a
+        // silently shorter card is the shape of a gate that stopped looking.
+        let out = render(&[("ghost".to_string(), c(4, 2))], &[]);
+        assert!(out.contains("ghost"));
+        assert!(out.contains("50.00%"));
+    }
+
+    // ── Every finding says what to do about it ────────────────────────
+
+    #[test]
+    fn fell_names_both_numbers() {
+        let m = Finding::Fell {
+            family: "alg".into(),
+            found_bp: 3_928,
+            floor_bp: 3_956,
+        }
+        .to_string();
+        assert!(
+            m.contains("alg") && m.contains("39.28%") && m.contains("39.56%"),
+            "{m}"
+        );
+    }
+
+    #[test]
+    fn shrank_says_the_deletion_may_be_intended() {
+        let m = Finding::Shrank {
+            family: "bound".into(),
+            found: 171,
+            floor: 172,
+        }
+        .to_string();
+        assert!(
+            m.contains("population_floor"),
+            "names the pin to lower: {m}"
+        );
+        assert!(m.contains("dated note"), "{m}");
+    }
+
+    #[test]
+    fn slack_cites_the_rule_it_enforces() {
+        let m = Finding::Slack {
+            family: "bound".into(),
+            found_bp: 9_942,
+            floor_bp: 9_941,
+        }
+        .to_string();
+        assert!(
+            m.contains("I-1"),
+            "a pin with slack has stopped gating: {m}"
+        );
+    }
+
+    #[test]
+    fn unpinned_and_stale_each_name_the_family_and_the_file() {
+        let u = Finding::Unpinned {
+            family: "alg".into(),
+        }
+        .to_string();
+        assert!(u.contains("alg") && u.contains(RATCHET), "{u}");
+        let s = Finding::Stale {
+            family: "ghost".into(),
+        }
+        .to_string();
+        assert!(s.contains("ghost") && s.contains(RATCHET), "{s}");
+    }
+
+    #[test]
+    fn outstanding_is_the_undischarged_remainder() {
+        assert_eq!(c(278, 110).outstanding(), 168);
+        // Saturating, so a clamped census never underflows into a huge number.
+        assert_eq!(c(5, 9).outstanding(), 0);
+    }
+
+    // ── The card, built from families ─────────────────────────────────
+
+    struct Counting(&'static str, Census);
+    impl Family for Counting {
+        fn name(&self) -> &'static str {
+            self.0
+        }
+        fn unit(&self) -> &'static str {
+            "unit"
+        }
+        fn census(&self, _: &BTreeMap<String, String>) -> Result<Census> {
+            Ok(self.1)
+        }
+    }
+
+    #[test]
+    fn every_family_contributes_one_row_in_order() {
+        let families: Vec<Box<dyn Family>> = vec![
+            Box::new(Counting("bound", c(172, 171))),
+            Box::new(Counting("alg", c(278, 110))),
+        ];
+        let card = card_of(&families, &BTreeMap::new()).expect("both families count");
+        assert_eq!(
+            card,
+            vec![
+                ("bound".to_string(), c(172, 171)),
+                ("alg".to_string(), c(278, 110))
+            ]
+        );
+    }
+
+    #[test]
+    fn a_census_discharging_more_than_it_declares_is_refused() {
+        // Not a formality: the ratio would exceed 100% and mean nothing.
+        let families: Vec<Box<dyn Family>> = vec![Box::new(Counting("bad", c(10, 11)))];
+        let err = card_of(&families, &BTreeMap::new())
+            .expect_err("11 of 10 is not a ratio")
+            .to_string();
+        assert!(err.contains("two different things"), "{err}");
+    }
+
+    #[test]
+    fn an_empty_card_has_no_badge_rather_than_a_green_one() {
+        let err = badge_json(&[]).expect_err("nothing to name").to_string();
+        assert!(err.contains("name nothing"), "{err}");
+    }
+
+    #[test]
+    fn the_badge_names_the_weakest_and_colours_by_it() {
+        let orange = badge_json(&[
+            ("bound".to_string(), c(172, 171)),
+            ("alg".to_string(), c(278, 110)),
+        ])
+        .expect("a card with rows has a badge");
+        assert!(orange.contains(r#""message":"alg 39.56%""#), "{orange}");
+        assert!(orange.contains("orange"), "under three quarters: {orange}");
+
+        let green = badge_json(&[("bound".to_string(), c(172, 171))]).expect("one row");
+        assert!(green.contains("brightgreen"), "{green}");
+
+        let yellow = badge_json(&[("x".to_string(), c(100, 80))]).expect("one row");
+        assert!(yellow.contains("yellow"), "{yellow}");
+    }
+
+    #[test]
+    fn the_badge_is_well_formed_json() {
+        let b = badge_json(&[("alg".to_string(), c(278, 110))]).expect("one row");
+        assert!(b.starts_with('{') && b.ends_with('}'), "{b}");
+        assert_eq!(b.matches('"').count() % 2, 0, "balanced quotes: {b}");
+        assert!(b.contains(r#""schemaVersion":1"#), "{b}");
     }
 
     #[test]

--- a/crates/xtask/src/scorecard.rs
+++ b/crates/xtask/src/scorecard.rs
@@ -157,7 +157,7 @@ impl Family for Bound {
 
 /// Every family on the card, in the order they are printed.
 pub fn families() -> Vec<Box<dyn Family>> {
-    vec![Box::new(Bound)]
+    vec![Box::new(Bound), Box::new(crate::alg::Alg)]
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/scripts/check-gates-can-fail.sh
+++ b/scripts/check-gates-can-fail.sh
@@ -674,12 +674,22 @@ perturb_scorecard_slack() {
     append_line "$1" 'fn _gate_of_gates_scorecard(authority: Authority) {}'
 }
 
+# One more law-bearing trait impl with no `lattice_laws!` declaration beside it:
+# two obligations the tree now states and nothing discharges. This is the `alg`
+# family's whole subject, and it drives the OTHER half of the scorecard's decision
+# procedure from the perturbation above -- Fell rather than Slack.
+perturb_scorecard_undischarged_law() {
+    append_line "$1" 'impl DistributiveLattice for _GateOfGatesAlg {}'
+}
+
 probe_xtask convergence crates/nucleus-tool-proxy/src/run_gate.rs \
     "one more affine type taken by reference" perturb_convergence_linearity
 probe_xtask bound crates/nucleus-tool-proxy/src/run_gate.rs \
     "one more witness accepted and dropped" perturb_bound_dropped_witness
 probe_xtask scorecard crates/nucleus-tool-proxy/src/run_gate.rs \
     "a family's pin gone slack under it" perturb_scorecard_slack
+probe_xtask scorecard crates/nucleus-tool-proxy/src/pod_mgmt.rs \
+    "a law the tree declares and nothing discharges" perturb_scorecard_undischarged_law
 probe_xtask assurance-required ci/assurance-required-ratchet.txt \
     "a claim whose falsifier the merge queue does not gate on, past the pin" perturb_assurance_required_pin
 probe_xtask pin-parity ci/lean/lean-toolchain \

--- a/scripts/check-gates-can-fail.sh
+++ b/scripts/check-gates-can-fail.sh
@@ -661,10 +661,25 @@ perturb_bound_dropped_witness() {
     append_line "$1" 'fn _gate_of_gates_dropped(_authority: Authority) {}'
 }
 
+# One more witness accepted under a CONSULTABLE name. The `bound` family rises to
+# 172/173, above its pinned floor, and the scorecard refuses: a floor with slack
+# under it has already stopped gating (ADR 0007 I-1), so the pin must be raised in
+# the same edit that earned it.
+#
+# Deliberately the opposite perturbation to the one above. A dropped witness would
+# red the scorecard too, but through `bound`'s INERT_TOTAL cross-check -- an error,
+# not a verdict, and it would prove the scorecard reds when a DEPENDENCY errors
+# rather than when its own decision procedure fires.
+perturb_scorecard_slack() {
+    append_line "$1" 'fn _gate_of_gates_scorecard(authority: Authority) {}'
+}
+
 probe_xtask convergence crates/nucleus-tool-proxy/src/run_gate.rs \
     "one more affine type taken by reference" perturb_convergence_linearity
 probe_xtask bound crates/nucleus-tool-proxy/src/run_gate.rs \
     "one more witness accepted and dropped" perturb_bound_dropped_witness
+probe_xtask scorecard crates/nucleus-tool-proxy/src/run_gate.rs \
+    "a family's pin gone slack under it" perturb_scorecard_slack
 probe_xtask assurance-required ci/assurance-required-ratchet.txt \
     "a claim whose falsifier the merge queue does not gate on, past the pin" perturb_assurance_required_pin
 probe_xtask pin-parity ci/lean/lean-toolchain \


### PR DESCRIPTION
## Why

A census of all 868 issues classified the 120 that are `bug`-labelled or carry an audit prefix. Four families account for ~90%:

| family | defects | the defect |
|---|---|---|
| `bound` | 72 (60%) | a mechanism exists and nothing binds it to the live path |
| `alg` | 15 (13%) | a law of a structure the code already claims to be |
| `life` | 14 (12%) | unbounded carrier, no durable state, no validity interval |
| `tot` | 7 (6%) | a function whose type says total, that panics |
| *novel* | 12 (10%) | DX, release infra, an SDK format mismatch |

The three families beside `bound` answer an objection worth stating: that a gate cannot find a property nobody thought of. For these, **nobody has to think of the property** — it is generated from a declaration. `AnyOf` as a join semilattice obliges commutativity, and #1222 ("AnyOf combinator is order-dependent — violates join commutativity") is an audit finding that would have been a failing generated test on day one.

`bound` landed this morning with no siblings and no card. This is the frame.

## What a family reports

```
  scorecard | bound 99.41%

  family  unit                              population  discharged         %  undeclared
  bound   witness-accepting parameter site         172         171    99.41%          32
```

- **population** — obligations the tree declares
- **discharged** — those a mechanism that can fail covers
- **undeclared** — sites carrying the family's *shape* that are not declared into it, so they sit outside the population

The third column is the lesson of `bound`: 32 of its 33 dropped witnesses are class-`N` legitimate doubles (`DenyAllEffects::run` refuses unconditionally, so it performs no act and correctly consults nothing), and a census without that column reads 83.82% where the truth is 99.41%. A number that silently omits its undeclared surface is the `law-mechanisms-manifest.txt` failure: a numerator with no denominator.

The shape is gatehouse's `trusted-base.txt` principle — *"THE POPULATION IS ENUMERATED, NOT LISTED … the assumptions are then the COMPLEMENT of what is pinned, over a closed population."*

## Why the badge names the weakest family

Not an average. Pooling numerators over pooled denominators gives a figure dominated by whichever family has the largest population — `tot` alone measures in the thousands — so a family at 0% would vanish into it. An unweighted mean has the same defect more slowly. Counting families at target is ungameable but cannot tell 14% from 84%.

Naming the weakest moves when the weakest improves, cannot hide a bad family behind a good one, and says where the next hour goes. ADR 0007 I-1: *a gate whose green is indistinguishable from vacuity* — an average would be one.

## Two pins per family

`.scorecard-ratchet.toml` carries `floor_bp` and `population_floor` per `[family.<name>]` section, the discipline `.bound-ratchet.toml` established. A floor on the ratio alone rewards deleting obligations, since numerator and denominator fall together while the ratio rises; a pin on the debt alone misses a ratio falling at constant debt. A missing pin is an error rather than a default, and a pin naming a family not on the card is a finding — a gate ranging over nothing.

The `bound` family is a thin adapter over `crate::bound`, not a second implementation: two censuses of one population that could disagree is the defect `bound` itself bails on. The card agrees with `cargo xtask bound` on every number.

## Verification

Probed red-then-green on the real tree **through the scorecard's own decision procedure**, not a dependency's:

```
ok    xtask scorecard — RED on a family's pin gone slack under it, GREEN when restored
```

One more witness accepted under a consultable name lifts `bound` to 172/173, above its floor, and the gate refuses the slack. The opposite perturbation — a dropped witness — would also red it, but via `bound`'s `INERT_TOTAL` cross-check, which would only prove the scorecard reds when a *dependency* errors.

Gate-of-gates: 39 probed, 0 unaccounted, exit 0. `cargo clippy -p xtask --all-targets --all-features -- -D warnings` clean. 154 xtask unit tests pass, 14 of them new — including that an empty population scores 0 and not 100%, that ties break by name so the badge does not flicker, and that deleting obligations to reach 100% is refused.

Registered in `manifest-guards.yml` flagless, as `probe_xtask`'s CI-PARITY guard requires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016t7JSuCtg4dC54HZjFgBjr