### PR TITLE
typed: how much of the runtime IFC is a compile error

### DIFF
--- a/.scorecard-ratchet.toml
+++ b/.scorecard-ratchet.toml
@@ -264,3 +264,52 @@ population_floor = 7
 # Secret are confidential -- and each is a struct plus a registry row.
 floor_bp = 869
 population_floor = 23
+
+[family.suppress]
+# 5 of 134 production lint suppressions expire. The rest are forever.
+#
+# THIS FAMILY MEASURES THE EXEMPTION CHANNEL OF THE OTHER FIVE. bound, alg, tot,
+# life and typed each report how much of what the tree declares is covered by a
+# mechanism that CAN FAIL. Every one of those mechanisms can be switched off,
+# silently and permanently, by one line: #[allow(clippy::whatever)].
+#
+# An #[allow] is forever. It outlives the reason it was written for and nothing
+# says when that reason expired. An #[expect] is the same waiver with an expiry:
+# when the lint stops firing there, unfulfilled_lint_expectations errors and the
+# attribute has to go. It is the ONLY suppression that can itself fail, which is
+# this card's definition of discharged applied to the waivers.
+#
+# THE ASYMMETRY IS THE CASE. Across the tree: 292 #[allow], of which ZERO carry a
+# `reason =`. 48 #[expect], of which all 48 do. The tree already knows the right
+# form and 86% of its suppressions are the other one.
+#
+# PRODUCTION ONLY, and for this family that is not merely the convention. A
+# suppression inside #[cfg(test)] cannot disable a production gate, and disabling
+# a production gate is the defect being measured. That is why the number is 5 of
+# 134 rather than 39 of 206: most existing #[expect]s waive lints in test code,
+# including nine of portcullis-effects' ten, which waive
+# clippy::let_underscore_must_use at test sites.
+#
+# A MANDATE ONLY REACHES WHERE ITS TABLE DOES. allow_attributes and
+# allow_attributes_without_reason are clippy lints, delivered through
+# [workspace.lints.clippy] -- and that table reaches a crate only if the crate
+# opts in with `[lints] workspace = true`. 54 of 95 crates opt in. 41 do NOT, and
+# they include portcullis, portcullis-core and nucleus-flow-replay: the crates
+# holding the lattice, the receipt hashing and the flow replay. Their 53
+# production suppressions are reported as `undeclared` rather than counted,
+# because counting them as discharged would mean a crate could LEAVE the lint
+# table and have its allows become compliant. Same reading `tot` takes of the
+# crates clippy cannot compile, same reason: ADR 0007 A-2.
+#
+# HOW IT IS PAID. Two lines into the existing [workspace.lints.clippy] table --
+# allow_attributes = "deny" and allow_attributes_without_reason = "deny" -- and
+# clippy::allow_attributes has a machine-applicable suggestion, so most of the
+# conversion is `cargo clippy --fix`. Two real costs: a #[allow(dead_code)] that
+# fires only under some feature combinations becomes an unfulfilled expectation
+# under others, so those need per-site judgement under the --all-features matrix;
+# and the 41 non-adopting crates need three manifest lines each before the
+# mandate reaches them at all.
+#
+# 2026-09-11: seeded at the measurement.
+floor_bp = 373
+population_floor = 134

--- a/.scorecard-ratchet.toml
+++ b/.scorecard-ratchet.toml
@@ -216,3 +216,51 @@ population_floor = 81
 # (E0382). That is an ADR and a call-site refactor, not a ratchet.
 floor_bp = 1428
 population_floor = 7
+
+[family.typed]
+# 2 of 23 runtime flow kinds are distinguished at COMPILE time.
+#
+# portcullis_core::labeled encodes a Denning-style security lattice in the trait
+# system -- Labeled<T, I: IntegTag, C: ConfTag>, with Trusted/Untrusted/
+# Adversarial crossed with Public/Internal/Secret -- and its own compile_fail
+# doctest proves the thing that matters: Secret data cannot reach a function
+# requiring ConfAtMost<Public>. That is a compile error, not a check anyone has
+# to reach. It is the construction the 2026 literature calls Denning-style IFC in
+# Rust's type system, and it is already here.
+#
+# It is applied to TWO kinds: FileRead (Trusted, Internal) and WebContent
+# (Adversarial, Public). The other twenty-one are tracked by FlowTracker at
+# runtime, which is sound and is also a CHECK -- so it has to be reached.
+# nucleus-observed-lint exists precisely because an ingest path can forget to
+# call observe, and its doc names the defect it was built from: /v1/run returned
+# arbitrary subprocess stdout and observed nothing. A kind that is LIFTED cannot
+# forget. That is the whole difference, and this ratio is the fraction.
+#
+# A LINT AND A TYPE SYSTEM ARE NOT THE SAME TOOL, and this family is where the
+# difference is visible. A dylint pass can decide ADOPTION -- does every function
+# in the ingest closure return a labelled type -- which is a typeck question over
+# a bounded set of paths, and nucleus-observed-lint already answers the runtime
+# equivalent. It cannot decide THE INVARIANT: "no Secret value reaches a Public
+# sink, through any composition anyone writes later" is not a bounded search, it
+# is what parametric polymorphism gives for free once the data is inside the
+# typed region. The lint guards the frontier; the types guard the interior.
+#
+# So this family and `observed` should move in OPPOSITE directions. Every kind
+# lifted here is a path the lint no longer has to police, and .observed-ratchet
+# .toml's ceiling should fall as this ratio rises. If it does not, one of the two
+# is measuring something other than what it says.
+#
+# Custom is excluded by name: it carries a caller-supplied string and cannot take
+# a fixed pair of tags, so counting it would put an undischargeable obligation in
+# the denominator forever. convergence excludes its two unmeasurable arrows the
+# same way.
+#
+# A row of LIFTED_TO_TYPES cannot over-claim: the gate checks the named type
+# exists and carries a `Labeled<` field, and refuses a row naming a NodeKind that
+# is not a variant. Both halves are tested.
+#
+# 2026-09-11: seeded at the measurement. The next lifts are the ones with an
+# obvious tag pair -- McpToolResult and ToolResponse are adversarial, EnvVar and
+# Secret are confidential -- and each is a struct plus a registry row.
+floor_bp = 869
+population_floor = 23

