### PR TITLE
fix(ci-spec): I10's pin had rotted to 7 stale entries of 16, advisedly

### DIFF
--- a/ci/image-dependent-jobs.txt
+++ b/ci/image-dependent-jobs.txt
@@ -14,19 +14,25 @@
 #   ENOSPC / ld signal 7             build machines had no volume, an 8 GB rootfs filled
 #   Scoped Aeneas, charon drift      the image had no aeneas/charon
 # gatehouse states this as A-10 and now enforces it at admission; nucleus is not a tenant yet.
+#
+# 2026-09-11 — seven entries removed, all `*-lean`: ci-spec-lean, ck-policy-lean, econ-lean,
+# ifc-lean, portcullis-core-proven-lean, research-lean-build, rubric-lean. `CI-I10-STALE` had
+# been reporting all seven, and they are genuinely stale: each of those workflows mentions
+# `runner.environment == 'github-hosted'` exactly once, as a `with:` INPUT selecting a cache
+# (`use-github-cache:`), never as an `if:` guard on an install step. A cache is deliberately not
+# a contract with the image — a miss costs time, not a verdict — so these jobs assume nothing of
+# it. Checked per job: 0 `if:` guards, 1 `with:` input, each.
+#
+# Worth recording because the check nearly went the other way. A grep for the STRING
+# `github-hosted` inside each job body returns 1 for all seven and reads as "still
+# image-dependent, the advisory is a false positive". It is the `if:`/`with:` distinction that
+# decides, and only the invariant's own predicate makes it.
 aeneas-certchain/aeneas-certchain
 aeneas-decide-pure/aeneas-decide-pure
 aeneas-ifc-scoped/aeneas-ifc-scoped
 aeneas-oidc-spiffe/aeneas-oidc-spiffe
 aeneas/aeneas-translate
-ci-spec-lean/ci-spec-lean
 ci/musl-check
 ci/workspace-tests
 ck-policy-aeneas/ck-policy-aeneas
-ck-policy-lean/ck-policy-lean
 deny/deny
-econ-lean/econ-lean
-ifc-lean/ifc-lean
-portcullis-core-proven-lean/portcullis-core-proven-lean
-research-lean-build/research-lean-build
-rubric-lean/rubric-lean

--- a/crates/ci-spec/src/invariants/self_hosted_tools.rs
+++ b/crates/ci-spec/src/invariants/self_hosted_tools.rs
@@ -127,7 +127,14 @@ pub fn check(m: &Model) -> Vec<Finding> {
     for job in pin.difference(&live) {
         out.push(finding(
             "CI-I10-STALE",
-            Severity::Info,
+            // Medium, not Info. The header above says a stale entry is a finding "so the file
+            // cannot rot into a list nobody reads" -- and under Info it rotted anyway: on
+            // 2026-09-11 seven of sixteen entries were stale, all reported and none acted on,
+            // because an advisory is something a reader scrolls past. A pin that may only
+            // shrink has to be able to fail in BOTH directions or the shrink half is prose.
+            // This file is not under .github/workflows/, so the required-context downgrade in
+            // lib.rs does not apply to it and Medium means what it says.
+            Severity::Medium,
             INVENTORY,
             0,
             job,


### PR DESCRIPTION
`crates/ci-spec/src/invariants/self_hosted_tools.rs` says a stale entry is a finding **"so the file cannot rot into a list nobody reads."**

Under `Severity::Info` it rotted anyway: **7 of 16 entries were stale**, reported on every run, none acted on. An advisory is something a reader scrolls past — the same argument gatehouse F-80 makes about a cancelled job and F-85 about a pin nothing reads.

## The seven, and how I nearly got them wrong

All seven are `*-lean` lanes. Establishing they were genuinely stale took the invariant's own predicate, not a grep.

Each of those workflows mentions `runner.environment == 'github-hosted'` **exactly once** — as a `with:` input selecting a cache (`use-github-cache:`), never as an `if:` guard on an install step. Checked per job: **0 `if:` guards, 1 `with:` input**, each. A cache is deliberately not a contract with the image; `is_install`'s own comment says a miss "costs time, not a verdict".

**I had the opposite conclusion written before I read that predicate.** A grep for the string `github-hosted` in each job body returns 1 for all seven and reads as *"still image-dependent, the advisory is a false positive"* — which would have deleted nothing and left the rot in place. The committed check was right and my regex was wrong.

## The change

- The 7 stale entries removed, with a dated note in the file recording the `if:`/`with:` distinction that decides it.
- `CI-I10-STALE` raised **Info → Medium**. A pin that may only shrink has to fail in *both* directions or the shrink half is prose. This file is not under `.github/workflows/`, so `lib.rs`'s required-context downgrade does not apply and Medium means what it says.

## Measured while probing, and deliberately not changed

Of the 9 remaining entries, removing one is a **hard failure for 4** and an **advisory for 5**. `CI-I10-UNPINNED` is declared `High`, but a job producing no required context is downgraded to `Info` by `lib.rs`. That is consistent with I10's own argument — which is about *ejecting a merge-queue entry* — so it is recorded here rather than adjusted. Worth a decision, not worth me making it.

## Verification

- Driven **RED on the real defect**: a stale entry restored now exits **1** at `medium`; the same perturbation exited **0** at `info` before. File restores byte-exact.
- `check-ci-spec.sh` RC=0 with **zero** CI-I10 findings.
- `cargo test -p ci-spec` 46 passed; fmt and clippy RC=0.
- Test-merged against the queued #2830: **rc=0, no conflicts.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)