### PR TITLE
alg: the laws a declaration already claims, counted per law

### DIFF
--- a/.scorecard-ratchet.toml
+++ b/.scorecard-ratchet.toml
@@ -54,3 +54,37 @@
 # they are reported as `undeclared` rather than counted against the ratio.
 floor_bp = 9941
 population_floor = 172
+
+[family.alg]
+# 110 of 278 (type, law) obligations are discharged by a `lattice_laws!`
+# declaration. The unit is one law of one type, not one type: a per-type census
+# calls six types covered that between them check nine, six, four, four, four and
+# one of the fifteen their traits oblige.
+#
+# 21 types across 3 traits. Lattice obliges 9 laws, BoundedLattice 4 more,
+# DistributiveLattice 2 — exactly what verify_lattice_laws,
+# verify_bounded_lattice_laws and verify_distributive_laws check, counted by
+# reading them.
+#
+# MeetSemilattice and JoinSemilattice are implemented here and have NO verifier,
+# so their obligations are excluded rather than counted as undischarged: mixing
+# "a checker exists and is not wired" with "no checker exists" hides two
+# different debts behind one number. `convergence` made the same call for its
+# two unmeasurable arrows. When a semilattice verifier lands the population
+# rises, which is a number going up because the measurement got honest.
+#
+# 9 types carry meet/join/leq with no lattice trait impl at all -- WasiGrant,
+# WasiWorld, the two CRDT joins, RiskCost/WeakeningCost among them. No generic
+# suite can reach them, so they are reported as `undeclared` rather than counted
+# against the ratio: shape without declaration.
+#
+# UNDERSTATED, ON PURPOSE, FOR A STATED REASON: six types in
+# crates/portcullis/tests/proptest_lattice.rs are law-checked today by hand with
+# generated samples, and this gate cannot see them because it counts
+# declarations, not inferred coverage. Converting them STRENGTHENS those suites
+# from four laws to nine and may turn something red -- PathLattice,
+# CommandLattice, BudgetLattice and TimeLattice have never had associativity or
+# absorption checked -- so it is its own commit. This number rises when that
+# lands.
+floor_bp = 3956
+population_floor = 278

