### PR TITLE
tot: how many crates have declared themselves panic-free

### DIFF
--- a/.scorecard-ratchet.toml
+++ b/.scorecard-ratchet.toml
@@ -142,8 +142,8 @@ population_floor = 278
 # 67 remaining crates need their sites fixed before they can declare; the two
 # tractable lints there are unwrap_used (87) and panic (10), and the 1528
 # arithmetic and indexing sites are a program, not a gate.
-floor_bp = 1625
-population_floor = 80
+floor_bp = 1728
+population_floor = 81
 
 [family.life]
 # 7 affine rights, 0 with a validity interval.

--- a/.scorecard-ratchet.toml
+++ b/.scorecard-ratchet.toml
@@ -88,3 +88,59 @@ population_floor = 172
 # lands.
 floor_bp = 3956
 population_floor = 278
+
+[family.tot]
+# 13 of 80 production crates declare themselves panic-free for the shipped
+# build. A function whose signature says `-> T` and panics is lying about its
+# type: #1203 (FlowTracker::label(0), u64 underflow on an unguarded sentinel),
+# #1184 (truncate() on multi-byte UTF-8), #481 (Ed25519 keygen .expect() in a
+# hot path), #2395 (a guest_cid other than 3 panics the guest, silently).
+#
+# THE SITE CENSUS, recorded here rather than gated, per clippy.toml's own rule:
+# "Where a mandate is not yet clean, the ADR records the measured count and the
+# ratchet instead of putting a red gate on main."
+#
+#   2026-09-11, production region, 1787 sites:
+#     arithmetic_side_effects  912
+#     indexing_slicing         616
+#     expect_used              155
+#     unwrap_used               87
+#     panic                     10
+#     unreachable                7
+#     todo                       0
+#
+#   cargo clippy --workspace --exclude nucleus-verifier-service --lib --bins \
+#     --all-features --message-format=json -- \
+#     -W clippy::unwrap_used -W clippy::expect_used -W clippy::indexing_slicing \
+#     -W clippy::arithmetic_side_effects -W clippy::panic \
+#     -W clippy::unreachable -W clippy::todo -A clippy::all
+#
+# That takes minutes and this gate runs in the fast Manifest Guards job, so the
+# gate does not recompute it. It asks the binding question, which is a grep: how
+# many crates have DECLARED themselves panic-free. A count of sites nothing
+# enforces is a measurement; a crate-level deny is a gate.
+#
+# WHY cfg_attr(not(test), deny(...)). assert! is a panic. Of the 13 crates
+# measuring zero over lib and bins, only 2 are also clean under --all-targets --
+# the other 11 are clean where it matters and panic in their own test modules,
+# correctly. So the declaration is scoped to the shipped build, the same line
+# law_mechanisms::production_region draws when it strips the test region.
+#
+# ALL SEVEN LINTS OR NONE. Six of seven leaves a way to panic, and crediting it
+# would make the ratio mean "mostly".
+#
+# UNMEASURABLE IS NOT CLEAN. Eighteen crates showed zero; five showed zero
+# because clippy never looked -- four are workspace excludes (wasm, maturin,
+# RISC-V) and nucleus-verifier-service needs a wasm artifact CI builds. Counting
+# them as discharged is ADR 0007 A-2 exactly: "I could not look" is never "I
+# looked and it was fine". They are reported as undeclared and the population is
+# the 80 crates clippy can see.
+#
+# 2026-09-11: seeded after annotating the 13 crates that were already clean, and
+# probing one of them red -- `v[0] + 1` in nucleus-pca fires indexing_slicing and
+# arithmetic_side_effects, and the crate is green again when it is removed. The
+# 67 remaining crates need their sites fixed before they can declare; the two
+# tractable lints there are unwrap_used (87) and panic (10), and the 1528
+# arithmetic and indexing sites are a program, not a gate.
+floor_bp = 1625
+population_floor = 80

--- a/.scorecard-ratchet.toml
+++ b/.scorecard-ratchet.toml
@@ -136,13 +136,21 @@ population_floor = 278
 # looked and it was fine". They are reported as undeclared and the population is
 # the 80 crates clippy can see.
 #
+# 2026-09-11 (second pass): nine more crates cleared and annotated, 13 -> 22.
+# Each was ONE arithmetic site -- a Vec::with_capacity hint or a counter -- where
+# saturating_add/mul is exactly equivalent: a capacity hint that saturates
+# allocates rather than wraps, and the loop fills the real size. 24 more crates
+# sit within 8 sites of clean; clearing all of them would reach 46 of 80 (57.5%).
+# The remainder need judgement about a contract rather than an arithmetic
+# rewrite, so they are not batched in here.
+#
 # 2026-09-11: seeded after annotating the 13 crates that were already clean, and
 # probing one of them red -- `v[0] + 1` in nucleus-pca fires indexing_slicing and
 # arithmetic_side_effects, and the crate is green again when it is removed. The
 # 67 remaining crates need their sites fixed before they can declare; the two
 # tractable lints there are unwrap_used (87) and panic (10), and the 1528
 # arithmetic and indexing sites are a program, not a gate.
-floor_bp = 1728
+floor_bp = 2839
 population_floor = 81
 
 [family.life]

--- a/.scorecard-ratchet.toml
+++ b/.scorecard-ratchet.toml
@@ -144,3 +144,48 @@ population_floor = 278
 # arithmetic and indexing sites are a program, not a gate.
 floor_bp = 1625
 population_floor = 80
+
+[family.life]
+# 7 affine rights, 0 with a validity interval.
+#
+# Every one-shot right in nucleus is affine and enforced as such. `Authority`
+# carries #[must_use = "an Authority that is never spent is an action that was
+# authorised and not taken"], is consumed by value in spend_on, and has two
+# compile_fail doctests proving replay (E0382) and clone (E0599) are rejected.
+# DecisionToken, CheckProof, DischargedBundle, PodRuntime, ServeToken and
+# VerifyToken are the same shape.
+#
+# NOT ONE OF THEM EXPIRES. A token minted at t=0 authorises at t=infinity, so the
+# window between time-of-check and time-of-use is unbounded on every right in the
+# system. The affine half of the discipline is done; the temporal half was never
+# started. 14 of the 120 audit-and-bug issues are lifecycle defects.
+#
+# WHY THIS SUB-CENSUS AND NOT THE OTHER TWO. Unbounded carriers have a real
+# defect behind them -- Kernel.trace is a Vec<Decision> appended once per allowed
+# operation with no cap, and FlowTracker never compacts while its capped mirror
+# FlowGraph carries four named ceilings -- but the population is "a collection in
+# a LONG-LIVED struct", and long-lived is a judgement. The measurement that
+# exists (902 collection fields, 328 grown and never bounded, 69 in structs whose
+# NAMES suggest they persist) rests on a regex over struct names, and a
+# denominator decided that way is the metric equivalent of a gate that cannot
+# fail. Transition totality has almost no population: three transition functions
+# in the whole repo, one of them on a mock whose trait declares no transition law
+# at all. Both are ADRs, not ratchets, and both become countable once their
+# design question is answered. convergence made the same call for two of its four
+# arrows and named them rather than averaging them in.
+#
+# WHY floor_bp = 0 IS PINNED AND NOT MISSING. A zero floor normally means a gate
+# that passes for every tree. Here the zero is still gated from both sides:
+# population_floor keeps the denominator from shrinking, and the slack check
+# fires the moment the first right gains an interval -- turning the gate red and
+# forcing the pin up to meet it. measured_zero = true makes that a deliberate
+# sentence rather than a value someone left out, and the parser refuses the key
+# once floor_bp rises above zero, so the acknowledgement cannot go stale.
+#
+# 2026-09-11: seeded at the measurement. Giving a right an expiry is a behaviour
+# change on a security boundary -- a clock at the mint site, a check at the
+# consume site, and a decision about what expiry means for an operation already
+# in flight. This gate states the debt exactly; it does not pay it.
+floor_bp = 0
+population_floor = 7
+measured_zero = true

--- a/crates/ctf-mcp/src/main.rs
+++ b/crates/ctf-mcp/src/main.rs
@@ -9,6 +9,23 @@
 //!   - submit_attack: Submit a tool-call sequence against a level
 //!   - run_challenge: Run attacks across multiple levels in one call
 
+// ADR 0007 totality: a function whose signature says it returns is lying if it
+// panics. Denied for the shipped build only — `assert!` IS a panic, so denying
+// inside `#[cfg(test)]` would forbid the thing tests are made of. This is the
+// same line `is_production_path` draws when it strips the test region.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::indexing_slicing,
+        clippy::arithmetic_side_effects,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo
+    )
+)]
+
 use std::collections::BTreeSet;
 
 use rmcp::handler::server::router::tool::ToolRouter;
@@ -245,7 +262,7 @@ impl VaultCtfServer {
                 meta.defenses.iter().map(|d| d.name.to_string()).collect();
             let mut engine = CtfEngine::new(&level);
             let result = engine.run_attack(&tool_calls);
-            total_score += result.score;
+            total_score = total_score.saturating_add(result.score);
             for d in &result.defenses_activated {
                 all_defenses.insert(d.clone());
             }

--- a/crates/nucleus-adversary-probe/src/main.rs
+++ b/crates/nucleus-adversary-probe/src/main.rs
@@ -39,6 +39,23 @@
 //! BREACH; withhold the proxy URL to force INCONCLUSIVE). In the real guest the
 //! defaults hit the real surfaces (`/proc/1/environ`, `/`, the public internet).
 
+// ADR 0007 totality: a function whose signature says it returns is lying if it
+// panics. Denied for the shipped build only — `assert!` IS a panic, so denying
+// inside `#[cfg(test)]` would forbid the thing tests are made of. This is the
+// same line `is_production_path` draws when it strips the test region.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::indexing_slicing,
+        clippy::arithmetic_side_effects,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo
+    )
+)]
+
 use std::io::{Read, Write};
 use std::net::TcpStream;
 use std::os::unix::net::UnixStream;
@@ -158,7 +175,7 @@ fn stage_exfil(breaches: &mut Vec<&'static str>, timeout: Duration) {
         let Ok(addr) = target.parse::<std::net::SocketAddr>() else {
             continue;
         };
-        probed += 1;
+        probed = probed.saturating_add(1);
         if TcpStream::connect_timeout(&addr, timeout).is_ok() {
             escaped = true;
         }

--- a/crates/nucleus-control-plane/src/lib.rs
+++ b/crates/nucleus-control-plane/src/lib.rs
@@ -21,6 +21,27 @@
 //! [`JobRunner`]: runner::JobRunner
 //! [`execute_job`]: executor::execute_job
 
+// ADR 0007 totality: a function whose signature says it returns is lying if it
+// panics. Denied for the shipped build only — `assert!` IS a panic, so denying
+// inside `#[cfg(test)]` would forbid the thing tests are made of. This is the
+// same line `is_production_path` draws when it strips the test region.
+//
+// Added because this crate measures ZERO of all seven lints today, per
+// `clippy.toml`'s own rule: entries are added only when the tree is already
+// clean of them.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::indexing_slicing,
+        clippy::arithmetic_side_effects,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo
+    )
+)]
+
 pub mod executor;
 pub mod runner;
 pub mod session_writer;

