### PR TITLE
fix(ci): four dylint gates discarded the exit status and blacklisted failures

### DIFF
--- a/.github/workflows/dylint-separation.yml
+++ b/.github/workflows/dylint-separation.yml
@@ -163,8 +163,17 @@ jobs:
           total=0
           for crate in nucleus-node nucleus-cred-broker nucleus-tool-proxy portcullis-effects; do
             echo "::group::$crate"
-            out=$(cargo dylint --lib nucleus_cb4a_lint -- -p "$crate" 2>&1) || true
+            # Keep the exit status. `|| true` discarded it, leaving only a grep for two known
+            # failure strings -- and a run that fails printing NEITHER (a dylint panic, an
+            # OOM, a driver that never started) yields an empty $out, a zero count, and a
+            # PASS. Assert the run ARRIVED rather than enumerating the ways it can die.
+            rc=0
+            out=$(cargo dylint --lib nucleus_cb4a_lint -- -p "$crate" 2>&1) || rc=$?
             echo "$out"
+            if [ "$rc" -ne 0 ]; then
+              echo "::error::the lint run over $crate exited $rc — it did not complete, so zero findings would be a false green."
+              exit 1
+            fi
             echo "::endgroup::"
             # A crate that fails to COMPILE under the lint reports zero findings,
             # and the `|| true` above swallows the exit status — so a broken
@@ -239,8 +248,17 @@ jobs:
           DYLINT_LIBRARY_PATH: ${{ github.workspace }}/tools/nucleus-identity-lint/target/debug
         run: |
           set -o pipefail
-          out=$(cargo dylint --lib nucleus_identity_lint -- -p nucleus-tool-proxy 2>&1) || true
+          # Keep the exit status. `|| true` discarded it, leaving only a grep for two known
+          # failure strings -- and a run that fails printing NEITHER (a dylint panic, an
+          # OOM, a driver that never started) yields an empty $out, a zero count, and a
+          # PASS. Assert the run ARRIVED rather than enumerating the ways it can die.
+          rc=0
+          out=$(cargo dylint --lib nucleus_identity_lint -- -p nucleus-tool-proxy 2>&1) || rc=$?
           echo "$out"
+          if [ "$rc" -ne 0 ]; then
+            echo "::error::the lint run over nucleus-tool-proxy exited $rc — it did not complete, so zero findings would be a false green."
+            exit 1
+          fi
           # Same false-green guard as the cb4a job: a compile failure yields
           # zero findings and `|| true` swallows the status.
           if printf '%s\n' "$out" | grep -qE 'could not compile|Compilation failed'; then
@@ -284,8 +302,17 @@ jobs:
           DYLINT_LIBRARY_PATH: ${{ github.workspace }}/tools/nucleus-egress-lint/target/debug
         run: |
           set -o pipefail
-          out=$(cargo dylint --lib nucleus_egress_lint -- -p nucleus-node --all-features 2>&1) || true
+          # Keep the exit status. `|| true` discarded it, leaving only a grep for two known
+          # failure strings -- and a run that fails printing NEITHER (a dylint panic, an
+          # OOM, a driver that never started) yields an empty $out, a zero count, and a
+          # PASS. Assert the run ARRIVED rather than enumerating the ways it can die.
+          rc=0
+          out=$(cargo dylint --lib nucleus_egress_lint -- -p nucleus-node --all-features 2>&1) || rc=$?
           echo "$out"
+          if [ "$rc" -ne 0 ]; then
+            echo "::error::the lint run over nucleus-node exited $rc — it did not complete, so zero findings would be a false green."
+            exit 1
+          fi
           n=$(printf '%s\n' "$out" | grep -c 'HTTP client constructed outside' || true)
           if [ "$n" -lt 1 ]; then
             echo "::error::the pass reported 0 findings on a crate known to build raw clients — it is not running, so a clean guest below would be a false green."
@@ -302,8 +329,17 @@ jobs:
           total=0
           for crate in nucleus-tool-proxy nucleus-client; do
             echo "::group::$crate"
-            out=$(cargo dylint --lib nucleus_egress_lint -- -p "$crate" --all-features 2>&1) || true
+            # Keep the exit status. `|| true` discarded it, leaving only a grep for two known
+            # failure strings -- and a run that fails printing NEITHER (a dylint panic, an
+            # OOM, a driver that never started) yields an empty $out, a zero count, and a
+            # PASS. Assert the run ARRIVED rather than enumerating the ways it can die.
+            rc=0
+            out=$(cargo dylint --lib nucleus_egress_lint -- -p "$crate" --all-features 2>&1) || rc=$?
             echo "$out"
+            if [ "$rc" -ne 0 ]; then
+              echo "::error::the lint run over $crate exited $rc — it did not complete, so zero findings would be a false green."
+              exit 1
+            fi
             echo "::endgroup::"
             if printf '%s\n' "$out" | grep -qE 'could not compile|Compilation failed'; then
               echo "::error::$crate failed to compile under the pass — zero findings would be a false green."


### PR DESCRIPTION
Each of the four `cargo dylint` invocations in this workflow read

```sh
out=$(cargo dylint ... 2>&1) || true
```

and compensated by grepping `$out` for two known failure strings.

**The author already knew the hazard** — the comments say so: *"a compile failure yields zero findings and `|| true` swallows the status"* — and the guard is a real fix for the failure it enumerates.

It is a **blacklist**, which is what `ci-spec`'s GI005 names: a run that fails printing *neither* string yields an empty `$out`, a zero count, and a **pass**. A dylint driver panic, an OOM, a missing `DYLINT_LIBRARY_PATH`, a toolchain that never started — none of them say "could not compile".

## Reproduced both ways

With a command that exits 101 printing neither signature:

```
OLD:  findings: 0 / RESULT: PASSED (false green)      rc=0
NEW:  ::error::the lint run over ... exited 101       rc=1
```

## The fix

As GI005 prescribes: **assert the run arrived** rather than enumerating the ways it can die. `|| rc=$?` keeps the status without tripping `bash -e` before the message can print.

The text guards are **left in place**. They catch the case where cargo exits 0 having printed a compile error, which the status alone would miss — so the two are complements, not substitutes.

## Normal paths verified unchanged

This matters because exit status is **not** the findings signal here: the lint is `Warn`, so a run that reports still exits 0.

| case | result |
|---|---|
| run fails, prints neither string | **rc=1** (was rc=0, false green) |
| run succeeds with 2 findings | rc=1 on the count — unchanged |
| run succeeds, zero findings | rc=0 — unchanged |

GI005 findings: **3 before, 0 after**. `check-ci-spec.sh` RC=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)