### PR TITLE
A decision may only be redeemed under the permissions it was taken against

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,5 +1,11 @@
 # cargo-mutants configuration.
 #
+# In .cargo/, not the repo root. `cargo mutants --help` says so plainly —
+# "Read configuration from this file instead of .cargo/mutants.toml" — and a
+# root-level mutants.toml is read by nothing. The first version of this file was
+# at the root, CI reported the same two survivors unchanged, and `--list` locally
+# confirmed the exclusion was doing nothing at all.
+#
 # WHY THIS FILE EXISTS
 #
 # `Mutation Testing` runs `cargo mutants --package portcullis --all-features`.

--- a/.scorecard-ratchet.toml
+++ b/.scorecard-ratchet.toml
@@ -190,10 +190,29 @@ population_floor = 81
 # sentence rather than a value someone left out, and the parser refuses the key
 # once floor_bp rises above zero, so the acknowledgement cannot go stale.
 #
-# 2026-09-11: seeded at the measurement. Giving a right an expiry is a behaviour
-# change on a security boundary -- a clock at the mint site, a check at the
-# consume site, and a decision about what expiry means for an operation already
-# in flight. This gate states the debt exactly; it does not pay it.
-floor_bp = 0
+# 2026-09-11 (second pass): DecisionToken carries the checksum of the effective
+# permissions it was decided against, and the executor refuses a token whose
+# checksum is not the one it is about to run under. 0 -> 1 of 7.
+#
+# The measured zero did exactly what it was admitted to do. It did not sit
+# quietly at zero while the work happened: the slack check turned the first
+# discharge into a red -- "life is at 14.28% but the floor is pinned at 0.00%"
+# -- and the pin could not be carried forward. That is the whole defence of
+# admitting floor_bp = 0, and it was driven rather than argued.
+#
+# A STATE FINGERPRINT IS A TIGHTER BOUND THAN A CLOCK, not a weaker one. A TTL
+# asks "how long has it been?"; the invariant a one-shot right needs is "has
+# anything it depended on changed?". Those diverge both ways -- a thirty-second
+# token is stale at one millisecond if the policy was amended, and sound an hour
+# later if nothing moved -- and a TTL also imports a trusted clock and host/guest
+# skew across the vsock boundary. So the family counts either form, and the
+# vocabulary says which is which.
+#
+# Not yet bounded: Authority, CheckProof, DischargedBundle, PodRuntime,
+# ServeToken, VerifyToken. The last two cross a process boundary and are
+# serialized, so they need the fingerprint checked on arrival rather than a
+# borrow; the first four are in-process and could take a lifetime instead, which
+# would make staleness a compile error the way affinity already makes replay one
+# (E0382). That is an ADR and a call-site refactor, not a ratchet.
+floor_bp = 1428
 population_floor = 7
-measured_zero = true