--- a/crates/nucleus-cred-broker/src/lib.rs
+++ b/crates/nucleus-cred-broker/src/lib.rs
@@ -43,6 +43,26 @@
 //! accurate `unused-wrapper` warning for the entry in `deny.toml`: the
 //! permission is declared ahead of its first use.
 
+// ADR 0007 totality: a function whose signature says it returns is lying if it
+// panics. Denied for the shipped build only — `assert!` IS a panic, so denying
+// inside `#[cfg(test)]` would forbid the thing tests are made of. This is the
+// same line `is_production_path` draws when it strips the test region.
+//
+// Added because this crate measures ZERO of all seven lints today, per
+// `clippy.toml`'s own rule: entries are added only when the tree is already
+// clean of them.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::indexing_slicing,
+        clippy::arithmetic_side_effects,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo
+    )
+)]
 // ADR 0007 B-3/E-2: a wildcard arm over an enum silently absorbs variants added
 // later, which is how a sum type loses a case without anyone reading the diff.
 // Denied here rather than workspace-wide because the workspace baseline is ~200

--- a/crates/nucleus-delivery-conformance/src/main.rs
+++ b/crates/nucleus-delivery-conformance/src/main.rs
@@ -22,6 +22,23 @@
 //!
 //! Exit codes: 0 conformant; 1 violation or missing/empty inventory; 2 usage.
 
+// ADR 0007 totality: a function whose signature says it returns is lying if it
+// panics. Denied for the shipped build only — `assert!` IS a panic, so denying
+// inside `#[cfg(test)]` would forbid the thing tests are made of. This is the
+// same line `is_production_path` draws when it strips the test region.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::indexing_slicing,
+        clippy::arithmetic_side_effects,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo
+    )
+)]
+
 use nucleus_ifc_kernel::env_classifier::env_key_material;
 use nucleus_ifc_kernel::extracted::identity::{Principal, ident_may_deliver};
 
@@ -39,7 +56,7 @@ fn parse_inventory(log: &str) -> Vec<String> {
     let mut names = Vec::new();
     for line in log.lines() {
         if let Some(idx) = line.find(INVENTORY_NEEDLE) {
-            let name = line[idx + INVENTORY_NEEDLE.len()..].trim();
+            let name = line[idx.saturating_add(INVENTORY_NEEDLE.len())..].trim();
             // Guest consoles interleave; keep only plausible env names so a
             // corrupted line cannot smuggle an unparseable entry past review.
             if !name.is_empty()

--- a/crates/nucleus-econ-types/src/lib.rs
+++ b/crates/nucleus-econ-types/src/lib.rs
@@ -30,6 +30,26 @@
 //! the Lean-parity proptests, signed receipts, or HTTP contracts.
 
 #![forbid(unsafe_code)]
+// ADR 0007 totality: a function whose signature says it returns is lying if it
+// panics. Denied for the shipped build only — `assert!` IS a panic, so denying
+// inside `#[cfg(test)]` would forbid the thing tests are made of. This is the
+// same line `is_production_path` draws when it strips the test region.
+//
+// Added because this crate measures ZERO of all seven lints today, per
+// `clippy.toml`'s own rule: entries are added only when the tree is already
+// clean of them.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::indexing_slicing,
+        clippy::arithmetic_side_effects,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo
+    )
+)]
 
 use std::fmt;
 use std::str::FromStr;

--- a/crates/nucleus-egress-probe/src/main.rs
+++ b/crates/nucleus-egress-probe/src/main.rs
@@ -65,6 +65,23 @@
 //! `scripts/check-egress-probe.sh` can point them at a hermetic peer it controls
 //! inside a netns.
 
+// ADR 0007 totality: a function whose signature says it returns is lying if it
+// panics. Denied for the shipped build only — `assert!` IS a panic, so denying
+// inside `#[cfg(test)]` would forbid the thing tests are made of. This is the
+// same line `is_production_path` draws when it strips the test region.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::indexing_slicing,
+        clippy::arithmetic_side_effects,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo
+    )
+)]
+
 use std::io::{Read, Write};
 use std::net::TcpStream;
 use std::os::unix::net::UnixStream;
@@ -161,7 +178,7 @@ fn check_denied_connects(fails: &mut Vec<String>, timeout: Duration) {
                 continue;
             }
         };
-        probed += 1;
+        probed = probed.saturating_add(1);
         match TcpStream::connect_timeout(&addr, timeout) {
             Err(err) => {
                 eprintln!("NUCLEUS_EGRESS_CHECK: denied-connect {addr} REFUSED ({err}) (ok)");

--- a/crates/nucleus-ifc/src/lib.rs
+++ b/crates/nucleus-ifc/src/lib.rs
@@ -42,6 +42,27 @@
 //! carry `Directive` authority. The labels propagate through the causal
 //! DAG via lattice join — taint cannot be laundered.
 
+// ADR 0007 totality: a function whose signature says it returns is lying if it
+// panics. Denied for the shipped build only — `assert!` IS a panic, so denying
+// inside `#[cfg(test)]` would forbid the thing tests are made of. This is the
+// same line `is_production_path` draws when it strips the test region.
+//
+// Added because this crate measures ZERO of all seven lints today, per
+// `clippy.toml`'s own rule: entries are added only when the tree is already
+// clean of them.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::indexing_slicing,
+        clippy::arithmetic_side_effects,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo
+    )
+)]
+
 // Re-export the public API from portcullis-core.
 pub use portcullis_core::flow::NodeKind;
 pub use portcullis_core::ifc_api::{FlowError, FlowTracker, SafetyCheck};

--- a/crates/nucleus-mcp/src/main.rs
+++ b/crates/nucleus-mcp/src/main.rs
@@ -1,3 +1,24 @@
+// ADR 0007 totality: a function whose signature says it returns is lying if it
+// panics. Denied for the shipped build only — `assert!` IS a panic, so denying
+// inside `#[cfg(test)]` would forbid the thing tests are made of. This is the
+// same line `is_production_path` draws when it strips the test region.
+//
+// Added because this crate measures ZERO of all seven lints today, per
+// `clippy.toml`'s own rule: entries are added only when the tree is already
+// clean of them.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::indexing_slicing,
+        clippy::arithmetic_side_effects,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo
+    )
+)]
+
 use anyhow::{Context, Result, anyhow};
 use clap::Parser;
 use nucleus_client::sign_http_headers;

--- a/crates/nucleus-memory/src/lib.rs
+++ b/crates/nucleus-memory/src/lib.rs
@@ -42,6 +42,27 @@
 //! labels** — confidentiality, integrity, authority class, and provenance bitflags.
 //! Tainted entries can't silently influence privileged operations.
 
+// ADR 0007 totality: a function whose signature says it returns is lying if it
+// panics. Denied for the shipped build only — `assert!` IS a panic, so denying
+// inside `#[cfg(test)]` would forbid the thing tests are made of. This is the
+// same line `is_production_path` draws when it strips the test region.
+//
+// Added because this crate measures ZERO of all seven lints today, per
+// `clippy.toml`'s own rule: entries are added only when the tree is already
+// clean of them.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::indexing_slicing,
+        clippy::arithmetic_side_effects,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo
+    )
+)]
+
 // Re-export the public API from portcullis-core.
 pub use portcullis_core::memory::{
     GovernedMemory, MemoryAuthority, MemoryEntry, MemoryLabel, RebuttalEntry, SchemaType,

--- a/crates/nucleus-net-probe/src/main.rs
+++ b/crates/nucleus-net-probe/src/main.rs
@@ -1,3 +1,24 @@
+// ADR 0007 totality: a function whose signature says it returns is lying if it
+// panics. Denied for the shipped build only — `assert!` IS a panic, so denying
+// inside `#[cfg(test)]` would forbid the thing tests are made of. This is the
+// same line `is_production_path` draws when it strips the test region.
+//
+// Added because this crate measures ZERO of all seven lints today, per
+// `clippy.toml`'s own rule: entries are added only when the tree is already
+// clean of them.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::indexing_slicing,
+        clippy::arithmetic_side_effects,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo
+    )
+)]
+
 use std::net::{SocketAddr, TcpStream, ToSocketAddrs};
 use std::time::Duration;
 

--- a/crates/nucleus-node-binding/src/lib.rs
+++ b/crates/nucleus-node-binding/src/lib.rs
@@ -58,6 +58,23 @@
 //! verify_binding(&binding, &passport_pk).expect("binding verifies");
 //! ```
 
+// ADR 0007 totality: a function whose signature says it returns is lying if it
+// panics. Denied for the shipped build only — `assert!` IS a panic, so denying
+// inside `#[cfg(test)]` would forbid the thing tests are made of. This is the
+// same line `is_production_path` draws when it strips the test region.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::indexing_slicing,
+        clippy::arithmetic_side_effects,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo
+    )
+)]
+
 use ed25519_dalek::Signer;
 use serde::{Deserialize, Serialize};
 
@@ -100,7 +117,13 @@ pub struct NodeBinding {
 /// This is a total, deterministic function of its inputs: the same
 /// `(node_id, principal)` pair always yields identical bytes.
 pub fn binding_message(node_id: &[u8; 32], principal: &str) -> Vec<u8> {
-    let mut msg = Vec::with_capacity(DOMAIN_PREFIX.len() + 32 + 1 + principal.len());
+    let mut msg = Vec::with_capacity(
+        DOMAIN_PREFIX
+            .len()
+            .saturating_add(32)
+            .saturating_add(1)
+            .saturating_add(principal.len()),
+    );
     msg.extend_from_slice(DOMAIN_PREFIX);
     msg.extend_from_slice(node_id);
     msg.push(b':');

--- a/crates/nucleus-pca/src/lib.rs
+++ b/crates/nucleus-pca/src/lib.rs
@@ -36,6 +36,27 @@
 //! - **Isolation** — the posture a backend can actually enforce, clamped **up**
 //!   to the nearest enforceable level (never weaker).
 
+// ADR 0007 totality: a function whose signature says it returns is lying if it
+// panics. Denied for the shipped build only — `assert!` IS a panic, so denying
+// inside `#[cfg(test)]` would forbid the thing tests are made of. This is the
+// same line `is_production_path` draws when it strips the test region.
+//
+// Added because this crate measures ZERO of all seven lints today, per
+// `clippy.toml`'s own rule: entries are added only when the tree is already
+// clean of them.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::indexing_slicing,
+        clippy::arithmetic_side_effects,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo
+    )
+)]
+
 use chrono::{TimeZone, Utc};
 
 use nucleus_ifc::decision::{FlowDeclaration, IfcVerdict};

--- a/crates/nucleus-podlist-probe/src/main.rs
+++ b/crates/nucleus-podlist-probe/src/main.rs
@@ -39,6 +39,27 @@
 //! host-side. This is why PASS here means "the listing is real and self-scoped,
 //! now go check exclusion" — not "cross-pod isolation holds".
 
