### PR TITLE
fix(flow-replay): the comment promised to surface it; the line under it dropped it

### DIFF
--- a/crates/nucleus-flow-replay/src/lib.rs
+++ b/crates/nucleus-flow-replay/src/lib.rs
@@ -22,6 +22,12 @@
 //! **kernel decision**, not about the HTTP surface. Stated so the boundary is
 //! not silently overclaimed later.
 
+// ADR 0007 C-5: a discarded Result on a flow-write path is a taint state that
+// stopped being provable. Denied here because this crate is now clean of it and
+// its whole output is a taint measurement -- the one place where losing an
+// observation invalidates the number rather than merely risking it.
+#![deny(clippy::let_underscore_must_use)]
+
 use portcullis::action_term::ActionTerm;
 use portcullis::gate_class::{self, GateClass};
 use portcullis::kernel::{DenyReason, Kernel, Verdict};
@@ -123,6 +129,16 @@ pub struct ReplaySummary {
     /// Refusal-code histogram, so a reader can see *which* gate fired rather
     /// than only how often something did.
     pub deny_codes: std::collections::BTreeMap<String, usize>,
+    /// Ingest steps whose observation FAILED, so the taint state this summary
+    /// describes is not provable for the rest of the episode.
+    ///
+    /// Any value above zero invalidates every taint-derived number below it:
+    /// once an observation is lost the session's label is a guess, and
+    /// `ceiling_attributable` in particular is counting against a ceiling that
+    /// no longer reflects what was ingested. Reported rather than returned
+    /// because a replay harness that stops at the first anomaly measures less
+    /// than one that finishes and says what it could not account for.
+    pub unobserved_ingests: usize,
 
     // ── How the refusals split by sink consequence ─────────────────────────
     // The question this answers: are the denials concentrated on expensive,
@@ -232,9 +248,22 @@ pub fn replay(steps: &[TraceStep]) -> (Vec<StepOutcome>, ReplaySummary) {
             && let Some(kind) = step.ingest
         {
             let bytes = step.content.as_deref().unwrap_or("").as_bytes();
-            // A dropped observation poisons the session by design; surface it
-            // rather than silently continuing with an unprovable taint state.
-            let _ = flow.observe_with_content_hash(kind, content_hash(bytes));
+            // The comment that used to sit here said "surface it rather than
+            // silently continuing with an unprovable taint state", and the line
+            // under it was `let _ = ...`, which silently continues. The prose
+            // was right and the code did the opposite.
+            //
+            // A lost observation means every taint number after this step is a
+            // guess, so it is counted and the count is reported. The replay
+            // finishes — a harness that aborts measures less than one that
+            // finishes and says what it could not account for — but it can no
+            // longer claim the taint state it describes is provable.
+            if flow
+                .observe_with_content_hash(kind, content_hash(bytes))
+                .is_err()
+            {
+                summary.unobserved_ingests += 1;
+            }
         }
     }
 


### PR DESCRIPTION
```rust
// A dropped observation poisons the session by design; surface it
// rather than silently continuing with an unprovable taint state.
let _ = flow.observe_with_content_hash(kind, content_hash(bytes));
```

The prose was right and the code did the opposite. `observe_with_content_hash` returns `Result<u64, FlowError>`, and `let _ =` is the one way to discard a `#[must_use]` without the compiler saying anything.

## Why it matters more here than almost anywhere

This crate's entire output is a taint measurement. A lost observation doesn't merely risk a wrong answer — it makes every taint-derived number after that step a guess. `ceiling_attributable` in particular counts against a ceiling that no longer reflects what was ingested.

So the failure is counted and reported: `ReplaySummary::unobserved_ingests`. The replay still finishes, because **a harness that aborts at the first anomaly measures less than one that finishes and says what it could not account for.** It just can no longer claim the taint state it describes is provable.

With the site gone the crate is clean, so it takes `#![deny(clippy::let_underscore_must_use)]` — ADR 0007 C-5, and `clippy.toml`'s own rule that an entry is added only where the tree is already clean of it.

## A measurement error worth recording

I found this while sizing a candidate scorecard family, and got the count wrong twice first. Grepping `cargo clippy --message-format=short` output for the **lint name** finds nothing — that format prints the message text (`non-binding `let` on an expression with `#[must_use]` type`), not the name. My first pass reported zero sites across five crates.

## Verification

`cargo clippy -p nucleus-flow-replay --all-targets --all-features -- -D warnings` clean with the deny in place; the `let_underscore_must_use` count on this crate goes 1 → 0. Tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016t7JSuCtg4dC54HZjFgBjr