--- a/crates/portcullis-core/src/category.rs
+++ b/crates/portcullis-core/src/category.rs
@@ -643,6 +643,264 @@ pub fn verify_distributive_laws<L: Lattice + std::fmt::Debug>(samples: &[L]) -> 
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
+// Generated law suites
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Declare that a type discharges the laws its lattice traits oblige.
+///
+/// ```ignore
+/// lattice_laws!(conf_level, ConfLevel, ConfLevel::ALL.to_vec(), [lattice, bounded, distributive]);
+/// ```
+///
+/// generates a `#[cfg(test)] mod conf_level` with one `#[test]` per law family,
+/// each calling the corresponding `verify_*` function above.
+///
+/// # Why a macro and not a blanket impl
+///
+/// The question a gate wants to ask is "for every `impl Lattice for T`, is there
+/// a law check for `T`?", and answering it needs the check's *type argument*
+/// resolved — `verify_lattice_laws::<ConfLevel>` — which is a `typeck` question,
+/// not a grep. A first attempt at the grep attributed `CapabilityLevel`
+/// correctly, missed `ConfLevel`, `IFCLabel`, `Verdict` and `FlowState`, and
+/// picked up a bare generic parameter `L` as though it were a type.
+///
+/// So the covered set is not inferred, it is **declared**: one invocation per
+/// line, naming the type and the law families it discharges. Both sides of the
+/// ratio are then syntax a gate can see without a resolver, which is the
+/// discipline `inert_authority`'s closed `WITNESS` vocabulary already uses.
+///
+/// # The macro cannot over-claim
+///
+/// Listing `bounded` for a type that does not implement [`BoundedLattice`] fails
+/// to compile, because the generated body calls a function with that bound.
+/// Listing too *few* families is possible, and is exactly the gap the gate
+/// measures: population comes from the `impl` lines, discharged from these.
+///
+/// # Equality
+///
+/// The `verify_*` functions compare with `PartialEq`, so a type whose derived
+/// equality is finer than its law equality would report spurious violations. The
+/// tree's answer is to make `PartialEq` *be* the law equality —
+/// `LiteralDelegation` hand-writes it for precisely this reason, since deriving
+/// it "would break join commutativity: `a ∨ b` and `b ∨ a` list elements in
+/// different orders". No separate hook exists because nothing needs one; if a
+/// type ever does, that is the place to add it.
+#[macro_export]
+macro_rules! lattice_laws {
+    ($name:ident, $ty:ty, $samples:expr, [$($law:ident),+ $(,)?]) => {
+        #[cfg(test)]
+        mod $name {
+            #[allow(unused_imports)]
+            use super::*;
+            $( $crate::lattice_law_case!($law, $ty, $samples); )+
+        }
+    };
+}
+
+/// One law family for [`lattice_laws!`]. Not called directly.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! lattice_law_case {
+    (lattice, $ty:ty, $samples:expr) => {
+        #[test]
+        fn lattice() {
+            let samples: ::std::vec::Vec<$ty> = $samples;
+            $crate::category::assert_samples_are_witnesses(&samples, stringify!($ty));
+            let v = $crate::category::verify_lattice_laws(&samples);
+            assert!(
+                v.is_empty(),
+                "{} violates lattice laws: {:?}",
+                stringify!($ty),
+                v
+            );
+        }
+    };
+    (bounded, $ty:ty, $samples:expr) => {
+        #[test]
+        fn bounded() {
+            let samples: ::std::vec::Vec<$ty> = $samples;
+            $crate::category::assert_samples_are_witnesses(&samples, stringify!($ty));
+            let v = $crate::category::verify_bounded_lattice_laws(&samples);
+            assert!(
+                v.is_empty(),
+                "{} violates bounded lattice laws: {:?}",
+                stringify!($ty),
+                v
+            );
+        }
+    };
+    (distributive, $ty:ty, $samples:expr) => {
+        #[test]
+        fn distributive() {
+            let samples: ::std::vec::Vec<$ty> = $samples;
+            $crate::category::assert_samples_are_witnesses(&samples, stringify!($ty));
+            let v = $crate::category::verify_distributive_laws(&samples);
+            assert!(
+                v.is_empty(),
+                "{} violates distributivity: {:?}",
+                stringify!($ty),
+                v
+            );
+        }
+    };
+}
+
+/// Refuse a sample set that would make the law checks pass without testing them.
+///
+/// Every `verify_*` function above returns an empty violation list for an empty
+/// slice, and a one-element slice satisfies commutativity, associativity and
+/// distributivity for free — `a ∧ a = a ∧ a` holds in any structure. A suite
+/// seeded that way is green and proves nothing, which is the failure ADR 0007
+/// I-1 names: a gate whose green is indistinguishable from vacuity.
+///
+/// Three samples, at least two of them distinct: three because the associativity
+/// and distributivity loops are ternary and a shorter slice never varies all
+/// three indices, and two distinct because binary laws over a constant are
+/// tautologies.
+///
+/// # Panics
+///
+/// If `samples` is too short or carries no two distinct values.
+pub fn assert_samples_are_witnesses<L: PartialEq>(samples: &[L], ty: &str) {
+    assert!(
+        samples.len() >= 3,
+        "{ty}: {} sample(s) cannot witness a ternary law; the associativity and \
+         distributivity loops would never vary all three indices and the suite \
+         would be green without testing anything (ADR 0007 I-1)",
+        samples.len()
+    );
+    assert!(
+        samples.iter().any(|a| a != &samples[0]),
+        "{ty}: every sample is equal, so commutativity, associativity and \
+         distributivity hold as tautologies over a constant. The suite would be \
+         green without testing anything (ADR 0007 I-1)"
+    );
+}
+
+// ── Declared law suites ──────────────────────────────────────────────────────
+//
+// One invocation per type, naming the law families it discharges. These replace
+// eight hand-written test functions that called the `verify_*` helpers directly
+// and were, between them, four different spellings of the same three assertions.
+//
+// The families listed are exactly those the hand-written tests checked, so this
+// change is verdict-for-verdict identical. Where a type implements a trait whose
+// laws are NOT listed here — `CapabilityLattice` and `AuthorityLevel` both
+// implement `DistributiveLattice` and neither had a distributivity test — the
+// omission is now visible on one line instead of spread across a test module,
+// which is the point.
+
+lattice_laws!(
+    capability_level_laws,
+    CapabilityLevel,
+    vec![
+        CapabilityLevel::Never,
+        CapabilityLevel::LowRisk,
+        CapabilityLevel::Always,
+    ],
+    [bounded, distributive]
+);
+
+lattice_laws!(
+    capability_lattice_laws,
+    CapabilityLattice,
+    vec![
+        CapabilityLattice::bottom(),
+        CapabilityLattice::default(),
+        CapabilityLattice::top(),
+    ],
+    [bounded]
+);
+
+lattice_laws!(
+    conf_level_laws,
+    ConfLevel,
+    vec![ConfLevel::Public, ConfLevel::Internal, ConfLevel::Secret],
+    [bounded, distributive]
+);
+
+lattice_laws!(
+    integ_level_laws,
+    IntegLevel,
+    vec![
+        IntegLevel::Adversarial,
+        IntegLevel::Untrusted,
+        IntegLevel::Trusted,
+    ],
+    [bounded, distributive]
+);
+
+lattice_laws!(
+    authority_level_laws,
+    AuthorityLevel,
+    vec![
+        AuthorityLevel::NoAuthority,
+        AuthorityLevel::Informational,
+        AuthorityLevel::Suggestive,
+        AuthorityLevel::Directive,
+    ],
+    [bounded]
+);
+
+lattice_laws!(
+    derivation_class_laws,
+    DerivationClass,
+    vec![
+        DerivationClass::Deterministic,
+        DerivationClass::AIDerived,
+        DerivationClass::HumanPromoted,
+        DerivationClass::Mixed,
+        DerivationClass::OpaqueExternal,
+    ],
+    [bounded, distributive]
+);
+
+// Uniform freshness, because `Freshness::leq` has a known inconsistency with
+// `Freshness::meet` around `ttl_secs = 0` — see the NOTE above. Meet and join are
+// correct; only `leq` has the edge case, which is also why `IFCLabel` does not
+// implement `BoundedLattice` and why only `lattice` is listed here.
+lattice_laws!(
+    ifc_label_laws,
+    IFCLabel,
+    {
+        let fresh = Freshness {
+            observed_at: 1000,
+            ttl_secs: 3600,
+        };
+        vec![
+            IFCLabel {
+                freshness: fresh,
+                ..IFCLabel::bottom()
+            },
+            IFCLabel {
+                freshness: fresh,
+                ..IFCLabel::top()
+            },
+            IFCLabel {
+                freshness: fresh,
+                ..IFCLabel::default()
+            },
+            IFCLabel {
+                freshness: fresh,
+                ..IFCLabel::web_content(1000)
+            },
+        ]
+    },
+    [lattice]
+);
+
+lattice_laws!(
+    product_lattice_laws,
+    ProductLattice<ConfLevel, IntegLevel>,
+    vec![
+        ProductLattice(ConfLevel::Public, IntegLevel::Trusted),
+        ProductLattice(ConfLevel::Secret, IntegLevel::Adversarial),
+        ProductLattice(ConfLevel::Internal, IntegLevel::Untrusted),
+    ],
+    [bounded, distributive]
+);
+
+// ═══════════════════════════════════════════════════════════════════════════
 // Functoriality of label propagation
 // ═══════════════════════════════════════════════════════════════════════════
 
@@ -714,103 +972,36 @@ mod tests {
         (h.finish() as usize) % n
     }
 
+    // ── The sample guard, driven both ways ────────────────────────────
+    //
+    // `verify_lattice_laws(&[])` returns no violations, and so does a
+    // single-element slice: `a ∧ a = a ∧ a` holds in any structure. A suite
+    // seeded that way is green and tests nothing. These two are the probe.
+
+    #[test]
+    #[should_panic(expected = "cannot witness a ternary law")]
+    fn two_samples_cannot_witness_a_ternary_law() {
+        assert_samples_are_witnesses(&[ConfLevel::Public, ConfLevel::Secret], "ConfLevel");
+    }
+
+    #[test]
+    #[should_panic(expected = "tautologies over a constant")]
+    fn three_equal_samples_make_every_binary_law_a_tautology() {
+        assert_samples_are_witnesses(
+            &[ConfLevel::Public, ConfLevel::Public, ConfLevel::Public],
+            "ConfLevel",
+        );
+    }
+
+    #[test]
+    fn three_samples_with_two_distinct_are_accepted() {
+        assert_samples_are_witnesses(
+            &[ConfLevel::Public, ConfLevel::Public, ConfLevel::Secret],
+            "ConfLevel",
+        );
+    }
+
     // ── Generic lattice law tests ─────────────────────────────────────
