### PR TITLE
fix(registry): nine tests shared a directory named by the clock

### DIFF
--- a/crates/portcullis-core/src/registry.rs
+++ b/crates/portcullis-core/src/registry.rs
@@ -575,13 +575,30 @@ mod tests {
 
     // ── helpers ────────────────────────────────────────────────────
 
+    /// A directory no other test can name.
+    ///
+    /// This used to be `temp_dir().join(format!("nucleus-registry-test-{nanos}"))`
+    /// followed by `remove_dir_all`. Nine tests in this module share it, and two
+    /// landing in the same nanosecond bucket get the SAME PATH — at which point
+    /// the second one's `remove_dir_all` deletes the first one's registry
+    /// underneath it, mid-test.
+    ///
+    /// That is not hypothetical. `push_pull_roundtrip` failed in CI twice on one
+    /// PR whose diff was a workflow timeout, 1 failure in 7444, and re-running
+    /// reproduced it: a clock-keyed name is a race that fires under load, not a
+    /// flake that goes away.
+    ///
+    /// Process id AND a counter, because the two runners collide differently.
+    /// `cargo nextest` gives each test its own process, so the pid separates
+    /// them; plain `cargo test` runs them as threads in one process, so the pid
+    /// is shared and only the counter does. Neither reads a clock.
     fn tempdir() -> PathBuf {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static NEXT: AtomicU64 = AtomicU64::new(0);
         let dir = std::env::temp_dir().join(format!(
-            "nucleus-registry-test-{}",
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
+            "nucleus-registry-test-{}-{}",
+            std::process::id(),
+            NEXT.fetch_add(1, Ordering::Relaxed)
         ));
         let _ = fs::remove_dir_all(&dir);
         dir


### PR DESCRIPTION
`tempdir()` in `portcullis-core::registry`'s test module built its path from `SystemTime::now().as_nanos()` and then `remove_dir_all`-ed it. **Nine tests in that module call it.** Two landing in the same nanosecond bucket get the same path, and the second one's `remove_dir_all` deletes the first one's registry underneath it, mid-test.

## How it was found

`push_pull_roundtrip` failed on #2825 — a PR whose entire diff is a workflow timeout — as **1 failure in 7444**.

The failure was invisible from the job that reported it. `Tests` contains only a `Report` step relaying `STEP: failure` from `Workspace build + tests`, a job whose own conclusion is `success` because the step carries `continue-on-error`. So the GitHub API never lists it as failed, and the test name was three jobs away from the red mark.

**I re-ran it first**, on the theory it was the known `NomError(Eof)` flake (#91), and said at the time that was a guess rather than a diagnosis. It reproduced — which is what a clock-keyed name does under load. It is a race, not noise.

## The fix

Process id **and** a counter, because the two runners collide differently:

- `cargo nextest` gives each test its own process, so the pid alone separates them
- plain `cargo test` runs them as threads in one process, so the pid is shared and only the counter does

Neither reads a clock, so neither can collide.

## Verification

`cargo test -p portcullis-core --all-features --lib registry::` — 54 passed, run three times. Clippy clean.

This is on `main` rather than in my PR stack because it affects every PR's `Tests` job, not just mine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016t7JSuCtg4dC54HZjFgBjr