### PR TITLE
Checking a token becomes the only way to read one

### DIFF
--- a/crates/nucleus/src/command.rs
+++ b/crates/nucleus/src/command.rs
@@ -417,11 +417,7 @@ impl<'a> Executor<'a> {
         decision: DecisionToken,
         authority: Authority,
     ) -> Result<Output> {
-        crate::decision_scope::require_decision_for(decision.operation(), Operation::RunBash)?;
-        crate::decision_scope::require_permissions_match(
-            decision.permissions(),
-            &self.permissions,
-        )?;
+        decision.redeem(&self.permissions, Operation::RunBash)?;
         // Fail-closed isolation gate: refuse unless containment is declared and
         // meets the policy's required isolation (most-paranoid #2).
         self.enforce_isolation()?;
@@ -537,11 +533,7 @@ impl<'a> Executor<'a> {
         decision: DecisionToken,
         authority: Authority,
     ) -> Result<Output> {
-        crate::decision_scope::require_decision_for(decision.operation(), Operation::RunBash)?;
-        crate::decision_scope::require_permissions_match(
-            decision.permissions(),
-            &self.permissions,
-        )?;
+        decision.redeem(&self.permissions, Operation::RunBash)?;
         self.run_args_internal(args, stdin, directory, None, authority)
     }
 
@@ -555,11 +547,7 @@ impl<'a> Executor<'a> {
         approval: &ApprovalToken,
         authority: Authority,
     ) -> Result<Output> {
-        crate::decision_scope::require_decision_for(decision.operation(), Operation::RunBash)?;
-        crate::decision_scope::require_permissions_match(
-            decision.permissions(),
-            &self.permissions,
-        )?;
+        decision.redeem(&self.permissions, Operation::RunBash)?;
         self.run_args_internal(args, stdin, directory, Some(approval), authority)
     }
 
@@ -643,11 +631,7 @@ impl<'a> Executor<'a> {
         approval: &ApprovalToken,
         authority: Authority,
     ) -> Result<Output> {
-        crate::decision_scope::require_decision_for(decision.operation(), Operation::RunBash)?;
-        crate::decision_scope::require_permissions_match(
-            decision.permissions(),
-            &self.permissions,
-        )?;
+        decision.redeem(&self.permissions, Operation::RunBash)?;
         // Fail-closed isolation gate (most-paranoid #2).
         self.enforce_isolation()?;
         // Check temporal constraints
@@ -708,11 +692,7 @@ impl<'a> Executor<'a> {
         decision: DecisionToken,
         authority: Authority,
     ) -> Result<Output> {
-        crate::decision_scope::require_decision_for(decision.operation(), Operation::RunBash)?;
-        crate::decision_scope::require_permissions_match(
-            decision.permissions(),
-            &self.permissions,
-        )?;
+        decision.redeem(&self.permissions, Operation::RunBash)?;
         // Fail-closed isolation gate (most-paranoid #2).
         self.enforce_isolation()?;
         // Check temporal constraints
@@ -762,11 +742,7 @@ impl<'a> Executor<'a> {
         approval: &ApprovalToken,
         authority: Authority,
     ) -> Result<Output> {
-        crate::decision_scope::require_decision_for(decision.operation(), Operation::RunBash)?;
-        crate::decision_scope::require_permissions_match(
-            decision.permissions(),
-            &self.permissions,
-        )?;
+        decision.redeem(&self.permissions, Operation::RunBash)?;
         // Fail-closed isolation gate (most-paranoid #2).
         self.enforce_isolation()?;
         // Check temporal constraints

--- a/crates/nucleus/src/decision_scope.rs
+++ b/crates/nucleus/src/decision_scope.rs
@@ -32,8 +32,6 @@
 //! caller cannot present a decision about one act while spending an authority
 //! for another.
 
-use portcullis::Operation;
-
 use crate::error::NucleusError;
 
 /// Refuse a decision that was made about a different operation.
@@ -42,82 +40,65 @@ use crate::error::NucleusError;
 /// uses for "earned for a different action", because that is what this is.
 ///
 /// Checked in every profile. That is the whole point; see the module docs.
-pub(crate) fn require_decision_for(
-    decision_op: Operation,
-    performing: Operation,
-) -> Result<(), NucleusError> {
-    if decision_op == performing {
-        return Ok(());
+/// A refused redeem becomes a scope mismatch.
+///
+/// Both variants are the same kind of failure to a caller — the decision does
+/// not authorise this effect — and the message says which kind it was.
+///
+/// # Why this module is now three lines
+///
+/// It used to hold `require_decision_for`, which compared two `Operation`s and
+/// consulted no state, and callers were trusted to also compare permissions.
+/// They mostly did not: 24 of the 30 redeem sites in this crate checked the
+/// operation and nothing else, so a decision taken under one policy was
+/// redeemable under any other at every one of them.
+///
+/// The check now lives on the token as [`portcullis::kernel::DecisionToken::redeem`],
+/// which takes `self` by value and requires both the operation and the
+/// permissions in force. `DecisionToken::operation` is `pub(crate)` to
+/// portcullis, so there is no other way to read what a token authorises — a new
+/// effect method cannot forget, because there is nothing else to call.
+impl From<portcullis::kernel::RedeemError> for NucleusError {
+    fn from(e: portcullis::kernel::RedeemError) -> Self {
+        Self::ScopeMismatch {
+            reason: e.to_string(),
+        }
     }
-    Err(NucleusError::ScopeMismatch {
-        reason: format!("decision authorises {decision_op:?}, this effect is {performing:?}"),
-    })
-}
-
-/// A decision may only be redeemed under the permissions it was taken against.
-///
-/// The affine discipline on `DecisionToken` proves it cannot be used TWICE — two
-/// `compile_fail` doctests on `Authority` next door prove the same for replay
-/// (E0382) and clone (E0599). It proves nothing about whether the token is still
-/// TRUE, and until now nothing else did either: [`require_decision_for`] above
-/// compares two `Operation`s and consults no state, so a token decided under one
-/// policy was redeemable under any other.
-///
-/// The token carries the checksum of the effective permissions at decision time;
-/// the executor carries the checksum of the permissions it is about to act
-/// under. Equal or refuse.
-///
-/// This is the first step of a validity interval, and the honest statement of
-/// what it bounds: **not elapsed time, but whether the thing the decision
-/// depended on is the thing being executed under.** It does not yet catch a
-/// budget spent or an approval consumed between decision and effect — those are
-/// kernel state the executor does not hold — and it does not re-read the kernel,
-/// so a policy attenuated after this executor was built is not seen. Both are
-/// the next steps, and both are cheap once the fingerprint is on the token.
-pub(crate) fn require_permissions_match(
-    decided_under: &str,
-    executing_under: &str,
-) -> Result<(), NucleusError> {
-    if decided_under == executing_under {
-        return Ok(());
-    }
-    Err(NucleusError::ScopeMismatch {
-        reason: format!(
-            "decision was taken against permissions {} but this effect runs under {}: \
-             a decision does not carry across a change of policy",
-            short(decided_under),
-            short(executing_under)
-        ),
-    })
-}
-
-/// First eight hex characters, or the whole string when it is shorter.
-///
-/// Enough to tell two checksums apart in a message; the full digest belongs in
-/// the trace, not in an error a human reads.
-fn short(digest: &str) -> &str {
-    digest.get(..8).unwrap_or(digest)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use portcullis::Operation;
+    use portcullis::kernel::RedeemError;
 
+    /// THE regression, preserved. This check used to be
+    /// `debug_assert_eq!(decision.operation(), op, ..)`, which compiles to
+    /// nothing when `debug_assertions` is off — every release build — so a
+    /// `DecisionToken` minted for `ReadFiles` and handed to a `RunBash` entry
+    /// point was accepted exactly as readily as the right one.
+    ///
+    /// It is now a refusal in both profiles, and it is no longer a call site's
+    /// job to remember: `DecisionToken::redeem` is the only way to read a token.
+    /// The property lives with `redeem` in portcullis; this pins that the
+    /// refusal still arrives here as a `ScopeMismatch` rather than being
+    /// swallowed.
     #[test]
-    fn permissions_that_match_are_accepted() {
-        assert!(require_permissions_match("abc123", "abc123").is_ok());
-    }
+    fn a_refused_redeem_arrives_as_a_scope_mismatch() {
+        let scope = NucleusError::from(RedeemError::ScopeMismatch {
+            authorised: Operation::ReadFiles,
+            performing: Operation::RunBash,
+        });
+        assert!(matches!(scope, NucleusError::ScopeMismatch { .. }));
+        assert!(scope.to_string().contains("ReadFiles"), "{scope}");
+        assert!(scope.to_string().contains("RunBash"), "{scope}");
 
-    #[test]
-    fn a_decision_taken_under_other_permissions_is_refused() {
-        // THE property. Before this, the redeem side compared two `Operation`s
-        // and consulted no state at all, so a token decided under one policy was
-        // redeemable under any other. The affine discipline proved the token
-        // could not be used twice; nothing proved it was still true.
-        let err = require_permissions_match("aaaaaaaabbbb", "ccccccccdddd")
-            .expect_err("a decision does not carry across a change of policy");
-        assert!(matches!(err, NucleusError::ScopeMismatch { .. }));
-        let msg = err.to_string();
+        let stale = NucleusError::from(RedeemError::StalePermissions {
+            decided_under: "aaaaaaaabbbb".to_string(),
+            executing_under: "ccccccccdddd".to_string(),
+        });
+        assert!(matches!(stale, NucleusError::ScopeMismatch { .. }));
+        let msg = stale.to_string();
         assert!(
             msg.contains("aaaaaaaa"),
             "names what it was decided under: {msg}"
@@ -126,54 +107,6 @@ mod tests {
             msg.contains("cccccccc"),
             "and what it would run under: {msg}"
         );
-    }
-
-    #[test]
-    fn the_message_shortens_a_digest_without_losing_a_short_one() {
-        // Eight hex characters is enough to tell two checksums apart; the full
-        // digest belongs in the trace, not in an error a human reads.
-        assert_eq!(short("0123456789abcdef"), "01234567");
-        assert_eq!(short("tiny"), "tiny");
-    }
-
-    #[test]
-    fn a_matching_decision_is_accepted() {
-        assert!(require_decision_for(Operation::RunBash, Operation::RunBash).is_ok());
-    }
-
-    /// THE regression. Under `debug_assert_eq!` this case PANICKED in a debug
-    /// build and was SILENTLY ACCEPTED in a release one. It is now a refusal in
-    /// both.
-    #[test]
-    fn a_decision_about_another_operation_is_refused() {
-        let err = require_decision_for(Operation::ReadFiles, Operation::RunBash)
-            .expect_err("a decision about ReadFiles must not authorise RunBash");
-        assert!(
-            matches!(err, NucleusError::ScopeMismatch { .. }),
-            "a decision for the wrong operation is a scope mismatch, got {err:?}"
-        );
-    }
-
-    /// The message has to name BOTH sides, or it sends the reader to inspect
-    /// the wrong one. `15e3530f`'s lesson (ADR 0007 A-4) in a smaller place.
-    #[test]
-    fn the_refusal_names_what_was_held_and_what_was_attempted() {
-        let err = require_decision_for(Operation::ReadFiles, Operation::RunBash)
-            .expect_err("must refuse");
-        let msg = err.to_string();
-        assert!(msg.contains("ReadFiles"), "{msg}");
-        assert!(msg.contains("RunBash"), "{msg}");
-    }
-
-    /// Non-vacuity: the refusal test above would pass against a function that
-    /// refused everything. Every operation must authorise itself.
-    #[test]
-    fn every_operation_authorises_itself() {
-        for op in Operation::ALL {
-            assert!(
-                require_decision_for(op, op).is_ok(),
-                "{op:?} must authorise itself"
-            );
-        }
+        assert!(msg.contains("change of policy"), "{msg}");
     }
 }

--- a/crates/nucleus/src/sandbox.rs
+++ b/crates/nucleus/src/sandbox.rs
@@ -57,6 +57,12 @@ pub struct Sandbox {
     obligations: Obligations,
     /// Approver for approval-gated operations
     approver: Option<Arc<dyn Approver>>,
+    /// Checksum of the permissions this sandbox enforces.
+    ///
+    /// `DecisionToken::redeem` requires it, so every redeem site here names what
+    /// it is executing under. Before `redeem` existed, all 24 of this file's
+    /// redeem sites checked the operation and nothing else.
+    permissions: String,
     /// The log every authority spent through this sandbox is recorded against.
     ///
     /// Sandbox writes spend their authority DIRECTLY, in `spend_as`, rather than
@@ -82,6 +88,7 @@ impl Sandbox {
     pub fn new(policy: &PermissionLattice, root: impl AsRef<Path>) -> Result<Self> {
         let root_path = root.as_ref().to_path_buf();
         let normalized = policy.clone().normalize();
+        let permissions = normalized.checksum();
 
         // Open the root directory - this is our capability handle
         let root_dir = Dir::open_ambient_dir(&root_path, cap_std::ambient_authority())?;
@@ -94,6 +101,7 @@ impl Sandbox {
             capabilities: normalized.capabilities,
             obligations: normalized.obligations,
             approver: None,
+            permissions,
         })
     }
 
@@ -143,7 +151,7 @@ impl Sandbox {
         decision: DecisionToken,
         authority: Authority,
     ) -> Result<File> {
-        crate::decision_scope::require_decision_for(decision.operation(), Operation::ReadFiles)?;
+        decision.redeem(&self.permissions, Operation::ReadFiles)?;
         self.spend_as(authority, Operation::ReadFiles, SinkClass::AuditLogAppend)?;
         self.open_internal(path.as_ref(), None)
     }
@@ -156,7 +164,7 @@ impl Sandbox {
         approval: &ApprovalToken,
         authority: Authority,
     ) -> Result<File> {
-        crate::decision_scope::require_decision_for(decision.operation(), Operation::ReadFiles)?;
+        decision.redeem(&self.permissions, Operation::ReadFiles)?;
         self.spend_as(authority, Operation::ReadFiles, SinkClass::AuditLogAppend)?;
         self.open_internal(path.as_ref(), Some(approval))
     }
@@ -185,7 +193,7 @@ impl Sandbox {
         decision: DecisionToken,
         authority: Authority,
     ) -> Result<File> {
-        crate::decision_scope::require_decision_for(decision.operation(), Operation::EditFiles)?;
+        decision.redeem(&self.permissions, Operation::EditFiles)?;
         self.spend_as(authority, Operation::EditFiles, SinkClass::WorkspaceWrite)?;
         self.open_with_internal(path.as_ref(), options, None)
     }
@@ -199,7 +207,7 @@ impl Sandbox {
         approval: &ApprovalToken,
         authority: Authority,
     ) -> Result<File> {
-        crate::decision_scope::require_decision_for(decision.operation(), Operation::EditFiles)?;
+        decision.redeem(&self.permissions, Operation::EditFiles)?;
         self.spend_as(authority, Operation::EditFiles, SinkClass::WorkspaceWrite)?;
         self.open_with_internal(path.as_ref(), options, Some(approval))
     }
@@ -229,7 +237,7 @@ impl Sandbox {
         decision: DecisionToken,
         authority: Authority,
     ) -> Result<File> {
-        crate::decision_scope::require_decision_for(decision.operation(), Operation::WriteFiles)?;
+        decision.redeem(&self.permissions, Operation::WriteFiles)?;
         self.spend_as(authority, Operation::WriteFiles, SinkClass::WorkspaceWrite)?;
         self.create_internal(path.as_ref(), None)
     }
@@ -242,7 +250,7 @@ impl Sandbox {
         approval: &ApprovalToken,
         authority: Authority,
     ) -> Result<File> {
-        crate::decision_scope::require_decision_for(decision.operation(), Operation::WriteFiles)?;
+        decision.redeem(&self.permissions, Operation::WriteFiles)?;
         self.spend_as(authority, Operation::WriteFiles, SinkClass::WorkspaceWrite)?;
         self.create_internal(path.as_ref(), Some(approval))
     }
@@ -264,7 +272,7 @@ impl Sandbox {
         decision: DecisionToken,
         authority: Authority,
     ) -> Result<Vec<u8>> {
-        crate::decision_scope::require_decision_for(decision.operation(), Operation::ReadFiles)?;
+        decision.redeem(&self.permissions, Operation::ReadFiles)?;
         self.spend_as(authority, Operation::ReadFiles, SinkClass::AuditLogAppend)?;
         self.read_internal(path.as_ref(), None)
     }
@@ -277,7 +285,7 @@ impl Sandbox {
         approval: &ApprovalToken,
         authority: Authority,
     ) -> Result<Vec<u8>> {
-        crate::decision_scope::require_decision_for(decision.operation(), Operation::ReadFiles)?;
+        decision.redeem(&self.permissions, Operation::ReadFiles)?;
         self.spend_as(authority, Operation::ReadFiles, SinkClass::AuditLogAppend)?;
         self.read_internal(path.as_ref(), Some(approval))
     }
@@ -299,7 +307,7 @@ impl Sandbox {
         decision: DecisionToken,
         authority: Authority,
     ) -> Result<String> {
-        crate::decision_scope::require_decision_for(decision.operation(), Operation::ReadFiles)?;
+        decision.redeem(&self.permissions, Operation::ReadFiles)?;
         self.spend_as(authority, Operation::ReadFiles, SinkClass::AuditLogAppend)?;
         self.read_to_string_internal(path.as_ref(), None)
     }
@@ -312,7 +320,7 @@ impl Sandbox {
         approval: &ApprovalToken,
         authority: Authority,
     ) -> Result<String> {
-        crate::decision_scope::require_decision_for(decision.operation(), Operation::ReadFiles)?;
+        decision.redeem(&self.permissions, Operation::ReadFiles)?;
         self.spend_as(authority, Operation::ReadFiles, SinkClass::AuditLogAppend)?;
         self.read_to_string_internal(path.as_ref(), Some(approval))
     }
@@ -374,7 +382,7 @@ impl Sandbox {
         // minted — "bundle authorises EditFiles/WorkspaceWrite, this effect is
         // WriteFiles/WorkspaceWrite" — measured on a live pod.
         let op = self.write_operation_for(path.as_ref());
-        crate::decision_scope::require_decision_for(decision.operation(), op)?;
+        decision.redeem(&self.permissions, op)?;
         self.spend_as(authority, op, SinkClass::WorkspaceWrite)?;
         self.write_internal(path.as_ref(), contents, None)
     }
@@ -400,7 +408,7 @@ impl Sandbox {
         // minted — "bundle authorises EditFiles/WorkspaceWrite, this effect is
         // WriteFiles/WorkspaceWrite" — measured on a live pod.
         let op = self.write_operation_for(path.as_ref());
-        crate::decision_scope::require_decision_for(decision.operation(), op)?;
+        decision.redeem(&self.permissions, op)?;
         self.spend_as(authority, op, SinkClass::WorkspaceWrite)?;
         self.write_internal(path.as_ref(), contents, Some(approval))
     }
@@ -448,7 +456,7 @@ impl Sandbox {
         decision: DecisionToken,
         authority: Authority,
     ) -> Result<()> {
-        crate::decision_scope::require_decision_for(decision.operation(), Operation::WriteFiles)?;
+        decision.redeem(&self.permissions, Operation::WriteFiles)?;
         self.spend_as(authority, Operation::WriteFiles, SinkClass::WorkspaceWrite)?;
         self.create_dir_internal(path.as_ref(), None)
     }
@@ -461,7 +469,7 @@ impl Sandbox {
         approval: &ApprovalToken,
         authority: Authority,
     ) -> Result<()> {
-        crate::decision_scope::require_decision_for(decision.operation(), Operation::WriteFiles)?;
+        decision.redeem(&self.permissions, Operation::WriteFiles)?;
         self.spend_as(authority, Operation::WriteFiles, SinkClass::WorkspaceWrite)?;
         self.create_dir_internal(path.as_ref(), Some(approval))
     }
@@ -483,7 +491,7 @@ impl Sandbox {
         decision: DecisionToken,
         authority: Authority,
     ) -> Result<()> {
-        crate::decision_scope::require_decision_for(decision.operation(), Operation::WriteFiles)?;
+        decision.redeem(&self.permissions, Operation::WriteFiles)?;
         self.spend_as(authority, Operation::WriteFiles, SinkClass::WorkspaceWrite)?;
         self.create_dir_all_internal(path.as_ref(), None)
     }
@@ -496,7 +504,7 @@ impl Sandbox {
         approval: &ApprovalToken,
         authority: Authority,
     ) -> Result<()> {
-        crate::decision_scope::require_decision_for(decision.operation(), Operation::WriteFiles)?;
+        decision.redeem(&self.permissions, Operation::WriteFiles)?;
         self.spend_as(authority, Operation::WriteFiles, SinkClass::WorkspaceWrite)?;
         self.create_dir_all_internal(path.as_ref(), Some(approval))
     }
@@ -518,7 +526,7 @@ impl Sandbox {
         decision: DecisionToken,
         authority: Authority,
     ) -> Result<()> {
-        crate::decision_scope::require_decision_for(decision.operation(), Operation::EditFiles)?;
+        decision.redeem(&self.permissions, Operation::EditFiles)?;
         self.spend_as(authority, Operation::EditFiles, SinkClass::WorkspaceWrite)?;
         self.remove_file_internal(path.as_ref(), None)
     }
@@ -531,7 +539,7 @@ impl Sandbox {
         approval: &ApprovalToken,
         authority: Authority,
     ) -> Result<()> {
-        crate::decision_scope::require_decision_for(decision.operation(), Operation::EditFiles)?;
+        decision.redeem(&self.permissions, Operation::EditFiles)?;
         self.spend_as(authority, Operation::EditFiles, SinkClass::WorkspaceWrite)?;
         self.remove_file_internal(path.as_ref(), Some(approval))
     }
@@ -553,7 +561,7 @@ impl Sandbox {
         decision: DecisionToken,
         authority: Authority,
     ) -> Result<()> {
-        crate::decision_scope::require_decision_for(decision.operation(), Operation::EditFiles)?;
+        decision.redeem(&self.permissions, Operation::EditFiles)?;
         self.spend_as(authority, Operation::EditFiles, SinkClass::WorkspaceWrite)?;
         self.remove_dir_internal(path.as_ref(), None)
     }
@@ -566,7 +574,7 @@ impl Sandbox {
         approval: &ApprovalToken,
         authority: Authority,
     ) -> Result<()> {
-        crate::decision_scope::require_decision_for(decision.operation(), Operation::EditFiles)?;
+        decision.redeem(&self.permissions, Operation::EditFiles)?;
         self.spend_as(authority, Operation::EditFiles, SinkClass::WorkspaceWrite)?;
         self.remove_dir_internal(path.as_ref(), Some(approval))
     }
@@ -588,7 +596,7 @@ impl Sandbox {
     /// not there" (ADR 0007 A-2). Before the scope check was enforced there was
     /// no third answer to return, so there was no reason for the `Result`.
     pub fn exists(&self, path: impl AsRef<Path>, decision: DecisionToken) -> Result<bool> {
-        crate::decision_scope::require_decision_for(decision.operation(), Operation::ReadFiles)?;
+        decision.redeem(&self.permissions, Operation::ReadFiles)?;
         Ok(self.exists_internal(path.as_ref(), None))
     }
 
@@ -599,7 +607,7 @@ impl Sandbox {
         decision: DecisionToken,
         approval: &ApprovalToken,
     ) -> Result<bool> {
-        crate::decision_scope::require_decision_for(decision.operation(), Operation::ReadFiles)?;
+        decision.redeem(&self.permissions, Operation::ReadFiles)?;
         Ok(self.exists_internal(path.as_ref(), Some(approval)))
     }
 
@@ -816,7 +824,7 @@ impl Sandbox {
         decision: DecisionToken,
         authority: Authority,
     ) -> Result<Sandbox> {
-        crate::decision_scope::require_decision_for(decision.operation(), Operation::ReadFiles)?;
+        decision.redeem(&self.permissions, Operation::ReadFiles)?;
         self.spend_as(authority, Operation::ReadFiles, SinkClass::AuditLogAppend)?;
         self.open_dir_internal(path.as_ref(), None)
     }
@@ -829,7 +837,7 @@ impl Sandbox {
         approval: &ApprovalToken,
         authority: Authority,
     ) -> Result<Sandbox> {
-        crate::decision_scope::require_decision_for(decision.operation(), Operation::ReadFiles)?;
+        decision.redeem(&self.permissions, Operation::ReadFiles)?;
         self.spend_as(authority, Operation::ReadFiles, SinkClass::AuditLogAppend)?;
         self.open_dir_internal(path.as_ref(), Some(approval))
     }
@@ -852,6 +860,10 @@ impl Sandbox {
             capabilities: self.capabilities.clone(),
             obligations: self.obligations.clone(),
             approver: self.approver.clone(),
+            // A subdirectory enforces the SAME permissions as its parent — the
+            // path narrows, the policy does not — so a token redeemable here is
+            // redeemable there.
+            permissions: self.permissions.clone(),
         })
     }
 }

--- a/crates/portcullis/src/kani.rs
+++ b/crates/portcullis/src/kani.rs
@@ -1725,7 +1725,7 @@ fn proof_issue_approved_token_is_audited() {
     let token = kernel.issue_approved_token(op, "external-approval");
 
     // Token carries the correct operation
-    assert!(token.operation() == op);
+    assert!(token.operation == op);
     // Trace grew — the operation is auditable
     assert!(kernel.trace().len() > trace_len_before);
     // Exposure is monotonic — never decreases
@@ -1755,7 +1755,7 @@ fn proof_approved_token_bypass_is_audited() {
     let token = kernel.issue_approved_token(Operation::RunBash, "external-override");
 
     // But the bypass is audited
-    assert!(token.operation() == Operation::RunBash);
+    assert!(token.operation == Operation::RunBash);
     assert!(kernel.trace().len() > trace_len_before);
 }
 

--- a/crates/portcullis/src/kani.rs
+++ b/crates/portcullis/src/kani.rs
@@ -1663,7 +1663,7 @@ fn proof_decision_token_unforgeable() {
     if matches!(decision.verdict, Verdict::Allow) {
         assert!(token.is_some());
         let t = token.unwrap();
-        assert!(t.operation() == op);
+        assert!(t.operation == op);
         assert!(t.sequence() == decision.sequence);
     } else {
         assert!(token.is_none());
@@ -1689,7 +1689,7 @@ fn proof_denied_ops_have_no_token() {
 
 /// **E3 — Token operation matches decision operation.**
 ///
-/// For any operation, when a token is produced, its `operation()` and
+/// For any operation, when a token is produced, its `operation` field and
 /// `sequence()` must match the decision's fields exactly.
 #[kani::proof]
 #[kani::solver(cadical)]
@@ -1700,7 +1700,7 @@ fn proof_token_operation_matches_decision() {
     let op = arbitrary_operation();
     let (decision, token) = kernel.decide(op, "subject");
     if let Some(t) = token {
-        assert!(t.operation() == decision.operation);
+        assert!(t.operation == decision.operation);
         assert!(t.sequence() == decision.sequence);
     }
 }

--- a/crates/portcullis/src/kernel.rs
+++ b/crates/portcullis/src/kernel.rs
@@ -370,6 +370,56 @@ pub enum ApprovalSource {
     },
 }
 
+/// Why a [`DecisionToken`] could not be redeemed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RedeemError {
+    /// The decision authorises a different operation than the one being done.
+    ScopeMismatch {
+        /// What the decision authorises.
+        authorised: Operation,
+        /// What the effect is.
+        performing: Operation,
+    },
+    /// The decision was taken against permissions other than the ones in force.
+    StalePermissions {
+        /// Checksum of the permissions the decision was taken against.
+        decided_under: String,
+        /// Checksum of the permissions the effect would run under.
+        executing_under: String,
+    },
+}
+
+impl std::fmt::Display for RedeemError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        /// First eight hex characters: enough to tell two digests apart in a
+        /// message a human reads. The full digest belongs in the trace.
+        fn short(d: &str) -> &str {
+            d.get(..8).unwrap_or(d)
+        }
+        match self {
+            Self::ScopeMismatch {
+                authorised,
+                performing,
+            } => write!(
+                f,
+                "decision authorises {authorised:?}, this effect is {performing:?}"
+            ),
+            Self::StalePermissions {
+                decided_under,
+                executing_under,
+            } => write!(
+                f,
+                "decision was taken against permissions {} but this effect runs under {}: \
+                 a decision does not carry across a change of policy",
+                short(decided_under),
+                short(executing_under)
+            ),
+        }
+    }
+}
+
+impl std::error::Error for RedeemError {}
+
 /// Proof that Kernel::decide() returned Allow.
 ///
 /// This token is:
@@ -379,6 +429,10 @@ pub enum ApprovalSource {
 ///
 /// Only Kernel::decide() can create this token. Kani proof
 /// `proof_decision_token_unforgeable` verifies no other construction path exists.
+///
+/// The only way to USE one is [`DecisionToken::redeem`], which checks both
+/// that the decision authorises this operation and that it was taken against
+/// the permissions now in force.
 #[must_use = "DecisionToken must be consumed by executing the authorized operation"]
 pub struct DecisionToken {
     /// The operation this token authorizes.
@@ -403,9 +457,39 @@ pub struct DecisionToken {
 }
 
 impl DecisionToken {
-    /// The operation this token authorizes.
-    pub fn operation(&self) -> Operation {
-        self.operation
+    /// Consume this token to perform `performing` under `executing_under`.
+    ///
+    /// The only public way to use a `DecisionToken`, and it checks both things a
+    /// redeemer must check:
+    ///
+    /// * **scope** — the decision authorises the operation being performed;
+    /// * **currency** — the decision was taken against the very permissions the
+    ///   effect is about to run under.
+    ///
+    /// Taking `self` by value makes this the token's single use, so the affine
+    /// discipline and the two checks are one event rather than three things a
+    /// call site is trusted to do in order. A new effect method cannot read the
+    /// token without performing them: there is nothing else to call.
+    ///
+    /// # Errors
+    ///
+    /// [`RedeemError::ScopeMismatch`] when the decision authorises a different
+    /// operation; [`RedeemError::StalePermissions`] when it was taken against a
+    /// different policy.
+    pub fn redeem(self, executing_under: &str, performing: Operation) -> Result<(), RedeemError> {
+        if self.operation != performing {
+            return Err(RedeemError::ScopeMismatch {
+                authorised: self.operation,
+                performing,
+            });
+        }
+        if self.permissions != executing_under {
+            return Err(RedeemError::StalePermissions {
+                decided_under: self.permissions,
+                executing_under: executing_under.to_string(),
+            });
+        }
+        Ok(())
     }
 
     /// The decision sequence number for audit correlation.

--- a/crates/portcullis/src/kernel_tests.rs
+++ b/crates/portcullis/src/kernel_tests.rs
@@ -2066,3 +2066,64 @@ fn test_extract_host() {
     assert_eq!(extract_host("api.example.com"), "api.example.com");
     assert_eq!(extract_host("https://host.com"), "host.com");
 }
+
+// ── redeem: the only way to use a token ───────────────────────────────────────
+
+fn a_bash_token(kernel: &mut Kernel) -> DecisionToken {
+    kernel.issue_approved_token(Operation::RunBash, "test")
+}
+
+fn perms_of(kernel: &Kernel) -> String {
+    kernel.effective().clone().normalize().checksum()
+}
+
+#[test]
+fn a_token_redeems_under_the_permissions_it_was_decided_against() {
+    let mut kernel = Kernel::new(PermissionLattice::permissive());
+    let perms = perms_of(&kernel);
+    let token = a_bash_token(&mut kernel);
+    assert!(token.redeem(&perms, Operation::RunBash).is_ok());
+}
+
+#[test]
+fn a_token_is_refused_for_another_operation() {
+    // THE regression this replaces was `debug_assert_eq!`, which compiles to
+    // nothing in release: a token minted for one operation was accepted by the
+    // entry point of another in every shipped binary.
+    let mut kernel = Kernel::new(PermissionLattice::permissive());
+    let perms = perms_of(&kernel);
+    let token = a_bash_token(&mut kernel);
+    assert_eq!(
+        token.redeem(&perms, Operation::ReadFiles),
+        Err(RedeemError::ScopeMismatch {
+            authorised: Operation::RunBash,
+            performing: Operation::ReadFiles,
+        })
+    );
+}
+
+#[test]
+fn a_token_is_refused_under_other_permissions() {
+    let mut kernel = Kernel::new(PermissionLattice::permissive());
+    let token = a_bash_token(&mut kernel);
+    let elsewhere = PermissionLattice::restrictive().normalize().checksum();
+    let err = token
+        .redeem(&elsewhere, Operation::RunBash)
+        .expect_err("a decision does not carry across a change of policy");
+    assert!(matches!(err, RedeemError::StalePermissions { .. }));
+    assert!(err.to_string().contains("change of policy"), "{err}");
+}
+
+#[test]
+fn scope_is_checked_before_currency() {
+    // A token wrong on BOTH counts reports the operation mismatch, which is the
+    // one a caller can act on: the effect asked for the wrong authorisation, not
+    // merely a stale one.
+    let mut kernel = Kernel::new(PermissionLattice::permissive());
+    let token = a_bash_token(&mut kernel);
+    let elsewhere = PermissionLattice::restrictive().normalize().checksum();
+    assert!(matches!(
+        token.redeem(&elsewhere, Operation::ReadFiles),
+        Err(RedeemError::ScopeMismatch { .. })
+    ));
+}


### PR DESCRIPTION
The previous PR put a permissions check at six redeem sites in `command.rs`. **It found the wrong number of sites.**

## The hole the last PR left open

`sandbox.rs` redeems `DecisionToken` at **twenty-four more**, and every one called `require_decision_for(decision.operation(), op)` and nothing else:

```
command.rs:  require_decision_for = 6    require_permissions_match = 6
sandbox.rs:  require_decision_for = 24   require_permissions_match = 0
```

So after wiring six, 24 of the 30 redeem sites still accepted a decision taken under any policy at all. That is not an oversight to patch twenty-four more times — it is what happens when a check is a line a call site is trusted to write, and it would have been true again for site thirty-one.

## The check stops being a line and becomes the type's only door

`DecisionToken::operation` is **gone**. There is no way to read what a token authorises. The one public method is:

```rust
pub fn redeem(self, executing_under: &str, performing: Operation) -> Result<(), RedeemError>
```

It takes `self` by value and checks both things a redeemer must check:

- **scope** — this decision authorises this operation
- **currency** — it was taken against the very permissions the effect is about to run under

The affine consumption and the two checks are now one event rather than three things done in order by convention. **A new effect method cannot forget, because there is nothing else to call.**

## The compiler enumerated the defect

Making the accessor `pub(crate)` turned the hole into **28 compiler errors**, one per unchecked site, in exactly the two files that had them. That is the argument for the shape.

## Also

`Sandbox` gains the permissions fingerprint alongside `Executor`'s; a subdirectory inherits its parent's, since `open_dir` narrows the path and not the policy.

`decision_scope` loses both free functions and keeps three lines — the `From<RedeemError>` that turns a refusal into a `ScopeMismatch`. **THE regression its doc records is preserved**: `debug_assert_eq!` compiled to nothing in release, so a token minted for `ReadFiles` was accepted by a `RunBash` entry point in every shipped binary. It is now pinned where the check lives, in `kernel_tests.rs`, together with the currency refusal and the ordering between them — a token wrong on both counts reports the scope mismatch, which is the one a caller can act on.

`operation()` became dead the moment `redeem` read the field directly, and clippy said so. Removed rather than kept alive for one Kani assertion, which now reads the field it is in the same crate as.

## Verification

`cargo test -p portcullis -p nucleus` — **25 suites green**, 1058 portcullis lib tests and 75 nucleus lib tests. `cargo clippy --workspace --exclude nucleus-verifier-service --all-targets --all-features -- -D warnings` clean. Scorecard unchanged at `life 14.28%` — this PR makes the existing property unforgettable rather than adding a new one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016t7JSuCtg4dC54HZjFgBjr