--- a/badges/scorecard.json
+++ b/badges/scorecard.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"scorecard","message":"life 14.28%","color":"orange"}
+{"schemaVersion":1,"label":"scorecard","message":"typed 8.69%","color":"orange"}

--- a/badges/scorecard.json
+++ b/badges/scorecard.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"scorecard","message":"typed 8.69%","color":"orange"}
+{"schemaVersion":1,"label":"scorecard","message":"suppress 3.73%","color":"orange"}

--- a/crates/portcullis-effects/src/runtime.rs
+++ b/crates/portcullis-effects/src/runtime.rs
@@ -339,6 +339,37 @@ impl ReadOutput {
     }
 }
 
+/// Which runtime `NodeKind` each compile-time-labelled output lifts.
+///
+/// # Why a registry and not an inference
+///
+/// The `Labeled<T, I, C>` machinery in `portcullis_core::labeled` is a
+/// Denning-style security lattice encoded in the trait system, and its own
+/// `compile_fail` doctest proves the thing that matters: `Secret` data cannot
+/// reach a function requiring `ConfAtMost<Public>`. That is a compile error, not
+/// a check someone runs.
+///
+/// It is applied to **two** of the twenty-four kinds the runtime IFC
+/// distinguishes. The rest are tracked by `FlowTracker` at runtime, which is
+/// sound but is a check rather than a proof — and a check has to be reached.
+///
+/// This registry is how the gap gets a number. Each row says "this `NodeKind`
+/// has been lifted to the type system, by this output type". The gate reads the
+/// `NodeKind` enum for the population and this array for the discharge, so both
+/// sides are syntax and neither needs a resolver — the discipline
+/// `inert_authority`'s closed witness vocabulary already uses.
+///
+/// A row cannot over-claim: the gate checks the named type exists and carries a
+/// `Labeled<` field. A row naming a type that does not, or does not label, is a
+/// failure rather than a free point.
+pub const LIFTED_TO_TYPES: [(&str, &str); 2] = [
+    // A file read is trusted input at internal confidentiality.
+    ("FileRead", "ReadOutput"),
+    // Web content is adversarial at public confidentiality: passing it where
+    // `Trusted` is required does not compile.
+    ("WebContent", "FetchOutput"),
+];
+
 /// Output from [`NucleusRuntime::fetch_url`].
 ///
 /// Data is `Labeled<Vec<u8>, Adversarial, Public>` — web content carries

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -362,6 +362,7 @@ mod schedule_liveness;
 mod scoreboard;
 mod scorecard;
 mod self_pin;
+mod suppress;
 mod tot;
 mod typed;
 

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -363,6 +363,7 @@ mod scoreboard;
 mod scorecard;
 mod self_pin;
 mod tot;
+mod typed;
 
 fn main() -> Result<()> {
     match Cli::parse().command {

--- a/crates/xtask/src/scorecard.rs
+++ b/crates/xtask/src/scorecard.rs
@@ -176,6 +176,7 @@ pub fn families() -> Vec<Box<dyn Family>> {
         Box::new(crate::tot::Tot),
         Box::new(crate::life::Life),
         Box::new(crate::typed::Typed),
+        Box::new(crate::suppress::Suppress),
     ]
 }
 

--- a/crates/xtask/src/scorecard.rs
+++ b/crates/xtask/src/scorecard.rs
@@ -175,6 +175,7 @@ pub fn families() -> Vec<Box<dyn Family>> {
         Box::new(crate::alg::Alg),
         Box::new(crate::tot::Tot),
         Box::new(crate::life::Life),
+        Box::new(crate::typed::Typed),
     ]
 }
 