-
-    #[test]
-    fn capability_level_lattice_laws() {
-        let samples = vec![
-            CapabilityLevel::Never,
-            CapabilityLevel::LowRisk,
-            CapabilityLevel::Always,
-        ];
-        let v = verify_bounded_lattice_laws(&samples);
-        assert!(v.is_empty(), "CapabilityLevel violations: {v:?}");
-    }
-
-    #[test]
-    fn capability_lattice_lattice_laws() {
-        let samples = vec![
-            CapabilityLattice::bottom(),
-            CapabilityLattice::default(),
-            CapabilityLattice::top(),
-        ];
-        let v = verify_bounded_lattice_laws(&samples);
-        assert!(v.is_empty(), "CapabilityLattice violations: {v:?}");
-    }
-
-    #[test]
-    fn conf_level_lattice_laws() {
-        let samples = vec![ConfLevel::Public, ConfLevel::Internal, ConfLevel::Secret];
-        let v = verify_bounded_lattice_laws(&samples);
-        assert!(v.is_empty(), "ConfLevel violations: {v:?}");
-    }
-
-    #[test]
-    fn integ_level_lattice_laws() {
-        let samples = vec![
-            IntegLevel::Adversarial,
-            IntegLevel::Untrusted,
-            IntegLevel::Trusted,
-        ];
-        let v = verify_bounded_lattice_laws(&samples);
-        assert!(v.is_empty(), "IntegLevel violations: {v:?}");
-    }
-
-    #[test]
-    fn authority_level_lattice_laws() {
-        let samples = vec![
-            AuthorityLevel::NoAuthority,
-            AuthorityLevel::Informational,
-            AuthorityLevel::Suggestive,
-            AuthorityLevel::Directive,
-        ];
-        let v = verify_bounded_lattice_laws(&samples);
-        assert!(v.is_empty(), "AuthorityLevel violations: {v:?}");
-    }
-
-    #[test]
-    fn derivation_class_lattice_laws() {
-        let samples = vec![
-            DerivationClass::Deterministic,
-            DerivationClass::AIDerived,
-            DerivationClass::HumanPromoted,
-            DerivationClass::Mixed,
-            DerivationClass::OpaqueExternal,
-        ];
-        let v = verify_bounded_lattice_laws(&samples);
-        assert!(v.is_empty(), "DerivationClass violations: {v:?}");
-    }
-
-    #[test]
-    fn ifc_label_lattice_laws() {
-        // Use samples with uniform freshness to avoid the known Freshness::leq
-        // inconsistency around ttl_secs=0 (see NOTE above BoundedLattice comment).
-        // Meet/join are fully correct; only leq has the edge case.
-        let fresh = Freshness {
-            observed_at: 1000,
-            ttl_secs: 3600,
-        };
-        let samples = vec![
-            IFCLabel {
-                freshness: fresh,
-                ..IFCLabel::bottom()
-            },
-            IFCLabel {
-                freshness: fresh,
-                ..IFCLabel::top()
-            },
-            IFCLabel {
-                freshness: fresh,
-                ..IFCLabel::default()
-            },
-            IFCLabel {
-                freshness: fresh,
-                ..IFCLabel::web_content(1000)
-            },
-        ];
-        let v = verify_lattice_laws(&samples);
-        assert!(v.is_empty(), "IFCLabel violations: {v:?}");
-    }
 
     // ── Legacy semilattice law tests (kept for coverage) ──────────────
 