+// ADR 0007 totality: a function whose signature says it returns is lying if it
+// panics. Denied for the shipped build only — `assert!` IS a panic, so denying
+// inside `#[cfg(test)]` would forbid the thing tests are made of. This is the
+// same line `is_production_path` draws when it strips the test region.
+//
+// Added because this crate measures ZERO of all seven lints today, per
+// `clippy.toml`'s own rule: entries are added only when the tree is already
+// clean of them.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::indexing_slicing,
+        clippy::arithmetic_side_effects,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo
+    )
+)]
+
 use std::io::{BufRead, BufReader, Write};
 use std::time::Duration;
 use vsock::VsockStream;

--- a/crates/nucleus-policy-kernel/src/lib.rs
+++ b/crates/nucleus-policy-kernel/src/lib.rs
@@ -34,6 +34,22 @@
 //! the property over the **entire** (infinite) request space. No floats, no
 //! `unsafe`, no zkVM toolchain in the default build.
 
+// ADR 0007 totality: a function whose signature says it returns is lying if it
+// panics. Denied for the shipped build only — `assert!` IS a panic, so denying
+// inside `#[cfg(test)]` would forbid the thing tests are made of. This is the
+// same line `is_production_path` draws when it strips the test region.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::indexing_slicing,
+        clippy::arithmetic_side_effects,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo
+    )
+)]
 // ADR 0007 B-3/E-2: a wildcard arm over an enum silently absorbs variants added
 // later, which is how a sum type loses a case without anyone reading the diff.
 // Denied here rather than workspace-wide because the workspace baseline is ~200
@@ -190,7 +206,14 @@ pub fn representative_requests(old: &Policy, new: &Policy) -> Vec<Request> {
     let principals = field_representatives(old, new, |r| &r.principal);
     let actions = field_representatives(old, new, |r| &r.action);
     let resources = field_representatives(old, new, |r| &r.resource);
-    let mut out = Vec::with_capacity(principals.len() * actions.len() * resources.len());
+    // A capacity HINT, so saturating is exactly right: an over-large product
+    // would allocate rather than wrap, and the loop below fills the real size.
+    let mut out = Vec::with_capacity(
+        principals
+            .len()
+            .saturating_mul(actions.len())
+            .saturating_mul(resources.len()),
+    );
     for p in &principals {
         for a in &actions {
             for res in &resources {

--- a/crates/nucleus-proto/src/lib.rs
+++ b/crates/nucleus-proto/src/lib.rs
@@ -1,3 +1,24 @@
+// ADR 0007 totality: a function whose signature says it returns is lying if it
+// panics. Denied for the shipped build only — `assert!` IS a panic, so denying
+// inside `#[cfg(test)]` would forbid the thing tests are made of. This is the
+// same line `is_production_path` draws when it strips the test region.
+//
+// Added because this crate measures ZERO of all seven lints today, per
+// `clippy.toml`'s own rule: entries are added only when the tree is already
+// clean of them.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::indexing_slicing,
+        clippy::arithmetic_side_effects,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo
+    )
+)]
+
 /// Generated gRPC types for nucleus-node service.
 pub mod nucleus_node {
     tonic::include_proto!("nucleus.node.v1");

--- a/crates/nucleus-provenance/src/lib.rs
+++ b/crates/nucleus-provenance/src/lib.rs
@@ -25,6 +25,22 @@
 //! clock) and fully unit-testable.
 
 #![forbid(unsafe_code)]
+// ADR 0007 totality: a function whose signature says it returns is lying if it
+// panics. Denied for the shipped build only — `assert!` IS a panic, so denying
+// inside `#[cfg(test)]` would forbid the thing tests are made of. This is the
+// same line `is_production_path` draws when it strips the test region.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::indexing_slicing,
+        clippy::arithmetic_side_effects,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo
+    )
+)]
 
 use std::collections::BTreeMap;
 
@@ -189,7 +205,11 @@ struct Subject {
 /// Standard DSSE Pre-Authentication Encoding:
 /// `"DSSEv1" SP LEN(type) SP type SP LEN(body) SP body` (LEN = ASCII-decimal).
 fn pae(payload_type: &str, payload: &[u8]) -> Vec<u8> {
-    let mut out = Vec::with_capacity(32 + payload_type.len() + payload.len());
+    let mut out = Vec::with_capacity(
+        32usize
+            .saturating_add(payload_type.len())
+            .saturating_add(payload.len()),
+    );
     out.extend_from_slice(b"DSSEv1 ");
     out.extend_from_slice(payload_type.len().to_string().as_bytes());
     out.push(b' ');

--- a/crates/nucleus-trust-registry/src/lib.rs
+++ b/crates/nucleus-trust-registry/src/lib.rs
@@ -1,3 +1,19 @@
+// ADR 0007 totality: a function whose signature says it returns is lying if it
+// panics. Denied for the shipped build only — `assert!` IS a panic, so denying
+// inside `#[cfg(test)]` would forbid the thing tests are made of. This is the
+// same line `is_production_path` draws when it strips the test region.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::indexing_slicing,
+        clippy::arithmetic_side_effects,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo
+    )
+)]
 // SPDX-License-Identifier: MIT
 //
 //! `nucleus-trust-registry` — "Let's Encrypt for agents": a PR-rooted,

--- a/crates/nucleus-trust-registry/src/main.rs
+++ b/crates/nucleus-trust-registry/src/main.rs
@@ -1,3 +1,19 @@
+// ADR 0007 totality: a function whose signature says it returns is lying if it
+// panics. Denied for the shipped build only — `assert!` IS a panic, so denying
+// inside `#[cfg(test)]` would forbid the thing tests are made of. This is the
+// same line `is_production_path` draws when it strips the test region.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::indexing_slicing,
+        clippy::arithmetic_side_effects,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo
+    )
+)]
 // SPDX-License-Identifier: MIT
 //
 //! `nucleus-trust-registry` CLI — the enrollment gate.

--- a/crates/nucleus-trust-registry/src/tlog.rs
+++ b/crates/nucleus-trust-registry/src/tlog.rs
@@ -369,7 +369,7 @@ pub fn verify_binding_inclusion(
         .iter()
         .filter(|s| s.trust_domain == trust_domain)
     {
-        candidates += 1;
+        candidates = candidates.saturating_add(1);
         let leaf_hash = binding_leaf(trust_domain, bundle_bytes, owner_id, stored.ts)?;
         if hex::encode(leaf_hash) != stored.leaf_hash_hex {
             continue;

--- a/crates/nucleus-verify-commerce/src/lib.rs
+++ b/crates/nucleus-verify-commerce/src/lib.rs
@@ -30,6 +30,23 @@
 //!   that any party can check with `nucleus_envelope::verify_bundle` or the
 //!   public verifier — the verify-then-pay artifact.
 
+// ADR 0007 totality: a function whose signature says it returns is lying if it
+// panics. Denied for the shipped build only — `assert!` IS a panic, so denying
+// inside `#[cfg(test)]` would forbid the thing tests are made of. This is the
+// same line `is_production_path` draws when it strips the test region.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::indexing_slicing,
+        clippy::arithmetic_side_effects,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo
+    )
+)]
+
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -253,7 +270,7 @@ where
 /// SHA-256 of `bytes` as a lowercase hex string.
 pub fn body_sha256_hex(bytes: &[u8]) -> String {
     let digest = Sha256::digest(bytes);
-    let mut s = String::with_capacity(digest.len() * 2);
+    let mut s = String::with_capacity(digest.len().saturating_mul(2));
     for b in digest {
         use std::fmt::Write as _;
         let _ = write!(s, "{b:02x}");

--- a/crates/nucleus-witness-gossip/src/lib.rs
+++ b/crates/nucleus-witness-gossip/src/lib.rs
@@ -44,6 +44,27 @@
 //! `b"cosignature/v1\n" + b"time <ts>\n" + note_body` — and checks the
 //! Ed25519 signature against it.
 
+// ADR 0007 totality: a function whose signature says it returns is lying if it
+// panics. Denied for the shipped build only — `assert!` IS a panic, so denying
+// inside `#[cfg(test)]` would forbid the thing tests are made of. This is the
+// same line `is_production_path` draws when it strips the test region.
+//
+// Added because this crate measures ZERO of all seven lints today, per
+// `clippy.toml`'s own rule: entries are added only when the tree is already
+// clean of them.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::indexing_slicing,
+        clippy::arithmetic_side_effects,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo
+    )
+)]
+
 use std::collections::{HashMap, HashSet};
 
 use ed25519_dalek::{Signature, VerifyingKey};

--- a/crates/portcullis-profiles/src/lib.rs
+++ b/crates/portcullis-profiles/src/lib.rs
@@ -26,6 +26,27 @@
 //! let needs_approval = kind.approval_required_operations();
 //! ```
 
+// ADR 0007 totality: a function whose signature says it returns is lying if it
+// panics. Denied for the shipped build only — `assert!` IS a panic, so denying
+// inside `#[cfg(test)]` would forbid the thing tests are made of. This is the
+// same line `is_production_path` draws when it strips the test region.
+//
+// Added because this crate measures ZERO of all seven lints today, per
+// `clippy.toml`'s own rule: entries are added only when the tree is already
+// clean of them.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::indexing_slicing,
+        clippy::arithmetic_side_effects,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo
+    )
+)]
+
 pub use portcullis_core::Operation;
 
 /// Application-specific task categories.

--- a/crates/portcullis-wasi/src/lib.rs
+++ b/crates/portcullis-wasi/src/lib.rs
@@ -65,6 +65,26 @@
 //! as a host-side monitor. This crate only claims the access-control mapping.
 
 #![forbid(unsafe_code)]
+// ADR 0007 totality: a function whose signature says it returns is lying if it
+// panics. Denied for the shipped build only — `assert!` IS a panic, so denying
+// inside `#[cfg(test)]` would forbid the thing tests are made of. This is the
+// same line `is_production_path` draws when it strips the test region.
+//
+// Added because this crate measures ZERO of all seven lints today, per
+// `clippy.toml`'s own rule: entries are added only when the tree is already
+// clean of them.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::indexing_slicing,
+        clippy::arithmetic_side_effects,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo
+    )
+)]
 
 pub mod ifc;
 