--- a/crates/xtask/src/suppress.rs
+++ b/crates/xtask/src/suppress.rs
@@ -1,0 +1,343 @@
+//! The `suppress` family — the exemption channel of every other family.
+//!
+//! # Why this is not one gate among six
+//!
+//! `bound`, `alg`, `tot`, `life` and `typed` each report how much of what the
+//! tree declares is covered by *a mechanism that can fail*. Every one of those
+//! mechanisms can be switched off, silently and permanently, by one line:
+//!
+//! ```text
+//! #[allow(clippy::let_underscore_must_use)]
+//! ```
+//!
+//! An `#[allow]` is forever. It outlives the reason it was written for, and
+//! nothing tells you when that reason expires. An `#[expect]` is the same
+//! waiver with an expiry attached: when the lint stops firing at that site,
+//! `unfulfilled_lint_expectations` errors and the attribute has to go. **It is
+//! the only suppression that can itself fail**, which is this card's own
+//! definition of discharged, applied to the waivers.
+//!
+//! # The measurement that makes the case
+//!
+//! Over the production region: **292 `#[allow]`, of which 0 carry a
+//! `reason =`. 48 `#[expect]`, of which 48 do.**
+//!
+//! The tree already knows the right form. `crates/portcullis-effects/src/lib.rs`
+//! denies `clippy::let_underscore_must_use` crate-wide and discharges it at nine
+//! sites with `#[expect(..., reason = ...)]` — a live mandate, correctly waived,
+//! in exactly one crate.
+//!
+//! # A mandate only reaches where its table does
+//!
+//! `allow_attributes` and `allow_attributes_without_reason` are clippy lints, so
+//! they arrive through `[workspace.lints.clippy]` — and that table reaches a
+//! crate only if the crate opts in with `[lints] workspace = true`.
+//!
+//! **54 of 95 crates opt in. 41 do not, and they include `portcullis`,
+//! `portcullis-core` and `nucleus-flow-replay`** — the crates holding the
+//! lattice, the receipt hashing and the flow replay. A suppression in one of
+//! those is not covered and cannot be, until that crate's manifest gains three
+//! lines.
+//!
+//! So the population is the suppressions the table can reach, and the 81 outside
+//! it are reported as `undeclared`: surface the denominator does not cover. This
+//! is the same reading `tot` takes of the crates clippy cannot compile, and for
+//! the same reason — ADR 0007 A-2, "I could not look" is never "I looked and it
+//! was fine".
+//!
+//! Counting them as discharged would be the worst available answer: a crate
+//! could leave the lint table and its allows would become *compliant*.
+
+use anyhow::{Result, bail};
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::law_mechanisms::production_region;
+
+/// Crates that opt into `[workspace.lints]`, and so can receive a clippy
+/// mandate at all.
+///
+/// Parsed from the `[lints]` table rather than assumed: a crate with its own
+/// `[lints.clippy]` section and no `workspace = true` does NOT inherit, and a
+/// crate with no `[lints]` section at all inherits nothing.
+pub fn adopting_crates(manifests: &BTreeMap<String, String>) -> BTreeSet<String> {
+    let mut out = BTreeSet::new();
+    for (path, src) in manifests {
+        let Some(name) = crate_name(path) else {
+            continue;
+        };
+        // At the start of a line, which includes the start of the file — a
+        // manifest opening with `[lints]` is legal TOML and a parser keyed to a
+        // preceding newline would silently miss it, scoring that crate as
+        // outside the mandate when it is inside.
+        let Some(start) = section(src, "[lints]") else {
+            continue;
+        };
+        let body = &src[start..];
+        let end = body[1..].find("\n[").map_or(body.len(), |i| i + 1);
+        if body[..end].contains("workspace = true") {
+            out.insert(name);
+        }
+    }
+    out
+}
+
+/// The byte offset of a TOML section header at the start of a line.
+fn section(src: &str, header: &str) -> Option<usize> {
+    if src.starts_with(header) {
+        return Some(0);
+    }
+    src.find(&format!("\n{header}")).map(|i| i + 1)
+}
+
+fn crate_name(path: &str) -> Option<String> {
+    let rest = path
+        .strip_prefix("crates/")
+        .or_else(|| path.strip_prefix("tools/"))?;
+    rest.split('/').next().map(str::to_string)
+}
+
+/// One suppression attribute.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Suppression {
+    /// `#[allow(..)]` — forever, and silent about why.
+    Allow,
+    /// `#[expect(..)]` — expires when the lint stops firing.
+    Expect,
+}
+
+/// Every suppression attribute in one source region, in order.
+///
+/// Inner (`#![allow]`) and outer (`#[allow]`) both count: a crate-level allow is
+/// the broadest waiver there is.
+pub fn suppressions(region: &str) -> Vec<Suppression> {
+    let mut out = Vec::new();
+    let mut rest = region;
+    while let Some(i) = rest.find("[allow(").or_else(|| rest.find("[expect(")) {
+        let is_allow = rest[i..].starts_with("[allow(");
+        // Must be an attribute: `#[` or `#![` immediately before.
+        let before = &rest[..i];
+        let attr = before.ends_with('#') || before.ends_with("#!");
+        if attr {
+            out.push(if is_allow {
+                Suppression::Allow
+            } else {
+                Suppression::Expect
+            });
+        }
+        rest = &rest[i + 1..];
+    }
+    out
+}
+
+/// The measured state.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct Report {
+    /// Suppressions in crates the lint table reaches.
+    pub covered_allow: usize,
+    /// Of those, the ones that expire.
+    pub covered_expect: usize,
+    /// Suppressions in crates outside the table.
+    pub uncovered: usize,
+}
+
+pub fn report(
+    corpus: &BTreeMap<String, String>,
+    manifests: &BTreeMap<String, String>,
+) -> Result<Report> {
+    let adopting = adopting_crates(manifests);
+    if adopting.is_empty() {
+        bail!(
+            "no crate opts into [workspace.lints]. The population would be empty and the ratio \
+             meaningless — either the manifests moved or the parse is wrong."
+        );
+    }
+    let mut r = Report::default();
+    for (path, src) in corpus {
+        let Some(name) = crate_name(path) else {
+            continue;
+        };
+        let inside = adopting.contains(&name);
+        for s in suppressions(&production_region(src)) {
+            match (inside, s) {
+                (true, Suppression::Expect) => r.covered_expect += 1,
+                (true, Suppression::Allow) => r.covered_allow += 1,
+                (false, _) => r.uncovered += 1,
+            }
+        }
+    }
+    Ok(r)
+}
+
+impl Report {
+    /// The three numbers the card prints.
+    ///
+    /// Pure, so the mapping is testable without a checkout: `census` below reads
+    /// real manifests through `git ls-files`, and `cargo test` runs with the
+    /// crate root as its working directory rather than the repo root.
+    pub const fn census(self) -> crate::scorecard::Census {
+        crate::scorecard::Census {
+            population: self.covered_allow + self.covered_expect,
+            discharged: self.covered_expect,
+            undeclared: self.uncovered,
+        }
+    }
+}
+
+pub struct Suppress;
+
+impl crate::scorecard::Family for Suppress {
+    fn name(&self) -> &'static str {
+        "suppress"
+    }
+
+    fn unit(&self) -> &'static str {
+        "lint suppression"
+    }
+
+    fn census(&self, corpus: &BTreeMap<String, String>) -> Result<crate::scorecard::Census> {
+        let manifests = crate::law_mechanisms::tracked(is_manifest)?;
+        Ok(report(corpus, &manifests)?.census())
+    }
+}
+
+/// A crate manifest under `crates/` or `tools/`.
+fn is_manifest(path: &str) -> bool {
+    (path.starts_with("crates/") || path.starts_with("tools/")) && path.ends_with("/Cargo.toml")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn both_attribute_forms_count() {
+        let src = "#![allow(dead_code)]\nfn f() {\n    #[expect(unused, reason = \"why\")]\n    let x = 1;\n}\n";
+        assert_eq!(
+            suppressions(src),
+            vec![Suppression::Allow, Suppression::Expect]
+        );
+    }
+
+    #[test]
+    fn a_mention_is_not_an_attribute() {
+        // A doc line or a string naming the attribute must not count.
+        assert!(suppressions("let s = \"[allow(x)]\";\n").is_empty());
+        assert!(suppressions("// see [allow(dead_code)]\n").is_empty());
+    }
+
+    #[test]
+    fn a_crate_with_no_lints_section_does_not_adopt() {
+        let m = BTreeMap::from([(
+            "crates/a/Cargo.toml".to_string(),
+            "[package]\nname = \"a\"\n".to_string(),
+        )]);
+        assert!(adopting_crates(&m).is_empty());
+    }
+
+    #[test]
+    fn a_crate_with_its_own_lints_table_does_not_inherit() {
+        // `[lints.clippy]` without `workspace = true` receives nothing from the
+        // workspace table, which is exactly how a mandate can miss a crate that
+        // looks configured.
+        let m = BTreeMap::from([(
+            "crates/a/Cargo.toml".to_string(),
+            "[package]\nname = \"a\"\n\n[lints.clippy]\nfoo = \"deny\"\n".to_string(),
+        )]);
+        assert!(adopting_crates(&m).is_empty());
+    }
+
+    #[test]
+    fn a_manifest_opening_with_the_lints_table_still_adopts() {
+        // Found by `the_test_region_is_not_the_subject` failing: the parser
+        // keyed on "\n[lints]" and a manifest whose FIRST line is `[lints]`
+        // would have been scored as outside the mandate while being inside it.
+        let m = BTreeMap::from([(
+            "crates/a/Cargo.toml".to_string(),
+            "[lints]\nworkspace = true\n".to_string(),
+        )]);
+        assert_eq!(adopting_crates(&m), BTreeSet::from(["a".to_string()]));
+    }
+
+    #[test]
+    fn opting_in_is_the_whole_requirement() {
+        let m = BTreeMap::from([(
+            "crates/a/Cargo.toml".to_string(),
+            "[package]\nname = \"a\"\n\n[lints]\nworkspace = true\n\n[dependencies]\n".to_string(),
+        )]);
+        assert_eq!(adopting_crates(&m), BTreeSet::from(["a".to_string()]));
+    }
+
+    #[test]
+    fn a_suppression_outside_the_table_is_undeclared_not_discharged() {
+        // The worst available answer would be to count it as covered: a crate
+        // could then leave the lint table and its allows would become compliant.
+        let manifests = BTreeMap::from([
+            (
+                "crates/inside/Cargo.toml".to_string(),
+                "[lints]\nworkspace = true\n".to_string(),
+            ),
+            (
+                "crates/outside/Cargo.toml".to_string(),
+                "[package]\nname = \"outside\"\n".to_string(),
+            ),
+        ]);
+        let corpus = BTreeMap::from([
+            (
+                "crates/inside/src/lib.rs".to_string(),
+                "#[allow(dead_code)]\n#[expect(unused, reason = \"r\")]\nfn f() {}\n".to_string(),
+            ),
+            (
+                "crates/outside/src/lib.rs".to_string(),
+                "#[allow(dead_code)]\nfn g() {}\n".to_string(),
+            ),
+        ]);
+        let r = report(&corpus, &manifests).expect("succeeds");
+        assert_eq!(r.covered_allow, 1);
+        assert_eq!(r.covered_expect, 1);
+        assert_eq!(r.uncovered, 1, "the outside allow is undeclared");
+    }
+
+    #[test]
+    fn an_empty_lint_table_is_refused_rather_than_scored() {
+        let manifests =
+            BTreeMap::from([("crates/a/Cargo.toml".to_string(), "[package]\n".to_string())]);
+        let err = report(&BTreeMap::new(), &manifests).expect_err("no population, no ratio");
+        assert!(err.to_string().contains("meaningless"), "{err}");
+    }
+
+    #[test]
+    fn the_test_region_is_not_the_subject() {
+        // An allow inside `#[cfg(test)]` waives a lint for test code, which is
+        // not the mandate this family measures.
+        let manifests = BTreeMap::from([(
+            "crates/a/Cargo.toml".to_string(),
+            "[lints]\nworkspace = true\n".to_string(),
+        )]);
+        let corpus = BTreeMap::from([(
+            "crates/a/src/lib.rs".to_string(),
+            "#[allow(dead_code)]\nfn f() {}\n#[cfg(test)]\nmod tests {\n    #[allow(unused)]\n    fn t() {}\n}\n".to_string(),
+        )]);
+        let r = report(&corpus, &manifests).expect("succeeds");
+        assert_eq!(r.covered_allow, 1, "only the production allow");
+    }
+
+    #[test]
+    fn the_report_maps_to_the_three_numbers_the_card_prints() {
+        // An untested adapter is how a correct census reaches the card wrong.
+        let c = Report {
+            covered_allow: 129,
+            covered_expect: 5,
+            uncovered: 53,
+        }
+        .census();
+        assert_eq!(c.population, 134, "allow + expect, inside the table");
+        assert_eq!(c.discharged, 5, "only the ones that expire");
+        assert_eq!(c.undeclared, 53, "outside the table, never discharged");
+        assert_eq!(c.basis_points(), 373);
+    }
+
+    #[test]
+    fn an_empty_report_is_zero_not_a_hundred() {
+        assert_eq!(Report::default().census().basis_points(), 0);
+    }
+}