@@ -975,18 +1166,6 @@ mod tests {
     // ── Product lattice tests ─────────────────────────────────────────
 
     #[test]
-    fn product_lattice_laws() {
-        use super::ProductLattice;
-        let samples = vec![
-            ProductLattice(ConfLevel::Public, IntegLevel::Trusted),
-            ProductLattice(ConfLevel::Secret, IntegLevel::Adversarial),
-            ProductLattice(ConfLevel::Internal, IntegLevel::Untrusted),
-        ];
-        let v = verify_bounded_lattice_laws(&samples);
-        assert!(v.is_empty(), "ProductLattice violations: {v:?}");
-    }
-
-    #[test]
     fn product_lattice_pointwise() {
         use super::ProductLattice;
         let a = ProductLattice(CapabilityLevel::LowRisk, ConfLevel::Internal);
@@ -1042,69 +1221,6 @@ mod tests {
     }
 
     // ── Distributive lattice tests ────────────────────────────────────
-
-    #[test]
-    fn capability_level_distributive() {
-        let samples = vec![
-            CapabilityLevel::Never,
-            CapabilityLevel::LowRisk,
-            CapabilityLevel::Always,
-        ];
-        let v = super::verify_distributive_laws(&samples);
-        assert!(
-            v.is_empty(),
-            "CapabilityLevel distributivity violations: {v:?}"
-        );
-    }
-
-    #[test]
-    fn conf_level_distributive() {
-        let samples = vec![ConfLevel::Public, ConfLevel::Internal, ConfLevel::Secret];
-        let v = super::verify_distributive_laws(&samples);
-        assert!(v.is_empty(), "ConfLevel distributivity violations: {v:?}");
-    }
-
-    #[test]
-    fn integ_level_distributive() {
-        let samples = vec![
-            IntegLevel::Adversarial,
-            IntegLevel::Untrusted,
-            IntegLevel::Trusted,
-        ];
-        let v = super::verify_distributive_laws(&samples);
-        assert!(v.is_empty(), "IntegLevel distributivity violations: {v:?}");
-    }
-
-    #[test]
-    fn derivation_class_distributive() {
-        let samples = vec![
-            DerivationClass::Deterministic,
-            DerivationClass::AIDerived,
-            DerivationClass::HumanPromoted,
-            DerivationClass::Mixed,
-            DerivationClass::OpaqueExternal,
-        ];
-        let v = super::verify_distributive_laws(&samples);
-        assert!(
-            v.is_empty(),
-            "DerivationClass distributivity violations: {v:?}"
-        );
-    }
-
-    #[test]
-    fn product_lattice_distributive() {
-        use super::ProductLattice;
-        let samples = vec![
-            ProductLattice(ConfLevel::Public, IntegLevel::Trusted),
-            ProductLattice(ConfLevel::Secret, IntegLevel::Adversarial),
-            ProductLattice(ConfLevel::Internal, IntegLevel::Untrusted),
-        ];
-        let v = super::verify_distributive_laws(&samples);
-        assert!(
-            v.is_empty(),
-            "ProductLattice distributivity violations: {v:?}"
-        );
-    }
 
     // ── Monotone map tests ────────────────────────────────────────────
 

--- a/crates/xtask/src/alg.rs
+++ b/crates/xtask/src/alg.rs
@@ -1,0 +1,573 @@
+//! The `alg` family — laws a declaration already claims.
+//!
+//! # The defect
+//!
+//! Of the 120 audit-and-bug issues the 2026-09-11 census classified, 15 are a
+//! law of a structure the code already says it is. #1222: *"AnyOf combinator is
+//! order-dependent for RequiresApproval — violates join commutativity."* #735:
+//! *"DelegationScope subset check uses string equality — glob subsumption not
+//! evaluated"*, which is an ordering implemented as syntactic equality, the same
+//! bug gatehouse's `writ` fixed by making `globSubsumes` the rule. #747 and #740:
+//! a receipt hash over `format!("{:?}")` and a canonical encoding that admits a
+//! length-extension collision — injectivity and stability.
+//!
+//! None of these needed inventing. They are the laws of the structure the type
+//! declares itself to be, and they arrive with the declaration.
+//!
+//! # Population is (type, law), not (type, trait)
+//!
+//! "Does type `T` have a law check?" scores this tree far too well.
+//! `crates/portcullis/tests/proptest_lattice.rs` covers six types, and not to the
+//! same depth: `CapabilityLattice` has nine laws checked, `BudgetLattice` six,
+//! `CommandLattice`/`PathLattice`/`TimeLattice` four each — commutativity and
+//! idempotence only, no associativity, no absorption, no order laws — and
+//! `PermissionLattice` has one, `normalize_is_idempotent`, against the fifteen
+//! its three traits oblige. A per-type census calls all six covered.
+//!
+//! So the unit is one law of one type, and the obligation table is fixed:
+//!
+//! | trait | laws | which |
+//! |---|---|---|
+//! | `Lattice` | 9 | commutativity, associativity, idempotence for meet and join; two absorption; `leq`/meet consistency |
+//! | `BoundedLattice` | 4 | top and bottom identity, top and bottom annihilator |
+//! | `DistributiveLattice` | 2 | meet-over-join and its dual |
+//!
+//! Those are exactly what [`verify_lattice_laws`], [`verify_bounded_lattice_laws`]
+//! and [`verify_distributive_laws`] check, counted by reading them. A type
+//! implementing all three owes 15.
+//!
+//! [`verify_lattice_laws`]: https://docs.rs/portcullis-core
+//! [`verify_bounded_lattice_laws`]: https://docs.rs/portcullis-core
+//! [`verify_distributive_laws`]: https://docs.rs/portcullis-core
+//!
+//! # Why only these three traits
+//!
+//! `MeetSemilattice` and `JoinSemilattice` are implemented in this tree and have
+//! **no verifier at all**, so counting their obligations would mix "a checker
+//! exists and is not wired" with "no checker exists" — two different debts with
+//! two different fixes. `convergence` made the same call and said so: its two
+//! unmeasurable arrows are *"excluded because a hand-listed denominator is the
+//! metric equivalent of a gate that cannot fail."* When a semilattice verifier
+//! lands, its traits join the table here and the population rises, which is a
+//! number going up because the measurement got honest.
+//!
+//! # Discharged is declared, not inferred
+//!
+//! Asking "is there a law check for `T`?" needs the check's type argument
+//! resolved — a `typeck` question. A grep for it attributed `CapabilityLevel`
+//! correctly, missed `ConfLevel`, `IFCLabel`, `Verdict` and `FlowState`, and
+//! picked up a bare generic parameter `L` as though it were a type. So the
+//! numerator reads `lattice_laws!` invocations, which name their type and their
+//! families on one line, and both sides of the ratio are syntax without a
+//! resolver.
+//!
+//! A consequence to state plainly: **the six types covered by
+//! `proptest_lattice.rs` count as undischarged today.** They are checked, by
+//! hand, with generated samples — but not declared, so this gate cannot see
+//! them. Converting them is a strengthening (four laws to nine) that may turn
+//! something red, which is why it is its own commit rather than folded in here.
+//! Until it lands, the `alg` number understates real coverage for a stated
+//! reason, and it rises when the conversion happens.
+//!
+//! # Undeclared
+//!
+//! Types with `meet`, `join` or `leq` and no lattice trait impl are outside the
+//! population entirely: no generic suite can reach them. `WasiGrant`,
+//! `WasiWorld`, the two CRDT joins and `RiskCost`/`WeakeningCost` — the only
+//! hand-written `PartialOrd`/`Ord` in the workspace, antisymmetry and
+//! transitivity unverified — are the shape without the declaration. They are
+//! reported, not counted against the ratio, for the reason `bound`'s class-`N`
+//! sites are: a number that silently omits its own surface is a numerator with
+//! no denominator.
+
+use anyhow::Result;
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::inert_authority::scope_of;
+use crate::law_mechanisms::production_region;
+use crate::scorecard::{Census, Family};
+
+/// Laws `verify_lattice_laws` checks: commutativity, associativity and
+/// idempotence for meet and join (6), two absorption laws, and the
+/// `a ≤ b ⟺ a ∧ b = a` consistency check.
+const LATTICE_LAWS: usize = 9;
+
+/// Laws `verify_bounded_lattice_laws` adds: `a ∧ ⊤ = a`, `a ∨ ⊥ = a`,
+/// `a ∧ ⊥ = ⊥`, `a ∨ ⊤ = ⊤`.
+const BOUNDED_LAWS: usize = 4;
+
+/// Laws `verify_distributive_laws` checks: `a ∧ (b ∨ c) = (a ∧ b) ∨ (a ∧ c)`
+/// and its dual.
+const DISTRIBUTIVE_LAWS: usize = 2;
+
+/// The traits whose laws a verifier exists for, and what each obliges.
+///
+/// `BoundedLattice: Lattice`, so a bounded type also carries a `Lattice` impl
+/// and the nine arrive once from that row rather than twice.
+const OBLIGATIONS: [(&str, usize); 3] = [
+    ("Lattice", LATTICE_LAWS),
+    ("BoundedLattice", BOUNDED_LAWS),
+    ("DistributiveLattice", DISTRIBUTIVE_LAWS),
+];
+
+/// What one `lattice_laws!` family keyword discharges.
+///
+/// `bounded` discharges thirteen, not four: `verify_bounded_lattice_laws` calls
+/// `verify_lattice_laws` first, so declaring it covers the base lattice laws too.
+fn discharged_by(family: &str) -> usize {
+    match family {
+        "lattice" => LATTICE_LAWS,
+        "bounded" => LATTICE_LAWS + BOUNDED_LAWS,
+        "distributive" => DISTRIBUTIVE_LAWS,
+        _ => 0,
+    }
+}
+
+/// A trait impl found in the tree: which trait, for which type.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Impl {
+    pub trait_name: String,
+    pub type_name: String,
+}
+
+/// Find `impl [<generics>] [path::]Trait for Type` over one source region.
+///
+/// A grep, not a resolver — the trait vocabulary is a closed list for the same
+/// reason `inert_authority`'s witness vocabulary is. The spellings in this tree
+/// are `impl Lattice for X`, `impl crate::frame::Lattice for X` and
+/// `impl crate::category::BoundedLattice for X`, all of which this accepts, and
+/// the type is taken as the head identifier so `ProductLattice<A, B>` is
+/// `ProductLattice`.
+pub fn impls_in(region: &str) -> Vec<Impl> {
+    let mut out = Vec::new();
+    for line in region.lines() {
+        let t = line.trim_start();
+        let Some(rest) = t.strip_prefix("impl") else {
+            continue;
+        };
+        if !rest.starts_with(|c: char| c.is_whitespace() || c == '<') {
+            continue;
+        }
+        let Some(head) = rest.split('{').next() else {
+            continue;
+        };
+        let Some((before, after)) = head.rsplit_once(" for ") else {
+            continue;
+        };
+        // The trait is the last path segment before ` for `.
+        let trait_name = before
+            .rsplit(|c: char| c == ':' || c.is_whitespace())
+            .find(|s| !s.is_empty())
+            .unwrap_or("")
+            .trim_end_matches('>');
+        // Longest match first: `BoundedLattice` must not read as `Lattice`.
+        let Some((matched, _)) = OBLIGATIONS.iter().find(|(name, _)| *name == trait_name) else {
+            continue;
+        };
+        let type_name: String = after
+            .trim()
+            .trim_start_matches('&')
+            .chars()
+            .take_while(|c| c.is_ascii_alphanumeric() || *c == '_')
+            .collect();
+        if type_name.is_empty() {
+            continue;
+        }
+        out.push(Impl {
+            trait_name: (*matched).to_string(),
+            type_name,
+        });
+    }
+    out
+}
+
+/// A `lattice_laws!` invocation: the type it names and the families it lists.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Declaration {
+    pub type_name: String,
+    pub families: Vec<String>,
+}
+
+/// Find `lattice_laws!(name, Type, samples, [families])` over one source region.
+///
+/// Invocations span several lines once rustfmt has had them, so this walks to the
+/// matching `)` rather than reading a line. The type is the head identifier after
+/// the first comma, which is why `ProductLattice<ConfLevel, IntegLevel>` does not
+/// need comma-in-generics handling. The families are the bracketed list of
+/// lowercase identifiers immediately before the closing paren — unambiguous
+/// against the `vec![…]` in the samples argument, whose contents are not all
+/// lowercase.
+pub fn declarations_in(region: &str) -> Vec<Declaration> {
+    const NEEDLE: &str = "lattice_laws!(";
+    let mut out = Vec::new();
+    let mut search = 0usize;
+    while let Some(found) = region[search..].find(NEEDLE) {
+        let open = search + found + NEEDLE.len() - 1;
+        // `lattice_law_case!` and the `macro_rules!` definition do not contain
+        // this needle, but a qualified call `$crate::lattice_laws!(` would; the
+        // head check keeps the needle anchored to an identifier boundary.
+        let prev = region[..search + found].chars().next_back();
+        if matches!(prev, Some(c) if c.is_ascii_alphanumeric() || c == '_') {
+            search = open + 1;
+            continue;
+        }
+        let mut depth = 0usize;
+        let mut close = None;
+        for (i, c) in region[open..].char_indices() {
+            match c {
+                '(' => depth += 1,
+                ')' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        close = Some(open + i);
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+        let Some(close) = close else { break };
+        let span = &region[open + 1..close];
+        search = close + 1;
+
+        let Some((_, after_first_comma)) = span.split_once(',') else {
+            continue;
+        };
+        let type_name: String = after_first_comma
+            .trim_start()
+            .chars()
+            .take_while(|c| c.is_ascii_alphanumeric() || *c == '_')
+            .collect();
+        if type_name.is_empty() {
+            continue;
+        }
+        // The family list: the last bracketed run of lowercase identifiers.
+        let families = span
+            .rmatch_indices('[')
+            .find_map(|(i, _)| {
+                let rest = &span[i + 1..];
+                let end = rest.find(']')?;
+                let inner = &rest[..end];
+                let ok = !inner.is_empty()
+                    && inner.chars().all(|c| {
+                        c.is_ascii_lowercase() || c == '_' || c == ',' || c.is_whitespace()
+                    });
+                ok.then(|| {
+                    inner
+                        .split(',')
+                        .map(str::trim)
+                        .filter(|s| !s.is_empty())
+                        .map(str::to_string)
+                        .collect::<Vec<_>>()
+                })
+            })
+            .unwrap_or_default();
+        if families.is_empty() {
+            continue;
+        }
+        out.push(Declaration {
+            type_name,
+            families,
+        });
+    }
+    out
+}
+
+/// Types carrying a lattice-shaped method, by the impl block they live in.
+///
+/// Reuses `inert_authority::scope_of`, which attributes `impl Trait for Type` to
+/// `Type` — the same reason a type whose `meet` lives inside its trait impl is
+/// found here too, and then cancels out against the declared set.
+pub fn lattice_shaped(region: &str) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    let mut scope = String::from("<free>");
+    for line in region.lines() {
+        if let Some(s) = scope_of(line) {
+            scope = s;
+        }
+        let t = line.trim_start();
+        if (t.starts_with("fn meet") || t.starts_with("fn join") || t.starts_with("fn leq"))
+            && scope != "<free>"
+        {
+            out.insert(scope.clone());
+        }
+    }
+    out
+}
+
+/// The measured state of the family.
+#[derive(Debug, Clone, Default)]
+pub struct Report {
+    /// Obligations per type, summed over its law-bearing trait impls.
+    pub obliged: BTreeMap<String, usize>,
+    /// Obligations per type that a `lattice_laws!` invocation discharges,
+    /// clamped so a declaration can never claim more than the type owes.
+    pub declared: BTreeMap<String, usize>,
+    /// Types with a lattice-shaped method and no law-bearing trait impl.
+    pub undeclared: BTreeSet<String>,
+}
+
+/// The crate a tracked path belongs to, used to key types.
+///
+/// Two distinct types share the name `CapabilityLattice` — one at
+/// `nucleus-ifc-kernel/src/capability_lattice.rs:21` whose impls live in
+/// `portcullis-core`, one at `portcullis/src/capability.rs:115` whose impls live
+/// in `portcullis`. Both implement all three traits, so a bare-name key sums
+/// their obligations to 30 **and lets one declaration discharge both**. That is
+/// unsound in the numerator, which is the half that must never over-report.
+///
+/// Keying by the crate the `impl` or the declaration is written in separates
+/// them. The cost is that a declaration written in a different crate from the
+/// impl reads as undischarged; that direction understates coverage rather than
+/// inventing it, which is the error worth having.
+fn crate_of(path: &str) -> &str {
+    path.strip_prefix("crates/")
+        .and_then(|r| r.split('/').next())
+        .unwrap_or("<unknown>")
+}
+
+fn key(path: &str, type_name: &str) -> String {
+    format!("{}::{type_name}", crate_of(path))
+}
+
+pub fn report(corpus: &BTreeMap<String, String>) -> Report {
+    let mut obliged: BTreeMap<String, usize> = BTreeMap::new();
+    let mut declared: BTreeMap<String, usize> = BTreeMap::new();
+    let mut shaped: BTreeSet<String> = BTreeSet::new();
+
+    for (path, src) in corpus {
+        let region = production_region(src);
+        for i in impls_in(&region) {
+            let laws = OBLIGATIONS
+                .iter()
+                .find(|(n, _)| *n == i.trait_name)
+                .map_or(0, |(_, l)| *l);
+            *obliged.entry(key(path, &i.type_name)).or_insert(0) += laws;
+        }
+        for d in declarations_in(&region) {
+            let sum: usize = d.families.iter().map(|f| discharged_by(f)).sum();
+            *declared.entry(key(path, &d.type_name)).or_insert(0) += sum;
+        }
+        shaped.extend(lattice_shaped(&region).into_iter().map(|t| key(path, &t)));
+    }
+
+    // A declaration cannot discharge more than the type owes. Listing `bounded`
+    // on a type that only implements `Lattice` does not compile, so this clamp
+    // never fires in practice — but a census that could report more discharged
+    // than declared is measuring two different things, and the ratio would be
+    // meaningless rather than merely wrong.
+    for (ty, d) in &mut declared {
+        let cap = obliged.get(ty).copied().unwrap_or(0);
+        *d = (*d).min(cap);
+    }
+
+    let undeclared = shaped
+        .into_iter()
+        .filter(|t| !obliged.contains_key(t))
+        .collect();
+
+    Report {
+        obliged,
+        declared,
+        undeclared,
+    }
+}
+
+pub struct Alg;
+
+impl Family for Alg {
+    fn name(&self) -> &'static str {
+        "alg"
+    }
+
+    fn unit(&self) -> &'static str {
+        "(lattice type, law) obligation"
+    }
+
+    fn census(&self, corpus: &BTreeMap<String, String>) -> Result<Census> {
+        let r = report(corpus);
+        Ok(Census {
+            population: r.obliged.values().sum(),
+            discharged: r.declared.values().sum(),
+            undeclared: r.undeclared.len(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_bare_impl_is_found() {
+        let v = impls_in("impl Lattice for ConfLevel {\n");
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].trait_name, "Lattice");
+        assert_eq!(v[0].type_name, "ConfLevel");
+    }
+
+    #[test]
+    fn a_qualified_impl_is_found() {
+        let v = impls_in("impl crate::frame::Lattice for CommandLattice {\n");
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].type_name, "CommandLattice");
+    }
+
+    #[test]
+    fn bounded_does_not_read_as_lattice() {
+        // The whole obligation table turns on this: `BoundedLattice` owes 4, not
+        // 9, because the 9 arrive from the `Lattice` impl beside it.
+        let v = impls_in("impl BoundedLattice for CapabilityLevel {\n");
+        assert_eq!(v[0].trait_name, "BoundedLattice");
+    }
+
+    #[test]
+    fn generics_do_not_hide_the_trait_or_the_type() {
+        let v = impls_in("impl<A: Lattice, B: Lattice> Lattice for ProductLattice<A, B> {\n");
+        assert_eq!(v.len(), 1);
+        assert_eq!(v[0].trait_name, "Lattice");
+        assert_eq!(v[0].type_name, "ProductLattice");
+    }
+
+    #[test]
+    fn an_unrelated_trait_is_not_an_obligation() {
+        assert!(impls_in("impl Display for ConfLevel {\n").is_empty());
+        assert!(impls_in("impl LatticeOperation for Foo {\n").is_empty());
+    }
+
+    #[test]
+    fn an_inherent_impl_is_not_a_trait_impl() {
+        assert!(impls_in("impl ConfLevel {\n").is_empty());
+    }
+
+    #[test]
+    fn a_single_line_declaration_parses() {
+        let d = declarations_in("lattice_laws!(conf_laws, ConfLevel, s(), [bounded]);\n");
+        assert_eq!(d.len(), 1);
+        assert_eq!(d[0].type_name, "ConfLevel");
+        assert_eq!(d[0].families, vec!["bounded"]);
+    }
+
+    #[test]
+    fn a_multi_line_declaration_parses() {
+        let src = "\
+lattice_laws!(
+    conf_level_laws,
+    ConfLevel,
+    vec![ConfLevel::Public, ConfLevel::Internal, ConfLevel::Secret],
+    [bounded, distributive]
+);
+";
+        let d = declarations_in(src);
+        assert_eq!(d.len(), 1);
+        assert_eq!(d[0].type_name, "ConfLevel");
+        assert_eq!(d[0].families, vec!["bounded", "distributive"]);
+    }
+
+    #[test]
+    fn a_generic_type_argument_does_not_break_the_comma_split() {
+        // `ProductLattice<ConfLevel, IntegLevel>` carries a comma inside its
+        // generics; taking the head identifier sidesteps it entirely.
+        let src = "lattice_laws!(p, ProductLattice<ConfLevel, IntegLevel>, v(), [bounded]);\n";
+        let d = declarations_in(src);
+        assert_eq!(d[0].type_name, "ProductLattice");
+        assert_eq!(d[0].families, vec!["bounded"]);
+    }
+
+    #[test]
+    fn the_samples_vec_is_not_mistaken_for_the_family_list() {
+        let src = "lattice_laws!(n, T, vec![T::A, T::B, T::C], [lattice]);\n";
+        let d = declarations_in(src);
+        assert_eq!(d[0].families, vec!["lattice"]);
+    }
+
+    #[test]
+    fn bounded_discharges_the_base_laws_too() {
+        // verify_bounded_lattice_laws calls verify_lattice_laws first.
+        assert_eq!(discharged_by("bounded"), LATTICE_LAWS + BOUNDED_LAWS);
+        assert_eq!(discharged_by("lattice"), LATTICE_LAWS);
+        assert_eq!(discharged_by("distributive"), DISTRIBUTIVE_LAWS);
+        assert_eq!(discharged_by("nonsense"), 0);
+    }
+
+    #[test]
+    fn two_types_sharing_a_name_in_different_crates_are_not_one_type() {
+        // `CapabilityLattice` exists twice — nucleus-ifc-kernel and portcullis —
+        // and both implement all three traits. Under a bare-name key their
+        // obligations sum to 30 and ONE declaration discharges both, which
+        // over-reports the numerator. The crate keeps them apart.
+        let corpus = BTreeMap::from([
+            (
+                "crates/alpha/src/lib.rs".to_string(),
+                "impl Lattice for Shared {}\nlattice_laws!(s, Shared, v(), [lattice]);\n"
+                    .to_string(),
+            ),
+            (
+                "crates/beta/src/lib.rs".to_string(),
+                "impl Lattice for Shared {}\n".to_string(),
+            ),
+        ]);
+        let r = report(&corpus);
+        assert_eq!(r.obliged["alpha::Shared"], LATTICE_LAWS);
+        assert_eq!(r.obliged["beta::Shared"], LATTICE_LAWS);
+        assert_eq!(r.declared.get("alpha::Shared"), Some(&LATTICE_LAWS));
+        assert_eq!(
+            r.declared.get("beta::Shared"),
+            None,
+            "alpha's declaration must not discharge beta's obligations"
+        );
+    }
+
+    #[test]
+    fn a_type_with_meet_and_no_trait_impl_is_undeclared() {
+        let corpus = BTreeMap::from([(
+            "crates/demo/src/lib.rs".to_string(),
+            "impl WasiGrant {\n    fn meet(&self, o: &Self) -> Self { todo!() }\n}\n".to_string(),
+        )]);
+        let r = report(&corpus);
+        assert!(r.undeclared.contains("demo::WasiGrant"));
+        assert!(r.obliged.is_empty());
+    }
+
+    #[test]
+    fn a_declared_type_is_not_also_counted_as_undeclared() {
+        let corpus = BTreeMap::from([(
+            "crates/demo/src/lib.rs".to_string(),
+            "impl Lattice for ConfLevel {\n    fn meet(&self, o: &Self) -> Self { todo!() }\n}\n"
+                .to_string(),
+        )]);
+        let r = report(&corpus);
+        assert!(r.undeclared.is_empty());
+        assert_eq!(r.obliged["demo::ConfLevel"], LATTICE_LAWS);
+    }
+
+    #[test]
+    fn a_declaration_cannot_discharge_more_than_the_type_owes() {
+        let corpus = BTreeMap::from([(
+            "crates/demo/src/lib.rs".to_string(),
+            "impl Lattice for T {}\nlattice_laws!(t, T, s(), [bounded, distributive]);\n"
+                .to_string(),
+        )]);
+        let r = report(&corpus);
+        assert_eq!(r.obliged["demo::T"], LATTICE_LAWS);
+        assert_eq!(
+            r.declared["demo::T"], LATTICE_LAWS,
+            "clamped to what is owed"
+        );
+    }
+
+    #[test]
+    fn obligations_sum_across_the_traits_a_type_implements() {
+        let corpus = BTreeMap::from([(
+            "crates/demo/src/lib.rs".to_string(),
+            "impl Lattice for T {}\nimpl BoundedLattice for T {}\nimpl DistributiveLattice for T {}\n"
+                .to_string(),
+        )]);
+        let r = report(&corpus);
+        assert_eq!(
+            r.obliged["demo::T"],
+            LATTICE_LAWS + BOUNDED_LAWS + DISTRIBUTIVE_LAWS,
+            "a type implementing all three owes 15"
+        );
+    }
+}

