### PR TITLE
fix(ci): three workflows cancelled their own signal for commits on main

### DIFF
--- a/.github/workflows/dylint-separation.yml
+++ b/.github/workflows/dylint-separation.yml
@@ -81,7 +81,12 @@ permissions:
 
 concurrency:
   group: dylint-separation-${{ github.ref }}
-  cancel-in-progress: true
+  # Only on pull_request. Under `push:` this group is keyed on `github.ref`, so a second
+  # push to main cancels the run for the commit BEFORE it -- a commit already on main, whose
+  # CI signal is then simply absent rather than red. A gate that stopped running looks like a
+  # gate that passed. On a pull request superseding is what you want; on main it is a hole.
+  # Same form gatehouse-shadow.yml already uses.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   # ONE pod for all four passes (CI review, 2026-09-05). Each pass used to be

--- a/.github/workflows/oidc-gates.yml
+++ b/.github/workflows/oidc-gates.yml
@@ -27,7 +27,12 @@ on:
 # when a new push lands.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Only on pull_request. Under `push:` this group is keyed on `github.ref`, so a second
+  # push to main cancels the run for the commit BEFORE it -- a commit already on main, whose
+  # CI signal is then simply absent rather than red. A gate that stopped running looks like a
+  # gate that passed. On a pull request superseding is what you want; on main it is a hole.
+  # Same form gatehouse-shadow.yml already uses.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/tpm-and-net-isolation.yml
+++ b/.github/workflows/tpm-and-net-isolation.yml
@@ -47,7 +47,12 @@ permissions:
 
 concurrency:
   group: tpm-net-isolation-${{ github.ref }}
-  cancel-in-progress: true
+  # Only on pull_request. Under `push:` this group is keyed on `github.ref`, so a second
+  # push to main cancels the run for the commit BEFORE it -- a commit already on main, whose
+  # CI signal is then simply absent rather than red. A gate that stopped running looks like a
+  # gate that passed. On a pull request superseding is what you want; on main it is a hole.
+  # Same form gatehouse-shadow.yml already uses.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   tpm-credential-activation:


### PR DESCRIPTION
`cancel-in-progress: true`, with a group keyed on `github.ref`, under a trigger that includes `push:`.

A second push to main therefore **cancels the run for the commit before it** — a commit already merged, whose CI signal is then *absent* rather than red. **A gate that stopped running looks like a gate that passed.**

On a pull request superseding is exactly what you want. On main it is a hole.

## The fix is the repo's own

`ci-spec` has been flagging all three as `CI-I4-CANCEL` and prints the remedy it wants:

```yaml
cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

That is also the form `gatehouse-shadow.yml` already uses, so this is existing precedent rather than a new convention.

| workflow | before | after |
|---|---|---|
| `dylint-separation.yml` | `true` | `${{ github.event_name == 'pull_request' }}` |
| `oidc-gates.yml` | `true` | `${{ github.event_name == 'pull_request' }}` |
| `tpm-and-net-isolation.yml` | `true` | `${{ github.event_name == 'pull_request' }}` |

## Verification

- **3** `CI-I4-CANCEL` findings before, **0** after.
- Reverting one brings its finding back, and the file restores **byte-identical**.
- `cargo test -p ci-spec` RC=0; `check-ci-spec.sh` RC=0.

## Flagged, deliberately not fixed here

`CI-I4-CANCEL` is declared **`Severity::High`** but reports as `info`, because `lib.rs` downgrades any High/Medium finding whose job produces no required context.

That downgrade's rationale is about **ejecting a merge-queue entry**. The harm *this* rule names is different — losing main's CI signal for a commit — and no required-context test can see it. So the downgrade may be mis-applied for this one rule, which is why these three sat visible and unactioned.

Changing a rule's own severity in its own file is local (that is what #2837 does for `CI-I10-STALE`). Changing the global downgrade is not, and is a decision rather than a defect — so it is recorded here for you rather than taken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)