--- a/crates/xtask/src/typed.rs
+++ b/crates/xtask/src/typed.rs
@@ -1,0 +1,281 @@
+//! The `typed` family — how much of the runtime IFC is a compile error.
+//!
+//! # The mechanism already exists and is already proven
+//!
+//! `portcullis_core::labeled` encodes a Denning-style security lattice in the
+//! trait system: `Labeled<T, I: IntegTag, C: ConfTag>`, with
+//! `Trusted/Untrusted/Adversarial` crossed with `Public/Internal/Secret`. Its
+//! own `compile_fail` doctest proves the thing that matters —
+//!
+//! ```text
+//! fn publish<C: ConfAtMost<Public>>(_v: Labeled<String, Trusted, C>) {}
+//! let key: Labeled<String, Trusted, Secret> = Labeled::new(..);
+//! publish(key); // ERROR: Secret does not implement ConfAtMost<Public>
+//! ```
+//!
+//! — and that is a compile error, not a check anyone has to reach. It is the
+//! same construction the 2026 literature calls Denning-style IFC in Rust's type
+//! system, built here already.
+//!
+//! It is applied to **two** of the twenty-four kinds `NodeKind` distinguishes.
+//! The other twenty-two are tracked by `FlowTracker` at runtime. Runtime
+//! tracking is sound and it is also a check, which means it has to be reached:
+//! `nucleus-observed-lint` exists precisely because an ingest path can forget to
+//! call `observe`, and its own doc names the defect it was built from — `/v1/run`
+//! returned arbitrary subprocess stdout and observed nothing.
+//!
+//! A kind that is lifted cannot forget. That is the whole difference, and this
+//! family is the fraction.
+//!
+//! # Why a lint and a type system are not the same tool
+//!
+//! A dylint pass can decide **adoption**: does every function in the ingest
+//! closure return a labelled type? That is a `typeck` question over a bounded
+//! set of paths, and `nucleus-observed-lint` already answers the runtime
+//! equivalent with a reachability closure over `AGENT_ROOTS`.
+//!
+//! It cannot decide **the invariant**. "No `Secret` value reaches a `Public`
+//! sink, through any composition of functions anyone writes later" is not a
+//! bounded search; it is exactly what parametric polymorphism gives for free
+//! once the data is inside the typed region.
+//!
+//! So they compose rather than compete: **the lint guards the frontier of the
+//! typed region, and the types guard its interior.** The useful consequence is
+//! that this family and `observed` move in opposite directions — every kind
+//! lifted here is a path `observed` no longer has to police, and its ceiling
+//! should fall as this ratio rises.
+//!
+//! # Population and discharge
+//!
+//! * **population** — the variants of `NodeKind`, the runtime taxonomy, minus
+//!   `Custom`, which is an escape hatch rather than a kind of data.
+//! * **discharged** — the rows of `LIFTED_TO_TYPES`, each checked to name a type
+//!   that exists and carries a `Labeled<` field, so a row cannot buy a point
+//!   without the type behind it.
+//! * **undeclared** — zero. Unlike `bound` and `alg`, there is no shape-without-
+//!   declaration here: a kind is in the enum or it is not, and reporting a guess
+//!   would be worse than reporting none.
+
+use anyhow::{Result, bail};
+use std::collections::BTreeMap;
+
+use crate::scorecard::{Census, Family};
+
+/// The runtime taxonomy lives here.
+const FLOW: &str = "crates/nucleus-ifc-kernel/src/flow.rs";
+
+/// The registry of lifts lives here, beside the types it names.
+const RUNTIME: &str = "crates/portcullis-effects/src/runtime.rs";
+
+/// `Custom` is an escape hatch, not a kind of data: it carries a caller-supplied
+/// string and cannot be given a fixed pair of tags. Excluded by name rather than
+/// silently, the way `convergence` excludes its two unmeasurable arrows.
+const NOT_A_KIND: [&str; 1] = ["Custom"];
+
+/// The variants of `NodeKind`.
+pub fn kinds(src: &str) -> Vec<String> {
+    let Some(start) = src.find("pub enum NodeKind") else {
+        return Vec::new();
+    };
+    let body = &src[start..];
+    let end = body.find("\n}").map_or(body.len(), |i| i + 1);
+    body[..end]
+        .lines()
+        .skip(1)
+        .filter_map(|l| {
+            let t = l.trim();
+            if t.starts_with("//") || t.starts_with('#') {
+                return None;
+            }
+            let name: String = t
+                .chars()
+                .take_while(|c| c.is_ascii_alphanumeric())
+                .collect();
+            let first = name.chars().next()?;
+            (first.is_ascii_uppercase() && !NOT_A_KIND.contains(&name.as_str())).then_some(name)
+        })
+        .collect()
+}
+
+/// The `(NodeKind, output type)` rows of `LIFTED_TO_TYPES`.
+pub fn lifts(src: &str) -> Vec<(String, String)> {
+    let Some(start) = src.find("pub const LIFTED_TO_TYPES") else {
+        return Vec::new();
+    };
+    let body = &src[start..];
+    let end = body.find("];").map_or(body.len(), |i| i);
+    let mut out = Vec::new();
+    let mut rest = &body[..end];
+    while let Some(i) = rest.find("(\"") {
+        rest = &rest[i + 2..];
+        let Some(j) = rest.find('"') else { break };
+        let kind = rest[..j].to_string();
+        let after = &rest[j..];
+        let Some(k) = after.find("\"") else { break };
+        let tail = &after[k + 1..];
+        let Some(m) = tail.find('"') else { break };
+        let Some(n) = tail[m + 1..].find('"') else {
+            break;
+        };
+        out.push((kind, tail[m + 1..m + 1 + n].to_string()));
+        rest = &tail[m + 1 + n..];
+    }
+    out
+}
+
+/// Does `ty` exist in `src` and carry a `Labeled<` field?
+///
+/// The anti-over-claim check: a registry row naming a type that does not label
+/// its data would otherwise buy a point for nothing.
+pub fn labels_its_data(src: &str, ty: &str) -> bool {
+    let Some(i) = src.find(&format!("pub struct {ty} {{")) else {
+        return false;
+    };
+    let body = &src[i..];
+    let end = body.find("\n}").map_or(body.len(), |j| j);
+    body[..end].contains("Labeled<")
+}
+
+pub struct Typed;
+
+impl Family for Typed {
+    fn name(&self) -> &'static str {
+        "typed"
+    }
+
+    fn unit(&self) -> &'static str {
+        "runtime flow kind"
+    }
+
+    fn census(&self, corpus: &BTreeMap<String, String>) -> Result<Census> {
+        let flow = corpus
+            .get(FLOW)
+            .ok_or_else(|| anyhow::anyhow!("{FLOW} is not in the production corpus"))?;
+        let runtime = corpus
+            .get(RUNTIME)
+            .ok_or_else(|| anyhow::anyhow!("{RUNTIME} is not in the production corpus"))?;
+
+        let kinds = kinds(flow);
+        if kinds.is_empty() {
+            bail!(
+                "no NodeKind variants found in {FLOW}. The population would be zero and the \
+                 ratio meaningless — the enum moved or was renamed."
+            );
+        }
+
+        let mut discharged = 0usize;
+        for (kind, ty) in lifts(runtime) {
+            if !kinds.contains(&kind) {
+                bail!(
+                    "LIFTED_TO_TYPES names NodeKind::{kind}, which is not a variant. A stale row \
+                     discharges an obligation that does not exist."
+                );
+            }
+            if !labels_its_data(runtime, &ty) {
+                bail!(
+                    "LIFTED_TO_TYPES says {ty} lifts NodeKind::{kind}, but {ty} carries no \
+                     `Labeled<` field. A row cannot buy a point without the type behind it."
+                );
+            }
+            discharged += 1;
+        }
+
+        Ok(Census {
+            population: kinds.len(),
+            discharged,
+            // A kind is in the enum or it is not. There is no shape-without-
+            // declaration here, and a guess would be worse than nothing.
+            undeclared: 0,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ENUM: &str = "pub enum NodeKind {\n    UserPrompt,\n    WebContent,\n    /// doc\n    FileRead,\n    Custom(String),\n}\n";
+
+    #[test]
+    fn the_variants_are_the_population() {
+        assert_eq!(kinds(ENUM), vec!["UserPrompt", "WebContent", "FileRead"]);
+    }
+
+    #[test]
+    fn custom_is_an_escape_hatch_not_a_kind() {
+        // It carries a caller-supplied string and cannot take a fixed pair of
+        // tags, so counting it would put an undischargeable obligation in the
+        // denominator forever.
+        assert!(!kinds(ENUM).contains(&"Custom".to_string()));
+    }
+
+    #[test]
+    fn a_doc_comment_is_not_a_variant() {
+        assert!(!kinds(ENUM).iter().any(|k| k == "doc"));
+    }
+
+    #[test]
+    fn the_registry_parses() {
+        let src = "pub const LIFTED_TO_TYPES: [(&str, &str); 2] = [\n    // c\n    (\"FileRead\", \"ReadOutput\"),\n    (\"WebContent\", \"FetchOutput\"),\n];\n";
+        assert_eq!(
+            lifts(src),
+            vec![
+                ("FileRead".into(), "ReadOutput".into()),
+                ("WebContent".into(), "FetchOutput".into())
+            ]
+        );
+    }
+
+    #[test]
+    fn a_type_without_a_labeled_field_does_not_discharge() {
+        let src = "pub struct Bare {\n    data: Vec<u8>,\n}\n";
+        assert!(!labels_its_data(src, "Bare"));
+        let ok = "pub struct Tagged {\n    data: Labeled<Vec<u8>, Trusted, Internal>,\n}\n";
+        assert!(labels_its_data(ok, "Tagged"));
+    }
+
+    fn corpus(flow: &str, runtime: &str) -> BTreeMap<String, String> {
+        BTreeMap::from([
+            (FLOW.to_string(), flow.to_string()),
+            (RUNTIME.to_string(), runtime.to_string()),
+        ])
+    }
+
+    #[test]
+    fn the_census_is_lifts_over_kinds() {
+        let runtime = "pub const LIFTED_TO_TYPES: [(&str, &str); 1] = [\n    (\"WebContent\", \"FetchOutput\"),\n];\npub struct FetchOutput {\n    data: Labeled<Vec<u8>, Adversarial, Public>,\n}\n";
+        let c = Typed.census(&corpus(ENUM, runtime)).expect("succeeds");
+        assert_eq!(c.population, 3);
+        assert_eq!(c.discharged, 1);
+        assert_eq!(c.undeclared, 0);
+    }
+
+    #[test]
+    fn a_row_naming_a_type_that_does_not_label_is_refused() {
+        let runtime = "pub const LIFTED_TO_TYPES: [(&str, &str); 1] = [\n    (\"WebContent\", \"Bare\"),\n];\npub struct Bare {\n    data: Vec<u8>,\n}\n";
+        let err = Typed
+            .census(&corpus(ENUM, runtime))
+            .expect_err("a row cannot buy a point without the type behind it");
+        assert!(err.to_string().contains("carries no"), "{err}");
+    }
+
+    #[test]
+    fn a_row_naming_a_variant_that_does_not_exist_is_refused() {
+        let runtime = "pub const LIFTED_TO_TYPES: [(&str, &str); 1] = [\n    (\"Ghost\", \"FetchOutput\"),\n];\npub struct FetchOutput {\n    data: Labeled<Vec<u8>, Adversarial, Public>,\n}\n";
+        let err = Typed
+            .census(&corpus(ENUM, runtime))
+            .expect_err("a stale row discharges nothing");
+        assert!(err.to_string().contains("not a variant"), "{err}");
+    }
+
+    #[test]
+    fn an_empty_taxonomy_is_refused_rather_than_scored() {
+        let err = Typed
+            .census(&corpus("pub enum Other {}", ""))
+            .expect_err("no population means no ratio");
+        assert!(
+            err.to_string().contains("population would be zero"),
+            "{err}"
+        );
+    }
+}

--- a/scripts/check-gates-can-fail.sh
+++ b/scripts/check-gates-can-fail.sh
@@ -697,6 +697,14 @@ perturb_scorecard_partial_totality() {
 # red demanding the pin be raised. This probe is that claim, on a real type: give
 # ServeToken an `expires_at` and the family goes 0.00% -> 14.28% and the gate
 # refuses to carry the stale zero forward.
+# A waiver that expires becomes one that never does. `#[expect]` errors when its
+# lint stops firing, so it dies with the reason that created it; `#[allow]` is
+# forever and silent. This is the `suppress` family's whole subject, and the
+# subject is a real production attribute rather than an appended line.
+perturb_scorecard_forever_waiver() {
+    sed -i.gate-bak 's/^    #\[expect($/    #[allow(/' "$1" && rm -f "$1.gate-bak"
+}
+
 perturb_scorecard_first_expiry() {
     sed -i.gate-bak 's/^pub struct ServeToken {$/pub struct ServeToken {\n    expires_at: u64,/' "$1" && rm -f "$1.gate-bak"
 }
@@ -714,6 +722,9 @@ probe_xtask scorecard crates/nucleus-pca/src/lib.rs \
     perturb_scorecard_partial_totality
 probe_xtask scorecard crates/nucleus-node/src/broker_launch.rs \
     "the first affine right to gain a validity interval" perturb_scorecard_first_expiry
+probe_xtask scorecard crates/nucleus-tool-proxy/src/art12.rs \
+    "a waiver that expires downgraded to one that never does" \
+    perturb_scorecard_forever_waiver
 probe_xtask assurance-required ci/assurance-required-ratchet.txt \
     "a claim whose falsifier the merge queue does not gate on, past the pin" perturb_assurance_required_pin
 probe_xtask pin-parity ci/lean/lean-toolchain \


### PR DESCRIPTION
The fifth family, and the new weakest — so the badge names it.

```
  scorecard | typed 8.69%

  family  unit                              population  discharged         %  undeclared
  bound   witness-accepting parameter site         172         171    99.41%          32
  alg     (lattice type, law) obligation           278         110    39.56%           8
  tot     production crate                          80          22    27.50%           5
  life    affine right                               7           1    14.28%           0
  typed   runtime flow kind                         23           2     8.69%           0
```

## The mechanism was already here, and already proven

`portcullis_core::labeled` encodes a Denning-style security lattice in the trait system — `Labeled<T, I: IntegTag, C: ConfTag>`, with `Trusted/Untrusted/Adversarial` crossed with `Public/Internal/Secret`. Its own `compile_fail` doctest proves the thing that matters:

```rust
fn publish<C: ConfAtMost<Public>>(_v: Labeled<String, Trusted, C>) {}
let key: Labeled<String, Trusted, Secret> = Labeled::new(..);
publish(key); // ERROR: Secret does not implement ConfAtMost<Public>
```

That is a **compile error**, not a check anyone has to reach. It is the construction the 2026 literature calls Denning-style IFC in Rust's type system ([Filament, arXiv 2604.14357](https://arxiv.org/pdf/2604.14357)), and it was built here already.

**It is applied to two of the twenty-three kinds `NodeKind` distinguishes.** The other twenty-one are tracked by `FlowTracker` at runtime — sound, and a *check*, so it has to be reached. `nucleus-observed-lint` exists precisely because an ingest path can forget to call `observe`, and its own doc names the defect it was built from: `/v1/run` returned arbitrary subprocess stdout and observed nothing.

A kind that is lifted cannot forget. That is the whole difference, and this ratio is the fraction.

## A lint and a type system are not the same tool

This family is where the difference is visible, and the ratchet says so:

- A dylint pass decides **adoption** — does every function in the ingest closure return a labelled type. A bounded, type-directed question; `nucleus-observed-lint` already answers the runtime equivalent with a reachability closure over `AGENT_ROOTS`.
- It cannot decide **the invariant** — "no `Secret` reaches a `Public` sink through any composition anyone writes later" is not a bounded search. That is what parametric polymorphism gives once the data is inside the typed region.

**The lint guards the frontier; the types guard the interior.** So `typed` and `observed` should move in opposite directions: every kind lifted here is a path the lint no longer has to police, and `.observed-ratchet.toml`'s ceiling should fall as this rises. If it doesn't, one of the two is measuring something other than what it says.

## A row cannot buy a point

`LIFTED_TO_TYPES` is a registry, and the gate checks both halves: a row naming a `NodeKind` that is not a variant is refused, and a row whose named type carries no `Labeled<` field is refused. `Custom` is excluded by name — it takes a caller-supplied string, so it could never have a fixed tag pair, and counting it would put an undischargeable obligation in the denominator forever. `convergence` excludes its two unmeasurable arrows the same way.

## The badge gate caught its own author

Adding the family turned the badge red without anyone touching the badge: the card said `typed 8.69%` while `badges/scorecard.json` still said `life 14.28%`. Regenerated in the same commit, which is what its design requires.

## Verification

Probed: one more `NodeKind` variant with no lift drops `typed` 8.69% → 8.33%. 235 xtask tests green, 9 new — including that a doc comment is not a variant, that a type without a `Labeled` field does not discharge, and that an empty taxonomy is refused rather than scored. Clippy clean on `xtask` and `portcullis-effects`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016t7JSuCtg4dC54HZjFgBjr