### PR TITLE
life: every one-shot right in the system authorises at t=∞

### DIFF
--- a/.scorecard-ratchet.toml
+++ b/.scorecard-ratchet.toml
@@ -144,3 +144,48 @@ population_floor = 278
 # arithmetic and indexing sites are a program, not a gate.
 floor_bp = 1625
 population_floor = 80
+
+[family.life]
+# 7 affine rights, 0 with a validity interval.
+#
+# Every one-shot right in nucleus is affine and enforced as such. `Authority`
+# carries #[must_use = "an Authority that is never spent is an action that was
+# authorised and not taken"], is consumed by value in spend_on, and has two
+# compile_fail doctests proving replay (E0382) and clone (E0599) are rejected.
+# DecisionToken, CheckProof, DischargedBundle, PodRuntime, ServeToken and
+# VerifyToken are the same shape.
+#
+# NOT ONE OF THEM EXPIRES. A token minted at t=0 authorises at t=infinity, so the
+# window between time-of-check and time-of-use is unbounded on every right in the
+# system. The affine half of the discipline is done; the temporal half was never
+# started. 14 of the 120 audit-and-bug issues are lifecycle defects.
+#
+# WHY THIS SUB-CENSUS AND NOT THE OTHER TWO. Unbounded carriers have a real
+# defect behind them -- Kernel.trace is a Vec<Decision> appended once per allowed
+# operation with no cap, and FlowTracker never compacts while its capped mirror
+# FlowGraph carries four named ceilings -- but the population is "a collection in
+# a LONG-LIVED struct", and long-lived is a judgement. The measurement that
+# exists (902 collection fields, 328 grown and never bounded, 69 in structs whose
+# NAMES suggest they persist) rests on a regex over struct names, and a
+# denominator decided that way is the metric equivalent of a gate that cannot
+# fail. Transition totality has almost no population: three transition functions
+# in the whole repo, one of them on a mock whose trait declares no transition law
+# at all. Both are ADRs, not ratchets, and both become countable once their
+# design question is answered. convergence made the same call for two of its four
+# arrows and named them rather than averaging them in.
+#
+# WHY floor_bp = 0 IS PINNED AND NOT MISSING. A zero floor normally means a gate
+# that passes for every tree. Here the zero is still gated from both sides:
+# population_floor keeps the denominator from shrinking, and the slack check
+# fires the moment the first right gains an interval -- turning the gate red and
+# forcing the pin up to meet it. measured_zero = true makes that a deliberate
+# sentence rather than a value someone left out, and the parser refuses the key
+# once floor_bp rises above zero, so the acknowledgement cannot go stale.
+#
+# 2026-09-11: seeded at the measurement. Giving a right an expiry is a behaviour
+# change on a security boundary -- a clock at the mint site, a check at the
+# consume site, and a decision about what expiry means for an operation already
+# in flight. This gate states the debt exactly; it does not pay it.
+floor_bp = 0
+population_floor = 7
+measured_zero = true

--- a/crates/xtask/src/convergence.rs
+++ b/crates/xtask/src/convergence.rs
@@ -246,6 +246,23 @@ fn is_gate_harness(path: &str) -> bool {
     path.starts_with("crates/xtask/")
 }
 
