### PR TITLE
fix(ci): two proof-debt ratchets passed silently on an unusable baseline

### DIFF
--- a/.github/workflows/research-lean-build.yml
+++ b/.github/workflows/research-lean-build.yml
@@ -95,7 +95,16 @@ jobs:
           PAT='^[[:space:]]*(sorry|admit)\b'
           count=$(grep -rhcE "$PAT" --include='*.lean' \
                     --exclude-dir=.lake . 2>/dev/null | awk '{s+=$1} END{print s+0}')
-          baseline=$(cat .research-sorry-baseline)
+          # Establish the operand before comparing on it. `[ "$count" -gt "" ]` does not
+          # evaluate false -- it ERRORS with "integer expression expected", and an `if`
+          # condition is exempt from `set -e`, so the error is swallowed and the gate
+          # PASSES. An empty or missing .research-sorry-baseline would therefore retire this
+          # ratchet silently, which is the one failure a ratchet must not have.
+          baseline=$(cat .research-sorry-baseline 2>/dev/null || true)
+          if ! [[ "$baseline" =~ ^[0-9]+$ ]]; then
+            echo "::error::.research-sorry-baseline is not a non-negative integer (read: '$baseline'). The research-tier sorry ratchet compares against it numerically, and an unusable value makes the comparison error and the gate pass."
+            exit 1
+          fi
           echo "research-tier sorries: $count (baseline $baseline)"
           echo "per-file:"
           grep -rlE "$PAT" --include='*.lean' --exclude-dir=.lake . 2>/dev/null \

--- a/.github/workflows/uniform-primitive-lean.yml
+++ b/.github/workflows/uniform-primitive-lean.yml
@@ -121,7 +121,16 @@ jobs:
           # always is — so `^axiom ` counts real axioms and ignores comment prose.
           count=$(grep -rhcE '^axiom ' --include='*.lean' --exclude-dir=.lake . 2>/dev/null \
                     | awk '{s+=$1} END{print s+0}')
-          baseline=$(cat .uniform-primitive-axiom-baseline)
+          # Establish the operand before comparing on it. `[ "$count" -gt "" ]` does not
+          # evaluate false -- it ERRORS with "integer expression expected", and an `if`
+          # condition is exempt from `set -e`, so the error is swallowed and the gate
+          # PASSES. An empty or missing .uniform-primitive-axiom-baseline would therefore retire this
+          # ratchet silently, which is the one failure a ratchet must not have.
+          baseline=$(cat .uniform-primitive-axiom-baseline 2>/dev/null || true)
+          if ! [[ "$baseline" =~ ^[0-9]+$ ]]; then
+            echo "::error::.uniform-primitive-axiom-baseline is not a non-negative integer (read: '$baseline'). The layer-bridge axiom ratchet compares against it numerically, and an unusable value makes the comparison error and the gate pass."
+            exit 1
+          fi
           echo "uniform-primitive layer-bridge axioms: $count (baseline $baseline)"
           grep -rnE '^axiom ' --include='*.lean' --exclude-dir=.lake . || true
           if [ "$count" -gt "$baseline" ]; then


### PR DESCRIPTION
Both ratchets read a baseline with `cat` and then compare on it numerically, with nothing establishing it is an integer:

```sh
baseline=$(cat .research-sorry-baseline)
if [ "$count" -gt "$baseline" ]; then ... exit 1; fi
```

`[ "5" -gt "" ]` **does not evaluate false.** It errors — `integer expression expected` — and an `if` *condition* is exempt from `set -e`, so the error is swallowed and **the gate passes.** Reproduced directly:

```
$ count=5 baseline="" ; if [ "$count" -gt "$baseline" ]; then echo fired; exit 1; fi
bash: line 4: [: : integer expected
GATE PASSED with empty baseline      (rc=0)
```

An empty or missing baseline file therefore **retires the ratchet silently** — the one failure a ratchet must not have. These two guard proof debt (research-tier `sorry`/`admit`, layer-bridge `axiom`), so a silent retirement means new proof holes stop being counted at all.

## The fix

Exactly what `ci-spec`'s GI006 prescribes: establish the operand first, fail loudly if it is not a non-negative integer, and say what the unusable value was.

## Verification

Ran the guarded logic in all three cases:

| case | before | after |
|---|---|---|
| empty baseline | **rc=0 (passes)** | **rc=1** |
| count over baseline | rc=1 | rc=1 |
| count under baseline | rc=0 | rc=0 |

The committed baselines are `20` (`crates/portcullis-core/lean/.research-sorry-baseline`) and `3` (`crates/nucleus-uniform-primitive/lean/.uniform-primitive-axiom-baseline`) — **both pass the guard, so no gate turns red on this change.**

`check-ci-spec.sh` RC=0 with **0** GI006 findings, down from 2. `cargo test -p ci-spec` RC=0.

## One near-miss, recorded

I first read `.research-sorry-baseline` from the repository root, got nothing, and briefly had *"the hazard is live right now"* written down. The step declares `working-directory: crates/portcullis-core/lean` and the file is there with `20` in it.

Reading a path without the working directory that gives it meaning is the same error as reading a gate's name without its log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)