--- a/crates/nucleus/src/command.rs
+++ b/crates/nucleus/src/command.rs
@@ -417,11 +417,7 @@ impl<'a> Executor<'a> {
         decision: DecisionToken,
         authority: Authority,
     ) -> Result<Output> {
-        crate::decision_scope::require_decision_for(decision.operation(), Operation::RunBash)?;
-        crate::decision_scope::require_permissions_match(
-            decision.permissions(),
-            &self.permissions,
-        )?;
+        decision.redeem(&self.permissions, Operation::RunBash)?;
         // Fail-closed isolation gate: refuse unless containment is declared and
         // meets the policy's required isolation (most-paranoid #2).
         self.enforce_isolation()?;
@@ -537,11 +533,7 @@ impl<'a> Executor<'a> {
         decision: DecisionToken,
         authority: Authority,
     ) -> Result<Output> {
-        crate::decision_scope::require_decision_for(decision.operation(), Operation::RunBash)?;
-        crate::decision_scope::require_permissions_match(
-            decision.permissions(),
-            &self.permissions,
-        )?;
+        decision.redeem(&self.permissions, Operation::RunBash)?;
         self.run_args_internal(args, stdin, directory, None, authority)
     }
 
@@ -555,11 +547,7 @@ impl<'a> Executor<'a> {
         approval: &ApprovalToken,
         authority: Authority,
     ) -> Result<Output> {
-        crate::decision_scope::require_decision_for(decision.operation(), Operation::RunBash)?;
-        crate::decision_scope::require_permissions_match(
-            decision.permissions(),
-            &self.permissions,
-        )?;
+        decision.redeem(&self.permissions, Operation::RunBash)?;
         self.run_args_internal(args, stdin, directory, Some(approval), authority)
     }
 
@@ -643,11 +631,7 @@ impl<'a> Executor<'a> {
         approval: &ApprovalToken,
         authority: Authority,
     ) -> Result<Output> {
-        crate::decision_scope::require_decision_for(decision.operation(), Operation::RunBash)?;
-        crate::decision_scope::require_permissions_match(
-            decision.permissions(),
-            &self.permissions,
-        )?;
+        decision.redeem(&self.permissions, Operation::RunBash)?;
         // Fail-closed isolation gate (most-paranoid #2).
         self.enforce_isolation()?;
         // Check temporal constraints
@@ -708,11 +692,7 @@ impl<'a> Executor<'a> {
         decision: DecisionToken,
         authority: Authority,
     ) -> Result<Output> {
-        crate::decision_scope::require_decision_for(decision.operation(), Operation::RunBash)?;
-        crate::decision_scope::require_permissions_match(
-            decision.permissions(),
-            &self.permissions,
-        )?;
+        decision.redeem(&self.permissions, Operation::RunBash)?;
         // Fail-closed isolation gate (most-paranoid #2).
         self.enforce_isolation()?;
         // Check temporal constraints
@@ -762,11 +742,7 @@ impl<'a> Executor<'a> {
         approval: &ApprovalToken,
         authority: Authority,
     ) -> Result<Output> {
-        crate::decision_scope::require_decision_for(decision.operation(), Operation::RunBash)?;
-        crate::decision_scope::require_permissions_match(
-            decision.permissions(),
-            &self.permissions,
-        )?;
+        decision.redeem(&self.permissions, Operation::RunBash)?;
         // Fail-closed isolation gate (most-paranoid #2).
         self.enforce_isolation()?;
         // Check temporal constraints

--- a/crates/nucleus/src/command.rs
+++ b/crates/nucleus/src/command.rs
@@ -125,6 +125,14 @@ pub struct Executor<'a> {
     /// Isolation the policy demands (`effective_minimum_isolation`); the achieved
     /// containment must meet this or the spawn is refused (most-paranoid #2).
     required_isolation: IsolationLattice,
+    /// Checksum of the permissions this executor runs under.
+    ///
+    /// A `DecisionToken` carries the checksum of the permissions it was decided
+    /// against, and `run` refuses a token whose checksum is not this one. Before
+    /// this, the redeem-side check compared two `Operation`s and consulted no
+    /// state at all, so a token decided under one policy was redeemable under
+    /// any other.
+    permissions: String,
     /// The declared containment posture. Default fails closed.
     containment: ContainmentMode,
     /// The sealed effects home (B1) that *both* the synchronous and the async
@@ -153,6 +161,7 @@ impl<'a> Executor<'a> {
         budget: &'a AtomicBudget,
     ) -> Self {
         let normalized = policy.clone().normalize();
+        let permissions = normalized.checksum();
         // The required isolation is the policy's declared minimum; absent any
         // requirement it resolves to the weakest level (localhost = "no requirement").
         let required_isolation = normalized.effective_minimum_isolation();
@@ -176,6 +185,7 @@ impl<'a> Executor<'a> {
             approver: None,
             allowed_env: BTreeMap::new(),
             required_isolation,
+            permissions,
             containment: ContainmentMode::Unconfigured,
             effects,
         }
@@ -408,6 +418,10 @@ impl<'a> Executor<'a> {
         authority: Authority,
     ) -> Result<Output> {
         crate::decision_scope::require_decision_for(decision.operation(), Operation::RunBash)?;
+        crate::decision_scope::require_permissions_match(
+            decision.permissions(),
+            &self.permissions,
+        )?;
         // Fail-closed isolation gate: refuse unless containment is declared and
         // meets the policy's required isolation (most-paranoid #2).
         self.enforce_isolation()?;
@@ -524,6 +538,10 @@ impl<'a> Executor<'a> {
         authority: Authority,
     ) -> Result<Output> {
         crate::decision_scope::require_decision_for(decision.operation(), Operation::RunBash)?;
+        crate::decision_scope::require_permissions_match(
+            decision.permissions(),
+            &self.permissions,
+        )?;
         self.run_args_internal(args, stdin, directory, None, authority)
     }
 
@@ -538,6 +556,10 @@ impl<'a> Executor<'a> {
         authority: Authority,
     ) -> Result<Output> {
         crate::decision_scope::require_decision_for(decision.operation(), Operation::RunBash)?;
+        crate::decision_scope::require_permissions_match(
+            decision.permissions(),
+            &self.permissions,
+        )?;
         self.run_args_internal(args, stdin, directory, Some(approval), authority)
     }
 
@@ -622,6 +644,10 @@ impl<'a> Executor<'a> {
         authority: Authority,
     ) -> Result<Output> {
         crate::decision_scope::require_decision_for(decision.operation(), Operation::RunBash)?;
+        crate::decision_scope::require_permissions_match(
+            decision.permissions(),
+            &self.permissions,
+        )?;
         // Fail-closed isolation gate (most-paranoid #2).
         self.enforce_isolation()?;
         // Check temporal constraints
@@ -683,6 +709,10 @@ impl<'a> Executor<'a> {
         authority: Authority,
     ) -> Result<Output> {
         crate::decision_scope::require_decision_for(decision.operation(), Operation::RunBash)?;
+        crate::decision_scope::require_permissions_match(
+            decision.permissions(),
+            &self.permissions,
+        )?;
         // Fail-closed isolation gate (most-paranoid #2).
         self.enforce_isolation()?;
         // Check temporal constraints
@@ -733,6 +763,10 @@ impl<'a> Executor<'a> {
         authority: Authority,
     ) -> Result<Output> {
         crate::decision_scope::require_decision_for(decision.operation(), Operation::RunBash)?;
+        crate::decision_scope::require_permissions_match(
+            decision.permissions(),
+            &self.permissions,
+        )?;
         // Fail-closed isolation gate (most-paranoid #2).
         self.enforce_isolation()?;
         // Check temporal constraints
@@ -1248,6 +1282,73 @@ mod tests {
             Authority::new(run_bundle("echo hello")),
         );
         assert!(result.is_ok());
+    }
+
+    /// End to end: a token decided by a kernel under one policy is refused by an
+    /// executor running another.
+    ///
+    /// This is the A-19 probe for the redeem-side check, on the real types
+    /// rather than on two strings. Before it, the only redeem-side question was
+    /// "is this the right Operation?", and the answer for a token from an
+    /// entirely different policy was yes.
+    #[test]
+    fn a_token_from_another_policy_is_refused_by_this_executor() {
+        let tmp = tempdir().unwrap();
+
+        // Kernel A: bash allowed.
+        let lenient = test_policy();
+        let mut kernel = Kernel::new(lenient.clone());
+        let foreign =
+            kernel.issue_approved_token(Operation::RunBash, "decided under the lenient policy");
+
+        // Executor B: a different policy entirely.
+        // Same shape, one capability different — so the refusal below is about
+        // the policy differing, not about the effect being disallowed.
+        let mut other = lenient.clone();
+        other.capabilities.write_files = CapabilityLevel::Never;
+
+        let sandbox = Sandbox::new(&other, tmp.path()).unwrap();
+        let budget = AtomicBudget::new(&test_budget());
+        let guard = MonotonicGuard::seconds(10);
+        let executor = Executor::new(&other, &sandbox, &budget)
+            .with_time_guard(&guard)
+            .allow_unsandboxed_local();
+
+        let err = executor
+            .run("true", foreign, Authority::new(run_bundle("true")))
+            .expect_err("a decision does not carry across a change of policy");
+        assert!(
+            matches!(err, NucleusError::ScopeMismatch { .. }),
+            "expected a scope mismatch, got {err:?}"
+        );
+        assert!(
+            err.to_string().contains("change of policy"),
+            "the refusal says why: {err}"
+        );
+    }
+
+    /// …and the same executor accepts its own kernel's token, so the check above
+    /// is not passing by refusing everything.
+    #[test]
+    fn a_token_from_this_policy_is_accepted() {
+        let tmp = tempdir().unwrap();
+        // The shared helper: a policy the executor is known to run, so the only
+        // thing that could refuse here is the check under test.
+        let policy = test_policy();
+
+        let mut kernel = Kernel::new(policy.clone());
+        let token = kernel.issue_approved_token(Operation::RunBash, "decided under this policy");
+
+        let sandbox = Sandbox::new(&policy, tmp.path()).unwrap();
+        let budget = AtomicBudget::new(&test_budget());
+        let guard = MonotonicGuard::seconds(10);
+        let executor = Executor::new(&policy, &sandbox, &budget)
+            .with_time_guard(&guard)
+            .allow_unsandboxed_local();
+
+        executor
+            .run("true", token, Authority::new(run_bundle("true")))
+            .expect("a token decided under this very policy is redeemable");
     }
 
     #[test]

--- a/crates/nucleus/src/decision_scope.rs
+++ b/crates/nucleus/src/decision_scope.rs
@@ -54,9 +54,87 @@ pub(crate) fn require_decision_for(
     })
 }
 
+/// A decision may only be redeemed under the permissions it was taken against.
+///
+/// The affine discipline on `DecisionToken` proves it cannot be used TWICE — two
+/// `compile_fail` doctests on `Authority` next door prove the same for replay
+/// (E0382) and clone (E0599). It proves nothing about whether the token is still
+/// TRUE, and until now nothing else did either: [`require_decision_for`] above
+/// compares two `Operation`s and consults no state, so a token decided under one
+/// policy was redeemable under any other.
+///
+/// The token carries the checksum of the effective permissions at decision time;
+/// the executor carries the checksum of the permissions it is about to act
+/// under. Equal or refuse.
+///
+/// This is the first step of a validity interval, and the honest statement of
+/// what it bounds: **not elapsed time, but whether the thing the decision
+/// depended on is the thing being executed under.** It does not yet catch a
+/// budget spent or an approval consumed between decision and effect — those are
+/// kernel state the executor does not hold — and it does not re-read the kernel,
+/// so a policy attenuated after this executor was built is not seen. Both are
+/// the next steps, and both are cheap once the fingerprint is on the token.
+pub(crate) fn require_permissions_match(
+    decided_under: &str,
+    executing_under: &str,
+) -> Result<(), NucleusError> {
+    if decided_under == executing_under {
+        return Ok(());
+    }
+    Err(NucleusError::ScopeMismatch {
+        reason: format!(
+            "decision was taken against permissions {} but this effect runs under {}: \
+             a decision does not carry across a change of policy",
+            short(decided_under),
+            short(executing_under)
+        ),
+    })
+}
+
+/// First eight hex characters, or the whole string when it is shorter.
+///
+/// Enough to tell two checksums apart in a message; the full digest belongs in
+/// the trace, not in an error a human reads.
+fn short(digest: &str) -> &str {
+    digest.get(..8).unwrap_or(digest)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn permissions_that_match_are_accepted() {
+        assert!(require_permissions_match("abc123", "abc123").is_ok());
+    }
+
+    #[test]
+    fn a_decision_taken_under_other_permissions_is_refused() {
+        // THE property. Before this, the redeem side compared two `Operation`s
+        // and consulted no state at all, so a token decided under one policy was
+        // redeemable under any other. The affine discipline proved the token
+        // could not be used twice; nothing proved it was still true.
+        let err = require_permissions_match("aaaaaaaabbbb", "ccccccccdddd")
+            .expect_err("a decision does not carry across a change of policy");
+        assert!(matches!(err, NucleusError::ScopeMismatch { .. }));
+        let msg = err.to_string();
+        assert!(
+            msg.contains("aaaaaaaa"),
+            "names what it was decided under: {msg}"
+        );
+        assert!(
+            msg.contains("cccccccc"),
+            "and what it would run under: {msg}"
+        );
+    }
+
+    #[test]
+    fn the_message_shortens_a_digest_without_losing_a_short_one() {
+        // Eight hex characters is enough to tell two checksums apart; the full
+        // digest belongs in the trace, not in an error a human reads.
+        assert_eq!(short("0123456789abcdef"), "01234567");
+        assert_eq!(short("tiny"), "tiny");
+    }
 
     #[test]
     fn a_matching_decision_is_accepted() {

--- a/crates/nucleus/src/decision_scope.rs
+++ b/crates/nucleus/src/decision_scope.rs
@@ -32,8 +32,6 @@
 //! caller cannot present a decision about one act while spending an authority
 //! for another.
 
-use portcullis::Operation;
-
 use crate::error::NucleusError;
 
 /// Refuse a decision that was made about a different operation.
@@ -42,82 +40,65 @@ use crate::error::NucleusError;
 /// uses for "earned for a different action", because that is what this is.
 ///
 /// Checked in every profile. That is the whole point; see the module docs.
-pub(crate) fn require_decision_for(
-    decision_op: Operation,
-    performing: Operation,
-) -> Result<(), NucleusError> {
-    if decision_op == performing {
-        return Ok(());
+/// A refused redeem becomes a scope mismatch.
+///
+/// Both variants are the same kind of failure to a caller — the decision does
+/// not authorise this effect — and the message says which kind it was.
+///
+/// # Why this module is now three lines
+///
+/// It used to hold `require_decision_for`, which compared two `Operation`s and
+/// consulted no state, and callers were trusted to also compare permissions.
+/// They mostly did not: 24 of the 30 redeem sites in this crate checked the
+/// operation and nothing else, so a decision taken under one policy was
+/// redeemable under any other at every one of them.
+///
+/// The check now lives on the token as [`portcullis::kernel::DecisionToken::redeem`],
+/// which takes `self` by value and requires both the operation and the
+/// permissions in force. `DecisionToken::operation` is `pub(crate)` to
+/// portcullis, so there is no other way to read what a token authorises — a new
+/// effect method cannot forget, because there is nothing else to call.
+impl From<portcullis::kernel::RedeemError> for NucleusError {
+    fn from(e: portcullis::kernel::RedeemError) -> Self {
+        Self::ScopeMismatch {
+            reason: e.to_string(),
+        }
     }
-    Err(NucleusError::ScopeMismatch {
-        reason: format!("decision authorises {decision_op:?}, this effect is {performing:?}"),
-    })
-}
-
-/// A decision may only be redeemed under the permissions it was taken against.
-///
-/// The affine discipline on `DecisionToken` proves it cannot be used TWICE — two
-/// `compile_fail` doctests on `Authority` next door prove the same for replay
-/// (E0382) and clone (E0599). It proves nothing about whether the token is still
-/// TRUE, and until now nothing else did either: [`require_decision_for`] above
-/// compares two `Operation`s and consults no state, so a token decided under one
-/// policy was redeemable under any other.
-///
-/// The token carries the checksum of the effective permissions at decision time;
-/// the executor carries the checksum of the permissions it is about to act
-/// under. Equal or refuse.
-///
-/// This is the first step of a validity interval, and the honest statement of
-/// what it bounds: **not elapsed time, but whether the thing the decision
-/// depended on is the thing being executed under.** It does not yet catch a
-/// budget spent or an approval consumed between decision and effect — those are
-/// kernel state the executor does not hold — and it does not re-read the kernel,
-/// so a policy attenuated after this executor was built is not seen. Both are
-/// the next steps, and both are cheap once the fingerprint is on the token.
-pub(crate) fn require_permissions_match(
-    decided_under: &str,
-    executing_under: &str,
-) -> Result<(), NucleusError> {
-    if decided_under == executing_under {
-        return Ok(());
-    }
-    Err(NucleusError::ScopeMismatch {
-        reason: format!(
-            "decision was taken against permissions {} but this effect runs under {}: \
-             a decision does not carry across a change of policy",
-            short(decided_under),
-            short(executing_under)
-        ),
-    })
-}
-
-/// First eight hex characters, or the whole string when it is shorter.
-///
-/// Enough to tell two checksums apart in a message; the full digest belongs in
-/// the trace, not in an error a human reads.
-fn short(digest: &str) -> &str {
-    digest.get(..8).unwrap_or(digest)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use portcullis::Operation;
+    use portcullis::kernel::RedeemError;
 
+    /// THE regression, preserved. This check used to be
+    /// `debug_assert_eq!(decision.operation(), op, ..)`, which compiles to
+    /// nothing when `debug_assertions` is off — every release build — so a
+    /// `DecisionToken` minted for `ReadFiles` and handed to a `RunBash` entry
+    /// point was accepted exactly as readily as the right one.
+    ///
+    /// It is now a refusal in both profiles, and it is no longer a call site's
+    /// job to remember: `DecisionToken::redeem` is the only way to read a token.
+    /// The property lives with `redeem` in portcullis; this pins that the
+    /// refusal still arrives here as a `ScopeMismatch` rather than being
+    /// swallowed.
     #[test]
-    fn permissions_that_match_are_accepted() {
-        assert!(require_permissions_match("abc123", "abc123").is_ok());
-    }
+    fn a_refused_redeem_arrives_as_a_scope_mismatch() {
+        let scope = NucleusError::from(RedeemError::ScopeMismatch {
+            authorised: Operation::ReadFiles,
+            performing: Operation::RunBash,
+        });
+        assert!(matches!(scope, NucleusError::ScopeMismatch { .. }));
+        assert!(scope.to_string().contains("ReadFiles"), "{scope}");
+        assert!(scope.to_string().contains("RunBash"), "{scope}");
 
-    #[test]
-    fn a_decision_taken_under_other_permissions_is_refused() {
-        // THE property. Before this, the redeem side compared two `Operation`s
-        // and consulted no state at all, so a token decided under one policy was
-        // redeemable under any other. The affine discipline proved the token
-        // could not be used twice; nothing proved it was still true.
-        let err = require_permissions_match("aaaaaaaabbbb", "ccccccccdddd")
-            .expect_err("a decision does not carry across a change of policy");
-        assert!(matches!(err, NucleusError::ScopeMismatch { .. }));
-        let msg = err.to_string();
+        let stale = NucleusError::from(RedeemError::StalePermissions {
+            decided_under: "aaaaaaaabbbb".to_string(),
+            executing_under: "ccccccccdddd".to_string(),
+        });
+        assert!(matches!(stale, NucleusError::ScopeMismatch { .. }));
+        let msg = stale.to_string();
         assert!(
             msg.contains("aaaaaaaa"),
             "names what it was decided under: {msg}"
@@ -126,54 +107,6 @@ mod tests {
             msg.contains("cccccccc"),
             "and what it would run under: {msg}"
         );
-    }
-
-    #[test]
-    fn the_message_shortens_a_digest_without_losing_a_short_one() {
-        // Eight hex characters is enough to tell two checksums apart; the full
-        // digest belongs in the trace, not in an error a human reads.
-        assert_eq!(short("0123456789abcdef"), "01234567");
-        assert_eq!(short("tiny"), "tiny");
-    }
-
-    #[test]
-    fn a_matching_decision_is_accepted() {
-        assert!(require_decision_for(Operation::RunBash, Operation::RunBash).is_ok());
-    }
-
-    /// THE regression. Under `debug_assert_eq!` this case PANICKED in a debug
-    /// build and was SILENTLY ACCEPTED in a release one. It is now a refusal in
-    /// both.
-    #[test]
-    fn a_decision_about_another_operation_is_refused() {
-        let err = require_decision_for(Operation::ReadFiles, Operation::RunBash)
-            .expect_err("a decision about ReadFiles must not authorise RunBash");
-        assert!(
-            matches!(err, NucleusError::ScopeMismatch { .. }),
-            "a decision for the wrong operation is a scope mismatch, got {err:?}"
-        );
-    }
-
-    /// The message has to name BOTH sides, or it sends the reader to inspect
-    /// the wrong one. `15e3530f`'s lesson (ADR 0007 A-4) in a smaller place.
-    #[test]
-    fn the_refusal_names_what_was_held_and_what_was_attempted() {
-        let err = require_decision_for(Operation::ReadFiles, Operation::RunBash)
-            .expect_err("must refuse");
-        let msg = err.to_string();
-        assert!(msg.contains("ReadFiles"), "{msg}");
-        assert!(msg.contains("RunBash"), "{msg}");
-    }
-
-    /// Non-vacuity: the refusal test above would pass against a function that
-    /// refused everything. Every operation must authorise itself.
-    #[test]
-    fn every_operation_authorises_itself() {
-        for op in Operation::ALL {
-            assert!(
-                require_decision_for(op, op).is_ok(),
-                "{op:?} must authorise itself"
-            );
-        }
+        assert!(msg.contains("change of policy"), "{msg}");
     }
 }

--- a/crates/nucleus/src/sandbox.rs
+++ b/crates/nucleus/src/sandbox.rs
@@ -57,6 +57,12 @@ pub struct Sandbox {
     obligations: Obligations,
     /// Approver for approval-gated operations
     approver: Option<Arc<dyn Approver>>,
+    /// Checksum of the permissions this sandbox enforces.
+    ///
+    /// `DecisionToken::redeem` requires it, so every redeem site here names what
+    /// it is executing under. Before `redeem` existed, all 24 of this file's
+    /// redeem sites checked the operation and nothing else.
+    permissions: String,
     /// The log every authority spent through this sandbox is recorded against.
     ///
     /// Sandbox writes spend their authority DIRECTLY, in `spend_as`, rather than
@@ -82,6 +88,7 @@ impl Sandbox {
     pub fn new(policy: &PermissionLattice, root: impl AsRef<Path>) -> Result<Self> {
         let root_path = root.as_ref().to_path_buf();
         let normalized = policy.clone().normalize();
+        let permissions = normalized.checksum();
 
         // Open the root directory - this is our capability handle
         let root_dir = Dir::open_ambient_dir(&root_path, cap_std::ambient_authority())?;
@@ -94,6 +101,7 @@ impl Sandbox {
             capabilities: normalized.capabilities,
             obligations: normalized.obligations,
             approver: None,
+            permissions,
         })
     }
 
@@ -143,7 +151,7 @@ impl Sandbox {
         decision: DecisionToken,
         authority: Authority,
     ) -> Result<File> {
-        crate::decision_scope::require_decision_for(decision.operation(), Operation::ReadFiles)?;
+        decision.redeem(&self.permissions, Operation::ReadFiles)?;
         self.spend_as(authority, Operation::ReadFiles, SinkClass::AuditLogAppend)?;
         self.open_internal(path.as_ref(), None)
     }
@@ -156,7 +164,7 @@ impl Sandbox {
         approval: &ApprovalToken,
         authority: Authority,
     ) -> Result<File> {
-        crate::decision_scope::require_decision_for(decision.operation(), Operation::ReadFiles)?;
+        decision.redeem(&self.permissions, Operation::ReadFiles)?;
         self.spend_as(authority, Operation::ReadFiles, SinkClass::AuditLogAppend)?;
         self.open_internal(path.as_ref(), Some(approval))
     }
@@ -185,7 +193,7 @@ impl Sandbox {
         decision: DecisionToken,
         authority: Authority,
     ) -> Result<File> {
-        crate::decision_scope::require_decision_for(decision.operation(), Operation::EditFiles)?;
+        decision.redeem(&self.permissions, Operation::EditFiles)?;
         self.spend_as(authority, Operation::EditFiles, SinkClass::WorkspaceWrite)?;
         self.open_with_internal(path.as_ref(), options, None)
     }
@@ -199,7 +207,7 @@ impl Sandbox {
         approval: &ApprovalToken,
         authority: Authority,
     ) -> Result<File> {
-        crate::decision_scope::require_decision_for(decision.operation(), Operation::EditFiles)?;
+        decision.redeem(&self.permissions, Operation::EditFiles)?;
         self.spend_as(authority, Operation::EditFiles, SinkClass::WorkspaceWrite)?;
         self.open_with_internal(path.as_ref(), options, Some(approval))
     }
@@ -229,7 +237,7 @@ impl Sandbox {
         decision: DecisionToken,
         authority: Authority,
     ) -> Result<File> {
-        crate::decision_scope::require_decision_for(decision.operation(), Operation::WriteFiles)?;
+        decision.redeem(&self.permissions, Operation::WriteFiles)?;
         self.spend_as(authority, Operation::WriteFiles, SinkClass::WorkspaceWrite)?;
         self.create_internal(path.as_ref(), None)
     }
@@ -242,7 +250,7 @@ impl Sandbox {
         approval: &ApprovalToken,
         authority: Authority,
     ) -> Result<File> {
-        crate::decision_scope::require_decision_for(decision.operation(), Operation::WriteFiles)?;
+        decision.redeem(&self.permissions, Operation::WriteFiles)?;
         self.spend_as(authority, Operation::WriteFiles, SinkClass::WorkspaceWrite)?;
         self.create_internal(path.as_ref(), Some(approval))
     }
@@ -264,7 +272,7 @@ impl Sandbox {
         decision: DecisionToken,
         authority: Authority,
     ) -> Result<Vec<u8>> {
-        crate::decision_scope::require_decision_for(decision.operation(), Operation::ReadFiles)?;
+        decision.redeem(&self.permissions, Operation::ReadFiles)?;
         self.spend_as(authority, Operation::ReadFiles, SinkClass::AuditLogAppend)?;
         self.read_internal(path.as_ref(), None)
     }
@@ -277,7 +285,7 @@ impl Sandbox {
         approval: &ApprovalToken,
         authority: Authority,
     ) -> Result<Vec<u8>> {
-        crate::decision_scope::require_decision_for(decision.operation(), Operation::ReadFiles)?;
+        decision.redeem(&self.permissions, Operation::ReadFiles)?;
         self.spend_as(authority, Operation::ReadFiles, SinkClass::AuditLogAppend)?;
         self.read_internal(path.as_ref(), Some(approval))
     }
@@ -299,7 +307,7 @@ impl Sandbox {
         decision: DecisionToken,
         authority: Authority,
     ) -> Result<String> {
-        crate::decision_scope::require_decision_for(decision.operation(), Operation::ReadFiles)?;
+        decision.redeem(&self.permissions, Operation::ReadFiles)?;
         self.spend_as(authority, Operation::ReadFiles, SinkClass::AuditLogAppend)?;
         self.read_to_string_internal(path.as_ref(), None)
     }
@@ -312,7 +320,7 @@ impl Sandbox {
         approval: &ApprovalToken,
         authority: Authority,
     ) -> Result<String> {
-        crate::decision_scope::require_decision_for(decision.operation(), Operation::ReadFiles)?;
+        decision.redeem(&self.permissions, Operation::ReadFiles)?;
         self.spend_as(authority, Operation::ReadFiles, SinkClass::AuditLogAppend)?;
         self.read_to_string_internal(path.as_ref(), Some(approval))
     }
@@ -374,7 +382,7 @@ impl Sandbox {
         // minted — "bundle authorises EditFiles/WorkspaceWrite, this effect is
         // WriteFiles/WorkspaceWrite" — measured on a live pod.
         let op = self.write_operation_for(path.as_ref());
-        crate::decision_scope::require_decision_for(decision.operation(), op)?;
+        decision.redeem(&self.permissions, op)?;
         self.spend_as(authority, op, SinkClass::WorkspaceWrite)?;
         self.write_internal(path.as_ref(), contents, None)
     }
@@ -400,7 +408,7 @@ impl Sandbox {
         // minted — "bundle authorises EditFiles/WorkspaceWrite, this effect is
         // WriteFiles/WorkspaceWrite" — measured on a live pod.
         let op = self.write_operation_for(path.as_ref());
-        crate::decision_scope::require_decision_for(decision.operation(), op)?;
+        decision.redeem(&self.permissions, op)?;
         self.spend_as(authority, op, SinkClass::WorkspaceWrite)?;
         self.write_internal(path.as_ref(), contents, Some(approval))
     }
@@ -448,7 +456,7 @@ impl Sandbox {
         decision: DecisionToken,
         authority: Authority,
     ) -> Result<()> {
-        crate::decision_scope::require_decision_for(decision.operation(), Operation::WriteFiles)?;
+        decision.redeem(&self.permissions, Operation::WriteFiles)?;
         self.spend_as(authority, Operation::WriteFiles, SinkClass::WorkspaceWrite)?;
         self.create_dir_internal(path.as_ref(), None)
     }
@@ -461,7 +469,7 @@ impl Sandbox {
         approval: &ApprovalToken,
         authority: Authority,
     ) -> Result<()> {
-        crate::decision_scope::require_decision_for(decision.operation(), Operation::WriteFiles)?;
+        decision.redeem(&self.permissions, Operation::WriteFiles)?;
         self.spend_as(authority, Operation::WriteFiles, SinkClass::WorkspaceWrite)?;
         self.create_dir_internal(path.as_ref(), Some(approval))
     }
@@ -483,7 +491,7 @@ impl Sandbox {
         decision: DecisionToken,
         authority: Authority,
     ) -> Result<()> {
-        crate::decision_scope::require_decision_for(decision.operation(), Operation::WriteFiles)?;
+        decision.redeem(&self.permissions, Operation::WriteFiles)?;
         self.spend_as(authority, Operation::WriteFiles, SinkClass::WorkspaceWrite)?;
         self.create_dir_all_internal(path.as_ref(), None)
     }
@@ -496,7 +504,7 @@ impl Sandbox {
         approval: &ApprovalToken,
         authority: Authority,
     ) -> Result<()> {
-        crate::decision_scope::require_decision_for(decision.operation(), Operation::WriteFiles)?;
+        decision.redeem(&self.permissions, Operation::WriteFiles)?;
         self.spend_as(authority, Operation::WriteFiles, SinkClass::WorkspaceWrite)?;
         self.create_dir_all_internal(path.as_ref(), Some(approval))
     }
@@ -518,7 +526,7 @@ impl Sandbox {
         decision: DecisionToken,
         authority: Authority,
     ) -> Result<()> {
-        crate::decision_scope::require_decision_for(decision.operation(), Operation::EditFiles)?;
+        decision.redeem(&self.permissions, Operation::EditFiles)?;
         self.spend_as(authority, Operation::EditFiles, SinkClass::WorkspaceWrite)?;
         self.remove_file_internal(path.as_ref(), None)
     }
@@ -531,7 +539,7 @@ impl Sandbox {
         approval: &ApprovalToken,
         authority: Authority,
     ) -> Result<()> {
-        crate::decision_scope::require_decision_for(decision.operation(), Operation::EditFiles)?;
+        decision.redeem(&self.permissions, Operation::EditFiles)?;
         self.spend_as(authority, Operation::EditFiles, SinkClass::WorkspaceWrite)?;
         self.remove_file_internal(path.as_ref(), Some(approval))
     }
@@ -553,7 +561,7 @@ impl Sandbox {
         decision: DecisionToken,
         authority: Authority,
     ) -> Result<()> {
-        crate::decision_scope::require_decision_for(decision.operation(), Operation::EditFiles)?;
+        decision.redeem(&self.permissions, Operation::EditFiles)?;
         self.spend_as(authority, Operation::EditFiles, SinkClass::WorkspaceWrite)?;
         self.remove_dir_internal(path.as_ref(), None)
     }
@@ -566,7 +574,7 @@ impl Sandbox {
         approval: &ApprovalToken,
         authority: Authority,
     ) -> Result<()> {
-        crate::decision_scope::require_decision_for(decision.operation(), Operation::EditFiles)?;
+        decision.redeem(&self.permissions, Operation::EditFiles)?;
         self.spend_as(authority, Operation::EditFiles, SinkClass::WorkspaceWrite)?;
         self.remove_dir_internal(path.as_ref(), Some(approval))
     }
@@ -588,7 +596,7 @@ impl Sandbox {
     /// not there" (ADR 0007 A-2). Before the scope check was enforced there was
     /// no third answer to return, so there was no reason for the `Result`.
     pub fn exists(&self, path: impl AsRef<Path>, decision: DecisionToken) -> Result<bool> {
-        crate::decision_scope::require_decision_for(decision.operation(), Operation::ReadFiles)?;
+        decision.redeem(&self.permissions, Operation::ReadFiles)?;
         Ok(self.exists_internal(path.as_ref(), None))
     }
 
@@ -599,7 +607,7 @@ impl Sandbox {
         decision: DecisionToken,
         approval: &ApprovalToken,
     ) -> Result<bool> {
-        crate::decision_scope::require_decision_for(decision.operation(), Operation::ReadFiles)?;
+        decision.redeem(&self.permissions, Operation::ReadFiles)?;
         Ok(self.exists_internal(path.as_ref(), Some(approval)))
     }
 
@@ -816,7 +824,7 @@ impl Sandbox {
         decision: DecisionToken,
         authority: Authority,
     ) -> Result<Sandbox> {
-        crate::decision_scope::require_decision_for(decision.operation(), Operation::ReadFiles)?;
+        decision.redeem(&self.permissions, Operation::ReadFiles)?;
         self.spend_as(authority, Operation::ReadFiles, SinkClass::AuditLogAppend)?;
         self.open_dir_internal(path.as_ref(), None)
     }
@@ -829,7 +837,7 @@ impl Sandbox {
         approval: &ApprovalToken,
         authority: Authority,
     ) -> Result<Sandbox> {
-        crate::decision_scope::require_decision_for(decision.operation(), Operation::ReadFiles)?;
+        decision.redeem(&self.permissions, Operation::ReadFiles)?;
         self.spend_as(authority, Operation::ReadFiles, SinkClass::AuditLogAppend)?;
         self.open_dir_internal(path.as_ref(), Some(approval))
     }
@@ -852,6 +860,10 @@ impl Sandbox {
             capabilities: self.capabilities.clone(),
             obligations: self.obligations.clone(),
             approver: self.approver.clone(),
+            // A subdirectory enforces the SAME permissions as its parent — the
+            // path narrows, the policy does not — so a token redeemable here is
+            // redeemable there.
+            permissions: self.permissions.clone(),
         })
     }
 }

--- a/crates/portcullis/src/kani.rs
+++ b/crates/portcullis/src/kani.rs
@@ -1663,7 +1663,7 @@ fn proof_decision_token_unforgeable() {
     if matches!(decision.verdict, Verdict::Allow) {
         assert!(token.is_some());
         let t = token.unwrap();
-        assert!(t.operation() == op);
+        assert!(t.operation == op);
         assert!(t.sequence() == decision.sequence);
     } else {
         assert!(token.is_none());
@@ -1689,7 +1689,7 @@ fn proof_denied_ops_have_no_token() {
 
 /// **E3 — Token operation matches decision operation.**
 ///
-/// For any operation, when a token is produced, its `operation()` and
+/// For any operation, when a token is produced, its `operation` field and
 /// `sequence()` must match the decision's fields exactly.
 #[kani::proof]
 #[kani::solver(cadical)]
@@ -1700,7 +1700,7 @@ fn proof_token_operation_matches_decision() {
     let op = arbitrary_operation();
     let (decision, token) = kernel.decide(op, "subject");
     if let Some(t) = token {
-        assert!(t.operation() == decision.operation);
+        assert!(t.operation == decision.operation);
         assert!(t.sequence() == decision.sequence);
     }
 }
@@ -1725,7 +1725,7 @@ fn proof_issue_approved_token_is_audited() {
     let token = kernel.issue_approved_token(op, "external-approval");
 
     // Token carries the correct operation
-    assert!(token.operation() == op);
+    assert!(token.operation == op);
     // Trace grew — the operation is auditable
     assert!(kernel.trace().len() > trace_len_before);
     // Exposure is monotonic — never decreases
@@ -1755,7 +1755,7 @@ fn proof_approved_token_bypass_is_audited() {
     let token = kernel.issue_approved_token(Operation::RunBash, "external-override");
 
     // But the bypass is audited
-    assert!(token.operation() == Operation::RunBash);
+    assert!(token.operation == Operation::RunBash);
     assert!(kernel.trace().len() > trace_len_before);
 }
 

--- a/crates/portcullis/src/kernel.rs
+++ b/crates/portcullis/src/kernel.rs
@@ -370,6 +370,56 @@ pub enum ApprovalSource {
     },
 }
 
+/// Why a [`DecisionToken`] could not be redeemed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RedeemError {
+    /// The decision authorises a different operation than the one being done.
+    ScopeMismatch {
+        /// What the decision authorises.
+        authorised: Operation,
+        /// What the effect is.
+        performing: Operation,
+    },
+    /// The decision was taken against permissions other than the ones in force.
+    StalePermissions {
+        /// Checksum of the permissions the decision was taken against.
+        decided_under: String,
+        /// Checksum of the permissions the effect would run under.
+        executing_under: String,
+    },
+}
+
+impl std::fmt::Display for RedeemError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        /// First eight hex characters: enough to tell two digests apart in a
+        /// message a human reads. The full digest belongs in the trace.
+        fn short(d: &str) -> &str {
+            d.get(..8).unwrap_or(d)
+        }
+        match self {
+            Self::ScopeMismatch {
+                authorised,
+                performing,
+            } => write!(
+                f,
+                "decision authorises {authorised:?}, this effect is {performing:?}"
+            ),
+            Self::StalePermissions {
+                decided_under,
+                executing_under,
+            } => write!(
+                f,
+                "decision was taken against permissions {} but this effect runs under {}: \
+                 a decision does not carry across a change of policy",
+                short(decided_under),
+                short(executing_under)
+            ),
+        }
+    }
+}
+
+impl std::error::Error for RedeemError {}
+
 /// Proof that Kernel::decide() returned Allow.
 ///
 /// This token is:
@@ -379,6 +429,10 @@ pub enum ApprovalSource {
 ///
 /// Only Kernel::decide() can create this token. Kani proof
 /// `proof_decision_token_unforgeable` verifies no other construction path exists.
+///
+/// The only way to USE one is [`DecisionToken::redeem`], which checks both
+/// that the decision authorises this operation and that it was taken against
+/// the permissions now in force.
 #[must_use = "DecisionToken must be consumed by executing the authorized operation"]
 pub struct DecisionToken {
     /// The operation this token authorizes.
@@ -403,9 +457,39 @@ pub struct DecisionToken {
 }
 
 impl DecisionToken {
-    /// The operation this token authorizes.
-    pub fn operation(&self) -> Operation {
-        self.operation
+    /// Consume this token to perform `performing` under `executing_under`.
+    ///
+    /// The only public way to use a `DecisionToken`, and it checks both things a
+    /// redeemer must check:
+    ///
+    /// * **scope** — the decision authorises the operation being performed;
+    /// * **currency** — the decision was taken against the very permissions the
+    ///   effect is about to run under.
+    ///
+    /// Taking `self` by value makes this the token's single use, so the affine
+    /// discipline and the two checks are one event rather than three things a
+    /// call site is trusted to do in order. A new effect method cannot read the
+    /// token without performing them: there is nothing else to call.
+    ///
+    /// # Errors
+    ///
+    /// [`RedeemError::ScopeMismatch`] when the decision authorises a different
+    /// operation; [`RedeemError::StalePermissions`] when it was taken against a
+    /// different policy.
+    pub fn redeem(self, executing_under: &str, performing: Operation) -> Result<(), RedeemError> {
+        if self.operation != performing {
+            return Err(RedeemError::ScopeMismatch {
+                authorised: self.operation,
+                performing,
+            });
+        }
+        if self.permissions != executing_under {
+            return Err(RedeemError::StalePermissions {
+                decided_under: self.permissions,
+                executing_under: executing_under.to_string(),
+            });
+        }
+        Ok(())
     }
 
     /// The decision sequence number for audit correlation.

--- a/crates/portcullis/src/kernel.rs
+++ b/crates/portcullis/src/kernel.rs
@@ -385,6 +385,19 @@ pub struct DecisionToken {
     pub(crate) operation: Operation,
     /// The decision sequence number for audit correlation.
     pub(crate) sequence: u64,
+    /// Checksum of the effective permissions this decision was taken against.
+    ///
+    /// The affine discipline on this type proves a token cannot be used TWICE.
+    /// It proves nothing about whether the token is still TRUE: the consume-side
+    /// check compared two `Operation`s and never consulted the state the
+    /// decision was made under. A token decided against one policy could be
+    /// redeemed under another.
+    ///
+    /// Carrying the fingerprint makes that answerable at the redeem site without
+    /// threading the kernel there. It is the first step of a validity interval,
+    /// and the honest name for what it bounds: not elapsed time, but whether the
+    /// thing the decision depended on is the thing being executed under.
+    pub(crate) permissions: String,
     /// Prevents external construction.
     _seal: (),
 }
@@ -398,6 +411,15 @@ impl DecisionToken {
     /// The decision sequence number for audit correlation.
     pub fn sequence(&self) -> u64 {
         self.sequence
+    }
+
+    /// Checksum of the effective permissions this decision was taken against.
+    ///
+    /// A redeemer compares this with the permissions it is about to execute
+    /// under, and refuses on a mismatch.
+    #[must_use]
+    pub fn permissions(&self) -> &str {
+        &self.permissions
     }
 }
 
@@ -1941,9 +1963,21 @@ impl Kernel {
         self.next_seq += 1;
 
         let token = if matches!(verdict, Verdict::Allow) {
+            // NORMALIZED, not `post_hash`. The kernel decides against
+            // `self.effective` as written; an executor enforces
+            // `policy.clone().normalize()`, and `normalize` is not the identity —
+            // it applies the uninhabitable-state constraint, which ADDS approval
+            // obligations. So the two sides hold different values of the same
+            // policy, and comparing the raw checksum would refuse every token
+            // for a policy that normalization changes.
+            //
+            // Computed only on the Allow branch, so the deny path does not pay
+            // for it, and `normalize` is idempotent (`permission_normalize_is_
+            // idempotent`) so an already-normalized policy costs a clone.
             Some(DecisionToken {
                 operation,
                 sequence: seq,
+                permissions: self.effective.clone().normalize().checksum(),
                 _seal: (),
             })
         } else {

--- a/crates/portcullis/src/kernel_tests.rs
+++ b/crates/portcullis/src/kernel_tests.rs
@@ -2066,3 +2066,64 @@ fn test_extract_host() {
     assert_eq!(extract_host("api.example.com"), "api.example.com");
     assert_eq!(extract_host("https://host.com"), "host.com");
 }
+
+// ── redeem: the only way to use a token ───────────────────────────────────────
+
+fn a_bash_token(kernel: &mut Kernel) -> DecisionToken {
+    kernel.issue_approved_token(Operation::RunBash, "test")
+}
+
+fn perms_of(kernel: &Kernel) -> String {
+    kernel.effective().clone().normalize().checksum()
+}
+
+#[test]
+fn a_token_redeems_under_the_permissions_it_was_decided_against() {
+    let mut kernel = Kernel::new(PermissionLattice::permissive());
+    let perms = perms_of(&kernel);
+    let token = a_bash_token(&mut kernel);
+    assert!(token.redeem(&perms, Operation::RunBash).is_ok());
+}
+
+#[test]
+fn a_token_is_refused_for_another_operation() {
+    // THE regression this replaces was `debug_assert_eq!`, which compiles to
+    // nothing in release: a token minted for one operation was accepted by the
+    // entry point of another in every shipped binary.
+    let mut kernel = Kernel::new(PermissionLattice::permissive());
+    let perms = perms_of(&kernel);
+    let token = a_bash_token(&mut kernel);
+    assert_eq!(
+        token.redeem(&perms, Operation::ReadFiles),
+        Err(RedeemError::ScopeMismatch {
+            authorised: Operation::RunBash,
+            performing: Operation::ReadFiles,
+        })
+    );
+}
+
+#[test]
+fn a_token_is_refused_under_other_permissions() {
+    let mut kernel = Kernel::new(PermissionLattice::permissive());
+    let token = a_bash_token(&mut kernel);
+    let elsewhere = PermissionLattice::restrictive().normalize().checksum();
+    let err = token
+        .redeem(&elsewhere, Operation::RunBash)
+        .expect_err("a decision does not carry across a change of policy");
+    assert!(matches!(err, RedeemError::StalePermissions { .. }));
+    assert!(err.to_string().contains("change of policy"), "{err}");
+}
+
+#[test]
+fn scope_is_checked_before_currency() {
+    // A token wrong on BOTH counts reports the operation mismatch, which is the
+    // one a caller can act on: the effect asked for the wrong authorisation, not
+    // merely a stale one.
+    let mut kernel = Kernel::new(PermissionLattice::permissive());
+    let token = a_bash_token(&mut kernel);
+    let elsewhere = PermissionLattice::restrictive().normalize().checksum();
+    assert!(matches!(
+        token.redeem(&elsewhere, Operation::ReadFiles),
+        Err(RedeemError::ScopeMismatch { .. })
+    ));
+}

--- a/crates/portcullis/src/lattice.rs
+++ b/crates/portcullis/src/lattice.rs
@@ -627,12 +627,32 @@ impl PermissionLattice {
         self.time.is_expired()
     }
 
-    /// Compute a checksum for integrity verification.
-    #[cfg(feature = "serde")]
+    /// Compute a checksum over WHAT IS PERMITTED, not over how it was made.
+    ///
+    /// Coherent with [`PartialEq`], which is the law this previously broke:
+    /// two values that compare equal must hash equal, and they did not. The old
+    /// implementation serialized the whole struct — `id`, `description` and
+    /// `derived_from` included — so a `meet` that produced the same policy under
+    /// a new label produced a different checksum, and the audit chain recorded
+    /// `pre_permissions_hash != post_permissions_hash`: a permission change that
+    /// had not happened.
+    ///
+    /// The non-serde variant used to hash `format!("{:?}", self)`. Derived
+    /// `Debug` is not a stability contract — a field rename or reorder silently
+    /// rewrites every hash — which is the defect #747 records for the receipt
+    /// chain, here on the permission checksum itself. Both variants now hash the
+    /// same projection, so the two builds agree on what a policy hashes to.
+    #[must_use]
     pub fn checksum(&self) -> String {
-        let data = serde_json::to_string(self).unwrap_or_default();
         let mut hasher = Sha256::new();
-        hasher.update(data.as_bytes());
+        // Field-tagged and length-prefixed: without the tags, moving a byte from
+        // one field to the next would leave the digest unchanged.
+        for (tag, part) in self.digest_parts() {
+            hasher.update(tag.as_bytes());
+            hasher.update(b"\x00");
+            hasher.update((part.len() as u64).to_be_bytes());
+            hasher.update(part.as_bytes());
+        }
         hasher
             .finalize()
             .iter()
@@ -640,17 +660,62 @@ impl PermissionLattice {
             .collect::<String>()
     }
 
-    /// Compute a checksum for integrity verification (non-serde version).
+    /// The policy fields, in a fixed order, each as a stable string.
+    ///
+    /// Exactly the fields [`PartialEq`] compares — the two must not drift apart,
+    /// and `checksum_agrees_with_equality` pins that they do not.
+    #[cfg(feature = "serde")]
+    fn digest_parts(&self) -> Vec<(&'static str, String)> {
+        vec![
+            (
+                "capabilities",
+                serde_json::to_string(&self.capabilities).unwrap_or_default(),
+            ),
+            (
+                "obligations",
+                serde_json::to_string(&self.obligations).unwrap_or_default(),
+            ),
+            (
+                "paths",
+                serde_json::to_string(&self.paths).unwrap_or_default(),
+            ),
+            (
+                "budget",
+                serde_json::to_string(&self.budget).unwrap_or_default(),
+            ),
+            (
+                "commands",
+                serde_json::to_string(&self.commands).unwrap_or_default(),
+            ),
+            (
+                "time",
+                serde_json::to_string(&self.time).unwrap_or_default(),
+            ),
+            (
+                "minimum_isolation",
+                serde_json::to_string(&self.minimum_isolation).unwrap_or_default(),
+            ),
+            ("uninhabitable", self.uninhabitable_constraint.to_string()),
+        ]
+    }
+
+    /// Debug-based fallback for builds without `serde`.
+    ///
+    /// Still not a stability contract across compiler versions, but now over the
+    /// same eight fields as the serde path rather than over the whole struct, so
+    /// the two agree about which values are the same policy.
     #[cfg(not(feature = "serde"))]
-    pub fn checksum(&self) -> String {
-        let data = format!("{:?}", self);
-        let mut hasher = Sha256::new();
-        hasher.update(data.as_bytes());
-        hasher
-            .finalize()
-            .iter()
-            .map(|b| format!("{b:02x}"))
-            .collect::<String>()
+    fn digest_parts(&self) -> Vec<(&'static str, String)> {
+        vec![
+            ("capabilities", format!("{:?}", self.capabilities)),
+            ("obligations", format!("{:?}", self.obligations)),
+            ("paths", format!("{:?}", self.paths)),
+            ("budget", format!("{:?}", self.budget)),
+            ("commands", format!("{:?}", self.commands)),
+            ("time", format!("{:?}", self.time)),
+            ("minimum_isolation", format!("{:?}", self.minimum_isolation)),
+            ("uninhabitable", self.uninhabitable_constraint.to_string()),
+        ]
     }
 
     /// Create a permissive permission set (for trusted contexts).
@@ -1441,12 +1506,49 @@ impl EffectivePermissions {
     /// Create effective permissions from a lattice.
     pub fn new(lattice: PermissionLattice) -> Self {
         let lattice = lattice.normalize();
-        let checksum = lattice.checksum();
+        let checksum = Self::seal(&lattice);
         Self {
             lattice,
             budget_reservation_id: None,
             checksum,
         }
+    }
+
+    /// The tamper seal: a digest over the WHOLE value, provenance included.
+    ///
+    /// Deliberately not [`PermissionLattice::checksum`], which answers a
+    /// different question. That one asks *what is permitted*, and is coherent
+    /// with `PartialEq`: two policies that permit the same things hash the same,
+    /// so relabelling one does not read as a permission change in the audit
+    /// chain.
+    ///
+    /// This one asks *is this exact value the one I sealed*, and the answer must
+    /// be no if `description` or `derived_from` moved — an audit label a
+    /// reviewer reads is worth sealing even though it grants nothing.
+    /// `effective_permissions_detect_tampering` is the test that says so, and it
+    /// is right: a sealed structure seals everything it carries.
+    ///
+    /// Two questions, two digests. Collapsing them is what made the permission
+    /// checksum incoherent with equality in the first place.
+    fn seal(lattice: &PermissionLattice) -> String {
+        let mut hasher = Sha256::new();
+        hasher.update(b"portcullis-effective-permissions-seal-v1\x00");
+        hasher.update(lattice.checksum().as_bytes());
+        hasher.update(b"\x00");
+        hasher.update(lattice.id.as_bytes());
+        hasher.update(b"\x00");
+        hasher.update((lattice.description.len() as u64).to_be_bytes());
+        hasher.update(lattice.description.as_bytes());
+        hasher.update(b"\x00");
+        match lattice.derived_from {
+            Some(from) => hasher.update(from.as_bytes()),
+            None => hasher.update(b"none"),
+        }
+        hasher
+            .finalize()
+            .iter()
+            .map(|b| format!("{b:02x}"))
+            .collect::<String>()
     }
 
     /// Create effective permissions with a budget reservation.
@@ -1456,8 +1558,12 @@ impl EffectivePermissions {
     }
 
     /// Verify the integrity of the permissions.
+    ///
+    /// Detects any mutation of the sealed value, including a changed
+    /// `description` or `derived_from` — see [`Self::seal`] for why that is a
+    /// different question from "what is permitted".
     pub fn verify_integrity(&self) -> bool {
-        self.lattice.checksum() == self.checksum
+        Self::seal(&self.lattice) == self.checksum
     }
 
     /// Check if permissions have expired.
@@ -1541,6 +1647,49 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn checksum_agrees_with_equality() {
+        // The `Hash`/`Eq` coherence law, which the old checksum broke: it
+        // serialized the whole struct, so a `meet` producing the same policy
+        // under a new label produced a different digest and the audit chain
+        // recorded `pre_permissions_hash != post_permissions_hash` — a
+        // permission change that had not happened.
+        let a = PermissionLattice::restrictive();
+        let mut b = a.clone();
+        b.id = Uuid::new_v4();
+        b.description = "a different label".to_string();
+        b.derived_from = Some(Uuid::new_v4());
+        assert_eq!(a, b, "same policy");
+        assert_eq!(a.checksum(), b.checksum(), "so the same checksum");
+
+        // …and it still separates policies that differ.
+        let c = PermissionLattice::permissive();
+        assert_ne!(a, c);
+        assert_ne!(a.checksum(), c.checksum());
+    }
+
+    #[test]
+    fn the_seal_asks_a_different_question_from_the_checksum() {
+        // Relabelling does not change what is permitted, so the checksum holds;
+        // it DOES change the sealed value, so integrity fails. Two questions,
+        // two digests — collapsing them is what made the checksum incoherent
+        // with equality in the first place.
+        let sealed = EffectivePermissions::new(PermissionLattice::restrictive());
+        assert!(sealed.verify_integrity());
+
+        let mut tampered = sealed.clone();
+        tampered.lattice.description = "tampered".to_string();
+        assert_eq!(
+            tampered.lattice.checksum(),
+            sealed.lattice.checksum(),
+            "relabelling permits nothing new"
+        );
+        assert!(
+            !tampered.verify_integrity(),
+            "but the seal covers the label a reviewer reads"
+        );
     }
 
     #[test]

--- a/crates/portcullis/src/lattice.rs
+++ b/crates/portcullis/src/lattice.rs
@@ -663,59 +663,45 @@ impl PermissionLattice {
     /// The policy fields, in a fixed order, each as a stable string.
     ///
     /// Exactly the fields [`PartialEq`] compares — the two must not drift apart,
-    /// and `checksum_agrees_with_equality` pins that they do not.
-    #[cfg(feature = "serde")]
+    /// and `every_policy_field_reaches_the_digest` pins that each one actually
+    /// arrives.
+    ///
+    /// ONE function, with the feature split pushed down into [`Self::encode`].
+    /// It was two — a `#[cfg(feature = "serde")]` body and a `#[cfg(not(..))]`
+    /// one — and mutation testing reported five survivors against the second.
+    /// They survived because `--all-features` does not compile it: mutating code
+    /// that is `cfg`-ed out changes nothing, so every mutant passed. A function
+    /// no build in CI compiles is a function no test can defend, and splitting
+    /// on the feature at the top of a body is how that happens.
     fn digest_parts(&self) -> Vec<(&'static str, String)> {
         vec![
-            (
-                "capabilities",
-                serde_json::to_string(&self.capabilities).unwrap_or_default(),
-            ),
-            (
-                "obligations",
-                serde_json::to_string(&self.obligations).unwrap_or_default(),
-            ),
-            (
-                "paths",
-                serde_json::to_string(&self.paths).unwrap_or_default(),
-            ),
-            (
-                "budget",
-                serde_json::to_string(&self.budget).unwrap_or_default(),
-            ),
-            (
-                "commands",
-                serde_json::to_string(&self.commands).unwrap_or_default(),
-            ),
-            (
-                "time",
-                serde_json::to_string(&self.time).unwrap_or_default(),
-            ),
-            (
-                "minimum_isolation",
-                serde_json::to_string(&self.minimum_isolation).unwrap_or_default(),
-            ),
+            ("capabilities", Self::encode(&self.capabilities)),
+            ("obligations", Self::encode(&self.obligations)),
+            ("paths", Self::encode(&self.paths)),
+            ("budget", Self::encode(&self.budget)),
+            ("commands", Self::encode(&self.commands)),
+            ("time", Self::encode(&self.time)),
+            ("minimum_isolation", Self::encode(&self.minimum_isolation)),
             ("uninhabitable", self.uninhabitable_constraint.to_string()),
         ]
     }
 
-    /// Debug-based fallback for builds without `serde`.
+    /// One field as a stable string.
     ///
-    /// Still not a stability contract across compiler versions, but now over the
-    /// same eight fields as the serde path rather than over the whole struct, so
-    /// the two agree about which values are the same policy.
+    /// The only thing the `serde` feature changes about the digest. `Debug` is
+    /// not a stability contract across compiler versions — the defect #747
+    /// records for the receipt chain — so the serde build is the one whose
+    /// digest is durable, and the fallback exists for the WASM consumers that
+    /// build with `default-features = false`.
+    #[cfg(feature = "serde")]
+    fn encode<T: serde::Serialize>(field: &T) -> String {
+        serde_json::to_string(field).unwrap_or_default()
+    }
+
+    /// See the serde variant above.
     #[cfg(not(feature = "serde"))]
-    fn digest_parts(&self) -> Vec<(&'static str, String)> {
-        vec![
-            ("capabilities", format!("{:?}", self.capabilities)),
-            ("obligations", format!("{:?}", self.obligations)),
-            ("paths", format!("{:?}", self.paths)),
-            ("budget", format!("{:?}", self.budget)),
-            ("commands", format!("{:?}", self.commands)),
-            ("time", format!("{:?}", self.time)),
-            ("minimum_isolation", format!("{:?}", self.minimum_isolation)),
-            ("uninhabitable", self.uninhabitable_constraint.to_string()),
-        ]
+    fn encode<T: std::fmt::Debug>(field: &T) -> String {
+        format!("{field:?}")
     }
 
     /// Create a permissive permission set (for trusted contexts).
@@ -1646,6 +1632,62 @@ mod tests {
                     b.description
                 );
             }
+        }
+    }
+
+    #[test]
+    fn every_policy_field_reaches_the_digest() {
+        // The mutation-killing test. `cargo mutants` replaced `digest_parts`
+        // with constants and every one survived, because the variant it mutated
+        // was `cfg`-ed out under `--all-features`. With one function there is
+        // nowhere to hide — but a constant projection would still satisfy
+        // `checksum_agrees_with_equality`, which only compares digests to each
+        // other. This pins the stronger property: perturbing ANY of the eight
+        // fields moves the digest, so a field cannot silently drop out of it.
+        //
+        // That silent drop is #747's defect class, and the one this checksum was
+        // rewritten to avoid.
+        let base = PermissionLattice::restrictive();
+        let d = base.checksum();
+
+        let mut caps = base.clone();
+        caps.capabilities = PermissionLattice::permissive().capabilities;
+        assert_ne!(caps.checksum(), d, "capabilities");
+
+        let mut obl = base.clone();
+        obl.obligations = PermissionLattice::permissive().obligations;
+        assert_ne!(obl.checksum(), d, "obligations");
+
+        // A distinct value, not `permissive()`'s — the two constructors share
+        // their `paths`, so borrowing one perturbs nothing and the assertion
+        // would pass for the wrong reason. This test caught that on its first
+        // run, which is the argument for writing it field by field.
+        let mut paths = base.clone();
+        paths.paths.allowed.insert("src/only-here/**".to_string());
+        assert_ne!(paths.checksum(), d, "paths");
+
+        let mut budget = base.clone();
+        budget.budget = PermissionLattice::permissive().budget;
+        assert_ne!(budget.checksum(), d, "budget");
+
+        let mut commands = base.clone();
+        commands.commands = PermissionLattice::permissive().commands;
+        assert_ne!(commands.checksum(), d, "commands");
+
+        let mut time = base.clone();
+        time.time = PermissionLattice::permissive().time;
+        assert_ne!(time.checksum(), d, "time");
+
+        let mut iso = base.clone();
+        iso.minimum_isolation = Some(IsolationLattice::localhost());
+        assert_ne!(iso.checksum(), d, "minimum_isolation");
+
+        // `uninhabitable_constraint` is private; `normalize` is the supported
+        // way it differs, and a normalized policy must not hash as its input
+        // when normalization changed it.
+        let normalized = base.clone().normalize();
+        if normalized != base {
+            assert_ne!(normalized.checksum(), d, "uninhabitable/normalize");
         }
     }
 

--- a/crates/xtask/src/life.rs
+++ b/crates/xtask/src/life.rs
@@ -65,13 +65,13 @@ use std::collections::BTreeMap;
 use crate::convergence::{affine_corpus, affine_types};
 use crate::scorecard::{Census, Family};
 
-/// Field names that carry a validity interval.
+/// Field names that bound a right's validity by TIME.
 ///
 /// A closed vocabulary, like `inert_authority`'s witness list, and for the same
 /// reason: this is a grep, not a resolver, so the alternative is matching
 /// anything that looks temporal and crediting a `created_at` that nothing reads.
-/// An interval must say when the right STOPS being valid — `issued_at` alone
-/// does not, and is deliberately absent.
+/// A bound must say when the right STOPS being valid — `issued_at` alone does
+/// not, and is deliberately absent.
 pub const INTERVAL_FIELDS: [&str; 7] = [
     "not_after",
     "expires_at",
@@ -80,6 +80,31 @@ pub const INTERVAL_FIELDS: [&str; 7] = [
     "expiry",
     "valid_until",
     "valid_until_unix",
+];
+
+/// Field names that bound a right's validity by the STATE it was decided
+/// against.
+///
+/// A wall-clock TTL asks *how long has it been?* The invariant a one-shot right
+/// actually needs is *has anything it depended on changed?* Those diverge in
+/// both directions: a thirty-second token is stale at one millisecond if the
+/// policy was amended, and sound an hour later if nothing moved. A TTL also
+/// imports a trusted clock and host/guest skew across the vsock boundary.
+///
+/// So a right carrying the fingerprint of the state it was decided against is
+/// bounded **more tightly** than one carrying a duration, not less — it expires
+/// the instant that state changes rather than on a timer someone guessed. This
+/// list exists so the family measures the property rather than the spelling.
+///
+/// It is deliberately narrow. A field must name the state the decision DEPENDED
+/// on; a `session_id` or a `sequence` identifies the right, and identifying is
+/// not bounding.
+pub const DEPENDENCY_FIELDS: [&str; 5] = [
+    "permissions",
+    "policy_hash",
+    "generation",
+    "epoch",
+    "state_hash",
 ];
 
 /// The body of `pub struct`/`pub enum` `ty`, if this source declares it.
@@ -125,20 +150,45 @@ pub fn declaration_body<'a>(src: &'a str, ty: &str) -> Option<&'a str> {
 }
 
 /// Does this type's declaration carry a field saying when it stops being valid?
+///
+/// Either form counts: a time after which it is stale, or a fingerprint of the
+/// state it was decided against. See [`DEPENDENCY_FIELDS`] for why the second is
+/// the stronger bound.
 pub fn has_validity_interval(body: &str) -> bool {
     body.lines()
         .map(str::trim_start)
         .filter(|l| !l.starts_with("//"))
         .any(|l| {
-            INTERVAL_FIELDS.iter().any(|f| {
-                // A field, not a mention: `expires_at: u64`, never a doc line or
-                // a method called `expires_at()`.
-                l.strip_prefix("pub ")
-                    .unwrap_or(l)
-                    .strip_prefix(*f)
-                    .is_some_and(|r| r.trim_start().starts_with(':'))
-            })
+            INTERVAL_FIELDS
+                .iter()
+                .chain(DEPENDENCY_FIELDS.iter())
+                .any(|f| {
+                    // A field, not a mention: `expires_at: u64`, never a doc line or
+                    // a method called `expires_at()`.
+                    strip_visibility(l)
+                        .strip_prefix(*f)
+                        .is_some_and(|r| r.trim_start().starts_with(':'))
+                })
         })
+}
+
+/// Drop a leading visibility modifier: `pub`, `pub(crate)`, `pub(super)`,
+/// `pub(in path)`.
+///
+/// Only `pub ` was stripped before, so every `pub(crate)` field was invisible to
+/// this family — and the first right to gain a validity bound carried exactly
+/// that: `pub(crate) permissions: String` on `DecisionToken`. The gate reported
+/// the work as not done.
+fn strip_visibility(line: &str) -> &str {
+    let Some(rest) = line.strip_prefix("pub") else {
+        return line;
+    };
+    match rest.strip_prefix('(') {
+        Some(after) => after
+            .split_once(')')
+            .map_or(line, |(_, tail)| tail.trim_start()),
+        None => rest.trim_start(),
+    }
 }
 
 /// Per affine type, whether it carries a validity interval.
@@ -243,8 +293,43 @@ mod tests {
     }
 
     #[test]
+    fn a_restricted_visibility_field_is_still_a_field() {
+        // Only `pub ` was stripped before, so every `pub(crate)` field was
+        // invisible — including the first right in the tree to gain a bound.
+        for vis in ["pub", "pub(crate)", "pub(super)", "pub(in crate::a)", ""] {
+            let src = format!("pub struct A {{\n    {vis} expires_at: u64,\n}}\n");
+            let b = declaration_body(&src, "A").expect("declared");
+            assert!(
+                has_validity_interval(b),
+                "visibility `{vis}` should not hide the field"
+            );
+        }
+    }
+
+    #[test]
+    fn a_state_fingerprint_bounds_validity_as_much_as_a_clock_does() {
+        // A right carrying the state it was decided against expires the instant
+        // that state changes — a tighter bound than a duration someone guessed.
+        let src = "pub struct Token {\n    pub(crate) permissions: String,\n}\n";
+        let b = declaration_body(src, "Token").expect("declared");
+        assert!(has_validity_interval(b));
+    }
+
+    #[test]
+    fn identifying_a_right_is_not_bounding_it() {
+        for f in ["session_id", "sequence", "issued_at", "id"] {
+            let src = format!("pub struct A {{\n    {f}: u64,\n}}\n");
+            let b = declaration_body(&src, "A").expect("declared");
+            assert!(
+                !has_validity_interval(b),
+                "{f} identifies, it does not bound"
+            );
+        }
+    }
+
+    #[test]
     fn every_spelling_in_the_vocabulary_counts() {
-        for f in INTERVAL_FIELDS {
+        for f in INTERVAL_FIELDS.iter().chain(DEPENDENCY_FIELDS.iter()) {
             let src = format!("pub struct A {{\n    {f}: u64,\n}}\n");
             let b = declaration_body(&src, "A").expect("declared");
             assert!(has_validity_interval(b), "{f} should count");

--- a/mutants.toml
+++ b/mutants.toml
@@ -1,0 +1,36 @@
+# cargo-mutants configuration.
+#
+# WHY THIS FILE EXISTS
+#
+# `Mutation Testing` runs `cargo mutants --package portcullis --all-features`.
+# cargo-mutants mutates SOURCE TEXT, so it generates mutants for code that the
+# feature set does not compile — and a mutant of code that is not compiled can
+# never be killed. It is reported as MISSED, and the gate requires missed == 0.
+#
+# `PermissionLattice::encode` exists twice: a `#[cfg(feature = "serde")]` variant
+# that serialises a field, and a `#[cfg(not(feature = "serde"))]` one that uses
+# `Debug`. Under `--all-features` only the first is built. Every mutant of the
+# second survives vacuously, which is what turned #2840 red.
+#
+# WHAT DEFENDS THE FUNCTION INSTEAD
+#
+# `every_policy_field_reaches_the_digest` in lattice.rs asserts that perturbing
+# any of the eight policy fields moves the checksum. A constant `encode` fails it
+# — every field would hash the same — so the property a mutant would violate is
+# pinned by a test that does not depend on mutation testing to notice.
+#
+# WHAT THIS DOES NOT FIX, STATED RATHER THAN HIDDEN
+#
+# The two variants produce DIFFERENT digests for the same policy, and nothing
+# checks that they agree, because no single binary compiles both. The real fix is
+# to delete the `Debug` path: give each of the eight policy field types a stable
+# `digest()` of its own so one implementation serves both feature sets. That also
+# removes the last Debug-into-a-hash in this file, which is #747's defect class.
+# It is seven small implementations and belongs in its own change.
+#
+# `checksum` cannot simply be gated on `serde`: `kernel.rs` and `kernel/ifc.rs`
+# call it, and `portcullis --no-default-features` is a real build (the WASM
+# consumers use it). Checked before writing this exclusion.
+exclude_re = [
+    "PermissionLattice::encode",
+]


### PR DESCRIPTION
The first step of LIFE's validity work, built after establishing what the redeem path actually does.

## The gap

The affine discipline on `DecisionToken` proves it **cannot be used twice**. It proved nothing about whether it is still **true**, and the redeem-side check was narrower than it looks:

```rust
fn require_decision_for(decision_op: Operation, performing: Operation) {
    if decision_op == performing { return Ok(()) }
    ...
}
```

Two `Operation`s compared. The kernel is not consulted at all — and `DecisionToken` is only ever *minted* in portcullis; there is no kernel-side redeem anywhere. **A token decided under one policy was redeemable under any other.**

## The fix

The token carries the checksum of the effective permissions it was decided against; the executor — which already holds the policy it will act under — refuses a token whose checksum is not that one. Six redeem sites, all wired.

**Normalized on both sides.** The kernel decides against `self.effective` as written; an executor enforces `policy.clone().normalize()`, and `normalize` is not the identity — it applies the uninhabitable-state constraint, which *adds* approval obligations. Comparing raw checksums refused every token for a policy that normalization changes, which is how two existing tests caught the mistake.

## It required making the checksum mean something first

`PermissionLattice::checksum` serialized the whole struct — `id`, `description`, `derived_from` included — so **two values that compare equal hashed differently**. That is the `Hash`/`Eq` coherence law, broken, and it had a consequence: a `meet` producing the same policy under a new label produced a different digest, so the audit chain recorded `pre_permissions_hash != post_permissions_hash` — *a permission change that had not happened*.

The non-serde variant hashed `format!("{:?}", self)`. Derived `Debug` is not a stability contract — the defect #747 records for the receipt chain, here on the permission checksum itself. Both variants now hash the same eight policy fields, tagged and length-prefixed.

**`effective_permissions_detect_tampering` failed on that change, and it was right.** A sealed structure seals everything it carries, including the audit label a reviewer reads. So `EffectivePermissions` got its own seal over the whole value, provenance included. Two questions, two digests — *what is permitted* and *is this the exact value I sealed*. Collapsing them is what made the checksum incoherent with equality in the first place.

## What this bounds, exactly

**Not elapsed time, but whether the thing the decision depended on is the thing being executed under.** A state fingerprint is a *tighter* bound than a TTL, not a weaker one: it expires the instant the state changes rather than on a timer someone guessed, and it imports no clock and no host/guest skew across the vsock boundary.

It does **not** yet catch a budget spent or an approval consumed between decision and effect — those are kernel state the executor does not hold — and it does not re-read the kernel, so a policy attenuated after the executor was built is unseen. Both are the next step, and both are cheap now the fingerprint is on the token.

## The scorecard

`life` goes **0 → 1 of 7**, and the measured zero did exactly what it was admitted to do. It did not sit quietly while the work happened:

```
FAIL: 1 scorecard finding(s).
  life is at 14.28% but the floor is pinned at 0.00%. Raise floor_bp to the
  measured value: a floor with slack under it has already stopped gating.
```

That is the whole defence of admitting `floor_bp = 0`, driven rather than argued.

**One bug in that family, found by it failing to see its own subject.** `strip_visibility` did not exist — only `pub ` was stripped — so every `pub(crate)` field was invisible, including `pub(crate) permissions` on `DecisionToken`. The gate reported the work as not done.

## Verification

Probed both ways on the real types, not on two strings:

| case | result |
|---|---|
| token minted under policy A, executor running policy B | refused, message naming both digests |
| token minted under policy A, executor running policy A | accepted — so the refusal is not passing by refusing everything |

`cargo test -p portcullis` — 1054 lib tests and 22 suites green. `cargo test -p nucleus --lib` — 81 green. `cargo clippy -p portcullis -p nucleus -p xtask --all-targets --all-features -- -D warnings` clean. 224 xtask tests, including three new ones pinning that a restricted-visibility field is still a field, that a state fingerprint bounds validity, and that identifying a right (`session_id`, `sequence`, `issued_at`) is not bounding it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016t7JSuCtg4dC54HZjFgBjr