--- a/crates/portcullis/src/lattice.rs
+++ b/crates/portcullis/src/lattice.rs
@@ -55,7 +55,7 @@ use crate::{
 /// • Commands: intersection(allowed), union(blocked)
 /// • Time: max(valid_from), min(valid_until)
 /// ```
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct PermissionLattice {
     /// Unique identifier for this permission set
@@ -116,6 +116,44 @@ pub struct PermissionLattice {
     pub created_at: DateTime<Utc>,
     /// Who/what created this permission
     pub created_by: String,
+}
+
+/// Equality is over what the permissions PERMIT, not over how they were made.
+///
+/// Derived `PartialEq` compared `id`, `description` and `derived_from` — audit
+/// provenance that `meet`, `join` and `leq` all deliberately ignore. Since
+/// `meet` mints `id: Uuid::new_v4()` on every call and builds an order-dependent
+/// `description`, the derived equality made this type satisfy **none** of the
+/// fifteen laws its three lattice traits declare: `verify_lattice_laws` over
+/// three of its own constructors reported 99 violations, `a.meet(&a) != a` among
+/// them, and `a.meet(&b) == a` was never true for any `a` and `b` — which breaks
+/// the `a ≤ b ⟺ a ∧ b = a` correspondence by construction.
+///
+/// It also meant two policy-identical permission sets compared unequal, which is
+/// the wrong answer to the only question `==` is ever asked here.
+///
+/// This is the move [`crate::delegation`]'s neighbour already makes:
+/// `portcullis_core::attenuation::LiteralDelegation` hand-writes `PartialEq`
+/// because *"deriving `PartialEq` would break join commutativity: `a ∨ b` and
+/// `b ∨ a` list elements in different orders"*. Same wall, same answer — make
+/// `PartialEq` **be** the law equality rather than adding a second notion of
+/// equality beside it.
+///
+/// `leq` was never affected and is unchanged: it compares only the policy
+/// fields, so the one production enforcement site
+/// (`certificate.rs`'s `effective_permissions.leq(prev_permissions)`) was sound
+/// throughout.
+impl PartialEq for PermissionLattice {
+    fn eq(&self, other: &Self) -> bool {
+        self.capabilities == other.capabilities
+            && self.obligations == other.obligations
+            && self.paths == other.paths
+            && self.budget == other.budget
+            && self.commands == other.commands
+            && self.time == other.time
+            && self.minimum_isolation == other.minimum_isolation
+            && self.uninhabitable_constraint == other.uninhabitable_constraint
+    }
 }
 
 /// Parse a UUID from a string WITHOUT risking a panic on hostile input.
@@ -1441,6 +1479,117 @@ impl Default for EffectivePermissions {
 
 #[cfg(test)]
 mod tests {
+    // ── The laws PermissionLattice actually satisfies ─────────────────
+    //
+    // `verify_lattice_laws` is all-or-nothing, and this type does not pass it:
+    // absorption fails, for a reason worth naming rather than papering over.
+    // These pin the four laws that DO hold, so the equality fix below cannot
+    // regress silently, and `absorption_fails_because_meet_applies_a_closure`
+    // records the one that does not.
+
+    fn law_samples() -> Vec<PermissionLattice> {
+        vec![
+            PermissionLattice::permissive(),
+            PermissionLattice::restrictive(),
+            PermissionLattice::default(),
+        ]
+    }
+
+    #[test]
+    fn meet_and_join_are_idempotent() {
+        for a in law_samples() {
+            assert_eq!(a.meet(&a), a, "a ∧ a = a");
+            assert_eq!(a.join(&a), a, "a ∨ a = a");
+        }
+    }
+
+    #[test]
+    fn meet_and_join_are_commutative() {
+        for a in law_samples() {
+            for b in law_samples() {
+                assert_eq!(a.meet(&b), b.meet(&a), "a ∧ b = b ∧ a");
+                assert_eq!(a.join(&b), b.join(&a), "a ∨ b = b ∨ a");
+            }
+        }
+    }
+
+    #[test]
+    fn meet_and_join_are_associative() {
+        for a in law_samples() {
+            for b in law_samples() {
+                for c in law_samples() {
+                    assert_eq!(a.meet(&b.meet(&c)), a.meet(&b).meet(&c));
+                    assert_eq!(a.join(&b.join(&c)), a.join(&b).join(&c));
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn leq_agrees_with_meet() {
+        // `a ≤ b ⟺ a ∧ b = a`. This was FALSE for every pair before the
+        // equality fix, because `meet` mints a fresh `id` so `a.meet(&b) == a`
+        // could never hold.
+        for a in law_samples() {
+            for b in law_samples() {
+                assert_eq!(
+                    a.leq(&b),
+                    a.meet(&b) == a,
+                    "leq and meet must agree on {} ≤ {}",
+                    a.description,
+                    b.description
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn equality_is_over_what_is_permitted_not_over_provenance() {
+        let a = PermissionLattice::restrictive();
+        let mut b = a.clone();
+        b.id = Uuid::new_v4();
+        b.description = "a different label".to_string();
+        b.derived_from = Some(Uuid::new_v4());
+        assert_eq!(a, b, "provenance is an audit handle, not identity");
+    }
+
+    #[test]
+    fn absorption_fails_because_meet_applies_a_closure() {
+        // `a ∧ (a ∨ b) = a` is the law a closure operator breaks, and `meet`
+        // applies one: `IncompatibilityConstraint::enforcing()` adds approval
+        // obligations for the capabilities the meet produces. So the composite
+        // is `j(a ∧ b)` for a closure `j`, which is a NUCLEUS on a lattice and
+        // not a lattice meet.
+        //
+        // Recorded rather than fixed: the obligations it adds are the
+        // uninhabitable-state constraint doing its job, so "make absorption
+        // hold" would mean weakening it. The type nonetheless implements
+        // `Lattice`, `BoundedLattice` and `DistributiveLattice`, three traits
+        // whose laws it does not satisfy — and this repo already has the right
+        // vocabulary for what it IS: `frame::Nucleus`, and the
+        // `ConstraintNucleus` that `scripts/law-mechanisms-manifest.txt` records
+        // as declared-dead, with production using "hardcoded ifs" instead.
+        //
+        // This test exists so that stops being invisible. If absorption ever
+        // starts holding, something changed about the constraint and this test
+        // says so.
+        let a = PermissionLattice::restrictive();
+        let b = PermissionLattice::permissive();
+        let absorbed = a.meet(&a.join(&b));
+        assert_ne!(
+            absorbed, a,
+            "if this now passes, meet stopped applying the uninhabitable closure"
+        );
+        assert_eq!(
+            absorbed.capabilities, a.capabilities,
+            "the break is in obligations, not capabilities"
+        );
+        assert!(
+            absorbed.obligations != a.obligations,
+            "the closure added approval obligations the operand did not carry"
+        );
+    }
+
     use super::*;
 
     /// Regression: a non-ASCII `id` used to PANIC uuid's error formatter

--- a/crates/xtask/src/convergence.rs
+++ b/crates/xtask/src/convergence.rs
@@ -246,6 +246,23 @@ fn is_gate_harness(path: &str) -> bool {
     path.starts_with("crates/xtask/")
 }
 
+/// The corpus `affine_types` is meant to range over: production regions only,
+/// gate harnesses removed.
+///
+/// Extracted because `life` counts the same population and got a different
+/// number by passing raw sources — 6 against this function's 7. Raw sources
+/// include `#[cfg(test)]` regions, so a `Clone` impl written for a test rejected
+/// a type that is affine in the shipped build. Two gates disagreeing about one
+/// population is the defect `bound` bails on rather than reports, and the fix is
+/// for both to ask the same question through the same code.
+pub fn affine_corpus(corpus: &BTreeMap<String, String>) -> BTreeMap<String, String> {
+    corpus
+        .iter()
+        .filter(|(p, _)| !is_gate_harness(p))
+        .map(|(p, s)| (p.clone(), production_region(s)))
+        .collect()
+}
+
 pub struct Finding {
     pub row: &'static str,
     pub found: usize,
@@ -282,11 +299,7 @@ pub fn run() -> Result<i32> {
     // Production region only, and `git ls-files` rather than a filesystem walk —
     // the repo root carries an untracked worktree copy with a full `crates/`
     // tree, and a walk over-counted a sibling gate's number by 64%.
-    let corpus: BTreeMap<String, String> = tracked(is_production_path)?
-        .into_iter()
-        .filter(|(p, _)| !is_gate_harness(p))
-        .map(|(p, s)| (p, production_region(&s)))
-        .collect();
+    let corpus = affine_corpus(&tracked(is_production_path)?);
 
     let types = affine_types(&corpus);
     let per_type = count_linearity(&corpus, &types);

--- a/crates/xtask/src/law_mechanisms.rs
+++ b/crates/xtask/src/law_mechanisms.rs
@@ -333,14 +333,38 @@ pub fn is_production_path(path: &str) -> bool {
     if !path.ends_with(".rs") || !path.starts_with("crates/") {
         return false;
     }
-    let excluded = ["/tests/", "/benches/", "/examples/", "/fuzz/"];
+    // Directory segments that never ship. `/proofs/` and `/kani/` join the
+    // original four because a proof harness is not production code: it is
+    // written against a narrowed model on purpose, and counting it makes the
+    // crate holding the most proofs look like the crate with the most defects.
+    // 44 of `portcullis`'s 69 `.unwrap()` calls live in `src/kani.rs`, which
+    // ships in no binary — a gate reading them reports roughly twice the truth
+    // and names the wrong worst crate.
+    let excluded = [
+        "/tests/",
+        "/benches/",
+        "/examples/",
+        "/fuzz/",
+        "/proofs/",
+        "/kani/",
+    ];
     if excluded.iter().any(|seg| path.contains(seg)) {
         return false;
     }
-    !Path::new(path)
-        .file_name()
-        .and_then(|f| f.to_str())
-        .is_some_and(|f| f.ends_with("_tests.rs"))
+    let Some(file) = Path::new(path).file_name().and_then(|f| f.to_str()) else {
+        return false;
+    };
+    // `_tests.rs` was the original rule and missed `_test.rs` by one character;
+    // `crates/portcullis/src/certificate_convergence_test.rs` sat in the
+    // production corpus for as long as this helper has existed. `kani.rs` is the
+    // filename form of the `/kani/` segment above, and is the same exclusion the
+    // coverage gate already spells as `--ignore-filename-regex '…kani\.rs…'`.
+    // `build.rs` runs at compile time on the host and is not part of any shipped
+    // artifact.
+    !(file.ends_with("_test.rs")
+        || file.ends_with("_tests.rs")
+        || file == "kani.rs"
+        || file == "build.rs")
 }
 
 /// The verdict for one row: where its anchor was seen, outside its own file.
@@ -742,5 +766,50 @@ mod tests {
         assert!(!is_production_path("crates/a/tests/it.rs"));
         assert!(!is_production_path("crates/a/src/foo_tests.rs"));
         assert!(!is_production_path("crates/a/src/lib.md"));
+    }
+
+    #[test]
+    fn a_proof_harness_is_not_production_code() {
+        // A Kani harness is written against a deliberately narrowed model —
+        // `portcullis` marks whole fields `#[cfg(not(kani))]` — so counting it
+        // measures the proof, not the binary. Every real path in the tree:
+        assert!(!is_production_path("crates/portcullis/src/kani.rs"));
+        assert!(!is_production_path(
+            "crates/portcullis/src/kani/certificate_harnesses.rs"
+        ));
+        assert!(!is_production_path(
+            "crates/nucleus-econ-kernels/proofs/welfare_no_overflow.rs"
+        ));
+    }
+
+    #[test]
+    fn the_singular_test_suffix_was_missed_by_one_character() {
+        // `_tests.rs` was the original rule.
+        // `crates/portcullis/src/certificate_convergence_test.rs` has been in the
+        // production corpus for as long as this helper has existed.
+        assert!(!is_production_path("crates/a/src/foo_test.rs"));
+        assert!(!is_production_path(
+            "crates/portcullis/src/certificate_convergence_test.rs"
+        ));
+    }
+
+    #[test]
+    fn a_build_script_runs_on_the_host_and_ships_in_nothing() {
+        assert!(!is_production_path("crates/portcullis/build.rs"));
+        assert!(!is_production_path("crates/nucleus-proto/build.rs"));
+        // But a module merely NAMED after one is production.
+        assert!(is_production_path("crates/a/src/rebuild.rs"));
+    }
+
+    #[test]
+    fn the_tightening_does_not_swallow_ordinary_source() {
+        // The exclusions are segments and whole filenames, not substrings: a
+        // crate called `kani-utils` or a module called `proofs_index` still
+        // ships, and a gate that quietly stopped looking at them would be the
+        // failure this whole campaign is about.
+        assert!(is_production_path("crates/kani-utils/src/lib.rs"));
+        assert!(is_production_path("crates/a/src/proofs_index.rs"));
+        assert!(is_production_path("crates/a/src/kani_support.rs"));
+        assert!(is_production_path("crates/a/src/testing.rs"));
     }
 }

--- a/crates/xtask/src/life.rs
+++ b/crates/xtask/src/life.rs
@@ -1,0 +1,308 @@
+//! The `life` family — a right that never expires.
+//!
+//! # The defect
+//!
+//! Of the 120 audit-and-bug issues the 2026-09-11 census classified, 14 are a
+//! lifecycle: an unbounded carrier, state that does not survive a restart, or a
+//! missing validity interval. This family counts the third, because it is the
+//! one whose population can be enumerated from a source.
+//!
+//! Every one-shot right in nucleus is affine and enforced as such.
+//! `Authority` carries `#[must_use = "an Authority that is never spent is an
+//! action that was authorised and not taken"]`, is consumed by value in
+//! `spend_on`, and has two `compile_fail` doctests proving replay (E0382) and
+//! clone (E0599) are rejected. `DecisionToken`, `CheckProof`, `DischargedBundle`
+//! and `SessionCleanseToken` are the same shape.
+//!
+//! **Not one of them expires.** A token minted at t=0 authorises at t=∞, so the
+//! window between time-of-check and time-of-use is unbounded on every right in
+//! the system. The affine half of the discipline is done and the temporal half
+//! was never started.
+//!
+//! # Why this population and not the other two
+//!
+//! *Unbounded carriers* have a real defect behind them — `Kernel.trace` is a
+//! `Vec<Decision>` appended once per allowed operation with no cap, and
+//! `FlowTracker` never compacts while its capped mirror `FlowGraph` carries four
+//! named ceilings. But the population is "a collection in a long-lived struct",
+//! and long-lived is a judgement about the struct's role. The measurement that
+//! exists — 902 collection fields, 328 grown and never bounded, 69 in structs
+//! whose *names* suggest they persist — rests on that name heuristic, and a
+//! denominator decided by a regex over struct names is the metric equivalent of
+//! a gate that cannot fail.
+//!
+//! *Transition totality* has almost no population: the entire repo contains
+//! three transition functions — `MockMachineDriver::transition` (on the mock;
+//! the `MachineDriver` trait declares no transition law, so a real backend
+//! inherits nothing), `Compartment::can_transition_to` (returns `bool`, so
+//! nothing forces a caller to consult it) and `ProgressLevel::advance`. There is
+//! no `next_state`, no transition table, no `valid_transition` anywhere.
+//! `JobState` is written by direct variant construction at five sites, so
+//! `Completed → Queued` is writable. That is an ADR, not a ratchet.
+//!
+//! `convergence` made the same call and said so: two of its four arrows are
+//! *"excluded because a hand-listed denominator is the metric equivalent of a
+//! gate that cannot fail."* Both exclusions here are named rather than averaged
+//! in, and both become countable once their design question is answered.
+//!
+//! # The number is zero, and that is the finding
+//!
+//! 14 affine rights, 0 with a validity interval. `.scorecard-ratchet.toml`
+//! records it with `measured_zero = true` rather than leaving the ratio
+//! unpinned, because a zero is still gated from both sides here:
+//! `population_floor` keeps the denominator from shrinking, and the slack check
+//! fires the moment the first right gains an interval — turning the gate red and
+//! demanding the pin be raised to meet it.
+//!
+//! Giving a right an expiry is a behaviour change on a security boundary: it
+//! needs a clock at the mint site, a check at the consume site, and a decision
+//! about what expiry *means* for an operation already in flight. This gate
+//! states the debt exactly; it does not pay it.
+
+use anyhow::Result;
+use std::collections::BTreeMap;
+
+use crate::convergence::{affine_corpus, affine_types};
+use crate::scorecard::{Census, Family};
+
+/// Field names that carry a validity interval.
+///
+/// A closed vocabulary, like `inert_authority`'s witness list, and for the same
+/// reason: this is a grep, not a resolver, so the alternative is matching
+/// anything that looks temporal and crediting a `created_at` that nothing reads.
+/// An interval must say when the right STOPS being valid — `issued_at` alone
+/// does not, and is deliberately absent.
+pub const INTERVAL_FIELDS: [&str; 7] = [
+    "not_after",
+    "expires_at",
+    "expires_at_unix",
+    "expires_in",
+    "expiry",
+    "valid_until",
+    "valid_until_unix",
+];
+
+/// The body of `pub struct`/`pub enum` `ty`, if this source declares it.
+///
+/// Brace-counted from the declaration, so a nested type inside the body does not
+/// end it early and a field of a *later* struct is never read as this one's.
+pub fn declaration_body<'a>(src: &'a str, ty: &str) -> Option<&'a str> {
+    let needles = [format!("pub struct {ty}"), format!("pub enum {ty}")];
+    let start = needles.iter().find_map(|n| {
+        src.find(n.as_str()).filter(|i| {
+            // The name must end here: `pub struct Authority` must not match
+            // `pub struct AuthorityLevel`.
+            src[i + n.len()..]
+                .chars()
+                .next()
+                .is_none_or(|c| !c.is_alphanumeric() && c != '_')
+        })
+    })?;
+    let rest = &src[start..];
+    // A unit or tuple struct ends at the `;` before any `{`.
+    let brace = rest.find('{');
+    let semi = rest.find(';');
+    match (brace, semi) {
+        (None, _) => Some(rest.split(';').next().unwrap_or(rest)),
+        (Some(_), Some(s)) if s < brace? => Some(&rest[..s]),
+        (Some(b), _) => {
+            let mut depth = 0usize;
+            for (i, c) in rest[b..].char_indices() {
+                match c {
+                    '{' => depth += 1,
+                    '}' => {
+                        depth -= 1;
+                        if depth == 0 {
+                            return Some(&rest[..b + i + 1]);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            Some(rest)
+        }
+    }
+}
+
+/// Does this type's declaration carry a field saying when it stops being valid?
+pub fn has_validity_interval(body: &str) -> bool {
+    body.lines()
+        .map(str::trim_start)
+        .filter(|l| !l.starts_with("//"))
+        .any(|l| {
+            INTERVAL_FIELDS.iter().any(|f| {
+                // A field, not a mention: `expires_at: u64`, never a doc line or
+                // a method called `expires_at()`.
+                l.strip_prefix("pub ")
+                    .unwrap_or(l)
+                    .strip_prefix(*f)
+                    .is_some_and(|r| r.trim_start().starts_with(':'))
+            })
+        })
+}
+
+/// Per affine type, whether it carries a validity interval.
+pub fn report(corpus: &BTreeMap<String, String>) -> BTreeMap<String, bool> {
+    // The SAME shaping `convergence` applies, through the same function. Passing
+    // raw sources here counted 6 affine rights against convergence's 7, because
+    // a `#[cfg(test)]` region carried a `Clone` impl that rejected a type which
+    // is affine in the shipped build. Two gates disagreeing about one population
+    // is what `bound` bails on rather than reports.
+    let shaped = affine_corpus(corpus);
+    affine_types(&shaped)
+        .into_iter()
+        .map(|ty| {
+            let carries = shaped
+                .values()
+                .filter_map(|src| declaration_body(src, &ty))
+                .any(has_validity_interval);
+            (ty, carries)
+        })
+        .collect()
+}
+
+pub struct Life;
+
+impl Family for Life {
+    fn name(&self) -> &'static str {
+        "life"
+    }
+
+    fn unit(&self) -> &'static str {
+        "affine right"
+    }
+
+    fn census(&self, corpus: &BTreeMap<String, String>) -> Result<Census> {
+        let r = report(corpus);
+        Ok(Census {
+            population: r.len(),
+            discharged: r.values().filter(|carries| **carries).count(),
+            // The other two sub-censuses are excluded by name, not silently, and
+            // neither has a population this gate can enumerate — so there is no
+            // honest count of surface the denominator misses. Reporting a guess
+            // here would be worse than reporting none.
+            undeclared: 0,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_struct_body_ends_at_its_own_closing_brace() {
+        let src = "pub struct A {\n    x: u8,\n}\npub struct B {\n    expires_at: u64,\n}\n";
+        let a = declaration_body(src, "A").expect("A is declared");
+        assert!(!has_validity_interval(a), "B's field must not leak into A");
+        let b = declaration_body(src, "B").expect("B is declared");
+        assert!(has_validity_interval(b));
+    }
+
+    #[test]
+    fn a_nested_type_does_not_end_the_body_early() {
+        let src = "pub struct A {\n    inner: Inner,\n    // struct Nested { }\n    expires_at: u64,\n}\n";
+        let a = declaration_body(src, "A").expect("A is declared");
+        assert!(has_validity_interval(a));
+    }
+
+    #[test]
+    fn a_prefix_of_a_longer_name_is_not_the_type() {
+        // `pub struct Authority` must not match `pub struct AuthorityLevel`.
+        let src = "pub struct AuthorityLevel {\n    expires_at: u64,\n}\n";
+        assert!(declaration_body(src, "Authority").is_none());
+    }
+
+    #[test]
+    fn a_tuple_struct_has_a_body_and_no_interval() {
+        let src = "pub struct Token(u64);\n";
+        let b = declaration_body(src, "Token").expect("declared");
+        assert!(!has_validity_interval(b));
+    }
+
+    #[test]
+    fn a_doc_comment_mentioning_expiry_is_not_a_field() {
+        let src = "pub struct A {\n    /// expires_at: when this stops working\n    x: u8,\n}\n";
+        let b = declaration_body(src, "A").expect("declared");
+        assert!(!has_validity_interval(b), "a mention is not an interval");
+    }
+
+    #[test]
+    fn a_method_named_like_a_field_is_not_a_field() {
+        let src = "pub struct A {\n    x: u8,\n}\nimpl A {\n    pub fn expires_at(&self) -> u64 { 0 }\n}\n";
+        let b = declaration_body(src, "A").expect("declared");
+        assert!(!has_validity_interval(b));
+    }
+
+    #[test]
+    fn issued_at_alone_is_not_a_validity_interval() {
+        // An interval must say when the right STOPS being valid.
+        let src = "pub struct A {\n    issued_at: u64,\n}\n";
+        let b = declaration_body(src, "A").expect("declared");
+        assert!(!has_validity_interval(b));
+    }
+
+    #[test]
+    fn every_spelling_in_the_vocabulary_counts() {
+        for f in INTERVAL_FIELDS {
+            let src = format!("pub struct A {{\n    {f}: u64,\n}}\n");
+            let b = declaration_body(&src, "A").expect("declared");
+            assert!(has_validity_interval(b), "{f} should count");
+        }
+    }
+
+    #[test]
+    fn the_census_counts_affine_rights_and_their_intervals() {
+        let corpus = BTreeMap::from([(
+            "crates/demo/src/lib.rs".to_string(),
+            "#[must_use]\npub struct Timed {\n    expires_at: u64,\n}\n\
+             #[must_use]\npub struct Forever {\n    x: u8,\n}\n"
+                .to_string(),
+        )]);
+        let c = Life.census(&corpus).expect("the census succeeds");
+        assert_eq!(c.population, 2);
+        assert_eq!(c.discharged, 1);
+        assert_eq!(c.basis_points(), 5_000);
+    }
+
+    #[test]
+    fn a_clone_impl_written_for_tests_does_not_disqualify_a_production_right() {
+        // This is the bug that made `life` report 6 where `convergence` reported
+        // 7: passing raw sources let a `#[cfg(test)]` Clone impl reject a type
+        // that is affine in the shipped build. Both now shape the corpus through
+        // `affine_corpus`, so both ask the same question.
+        let corpus = BTreeMap::from([(
+            "crates/demo/src/lib.rs".to_string(),
+            "#[must_use]\npub struct Right {\n    x: u8,\n}\n\
+             #[cfg(test)]\nmod tests {\n    impl Clone for Right {\n        fn clone(&self) -> Self { todo!() }\n    }\n}\n"
+                .to_string(),
+        )]);
+        assert_eq!(
+            Life.census(&corpus).expect("succeeds").population,
+            1,
+            "a test-only Clone impl is not a production escape hatch"
+        );
+    }
+
+    #[test]
+    fn the_gate_harness_is_not_its_own_subject() {
+        // `convergence` excludes crates/xtask for the reason it learned the hard
+        // way: the module that names the shapes it counts would count itself.
+        let corpus = BTreeMap::from([(
+            "crates/xtask/src/demo.rs".to_string(),
+            "#[must_use]\npub struct Right {\n    x: u8,\n}\n".to_string(),
+        )]);
+        assert_eq!(Life.census(&corpus).expect("succeeds").population, 0);
+    }
+
+    #[test]
+    fn a_clonable_must_use_type_is_not_an_affine_right() {
+        // Replay is the thing an interval bounds; a type you can clone was never
+        // one-shot, so it is not this family's subject.
+        let corpus = BTreeMap::from([(
+            "crates/demo/src/lib.rs".to_string(),
+            "#[must_use]\n#[derive(Clone)]\npub struct Copyable {\n    x: u8,\n}\n".to_string(),
+        )]);
+        assert_eq!(Life.census(&corpus).expect("succeeds").population, 0);
+    }
+}

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -353,6 +353,7 @@ mod inert_authority;
 mod kani_coverage;
 mod law_mechanisms;
 mod lean_action_builds;
+mod life;
 mod line_ratchet;
 mod pin_parity;
 mod push_auth;

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -361,6 +361,7 @@ mod schedule_liveness;
 mod scoreboard;
 mod scorecard;
 mod self_pin;
+mod tot;
 
 fn main() -> Result<()> {
     match Cli::parse().command {

--- a/crates/xtask/src/scorecard.rs
+++ b/crates/xtask/src/scorecard.rs
@@ -161,6 +161,7 @@ pub fn families() -> Vec<Box<dyn Family>> {
         Box::new(Bound),
         Box::new(crate::alg::Alg),
         Box::new(crate::tot::Tot),
+        Box::new(crate::life::Life),
     ]
 }
 
@@ -174,6 +175,20 @@ pub struct Pin {
     pub floor_bp: u32,
     /// Minimum `population`. A shrinking surface is a decision, not a win.
     pub population_floor: usize,
+    /// This family measures zero and `floor_bp = 0` records that, rather than
+    /// leaving the ratio unpinned.
+    ///
+    /// A zero floor normally means a gate that passes for every tree, and it is
+    /// refused. It is admissible here for one reason: **a zero in this schema is
+    /// still gated from both sides.** `population_floor` keeps the denominator
+    /// from shrinking, and `Slack` fires the moment the ratio rises above the
+    /// pin — so the first obligation a family discharges turns the gate red and
+    /// demands the pin be raised to meet it. A measured zero cannot sit quietly
+    /// at zero while work happens.
+    ///
+    /// Requiring the key makes it a deliberate sentence in the ratchet rather
+    /// than a value someone left out.
+    pub measured_zero: bool,
 }
 
 /// Parse `.scorecard-ratchet.toml`: `[family.<name>]` sections, two keys each.
@@ -185,6 +200,7 @@ pub fn parse_ratchet(text: &str) -> Result<BTreeMap<String, Pin>> {
     let mut current: Option<String> = None;
     let mut floor_bp: Option<u32> = None;
     let mut population_floor: Option<usize> = None;
+    let mut measured_zero = false;
 
     // Close the section under construction, if any.
     fn close(
@@ -192,6 +208,7 @@ pub fn parse_ratchet(text: &str) -> Result<BTreeMap<String, Pin>> {
         name: &Option<String>,
         floor_bp: Option<u32>,
         population_floor: Option<usize>,
+        measured_zero: bool,
     ) -> Result<()> {
         let Some(name) = name else { return Ok(()) };
         let floor_bp = floor_bp.with_context(|| {
@@ -204,8 +221,19 @@ pub fn parse_ratchet(text: &str) -> Result<BTreeMap<String, Pin>> {
                  while the ratio rises."
             )
         })?;
-        if floor_bp == 0 {
-            bail!("[family.{name}] floor_bp=0 passes for every tree, including an empty one");
+        if floor_bp == 0 && !measured_zero {
+            bail!(
+                "[family.{name}] floor_bp=0 leaves the ratio unpinned. If the family genuinely \
+                 measures zero, say so with `measured_zero = true`: the zero is still gated from \
+                 both sides — population_floor keeps the denominator honest, and the first \
+                 obligation discharged trips the slack check and forces the pin up."
+            );
+        }
+        if floor_bp > 0 && measured_zero {
+            bail!(
+                "[family.{name}] carries measured_zero = true with floor_bp={floor_bp}. The \
+                 acknowledgement is stale: the family is no longer at zero, so delete the key."
+            );
         }
         if floor_bp > 10_000 {
             bail!("[family.{name}] floor_bp={floor_bp} exceeds 10000bp; the gate could never pass");
@@ -219,6 +247,7 @@ pub fn parse_ratchet(text: &str) -> Result<BTreeMap<String, Pin>> {
                 Pin {
                     floor_bp,
                     population_floor,
+                    measured_zero,
                 },
             )
             .is_some()
@@ -234,9 +263,16 @@ pub fn parse_ratchet(text: &str) -> Result<BTreeMap<String, Pin>> {
             continue;
         }
         if let Some(header) = line.strip_prefix('[').and_then(|s| s.strip_suffix(']')) {
-            close(&mut out, &current, floor_bp, population_floor)?;
+            close(
+                &mut out,
+                &current,
+                floor_bp,
+                population_floor,
+                measured_zero,
+            )?;
             floor_bp = None;
             population_floor = None;
+            measured_zero = false;
             let name = header.strip_prefix("family.").with_context(|| {
                 format!(
                     "line {}: only [family.<name>] sections are allowed",
@@ -272,10 +308,24 @@ pub fn parse_ratchet(text: &str) -> Result<BTreeMap<String, Pin>> {
                     format!("line {}: population_floor is not a number", lineno + 1)
                 })?);
             }
+            "measured_zero" => {
+                measured_zero = value.parse().with_context(|| {
+                    format!(
+                        "line {}: measured_zero is not `true` or `false`",
+                        lineno + 1
+                    )
+                })?;
+            }
             other => bail!("line {}: unknown key `{other}`", lineno + 1),
         }
     }
-    close(&mut out, &current, floor_bp, population_floor)?;
+    close(
+        &mut out,
+        &current,
+        floor_bp,
+        population_floor,
+        measured_zero,
+    )?;
 
     if out.is_empty() {
         bail!("{RATCHET} declares no families; the card would be empty and the gate vacuous");
@@ -619,6 +669,7 @@ mod tests {
             Pin {
                 floor_bp: 9_941,
                 population_floor: 172,
+                measured_zero: false,
             },
         )]);
         let card = vec![("bound".to_string(), c(172, 170))];
@@ -635,6 +686,7 @@ mod tests {
             Pin {
                 floor_bp: 5_000,
                 population_floor: 172,
+                measured_zero: false,
             },
         )]);
         let card = vec![("bound".to_string(), c(172, 171))];
@@ -652,6 +704,7 @@ mod tests {
             Pin {
                 floor_bp: 9_941,
                 population_floor: 172,
+                measured_zero: false,
             },
         )]);
         let card = vec![("bound".to_string(), c(100, 100))];
@@ -675,6 +728,7 @@ mod tests {
             Pin {
                 floor_bp: 1,
                 population_floor: 1,
+                measured_zero: false,
             },
         )]);
         assert!(matches!(
@@ -702,13 +756,70 @@ mod tests {
     }
 
     #[test]
-    fn a_zero_floor_is_rejected_rather_than_passing_vacuously() {
+    fn an_unacknowledged_zero_floor_is_rejected_rather_than_passing_vacuously() {
+        // Superseded in wording, not in force: a bare zero is still refused. The
+        // difference is that it can now be ADMITTED with `measured_zero = true`,
+        // which the next test pins.
         let text = "[family.bound]\nfloor_bp = 0\npopulation_floor = 1\n";
         assert!(
             parse_ratchet(text)
                 .unwrap_err()
                 .to_string()
-                .contains("every tree")
+                .contains("unpinned")
+        );
+    }
+
+    #[test]
+    fn a_measured_zero_must_be_acknowledged_not_merely_left_at_zero() {
+        let bare = "[family.life]\nfloor_bp = 0\npopulation_floor = 7\n";
+        assert!(
+            parse_ratchet(bare)
+                .unwrap_err()
+                .to_string()
+                .contains("measured_zero"),
+            "a zero floor needs a deliberate sentence, not an omission"
+        );
+        let acked = "[family.life]\nfloor_bp = 0\npopulation_floor = 7\nmeasured_zero = true\n";
+        let pins = parse_ratchet(acked).expect("an acknowledged zero parses");
+        assert_eq!(pins["life"].floor_bp, 0);
+        assert!(pins["life"].measured_zero);
+    }
+
+    #[test]
+    fn the_acknowledgement_cannot_go_stale() {
+        // Once the family rises above zero the key is a lie, and the parser says
+        // so rather than carrying it forward.
+        let stale = "[family.life]\nfloor_bp = 1428\npopulation_floor = 7\nmeasured_zero = true\n";
+        assert!(
+            parse_ratchet(stale)
+                .unwrap_err()
+                .to_string()
+                .contains("stale"),
+            "a measured_zero beside a non-zero floor is stale"
+        );
+    }
+
+    #[test]
+    fn a_family_at_zero_still_reds_on_its_first_discharge() {
+        // The whole defence of `measured_zero`: the slack check turns the first
+        // obligation discharged into a red that demands the pin be raised.
+        let pins = BTreeMap::from([(
+            "life".to_string(),
+            Pin {
+                floor_bp: 0,
+                population_floor: 7,
+                measured_zero: true,
+            },
+        )]);
+        assert!(matches!(
+            decide(&pins, &[("life".to_string(), c(7, 1))]).as_slice(),
+            [Finding::Slack { .. }]
+        ));
+        // …and on a shrinking denominator.
+        assert!(
+            decide(&pins, &[("life".to_string(), c(6, 0))])
+                .iter()
+                .any(|f| matches!(f, Finding::Shrank { .. }))
         );
     }
 

--- a/crates/xtask/src/scorecard.rs
+++ b/crates/xtask/src/scorecard.rs
@@ -157,7 +157,11 @@ impl Family for Bound {
 
 /// Every family on the card, in the order they are printed.
 pub fn families() -> Vec<Box<dyn Family>> {
-    vec![Box::new(Bound), Box::new(crate::alg::Alg)]
+    vec![
+        Box::new(Bound),
+        Box::new(crate::alg::Alg),
+        Box::new(crate::tot::Tot),
+    ]
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/crates/xtask/src/tot.rs
+++ b/crates/xtask/src/tot.rs
@@ -1,0 +1,300 @@
+//! The `tot` family — a function whose type says total, that panics.
+//!
+//! # The defect
+//!
+//! Of the 120 audit-and-bug issues the 2026-09-11 census classified, 7 are this:
+//! #1203, `FlowTracker::label(0)` panicking on a `u64` underflow because a
+//! sentinel id was not guarded; #1184, `truncate()` panicking on multi-byte
+//! UTF-8; #481, Ed25519 key generation panicking in a hot path via `.expect()`;
+//! #2395, a `guest_cid` other than 3 panicking the guest with nothing saying so.
+//!
+//! A function whose signature says `-> T` and panics is lying about its type.
+//! Nothing has to notice the specific panic: the lint family decides it.
+//!
+//! # The measurement, and why the gate does not take it
+//!
+//! Measured 2026-09-11 over the production region, reproducible with:
+//!
+//! ```sh
+//! cargo clippy --workspace --exclude nucleus-verifier-service --lib --bins \
+//!   --all-features --message-format=json -- \
+//!   -W clippy::unwrap_used -W clippy::expect_used -W clippy::indexing_slicing \
+//!   -W clippy::arithmetic_side_effects -W clippy::panic -W clippy::unreachable \
+//!   -W clippy::todo -A clippy::all
+//! ```
+//!
+//! | lint | sites |
+//! |---|---|
+//! | `arithmetic_side_effects` | 912 |
+//! | `indexing_slicing` | 616 |
+//! | `expect_used` | 155 |
+//! | `unwrap_used` | 87 |
+//! | `panic` | 10 |
+//! | `unreachable` | 7 |
+//! | `todo` | 0 |
+//! | **total** | **1787** |
+//!
+//! That census takes minutes and this gate runs in the fast `Manifest Guards`
+//! job, so the gate does not recompute it. It asks the *binding* question
+//! instead, which is a grep: **how many production crates have declared
+//! themselves panic-free?** A count of sites that nothing enforces is a
+//! measurement; a crate-level `deny` is a gate.
+//!
+//! # Why `cfg_attr(not(test), deny(…))` and not `deny(…)`
+//!
+//! `assert!` is a panic. Denying the family inside `#[cfg(test)]` forbids the
+//! thing tests are made of, and the numbers say so: of 13 crates measuring zero
+//! over lib and bins, only **2** are also clean under `--all-targets`. The other
+//! 11 are clean where it matters and panic in their own test modules, correctly.
+//!
+//! So the declaration is scoped to the shipped build. That is the same line
+//! `law_mechanisms::production_region` already draws when it strips the test
+//! region, and it is not a dodge: the defect class is a *production* function
+//! that panics.
+//!
+//! # Unmeasurable crates are not clean crates
+//!
+//! Eighteen crates showed zero in the first census. Five of them showed zero
+//! because **clippy never looked**: four are `exclude`d from the workspace
+//! (`exposure-web`, `nucleus-marketplace-dashboard-frontend`,
+//! `portcullis-python`, `portcullis-zkvm-guest` — wasm, maturin and RISC-V
+//! targets built separately) and `nucleus-verifier-service` needs a wasm
+//! artifact CI builds. Counting them as discharged would be ADR 0007 A-2
+//! exactly: *"I could not look" is never "I looked and it was fine."*
+//!
+//! They are reported as `undeclared` — surface the denominator does not reach —
+//! and the population is the 80 crates clippy can actually see.
+
+use anyhow::Result;
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::scorecard::{Census, Family};
+
+/// The lints the family is made of. A crate discharges the obligation by
+/// denying **all** of them: six of seven is a crate that can still panic.
+pub const LINTS: [&str; 7] = [
+    "clippy::unwrap_used",
+    "clippy::expect_used",
+    "clippy::indexing_slicing",
+    "clippy::arithmetic_side_effects",
+    "clippy::panic",
+    "clippy::unreachable",
+    "clippy::todo",
+];
+
+/// Crates clippy cannot reach, and why. Each must be a real workspace `exclude`
+/// or a documented build blocker; a crate on this list is neither discharged nor
+/// counted against the ratio.
+///
+/// This is a hand-list, which is normally the shape of a gate that cannot fail.
+/// It is bounded here by being checked against the tree: `unmeasurable_rows`
+/// refuses an entry naming a crate that does not exist, so it can go stale in
+/// only one direction and that direction is caught.
+pub const UNMEASURABLE: [(&str, &str); 5] = [
+    (
+        "exposure-web",
+        "workspace exclude: wasm32-unknown-unknown only",
+    ),
+    (
+        "nucleus-marketplace-dashboard-frontend",
+        "workspace exclude: Leptos CSR, built with trunk",
+    ),
+    ("portcullis-python", "workspace exclude: requires maturin"),
+    (
+        "portcullis-zkvm-guest",
+        "workspace exclude: RISC-V guest, built by risc0-build",
+    ),
+    (
+        "nucleus-verifier-service",
+        "needs a wasm artifact CI builds; excluded from the clippy invocation",
+    ),
+];
+
+/// Does `src` carry a crate-level denial of the whole family?
+///
+/// Accepts `deny` and `forbid`, bare or under any `cfg_attr`, because the
+/// question is whether the shipped build refuses the lint and not how the author
+/// spelled it. Requires **every** lint in [`LINTS`]: a partial denial leaves a
+/// way to panic, and crediting it would make the ratio mean "mostly".
+pub fn declares_totality(src: &str) -> bool {
+    // Inner attributes only, and only the ones that deny. A `#[allow]` naming
+    // the same lints must not read as a declaration.
+    let denies: String = src
+        .split("#![")
+        .skip(1)
+        .filter(|chunk| {
+            let head = chunk.split(']').next().unwrap_or("");
+            head.contains("deny") || head.contains("forbid")
+        })
+        .collect();
+    LINTS.iter().all(|l| denies.contains(l))
+}
+
+/// Every crate with at least one production source file.
+pub fn production_crates(corpus: &BTreeMap<String, String>) -> BTreeSet<String> {
+    corpus
+        .keys()
+        .filter_map(|p| p.strip_prefix("crates/"))
+        .filter_map(|r| r.split('/').next())
+        .map(str::to_string)
+        .collect()
+}
+
+/// Crates whose crate root declares the family.
+pub fn declaring_crates(corpus: &BTreeMap<String, String>) -> BTreeSet<String> {
+    corpus
+        .iter()
+        .filter(|(p, src)| {
+            (p.ends_with("/src/lib.rs") || p.ends_with("/src/main.rs")) && declares_totality(src)
+        })
+        .filter_map(|(p, _)| p.strip_prefix("crates/"))
+        .filter_map(|r| r.split('/').next())
+        .map(str::to_string)
+        .collect()
+}
+
+/// The unmeasurable crates that actually exist in the tree.
+///
+/// An entry naming a crate with no production source is a stale row and an
+/// error: it would shrink the denominator for a crate that is not there.
+pub fn unmeasurable_rows(present: &BTreeSet<String>) -> Result<BTreeSet<String>> {
+    let mut out = BTreeSet::new();
+    for (name, why) in UNMEASURABLE {
+        if !present.contains(name) {
+            anyhow::bail!(
+                "UNMEASURABLE names `{name}` ({why}) and no crate by that name has a production \
+                 source file. A stale row shrinks the denominator for a crate that is not there; \
+                 delete it."
+            );
+        }
+        out.insert(name.to_string());
+    }
+    Ok(out)
+}
+
+pub struct Tot;
+
+impl Family for Tot {
+    fn name(&self) -> &'static str {
+        "tot"
+    }
+
+    fn unit(&self) -> &'static str {
+        "production crate"
+    }
+
+    fn census(&self, corpus: &BTreeMap<String, String>) -> Result<Census> {
+        let present = production_crates(corpus);
+        let unreachable = unmeasurable_rows(&present)?;
+        let population = present.difference(&unreachable).count();
+        let discharged = declaring_crates(corpus).difference(&unreachable).count();
+        Ok(Census {
+            population,
+            discharged,
+            undeclared: unreachable.len(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn all_seven(kind: &str) -> String {
+        format!("#![{kind}({})]\n", LINTS.join(", "))
+    }
+
+    #[test]
+    fn a_bare_deny_of_every_lint_is_a_declaration() {
+        assert!(declares_totality(&all_seven("deny")));
+    }
+
+    #[test]
+    fn forbid_counts_too() {
+        assert!(declares_totality(&all_seven("forbid")));
+    }
+
+    #[test]
+    fn the_cfg_attr_form_the_tree_uses_counts() {
+        let src = format!(
+            "//! docs\n#![cfg_attr(not(test), deny(\n{}\n))]\n",
+            LINTS.join(",\n")
+        );
+        assert!(declares_totality(&src));
+    }
+
+    #[test]
+    fn six_of_seven_is_not_a_declaration() {
+        // A partial denial leaves a way to panic; crediting it would make the
+        // ratio mean "mostly".
+        let src = format!("#![deny({})]\n", LINTS[..6].join(", "));
+        assert!(!declares_totality(&src));
+    }
+
+    #[test]
+    fn an_allow_naming_the_same_lints_is_not_a_declaration() {
+        assert!(!declares_totality(&all_seven("allow")));
+        assert!(!declares_totality(&all_seven("warn")));
+    }
+
+    #[test]
+    fn a_crate_with_no_attribute_is_not_a_declaration() {
+        assert!(!declares_totality("pub fn f() {}\n"));
+    }
+
+    #[test]
+    fn only_a_crate_root_declares() {
+        // A module deep in the crate cannot deny for the crate.
+        let corpus = BTreeMap::from([("crates/demo/src/inner.rs".to_string(), all_seven("deny"))]);
+        assert!(declaring_crates(&corpus).is_empty());
+    }
+
+    #[test]
+    fn a_main_rs_declares_for_a_binary_crate() {
+        let corpus = BTreeMap::from([("crates/demo/src/main.rs".to_string(), all_seven("deny"))]);
+        assert_eq!(declaring_crates(&corpus).len(), 1);
+    }
+
+    #[test]
+    fn an_unmeasurable_crate_is_neither_discharged_nor_counted() {
+        // "I could not look" is never "I looked and it was fine" (A-2). The
+        // four workspace excludes and nucleus-verifier-service showed zero in
+        // the first census because clippy never ran on them.
+        let mut corpus =
+            BTreeMap::from([("crates/seen/src/lib.rs".to_string(), all_seven("deny"))]);
+        for (name, _) in UNMEASURABLE {
+            corpus.insert(format!("crates/{name}/src/lib.rs"), String::new());
+        }
+        let c = Tot.census(&corpus).expect("every unmeasurable row exists");
+        assert_eq!(c.population, 1, "only the crate clippy can see");
+        assert_eq!(c.discharged, 1);
+        assert_eq!(c.undeclared, UNMEASURABLE.len());
+        assert_eq!(c.basis_points(), 10_000);
+    }
+
+    #[test]
+    fn an_unmeasurable_crate_that_declares_is_still_not_credited() {
+        // Otherwise adding the attribute to a crate nothing compiles would raise
+        // the ratio for free.
+        let mut corpus = BTreeMap::new();
+        for (name, _) in UNMEASURABLE {
+            corpus.insert(format!("crates/{name}/src/lib.rs"), all_seven("deny"));
+        }
+        corpus.insert("crates/seen/src/lib.rs".to_string(), String::new());
+        let c = Tot.census(&corpus).expect("rows exist");
+        assert_eq!(
+            c.discharged, 0,
+            "a crate clippy cannot check discharges nothing"
+        );
+        assert_eq!(c.population, 1);
+    }
+
+    #[test]
+    fn a_stale_unmeasurable_row_is_an_error_not_a_smaller_denominator() {
+        let corpus = BTreeMap::from([("crates/only/src/lib.rs".to_string(), String::new())]);
+        let err = Tot
+            .census(&corpus)
+            .expect_err("the rows name absent crates");
+        assert!(err.to_string().contains("delete it"), "{err}");
+    }
+}

--- a/scripts/check-gates-can-fail.sh
+++ b/scripts/check-gates-can-fail.sh
@@ -691,6 +691,16 @@ perturb_scorecard_partial_totality() {
     sed -i.gate-bak 's/^        clippy::indexing_slicing,$//' "$1" && rm -f "$1.gate-bak"
 }
 
+# The first affine right to gain a validity interval. `life` is pinned at a
+# MEASURED zero -- 7 rights, none of which expires -- and the whole defence of
+# admitting a zero floor is that the slack check turns the first discharge into a
+# red demanding the pin be raised. This probe is that claim, on a real type: give
+# ServeToken an `expires_at` and the family goes 0.00% -> 14.28% and the gate
+# refuses to carry the stale zero forward.
+perturb_scorecard_first_expiry() {
+    sed -i.gate-bak 's/^pub struct ServeToken {$/pub struct ServeToken {\n    expires_at: u64,/' "$1" && rm -f "$1.gate-bak"
+}
+
 probe_xtask convergence crates/nucleus-tool-proxy/src/run_gate.rs \
     "one more affine type taken by reference" perturb_convergence_linearity
 probe_xtask bound crates/nucleus-tool-proxy/src/run_gate.rs \
@@ -702,6 +712,8 @@ probe_xtask scorecard crates/nucleus-tool-proxy/src/pod_mgmt.rs \
 probe_xtask scorecard crates/nucleus-pca/src/lib.rs \
     "a crate's totality declaration losing one of its seven lints" \
     perturb_scorecard_partial_totality
+probe_xtask scorecard crates/nucleus-node/src/broker_launch.rs \
+    "the first affine right to gain a validity interval" perturb_scorecard_first_expiry
 probe_xtask assurance-required ci/assurance-required-ratchet.txt \
     "a claim whose falsifier the merge queue does not gate on, past the pin" perturb_assurance_required_pin
 probe_xtask pin-parity ci/lean/lean-toolchain \

--- a/scripts/check-gates-can-fail.sh
+++ b/scripts/check-gates-can-fail.sh
@@ -682,6 +682,15 @@ perturb_scorecard_undischarged_law() {
     append_line "$1" 'impl DistributiveLattice for _GateOfGatesAlg {}'
 }
 
+# A crate that declared itself panic-free drops one lint from the list. Six of
+# seven still leaves a way to panic, so the crate stops discharging the `tot`
+# obligation and the family falls. The subject is a real annotation on a real
+# crate, not an appended line, because this is the one family whose declaration
+# is something the tree already carries.
+perturb_scorecard_partial_totality() {
+    sed -i.gate-bak 's/^        clippy::indexing_slicing,$//' "$1" && rm -f "$1.gate-bak"
+}
+
 probe_xtask convergence crates/nucleus-tool-proxy/src/run_gate.rs \
     "one more affine type taken by reference" perturb_convergence_linearity
 probe_xtask bound crates/nucleus-tool-proxy/src/run_gate.rs \
@@ -690,6 +699,9 @@ probe_xtask scorecard crates/nucleus-tool-proxy/src/run_gate.rs \
     "a family's pin gone slack under it" perturb_scorecard_slack
 probe_xtask scorecard crates/nucleus-tool-proxy/src/pod_mgmt.rs \
     "a law the tree declares and nothing discharges" perturb_scorecard_undischarged_law
+probe_xtask scorecard crates/nucleus-pca/src/lib.rs \
+    "a crate's totality declaration losing one of its seven lints" \
+    perturb_scorecard_partial_totality
 probe_xtask assurance-required ci/assurance-required-ratchet.txt \
     "a claim whose falsifier the merge queue does not gate on, past the pin" perturb_assurance_required_pin
 probe_xtask pin-parity ci/lean/lean-toolchain \


### PR DESCRIPTION
The third family on the card, and the first whose number is genuinely low. The badge now names it.

```
  scorecard | tot 16.25%

  family  unit                              population  discharged         %  undeclared
  bound   witness-accepting parameter site         172         171    99.41%          32
  alg     (lattice type, law) obligation           278         110    39.56%           8
  tot     production crate                          80          13    16.25%           5
```

Three commits, in dependency order.

## 1 — a proof harness, a build script and a `_test.rs` are not production

`is_production_path` defines the corpus five gates range over and let through three kinds of file that ship in no binary: three Kani harnesses, `crates/nucleus-econ-kernels/proofs/`, `certificate_convergence_test.rs` (`_test.rs` — the original rule said `_tests.rs` and missed by one character), and two `build.rs`.

The Kani case is worse than an omission: a proof harness is written against a deliberately narrowed model — `portcullis` marks whole fields `#[cfg(not(kani))]` — so counting it measures the proof rather than the binary. The coverage gate already excludes it as `--ignore-filename-regex '(tests/|kani\.rs|main\.rs)'`.

**Measured on the family this unblocks:** `.unwrap()`/`.expect()` in production falls 440 → 393, and **`portcullis` drops 89 → 43 and stops being the worst crate** — `nucleus-tool-proxy` at 81 is. A gate reading the loose corpus reports roughly twice the truth for `portcullis` and names the wrong crate to fix first.

**No pinned ratchet moves.** The corpus goes 691 → 684 files and `law-mechanisms` (9 dead, 132 allowances), `inert-authority` (33), `bound` (171/172), `convergence` and the scorecard all report exactly what they did before. That is why it is its own commit: the claim worth checking is that the corpus changed and no verdict did.

A test pins that the exclusions are segments and whole filenames, not substrings — `kani-utils`, `proofs_index.rs`, `kani_support.rs` and `testing.rs` all still ship.

## 2 — thirteen crates declare themselves panic-free

None of the seven lints that decide totality was configured anywhere in this repo. The production region carries **1,787 sites**:

| lint | sites |
|---|---|
| `arithmetic_side_effects` | 912 |
| `indexing_slicing` | 616 |
| `expect_used` | 155 |
| `unwrap_used` | 87 |
| `panic` | 10 |
| `unreachable` | 7 |

That is a program, not a gate, so this follows `clippy.toml`'s own rule — *"entries are added only when the tree is already clean of them"* — and annotates the thirteen crates that measure zero.

**`cfg_attr(not(test), …)` and not a bare `deny`, because `assert!` is a panic.** Of the thirteen crates clean over lib and bins, only **two** are also clean under `--all-targets`; the other eleven are clean where it matters and panic in their own test modules, which is what tests are made of. The declaration is scoped to the shipped build — the same line `production_region` draws when it strips the test region.

## 3 — the `tot` family

The gate does **not** recompute the 1,787-site census: it takes minutes and this runs in the fast `Manifest Guards` job. It asks the binding question instead, which is a grep — *how many crates have declared themselves panic-free*. A count of sites nothing enforces is a measurement; a crate-level deny is a gate. The census is recorded in the ratchet with the command that reproduces it.

Two things the census refuses to fudge:

- **All seven lints or none.** A crate denying six can still panic, and crediting it would make the ratio mean "mostly".
- **Unmeasurable is not clean.** Eighteen crates showed zero; **five showed zero because clippy never looked** — four workspace `exclude`s (wasm, maturin, RISC-V) and `nucleus-verifier-service`, which needs a wasm artifact CI builds. Counting them as discharged is ADR 0007 A-2 exactly: *"I could not look" is never "I looked and it was fine."* They are reported as `undeclared`, the population is the 80 crates clippy can see, and a crate on that list that *does* carry the attribute is still not credited — so annotating something nothing compiles cannot raise the ratio.

## Verification

| perturbation | result |
|---|---|
| `v[0] + 1` appended to `nucleus-pca` | RED on both `indexing_slicing` and `arithmetic_side_effects` |
| one lint dropped from a crate's declaration | RED — `tot` 16.25% → 15.00% |

Gate-of-gates: 41 probed, 0 unaccounted, exit 0 — the scorecard now reds on three independent subjects, one per family. All thirteen annotated crates pass `cargo clippy --all-targets --all-features -- -D warnings`. 206 xtask unit tests pass, 11 of them new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016t7JSuCtg4dC54HZjFgBjr