### PR TITLE
fix(test): registry tests shared a temp dir, so one pulled another's manifest

### DIFF
--- a/crates/portcullis-core/src/registry.rs
+++ b/crates/portcullis-core/src/registry.rs
@@ -575,9 +575,32 @@ mod tests {
 
     // ── helpers ────────────────────────────────────────────────────
 
+    /// A directory no other test shares.
+    ///
+    /// This used to key on `SystemTime::now().as_nanos()` alone, which is not unique: the
+    /// name says nanoseconds but the clock does not supply them. Measured 2026-09-11 on
+    /// macOS, 196,175 of 200,000 consecutive calls returned an IDENTICAL value and the
+    /// smallest non-zero delta was 1000 ns — it is a microsecond counter wearing a
+    /// nanosecond type. Two tests starting in the same microsecond therefore got the same
+    /// directory, and one pulled the other's manifest:
+    ///
+    /// ```text
+    /// assertion `left == right` failed
+    ///   left: Some("{\"data\":\"value\"}")            <- pull_by_digest's manifest
+    ///  right: Some("{\"schema_version\":\"1\",\"layers\":[]}")
+    /// ```
+    ///
+    /// Three components, because no one of them is sufficient: the PID separates nextest's
+    /// one-process-per-test (where an in-process counter cannot help), the counter separates
+    /// tests sharing a process under plain `cargo test` (where the PID cannot help), and the
+    /// timestamp separates runs. Uniqueness is now by construction rather than by hoping two
+    /// threads never land on the same tick.
     fn tempdir() -> PathBuf {
+        static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
         let dir = std::env::temp_dir().join(format!(
-            "nucleus-registry-test-{}",
+            "nucleus-registry-test-{}-{}-{}",
+            std::process::id(),
+            SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap()
@@ -585,5 +608,14 @@ mod tests {
         ));
         let _ = fs::remove_dir_all(&dir);
         dir
+    }
+
+    /// The property the old helper lacked: two calls never collide, even when the clock
+    /// does not move between them.
+    #[test]
+    fn tempdir_is_unique_within_a_process() {
+        let n = 64;
+        let dirs: std::collections::BTreeSet<PathBuf> = (0..n).map(|_| tempdir()).collect();
+        assert_eq!(dirs.len(), n, "tempdir() handed out a duplicate path");
     }
 }


### PR DESCRIPTION
`Tests` went red on an unrelated PR (#2825, which touches nothing within three crates of this):

```
assertion `left == right` failed
  left: Some("{\"data\":\"value\"}")
 right: Some("{\"schema_version\":\"1\",\"layers\":[]}")
```

`push_pull_roundtrip` pushed the manifest on the **right** and pulled back the one on the **left** — which belongs to `pull_by_digest`, forty lines below it. **Two tests were using the same directory.**

## Why

The helper keyed the directory on `SystemTime::now().as_nanos()` alone. The name says nanoseconds; the clock does not supply them. Measured, 200,000 consecutive calls:

| | |
|---|---|
| identical consecutive values | **196,175 / 200,000** (98.1%) |
| smallest non-zero delta | **1000 ns** |

It is a microsecond counter wearing a nanosecond type. Two tests starting in the same microsecond get the same path — and CI runs **nextest, one process per test**, on 8 cores.

## The fix

Three components, because **no one of them is sufficient**:

- **PID** — separates nextest's one-process-per-test, where an in-process counter cannot help.
- **atomic counter** — separates tests sharing a process under plain `cargo test`, where the PID cannot help.
- **timestamp** — separates runs.

Uniqueness by construction, rather than by hoping two threads never land on the same tick.

## Verification (A-19)

Driven RED on the real defect. 64 calls to each helper:

```
OLD tempdir: 17/64 distinct  -> test would FAIL
NEW tempdir: 64/64 distinct  -> test would PASS
```

The added `tempdir_is_unique_within_a_process` is the falsifier, and it did not exist before. 25 registry tests pass; clippy and fmt RC=0.

## Worth naming

This is a **flake**, which is the failure mode that costs most per unit of defect: it fails somebody else's PR, at random, for a reason their change cannot explain — and the cheapest response is to re-run rather than read. Nine tests in this file use the helper, so any pair of them could have collided.

🤖 Generated with [Claude Code](https://claude.com/claude-code)