--- a/crates/xtask/src/alg.rs
+++ b/crates/xtask/src/alg.rs
@@ -557,6 +557,25 @@ lattice_laws!(
     }
 
     #[test]
+    fn the_family_entry_point_reports_the_three_numbers_the_card_prints() {
+        // The scorecard calls this, not `report`; an untested adapter is how a
+        // correct census reaches the card wrong.
+        let corpus = BTreeMap::from([(
+            "crates/demo/src/lib.rs".to_string(),
+            "impl Lattice for Declared {}\n\
+             impl BoundedLattice for Declared {}\n\
+             lattice_laws!(d, Declared, v(), [lattice]);\n\
+             impl Orphan {\n    fn meet(&self, o: &Self) -> Self { todo!() }\n}\n"
+                .to_string(),
+        )]);
+        let c = Alg.census(&corpus).expect("the census succeeds");
+        assert_eq!(c.population, LATTICE_LAWS + BOUNDED_LAWS, "9 + 4 obliged");
+        assert_eq!(c.discharged, LATTICE_LAWS, "only `lattice` declared");
+        assert_eq!(c.undeclared, 1, "Orphan has meet and no trait impl");
+        assert_eq!(c.basis_points(), 6_923, "9 of 13");
+    }
+
+    #[test]
     fn obligations_sum_across_the_traits_a_type_implements() {
         let corpus = BTreeMap::from([(
             "crates/demo/src/lib.rs".to_string(),

--- a/crates/xtask/src/inert_authority.rs
+++ b/crates/xtask/src/inert_authority.rs
@@ -302,7 +302,7 @@ fn inert_site(line: &str, witness: &[String]) -> bool {
 /// asks is "which implementation drops the witness", and two impls of the same
 /// trait — `RealEffects` and `DenyAllEffects` — are exactly what must not share
 /// a row.
-fn scope_of(line: &str) -> Option<String> {
+pub fn scope_of(line: &str) -> Option<String> {
     let t = line.trim_start();
     if let Some(rest) = t.strip_prefix("impl") {
         if !rest.starts_with(|c: char| c.is_whitespace() || c == '<') {

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -336,6 +336,7 @@ enum CiSpecCmd {
     },
 }
 
+mod alg;
 mod allowlist_gates;
 mod assurance_required;
 mod bound;

--- a/crates/xtask/src/scorecard.rs
+++ b/crates/xtask/src/scorecard.rs
@@ -157,7 +157,7 @@ impl Family for Bound {
 
 /// Every family on the card, in the order they are printed.
 pub fn families() -> Vec<Box<dyn Family>> {
-    vec![Box::new(Bound)]
+    vec![Box::new(Bound), Box::new(crate::alg::Alg)]
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/scripts/check-gates-can-fail.sh
+++ b/scripts/check-gates-can-fail.sh
@@ -674,12 +674,22 @@ perturb_scorecard_slack() {
     append_line "$1" 'fn _gate_of_gates_scorecard(authority: Authority) {}'
 }
 
+# One more law-bearing trait impl with no `lattice_laws!` declaration beside it:
+# two obligations the tree now states and nothing discharges. This is the `alg`
+# family's whole subject, and it drives the OTHER half of the scorecard's decision
+# procedure from the perturbation above -- Fell rather than Slack.
+perturb_scorecard_undischarged_law() {
+    append_line "$1" 'impl DistributiveLattice for _GateOfGatesAlg {}'
+}
+
 probe_xtask convergence crates/nucleus-tool-proxy/src/run_gate.rs \
     "one more affine type taken by reference" perturb_convergence_linearity
 probe_xtask bound crates/nucleus-tool-proxy/src/run_gate.rs \
     "one more witness accepted and dropped" perturb_bound_dropped_witness
 probe_xtask scorecard crates/nucleus-tool-proxy/src/run_gate.rs \
     "a family's pin gone slack under it" perturb_scorecard_slack
+probe_xtask scorecard crates/nucleus-tool-proxy/src/pod_mgmt.rs \
+    "a law the tree declares and nothing discharges" perturb_scorecard_undischarged_law
 probe_xtask assurance-required ci/assurance-required-ratchet.txt \
     "a claim whose falsifier the merge queue does not gate on, past the pin" perturb_assurance_required_pin
 probe_xtask pin-parity ci/lean/lean-toolchain \


### PR DESCRIPTION
## Why

Of the 120 audit-and-bug issues the census classified, **15 are a law of a structure the code already says it is**:

- **#1222** — *"AnyOf combinator is order-dependent for RequiresApproval — violates join commutativity"*
- **#735** — a `DelegationScope` subset check implemented as string equality: an ordering made syntactic, the same bug gatehouse's `writ` fixed by making `globSubsumes` the rule rather than comparing pattern strings
- **#747 / #740** — a receipt hash over `format!("{:?}")`, and a canonical encoding admitting a length-extension collision

None needed inventing. They are the laws of the structure the type declares itself to be, and they arrive with the declaration.

## The unit is one law of one type

That choice is the whole gate. **Per type this tree scores well** — `crates/portcullis/tests/proptest_lattice.rs` covers six. **Per law it scores 110 of 278**, because those six check 9, 6, 4, 4, 4 and 1 of the 15 laws their traits oblige:

| type | laws checked | missing |
|---|---|---|
| `CapabilityLattice` | 9 | absorption |
| `BudgetLattice` | 6 | join associativity, absorption, antisymmetry, transitivity |
| `CommandLattice`, `PathLattice`, `TimeLattice` | 4 each | associativity, absorption, leq consistency, all order laws |
| `PermissionLattice` | 1 (`normalize_is_idempotent`) | the other fourteen |

The obligation table is **read off the verifiers**, not invented: `Lattice` obliges 9, `BoundedLattice` 4 more, `DistributiveLattice` 2 — exactly what `verify_lattice_laws`, `verify_bounded_lattice_laws` and `verify_distributive_laws` check. 21 types, 278 obligations, independently re-derived before the pin was written.

## Commit 1 — a type declares the laws it discharges, on one line

`verify_*` have existed in `category.rs` for a long time. Thirteen hand-written test functions called them, in four different spellings, and which type had which family checked was a fact you could only learn by reading the whole test module.

`lattice_laws!(conf_level_laws, ConfLevel, samples, [bounded, distributive])` is that fact on one line. Thirteen functions become eight declarations generating **exactly thirteen tests** — `cargo test -- --list` names the same thirteen verdicts before and after.

**The macro cannot over-claim**: listing `bounded` for a type that doesn't implement `BoundedLattice` fails to compile. Listing too *few* is possible, and is exactly the gap worth measuring — `CapabilityLattice` and `AuthorityLevel` both implement `DistributiveLattice` and neither had a distributivity test.

`assert_samples_are_witnesses` refuses a seed that would pass without testing: `verify_lattice_laws(&[])` returns no violations, and a one-element slice satisfies commutativity, associativity and distributivity for free. Three samples, two distinct — driven both ways by `#[should_panic]` tests and probed on a real declared suite.

Equality needs no hook: the tree's answer to a type whose derived equality is finer than its law equality is to make `PartialEq` *be* the law equality, which `LiteralDelegation` hand-writes for exactly that reason. Nothing needs a separate hook, so none is built.

## Commit 2 — the `alg` family

```
  scorecard | alg 39.56%

  family  unit                              population  discharged         %  undeclared
  bound   witness-accepting parameter site         172         171    99.41%          32
  alg     (lattice type, law) obligation           278         110    39.56%           9
```

Three deliberate scoping calls, each stated in the ratchet:

- **`MeetSemilattice`/`JoinSemilattice` are excluded.** They are implemented here and have **no verifier at all**, so counting them would mix "a checker exists and is not wired" with "no checker exists" — two debts with different fixes behind one number. `convergence` made the same call for its two unmeasurable arrows.
- **Keyed by crate, not by bare type name.** Two distinct types are named `CapabilityLattice` (`nucleus-ifc-kernel`, `portcullis`) and both implement all three traits. A bare-name key sums them to 30 **and lets one declaration discharge both** — over-reporting the numerator, the half that must never over-report. The cost is that a declaration written in a different crate from its impl reads as undischarged; that understates rather than invents.
- **Understated on purpose, for a stated reason.** The six types in `proptest_lattice.rs` are law-checked today by hand, and this gate counts *declarations* rather than inferring coverage, so it cannot see them. Converting them strengthens those suites from four laws to nine and **may turn something red** — `PathLattice`, `CommandLattice`, `BudgetLattice` and `TimeLattice` have never had associativity or absorption checked — so it is its own commit. This number rises when that lands.

Nine types carry `meet`/`join`/`leq` with no lattice trait impl at all (`WasiGrant`, `WasiWorld`, the two CRDT joins, `RiskCost`/`WeakeningCost`). No generic suite can reach them, so they are reported as `undeclared` rather than counted against the ratio.

## Verification

Both halves of the scorecard's decision procedure driven red on the real tree:

| perturbation | result |
|---|---|
| one more law-bearing impl, no declaration | RED — `alg` 39.56% → 39.28% (`Fell`) |
| one more consultable witness | RED — `bound` above its floor (`Slack`) |

Gate-of-gates: 40 probed, 0 unaccounted, exit 0. `cargo clippy -p xtask -p portcullis-core --all-targets --all-features -- -D warnings` clean. 170 xtask unit tests and 612 portcullis-core tests pass — 16 of the xtask ones new, including that two same-named types in different crates are not one type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016t7JSuCtg4dC54HZjFgBjr