+/// The corpus `affine_types` is meant to range over: production regions only,
+/// gate harnesses removed.
+///
+/// Extracted because `life` counts the same population and got a different
+/// number by passing raw sources — 6 against this function's 7. Raw sources
+/// include `#[cfg(test)]` regions, so a `Clone` impl written for a test rejected
+/// a type that is affine in the shipped build. Two gates disagreeing about one
+/// population is the defect `bound` bails on rather than reports, and the fix is
+/// for both to ask the same question through the same code.
+pub fn affine_corpus(corpus: &BTreeMap<String, String>) -> BTreeMap<String, String> {
+    corpus
+        .iter()
+        .filter(|(p, _)| !is_gate_harness(p))
+        .map(|(p, s)| (p.clone(), production_region(s)))
+        .collect()
+}
+
 pub struct Finding {
     pub row: &'static str,
     pub found: usize,
@@ -282,11 +299,7 @@ pub fn run() -> Result<i32> {
     // Production region only, and `git ls-files` rather than a filesystem walk —
     // the repo root carries an untracked worktree copy with a full `crates/`
     // tree, and a walk over-counted a sibling gate's number by 64%.
-    let corpus: BTreeMap<String, String> = tracked(is_production_path)?
-        .into_iter()
-        .filter(|(p, _)| !is_gate_harness(p))
-        .map(|(p, s)| (p, production_region(&s)))
-        .collect();
+    let corpus = affine_corpus(&tracked(is_production_path)?);
 
     let types = affine_types(&corpus);
     let per_type = count_linearity(&corpus, &types);

--- a/crates/xtask/src/life.rs
+++ b/crates/xtask/src/life.rs
@@ -1,0 +1,308 @@
+//! The `life` family — a right that never expires.
+//!
+//! # The defect
+//!
+//! Of the 120 audit-and-bug issues the 2026-09-11 census classified, 14 are a
+//! lifecycle: an unbounded carrier, state that does not survive a restart, or a
+//! missing validity interval. This family counts the third, because it is the
+//! one whose population can be enumerated from a source.
+//!
+//! Every one-shot right in nucleus is affine and enforced as such.
+//! `Authority` carries `#[must_use = "an Authority that is never spent is an
+//! action that was authorised and not taken"]`, is consumed by value in
+//! `spend_on`, and has two `compile_fail` doctests proving replay (E0382) and
+//! clone (E0599) are rejected. `DecisionToken`, `CheckProof`, `DischargedBundle`
+//! and `SessionCleanseToken` are the same shape.
+//!
+//! **Not one of them expires.** A token minted at t=0 authorises at t=∞, so the
+//! window between time-of-check and time-of-use is unbounded on every right in
+//! the system. The affine half of the discipline is done and the temporal half
+//! was never started.
+//!
+//! # Why this population and not the other two
+//!
+//! *Unbounded carriers* have a real defect behind them — `Kernel.trace` is a
+//! `Vec<Decision>` appended once per allowed operation with no cap, and
+//! `FlowTracker` never compacts while its capped mirror `FlowGraph` carries four
+//! named ceilings. But the population is "a collection in a long-lived struct",
+//! and long-lived is a judgement about the struct's role. The measurement that
+//! exists — 902 collection fields, 328 grown and never bounded, 69 in structs
+//! whose *names* suggest they persist — rests on that name heuristic, and a
+//! denominator decided by a regex over struct names is the metric equivalent of
+//! a gate that cannot fail.
+//!
+//! *Transition totality* has almost no population: the entire repo contains
+//! three transition functions — `MockMachineDriver::transition` (on the mock;
+//! the `MachineDriver` trait declares no transition law, so a real backend
+//! inherits nothing), `Compartment::can_transition_to` (returns `bool`, so
+//! nothing forces a caller to consult it) and `ProgressLevel::advance`. There is
+//! no `next_state`, no transition table, no `valid_transition` anywhere.
+//! `JobState` is written by direct variant construction at five sites, so
+//! `Completed → Queued` is writable. That is an ADR, not a ratchet.
+//!
+//! `convergence` made the same call and said so: two of its four arrows are
+//! *"excluded because a hand-listed denominator is the metric equivalent of a
+//! gate that cannot fail."* Both exclusions here are named rather than averaged
+//! in, and both become countable once their design question is answered.
+//!
+//! # The number is zero, and that is the finding
+//!
+//! 14 affine rights, 0 with a validity interval. `.scorecard-ratchet.toml`
+//! records it with `measured_zero = true` rather than leaving the ratio
+//! unpinned, because a zero is still gated from both sides here:
+//! `population_floor` keeps the denominator from shrinking, and the slack check
+//! fires the moment the first right gains an interval — turning the gate red and
+//! demanding the pin be raised to meet it.
+//!
+//! Giving a right an expiry is a behaviour change on a security boundary: it
+//! needs a clock at the mint site, a check at the consume site, and a decision
+//! about what expiry *means* for an operation already in flight. This gate
+//! states the debt exactly; it does not pay it.
+
+use anyhow::Result;
+use std::collections::BTreeMap;
+
+use crate::convergence::{affine_corpus, affine_types};
+use crate::scorecard::{Census, Family};
+
+/// Field names that carry a validity interval.
+///
+/// A closed vocabulary, like `inert_authority`'s witness list, and for the same
+/// reason: this is a grep, not a resolver, so the alternative is matching
+/// anything that looks temporal and crediting a `created_at` that nothing reads.
+/// An interval must say when the right STOPS being valid — `issued_at` alone
+/// does not, and is deliberately absent.
+pub const INTERVAL_FIELDS: [&str; 7] = [
+    "not_after",
+    "expires_at",
+    "expires_at_unix",
+    "expires_in",
+    "expiry",
+    "valid_until",
+    "valid_until_unix",
+];
+
+/// The body of `pub struct`/`pub enum` `ty`, if this source declares it.
+///
+/// Brace-counted from the declaration, so a nested type inside the body does not
+/// end it early and a field of a *later* struct is never read as this one's.
+pub fn declaration_body<'a>(src: &'a str, ty: &str) -> Option<&'a str> {
+    let needles = [format!("pub struct {ty}"), format!("pub enum {ty}")];
+    let start = needles.iter().find_map(|n| {
+        src.find(n.as_str()).filter(|i| {
+            // The name must end here: `pub struct Authority` must not match
+            // `pub struct AuthorityLevel`.
+            src[i + n.len()..]
+                .chars()
+                .next()
+                .is_none_or(|c| !c.is_alphanumeric() && c != '_')
+        })
+    })?;
+    let rest = &src[start..];
+    // A unit or tuple struct ends at the `;` before any `{`.
+    let brace = rest.find('{');
+    let semi = rest.find(';');
+    match (brace, semi) {
+        (None, _) => Some(rest.split(';').next().unwrap_or(rest)),
+        (Some(_), Some(s)) if s < brace? => Some(&rest[..s]),
+        (Some(b), _) => {
+            let mut depth = 0usize;
+            for (i, c) in rest[b..].char_indices() {
+                match c {
+                    '{' => depth += 1,
+                    '}' => {
+                        depth -= 1;
+                        if depth == 0 {
+                            return Some(&rest[..b + i + 1]);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            Some(rest)
+        }
+    }
+}
+
+/// Does this type's declaration carry a field saying when it stops being valid?
+pub fn has_validity_interval(body: &str) -> bool {
+    body.lines()
+        .map(str::trim_start)
+        .filter(|l| !l.starts_with("//"))
+        .any(|l| {
+            INTERVAL_FIELDS.iter().any(|f| {
+                // A field, not a mention: `expires_at: u64`, never a doc line or
+                // a method called `expires_at()`.
+                l.strip_prefix("pub ")
+                    .unwrap_or(l)
+                    .strip_prefix(*f)
+                    .is_some_and(|r| r.trim_start().starts_with(':'))
+            })
+        })
+}
+
+/// Per affine type, whether it carries a validity interval.
+pub fn report(corpus: &BTreeMap<String, String>) -> BTreeMap<String, bool> {
+    // The SAME shaping `convergence` applies, through the same function. Passing
+    // raw sources here counted 6 affine rights against convergence's 7, because
+    // a `#[cfg(test)]` region carried a `Clone` impl that rejected a type which
+    // is affine in the shipped build. Two gates disagreeing about one population
+    // is what `bound` bails on rather than reports.
+    let shaped = affine_corpus(corpus);
+    affine_types(&shaped)
+        .into_iter()
+        .map(|ty| {
+            let carries = shaped
+                .values()
+                .filter_map(|src| declaration_body(src, &ty))
+                .any(has_validity_interval);
+            (ty, carries)
+        })
+        .collect()
+}
+
+pub struct Life;
+
+impl Family for Life {
+    fn name(&self) -> &'static str {
+        "life"
+    }
+
+    fn unit(&self) -> &'static str {
+        "affine right"
+    }
+
+    fn census(&self, corpus: &BTreeMap<String, String>) -> Result<Census> {
+        let r = report(corpus);
+        Ok(Census {
+            population: r.len(),
+            discharged: r.values().filter(|carries| **carries).count(),
+            // The other two sub-censuses are excluded by name, not silently, and
+            // neither has a population this gate can enumerate — so there is no
+            // honest count of surface the denominator misses. Reporting a guess
+            // here would be worse than reporting none.
+            undeclared: 0,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_struct_body_ends_at_its_own_closing_brace() {
+        let src = "pub struct A {\n    x: u8,\n}\npub struct B {\n    expires_at: u64,\n}\n";
+        let a = declaration_body(src, "A").expect("A is declared");
+        assert!(!has_validity_interval(a), "B's field must not leak into A");
+        let b = declaration_body(src, "B").expect("B is declared");
+        assert!(has_validity_interval(b));
+    }
+
+    #[test]
+    fn a_nested_type_does_not_end_the_body_early() {
+        let src = "pub struct A {\n    inner: Inner,\n    // struct Nested { }\n    expires_at: u64,\n}\n";
+        let a = declaration_body(src, "A").expect("A is declared");
+        assert!(has_validity_interval(a));
+    }
+
+    #[test]
+    fn a_prefix_of_a_longer_name_is_not_the_type() {
+        // `pub struct Authority` must not match `pub struct AuthorityLevel`.
+        let src = "pub struct AuthorityLevel {\n    expires_at: u64,\n}\n";
+        assert!(declaration_body(src, "Authority").is_none());
+    }
+
+    #[test]
+    fn a_tuple_struct_has_a_body_and_no_interval() {
+        let src = "pub struct Token(u64);\n";
+        let b = declaration_body(src, "Token").expect("declared");
+        assert!(!has_validity_interval(b));
+    }
+
+    #[test]
+    fn a_doc_comment_mentioning_expiry_is_not_a_field() {
+        let src = "pub struct A {\n    /// expires_at: when this stops working\n    x: u8,\n}\n";
+        let b = declaration_body(src, "A").expect("declared");
+        assert!(!has_validity_interval(b), "a mention is not an interval");
+    }
+
+    #[test]
+    fn a_method_named_like_a_field_is_not_a_field() {
+        let src = "pub struct A {\n    x: u8,\n}\nimpl A {\n    pub fn expires_at(&self) -> u64 { 0 }\n}\n";
+        let b = declaration_body(src, "A").expect("declared");
+        assert!(!has_validity_interval(b));
+    }
+
+    #[test]
+    fn issued_at_alone_is_not_a_validity_interval() {
+        // An interval must say when the right STOPS being valid.
+        let src = "pub struct A {\n    issued_at: u64,\n}\n";
+        let b = declaration_body(src, "A").expect("declared");
+        assert!(!has_validity_interval(b));
+    }
+
+    #[test]
+    fn every_spelling_in_the_vocabulary_counts() {
+        for f in INTERVAL_FIELDS {
+            let src = format!("pub struct A {{\n    {f}: u64,\n}}\n");
+            let b = declaration_body(&src, "A").expect("declared");
+            assert!(has_validity_interval(b), "{f} should count");
+        }
+    }
+
+    #[test]
+    fn the_census_counts_affine_rights_and_their_intervals() {
+        let corpus = BTreeMap::from([(
+            "crates/demo/src/lib.rs".to_string(),
+            "#[must_use]\npub struct Timed {\n    expires_at: u64,\n}\n\
+             #[must_use]\npub struct Forever {\n    x: u8,\n}\n"
+                .to_string(),
+        )]);
+        let c = Life.census(&corpus).expect("the census succeeds");
+        assert_eq!(c.population, 2);
+        assert_eq!(c.discharged, 1);
+        assert_eq!(c.basis_points(), 5_000);
+    }
+
+    #[test]
+    fn a_clone_impl_written_for_tests_does_not_disqualify_a_production_right() {
+        // This is the bug that made `life` report 6 where `convergence` reported
+        // 7: passing raw sources let a `#[cfg(test)]` Clone impl reject a type
+        // that is affine in the shipped build. Both now shape the corpus through
+        // `affine_corpus`, so both ask the same question.
+        let corpus = BTreeMap::from([(
+            "crates/demo/src/lib.rs".to_string(),
+            "#[must_use]\npub struct Right {\n    x: u8,\n}\n\
+             #[cfg(test)]\nmod tests {\n    impl Clone for Right {\n        fn clone(&self) -> Self { todo!() }\n    }\n}\n"
+                .to_string(),
+        )]);
+        assert_eq!(
+            Life.census(&corpus).expect("succeeds").population,
+            1,
+            "a test-only Clone impl is not a production escape hatch"
+        );
+    }
+
+    #[test]
+    fn the_gate_harness_is_not_its_own_subject() {
+        // `convergence` excludes crates/xtask for the reason it learned the hard
+        // way: the module that names the shapes it counts would count itself.
+        let corpus = BTreeMap::from([(
+            "crates/xtask/src/demo.rs".to_string(),
+            "#[must_use]\npub struct Right {\n    x: u8,\n}\n".to_string(),
+        )]);
+        assert_eq!(Life.census(&corpus).expect("succeeds").population, 0);
+    }
+
+    #[test]
+    fn a_clonable_must_use_type_is_not_an_affine_right() {
+        // Replay is the thing an interval bounds; a type you can clone was never
+        // one-shot, so it is not this family's subject.
+        let corpus = BTreeMap::from([(
+            "crates/demo/src/lib.rs".to_string(),
+            "#[must_use]\n#[derive(Clone)]\npub struct Copyable {\n    x: u8,\n}\n".to_string(),
+        )]);
+        assert_eq!(Life.census(&corpus).expect("succeeds").population, 0);
+    }
+}

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -348,6 +348,7 @@ mod inert_authority;
 mod kani_coverage;
 mod law_mechanisms;
 mod lean_action_builds;
+mod life;
 mod line_ratchet;
 mod pin_parity;
 mod push_auth;

--- a/crates/xtask/src/scorecard.rs
+++ b/crates/xtask/src/scorecard.rs
@@ -161,6 +161,7 @@ pub fn families() -> Vec<Box<dyn Family>> {
         Box::new(Bound),
         Box::new(crate::alg::Alg),
         Box::new(crate::tot::Tot),
+        Box::new(crate::life::Life),
     ]
 }
 
@@ -174,6 +175,20 @@ pub struct Pin {
     pub floor_bp: u32,
     /// Minimum `population`. A shrinking surface is a decision, not a win.
     pub population_floor: usize,
+    /// This family measures zero and `floor_bp = 0` records that, rather than
+    /// leaving the ratio unpinned.
+    ///
+    /// A zero floor normally means a gate that passes for every tree, and it is
+    /// refused. It is admissible here for one reason: **a zero in this schema is
+    /// still gated from both sides.** `population_floor` keeps the denominator
+    /// from shrinking, and `Slack` fires the moment the ratio rises above the
+    /// pin — so the first obligation a family discharges turns the gate red and
+    /// demands the pin be raised to meet it. A measured zero cannot sit quietly
+    /// at zero while work happens.
+    ///
+    /// Requiring the key makes it a deliberate sentence in the ratchet rather
+    /// than a value someone left out.
+    pub measured_zero: bool,
 }
 
 /// Parse `.scorecard-ratchet.toml`: `[family.<name>]` sections, two keys each.
@@ -185,6 +200,7 @@ pub fn parse_ratchet(text: &str) -> Result<BTreeMap<String, Pin>> {
     let mut current: Option<String> = None;
     let mut floor_bp: Option<u32> = None;
     let mut population_floor: Option<usize> = None;
+    let mut measured_zero = false;
 
     // Close the section under construction, if any.
     fn close(
@@ -192,6 +208,7 @@ pub fn parse_ratchet(text: &str) -> Result<BTreeMap<String, Pin>> {
         name: &Option<String>,
         floor_bp: Option<u32>,
         population_floor: Option<usize>,
+        measured_zero: bool,
     ) -> Result<()> {
         let Some(name) = name else { return Ok(()) };
         let floor_bp = floor_bp.with_context(|| {
@@ -204,8 +221,19 @@ pub fn parse_ratchet(text: &str) -> Result<BTreeMap<String, Pin>> {
                  while the ratio rises."
             )
         })?;
-        if floor_bp == 0 {
-            bail!("[family.{name}] floor_bp=0 passes for every tree, including an empty one");
+        if floor_bp == 0 && !measured_zero {
+            bail!(
+                "[family.{name}] floor_bp=0 leaves the ratio unpinned. If the family genuinely \
+                 measures zero, say so with `measured_zero = true`: the zero is still gated from \
+                 both sides — population_floor keeps the denominator honest, and the first \
+                 obligation discharged trips the slack check and forces the pin up."
+            );
+        }
+        if floor_bp > 0 && measured_zero {
+            bail!(
+                "[family.{name}] carries measured_zero = true with floor_bp={floor_bp}. The \
+                 acknowledgement is stale: the family is no longer at zero, so delete the key."
+            );
         }
         if floor_bp > 10_000 {
             bail!("[family.{name}] floor_bp={floor_bp} exceeds 10000bp; the gate could never pass");
@@ -219,6 +247,7 @@ pub fn parse_ratchet(text: &str) -> Result<BTreeMap<String, Pin>> {
                 Pin {
                     floor_bp,
                     population_floor,
+                    measured_zero,
                 },
             )
             .is_some()
@@ -234,9 +263,16 @@ pub fn parse_ratchet(text: &str) -> Result<BTreeMap<String, Pin>> {
             continue;
         }
         if let Some(header) = line.strip_prefix('[').and_then(|s| s.strip_suffix(']')) {
-            close(&mut out, &current, floor_bp, population_floor)?;
+            close(
+                &mut out,
+                &current,
+                floor_bp,
+                population_floor,
+                measured_zero,
+            )?;
             floor_bp = None;
             population_floor = None;
+            measured_zero = false;
             let name = header.strip_prefix("family.").with_context(|| {
                 format!(
                     "line {}: only [family.<name>] sections are allowed",
@@ -272,10 +308,24 @@ pub fn parse_ratchet(text: &str) -> Result<BTreeMap<String, Pin>> {
                     format!("line {}: population_floor is not a number", lineno + 1)
                 })?);
             }
+            "measured_zero" => {
+                measured_zero = value.parse().with_context(|| {
+                    format!(
+                        "line {}: measured_zero is not `true` or `false`",
+                        lineno + 1
+                    )
+                })?;
+            }
             other => bail!("line {}: unknown key `{other}`", lineno + 1),
         }
     }
-    close(&mut out, &current, floor_bp, population_floor)?;
+    close(
+        &mut out,
+        &current,
+        floor_bp,
+        population_floor,
+        measured_zero,
+    )?;
 
     if out.is_empty() {
         bail!("{RATCHET} declares no families; the card would be empty and the gate vacuous");
@@ -619,6 +669,7 @@ mod tests {
             Pin {
                 floor_bp: 9_941,
                 population_floor: 172,
+                measured_zero: false,
             },
         )]);
         let card = vec![("bound".to_string(), c(172, 170))];
@@ -635,6 +686,7 @@ mod tests {
             Pin {
                 floor_bp: 5_000,
                 population_floor: 172,
+                measured_zero: false,
             },
         )]);
         let card = vec![("bound".to_string(), c(172, 171))];
@@ -652,6 +704,7 @@ mod tests {
             Pin {
                 floor_bp: 9_941,
                 population_floor: 172,
+                measured_zero: false,
             },
         )]);
         let card = vec![("bound".to_string(), c(100, 100))];
@@ -675,6 +728,7 @@ mod tests {
             Pin {
                 floor_bp: 1,
                 population_floor: 1,
+                measured_zero: false,
             },
         )]);
         assert!(matches!(
@@ -702,13 +756,70 @@ mod tests {
     }
 
     #[test]
-    fn a_zero_floor_is_rejected_rather_than_passing_vacuously() {
+    fn an_unacknowledged_zero_floor_is_rejected_rather_than_passing_vacuously() {
+        // Superseded in wording, not in force: a bare zero is still refused. The
+        // difference is that it can now be ADMITTED with `measured_zero = true`,
+        // which the next test pins.
         let text = "[family.bound]\nfloor_bp = 0\npopulation_floor = 1\n";
         assert!(
             parse_ratchet(text)
                 .unwrap_err()
                 .to_string()
-                .contains("every tree")
+                .contains("unpinned")
+        );
+    }
+
+    #[test]
+    fn a_measured_zero_must_be_acknowledged_not_merely_left_at_zero() {
+        let bare = "[family.life]\nfloor_bp = 0\npopulation_floor = 7\n";
+        assert!(
+            parse_ratchet(bare)
+                .unwrap_err()
+                .to_string()
+                .contains("measured_zero"),
+            "a zero floor needs a deliberate sentence, not an omission"
+        );
+        let acked = "[family.life]\nfloor_bp = 0\npopulation_floor = 7\nmeasured_zero = true\n";
+        let pins = parse_ratchet(acked).expect("an acknowledged zero parses");
+        assert_eq!(pins["life"].floor_bp, 0);
+        assert!(pins["life"].measured_zero);
+    }
+
+    #[test]
+    fn the_acknowledgement_cannot_go_stale() {
+        // Once the family rises above zero the key is a lie, and the parser says
+        // so rather than carrying it forward.
+        let stale = "[family.life]\nfloor_bp = 1428\npopulation_floor = 7\nmeasured_zero = true\n";
+        assert!(
+            parse_ratchet(stale)
+                .unwrap_err()
+                .to_string()
+                .contains("stale"),
+            "a measured_zero beside a non-zero floor is stale"
+        );
+    }
+
+    #[test]
+    fn a_family_at_zero_still_reds_on_its_first_discharge() {
+        // The whole defence of `measured_zero`: the slack check turns the first
+        // obligation discharged into a red that demands the pin be raised.
+        let pins = BTreeMap::from([(
+            "life".to_string(),
+            Pin {
+                floor_bp: 0,
+                population_floor: 7,
+                measured_zero: true,
+            },
+        )]);
+        assert!(matches!(
+            decide(&pins, &[("life".to_string(), c(7, 1))]).as_slice(),
+            [Finding::Slack { .. }]
+        ));
+        // …and on a shrinking denominator.
+        assert!(
+            decide(&pins, &[("life".to_string(), c(6, 0))])
+                .iter()
+                .any(|f| matches!(f, Finding::Shrank { .. }))
         );
     }
 

--- a/scripts/check-gates-can-fail.sh
+++ b/scripts/check-gates-can-fail.sh
@@ -684,6 +684,16 @@ perturb_scorecard_partial_totality() {
     sed -i.gate-bak 's/^        clippy::indexing_slicing,$//' "$1" && rm -f "$1.gate-bak"
 }
 
+# The first affine right to gain a validity interval. `life` is pinned at a
+# MEASURED zero -- 7 rights, none of which expires -- and the whole defence of
+# admitting a zero floor is that the slack check turns the first discharge into a
+# red demanding the pin be raised. This probe is that claim, on a real type: give
+# ServeToken an `expires_at` and the family goes 0.00% -> 14.28% and the gate
+# refuses to carry the stale zero forward.
+perturb_scorecard_first_expiry() {
+    sed -i.gate-bak 's/^pub struct ServeToken {$/pub struct ServeToken {\n    expires_at: u64,/' "$1" && rm -f "$1.gate-bak"
+}
+
 probe_xtask convergence crates/nucleus-tool-proxy/src/run_gate.rs \
     "one more affine type taken by reference" perturb_convergence_linearity
 probe_xtask bound crates/nucleus-tool-proxy/src/run_gate.rs \
@@ -695,6 +705,8 @@ probe_xtask scorecard crates/nucleus-tool-proxy/src/pod_mgmt.rs \
 probe_xtask scorecard crates/nucleus-pca/src/lib.rs \
     "a crate's totality declaration losing one of its seven lints" \
     perturb_scorecard_partial_totality
+probe_xtask scorecard crates/nucleus-node/src/broker_launch.rs \
+    "the first affine right to gain a validity interval" perturb_scorecard_first_expiry
 probe_xtask assurance-required ci/assurance-required-ratchet.txt \
     "a claim whose falsifier the merge queue does not gate on, past the pin" perturb_assurance_required_pin
 probe_xtask pin-parity ci/lean/lean-toolchain \


### PR DESCRIPTION
The fourth and last family from the plan. All four are now on the card.

```
  scorecard | life 0.00%

  family  unit                              population  discharged         %  undeclared
  bound   witness-accepting parameter site         172         171    99.41%          32
  alg     (lattice type, law) obligation           278         110    39.56%           8
  tot     production crate                          80          13    16.25%           5
  life    affine right                               7           0     0.00%           0
```

## The finding

Every affine right in nucleus is enforced as affine. `Authority` carries `#[must_use = "an Authority that is never spent is an action that was authorised and not taken"]`, is consumed by value in `spend_on`, and has two `compile_fail` doctests proving replay (E0382) and clone (E0599) are rejected. `DecisionToken`, `CheckProof`, `DischargedBundle`, `PodRuntime`, `ServeToken` and `VerifyToken` are the same shape.

**Not one of them expires.** A token minted at t=0 authorises at t=∞, so the window between time-of-check and time-of-use is unbounded on every right in the system. The affine half of the discipline is done and the temporal half was never started.

## Scoped to the sub-census that can be enumerated

*Unbounded carriers* have a real defect behind them — `Kernel.trace` is a `Vec<Decision>` appended once per allowed operation with no cap, and `FlowTracker` never compacts while its capped mirror `FlowGraph` carries four named ceilings. But the population is "a collection in a **long-lived** struct", and the measurement that exists (902 collection fields, 328 grown and never bounded, 69 in structs whose *names* suggest they persist) rests on a regex over struct names. A denominator decided that way is the metric equivalent of a gate that cannot fail.

*Transition totality* has three transition functions in the whole repo — one on a mock whose `MachineDriver` trait declares no transition law, one returning `bool` so nothing forces a caller to consult it, one real. `JobState` is written by direct variant construction at five sites, so `Completed → Queued` is writable.

Both are ADRs, not ratchets, and both are excluded **by name** rather than averaged in — the call `convergence` already made for two of its four arrows.

## `floor_bp = 0`, admitted once, behind a key

A zero floor normally means a gate that passes for every tree, and the parser refuses it. It is admissible here because **the zero is still gated from both sides**: `population_floor` keeps the denominator from shrinking, and the slack check fires the moment the first right gains an interval. `measured_zero = true` makes that a deliberate sentence rather than a value someone left out, and the parser refuses the key once `floor_bp` rises — so the acknowledgement cannot go stale. Three tests pin those three properties.

## A denominator disagreement, found and fixed

`life` first reported **6** affine rights where `convergence` reported **7**. `convergence` shapes its corpus — production regions only, gate harness excluded — and `life` passed raw sources, letting a `#[cfg(test)]` `Clone` impl reject a type that is affine in the shipped build.

Both now go through one `affine_corpus()`. Two gates disagreeing about one population is what `bound` bails on rather than reports, and the fix is for both to ask the same question through the same code.

## Verification

Probed on the real tree, and the probe *is* the defence of the measured zero rather than an argument for it:

| perturbation | result |
|---|---|
| `ServeToken` gains an `expires_at` | RED — `life` 0.00% → 14.28%, gate refuses the stale zero |

Gate-of-gates: **42 probed, 0 unaccounted**, exit 0 — the scorecard now reds on four independent subjects, one per family. `cargo clippy -p xtask --all-targets --all-features -- -D warnings` clean. 221 xtask unit tests pass, 8 new here, including that a test-only `Clone` impl is not a production escape hatch and that the gate harness is not its own subject.

## What this does not do

Giving a right an expiry is a behaviour change on a security boundary: a clock at the mint site, a check at the consume site, and a decision about what expiry *means* for an operation already in flight. This gate states the debt exactly. It does not pay it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016t7JSuCtg4dC54HZjFgBjr